### PR TITLE
Show aliases in per command help

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -27,3 +27,4 @@ The format for this list: name, GitHub handle, and then optional blurb about wha
 * Silvino Escalona (@sunrisem)
 * James Sully (@sullyj3)
 * Prat Tana (@pt2121)
+* Jonas De Vuyst (@jdevuyst)

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -766,7 +766,7 @@ help = InputPattern
       [isHelp -> Just msg] -> Left msg
       [cmd] -> case Map.lookup cmd commandsByName of
         Nothing  -> Left . warn $ "I don't know of that command. Try `help`."
-        Just pat -> Left $ I.help pat
+        Just pat -> Left $ showPatternHelp pat
       _ -> Left $ warn "Use `help <cmd>` or `help`.")
     where
       commandsByName = Map.fromList [


### PR DESCRIPTION
This fixes #810, which is a request to show aliases in the per command help messages.

I figured it's also a bit confusing that when you enter `help j`, all the examples use the original `namespace` name. Hence I thought it might be useful to print both the original name and the aliases in the per command help. And it turns out there's already code that does just that.