### PR TITLE
Add required libcurl4 to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM haskell:7.10.3
 WORKDIR /opt/unison
 RUN apt-get update -q && \
-    apt-get install -qy git nodejs nodejs-legacy && \
+    apt-get install -qy git nodejs nodejs-legacy libcurl4-openssl-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 ADD . /opt/unison


### PR DESCRIPTION
Unfortunately, the docker build still fails while running

```
stack --stack-yaml editor.yaml build
```

with

```
--  While building package unison-editor-0.1 using:
      /root/.stack/setup-exe-cache/x86_64-linux/setup-Simple-Cabal-1.22.4.0-ghcjs-0.2.0.20151001_ghc-7.10.2 --builddir=.stack-work/dist/x86_64-linux/Cabal-1.22.4.0_ghcjs build lib:unison-editor exe:editor --ghc-options " -ddump-hi -ddump-to-file"
    Process exited with code: ExitFailure 1
    Logs have been written to: /opt/unison/.stack-work/logs/unison-editor-0.1.log

    Configuring unison-editor-0.1...
    Preprocessing library unison-editor-0.1...
    [1 of 8] Compiling Unison.TermSearchboxParser ( src/Unison/TermSearchboxParser.hs, .stack-work/dist/x86_64-linux/Cabal-1.22.4.0_ghcjs/build/Unison/TermSearchboxParser.js_o )

    /opt/unison/editor/src/Unison/TermSearchboxParser.hs:34:10:
        Couldn't match expected type ‘Parser String’
                    with actual type ‘(Char -> Bool) -> Parser String’
        Probable cause: ‘takeWhile’ is applied to too few arguments
        In the expression: takeWhile Char.isDigit
        In an equation for ‘digits’: digits = takeWhile Char.isDigit

    /opt/unison/editor/src/Unison/TermSearchboxParser.hs:34:20:
        Couldn't match type ‘Char -> Bool’ with ‘[Char]’
        Expected type: String
          Actual type: Char -> Bool
        Probable cause: ‘Char.isDigit’ is applied to too few arguments
        In the first argument of ‘takeWhile’, namely ‘Char.isDigit’
        In the expression: takeWhile Char.isDigit

    /opt/unison/editor/src/Unison/TermSearchboxParser.hs:46:29:
        Couldn't match expected type ‘Parser String’
                    with actual type ‘(Char -> Bool) -> Parser String’
        Probable cause: ‘takeWhile’ is applied to too few arguments
        In the second argument of ‘(*>)’, namely
          ‘takeWhile (\ c -> c /= '"')’
        In the first argument of ‘(<*)’, namely
          ‘char '"' *> takeWhile (\ c -> c /= '"')’

    /opt/unison/editor/src/Unison/TermSearchboxParser.hs:46:40:
        Couldn't match expected type ‘Char -> Bool’
                    with actual type ‘[Char]’
        The lambda expression ‘\ c -> c /= '"'’ has one argument,
        but its type ‘String’ has none
        In the first argument of ‘takeWhile’, namely ‘(\ c -> c /= '"')’
        In the second argument of ‘(*>)’, namely
          ‘takeWhile (\ c -> c /= '"')’
```

If anyone can help me with that problem, I'll try to get the Docker build to work again.
