### PR TITLE
`edit` command

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor.hs
@@ -147,10 +147,18 @@ data Input
   | SwitchBranchI BranchName
   | ForkBranchI BranchName
   | MergeBranchI BranchName
-  | ShowDefinitionI [String]
+  | ShowDefinitionI OutputLocation [String]
   | TodoI
   | QuitI
   deriving (Show)
+
+-- Some commands, like `view`, can dump output to either console or a file.
+data OutputLocation
+  = ConsoleLocation
+  | LatestFileLocation
+  | FileLocation FilePath deriving Show
+  -- ClipboardLocation
+
 
 -- Whether or not updates are allowed during file slurping
 type AllowUpdates = Bool
@@ -182,7 +190,7 @@ data Output v
   | Evaluated Names ([(Text, Term v ())], Term v ())
   | Typechecked SourceName PPE.PrettyPrintEnv (UF.TypecheckedUnisonFile' v Ann)
   | FileChangeEvent SourceName Text
-  | DisplayDefinitions PPE.PrettyPrintEnv
+  | DisplayDefinitions (Maybe FilePath) PPE.PrettyPrintEnv
                        [(Reference, DisplayThing (Term v Ann))]
                        [(Reference, DisplayThing (Decl v Ann))]
   | TodoOutput Branch (TodoOutput v Ann)


### PR DESCRIPTION
`edit` behaves just like view, but dumps the contents of the definition to the top of the most recently edited file (otherwise to a file called `<currentBranchName>.u`), "above the fold". Am open to tweaking this behavior.

<img width="1067" alt="screen shot 2019-01-20 at 4 18 07 pm" src="https://user-images.githubusercontent.com/11074/51445091-22d98700-1ccf-11e9-81ee-00cfca4eaf86.png">

In `1.u`, it generates:

<img width="842" alt="screen shot 2019-01-20 at 4 19 37 pm" src="https://user-images.githubusercontent.com/11074/51445099-3389fd00-1ccf-11e9-9c43-1cb8b630ebb3.png">

One thing I'd like to address later is that the newly edited file triggers a file change event, so the file gets immediately typechecked. Maybe that is okay, but I think it's a little weird. To fix, we'll need some way of telling the code that responds to those file change events that it should ignore the event we just triggered by writing to the file.

Haven't played with it much, but so far, I would say it makes the editing process more fluid. The only thing I dislike is you still have to switch to the appropriate text buffer after you do the edit... it would be cool if somehow that text buffer were just opened automatically, and if it's already open, switch to it.