### PR TITLE
Unison transcript runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Unison
 .unison*/
 .unisonHistory
+test-output
 
 # Haskell
 dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,4 @@ install:
 
 script:
 - stack --no-terminal exec tests
+- stack --no-terminal exec transcripts

--- a/development.markdown
+++ b/development.markdown
@@ -2,16 +2,17 @@ These are commands that will likely be useful during development.
 
 __General:__ `./scripts/test.sh` compiles and builds the Haskell code and runs all tests. Recommended that you run this before pushing any code to a branch that others might be working on.
 
-_Disclaimer_ If you have trouble getting started, please get in touch via [gitter](https://gitter.im/unisonweb/unison) so we can help.  If you have any fixes to the process, please send us a PR!
+_Disclaimer_ If you have trouble getting started, please get in touch via [Slack](https://unisonweb.org/community) so we can help.  If you have any fixes to the process, please send us a PR!
 
 ## Running Unison
 
-To get cracking with Unison,
+To get cracking with Unison:
+
 * [Install `stack`](https://docs.haskellstack.org/en/stable/README/#how-to-install).
-* Build the project with `stack build`.
+* Build the project with `stack build`. This builds all executables.
 * After building, `stack exec unison` will fire up the codebase editor, create a codebase in the current directory, and watch for `.u` file changes.  If you want to run it in a different directory, just add `unison` to your `PATH`, after finding it with `find .stack-work -name unison -type f`.  (For me, this finds two, they both work, but have different contents.  ¯\\\_(ツ)\_/¯ )
-* Once a file is typechecked, you can do `add` to add it to the codebase,
-* and then `view` to view a definition, or `help` for more ideas.
+* `stack exec tests` runs the tests
+* `stack exec transcripts` runs all the integration tests, found in `unison-src/transcripts`. You can add more tests to this directory.
 
 ### What if you want a profiled build?
 

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -2071,7 +2071,7 @@ addRunMain args uf = let
       a = ABT.annotation tm 
       in
       if Typechecker.isSubtype ty (nullaryMain a) then Just $ let 
-        runMain = Term.app a (Term.var a v) (Term.ref a DD.unitRef) 
+        runMain = DD.forceTerm a a (Term.var a v)
         in UF.typecheckedUnisonFile 
              (UF.dataDeclarations' uf)
              (UF.effectDeclarations' uf)

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -727,7 +727,8 @@ loop = do
         do
           eval . Notify
             $ DisplayDefinitions loc ppe loadedDisplayTypes loadedDisplayTerms
-          eval . Notify . SearchTermsNotFound $ fmap fst misses
+          when (not $ null misses) $
+            eval . Notify . SearchTermsNotFound $ fmap fst misses
           -- We set latestFile to be programmatically generated, if we
           -- are viewing these definitions to a file - this will skip the
           -- next update for that file (which will happen immediately)

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1039,16 +1039,14 @@ loop = do
         updated <- propagatePatch patch (resolveToAbsolute scopePath)
         unless updated (respond $ NothingToPatch patchPath scopePath)
 
-      ExecuteI args -> case uf of
-        Nothing -> respond $ NoUnisonFile input
-        Just uf -> case addRunMain args uf of
-          Nothing -> do
-            names0 <- basicPrettyPrintNames0
-            ppe <- prettyPrintEnv (Names3.Names names0 mempty)
-            respond $ NoMainFunction input ppe (mainTypes External)
-          Just unisonFile -> do
-            ppe <- executePPE unisonFile
-            eval $ Execute ppe unisonFile
+      ExecuteI main -> addRunMain main uf >>= \case
+        Nothing -> do
+          names0 <- basicPrettyPrintNames0
+          ppe <- prettyPrintEnv (Names3.Names names0 mempty)
+          respond $ NoMainFunction input main ppe (mainTypes External)
+        Just unisonFile -> do
+          ppe <- executePPE unisonFile
+          eval $ Execute ppe unisonFile
 
       -- UpdateBuiltinsI -> do
       --   stepAt updateBuiltins
@@ -2102,26 +2100,44 @@ ioUnit a = Type.effect a [Type.ref a ioReference] (Type.ref a DD.unitRef)
 nullaryMain :: Ord v => a -> Type v a
 nullaryMain a = Type.arrow a (Type.ref a DD.unitRef) (ioUnit a)
 
--- [Text] ->{IO} ()
-argsMain :: Ord v => a -> Type v a
-argsMain a = Type.arrow a (Type.app a (Type.vector a) (Type.text a)) (ioUnit a)
-
 mainTypes :: Ord v => a -> [Type v a]
-mainTypes a = [argsMain a, nullaryMain a]
+mainTypes a = [nullaryMain a]
 
--- Given a typechecked file with a binding `main : '{IO} ()`
--- or `main : [Text] ->{IO} ()`, adds an extra binding which
+-- Given a typechecked file with a main function called `mainName`
+-- of the type `'{IO} ()`, adds an extra binding which
 -- forces the `main` function.
+--
+-- If that function doesn't exist in the typechecked file, the
+-- codebase is consulted.
 addRunMain
-  :: Var v
-  => [String]
-  -> TypecheckedUnisonFile v a
-  -> Maybe (TypecheckedUnisonFile v a)
-addRunMain args uf = let
-  components = join $ UF.topLevelComponents uf
-  mainComponent = filter ((\v -> Var.name v == "main") . view _1) components 
-  in case mainComponent of 
-    [(v, tm, ty)] -> let 
+  :: (Monad m, Var v)
+  => String
+  -> Maybe (TypecheckedUnisonFile v Ann)
+  -> Action' m v (Maybe (TypecheckedUnisonFile v Ann))
+addRunMain mainName Nothing = do 
+  parseNames0 <- basicParseNames0
+  case HQ.fromString mainName of
+    Nothing -> pure Nothing
+    Just hq -> do
+      -- note: not allowing historical search
+      let refs = Names3.lookupHQTerm hq (Names3.Names parseNames0 mempty)
+      let a = External 
+      case toList refs of
+        [] -> pure Nothing
+        [Referent.Ref ref] -> do
+          typ <- eval $ LoadTypeOfTerm ref 
+          case typ of
+            Just typ | Typechecker.isSubtype typ (nullaryMain a) -> do
+              let runMain = DD.forceTerm a a (Term.ref a ref)
+              let v = Var.named (HQ.toText hq)
+              pure . Just $ UF.typecheckedUnisonFile mempty mempty [[(v, runMain, typ)]] mempty
+            _ -> pure Nothing
+        _ -> pure Nothing
+addRunMain mainName (Just uf) = do
+  let components = join $ UF.topLevelComponents uf
+  let mainComponent = filter ((\v -> Var.nameStr v == mainName) . view _1) components 
+  case mainComponent of 
+    [(v, tm, ty)] -> pure $ let 
       v2 = Var.freshIn (Set.fromList [v]) v 
       a = ABT.annotation tm 
       in
@@ -2132,16 +2148,8 @@ addRunMain args uf = let
              (UF.effectDeclarations' uf)
              (UF.topLevelComponents' uf <> [[(v2, runMain, nullaryMain a)]])
              (UF.watchComponents uf) 
-      else if Typechecker.isSubtype ty (argsMain a) then Just $ let
-        runMain = Term.app a (Term.var a v) (Term.seq a (Term.text a . Text.pack <$> args)) 
-        in UF.typecheckedUnisonFile 
-             (UF.dataDeclarations' uf)
-             (UF.effectDeclarations' uf)
-             (UF.topLevelComponents' uf <> [[(v2, runMain, argsMain a)]])
-             (UF.watchComponents uf) 
-      else
-        Nothing 
-    _ -> Nothing
+      else Nothing 
+    _ -> addRunMain mainName Nothing 
 
 executePPE
   :: (Var v, Monad m)

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -725,8 +725,8 @@ loop = do
               FileLocation path  -> Just path
               LatestFileLocation -> fmap fst latestFile' <|> Just "scratch.u"
         do
-          eval . Notify
-            $ DisplayDefinitions loc ppe loadedDisplayTypes loadedDisplayTerms
+          when (not $ null loadedDisplayTypes && null loadedDisplayTerms) $ 
+            eval . Notify $ DisplayDefinitions loc ppe loadedDisplayTypes loadedDisplayTerms
           when (not $ null misses) $
             eval . Notify . SearchTermsNotFound $ fmap fst misses
           -- We set latestFile to be programmatically generated, if we

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -239,7 +239,6 @@ loop = do
         then modifying latestFile (fmap (const False) <$>)
         else do
           let lexed = L.lexer (Text.unpack sourceName) (Text.unpack text)
-          eval (Notify $ FileChangeEvent sourceName text)
           withFile [] sourceName (text, lexed) $ \unisonFile -> do
             sr <- toSlurpResult unisonFile <$> slurpResultNames0
             hnames <- makeShadowedPrintNamesFromLabeled

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -92,7 +92,7 @@ data Input
   -- Second `Maybe Int` is cap on diff elements shown, if any
   | HistoryI (Maybe Int) (Maybe Int) BranchId 
   -- execute an IO object with arguments
-  | ExecuteI String
+  | ExecuteI [String]
   | TestI Bool Bool -- TestI showSuccesses showFailures
   -- metadata
   -- link from to

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -91,8 +91,8 @@ data Input
   -- First `Maybe Int` is cap on number of results, if any
   -- Second `Maybe Int` is cap on diff elements shown, if any
   | HistoryI (Maybe Int) (Maybe Int) BranchId 
-  -- execute an IO object with arguments
-  | ExecuteI [String]
+  -- execute an IO thunk
+  | ExecuteI String
   | TestI Bool Bool -- TestI showSuccesses showFailures
   -- metadata
   -- link from to

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -110,7 +110,6 @@ data Output v
               [(v, Term v ())]
               (Map v (Ann, UF.WatchKind, Term v (), Runtime.IsCacheHit))
   | Typechecked SourceName PPE.PrettyPrintEnv (SlurpResult v) (UF.TypecheckedUnisonFile v Ann)
-  | FileChangeEvent SourceName Text
   -- "display" definitions, possibly to a FilePath on disk (e.g. editing)
   | DisplayDefinitions (Maybe FilePath)
                        PPE.PrettyPrintEnv
@@ -206,7 +205,6 @@ isFailure o = case o of
   EvaluationFailure{} -> True
   Evaluated{} -> False
   Typechecked{} -> False
-  FileChangeEvent{} -> False
   DisplayDefinitions{} -> False
   TodoOutput _ todo -> TO.todoScore todo /= 0
   TestIncrementalOutputStart{} -> False

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -205,7 +205,7 @@ isFailure o = case o of
   EvaluationFailure{} -> True
   Evaluated{} -> False
   Typechecked{} -> False
-  DisplayDefinitions{} -> False
+  DisplayDefinitions _ _ m1 m2 -> null m1 && null m2
   TodoOutput _ todo -> TO.todoScore todo /= 0
   TestIncrementalOutputStart{} -> False
   TestIncrementalOutputEnd{} -> False

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -188,7 +188,7 @@ isFailure o = case o of
   TypeNotFound{} -> True
   TermNotFound{} -> True
   TermNotFound'{} -> True
-  SearchTermsNotFound{} -> True
+  SearchTermsNotFound ts -> not (null ts)
   DeleteBranchConfirmation{} -> False
   CantDelete{} -> True
   DeleteEverythingConfirmation -> False

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -62,7 +62,9 @@ data Output v
   -- to vary based on the command the user submitted.
   = Success Input
   -- User did `add` or `update` before typechecking a file?
-  | NoUnisonFile
+  | NoUnisonFile Input
+  -- No main function, the [Type v Ann] are the allowed types for `main`
+  | NoMainFunction Input PPE.PrettyPrintEnv [Type v Ann]
   | CreatedNewBranch Path.Absolute
   | BranchAlreadyExists Input Path'
   | PatchAlreadyExists Input Path.Split'
@@ -170,7 +172,8 @@ type SourceFileContents = Text
 isFailure :: Ord v => Output v -> Bool
 isFailure o = case o of
   Success{} -> False
-  NoUnisonFile -> True
+  NoUnisonFile{} -> True
+  NoMainFunction{} -> True
   CreatedNewBranch{} -> False
   BranchAlreadyExists{} -> True
   PatchAlreadyExists{} -> True

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -67,8 +67,8 @@ data Output v
   = Success Input
   -- User did `add` or `update` before typechecking a file?
   | NoUnisonFile Input
-  -- No main function, the [Type v Ann] are the allowed types for `main`
-  | NoMainFunction Input PPE.PrettyPrintEnv [Type v Ann]
+  -- No main function, the [Type v Ann] are the allowed types
+  | NoMainFunction Input String PPE.PrettyPrintEnv [Type v Ann]
   | CreatedNewBranch Path.Absolute
   | BranchAlreadyExists Input Path'
   | PatchAlreadyExists Input Path.Split'

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -38,7 +38,6 @@ import           UnliftIO.Directory             ( createDirectoryIfMissing
                                                 , createDirectory
                                                 , removeFile
                                                 , doesPathExist
-                                                , getCurrentDirectory
                                                 -- , removeDirectoryRecursive
                                                 )
 import           System.FilePath                ( FilePath
@@ -101,17 +100,17 @@ data Err
 codebasePath :: FilePath
 codebasePath = ".unison" </> "v1"
 
-ensureCodebaseInitialized :: IO (FilePath, Codebase IO Symbol Ann)
-ensureCodebaseInitialized = do
-  dir <- getCurrentDirectory
+ensureCodebaseInitialized :: FilePath -> IO (FilePath, Codebase IO Symbol Ann)
+ensureCodebaseInitialized dir = do
+  let path = dir </> codebasePath
   let theCodebase = codebase1 V1.formatSymbol formatAnn codebasePath
-  unlessM (exists codebasePath) $ do
+  unlessM (exists path) $ do
     PT.putPrettyLn'
       .  P.callout "☝️"
       .  P.wrap
       $  "No codebase exists here so I'm initializing one in: "
-      <> P.string codebasePath
-    initialize codebasePath
+      <> P.string path
+    initialize path
     Codebase.initializeCodebase theCodebase
   pure (dir, theCodebase)
   where formatAnn = S.Format (pure External) (\_ -> pure ())

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -105,10 +105,10 @@ ensureCodebaseInitialized dir = do
   let theCodebase = codebase1 V1.formatSymbol formatAnn path
   unlessM (exists path) $ do
     PT.putPrettyLn'
-      .  P.callout "☝️"
+      .  P.warnCallout
       .  P.wrap
       $  "No codebase exists here so I'm initializing one in: "
-      <> P.string path
+      <> P.string dir
     initialize path
     Codebase.initializeCodebase theCodebase
   pure theCodebase

--- a/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
@@ -151,6 +151,7 @@ run dir stanzas codebase = do
                       awaitInput
                     Right input -> pure $ Right input
           Nothing -> do
+            writeIORef hidden False
             stanza <- atomically (Q.tryDequeue inputQueue)
             case stanza of
               Nothing -> pure $ Right QuitI
@@ -164,11 +165,10 @@ run dir stanzas codebase = do
                 Unison hide filename txt -> do
                   output $ show s
                   writeIORef hidden hide
-                  output $ "```ucm"
+                  output "```ucm"
                   atomically . Q.enqueue cmdQueue $ Nothing
                   pure $ Left (UnisonFileChanged (fromMaybe "scratch.u" filename) txt)
                 Ucm hide cmds -> do
-                  -- output $ show s
                   writeIORef hidden hide
                   output $ "```ucm"
                   traverse_ (atomically . Q.enqueue cmdQueue . Just) cmds

--- a/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
@@ -169,7 +169,7 @@ run dir stanzas codebase = do
                   output $ show s
                   writeIORef hidden hide
                   writeIORef allowErrors errOk
-                  output "```ucm"
+                  output "```ucm\n"
                   atomically . Q.enqueue cmdQueue $ Nothing
                   pure $ Left (UnisonFileChanged (fromMaybe "scratch.u" filename) txt)
                 Ucm hide errOk cmds -> do
@@ -188,7 +188,10 @@ run dir stanzas codebase = do
         output rendered
         when (not errOk && Output.isFailure o) $ do
           output "\n```\n\n"
-          die "Transcript failed due to message above."
+          die "\128721  Transcript failed due to message above."
+        when (errOk && not (Output.isFailure o)) $ do
+          output "\n```\n\n"
+          die "\128721  Transcript failed due to an unexpected success above."
         pure ()
 
       loop state = do

--- a/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
@@ -188,10 +188,18 @@ run dir stanzas codebase = do
         output rendered
         when (not errOk && Output.isFailure o) $ do
           output "\n```\n\n"
-          die "\128721  Transcript failed due to message above."
+          die $ unlines [
+            "\128721", "",
+            "Transcript failed due to the message above.",
+            "Codebase as of the point of failure is in:",
+            "  " <> dir ]
         when (errOk && not (Output.isFailure o)) $ do
           output "\n```\n\n"
-          die "\128721  Transcript failed due to an unexpected success above."
+          die $ unlines [
+            "\128721", "",
+            "Transcript failed due to an unexpected success above.",
+            "Codebase as of the point of failure is in:",
+            "  " <> dir ]
         pure ()
 
       loop state = do

--- a/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
@@ -233,7 +233,7 @@ ucmCommand = do
 fenced :: P Stanza
 fenced = do
   fence
-  fenceType <- lineToken (word "ucm" <|> word "unison" <|> untilSpace1)
+  fenceType <- lineToken (word "ucm" <|> word "unison" <|> lineUntilSpace)
   stanza <-
     if fenceType == "ucm" then do
       hideOutput <- hideOutput
@@ -309,6 +309,9 @@ expectingError = isJust <$> optional (word ":error")
 
 untilSpace1 :: P Text
 untilSpace1 = P.takeWhile1P Nothing (not . Char.isSpace)
+
+lineUntilSpace :: P Text 
+lineUntilSpace = P.takeWhileP Nothing (\ch -> ch `elem` (" \t" :: String))
 
 spaces :: P ()
 spaces = void $ P.takeWhileP (Just "spaces") Char.isSpace

--- a/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
@@ -191,14 +191,14 @@ run dir stanzas codebase = do
           die $ unlines [
             "\128721", "",
             "Transcript failed due to the message above.",
-            "Codebase as of the point of failure is in:",
+            "Codebase as of the point of failure is in:", "",
             "  " <> dir ]
         when (errOk && not (Output.isFailure o)) $ do
           output "\n```\n\n"
           die $ unlines [
             "\128721", "",
             "Transcript failed due to an unexpected success above.",
-            "Codebase as of the point of failure is in:",
+            "Codebase as of the point of failure is in:", "",
             "  " <> dir ]
         pure ()
 

--- a/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
@@ -187,7 +187,7 @@ run dir stanzas codebase = do
         let rendered = P.toPlain 65 msg -- (P.indentN 2 msg)
         output rendered
         when (not errOk && Output.isFailure o) $ do
-          output "```\n\n"
+          output "\n```\n\n"
           die "Transcript failed due to message above."
         pure ()
 

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -781,6 +781,21 @@ debugBranchHistory = InputPattern "debug.history" []
   "Dump codebase history, compatible with bit-booster.com/graph.html"
   (const $ Right Input.DebugBranchHistoryI)
 
+test :: InputPattern
+test = InputPattern "test" [] []
+    "`test` runs unit tests for the current branch."
+    (const $ pure $ Input.TestI True True)
+
+execute :: InputPattern
+execute = InputPattern "run" ["execute"] []
+  (P.wrapColumn2 [
+    ("`run`", "Runs `!main` or `main []` using the `main` function from the" <> 
+              "most recently typechecked file."),
+    ("`run arg1 arg2`", "Runs `main [arg1, arg2]` using the `main` function" <>
+                        "from the most recently typechecked file.")
+    ])
+  (\ws -> pure . Input.ExecuteI $ ws)
+
 validInputs :: [InputPattern]
 validInputs =
   [ help
@@ -817,14 +832,8 @@ validInputs =
   , link
   , unlink
   , links
-  , InputPattern "test" [] []
-    "`test` runs unit tests for the current branch."
-    (const $ pure $ Input.TestI True True)
-  , InputPattern "execute" [] []
-    "`execute foo` evaluates the Unison expression `foo` of type `()` with access to the `IO` ability."
-    (\ws -> if null ws
-               then Left $ warn "`execute` needs a Unison language expression."
-               else pure . Input.ExecuteI $ unwords ws)
+  , test
+  , execute
   , quit
   , updateBuiltins
   , mergeBuiltins

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -806,14 +806,14 @@ test = InputPattern "test" [] []
     (const $ pure $ Input.TestI True True)
 
 execute :: InputPattern
-execute = InputPattern "run" ["execute"] []
+execute = InputPattern "run" [] []
   (P.wrapColumn2 [
-    ("`run`", "Runs `!main` or `main []` using the `main` function from the" <> 
-              "most recently typechecked file."),
-    ("`run arg1 arg2`", "Runs `main [arg1, arg2]` using the `main` function" <>
-                        "from the most recently typechecked file.")
+    ("`run mymain`", "Runs `!mymain`, where `mymain` is searched for in the most recent" <>
+                     "typechecked file, or in the codebase.")
     ])
-  (\ws -> pure . Input.ExecuteI $ ws)
+  (\ws -> case ws of
+    [w] -> pure . Input.ExecuteI $ w
+    _ -> Left $ showPatternHelp execute)
 
 validInputs :: [InputPattern]
 validInputs =

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -358,24 +358,25 @@ notifyUser dir o = case o of
         if fileStatusMsg == mempty then
           P.okCallout $ fileName <> " changed."
         else if  SlurpResult.isAllDuplicates slurpResult then
-          (P.newline <>) . P.okCallout . P.wrap $ "I found and"
+          P.wrap $ "I found and"
              <> P.bold "typechecked" <> "the definitions in "
              <> P.group (fileName <> ".")
              <> "This file " <> P.bold "has been previously added" <> "to the codebase."
         else
-          (P.newline <>) . P.linesSpaced $ [
-            P.okCallout . P.wrap $ "I found and"
+          P.linesSpaced $ [
+            P.wrap $ "I found and"
              <> P.bold "typechecked" <> "these definitions in "
              <> P.group (fileName <> ".")
              <> "If you do an "
              <> IP.makeExample' IP.add
              <> " or "
-             <> IP.makeExample' IP.update
-             <> ", here's how your codebase would"
+             <> P.group (IP.makeExample' IP.update <> ",")
+             <> "here's how your codebase would"
              <> "change:"
             , P.indentN 2 $ SlurpResult.pretty False ppe slurpResult
             ]
           ,
+         " ",
          P.wrap $ "Now evaluating any watch expressions"
                <> "(lines starting with `>`)... "
                <> P.group (P.hiBlack "Ctrl+C cancels.")

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -354,7 +354,6 @@ notifyUser dir o = case o of
         ]
     -- TODO: Present conflicting TermEdits and TypeEdits
     -- if we ever allow users to edit hashes directly.
-  FileChangeEvent _sourceName _src -> pure mempty
   Typechecked sourceName ppe slurpResult uf -> do
     let fileStatusMsg = SlurpResult.pretty False ppe slurpResult
     if UF.nonEmpty uf then do

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -209,7 +209,12 @@ notifyUser dir o = case o of
   CantUndo reason -> case reason of
     CantUndoPastStart -> pure . P.warnCallout $ "Nothing more to undo."
     CantUndoPastMerge -> pure . P.warnCallout $ "Sorry, I can't undo a merge (not implemented yet)."
-  NoUnisonFile -> do
+  NoMainFunction _input ppe ts -> pure . P.callout "😶" $ P.lines [
+    P.wrap "If you'd like me to run this code, add a `main` function with one of these types:",
+    "",
+    P.indentN 2 $ P.lines [ "main : " <> TypePrinter.pretty ppe t | t <- ts ]
+    ]
+  NoUnisonFile _input -> do
     dir' <- canonicalizePath dir
     fileName <- renderFileName dir'
     pure . P.callout "😶" $ P.lines
@@ -349,7 +354,7 @@ notifyUser dir o = case o of
         ]
     -- TODO: Present conflicting TermEdits and TypeEdits
     -- if we ever allow users to edit hashes directly.
-  FileChangeEvent _sourceName _src -> pure "\n"
+  FileChangeEvent _sourceName _src -> pure mempty
   Typechecked sourceName ppe slurpResult uf -> do
     let fileStatusMsg = SlurpResult.pretty False ppe slurpResult
     if UF.nonEmpty uf then do

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -715,7 +715,7 @@ displayDefinitions :: Var v => Ord a1 =>
   -> Map Reference.Reference (DisplayThing (Unison.Term.AnnotatedTerm v a1))
   -> IO Pretty
 displayDefinitions outputLoc ppe types terms | Map.null types && Map.null terms =
-  pure mempty
+  pure $ P.callout "😶" "No results to display."
 displayDefinitions outputLoc ppe types terms =
   maybe displayOnly scratchAndDisplay outputLoc
   where

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -210,10 +210,11 @@ notifyUser dir o = case o of
   CantUndo reason -> case reason of
     CantUndoPastStart -> pure . P.warnCallout $ "Nothing more to undo."
     CantUndoPastMerge -> pure . P.warnCallout $ "Sorry, I can't undo a merge (not implemented yet)."
-  NoMainFunction _input ppe ts -> pure . P.callout "😶" $ P.lines [
-    P.wrap "If you'd like me to run this code, add a `main` function with one of these types:",
+  NoMainFunction _input main ppe ts -> pure . P.callout "😶" $ P.lines [
+    P.wrap $ "I looked for a function" <> P.backticked (P.string main) 
+          <> "in the most recently typechecked file and codebase but couldn't find one. It has to have the type:",
     "",
-    P.indentN 2 $ P.lines [ "main : " <> TypePrinter.pretty ppe t | t <- ts ]
+    P.indentN 2 $ P.lines [ P.string main <> " : " <> TypePrinter.pretty ppe t | t <- ts ]
     ]
   NoUnisonFile _input -> do
     dir' <- canonicalizePath dir

--- a/parser-typechecker/src/Unison/Prelude.hs
+++ b/parser-typechecker/src/Unison/Prelude.hs
@@ -1,9 +1,9 @@
 module Unison.Prelude
-  ( module X, readUtf8, writeUtf8
+  ( module X, readUtf8, safeReadUtf8, writeUtf8
   ) where
 
 import Control.Applicative as X
-import Control.Exception as X (Exception, SomeException)
+import Control.Exception as X (Exception, SomeException, IOException, try)
 import Control.Monad as X
 import Control.Monad.Extra as X (ifM, unlessM, whenM)
 import Control.Monad.IO.Class as X (MonadIO(liftIO))
@@ -34,6 +34,9 @@ import qualified Data.ByteString as BS
 -- Read an entire file strictly assuming UTF8
 readUtf8 :: FilePath -> IO Text
 readUtf8 p = decodeUtf8 <$> BS.readFile p
+
+safeReadUtf8 :: FilePath -> IO (Either IOException Text)
+safeReadUtf8 p = try (readUtf8 p)
 
 writeUtf8 :: FilePath -> Text -> IO ()
 writeUtf8 p txt = BS.writeFile p (encodeUtf8 txt) 

--- a/parser-typechecker/src/Unison/Prelude.hs
+++ b/parser-typechecker/src/Unison/Prelude.hs
@@ -1,5 +1,5 @@
 module Unison.Prelude
-  ( module X, readUtf8
+  ( module X, readUtf8, writeUtf8
   ) where
 
 import Control.Applicative as X
@@ -34,3 +34,6 @@ import qualified Data.ByteString as BS
 -- Read an entire file strictly assuming UTF8
 readUtf8 :: FilePath -> IO Text
 readUtf8 p = decodeUtf8 <$> BS.readFile p
+
+writeUtf8 :: FilePath -> Text -> IO ()
+writeUtf8 p txt = BS.writeFile p (encodeUtf8 txt) 

--- a/parser-typechecker/src/Unison/Prelude.hs
+++ b/parser-typechecker/src/Unison/Prelude.hs
@@ -1,5 +1,5 @@
 module Unison.Prelude
-  ( module X, readUtf8, safeReadUtf8, writeUtf8
+  ( module X, readUtf8, safeReadUtf8, safeReadUtf8StdIn, writeUtf8
   ) where
 
 import Control.Applicative as X
@@ -37,6 +37,9 @@ readUtf8 p = decodeUtf8 <$> BS.readFile p
 
 safeReadUtf8 :: FilePath -> IO (Either IOException Text)
 safeReadUtf8 p = try (readUtf8 p)
+
+safeReadUtf8StdIn :: IO (Either IOException Text) 
+safeReadUtf8StdIn = try $ decodeUtf8 <$> BS.getContents
 
 writeUtf8 :: FilePath -> Text -> IO ()
 writeUtf8 p txt = BS.writeFile p (encodeUtf8 txt) 

--- a/parser-typechecker/src/Unison/PrettyTerminal.hs
+++ b/parser-typechecker/src/Unison/PrettyTerminal.hs
@@ -13,19 +13,22 @@ stripSurroundingBlanks s = unlines (dropWhile isBlank . dropWhileEnd isBlank $ l
 
 -- like putPrettyLn' but prints a blank line before and after.
 putPrettyLn :: P.Pretty CT.ColorText -> IO ()
+putPrettyLn p | p == mempty = pure ()
 putPrettyLn p = do
   width <- getAvailableWidth
-  less . stripSurroundingBlanks . P.toANSI width $ P.border 2 p
+  less . P.toANSI width $ P.border 2 p
 
 putPrettyLnUnpaged :: P.Pretty CT.ColorText -> IO ()
+putPrettyLnUnpaged p | p == mempty = pure ()
 putPrettyLnUnpaged p = do
   width <- getAvailableWidth
-  putStrLn . stripSurroundingBlanks . P.toANSI width $ P.border 2 p
+  putStrLn . P.toANSI width $ P.border 2 p
 
 putPrettyLn' :: P.Pretty CT.ColorText -> IO ()
+putPrettyLn' p | p == mempty = pure ()
 putPrettyLn' p = do
   width <- getAvailableWidth
-  less . stripSurroundingBlanks . P.toANSI width $ P.indentN 2 p
+  less . P.toANSI width $ P.indentN 2 p
 
 clearCurrentLine :: IO ()
 clearCurrentLine = do
@@ -44,5 +47,5 @@ getAvailableWidth =
   maybe 80 (\s -> 100 `min` Terminal.width s) <$> Terminal.size
 
 putPrettyNonempty :: P.Pretty P.ColorText -> IO ()
-putPrettyNonempty msg =
+putPrettyNonempty msg = do
   if msg == mempty then pure () else putPrettyLn msg

--- a/parser-typechecker/src/Unison/PrettyTerminal.hs
+++ b/parser-typechecker/src/Unison/PrettyTerminal.hs
@@ -4,22 +4,28 @@ import           Unison.Util.Less              (less)
 import qualified Unison.Util.Pretty            as P
 import qualified Unison.Util.ColorText         as CT
 import qualified System.Console.Terminal.Size  as Terminal
+import Data.List (dropWhileEnd)
+import Data.Char (isSpace)
+
+stripSurroundingBlanks :: String -> String
+stripSurroundingBlanks s = unlines (dropWhile isBlank . dropWhileEnd isBlank $ lines s) where
+  isBlank line = all isSpace line
 
 -- like putPrettyLn' but prints a blank line before and after.
 putPrettyLn :: P.Pretty CT.ColorText -> IO ()
 putPrettyLn p = do
   width <- getAvailableWidth
-  less . P.toANSI width $ P.border 2 p
+  less . stripSurroundingBlanks . P.toANSI width $ P.border 2 p
 
 putPrettyLnUnpaged :: P.Pretty CT.ColorText -> IO ()
 putPrettyLnUnpaged p = do
   width <- getAvailableWidth
-  putStrLn . P.toANSI width $ P.border 2 p
+  putStrLn . stripSurroundingBlanks . P.toANSI width $ P.border 2 p
 
 putPrettyLn' :: P.Pretty CT.ColorText -> IO ()
 putPrettyLn' p = do
   width <- getAvailableWidth
-  less . P.toANSI width $ P.indentN 2 p
+  less . stripSurroundingBlanks . P.toANSI width $ P.indentN 2 p
 
 clearCurrentLine :: IO ()
 clearCurrentLine = do

--- a/parser-typechecker/tests/Unison/Test/Transcripts.hs
+++ b/parser-typechecker/tests/Unison/Test/Transcripts.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import Unison.Prelude
+import EasyTest
+import Shellmet ()
+import System.Directory
+import System.FilePath ( (</>), takeExtensions )
+import Data.Text (pack)
+import Data.List
+
+test :: Test ()
+test = do
+  let dir = "unison-src" </> "transcripts"
+  files <- io $ listDirectory dir 
+  let transcripts = filter (\f -> takeExtensions f == ".md") files 
+      run t = scope t $ do  
+        io $ "stack" ["exec", "unison", "--", "sandbox", pack (dir </> t)]
+        ok
+  tests (run <$> transcripts)
+  -- Assuming everything passed, we now delete the transcript directories
+  -- If the above fails, this won't be run, so you can inspect the codebase
+  -- that resulted from any failures.
+  files' <- io $ listDirectory "."
+  let dirs = filter (\f -> "transcript-" `isPrefixOf` f) files' 
+  io $ createDirectoryIfMissing True "test-output"
+  io $ for_ dirs (\d -> renameDirectory d ("test-output" </> d))
+
+main :: IO ()
+main = run test

--- a/parser-typechecker/tests/Unison/Test/Transcripts.hs
+++ b/parser-typechecker/tests/Unison/Test/Transcripts.hs
@@ -16,7 +16,7 @@ test = do
   files <- io $ listDirectory dir 
   let transcripts = filter (\f -> takeExtensions f == ".md") files 
       run t = scope t $ do  
-        io $ "stack" ["exec", "unison", "--", "sandbox", pack (dir </> t)]
+        io $ "stack" ["exec", "unison", "--", "transcript", pack (dir </> t)]
         ok
   tests (run <$> transcripts)
   -- Assuming everything passed, we now delete the transcript directories

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -251,6 +251,7 @@ executable unison
     containers,
     directory,
     filepath,
+    fsutils,
     safe,
     shellmet,
     template-haskell,

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -254,6 +254,7 @@ executable unison
     safe,
     shellmet,
     template-haskell,
+    temporary,
     text,
     unison-parser-typechecker
 

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -309,3 +309,17 @@ executable tests
     text,
     transformers,
     unison-parser-typechecker
+
+executable transcripts
+  main-is:        Unison/Test/Transcripts.hs
+  ghc-options:    -W -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -threaded -rtsopts -with-rtsopts=-N -v0
+  hs-source-dirs: tests
+  other-modules:
+  build-depends:
+    base,
+    directory,
+    easytest,
+    filepath,
+    shellmet,
+    text,
+    unison-parser-typechecker

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -1,6 +1,6 @@
 {-# Language OverloadedStrings #-}
 {-# Language PartialTypeSignatures #-}
-{-# OPTIONS_GHC -Wno-error=partial-type-signatures #-}
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 
 module Main where
 
@@ -40,7 +40,7 @@ usage = P.callout "🌻" $ P.lines [
   P.wrap $ "Executes the definition called `mymain` in `foo.u`, then exits.",
   "",
   P.bold "ucm run.pipe mymain",
-  P.wrap $ "Executes the definition called `mymain` from a `.u` file read from standard in, then exits.",
+  P.wrap $ "Executes the definition called `mymain` from a `.u` file read from the standard input, then exits.",
   "",
   P.bold "ucm transcript mytranscript.md",
   P.wrap $ "Executes the `mytranscript.md` transcript and creates"
@@ -137,7 +137,9 @@ runTranscripts inFork codepath args = do
           P.lines [
             "I've finished running the transcript(s) in this codebase:", "",
             P.indentN 2 (P.string transcriptDir), "",
-            "You can run `ucm` in this directory to do more work on it."])
+            P.wrap $ "You can run"
+                  <> P.backticked ("ucm -codebase " <> P.string transcriptDir)
+                  <> "to do more work with it."])
     [] -> do
       PT.putPrettyLn usage
       Exit.exitWith (Exit.ExitFailure 1)

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -1,4 +1,6 @@
 {-# Language OverloadedStrings #-}
+{-# Language PartialTypeSignatures #-}
+{-# OPTIONS_GHC -Wno-error=partial-type-signatures #-}
 
 module Main where
 
@@ -11,6 +13,7 @@ import qualified Unison.Runtime.Rt1IO          as Rt1
 import qualified Unison.Codebase.Path          as Path
 import qualified Version as Version
 import qualified Unison.Codebase.TranscriptParser as TR
+import qualified System.Path as Path
 import qualified System.FilePath as FP
 import qualified System.IO.Temp as Temp
 import qualified System.Exit as Exit
@@ -19,75 +22,56 @@ import qualified Unison.Util.Pretty as P
 import qualified Unison.PrettyTerminal as PT
 import qualified Data.Text as Text
 
+usage :: P.Pretty P.ColorText 
+usage = P.callout "🌻" $ P.lines [
+  P.bold "Usage instructions for the Unison Codebase Manager",
+  "You are running version: " <> P.string Version.gitDescribe,
+  "",
+  P.bold "ucm",
+  P.wrap "Starts Unison and listens for commands and file changes.",
+  "",
+  P.bold "ucm run .mylib.mymain",
+  P.wrap $ "Executes the definition `.mylib.mymain` from the codebase namespac, then exits.",
+  "",
+  P.bold "ucm run.file foo.u mymain",
+  P.wrap $ "Executes the definition called `mymain` in `foo.u`, then exits.",
+  "",
+  P.bold "ucm run.pipe mymain",
+  P.wrap $ "Executes the definition called `mymain` from a `.u` file read from standard in, then exits.",
+  "",
+  P.bold "ucm transcript mytranscript.md",
+  P.wrap $ "Executes the `mytranscript.md` transcript and creates"
+        <> "`mytranscript.output.md` if successful. Exits after completion."
+        <> "Multiple transcript files may be provided; they are processed in sequence"
+        <> "starting from the same codebase.",
+  "",
+  P.bold "ucm transcript.fork mytranscript.md",
+  P.wrap $ "Executes the `mytranscript.md` transcript in a copy of the current codebase"
+        <> "and creates `mytranscript.output.md` if successful. Exits after completion."
+        <> "Multiple transcript files may be provided; they are processed in sequence"
+        <> "starting from the same codebase.",
+  "",
+  P.bold "ucm version",
+  "Prints version of Unison then quits.",
+  "",
+  P.bold "ucm help",
+  "Prints this help."
+  ]
+
 main :: IO ()
 main = do
   args               <- getArgs
   -- hSetBuffering stdout NoBuffering -- cool
-  let usage = P.callout "🌻" $ P.lines [
-        P.bold "Usage instructions for the Unison Codebase Manager",
-        "You are running version: " <> P.string Version.gitDescribe,
-        "",
-        P.bold "ucm",
-        P.wrap "Starts Unison and listens for commands and file changes.",
-        "",
-        P.bold "ucm run .mylib.mymain",
-        P.wrap $ "Executes the definition `.mylib.mymain` from the codebase namespac, then exits.",
-        "",
-        P.bold "ucm run.file foo.u mymain",
-        P.wrap $ "Executes the definition called `mymain` in `foo.u`, then exits.",
-        "",
-        P.bold "ucm run.pipe mymain",
-        P.wrap $ "Executes the definition called `mymain` from a `.u` file read from standard in, then exits.",
-        "",
-        P.bold "ucm transcript mytranscript.md",
-        P.wrap $ "Executes the `mytranscript.md` transcript and creates"
-              <> "`mytranscript.output.md` if successful. Exits after completion."
-              <> "Multiple transcript files may be provided; they are processed in sequence"
-              <> "starting from the same codebase.",
-        "",
-        P.bold "ucm transcript.fork mytranscript.md",
-        P.wrap $ "Executes the `mytranscript.md` transcript in a copy of the current codebase"
-              <> "and creates `mytranscript.output.md` if successful. Exits after completion."
-              <> "Multiple transcript files may be provided; they are processed in sequence"
-              <> "starting from the same codebase.",
-        "",
-        P.bold "ucm version",
-        "Prints version of Unison then quits.",
-        "",
-        P.bold "ucm help",
-        "Prints this help."
-        ]
 
-  -- so we can do `ucm --help`, `ucm -help` or `ucm help` (I hate
-  -- having to remember which one is supported)
-  let isFlag f arg = arg == f || arg == "-" ++ f || arg == "--" ++ f
-      initialPath = Path.absoluteEmpty
-      launch dir code inputs = CommandLine.main dir
-                                     initialPath
-                                     inputs
-                                     (pure Rt1.runtime)
-                                     code
-  let hasTranscript = any isMarkdown args
-      allOk = all isDotU (take 1 args) || all isOk args
-      isOk arg = isMarkdown arg || isDotU arg
-              || isFlag "version" arg || isFlag "help" arg || isFlag "sandbox" arg
-      isDotU file = FP.takeExtension file == ".u"
-      isMarkdown md = case FP.takeExtension md of
-        ".md" -> True
-        ".markdown" -> True
-        _ -> False
   currentDir <- getCurrentDirectory
-  transcriptDir <- if hasTranscript then Temp.createTempDirectory currentDir "transcript"
-                   else pure currentDir
-  when (not allOk) $ do
-    PT.putPrettyLn usage
-    Exit.exitWith (Exit.ExitFailure 1)
   case args of
+    [] -> do
+      theCodebase <- FileCodebase.ensureCodebaseInitialized currentDir
+      launch currentDir theCodebase []
     [version] | isFlag "version" version ->
       putStrLn $ "ucm version: " ++ Version.gitDescribe
     [help] | isFlag "help" help -> PT.putPrettyLn usage
     "run" : [mainName] -> do
-      putStrLn "asdlkfjasdlfkjasdflkj"
       theCodebase <- FileCodebase.ensureCodebaseInitialized currentDir
       launch currentDir theCodebase [Right $ Input.ExecuteI mainName, Right Input.QuitI]
     "run.file" : file : [mainName] | isDotU file -> do
@@ -106,32 +90,62 @@ main = do
           theCodebase <- FileCodebase.ensureCodebaseInitialized currentDir
           let fileEvent = Input.UnisonFileChanged (Text.pack "<standard input>") contents
           launch currentDir theCodebase [Left fileEvent, Right $ Input.ExecuteI mainName, Right Input.QuitI]
-    args -> do
-      theCodebase <- FileCodebase.ensureCodebaseInitialized currentDir
-      let sandboxed = take 1 args == ["sandbox"]
-      case args of
-        args@(_:_) -> do
-          for_ args $ \arg -> case arg of
-            md | isMarkdown md -> do
-              parsed <- TR.parseFile arg
-              case parsed of
-                Left err -> putStrLn $ "Parse error: \n" <> show err
-                Right stanzas -> do
-                  theCodebase <-
-                    if sandboxed then FileCodebase.ensureCodebaseInitialized transcriptDir
-                    else pure theCodebase
-                  mdOut <- TR.run currentDir stanzas theCodebase
-                  let out = currentDir FP.</>
-                             FP.addExtension (FP.dropExtension arg ++ ".output")
-                                             (FP.takeExtension md)
-                  writeUtf8 out mdOut
-                  putStrLn $ "💾  Wrote " <> out
-            "sandbox" -> pure ()
-            wat -> putStrLn $ "Unrecognized command, skipping: " <> wat
-          when hasTranscript . PT.putPrettyLn $
-            P.callout "🌸" (
-              P.lines [
-                "I've finished running the transcript(s) in this codebase:", "",
-                P.indentN 2 (P.string transcriptDir), "",
-                "You can run `ucm` in this directory to do more work on it."])
-        _ -> launch currentDir theCodebase []
+    "transcript" : args -> runTranscripts False args
+    "transcript.fork" : args -> runTranscripts True args
+    _ -> do 
+      PT.putPrettyLn usage
+      Exit.exitWith (Exit.ExitFailure 1)
+
+runTranscripts :: Bool -> [String] -> IO ()
+runTranscripts inFork args = do
+  currentDir <- getCurrentDirectory
+  transcriptDir <- do
+    tmp <- Temp.createTempDirectory currentDir "transcript"
+    when inFork $ Path.copyDir (currentDir FP.</> ".unison") (tmp FP.</> ".unison")
+    pure tmp
+  theCodebase <- FileCodebase.ensureCodebaseInitialized transcriptDir
+  case args of
+    args@(_:_) -> do
+      for_ args $ \arg -> case arg of
+        md | isMarkdown md -> do
+          parsed <- TR.parseFile arg
+          case parsed of
+            Left err -> putStrLn $ "Parse error: \n" <> show err
+            Right stanzas -> do 
+              mdOut <- TR.run currentDir stanzas theCodebase
+              let out = currentDir FP.</>
+                         FP.addExtension (FP.dropExtension arg ++ ".output")
+                                         (FP.takeExtension md)
+              writeUtf8 out mdOut
+              putStrLn $ "💾  Wrote " <> out
+        wat -> putStrLn $ "Unrecognized command, skipping: " <> wat
+      PT.putPrettyLn $
+        P.callout "🌸" (
+          P.lines [
+            "I've finished running the transcript(s) in this codebase:", "",
+            P.indentN 2 (P.string transcriptDir), "",
+            "You can run `ucm` in this directory to do more work on it."])
+    [] -> do
+      PT.putPrettyLn usage
+      Exit.exitWith (Exit.ExitFailure 1)
+
+initialPath :: Path.Absolute
+initialPath = Path.absoluteEmpty
+
+launch :: FilePath -> _ -> [Either Input.Event Input.Input] -> IO ()
+launch dir code inputs = 
+  CommandLine.main dir initialPath inputs (pure Rt1.runtime) code
+
+isMarkdown :: String -> Bool
+isMarkdown md = case FP.takeExtension md of
+  ".md" -> True
+  ".markdown" -> True
+  _ -> False
+
+isDotU :: String -> Bool
+isDotU file = FP.takeExtension file == ".u"
+
+-- so we can do `ucm --help`, `ucm -help` or `ucm help` (I hate
+-- having to remember which one is supported)
+isFlag :: String -> String -> Bool
+isFlag f arg = arg == f || arg == "-" ++ f || arg == "--" ++ f

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -1,7 +1,8 @@
+{-# Language OverloadedStrings #-}
+
 module Main where
 
 import Unison.Prelude
-import           Safe                           ( headMay )
 import           System.Environment             ( getArgs )
 import qualified Unison.Codebase.FileCodebase  as FileCodebase
 import qualified Unison.CommandLine.Main       as CommandLine
@@ -13,42 +14,56 @@ import qualified System.FilePath as FP
 import qualified System.IO.Temp as Temp
 import qualified System.Directory as Directory
 import qualified System.Exit as Exit
-
+import qualified Unison.Codebase.Editor.Input as Input
+import qualified Unison.Util.Pretty as P
+import qualified Unison.PrettyTerminal as PT
+import qualified Data.Text as Text
 
 main :: IO ()
 main = do
   args               <- getArgs
   -- hSetBuffering stdout NoBuffering -- cool
-  let usage = unlines [
-        "ucm",
-        "  Starts Unison and listens for commands and file changes.",
+  let usage = P.callout "🌻" $ P.lines [
+        P.bold "Usage instructions for the Unison Codebase Manager",
+        "You are running version: " <> P.string Version.gitDescribe,
         "",
-        "ucm mymain.u",
-        "  Executes the definition called `main` in `mymain.u` and",
-        "  exits after completion.",
+        P.bold "ucm",
+        P.wrap "Starts Unison and listens for commands and file changes.", 
         "",
-        "ucm mytranscript.md",
-        "  Executes the `mytranscript.md` transcript and creates",
-        "  `mytranscript.output.md` if successful. Exits after completion.",
+        P.bold "ucm mymain.u arg1 arg2",
+        P.wrap $ "Executes the definition called `main` in `mymain.u`, passing"
+              <> "any optional arguments arg1, arg2, etc, then exits after completion.",
         "",
-        "ucm version",
-        "  Prints version of Unison then quits.",
+        P.bold "ucm mytranscript.md",
+        P.wrap $ "Executes the `mytranscript.md` transcript and creates"
+              <> "`mytranscript.output.md` if successful. Exits after completion." 
+              <> "Multiple transcript files may be provided; they are processed in sequence"
+              <> "starting from the same codebase.",
         "",
-        "ucm help",
-        "  Prints this help."
+        P.bold "ucm sandbox mytranscript.md",
+        P.wrap $ "Executes the `mytranscript.md` transcript in a fresh codebase"
+              <> "and creates `mytranscript.output.md` if successful. Exits after completion."
+              <> "Multiple transcript files may be provided; they are processed in sequence"
+              <> "starting from the same codebase.",
+        "",
+        P.bold "ucm version",
+        "Prints version of Unison then quits.",
+        "",
+        P.bold "ucm help",
+        "Prints this help."
         ]
 
   -- so we can do `ucm --help`, `ucm -help` or `ucm help` (I hate
   -- having to remember which one is supported)
   let isFlag f arg = arg == f || arg == "-" ++ f || arg == "--" ++ f    
       initialPath = Path.absoluteEmpty
-      launch dir code = CommandLine.main dir
+      launch dir code inputs = CommandLine.main dir
                                      initialPath
-                                     (headMay args)
+                                     inputs 
                                      (pure Rt1.runtime)
                                      code
   let hasTranscript = any isMarkdown args 
-      allOk = all isOk args
+      allOk = all isDotU (take 1 args) || all isOk args
       isOk arg = isMarkdown arg || isDotU arg
               || isFlag "version" arg || isFlag "help" arg || isFlag "sandbox" arg
       isDotU file = FP.takeExtension file == ".u"
@@ -60,12 +75,20 @@ main = do
   transcriptDir <- if hasTranscript then Temp.createTempDirectory currentDir "transcript"
                    else pure currentDir
   when (not allOk) $ do
-    putStrLn $ "\n" ++ usage
+    PT.putPrettyLn usage
     Exit.exitWith (Exit.ExitFailure 1)
   case args of
     [version] | isFlag "version" version ->
       putStrLn $ "ucm version: " ++ Version.gitDescribe
-    [help] | isFlag "help" help -> putStrLn usage
+    [help] | isFlag "help" help -> PT.putPrettyLn usage
+    (file:args) | isDotU file -> do 
+      e <- safeReadUtf8 file
+      case e of
+        Left _ -> PT.putPrettyLn $ P.callout "⚠️" "I couldn't find that file or it is for some reason unreadable."
+        Right contents -> do
+          (dir, theCodebase) <- FileCodebase.ensureCodebaseInitialized currentDir
+          let fileEvent = Input.UnisonFileChanged (Text.pack file) contents
+          launch dir theCodebase [Left fileEvent, Right $ Input.ExecuteI args, Right Input.QuitI]    
     args -> do
       (dir, theCodebase) <- FileCodebase.ensureCodebaseInitialized currentDir
       let sandboxed = take 1 args == ["sandbox"]
@@ -86,13 +109,12 @@ main = do
                                              (FP.takeExtension md)
                   writeUtf8 out mdOut
                   putStrLn $ "💾  Wrote " <> out
-            file | isDotU file -> undefined
             "sandbox" -> pure ()
             wat -> putStrLn $ "Unrecognized command, skipping: " <> wat
-          when hasTranscript $ putStrLn $ unlines [ 
-            "", "",
-            "🌸  I've finished running the transcript(s) in this codebase:", "",
-            "  " <> transcriptDir, "",
-            "You can run `ucm` in this directory to do more work on it."
-            ]
-        _ -> launch dir theCodebase
+          when hasTranscript . PT.putPrettyLn $
+            P.callout "🌸" (
+              P.lines [
+                "I've finished running the transcript(s) in this codebase:", "",
+                P.indentN 2 (P.string transcriptDir), "",
+                "You can run `ucm` in this directory to do more work on it."])
+        _ -> launch dir theCodebase []

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -68,7 +68,7 @@ main = do
     args -> do
       (dir, theCodebase) <- FileCodebase.ensureCodebaseInitialized currentDir
       case args of 
-        args @ (_:_) -> do
+        args@(_:_) -> do
           for_ args $ \arg -> case arg of
             md | isMarkdown md -> do
               parsed <- TR.parseFile arg
@@ -77,7 +77,10 @@ main = do
                 Right stanzas -> do
                   (dir, theCodebase) <- FileCodebase.ensureCodebaseInitialized transcriptDir
                   mdOut <- TR.run dir stanzas theCodebase
-                  writeUtf8 (currentDir FP.</> (FP.addExtension (FP.dropExtension arg ++ ".output") md)) mdOut
+                  writeUtf8 (currentDir FP.</> 
+                             FP.addExtension (FP.dropExtension arg ++ ".output") 
+                                             (FP.takeExtension md)) 
+                            mdOut
             file | isDotU file -> undefined
             wat -> putStrLn $ "Unrecognized command, skipping: " <> wat
           when hasTranscript $ putStrLn $ unlines [ 

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -10,6 +10,9 @@ import qualified Unison.Codebase.Path          as Path
 import qualified Version as Version
 import qualified Unison.Codebase.TranscriptParser as TR
 import qualified System.FilePath as FP
+import qualified System.IO.Temp as Temp
+import qualified System.Directory as Directory
+import qualified System.Exit as Exit
 
 
 main :: IO ()
@@ -26,45 +29,60 @@ main = do
         "",
         "ucm mytranscript.md",
         "  Executes the `mytranscript.md` transcript and creates",
-        "  `mytranscript-output.md` if successful. Exits after completion.",
+        "  `mytranscript.output.md` if successful. Exits after completion.",
         "",
         "ucm version",
-        "  Prints version of Unison then quits",
+        "  Prints version of Unison then quits.",
         "",
         "ucm help",
-        "  Prints this help"
+        "  Prints this help."
         ]
 
   -- so we can do `ucm --help`, `ucm -help` or `ucm help` (I hate
   -- having to remember which one is supported)
   let isFlag f arg = arg == f || arg == "-" ++ f || arg == "--" ++ f    
-
+      initialPath = Path.absoluteEmpty
+      launch dir code = CommandLine.main dir
+                                     initialPath
+                                     (headMay args)
+                                     (pure Rt1.runtime)
+                                     code
+  let hasTranscript = any isMarkdown args 
+      allOk = all isOk args
+      isOk arg = isMarkdown arg || isDotU arg
+      isDotU file = FP.takeExtension file == ".u"
+      isMarkdown md = case FP.takeExtension md of
+        ".md" -> True
+        ".markdown" -> True
+        _ -> False
+  currentDir <- Directory.getCurrentDirectory
+  transcriptDir <- if hasTranscript then Temp.createTempDirectory currentDir "transcript"
+                   else pure currentDir
+  when (not allOk) $ do
+    putStrLn $ "\n" ++ usage
+    Exit.exitWith (Exit.ExitFailure 1)
   case args of
     [version] | isFlag "version" version ->
       putStrLn $ "ucm version: " ++ Version.gitDescribe
     [help] | isFlag "help" help -> putStrLn usage
     args -> do
-      (dir, theCodebase) <- FileCodebase.ensureCodebaseInitialized
-      let initialPath = Path.absoluteEmpty
-          launch      = CommandLine.main dir
-                                         initialPath
-                                         (headMay args)
-                                         (pure Rt1.runtime)
-                                         theCodebase
+      (dir, theCodebase) <- FileCodebase.ensureCodebaseInitialized currentDir
       case args of 
-        args @ (_:_) -> for_ args $ \arg -> case FP.takeExtension arg of
-          md | md == ".md" || md == ".markdown" -> do
-            parsed <- TR.parseFile arg
-            case parsed of
-              Left err -> do
-                putStrLn "Parse error: "
-                putStrLn $ show err
-              Right stanzas -> do
-                -- todo: run on a copy of the codebase?
-                mdOut <- TR.run dir stanzas theCodebase
-                writeUtf8 (dir FP.</> (FP.addExtension (FP.dropExtension arg ++ "-output") md)) mdOut
-          ".u" -> undefined
-          _wat -> do
-            putStrLn $ "That's not a command I recognize, sorry!"
-            putStrLn $ "\n" ++ usage
-        _ -> launch
+        args @ (_:_) -> do
+          for_ args $ \arg -> case arg of
+            md | isMarkdown md -> do
+              parsed <- TR.parseFile arg
+              case parsed of
+                Left err -> putStrLn $ "Parse error: \n" <> show err
+                Right stanzas -> do
+                  (dir, theCodebase) <- FileCodebase.ensureCodebaseInitialized transcriptDir
+                  mdOut <- TR.run dir stanzas theCodebase
+                  writeUtf8 (currentDir FP.</> (FP.addExtension (FP.dropExtension arg ++ ".output") md)) mdOut
+            file | isDotU file -> undefined
+            wat -> putStrLn $ "Unrecognized command, skipping: " <> wat
+          when hasTranscript $ putStrLn $ unlines [ 
+            "I've finished running the transcript(s). You can do:\n",
+            "  pull " <> transcriptDir <> " .somepath", "",
+            "from ucm to bring the resulting codebase into your local codebase."
+            ]
+        _ -> launch dir theCodebase

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -81,16 +81,16 @@ main = do
                     if sandboxed then FileCodebase.ensureCodebaseInitialized transcriptDir
                     else pure (dir, theCodebase)
                   mdOut <- TR.run dir stanzas theCodebase
-                  writeUtf8 (currentDir FP.</> 
+                  let out = currentDir FP.</> 
                              FP.addExtension (FP.dropExtension arg ++ ".output") 
-                                             (FP.takeExtension md)) 
-                            mdOut
+                                             (FP.takeExtension md)
+                  writeUtf8 out mdOut
+                  putStrLn $ "Wrote " <> out
             file | isDotU file -> undefined
             "sandbox" -> pure ()
             wat -> putStrLn $ "Unrecognized command, skipping: " <> wat
           when hasTranscript $ putStrLn $ unlines [ 
-            "I've finished running the transcript(s). You can do:\n",
-            "  pull " <> transcriptDir <> " .somepath", "",
-            "from ucm to bring the resulting codebase into your local codebase."
+            "I've finished running the transcript(s) in this codebase:", "",
+            "  " <> transcriptDir, ""
             ]
         _ -> launch dir theCodebase

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -1,5 +1,6 @@
 module Main where
 
+import Unison.Prelude
 import           Safe                           ( headMay )
 import           System.Environment             ( getArgs )
 import qualified Unison.Codebase.FileCodebase  as FileCodebase
@@ -7,19 +8,63 @@ import qualified Unison.CommandLine.Main       as CommandLine
 import qualified Unison.Runtime.Rt1IO          as Rt1
 import qualified Unison.Codebase.Path          as Path
 import qualified Version as Version
+import qualified Unison.Codebase.TranscriptParser as TR
+import qualified System.FilePath as FP
 
 
 main :: IO ()
 main = do
   args               <- getArgs
   -- hSetBuffering stdout NoBuffering -- cool
-  (dir, theCodebase) <- FileCodebase.ensureCodebaseInitialized
-  let initialPath = Path.absoluteEmpty
-      launch      = CommandLine.main dir
-                                     initialPath
-                                     (headMay args)
-                                     (pure Rt1.runtime)
-                                     theCodebase
+  let usage = unlines [
+        "ucm",
+        "  Starts Unison and listens for commands and file changes.",
+        "",
+        "ucm mymain.u",
+        "  Executes the definition called `main` in `mymain.u` and",
+        "  exits after completion.",
+        "",
+        "ucm mytranscript.md",
+        "  Executes the `mytranscript.md` transcript and creates",
+        "  `mytranscript-output.md` if successful. Exits after completion.",
+        "",
+        "ucm version",
+        "  Prints version of Unison then quits",
+        "",
+        "ucm help",
+        "  Prints this help"
+        ]
+
+  -- so we can do `ucm --help`, `ucm -help` or `ucm help` (I hate
+  -- having to remember which one is supported)
+  let isFlag f arg = arg == f || arg == "-" ++ f || arg == "--" ++ f    
+
   case args of
-    ["--version"] -> putStrLn $ "ucm version: " ++ Version.gitDescribe
-    _ -> launch
+    [version] | isFlag "version" version ->
+      putStrLn $ "ucm version: " ++ Version.gitDescribe
+    [help] | isFlag "help" help -> putStrLn usage
+    args -> do
+      (dir, theCodebase) <- FileCodebase.ensureCodebaseInitialized
+      let initialPath = Path.absoluteEmpty
+          launch      = CommandLine.main dir
+                                         initialPath
+                                         (headMay args)
+                                         (pure Rt1.runtime)
+                                         theCodebase
+      case args of 
+        args @ (_:_) -> for_ args $ \arg -> case FP.takeExtension arg of
+          md | md == ".md" || md == ".markdown" -> do
+            parsed <- TR.parseFile arg
+            case parsed of
+              Left err -> do
+                putStrLn "Parse error: "
+                putStrLn $ show err
+              Right stanzas -> do
+                -- todo: run on a copy of the codebase?
+                mdOut <- TR.run dir stanzas theCodebase
+                writeUtf8 (dir FP.</> (FP.addExtension (FP.dropExtension arg ++ "-output") md)) mdOut
+          ".u" -> undefined
+          _wat -> do
+            putStrLn $ "That's not a command I recognize, sorry!"
+            putStrLn $ "\n" ++ usage
+        _ -> launch

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -85,12 +85,14 @@ main = do
                              FP.addExtension (FP.dropExtension arg ++ ".output") 
                                              (FP.takeExtension md)
                   writeUtf8 out mdOut
-                  putStrLn $ "Wrote " <> out
+                  putStrLn $ "💾  Wrote " <> out
             file | isDotU file -> undefined
             "sandbox" -> pure ()
             wat -> putStrLn $ "Unrecognized command, skipping: " <> wat
           when hasTranscript $ putStrLn $ unlines [ 
-            "I've finished running the transcript(s) in this codebase:", "",
-            "  " <> transcriptDir, ""
+            "", "",
+            "🌸  I've finished running the transcript(s) in this codebase:", "",
+            "  " <> transcriptDir, "",
+            "You can run `ucm` in this directory to do more work on it."
             ]
         _ -> launch dir theCodebase

--- a/stack.yaml
+++ b/stack.yaml
@@ -22,4 +22,4 @@ extra-deps:
 
 ghc-options:
  # All packages
- "$locals": -Werror #-freverse-errors
+ "$locals": -Werror -Wno-type-defaults #-freverse-errors

--- a/unison-src/transcripts/hello.md
+++ b/unison-src/transcripts/hello.md
@@ -1,0 +1,57 @@
+
+# Hello!
+
+This markdown file is also a Unison transcript file. Transcript files are an easy way to create self-documenting Unison programs, libraries, and tutorials.
+
+The format is just a regular markdown file with some fenced code blocks that are typechecked and elaborated by `ucm`. For example, you can call this transcript via:
+
+```
+$ ucm hello.md
+```
+
+> Alternately `ucm sandbox hello.md` runs the transcript on a freshly generated temporary codebase. Do `ucm help` to learn more about usage.
+
+Fenced code blocks of type `unison` and `ucm` are treated specially:
+
+* `ucm` blocks are executed, and the output is interleaved into the output markdown file after each command, replacing the original `ucm` block.
+* `unison` blocks are typechecked, and a `ucm` block with the output of typechecking and execution of the file is inserted immediately afterwards.
+
+## Let's try it out!!
+
+In the `unison` fenced block, you can give an (optional) file name (defaults to `scratch.u`), like so:
+
+```unison myfile.u
+x = 42
+```
+
+Let's go ahead and add that to the codebase, then make sure it's there:
+
+```ucm
+.> add
+.> view x
+```
+
+If `view` returned no results, the transcript would fail at this point.
+
+## Hiding output
+
+You may not always want to view the output of typechecking and evaluaion every time, in which case, you can add `:hide` to the block. For instance:
+
+```unison:hide
+y = 99
+```
+
+This works for `ucm` blocks as well.
+
+```ucm:hide
+.> rename.term x answerToUltimateQuestionOfLife
+```
+
+## Expecting failures
+
+Sometimes, you have a block which you are _expecting_ to fail, perhaps because you're illustrating how something would be a type error. Adding `:error` to the block will check for this. For instance, this program has a type error:
+
+```unison:error
+hmm : .builtin.Nat
+hmm = "Not, in fact, a number"
+```

--- a/unison-src/transcripts/hello.output.md
+++ b/unison-src/transcripts/hello.output.md
@@ -1,0 +1,82 @@
+
+# Hello!
+
+This markdown file is also a Unison transcript file. Transcript files are an easy way to create self-documenting Unison programs, libraries, and tutorials.
+
+The format is just a regular markdown file with some fenced code blocks that are typechecked and elaborated by `ucm`. For example, you can call this transcript via:
+
+```
+$ ucm hello.md
+
+```
+
+> Alternately `ucm sandbox hello.md` runs the transcript on a freshly generated temporary codebase. Do `ucm help` to learn more about usage.
+
+Fenced code blocks of type `unison` and `ucm` are treated specially:
+
+* `ucm` blocks are executed, and the output is interleaved into the output markdown file after each command, replacing the original `ucm` block.
+* `unison` blocks are typechecked, and a `ucm` block with the output of typechecking and execution of the file is inserted immediately afterwards.
+
+## Let's try it out!!
+
+In the `unison` fenced block, you can give an (optional) file name (defaults to `scratch.u`), like so:
+
+```unison
+---
+title: myfile.u
+---
+x = 42
+
+```
+
+
+```ucm
+I found and typechecked these definitions in myfile.u. If you do
+an `add` or `update`, here's how your codebase would change:
+
+  ⍟ These new definitions are ok to `add`:
+  
+    x : builtin.Nat
+ 
+Now evaluating any watch expressions (lines starting with
+`>`)... Ctrl+C cancels.
+```
+Let's go ahead and add that to the codebase, then make sure it's there:
+
+```ucm
+.> add
+⍟ I've added these definitions:
+
+  x : builtin.Nat
+.> view x
+x : builtin.Nat
+x = 42
+```
+If `view` returned no results, the transcript would fail at this point.
+
+## Hiding output
+
+You may not always want to view the output of typechecking and evaluaion every time, in which case, you can add `:hide` to the block. For instance:
+
+```unison
+y = 99
+```
+
+This works for `ucm` blocks as well.
+
+## Expecting failures
+
+Sometimes, you have a block which you are _expecting_ to fail, perhaps because you're illustrating how something would be a type error. Adding `:error` to the block will check for this. For instance, this program has a type error:
+
+```unison
+hmm : .builtin.Nat
+hmm = "Not, in fact, a number"
+```
+
+```ucm
+I found a value of type builtin.Text where I expected to find one of type builtin.Nat:
+
+    1 | hmm : .builtin.Nat
+    2 | hmm = "Not, in fact, a number"
+
+```

--- a/unison-src/transcripts/merges.md
+++ b/unison-src/transcripts/merges.md
@@ -1,0 +1,115 @@
+# Forking and merging namespaces in `ucm`
+
+The Unison namespace is a versioned tree of names that map to Unison definitions. You can change this namespace and fork and merge subtrees of it. Let's start by introducing a few definitions into a new namespace, `foo`:
+
+```unison
+x = 42
+```
+
+```ucm
+.> add
+```
+
+Let's move `x` into a new namespace, `master`:
+
+```ucm
+.> rename.term x master.x
+```
+
+If you want to do some experimental work in a namespace without disturbing anyone else, you can `fork` it (which is a shorthand for `copy.namespace`). This creates a copy of it, preserving its history.
+
+> __Note:__ these copies are very efficient to create as they just have pointers into the same underlying definitions. Create as many as you like.
+
+Let's go ahead and do this:
+
+```
+.> fork master feature1
+.> view master.x
+.> view feature1.x
+```
+
+Great! We can now do some further work in the `feature1` branch, then merge it back into `master` when we're ready.
+
+```unison
+y = "hello"
+```
+
+```ucm
+.feature1> add
+.master> merge .feature1
+.master> view y
+```
+
+> Note: `merge src`, with one argument, merges `src` into the current namespace. You can also do `merge src dest` to merge into any destination namespace.
+
+Notice that `master` now has the definition of `y` we wrote.
+
+We can also delete the fork if we're done with it. (Don't worry, it's still in the `history` and can be resurrected at any time.)
+
+```ucm
+.> delete.namespace .feature1
+.> history
+```
+
+To resurrect an old version of a namespace, you can learn its hash via the `history` command, then use `fork #namespacehash .newname`.
+
+## Concurrent edits and merges
+
+In the above scenario the destination namespace (`master`) was strictly behind the source namespace, so the merge didn't have anything interesting to do (Git would call this a "fast forward" merge). In other cases, the source and destination namespaces will each have changes the other doesn't know about, and the merge needs to something more interesting. That's okay too, and Unison will merge those results, using a 3-way merge algorithm.
+
+> __Note:__ When merging nested namespaces, Unison actually uses a recursive 3-way merge, so it finds a different (and possibly closer) common ancestor at each level of the tree.
+
+Let's see how this works. We are going to create a copy of `master`, add and delete some definitions in `master` and in the fork, then merge.
+
+```ucm
+.> fork master feature2
+```
+
+Here's one fork, we add `z` and delete `x`:
+
+```unison
+z = 99
+```
+
+```ucm
+.feature2> add
+.feature2> delete.term x
+```
+
+And here's the other fork, where we update `y` and add a new definition, `frobnicate`:
+
+```unison
+master.y = "updated y"
+master.frobnicate n = n + 1
+```
+
+```ucm
+.> update
+.> view master.y
+.> view master.frobnicate
+```
+
+At this point, `master` and `feature2` both have some changes the other doesn't know about. Let's merge them.
+
+```ucm
+.> merge feature2 master
+```
+
+Notice that `x` is deleted in the merged branch (it was deleted in `feature2` and untouched by `master`):
+
+```ucm:error
+.> view master.x
+```
+
+And notice that `y` has the most recent value, and that `z` and `frobnicate` both exist as well:
+
+```ucm
+.> view master.y
+.> view master.z
+.> view master.frobnicate
+```
+
+## FAQ
+
+* What happens if namespace1 deletes a name that namespace2 has updated? A: ???
+* ...

--- a/yaks/easytest/src/EasyTest.hs
+++ b/yaks/easytest/src/EasyTest.hs
@@ -398,8 +398,8 @@ instance Alternative Test where
       let (rng1, rng2) = Random.split currentRng
       (,) <$> newTVar rng1 <*> newTVar rng2
     lift $ do
-      _ <- runWrap (env { rng = rng1 }) t1
-      runWrap (env { rng = rng2 }) t2
+      r1 <- runWrap (env { rng = rng1 }) t1
+      (<|> r1) <$> runWrap (env { rng = rng2 }) t2
 
 instance MonadPlus Test where
   mzero = empty


### PR DESCRIPTION
`ucm` now takes some optional arguments:

<img width="1218" alt="Screen Shot 2019-09-24 at 1 44 17 PM" src="https://user-images.githubusercontent.com/11074/65536456-6e34dc80-ded1-11e9-8ed1-730117fa4d87.png">

So you can run standalone scripts now via `ucm mymain.u` (looks for a `main` binding) which is nice.

There's a couple example transcript files along with their output in [this directory](https://github.com/unisonweb/unison/tree/topic/transcripts/unison-src/transcripts). [This file](https://github.com/unisonweb/unison/blob/topic/transcripts/unison-src/transcripts/hello.md) is a good overview of the format, and then [this file](https://github.com/unisonweb/unison/blob/topic/transcripts/unison-src/transcripts/merges.md) has a test of some of the merge operations. Be sure to peep the raw markdown of the source so you can see the different kinds of fenced code blocks and flags for each in use.

All the transcripts in there are run when you do `stack exec transcripts` (which will exit with , and Travis will run through them as well.

### How it's done

Implementation is [here](https://github.com/unisonweb/unison/blob/topic/transcripts/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs). Some notes:

* The transcript parser is written with Megaparsec. That part was easy peasy.
* The runner is [in that same file](https://github.com/unisonweb/unison/blob/topic/transcripts/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs#L98). Warning: Implementation is pretty ugly but self contained, and it shares the exact same code path as `ucm` itself and even calls `CommandLine.main`. This means that everything works like you'd expect.
  - [ ] Todo: document the runner better, at least with some comments
* There is probably a way of refactoring `CommandLine.main` to make it more amenable to having a nicer transcript runner, but I didn't have the stomach for it.

### Other changes

* `execute` (now aliased as `run`) works a bit differently - it looks for a `main` function in the latest typechecked scratch file and calls it with any supplied args and giving it access to `IO`. I thought about introducing another command just to keep the old behavior around, but eventually decided not to for now. What you'd formerly put as the argument to `execute` you can just as easily put in your scratch file or in a `main.u` file.
* So, you can run `IO` stuff without first adding it to the codebase, and your `main` function can still reference preexisting definitions in the codebase.
* A bunch of output message formatting suff. The transcript runner needed to get the output messages before they were printed to the console, so it could splice them into the file.
* The transcript runner also needed to know which messages are considered error messages. That function is given [here](https://github.com/unisonweb/unison/blob/topic/transcripts/parser-typechecker/src/Unison/Codebase/Editor/Output.hs#L171). You can see where that's used in the transcript runner [here](https://github.com/unisonweb/unison/blob/topic/transcripts/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs#L189-L202).
* Fixed a bug in EasyTest

I'm going to do a cleanup pass, will lift the draft status once that's done.