### PR TITLE
Fix bug in TDNR

### DIFF
--- a/parser-typechecker/src/Unison/Result.hs
+++ b/parser-typechecker/src/Unison/Result.hs
@@ -1,13 +1,22 @@
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ViewPatterns #-}
+
 module Unison.Result where
 
-import Data.Maybe
-import Control.Monad
-import Data.Sequence (Seq)
+import           Control.Monad
+import           Control.Monad.Fail (MonadFail(..))
+import           Control.Monad.Trans ( lift )
+import           Control.Monad.Trans.Maybe
+import           Control.Monad.Writer (Writer, runWriter, MonadWriter(..))
 import qualified Data.Foldable as Foldable
-import qualified Unison.Typechecker.Context as Context
-import Unison.Paths (Path)
-import Unison.Term (AnnotatedTerm)
+import           Data.Maybe
+import           Data.Sequence ( Seq )
+import qualified Data.Sequence as Seq
 import qualified Unison.Parser as Parser
+import           Unison.Paths ( Path )
+import           Unison.Term ( AnnotatedTerm )
+import qualified Unison.Typechecker.Context as Context
 
 data Result note a = Result { notes :: Seq note, result :: Maybe a }
   deriving Show
@@ -34,11 +43,24 @@ toMaybe = result
 toEither :: Result note a -> Either [note] a
 toEither r = case result r of
   Nothing -> Left (Foldable.toList $ notes r)
-  Just a -> Right a
+  Just a  -> Right a
 
 fromParsing :: Either (Parser.Err v) a -> Result (Note v loc) a
-fromParsing (Left e) = Result (pure $ Parsing e) Nothing
+fromParsing (Left  e) = Result (pure $ Parsing e) Nothing
 fromParsing (Right a) = pure a
+
+failNote :: note -> Result note a
+failNote note = do
+  tell $ Seq.singleton note
+  Control.Monad.Fail.fail ""
+
+fromTrans :: MaybeT (Writer (Seq note)) a -> Result note a
+fromTrans (runWriter . runMaybeT -> (r, n)) = Result n r
+
+toTrans :: Result note a -> MaybeT (Writer (Seq note)) a
+toTrans (Result notes may) = do
+  lift $ tell notes
+  MaybeT (pure may)
 
 instance Functor (Result note) where
   fmap = liftM
@@ -52,3 +74,11 @@ instance Monad (Result note) where
   Result notes Nothing >>= _f = Result notes Nothing
   Result notes (Just a) >>= f = case f a of
     Result notes2 b -> Result (notes `mappend` notes2) b
+
+instance (MonadWriter (Seq note)) (Result note) where
+  tell note = fromTrans $ tell note
+  listen (Result notes may) = Result notes ((,notes) <$> may)
+  pass = fromTrans . pass . toTrans
+
+instance MonadFail (Result note) where
+  fail _ = Result Seq.empty Nothing

--- a/parser-typechecker/src/Unison/Result.hs
+++ b/parser-typechecker/src/Unison/Result.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -49,7 +50,7 @@ fromParsing :: Either (Parser.Err v) a -> Result (Note v loc) a
 fromParsing (Left  e) = Result (pure $ Parsing e) Nothing
 fromParsing (Right a) = pure a
 
-failNote :: note -> Result note a
+failNote :: (MonadWriter (Seq note) m, MonadFail m) => note -> m ()
 failNote note = do
   tell $ Seq.singleton note
   Control.Monad.Fail.fail ""

--- a/parser-typechecker/src/Unison/Typechecker.hs
+++ b/parser-typechecker/src/Unison/Typechecker.hs
@@ -188,8 +188,11 @@ typeDirectedNameResolution resultSoFar env = do
               traverse_ substSuggestion res2
               synthesizeAndResolve env
             else
-           -- The type hasn't changed
-                 let Result ns _ = suggest res2 in lift . pure $ Result ns may
+              -- The type hasn't changed
+              lift . pure $ do
+                tp <- resultSoFar
+                suggest res2
+                pure tp
  where
   suggest :: [Resolution v loc] -> Result (Note v loc) ()
   suggest = traverse_

--- a/parser-typechecker/src/Unison/Typechecker.hs
+++ b/parser-typechecker/src/Unison/Typechecker.hs
@@ -159,9 +159,9 @@ resolvable _ = False
 synthesizeAndResolve
   :: (Monad f, Var v, Ord loc)
   => Env f v loc
-  -> Term v loc
   -> TDNR f v loc (Type v loc)
-synthesizeAndResolve env t = do
+synthesizeAndResolve env = do
+  t <- get
   r1 <- lift $ synthesize env t
   typeDirectedNameResolution r1 env
 
@@ -192,8 +192,7 @@ typeDirectedNameResolution resultSoFar env = do
       in if goAgain
             then do
               traverse_ substSuggestion res2
-              newTerm <- get
-              synthesizeAndResolve env newTerm
+              synthesizeAndResolve env
             else
               -- The type hasn't changed
               let Result ns _ = suggest res2

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -114,7 +114,9 @@ type ActualArgCount = Int
 type ConstructorId = Int
 
 data Suggestion v loc =
-  Suggestion { suggestionName :: Text, suggestionType :: Type v loc }
+  Suggestion { suggestionName :: Text
+             , suggestionType :: Type v loc
+             }
   deriving Show
 
 data Cause v loc

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -86,7 +86,6 @@ library
     hashable,
     lens,
     memory,
-    mmorph,
     monad-loops,
     mtl,
     murmur-hash,

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -86,6 +86,7 @@ library
     hashable,
     lens,
     memory,
+    mmorph,
     monad-loops,
     mtl,
     murmur-hash,

--- a/unison-src/errors/tdnr.u
+++ b/unison-src/errors/tdnr.u
@@ -1,0 +1,3 @@
+foo a b = a + b
+
+foo

--- a/unison-src/tests/tdnr2.u
+++ b/unison-src/tests/tdnr2.u
@@ -7,5 +7,9 @@ y = +42 + -2
 z : Float
 z = 42.0 - 2.0
 
+foo a b = (a + b) + 3
+
+bar a b = 3 + b + a
+
 x
 


### PR DESCRIPTION
This fixes a bug where type-directed name resolution would fail if it encountered an unresolvable symbol before a resolvable one (which might make the unresolvable one resolvable).
