### PR TITLE
upgrade to sbt 1.1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ before_install:
 - mkdir -p ~/.local/bin
 - export PATH=$HOME/.local/bin:$PATH
 - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+# Download paulp/sbt-extras because Travis CI's copy is 3 years old as of this writing
+- curl -Ls https://git.io/sbt > ~/.local/bin/sbt && chmod 0755 ~/.local/bin/sbt
 
 install:
 - stack ghc -- --version

--- a/runtime-jvm/project/build.properties
+++ b/runtime-jvm/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.1.6


### PR DESCRIPTION
This upgrade seems to improve incremental compilation which broke at some point.

We have to manually download an updated paulp/sbt-extras because Travis CI's is currently very old.