### PR TITLE
Scoped type variables

### DIFF
--- a/parser-typechecker/src/Unison/ABT.hs
+++ b/parser-typechecker/src/Unison/ABT.hs
@@ -12,7 +12,6 @@ module Unison.ABT where
 
 import Control.Applicative
 import Control.Monad
-import Data.Bifunctor (second)
 import Data.Word (Word64)
 import Data.Functor.Identity (runIdentity)
 import Data.List hiding (cycle)
@@ -369,7 +368,8 @@ rebuildUp' f (Term _ ann body) = case body of
   Tm body -> f $ tm' ann (fmap (rebuildUp' f) body)
 
 freeVarOccurrences :: (Traversable f, Ord v) => Set v -> Term f v a -> [(v, a)]
-freeVarOccurrences except t = go $ second (`Set.difference` except) <$> annotateBound t
+freeVarOccurrences except t =
+  [ (v, a) | (v,a) <- go $ annotateBound t, not (Set.member v except) ]
   where
   go e = case out e of
     Var v -> if Set.member v (snd $ annotation e)

--- a/parser-typechecker/src/Unison/ABT.hs
+++ b/parser-typechecker/src/Unison/ABT.hs
@@ -12,6 +12,7 @@ module Unison.ABT where
 
 import Control.Applicative
 import Control.Monad
+import Data.Bifunctor (second)
 import Data.Word (Word64)
 import Data.Functor.Identity (runIdentity)
 import Data.List hiding (cycle)
@@ -367,13 +368,16 @@ rebuildUp' f (Term _ ann body) = case body of
   Abs x e -> f $ abs' ann x (rebuildUp' f e)
   Tm body -> f $ tm' ann (fmap (rebuildUp' f) body)
 
