### PR TITLE
Fix ABT.freshInBoth and ABT.subst'

### DIFF
--- a/parser-typechecker/src/Unison/ABT.hs
+++ b/parser-typechecker/src/Unison/ABT.hs
@@ -262,7 +262,7 @@ changeVars m t = case out t of
 
 -- | Produce a variable which is free in both terms
 freshInBoth :: Var v => Term f v a -> Term f v a -> v -> v
-freshInBoth t1 t2 = fresh t2 . fresh t1
+freshInBoth t1 t2 = freshIn $ Set.union (freeVars t1) (freeVars t2)
 
 fresh :: Var v => Term f v a -> v -> v
 fresh t = freshIn (freeVars t)

--- a/parser-typechecker/src/Unison/ABT.hs
+++ b/parser-typechecker/src/Unison/ABT.hs
@@ -309,7 +309,7 @@ subst' replace v r t2@(Term fvs ann body)
     Cycle body -> cycle' ann (subst' replace v r body)
     Abs x _ | x == v -> t2 -- x shadows v; ignore subtree
     Abs x e -> abs' ann x' e'
-      where x' = fresh t2 (freshIn r x)
+      where x' = freshIn (fvs `Set.union` r) x
             -- rename x to something that cannot be captured by `r`
             e' = if x /= x' then subst' replace v r (rename x x' e)
                  else subst' replace v r e

--- a/parser-typechecker/tests/Suite.hs
+++ b/parser-typechecker/tests/Suite.hs
@@ -5,6 +5,7 @@ module Main where
 import           EasyTest
 import           System.Environment (getArgs)
 import           System.IO
+import qualified Unison.Test.ABT as ABT
 import qualified Unison.Test.Codebase.Causal as Causal
 import qualified Unison.Test.Codebase.Path as Path
 import qualified Unison.Test.ColorText as ColorText
@@ -40,6 +41,7 @@ test = tests
   , Causal.test
   , Referent.test
   , FileCodebase.test
+  , ABT.test
  ]
 
 main :: IO ()

--- a/parser-typechecker/tests/Unison/Test/ABT.hs
+++ b/parser-typechecker/tests/Unison/Test/ABT.hs
@@ -1,0 +1,24 @@
+{-# Language OverloadedStrings #-}
+
+module Unison.Test.ABT where
+
+import Data.Set as Set
+import EasyTest
+import Unison.ABT as ABT
+import Unison.Symbol (Symbol(..))
+import Unison.Var as Var
+
+test :: Test ()
+test = scope "abt" $ tests [
+  scope "freshInBoth" $
+    let
+      symbol i n = Symbol i (Var.User n)
+      var i n = ABT.var $ symbol i n
+      t1 = var 1 "a"
+      t2 = var 0 "a"
+      fresh = ABT.freshInBoth t1 t2 $ symbol 0 "a"
+    in tests
+      [ scope "first"  $ expect (not $ Set.member fresh (ABT.freeVars t1))
+      , scope "second" $ expect (not $ Set.member fresh (ABT.freeVars t2))
+      ]
+  ]

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -271,6 +271,7 @@ executable tests
   ghc-options:    -W -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -threaded -rtsopts -with-rtsopts=-N -v0
   hs-source-dirs: tests
   other-modules:
+    Unison.Test.ABT
     Unison.Test.Codebase.Causal
     Unison.Test.Codebase.FileCodebase
     Unison.Test.Codebase.Path


### PR DESCRIPTION
The problem was that in general, it is not guaranteed that after

```
v' = freshIn vs2 . freshIn vs1 $ v
```

`v'` is not a member of `vs1`. Therefore, freshening cannot be done gradually, but has to be done at once.

A test case of `freshInBoth` that would previously fail is included.