### PR TITLE
Possible fix #548 and fix #544 but needs review

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/SlurpResult.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/SlurpResult.hs
@@ -208,9 +208,7 @@ pretty isPast ppe sr = let
       (typeLineFor Alias <$> typeAlias') ++
       (typeLineFor Conflicted <$> toList (types (conflicts sr))) ++
       (typeLineFor Collision <$> toList (types (collisions sr))) ++
-      (typeLineFor BlockedDependency <$> toList (types (defsWithBlockedDependencies sr))) ++
-      (typeLineFor ConstructorExistingTermCollision <$> toList (constructorExistingTermCollisions sr)) ++
-      (typeLineFor TermExistingConstructorCollision <$> toList (termExistingConstructorCollisions sr))
+      (typeLineFor BlockedDependency <$> toList (types (defsWithBlockedDependencies sr)))
     termLineFor status v = case Map.lookup v tms of
       Just (_, _, ty) -> (prettyStatus status, lhs,
          ": " <> P.indentNAfterNewline 6 (TP.pretty ppe ty))


### PR DESCRIPTION
A few things seemed to be busted:

* When updating a type, the constructors of the updated type weren't being added to the namespace. I changed the call to `doSlurpAdds` inside the `update` command to include these new constructors.
* When updating a type, the constructors for the old type with names in the current path weren't being removed from the namespace. I did that, using a helper function `Names3.constructorsForType`.
* There were some things about how the slurp result was being built up that were wrong, like: 
  * constructors of types being updated could still count as a ctor/term collision.
  * duplicates were getting double counted as both duplicates and aliases.

I don't know if the `patch` command correctly removes old constructors from the namespace for types being updated, but it should probably do that.

Lastly, there are a bunch of weird corner cases to think through when the constructors for a type don't live directly under the path of the type itself. Maybe we could think through those, but I'd be in favor of just enforcing this restriction, using a check in `rename.term` and `alias.term`.
