### PR TITLE
Feature/sticky resource pool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ tags
 .DS_Store
 .virthualenv
 .vagrant
+/node/testreleases

--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,3 @@ tags
 .DS_Store
 .virthualenv
 .vagrant
-/node/testreleases
-/node/testacquires

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ tags
 .virthualenv
 .vagrant
 /node/testreleases
+/node/testacquires

--- a/node/runtests.sh
+++ b/node/runtests.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
-# run 'stack test" to correctly configure this
 # I always forget this flag
 cabal test --show-details=streaming

--- a/node/src/Unison/Runtime/ResourcePool.hs
+++ b/node/src/Unison/Runtime/ResourcePool.hs
@@ -3,6 +3,7 @@ module Unison.Runtime.ResourcePool where
 import qualified Data.Map as M
 import qualified Control.Concurrent.MVar as MVar
 import Data.Time (UTCTime,getCurrentTime)
+import Control.Concurrent
 
 -- acquire returns the resource, and the cleanup action ("finalizer") for that resource
 data Pool p r = Pool { acquire :: p -> Int -> IO (r, IO ()) }
@@ -14,14 +15,25 @@ _acquire acquirer releaser cache p wait = do
   now <- getCurrentTime
   cachemap <- MVar.takeMVar cache
   r <- case M.lookup p cachemap of
-          Just (r, _) ->
-            return r
-          Nothing ->
-            acquirer p
+          Just (r, _) -> return r
+          Nothing -> acquirer p
   let newCacheMap =
         if wait > 0 then M.insert p (r,now) cachemap
         else cachemap
   MVar.putMVar cache newCacheMap >> return (r, (releaser r))
+
+cleanCache :: (Ord p) => Cache p r -> IO ()
+cleanCache cache = do
+  now <- getCurrentTime
+  cachemap <- MVar.takeMVar cache
+  let keys = M.keys cachemap
+      newmap = foldr (\k m ->
+                    case M.lookup k cachemap of
+                        Just (_, expiry) ->
+                          if expiry < now then M.delete k m else m
+                        Nothing -> m) cachemap keys
+  MVar.putMVar cache newmap
+
 
 pool :: Ord p => Int -> (p -> IO r) -> (r -> IO ()) -> IO (Pool p r)
 pool maxPoolSize acquirer releaser = do

--- a/node/src/Unison/Runtime/ResourcePool.hs
+++ b/node/src/Unison/Runtime/ResourcePool.hs
@@ -1,0 +1,15 @@
+module Unison.Runtime.ResourcePool where
+
+import qualified Data.Map as M
+
+-- acquire returns the resource, and the cleanup action ("finalizer") for that resource
+data Pool p r = Pool { acquire :: p -> IO (r, IO ()) }
+
+iacquire :: (p -> IO r) -> p -> IO (r, IO ())
+iacquire a p = do
+  r <- a p
+  return (r, return ())
+
+pool :: Ord p => Int -> (p -> IO r) -> (r -> IO ()) -> IO (Pool p r)
+pool maxPoolSize a release =
+  return $ Pool { acquire = iacquire a }

--- a/node/src/Unison/Runtime/ResourcePool.hs
+++ b/node/src/Unison/Runtime/ResourcePool.hs
@@ -1,64 +1,69 @@
 module Unison.Runtime.ResourcePool where
 
-import qualified Data.Map as M
-import qualified Control.Concurrent.MVar as MVar
 import Data.Time (UTCTime, getCurrentTime, addUTCTime)
 import qualified Control.Concurrent as CC
+import qualified Control.Concurrent.Map as M
+import qualified Control.Concurrent.STM.TQueue as TQ
+import qualified Control.Concurrent.MVar as MVar
+import qualified Data.Hashable as H
 
 -- acquire returns the resource, and the cleanup action ("finalizer") for that resource
 data Pool p r = Pool { acquire :: p -> Int -> IO (r, IO ()) }
 
 type ResourceKey p = (p,CC.ThreadId)
-type Cache p r = MVar.MVar (M.Map (ResourceKey p) (r, UTCTime, IO ()))
+type Cache p r = M.Map (ResourceKey p) (r, UTCTime, IO ())
 
-addResourceToMap :: Ord p =>  (r -> IO ()) -> Cache p r -> p -> r -> Int -> Int -> IO CC.ThreadId -> IO ()
-addResourceToMap releaser mVarCache p r wait maxPoolSize getThread = do
+addResourceToMap :: (Ord p, H.Hashable p) =>  (r -> IO ()) -> Cache p r -> p -> r -> Int -> Int -> IO CC.ThreadId -> MVar.MVar Int -> IO ()
+addResourceToMap releaser map p r wait maxPoolSize getThread ps = do
   now <- getCurrentTime
+  poolSize <- MVar.takeMVar poolSize
   threadId <- getThread
   let expiry = addUTCTime (fromIntegral wait) now
-  cacheMap <- MVar.takeMVar mVarCache
-  newCacheMap <- if wait > 0 && ((length cacheMap) < maxPoolSize) then
-                   -- add the resource to the mVarCache with the releaser
-                   return $ M.insert (p,threadId) (r,expiry, (releaser r)) cacheMap
-                 else -- immedately release and dont add to mVarCache
-                   releaser r >> return cacheMap
-  MVar.putMVar mVarCache newCacheMap
+  if wait > 0 && (poolSize < maxPoolSize) then
+    -- add the resource to the map with the releaser
+    M.insert (p,threadId) (r,expiry, (releaser r)) map
+      >> MVar.putMVar ps (poolSize + 1)
+  else -- immedately release
+    releaser r
 
-_acquire :: Ord p => (p -> IO r) -> (r -> IO ()) -> Cache p r -> Int -> IO CC.ThreadId -> p -> Int -> IO (r, IO ())
-_acquire acquirer releaser mVarCache maxPoolSize getThread p wait = do
+_acquire :: (Ord p, H.Hashable p) => (p -> IO r) -> (r -> IO ()) -> Cache p r -> Int -> IO CC.ThreadId -> MVar.MVar Int -> p -> Int -> IO (r, IO ())
+_acquire acquirer releaser map maxPoolSize getThread ps p wait = do
   threadId <- getThread
-  cacheMap <- MVar.takeMVar mVarCache
-  (newMap, r) <- case M.lookup (p,threadId) cacheMap of
-                  Just (r, _, _) -> return (M.delete (p,threadId) cacheMap, r)
-                  Nothing -> ((,) cacheMap) <$> acquirer p
-  MVar.putMVar mVarCache newMap
-    >> return (r, (addResourceToMap releaser mVarCache p r wait maxPoolSize getThread))
+  m <- M.lookup (p,threadId) map
+  poolSize <- MVar.takeMVar poolSize
+  r <- case m of
+        Just (r, _, _) -> M.delete (p,threadId) map
+          >> MVar.putMVar ps (poolSize - 1)
+          >> return r
+        Nothing -> acquirer p
+  return (r, (addResourceToMap releaser map p r wait maxPoolSize getThread))
 
-cleanCache :: Ord p => Cache p r -> IO ()
-cleanCache mVarCache = do
-  now <- getCurrentTime
-  cacheMap <- MVar.takeMVar mVarCache
-  let keysNReleasers = M.foldrWithKey (\k _ knrs ->
-                                      case M.lookup k cacheMap of
-                                          Just (_, expiry, releaser) ->
-                                            if expiry < now then (k, releaser) : knrs
-                                            else knrs
-                                          Nothing -> knrs) [] cacheMap
-      newMap = foldr (\(k,_) m -> M.delete k m) cacheMap keysNReleasers
-  (sequence $ map snd keysNReleasers)
-    >> MVar.putMVar mVarCache newMap
+cleanCache :: (Ord p, H.Hashable p) => Cache p r -> IO ()
+cleanCache map = do
+  return ()
+  -- now <- getCurrentTime
+  -- let keysNReleasers = M.foldrWithKey (\k _ knrs ->
+  --                                     case M.lookup k map of
+  --                                         Just (_, expiry, releaser) ->
+  --                                           if expiry < now then (k, releaser) : knrs
+  --                                           else knrs
+  --                                         Nothing -> knrs) [] map
+  --     newMap = foldr (\(k,_) m -> M.delete k m) map keysNReleasers
+  -- (sequence $ map snd keysNReleasers)
 
