### PR TITLE
shallow-ls: can merge if desired in its current state; proposed remaining work is listed below

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -740,12 +740,12 @@ loop = do
               , (seg, _) <- Map.toList (Branch._edits b) ]
         in respond $ ListOfPatches patches
 
-      FindShallow -> do
+      FindShallow pathArg -> do
         prettyPrintNames0 <- basicPrettyPrintNames0
         ppe <- prettyPrintEnv $ Names prettyPrintNames0 mempty
         hashLen <- eval CodebaseHashLength
+        b0 <- Branch.head <$> getAt (Path.toAbsolutePath currentPath' pathArg)
         let
-          b0 = currentBranch0
           hqTerm b0 ns r =
             let refs = Star3.lookupD1 ns . _terms $ b0
             in case length refs of
@@ -765,14 +765,14 @@ loop = do
           \(r, ns) -> do
             ot <- loadReferentType r
             pure $ ShallowTermEntry r (hqTerm b0 ns r) ot
-        let 
-          typeEntries = 
+        let
+          typeEntries =
             [ ShallowTypeEntry r (hqType b0 ns r)
             | (r, ns) <- R.toList . Star3.d1 $ _types b0 ]
-          branchEntries = 
+          branchEntries =
             [ ShallowBranchEntry ns (defnCount b)
             | (ns, b) <- Map.toList $ _children b0 ]
-          patchEntries = 
+          patchEntries =
             [ ShallowPatchEntry ns
             | (ns, (_h, mp)) <- Map.toList $ _edits b0 ]
         let

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -45,7 +45,7 @@ import           Data.Configurator              ()
 import qualified Data.Graph as Graph
 import qualified Data.List                      as List
 import           Data.List                      ( partition, sortOn )
-import           Data.List.Extra                (nubOrd, intercalate)
+import           Data.List.Extra                (nubOrd, intercalate, sort)
 import           Data.Maybe                     ( fromJust
                                                 )
 import qualified Data.Map                      as Map
@@ -53,7 +53,7 @@ import qualified Data.Text                     as Text
 import qualified Data.Set                      as Set
 import           Data.Sequence                  ( Seq(..) )
 import qualified Unison.ABT                    as ABT
-import           Unison.Codebase.Branch         ( Branch
+import           Unison.Codebase.Branch         ( Branch(..)
                                                 , Branch0(..)
                                                 )
 import qualified Unison.Codebase.Branch        as Branch
@@ -739,6 +739,50 @@ loop = do
               | (p, b) <- Branch.toList0 currentBranch0
               , (seg, _) <- Map.toList (Branch._edits b) ]
         in respond $ ListOfPatches patches
+
+      FindShallow -> do
+        prettyPrintNames0 <- basicPrettyPrintNames0
+        ppe <- prettyPrintEnv $ Names prettyPrintNames0 mempty
+        hashLen <- eval CodebaseHashLength
+        let
+          b0 = currentBranch0
+          hqTerm b0 ns r =
+            let refs = Star3.lookupD1 ns . _terms $ b0
+            in case length refs of
+              1 -> HQ'.fromName ns
+              _ -> HQ'.take hashLen $ HQ'.fromNamedReferent ns r
+          hqType b0 ns r =
+            let refs = Star3.lookupD1 ns . _types $ b0
+            in case length refs of
+              1 -> HQ'.fromName ns
+              _ -> HQ'.take hashLen $ HQ'.fromNamedReference ns r
+          defnCount b =
+            (length . R.ran . Star3.d1 . deepTerms $ Branch.head b) +
+            (length . R.ran . Star3.d1 . deepTypes $ Branch.head b)
+          patchCount b = (length . deepEdits $ Branch.head b)
+
+        termEntries <- for (R.toList . Star3.d1 $ _terms b0) $
+          \(r, ns) -> do
+            ot <- loadReferentType r
+            pure $ ShallowTermEntry r (hqTerm b0 ns r) ot
+        let 
+          typeEntries = 
+            [ ShallowTypeEntry r (hqType b0 ns r)
+            | (r, ns) <- R.toList . Star3.d1 $ _types b0 ]
+          branchEntries = 
+            [ ShallowBranchEntry ns (defnCount b)
+            | (ns, b) <- Map.toList $ _children b0 ]
+          patchEntries = 
+            [ ShallowPatchEntry ns
+            | (ns, (_h, mp)) <- Map.toList $ _edits b0 ]
+        let
+          entries :: [ShallowListEntry v Ann]
+          entries = sort $ termEntries ++ typeEntries ++ branchEntries
+        respond $ ListShallow ppe entries
+        where
+
+
+
 
       SearchByNameI isVerbose _showAll ws -> do
         prettyPrintNames0 <- basicPrettyPrintNames0

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -103,6 +103,7 @@ data Input
   | LinksI Path.HQSplit' (Maybe String)
   -- other
   | SearchByNameI Bool Bool [String] -- SearchByName isVerbose showAll query
+  | FindShallow
   | FindPatchI
   | ShowDefinitionI OutputLocation [String]
   | ShowDefinitionByPrefixI OutputLocation [String]

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -103,7 +103,7 @@ data Input
   | LinksI Path.HQSplit' (Maybe String)
   -- other
   | SearchByNameI Bool Bool [String] -- SearchByName isVerbose showAll query
-  | FindShallow
+  | FindShallow Path'
   | FindPatchI
   | ShowDefinitionI OutputLocation [String]
   | ShowDefinitionByPrefixI OutputLocation [String]

--- a/parser-typechecker/src/Unison/Codebase/NameSegment.hs
+++ b/parser-typechecker/src/Unison/Codebase/NameSegment.hs
@@ -26,6 +26,9 @@ isPrefixOf n1 n2 = Text.isPrefixOf (toText n1) (toText n2)
 toString :: NameSegment -> String
 toString = Text.unpack . toText
 
+toName :: NameSegment -> Name.Name
+toName = Name.Name . toText
+
 segments :: Name.Name -> [NameSegment]
 segments name = NameSegment <$> Text.splitOn "." (Name.toText name)
 

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -205,7 +205,7 @@ viewByPrefix
 find :: InputPattern
 find = InputPattern
   "find"
-  ["list", "ls"]
+  []
   [(ZeroPlus, fuzzyDefinitionQueryArg)]
   (P.wrapColumn2
     [ ("`find`", "lists all definitions in the current namespace.")
@@ -220,6 +220,26 @@ find = InputPattern
     ]
   )
   (pure . Input.SearchByNameI False False)
+
+findShallow :: InputPattern
+findShallow = InputPattern
+  "ls"
+  ["find.shallow"]
+  []
+  mempty
+--  (P.wrapColumn2
+--    [ ("`find`", "lists all definitions in the current namespace.")
+--    , ( "`find foo`"
+--      , "lists all definitions with a name similar to 'foo' in the current "
+--        <> "namespace."
+--      )
+--    , ( "`find foo bar`"
+--      , "lists all definitions with a name similar to 'foo' or 'bar' in the "
+--        <> "current namespace."
+--      )
+--    ]
+--  )
+  (pure . const Input.FindShallow)
 
 findVerbose :: InputPattern
 findVerbose = InputPattern
@@ -799,6 +819,7 @@ validInputs =
   , renamePatch
   , copyPatch
   , find
+  , findShallow
   , findVerbose
   , view
   , findPatch

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -225,21 +225,24 @@ findShallow :: InputPattern
 findShallow = InputPattern
   "ls"
   ["find.shallow"]
-  []
-  mempty
---  (P.wrapColumn2
---    [ ("`find`", "lists all definitions in the current namespace.")
---    , ( "`find foo`"
---      , "lists all definitions with a name similar to 'foo' in the current "
---        <> "namespace."
---      )
---    , ( "`find foo bar`"
---      , "lists all definitions with a name similar to 'foo' or 'bar' in the "
---        <> "current namespace."
---      )
---    ]
---  )
-  (pure . const Input.FindShallow)
+  [(Optional, pathArg)]
+  (P.wrapColumn2
+    [ ("`ls`", "lists all definitions in the current namespace.")
+    , ( "`ls foo`"
+      , "lists all definitions in the 'foo' namespace."
+      )
+    , ( "`ls .foo`"
+      , "lists all definitions in the '.foo' namespace."
+      )
+    ]
+  )
+  (\case
+    [] -> pure $ Input.FindShallow Path.relativeEmpty'
+    [path] -> first fromString $ do
+      p <- Path.parsePath' path
+      pure $ Input.FindShallow p
+    _ -> Left (I.help findShallow)
+  )
 
 findVerbose :: InputPattern
 findVerbose = InputPattern

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -284,9 +284,16 @@ notifyUser dir o = case o of
   --
   --   Term (with hash #asldfkjsdlfkjsdf): .util.frobnicate, foo, blarg.mcgee
   --   Types (with hash #hsdflkjsdfsldkfj): Optional, Maybe, foo
-  ListShallow ppe entries -> undefined
+  ListShallow ppe entries -> pure $
     -- todo: make a version of prettyNumberedResult to support 3-columns
+    if null entries then P.lit "nothing to show"
+    else numberedEntries entries
     where
+    numberedEntries :: [ShallowListEntry v a] -> P.Pretty P.ColorText
+    numberedEntries entries =
+      (P.column3 . fmap f) ([(1::Integer)..] `zip` fmap formatEntry entries)
+      where
+      f (i, (p1, p2)) = (P.hiBlack . fromString $ show i <> ".", p1, p2)
     formatEntry :: ShallowListEntry v a -> (P.Pretty P.ColorText, P.Pretty P.ColorText)
     formatEntry = \case
       ShallowTermEntry r hq ot ->

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -311,8 +311,8 @@ notifyUser dir o = case o of
         ((P.syntaxToColor . prettyName . NameSegment.toName) ns
         ,P.lit "(patch)")
     isBuiltin = \case
-      Reference.Builtin{} -> P.lit "(builtin)"
-      Reference.DerivedId{} -> mempty
+      Reference.Builtin{} -> P.lit "(builtin type)"
+      Reference.DerivedId{} -> P.lit "(type)"
 
   SlurpOutput input ppe s -> let
     isPast = case input of Input.AddI{} -> True

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -61,6 +61,7 @@ import qualified Unison.HashQualified          as HQ
 import qualified Unison.HashQualified'         as HQ'
 import           Unison.Name                   (Name)
 import qualified Unison.Name                   as Name
+import qualified Unison.Codebase.NameSegment   as NameSegment
 import           Unison.NamePrinter            (prettyHashQualified,
                                                 prettyName, prettyShortHash,
                                                 styleHashQualified,
@@ -283,7 +284,28 @@ notifyUser dir o = case o of
   --
   --   Term (with hash #asldfkjsdlfkjsdf): .util.frobnicate, foo, blarg.mcgee
   --   Types (with hash #hsdflkjsdfsldkfj): Optional, Maybe, foo
-
+  ListShallow ppe entries -> undefined
+    -- todo: make a version of prettyNumberedResult to support 3-columns
+    where
+    formatEntry :: ShallowListEntry v a -> (P.Pretty P.ColorText, P.Pretty P.ColorText)
+    formatEntry = \case
+      ShallowTermEntry r hq ot ->
+        (P.syntaxToColor . prettyHashQualified' . fmap NameSegment.toName $ hq
+        , P.lit "(" <> maybe "type missing" (TypePrinter.pretty ppe) ot <> P.lit ")" )
+      ShallowTypeEntry r hq ->
+        (P.syntaxToColor . prettyHashQualified' . fmap NameSegment.toName $ hq
+        ,isBuiltin r)
+      ShallowBranchEntry ns count ->
+        ((P.syntaxToColor . prettyName . NameSegment.toName) ns <> "/"
+        ,case count of
+          1 -> P.lit ("(1 definition)")
+          n -> P.lit "(" <> P.shown count <> P.lit " definitions)")
+      ShallowPatchEntry ns ->
+        ((P.syntaxToColor . prettyName . NameSegment.toName) ns
+        ,P.lit "(patch)")
+    isBuiltin = \case
+      Reference.Builtin{} -> P.lit "(builtin)"
+      Reference.DerivedId{} -> mempty
 
   SlurpOutput input ppe s -> let
     isPast = case input of Input.AddI{} -> True

--- a/parser-typechecker/src/Unison/HashQualified'.hs
+++ b/parser-typechecker/src/Unison/HashQualified'.hs
@@ -18,7 +18,7 @@ import qualified Unison.ShortHash              as SH
 import qualified Unison.HashQualified          as HQ
 
 data HashQualified' n = NameOnly n | HashQualified n ShortHash
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Functor)
 
 type HashQualified = HashQualified' Name
 
@@ -40,7 +40,7 @@ take i = \case
 toNameOnly :: HashQualified' n -> HashQualified' n
 toNameOnly = fromName . toName
 
-toHash :: HashQualified -> Maybe ShortHash
+toHash :: HashQualified' n -> Maybe ShortHash
 toHash = \case
   NameOnly _         -> Nothing
   HashQualified _ sh -> Just sh


### PR DESCRIPTION
- [x] accept an optional path input
- [ ] display type args or kind next to type name
- [ ] add numbered search results to LoopState appropriately (or get rid of numbers?)

what else?

```
.> ls .base

  1.  ()/        (0 definitions)
  2.  .          ((b ->{𝕖} c) -> (a ->{𝕖} b) -> a ->{𝕖} c)
  3.  <|         ((a ->{𝕖} b) -> a ->{𝕖} b)
  4.  Boolean    (builtin type)
  5.  Boolean/   (1 definition)
  6.  Bytes      (builtin type)
  7.  Bytes/     (9 definitions)
  8.  Char       (builtin type)
  9.  Char/      (2 definitions)
  10. Debug/     (1 definition)
  11. Either     (type)
  12. Either/    (2 definitions)
  13. Float      (builtin type)
  14. Float/     (36 definitions)
  15. Heap       (type)
  16. Heap/      (12 definitions)
  17. Int        (builtin type)
  18. Int/       (21 definitions)
  19. IsTest     (type)
  20. IsTest/    (1 definition)
  21. List       (builtin type)
  22. List/      (30 definitions)
```