### PR TITLE
Fast, fused, unboxed stream type

### DIFF
--- a/runtime-jvm/benchmark/src/main/scala/Compilation2Benchmarks.scala
+++ b/runtime-jvm/benchmark/src/main/scala/Compilation2Benchmarks.scala
@@ -3,6 +3,9 @@ package org.unisonweb.benchmark
 import org.unisonweb._
 import compilation2._
 import Term.Term
+import org.unisonweb.ABT.Name
+import org.unisonweb.compilation2.Value.Lambda
+import org.unisonweb.util.{Stream, Unboxed}
 
 object Compilation2Benchmarks {
 
@@ -39,8 +42,15 @@ object Compilation2Benchmarks {
         }
       },
       {
+        val plusU = UnisonToScala.toUnboxed2 {
+          Lib2.builtins(Name("+")) match { case Return(lam: Lambda) => lam }
+        }.asInstanceOf[Unboxed.F2[UnisonToScala.Env,Param,Param,Param]]
+
+        val env = (new Array[U](20), new Array[B](20), new StackPtr(0), Result())
         profile("stream-triangle-unisonfold") {
-          util.Stream.from(N(0)).take(N(triangleCount)).sum(()).toLong
+          Stream.from(0.0).take(N(triangleCount))
+            .asInstanceOf[Stream[UnisonToScala.Env,Param]]
+            .foldLeft(env, U0, null:Param)(plusU)((u,_) => u).toLong
         }
       }
     )

