### PR TITLE
Patterns now checked against scrutinee type

### DIFF
--- a/parser-typechecker/src/Unison/ABT.hs
+++ b/parser-typechecker/src/Unison/ABT.hs
@@ -224,19 +224,39 @@ freshNamed' used n = fresh' used (v' n)
 -- | `subst v e body` substitutes `e` for `v` in `body`, avoiding capture by
 -- renaming abstractions in `body`
 subst :: (Foldable f, Functor f, Var v) => v -> Term f v a -> Term f v a -> Term f v a
-subst v r t2@(Term fvs ann body)
+subst v r t2 = subst' (const r) v (freeVars r) t2
+
+-- Slightly generalized version of `subst`, the replacement action is handled
+-- by the function `replace`, which is given the annotation `a` at the point
+-- of replacement. `r` should be the set of free variables contained in the
+-- term returned by `replace`. See `substInheritAnnotation` for an example usage.
+subst' :: (Foldable f, Functor f, Var v) => (a -> Term f v a) -> v -> Set v -> Term f v a -> Term f v a
+subst' replace v r t2@(Term fvs ann body)
   | Set.notMember v fvs = t2 -- subtrees not containing the var can be skipped
   | otherwise = case body of
-    Var v' | v == v' -> r    -- var match; perform replacement
+    Var v' | v == v' -> replace ann -- var match; perform replacement
            | otherwise -> t2 -- var did not match one being substituted; ignore
-    Cycle body -> cycle' ann (subst v r body)
+    Cycle body -> cycle' ann (subst' replace v r body)
     Abs x _ | x == v -> t2 -- x shadows v; ignore subtree
     Abs x e -> abs' ann x' e'
-      where x' = freshInBoth r t2 x
+      where x' = fresh t2 (fresh' r x)
             -- rename x to something that cannot be captured by `r`
-            e' = if x /= x' then subst v r (rename x x' e)
-                 else subst v r e
-    Tm body -> tm' ann (fmap (subst v r) body)
+            e' = if x /= x' then subst' replace v r (rename x x' e)
+                 else subst' replace v r e
+    Tm body -> tm' ann (fmap (subst' replace v r) body)
+
+-- Like `subst`, but the annotation of the replacement is inherited from
+-- the previous annotation at each replacement point.
+substInheritAnnotation :: (Foldable f, Functor f, Var v)
+                       => v -> Term f v b -> Term f v a -> Term f v a
+substInheritAnnotation v r t =
+  subst' (\ann -> const ann <$> r) v (freeVars r) t
+
+substsInheritAnnotation
+  :: (Foldable f, Functor f, Var v)
+  => [(v, Term f v b)] -> Term f v a -> Term f v a
+substsInheritAnnotation replacements body = foldr f body (reverse replacements) where
+  f (v, t) body = substInheritAnnotation v t body
 
 -- | `substs [(t1,v1), (t2,v2), ...] body` performs multiple simultaneous
 -- substitutions, avoiding capture
@@ -244,25 +264,6 @@ substs :: (Foldable f, Functor f, Var v)
        => [(v, Term f v a)] -> Term f v a -> Term f v a
 substs replacements body = foldr f body (reverse replacements) where
   f (v, t) body = subst v t body
