### PR TITLE
Lexer fixes

### DIFF
--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -108,6 +108,7 @@ lexer scope rem =
         let end = incBy kw pos
         in Token Close pos pos
              : Token (Open kw) pos end
+             -- todo: would be nice to check that top of `l` is an Open "if" or "then"
              : pushLayout (drop 1 l) end rem
 
     -- Examine current column and pop the layout stack
@@ -131,6 +132,7 @@ lexer scope rem =
 
     -- after we've dealt with whitespace and layout, read a token
     go2 l pos rem = case rem of
+      [] -> popLayout0 l pos []
       -- delimiters - `:`, `@`, `|`, `=`, and `->`
       ch : rem | Set.member ch delimiters ->
         Token (Reserved [ch]) pos (inc pos) : go1 l (inc pos) rem

--- a/parser-typechecker/tests/Suite.hs
+++ b/parser-typechecker/tests/Suite.hs
@@ -5,13 +5,15 @@ module Main where
 import EasyTest
 import System.IO
 import System.Environment (getArgs)
+import qualified Unison.Test.DataDeclaration as DataDeclaration
+import qualified Unison.Test.FileParser as FileParser
+import qualified Unison.Test.Lexer as Lexer
 import qualified Unison.Test.TermParser as TermParser
 import qualified Unison.Test.Typechecker as Typechecker
-import qualified Unison.Test.FileParser as FileParser
-import qualified Unison.Test.DataDeclaration as DataDeclaration
 
 test :: Test ()
 test = tests [
+  Lexer.test,
   TermParser.test,
   Typechecker.test,
   FileParser.test,

--- a/parser-typechecker/tests/Unison/Test/Lexer.hs
+++ b/parser-typechecker/tests/Unison/Test/Lexer.hs
@@ -44,6 +44,11 @@ test = scope "lexer" . tests $
             , Open "if", WordyId "c", Close, Open "then", WordyId "d", Close, Open "else"
             , Open "if", WordyId "e", Close, Open "then", WordyId "f", Close, Open "else"
             , WordyId "g", Close, Close, Close ] -- close of the three `else` blocks
+
+  -- In an empty `then` clause, the `else` is interpreted as a `Reserved` token
+  , t "if x then else" [Open "if", WordyId "x", Close, Open "then", Reserved "else", Close]
+  -- Empty `else` clause
+  , t "if x then 1 else" [Open "if", WordyId "x", Close, Open "then", Numeric "1", Close, Open "else", Close]
   ]
 
 t :: String -> [Lexeme] -> Test ()

--- a/parser-typechecker/tests/Unison/Test/Lexer.hs
+++ b/parser-typechecker/tests/Unison/Test/Lexer.hs
@@ -1,0 +1,57 @@
+module Unison.Test.Lexer where
+
+import EasyTest
+import Unison.Lexer
+
+test :: Test ()
+test = scope "lexer" . tests $
+  [ t "1" $ [Numeric "1"]
+  , t "+1" $ [Numeric "+1"]
+  , t "-1" $ [Numeric "-1"]
+  , t "-1.0" $ [Numeric "-1.0"]
+  , t "+1.0" $ [Numeric "+1.0"]
+  , t "-- a comment 1.0" $ []
+  , t "\"woot\" -- a comment 1.0" $ [Textual "woot"]
+
+  -- note - these are all the same, just with different spacing
+  , let ex1 = "if x then y else z"
+        ex2 = unlines
+          [ "if"
+          , "  x"
+          , "then"
+          , "  y"
+          , "else z" ]
+        ex3 = unlines
+          [ "if"
+          , "  x"
+          , "  then"
+          , "    y"
+          , "else z" ]
+        ex4 = unlines
+          [ "if"
+          , "  x"
+          , "  then"
+          , "  y"
+          , "else z" ]
+        expected = [Open "if", WordyId "x", Close, Open "then", WordyId "y", Close, Open "else", WordyId "z", Close]
+    in tests $ map (`t` expected) [ex1, ex2, ex3, ex4]
+
+  , let ex = unlines [ "if a then b"
+                     , "else if c then d"
+                     , "else if e then f"
+                     , "else g" ]
+    in t ex [ Open "if", WordyId "a", Close, Open "then", WordyId "b", Close, Open "else"
+            , Open "if", WordyId "c", Close, Open "then", WordyId "d", Close, Open "else"
+            , Open "if", WordyId "e", Close, Open "then", WordyId "f", Close, Open "else"
+            , WordyId "g", Close, Close, Close ] -- close of the three `else` blocks
+  ]
+
+t :: String -> [Lexeme] -> Test ()
+t s expected =
+  let actual0 = payload <$> lexer "ignored filename" s
+      actual = take (length actual0 - 2) . drop 1 $ actual0
+  in scope s $
+      if actual == expected then ok
+      else do note $ "expected: " ++ show expected
+              note $ "actual  : "   ++ show actual
+              crash "actual != expected"

--- a/parser-typechecker/tests/Unison/Test/TermParser.hs
+++ b/parser-typechecker/tests/Unison/Test/TermParser.hs
@@ -86,25 +86,25 @@ test = scope "termparser" . tests . map parses $
   --
   -- Conditionals
   , "if x then y else z"
+  , "if\n" ++
+    "  s = 0\n" ++
+    "  s > 0\n" ++
+    "then\n" ++
+    "  s = 0\n" ++
+    "  s + 1\n" ++
+    "else\n" ++
+    "  s = 0\n" ++
+    "  s + 2\n"
   --, "if\n" ++
   --  "  s = 0\n" ++
   --  "  s > 0\n" ++
   --  "then\n" ++
-  --  "  s = 0\n" ++
+  --  "  s : Int64\n" ++
+  --  "  s = (0: Int64)\n" ++
   --  "  s + 1\n" ++
   --  "else\n" ++
   --  "  s = 0\n" ++
   --  "  s + 2\n"
-  -- , "if\n" ++
-  --   "  s = 0\n" ++
-  --   "  s > 0\n" ++
-  --   "then\n" ++
-  --   "  s : Int64\n" ++
-  --   "  s = (0: Int64)\n" ++
-  --   "  s + 1\n" ++
-  --   "else\n" ++
-  --   "  s = 0\n" ++
-  --   "  s + 2\n"
   -- , "and x y"
   -- , "or x y"
   -- , [r|let

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -135,6 +135,7 @@ executable tests
     Unison.Test.Common
     Unison.Test.DataDeclaration
     Unison.Test.FileParser
+    Unison.Test.Lexer
     Unison.Test.TermParser
     Unison.Test.Typechecker
     Unison.Test.Typechecker.Components


### PR DESCRIPTION
Fixed the issue we were seeing earlier and added unit tests. Tests are in `Unison.Test.Lexer`, which we can add to if/when we encounter other weirdness:

```Haskell
test :: Test ()
test = scope "lexer" . tests $
  [ t "1" $ [Numeric "1"]
  , t "+1" $ [Numeric "+1"]
  , t "-1" $ [Numeric "-1"]
  , t "-1.0" $ [Numeric "-1.0"]
  , t "+1.0" $ [Numeric "+1.0"]
  , t "-- a comment 1.0" $ []
  , t "\"woot\" -- a comment 1.0" $ [Textual "woot"]
  ...
```

In particular, there's tests for the variety of ways of formatting if/then/else.

The fix had the effect of eliminating that stray `Semi` before a `then` or `else` in code where the `if` and `then` were at the same column, eg:

```Haskell
if blah
-- then is at same indentation level as `if`, so this was emitting a `Semi` before 
-- unless you indented the `then`, which is weak
then blah
```
