### PR TITLE
Switched implementation of `[a]` type to use Data.Sequence and cleanup naming

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Serialization/V0.hs
+++ b/parser-typechecker/src/Unison/Codebase/Serialization/V0.hs
@@ -3,7 +3,6 @@
 module Unison.Codebase.Serialization.V0 where
 
 -- import qualified Data.Text as Text
-import qualified Data.Vector                   as Vector
 import qualified Unison.PatternP               as Pattern
 import           Unison.PatternP                ( Pattern )
 import           Control.Applicative            ( liftA2
@@ -44,6 +43,7 @@ import           Unison.Symbol                  ( Symbol(..) )
 import           Unison.Term                    ( AnnotatedTerm )
 import qualified Data.ByteString               as B
 import qualified Data.Map                      as Map
+import qualified Data.Sequence                 as Sequence
 import qualified Data.Set                      as Set
 import qualified Unison.ABT                    as ABT
 import qualified Unison.Codebase.Causal        as Causal
@@ -369,7 +369,7 @@ putTerm putVar putA typ = putABT putVar putA go typ where
       -> putWord8 9 *> putChild f *> putChild arg
     Term.Ann e t
       -> putWord8 10 *> putChild e *> putType putVar putA t
-    Term.Vector vs
+    Term.Sequence vs
       -> putWord8 11 *> putFoldable vs putChild
     Term.If cond t f
       -> putWord8 12 *> putChild cond *> putChild t *> putChild f
@@ -405,7 +405,7 @@ getTerm getVar getA = getABT getVar getA go where
     8 -> Term.Handle <$> getChild <*> getChild
     9 -> Term.App <$> getChild <*> getChild
     10 -> Term.Ann <$> getChild <*> getType getVar getA
-    11 -> Term.Vector . Vector.fromList <$> getList getChild
+    11 -> Term.Sequence . Sequence.fromList <$> getList getChild
     12 -> Term.If <$> getChild <*> getChild <*> getChild
     13 -> Term.And <$> getChild <*> getChild
     14 -> Term.Or <$> getChild <*> getChild

--- a/parser-typechecker/src/Unison/Codecs.hs
+++ b/parser-typechecker/src/Unison/Codecs.hs
@@ -106,7 +106,7 @@ serializeTerm x = do
         putWord8 6
         serializeBoolean b
         incPosition
-      Vector v -> do
+      Sequence v -> do
         elementPositions <- traverse serializeTerm v
         putTag
         putWord8 7

--- a/parser-typechecker/src/Unison/Runtime/ANF.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF.hs
@@ -11,7 +11,7 @@ module Unison.Runtime.ANF (optimize, fromTerm, fromTerm', term, minimizeCyclesOr
 import Data.Bifunctor (second)
 import Data.Foldable hiding (and,or)
 import Data.List hiding (and,or)
-import Prelude hiding (abs,and,or)
+import Prelude hiding (abs,and,or,seq)
 import Unison.Term
 import Unison.Var (Var)
 import Data.Set (Set)
@@ -163,8 +163,8 @@ fromTerm liftVar t = ANF_ (go $ lambdaLift liftVar t) where
   go (Let1Named' v b e) = let1' False [(v, go b)] (go e)
   -- top = False because we don't care to emit typechecker notes about TLDs
   go (LetRecNamed' bs e) = letRec' False (fmap (second go) bs) (go e)
-  go e@(Vector' vs) =
+  go e@(Sequence' vs) =
     if all isLeaf vs then e
-    else fixup (ABT.freeVars e) (vector (ann e)) (toList vs)
+    else fixup (ABT.freeVars e) (seq (ann e)) (toList vs)
   go e@(Ann' tm typ) = Term.ann (ann e) (go tm) typ
   go e = error $ "ANF.term: I thought we got all of these\n" <> show e

--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -17,7 +17,7 @@ import           Data.Int (Int64)
 import           Data.List (elem)
 import           Data.Maybe (isJust, fromMaybe)
 import           Data.Word (Word64)
-import           Prelude hiding (and, or)
+import           Prelude hiding (and, or, seq)
 import qualified Text.Megaparsec as P
 import qualified Unison.ABT as ABT
 import qualified Unison.Lexer as L
@@ -204,18 +204,18 @@ boolean = ((\t -> Term.boolean (ann t) True) <$> reserved "true") <|>
 placeholder :: Var v => TermP v
 placeholder = (\t -> Term.placeholder (ann t) (L.payload t)) <$> blank
 
-vector :: Var v => TermP v -> TermP v
-vector p = f <$> reserved "[" <*> elements <*> trailing
+seq :: Var v => TermP v -> TermP v
+seq p = f <$> reserved "[" <*> elements <*> trailing
   where
     trailing = optional semi *> reserved "]"
     sep = P.try $ optional semi *> reserved "," <* optional semi
     elements = sepBy sep p
-    f open elems close = Term.vector (ann open <> ann close) elems
+    f open elems close = Term.seq (ann open <> ann close) elems
 
 termLeaf :: forall v. Var v => TermP v
 termLeaf = do
   e <- asum [hashLit, prefixTerm, text, number, boolean,
-             tupleOrParenthesizedTerm, keywordBlock, placeholder, vector term,
+             tupleOrParenthesizedTerm, keywordBlock, placeholder, seq term,
              delayQuote, bang]
   q <- optional (reserved "?")
   case q of

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -164,7 +164,7 @@ pretty n AmbientContext { precedence = p, blockContext = bc, infixContext = ic }
     AskInfo' x -> paren (p >= 11) $ pretty n (ac 11 Normal) x <> l "?"
     LamNamed' v x | (Var.name v) == "()" ->
       paren (p >= 11) $ l "'" <> pretty n (ac 11 Normal) x
-    Vector' xs -> PP.group $
+    Sequence' xs -> PP.group $
       "[" <> optSpace
           <> intercalateMap ("," <> PP.softbreak <> optSpace)
                             (pretty n (ac 0 Normal))

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -765,7 +765,7 @@ synthesize e = scope (InSynthesize e) $
     ctx <- getContext
     (vs, ft) <- ungeneralize' ft
     scope (InFunctionCall vs f ft args) $ synthesizeApps (apply ctx ft) args
-  go (Term.Vector' v) = do
+  go (Term.Sequence' v) = do
     ft <- vectorConstructorOfArity (Foldable.length v)
     case Foldable.toList v of
       [] -> pure ft

--- a/parser-typechecker/src/Unison/Util/CyclicEq.hs
+++ b/parser-typechecker/src/Unison/Util/CyclicEq.hs
@@ -5,8 +5,10 @@
 
 module Unison.Util.CyclicEq where
 
+import Data.Foldable (toList)
 import Data.Vector (Vector)
 import qualified Data.Vector as V
+import qualified Data.Sequence as S
 import qualified Unison.Util.CycleTable as CT
 
 {-
@@ -39,6 +41,11 @@ instance CyclicEq a => CyclicEq [a] where
   cyclicEq h1 h2 (x:xs) (y:ys) = bothEq h1 h2 x y xs ys
   cyclicEq _ _ [] [] = pure True
   cyclicEq _ _ _ _   = pure False
+
+instance CyclicEq a => CyclicEq (S.Seq a) where
+  cyclicEq h1 h2 xs ys =
+    if S.length xs == S.length ys then cyclicEq h1 h2 (toList xs) (toList ys)
+    else pure False
 
 instance CyclicEq a => CyclicEq (Vector a) where
   cyclicEq h1 h2 xs ys =

--- a/parser-typechecker/src/Unison/Util/CyclicOrd.hs
+++ b/parser-typechecker/src/Unison/Util/CyclicOrd.hs
@@ -5,9 +5,11 @@
 
 module Unison.Util.CyclicOrd where
 
+import Data.Foldable (toList)
 import Data.Vector (Vector)
 import Unison.Util.CycleTable (CycleTable)
 import qualified Data.Vector as V
+import qualified Data.Sequence as S
 import qualified Unison.Util.CycleTable as CT
 
 -- Same idea as `CyclicEq`, but for ordering.
@@ -35,6 +37,9 @@ instance CyclicOrd a => CyclicOrd [a] where
   cyclicOrd _ _ [] []  = pure EQ
   cyclicOrd _ _ [] _   = pure LT
   cyclicOrd _ _ _ []   = pure GT
+
+instance CyclicOrd a => CyclicOrd (S.Seq a) where
+  cyclicOrd h1 h2 xs ys = cyclicOrd h1 h2 (toList xs) (toList ys)
 
 instance CyclicOrd a => CyclicOrd (Vector a) where
   cyclicOrd h1 h2 xs ys = go 0 h1 h2 xs ys


### PR DESCRIPTION
Not a very exciting change, but the `[a]` type is now backed by `Data.Sequence`. I've been meaning to clean this up for a while and was reminded of it because this [pure Unison `Map` type](https://github.com/unisonweb/unison/blob/b37b1231a6de9f78e9248154baf4498b933b3a42/unison-src/Map.u) relies on having a sequence type that supports efficient, slicing, random access, and concatenation.

I also cleaned up the naming - like 50% of places were still using "Vector", so now everything uses "Sequence" consistently.