### PR TITLE
Added text literals and various builtin functions operating on Text

### DIFF
--- a/runtime-jvm/main/src/main/scala/Param.scala
+++ b/runtime-jvm/main/src/main/scala/Param.scala
@@ -82,6 +82,10 @@ object Value {
     def unapply(l: Lambda): Option[(Int, Computation, Term)] =
       Some((l.arity, l.body, l.decompile))
 
+    /**
+     * A `Lambda` of arity 2 that forms a closure when underapplied, rather
+     * than specializing away the supplied argument.
+     */
     class ClosureForming2(decompiled: Term, arg1: Name, arg2: Name, body: Computation)
       extends Lambda(2,body,decompiled) {
       val names = List(arg1,arg2)

--- a/runtime-jvm/main/src/main/scala/compilation.scala
+++ b/runtime-jvm/main/src/main/scala/compilation.scala
@@ -746,6 +746,7 @@ object compilation {
 
     e match {
       case Term.Unboxed(n,t) => compileUnboxed(n,t)
+      case Term.Text(txt) => Return(Builtins.External(txt, e))
       case Term.Builtin(name) => builtins(name)
       case Term.Compiled(param) =>
         if (param.toValue eq null)

--- a/runtime-jvm/main/src/main/scala/util/Text.scala
+++ b/runtime-jvm/main/src/main/scala/util/Text.scala
@@ -21,6 +21,25 @@ object Text {
 
   type Text = Sequence[Codepoint]
 
+  /**
+   * Lexicographical comparison.
+   * Returns: -1 if t1 < t2
+   *           1 if t1 > t2
+   *           0 if t1 == t2
+   */
+  def compare(t1: Text, t2: Text): Long = {
+    if (t1 eq t2) return 0
+    var i = 0; while (i < t1.size && i < t2.size) {
+      val codepoint1 = t1(i)
+      val codepoint2 = t2(i)
+      if (codepoint1 < codepoint2) return -1
+      else if (codepoint1 > codepoint2) return 1
+      else i += 1 // keep going
+    }
+    // smaller text comes first if one is a prefix of another
+    (t1.size - t2.size).signum
+  }
+
   /** The empty `Text`, consists of no characters. */
   def empty: Text =
     Sequence.Flat(Deque.fromBlock(emptyBlock, 0))

--- a/runtime-jvm/main/src/test/scala/CompilationTests.scala
+++ b/runtime-jvm/main/src/test/scala/CompilationTests.scala
@@ -117,6 +117,29 @@ object CompilationTests {
       },
       test("ex1") { implicit T =>
         equal(eval(Sequence.size(Sequence(1,2,3))), 3: Term)
+      },
+      test("ex2 (underapplication)") { implicit T =>
+        val t: Term =
+          Let('x -> Sequence(1,2,3),
+              'fn -> Sequence.take(2))(Sequence.size('fn.v('x)))
+        equal(eval(t), 2: Term)
+      }
+    ),
+    suite("text") (
+      test("examples") { implicit T =>
+        equal1(eval(Text.concatenate("abc", "123")), "abc123": Term)
+        equal1(eval(Text.concatenate(Text.empty, "123")), "123": Term)
+        equal1(eval(Text.concatenate("123", Text.empty)), "123": Term)
+        equal1(eval(Text.drop(3, "abc123")), "123": Term)
+        equal1(eval(Text.take(3, "abc123")), "abc": Term)
+        equal1(eval(Text.equal("abc", "abc")), true: Term)
+        equal1(eval(Text.lt("Alice", "Bob")), true: Term)
+        equal1(eval(Text.lteq("Runar", "Runarorama")), true: Term)
+        equal1(eval(Text.lt("Arya", "Arya-orama")), true: Term)
+        equal1(eval(Text.gt("Bob", "Alice")), true: Term)
+        equal1(eval(Text.gteq("Runarorama", "Runar")), true: Term)
+        equal1(eval(Text.gteq("Arya-orama", "Arya")), true: Term)
+        ok
       }
     ),
     suite("pattern")(
@@ -154,11 +177,9 @@ object CompilationTests {
       test("wildcard0") { implicit T =>
         /* case 10 of y -> y + 4 */
         val v: Term = 14
-        println("begin wildcard0")
         val c = MatchCase(Wildcard, ABT.Abs('y, 'y.v + 4))
         val p = Match(10)(c)
         equal(eval(p), v)
-        println("end wildcard0")
       },
       test("uncaptured") { implicit T =>
         /* let x = 42; case 10 of 10 | false -> x + 1; _ -> x + 2
@@ -348,5 +369,20 @@ object Terms {
     val snoc = termFor(Sequence_snoc)
     val take = termFor(Sequence_take)
     val size = termFor(Sequence_size)
+  }
+
+  object Text {
+    import Builtins._
+
+    val empty = termFor(Text_empty)
+    val take = termFor(Text_take)
+    val drop = termFor(Text_drop)
+    val concatenate = termFor(Text_concatenate)
+    val size = termFor(Text_size)
+    val equal = termFor(Text_eq)
+    val lt = termFor(Text_lt)
+    val gt = termFor(Text_gt)
+    val lteq = termFor(Text_lteq)
+    val gteq = termFor(Text_gteq)
   }
 }


### PR DESCRIPTION
This was pretty straightforward: 

* There's now a `Term.Text` constructor in the syntax tree. Takes a `util.Text.Text` value, which is a `Sequence[Codepoint]`. Lots of functions can be defined on this.
* The runtime representation of `Text` is just an `External` wrapping that `Sequence[Codepoint]`.
* There's one more case in the `compile` function for handling this new kind of term. It's 1 LOC there - `      case Term.Text(txt) => Return(Builtins.External(txt, e))`
* I added appropriate instances in `Builtins` to make it nice to define functions operating over `Text` values. I think just needed `Decompile` and `Decode`.
* Added some tests that actually exercise the new builtin functions added.

Two more things:

* Added some additional helper functions, `fup_p` (takes an unboxed argument as first param) and `fpp_u` (takes two polymorphic values, returns an unboxed value), which follow the same naming convention we've established. Converted a couple functions (like `Sequence.take`) to use the more efficient `fup_p` form.
* I spotted a bug with underapplication of builtin functions, which have to form a closure. I added a failing test for this, fixed it, and factored corrected logic out into a class, `Lambda.ClosureForming2`, which am using in several places now. Example below:

```Scala
    val body: Computation = ...
    // this lambda will form a closure when underapplied, rather than specializing
    // the body for the given arguments
    val lambda: Lambda = new Lambda.ClosureForming2(Builtin("my-builtin"), "arg1", "arg2", body)
```