### PR TITLE
Fix #595

### DIFF
--- a/parser-typechecker/src/Unison/Type.hs
+++ b/parser-typechecker/src/Unison/Type.hs
@@ -604,7 +604,8 @@ toReference t = Reference.Derived (ABT.hash t) 0 1
 toReferenceMentions :: Var v => Type v a -> Set Reference
 toReferenceMentions ty =
   let (vs, _) = unforall' ty
-  in Set.fromList $ toReference . generalize vs <$> ABT.subterms ty
+      gen ty = generalize (Set.toList (freeVars ty)) $ generalize vs ty
+  in Set.fromList $ toReference . gen <$> ABT.subterms ty
 
 instance Hashable1 F where
   hash1 hashCycle hash e =

--- a/unison-src/tests/595.u
+++ b/unison-src/tests/595.u
@@ -1,9 +1,9 @@
 
-type Any = Any (∀ r . (∀ a . a -> r) -> r) 
-  
+type Any = Any (∀ r . (∀ a . a -> r) -> r)
+
 -- also typechecks as expected
--- any : a -> Any
--- any a = Any.Any (k -> k a) 
+any : a -> Any
+any a = Any.Any (k -> k a)
 
 ---
 This typechecks fine, as expected, but try to `add` to codebase, get:


### PR DESCRIPTION
Wanted to investigate this one in case something was busted with hashing, which would be serious and could necessitate a repo change if hashing being done incorrectly. 

Hashing is fine, issue was with logic for building up the "type mentions" used for fuzzy type matching. It would sometimes pass a type with free vars to the hashing algorithm if the type was higher rank. The hashing algo would then crash as expected.

Small fix to that code to ensure type mentions never try to hash a type with free vars.