### PR TITLE
Fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM haskell:7.10.3
 WORKDIR /opt/unison
 RUN apt-get update -q && \
-    apt-get install -qy git nodejs nodejs-legacy && \
+    apt-get install -qy git nodejs nodejs-legacy libcurl4-openssl-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 ADD . /opt/unison


### PR DESCRIPTION
There was a missing libcurl dependency. With this change, `docker build` is working for me.
I'm just uploading a freshly built version to https://hub.docker.com/r/nightscape/unison/