### PR TITLE
runtime FileCompilationTests

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -119,6 +119,7 @@ builtins = Map.fromList $
 
       , ("Stream.empty", "forall a . Stream a")
       , ("Stream.from-int64", "Int64 -> Stream Int64")
+      , ("Stream.from-uint64", "UInt64 -> Stream UInt64")
       , ("Stream.cons", "forall a . a -> Stream a -> Stream a")
       , ("Stream.take", "forall a . UInt64 -> Stream a -> Stream a")
       , ("Stream.drop", "forall a . UInt64 -> Stream a -> Stream a")

--- a/runtime-jvm/benchmark/src/main/scala/CompilationBenchmarks.scala
+++ b/runtime-jvm/benchmark/src/main/scala/CompilationBenchmarks.scala
@@ -73,7 +73,7 @@ object CompilationBenchmarks {
 
         val env = (new Array[U](20), new Array[B](20), StackPtr.empty, Result())
         profile("triangle stream .foldLeft(plusU)") {
-          Stream.fromUnison(0).take(N(triangleCount))
+          Stream.fromInt64(0).take(N(triangleCount))
             .foldLeft(Value(0))(plusU(env)) match {
             case Value.Unboxed(n, _) => n
           }

--- a/runtime-jvm/build.sbt
+++ b/runtime-jvm/build.sbt
@@ -1,18 +1,4 @@
 lazy val commonSettings = Seq(
-  fork := true,
-  javaOptions in run ++= Seq(
-    // https://docs.oracle.com/javase/8/embedded/develop-apps-platforms/codecache.htm
-//    "-XX:+UnlockDiagnosticVMOptions",
-//    "-XX:+LogCompilation",
-    "-XX:InlineSmallCode=9001",
-    "-XX:MaxInlineLevel=35"
-    //"-XX:MaxInlineSize=9001"
-    //"-XX:CompileThreshold=10"
-    //"-XX:MinInliningThreshold=10"
-    //"-XX:FreqInlineSize"
-    //"-XX:MaxTrivialSize"
-    //"-XX:LiveNodeCountInliningCutoff"
-  ),
   organization := "org.unisonweb",
   scalaVersion := "2.12.6",
   scalacOptions ++= Seq(
@@ -62,6 +48,22 @@ lazy val benchmark = project.in(file("benchmark"))
   .settings(commonSettings)
   .settings(name := "unison-runtime-benchmark")
   .settings(scalacOptions += "-Xdisable-assertions")
+  .settings(
+    //  fork := true,
+    javaOptions in run ++= Seq(
+      // https://docs.oracle.com/javase/8/embedded/develop-apps-platforms/codecache.htm
+      //    "-XX:+UnlockDiagnosticVMOptions",
+      //    "-XX:+LogCompilation",
+      "-XX:InlineSmallCode=9001",
+      "-XX:MaxInlineLevel=35"
+      //"-XX:MaxInlineSize=9001"
+      //"-XX:CompileThreshold=10"
+      //"-XX:MinInliningThreshold=10"
+      //"-XX:FreqInlineSize"
+      //"-XX:MaxTrivialSize"
+      //"-XX:LiveNodeCountInliningCutoff"
+    )
+  )
   .settings(libraryDependencies +=
               scalaOrganization.value % "scala-reflect" % scalaVersion.value)
   .dependsOn(main % "compile->test")

--- a/runtime-jvm/main/src/main/scala/Bootstrap.scala
+++ b/runtime-jvm/main/src/main/scala/Bootstrap.scala
@@ -67,7 +67,7 @@ object Bootstrap {
   val UNISON_PROJECT_ROOT =
     new File(Option(System.getProperty(PROJECT_ROOT_ENV_NAME))
                .orElse(Option(System.getenv(PROJECT_ROOT_ENV_NAME)))
-               .getOrElse("../.."))
+               .getOrElse(".."))
 
   def normalizedFromTextFile(u: File,
                              stackDir: File = UNISON_PROJECT_ROOT

--- a/runtime-jvm/main/src/main/scala/Bootstrap.scala
+++ b/runtime-jvm/main/src/main/scala/Bootstrap.scala
@@ -1,13 +1,15 @@
 package org.unisonweb
 
+import java.io.File
+
 import org.unisonweb.ABT.Name
+import org.unisonweb.Term.Term
 import org.unisonweb.BuiltinTypes._
 import org.unisonweb.compilation._
 import org.unisonweb.util._
 
 object Bootstrap {
   def main(args: Array[String]): Unit = {
-    import Codecs._
 
     val fileName = args match {
       case Array(s) => s
@@ -15,7 +17,22 @@ object Bootstrap {
         println("usage: Bootstrap <file.ub>")
         sys.exit(1)
     }
-    val src = Source.fromFile(fileName)
+
+    println {
+      PrettyPrint.prettyTerm(normalizedFromBinaryFile(fileName)).render(80)
+    }
+  }
+
+  def normalizedFromBinaryFile(fileName: String): Term =
+    normalizedFromBinarySource(Source.fromFile(fileName))
+
+  def normalizedFromBinarySource(src: Source): Term = {
+    fromBinarySource(src, normalize(_)(_))
+  }
+
+  def fromBinarySource[A](src: Source, f: (Environment, Term) => A): A = {
+    import org.unisonweb.Codecs.{decodeConstructorArities, termDecoder}
+
     val data = decodeConstructorArities(src)
     val effects = decodeConstructorArities(src)
 
@@ -43,6 +60,47 @@ object Bootstrap {
         effects = Environment.standard.effects ++ effectss
       )
 
-    println(PrettyPrint.prettyTerm(normalize(env)(term)).render(80))
+    f(env, term)
+  }
+
+  val PROJECT_ROOT_ENV_NAME = "UNISON_PROJECT_ROOT"
+  val UNISON_PROJECT_ROOT =
+    new File(Option(System.getProperty(PROJECT_ROOT_ENV_NAME))
+               .orElse(Option(System.getenv(PROJECT_ROOT_ENV_NAME)))
+               .getOrElse("../.."))
+
+  def normalizedFromTextFile(u: File,
+                             stackDir: File = UNISON_PROJECT_ROOT
+                            ): Either[String,Term] = {
+    if (! new File(UNISON_PROJECT_ROOT, "stack.yaml").isFile) Left {
+      import java.nio.file.FileSystems
+      import java.nio.file.Path
+
+      val path: Path = FileSystems.getDefault.getPath(".").toAbsolutePath
+      s"""Expected to find `stack.yaml` in `$UNISON_PROJECT_ROOT` to `stack exec bootstrap`,
+         |but didn't. Specify the correct directory by setting a Java system property or
+         |system environment variable called `$PROJECT_ROOT_ENV_NAME`.
+         |Current directory is: $path"""
+        .stripMargin
+    }
+    else {
+      import sys.process._
+      val ub = File.createTempFile(u.getName, ".ub")
+      val stderrBuffer = new StringBuffer
+      val log = new ProcessLogger {
+        def buffer[T](f: => T): T = f
+        def out(s: => String): Unit = ()
+        def err(s: => String): Unit = {
+          stderrBuffer.append(s)
+          stderrBuffer.append("\n")
+          ()
+        }
+      }
+      val result =
+        Process(Seq("stack", "build"), stackDir) #&&
+          Process(Seq("stack", "exec", "bootstrap", u.toString, ub.toString)) ! log
+      if (result > 0) Left(stderrBuffer.toString)
+      else Right(normalizedFromBinaryFile(ub.toString))
+    }
   }
 }

--- a/runtime-jvm/main/src/main/scala/Builtins.scala
+++ b/runtime-jvm/main/src/main/scala/Builtins.scala
@@ -19,9 +19,12 @@ object Builtins {
     c0z("Stream.empty", Stream.empty[Value])
 
 
-  // Stream.fromInt : Integer -> Stream Integer
-  val Stream_fromInt = // Stream.iterate(unison 0)(Integer_inc)
-    fp_z("Stream.from-int64", "n", Stream.fromUnison)
+  // Stream.fromInt : Int64 -> Stream Integer
+  val Stream_fromInt64 =
+    fp_z("Stream.from-int64", "n", Stream.fromInt64)
+
+  val Stream_fromUInt64 =
+    fp_z("Stream.from-uint64", "n", Stream.fromUInt64)
 
   // Stream.cons : a -> Stream a -> Stream a
   val Stream_cons =
@@ -77,7 +80,8 @@ object Builtins {
 
   val streamBuiltins = Map(
     Stream_empty,
-    Stream_fromInt,
+    Stream_fromInt64,
+    Stream_fromUInt64,
     Stream_cons,
     Stream_drop,
     Stream_take,

--- a/runtime-jvm/main/src/main/scala/Term.scala
+++ b/runtime-jvm/main/src/main/scala/Term.scala
@@ -479,10 +479,12 @@ object Term {
 
     implicit class IntegerSyntax(val i: Int) extends AnyVal {
       def unsigned: Term = Unboxed(intToUnboxed(i), UnboxedType.UInt64)
+      def u: Term = unsigned
     }
 
     implicit class LongSyntax(val l: Long) extends AnyVal {
       def unsigned: Term = Unboxed(longToUnboxed(l), UnboxedType.UInt64)
+      def u: Term = unsigned
     }
 
     implicit def bool(b: Boolean): Term = Unboxed(boolToUnboxed(b), UnboxedType.Boolean)

--- a/runtime-jvm/main/src/main/scala/util/Stream.scala
+++ b/runtime-jvm/main/src/main/scala/util/Stream.scala
@@ -297,10 +297,16 @@ object Stream {
       () => { i += by; k(doubleToUnboxed(i),null) }
     }
 
-  final def fromUnison(n: Long): Stream[UnboxedType] =
+  final def fromInt64(n: Long): Stream[UnboxedType] =
     k => {
       var i = n - 1
       () => { i += 1; k(i, UnboxedType.Int64) }
+    }
+
+  final def fromUInt64(n: Long): Stream[UnboxedType] =
+    k => {
+      var i = n - 1
+      () => { i += 1; k(i, UnboxedType.UInt64) }
     }
 
   private final def iterate0[A](u0: U, a0: A)(f: F1[A,A]): Stream[A] = {

--- a/runtime-jvm/main/src/test/scala/AllTests.scala
+++ b/runtime-jvm/main/src/test/scala/AllTests.scala
@@ -8,8 +8,9 @@ object AllTests {
     DecompileTests.tests,
     UtilTests.tests,
     CompilationTests.tests,
+    FileCompilationTests.tests,
     CodecsTests.tests,
-    StreamTests.tests
+    StreamTests.tests,
   )
 }
 

--- a/runtime-jvm/main/src/test/scala/CompilationTests.scala
+++ b/runtime-jvm/main/src/test/scala/CompilationTests.scala
@@ -645,7 +645,7 @@ object CompilationTests {
                 100,
                 termFor(Builtins.Stream_map)(
                   termFor(Builtins.Int64_inc),
-                  termFor(Builtins.Stream_fromInt)(0)))
+                  termFor(Builtins.Stream_fromInt64)(0)))
             )
           ),
           scala.Stream.from(0).map(1+).take(100).foldLeft(0)(_+_)
@@ -982,6 +982,12 @@ object Terms {
       def <(t1: Term) = Builtins.termFor(Builtins.Int64_lt)(t0, t1)
       def >(t1: Term) = Builtins.termFor(Builtins.Int64_gt)(t0, t1)
     }
+  }
+
+  object Int64 {
+    import Builtins._
+    val + = termFor(Int64_add)
+    val inc = termFor(Int64_inc)
   }
 
   object Sequence {

--- a/runtime-jvm/main/src/test/scala/FileCompilationTests.scala
+++ b/runtime-jvm/main/src/test/scala/FileCompilationTests.scala
@@ -9,7 +9,7 @@ import org.unisonweb.util.PrettyPrint.prettyTerm
 
 object FileCompilationTests {
   import EasyTest._
-  val testFiles = new File("../../unison-src/tests").toPath
+  val testFiles = new File("../unison-src/tests").toPath
 
   val checkResultTests = Map[String, Term](
     "fib4" -> 2249999.u

--- a/runtime-jvm/main/src/test/scala/FileCompilationTests.scala
+++ b/runtime-jvm/main/src/test/scala/FileCompilationTests.scala
@@ -1,0 +1,50 @@
+package org.unisonweb
+
+import java.io.File
+import java.nio.file.{Files, Path}
+
+import org.unisonweb.Term.Syntax._
+import org.unisonweb.Term.Term
+import org.unisonweb.util.PrettyPrint.prettyTerm
+
+object FileCompilationTests {
+  import EasyTest._
+  val testFiles = new File("../../unison-src/tests").toPath
+
+  val checkResultTests = Map[String, Term](
+    "fib4" -> 2249999.u
+  )
+
+  def tests = suite("compilation.file")(
+    checkResultTests.toList.map((checkResult _).tupled) ++
+      uncheckedEvaluation: _*
+  )
+
+  def uncheckedEvaluation: Seq[Test[Unit]] = {
+    import scala.collection.JavaConverters._
+    Files.walk(testFiles).iterator().asScala
+      .filter {
+        p => p.toString.endsWith(".u") &&
+          // (_:Path).toString.dropRight is very different from
+          // (_:Path).dropRight
+          !checkResultTests.contains(p.getFileName.toString.dropRight(2))
+      }
+      .map(normalize)
+      .toSeq
+  }
+
+  def checkResult(filePrefix: String, result: Term): Test[Unit] = {
+    val filename = s"$filePrefix.u"
+    val file = testFiles.resolve(filename)
+    test(s"$filePrefix = ${prettyTerm(result).render(100)}") { implicit T =>
+      Bootstrap.normalizedFromTextFile(file.toFile).fold(fail(_), equal(_, result))
+    }
+  }
+
+  def normalize(p: Path): Test[Unit] = {
+    test(testFiles.relativize(p).toString.dropRight(2)) {
+      implicit T =>
+        Bootstrap.normalizedFromTextFile(p.toFile).fold(fail(_), _ => ok)
+    }
+  }
+}

--- a/runtime-jvm/main/src/test/scala/util/StreamTests.scala
+++ b/runtime-jvm/main/src/test/scala/util/StreamTests.scala
@@ -158,14 +158,14 @@ object StreamTests {
         test("foldLeft Int64_add") { implicit T =>
           val plusU = UnisonToScala.toUnboxed2(Builtins.Int64_add)
           equal(
-            Stream.fromUnison(0).take(10000).foldLeft(Value(0))(plusU(env)),
+            Stream.fromInt64(0).take(10000).foldLeft(Value(0))(plusU(env)),
             Value((0 until 10000).sum)
           )
         },
         test("scanLeft Int64_add") { implicit T =>
           val int64add = UnisonToScala.toUnboxed2(Builtins.Int64_add)(env)
           equal(
-            Stream.fromUnison(1).take(10000).scanLeft(Value(0))(int64add).reduce(Value(0))(int64add),
+            Stream.fromInt64(1).take(10000).scanLeft(Value(0))(int64add).reduce(Value(0))(int64add),
             Value(scala.Stream.from(1).take(10000).scanLeft(0l)(_+_).sum)
           )
         },

--- a/unison-src/tests/fib4.u
+++ b/unison-src/tests/fib4.u
@@ -1,0 +1,29 @@
+(+) = (+_UInt64)
+(<) = (<_UInt64)
+(-) = (UInt64.drop)
+(*) = (*_UInt64)
+
+fib4 n =
+  loop a b c d n = case n of
+    0 -> 0
+    1 -> d
+    n -> loop b c d (a + b + c + d) (n - 1)
+  loop 0 0 0 1 n
+
+ten-simple =
+  t = Stream.take 10 (Stream.map fib4 (Stream.from-uint64 0))
+  p = 9000
+  q = 900
+  r = 90
+  s = 9
+  sum = Stream.fold-left 0 (+) t
+  sum * 10000 + p + q + r + s
+
+-- ten-simpler =
+--   t = Stream.take 10 (Stream.map fib4 (Stream.from-uint64 0))
+--   sum = Stream.fold-left 0 (+) t
+--   sum + 1
+--
+-- sum4 a b c d = a + b + c + d
+
+ten-simple


### PR DESCRIPTION
Added `Bootstrap.normalizedFromTextFile(filename: File): Term` which sends `filename` through the Haskell parser-typechecker serialization bootstrap, compiles/normalizes the Term and returns it.

Also added `FileCompilationTests.scala` which tries to compile all of the files in the `<base>/unison-src/tests` directory, and also lets you check specific files to assert that their file body evaluates to some other term.  e.g.:
```scala
val checkResultTests = Map[String, Term](
  "fib4" -> 2249999.u,
  "foo/test1" -> 7,
)
```
will pass if `<base>/unison-src/tests/fib4.u` evaluates to `2249999` 
and `<base>/unison-src/tests/foo/test1.u` evaluates to `+7`.

I also wanted to make `sbt ~main/test:run` watch for file changes in `<base>/unison-src/tests` and re-run tests when there are any, but couldn't get it to work, despite much futzing.  sbt's `watchSources` [seems to be a beleaguered feature](https://github.com/sbt/sbt/issues?q=is%3Aissue+is%3Aopen+label%3Aarea%2Fwatch).