### PR TITLE
WIP on I/O functions

### DIFF
--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -43,7 +43,6 @@ import           Unison.HashQualified           ( HashQualified )
 import qualified Unison.HashQualified          as HQ
 import           Unison.Name                    ( Name )
 import qualified Unison.Name                   as Name
-import           Unison.Parser                  ( Ann )
 import qualified Unison.PrettyPrintEnv         as PPE
 import           Unison.Reference               ( Reference )
 import qualified Unison.Reference              as Reference
@@ -167,18 +166,6 @@ putTypeDeclaration c rid decl = do
     Left  ed -> DD.effectConstructorTerms rid ed
     Right dd -> DD.dataConstructorTerms rid dd
   where go (r, tm, typ) = putTerm c r tm typ
-
--- | Put all the builtins into the codebase
-initialize :: (Var.Var v, Monad m) => Codebase m v Ann -> m ()
-initialize c = do
-  traverse_ goData   Builtin.builtinDataDecls
-  traverse_ goEffect Builtin.builtinEffectDecls
- where
-  go f (_, (ref, decl)) = case ref of
-    Reference.DerivedId id -> putTypeDeclaration c id (f decl)
-    _                      -> pure ()
-  goEffect = go Left
-  goData   = go Right
 
 prettyBinding
   :: (Var.Var v, Monad m)

--- a/parser-typechecker/src/Unison/Codebase/Editor.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor.hs
@@ -16,7 +16,9 @@ import           Data.Char                      ( toLower )
 import Data.List (sortOn, isSuffixOf, isPrefixOf)
 import           Control.Monad                  ( forM_, forM, foldM, filterM, void)
 import           Control.Monad.Extra            ( ifM )
-import Data.Foldable (toList)
+import           Data.Foldable                  ( toList
+                                                , traverse_
+                                                )
 import           Data.Bifunctor                 ( bimap, second )
 import           Data.List.Extra                ( nubOrd )
 import qualified Data.Map                      as Map
