### PR TITLE
Node container worker main

### DIFF
--- a/node/src/Node.hs
+++ b/node/src/Node.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms, CPP #-}
 
 module Main where
@@ -43,7 +44,7 @@ makeRandomAddress crypt = Address <$> C.randomBytes crypt 64
 main :: IO ()
 main = do
   store' <- store
-  let crypto = C.noop 0
+  let crypto = C.noop "dummypublickey"
   blockStore <- FBS.make' (makeRandomAddress crypto) makeAddress "Index"
   keyValueOps <- EB.makeAPI blockStore crypto
   let makeBuiltins whnf = concat [Builtin.makeBuiltins whnf, keyValueOps whnf]

--- a/node/src/Unison/Hash/Extra.hs
+++ b/node/src/Unison/Hash/Extra.hs
@@ -4,7 +4,6 @@ module Unison.Hash.Extra where
 
 import Data.Bytes.Serial
 import Data.List
-import System.Random
 import Unison.Hash
 import qualified Crypto.Hash as CH
 import qualified Data.ByteArray as BA
@@ -28,13 +27,3 @@ instance H.Accumulate Hash where
 instance Serial Hash where
   serialize h = serialize (toBytes h)
   deserialize = fromBytes <$> deserialize
-
-instance Random Hash where
-  -- bounds are ignored
-  randomR (_, _) gen =
-    let rs = iterate (random . snd) (0, gen)
-        rPairs = take 64 $ tail rs
-        newGen = snd . head $ reverse rPairs
-        bstring = B.pack $ map fst rPairs
-    in (fromBytes bstring, newGen)
-  random = randomR (undefined, undefined)

--- a/node/src/Unison/NodeProtocol/V0.hs
+++ b/node/src/Unison/NodeProtocol/V0.hs
@@ -4,12 +4,12 @@ module Unison.NodeProtocol.V0 where
 
 import qualified Unison.NodeProtocol as P
 import qualified Unison.Runtime.Multiplex as Mux
-import qualified Unison.Node.BasicNode as BN
+import Unison.SerializationAndHashing (TermV)
 import Data.ByteString
 import Unison.Term (Term)
 import Unison.Hash (Hash)
 
-protocol :: P.Protocol (Term BN.V) ByteString ByteString Hash
+protocol :: P.Protocol TermV ByteString ByteString Hash
 protocol = P.Protocol -- keeping channel ids human readable for debuggability
   (Mux.Channel Mux.Type "v0-destroyIn")
   (Mux.Channel Mux.Type "v0-destroyOut")
@@ -24,4 +24,3 @@ protocol = P.Protocol -- keeping channel ids human readable for debuggability
   (Mux.Channel Mux.Type "v0-append")
   (Mux.Channel Mux.Type "v0-resolve")
   (Mux.Channel Mux.Type "v0-resolves")
-

