### PR TITLE
Pretty-printer - don't put `use` inside of the `if` condition

### DIFF
--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -203,7 +203,7 @@ pretty0 n AmbientContext { precedence = p, blockContext = bc, infixContext = ic,
        ]
      where
        height = PP.preferredHeight pt `max` PP.preferredHeight pf
-       pcond  = branch cond
+       pcond  = pretty0 n (ac 2 Block im) cond
        pt     = branch t
        pf     = branch f
        branch tm = let (im', uses) = calcImports im tm
@@ -821,7 +821,7 @@ allInSubBlock tm p s i = let found = concat $ ABT.find finder tm
 immediateChildBlockTerms :: (Var vt, Var v) => AnnotatedTerm2 vt at ap v a -> [AnnotatedTerm2 vt at ap v a]
 immediateChildBlockTerms = \case
     Handle' _ body -> [body]
-    If' cond t f -> [cond, t, f]
+    If' _ t f -> [t, f]
     tm@(LetRecNamed' bs _) -> [tm] ++ (concat $ map doLet bs)
     tm@(Lets' bs _)        -> [tm] ++ (concat $ map doLet ((map (\(_, v, binding) -> (v, binding)) bs)))
     Match' _ branches -> concat $ map doCase branches

--- a/parser-typechecker/tests/Unison/Test/TermPrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/TermPrinter.hs
@@ -419,11 +419,17 @@ test = scope "termprinter" . tests $
                  \  f (x : (∀ t. Pair t t))\n\
                  \else\n\
                  \  f (x : (∀ t. Pair t t))"
-  , tc_breaks 12 "if\n\
-                 \  use A x\n\
-                 \  f x x then\n\
-                 \  x\n\
-                 \else y"  -- missing break before 'then', issue #518
+  , tc_diff_rtt False "handle foo in\n\
+                      \  use A x\n\
+                      \  (if f x x then\n\
+                      \    x\n\
+                      \  else y)"  -- missing break before 'then', issue #518; surplus parentheses #517
+                      "handle foo\n\
+                      \in\n\
+                      \  use A x\n\
+                      \  (if f x x then\n\
+                      \    x\n\
+                      \  else y)" 15  -- parser doesn't like 'in' beginning a line
   , tc_breaks 20 "case x of\n\
                  \  () ->\n\
                  \    use A y\n\


### PR DESCRIPTION
Fixes #568

Instead of 

![image](https://user-images.githubusercontent.com/21991324/61172677-ab9af680-a57f-11e9-9dee-d0c0cd65ffd7.png)

we now get

![image](https://user-images.githubusercontent.com/21991324/61172687-df761c00-a57f-11e9-89fc-85ac39dbbcf6.png)