-cleanCacheLoop :: Ord p => Cache p r -> IO b
+cleanCacheLoop :: (Ord p, H.Hashable p) => Cache p r -> IO b
 cleanCacheLoop mVarCache =
   cleanCache mVarCache >> CC.threadDelay 1000000 >> cleanCacheLoop mVarCache
 
-pool :: Ord p => Int -> (p -> IO r) -> (r -> IO ()) -> IO (Pool p r)
+pool :: (Ord p, H.Hashable p) => Int -> (p -> IO r) -> (r -> IO ()) -> IO (Pool p r)
 pool maxPoolSize acquirer releaser = do
-  mVarCache <- MVar.newMVar M.empty
-  _ <- CC.forkIO (cleanCacheLoop mVarCache)
-  return Pool { acquire = _acquire acquirer releaser mVarCache maxPoolSize CC.myThreadId }
+  map <- M.empty
+  ps  <- MVar.newMVar 0
+  _ <- CC.forkIO (cleanCacheLoop map)
+  return Pool { acquire = _acquire acquirer releaser map maxPoolSize CC.myThreadId ps }
 
-poolWithoutGC :: Ord p => Int -> (p -> IO r) -> (r -> IO ()) -> IO (Pool p r)
+poolWithoutGC :: (Ord p, H.Hashable p) => Int -> (p -> IO r) -> (r -> IO ()) -> IO (Pool p r)
 poolWithoutGC maxPoolSize acquirer releaser = do
-  mVarCache <- MVar.newMVar M.empty
-  return Pool { acquire = _acquire acquirer releaser mVarCache maxPoolSize CC.myThreadId }
+  map <- M.empty
+  ps  <- MVar.newMVar 0
+  return Pool { acquire = _acquire acquirer releaser map maxPoolSize CC.myThreadId ps }

--- a/node/src/Unison/Runtime/ResourcePool.hs
+++ b/node/src/Unison/Runtime/ResourcePool.hs
@@ -15,28 +15,30 @@ type ResourceKey p = (p,CC.ThreadId)
 type Cache p r = M.Map (ResourceKey p) (r, UTCTime, IO ())
 type ReaperQueue p = TQ.TQueue (ResourceKey p)
 type MaxPoolSize = Int
+type Seconds = Int
+type PoolSize = Int
 
 incRef :: Num t => t -> (t, ())
 incRef a = (a+1,())
 decRef :: Num t => t -> (t, ())
 decRef a = (a-1,())
 
-addResourceToMap :: (Ord p, H.Hashable p) =>  (r -> IO ()) -> Cache p r -> p -> r -> Int -> MaxPoolSize -> IO CC.ThreadId -> IORef.IORef Int -> ReaperQueue p -> IO ()
-addResourceToMap release pool p r wait maxPoolSize getThread poolSizeR queue = do
+addResourceToMap :: (Ord p, H.Hashable p) =>  (r -> IO ()) -> Cache p r -> p -> r -> Seconds -> MaxPoolSize -> IO CC.ThreadId -> IORef.IORef PoolSize -> ReaperQueue p -> IO ()
+addResourceToMap release pool p r waitInSeconds maxPoolSize getThread poolSizeR queue = do
   now <- getCurrentTime
   poolSize <- IORef.readIORef poolSizeR
   threadId <- getThread
-  let expiry = addUTCTime (fromIntegral wait) now
+  let expiry = addUTCTime (fromIntegral waitInSeconds) now
   let key = (p,threadId)
-  if wait > 0 && (poolSize < maxPoolSize) then
+  if waitInSeconds > 0 && (poolSize < maxPoolSize) then
     -- add the resource to the pool with the release
     M.insert key (r, expiry, (release r)) pool
       >> IORef.atomicModifyIORef poolSizeR incRef
       >> STM.atomically (TQ.writeTQueue queue key)
     else release r
 
-_acquire :: (Ord p, H.Hashable p) => (p -> IO r) -> (r -> IO ()) -> Cache p r -> Int -> MaxPoolSize -> IORef.IORef Int -> ReaperQueue p -> IO CC.ThreadId -> p -> IO (r, IO ())
-_acquire acquire release pool wait maxPoolSize poolSizeR queue getThread p = do
+_acquire :: (Ord p, H.Hashable p) => (p -> IO r) -> (r -> IO ()) -> Cache p r -> Seconds -> MaxPoolSize -> IORef.IORef PoolSize -> ReaperQueue p -> IO CC.ThreadId -> p -> IO (r, IO ())
+_acquire acquire release pool waitInSeconds maxPoolSize poolSizeR queue getThread p = do
   threadId <- getThread
   m <- M.lookup (p,threadId) pool
   r <- case m of
@@ -44,7 +46,7 @@ _acquire acquire release pool wait maxPoolSize poolSizeR queue getThread p = do
           >> IORef.atomicModifyIORef poolSizeR decRef
           >> return r
         Nothing -> acquire p
-  return (r, (addResourceToMap release pool p r wait maxPoolSize getThread poolSizeR queue))
+  return (r, (addResourceToMap release pool p r waitInSeconds maxPoolSize getThread poolSizeR queue))
 
 cleanPool :: (Ord p, H.Hashable p) => Cache p r -> ReaperQueue p -> IO ()
 cleanPool pool queue = do
@@ -64,17 +66,17 @@ cleanPool pool queue = do
              >> cleanPool pool queue
     Nothing -> return ()
 
-pool :: (Ord p, H.Hashable p) => Int -> MaxPoolSize -> (p -> IO r) -> (r -> IO ()) -> IO (Pool p r)
-pool wait maxPoolSize acquire release = do
+pool :: (Ord p, H.Hashable p) => Seconds -> MaxPoolSize -> (p -> IO r) -> (r -> IO ()) -> IO (Pool p r)
+pool waitInSeconds maxPoolSize acquire release = do
   pool <- M.empty
   q <- STM.atomically TQ.newTQueue
   ps  <- IORef.newIORef 0
   _ <- CC.forkIO (cleanPool pool q)
-  return Pool { acquire = _acquire acquire release pool wait maxPoolSize ps q CC.myThreadId }
+  return Pool { acquire = _acquire acquire release pool waitInSeconds maxPoolSize ps q CC.myThreadId }
 
-poolWithoutGC :: (Ord p, H.Hashable p) => Int -> MaxPoolSize -> (p -> IO r) -> (r -> IO ()) -> IO (Pool p r)
-poolWithoutGC wait maxPoolSize acquire release = do
+poolWithoutGC :: (Ord p, H.Hashable p) => Seconds -> MaxPoolSize -> (p -> IO r) -> (r -> IO ()) -> IO (Pool p r)
+poolWithoutGC waitInSeconds maxPoolSize acquire release = do
   pool <- M.empty
   q <- STM.atomically TQ.newTQueue
   ps  <- IORef.newIORef 0
-  return Pool { acquire = _acquire acquire release pool wait maxPoolSize ps q CC.myThreadId }
+  return Pool { acquire = _acquire acquire release pool waitInSeconds maxPoolSize ps q CC.myThreadId }

--- a/node/src/Unison/Runtime/ResourcePool.hs
+++ b/node/src/Unison/Runtime/ResourcePool.hs
@@ -2,40 +2,65 @@ module Unison.Runtime.ResourcePool where
 
 import qualified Data.Map as M
 import qualified Control.Concurrent.MVar as MVar
-import Data.Time (UTCTime,getCurrentTime)
-import Control.Concurrent
+import Data.Time (UTCTime, getCurrentTime, addUTCTime,secondsToDiffTime)
+import qualified Control.Concurrent as CC
+import qualified Control.Monad
 
 -- acquire returns the resource, and the cleanup action ("finalizer") for that resource
 data Pool p r = Pool { acquire :: p -> Int -> IO (r, IO ()) }
 
