### PR TITLE
Removed pointless `decompile` field from `Computation` and then converted to use Scala lambda syntax to construct `Computation` values

### DIFF
--- a/runtime-jvm/main/src/main/scala/Lib2.scala
+++ b/runtime-jvm/main/src/main/scala/Lib2.scala
@@ -42,26 +42,18 @@ object Lib2 {
   }
 
   def builtin1(decompiled: Term, n: Name, f: NumericUnaryOp): Lambda = {
-    val body = new Computation(null) {
-      def apply(r: R, rec: Lambda, top: StackPtr,
-                stackU: Array[U], x1: U, x0: U,
-                stackB: Array[B], x1b: B, x0b: B): U = {
-        r.boxed = null
-        f(x0)
-      }
+    val body: Computation = (r,rec,top,stackU,x1,x0,stackB,x1b,x0b) => {
+      r.boxed = null
+      f(x0)
     }
     val ns = List(n)
     new Lambda(1, body, decompiled) { def names = ns }
   }
 
   def builtin2(decompiled: Term, ns: List[Name], f: NumericBinOp): Lambda = {
-    val body = new Computation(null) {
-      def apply(r: R, rec: Lambda, top: StackPtr,
-                stackU: Array[U], x1: U, x0: U,
-                stackB: Array[B], x1b: B, x0b: B): U = {
-        r.boxed = null
-        f(x1, x0)
-      }
+    val body: Computation = (r,rec,top,stackU,x1,x0,stackB,x1b,x0b) => {
+      r.boxed = null
+      f(x1, x0)
     }
 
     new Lambda(2, body, decompiled) { self =>
@@ -72,14 +64,11 @@ object Lib2 {
           case List((_,term)) => term match {
             case Term.Compiled2(p: Param) =>
               val n = p.toValue.asInstanceOf[Value.Num].n
-              new Lambda(1, new Computation(null) {
-                def apply(r: R, rec: Lambda, top: StackPtr,
-                          stackU: Array[U], x1: U, x0: U,
-                          stackB: Array[B], x1b: B, x0b: B): U = {
-                  r.boxed = null
-                  f(n, x0)
-                }
-              }, Term.Apply(decompiled, term)) {
+              val body: Computation = (r,rec,top,stackU,x1,x0,stackB,x1b,x0b) => {
+                r.boxed = null
+                f(n, x0)
+              }
+              new Lambda(1, body, Term.Apply(decompiled, term)) {
                 def names = self.names drop argCount
               }
             case _ => sys.error("")


### PR DESCRIPTION
Much more readable! Bonus: this also seems to have improved performance. If I had to guess, I'm thinking that the JVM is more willing to inline the Single Abstract Method classes than it is to inline an abstract class with a field?

Here's what I'm seeing (this is still not good, but getting in the ballpark of reasonable, rather than "WTF is this even doing").

```
[info] Running org.unisonweb.benchmark.Compilation2Benchmarks 
 - scala-fib:  71.612 microseconds (4.8% deviation, N=1436, K = 290)                             
 - unison-fib:  10.921 milliseconds (3.6% deviation, N=31, K = 107)                               
1.0             scala-fib
152.5           unison-fib
 * scala-triangle: 1000.0 milliseconds, N=19, deviation=Infinity%, target deviation: 5.0%             - scala-triangle:  403.5 nanoseconds (3.2% deviation, N=283723, K = 361)                           
 * unison-triangle: 1000.0 milliseconds, N=19, deviation=Infinity%, target deviation: 5.0%            * unison-triangle: 869.964 microseconds, N=114, deviation=106.0%, target deviation: 5.0%             - unison-triangle:  194.554 microseconds (4.1% deviation, N=1132, K = 232)                          
1.0             scala-triangle
482.16          unison-triangle
 * scala-fibPrime: 1000.0 milliseconds, N=19, deviation=Infinity%, target deviation: 5.0%             - scala-fibPrime:  39.37 microseconds (2.9% deviation, N=3921, K = 171)                             
 * unison-fibPrime: 1000.0 milliseconds, N=19, deviation=Infinity%, target deviation: 5.0%            - unison-fibPrime:  20.513 milliseconds (2.0% deviation, N=22, K = 448)                          
1.0             scala-fibPrime
521.04          unison-fibPrime
``` 

ProTip is I told vim to expand `csig` to `(r,rec,top,stackU,x1,x0,stackB,x1b,x0b) => {`

```
:iab csig (r,rec,top,stackU,x1,x0,stackB,x1b,x0b) => { 
```