-
--- | `replace f t body` substitutes `t` for all maximal (outermost)
--- subterms matching the predicate `f` in `body`, avoiding capture.
-replace :: (Foldable f, Functor f, Var v)
-        => (Term f v a -> Bool)
-        -> Term f v a
-        -> Term f v a
-        -> Term f v a
-replace f t body | f body = t
-replace f t t2@(Term _ ann body) = case body of
-  Var v -> annotatedVar ann v
-  Cycle body -> cycle' ann (replace f t body)
-  Abs x e | f (annotatedVar ann x) -> abs' ann x e
-  Abs x e -> abs' ann x' e'
-    where x' = freshInBoth t t2 x
-          -- rename x to something that cannot be captured by `t`
-          e' = if x /= x' then replace f t (rename x x' e)
-               else replace f t e
-  Tm body -> tm' ann (fmap (replace f t) body)
 
 rebuildUp :: (Ord v, Foldable f, Functor f)
           => (f (Term f v a) -> f (Term f v a))
@@ -281,27 +282,27 @@ rebuildUp f (Term _ ann body) = case body of
 -- `visit (const Nothing) t == pure t` and
 -- `visit (const (Just (pure t2))) t == pure t2`
 visit :: (Traversable f, Applicative g, Ord v)
-      => (Term f v () -> Maybe (g (Term f v ())))
-      -> Term f v ()
-      -> g (Term f v ())
+      => (Term f v a -> Maybe (g (Term f v a)))
+      -> Term f v a
+      -> g (Term f v a)
 visit f t = case f t of
   Just gt -> gt
   Nothing -> case out t of
     Var _ -> pure t
-    Cycle body -> cycle <$> visit f body
-    Abs x e -> abs x <$> visit f e
-    Tm body -> tm <$> traverse (visit f) body
+    Cycle body -> cycle' (annotation t) <$> visit f body
+    Abs x e -> abs' (annotation t) x <$> visit f e
+    Tm body -> tm' (annotation t) <$> traverse (visit f) body
 
 -- | Apply an effectful function to an ABT tree top down, sequencing the results.
 visit' :: (Traversable f, Applicative g, Monad g, Ord v)
-       => (f (Term f v ()) -> g (f (Term f v ())))
-       -> Term f v ()
-       -> g (Term f v ())
+       => (f (Term f v a) -> g (f (Term f v a)))
+       -> Term f v a
+       -> g (Term f v a)
 visit' f t = case out t of
   Var _ -> pure t
-  Cycle body -> cycle <$> visit' f body
-  Abs x e -> abs x <$> visit' f e
-  Tm body -> f body >>= \body -> tm <$> traverse (visit' f) body
+  Cycle body -> cycle' (annotation t) <$> visit' f body
+  Abs x e -> abs' (annotation t) x <$> visit' f e
+  Tm body -> f body >>= \body -> tm' (annotation t) <$> traverse (visit' f) body
 
 data Subst f v a =
   Subst { freshen :: forall m v' . Monad m => (v -> m v') -> m v'

--- a/parser-typechecker/src/Unison/Term.hs
+++ b/parser-typechecker/src/Unison/Term.hs
@@ -102,7 +102,10 @@ bindBuiltins termBuiltins typeBuiltins =
 vmap :: Ord v2 => (v -> v2) -> AnnotatedTerm v a -> AnnotatedTerm v2 a
 vmap f = ABT.vmap f . typeMap (ABT.vmap f)
 
-typeMap :: Ord v2 => (Type v -> Type v2) -> AnnotatedTerm v a -> ABT.Term (F v2) v a
+vtmap :: Ord vt2 => (vt -> vt2) -> AnnotatedTerm' vt v a -> AnnotatedTerm' vt2 v a
+vtmap f = typeMap (ABT.vmap f)
+
+typeMap :: Ord vt2 => (Type vt -> Type vt2) -> AnnotatedTerm' vt v a -> ABT.Term (F vt2) v a
 typeMap f t = go t where
   go (ABT.Term fvs a t) = ABT.Term fvs a $ case t of
     ABT.Abs v t -> ABT.Abs v (go t)

--- a/parser-typechecker/src/Unison/Term.hs
+++ b/parser-typechecker/src/Unison/Term.hs
@@ -169,43 +169,43 @@ fresh = ABT.fresh
 
 -- some smart constructors
 
-var :: v -> Term v
+var :: v -> Term' vt v
 var = ABT.var
 
-var' :: Var v => Text -> Term v
+var' :: Var v => Text -> Term' vt v
 var' = var . ABT.v'
 
-derived :: Ord v => Hash -> Term v
+derived :: Ord v => Hash -> Term' vt v
 derived = ref . Reference.Derived
 
-derived' :: Ord v => Text -> Maybe (Term v)
+derived' :: Ord v => Text -> Maybe (Term' vt v)
 derived' base58 = derived <$> Hash.fromBase58 base58
 
-ref :: Ord v => Reference -> Term v
+ref :: Ord v => Reference -> Term' vt v
 ref r = ABT.tm (Ref r)
 
