### PR TITLE
ABT.Var: minimal typeclass for variables in ABT

### DIFF
--- a/parser-typechecker/src/Unison/ABT.hs
+++ b/parser-typechecker/src/Unison/ABT.hs
@@ -18,20 +18,16 @@ import Data.List hiding (cycle)
 import Data.Map (Map)
 import Data.Maybe
 import Data.Set (Set)
-import Data.Text (Text)
 import Data.Traversable
 import Data.Vector ((!))
 import Prelude hiding (abs,cycle)
 import Prelude.Extras (Eq1(..), Show1(..), Ord1(..))
 import Unison.Hashable (Accumulate,Hashable1,hash1)
-import Unison.Var (Var)
 import qualified Data.Foldable as Foldable
 import qualified Data.Map as Map
 import qualified Data.Set as Set
-import qualified Data.Text as Text
 import qualified Data.Vector as Vector
 import qualified Unison.Hashable as Hashable
-import qualified Unison.Var as Var
 import qualified Unison.Util.Components as Components
 
 data ABT f v r
@@ -44,6 +40,13 @@ data ABT f v r
 -- a value of type `a`. Variables are of type `v`.
 data Term f v a = Term { freeVars :: Set v, annotation :: a, out :: ABT f v (Term f v a) }
 
+-- | A class for variables.
+--
+--   * `Set.notMember (freshIn vs v) vs`:
+--     `freshIn` returns a variable not used in the `Set`
+class Ord v => Var v where
+  freshIn :: Set v -> v -> v
+
 data V v = Free v | Bound v deriving (Eq,Ord,Show,Functor)
 
 unvar :: V v -> v
@@ -51,14 +54,7 @@ unvar (Free v) = v
 unvar (Bound v) = v
 
 instance Var v => Var (V v) where
-  typed t = Bound (Var.typed t)
-  retype t v = case v of
-    Free v -> Free (Var.retype t v)
-    Bound v -> Bound (Var.retype t v)
-  typeOf v = Var.typeOf (unvar v)
-  freshId v = Var.freshId (unvar v)
-  freshIn s v = Var.freshIn (Set.map unvar s) <$> v
-  freshenId id v = Var.freshenId id <$> v
+  freshIn s v = freshIn (Set.map unvar s) <$> v
 
 newtype Path s t a b m = Path { focus :: s -> Maybe (a, b -> Maybe t, m) }
 
@@ -192,14 +188,8 @@ unabs1A t = case unabsA t of
   ([], _) -> Nothing
   x -> Just x
 
-v' :: Var v => Text -> v
-v' = Var.named
-
 var :: v -> Term f v ()
 var = annotatedVar ()
-
-var' :: Var v => Text -> Term f v ()
-var' v = var (Var.named v)
 
 annotatedVar :: a -> v -> Term f v a
 annotatedVar a v = Term (Set.singleton v) a (Var v)
@@ -280,10 +270,10 @@ freshInBoth :: Var v => Term f v a -> Term f v a -> v -> v
 freshInBoth t1 t2 = fresh t2 . fresh t1
 
 fresh :: Var v => Term f v a -> v -> v
-fresh t = fresh' (freeVars t)
+fresh t = freshIn (freeVars t)
 
 freshEverywhere :: (Foldable f, Var v) => Term f v a -> v -> v
-freshEverywhere t = fresh' . Set.fromList $ allVars t
+freshEverywhere t = freshIn . Set.fromList $ allVars t
 
 allVars :: Foldable f => Term f v a -> [v]
 allVars t = case out t of
@@ -292,17 +282,14 @@ allVars t = case out t of
   Abs v body -> v : allVars body
   Tm v -> Foldable.toList v >>= allVars
 
-fresh' :: Var v => Set v -> v -> v
-fresh' = Var.freshIn
-
 freshes :: Var v => Term f v a -> [v] -> [v]
