### PR TITLE
end of streams for now

### DIFF
--- a/runtime-jvm/benchmark/src/main/scala/CompilationBenchmarks.scala
+++ b/runtime-jvm/benchmark/src/main/scala/CompilationBenchmarks.scala
@@ -73,7 +73,7 @@ object CompilationBenchmarks {
 
         val env = (new Array[U](20), new Array[B](20), StackPtr.empty, Result())
         profile("triangle stream .foldLeft(plusU)") {
-          Stream.fromUnison(0).take(N(triangleCount))
+          Stream.fromInt64(0).take(N(triangleCount))
             .foldLeft(Value(0))(plusU(env)) match {
             case Value.Unboxed(n, _) => n
           }

--- a/runtime-jvm/main/src/main/scala/Builtins.scala
+++ b/runtime-jvm/main/src/main/scala/Builtins.scala
@@ -269,6 +269,8 @@ object Builtins {
   val numericBuiltins: Map[Name, Computation] = Map(
     // arithmetic
     Int64_inc,
+    Int64_isEven,
+    Int64_isOdd,
     Int64_add,
     Int64_sub,
     Int64_mul,

--- a/runtime-jvm/main/src/main/scala/Builtins.scala
+++ b/runtime-jvm/main/src/main/scala/Builtins.scala
@@ -12,7 +12,7 @@ import org.unisonweb.util.{Sequence, Stream, Text}
 /* Sketch of convenience functions for constructing builtin functions. */
 object Builtins {
   def env =
-    (new Array[U](20), new Array[B](20), StackPtr.empty, Result())
+    (new Array[U](1024), new Array[B](1024), StackPtr.empty, Result())
 
   // Stream.empty : Stream a
   val Stream_empty =
@@ -52,7 +52,6 @@ object Builtins {
            (acc: Value, f: Value, s: Stream[Value]) =>
              s.foldLeft(acc)(
                UnisonToScala.toUnboxed2(f.asInstanceOf[Lambda])(env))
-           // todo: env needs to be bigger here
     )
 
   abstract class FPPP_P[A,B,C,D] { def apply(a: A, b: B, c: C): D }

--- a/runtime-jvm/main/src/main/scala/Builtins.scala
+++ b/runtime-jvm/main/src/main/scala/Builtins.scala
@@ -19,9 +19,13 @@ object Builtins {
     c0z("Stream.empty", Stream.empty[Value])
 
 
-  // Stream.fromInt : Integer -> Stream Integer
-  val Stream_fromInt = // Stream.iterate(unison 0)(Integer_inc)
-    fp_z("Stream.from-int64", "n", Stream.fromUnison)
+  // Stream.fromInt64 : Int64 -> Stream Int64
+  val Stream_fromInt64 =
+    fp_z("Stream.from-int64", "n", Stream.fromInt64)
+
+  // Stream.fromUInt64 : UInt64 -> Stream UInt64
+  val Stream_fromUInt64 =
+    fp_z("Stream.from-uint64", "n", Stream.fromUInt64)
 
   // Stream.cons : a -> Stream a -> Stream a
   val Stream_cons =
@@ -77,7 +81,8 @@ object Builtins {
 
   val streamBuiltins = Map(
     Stream_empty,
-    Stream_fromInt,
+    Stream_fromInt64,
+    Stream_fromUInt64,
     Stream_cons,
     Stream_drop,
     Stream_take,

--- a/runtime-jvm/main/src/main/scala/Term.scala
+++ b/runtime-jvm/main/src/main/scala/Term.scala
@@ -487,6 +487,11 @@ object Term {
       def u: Term = unsigned
     }
 
+    implicit def tuple2[A<%Term,B<%Term](t: (A,B)): Term =
+      BuiltinTypes.Tuple.term(t._1, t._2)
+    implicit def tuple3[A<%Term,B<%Term,C<%Term](t: (A,B,C)): Term =
+      BuiltinTypes.Tuple.term(t._1, t._2, t._3)
+
     implicit def bool(b: Boolean): Term = Unboxed(boolToUnboxed(b), UnboxedType.Boolean)
     implicit def signed(n: Long): Term = Unboxed(longToUnboxed(n), UnboxedType.Int64)
     implicit def signed(n: Int): Term = Unboxed(intToUnboxed(n), UnboxedType.Int64)

--- a/runtime-jvm/main/src/main/scala/util/Stream.scala
+++ b/runtime-jvm/main/src/main/scala/util/Stream.scala
@@ -287,10 +287,16 @@ object Stream {
       () => { i += by; k(doubleToUnboxed(i),null) }
     }
 
-  final def fromUnison(n: Long): Stream[UnboxedType] =
+  final def fromInt64(u: U): Stream[UnboxedType] =
     k => {
-      var i = n - 1
-      () => { i += 1; k(i, UnboxedType.Int64) }
+      var i = unboxedToLong(u) - 1
+      () => { i += 1; k(longToUnboxed(i), UnboxedType.Int64) }
+    }
+
+  final def fromUInt64(u: U): Stream[UnboxedType] =
+    k => {
+      var i = unboxedToLong(u) - 1
+      () => { i += 1; k(longToUnboxed(i), UnboxedType.UInt64) }
     }
 
   private final def iterate0[A](u0: U, a0: A)(f: F1[A,A]): Stream[A] = {

--- a/runtime-jvm/main/src/main/scala/util/Stream.scala
+++ b/runtime-jvm/main/src/main/scala/util/Stream.scala
@@ -41,16 +41,22 @@ abstract class Stream[A] { self =>
   final def map[B](f: F1[A,B]): Stream[B] =
     k => self.stage(f andThen k)
 
+  final def flatMap[B](f: F1[A,Stream[B]]): Stream[B] =
+    k => self.stage {
+      val cf = f andThen { (_,sb) => sb.stage { (u,b) => k(u,b) }.run() }
+      (u,a) => cf(u,a)
+    }
+
   /** Only emit elements from `this` for which `f` returns a nonzero value. */
-  final def filter(f: F1[A,Unboxed[Boolean]]): Stream[A] =
+  final def filter(f: F1[A,_]): Stream[A] =
     k => self.stage(Unboxed.choose(f, k, Unboxed.K.noop))
 
   /** Emit the longest prefix of `this` for which `f` returns nonzero. */
-  final def takeWhile(f: F1[A,Unboxed[Boolean]]): Stream[A] =
+  final def takeWhile(f: F1[A,_]): Stream[A] =
     k => self.stage(Unboxed.choose[A](f, k, (_,_) => throw Done))
 
   /** Skip the longest prefix of `this` for which `f` returns nonzero. */
-  final def dropWhile(f: F1[A,Unboxed[Boolean]]): Stream[A] =
+  final def dropWhile(f: F1[A,_]): Stream[A] =
     k => self.stage(Unboxed.switchWhen0(f, Unboxed.K.noop, k)())
 
   final def take(n: Long): Stream[A] =
@@ -182,22 +188,6 @@ object Stream {
     def toUnboxed(a: Native): U
   }
   object Extract {
-    implicit val foo: Extract[Param, Value] =
-      new Extract[Param, Value] {
-        override val extract: FUP_P[Value, B] =
-          (u,b) => Value.fromParam(u, b)
-
-        override def toBoxed(a: B): Value = a match {
-          case Value.Unboxed(_, typ) => typ
-          case v => v.toValue
-        }
-
-        override def toUnboxed(a: B): U = a match {
-          case Value.Unboxed(n, _) => n
-          case _ => U0
-        }
-      }
-
     implicit val extractValue: Extract[Value, Value] =
       new Extract[Value, Value] {
 

--- a/runtime-jvm/main/src/main/scala/util/Stream.scala
+++ b/runtime-jvm/main/src/main/scala/util/Stream.scala
@@ -287,12 +287,14 @@ object Stream {
       () => { i += by; k(doubleToUnboxed(i),null) }
     }
 
+  /** intended to be called from Unison code */
   final def fromInt64(u: U): Stream[UnboxedType] =
     k => {
       var i = unboxedToLong(u) - 1
       () => { i += 1; k(longToUnboxed(i), UnboxedType.Int64) }
     }
 
+  /** intended to be called from Unison code */
   final def fromUInt64(u: U): Stream[UnboxedType] =
     k => {
       var i = unboxedToLong(u) - 1

--- a/runtime-jvm/main/src/main/scala/util/Unboxed.scala
+++ b/runtime-jvm/main/src/main/scala/util/Unboxed.scala
@@ -76,8 +76,8 @@ object Unboxed {
    * A continuation which invokes `t` whenver `cond` is nonzero on the
    * input, and which invokes `f` whenever `cond` is zero on the input.
    */
-  def choose[A](cond: F1[A,Unboxed[Boolean]], t: K[A], f: K[A]): K[A] = {
-    val ccond = cond[A]((u,b,u2,a) => if (unboxedToBool(u)) t(u2,a) else f(u2,a))
+  def choose[A](cond: F1[A,_], t: K[A], f: K[A]): K[A] = {
+    val ccond = cond[A]((u,_,u2,a) => if (unboxedToBool(u)) t(u2,a) else f(u2,a))
     (u,a) => ccond(u,a,u,a)
   }
 
@@ -85,7 +85,7 @@ object Unboxed {
    * A continuation which acts as `segment1` until `cond` emits 0, then
    * acts as `segment2` forever thereafter.
    */
-  def switchWhen0[A](cond: F1[A,Unboxed[Boolean]], segment1: K[A], segment2: K[A]): () => K[A] = () => {
+  def switchWhen0[A](cond: F1[A,_], segment1: K[A], segment2: K[A]): () => K[A] = () => {
     var switched = false
     val ccond = cond[A]((u,_,u2,a) =>
                           if (switched || !unboxedToBool(u)) {
@@ -137,14 +137,23 @@ object Unboxed {
             kux(boolToUnboxed(f.test(unboxedToDouble(u))), null, ux, bx)
       }
 
+    abstract class L_P[A] { def apply(l: Long): A }
+    def L_P[A](f: L_P[A]) =
+      new F1[Unboxed[Long], A] {
+        def apply[X]: K2[A, X] => K2[Unboxed[U], X] =
+          kux => (u,_,ux,bx) =>
+            kux(U0, f(unboxedToLong(u)), ux, bx)
+      }
+
   }
 
   object F2 {
     /**
-     * Convert a Scala `(A,B) => C` to an `F2[A,B,C]` that acts on boxed input and produces boxed output.
-     * Named `BB_B` since it takes two boxed input and produces boxed output.
-     */
-    def BB_B[A,B,C](f: (A,B) => C): F2[A,B,C] = new F2[A,B,C] {
+      * Convert a Scala `(A,B) => C` to an `F2[A,B,C]` that acts on boxed input and produces boxed output.
+      * Named `PP_P` since it takes two polymorphic/boxed input and produces
+      * polymorphic/boxed output.
+      */
+    def PP_P[A,B,C](f: (A,B) => C): F2[A,B,C] = new F2[A,B,C] {
       def apply[x] = kcx =>
         (_,a,_,b,u3,x) => kcx(U0, f(a,b), u3, x)
     }

--- a/runtime-jvm/main/src/test/scala/CompilationTests.scala
+++ b/runtime-jvm/main/src/test/scala/CompilationTests.scala
@@ -635,7 +635,7 @@ object CompilationTests {
                     termFor(Builtins.Stream_cons)(1, termFor(Builtins.Stream_empty)))
       },
       test("map") { implicit T =>
-        // Stream.foldLeft 0 (+) (Stream.take 100 (Stream.map (+1) (Stream.fromInt 0)))
+        // Stream.foldLeft +0 (+) (Stream.take 100 (Stream.map (\x -> x + 1) (Stream.fromInt +0)))
         equal[Term](
           eval(
             termFor(Builtins.Stream_foldLeft)(
@@ -645,7 +645,7 @@ object CompilationTests {
                 100,
                 termFor(Builtins.Stream_map)(
                   termFor(Builtins.Int64_inc),
-                  termFor(Builtins.Stream_fromInt)(0)))
+                  termFor(Builtins.Stream_fromInt64)(0)))
             )
           ),
           scala.Stream.from(0).map(1+).take(100).foldLeft(0)(_+_)

--- a/runtime-jvm/main/src/test/scala/CompilationTests.scala
+++ b/runtime-jvm/main/src/test/scala/CompilationTests.scala
@@ -635,19 +635,8 @@ object CompilationTests {
                     termFor(Builtins.Stream_cons)(1, termFor(Builtins.Stream_empty)))
       },
       test("map") { implicit T =>
-        // Stream.foldLeft +0 (+) (Stream.take 100 (Stream.map (\x -> x + 1) (Stream.fromInt +0)))
         equal[Term](
-          eval(
-            termFor(Builtins.Stream_foldLeft)(
-              0,
-              termFor(Builtins.Int64_add),
-              termFor(Builtins.Stream_take)(
-                100,
-                termFor(Builtins.Stream_map)(
-                  termFor(Builtins.Int64_inc),
-                  termFor(Builtins.Stream_fromInt64)(0)))
-            )
-          ),
+          eval(Stream.foldLeft(0, Int64.+, Stream.take(100, Stream.map(Int64.inc, Stream.fromInt64(0))))),
           scala.Stream.from(0).map(1+).take(100).foldLeft(0)(_+_)
         )
       }
@@ -1016,6 +1005,18 @@ object Terms {
     val gt = termFor(Text_gt)
     val lteq = termFor(Text_lteq)
     val gteq = termFor(Text_gteq)
+  }
+  
+  object Stream {
+    import Builtins._
+    val empty = termFor(Stream_empty)
+    val fromInt64 = termFor(Stream_fromInt64)
+    val fromUInt64 = termFor(Stream_fromUInt64)
+    val cons = termFor(Stream_cons)
+    val drop = termFor(Stream_drop)
+    val take = termFor(Stream_take)
+    val map = termFor(Stream_map)
+    val foldLeft = termFor(Stream_foldLeft)
   }
 
   object Debug {

--- a/runtime-jvm/main/src/test/scala/FileCompilationTests.scala
+++ b/runtime-jvm/main/src/test/scala/FileCompilationTests.scala
@@ -12,7 +12,8 @@ object FileCompilationTests {
   val testFiles = new File("../../unison-src/tests").toPath
 
   val checkResultTests = Map[String, Term](
-    "fib4" -> 2249999.u
+    "fib4" -> 2249999.u,
+    "stream-shouldnt-damage-stack" -> ((4950.u, 9999.u)),
   )
 
   def tests = suite("compilation.file")(

--- a/runtime-jvm/main/src/test/scala/util/StreamTests.scala
+++ b/runtime-jvm/main/src/test/scala/util/StreamTests.scala
@@ -3,9 +3,9 @@ package org.unisonweb.util
 import org.unisonweb.EasyTest._
 import org.unisonweb._
 import org.unisonweb.compilation._
+import org.unisonweb.util.Unboxed.F1.{D_B, L_B, L_L, L_P}
+import org.unisonweb.util.Unboxed.F2.{DD_D, LD_L, LL_L}
 import org.unisonweb.util.Unboxed.Unboxed
-import org.unisonweb.util.Unboxed.F1.{L_B, D_B, L_L}
-import org.unisonweb.util.Unboxed.F2.{LL_L,DD_D,LD_L}
 
 object StreamTests {
   val tests = suite("stream")(
@@ -23,38 +23,46 @@ object StreamTests {
       },
       test("map") { implicit T =>
         equal(
-          Stream.from(0).take(10000).map(L_L(_ + 1)).sumIntegers,
-          (0 until 10000).map(_ + 1).sum
+          Stream.from(0).take(10000).map(L_L(_ + 1)).toSequence.toList,
+          (0 until 10000).map(_ + 1).toList
+        )
+      },
+      test("flatMap") { implicit T =>
+        equal(
+          Stream.from(1).take(100)
+            .flatMap(L_P(n => Stream.constant(n).take(n))).toSequence.toList,
+          scala.Stream.from(1).take(100)
+            .flatMap(n => scala.Stream.continually(n).take(n)).toList
         )
       },
       test("filter") { implicit T =>
         equal(
-          Stream.from(0).take(10000).filter(L_B(_ % 2 == 0)).sumIntegers,
-          (0 until 10000).filter(_ % 2 == 0).sum
+          Stream.from(0).take(10000).filter(L_B(_ % 2 == 0)).toSequence.toList,
+          (0 until 10000).filter(_ % 2 == 0).toList
         )
       },
       test("takeWhile") { implicit T =>
         equal(
-          Stream.from(0).take(100).takeWhile(L_B(_ < 50)).sumIntegers,
-          (0 until 100).takeWhile(_ < 50).sum
+          Stream.from(0).take(100).takeWhile(L_B(_ < 50)).toSequence.toList,
+          (0 until 100).takeWhile(_ < 50).toList
         )
         equal(
-          Stream.from(0.0, by = 1.0).take(100).takeWhile(D_B(_ < 50.0)).sumFloats,
-          (0 until 100).takeWhile(_ < 50).sum
+          Stream.from(0.0, by = 1.0).take(100).takeWhile(D_B(_ < 50.0)).toSequence.toList,
+          (0 until 100).takeWhile(_ < 50).toList
         )
       },
       test("dropWhile") { implicit T =>
         equal(
-          Stream.from(0).take(100).dropWhile(L_B(_ < 50)).sumIntegers,
-          (0 until 100).dropWhile(_ < 50).sum
+          Stream.from(0).take(100).dropWhile(L_B(_ < 50)).toSequence.toList,
+          (0 until 100).dropWhile(_ < 50).toList
         )
       },
       test("zipWith") { implicit T =>
         val s1 = Stream.from(0)
         val s2 = scala.collection.immutable.Stream.from(0)
         equal(
-          s1.zipWith(s1.drop(1))(LL_L(_ * _)).take(100).sumIntegers,
-          s2.zip(s2.drop(1)).map { case (a,b) => a * b }.take(100).sum
+          s1.zipWith(s1.drop(1))(LL_L(_ * _)).take(100).toSequence.toList,
+          s2.zip(s2.drop(1)).map { case (a,b) => a * b }.take(100).toList
         )
       },
       test("toSequence0") { implicit T =>
@@ -109,24 +117,28 @@ object StreamTests {
       },
       test("++") { implicit T =>
         equal(
-          (Stream.from(0).take(10000) ++ Stream.from(20000).take(5)).sumIntegers,
-          (scala.Stream.from(0).take(10000) ++ scala.Stream.from(20000).take(5)).sum
+          (Stream.from(0).take(10000) ++ Stream.from(20000).take(5))
+            .toSequence.toList,
+          (scala.Stream.from(0).take(10000) ++ scala.Stream.from(20000).take(5))
+            .toList
         )
         equal(
-          (Stream.from(0).drop(10000).take(10000) ++ Stream.from(20000).take(5)).sumIntegers,
-          (scala.Stream.from(0).drop(10000).take(10000) ++ scala.Stream.from(20000).take(5)).sum
+          (Stream.from(0).drop(10000).take(10000) ++ Stream.from(20000).take(5))
+            .toSequence.toList,
+          (scala.Stream.from(0).drop(10000).take(10000) ++
+            scala.Stream.from(20000).take(5)).toList
         )
       },
       test("cons") { implicit T =>
         equal(
-          (-10l :: Stream.from(0).take(10)).sumIntegers,
-          (-10 #:: scala.Stream.from(0).take(10)).sum
+          (-10l :: Stream.from(0).take(10)).toSequence.toList,
+          (-10 #:: scala.Stream.from(0).take(10)).toList
         )
       },
       test("iterate-from0") { implicit T =>
         equal(
-          Stream.iterate(0l)(L_L(_ + 1)).take(10).sumIntegers,
-          (scala.Stream.from(0).take(10)).sum
+          Stream.iterate(0l)(L_L(_ + 1)).take(10).toSequence.toList,
+          (scala.Stream.from(0).take(10)).toList
         )
       }
     ),
@@ -135,6 +147,7 @@ object StreamTests {
         (new Array[U](20), new Array[B](20), StackPtr.empty, Result())
       val incU = UnisonToScala.toUnboxed1(Builtins.Int64_inc)
       val plusU = UnisonToScala.toUnboxed2(Builtins.Int64_add)
+      val evenU = UnisonToScala.toUnboxed1(Builtins.Int64_isEven)
 
       suite("unison") (
         test("take/drop") { implicit T =>
@@ -144,15 +157,16 @@ object StreamTests {
           )
         },
         test("map") { implicit T =>
-          equal[Int](
-            Stream.iterate(0)(incU(env)).take(10000).map(incU(env)).reduce(0)(plusU(env)),
-            scala.Stream.from(0).take(10000).map(_ + 1).sum
+          equal[List[Long]](
+            Stream.fromUnison(0).take(10).map(incU(env)).toSequence[Long].toList,
+            scala.Stream.from(0).take(10).map(_ + 1l).toList
           )
         },
         test("filter") { implicit T =>
-          equal[Int](
-            Stream.iterate(0)(incU(env)).take(10000).map(incU(env)).reduce(0)(plusU(env)),
-            scala.Stream.from(0).take(10000).map(_ + 1).sum
+          equal[List[Long]](
+            Stream.iterate(0)(incU(env)).take(10000).filter(evenU(env))
+              .toSequence[Long].toList,
+            scala.Stream.from(0).map(_.toLong).take(10000).filter(_ % 2 == 0).toList
           )
         },
         test("foldLeft Int64_add") { implicit T =>

--- a/runtime-jvm/main/src/test/scala/util/StreamTests.scala
+++ b/runtime-jvm/main/src/test/scala/util/StreamTests.scala
@@ -1,8 +1,8 @@
 package org.unisonweb.util
 
+import org.unisonweb.Builtins.env
 import org.unisonweb.EasyTest._
 import org.unisonweb._
-import org.unisonweb.compilation._
 import org.unisonweb.util.Unboxed.F1.{D_B, L_B, L_L, L_P}
 import org.unisonweb.util.Unboxed.F2.{DD_D, LD_L, LL_L}
 import org.unisonweb.util.Unboxed.Unboxed
@@ -143,8 +143,6 @@ object StreamTests {
       }
     ),
     {
-      def env =
-        (new Array[U](20), new Array[B](20), StackPtr.empty, Result())
       val incU = UnisonToScala.toUnboxed1(Builtins.Int64_inc)
       val plusU = UnisonToScala.toUnboxed2(Builtins.Int64_add)
       val evenU = UnisonToScala.toUnboxed1(Builtins.Int64_isEven)
@@ -158,7 +156,7 @@ object StreamTests {
         },
         test("map") { implicit T =>
           equal[List[Long]](
-            Stream.fromUnison(0).take(10).map(incU(env)).toSequence[Long].toList,
+            Stream.fromInt64(0).take(10).map(incU(env)).toSequence[Long].toList,
             scala.Stream.from(0).take(10).map(_ + 1l).toList
           )
         },
@@ -172,14 +170,14 @@ object StreamTests {
         test("foldLeft Int64_add") { implicit T =>
           val plusU = UnisonToScala.toUnboxed2(Builtins.Int64_add)
           equal(
-            Stream.fromUnison(0).take(10000).foldLeft(Value(0))(plusU(env)),
+            Stream.fromInt64(0).take(10000).foldLeft(Value(0))(plusU(env)),
             Value((0 until 10000).sum)
           )
         },
         test("scanLeft Int64_add") { implicit T =>
           val int64add = UnisonToScala.toUnboxed2(Builtins.Int64_add)(env)
           equal(
-            Stream.fromUnison(1).take(10000).scanLeft(Value(0))(int64add).reduce(Value(0))(int64add),
+            Stream.fromInt64(1).take(10000).scanLeft(Value(0))(int64add).reduce(Value(0))(int64add),
             Value(scala.Stream.from(1).take(10000).scanLeft(0l)(_+_).sum)
           )
         },

--- a/unison-src/tests/fib4.u
+++ b/unison-src/tests/fib4.u
@@ -19,11 +19,4 @@ ten-simple =
   sum = Stream.fold-left 0 (+) t
   sum * 10000 + p + q + r + s
 
--- ten-simpler =
---   t = Stream.take 10 (Stream.map fib4 (Stream.from-uint64 0))
---   sum = Stream.fold-left 0 (+) t
---   sum + 1
---
--- sum4 a b c d = a + b + c + d
-
 ten-simple

--- a/unison-src/tests/fib4.u
+++ b/unison-src/tests/fib4.u
@@ -10,13 +10,10 @@ fib4 n =
     n -> loop b c d (a + b + c + d) (n - 1)
   loop 0 0 0 1 n
 
-ten-simple =
-  t = Stream.take 10 (Stream.map fib4 (Stream.from-uint64 0))
-  p = 9000
-  q = 900
-  r = 90
-  s = 9
-  sum = Stream.fold-left 0 (+) t
-  sum * 10000 + p + q + r + s
-
-ten-simple
+t = Stream.take 10 (Stream.map fib4 (Stream.from-uint64 0))
+p = 9000
+q = 900
+r = 90
+s = 9
+sum = Stream.fold-left 0 (+) t
+sum * 10000 + p + q + r + s

--- a/unison-src/tests/stream-shoudnt-damage-stack.u
+++ b/unison-src/tests/stream-shoudnt-damage-stack.u
@@ -1,0 +1,15 @@
+(+) = (+_UInt64)
+(-) = UInt64.drop
+(*) = (*_UInt64)
+
+eat-stack n = case n of
+  0 -> 0
+  n -> eat-stack (n - 1) + 1
+
+t = Stream.take 1 (Stream.map eat-stack (Stream.from-uint64 0))
+p = 9000
+q = 900
+r = 90
+s = 9
+sum = Stream.fold-left 0 (+) t
+sum * 10000 + p + q + r + s

--- a/unison-src/tests/stream-shouldnt-damage-stack.u
+++ b/unison-src/tests/stream-shouldnt-damage-stack.u
@@ -6,10 +6,10 @@ eat-stack n = case n of
   0 -> 0
   n -> eat-stack (n - 1) + 1
 
-t = Stream.take 1 (Stream.map eat-stack (Stream.from-uint64 0))
+t = Stream.take 100 (Stream.map eat-stack (Stream.from-uint64 0))
 p = 9000
 q = 900
 r = 90
 s = 9
 sum = Stream.fold-left 0 (+) t
-sum * 10000 + p + q + r + s
+(sum, p + q + r + s)


### PR DESCRIPTION
I want to merge this (after #211) mainly so I don't have to resolve merge conflicts on it forever.  It's basically unchanged since May.

This implementation still allocates a new stack to be closed into higher-order functions; I've added a test program that I expect will bomb if the Stream implementation is updated in a non-stack-safe way.  We can then always update the implementation later.