### PR TITLE
`todo` command now shows both edit and name conflicts nicely

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -324,6 +324,14 @@ before b b2 = unbranch b `Causal.before` unbranch b2
 conflicts'' :: (Ord a, Ord b) => Relation a b -> Relation a b
 conflicts'' r = R.filterDom ((>1). length . flip R.lookupDom r) r
 
+-- Returns the list of edit conflicts, for both terms and types
+editConflicts :: Branch0 -> [Either (Reference, Set TypeEdit) (Reference, Set TermEdit) ]
+editConflicts b = let
+  termConflicts = conflicts'' (editedTerms b)
+  typeConflicts = conflicts'' (editedTypes b)
+  in [ Left (r, ts) | (r, ts) <- Map.toList (R.domain typeConflicts) ] ++
+     [ Right (r, es) | (r, es) <- Map.toList (R.domain termConflicts) ]
+
 conflicts' :: Branch0 -> Branch0
 conflicts' b = Branch0 (Namespace (c termNamespace) (c typeNamespace))
                        mempty

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -352,6 +352,17 @@ resolveNamedTermConflict old new typ b = let
   addName b name = addTermName (Referent.Ref new) name b
   in foldl' addName b'' (namesForTerm (Referent.Ref new) b)
 
+-- Like resolveNamedTermConflict, but for types
+resolveNamedTypeConflict :: Reference -> Reference -> Branch0 -> Branch0
+resolveNamedTypeConflict old new b = let
+  b' = resolveTypeConflict old new b
+  edits = R.lookupDom old (editedTypes b)
+  names = typeNamespace b R.|> Set.fromList (toList edits >>= TypeEdit.references)
+  b'' = foldl' del b' (R.toList names)
+    where del b (name, referent) = deleteTypeName referent name b
+  addName b name = addTypeName new name b
+  in foldl' addName b'' (namesForType new b)
+
 -- Use as `resolved editedTerms branch`
 resolved :: Ord a => (Branch0 -> Relation a b) -> Branch0 -> Map a b
 resolved f = resolved' . f where

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -306,14 +306,15 @@ namesForType ref b = let
 
 hashQualifyTermName :: Int -> Name -> Set Referent -> Map Referent Name
 hashQualifyTermName numHashChars n rs =
-  Map.fromList
-    [ (r, n <> Text.pack (Referent.showShort numHashChars r)) | r <- toList rs ]
+  if Set.size rs < 2 then Map.fromList [(r, n) | r <- toList rs ]
+  else Map.fromList [ (r, n <> Text.pack (Referent.showShort numHashChars r))
+                    | r <- toList rs ]
 
 hashQualifyTypeName :: Int -> Name -> Set Reference -> Map Reference Name
 hashQualifyTypeName numHashChars n rs =
-  Map.fromList
-    [ (r, n <> Text.pack (Reference.showShort numHashChars r)) | r <- toList rs ]
-
+  if Set.size rs < 2 then Map.fromList [(r, n) | r <- toList rs ]
+  else Map.fromList [ (r, n <> Text.pack (Reference.showShort numHashChars r))
+                    | r <- toList rs ]
 
 oldNamesForTerm :: Int -> Referent -> Branch0 -> Set Name
 oldNamesForTerm numHashChars ref
@@ -328,7 +329,7 @@ oldNamesForType numHashChars ref
   . (view $ oldNamespaceL . types)
 
 numHashChars :: Branch0 -> Int
-numHashChars = const 8 -- todo: use trie to find depth of branching
+numHashChars = const 3 -- todo: use trie to find depth of branching
 
 prettyPrintEnv1 :: Branch0 -> PrettyPrintEnv
 prettyPrintEnv1 b = PPE.PrettyPrintEnv terms types where

--- a/parser-typechecker/src/Unison/Codebase/CommandLine2.hs
+++ b/parser-typechecker/src/Unison/Codebase/CommandLine2.hs
@@ -452,9 +452,9 @@ notifyUser dir o = case o of
               [""],
               [P.lines . join $ [
                 if null conflictedTypeNames then []
-                else [P.hang "Types:" (P.oxfordCommas (P.text <$> toList conflictedTypeNames))],
+                else [P.hang "Types:" (P.commas (P.text <$> toList conflictedTypeNames))],
                 if null conflictedTermNames then []
-                else [P.hang "Terms:" (P.oxfordCommas (P.text <$> toList conflictedTermNames))]
+                else [P.hang "Terms:" (P.commas (P.text <$> toList conflictedTermNames))]
               ]]
             ]
         ]) ++
@@ -530,6 +530,36 @@ notifyUser dir o = case o of
       <> "\n\n"
       <> P.column2 [ (P.text name, fromString (show ref)) | (name, ref) <- types ])
     ]
