### PR TITLE
Improve delete.namespace feedback a bit

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -387,8 +387,15 @@ loop = do
                   (Path.toName . Path.unsplit . resolveSplit' $ p)
                   (Branch.toNames0 b)
             in getEndangeredDependents (eval . GetDependents) toDelete rootNames
-          if failed == mempty then
+          if failed == mempty then do
             stepAt $ BranchUtil.makeSetBranch (resolveSplit' p) Branch.empty
+            -- Looks similar to the 'toDelete' above... investigate me! ;)
+            let deletedNames =
+                  Names.prefix0
+                    (Path.toName' (Path.unsplit' p))
+                    (Branch.toNames0 b)
+                diff = Names3.diff0 deletedNames mempty
+            respond $ ShowDiff input diff
           else do
             failed <- loadSearchResults $ Names.asSearchResults failed
             failedDependents <- loadSearchResults $ Names.asSearchResults failedDependents

--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -259,6 +259,10 @@ fromName = fromList . fmap NameSegment . Text.splitOn "." . Name.toText
 toName :: Path -> Name
 toName = Name.unsafeFromText . toText
 
+-- | Convert a Path' to a Name
+toName' :: Path' -> Name
+toName' = Name.unsafeFromText . toText'
+
 -- Returns the nearest common ancestor, along with the
 -- two inputs relativized to that ancestor.
 relativeToAncestor :: Path -> Path -> (Path, Path, Path)
@@ -282,3 +286,8 @@ instance Show Path where
 
 toText :: Path -> Text
 toText (Path nss) = intercalateMap "." NameSegment.toText nss
+
+toText' :: Path' -> Text
+toText' = \case
+  Path' (Left (Absolute path)) -> Text.cons '.' (toText path)
+  Path' (Right (Relative path)) -> toText path

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -539,6 +539,14 @@ notifyUser dir o = case o of
           , ""
           , prettyDiff Nothing diff
           ]
+    Input.DeleteBranchI _ -> P.callout "🆕" . P.lines $
+      [ P.wrap $
+          "Here's what's changed after the delete:"
+      , ""
+      , prettyDiff (Just 10) diff
+      , ""
+      , tip "You can always `undo` if this wasn't what you wanted."
+      ]
     _ -> prettyDiff Nothing diff
   NothingTodo input -> putPrettyLn . P.callout "😶" $ case input of
     Input.MergeLocalBranchI src dest ->


### PR DESCRIPTION
@exw and I set out to solve #648... this is what we came up with. The current output could be improved.

If you are in `.foo`, which contains `.foo.a`, and you `delete.namespace .foo`, you will see:

```
.foo> delete.namespace .foo

  🆕

  Here's what's changed after the delete:

  - Deletes:

    .foo.a

  Tip: You can always `undo` if this wasn't what you wanted.
```

It seems like this could be shortened to just `a`, relative to the current directory. However, we discovered that it is (currently) rather difficult to make a path/name relative in this way, so we decided to punt on that for now.