### PR TITLE
Add codebase init command, no longer create codebases implicitly

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -24,3 +24,4 @@ The format for this list: name, GitHub handle, and then optional blurb about wha
 * Ian Denhardt (@zenhack)
 * Mitchell Rosen (@mitchellwrosen)
 * Ian Jeffries (@seagreen)
+* James Sully (@sullyj3)

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -14,6 +14,7 @@ module Unison.Codebase.FileCodebase
 , encodeFileName
 , codebasePath
 , initCodebaseAndExit
+, initCodebase
 , getCodebaseOrExit
 ) where
 
@@ -137,7 +138,7 @@ getCodebaseOrExit mdir = do
   (dir, errMsg) <- case mdir of
     Just dir -> pure $
       ( dir
-      , "No codebase exists at "
+      , "No codebase exists in "
           <> P.string dir
           <> P.newline
           <> "Run `ucm -codebase "
@@ -145,7 +146,7 @@ getCodebaseOrExit mdir = do
           <> " init` to create one, then try again!" )
     Nothing -> do
       dir <- getHomeDirectory
-      let errMsg = P.lines [ "No codebase exists at " <> P.string dir
+      let errMsg = P.lines [ "No codebase exists in " <> P.string dir
                            , "Run `ucm init` to create one, then try again!" ]
       pure (dir, errMsg)
 

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -76,6 +76,7 @@ main = do
     [version] | isFlag "version" version ->
       putStrLn $ "ucm version: " ++ Version.gitDescribe
     [help] | isFlag "help" help -> PT.putPrettyLn usage
+    ["init"] -> FileCodebase.initCodebaseAndExit codepath
     "run" : [mainName] -> do
       theCodebase <- FileCodebase.ensureCodebaseInitialized codepath
       launch currentDir theCodebase [Right $ Input.ExecuteI mainName, Right Input.QuitI]


### PR DESCRIPTION
~Questions:
Can I use lambdacase in main? (Main.hs:118)
How can I get rid of the parens around the do block in FileCodebase? (FileCodebase.hs:125)
Is it OK to pull out formatAnn to the top level? I'm not sure what it's for. (FileCodebase.hs:155)~