### PR TITLE
forward-autocompletion and exact matching for `view` / `edit` commands

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/Actions.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Actions.hs
@@ -142,13 +142,13 @@ loop = do
             respond . ListOfDefinitions currentBranch' True
         -- ls with arguments
         SearchByNameI ("-l" : (fmap HQ.fromString -> qs)) ->
-            (eval $ SearchBranch currentBranch' qs)
+            (eval $ SearchBranch currentBranch' qs Editor.FuzzySearch)
               >>= respond . ListOfDefinitions currentBranch' True
         SearchByNameI (map HQ.fromString -> qs) ->
-            (eval $ SearchBranch currentBranch' qs)
+            (eval $ SearchBranch currentBranch' qs Editor.FuzzySearch)
               >>= respond . ListOfDefinitions currentBranch' False
         ShowDefinitionI outputLoc (fmap HQ.fromString -> qs) -> do
-          results <- eval $ SearchBranch currentBranch' qs
+          results <- eval $ SearchBranch currentBranch' qs Editor.ExactSearch
           let termTypes :: Map.Map Reference (Editor.Type v Ann)
               termTypes = Map.fromList
                 [ (r, t)

--- a/parser-typechecker/src/Unison/CommandLine.hs
+++ b/parser-typechecker/src/Unison/CommandLine.hs
@@ -138,7 +138,7 @@ fuzzyCompleteHashQualified b q0@(HQ.fromString -> query) =
 
 fuzzyComplete :: String -> [String] -> [Line.Completion]
 fuzzyComplete q ss =
-  fixupCompletion q (prettyCompletion <$> Find.fuzzyFinder q ss)
+  fixupCompletion q (prettyCompletion <$> Find.fuzzyFinder q ss id)
 
 -- workaround for https://github.com/judah/haskeline/issues/100
 -- if the common prefix of all the completions is smaller than
@@ -155,6 +155,13 @@ fixupCompletion q cs@(h:t) = let
   in if length overallCommonPrefix < length q
      then [ c { Line.replacement = q } | c <- cs ]
      else cs
+
+autoCompleteHashQualified :: Branch0 -> String -> [Line.Completion]
+autoCompleteHashQualified b (HQ.fromString -> query) =
+  makeCompletion <$> Find.prefixFindInBranch b query
+  where
+  makeCompletion (sr, p) =
+    prettyCompletion (HQ.toString . SR.name $ sr, p)
 
 parseInput
   :: Map String InputPattern -> [String] -> Either (P.Pretty CT.ColorText) Input

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -72,7 +72,7 @@ validInputs =
       _ -> Left . warn . P.wrap $ "Use `fork foo` to create the branch 'foo'"
                                 <> "from the current branch."
     )
-  , InputPattern "find" ["ls","list"] [(True, definitionQueryArg)]
+  , InputPattern "find" ["ls","list"] [(True, fuzzyDefinitionQueryArg)]
     (P.wrapColumn2
       [ ("`find`"
         , "lists all definitions in the current branch.")
@@ -92,14 +92,14 @@ validInputs =
       _ -> Left . warn . P.wrap $
         "Use `merge foo` to merge the branch 'foo' into the current branch."
     )
-  , InputPattern "view" [] [(False, definitionQueryArg)]
+  , InputPattern "view" [] [(False, exactDefinitionQueryArg)]
       "`view foo` prints the definition of `foo`."
       (pure . ShowDefinitionI E.ConsoleLocation)
-  , InputPattern "edit" [] [(False, definitionQueryArg)]
+  , InputPattern "edit" [] [(False, exactDefinitionQueryArg)]
       "`edit foo` prepends the definition of `foo` to the top of the most recently saved file."
       (pure . ShowDefinitionI E.LatestFileLocation)
   , InputPattern "rename" ["mv"]
-    [(False, definitionQueryArg), (False, noCompletions)]
+    [(False, exactDefinitionQueryArg), (False, noCompletions)]
     "`rename foo bar` renames `foo` to `bar`."
     (\case
       [oldName, newName] -> Right $ RenameUnconflictedI
@@ -109,7 +109,7 @@ validInputs =
       _ -> Left . P.warnCallout $ P.wrap
         "`rename` takes two arguments, like `rename oldname newname`.")
   , InputPattern "alias" ["cp"]
-    [(False, definitionQueryArg), (False, noCompletions)]
+    [(False, exactDefinitionQueryArg), (False, noCompletions)]
     "`alias foo bar` introduces `bar` with the same definition as `foo`."
     (\case
       [oldName, newName] -> Right $ AliasUnconflictedI
@@ -161,10 +161,15 @@ branchArg = ArgumentType "branch" $ \q codebase _b -> do
   let bs = Text.unpack <$> branches
   pure $ fuzzyComplete q bs
 
-definitionQueryArg :: ArgumentType
-definitionQueryArg =
-  ArgumentType "definition query" $ \q _ (Branch.head -> b) -> do
+fuzzyDefinitionQueryArg :: ArgumentType
+fuzzyDefinitionQueryArg =
+  ArgumentType "fuzzy definition query" $ \q _ (Branch.head -> b) -> do
     pure $ fuzzyCompleteHashQualified b q
+
+exactDefinitionQueryArg :: ArgumentType
+exactDefinitionQueryArg =
+  ArgumentType "definition query" $ \q _ (Branch.head -> b) -> do
+    pure $ autoCompleteHashQualified b q
 
 noCompletions :: ArgumentType
 noCompletions = ArgumentType "a word" noSuggestions

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DoAndIfThenElse     #-}
 {-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/parser-typechecker/src/Unison/Name.hs
+++ b/parser-typechecker/src/Unison/Name.hs
@@ -1,4 +1,4 @@
-module Unison.Name (Name(..), unsafeFromText, toString, fromString, toVar, unsafeFromVar) where
+module Unison.Name (Name(..), unsafeFromText, toString, fromString, toVar, unsafeFromVar, isPrefixOf) where
 
 import           Data.String (IsString, fromString)
 import           Data.Text   (Text)
@@ -22,6 +22,9 @@ unsafeFromVar = unsafeFromText . Var.name
 
 toString :: Name -> String
 toString = Text.unpack . toText
+
+isPrefixOf :: Name -> Name -> Bool
+a `isPrefixOf` b = toText a `Text.isPrefixOf` toText b
 
 instance Show Name where
   show = toString

--- a/parser-typechecker/src/Unison/ShortHash.hs
+++ b/parser-typechecker/src/Unison/ShortHash.hs
@@ -13,6 +13,12 @@ data ShortHash
   | ShortHash { prefix :: Text, cycle :: Maybe Text, cid :: Maybe Text }
   deriving (Eq, Ord)
 
+-- currently unused
+isConstructor :: ShortHash -> Bool
+isConstructor = \case
+  ShortHash _ _ (Just _) -> True
+  _ -> False
+
 -- Parse a string like those described in Referent.fromText:
 -- examples:
 -- `##Text.take` — builtins don’t have cycles


### PR DESCRIPTION
mainly:
```haskell
data Editor.SearchMode = FuzzySearch | ExactSearch
```
is now passed to the `Editor.SearchBranch` command

and added `InputPatterns.exactDefinitionQueryArg :: InputPatterns.ArgumentType` which does forward-autocompletion of definition names from a branch.

`> view ba<tab><tab><enter>` yields all of this:
![image](https://user-images.githubusercontent.com/538571/54388755-d24e2c80-4674-11e9-89bc-993d4e9d0915.png)