-builtin :: Ord v => Text -> Term v
+builtin :: Ord v => Text -> Term' vt v
 builtin n = ref (Reference.Builtin n)
 
-float :: Ord v => Double -> Term v
+float :: Ord v => Double -> Term' vt v
 float d = ABT.tm (Float d)
 
-boolean :: Ord v => Bool -> Term v
+boolean :: Ord v => Bool -> Term' vt v
 boolean b = ABT.tm (Boolean b)
 
-int64 :: Ord v => Int64 -> Term v
+int64 :: Ord v => Int64 -> Term' vt v
 int64 d = ABT.tm (Int64 d)
 
-uint64 :: Ord v => Word64 -> Term v
+uint64 :: Ord v => Word64 -> Term' vt v
 uint64 d = ABT.tm (UInt64 d)
 
-text :: Ord v => Text -> Term v
+text :: Ord v => Text -> Term' vt v
 text = ABT.tm . Text
 
-blank :: Ord v => Term v
+blank :: Ord v => Term' vt v
 blank = ABT.tm Blank
 
-app :: Ord v => Term v -> Term v -> Term v
+app :: Ord v => Term' vt v -> Term' vt v -> Term' vt v
 app f arg = ABT.tm (App f arg)
 
 match :: Ord v => Term v -> [MatchCase (Term v)] -> Term v
@@ -220,31 +220,31 @@ and x y = ABT.tm (And x y)
 or :: Ord v => Term v -> Term v -> Term v
 or x y = ABT.tm (Or x y)
 
-constructor :: Ord v => Reference -> Int -> Term v
+constructor :: Ord v => Reference -> Int -> Term' vt v
 constructor ref n = ABT.tm (Constructor ref n)
 
-apps :: Ord v => Term v -> [Term v] -> Term v
+apps :: Ord v => Term' vt v -> [Term' vt v] -> Term' vt v
 apps f = foldl' app f
 
-iff :: Ord v => Term v -> Term v -> Term v -> Term v
+iff :: Ord v => Term' vt v -> Term' vt v -> Term' vt v -> Term' vt v
 iff cond t f = ABT.tm (If cond t f)
 
-ann :: Ord v => Term v -> Type v -> Term v
+ann :: Ord v => Term' vt v -> Type vt -> Term' vt v
 ann e t = ABT.tm (Ann e t)
 
-vector :: Ord v => [Term v] -> Term v
+vector :: Ord v => [Term' vt v] -> Term' vt v
 vector es = ABT.tm (Vector (Vector.fromList es))
 
-vector' :: Ord v => Vector (Term v) -> Term v
+vector' :: Ord v => Vector (Term' vt v) -> Term' vt v
 vector' es = ABT.tm (Vector es)
 
-lam :: Ord v => v -> Term v -> Term v
+lam :: Ord v => v -> Term' vt v -> Term' vt v
 lam v body = ABT.tm (Lam (ABT.abs v body))
 
-lam' :: Var v => [Text] -> Term v -> Term v
+lam' :: Var v => [Text] -> Term' vt v -> Term' vt v
 lam' vs body = foldr lam body (map ABT.v' vs)
 
-lam'' :: Ord v => [v] -> Term v -> Term v
+lam'' :: Ord v => [v] -> Term' vt v -> Term' vt v
 lam'' vs body = foldr lam body vs
 
 -- | Smart constructor for let rec blocks. Each binding in the block may
@@ -262,18 +262,18 @@ letRec' bs e = letRec [(ABT.v' name, b) | (name,b) <- bs] e
 -- | Smart constructor for let blocks. Each binding in the block may
 -- reference only previous bindings in the block, not including itself.
 -- The output expression may reference any binding in the block.
-let1 :: Ord v => [(v,Term v)] -> Term v -> Term v
+let1 :: Ord v => [(v,Term' vt v)] -> Term' vt v -> Term' vt v
 let1 bindings e = foldr f e bindings
   where
     f (v,b) body = ABT.tm (Let b (ABT.abs v body))
 
-let1' :: Var v => [(Text,Term v)] -> Term v -> Term v
+let1' :: Var v => [(Text, Term' vt v)] -> Term' vt v -> Term' vt v
 let1' bs e = let1 [(ABT.v' name, b) | (name,b) <- bs ] e
 
