### PR TITLE
fix & speed up travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,25 +14,37 @@ cache:
 
 before_cache:
 # Cleanup the cached directories to avoid unnecessary cache updates
-- find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
-- find $HOME/.sbt        -name "*.lock"               -print -delete
+- find $HOME/.ivy2/cache -name "ivydata-*.properties" -delete
+- find $HOME/.sbt        -name "*.lock"               -delete
+# diagnostic stuff, temporary
+- find $HOME/.stack
+# - find $HOME/.ivy2/cache
+# - find $HOME/.sbt
+# - ls -ld /opt/ghc/*
 
 before_install:
 # Download and unpack the stack executable
 - mkdir -p ~/.local/bin
 - export PATH=$HOME/.local/bin:$PATH
 - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+# Configure stack to use the system GHC installation
+
+install:
+  # - stack ghc -- --version
+  - travis_wait stack --no-terminal setup
+  - travis_wait stack --no-terminal test --only-snapshot
+  - travis_wait stack --no-terminal build
 
 script:
-  - stack --no-terminal build && stack --no-terminal exec tests
+  - stack --no-terminal exec tests
   - pushd runtime-jvm
   - sbt main/test:run
   - popd
 
 addons:
   apt:
+    sources:
+    # - hvr-ghc
     packages:
-      - libgmp-dev
+    # - ghc-8.0.1
 
-install:
-  - stack --no-terminal --install-ghc test --only-dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,35 +16,19 @@ before_cache:
 # Cleanup the cached directories to avoid unnecessary cache updates
 - find $HOME/.ivy2/cache -name "ivydata-*.properties" -delete
 - find $HOME/.sbt        -name "*.lock"               -delete
-# diagnostic stuff, temporary
-- find $HOME/.stack
-# - find $HOME/.ivy2/cache
-# - find $HOME/.sbt
-# - ls -ld /opt/ghc/*
 
 before_install:
 # Download and unpack the stack executable
 - mkdir -p ~/.local/bin
 - export PATH=$HOME/.local/bin:$PATH
 - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
-# Configure stack to use the system GHC installation
 
 install:
-  # - stack ghc -- --version
-  - travis_wait stack --no-terminal setup
-  - travis_wait stack --no-terminal test --only-snapshot
-  - travis_wait stack --no-terminal build
+- stack ghc -- --version
+- travis_wait stack --no-terminal setup
+- travis_wait stack --no-terminal test --only-snapshot
+- travis_wait stack --no-terminal build
 
 script:
-  - stack --no-terminal exec tests
-  - pushd runtime-jvm
-  - sbt main/test:run
-  - popd
-
-addons:
-  apt:
-    sources:
-    # - hvr-ghc
-    packages:
-    # - ghc-8.0.1
-
+- stack --no-terminal exec tests
+- (cd runtime-jvm; sbt main/test:run)

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,4 @@ install:
 
 script:
 - stack --no-terminal exec tests
-- (cd runtime-jvm; sbt main/test:run)
+- (cd runtime-jvm; sbt benchmark/compile main/test:run)

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
 - stack setup
 
 script:
-  - stack build && stack exec test
+  - stack build && stack exec tests
   - pushd runtime-jvm
   - sbt main/test:run
   - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
 - stack setup
 
 script:
-  - stack --no-terminal --skip-ghc-check build && stack --no-terminal --skip-ghc-check exec tests
+  - stack --no-terminal build && stack --no-terminal exec tests
   - pushd runtime-jvm
   - sbt main/test:run
   - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,4 @@ addons:
       - libgmp-dev
 
 install:
-  - stack --no-terminal install-ghc test --only-dependencies
+  - stack --no-terminal --install-ghc test --only-dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
 - stack setup
 
 script:
-  - stack --skip-ghc-check build && stack --skip-ghc-check exec tests
+  - stack --no-terminal --skip-ghc-check build && stack --no-terminal --skip-ghc-check exec tests
   - pushd runtime-jvm
   - sbt main/test:run
   - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
   - $HOME/.stack
   - $HOME/.ivy2/cache
   - $HOME/.sbt
