### PR TITLE
Fix printing braces in effects

### DIFF
--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -727,8 +727,10 @@ renderType
   -> AnnotatedText a
 renderType env f t = renderType0 env f (0 :: Int) (Type.ungeneralizeEffects t)
  where
-  paren :: (IsString a, Semigroup a) => Bool -> a -> a
-  paren test s = if test then "(" <> s <> ")" else s
+  wrap :: (IsString a, Semigroup a) => a -> a -> Bool -> a -> a
+  wrap start end test s = if test then start <> s <> end else s
+  paren = wrap "(" ")"
+  curly = wrap "{" "}"
   renderType0 env f p t = f (ABT.annotation t) $ case t of
     Type.Ref' r -> showTypeRef env r
     Type.Arrow' i (Type.Effect1' e o) ->
@@ -739,7 +741,7 @@ renderType env f t = renderType0 env f (0 :: Int) (Type.ungeneralizeEffects t)
     Type.Apps' (Type.Ref' (R.Builtin "Sequence")) [arg] ->
       "[" <> go 0 arg <> "]"
     Type.Apps' f' args -> paren (p >= 3) $ spaces (go 3) (f' : args)
-    Type.Effects' es   -> commas (go 0) es
+    Type.Effects' es   -> curly (p >= 3) $ commas (go 0) es
     Type.Effect' es t  -> case es of
       [] -> go p t
       _  -> "{" <> commas (go 0) es <> "} " <> go 3 t

--- a/unison-src/tests/multiple-effects.u
+++ b/unison-src/tests/multiple-effects.u
@@ -1,0 +1,17 @@
+effect State s where
+  get : {State s} s
+  set : s -> {State s} ()
+
+effect Console where
+  read : {Console} (Optional Text)
+  write : Text -> {Console} ()
+
+namespace Console where
+  state : s -> Effect (State s) a -> a
+  state s c = case c of
+    {State.get -> k} -> handle state s in k s
+    {State.set s' -> k} -> handle state s' in k ()
+    {a} -> a
+
+multiHandler : s -> [w] -> Nat -> Effect {State s, Console} a -> ()
+multiHandler _ _ _ _ = ()


### PR DESCRIPTION
@aryairani this should fix #375. Given the code in `multiple-effects.u`, the output is:

```
-- Before
ability Console
ability State s
Console.state : s -> Effect (State s) a -> a
multiHandler : s -> [w] -> Nat -> Effect State s, Console a -> ()

-- After
ability Console
ability State s
Console.state : s -> Effect (State s) a -> a
multiHandler : s -> [w] -> Nat -> Effect {State s, Console} a -> ()
```

I just had one question &mdash; I haven't fully grokked when it's necessary to pass 0 or 3 to `go`, but I tried changing it to 3 in this case and got this for `multiHandler`:

```
multiHandler : s -> [w] -> Nat -> Effect {(State s), Console} a -> ()
```

Is having the parentheses around `State s` desirable since it's printed with parentheses in the `Console.state` type?