### PR TITLE
Pretty-printer support for colored output

### DIFF
--- a/parser-typechecker/src/Unison/DeclPrinter.hs
+++ b/parser-typechecker/src/Unison/DeclPrinter.hs
@@ -21,6 +21,8 @@ import           Unison.PrettyPrintEnv          ( PrettyPrintEnv )
 import qualified Unison.PrettyPrintEnv         as PPE
 import qualified Unison.Referent               as Referent
 import           Unison.Reference               ( Reference )
+import qualified Unison.SyntaxHighlights       as S
+import           Unison.SyntaxHighlights        ( fmt )
 import qualified Unison.Term                   as Term
 import qualified Unison.Type                   as Type
 import qualified Unison.TypePrinter            as TypePrinter
@@ -53,13 +55,13 @@ prettyGADT env r name dd = P.hang header . P.lines $ constructor <$> zip
  where
   constructor (n, (_, _, t)) =
     prettyPattern env r name n
-      <>       " :"
+      <>       (fmt S.TypeAscriptionColon " :")
       `P.hang` TypePrinter.pretty env Map.empty (-1) t
-  header = prettyEffectHeader name (DD.EffectDeclaration dd) <> " where"
+  header = prettyEffectHeader name (DD.EffectDeclaration dd) <> (fmt S.ControlKeyword " where")
 
 prettyPattern
   :: PrettyPrintEnv -> Reference -> HashQualified -> Int -> Pretty ColorText
-prettyPattern env r namespace n = prettyHashQualified
+prettyPattern env r namespace n = fmt S.Constructor $ prettyHashQualified
   ( HQ.stripNamespace (fromMaybe "" $ Name.toText <$> HQ.toName namespace)
   $ PPE.patternName env r n
   )
@@ -72,7 +74,7 @@ prettyDataDecl
   -> DataDeclaration' v a
   -> Pretty ColorText
 prettyDataDecl env r name dd =
-  (header <>) . P.sep (" | " `P.orElse` "\n  | ") $ constructor <$> zip
+  (header <>) . P.sep (fmt S.DelimiterChar (" | " `P.orElse` "\n  | ")) $ constructor <$> zip
     [0 ..]
     (DD.constructors' dd)
  where
@@ -83,13 +85,13 @@ prettyDataDecl env r name dd =
     Just ts -> case fieldNames env r name dd of
       Nothing -> P.group . P.hang' (prettyPattern env r name n) "      "
                $ P.spaced (TypePrinter.pretty0 env Map.empty 10 <$> init ts)
-      Just fs -> P.group $ "{ "
-                        <> P.sep ("," <> " " `P.orElse` "\n      ")
+      Just fs -> P.group $ (fmt S.DelimiterChar "{ ")
+                        <> P.sep ((fmt S.DelimiterChar ",") <> " " `P.orElse` "\n      ")
                                  (field <$> zip fs (init ts))
-                        <> " }"
-  field (fname, typ) = P.group $
-    prettyHashQualified fname <> " :" `P.hang` TypePrinter.pretty0 env Map.empty (-1) typ
-  header = prettyDataHeader name dd <> (" = " `P.orElse` "\n  = ")
+                        <> (fmt S.DelimiterChar " }")
+  field (fname, typ) = P.group $ prettyHashQualified fname <> 
+    (fmt S.TypeAscriptionColon " :") `P.hang` TypePrinter.pretty0 env Map.empty (-1) typ
+  header = prettyDataHeader name dd <> (fmt S.DelimiterChar (" = " `P.orElse` "\n  = "))
 
 -- Comes up with field names for a data declaration which has the form of a
 -- record, like `type Pt = { x : Int, y : Int }`. Works by generating the
@@ -138,22 +140,22 @@ fieldNames env r name dd = case DD.constructors dd of
 prettyModifier :: DD.Modifier -> Pretty ColorText
 prettyModifier DD.Structural = mempty
 prettyModifier (DD.Unique _uid) =
-  P.hiBlack "unique" -- <> P.hiBlack ("[" <> P.text uid <> "] ")
+  fmt S.DataTypeModifier "unique" -- <> ("[" <> P.text uid <> "] ")
 
 prettyDataHeader :: Var v => HashQualified -> DD.DataDeclaration' v a -> Pretty ColorText
 prettyDataHeader name dd =
   P.sepNonEmpty " " [
     prettyModifier (DD.modifier dd),
-    P.hiBlue "type",
-    P.blue (prettyHashQualified name),
-    P.sep " " (P.text . Var.name <$> DD.bound dd) ]
+    fmt S.DataTypeKeyword "type",
+    fmt S.DataType (prettyHashQualified name),
+    P.sep " " (fmt S.DataTypeParams . P.text . Var.name <$> DD.bound dd) ]
 
 prettyEffectHeader :: Var v => HashQualified -> DD.EffectDeclaration' v a -> Pretty ColorText
 prettyEffectHeader name ed = P.sepNonEmpty " " [
   prettyModifier (DD.modifier (DD.toDataDecl ed)),
-  P.hiBlue "ability",
-  P.blue (prettyHashQualified name),
-  P.sep " " (P.text . Var.name <$> DD.bound (DD.toDataDecl ed)) ]
+  fmt S.DataTypeKeyword "ability",
+  fmt S.DataType (prettyHashQualified name),
+  P.sep " " (fmt S.DataTypeParams . P.text . Var.name <$> DD.bound (DD.toDataDecl ed)) ]
 
 prettyDeclHeader
   :: Var v

