### PR TITLE
all journal sync codepaths now signal 'done' semaphore

### DIFF
--- a/node/src/Unison/Runtime/Journal.hs
+++ b/node/src/Unison/Runtime/Journal.hs
@@ -84,7 +84,7 @@ fromBlocks bs zero apply checkpoint us = do
           catch (Block.append bs us u >> update) handle
           where
           update | not vnow  = atomically $ done >> modifyTVar' current (apply u)
-                 | otherwise = pure ()
+                 | otherwise = atomically done
   pure $ Journal get (Updates flush append) (record updateQ)
   where
   record updateQ = do

--- a/node/tests/Unison/Test/Journal.hs
+++ b/node/tests/Unison/Test/Journal.hs
@@ -40,11 +40,8 @@ readAfterUpdate bs = do
       updates = makeBlock "u " NoOp
   j <- J.fromBlocks bs NoOp simpleUpdate values updates
   J.update Inc j
-  putStrLn "can we just update, friends?"
-  atomically . J.flush . J.updates $ j
-  putStrLn "hey, at least we flushed"
   result <- atomically $ J.get j
-  when (result /= 0) $ fail ("incorrect value after update, result " ++ show result)
+  when (result /= 1) $ fail ("incorrect value after update, result " ++ show result)
 
 ioTests :: IO TestTree
 ioTests = do


### PR DESCRIPTION
It looks like KeyValueStore based on Journal now works as well, but I'll submit this PR first.