### PR TITLE
Add `branch.delete`

### DIFF
--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -87,6 +87,7 @@ data Codebase m v a =
            -- branch on disk, or creates a new branch if there's no existing
            -- branch with that name
            , syncBranch         :: BranchName -> Branch -> m Branch
+           , deleteBranch       :: BranchName -> m ()
            , branchUpdates      :: m (m (), m (Set BranchName))
 
            , dependentsImpl :: Reference -> m (Set Reference.Id)

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -39,6 +39,7 @@ import           System.Directory               ( createDirectoryIfMissing
                                                 , doesDirectoryExist
                                                 , listDirectory
                                                 , removeFile
+                                                , removeDirectoryRecursive
                                                 )
 import           System.FilePath                ( FilePath
                                                 , takeBaseName
@@ -258,6 +259,9 @@ codebase1 builtinTypeAnnotation (S.Format getV putV) (S.Format getA putA) path
         overwriteBranch name newBranch
         pure newBranch
 
+      deleteBranch name = removeDirectoryRecursive (branchPath path name)
+
+
       dependents :: Reference -> IO (Set Reference.Id)
       dependents r = do
         d  <- dir
@@ -304,6 +308,7 @@ codebase1 builtinTypeAnnotation (S.Format getV putV) (S.Format getA putA) path
                branches
                getBranch
                mergeBranch
+               deleteBranch
                branchUpdates
                dependents
                builtinTypeAnnotation

--- a/parser-typechecker/src/Unison/CommandLine.hs
+++ b/parser-typechecker/src/Unison/CommandLine.hs
@@ -14,6 +14,7 @@ module Unison.CommandLine where
 import           Control.Concurrent              (forkIO, killThread)
 import           Control.Concurrent.STM          (atomically)
 import           Control.Monad                   (forever, when)
+import           Data.Foldable                   (toList)
 import           Data.List                       (isSuffixOf)
 import           Data.ListLike                   (ListLike)
 import           Data.Map                        (Map)
@@ -179,6 +180,18 @@ parseInput patterns ss = case ss of
 
 prompt :: String
 prompt = "> "
+
+-- `plural [] "cat" "cats" = "cats"`
+-- `plural ["meow"] "cat" "cats" = "cat"`
+-- `plural ["meow", "meow"] "cat" "cats" = "cats"`
+plural :: Foldable f => f a -> b -> b -> b
+plural items one other = case toList items of
+  _ : [] -> one
+  _ -> other
+
+plural' :: Integral a => a -> b -> b -> b
+plural' 1 one _other = one
+plural' _ _one other = other
 
 -- like putPrettyLn' but prints a blank line before and after.
 putPrettyLn :: P.Pretty CT.ColorText -> IO ()

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -37,7 +37,7 @@ import qualified Unison.Codebase.TypeEdit      as TypeEdit
 import           Unison.CommandLine            (backtick, backtickEOS,
                                                 bigproblem, putPrettyLn,
                                                 putPrettyLn', tip, warn,
-                                                watchPrinter)
+                                                watchPrinter, plural)
 import           Unison.CommandLine.InputPatterns (makeExample, makeExample')
 import qualified Unison.CommandLine.InputPatterns as IP
 import qualified Unison.HashQualified          as HQ
@@ -139,8 +139,25 @@ notifyUser dir o = case o of
          $  "You can switch to that branch via"
          <> makeExample IP.branch [P.text b]
          <> "or delete it via"
-         <> makeExample IP.branchDelete [P.text b]
+         <> makeExample IP.deleteBranch [P.text b]
          )
+  DeletingCurrentBranch ->
+    putPrettyLn . P.warnCallout . P.wrap $
+      "Please use " <> makeExample' IP.branch <> " to switch to a different branch before deleting this one."
+  DeleteBranchConfirmation uniqueDeletions ->
+    let
+      pretty (branchName, (ppe, results)) =
+        header $ listOfDefinitions' ppe False results
+        where
+        header = plural uniqueDeletions id ((P.text branchName <> ":") `P.hang`)
+
+    in putPrettyLn . P.warnCallout
+      $ P.wrap ("The"
+      <> plural uniqueDeletions "branch contains" "branches contain"
+      <> "definitions that don't exist in any other branches:")
+      <> P.border 2 (mconcat (fmap pretty uniqueDeletions))
+      <> P.newline
+      <> P.wrap "Please repeat the same command to confirm the deletion."
   ListOfBranches current branches ->
     putPrettyLn
       $ let
@@ -505,8 +522,18 @@ todoOutput (Branch.head -> branch) todo =
 
 listOfDefinitions ::
   Var v => Branch0 -> E.ListDetailed -> [E.SearchResult' v a] -> IO ()
-listOfDefinitions branch detailed results = do
-  putPrettyLn . P.lines . P.nonEmpty $ prettyResults ++
+listOfDefinitions branch detailed results =
+  putPrettyLn $ listOfDefinitions' ppe detailed results
+  where
+  ppe = Branch.prettyPrintEnv branch
+
+listOfDefinitions' :: Var v
+                   => PPE.PrettyPrintEnv -- for printing types of terms :-\
+                   -> E.ListDetailed
+                   -> [E.SearchResult' v a]
+                   -> P.Pretty P.ColorText
+listOfDefinitions' ppe detailed results =
+  P.lines . P.nonEmpty $ prettyResults ++
     [formatMissingStuff termsWithMissingTypes missingTypes
     ,unlessM (null missingBuiltins) . bigproblem $ P.wrap
       "I encountered an inconsistency in the codebase; these definitions refer to built-ins that this version of unison doesn't know about:" `P.hang`
@@ -516,7 +543,6 @@ listOfDefinitions branch detailed results = do
                                 (P.text . Referent.toText)) missingBuiltins))
     ]
   where
-  ppe  = Branch.prettyPrintEnv branch
   prettyResults =
     map (E.foldResult' renderTerm renderType) (filter (not.missingType) results)
     where


### PR DESCRIPTION
Also added a couple utility functions:
```
-- plural [] "cat" "cats" = "cats"
-- plural ["meow"] "cat" "cats" = "cat"
CommandLine.plural :: Foldable f => f a -> b -> b -> b
CommandLine.plural' :: Integral a => a -> b -> b -> b

InputPatterns.helpFor :: InputPattern -> Either (P.Pretty CT.ColorText) Input
-- Returns the command to display the help for a particular input pattern; 
-- can be used to delegate to 'help' in the input args parser.
```

Refactored replaced `Editor.SwitchBranch` and `Editor.ListBranch`, which were basically pure functions, with `LoadSearchResults`, which is shared by `find`, `search`, and `branch.delete` Actions.
```
LoadSearchResults :: [SR.SearchResult] -> Command i v [SearchResult' v Ann]
```
(Reminder: a `SR.SearchResult` is made up of pure stuff that you can pull out of a `Branch0`.  A `Editor.SearchResult' v Ann` contains extra goodies like "type of term" and whether a type is data or effect; stuff that you have to hit the `Codebase` for, for printing our specific output messages.)