### PR TITLE
updating resolver

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,7 @@ packages:
 - shared
 - node
 
-resolver: lts-3.10
+resolver: lts-5.9
 
 extra-deps:
   - applicative-extras-0.1.8


### PR DESCRIPTION
There seem to be a few packages missing from lts-3.10, such as haskell-leveldb. I chose 5.9 because it's the latest resolver available for my distro (nixos).

I've run stack test with the new resolver.