### PR TITLE
Fix scripts/unisonloop.sh.

### DIFF
--- a/scripts/unisonloop.sh
+++ b/scripts/unisonloop.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 until (stack build && \
-       stack exec unison "$1")
+       stack exec unison)
 do
   echo "Well that didn't work."
   echo Press any key to re-launch.


### PR DESCRIPTION
`scripts/unisonloop.sh` stopped working recently. Not sure if removing the argument to `stack exec unison` is the right fix, but otherwise it gives me

```
$ scripts/unisonloop.sh 
WARNING: Ignoring out of range dependency (allow-newer enabled): base-4.12.0.0. fsutils requires: >=4.5 && <4.7
WARNING: Ignoring out of range dependency (allow-newer enabled): directory-1.3.3.0. fsutils requires: >=1.1.0 && <1.3
WARNING: Ignoring out of range dependency (allow-newer enabled): filepath-1.4.2.1. fsutils requires: ==1.3.0.*

  🌻
  
  Usage instructions for the Unison Codebase Manager
  You are running version: release/M2-base-160-ge08581b6
  
  ucm
  Starts Unison interactively, using the codebase in the home directory.
  
  ucm -codebase path/to/codebase
  Starts Unison interactively, using the specified codebase. This flag can also be set for any of
  the below commands.
  
  ucm run .mylib.mymain
  Executes the definition `.mylib.mymain` from the codebase, then exits.
  
  ucm run.file foo.u mymain
  Executes the definition called `mymain` in `foo.u`, then exits.
  
  ucm run.pipe mymain
  Executes the definition called `mymain` from a `.u` file read from the standard input, then
  exits.
  
  ucm transcript mytranscript.md
  Executes the `mytranscript.md` transcript and creates `mytranscript.output.md` if successful.
  Exits after completion. Multiple transcript files may be provided; they are processed in sequence
  starting from the same codebase.
  
  ucm transcript.fork mytranscript.md
  Executes the `mytranscript.md` transcript in a copy of the current codebase and creates
  `mytranscript.output.md` if successful. Exits after completion. Multiple transcript files may be
  provided; they are processed in sequence starting from the same codebase.
  
  ucm version
  Prints version of Unison then quits.
  
  ucm help
  Prints this help.

Well that didn't work.
Press any key to re-launch.
```