### PR TITLE
Revised sticky resource pool implementation

### DIFF
--- a/node/src/Unison/Runtime/ResourcePool.hs
+++ b/node/src/Unison/Runtime/ResourcePool.hs
@@ -67,7 +67,7 @@ lookupQueue p (Cache _ m) = do
       q <- STM.atomically TQ.newTQueue
       qSize <- STM.atomically (TVar.newTVar 0)
       let tweak old = Just $ fromMaybe (qSize,q) old
-      STM.atomically $ TVar.modifyTVar' m (\m -> Map.alter tweak p  m)
+      STM.atomically $ TVar.modifyTVar' m (\m -> Map.alter tweak p m)
       pure (qSize, q)
     Just q -> pure q
 
@@ -108,7 +108,7 @@ _acquire acquire release cache waitInSeconds maxPoolSize p = do
             -- if an acquire succeeds at the same time, the TMVar will be empty, so noop
             msg <- STM.atomically $ TMVar.tryTakeTMVar r'
             case msg of
-              Nothing -> pure ();
+              Nothing -> pure ()
               Just _ -> release >> STM.atomically (TVar.modifyTVar' qn (\n -> n - 1))
             STM.atomically $ do -- GC empty queues
               n <- TVar.readTVar qn

--- a/node/src/Unison/Runtime/ResourcePool.hs
+++ b/node/src/Unison/Runtime/ResourcePool.hs
@@ -1,82 +1,146 @@
 module Unison.Runtime.ResourcePool where
 
+import Control.Concurrent.MVar (MVar)
 import Data.Time (UTCTime, getCurrentTime, addUTCTime, diffUTCTime)
 import qualified Control.Concurrent as CC
+import qualified Control.Concurrent.MVar as MVar
 import qualified Control.Concurrent.Map as M
 import qualified Control.Concurrent.STM.TQueue as TQ
-import qualified Data.Hashable as H
 import qualified Control.Monad.STM as STM
+import qualified Data.Hashable as H
 import qualified Data.IORef as IORef
 
--- acquire returns the resource, and the cleanup action ("finalizer") for that resource
-data Pool p r = Pool { acquire :: p -> IO (r, IO ()) }
+-- | `acquire` returns the resource, and the cleanup action ("finalizer") for that resource
+data ResourcePool p r = ResourcePool { acquire :: p -> IO (r, IO ()) }
 
-type ResourceKey p = (p,CC.ThreadId)
-type Cache p r = M.Map (ResourceKey p) (r, UTCTime, IO ())
-type ReaperQueue p = TQ.TQueue (ResourceKey p)
+{-
+The `ResourcePool p r` is backed by a mutable `Map p (RecycleQueue r)`.
+The `RecycleQueue r` is a queue of resources that have been logically
+'released' but are available for recycling. After their expiration, a
+separate 'reaper thread' will remove them from the queue.
+
+The basic logic for `acquire` is:
+
+1.  Try to obtain a recycled resource for the requested key.
+2a. If that succeeds, the resource is taken from the recycle queue,
+    preventing multiple threads from accessing the same resource.
+2b. If that fails, acquire a fresh resource.
+3.  The returned finalizer just adds an entry to the recycle queue,
+    for the recycled or newly acquired resource, with a new expiration
+    based a delta plus the time the finalizer is called.
+
+Thus, multiple resources may be acquired for the same key simultaneously,
+and these resources will be recycled if another acquisition occurs before
+expiration.
+-}
+
+data Cache p r =
+  Cache { count :: IORef.IORef PoolSize
+        , lock :: MVar ()  -- used as a lock when allocating new RecycleQueue
+        , recycleQueues :: M.Map p (RecycleQueue r) }
+
+type RecycleQueue r = TQ.TQueue (r, UTCTime, IO ())
+type ReaperQueue p = TQ.TQueue p
 type MaxPoolSize = Int
 type Seconds = Int
 type PoolSize = Int
 
-incRef :: Num t => t -> (t, ())
-incRef a = (a+1,())
-decRef :: Num t => t -> (t, ())
-decRef a = (a-1,())
+incrementCount :: Cache p r -> IO ()
+incrementCount (Cache count _ _) = IORef.atomicModifyIORef' count (\a -> (a+1, ()))
 
-addResourceToMap :: (Ord p, H.Hashable p) =>  (r -> IO ()) -> Cache p r -> p -> r -> Seconds -> MaxPoolSize -> IO CC.ThreadId -> IORef.IORef PoolSize -> ReaperQueue p -> IO ()
-addResourceToMap release pool p r waitInSeconds maxPoolSize getThread poolSizeR queue = do
+decrementCount :: Cache p r -> IO ()
+decrementCount (Cache count _ _) = IORef.atomicModifyIORef' count (\a -> (a-1, ()))
+
+getCount :: Cache p r -> IO Int
+getCount (Cache count _ _) = IORef.readIORef count
+
+drainQueue :: RecycleQueue r -> IO ()
+drainQueue q = do
+  (_, _, release) <- STM.atomically $ TQ.readTQueue q
+  release
+  drainQueue q
+
+deleteQueue :: (Ord p, H.Hashable p) => p -> Cache p r -> IO ()
+deleteQueue p (Cache count lock m) = do
+  q <- M.lookup p m
+  case q of
+    Nothing -> pure ()
+    Just q -> do
+      M.delete p m
+      -- ensures we don't miss calling any finalizers, drain thread will get GC'd
+      _ <- CC.forkIO $ drainQueue q
+      pure ()
+
+lookupQueue :: (Ord p, H.Hashable p) => p -> Cache p r -> IO (RecycleQueue r)
+lookupQueue p (Cache count lock m) = do
+  q <- M.lookup p m
+  case q of
+    Nothing -> do
+      MVar.takeMVar lock
+      q <- STM.atomically TQ.newTQueue
+      M.insert p q m
+      MVar.putMVar lock ()
+      pure q
+    Just q -> pure q
+
+_acquire :: (Ord p, H.Hashable p)
+         => (p -> IO r)
+         -> (r -> IO ())
+         -> Cache p r
+         -> Seconds
+         -> MaxPoolSize
+         -> ReaperQueue p
+         -> p
+         -> IO (r, IO ())
+_acquire acquire release cache waitInSeconds maxPoolSize reaper p = do
+  q <- lookupQueue p cache
+  avail <- STM.atomically $ TQ.tryReadTQueue q
+  (r, release) <- case avail of
+    Nothing -> do
+      r <- acquire p
+      incrementCount cache
+      pure (r, release r)
+    Just (r, _, release) -> pure (r, release)
+  delayedRelease <- pure $ do
+    now <- getCurrentTime
+    currentSize <- IORef.readIORef (count cache)
+    case currentSize of
+      n | n >= maxPoolSize -> release
+        | otherwise        -> STM.atomically $ TQ.writeTQueue q (r, expiry, release)
+          where expiry = addUTCTime (fromIntegral waitInSeconds) now
+  STM.atomically $ TQ.writeTQueue reaper p
+  pure (r, delayedRelease)
+
+reaper :: (Ord p, H.Hashable p) => Cache p r -> ReaperQueue p -> IO ()
+reaper cache queue = do
+  key <- STM.atomically $ TQ.readTQueue queue
+  valueQueue <- lookupQueue key cache
+  value <- STM.atomically $ TQ.tryReadTQueue valueQueue
   now <- getCurrentTime
-  poolSize <- IORef.readIORef poolSizeR
-  threadId <- getThread
-  let expiry = addUTCTime (fromIntegral waitInSeconds) now
-  let key = (p,threadId)
-  if waitInSeconds > 0 && (poolSize < maxPoolSize) then
-    -- add the resource to the pool with the release
-    M.insert key (r, expiry, (release r)) pool
-      >> IORef.atomicModifyIORef poolSizeR incRef
-      >> STM.atomically (TQ.writeTQueue queue key)
-    else release r
-
-_acquire :: (Ord p, H.Hashable p) => (p -> IO r) -> (r -> IO ()) -> Cache p r -> Seconds -> MaxPoolSize -> IORef.IORef PoolSize -> ReaperQueue p -> IO CC.ThreadId -> p -> IO (r, IO ())
-_acquire acquire release pool waitInSeconds maxPoolSize poolSizeR queue getThread p = do
-  threadId <- getThread
-  m <- M.lookup (p,threadId) pool
-  r <- case m of
-        Just (r, _, _) -> M.delete (p,threadId) pool
-          >> IORef.atomicModifyIORef poolSizeR decRef
-          >> return r
-        Nothing -> acquire p
-  return (r, (addResourceToMap release pool p r waitInSeconds maxPoolSize getThread poolSizeR queue))
-
-cleanPool :: (Ord p, H.Hashable p) => Cache p r -> ReaperQueue p -> IO ()
-cleanPool pool queue = do
-  key <- STM.atomically $ TQ.peekTQueue queue
-  now <- getCurrentTime
-  value <- M.lookup key pool
   case value of
-    Just (_, expiry, releaser) ->
-      if expiry < now then
-        (STM.atomically $ TQ.readTQueue queue)
-          >> M.delete key pool
-          >> releaser
-          >> cleanPool pool queue
-      else
-        let nextExpiry = round ((realToFrac $ diffUTCTime now expiry)::Double)
-        in CC.threadDelay (1000000*nextExpiry)
-             >> cleanPool pool queue
-    Nothing -> return ()
+    Just (_, expiry, releaser) | expiry < now -> do
+      empty <- STM.atomically (TQ.isEmptyTQueue valueQueue)
+      case empty of
+        True -> deleteQueue key cache
+        False -> pure ()
+      decrementCount cache
+      releaser
+      reaper cache queue
+    Just r@(_, expiry, _) -> do
+      let nextExpiry = round ((realToFrac $ diffUTCTime now expiry) :: Double)
+      STM.atomically $ TQ.unGetTQueue valueQueue r
+      STM.atomically $ TQ.unGetTQueue queue key
+      CC.threadDelay (1000000 * nextExpiry)
+      reaper cache queue
+    Nothing -> reaper cache queue
 
-pool :: (Ord p, H.Hashable p) => Seconds -> MaxPoolSize -> (p -> IO r) -> (r -> IO ()) -> IO (Pool p r)
-pool waitInSeconds maxPoolSize acquire release = do
-  pool <- M.empty
-  q <- STM.atomically TQ.newTQueue
-  ps  <- IORef.newIORef 0
-  _ <- CC.forkIO (cleanPool pool q)
-  return Pool { acquire = _acquire acquire release pool waitInSeconds maxPoolSize ps q CC.myThreadId }
-
-poolWithoutGC :: (Ord p, H.Hashable p) => Seconds -> MaxPoolSize -> (p -> IO r) -> (r -> IO ()) -> IO (Pool p r)
-poolWithoutGC waitInSeconds maxPoolSize acquire release = do
-  pool <- M.empty
-  q <- STM.atomically TQ.newTQueue
-  ps  <- IORef.newIORef 0
-  return Pool { acquire = _acquire acquire release pool waitInSeconds maxPoolSize ps q CC.myThreadId }
+make :: (Ord p, H.Hashable p)
+     => Seconds -> MaxPoolSize -> (p -> IO r) -> (r -> IO ()) -> IO (ResourcePool p r)
+make waitInSeconds maxPoolSize acquire release = do
+  ps <- IORef.newIORef 0
+  lock <- MVar.newMVar ()
+  recycleQueues <- M.empty
+  reaperQueue <- STM.atomically TQ.newTQueue
+  let cache = Cache ps lock recycleQueues
+  _ <- CC.forkIO (reaper cache reaperQueue)
+  pure $ ResourcePool { acquire = _acquire acquire release cache waitInSeconds maxPoolSize reaperQueue }

--- a/node/tests/Unison/Test/ResourcePool.hs
+++ b/node/tests/Unison/Test/ResourcePool.hs
@@ -80,7 +80,7 @@ delaySeconds μs = threadDelay (1000000 * μs)
 
 eventually :: Assertion -> Assertion
 eventually cond = go 1 where
-  go n | n > 32 = cond
+  go n | n > 8 = cond
   go n = cond <|> (delaySeconds n >> go (n*2))
 
 tests :: TestTree

--- a/node/tests/Unison/Test/ResourcePool.hs
+++ b/node/tests/Unison/Test/ResourcePool.hs
@@ -1,180 +1,93 @@
 module Unison.Test.ResourcePool where
 
-import qualified Unison.Runtime.ResourcePool as RP
+import Control.Concurrent
+import Control.Applicative
+import Control.Monad
+import Data.Functor
+import Data.IORef (IORef)
+import Data.Maybe
+import Data.Time (UTCTime,getCurrentTime, addUTCTime)
 import Test.Tasty
 import Test.Tasty.HUnit
-import Control.Concurrent
-import Data.Time (UTCTime,getCurrentTime, addUTCTime)
 import qualified Control.Concurrent as CC
-import qualified Control.Monad.STM as STM
-import qualified Data.IORef as IORef
-import qualified Data.Hashable as H
+import qualified Control.Concurrent.MVar as MVar
 import qualified Control.Concurrent.Map as M
 import qualified Control.Concurrent.STM.TQueue as TQ
-import Data.Maybe
+import qualified Control.Monad.STM as STM
+import qualified Data.Hashable as H
+import qualified Data.IORef as IORef
+import qualified Unison.Runtime.ResourcePool as RP
 
 type Resource = String
 type Params = String
 type TestState = M.Map String String
 
-{-
-loadState :: TestState -> String -> IO String
-loadState m k = do
-  x <- M.lookup k m
-  return $ case x of
-              Just s -> s
-              Nothing -> ""
+increment :: IORef Int -> IO Int
+increment ref = IORef.atomicModifyIORef' ref (\n -> (n+1, n))
 
-saveState :: TestState -> String -> String -> IO ()
-saveState m k newState = do
-  s <- loadState m k
-  M.insert k (s++newState) m
+decrement :: IORef Int -> IO Int
+decrement ref = IORef.atomicModifyIORef' ref (\n -> (n-1, n))
 
-fakeAcquire :: TestState -> Params -> IO Resource
-fakeAcquire s p = do
-  saveState s "testacquires" (p++"r")
-  >> return (p++"r")
+makePool :: RP.MaxPoolSize -> IO (RP.ResourcePool Int Int, Assertion)
+makePool maxSize = do
+  rs <- IORef.newIORef 0
+  nonce <- IORef.newIORef 0
+  pool <- RP.make 1 maxSize (\_ -> increment rs >> increment nonce) (\_ -> decrement rs $> ())
+  pure (pool, IORef.readIORef rs >>= \n -> if n == 0 then pure () else fail $ "count nonzero: " ++ show n)
 
-fakeRelease :: TestState -> Resource -> IO ()
-fakeRelease s r = do
-  saveState s "testreleases" r
+acquireSequential1 :: Assertion
+acquireSequential1 = do
+  (pool, ok) <- makePool 10
+  replicateM_ 100 (RP.acquire pool 42 >>= \(n, release) -> assertEqual "resource not recycled" 0 n >> release)
+  eventually ok
 
-getPool wait = do
-  state <- M.empty
-  pool <- RP.make wait 3 (fakeAcquire state) (fakeRelease state)
-  return (pool, state)
+acquireSequential2 :: Assertion
+acquireSequential2 = do
+  (pool, ok) <- makePool 100
+  -- let check n = putStrLn $ "got: " ++ show n
+  let check n = assertEqual "resource not recycled" True (n <= 100)
+  let acquire i = RP.acquire pool i >>= \(n, release) -> check n >> release
+  mapM_ acquire ([1..100] ++ [1..100]) -- second 100 acquires should get cached
+  eventually ok
 
-correctlyAcquiresTest :: Assertion
-correctlyAcquiresTest = do
-  (pool, ts) <- getPool 0
-  (resource, release1) <- RP.acquire pool "p1"
-  didAcquire <- release1
-                >> RP.acquire pool "p1"
-                >> loadState ts "testacquires"
-  didRelease <- loadState ts "testreleases"
+parallelTraverse :: (a -> IO b) -> [a] -> IO [b]
+parallelTraverse f xs = sequence =<< mapM spawn xs where
+  spawn a = do
+    r <- MVar.newEmptyMVar
+    _ <- CC.forkIO $ f a >>= \b -> MVar.putMVar r b
+    pure (MVar.takeMVar r)
 
-  assertEqual "the correct resource is returned" "p1r" resource
-    >> assertEqual "r is acquired twice" "p1rp1r" didAcquire
-    >> assertEqual "called release once" "p1r" didRelease
+parallelSequence :: [IO a] -> IO [a]
+parallelSequence = parallelTraverse id
 
-correctlyReleasesTest :: Assertion
-correctlyReleasesTest = do
-  (pool, ts) <- getPool 0
-  (_, releaser) <- RP.acquire pool "p1"
-  didRelease <- releaser >> loadState ts "testreleases"
-  assertEqual "r was released after use" "p1r" didRelease
+parallelSequence_ :: [IO a] -> IO ()
+parallelSequence_ ios = void $ parallelSequence ios
 
-acquireShouldCacheConnectionTest :: Assertion
-acquireShouldCacheConnectionTest = do
-  (pool, ts) <- getPool 1
-  (r, releaser1) <- RP.acquire pool "p1"
-  (r2, releaser2) <- releaser1 >> RP.acquire pool "p1"
-  didAcquire <- releaser2 >> loadState ts "testacquires"
-  didRelease <- loadState ts "testreleases"
-  -- a 100 second wait would prevent immediate release both times
-  assertEqual "r was only acquired once" "p1r" didAcquire
-    >> assertEqual "didn't call release" "" didRelease
+acquireConcurrent1 :: Assertion
+acquireConcurrent1 = do
+  (pool, ok) <- makePool 10
+  parallelSequence_ $ replicate 100 (RP.acquire pool 42 >>= \(n, release) -> release)
+  eventually ok
 
-acquireCannotCacheTooManyConnections :: Assertion
-acquireCannotCacheTooManyConnections = do
-  (pool, ts) <- getPool 1
-  (r1, releaser1) <- RP.acquire pool "p1"
-  (r2, releaser2) <- RP.acquire pool "p2"
-  (r3, releaser3) <- RP.acquire pool "p3"
-  (r4, releaser4) <- RP.acquire pool "p4"
-  didRelease <- releaser1 >> releaser2 >> releaser3 >> releaser4
-                >> loadState ts "testreleases"
-  assertEqual "only p4 got released" "p4r" didRelease
-
-tenSecondsAgo :: UTCTime -> UTCTime
-tenSecondsAgo now = addUTCTime (-10) now
-
-twentySecondsAgo :: UTCTime -> UTCTime
-twentySecondsAgo now = addUTCTime (-20) now
-
-inTenSeconds :: UTCTime -> UTCTime
-inTenSeconds now = addUTCTime (10) now
-
-aThreeFullCache :: UTCTime -> CC.ThreadId -> IO () -> IO () -> IO () -> IO (RP.Cache String String)
-aThreeFullCache now threadId f1 f2 f3 =
-  M.fromList [(("p1",threadId), ("p1", now, f1))
-             , (("p2",threadId), ("p2", tenSecondsAgo now, f2))
-             , (("p3",threadId), ("p3", inTenSeconds now, f3))
-             ]
-
-getPoolWithGC wait = do
-  state <- M.empty
-  pool <- RP.make wait 3 (fakeAcquire state) (fakeRelease state)
-  return (pool, state)
+acquireConcurrent2 :: Assertion
+acquireConcurrent2 = do
+  (pool, ok) <- makePool 100
+  let acquire i = RP.acquire pool i >>= \(n, release) -> release
+  _ <- parallelTraverse acquire ([1..100] ++ [1..100])
+  eventually ok
 
 delaySeconds μs = threadDelay (1000000 * μs)
 
-threadGCsResourcesFromPoolTest :: Assertion
-threadGCsResourcesFromPoolTest = do
-  (pool, ts) <- getPoolWithGC 2
-  (_, release1) <- RP.acquire pool "p1"
-  didRelease1a <- release1
-                    >> delaySeconds 1
-                    >> loadState ts "testreleases"
-  didRelease1b <- delaySeconds 3 >> loadState ts "testreleases"
-  (_, release2) <- RP.acquire pool "p2"
-  didRelease2a <- release2
-                    >> delaySeconds 1
-                    >> loadState ts "testreleases"
-  didRelease2b <- delaySeconds 3 >> loadState ts "testreleases"
-  assertEqual "shouldn't immediately release p1" "" didRelease1a
-    >> assertEqual "reaper released p1 after 3 seconds" "p1r" didRelease1b
-    >> assertEqual "shouldn't immediately release p2" "p1r" didRelease2a
-    >> assertEqual "reaper released p2 after 3 seconds" "p1rp2r" didRelease2b
-
-fakeGetThread :: CC.ThreadId -> IO CC.ThreadId
-fakeGetThread t = return t
-
-acquireIsThreadSpecificTest :: Assertion
-acquireIsThreadSpecificTest = do
-  ps  <- IORef.newIORef 0
-  ts <- M.empty
-  q <- STM.atomically TQ.newTQueue
-  pool <- M.empty
-  someOtherThread <- forkIO (putStrLn "")
-  let aquire = RP._acquire (fakeAcquire ts) (fakeRelease ts) pool 10 3 ps q
-  (r1, release1) <- aquire CC.myThreadId "p1"
-  (r1b, release1b) <- release1 >> aquire (fakeGetThread someOtherThread) "p1"
-  didAcquire <- release1b >> loadState ts "testacquires"
-
-  poolSize <- IORef.readIORef ps
-
-  assertEqual "got the correct r" "p1r" r1
-    >> assertEqual "got the correct r" "p1r" r1b
-    >> assertEqual "r is acquired twice" "p1rp1r" didAcquire
-    >> assertEqual "two connections are in the map" 2 poolSize
-
-acquireRemovesFromPoolTest :: Assertion
-acquireRemovesFromPoolTest = do
-  (pool, ts) <- getPool 1
-  (r1, release1) <- RP.acquire pool "p1"
-  (r2, _) <- release1 >> RP.acquire pool "p1" -- acquire p1 a third time, without releasing r2
-  (r3, _) <-  RP.acquire pool "p1"
-  didAcquire <- loadState ts "testacquires"
-  didRelease <- loadState ts "testreleases"
-
-  assertEqual "the correct resource is returned" "p1r" r1
-    >> assertEqual "the correct resource is returned" "p1r" r2
-    >> assertEqual "the correct resource is returned" "p1r" r3
-    >> assertEqual "r is acquired twice" "p1rp1r" didAcquire
-
--}
+eventually :: Assertion -> Assertion
+eventually cond = go 1 where
+  go n | n > 32 = cond
+  go n = cond <|> (delaySeconds n >> go (n*2))
 
 tests :: TestTree
 tests = testGroup "ResourcePool"
-  [ ]
- --   testCase "correctlyAcquiresTest" $ correctlyAcquiresTest
- --   , testCase "correctlyReleasesTest" $ correctlyReleasesTest
- --   , testCase "acquireShouldCacheConnectionTest" $  acquireShouldCacheConnectionTest
- --   , testCase "acquireCannotCacheTooManyConnections" $  acquireCannotCacheTooManyConnections
- --   , testCase "threadGCsResourcesFromPoolTest" $ threadGCsResourcesFromPoolTest
- --   , testCase "acquireIsThreadSpecificTest" $ acquireIsThreadSpecificTest
- --   , testCase "acquireRemovesFromPoolTest" $ acquireRemovesFromPoolTest
- --   ]
+  [ testCase "acquireSequential1" acquireSequential1
+  , testCase "acquireSequential2" acquireSequential2
+  , testCase "acquireConcurrent1" acquireConcurrent1
+  , testCase "acquireConcurrent2" acquireConcurrent2 ]
 
 main = defaultMain tests

