### PR TITLE
use updated body of synthesized UnisonFile when serializing

### DIFF
--- a/parser-typechecker/bootstrap/Bootstrap.hs
+++ b/parser-typechecker/bootstrap/Bootstrap.hs
@@ -36,11 +36,11 @@ main = do
   case args of
     [sourceFile, outputFile] -> do
       unisonFile <- Parsers.unsafeReadAndParseFile Parser.penv0 sourceFile
-      let r = FileParsers.synthesizeFile unisonFile
-          f typ = do
+      let r = FileParsers.synthesizeUnisonFile unisonFile
+          f (unisonFile', typ) = do
             putStrLn ("typechecked as " ++ show typ)
-            let bs = runPutS $ flip evalStateT 0 $ Codecs.serializeFile unisonFile
+            let bs = runPutS $ flip evalStateT 0 $ Codecs.serializeFile unisonFile'
             BS.writeFile outputFile bs
-      either (putStrLn . show) (f . snd) r
+      either (putStrLn . show) f r
 
     _ -> putStrLn "usage: bootstrap <in-file.u> <out-file.ub>"


### PR DESCRIPTION
`FileParsers.synthesizeFile` was picking apart a `UnisonFile `, updating its `term` by substing the free vars for builtins, and then returning the new term and synthesized type.  

Bootstrap.hs was using that `synthesizeFile` to typecheck the `UnisonFile` sub, but then serialized the original `UnisonFile` which had the free vars.

This PR introduces a `synthesizeUnisonFile`, which produces an updated `UnisonFile` instead of an updated  `Term`, and updates Bootstrap to serialize the resulting `UnisonFile`.