### PR TITLE
New builtins: Text.fromList & Text.toList

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -324,8 +324,8 @@ builtinsSrc =
   , B "Text.uncons" $ text --> optional (tuple [char, text])
   , B "Text.unsnoc" $ text --> optional (tuple [text, char])
 
-  , B "Text.toList" $ text --> list char
-  , B "Text.fromList" $ list char --> text
+  , B "Text.toCharList" $ text --> list char
+  , B "Text.fromCharList" $ list char --> text
 
   , B "Char.toNat" $ char --> nat
   , B "Char.fromNat" $ nat --> char

--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -324,6 +324,9 @@ builtinsSrc =
   , B "Text.uncons" $ text --> optional (tuple [char, text])
   , B "Text.unsnoc" $ text --> optional (tuple [text, char])
 
+  , B "Text.toList" $ text --> list char
+  , B "Text.fromList" $ list char --> text
+
   , B "Char.toNat" $ char --> nat
   , B "Char.fromNat" $ nat --> char
 

--- a/parser-typechecker/src/Unison/Runtime/Rt1.hs
+++ b/parser-typechecker/src/Unison/Runtime/Rt1.hs
@@ -281,10 +281,10 @@ builtinCompilationEnv = CompilationEnv (builtinsMap <> IR.builtins) mempty
         )
         $ Text.unsnoc
 
-    , mk1 "Text.toList" att (pure . Sequence)
+    , mk1 "Text.toCharList" att (pure . Sequence)
         (Sequence.fromList . map C . Text.unpack)
 
-    , mk1 "Text.fromList" ats (pure . T)
+    , mk1 "Text.fromCharList" ats (pure . T)
         (\s -> Text.pack [ c | C c <- toList s ])
 
     , mk1 "Char.toNat" atc (pure . N) (fromIntegral . fromEnum)

--- a/parser-typechecker/src/Unison/Runtime/Rt1.hs
+++ b/parser-typechecker/src/Unison/Runtime/Rt1.hs
@@ -281,6 +281,12 @@ builtinCompilationEnv = CompilationEnv (builtinsMap <> IR.builtins) mempty
         )
         $ Text.unsnoc
 
+    , mk1 "Text.toList" att (pure . Sequence)
+        (Sequence.fromList . map C . Text.unpack)
+
+    , mk1 "Text.fromList" ats (pure . T)
+        (\s -> Text.pack [ c | C c <- toList s ])
+
     , mk1 "Char.toNat" atc (pure . N) (fromIntegral . fromEnum)
     , mk1 "Char.fromNat" atn (pure . C) (toEnum . fromIntegral)
 


### PR DESCRIPTION
I also wrote some tests for these. Per @pchiusano's suggestion, these are published at:

https://github.com/zenhack/unisonbase

under the namespace `.zenhack.builtins.tests`