### PR TITLE
Fill out Int.truncate0 and add Nat.toInt

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -199,6 +199,7 @@ builtins0 = Map.fromList $
       , ("Nat.increment", "Nat -> Nat")
       , ("Nat.isEven", "Nat -> Boolean")
       , ("Nat.isOdd", "Nat -> Boolean")
+      , ("Nat.toInt", "Nat -> Int")
 
       , ("Float.+", "Float -> Float -> Float")
       , ("Float.-", "Float -> Float -> Float")

--- a/parser-typechecker/src/Unison/Runtime/IR.hs
+++ b/parser-typechecker/src/Unison/Runtime/IR.hs
@@ -209,7 +209,7 @@ data IR' ann z
   -- Ints
   | AddI z z | SubI z z | MultI z z | DivI z z
   | GtI z z | LtI z z | GtEqI z z | LtEqI z z | EqI z z
-  | SignumI z | NegateI z | ModI z z
+  | SignumI z | NegateI z | Truncate0I z | ModI z z
   -- Nats
   | AddN z z | DropN z z | SubN z z | MultN z z | DivN z z
   | GtN z z | LtN z z | GtEqN z z | LtEqN z z | EqN z z
@@ -273,6 +273,7 @@ prettyIR ppe prettyE prettyCont ir = pir ir
     EqI a b -> P.parenthesize $ "EqI" `P.hang` P.spaced [pz a, pz b]
     SignumI a -> P.parenthesize $ "SignumI" `P.hang` P.spaced [pz a]
     NegateI a -> P.parenthesize $ "NegateI" `P.hang` P.spaced [pz a]
+    Truncate0I a -> P.parenthesize $ "Truncate0I" `P.hang` P.spaced [pz a]
     ModI a b -> P.parenthesize $ "ModI" `P.hang` P.spaced [pz a, pz b]
 
     AddN a b -> P.parenthesize $ "AddN" `P.hang` P.spaced [pz a, pz b]
@@ -649,6 +650,7 @@ boundVarsIR = \case
   EqI _ _ -> mempty
   SignumI _ -> mempty
   NegateI _ -> mempty
+  Truncate0I _ -> mempty
   ModI _ _ -> mempty
   AddN _ _ -> mempty
   DropN _ _ -> mempty
@@ -697,6 +699,7 @@ decompileIR stack = \case
   EqI x y -> builtin "Int.==" [x,y]
   SignumI x -> builtin "Int.signum" [x]
   NegateI x -> builtin "Int.negate" [x]
+  Truncate0I x -> builtin "Int.truncate0" [x]
   ModI x y -> builtin "Int.mod" [x,y]
   AddN x y -> builtin "Nat.+" [x,y]
   DropN x y -> builtin "Nat.drop" [x,y]
@@ -858,6 +861,7 @@ builtins = Map.fromList $ arity0 <> arityN
         , ("Int.increment", 1, AddI (Val (I 1)) (Slot 0))
         , ("Int.signum", 1, SignumI (Slot 0))
         , ("Int.negate", 1, NegateI (Slot 0))
+        , ("Int.truncate0", 1, Truncate0I (Slot 0))
         , ("Int.mod", 2, ModI (Slot 1) (Slot 0))
         , ("Int.isEven", 1, let' var (ModI (Slot 0) (Val (I 2)))
                                      (EqI (Val (I 0)) (Slot 0)))

--- a/parser-typechecker/src/Unison/Runtime/IR.hs
+++ b/parser-typechecker/src/Unison/Runtime/IR.hs
@@ -213,7 +213,7 @@ data IR' ann z
   -- Nats
   | AddN z z | DropN z z | SubN z z | MultN z z | DivN z z
   | GtN z z | LtN z z | GtEqN z z | LtEqN z z | EqN z z
-  | ModN z z
+  | ModN z z | ToIntN z
   -- Floats
   | AddF z z | SubF z z | MultF z z | DivF z z
   | GtF z z | LtF z z | GtEqF z z | LtEqF z z | EqF z z
@@ -287,6 +287,7 @@ prettyIR ppe prettyE prettyCont ir = pir ir
     LtEqN a b -> P.parenthesize $ "LtEqN" `P.hang` P.spaced [pz a, pz b]
     EqN a b -> P.parenthesize $ "EqN" `P.hang` P.spaced [pz a, pz b]
     ModN a b -> P.parenthesize $ "ModN" `P.hang` P.spaced [pz a, pz b]
