### PR TITLE
Text.uncons/unsnoc: use tuples instead of "Pair"

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -320,8 +320,8 @@ builtinsSrc =
   , B "Text.>=" $ text --> text --> boolean
   , B "Text.<" $ text --> text --> boolean
   , B "Text.>" $ text --> text --> boolean
-  , B "Text.uncons" $ text --> optional (pair char text)
-  , B "Text.unsnoc" $ text --> optional (pair text char)
+  , B "Text.uncons" $ text --> optional (tuple [char, text])
+  , B "Text.unsnoc" $ text --> optional (tuple [text, char])
 
   , B "Char.toNat" $ char --> nat
   , B "Char.fromNat" $ nat --> char
@@ -377,6 +377,10 @@ builtinsSrc =
 
     optional :: Ord v => Type v -> Type v
     optional arg = DD.optionalType () `app` arg
+
+    tuple :: Ord v => [Type v] -> Type v
+    tuple [t] = t
+    tuple ts = foldr pair (DD.unitType ()) ts
 
     pair :: Ord v => Type v -> Type v -> Type v
     pair l r = DD.pairType () `app` l `app` r

--- a/parser-typechecker/src/Unison/Runtime/IR.hs
+++ b/parser-typechecker/src/Unison/Runtime/IR.hs
@@ -129,6 +129,10 @@ unit = Data DD.unitRef 0 []
 pair :: (Value e cont, Value e cont) -> Value e cont
 pair (a, b) = Data DD.pairRef 0 [a, b]
 
+tuple :: [Value e cont] -> Value e cont
+tuple [v] = v
+tuple vs = foldr (curry pair) unit vs
+
 -- When a lambda is underapplied, for instance, `(x y -> x) 19`, we can do
 -- one of two things: we can substitute away the arguments that have
 -- been applied, in this example, creating the lambda `x -> 19`. This

--- a/parser-typechecker/src/Unison/Runtime/Rt1.hs
+++ b/parser-typechecker/src/Unison/Runtime/Rt1.hs
@@ -283,13 +283,13 @@ builtinCompilationEnv = CompilationEnv (builtinsMap <> IR.builtins) mempty
     , mk1 "Text.uncons" att
         ( pure
         . IR.maybeToOptional
-        . fmap (\(h, t) -> IR.pair (C h, T t))
+        . fmap (\(h, t) -> IR.tuple [C h, T t])
         )
         $ Text.uncons
     , mk1 "Text.unsnoc" att
         ( pure
         . IR.maybeToOptional
-        . fmap (\(i, l) -> IR.pair (T i, C l))
+        . fmap (\(i, l) -> IR.tuple [T i, C l])
         )
         $ Text.unsnoc
 


### PR DESCRIPTION
I'd misunderstood the role of `Pair` when I added these in the first place.

It would be good to have a better story re: migrations of builtins, but I found that just updating the definitions that used it (only one, actually) worked ok for unison-parsers.