### PR TITLE
Infix boolean operators (Fix #530)

### DIFF
--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -372,6 +372,12 @@ lexer0 scope rem =
       '_' : (wordyId -> Right (id, rem)) ->
         let pos' = incBy id $ inc pos
         in Token (Blank id) pos pos' : goWhitespace l pos' rem
+      '&' : '&' : rem -> 
+        let end = incBy "&&" pos
+        in Token (Reserved "&&") pos end : goWhitespace l end rem
+      '|' : '|' : rem -> 
+        let end = incBy "||" pos
+        in Token (Reserved "||") pos end : goWhitespace l end rem
       '|' : c : rem | isSpace c || isAlphaNum c ->
         Token (Reserved "|") pos (inc pos) : goWhitespace l (inc pos) (c:rem)
       '=' : rem@(c : _) | isSpace c || isAlphaNum c ->
@@ -652,7 +658,7 @@ keywords = Set.fromList [
   "if", "then", "else", "forall", "∀",
   "handle", "in", "unique",
   "where", "use",
-  "and", "or", "true", "false",
+  "true", "false",
   "type", "ability", "alias",
   "let", "namespace", "case", "of"]
 
@@ -686,7 +692,7 @@ reserved :: Set Char
 reserved = Set.fromList "=:`\""
 
 reservedOperators :: Set String
-reservedOperators = Set.fromList ["->", ":"]
+reservedOperators = Set.fromList ["->", ":", "&&", "||"]
 
 inc :: Pos -> Pos
 inc (Pos line col) = Pos line (col + 1)

--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -276,11 +276,11 @@ bang = P.label "bang" $ do
   e <- termLeaf
   pure $ DD.forceTerm (ann start <> ann e) (ann start) e
 
-and = label "and" $ f <$> reserved "and" <*> termLeaf <*> termLeaf
-  where f kw x y = Term.and (ann kw <> ann y) x y
+and = label "and" $ P.try (f <$>termLeaf <*> reserved "&&" <*> termLeaf)
+  where f x kw y = Term.and (ann kw <> ann y) x y
 
-or = label "or" $ f <$> reserved "or" <*> termLeaf <*> termLeaf
-  where f kw x y = Term.or (ann kw <> ann y) x y
+or = label "or" $ P.try (f <$> termLeaf <*> reserved "||" <*> termLeaf)
+  where f x kw y = Term.or (ann kw <> ann y) x y
 
 var :: Var v => L.Token v -> AnnotatedTerm v Ann
 var t = Term.var (ann t) (L.payload t)

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -206,14 +206,14 @@ pretty0 n AmbientContext { precedence = p, blockContext = bc, infixContext = ic,
                    in uses $ [pretty0 n (ac 0 Block im') tm]
     And' x y ->
       paren (p >= 10) $ PP.spaced [
-        fmt S.ControlKeyword "and",
         pretty0 n (ac 10 Normal im) x,
+        fmt S.ControlKeyword "&&",
         pretty0 n (ac 10 Normal im) y
       ]
     Or' x y ->
       paren (p >= 10) $ PP.spaced [
-        fmt S.ControlKeyword "or",
         pretty0 n (ac 10 Normal im) x,
+        fmt S.ControlKeyword "||",
         pretty0 n (ac 10 Normal im) y
       ]
     LetRecNamed' bs e -> printLet bc bs e im' uses

--- a/parser-typechecker/tests/Unison/Test/TermParser.hs
+++ b/parser-typechecker/tests/Unison/Test/TermParser.hs
@@ -155,8 +155,8 @@ test1 = scope "termparser" . tests . map parses $
     "else\n" ++
     "  s = 0\n" ++
     "  s + 2\n"
-   , "and x y"
-   , "or x y"
+   , "x && y"
+   , "x || y"
    , [r|--let r1
    let r1 : Nat
        r1 = case Optional.Some 3 of

--- a/parser-typechecker/tests/Unison/Test/TermPrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/TermPrinter.hs
@@ -105,19 +105,19 @@ test = scope "termprinter" . tests $
   , tc "[2, 3, 4]"
   , tc "[2]"
   , tc "[]"
-  , tc "and true false"
-  , tc "or false false"
-  , tc "g (and (or true false) (f x y))"
+  , tc "true && false"
+  , tc "false || false"
+  , tc "g ((true || false) && (f x y))"
   , tc "if _something then _foo else _blah"
   , tc "3.14159"
   , tc "+0"
   , tc "\"some text\""
   , pending $ tc "\"they said \\\"hi\\\"\""  -- TODO lexer doesn't support strings with quotes in
   , tc "2 : Nat"
-  , tc "x -> and x false"
-  , tc "x y -> and x y"
-  , tc "x y z -> and x y"
-  , tc "x y y -> and x y"
+  , tc "x -> x && false"
+  , tc "x y -> x && y"
+  , tc "x y z -> x && y"
+  , tc "x y y -> x && y"
   , tc "()"
   , tc "Cons"
   , tc "foo"
@@ -231,7 +231,7 @@ test = scope "termprinter" . tests $
               \    else c"
   , tcDiffRtt True "if foo\n\
             \then\n\
-            \  and true true\n\
+            \  true && true\n\
             \  12\n\
             \else\n\
             \  namespace baz where\n\
@@ -239,14 +239,14 @@ test = scope "termprinter" . tests $
             \    f x = x\n\
             \  13"
             "if foo then\n\
-            \  and true true\n\
+            \  true && true\n\
             \  12\n\
             \else\n\
             \  baz.f : Int -> Int\n\
             \  baz.f x = x\n\
             \  13" 50
   , tcBreaks 50 "if foo then\n\
-                 \  and true true\n\
+                 \  true && true\n\
                  \  12\n\
                  \else\n\
                  \  baz.f : Int -> Int\n\

--- a/parser-typechecker/tests/Unison/Test/Typechecker/TypeError.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker/TypeError.hs
@@ -19,16 +19,16 @@ import qualified Unison.Test.Common as Common
 
 test :: Test ()
 test = scope "> extractor" . tests $
-  [ y "> and true 3" Err.and
-  , y "> or true 3" Err.or
+  [ y "> true && 3" Err.and
+  , y "> true || 3" Err.or
   , y "> if 3 then 1 else 2" Err.cond
   , y "> if true then 1 else \"surprise\"" Err.ifBody
   , y "> case 3 of 3 | 3 -> 3" Err.matchGuard
   , y "> case 3 of\n 3 -> 3\n 4 -> \"surprise\"" Err.matchBody
   -- , y "> case 3 of true -> true" Err.
   , y "> [1, +1]" Err.vectorBody
-  , n "> and true ((x -> x + 1) true)" Err.and
-  , n "> or true ((x -> x + 1) true)" Err.or
+  , n "> true && ((x -> x + 1) true)" Err.and
+  , n "> true || ((x -> x + 1) true)" Err.or
   , n "> if ((x -> x + 1) true) then 1 else 2" Err.cond
   , n "> case 3 of 3 | 3 -> 3" Err.matchBody
   , y "> 1 1" Err.applyingNonFunction

--- a/unison-src/tests/guard-boolean-operators.u
+++ b/unison-src/tests/guard-boolean-operators.u
@@ -2,10 +2,10 @@ type Foo = Foo Boolean Boolean
 
 f : Foo -> Boolean
 f x = case x of
-  Foo.Foo a b | or a b -> true
+  Foo.Foo a b | a || b -> true
   _ -> false
 
 g : Foo -> Boolean
 g x = case x of
-  Foo.Foo a b | and a b -> true
+  Foo.Foo a b | a && b -> true
   _ -> false

--- a/unison-src/tests/keyword-parse.u
+++ b/unison-src/tests/keyword-parse.u
@@ -1,4 +1,4 @@
 f x = x
 
-> and (f false) false
+> (f false) && false
 -- and false false

--- a/unison-src/tests/tictactoe.u
+++ b/unison-src/tests/tictactoe.u
@@ -24,7 +24,7 @@ namespace P where
 isWin : Board -> Optional P
 isWin board =
   same : P -> P -> P -> Optional P
-  same a b c = if and (and (a P.== b) (a P.== c)) (a P./= E)
+  same a b c = if ((a P.== b) && (a P.== c)) && (a P./= E)
                then Some a
                else None
   case board of

--- a/unison-src/tests/tictactoe0.u
+++ b/unison-src/tests/tictactoe0.u
@@ -28,7 +28,7 @@ b = (Board X O X
 
 isWin board =
   same : P -> P -> P -> Optional P
-  same a b c = if and (and (a P.== b) (a P.== c)) (a P./= E)
+  same a b c = if ((a P.== b) && (a P.== c)) && (a P./= E)
                then Some a
                else None
   case board of

--- a/unison-src/tests/tictactoe2.u
+++ b/unison-src/tests/tictactoe2.u
@@ -19,7 +19,7 @@ namespace P where
 isWin : Board -> Optional P
 isWin board =
   same : P -> P -> P -> Optional P
-  same a b c = if and (and (a P.== b) (a P.== c)) (a P./= E)
+  same a b c = if ((a P.== b) && (a P.== c)) && (a P./= E)
                then Some a
                else None
   case board of


### PR DESCRIPTION
This implements infix boolean operators using the standard C-style notation.
So `and a b` is now `a && b` and `or a b`, `a || b`.
What I'm not sure about is the label in the parser. Maybe these should use the new notation too but all other labels for symbols use the symbols name instead of the actual symbol