### PR TITLE
Fix remaining bugs re: effect checking and add nullary effects

### DIFF
--- a/parser-typechecker/src/Unison/Type.hs
+++ b/parser-typechecker/src/Unison/Type.hs
@@ -73,10 +73,6 @@ arity (ForallNamed' _ body) = arity body
 arity (Arrow' _ o) = 1 + arity o
 arity _ = 0
 
-unEffect0 :: Type v -> ([Type v], Type v)
-unEffect0 (Effect' es t) = (es, t)
-unEffect0 t = ([], t)
-
 -- some smart patterns
 pattern Ref' r <- ABT.Tm' (Ref r)
 pattern Arrow' i o <- ABT.Tm' (Arrow i o)
@@ -85,7 +81,7 @@ pattern Ann' t k <- ABT.Tm' (Ann t k)
 pattern App' f x <- ABT.Tm' (App f x)
 pattern Apps' f args <- (unApps -> Just (f, args))
 pattern Effect' es t <- ABT.Tm' (Effect es t)
-pattern Effect'' es t <- (unEffect0 -> (es, t))
+pattern Effect'' es t <- (stripEffect -> (es, t))
 pattern Forall' subst <- ABT.Tm' (Forall (ABT.Abs' subst))
 pattern ForallNamed' v body <- ABT.Tm' (Forall (ABT.out -> ABT.Abs v body))
 pattern Var' v <- ABT.Var' v
@@ -211,7 +207,7 @@ effectV e t = apps (builtin "Effect") [e, t]
 
 -- Strips effects from a type. E.g. `{e} a` becomes `a`.
 stripEffect :: Type v -> ([Type v], Type v)
-stripEffect (Effect' e t) = (e, t)
+stripEffect (Effect' e t) = case stripEffect t of (ei, t) -> (e ++ ei, t)
 stripEffect t = ([], t)
 
 -- The type of the flipped function application operator:

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -598,9 +598,10 @@ check e t = getContext >>= \ctx ->
         appendContext $ context [Existential e, Existential i]
         check h $ Type.effectV (Type.existential e) (Type.existential i) `Type.arrow` t
         ctx <- getContext
-        withEffects [Type.existential e] $ do
+        withEffects [apply ctx $ Type.existential e] $ do
           ambient <- getAbilities
-          check body (apply ctx (Type.effect ambient (Type.existential i)))
+          let (_, i') = Type.stripEffect (apply ctx (Type.existential i))
+          check body (Type.effect ambient i')
       go _ _ = do -- Sub
         a <- synthesize e; ctx <- getContext
         subtype (apply ctx a) (apply ctx t)

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -48,7 +48,9 @@ import qualified Unison.Var as Var
 
 -- uncomment for debugging
 watch :: Show a => String -> a -> a
-watch msg a = trace (msg ++ ":  " ++ show a) a
+watch msg a =
+  let !r = trace (msg ++ ":  " ++ show a) a
+  in r
 
 -- | We deal with type variables annotated with whether they are universal or existential
 type Type v = Type.Type (TypeVar v)
@@ -455,8 +457,8 @@ subtype tx ty = scope (show tx++" <: "++show ty) $
   go _ (Type.Effect'' es1 a1) (Type.Effect' es2 a2) = do
      subtype a1 a2
      ctx <- getContext
-     let !es1' = watch "es1'" $ map (apply ctx) es1
-         !es2' = watch "es2'" $ map (apply ctx) es2
+     let es1' = map (apply ctx) es1
+         es2' = map (apply ctx) es2
      abilityCheck' es2' es1'
   go _ _ _ = fail "not a subtype"
 
@@ -860,7 +862,6 @@ synthesizeApp ft arg = scope ("synthesizeApp: " ++ show ft ++ ", " ++ show arg) 
     let soln = Type.Monotype (Type.existential i `Type.arrow` Type.existential o)
     let ctxMid = context [Existential o, Existential i, Solved a soln]
     modifyContext' $ replace (Existential a) ctxMid
-    logContext "synthesizeApp (Existential)"
     scope "a^App" $ (Type.existential o <$ check arg (Type.existential i))
   go _ = scope "unable to synthesize type of application" $
          scope ("function type: " ++ show ft) $

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -483,7 +483,7 @@ instantiateL v t = getContext >>= \ctx -> case Type.monotype t >>= trace "L" (so
       ctx <- getContext
       instantiateL o' (apply ctx o)
     Type.App' x y -> do -- analogue of InstLArr
-      [x', y'] <- traverse freshenVar [ABT.v' "x", ABT.v' "yyyy"]
+      [x', y'] <- traverse freshenVar [ABT.v' "x", ABT.v' "y"]
       let s = Solved v (Type.Monotype (Type.app (Type.existential x') (Type.existential y')))
       modifyContext' $ replace (Existential v) (context [Existential y', Existential x', s])
       ctx0 <- getContext
@@ -491,7 +491,7 @@ instantiateL v t = getContext >>= \ctx -> case Type.monotype t >>= trace "L" (so
       instantiateL y' (apply ctx' y)
     Type.Effect' es vt -> do
       es' <- replicateM (length es) (freshNamed "eeee")
-      vt' <- freshNamed "vtttt"
+      vt' <- freshNamed "vt"
       let s = Solved v (Type.Monotype (Type.effect (Type.existential <$> es') (Type.existential vt')))
       modifyContext' $ replace (Existential v) (context $ (Existential <$> es') ++ [Existential vt', s])
       Foldable.for_ (es' `zip` es) $ \(e',e) -> do

--- a/parser-typechecker/tests/Unison/Test/Typechecker.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker.hs
@@ -172,11 +172,14 @@ test = scope "typechecker" . tests $
              |  put : ∀ se . se -> {State se} ()
              |  get : ∀ se . () -> {State se} se
              |
+             |-- state : ∀ s a . s -> Effect (State s) a -> (s, a)
              |state woot eff = case eff of
+             |  { State.put snew -> k } -> handle (state snew) in k ()
              |  { State.get () -> k } -> handle state woot in k woot
-             |  { State.put snew -> k } -> handle (state snew) in (k ())
              |  { a } -> (woot, a)
              |
+             |blah : ∀ s a . s -> Effect (State s) a -> (s, a)
+             |blah = state
              |()
              |]
    , checks [r|--State1a effect

--- a/parser-typechecker/tests/Unison/Test/Typechecker.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker.hs
@@ -266,7 +266,7 @@ test = scope "typechecker" . tests $
              |]
   , bombs  [r|--IO/State1 effect
              |effect IO where
-             |  launch-missiles : () -> {IO} ()
+             |  launch-missiles : {IO} ()
              |
              |effect State se2 where
              |  put : ∀ se . se -> {State se} ()
@@ -278,7 +278,7 @@ test = scope "typechecker" . tests $
              |-- them explicitly
              |  inc-by : Int64 -> {State Int} ()
              |  inc-by i =
-             |    launch-missiles() -- not allowed
+             |    launch-missiles -- not allowed
              |    y = State.get()
              |    State.put (y +_Int64 i)
              |  ()
@@ -287,18 +287,18 @@ test = scope "typechecker" . tests $
              |]
   , checks [r|--IO/State2 effect
              |effect IO where
-             |  launch-missiles : () -> {IO} ()
+             |  launch-missiles : {IO} ()
              |
              |effect State se2 where
              |  put : ∀ se . se -> {State se} ()
-             |  get : ∀ se . () -> {State se} se
+             |  get : ∀ se . {State se} se
              |
              |foo : () -> {IO} ()
              |foo unit =
              |  inc-by : Int64 -> {IO, State Int64} ()
              |  inc-by i =
-             |    IO.launch-missiles() -- OK, since declared by `inc-by` signature
-             |    y = State.get()
+             |    IO.launch-missiles -- OK, since declared by `inc-by` signature
+             |    y = State.get
              |    State.put (y +_Int64 i)
              |  ()
              |

--- a/parser-typechecker/tests/Unison/Test/Typechecker.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker.hs
@@ -185,13 +185,13 @@ test = scope "typechecker" . tests $
    , checks [r|--State1a effect
              |effect State se2 where
              |  put : ∀ se . se -> {State se} ()
-             |  get : ∀ se . () -> {State se} se
+             |  get : ∀ se . {State se} se
              |
              |id : Int64 -> Int64
              |id i = i
              |
              |foo : () -> {State Int64} Int64
-             |foo unit = id (State.get() +_Int64 State.get())
+             |foo unit = id (State.get +_Int64 State.get)
              |
              |()
              |]

--- a/parser-typechecker/tests/Unison/Test/Typechecker.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker.hs
@@ -360,8 +360,9 @@ test = scope "typechecker" . tests $
              |zappy : () -> {Noop} (List UInt64)
              |zappy u = map (zap -> (Noop.noop zap +_UInt64 1)) ex
              |
-             |--zappy2 : () -> {Noop, Noop2} (List UInt64)
-             |--zappy2 u = map (zap -> Noop.noop zap +_UInt64 Noop2.noop2 2 7) ex
+             |zappy2 : () -> {Noop, Noop2} (List UInt64)
+             |zappy2 u = map (zap -> Noop.noop zap +_UInt64 Noop2.noop2 2 7) ex
+             |
              |()
              |]
   ]


### PR DESCRIPTION
This PR is a bit of a mess, but wanted to get all the latest stuff merged. Tests all pass and I haven't been able to find any more typechecking bugs. A change is that existentials can now be instantiated to effect types - we didn't have logic for this before which was resulting in counterintuitive ability check failures. There was also an issue with checking of `EffectBind r cid args k` - the `k` continuation in an effect bind should be of the form `exists a . a -> {e} a` for the same effect type as is produced by the constructor.

Also this works now:

```Haskell
effect IO where 
  launch-missiles : {IO} ()

foo : () -> {IO} ()
foo unused = IO.launch-missiles -- no parens needed!
```

If you don't want to evaluate `IO.launch-missiles`,  you have to guard it with a lambda.