### PR TITLE
Let `view` show historical names as needed for dependencies.

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -109,6 +109,12 @@ findHistoricalHQs = findInHistory
   (\hq r n -> HQ.matchesNamedReferent n r hq)
   (\hq r n -> HQ.matchesNamedReference n r hq)
 
+findHistoricalRefs :: Monad m => Set (Either Reference Referent) -> Branch m
+                   -> m (Set (Either Reference Referent), Names0)
+findHistoricalRefs = findInHistory
+  (\query r _n -> either (const False) (==r) query)
+  (\query r _n -> either (==r) (const False) query)
+
 findInHistory :: forall m q. (Monad m, Ord q)
   => (q -> Referent -> Name -> Bool)
   -> (q -> Reference -> Name -> Bool)

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -39,6 +39,7 @@ import qualified Unison.Codebase.Metadata      as Metadata
 import qualified Unison.Hash                   as Hash
 import           Unison.Hashable                ( Hashable )
 import qualified Unison.Hashable               as H
+import qualified Unison.HashQualified          as HQ
 import           Unison.Name                    ( Name(..) )
 import qualified Unison.Name                   as Name
 import           Unison.Names2                  ( Names'(Names), Names0 )
@@ -86,6 +87,9 @@ makeLenses ''Raw
 toNames0 :: Branch0 m -> Names0
 toNames0 b = Names (R.swap . Star3.d1 . deepTerms $ b)
                    (R.swap . Star3.d1 . deepTypes $ b)
+
+findHistoricalNames0 :: Set HQ.HashQualified -> Branch m -> m Names0
+findHistoricalNames0 = error "todo"
 
 deepReferents :: Branch0 m -> Set Referent
 deepReferents = Star3.fact . deepTerms

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -41,16 +41,21 @@ import           Unison.Hashable                ( Hashable )
 import qualified Unison.Hashable               as H
 import           Unison.Name                    ( Name(..) )
 import qualified Unison.Name                   as Name
+import qualified Unison.Names2                 as Names
 import           Unison.Names2                  ( Names'(Names), Names0 )
 import           Unison.Reference               ( Reference )
 import           Unison.Referent                ( Referent )
 import qualified Unison.Referent              as Referent
+import qualified Unison.Reference              as Reference
 
 import qualified Unison.Util.Relation         as R
 import           Unison.Util.Relation           ( Relation )
 import qualified Unison.Util.Star3             as Star3
 import qualified Unison.Util.List              as List
 import Unison.ShortHash (ShortHash)
+import qualified Unison.ShortHash as SH
+import qualified Unison.HashQualified as HQ
+import Unison.HashQualified (HashQualified)
 
 newtype Branch m = Branch { _history :: Causal m Raw (Branch0 m) }
   deriving (Eq, Ord)
@@ -88,20 +93,50 @@ toNames0 :: Branch0 m -> Names0
 toNames0 b = Names (R.swap . Star3.d1 . deepTerms $ b)
                    (R.swap . Star3.d1 . deepTypes $ b)
 
--- the search stops searching for a given ShortHash once it encounters
--- any Branch0 that satisfies that ShortHash.
-findHistoricalNames0 ::
-  Monad m => Set ShortHash -> Branch m -> m (Set ShortHash, Names0)
-findHistoricalNames0 shortHashes b =
-  (Causal.foldHistoryUntil f (shortHashes, mempty) . _history) b <&> \case
-    -- could do something more sophisticated here later
+
+
+-- This stops searching for a given ShortHash once it encounters
+-- any term or type in any Branch0 that satisfies that ShortHash.
+findHistoricalSHs :: Monad m => Set ShortHash -> Branch m -> m (Set ShortHash, Names0)
+findHistoricalSHs = findInHistory
+  (\sh r _n -> sh `SH.isPrefixOf` Referent.toShortHash r)
+  (\sh r _n -> sh `SH.isPrefixOf` Reference.toShortHash r)
+
+-- This stops searching for a given HashQualified once it encounters
+-- any term or type in any Branch0 that satisfies that HashQualified.
+findHistoricalHQs :: Monad m => Set HashQualified -> Branch m -> m (Set HashQualified, Names0)
+findHistoricalHQs = findInHistory
+  (\hq r n -> HQ.matchesNamedReferent n r hq)
+  (\hq r n -> HQ.matchesNamedReference n r hq)
+
+findInHistory :: forall m q. (Monad m, Ord q)
+  => (q -> Referent -> Name -> Bool)
+  -> (q -> Reference -> Name -> Bool)
+  -> Set q -> Branch m -> m (Set q, Names0)
+findInHistory termMatches typeMatches queries b =
+  (Causal.foldHistoryUntil f (queries, mempty) . _history) b <&> \case
+    -- could do something more sophisticated here later to report that some SH
+    -- couldn't be found anywhere in the history.  but for now, I assume that
+    -- the normal thing will happen when it doesn't show up in the namespace.
     Causal.Satisfied   (_, names)       -> (mempty, names)
     Causal.Unsatisfied (missing, names) -> (missing, names)
   where
-  f (_shortHashes, _namesAcc) _b0 = ((shortHashes', namesAcc'), null shortHashes')
+  -- in order to not favor terms over types, we iterate through the ShortHashes,
+  -- for each `remainingQueries`, if we find a matching Referent or Reference,
+  -- we remove `q` from the accumulated `remainingQueries`, and add the Ref* to
+  -- the accumulated `names0`.
+  f acc@(remainingQueries, _) b0 = (acc', null remainingQueries')
     where
-    shortHashes' = undefined :: Set ShortHash
-    namesAcc' = undefined :: Names0
+    acc'@(remainingQueries', _) = foldl' findQ acc remainingQueries
+    findQ :: (Set q, Names0) -> q -> (Set q, Names0)
+    findQ acc sh =
+      foldl' (doType sh) (foldl' (doTerm sh) acc
+                            (R.toList . Metadata.toRelation $ deepTerms b0))
+                          (R.toList . Metadata.toRelation $ deepTypes b0)
+    doTerm q acc@(remainingSHs, names0) (r, n) = if termMatches q r n
+      then (Set.delete q remainingSHs, Names.addTerm n r names0) else acc
+    doType q acc@(remainingSHs, names0) (r, n) = if typeMatches q r n
+      then (Set.delete q remainingSHs, Names.addType n r names0) else acc
 
 deepReferents :: Branch0 m -> Set Referent
 deepReferents = Star3.fact . deepTerms

--- a/parser-typechecker/src/Unison/Codebase/Causal.hs
+++ b/parser-typechecker/src/Unison/Codebase/Causal.hs
@@ -237,10 +237,10 @@ transform nt c = case c of
 -- foldHistoryUntil some condition on the accumulator is met,
 -- attempting to work backwards fairly through merge nodes
 -- (rather than following one back all the way to its root before working
--- through others).  Returns Left if the condition was never satisfied,
--- otherwise Right.
+-- through others).  Returns Unsatisfied if the condition was never satisfied,
+-- otherwise Satisfied.
 data FoldHistoryResult a = Satisfied a | Unsatisfied a deriving (Eq,Ord,Show)