-type Cache p r = MVar.MVar (M.Map p (r, UTCTime))
+type Cache p r = MVar.MVar (M.Map p (r, UTCTime, IO ()))
+
+addResourceToMap :: (Ord p) =>  (r -> IO()) -> Cache p r -> p -> r -> Int -> IO ()
+addResourceToMap releaser cache p r wait = do
+  now <- getCurrentTime
+  let expiry = addUTCTime (fromIntegral wait) now
+  cachemap <- MVar.takeMVar cache
+  newCacheMap <-
+        if wait > 0 then
+          -- add the resource to the cache with the releaser
+          return $ M.insert p (r,expiry, (releaser r)) cachemap
+        else -- immedately release and dont add to cache
+          releaser r >> return cachemap
+  MVar.putMVar cache newCacheMap
 
 _acquire :: (Ord p) => (p -> IO r) -> (r -> IO()) -> Cache p r -> p -> Int -> IO (r, IO ())
 _acquire acquirer releaser cache p wait = do
-  now <- getCurrentTime
   cachemap <- MVar.takeMVar cache
   r <- case M.lookup p cachemap of
-          Just (r, _) -> return r
+          Just (r, _, _) -> return r
           Nothing -> acquirer p
-  let newCacheMap =
-        if wait > 0 then M.insert p (r,now) cachemap
-        else cachemap
-  MVar.putMVar cache newCacheMap >> return (r, (releaser r))
+  MVar.putMVar cache cachemap
+    >> return (r, (addResourceToMap releaser cache p r wait))
 
 cleanCache :: (Ord p) => Cache p r -> IO ()
 cleanCache cache = do
-  now <- getCurrentTime
+  now <- CC.threadDelay 1 >> getCurrentTime
   cachemap <- MVar.takeMVar cache
-  let keys = M.keys cachemap
-      newmap = foldr (\k m ->
-                    case M.lookup k cachemap of
-                        Just (_, expiry) ->
-                          if expiry < now then M.delete k m else m
-                        Nothing -> m) cachemap keys
-  MVar.putMVar cache newmap
+  let emptyKeys = [] :: [(p, IO())]
+  let keysNReleasers = M.foldrWithKey (\k _ knrs ->
+                                      case M.lookup k cachemap of
+                                          Just (_, expiry, releaser) ->
+                                            if expiry < now then (k, releaser) : knrs
+                                            else knrs
+                                          Nothing -> knrs) emptyKeys cachemap
+      newMap = foldr (\(k,_) m -> M.delete k m) cachemap keysNReleasers
+  id <- CC.myThreadId
+  putStrLn ("\nthread: " ++ (show id) ++ " found: " ++ (show . length $ keysNReleasers))
+  (sequence $ map snd keysNReleasers)
+    >> MVar.putMVar cache newMap
 
+cleanCacheLoop cache =
+  cleanCache cache >> cleanCacheLoop cache
 
 pool :: Ord p => Int -> (p -> IO r) -> (r -> IO ()) -> IO (Pool p r)
 pool maxPoolSize acquirer releaser = do
   cache <- MVar.newMVar M.empty
+  return Pool { acquire = _acquire acquirer releaser cache }
+
+poolWithGC :: Ord p => Int -> (p -> IO r) -> (r -> IO ()) -> IO (Pool p r)
+poolWithGC maxPoolSize acquirer releaser = do
+  cache <- MVar.newMVar M.empty
+  id <- CC.forkIO (cleanCacheLoop cache)
+  putStrLn ("spawing: " ++ (show id))
   return Pool { acquire = _acquire acquirer releaser cache }

--- a/node/src/Unison/Runtime/ResourcePool.hs
+++ b/node/src/Unison/Runtime/ResourcePool.hs
@@ -1,15 +1,29 @@
 module Unison.Runtime.ResourcePool where
 
 import qualified Data.Map as M
+import qualified Control.Concurrent.MVar as MVar
+import Data.Time (UTCTime,getCurrentTime)
 
 -- acquire returns the resource, and the cleanup action ("finalizer") for that resource
-data Pool p r = Pool { acquire :: p -> IO (r, IO ()) }
+data Pool p r = Pool { acquire :: p -> Int -> IO (r, IO ()) }
 
-iacquire :: (p -> IO r) -> (r -> IO()) -> p -> IO (r, IO ())
-iacquire acquirer releaser p = do
-  r <- acquirer p
-  return (r, (releaser r))
+type Cache p r = MVar.MVar (M.Map p (r, UTCTime))
+
+_acquire :: (Ord p) => (p -> IO r) -> (r -> IO()) -> Cache p r -> p -> Int -> IO (r, IO ())
+_acquire acquirer releaser cache p wait = do
+  now <- getCurrentTime
+  cachemap <- MVar.takeMVar cache
+  r <- case M.lookup p cachemap of
+          Just (r, _) ->
+            return r
+          Nothing ->
+            acquirer p
+  let newCacheMap =
+        if wait > 0 then M.insert p (r,now) cachemap
+        else cachemap
+  MVar.putMVar cache newCacheMap >> return (r, (releaser r))
 
 pool :: Ord p => Int -> (p -> IO r) -> (r -> IO ()) -> IO (Pool p r)
-pool maxPoolSize acquirer releaser =
-  return $ Pool { acquire = iacquire acquirer releaser }
+pool maxPoolSize acquirer releaser = do
+  cache <- MVar.newMVar M.empty
+  return Pool { acquire = _acquire acquirer releaser cache }

--- a/node/src/Unison/Runtime/ResourcePool.hs
+++ b/node/src/Unison/Runtime/ResourcePool.hs
@@ -2,9 +2,8 @@ module Unison.Runtime.ResourcePool where
 
 import qualified Data.Map as M
 import qualified Control.Concurrent.MVar as MVar
-import Data.Time (UTCTime, getCurrentTime, addUTCTime,secondsToDiffTime)
+import Data.Time (UTCTime, getCurrentTime, addUTCTime)
 import qualified Control.Concurrent as CC
-import qualified Control.Monad
 
 -- acquire returns the resource, and the cleanup action ("finalizer") for that resource
 data Pool p r = Pool { acquire :: p -> Int -> IO (r, IO ()) }
@@ -12,52 +11,52 @@ data Pool p r = Pool { acquire :: p -> Int -> IO (r, IO ()) }
 type Cache p r = MVar.MVar (M.Map p (r, UTCTime, IO ()))
 
 addResourceToMap :: (Ord p) =>  (r -> IO()) -> Cache p r -> p -> r -> Int -> Int -> IO ()
-addResourceToMap releaser cache p r wait maxPoolSize = do
+addResourceToMap releaser mVarCache p r wait maxPoolSize = do
   now <- getCurrentTime
   let expiry = addUTCTime (fromIntegral wait) now
-  cachemap <- MVar.takeMVar cache
-  newCacheMap <- if wait > 0 && ((length cachemap) < maxPoolSize) then
-                   -- add the resource to the cache with the releaser
-                   return $ M.insert p (r,expiry, (releaser r)) cachemap
-                 else -- immedately release and dont add to cache
-                   releaser r >> return cachemap
-  MVar.putMVar cache newCacheMap
+  cacheMap <- MVar.takeMVar mVarCache
+  newCacheMap <- if wait > 0 && ((length cacheMap) < maxPoolSize) then
+                   -- add the resource to the mVarCache with the releaser
+                   return $ M.insert p (r,expiry, (releaser r)) cacheMap
+                 else -- immedately release and dont add to mVarCache
+                   releaser r >> return cacheMap
+  MVar.putMVar mVarCache newCacheMap
 
 _acquire :: (Ord p) => (p -> IO r) -> (r -> IO()) -> Cache p r -> Int -> p -> Int -> IO (r, IO ())