+
+{-
+  These definitions were updated in separate branches that have been merged into this branch; as a result, I'm not sure which definition to use as the canonical replacement:
+
+    type Foo#asd was replaced with: Foo, Bar#s92, and Baz
+    id#3ff       was replaced with: id, unsafeId
+
+  Tip: Use `view Foo Bar#s92 Baz` to view these candidates` and `resolve-update Foo#asd <replacement>` to select one.
+
+  [Moreover, ] these names have conflicting definitions as a result of a merge:
+    Types: Bar
+    Terms: cat, dog
+
+  Tip: Use `view cat` to see the conflicting definitions, and some combination of `rename` and `replace` to resolve the conflict.
+
+  ----
+  conflict situations
+  a) multiple edits to a definition
+    1) the new definitions share the same name
+    2) the new definitions have distinct names
+  b) multiple definitions to a name
+    - suppress if coinciding with a1)
+-}
+data WrangledEditConflicts = WrangledEditConflicts
+  {                               -- `Nothing` means Deprecation
+    conflictedUpgrades :: Map Reference (Set (Maybe Reference))
+  , 
+  }
+wrangleEditConflicts :: Branch0 -> (Map Reference (Set Reference), Set Name)
+
 
 allow :: FilePath -> Bool
 allow = (||) <$> (".u" `isSuffixOf`) <*> (".uu" `isSuffixOf`)

--- a/parser-typechecker/src/Unison/Codebase/CommandLine2.hs
+++ b/parser-typechecker/src/Unison/Codebase/CommandLine2.hs
@@ -457,12 +457,12 @@ notifyUser dir o = case o of
               renderEditConflicts ppe (Branch.head branch),
               if Set.null conflictedTypeNames then []
               else [
-                P.wrap ("These" <> P.bold "types have conflicted definitions" <> ":")
+                P.wrap ("These" <> P.bold "types have conflicted definitions:")
                 `P.hang` P.commas (P.text <$> toList conflictedTypeNames)
               ],
               if Set.null conflictedTermNames then []
               else [
-                P.wrap ("These" <> P.bold "terms have conflicted definitions" <> ":")
+                P.wrap ("These" <> P.bold "terms have conflicted definitions:")
                 `P.hang` P.commas (P.text <$> toList conflictedTermNames)
               ],
               if Set.null conflictedTermNames && Set.null conflictedTypeNames
@@ -499,15 +499,12 @@ notifyUser dir o = case o of
     P.wrap $ "These" <> P.bold "definitions were edited differently"
           <> "in branches that have been merged into this branch."
           <> "You'll have to tell me what to use as the new definition:",
-    "",
-    P.lines (formatConflict <$> cs),
-    "",
-    tip $ "Use " <> P.group ("`view " <> P.sep " " (map name cs) <> "`")
-       <> "to view these definitions and"
-       <> P.group ("`resolve-edit " <> name e <> "<replacement>")
-       <> "to pick a replacement."
+    P.indentN 2 (P.lines (formatConflict <$> cs)),
+    tip $ P.group ("`resolve-edit " <> name e <> " <replacement>")
+          <> "to pick a replacement." -- todo: eventually something with `edit`
     ]
     where
+      editTargets  =
       name (Left (r,_)) = P.text (PPE.typeName ppe r)
       name (Right (r,_)) = P.text (PPE.termName ppe (Referent.Ref r))
       formatTypeEdits es = P.wrap $ mconcat [
@@ -525,9 +522,9 @@ notifyUser dir o = case o of
         P.oxfordCommas [ P.text (PPE.termName ppe (Referent.Ref r)) | TermEdit.Replace r _ <- toList es ]
         ]
       formatConflict e@(Left (_, edits)) =
-        "The type " <> P.bold (name e) <> formatTypeEdits (toList edits)
+        "The type " <> name e <> formatTypeEdits (toList edits)
       formatConflict e@(Right (_, edits)) =
-        "The term " <> P.bold (name e) <> " " <> formatTermEdits edits
+        "The term " <> name e <> " " <> formatTermEdits edits
   renderEditConflicts _ppe _ = []
 
   renderFileName = P.group . P.blue . fromString

--- a/parser-typechecker/src/Unison/Codebase/CommandLine2.hs
+++ b/parser-typechecker/src/Unison/Codebase/CommandLine2.hs
@@ -504,7 +504,6 @@ notifyUser dir o = case o of
           <> "to pick a replacement." -- todo: eventually something with `edit`
     ]
     where
-      editTargets  =
       name (Left (r,_)) = P.text (PPE.typeName ppe r)
       name (Right (r,_)) = P.text (PPE.termName ppe (Referent.Ref r))
       formatTypeEdits es = P.wrap $ mconcat [

--- a/parser-typechecker/src/Unison/Codebase/CommandLine2.hs
+++ b/parser-typechecker/src/Unison/Codebase/CommandLine2.hs
@@ -502,7 +502,7 @@ notifyUser dir o = case o of
     "",
     P.lines (formatConflict <$> cs),
     "",
-    tip $ "Use " <> P.group ("`view" <> P.sep " " (map name cs) <> "`")
+    tip $ "Use " <> P.group ("`view " <> P.sep " " (map name cs) <> "`")
        <> "to view these definitions and"
        <> P.group ("`resolve-edit " <> name e <> "<replacement>")
        <> "to pick a replacement."
@@ -579,35 +579,6 @@ notifyUser dir o = case o of
       <> "\n\n"
       <> P.column2 [ (P.text name, fromString (show ref)) | (name, ref) <- types ])
     ]
