### PR TITLE
Some progress..

### DIFF
--- a/parser-typechecker/src/Unison/ABT.hs
+++ b/parser-typechecker/src/Unison/ABT.hs
@@ -394,6 +394,6 @@ instance (Show1 f, Var v) => Show (Term f v a) where
   -- annotations not shown
   showsPrec p (Term _ _ out) = case out of
     Var v -> (show v ++)
-    Cycle body -> showsPrec p body
+    Cycle body -> ("Cycle " ++) . showsPrec p body
     Abs v body -> showParen True $ (Text.unpack (Var.shortName v) ++) . showString ". " . showsPrec p body
     Tm f -> showsPrec1 p f

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -683,7 +683,9 @@ synthesize e = scope ("synth: " ++ show e) $ go (minimize' e)
     tbinding <- synthesize binding
     v' <- ABT.freshen e freshenVar
     appendContext (context [Ann v' tbinding])
-    synthesize (ABT.bind e (Term.var v'))
+    t <- synthesize (ABT.bind e (Term.var v'))
+    modifyContext (retract (Ann v' tbinding))
+    pure t
   --  -- TODO: figure out why this retract sometimes generates invalid contexts,
   --  -- (ctx, ctx2) <- breakAt (Ann v' tbinding) <$> getContext
   --  -- as in (f -> let x = (let saved = f in 42) in 1)

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -584,7 +584,6 @@ check e t = getContext >>= \ctx -> scope ("check: " ++ show e ++ ":   " ++ show 
       go _ _ = do -- Sub
         a <- synthesize e; ctx <- getContext
         subtype (apply ctx a) (apply ctx t)
-      -- (as, t') = Type.stripEffect t
     in go (minimize' e) t
   else
     scope ("context: " ++ show ctx) .

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -640,8 +640,9 @@ synthesize e = scope ("synth: " ++ show e) $ go (minimize' e)
     Nothing -> fail $ "type not known for term var: " ++ Text.unpack (Var.name v)
     Just t -> pure t
   go Term.Blank' = do
-    v <- freshVar
-    pure $ Type.forall (TypeVar.Universal v) (Type.universal v)
+    v <- freshNamed "_"
+    appendContext $ context [Existential v]
+    pure $ Type.existential v -- forall (TypeVar.Universal v) (Type.universal v)
   go (Term.Ann' (Term.Ref' _) t) = case ABT.freeVars t of
     s | Set.null s ->
       -- innermost Ref annotation assumed to be correctly provided by `synthesizeClosed`

--- a/parser-typechecker/tests/Unison/Test/Typechecker.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker.hs
@@ -313,6 +313,25 @@ test = scope "typechecker" . tests $
              |
              |()
              |]
+  , checks [r|--map/traverse
+             |effect Noop where
+             |  noop : ∀ a . a -> {Noop} a
+             |
+             |type List a = Nil | Cons a (List a)
+             |
+             |map : ∀ a b . (a -> b) -> List a -> List b
+             |map f as = case as of
+             |  List.Nil -> List.Nil
+             |  List.Cons h t -> List.Cons (f h) (map f t)
+             |
+             |c = List.Cons
+             |z = List.Nil
+             |
+             |ex = (c 1 (c 2 (c 3 z)))
+             |
+             |()
+             |-- map (a -> Noop.noop a)
+             |]
   ]
   where c tm typ = scope tm . expect $ check (stripMargin tm) typ
         bombs s = scope s (expect . not . fileTypechecks $ s)

--- a/parser-typechecker/tests/Unison/Test/Typechecker.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker.hs
@@ -298,6 +298,8 @@ test = scope "typechecker" . tests $
              |    IO.launch-missiles() -- OK, since declared by `inc-by` signature
              |    y = State.get()
              |    State.put (y +_Int64 i)
+             |    -- not sure why, but putting the `()` as the body causes test to pass
+             |    ()
              |  ()
              |
              |()

--- a/parser-typechecker/tests/Unison/Test/Typechecker.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker.hs
@@ -129,7 +129,7 @@ test = scope "typechecker" . tests $
              |id x = x
              |
              |r13 : (UInt64, Text)
-             |r13 = let
+             |r13 =
              |  id = ((x -> x): forall a . a -> a)
              |  (id 10, id "foo")
              |

--- a/parser-typechecker/tests/Unison/Test/Typechecker.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker.hs
@@ -228,7 +228,6 @@ test = scope "typechecker" . tests $
              |
              |ex1d = handle (state 42) in 49
              |
-             |-- this fails - something busted with inference of `handle` blocks
              |ex2 = handle (state 42) in State.get ()
              |
              |ex3 : (UInt64, UInt64)
@@ -298,8 +297,6 @@ test = scope "typechecker" . tests $
              |    IO.launch-missiles() -- OK, since declared by `inc-by` signature
              |    y = State.get()
              |    State.put (y +_Int64 i)
-             |    -- not sure why, but putting the `()` as the body causes test to pass
-             |    ()
              |  ()
              |
              |()


### PR DESCRIPTION
@runarorama we were missing a case in `check`:

``` haskell
      go (Term.Lam' body) (Type.Arrow' i o) = do -- =>I
        x <- ABT.freshen body freshenVar
        modifyContext' (extend (Ann x i))
        let Type.Effect'' es _ = o
        scope ("pushing effects: " ++ show es) . withEffects0 es $ check (ABT.bind body (Term.var x)) o
        modifyContext (retract (Ann x i))
```

So the body of the lambda gets access to the abilities introduced by the arrow type (and no other abilities - like it cannot access abilities from outer scopes). We'd talked about this IIRC.

We also had [this snippet, which I think was just wrong](https://github.com/unisonweb/unison/compare/wip/typechecker...pchiusano:wip/typechecker2?expand=1#diff-ba491a6b28216fbef57af9bf084d0d5cL582).

I got the tests passing after that and decided to write some more tests, which uncovered something very wonky I don't understand yet - this (incorrect) program somehow typechecks (you can run via `stack exec tests "typechecker.--Type.apply"):

```Haskell
  , bombs [r|--Type.apply
            |type List a = Nil | Cons a (List a)
            |
            |map : ∀ a b . (a -> b) -> List a -> List b
            |map f as = case as of
            |  List.Nil -> List.Nil
            |  List.Cons h t -> List.Cons h (map f t) -- should not typecheck, missing (f h)
            |
            |-- definitely should not typecheck!
            |map2 : ∀ a . a
            |map2 = map
            |
            |c = List.Cons
            |z = List.Nil
            |
            |ex = c 1 (c 2 (c 3 z))
            |
            |pure-map : List Int64 -- should fail, output is a `List Text`
            |pure-map = map (a -> "hi") ex
            |
            |()
            |]
```