--- a/runtime-jvm/benchmark/src/main/scala/Compilation2Benchmarks.scala
+++ b/runtime-jvm/benchmark/src/main/scala/Compilation2Benchmarks.scala
@@ -21,7 +21,7 @@ object Compilation2Benchmarks {
   def runTerm(t: Term): Value.Lambda =
     run(compileTop(Lib2.builtins)(t)).asInstanceOf[Value.Lambda]
 
-  val triangleCount = 10000
+  val triangleCount = 100000
 
   def main(args: Array[String]): Unit = {
     suite(
@@ -39,6 +39,12 @@ object Compilation2Benchmarks {
       {
         profile("stream-triangle") {
           util.Stream.from(N(0)).take(N(triangleCount)).sum(()).toLong
+        }
+      },
+      {
+        profile("stream-triangle-fold-left") {
+          util.Stream.from(N(0)).take(N(triangleCount))
+            .foldLeft((), 0, null)(_ => _ => (u,_,u2,_) => u + u2)((u,_) => u).toLong
         }
       },
       {

--- a/runtime-jvm/benchmark/src/main/scala/Compilation2Benchmarks.scala
+++ b/runtime-jvm/benchmark/src/main/scala/Compilation2Benchmarks.scala
@@ -38,25 +38,25 @@ object Compilation2Benchmarks {
       },
       {
         profile("stream-triangle") {
-          util.Stream.from(N(0)).take(N(triangleCount)).sum(()).toLong
+          util.Stream.from(N(0)).take(N(triangleCount)).sum.toLong
         }
       },
       {
         profile("stream-triangle-fold-left") {
-          util.Stream.from(N(0)).take(N(triangleCount))
-            .foldLeft((), 0, null)(_ => _ => (u,_,u2,_) => u + u2)((u,_) => u).toLong
+          Stream.from(N(0)).take(N(triangleCount))
+            .foldLeft(0, null: Unboxed.Unboxed[U])(Unboxed.F2.UU_U(_ + _))((u,_) => u).toLong
         }
       },
       {
         val plusU = UnisonToScala.toUnboxed2 {
           Lib2.builtins(Name("+")) match { case Return(lam: Lambda) => lam }
-        }.asInstanceOf[Unboxed.F2[UnisonToScala.Env,Param,Param,Param]]
+        }
 
         val env = (new Array[U](20), new Array[B](20), new StackPtr(0), Result())
         profile("stream-triangle-unisonfold") {
           Stream.from(0.0).take(N(triangleCount))
-            .asInstanceOf[Stream[UnisonToScala.Env,Param]]
-            .foldLeft(env, U0, null:Param)(plusU)((u,_) => u).toLong
+            .asInstanceOf[Stream[Param]]
+            .foldLeft(U0, null:Param)(plusU(env))((u,_) => u).toLong
         }
       }
     )

--- a/runtime-jvm/benchmark/src/main/scala/Compilation2Benchmarks.scala
+++ b/runtime-jvm/benchmark/src/main/scala/Compilation2Benchmarks.scala
@@ -30,6 +30,9 @@ object Compilation2Benchmarks {
           if (n == 0) acc else triangle(n - 1, acc + n)
         triangle(N(triangleCount), N(0))
       },
+      { val s = scala.Stream.range(0, N(triangleCount))
+        profile("scala-stream-triangle") { s.foldLeft(N(0))(_ + _).toLong }
+      },
       {
         val p = runTerm(Terms.triangle)
         profile("unison-triangle") {

--- a/runtime-jvm/benchmark/src/main/scala/Compilation2Benchmarks.scala
+++ b/runtime-jvm/benchmark/src/main/scala/Compilation2Benchmarks.scala
@@ -18,17 +18,29 @@ object Compilation2Benchmarks {
   def runTerm(t: Term): Value.Lambda =
     run(compileTop(Lib2.builtins)(t)).asInstanceOf[Value.Lambda]
 
+  val triangleCount = 10000
+
   def main(args: Array[String]): Unit = {
     suite(
       profile("scala-triangle") {
         def triangle(n: Int, acc: Int): Int =
           if (n == 0) acc else triangle(n - 1, acc + n)
-        triangle(N(10000), N(0))
+        triangle(N(triangleCount), N(0))
       },
       {
         val p = runTerm(Terms.triangle)
         profile("unison-triangle") {
-          evalLam(p, r, top, stackU, N(10000), N(0), stackB, null, null).toLong
+          evalLam(p, r, top, stackU, N(triangleCount), N(0), stackB, null, null).toLong
+        }
+      },
+      {
+        profile("stream-triangle") {
+          util.Stream.from(N(0)).take(N(triangleCount)).sum(()).toLong
+        }
+      },
+      {
+        profile("stream-triangle-unisonfold") {
+          util.Stream.from(N(0)).take(N(triangleCount)).sum(()).toLong
         }
       }
     )

--- a/runtime-jvm/main/src/main/scala/Lib2.scala
+++ b/runtime-jvm/main/src/main/scala/Lib2.scala
@@ -103,28 +103,3 @@ object Lib2 {
   }
 }
 
-object UnisonFnToScala {
-
-  import org.unisonweb.util.{Unboxed1,Unboxed2}
-  type Env = (Array[U], Array[B], StackPtr, Result)
-
-  def toUnboxed1(f: Value.Lambda): Unboxed1[Env,Param,Value] =
-    env => set => {
-      val (stackU, stackB, top, r) = env
-      (u,a) => {
-        val out = evalLam(f, r, top, stackU, U0, u, stackB, null, a)
-        set(r.boxed)
-        out
-      }
-    }
-
-  def toUnboxed2(f: Value.Lambda): Unboxed2[Env,Param,Param,Value] =
-    env => set => {
-      val (stackU, stackB, top, r) = env
-      (u1,a,u2,b) => {
-        val out = evalLam(f, r, top, stackU, u1, u2, stackB, a, b)
-        set(r.boxed)
-        out
-      }
-    }
-}

--- a/runtime-jvm/main/src/main/scala/Lib2.scala
+++ b/runtime-jvm/main/src/main/scala/Lib2.scala
@@ -102,3 +102,29 @@ object Lib2 {
     }
   }
 }
+
+object UnisonFnToScala {
+
+  import org.unisonweb.util.{Unboxed1,Unboxed2}
+  type Env = (Array[U], Array[B], StackPtr, Result)
+
+  def toUnboxed1(f: Value.Lambda): Unboxed1[Env,Param,Value] =
+    env => set => {
+      val (stackU, stackB, top, r) = env
+      (u,a) => {
+        val out = evalLam(f, r, top, stackU, U0, u, stackB, null, a)
+        set(r.boxed)
+        out
+      }
+    }
+
+  def toUnboxed2(f: Value.Lambda): Unboxed2[Env,Param,Param,Value] =
+    env => set => {
+      val (stackU, stackB, top, r) = env
+      (u1,a,u2,b) => {
+        val out = evalLam(f, r, top, stackU, u1, u2, stackB, a, b)
+        set(r.boxed)
+        out
+      }
+    }
+}

--- a/runtime-jvm/main/src/main/scala/UnisonToScala.scala
+++ b/runtime-jvm/main/src/main/scala/UnisonToScala.scala
@@ -7,31 +7,37 @@ object UnisonToScala {
 
   type Env = (Array[U], Array[B], StackPtr, Result)
 
-  def toUnboxed1(f: Value.Lambda): Unboxed.F1[Env,Param,Value] = {
+  def toUnboxed1(f: Value.Lambda): Env => Unboxed.F1[Param,Value] = {
     require (f.arity == 1)
-    env => set => {
+    env => {
       val (stackU, stackB, top, r) = env
       f.body match {
-        case body: Computation.C1U => (u1,a) => body(r,u1)
-        case body => (u,a) => {
-          val out = evalLam(f, r, top, stackU, U0, u, stackB, null, a)
-          set(r.boxed)
-          out
+        case body: Computation.C1U => new Unboxed.F1[Param,Value] {
+          def apply[x] = kvx => (u1,a,u2,x) => kvx(body(r,u1), null, u2, x)
+        }
+        case body => new Unboxed.F1[Param,Value] {
+          def apply[x] = kvx => (u1,a,u2,x) => {
+            val out = evalLam(f, r, top, stackU, U0, u1, stackB, null, a)
+            kvx(out, r.boxed, u2, x)
+          }
         }
       }
     }
   }
 
-  def toUnboxed2(f: Value.Lambda): Unboxed.F2[Env,Param,Param,Value] = {
+  def toUnboxed2(f: Value.Lambda): Env => Unboxed.F2[Param,Param,Value] = {
     require (f.arity == 2)
-    env => set => {
+    env => {
       val (stackU, stackB, top, r) = env
       f.body match {
-        case body : Computation.C2U => (u1,a,u2,b) => body(r,u1,u2)
-        case body => (u1,a,u2,b) => {
-          val out = evalLam(f, r, top, stackU, u1, u2, stackB, a, b)
-          set(r.boxed)
-          out
+        case body : Computation.C2U => new Unboxed.F2[Param,Param,Value] {
+          def apply[x] = kvx => (u1,a,u2,b,u3,x) => kvx(body(r,u1,u2), null, u3, x)
+        }
+        case body => new Unboxed.F2[Param,Param,Value] {
+          def apply[x] = kvx => (u1,a,u2,b,u3,x) => {
+            val out = evalLam(f, r, top, stackU, u1, u2, stackB, a, b)
+            kvx(out, r.boxed, u3, x)
+          }
         }
       }
     }

--- a/runtime-jvm/main/src/main/scala/UnisonToScala.scala
+++ b/runtime-jvm/main/src/main/scala/UnisonToScala.scala
@@ -1,0 +1,29 @@
+package org.unisonweb
+
+object UnisonToScala {
+
+  import org.unisonweb.util.Unboxed
+  import compilation2._
+
+  type Env = (Array[U], Array[B], StackPtr, Result)
+
+  def toUnboxed1(f: Value.Lambda): Unboxed.F1[Env,Param,Value] =
+    env => set => {
+      val (stackU, stackB, top, r) = env
+      (u,a) => {
+        val out = evalLam(f, r, top, stackU, U0, u, stackB, null, a)
+        set(r.boxed)
+        out
+      }
+    }
+
+  def toUnboxed2(f: Value.Lambda): Unboxed.F2[Env,Param,Param,Value] =
+    env => set => {
+      val (stackU, stackB, top, r) = env
+      (u1,a,u2,b) => {
+        val out = evalLam(f, r, top, stackU, u1, u2, stackB, a, b)
+        set(r.boxed)
+        out
+      }
+    }
+}

--- a/runtime-jvm/main/src/main/scala/UnisonToScala.scala
+++ b/runtime-jvm/main/src/main/scala/UnisonToScala.scala
@@ -7,23 +7,33 @@ object UnisonToScala {
 
   type Env = (Array[U], Array[B], StackPtr, Result)
 
-  def toUnboxed1(f: Value.Lambda): Unboxed.F1[Env,Param,Value] =
+  def toUnboxed1(f: Value.Lambda): Unboxed.F1[Env,Param,Value] = {
+    require (f.arity == 1)
     env => set => {
       val (stackU, stackB, top, r) = env
-      (u,a) => {
-        val out = evalLam(f, r, top, stackU, U0, u, stackB, null, a)
-        set(r.boxed)
-        out
+      f.body match {
+        case body: Computation.C1U => (u1,a) => body(r,u1)
+        case body => (u,a) => {
+          val out = evalLam(f, r, top, stackU, U0, u, stackB, null, a)
+          set(r.boxed)
+          out
+        }
       }
     }
+  }
 
-  def toUnboxed2(f: Value.Lambda): Unboxed.F2[Env,Param,Param,Value] =
+  def toUnboxed2(f: Value.Lambda): Unboxed.F2[Env,Param,Param,Value] = {
+    require (f.arity == 2)
     env => set => {
       val (stackU, stackB, top, r) = env
-      (u1,a,u2,b) => {
-        val out = evalLam(f, r, top, stackU, u1, u2, stackB, a, b)
-        set(r.boxed)
-        out
+      f.body match {
+        case body : Computation.C2U => (u1,a,u2,b) => body(r,u1,u2)
+        case body => (u1,a,u2,b) => {
+          val out = evalLam(f, r, top, stackU, u1, u2, stackB, a, b)
+          set(r.boxed)
+          out
+        }
       }
     }
+  }
 }

--- a/runtime-jvm/main/src/main/scala/compilation2.scala
+++ b/runtime-jvm/main/src/main/scala/compilation2.scala
@@ -89,7 +89,7 @@ object compilation2 {
       def toResult(r: Result) = n
     }
 
-    abstract class Lambda(final val arity: Int, final private val body: Computation, val decompile: Term) extends Value {
+    abstract class Lambda(final val arity: Int, final val body: Computation, val decompile: Term) extends Value {
       def names: List[Name]
       def toComputation = Return(this, decompile)
 
@@ -153,6 +153,26 @@ object compilation2 {
   abstract class Computation {
     def apply(r: R, rec: Lambda, top: StackPtr, stackU: Array[U], x1: U, x0: U, stackB: Array[B], x1b: B, x0b: B): U
   }
+
+  object Computation {
+    // Special cases for computations that take unboxed arguments and produce unboxed results,
+    // and which are guaranteed not to throw tail call exceptions during evaluation. We check for
+    // these in various places to emit more efficient code for common cases.
+    abstract class C2U extends Computation {
+      def apply(r: R, x1: U, x0: U): U
+      final def apply(r: R, rec: Lambda, top: StackPtr, stackU: Array[U], x1: U, x0: U, stackB: Array[B], x1b: B, x0b: B): U =
+        apply(r, x1, x0)
+    }
+    abstract class C1U extends C2U {
+      def apply(r: R, x0: U): U
+      final def apply(r: R, x1: U, x0: U): U = apply(r, x0)
+    }
+    abstract class C0U extends C1U {
+      def apply(r: R): U
+      final def apply(r: R, x0: U): U = apply(r)
+    }
+  }
+
 
   /** Put `v` into `r.boxed` */
   @inline private def returnBoxed(r: R, v: Value): U = { r.boxed = v; U0 }

--- a/runtime-jvm/main/src/main/scala/util/Stream.scala
+++ b/runtime-jvm/main/src/main/scala/util/Stream.scala
@@ -2,32 +2,7 @@ package org.unisonweb
 package util
 
 import Stream._
-import compilation2.{Ref => _, _}
-// import Env.Env
-
-object Env {
-  type Env = (Array[U], Array[B], StackPtr, Result)
-}
-
-abstract class Unboxed1[-Env,A,B] {
-  def stage(e: Env): (B => Unit) => Unboxed1.Compiled[A,B]
-}
-
-object Unboxed1 {
-  def fromLambda(f: Value.Lambda): Unboxed1[Env.Env,Any,Any] =
-    env => set => {
-      val (stackU, stackB, top, r) = env
-      (u,a) => {
-        val out = evalLam(f, r, top, stackU, U0, u, stackB, null, a.asInstanceOf[Param])
-        set(r.boxed)
-        out
-      }
-    }
-
-  abstract class Compiled[A,B] {
-    def apply(u: U, a: Ref[A]): U
-  }
-}
+import compilation2.{U,U0}
 
 abstract class Stream[Env,A] { self =>
 
@@ -35,99 +10,92 @@ abstract class Stream[Env,A] { self =>
 
   def covaryEnv[E2<:Env]: Stream[E2,A] = this.asInstanceOf[Stream[E2,A]]
 
-  final def map(f: Unboxed1[Env,A,B]): Stream[Env,B] =
+  final def map[B](f: Unboxed1[Env,A,B]): Stream[Env,B] =
     env => k => {
-      var b : Ref[B] = null
-      val ufn = f.stage(env) (br => b = Ref(br))
-      self.stage(env) { (u,a) => k(ufn(u,a), b) }
+      var b : B = null.asInstanceOf[B]
+      val fc = f.stage(env) (br => b = br)
+      self.stage(env) { (u,a) => k(fc(u,a), b) }
     }
 
-  //final def filter(f: Predicate[A]): Stream[A] =
-  //  k => self stage { (u,a) => if (f(u,a)) k(u,a) }
+  /** Only emit elements from `this` for which `f` returns a nonzero value. */
+  final def filter(f: Unboxed1[Env,A,U]): Stream[Env,A] =
+    env => k => {
+      val fc = f.stage(env) { br => }
+      self.stage(env) { (u,a) => if (fc(u,a) != U0) k(u,a) }
+    }
 
-  //final def take(n: Long): Stream[A] =
-  //  k => self stage {
-  //    var rem = n
-  //    (u,a) => if (rem > 0) { rem -= 1; k(u,a) }
-  //             else throw Done
-  //  }
+  /** Emit the longest prefix of `this` for which `f` returns nonzero. */
+  final def takeWhile(f: Unboxed1[Env,A,U]): Stream[Env,A] =
+    env => k => self.stage(env) {
+      val fc = f.stage(env) { br => }
+      (u,a) => if (fc(u,a) != U0) k(u,a)
+               else throw Done
+    }
 
-  //final def drop(n: Long): Stream[A] =
-  //  k => self stage {
-  //    var rem = n
-  //    (u,a) => if (rem > 0) rem -= 1
-  //             else k(u,a)
-  //  }
+  /** Skip the longest prefix of `this` for which `f` returns nonzero. */
+  final def dropWhile(f: Unboxed1[Env,A,U]): Stream[Env,A] =
+    env => k => self.stage(env) {
+      val fc = f.stage(env) { br => }
+      var dropping = true
+      (u,a) => if (!dropping) k(u,a)
+               else if (fc(u,a) == U0) { dropping = false; k(u,a) }
+    }
 
-  //final def takeWhile(f: Predicate[A]): Stream[A] =
-  //  k => self stage { (u,a) =>
-  //    if (f(u,a)) k(u,a)
-  //    else throw Done
-  //  }
 
-  //final def dropWhile(f: Predicate[A]): Stream[A] =
-  //  k => self stage {
-  //    var dropping = true
-  //    (u,a) => if (!dropping) k(u,a)
-  //             else if (!f(u,a)) { dropping = false; k(u,a) }
-  //  }
+  final def take(n: Long): Stream[Env,A] =
+    env => k => self.stage(env) {
+      var rem = n
+      (u,a) => if (rem > 0) { rem -= 1; k(u,a) }
+               else throw Done
+    }
 
-  //final def sum(implicit A: A =:= Long): Long = {
-  //  var total = 0L
-  //  val s = self stage { (u,_) => total += u }
-  //  try { while (true) s() } catch { case Done => }
-  //  total
-  //}
+  final def drop(n: Long): Stream[Env,A] =
+    env => k => self.stage(env) {
+      var rem = n
+      (u,a) => if (rem > 0) rem -= 1
+               else k(u,a)
+    }
 
-  //final def zipWith[B,C](s: Stream[B])(f: F2[A,B,C]): Stream[C] =
-  //  k => {
-  //    var au = 0L; var ab: Ref[A] = null
-  //    val as = self stage { (u,a) => au = u; ab = a }
-  //    val k2 = f(k)
-  //    val bs = s stage { (u,b) => k2(au,ab,u,b) }
-  //    () => { as(); bs() }
-  //  }
+  final def sum(env: Env)(implicit A: A =:= U): U = {
+    var total = U0
+    val s = self.stage(env) { (u,_) => total += u }
+    try { while (true) s() } catch { case Done => }
+    total
+  }
 
-  //final def evens: Stream[A] = {
-  //  k => self stage {
-  //    var ok = true
-  //    (u,a) => { ok = { if (ok) k(u,a); !ok }}
-  //  }
-  //}
+  final def zipWith[B,C](bs: Stream[Env,B])(f: Unboxed2[Env,A,B,C]): Stream[Env,C] =
+    env => k => {
+      var au = U0; var ab: A = null.asInstanceOf[A]; var cb: C = null.asInstanceOf[C]
+      val fc = f.stage(env) { c => cb = c }
+      val left = self.stage(env) { (u,a) => au = u; ab = a }
+      val right = bs.stage(env) { (bu,bb) => k(fc(au,ab,bu,bb), cb) }
+      () => { left(); right(); ab = null.asInstanceOf[A]; cb = null.asInstanceOf[C] }
+    }
 
-  //final def odds: Stream[A] = {
-  //  k => self stage {
-  //    var ok = false
-  //    (u,a) => { ok = { if (ok) k(u,a); !ok }}
-  //  }
-  //}
-
-  //def ++(s: Stream[A]): Stream[A] = k => {
-  //  var done = false
-  //  val cself = self stage k
-  //  val cs = s stage k
-  //  () => {
-  //    if (done) cs()
-  //    else { try cself() catch { case Done => done = true } }
-  //  }
-  //}
+  def ++(s: Stream[Env,A]): Stream[Env,A] = env => k => {
+    var done = false
+    val cself = self.stage(env)(k)
+    val cs = s.stage(env)(k)
+    () => {
+      if (done) cs()
+      else { try cself() catch { case Done => done = true } }
+    }
+  }
 }
 
 object Stream {
 
-  abstract class K[A] { def apply(u: U, b: Ref[A]): Unit }
-  abstract class K2[A,B] { def apply(u1: U, b1: Ref[A], u2: U, b2: Ref[B]): Unit }
+  abstract class K[A] { def apply(u: U, b: A): Unit }
   abstract class Step { def apply(): Unit }
-  case class Ref[B](get: B)
 
   case object Done extends Throwable { override def fillInStackTrace = this }
 
   final def constant(n: U): Stream[Any,U] =
-    _ => k => () => k(n, null)
+    _ => k => () => k(n, null.asInstanceOf[U])
 
   final def from(n: U): Stream[Any,U] =
     _ => k => {
       var i = n - 1
-      () => { i += 1; k(i,null) }
+      () => { i += 1; k(i,null.asInstanceOf[U]) }
     }
 }

--- a/runtime-jvm/main/src/main/scala/util/Stream.scala
+++ b/runtime-jvm/main/src/main/scala/util/Stream.scala
@@ -2,85 +2,88 @@ package org.unisonweb
 package util
 
 import Stream._
-import compilation2.{U}
-import Unboxed.{F1,K}
-// import Unboxed.{F1, F2, K}
+import compilation2.{U,U0}
+import Unboxed.{F1,F2,K,Unboxed}
 
-abstract class Stream[Env,A] { self =>
+abstract class Stream[A] { self =>
 
-  def stage(e: Env): K[A] => Step
+  def stage(callback: K[A]): Step
 
-  def covaryEnv[E2<:Env]: Stream[E2,A] = this.asInstanceOf[Stream[E2,A]]
-
-  final def map[B](f: Env => F1[A,B]): Stream[Env,B] =
-    env => k => self.stage(env)(f(env) contramap k)
+  final def map[B](f: F1[A,B]): Stream[B] =
+    k => self.stage(f andThen k)
 
   /** Only emit elements from `this` for which `f` returns a nonzero value. */
-  final def filter(f: Env => F1[A,U]): Stream[Env,A] =
-    env => k => self.stage(env)(Unboxed.choose(f(env), k, Unboxed.K.noop))
+  final def filter(f: F1[A,U]): Stream[A] =
+    k => self.stage(Unboxed.choose(f, k, Unboxed.K.noop))
 
   /** Emit the longest prefix of `this` for which `f` returns nonzero. */
-  final def takeWhile(f: Env => F1[A,U]): Stream[Env,A] =
-    env => k => self.stage(env)(Unboxed.choose[A](f(env), k, (_,_) => throw Done))
+  final def takeWhile(f: F1[A,U]): Stream[A] =
+    k => self.stage(Unboxed.choose[A](f, k, (_,_) => throw Done))
 
   /** Skip the longest prefix of `this` for which `f` returns nonzero. */
-  final def dropWhile(f: Env => F1[A,U]): Stream[Env,A] =
-    env => k => self.stage(env)(Unboxed.switchWhen(f(env), Unboxed.K.noop, k)())
+  final def dropWhile(f: F1[A,U]): Stream[A] =
+    k => self.stage(Unboxed.switchWhen0(f, Unboxed.K.noop, k)())
 
-  //final def take(n: Long): Stream[Env,A] =
-  //  env => k => self.stage(env) {
-  //    var rem = n
-  //    (u,a) => if (rem > 0) { rem -= 1; k(u,a) }
-  //             else throw Done
-  //  }
+  final def take(n: Long): Stream[A] =
+    k => self.stage {
+      var rem = n
+      (u,a) => if (rem > 0) { rem -= 1; k(u,a) }
+               else throw Done
+    }
 
-  //final def drop(n: Long): Stream[Env,A] =
-  //  env => k => self.stage(env) {
-  //    var rem = n
-  //    (u,a) => if (rem > 0) rem -= 1
-  //             else k(u,a)
-  //  }
+  final def drop(n: Long): Stream[A] =
+    k => self.stage {
+      var rem = n
+      (u,a) => if (rem > 0) rem -= 1
+               else k(u,a)
+    }
 
-  //final def sum(env: Env)(implicit A: A =:= Unboxed[U]): U = {
-  //  var total = U0
-  //  self.stage(env) { (u,_) => total += u }.run()
-  //  total
-  //}
+  final def sum(implicit A: A =:= Unboxed[U]): U = {
+    var total = U0
+    self.stage { (u,_) => total += u }.run()
+    total
+  }
 
-  //final def zipWith[B,C](bs: Stream[Env,B])(f: F2[Env,A,B,C]): Stream[Env,C] =
-  //  env => k => {
-  //    var au = U0; var ab: A = null.asInstanceOf[A]; var cb: C = null.asInstanceOf[C]
-  //    val fc = f.stage(env) { c => cb = c }
-  //    val left = self.stage(env) { (u,a) => au = u; ab = a }
-  //    val right = bs.stage(env) { (bu,bb) => k(fc(au,ab,bu,bb), cb) }
-  //    () => { left(); right(); ab = null.asInstanceOf[A]; cb = null.asInstanceOf[C] }
-  //  }
+  final def zipWith[B,C](bs: Stream[B])(f: F2[A,B,C]): Stream[C] =
+    k => {
+      var au = U0; var ab: A = null.asInstanceOf[A]
+      val fc = f andThen k
+      var askingLeft = true
+      val left = self.stage { (u,a) => au = u; ab = a; askingLeft = false }
+      val right = bs.stage { (bu,bb) => askingLeft = true; fc(au, ab, bu, bb) }
+      () => {
+        if (askingLeft) left()
+        else right()
+      }
+    }
 
-  //def foldLeft[B,C](env: Env, u0: U, b0: B)(f: F2[Env,B,A,B])(extract: (U,B) => C): C = {
-  //  var (u, b) = (U0, b0)
-  //  val cf = f.stage(env) { b2 => b = b2 }
-  //  self.stage(env) { (u2,a) => u = cf(u, b, u2, a) }.run()
-  //  extract(u,b)
-  //}
+  def foldLeft[B,C](u0: U, b0: B)(f: F2[B,A,B])(extract: (U,B) => C): C = {
+    var u = U0; var b = b0
+    val cf = f andThen { (u2,b2) => u = u2; b = b2 }
+    self.stage { (u2,a) => cf(u, b, u2, a) }.run()
+    extract(u,b)
+  }
 
-  //def box[T](f: U => T)(implicit A: A =:= Unboxed[T]): Stream[Env,T] =
-  //  map(env => set => (u,_) => { set(f(u)); U0 })
+  def box[T](f: U => T)(implicit A: A =:= Unboxed[T]): Stream[T] =
+    map(new Unboxed.F1[A,T] {
+      def apply[x] = ktx => (u,_,u2,x) => ktx(U0,f(u),u2,x)
+    })
 
-  //def ++(s: Stream[Env,A]): Stream[Env,A] = env => k => {
-  //  var done = false
-  //  val cself = self.stage(env)(k)
-  //  val cs = s.stage(env)(k)
-  //  () => {
-  //    if (done) cs()
-  //    else { try cself() catch { case Done => done = true } }
-  //  }
-  //}
+  def ++(s: Stream[A]): Stream[A] = k => {
+    var done = false
+    val cself = self.stage(k)
+    val cs = s.stage(k)
+    () => {
+      if (done) cs()
+      else { try cself() catch { case Done => done = true } }
+    }
+  }
 
-  //def toSequence[B](env: Env)(f: (U,A) => B): Sequence[B] = {
-  //  var result = Sequence.empty[B]
-  //  self.stage(env) { (u, a) => result = result :+ f(u,a) }.run()
-  //  result
-  //}
+  def toSequence[B](f: (U,A) => B): Sequence[B] = {
+    var result = Sequence.empty[B]
+    self.stage { (u,a) => result = result :+ f(u,a) }.run()
+    result
+  }
 }
 
 object Stream {
@@ -92,21 +95,14 @@ object Stream {
       try { while (true) apply() } catch { case Done => }
   }
 
-  /**
-   * Marker type with no instances. A `Stream[E,Unboxed[T]]` implies
-   * the stream emits only `null` for the boxed portion of its output and that
-   * there exists a `U => T` for extracting a `T` from the unboxed portion of
-   * its output.
-   */
-  sealed abstract class Unboxed[T]
-
   case object Done extends Throwable { override def fillInStackTrace = this }
+  // idea: case class More(s: Step) extends Throwable { override def fillInStackTrace = this }
 
-  final def constant(n: U): Stream[Any,Unboxed[U]] =
-    _ => k => () => k(n, null)
+  final def constant(n: U): Stream[Unboxed[U]] =
+    k => () => k(n, null)
 
-  final def from(n: U): Stream[Any,Unboxed[U]] =
-    _ => k => {
+  final def from(n: U): Stream[Unboxed[U]] =
+    k => {
       var i = n - 1
       () => { i += 1; k(i,null) }
     }

--- a/runtime-jvm/main/src/main/scala/util/Stream.scala
+++ b/runtime-jvm/main/src/main/scala/util/Stream.scala
@@ -3,6 +3,7 @@ package util
 
 import Stream._
 import compilation2.{U,U0}
+import Unboxed.{F1,F2}
 
 abstract class Stream[Env,A] { self =>
 
@@ -10,7 +11,7 @@ abstract class Stream[Env,A] { self =>
 
   def covaryEnv[E2<:Env]: Stream[E2,A] = this.asInstanceOf[Stream[E2,A]]
 
-  final def map[B](f: Unboxed1[Env,A,B]): Stream[Env,B] =
+  final def map[B](f: F1[Env,A,B]): Stream[Env,B] =
     env => k => {
       var b : B = null.asInstanceOf[B]
       val fc = f.stage(env) (br => b = br)
@@ -18,14 +19,14 @@ abstract class Stream[Env,A] { self =>
     }
 
   /** Only emit elements from `this` for which `f` returns a nonzero value. */
-  final def filter(f: Unboxed1[Env,A,U]): Stream[Env,A] =
+  final def filter(f: F1[Env,A,U]): Stream[Env,A] =
     env => k => {
       val fc = f.stage(env) { br => }
       self.stage(env) { (u,a) => if (fc(u,a) != U0) k(u,a) }
     }
 
   /** Emit the longest prefix of `this` for which `f` returns nonzero. */
-  final def takeWhile(f: Unboxed1[Env,A,U]): Stream[Env,A] =
+  final def takeWhile(f: F1[Env,A,U]): Stream[Env,A] =
     env => k => self.stage(env) {
       val fc = f.stage(env) { br => }
       (u,a) => if (fc(u,a) != U0) k(u,a)
@@ -33,7 +34,7 @@ abstract class Stream[Env,A] { self =>
     }
 
   /** Skip the longest prefix of `this` for which `f` returns nonzero. */
-  final def dropWhile(f: Unboxed1[Env,A,U]): Stream[Env,A] =
+  final def dropWhile(f: F1[Env,A,U]): Stream[Env,A] =
     env => k => self.stage(env) {
       val fc = f.stage(env) { br => }
       var dropping = true
@@ -63,7 +64,7 @@ abstract class Stream[Env,A] { self =>
     total
   }
 
-  final def zipWith[B,C](bs: Stream[Env,B])(f: Unboxed2[Env,A,B,C]): Stream[Env,C] =
+  final def zipWith[B,C](bs: Stream[Env,B])(f: F2[Env,A,B,C]): Stream[Env,C] =
     env => k => {
       var au = U0; var ab: A = null.asInstanceOf[A]; var cb: C = null.asInstanceOf[C]
       val fc = f.stage(env) { c => cb = c }

--- a/runtime-jvm/main/src/main/scala/util/Stream.scala
+++ b/runtime-jvm/main/src/main/scala/util/Stream.scala
@@ -3,7 +3,7 @@ package util
 
 import Stream._
 import compilation2.{U, U0}
-import Unboxed.{F1, F2, Unboxed}
+import Unboxed.{F1, F2}
 
 abstract class Stream[Env,A] { self =>
 
@@ -108,6 +108,14 @@ object Stream {
     @inline final def run(): Unit =
       try { while (true) apply() } catch { case Done => }
   }
+
+  /**
+   * Marker type with no instances. A `Stream[E,Unboxed[T]]` implies
+   * the stream emits only `null` for the boxed portion of its output and that
+   * there exists a `U => T` for extracting a `T` from the unboxed portion of
+   * its output.
+   */
+  sealed abstract class Unboxed[T]
 
   case object Done extends Throwable { override def fillInStackTrace = this }
 

--- a/runtime-jvm/main/src/main/scala/util/Stream.scala
+++ b/runtime-jvm/main/src/main/scala/util/Stream.scala
@@ -1,0 +1,63 @@
+package org.unisonweb.util
+
+import Stream._
+
+abstract class Stream[A] { self =>
+  def stage(k: K[A]): Step
+
+  final def map[B](f: F[A,B]): Stream[B] =
+    k => self.stage(f(k))
+
+  final def filter(f: Predicate[A]): Stream[A] =
+    k => self stage { (u,a) => if (f(u,a)) k(u,a) }
+
+  final def take(n: Long): Stream[A] =
+    k => self stage {
+      var rem = n
+      (u,a) => if (rem > 0) { rem -= 1; k(u,a) }
+               else throw Done
+    }
+
+  final def drop(n: Long): Stream[A] =
+    k => self stage {
+      var rem = n
+      (u,a) => if (rem > 0) rem -= 1
+               else k(u,a)
+    }
+
+  final def takeWhile(f: Predicate[A]): Stream[A] =
+    k => self stage { (u,a) =>
+      if (f(u,a)) k(u,a)
+      else throw Done
+    }
+
+  final def dropWhile(f: Predicate[A]): Stream[A] =
+    k => self stage {
+      var dropping = true
+      (u,a) => if (!dropping) k(u,a)
+               else if (!f(u,a)) { dropping = false; k(u,a) }
+    }
+
+  final def sum(implicit A: A =:= Long): Long = {
+    var total = 0L
+    val s = self stage { (u,_) => total += u }
+    try { while (true) s() } catch { case Done => }
+    total
+  }
+}
+
+object Stream {
+  abstract class Predicate[A] { def apply(u: Long, a: Ref[A]): Boolean }
+  abstract class F[A,B] { def apply(k: K[B]): K[A] }
+  abstract class K[A] { def apply(u: Long, b: Ref[A]): Unit }
+  abstract class Step { def apply(): Unit }
+  case class Ref[A](get: A)
+
+  case object Done extends Throwable { override def fillInStackTrace = this }
+
+  final def from(n: Long): Stream[Long] =
+    k => {
+      var i = n - 1
+      () => { i += 1; k(i,null) }
+    }
+}

--- a/runtime-jvm/main/src/main/scala/util/Stream.scala
+++ b/runtime-jvm/main/src/main/scala/util/Stream.scala
@@ -1,105 +1,132 @@
-package org.unisonweb.util
+package org.unisonweb
+package util
 
 import Stream._
+import compilation2.{Ref => _, _}
+// import Env.Env
 
-abstract class Stream[A] { self =>
-  def stage(k: K[A]): Step
+object Env {
+  type Env = (Array[U], Array[B], StackPtr, Result)
+}
 
-  final def map[B](f: F[A,B]): Stream[B] =
-    k => self.stage(f(k))
+abstract class Unboxed1[-Env,A,B] {
+  def stage(e: Env): (B => Unit) => Unboxed1.Compiled[A,B]
+}
 
-  final def filter(f: Predicate[A]): Stream[A] =
-    k => self stage { (u,a) => if (f(u,a)) k(u,a) }
-
-  final def take(n: Long): Stream[A] =
-    k => self stage {
-      var rem = n
-      (u,a) => if (rem > 0) { rem -= 1; k(u,a) }
-               else throw Done
+object Unboxed1 {
+  def fromLambda(f: Value.Lambda): Unboxed1[Env.Env,Any,Any] =
+    env => set => {
+      val (stackU, stackB, top, r) = env
+      (u,a) => {
+        val out = evalLam(f, r, top, stackU, U0, u, stackB, null, a.asInstanceOf[Param])
+        set(r.boxed)
+        out
+      }
     }
 
-  final def drop(n: Long): Stream[A] =
-    k => self stage {
-      var rem = n
-      (u,a) => if (rem > 0) rem -= 1
-               else k(u,a)
-    }
-
-  final def takeWhile(f: Predicate[A]): Stream[A] =
-    k => self stage { (u,a) =>
-      if (f(u,a)) k(u,a)
-      else throw Done
-    }
-
-  final def dropWhile(f: Predicate[A]): Stream[A] =
-    k => self stage {
-      var dropping = true
-      (u,a) => if (!dropping) k(u,a)
-               else if (!f(u,a)) { dropping = false; k(u,a) }
-    }
-
-  final def sum(implicit A: A =:= Long): Long = {
-    var total = 0L
-    val s = self stage { (u,_) => total += u }
-    try { while (true) s() } catch { case Done => }
-    total
-  }
-
-  final def zipWith[B,C](s: Stream[B])(f: F2[A,B,C]): Stream[C] =
-    k => {
-      var au = 0L; var ab: Ref[A] = null
-      val as = self stage { (u,a) => au = u; ab = a }
-      val k2 = f(k)
-      val bs = s stage { (u,b) => k2(au,ab,u,b) }
-      () => { as(); bs() }
-    }
-
-  final def evens: Stream[A] = {
-    k => self stage {
-      var ok = true
-      (u,a) => { ok = { if (ok) k(u,a); !ok }}
-    }
-  }
-
-  final def odds: Stream[A] = {
-    k => self stage {
-      var ok = false
-      (u,a) => { ok = { if (ok) k(u,a); !ok }}
-    }
-  }
-
-  def ++(s: Stream[A]): Stream[A] = k => {
-    var done = false
-    val cself = self stage k
-    val cs = s stage k
-    () => {
-      if (done) cs()
-      else { try cself() catch { case Done => done = true } }
-    }
+  abstract class Compiled[A,B] {
+    def apply(u: U, a: Ref[A]): U
   }
 }
 
+abstract class Stream[Env,A] { self =>
+
+  def stage(e: Env): K[A] => Step
+
+  def covaryEnv[E2<:Env]: Stream[E2,A] = this.asInstanceOf[Stream[E2,A]]
+
+  final def map(f: Unboxed1[Env,A,B]): Stream[Env,B] =
+    env => k => {
+      var b : Ref[B] = null
+      val ufn = f.stage(env) (br => b = Ref(br))
+      self.stage(env) { (u,a) => k(ufn(u,a), b) }
+    }
+
+  //final def filter(f: Predicate[A]): Stream[A] =
+  //  k => self stage { (u,a) => if (f(u,a)) k(u,a) }
+
+  //final def take(n: Long): Stream[A] =
+  //  k => self stage {
+  //    var rem = n
+  //    (u,a) => if (rem > 0) { rem -= 1; k(u,a) }
+  //             else throw Done
+  //  }
+
+  //final def drop(n: Long): Stream[A] =
+  //  k => self stage {
+  //    var rem = n
+  //    (u,a) => if (rem > 0) rem -= 1
+  //             else k(u,a)
+  //  }
+
+  //final def takeWhile(f: Predicate[A]): Stream[A] =
+  //  k => self stage { (u,a) =>
+  //    if (f(u,a)) k(u,a)
+  //    else throw Done
+  //  }
+
+  //final def dropWhile(f: Predicate[A]): Stream[A] =
+  //  k => self stage {
+  //    var dropping = true
+  //    (u,a) => if (!dropping) k(u,a)
+  //             else if (!f(u,a)) { dropping = false; k(u,a) }
+  //  }
+
+  //final def sum(implicit A: A =:= Long): Long = {
+  //  var total = 0L
+  //  val s = self stage { (u,_) => total += u }
+  //  try { while (true) s() } catch { case Done => }
+  //  total
+  //}
+
+  //final def zipWith[B,C](s: Stream[B])(f: F2[A,B,C]): Stream[C] =
+  //  k => {
+  //    var au = 0L; var ab: Ref[A] = null
+  //    val as = self stage { (u,a) => au = u; ab = a }
+  //    val k2 = f(k)
+  //    val bs = s stage { (u,b) => k2(au,ab,u,b) }
+  //    () => { as(); bs() }
+  //  }
+
+  //final def evens: Stream[A] = {
+  //  k => self stage {
+  //    var ok = true
+  //    (u,a) => { ok = { if (ok) k(u,a); !ok }}
+  //  }
+  //}
+
+  //final def odds: Stream[A] = {
+  //  k => self stage {
+  //    var ok = false
+  //    (u,a) => { ok = { if (ok) k(u,a); !ok }}
+  //  }
+  //}
+
+  //def ++(s: Stream[A]): Stream[A] = k => {
+  //  var done = false
+  //  val cself = self stage k
+  //  val cs = s stage k
+  //  () => {
+  //    if (done) cs()
+  //    else { try cself() catch { case Done => done = true } }
+  //  }
+  //}
+}
+
 object Stream {
-  abstract class Predicate[A] { def apply(u: Long, a: Ref[A]): Boolean }
-  abstract class F[A,B] { def apply(k: K[B]): K[A] }
-  abstract class F2[A,B,C] { def apply(k: K[C]): K2[A,B] }
-  abstract class K[A] { def apply(u: Long, b: Ref[A]): Unit }
-  abstract class K2[A,B] { def apply(u1: Long, b1: Ref[A], u2: Long, b2: Ref[B]): Unit }
+
+  abstract class K[A] { def apply(u: U, b: Ref[A]): Unit }
+  abstract class K2[A,B] { def apply(u1: U, b1: Ref[A], u2: U, b2: Ref[B]): Unit }
   abstract class Step { def apply(): Unit }
-  case class Ref[A](get: A)
+  case class Ref[B](get: B)
 
   case object Done extends Throwable { override def fillInStackTrace = this }
 
-  final def constant(n: Long): Stream[Long] = k => () => k(n,null)
+  final def constant(n: U): Stream[Any,U] =
+    _ => k => () => k(n, null)
 
-  final def range(start: Long, stopExclusive: Long): Stream[Long] =
-    k => {
-      var i = start - 1
-      () => { i += 1; if (i < stopExclusive) k(i,null) else throw Done }
-    }
-
-  final def from(n: Long): Stream[Long] =
-    k => {
+  final def from(n: U): Stream[Any,U] =
+    _ => k => {
       var i = n - 1
       () => { i += 1; k(i,null) }
     }

--- a/runtime-jvm/main/src/main/scala/util/Stream.scala
+++ b/runtime-jvm/main/src/main/scala/util/Stream.scala
@@ -69,6 +69,12 @@ object Stream {
 
   case object Done extends Throwable { override def fillInStackTrace = this }
 
+  final def range(start: Long, stopExclusive: Long): Stream[Long] =
+    k => {
+      var i = start - 1
+      () => { i += 1; if (i < stopExclusive) k(i,null) else throw Done }
+    }
+
   final def from(n: Long): Stream[Long] =
     k => {
       var i = n - 1

--- a/runtime-jvm/main/src/main/scala/util/Stream.scala
+++ b/runtime-jvm/main/src/main/scala/util/Stream.scala
@@ -44,6 +44,20 @@ abstract class Stream[A] { self =>
     try { while (true) s() } catch { case Done => }
     total
   }
+
+  final def evens: Stream[A] = {
+    k => self stage {
+      var ok = true
+      (u,a) => { ok = { if (ok) k(u,a); !ok }}
+    }
+  }
+
+  final def odds: Stream[A] = {
+    k => self stage {
+      var ok = false
+      (u,a) => { ok = { if (ok) k(u,a); !ok }}
+    }
+  }
 }
 
 object Stream {

--- a/runtime-jvm/main/src/main/scala/util/Stream.scala
+++ b/runtime-jvm/main/src/main/scala/util/Stream.scala
@@ -2,8 +2,9 @@ package org.unisonweb
 package util
 
 import Stream._
-import compilation2.{U, U0}
-import Unboxed.{F1, F2}
+import compilation2.{U}
+import Unboxed.{F1,K}
+// import Unboxed.{F1, F2, K}
 
 abstract class Stream[Env,A] { self =>
 
@@ -11,97 +12,79 @@ abstract class Stream[Env,A] { self =>
 
   def covaryEnv[E2<:Env]: Stream[E2,A] = this.asInstanceOf[Stream[E2,A]]
 
-  final def map[B](f: F1[Env,A,B]): Stream[Env,B] =
-    env => k => {
-      var b : B = null.asInstanceOf[B]
-      val fc = f.stage(env) (br => b = br)
-      self.stage(env) { (u,a) => k(fc(u,a), b) }
-    }
+  final def map[B](f: Env => F1[A,B]): Stream[Env,B] =
+    env => k => self.stage(env)(f(env) contramap k)
 
   /** Only emit elements from `this` for which `f` returns a nonzero value. */
-  final def filter(f: F1[Env,A,U]): Stream[Env,A] =
-    env => k => {
-      val fc = f.stage(env) { br => }
-      self.stage(env) { (u,a) => if (fc(u,a) != U0) k(u,a) }
-    }
+  final def filter(f: Env => F1[A,U]): Stream[Env,A] =
+    env => k => self.stage(env)(Unboxed.choose(f(env), k, Unboxed.K.noop))
 
   /** Emit the longest prefix of `this` for which `f` returns nonzero. */
-  final def takeWhile(f: F1[Env,A,U]): Stream[Env,A] =
-    env => k => self.stage(env) {
-      val fc = f.stage(env) { br => }
-      (u,a) => if (fc(u,a) != U0) k(u,a)
-               else throw Done
-    }
+  final def takeWhile(f: Env => F1[A,U]): Stream[Env,A] =
+    env => k => self.stage(env)(Unboxed.choose[A](f(env), k, (_,_) => throw Done))
 
   /** Skip the longest prefix of `this` for which `f` returns nonzero. */
-  final def dropWhile(f: F1[Env,A,U]): Stream[Env,A] =
-    env => k => self.stage(env) {
-      val fc = f.stage(env) { br => }
-      var dropping = true
-      (u,a) => if (!dropping) k(u,a)
-               else if (fc(u,a) == U0) { dropping = false; k(u,a) }
-    }
+  final def dropWhile(f: Env => F1[A,U]): Stream[Env,A] =
+    env => k => self.stage(env)(Unboxed.switchWhen(f(env), Unboxed.K.noop, k)())
 
+  //final def take(n: Long): Stream[Env,A] =
+  //  env => k => self.stage(env) {
+  //    var rem = n
+  //    (u,a) => if (rem > 0) { rem -= 1; k(u,a) }
+  //             else throw Done
+  //  }
 
-  final def take(n: Long): Stream[Env,A] =
-    env => k => self.stage(env) {
-      var rem = n
-      (u,a) => if (rem > 0) { rem -= 1; k(u,a) }
-               else throw Done
-    }
+  //final def drop(n: Long): Stream[Env,A] =
+  //  env => k => self.stage(env) {
+  //    var rem = n
+  //    (u,a) => if (rem > 0) rem -= 1
+  //             else k(u,a)
+  //  }
 
-  final def drop(n: Long): Stream[Env,A] =
-    env => k => self.stage(env) {
-      var rem = n
-      (u,a) => if (rem > 0) rem -= 1
-               else k(u,a)
-    }
+  //final def sum(env: Env)(implicit A: A =:= Unboxed[U]): U = {
+  //  var total = U0
+  //  self.stage(env) { (u,_) => total += u }.run()
+  //  total
+  //}
 
-  final def sum(env: Env)(implicit A: A =:= Unboxed[U]): U = {
-    var total = U0
-    self.stage(env) { (u,_) => total += u }.run()
-    total
-  }
+  //final def zipWith[B,C](bs: Stream[Env,B])(f: F2[Env,A,B,C]): Stream[Env,C] =
+  //  env => k => {
+  //    var au = U0; var ab: A = null.asInstanceOf[A]; var cb: C = null.asInstanceOf[C]
+  //    val fc = f.stage(env) { c => cb = c }
+  //    val left = self.stage(env) { (u,a) => au = u; ab = a }
+  //    val right = bs.stage(env) { (bu,bb) => k(fc(au,ab,bu,bb), cb) }
+  //    () => { left(); right(); ab = null.asInstanceOf[A]; cb = null.asInstanceOf[C] }
+  //  }
 
-  final def zipWith[B,C](bs: Stream[Env,B])(f: F2[Env,A,B,C]): Stream[Env,C] =
-    env => k => {
-      var au = U0; var ab: A = null.asInstanceOf[A]; var cb: C = null.asInstanceOf[C]
-      val fc = f.stage(env) { c => cb = c }
-      val left = self.stage(env) { (u,a) => au = u; ab = a }
-      val right = bs.stage(env) { (bu,bb) => k(fc(au,ab,bu,bb), cb) }
-      () => { left(); right(); ab = null.asInstanceOf[A]; cb = null.asInstanceOf[C] }
-    }
+  //def foldLeft[B,C](env: Env, u0: U, b0: B)(f: F2[Env,B,A,B])(extract: (U,B) => C): C = {
+  //  var (u, b) = (U0, b0)
+  //  val cf = f.stage(env) { b2 => b = b2 }
+  //  self.stage(env) { (u2,a) => u = cf(u, b, u2, a) }.run()
+  //  extract(u,b)
+  //}
 
-  def foldLeft[B,C](env: Env, u0: U, b0: B)(f: F2[Env,B,A,B])(extract: (U,B) => C): C = {
-    var (u, b) = (U0, b0)
-    val cf = f.stage(env) { b2 => b = b2 }
-    self.stage(env) { (u2,a) => u = cf(u, b, u2, a) }.run()
-    extract(u,b)
-  }
+  //def box[T](f: U => T)(implicit A: A =:= Unboxed[T]): Stream[Env,T] =
+  //  map(env => set => (u,_) => { set(f(u)); U0 })
 
-  def box[T](f: U => T)(implicit A: A =:= Unboxed[T]): Stream[Env,T] =
-    map(env => set => (u,_) => { set(f(u)); U0 })
+  //def ++(s: Stream[Env,A]): Stream[Env,A] = env => k => {
+  //  var done = false
+  //  val cself = self.stage(env)(k)
+  //  val cs = s.stage(env)(k)
+  //  () => {
+  //    if (done) cs()
+  //    else { try cself() catch { case Done => done = true } }
+  //  }
+  //}
 
-  def ++(s: Stream[Env,A]): Stream[Env,A] = env => k => {
-    var done = false
-    val cself = self.stage(env)(k)
-    val cs = s.stage(env)(k)
-    () => {
-      if (done) cs()
-      else { try cself() catch { case Done => done = true } }
-    }
-  }
-
-  def toSequence[B](env: Env)(f: (U,A) => B): Sequence[B] = {
-    var result = Sequence.empty[B]
-    self.stage(env) { (u, a) => result = result :+ f(u,a) }.run()
-    result
-  }
+  //def toSequence[B](env: Env)(f: (U,A) => B): Sequence[B] = {
+  //  var result = Sequence.empty[B]
+  //  self.stage(env) { (u, a) => result = result :+ f(u,a) }.run()
+  //  result
+  //}
 }
 
 object Stream {
 
-  abstract class K[A] { def apply(u: U, b: A): Unit }
   abstract class Step {
     def apply(): Unit
 

--- a/runtime-jvm/main/src/main/scala/util/Unboxed.scala
+++ b/runtime-jvm/main/src/main/scala/util/Unboxed.scala
@@ -1,0 +1,24 @@
+package org.unisonweb.util
+
+import org.unisonweb.compilation2.U
+
+abstract class Unboxed1[-Env,A,B] {
+  def stage(e: Env): (B => Unit) => Unboxed1.Compiled[A,B]
+}
+
+object Unboxed1 {
+  abstract class Compiled[A,B] {
+    def apply(u: U, a: A): U
+  }
+}
+
+abstract class Unboxed2[-Env,A,B,C] {
+  def stage(e: Env): (C => Unit) => Unboxed2.Compiled[A,B,C]
+}
+
+object Unboxed2 {
+
+  abstract class Compiled[A,B,C] {
+    def apply(u: U, a: A, u2: U, b: B): U
+  }
+}

--- a/runtime-jvm/main/src/main/scala/util/Unboxed.scala
+++ b/runtime-jvm/main/src/main/scala/util/Unboxed.scala
@@ -1,24 +1,33 @@
 package org.unisonweb.util
 
-import org.unisonweb.compilation2.U
+import org.unisonweb.compilation2.{U,U0}
 
 object Unboxed {
+
+  sealed abstract class Unboxed[T]
+
   abstract class F1[-Env,A,B] {
-    def stage(e: Env): (B => Unit) => F1.Compiled[A,B]
+    def stage(e: Env): (B => Unit) => F1.Compiled[A]
   }
 
   object F1 {
-    abstract class Compiled[A,B] {
+    def boxedScalaFunction[A,B](f: A => B): F1[Any,A,B] =
+      _ => set => (_,a) => { set(f(a)); U0 }
+
+    abstract class Compiled[A] {
       def apply(u: U, a: A): U
     }
   }
 
   abstract class F2[-Env,A,B,C] {
-    def stage(e: Env): (C => Unit) => F2.Compiled[A,B,C]
+    def stage(e: Env): (C => Unit) => F2.Compiled[A,B]
   }
 
   object F2 {
-    abstract class Compiled[A,B,C] {
+    def boxedScalaFunction[A,B,C](f: (A,B) => C): F2[Any,A,B,C] =
+      _ => set => (_,a,_,b) => { set(f(a,b)); U0 }
+
+    abstract class Compiled[A,B] {
       def apply(u: U, a: A, u2: U, b: B): U
     }
   }

--- a/runtime-jvm/main/src/main/scala/util/Unboxed.scala
+++ b/runtime-jvm/main/src/main/scala/util/Unboxed.scala
@@ -11,17 +11,28 @@ object Unboxed {
   abstract class K2[-A,-B] { def apply(u: U, a: A, u2: U, b: B): Unit }
   abstract class K3[-A,-B,-C] { def apply(u: U, a: A, u2: U, b: B, u3: U, c: C): Unit }
 
-  abstract class F1[A,B] { self =>
+  abstract class F1[-A,+B] { self =>
     def apply[X]: K2[B,X] => K2[A,X]
-    def contramap: K[B] => K[A] = kb => {
+    def andThen: K[B] => K[A] = kb => {
       val f = self.apply[AnyRef](kb.toK2)
       (u,a) => f(u,a,U0,null)
     }
   }
 
-  abstract class F2[A,B,C] {
+  abstract class F2[-A,-B,+C] {
     def apply[X]: K2[C,X] => K3[A,B,X]
+    final def andThen: K[C] => K2[A,B] =
+      kc => { val kabx = apply(kc.toK2[AnyRef])
+              (u,a,u2,b) => kabx(u,a,u2,b,U0,null) }
   }
+
+  /**
+   * Marker type with no instances. A `F[Unboxed[T]]` indicates that `F`
+   * does not use the boxed portion of its representation and that there
+   * exists a `U => T` for extracting a `T` from the unboxed portion of
+   * its representation.
+   */
+  sealed abstract class Unboxed[T]
 
   object K {
     val noop: K[Any] = (_,_) => {}
@@ -32,9 +43,9 @@ object Unboxed {
     (u,a) => ccond(u,a,u,a)
   }
 
-  def switchWhen[A](cond: F1[A,U], segment1: K[A], segment2: K[A]): () => K[A] = () => {
+  def switchWhen0[A](cond: F1[A,U], segment1: K[A], segment2: K[A]): () => K[A] = () => {
     var switched = false
-    val ccond = cond[A]((u,_,u2,a) => if (u != U0) { switched = true; segment1(u2,a) } else segment2(u2,a))
+    val ccond = cond[A]((u,_,u2,a) => if (u == U0) { switched = true; segment1(u2,a) } else segment2(u2,a))
     (u,a) => ccond(u,a,u,a)
   }
 
@@ -48,5 +59,11 @@ object Unboxed {
     def boxedScalaFunction[A,B,C](f: (A,B) => C): F2[A,B,C] = new F2[A,B,C] {
       def apply[x] = kcx => (u,a,u2,b,u3,x) => kcx(U0, f(a,b), u3, x)
     }
+
+    /** An `F2[Unboxed[U],Unboxed[U],Unboxed[U]]`. */
+    def UU_U(fn: UU_U): F2[Unboxed[U],Unboxed[U],Unboxed[U]] = new F2[Unboxed[U],Unboxed[U],Unboxed[U]] {
+      def apply[x] = kux => (u,_,u2,_,u3,x) => kux(fn(u,u2),null,u3,x)
+    }
+    abstract class UU_U { def apply(u: U, u2: U): U }
   }
 }

--- a/runtime-jvm/main/src/main/scala/util/Unboxed.scala
+++ b/runtime-jvm/main/src/main/scala/util/Unboxed.scala
@@ -2,23 +2,24 @@ package org.unisonweb.util
 
 import org.unisonweb.compilation2.U
 
-abstract class Unboxed1[-Env,A,B] {
-  def stage(e: Env): (B => Unit) => Unboxed1.Compiled[A,B]
-}
-
-object Unboxed1 {
-  abstract class Compiled[A,B] {
-    def apply(u: U, a: A): U
+object Unboxed {
+  abstract class F1[-Env,A,B] {
+    def stage(e: Env): (B => Unit) => F1.Compiled[A,B]
   }
-}
 
-abstract class Unboxed2[-Env,A,B,C] {
-  def stage(e: Env): (C => Unit) => Unboxed2.Compiled[A,B,C]
-}
+  object F1 {
+    abstract class Compiled[A,B] {
+      def apply(u: U, a: A): U
+    }
+  }
 
-object Unboxed2 {
+  abstract class F2[-Env,A,B,C] {
+    def stage(e: Env): (C => Unit) => F2.Compiled[A,B,C]
+  }
 
-  abstract class Compiled[A,B,C] {
-    def apply(u: U, a: A, u2: U, b: B): U
+  object F2 {
+    abstract class Compiled[A,B,C] {
+      def apply(u: U, a: A, u2: U, b: B): U
+    }
   }
 }

--- a/runtime-jvm/main/src/main/scala/util/Unboxed.scala
+++ b/runtime-jvm/main/src/main/scala/util/Unboxed.scala
@@ -2,25 +2,58 @@ package org.unisonweb.util
 
 import org.unisonweb.compilation2.{U,U0}
 
+/** Unboxed functions and continuations / callbacks. */
 object Unboxed {
 
+  /** A continuation receiving 1 value of type `A`, potentially unboxed. */
   abstract class K[-A] { self =>
     def apply(u: U, a: A): Unit
     final def toK2[B]: K2[A,B] = (u,a,u2,b) => self(u,a)
   }
+
+  /** A continuation receiving an A and a B, both potentially unboxed. */
   abstract class K2[-A,-B] { def apply(u: U, a: A, u2: U, b: B): Unit }
+
+  /** A continuation receiving an A, B, and C, all potentially unboxed. */
   abstract class K3[-A,-B,-C] { def apply(u: U, a: A, u2: U, b: B, u3: U, c: C): Unit }
 
+  /**
+   * Denotes functions `A -> B`. Unlike Scala's `A => B`, this function
+   * can be passed unboxed input, and we can consume its output without
+   * boxing.
+   */
   abstract class F1[-A,+B] { self =>
+
+    /**
+     * Holy shit! A function from `A -> B` represented as a "continuation transformer".
+     * The continuation which accepts a `B` value (potentially unboxed) is transformed
+     * into a continuation which accepts an `A` value (potentially unboxed).
+     *
+     * The requirement that an `F1` be able to pass along an extra `X`, parametrically,
+     * effectively adds products to the category.
+     */
     def apply[X]: K2[B,X] => K2[A,X]
+
+    /** Compose two `F1`s. */
+    def map[C](f: F1[B,C]): F1[A,C] = new F1[A,C] {
+      def apply[x] = kcx => self.apply(f.apply(kcx))
+    }
+
     def andThen: K[B] => K[A] = kb => {
       val f = self.apply[AnyRef](kb.toK2)
       (u,a) => f(u,a,U0,null)
     }
   }
 
+  /**
+   * Denotes functions `(A,B) -> C`. Unlike Scala's `(A,B) => C`, this function
+   * can be passed unboxed input, and we can consume its output without
+   * boxing.
+   */
   abstract class F2[-A,-B,+C] {
+
     def apply[X]: K2[C,X] => K3[A,B,X]
+
     final def andThen: K[C] => K2[A,B] =
       kc => { val kabx = apply(kc.toK2[AnyRef])
               (u,a,u2,b) => kabx(u,a,u2,b,U0,null) }
@@ -38,11 +71,19 @@ object Unboxed {
     val noop: K[Any] = (_,_) => {}
   }
 
+  /**
+   * A continuation which invokes `t` whenver `cond` is nonzero on the
+   * input, and which invokes `f` whenever `cond` is zero on the input.
+   */
   def choose[A](cond: F1[A,U], t: K[A], f: K[A]): K[A] = {
     val ccond = cond[A]((u,_,u2,a) => if (u != U0) t(u2,a) else f(u2,a))
     (u,a) => ccond(u,a,u,a)
   }
 
+  /**
+   * A continuation which acts as `segment1` until `cond` emits 0, then
+   * acts as `segment2` forever thereafter.
+   */
   def switchWhen0[A](cond: F1[A,U], segment1: K[A], segment2: K[A]): () => K[A] = () => {
     var switched = false
     val ccond = cond[A]((u,_,u2,a) => if (u == U0) { switched = true; segment1(u2,a) } else segment2(u2,a))
@@ -50,20 +91,32 @@ object Unboxed {
   }
 
   object F1 {
-    def boxedScalaFunction[A,B](f: A => B): F1[A,B] = new F1[A,B] {
+    /**
+     * Convert a Scala `A => B` to an `F1[A,B]` that acts on boxed input and produces boxed output.
+     * Named `B_B` since it takes one boxed input and produces boxed output.
+     */
+    def B_B[A,B](f: A => B): F1[A,B] = new F1[A,B] {
       def apply[x] = kbx => (u,a,u2,x) => kbx(U0, f(a), u2, x)
     }
   }
 
   object F2 {
-    def boxedScalaFunction[A,B,C](f: (A,B) => C): F2[A,B,C] = new F2[A,B,C] {
+    /**
+     * Convert a Scala `(A,B) => C` to an `F2[A,B,C]` that acts on boxed input and produces boxed output.
+     * Named `BB_B` since it takes two boxed input and produces boxed output.
+     */
+    def BB_B[A,B,C](f: (A,B) => C): F2[A,B,C] = new F2[A,B,C] {
       def apply[x] = kcx => (u,a,u2,b,u3,x) => kcx(U0, f(a,b), u3, x)
     }
 
-    /** An `F2[Unboxed[U],Unboxed[U],Unboxed[U]]`. */
+    /**
+     * An `F2[Unboxed[U],Unboxed[U],Unboxed[U]]` which works on unboxed input and produces unboxed output.
+     * Named `UU_U` since it takes two unboxed input and produces unboxed output.
+     */
     def UU_U(fn: UU_U): F2[Unboxed[U],Unboxed[U],Unboxed[U]] = new F2[Unboxed[U],Unboxed[U],Unboxed[U]] {
       def apply[x] = kux => (u,_,u2,_,u3,x) => kux(fn(u,u2),null,u3,x)
     }
+
     abstract class UU_U { def apply(u: U, u2: U): U }
   }
 }

--- a/runtime-jvm/main/src/main/scala/util/Unboxed.scala
+++ b/runtime-jvm/main/src/main/scala/util/Unboxed.scala
@@ -4,8 +4,6 @@ import org.unisonweb.compilation2.{U,U0}
 
 object Unboxed {
 
-  sealed abstract class Unboxed[T]
-
   abstract class F1[-Env,A,B] {
     def stage(e: Env): (B => Unit) => F1.Compiled[A]
   }

--- a/runtime-jvm/main/src/main/scala/util/Unboxed.scala
+++ b/runtime-jvm/main/src/main/scala/util/Unboxed.scala
@@ -4,29 +4,49 @@ import org.unisonweb.compilation2.{U,U0}
 
 object Unboxed {
 
-  abstract class F1[-Env,A,B] {
-    def stage(e: Env): (B => Unit) => F1.Compiled[A]
+  abstract class K[-A] { self =>
+    def apply(u: U, a: A): Unit
+    final def toK2[B]: K2[A,B] = (u,a,u2,b) => self(u,a)
   }
+  abstract class K2[-A,-B] { def apply(u: U, a: A, u2: U, b: B): Unit }
+  abstract class K3[-A,-B,-C] { def apply(u: U, a: A, u2: U, b: B, u3: U, c: C): Unit }
 
-  object F1 {
-    def boxedScalaFunction[A,B](f: A => B): F1[Any,A,B] =
-      _ => set => (_,a) => { set(f(a)); U0 }
-
-    abstract class Compiled[A] {
-      def apply(u: U, a: A): U
+  abstract class F1[A,B] { self =>
+    def apply[X]: K2[B,X] => K2[A,X]
+    def contramap: K[B] => K[A] = kb => {
+      val f = self.apply[AnyRef](kb.toK2)
+      (u,a) => f(u,a,U0,null)
     }
   }
 
-  abstract class F2[-Env,A,B,C] {
-    def stage(e: Env): (C => Unit) => F2.Compiled[A,B]
+  abstract class F2[A,B,C] {
+    def apply[X]: K2[C,X] => K3[A,B,X]
+  }
+
+  object K {
+    val noop: K[Any] = (_,_) => {}
+  }
+
+  def choose[A](cond: F1[A,U], t: K[A], f: K[A]): K[A] = {
+    val ccond = cond[A]((u,_,u2,a) => if (u != U0) t(u2,a) else f(u2,a))
+    (u,a) => ccond(u,a,u,a)
+  }
+
+  def switchWhen[A](cond: F1[A,U], segment1: K[A], segment2: K[A]): () => K[A] = () => {
+    var switched = false
+    val ccond = cond[A]((u,_,u2,a) => if (u != U0) { switched = true; segment1(u2,a) } else segment2(u2,a))
+    (u,a) => ccond(u,a,u,a)
+  }
+
+  object F1 {
+    def boxedScalaFunction[A,B](f: A => B): F1[A,B] = new F1[A,B] {
+      def apply[x] = kbx => (u,a,u2,x) => kbx(U0, f(a), u2, x)
+    }
   }
 
   object F2 {
-    def boxedScalaFunction[A,B,C](f: (A,B) => C): F2[Any,A,B,C] =
-      _ => set => (_,a,_,b) => { set(f(a,b)); U0 }
-
-    abstract class Compiled[A,B] {
-      def apply(u: U, a: A, u2: U, b: B): U
+    def boxedScalaFunction[A,B,C](f: (A,B) => C): F2[A,B,C] = new F2[A,B,C] {
+      def apply[x] = kcx => (u,a,u2,b,u3,x) => kcx(U0, f(a,b), u3, x)
     }
   }
 }

--- a/runtime-jvm/main/src/test/scala/util/StreamTests.scala
+++ b/runtime-jvm/main/src/test/scala/util/StreamTests.scala
@@ -20,7 +20,7 @@ object StreamTests {
       )
     },
     test("foldLeft-scalaPlus") { implicit T =>
-      val plus: Unboxed.F2[U, U, U] = Unboxed.F2.boxedScalaFunction(_ + _)
+      val plus: Unboxed.F2[U, U, U] = Unboxed.F2.BB_B(_ + _)
       equal(
         Stream.from(0.0).take(10000).box[U](identity)
           .foldLeft(U0, U0)(plus)((_,a) => a),

--- a/runtime-jvm/main/src/test/scala/util/StreamTests.scala
+++ b/runtime-jvm/main/src/test/scala/util/StreamTests.scala
@@ -10,30 +10,29 @@ object StreamTests {
   val tests = suite("Stream")(
     test("ex1") { implicit T =>
       equal(
-        Stream.from(0.0).take(10000).sum(()),
+        Stream.from(0.0).take(10000).sum,
         (0 until 10000).sum.toDouble)
     },
     test("toSequence") { implicit T =>
       equal(
-        Stream.from(0.0).take(10000).toSequence(()){ (u, _) => u },
+        Stream.from(0.0).take(10000).toSequence { (u, _) => u },
         Sequence.apply(0 until 10000: _*).map(_.toDouble)
       )
     },
     test("foldLeft-scalaPlus") { implicit T =>
-      val plus: Unboxed.F2[Any, U, U, U] = Unboxed.F2.boxedScalaFunction(_ + _)
+      val plus: Unboxed.F2[U, U, U] = Unboxed.F2.boxedScalaFunction(_ + _)
       equal(
         Stream.from(0.0).take(10000).box[U](identity)
-          .foldLeft((), U0, U0)(plus)((_,a) => a),
+          .foldLeft(U0, U0)(plus)((_,a) => a),
         (0 until 10000).sum.toDouble
       )
     },
     test("foldLeft-unisonPlus") { implicit T =>
       val plusU = UnisonToScala.toUnboxed2(Lib2.builtins(Name("+")) match { case Return(lam: Lambda) => lam })
-                                  .asInstanceOf[Unboxed.F2[UnisonToScala.Env,Param,Param,Param]]
       val env = (new Array[U](20), new Array[B](20), new StackPtr(0), Result())
       equal(
-        Stream.from(0.0).take(10000).asInstanceOf[Stream[UnisonToScala.Env,Param]]
-                                    .foldLeft(env, U0, null:Param)(plusU)((u,_) => u),
+        Stream.from(0.0).take(10000).asInstanceOf[Stream[Param]]
+                                    .foldLeft(U0, null:Param)(plusU(env))((u,_) => u),
         (0 until 10000).sum.toDouble
       )
     }

--- a/runtime-jvm/main/src/test/scala/util/StreamTests.scala
+++ b/runtime-jvm/main/src/test/scala/util/StreamTests.scala
@@ -1,7 +1,10 @@
 package org.unisonweb.util
 
+import org.unisonweb.ABT.Name
 import org.unisonweb.EasyTest._
-import org.unisonweb.compilation2.{U,U0}
+import org.unisonweb.compilation2._
+import org.unisonweb.{Lib2, UnisonToScala}
+import org.unisonweb.compilation2.Value.Lambda
 
 object StreamTests {
   val tests = suite("Stream")(
@@ -21,6 +24,16 @@ object StreamTests {
       equal(
         Stream.from(0.0).take(10000).box[U](identity)
           .foldLeft((), U0, U0)(plus)((_,a) => a),
+        (0 until 10000).sum.toDouble
+      )
+    },
+    test("foldLeft-unisonPlus") { implicit T =>
+      val plusU = UnisonToScala.toUnboxed2(Lib2.builtins(Name("+")) match { case Return(lam: Lambda) => lam })
+                                  .asInstanceOf[Unboxed.F2[UnisonToScala.Env,Param,Param,Param]]
+      val env = (new Array[U](20), new Array[B](20), new StackPtr(0), Result())
+      equal(
+        Stream.from(0.0).take(10000).asInstanceOf[Stream[UnisonToScala.Env,Param]]
+                                    .foldLeft(env, U0, null:Param)(plusU)((u,_) => u),
         (0 until 10000).sum.toDouble
       )
     }

--- a/runtime-jvm/main/src/test/scala/util/StreamTests.scala
+++ b/runtime-jvm/main/src/test/scala/util/StreamTests.scala
@@ -1,0 +1,28 @@
+package org.unisonweb.util
+
+import org.unisonweb.EasyTest._
+import org.unisonweb.compilation2.{U,U0}
+
+object StreamTests {
+  val tests = suite("Stream")(
+    test("ex1") { implicit T =>
+      equal(
+        Stream.from(0.0).take(10000).sum(()),
+        (0 until 10000).sum.toDouble)
+    },
+    test("toSequence") { implicit T =>
+      equal(
+        Stream.from(0.0).take(10000).toSequence(()){ (u, _) => u },
+        Sequence.apply(0 until 10000: _*).map(_.toDouble)
+      )
+    },
+    test("foldLeft-scalaPlus") { implicit T =>
+      val plus: Unboxed.F2[Any, U, U, U] = Unboxed.F2.boxedScalaFunction(_ + _)
+      equal(
+        Stream.from(0.0).take(10000).box[U](identity)
+          .foldLeft((), U0, U0)(plus)((_,a) => a),
+        (0 until 10000).sum.toDouble
+      )
+    }
+  )
+}

--- a/runtime-jvm/main/src/test/scala/util/UtilTests.scala
+++ b/runtime-jvm/main/src/test/scala/util/UtilTests.scala
@@ -9,6 +9,7 @@ object UtilTests {
           SequenceTests.tests,
           BytesTests.tests,
           TextTests.tests,
-          CritbyteTests.tests)
+          CritbyteTests.tests,
+          StreamTests.tests)
   }
 }


### PR DESCRIPTION
A fused stream type. Any number of stream operations are fused into a single imperative loop, without boxing or tupling or pattern matching happening at runtime!

Main type is [here](https://github.com/unisonweb/unison/blob/topic/stream-fusion/runtime-jvm/main/src/main/scala/util/Stream.scala) also see [Unboxed.scala](https://github.com/unisonweb/unison/blob/topic/stream-fusion/runtime-jvm/main/src/main/scala/util/Unboxed.scala) which has an interesting representation of functions that consume and/or produce unboxed values. This is used by various stream functions like `map`, `zipWith`, `filter`, etc, to avoid the boxing and unboxing that would otherwise occur with use of these functions.

Here's ratio of runtimes from a benchmarking run (smaller is better):

```
[info] 1.0             scala-triangle
[info] 8.0             stream-triangle-unisonfold
[info] 8.48            stream-triangle
[info] 9.03            stream-triangle-fold-left
[info] 19.63           scala-stream-triangle
```

* `scala-triangle` is a monolithic unboxed Scala loop. Hard to beat that. A 0-allocation loop where all the the loop state is probably in registers.
* `stream-triangle-*` are different versions of the program `Stream.from(0).take(N).fold(_ + _)`. In particular, testing with `unisonfold`, a function produced from a Unison `Lambda` value.
* `scala-stream-triangle` is using the Scala standard library Stream type. I believe its performance would fall even further behind if we had a more interesting loop, since each HOF pays for boxing/unboxing.