@@ -56,6 +58,8 @@ import           Unison.Result                  ( Note
 import qualified Unison.Result                 as Result
 import           Unison.Referent                ( Referent )
 import qualified Unison.Referent               as Referent
+import qualified Unison.Runtime.IOSource       as IOSource
+import           Unison.Symbol                  ( Symbol )
 import           Unison.Util.Relation          (Relation)
 import qualified Unison.Util.Relation as R
 import qualified Unison.Codebase.Runtime       as Runtime
@@ -614,7 +618,11 @@ typecheck ambient codebase names sourceName src =
     src
 
 builtinBranch :: Branch
-builtinBranch = Branch.append (Branch.fromNames B.names) mempty
+builtinBranch = Branch.append
+  (  Branch.fromNames B.names
+  <> Branch.fromTypecheckedFile IOSource.typecheckedFile
+  )
+  mempty
 
 newBranch :: Monad m => Codebase m v a -> BranchName -> m Bool
 newBranch codebase branchName = forkBranch codebase builtinBranch branchName
@@ -766,6 +774,19 @@ fuzzyNameDistance (Name.toString -> q) (Name.toString -> n) =
   case Find.fuzzyFindMatchArray q [n] id of
     [] -> Nothing
     (m, _) : _ -> Just m
+
+-- | Put all the builtins into the codebase
+initializeCodebase :: forall m . Monad m => Codebase m Symbol Ann -> m Branch
+initializeCodebase c = do
+  traverse_ (go Right) B.builtinDataDecls
+  traverse_ (go Left)  B.builtinEffectDecls
+  r <- fileToBranch updateCollisionHandler c mempty IOSource.typecheckedFile
+  pure $ updatedBranch r
+ where
+  go :: (t -> Decl Symbol Ann) -> (a, (Reference.Reference, t)) -> m ()
+  go f (_, (ref, decl)) = case ref of
+    Reference.DerivedId id -> Codebase.putTypeDeclaration c id (f decl)
+    _                      -> pure ()
 
 -- todo: probably don't use this anywhere
 nameDistance :: Name -> Name -> Maybe Int

--- a/parser-typechecker/src/Unison/Codebase/Runtime.hs
+++ b/parser-typechecker/src/Unison/Codebase/Runtime.hs
@@ -26,10 +26,8 @@ import Unison.DataDeclaration (pattern TupleTerm', tupleTerm)
 data Runtime v = Runtime
   { terminate :: IO ()
   , evaluate
-      :: forall a
-      .  Monoid a
-      => CL.CodeLookup IO v a
-      -> AnnotatedTerm v a
+      :: CL.CodeLookup IO v ()
+      -> Term v
       -> IO (Term v)
   }
 

--- a/parser-typechecker/src/Unison/Runtime/IOSource.hs
+++ b/parser-typechecker/src/Unison/Runtime/IOSource.hs
@@ -1,0 +1,194 @@
+{-# Language TemplateHaskell #-}
+{-# Language QuasiQuotes #-}
+
+module Unison.Runtime.IOSource where
+
+import Control.Monad.Identity (runIdentity, Identity)
+import Data.String (fromString)
+import Data.Text (Text)
+import Text.RawString.QQ (r)
+import Unison.FileParsers (parseAndSynthesizeFile)
+import Unison.Parser (Ann(..))
+import Unison.Symbol (Symbol)
+import qualified Unison.Builtin as Builtin
+import qualified Unison.Result as Result
+import qualified Unison.Typechecker.TypeLookup as TL
+import qualified Unison.UnisonFile as UF
+
+typecheckedFile :: UF.TypecheckedUnisonFile Symbol Ann
+typecheckedFile = let
+  tl :: a -> Identity (TL.TypeLookup Symbol Ann)
+  tl = const $ pure (External <$ TL.builtinTypeLookup)
+  r = parseAndSynthesizeFile [] tl Builtin.names "<IO.u builtin>" source
+  in case runIdentity $ Result.runResultT r of
+    (Nothing, notes) -> error $ "parsing failed: " <> show notes
+    (Just (_ppe, Nothing), notes) -> error $ "typechecking failed" <> show notes
+    (Just (_, Just file), _) -> file
+
+source :: Text
+source = fromString [r|
+
+-- Handles are unique identifiers.
+-- The implementation of IO in the runtime will supply Haskell
+-- file handles and map those to Unison handles.
+-- A pure implementation of I/O might use some kind of pure supply
+-- of unique IDs instead.
+type Handle = Handle Text
+
+-- Ditto for sockets
+type Socket = Socket Text
+
+-- Builtin handles: standard in, out, error
+
+namespace IO where
+  stdin: Handle
+  stdin = Handle "stdin"
+
+  stdout: Handle
+  stdout = Handle "stdout"
+
+  stderr: Handle
+  stderr = Handle "stderr"
+
+  printLine : Text -> {IO} ()
+  printLine t =
+    IO.putText stdout t
+    IO.putText stdout "\n"
+
+-- IO Modes from the Haskell API
+type IOMode = Read | Write | Append | ReadWrite
+
+-- IO error types from the Haskell API
+type IOErrorType
+  = AlreadyExists
+  | NoSuchThing
+  | ResourceBusy
+  | ResourceExhausted
+  | EOF
+  | IllegalOperation
+  | PermissionDenied
+  | UserError
+
+type ErrorLocation = ErrorLocation Text
+type ErrorDescription = ErrorDescription Text
+type FilePath = FilePath Text
+
+type IOError =
+  IOError
+    (Optional Handle)
+    IOErrorType
+    ErrorLocation
+    ErrorDescription
+    (Optional FilePath)
+
+type SeekMode = Absolute | Relative | FromEnd
+
+-- If the buffer size is not specified,
+-- use an implementation-specific size.
+type BufferMode = Line | Block (Optional Nat)
+
+type EpochTime = EpochTime Nat
+
+-- Either a host name e.g., "unisonweb.org" or a numeric host address
+-- string consisting of a dotted decimal IPv4 address or an IPv6 address
+-- e.g., "192.168.0.1".
+type HostName = HostName Text
+
+type PortNumber = Nat
+
+-- Represents a 32-bit host address
+type HostAddress = HostAddress Int
+
+-- Internet protocol v4 socket address
+type SocketAddress = SocketAddress HostAddress PortNumber
+
+
+ability IO where
+
+  -- Basic file IO
+  openFile : FilePath -> IOMode ->{IO} Handle
+  closeFile : Handle ->{IO} ()
+  isEOF : Handle ->{IO} Boolean
+  isFileOpen : Handle ->{IO} Boolean
+
+  -- Text input and output
+
+  --getChar : Handle ->{IO} Char
+  getLine : Handle ->{IO} Text
+  -- Get the entire contents of the file as text
+  getText : Handle ->{IO} Text
+  -- putChar : Handle -> Char ->{IO} ()
+  putText : Handle -> Text ->{IO} ()
+
+  -- Handling I/O errors.
+  -- Question: can we do better?
+  throw : IOError ->{IO} a
+  catch : '{IO} a -> (IOError ->{IO} a) ->{IO} a
+
+  -- File positioning
+  isSeekable : Handle ->{IO} Boolean
+  seek : Handle -> SeekMode -> Int ->{IO} ()
+  position : Handle ->{IO} Int
+
+  -- File buffering
+  getBuffering : Handle ->{IO} (Optional BufferMode)
+  setBuffering : Handle -> Optional BufferMode ->{IO} ()
+
+  -- Should we expose mutable arrays for byte buffering?
+  -- Inclined to say no, although that sounds a lot like
+  -- a decision to just be slow.
+  -- We'll need a byte buffer manipulation library in that case.
+
+  -- getBytes : Handle -> Nat ->{IO} Bytes
+  -- putBytes : Handle -> Bytes ->{IO} ()
+
+  -- getBytes : Handle -> Nat -> ByteArray ->{IO} Nat
+  -- putBytes : Handle -> Nat -> ByteArray ->{IO} ()
+
+  systemTime : {IO} EpochTime
+
+
+  -- File system operations
+  getCurrentDirectory : {IO} FilePath
+  setCurrentDirectory : FilePath ->{IO} ()
+  directoryContents : FilePath ->{IO} [FilePath]
+  fileExists : FilePath -> {IO} Boolean
+  isDirectory : FilePath ->{IO} Boolean
+  createDirectory : FilePath ->{IO} ()
+  removeDirectory : FilePath ->{IO} ()
+  renameDirectory : FilePath -> FilePath -> {IO} ()
+  removeFile : FilePath ->{IO} ()
+  renameFile : FilePath -> FilePath ->{IO} ()
+  getFileTimestamp : FilePath ->{IO} EpochTime
+  getFileSize : FilePath ->{IO} Nat
+
+
+  -- Network I/O
+
+  -- Glossing over address families (ipv4, ipv6),
+  -- and socket types (stream, raw, etc)
+
+  -- Creates a socket and binds it to a the given local port
+  serverSocket : SocketAddress -> {IO} Socket
+
+  -- Creates a socket connected to the given remote address
+  clientSocket : SocketAddress -> {IO} Socket
+
+  socketToHandle : Socket ->{IO} Handle
+  handleToSocket : Handle ->{IO} Socket
+  closeSocket : Socket ->{IO} ()
+
+  -- Accept a connection on a socket.
+  -- Returns a socket that can send and receive data on a new connection,
+  -- together with the remote host information.
+  accept : Socket ->{IO} (Socket, SocketAddress)
+
+  -- Returns the number of bytes actually sent
+  -- send : Socket -> Bytes ->{IO} Int
+
+  -- scatter/gather mode network I/O
+  -- sendMany : Socket -> [Bytes] ->{IO} Int
+
+  -- Read the spefified number of bytes from the socket.
+  -- receive : Socket -> Int ->{IO} Bytes
+|]

--- a/parser-typechecker/src/Unison/Runtime/IOSource.hs
+++ b/parser-typechecker/src/Unison/Runtime/IOSource.hs
@@ -10,10 +10,13 @@ import Text.RawString.QQ (r)
 import Unison.FileParsers (parseAndSynthesizeFile)
 import Unison.Parser (Ann(..))
 import Unison.Symbol (Symbol)
+import qualified Data.Map as Map
 import qualified Unison.Builtin as Builtin
+import qualified Unison.Reference as R
 import qualified Unison.Result as Result
 import qualified Unison.Typechecker.TypeLookup as TL
 import qualified Unison.UnisonFile as UF
+import qualified Unison.Var as Var
 
 typecheckedFile :: UF.TypecheckedUnisonFile Symbol Ann
 typecheckedFile = let
@@ -24,6 +27,23 @@ typecheckedFile = let
     (Nothing, notes) -> error $ "parsing failed: " <> show notes
     (Just (_ppe, Nothing), notes) -> error $ "typechecking failed" <> show notes
     (Just (_, Just file), _) -> file
+
+typeNamed :: String -> R.Reference
+typeNamed s =
+  case Map.lookup (Var.nameds s) (UF.dataDeclarations' typecheckedFile) of
+    Nothing -> error $ "No builtin type called: " <> s
+    Just (r, _) -> r
+
+abilityNamed :: String -> R.Reference
+abilityNamed s =
+  case Map.lookup (Var.nameds s) (UF.effectDeclarations' typecheckedFile) of
+    Nothing -> error $ "No builtin ability called: " <> s
+    Just (r, _) -> r
+
+ioReference, bufferModeReference :: R.Reference
+ioReference = abilityNamed "IO"
+bufferModeReference = typeNamed "BufferMode"
+-- .. todo - fill in the rest of these
 
 source :: Text
 source = fromString [r|

--- a/parser-typechecker/src/Unison/Typechecker/TypeLookup.hs
+++ b/parser-typechecker/src/Unison/Typechecker/TypeLookup.hs
@@ -2,13 +2,14 @@ module Unison.Typechecker.TypeLookup where
 
 import Control.Applicative ((<|>))
 import Data.Map (Map)
-import qualified Data.Map as Map
 import Unison.Reference (Reference)
 import Unison.Referent (Referent)
-import qualified Unison.Referent as Referent
 import Unison.Type (AnnotatedType)
-import qualified Unison.DataDeclaration as DD
+import Unison.Var (Var)
+import qualified Data.Map as Map
 import qualified Unison.ConstructorType as CT
+import qualified Unison.DataDeclaration as DD
+import qualified Unison.Referent as Referent
 
 type Type v a = AnnotatedType v a
 type DataDeclaration v a = DD.DataDeclaration' v a
@@ -22,6 +23,10 @@ data TypeLookup v a =
              , dataDecls :: Map Reference (DataDeclaration v a)
              , effectDecls :: Map Reference (EffectDeclaration v a) }
   deriving Show
+
+builtinTypeLookup :: Var v => TypeLookup v ()
+builtinTypeLookup = TypeLookup mempty decls mempty where
+  decls = Map.fromList [ (r, dd) | (_, r, dd) <- DD.builtinDataDecls ]
 
 typeOfReferent :: TypeLookup v a -> Referent -> Maybe (Type v a)
 typeOfReferent tl r = case r of

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -85,6 +85,7 @@ library
     Unison.Runtime.IR
     Unison.Runtime.Rt1
     Unison.Runtime.Rt1IO
+    Unison.Runtime.IOSource
     Unison.Runtime.Vector
     Unison.Runtime.SparseVector
     Unison.Settings
@@ -155,6 +156,7 @@ library
     megaparsec,
     prelude-extras,
     random,
+    raw-strings-qq,
     regex-base,
     regex-tdfa,
     safe,

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -2,16 +2,17 @@
 
 module Main where
 
-import           Control.Monad                    (when)
-import           Safe                             (headMay)
-import           System.Environment               (getArgs)
-import qualified Unison.Codebase                  as Codebase
-import qualified Unison.Codebase.FileCodebase     as FileCodebase
-import qualified Unison.Codebase.Serialization    as S
-import           Unison.Codebase.Serialization.V0 (formatSymbol)
-import qualified Unison.CommandLine.Main          as CommandLine
-import           Unison.Parser                    (Ann (External))
-import qualified Unison.Runtime.Rt1IO             as Rt1
+import           Control.Monad                  ( when )
+import           Safe                           ( headMay )
+import           System.Environment             ( getArgs )
+import qualified Unison.Codebase.FileCodebase  as FileCodebase
+import qualified Unison.Codebase.Serialization as S
+import           Unison.Codebase.Serialization.V0
+                                                ( formatSymbol )
+import qualified Unison.CommandLine.Main       as CommandLine
+import           Unison.Parser                  ( Ann(External) )
+import qualified Unison.Runtime.Rt1IO          as Rt1
+import qualified Unison.Codebase.Editor        as Editor
 
 main :: IO ()
 main = do
@@ -22,9 +23,10 @@ main = do
       scratchFilePath   = "."
       theCodebase =
         FileCodebase.codebase1 External formatSymbol formatAnn codebasePath
-      launch = CommandLine.main
+      launch baseBranch = CommandLine.main
         scratchFilePath
         initialBranchName
+        baseBranch
         (headMay args)
         (pure Rt1.runtime)
         theCodebase
@@ -32,8 +34,8 @@ main = do
   when (not exists) $ do
     putStrLn $ "☝️  No codebase exists here so I'm initializing one in: " <> codebasePath
     FileCodebase.initialize codebasePath
-    Codebase.initialize theCodebase
-  launch
+  baseBranch <- Editor.initializeCodebase theCodebase
+  launch baseBranch
 
 formatAnn :: S.Format Ann
 formatAnn = S.Format (pure External) (\_ -> pure ())


### PR DESCRIPTION
This is still WIP but wanted to get this merged - what's there is functional and doesn't break anything else.

There's an `execute` command which takes an expression to evaluate with access to the `IO` ability:

    > execute IO.printLine "hello world"

And the `IO` type is added to the codebase on initialization, and `IO` names are added to newly created branches.

`IO` API will be going through rapid changes over next few weeks.

One thing we'll likely add to the `unison` executable is a way of running commands (like `execute`) on launch, so you can run a Unison program as a standalone command line tool.