### PR TITLE
vagrant box needs libtinfo-dev

### DIFF
--- a/vagrant-provision.sh
+++ b/vagrant-provision.sh
@@ -1,3 +1,3 @@
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 575159689BEFB442
 echo 'deb http://download.fpcomplete.com/ubuntu trusty main'|sudo tee /etc/apt/sources.list.d/fpco.list
-sudo apt-get update && sudo apt-get install stack -y
+sudo apt-get update && sudo apt-get install stack libtinfo-dev -y


### PR DESCRIPTION
`README.md` talks about this potential Ubuntu build issue, and the Vagrant VM has it too.