--- a/parser-typechecker/src/Unison/DeclPrinter.hs
+++ b/parser-typechecker/src/Unison/DeclPrinter.hs
@@ -16,7 +16,7 @@ import qualified Unison.DataDeclaration        as DD
 import           Unison.HashQualified           ( HashQualified )
 import qualified Unison.HashQualified          as HQ
 import qualified Unison.Name                   as Name
-import           Unison.NamePrinter             ( prettyHashQualified )
+import           Unison.NamePrinter             ( styleHashQualified'' )
 import           Unison.PrettyPrintEnv          ( PrettyPrintEnv )
 import qualified Unison.PrettyPrintEnv         as PPE
 import qualified Unison.Referent               as Referent
@@ -61,7 +61,7 @@ prettyGADT env r name dd = P.hang header . P.lines $ constructor <$> zip
 
 prettyPattern
   :: PrettyPrintEnv -> Reference -> HashQualified -> Int -> Pretty ColorText
-prettyPattern env r namespace n = fmt S.Constructor $ prettyHashQualified
+prettyPattern env r namespace n = styleHashQualified'' (fmt S.Constructor)
   ( HQ.stripNamespace (fromMaybe "" $ Name.toText <$> HQ.toName namespace)
   $ PPE.patternName env r n
   )
@@ -89,7 +89,7 @@ prettyDataDecl env r name dd =
                         <> P.sep ((fmt S.DelimiterChar ",") <> " " `P.orElse` "\n      ")
                                  (field <$> zip fs (init ts))
                         <> (fmt S.DelimiterChar " }")
-  field (fname, typ) = P.group $ prettyHashQualified fname <> 
+  field (fname, typ) = P.group $ styleHashQualified'' (fmt S.Constructor) fname <> 
     (fmt S.TypeAscriptionColon " :") `P.hang` TypePrinter.pretty0 env Map.empty (-1) typ
   header = prettyDataHeader name dd <> (fmt S.DelimiterChar (" = " `P.orElse` "\n  = "))
 
@@ -147,14 +147,14 @@ prettyDataHeader name dd =
   P.sepNonEmpty " " [
     prettyModifier (DD.modifier dd),
     fmt S.DataTypeKeyword "type",
-    fmt S.DataType (prettyHashQualified name),
+    styleHashQualified'' (fmt S.DataType) name,
     P.sep " " (fmt S.DataTypeParams . P.text . Var.name <$> DD.bound dd) ]
 
 prettyEffectHeader :: Var v => HashQualified -> DD.EffectDeclaration' v a -> Pretty ColorText
 prettyEffectHeader name ed = P.sepNonEmpty " " [
   prettyModifier (DD.modifier (DD.toDataDecl ed)),
   fmt S.DataTypeKeyword "ability",
-  fmt S.DataType (prettyHashQualified name),
+  styleHashQualified'' (fmt S.DataType) name,
   P.sep " " (fmt S.DataTypeParams . P.text . Var.name <$> DD.bound (DD.toDataDecl ed)) ]
 
 prettyDeclHeader

--- a/parser-typechecker/src/Unison/NamePrinter.hs
+++ b/parser-typechecker/src/Unison/NamePrinter.hs
@@ -7,6 +7,8 @@ import           Unison.Name          (Name)
 import qualified Unison.Name          as Name
 import           Unison.ShortHash     (ShortHash)
 import qualified Unison.ShortHash     as SH
+import qualified Unison.SyntaxHighlights as S
+import           Unison.SyntaxHighlights ( fmt )
 import           Unison.Util.Pretty   (Pretty, ColorText)
 import qualified Unison.Util.Pretty   as PP
 
@@ -14,7 +16,7 @@ prettyName :: IsString s => Name -> Pretty s
 prettyName = PP.text . Name.toText
 
 prettyHashQualified :: HQ.HashQualified -> Pretty ColorText
-prettyHashQualified = styleHashQualified' id PP.hiBlack
+prettyHashQualified = styleHashQualified' id (fmt S.HashQualifier)
 
 prettyHashQualified' :: HQ'.HashQualified -> Pretty ColorText
 prettyHashQualified' = prettyHashQualified . HQ'.toHQ
@@ -39,3 +41,8 @@ styleHashQualified' nameStyle hashStyle = \case
   HQ.HashOnly h -> hashStyle (prettyShortHash h)
   HQ.HashQualified n h ->
     PP.group $ nameStyle (prettyName n) <> hashStyle (prettyShortHash h)
+
+styleHashQualified'' :: (Pretty ColorText -> Pretty ColorText)
+                     -> HQ.HashQualified
+                     -> Pretty ColorText
+styleHashQualified'' nameStyle = styleHashQualified' nameStyle (fmt S.HashQualifier)