-freshes = Var.freshes . freeVars
+freshes = freshes' . freeVars
 
 freshes' :: Var v => Set v -> [v] -> [v]
-freshes' = Var.freshes
-
-freshNamed' :: Var v => Set v -> Text -> v
-freshNamed' used = fresh' used . v'
+freshes' _ [] = []
+freshes' used (h:t) =
+  let h' = freshIn used h
+  in h' : freshes' (Set.insert h' used) t
 
 -- | `subst v e body` substitutes `e` for `v` in `body`, avoiding capture by
 -- renaming abstractions in `body`
@@ -327,7 +314,7 @@ subst' replace v r t2@(Term fvs ann body)
     Cycle body -> cycle' ann (subst' replace v r body)
     Abs x _ | x == v -> t2 -- x shadows v; ignore subtree
     Abs x e -> abs' ann x' e'
-      where x' = fresh t2 (fresh' r x)
+      where x' = fresh t2 (freshIn r x)
             -- rename x to something that cannot be captured by `r`
             e' = if x /= x' then subst' replace v r (rename x x' e)
                  else subst' replace v r e
@@ -565,7 +552,7 @@ components = Components.components freeVars
 
 -- Hash a strongly connected component and sort its definitions into a canonical order.
 hashComponent ::
-  (Functor f, Hashable1 f, Foldable f, Eq v, Var v, Ord h, Accumulate h)
+  (Functor f, Hashable1 f, Foldable f, Eq v, Show v, Var v, Ord h, Accumulate h)
   => Map.Map v (Term f v a) -> (h, [(v, Term f v a)])
 hashComponent byName = let
   ts = Map.toList byName
@@ -582,7 +569,7 @@ hashComponent byName = let
 -- components (using the `termFromHash` function). Requires that the
 -- overall component has no free variables.
 hashComponents
-  :: (Functor f, Hashable1 f, Foldable f, Eq v, Var v, Ord h, Accumulate h)
+  :: (Functor f, Hashable1 f, Foldable f, Eq v, Show v, Var v, Ord h, Accumulate h)
   => (h -> Word64 -> Word64 -> Term f v ())
   -> Map.Map v (Term f v a)
   -> [(h, [(v, Term f v a)])]