-freeVarAnnotations :: (Traversable f, Ord v) => Term f v a -> [(v, a)]
-freeVarAnnotations t =
-  join . runIdentity $ foreachSubterm f (annotateBound t) where
-    f t@(Var' v)
-      | Set.notMember v (snd . annotation $ t) = pure [(v, fst . annotation $ t)]
-    f _ = pure []
-
+freeVarOccurrences :: (Traversable f, Ord v) => Set v -> Term f v a -> [(v, a)]
+freeVarOccurrences except t = go $ second (`Set.difference` except) <$> annotateBound t
+  where
+  go e = case out e of
+    Var v -> if Set.member v (snd $ annotation e)
+             then []
+             else [(v, fst $ annotation e)]
+    Cycle body -> go body
+    Abs _ body -> go body
+    Tm body -> foldMap go body
 
 foreachSubterm
   :: (Traversable f, Applicative g, Ord v)
@@ -385,17 +389,6 @@ foreachSubterm f e = case out e of
   Cycle body -> liftA2 (:) (f e) (foreachSubterm f body)
   Abs _ body -> liftA2 (:) (f e) (foreachSubterm f body)
   Tm body -> liftA2 (:) (f e) (join . Foldable.toList <$> (sequenceA $ foreachSubterm f <$> body))
-
-freeVarOccurrences :: (Traversable f, Ord v) => Term f v a -> [(v, a)]
-freeVarOccurrences t = go $ annotateBound t
-  where
-  go e = case out e of
-    Var v -> if Set.member v (snd $ annotation e)
-             then []
-             else [(v, fst $ annotation e)]
-    Cycle body -> go body
-    Abs _ body -> go body
-    Tm body -> foldMap go body
 
 -- | `visit f t` applies an effectful function to each subtree of
 -- `t` and sequences the results. When `f` returns `Nothing`, `visit`

--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -61,7 +61,7 @@ t :: Var v => String -> Type v
 t s = ABT.amap (const Intrinsic) .
           Names.bindType names . either (error . showParseError s) tweak $
           Parser.run (Parser.root TypeParser.valueType) s mempty
-  where tweak = Type.generalizeLowercase
+  where tweak = Type.generalizeLowercase mempty
 
 -- parse a term, hard-coding the builtins defined in this file
 tm :: Var v => String -> Term v

--- a/parser-typechecker/src/Unison/Codebase/Serialization/V0.hs
+++ b/parser-typechecker/src/Unison/Codebase/Serialization/V0.hs
@@ -280,6 +280,7 @@ putType putVar putA typ = putABT putVar putA go typ where
     Type.Effect e t  -> putWord8 4 *> putChild e *> putChild t
     Type.Effects es  -> putWord8 5 *> putFoldable es putChild
     Type.Forall body -> putWord8 6 *> putChild body
+    Type.IntroOuter body -> putWord8 7 *> putChild body
 
 getType :: (MonadGet m, Ord v)
         => m v -> m a -> m (Type.AnnotatedType v a)
@@ -292,6 +293,7 @@ getType getVar getA = getABT getVar getA go where
     4 -> Type.Effect <$> getChild <*> getChild
     5 -> Type.Effects <$> getList getChild
     6 -> Type.Forall <$> getChild
+    7 -> Type.IntroOuter <$> getChild
     _ -> unknownTag "getType" tag
 
 putSymbol :: MonadPut m => Symbol -> m ()

--- a/parser-typechecker/src/Unison/Codebase/Serialization/V1.hs
+++ b/parser-typechecker/src/Unison/Codebase/Serialization/V1.hs
@@ -368,6 +368,7 @@ putType putVar putA typ = putABT putVar putA go typ where
     Type.Effect e t  -> putWord8 4 *> putChild e *> putChild t
     Type.Effects es  -> putWord8 5 *> putFoldable putChild es
     Type.Forall body -> putWord8 6 *> putChild body
+    Type.IntroOuter body -> putWord8 7 *> putChild body
 
 getType :: (MonadGet m, Ord v)
         => m v -> m a -> m (Type.AnnotatedType v a)
@@ -380,6 +381,7 @@ getType getVar getA = getABT getVar getA go where
     4 -> Type.Effect <$> getChild <*> getChild
     5 -> Type.Effects <$> getList getChild
     6 -> Type.Forall <$> getChild
+    7 -> Type.IntroOuter <$> getChild
     _ -> unknownTag "getType" tag
 
 putSymbol :: MonadPut m => Symbol -> m ()

--- a/parser-typechecker/src/Unison/FileParser.hs
+++ b/parser-typechecker/src/Unison/FileParser.hs
@@ -59,11 +59,11 @@ file = do
     let (termsr, watchesr) = foldl' go ([], []) stanzas
         go (terms, watches) s = case s of
           WatchBinding kind _ ((_, v), at) ->
-            (terms, (kind,(v,at)) : watches)
+            (terms, (kind,(v,Term.generalizeTypeSignatures at)) : watches)
           WatchExpression kind guid _ at ->
-            (terms, (kind, (Var.unnamedTest guid, at)) : watches)
-          Binding ((_, v), at) -> ((v,at) : terms, watches)
-          Bindings bs -> ([(v,at) | ((_,v), at) <- bs ] ++ terms, watches)
+            (terms, (kind, (Var.unnamedTest guid, Term.generalizeTypeSignatures at)) : watches)
+          Binding ((_, v), at) -> ((v,Term.generalizeTypeSignatures at) : terms, watches)
+          Bindings bs -> ([(v,Term.generalizeTypeSignatures at) | ((_,v), at) <- bs ] ++ terms, watches)
     let (terms, watches) = (reverse termsr, List.multimap $ reverse watchesr)
         toPair (tok, _) = (L.payload tok, ann tok)
         accessors =

--- a/parser-typechecker/src/Unison/FileParser.hs
+++ b/parser-typechecker/src/Unison/FileParser.hs
@@ -241,5 +241,5 @@ effectDeclaration mod = do
   where
     constructor :: Var v => L.Token v -> P v (Ann, v, AnnotatedType v Ann)
     constructor name = explodeToken <$>
-      prefixVar <* reserved ":" <*> (Type.generalizeLowercase <$> TypeParser.computationType)
+      prefixVar <* reserved ":" <*> (Type.generalizeLowercase mempty <$> TypeParser.computationType)
       where explodeToken v t = (ann v, Var.namespaced [L.payload name, L.payload v], t)

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -390,11 +390,15 @@ renderTypeError e env src = case e of
     , "\n"
     , showSourceMaybes src [ (,ErrorSite) <$> rangeForAnnotated loc | loc <- locs ]]
 