+  - $HOME/.coursier
 
 before_cache:
 # Cleanup the cached directories to avoid unnecessary cache updates

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,13 @@ language: generic
 cache:
   directories:
   - $HOME/.stack
+  - $HOME/.ivy2/cache
+  - $HOME/.sbt
+
+before_cache:
+# Cleanup the cached directories to avoid unnecessary cache updates
+- find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+- find $HOME/.sbt        -name "*.lock"               -print -delete
 
 before_install:
 # Download and unpack the stack executable

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,6 @@ before_install:
 - mkdir -p ~/.local/bin
 - export PATH=$HOME/.local/bin:$PATH
 - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
-# Configure stack to use the system GHC installation
-- stack config set system-ghc --global true
-- export PATH=/opt/ghc/8.0.1/bin:$PATH
-- stack setup
 
 script:
   - stack --no-terminal build && stack --no-terminal exec tests
@@ -35,12 +31,8 @@ script:
 
 addons:
   apt:
-    sources:
-      - hvr-ghc
     packages:
-      - ghc-8.0.1
-      - libc6
-      - libc6-dev
+      - libgmp-dev
+
 install:
-  - travis_wait stack --no-terminal --skip-ghc-check setup
-  - travis_wait stack --no-terminal --skip-ghc-check test --only-snapshot
+  - stack --no-terminal install-ghc test --only-dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ before_install:
 - stack setup
 
 script:
-  - stack --no-terminal --skip-ghc-check build unison-shared
-  - stack --no-terminal --skip-ghc-check exec shared-tests
-  - stack --no-terminal --skip-ghc-check test unison-node
-  - stack --no-terminal --skip-ghc-check exec node-tests
+  - stack build && stack exec test
+  - pushd runtime-jvm
+  - sbt main/test:run
+  - popd
 
 addons:
   apt:
@@ -37,4 +37,3 @@ addons:
 install:
   - travis_wait stack --no-terminal --skip-ghc-check setup
   - travis_wait stack --no-terminal --skip-ghc-check test --only-snapshot
-  

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
 - stack setup
 
 script:
-  - stack build && stack exec tests
+  - stack --skip-ghc-check build && stack --skip-ghc-check exec tests
   - pushd runtime-jvm
   - sbt main/test:run
   - popd

--- a/runtime-jvm/project/plugins.sbt
+++ b/runtime-jvm/project/plugins.sbt
@@ -4,3 +4,4 @@ scalacOptions ++= Seq(
 )
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")

--- a/runtime-jvm/project/plugins.sbt
+++ b/runtime-jvm/project/plugins.sbt
@@ -4,4 +4,3 @@ scalacOptions ++= Seq(
 )
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,7 +14,7 @@ compiler: ghc-8.4.2
 extra-deps:
 #  - applicative-extras-0.1.8
 #  - ctrie-0.1.0.3
-- cryptonite-0.17
+#  - cryptonite-0.17
 - GraphSCC-1.0.4
 - base58-bytestring-0.1.0
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,7 @@ packages:
 
 #compiler-check: match-exact
 resolver: lts-11.9
-compiler: ghc-8.4.3
+compiler: ghc-8.4.2
 
 extra-deps:
 #  - applicative-extras-0.1.8

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,7 @@ packages:
 
 #compiler-check: match-exact
 resolver: lts-11.9
-compiler: ghc-8.0.1
+compiler: ghc-8.4.3
 
 extra-deps:
 #  - applicative-extras-0.1.8

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,7 @@ packages:
 
 #compiler-check: match-exact
 resolver: lts-11.9
-compiler: ghc-8.4.2
+compiler: ghc-8.0.1
 
 extra-deps:
 #  - applicative-extras-0.1.8


### PR DESCRIPTION
* Switch away from using `apt` and hard-coded paths in the travis script; use `stack` to install and cache per-user `ghc` distro.
* Run `runtime-jvm` tests in addition to Haskell tests.
* Reintroduce `sbt-coursier` plugin to hopefully speed up sbt dependency resolution.
* Brings CI time from ~15min to ~3min