### PR TITLE
Some quality of life improvements for `find` command

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -714,7 +714,7 @@ loop = do
               , (seg, _) <- Map.toList (Branch._edits b) ]
         in respond $ ListOfPatches patches
 
-      SearchByNameI isVerbose ws -> do
+      SearchByNameI isVerbose showAll ws -> do
         prettyPrintNames0 <- basicPrettyPrintNames0
         -- results became an Either to accommodate `parseSearchType` returning an error
         results <- runExceptT $ case ws of
@@ -752,7 +752,7 @@ loop = do
             ppe <- prettyPrintEnv =<<
               makePrintNamesFromLabeled'
                 (foldMap SR'.labeledDependencies results')
-            respond $ ListOfDefinitions ppe isVerbose results'
+            respond $ ListOfDefinitions ppe isVerbose showAll results'
 
       ResolveTypeNameI hq ->
         zeroOneOrMore (getHQ'Types hq) (typeNotFound hq) go (typeConflicted hq)

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1146,10 +1146,8 @@ searchResultToHQString = \case
 
 -- Return a list of definitions whose names fuzzy match the given queries.
 fuzzyNameDistance :: Name -> Name -> Maybe _ -- MatchArray
-fuzzyNameDistance (Name.toString -> q) (Name.toString -> n) =
-  case Find.fuzzyFindMatchArray q [n] id of
-    [] -> Nothing
-    (m, _) : _ -> Just m
+fuzzyNameDistance (Name.toString -> q) (Name.toString -> n) = 
+  Find.simpleFuzzyScore q n
 
 -- return `name` and `name.<everything>...`
 _searchBranchPrefix :: Branch m -> Name -> [SearchResult]

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -89,7 +89,7 @@ data Input
   | LinksI Path.HQSplit' (Maybe String)
   -- other
   | UndoRootI
-  | SearchByNameI Bool [String]
+  | SearchByNameI Bool Bool [String] -- SearchByName isVerbose showAll query
   | FindPatchI
   | ShowDefinitionI OutputLocation [String]
   | ShowDefinitionByPrefixI OutputLocation [String]

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -3,6 +3,7 @@
 module Unison.Codebase.Editor.Output
   ( Output(..)
   , ListDetailed
+  , ShowAll
   , TestReportStats(..)
   , UndoFailureReason(..)
   , PushPull(..)
@@ -43,6 +44,7 @@ import qualified Unison.Names3 as Names
 
 type Term v a = Term.AnnotatedTerm v a
 type ListDetailed = Bool
+type ShowAll = Bool
 type SourceName = Text
 
 data PushPull = Push | Pull deriving (Eq, Ord, Show)
@@ -85,7 +87,7 @@ data Output v
   | ListNames [(Referent, Set HQ'.HashQualified)] -- term match, term names
               [(Reference, Set HQ'.HashQualified)] -- type match, type names
   -- list of all the definitions within this branch
-  | ListOfDefinitions PPE.PrettyPrintEnv ListDetailed [SearchResult' v Ann]
+  | ListOfDefinitions PPE.PrettyPrintEnv ListDetailed ShowAll [SearchResult' v Ann]
   | ListOfPatches (Set Name)
   -- show the result of add/update
   | SlurpOutput Input PPE.PrettyPrintEnv (SlurpResult v)

--- a/parser-typechecker/src/Unison/CommandLine.hs
+++ b/parser-typechecker/src/Unison/CommandLine.hs
@@ -132,11 +132,11 @@ fuzzyCompleteHashQualified b q0@(HQ.fromString -> query) = case query of
       makeCompletion <$> Find.fuzzyFindInBranch b query
   where
   makeCompletion (sr, p) =
-    prettyCompletion (HQ.toString . SR.name $ sr, p)
+    prettyCompletion' (HQ.toString . SR.name $ sr, p)
 
 fuzzyComplete :: String -> [String] -> [Line.Completion]
 fuzzyComplete q ss =
-  fixupCompletion q (prettyCompletion' <$> Find.fuzzyFinder q ss id)
+  fixupCompletion q (prettyCompletion' <$> Find.simpleFuzzyFinder q ss id)
 
 exactComplete :: String -> [String] -> [Line.Completion]
 exactComplete q ss = go <$> filter (isPrefixOf q) ss where
@@ -155,7 +155,7 @@ fixupCompletion q cs@(h:t) = let
   commonPrefix _ _             = ""
   overallCommonPrefix =
     foldl commonPrefix (Line.replacement h) (Line.replacement <$> t)
-  in if length overallCommonPrefix < length q
+  in if not (q `isPrefixOf` overallCommonPrefix)
      then [ c { Line.replacement = q } | c <- cs ]
      else cs
 

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -186,12 +186,17 @@ find = InputPattern "find" ["list", "ls"] [(ZeroPlus, fuzzyDefinitionQueryArg)]
         , "lists all definitions with a name similar to 'foo' or 'bar' in the current branch.")
       ]
     )
-    (pure . Input.SearchByNameI False)
+    (pure . Input.SearchByNameI False False)
 
 findVerbose :: InputPattern
 findVerbose = InputPattern "find.verbose" ["list.verbose", "ls.verbose"] [(ZeroPlus, fuzzyDefinitionQueryArg)]
   "`find.verbose` searches for definitions like `find`, but includes hashes and aliases in the results."
-  (pure . Input.SearchByNameI True)
+  (pure . Input.SearchByNameI True False)
+
+findAll :: InputPattern
+findAll = InputPattern "find.all" ["list.all", "ls.all"] [(ZeroPlus, fuzzyDefinitionQueryArg)]
+  "`find.all` searches for definitions like `find` and shows the full result list."
+  (pure . Input.SearchByNameI False True)
 
 
 findPatch :: InputPattern
@@ -683,6 +688,7 @@ validInputs =
   , renamePatch
   , copyPatch
   , find
+  , findAll
   , findVerbose
   , view
   , findPatch

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -879,7 +879,8 @@ listOfDefinitions' :: Var v
 listOfDefinitions' ppe detailed results =
   if null results then noResults
   else P.lines . P.nonEmpty $ prettyNumberedResults :
-    [formatMissingStuff termsWithMissingTypes missingTypes
+    [ if len <= cap then "" else "... " <> P.shown (len - cap) <> " more" 
+    ,formatMissingStuff termsWithMissingTypes missingTypes
     ,unlessM (null missingBuiltins) . bigproblem $ P.wrap
       "I encountered an inconsistency in the codebase; these definitions refer to built-ins that this version of unison doesn't know about:" `P.hang`
         P.column2 ( (P.bold "Name", P.bold "Built-in")
@@ -888,8 +889,11 @@ listOfDefinitions' ppe detailed results =
                                 (P.text . Referent.toText)) missingBuiltins)
     ]
   where
+  cap = 15
+  len = length results
   prettyNumberedResults =
-    P.numbered (\i -> P.hiBlack . fromString $ show i <> ".") prettyResults
+    P.numbered (\i -> P.hiBlack . fromString $ show i <> ".") 
+               (take cap prettyResults)
   -- todo: group this by namespace
   prettyResults =
     map (SR'.foldResult' renderTerm renderType)

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -202,10 +202,10 @@ notifyUser dir o = case o of
   CantDelete input ppe failed failedDependents -> putPrettyLn . P.warnCallout $
     P.lines [
       P.wrap "I couldn't delete ",
-      "", P.indentN 2 $ listOfDefinitions' ppe False failed,
+      "", P.indentN 2 $ listOfDefinitions' ppe False True failed,
       "",
       "because it's still being used by these definitions:",
-      "", P.indentN 2 $ listOfDefinitions' ppe False failedDependents
+      "", P.indentN 2 $ listOfDefinitions' ppe False True failedDependents
     ]
   CantUndo reason -> case reason of
     CantUndoPastStart -> putPrettyLn . P.warnCallout $ "Nothing more to undo."
@@ -258,8 +258,8 @@ notifyUser dir o = case o of
     --   <> P.border 2 (mconcat (fmap pretty uniqueDeletions))
     --   <> P.newline
     --   <> P.wrap "Please repeat the same command to confirm the deletion."
-  ListOfDefinitions ppe detailed results ->
-     listOfDefinitions ppe detailed results
+  ListOfDefinitions ppe detailed showAll results ->
+     listOfDefinitions ppe detailed showAll results
   ListNames [] [] -> putPrettyLn . P.callout "😶" $
     P.wrap "I couldn't find anything by that name."
   ListNames terms types -> putPrettyLn . P.sepNonEmpty "\n\n" $ [
@@ -862,9 +862,9 @@ todoOutput ppe todo =
       ]
 
 listOfDefinitions ::
-  Var v => PPE.PrettyPrintEnv -> E.ListDetailed -> [SR'.SearchResult' v a] -> IO ()
-listOfDefinitions ppe detailed results =
-  putPrettyLn $ listOfDefinitions' ppe detailed results
+  Var v => PPE.PrettyPrintEnv -> E.ListDetailed -> E.ShowAll -> [SR'.SearchResult' v a] -> IO ()
+listOfDefinitions ppe detailed showAll results =
+  putPrettyLn $ listOfDefinitions' ppe detailed showAll results
 
 noResults :: P.Pretty P.ColorText
 noResults = P.callout "😶" $
@@ -874,12 +874,18 @@ noResults = P.callout "😶" $
 listOfDefinitions' :: Var v
                    => PPE.PrettyPrintEnv -- for printing types of terms :-\
                    -> E.ListDetailed
+                   -> E.ShowAll 
                    -> [SR'.SearchResult' v a]
                    -> P.Pretty P.ColorText
-listOfDefinitions' ppe detailed results =
+listOfDefinitions' ppe detailed showAll results =
   if null results then noResults
   else P.lines . P.nonEmpty $ prettyNumberedResults :
-    [ if len <= cap then "" else "... " <> P.shown (len - cap) <> " more" 
+    [ if len <= cap then mempty 
+      else P.lines [ "... " <> P.shown (len - cap) <> " more"
+                   , ""
+                   , P.wrap $ 
+                       "The" <> makeExample IP.findAll [] <> 
+                       "command shows all results." ]
     ,formatMissingStuff termsWithMissingTypes missingTypes
     ,unlessM (null missingBuiltins) . bigproblem $ P.wrap
       "I encountered an inconsistency in the codebase; these definitions refer to built-ins that this version of unison doesn't know about:" `P.hang`
@@ -889,8 +895,8 @@ listOfDefinitions' ppe detailed results =
                                 (P.text . Referent.toText)) missingBuiltins)
     ]
   where
-  cap = 15
   len = length results
+  cap = if detailed || showAll then len else 15
   prettyNumberedResults =
     P.numbered (\i -> P.hiBlack . fromString $ show i <> ".") 
                (take cap prettyResults)

--- a/parser-typechecker/src/Unison/Util/Pretty.hs
+++ b/parser-typechecker/src/Unison/Util/Pretty.hs
@@ -389,7 +389,7 @@ align'
   -> [(Pretty s, Pretty s)]
 align' rows = alignedRows
  where
-  maxWidth = foldl' max 0 (preferredWidth . fst <$> rows) + 2
+  maxWidth = foldl' max 0 (preferredWidth . fst <$> rows) + 1
   alignedRows =
     [ (rightPad maxWidth col0, indentNAfterNewline maxWidth col1)
     | (col0, col1) <- rows


### PR DESCRIPTION
This PR makes some tweaks to the `find` command:

* `find` searches both the local namespace and the root but prefers results from the current namespace. Previously it would only search the current namespace, forcing you to `cd` just to execute a search outside your current namespace. This got old real quick, since you are often working within a small namespace but referencing plenty of external definitions.
* `find` results are capped at 15, then it shows `... 28 more`. (For later, make this configurable or have a separate command to show all results). Most of the time, it's not really very useful to have screens full of results, only a few lines of which you are actually interested in. You're better off just refining your search. I feel this is a case where the CLI just can't provide the right experience - you want a search box that refines in real time as you type.
* The autocomplete provider doesn't cap the number of completions, so a typical usage will tab complete until getting the list to a manageable size, then press enter to get detail.
* The matching algorithm is a simple `isInfixOf` check. Of those that match, it prefers prefix matches, suffix matches, infix matches, and lastly infix matches of the wrong case. There's a penalty for names that start with '.' so that local names are preferred.
* Old matching algorithm is still around, just not hooked up. I could see the old algorithm being ok if you have a UI that can refine results as you type, since in that case, the extra fuzziness doesn't get in your way as much as long as the ranking is okay.

I think the find command could still use more work in how it summarizes / aggregates results, like I'd love to see it summarize "the `math` namespace has 45 definitions". Another day. 

I'd call this PR is a definite improvement over what's there now.