### PR TITLE
Change comment to match function behavour.

### DIFF
--- a/parser-typechecker/src/Unison/ABT.hs
+++ b/parser-typechecker/src/Unison/ABT.hs
@@ -121,7 +121,7 @@ annotateBound t = go Set.empty t where
     Abs x body -> abs' a x (go (Set.insert x bound) body)
     Tm body -> tm' a (go bound <$> body)
 
--- | Return the list of all variables bound by this ABT
+-- | Return the set of all variables bound by this ABT
 bound :: (Ord v, Foldable f) => Term f v a -> Set v
 bound t = Set.fromList (bound' t)
 


### PR DESCRIPTION
`bound'` returns the list of all bound variables whereas `bound` returns the set of all bound variables. Changed the comment accordingly.