--- a/node/tests/Unison/Test/ResourcePool.hs
+++ b/node/tests/Unison/Test/ResourcePool.hs
@@ -38,7 +38,8 @@ makePool maxSize = do
 acquireSequential1 :: Assertion
 acquireSequential1 = do
   (pool, ok) <- makePool 10
-  replicateM_ 100 (RP.acquire pool 42 >>= \(n, release) -> assertEqual "resource not recycled" 0 n >> release)
+  let check n = assertEqual "resource not recycled" 0 n
+  replicateM_ 100 (RP.acquire pool 42 >>= \(n, release) -> check n >> release)
   eventually ok
 
 acquireSequential2 :: Assertion

--- a/node/tests/Unison/Test/ResourcePool.hs
+++ b/node/tests/Unison/Test/ResourcePool.hs
@@ -17,6 +17,7 @@ type Resource = String
 type Params = String
 type TestState = M.Map String String
 
+{-
 loadState :: TestState -> String -> IO String
 loadState m k = do
   x <- M.lookup k m
@@ -40,7 +41,7 @@ fakeRelease s r = do
 
 getPool wait = do
   state <- M.empty
-  pool <- (RP.poolWithoutGC wait 3 (fakeAcquire state) (fakeRelease state))
+  pool <- RP.make wait 3 (fakeAcquire state) (fakeRelease state)
   return (pool, state)
 
 correctlyAcquiresTest :: Assertion
@@ -103,7 +104,7 @@ aThreeFullCache now threadId f1 f2 f3 =
 
 getPoolWithGC wait = do
   state <- M.empty
-  pool <- (RP.pool wait 3 (fakeAcquire state) (fakeRelease state))
+  pool <- RP.make wait 3 (fakeAcquire state) (fakeRelease state)
   return (pool, state)
 
 delaySeconds μs = threadDelay (1000000 * μs)
@@ -162,16 +163,18 @@ acquireRemovesFromPoolTest = do
     >> assertEqual "the correct resource is returned" "p1r" r3
     >> assertEqual "r is acquired twice" "p1rp1r" didAcquire
 
+-}
+
 tests :: TestTree
 tests = testGroup "ResourcePool"
