### PR TITLE
Implement ordering for char literals (fix #850)

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/IR.hs
+++ b/parser-typechecker/src/Unison/Runtime/IR.hs
@@ -1060,6 +1060,7 @@ instance (CyclicOrd e, CyclicOrd cont) => CyclicOrd (Value e cont) where
   cyclicOrd _ _ (N x) (N y) = pure (x `compare` y)
   cyclicOrd _ _ (B x) (B y) = pure (x `compare` y)
   cyclicOrd _ _ (T x) (T y) = pure (x `compare` y)
+  cyclicOrd _ _ (C x) (C y) = pure (x `compare` y)
   cyclicOrd _ _ (Bs x) (Bs y) = pure (x `compare` y)
   cyclicOrd h1 h2 (Lam arity1 us _) (Lam arity2 us2 _) =
     COrd.bothOrd' h1 h2 arity1 arity2 us us2

--- a/unison-src/tests/methodical/universals.u
+++ b/unison-src/tests/methodical/universals.u
@@ -3,6 +3,7 @@ use Universal == < > <= >= compare
 > ([1,2,3] `compare` [1,2,3],
    [1,2,3] `compare` [1],
    [1] `compare` [1,2,3],
+   ?a `compare` ?b,
    ("hi", "there") == ("hi", "there"),
    1 < 1,
    1 < 2,

--- a/unison-src/tests/methodical/universals.ur
+++ b/unison-src/tests/methodical/universals.ur
@@ -1,6 +1,7 @@
 (+0,
  +1,
  -1,
+ -1,
  true,
  false,
  true, 


### PR DESCRIPTION
By adding a case to cyclicOrd, Universal.compare now works for character literals. (fixes #850)