### PR TITLE
unique types

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -21,7 +21,6 @@ import           Unison.DataDeclaration         ( DataDeclaration'
                                                 , EffectDeclaration'
                                                 )
 import qualified Unison.DataDeclaration        as DD
-import qualified Unison.FileParser             as FileParser
 import qualified Unison.Lexer                  as L
 import           Unison.Parser                  ( Ann(..) )
 import qualified Unison.Parser                 as Parser
@@ -72,14 +71,6 @@ constructorType r =
   else if any f (builtinEffectDecls @Symbol) then CT.Effect
   else error "a builtin term referenced a constructor for a non-builtin type"
   where f = (==r) . fst . snd
-
--- todo: does this need to be refactored if we have mutually recursive decls
-parseDataDeclAsBuiltin :: Var v => String -> (v, (R.Reference, DataDeclaration v))
-parseDataDeclAsBuiltin s =
-  let (v, dd) = either (error . showParseError s) id $
-        Parser.run (Parser.root FileParser.dataDeclaration) s mempty
-      [(_, r, dd')] = DD.hashDecls $ Map.singleton v (DD.bindBuiltins names0 dd)
-  in (v, (r, const Intrinsic <$> dd'))
 
 -- Todo: These definitions and groupings of builtins are getting a little
 -- confusing.  Sort out these labrinthine definitions!

--- a/parser-typechecker/src/Unison/Codebase/Editor.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor.hs
@@ -698,7 +698,7 @@ commandLine awaitInput rt notifyUser codebase command = do
       fileToBranch handler codebase branch unisonFile
     Typecheck ambient branch sourceName source -> do
       -- todo: if guids are being shown to users, not ideal to generate new guid every time
-      namegen <- Parser.uniqueBase58Namegen 8
+      namegen <- Parser.uniqueBase58Namegen
       typecheck ambient codebase (namegen, Branch.toNames branch) sourceName source
     Evaluate ppe unisonFile           -> evalUnisonFile ppe unisonFile
     ListBranches                      -> Codebase.branches codebase

--- a/parser-typechecker/src/Unison/Codebase/Serialization/V0.hs
+++ b/parser-typechecker/src/Unison/Codebase/Serialization/V0.hs
@@ -539,15 +539,27 @@ putDataDeclaration :: (MonadPut m, Ord v)
                    -> DataDeclaration' v a
                    -> m ()
 putDataDeclaration putV putA decl = do
-  putA $ DataDeclaration.annotation decl
+  putModifier (DataDeclaration.modifier decl)
+  putA (DataDeclaration.annotation decl)
   putFoldable (DataDeclaration.bound decl) putV
   putFoldable (DataDeclaration.constructors' decl) (putTuple3' putA putV (putType putV putA))
 
 getDataDeclaration :: (MonadGet m, Ord v) => m v -> m a -> m (DataDeclaration' v a)
 getDataDeclaration getV getA = DataDeclaration.DataDeclaration <$>
+  getModifier <*>
   getA <*>
   getList getV <*>
   getList (getTuple3 getA getV (getType getV getA))
+
+putModifier :: MonadPut m => DataDeclaration.Modifier -> m ()
+putModifier DataDeclaration.Structural   = putWord8 0
+putModifier (DataDeclaration.Unique txt) = putWord8 1 *> putText txt
+
+getModifier :: MonadGet m => m DataDeclaration.Modifier
+getModifier = getWord8 >>= \case
+  0 -> pure DataDeclaration.Structural
+  1 -> DataDeclaration.Unique <$> getText
+  tag -> unknownTag "DataDeclaration.Modifier" tag
 
 putEffectDeclaration ::
   (MonadPut m, Ord v) => (v -> m ()) -> (a -> m ()) -> EffectDeclaration' v a -> m ()

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -215,19 +215,17 @@ notifyUser dir o = case o of
     -- Console.clearScreen
     -- Console.setCursorPosition 0 0
   Typechecked sourceName ppe uf -> do
-    Console.setTitle "Unison ☺︎"
+    Console.setTitle "Unison ✅"
     let terms = sortOn fst [ (HQ.fromVar v, typ) | (v, _, typ) <- join $ UF.topLevelComponents uf ]
         typeDecls =
           [ (HQ.fromVar v, Left e)  | (v, (_,e)) <- Map.toList (UF.effectDeclarations' uf) ] ++
           [ (HQ.fromVar v, Right d) | (v, (_,d)) <- Map.toList (UF.dataDeclarations' uf) ]
-    if UF.nonEmpty uf then putPrettyLn' . ("\n" <>) . P.okCallout . P.nonEmpty $ [
+    if UF.nonEmpty uf then putPrettyLn' . ("\n" <>) . P.okCallout . P.sep "\n\n" $ [
       P.wrap $ "I found and" <> P.bold "typechecked" <> "these definitions in "
-             <> P.group (P.text sourceName <> ":"),
-      "",
-      P.lines $
-        (uncurry DeclPrinter.prettyDeclHeader <$> typeDecls) ++
-        TypePrinter.prettySignatures' ppe terms,
-      "",
+            <> P.group (P.text sourceName <> ":"),
+      P.indentN 2 . P.sepNonEmpty "\n\n" $ [
+        P.lines (fmap (uncurry DeclPrinter.prettyDeclHeader) typeDecls),
+        P.lines (TypePrinter.prettySignatures' ppe terms) ],
       P.wrap "Now evaluating any watch expressions (lines starting with `>`)..." ]
     else when (null $ UF.watchComponents uf) $ putPrettyLn' . P.wrap $
       "I loaded " <> P.text sourceName <> " and didn't find anything."

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -450,11 +450,11 @@ prettyDeclTriple ::
   (HQ.HashQualified, Reference.Reference, DisplayThing (TL.Decl v a))
   -> P.Pretty P.ColorText
 prettyDeclTriple (name, _, displayDecl) = case displayDecl of
-   BuiltinThing -> P.wrap $ DeclPrinter.prettyDataHeader name <> "(built-in)"
+   BuiltinThing -> P.bold "builtin type " <> prettyHashQualified name
    MissingThing _ -> mempty -- these need to be handled elsewhere
    RegularThing decl -> case decl of
-     Left _ability -> DeclPrinter.prettyEffectHeader name
-     Right _data   -> DeclPrinter.prettyDataHeader name
+     Left ed -> DeclPrinter.prettyEffectHeader name ed
+     Right dd   -> DeclPrinter.prettyDataHeader name dd
 
 renderNameConflicts :: Set.Set Name -> Set.Set Name -> P.Pretty CT.ColorText
 renderNameConflicts conflictedTypeNames conflictedTermNames =
@@ -622,8 +622,8 @@ slurpOutput s =
     | v <- toList vs
     , t <- maybe (error $ "There wasn't a type for " ++ show v ++ " in termTypesFromFile!") pure (Map.lookup v termTypesFromFile)]
   prettyDeclHeader v = case UF.getDecl' file v of
-    Just (Left _)  -> DeclPrinter.prettyEffectHeader (HQ.fromVar v)
-    Just (Right _) -> DeclPrinter.prettyDataHeader (HQ.fromVar v)
+    Just (Left e)  -> DeclPrinter.prettyEffectHeader (HQ.fromVar v) e
+    Just (Right e) -> DeclPrinter.prettyDataHeader (HQ.fromVar v) e
     Nothing        -> error "Wat."
   addedMsg =
     unlessM (null addedTypes && null addedTerms) . P.okCallout $

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -452,7 +452,7 @@ prettyDeclTriple ::
   (HQ.HashQualified, Reference.Reference, DisplayThing (TL.Decl v a))
   -> P.Pretty P.ColorText
 prettyDeclTriple (name, _, displayDecl) = case displayDecl of
-   BuiltinThing -> P.bold "builtin type " <> prettyHashQualified name
+   BuiltinThing -> P.hiBlack "builtin " <>  P.blue "type " <> P.blue (prettyHashQualified name)
    MissingThing _ -> mempty -- these need to be handled elsewhere
    RegularThing decl -> case decl of
      Left ed -> DeclPrinter.prettyEffectHeader name ed

--- a/parser-typechecker/src/Unison/DeclPrinter.hs
+++ b/parser-typechecker/src/Unison/DeclPrinter.hs
@@ -84,8 +84,8 @@ prettyDataDecl env r name dd =
 
 prettyModifier :: DD.Modifier -> Pretty ColorText
 prettyModifier DD.Structural = mempty
-prettyModifier (DD.Unique uid) =
-  P.bold "unique" <> P.hiBlack ("[" <> P.text uid <> "] ")
+prettyModifier (DD.Unique _uid) =
+  P.bold "unique " -- <> P.hiBlack ("[" <> P.text uid <> "] ")
 
 prettyDataHeader :: HashQualified -> DD.DataDeclaration' v a -> Pretty ColorText
 prettyDataHeader name dd =
@@ -94,3 +94,7 @@ prettyDataHeader name dd =
 prettyEffectHeader :: HashQualified -> DD.EffectDeclaration' v a -> Pretty ColorText
 prettyEffectHeader name ed =
   prettyModifier (DD.modifier (DD.toDataDecl ed)) <> P.bold "ability " <> prettyHashQualified name
+
+prettyDeclHeader :: HashQualified -> Either (DD.EffectDeclaration' v a) (DD.DataDeclaration' v a) -> Pretty ColorText
+prettyDeclHeader name (Left e) = prettyEffectHeader name e
+prettyDeclHeader name (Right d) = prettyDataHeader name d

--- a/parser-typechecker/src/Unison/DeclPrinter.hs
+++ b/parser-typechecker/src/Unison/DeclPrinter.hs
@@ -85,15 +85,15 @@ prettyDataDecl env r name dd =
 prettyModifier :: DD.Modifier -> Pretty ColorText
 prettyModifier DD.Structural = mempty
 prettyModifier (DD.Unique _uid) =
-  P.bold "unique " -- <> P.hiBlack ("[" <> P.text uid <> "] ")
+  P.hiBlack "unique " -- <> P.hiBlack ("[" <> P.text uid <> "] ")
 
 prettyDataHeader :: HashQualified -> DD.DataDeclaration' v a -> Pretty ColorText
 prettyDataHeader name dd =
-  prettyModifier (DD.modifier dd) <> P.bold "type " <> prettyHashQualified name
+  prettyModifier (DD.modifier dd) <> P.blue "type " <> P.blue (prettyHashQualified name)
 
 prettyEffectHeader :: HashQualified -> DD.EffectDeclaration' v a -> Pretty ColorText
 prettyEffectHeader name ed =
-  prettyModifier (DD.modifier (DD.toDataDecl ed)) <> P.bold "ability " <> prettyHashQualified name
+  prettyModifier (DD.modifier (DD.toDataDecl ed)) <> P.blue "ability " <> P.blue (prettyHashQualified name)
 
 prettyDeclHeader :: HashQualified -> Either (DD.EffectDeclaration' v a) (DD.DataDeclaration' v a) -> Pretty ColorText
 prettyDeclHeader name (Left e) = prettyEffectHeader name e

--- a/parser-typechecker/src/Unison/DeclPrinter.hs
+++ b/parser-typechecker/src/Unison/DeclPrinter.hs
@@ -50,7 +50,7 @@ prettyGADT env r name dd = P.hang header . P.lines $ constructor <$> zip
       <>       " :"
       `P.hang` TypePrinter.pretty env (-1) t
   header =
-    P.sep " " (prettyEffectHeader name : (P.text . Var.name <$> DD.bound dd))
+    P.sep " " (prettyEffectHeader name (DD.EffectDeclaration dd) : (P.text . Var.name <$> DD.bound dd))
       <> " where"
 
 prettyPattern
@@ -79,11 +79,18 @@ prettyDataDecl env r name dd =
     Just ts -> P.group . P.hang' (prettyPattern env r name n) "      "
              $ P.spaced (TypePrinter.pretty env 10 <$> init ts)
   header =
-    P.sep " " (prettyDataHeader name : (P.text . Var.name <$> DD.bound dd))
+    P.sep " " (prettyDataHeader name dd : (P.text . Var.name <$> DD.bound dd))
       <> (" = " `P.orElse` "\n  = ")
 
-prettyDataHeader :: HashQualified -> Pretty ColorText
-prettyDataHeader name = P.bold "type " <> prettyHashQualified name
+prettyModifier :: DD.Modifier -> Pretty ColorText
+prettyModifier DD.Structural = mempty
+prettyModifier (DD.Unique uid) =
+  P.bold "unique" <> P.hiBlack ("[" <> P.text uid <> "] ")
 
-prettyEffectHeader :: HashQualified -> Pretty ColorText
-prettyEffectHeader name = P.bold "ability " <> prettyHashQualified name
+prettyDataHeader :: HashQualified -> DD.DataDeclaration' v a -> Pretty ColorText
+prettyDataHeader name dd =
+  prettyModifier (DD.modifier dd) <> P.bold "type " <> prettyHashQualified name
+
+prettyEffectHeader :: HashQualified -> DD.EffectDeclaration' v a -> Pretty ColorText
+prettyEffectHeader name ed =
+  prettyModifier (DD.modifier (DD.toDataDecl ed)) <> P.bold "ability " <> prettyHashQualified name

--- a/parser-typechecker/src/Unison/Parser.hs
+++ b/parser-typechecker/src/Unison/Parser.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies      #-}
 {-# LANGUAGE ViewPatterns      #-}
+{-# LANGUAGE DoAndIfThenElse   #-}
 
 module Unison.Parser where
 
@@ -10,6 +11,7 @@ import           Data.Bytes.VarInt              ( VarInt(..) )
 import           Control.Applicative
 import           Control.Monad        (join, when)
 import           Data.Bifunctor       (bimap)
+import qualified Data.Char            as Char
 import           Data.List.NonEmpty   (NonEmpty (..))
 import           Data.Maybe
 import qualified Data.Set             as Set
@@ -43,31 +45,37 @@ type P v = P.ParsecT (Error v) Input ((->) (UniqueName, Names))
 type Token s = P.Token s
 type Err v = P.ParseError (Token Input) (Error v)
 
-newtype UniqueName = UniqueName (L.Pos -> Maybe Text)
+newtype UniqueName = UniqueName (L.Pos -> Int -> Maybe Text)
 
 instance Semigroup UniqueName where (<>) = mappend
 instance Monoid UniqueName where
-  mempty = UniqueName (const Nothing)
+  mempty = UniqueName (\_ _ -> Nothing)
   mappend (UniqueName f) (UniqueName g) =
-    UniqueName $ \pos -> f pos <|> g pos
+    UniqueName $ \pos len -> f pos len <|> g pos len
 
-uniqueBase58Namegen :: Int -> IO UniqueName
-uniqueBase58Namegen lenInBase58 = do
+uniqueBase58Namegen :: IO UniqueName
+uniqueBase58Namegen = do
   rng <- Random.getSystemDRG
-  pure . UniqueName $ \pos -> let
-    (bytes,_) = Random.randomBytesGenerate 32 rng
+  pure . UniqueName $ \pos lenInBase58 -> go pos lenInBase58 rng
+  where
+  -- if the identifier starts with a number, try again, since
+  -- we want the name to work as a valid wordyId
+  go pos lenInBase58 rng0 = let
+    (bytes,rng) = Random.randomBytesGenerate 32 rng0
     posBytes = runPutS $ do
       serialize $ VarInt (L.line pos)
       serialize $ VarInt (L.column pos)
     h = Hashable.accumulate' $ bytes <> posBytes
-    in Just . ("z" <>) . Text.take lenInBase58 . Hash.base58 $ h
+    b58 = Hash.base58 h
+    in if Char.isDigit (Text.head b58) then go pos lenInBase58 rng
+       else Just . Text.take lenInBase58 $ b58
 
-uniqueName :: Var v => P v Text
-uniqueName = do
+uniqueName :: Var v => Int -> P v Text
+uniqueName lenInBase58 = do
   (UniqueName mkName, _) <- ask
   pos <- L.start <$> P.lookAhead anyToken
   let none = Hash.base58 . Hash.fromBytes . encodeUtf8 . Text.pack $ show pos
-  pure . fromMaybe none $ mkName pos
+  pure . fromMaybe none $ mkName pos lenInBase58
 
 data Error v
   = SignatureNeedsAccompanyingBody (L.Token v)
@@ -267,6 +275,12 @@ wordyId :: Var v => P v (L.Token String)
 wordyId = queryToken getWordy
   where getWordy (L.WordyId s) = Just s
         getWordy _             = Nothing
+
+-- Parse a specific wordy id
+exactWordyId :: Var v => String -> P v (L.Token String)
+exactWordyId target = queryToken getWordy
+  where getWordy (L.WordyId s) | s == target = Just s
+        getWordy _                           = Nothing
 
 -- Parse a symboly ID like >>= or &&
 symbolyId :: Var v => P v (L.Token String)

--- a/parser-typechecker/src/Unison/UnisonFile.hs
+++ b/parser-typechecker/src/Unison/UnisonFile.hs
@@ -163,6 +163,14 @@ toNames (UnisonFile {..}) = datas <> effects
 typecheckedUnisonFile0 :: TypecheckedUnisonFile v a
 typecheckedUnisonFile0 = TypecheckedUnisonFile Map.empty Map.empty mempty mempty
 
+-- Returns true if the file has any definitions or watches
+nonEmpty :: TypecheckedUnisonFile v a -> Bool
+nonEmpty uf =
+  not (Map.null (dataDeclarations' uf)) ||
+  not (Map.null (effectDeclarations' uf)) ||
+  any (not . null) (topLevelComponents' uf) ||
+  any (not . null) (watchComponents uf)
+
 hashConstructors
   :: forall v a. Var v => TypecheckedUnisonFile v a -> Map v Referent
 hashConstructors file =

--- a/parser-typechecker/src/Unison/Util/Pretty.hs
+++ b/parser-typechecker/src/Unison/Util/Pretty.hs
@@ -50,6 +50,7 @@ module Unison.Util.Pretty (
    renderUnbroken,
    rightPad,
    sep,
+   sepNonEmpty,
    sepSpaced,
    shown,
    softbreak,
@@ -245,6 +246,9 @@ sepSpaced between = sep (between <> softbreak)
 
 sep :: (Foldable f, IsString s) => Pretty s -> f (Pretty s) -> Pretty s
 sep between = intercalateMap between id
+
+sepNonEmpty :: (Foldable f, IsString s) => Pretty s -> f (Pretty s) -> Pretty s
+sepNonEmpty between ps = sep between (nonEmpty ps)
 
 nonEmpty :: (Foldable f, IsString s) => f (Pretty s) -> [Pretty s]
 nonEmpty (toList -> l) = case l of

--- a/parser-typechecker/tests/Unison/Test/FileParser.hs
+++ b/parser-typechecker/tests/Unison/Test/FileParser.hs
@@ -39,7 +39,7 @@ module Unison.Test.FileParser where
     ------ --   ,"  Just : a -> Optional a"
     ------ --   ,"  Nothing : Optional Int"]
     , unlines -- NB: this currently fails because we don't have type AST or parser for effect types yet
-      ["effect State s where"
+      ["ability State s where"
       ,"  get : {State s} s"
       ,"  set : s -> {State s} ()"
       ]

--- a/unison-src/errors/abort-ability-checks-against-pure.u
+++ b/unison-src/errors/abort-ability-checks-against-pure.u
@@ -1,5 +1,5 @@
 --Abort
-effect Abort where
+ability Abort where
   Abort : forall a . () -> {Abort} a
 
 bork = u -> 1 + (Abort.Abort ())

--- a/unison-src/errors/all-errors.u
+++ b/unison-src/errors/all-errors.u
@@ -1,9 +1,9 @@
 type Optional a = Some a | None
 
-effect Abort where
+ability Abort where
   Abort : forall a . () -> {Abort} a
 
-effect Abort2 where
+ability Abort2 where
   Abort2  : forall a . () -> {Abort2} a
   Abort2' : forall a . () -> {Abort2} a
 
@@ -16,8 +16,8 @@ app' = 3
 arrow : Int -> Int -> Int
 arrow a = 3
 
-effect' : Nat -> { Abort } Int
-effect' n = Abort2.Abort2 ()
+ability' : Nat -> { Abort } Int
+ability' n = Abort2.Abort2 ()
 
 id : forall a . a -> a
 id x = 3

--- a/unison-src/errors/console.u
+++ b/unison-src/errors/console.u
@@ -1,8 +1,8 @@
-effect State s where
+ability State s where
   get : Nat -> {State s} s
   set : s -> {State s} ()
 
-effect Console where
+ability Console where
   read : () -> {Console} (Optional Text)
   write : Text -> {Console} ()
 

--- a/unison-src/errors/console2.u
+++ b/unison-src/errors/console2.u
@@ -1,8 +1,8 @@
-effect State s where
+ability State s where
   get : {State s} s
   set : s -> {State s} ()
 
-effect Console where
+ability Console where
   read : {Console} (Optional Text)
   write : Text -> {Console} ()
 

--- a/unison-src/errors/effect-inference1.u
+++ b/unison-src/errors/effect-inference1.u
@@ -1,4 +1,4 @@
-effect Abort where
+ability Abort where
   Abort : forall a . () -> {Abort} a
 
 foo n = if n >= 1000 then n else !Abort.Abort
@@ -9,4 +9,4 @@ bar f i = f i
 bar foo 3
 
 -- as of 3935b366383fe8184f96cfe714c31ca04234cf27, this typechecks (unexpected)
--- and then bombs in the runtime because the Abort effect isn't handled.
+-- and then bombs in the runtime because the Abort ability isn't handled.

--- a/unison-src/errors/effect_unknown_type.uu
+++ b/unison-src/errors/effect_unknown_type.uu
@@ -15,6 +15,6 @@ CallStack (from HasCallStack):
 -- Typechecker emits a helpful error about b's use of an unknown type, but not a's.
 --
 -- Error for b:
---   typechecker.tests/effect_unknown_type.u FAILURE I don't know about the type Unknown.  Make sure it's imported and spelled correctly:
+--   typechecker.tests/ability_unknown_type.u FAILURE I don't know about the type Unknown.  Make sure it's imported and spelled correctly:
 --
 --   22 | b : Unknown

--- a/unison-src/errors/handle-inference.u
+++ b/unison-src/errors/handle-inference.u
@@ -1,5 +1,5 @@
 --handle inference
-effect State s where
+ability State s where
   get : ∀ s . () -> {State s} s
   set : ∀ s . s -> {State s} ()
 state : ∀ a s . s -> Effect (State s) a -> a

--- a/unison-src/errors/handler-coverage-checking.uu
+++ b/unison-src/errors/handler-coverage-checking.uu
@@ -1,5 +1,5 @@
---State3 effect
-effect State se2 where
+--State3 ability
+ability State se2 where
   put : ∀ se . se -> {State se} ()
   get : ∀ se . () -> {State se} se
 

--- a/unison-src/errors/io-effect.u
+++ b/unison-src/errors/io-effect.u
@@ -1,5 +1,5 @@
---IO effect
-effect IO where
+--IO ability
+ability IO where
   launchMissiles : () -> {IO} ()
 -- binding is not guarded by a lambda, it only can access
 -- ambient abilities (which will be empty)

--- a/unison-src/errors/io-state1.u
+++ b/unison-src/errors/io-state1.u
@@ -1,7 +1,7 @@
---IO/State1 effect
-effect IO where
+--IO/State1 ability
+ability IO where
   launchMissiles : {IO} ()
-effect State se2 where
+ability State se2 where
   put : ∀ se . se -> {State se} ()
   get : ∀ se . () -> {State se} se
 foo : () -> {IO} ()

--- a/unison-src/errors/map-reduce.u
+++ b/unison-src/errors/map-reduce.u
@@ -1,6 +1,6 @@
 
--- A simple distributed computation effect
-effect Remote n where
+-- A simple distributed computation ability
+ability Remote n where
 
   -- Spawn a new node, of type `n`
   spawn : {Remote n} n

--- a/unison-src/errors/map-traverse3.u
+++ b/unison-src/errors/map-traverse3.u
@@ -1,5 +1,5 @@
 --map/traverse
-effect Noop where
+ability Noop where
   noop : a -> {Noop} a
 
 type List a = Nil | Cons a (List a)

--- a/unison-src/errors/poor-error-message/ability-check-fail-by-calling-wrong-function.u
+++ b/unison-src/errors/poor-error-message/ability-check-fail-by-calling-wrong-function.u
@@ -8,7 +8,7 @@ reduce2 a0 f s = case at 0 s of
 -- as of commit a48fa3b, we get the following error
 
     --The expression at Line 18, columns 40-41 (in red below) is requesting
-    --    {𝛆3} effects, but this location only has access to
+    --    {𝛆3} abilitys, but this location only has access to
     --    {}
     --
     --   18 |   Optional.Some a1 -> reduce (f a0 a1) f (drop 1 s)
@@ -17,7 +17,7 @@ reduce2 a0 f s = case at 0 s of
     --    AbilityCheckFailure: ambient={} requested={𝛆3}
 
 -- The problem is that I've accidentally called `reduce` instead of `reduce2`,
--- which TDNRs to `Stream.reduce`, which doesn't allow effects, and `f` isn't
+-- which TDNRs to `Stream.reduce`, which doesn't allow abilitys, and `f` isn't
 -- restricted to be pure.
 
 -- I'd like to know:

--- a/unison-src/errors/poor-error-message/consoleh.u
+++ b/unison-src/errors/poor-error-message/consoleh.u
@@ -4,11 +4,11 @@
 -- expecting : or the rest of infixApp
 --    51 | ()
 
-effect State s where
+ability State s where
   get : {State s} s
   set : s -> {State s} ()
 
-effect Console where
+ability Console where
   read : {Console} (Optional Text)
   write : Text -> {Console} ()
 

--- a/unison-src/errors/poor-error-message/handle.u
+++ b/unison-src/errors/poor-error-message/handle.u
@@ -7,7 +7,7 @@
 
 type Optional a = None | Some a
 
-effect State s where
+ability State s where
   put : s -> {State s} ()
   get : {State s} s
 

--- a/unison-src/errors/poor-error-message/handler-ex.u
+++ b/unison-src/errors/poor-error-message/handler-ex.u
@@ -11,7 +11,7 @@
 --
 -- Verbiage could be improved, but also the `()` location should
 -- point to line 22, the `k ()` call.
-effect Ask foo where
+ability Ask foo where
   ask : () -> {Ask a} a
 
 supply : Text -> Effect (Ask Text) a -> a

--- a/unison-src/errors/poor-error-message/notaguard.u
+++ b/unison-src/errors/poor-error-message/notaguard.u
@@ -10,7 +10,7 @@
 --
 -- even though this program doesn't use guards!
 
-effect Ask a where
+ability Ask a where
   ask : {Ask a} a
 
 supply : Text -> Effect (Ask Text) a -> a

--- a/unison-src/errors/state4.u
+++ b/unison-src/errors/state4.u
@@ -1,5 +1,5 @@
---State4 effect
-effect State se2 where
+--State4 ability
+ability State se2 where
   put : ∀ se . se -> {State se} ()
   get : ∀ se . () -> {State se} se
 -- binding is not guarded by a lambda, it only can access

--- a/unison-src/errors/term-functor-inspired/effect1.u
+++ b/unison-src/errors/term-functor-inspired/effect1.u
@@ -1,4 +1,4 @@
-effect State s where
+ability State s where
   get : () -> {State s} s
   set : s -> {State s} ()
 

--- a/unison-src/errors/type-functor-inspired/effect2.u
+++ b/unison-src/errors/type-functor-inspired/effect2.u
@@ -1,11 +1,11 @@
-effect Abort where
+ability Abort where
   Abort : forall a . () -> {Abort} a
 
-effect Abort2 where
+ability Abort2 where
   Abort2  : forall a . () -> {Abort2} a
   Abort2' : forall a . () -> {Abort2} a
 
-effect' : Nat -> { Abort } Int
-effect' n = Abort2.Abort2 ()
+ability' : Nat -> { Abort } Int
+ability' n = Abort2.Abort2 ()
 
 ()

--- a/unison-src/errors/type-functor-inspired/need-nonstructural-types.uu
+++ b/unison-src/errors/type-functor-inspired/need-nonstructural-types.uu
@@ -1,11 +1,11 @@
-effect Abort where
+ability Abort where
   Abort : forall a . () -> {Abort} a
 
-effect Abort2 where
+ability Abort2 where
   Abort2 : forall a . () -> {Abort2} a
 
-effect' : Nat -> { Abort } Int
-effect' n = Abort2.Abort2 ()
+ability' : Nat -> { Abort } Int
+ability' n = Abort2.Abort2 ()
 
 ()
 

--- a/unison-src/errors/unexpected-loop.u
+++ b/unison-src/errors/unexpected-loop.u
@@ -1,5 +1,5 @@
 --Abort
-effect Abort where
+ability Abort where
   Abort : forall a . () -> {Abort} a
 
 use Nat +

--- a/unison-src/errors/unsound-cont.u
+++ b/unison-src/errors/unsound-cont.u
@@ -1,5 +1,5 @@
 
-effect Ask a where
+ability Ask a where
   ask : {Ask a} a
 
 supply : Text -> Effect (Ask Text) a -> a

--- a/unison-src/tests/abort.u
+++ b/unison-src/tests/abort.u
@@ -1,5 +1,5 @@
 --Abort
-effect Abort where
+ability Abort where
   Abort : forall a . () -> {Abort} a
 eff : forall a b . (a -> b) -> b -> Effect Abort a -> b
 eff f z e = case e of

--- a/unison-src/tests/ask-inferred.u
+++ b/unison-src/tests/ask-inferred.u
@@ -1,14 +1,14 @@
 --Ask inferred
 
-effect Ask a where
+ability Ask a where
   ask : {Ask a} a
 
-effect AskU where
+ability AskU where
   ask : {AskU} Nat
 
 use Nat +
 
-effect AskT where
+ability AskT where
   ask : {AskT} Text
 
 x = '(Ask.ask + 1)

--- a/unison-src/tests/console.u
+++ b/unison-src/tests/console.u
@@ -1,8 +1,8 @@
-effect State s where
+ability State s where
   get : {State s} s
   set : s -> {State s} ()
 
-effect Console where
+ability Console where
   read : {Console} (Optional Text)
   write : Text -> {Console} ()
 

--- a/unison-src/tests/console1.u
+++ b/unison-src/tests/console1.u
@@ -1,11 +1,11 @@
 -- This confusingly gives an error that
 -- it doesn't know what `Console.simulate` is.
 
-effect State s where
+ability State s where
   get : {State s} s
   set : s -> {State s} ()
 
-effect Console where
+ability Console where
   read : {Console} (Optional Text)
   write : Text -> {Console} ()
 

--- a/unison-src/tests/delay_parse.u
+++ b/unison-src/tests/delay_parse.u
@@ -1,4 +1,4 @@
-effect T where
+ability T where
   foo : {T} ()
 
 -- parses fine

--- a/unison-src/tests/effect-instantiation.u
+++ b/unison-src/tests/effect-instantiation.u
@@ -2,7 +2,7 @@
 blah : a -> a -> a
 blah a a2 = a2
 
-effect Foo where
+ability Foo where
   foo : {Foo} Text
 
 -- previously this didn't work as first argument was pure

--- a/unison-src/tests/effect1.u
+++ b/unison-src/tests/effect1.u
@@ -4,7 +4,7 @@ eff f z e = case e of
   { Abort.Abort _ -> k } -> z
   { a } -> f a
 
-effect Abort where
+ability Abort where
   Abort : forall a . () -> {Abort} a
 
 

--- a/unison-src/tests/empty-above-the-fold.u
+++ b/unison-src/tests/empty-above-the-fold.u
@@ -3,4 +3,4 @@
 
 -- /Users/arya/unison/unison-src/tests/empty-above-the-fold.u:1:1:
 -- unexpected end of input
--- expecting ability, effect, or use
+-- expecting ability, ability, or use

--- a/unison-src/tests/force.u
+++ b/unison-src/tests/force.u
@@ -1,4 +1,4 @@
-effect Woot where woot : {Woot} Text
+ability Woot where woot : {Woot} Text
 
 force : '{e} a ->{e} a
 force a = !a

--- a/unison-src/tests/handler-stacking.u
+++ b/unison-src/tests/handler-stacking.u
@@ -13,11 +13,11 @@ replicate n x =
     !x
     replicate (n `drop` 1) x
 
-effect State a where
+ability State a where
   get : {State a} a
   put : a -> {State a} ()
 
-effect Writer w where
+ability Writer w where
   tell : w -> {Writer w} ()
 
 stateHandler : s -> Effect {State s} a -> (s, a)

--- a/unison-src/tests/io-state2.u
+++ b/unison-src/tests/io-state2.u
@@ -1,5 +1,5 @@
---IO/State2 effect
-effect IO where
+--IO/State2 ability
+ability IO where
   launchMissiles : {IO} ()
 
 foo : () -> {IO} ()
@@ -14,7 +14,7 @@ foo unit =
 type Optional a =
   Some a | None
 
-effect State se2 where
+ability State se2 where
   put : ∀ se . se -> {State se} ()
   get : ∀ se . {State se} se
 

--- a/unison-src/tests/io-state3.u
+++ b/unison-src/tests/io-state3.u
@@ -1,5 +1,5 @@
---IO3 effect
-effect IO where
+--IO3 ability
+ability IO where
   launchMissiles : () -> {IO} ()
 -- binding IS guarded, so its body can access whatever abilities
 -- are declared by the type of the binding

--- a/unison-src/tests/map-traverse.u
+++ b/unison-src/tests/map-traverse.u
@@ -1,8 +1,8 @@
 --map/traverse
-effect Noop where
+ability Noop where
   noop : ∀ a . a -> {Noop} a
 
-effect Noop2 where
+ability Noop2 where
   noop2 : ∀ a . a -> a -> {Noop2} a
 
 type List a = Nil | Cons a (List a)
@@ -21,11 +21,11 @@ ex = (c 1 (c 2 (c 3 z)))
 pureMap : List Text
 pureMap = map (a -> "hello") ex
 
--- `map` is effect polymorphic
+-- `map` is ability polymorphic
 zappy : () -> {Noop} (List Nat)
 zappy u = map (zap -> (Noop.noop (zap Nat.+ 1))) ex
 
--- mixing multiple effects in a call to `map` works fine
+-- mixing multiple abilitys in a call to `map` works fine
 zappy2 : () -> {Noop, Noop2} (List Nat)
 zappy2 u = map (zap -> Noop.noop (zap Nat.+ Noop2.noop2 2 7)) ex
 

--- a/unison-src/tests/map-traverse2.u
+++ b/unison-src/tests/map-traverse2.u
@@ -1,8 +1,8 @@
 --map/traverse
-effect Noop where
+ability Noop where
   noop : a -> {Noop} a
 
-effect Noop2 where
+ability Noop2 where
   noop2 : a -> a -> {Noop2} a
 
 type List a = Nil | Cons a (List a)
@@ -22,11 +22,11 @@ ex = (c 1 (c 2 (c 3 z)))
 pureMap : List Text
 pureMap = map (a -> "hello") ex
 
--- `map` is effect polymorphic
+-- `map` is ability polymorphic
 zappy : '{Noop} (List Nat)
 zappy = 'let map (zap -> Noop.noop (zap Nat.+ 1)) ex
 
--- mixing multiple effects in a call to `map` works fine
+-- mixing multiple abilitys in a call to `map` works fine
 zappy2 : '{Noop, Noop2} (List Nat)
 zappy2 = 'let
   map (zap -> Noop.noop (zap Nat.+ Noop2.noop2 2 7)) ex

--- a/unison-src/tests/multiple-effects.u
+++ b/unison-src/tests/multiple-effects.u
@@ -1,8 +1,8 @@
-effect State s where
+ability State s where
   get : {State s} s
   set : s -> {State s} ()
 
-effect Console where
+ability Console where
   read : {Console} (Optional Text)
   write : Text -> {Console} ()
 

--- a/unison-src/tests/state1.u
+++ b/unison-src/tests/state1.u
@@ -1,5 +1,5 @@
---State1 effect
-effect State se2 where
+--State1 ability
+ability State se2 where
   put : ∀ se . se -> {State se} ()
   get : ∀ se . () -> {State se} se
 

--- a/unison-src/tests/state1a.u
+++ b/unison-src/tests/state1a.u
@@ -1,5 +1,5 @@
---State1a effect
-effect State se2 where
+--State1a ability
+ability State se2 where
   put : ∀ se . se -> {State se} ()
   get : ∀ se . {State se} se
 id : Int -> Int

--- a/unison-src/tests/state2.u
+++ b/unison-src/tests/state2.u
@@ -1,5 +1,5 @@
---State2 effect
-effect State se2 where
+--State2 ability
+ability State se2 where
   put : ∀ se . se -> {State se} ()
   get : ∀ se . () -> {State se} se
 state : ∀ s a . s -> Effect (State s) a -> (s, a)

--- a/unison-src/tests/state2a-min.u
+++ b/unison-src/tests/state2a-min.u
@@ -1,5 +1,5 @@
---State2 effect
-effect State s where
+--State2 ability
+ability State s where
   put : s -> {State s} ()
 
 state : s -> Effect (State s) a -> a

--- a/unison-src/tests/state2a.u
+++ b/unison-src/tests/state2a.u
@@ -1,8 +1,8 @@
---State2 effect
+--State2 ability
 
 type Optional a = None | Some a
 
-effect State s where
+ability State s where
   put : s -> {State s} ()
   get : {State s} s
 

--- a/unison-src/tests/state2a.uu
+++ b/unison-src/tests/state2a.uu
@@ -1,8 +1,8 @@
---State2 effect
+--State2 ability
 
 type Optional a = None | Some a
 
-effect State s where
+ability State s where
   put : s -> {State s} ()
   get : {State s} s
 

--- a/unison-src/tests/state2b-min.u
+++ b/unison-src/tests/state2b-min.u
@@ -1,5 +1,5 @@
---State2 effect
-effect State s where
+--State2 ability
+ability State s where
   put : s -> {State s} ()
 
 state : s -> Effect (State s) a -> s

--- a/unison-src/tests/state2b.u
+++ b/unison-src/tests/state2b.u
@@ -1,8 +1,8 @@
---State2 effect
+--State2 ability
 
 type Optional a = None | Some a
 
-effect State s where
+ability State s where
   put : s -> {State s} ()
   get : {State s} s
 

--- a/unison-src/tests/state3.u
+++ b/unison-src/tests/state3.u
@@ -1,5 +1,5 @@
---State3 effect
-effect State se2 where
+--State3 ability
+ability State se2 where
   put : ∀ se . se -> {State se} ()
   get : ∀ se . () -> {State se} se
 

--- a/unison-src/tests/state4.u
+++ b/unison-src/tests/state4.u
@@ -1,4 +1,4 @@
-effect State s where
+ability State s where
   put : s -> {State s} ()
   get : {State s} s
 

--- a/unison-src/tests/state4a.u
+++ b/unison-src/tests/state4a.u
@@ -1,4 +1,4 @@
-effect State s where
+ability State s where
   put : s -> {State s} ()
   get : {State s} s
 

--- a/unison-src/tests/unique.u
+++ b/unison-src/tests/unique.u
@@ -1,0 +1,28 @@
+
+unique ability Zing where zing : {Zang} Nat
+
+unique[asdlfkjasdflkj] ability Zang where
+  zang : {Zing} Nat
+
+unique
+  ability Blarg where
+  oog : {Blarg} Text
+
+unique type Bool = T | F
+
+unique[sdalfkjsdf] type BetterBool = Ya | Nah
+
+unique[asdflkajsdf] type Day
+  = Sun | Mon | Tue | Wed | Thu | Fri | Sat
+
+id x = x
+
+unique type Day2
+  = Sun
+  | Mon
+  | Tue
+  | Wed
+  | Thu
+  | Fri
+  | Sat
+


### PR DESCRIPTION
This PR allows you to create types whose identity is a combination of type structure + GUID. [Here's the main change to the implementation](https://github.com/unisonweb/unison/pull/492/files#r282575045). 

Useful for things like enums, whose meaning is determined "by convention". For instance:

```Haskell
unique type Day = Sun | Mon | Tue | Wed | Thu | Fri | Sat

-- alternately, if you want to supply your own guid
unique[anyValidWordyIdentifierHere] type Day = Sun | Mon | Tue | Wed | Thu | Fri | Sat
```

`unique` is a modifier you can place in front of `ability` or `type`, followed by an optional `wordyId` inside `[]`. If the user doesn't provide a GUID, one will be generated using system randomness.

<img width="756" alt="Screen Shot 2019-05-08 at 3 44 14 PM" src="https://user-images.githubusercontent.com/11074/57403656-2b839980-71a8-11e9-81eb-955e51ab43ca.png">

__A couple things still todo before mergeable:__

- [x] File watch typechecking display should render the modifier
- [x] `unique` should introduce a layout block
- [x] test `.u` files
- [x] `view` should show the `unique[..]` on its own line (and add test for this)
- [x] `find` should elide the `unique` guid