### PR TITLE
A bunch of speed improvements for nocodegen branch

### DIFF
--- a/runtime-jvm/.sbtopts
+++ b/runtime-jvm/.sbtopts
@@ -1,9 +1,9 @@
 # https://docs.oracle.com/javase/8/embedded/develop-apps-platforms/codecache.htm
-#-J-XX:InlineSmallCode=9001
-#-J-XX:MaxInlineLevel=9001
-#-J-XX:MaxInlineSize=9001
-#-J-XX:CompileThreshold=10
-#-J-XX:MinInliningThreshold=10
+-J-XX:InlineSmallCode=8000
+-J-XX:MaxInlineLevel=30
+-J-XX:MaxInlineSize=9001
+-J-XX:CompileThreshold=10
+-J-XX:MinInliningThreshold=10
 #-J-XX:FreqInlineSize 
-#-J-XX:MaxTrivialSize
+-J-XX:MaxTrivialSize=50
 #-J-XX:LiveNodeCountInliningCutoff

--- a/runtime-jvm/benchmark/src/main/scala/Compilation2Benchmarks.scala
+++ b/runtime-jvm/benchmark/src/main/scala/Compilation2Benchmarks.scala
@@ -28,9 +28,7 @@ object Compilation2Benchmarks {
       {
         val p = runTerm(Terms.fib)
         profile("unison-fib") {
-          eval(p.body, r, p, top,
-               stackU, U0, N(21).toDouble,
-               stackB, null, null).toLong
+          evalLam(p, r, top, stackU, U0, N(21).toDouble, stackB, null, null).toLong
         }
       }
     )
@@ -43,9 +41,7 @@ object Compilation2Benchmarks {
       {
         val p = runTerm(Terms.triangle)
         profile("unison-triangle") {
-          eval(p.body, r, p, top,
-               stackU, N(1000), N(0),
-               stackB, null, null).toLong
+          evalLam(p, r, top, stackU, N(1000), N(0), stackB, null, null).toLong
         }
       }
     )
@@ -60,9 +56,7 @@ object Compilation2Benchmarks {
       {
         val p = runTerm(Terms.fibPrime)
         profile("unison-fibPrime") {
-          eval(p.body, r, p, top,
-               stackU, U0, N(21),
-               stackB, null, null).toLong
+          evalLam(p, r, top, stackU, U0, N(21), stackB, null, null).toLong
         }
       }
     )

