### PR TITLE
Escape annotation highlighting when enclosed with quotation marks

### DIFF
--- a/editor-support/atom/language-unison/grammars/unison.cson
+++ b/editor-support/atom/language-unison/grammars/unison.cson
@@ -31,7 +31,7 @@ repository:
     captures: {2: {name: 'keyword.control.unison'}}
   annotation:
     name: 'meta.function.type-declaration.unison'
-    match: '(\\S+)\\s*(:)(?=\\s)'
+    match: '([^\\r\\n\\t\\f\\v \"]+)\\s*(:)(?=\\s)'
     captures:
       1: {name: 'entity.name.function.unison' }
       2: {name: 'keyword.other.colon.unison' }


### PR DESCRIPTION
Otherwise this leads to:

![2019-04-06-18:50:25_1920x1080_scrot](https://user-images.githubusercontent.com/1737211/55672598-07792380-589d-11e9-9daa-607a926cf333.png)