-effectPure :: Ord v => Term v -> Term v
+effectPure :: Ord v => Term' vt v -> Term' vt v
 effectPure t = ABT.tm (EffectPure t)
 
-effectBind :: Ord v => Reference -> Int -> [Term v] -> Term v -> Term v
+effectBind :: Ord v => Reference -> Int -> [Term' vt v] -> Term' vt v -> Term' vt v
 effectBind r cid args k = ABT.tm (EffectBind r cid args k)
 
 unLet1 :: Var v => AnnotatedTerm' vt v a -> Maybe (AnnotatedTerm' vt v a, ABT.Subst (F vt) v a)

--- a/parser-typechecker/src/Unison/Typechecker.hs
+++ b/parser-typechecker/src/Unison/Typechecker.hs
@@ -108,7 +108,7 @@ synthesize
   -> Term v
   -> Noted f (Type v)
 synthesize typeOf decl t =
-  ABT.vmap TypeVar.underlying <$> Context.synthesizeClosed typeOf decl t
+  ABT.vmap TypeVar.underlying <$> Context.synthesizeClosed typeOf decl (Term.vtmap TypeVar.Universal t)
 
 -- | Infer the type of a 'Unison.Syntax.Term', assumed
 -- not to contain any @Ref@ constructors

--- a/unison-src/test1.u
+++ b/unison-src/test1.u
@@ -4,7 +4,7 @@ type Optional a = None | Some a
 Optional.isEmpty : ∀ a . Optional a -> Boolean
 Optional.isEmpty o = case o of
   Optional.None -> true
-  _ -> false
+  Optional.Some _ -> false
 
 increment x = x +_UInt64 1
 


### PR DESCRIPTION
Without this PR, you could write things like:

```Haskell
case 42 of
  Optional.None -> true
  Optional.Some _ -> false
```

and it would still typecheck. Now, you'll get a type error as expected. Yay! (Error messages are terrible though - we will need to do a pass to improve that)

The main change is [here](https://github.com/unisonweb/unison/compare/topic/typechecker...wip/pattern-typechecking?expand=1#diff-ba491a6b28216fbef57af9bf084d0d5cR625), just adding an `Term.ann patTerm scrutineeType`, where before we just had the `patTerm` without any annotation.

In order to make this possible, there were a bunch of rather mechanical changes:

* We were using the `Term v` type alias everywhere, which has a single type parameter `v`, which is the type of both _term variables_ (like you see in the body of a lambda) and _type variables_ (like you see in a `forall` that is attached to a term as a type annotation). This requirement that both kinds of variables be of the same type needed to be relaxed.
  * [`Term v`](https://github.com/unisonweb/unison/blob/88d62e43c4e936dae2a8eec8e3ec019129d38132/parser-typechecker/src/Unison/Term.hs#L94) is an alias for `ABT.Term (Term.F v) v ()` - an annotated ABT where the annotation is `()` and the term and type variables are the same - `v`.
  * There is the alias `Term' vt v`, which allows the `vt` (variable type used for types appearing in term annotations) and `v` (used for term variables) to be different.
  * And there is the alias `AnnotatedTerm' vt v a` which is like `Term' vt v` but has `a` as the annotation type at each node in the ABT.
* So I moved to using `Term' vt v` or `AnnotatedTerm' vt v a` everywhere. There were a bunch of random helper functions and smart constructors that needed updating / more general type signatures.
* Locally within the typechecker, I define the alias [`Term v = Term' (TypeVar v) v`](https://github.com/unisonweb/unison/compare/topic/typechecker...wip/pattern-typechecking?expand=1#diff-ba491a6b28216fbef57af9bf084d0d5cR49). That is, the typechecker is expecting terms whose type annotations can have existential or universal type vars. Using this type alias means that none of the type signatures in the typechecker needed to change and you can see the diff in that file is pretty small.
* Then I just fixed all the type errors.