--- a/parser-typechecker/src/Unison/SyntaxHighlights.hs
+++ b/parser-typechecker/src/Unison/SyntaxHighlights.hs
@@ -1,0 +1,40 @@
+module Unison.SyntaxHighlights where
+
+import Unison.Util.ColorText
+
+-- The elements of the Unison grammar, for syntax highlighting purposes
+data Element = NumericLiteral
+             | TextLiteral
+             | BooleanLiteral
+             | Blank
+             | Var
+             | Reference
+             | Constructor
+             | Request
+             -- let|alias|handle|in|namespace|type|ability|where|case|of|->|if|then|else|and|or
+             | ControlKeyword 
+             | TypeAscriptionColon
+             -- forall|∀|->
+             | TypeOperator
+             | UseStatement
+             -- , ` [ ] { } @ | =
+             | DelimiterChar
+             | Parenthesis
+
+-- TODO this is currently just inspired by the sublime haskell colors - what would people rather?
+defaultColors :: Element -> ColorText -> ColorText
+defaultColors = \case 
+  NumericLiteral      -> purple
+  TextLiteral         -> yellow
+  BooleanLiteral      -> cyan
+  Blank               -> hiCyan
+  Var                 -> white
+  Reference           -> green
+  Constructor         -> green
+  Request             -> green
+  ControlKeyword      -> red
+  TypeAscriptionColon -> red
+  TypeOperator        -> red
+  UseStatement        -> white
+  DelimiterChar       -> white
+  Parenthesis         -> white

--- a/parser-typechecker/src/Unison/SyntaxHighlights.hs
+++ b/parser-typechecker/src/Unison/SyntaxHighlights.hs
@@ -22,7 +22,7 @@ data Element = NumericLiteral
              | UseKeyword
              | UsePrefix
              | UseSuffix
-             -- ? ! , ` [ ] { } @ | = _
+             -- ? ! , ' ` [ ] { } @ | = _
              | DelimiterChar
              | Parenthesis
 

--- a/parser-typechecker/src/Unison/SyntaxHighlights.hs
+++ b/parser-typechecker/src/Unison/SyntaxHighlights.hs
@@ -12,18 +12,29 @@ data Element = NumericLiteral
              | Reference
              | Constructor
              | Request
-             -- let|alias|handle|in|namespace|type|ability|where|case|of|->|if|then|else|and|or
+             | AbilityBraces
+             -- let|alias|handle|in|namespace|where|case|of|->|if|then|else|and|or
              | ControlKeyword 
              | BindingEquals
-             | TypeAscriptionColon
              -- forall|∀|->
              | TypeOperator
+             | TypeAscriptionColon
+             -- type|ability
+             | DataTypeKeyword
+             | DataTypeParams
+             | DataType
+             -- unique
+             | DataTypeModifier
              -- `use Foo bar` is keyword, prefix, suffix
              | UseKeyword
              | UsePrefix
              | UseSuffix
              -- ? ! , ' ` [ ] { } @ | = _
+             -- Currently not all commas in the pretty-print output are marked up as DelimiterChar - we miss
+             -- out characters emitted by Pretty.hs helpers like Pretty.commas.
+             | DelayForceChar
              | DelimiterChar
+             -- ! '
              | Parenthesis
 
 defaultColors :: Element -> ColorText -> ColorText
@@ -35,14 +46,20 @@ defaultColors = \case
   Var                 -> white
   Reference           -> green
   Constructor         -> green
-  Request             -> green
+  Request             -> hiGreen
+  AbilityBraces       -> hiGreen
   ControlKeyword      -> red
   BindingEquals       -> red
-  TypeAscriptionColon -> red
   TypeOperator        -> red
+  TypeAscriptionColon -> hiBlack
+  DataTypeKeyword     -> hiBlue
+  DataType            -> blue
+  DataTypeParams      -> white
+  DataTypeModifier    -> hiBlack
   UseKeyword          -> hiBlack
   UsePrefix           -> hiBlack
   UseSuffix           -> hiBlack
+  DelayForceChar      -> yellow
   DelimiterChar       -> white
   Parenthesis         -> white
 

--- a/parser-typechecker/src/Unison/SyntaxHighlights.hs
+++ b/parser-typechecker/src/Unison/SyntaxHighlights.hs
@@ -13,11 +13,11 @@ data Element = NumericLiteral
              | Constructor
              | Request
              | AbilityBraces
-             -- let|alias|handle|in|namespace|where|case|of|->|if|then|else|and|or
+             -- let|handle|in|where|case|of|->|if|then|else|and|or
              | ControlKeyword 
-             | BindingEquals
-             -- forall|∀|->
+             -- forall|->
              | TypeOperator
+             | BindingEquals
              | TypeAscriptionColon
              -- type|ability
              | DataTypeKeyword
@@ -29,10 +29,11 @@ data Element = NumericLiteral
              | UseKeyword
              | UsePrefix
              | UseSuffix
