### PR TITLE
Make AskInfo a Term instead of a kind of variable.

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Serialization/V1.hs
+++ b/parser-typechecker/src/Unison/Codebase/Serialization/V1.hs
@@ -494,6 +494,8 @@ putTerm putVar putA = putABT putVar putA go where
       -> putWord8 4 *> putText t
     Term.Blank _
       -> error "can't serialize term with blanks"
+    Term.AskInfo _
+      -> error "can't serialize term with AskInfo"
     Term.Ref r
       -> putWord8 5 *> putReference r
     Term.Constructor r cid

--- a/parser-typechecker/src/Unison/Codecs.hs
+++ b/parser-typechecker/src/Unison/Codecs.hs
@@ -170,6 +170,7 @@ serializeTerm x = do
         incPosition
       Blank b -> error $ "cannot serialize program with blank " ++
                          fromMaybe ""  (Blank.nameb b)
+      AskInfo _ -> error "cannot serialize program with AskInfo"
       Handle h body -> do
         hpos <- serializeTerm h
         bpos <- serializeTerm body

--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -259,10 +259,7 @@ termLeaf = do
   q <- optional (reserved "?")
   case q of
     Nothing -> pure e
-    Just q  -> pure $ Term.app
-      (ann q <> ann e)
-      (Term.var (ann e) (positionalVar q Var.askInfo))
-      e
+    Just q  -> pure $ Term.askInfo (ann q <> ann e) e
 
 delayQuote :: Var v => TermP v
 delayQuote = P.label "quote" $ do

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -233,7 +233,7 @@ pretty0 n AmbientContext { precedence = p, blockContext = bc, infixContext = ic,
     BinaryAppsPred' apps lastArg -> paren (p >= 3) $
       binaryApps apps (pretty0 n (ac 3 Normal im) lastArg)
     _ -> case (term, nonForcePred) of
-      AppsPred' f args | not $ isVarKindInfo f ->
+      AppsPred' f args ->
         paren (p >= 10) $ pretty0 n (ac 10 Normal im) f `PP.hang`
           PP.spacedMap (pretty0 n (ac 10 Normal im)) args
       _ -> case (term, nonUnitArgPred) of

--- a/parser-typechecker/src/Unison/Var.hs
+++ b/parser-typechecker/src/Unison/Var.hs
@@ -51,7 +51,6 @@ name v = case typeOf v of
   MissingResult -> "_" <> showid v
   Blank -> "_" <> showid v
   UnnamedWatch k guid -> fromString k <> "." <> guid <> showid v
-  AskInfo -> "?" <> showid v
   where
   showid (freshId -> 0) = ""
   showid (freshId -> n) = pack (show n)
@@ -61,11 +60,10 @@ uncapitalize v = nameds $ go (nameStr v) where
   go (c:rest) = toLower c : rest
   go n = n
 
-askInfo, missingResult, blank, inferInput, inferOutput, inferAbility,
+missingResult, blank, inferInput, inferOutput, inferAbility,
   inferPatternPureE, inferPatternPureV, inferPatternBindE, inferPatternBindV,
   inferTypeConstructor, inferTypeConstructorArg,
   inferOther :: Var v => v
-askInfo = typed AskInfo
 missingResult = typed MissingResult
 blank = typed Blank
 inferInput = typed (Inference Input)
@@ -91,8 +89,6 @@ data Type
   | RefNamed Reference
   -- Variables created to finish a block that doesn't end with an expression
   | MissingResult
-  -- Variables invented to query the typechecker for the type of subexpressions
-  | AskInfo
   -- Variables invented for placeholder values inserted by user or by TDNR
   | Blank
   -- An unnamed watch expression of the given kind, for instance:


### PR DESCRIPTION
Reason: It has nothing to do with variables. Var operations like freshening do not make sense for `AskInfo`.

Direct representation as a term also avoids the special treatment of the _"`AskInfo` variable applied to a term"_ pattern, which used to encode _"term inside `AskInfo`"_.

---
Also, this is a step towards #899.