### PR TITLE
implement `reflog` and `reset-root`

### DIFF
--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -33,6 +33,7 @@ import           Unison.Symbol                  ( Symbol )
 import qualified Unison.Codebase.BranchUtil as BranchUtil
 import Unison.DataDeclaration (Decl)
 import Unison.Type (Type)
+import Unison.Codebase.ShortBranchHash (ShortBranchHash)
 
 --import Debug.Trace
 
@@ -78,6 +79,9 @@ data Codebase m v a =
            -- number of base58 characters needed to distinguish any two references in the codebase
            , hashLength         :: m Int
            , referencesByPrefix :: Text -> m (Set Reference.Id)
+           
+           , branchHashLength   :: m Int
+           , branchHashesByPrefix :: ShortBranchHash -> m (Set Branch.Hash)
            }
 
 -- | Write all of the builtins types and IO types into the codebase

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -11,6 +11,7 @@ import qualified Unison.Builtin                as Builtin
 import           Unison.Codebase.Branch         ( Branch )
 import qualified Unison.Codebase.Branch        as Branch
 import qualified Unison.Codebase.CodeLookup    as CL
+import qualified Unison.Codebase.Reflog        as Reflog
 import qualified Unison.DataDeclaration        as DD
 import           Unison.Name                    ( Name(..) )
 import qualified Unison.Names2                 as Names
@@ -66,6 +67,9 @@ data Codebase m v a =
            , watches            :: UF.WatchKind -> m [Reference.Id]
            , getWatch           :: UF.WatchKind -> Reference.Id -> m (Maybe (Term v a))
            , putWatch           :: UF.WatchKind -> Reference.Id -> Term v a -> m ()
+           
+           , getReflog          :: m [Reflog.Entry]
+           , appendReflog       :: Text -> Branch m -> Branch m -> m ()
 
            -- list of terms of the given type
            , termsOfTypeImpl    :: Reference -> m (Set Referent)

--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -19,6 +19,7 @@ import           Unison.Codebase.Editor.RemoteRepo
 import           Unison.Codebase.Branch         ( Branch )
 import qualified Unison.Codebase.Branch        as Branch
 import           Unison.Codebase.GitError
+import qualified Unison.Codebase.Reflog        as Reflog
 import           Unison.Names3                  ( Names, Names0 )
 import           Unison.Parser                  ( Ann )
 import           Unison.Referent                ( Referent )
@@ -121,6 +122,11 @@ data Command m i v a where
   -- Any definitions in the head of the supplied branch that aren't in the target
   -- codebase are copied there.
   SyncLocalRootBranch :: Branch m -> Command m i v ()
+
+  AppendToReflog :: Text -> Branch m -> Branch m -> Command m i v ()
+
+  -- load the reflog in file (chronological) order
+  LoadReflog :: Command m i v [Reflog.Entry]
 
   SyncRemoteRootBranch ::
     RemoteRepo -> Branch m -> Command m i v (Either GitError ())

--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -36,6 +36,7 @@ import qualified Unison.Lexer                  as L
 import qualified Unison.Parser                 as Parser
 import           Unison.ShortHash               ( ShortHash )
 import Unison.Type (Type)
+import Unison.Codebase.ShortBranchHash (ShortBranchHash)
 
 
 type AmbientAbilities v = [Type v Ann]
@@ -64,7 +65,12 @@ data Command m i v a where
   -- the hash length needed to disambiguate any definition in the codebase
   CodebaseHashLength :: Command m i v Int
 
-  GetReferencesByShortHash :: ShortHash -> Command m i v (Set Reference.Id)
+  ReferencesByShortHash :: ShortHash -> Command m i v (Set Reference.Id)
+  
+  -- the hash length needed to disambiguate any branch in the codebase
+  BranchHashLength :: Command m i v Int
+  
+  BranchHashesByPrefix :: ShortBranchHash -> Command m i v (Set Branch.Hash)
 
   ParseType :: Names -> LexedSource
             -> Command m i v (Either (Parser.Err v) (Type v Ann))

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -129,8 +129,10 @@ commandLine config awaitInput setBranchRef rt notifyUser codebase =
     GetTermsOfType ty -> Codebase.termsOfType codebase ty
     GetTermsMentioningType ty -> Codebase.termsMentioningType codebase ty
     CodebaseHashLength -> Codebase.hashLength codebase
