### PR TITLE
`update` and `merge` now propagate type-preserving edits to the branch

### DIFF
--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -16,6 +16,7 @@ import           Control.Monad                  ( foldM
 import           Data.Char                      ( toLower )
 import           Data.Foldable                  ( toList
                                                 , traverse_
+                                                , forM_
                                                 )
 import           Data.Function                  ( on )
 import           Data.List
@@ -208,7 +209,9 @@ putTermComponent :: (Monad m, Ord v)
                  => Codebase m v a
                  -> Map v (Reference, Term v a, Type v a)
                  -> m ()
-putTermComponent = undefined
+putTermComponent code m = forM_ (toList m) $ \(ref, tm, typ) -> case ref of
+  Reference.DerivedId id -> putTerm code id tm typ
+  _ -> pure ()
 
 putTypeDeclaration
   :: (Monad m, Ord v) => Codebase m v a -> Reference.Id -> Decl v a -> m ()

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -624,6 +624,7 @@ typecheckTerms code bindings = do
   let tm = Term.letRec' True bindings $ Term.unit mempty
   env <- typecheckingEnvironment' code tm
   (o, notes) <- Result.runResultT $ Typechecker.synthesize env tm
+  -- todo: assert that the output map has a type for all variables in the input
   case o of
     Nothing -> fail $ "A typechecking error occurred - this indicates a bug in Unison"
     Just _ -> pure $

--- a/parser-typechecker/src/Unison/Codebase/CommandLine2.hs
+++ b/parser-typechecker/src/Unison/Codebase/CommandLine2.hs
@@ -73,7 +73,8 @@ import qualified Unison.Var                     as Var
 
 notifyUser :: forall v . Var v => FilePath -> Output v -> IO ()
 notifyUser dir o = case o of
-  Success _    -> putStrLn "Done."
+  Success (MergeBranchI _) -> putPrettyLn $ P.bold "Merged. " <> "Here's what's `todo` after the merge:"
+  Success _    -> putPrettyLn $ P.bold "Done."
   DisplayDefinitions outputLoc ppe terms types -> let
     prettyTerms = map go terms
     go (r, dt) =
@@ -855,6 +856,14 @@ validInputs = validPatterns
           then Left $ warn "`update` doesn't take any arguments."
           else pure $ SlurpFileI True
         )
+      , InputPattern
+        "propagate"
+        []
+        []
+        (P.wrap $ "`propagate` rewrites any definitions that"
+               <> "depend on definitions with type-preserving edits to use"
+               <> "the updated versions of these dependencies.")
+        (const $ pure PropagateI)
       , InputPattern
         "todo"
         []

--- a/parser-typechecker/src/Unison/Codebase/Editor.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor.hs
@@ -457,6 +457,8 @@ fileToBranch handleCollisions codebase branch uf = do
   -- by folding over the outcomes.
   (result, b0) <- foldM addOutcome
     (SlurpResult uf branch mempty mempty mempty mempty mempty mempty mempty mempty mempty mempty, Branch.head branch) outcomes'
+  -- todo: be a little smarter about avoiding needless propagation
+  b0 <- Codebase.propagate codebase b0
   pure $ result { updatedBranch = Branch.cons b0 branch }
   where
     b0 = Branch.head branch

--- a/parser-typechecker/src/Unison/Codebase/Editor.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor.hs
@@ -149,6 +149,7 @@ data Input
   | MergeBranchI BranchName
   | ShowDefinitionI OutputLocation [String]
   | TodoI
+  | PropagateI
   | QuitI
   deriving (Show)
 
@@ -316,6 +317,8 @@ data Command i v a where
   LoadType :: Reference.Id -> Command i v (Maybe (Decl v Ann))
 
   Todo :: Branch -> Command i v (TodoOutput v Ann)
+
+  Propagate :: Branch -> Command i v Branch
 
 data Outcome
   -- New definition that was added to the branch
