### PR TITLE
use template haskell to embed git version during compilation

### DIFF
--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -241,12 +241,17 @@ executable unison
   main-is: Main.hs
   hs-source-dirs: unison
   ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
+  other-modules:
+    Version
   build-depends:
     base,
     containers,
     directory,
     filepath,
     safe,
+    shellmet,
+    template-haskell,
+    text,
     unison-parser-typechecker
 
 executable prettyprintdemo

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 module Main where
 
 import           Safe                           ( headMay )
@@ -6,6 +8,7 @@ import qualified Unison.Codebase.FileCodebase  as FileCodebase
 import qualified Unison.CommandLine.Main       as CommandLine
 import qualified Unison.Runtime.Rt1IO          as Rt1
 import qualified Unison.Codebase.Path          as Path
+import qualified Version as Version
 
 
 main :: IO ()
@@ -13,6 +16,7 @@ main = do
   args               <- getArgs
   -- hSetBuffering stdout NoBuffering -- cool
   (dir, theCodebase) <- FileCodebase.ensureCodebaseInitialized
+  putStrLn $ "Version: " ++ Version.gitDescribe
   let initialPath = Path.absoluteEmpty
       launch      = CommandLine.main dir
                                      initialPath

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Main where
 
 import           Safe                           ( headMay )
@@ -16,11 +14,12 @@ main = do
   args               <- getArgs
   -- hSetBuffering stdout NoBuffering -- cool
   (dir, theCodebase) <- FileCodebase.ensureCodebaseInitialized
-  putStrLn $ "Version: " ++ Version.gitDescribe
   let initialPath = Path.absoluteEmpty
       launch      = CommandLine.main dir
                                      initialPath
                                      (headMay args)
                                      (pure Rt1.runtime)
                                      theCodebase
-  launch
+  case args of
+    ["--version"] -> putStrLn $ "ucm version: " ++ Version.gitDescribe
+    _ -> launch

--- a/parser-typechecker/unison/Version.hs
+++ b/parser-typechecker/unison/Version.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Version where
+
+import Language.Haskell.TH (runIO)
+import Language.Haskell.TH.Syntax (Exp(LitE), Lit(StringL))
+import Shellmet
+import Data.Text
+
+gitDescribe :: String
+gitDescribe = $( fmap (LitE . StringL . unpack) . runIO $
+  "git" $| ["describe", "--tags", "--always", "--dirty='"]
+        $? pure "unknown"
+  )
+


### PR DESCRIPTION
A quick implementation using TemplateHaskell to embed the git version into the unison executable.

However, `stack` / `cabal` don't know to update the info when it changes; see discussion in #725.  The remaining work will be tracked in #736.
