### PR TITLE
`view` reports missing names.

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor.hs
@@ -236,6 +236,7 @@ data Output v
   | DisplayDefinitions (Maybe FilePath) PPE.PrettyPrintEnv
                        [(Reference, DisplayThing (Term v Ann))]
                        [(Reference, DisplayThing (Decl v Ann))]
+  | NotInCodebase HashQualified
   | TodoOutput Branch (TodoOutput v Ann)
   | ListEdits Branch0
   -- new/unrepresented references followed by old/removed

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -76,6 +76,8 @@ notifyUser dir o = case o of
   Success _    -> putPrettyLn $ P.bold "Done."
   DisplayDefinitions outputLoc ppe terms types ->
     displayDefinitions outputLoc ppe terms types
+  NotInCodebase name ->
+    putPrettyLn . warn $ "--" <> prettyHashQualified name <> " not found in the codebase."
   NoUnisonFile -> do
     dir' <- canonicalizePath dir
     putPrettyLn . P.callout "😶" $ P.lines


### PR DESCRIPTION
Resolves #490.

Before:

```
master> view Int.+ foo

  -- Int.+ is built-in.

master> 
```

After:

```
master> view Int.+ foo

  -- Int.+ is built-in.


  ⚠️
  -- foo not found in the codebase.

master> 
```