### PR TITLE
Showing diff output in `undo`, `merge`, `pull`, also new `merge.preview` cmd

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -42,6 +42,7 @@ import qualified Unison.Hashable               as H
 import           Unison.Name                    ( Name(..) )
 import qualified Unison.Name                   as Name
 import qualified Unison.Names2                 as Names
+import qualified Unison.Names3                 as Names
 import           Unison.Names2                  ( Names'(Names), Names0 )
 import           Unison.Reference               ( Reference )
 import           Unison.Referent                ( Referent )
@@ -613,6 +614,9 @@ deleteTypeName :: Reference -> NameSegment -> Branch0 m -> Branch0 m
 deleteTypeName r n b | Star3.memberD1 (r,n) (view types b)
                      = over types (Star3.deletePrimaryD1 (r,n)) b
 deleteTypeName _ _ b = b
+
+namesDiff :: Branch m -> Branch m -> Names.Diff
+namesDiff b1 b2 = Names.diff0 (toNames0 (head b1)) (toNames0 (head b2))
 
 data RefCollisions =
   RefCollisions { termCollisions :: Relation Name Name

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -31,6 +31,7 @@ data Input
     = ForkLocalBranchI Path' Path'
     -- merge first causal into destination
     | MergeLocalBranchI Path' Path'
+    | PreviewMergeLocalBranchI Path' Path'
     | PullRemoteBranchI (Maybe RemoteRepo) Path'
     | PushRemoteBranchI (Maybe RemoteRepo) Path'
     -- todo: Q: Does it make sense to publish to not-the-root of a Github repo?

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -130,6 +130,8 @@ data Output v
   | PatchNeedsToBeConflictFree
   | PatchInvolvesExternalDependents PPE.PrettyPrintEnv (Set Reference)
   | WarnIncomingRootBranch (Set Branch.Hash)
+  | ShowDiff Input Names.Diff 
+  | NothingTodo Input 
   | NotImplemented
   deriving (Show)
 

--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -31,6 +31,10 @@ newtype Absolute = Absolute { unabsolute :: Path } deriving (Eq,Ord)
 newtype Relative = Relative { unrelative :: Path } deriving (Eq,Ord)
 newtype Path' = Path' (Either Absolute Relative) deriving (Eq,Ord)
 
+isCurrentPath :: Path' -> Bool
+isCurrentPath (Path' (Right (Relative (Path e)))) | e == mempty = True
+isCurrentPath _ = False
+
 instance Show Path' where
   show (Path' (Left abs)) = show abs
   show (Path' (Right rel)) = show rel

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -456,7 +456,9 @@ push = InputPattern
 mergeLocal :: InputPattern
 mergeLocal = InputPattern "merge" [] [(Required, pathArg)
                                      ,(Optional, pathArg)]
- "`merge foo` merges the path 'foo' into the current branch."
+ (P.column2 [
+   ("`merge src`", "merges `src` namespace into the current namespace"),
+   ("`merge src dest`", "merges `src` namespace into the `dest` namespace")])
  (\case
       [src] -> first fromString $ do
         src <- Path.parsePath' src
@@ -466,6 +468,23 @@ mergeLocal = InputPattern "merge" [] [(Required, pathArg)
         dest <- Path.parsePath' dest
         pure $ Input.MergeLocalBranchI src dest
       _ -> Left (I.help mergeLocal)
+ )
+
+previewMergeLocal :: InputPattern
+previewMergeLocal = InputPattern "merge.preview" [] [(Required, pathArg)
+                                     ,(Optional, pathArg)]
+ (P.column2 [
+   ("`merge.preview src`", "shows how the current namespace will change after a `merge src`."),
+   ("`merge.preview src dest`", "shows how `dest` namespace will change after a `merge src dest`.") ])
+ (\case
+      [src] -> first fromString $ do
+        src <- Path.parsePath' src
+        pure $ Input.PreviewMergeLocalBranchI src Path.relativeEmpty'
+      [src, dest] -> first fromString $ do
+        src <- Path.parsePath' src
+        dest <- Path.parsePath' dest
+        pure $ Input.PreviewMergeLocalBranchI src dest
+      _ -> Left (I.help previewMergeLocal)
  )
 
 -- replace,resolve :: InputPattern
@@ -652,6 +671,7 @@ validInputs =
   , update
   , forkLocal
   , mergeLocal
+  , previewMergeLocal
   , names
   , push
   , pull

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -47,6 +47,7 @@ import qualified Unison.ABT                    as ABT
 import qualified Unison.UnisonFile             as UF
 import qualified Unison.Codebase               as Codebase
 import           Unison.Codebase.GitError
+import qualified Unison.Codebase.Path          as Path
 import qualified Unison.Codebase.Patch         as Patch
 import           Unison.Codebase.Patch         (Patch(..))
 import qualified Unison.Codebase.TermEdit      as TermEdit
@@ -498,6 +499,37 @@ notifyUser dir o = case o of
   PatchNeedsToBeConflictFree -> putPrettyLn "A patch needs to be conflict-free."
   PatchInvolvesExternalDependents _ _ ->
     putPrettyLn "That patch involves external dependents."
+  ShowDiff input diff -> putPrettyLn $ case input of
+    Input.UndoI -> P.callout "⏪" . P.lines $ [
+      "Here's the changes I undid:", "",
+      prettyDiff diff
+      ]
+    Input.MergeLocalBranchI src dest -> P.callout "🆕" . P.lines $ [
+      P.wrap $ "Here's what's changed in " <> prettyPath' dest <> "after the merge:", "",
+      prettyDiff diff, "",
+      tip "You can always `undo` if this wasn't what you wanted." ]
+    Input.PullRemoteBranchI _ dest -> 
+      if Names.isEmptyDiff diff then
+        "✅  Looks like " <> prettyPath' dest <> " is up to date."
+      else P.callout "🆕" . P.lines $ [
+        P.wrap $ "Here's what's changed in " <> prettyPath' dest <> "after the pull:", "",
+        prettyDiff diff, "",
+        tip "You can always `undo` if this wasn't what you wanted." ]
+    Input.PreviewMergeLocalBranchI src dest -> P.callout "🔎" . P.lines $ [
+      P.wrap $ "Here's what would change in " <> prettyPath' dest <> "after the merge:", "",
+      prettyDiff diff
+      ]
+    _ -> prettyDiff diff
+  NothingTodo input -> putPrettyLn . P.callout "😶" $ case input of
+    Input.MergeLocalBranchI src dest -> 
+      P.wrap $ "The merge had no effect, since the destination"
+            <> P.shown dest <> "is at or ahead of the source"
+            <> P.group (P.shown src <> ".")
+    Input.PreviewMergeLocalBranchI src dest -> 
+      P.wrap $ "The merge will have no effect, since the destination"
+            <> P.shown dest <> "is at or ahead of the source"
+            <> P.group (P.shown src <> ".")
+    _ -> "Nothing to do."
   where
   _nameChange _cmd _pastTenseCmd _oldName _newName _r = error "todo"
   -- do
@@ -526,6 +558,11 @@ notifyUser dir o = case o of
 --    where
 --      ns targets = P.oxfordCommas $
 --        map (fromString . Names.renderNameTarget) (toList targets)
+
+prettyPath' :: Path.Path' -> P.Pretty P.ColorText
+prettyPath' p' = case show p' of
+  [] -> "the current path"
+  s  -> P.shown s
 
 formatMissingStuff :: (Show tm, Show typ) =>
   [(HQ.HashQualified, tm)] -> [(HQ.HashQualified, typ)] -> P.Pretty P.ColorText

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -560,9 +560,10 @@ notifyUser dir o = case o of
 --        map (fromString . Names.renderNameTarget) (toList targets)
 
 prettyPath' :: Path.Path' -> P.Pretty P.ColorText
-prettyPath' p' = case show p' of
-  [] -> "the current path"
-  s  -> P.shown s
+prettyPath' p' = 
+  if Path.isCurrentPath p'
+  then "the current path"
+  else P.shown p'
 
 formatMissingStuff :: (Show tm, Show typ) =>
   [(HQ.HashQualified, tm)] -> [(HQ.HashQualified, typ)] -> P.Pretty P.ColorText

--- a/parser-typechecker/src/Unison/Names3.hs
+++ b/parser-typechecker/src/Unison/Names3.hs
@@ -56,6 +56,12 @@ data Diff =
        , removedNames  :: Names0
        } deriving Show
 
+isEmptyDiff :: Diff -> Bool
+isEmptyDiff d = isEmpty0 (addedNames d) && isEmpty0 (removedNames d)
+
+isEmpty0 :: Names0 -> Bool
+isEmpty0 n = R.null (terms0 n) && R.null (types0 n) 
+
 -- Add `n1` to `currentNames`, shadowing anything with the same name and
 -- moving shadowed definitions into `oldNames` so they can can still be
 -- referenced hash qualified.

--- a/parser-typechecker/src/Unison/Util/Pretty.hs
+++ b/parser-typechecker/src/Unison/Util/Pretty.hs
@@ -276,7 +276,7 @@ sepNonEmpty between ps = sep between (nonEmpty ps)
 
 -- if list is too long, adds `... 22 more` to the end
 excerptSep :: IsString s => Int -> Pretty s -> [Pretty s] -> Pretty s
-excerptSep maxCount = excerptSep' maxCount (\i -> "... " <> shown i <> " more")
+excerptSep maxCount = excerptSep' maxCount (\i -> group ("... " <> shown i <> " more"))
 
 excerptSep' :: IsString s => Int -> (Int -> Pretty s) -> Pretty s -> [Pretty s] -> Pretty s
 excerptSep' maxCount summarize s ps =
@@ -346,7 +346,7 @@ excerptColumn2Headed
   -> Pretty s
 excerptColumn2Headed max hd cols = 
   let len = length cols 
-  in if len <= max then column2 cols 
+  in if len <= max then column2 (hd:cols)
      else lines [column2 (hd:take max cols), "... " <> shown (len - max) <> " more"]
 
 excerptColumn2 
@@ -389,7 +389,7 @@ align'
   -> [(Pretty s, Pretty s)]
 align' rows = alignedRows
  where
-  maxWidth = foldl' max 0 (preferredWidth . fst <$> rows) + 1
+  maxWidth = foldl' max 0 (preferredWidth . fst <$> rows) + 2
   alignedRows =
     [ (rightPad maxWidth col0, indentNAfterNewline maxWidth col1)
     | (col0, col1) <- rows


### PR DESCRIPTION
Previously, we would just report `Done.` for these commands. Now it tells you what changed. This builds on #604 diff presentation. Was super easy to hook this up to other commands:

<img width="762" alt="Screen Shot 2019-07-26 at 10 15 50 PM" src="https://user-images.githubusercontent.com/11074/61988910-1aebfe00-aff6-11e9-982e-48ecf79a1ba7.png">

<img width="802" alt="Screen Shot 2019-07-26 at 10 15 15 PM" src="https://user-images.githubusercontent.com/11074/61988914-24756600-aff6-11e9-9ff9-84d7b43f4df6.png">

The `merge.preview` command lets you see what the diff would be after a merge, without actually doing the merge:

<img width="578" alt="Screen Shot 2019-07-26 at 10 42 47 PM" src="https://user-images.githubusercontent.com/11074/61988954-c39a5d80-aff6-11e9-84bd-3dc8c7b2a325.png">