-_acquire acquirer releaser cache maxPoolSize p wait = do
-  cachemap <- MVar.takeMVar cache
-  r <- case M.lookup p cachemap of
+_acquire acquirer releaser mVarCache maxPoolSize p wait = do
+  cacheMap <- MVar.takeMVar mVarCache
+  r <- case M.lookup p cacheMap of
           Just (r, _, _) -> return r
           Nothing -> acquirer p
-  MVar.putMVar cache cachemap
-    >> return (r, (addResourceToMap releaser cache p r wait maxPoolSize))
+  MVar.putMVar mVarCache cacheMap
+    >> return (r, (addResourceToMap releaser mVarCache p r wait maxPoolSize))
 
 cleanCache :: (Ord p) => Cache p r -> IO ()
-cleanCache cache = do
+cleanCache mVarCache = do
   now <- getCurrentTime
-  cachemap <- MVar.takeMVar cache
+  cacheMap <- MVar.takeMVar mVarCache
   let emptyKeys = [] :: [(p, IO())]
   let keysNReleasers = M.foldrWithKey (\k _ knrs ->
-                                      case M.lookup k cachemap of
+                                      case M.lookup k cacheMap of
                                           Just (_, expiry, releaser) ->
                                             if expiry < now then (k, releaser) : knrs
                                             else knrs
-                                          Nothing -> knrs) emptyKeys cachemap
-      newMap = foldr (\(k,_) m -> M.delete k m) cachemap keysNReleasers
-  id <- CC.myThreadId
+                                          Nothing -> knrs) emptyKeys cacheMap
+      newMap = foldr (\(k,_) m -> M.delete k m) cacheMap keysNReleasers
   (sequence $ map snd keysNReleasers)
-    >> MVar.putMVar cache newMap
+    >> MVar.putMVar mVarCache newMap
 
-cleanCacheLoop cache =
-  cleanCache cache >> CC.threadDelay 1000000 >> cleanCacheLoop cache
+cleanCacheLoop :: Ord p => Cache p r -> IO b
+cleanCacheLoop mVarCache =
+  cleanCache mVarCache >> CC.threadDelay 1000000 >> cleanCacheLoop mVarCache
 
 pool :: Ord p => Int -> (p -> IO r) -> (r -> IO ()) -> IO (Pool p r)
 pool maxPoolSize acquirer releaser = do
-  cache <- MVar.newMVar M.empty
-  id <- CC.forkIO (cleanCacheLoop cache)
-  return Pool { acquire = _acquire acquirer releaser cache maxPoolSize }
+  mVarCache <- MVar.newMVar M.empty
+  _ <- CC.forkIO (cleanCacheLoop mVarCache)
+  return Pool { acquire = _acquire acquirer releaser mVarCache maxPoolSize }
 
 poolWithoutGC :: Ord p => Int -> (p -> IO r) -> (r -> IO ()) -> IO (Pool p r)
 poolWithoutGC maxPoolSize acquirer releaser = do
-  cache <- MVar.newMVar M.empty
-  return Pool { acquire = _acquire acquirer releaser cache maxPoolSize }
+  mVarCache <- MVar.newMVar M.empty
+  return Pool { acquire = _acquire acquirer releaser mVarCache maxPoolSize }

--- a/node/src/Unison/Runtime/ResourcePool.hs
+++ b/node/src/Unison/Runtime/ResourcePool.hs
@@ -5,11 +5,11 @@ import qualified Data.Map as M
 -- acquire returns the resource, and the cleanup action ("finalizer") for that resource
 data Pool p r = Pool { acquire :: p -> IO (r, IO ()) }
 
-iacquire :: (p -> IO r) -> p -> IO (r, IO ())
-iacquire a p = do
-  r <- a p
-  return (r, return ())
+iacquire :: (p -> IO r) -> (r -> IO()) -> p -> IO (r, IO ())
+iacquire acquirer releaser p = do
+  r <- acquirer p
+  return (r, (releaser r))
 
 pool :: Ord p => Int -> (p -> IO r) -> (r -> IO ()) -> IO (Pool p r)
-pool maxPoolSize a release =
-  return $ Pool { acquire = iacquire a }
+pool maxPoolSize acquirer releaser =
+  return $ Pool { acquire = iacquire acquirer releaser }

--- a/node/src/Unison/Runtime/ResourcePool.hs
+++ b/node/src/Unison/Runtime/ResourcePool.hs
@@ -8,40 +8,42 @@ import qualified Control.Concurrent as CC
 -- acquire returns the resource, and the cleanup action ("finalizer") for that resource
 data Pool p r = Pool { acquire :: p -> Int -> IO (r, IO ()) }
 
-type Cache p r = MVar.MVar (M.Map p (r, UTCTime, IO ()))
+type ResourceKey p = (p,CC.ThreadId)
+type Cache p r = MVar.MVar (M.Map (ResourceKey p) (r, UTCTime, IO ()))
 
-addResourceToMap :: (Ord p) =>  (r -> IO()) -> Cache p r -> p -> r -> Int -> Int -> IO ()
-addResourceToMap releaser mVarCache p r wait maxPoolSize = do
+addResourceToMap :: (Ord p) =>  (r -> IO()) -> Cache p r -> p -> r -> Int -> Int -> IO(CC.ThreadId) -> IO ()
+addResourceToMap releaser mVarCache p r wait maxPoolSize getThread = do
   now <- getCurrentTime
+  threadId <- getThread
   let expiry = addUTCTime (fromIntegral wait) now
   cacheMap <- MVar.takeMVar mVarCache
   newCacheMap <- if wait > 0 && ((length cacheMap) < maxPoolSize) then
                    -- add the resource to the mVarCache with the releaser
-                   return $ M.insert p (r,expiry, (releaser r)) cacheMap
+                   return $ M.insert (p,threadId) (r,expiry, (releaser r)) cacheMap
                  else -- immedately release and dont add to mVarCache
                    releaser r >> return cacheMap
   MVar.putMVar mVarCache newCacheMap
 
-_acquire :: (Ord p) => (p -> IO r) -> (r -> IO()) -> Cache p r -> Int -> p -> Int -> IO (r, IO ())
-_acquire acquirer releaser mVarCache maxPoolSize p wait = do
+_acquire :: (Ord p) => (p -> IO r) -> (r -> IO()) -> Cache p r -> Int -> IO(CC.ThreadId) -> p -> Int -> IO (r, IO ())
+_acquire acquirer releaser mVarCache maxPoolSize getThread p wait = do
+  threadId <- getThread
   cacheMap <- MVar.takeMVar mVarCache
-  r <- case M.lookup p cacheMap of
+  r <- case M.lookup (p,threadId) cacheMap of
           Just (r, _, _) -> return r
           Nothing -> acquirer p
   MVar.putMVar mVarCache cacheMap
-    >> return (r, (addResourceToMap releaser mVarCache p r wait maxPoolSize))
+    >> return (r, (addResourceToMap releaser mVarCache p r wait maxPoolSize getThread))
 
 cleanCache :: (Ord p) => Cache p r -> IO ()
 cleanCache mVarCache = do
   now <- getCurrentTime
   cacheMap <- MVar.takeMVar mVarCache
-  let emptyKeys = [] :: [(p, IO())]
   let keysNReleasers = M.foldrWithKey (\k _ knrs ->
                                       case M.lookup k cacheMap of
                                           Just (_, expiry, releaser) ->
                                             if expiry < now then (k, releaser) : knrs
                                             else knrs
-                                          Nothing -> knrs) emptyKeys cacheMap
+                                          Nothing -> knrs) [] cacheMap
       newMap = foldr (\(k,_) m -> M.delete k m) cacheMap keysNReleasers
   (sequence $ map snd keysNReleasers)
     >> MVar.putMVar mVarCache newMap
@@ -54,9 +56,9 @@ pool :: Ord p => Int -> (p -> IO r) -> (r -> IO ()) -> IO (Pool p r)
 pool maxPoolSize acquirer releaser = do
   mVarCache <- MVar.newMVar M.empty
   _ <- CC.forkIO (cleanCacheLoop mVarCache)