--- a/node/src/Unison/SerializationAndHashing.hs
+++ b/node/src/Unison/SerializationAndHashing.hs
@@ -1,11 +1,11 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-{-# LANGUAGE TypeSynonymInstances #-}
-module Unison.SerializationAndHashing where
+
+module Unison.SerializationAndHashing
+  (V, TermV, DFO, hash, hash', serializeTerm, deserializeTerm, deserializeTermFromBytes) where
 
 import Control.Comonad.Cofree (Cofree((:<)))
 import Data.ByteString (ByteString)
 import Data.Bytes.Serial (serialize, Serial(..), Serial1(..))
-import Data.Serialize.Put (Put)
 import Data.Serialize.Get (Get)
 import Unison.ABT.Extra () -- Serial instances
 import Unison.Reference (Reference)
@@ -76,10 +76,3 @@ deserializeTerm = deserialize
 
 deserializeTermFromBytes :: (Var v, Serial v) => ByteString -> Either String (Term.Term v)
 deserializeTermFromBytes = Get.runGetS deserializeTerm
-
-testTerm2 :: TermV
-testTerm2 = undefined
-
-testSerialize2 :: Put
-testSerialize2 = serialize testTerm2
-

--- a/node/src/Worker.hs
+++ b/node/src/Worker.hs
@@ -2,24 +2,45 @@
 
 module Main where
 
+import Control.Monad
 import Unison.NodeProtocol.V0 (protocol)
 import Unison.NodeWorker as W
-import qualified Unison.Cryptography as C
 import Unison.SerializationAndHashing (TermV)
-import qualified Unison.Term as Term
-import qualified Unison.Runtime.Remote as R
+import qualified Data.Set as Set
+import qualified Unison.Cryptography as C
 import qualified Unison.Remote as RT
+import qualified Unison.Runtime.Remote as R
+import qualified Unison.Term as Term
+import qualified Unison.Runtime.ExtraBuiltins as ExtraBuiltins
+import qualified Unison.Node.Builtin as Builtin
+import qualified Unison.Eval.Interpreter as I
+import qualified Unison.Eval as Eval
+import qualified Data.Map as Map
+import qualified Unison.Note as Note
 import Unison.Hash (Hash)
 
 main :: IO ()
 main = W.make protocol crypto (pure lang) where
   crypto keypair = C.noop (W.public keypair)
-  lang blockstore = pure $
-    (R.Language localDependencies eval apply node unit channel local unRemote remote
+  lang crypto blockstore = do
+    let b0 = Builtin.makeBuiltins
+    b1 <- ExtraBuiltins.makeAPI blockstore crypto
+    pure (R.Language localDependencies (eval b0 b1) apply node unit channel local unRemote remote
       :: R.Language TermV Hash)
     where
-      localDependencies t = undefined
-      eval t = undefined
+      codestore = R.makeCodestore blockstore :: R.Codestore TermV Hash
+      localDependencies _ = Set.empty -- todo, compute this for real
+      eval b0 b1 =
+        let
+          evaluator = I.eval allprimops
+          whnf = Eval.whnf evaluator gethash
+          allbuiltins = b0 whnf ++ b1 whnf
+          allprimops = Map.fromList [ (r, op) | Builtin.Builtin r (Just op) _ _ <- allbuiltins ]
+          gethash h = Note.lift $ do
+            [(h',t)] <- R.getHashes codestore (Set.singleton h)
+            guard $ h == h'
+            pure t
+        in \t -> Note.run (whnf t)
       apply = Term.app
       node = Term.node
       unit = Term.builtin "()"

--- a/node/src/Worker.hs
+++ b/node/src/Worker.hs
@@ -1,11 +1,30 @@
+{-# Language OverloadedStrings #-}
+
 module Main where
 
 import Unison.NodeProtocol.V0 (protocol)
 import Unison.NodeWorker as W
 import qualified Unison.Cryptography as C
-import Unison.SerializationAndHashing ()
+import Unison.SerializationAndHashing (TermV)
+import qualified Unison.Term as Term
+import qualified Unison.Runtime.Remote as R
+import qualified Unison.Remote as RT
+import Unison.Hash (Hash)
 
 main :: IO ()
-main = W.make protocol crypto lang where
+main = W.make protocol crypto (pure lang) where
   crypto keypair = C.noop (W.public keypair)
-  lang = undefined
+  lang blockstore = pure $
+    (R.Language localDependencies eval apply node unit channel local unRemote remote
+      :: R.Language TermV Hash)
+    where
+      localDependencies t = undefined
+      eval t = undefined
+      apply = Term.app
+      node = Term.node
+      unit = Term.builtin "()"
+      channel = Term.channel
+      local l = Term.remote (RT.Step (RT.Local l))
+      unRemote (Term.Distributed' (Term.Remote r)) = Just r
+      unRemote _ = Nothing
+      remote = Term.remote

--- a/node/src/Worker.hs
+++ b/node/src/Worker.hs
@@ -1,4 +1,11 @@
 module Main where
 
+import Unison.NodeProtocol.V0 (protocol)
+import Unison.NodeWorker as W
+import qualified Unison.Cryptography as C
+import Unison.SerializationAndHashing ()
+
 main :: IO ()
-main = putStrLn "hello world!"
+main = W.make protocol crypto lang where
+  crypto keypair = C.noop (W.public keypair)
+  lang = undefined

--- a/node/tests/Unison/Test/BlockStore.hs
+++ b/node/tests/Unison/Test/BlockStore.hs
@@ -1,4 +1,6 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# Language OverloadedStrings #-}
+
 module Unison.Test.BlockStore where
 
 import Control.Concurrent (forkIO, ThreadId)
@@ -20,7 +22,7 @@ instance Arbitrary Address where
   arbitrary = (fromBytes . B.pack) <$> vectorOf 64 arbitrary
 
 makeRandomAddress :: IO Address
-makeRandomAddress = Address <$> C.randomBytes (C.noop 0) 64
+makeRandomAddress = Address <$> C.randomBytes (C.noop "dummypublickey") 64
 
 roundTrip :: BS.BlockStore Address -> HU.Assertion
 roundTrip bs = do

--- a/node/tests/Unison/Test/Index.hs
+++ b/node/tests/Unison/Test/Index.hs
@@ -23,8 +23,8 @@ instance Arbitrary BS.Series where
 
 makeRandomId :: IO (BS.Series, BS.Series)
 makeRandomId = do
-  cp <- BS.Series <$> C.randomBytes (C.noop 0) 64
-  ud <- BS.Series <$> C.randomBytes (C.noop 0) 64
+  cp <- BS.Series <$> C.randomBytes (C.noop "dummypublickey") 64
+  ud <- BS.Series <$> C.randomBytes (C.noop "dummypublickey") 64
   pure (cp, ud)
 
 roundTrip :: BS.BlockStore Address -> Assertion

--- a/node/tests/Unison/Test/NodeUtil.hs
+++ b/node/tests/Unison/Test/NodeUtil.hs
@@ -1,3 +1,5 @@
+{-# Language OverloadedStrings #-}
+
 module Unison.Test.NodeUtil where
 
 import Unison.Hash (Hash)
@@ -34,7 +36,7 @@ makeRandomAddress crypt = Address <$> C.randomBytes crypt 64
 
 makeTestNode :: IO TestNode
 makeTestNode = do
-  let crypto = C.noop 0
+  let crypto = C.noop "dummypublickey"
   blockStore <- MBS.make' (makeRandomAddress crypto) makeAddress
   store' <- UBS.make blockStore
   keyValueOps <- EB.makeAPI blockStore crypto

--- a/node/unison-node.cabal
+++ b/node/unison-node.cabal
@@ -154,9 +154,25 @@ executable worker
     ghc-options: -funbox-strict-fields -O2
 
   build-depends:
+    async,
     base,
+    bytes,
+    bytestring,
+    cereal,
+    containers,
+    cryptonite,
+    free,
+    hashable,
+    list-t,
+    memory,
+    mtl,
+    stm,
+    stm-containers,
+    time,
+    transformers,
     unison-node,
-    unison-shared
+    unison-shared,
+    vector
 
 executable container
   main-is: Container.hs

--- a/node/unison-node.cabal
+++ b/node/unison-node.cabal
@@ -156,6 +156,7 @@ executable worker
   build-depends:
     async,
     base,
+    base64-bytestring,
     bytes,
     bytestring,
     cereal,
@@ -168,6 +169,8 @@ executable worker
     mtl,
     stm,
     stm-containers,
+    tagsoup,
+    text,
     time,
     transformers,
     unison-node,


### PR DESCRIPTION
This PR adds a new executable in the `node/` project, called `worker`. It basically binds all the dependencies of `Unison.NodeWorker` and will be used by the container for representing a currently running node. It takes no arguments, and the container will communicate with worker processes it spawns over standard in / standard out.

See #82