### PR TITLE
Parse underscores correctly

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -14,3 +14,4 @@ The format for this list: name, GitHub handle, and then optional blurb about wha
 * Chris Gibbs (@atacratic) - Pretty-printer
 * Noah Haasis (@noahhaasis) - Tool that makes improving the error messages easier
 * Francis De Brabandere (@francisdb)
+* Matt Dziuban (@mrdziuban)

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -388,7 +388,7 @@ wordyId :: String -> Either Err (String, String)
 wordyId s = qualifiedId False s wordyId0 wordyId0
 
 wordyIdStartChar :: Char -> Bool
-wordyIdStartChar ch = isAlphaNum ch || isEmoji ch
+wordyIdStartChar ch = isAlphaNum ch || isEmoji ch || ch == '_'
 
 wordyIdChar :: Char -> Bool
 wordyIdChar ch =

--- a/parser-typechecker/src/Unison/Parser.hs
+++ b/parser-typechecker/src/Unison/Parser.hs
@@ -249,7 +249,7 @@ reserved w = label w $ queryToken getReserved
 -- Parse a placeholder or typed hole
 blank :: Var v => P v (L.Token String)
 blank = label "blank" $ queryToken getBlank
-  where getBlank (L.Blank s) = Just s
+  where getBlank (L.Blank s) = Just ('_' : s)
         getBlank _           = Nothing
 
 numeric :: Var v => P v (L.Token String)
@@ -269,7 +269,7 @@ sepBy1 sep pb = P.sepBy1 pb sep
 prefixVar :: Var v => P v (L.Token v)
 prefixVar = fmap (Var.named . Text.pack) <$> label "symbol" prefixOp
   where
-    prefixOp = wordyId <|> label "prefix-operator" (P.try (reserved "(" *> symbolyId) <* reserved ")")
+    prefixOp = blank <|> wordyId <|> label "prefix-operator" (P.try (reserved "(" *> symbolyId) <* reserved ")")
 
 infixVar :: Var v => P v (L.Token v)
 infixVar =

--- a/unison-src/tests/underscore-parsing.u
+++ b/unison-src/tests/underscore-parsing.u
@@ -1,0 +1,7 @@
+_prefix = 1
+prefix_ _x = _x
+_prefix_ _ = 2
+
+_x `_infix` y_ = (_x, y_)
+x_ `infix_` _y = (x_, _y)
+_ `_infix_` _ = ()


### PR DESCRIPTION
This fixes #381 by updating the lexer and parser to support underscores in both prefix and infix function names. The changes necessary to get this working were:

- Support `Blank`s as prefix vars, as `_foo` is parsed as a `Blank`
- Prepend `_` to the string value of a `Blank` when using it as a prefix var
- Recognize `_` as a valid starting character of a wordy id to allow the parsing of backticked terms with leading underscores