### PR TITLE
Got test Unison program working with `Index` values

### DIFF
--- a/node/src/Container.hs
+++ b/node/src/Container.hs
@@ -13,7 +13,7 @@ import System.IO (hSetBinaryMode, hFlush, stdin)
 import System.Process as P
 import Unison.NodeProtocol.V0 (protocol)
 import Unison.NodeServer as NS
-import Unison.Parsers (unsafeParseTerm)
+import Unison.Parsers (unsafeParseTermWithPrelude)
 import Unison.Runtime.Lock (Lock(..),Lease(..))
 import Web.Scotty as S
 import qualified Data.ByteArray as BA
@@ -65,7 +65,7 @@ main = Mux.uniqueChannel >>= \rand ->
         let node = R.Node "localhost" (Put.runPutS . serialize . Base64.decodeLenient $ nodepk)
         programtxt <- S.body
         let programstr = Text.unpack (decodeUtf8 (LB.toStrict programtxt))
-        let !prog = unsafeParseTerm programstr
+        let !prog = unsafeParseTermWithPrelude programstr
         let !prog' = Components.minimize' prog
         liftIO . putStrLn $ "parsed " ++ show prog
         liftIO . putStrLn $ "parsed' " ++ show prog'

--- a/node/src/Unison/Runtime/ExtraBuiltins.hs
+++ b/node/src/Unison/Runtime/ExtraBuiltins.hs
@@ -67,15 +67,7 @@ makeAPI blockStore crypto = do
              pure . index self . Term.lit . Term.Text . Index.idToText $ ident
            op _ = fail "Index.unsafeEmpty unpossible"
            type' = unsafeParseType "forall k v. Node -> Index k v"
