### PR TITLE
Change `Reference` to support indexing into a strongly connected component

### DIFF
--- a/parser-typechecker/src/Unison/ABT.hs
+++ b/parser-typechecker/src/Unison/ABT.hs
@@ -476,7 +476,7 @@ hashComponent byName = let
 -- components (using the `termFromHash` function).
 hashComponents
   :: (Functor f, Hashable1 f, Foldable f, Eq v, Var v, Ord h, Accumulate h)
-  => (h -> Word64 -> Term f v ())
+  => (h -> Word64 -> Word64 -> Term f v ())
   -> Map.Map v (Term f v a)
   -> [(h, [(v, Term f v a)])]
 hashComponents termFromHash termsByName = let
@@ -485,7 +485,8 @@ hashComponents termFromHash termsByName = let
   go prevHashes (component : rest) = let
     sub = substsInheritAnnotation (Map.toList prevHashes)
     (h, sortedComponent) = hashComponent $ Map.fromList [ (v, sub t) | (v, t) <- component ]
-    curHashes = Map.fromList [ (v, termFromHash h i) | ((v, _),i) <- sortedComponent `zip` [1..]]
+    size = fromIntegral (length sortedComponent)
+    curHashes = Map.fromList [ (v, termFromHash h i size) | ((v, _),i) <- sortedComponent `zip` [0..]]
     newHashes = prevHashes `Map.union` curHashes
     newHashesL = Map.toList newHashes
     sortedComponent' = [ (v, substsInheritAnnotation newHashesL t) | (v, t) <- sortedComponent ]

