### PR TITLE
`history` command (alias: `log`) for viewing history of a namespace

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -19,6 +19,7 @@ import           Unison.Codebase.Editor.Output
 import           Unison.Codebase.Editor.RemoteRepo
 
 import           Unison.Codebase.Branch         ( Branch )
+import qualified Unison.Codebase.Branch        as Branch
 import           Unison.Codebase.GitError
 import           Unison.Names3                  ( Names, Names0 )
 import           Unison.Parser                  ( Ann )
@@ -108,6 +109,9 @@ data Command m i v a where
   -- Any definitions in the head of the requested root that aren't in the local
   -- codebase are copied there.
   LoadLocalRootBranch :: Command m i v (Branch m)
+
+  -- Like `LoadLocalRootBranch`.
+  LoadLocalBranch :: Branch.Hash -> Command m i v (Branch m) 
 
   LoadRemoteRootBranch ::
     RemoteRepo -> Command m i v (Either GitError (Branch m))

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -105,6 +105,7 @@ commandLine config awaitInput setBranchRef rt notifyUser codebase =
     Evaluate ppe unisonFile        -> evalUnisonFile ppe unisonFile
     Evaluate1 ppe term             -> eval1 ppe term
     LoadLocalRootBranch        -> Codebase.getRootBranch codebase