@@ -602,8 +589,8 @@ hashComponents termFromHash termsByName = let
     in (h, sortedComponent') : go newHashes rest
   in if Set.null escapedVars then go Map.empty sccs
      else error $ "can't hashComponents if bindings have free variables:\n  "
-               ++ show (map Var.name (Set.toList escapedVars))
-               ++ "\n  " ++ show (map Var.name (Map.keys termsByName))
+               ++ show (map show (Set.toList escapedVars))
+               ++ "\n  " ++ show (map show (Map.keys termsByName))
 
 -- Implementation detail of hashComponent
 data Component f a = Component [a] a | Embed (f a) deriving (Functor, Traversable, Foldable)
@@ -618,7 +605,7 @@ instance (Hashable1 f, Functor f) => Hashable1 (Component f) where
 
 -- | We ignore annotations in the `Term`, as these should never affect the
 -- meaning of the term.
-hash :: forall f v a h . (Functor f, Hashable1 f, Eq v, Var v, Ord h, Accumulate h)
+hash :: forall f v a h . (Functor f, Hashable1 f, Eq v, Show v, Var v, Ord h, Accumulate h)
      => Term f v a -> h
 hash = hash' [] where
   hash' :: [Either [v] v] -> Term f v a -> h
@@ -629,7 +616,7 @@ hash = hash' [] where
             ind = findIndex lookup env
             hashInt :: Int -> h
             hashInt i = Hashable.accumulate [Hashable.Nat $ fromIntegral i]
-            die = error $ "unknown var in environment: " ++ show (Var.name v)
+            die = error $ "unknown var in environment: " ++ show v
                         ++ " environment = " ++ show env
     Cycle (AbsN' vs t) -> hash' (Left vs : env) t
     Cycle t -> hash' env t
@@ -648,7 +635,7 @@ hash = hash' [] where
   hashCycle env ts = (map (hash' env) ts, hash' env)
 
 -- | Use the `hash` function to efficiently remove duplicates from the list, preserving order.
-distinct :: forall f v h a proxy . (Functor f, Hashable1 f, Eq v, Var v, Ord h, Accumulate h)
+distinct :: forall f v h a proxy . (Functor f, Hashable1 f, Eq v, Show v, Var v, Ord h, Accumulate h)
          => proxy h
          -> [Term f v a] -> [Term f v a]
 distinct _ ts = fst <$> sortOn snd m
@@ -656,17 +643,17 @@ distinct _ ts = fst <$> sortOn snd m
         hashes = map hash ts :: [h]
 
 -- | Use the `hash` function to remove elements from `t1s` that exist in `t2s`, preserving order.
-subtract :: forall f v h a proxy . (Functor f, Hashable1 f, Eq v, Var v, Ord h, Accumulate h)
+subtract :: forall f v h a proxy . (Functor f, Hashable1 f, Eq v, Show v, Var v, Ord h, Accumulate h)
          => proxy h
          -> [Term f v a] -> [Term f v a] -> [Term f v a]
 subtract _ t1s t2s =
   let skips = Set.fromList (map hash t2s :: [h])
   in filter (\t -> Set.notMember (hash t) skips) t1s
 
-instance (Show1 f, Var v) => Show (Term f v a) where
+instance (Show1 f, Show v) => Show (Term f v a) where
   -- annotations not shown
   showsPrec p (Term _ _ out) = case out of
     Var v -> \x -> "Var " ++ show v ++ x
     Cycle body -> ("Cycle " ++) . showsPrec p body
-    Abs v body -> showParen True $ (Text.unpack (Var.name v) ++) . showString ". " . showsPrec p body
+    Abs v body -> showParen True $ (show v ++) . showString ". " . showsPrec p body
     Tm f -> showsPrec1 p f

--- a/parser-typechecker/src/Unison/Reference/Util.hs
+++ b/parser-typechecker/src/Unison/Reference/Util.hs
@@ -2,13 +2,13 @@ module Unison.Reference.Util where
 
 import Unison.Reference
 import Unison.Hashable (Hashable1)
-import Unison.Var (Var)
+import Unison.ABT (Var)
 import qualified Unison.ABT as ABT
 import Data.Map (Map)
 import qualified Data.Map as Map
 
 hashComponents ::
-     (Functor f, Hashable1 f, Foldable f, Eq v, Var v)
+     (Functor f, Hashable1 f, Foldable f, Eq v, Show v, Var v)
   => (Reference -> ABT.Term f v ())
   -> Map v (ABT.Term f v a)
   -> Map v (Reference, ABT.Term f v a)

--- a/parser-typechecker/src/Unison/Runtime/IR.hs
+++ b/parser-typechecker/src/Unison/Runtime/IR.hs
@@ -921,14 +921,16 @@ instance Eq SymbolC where
 instance Ord SymbolC where
   SymbolC _ s `compare` SymbolC _ s2 = s `compare` s2
 
+instance ABT.Var SymbolC where
+  freshIn vs (SymbolC i s) =
+    SymbolC i (ABT.freshIn (Set.map underlyingSymbol vs) s)
+
 instance Var SymbolC where
   typed s = SymbolC False (Var.typed s)
   typeOf (SymbolC _ s) = Var.typeOf s
   retype t (SymbolC b s) = SymbolC b (Var.retype t s)
   freshId (SymbolC _ s) = Var.freshId s
   freshenId n (SymbolC i s) = SymbolC i (Var.freshenId n s)
-  freshIn vs (SymbolC i s) =
-    SymbolC i (Var.freshIn (Set.map underlyingSymbol vs) s)
 
 instance (Show e, Show cont) => Show (Value e cont) where
   show (I n) = show n

--- a/parser-typechecker/src/Unison/Symbol.hs
+++ b/parser-typechecker/src/Unison/Symbol.hs
@@ -8,18 +8,21 @@ import Data.Word (Word64)
 import GHC.Generics
 import Unison.Var (Var(..))
 import qualified Data.Set as Set
+import qualified Unison.ABT as ABT
 import qualified Unison.Var as Var
 
 data Symbol = Symbol !Word64 Var.Type deriving (Generic)
+
+instance ABT.Var Symbol where
+  freshIn vs s | Set.null vs || Set.notMember s vs = s -- already fresh!
+  freshIn vs s@(Symbol i n) = case Set.elemAt (Set.size vs - 1) vs of
+    Symbol i2 _ -> if i > i2 then s else Symbol (i2+1) n
 
 instance Var Symbol where
   typed t = Symbol 0 t
   typeOf (Symbol _ t) = t
   retype t (Symbol id _) = Symbol id t
   freshId (Symbol id _) = id
-  freshIn vs s | Set.null vs || Set.notMember s vs = s -- already fresh!
-  freshIn vs s@(Symbol i n) = case Set.elemAt (Set.size vs - 1) vs of
-    Symbol i2 _ -> if i > i2 then s else Symbol (i2+1) n
   freshenId id (Symbol _ n) = Symbol id n
 
 instance Eq Symbol where

--- a/parser-typechecker/src/Unison/Term.hs
+++ b/parser-typechecker/src/Unison/Term.hs
@@ -316,7 +316,7 @@ substTypeVars subs e = foldl' go e subs where
 -- will replace that type variable wherever it appears in type signatures of
 -- the term, avoiding capture by renaming ∀-binders.
 substTypeVar
-  :: (Ord v, Var vt)
+  :: (Ord v, ABT.Var vt)
   => vt
   -> Type vt b
   -> AnnotatedTerm' vt v a
@@ -346,7 +346,7 @@ substTypeVar vt ty = go Set.empty where
     (ABT.out -> ABT.Cycle body) -> ABT.cycle' loc (go bound body)
     _ -> error "unpossible"
 
-renameTypeVar :: (Ord v, Var vt) => vt -> vt -> AnnotatedTerm' vt v a -> AnnotatedTerm' vt v a
+renameTypeVar :: (Ord v, ABT.Var vt) => vt -> vt -> AnnotatedTerm' vt v a -> AnnotatedTerm' vt v a
 renameTypeVar old new = go Set.empty where
   go bound tm | Set.member old bound = tm
   go bound tm = let loc = ABT.annotation tm in case tm of
@@ -456,7 +456,7 @@ var :: a -> v -> AnnotatedTerm2 vt at ap v a
 var = ABT.annotatedVar
 
 var' :: Var v => Text -> Term' vt v
-var' = var() . ABT.v'
+var' = var() . Var.named
 
 ref :: Ord v => a -> Reference -> AnnotatedTerm2 vt at ap v a
 ref a r = ABT.tm' a (Ref r)

--- a/parser-typechecker/src/Unison/Type.hs
+++ b/parser-typechecker/src/Unison/Type.hs
@@ -287,19 +287,19 @@ introOuter a v body = ABT.tm' a (IntroOuter (ABT.abs' a v body))
 
 iff :: Var v => Type v ()
 iff = forall () aa $ arrows (f <$> [boolean(), a, a]) a
-  where aa = ABT.v' "a"
+  where aa = Var.named "a"
         a = var () aa
         f x = ((), x)
 
 iff' :: Var v => a -> Type v a
 iff' loc = forall loc aa $ arrows (f <$> [boolean loc, a, a]) a
-  where aa = ABT.v' "a"
+  where aa = Var.named "a"
         a = var loc aa
         f x = (loc, x)
 
 iff2 :: Var v => a -> Type v a
 iff2 loc = forall loc aa $ arrows (f <$> [a, a]) a
-  where aa = ABT.v' "a"
+  where aa = Var.named "a"
         a = var loc aa
         f x = (loc, x)
 
@@ -330,11 +330,11 @@ universal' :: Ord v => a -> v -> Type (TypeVar b v) a
 universal' a v = ABT.annotatedVar a (TypeVar.Universal v)
 
 v' :: Var v => Text -> Type v ()
-v' s = ABT.var (ABT.v' s)
+v' s = ABT.var (Var.named s)
 
 -- Like `v'`, but creates an annotated variable given an annotation
 av' :: Var v => a -> Text -> Type v a