@@ -636,6 +639,9 @@ commandLine awaitInput rt branchChange notifyUser codebase command = do
     LoadTerm r -> Codebase.getTerm codebase r
     LoadType r -> Codebase.getTypeDeclaration codebase r
     Todo b -> doTodo codebase (Branch.head b)
+    Propagate b -> do
+      b0 <- Codebase.propagate codebase (Branch.head b)
+      pure $ Branch.append b0 b
 
 doTodo :: Monad m => Codebase m v a -> Branch0 -> m (TodoOutput v a)
 doTodo code b = do

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -298,6 +298,7 @@ codebase1 builtinTypeAnnotation (S.Format getV putV) (S.Format getA putA) path
                mergeBranch
                branchUpdates
                dependents
+               builtinTypeAnnotation
 
 ubfPathToName :: FilePath -> Name
 ubfPathToName = Text.pack . takeFileName . takeDirectory

--- a/parser-typechecker/src/Unison/Codebase/TermEdit.hs
+++ b/parser-typechecker/src/Unison/Codebase/TermEdit.hs
@@ -29,3 +29,14 @@ instance Hashable TermEdit where
 toReference :: TermEdit -> Maybe Reference
 toReference (Replace r _) = Just r
 toReference Deprecate     = Nothing
+
+isTypePreserving :: TermEdit -> Bool
+isTypePreserving e = case e of
+  Replace _ Same -> True
+  Replace _ Subtype -> True
+  _ -> False
+
+isSame :: TermEdit -> Bool
+isSame e = case e of
+  Replace _ Same -> True
+  _              -> False

--- a/parser-typechecker/src/Unison/Parser.hs
+++ b/parser-typechecker/src/Unison/Parser.hs
@@ -49,10 +49,17 @@ data Ann
   | Ann { start :: L.Pos, end :: L.Pos }
   deriving (Eq, Ord, Show)
 
+instance Monoid Ann where
+  mempty = External
+  mappend = (<>)
+
 instance Semigroup Ann where
   Ann s1 _ <> Ann _ e2 = Ann s1 e2
-  x <> y = error $ "Compiler bug! Tried to combine terms annotated with ("
-                   ++ show x ++ ") and (" ++ show y ++ ")"
+  -- If we have a concrete location from a file, use it
+  External <> a = a
+  a <> External = a
+  Intrinsic <> a = a
+  a <> Intrinsic = a
 
 tokenToPair :: L.Token a -> (Ann, a)
 tokenToPair t = (ann t, L.payload t)

--- a/parser-typechecker/src/Unison/Reference.hs
+++ b/parser-typechecker/src/Unison/Reference.hs
@@ -54,10 +54,13 @@ type Size = Word64
 
 newtype Component = Component { members :: Set Reference }
 
+-- Gives the component (dependency cycle) that the reference is a part of
 componentFor :: Reference -> Component
-componentFor b@(Builtin_ _) = Component (Set.singleton b)
-componentFor (DerivedPrivate_ (Id h _ n)) =
-  Component (Set.fromList [ DerivedPrivate_ (Id h i n) | i <- take (fromIntegral n) [0..]])
+componentFor b@(Builtin_        _         ) = Component (Set.singleton b)
+componentFor (  DerivedPrivate_ (Id h _ n)) = Component
+  (Set.fromList
+    [ DerivedPrivate_ (Id h i n) | i <- take (fromIntegral n) [0 ..] ]
+  )
 
 derivedBase58 :: Text -> Pos -> Size -> Reference
 derivedBase58 b58 i n = DerivedPrivate_ (Id (fromJust h) i n)

--- a/parser-typechecker/src/Unison/Term.hs
+++ b/parser-typechecker/src/Unison/Term.hs
@@ -637,12 +637,14 @@ referencedEffectDeclarationsP p = Set.fromList . Writer.execWriter $ go p
     Writer.tell [id] *> traverse_ go args *> go k
   go _ = pure ()
 
