### PR TITLE
add ANSI-patched haskeline as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "yaks/haskeline"]
+	path = yaks/haskeline
+	url = https://github.com/aryairani/haskeline.git
+	branch = topic/align-ansi-completions

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,6 +6,7 @@ allow-different-user: true
 
 packages:
 - yaks/easytest
+- yaks/haskeline
 - parser-typechecker
 
 #compiler-check: match-exact


### PR DESCRIPTION
This PR adds haskeline with [an alignment fix](https://github.com/judah/haskeline/pull/115) and [some flags tweaking](https://github.com/unisonweb/unison/commit/64e26f386facd6574a9d26d0082e393060b50aa2) as a git submodule and stack subproject.