-             -- ? ! , ' ` [ ] { } @ | = _
+             | HashQualifier
+             | DelayForceChar
+             -- ? , ` [ ] @ |
              -- Currently not all commas in the pretty-print output are marked up as DelimiterChar - we miss
              -- out characters emitted by Pretty.hs helpers like Pretty.commas.
-             | DelayForceChar
              | DelimiterChar
              -- ! '
              | Parenthesis
@@ -49,8 +50,8 @@ defaultColors = \case
   Request             -> hiGreen
   AbilityBraces       -> hiGreen
   ControlKeyword      -> red
-  BindingEquals       -> red
   TypeOperator        -> red
+  BindingEquals       -> hiBlack
   TypeAscriptionColon -> hiBlack
   DataTypeKeyword     -> hiBlue
   DataType            -> blue
@@ -59,6 +60,7 @@ defaultColors = \case
   UseKeyword          -> hiBlack
   UsePrefix           -> hiBlack
   UseSuffix           -> hiBlack
+  HashQualifier       -> hiBlack
   DelayForceChar      -> yellow
   DelimiterChar       -> white
   Parenthesis         -> white

--- a/parser-typechecker/src/Unison/SyntaxHighlights.hs
+++ b/parser-typechecker/src/Unison/SyntaxHighlights.hs
@@ -1,6 +1,7 @@
 module Unison.SyntaxHighlights where
 
 import Unison.Util.ColorText
+import Unison.Util.Pretty             ( Pretty )
 
 -- The elements of the Unison grammar, for syntax highlighting purposes
 data Element = NumericLiteral
@@ -13,6 +14,7 @@ data Element = NumericLiteral
              | Request
              -- let|alias|handle|in|namespace|type|ability|where|case|of|->|if|then|else|and|or
              | ControlKeyword 
+             | BindingEquals
              | TypeAscriptionColon
              -- forall|∀|->
              | TypeOperator
@@ -20,7 +22,7 @@ data Element = NumericLiteral
              | UseKeyword
              | UsePrefix
              | UseSuffix
-             -- ? ! , ` [ ] { } @ | =
+             -- ? ! , ` [ ] { } @ | = _
              | DelimiterChar
              | Parenthesis
 
@@ -35,10 +37,14 @@ defaultColors = \case
   Constructor         -> green
   Request             -> green
   ControlKeyword      -> red
+  BindingEquals       -> red
   TypeAscriptionColon -> red
   TypeOperator        -> red
-  UseKeyword          -> white
-  UsePrefix           -> white
-  UseSuffix           -> white
+  UseKeyword          -> hiBlack
+  UsePrefix           -> hiBlack
+  UseSuffix           -> hiBlack
   DelimiterChar       -> white
   Parenthesis         -> white
+
+fmt :: Element -> Pretty ColorText -> Pretty ColorText
+fmt e = fmap $ defaultColors e

--- a/parser-typechecker/src/Unison/SyntaxHighlights.hs
+++ b/parser-typechecker/src/Unison/SyntaxHighlights.hs
@@ -16,12 +16,14 @@ data Element = NumericLiteral
              | TypeAscriptionColon
              -- forall|∀|->
              | TypeOperator
-             | UseStatement
-             -- , ` [ ] { } @ | =
+             -- `use Foo bar` is keyword, prefix, suffix
+             | UseKeyword
+             | UsePrefix
+             | UseSuffix
+             -- ? ! , ` [ ] { } @ | =
              | DelimiterChar
              | Parenthesis
 
--- TODO this is currently just inspired by the sublime haskell colors - what would people rather?
 defaultColors :: Element -> ColorText -> ColorText
 defaultColors = \case 
   NumericLiteral      -> purple
@@ -35,6 +37,8 @@ defaultColors = \case
   ControlKeyword      -> red
   TypeAscriptionColon -> red
   TypeOperator        -> red
-  UseStatement        -> white
+  UseKeyword          -> white
+  UsePrefix           -> white
+  UseSuffix           -> white
   DelimiterChar       -> white
   Parenthesis         -> white

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -54,11 +54,8 @@ import qualified Unison.DataDeclaration        as DD
 import Unison.DataDeclaration (pattern TuplePattern, pattern TupleTerm')
 
 --TODO #287:
---  - rebase onto branchless
 --  - (fix Pair/Unit tuple FQN elision)
 --  - hash qualification
---  - PP.commas etc
---  - DeclPrinter
 
 -- Information about the context in which a term appears, which affects how the
 -- term should be rendered.
@@ -184,10 +181,10 @@ pretty n AmbientContext { precedence = p, blockContext = bc, infixContext = ic, 
         <> PP.softbreak
         <> ((fmt S.ControlKeyword "in") `PP.hang` (uses $ [pretty n (ac 2 Block im') body]))
     App' x (Constructor' DD.UnitRef 0) ->
-      paren (p >= 11) $ (fmt S.DelimiterChar $ l "!") <> pretty n (ac 11 Normal im) x
+      paren (p >= 11) $ (fmt S.DelayForceChar $ l "!") <> pretty n (ac 11 Normal im) x
     AskInfo' x -> paren (p >= 11) $ pretty n (ac 11 Normal im) x <> (fmt S.DelimiterChar $ l "?")
     LamNamed' v x | (Var.name v) == "()" ->
-      paren (p >= 11) $ (fmt S.DelimiterChar $ l "'") <> pretty n (ac 11 Normal im) x
+      paren (p >= 11) $ (fmt S.DelayForceChar $ l "'") <> pretty n (ac 11 Normal im) x
     Sequence' xs -> PP.group $
       (fmt S.DelimiterChar $ l "[") <> optSpace
           <> intercalateMap ((fmt S.DelimiterChar $ l ",") <> PP.softbreak <> optSpace <> optSpace)

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -271,7 +271,7 @@ pretty n AmbientContext { precedence = p, blockContext = bc, infixContext = ic, 
     where
     lhs = PP.group (fst (prettyPattern n (ac 0 Block im) (-1) vs pat) <> " ")
        <> printGuard guard
-       <> (fmt S.ControlKeyword " ->")
+       <> (fmt S.ControlKeyword "->")
     printGuard (Just g) = PP.group $ PP.spaced [(fmt S.DelimiterChar "|"), pretty n (ac 2 Normal im) g, ""]
     printGuard Nothing  = mempty
     (im', uses) = calcImports im body

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -53,6 +53,13 @@ import qualified Unison.PrettyPrintEnv         as PrettyPrintEnv
 import qualified Unison.DataDeclaration        as DD
 import Unison.DataDeclaration (pattern TuplePattern, pattern TupleTerm')
 
+--TODO #287:
+--  - rebase onto branchless
+--  - (fix Pair/Unit tuple FQN elision)
+--  - hash qualification
+--  - PP.commas etc
+--  - DeclPrinter
+
 -- Information about the context in which a term appears, which affects how the
 -- term should be rendered.
 data AmbientContext = AmbientContext

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -36,6 +36,7 @@ import qualified Unison.Pattern                as Pattern
 import           Unison.PatternP                ( Pattern )
 import qualified Unison.PatternP               as PatternP
 import qualified Unison.Referent               as Referent
+import qualified Unison.SyntaxHighlights       as S
 import           Unison.Term
 import           Debug.Trace                    ( trace )
 import           Unison.Type                    ( AnnotatedType )
@@ -143,7 +144,7 @@ pretty
   -> Pretty ColorText
 pretty n AmbientContext { precedence = p, blockContext = bc, infixContext = ic, imports = im} term
   = specialCases term $ \case
-    Var' v -> parenIfInfix name ic . prettyHashQualified $ name
+    Var' v -> fmt S.Var $ parenIfInfix name ic . prettyHashQualified $ name -- TODO and similarly throughout
       -- OK since all term vars are user specified, any freshening was just added during typechecking
       where name = elideFQN im $ HQ.fromVar (Var.reset v)
     Ref' r -> parenIfInfix name ic . prettyHashQualified0 $ name
@@ -482,6 +483,9 @@ isBlank _ = False
 
 ac :: Int -> BlockContext -> Imports -> AmbientContext
 ac prec bc im = AmbientContext prec bc NonInfix im
+
+fmt :: S.Element -> Pretty ColorText -> Pretty ColorText
+fmt _ = id -- TODO - use S.defaultColors
 
 {- # FQN elision
 

--- a/parser-typechecker/src/Unison/TypePrinter.hs
+++ b/parser-typechecker/src/Unison/TypePrinter.hs
@@ -5,18 +5,20 @@
 
 module Unison.TypePrinter where
 
-import qualified Data.ListLike                 as LL
 import qualified Data.Map              as Map
 import           Data.Maybe            (isJust)
-import           Data.String           (IsString, fromString)
+import           Data.String           (fromString)
 import           Unison.HashQualified  (HashQualified)
 import           Unison.NamePrinter    ( prettyHashQualified
                                        , prettyHashQualified0)
 import           Unison.PrettyPrintEnv (PrettyPrintEnv, Imports, elideFQN)
 import qualified Unison.PrettyPrintEnv as PrettyPrintEnv
 import           Unison.Reference      (pattern Builtin)
+import qualified Unison.SyntaxHighlights as S
+import           Unison.SyntaxHighlights ( fmt )
 import           Unison.Type
 import           Unison.Util.Pretty    (ColorText, Pretty)
+import           Unison.Util.ColorText (toPlain)
 import qualified Unison.Util.Pretty    as PP
 import           Unison.Var            (Var)
 import qualified Unison.Var            as Var
@@ -50,37 +52,37 @@ prettyTop
 prettyTop ppe ty = pretty ppe mempty (-1) ty
 
 pretty
-  :: forall s v a . (IsString s, LL.ListLike s Char, Var v)
+  :: forall v a . (Var v)
   => PrettyPrintEnv
   -> Imports
   -> Int
   -> AnnotatedType v a
-  -> Pretty s
+  -> Pretty ColorText
 pretty n im p tp = pretty0 n im p (cleanup (removePureEffects tp))
 
 pretty0
-  :: forall s v a . (IsString s, LL.ListLike s Char, Var v)
+  :: forall v a . (Var v)
   => PrettyPrintEnv
   -> Imports
   -> Int
   -> AnnotatedType v a
-  -> Pretty s
+  -> Pretty ColorText
 -- p is the operator precedence of the enclosing context (a number from 0 to
 -- 11, or -1 to avoid outer parentheses unconditionally).  Function
 -- application has precedence 10.
 pretty0 n im p tp = go n im p tp
   where
-  go :: PrettyPrintEnv -> Imports -> Int -> AnnotatedType v a -> Pretty s
+  go :: PrettyPrintEnv -> Imports -> Int -> AnnotatedType v a -> Pretty ColorText
   go n im p tp = case stripIntroOuters tp of
-    Var' v     -> PP.text (Var.name v)
-    Ref' r     -> prettyHashQualified0 $ elideFQN im (PrettyPrintEnv.typeName n r)
+    Var' v     -> fmt S.Var $ PP.text (Var.name v)
+    Ref' r     -> fmt S.Reference $ prettyHashQualified0 $ elideFQN im (PrettyPrintEnv.typeName n r)
     Cycle' _ _ -> fromString "error: TypeParser does not currently emit Cycle"
     Abs' _     -> fromString "error: TypeParser does not currently emit Abs"
     Ann' _ _   -> fromString "error: TypeParser does not currently emit Ann"
     App' (Ref' (Builtin "Sequence")) x ->
-      PP.group $ "[" <> go n im 0 x <> "]"
-    DD.TupleType' [x] -> PP.parenthesizeIf (p >= 10) $ "Pair" `PP.hang` PP.spaced
-      [go n im 10 x, "()"]
+      PP.group $ (fmt S.DelimiterChar "[") <> go n im 0 x <> (fmt S.DelimiterChar "]")
+    DD.TupleType' [x] -> PP.parenthesizeIf (p >= 10) $ (fmt S.Reference "Pair") `PP.hang` PP.spaced
+      [go n im 10 x, (fmt S.Reference "()")]
     DD.TupleType' xs  -> PP.parenthesizeCommas $ map (go n im 0) xs
     Apps' f xs -> PP.parenthesizeIf (p >= 10) $ go n im 9 f `PP.hang` PP.spaced
       (go n im 10 <$> xs)
@@ -91,7 +93,7 @@ pretty0 n im p tp = go n im p tp
       then go n im p body
       else
         paren True
-        $         ("∀ " <> PP.text (Var.name v) <> ".")
+        $         ((fmt S.TypeOperator "∀ ") <> (fmt S.Var $ PP.text (Var.name v)) <> (fmt S.TypeOperator "."))
         `PP.hang` go n im (-1) body
     t@(Arrow' _ _) -> case t of
       EffectfulArrows' (Ref' DD.UnitRef) rest -> arrows True True rest
@@ -100,14 +102,14 @@ pretty0 n im p tp = go n im p tp
       _ -> "error"
     _ -> "error"
   effects Nothing   = mempty
-  effects (Just es) = PP.group $ "{" <> PP.commas (go n im 0 <$> es) <> "}"
+  effects (Just es) = PP.group $ (fmt S.DelimiterChar "{") <> PP.commas (go n im 0 <$> es) <> (fmt S.DelimiterChar "}")
   arrow delay first mes =
-    (if first then mempty else PP.softbreak <> "->")
-      <> (if delay then (if first then "'" else " '") else mempty)
+    (if first then mempty else PP.softbreak <> (fmt S.TypeOperator "->"))
+      <> (if delay then (if first then (fmt S.DelimiterChar "'") else (fmt S.DelimiterChar " '")) else mempty)
       <> effects mes
       <> if (isJust mes) || (not delay) && (not first) then " " else mempty
 
-  arrows delay first [(mes, Ref' DD.UnitRef)] = arrow delay first mes <> "()"
+  arrows delay first [(mes, Ref' DD.UnitRef)] = arrow delay first mes <> (fmt S.Reference "()")
   arrows delay first ((mes, Ref' DD.UnitRef) : rest) =
     arrow delay first mes <> (parenNoGroup delay $ arrows True True rest)
   arrows delay first ((mes, arg) : rest) =
@@ -120,18 +122,16 @@ pretty0 n im p tp = go n im p tp
   arrows False True  [] = mempty  -- not reachable
   arrows True  _     [] = mempty  -- not reachable
 
-  paren True  s = PP.group $ "(" <> s <> ")"
+  paren True  s = PP.group $ ( fmt S.Parenthesis "(" ) <> s <> ( fmt S.Parenthesis ")" )
   paren False s = PP.group s
 
-  parenNoGroup True  s = "(" <> s <> ")"
+  parenNoGroup True  s = ( fmt S.Parenthesis "(" ) <> s <> ( fmt S.Parenthesis ")" )
   parenNoGroup False s = s
 
-  -- parenNest useParen contents = PP.Nest "  " $ paren useParen contents
-  -- b = Breakable
 
 pretty' :: Var v => Maybe Int -> PrettyPrintEnv -> AnnotatedType v a -> String
-pretty' (Just width) n t = PP.render width $ pretty n Map.empty (-1) t
-pretty' Nothing      n t = PP.render maxBound $ pretty n Map.empty (-1) t
+pretty' (Just width) n t = toPlain $ PP.render width $ pretty n Map.empty (-1) t
+pretty' Nothing      n t = toPlain $ PP.render maxBound $ pretty n Map.empty (-1) t
 
 -- todo: provide sample output in comment
 prettySignatures'
@@ -139,8 +139,8 @@ prettySignatures'
   -> [(HashQualified, AnnotatedType v a)]
   -> [Pretty ColorText]
 prettySignatures' env ts = PP.align
-  [ (prettyHashQualified name, (": " <> PP.map fromString (pretty env Map.empty (-1) typ)) `PP.orElse`
-                   (": " <> PP.indentNAfterNewline 2 (PP.map fromString (pretty env Map.empty (-1) typ))))
+  [ (prettyHashQualified name, ((fmt S.TypeAscriptionColon ": ") <> (pretty env Map.empty (-1) typ)) `PP.orElse`
+                   ((fmt S.TypeAscriptionColon ": ") <> PP.indentNAfterNewline 2 (pretty env Map.empty (-1) typ)))
   | (name, typ) <- ts
   ]
 
@@ -150,8 +150,8 @@ prettySignaturesAlt'
   -> [([HashQualified], AnnotatedType v a)]
   -> [Pretty ColorText]
 prettySignaturesAlt' env ts = PP.align
-  [ (PP.commas . fmap prettyHashQualified $ names, (": " <> PP.map fromString (pretty env Map.empty (-1) typ)) `PP.orElse`
-     (": " <> PP.indentNAfterNewline 2 (PP.map fromString (pretty env Map.empty (-1) typ))))
+  [ (PP.commas . fmap prettyHashQualified $ names, ((fmt S.TypeAscriptionColon ": ") <> (pretty env Map.empty (-1) typ)) `PP.orElse`
+     ((fmt S.TypeAscriptionColon ": ") <> PP.indentNAfterNewline 2 (pretty env Map.empty (-1) typ)))
   | (names, typ) <- ts
   ]
 
@@ -173,5 +173,3 @@ prettySignaturesAlt
   -> Pretty ColorText
 prettySignaturesAlt env ts = PP.lines $
   PP.group <$> prettySignaturesAlt' env ts
-
-

--- a/parser-typechecker/src/Unison/TypePrinter.hs
+++ b/parser-typechecker/src/Unison/TypePrinter.hs
@@ -47,8 +47,8 @@ import qualified Unison.DataDeclaration as DD
 -}
 
 prettyTop
-  :: forall s v a . (IsString s, LL.ListLike s Char, Var v)
-  => PrettyPrintEnv -> AnnotatedType v a -> Pretty s
+  :: forall v a . (Var v)
+  => PrettyPrintEnv -> AnnotatedType v a -> Pretty ColorText
 prettyTop ppe ty = pretty ppe mempty (-1) ty
 
 pretty

--- a/parser-typechecker/src/Unison/TypePrinter.hs
+++ b/parser-typechecker/src/Unison/TypePrinter.hs
@@ -9,13 +9,12 @@ import qualified Data.Map              as Map
 import           Data.Maybe            (isJust)
 import           Data.String           (fromString)
 import           Unison.HashQualified  (HashQualified)
-import           Unison.NamePrinter    ( prettyHashQualified
-                                       , prettyHashQualified0)
+import           Unison.NamePrinter    (styleHashQualified'')
 import           Unison.PrettyPrintEnv (PrettyPrintEnv, Imports, elideFQN)
 import qualified Unison.PrettyPrintEnv as PrettyPrintEnv
 import           Unison.Reference      (pattern Builtin)
 import qualified Unison.SyntaxHighlights as S
-import           Unison.SyntaxHighlights ( fmt )
+import           Unison.SyntaxHighlights (fmt)
 import           Unison.Type
 import           Unison.Util.Pretty    (ColorText, Pretty)
 import           Unison.Util.ColorText (toPlain)
@@ -76,7 +75,7 @@ pretty0 n im p tp = go n im p tp
   go n im p tp = case stripIntroOuters tp of
     Var' v     -> fmt S.Var $ PP.text (Var.name v)
     -- Would be nice to use a different SyntaxHighlights color if the reference is an ability.
-    Ref' r     -> fmt S.DataType $ prettyHashQualified0 $ elideFQN im (PrettyPrintEnv.typeName n r)
+    Ref' r     -> styleHashQualified'' (fmt S.DataType) $ elideFQN im (PrettyPrintEnv.typeName n r)
     Cycle' _ _ -> fromString "error: TypeParser does not currently emit Cycle"
     Abs' _     -> fromString "error: TypeParser does not currently emit Abs"
     Ann' _ _   -> fromString "error: TypeParser does not currently emit Ann"
@@ -140,7 +139,7 @@ prettySignatures'
   -> [(HashQualified, AnnotatedType v a)]
   -> [Pretty ColorText]
 prettySignatures' env ts = PP.align
-  [ (prettyHashQualified name, ((fmt S.TypeAscriptionColon ": ") <> (pretty env Map.empty (-1) typ)) `PP.orElse`
+  [ (styleHashQualified'' (fmt S.DataType) name, ((fmt S.TypeAscriptionColon ": ") <> (pretty env Map.empty (-1) typ)) `PP.orElse`
                    ((fmt S.TypeAscriptionColon ": ") <> PP.indentNAfterNewline 2 (pretty env Map.empty (-1) typ)))
   | (name, typ) <- ts
   ]
@@ -151,7 +150,7 @@ prettySignaturesAlt'
   -> [([HashQualified], AnnotatedType v a)]
   -> [Pretty ColorText]
 prettySignaturesAlt' env ts = PP.align
-  [ (PP.commas . fmap prettyHashQualified $ names, ((fmt S.TypeAscriptionColon ": ") <> (pretty env Map.empty (-1) typ)) `PP.orElse`
+  [ (PP.commas . fmap (styleHashQualified'' (fmt S.DataType)) $ names, ((fmt S.TypeAscriptionColon ": ") <> (pretty env Map.empty (-1) typ)) `PP.orElse`
      ((fmt S.TypeAscriptionColon ": ") <> PP.indentNAfterNewline 2 (pretty env Map.empty (-1) typ)))
   | (names, typ) <- ts
   ]

--- a/parser-typechecker/tests/Unison/Test/TermPrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/TermPrinter.hs
@@ -354,6 +354,11 @@ test = scope "termprinter" . tests $
   , tc_breaks 80 "Stream.foldLeft 0 (+) t"
   , tc_breaks 80 "foo?"
   , tc_breaks 80 "(foo a b)?"
+  , tc_diff_rtt False "let\n\
+                      \  delay = 'isEven" 
+                      "let\n\
+                      \  delay () = isEven\n\
+                      \  _" 80 -- TODO the latter doesn't parse - can't handle the () on the LHS
 
 -- FQN elision tests
   , tc_breaks 12 "if foo then\n\

--- a/parser-typechecker/tests/Unison/Test/TermPrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/TermPrinter.hs
@@ -358,6 +358,11 @@ test = scope "termprinter" . tests $
                       "let\n\
                       \  delay () = isEven\n\
                       \  _" 80 -- TODO the latter doesn't parse - can't handle the () on the LHS
+  , tc_breaks 80 "let\n\
+                 \  a = ()\n\
+                 \  b = ()\n\
+                 \  c = (1, 2)\n\
+                 \  ()"
 
 -- FQN elision tests
   , tc_breaks 12 "if foo then\n\

--- a/parser-typechecker/tests/Unison/Test/TypePrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/TypePrinter.hs
@@ -3,7 +3,10 @@ module Unison.Test.TypePrinter where
 import EasyTest
 import qualified Data.Map as Map
 import Unison.TypePrinter
+import Unison.Symbol (Symbol)
 import qualified Unison.Builtin
+import Unison.Parser (Ann(..))
+import Unison.Util.ColorText (toPlain)
 import qualified Unison.Util.Pretty as PP
 import qualified Unison.PrettyPrintEnv as PPE
 import Unison.Test.Common
@@ -18,7 +21,7 @@ tc_diff_rtt :: Bool -> String -> String -> Int -> Test ()
 tc_diff_rtt rtt s expected width =
    let input_type = Unison.Test.Common.t s
        get_names = PPE.fromNames0 Unison.Builtin.names0
-       prettied = pretty0 get_names Map.empty (-1) input_type
+       prettied = fmap toPlain $ pretty0 get_names Map.empty (-1) input_type
        actual = if width == 0
                 then PP.renderUnbroken $ prettied
                 else PP.render width $ prettied

--- a/parser-typechecker/tests/Unison/Test/TypePrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/TypePrinter.hs
@@ -3,9 +3,7 @@ module Unison.Test.TypePrinter where
 import EasyTest
 import qualified Data.Map as Map
 import Unison.TypePrinter
-import Unison.Symbol (Symbol)
 import qualified Unison.Builtin
-import Unison.Parser (Ann(..))
 import Unison.Util.ColorText (toPlain)
 import qualified Unison.Util.Pretty as PP
 import qualified Unison.PrettyPrintEnv as PPE

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -110,6 +110,7 @@ library
     Unison.Settings
     Unison.ShortHash
     Unison.Symbol
+    Unison.SyntaxHighlights
     Unison.Term
     Unison.TermParser
     Unison.TermPrinter

--- a/unison-src/tests/rainbow.u
+++ b/unison-src/tests/rainbow.u
@@ -26,4 +26,7 @@ ability Ask a where
 
 type Either a b = Left a | Right b  
 
+unique ability Zang where
+  zang : {Zang} Nat
+
 > ()

--- a/unison-src/tests/rainbow.u
+++ b/unison-src/tests/rainbow.u
@@ -1,7 +1,7 @@
 -- Hits all the syntactic elements listed in SyntaxHighlights.hs.  
 -- Use the 'view' command to see this in colour.  
 
-rainbow : Int ->{IO} Int
+rainbow : Int ->{Ask Int} Int
 rainbow x =
   use Int isEven
   number = 3
@@ -18,7 +18,12 @@ rainbow x =
   a = if isEven x then Either.Left 0 else Either.Right 0
   b = if isEven x then 1 else 0
   c = case x of _ -> 3
-  IO.printLine text
+  d = (Ask.ask : Int)
   +42
+
+ability Ask a where
+  ask : {Ask a} a
+
+type Either a b = Left a | Right b  
 
 > ()

--- a/unison-src/tests/rainbow.u
+++ b/unison-src/tests/rainbow.u
@@ -1,0 +1,24 @@
+-- Hits all the syntactic elements listed in SyntaxHighlights.hs.  
+-- Use the 'view' command to see this in colour.  
+
+rainbow : Int ->{IO} Int
+rainbow x =
+  use Int isEven
+  number = 3
+  text = "hello"
+  float = 3.14
+  bool = false
+  lam z =
+    use Nat * +
+    z + 1 * 2
+  seq = [1, 2, 3]
+  delay : '(Int -> Boolean)
+  delay _ = isEven
+  force = !delay +2
+  a = if isEven x then Either.Left 0 else Either.Right 0
+  b = if isEven x then 1 else 0
+  c = case x of _ -> 3
+  IO.printLine text
+  +42
+
+> ()


### PR DESCRIPTION
Fixes #287 

Produces output that looks like this:
![image](https://user-images.githubusercontent.com/21991324/60759136-776f8500-a017-11e9-8ec8-114c331562d7.png)

Bikeshedding over colors welcome!  I'd recommend actually checking out the branch and playing around with how different colors look, rather than just trying to imagine.  
 - I started from the colors that sublime uses for haskell by default, FWIW.  I'm not especially attached to these.
 - Effectful stuff: uses of requests, and the braces around lists of ability type names in signatures (unfortunately not the ability type names themselves), get hiGreen.
 - Force and delay (! and ') get yellow.
 - Things I'm not super sure about:
    - does so much stuff really want to be green?
    - really red for all the control keywords, and `->`?  
    - what is something just being white meant to signify?  white stuff actually looks quite prominent  (e.g. type parameters)
    - should all the things I've lumped together as control keywords (`let|handle|in|where|case|of|->|if|then|else|and|or`) really be colored the same?  Maybe `let` and `where` should be white or even hiBlack rather than red.  Maybe `->` should be white.
    - have I successfully implemented 'types are blue', and not confused which things are type-level and which things are value-level?
        - In, say, `reverse : [a] -> [a]`, the list brackets are rendered white rather than blue - maybe wrong?

The mapping is in [SyntaxHighlights.hs](https://github.com/unisonweb/unison/blob/c255d4dfd151f998cbc71b3ead5560d96d505dbb/parser-typechecker/src/Unison/SyntaxHighlights.hs).  Some of the way this breaks things down is inspired by the [atom syntax highlighting unison grammar](https://github.com/unisonweb/unison/blob/c255d4dfd151f998cbc71b3ead5560d96d505dbb/editor-support/atom/language-unison/grammars/unison.cson).  Feel free to just change the color scheme yourself before merging.  

The pretty-printer is now free of direct uses of color markup (`hiBlack` etc), and I think should stay that way.  

My intention was that all non-whitespace characters emitted by the pretty-printer are marked up with one of the syntax highlight elements.  (I didn't quite achieve that because things like commas emitted by `Pretty.commas` aren't marked up.)  

I haven't attempted to sync this up with any other syntax highlighting that might be going on elsewhere, e.g. in error message generation.  Is there anything to do there?

This changes some of the pretty-printing functions over from returning `Pretty s` to `Pretty ColorText`.

Also smuggled in with this: a fix to avoid emitting `use () ()` or `use Pair Pair`, which are usually unnecessary due to how tuple syntax works.  Bug in FQN elision spotted by Paul.  