### PR TITLE
Fix #785: Allow sequence literals as arguments to constructors

### DIFF
--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -183,7 +183,7 @@ parsePattern =
         f patterns vs =
           let loc = foldl (<>) (ann tok) $ map ann patterns
           in (Pattern.Constructor loc ref cid patterns, vs)
-    unzipPatterns f <$> many leaf
+    unzipPatterns f <$> many (leaf <|> seqLiteral)
 
   seqLiteral = Parser.seq f leaf
     where f loc = unzipPatterns ((,) . Pattern.SequenceLiteral loc)

--- a/unison-src/tests/sequence-literal-argument-parsing.u
+++ b/unison-src/tests/sequence-literal-argument-parsing.u
@@ -1,0 +1,5 @@
+type X a = X [a]
+
+f : X a -> a
+f x = case x of
+  X.X [b] -> b


### PR DESCRIPTION
This fixes #785 by allowing sequence literals, which are handled separately from all other values, as arguments to constructors.