-  return Pool { acquire = _acquire acquirer releaser mVarCache maxPoolSize }
+  return Pool { acquire = _acquire acquirer releaser mVarCache maxPoolSize CC.myThreadId }
 
 poolWithoutGC :: Ord p => Int -> (p -> IO r) -> (r -> IO ()) -> IO (Pool p r)
 poolWithoutGC maxPoolSize acquirer releaser = do
   mVarCache <- MVar.newMVar M.empty
-  return Pool { acquire = _acquire acquirer releaser mVarCache maxPoolSize }
+  return Pool { acquire = _acquire acquirer releaser mVarCache maxPoolSize CC.myThreadId }

--- a/node/tests/Suite.hs
+++ b/node/tests/Suite.hs
@@ -1,0 +1,10 @@
+module Main where
+
+import Test.Tasty
+import qualified Unison.Test.ResourcePool as ResourcePool
+
+tests :: TestTree
+tests = testGroup "unison" [ResourcePool.tests]
+
+main :: IO ()
+main = defaultMain tests

--- a/node/tests/Unison/Test/ResourcePool.hs
+++ b/node/tests/Unison/Test/ResourcePool.hs
@@ -38,17 +38,17 @@ fakeRelease :: TestState -> Resource -> IO ()
 fakeRelease s r = do
   saveState s "testreleases" r
 
-getPool = do
+getPool wait = do
   state <- M.empty
-  pool <- (RP.poolWithoutGC 3 (fakeAcquire state) (fakeRelease state))
+  pool <- (RP.poolWithoutGC wait 3 (fakeAcquire state) (fakeRelease state))
   return (pool, state)
 
 correctlyAcquiresTest :: Assertion
 correctlyAcquiresTest = do
-  (pool, ts) <- getPool
-  (resource, release1) <- RP.acquire pool "p1" 0
+  (pool, ts) <- getPool 0
+  (resource, release1) <- RP.acquire pool "p1"
   didAcquire <- release1
-                >> RP.acquire pool "p1" 0
+                >> RP.acquire pool "p1"
                 >> loadState ts "testacquires"
   didRelease <- loadState ts "testreleases"
 
@@ -58,16 +58,16 @@ correctlyAcquiresTest = do
 
 correctlyReleasesTest :: Assertion
 correctlyReleasesTest = do
-  (pool, ts) <- getPool
-  (_, releaser) <- RP.acquire pool "p1" 0
+  (pool, ts) <- getPool 0
+  (_, releaser) <- RP.acquire pool "p1"
   didRelease <- releaser >> loadState ts "testreleases"
   assertEqual "r was released after use" "p1r" didRelease
 
 acquireShouldCacheConnectionTest :: Assertion
 acquireShouldCacheConnectionTest = do
-  (pool, ts) <- getPool
-  (r, releaser1) <- RP.acquire pool "p1" 1
-  (r2, releaser2) <- releaser1 >> RP.acquire pool "p1" 1
+  (pool, ts) <- getPool 1
+  (r, releaser1) <- RP.acquire pool "p1"
+  (r2, releaser2) <- releaser1 >> RP.acquire pool "p1"
   didAcquire <- releaser2 >> loadState ts "testacquires"
   didRelease <- loadState ts "testreleases"
   -- a 100 second wait would prevent immediate release both times
@@ -76,11 +76,11 @@ acquireShouldCacheConnectionTest = do
 
 acquireCannotCacheTooManyConnections :: Assertion
 acquireCannotCacheTooManyConnections = do
-  (pool, ts) <- getPool
-  (r1, releaser1) <- RP.acquire pool "p1" 1
-  (r2, releaser2) <- RP.acquire pool "p2" 1
-  (r3, releaser3) <- RP.acquire pool "p3" 1
-  (r4, releaser4) <- RP.acquire pool "p4" 1
+  (pool, ts) <- getPool 1
+  (r1, releaser1) <- RP.acquire pool "p1"
+  (r2, releaser2) <- RP.acquire pool "p2"
+  (r3, releaser3) <- RP.acquire pool "p3"
+  (r4, releaser4) <- RP.acquire pool "p4"
   didRelease <- releaser1 >> releaser2 >> releaser3 >> releaser4
                 >> loadState ts "testreleases"
   assertEqual "only p4 got released" "p4r" didRelease
@@ -101,49 +101,22 @@ aThreeFullCache now threadId f1 f2 f3 =
              , (("p3",threadId), ("p3", inTenSeconds now, f3))
              ]
 
--- The reaper queue should only get a notification
--- of the key that might need to be reaped, it then
--- checks to see if the expiry has passed
-cleanPoolShouldReleaseFinalizer :: Assertion
-cleanPoolShouldReleaseFinalizer = do
-  ts <- M.empty
-  now <- getCurrentTime
-  threadId <- CC.myThreadId
-  q <- STM.atomically TQ.newTQueue
-  cache <- (aThreeFullCache now threadId
-                         (fakeRelease ts "p1")
-                         (fakeRelease ts "p2")
-                         (fakeRelease ts "p3"))
-  let k1 = ("p1", threadId)
-  let k2 = ("p2", threadId)
-  let k3 = ("p3", threadId)
-  -- signal all three to reaper queue
-  STM.atomically $ TQ.writeTQueue q k1
-                     >> TQ.writeTQueue q k2
-                     >> TQ.writeTQueue q k3
-  RP.cleanPool cache q
-  assertBool "p1 removed" <$> isNothing <$> M.lookup k1 cache
-  assertBool "p2 removed" <$> isNothing <$> M.lookup k2 cache
-  assertBool "p3 still cached" <$> isJust <$> M.lookup k3 cache
-  didRelease <- loadState ts "testreleases"
-  assertEqual "p1 and p2 are released" "p1p2" didRelease
-
-getPoolWithGC = do
+getPoolWithGC wait = do
   state <- M.empty
-  pool <- (RP.pool 3 (fakeAcquire state) (fakeRelease state))
+  pool <- (RP.pool wait 3 (fakeAcquire state) (fakeRelease state))
   return (pool, state)
 
 delaySeconds μs = threadDelay (1000000 * μs)
 
 threadGCsResourcesFromPoolTest :: Assertion
 threadGCsResourcesFromPoolTest = do
-  (pool, ts) <- getPoolWithGC
-  (_, release1) <- RP.acquire pool "p1" 2
+  (pool, ts) <- getPoolWithGC 2
+  (_, release1) <- RP.acquire pool "p1"
   didRelease1a <- release1
                     >> delaySeconds 1
                     >> loadState ts "testreleases"
   didRelease1b <- delaySeconds 3 >> loadState ts "testreleases"
-  (_, release2) <- RP.acquire pool "p2" 2
+  (_, release2) <- RP.acquire pool "p2"
   didRelease2a <- release2
                     >> delaySeconds 1
                     >> loadState ts "testreleases"
@@ -152,32 +125,6 @@ threadGCsResourcesFromPoolTest = do
     >> assertEqual "reaper released p1 after 3 seconds" "p1r" didRelease1b
     >> assertEqual "shouldn't immediately release p2" "p1r" didRelease2a
     >> assertEqual "reaper released p2 after 3 seconds" "p1rp2r" didRelease2b
-
--- T - Time, p - param, Q - reaper queue, E - Expiry Time, C - Cache
--- T1:  p1 acquired, released, Q(p1) on queue, C(p1,E16) cached
--- T2:  reaper awakens, Q(p1) peeked
---      cache shows C(p1,E16), read and re-enqueue Q(p1)
--- T3:  p2 acquired, released, Q(p2) on queue, C(p2,E5) cached
--- T5:  reaper awakens, Q(p2) peeked
---      cache shows C(p2,E5), read and release
---      Q(p1) peeked
---      cache shows C(p1,E16), read and re-enqueue Q(p1)
--- ...
--- T16: reaper awakens, Q(p1) peeked
---      cache shows C(p1, E16), read and release
-threadGCsWillReenqueueFutureReleasesTest :: Assertion
-threadGCsWillReenqueueFutureReleasesTest = do
-  (pool, ts) <- getPoolWithGC
-  (_, release1) <- RP.acquire pool "p1" 16
-  didRelease1 <- release1
-                    >> delaySeconds 3 -- allows the reaper to awake/sleep thrice
-                    >> loadState ts "testreleases"
-  (_, release2) <- RP.acquire pool "p2" 2
-  didRelease2 <- release2
-                    >> delaySeconds 4
-                    >> loadState ts "testreleases"
-  assertEqual "shouldn't immediately release p1" "" didRelease1
-    >> assertEqual "released p2" "p2r" didRelease2
 
 fakeGetThread :: CC.ThreadId -> IO CC.ThreadId
 fakeGetThread t = return t
