### PR TITLE
Validating type declarations (ensure all types are resolved, no duplicate types)

### DIFF
--- a/parser-typechecker/src/Unison/FileParser.hs
+++ b/parser-typechecker/src/Unison/FileParser.hs
@@ -36,7 +36,9 @@ file = do
   _ <- openBlock
   names <- ask
   (dataDecls, effectDecls) <- declarations
-  let env = environmentFor names dataDecls effectDecls
+  env <- case environmentFor names dataDecls effectDecls of
+    Right env -> pure env
+    Left es -> P.customFailure $ TypeDeclarationErrors es
   -- push names onto the stack ahead of existing names
   local (UF.names env `mappend`) $ do
     names <- ask

--- a/parser-typechecker/src/Unison/FileParser.hs
+++ b/parser-typechecker/src/Unison/FileParser.hs
@@ -1,3 +1,4 @@
+{-# Language DoAndIfThenElse #-}
 {-# Language DeriveFunctor #-}
 {-# Language ScopedTypeVariables #-}
 
@@ -121,7 +122,19 @@ declarations = do
   declarations <- many $
     ((Left <$> dataDeclaration) <|> Right <$> effectDeclaration) <* optional semi
   let (dataDecls, effectDecls) = partitionEithers declarations
-  pure (Map.fromList dataDecls, Map.fromList effectDecls)
+      multimap :: Ord k => [(k,v)] -> Map k [v]
+      multimap kvs = foldl' mi Map.empty kvs
+      mi m (k,v) = Map.insertWith (++) k [v] m
+      mds = multimap dataDecls
+      mes = multimap effectDecls
+      mdsBad = Map.filter (\xs -> length xs /= 1) mds
+      mesBad = Map.filter (\xs -> length xs /= 1) mes
+  if Map.null mdsBad && Map.null mesBad then
+    pure (Map.fromList dataDecls, Map.fromList effectDecls)
+  else
+    P.customFailure . DuplicateTypeNames $
+      [ (v, DD.annotation <$> ds) | (v, ds) <- Map.toList mdsBad ] <>
+      [ (v, DD.annotation . DD.toDataDecl <$> es) | (v, es) <- Map.toList mesBad ]
 
 -- type Optional a = Some a | None
 --                   a -> Optional a
@@ -145,7 +158,8 @@ dataDeclaration = do
         -- ctorType e.g. `a -> Optional a`
         --    or just `Optional a` in the case of `None`
         ctorType = foldr arrow ctorReturnType ctorArgs
-        ctorAnn = ann ctorName <> ann (last ctorArgs)
+        ctorAnn = ann ctorName <>
+                  (if null ctorArgs then mempty else ann (last ctorArgs))
         in (ann ctorName, Var.namespaced [L.payload name, L.payload ctorName],
             Type.foralls ctorAnn typeArgVs ctorType)
       dataConstructor = go <$> prefixVar <*> many TypeParser.valueTypeLeaf

--- a/parser-typechecker/src/Unison/Parser.hs
+++ b/parser-typechecker/src/Unison/Parser.hs
@@ -25,6 +25,7 @@ import qualified Unison.PatternP      as Pattern
 import           Unison.Term          (MatchCase (..))
 import           Unison.Var           (Var)
 import qualified Unison.Var           as Var
+import qualified Unison.UnisonFile    as UF
 import Unison.Names (Names)
 
 debug :: Bool
@@ -42,6 +43,7 @@ data Error v
   | ExpectedBlockOpen String (L.Token L.Lexeme)
   | EmptyWatch
   | DidntExpectExpression (L.Token L.Lexeme) (Maybe (L.Token L.Lexeme))
+  | TypeDeclarationErrors [UF.Error v Ann]
   deriving (Show, Eq, Ord)
 
 data Ann

--- a/parser-typechecker/src/Unison/Parser.hs
+++ b/parser-typechecker/src/Unison/Parser.hs
@@ -44,6 +44,7 @@ data Error v
   | EmptyWatch
   | DidntExpectExpression (L.Token L.Lexeme) (Maybe (L.Token L.Lexeme))
   | TypeDeclarationErrors [UF.Error v Ann]
+  | DuplicateTypeNames [(v, [Ann])]
   deriving (Show, Eq, Ord)
 
 data Ann

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -964,7 +964,7 @@ prettyParseError s = \case
     dupDataAndAbilities = [ (v, a, a2) | UF.DupDataAndAbility v a a2 <- es ]
     unknownTypesMsg =
       mconcat [ "I don't know about the type(s) "
-              , intercalateMap "," errorVar (nubOrd $ fst <$> unknownTypes)
+              , intercalateMap ", " errorVar (nubOrd $ fst <$> unknownTypes)
               , ":\n\n"
               , annotatedsAsStyle ErrorSite s (snd <$> unknownTypes)
               ]

--- a/parser-typechecker/src/Unison/Typechecker/TypeError.hs
+++ b/parser-typechecker/src/Unison/Typechecker/TypeError.hs
@@ -213,7 +213,7 @@ existentialMismatch0 em getExpectedLoc = do
   let mismatchLoc = ABT.annotation mismatchSite
   ([foundType, expectedType], expectedLoc) <- Ex.unique $ do
     Ex.pathStart
-    subtypes <- Ex.some Ex.inSubtype
+    subtypes@(_:_) <- Ex.some Ex.inSubtype
     let (foundType, expectedType) = last subtypes
     void $ Ex.some Ex.inCheck
     expectedLoc <- getExpectedLoc

--- a/parser-typechecker/src/Unison/Util/Range.hs
+++ b/parser-typechecker/src/Unison/Util/Range.hs
@@ -17,6 +17,11 @@ isMultiLine (Range (Pos startLine _) (Pos endLine _)) = startLine < endLine
 
 data Range = Range { start :: Pos, end :: Pos } deriving (Eq, Ord, Show)
 
+startingLine :: Range -> Range
+startingLine r@(Range start@(Pos startLine _) (Pos stopLine _)) =
+  if stopLine == startLine then r
+  else Range start (Pos (startLine+1) 0)
+
 instance Semigroup Range where
   (Range start end) <> (Range start2 end2) =
     Range (min start start2) (max end end2)


### PR DESCRIPTION
Fixes #329 and Fixes #344 

The `environmentFor` function in `UnisonFile` is where the logic for detecting these cases is. That would also be a good spot to do kind checking and/or other validation of type declarations.
 
Here's a couple screenshots:

<img width="768" alt="Screen Shot 2019-04-30 at 12 12 23 AM" src="https://user-images.githubusercontent.com/11074/56940564-56e9f280-6add-11e9-90f6-0d77de116152.png">

<img width="783" alt="Screen Shot 2019-04-30 at 12 12 48 AM" src="https://user-images.githubusercontent.com/11074/56940565-56e9f280-6add-11e9-8f10-121c6318418e.png">

<img width="865" alt="Screen Shot 2019-04-30 at 12 14 25 AM" src="https://user-images.githubusercontent.com/11074/56940567-56e9f280-6add-11e9-8f28-d44cda6e9355.png">
