### PR TITLE
move outputType from `Lambda` to primitive `Computation`s

### DIFF
--- a/runtime-jvm/main/src/main/scala/BuiltinTypes.scala
+++ b/runtime-jvm/main/src/main/scala/BuiltinTypes.scala
@@ -134,7 +134,7 @@ object BuiltinTypes {
     }
     val lam: Computation =
       if (arity >= 1)
-        new Value.Lambda.ClosureForming(paramNames.toList, body, None, decompile)
+        new Value.Lambda.ClosureForming(paramNames.toList, body, decompile)
           .toComputation
       else try {
         Return(req(Array()))

--- a/runtime-jvm/main/src/main/scala/Builtins.scala
+++ b/runtime-jvm/main/src/main/scala/Builtins.scala
@@ -71,7 +71,7 @@ object Builtins {
       }
     val decompiled = Term.Id(name)
     val lambda =
-      new Value.Lambda.ClosureForming(List(arg1, arg2, arg3), body, None, decompiled)
+      new Value.Lambda.ClosureForming(List(arg1, arg2, arg3), body, decompiled)
     name -> Return(lambda)
   }
 
@@ -383,7 +383,7 @@ object Builtins {
                (implicit A: Decode[A], B: Encode[B]): (Name, Computation) = {
     val body: Computation.C1P = (r,x0,x0b) => B.encode(r, f(A.decode(x0, x0b)))
     val decompile = Term.Id(name)
-    name -> Return(new Lambda1(arg, body, None, decompile))
+    name -> Return(new Lambda1(arg, body, decompile))
   }
 
   // Monomorphic one-argument function on unboxed values
@@ -395,7 +395,7 @@ object Builtins {
       def raw(x0: U): U = f.applyAsLong(x0)
     }
     val decompile = Term.Id(name)
-    val computation = Return(new Lambda1(arg, body, Some(outputType), decompile))
+    val computation = Return(new Lambda1(arg, body, decompile))
     name -> computation
   }
 
@@ -427,7 +427,7 @@ object Builtins {
     val body: Computation.C1P = (r,x0,x0b) => {
       B.encodeOp(r, f(A.decode(x0, x0b)), name, Value.fromParam(x0, x0b))
     }
-    val lambda = new Lambda.Lambda1(arg, body, None, Term.Id(name))
+    val lambda = new Lambda.Lambda1(arg, body, Term.Id(name))
     name -> Return(lambda)
   }
 
@@ -439,7 +439,7 @@ object Builtins {
       (r,x1,x0,x1b,x0b) =>
         C.encode(r, f(A.decode(x1, x1b), B.decode(x0, x0b)))
     val decompiled = Term.Id(name)
-    val lambda = new Lambda.ClosureForming(List(arg1, arg2), body, None, decompiled)
+    val lambda = new Lambda.ClosureForming(List(arg1, arg2), body, decompiled)
     name -> Return(lambda)
   }
 
@@ -456,7 +456,7 @@ object Builtins {
                    Value.fromParam(x0, x0b))
       }
     val decompiled = Term.Id(name)
-    val lambda = new Lambda.ClosureForming(List(arg1, arg2), body, None, decompiled)
+    val lambda = new Lambda.ClosureForming(List(arg1, arg2), body, decompiled)
     name -> Return(lambda)
   }
 
@@ -471,7 +471,7 @@ object Builtins {
     val body: Computation.C2P = (r,x1,x0,_,x0b) =>
       B.encode(r, f(x1, A.decode(x0, x0b)))
     val decompiled = Term.Id(name)
-    val lambda = new Lambda.ClosureForming(List(arg1, arg2), body, None, decompiled)
+    val lambda = new Lambda.ClosureForming(List(arg1, arg2), body, decompiled)
     name -> Return(lambda)
   }
 
@@ -483,7 +483,7 @@ object Builtins {
                  name,
                  Value.fromParam(x1,x1b),
                  Value.fromParam(x0,x0b))
-    name -> Return(new Value.Lambda.ClosureForming(List(arg1, arg2), body, None, Term.Id(name)))
+    name -> Return(new Value.Lambda.ClosureForming(List(arg1, arg2), body, Term.Id(name)))
   }
 
 
@@ -499,7 +499,7 @@ object Builtins {
                  Value.fromParam(x0, x0b))
 
     val decompiled = Term.Id(name)
-    val lambda = new Lambda.ClosureForming(List(arg1, arg2), body, None, decompiled)
+    val lambda = new Lambda.ClosureForming(List(arg1, arg2), body, decompiled)
     name -> Return(lambda)
   }
 
