### PR TITLE
Compute the hashes of `unit`, `pair`, and `optional` at runtime, from their definitions

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -127,18 +127,8 @@ builtinTypes = liftA2 (,) Name.unsafeFromText R.Builtin <$>
 -- | parse some builtin data types, and resolve their free variables using
 -- | builtinTypes' and those types defined herein
 builtinDataDecls :: Var v => [(v, (R.Reference, DataDeclaration v))]
-builtinDataDecls = l
-  where
-    l = [ (Var.named "()",
-            (Type.unitRef,
-             DD.mkDataDecl' Intrinsic [] [(Intrinsic,
-                                           Var.named "()",
-                                           Type.unit Intrinsic)]))
-    -- todo: figure out why `type () = ()` doesn't parse:
-    -- l = [ parseDataDeclAsBuiltin "type () = ()"
-        , parseDataDeclAsBuiltin "type Pair a b = Pair a b"
-        , parseDataDeclAsBuiltin "type Optional a = None | Some a"
-        ]
+builtinDataDecls =
+  [ (v, (r, Intrinsic <$ d)) | (v, r, d) <- DD.builtinDataDecls ]
 
 builtinEffectDecls :: Var v => [(v, (R.Reference, EffectDeclaration v))]
 builtinEffectDecls = []

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -548,7 +548,7 @@ typecheckTerms :: (Monad m, Var v, Ord a, Monoid a)
                -> [(v, Term v a)]
                -> m (Map v (Type v a))
 typecheckTerms code bindings = do
-  let tm = Term.letRec' True bindings $ Term.unit mempty
+  let tm = Term.letRec' True bindings $ DD.unitTerm mempty
   env <- typecheckingEnvironment' code tm
   (o, notes) <- Result.runResultT $ Typechecker.synthesize env tm
   -- todo: assert that the output map has a type for all variables in the input