-updateDependencies :: Ord v => Map Reference Reference -> Term v -> Term v
-updateDependencies u tm = ABT.rebuildUp go tm where
+updateDependencies
+  :: Ord v => Map Reference Reference -> AnnotatedTerm v a -> AnnotatedTerm v a
+updateDependencies u tm = ABT.rebuildUp go tm
+ where
   -- todo: this function might need tweaking if we ever allow type replacements
   -- would need to look inside pattern matching and constructor calls
   go (Ref r) = Ref (Map.findWithDefault r r u)
-  go f = f
+  go f       = f
 
 -- | If the outermost term is a function application,
 -- perform substitution of the argument into the body

--- a/parser-typechecker/src/Unison/Term.hs
+++ b/parser-typechecker/src/Unison/Term.hs
@@ -386,6 +386,18 @@ unLetRecNamedAnnotated (ABT.CycleA' ann avs (ABT.Tm' (LetRec isTop bs e))) =
   Just (isTop, ann, avs `zip` bs, e)
 unLetRecNamedAnnotated _ = Nothing
 
+letRec'
+  :: (Ord v, Monoid a)
+  => Bool
+  -> [(v, AnnotatedTerm' vt v a)]
+  -> AnnotatedTerm' vt v a
+  -> AnnotatedTerm' vt v a
+letRec' isTop bindings body =
+  letRec isTop
+    (foldMap (ABT.annotation . snd) bindings)
+    [ ((ABT.annotation b, v), b) | (v,b) <- bindings ]
+    body
+
 letRec
   :: Ord v
   => Bool

--- a/parser-typechecker/src/Unison/Term.hs
+++ b/parser-typechecker/src/Unison/Term.hs
@@ -652,6 +652,20 @@ betaReduce :: Var v => Term v -> Term v
 betaReduce (App' (Lam' f) arg) = ABT.bind f arg
 betaReduce e = e
 
+-- This converts `Reference`s it finds that are in the input `Map`
+-- back to free variables
+unhashComponent :: Var v
+                => Map v (Reference, AnnotatedTerm v a)
+                -> Map v (Reference, AnnotatedTerm v a)
+unhashComponent m = let
+  refToVar = Map.fromList [ (r, v) | (v, (r,_)) <- Map.toList m ]
+  unhash1 e = ABT.rebuildUp' go e where
+    go e@(Ref' r) = case Map.lookup r refToVar of
+      Nothing -> e
+      Just v -> var (ABT.annotation e) v
+    go e = e
+  in Map.fromList [ (v, (r, unhash1 e)) | (v, (r,e)) <- Map.toList m ]
+
 hashComponents
   :: Var v => Map v (AnnotatedTerm v a) -> Map v (Reference, AnnotatedTerm v a)
 hashComponents m = Reference.hashComponents (\r -> ref () r) m

--- a/parser-typechecker/src/Unison/Util/Components.hs
+++ b/parser-typechecker/src/Unison/Util/Components.hs
@@ -5,7 +5,6 @@ import qualified Data.Map as Map
 import           Data.Maybe
 import           Data.Set (Set)
 import qualified Data.Set as Set
-import           Unison.Var (Var)
 
 -- | Order bindings by dependencies and group into components.
 -- Each component consists of > 1 bindings, each of which depends
@@ -33,7 +32,7 @@ import           Unison.Var (Var)
 --
 -- Uses Tarjan's algorithm:
 --   https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
-components :: Var v => (t -> Set v) -> [(v, t)] -> [[(v, t)]]
+components :: Ord v => (t -> Set v) -> [(v, t)] -> [[(v, t)]]
 components freeVars bs =
   let varIds =
         Map.fromList (map fst bs `zip` reverse [(1 :: Int) .. length bs])


### PR DESCRIPTION
We implemented `Codebase.propagate`, which propagates type-preserving edits within a branch, and this is called automatically after a `merge` or `add/update`.

This was an important thing needed to be able to edit code without a bunch of manual work. You only make manual edits until reaching a type-preserving frontier of edits. After that, the transitive dependents are updated automatically. So it's the same amount of work vs mutating a bag of text files, but you never have a big list of misleading type errors to deal with.