### PR TITLE
update stack resolver from nightly to lts-12.5 which includes ghc-8.4

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -8,7 +8,7 @@ packages:
 - parser-typechecker
 
 #compiler-check: match-exact
-resolver: nightly-2018-06-25
+resolver: lts-12.5
 
 extra-deps:
 - base58-bytestring-0.1.0


### PR DESCRIPTION
I thought I did this already, but maybe I dreamed it.