### PR TITLE
Correct editor yam file path in Docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update -q && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 ADD stack.yaml /opt/unison/stack.yaml
 RUN stack setup
-ADD editor/stack.yaml /opt/unison/editor/stack.yaml
+ADD editor.yaml /opt/unison/editor/stack.yaml
 RUN cd editor && stack setup
 ADD shared/unison-shared.cabal /opt/unison/shared/unison-shared.cabal
 ADD node/unison-node.cabal /opt/unison/node/unison-node.cabal


### PR DESCRIPTION
When trying to run the Docker command `docker build -t unisonweb/platform .` on OSX with the latest Docker beta. The command failed as it couldn't find the editor yaml.