@@ -518,7 +518,7 @@ object Builtins {
         f(A.decode(x1, x1b), B.decode(x0, x0b))
       }
     val decompiled = Term.Id(name)
-    val lambda = new Lambda.ClosureForming(List(arg1, arg2), body, None, decompiled)
+    val lambda = new Lambda.ClosureForming(List(arg1, arg2), body, decompiled)
     name -> Return(lambda)
   }
 
@@ -554,7 +554,7 @@ object Builtins {
     }
 
     val decompiled = Term.Id(name)
-    val lam = new Lambda(List(arg1, arg2), body, Some(outputType), decompiled) {
+    val lam = new Lambda(List(arg1, arg2), body, decompiled) {
       self =>
 
       override def saturatedNonTailCall(args: List[Computation]) = args match {
@@ -613,11 +613,11 @@ object Builtins {
               val body = new Computation.C1U(outputType) {
                 def raw(x0: U): U = f.applyAsLong(n, x0)
               }
-              new Lambda(self.names drop argCount, body, unboxedType,
+              new Lambda(self.names drop argCount, body,
                          Term.Apply(decompiled, term))
             case _ => sys.error("")
           }
-          case _ => sys.error("unpossible")
+          case _ => sys.error("can't underapply a function of 2 args with anything but 1 arg")
         }
     }
     name -> Return(lam)

--- a/runtime-jvm/main/src/main/scala/Param.scala
+++ b/runtime-jvm/main/src/main/scala/Param.scala
@@ -122,7 +122,7 @@ object Value {
       Some((l.arity, l.body, l.decompile))
 
     val identity: Lambda1 = {
-      val c: Computation = (r,rec,top,stackU,x1,x0,stackB,x1b,x0b) => {
+      val c: Computation.C1P = (r,x0,x0b) => {
         r.boxed = x0b.toValue
         x0
       }

--- a/runtime-jvm/main/src/main/scala/Param.scala
+++ b/runtime-jvm/main/src/main/scala/Param.scala
@@ -59,7 +59,6 @@ object Value {
   class Lambda(
     final val names: List[Name],
     final val body: Computation,
-    final val unboxedType: Option[UnboxedType],
     // the lambda decompiled form may have one free var, referring to itself
     decompileWithPossibleFreeVar: Term) extends Value { self =>
 
@@ -81,14 +80,25 @@ object Value {
 
     def compose(f: Lambda): Lambda = {
       assert(arity == 1)
-      val k: Computation = (r, rec, top, stackU, x1, x0, stackB, x1b, x0b) => {
-        val v = evalLam(f,r,top,stackU,x1,x0,stackB,x1b,x0b)
-        val vb = r.boxed
-        self(r,top,stackU,U0,v,stackB,null,vb)
+
+      val k: Computation = (self.body, f.body) match {
+        case (left: Computation.C1U, right: Computation.C1U) =>
+          new compilation.Computation.C1U(left.outputType) {
+            def raw(x0: U): U = left.raw(right.raw(x0))
+          }
+        case (left: Computation.C1U, right: Computation.C2U) =>
+          new Computation.C2U(left.outputType) {
+            def raw(x1: U, x0: U): U = left.raw(right.raw(x1, x0))
+          }
+        case _ =>
+          (r, rec, top, stackU, x1, x0, stackB, x1b, x0b) => {
+            val v = evalLam(f,r,top,stackU,x1,x0,stackB,x1b,x0b)
+            val vb = r.boxed
+            self(r,top,stackU,U0,v,stackB,null,vb)
+          }
       }
       val compose = Term.Lam('f, 'g, 'x)('f.v('g.v('x))) // todo: intern this
-      new Lambda(f.names, k, self.unboxedType,
-                 compose(self.decompile, f.decompile))
+      new Lambda(f.names, k, compose(self.decompile, f.decompile))
     }
 
     def saturatedNonTailCall(args: List[Computation]): Computation =
@@ -112,10 +122,9 @@ object Value {
   object Lambda {
     final def toValue = this
 
-    def apply(arity: Int, body: Computation, unboxedType: Option[UnboxedType],
-              decompile: Term) = {
+    def apply(arity: Int, body: Computation, decompile: Term) = {
       new Lambda(names = decompile match { case Term.Lam(names, _) => names },
-                 body, unboxedType, decompile)
+                 body, decompile)
     }
 
     def unapply(l: Lambda): Option[(Int, Computation, Term)] =
@@ -126,23 +135,20 @@ object Value {
         r.boxed = x0b.toValue
         x0
       }
-      Lambda1("x", c, None, Term.Lam('x)('x))
+      Lambda1("x", c, Term.Lam('x)('x))
     }
 
     /** A `Lambda` of arity 1. */
     // todo: delete this and ClosureForming2 later
-    case class Lambda1(arg1: Name, _body: Computation,
-                       outputType: Option[UnboxedType], decompiled: Term)
-      extends Lambda(names = List(arg1),_body,outputType,decompiled) {
+    case class Lambda1(arg1: Name, _body: Computation, decompiled: Term)
+      extends Lambda(names = List(arg1),_body,decompiled) {
       override def underapply(builtins: Environment)(
         argCount: Arity, substs: Map[Name, Term]): Lambda =
         sys.error("a lambda with arity 1 cannot be underapplied")
     }
 
-    class ClosureForming(names: List[Name], body: Computation,
-                                  outputType: Option[UnboxedType],
-                                  decompiled: Term)
-        extends Lambda(names,body,outputType,decompiled) { self =>
+    class ClosureForming(names: List[Name], body: Computation, decompiled: Term)
+        extends Lambda(names,body,decompiled) { self =>
       val namesArray = names.toArray
 
       /** Underapply this `Lambda`, passing 1 argument (named `substName`). */
@@ -157,8 +163,16 @@ object Value {
         val body2: Computation = arity match {
           // stack passed to `body2`: [a]
           // stack passed to `body` : [arg,a]
-          case 2 => (r,rec,top,stackU,x1,x0,stackB,x1b,x0b) =>
-            body(r,rec,top,stackU,argv,x0,stackB,argvb,x0b)
+          case 2 =>
+            body match {
+              case c2u: Computation.C2U => new Computation.C1U(c2u.outputType) {
+                def raw(x0: U): U = c2u.raw(argv,x0)
+              }
+              case _ =>
+                (r,rec,top,stackU,x1,x0,stackB,x1b,x0b) =>
+                  body(r,rec,top,stackU,argv,x0,stackB,argvb,x0b)
+            }
+
           // stack passed to `body2`: [a,b]
           // stack passed to `body` : [arg,a,b]
           case 3 => (r,rec,top,stackU,x1,x0,stackB,x1b,x0b) => {
@@ -181,7 +195,7 @@ object Value {
             body(r,rec,top.inc,stackU,x1,x0,stackB,x1b,x0b)
           }
         }
-        new ClosureForming(names drop 1, body2, outputType, decompiled(substTerm))
+        new ClosureForming(names drop 1, body2, decompiled(substTerm))
       }
 
       // todo: try for more efficient implementation of underapply, O(n) vs n^2

--- a/runtime-jvm/main/src/main/scala/UnisonToScala.scala
+++ b/runtime-jvm/main/src/main/scala/UnisonToScala.scala
@@ -14,10 +14,8 @@ object UnisonToScala {
     require (f.arity == 1)
     f.body match {
       case body: Computation.C1U =>
-        env =>
-          val (stackU, stackB, top, r) = env
+        _env =>
           new Unboxed.F1[Param, Value] {
-            // todo: can I just call body.raw(u1) here instead of body.apply?
             def apply[x] = kvx => (u1,a,u2,x) => kvx(body.raw(u1), body.outputType, u2, x)
           }
       case _body =>
@@ -39,13 +37,12 @@ object UnisonToScala {
     require(f.arity == 2)
     f.body match {
       case body: Computation.C2U =>
-        env =>
-          val (stackU, stackB, top, r) = env
+        _env =>
           new Unboxed.F2[Param, Param, Value] {
             def apply[x] = kvx => (u1, a, u2, b, u3, x) => kvx(body.raw(u1, u2), body.outputType, u3, x)
           }
 
-      case body =>
+      case _body =>
         env =>
           val (stackU, stackB, top, r) = env
           new Unboxed.F2[Param, Param, Value] {

--- a/runtime-jvm/main/src/test/scala/CompilationTests.scala
+++ b/runtime-jvm/main/src/test/scala/CompilationTests.scala
@@ -157,7 +157,7 @@ object CompilationTests {
         }
 
       val lam = Term.Compiled(
-        new ClosureForming(List("a","b","c","d"), body, Some(UnboxedType.Int64), 42))
+        new ClosureForming(List("a","b","c","d"), body, 42))
       val p = Let('f -> lam(1))('f.v(2,3,4))
       val p2 = Let('f -> lam(1), 'g -> 'f.v(2))('g.v(3,4))
       val p3 = Let('f -> lam(1), 'g -> 'f.v(2), 'h -> 'g.v(3))('h.v(4))


### PR DESCRIPTION
This fixes the broken invariant that was causing https://trello.com/c/D1bb460e/57-streammap-runtime-error, and eliminates some unnecessary `r.boxed` writing for chains of primitive functions.