### PR TITLE
The `todo` command

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -5,29 +5,35 @@
 {-# LANGUAGE TypeApplications #-}
 module Unison.Builtin where
 
-import           Control.Arrow (first)
-import qualified Data.Map as Map
-import qualified Text.Megaparsec.Error as MPE
-import qualified Unison.ABT as ABT
-import           Unison.DataDeclaration (DataDeclaration', EffectDeclaration')
-import qualified Unison.DataDeclaration as DD
-import qualified Unison.FileParser as FileParser
-import qualified Unison.Lexer as L
-import           Unison.Parser (Ann(..))
-import qualified Unison.Parser as Parser
-import           Unison.PrintError (prettyParseError)
-import qualified Unison.Reference as R
-import           Unison.Symbol (Symbol)
-import qualified Unison.Term as Term
-import qualified Unison.TermParser as TermParser
-import           Unison.Type (AnnotatedType)
-import qualified Unison.Type as Type
-import qualified Unison.TypeParser as TypeParser
-import qualified Unison.Util.ColorText as Color
-import           Unison.Var (Var)
-import qualified Unison.Var as Var
-import Unison.Names (Names, Name)
-import qualified Unison.Names as Names
+import           Control.Arrow                  ( first )
+import qualified Data.Map                      as Map
+import           Data.Set                       ( Set )
+import qualified Data.Set                      as Set
+import qualified Text.Megaparsec.Error         as MPE
+import qualified Unison.ABT                    as ABT
+import           Unison.DataDeclaration         ( DataDeclaration'
+                                                , EffectDeclaration'
+                                                )
+import qualified Unison.DataDeclaration        as DD
+import qualified Unison.FileParser             as FileParser
+import qualified Unison.Lexer                  as L
+import           Unison.Parser                  ( Ann(..) )
+import qualified Unison.Parser                 as Parser
+import           Unison.PrintError              ( prettyParseError )
+import qualified Unison.Reference              as R
+import           Unison.Symbol                  ( Symbol )
+import qualified Unison.Term                   as Term
+import qualified Unison.TermParser             as TermParser
+import           Unison.Type                    ( AnnotatedType )
+import qualified Unison.Type                   as Type
+import qualified Unison.TypeParser             as TypeParser
+import qualified Unison.Util.ColorText         as Color
+import           Unison.Var                     ( Var )
+import qualified Unison.Var                    as Var
+import           Unison.Names                   ( Names
+                                                , Name
+                                                )
+import qualified Unison.Names                  as Names
 import qualified Unison.Typechecker.TypeLookup as TL
 
 type Term v = Term.AnnotatedTerm v Ann
@@ -122,6 +128,10 @@ builtinEffectDecls = []
 toSymbol :: Var v => R.Reference -> v
 toSymbol (R.Builtin txt) = Var.named txt
 toSymbol _ = error "unpossible"
+
+-- TODO
+dependents :: R.Reference -> Set R.Reference
+dependents = const Set.empty
 
 builtins0 :: Var v => Map.Map R.Reference (Type v)
 builtins0 = Map.fromList $

--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -136,12 +136,16 @@ toSymbol _ = error "unpossible"
 -- mention that type.
 builtinTypeDependents :: R.Reference -> Set R.Reference
 builtinTypeDependents r =
-  if r `elem` map snd builtinTypes then
+  if r `Set.member` allReferencedTypes then
     Set.fromList [
       k | (k, t) <- Map.toList (builtins0 @ Symbol)
         , r `Set.member` Type.dependencies t ]
   else
     Set.empty
+
+allReferencedTypes :: Set R.Reference
+allReferencedTypes =
+  Set.unions (Type.dependencies <$> Map.elems (builtins0 @Symbol))
 
 builtins0 :: Var v => Map.Map R.Reference (Type v)
 builtins0 = Map.fromList $

--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -65,10 +65,19 @@ names0 :: Names
 names0 = Names.fromTypes builtinTypes
 
 names :: Names
-names = Names.fromBuiltins (Map.keys $ builtins0 @Symbol)
-     <> Names.fromTypes builtinTypes
-     <> foldMap (DD.dataDeclToNames' @Symbol) builtinDataDecls
-     <> foldMap (DD.effectDeclToNames' @Symbol) builtinEffectDecls
+names = Names.fromBuiltins (Map.keys $ builtins0 @Symbol) <> allTypeNames
+
+allTypeNames :: Names
+allTypeNames =
+  Names.fromTypes builtinTypes
+    <> foldMap (DD.dataDeclToNames' @Symbol)   builtinDataDecls
+    <> foldMap (DD.effectDeclToNames' @Symbol) builtinEffectDecls
+
+isBuiltinTerm :: Name -> Bool
+isBuiltinTerm n = Map.member n $ Names.termNames names
+
+isBuiltinType :: Name -> Bool
+isBuiltinType n = Map.member n $ Names.typeNames names
 
 typeLookup :: Var v => TL.TypeLookup v Ann
 typeLookup =

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -10,7 +10,6 @@ module Unison.Codebase where
 import           Control.Monad                  ( foldM
                                                 , forM
                                                 )
-import           Control.Monad.State
 import           Data.Char                      ( toLower )
 import           Data.Foldable                  ( toList
                                                 , traverse_
@@ -78,7 +77,7 @@ data Codebase m v a =
            , mergeBranch        :: Name -> Branch -> m Branch
            , branchUpdates      :: m (m (), m (Set Name))
 
-           , dependents :: Reference -> m (Set Reference)
+           , dependentsImpl :: Reference -> m (Set Reference.Id)
            }
 
 getTypeOfConstructor ::
@@ -432,6 +431,12 @@ isTerm = ((isJust <$>) .) . getTerm
 
 isType :: Functor m => Codebase m v a -> Reference.Id -> m Bool
 isType = ((isJust <$>) .) . getTerm
+
+dependents :: Functor m => Codebase m v a -> Reference -> m (Set Reference)
+dependents c r =
+  Set.union (Builtin.dependents r)
+    .   Set.map Reference.DerivedId
+    <$> dependentsImpl c r
 
 referenceOps
   :: (Ord v, Applicative m) => Codebase m v a -> Branch.ReferenceOps m

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -441,6 +441,15 @@ dependents c r
     . Set.map Reference.DerivedId
   <$> dependentsImpl c r
 
+transitiveDependents :: Monad m => Codebase m v a -> Set Reference -> m (Set Reference)
+transitiveDependents c rs = go Set.empty (toList rs) where
+  go seen [] = pure seen
+  go seen (r:rs) =
+    if Set.member r seen then go seen rs
+    else do
+      ds <- dependents c r
+      go (Set.insert r seen) (toList ds <> rs)
+
 referenceOps
   :: (Ord v, Applicative m) => Codebase m v a -> Branch.ReferenceOps m
 referenceOps c = Branch.ReferenceOps (isTerm c) (isType c) dependencies dependents'
@@ -450,4 +459,3 @@ referenceOps c = Branch.ReferenceOps (isTerm c) (isType c) dependencies dependen
       fromMaybe Set.empty . fmap Term.dependencies <$> getTerm c r
     _ -> pure Set.empty
   dependents' = dependents c
-

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -363,89 +363,117 @@ data RemainingWork
   | ObsoleteType Reference (Set (Reference, TypeEdit))
   deriving (Eq, Ord, Show)
 
-remaining :: forall m. Monad m => ReferenceOps m -> Branch0 -> m (Set RemainingWork)
+remaining
+  :: forall m . Monad m => ReferenceOps m -> Branch0 -> m (Set RemainingWork)
 remaining ops b = do
--- If any of r's dependencies have been updated, r should be updated.
--- Alternatively: If `a` has been edited, then all of a's dependents
--- should be edited. (Maybe a warning if they are updated to something
--- that still uses `a`.)
+  -- If any of r's dependencies have been updated, r should be updated.
+  -- Alternatively: If `a` has been edited, then all of a's dependents
+  -- should be edited. (Maybe a warning if they are updated to something
+  -- that still uses `a`.)
   -- map from updated term to dependent + termedit
-  (obsoleteTerms, obsoleteTypes) <- wrangleUpdatedTypes ops =<< wrangleUpdatedTerms
-  pure . Set.fromList $
-    (uncurry TermNameConflict <$> Map.toList (conflicts termNamespace b)) ++
-    (uncurry TypeNameConflict <$> Map.toList (conflicts typeNamespace b)) ++
-    (uncurry TermEditConflict <$> Map.toList (conflicts editedTerms b)) ++
-    (uncurry TypeEditConflict <$> Map.toList (conflicts editedTypes b)) ++
-    (uncurry ObsoleteTerm <$> Map.toList obsoleteTerms) ++
-    (uncurry ObsoleteType <$> Map.toList obsoleteTypes)
-  where                    -- referent -> (oldreference, edit)
-    wrangleUpdatedTerms :: m (Map Reference (Set (Reference, Either TermEdit TypeEdit)))
-    wrangleUpdatedTerms =
-      -- 1. filter the edits to find the ones that are resolved (not conflicted)
-      -- 2. for each resolved (oldref,edit) pair,
-      -- 2b.  look up the referents of that oldref.
-      -- 2c.  if the referent is unedited, add it to the work:
-      -- 2c(i).  add it to the term work list if it's a term ref,
-      -- 2c(ii). only terms can depend on terms, so it's a term ref.
-      let termEdits :: Map Reference TermEdit -- oldreference, edit
-          termEdits = resolved editedTerms b
-          transitiveDependents :: Reference -> m (Set Reference)
-          transitiveDependents r = transitiveClosure1 (dependents ops) r
-          isEdited r = R.memberDom r (editedTerms b)
-          uneditedTransitiveDependents :: Reference -> m [Reference]
-          uneditedTransitiveDependents r =
-            filter (not . isEdited) . toList <$> transitiveDependents r
-          asSingleton :: Reference -> TermEdit -> Reference -> Map Reference (Set (Reference, Either TermEdit TypeEdit))
-          asSingleton oldRef edit referent = Map.singleton referent (Set.singleton (oldRef, Left edit))
-          workFromEdit :: (Reference, TermEdit) -> m (Map Reference (Set (Reference, Either TermEdit TypeEdit)))
-          workFromEdit (oldRef, edit) =
-            mconcat . fmap (asSingleton oldRef edit) <$> uneditedTransitiveDependents oldRef
-      in fmap mconcat (traverse workFromEdit $ Map.toList termEdits)
+  (obsoleteTerms, obsoleteTypes) <-
+    wrangleUpdatedTypes ops =<< wrangleUpdatedTerms
+  pure
+    .  Set.fromList
+    $  (uncurry TermNameConflict <$> Map.toList (conflicts termNamespace b))
+    ++ (uncurry TypeNameConflict <$> Map.toList (conflicts typeNamespace b))
+    ++ (uncurry TermEditConflict <$> Map.toList (conflicts editedTerms b))
+    ++ (uncurry TypeEditConflict <$> Map.toList (conflicts editedTypes b))
+    ++ (uncurry ObsoleteTerm <$> Map.toList obsoleteTerms)
+    ++ (uncurry ObsoleteType <$> Map.toList obsoleteTypes)
+ where                    -- referent -> (oldreference, edit)
+  wrangleUpdatedTerms
+    :: m (Map Reference (Set (Reference, Either TermEdit TypeEdit)))
+  wrangleUpdatedTerms =
+    -- 1. filter the edits to find the ones that are resolved (not conflicted)
+    -- 2. for each resolved (oldref,edit) pair,
+    -- 2b.  look up the referents of that oldref.
+    -- 2c.  if the referent is unedited, add it to the work:
+    -- 2c(i).  add it to the term work list if it's a term ref,
+    -- 2c(ii). only terms can depend on terms, so it's a term ref.
+    let termEdits :: Map Reference TermEdit -- oldreference, edit
+        termEdits = resolved editedTerms b
+        transitiveDependents :: Reference -> m (Set Reference)
+        transitiveDependents r = transitiveClosure1 (dependents ops) r
+        isEdited r = R.memberDom r (editedTerms b)
+        uneditedTransitiveDependents :: Reference -> m [Reference]
+        uneditedTransitiveDependents r =
+          filter (not . isEdited) . toList <$> transitiveDependents r
+        asSingleton
+          :: Reference
+          -> TermEdit
+          -> Reference
+          -> Map Reference (Set (Reference, Either TermEdit TypeEdit))
+        asSingleton oldRef edit referent =
+          Map.singleton referent (Set.singleton (oldRef, Left edit))
+        workFromEdit
+          :: (Reference, TermEdit)
+          -> m (Map Reference (Set (Reference, Either TermEdit TypeEdit)))
+        workFromEdit (oldRef, edit) =
+          mconcat
+            .   fmap (asSingleton oldRef edit)
+            <$> uneditedTransitiveDependents oldRef
+    in  fmap mconcat (traverse workFromEdit $ Map.toList termEdits)
 
-    wrangleUpdatedTypes ::
-      Monad m => ReferenceOps m
-              -> Map Reference (Set (Reference, Either TermEdit TypeEdit))
-              -> m (Map Reference (Set (Reference, Either TermEdit TypeEdit))
-                   ,Map Reference (Set (Reference, TypeEdit)))
-    wrangleUpdatedTypes ops initialTermEdits =
-      -- 1. filter the edits to find the ones that are resolved (not conflicted)
-      -- 2. for each resolved (oldref,edit) pair,
-      -- 2b.  look up the referents of that oldref.
-      -- 2c.  if the referent is unedited, add it to the work:
-      -- 2c(i).  add it to the term work list if it's a term ref,
-      -- 2c(ii). add it to the type work list if it's a type ref
-      foldM go (initialTermEdits, Map.empty) (Map.toList typeEdits)
-      where
-        typeEdits :: Map Reference TypeEdit -- oldreference, edit
-        typeEdits = resolved editedTypes b
-        go :: Monad m
-           => (Map Reference (Set (Reference, Either TermEdit TypeEdit))
-                ,Map Reference (Set (Reference, TypeEdit)))
-           -> (Reference, TypeEdit)
-           -> m (Map Reference (Set (Reference, Either TermEdit TypeEdit))
-                ,Map Reference (Set (Reference, TypeEdit)))
-        go (termWork, typeWork) (oldRef, edit) =
-          foldM go2 (termWork, typeWork) =<<
-                    (transitiveClosure1 (dependents ops) oldRef) where
-            single referent oldRef edit =
-              Map.singleton referent (Set.singleton (oldRef, edit))
-            singleRight referent oldRef edit =
-              Map.singleton referent (Set.singleton (oldRef, Right edit))
-            go2 :: (Map Reference (Set (Reference, Either TermEdit TypeEdit))
-                   ,Map Reference (Set (Reference, TypeEdit)))
-                -> Reference
-                -> m (Map Reference (Set (Reference, Either TermEdit TypeEdit))
-                     ,Map Reference (Set (Reference, TypeEdit)))
-            go2 (termWorkAcc, typeWorkAcc) referent =
-              termOrTypeOp ops referent
-                (pure $
-                  if not $ R.memberDom referent (editedTerms b)
-                  then (termWorkAcc <> singleRight referent oldRef edit, typeWorkAcc)
-                  else (termWorkAcc, typeWorkAcc))
-                (pure $
-                  if not $ R.memberDom referent (editedTypes b)
-                  then (termWorkAcc, typeWorkAcc <> single referent oldRef edit)
-                  else (termWorkAcc, typeWorkAcc))
+  -- 1. filter the edits to find the ones that are resolved (not conflicted)
+  -- 2. for each resolved (oldref,edit) pair,
+  -- 2b.  look up the referents of that oldref.
+  -- 2c.  if the referent is unedited, add it to the work:
+  -- 2c(i).  add it to the term work list if it's a term ref,
+  -- 2c(ii). add it to the type work list if it's a type ref
+  wrangleUpdatedTypes
+    :: Monad m
+    => ReferenceOps m
+    -> Map Reference (Set (Reference, Either TermEdit TypeEdit))
+    -> m
+         ( Map Reference (Set (Reference, Either TermEdit TypeEdit))
+         , Map Reference (Set (Reference, TypeEdit))
+         )
+  wrangleUpdatedTypes ops initialTermEdits = foldM
+    go
+    (initialTermEdits, Map.empty)
+    (Map.toList typeEdits)
+   where
+    typeEdits :: Map Reference TypeEdit -- oldreference, edit
+    typeEdits = resolved editedTypes b
+    go
+      :: Monad m
+      => ( Map Reference (Set (Reference, Either TermEdit TypeEdit))
+         , Map Reference (Set (Reference, TypeEdit))
+         )
+      -> (Reference, TypeEdit)
+      -> m
+           ( Map Reference (Set (Reference, Either TermEdit TypeEdit))
+           , Map Reference (Set (Reference, TypeEdit))
+           )
+    go (termWork, typeWork) (oldRef, edit) =
+      foldM go2 (termWork, typeWork)
+        =<< (transitiveClosure1 (dependents ops) oldRef)
+     where
+      single referent oldRef edit =
+        Map.singleton referent (Set.singleton (oldRef, edit))
+      singleRight referent oldRef edit =
+        Map.singleton referent (Set.singleton (oldRef, Right edit))
+      go2
+        :: ( Map Reference (Set (Reference, Either TermEdit TypeEdit))
+           , Map Reference (Set (Reference, TypeEdit))
+           )
+        -> Reference
+        -> m
+             ( Map Reference (Set (Reference, Either TermEdit TypeEdit))
+             , Map Reference (Set (Reference, TypeEdit))
+             )
+      go2 (termWorkAcc, typeWorkAcc) referent = termOrTypeOp
+        ops
+        referent
+        (pure $ if not $ R.memberDom referent (editedTerms b)
+          then (termWorkAcc <> singleRight referent oldRef edit, typeWorkAcc)
+          else (termWorkAcc, typeWorkAcc)
+        )
+        (pure $ if not $ R.memberDom referent (editedTypes b)
+          then (termWorkAcc, typeWorkAcc <> single referent oldRef edit)
+          else (termWorkAcc, typeWorkAcc)
+        )
 
 empty :: Branch
 empty = Branch (Causal.one mempty)

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -109,6 +109,12 @@ termNamespace = view $ namespaceL . terms
 typeNamespace :: Branch0 -> Relation Name Reference
 typeNamespace = view $ namespaceL . types
 
+allTerms :: Branch0 -> Set Referent
+allTerms = R.ran . termNamespace
+
+allTypes :: Branch0 -> Set Reference
+allTypes = R.ran . typeNamespace
+
 intersectNames :: Namespace -> Namespace -> Namespace
 intersectNames n1 n2 = Namespace terms types
  where

--- a/parser-typechecker/src/Unison/Codebase/CommandLine2.hs
+++ b/parser-typechecker/src/Unison/Codebase/CommandLine2.hs
@@ -414,7 +414,7 @@ notifyUser dir o = do
     TodoOutput branch todo ->
       let ppe = Branch.prettyPrintEnv1 (Branch.head branch) in
       if E.todoScore todo == 0
-      then putPrettyLn . emojiNote "✅" $ "No conflicts or edits in progress."
+      then putPrettyLn . P.okCallout $ "No conflicts or edits in progress."
       else do
         let (frontierTerms, frontierTypes) = E.todoFrontier todo
             (dirtyTerms, dirtyTypes) = E.todoFrontierDependents todo
@@ -424,13 +424,14 @@ notifyUser dir o = do
 
         putPrettyLn . P.callout "🚧" . P.lines . join $ [
           [P.wrap ("The branch has" <> fromString (show (E.todoScore todo))
-                  <> "transitive dependents left to upgrade."
+                  <> "transitive dependent(s) left to upgrade."
                   <> "Your edit frontier is the dependents of these definitions:")],
           [""],
           [P.indentN 2 . P.lines $ (
               (prettyDeclTriple <$> toList frontierTypes) ++
               TypePrinter.prettySignatures' ppe (goodTerms frontierTerms)
            )],
+          [""],
           [P.wrap "I recommend working on them in the following order:"],
           [""],
           [P.indentN 2 . P.lines $

--- a/parser-typechecker/src/Unison/Codebase/CommandLine2.hs
+++ b/parser-typechecker/src/Unison/Codebase/CommandLine2.hs
@@ -409,7 +409,8 @@ notifyUser dir o = do
       putStrLn $
           "👀  Now evaluating any watch expressions (lines starting with `>`)"
         <> " ...\n"
-    TodoOutput ppe todo ->
+    TodoOutput branch todo ->
+      let ppe = Branch.prettyPrintEnv1 (Branch.head branch) in
       if E.todoScore todo == 0
       then putPrettyLn . emojiNote "✅" $ "No conflicts or edits in progress."
       else do

--- a/parser-typechecker/src/Unison/Codebase/CommandLine2.hs
+++ b/parser-typechecker/src/Unison/Codebase/CommandLine2.hs
@@ -531,15 +531,15 @@ validInputs = validPatterns
         ["ls"]
         [(True, definitionQueryArg)]
         (P.column2
-          [ ("`list`", P.wrap $ "shows all definitions in the current branch.")
+          [ ("`list`", P.wrap $ "lists all definitions in the current branch.")
           , ( "`list foo`"
             , P.wrap
-            $  "shows all definitions with a name similar"
+            $  "lists all definitions with a name similar"
             <> "to 'foo' in the current branch."
             )
           , ( "`list foo bar`"
             , P.wrap
-            $  "shows all definitions with a name similar"
+            $  "lists all definitions with a name similar"
             <> "to 'foo' or 'bar' in the current branch."
             )
           ]
@@ -596,17 +596,29 @@ validInputs = validPatterns
         "update"
         []
         []
-        -- TODO: Say something about the structured refactoring session here.
         (  P.wrap
         $  "`update` works like `add`, except "
         <> "if a definition in the file "
         <> "has the same name as an existing definition, the name gets updated "
-        <> "to point to the new definition."
+        <> "to point to the new definition. "
+        <> "If the old definition has any dependents, `update` will add "
+        <> "those dependents to a refactoring session."
         )
         (\ws -> if not $ null ws
           then Left $ warn "`update` doesn't take any arguments."
           else pure $ SlurpFileI True
         )
+      , InputPattern
+        "todo"
+        []
+        []
+        (P.wrap
+        $ "`todo` lists the work remaining in the current branch " <>
+          "to complete an ongoing refactoring."
+        )
+        (\ws -> if not $ null ws
+                   then Left $ warn "`todo` doesn't take any arguments."
+                   else pure $ TodoI)
       , quit
       ]
   allTargets = Set.fromList [Names.TermName, Names.TypeName]

--- a/parser-typechecker/src/Unison/Codebase/CommandLine2.hs
+++ b/parser-typechecker/src/Unison/Codebase/CommandLine2.hs
@@ -181,8 +181,10 @@ notifyUser dir o = do
       let ppe  = Branch.prettyPrintEnv1 (Branch.head branch)
           sigs0 = (\(name, _, typ) -> (name, typ)) <$> terms
           sigs = [(name,t) | (name, Just t) <- sigs0 ]
-          impossible = terms >>= \(name, r, _) -> case r of
-            Referent.Ref (Reference.Builtin _) -> [(name,r)]
+          impossible = terms >>= \case
+            (name, r, Nothing) -> case r of
+              Referent.Ref (Reference.Builtin _) -> [(name,r)]
+              _ -> []
             _ -> []
           termsWithMissingTypes =
             [ (name, r) | (name, Referent.Ref (Reference.DerivedId r), Nothing) <- terms ]

--- a/parser-typechecker/src/Unison/Codebase/Editor.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor.hs
@@ -11,7 +11,7 @@ module Unison.Codebase.Editor where
 
 -- import Debug.Trace
 
-import Data.List (foldl')
+import Data.List (foldl', sortOn)
 import           Control.Monad                  ( forM_, forM, foldM, filterM)
 import           Control.Monad.Extra            ( ifM )
 import Data.Foldable (toList)
@@ -639,15 +639,16 @@ doTodo code b = do
       ppe = Branch.prettyPrintEnv1 b
   (frontierTerms, frontierTypes) <- loadDefinitions code frontier
   (dirtyTerms, dirtyTypes) <- loadDefinitions code dirty
-  scoreFn <- pure $ const 1 -- todo: come up with something sensible
+  -- todo: something more intelligent here?
+  scoreFn <- pure $ const 1
   let
     addTermNames terms = [(PPE.termName ppe (Referent.Ref r), r, t) | (r,t) <- terms ]
     addTypeNames types = [(PPE.typeName ppe r, r, d) | (r,d) <- types ]
     frontierTermsNamed = addTermNames frontierTerms
     frontierTypesNamed = addTypeNames frontierTypes
-    dirtyTermsNamed =
+    dirtyTermsNamed = sortOn (\(s,_,_,_) -> s) $
       [ (scoreFn r, n, r, t) | (n,r,t) <- addTermNames dirtyTerms ]
-    dirtyTypesNamed =
+    dirtyTypesNamed = sortOn (\(s,_,_,_) -> s) $
       [ (scoreFn r, n, r, t) | (n,r,t) <- addTypeNames dirtyTypes ]
     overallScore = foldl' (+) 0 (map scoreFn $ toList frontier)
   pure $

--- a/parser-typechecker/src/Unison/Codebase/Editor.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor.hs
@@ -629,8 +629,12 @@ commandLine awaitInput rt branchChange notifyUser codebase command = do
       Branch.remaining (Codebase.referenceOps codebase) (Branch.head b)
     Todo b -> doTodo codebase (Branch.head b)
 
-doTodo :: Codebase m v a -> Branch0 -> m (TodoOutput v)
-doTodo c b = undefined c b
+doTodo :: Monad m => Codebase m v a -> Branch0 -> m (TodoOutput v)
+doTodo code b = do
+  f <- frontier (Codebase.dependents code) b
+  let dirty = R.dom f
+      frontier = R.ran f
+  error "todo"
 
 -- (f, d) when d is "dirty" (needs update),
 --             f is in the frontier,

--- a/parser-typechecker/src/Unison/Codebase/Editor.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor.hs
@@ -629,6 +629,11 @@ doTodo c b = undefined c b
 -- (f, d) when d is "dirty" (needs update),
 --             f is in the frontier,
 --         and d depends of f
+-- a ⋖ b = a depends on b (with no intermediate dependencies)
+-- dirty(D) ∧ frontier(F) <=> not(edited(D)) ∧ edited(F) ∧ D ⋖ F
+--
+-- The range of this relation is the frontier, and the domain is
+-- the set of dirty references.
 frontier :: forall m . Monad m
          => (Reference -> m (Set Reference)) -- eg Codebase.dependents codebase
          -> Branch0
@@ -640,5 +645,5 @@ frontier getDependents b = let
   addDependents dependents ref =
     (\ds -> R.insertManyDom ds ref dependents) <$> getDependents ref
   in do
-    dependentOf <- foldM addDependents R.empty edited
-    pure $ R.filterRan (not . flip Set.member edited) dependentOf
+    dependsOn <- foldM addDependents R.empty edited
+    pure $ R.filterRan (not . flip Set.member edited) dependsOn

--- a/parser-typechecker/src/Unison/Codebase/Editor.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor.hs
@@ -165,7 +165,6 @@ data Output v
   | Evaluated Names ([(Text, Term v ())], Term v ())
   | Typechecked SourceName PPE.PrettyPrintEnv (UF.TypecheckedUnisonFile' v Ann)
   | FileChangeEvent SourceName Text
-  | TodoOutput
   | DisplayDefinitions PPE.PrettyPrintEnv
                        [(Reference, DisplayThing (Term v Ann))]
                        [(Reference, DisplayThing (Decl v Ann))]

--- a/parser-typechecker/src/Unison/Codebase/Editor.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor.hs
@@ -639,7 +639,7 @@ doTodo code b = do
       ppe = Branch.prettyPrintEnv1 b
   (frontierTerms, frontierTypes) <- loadDefinitions code frontier
   (dirtyTerms, dirtyTypes) <- loadDefinitions code dirty
-  scoreFn <- error "todo"
+  scoreFn <- pure $ const 1 -- todo: come up with something sensible
   let
     addTermNames terms = [(PPE.termName ppe (Referent.Ref r), r, t) | (r,t) <- terms ]
     addTypeNames types = [(PPE.typeName ppe r, r, d) | (r,d) <- types ]
@@ -655,7 +655,7 @@ doTodo code b = do
       overallScore
       (frontierTermsNamed, frontierTypesNamed)
       (dirtyTermsNamed, dirtyTypesNamed)
-      (error "compute conflicts :: Branch0 from b")
+      (Branch.conflicts' b)
 
 loadDefinitions :: Monad m => Codebase m v a -> Set Reference
                 -> m ( [(Reference, Maybe (Type v a))],

--- a/parser-typechecker/src/Unison/Codebase/Editor.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor.hs
@@ -169,7 +169,22 @@ data Output v
   | DisplayDefinitions PPE.PrettyPrintEnv
                        [(Reference, DisplayThing (Term v Ann))]
                        [(Reference, DisplayThing (Decl v Ann))]
+  | TodoOutput PPE.PrettyPrintEnv (TodoOutput v)
   deriving (Show)
+
+type Score = Int
+
+data TodoOutput v
+  = TodoOutput_ {
+      todoScore :: Int,
+      todoFrontier ::
+        ( [(Name, Reference, Maybe (Type v Ann))]
+        , [(Name, Reference, DisplayThing (Decl v Ann))]),
+      todoFrontierDependents ::
+        ( [(Score, Name, Reference, Maybe (Type v Ann))]
+        , [(Score, Name, Reference, DisplayThing (Decl v Ann))]),
+      todoConflicts :: Branch0
+    } deriving (Show)
 
 data NameChangeResult = NameChangeResult
   { oldNameConflicted :: Set NameTarget

--- a/parser-typechecker/src/Unison/Codebase/Editor.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor.hs
@@ -633,6 +633,7 @@ commandLine awaitInput rt branchChange notifyUser codebase command = do
 
 doTodo :: Monad m => Codebase m v a -> Branch0 -> m (TodoOutput v a)
 doTodo code b = do
+  -- traceM $ "edited terms: " ++ show (Branch.editedTerms b)
   f <- frontier (Codebase.dependents code) b
   let dirty = R.dom f
       frontier = R.ran f
@@ -696,5 +697,6 @@ frontier getDependents b = let
   addDependents dependents ref =
     (\ds -> R.insertManyDom ds ref dependents) <$> getDependents ref
   in do
+    -- (r,r2) ∈ dependsOn if r depends on r2
     dependsOn <- foldM addDependents R.empty edited
-    pure $ R.filterRan (not . flip Set.member edited) dependsOn
+    pure $ R.filterDom (not . flip Set.member edited) dependsOn

--- a/parser-typechecker/src/Unison/Codebase/Editor.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor.hs
@@ -679,7 +679,7 @@ loadDefinitions code refs = do
 --             f is in the frontier,
 --         and d depends of f
 -- a ⋖ b = a depends on b (with no intermediate dependencies)
--- dirty(D) ∧ frontier(F) <=> not(edited(D)) ∧ edited(F) ∧ D ⋖ F
+-- dirty(d) ∧ frontier(f) <=> not(edited(d)) ∧ edited(f) ∧ d ⋖ f
 --
 -- The range of this relation is the frontier, and the domain is
 -- the set of dirty references.

--- a/parser-typechecker/src/Unison/Codebase/Editor.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor.hs
@@ -183,7 +183,7 @@ data Output v
   | DisplayDefinitions PPE.PrettyPrintEnv
                        [(Reference, DisplayThing (Term v Ann))]
                        [(Reference, DisplayThing (Decl v Ann))]
-  | TodoOutput PPE.PrettyPrintEnv (TodoOutput v)
+  | TodoOutput Branch (TodoOutput v)
   deriving (Show)
 
 type Score = Int
@@ -307,6 +307,8 @@ data Command i v a where
   LoadTerm :: Reference.Id -> Command i v (Maybe (Term v Ann))
 
   LoadType :: Reference.Id -> Command i v (Maybe (Decl v Ann))
+
+  Todo :: Branch -> Command i v (TodoOutput v)
 
 data Outcome
   -- New definition that was added to the branch
@@ -619,4 +621,11 @@ commandLine awaitInput rt branchChange notifyUser codebase command = do
     LoadType r -> Codebase.getTypeDeclaration codebase r
     RemainingWork b ->
       Branch.remaining (Codebase.referenceOps codebase) (Branch.head b)
+    Todo b -> doTodo b codebase
+
+doTodo :: Branch -> Codebase m v a -> m (TodoOutput v)
+doTodo b c = undefined b c
+
+frontier :: Branch -> Codebase m v a -> m (Set Reference)
+frontier = undefined
 

--- a/parser-typechecker/src/Unison/Codebase/Editor.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor.hs
@@ -650,6 +650,7 @@ doTodo code b = do
       [ (scoreFn r, n, r, t) | (n,r,t) <- addTermNames dirtyTerms ]
     dirtyTypesNamed = sortOn (\(s,_,_,_) -> s) $
       [ (scoreFn r, n, r, t) | (n,r,t) <- addTypeNames dirtyTypes ]
+    -- todo: revisit, think about this
     overallScore = foldl' (+) 0 (map scoreFn $ toList frontier)
   pure $
     TodoOutput_

--- a/parser-typechecker/src/Unison/Codebase/Editor/Actions.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Actions.hs
@@ -116,6 +116,8 @@ loop s = Free.unfold' go s
               (r, ) . maybe (MissingThing i) RegularThing <$> Free.eval
                 (LoadType i)
             _ -> pure (r, BuiltinThing)
+          -- makes sure that the user search terms get used as the names
+          -- in the pretty-printer
           let ppe =
                 PPE.fromTermNames [ (r, n) | (n, r, _) <- terms ]
                   `PPE.unionLeft` PPE.fromTypeNames (swap <$> types)
@@ -179,7 +181,8 @@ loop s = Free.unfold' go s
           (respond $ BranchAlreadyExists targetBranchName)
         MergeBranchI inputBranchName -> withBranch inputBranchName respond
           $ \branch -> mergeBranch currentBranchName respond success branch
-        TodoI -> undefined
+        TodoI ->
+          Free.eval (Todo currentBranch) >>= respond . TodoOutput currentBranch
         QuitI -> quit
        where
         success       = respond $ Success input

--- a/parser-typechecker/src/Unison/Codebase/Editor/Actions.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Actions.hs
@@ -180,6 +180,7 @@ loop s = Free.unfold' go s
           (respond $ BranchAlreadyExists targetBranchName)
         MergeBranchI inputBranchName -> withBranch inputBranchName respond
           $ \branch -> mergeBranch currentBranchName respond success branch
+        TodoI -> undefined
         QuitI -> quit
        where
         success       = respond $ Success input

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -4,42 +4,64 @@
 
 module Unison.Codebase.FileCodebase where
 
-import           Control.Concurrent               (forkIO, killThread)
-import           Control.Monad                    (filterM, forever, when)
-import           Control.Monad.Error.Class        (MonadError, throwError)
-import           Control.Monad.Except             (runExceptT)
-import           Control.Monad.IO.Class           (MonadIO, liftIO)
-import           Control.Monad.STM                (atomically)
-import qualified Data.Bytes.Get                   as Get
-import qualified Data.ByteString                  as BS
-import           Data.Foldable                    (traverse_)
-import           Data.List                        (isSuffixOf, partition)
-import qualified Data.Map                         as Map
-import           Data.Maybe                       (catMaybes)
-import           Data.Set                         (Set)
-import qualified Data.Set                         as Set
-import           Data.Text                        (Text)
-import qualified Data.Text                        as Text
-import Data.Word (Word64)
-import           System.Directory                 (createDirectoryIfMissing,
-                                                   doesDirectoryExist,
-                                                   listDirectory, removeFile)
-import           System.FilePath                  (FilePath, takeBaseName,
-                                                   takeDirectory, takeExtension,
-                                                   takeFileName, (</>))
-import qualified Unison.Builtin                   as Builtin
-import           Unison.Codebase                  (Codebase (Codebase),
-                                                   Err (InvalidBranchFile))
-import           Unison.Codebase.Branch           (Branch)
-import qualified Unison.Codebase.Branch           as Branch
-import Unison.Names (Name)
-import qualified Unison.Codebase.Serialization    as S
-import qualified Unison.Codebase.Serialization.V0 as V0
-import qualified Unison.Codebase.Watch            as Watch
-import qualified Unison.Hash                      as Hash
-import qualified Unison.Reference as Reference
-import qualified Unison.Util.TQueue               as TQueue
-import           Unison.Var                       (Var)
+import           Control.Concurrent             ( forkIO
+                                                , killThread
+                                                )
+import           Control.Monad                  ( filterM
+                                                , forever
+                                                , when
+                                                )
+import           Control.Monad.Error.Class      ( MonadError
+                                                , throwError
+                                                )
+import           Control.Monad.Except           ( runExceptT )
+import           Control.Monad.IO.Class         ( MonadIO
+                                                , liftIO
+                                                )
+import           Control.Monad.STM              ( atomically )
+import qualified Data.Bytes.Get                as Get
+import qualified Data.ByteString               as BS
+import           Data.Foldable                  ( traverse_ )
+import           Data.List                      ( isSuffixOf
+                                                , partition
+                                                )
+import qualified Data.Map                      as Map
+import           Data.Maybe                     ( catMaybes )
+import           Data.Set                       ( Set )
+import qualified Data.Set                      as Set
+import           Data.Text                      ( Text )
+import qualified Data.Text                     as Text
+import           Data.Word                      ( Word64 )
+import           System.Directory               ( createDirectoryIfMissing
+                                                , doesDirectoryExist
+                                                , listDirectory
+                                                , removeFile
+                                                , writeFile
+                                                )
+import           System.FilePath                ( FilePath
+                                                , takeBaseName
+                                                , takeDirectory
+                                                , takeExtension
+                                                , takeFileName
+                                                , (</>)
+                                                )
+import qualified Unison.Builtin                as Builtin
+import           Unison.Codebase                ( Codebase(Codebase)
+                                                , Err(InvalidBranchFile)
+                                                , isTerm
+                                                , isType
+                                                )
+import           Unison.Codebase.Branch         ( Branch )
+import qualified Unison.Codebase.Branch        as Branch
+import           Unison.Names                   ( Name )
+import qualified Unison.Codebase.Serialization as S
+import qualified Unison.Codebase.Serialization.V0
+                                               as V0
+import qualified Unison.Codebase.Watch         as Watch
+import qualified Unison.Hash                   as Hash
+import qualified Unison.Reference              as Reference
+import qualified Unison.Util.TQueue            as TQueue
+import           Unison.Var                     ( Var )
 -- import Debug.Trace
 
 -- checks if `path` looks like a unison codebase
@@ -76,35 +98,44 @@ branchFromFile' ubf = go =<< runExceptT (branchFromFile ubf)
       pure Nothing
     go (Right b) = pure (Just b)
 
--- todo: might want to have richer return type that reflects merges that may have been done
+-- todo: might want to have richer return type that reflects merges that
+-- may have been done
 branchFromDirectory :: FilePath -> IO (Maybe Branch)
 branchFromDirectory dir = do
   exists <- doesDirectoryExist dir
   case exists of
     False -> pure Nothing
-    True -> do
-      bos <- traverse branchFromFile' =<< filesInPathMatchingExtension dir ".ubf"
+    True  -> do
+      bos <- traverse branchFromFile'
+        =<< filesInPathMatchingExtension dir ".ubf"
       pure $ case catMaybes bos of
         []  -> Nothing
         bos -> Just (mconcat bos)
 
 filesInPathMatchingExtension :: FilePath -> String -> IO [FilePath]
-filesInPathMatchingExtension path extension = doesDirectoryExist path >>= \ok ->
-  if ok then fmap (path </>) <$> (filter (((==) extension) . takeExtension) <$> listDirectory path)
-  else pure []
+filesInPathMatchingExtension path extension =
+  doesDirectoryExist path >>= \ok -> if ok
+    then
+      fmap (path </>)
+        <$> (filter (((==) extension) . takeExtension) <$> listDirectory path)
+    else pure []
 
 isValidBranchDirectory :: FilePath -> IO Bool
 isValidBranchDirectory path =
   not . null <$> filesInPathMatchingExtension path ".ubf"
 
-termPath, typePath, declPath :: FilePath -> Reference.Id -> FilePath
-termPath path (Reference.Id h i n) = path </> "terms" </> (addComponentId i n (Hash.base58s h)) </> "compiled.ub"
-typePath path (Reference.Id h i n) = path </> "terms" </> (addComponentId i n (Hash.base58s h)) </> "type.ub"
-declPath path (Reference.Id h i n) = path </> "types" </> (addComponentId i n (Hash.base58s h)) </> "compiled.ub"
+termDir, declDir :: FilePath -> Reference.Id -> FilePath
+termDir path r = path </> "terms" </> componentId r
 
-addComponentId :: Word64 -> Word64 -> String -> String
-addComponentId 0 1 s = s
-addComponentId i n s = show i <> "-" <> show n <> "-" <> s
+termPath, typePath, declPath :: FilePath -> Reference.Id -> FilePath
+termPath path r = termDir path r </> "compiled.ub"
+typePath path r = termDir path r </> "type.ub"
+declPath path r = declDir path r </> "compiled.ub"
+
+componentId :: Reference.Id -> String
+componentId (Reference.Id h 0 1) = Hash.base58s h
+componentId (Reference.Id h i n) =
+  show i <> "-" <> show n <> "-" <> Hash.base58 h
 
 branchesPath :: FilePath -> FilePath
 branchesPath path = path </> "branches"
@@ -112,84 +143,119 @@ branchesPath path = path </> "branches"
 branchPath :: FilePath -> Text -> FilePath
 branchPath path name = branchesPath path </> Text.unpack name
 
+touchDependentFile :: Reference.Id -> FilePath -> IO ()
+touchDependentFile dependent fp = do
+  createDirectoryIfMissing True (fp </> "dependents")
+  writeFile (fp </> "dependents" </> componentId dependent) ""
+
 -- todo: builtin data decls (optional, unit, pair) should just have a regular
 -- hash-based reference, rather than being Reference.Builtin
 -- and we should verify that this doesn't break the runtime
-codebase1 :: Var v => a -> S.Format v -> S.Format a -> FilePath -> Codebase IO v a
-codebase1 builtinTypeAnnotation
-          (S.Format getV putV) (S.Format getA putA) path = let
-  getTerm h = S.getFromFile (V0.getTerm getV getA) (termPath path h)
-  putTerm h e typ = do
-    S.putWithParentDirs (V0.putTerm putV putA) (termPath path h) e
-    S.putWithParentDirs (V0.putType putV putA) (typePath path h) typ
-  getTypeOfTerm r = case r of
-    (Reference.Builtin _) -> pure $
-      fmap (const builtinTypeAnnotation) <$>
-      Map.lookup r Builtin.builtins0
-    Reference.DerivedId h ->
-      S.getFromFile (V0.getType getV getA) (typePath path h)
-    _ -> error "impossible"
-  getDecl h =
-    S.getFromFile (V0.getEither (V0.getEffectDeclaration getV getA)
-                                (V0.getDataDeclaration getV getA))
-                  (declPath path h)
-  putDecl h decl =
-    S.putWithParentDirs (V0.putEither (V0.putEffectDeclaration putV putA)
-                                      (V0.putDataDeclaration putV putA))
-                        (declPath path h)
-                        decl
-  branches = map Text.pack <$> do
-    files <- listDirectory (branchesPath path)
-    let paths = (branchesPath path </>) <$> files
-    fmap takeFileName <$>
-        filterM isValidBranchDirectory paths
+codebase1
+  :: Var v => a -> S.Format v -> S.Format a -> FilePath -> Codebase IO v a
+codebase1 builtinTypeAnnotation (S.Format getV putV) (S.Format getA putA) path
+  = let
+      getTerm h = S.getFromFile (V0.getTerm getV getA) (termPath path h)
+      putTerm h e typ = do
+        S.putWithParentDirs (V0.putTerm putV putA) (termPath path h) e
+        S.putWithParentDirs (V0.putType putV putA) (typePath path h) typ
+        let declDependencies = Term.referencedDataDeclarations e
+              <> Term.referencedEffectDeclarations e
+        -- Add the term as a dependent of its dependencies
+        traverse_ (touchDependentFile h . termDir path) $ Term.dependencies' e
+        traverse_ (touchDependentFile h . declDir path) $ declDependencies
+      getTypeOfTerm r = case r of
+        (Reference.Builtin _) ->
+          pure
+            $   fmap (const builtinTypeAnnotation)
+            <$> Map.lookup r Builtin.builtins0
+        Reference.DerivedId h ->
+          S.getFromFile (V0.getType getV getA) (typePath path h)
+        _ -> error "impossible"
+      getDecl h = S.getFromFile
+        (V0.getEither (V0.getEffectDeclaration getV getA)
+                      (V0.getDataDeclaration getV getA)
+        )
+        (declPath path h)
+      putDecl h decl = S.putWithParentDirs
+        (V0.putEither (V0.putEffectDeclaration putV putA)
+                      (V0.putDataDeclaration putV putA)
+        )
+        (declPath path h)
+        decl
+      branches = map Text.pack <$> do
+        files <- listDirectory (branchesPath path)
+        let paths = (branchesPath path </>) <$> files
+        fmap takeFileName <$> filterM isValidBranchDirectory paths
 
-  getBranch name = branchFromDirectory (branchPath path name)
+      getBranch name = branchFromDirectory (branchPath path name)
 
-  -- delete any leftover branch files "before" this one,
-  -- and write this one if it doesn't already exist.
-  overwriteBranch :: Name -> Branch -> IO ()
-  overwriteBranch name branch = do
-    let newBranchHash = Hash.base58s . Branch.toHash $ branch
-    (match, nonmatch) <-
-      partition (\s -> newBranchHash == takeBaseName s) <$>
-         filesInPathMatchingExtension (branchPath path name) ".ubf"
-    let
-      isBefore :: Branch -> FilePath -> IO Bool
-      isBefore b ubf = maybe False (`Branch.before` b) <$> branchFromFile' ubf
-    -- delete any existing .ubf files
-    traverse_ removeFile =<< filterM (isBefore branch) nonmatch
-    -- save new branch data under <base58>.ubf
-    when (null match) $
-      branchToFile (branchPath path name </> newBranchHash <> ".ubf") branch
+      -- delete any leftover branch files "before" this one,
+      -- and write this one if it doesn't already exist.
+      overwriteBranch :: Name -> Branch -> IO ()
+      overwriteBranch name branch = do
+        let newBranchHash = Hash.base58s . Branch.toHash $ branch
+        (match, nonmatch) <-
+          partition (\s -> newBranchHash == takeBaseName s)
+            <$> filesInPathMatchingExtension (branchPath path name) ".ubf"
+        let isBefore :: Branch -> FilePath -> IO Bool
+            isBefore b ubf =
+              maybe False (`Branch.before` b) <$> branchFromFile' ubf
+        -- delete any existing .ubf files
+        traverse_ removeFile =<< filterM (isBefore branch) nonmatch
+        -- save new branch data under <base58>.ubf
+        when (null match) $ branchToFile
+          (branchPath path name </> newBranchHash <> ".ubf")
+          branch
 
-  mergeBranch name branch = do
-    target <- getBranch name
-    let newBranch = case target of
-          -- merge with existing branch if present
-          Just existing -> Branch.merge branch existing
-          -- or save new branch
-          Nothing       -> branch
-    overwriteBranch name newBranch
-    pure newBranch
+      mergeBranch name branch = do
+        target <- getBranch name
+        let newBranch = case target of
+              -- merge with existing branch if present
+              Just existing -> Branch.merge branch existing
+              -- or save new branch
+              Nothing       -> branch
+        overwriteBranch name newBranch
+        pure newBranch
 
-  branchUpdates :: IO (IO (), IO (Set Name))
-  branchUpdates = do
-    branchFileChanges <- TQueue.newIO
-    (cancelWatch, watcher) <- Watch.watchDirectory' (branchesPath path)
-    -- add .ubf file changes to intermediate queue
-    watcher1 <- forkIO $ do
-      forever $ do
-        (filePath,_) <- watcher
-        when (".ubf" `isSuffixOf` filePath) $
-          atomically . TQueue.enqueue branchFileChanges $ filePath
-    -- smooth out intermediate queue
-    pure $ (cancelWatch >> killThread watcher1,
-            Set.map ubfPathToName . Set.fromList <$>
-              Watch.collectUntilPause branchFileChanges 400000)
-  in Codebase getTerm getTypeOfTerm putTerm
-              getDecl putDecl
-              branches getBranch mergeBranch branchUpdates
+      dependents :: Reference.Id -> IO (Set Reference.Id)
+      dependents id = do
+        b  <- isTerm id
+        ls <-
+          listDirectory
+          $   (if b then termDir else declDir) path id
+          </> "dependents"
+        pure . Set.fromList $ ls >>= (toList . parseHash)
 
+      branchUpdates :: IO (IO (), IO (Set Name))
+      branchUpdates = do
+        branchFileChanges      <- TQueue.newIO
+        (cancelWatch, watcher) <- Watch.watchDirectory' (branchesPath path)
+        -- add .ubf file changes to intermediate queue
+        watcher1               <- forkIO $ do
+          forever $ do
+            (filePath, _) <- watcher
+            when (".ubf" `isSuffixOf` filePath)
+              $ atomically
+              . TQueue.enqueue branchFileChanges
+              $ filePath
+        -- smooth out intermediate queue
+        pure
+          $ ( cancelWatch >> killThread watcher1
+            , Set.map ubfPathToName . Set.fromList <$> Watch.collectUntilPause
+              branchFileChanges
+              400000
+            )
+    in
+      Codebase getTerm
+               getTypeOfTerm
+               putTerm
+               getDecl
+               putDecl
+               branches
+               getBranch
+               mergeBranch
+               branchUpdates
+               dependents
 ubfPathToName :: FilePath -> Name
 ubfPathToName = Text.pack . takeFileName . takeDirectory

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -249,7 +249,7 @@ codebase1 builtinTypeAnnotation (S.Format getV putV) (S.Format getA putA) path
       dependents :: Reference -> IO (Set Reference.Id)
       dependents r = do
         d  <- dir
-        e  <- doesDirectoryExist d
+        e  <- doesDirectoryExist (d </> "dependents")
         if e then do
               ls <- listDirectory (d </> "dependents")
               pure . Set.fromList $ ls >>= (toList . parseHash)

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -266,6 +266,7 @@ codebase1 builtinTypeAnnotation (S.Format getV putV) (S.Format getA putA) path
           Reference.DerivedId id -> do
             b <- isJust <$> getTerm id
             pure $ (if b then termDir else declDir) path id
+          _ -> error "impossible: these patterns should be enough"
 
       branchUpdates :: IO (IO (), IO (Set Name))
       branchUpdates = do

--- a/parser-typechecker/src/Unison/Codebase/Runtime.hs
+++ b/parser-typechecker/src/Unison/Codebase/Runtime.hs
@@ -1,16 +1,18 @@
 {-#LANGUAGE RankNTypes#-}
 module Unison.Codebase.Runtime where
 
+import           Control.Monad.IO.Class         ( MonadIO )
 import           Data.Text                      ( Text )
 import           Unison.Codebase                ( Codebase )
 import           Unison.UnisonFile              ( UnisonFile )
 import           Unison.Term                    ( Term )
 
 data Runtime v = Runtime
-  { terminate :: IO ()
+  { terminate :: forall m. MonadIO m => m ()
   , evaluate
-      :: forall a b
-       . UnisonFile v a
-      -> Codebase IO v b
-      -> IO ([(Text, Term v)], Term v)
+      :: forall a b m
+      .  MonadIO m
+      => UnisonFile v a
+      -> Codebase m v b
+      -> m ([(Text, Term v)], Term v)
   }

--- a/parser-typechecker/src/Unison/DataDeclaration.hs
+++ b/parser-typechecker/src/Unison/DataDeclaration.hs
@@ -123,13 +123,14 @@ dataDeclToNames :: Var v => v -> Reference -> DataDeclaration' v a -> Names
 dataDeclToNames typeSymbol r dd = toNames0 typeSymbol r Referent.Con dd
 
 effectDeclToNames :: Var v => v -> Reference -> EffectDeclaration' v a -> Names
-effectDeclToNames typeSymbol r ed = toNames0 typeSymbol r Referent.Req $ toDataDecl ed
+effectDeclToNames typeSymbol r ed =
+  toNames0 typeSymbol r Referent.Req $ toDataDecl ed
 
 dataDeclToNames' :: Var v => (v, (Reference, DataDeclaration' v a)) -> Names
 dataDeclToNames' (v,(r,d)) = dataDeclToNames v r d
 
 effectDeclToNames' :: Var v => (v, (Reference, EffectDeclaration' v a)) -> Names
-effectDeclToNames' (v,(r,d)) = effectDeclToNames v r d
+effectDeclToNames' (v, (r, d)) = effectDeclToNames v r d
 
 type EffectDeclaration v = EffectDeclaration' v ()
 
@@ -140,7 +141,8 @@ newtype EffectDeclaration' v a = EffectDeclaration {
 withEffectDecl :: (DataDeclaration' v a -> DataDeclaration' v' a') -> (EffectDeclaration' v a -> EffectDeclaration' v' a')
 withEffectDecl f e = EffectDeclaration (f . toDataDecl $ e)
 
-mkEffectDecl' :: a -> [v] -> [(a, v, AnnotatedType v a)] -> EffectDeclaration' v a
+mkEffectDecl'
+  :: a -> [v] -> [(a, v, AnnotatedType v a)] -> EffectDeclaration' v a
 mkEffectDecl' a b cs = EffectDeclaration (DataDeclaration a b cs)
 
 mkEffectDecl :: [v] -> [(v, AnnotatedType v ())] -> EffectDeclaration' v ()
@@ -155,10 +157,6 @@ mkDataDecl b cs = mkDataDecl' () b $ map (\(v,t) -> ((),v,t)) cs
 constructorArities :: DataDeclaration' v a -> [Int]
 constructorArities (DataDeclaration _a _bound ctors) =
   Type.arity . (\(_,_,t) -> t) <$> ctors
-
--- type List a = Nil | Cons a (List a)
--- cycle (abs "List" (LetRec [abs "a" (cycle (absChain ["Nil","Cons"] (Constructors [List a, a -> List a -> List a])))] "List"))
--- absChain [a] (cycle ())"List")
 
 data F a
   = Type (Type.F a)
@@ -198,12 +196,12 @@ hash recursiveDecls = zip (fst <$> recursiveDecls) hashes where
   hashes = ABT.hash <$> toLetRec recursiveDecls
 
 toLetRec :: Ord v => [(v, ABT.Term F v ())] -> [ABT.Term F v ()]
-toLetRec decls =
-  do1 <$> vs
-  where
-    (vs, decls') = unzip decls
-    -- we duplicate this letrec once (`do1`) for each of the mutually recursive types
-    do1 v = ABT.cycle (ABT.absChain vs . ABT.tm $ LetRec decls' (ABT.var v))
+toLetRec decls = do1 <$> vs
+ where
+  (vs, decls') = unzip decls
+  -- we duplicate this letrec once (`do1`)
+  -- for each of the mutually recursive types
+  do1 v = ABT.cycle (ABT.absChain vs . ABT.tm $ LetRec decls' (ABT.var v))
 
 unsafeUnwrapType :: (Var v) => ABT.Term F v a -> AnnotatedType v a
 unsafeUnwrapType typ = ABT.transform f typ
@@ -211,29 +209,29 @@ unsafeUnwrapType typ = ABT.transform f typ
         f _ = error $ "Tried to unwrap a type that wasn't a type: " ++ show typ
 
 toABT :: Var v => DataDeclaration v -> ABT.Term F v ()
-toABT dd =
-  ABT.absChain (bound dd) (ABT.cycle (ABT.absChain (fst <$> constructors dd)
-                                                   (ABT.tm $ Constructors stuff)))
+toABT dd = ABT.absChain
+  (bound dd)
+  (ABT.cycle
+    (ABT.absChain (fst <$> constructors dd) (ABT.tm $ Constructors stuff))
+  )
   where stuff = ABT.transform Type . snd <$> constructors dd
 
 fromABT :: Var v => ABT.Term F v () -> DataDeclaration' v ()
-fromABT (ABT.AbsN' bound (
-           ABT.Cycle' names (ABT.Tm' (Constructors stuff)))) =
-  DataDeclaration ()
+fromABT (ABT.AbsN' bound (ABT.Cycle' names (ABT.Tm' (Constructors stuff)))) =
+  DataDeclaration
+    ()
     bound
-    [((), v, unsafeUnwrapType t) | (v, t) <- names `zip` stuff]
-fromABT a = error $ "ABT not of correct form to convert to DataDeclaration: " ++ show a
+    [ ((), v, unsafeUnwrapType t) | (v, t) <- names `zip` stuff ]
+fromABT a =
+  error $ "ABT not of correct form to convert to DataDeclaration: " ++ show a
 
 -- Implementation detail of `hashDecls`, works with unannotated data decls
-hashDecls0
-  :: (Eq v, Var v)
-  => Map v (DataDeclaration' v ())
-  -> [(v, Reference)]
-hashDecls0 decls = let
-  abts  = toABT <$> decls
-  ref r = ABT.tm (Type (Type.Ref r))
-  cs = Reference.hashComponents ref abts
-  in [(v,r) | (v, (r,_)) <- Map.toList cs ]
+hashDecls0 :: (Eq v, Var v) => Map v (DataDeclaration' v ()) -> [(v, Reference)]
+hashDecls0 decls =
+  let abts = toABT <$> decls
+      ref r = ABT.tm (Type (Type.Ref r))
+      cs = Reference.hashComponents ref abts
+  in  [ (v, r) | (v, (r, _)) <- Map.toList cs ]
 
 -- | compute the hashes of these user defined types and update any free vars
 --   corresponding to these decls with the resulting hashes
@@ -261,3 +259,4 @@ bindDecls decls refs = sortCtors . bindBuiltins refs <$> decls
   sortCtors dd =
     DataDeclaration (annotation dd) (bound dd) (sortOn hash3 $ constructors' dd)
   hash3 (_, _, typ) = ABT.hash typ :: Hash
+

--- a/parser-typechecker/src/Unison/Reference.hs
+++ b/parser-typechecker/src/Unison/Reference.hs
@@ -48,8 +48,6 @@ instance Show Id where
 pattern Builtin t = Builtin_ t
 pattern Derived h n i = DerivedPrivate_ (Id h n i)
 pattern DerivedId id = DerivedPrivate_ id
-{-# COMPLETE Derived, Builtin #-}
-{-# COMPLETE DerivedId, Builtin #-}
 
 type Pos = Word64
 type Size = Word64

--- a/parser-typechecker/src/Unison/Reference.hs
+++ b/parser-typechecker/src/Unison/Reference.hs
@@ -46,7 +46,7 @@ instance Show Id where
 
 pattern Builtin t = Builtin_ t
 pattern Derived h n i <- DerivedPrivate_ (Id h n i)
-pattern DerivedId id <- DerivedPrivate_ id
+pattern DerivedId id = DerivedPrivate_ id
 
 type Pos = Word64
 type Size = Word64

--- a/parser-typechecker/src/Unison/Reference.hs
+++ b/parser-typechecker/src/Unison/Reference.hs
@@ -46,7 +46,7 @@ instance Show Id where
 
 pattern Builtin t = Builtin_ t
 pattern Derived h n i <- DerivedPrivate_ (Id h n i)
-pattern DerivedId id = DerivedPrivate_ id
+pattern DerivedId id <- DerivedPrivate_ id
 
 type Pos = Word64
 type Size = Word64

--- a/parser-typechecker/src/Unison/Reference.hs
+++ b/parser-typechecker/src/Unison/Reference.hs
@@ -46,8 +46,10 @@ instance Show Id where
   show (Id h i _) = show h <> "-" <> show i
 
 pattern Builtin t = Builtin_ t
-pattern Derived h n i <- DerivedPrivate_ (Id h n i)
+pattern Derived h n i = DerivedPrivate_ (Id h n i)
 pattern DerivedId id = DerivedPrivate_ id
+{-# COMPLETE Derived, Builtin #-}
+{-# COMPLETE DerivedId, Builtin #-}
 
 type Pos = Word64
 type Size = Word64

--- a/parser-typechecker/src/Unison/Term.hs
+++ b/parser-typechecker/src/Unison/Term.hs
@@ -570,12 +570,14 @@ isVarKindInfo t = case t of
   Var' v | (Var.kind v) == "info" -> True
   _ -> False
 
+-- Dependencies including referenced data and effect decls
 dependencies :: (Ord v, Ord vt) => AnnotatedTerm2 vt at ap v a -> Set Reference
 dependencies t =
   dependencies' t
     <> referencedDataDeclarations t
     <> referencedEffectDeclarations t
 
+-- Dependencies including only term references (no types or effects)
 dependencies' :: (Ord v, Ord vt) => AnnotatedTerm2 vt at ap v a -> Set Reference
 dependencies' t = Set.fromList . Writer.execWriter $ ABT.visit' f t
  where

--- a/parser-typechecker/src/Unison/Term.hs
+++ b/parser-typechecker/src/Unison/Term.hs
@@ -577,12 +577,18 @@ dependencies t =
     <> referencedDataDeclarations t
     <> referencedEffectDeclarations t
 
--- Dependencies including only term references (no types or effects)
+-- Term and type dependencies, not including references to user-defined types
 dependencies' :: (Ord v, Ord vt) => AnnotatedTerm2 vt at ap v a -> Set Reference
 dependencies' t = Set.fromList . Writer.execWriter $ ABT.visit' f t
  where
   f t@(Ref r    ) = Writer.tell [r] *> pure t
   f t@(Ann _ typ) = Writer.tell (Set.toList (Type.dependencies typ)) *> pure t
+  f t@(Nat _)     = Writer.tell [Type.natRef] *> pure t
+  f t@(Int _)     = Writer.tell [Type.intRef] *> pure t
+  f t@(Float _)   = Writer.tell [Type.floatRef] *> pure t
+  f t@(Boolean _) = Writer.tell [Type.booleanRef] *> pure t
+  f t@(Text _)    = Writer.tell [Type.textRef] *> pure t
+  f t@(Vector _)  = Writer.tell [Type.vectorRef] *> pure t
   f t             = pure t
 
 referencedDataDeclarations

--- a/parser-typechecker/src/Unison/Term.hs
+++ b/parser-typechecker/src/Unison/Term.hs
@@ -566,49 +566,67 @@ unAskInfo tm = case tm of
   _ -> Nothing
 
 isVarKindInfo :: Var v => AnnotatedTerm' vt v a -> Bool
-isVarKindInfo t = case t of 
+isVarKindInfo t = case t of
   Var' v | (Var.kind v) == "info" -> True
   _ -> False
 
 dependencies :: (Ord v, Ord vt) => AnnotatedTerm2 vt at ap v a -> Set Reference
 dependencies t =
-  dependencies' t <> referencedDataDeclarations t <> referencedEffectDeclarations t
+  dependencies' t
+    <> referencedDataDeclarations t
+    <> referencedEffectDeclarations t
 
 dependencies' :: (Ord v, Ord vt) => AnnotatedTerm2 vt at ap v a -> Set Reference
 dependencies' t = Set.fromList . Writer.execWriter $ ABT.visit' f t
-  where f t@(Ref r) = Writer.tell [r] *> pure t
-        f t@(Ann _ typ) = Writer.tell (Set.toList (Type.dependencies typ)) *> pure t
-        f t = pure t
+ where
+  f t@(Ref r    ) = Writer.tell [r] *> pure t
+  f t@(Ann _ typ) = Writer.tell (Set.toList (Type.dependencies typ)) *> pure t
+  f t             = pure t
 
-referencedDataDeclarations :: Ord v => AnnotatedTerm2 vt at ap v a -> Set Reference
-referencedDataDeclarations t = Set.fromList . Writer.execWriter $ ABT.visit' f t
-  where f t@(Constructor r _) = Writer.tell [r] *> pure t
-        f t@(Match _ cases) = traverse_ g cases *> pure t where
-          g (MatchCase pat _ _) = Writer.tell (Set.toList (referencedDataDeclarationsP pat))
-        f t = pure t
+referencedDataDeclarations
+  :: Ord v => AnnotatedTerm2 vt at ap v a -> Set Reference
+referencedDataDeclarations t = Set.fromList . Writer.execWriter $ ABT.visit'
+  f
+  t
+ where
+  f t@(Constructor r _    ) = Writer.tell [r] *> pure t
+  f t@(Match       _ cases) = traverse_ g cases *> pure t
+   where
+    g (MatchCase pat _ _) =
+      Writer.tell (Set.toList (referencedDataDeclarationsP pat))
+  f t = pure t
 
 referencedDataDeclarationsP :: Pattern loc -> Set Reference
-referencedDataDeclarationsP p = Set.fromList . Writer.execWriter $ go p where
+referencedDataDeclarationsP p = Set.fromList . Writer.execWriter $ go p
+ where
   go (Pattern.As _ p) = go p
   go (Pattern.Constructor _ id _ args) = Writer.tell [id] *> traverse_ go args
   go (Pattern.EffectPure _ p) = go p
   go (Pattern.EffectBind _ _ _ args k) = traverse_ go args *> go k
   go _ = pure ()
 
-referencedEffectDeclarations :: Ord v => AnnotatedTerm2 vt at ap v a -> Set Reference
-referencedEffectDeclarations t = Set.fromList . Writer.execWriter $ ABT.visit' f t
-  where f t@(Request r _) = Writer.tell [r] *> pure t
-        f t@(Match _ cases) = traverse_ g cases *> pure t where
-          g (MatchCase pat _ _) = Writer.tell (Set.toList (referencedEffectDeclarationsP pat))
-          -- todo: does this traverse the guard and body of MatchCase?
-        f t = pure t
+referencedEffectDeclarations
+  :: Ord v => AnnotatedTerm2 vt at ap v a -> Set Reference
+referencedEffectDeclarations t = Set.fromList . Writer.execWriter $ ABT.visit'
+  f
+  t
+ where
+  f t@(Request r _    ) = Writer.tell [r] *> pure t
+  f t@(Match   _ cases) = traverse_ g cases *> pure t
+   where
+    g (MatchCase pat _ _) =
+      Writer.tell (Set.toList (referencedEffectDeclarationsP pat))
+    -- todo: does this traverse the guard and body of MatchCase?
+  f t = pure t
 
 referencedEffectDeclarationsP :: Pattern loc -> Set Reference
-referencedEffectDeclarationsP p = Set.fromList . Writer.execWriter $ go p where
-  go (Pattern.As _ p) = go p
+referencedEffectDeclarationsP p = Set.fromList . Writer.execWriter $ go p
+ where
+  go (Pattern.As _ p                ) = go p
   go (Pattern.Constructor _ _ _ args) = traverse_ go args
-  go (Pattern.EffectPure _ p) = go p
-  go (Pattern.EffectBind _ id _ args k) = Writer.tell [id] *> traverse_ go args *> go k
+  go (Pattern.EffectPure _ p        ) = go p
+  go (Pattern.EffectBind _ id _ args k) =
+    Writer.tell [id] *> traverse_ go args *> go k
   go _ = pure ()
 
 updateDependencies :: Ord v => Map Reference Reference -> Term v -> Term v
@@ -622,8 +640,9 @@ betaReduce :: Var v => Term v -> Term v
 betaReduce (App' (Lam' f) arg) = ABT.bind f arg
 betaReduce e = e
 
-hashComponents :: Var v => Map v (AnnotatedTerm v a) -> Map v (Reference, AnnotatedTerm v a)
-hashComponents m = Reference.hashComponents (\r -> ref() r) m
+hashComponents
+  :: Var v => Map v (AnnotatedTerm v a) -> Map v (Reference, AnnotatedTerm v a)
+hashComponents m = Reference.hashComponents (\r -> ref () r) m
 
 -- The hash for a constructor
 hashConstructor'
@@ -656,110 +675,147 @@ toReferent t = case t of
   Constructor' r i -> Just $ Referent.Con r i
   _                -> Nothing
 
-
 anf :: ∀ vt at v a . (Semigroup a, Var v)
     => AnnotatedTerm2 vt at a v a -> AnnotatedTerm2 vt at a v a
-anf t = go t where
+anf t = go t
+ where
   ann = ABT.annotation
   isVar (Var' _) = True
-  isVar _ = False
+  isVar _        = False
   isClosedLam t@(LamNamed' _ _) | Set.null (ABT.freeVars t) = True
   isClosedLam _ = False
   fixAp t f args =
-    let
-      args' = Map.fromList $ toVar =<< (args `zip` [0..])
-      toVar (b, i) | isVar b   = []
-                   | otherwise = [(i, ABT.fresh t (Var.named . Text.pack $ "arg" ++ show i))]
-      argsANF = map toANF (args `zip` [0..])
-      toANF (b,i) = maybe b (var (ann b)) $ Map.lookup i args'
-      addLet (b,i) body = maybe body (\v -> let1' False [(v,go b)] body) (Map.lookup i args')
-    in foldr addLet (apps' f argsANF) (args `zip` [(0::Int)..])
+    let args' = Map.fromList $ toVar =<< (args `zip` [0 ..])
+        toVar (b, i)
+          | isVar b
+          = []
+          | otherwise
+          = [(i, ABT.fresh t (Var.named . Text.pack $ "arg" ++ show i))]
+        argsANF = map toANF (args `zip` [0 ..])
+        toANF (b, i) = maybe b (var (ann b)) $ Map.lookup i args'
+        addLet (b, i) body =
+          maybe body (\v -> let1' False [(v, go b)] body) (Map.lookup i args')
+    in  foldr addLet (apps' f argsANF) (args `zip` [(0 :: Int) ..])
   go :: AnnotatedTerm2 vt at a v a -> AnnotatedTerm2 vt at a v a
-  go (Apps' f@(LamsNamed' vs body) args) | isClosedLam f = ap vs body args where
-    ap vs body [] = lam' (ann f) vs body
-    ap (v:vs) body (arg:args) = let1' False [(v,arg)] $ ap vs body args
-    ap [] _body _args = error "type error"
+  go (Apps' f@(LamsNamed' vs body) args) | isClosedLam f = ap vs body args
+   where
+    ap vs       body  []           = lam' (ann f) vs body
+    ap (v : vs) body  (arg : args) = let1' False [(v, arg)] $ ap vs body args
+    ap []       _body _args        = error "type error"
   go t@(Apps' f args)
-    | isVar f = fixAp t f args
-    | otherwise = let fv' = ABT.fresh t (Var.named "f")
-                  in let1' False [(fv', anf f)] (fixAp t (var (ann f) fv') args)
+    | isVar f
+    = fixAp t f args
+    | otherwise
+    = let fv' = ABT.fresh t (Var.named "f")
+      in  let1' False [(fv', anf f)] (fixAp t (var (ann f) fv') args)
   go e@(Handle' h body)
-    | isVar h = handle (ann e) h (go body)
-    | otherwise = let h' = ABT.fresh e (Var.named "handler")
-                  in let1' False [(h', go h)] (handle (ann e) (var (ann h) h') (go body))
+    | isVar h
+    = handle (ann e) h (go body)
+    | otherwise
+    = let h' = ABT.fresh e (Var.named "handler")
+      in  let1' False [(h', go h)] (handle (ann e) (var (ann h) h') (go body))
   go e@(If' cond t f)
-    | isVar cond = iff (ann e) cond (go t) (go f)
-    | otherwise = let cond' = ABT.fresh e (Var.named "cond")
-                  in let1' False [(cond', anf cond)] (iff (ann e) (var (ann cond) cond') t f)
+    | isVar cond
+    = iff (ann e) cond (go t) (go f)
+    | otherwise
+    = let cond' = ABT.fresh e (Var.named "cond")
+      in  let1' False
+                [(cond', anf cond)]
+                (iff (ann e) (var (ann cond) cond') t f)
   go e@(Match' scrutinee cases)
-    | isVar scrutinee = match (ann e) scrutinee (fmap go <$> cases)
-    | otherwise = let scrutinee' = ABT.fresh e (Var.named "scrutinee")
-                  in let1' False [(scrutinee', go scrutinee)] (match (ann e) (var (ann scrutinee) scrutinee') cases)
+    | isVar scrutinee
+    = match (ann e) scrutinee (fmap go <$> cases)
+    | otherwise
+    = let scrutinee' = ABT.fresh e (Var.named "scrutinee")
+      in  let1' False
+                [(scrutinee', go scrutinee)]
+                (match (ann e) (var (ann scrutinee) scrutinee') cases)
   go e@(And' x y)
-    | isVar x = and (ann e) x (go y)
-    | otherwise =
-        let x' = ABT.fresh e (Var.named "argX")
-        in let1' False [(x', anf x)] (and (ann e) (var (ann x) x') (go y))
+    | isVar x
+    = and (ann e) x (go y)
+    | otherwise
+    = let x' = ABT.fresh e (Var.named "argX")
+      in  let1' False [(x', anf x)] (and (ann e) (var (ann x) x') (go y))
   go e@(Or' x y)
-    | isVar x = or (ann e) x (go y)
-    | otherwise =
-        let x' = ABT.fresh e (Var.named "argX")
-        in let1' False [(x', go x)] (or (ann e) (var (ann x) x') (go y))
-  go e@(ABT.Tm' f) = ABT.tm' (ann e) (go <$> f)
-  go e@(ABT.Var' _) = e
+    | isVar x
+    = or (ann e) x (go y)
+    | otherwise
+    = let x' = ABT.fresh e (Var.named "argX")
+      in  let1' False [(x', go x)] (or (ann e) (var (ann x) x') (go y))
+  go e@(ABT.Tm'  f               ) = ABT.tm' (ann e) (go <$> f)
+  go e@(ABT.Var' _               ) = e
   go e@(ABT.out -> ABT.Cycle body) = ABT.cycle' (ann e) (go body)
   go e@(ABT.out -> ABT.Abs v body) = ABT.abs' (ann e) v (go body)
-  go e = e
+  go e                             = e
 
 instance Var v => Hashable1 (F v a p) where
-  hash1 hashCycle hash e =
-    let
-      (tag, hashed, varint) = (Hashable.Tag, Hashable.Hashed, Hashable.Nat . fromIntegral)
-    in case e of
-      -- So long as `Reference.Derived` ctors are created using the same hashing
-      -- function as is used here, this case ensures that references are 'transparent'
-      -- wrt hash and hashing is unaffected by whether expressions are linked.
-      -- So for example `x = 1 + 1` and `y = x` hash the same.
-      Ref (Reference.Derived h 0 1) -> Hashable.fromBytes (Hash.toBytes h)
-      Ref (Reference.Derived h i n) ->
-        Hashable.accumulate [tag 1, hashed $ Hashable.fromBytes (Hash.toBytes h), Hashable.Nat i, Hashable.Nat n]
-      -- Note: start each layer with leading `1` byte, to avoid collisions with
-      -- types, which start each layer with leading `0`. See `Hashable1 Type.F`
-      _ -> Hashable.accumulate $ tag 1 : case e of
-        Nat i -> [tag 64, accumulateToken i]
-        Int i -> [tag 65, accumulateToken i]
-        Float n -> [tag 66, Hashable.Double n]
-        Boolean b -> [tag 67, accumulateToken b]
-        Text t -> [tag 68, accumulateToken t]
-        Blank b -> tag 1 :
-          case b of
-            B.Blank -> [tag 0]
-            B.Recorded (B.Placeholder _ s) -> [tag 1, Hashable.Text (Text.pack s)]
-            B.Recorded (B.Resolve _ s)  -> [tag 2, Hashable.Text (Text.pack s)]
-        Ref (Reference.Builtin name) -> [tag 2, accumulateToken name]
-        Ref (Reference.Derived _ _ _) -> error "handled above, but GHC can't figure this out"
-        App a a2 -> [tag 3, hashed (hash a), hashed (hash a2)]
-        Ann a t -> [tag 4, hashed (hash a), hashed (ABT.hash t)]
-        Vector as -> tag 5 : varint (Vector.length as) : map (hashed . hash) (Vector.toList as)
-        Lam a -> [tag 6, hashed (hash a) ]
-        -- note: we use `hashCycle` to ensure result is independent of let binding order
-        LetRec _ as a -> case hashCycle as of
-          (hs, hash) -> tag 7 : hashed (hash a) : map hashed hs
-        -- here, order is significant, so don't use hashCycle
-        Let _ b a -> [tag 8, hashed $ hash b, hashed $ hash a]
-        If b t f -> [tag 9, hashed $ hash b, hashed $ hash t, hashed $ hash f]
-        Request r n -> [tag 10, accumulateToken r, varint n]
-        Constructor r n -> [tag 12, accumulateToken r, varint n]
-        Match e branches -> tag 13 : hashed (hash e) : concatMap h branches
-          where
-            h (MatchCase pat guard branch) =
-              concat [[accumulateToken pat],
-                      toList (hashed . hash <$> guard),
-                      [hashed (hash branch)]]
-        Handle h b -> [tag 15, hashed $ hash h, hashed $ hash b]
-        And x y -> [tag 16, hashed $ hash x, hashed $ hash y]
-        Or x y -> [tag 17, hashed $ hash x, hashed $ hash y]
-        _ -> error $ "unhandled case in show: " <> show (const () <$> e)
+  hash1 hashCycle hash e
+    = let (tag, hashed, varint) =
+            (Hashable.Tag, Hashable.Hashed, Hashable.Nat . fromIntegral)
+      in
+        case e of
+        -- So long as `Reference.Derived` ctors are created using the same
+        -- hashing function as is used here, this case ensures that references
+        -- are 'transparent' wrt hash and hashing is unaffected by whether
+        -- expressions are linked. So for example `x = 1 + 1` and `y = x` hash
+        -- the same.
+          Ref (Reference.Derived h 0 1) -> Hashable.fromBytes (Hash.toBytes h)
+          Ref (Reference.Derived h i n) -> Hashable.accumulate
+            [ tag 1
+            , hashed $ Hashable.fromBytes (Hash.toBytes h)
+            , Hashable.Nat i
+            , Hashable.Nat n
+            ]
+          -- Note: start each layer with leading `1` byte, to avoid collisions
+          -- with types, which start each layer with leading `0`.
+          -- See `Hashable1 Type.F`
+          _ ->
+            Hashable.accumulate
+              $ tag 1
+              : case e of
+                  Nat     i -> [tag 64, accumulateToken i]
+                  Int     i -> [tag 65, accumulateToken i]
+                  Float   n -> [tag 66, Hashable.Double n]
+                  Boolean b -> [tag 67, accumulateToken b]
+                  Text    t -> [tag 68, accumulateToken t]
+                  Blank   b -> tag 1 : case b of
+                    B.Blank -> [tag 0]
+                    B.Recorded (B.Placeholder _ s) ->
+                      [tag 1, Hashable.Text (Text.pack s)]
+                    B.Recorded (B.Resolve _ s) ->
+                      [tag 2, Hashable.Text (Text.pack s)]
+                  Ref (Reference.Builtin name) -> [tag 2, accumulateToken name]
+                  Ref (Reference.Derived _ _ _) ->
+                    error "handled above, but GHC can't figure this out"
+                  App a a2  -> [tag 3, hashed (hash a), hashed (hash a2)]
+                  Ann a t   -> [tag 4, hashed (hash a), hashed (ABT.hash t)]
+                  Vector as -> tag 5 : varint (Vector.length as) : map
+                    (hashed . hash)
+                    (Vector.toList as)
+                  Lam a         -> [tag 6, hashed (hash a)]
+                  -- note: we use `hashCycle` to ensure result is independent of
+                  -- let binding order
+                  LetRec _ as a -> case hashCycle as of
+                    (hs, hash) -> tag 7 : hashed (hash a) : map hashed hs
+                  -- here, order is significant, so don't use hashCycle
+                  Let _ b a -> [tag 8, hashed $ hash b, hashed $ hash a]
+                  If b t f ->
+                    [tag 9, hashed $ hash b, hashed $ hash t, hashed $ hash f]
+                  Request     r n -> [tag 10, accumulateToken r, varint n]
+                  Constructor r n -> [tag 12, accumulateToken r, varint n]
+                  Match e branches ->
+                    tag 13 : hashed (hash e) : concatMap h branches
+                   where
+                    h (MatchCase pat guard branch) = concat
+                      [ [accumulateToken pat]
+                      , toList (hashed . hash <$> guard)
+                      , [hashed (hash branch)]
+                      ]
+                  Handle h b -> [tag 15, hashed $ hash h, hashed $ hash b]
+                  And    x y -> [tag 16, hashed $ hash x, hashed $ hash y]
+                  Or     x y -> [tag 17, hashed $ hash x, hashed $ hash y]
+                  _ ->
+                    error $ "unhandled case in show: " <> show (const () <$> e)
 
 -- mostly boring serialization code below ...
 
@@ -785,44 +841,56 @@ instance (Var vt, Eq at, Eq a) => Eq (F vt at p a) where
   Or a b == Or a2 b2 = a == a2 && b == b2
   Lam a == Lam b = a == b
   LetRec _ bs body == LetRec _ bs2 body2 = bs == bs2 && body == body2
-  Let _ binding body == Let _ binding2 body2 = binding == binding2 && body == body2
+  Let _ binding body == Let _ binding2 body2 =
+    binding == binding2 && body == body2
   Match scrutinee cases == Match s2 cs2 = scrutinee == s2 && cases == cs2
   _ == _ = False
 
 
 instance (Var v, Show a) => Show (F v a0 p a) where
-  showsPrec p fa = go p fa where
-    showConstructor r n = showsPrec 0 r <> s"#" <> showsPrec 0 n
-    go _ (Int n) = (if n >= 0 then s "+" else s "") <> showsPrec 0 n
-    go _ (Nat n) = showsPrec 0 n
-    go _ (Float n) = showsPrec 0 n
-    go _ (Boolean True) = s"true"
-    go _ (Boolean False) = s"false"
-    go p (Ann t k) = showParen (p > 1) $ showsPrec 0 t <> s":" <> showsPrec 0 k
-    go p (App f x) =
-      showParen (p > 9) $ showsPrec 9 f <> s" " <> showsPrec 10 x
-    go _ (Lam body) = showParen True (s"λ " <> showsPrec 0 body)
-    go _ (Vector vs) = showListWith (showsPrec 0) (Vector.toList vs)
-    go _ (Blank b) =
-      case b of
-        B.Blank -> s"_"
-        B.Recorded (B.Placeholder _ r) -> s("_" ++ r)
-        B.Recorded (B.Resolve _ r) -> s r
-    go _ (Ref r) = s"Ref(" <> showsPrec 0 r <> s")"
-    go _ (Let _ b body) = showParen True (s"let " <> showsPrec 0 b <> s" in " <> showsPrec 0 body)
-    go _ (LetRec _ bs body) = showParen True (s"let rec" <> showsPrec 0 bs <> s" in " <> showsPrec 0 body)
-    go _ (Handle b body) = showParen True (s"handle " <> showsPrec 0 b <> s " in " <> showsPrec 0 body)
-    go _ (Constructor r n) = showConstructor r n
-    go _ (Match scrutinee cases) =
-      showParen True (s"case " <> showsPrec 0 scrutinee <> s" of " <> showsPrec 0 cases)
-    go _ (Text s) = showsPrec 0 s
+  showsPrec p fa = go p fa
+   where
+    showConstructor r n = showsPrec 0 r <> s "#" <> showsPrec 0 n
+    go _ (Int     n    ) = (if n >= 0 then s "+" else s "") <> showsPrec 0 n
+    go _ (Nat     n    ) = showsPrec 0 n
+    go _ (Float   n    ) = showsPrec 0 n
+    go _ (Boolean True ) = s "true"
+    go _ (Boolean False) = s "false"
+    go p (Ann t k) = showParen (p > 1) $ showsPrec 0 t <> s ":" <> showsPrec 0 k
+    go p (App f x) = showParen (p > 9) $ showsPrec 9 f <> s " " <> showsPrec 10 x
+    go _ (Lam    body  ) = showParen True (s "λ " <> showsPrec 0 body)
+    go _ (Vector vs    ) = showListWith (showsPrec 0) (Vector.toList vs)
+    go _ (Blank  b     ) = case b of
+      B.Blank                        -> s "_"
+      B.Recorded (B.Placeholder _ r) -> s ("_" ++ r)
+      B.Recorded (B.Resolve     _ r) -> s r
+    go _ (Ref r) = s "Ref(" <> showsPrec 0 r <> s ")"
+    go _ (Let _ b body) =
+      showParen True (s "let " <> showsPrec 0 b <> s " in " <> showsPrec 0 body)
+    go _ (LetRec _ bs body) = showParen
+      True
+      (s "let rec" <> showsPrec 0 bs <> s " in " <> showsPrec 0 body)
+    go _ (Handle b body) = showParen
+      True
+      (s "handle " <> showsPrec 0 b <> s " in " <> showsPrec 0 body)
+    go _ (Constructor r         n    ) = showConstructor r n
+    go _ (Match       scrutinee cases) = showParen
+      True
+      (s "case " <> showsPrec 0 scrutinee <> s " of " <> showsPrec 0 cases)
+    go _ (Text s     ) = showsPrec 0 s
     go _ (Request r n) = showConstructor r n
-    go p (If c t f) = showParen (p > 0) $
-      s"if " <> showsPrec 0 c <> s" then " <> showsPrec 0 t <>
-      s" else " <> showsPrec 0 f
-    go p (And x y) = showParen (p > 0) $
-      s"and " <> showsPrec 0 x <> s" " <> showsPrec 0 y
-    go p (Or x y) = showParen (p > 0) $
-      s"or " <> showsPrec 0 x <> s" " <> showsPrec 0 y
+    go p (If c t f) =
+      showParen (p > 0)
+        $  s "if "
+        <> showsPrec 0 c
+        <> s " then "
+        <> showsPrec 0 t
+        <> s " else "
+        <> showsPrec 0 f
+    go p (And x y) =
+      showParen (p > 0) $ s "and " <> showsPrec 0 x <> s " " <> showsPrec 0 y
+    go p (Or x y) =
+      showParen (p > 0) $ s "or " <> showsPrec 0 x <> s " " <> showsPrec 0 y
     (<>) = (.)
-    s = showString
+    s    = showString
+

--- a/parser-typechecker/src/Unison/Type.hs
+++ b/parser-typechecker/src/Unison/Type.hs
@@ -188,9 +188,6 @@ isArrow _ = False
 
 -- some smart constructors
 
-vector :: Ord v => a -> AnnotatedType v a
-vector a = builtin a "Sequence"
-
 --vectorOf :: Ord v => a -> AnnotatedType v a -> Type v
 --vectorOf a t = vector `app` t
 
@@ -214,26 +211,38 @@ unit = flip ref unitRef
 pair = flip ref pairRef
 optional = flip ref optionalRef
 
+intRef, natRef, floatRef, booleanRef, textRef, streamRef, vectorRef :: Reference
+intRef = Reference.Builtin "Int"
+natRef = Reference.Builtin "Nat"
+floatRef = Reference.Builtin "Float"
+booleanRef = Reference.Builtin "Boolean"
+textRef = Reference.Builtin "Text"
+streamRef = Reference.Builtin "Stream"
+vectorRef = Reference.Builtin "Sequence"
+
 builtin :: Ord v => a -> Text -> AnnotatedType v a
 builtin a = ref a . Reference.Builtin
 
 int :: Ord v => a -> AnnotatedType v a
-int a = builtin a "Int"
+int a = ref a $ intRef
 
 nat :: Ord v => a -> AnnotatedType v a
-nat a = builtin a "Nat"
+nat a = ref a $ natRef
 
 float :: Ord v => a -> AnnotatedType v a
-float a = builtin a "Float"
+float a = ref a $ floatRef
 
 boolean :: Ord v => a -> AnnotatedType v a
-boolean a = builtin a "Boolean"
+boolean a = ref a $ booleanRef
 
 text :: Ord v => a -> AnnotatedType v a
-text a = builtin a "Text"
+text a = ref a $ textRef
 
 stream :: Ord v => a -> AnnotatedType v a
-stream a = builtin a "Stream"
+stream a = ref a $ streamRef
+
+vector :: Ord v => a -> AnnotatedType v a
+vector a = ref a $ vectorRef
 
 app :: Ord v => a -> AnnotatedType v a -> AnnotatedType v a -> AnnotatedType v a
 app a f arg = ABT.tm' a (App f arg)

--- a/parser-typechecker/src/Unison/Type.hs
+++ b/parser-typechecker/src/Unison/Type.hs
@@ -159,7 +159,7 @@ unForalls t = go t []
         go body vs = Just(reverse vs, body)
 
 unTuple :: Var v => AnnotatedType v a -> Maybe [AnnotatedType v a]
-unTuple t = case t of 
+unTuple t = case t of
   Apps' (Ref' PairRef) [fst, snd] -> (fst :) <$> unTuple snd
   Ref' UnitRef -> Just []
   _ -> Nothing

--- a/parser-typechecker/src/Unison/Util/Relation.hs
+++ b/parser-typechecker/src/Unison/Util/Relation.hs
@@ -34,8 +34,10 @@ import qualified Data.Map                      as Map
 data Relation a b  = Relation { domain ::  M.Map a (Set b)
                               , range  ::  M.Map b (Set a)
                               }
-    deriving (Show, Eq, Ord)
+    deriving (Eq, Ord)
 
+instance (Show a, Show b) => Show (Relation a b) where
+  show = show . toList
 
 -- * Functions about relations
 

--- a/parser-typechecker/src/Unison/Util/Relation.hs
+++ b/parser-typechecker/src/Unison/Util/Relation.hs
@@ -1,6 +1,7 @@
 module Unison.Util.Relation where
 
 import           Prelude                 hiding ( null )
+import           Data.Bifunctor                 ( first, second )
 import           Data.Foldable                  ( foldl' )
 import qualified Data.Map                      as M
 import           Data.Set                       ( Set )
@@ -343,6 +344,14 @@ deleteRan b r = foldl' (\r a -> delete a b r) r $ lookupRan b r
 deleteDom :: (Ord a, Ord b) => a -> Relation a b -> Relation a b
 deleteDom a r = foldl' (\r b -> delete a b r) r $ lookupDom a r
 
+-- aka first
+mapDom :: (Ord a, Ord a', Ord b) => (a -> a') -> Relation a b -> Relation a' b
+mapDom f = fromList . fmap (first f) . toList
+
+-- aka second
+mapRan :: (Ord a, Ord b, Ord b') => (b -> b') -> Relation a b -> Relation a b'
+mapRan f = fromList . fmap (second f) . toList
+
 fromMap :: (Ord a, Ord b) => Map a b -> Relation a b
 fromMap = fromList . Map.toList
 
@@ -352,6 +361,13 @@ fromMultimap m =
 
 fromSet :: (Ord a, Ord b) => Set (a,b) -> Relation a b
 fromSet = fromList . S.toList
+
+swap :: Relation a b -> Relation b a
+swap (Relation a b) = Relation b a
+
+bimap :: (Ord a, Ord b, Ord c, Ord d)
+      => (a -> c) -> (b -> d) -> Relation a b -> Relation c d
+bimap f g = fromList . fmap (\(a,b) -> (f a, g b)) . toList
 
 instance (Ord a, Ord b) => Monoid (Relation a b) where
   mempty = empty

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -136,6 +136,7 @@ library
     prelude-extras,
     random,
     safe,
+    split,
     stm,
     strings,
     terminal-size,


### PR DESCRIPTION
ITS WORKING!! In the screenshotted example, I edited the `Optional` type, so a couple builtin functions that use that type are marked as needing updates.

<img width="957" alt="image" src="https://user-images.githubusercontent.com/11074/51415979-b5e6b580-1b45-11e9-96db-f0ff36cbed74.png">

You can now edit definitions that have transitive dependents, and the `todo` command will tell you what the "frontier" of your refactoring is and walk you though which definitions need updating.

Still missing:

* A `dependents`/`usages` command
* An `edit` command, for conveniently starting an edit on a definition (basically `view` into a scratch file)

Kind of interesting - nothing stops you from editing a builtin type or term, though that's probably not something you would commonly do.