### PR TITLE
Print custom error message in case of an empty watch expression

### DIFF
--- a/parser-typechecker/src/Unison/Parser.hs
+++ b/parser-typechecker/src/Unison/Parser.hs
@@ -42,6 +42,7 @@ data Error v
   | UnknownEffectConstructor (L.Token String)
   | UnknownDataConstructor (L.Token String)
   | ExpectedBlockOpen String (L.Token L.Lexeme)
+  | EmptyWatch
   deriving (Show, Eq, Ord)
 
 data Ann

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -962,6 +962,8 @@ prettyParseError s = \case
     , "but there wasn't one.  Maybe check your indentation:\n"
     , tokenAsErrorSite s tok
     ]
+  go (Parser.EmptyWatch) =
+    "I expected a non-empty watch expression and not just \">\""
   go (Parser.UnknownEffectConstructor tok) = unknownConstructor "effect" tok
   go (Parser.UnknownDataConstructor   tok) = unknownConstructor "data" tok
   unknownConstructor


### PR DESCRIPTION
c.f. #425

What's the best way to go about unit testing? Should I add to https://github.com/unisonweb/unison/blob/master/parser-typechecker/tests/Unison/Test/FileParser.hs ?