-  UnknownType {..} -> mconcat
-    [ "I don't know about the type "
-    , style ErrorSite (renderVar unknownTypeV)
-    , ".  Make sure it's imported and spelled correctly:\n\n"
-    , annotatedAsErrorSite src typeSite
+  UnknownType {..} -> mconcat [
+    if ann typeSite == Intrinsic then
+      "I don't know about the builtin type " <> style ErrorSite (renderVar unknownTypeV) <> ". "
+    else if ann typeSite == External then
+      "I don't know about the type " <> style ErrorSite (renderVar unknownTypeV) <> ". "
+    else
+      "I don't know about the type " <> style ErrorSite (renderVar unknownTypeV) <> ":\n"
+      <> annotatedAsErrorSite src typeSite
+    , "Make sure it's imported and spelled correctly."
     ]
   UnknownTerm {..}
     | Type.isArrow expectedType && Var.typeOf unknownTermV == Var.AskInfo

--- a/parser-typechecker/src/Unison/Term.hs
+++ b/parser-typechecker/src/Unison/Term.hs
@@ -212,6 +212,7 @@ substTypeVar vt ty tm = go Set.empty tm where
     Ann' e t1@(Type.ForallsNamed' vs _) ->
       let bound' = bound <> Set.fromList vs
       in ann loc (go bound' e) (ABT.substInheritAnnotation vt ty t1)
+    Ann' e t -> ann loc (go bound e) (ABT.substInheritAnnotation vt ty t)
     ABT.Tm' f -> ABT.tm' loc (go bound <$> f)
     (ABT.out -> ABT.Abs v body) -> ABT.abs' loc v (go bound body)
     (ABT.out -> ABT.Cycle body) -> ABT.cycle' loc (go bound body)

--- a/parser-typechecker/src/Unison/Term.hs
+++ b/parser-typechecker/src/Unison/Term.hs
@@ -224,11 +224,11 @@ generalizeTypeSignatures :: (Var vt, Var v) => AnnotatedTerm' vt v a -> Annotate
 generalizeTypeSignatures tm = go Set.empty tm where
   go bound tm = let loc = ABT.annotation tm in case tm of
     Var' _ -> tm
-    Ann' e t -> let
+    Ann' e (Type.generalizeLowercase bound -> t) -> let
       bound' = case Type.unForalls t of
         Nothing -> bound
         Just (vs, _) -> bound <> Set.fromList vs
-      in ann loc (go bound' e) (Type.freeVarsToOuters bound $ Type.generalizeLowercase bound t)
+      in ann loc (go bound' e) (Type.freeVarsToOuters bound t)
     ABT.Tm' f -> ABT.tm' loc (go bound <$> f)
     (ABT.out -> ABT.Abs v body) -> ABT.abs' loc v (go bound body)
     (ABT.out -> ABT.Cycle body) -> ABT.cycle' loc (go bound body)

--- a/parser-typechecker/src/Unison/Term.hs
+++ b/parser-typechecker/src/Unison/Term.hs
@@ -196,7 +196,7 @@ freeTypeVarAnnotations :: Ord vt => AnnotatedTerm' vt v a -> Map vt [a]
 freeTypeVarAnnotations e = multimap $ go Set.empty e where
   go bound tm = case tm of
     Var' _ -> mempty
-    Ann' e t1@(Type.ForallsNamed' vs _) ->
+    Ann' e (Type.stripIntroOuters -> t1@(Type.ForallsNamed' vs _)) ->
       let bound' = bound <> Set.fromList vs
       in go bound' e <> ABT.freeVarOccurrences bound t1
     ABT.Tm' f -> foldMap (go bound) f

--- a/parser-typechecker/src/Unison/Term.hs
+++ b/parser-typechecker/src/Unison/Term.hs
@@ -42,7 +42,7 @@ import qualified Unison.Reference as Reference
 import qualified Unison.Reference.Util as ReferenceUtil
 import           Unison.Referent (Referent)
 import qualified Unison.Referent as Referent
