### PR TITLE
Fix parser regression regarding int array literals

### DIFF
--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -209,6 +209,7 @@ lexer0 scope rem =
     -- state to the lexer, so we have a hacky postprocessing pass to convert
     -- it to [1, +, 1]
     tweak [] = []
+    tweak (h@(payload -> Reserved _):t) = h : tweak t
     tweak (t1:t2@(payload -> Numeric num):rem)
       | notLayout t1 && touches t1 t2 && isSigned num =
         t1 : Token (SymbolyId $ take 1 num) (start t2) (inc $ start t2)

--- a/parser-typechecker/tests/Unison/Test/Lexer.hs
+++ b/parser-typechecker/tests/Unison/Test/Lexer.hs
@@ -15,6 +15,8 @@ test = scope "lexer" . tests $
   , t "1 +1" $ [Numeric "1", Numeric "+1"]
   , t "1+ 1" $ [Numeric "1", SymbolyId "+", Numeric "1"]
   , t "x+y" $ [WordyId "x", SymbolyId "+", WordyId "y"]
+  , t "[+1,+1]" $ [Reserved "[", Numeric "+1", Reserved ",", Numeric "+1", Reserved "]"]
+  , t "[ +1 , +1 ]" $ [Reserved "[", Numeric "+1", Reserved ",", Numeric "+1", Reserved "]"]
   , t "-- a comment 1.0" $ []
   , t "\"woot\" -- a comment 1.0" $ [Textual "woot"]
   , t "0:Int" $ [Numeric "0", Reserved ":", WordyId "Int"]


### PR DESCRIPTION
c.f. #500 

turns out it was introduced by 89e39f95f957340f6933448923d2fa036bf5f077

I went a bit ham with the fix, happy to change it to something more fine-grained :+1: