### PR TITLE
Advertise base library on first launch

### DIFF
--- a/parser-typechecker/src/Unison/CommandLine/Main.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Main.hs
@@ -116,6 +116,11 @@ welcomeMessage dir =
          , P.wrap ("Type " <> P.hiBlue "help" <> " to get help. 😎")
          ]
 
+hintFreshCodebase :: P.Pretty P.ColorText
+hintFreshCodebase =
+  P.wrap $ "Enter " <> P.hiBlue "pull https://github.com/unisonweb/base .base"
+    <> "to set up the default base library. 🏗"
+
 main
   :: forall v
   . Var v
@@ -127,8 +132,10 @@ main
   -> IO ()
 main dir initialPath initialInputs startRuntime codebase = do
   dir' <- shortenDirectory dir
-  putPrettyLn $ welcomeMessage dir'
   root <- Codebase.getRootBranch codebase
+  putPrettyLn $ if Branch.isOne root
+    then welcomeMessage dir' <> P.newline <> P.newline <> hintFreshCodebase
+    else welcomeMessage dir'
   eventQueue <- Q.newIO
   do
     runtime                  <- startRuntime


### PR DESCRIPTION
I'm not entirely sure this is a good idea...

More than once I caught myself (as a new user) being surprised that I couldn't `use` functions and types from `.base`, only to discover I first had to pull in the base library.

Here's a tweak to the welcome message that points out to users that they may want to do this:

<img width="801" alt="Screen Shot 2019-10-16 at 23 34 00" src="https://user-images.githubusercontent.com/4509979/66935228-49fe9280-f06e-11e9-8823-afe4d9c85175.png">

The message is only shown for new codebases. I'm using `Branch.isOne` because `.builtin` would already be available. I'm actually wondering if maybe it is worth pointing out in the message that `.builtin` exists.

Or perhaps a link to the tutorial would be better.

So, as I mentioned already, I'm not entirely sure if this change is worth retaining. :)