-import           Unison.Type (Type)
+import           Unison.Type (AnnotatedType, Type)
 import qualified Unison.Type as Type
 import qualified Unison.TypeVar as TypeVar
 import qualified Unison.ConstructorType as CT
@@ -197,6 +197,29 @@ freeTypeVars t = go t where
     ABT.Cycle t -> go t
     ABT.Tm (Ann e t) -> Type.freeVars t `union` go e
     ABT.Tm ts -> foldMap go ts
+
+freeTypeVarAnnotations :: Ord vt => AnnotatedTerm' vt v a -> Map vt [a]
+freeTypeVarAnnotations e = error "todo"
+
+substTypeVar :: Var vt => vt -> AnnotatedType vt b -> AnnotatedTerm' vt v a -> AnnotatedTerm' vt v a
+substTypeVar vt tm =
+  error "todo - perform scopetypevar style substitution"
+
+generalizeTypeSignatures :: Var v => AnnotatedTerm' vt v a -> AnnotatedTerm' vt v a
+generalizeTypeSignatures tm =
+  error "todo - generalize over lowercase free type variables, call once at parser root"
+
+unForallAnn
+  :: Var vt
+  => AnnotatedTerm' vt v a
+  -> Maybe (vt, AnnotatedType vt b -> (AnnotatedTerm' vt v a, AnnotatedType vt a))
+unForallAnn tm = case tm of
+  Ann' e (Type.Forall' t) -> Just (tv, sub) where
+    sub ty = (substTypeVar tv ty e, ABT.bindInheritAnnotation t ty)
+    tv = ABT.variable t
+  _ -> Nothing
+
+pattern AnnForall' vt f <- (unForallAnn -> Just (vt, f))
 
 -- nicer pattern syntax
 

--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -28,7 +28,6 @@ import qualified Unison.PatternP as Pattern
 import qualified Unison.Reference as R
 import           Unison.Term (AnnotatedTerm, IsTop)
 import qualified Unison.Term as Term
-import qualified Unison.Type as Type
 import           Unison.Type (AnnotatedType)
 import qualified Unison.TypeParser as TypeParser
 import           Unison.Var (Var)
@@ -274,7 +273,7 @@ infixApp = label "infixApp" $
 typedecl :: Var v => P v (L.Token v, AnnotatedType v Ann)
 typedecl =
   (,) <$> P.try (prefixVar <* reserved ":")
-      <*> (Type.generalizeLowercase <$> TypeParser.valueType)
+      <*> TypeParser.valueType
       <* semi
 
 binding :: forall v. Var v => P v ((Ann, v), AnnotatedTerm v Ann)

--- a/parser-typechecker/src/Unison/Type.hs
+++ b/parser-typechecker/src/Unison/Type.hs
@@ -147,6 +147,9 @@ unIntroOuters t = go t []
         go _body [] = Nothing
         go body vs = Just (reverse vs, body)
 
+-- Most code doesn't care about `introOuter` binders and is fine dealing with the
+-- these outer variable references as free variables. This function strips out
+-- one or more `introOuter` binders, so `outer a b . (a, b)` becomes `(a, b)`.
 stripIntroOuters :: AnnotatedType v a -> AnnotatedType v a
 stripIntroOuters t = case unIntroOuters t of
   Just (_, t) -> t
@@ -461,6 +464,7 @@ generalizeLowercase except t = foldr (forall (ABT.annotation t)) t vars
   where vars = [ v | v <- Set.toList (ABT.freeVars t `Set.difference` except), isLow v]
         isLow v = all Char.isLower . take 1 . Text.unpack . Var.name $ v
 
+-- Convert all free variables in `allowed` to variables bound by an `introOuter`.
 freeVarsToOuters :: Var v => Set v -> AnnotatedType v a -> AnnotatedType v a
 freeVarsToOuters allowed t = foldr (introOuter (ABT.annotation t)) t vars
   where vars = [ v | v <- Set.toList (ABT.freeVars t `Set.intersection` allowed)]

--- a/parser-typechecker/src/Unison/Type.hs
+++ b/parser-typechecker/src/Unison/Type.hs
@@ -435,10 +435,11 @@ functionResult t = go False t where
   go inArr t = if inArr then Just t else Nothing
 
 
--- | Bind all free variables that start with a lowercase letter with an outer `forall`.
-generalizeLowercase :: Var v => AnnotatedType v a -> AnnotatedType v a
-generalizeLowercase t = foldr (forall (ABT.annotation t)) t vars
-  where vars = [ v | v <- Set.toList (ABT.freeVars t), isLow v]
+-- | Bind all free variables (not in `except`) that start with a lowercase
+-- letter with an outer `forall`.
+generalizeLowercase :: Var v => Set v -> AnnotatedType v a -> AnnotatedType v a
+generalizeLowercase except t = foldr (forall (ABT.annotation t)) t vars
+  where vars = [ v | v <- Set.toList (ABT.freeVars t `Set.difference` except), isLow v]
         isLow v = all Char.isLower . take 1 . Text.unpack . Var.name $ v
 
 -- | This function removes all variable shadowing from the types and reduces

--- a/parser-typechecker/src/Unison/Type.hs
+++ b/parser-typechecker/src/Unison/Type.hs
@@ -49,6 +49,9 @@ data F a
   | Effect a a
   | Effects [a]
   | Forall a
+  | IntroOuter a -- binder like ∀, used to introduce variables that are
+                 -- bound by outer type signatures, to support scoped type
+                 -- variables
   deriving (Foldable,Functor,Generic,Generic1,Eq,Ord,Traversable)
 
 instance Eq1 F where (==#) = (==)
@@ -104,6 +107,8 @@ pattern Effect'' es t <- (unEffect0 -> (es, t))
 -- Effect0' may match zero effects
 pattern Effect0' es t <- (unEffect0 -> (es, t))
 pattern Forall' subst <- ABT.Tm' (Forall (ABT.Abs' subst))
+pattern IntroOuter' subst <- ABT.Tm' (IntroOuter (ABT.Abs' subst))
+pattern IntroOuterNamed' v body <- ABT.Tm' (IntroOuter (ABT.out -> ABT.Abs v body))
 pattern ForallsNamed' vs body <- (unForalls -> Just (vs, body))
 pattern ForallNamed' v body <- ABT.Tm' (Forall (ABT.out -> ABT.Abs v body))
 pattern Var' v <- ABT.Var' v
@@ -135,6 +140,17 @@ unApps :: AnnotatedType v a -> Maybe (AnnotatedType v a, [AnnotatedType v a])
 unApps t = case go t [] of [] -> Nothing; [_] -> Nothing; f:args -> Just (f,args)
   where go (App' i o) acc = go i (o:acc)
         go fn args = fn:args
+
+unIntroOuters :: AnnotatedType v a -> Maybe ([v], AnnotatedType v a)
+unIntroOuters t = go t []
+  where go (IntroOuterNamed' v body) vs = go body (v:vs)
+        go _body [] = Nothing
+        go body vs = Just (reverse vs, body)
+
+stripIntroOuters :: AnnotatedType v a -> AnnotatedType v a
+stripIntroOuters t = case unIntroOuters t of
+  Just (_, t) -> t
+  Nothing     -> t
 
 unForalls :: AnnotatedType v a -> Maybe ([v], AnnotatedType v a)
 unForalls t = go t []
@@ -241,6 +257,9 @@ ann a e t = ABT.tm' a (Ann e t)
 
 forall :: Ord v => a -> v -> AnnotatedType v a -> AnnotatedType v a
 forall a v body = ABT.tm' a (Forall (ABT.abs' a v body))
+
+introOuter :: Ord v => a -> v -> AnnotatedType v a -> AnnotatedType v a
+introOuter a v body = ABT.tm' a (IntroOuter (ABT.abs' a v body))
 
 iff :: Var v => Type v
 iff = forall () aa $ arrows (f <$> [boolean(), a, a]) a
@@ -442,6 +461,10 @@ generalizeLowercase except t = foldr (forall (ABT.annotation t)) t vars
   where vars = [ v | v <- Set.toList (ABT.freeVars t `Set.difference` except), isLow v]
         isLow v = all Char.isLower . take 1 . Text.unpack . Var.name $ v
 
+freeVarsToOuters :: Var v => Set v -> AnnotatedType v a -> AnnotatedType v a
+freeVarsToOuters allowed t = foldr (introOuter (ABT.annotation t)) t vars
+  where vars = [ v | v <- Set.toList (ABT.freeVars t `Set.intersection` allowed)]
+
 -- | This function removes all variable shadowing from the types and reduces
 -- fresh ids to the minimum possible to avoid ambiguity. Useful when showing
 -- two different types.
@@ -511,6 +534,7 @@ instance Hashable1 F where
         in [tag 4] ++ map hashed hs
       Effect e t -> [tag 5, hashed (hash e), hashed (hash t)]
       Forall a -> [tag 6, hashed (hash a)]
+      IntroOuter a -> [tag 7, hashed (hash a)]
 
 instance Show a => Show (F a) where
   showsPrec p fa = go p fa where
@@ -528,5 +552,8 @@ instance Show a => Show (F a) where
     go p (Forall body) = case p of
       0 -> showsPrec p body
       _ -> showParen True $ s"∀ " <> showsPrec 0 body
+    go p (IntroOuter body) = case p of
+      0 -> showsPrec p body
+      _ -> showParen True $ s"outer " <> showsPrec 0 body
     (<>) = (.)
     s = showString

--- a/parser-typechecker/src/Unison/TypePrinter.hs
+++ b/parser-typechecker/src/Unison/TypePrinter.hs
@@ -62,7 +62,7 @@ pretty0
 pretty0 n p tp = go n p tp
   where
   go :: PrettyPrintEnv -> Int -> AnnotatedType v a -> Pretty s
-  go n p tp = case tp of
+  go n p tp = case stripIntroOuters tp of
     Var' v     -> PP.text (Var.name v)
     Ref' r     -> prettyHashQualified' $ (PrettyPrintEnv.typeName n r)
     Cycle' _ _ -> fromString "error: TypeParser does not currently emit Cycle"

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -1613,7 +1613,7 @@ run
 run builtinLoc ambient datas effects m =
   fmap fst
     . runM m
-    . MEnv (Env 0 mempty) ambient builtinLoc datas effects
+    . MEnv (Env 1 mempty) ambient builtinLoc datas effects
     . const
     $ pure True
 

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -1200,6 +1200,10 @@ generalizeExistentials ctx t =
                            t)
       else t -- don't bother introducing a forall if type variable is unused
 
+-- This checks `e` against the type `t`, but if `t` is a `∀`, any ∀-quantified
+-- variables are freshened and substituted into `e`. This should be called whenever
+-- a term is being checked against a type due to a user-provided signature on `e`.
+-- See its usage in `synthesize` and `annotateLetRecBindings`.
 checkScoped :: forall v loc . (Var v, Ord loc) => Term v loc -> Type v loc -> M v loc ()
 checkScoped e t = case t of
   Type.Forall' body -> do -- ForallI

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -772,8 +772,9 @@ synthesize e = scope (InSynthesize e) $
     t <- ungeneralize =<< getEffectConstructorType r cid
     existentializeArrows t
   go tm@(Term.AnnForall' vt f) = do
-    vt' <- freshenVar vt
-    let (e, t) = f (Type.var() vt')
+    vt <- freshenVar vt
+    appendContext $ context [Var vt]
+    let (e, t) = f (Type.var() vt)
     go (Term.ann (loc tm) e t)
   go (Term.Ann' e' t) = do
     t <- existentializeArrows t

--- a/parser-typechecker/src/Unison/UnisonFile.hs
+++ b/parser-typechecker/src/Unison/UnisonFile.hs
@@ -285,7 +285,7 @@ environmentFor names0 dataDecls0 effectDecls0 =
     okVars = Map.keysSet allDecls0
     unknownTypeRefs = Map.elems allDecls0 >>= \dd ->
       let cts = DD.constructorTypes dd
-      in cts >>= \ct -> [ UnknownType v a | (v,a) <- ABT.freeVarOccurrences ct
+      in cts >>= \ct -> [ UnknownType v a | (v,a) <- ABT.freeVarOccurrences mempty ct
                                           , not (Set.member v okVars) ]
   in
     if null overlaps && null unknownTypeRefs

--- a/parser-typechecker/tests/Unison/Test/Typechecker.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker.hs
@@ -31,6 +31,8 @@ import           Unison.Term            ( amap )
 import           Unison.Test.Common     (parseAndSynthesizeAsFile)
 import qualified Unison.UnisonFile      as UF
 import           Unison.Util.Monoid     (intercalateMap)
+import qualified Unison.Var as Var
+import qualified Unison.Type as Type
 
 type Note = Result.Note Symbol Parser.Ann
 
@@ -63,6 +65,30 @@ test = do
       , go rt shouldFailNow   bad
       , go rt shouldPassLater (pending . bad)
       , go rt shouldFailLater (pending . good)
+      , scope "Term.substTypeVar" $ do
+          -- check that capture avoidance works in substTypeVar
+          let v s = Var.nameds s :: Symbol
+              tv s = Type.var() (v s)
+              v1 s = Var.freshenId 1 (v s)
+              tm :: Term.Term Symbol
+              tm = Term.ann() (Term.ann()
+                                 (Term.nat() 42)
+                                 (Type.introOuter() (v "a") $
+                                   Type.arrow() (tv "a") (tv "x")))
+                              (Type.forall() (v "a") (tv "a"))
+              tm' = Term.substTypeVar (v "x") (tv "a") tm
+              expected =
+                Term.ann() (Term.ann()
+                              (Term.nat() 42)
+                              (Type.introOuter() (v1 "a") $
+                                Type.arrow() (Type.var() $ v1 "a") (tv "a")))
+                           (Type.forall() (v1 "a") (Type.var() $ v1 "a"))
+          note $ show tm'
+          note $ show expected
+          expect $ tm == tm
+          expect $ tm' == tm'
+          expect $ tm' == expected
+          ok
       ]
 
 shouldPassPath, shouldFailPath :: String

--- a/unison-src/tests/methodical/scopedtypevars.u
+++ b/unison-src/tests/methodical/scopedtypevars.u
@@ -1,0 +1,29 @@
+
+ex1 : x -> y -> x
+ex1 a b =
+  temp : x -- refers to the variable in the outer scope
+  temp = a
+  a
+
+ex2 : x -> y -> x
+ex2 a b =
+  id : ∀ x . x -> x -- doesn't refer the variable in outer scope
+  id x = x
+  id 42
+  id a
+
+merge : (a -> a -> Boolean) -> [a] -> [a] -> [a]
+merge lte a b =
+  use Sequence ++ drop at snoc
+  use Optional None Some
+  go : [a] -> [a] -> [a] -> [a] -- refers to the outer `a` type
+  go acc a b = case at 0 a of
+    None -> acc ++ b
+    Some hd1 -> case at 0 b of
+      None -> acc ++ a
+      Some hd2 ->
+        if hd1 `lte` hd2 then
+          go (acc `snoc` hd1) (drop 1 a) b
+        else
+          go (acc `snoc` hd2) a (drop 1 b)
+  go [] a b


### PR DESCRIPTION
Fixes #343 and #409 

Type signatures inside of a function can now refer to type variables introduced by signatures on enclosing expressions, as in `ScopedTypeVariables` extension in Haskell.

Example:

```Haskell
ex1 : x -> y -> x
ex1 a b =
  temp : x -- refers to the variable in the outer scope
  temp = a
  a

ex2 : x -> y -> x
ex2 a b =
  id : ∀ x . x -> x -- doesn't refer the variable in outer scope
  id x = x
  id 42
  id a
```

The main change in the typechecker is the function `checkScoped`. It does the work of substituting introduced type variables into the term. The other notable change is the the `Type` AST has a new binder `IntroOuter`, which tracks which variables were introduced by an outer scope... this lets us distinguish between variables which are "really" free vs variables that are bound by an outer signature.

Implementation was kind of subtle and I had a few bugs with the implementation, even though very little code changed. The functions to look at are `Term.generalizeTypeSignatures`, `Term.substTypeVar`, and `Type.generalizeLowercase` and `Type.freeVarsToOuters`.