### PR TITLE
Decompilation of terms (including terms with cyclic references)

### DIFF
--- a/runtime-jvm/main/src/main/scala/ABT.scala
+++ b/runtime-jvm/main/src/main/scala/ABT.scala
@@ -1,6 +1,6 @@
 package org.unisonweb
 
-import org.unisonweb.util.{Functor, Traverse}
+import org.unisonweb.util.{Functor, Traverse, Monoid}
 
 sealed abstract class ABT[F[+_],+R] {
   import ABT._
@@ -44,17 +44,14 @@ object ABT {
     }
 
     /** Accumulate `B` values up the tree. `f` is only applied to leaf nodes of the tree (either `Var` or `Tm` with no children). */
-    def annotateUp[B](combine: (B,B) => B, zero: B)(f: AnnotatedTerm[F,A] => AnnotatedTerm[F,B])(implicit F: Traverse[F]): AnnotatedTerm[F,(A,B)] = {
-       get.map(_.annotateUp(combine, zero)(f)) match {
+    def annotateUp[B](f: AnnotatedTerm[F,A] => AnnotatedTerm[F,B])(B: Monoid[B])(implicit F: Traverse[F]): AnnotatedTerm[F,B] = {
+       get.map(_.annotateUp(f)(B)) match {
          case abt @ Tm_(t) =>
            val children = F.toVector(t)
-           if (children.isEmpty) f(this).map(b => (annotation, b))
-           else {
-             val b = children.foldLeft(zero) { case (b, tm) => combine(b, tm.annotation._2) }
-             AnnotatedTerm((annotation, b), abt)
-           }
-         case Var_(_) => f(this).map(b => (annotation,b))
-         case abt@Abs_(name, body) => AnnotatedTerm(annotation -> body.annotation._2, abt)
+           if (children.isEmpty) f(this)
+           else AnnotatedTerm(B.reduce(children.map(_.annotation)), abt)
+         case Var_(_) => f(this)
+         case abt@Abs_(name, body) => AnnotatedTerm(body.annotation, abt)
        }
     }
 
@@ -62,23 +59,38 @@ object ABT {
      * Applies `f` to all leaf nodes (either vars or Tm nodes with no children),
      * then accumulates the values up the tree.
      */
-    def foldMap[B](f: AnnotatedTerm[F,A] => B)(combine: (B,B) => B, zero: B)(
+    def foldMap[B](f: AnnotatedTerm[F,A] => B)(B: Monoid[B])(
         implicit F: Traverse[F]): B =
-      get.map(_.foldMap(f)(combine, zero)) match {
+      get.map(_.foldMap(f)(B)) match {
          case abt @ Tm_(t) =>
            val children = F.toVector(t)
            if (children.isEmpty) f(this)
-           else children.foldLeft(zero)(combine)
+           else B.reduce(children)
          case Var_(_) => f(this)
          case Abs_(name, b) => b
       }
 
     /** Apply `f` to `this`, and then recursively to the children of the resulting term. */
-    def rewriteDown(f: AnnotatedTerm[F,A] => AnnotatedTerm[F,A])(implicit F: Functor[F]): AnnotatedTerm[F,A] =
-      f(this) match {
+    def rewriteDown(f: AnnotatedTerm[F,A] => AnnotatedTerm[F,A])(
+      implicit F: Functor[F]): AnnotatedTerm[F,A] = f(this) match {
         case AnnotatedTerm(ann, abt) => AnnotatedTerm(ann, abt.map(_ rewriteDown f))
       }
 
+    def rewriteUp(f: AnnotatedTerm[F,A] => AnnotatedTerm[F,A])(
+      implicit F: Traverse[F]): AnnotatedTerm[F,A] = get match {
+         case abt @ Tm_(t) =>
+           val children = F.toVector(t)
+           if (children.isEmpty) f(this)
+           else f(AnnotatedTerm(annotation, Tm_(F.map(t) { _ rewriteUp f })))
+         case Var_(_) => f(this)
+         case abt@Abs_(name, body) =>
+           f(AnnotatedTerm(annotation, ABT.Abs_(name, body.rewriteUp(f))))
+       }
+
+    /**
+     * Like `rewriteDown`, but the function `f` receives state `S` which is
+     * updated while moving down the tree.
+     */
     def rewriteDownS[S](s: S)(f: (S,AnnotatedTerm[F,A]) => (S,AnnotatedTerm[F,A]))(
       implicit F: Functor[F]): AnnotatedTerm[F,A] =
       f(s, this) match { case (s, AnnotatedTerm(ann,abt)) =>

--- a/runtime-jvm/main/src/main/scala/Term.scala
+++ b/runtime-jvm/main/src/main/scala/Term.scala
@@ -1,6 +1,7 @@
 package org.unisonweb
 
-import org.unisonweb.util.{Traverse, LCA}
+import org.unisonweb.util.{Traverse,Monoid}
+// import org.unisonweb.util.{Traverse, LCA}
 import ABT.{Abs, AnnotatedTerm, Tm}
 import compilation.{Ref,Param,Value}
 
@@ -71,42 +72,39 @@ object Term {
     case _ => t
   }
 
-
-  def selfToLetRec(t: Term): Term = t rewriteDown {
-    case Lam(names, body) =>
-      val selfRefs = body.foldMap {
-        case Term.Self(name) => Set(name)
-        case _ => Set.empty[Name]
-      } (_ union _, Set.empty)
-      selfRefs.toList match {
-        case Nil => Lam(names: _*)(body) // no self calls
-        case rec :: Nil =>
-          val body2 = Lam(names: _*)(body)
-          // LetRec(rec -> )
-          ???
-        case _ => ??? // should not happen
+  /** Converts self refs within lambdas to regular named let recs. */
+  def selfToLetRec(t: Term): Term = {
+    val t2 = t.rewriteDown {
+      case Term.Self(name) => Term.Var(name)
+      case t => t
+    }.annotateFree.rewriteUp {
+      case t@Lam(names, body) => Term.freeVars(t).toList match {
+        case Nil => t
+        case rec :: Nil => LetRec(rec -> t)(t)
+        case recs => sys.error("more than one recursive var in scope: " + recs)
       }
-    case _ => ???
+      case t => t
+    }.annotateFree
+    assert (Term.freeVars(t2).isEmpty)
+    t2
   }
 
   def fullyDecompile(t: Term): Term = {
-    // Proposed simpler algorithm:
-    // 1. Pass to convert self calls to regular let rec
-    // 2. Collect full set of refs via transitive closure - a `Set[Ref]`
-    // 3. Freshen names for each `Ref`, if needed
-    // 4. Introduce one outer let rec block for each `Ref`, substitute away all refs
+    // 1. Collect full set of refs via transitive closure - a `Set[Ref]`
+    // 2. Compute all used names (including self recursive names), freshen names for each `Ref`
+    // 3. Introduce one outer let rec block for each `Ref`, substitute away all refs
+    // 4. Pass to convert self calls to regular let rec
     // 5. (optional) Pass to float bindings in to their LCA of all reference points,
     //               but there's not much advantage to this.
 
-    def annotateRefs(t: Term): AnnotatedTerm[Term.F, (Set[Name], LCA[Ref])] =
-      t.annotateUp[LCA[Ref]](_ combine _, LCA.empty) {
-        case Compiled(r : Ref) => Term.Var(r.name) map { _ => LCA.single(r) } // okay to replace this here
-        case Compiled(v : Value) => v.decompile map { _ => LCA.empty }
-        // case Self(name) => Term.Var(name) map { _ => } todo handle this correctly
-        case x => x map { _ => LCA.empty }
-      }
+    def names(t: Term): Set[Name] = t.foldMap[Set[Name]] {
+      case Var(name) => Set(name)
+      case Self(name) => Set(name)
+      case Abs(name, _) => Set(name)
+      case _ => Set.empty
+    } (Monoid.Set)
 
-    def transitiveClosure(seen: Set[Ref], cur: Term): Set[Ref] = cur match {
+    def transitiveClosure(seen: Map[Ref,Term], cur: Term): Map[Ref,Term] = cur match {
       case Builtin(_) | Num(_) | Var(_) => seen
       case Apply(f, args) =>
         args.foldLeft(transitiveClosure(seen, f))(transitiveClosure _)
@@ -117,35 +115,25 @@ object Term {
         transitiveClosure(transitiveClosure(seen, binding), body)
       case LetRec(bindings, body) =>
         bindings.map(_._2).foldLeft(transitiveClosure(seen, body))(transitiveClosure)
-      case Compiled(r : Ref) => if (seen.contains(r)) seen else transitiveClosure(seen + r, r.value.decompile)
+      case Compiled(r : Ref) =>
+        if (seen.contains(r)) seen
+        else { val v = r.value.decompile; transitiveClosure(seen + (r -> v), v) }
       case Compiled(v) => transitiveClosure(seen, v.decompile)
     }
 
-    type TermLR = AnnotatedTerm[Term.F, Set[Ref]]
-    val refs = annotateRefs(stripOuterCompiled(t))
-
-    val letGroups: TermLR = annotateRefs(stripOuterCompiled(t)).annotateDown(Set.empty[Ref]) { (seen, tm) =>
-      val lcas2 = tm.annotation._2.lcas -- seen
-      val bindingsToIntroduce = lcas2.foldLeft(Set.empty[Ref])((seen,ref) => transitiveClosure(seen, ref.value.decompile))
-      (seen ++ bindingsToIntroduce, bindingsToIntroduce)
+    // 1. Collect full set of refs via transitive closure - a `Set[Ref]`
+    val refs = transitiveClosure(Map.empty, t)
+    val usedNames = refs.values.map(names).foldLeft(names(t))(_ union _)
+    // 2. Freshen names for each `Ref`, if needed
+    val freshRefNames = refs.keys.view.map(r => (r, ABT.freshen(r.name, usedNames))).toMap
+    def replaceRefs(t: Term): Term = selfToLetRec(t).rewriteDown {
+      case Compiled(r : Ref) => Var(freshRefNames(r))
+      case t => t
     }
-    // println("let groups: " + letGroups)
-
-    import ABT.{Tm_, Abs_}
-    def Tm(f: Term.F[TermLR]): AnnotatedTerm[Term.F, Set[Ref]] = AnnotatedTerm(Set.empty[Ref], Tm_(f))
-
-    val letTree = letGroups rewriteDown { t =>
-      if (t.annotation.isEmpty) t
-      else {
-        def letrec(bs: List[(Name,TermLR)], body: TermLR): TermLR =
-          Tm(F.Rec_(bs.map(_._1).foldRight(Tm(F.LetRec_(bs.map(_._2).toList, body)))((name,body) => AnnotatedTerm(Set.empty, Abs_(name,body)))))
-        letrec(
-          t.annotation.toList.map(r => r.name -> r.value.decompile.rewriteDown(stripOuterCompiled).map(_ => Set.empty[Ref])),
-          t
-        )
-      }
-    }
-    letTree.annotateFree
+    val refBindings = refs.toList.map { case (ref,tm) => (freshRefNames(ref), replaceRefs(tm)) }
+    // 3. Introduce one outer let rec block with all uniquely named refs
+    // 4. Pass to convert self calls to regular let rec
+    LetRec(refBindings: _*)(replaceRefs(t))
   }
 
   // todo - test when function being applied is a compound expression
@@ -288,7 +276,8 @@ object Term {
 
   object LetRec {
     def apply(bs: (Name, Term)*)(body: Term): Term =
-      Tm(Rec_(bs.map(_._1).foldRight(Tm(LetRec_(bs.map(_._2).toList, body)))((name,body) => Abs(name,body))))
+      if (bs.isEmpty) body
+      else Tm(Rec_(bs.map(_._1).foldRight(Tm(LetRec_(bs.map(_._2).toList, body)))((name,body) => Abs(name,body))))
     def unapply[A](t: AnnotatedTerm[F,A]): Option[(List[(Name,AnnotatedTerm[F,A])], AnnotatedTerm[F,A])] = t match {
       case Tm(Rec_(ABT.AbsChain(names, Tm(LetRec_(bindings, body))))) =>
         Some((names zip bindings, body))

--- a/runtime-jvm/main/src/main/scala/Term.scala
+++ b/runtime-jvm/main/src/main/scala/Term.scala
@@ -71,15 +71,25 @@ object Term {
     case _ => t
   }
 
+
+  def selfToLetRec(t: Term): Term = t rewriteDown {
+    case Lam(names, body) =>
+      val selfRefs = body.foldMap {
+        case Term.Self(name) => Set(name)
+        case _ => Set.empty[Name]
+      } (_ union _, Set.empty)
+      selfRefs.toList match {
+        case Nil => Lam(names: _*)(body) // no self calls
+        case rec :: Nil =>
+          val body2 = Lam(names: _*)(body)
+          // LetRec(rec -> )
+          ???
+        case _ => ??? // should not happen
+      }
+    case _ => ???
+  }
+
   def fullyDecompile(t: Term): Term = {
-    // general idea:
-    // 1. accumulate lowest common ancestor info of Refs up the tree
-    // 2. expand set of Refs at each node to include transitive closure of references
-    // 3. traverse down the tree, if a
-    // 4. introduce let rec at each point in the tree with a nonempty cycle of refs
-    //    (and a let rec for each Lam with a Self ref)
-    // question - seems like could do the transitive closure computation before or after accumulating LCA
-    //
     // Proposed simpler algorithm:
     // 1. Pass to convert self calls to regular let rec
     // 2. Collect full set of refs via transitive closure - a `Set[Ref]`

--- a/runtime-jvm/main/src/main/scala/compilation.scala
+++ b/runtime-jvm/main/src/main/scala/compilation.scala
@@ -87,8 +87,7 @@ package object compilation extends TailCalls with CompileLambda with CompileLet1
   def normalize(builtins: Name => Computation)(e: Term): Term = {
     val c = compile(builtins)(e)
     val r = Result()
-    val x = Value(c(null, r), r.boxed).decompile
-    // val x = Term.etaNormalForm(Value(c(null, r), r.boxed).decompile)
+    val x = Term.etaNormalForm(Value(c(null, r), r.boxed).decompile)
     Term.fullyDecompile(x)
   }
 

--- a/runtime-jvm/main/src/main/scala/util/LCA.scala
+++ b/runtime-jvm/main/src/main/scala/util/LCA.scala
@@ -15,4 +15,10 @@ case class LCA[A](union: Set[A], lcas: Set[A]) {
 object LCA {
   def single[A](a: A): LCA[A] = LCA(Set(a), Set())
   def empty[A]: LCA[A] = LCA(Set(), Set())
+
+  implicit def Monoid[A]: Monoid[LCA[A]] = new Monoid[LCA[A]] {
+    type T = LCA[A]
+    val id = empty[A]
+    def op(t1: T, t2: T) = t1 combine t2
+  }
 }

--- a/runtime-jvm/main/src/main/scala/util/Monoid.scala
+++ b/runtime-jvm/main/src/main/scala/util/Monoid.scala
@@ -1,0 +1,44 @@
+package org.unisonweb.util
+
+/**
+ * Algebraic structure over some type, `A`, satisfying:
+ *  - op(id, x) == x` (left identity)
+ *  - op(x, id) == x` (right identity)
+ *  - op(op(x, y), z) == op(x, op(y, z))` (associativity).
+ */
+trait Monoid[A] {
+  def id: A
+  def op(a1: A, a2: A): A
+
+  /**
+   * Allow the monoid to choose associativity when reducing a sequence,
+   * as some monoids (like List with `++`) perform best right associative,
+   * others (like `Array` with ++) perform best as a balanced reduction,
+   * etc.
+   */
+  def reduce(s: Seq[A]): A = s.foldLeft(id)(op)
+}
+
+object Monoid {
+
+  implicit def Set[A]: Monoid[Set[A]] = new Monoid[Set[A]] {
+    type T = Set[A]
+    def id = collection.immutable.Set.empty[A]
+    def op(a: T, a2: T) = a union a2
+  }
+
+  implicit def product[A,B](implicit A: Monoid[A], B: Monoid[B]): Monoid[(A,B)] = new Monoid[(A,B)] {
+    type T = (A,B)
+    val id = (A.id, B.id)
+    def op(a: T, b: T) = (A.op(a._1, b._1), B.op(a._2, b._2))
+
+    override def reduce(s: Seq[T]): T =
+      A.reduce(s.view.map(_._1)) -> B.reduce(s.view.map(_._2))
+  }
+
+  implicit val unit: Monoid[Unit] = new Monoid[Unit] {
+    type T = Unit
+    def id = ()
+    def op(a: T, b: T) = ()
+  }
+}

--- a/runtime-jvm/main/src/test/scala/AllTests.scala
+++ b/runtime-jvm/main/src/test/scala/AllTests.scala
@@ -1,0 +1,15 @@
+package org.unisonweb
+
+import org.unisonweb.EasyTest._
+import org.unisonweb.util.UtilTests
+
+object AllTests {
+  val tests = suite(
+    DecompileTests.tests,
+    UtilTests.tests
+  )
+}
+
+object RunAllTests extends App {
+  run()(AllTests.tests)
+}

--- a/runtime-jvm/main/src/test/scala/AllTests.scala
+++ b/runtime-jvm/main/src/test/scala/AllTests.scala
@@ -10,6 +10,9 @@ object AllTests {
   )
 }
 
-object RunAllTests extends App {
-  run()(AllTests.tests)
+object RunAllTests {
+  def main(args: Array[String]) = {
+    val prefix = if (args.length == 1) args(0) else ""
+    run(prefix = prefix)(AllTests.tests)
+  }
 }

--- a/runtime-jvm/main/src/test/scala/DecompileTests.scala
+++ b/runtime-jvm/main/src/test/scala/DecompileTests.scala
@@ -11,7 +11,7 @@ object DecompileTests {
         Term.LetRec(
           "ping" -> Term.Lam("x")(Term.Var("pong")(Term.Var("x"))),
           "pong" -> Term.Lam("x")(Term.Num(79))) {
-            Term.Var("ping")
+            Term.Var("pong")
           }
       note(PrettyPrint.prettyTerm(compilation.normalize(_ => ???)(pingpong)).render(40), includeAlways = true)
       ok
@@ -35,14 +35,8 @@ object DecompileTests {
           "pong" -> Term.Lam("x")(Term.Var("ping")(Term.Var("pang")(Term.Var("x"))))) {
             Term.Var("ping")
           }
-      note(pingpong, true)
       note(PrettyPrint.prettyTerm(compilation.normalize(_ => ???)(pingpong)).render(40), includeAlways = true)
       ok
     }
   )
-
-  // seems like there's something wonky with Refs appearing as the result of a computation
-  // perhaps use types to prevent this from happening, types distinguish between things that can be passed a param (could be a ref)
-  // vs things that may be returned from a computation (cannot be a ref)
-  // seems like fullyDecompile not expanding Refs sufficiently?
 }

--- a/runtime-jvm/main/src/test/scala/DecompileTests.scala
+++ b/runtime-jvm/main/src/test/scala/DecompileTests.scala
@@ -8,21 +8,25 @@ object DecompileTests {
   val tests = suite("decompile") (
     test("ex1") { implicit T =>
       val pingpong =
-        Term.LetRec(
-          "ping" -> Term.Lam("x")(Term.Var("pong")(Term.Var("x"))),
-          "pong" -> Term.Lam("x")(Term.Num(79))) {
-            Term.Var("pong")
-          }
+        Term.Let("k" -> Term.Num(79)) {
+          Term.LetRec(
+            "ping" -> Term.Lam("x")(Term.Var("pong")(Term.Var("x"))),
+            "pong" -> Term.Lam("x")(Term.Var("k"))) {
+              Term.Var("pong")
+            }
+        }
       note(PrettyPrint.prettyTerm(compilation.normalize(_ => ???)(pingpong)).render(40), includeAlways = true)
       ok
     },
     test("ex2") { implicit T =>
       val pingpong =
-        Term.LetRec(
-          "ping" -> Term.Lam("x")(Term.Var("pong")(Term.Var("x"))),
-          "pong" -> Term.Lam("x")(Term.Var("ping")(Term.Var("x")))) {
-            Term.Var("ping")
-          }
+        Term.Let("id" -> Term.Lam("x")(Term.Var("x"))) {
+          Term.LetRec(
+            "ping" -> Term.Lam("x")(Term.Var("pong")(Term.Var("id")(Term.Var("x")))),
+            "pong" -> Term.Lam("x")(Term.Var("ping")(Term.Var("x")))) {
+              Term.Var("ping")
+            }
+        }
       note(PrettyPrint.prettyTerm(compilation.normalize(_ => ???)(pingpong)).render(40), includeAlways = true)
       ok
     },

--- a/runtime-jvm/main/src/test/scala/EasyTest.scala
+++ b/runtime-jvm/main/src/test/scala/EasyTest.scala
@@ -221,7 +221,7 @@ object EasyTest {
       }
     }}
     bg.start
-    println("STARTING TESTS, raw output to follow ... ")
+    println(s"STARTING TESTS with prefix '$prefix', raw output to follow ... ")
     println("--------------------------------------------------\n")
     try t.run
     catch {

--- a/runtime-jvm/main/src/test/scala/util/UtilTests.scala
+++ b/runtime-jvm/main/src/test/scala/util/UtilTests.scala
@@ -12,9 +12,3 @@ object UtilTests {
           CritbyteTests.tests)
   }
 }
-
-object RunUtilTests extends App {
-  run()(UtilTests.tests)
-  // run(prefix = "util.Critbyte.works")(UtilTests.tests)
-}
-

--- a/runtime-jvm/main/src/test/scala/util/UtilTests.scala
+++ b/runtime-jvm/main/src/test/scala/util/UtilTests.scala
@@ -4,7 +4,7 @@ import org.unisonweb.EasyTest._
 
 object UtilTests {
 
-  lazy val tests = scope("util") {
+  val tests = scope("util") {
     suite(DequeTests.tests,
           SequenceTests.tests,
           BytesTests.tests,


### PR DESCRIPTION
This is really important. We can now compile terms, execute them using the JIT'd runtime representation, but retain enough metadata to be able to decompile results after (or during) execution, with human-readable results.

This is useful just for having a really nice interactive editor (the result of any computation can be displayed back to the user as an "ordinary" Unison program, rather than showing them some ad hoc `toString` representation that the user often has to write and which can't print out functions or cyclic structures), for debugging (imagine being able to pause a computation at any point, obtaining the continuation as a regular Unison function whose source you can inspect), and all sorts of other stuff (perhaps serialization of continuations for inter-node protocol). 

An example, after evaluating this:

```Haskell
let 
  id x = x
  let rec
      pong x = ping x
      ping x = pong (id x)
      ping
```

We get:

```Haskell
let rec
    pong x = ping x
    ping x = pong ((x -> x) x)
    x -> pong ((x -> x) x)
```

The `id` definition has been substituted away during execution, but we've retained enough metadata about the resulting value to know to decompile it to `x -> x` (since `x` was the parameter name chosen for `id`).

Some other minor cleanup:

* Removed `RunUtilTests`, added `AllTests` and `RunAllTests`, which is the sole `main` in the test directory.
* Handy: `RunAllTests` takes a command line arg for the prefix, ex: `> test:run "util"` or `> test:run "util.Critbyte"`. I got tired of editing the code just to select a subsuite of tests.
* Added `org.unisonweb.util.Monoid`, using it in a couple places instead of passing a pair of args.

@refried The simplified algorithm I proposed seems like it works, but we should try to beef up the tests at some point and see if can break it.