### PR TITLE
TDNR resolves definitions in the same source file

### DIFF
--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -14,7 +14,6 @@ import           Data.Functor.Identity (runIdentity, Identity(..))
 import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Maybe
-import qualified Data.Text as Text
 import qualified Unison.Builtin as B
 import qualified Unison.Codecs as Codecs
 import           Unison.DataDeclaration (DataDeclaration')
@@ -74,14 +73,13 @@ synthesizeFile unisonFile
       dataDeclaration r = pure $ fromMaybe (die "data" r) $ Map.lookup r datas
       effectDeclaration r =
         pure $ fromMaybe (die "effect" r) $ Map.lookup r effects
-      unqualified = last . Text.splitOn "."
       typeSigs    = Map.fromList $ fmap
         (\(v, (_tm, typ)) -> (Builtin (Var.name v), typ))
         B.builtinTypedTerms
       unqualifiedLookup = Map.fromListWith mappend $ fmap
         (\(v, (_tm, typ)) ->
-          ( unqualified $ Var.name v
-          , [Typechecker.NamedReference (Var.name v) typ]
+          ( Var.unqualified v
+          , [Typechecker.NamedReference (Var.name v) typ True]
           )
         )
         B.builtinTypedTerms

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -359,7 +359,7 @@ renderTypeError env e src = case e of
           ]
           where
             formatSuggestion :: C.Suggestion v loc -> AT.AnnotatedDocument Color.Style
-            formatSuggestion (C.Suggestion name typ) =
+            formatSuggestion (C.Suggestion name typ _) =
               "  - " <> fromString (Text.unpack name)
               <> " : " <> renderType' env typ
     ]
@@ -571,7 +571,7 @@ renderType env f = renderType0 env f (0 :: Int) where
 
 renderSuggestion :: (IsString s, Semigroup s, Var v)
                  => Env -> C.Suggestion v loc -> s
-renderSuggestion env (C.Suggestion name typ) =
+renderSuggestion env (C.Suggestion name typ _) =
   fromString (Text.unpack name) <> " : " <> renderType' env typ
 
 spaces :: (IsString a, Monoid a) => (b -> a) -> [b] -> a

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -143,6 +143,7 @@ type ConstructorId = Int
 data Suggestion v loc =
   Suggestion { suggestionName :: Text
              , suggestionType :: Type v loc
+             , builtin :: Bool
              }
   deriving Show
 

--- a/parser-typechecker/src/Unison/Var.hs
+++ b/parser-typechecker/src/Unison/Var.hs
@@ -36,6 +36,9 @@ class (Show v, Eq v, Ord v) => Var v where
   freshIn :: Set v -> v -> v
   freshenId :: Word -> v -> v
 
+  unqualified :: v -> Text
+  unqualified = last . Text.splitOn "." . name
+
 type Kind = String
 
 kind :: Var v => v -> Kind

--- a/unison-src/tests/tdnr3.u
+++ b/unison-src/tests/tdnr3.u
@@ -1,0 +1,6 @@
+-- Local definitions should be resolved by type
+
+Foo.bar x = x + 1
+
+bar 99
+


### PR DESCRIPTION
This change allows TDNR to resolve situations like:

```
Local.foo x = x + 1

> foo 99 
```