@@ -189,9 +136,9 @@ acquireIsThreadSpecificTest = do
   q <- STM.atomically TQ.newTQueue
   pool <- M.empty
   someOtherThread <- forkIO (putStrLn "")
-  let aquire = RP._acquire (fakeAcquire ts) (fakeRelease ts) pool 3 ps q
-  (r1, release1) <- aquire CC.myThreadId "p1" 10
-  (r1b, release1b) <- release1 >> aquire (fakeGetThread someOtherThread) "p1" 10
+  let aquire = RP._acquire (fakeAcquire ts) (fakeRelease ts) pool 10 3 ps q
+  (r1, release1) <- aquire CC.myThreadId "p1"
+  (r1b, release1b) <- release1 >> aquire (fakeGetThread someOtherThread) "p1"
   didAcquire <- release1b >> loadState ts "testacquires"
 
   poolSize <- IORef.readIORef ps
@@ -203,10 +150,10 @@ acquireIsThreadSpecificTest = do
 
 acquireRemovesFromPoolTest :: Assertion
 acquireRemovesFromPoolTest = do
-  (pool, ts) <- getPool
-  (r1, release1) <- RP.acquire pool "p1" 1
-  (r2, _) <- release1 >> RP.acquire pool "p1" 1 -- acquire p1 a third time, without releasing r2
-  (r3, _) <-  RP.acquire pool "p1" 1
+  (pool, ts) <- getPool 1
+  (r1, release1) <- RP.acquire pool "p1"
+  (r2, _) <- release1 >> RP.acquire pool "p1" -- acquire p1 a third time, without releasing r2
+  (r3, _) <-  RP.acquire pool "p1"
   didAcquire <- loadState ts "testacquires"
   didRelease <- loadState ts "testreleases"
 
@@ -221,10 +168,8 @@ tests = testGroup "ResourcePool"
     testCase "correctlyAcquiresTest" $ correctlyAcquiresTest
     , testCase "correctlyReleasesTest" $ correctlyReleasesTest
     , testCase "acquireShouldCacheConnectionTest" $  acquireShouldCacheConnectionTest
-    , testCase "cleanPoolShouldReleaseFinalizer" $  cleanPoolShouldReleaseFinalizer
     , testCase "acquireCannotCacheTooManyConnections" $  acquireCannotCacheTooManyConnections
     , testCase "threadGCsResourcesFromPoolTest" $ threadGCsResourcesFromPoolTest
-    , testCase "threadGCsWillReenqueueFutureReleasesTest" $ threadGCsWillReenqueueFutureReleasesTest
     , testCase "acquireIsThreadSpecificTest" $ acquireIsThreadSpecificTest
     , testCase "acquireRemovesFromPoolTest" $ acquireRemovesFromPoolTest
     ]

--- a/node/tests/Unison/Test/ResourcePool.hs
+++ b/node/tests/Unison/Test/ResourcePool.hs
@@ -3,26 +3,48 @@ module Unison.Test.ResourcePool where
 import qualified Unison.Runtime.ResourcePool as RP
 import Test.Tasty
 import Test.Tasty.HUnit
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString as Str
 
 type Resource = String
 type Params = String
+
+loadState :: (Read a) => IO a
+loadState = read <$> BS.unpack <$> Str.readFile "testreleases"
+
+saveState :: (Show a) => a -> IO ()
+saveState x = Str.writeFile "testreleases" (BS.pack . show $ x)
 
 fakeAcquire :: Params -> IO Resource
 fakeAcquire p = return "r1"
 
 fakeRelease :: Resource -> IO ()
-fakeRelease r = return ()
+fakeRelease r = do
+  saveState r
+  return ()
 
-correctlyReturnsTest :: Assertion
-correctlyReturnsTest = do
+correctlyAcquiresTest :: Assertion
+correctlyAcquiresTest = do
+  saveState ""
   pool <- (RP.pool 3 fakeAcquire fakeRelease)
-  (r, _) <- RP.acquire pool "p1"
-  assertEqual "the correct resource is returned" "r1" r
+  (resource, _) <- RP.acquire pool "p1"
+  didRelease <- loadState
+  assertEqual "the correct resource is returned" "r1" resource
+    >> assertEqual "didn't call release" "" didRelease
+
+correctlyReleasesTest :: Assertion
+correctlyReleasesTest = do
+  saveState ""
+  pool <- (RP.pool 3 fakeAcquire fakeRelease)
+  (_, releaser) <- RP.acquire pool "p1"
+  didRelease <- releaser >> loadState
+  assertEqual "r was released after use" "r1" didRelease
 
 tests :: TestTree
 tests = testGroup "Doc"
   [
-    testCase "Test" $ correctlyReturnsTest
+    testCase "AcquiresTest" $ correctlyAcquiresTest,
+    testCase "ReleasesTest" $ correctlyReleasesTest
   ]
 
 main = defaultMain tests

--- a/node/tests/Unison/Test/ResourcePool.hs
+++ b/node/tests/Unison/Test/ResourcePool.hs
@@ -144,6 +144,13 @@ threadGCsResourcesFromCacheTest = do
     >> assertEqual "shouldn't immediately release p2" "p1r" didRelease2a
     >> assertEqual "auto released p2 after 3 seconds" "p1rp2r" didRelease2b
 
+getPoolWithCache = do
+  cache <- MVar.newMVar M.empty
+  testState <- MVar.newMVar M.empty
+  pool <- cleanTestFiles testState
+          >> (RP.poolWithoutGC 3 (fakeAcquire testState) (fakeRelease testState))
+  return (pool, testState, cache)
+
 tests :: TestTree
 tests = testGroup "Doc"
   [
@@ -152,7 +159,7 @@ tests = testGroup "Doc"
     , testCase "acquireShouldCacheConnectionTest" $  acquireShouldCacheConnectionTest
     , testCase "cleanCacheShouldReleaseFinalizer" $  cleanCacheShouldReleaseFinalizer
     , testCase "acquireCannotCacheTooManyConnections" $  acquireCannotCacheTooManyConnections
-    , testCase "threadGCsResourcesFromCacheTest " $  threadGCsResourcesFromCacheTest
-   ]
+    , testCase "threadGCsResourcesFromCacheTest" $  threadGCsResourcesFromCacheTest
+    ]
 
 main = defaultMain tests

--- a/node/tests/Unison/Test/ResourcePool.hs
+++ b/node/tests/Unison/Test/ResourcePool.hs
@@ -174,10 +174,10 @@ acquireRemovesFromCacheTest = do
     >> assertEqual "r is acquired twice" "p1rp1r" didAcquire
 
 tests :: TestTree
