### PR TITLE
Add Unison.Prelude

### DIFF
--- a/parser-typechecker/src/Unison/ABT.hs
+++ b/parser-typechecker/src/Unison/ABT.hs
@@ -10,15 +10,10 @@
 
 module Unison.ABT where
 
-import Control.Applicative
-import Control.Monad
-import Data.Word (Word64)
+import Unison.Prelude
+
 import Data.Functor.Identity (runIdentity)
 import Data.List hiding (cycle)
-import Data.Map (Map)
-import Data.Maybe
-import Data.Set (Set)
-import Data.Traversable
 import Data.Vector ((!))
 import Prelude hiding (abs,cycle)
 import Prelude.Extras (Eq1(..), Show1(..), Ord1(..))

--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -19,13 +19,10 @@ module Unison.Builtin
   ,termRefTypes
   ) where
 
-import           Control.Applicative            ( (<|>) )
+import Unison.Prelude
+
 import           Data.Bifunctor                 ( second )
-import           Data.Foldable                  ( foldl', toList )
-import           Data.Map                       ( Map )
 import qualified Data.Map                      as Map
-import           Data.Set                       ( Set )
-import           Data.Text                      ( Text )
 import qualified Data.Text                     as Text
 import qualified Unison.ConstructorType        as CT
 import           Unison.Codebase.CodeLookup     ( CodeLookup(..) )

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -2,13 +2,9 @@
 
 module Unison.Codebase where
 
-import           Control.Monad                  ( foldM
-                                                , forM
-                                                )
-import           Data.Foldable                  ( toList, traverse_ )
+import Unison.Prelude
+
 import qualified Data.Map                      as Map
-import           Data.Maybe                     ( catMaybes, isJust )
-import           Data.Set                       ( Set )
 import qualified Data.Set                      as Set
 import qualified Unison.ABT                    as ABT
 import qualified Unison.Builtin                as Builtin
@@ -59,7 +55,7 @@ data Codebase m v a =
            , dependentsImpl     :: Reference -> m (Set Reference.Id)
            , syncFromDirectory  :: FilePath -> m ()
            -- This returns the merged branch that results from
-           -- merging the input branch with the root branch at the 
+           -- merging the input branch with the root branch at the
            -- given file path
            , syncToDirectory    :: FilePath -> Branch m -> m (Branch m)
 

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -10,18 +10,14 @@
 
 module Unison.Codebase.Branch where
 
+import Unison.Prelude hiding (empty)
+
 import           Prelude                  hiding (head,read,subtract)
 
 import           Control.Lens            hiding ( children, cons, transform )
 import qualified Control.Monad                 as Monad
-import           Data.List                      ( foldl' )
-import           Data.Maybe                     ( fromMaybe )
 import qualified Data.Map                      as Map
-import           Data.Map                       ( Map )
 import qualified Data.Set                      as Set
-import           Data.Set                       ( Set )
-import           Data.Foldable                  ( for_, toList )
-import           Data.Traversable               ( for )
 import qualified Unison.Codebase.Patch         as Patch
 import           Unison.Codebase.Patch          ( Patch )
 import qualified Unison.Codebase.Causal        as Causal

--- a/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
+++ b/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
@@ -1,6 +1,7 @@
 module Unison.Codebase.BranchUtil where
 
-import Data.Set (Set)
+import Unison.Prelude
+
 import qualified Data.Set as Set
 import qualified Data.Map as Map
 import Unison.Codebase.Path (Path)

--- a/parser-typechecker/src/Unison/Codebase/Causal.hs
+++ b/parser-typechecker/src/Unison/Codebase/Causal.hs
@@ -3,27 +3,22 @@
 {-# LANGUAGE RecordWildCards #-}
 module Unison.Codebase.Causal where
 
+import Unison.Prelude
+
 import           Prelude                 hiding ( head
                                                 , tail
                                                 , read
                                                 )
-import           Control.Applicative            ( liftA2 )
 import           Control.Lens                   ( (<&>) )
-import           Control.Monad                  ( unless )
-import           Control.Monad.Extra            ( ifM )
 import           Control.Monad.Loops            ( anyM )
 import           Data.List                      ( foldl1' )
-import           Data.Sequence                  ( Seq )
 import qualified Data.Sequence                 as Seq
 import           Unison.Hash                    ( Hash )
 -- import qualified Unison.Hash                   as H
 import qualified Unison.Hashable               as Hashable
 import           Unison.Hashable                ( Hashable )
-import           Data.Map                       ( Map )
 import qualified Data.Map                      as Map
-import           Data.Set                       ( Set )
 import qualified Data.Set                      as Set
-import           Data.Foldable                  ( for_, toList )
 import           Util                           ( bind2 )
 
 {-

--- a/parser-typechecker/src/Unison/Codebase/CodeLookup.hs
+++ b/parser-typechecker/src/Unison/Codebase/CodeLookup.hs
@@ -1,6 +1,7 @@
 module Unison.Codebase.CodeLookup where
 
-import Control.Applicative
+import Unison.Prelude
+
 import Control.Monad.Morph
 import qualified Data.Map                      as Map
 import           Unison.UnisonFile              ( UnisonFile )

--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -9,11 +9,9 @@ module Unison.Codebase.Editor.Command (
   TypecheckingResult
   ) where
 
+import Unison.Prelude
+
 import           Data.Configurator.Types        ( Configured )
-import           Data.Map                       ( Map )
-import           Data.Set                       ( Set )
-import           Data.Sequence                  ( Seq )
-import           Data.Text                      ( Text )
 
 import           Unison.Codebase.Editor.Output
 import           Unison.Codebase.Editor.RemoteRepo

--- a/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
@@ -2,23 +2,15 @@
 
 module Unison.Codebase.Editor.Git where
 
-import           Control.Monad                  ( when
-                                                , unless
-                                                )
-import           Control.Monad.Extra            ( whenM )
+import Unison.Prelude
+
 import           Control.Monad.Catch            ( MonadCatch
                                                 , onException
                                                 )
-import           Control.Monad.Trans            ( lift )
 import           Control.Monad.Except           ( MonadError
                                                 , throwError
                                                 , ExceptT
                                                 )
-import           Control.Monad.IO.Class         ( MonadIO
-                                                , liftIO
-                                                )
-import           Data.Maybe                     ( isNothing )
-import           Data.Text                      ( Text )
 import qualified Data.Text                     as Text
 import           Shellmet                       ( ($?), ($|) )
 import           System.Directory               ( getCurrentDirectory
@@ -58,11 +50,11 @@ prepGitPull
 prepGitPull localPath uri = do
   checkForGit
   wd <- liftIO getCurrentDirectory
-  e <- liftIO . Ex.tryAny . whenM (doesDirectoryExist localPath) $ 
+  e <- liftIO . Ex.tryAny . whenM (doesDirectoryExist localPath) $
     removeDirectoryRecursive localPath
   case e of
     Left e -> throwError (SomeOtherError (Text.pack (show e)))
-    Right a -> pure a 
+    Right a -> pure a
   clone uri localPath
   liftIO $ setCurrentDirectory localPath
   isGitDir <- liftIO checkGitDir
@@ -143,10 +135,10 @@ pushGitRootBranch localPath codebase branch url treeish = do
   -- Stick our changes in the checked-out copy
   merged <- lift $ syncToDirectory codebase (localPath </> codebasePath) branch
   isBefore <- lift $ Branch.before merged branch
-  let mergednames = Branch.toNames0 (Branch.head merged) 
-      localnames  = Branch.toNames0 (Branch.head branch) 
+  let mergednames = Branch.toNames0 (Branch.head merged)
+      localnames  = Branch.toNames0 (Branch.head branch)
       diff = Names.diff0 localnames mergednames
-  when (not isBefore) $ 
+  when (not isBefore) $
     throwError (PushDestinationHasNewStuff url treeish diff)
   let
     push = do

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -8,22 +8,18 @@
 
 module Unison.Codebase.Editor.HandleCommand where
 
-import Data.Maybe (catMaybes)
+import Unison.Prelude
+
 import Unison.Codebase.Editor.Output
 import Unison.Codebase.Editor.Command
 import Unison.Codebase.Editor.RemoteRepo
 
 import qualified Unison.Builtin                as B
 
--- import Debug.Trace
-
 import           Control.Monad.Except           ( runExceptT )
 import qualified Data.Configurator             as Config
 import           Data.Configurator.Types        ( Config )
-import           Data.Functor
-import           Data.Foldable                  ( forM_, toList )
 import qualified Data.Map                      as Map
-import           Data.Text                      ( Text )
 import qualified Data.Text                     as Text
 import           System.Directory               ( getXdgDirectory
                                                 , XdgDirectory(..)

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -20,6 +20,8 @@
 
 module Unison.Codebase.Editor.HandleInput (loop, loopState0, LoopState(..), parseSearchType) where
 
+import Unison.Prelude
+
 import Unison.Codebase.Editor.Command
 import Unison.Codebase.Editor.Input
 import Unison.Codebase.Editor.Output
@@ -32,40 +34,23 @@ import Unison.Codebase.Editor.SlurpComponent (SlurpComponent(..))
 import qualified Unison.Codebase.Editor.SlurpComponent as SC
 import Unison.Codebase.Editor.RemoteRepo
 
-import           Control.Applicative
 import           Control.Lens
 import           Control.Lens.TH                ( makeLenses )
-import           Control.Monad                  ( filterM, foldM, forM,
-                                                  unless, join, when, void)
-import           Control.Monad.Extra            ( ifM )
 import           Control.Monad.State            ( StateT
                                                 )
-import           Control.Monad.Trans            ( lift )
 import           Control.Monad.Trans.Except     ( ExceptT(..), runExceptT)
-import           Control.Monad.Trans.Maybe      ( MaybeT(..) )
 import           Data.Bifunctor                 ( second )
 import           Data.Configurator.Types        ( Config )
 import           Data.Configurator              ()
-import           Data.Foldable                  ( toList
-                                                , fold
-                                                , foldl'
-                                                , traverse_
-                                                )
 import qualified Data.Graph as Graph
 import qualified Data.List                      as List
 import           Data.List                      ( partition, sortOn )
 import           Data.List.Extra                (nubOrd, intercalate)
-import           Data.Maybe                     ( catMaybes
-                                                , fromMaybe
-                                                , fromJust
-                                                , mapMaybe
+import           Data.Maybe                     ( fromJust
                                                 )
-import           Data.Map                       ( Map )
 import qualified Data.Map                      as Map
 import qualified Data.Text                     as Text
-import           Data.Traversable               ( for )
 import qualified Data.Set                      as Set
-import           Data.Set                       ( Set )
 import           Data.Sequence                  ( Seq(..) )
 import qualified Unison.ABT                    as ABT
 import           Unison.Codebase.Branch         ( Branch
@@ -132,7 +117,6 @@ import qualified Unison.Codebase.Editor.SearchResult' as SR'
 import qualified Unison.LabeledDependency as LD
 import Unison.LabeledDependency (LabeledDependency)
 import Unison.Type (Type)
-import Debug.Trace (traceShowM, traceM)
 import qualified Unison.Builtin as Builtin
 import Unison.Codebase.NameSegment (NameSegment(..))
 

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -5,8 +5,8 @@ module Unison.Codebase.Editor.Input
   , PatchPath
   ) where
 
-import           Data.Set                       ( Set )
-import           Data.Text                      ( Text )
+import Unison.Prelude
+
 import qualified Unison.Codebase.Branch        as Branch
 import qualified Unison.HashQualified          as HQ
 import qualified Unison.HashQualified'         as HQ'

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -10,9 +10,8 @@ module Unison.Codebase.Editor.Output
   , pushPull
   ) where
 
-import Data.Map (Map)
-import Data.Set (Set)
-import Data.Text (Text)
+import Unison.Prelude
+
 import Unison.Codebase.Editor.Input
 import Unison.Codebase.Editor.SlurpResult (SlurpResult(..))
 import Unison.Codebase.GitError

--- a/parser-typechecker/src/Unison/Codebase/Editor/RemoteRepo.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/RemoteRepo.hs
@@ -1,6 +1,6 @@
 module Unison.Codebase.Editor.RemoteRepo where
 
-import Data.Text (Text)
+import Unison.Prelude
 
 data RemoteRepo = GitRepo { url :: Text, commit :: Text }
   deriving (Eq, Ord, Show)

--- a/parser-typechecker/src/Unison/Codebase/Editor/SearchResult'.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/SearchResult'.hs
@@ -2,6 +2,8 @@
 
 module Unison.Codebase.Editor.SearchResult' where
 
+import Unison.Prelude
+
 import Unison.Referent (Referent)
 import Unison.Reference (Reference)
 import qualified Unison.HashQualified' as HQ'
@@ -9,7 +11,6 @@ import qualified Data.Set as Set
 import qualified Unison.DataDeclaration as DD
 import qualified Unison.Codebase.Editor.DisplayThing as DT
 import qualified Unison.Type as Type
-import Data.Set (Set)
 import Unison.DataDeclaration (Decl)
 import Unison.Codebase.Editor.DisplayThing (DisplayThing)
 import Unison.Type (Type)

--- a/parser-typechecker/src/Unison/Codebase/Editor/SlurpComponent.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/SlurpComponent.hs
@@ -3,11 +3,8 @@
 
 module Unison.Codebase.Editor.SlurpComponent where
 
-import Control.Applicative ((<|>))
-import Data.List (foldl')
-import Data.Maybe (fromMaybe)
-import Data.Map (Map)
-import Data.Set (Set)
+import Unison.Prelude
+
 import Data.Tuple (swap)
 import Unison.Reference ( Reference )
 import Unison.UnisonFile (TypecheckedUnisonFile)

--- a/parser-typechecker/src/Unison/Codebase/Editor/SlurpResult.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/SlurpResult.hs
@@ -4,9 +4,8 @@
 
 module Unison.Codebase.Editor.SlurpResult where
 
-import Data.Foldable (toList)
-import Data.Map (Map)
-import Data.Set (Set)
+import Unison.Prelude
+
 import Unison.Codebase.Editor.SlurpComponent (SlurpComponent(..))
 import Unison.Name ( Name )
 import Unison.Parser ( Ann )

--- a/parser-typechecker/src/Unison/Codebase/Editor/TodoOutput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/TodoOutput.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE RecordWildCards #-}
 module Unison.Codebase.Editor.TodoOutput where
 
+import Unison.Prelude
+
 import qualified Unison.Names3 as Names
 import qualified Unison.Type as Type
 import qualified Unison.Util.Relation as R
@@ -13,8 +15,6 @@ import Unison.Codebase.Patch (Patch)
 import Unison.Codebase.Editor.DisplayThing (DisplayThing(RegularThing))
 import Unison.Type (Type)
 import Unison.DataDeclaration (Decl)
-import Data.Foldable (toList)
-import Data.Set (Set)
 import qualified Unison.LabeledDependency as LD
 import Unison.LabeledDependency (LabeledDependency)
 

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -16,27 +16,17 @@ module Unison.Codebase.FileCodebase
 , ensureCodebaseInitialized
 ) where
 
-import           Control.Monad                  ( forever, foldM, unless, when)
-import           Control.Monad.Extra            ( unlessM )
-import           UnliftIO                       ( MonadIO
-                                                , MonadUnliftIO
-                                                , liftIO )
+import Unison.Prelude
+
+import           UnliftIO                       ( MonadUnliftIO )
 import           UnliftIO.Concurrent            ( forkIO
                                                 , killThread
                                                 )
 import           UnliftIO.STM                   ( atomically )
 import qualified Data.Char                     as Char
-import           Data.Foldable                  ( traverse_
-                                                , toList
-                                                , forM_
-                                                , for_
-                                                )
 import qualified Data.Hex                      as Hex
 import           Data.List                      ( isSuffixOf )
-import           Data.Maybe                     ( fromMaybe )
-import           Data.Set                       ( Set )
 import qualified Data.Set                      as Set
-import           Data.Text                      ( Text )
 import qualified Data.Text                     as Text
 import           Data.Text.Encoding             ( encodeUtf8
                                                 , decodeUtf8
@@ -376,14 +366,14 @@ writeAllTermsAndTypes
   -> m (Branch m)
 writeAllTermsAndTypes fmtV fmtA codebase localPath branch = do
   b <- doesDirectoryExist localPath
-  if b then do 
-    code <- pure $ codebase1 fmtV fmtA localPath 
+  if b then do
+    code <- pure $ codebase1 fmtV fmtA localPath
     remoteRoot <- Codebase.getRootBranch code
     Branch.sync (hashExists localPath) serialize (serializeEdits localPath) branch
-    merged <- Branch.merge branch remoteRoot 
-    Codebase.putRootBranch code merged 
+    merged <- Branch.merge branch remoteRoot
+    Codebase.putRootBranch code merged
     pure merged
-  else do 
+  else do
     Branch.sync (hashExists localPath) serialize (serializeEdits localPath) branch
     updateCausalHead (branchHeadDir localPath) $ Branch._history branch
     pure branch

--- a/parser-typechecker/src/Unison/Codebase/GitError.hs
+++ b/parser-typechecker/src/Unison/Codebase/GitError.hs
@@ -1,7 +1,7 @@
 module Unison.Codebase.GitError where
 
-import Data.Text (Text)
-import System.IO (FilePath)
+import Unison.Prelude
+
 import qualified Unison.Names3 as Names
 
 data GitError = NoGit

--- a/parser-typechecker/src/Unison/Codebase/Metadata.hs
+++ b/parser-typechecker/src/Unison/Codebase/Metadata.hs
@@ -1,9 +1,7 @@
 module Unison.Codebase.Metadata where
 
-import Data.Foldable (toList)
-import Data.Map (Map)
-import Data.Set (Set)
-import Data.List (foldl')
+import Unison.Prelude
+
 import Unison.Reference (Reference)
 import Unison.Util.Star3 (Star3)
 import qualified Data.Map as Map

--- a/parser-typechecker/src/Unison/Codebase/NameEdit.hs
+++ b/parser-typechecker/src/Unison/Codebase/NameEdit.hs
@@ -1,7 +1,7 @@
 module Unison.Codebase.NameEdit where
 
-import Data.Set (Set)
-import Data.Foldable (toList)
+import Unison.Prelude
+
 import Unison.Reference (Reference)
 import Unison.Hashable (Hashable, tokens)
 

--- a/parser-typechecker/src/Unison/Codebase/NameSegment.hs
+++ b/parser-typechecker/src/Unison/Codebase/NameSegment.hs
@@ -2,7 +2,8 @@
 
 module Unison.Codebase.NameSegment where
 
-import           Data.Text                      ( Text )
+import Unison.Prelude
+
 import qualified Data.Text                     as Text
 import qualified Unison.Hashable               as H
 import qualified Unison.HashQualified'         as HQ'

--- a/parser-typechecker/src/Unison/Codebase/Patch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Patch.hs
@@ -4,10 +4,11 @@
 
 module Unison.Codebase.Patch where
 
+import Unison.Prelude hiding (empty)
+
 import           Prelude                  hiding (head,read,subtract)
 
 import           Control.Lens            hiding ( children, cons, transform )
-import           Data.Set                       ( Set )
 import qualified Data.Set                      as Set
 import           Unison.Codebase.TermEdit       ( TermEdit, Typing(Same) )
 import qualified Unison.Codebase.TermEdit      as TermEdit

--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -4,13 +4,12 @@
 
 module Unison.Codebase.Path where
 
---import Debug.Trace
+import Unison.Prelude hiding (empty, toList)
+
 import           Data.List.Extra                ( dropPrefix )
 import Control.Lens hiding (unsnoc, cons, snoc)
 import qualified Control.Lens as Lens
-import Data.Either.Combinators (maybeToRight)
 import qualified Data.Foldable as Foldable
-import           Data.Text                      ( Text )
 import qualified Data.Text                     as Text
 import           Data.Sequence                  (Seq((:<|),(:|>) ))
 import qualified Data.Sequence                 as Seq

--- a/parser-typechecker/src/Unison/Codebase/Runtime.hs
+++ b/parser-typechecker/src/Unison/Codebase/Runtime.hs
@@ -4,11 +4,9 @@
 
 module Unison.Codebase.Runtime where
 
-import           Data.Foldable
-import           Data.Traversable               ( for )
+import Unison.Prelude
+
 import qualified Unison.ABT                    as ABT
-import           Data.Functor                   ( void )
-import           Data.Map                       ( Map )
 import qualified Data.Map                      as Map
 import qualified Data.Set                      as Set
 import qualified Unison.Codebase.CodeLookup    as CL

--- a/parser-typechecker/src/Unison/Codebase/SearchResult.hs
+++ b/parser-typechecker/src/Unison/Codebase/SearchResult.hs
@@ -2,7 +2,8 @@
 
 module Unison.Codebase.SearchResult where
 
-import           Data.Set             (Set)
+import Unison.Prelude
+
 import qualified Data.Set             as Set
 import           Unison.HashQualified' (HashQualified)
 import qualified Unison.HashQualified' as HQ

--- a/parser-typechecker/src/Unison/Codebase/Serialization/V1.hs
+++ b/parser-typechecker/src/Unison/Codebase/Serialization/V1.hs
@@ -3,6 +3,8 @@
 
 module Unison.Codebase.Serialization.V1 where
 
+import Unison.Prelude
+
 import Prelude hiding (getChar, putChar)
 
 -- import qualified Data.Text as Text
@@ -10,10 +12,6 @@ import qualified Unison.Pattern                 as Pattern
 import           Unison.PatternP                ( Pattern
                                                 , SeqOp
                                                 )
-import           Control.Applicative            ( liftA2
-                                                , liftA3
-                                                )
-import           Control.Monad                  ( replicateM )
 import           Data.Bits                      ( Bits )
 import           Data.Bytes.Get
 import           Data.Bytes.Put
@@ -24,18 +22,12 @@ import           Data.Bytes.Serial              ( serialize
                                                 )
 import           Data.Bytes.Signed              ( Unsigned )
 import           Data.Bytes.VarInt              ( VarInt(..) )
-import           Data.Foldable                  ( traverse_ )
-import           Data.Int                       ( Int64 )
-import           Data.Map                       ( Map )
 import qualified Data.Map                      as Map
 import           Data.List                      ( elemIndex
-                                                , foldl'
                                                 )
-import           Data.Text                      ( Text )
 import           Data.Text.Encoding             ( encodeUtf8
                                                 , decodeUtf8
                                                 )
-import           Data.Word                      ( Word64 )
 import qualified Unison.Codebase.Branch         as Branch
 import           Unison.Codebase.Causal         ( Raw(..)
                                                 , RawHash(..)

--- a/parser-typechecker/src/Unison/Codebase/Watch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Watch.hs
@@ -4,27 +4,23 @@
 
 module Unison.Codebase.Watch where
 
-import           Control.Applicative
+import Unison.Prelude
+
 import           UnliftIO.Concurrent            ( forkIO
                                                 , threadDelay
                                                 , killThread
                                                 )
-import           UnliftIO                       ( MonadIO, MonadUnliftIO
-                                                , liftIO, withRunInIO )
+import           UnliftIO                       ( MonadUnliftIO
+                                                , withRunInIO )
 import           UnliftIO.MVar                  ( newEmptyMVar, takeMVar
                                                 , tryTakeMVar, putMVar )
 import           UnliftIO.STM                   ( atomically )
 import           UnliftIO.Exception             ( catch, IOException)
-import           Control.Monad                  ( forever
-                                                , void
-                                                , join
-                                                )
 import           UnliftIO.IORef                 ( newIORef
                                                 , readIORef
                                                 , writeIORef
                                                 )
 import qualified Data.Map                      as Map
-import           Data.Text                      ( Text )
 import qualified Data.Text.IO
 import           Data.Time.Clock                ( UTCTime
                                                 , diffUTCTime
@@ -35,7 +31,6 @@ import           System.FSNotify                ( Event(Added, Modified)
                                                 )
 import           Unison.Util.TQueue             ( TQueue )
 import qualified Unison.Util.TQueue            as TQueue
--- import Debug.Trace
 
 watchDirectory'
   :: forall m. MonadUnliftIO m => FilePath -> m (m (), m (FilePath, UTCTime))

--- a/parser-typechecker/src/Unison/Codecs.hs
+++ b/parser-typechecker/src/Unison/Codecs.hs
@@ -4,7 +4,8 @@ module Unison.Codecs where
 
 -- A format for encoding runtime values, with sharing for compiled nodes.
 
-import Data.Text (Text)
+import Unison.Prelude
+
 import           Control.Arrow (second)
 import           Control.Monad.State
 import           Data.Bits (Bits)
@@ -15,10 +16,7 @@ import qualified Data.ByteString as B
 import           Data.ByteString.Builder (doubleBE, int64BE, toLazyByteString)
 import qualified Data.ByteString.Lazy as BL
 import           Data.Bytes.Put
-import           Data.Foldable (toList, traverse_)
-import           Data.Maybe (fromMaybe)
 import           Data.Text.Encoding (encodeUtf8)
-import           Data.Word (Word64)
 import qualified Unison.ABT as ABT
 import qualified Unison.Blank as Blank
 import qualified Unison.DataDeclaration as DD
@@ -32,7 +30,6 @@ import           Unison.Var (Var)
 import qualified Unison.Var as Var
 import Unison.PatternP (Pattern)
 import qualified Unison.PatternP as Pattern
-import Data.Int (Int64)
 
 type Pos = Word64
 

--- a/parser-typechecker/src/Unison/CommandLine.hs
+++ b/parser-typechecker/src/Unison/CommandLine.hs
@@ -8,18 +8,16 @@
 
 module Unison.CommandLine where
 
+import Unison.Prelude
+
 import           Control.Concurrent              (forkIO, killThread)
 import           Control.Concurrent.STM          (atomically)
-import           Control.Monad                   (forever, when)
 import           Data.Configurator               (autoReload, autoConfig)
 import           Data.Configurator.Types         (Config, Worth (..))
-import           Data.Foldable                   (toList)
 import           Data.List                       (isSuffixOf, isPrefixOf)
 import           Data.ListLike                   (ListLike)
-import           Data.Map                        (Map)
 import qualified Data.Map                        as Map
 import qualified Data.Set                        as Set
-import           Data.String                     (IsString, fromString)
 import qualified Data.Text                       as Text
 import           Prelude                         hiding (readFile, writeFile)
 import qualified System.Console.Haskeline        as Line

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -6,15 +6,11 @@
 
 module Unison.CommandLine.InputPatterns where
 
--- import Debug.Trace
+import Unison.Prelude
+
 import Data.Bifunctor (first)
-import Data.Foldable (toList)
 import Data.List (intercalate, sortOn, isPrefixOf)
 import Data.List.Extra (nubOrdOn)
-import Data.Map (Map)
-import Data.Set (Set)
-import Data.String (fromString)
-import Data.Text (Text)
 import qualified System.Console.Haskeline.Completion as Completion
 import System.Console.Haskeline.Completion (Completion)
 import Unison.Codebase (Codebase)
@@ -23,7 +19,6 @@ import Unison.Codebase.Editor.RemoteRepo
 import Unison.CommandLine.InputPattern (ArgumentType (ArgumentType), InputPattern (InputPattern), IsOptional(Optional,Required,ZeroPlus,OnePlus))
 import Unison.CommandLine
 import Unison.Util.Monoid (intercalateMap)
-import Data.Either.Combinators (mapLeft)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Text as Text

--- a/parser-typechecker/src/Unison/CommandLine/Main.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Main.hs
@@ -6,21 +6,16 @@
 
 module Unison.CommandLine.Main where
 
+import Unison.Prelude
+
 import Control.Concurrent.STM (atomically)
 import Control.Exception (finally)
-import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.State (runStateT)
-import Control.Monad.Trans (lift)
-import Control.Monad.Trans.Maybe (runMaybeT)
 import Data.IORef
-import Data.Map (Map)
-import Data.Maybe (fromMaybe)
-import Data.String (fromString)
 import Prelude hiding (readFile, writeFile)
 import System.FilePath ((</>))
 import System.IO.Error (catchIOError)
 import System.Exit (die)
-import Safe
 import Unison.Codebase.Branch (Branch)
 import qualified Unison.Codebase.Branch as Branch
 import Unison.Codebase.Editor.Input (Input (..))

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -14,6 +14,8 @@
 
 module Unison.CommandLine.OutputMessages where
 
+import Unison.Prelude hiding (unlessM)
+
 import Unison.Codebase.Editor.Output
 import qualified Unison.Codebase.Editor.Output       as E
 import qualified Unison.Codebase.Editor.TodoOutput       as TO
@@ -21,22 +23,14 @@ import Unison.Codebase.Editor.SlurpResult (SlurpResult(..))
 import qualified Unison.Codebase.Editor.SearchResult' as SR'
 
 
---import Debug.Trace
 import Control.Lens (over, _1)
-import           Control.Monad                 (when, unless, join)
 import           Data.Bifunctor                (bimap, first)
-import           Data.Foldable                 (toList, traverse_)
 import           Data.List                     (sortOn, stripPrefix)
 import           Data.List.Extra               (nubOrdOn, nubOrd)
 import qualified Data.ListLike                 as LL
 import           Data.ListLike                 (ListLike)
-import           Data.Maybe                    (fromMaybe)
-import           Data.Map                      (Map)
 import qualified Data.Map                      as Map
 import qualified Data.Set                      as Set
-import           Data.Set                      (Set)
-import           Data.String                   (IsString, fromString)
-import           Data.Text                     (Text)
 import qualified Data.Text                     as Text
 import           Data.Text.IO                  (readFile, writeFile)
 import           Data.Tuple.Extra              (dupe)

--- a/parser-typechecker/src/Unison/DataDeclaration.hs
+++ b/parser-typechecker/src/Unison/DataDeclaration.hs
@@ -9,18 +9,14 @@
 
 module Unison.DataDeclaration where
 
+import Unison.Prelude
+
 import Control.Lens (_3, over)
 import Data.Bifunctor (first)
-import Data.Traversable (for)
 import qualified Unison.Util.Relation as Rel
-import           Safe                           ( atMay )
 import           Data.List                      ( sortOn, elemIndex, find )
 import           Unison.Hash                    ( Hash )
-import           Control.Monad                  ( join )
-import           Data.Functor
-import           Data.Map                       ( Map )
 import qualified Data.Map                      as Map
-import           Data.Set                       ( Set )
 import qualified Data.Set                      as Set
 import           Prelude                 hiding ( cycle )
 import           Prelude.Extras                 ( Show1 )
@@ -41,7 +37,6 @@ import           Unison.Term                    ( AnnotatedTerm
 import           Unison.Type                    ( Type )
 import qualified Unison.Type                   as Type
 import           Unison.Var                     ( Var )
-import           Data.Text                      ( Text )
 import qualified Unison.Var                    as Var
 import           Unison.Names3                 (Names0)
 import qualified Unison.Names3                 as Names

--- a/parser-typechecker/src/Unison/DeclPrinter.hs
+++ b/parser-typechecker/src/Unison/DeclPrinter.hs
@@ -5,8 +5,9 @@
 
 module Unison.DeclPrinter where
 
+import Unison.Prelude
+
 import           Data.List                      ( isPrefixOf )
-import           Data.Maybe                     ( fromMaybe )
 import qualified Data.Map                      as Map
 import           Unison.DataDeclaration         ( DataDeclaration'
                                                 , EffectDeclaration'
@@ -51,7 +52,7 @@ prettyGADT env r name dd = P.hang header . P.lines $ constructor <$> zip
   [0 ..]
   (DD.constructors' dd)
  where
-  constructor (n, (_, _, t)) = 
+  constructor (n, (_, _, t)) =
     prettyPattern env r name n
       <>       (fmt S.TypeAscriptionColon " :")
       `P.hang` TypePrinter.pretty0 env Map.empty (-1) t
@@ -71,7 +72,7 @@ prettyDataDecl
   -> HashQualified
   -> DataDeclaration' v a
   -> Pretty SyntaxText
-prettyDataDecl env r name dd = 
+prettyDataDecl env r name dd =
   (header <>) . P.sep (fmt S.DelimiterChar (" | " `P.orElse` "\n  | ")) $ constructor <$> zip
     [0 ..]
     (DD.constructors' dd)
@@ -87,7 +88,7 @@ prettyDataDecl env r name dd =
                         <> P.sep ((fmt S.DelimiterChar ",") <> " " `P.orElse` "\n      ")
                                  (field <$> zip fs (init ts))
                         <> (fmt S.DelimiterChar " }")
-  field (fname, typ) = P.group $ styleHashQualified'' (fmt S.Constructor) fname <> 
+  field (fname, typ) = P.group $ styleHashQualified'' (fmt S.Constructor) fname <>
     (fmt S.TypeAscriptionColon " :") `P.hang` TypePrinter.prettyRaw env Map.empty (-1) typ
   header = prettyDataHeader name dd <> (fmt S.DelimiterChar (" = " `P.orElse` "\n  = "))
 
@@ -137,11 +138,11 @@ fieldNames env r name dd = case DD.constructors dd of
 
 prettyModifier :: DD.Modifier -> Pretty SyntaxText
 prettyModifier DD.Structural = mempty
-prettyModifier (DD.Unique _uid) = 
+prettyModifier (DD.Unique _uid) =
   fmt S.DataTypeModifier "unique" -- <> ("[" <> P.text uid <> "] ")
 
 prettyDataHeader :: Var v => HashQualified -> DD.DataDeclaration' v a -> Pretty SyntaxText
-prettyDataHeader name dd = 
+prettyDataHeader name dd =
   P.sepNonEmpty " " [
     prettyModifier (DD.modifier dd),
     fmt S.DataTypeKeyword "type",

--- a/parser-typechecker/src/Unison/FileParser.hs
+++ b/parser-typechecker/src/Unison/FileParser.hs
@@ -7,19 +7,12 @@
 
 module Unison.FileParser where
 
+import Unison.Prelude
+
 import qualified Unison.ABT as ABT
 import qualified Data.Set as Set
-import Data.Foldable (toList)
-import Data.String (fromString)
 import Control.Lens
-import           Control.Applicative
-import           Control.Monad (guard, msum, join)
 import           Control.Monad.Reader (local, asks)
-import           Data.Functor
-import           Data.Either (partitionEithers)
-import           Data.List (foldl')
-import           Data.Text (Text)
-import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Prelude hiding (readFile)
 import qualified Text.Megaparsec as P
@@ -76,7 +69,7 @@ file = do
           Bindings bs -> ([(v,Term.generalizeTypeSignatures at) | ((_,v), at) <- bs ] ++ terms, watches)
     let (terms, watches) = (reverse termsr, reverse watchesr)
     -- local term bindings shadow any same-named thing from the outer codebase scope
-    let locals = stanzas0 >>= getVars 
+    let locals = stanzas0 >>= getVars
     let curNames = Names.deleteTerms0 (Name.fromVar <$> locals) (Names.currentNames names)
     terms <- case List.validate (traverse $ Term.bindSomeNames curNames) terms of
       Left es -> resolutionFailures (toList es)

--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -5,25 +5,19 @@
 
 module Unison.FileParsers where
 
--- import Debug.Trace
+import Unison.Prelude
+
 import Control.Lens (view, _3)
 import qualified Unison.Parser as Parser
-import           Control.Monad              (foldM)
-import           Control.Monad.Trans        (lift)
 import           Control.Monad.State        (evalStateT)
 import Control.Monad.Writer (tell)
 import           Data.Bifunctor             ( first )
-import           Data.Functor               ( ($>) )
-import           Data.Foldable              ( toList )
 import qualified Data.Foldable              as Foldable
-import           Data.Map                   (Map)
 import qualified Data.Map                   as Map
 import Data.List (partition)
-import Data.Set (Set)
 import qualified Data.Set                   as Set
-import           Data.Sequence              (Seq)
 import qualified Data.Sequence              as Seq
-import           Data.Text                  (Text, unpack)
+import           Data.Text                  (unpack)
 import qualified Unison.ABT                 as ABT
 import qualified Unison.Blank               as Blank
 import           Unison.DataDeclaration     (DataDeclaration',

--- a/parser-typechecker/src/Unison/Hash.hs
+++ b/parser-typechecker/src/Unison/Hash.hs
@@ -3,12 +3,10 @@
 
 module Unison.Hash (Hash, toBytes, base32Hex, base32Hexs, fromBase32Hex, fromBytes, unsafeFromBase32Hex, showBase32Hex) where
 
-import Data.ByteString (ByteString)
+import Unison.Prelude
+
 import Data.ByteString.Builder (doubleBE, word64BE, int64BE, toLazyByteString)
-import Data.Maybe (fromMaybe)
-import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
-import GHC.Generics
 import qualified Data.ByteArray as BA
 
 import qualified Crypto.Hash as CH

--- a/parser-typechecker/src/Unison/HashQualified'.hs
+++ b/parser-typechecker/src/Unison/HashQualified'.hs
@@ -2,12 +2,10 @@
 
 module Unison.HashQualified' where
 
+import Unison.Prelude
+
 import           Data.Maybe                     ( fromJust )
-import           Data.Text                      ( Text )
 import qualified Data.Text                     as Text
-import           Data.String                    ( IsString
-                                                , fromString
-                                                )
 import           Prelude                 hiding ( take )
 import           Unison.Name                    ( Name )
 import qualified Unison.Name                   as Name

--- a/parser-typechecker/src/Unison/HashQualified.hs
+++ b/parser-typechecker/src/Unison/HashQualified.hs
@@ -2,11 +2,10 @@
 
 module Unison.HashQualified where
 
-import           Data.Maybe                     ( isJust
-                                                , fromMaybe
-                                                , fromJust
+import Unison.Prelude hiding (fromString)
+
+import           Data.Maybe                     ( fromJust
                                                 )
-import           Data.Text                      ( Text )
 import qualified Data.Text                     as Text
 import           Prelude                 hiding ( take )
 import           Unison.Name                    ( Name(Name) )

--- a/parser-typechecker/src/Unison/Hashable.hs
+++ b/parser-typechecker/src/Unison/Hashable.hs
@@ -2,10 +2,8 @@
 
 module Unison.Hashable where
 
-import Data.Int (Int64)
-import Data.Word (Word8, Word64)
-import Data.ByteString (ByteString)
-import Data.Text (Text)
+import Unison.Prelude
+
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 

--- a/parser-typechecker/src/Unison/Kind.hs
+++ b/parser-typechecker/src/Unison/Kind.hs
@@ -2,7 +2,8 @@
 
 module Unison.Kind where
 
-import GHC.Generics
+import Unison.Prelude
+
 import Unison.Hashable (Hashable)
 import qualified Unison.Hashable as Hashable
 

--- a/parser-typechecker/src/Unison/LabeledDependency.hs
+++ b/parser-typechecker/src/Unison/LabeledDependency.hs
@@ -1,7 +1,7 @@
 module Unison.LabeledDependency (derivedTerm, derivedType, termRef, typeRef, referent, dataConstructor, effectConstructor, fold, referents, LabeledDependency) where
 
-import Data.Foldable (toList)
-import Data.Set (Set)
+import Unison.Prelude hiding (fold)
+
 import Unison.ConstructorType (ConstructorType(Data, Effect))
 import Unison.Reference (Reference(DerivedId), Id)
 import Unison.Referent (Referent(Ref, Con))

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -9,14 +9,13 @@
 
 module Unison.Lexer where
 
+import Unison.Prelude
+
 import           Control.Lens.TH (makePrisms)
-import           Control.Monad (join)
 import qualified Control.Monad.State as S
 import           Data.Char
-import           Data.Foldable (toList)
 import           Data.List
 import qualified Data.List.NonEmpty as Nel
-import           Data.Set (Set)
 import Unison.Util.Monoid (intercalateMap)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set

--- a/parser-typechecker/src/Unison/Name.hs
+++ b/parser-typechecker/src/Unison/Name.hs
@@ -21,11 +21,9 @@ module Unison.Name
   )
 where
 
+import Unison.Prelude
+
 import           Control.Lens                   ( unsnoc )
-import           Data.String                    ( IsString
-                                                , fromString
-                                                )
-import           Data.Text                      ( Text )
 import qualified Data.Text                     as Text
 import qualified Unison.Hashable               as H
 import           Unison.Var                     ( Var )

--- a/parser-typechecker/src/Unison/NamePrinter.hs
+++ b/parser-typechecker/src/Unison/NamePrinter.hs
@@ -1,6 +1,7 @@
 module Unison.NamePrinter where
 
-import           Data.String          (IsString, fromString)
+import Unison.Prelude
+
 import qualified Unison.HashQualified as HQ
 import qualified Unison.HashQualified' as HQ'
 import           Unison.Name          (Name)

--- a/parser-typechecker/src/Unison/Names2.hs
+++ b/parser-typechecker/src/Unison/Names2.hs
@@ -43,9 +43,8 @@ module Unison.Names2
   )
 where
 
-import           Data.Foldable                (toList)
-import           Data.List                    (foldl')
-import           Data.Set                     (Set)
+import Unison.Prelude
+
 import qualified Data.Set                     as Set
 import           Prelude                      hiding (filter)
 import           Unison.Codebase.SearchResult (SearchResult)

--- a/parser-typechecker/src/Unison/Names3.hs
+++ b/parser-typechecker/src/Unison/Names3.hs
@@ -3,10 +3,8 @@
 
 module Unison.Names3 where
 
-import Data.Foldable (toList)
-import Data.List (foldl')
-import Data.Sequence (Seq)
-import Data.Set (Set)
+import Unison.Prelude
+
 import Unison.HashQualified (HashQualified)
 import qualified Unison.HashQualified as HQ
 import qualified Unison.HashQualified' as HQ'
@@ -40,18 +38,18 @@ filterTypes = Unison.Names2.filterTypes
 
 -- Simple 2 way diff, has the property that:
 --  addedNames (diff0 n1 n2) == removedNames (diff0 n2 n1)
--- 
+--
 -- `addedNames` are names in `n2` but not `n1`
 -- `removedNames` are names in `n1` but not `n2`
 diff0 :: Names0 -> Names0 -> Diff
 diff0 n1 n2 = Diff n1 added removed where
-  added = Names0 (terms0 n2 `R.difference` terms0 n1)  
+  added = Names0 (terms0 n2 `R.difference` terms0 n1)
                  (types0 n2 `R.difference` types0 n1)
   removed = Names0 (terms0 n1 `R.difference` terms0 n2)
                    (types0 n1 `R.difference` types0 n2)
 
-data Diff = 
-  Diff { originalNames :: Names0 
+data Diff =
+  Diff { originalNames :: Names0
        , addedNames    :: Names0
        , removedNames  :: Names0
        } deriving Show
@@ -60,7 +58,7 @@ isEmptyDiff :: Diff -> Bool
 isEmptyDiff d = isEmpty0 (addedNames d) && isEmpty0 (removedNames d)
 
 isEmpty0 :: Names0 -> Bool
-isEmpty0 n = R.null (terms0 n) && R.null (types0 n) 
+isEmpty0 n = R.null (terms0 n) && R.null (types0 n)
 
 -- Add `n1` to `currentNames`, shadowing anything with the same name and
 -- moving shadowed definitions into `oldNames` so they can can still be

--- a/parser-typechecker/src/Unison/Parser.hs
+++ b/parser-typechecker/src/Unison/Parser.hs
@@ -5,21 +5,19 @@
 
 module Unison.Parser where
 
+import Unison.Prelude
+
 import           Data.Bytes.Put                 (runPutS)
 import           Data.Bytes.Serial              ( serialize )
 import           Data.Bytes.VarInt              ( VarInt(..) )
-import           Control.Applicative
-import           Control.Monad        (join, when, void)
 import           Data.Bifunctor       (bimap)
 import qualified Data.Char            as Char
 import           Data.List.NonEmpty   (NonEmpty (..))
-import           Data.Maybe
+-- import           Data.Maybe
 import qualified Data.Set             as Set
-import           Data.Text            (Text)
 import qualified Data.Text            as Text
 import           Data.Text.Encoding   (encodeUtf8)
 import           Data.Typeable        (Proxy (..))
-import           Debug.Trace
 import           Text.Megaparsec      (runParserT)
 import qualified Text.Megaparsec      as P
 import qualified Text.Megaparsec.Char as P
@@ -39,7 +37,6 @@ import qualified Unison.Names3 as Names
 import Control.Monad.Reader.Class (asks)
 import qualified Crypto.Random as Random
 import qualified Unison.Hashable as Hashable
-import Data.Set (Set)
 import Unison.Referent (Referent)
 import Unison.Reference (Reference)
 

--- a/parser-typechecker/src/Unison/Parsers.hs
+++ b/parser-typechecker/src/Unison/Parsers.hs
@@ -1,5 +1,7 @@
 module Unison.Parsers where
 
+import Unison.Prelude
+
 import qualified Data.Text                     as Text
 import           Data.Text.IO                   ( readFile )
 import           Prelude                 hiding ( readFile )

--- a/parser-typechecker/src/Unison/Path.hs
+++ b/parser-typechecker/src/Unison/Path.hs
@@ -6,7 +6,7 @@
 
 module Unison.Path where
 
-import Control.Applicative
+import Unison.Prelude
 
 -- | Satisfies:
 --   * `extend root p == p` and `extend p root == p`

--- a/parser-typechecker/src/Unison/Paths.hs
+++ b/parser-typechecker/src/Unison/Paths.hs
@@ -3,9 +3,9 @@
 
 module Unison.Paths where
 
+import Unison.Prelude
+
 import Data.List
-import Data.Maybe
-import GHC.Generics
 import Unison.ABT (V)
 import Unison.Term (Term)
 import Unison.Var (Var)

--- a/parser-typechecker/src/Unison/Pattern.hs
+++ b/parser-typechecker/src/Unison/Pattern.hs
@@ -2,17 +2,14 @@
 
 module Unison.Pattern where
 
+import Unison.Prelude
+
 import Data.List (intercalate)
-import Data.Int (Int64)
-import Data.Text (Text)
-import Data.Word (Word64)
 import Data.Foldable as Foldable
-import GHC.Generics
 import Unison.Reference (Reference)
 import qualified Unison.Hashable as H
 import qualified Unison.Type as Type
 import qualified Data.Set as Set
-import Data.Set (Set)
 import qualified Unison.LabeledDependency as LD
 import Unison.LabeledDependency (LabeledDependency)
 

--- a/parser-typechecker/src/Unison/PatternP.hs
+++ b/parser-typechecker/src/Unison/PatternP.hs
@@ -2,8 +2,9 @@
 
 module Unison.PatternP where
 
+import Unison.Prelude
+
 import qualified Unison.Pattern as P
-import Data.Set.Internal (Set)
 import Unison.LabeledDependency (LabeledDependency)
 
 type Pattern loc = P.PatternP loc

--- a/parser-typechecker/src/Unison/Prelude.hs
+++ b/parser-typechecker/src/Unison/Prelude.hs
@@ -1,0 +1,29 @@
+module Unison.Prelude
+  ( module X
+  ) where
+
+import Control.Applicative as X
+import Control.Exception as X (Exception, SomeException)
+import Control.Monad as X
+import Control.Monad.Extra as X (ifM, unlessM, whenM)
+import Control.Monad.IO.Class as X (MonadIO(liftIO))
+import Control.Monad.Trans as X (MonadTrans(lift))
+import Control.Monad.Trans.Maybe as X (MaybeT(MaybeT, runMaybeT))
+import Data.ByteString as X (ByteString)
+import Data.Either as X
+import Data.Either.Combinators as X (mapLeft, maybeToRight)
+import Data.Foldable as X (asum, fold, foldl', for_, forM_, toList, traverse_)
+import Data.Functor as X
+import Data.Int as X
+import Data.Map as X (Map)
+import Data.Maybe as X (catMaybes, fromMaybe, isJust, isNothing, listToMaybe, mapMaybe, maybeToList)
+import Data.Sequence as X (Seq)
+import Data.Set as X (Set)
+import Data.String as X (IsString, fromString)
+import Data.Text as X (Text)
+import Data.Traversable as X (for)
+import Data.Word as X
+import Debug.Trace as X
+import GHC.Generics as X (Generic, Generic1)
+import Safe as X (atMay, headMay, lastMay, readMay)
+import Text.Read as X (readMaybe)

--- a/parser-typechecker/src/Unison/PrettyPrintEnv.hs
+++ b/parser-typechecker/src/Unison/PrettyPrintEnv.hs
@@ -3,11 +3,8 @@
 
 module Unison.PrettyPrintEnv where
 
-import           Control.Applicative            ( (<|>) )
-import           Data.Map                       ( Map )
-import           Data.Maybe                     ( fromMaybe )
-import           Data.Text                      ( Text )
-import           Debug.Trace                    ( trace )
+import Unison.Prelude
+
 import           Unison.HashQualified           ( HashQualified )
 import           Unison.Name                    ( Name )
 import           Unison.Names3                  ( Names )

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -9,18 +9,16 @@
 
 module Unison.PrintError where
 
+import Unison.Prelude
+
 import           Control.Lens                 ((%~))
 import           Control.Lens.Tuple           (_1, _2, _3)
-import           Data.Foldable
 import           Data.List                    (intersperse)
 import           Data.List.Extra              (nubOrd)
 import qualified Data.List.NonEmpty           as Nel
 import qualified Data.Map                     as Map
-import           Data.Maybe                   (catMaybes)
 import           Data.Sequence                (Seq (..))
 import qualified Data.Set                     as Set
-import           Data.String                  (IsString, fromString)
-import           Data.Text                    (Text)
 import qualified Data.Text                    as Text
 import           Data.Void                    (Void)
 import qualified Text.Megaparsec              as P

--- a/parser-typechecker/src/Unison/Reference.hs
+++ b/parser-typechecker/src/Unison/Reference.hs
@@ -25,17 +25,13 @@ module Unison.Reference
    unsafeId,
    toShortHash) where
 
-import           Control.Monad   (join)
-import           Data.Foldable   (toList)
+import Unison.Prelude
+
 import           Data.List hiding (isPrefixOf)
 import qualified Data.Map        as Map
 import           Data.Maybe      (fromJust)
-import           Data.Set        (Set)
 import qualified Data.Set        as Set
-import           Data.Text       (Text)
 import qualified Data.Text       as Text
-import           Data.Word       (Word64)
-import           GHC.Generics
 import qualified Unison.Hash     as H
 import           Unison.Hashable as Hashable
 import Unison.ShortHash (ShortHash)

--- a/parser-typechecker/src/Unison/Reference/Util.hs
+++ b/parser-typechecker/src/Unison/Reference/Util.hs
@@ -1,10 +1,11 @@
 module Unison.Reference.Util where
 
+import Unison.Prelude
+
 import Unison.Reference
 import Unison.Hashable (Hashable1)
 import Unison.ABT (Var)
 import qualified Unison.ABT as ABT
-import Data.Map (Map)
 import qualified Data.Map as Map
 
 hashComponents ::

--- a/parser-typechecker/src/Unison/Referent.hs
+++ b/parser-typechecker/src/Unison/Referent.hs
@@ -3,12 +3,10 @@
 
 module Unison.Referent where
 
--- import           Data.Maybe             (fromMaybe)
+import Unison.Prelude
+
 import qualified Data.Char              as Char
-import           Data.Maybe             ( fromMaybe )
-import           Data.Text              (Text)
 import qualified Data.Text              as Text
-import           Data.Word              (Word64)
 import           Unison.Hashable        (Hashable)
 import qualified Unison.Hashable        as H
 import           Unison.Reference       (Reference)

--- a/parser-typechecker/src/Unison/Result.hs
+++ b/parser-typechecker/src/Unison/Result.hs
@@ -5,16 +5,15 @@
 
 module Unison.Result where
 
+import Unison.Prelude
+
 import           Control.Monad.Except           ( ExceptT(..) )
 import           Data.Functor.Identity
 import qualified Control.Monad.Fail            as Fail
-import           Control.Monad.Trans.Maybe      ( MaybeT(..) )
 import           Control.Monad.Writer           ( WriterT(..)
                                                 , runWriterT
                                                 , MonadWriter(..)
                                                 )
-import           Data.Maybe
-import           Data.Sequence                  ( Seq )
 import           Unison.Name                    ( Name )
 import qualified Unison.Parser                 as Parser
 import           Unison.Paths                   ( Path )

--- a/parser-typechecker/src/Unison/Runtime/ANF.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF.hs
@@ -8,13 +8,13 @@
 
 module Unison.Runtime.ANF (optimize, fromTerm, fromTerm', term, minimizeCyclesOrCrash) where
 
+import Unison.Prelude
+
 import Data.Bifunctor (second)
-import Data.Foldable hiding (and,or)
 import Data.List hiding (and,or)
 import Prelude hiding (abs,and,or,seq)
 import Unison.Term
 import Unison.Var (Var)
-import Data.Set (Set)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Text as Text

--- a/parser-typechecker/src/Unison/Runtime/IOSource.hs
+++ b/parser-typechecker/src/Unison/Runtime/IOSource.hs
@@ -3,12 +3,11 @@
 
 module Unison.Runtime.IOSource where
 
+import Unison.Prelude
+
 import Control.Lens (view, _1)
 import Control.Monad.Identity (runIdentity, Identity)
 import Data.List (elemIndex, genericIndex)
-import Data.Maybe (fromMaybe)
-import Data.String (fromString)
-import Data.Text (Text)
 import Text.RawString.QQ (r)
 import Unison.Codebase.CodeLookup (CodeLookup(..))
 import Unison.FileParsers (parseAndSynthesizeFile)

--- a/parser-typechecker/src/Unison/Runtime/IR.hs
+++ b/parser-typechecker/src/Unison/Runtime/IR.hs
@@ -12,19 +12,11 @@
 
 module Unison.Runtime.IR where
 
-import Control.Applicative ((<|>))
-import Control.Monad.IO.Class (liftIO)
+import Unison.Prelude
+
 import Control.Monad.State.Strict (StateT, gets, modify, runStateT, lift)
 import Data.Bifunctor (first, second)
-import Data.Foldable
-import Data.Functor (void)
 import Data.IORef
-import Data.Int (Int64)
-import Data.Map (Map)
-import Data.Maybe (isJust,fromMaybe)
-import Data.Set (Set)
-import Data.Text (Text)
-import Data.Word (Word64)
 import Unison.Hash (Hash)
 import Unison.NamePrinter (prettyHashQualified0)
 import Unison.Symbol (Symbol)
@@ -50,7 +42,6 @@ import qualified Unison.Util.CycleTable as CyT
 import qualified Unison.Util.CyclicOrd as COrd
 import qualified Unison.Util.Pretty as P
 import qualified Unison.Var as Var
--- import Debug.Trace
 
 type Pos = Int
 type Arity = Int

--- a/parser-typechecker/src/Unison/Runtime/Rt1.hs
+++ b/parser-typechecker/src/Unison/Runtime/Rt1.hs
@@ -12,19 +12,10 @@
 
 module Unison.Runtime.Rt1 where
 
-import Debug.Trace (traceM)
-import Control.Monad (foldM, join, when)
-import Control.Monad.IO.Class (liftIO)
+import Unison.Prelude
+
 import Data.Bifunctor (second)
-import Data.Foldable (for_, toList)
 import Data.IORef
-import Data.Int (Int64)
-import Data.Map (Map)
-import Data.Text (Text)
-import Data.Traversable (for)
-import Data.Sequence (Seq)
-import Data.Word (Word64)
-import Text.Read (readMaybe)
 import Unison.Runtime.IR (pattern CompilationEnv, pattern Req)
 import Unison.Runtime.IR hiding (CompilationEnv, IR, Req, Value, Z)
 import Unison.Symbol (Symbol)
@@ -50,7 +41,6 @@ import qualified Unison.Var as Var
 
 -- import qualified Unison.TermPrinter as TP
 -- import qualified Unison.Util.Pretty as P
--- import Debug.Trace
 
 type CompilationEnv = IR.CompilationEnv ExternalFunction Continuation
 type IR = IR.IR ExternalFunction Continuation

--- a/parser-typechecker/src/Unison/Runtime/Rt1IO.hs
+++ b/parser-typechecker/src/Unison/Runtime/Rt1IO.hs
@@ -7,9 +7,10 @@
 
 module Unison.Runtime.Rt1IO where
 
+import Unison.Prelude
+
 import           Control.Exception              ( try
                                                 , throwIO
-                                                , Exception, SomeException
                                                 , AsyncException(UserInterrupt)
                                                 , finally
                                                 , bracket
@@ -29,8 +30,6 @@ import           Control.Concurrent.MVar        ( MVar
                                                 , putMVar
                                                 )
 import           Control.Lens
-import           Control.Monad.Trans            ( lift )
-import           Control.Monad.IO.Class         ( liftIO )
 import           Control.Monad.Morph            ( hoist )
 import           Control.Monad.Reader           ( ReaderT
                                                 , runReaderT
@@ -40,14 +39,9 @@ import           Control.Monad.Except           ( ExceptT(..)
                                                 , runExceptT
                                                 , throwError
                                                 )
-import           Data.Foldable                  ( traverse_ )
-import           Data.Functor                   ( void )
 import           Data.GUID                      ( genText )
-import           Data.Map                       ( Map )
 import qualified Data.Map                      as Map
-import           Data.Maybe                     ( isJust )
 import qualified Data.Sequence as Seq
-import           Data.Text                      ( Text )
 import           Data.Text                     as Text
 import           Data.Time.Clock.POSIX         as Time
 import qualified Network.Simple.TCP            as Net

--- a/parser-typechecker/src/Unison/Runtime/Vector.hs
+++ b/parser-typechecker/src/Unison/Runtime/Vector.hs
@@ -2,13 +2,10 @@
 
 module Unison.Runtime.Vector where
 
-import Data.Maybe (catMaybes)
-import Control.Applicative
--- import Data.Int (Int64)
-import Data.Word (Word64)
+import Unison.Prelude
+
 import qualified Data.MemoCombinators as Memo
 import qualified Data.Vector.Unboxed as UV
--- import qualified Data.Vector as V
 
 -- A `Vec a` denotes a `Nat -> Maybe a`
 data Vec a where

--- a/parser-typechecker/src/Unison/ShortHash.hs
+++ b/parser-typechecker/src/Unison/ShortHash.hs
@@ -3,8 +3,8 @@
 
 module Unison.ShortHash where
 
-import Data.Maybe (fromMaybe)
-import Data.Text (Text)
+import Unison.Prelude
+
 import qualified Data.Text as Text
 
 -- Arya created this type to be able to query the Codebase for anonymous definitions.  The parsing functions can't fail, because they only try to pull apart the syntactic elements "#" and ".".  They don't necessarily produce a meaningful reference; you'll figure that out during base58 decoding.  We don't attempt base58 decoding here because the base58 prefix doesn't correspond to anything useful.  We'll just compare strings against the codebase or namespace later.

--- a/parser-typechecker/src/Unison/Symbol.hs
+++ b/parser-typechecker/src/Unison/Symbol.hs
@@ -3,9 +3,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Unison.Symbol where
 
-import Data.Text (Text)
-import Data.Word (Word64)
-import GHC.Generics
+import Unison.Prelude
+
 import Unison.Var (Var(..))
 import qualified Data.Set as Set
 import qualified Unison.ABT as ABT

--- a/parser-typechecker/src/Unison/Term.hs
+++ b/parser-typechecker/src/Unison/Term.hs
@@ -12,23 +12,14 @@
 
 module Unison.Term where
 
--- import Debug.Trace
+import Unison.Prelude
+
 import Prelude hiding (and,or)
 import qualified Control.Monad.Writer.Strict as Writer
-import           Data.Functor (void, ($>))
-import           Data.Foldable (traverse_, toList)
-import           Data.Int (Int64)
-import           Data.List (foldl')
-import           Data.Map (Map)
 import qualified Data.Map as Map
-import           Data.Set (Set)
 import qualified Data.Set as Set
-import           Data.Text (Text)
 import qualified Data.Text as Text
-import           Data.Sequence (Seq)
 import qualified Data.Sequence as Sequence
-import           Data.Word (Word64)
-import           GHC.Generics
 import           Prelude.Extras (Eq1(..), Show1(..))
 import           Text.Show
 import qualified Unison.ABT as ABT
@@ -57,7 +48,6 @@ import qualified Unison.Var as Var
 import           Unsafe.Coerce
 import Unison.Symbol (Symbol)
 import qualified Unison.Name as Name
-import Data.Maybe (mapMaybe)
 import qualified Unison.LabeledDependency as LD
 import Unison.LabeledDependency (LabeledDependency)
 

--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -10,14 +10,9 @@
 
 module Unison.TermParser where
 
-import           Control.Applicative
-import           Control.Monad (join, when)
+import Unison.Prelude
+
 import           Control.Monad.Reader (asks, local)
-import           Data.Foldable (asum)
-import           Data.Functor
-import           Data.Int (Int64)
-import           Data.Maybe (isJust, fromMaybe)
-import           Data.Word (Word64)
 import           Prelude hiding (and, or, seq)
 import           Unison.Name (Name)
 import           Unison.Names3 (Names)
@@ -43,7 +38,6 @@ import qualified Unison.Type as Type
 import qualified Unison.TypeParser as TypeParser
 import qualified Unison.Var as Var
 
-import Debug.Trace
 import Unison.Reference (Reference)
 
 watch :: Show a => String -> a -> a

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -5,25 +5,17 @@
 
 module Unison.TermPrinter where
 
-import           Control.Monad                  ( join )
+import Unison.Prelude
+
 import           Data.List
 import           Data.List.Extra                ( dropEnd )
-import           Data.Either                    ( isRight )
-import           Data.Foldable                  ( fold
-                                                )
-import           Data.Map                       ( Map )
 import qualified Data.Map                      as Map
-import           Data.Maybe                     ( fromMaybe
-                                                , isJust
-                                                , fromJust
+import           Data.Maybe                     ( fromJust
                                                 )
-import           Data.Set                       ( Set )
 import qualified Data.Set                      as Set
-import           Data.String                    ( IsString, fromString )
-import           Data.Text                      ( Text, splitOn, unpack )
+import           Data.Text                      ( splitOn, unpack )
 import qualified Data.Text                     as Text
 import           Data.Vector                    ( )
-import           Text.Read                      ( readMaybe )
 import           Unison.ABT                     ( pattern AbsN', reannotateUp, annotation )
 import qualified Unison.ABT                    as ABT
 import qualified Unison.Blank                  as Blank
@@ -40,7 +32,6 @@ import qualified Unison.Referent               as Referent
 import qualified Unison.Util.SyntaxText        as S
 import           Unison.Util.SyntaxText         ( SyntaxText )
 import           Unison.Term
-import           Debug.Trace                    ( trace )
 import           Unison.Type                    ( Type )
 import qualified Unison.Type                   as Type
 import qualified Unison.TypePrinter            as TypePrinter

--- a/parser-typechecker/src/Unison/Type.hs
+++ b/parser-typechecker/src/Unison/Type.hs
@@ -12,19 +12,15 @@
 
 module Unison.Type where
 
+import Unison.Prelude
+
 import qualified Control.Monad.Writer.Strict as Writer
-import Control.Monad (join)
-import Data.Functor
 import Data.Functor.Identity (runIdentity)
 import Data.Functor.Const (Const(..), getConst)
 import Data.Monoid (Any(..))
-import           Data.List
 import           Data.List.Extra (nubOrd)
 import qualified Data.Map as Map
-import           Data.Set (Set)
 import qualified Data.Set as Set
-import           Data.Text (Text)
-import           GHC.Generics
 import           Prelude.Extras (Eq1(..),Show1(..),Ord1(..))
 import qualified Unison.ABT as ABT
 import           Unison.Blank

--- a/parser-typechecker/src/Unison/TypeParser.hs
+++ b/parser-typechecker/src/Unison/TypeParser.hs
@@ -2,8 +2,8 @@
 
 module Unison.TypeParser where
 
-import           Control.Applicative
-import           Data.List
+import Unison.Prelude
+
 import qualified Text.Megaparsec as P
 import qualified Unison.Lexer as L
 import           Unison.Parser

--- a/parser-typechecker/src/Unison/TypePrinter.hs
+++ b/parser-typechecker/src/Unison/TypePrinter.hs
@@ -5,9 +5,9 @@
 
 module Unison.TypePrinter where
 
+import Unison.Prelude
+
 import qualified Data.Map              as Map
-import           Data.Maybe            (isJust)
-import           Data.String           (fromString)
 import           Unison.HashQualified  (HashQualified)
 import           Unison.NamePrinter    (styleHashQualified'')
 import           Unison.PrettyPrintEnv (PrettyPrintEnv, Imports, elideFQN)

--- a/parser-typechecker/src/Unison/Typechecker.hs
+++ b/parser-typechecker/src/Unison/Typechecker.hs
@@ -13,20 +13,14 @@
 
 module Unison.Typechecker where
 
+import Unison.Prelude
+
 import           Control.Lens
-import           Control.Monad              (join)
 import           Control.Monad.Fail         (fail)
 import           Control.Monad.State        (State, StateT, execState, get,
                                              modify)
-import           Control.Monad.Trans        (lift)
-import           Control.Monad.Trans.Maybe (MaybeT(..))
 import           Control.Monad.Writer
-import           Data.Foldable              (for_, toList, traverse_)
-import           Data.Map                   (Map)
 import qualified Data.Map                   as Map
-import           Data.Maybe                 (catMaybes, fromMaybe, isJust, maybeToList)
-import           Data.Sequence              (Seq)
-import           Data.Text                  (Text)
 import qualified Data.Text                  as Text
 import qualified Unison.ABT                 as ABT
 import qualified Unison.Blank               as B
@@ -43,7 +37,6 @@ import           Unison.Var                 (Var)
 import qualified Unison.Var                 as Var
 import qualified Unison.Typechecker.TypeLookup as TL
 import           Unison.Util.List           ( uniqueBy )
--- import           Debug.Trace
 
 type Name = Text
 

--- a/parser-typechecker/src/Unison/Typechecker/Components.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Components.hs
@@ -1,5 +1,7 @@
 module Unison.Typechecker.Components (minimize, minimize') where
 
+import Unison.Prelude
+
 import           Control.Arrow ((&&&))
 import           Data.Bifunctor (first)
 import           Data.Function (on)
@@ -7,7 +9,7 @@ import           Data.List (groupBy, sortBy, sortOn)
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as Nel
 import qualified Data.Map as Map
-import           Data.Maybe
+import           Data.Maybe (fromJust)
 import qualified Data.Set as Set
 import qualified Unison.ABT as ABT
 import           Unison.Term (AnnotatedTerm')

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -41,34 +41,24 @@ module Unison.Typechecker.Context
   )
 where
 
-import           Control.Applicative            ( Alternative(..), liftA2 )
-import           Control.Monad
+import Unison.Prelude
+
 import           Control.Monad.Reader.Class
 import           Control.Monad.State            ( get
                                                 , put
                                                 , StateT
                                                 , runStateT
                                                 )
-import           Control.Monad.Trans            ( lift )
 import           Control.Monad.Writer           ( MonadWriter(..) )
 import           Data.Bifunctor                 ( first
                                                 , second
                                                 )
-import           Data.Foldable                  ( for_ )
 import qualified Data.Foldable                 as Foldable
-import           Data.Functor
 import           Data.List
 import           Data.List.NonEmpty             ( NonEmpty )
-import           Data.Map                       ( Map )
 import qualified Data.Map                      as Map
-import           Data.Maybe
-import           Data.Sequence                  ( Seq )
-import           Data.Set                       ( Set )
 import qualified Data.Set                      as Set
-import           Data.Text                      ( Text )
 import qualified Data.Text                     as Text
-import           Data.Word                      ( Word64 )
-import           Debug.Trace
 import qualified Unison.ABT                    as ABT
 import qualified Unison.Blank                  as B
 import           Unison.DataDeclaration         ( DataDeclaration'

--- a/parser-typechecker/src/Unison/Typechecker/Extractor.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Extractor.hs
@@ -3,24 +3,11 @@
 
 module Unison.Typechecker.Extractor where
 
-import           Control.Applicative            ( Alternative
-                                                , empty
-                                                , (<|>)
-                                                )
-import           Control.Monad                  ( MonadPlus
-                                                , ap
-                                                , join
-                                                , liftM
-                                                , mplus
-                                                , mzero
-                                                )
+import Unison.Prelude hiding (whenM)
+
 import           Control.Monad.Reader
-import           Control.Monad.Trans.Maybe
-import           Data.Foldable
 import qualified Data.List                     as List
-import           Data.Set                       ( Set )
 import qualified Data.Set                      as Set
-import           Debug.Trace
 import           Unison.Reference               ( Reference )
 import qualified Unison.Term                   as Term
 import qualified Unison.Type as Type

--- a/parser-typechecker/src/Unison/Typechecker/TypeError.hs
+++ b/parser-typechecker/src/Unison/Typechecker/TypeError.hs
@@ -4,12 +4,9 @@
 
 module Unison.Typechecker.TypeError where
 
--- import Debug.Trace
-import           Control.Applicative           (empty)
-import           Data.Foldable                 (asum, toList)
+import Unison.Prelude hiding (whenM)
+
 import           Data.Bifunctor                (second)
-import           Data.Functor                  (void)
-import           Data.Maybe                    (catMaybes)
 import           Prelude                       hiding (all, and, or)
 import qualified Unison.ABT                    as ABT
 import qualified Unison.Type                   as Type

--- a/parser-typechecker/src/Unison/Typechecker/TypeLookup.hs
+++ b/parser-typechecker/src/Unison/Typechecker/TypeLookup.hs
@@ -1,8 +1,7 @@
 module Unison.Typechecker.TypeLookup where
 
-import Control.Applicative ((<|>))
-import Data.Map (Map)
-import Data.Maybe (fromMaybe)
+import Unison.Prelude
+
 import Unison.Reference (Reference)
 import Unison.Referent (Referent)
 import Unison.Type (Type)

--- a/parser-typechecker/src/Unison/UnisonFile.hs
+++ b/parser-typechecker/src/Unison/UnisonFile.hs
@@ -6,15 +6,12 @@
 
 module Unison.UnisonFile where
 
+import Unison.Prelude
+
 import Control.Lens
-import           Control.Applicative    ((<|>))
-import           Control.Monad          (join)
 import           Data.Bifunctor         (second)
-import           Data.Foldable          (toList, foldl')
-import           Data.Map               (Map)
 import qualified Data.Map               as Map
 import qualified Data.Set               as Set
-import Data.Set (Set)
 import qualified Unison.ABT as ABT
 import qualified Unison.ConstructorType as CT
 import           Unison.DataDeclaration (DataDeclaration')

--- a/parser-typechecker/src/Unison/Util/AnnotatedText.hs
+++ b/parser-typechecker/src/Unison/Util/AnnotatedText.hs
@@ -8,17 +8,14 @@
 
 module Unison.Util.AnnotatedText where
 
-import           Control.Monad      (join)
+import Unison.Prelude
+
 import qualified Data.List as L
-import           Data.Foldable      (foldl')
 import qualified Data.Foldable      as Foldable
-import           Data.Map           (Map)
 import qualified Data.Map           as Map
 import           Data.Sequence      (Seq ((:|>), (:<|)))
 import qualified Data.Sequence      as Seq
-import           Data.String        (IsString (..))
 import           Data.Tuple.Extra   (second)
-import           Safe               (headMay, lastMay)
 import           Unison.Lexer       (Line, Pos (..))
 import           Unison.Util.Monoid (intercalateMap)
 import           Unison.Util.Range  (Range (..), inRange)

--- a/parser-typechecker/src/Unison/Util/Bytes.hs
+++ b/parser-typechecker/src/Unison/Util/Bytes.hs
@@ -5,10 +5,9 @@
 
 module Unison.Util.Bytes where
 
-import Data.Maybe
-import Data.Foldable
+import Unison.Prelude hiding (empty)
+
 import Data.Monoid (Sum(..))
-import Data.Word (Word8)
 import Prelude hiding (drop)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as BL

--- a/parser-typechecker/src/Unison/Util/ColorText.hs
+++ b/parser-typechecker/src/Unison/Util/ColorText.hs
@@ -7,9 +7,8 @@ module Unison.Util.ColorText (
   module Unison.Util.AnnotatedText)
 where
 
-import Control.Monad (join)
-import           Data.Foldable             (foldl', toList)
-import           Data.Sequence             (Seq)
+import Unison.Prelude
+
 import qualified System.Console.ANSI       as ANSI
 import           Unison.Util.AnnotatedText (AnnotatedText(..), annotate)
 import qualified Unison.Util.SyntaxText    as ST hiding (toPlain)

--- a/parser-typechecker/src/Unison/Util/Components.hs
+++ b/parser-typechecker/src/Unison/Util/Components.hs
@@ -1,9 +1,10 @@
 module Unison.Util.Components where
 
+import Unison.Prelude
+
 import qualified Data.Graph as Graph
 import qualified Data.Map as Map
-import           Data.Maybe
-import           Data.Set (Set)
+import           Data.Maybe (fromJust)
 import qualified Data.Set as Set
 
 -- | Order bindings by dependencies and group into components.

--- a/parser-typechecker/src/Unison/Util/CyclicEq.hs
+++ b/parser-typechecker/src/Unison/Util/CyclicEq.hs
@@ -5,7 +5,8 @@
 
 module Unison.Util.CyclicEq where
 
-import Data.Foldable (toList)
+import Unison.Prelude
+
 import Data.Vector (Vector)
 import qualified Data.Vector as V
 import qualified Data.Sequence as S

--- a/parser-typechecker/src/Unison/Util/CyclicOrd.hs
+++ b/parser-typechecker/src/Unison/Util/CyclicOrd.hs
@@ -5,7 +5,8 @@
 
 module Unison.Util.CyclicOrd where
 
-import Data.Foldable (toList)
+import Unison.Prelude
+
 import Data.Vector (Vector)
 import Unison.Util.CycleTable (CycleTable)
 import qualified Data.Vector as V

--- a/parser-typechecker/src/Unison/Util/Exception.hs
+++ b/parser-typechecker/src/Unison/Util/Exception.hs
@@ -1,10 +1,11 @@
 module Unison.Util.Exception where
 
+import Unison.Prelude
+
 import Control.Concurrent.Async (withAsync, waitCatch)
-import Control.Exception (SomeException)
 
 -- These are adapted from: https://github.com/snoyberg/classy-prelude/blob/ccd19f2c62882c69d5dcdd3da5c0df1031334c5a/classy-prelude/ClassyPrelude.hs#L320
--- License is MIT: https://github.com/snoyberg/classy-prelude/blob/ccd19f2c62882c69d5dcdd3da5c0df1031334c5a/classy-prelude/LICENSE 
+-- License is MIT: https://github.com/snoyberg/classy-prelude/blob/ccd19f2c62882c69d5dcdd3da5c0df1031334c5a/classy-prelude/LICENSE
 
 -- Catch all exceptions except asynchronous exceptions.
 tryAny :: IO a -> IO (Either SomeException a)

--- a/parser-typechecker/src/Unison/Util/Find.hs
+++ b/parser-typechecker/src/Unison/Util/Find.hs
@@ -6,14 +6,11 @@ module Unison.Util.Find (
   fuzzyFinder, simpleFuzzyFinder, simpleFuzzyScore, fuzzyFindInBranch, fuzzyFindMatchArray, prefixFindInBranch
   ) where
 
--- import           Debug.Trace
+import Unison.Prelude
+
 import qualified Data.Char as Char
-import           Data.Foldable                (toList)
 import qualified Data.List                    as List
-import           Data.Maybe                   (catMaybes)
-import           Data.Text                    (Text)
 import qualified Data.Text                    as Text
-import           Data.String                  (fromString)
 -- http://www.serpentine.com/blog/2007/02/27/a-haskell-regular-expression-tutorial/
 -- https://www.stackage.org/haddock/lts-13.9/regex-base-0.93.2/Text-Regex-Base-Context.html -- re-exported by TDFA
 -- https://www.stackage.org/haddock/lts-13.9/regex-tdfa-1.2.3.1/Text-Regex-TDFA.html
@@ -55,7 +52,7 @@ simpleFuzzyFinder query items render =
 
 -- highlights `query` if it is a prefix of `s`, or if it
 -- appears in the final segement of s (after the final `.`)
-highlightSimple :: String -> String -> P.Pretty P.ColorText  
+highlightSimple :: String -> String -> P.Pretty P.ColorText
 highlightSimple query = go where
   go [] = mempty
   go s@(h:t) | query `List.isPrefixOf` s = hiQuery <> go (drop len s)
@@ -64,7 +61,7 @@ highlightSimple query = go where
   hiQuery = P.hiBlack (P.string query)
 
 simpleFuzzyScore :: String -> String -> Maybe Int
-simpleFuzzyScore query s 
+simpleFuzzyScore query s
   | query `List.isPrefixOf` s = Just (bonus s 2)
   | query `List.isSuffixOf` s = Just (bonus s 1)
   | query `List.isInfixOf` s = Just (bonus s 3)
@@ -72,7 +69,7 @@ simpleFuzzyScore query s
   | otherwise = Nothing
   where
   -- prefer relative names
-  bonus ('.':_) n = n*10 
+  bonus ('.':_) n = n*10
   bonus _ n = n
   lowerquery = Char.toLower <$> query
   lowers = Char.toLower <$> s

--- a/parser-typechecker/src/Unison/Util/Free.hs
+++ b/parser-typechecker/src/Unison/Util/Free.hs
@@ -2,8 +2,7 @@
 
 module Unison.Util.Free where
 
-import Control.Monad (ap, liftM, (>=>))
-import Control.Monad.Trans.Class (MonadTrans, lift)
+import Unison.Prelude hiding (fold)
 
 -- We would use another package for this if we knew of one.
 -- Neither http://hackage.haskell.org/package/free

--- a/parser-typechecker/src/Unison/Util/List.hs
+++ b/parser-typechecker/src/Unison/Util/List.hs
@@ -1,11 +1,9 @@
 module Unison.Util.List where
 
-import Data.Foldable
-import Data.Map (Map)
+import Unison.Prelude
+
 import qualified Data.Set as Set
 import qualified Data.Map as Map
-import Data.Either (partitionEithers)
-import Safe (headMay)
 
 multimap :: Foldable f => Ord k => f (k, v) -> Map k [v]
 multimap kvs =

--- a/parser-typechecker/src/Unison/Util/Logger.hs
+++ b/parser-typechecker/src/Unison/Util/Logger.hs
@@ -12,10 +12,11 @@
 --
 module Unison.Util.Logger where
 
+import Unison.Prelude
+
 import Control.Concurrent (forkIO)
 import Control.Concurrent.MVar
 import Control.Exception (bracket, try)
-import Control.Monad
 import Data.List
 import System.IO (Handle, hPutStrLn, hGetLine, stdout, stderr)
 import System.IO.Error (isEOFError)

--- a/parser-typechecker/src/Unison/Util/Menu.hs
+++ b/parser-typechecker/src/Unison/Util/Menu.hs
@@ -5,13 +5,11 @@
 
 module Unison.Util.Menu (menu1, menuN, groupMenuN) where
 
-import           Control.Monad             (when)
+import Unison.Prelude
+
 import           Data.List                 (find, isPrefixOf)
-import           Data.Set                  (Set)
 import qualified Data.Set                  as Set
-import           Data.String               (IsString, fromString)
 import           Data.Strings              (strPadLeft)
-import           Safe                      (atMay)
 import qualified Text.Read                 as Read
 import           Unison.Util.AnnotatedText (textEmpty)
 import           Unison.Util.ColorText     (ColorText, toANSI)

--- a/parser-typechecker/src/Unison/Util/Monoid.hs
+++ b/parser-typechecker/src/Unison/Util/Monoid.hs
@@ -1,8 +1,8 @@
 module Unison.Util.Monoid where
 
+import Unison.Prelude hiding (whenM)
+
 import Data.List (intersperse)
-import Data.Foldable (toList)
-import Control.Monad (foldM)
 
 -- List.intercalate extended to any monoid
 -- "The type that intercalate should have had to begin with."

--- a/parser-typechecker/src/Unison/Util/Pretty.hs
+++ b/parser-typechecker/src/Unison/Util/Pretty.hs
@@ -85,12 +85,10 @@ module Unison.Util.Pretty (
    Width
   ) where
 
+import Unison.Prelude
+
 import           Data.Char                      ( isSpace )
-import           Data.Foldable                  ( toList )
-import           Data.List                      ( foldl' , foldr1, intersperse )
-import           Data.Sequence                  ( Seq )
-import           Data.String                    ( IsString , fromString )
-import           Data.Text                      ( Text )
+import           Data.List                      ( foldr1, intersperse )
 import           Prelude                 hiding ( lines , map )
 import           Unison.Util.AnnotatedText      ( annotateMaybe )
 import qualified Unison.Util.ColorText         as CT

--- a/parser-typechecker/src/Unison/Util/Relation.hs
+++ b/parser-typechecker/src/Unison/Util/Relation.hs
@@ -1,16 +1,12 @@
 module Unison.Util.Relation where
 
+import Unison.Prelude hiding (empty, toList)
+
 import           Prelude                 hiding ( null, map, filter )
 import           Data.Bifunctor                 ( first, second )
-import           Data.Foldable                  ( foldl' )
 import qualified Data.List                     as List
 import qualified Data.Map                      as M
-import           Data.Set                       ( Set )
 import qualified Data.Set                      as S
-import           Data.Maybe                     ( isJust
-                                                , fromMaybe
-                                                )
-import           Data.Map                       ( Map )
 import qualified Data.Map                      as Map
 import qualified Unison.Hashable               as H
 

--- a/parser-typechecker/src/Unison/Util/Star3.hs
+++ b/parser-typechecker/src/Unison/Util/Star3.hs
@@ -2,8 +2,8 @@
 
 module Unison.Util.Star3 where
 
-import Data.List (foldl')
-import Data.Set (Set)
+import Unison.Prelude
+
 import Unison.Util.Relation (Relation)
 import qualified Data.Set as Set
 import qualified Unison.Hashable as H

--- a/parser-typechecker/src/Unison/Util/SyntaxText.hs
+++ b/parser-typechecker/src/Unison/Util/SyntaxText.hs
@@ -1,7 +1,7 @@
 module Unison.Util.SyntaxText where
 
-import Control.Monad                  ( join )
-import Data.Foldable                  ( toList )
+import Unison.Prelude
+
 import Unison.Util.AnnotatedText      ( AnnotatedText(..), annotate )
 
 type SyntaxText = AnnotatedText Element

--- a/parser-typechecker/src/Unison/Util/TQueue.hs
+++ b/parser-typechecker/src/Unison/Util/TQueue.hs
@@ -1,12 +1,11 @@
 module Unison.Util.TQueue where
 
-import UnliftIO (MonadIO, MonadUnliftIO)
+import Unison.Prelude
+
+import UnliftIO (MonadUnliftIO)
 import UnliftIO.STM hiding (TQueue)
 import qualified UnliftIO.Async as Async
 
-import Data.Word (Word64)
-import Data.Foldable (toList)
-import Data.Functor (($>))
 import qualified Data.Sequence as S
 import Data.Sequence (Seq((:<|)), (|>))
 

--- a/parser-typechecker/src/Unison/Util/TransitiveClosure.hs
+++ b/parser-typechecker/src/Unison/Util/TransitiveClosure.hs
@@ -2,9 +2,9 @@
 
 module Unison.Util.TransitiveClosure where
 
-import           Data.Foldable
+import Unison.Prelude
+
 import           Data.Functor.Identity    (runIdentity)
-import           Data.Set                 (Set)
 import qualified Data.Set                 as Set
 
 transitiveClosure :: forall m a. (Monad m, Ord a)

--- a/parser-typechecker/src/Unison/Var.hs
+++ b/parser-typechecker/src/Unison/Var.hs
@@ -5,13 +5,12 @@
 
 module Unison.Var where
 
+import Unison.Prelude
+
 import Data.Char (toLower, isLower)
-import Data.Set (Set)
-import Data.String (fromString)
-import Data.Text (Text, pack)
+import Data.Text (pack)
 import qualified Data.Text as Text
 import qualified Data.Set as Set
-import Data.Word (Word64)
 import qualified Unison.ABT as ABT
 import Unison.Util.Monoid (intercalateMap)
 import Unison.Reference (Reference)
@@ -160,10 +159,10 @@ syntheticVars = Set.fromList . fmap typed $ [
   Inference TypeConstructorArg ]
 
 isLowercase :: forall v . Var v => v -> Bool
-isLowercase v = 
+isLowercase v =
   ok (name $ reset v) && unqualified v == v
   where
   ok n = (all isLower . take 1 . Text.unpack) n ||
          Set.member n syntheticVarNames
-  syntheticVarNames :: Set Text 
+  syntheticVarNames :: Set Text
   syntheticVarNames = Set.map name (syntheticVars @v)

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -98,6 +98,7 @@ library
     Unison.Paths
     Unison.Pattern
     Unison.PatternP
+    Unison.Prelude
     Unison.PrettyPrintEnv
     Unison.PrettyTerminal
     Unison.PrintError


### PR DESCRIPTION
This patch adds a `Unison.Prelude` module with some commonly-imported symbols from `base` and friends. 

Possible next step: re-export bits of `Prelude` from it, and add `NoImplictPrelude` to the `.cabal` file. But for now, it is just a layer on top of `Prelude`.