### PR TITLE
Some prettprinting tweaks

### DIFF
--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -679,7 +679,9 @@ countPatternUsages n p = Pattern.foldMap' f p where
     Pattern.SequenceOpP _ _ _ _   -> mempty
     Pattern.EffectPureP _ _       -> mempty
     Pattern.EffectBindP _ r i _ _ -> countHQ $ PrettyPrintEnv.patternName n r i
-    Pattern.ConstructorP _ r i _  -> countHQ $ PrettyPrintEnv.patternName n r i
+    Pattern.ConstructorP _ r i _  -> 
+      if r == DD.unitRef || r == DD.pairRef then mempty
+      else countHQ $ PrettyPrintEnv.patternName n r i
 
 countHQ :: HQ.HashQualified -> PrintAnnotation
 countHQ hq = fold $ fmap countName (HQ.toName $ hq)

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -35,6 +35,7 @@ import           Unison.NamePrinter             ( styleHashQualified'' )
 import qualified Unison.Pattern                as Pattern
 import           Unison.PatternP                ( Pattern )
 import qualified Unison.PatternP               as PatternP
+import           Unison.Reference               ( Reference )
 import qualified Unison.Referent               as Referent
 import qualified Unison.Util.SyntaxText        as S
 import           Unison.Util.SyntaxText         ( SyntaxText )
@@ -119,7 +120,7 @@ data InfixContext
        3x + 3y + ... 3z
 
      >=2
-       if 2a then 2b else 2c
+       if 0a then 0b else 0c
        handle 2h in 2b
        case 2x of
          a | 2g -> 0b

--- a/parser-typechecker/tests/Unison/Test/TermPrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/TermPrinter.hs
@@ -151,7 +151,7 @@ test = scope "termprinter" . tests $
   , tc "case e of { a } -> z"
   , pending $ tc "case e of { () -> k } -> z" -- TODO doesn't parse since 'many leaf' expected before the "-> k"
                                               -- need an actual effect constructor to test this with
-  , tc "if a then (if b then c else d) else e"
+  , tc "if a then if b then c else d else e"
   , tc "handle foo in (handle bar in baz)"
   , tc_breaks 16 "case (if a then\n\
                  \  b\n\
@@ -332,8 +332,8 @@ test = scope "termprinter" . tests $
                  \  go [] a b"
   , tc_breaks 30 "case x of\n\
                  \  (Optional.None, _) -> foo"
-  , tc_breaks 50 "if true then (case x of 12 -> x) else x"  -- re parens around case note #517
-  , tc_breaks 50 "if true then x else (case x of 12 -> x)"  -- re parens around case note #517
+  , tc_breaks 50 "if true then case x of 12 -> x else x"  -- re parens around case note #517
+  , tc_breaks 50 "if true then x else case x of 12 -> x"  -- re parens around case note #517
   , pending $ tc_breaks 80 "x -> (if c then t else f)"  -- TODO 'unexpected )', surplus parens
   , tc_breaks 80 "'let\n\
                  \  foo = bar\n\

--- a/parser-typechecker/tests/Unison/Test/TermPrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/TermPrinter.hs
@@ -332,8 +332,8 @@ test = scope "termprinter" . tests $
                  \  go [] a b"
   , tc_breaks 30 "case x of\n\
                  \  (Optional.None, _) -> foo"
-  , tc_breaks 50 "if true then case x of 12 -> x else x"  -- re parens around case note #517
-  , tc_breaks 50 "if true then x else case x of 12 -> x"  -- re parens around case note #517
+  , tc_breaks 50 "if true then case x of 12 -> x else x"
+  , tc_breaks 50 "if true then x else case x of 12 -> x"
   , pending $ tc_breaks 80 "x -> (if c then t else f)"  -- TODO 'unexpected )', surplus parens
   , tc_breaks 80 "'let\n\
                  \  foo = bar\n\


### PR DESCRIPTION
Switched to excluding the `()` and `Pair` not by name, but by Reference, when building up the annotations that form the basis of the `use` insertion. @atacratic could you let me know if this change looks okay? Or does this implementation somehow break something?

Also set ambient precedence to 0 for true and false branches of if, since parser does fine without the parens, even for things like `if true then if false then 0 else 1 else 2`, which looks confusing when all one one line like that but parses okay. I'd say this fixes #517 unless there are some issues with it that I can't see.