-tests = testGroup "Doc"
+tests = testGroup "ResourcePool"
   [
-    testCase "AcquiresTest" $ correctlyAcquiresTest
-    , testCase "ReleasesTest" $ correctlyReleasesTest
+    testCase "correctlyAcquiresTest" $ correctlyAcquiresTest
+    , testCase "correctlyReleasesTest" $ correctlyReleasesTest
     , testCase "acquireShouldCacheConnectionTest" $  acquireShouldCacheConnectionTest
     , testCase "cleanCacheShouldReleaseFinalizer" $  cleanCacheShouldReleaseFinalizer
     , testCase "acquireCannotCacheTooManyConnections" $  acquireCannotCacheTooManyConnections

--- a/node/tests/Unison/Test/ResourcePool.hs
+++ b/node/tests/Unison/Test/ResourcePool.hs
@@ -1,0 +1,28 @@
+module Unison.Test.ResourcePool where
+
+import qualified Unison.Runtime.ResourcePool as RP
+import Test.Tasty
+import Test.Tasty.HUnit
+
+type Resource = String
+type Params = String
+
+fakeAcquire :: Params -> IO Resource
+fakeAcquire p = return "r1"
+
+fakeRelease :: Resource -> IO ()
+fakeRelease r = return ()
+
+correctlyReturnsTest :: Assertion
+correctlyReturnsTest = do
+  pool <- (RP.pool 3 fakeAcquire fakeRelease)
+  (r, _) <- RP.acquire pool "p1"
+  assertEqual "the correct resource is returned" "r1" r
+
+tests :: TestTree
+tests = testGroup "Doc"
+  [
+    testCase "Test" $ correctlyReturnsTest
+  ]
+
+main = defaultMain tests

--- a/node/tests/Unison/Test/ResourcePool.hs
+++ b/node/tests/Unison/Test/ResourcePool.hs
@@ -3,7 +3,6 @@ module Unison.Test.ResourcePool where
 import qualified Unison.Runtime.ResourcePool as RP
 import Test.Tasty
 import Test.Tasty.HUnit
-import qualified System.IO.Strict as ST
 import Control.Concurrent
 import Data.Time (UTCTime,getCurrentTime, addUTCTime)
 import qualified Control.Concurrent.MVar as MVar
@@ -11,64 +10,74 @@ import qualified Data.Map as M
 
 type Resource = String
 type Params = String
+type TestState = MVar.MVar (M.Map String String)
 
-loadState :: FilePath -> IO String
-loadState p = do
-  c <- ST.readFile p
-  length c `seq` return c
+lookupState :: M.Map String String -> String -> String
+lookupState m k =
+  case (M.lookup k m) of
+    Just s -> s
+    Nothing -> ""
 
-saveState :: String -> FilePath -> IO ()
-saveState x p = do
-  s <- loadState p
-  length s `seq` writeFile p (s++x)
+loadState :: TestState -> String -> IO String
+loadState var k = do
+  m <- MVar.readMVar var
+  return (lookupState m k)
 
-clearState :: FilePath -> IO ()
-clearState p = writeFile p ""
+saveState :: TestState -> String -> String -> IO ()
+saveState var k newState = do
+  m <- MVar.takeMVar var
+  let s = lookupState m k
+  MVar.putMVar var (M.insert k (s++newState) m)
 
-fakeAcquire :: Params -> IO Resource
-fakeAcquire p = do
-  saveState (p++"r") "testacquires"
+fakeAcquire :: TestState -> Params -> IO Resource
+fakeAcquire s p = do
+  saveState s "testacquires" (p++"r")
   >> return (p++"r")
 
-cleanTestFiles =
-  clearState "testreleases"
-  >> clearState "testacquires"
+cleanTestFiles s =
+  saveState s "testacquires" ""
+  >> saveState s "testacquires" ""
 
-fakeRelease :: Resource -> IO ()
-fakeRelease r = do
-  saveState r "testreleases"
-  >> return ()
+fakeRelease :: TestState -> Resource -> IO ()
+fakeRelease s r = do
+  saveState s "testreleases" r
+
+getPool = do
+  state <- MVar.newMVar M.empty
+  pool <- cleanTestFiles state
+          >> (RP.pool 3 (fakeAcquire state) (fakeRelease state))
+  return (pool, state)
 
 correctlyAcquiresTest :: Assertion
 correctlyAcquiresTest = do
-  x <- cleanTestFiles
-  pool <- (RP.pool 3 fakeAcquire fakeRelease)
-  (resource, _) <- RP.acquire pool "p1" 0
-  (r2, _) <- RP.acquire pool "p1" 0
-  didAcquire <- loadState "testacquires"
-  didRelease <- loadState "testreleases"
+  (pool, ts) <- getPool
+  (resource, release1) <- RP.acquire pool "p1" 0
+  didAcquire <- release1
+                >> RP.acquire pool "p1" 0
+                >> loadState ts "testacquires"
+  didRelease <- loadState ts "testreleases"
 
   assertEqual "the correct resource is returned" "p1r" resource
     >> assertEqual "r is acquired twice" "p1rp1r" didAcquire
-    >> assertEqual "didn't call release" "" didRelease
+    >> assertEqual "called release once" "p1r" didRelease
 
 correctlyReleasesTest :: Assertion
 correctlyReleasesTest = do
-  x <- cleanTestFiles
-  pool <- (RP.pool 3 fakeAcquire fakeRelease)
+  (pool, ts) <- getPool
   (_, releaser) <- RP.acquire pool "p1" 0
-  didRelease <- releaser >> loadState "testreleases"
+  didRelease <- releaser >> loadState ts "testreleases"
   assertEqual "r was released after use" "p1r" didRelease
 
 acquireShouldCacheConnectionTest :: Assertion
 acquireShouldCacheConnectionTest = do
-  x <- cleanTestFiles
-  pool <- (RP.pool 3 fakeAcquire fakeRelease)
-  (r, _) <- RP.acquire pool "p1" 100000 -- 100 seconds
-  (r2, _) <- RP.acquire pool "p1" 100000 -- 100 seconds
-  didAcquire <- loadState "testacquires"
+  (pool, ts) <- getPool
+  (r, releaser1) <- RP.acquire pool "p1" 100000 -- 100 seconds
+  (r2, releaser2) <- releaser1 >> RP.acquire pool "p1" 100000 -- 100 seconds
+  didAcquire <- releaser2 >> loadState ts "testacquires"
+  didRelease <- loadState ts "testreleases"
+  -- a 100 second wait would prevent immediate release both times
   assertEqual "r was only acquired once" "p1r" didAcquire
-
+    >> assertEqual "didn't call release" "" didRelease
 
 tenSecondsAgo :: UTCTime -> UTCTime
 tenSecondsAgo now = addUTCTime (-10) now
@@ -76,30 +85,44 @@ tenSecondsAgo now = addUTCTime (-10) now
 inTenSeconds :: UTCTime -> UTCTime
 inTenSeconds now = addUTCTime (10) now
 
-emptyCache now = M.fromList [("p1", ("p1r", now))
-                        , ("p2", ("p2r", tenSecondsAgo now))
-                        , ("p3", ("p3r", inTenSeconds now))
-                        ]
-cleanCacheTest :: Assertion
-cleanCacheTest = do
+aThreeFullCache now f1 f2 f3=
+  M.fromList [("p1", ("p1", now, f1))
+             , ("p2", ("p2", tenSecondsAgo now, f2))
+             , ("p3", ("p3", inTenSeconds now, f3))
+             ]
+
+cleanCacheShouldReleaseFinalizer :: Assertion
+cleanCacheShouldReleaseFinalizer = do
+  (pool, ts) <- getPool
   now <- getCurrentTime
-  cache <- MVar.newMVar (emptyCache now)
+  cache <- MVar.newMVar (aThreeFullCache now
+                         (fakeRelease ts "p1")
+                         (fakeRelease ts "p2")
+                         (fakeRelease ts "p3"))
   RP.cleanCache cache
   c <- MVar.takeMVar cache
+  didRelease <- loadState ts "testreleases"
+
   assertEqual "p1 and p2 are cleaned from cache" ["p3"] (M.keys c)
+    >> assertEqual "p1 and p2 are released" "p1p2" didRelease
+
+
+getPoolWithGC = do
+  state <- MVar.newMVar M.empty
+  pool <- cleanTestFiles state
+          >> (RP.poolWithGC 3 (fakeAcquire state) (fakeRelease state))
+  return (pool, state)
 
 threadGCsResourcesFromCacheTest :: Assertion
 threadGCsResourcesFromCacheTest = do
-  x <- cleanTestFiles
-  pool <- (RP.pool 3 fakeAcquire fakeRelease)
-  (resource, _) <- RP.acquire pool "p1" 1
-  threadDelay 3
-  (r2, _) <- RP.acquire pool "p1" 1
-  didAcquire <- loadState "testacquires"
-  didRelease <- loadState "testreleases"
-
-  assertEqual "r is acquired twice" "p1rp1r" didAcquire
-    >> assertEqual "didn't call release" "" didRelease
+  (pool, ts) <- getPoolWithGC
+  (resource, release1) <- RP.acquire pool "p1" 4
+  didRelease1 <- release1
+                    >> threadDelay 1
+                    >> loadState ts "testreleases"
+  didRelease2 <- threadDelay 5 >> loadState ts "testreleases"
+  assertEqual "didn't immediately release" "" didRelease1
+    >> assertEqual "auto released after 3 seconds" "p1r" didRelease2
 
 tests :: TestTree
 tests = testGroup "Doc"
@@ -107,8 +130,8 @@ tests = testGroup "Doc"
     testCase "AcquiresTest" $ correctlyAcquiresTest
     , testCase "ReleasesTest" $ correctlyReleasesTest
     , testCase "acquireShouldCacheConnectionTest" $  acquireShouldCacheConnectionTest
-    -- , testCase "threadGCsResourcesFromCacheTest " $  threadGCsResourcesFromCacheTest
-    , testCase "cleanCacheTest" $  cleanCacheTest
+    , testCase "threadGCsResourcesFromCacheTest " $  threadGCsResourcesFromCacheTest
+    , testCase "cleanCacheShouldReleaseFinalizer" $  cleanCacheShouldReleaseFinalizer
    ]
 
 main = defaultMain tests