--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -81,9 +81,10 @@ builtinDataAndEffectCtors = (mkConstructors =<< builtinDataDecls')
 builtinTypes :: forall v. Var v => [(v, R.Reference)]
 builtinTypes = builtinTypes' ++ (f <$> Map.toList (builtinDataDecls @v))
   where f (r@(R.Builtin s), _) = (Var.named s, r)
-        f (R.Derived h, _) =
+        f (R.Derived h _ _, _) =
           error $ "expected builtin to be all R.Builtins; " ++
                   "don't know what name to assign to " ++ show h
+        f r = error $ "what is this " ++ show r
 
 builtinTypes' :: Var v => [(v, R.Reference)]
 builtinTypes' = (Var.named &&& R.Builtin) <$>

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -8,8 +8,8 @@ import           Data.Set               (Set)
 import           Unison.Codebase.Branch (Branch)
 import           Unison.Codebase.Name   (Name)
 import qualified Unison.DataDeclaration as DD
-import           Unison.Hash            (Hash)
 import           Unison.Reference       (Reference)
+import qualified Unison.Reference as Reference
 import qualified Unison.Term            as Term
 import qualified Unison.Type            as Type
 
@@ -20,12 +20,12 @@ type Type v a = Type.AnnotatedType v a
 type Decl v a = Either (EffectDeclaration v a) (DataDeclaration v a)
 
 data Codebase m v a =
-  Codebase { getTerm            :: Hash -> m (Maybe (Term v a))
+  Codebase { getTerm            :: Reference.Id -> m (Maybe (Term v a))
            , getTypeOfTerm      :: Reference -> m (Maybe (Type v a))
-           , putTerm            :: Hash -> Term v a -> Type v a -> m ()
+           , putTerm            :: Reference.Id -> Term v a -> Type v a -> m ()
 
-           , getTypeDeclaration :: Hash -> m (Maybe (Decl v a))
-           , putTypeDeclaration :: Hash -> Decl v a -> m ()
+           , getTypeDeclaration :: Reference.Id -> m (Maybe (Decl v a))
+           , putTypeDeclaration :: Reference.Id -> Decl v a -> m ()
 
            , branches           :: m [Name]
            , getBranch          :: Name -> m (Maybe Branch)

--- a/parser-typechecker/src/Unison/Codebase/Serialization/V0.hs
+++ b/parser-typechecker/src/Unison/Codebase/Serialization/V0.hs
@@ -130,16 +130,19 @@ putReference r = case r of
   Reference.Builtin name -> do
     putWord8 0
     putText name
-  Reference.Derived hash -> do
+  Reference.Derived hash i n -> do
     putWord8 1
     putHash hash
+    putLength i
+    putLength n
+  _ -> error "unpossible"
 
 getReference :: MonadGet m => m Reference
 getReference = do
   tag <- getWord8
   case tag of
     0 -> Reference.Builtin <$> getText
-    1 -> Reference.Derived <$> getHash
+    1 -> Reference.DerivedPrivate_ <$> (Reference.Id <$> getHash <*> getLength <*> getLength)
     _ -> unknownTag "Reference" tag
 
 putMaybe :: MonadPut m => Maybe a -> (a -> m ()) -> m ()

--- a/parser-typechecker/src/Unison/Codecs.hs
+++ b/parser-typechecker/src/Unison/Codecs.hs
@@ -21,7 +21,7 @@ import qualified Unison.ABT as ABT
 import qualified Unison.Blank as Blank
 import qualified Unison.DataDeclaration as DD
 import qualified Unison.Hash as Hash
-import           Unison.Reference
+import           Unison.Reference (Reference(..))
 import           Unison.Term
 import qualified Unison.Typechecker.Components as Components
 import           Unison.UnisonFile (UnisonFile(..))

--- a/parser-typechecker/src/Unison/Codecs.hs
+++ b/parser-typechecker/src/Unison/Codecs.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE PatternSynonyms, FlexibleContexts #-}
 
 module Unison.Codecs where
 
@@ -21,7 +21,7 @@ import qualified Unison.ABT as ABT
 import qualified Unison.Blank as Blank
 import qualified Unison.DataDeclaration as DD
 import qualified Unison.Hash as Hash
-import           Unison.Reference (Reference(..))
+import           Unison.Reference (Reference, pattern Builtin, pattern Derived)
 import           Unison.Term
 import qualified Unison.Typechecker.Components as Components
 import           Unison.UnisonFile (UnisonFile(..))
@@ -279,11 +279,14 @@ serializeReference ref = case ref of
   Builtin text -> do
     putWord8 0
     lengthEncode text
-  Derived hash -> do
+  Derived hash i n -> do
     putWord8 1
     let bs = Hash.toBytes hash
     putLength $ B.length bs
     putByteString bs
+    putLength i
+    putLength n
+  _ -> error "impossible"
 
 serializeConstructorArities :: MonadPut m => Reference -> [Int] -> m ()
 serializeConstructorArities r constructorArities = do

--- a/parser-typechecker/src/Unison/DataDeclaration.hs
+++ b/parser-typechecker/src/Unison/DataDeclaration.hs
@@ -138,9 +138,9 @@ hashDecls0
   -> [(v, Reference)]
 hashDecls0 decls = let
   abts  = toABT <$> decls
-  ref h i n = ABT.tm (Type (Type.Ref (Reference.derived h i n)))
-  cs = ABT.hashComponents ref abts
-  in [(v,r) | ((v,_),r) <- Reference.components cs ]
+  ref r = ABT.tm (Type (Type.Ref r))
+  cs = Reference.hashComponents ref abts
+  in [(v,r) | (v, (r,_)) <- Map.toList cs ]
 
 -- | compute the hashes of these user defined types and update any free vars
 --   corresponding to these decls with the resulting hashes

--- a/parser-typechecker/src/Unison/DataDeclaration.hs
+++ b/parser-typechecker/src/Unison/DataDeclaration.hs
@@ -6,9 +6,8 @@
 
 module Unison.DataDeclaration where
 
-import           Data.Bifunctor (second)
 import           Data.Functor
-import           Data.Map (Map, intersectionWith)
+import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Prelude hiding (cycle)
 import           Prelude.Extras (Show1)
@@ -20,13 +19,12 @@ import qualified Unison.Reference as Reference
 import           Unison.Type (AnnotatedType)
 import qualified Unison.Type as Type
 import           Unison.Var (Var)
-import Unison.Hash (Hash)
 
 type DataDeclaration v = DataDeclaration' v ()
 
 data DataDeclaration' v a = DataDeclaration {
   annotation :: a,
-  bound :: [v], -- todo: do we actually use the names? or just the length
+  bound :: [v],
   constructors' :: [(a, v, AnnotatedType v a)]
 } deriving (Show, Functor)
 
@@ -133,34 +131,16 @@ fromABT (ABT.AbsN' bound (
     [((), v, unsafeUnwrapType t) | (v, t) <- names `zip` stuff]
 fromABT a = error $ "ABT not of correct form to convert to DataDeclaration: " ++ show a
 
-hashDecls2
-  :: (Eq v, Var v)
-  => Map v (DataDeclaration' v a)
-  -> [(Hash, [v])]
-hashDecls2 decls = fixup <$> ABT.hashComponents mkRef (toABT . void <$> decls)
-  where mkRef h i = ABT.tm (Type (Type.Ref (Reference.Derived h)))
-        fixup (h, scc) = (h, fst <$> scc)
--- use this to impl hashDecls
-
 -- Implementation detail of `hashDecls`, works with unannotated data decls
 hashDecls0
   :: (Eq v, Var v)
   => Map v (DataDeclaration' v ())
-  -> [(v, Reference, DataDeclaration' v ())]
-hashDecls0 decls = reverse . snd . foldl f ([], []) $ ABT.components abts
- where
-  f (m, newDecls) cycle =
-    let
-      substed = second (ABT.substs m) <$> cycle
-      hs      = second Reference.Derived <$> hash substed
-      newM    = second toRef <$> hs
-      joined  = intersectionWith (,) (Map.fromList hs) (Map.fromList substed)
-    in
-      ( newM ++ m
-      , [ (v, r, fromABT d) | (v, (r, d)) <- Map.toList joined ] ++ newDecls
-      )
-  abts  = second toABT <$> Map.toList decls
-  toRef = ABT.tm . Type . Type.Ref
+  -> [(v, Reference)]
+hashDecls0 decls = let
+  abts  = toABT <$> decls
+  ref h i n = ABT.tm (Type (Type.Ref (Reference.derived h i n)))
+  cs = ABT.hashComponents ref abts
+  in [(v,r) | ((v,_),r) <- Reference.components cs ]
 
 -- | compute the hashes of these user defined types and update any free vars
 --   corresponding to these decls with the resulting hashes
@@ -173,10 +153,9 @@ hashDecls
   => Map v (DataDeclaration' v a)
   -> [(v, Reference, DataDeclaration' v a)]
 hashDecls decls =
-  let hs       = hashDecls0 (void <$> decls)
+  let varToRef = hashDecls0 (void <$> decls)
       decls'   = bindDecls decls varToRef
-      varToRef = [ (v, r) | (v, r, _) <- hs ]
-  in  [ (v, r, dd) | (v, r, _) <- hs, Just dd <- [Map.lookup v decls'] ]
+  in  [ (v, r, dd) | (v, r) <- varToRef, Just dd <- [Map.lookup v decls'] ]
 
 bindDecls :: Var v => Map v (DataDeclaration' v a) -> [(v, Reference)] -> Map v (DataDeclaration' v a)
 bindDecls decls refs = bindBuiltins refs <$> decls

--- a/parser-typechecker/src/Unison/DataDeclaration.hs
+++ b/parser-typechecker/src/Unison/DataDeclaration.hs
@@ -20,6 +20,7 @@ import qualified Unison.Reference as Reference
 import           Unison.Type (AnnotatedType)
 import qualified Unison.Type as Type
 import           Unison.Var (Var)
+import Unison.Hash (Hash)
 
 type DataDeclaration v = DataDeclaration' v ()
 
@@ -131,6 +132,15 @@ fromABT (ABT.AbsN' bound (
     bound
     [((), v, unsafeUnwrapType t) | (v, t) <- names `zip` stuff]
 fromABT a = error $ "ABT not of correct form to convert to DataDeclaration: " ++ show a
+
+hashDecls2
+  :: (Eq v, Var v)
+  => Map v (DataDeclaration' v a)
+  -> [(Hash, [v])]
+hashDecls2 decls = fixup <$> ABT.hashComponents mkRef (toABT . void <$> decls)
+  where mkRef h i = ABT.tm (Type (Type.Ref (Reference.Derived h)))
+        fixup (h, scc) = (h, fst <$> scc)
+-- use this to impl hashDecls
 
 -- Implementation detail of `hashDecls`, works with unannotated data decls
 hashDecls0

--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -22,7 +22,7 @@ import           Unison.DataDeclaration (DataDeclaration')
 import           Unison.Parser (Ann(Intrinsic), PEnv)
 import qualified Unison.Parsers as Parsers
 import qualified Unison.PrintError as PrintError
-import           Unison.Reference (Reference(..))
+import           Unison.Reference (Reference, pattern Builtin)
 import           Unison.Result (Result(..), Note(..))
 import qualified Unison.Result as Result
 import           Unison.Term (AnnotatedTerm)

--- a/parser-typechecker/src/Unison/Reference.hs
+++ b/parser-typechecker/src/Unison/Reference.hs
@@ -6,10 +6,25 @@ import GHC.Generics
 import Unison.Hashable as Hashable
 import qualified Data.Text as Text
 import qualified Unison.Hash as H
+import Data.Word (Word64)
 
 -- could add a `Word` parameter to `Derived`
 -- associated with each hash would actually be a list of terms / type decls
 data Reference = Builtin Text.Text | Derived H.Hash deriving (Eq,Ord,Generic)
+
+type Pos = Word64
+type Size = Word64
+
+derived :: H.Hash -> Pos -> Size -> Reference
+derived _h _pos _size = error "todo"
+
+component :: H.Hash -> [k] -> [(k, Reference)]
+component h ks = let
+  size = fromIntegral (length ks)
+  in [ (k, derived h i size) | (k, i) <- ks `zip` [0..]]
+
+components :: [(H.Hash, [k])] -> [[(k, Reference)]]
+components sccs = uncurry component <$> sccs
 
 instance Show Reference where
   show (Builtin t) = Text.unpack t

--- a/parser-typechecker/src/Unison/Reference.hs
+++ b/parser-typechecker/src/Unison/Reference.hs
@@ -1,48 +1,95 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE PatternSynonyms #-}
 
-module Unison.Reference where
+module Unison.Reference
+  (Reference(DerivedPrivate_),
+     pattern Builtin,
+     pattern Derived,
+     pattern DerivedId,
+   Id(..),
+   derivedBase58,
+   Component, members,
+   components,
+   hashComponents,
+   groupByComponent,
+   componentFor) where
 
 import GHC.Generics
+import Data.Maybe (fromJust)
 import Unison.Hashable as Hashable
 import qualified Data.Text as Text
 import qualified Unison.Hash as H
 import Data.Word (Word64)
 import Control.Monad (join)
 import qualified Data.Map as Map
+import qualified Data.Set as Set
+import Data.Set (Set)
 import Data.List
 import Data.Foldable (toList)
+import Data.Text (Text)
+import qualified Unison.ABT as ABT
+import qualified Unison.Var as Var
 
--- could add a `Word` parameter to `Derived`
--- associated with each hash would actually be a list of terms / type decls
-data Reference = Builtin Text.Text | Derived H.Hash deriving (Eq,Ord,Generic)
+data Reference
+  = Builtin_ Text.Text
+  -- `Derived` can be part of a strongly connected component.
+  -- The `Pos` refers to a particular element of the component
+  -- and the `Size` is the number of elements in the component.
+  -- Using an ugly name so no one tempted to use this
+  | DerivedPrivate_ Id deriving (Eq,Ord,Generic)
+
+data Id = Id H.Hash Pos Size deriving (Eq,Ord,Generic)
+
+pattern Builtin t = Builtin_ t
+pattern Derived h n i <- DerivedPrivate_ (Id h n i)
+pattern DerivedId id <- DerivedPrivate_ id
 
 type Pos = Word64
 type Size = Word64
 
-derived :: H.Hash -> Pos -> Size -> Reference
-derived _h _pos _size = error "todo"
+newtype Component = Component { members :: Set Reference }
+
+componentFor :: Reference -> Component
+componentFor b@(Builtin_ _) = Component (Set.singleton b)
+componentFor (DerivedPrivate_ (Id h _ n)) =
+  Component (Set.fromList [ DerivedPrivate_ (Id h i n) | i <- take (fromIntegral n) [0..]])
+
+derivedBase58 :: Text -> Pos -> Size -> Reference
+derivedBase58 b58 i n = DerivedPrivate_ (Id (fromJust h) i n)
+  where
+  h = H.fromBase58 b58
+
+hashComponents ::
+     (Functor f, Hashable1 f, Foldable f, Eq v, Var.Var v)
+  => (Reference -> ABT.Term f v ())
+  -> Map.Map v (ABT.Term f v a)
+  -> Map.Map v (Reference, ABT.Term f v a)
+hashComponents embedRef tms =
+  Map.fromList [ (v, (r,e)) | ((v,e), r) <- cs ]
+  where cs = components $ ABT.hashComponents ref tms
+        ref h i n = embedRef (DerivedPrivate_ (Id h i n))
 
 component :: H.Hash -> [k] -> [(k, Reference)]
 component h ks = let
   size = fromIntegral (length ks)
-  in [ (k, derived h i size) | (k, i) <- ks `zip` [0..]]
+  in [ (k, DerivedPrivate_ (Id h i size)) | (k, i) <- ks `zip` [0..]]
 
 components :: [(H.Hash, [k])] -> [(k, Reference)]
 components sccs = join $ uncurry component <$> sccs
 
-groupComponents :: [(k, Reference)] -> [[(k, Reference)]]
-groupComponents refs = done $ foldl' insert Map.empty refs
+groupByComponent :: [(k, Reference)] -> [[(k, Reference)]]
+groupByComponent refs = done $ foldl' insert Map.empty refs
   where
-    insert m (k, r@(Derived h)) =
+    insert m (k, r@(Derived h _ _)) =
       Map.unionWith (<>) m (Map.fromList [(Right h, [(k,r)])])
     insert m (k, r) =
       Map.unionWith (<>) m (Map.fromList [(Left r, [(k,r)])])
     done m = sortOn snd <$> toList m
 
 instance Show Reference where
-  show (Builtin t) = Text.unpack t
-  show (Derived h) = "#" <> show h
+  show (Builtin_ t) = Text.unpack t
+  show (DerivedPrivate_ (Id h i n)) = "#" <> show i <> "Q" <> show n <> "Q" <> show h
 
 instance Hashable.Hashable Reference where
-  tokens (Builtin txt) = [Hashable.Tag 0, Hashable.Text txt]
-  tokens (Derived h) = [Hashable.Tag 0, Hashable.Bytes (H.toBytes h)]
+  tokens (Builtin_ txt) = [Hashable.Tag 0, Hashable.Text txt]
+  tokens (DerivedPrivate_ (Id h i n)) = [Hashable.Tag 1, Hashable.Bytes (H.toBytes h), Hashable.Nat i, Hashable.Nat n]

--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -185,7 +185,9 @@ ifthen = label "if" $ do
   pure $ Term.iff (ann start <> ann f) c t f
 
 hashLit :: Var v => TermP v
-hashLit = tok Term.derived <$> hashLiteral
+hashLit =
+  -- todo: should probably come up with syntax for hash component refs
+  tok (\ann h -> Term.ref ann (R.DerivedPrivate_ (R.Id h 0 1))) <$> hashLiteral
 
 prefixTerm :: Var v => TermP v
 prefixTerm = tok Term.var <$> prefixVar

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -12,7 +12,7 @@ import           Unison.ABT (pattern AbsN')
 import qualified Unison.Blank as Blank
 import           Unison.PatternP (Pattern)
 import qualified Unison.PatternP as Pattern
-import           Unison.Reference (Reference(..))
+import           Unison.Reference (Reference)
 import           Unison.Term
 import qualified Unison.TypePrinter as TypePrinter
 import           Unison.Var (Var)

--- a/parser-typechecker/src/Unison/Type.hs
+++ b/parser-typechecker/src/Unison/Type.hs
@@ -12,8 +12,6 @@
 module Unison.Type where
 
 -- import Debug.Trace
-import qualified Unison.Hash as Hash
-import Data.Maybe (fromJust)
 import Control.Monad (join)
 import Data.Functor.Identity (runIdentity)
 import Data.Functor.Const (Const(..), getConst)
@@ -195,9 +193,7 @@ ref :: Ord v => a -> Reference -> AnnotatedType v a
 ref a = ABT.tm' a . Ref
 
 derivedBase58 :: Ord v => Text -> a -> AnnotatedType v a
-derivedBase58 base58 a = ref a $ Reference.Derived (fromJust h)
-  where
-  h = Hash.fromBase58 base58
+derivedBase58 base58 a = ref a $ Reference.derivedBase58 base58 0 1
 
 unit :: Ord v => a -> AnnotatedType v a
 unit = derivedBase58    "2cJAAHeh81dVaZFVfJQRvWo58QYnUNbErbFQtjVM5kKKMEDa3RpfDbiMJuxwXyaQKyv69qDptkkkM6y7X51tCDit"

--- a/parser-typechecker/src/Unison/TypePrinter.hs
+++ b/parser-typechecker/src/Unison/TypePrinter.hs
@@ -10,7 +10,7 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Foldable (fold)
 import           Data.Maybe (isJust)
-import           Unison.Reference (Reference(..))
+import           Unison.Reference (Reference, pattern Builtin)
 import           Unison.Type
 import           Unison.Var (Var)
 import qualified Unison.Var as Var

--- a/parser-typechecker/src/Unison/Typechecker.hs
+++ b/parser-typechecker/src/Unison/Typechecker.hs
@@ -31,7 +31,7 @@ import qualified Data.Text as Text
 import qualified Unison.ABT as ABT
 import qualified Unison.Blank as B
 import           Unison.DataDeclaration (DataDeclaration', EffectDeclaration')
-import           Unison.Reference (Reference(..))
+import           Unison.Reference (Reference, pattern Builtin)
 import           Unison.Result (Result(..))
 import           Unison.Term (AnnotatedTerm)
 import qualified Unison.Term as Term

--- a/parser-typechecker/src/Unison/UnisonFile.hs
+++ b/parser-typechecker/src/Unison/UnisonFile.hs
@@ -36,6 +36,18 @@ data TypecheckedUnisonFile v a = TypecheckedUnisonFile {
   terms :: [[(v, AnnotatedTerm v a, AnnotatedType v a)]]
 }
 
+-- Convenience function for extracting the term and type decl components
+-- of a Unison file. This would be presented to the user for adding to
+-- the codebase.
+components :: Var v => TypecheckedUnisonFile v a ->
+  ([[((v, AnnotatedTerm v a, AnnotatedType v a), Reference)]],
+   [[((v, Either (EffectDeclaration' v a) (DataDeclaration' v a)), Reference)]])
+components uf = let
+  tms = [ ((v,e,t), r) | (v, (r,e,t)) <- Map.toList $ hashTerms (terms uf) ]
+  ds = [ ((v, Right d), r) | (v, (r, d)) <- Map.toList $ dataDeclarations' uf ] ++
+       [ ((v, Left eff), r) | (v, (r, eff)) <- Map.toList $ effectDeclarations' uf ]
+  in (Reference.groupByComponent tms, Reference.groupByComponent ds)
+
 hashTerms ::
      Var v
   => [[(v, AnnotatedTerm v a, AnnotatedType v a)]]

--- a/parser-typechecker/src/Unison/UnisonFile.hs
+++ b/parser-typechecker/src/Unison/UnisonFile.hs
@@ -2,6 +2,7 @@
 
 module Unison.UnisonFile where
 
+import Control.Monad (join)
 import           Data.Bifunctor (second)
 import qualified Data.Foldable as Foldable
 import           Data.Map (Map)
@@ -19,6 +20,7 @@ import qualified Unison.Term as Term
 import           Unison.Type (AnnotatedType)
 import           Unison.Var (Var)
 import qualified Unison.Var as Var
+import qualified Unison.Reference as Reference
 
 data UnisonFile v a = UnisonFile {
   dataDeclarations :: Map v (Reference, DataDeclaration' v a),
@@ -34,9 +36,17 @@ data TypecheckedUnisonFile v a = TypecheckedUnisonFile {
   terms :: [[(v, AnnotatedTerm v a, AnnotatedType v a)]]
 }
 
-hashTermCycles ::
-  [[(v, AnnotatedTerm v a, AnnotatedType v a)]] -> Map v Reference
-hashTermCycles _components = error "todo"
+hashTerms ::
+     Var v
+  => [[(v, AnnotatedTerm v a, AnnotatedType v a)]]
+  -> Map v (Reference, AnnotatedTerm v a, AnnotatedType v a)
+hashTerms components = let
+  types = Map.fromList [(v,t) | (v,_,t) <- join components ]
+  terms = Map.fromList [(v,e) | (v,e,_) <- join components ]
+  ref r = Term.ref() r
+  hcs = Reference.hashComponents ref terms
+  in Map.fromList [ (v, (r, e, t)) | (v, (r, e)) <- Map.toList hcs,
+                                     Just t <- [Map.lookup v types] ]
 
 type CtorLookup = Map String (Reference, Int)
 

--- a/parser-typechecker/tests/Unison/Test/TermPrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/TermPrinter.hs
@@ -20,7 +20,8 @@ tc_diff_rtt rtt s expected width =
    let input_term = Unison.Builtin.tm s :: Unison.Term.AnnotatedTerm Symbol Ann
        get_names x _ = case x of
                          Builtin t -> t
-                         Derived _ -> Text.empty
+                         Derived _ _ _ -> Text.empty
+                         _ -> error "impossible"
        actual = if width == 0
                 then PP.renderUnbroken $ pretty get_names (-1) input_term
                 else PP.renderBroken width True '\n' $ pretty get_names (-1) input_term

--- a/parser-typechecker/tests/Unison/Test/TypePrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/TypePrinter.hs
@@ -20,7 +20,8 @@ tc_diff_rtt rtt s expected width =
    let input_type = Unison.Builtin.t s :: Unison.Type.AnnotatedType Symbol Ann
        get_names x = case x of
                        Builtin t -> t
-                       Derived _ -> Text.empty
+                       Derived _ _ _ -> Text.empty
+                       _ -> error "impossible"
        actual = if width == 0
                 then PP.renderUnbroken $ pretty get_names (-1) input_type
                 else PP.renderBroken width True '\n' $ pretty get_names (-1) input_type

--- a/runtime-jvm/main/src/main/scala/Codecs.scala
+++ b/runtime-jvm/main/src/main/scala/Codecs.scala
@@ -283,16 +283,18 @@ object Codecs {
 
   final def decodeId(source: Source): Id = (source.getByte: @switch) match {
     case 0 => Id.Builtin(source.getString)
-    case 1 => Id.HashRef(Hash(source.getFramed))
+    case 1 => Id.HashRef(Id.H(Hash(source.getFramed), source.getVarLong, source.getVarLong))
   }
 
   final def encodeId(id: Id, sink: Sink): Unit = id match {
     case Id.Builtin(name) =>
       sink putByte 0
       sink putString name.toString
-    case Id.HashRef(h) =>
+    case Id.HashRef(Id.H(h, i, n)) =>
       sink putByte 1
       sink putFramed h.bytes
+      sink putVarLong i
+      sink putVarLong n
   }
 
   final def decodeConstructorArities(source: Source): List[(Id, List[Int])] =

--- a/runtime-jvm/main/src/main/scala/Environment.scala
+++ b/runtime-jvm/main/src/main/scala/Environment.scala
@@ -5,7 +5,7 @@ import Term.Name
 
 case class Environment(
   builtins: Map[Name, Computation],
-  userDefined: Map[Hash, Computation],
+  userDefined: Map[Id.H, Computation],
   dataConstructors: Map[(Id,ConstructorId), Computation],
   effects: Map[(Id,ConstructorId), Computation]
 )

--- a/runtime-jvm/main/src/main/scala/Term.scala
+++ b/runtime-jvm/main/src/main/scala/Term.scala
@@ -316,7 +316,7 @@ object Term {
   object Id {
     def apply(id: org.unisonweb.Id): Term = Tm(Id_(id))
     def apply(n: Name): Term = Tm(Id_(org.unisonweb.Id(n)))
-    def apply(h: Hash): Term = Tm(Id_(org.unisonweb.Id(h)))
+    def apply(h: org.unisonweb.Id.H): Term = Tm(Id_(org.unisonweb.Id(h)))
     def unapply[A](t: AnnotatedTerm[F,A]): Option[Id] = t match {
       case Tm(Id_(id)) => Some(id)
       case _ => None

--- a/runtime-jvm/main/src/main/scala/compilation.scala
+++ b/runtime-jvm/main/src/main/scala/compilation.scala
@@ -972,7 +972,7 @@ package object compilation {
 
   case class Environment2(
     builtins: Map[Name, Computation],
-    userDefined: Map[Hash, Computation],
+    userDefined: Map[Id.H, Computation],
     dataConstructors: Map[(Id,ConstructorId), Computation],
     effects: Map[(Id,ConstructorId), Computation],
     // callback invoked on watch expressions during execution

--- a/runtime-jvm/main/src/main/scala/unisonweb.scala
+++ b/runtime-jvm/main/src/main/scala/unisonweb.scala
@@ -15,10 +15,11 @@ package object unisonweb {
 
   object Id {
     def apply(n: Name): Id = Builtin(n)
-    def apply(h: Hash): Id = HashRef(h)
+    def apply(h: H): Id = HashRef(h)
 
     case class Builtin(name: Term.Name) extends Id
-    case class HashRef(hash: Hash) extends Id
+    case class HashRef(id: H) extends Id
+    case class H(hash: Hash, pos: Long, size: Long)
   }
 
   case class ConstructorId(toInt: Int) extends AnyVal

--- a/runtime-jvm/main/src/main/scala/util/PrettyPrint.scala
+++ b/runtime-jvm/main/src/main/scala/util/PrettyPrint.scala
@@ -144,9 +144,10 @@ object PrettyPrint {
 
   def prettyId(typeId: Id, ctorId: ConstructorId): PrettyPrint = typeId match {
     case Id.Builtin(name) => prettyName(name) <> s"#${ctorId.toInt}"
-    case Id.HashRef(h) =>
+    case Id.HashRef(Id.H(h,i,n)) =>
       val hashString = Base58.encode(h.bytes).take(hashPrecision)
-      s"#$hashString#${ctorId.toInt}"
+      if (n == 1) s"#$hashString#${ctorId.toInt}"
+      else s"#${i}-$hashString#${ctorId.toInt}"
   }
 
   def distributeNames(patterns: Seq[Pattern], names: List[Name]): Seq[PrettyPrint] =


### PR DESCRIPTION
Main change is that `Reference.Derived` can now point to a single element of a strongly connected component. See the type `Reference.Id` - this is what you'll pass around instead of a `Hash`.

See `UnisonFile.components` for a simple convenience function to pull the components out of a typechecked `UnisonFile` and compute their hashes for terms and types in the correct order. The results of this function can be presented to the user when asking what they'd like to add to the codebase. Having this function to support the codebase editor `add` command was basically the whole reason for all the refactoring.

One caveat is that the components may depend on each other so if the user cherry-picks things to add, we need to ensure dependencies are added as well (and we should notify the user we're doing this).

This PR doesn't modify `Branch` at all. We talked about changing it to use `Reference.Component` in place of `Reference`. I'm not totally sure that's necessary, I think it can make sense to edit elements of a component individually (for instance, that might be how you break up a cycle), even if that's not what you want to do most of the time. In any case, if that changes let's do it with a separate PR.

Also note: as a result of the changes, serialized form differs slightly on both Haskell and Scala side.