### PR TITLE
gives guard expressions access to variables

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -13,3 +13,4 @@ The format for this list: name, GitHub handle, and then optional blurb about wha
 * Rúnar Bjarnason (@runarorama) - Typechecker, runtime, parser, code serialization
 * Chris Gibbs (@atacratic) - Pretty-printer
 * Noah Haasis (@noahhaasis) - Tool that makes improving the error messages easier
+* Francis De Brabandere (@francisdb)

--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -90,7 +90,7 @@ matchCase = do
   (p, boundVars) <- parsePattern
   guard <- optional $ reserved "|" *> infixApp
   t <- block "->"
-  pure . Term.MatchCase p guard $ ABT.absChain' boundVars t
+  pure . Term.MatchCase p (fmap (ABT.absChain' boundVars) guard) $ ABT.absChain' boundVars t
 
 parsePattern :: forall v. Var v => P v (Pattern Ann, [(Ann, v)])
 parsePattern = constructor <|> leaf

--- a/unison-src/tests/caseguard.u
+++ b/unison-src/tests/caseguard.u
@@ -1,0 +1,15 @@
+-- Used to fail on the guard
+--
+-- typechecker.tests/caseguard.u FAILURE I'm not sure what x means at line 3, columns 9-10
+--
+--    3 |     x | x == "woot" -> false
+--
+-- Whatever it is, it has a type that conforms to Text.
+
+
+f blah =
+  case blah of
+    x | x == "woot" -> false
+    y | y == "foo" -> true
+
+-- > f "woot"


### PR DESCRIPTION
fixes #327 

@pchiusano I tried adding a test case to `test/Termparser.hs` but it did not trigger the issue. Are there any similar tests that also invoke the TypeChecker to trigger this issue?