-       in (r, Just (I.Primop 0 op), type', prefix "unsafeEmpty")
-     , let r = R.Builtin "Index.empty"
-           op [] = pure $
-             Term.builtin "Remote.map" `Term.apps` [
-               Term.builtin "Index.unsafeEmpty",
-               Term.builtin "Remote.here" ]
-           op _ = fail "Index.empty unpossible"
-           type' = unsafeParseType "forall k v. Remote (Index k v)"
-       in (r, Just (I.Primop 0 op), type', prefix "empty")
+       in (r, Just (I.Primop 1 op), type', prefix "unsafeEmpty")
      , let r = R.Builtin "Index.unsafeLookup"
            op [key, indexToken] = inject g indexToken key where
              inject g indexToken key = do

--- a/node/src/Unison/Runtime/ExtraBuiltins.hs
+++ b/node/src/Unison/Runtime/ExtraBuiltins.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE PatternSynonyms #-}
 module Unison.Runtime.ExtraBuiltins where
 
+import Control.Exception (finally)
 import Control.Concurrent.STM (atomically)
 import Data.ByteString (ByteString)
 import Unison.BlockStore (Series(..), BlockStore)
@@ -15,6 +16,7 @@ import qualified Unison.Cryptography as C
 import qualified Unison.Eval.Interpreter as I
 import qualified Unison.Note as Note
 import qualified Unison.Reference as R
+import qualified Unison.Remote as Remote
 import qualified Unison.Runtime.Html as Html
 import qualified Unison.Runtime.Http as Http
 import qualified Unison.Runtime.Index as Index
@@ -26,8 +28,8 @@ import qualified Unison.Type as Type
 indexT :: Ord v => Type v -> Type v -> Type v
 indexT k v = Type.ref (R.Builtin "Index") `Type.app` k `Type.app` v
 
-index :: Term.Term V -> Term.Term V
-index h = Term.ref (R.Builtin "Index") `Term.app` h
+index :: Remote.Node -> Term.Term V -> Term.Term V
+index node h = Term.ref (R.Builtin "Index") `Term.apps` [Term.node node, h]
 
 linkT :: Ord v => Type v
 linkT = Type.ref (R.Builtin "Link")
@@ -39,9 +41,9 @@ linkToTerm :: Html.Link -> Term.Term V
 linkToTerm (Html.Link href description) = link (Term.lit $ Term.Text href)
   (Term.lit $ Term.Text description)
 
-pattern Index' s <- Term.App'
-                    (Term.Ref' (R.Builtin "Index"))
-                    (Term.Text' s)
+pattern Index' node s <-
+  Term.App' (Term.App' (Term.Ref' (R.Builtin "Index")) (Term.Distributed' (Term.Node node)))
+            (Term.Text' s)
 
 pattern Link' href description <-
   Term.App' (Term.App' (Term.Ref' (R.Builtin "Link"))
@@ -59,66 +61,80 @@ makeAPI blockStore crypto = do
   resourcePool <- RP.make 3 10 (Index.loadEncrypted blockStore crypto) Index.flush
   pure (\whnf -> map (\(r, o, t, m) -> Builtin r o t m)
      [ let r = R.Builtin "Index.unsafeEmpty"
-           op [] = Note.lift $ do
-             ident <- nextID
-             pure . index . Term.lit . Term.Text . Index.idToText $ ident
+           op [self] = do
+             ident <- Note.lift nextID
+             Term.Distributed' (Term.Node self) <- whnf self
+             pure . index self . Term.lit . Term.Text . Index.idToText $ ident
            op _ = fail "Index.unsafeEmpty unpossible"
-           type' = unsafeParseType "forall k v. Store k v"
+           type' = unsafeParseType "forall k v. Node -> Index k v"
        in (r, Just (I.Primop 0 op), type', prefix "unsafeEmpty")
      , let r = R.Builtin "Index.empty"
            op [] = pure $
-             Term.builtin "Remote.pure" `Term.app` Term.builtin "Index.unsafeEmpty"
+             Term.builtin "Remote.map" `Term.apps` [
+               Term.builtin "Index.unsafeEmpty",
+               Term.builtin "Remote.here" ]
            op _ = fail "Index.empty unpossible"
-           type' = unsafeParseType "forall k v. Remote (Store k v)"
+           type' = unsafeParseType "forall k v. Remote (Index k v)"
        in (r, Just (I.Primop 0 op), type', prefix "empty")
      , let r = R.Builtin "Index.unsafeLookup"
-           op [indexToken, key] = inject g indexToken key where
+           op [key, indexToken] = inject g indexToken key where
              inject g indexToken key = do
                i <- whnf indexToken
                k <- whnf key
                g i k
-             g (Index' h) k = do
+             g (Term.Text' h) k = do
                val <- Note.lift $ do
-                 (db, _) <- RP.acquire resourcePool . Index.textToId $ h
-                 result <- atomically $ Index.lookup (SAH.hash' k) db
-                 case result >>= (pure . SAH.deserializeTermFromBytes . snd) of
-                   Just (Left s) -> fail ("Index.unsafeLookup could not deserialize: " ++ s)
-                   Just (Right t) -> pure $ some t
-                   Nothing -> pure none
+                 (db, cleanup) <- RP.acquire resourcePool . Index.textToId $ h
+                 flip finally cleanup $ do
+                   result <- atomically $ Index.lookup (SAH.hash' k) db
+                   case result >>= (pure . SAH.deserializeTermFromBytes . snd) of
+                     Just (Left s) -> fail ("Index.unsafeLookup could not deserialize: " ++ s)
+                     Just (Right t) -> pure $ some t
+                     Nothing -> pure none
                pure val
              g s k = pure $ Term.ref r `Term.app` s `Term.app` k
            op _ = fail "Index.unsafeLookup unpossible"
-           type' = unsafeParseType "forall k v. k -> Store k v -> Option v"
+           type' = unsafeParseType "forall k v. k -> Index k v -> Optional v"
        in (r, Just (I.Primop 2 op), type', prefix "unsafeLookup")
      , let r = R.Builtin "Index.lookup"
-           op [indexToken, key] = pure $ Term.builtin "Remote.pure" `Term.app`
-             (Term.builtin "Index.unsafeLookup" `Term.app` indexToken `Term.app` key)
+           op [key, index] = do
+             Index' node tok <- whnf index
+             pure $
+               Term.builtin "Remote.map" `Term.apps` [
+                 Term.builtin "Index.unsafeLookup" `Term.app` key,
+                 Term.builtin "Remote.at" `Term.apps` [Term.node node, Term.text tok]
+               ]
            op _ = fail "Index.lookup unpossible"
-           type' = unsafeParseType "forall k v. k -> Store k v -> Remote (Option v)"
+           type' = unsafeParseType "forall k v. k -> Index k v -> Remote (Optional v)"
        in (r, Just (I.Primop 2 op), type', prefix "lookup")
      , let r = R.Builtin "Index.unsafeInsert"
-           op [k, v, store] = inject g k v store where
-             inject g k v store = do
+           op [k, v, index] = inject g k v index where
+             inject g k v index = do
                k' <- whnf k
                v' <- whnf v
-               s <- whnf store
+               s <- whnf index
                g k' v' s
-             g k v (Index' h) = do
+             g k v (Term.Text' h) = do
                Note.lift $ do
-                 (db, _) <- RP.acquire resourcePool . Index.textToId $ h
-                 atomically
+                 (db, cleanup) <- RP.acquire resourcePool . Index.textToId $ h
+                 flip finally cleanup $ atomically
                    (Index.insert (SAH.hash' k) (SAH.serializeTerm k, SAH.serializeTerm v) db)
                    >>= atomically
                pure unitRef
-             g k v store = pure $ Term.ref r `Term.app` k `Term.app` v `Term.app` store
+             g k v index = pure $ Term.ref r `Term.app` k `Term.app` v `Term.app` index
            op _ = fail "Index.unsafeInsert unpossible"
-           type' = unsafeParseType "forall k v. k -> v -> Store k v -> Unit"
+           type' = unsafeParseType "forall k v. k -> v -> Index k v -> Unit"
        in (r, Just (I.Primop 3 op), type', prefix "unsafeInsert")
      , let r = R.Builtin "Index.insert"
-           op [k, v, store] = pure $ Term.builtin "Remote.pure" `Term.app`
-             (Term.builtin "Index.unsafeInsert" `Term.app` k `Term.app` v `Term.app` store)
+           op [key, value, index] = do
+             Index' node tok <- whnf index
+             pure $
+               Term.builtin "Remote.map" `Term.apps` [
+                 Term.builtin "Index.unsafeInsert" `Term.apps` [key,value],
+                 Term.builtin "Remote.at" `Term.apps` [Term.node node, Term.text tok]
+               ]
            op _ = fail "Index.insert unpossible"
-           type' = unsafeParseType "forall k v. k -> v -> Store k v -> Remote Unit"
+           type' = unsafeParseType "forall k v. k -> v -> Index k v -> Remote Unit"
        in (r, Just (I.Primop 3 op), type', prefix "insert")
      , let r = R.Builtin "Html.getLinks"
            op [html] = do

--- a/node/src/Unison/Runtime/Remote.hs
+++ b/node/src/Unison/Runtime/Remote.hs
@@ -165,14 +165,15 @@ handle crypto allow env lang p r = Mux.debug (show r) >> case r of
       Just r -> handle crypto allow env lang p r
       Nothing -> fail "typechecker bug; function passed to Remote.bind did not return a Remote"
   where
-  transfer n t k = do
-    Mux.debug $ "transferring to node: " ++ show n
-    client crypto allow env p n r
-    Mux.debug $ "transferred to node: " ++ show n
-    where
-    r = case k of
-      Nothing -> Step (Local (Pure t))
-      Just k -> Bind (Local (Pure t)) k
+  transfer n t k =
+    let r = case k of
+          Nothing -> Step (Local (Pure t))
+          Just k -> Bind (Local (Pure t)) k
+    in if n == currentNode env then handle crypto allow env lang p r
+       else do
+         Mux.debug $ "transferring to node: " ++ show n
+         client crypto allow env p n r
+         Mux.debug $ "transferred to node: " ++ show n
   runLocal (Fork r) = do
     Mux.debug $ "runLocal Fork"
     Mux.fork (handle crypto allow env lang p r) $> unit lang

--- a/node/tests/html.u
+++ b/node/tests/html.u
@@ -1,0 +1,4 @@
+-- run from unison root directory
+-- curl -H "Content-Type: text/plain; charset=UTF-8" --data-binary @node/tests/html.u http://localhost:8081/compute/dummynode909
+
+Http.getURL "http://unisonweb.org"

--- a/node/tests/index.u
+++ b/node/tests/index.u
@@ -1,0 +1,15 @@
+-- run from unison root directory
+-- curl -H "Content-Type: text/plain; charset=UTF-8" --data-binary @node/tests/index.u http://localhost:8081/compute/dummynode909
+
+Remote {
+  n1 := Remote.spawn;
+  n2 := Remote.spawn;
+  ind := Remote {
+    Remote.transfer n1;
+    ind := Index.empty;
+    Index.insert "Unison" "Rulez!!!1" ind; 
+    pure ind;
+  };
+  Remote.transfer n2;
+  Index.lookup "Unison" ind;
+}

--- a/shared/src/Unison/Eval/Interpreter.hs
+++ b/shared/src/Unison/Eval/Interpreter.hs
@@ -65,6 +65,7 @@ eval env = Eval whnf step
       E.Ref' h -> case M.lookup h env of
         Just op | arity op == 0 -> call op []
         _ -> pure e
+      E.Ann' e _ -> whnf resolveRef e
       E.App' (E.Ann' f _) x -> whnf resolveRef (f `E.app` x)
       E.App' (E.LetRecNamed' bs body) x -> whnf resolveRef (E.letRec bs (body `E.app` x))
       E.App' (E.Let1Named' v b body) x -> whnf resolveRef (E.let1 [(v,b)] (body `E.app` x))

--- a/shared/src/Unison/Node/Builtin.hs
+++ b/shared/src/Unison/Node/Builtin.hs
@@ -150,7 +150,8 @@ makeBuiltins whnf =
        in (r, Just (I.Primop 1 op), remoteSignatureOf "Remote.pure", prefix "pure")
      , let r = R.Builtin "Remote.map"
            op [f, r] = pure $ Term.builtin "Remote.bind" `Term.app`
-             (Term.lam' ["x"] $ Term.builtin "Remote.pure" `Term.app` (f `Term.app` Term.var' "x"))
+             (Term.lam' ["x"] $ Term.remote
+               (Remote.Step . Remote.Local . Remote.Pure $ f `Term.app` Term.var' "x"))
              `Term.app` r
            op _ = fail "unpossible"
        in (r, Just (I.Primop 2 op), remoteSignatureOf "Remote.map", prefix "map")

--- a/shared/src/Unison/Parsers.hs
+++ b/shared/src/Unison/Parsers.hs
@@ -76,6 +76,7 @@ termBuiltins = (Var.named *** Term.ref) <$> (
     , Builtin "True"
     , Builtin "False"
     , Builtin "()"
+    , Alias "unit" "()"
     , Alias "some" "Optional.Some"
     , Alias "none" "Optional.None"
     , AliasFromModule "Vector"

--- a/shared/src/Unison/Parsers.hs
+++ b/shared/src/Unison/Parsers.hs
@@ -84,10 +84,10 @@ termBuiltins = (Var.named *** Term.ref) <$> (
     , AliasFromModule "Text"
         ["concatenate", "left", "right", "center", "justify"] []
     , AliasFromModule "Remote"
-        ["fork", "receive", "receiveAsync", "pure", "bind", "channel", "send", "here", "at", "spawn"] []
+        ["fork", "receive", "receiveAsync", "pure", "bind", "map", "channel", "send", "here", "at", "spawn"] []
     , AliasFromModule "Color" ["rgba"] []
     , AliasFromModule "Symbol" ["Symbol"] []
-    , AliasFromModule "Index" ["lookup", "unsafeLookup", "insert", "unsafeInsert"] ["empty", "unsafeEmpty"]
+    , AliasFromModule "Index" ["lookup", "unsafeLookup", "insert", "unsafeInsert", "empty", "unsafeEmpty"] []
     , AliasFromModule "Html" ["getLinks", "getHref", "getDescription"] []
     , AliasFromModule "Http" ["getURL", "unsafeGetURL"] []
     ] >>= unpackAliases)

--- a/shared/src/Unison/Parsers.hs
+++ b/shared/src/Unison/Parsers.hs
@@ -38,6 +38,19 @@ parseType' typeBuiltins s = case run (Parser.root TypeParser.type_) s of
   Succeed t n b -> Succeed (ABT.substs typeBuiltins t) n b
   fail -> fail
 
+prelude = unlines
+  [ "let"
+  , "  Index.empty : forall k v . Remote (Index k v);"
+  , "  Index.empty = Remote.map Index.unsafeEmpty Remote.here;"
+  , ""
+  , "  Remote.transfer : Node -> Remote Unit;"
+  , "  Remote.transfer node = Remote.at node unit"
+  , "in"
+  , ""]
+
+unsafeParseTermWithPrelude :: String -> Term V
+unsafeParseTermWithPrelude prog = unsafeParseTerm (prelude ++ prog)
+
 unsafeParseTerm :: String -> Term V
 unsafeParseTerm = unsafeGetSucceed . parseTerm
 
@@ -124,6 +137,6 @@ typeBuiltins = (Var.named *** Type.lit) <$>
   , builtin "Channel"
   , builtin "Future"
   , builtin "Remote"
-  , builtin "Remote!"
+  , builtin "Node"
   ]
   where builtin t = (t, Type.Ref $ R.Builtin t)

--- a/shared/src/Unison/Typechecker/Context.hs
+++ b/shared/src/Unison/Typechecker/Context.hs
@@ -608,7 +608,7 @@ remoteSignatures = Map.fromList
   where
   v' = Type.v'
   timeoutT = Type.builtin "Remote.Timeout"
-  unitT = Type.builtin "()"
+  unitT = Type.builtin "Unit"
   remote' t = Type.builtin "Remote" `Type.app` t
   channel t = Type.builtin "Channel" `Type.app` t
 

--- a/shared/tests/Unison/Test/TypeParser.hs
+++ b/shared/tests/Unison/Test/TypeParser.hs
@@ -28,7 +28,6 @@ tests = testGroup "TypeParser" $ fmap parseV strings
       , ("Text", T.lit T.Text)
       , ("Vector", T.lit T.Vector)
       , ("Remote", T.builtin "Remote")
-      , ("Remote!", T.builtin "Remote!")
       , ("Foo", foo)
       , ("Foo -> Foo", T.arrow foo foo)
       , ("a -> a", T.arrow a a)


### PR DESCRIPTION
Below is a program that now runs. We spawn two nodes, create an `Index` at one node, insert a value, then move to the other node and do a lookup in that `Index`, making sure we get back what was inserted.

```Haskell
Remote {
  n1 := Remote.spawn;
  n2 := Remote.spawn;
  ind := Remote {
    -- Remote.transfer : Node -> Remote ()
    Remote.transfer n1;
    ind := Index.empty;
    Index.insert "Unison" "Rulez!!!1" ind; 
    pure ind;
  };
  Remote.transfer n2;
  Index.lookup "Unison" ind;
}
```

 Demonstrates that `Index` values are serializable. The runtime representation of `Index` is now basically a `(Node, token)` pair. The `Node` is the originating node where the `Index` was created, and the token is the same token from before which indicates where to look in the `BlockStore` for the `Index` data.

Also added an `unsafeParseTermWithPrelude` function to `Unison.Parsers`, which just prepends a prelude (defined in same file) to the term before parsing it. Will do this in a less hacky way later, but it's an easy way to supply pure Unison "standard library" functions.