### PR TITLE
EasyTest fixes

### DIFF
--- a/runtime-jvm/main/src/test/scala/DecompileTests.scala
+++ b/runtime-jvm/main/src/test/scala/DecompileTests.scala
@@ -4,7 +4,7 @@ import org.unisonweb.util.PrettyPrint
 import org.unisonweb.EasyTest._
 import org.unisonweb.ABT.Name._
 
-object DecompileTests extends App {
+object DecompileTests {
   val tests = suite("decompile") (
     test("ex1") { implicit T =>
       val pingpong =
@@ -40,8 +40,6 @@ object DecompileTests extends App {
       ok
     }
   )
-
-  run()(tests)
 
   // seems like there's something wonky with Refs appearing as the result of a computation
   // perhaps use types to prevent this from happening, types distinguish between things that can be passed a param (could be a ref)

--- a/runtime-jvm/main/src/test/scala/EasyTest.scala
+++ b/runtime-jvm/main/src/test/scala/EasyTest.scala
@@ -107,6 +107,8 @@ object EasyTest {
     else throw Skip
   })
 
+  def testAlways[A](run0: Env => A): Test[A] = new Test[A](env => run0(env))
+
   def note(msg: => Any, includeAlways: Boolean = false)(implicit T: Env): Unit = T.note(msg, includeAlways)
   def ok(implicit T: Env): Unit = T.ok
   def fail(reason: String)(implicit T: Env): Nothing = T.fail(reason)
@@ -148,7 +150,7 @@ object EasyTest {
     replicate(size)(pair(a,b)).toMap
 
   /** Push `s` onto the scope stack. */
-  def scope[A](s: String)(t: Test[A]): Test[A] = test { env =>
+  def scope[A](s: String)(t: Test[A]): Test[A] = testAlways { env =>
     try t.run(env.copy(scope = concatScope(env.scope, s)))
     catch {
       case Skip => throw Skip
@@ -162,7 +164,7 @@ object EasyTest {
 
   def suite(s: String)(t: Test[Unit]*): Test[Unit] = scope(s)(suite(t: _*))
 
-  def suite(t: Test[Unit]*): Test[Unit] = test { implicit T =>
+  def suite(t: Test[Unit]*): Test[Unit] = testAlways { implicit T =>
     val n = T.long
     (0 until t.size).foreach { i =>
       T.rand.setSeed(n)

--- a/runtime-jvm/main/src/test/scala/util/BytesTests.scala
+++ b/runtime-jvm/main/src/test/scala/util/BytesTests.scala
@@ -2,7 +2,7 @@ package org.unisonweb.util
 
 import org.unisonweb.EasyTest._
 
-object BytesTests extends App {
+object BytesTests {
 
   val tests = test("Bytes.Seq") { implicit T =>
     0 until 1000 foreach { i =>
@@ -15,5 +15,4 @@ object BytesTests extends App {
     ok
   }
 
-  run()(tests)
 }

--- a/runtime-jvm/main/src/test/scala/util/CritbyteTests.scala
+++ b/runtime-jvm/main/src/test/scala/util/CritbyteTests.scala
@@ -2,7 +2,7 @@ package org.unisonweb.util
 
 import org.unisonweb.EasyTest._
 
-object CritbyteTests extends App {
+object CritbyteTests {
 
   val tests = suite("Critbyte")(
     test("works like a map") { implicit T =>
@@ -26,6 +26,4 @@ object CritbyteTests extends App {
   //def genCritbytes[A](size: => Int, a: => A)(implicit T: Env): Critbyte[A] =
   //  map(genBytes(intIn(0,256)), a)
 
-  run()(tests)
 }
-

--- a/runtime-jvm/main/src/test/scala/util/SequenceTests.scala
+++ b/runtime-jvm/main/src/test/scala/util/SequenceTests.scala
@@ -6,7 +6,7 @@ object SequenceTests {
 
   val S = Sequence
 
-  lazy val tests = suite("Sequence")(
+  val tests = suite("Sequence")(
     test("basic examples") { implicit T =>
       expect { S(1) == S(1) }
       expect { S(1) ++ S(1) == S(1,1) }

--- a/runtime-jvm/main/src/test/scala/util/TextTests.scala
+++ b/runtime-jvm/main/src/test/scala/util/TextTests.scala
@@ -73,7 +73,3 @@ object TextTests {
     }
   }
 }
-
-object RunTextTests extends App {
-  run()(TextTests.tests)
-}

--- a/runtime-jvm/main/src/test/scala/util/UtilTests.scala
+++ b/runtime-jvm/main/src/test/scala/util/UtilTests.scala
@@ -8,11 +8,13 @@ object UtilTests {
     suite(DequeTests.tests,
           SequenceTests.tests,
           BytesTests.tests,
-          TextTests.tests)
+          TextTests.tests,
+          CritbyteTests.tests)
   }
 }
 
 object RunUtilTests extends App {
   run()(UtilTests.tests)
+  // run(seed = 93276, prefix = "util.Critbyte.works like a map")(UtilTests.tests)
 }
 


### PR DESCRIPTION
tl;dr: 

* Fixed prefix filtering of tests in EasyTest - you can now run just a subsuite or an individual test based on a "scope prefix". See ex below.
* NPE due to Scala class initialization weirdness, gave a workaround.

A bit more detail - 

The NPE we were seeing was caused by weird class initialization issues when extending `App`, so if you have things like:

```Scala
object Blah extends App {
  val foo = "hello"
}

object Oog { val xy = Blah.foo }  
```

Then `xy` can end up being `null`, since `foo` isn't initialized at the time that `xy` is evaluated. `App` does some funky stuff with delayed class initialization... I didn't bother digging in. 

Instead, the new idiom is to just define your tests as a regular `object`:

```Scala
import org.unisonweb.EasyTest._

object MyTests {
  val tests = suite("mytests")(test1, test2) 
}

// if you wish, define a `main` as a separate object - by convention, just prefix 'Run' to the name
object RunMyTests extends App { run()(MyTests.tests) }

object AllTheTests { 
  val tests = suite (MyTests.tests, SequenceTests.tests, ... )
}
object RunAllTheTests extends App {
  // run(prefix = "mytests")(AllTheTests.tests)
  run()(AllTheTests.tests)
}
```

In this way, you can aggregate your tests into hierarchical suites however you like and filter which ones are run. When a suite fails, EasyTests tells you the prefix to run if you want to run just that portion of the suite again, so I got rid of the separate mains for now - there is just one main function.