### PR TITLE
TermPrinter: use unix line endings.

### DIFF
--- a/parser-typechecker/tests/Unison/Test/TermPrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/TermPrinter.hs
@@ -73,7 +73,7 @@ tc_binding width v mtp tm expected =
        input_term (Just (tp)) = ann (annotation tp) base_term tp
        input_term Nothing     = base_term
        var_v = symbol $ Text.pack v
-       prettied = fmap (CT.toPlain) $ PP.syntaxToColor $ 
+       prettied = fmap (CT.toPlain) $ PP.syntaxToColor $
         prettyBinding get_names (HQ.unsafeFromVar var_v) (input_term input_type)
        actual = if width == 0
                 then PP.renderUnbroken $ prettied


### PR DESCRIPTION
The file is currently using windows line endings ("\r\n"), unlike the
rest of the codebase.