+    ToIntN a -> P.parenthesize $ "ToIntN" `P.hang` P.spaced [pz a]
 
     AddF a b -> P.parenthesize $ "AddF" `P.hang` P.spaced [pz a, pz b]
     SubF a b -> P.parenthesize $ "SubF" `P.hang` P.spaced [pz a, pz b]
@@ -663,6 +664,7 @@ boundVarsIR = \case
   LtEqN _ _ -> mempty
   EqN _ _ -> mempty
   ModN _ _ -> mempty
+  ToIntN _ -> mempty
   AddF _ _ -> mempty
   SubF _ _ -> mempty
   MultF _ _ -> mempty
@@ -712,6 +714,7 @@ decompileIR stack = \case
   LtEqN x y -> builtin "Nat.<=" [x,y]
   EqN x y -> builtin "Nat.==" [x,y]
   ModN x y -> builtin "Nat.mod" [x,y]
+  ToIntN x -> builtin "Nat.toInt" [x]
   AddF x y -> builtin "Float.+" [x,y]
   SubF x y -> builtin "Float.-" [x,y]
   MultF x y -> builtin "Float.*" [x,y]
@@ -886,6 +889,7 @@ builtins = Map.fromList $ arity0 <> arityN
         , ("Nat.isOdd", 1, let' var (ModN (Slot 0) (Val (N 2)))
                                     (let' var (EqN (Val (N 0)) (Slot 0))
                                               (Not (Slot 0))))
+        , ("Nat.toInt", 1, ToIntN (Slot 0))
 
         , ("Float.+", 2, AddF (Slot 1) (Slot 0))
         , ("Float.-", 2, SubF (Slot 1) (Slot 0))

--- a/parser-typechecker/src/Unison/Runtime/Rt1.hs
+++ b/parser-typechecker/src/Unison/Runtime/Rt1.hs
@@ -463,6 +463,7 @@ run ioHandler env ir = do
       EqI i j -> do x <- ati size i m; y <- ati size j m; done (B (x == y))
       SignumI i -> do x <- ati size i m; done (I (signum x))
       NegateI i -> do x <- ati size i m; done (I (negate x))
+      Truncate0I i -> do x <- ati size i m; done (I (truncate0 x))
       ModI i j -> do x <- ati size i m; y <- ati size j m; done (I (x `mod` y))
 
       AddN i j -> do x <- atn size i m; y <- atn size j m; done (N (x + y))
@@ -789,3 +790,6 @@ continuationConstructorId k = case k of
   One _ _ _ _ -> 0
   Chain _ _ _ -> 1
   WrapHandler _ _ -> 2
+
+truncate0 :: (Num a, Ord a) => a -> a
+truncate0 x = if x >= 0 then x else 0

--- a/parser-typechecker/src/Unison/Runtime/Rt1.hs
+++ b/parser-typechecker/src/Unison/Runtime/Rt1.hs
@@ -463,7 +463,7 @@ run ioHandler env ir = do
       EqI i j -> do x <- ati size i m; y <- ati size j m; done (B (x == y))
       SignumI i -> do x <- ati size i m; done (I (signum x))
       NegateI i -> do x <- ati size i m; done (I (negate x))
-      Truncate0I i -> do x <- ati size i m; done (I (truncate0 x))
+      Truncate0I i -> do x <- ati size i m; done (N (fromIntegral (truncate0 x)))
       ModI i j -> do x <- ati size i m; y <- ati size j m; done (I (x `mod` y))
 
       AddN i j -> do x <- atn size i m; y <- atn size j m; done (N (x + y))
@@ -476,6 +476,7 @@ run ioHandler env ir = do
       MultN i j -> do x <- atn size i m; y <- atn size j m; done (N (x * y))
       DivN i j -> do x <- atn size i m; y <- atn size j m; done (N (x `div` y))
       ModN i j -> do x <- atn size i m; y <- atn size j m; done (N (x `mod` y))
+      ToIntN i -> do x <- atn size i m; done (I (fromIntegral x))
       GtN i j -> do x <- atn size i m; y <- atn size j m; done (B (x > y))
       GtEqN i j -> do x <- atn size i m; y <- atn size j m; done (B (x >= y))
       LtN i j -> do x <- atn size i m; y <- atn size j m; done (B (x < y))


### PR DESCRIPTION
Wanted to fill out `Int.truncate0 : Int -> Nat` since the missing implementation for it was stopping me implement my `replicate : Nat -> Text -> text`.

Paul helped, and asked for `Nat.toInt : Nat -> Int`, to go in the other direction.

Don't forget `builtins.update` if you want to try it out.

Both tested one-off using watch expressions - no regression tests added.