### PR TITLE
Add `expectEqual` to EasyTest.

### DIFF
--- a/yaks/easytest/src/EasyTest.hs
+++ b/yaks/easytest/src/EasyTest.hs
@@ -55,6 +55,10 @@ expect :: HasCallStack => Bool -> Test ()
 expect False = crash "unexpected"
 expect True = ok
 
+expectEqual :: (Eq a, Show a) => a -> a -> Test ()
+expectEqual expected actual = if expected == actual then ok
+                  else crash $ unlines ["", (show actual), "** did not equal expected value **", (show expected)]
+
 expectJust :: HasCallStack => Maybe a -> Test a
 expectJust Nothing = crash "expected Just, got Nothing"
 expectJust (Just a) = ok >> pure a


### PR DESCRIPTION
I started using EasyTest in a personal project and found I needed a function like this.  Is this reasonable or is there another way to achieve this?