--- a/parser-typechecker/src/Unison/DataDeclaration.hs
+++ b/parser-typechecker/src/Unison/DataDeclaration.hs
@@ -244,6 +244,11 @@ hashDecls0 decls =
 --   data List a = Nil | Cons a (List a)
 --   becomes something like
 --   (List, #xyz, [forall a. #xyz a, forall a. a -> (#xyz a) -> (#xyz a)])
+--
+-- NOTE: technical limitation, this implementation gives diff results if ctors
+-- have the same FQN as one of the types. TODO: assert this and bomb if not
+-- satisfied, or else do local mangling and unmangling to ensure this doesn't
+-- affect the hash.
 hashDecls
   :: (Eq v, Var v)
   => Map v (DataDeclaration' v a)
@@ -269,7 +274,8 @@ builtinDataDecls = hashDecls $
   v name = Var.named name
   var name = Type.var() (v name)
   arr = Type.arrow'
-  unit = DataDeclaration () [] [((), v "()", var "()")]
+  -- see note on `hashDecls` above for why ctor must be called `().()`.
+  unit = DataDeclaration () [] [((), v "().()", var "()")]
   pair = DataDeclaration () [v "a", v "b"] [
     ((), v "Pair.Pair", Type.foralls() [v"a",v"b"]
          (var "a" `arr` (var "b" `arr` Type.apps' (var "Pair") [var "a", var "b"])))

--- a/parser-typechecker/src/Unison/DataDeclaration.hs
+++ b/parser-typechecker/src/Unison/DataDeclaration.hs
@@ -1,8 +1,11 @@
 {-# LANGUAGE DeriveAnyClass #-}
-{-# Language DeriveFunctor #-}
 {-# Language DeriveFoldable #-}
+{-# Language DeriveFunctor #-}
 {-# Language DeriveTraversable #-}
 {-# Language OverloadedStrings #-}
+{-# Language PatternSynonyms #-}
+{-# Language TypeApplications #-}
+{-# Language ViewPatterns #-}
 
 module Unison.DataDeclaration where
 
@@ -25,7 +28,7 @@ import qualified Unison.Reference as Reference
 import           Unison.Referent (Referent)
 import qualified Unison.Referent as Referent
 import qualified Unison.Term as Term
-import           Unison.Term (AnnotatedTerm)
+import           Unison.Term (AnnotatedTerm, AnnotatedTerm2)
 import           Unison.Type (AnnotatedType)
 import qualified Unison.Type as Type
 import           Unison.Var (Var)
@@ -33,6 +36,8 @@ import Data.Text (Text)
 import qualified Unison.Var as Var
 import Unison.Names (Names)
 import Unison.Names as Names
+import Unison.Symbol (Symbol)
+import qualified Unison.Pattern as Pattern
 -- import Debug.Trace
 
 type DataDeclaration v = DataDeclaration' v ()
@@ -247,6 +252,90 @@ hashDecls decls =
   let varToRef = hashDecls0 (void <$> decls)
       decls'   = bindDecls decls (Names.fromTypesV varToRef)
   in  [ (v, r, dd) | (v, r) <- varToRef, Just dd <- [Map.lookup v decls'] ]
+
+unitRef, pairRef, optionalRef :: Reference
+(unitRef, pairRef, optionalRef) = let
+  decls = builtinDataDecls @ Symbol
+  [(_,unit,_)] = filter (\(v, _,_) -> v == Var.named "()") decls
+  [(_,pair,_)] = filter (\(v, _,_) -> v == Var.named "Pair") decls
+  [(_,opt,_)] = filter (\(v, _,_) -> v == Var.named "Optional") decls
+  in (unit, pair, opt)
+
+builtinDataDecls :: Var v => [(v, Reference, DataDeclaration' v ())]
+builtinDataDecls = hashDecls $
+  Map.fromList [
+    (v "()", unit), (v "Pair", pair), (v "Optional", opt) ]
+  where
+  v name = Var.named name
+  var name = Type.var() (v name)
+  arr = Type.arrow'
+  unit = DataDeclaration () [] [((), v "()", var "()")]
+  pair = DataDeclaration () [v "a", v "b"] [
+    ((), v "Pair.Pair", Type.foralls() [v"a",v"b"]
+         (var "a" `arr` (var "b" `arr` Type.apps' (var "Pair") [var "a", var "b"])))
+   ]
+  opt = DataDeclaration () [v "a"] [
+    ((), v "Optional.None", Type.foralls() [v "a"]
+      (              Type.app' (var "Optional") (var "a"))),
+    ((), v "Optional.Some", Type.foralls() [v "a"]
+      (var "a" `arr` Type.app' (var "Optional") (var "a")))
+   ]
+
+pattern UnitRef <- (unUnitRef -> True)
+pattern PairRef <- (unPairRef -> True)
+pattern OptionalRef <- (unOptionalRef -> True)
+pattern TupleType' ts <- (unTupleType -> Just ts)
+pattern TupleTerm' xs <- (unTupleTerm -> Just xs)
+pattern TuplePattern ps <- (unTuplePattern -> Just ps)
+
+unitType, pairType, optionalType :: Ord v => a -> AnnotatedType v a
+unitType a = Type.ref a unitRef
+pairType a = Type.ref a pairRef
+optionalType a = Type.ref a optionalRef
+
+unitTerm :: Var v => a -> AnnotatedTerm v a
+unitTerm ann = Term.constructor ann unitRef 0
+
+tupleConsTerm :: (Ord v, Semigroup a)
+              => AnnotatedTerm2 vt at ap v a
+              -> AnnotatedTerm2 vt at ap v a
+              -> AnnotatedTerm2 vt at ap v a
+tupleConsTerm hd tl =
+  Term.apps' (Term.constructor (ABT.annotation hd) pairRef 0) [hd, tl]
+
+tupleTerm :: (Var v, Monoid a) => [AnnotatedTerm v a] -> AnnotatedTerm v a
+tupleTerm = foldr tupleConsTerm (unitTerm mempty)
+
+-- delayed terms are just lambdas that take a single `()` arg
+-- `force` calls the function
+forceTerm :: Var v => a -> a -> AnnotatedTerm v a -> AnnotatedTerm v a
+forceTerm a au e = Term.app a e (unitTerm au)
+
+delayTerm :: Var v => a -> AnnotatedTerm v a -> AnnotatedTerm v a
+delayTerm a e = Term.lam a (Var.named "()") e
+
+unTupleTerm :: Term.AnnotatedTerm2 vt at ap v a -> Maybe [Term.AnnotatedTerm2 vt at ap v a]
+unTupleTerm t = case t of
+  Term.Apps' (Term.Constructor' PairRef 0) [fst, snd] -> (fst :) <$> unTupleTerm snd
+  Term.Constructor' UnitRef 0 -> Just []
+  _ -> Nothing
+
+unTupleType :: Var v => Type.AnnotatedType v a -> Maybe [Type.AnnotatedType v a]
+unTupleType t = case t of
+  Type.Apps' (Type.Ref' PairRef) [fst, snd] -> (fst :) <$> unTupleType snd
+  Type.Ref' UnitRef -> Just []
+  _ -> Nothing
+
+unTuplePattern :: Pattern.PatternP loc -> Maybe [Pattern.PatternP loc]
+unTuplePattern p = case p of
+  Pattern.ConstructorP _ PairRef 0 [fst, snd] -> (fst : ) <$> unTuplePattern snd
+  Pattern.ConstructorP _ UnitRef 0 [] -> Just []
+  _ -> Nothing
+
+unUnitRef,unPairRef,unOptionalRef :: Reference -> Bool
+unUnitRef = (== unitRef)
+unPairRef = (== pairRef)
+unOptionalRef = (== optionalRef)
 
 bindDecls
   :: Var v

--- a/parser-typechecker/src/Unison/FileParser.hs
+++ b/parser-typechecker/src/Unison/FileParser.hs
@@ -96,7 +96,7 @@ watched = P.try $ do
 
 terminateTerm :: Var v => AnnotatedTerm v Ann -> AnnotatedTerm v Ann
 terminateTerm e@(Term.LetRecNamedAnnotatedTop' top a bs body@(Term.Var' v))
-  | Set.member v (ABT.freeVars e) = Term.letRec top a bs (Term.unit (ABT.annotation body))
+  | Set.member v (ABT.freeVars e) = Term.letRec top a bs (DD.unitTerm (ABT.annotation body))
   | otherwise = e
 terminateTerm e = e
 

--- a/parser-typechecker/src/Unison/Pattern.hs
+++ b/parser-typechecker/src/Unison/Pattern.hs
@@ -10,7 +10,6 @@ import Data.Foldable as Foldable
 import GHC.Generics
 import Unison.Reference (Reference)
 import qualified Unison.Hashable as H
-import qualified Unison.Type as Type
 
 type Pattern = PatternP ()
 
@@ -81,13 +80,6 @@ pattern Constructor r cid ps = ConstructorP () r cid ps
 pattern As p = AsP () p
 pattern EffectPure p = EffectPureP () p
 pattern EffectBind r cid ps k = EffectBindP () r cid ps k
-pattern Tuple ps <- (unTuple -> Just ps)
-
-unTuple :: PatternP loc -> Maybe [PatternP loc]
-unTuple p = case p of
-  ConstructorP _ Type.PairRef 0 [fst, snd] -> (fst : ) <$> unTuple snd
-  ConstructorP _ Type.UnitRef 0 [] -> Just []
-  _ -> Nothing
 
 instance H.Hashable (PatternP p) where
   tokens (UnboundP _) = [H.Tag 0]

--- a/parser-typechecker/src/Unison/PatternP.hs
+++ b/parser-typechecker/src/Unison/PatternP.hs
@@ -17,7 +17,6 @@ pattern Constructor loc r cid ps = P.ConstructorP loc r cid ps
 pattern As loc p = P.AsP loc p
 pattern EffectPure loc p = P.EffectPureP loc p
 pattern EffectBind loc r c args k = P.EffectBindP loc r c args k
-pattern Tuple ps <- (P.unTuple -> Just ps)
 
 loc :: P.PatternP loc -> loc
 loc = P.loc

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -33,6 +33,7 @@ import           Data.Void                    (Void)
 import qualified Text.Megaparsec              as P
 import qualified Unison.ABT                   as ABT
 import qualified Unison.DataDeclaration       as DD
+import Unison.DataDeclaration (pattern TupleType')
 import qualified Unison.HashQualified         as HQ
 import           Unison.Kind                  (Kind)
 import qualified Unison.Kind                  as Kind
@@ -734,7 +735,7 @@ renderType env f t = renderType0 env f (0 :: Int) (Type.ungeneralizeEffects t)
       paren (p >= 2) $ go 2 i <> " ->{" <> go 1 e <> "} " <> go 1 o
     Type.Arrow' i o -> paren (p >= 2) $ go 2 i <> " -> " <> go 1 o
     Type.Ann'   t k -> paren True $ go 1 t <> " : " <> renderKind k
-    Type.Tuple' ts  -> paren True $ commas (go 0) ts
+    TupleType' ts  -> paren True $ commas (go 0) ts
     Type.Apps' (Type.Ref' (R.Builtin "Sequence")) [arg] ->
       "[" <> go 0 arg <> "]"
     Type.Apps' f' args -> paren (p >= 3) $ spaces (go 3) (f' : args)

--- a/parser-typechecker/src/Unison/Runtime/IR.hs
+++ b/parser-typechecker/src/Unison/Runtime/IR.hs
@@ -34,13 +34,13 @@ import Unison.Var (Var)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Unison.ABT as ABT
+import qualified Unison.DataDeclaration as DD
 import qualified Unison.Pattern as Pattern
 import qualified Unison.PrettyPrintEnv as PPE
 import qualified Unison.Reference as R
 import qualified Unison.Runtime.ANF as ANF
 import qualified Unison.Term as Term
 import qualified Unison.TermPrinter as TP
-import qualified Unison.Type as Type
 import qualified Unison.Util.Pretty as P
 import qualified Unison.Var as Var
 -- import Debug.Trace
@@ -91,14 +91,14 @@ data Value e cont
 -- would have preferred to make pattern synonyms
 maybeToOptional :: Maybe (Value e cont) -> Value e cont
 maybeToOptional = \case
-  Just a  -> Data Type.optionalRef 1 [a]
-  Nothing -> Data Type.optionalRef 0 []
+  Just a  -> Data DD.optionalRef 1 [a]
+  Nothing -> Data DD.optionalRef 0 []
 
 unit :: Value e cont
-unit = Data Type.unitRef 0 []
+unit = Data DD.unitRef 0 []
 
 pair :: (Value e cont, Value e cont) -> Value e cont
-pair (a, b) = Data Type.pairRef 0 [a, b]
+pair (a, b) = Data DD.pairRef 0 [a, b]
 
 -- When a lambda is underapplied, for instance, `(x y -> x) 19`, we can do
 -- one of two things: we can substitute away the arguments that have

--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -34,6 +34,7 @@ import qualified Unison.TypeParser as TypeParser
 import           Unison.Var (Var)
 import qualified Unison.Var as Var
 import qualified Unison.Names as Names
+import qualified Unison.DataDeclaration as DD
 import Unison.Names (Names)
 
 import Debug.Trace
@@ -106,9 +107,9 @@ parsePattern = constructor <|> leaf
   text = (\t -> Pattern.Text (ann t) (L.payload t)) <$> string
   parenthesizedOrTuplePattern :: P v (Pattern Ann, [(Ann, v)])
   parenthesizedOrTuplePattern = tupleOrParenthesized parsePattern unit pair
-  unit ann = (Pattern.Constructor ann Type.unitRef 0 [], [])
+  unit ann = (Pattern.Constructor ann DD.unitRef 0 [], [])
   pair (p1, v1) (p2, v2) =
-    (Pattern.Constructor (ann p1 <> ann p2) Type.pairRef 0 [p1, p2],
+    (Pattern.Constructor (ann p1 <> ann p2) DD.pairRef 0 [p1, p2],
      v1 ++ v2)
   varOrAs :: P v (Pattern Ann, [(Ann, v)])
   varOrAs = do
@@ -225,13 +226,13 @@ delayQuote :: Var v => TermP v
 delayQuote = P.label "quote" $ do
   start <- reserved "'"
   e <- termLeaf
-  pure $ Term.delay (ann start <> ann e) e
+  pure $ DD.delayTerm (ann start <> ann e) e
 
 bang :: Var v => TermP v
 bang = P.label "bang" $ do
   start <- reserved "!"
   e <- termLeaf
-  pure $ Term.force (ann start <> ann e) (ann start) e
+  pure $ DD.forceTerm (ann start <> ann e) (ann start) e
 
 and = label "and" $ f <$> reserved "and" <*> termLeaf <*> termLeaf
   where f kw x y = Term.and (ann kw <> ann y) x y
@@ -442,11 +443,11 @@ number' i u f = fmap go numeric
       | otherwise = u (read <$> num)
 
 tupleOrParenthesizedTerm :: Var v => TermP v
-tupleOrParenthesizedTerm = label "tuple" $ tupleOrParenthesized term Term.unit pair
+tupleOrParenthesizedTerm = label "tuple" $ tupleOrParenthesized term DD.unitTerm pair
   where
     pair t1 t2 =
       Term.app (ann t1 <> ann t2)
         (Term.app (ann t1)
-                  (Term.constructor (ann t1 <> ann t2) Type.pairRef 0)
+                  (Term.constructor (ann t1 <> ann t2) DD.pairRef 0)
                   t1)
         t2

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -24,7 +24,6 @@ import           Unison.PatternP                ( Pattern )
 import qualified Unison.PatternP               as Pattern
 import qualified Unison.Referent               as Referent
 import           Unison.Term
-import qualified Unison.Type                   as Type
 import qualified Unison.TypePrinter            as TypePrinter
 import           Unison.Var                     ( Var )
 import qualified Unison.Var                    as Var
@@ -33,6 +32,8 @@ import qualified Unison.Util.Pretty             as PP
 import           Unison.Util.Pretty             ( Pretty )
 import           Unison.PrettyPrintEnv          ( PrettyPrintEnv )
 import qualified Unison.PrettyPrintEnv         as PrettyPrintEnv
+import qualified Unison.DataDeclaration        as DD
+import Unison.DataDeclaration (pattern TuplePattern, pattern TupleTerm')
 
 --TODO use imports to trim fully qualified names
 
@@ -157,7 +158,7 @@ pretty n AmbientContext { precedence = p, blockContext = bc, infixContext = ic }
         $ ("handle" `PP.hang` pretty n (ac 2 Normal) h)
         <> PP.softbreak
         <> ("in" `PP.hang` pretty n (ac 2 Block) body)
-    App' x (Constructor' Type.UnitRef 0) ->
+    App' x (Constructor' DD.UnitRef 0) ->
       paren (p >= 11) $ l "!" <> pretty n (ac 11 Normal) x
     AskInfo' x -> paren (p >= 11) $ pretty n (ac 11 Normal) x <> l "?"
     LamNamed' v x | (Var.name v) == "()" ->
@@ -201,10 +202,10 @@ pretty n AmbientContext { precedence = p, blockContext = bc, infixContext = ic }
     t -> l "error: " <> l (show t)
  where
   specialCases term go = case (term, binaryOpsPred) of
-    (Tuple' [x], _) ->
+    (TupleTerm' [x], _) ->
       paren (p >= 10) $ "Pair" `PP.hang`
         PP.spaced [pretty n (ac 10 Normal) x, "()" ]
-    (Tuple' xs, _) -> paren True $ commaList xs
+    (TupleTerm' xs, _) -> paren True $ commaList xs
     BinaryAppsPred' apps lastArg -> paren (p >= 3) $
       binaryApps apps (pretty n (ac 3 Normal) lastArg)
     _ -> case (term, nonForcePred) of
@@ -260,7 +261,7 @@ pretty n AmbientContext { precedence = p, blockContext = bc, infixContext = ic }
 
   nonForcePred :: AnnotatedTerm v a -> Bool
   nonForcePred = \case
-    Constructor' Type.UnitRef 0 -> False
+    Constructor' DD.UnitRef 0 -> False
     _                           -> True
 
   nonUnitArgPred :: Var v => v -> Bool
@@ -310,11 +311,11 @@ prettyPattern n p vs patt = case patt of
   Pattern.Nat     _ u -> (l $ show u, vs)
   Pattern.Float   _ f -> (l $ show f, vs)
   Pattern.Text    _ t -> (l $ show t, vs)
-  Pattern.Tuple [pp] ->
+  TuplePattern [pp] ->
     let (printed, tail_vs) = prettyPattern n 10 vs pp
     in  ( paren (p >= 10) $ PP.sep " " ["Pair", printed, "()"]
         , tail_vs )
-  Pattern.Tuple pats ->
+  TuplePattern pats ->
     let (pats_printed, tail_vs) = patterns vs pats
     in  (PP.parenthesizeCommas pats_printed, tail_vs)
   Pattern.Constructor _ ref i [] ->

--- a/parser-typechecker/src/Unison/TypeParser.hs
+++ b/parser-typechecker/src/Unison/TypeParser.hs
@@ -14,6 +14,7 @@ import           Unison.Parser
 import           Unison.Type (AnnotatedType)
 import qualified Unison.Type as Type
 import           Unison.Var (Var)
+import qualified Unison.DataDeclaration as DD
 
 -- A parsed type is annotated with its starting and ending position in the
 -- source text.
@@ -48,7 +49,7 @@ delayed = do
   q <- reserved "'"
   t <- effect <|> type2
   pure $ Type.arrow (Ann (L.start q) (end $ ann t))
-                    (Type.unit (ann q))
+                    (DD.unitType (ann q))
                     t
 
 type2 :: Var v => TypeP v
@@ -81,11 +82,11 @@ sequenceTyp = do
   pure $ Type.app a (Type.vector a) t
 
 tupleOrParenthesizedType :: Var v => TypeP v -> TypeP v
-tupleOrParenthesizedType rec = tupleOrParenthesized rec Type.unit pair
+tupleOrParenthesizedType rec = tupleOrParenthesized rec DD.unitType pair
   where
     pair t1 t2 =
       let a = ann t1 <> ann t2
-      in Type.app a (Type.app (ann t1) (Type.pair a) t1) t2
+      in Type.app a (Type.app (ann t1) (DD.pairType a) t1) t2
 
 --  valueType ::= ... | Arrow valueType computationType
 arrow :: Var v => TypeP v -> TypeP v

--- a/parser-typechecker/src/Unison/TypePrinter.hs
+++ b/parser-typechecker/src/Unison/TypePrinter.hs
@@ -18,6 +18,7 @@ import           Unison.Util.Pretty    (ColorText, Pretty)
 import qualified Unison.Util.Pretty    as PP
 import           Unison.Var            (Var)
 import qualified Unison.Var            as Var
+import qualified Unison.DataDeclaration as DD
 
 {- Explanation of precedence handling
 
@@ -53,9 +54,9 @@ pretty n p tp = case tp of
   Ann' _ _   -> l $ "error" -- TypeParser does not currently emit Ann
   App' (Ref' (Builtin "Sequence")) x ->
     PP.group $ l "[" <> pretty n 0 x <> l "]"
-  Tuple' [x] -> PP.parenthesizeIf (p >= 10) $ "Pair" `PP.hang` PP.spaced
+  DD.TupleType' [x] -> PP.parenthesizeIf (p >= 10) $ "Pair" `PP.hang` PP.spaced
     [pretty n 10 x, "()"]
-  Tuple' xs  -> PP.parenthesizeCommas $ map (pretty n 0) xs
+  DD.TupleType' xs  -> PP.parenthesizeCommas $ map (pretty n 0) xs
   Apps' f xs -> PP.parenthesizeIf (p >= 10) $ pretty n 9 f `PP.hang` PP.spaced
     (pretty n 10 <$> xs)
   Effect1' e t ->
@@ -68,7 +69,7 @@ pretty n p tp = case tp of
       $         ("∀ " <> l (Text.unpack (Var.name v)) <> ".")
       `PP.hang` pretty n (-1) body
   t@(Arrow' _ _) -> case (ungeneralizeEffects t) of
-    EffectfulArrows' (Ref' UnitRef) rest -> arrows True True rest
+    EffectfulArrows' (Ref' DD.UnitRef) rest -> arrows True True rest
     EffectfulArrows' fst rest ->
       PP.parenthesizeIf (p >= 0) $ pretty n 0 fst <> arrows False False rest
     _ -> l "error"
@@ -82,8 +83,8 @@ pretty n p tp = case tp of
       <> effects mes
       <> if (isJust mes) || (not delay) && (not first) then l " " else mempty
 
-  arrows delay first [(mes, Ref' UnitRef)] = arrow delay first mes <> l "()"
-  arrows delay first ((mes, Ref' UnitRef) : rest) =
+  arrows delay first [(mes, Ref' DD.UnitRef)] = arrow delay first mes <> l "()"
+  arrows delay first ((mes, Ref' DD.UnitRef) : rest) =
     arrow delay first mes <> (parenNoGroup delay $ arrows True True rest)
   arrows delay first ((mes, arg) : rest) =
     arrow delay first mes

--- a/parser-typechecker/src/Unison/UnisonFile.hs
+++ b/parser-typechecker/src/Unison/UnisonFile.hs
@@ -44,7 +44,7 @@ data UnisonFile v a = UnisonFile {
 
 -- Converts a file to a single let rec with a body of `()`.
 uberTerm :: (Var v, Monoid a) => UnisonFile v a -> AnnotatedTerm v a
-uberTerm uf = Term.letRec' True (terms uf <> watches uf) (Term.unit mempty)
+uberTerm uf = Term.letRec' True (terms uf <> watches uf) (DD.unitTerm mempty)
 
 -- Converts a file and a body to a single let rec with the given body.
 uberTerm' :: (Var v, Monoid a) => UnisonFile v a -> AnnotatedTerm v a -> AnnotatedTerm v a


### PR DESCRIPTION
This required moving `unitRef`, `pairRef`, and `optionalRef` to `DataDeclaration`, where those types are declared (without use of the parser, the types are declared manually) and then hashed. The same declarations are then referenced in `Builtin.hs`.

There was a lot of turning the crank to get everything to compile and avoid circular module dependencies. For instance, the pattern `Term.Tuple'` is now `DataDeclaration.TupleTerm'`, the pattern `Type.Tuple'` is now `DataDeclaration.TupleType'`, etc.