-
-{-
-  These definitions were updated in separate branches that have been merged into this branch; as a result, I'm not sure which definition to use as the canonical replacement:
-
-    type Foo#asd was replaced with: Foo, Bar#s92, and Baz
-    id#3ff       was replaced with: id, unsafeId
-
-  Tip: Use `view Foo Bar#s92 Baz` to view these candidates` and `resolve-update Foo#asd <replacement>` to select one.
-
-  [Moreover, ] these names have conflicting definitions as a result of a merge:
-    Types: Bar
-    Terms: cat, dog
-
-  Tip: Use `view cat` to see the conflicting definitions, and some combination of `rename` and `replace` to resolve the conflict.
-
-  ----
-  conflict situations
-  a) multiple edits to a definition
-    1) the new definitions share the same name
-    2) the new definitions have distinct names
-  b) multiple definitions to a name
-    - suppress if coinciding with a1)
--}
--- data WrangledEditConflicts = WrangledEditConflicts
---   {                               -- `Nothing` means Deprecation
---     conflictedUpgrades :: R.Relation Map Reference (Set (Maybe Reference))
---   }
--- wrangleEditConflicts :: Branch0 -> (Map Reference (Set Reference), Set Name)
-
 
 allow :: FilePath -> Bool
 allow = (||) <$> (".u" `isSuffixOf`) <*> (".uu" `isSuffixOf`)

--- a/parser-typechecker/src/Unison/Codebase/CommandLine2.hs
+++ b/parser-typechecker/src/Unison/Codebase/CommandLine2.hs
@@ -553,12 +553,11 @@ notifyUser dir o = case o of
   b) multiple definitions to a name
     - suppress if coinciding with a1)
 -}
-data WrangledEditConflicts = WrangledEditConflicts
-  {                               -- `Nothing` means Deprecation
-    conflictedUpgrades :: Map Reference (Set (Maybe Reference))
-  , 
-  }
-wrangleEditConflicts :: Branch0 -> (Map Reference (Set Reference), Set Name)
+-- data WrangledEditConflicts = WrangledEditConflicts
+--   {                               -- `Nothing` means Deprecation
+--     conflictedUpgrades :: R.Relation Map Reference (Set (Maybe Reference))
+--   }
+-- wrangleEditConflicts :: Branch0 -> (Map Reference (Set Reference), Set Name)
 
 
 allow :: FilePath -> Bool

--- a/parser-typechecker/src/Unison/Codebase/TermEdit.hs
+++ b/parser-typechecker/src/Unison/Codebase/TermEdit.hs
@@ -7,9 +7,9 @@ import Unison.Reference (Reference)
 data TermEdit = Replace Reference Typing | Deprecate
   deriving (Eq, Ord, Show)
 
-referents :: TermEdit -> [Reference]
-referents (Replace r _) = [r]
-referents Deprecate = []
+references :: TermEdit -> [Reference]
+references (Replace r _) = [r]
+references Deprecate = []
 
 -- Replacements with the Same type can be automatically propagated.
 -- Replacements with a Subtype can be automatically propagated but may result in dependents getting more general types, so requires re-inference.

--- a/parser-typechecker/src/Unison/Reference.hs
+++ b/parser-typechecker/src/Unison/Reference.hs
@@ -92,7 +92,7 @@ groupByComponent refs = done $ foldl' insert Map.empty refs
     done m = sortOn snd <$> toList m
 
 showShort :: Int -> Reference -> String
-showShort _ (Builtin_ t) = Text.unpack t
+showShort _ (Builtin_ t) = "##" <> Text.unpack t
 showShort numHashChars (DerivedPrivate_ id) = "#" <> take numHashChars (show id)
 
 instance Show Reference where

--- a/parser-typechecker/src/Unison/Util/Pretty.hs
+++ b/parser-typechecker/src/Unison/Util/Pretty.hs
@@ -32,6 +32,7 @@ module Unison.Util.Pretty (
    lit,
    map,
    nest,
+   name,
    newline,
    numbered,
    orElse,
@@ -289,6 +290,10 @@ align' rows = alignedRows
 
 text :: IsString s => Text -> Pretty s
 text t = fromString (Text.unpack t)
+
+name :: (Pretty ColorText -> Pretty ColorText) -> Text -> Pretty ColorText
+name style t = case Text.span (/= '#') t of
+  (hd, tl) -> group $ style (text hd) <> text tl
 
 hang'
   :: (LL.ListLike s Char, IsString s)


### PR DESCRIPTION
Here's an example output:

<img width="943" alt="image" src="https://user-images.githubusercontent.com/11074/51772480-1469e180-20ba-11e9-998b-15cf01d5c979.png">

`resolve-edit` command still to be written.