--- a/runtime-jvm/benchmark/src/main/scala/Compilation2Benchmarks.scala
+++ b/runtime-jvm/benchmark/src/main/scala/Compilation2Benchmarks.scala
@@ -20,6 +20,19 @@ object Compilation2Benchmarks {
 
   def main(args: Array[String]): Unit = {
     suite(
+      profile("scala-triangle") {
+        def triangle(n: Int, acc: Int): Int =
+          if (n == 0) acc else triangle(n - 1, acc + n)
+        triangle(N(10000), N(0))
+      },
+      {
+        val p = runTerm(Terms.triangle)
+        profile("unison-triangle") {
+          evalLam(p, r, top, stackU, N(10000), N(0), stackB, null, null).toLong
+        }
+      }
+    )
+    suite(
       profile("scala-fib") {
         def fib(n: Int): Int =
           if (n < 2) n else fib(n - 1) + fib(n - 2)
@@ -29,19 +42,6 @@ object Compilation2Benchmarks {
         val p = runTerm(Terms.fib)
         profile("unison-fib") {
           evalLam(p, r, top, stackU, U0, N(21).toDouble, stackB, null, null).toLong
-        }
-      }
-    )
-    suite(
-      profile("scala-triangle") {
-        def triangle(n: Int, acc: Int): Int =
-          if (n == 0) acc else triangle(n - 1, acc + n)
-        triangle(N(1000), N(0))
-      },
-      {
-        val p = runTerm(Terms.triangle)
-        profile("unison-triangle") {
-          evalLam(p, r, top, stackU, N(1000), N(0), stackB, null, null).toLong
         }
       }
     )

--- a/runtime-jvm/build.sbt
+++ b/runtime-jvm/build.sbt
@@ -4,8 +4,8 @@ lazy val commonSettings = Seq(
     // https://docs.oracle.com/javase/8/embedded/develop-apps-platforms/codecache.htm
     //"-XX:+UnlockDiagnosticVMOptions",
     //"-XX:+LogCompilation"
-    //"-XX:InlineSmallCode=9001"
-    //"-XX:MaxInlineLevel=9001"
+    "-XX:InlineSmallCode=9001",
+    "-XX:MaxInlineLevel=35"
     //"-XX:MaxInlineSize=9001"
     //"-XX:CompileThreshold=10"
     //"-XX:MinInliningThreshold=10"

--- a/runtime-jvm/main/src/main/scala/Lib2.scala
+++ b/runtime-jvm/main/src/main/scala/Lib2.scala
@@ -67,6 +67,14 @@ object Lib2 {
           r.boxed = null
           f(x1, n)
         }
+        case List(CompiledVar1,CompiledVar0) => (r,rec,top,stackU,x1,x0,stackB,x1b,x0b) => {
+          r.boxed = null
+          f(x1, x0)
+        }
+        case List(CompiledVar0,CompiledVar1) => (r,rec,top,stackU,x1,x0,stackB,x1b,x0b) => {
+          r.boxed = null
+          f(x0, x1)
+        }
         case List(arg1,arg2) => (r,rec,top,stackU,x1,x0,stackB,x1b,x0b) => {
           val x1v = eval(arg1,r,rec,top,stackU,x1,x0,stackB,x1b,x0b)
           val x0v = eval(arg2,r,rec,top,stackU,x1,x0,stackB,x1b,x0b)

--- a/runtime-jvm/main/src/main/scala/Lib2.scala
+++ b/runtime-jvm/main/src/main/scala/Lib2.scala
@@ -33,11 +33,11 @@ object Lib2 {
 
   @inline def boolToNum(b: Boolean): U = if (b) True else False
 
-  trait NumericUnaryOp {
+  abstract class NumericUnaryOp {
     def apply(n1: U): U
   }
 
-  trait NumericBinOp {
+  abstract class NumericBinOp {
     def apply(n1: U, n2: U): U
   }
 
@@ -58,10 +58,19 @@ object Lib2 {
 
     new Lambda(2, body, decompiled) { self =>
       def names = ns
-      override def saturatedCall(args: List[Computation], isTail: IsTail) = args match {
+      override def saturatedNonTailCall(args: List[Computation]) = args match {
+        case List(CompiledVar0,Return(Value.Num(n))) => (r,rec,top,stackU,x1,x0,stackB,x1b,x0b) => {
+          r.boxed = null
+          f(x0, n)
+        }
+        case List(CompiledVar1,Return(Value.Num(n))) => (r,rec,top,stackU,x1,x0,stackB,x1b,x0b) => {
+          r.boxed = null
+          f(x1, n)
+        }
         case List(arg1,arg2) => (r,rec,top,stackU,x1,x0,stackB,x1b,x0b) => {
           val x1v = eval(arg1,r,rec,top,stackU,x1,x0,stackB,x1b,x0b)
           val x0v = eval(arg2,r,rec,top,stackU,x1,x0,stackB,x1b,x0b)
+          r.boxed = null
           f(x1v, x0v)
         }
       }

--- a/runtime-jvm/main/src/main/scala/Lib2.scala
+++ b/runtime-jvm/main/src/main/scala/Lib2.scala
@@ -42,26 +42,18 @@ object Lib2 {
   }
 
   def builtin1(decompiled: Term, n: Name, f: NumericUnaryOp): Lambda = {
-    val body = new Computation(null) {
-      def apply(r: R, rec: Lambda, top: StackPtr,
-                stackU: Array[U], x1: U, x0: U,
-                stackB: Array[B], x1b: B, x0b: B): U = {
-        r.boxed = null
-        f(x0)
-      }
+    val body: Computation = (r,rec,top,stackU,x1,x0,stackB,x1b,x0b) => {
+      r.boxed = null
+      f(x0)
     }
     val ns = List(n)
     new Lambda(1, body, decompiled) { def names = ns }
   }
 
   def builtin2(decompiled: Term, ns: List[Name], f: NumericBinOp): Lambda = {
-    val body = new Computation(null) {
-      def apply(r: R, rec: Lambda, top: StackPtr,
-                stackU: Array[U], x1: U, x0: U,
-                stackB: Array[B], x1b: B, x0b: B): U = {
-        r.boxed = null
-        f(x1, x0)
-      }
+    val body: Computation = (r,rec,top,stackU,x1,x0,stackB,x1b,x0b) => {
+      r.boxed = null
+      f(x1, x0)
     }
 
     new Lambda(2, body, decompiled) { self =>
@@ -72,14 +64,11 @@ object Lib2 {
           case List((_,term)) => term match {
             case Term.Compiled2(p: Param) =>
               val n = p.toValue.asInstanceOf[Value.Num].n
-              new Lambda(1, new Computation(null) {
-                def apply(r: R, rec: Lambda, top: StackPtr,
-                          stackU: Array[U], x1: U, x0: U,
-                          stackB: Array[B], x1b: B, x0b: B): U = {
-                  r.boxed = null
-                  f(n, x0)
-                }
-              }, Term.Apply(decompiled, term)) {
+              val body: Computation = (r,rec,top,stackU,x1,x0,stackB,x1b,x0b) => {
+                r.boxed = null
+                f(n, x0)
+              }
+              new Lambda(1, body, Term.Apply(decompiled, term)) {
                 def names = self.names drop argCount
               }
             case _ => sys.error("")

--- a/runtime-jvm/main/src/main/scala/Lib2.scala
+++ b/runtime-jvm/main/src/main/scala/Lib2.scala
@@ -58,6 +58,13 @@ object Lib2 {
 
     new Lambda(2, body, decompiled) { self =>
       def names = ns
+      override def saturatedCall(args: List[Computation], isTail: IsTail) = args match {
+        case List(arg1,arg2) => (r,rec,top,stackU,x1,x0,stackB,x1b,x0b) => {
+          val x1v = eval(arg1,r,rec,top,stackU,x1,x0,stackB,x1b,x0b)
+          val x0v = eval(arg2,r,rec,top,stackU,x1,x0,stackB,x1b,x0b)
+          f(x1v, x0v)
+        }
+      }
       override def underapply(builtins: Name => Computation)
                              (argCount: Int, substs: Map[Name, Term]): Lambda =
         substs.toList match {

--- a/runtime-jvm/main/src/main/scala/Lib2.scala
+++ b/runtime-jvm/main/src/main/scala/Lib2.scala
@@ -59,6 +59,10 @@ object Lib2 {
     new Lambda(2, body, decompiled) { self =>
       def names = ns
       override def saturatedNonTailCall(args: List[Computation]) = args match {
+        case List(Return(Value.Num(n1)), Return(Value.Num(n2))) => (r,rec,top,stackU,x1,x0,stackB,x1b,x0b) => {
+          r.boxed = null
+          f(n1, n2)
+        }
         case List(CompiledVar0,Return(Value.Num(n))) => (r,rec,top,stackU,x1,x0,stackB,x1b,x0b) => {
           r.boxed = null
           f(x0, n)
@@ -66,6 +70,14 @@ object Lib2 {
         case List(CompiledVar1,Return(Value.Num(n))) => (r,rec,top,stackU,x1,x0,stackB,x1b,x0b) => {
           r.boxed = null
           f(x1, n)
+        }
+        case List(Return(Value.Num(n)), CompiledVar0) => (r,rec,top,stackU,x1,x0,stackB,x1b,x0b) => {
+          r.boxed = null
+          f(n, x0)
+        }
+        case List(Return(Value.Num(n)), CompiledVar1) => (r,rec,top,stackU,x1,x0,stackB,x1b,x0b) => {
+          r.boxed = null
+          f(n, x1)
         }
         case List(CompiledVar1,CompiledVar0) => (r,rec,top,stackU,x1,x0,stackB,x1b,x0b) => {
           r.boxed = null

--- a/runtime-jvm/main/src/main/scala/compilation2.scala
+++ b/runtime-jvm/main/src/main/scala/compilation2.scala
@@ -91,6 +91,7 @@ object compilation2 {
 
     abstract class Lambda(final val arity: Int, final private val body: Computation, val decompile: Term) extends Value {
       def names: List[Name]
+      def toComputation = Return(this, decompile)
 
       final def apply(r: R, top: StackPtr, stackU: Array[U], x1: U, x0: U, stackB: Array[B], x1b: B, x0b: B): U =
         body(r, this, top, stackU, x1, x0, stackB, x1b, x0b)

--- a/runtime-jvm/main/src/main/scala/compilation2.scala
+++ b/runtime-jvm/main/src/main/scala/compilation2.scala
@@ -957,10 +957,12 @@ object compilation2 {
       try {
         // We've just caught a tail call - the arguments for the tail call are
         // in `r`. We copy these arguments to the current stack.
-        System.arraycopy(stackU, r.argsStart.toInt, stackU,
-                         top.toInt + 1, r.stackArgsCount)
-        System.arraycopy(stackB, r.argsStart.toInt, stackB,
-                         top.toInt + 1, r.stackArgsCount)
+        if (r.stackArgsCount != 0) {
+          System.arraycopy(stackU, r.argsStart.toInt, stackU,
+                           top.toInt + 1, r.stackArgsCount)
+          System.arraycopy(stackB, r.argsStart.toInt, stackB,
+                           top.toInt + 1, r.stackArgsCount)
+        }
         // ... and then null out the rest of the stack past the last argument
         // (todo: this is correct but maybe excessive - could be lazier or more
         //  targeted about nulling out the stack)

--- a/runtime-jvm/main/src/main/scala/compilation2.scala
+++ b/runtime-jvm/main/src/main/scala/compilation2.scala
@@ -927,7 +927,10 @@ object compilation2 {
 
   /** Returns `true` if a fully saturated call of `fn` should be compiled as a tail call. */
   def needsTailCall(fn: Term): Boolean = fn match {
-    case Term.Var(_) => true
+    // recursive calls must always go through a `Var` or `Self`, and recursive calls are the
+    // only calls required to be emitted as tail calls to ensure stack safety
+    // (you can create cycles via higher order functions, but these will still go through `Var`)
+    case Term.Var(_) | Term.Self(_) => true
     case _ => false
   }
 

--- a/runtime-jvm/main/src/main/scala/compilation2.scala
+++ b/runtime-jvm/main/src/main/scala/compilation2.scala
@@ -787,7 +787,7 @@ object compilation2 {
               // static tail call, fully saturated
               //   (x -> x+4) 42
               //   ^^^^^^^^^^^^^
-              if (isTail)
+              if (isTail && needsTailCall(fn))
                 compileStaticFullySaturatedTailCall(e, lam, compiledArgs)
 
               // static non-tail call, fully saturated
@@ -922,6 +922,12 @@ object compilation2 {
             }
         }
     }
+  }
+
+  /** Returns `true` if a fully saturated call of `fn` should be compiled as a tail call. */
+  def needsTailCall(fn: Term): Boolean = fn match {
+    case Term.Var(_) => true
+    case _ => false
   }
 
   def hasTailRecursiveCall(rec: CurrentRec, term: Term): Boolean =

--- a/runtime-jvm/main/src/test/scala/CompilationTests.scala
+++ b/runtime-jvm/main/src/test/scala/CompilationTests.scala
@@ -137,10 +137,9 @@ object Terms {
   val triangle =
     LetRec('triangle ->
              Lam('n, 'acc)(
-               If(
-                 'n.v unisonEquals zero,
-                 'acc.v,
-                 'triangle.v('n.v - 1, 'acc.v + 'n)))
+               If('n.v,
+                  'triangle.v('n.v - 1, 'acc.v + 'n),
+                  'acc.v))
     )('triangle)
 
   val odd =


### PR DESCRIPTION
This incorporates #170 

I did a bunch of tweaks to make performance more competitive with Scala. Results below. 

Summary:

* Tail calls are expensive (they end up as dynamic calls), so we avoid doing them willy nilly unless it is important for stack safety. Turns out there is an easy way to test for this - a tail call to a function which is a `Var` is the only way to create a cycle.
* Aside, for later - we may want to have some syntax to allow the user to annotate a call site as "mandatory" tail call, and have the compiler generate an error if it can't do so.
* The other big improvement came from allowing builtin functions in `Lib2` to control how fully saturated calls take place. So `+` can override how it works when fully applied to two `Computation`s, and can even specialize for the case when one or both of those `Computation`s are just variable lookup. This avoids going through the `eval` stuff for expressions like `n - 1` - if `n` is in a register, and `1` is just a constant, we can just immediately return `x0 - 1`, say.
* Also, JVM flags matter. I've checked in some flags that seem to work pretty well. I have noticed some runs where `unison-triangle` benchmark does miserably, but typical run is within 25x of Scala. In some ways this test is a worst case because it's just measuring loop overhead - the body of the loop is adding two numbers.

```
> benchmark/run
[warn] Multiple main classes detected.  Run 'show discoveredMainClasses' to see the list

Multiple main classes detected, select one to run:

 [1] org.unisonweb.benchmark.Compilation2Benchmarks
 [2] org.unisonweb.benchmark.NonTailRecBenchmarks
 [3] org.unisonweb.benchmark.SequenceBenchmark

Enter number: 1

[info] Running org.unisonweb.benchmark.Compilation2Benchmarks
[info]
[info]  * scala-triangle: 1000.0 milliseconds, N=19, deviation=Infinity%, target deviation: 5.0%
[info]  * scala-triangle: 23.832 microseconds, N=4180, deviation=151.0%, target deviation: 5.0%
[info]  - scala-triangle:  3.089 microseconds (4.3% deviation, N=4180, K = 209)
[info]
[info]  * unison-triangle: 1000.0 milliseconds, N=19, deviation=Infinity%, target deviation: 5.0%
[info]  * unison-triangle: 572.417 microseconds, N=171, deviation=204.6%, target deviation: 5.0%
[info]  * unison-triangle: 71.441 microseconds, N=1368, deviation=9.7%, target deviation: 5.0%
[info]  - unison-triangle:  71.69 microseconds (1.5% deviation, N=1368, K = 779)
[info] 1.0             scala-triangle
[info] 23.2            unison-triangle
[info]
[info]  * scala-fib: 1000.0 milliseconds, N=19, deviation=Infinity%, target deviation: 5.0%
[info]  * scala-fib: 44.378 microseconds, N=2242, deviation=27.1%, target deviation: 5.0%
[info]  - scala-fib:  40.078 microseconds (1.7% deviation, N=2242, K = 247)
[info]
[info]  * unison-fib: 1000.0 milliseconds, N=19, deviation=Infinity%, target deviation: 5.0%
[info]  * unison-fib: 1.083 milliseconds, N=76, deviation=65.1%, target deviation: 5.0%
[info]  * unison-fib: 325.267 microseconds, N=304, deviation=41.0%, target deviation: 5.0%
[info]  - unison-fib:  282.231 microseconds (2.1% deviation, N=304, K = 436)
[info] 1.0             scala-fib
[info] 7.04            unison-fib
[info]
[info]  * scala-fibPrime: 1000.0 milliseconds, N=19, deviation=Infinity%, target deviation: 5.0%
[info]  * scala-fibPrime: 36.562 microseconds, N=2717, deviation=54.6%, target deviation: 5.0%
[info]  - scala-fibPrime:  29.141 microseconds (3.5% deviation, N=2717, K = 299)
[info]
[info]  * unison-fibPrime: 1000.0 milliseconds, N=19, deviation=Infinity%, target deviation: 5.0%
[info]  * unison-fibPrime: 5.919 milliseconds, N=22, deviation=57.7%, target deviation: 5.0%
[info]  - unison-fibPrime:  4.813 milliseconds (2.8% deviation, N=22, K = 448)
[info] 1.0             scala-fibPrime
[info] 165.17          unison-fibPrime
[success] Total time: 10 s, completed Apr 1, 2018, 12:11:31 PM
```