-    GetReferencesByShortHash sh ->
+    ReferencesByShortHash sh ->
       Codebase.referencesByPrefix codebase (SH.toText sh)
+    BranchHashLength -> Codebase.branchHashLength codebase
+    BranchHashesByPrefix h -> Codebase.branchHashesByPrefix codebase h
     ParseType names (src, _) -> pure $
       Parsers.parseType (Text.unpack src) (Parser.ParsingEnv mempty names)
 

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -139,6 +139,8 @@ commandLine config awaitInput setBranchRef rt notifyUser codebase =
 --      b0 <- Codebase.propagate codebase (Branch.head b)
 --      pure $ Branch.append b0 b
     Execute ppe uf -> void $ evalUnisonFile ppe uf
+    AppendToReflog reason old new -> Codebase.appendReflog codebase reason old new
+    LoadReflog -> Codebase.getReflog codebase    
 
   eval1 :: PPE.PrettyPrintEnv -> Term.AnnotatedTerm v Ann -> _
   eval1 ppe tm = do

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -518,7 +518,7 @@ loop = do
             respond . CantUndo $ if Branch.isOne root' then CantUndoPastStart
                                  else CantUndoPastMerge
           Just (_, prev) -> do
-            updateRoot root' prev "old-style undo" 
+            updateRoot root' prev "undo" 
             respond $ ShowDiff input (Branch.namesDiff prev root')
 
       AliasTermI src dest -> case (toList (getHQ'Terms src), toList (getTerms dest)) of

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -72,6 +72,7 @@ import           Unison.Codebase.SearchResult   ( SearchResult )
 import qualified Unison.Codebase.SearchResult  as SR
 import qualified Unison.Codebase.ShortBranchHash as SBH
 import qualified Unison.DataDeclaration        as DD
+import qualified Unison.Hash                   as Hash
 import qualified Unison.HashQualified          as HQ
 import qualified Unison.HashQualified'         as HQ'
 import qualified Unison.Name                   as Name
@@ -354,7 +355,8 @@ loop = do
       in case input of
       ShowReflogI -> do
         entries <- fmap reverse $ eval LoadReflog
-        numberedArgs .= fmap (Text.unpack . Reflog.toText) entries
+        numberedArgs .=
+          fmap (('#':) . Hash.base32Hexs . Causal.unRawHash . Reflog.to) entries
         respond . ShowReflog $ fmap (shortenReflogEntry sbhLength) entries
       ForkLocalBranchI src0 dest0 -> do        
         let tryUpdateDest srcb dest0 = do

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -46,6 +46,7 @@ data Input
     | PreviewMergeLocalBranchI Path' Path'
     | PullRemoteBranchI (Maybe RemoteRepo) Path'
     | PushRemoteBranchI (Maybe RemoteRepo) Path'
+    | ResetRootI (Either ShortBranchHash Path')
     -- todo: Q: Does it make sense to publish to not-the-root of a Github repo?
     --          Does it make sense to fork from not-the-root of a Github repo?
     -- change directory

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -15,9 +15,9 @@ import           Unison.Codebase.Path           ( Path' )
 import qualified Unison.Codebase.Path          as Path
 import           Unison.Codebase.Editor.RemoteRepo
 import           Unison.Reference (Reference)
-import qualified Unison.Hash as Hash
 import           Unison.ShortHash (ShortHash)
-import qualified Unison.Codebase.Causal as Causal
+import           Unison.Codebase.ShortBranchHash (ShortBranchHash)
+import qualified Unison.Codebase.ShortBranchHash as SBH
 import qualified Data.Text as Text
 
 data Event
@@ -27,12 +27,12 @@ data Event
 type Source = Text -- "id x = x\nconst a b = a"
 type SourceName = Text -- "foo.u" or "buffer 7"
 type PatchPath = Path.Split'
-type BranchId = Either Branch.Hash Path'
+type BranchId = Either ShortBranchHash Path'
 
 parseBranchId :: String -> Either String BranchId
-parseBranchId ('#':s) = case Hash.fromBase32Hex (Text.pack s) of
+parseBranchId ('#':s) = case SBH.fromText (Text.pack s) of
   Nothing -> Left "Invalid hash, expected a base32hex string."
-  Just h -> pure . Left $ Causal.RawHash h
+  Just h -> pure $ Left h
 parseBranchId s = Right <$> Path.parsePath' s
 
 data Input
@@ -40,7 +40,7 @@ data Input
     -- directory ops
     -- `Link` must describe a repo and a source path within that repo.
     -- clone w/o merge, error if would clobber
-    = ForkLocalBranchI (Either Branch.Hash Path') Path'
+    = ForkLocalBranchI (Either ShortBranchHash Path') Path'
     -- merge first causal into destination
     | MergeLocalBranchI Path' Path'
     | PreviewMergeLocalBranchI Path' Path'

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -109,6 +109,7 @@ data Input
   | FindPatchI
   | ShowDefinitionI OutputLocation [String]
   | ShowDefinitionByPrefixI OutputLocation [String]
+  | ShowReflogI
   | UpdateBuiltinsI
   | MergeBuiltinsI
   | DebugBranchHistoryI

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -46,6 +46,7 @@ import Unison.Type (Type)
 import qualified Unison.Names3 as Names
 import qualified Data.Set as Set
 import Unison.Codebase.NameSegment (NameSegment, HQSegment)
+import qualified Unison.Codebase.Reflog as Reflog
 import Unison.ShortHash (ShortHash)
 import Unison.Var (Var)
 
@@ -149,6 +150,7 @@ data Output v
   | WarnIncomingRootBranch (Set Branch.Hash)
   | ShowDiff Input Names.Diff
   | History (Maybe Int) [(Branch.Hash, Names.Diff)] HistoryTail
+  | ShowReflog [Reflog.Entry]
   | NothingTodo Input
   | NotImplemented
   | NoBranchWithHash Input Branch.Hash
@@ -261,6 +263,7 @@ isFailure o = case o of
   NothingTodo{} -> False
   ListShallow _ es -> null es
   HashAmbiguous{} -> True
+  ShowReflog{} -> False
 
 
 

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -562,7 +562,7 @@ branchHashesByPrefix codebasePath p =
   where
     filenameToHash :: String -> Maybe Branch.Hash
     filenameToHash f = case Text.splitOn "." $ Text.pack f of
-      [h, ".ub"] -> Causal.RawHash <$> Hash.fromBase32Hex h
+      [h, "ub"] -> Causal.RawHash <$> Hash.fromBase32Hex h
       _ -> Nothing
 
 -- builds a `Codebase IO v a`, given serializers for `v` and `a`

--- a/parser-typechecker/src/Unison/Codebase/Reflog.hs
+++ b/parser-typechecker/src/Unison/Codebase/Reflog.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE RecordWildCards #-}
 
 module Unison.Codebase.Reflog where
 

--- a/parser-typechecker/src/Unison/Codebase/Reflog.hs
+++ b/parser-typechecker/src/Unison/Codebase/Reflog.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Unison.Codebase.Reflog where
+
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Unison.Codebase.Branch (Hash)
+import qualified Unison.Codebase.Causal as Causal
+import qualified Unison.Hash as Hash
+
+data Entry =
+  Entry
+    { from :: Hash
+    , to :: Hash
+    , reason :: Text
+    }
+
+fromText :: Text -> Maybe Entry
+fromText t =
+  case Text.words t of
+    (Hash.fromBase32Hex -> Just old) : (Hash.fromBase32Hex -> Just new) : (Text.unwords -> reason) ->
+      Just $ Entry (Causal.RawHash old) (Causal.RawHash new) reason
+    _ -> Nothing 
+
+      
+toText :: Entry -> Text
+toText (Entry old new reason) = 
+  Text.unwords [ Hash.base32Hex . Causal.unRawHash $ old
+               , Hash.base32Hex . Causal.unRawHash $ new
+               , reason ]

--- a/parser-typechecker/src/Unison/Codebase/ShortBranchHash.hs
+++ b/parser-typechecker/src/Unison/Codebase/ShortBranchHash.hs
@@ -1,0 +1,31 @@
+module Unison.Codebase.ShortBranchHash where
+
+import qualified Unison.Codebase.Branch as Branch
+import qualified Unison.Codebase.Causal as Causal
+import qualified Unison.Hash as Hash
+import qualified Data.Text as Text
+import Data.Text (Text)
+
+newtype ShortBranchHash = 
+  ShortBranchHash { toText :: Text } 
+  deriving (Eq, Ord)
+
+toString :: ShortBranchHash -> String
+toString = Text.unpack . toText
+
+toHash :: ShortBranchHash -> Maybe Branch.Hash
+toHash = fmap Causal.RawHash . Hash.fromBase32Hex . toText
+
+fromHash :: Int -> Branch.Hash -> ShortBranchHash
+fromHash len =
+  ShortBranchHash . Text.take len . Hash.base32Hex . Causal.unRawHash
+
+-- abc -> SBH abc
+-- #abc -> SBH abc
+fromText :: Text -> Maybe ShortBranchHash
+fromText t =
+  let h0 = ShortBranchHash . Text.dropWhile (=='#') $ t
+  in const h0 <$> toHash h0
+
+instance Show ShortBranchHash where
+  show (ShortBranchHash h) = '#' : Text.unpack h

--- a/parser-typechecker/src/Unison/Codebase/ShortBranchHash.hs
+++ b/parser-typechecker/src/Unison/Codebase/ShortBranchHash.hs
@@ -4,10 +4,11 @@ import qualified Unison.Codebase.Branch as Branch
 import qualified Unison.Codebase.Causal as Causal
 import qualified Unison.Hash as Hash
 import qualified Data.Text as Text
+import qualified Data.Set as Set
 import Data.Text (Text)
 
-newtype ShortBranchHash = 
-  ShortBranchHash { toText :: Text } 
+newtype ShortBranchHash =
+  ShortBranchHash { toText :: Text } -- base32hex characters
   deriving (Eq, Ord)
 
 toString :: ShortBranchHash -> String
@@ -23,9 +24,9 @@ fromHash len =
 -- abc -> SBH abc
 -- #abc -> SBH abc
 fromText :: Text -> Maybe ShortBranchHash
-fromText t =
-  let h0 = ShortBranchHash . Text.dropWhile (=='#') $ t
-  in const h0 <$> toHash h0
+fromText t | Text.all (`Set.member` Hash.validBase32HexChars) t =
+  Just . ShortBranchHash . Text.dropWhile (=='#') $ t
+fromText _ = Nothing
 
 instance Show ShortBranchHash where
   show (ShortBranchHash h) = '#' : Text.unpack h

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -449,6 +449,22 @@ forkLocal = InputPattern "fork" ["copy.namespace"] [(Required, pathArg)
       _ -> Left (I.help forkLocal)
     )
 
+resetRoot :: InputPattern
+resetRoot = InputPattern "reset-root" [] [(Required, pathArg)]
+  (P.wrapColumn2 [
+    (makeExample resetRoot [".foo"],
+      "Reset the root namespace (along with its history) to that of the `.foo` namespace."),
+    (makeExample resetRoot ["#9dndk3kbsk13nbpeu"],
+      "Reset the root namespace (along with its history) to that of the namespace with hash `#9dndk3kbsk13nbpeu`.")
+    ])
+  (\case
+    [src] -> first fromString $ do
+     src <- Input.parseBranchId src
+     pure $ Input.ResetRootI src
+    _ -> Left (I.help resetRoot))
+
+
+
 pull :: InputPattern
 pull = InputPattern
   "pull"
@@ -907,6 +923,7 @@ validInputs =
   , test
   , execute
   , viewReflog
+  , resetRoot
   , quit
   , updateBuiltins
   , mergeBuiltins

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -618,6 +618,17 @@ resolveEdit = InputPattern
   toHash (Left  h      ) = Just h
   toHash (Right (_, hq)) = HQ'.toHash hq
 
+viewReflog :: InputPattern
+viewReflog = InputPattern
+  "reflog"
+  []
+  []
+  ("`reflog` lists the changes that have affected the root namespace")
+  (\case
+    [] -> pure Input.ShowReflogI
+    _  -> Left . warn . P.string
+              $ I.patternName viewReflog ++ " doesn't take any arguments.")
+
 edit :: InputPattern
 edit = InputPattern
   "edit"
@@ -895,6 +906,7 @@ validInputs =
   , resolveEdit
   , test
   , execute
+  , viewReflog
   , quit
   , updateBuiltins
   , mergeBuiltins

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -560,10 +560,19 @@ notifyUser dir o = case o of
   PatchInvolvesExternalDependents _ _ ->
     pure "That patch involves external dependents."
   ShowReflog [] ->  pure . P.warnCallout $ "The reflog appears to be empty!"
-  ShowReflog entries -> do
-    pure . P.numbered (\i -> P.hiBlack . fromString $ show i <> ".")
+  ShowReflog entries -> pure $ 
+    P.lines [ 
+    P.wrap $ "Here is a log of the root namespace hashes, starting with the most recent."
+          <> "You can use something like" 
+          <> IP.makeExample IP.forkLocal ["2", ".old"]
+          <> "or"
+          <> IP.makeExample IP.forkLocal [prettySBH . Output.old $ head entries, ".old"]
+          <> "to make an old namespace accessible again.",
+         "", 
+    P.numbered (\i -> P.hiBlack . fromString $ show i <> ".")
          . fmap renderEntry
          $ entries
+         ]
     where
     renderEntry :: Output.ReflogEntry -> P.Pretty CT.ColorText
     renderEntry (Output.ReflogEntry old new reason) = P.wrap $

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -69,6 +69,7 @@ library
     Unison.Codebase.Serialization
     Unison.Codebase.Serialization.PutT
     Unison.Codebase.Serialization.V1
+    Unison.Codebase.ShortBranchHash
     Unison.Codebase.TermEdit
     Unison.Codebase.TranscriptParser
     Unison.Codebase.TypeEdit

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -63,6 +63,7 @@ library
     Unison.Codebase.NameSegment
     Unison.Codebase.Path
     Unison.Codebase.Patch
+    Unison.Codebase.Reflog
     Unison.Codebase.Runtime
     Unison.Codebase.SearchResult
     Unison.Codebase.Serialization

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -99,13 +99,13 @@ Tip: You can always `undo` if this wasn't what you wanted.
 Note: The most recent namespace hash is immediately below this
       message.
 
-⊙ #cc91hvn07lr8031sf2jjtfkh9ahqvrl3d0i9s1pdkeerm31gcq7mggavgldi99613v8labva1dr4o9td8dg8bh0l2756df7du5jr83o
+⊙ #cc91hvn07l
 
   - Deletes:
   
     feature1.y
 
-⊙ #gvo5gua46buv0a3s3r2n1mrm2cq4nalfokk0mcf182f01a5tgp3s6l4ktdbn0l6eurnkcpusn2945nbr01hn0sm248rjmddfil6djng
+⊙ #gvo5gua46b
 
   + Adds / updates:
   
@@ -116,20 +116,20 @@ Note: The most recent namespace hash is immediately below this
     Original name New name(s)
     feature1.y    master.y
 
-⊙ #s6figr2tuqd0fnu2lshhu166bpumk3omoa6ufirrq4s8fjedrjq8oit5916upi0hiashkfu5rur6uhoog4in6tnhg0l8pl0q088fhh8
+⊙ #s6figr2tuq
 
   + Adds / updates:
   
     feature1.y
 
-⊙ #fp6bvfhq6tn61e6ahjvlc05a813seikigko3kk4pn1nrqdlo4tnnie9f501951qh52cvr4a85d4nefg644c9272n57gr64274emgiv0
+⊙ #fp6bvfhq6t
 
   > Moves:
   
     Original name New name
     x             master.x
 
-⊙ #cnvvpmiqi42qhkrt9q81n0c3ccp0cneblqu3o253a52u0ql32u0n7433atcso7ndhf0cbmnvjm5tgpvq35ugbaom8tov3vb0b3qacfo
+⊙ #cnvvpmiqi4
 
   + Adds / updates:
   
@@ -137,7 +137,7 @@ Note: The most recent namespace hash is immediately below this
 
 This is the start of history. Later versions are listed below.
 
-□ #itm5ganb1oh60ccs5am06ldf4hjfqubalb9ljhj5tbmfr6ao8m9rpacsohpejg324dal4vpmnine546arq3fgl8vc1862mgfthqtobo
+□ #itm5ganb1o
 
 ```
 To resurrect an old version of a namespace, you can learn its hash via the `history` command, then use `fork #namespacehash .newname`.

--- a/unison-src/transcripts/reflog.md
+++ b/unison-src/transcripts/reflog.md
@@ -1,0 +1,27 @@
+First we make two changes to the codebase, so that there's more than one line
+for the `reflog` command to display:
+
+```unison
+x = 1
+```
+```ucm
+.> add
+```
+```unison
+y = 2
+```
+```ucm
+.> add
+.> view y
+```
+```ucm
+.> reflog
+```
+
+If we `reset-root` to its previous value, `y` disappears.
+```ucm
+.> reset-root #kih4ch6383
+```
+```ucm:error
+.> view y
+```

--- a/unison-src/transcripts/reflog.output.md
+++ b/unison-src/transcripts/reflog.output.md
@@ -1,0 +1,76 @@
+First we make two changes to the codebase, so that there's more than one line
+for the `reflog` command to display:
+
+```unison
+x = 1
+```
+
+```ucm
+I found and typechecked these definitions in scratch.u. If you
+do an `add` or `update`, here's how your codebase would change:
+
+  ⍟ These new definitions are ok to `add`:
+  
+    x : builtin.Nat
+ 
+Now evaluating any watch expressions (lines starting with
+`>`)... Ctrl+C cancels.
+```
+```ucm
+.> add
+⍟ I've added these definitions:
+
+  x : builtin.Nat
+```
+```unison
+y = 2
+```
+
+```ucm
+I found and typechecked these definitions in scratch.u. If you
+do an `add` or `update`, here's how your codebase would change:
+
+  ⍟ These new definitions are ok to `add`:
+  
+    y : builtin.Nat
+ 
+Now evaluating any watch expressions (lines starting with
+`>`)... Ctrl+C cancels.
+```
+```ucm
+.> add
+⍟ I've added these definitions:
+
+  y : builtin.Nat
+.> view y
+y : builtin.Nat
+y = 2
+```
+```ucm
+.> reflog
+Here is a log of the root namespace hashes, starting with the
+most recent, along with the command that got us there. Try:
+
+  `fork 2 .old`             
+  `fork #kih4ch6383 .old`   to make an old namespace accessible
+                            again,
+                            
+  `reset-root #kih4ch6383`  to reset the root namespace and its
+                            history to that of the specified
+                            namespace.
+
+1. #n23evntj7s : add
+2. #kih4ch6383 : add
+```
+If we `reset-root` to its previous value, `y` disappears.
+```ucm
+.> reset-root #kih4ch6383
+Done.
+```
+```ucm
+.> view y
+⚠️
+
+The following names were not found in the codebase. Check your spelling.
+  y
+```


### PR DESCRIPTION
- Added `reflog` command that lists and describes changes to the root namespace
- Added `reset-root` command which points the root branch and history to the specified branch's

- Added `ShortBranchHash` to represent a branch hash prefix
  - Use `ShortBranchHash` for various output messages (namely: `history`, `reflog`)
  - Support lookup by `ShortBranchHash` for various commands (namely: `fork`, `history`, `reset-root`

see reflog.output.md for details