-foldHistoryUntil :: forall m h e a. (Monad m, Ord h) => --(Show a, Show e) =>
+foldHistoryUntil :: forall m h e a. (Monad m) => --(Show a, Show e) =>
   (a -> e -> (a, Bool)) -> a -> Causal m h e -> m (FoldHistoryResult a)
 foldHistoryUntil f a c = step a mempty (pure c) where
   step :: a -> Set (RawHash h) -> Seq (Causal m h e) -> m (FoldHistoryResult a)
@@ -252,5 +252,5 @@ foldHistoryUntil f a c = step a mempty (pure c) where
       tails <- case c of
         One{} -> pure mempty
         Cons{} -> Seq.singleton <$> snd (tail c)
-        Merge{} -> Seq.fromList <$> (sequence . toList . tails) c
+        Merge{} -> Seq.fromList <$> (sequenceA . toList . tails) c
       step a (Set.insert (currentHash c) seen) (rest <> tails)

--- a/parser-typechecker/src/Unison/Codebase/Editor/DisplayThing.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/DisplayThing.hs
@@ -1,0 +1,12 @@
+module Unison.Codebase.Editor.DisplayThing where
+
+import Unison.Reference as Reference
+
+data DisplayThing a = BuiltinThing | MissingThing Reference.Id | RegularThing a
+  deriving (Eq, Ord, Show)
+
+toMaybe :: DisplayThing a -> Maybe a
+toMaybe = \case
+  RegularThing a -> Just a
+  _ -> Nothing
+

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -2,7 +2,6 @@
 
 module Unison.Codebase.Editor.Output
   ( Output(..)
-  , DisplayThing(..)
   , ListDetailed
   , SearchResult'(..)
   , TermResult'(..)
@@ -43,14 +42,12 @@ import qualified Unison.Term as Term
 import qualified Unison.Type as Type
 import qualified Unison.Typechecker.Context as Context
 import qualified Unison.UnisonFile as UF
+import Unison.Codebase.Editor.DisplayThing (DisplayThing)
 
 type Term v a = Term.AnnotatedTerm v a
 type Type v a = Type.AnnotatedType v a
 type ListDetailed = Bool
 type SourceName = Text
-
--- data DisplayThing a = BuiltinThing | MissingThing Reference.Id | RegularThing a
---   deriving (Eq, Ord, Show)
 
 data Output v
   -- Generic Success response; we might consider deleting this.
@@ -139,9 +136,6 @@ type ShowSuccesses = Bool -- whether to list results or just summarize
 type ShowFailures = Bool  -- whether to list results or just summarize
 
 data UndoFailureReason = CantUndoPastStart | CantUndoPastMerge deriving Show
-
-data DisplayThing a = BuiltinThing | MissingThing Reference.Id | RegularThing a
-  deriving (Eq, Ord, Show)
 
 data SearchResult' v a
   = Tm' (TermResult' v a)

