### PR TITLE
Fix #612

### DIFF
--- a/parser-typechecker/src/Unison/Names3.hs
+++ b/parser-typechecker/src/Unison/Names3.hs
@@ -217,3 +217,8 @@ expandWildcardImport prefix ns =
   go (full, _) = case Name.stripNamePrefix prefix full of
     Nothing -> Nothing
     Just suffix -> Just (suffix, full)
+
+deleteTerms0 :: [Name] -> Names0 -> Names0
+deleteTerms0 ns n0 = names0 terms' (types0 n0)
+  where
+  terms' = R.subtractDom (Set.fromList ns) (terms0 n0)


### PR DESCRIPTION
Locally bound term names weren't being subtracted from the codebase names before substituting into the file terms. Was a very localized fix.

I would love to have that testing harness so we could have automated tests for these fixes. :|