### PR TITLE
Fixed console.uu

### DIFF
--- a/parser-typechecker/src/Unison/Pattern.hs
+++ b/parser-typechecker/src/Unison/Pattern.hs
@@ -2,6 +2,7 @@
 
 module Unison.Pattern where
 
+import Data.List (intercalate)
 import Data.Int (Int64)
 import Data.Word (Word64)
 import Data.Foldable as Foldable
@@ -38,7 +39,21 @@ data PatternP loc
   | AsP loc (PatternP loc)
   | EffectPureP loc (PatternP loc)
   | EffectBindP loc !Reference !Int [PatternP loc] (PatternP loc)
-    deriving (Generic,Show,Functor,Foldable,Traversable)
+    deriving (Generic,Functor,Foldable,Traversable)
+
+instance Show (PatternP loc) where
+  show (UnboundP _  ) = "Unbound"
+  show (VarP     _  ) = "Var"
+  show (BooleanP _ x) = "Boolean " <> show x
+  show (Int64P   _ x) = "Int64 " <> show x
+  show (UInt64P  _ x) = "UInt64 " <> show x
+  show (FloatP   _ x) = "Float " <> show x
+  show (ConstructorP _ r i ps) =
+    "Constructor " <> intercalate " " [show r, show i, show ps]
+  show (AsP         _ p) = "As " <> show p
+  show (EffectPureP _ k) = "EffectPure " <> show k
+  show (EffectBindP _ r i ps k) =
+    "EffectBind " <> intercalate " " [show r, show i, show ps, show k]
 
 loc :: PatternP loc -> loc
 loc p = head $ Foldable.toList p

--- a/parser-typechecker/src/Unison/Term.hs
+++ b/parser-typechecker/src/Unison/Term.hs
@@ -489,7 +489,7 @@ instance Var v => Hashable1 (F v a p) where
 -- mostly boring serialization code below ...
 
 instance (Eq a, Var v) => Eq1 (F v a p) where (==#) = (==)
-instance (Show a, Show p, Var v) => Show1 (F v a p) where showsPrec1 = showsPrec
+instance (Var v) => Show1 (F v a p) where showsPrec1 = showsPrec
 
 instance (Var vt, Eq at, Eq a) => Eq (F vt at p a) where
   Int64 x == Int64 y = x == y
@@ -515,7 +515,7 @@ instance (Var vt, Eq at, Eq a) => Eq (F vt at p a) where
   _ == _ = False
 
 
-instance (Var v, Show p, Show a0, Show a) => Show (F v a0 p a) where
+instance (Var v, Show a) => Show (F v a0 p a) where
   showsPrec p fa = go p fa where
     showConstructor r n = showsPrec 0 r <> s"#" <> showsPrec 0 n
     go _ (Int64 n) = (if n >= 0 then s "+" else s "") <> showsPrec 0 n

--- a/unison-src/errors/poor-error-message/consoleh.u
+++ b/unison-src/errors/poor-error-message/consoleh.u
@@ -1,0 +1,58 @@
+-- Token {payload = Semi, start = Pos 51 1, end = Pos 51 1} :| []
+-- bootstrap: unison-src/tests/console.uu:51:1:
+-- unexpected Semi
+-- expecting : or the rest of infixApp
+--    51 | ()
+
+effect State s where
+  get : {State s} s
+  set : s -> {State s} ()
+
+effect Console where
+  read : {Console} (Optional Text)
+  write : Text -> {Console} ()
+
+fst x = case x of Pair.Pair a _ -> a
+
+snd x = case x of Pair.Pair _ (Pair.Pair b _) -> b
+
+namespace Console where
+
+  state : s -> Effect (State s) a -> a
+  state s c = case c of
+    {State.get -> k} -> handle state s in k s
+    {State.set s' -> k} -> handle state s' in k ()
+    {a} -> a
+
+  simulate : Effect Console d -> {State ([Text], [Text])} d
+  simulate c = case c of
+    {Console.read -> k} ->
+      io = State.get
+      ins = fst io
+      outs = snd io
+      State.set (drop 1 ins, outs)
+      -- this really should typecheck but doesn't for some reason
+      -- error is that `simulate` doesn't check against `Effect Console c -> r`,
+      -- but seems like that `r` should get instantiated as `{State (..)} c`. 
+      handle simulate in k (at 0 ins)
+    {Console.write t -> k} ->
+      io = State.get
+      ins = fst io
+      outs = snd io
+      -- same deal here 
+      handle simulate in k (State.set (ins, cons t outs))
+    {a} -> a
+
+(++) = concatenate
+
+handle 
+  handle Console.simulate in 
+    use Console read write
+    use Optional Some None
+    write "What's your name?"
+    case read of
+      Some name -> write ("Hello" ++ name)
+      None -> write "Fine, be that way."
+
+()
+

--- a/unison-src/tests/console.u
+++ b/unison-src/tests/console.u
@@ -12,7 +12,13 @@ snd x = case x of Pair.Pair _ (Pair.Pair b _) -> b
 
 namespace Console where
 
-  simulate : Effect Console c -> {State ([Text], [Text])} c
+  state : s -> Effect (State s) a -> a
+  state s c = case c of
+    {State.get -> k} -> handle state s in k s
+    {State.set s' -> k} -> handle state s' in k ()
+    {a} -> a
+
+  simulate : Effect Console d -> {State ([Text], [Text])} d
   simulate c = case c of
     {Console.read -> k} ->
       io = State.get
@@ -29,16 +35,17 @@ namespace Console where
       outs = snd io
       -- same deal here 
       handle simulate in k (State.set (ins, cons t outs))
+    {a} -> a
 
 (++) = concatenate
 
-handle Console.simulate in 
-  use Console read write
-  use Optional Some None
-  write "What's your name?"
-  case read of
-    Some name -> write ("Hello" ++ name)
-    None -> write "Fine, be that way."
-
+handle Console.state ([],[]) in
+  handle Console.simulate in 
+    use Console read write
+    use Optional Some None
+    write "What's your name?"
+    case read of
+      Some name -> write ("Hello" ++ name)
+      None -> write "Fine, be that way."
 
 ()

--- a/unison-src/tests/state1.u
+++ b/unison-src/tests/state1.u
@@ -2,11 +2,14 @@
 effect State se2 where
   put : ∀ se . se -> {State se} ()
   get : ∀ se . () -> {State se} se
+
 -- state : ∀ s a . s -> Effect (State s) a -> (s, a)
 state woot eff = case eff of
   { State.put snew -> k } -> handle (state snew) in k ()
   { State.get () -> k } -> handle state woot in k woot
   { a } -> (woot, a)
+
 blah : ∀ s a . s -> Effect (State s) a -> (s, a)
 blah = state
+
 ()


### PR DESCRIPTION
This fixes issue with console.uu, which previously was not typechecking.

Other changes:

* `Show` instance for `Term` no longer requires `Show` on the annotation type.
* Added an example of a terrible parse error we discovered to the poor-error-messages directory.