--- a/parser-typechecker/src/Unison/Codebase/Metadata.hs
+++ b/parser-typechecker/src/Unison/Codebase/Metadata.hs
@@ -9,6 +9,7 @@ import Unison.Util.Star3 (Star3)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Unison.Util.Star3 as Star3
+import Unison.Util.Relation (Relation)
 
 type Type = Reference
 type Value = Reference
@@ -45,3 +46,6 @@ empty = mempty
 
 singleton :: Type -> Value -> Metadata
 singleton ty v = Map.singleton ty (Set.singleton v)
+
+toRelation :: Star a n -> Relation a n
+toRelation = Star3.d1

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -98,6 +98,7 @@ import           Unison.Var                    (Var)
 import qualified Unison.Var                    as Var
 import qualified Unison.Codebase.Editor.SlurpResult as SlurpResult
 import           System.Directory               ( getHomeDirectory )
+import Unison.Codebase.Editor.DisplayThing (DisplayThing(MissingThing, BuiltinThing, RegularThing))
 
 shortenDirectory :: FilePath -> IO FilePath
 shortenDirectory dir = do

--- a/parser-typechecker/src/Unison/DataDeclaration.hs
+++ b/parser-typechecker/src/Unison/DataDeclaration.hs
@@ -50,6 +50,9 @@ type ConstructorId = Int
 type DataDeclaration v = DataDeclaration' v ()
 type Decl v a = Either (EffectDeclaration' v a) (DataDeclaration' v a)
 
+declDependencies :: Ord v => Decl v a -> Set Reference
+declDependencies = either (dependencies . toDataDecl) dependencies
+
 data Modifier = Structural | Unique Text -- | Opaque (Set Reference)
   deriving (Eq, Ord, Show)
 