-av' a s = ABT.annotatedVar a (ABT.v' s)
+av' a s = ABT.annotatedVar a (Var.named s)
 
 forall' :: Var v => a -> [Text] -> Type v a -> Type v a
 forall' a vs body = foldr (forall a) body (Var.named <$> vs)
@@ -383,7 +383,7 @@ stripEffect t = ([], t)
 -- `(a -> (a -> b) -> b)`
 flipApply :: Var v => Type v () -> Type v ()
 flipApply t = forall() b $ arrow() (arrow() t (var() b)) (var() b)
-  where b = ABT.fresh t (ABT.v' "b")
+  where b = ABT.fresh t (Var.named "b")
 
 generalize' :: Var v => Var.Type -> Type v a -> Type v a
 generalize' k t = generalize vsk t where
@@ -541,7 +541,7 @@ generalizeLowercase except t = foldr (forall (ABT.annotation t)) t vars
     [ v | v <- Set.toList (ABT.freeVars t `Set.difference` except), Var.isLowercase v ]
 
 -- Convert all free variables in `allowed` to variables bound by an `introOuter`.
-freeVarsToOuters :: Var v => Set v -> Type v a -> Type v a
+freeVarsToOuters :: ABT.Var v => Set v -> Type v a -> Type v a
 freeVarsToOuters allowed t = foldr (introOuter (ABT.annotation t)) t vars
   where vars = Set.toList $ ABT.freeVars t `Set.intersection` allowed
 

--- a/parser-typechecker/src/Unison/TypeVar.hs
+++ b/parser-typechecker/src/Unison/TypeVar.hs
@@ -3,6 +3,7 @@
 module Unison.TypeVar where
 
 import qualified Data.Set as Set
+import qualified Unison.ABT as ABT
 import           Unison.Var (Var)
 import qualified Unison.Var as Var
 
@@ -27,11 +28,13 @@ instance Show v => Show (TypeVar b v) where
   show (Universal v) = show v
   show (Existential _ v) = "'" ++ show v
 
+instance ABT.Var v => ABT.Var (TypeVar b v) where
+  freshIn s v = ABT.freshIn (Set.map underlying s) <$> v
+
 instance Var v => Var (TypeVar b v) where
   typed t = Universal (Var.typed t)
   typeOf v = Var.typeOf (underlying v)
   freshId v = Var.freshId (underlying v)
   retype t (Universal v) = Universal $ Var.retype t v
   retype t (Existential b v) = Existential b $ Var.retype t v
-  freshIn s v = Var.freshIn (Set.map underlying s) <$> v
   freshenId id v = Var.freshenId id <$> v

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -699,7 +699,7 @@ synthesizeApp (Type.stripIntroOuters -> Type.Effect'' es ft) argp@(arg, argNum) 
     abilityCheck es
     o <$ check arg i
   go (Type.Existential' b a) = do -- a^App
-    [i,e,o] <- traverse freshenVar [ABT.v' "i", ABT.v' "synthsizeApp-refined-effect", ABT.v' "o"]
+    [i,e,o] <- traverse freshenVar [Var.named "i", Var.named "synthsizeApp-refined-effect", Var.named "o"]
     let it = Type.existential' (loc ft) B.Blank i
         ot = Type.existential' (loc ft) B.Blank o
         et = Type.existential' (loc ft) B.Blank e
@@ -830,7 +830,7 @@ synthesize e = scope (InSynthesize e) $
     pure t
   go (Term.LetRecNamed' [] body) = synthesize body
   go (Term.LetRecTop' isTop letrec) = do
-    (t, ctx2) <- markThenRetract (ABT.v' "let-rec-marker") $ do
+    (t, ctx2) <- markThenRetract (Var.named "let-rec-marker") $ do
       e <- annotateLetRecBindings isTop letrec
       synthesize e
     pure $ generalizeExistentials ctx2 t
@@ -1247,7 +1247,7 @@ check e0 t0 = scope (InCheck e0 t0) $ do
       check (ABT.bindInheritAnnotation e (Term.var () v)) t
   go (Term.LetRecNamed' [] e) t = check e t
   go (Term.LetRecTop' isTop letrec) t =
-    markThenRetract0 (ABT.v' "let-rec-marker") $ do
+    markThenRetract0 (Var.named "let-rec-marker") $ do
       e <- annotateLetRecBindings isTop letrec
       check e t
   go block@(Term.Handle' h body) t = do

--- a/parser-typechecker/src/Unison/Var.hs
+++ b/parser-typechecker/src/Unison/Var.hs
@@ -12,6 +12,7 @@ import Data.Text (Text, pack)
 import qualified Data.Text as Text
 import qualified Data.Set as Set
 import Data.Word (Word64)
+import qualified Unison.ABT as ABT
 import Unison.Util.Monoid (intercalateMap)
 import Unison.Reference (Reference)
 import qualified Unison.Reference as R
@@ -20,17 +21,17 @@ import qualified Unison.Reference as R
 -- may not form part of their identity according to `Eq` / `Ord`. Laws:
 --
 --   * `typeOf (typed n) == n`
---   * `Set.notMember (freshIn vs v) vs`:
---     `freshIn` returns a variable not used in the `Set`
---   * `typeOf (freshIn vs v) == typeOf v`:
---     `freshIn` does not alter the name
-class (Show v, Eq v, Ord v) => Var v where
+--   * `typeOf (ABT.freshIn vs v) == typeOf v`:
+--     `ABT.freshIn` does not alter the name
+class (Show v, ABT.Var v) => Var v where
   typed :: Type -> v
   retype :: Type -> v -> v
   typeOf :: v -> Type
   freshId :: v -> Word64
-  freshIn :: Set v -> v -> v
   freshenId :: Word64 -> v -> v
+
+freshIn :: ABT.Var v => Set v -> v -> v
+freshIn = ABT.freshIn
 
 named :: Var v => Text -> v
 named n = typed (User n)
@@ -143,17 +144,8 @@ joinDot prefix v2 =
   if name prefix == "." then named (name prefix `mappend` name v2)
   else named (name prefix `mappend` "." `mappend` name v2)
 
-freshes :: Var v => Set v -> [v] -> [v]
-freshes _ [] = []
-freshes used (h:t) =
-  let h' = freshIn used h
-  in h' : freshes (Set.insert h' used) t
-
-freshInBoth :: Var v => Set v -> Set v -> v -> v
-freshInBoth vs1 vs2 = freshIn vs1 . freshIn vs2
-
 freshNamed :: Var v => Set v -> Text -> v
-freshNamed used n = freshIn used (named n)
+freshNamed used n = ABT.freshIn used (named n)
 
 syntheticVars :: Var v => Set v
 syntheticVars = Set.fromList . fmap typed $ [


### PR DESCRIPTION
Introduce a typeclass `ABT.Var`:

```haskell
class Ord v => Var v where
  freshIn :: Set v -> v -> v
```

which is sufficient for the purposes of ABT.

The `Var` class from `Unison.Var` used so far contains many Unison specifics irrelevant for the ABT.

Considering that in principle ABT could be moved to a separate library, this refactoring makes it easier to do so.