### PR TITLE
bump sbt version to 1.1.2, restoring incremental compilation

### DIFF
--- a/development.markdown
+++ b/development.markdown
@@ -9,12 +9,21 @@ Launch `sbt` in `runtime-jvm` directory, then here are various useful commands:
 * `main/test:run 102932 compilation.let3` - runs tests prefixed by `"compilation.let3"` with the random seed 102932
 * `benchmark/run` - presents menu of benchmarks to run
 * `;clean;coverage;main/test:run;coverageReport` followed optionally by `;coverageOff` - generates test coverage report
-* `one-jar` - builds a single jar for a project
-  * Then `java -jar runtime-jvm/main/target/scala-2.12/unison-runtime_2.12-0.1-SNAPSHOT-one-jar.jar` to run the interpreter.
+* `main/compile` - builds the interpreter
+* `main/run` - builds and runs the interpreter
 
 The runtime doesn't build with JDK 10 at the moment, but this will work:
 ```bash
 JAVA_HOME=`/usr/libexec/java_home -v 9` sbt <commands ...>
+```
+
+To run the built interpreter without booting sbt:
+```bash
+scala -cp main/target/scala-2.12/classes org.unisonweb.Bootstrap test.ub
+```
+or from the project root directory:
+```bash
+scala -cp runtime-jvm/main/target/scala-2.12/classes org.unisonweb.Bootstrap test.ub
 ```
 
 ## Haskell

--- a/runtime-jvm/build.sbt
+++ b/runtime-jvm/build.sbt
@@ -14,7 +14,7 @@ lazy val commonSettings = Seq(
     //"-XX:LiveNodeCountInliningCutoff"
   ),
   organization := "org.unisonweb",
-  scalaVersion := "2.12.4",
+  scalaVersion := "2.12.6",
   scalacOptions ++= Seq(
     "-feature",
     "-deprecation",
@@ -57,7 +57,6 @@ lazy val root = project.in(file(".")).
 lazy val main = project.in(file("main"))
   .settings(commonSettings)
   .settings(name := "unison-runtime")
-  .settings(com.github.retronym.SbtOneJar.oneJarSettings)
 
 lazy val benchmark = project.in(file("benchmark"))
   .settings(commonSettings)

--- a/runtime-jvm/project/build.properties
+++ b/runtime-jvm/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.1.2

--- a/runtime-jvm/project/plugins.sbt
+++ b/runtime-jvm/project/plugins.sbt
@@ -4,4 +4,3 @@ scalacOptions ++= Seq(
 )
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
-addSbtPlugin("org.scala-sbt.plugins" % "sbt-onejar" % "0.8")


### PR DESCRIPTION
removed sbt-onejar plugin as it isn't yet compatible
https://github.com/sbt/sbt-onejar/issues/35

and updated development.markdown