--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -26,6 +26,7 @@ import qualified Unison.ABT                 as ABT
 import qualified Unison.Blank               as Blank
 import           Unison.DataDeclaration     (DataDeclaration',
                                              EffectDeclaration')
+import qualified Unison.Name                as Name
 import qualified Unison.Names2              as Names
 import           Unison.Parser              (Ann)
 import qualified Unison.Parsers             as Parsers
@@ -121,7 +122,7 @@ synthesizeFile ambient preexistingTypes preexistingNames unisonFile = do
      where
       fqnsByShortName :: Map Name [Typechecker.NamedReference v Ann]
       fqnsByShortName = Map.fromListWith mappend
-         [ (Names.unqualified' name,
+         [ (Name.unqualified' name,
             [Typechecker.NamedReference name typ (Right r)]) |
            (name', r) <- Rel.toList $ Names.terms allTheNames,
            let name = HQ.toText name',

--- a/parser-typechecker/src/Unison/HashQualified'.hs
+++ b/parser-typechecker/src/Unison/HashQualified'.hs
@@ -2,7 +2,7 @@
 
 module Unison.HashQualified' where
 
-import           Data.Maybe                     ( fromMaybe, fromJust )
+import           Data.Maybe                     ( fromJust )
 import           Data.Text                      ( Text )
 import qualified Data.Text                     as Text
 import           Data.String                    ( IsString
@@ -23,14 +23,6 @@ data HashQualified' n = NameOnly n | HashQualified n ShortHash
   deriving (Eq, Ord)
 
 type HashQualified = HashQualified' Name
-
-stripNamespace :: Text -> HashQualified -> HashQualified
-stripNamespace namespace hq = case hq of
-  NameOnly name         -> NameOnly $ strip name
-  HashQualified name sh -> HashQualified (strip name) sh
- where
-  strip name =
-    fromMaybe name $ Name.stripPrefix (Name.Name $ namespace <> ".") name
 
 toHQ :: HashQualified' n -> HQ.HashQualified' n
 toHQ = \case

--- a/parser-typechecker/src/Unison/HashQualified.hs
+++ b/parser-typechecker/src/Unison/HashQualified.hs
@@ -11,7 +11,7 @@ import           Data.String                    ( IsString
 import           Data.Text                      ( Text )
 import qualified Data.Text                     as Text
 import           Prelude                 hiding ( take )
-import           Unison.Name                    ( Name )
+import           Unison.Name                    ( Name(Name) )
 import qualified Unison.Name                   as Name
 import           Unison.Reference               ( Reference )
 import qualified Unison.Reference              as Reference
@@ -35,7 +35,7 @@ stripNamespace namespace hq = case hq of
   ho                    -> ho
  where
   strip name =
-    fromMaybe name $ Name.stripPrefix (Name.Name $ namespace <> ".") name
+    fromMaybe name $ Name.stripNamePrefix (Name namespace) name
 
 toName :: HashQualified' n -> Maybe n
 toName = \case

--- a/parser-typechecker/src/Unison/Name.hs
+++ b/parser-typechecker/src/Unison/Name.hs
@@ -9,6 +9,8 @@ module Unison.Name
   , stripPrefixes
   , toString
   , toVar
+  , unqualified
+  , unqualified'
   , unsafeFromText
   , fromVar
   )
@@ -50,6 +52,12 @@ stripPrefixes = unsafeFromText . last . Text.splitOn "." . toText
 
 joinDot :: Name -> Name -> Name
 joinDot n1 n2 = Name $ toText n1 <> "." <> toText n2
+
+unqualified :: Name -> Name
+unqualified = unsafeFromText . unqualified' . toText
+
+unqualified' :: Text -> Text
+unqualified' = last . Text.splitOn "."
 
 instance Show Name where
   show = toString

--- a/parser-typechecker/src/Unison/Name.hs
+++ b/parser-typechecker/src/Unison/Name.hs
@@ -5,7 +5,7 @@ module Unison.Name
   , fromString
   , isPrefixOf
   , joinDot
-  , stripPrefix
+  , stripNamePrefix
   , stripPrefixes
   , toString
   , toVar
@@ -43,10 +43,23 @@ toString = Text.unpack . toText
 isPrefixOf :: Name -> Name -> Bool
 a `isPrefixOf` b = toText a `Text.isPrefixOf` toText b
 
-stripPrefix :: Name -> Name -> Maybe Name
-stripPrefix prefix name =
-  Name <$> Text.stripPrefix (toText prefix) (toText name)
+-- stripTextPrefix a.b. a.b.c = Just c
+-- stripTextPrefix a.b  a.b.c = Just .c;  you probably don't want to do this
+-- stripTextPrefix x.y. a.b.c = Nothing
+-- stripTextPrefix "" a.b.c = undefined
+_stripTextPrefix :: Text -> Name -> Maybe Name
+_stripTextPrefix prefix name =
+  Name <$> Text.stripPrefix prefix (toText name)
 
+-- stripNamePrefix a.b  a.b.c = Just c
+-- stripNamePrefix a.b. a.b.c = undefined, "a.b." isn't a valid name IMO
+-- stripNamePrefix x.y  a.b.c = Nothing, x.y isn't a prefix of a.b.c
+-- stripNamePrefix "" a.b.c = undefined, "" isn't a valid name IMO
+stripNamePrefix :: Name -> Name -> Maybe Name
+stripNamePrefix prefix name =
+  Name <$> Text.stripPrefix (toText prefix <> ".") (toText name)
+
+-- a.b.c.d -> d
 stripPrefixes :: Name -> Name
 stripPrefixes = unsafeFromText . last . Text.splitOn "." . toText
 

--- a/parser-typechecker/src/Unison/Names2.hs
+++ b/parser-typechecker/src/Unison/Names2.hs
@@ -6,22 +6,16 @@
 
 module Unison.Names2 where
 
--- import           Data.Bifunctor   (first)
-import Data.Foldable (toList)
+import           Data.Foldable (toList)
 import           Data.List        (foldl')
 import           Data.Set (Set)
---import qualified Data.Map         as Map
 import           Data.Maybe (mapMaybe)
 import qualified Data.Set         as Set
 import           Data.String      (fromString)
-import           Data.Text        (Text)
-import qualified Data.Text        as Text
--- import           Unison.ConstructorType (ConstructorType)
 import           Unison.Codebase.SearchResult   ( SearchResult )
 import qualified Unison.Codebase.SearchResult  as SR
 import           Unison.HashQualified'   (HashQualified)
 import qualified Unison.HashQualified' as HQ
--- import qualified Unison.Name      as Name
 import           Unison.Name      (Name)
 import qualified Unison.Name      as Name
 import qualified Unison.Referent  as Referent
@@ -29,7 +23,7 @@ import           Unison.Referent        (Referent(..))
 import           Unison.Reference        (Reference)
 import           Unison.Util.Relation   ( Relation )
 import qualified Unison.Util.Relation as R
-import Unison.Codebase.NameSegment (NameSegment)
+import           Unison.Codebase.NameSegment (NameSegment)
 
 -- This will support the APIs of both PrettyPrintEnv and the old Names.
 -- For pretty-printing, we need to look up names for References; they may have
@@ -319,17 +313,6 @@ contains names r =
 conflicts :: Ord n => Names' n -> Names' n
 conflicts Names{..} = Names (R.filterManyDom terms) (R.filterManyDom types)
 
-unqualified :: Name -> Name
-unqualified = Name.unsafeFromText . unqualified' . Name.toText
-
-unqualified' :: Text -> Text
-unqualified' = last . Text.splitOn "."
-
--- filterTypes :: (Name -> Bool) -> Names -> Names
--- filterTypes f (Names {..}) = Names termNames m2
---   where
---   m2 = Map.fromList $ [(k,v) | (k,v) <- Map.toList typeNames, f k]
-
 patternNameds :: Names0 -> String -> [(Reference, Int)]
 patternNameds ns s = patternNamed ns (fromString s)
 
@@ -338,27 +321,6 @@ patternNamed ns n = flip mapMaybe (toList . R.lookupDom n $ terms ns) $ \case
   Referent.Con r cid -> Just (r, cid)
   _ -> Nothing
 
--- bindType :: Var v => Names -> AnnotatedType v a -> AnnotatedType v a
--- bindType ns t = Type.bindBuiltins typeNames' t
---   where
---   typeNames' = [ (Name.toVar v, r) | (v, r) <- Map.toList $ typeNames ns ]
-
--- -- Given a mapping from name to qualified name, update a `PEnv`,
--- -- so for instance if the input has [(Some, Optional.Some)],
--- -- and `Optional.Some` is a constructor in the input `PEnv`,
--- -- the alias `Some` will map to that same constructor
--- importing :: Var v => [(v,v)] -> Names -> Names
--- importing shortToLongName0 (Names {..}) = let
---   go :: Ord k => Map k v -> (k, k) -> Map k v
---   go m (shortname, qname) = case Map.lookup qname m of
---     Nothing -> m
---     Just v  -> Map.insert shortname v m
---   shortToLongName = [
---     (Name.fromVar v, Name.fromVar v2) | (v,v2) <- shortToLongName0 ]
---   terms' = foldl' go termNames shortToLongName
---   types' = foldl' go typeNames shortToLongName
---   in Names terms' types'
---
 instance Ord n => Semigroup (Names' n) where (<>) = mappend
 
 instance Ord n => Monoid (Names' n) where

--- a/parser-typechecker/src/Unison/Reference.hs
+++ b/parser-typechecker/src/Unison/Reference.hs
@@ -57,6 +57,9 @@ data Reference
 
 pattern Derived h i n = DerivedId (Id h i n)
 
+-- A good idea, but causes a weird problem with view patterns in PatternP.hs in ghc 8.4.3
+--{-# COMPLETE Builtin, Derived #-}
+
 data Id = Id H.Hash Pos Size deriving (Eq,Ord,Generic)
 
 unsafeId :: Reference -> Id

--- a/parser-typechecker/src/Unison/ShortHash.hs
+++ b/parser-typechecker/src/Unison/ShortHash.hs
@@ -66,15 +66,17 @@ take _ b@(Builtin _) = b
 take i s@(ShortHash{..}) = s { prefix = (Text.take i prefix) }
 
 -- x `isPrefixOf` y is True iff x might be a shorter version of y
+-- if a constructor id is provided on the right-hand side, the left-hand side
+-- needs to match exactly (as of this commit).
 isPrefixOf :: ShortHash -> ShortHash -> Bool
 isPrefixOf (Builtin t) (Builtin t2) = t `Text.isPrefixOf` t2
 isPrefixOf (ShortHash h n cid) (ShortHash h2 n2 cid2) =
   (Text.isPrefixOf h h2) && (maybePrefixOf n n2) && (maybePrefixOf cid cid2)
   where
   Nothing `maybePrefixOf` Nothing = True
-  Nothing `maybePrefixOf` Just _ = True
+  Nothing `maybePrefixOf` Just _ = False
   Just _ `maybePrefixOf` Nothing = False
-  Just a `maybePrefixOf` Just b = a `Text.isPrefixOf` b
+  Just a `maybePrefixOf` Just b = a == b
 isPrefixOf _ _ = False
 
 instance Show ShortHash where

--- a/parser-typechecker/src/Unison/Term.hs
+++ b/parser-typechecker/src/Unison/Term.hs
@@ -743,6 +743,12 @@ dependencies t =
     f t@(Sequence _) = Writer.tell [Type.vectorRef] $> t
     f t             = pure t
 
+constructorDependencies :: (Ord v, Ord vt) => AnnotatedTerm2 vt at ap v a -> Set Referent
+constructorDependencies t = Set.fromList . Writer.execWriter $ ABT.visit' f t
+  where
+  f t@(Constructor r cid) = Writer.tell [Referent.Con r cid] $> t
+  f t                     = pure t
+
 referencedDataDeclarations
   :: Ord v => AnnotatedTerm2 vt at ap v a -> Set Reference
 referencedDataDeclarations t = Set.fromList . Writer.execWriter $ ABT.visit'

--- a/parser-typechecker/tests/Suite.hs
+++ b/parser-typechecker/tests/Suite.hs
@@ -18,6 +18,7 @@ import qualified Unison.Test.Typechecker.TypeError as TypeError
 import qualified Unison.Test.ColorText as ColorText
 import qualified Unison.Test.Util.Bytes as Bytes
 import qualified Unison.Test.Codebase.Path as Path
+import qualified Unison.Test.Codebase.Causal as Causal
 
 
 test :: Test ()
@@ -35,6 +36,7 @@ test = tests
   , ColorText.test
   , Bytes.test
   , Path.test
+  , Causal.test
  ]
 
 main :: IO ()

--- a/parser-typechecker/tests/Unison/Test/Codebase/Causal.hs
+++ b/parser-typechecker/tests/Unison/Test/Codebase/Causal.hs
@@ -5,6 +5,7 @@ module Unison.Test.Codebase.Causal where
 
 import EasyTest
 import Unison.Codebase.Causal (Causal(Cons, Merge), RawHash(..), one, currentHash, before)
+--import Unison.Codebase.Causal (cons, merge)
 import qualified Unison.Codebase.Causal as Causal
 import Control.Monad.Trans.State (State, state, put)
 import Data.Int (Int64)
@@ -16,6 +17,7 @@ import Data.List (foldl1')
 import Data.Functor ((<&>))
 import Unison.Hashable (Hashable)
 import Data.Set (Set)
+--import Data.Functor.Identity (Identity)
 
 c :: M (Causal M Int64 [Int64])
 c = merge (foldr cons (one [1]) t1)
@@ -23,19 +25,76 @@ c = merge (foldr cons (one [1]) t1)
   where
   t1, t2, t3 :: [[Int64]]
   t1 = fmap pure [5,4..2]
+  t2 = fmap pure [100..105]
+  t3 = fmap pure [999,998]
+
+c2 :: M (Causal M Int64 [Int64])
+c2 = merge (foldr cons (one [1]) t1)
+          (foldr cons (foldr cons (one [1]) t2) t3)
+  where
+  t1, t2, t3 :: [[Int64]]
+  t1 = fmap pure [5,4..2]
   t2 = fmap pure [10,9..2]
   t3 = fmap pure [999,998]
+
+{-
+λ> show Unison.Test.Codebase.Causal.c
+"Identity Merge 4gP [999,5] [\"3rG\",\"58U\"]"
+λ> runIdentity Unison.Test.Codebase.Causal.result
+step a=fromList [1,10] seen=[] rest=fromList [Merge 4gP [999,5] ["3rG","58U"]]
+step a=fromList [1,10] seen=["4gP"] rest=fromList [Cons 3rG [999] 4LX,Cons 58U [5] 4vC]
+step a=fromList [1,10] seen=["3rG","4gP"] rest=fromList [Cons 58U [5] 4vC,Cons 4LX [998] 26J]
+step a=fromList [1,10] seen=["3rG","4gP","58U"] rest=fromList [Cons 4LX [998] 26J,Cons 4vC [4] yFt]
+step a=fromList [1,10] seen=["3rG","4LX","4gP","58U"] rest=fromList [Cons 4vC [4] yFt,Cons 26J [100] 4FR]
+step a=fromList [1,10] seen=["3rG","4LX","4gP","4vC","58U"] rest=fromList [Cons 26J [100] 4FR,Cons yFt [3] 3So]
+step a=fromList [1,10] seen=["26J","3rG","4LX","4gP","4vC","58U"] rest=fromList [Cons yFt [3] 3So,Cons 4FR [101] 4az]
+step a=fromList [1,10] seen=["yFt","26J","3rG","4LX","4gP","4vC","58U"] rest=fromList [Cons 4FR [101] 4az,Cons 3So [2] 5Lu]
+step a=fromList [1,10] seen=["yFt","26J","3rG","4FR","4LX","4gP","4vC","58U"] rest=fromList [Cons 3So [2] 5Lu,Cons 4az [102] 2V3]
+step a=fromList [1,10] seen=["yFt","26J","3So","3rG","4FR","4LX","4gP","4vC","58U"] rest=fromList [Cons 4az [102] 2V3,One 5Lu [1]]
+step a=fromList [1,10] seen=["yFt","26J","3So","3rG","4FR","4LX","4az","4gP","4vC","58U"] rest=fromList [One 5Lu [1],Cons 2V3 [103] 5pS]
+step a=fromList [10] seen=["yFt","26J","3So","3rG","4FR","4LX","4az","4gP","4vC","58U","5Lu"] rest=fromList [Cons 2V3 [103] 5pS]
+step a=fromList [10] seen=["yFt","26J","2V3","3So","3rG","4FR","4LX","4az","4gP","4vC","58U","5Lu"] rest=fromList [Cons 5pS [104] 2tq]
+step a=fromList [10] seen=["yFt","26J","2V3","3So","3rG","4FR","4LX","4az","4gP","4vC","58U","5Lu","5pS"] rest=fromList [Cons 2tq [105] 5Lu]
+step a=fromList [10] seen=["yFt","26J","2V3","2tq","3So","3rG","4FR","4LX","4az","4gP","4vC","58U","5Lu","5pS"] rest=fromList [One 5Lu [1]]
+step a=fromList [10] seen=["yFt","26J","2V3","2tq","3So","3rG","4FR","4LX","4az","4gP","4vC","58U","5Lu","5pS"] rest=fromList []
+Unsatisfied (fromList [10])
+
+λ> runIdentity Unison.Test.Codebase.Causal.result (with c2)
+step a=fromList [1,10] seen=[] rest=fromList [Cons 2tg [999] 3AW]
+step a=fromList [1,10] seen=["2tg"] rest=fromList [Cons 3AW [998] 33b]
+step a=fromList [1,10] seen=["2tg","3AW"] rest=fromList [Cons 33b [10] 2NF]
+step a=fromList [1] seen=["2tg","33b","3AW"] rest=fromList [Cons 2NF [9] 57i]
+step a=fromList [1] seen=["2NF","2tg","33b","3AW"] rest=fromList [Cons 57i [8] ipV]
+step a=fromList [1] seen=["2NF","2tg","33b","3AW","57i"] rest=fromList [Cons ipV [7] 3BZ]
+step a=fromList [1] seen=["ipV","2NF","2tg","33b","3AW","57i"] rest=fromList [Cons 3BZ [6] 58U]
+step a=fromList [1] seen=["ipV","2NF","2tg","33b","3AW","3BZ","57i"] rest=fromList [Cons 58U [5] 4vC]
+step a=fromList [1] seen=["ipV","2NF","2tg","33b","3AW","3BZ","57i","58U"] rest=fromList [Cons 4vC [4] yFt]
+step a=fromList [1] seen=["ipV","2NF","2tg","33b","3AW","3BZ","4vC","57i","58U"] rest=fromList [Cons yFt [3] 3So]
+step a=fromList [1] seen=["ipV","yFt","2NF","2tg","33b","3AW","3BZ","4vC","57i","58U"] rest=fromList [Cons 3So [2] 5Lu]
+step a=fromList [1] seen=["ipV","yFt","2NF","2tg","33b","3AW","3BZ","3So","4vC","57i","58U"] rest=fromList [One 5Lu [1]]
+Satisfied (fromList [])
+λ>
+
+-}
 
 test :: Test ()
 test = scope "causal" . tests $ []
 --  [ scope "foldHistoryUntil" . expect $ execState c mempty == Set.fromList [3,2,1]]
 
-result :: M (Causal.FoldHistoryResult (Set Int64))
-result = Causal.foldHistoryUntil f (Set.fromList [10, 1]) =<< (do c' <- c; put mempty ; pure c') where
-  f s e = let s' = Set.difference s (Set.fromList e) in (s', Set.null s')
+--result :: M (Causal.FoldHistoryResult (Set Int64))
+--result = Causal.foldHistoryUntil f (Set.fromList [10, 1]) =<< c2 where
+--  f s e = let s' = Set.difference s (Set.fromList e) in (s', Set.null s')
 
+result, result2 :: M (Causal.FoldHistoryResult (Set Int64))
+(result, result2) =
+  (Causal.foldHistoryUntil f (Set.fromList [10, 1]) =<< (do c' <- c; put mempty ; pure c')
+  ,Causal.foldHistoryUntil f (Set.fromList [10, 1]) =<< (do c' <- c2; put mempty ; pure c'))
+  where f s e = let s' = Set.difference s (Set.fromList e) in (s', Set.null s')
+
+--type M = Identity
+
+---- special cons and merge that mess with state monad for logging
 type M = State [[Int64]]
--- special cons and merge that mess with state monad for logging
 cons :: [Int64]
      -> Causal M h [Int64]
      -> Causal M h [Int64]

--- a/parser-typechecker/tests/Unison/Test/Codebase/Causal.hs
+++ b/parser-typechecker/tests/Unison/Test/Codebase/Causal.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE PartialTypeSignatures #-}
+--{-# LANGUAGE #-}
+
+module Unison.Test.Codebase.Causal where
+
+import EasyTest
+import Unison.Codebase.Causal (Causal(Cons, Merge), RawHash(..), one, currentHash, before)
+import qualified Unison.Codebase.Causal as Causal
+import Control.Monad.Trans.State (State, state)
+import Data.Int (Int64)
+import qualified Data.Map as Map
+import Control.Monad.Extra (ifM)
+import Control.Applicative (liftA2)
+import Data.List (foldl1')
+import Data.Functor ((<&>))
+import Unison.Hashable (Hashable)
+
+c :: State [[Int64]] (Causal (State [[Int64]]) h [Int64])
+c = merge (foldr cons (one [1]) t1)
+          (foldr cons (foldr cons (one [1]) t2) t3)
+  where
+  t1, t2, t3 :: [[Int64]]
+  t1 = fmap pure [5,4..2]
+  t2 = fmap pure [10,9..2]
+  t3 = fmap pure [999,998]
+
+test :: Test ()
+test = scope "causal" . tests $ []
+--  [ scope "foldHistoryUntil" . expect $ execState c mempty == Set.fromList [3,2,1]]
+
+type M = State [[Int64]]
+-- special cons and merge that mess with state monad for logging
+cons :: [Int64]
+     -> Causal M h [Int64]
+     -> Causal M h [Int64]
+
+merge :: Causal M h [Int64]
+      -> Causal M h [Int64]
+      -> M (Causal M h [Int64])
+
+(cons, merge) = (cons'' pure, merge'' pure)
+  where
+  pure :: Causal m h [Int64] -> M (Causal m h [Int64])
+  pure c = state (\s -> (c, Causal.head c : s))
+
+cons'' :: Hashable e1
+       => (Causal m1 h e2 -> m2 (Causal m2 h e1))
+       -> e1 -> Causal m1 h e2 -> Causal m2 h e1
+cons'' pure e tl =
+  Cons (RawHash $ Causal.hash [Causal.hash e, unRawHash . currentHash $ tl]) e (currentHash tl, pure tl)
+
+merge'' :: (Monad m, Semigroup e)
+        => (Causal m h e -> m (Causal m h e))
+        -> Causal m h e -> Causal m h e -> m (Causal m h e)
+merge'' pure a b =
+  ifM (before a b) (pure b) . ifM (before b a) (pure a) $ case (a, b) of
+    (Merge _ _ tls, Merge _ _ tls2) -> merge0 $ Map.union tls tls2
+    (Merge _ _ tls, b) -> merge0 $ Map.insert (currentHash b) (pure b) tls
+    (b, Merge _ _ tls) -> merge0 $ Map.insert (currentHash b) (pure b) tls
+    (a, b) ->
+      merge0 $ Map.fromList [(currentHash a, pure a), (currentHash b, pure b)]
+  where
+  merge0 m =
+    let e = if Map.null m
+          then error "Causal.merge0 empty map"
+          else foldl1' (liftA2 (<>)) (fmap Causal.head <$> Map.elems m)
+        h = Causal.hash (Map.keys m) -- sorted order
+    in  e <&> \e -> Merge (RawHash h) e m
+

--- a/parser-typechecker/tests/Unison/Test/Codebase/Causal.hs
+++ b/parser-typechecker/tests/Unison/Test/Codebase/Causal.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE PartialTypeSignatures #-}
---{-# LANGUAGE #-}
 
 module Unison.Test.Codebase.Causal where
 

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -251,6 +251,7 @@ executable tests
   ghc-options:    -W -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -threaded -rtsopts -with-rtsopts=-N -v0
   hs-source-dirs: tests
   other-modules:
+    Unison.Test.Codebase.Causal
     Unison.Test.Codebase.Path
     Unison.Test.ColorText
     Unison.Test.Common
@@ -274,6 +275,7 @@ executable tests
     directory,
     easytest,
     errors,
+    extra,
     filepath,
     filemanip,
     lens,

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -45,6 +45,7 @@ library
     Unison.Codebase.Classes
     Unison.Codebase.CodeLookup
     Unison.Codebase.Editor.Command
+    Unison.Codebase.Editor.DisplayThing
     Unison.Codebase.Editor.Git
     Unison.Codebase.Editor.HandleInput
     Unison.Codebase.Editor.HandleCommand


### PR DESCRIPTION



Probably closes #535.

`add` the following:
```
foo = 1
bar = foo + 1

type MyEnum = X Int Int
x = MyEnum.X +3 +3
```
Then `update` with:
```
foo = "foo"
type MyEnum = Y Nat Nat
```
```
.> view.patch patch

  Edited Types: MyEnum#3Ry -> MyEnum#4t1


  Edited Terms: foo#495 -> foo#2a5

.> view bar

  bar : Nat
  bar =
    use Nat +
    foo#495 + 1

.> view x

  x : MyEnum#3Ry
  x = MyEnum.X +3 +3
```
Note, I couldn't test updating `MyEnum.X` in place due to #548.

---
Adds these search functions
```haskell
Branch.findHistoricalSHs
  :: Monad m => Set ShortHash -> Branch m -> m (Set ShortHash, Names0)

Branch.findHistoricalHQs
  :: Monad m => Set HashQualified -> Branch m -> m (Set HashQualified, Names0)

Branch.findHistoricalRefs :: Monad m => 
  Set (Either Reference Referent) -> Branch m -> m (Set (Either Reference Referent), Names0)
```
based on 
```haskell
data FoldHistoryResult a = Satisfied a | Unsatisfied a deriving (Eq,Ord,Show)
foldHistoryUntil 
  :: Monad m => (a -> e -> (a, Bool)) -> a -> Causal m h e -> m (FoldHistoryResult a)
```

and updates `view` to use them, in `ShowDefinitionI`.

---
Note: When incorporating the `Names0` that come from these search functions, put them on the RHS of `Names.unionLeftRef`, which allows adding name conflicts.