### PR TITLE
fix #378 close empty = blocks

### DIFF
--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -236,7 +236,15 @@ lexer0 scope rem =
       (spaces, '-':'-':rem) -> spanThru' (/= '\n') rem $ \(ignored, rem) ->
         pushLayout b l (incBy ('-':'-':ignored) . incBy spaces $ pos) rem
       (spaces, rem) ->
-        let pos' = incBy spaces pos in go ((b, column pos') : l) pos' rem
+        let topcol = top l
+            pos'   = incBy spaces pos
+            col'   = column pos'
+        in
+          if b == "=" && col' <= topcol then
+            -- force closing by introducing a fake col +1 layout
+            popLayout0 ((b, col' + 1) : l) pos' rem
+          else
+            go ((b, col') : l) pos' rem
 
     -- assuming we've dealt with whitespace and layout, read a token
     go :: Layout -> Pos -> [Char] -> [Token Lexeme]

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -958,8 +958,8 @@ prettyParseError s = \case
   go (Parser.EmptyBlock tok) = mconcat
     [ "I expected a block after this ("
     , describeStyle ErrorSite
-    , "),"
-    , ", but there wasn't one.  Maybe check your indentation:\n"
+    , "), "
+    , "but there wasn't one.  Maybe check your indentation:\n"
     , tokenAsErrorSite s tok
     ]
   go (Parser.UnknownEffectConstructor tok) = unknownConstructor "effect" tok

--- a/parser-typechecker/tests/Unison/Test/Lexer.hs
+++ b/parser-typechecker/tests/Unison/Test/Lexer.hs
@@ -38,6 +38,23 @@ test = scope "lexer" . tests $
         expected = [Open "if", WordyId "x", Close, Open "then", WordyId "y", Close, Open "else", WordyId "z", Close]
     in tests $ map (`t` expected) [ex1, ex2, ex3, ex4]
 
+  -- directly close empty = block
+  , let ex = unlines
+          [ "test ="
+          , ""
+          , "x = 1"]
+    in t ex [ WordyId "test", Open "=", Close, Semi,
+              WordyId "x", Open "=", Numeric "1", Close]
+
+  -- directly close nested empty blocks
+  , let ex = unlines
+          [ "test ="
+          , "  test2 ="
+          , ""
+          , "x = 1"]
+    in t ex [ WordyId "test",Open "=",WordyId "test2",Open "=",Close,Close,Semi,
+              WordyId "x",Open "=",Numeric "1",Close]
+
   , let ex = unlines [ "if a then b"
                      , "else if c then d"
                      , "else if e then f"


### PR DESCRIPTION
The result of this fix is:

```haskell
test =
  test3 =
    test4 =

> test
```

<img width="978" alt="image" src="https://user-images.githubusercontent.com/161305/54427600-46431000-471b-11e9-985f-3fab16fd0159.png">
