### PR TITLE
view command to report names missing from the codebase

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -44,6 +44,7 @@ import           Data.Foldable                  ( toList
                                                 )
 import qualified Data.Graph as Graph
 import qualified Data.List                      as List
+import           Data.List                      ( partition )
 import           Data.List.Extra                (nubOrd, intercalate)
 import           Data.Maybe                     ( catMaybes
                                                 , fromMaybe
@@ -554,7 +555,9 @@ loop = do
 
       -- todo: this should probably be able to show definitions by Path.HQSplit'
       ShowDefinitionI outputLoc (fmap HQ.fromString -> hqs) -> do
-        let results = searchBranchExact currentBranch' hqs
+        let resultss = searchBranchExact currentBranch' hqs
+            (misses, hits) = partition (\(_, results) -> null results) (zip hqs resultss)
+            results = List.sort . (uniqueBy SR.toReferent) $ hits >>= snd
             queryNames = Names terms types where
               terms = R.fromList [ (HQ'.toName hq, r) | SR.Tm' hq r _as <- results ]
               types = R.fromList [ (HQ'.toName hq, r) | SR.Tp' hq r _as <- results ]
@@ -651,6 +654,7 @@ loop = do
             LatestFileLocation -> fmap fst latestFile' <|> Just "scratch.u"
         do
           eval . Notify $ DisplayDefinitions loc ppe loadedDisplayTypes loadedDisplayTerms
+          eval . Notify . SearchTermsNotFound $ fmap fst misses
           -- We set latestFile to be programmatically generated, if we
           -- are viewing these definitions to a file - this will skip the
           -- next update for that file (which will happen immediately)
@@ -1123,7 +1127,8 @@ collateReferences (toList -> types) (toList -> terms) =
 -- #567 :: Int
 -- #567 = +3
 
-searchBranchExact :: Branch m -> [HQ.HashQualified] -> [SearchResult]
+-- | The result list corresponds to the query list.
+searchBranchExact :: Branch m -> [HQ.HashQualified] -> [[SearchResult]]
 searchBranchExact b queries = let
   names0 = Branch.toNames0 . Branch.head $ b
   matchesHashPrefix :: (r -> SH.ShortHash) -> (Name, r) -> HQ.HashQualified -> Bool
@@ -1132,23 +1137,23 @@ searchBranchExact b queries = let
     HQ.HashOnly q -> q `SH.isPrefixOf` toShortHash r
     HQ.HashQualified n q ->
       n == name && q `SH.isPrefixOf` toShortHash r
-  filteredTypes, filteredTerms, deduped :: [SearchResult]
-  filteredTypes =
+  searchTypes :: HQ.HashQualified -> [SearchResult]
+  searchTypes query =
     -- construct a search result with appropriately hash-qualified version of the query
     -- for each (n,r) see if it matches a query.  If so, get appropriately hash-qualified version.
     [ SR.typeResult (Names.hqTypeName names0 name r) r
                     (Names.hqTypeAliases names0 name r)
     | (name, r) <- R.toList $ Names.types names0
-    , any (matchesHashPrefix Reference.toShortHash (name, r)) queries
+    , matchesHashPrefix Reference.toShortHash (name, r) query
     ]
-  filteredTerms =
+  searchTerms :: HQ.HashQualified -> [SearchResult]
+  searchTerms query =
     [ SR.termResult (Names.hqTermName names0 name r) r
                     (Names.hqTermAliases names0 name r)
     | (name, r) <- R.toList $ Names.terms names0
-    , any (matchesHashPrefix Referent.toShortHash (name, r)) queries
+    , matchesHashPrefix Referent.toShortHash (name, r) query
     ]
-  deduped = uniqueBy SR.toReferent (filteredTypes <> filteredTerms)
-  in List.sort deduped
+  in [ searchTypes q <> searchTerms q | q <- queries ]
 
 
 respond :: Output v -> Action m i v ()

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -24,7 +24,6 @@ import Unison.Codebase.Editor.SlurpResult (SlurpResult(..))
 import Unison.Codebase.GitError
 import Unison.Codebase.Path (Path')
 import Unison.Codebase.Patch (Patch)
-import Unison.HashQualified' ( HashQualified )
 import Unison.Name ( Name )
 import Unison.Names2 ( Names, Names0 )
 import Unison.Parser ( Ann )
@@ -35,6 +34,8 @@ import Unison.Util.Relation (Relation)
 import qualified Unison.Codebase.Metadata as Metadata
 import qualified Unison.Codebase.Path as Path
 import qualified Unison.Codebase.Runtime as Runtime
+import qualified Unison.HashQualified as HQ
+import qualified Unison.HashQualified' as HQ'
 import qualified Unison.Parser as Parser
 import qualified Unison.PrettyPrintEnv as PPE
 import qualified Unison.Reference as Reference
@@ -72,6 +73,7 @@ data Output v
   | TypeNotFound Input Path.HQSplit'
   | TermNotFound Input Path.HQSplit'
   | TermNotFound' Input Reference.Id
+  | SearchTermsNotFound [HQ.HashQualified]
   -- ask confirmation before deleting the last branch that contains some defns
   -- `Path` is one of the paths the user has requested to delete, and is paired
   -- with whatever named definitions would not have any remaining names if
@@ -144,10 +146,10 @@ data SearchResult' v a
   | Tp' (TypeResult' v a)
   deriving (Eq, Show)
 data TermResult' v a =
-  TermResult' HashQualified (Maybe (Type v a)) Referent (Set HashQualified)
+  TermResult' HQ'.HashQualified (Maybe (Type v a)) Referent (Set HQ'.HashQualified)
   deriving (Eq, Show)
 data TypeResult' v a =
-  TypeResult' HashQualified (DisplayThing (Decl v a)) Reference (Set HashQualified)
+  TypeResult' HQ'.HashQualified (DisplayThing (Decl v a)) Reference (Set HQ'.HashQualified)
   deriving (Eq, Show)
 pattern Tm n t r as = Tm' (TermResult' n t r as)
 pattern Tp n t r as = Tp' (TypeResult' n t r as)
@@ -169,11 +171,11 @@ type Score = Int
 data TodoOutput v a = TodoOutput_
   { todoScore :: Int
   , todoFrontier ::
-        ( [(HashQualified, Reference, Maybe (Type v a))]
-        , [(HashQualified, Reference, DisplayThing (Decl v a))])
+        ( [(HQ'.HashQualified, Reference, Maybe (Type v a))]
+        , [(HQ'.HashQualified, Reference, DisplayThing (Decl v a))])
   , todoFrontierDependents ::
-        ( [(Score, HashQualified, Reference, Maybe (Type v a))]
-        , [(Score, HashQualified, Reference, DisplayThing (Decl v a))])
+        ( [(Score, HQ'.HashQualified, Reference, Maybe (Type v a))]
+        , [(Score, HQ'.HashQualified, Reference, DisplayThing (Decl v a))])
   , nameConflicts :: Names0
   , editConflicts :: Patch
   } deriving (Show)

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -152,6 +152,12 @@ notifyUser dir o = case o of
 
   LinkFailure input -> putPrettyLn . P.warnCallout . P.shown $ input
   EvaluationFailure err -> putPrettyLn err
+  SearchTermsNotFound hqs | null hqs -> return ()
+  SearchTermsNotFound hqs ->
+    putPrettyLn
+      $  P.warnCallout "The following names were not found in the codebase. Check your spelling."
+      <> P.newline
+      <> P.indent "  " (P.lines (prettyHashQualified <$> hqs))
   PatchNotFound input _ ->
     putPrettyLn . P.warnCallout $ "I don't know about that patch."
   TermNotFound input _ ->
@@ -474,7 +480,7 @@ displayDefinitions :: Var v => Ord a1 =>
   -> Map Reference.Reference (DisplayThing (Unison.Term.AnnotatedTerm v a1))
   -> IO ()
 displayDefinitions outputLoc ppe types terms | Map.null types && Map.null terms =
-  putPrettyLn $ noResults
+  return ()
 displayDefinitions outputLoc ppe types terms =
   maybe displayOnly scratchAndDisplay outputLoc
   where


### PR DESCRIPTION
Before:

```
.> view foo bar

  😶
  
  No results. Check your spelling, or try using tab completion to supply command arguments.

.> 
```

After:

```
.> view foo bar

  ⚠️
  
  The following names were not found in the codebase. Check your spelling.
    foo
    bar

.> 
```
---
Before:

```
.> view Nat.+ foo bar

  -- Nat.+ is built-in.

.> 
```

After:

```
.> view Nat.+ foo bar

  -- Nat.+ is built-in.


  ⚠️
  
  The following names were not found in the codebase. Check your spelling.
    foo
    bar

.> 
```