--- a/node/unison-node.cabal
+++ b/node/unison-node.cabal
@@ -77,6 +77,7 @@ library
     prelude-extras,
     scotty,
     text,
+    time,
     transformers,
     transformers-compat,
     unison-shared,
@@ -119,6 +120,7 @@ executable node
     prelude-extras,
     scotty,
     text,
+    time,
     transformers,
     transformers-compat,
     unison-node,
@@ -136,10 +138,10 @@ test-suite tests
   build-depends:
     base,
     containers,
+    strict,
     tasty,
     tasty-hunit,
     tasty-smallcheck,
     tasty-quickcheck,
     transformers,
-    unison-node,
-    bytestring 
+    unison-node

--- a/node/unison-node.cabal
+++ b/node/unison-node.cabal
@@ -59,31 +59,34 @@ library
     Unison.Runtime.ResourcePool
 
   build-depends:
-    aeson,
-    applicative-extras,
-    attoparsec,
-    base,
-    blaze-html,
-    bytes,
-    bytestring,
-    byteable,
-    cereal,
-    containers,
-    cryptohash,
-    directory,
-    filepath,
-    http-types,
-    mtl,
-    prelude-extras,
-    scotty,
-    text,
-    time,
-    transformers,
-    transformers-compat,
-    unison-shared,
-    vector,
-    wai-middleware-static,
-    wai-extra
+                  aeson
+                , applicative-extras
+                , attoparsec
+                , base
+                , blaze-html
+                , byteable
+                , bytes
+                , bytestring
+                , cereal
+                , containers
+                , cryptohash
+                , ctrie
+                , directory
+                , filepath
+                , hashable
+                , http-types
+                , mtl
+                , prelude-extras
+                , scotty
+                , stm
+                , text
+                , time
+                , transformers
+                , transformers-compat
+                , unison-shared
+                , vector
+                , wai-extra
+                , wai-middleware-static
 
   ghc-options: -Wall -fno-warn-name-shadowing -threaded -rtsopts -with-rtsopts=-N
 
@@ -102,32 +105,35 @@ executable node
     ghc-options: -funbox-strict-fields -O2
 
   build-depends:
-    aeson,
-    applicative-extras,
-    attoparsec,
-    base,
-    blaze-html,
-    bytes,
-    bytestring,
-    byteable,
-    cereal,
-    containers,
-    cryptohash,
-    directory,
-    filepath,
-    http-types,
-    mtl,
-    prelude-extras,
-    scotty,
-    text,
-    time,
-    transformers,
-    transformers-compat,
-    unison-node,
-    unison-shared,
-    vector,
-    wai-middleware-static,
-    wai-extra
+                  aeson
+                , applicative-extras
+                , attoparsec
+                , base
+                , blaze-html
+                , byteable
+                , bytes
+                , bytestring
+                , cereal
+                , containers
+                , cryptohash
+                , ctrie
+                , directory
+                , filepath
+                , hashable
+                , http-types
+                , mtl
+                , prelude-extras
+                , scotty
+                , stm
+                , text
+                , time
+                , transformers
+                , transformers-compat
+                , unison-node
+                , unison-shared
+                , vector
+                , wai-extra
+                , wai-middleware-static
 
 test-suite tests
   type:           exitcode-stdio-1.0
@@ -138,6 +144,8 @@ test-suite tests
   build-depends:
     base,
     containers,
+    ctrie,
+    hashable,
     tasty,
     tasty-hunit,
     tasty-smallcheck,

--- a/node/unison-node.cabal
+++ b/node/unison-node.cabal
@@ -138,7 +138,6 @@ test-suite tests
   build-depends:
     base,
     containers,
-    strict,
     tasty,
     tasty-hunit,
     tasty-smallcheck,

--- a/node/unison-node.cabal
+++ b/node/unison-node.cabal
@@ -141,4 +141,5 @@ test-suite tests
     tasty-smallcheck,
     tasty-quickcheck,
     transformers,
-    unison-node
+    unison-node,
+    bytestring 

--- a/node/unison-node.cabal
+++ b/node/unison-node.cabal
@@ -146,6 +146,7 @@ test-suite tests
     containers,
     ctrie,
     hashable,
+    stm,
     tasty,
     tasty-hunit,
     tasty-smallcheck,

--- a/node/unison-node.cabal
+++ b/node/unison-node.cabal
@@ -143,5 +143,6 @@ test-suite tests
     tasty-hunit,
     tasty-smallcheck,
     tasty-quickcheck,
+    time,
     transformers,
     unison-node

--- a/node/unison-node.cabal
+++ b/node/unison-node.cabal
@@ -56,6 +56,7 @@ library
     Unison.Runtime.Pcbt
     Unison.Runtime.Unfold
     Unison.Runtime.Vector
+    Unison.Runtime.ResourcePool
 
   build-depends:
     aeson,
@@ -125,3 +126,19 @@ executable node
     vector,
     wai-middleware-static,
     wai-extra
+
+test-suite tests
+  type:           exitcode-stdio-1.0
+  main-is:        Suite.hs
+  ghc-options:    -w -threaded -rtsopts -with-rtsopts=-N -v0
+  hs-source-dirs: tests
+  other-modules:
+  build-depends:
+    base,
+    containers,
+    tasty,
+    tasty-hunit,
+    tasty-smallcheck,
+    tasty-quickcheck,
+    transformers,
+    unison-node

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,3 +8,4 @@ resolver: lts-3.10
 
 extra-deps:
   - applicative-extras-0.1.8
+  - ctrie-0.1.0.3


### PR DESCRIPTION
Should match what is in the feature request. I added the check to allow different threads to each have their own resource in the pool, so they are segregated by parameter and ThreadId.

The entry points are ```pool``` and ```poolWithoutGC```. The regular ```pool``` will spawn a second thread that checks for expired resources every second. The ```poolWithoutGC``` will not spawn that thread, so the cache will never be cleaned.

The one gotcha right now is what happens when several requests are made to the same resource from the same thread without any of the requests being released. Right now that will cause undefined behavior as each "release" will overwrite the previous releases entry in the pool. I am not sure exactly what should happen in that case. 

It should be fairly well tested, which might account for a few oddities in the function signatures (like passing around a getter for the ThreadId). I am not sure how idiomatic that is in regular Haskell, but it struck me as better than manually testing everything.

Feel free to comment/reject, I am happy to change whatever!