### PR TITLE
Add a nicer error message for empty match lists

### DIFF
--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -80,8 +80,7 @@ match = do
   start <- reserved "case"
   scrutinee <- term
   _ <- openBlockWith "of"
-  -- TODO: Produce a nice error message for empty match list
-  cases <- sepBy1 semi matchCase
+  cases <- sepBy1 semi matchCase P.<?> "at least one case in case/of"
   _ <- closeBlock
   pure $ Term.match (ann start <> ann (last cases)) scrutinee cases
 


### PR DESCRIPTION
If a match the match list is empty you know get the error `expecting at least one case in case/of`