### PR TITLE
Always print foralls in type signatures.

### DIFF
--- a/parser-typechecker/src/Unison/TypePrinter.hs
+++ b/parser-typechecker/src/Unison/TypePrinter.hs
@@ -97,14 +97,12 @@ prettyRaw n im p tp = go n im p tp
     Effect1' e t ->
       PP.parenthesizeIf (p >= 10) $ go n im 9 e <> " " <> go n im 10 t
     Effects' es         -> effects (Just es)
-    ForallNamed' v body -> if p < 0
-      then go n im p body
-      else
-        paren True
-        $         fmt S.TypeOperator "∀ "
-        <>        fmt S.Var          (PP.text $ Var.name v)
-        <>        fmt S.TypeOperator "."
-        `PP.hang` go n im (-1) body
+    ForallNamed' v body ->
+      paren (p >= 0)
+      $         fmt S.TypeOperator "∀ "
+      <>        fmt S.Var          (PP.text $ Var.name v)
+      <>        fmt S.TypeOperator "."
+      `PP.hang` go n im (-1) body
     t@(Arrow' _ _) -> case t of
       EffectfulArrows' (Ref' DD.UnitRef) rest -> arrows True True rest
       EffectfulArrows' fst rest ->


### PR DESCRIPTION
This is a proposal to always print `∀` in type signatures.

#### Current situation

Even if the user provides explicit `∀` in the source code:

```
id : ∀ a. a -> a
id a = a
```

it is not printed back:

```
      ⍟ These new definitions are ok to `add`:
    
      id : a -> a
```

#### Motivation

I think it is better to err on the side of displaying more information than what is in the source code, not less.

Also, seeing unbound variables can be confusing for beginners (I remember it used to be for me).

#### After this PR

```  
    ⍟ These new definitions are ok to `add`:
    
      id : ∀ a. a -> a
```

#### Possible improvement

If you find explicit foralls too obtrusive, they could possibly be printed in a lower contrast color.