### PR TITLE
Remove example which know has a good error message

### DIFF
--- a/unison-src/errors/poor-error-message/ifcond.u
+++ b/unison-src/errors/poor-error-message/ifcond.u
@@ -1,2 +1,0 @@
-if 3 then 4 else 5
-


### PR DESCRIPTION
The error for the example is
`The condition for an if-expression has to be Boolean, but this one is UInt64:

    1 | if 3 then 4 else 5
`
I think that's a pretty clear error message