+    LoadLocalBranch h          -> Codebase.getBranchForHash codebase h 
     SyncLocalRootBranch branch -> do
       setBranchRef branch
       Codebase.putRootBranch codebase branch

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -410,6 +410,19 @@ loop = do
         branch' <- getAt path
         when (Branch.isEmpty branch') (respond $ CreatedNewBranch path)
 
+      LogI _range from -> case from of
+        Left path' -> do
+          path <- use $ currentPath . to (`Path.toAbsolutePath` path')
+          branch' <- getAt path 
+          if Branch.isEmpty branch' then respond $ CreatedNewBranch path
+          else doHistory branch' 
+        Right hash -> do
+          b <- eval $ LoadLocalBranch hash
+          if Branch.isEmpty b then respond $ NoBranchWithHash input hash
+          else doHistory b
+        where
+          doHistory _b = respond NotImplemented 
+
       UndoI -> do
         prev <- eval . Eval $ Branch.uncons root'
         case prev of
@@ -1040,7 +1053,6 @@ loop = do
       AddTypeReplacementI {} -> notImplemented
       RemoveTermReplacementI {} -> notImplemented
       RemoveTypeReplacementI {} -> notImplemented
-      UndoRootI -> notImplemented
       ShowDefinitionByPrefixI {} -> notImplemented
       UpdateBuiltinsI -> notImplemented
       QuitI -> MaybeT $ pure Nothing

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -432,7 +432,7 @@ loop = do
               Causal.One{} -> 
                 respond $ Log diffCap acc (EndOfLog $ Branch.headHash b)
               Causal.Merge{..} -> 
-                respond $ Log diffCap acc (MergeTail $ Map.keys tails) 
+                respond $ Log diffCap acc (MergeTail (Branch.headHash b) $ Map.keys tails) 
               Causal.Cons{..} -> do 
                 b' <- fmap Branch.Branch . eval . Eval $ snd tail
                 let elem = (Branch.headHash b, Branch.namesDiff b' b)

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -398,25 +398,25 @@ loop = do
         branch' <- getAt path
         when (Branch.isEmpty branch') (respond $ CreatedNewBranch path)
 
-      LogI resultsCap diffCap from -> case from of
-        Left path' -> do
+      HistoryI resultsCap diffCap from -> case from of
+        Left hash -> do
+          b <- eval $ LoadLocalBranch hash
+          if Branch.isEmpty b then respond $ NoBranchWithHash input hash
+          else doHistory 0 b []
+        Right path' -> do
           path <- use $ currentPath . to (`Path.toAbsolutePath` path')
           branch' <- getAt path 
           if Branch.isEmpty branch' then respond $ CreatedNewBranch path
           else doHistory 0 branch' []
-        Right hash -> do
-          b <- eval $ LoadLocalBranch hash
-          if Branch.isEmpty b then respond $ NoBranchWithHash input hash
-          else doHistory 0 b []
         where
           doHistory !n b acc = 
             if maybe False (n >=) resultsCap then 
-              respond $ Log diffCap acc (PageEnd (Branch.headHash b) n)
+              respond $ History diffCap acc (PageEnd (Branch.headHash b) n)
             else case Branch._history b of
               Causal.One{} -> 
-                respond $ Log diffCap acc (EndOfLog $ Branch.headHash b)
+                respond $ History diffCap acc (EndOfLog $ Branch.headHash b)
               Causal.Merge{..} -> 
-                respond $ Log diffCap acc (MergeTail (Branch.headHash b) $ Map.keys tails) 
+                respond $ History diffCap acc (MergeTail (Branch.headHash b) $ Map.keys tails) 
               Causal.Cons{..} -> do 
                 b' <- fmap Branch.Branch . eval . Eval $ snd tail
                 let elem = (Branch.headHash b, Branch.namesDiff b' b)

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -423,15 +423,15 @@ loop = do
         where
           doHistory !n b acc = 
             if maybe False (n >=) resultsCap then 
-              respond $ Log diffCap acc (PageEnd n)
+              respond $ Log diffCap acc (PageEnd (Branch.headHash b) n)
             else case Branch._history b of
               Causal.One{} -> 
-                respond $ Log diffCap acc EndOfLog 
+                respond $ Log diffCap acc (EndOfLog $ Branch.headHash b)
               Causal.Merge{..} -> 
                 respond $ Log diffCap acc (MergeTail $ Map.keys tails) 
               Causal.Cons{..} -> do 
                 b' <- fmap Branch.Branch . eval . Eval $ snd tail
-                let elem = (Branch.headHash b, Branch.namesDiff b b')
+                let elem = (Branch.headHash b, Branch.namesDiff b' b)
                 doHistory (n+1) b' (elem : acc)
 
       UndoI -> do

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -77,9 +77,9 @@ data Input
     | RemoveTermReplacementI PatchPath Reference Reference
     | RemoveTypeReplacementI PatchPath Reference Reference
   | UndoI
-  -- Maybe (Int,Int) is a start and end index into the results,
-  -- can be used for paging
-  | LogI (Maybe (Int,Int)) (Either Path' Branch.Hash)
+  -- First `Maybe Int` is cap on number of results, if any
+  -- Second `Maybe Int` is cap on diff elements shown, if any
+  | LogI (Maybe Int) (Maybe Int) (Either Path' Branch.Hash)
   -- execute an IO object with arguments
   | ExecuteI String
   | TestI Bool Bool -- TestI showSuccesses showFailures

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -28,7 +28,7 @@ data Input
     -- directory ops
     -- `Link` must describe a repo and a source path within that repo.
     -- clone w/o merge, error if would clobber
-    = ForkLocalBranchI Path' Path'
+    = ForkLocalBranchI (Either Branch.Hash Path') Path'
     -- merge first causal into destination
     | MergeLocalBranchI Path' Path'
     | PreviewMergeLocalBranchI Path' Path'

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -3,6 +3,7 @@ module Unison.Codebase.Editor.Input
   , Event(..)
   , OutputLocation(..)
   , PatchPath
+  , BranchId, parseBranchId
   ) where
 
 import Unison.Prelude
@@ -14,6 +15,9 @@ import           Unison.Codebase.Path           ( Path' )
 import qualified Unison.Codebase.Path          as Path
 import           Unison.Codebase.Editor.RemoteRepo
 import           Unison.Reference (Reference)
+import qualified Unison.Hash as Hash
+import qualified Unison.Codebase.Causal as Causal
+import qualified Data.Text as Text 
 
 data Event
   = UnisonFileChanged SourceName Source
@@ -22,6 +26,13 @@ data Event
 type Source = Text -- "id x = x\nconst a b = a"
 type SourceName = Text -- "foo.u" or "buffer 7"
 type PatchPath = Path.Split'
+type BranchId = Either Branch.Hash Path'
+
+parseBranchId :: String -> Either String BranchId
+parseBranchId ('#':s) = case Hash.fromBase32Hex (Text.pack s) of
+  Nothing -> Left "Invalid hash, expected a base32hex string."
+  Just h -> pure . Left $ Causal.RawHash h
+parseBranchId s = Right <$> Path.parsePath' s
 
 data Input
   -- names stuff:
@@ -79,7 +90,7 @@ data Input
   | UndoI
   -- First `Maybe Int` is cap on number of results, if any
   -- Second `Maybe Int` is cap on diff elements shown, if any
-  | LogI (Maybe Int) (Maybe Int) (Either Path' Branch.Hash)
+  | HistoryI (Maybe Int) (Maybe Int) BranchId 
   -- execute an IO object with arguments
   | ExecuteI String
   | TestI Bool Bool -- TestI showSuccesses showFailures

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -77,6 +77,9 @@ data Input
     | RemoveTermReplacementI PatchPath Reference Reference
     | RemoveTypeReplacementI PatchPath Reference Reference
   | UndoI
+  -- Maybe (Int,Int) is a start and end index into the results,
+  -- can be used for paging
+  | LogI (Maybe (Int,Int)) (Either Path' Branch.Hash)
   -- execute an IO object with arguments
   | ExecuteI String
   | TestI Bool Bool -- TestI showSuccesses showFailures
@@ -88,7 +91,6 @@ data Input
   -- links from <type>
   | LinksI Path.HQSplit' (Maybe String)
   -- other
-  | UndoRootI
   | SearchByNameI Bool Bool [String] -- SearchByName isVerbose showAll query
   | FindPatchI
   | ShowDefinitionI OutputLocation [String]

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -3,6 +3,7 @@
 module Unison.Codebase.Editor.Output
   ( Output(..)
   , ListDetailed
+  , LogTail(..)
   , ShowAll
   , TestReportStats(..)
   , UndoFailureReason(..)
@@ -139,12 +140,19 @@ data Output v
   | PatchInvolvesExternalDependents PPE.PrettyPrintEnv (Set Reference)
   | WarnIncomingRootBranch (Set Branch.Hash)
   | ShowDiff Input Names.Diff
+  | Log (Maybe Int) [(Branch.Hash, Names.Diff)] LogTail
   | NothingTodo Input
   | NotImplemented
   | NoBranchWithHash Input Branch.Hash
   | DumpBitBooster Branch.Hash (Map Branch.Hash [Branch.Hash])
   deriving (Show)
 
+data LogTail = 
+  EndOfLog | 
+  MergeTail [Branch.Hash] | 
+  PageEnd Int -- PageEnd nextIndex 
+  deriving (Show)
+  
 data TestReportStats
   = CachedTests TotalCount CachedCount
   | NewlyComputed deriving Show

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -3,7 +3,7 @@
 module Unison.Codebase.Editor.Output
   ( Output(..)
   , ListDetailed
-  , LogTail(..)
+  , HistoryTail(..)
   , ShowAll
   , TestReportStats(..)
   , UndoFailureReason(..)
@@ -139,14 +139,14 @@ data Output v
   | PatchInvolvesExternalDependents PPE.PrettyPrintEnv (Set Reference)
   | WarnIncomingRootBranch (Set Branch.Hash)
   | ShowDiff Input Names.Diff
-  | Log (Maybe Int) [(Branch.Hash, Names.Diff)] LogTail
+  | History (Maybe Int) [(Branch.Hash, Names.Diff)] HistoryTail
   | NothingTodo Input
   | NotImplemented
   | NoBranchWithHash Input Branch.Hash
   | DumpBitBooster Branch.Hash (Map Branch.Hash [Branch.Hash])
   deriving (Show)
 
-data LogTail = 
+data HistoryTail = 
   EndOfLog Branch.Hash | 
   MergeTail Branch.Hash [Branch.Hash] | 
   PageEnd Branch.Hash Int -- PageEnd nextHash nextIndex 

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -148,9 +148,9 @@ data Output v
   deriving (Show)
 
 data LogTail = 
-  EndOfLog | 
+  EndOfLog Branch.Hash | 
   MergeTail [Branch.Hash] | 
-  PageEnd Int -- PageEnd nextIndex 
+  PageEnd Branch.Hash Int -- PageEnd nextHash nextIndex 
   deriving (Show)
   
 data TestReportStats

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -149,7 +149,7 @@ data Output v
 
 data LogTail = 
   EndOfLog Branch.Hash | 
-  MergeTail [Branch.Hash] | 
+  MergeTail Branch.Hash [Branch.Hash] | 
   PageEnd Branch.Hash Int -- PageEnd nextHash nextIndex 
   deriving (Show)
   

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -141,6 +141,7 @@ data Output v
   | ShowDiff Input Names.Diff
   | NothingTodo Input
   | NotImplemented
+  | NoBranchWithHash Input Branch.Hash
   | DumpBitBooster Branch.Hash (Map Branch.Hash [Branch.Hash])
   deriving (Show)
 

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -238,10 +238,18 @@ initialize :: CodebasePath -> IO ()
 initialize path =
   traverse_ (createDirectoryIfMissing True) (minimalCodebaseStructure path)
 
-branchFromFiles :: MonadIO m => Bool -> FilePath -> Branch.Hash -> m (Branch m)
-branchFromFiles failIfMissing rootDir h@(RawHash h') = do 
+-- When loading a nonexistent branch, what should happen?
+-- Could bomb (`FailIfMissing`) or return the empty branch (`EmptyIfMissing`).
+--
+-- `EmptyIfMissing` mode is used when attempting to load a user-specified
+-- branch. `FailIfMissing` is used when loading the root branch - if the root
+-- does not exist, that's a serious problem.
+data BranchLoadMode = FailIfMissing | EmptyIfMissing deriving Eq
+
+branchFromFiles :: MonadIO m => BranchLoadMode -> FilePath -> Branch.Hash -> m (Branch m)
+branchFromFiles loadMode rootDir h@(RawHash h') = do 
   fileExists <- doesFileExist (branchPath rootDir h')
-  if fileExists || failIfMissing then 
+  if fileExists || loadMode == FailIfMissing then 
     Branch.read (deserializeRawBranch rootDir)
                 (deserializeEdits rootDir)
                 h
@@ -275,7 +283,7 @@ getRootBranch root = do
  where
   go single = case hashFromString single of
     Nothing -> failWith $ CantParseBranchHead single
-    Just h  -> branchFromFiles True root (RawHash h)
+    Just h  -> branchFromFiles FailIfMissing root (RawHash h)
 
 putRootBranch :: MonadIO m => CodebasePath -> Branch m -> m ()
 putRootBranch root b = do
@@ -502,7 +510,7 @@ codebase1 fmtV@(S.Format getV putV) fmtA@(S.Format getA putA) path
                      (getRootBranch path)
                      (putRootBranch path)
                      (branchHeadUpdates path)
-                     (branchFromFiles False path)
+                     (branchFromFiles EmptyIfMissing path)
                      dependents
                      (copyFromGit path)
                      -- This is fine as long as watat doesn't call

--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -33,8 +33,10 @@ newtype Path' = Path' { unPath' :: Either Absolute Relative }
   deriving (Eq,Ord)
 
 isCurrentPath :: Path' -> Bool
-isCurrentPath (Path' (Right (Relative (Path e)))) | e == mempty = True
-isCurrentPath _ = False
+isCurrentPath p = p == currentPath
+
+currentPath :: Path'
+currentPath = Path' (Right (Relative (Path mempty)))
 
 isRoot' :: Path' -> Bool
 isRoot' = either isRoot (const False) . unPath'

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -440,10 +440,15 @@ forkLocal = InputPattern "fork" ["copy.namespace"] [(Required, pathArg)
                                    ,(Required, pathArg)]
     "`fork foo bar` creates the namespace `bar` as a fork of `foo`."
     (\case
+      ['#':src, dest] -> case Hash.fromBase32Hex (Text.pack src) of
+        Nothing -> Left "Invalid hash, expected a base32hex string." 
+        Just h -> first fromString $ do
+          dest <- Path.parsePath' dest
+          pure $ Input.ForkLocalBranchI (Left (Causal.RawHash h)) dest
       [src, dest] -> first fromString $ do
         src <- Path.parsePath' src
         dest <- Path.parsePath' dest
-        pure $ Input.ForkLocalBranchI src dest
+        pure $ Input.ForkLocalBranchI (Right src) dest
       _ -> Left (I.help forkLocal)
     )
 

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -427,11 +427,11 @@ history = InputPattern "log"
     (\case
       ['#':src] -> case Hash.fromBase32Hex (Text.pack src) of
         Nothing -> Left ("Invalid hash, expected a base32hex string.") 
-        Just h -> pure $ Input.LogI Nothing (Right (Causal.RawHash h))
+        Just h -> pure $ Input.LogI (Just 10) (Just 10) (Right (Causal.RawHash h))
       [src] -> first fromString $ do
         p <- Path.parsePath' src
-        pure $ Input.LogI Nothing (Left p)
-      [] -> pure $ Input.LogI Nothing (Left Path.currentPath)
+        pure $ Input.LogI (Just 10) (Just 10) (Left p)
+      [] -> pure $ Input.LogI (Just 10) (Just 10) (Left Path.currentPath)
       _ -> Left (I.help history)
     )
 

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -517,7 +517,7 @@ notifyUser dir o = case o of
     where
     tailMsg = case tail of
       E.EndOfLog h -> P.lines [
-        "You've reached the beginning of recorded history.", "",
+        P.wrap "This is the start of history. Later versions are listed below.",
         "□ " <> phash h, ""
         ]
       E.MergeTail h hs -> P.lines [
@@ -528,7 +528,7 @@ notifyUser dir o = case o of
         "⊙ " <> phash h <> (if null history then mempty else "\n")
         ]
       E.PageEnd h n -> P.lines [
-        P.wrap $ "More history above here." <> ex, "",
+        P.wrap $ "There's more history before the versions shown here." <> ex, "",
         dots, "", 
         "⊙ " <> phash h,
         ""

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -508,6 +508,35 @@ notifyUser dir o = case o of
   PatchNeedsToBeConflictFree -> putPrettyLn "A patch needs to be conflict-free."
   PatchInvolvesExternalDependents _ _ ->
     putPrettyLn "That patch involves external dependents."
+  Log cap history tail -> putPrettyLn . P.callout "🌳" $ 
+    P.lines [
+      tailMsg,
+      P.sep "\n\n" [ go h diff | (h,diff) <- history ]
+      ]
+    where
+    tailMsg = case tail of
+      E.EndOfLog -> "□"
+      E.MergeTail hs -> P.lines [
+        P.wrap $ "This segment of history starts with a merge." <> ex,
+        "",
+        P.lines (phash <$> hs), 
+        dots,
+        ""
+        ]
+      E.PageEnd n -> P.lines [
+        P.wrap $ "More history above here." <> ex, "",
+        "⠇",
+        ""
+        ]
+    dots = "⠇"
+    go hash diff = P.lines [
+      "⊙ " <> phash hash,
+      "",
+      P.indentN 2 $ prettyDiff cap diff 
+      ]
+    ex = "Use" <> IP.makeExample IP.history ["#som3n8m3space"] 
+               <> "to view history starting from a given namespace hash."
+    phash hash = P.bold ("#" <> P.shown hash)
   ShowDiff input diff -> putPrettyLn $ case input of
     Input.UndoI -> P.callout "⏪" . P.lines $ [
       "Here's the changes I undid:", "",

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -508,14 +508,18 @@ notifyUser dir o = case o of
   PatchNeedsToBeConflictFree -> putPrettyLn "A patch needs to be conflict-free."
   PatchInvolvesExternalDependents _ _ ->
     putPrettyLn "That patch involves external dependents."
-  Log cap history tail -> putPrettyLn . P.callout "🌳" $ 
+  Log cap history tail -> putPrettyLn $ 
     P.lines [
       tailMsg,
-      P.sep "\n\n" [ go h diff | (h,diff) <- history ]
+      P.sep "\n\n" [ go h diff | (h,diff) <- history ], "",
+      note $ "The most recent namespace hash is immediately above this message."
       ]
     where
     tailMsg = case tail of
-      E.EndOfLog -> "□"
+      E.EndOfLog h -> P.lines [
+        "You've reached the beginning of recorded history.", "",
+        "□ " <> phash h, ""
+        ]
       E.MergeTail hs -> P.lines [
         P.wrap $ "This segment of history starts with a merge." <> ex,
         "",
@@ -523,16 +527,17 @@ notifyUser dir o = case o of
         dots,
         ""
         ]
-      E.PageEnd n -> P.lines [
+      E.PageEnd h n -> P.lines [
         P.wrap $ "More history above here." <> ex, "",
-        "⠇",
+        dots, "", 
+        "⊙ " <> phash h,
         ""
         ]
     dots = "⠇"
     go hash diff = P.lines [
-      "⊙ " <> phash hash,
+      P.indentN 2 $ prettyDiff cap diff,
       "",
-      P.indentN 2 $ prettyDiff cap diff 
+      "⊙ " <> phash hash
       ]
     ex = "Use" <> IP.makeExample IP.history ["#som3n8m3space"] 
                <> "to view history starting from a given namespace hash."

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -491,6 +491,8 @@ notifyUser dir o = case o of
           )
           <> "Type `help " <> pushPull "push" "pull" pp <>
           "` for more information."
+  NoBranchWithHash _ h -> putPrettyLn . P.callout "😶" $ 
+    P.wrap $ "I don't know of a namespace with that hash."
   NotImplemented -> putPrettyLn $ P.wrap "That's not implemented yet. Sorry! 😬"
   BranchAlreadyExists _ _ -> putPrettyLn "That namespace already exists."
   TypeAmbiguous _ _ _ -> putPrettyLn "That type is ambiguous."

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -502,7 +502,7 @@ notifyUser dir o = case o of
   PatchNeedsToBeConflictFree -> putPrettyLn "A patch needs to be conflict-free."
   PatchInvolvesExternalDependents _ _ ->
     putPrettyLn "That patch involves external dependents."
-  Log cap history tail -> putPrettyLn $ 
+  History cap history tail -> putPrettyLn $ 
     P.lines [
       tailMsg,
       P.sep "\n\n" [ go h diff | (h,diff) <- history ], "",
@@ -533,7 +533,7 @@ notifyUser dir o = case o of
       "",
       "⊙ " <> phash hash
       ]
-    ex = "Use" <> IP.makeExample IP.history ["#som3n8m3space"] 
+    ex = "Use" <> IP.makeExample IP.history ["#som3n4m3space"] 
                <> "to view history starting from a given namespace hash."
     phash hash = ("#" <> P.shown hash)
   ShowDiff input diff -> putPrettyLn $ case input of

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -520,12 +520,12 @@ notifyUser dir o = case o of
         "You've reached the beginning of recorded history.", "",
         "□ " <> phash h, ""
         ]
-      E.MergeTail hs -> P.lines [
+      E.MergeTail h hs -> P.lines [
         P.wrap $ "This segment of history starts with a merge." <> ex,
         "",
         P.lines (phash <$> hs), 
-        dots,
-        ""
+        "⑂",
+        "⊙ " <> phash h <> (if null history then mempty else "\n")
         ]
       E.PageEnd h n -> P.lines [
         P.wrap $ "More history above here." <> ex, "",
@@ -541,7 +541,7 @@ notifyUser dir o = case o of
       ]
     ex = "Use" <> IP.makeExample IP.history ["#som3n8m3space"] 
                <> "to view history starting from a given namespace hash."
-    phash hash = P.bold ("#" <> P.shown hash)
+    phash hash = ("#" <> P.shown hash)
   ShowDiff input diff -> putPrettyLn $ case input of
     Input.UndoI -> P.callout "⏪" . P.lines $ [
       "Here's the changes I undid:", "",


### PR DESCRIPTION
You can now ask for the history of any namespace. Supplying no args gives you the history of the root namespace. It stops when hitting a merge node:

<img width="1112" alt="Screen Shot 2019-08-14 at 1 27 29 PM" src="https://user-images.githubusercontent.com/11074/63042268-a3441d00-be97-11e9-8494-53fdd3760070.png">

As the message mentions, you can supply a (complete) hash to view the history of any namespace that isn't named in your current root. This can be used for paging (to see further into the past) or for exploring one of the branches of a merge node - just `history #somehash` to see the history starting from that hash.

Diffs are shown between each hash:

<img width="1092" alt="Screen Shot 2019-08-14 at 1 36 15 PM" src="https://user-images.githubusercontent.com/11074/63042690-8fe58180-be98-11e9-8054-4cf520e4ab3b.png">

Currently it shows 10 results at a time, and diff excerpts, but this isn't hardcoded in the command, just in the input pattern, so we could expose a different input pattern or flags to control how far back to look with a few LOC change in `InputPatterns.hs` (haven't done that for this PR).

<img width="1108" alt="Screen Shot 2019-08-14 at 1 38 09 PM" src="https://user-images.githubusercontent.com/11074/63042810-cf13d280-be98-11e9-9ed9-46aa21897341.png">

Also important is that the `fork` command can now take hashes to identify the source namespace, so you can now use `history` to browse the history, and `fork` to resurrect old versions of your codebase. Here, I forked a version of my codebase before adding the `.stream` namespace, and confirm that the `.stream` namespace is empty in the forked namespace:

<img width="828" alt="Screen Shot 2019-08-14 at 1 45 38 PM" src="https://user-images.githubusercontent.com/11074/63043261-ddaeb980-be99-11e9-8144-2d6a90d6839d.png">

One last thing: d0eff62c adds a fix to `FileCodebase.getBranchForHash`. It was crashing if the provided hash isn't in the codebase. There are cases where you do want to crash if the hash isn't found (like if you are traversing the history of an existing `Branch`, or loading the root), but for loading a user-provided hash like what is done for the `history` command, it's okay to not bomb and just report something to the user ("I don't know about a namespace with that hash"). So that's what's done now.