### PR TITLE
Fixes #739: Add optional semi to record field separators in FileParser

### DIFF
--- a/parser-typechecker/src/Unison/FileParser.hs
+++ b/parser-typechecker/src/Unison/FileParser.hs
@@ -236,7 +236,7 @@ dataDeclaration mod = do
       dataConstructor = go <$> prefixVar <*> many TypeParser.valueTypeLeaf
       record = do
         _ <- openBlockWith "{"
-        fields <- sepBy1 (reserved ",") $
+        fields <- sepBy1 (reserved "," <* optional semi) $
           liftA2 (,) (prefixVar <* reserved ":") TypeParser.valueType
         _ <- closeBlock
         pure ([go name (snd <$> fields)], [(name, fields)])

--- a/unison-src/tests/fix739.u
+++ b/unison-src/tests/fix739.u
@@ -1,0 +1,4 @@
+type MonoidRec a = {
+  combine : a -> a -> a,
+  empty   : a
+}


### PR DESCRIPTION
Fixes #739 as suggested by @pchiusano.