### PR TITLE
Fix for #407

### DIFF
--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -73,6 +73,7 @@ import           Unison.DataDeclaration         ( DataDeclaration'
 import qualified Unison.DataDeclaration        as DD
 import           Unison.PatternP                ( Pattern )
 import qualified Unison.PatternP               as Pattern
+import           Unison.PrettyPrintEnv          (typecheckedPrefix)
 import           Unison.Reference               ( Reference )
 import           Unison.Referent                ( Referent )
 import           Unison.Term                    ( AnnotatedTerm' )
@@ -779,7 +780,12 @@ synthesize e = scope (InSynthesize e) $
     when top $ noteTopLevelType e binding t
     v' <- ABT.freshen e freshenVar
     -- note: `Ann' (Ref'  _) t` synthesizes to `t`
-    e  <- pure $ ABT.bindInheritAnnotation e (Term.ann () (Term.builtin() (Var.name v')) t)
+    -- The typechecked closed expression is treated as a new builtin for purposes
+    -- of typechecking the body of the let. The `typecheckedPrefix` can be
+    -- recognized by whatever prints out the builtin.
+    -- TODO: it would be better to just give the builtin constructor more
+    -- structure, so information like this could be stashed there
+    e  <- pure $ ABT.bindInheritAnnotation e (Term.ann () (Term.builtin() (typecheckedPrefix <> Var.name v')) t)
     synthesize e
   go (Term.Let1Top' top binding e) = do
     -- note: no need to freshen binding, it can't refer to v

--- a/unison-src/errors/weird-builtin-error.u
+++ b/unison-src/errors/weird-builtin-error.u
@@ -1,0 +1,7 @@
+
+t : x -> x -> x
+t a _ = a
+
+blah x y = t x y
+
+> blah 10 "hi"


### PR DESCRIPTION
I'd call this a not ideal fix, but still an improvement over what is happening now, which is #407.

The issue, #407 is caused by the fact that the typechecker treats "previously typechecked definitions" exactly the same as new builtins (as in, after obtaining a type for some binding, `foo`, it replaces all references to the var `foo` with a builtin, also called `foo`, which has the given type). The PrettyPrintEnv has no idea the typechecker does this so it just tries to print that builtin like any other.

All I did for the fix was give these "virtual builtins" a unique prefix, which the PrettyPrintEnv can detect and print differently. I'd consider this kind of ugly.

I think a more comprehensive fix would be to make the `Ref` constructor inside a Term be a more structured type than just `Reference`, or make it a type parameter of the `Term` rather than hardcoding `Reference` there. Then the typechecker could use a richer type there. All these options seemed like huge refactorings though.