-  [
-    testCase "correctlyAcquiresTest" $ correctlyAcquiresTest
-    , testCase "correctlyReleasesTest" $ correctlyReleasesTest
-    , testCase "acquireShouldCacheConnectionTest" $  acquireShouldCacheConnectionTest
-    , testCase "acquireCannotCacheTooManyConnections" $  acquireCannotCacheTooManyConnections
-    , testCase "threadGCsResourcesFromPoolTest" $ threadGCsResourcesFromPoolTest
-    , testCase "acquireIsThreadSpecificTest" $ acquireIsThreadSpecificTest
-    , testCase "acquireRemovesFromPoolTest" $ acquireRemovesFromPoolTest
-    ]
+  [ ]
+ --   testCase "correctlyAcquiresTest" $ correctlyAcquiresTest
+ --   , testCase "correctlyReleasesTest" $ correctlyReleasesTest
+ --   , testCase "acquireShouldCacheConnectionTest" $  acquireShouldCacheConnectionTest
+ --   , testCase "acquireCannotCacheTooManyConnections" $  acquireCannotCacheTooManyConnections
+ --   , testCase "threadGCsResourcesFromPoolTest" $ threadGCsResourcesFromPoolTest
+ --   , testCase "acquireIsThreadSpecificTest" $ acquireIsThreadSpecificTest
+ --   , testCase "acquireRemovesFromPoolTest" $ acquireRemovesFromPoolTest
+ --   ]
 
 main = defaultMain tests


### PR DESCRIPTION
Allows multiple resources for a given key, and a resource acquired by one thread can be used by another thread when it is recycled.

At the moment, it uses a fresh thread to reclaim each resource when it expires, rather than a single reaper thread. I found it too tricky to get the single-reaper-thread solution correct.