### PR TITLE
add old nshash to reflog.verbose message

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -354,11 +354,11 @@ loop = do
         stepManyAtM = Unison.Codebase.Editor.HandleInput.stepManyAtM inputDescription
         updateAtM = Unison.Codebase.Editor.HandleInput.updateAtM inputDescription
       in case input of
-      ShowReflogI -> do
-        entries <- fmap reverse $ eval LoadReflog
-        numberedArgs .=
+      ShowReflogI verbose -> do
+        entries <- fmap reverse $ eval LoadReflog        
+        unless verbose $ numberedArgs .=
           fmap (('#':) . Hash.base32Hexs . Causal.unRawHash . Reflog.to) entries
-        respond . ShowReflog $ fmap (shortenReflogEntry sbhLength) entries
+        respond . ShowReflog verbose $ fmap (shortenReflogEntry sbhLength) entries
       ResetRootI src0 ->
         case src0 of
           Left hash -> resolveShortBranchHash input hash >>= \case

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -110,7 +110,7 @@ data Input
   | FindPatchI
   | ShowDefinitionI OutputLocation [String]
   | ShowDefinitionByPrefixI OutputLocation [String]
-  | ShowReflogI
+  | ShowReflogI Bool
   | UpdateBuiltinsI
   | MergeBuiltinsI
   | DebugBranchHistoryI

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -152,7 +152,7 @@ data Output v
   | WarnIncomingRootBranch (Set ShortBranchHash)
   | ShowDiff Input Names.Diff
   | History (Maybe Int) [(ShortBranchHash, Names.Diff)] HistoryTail
-  | ShowReflog [ReflogEntry]
+  | ShowReflog ListDetailed [ReflogEntry]
   | NothingTodo Input
   | NotImplemented
   | NoBranchWithHash Input ShortBranchHash

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -639,9 +639,20 @@ viewReflog = InputPattern
   "reflog"
   []
   []
-  ("`reflog` lists the changes that have affected the root namespace")
+  ("`reflog` lists the root namespace hashes resulting from recent commands")
   (\case
-    [] -> pure Input.ShowReflogI
+    [] -> pure $ Input.ShowReflogI False
+    _  -> Left . warn . P.string
+              $ I.patternName viewReflog ++ " doesn't take any arguments.")
+
+viewReflogVerbose :: InputPattern
+viewReflogVerbose = InputPattern
+  "reflog.verbose"
+  []
+  []
+  ("`reflog.verbose` lists the root namespace hashes before and after recent commands")
+  (\case
+    [] -> pure $ Input.ShowReflogI True
     _  -> Left . warn . P.string
               $ I.patternName viewReflog ++ " doesn't take any arguments.")
 
@@ -923,6 +934,7 @@ validInputs =
   , test
   , execute
   , viewReflog
+  , viewReflogVerbose
   , resetRoot
   , quit
   , updateBuiltins

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -602,6 +602,7 @@ notifyUser dir o = case o of
     where
     renderEntry :: Output.ReflogEntry -> P.Pretty CT.ColorText
     renderEntry (Output.ReflogEntry old new reason) = P.wrap $
+      P.blue (prettySBH old) <> " -> " <>
       P.blue (prettySBH new) <> " : " <> P.text reason
   History cap history tail -> pure $
     P.lines [

--- a/unison-src/transcripts/reflog.md
+++ b/unison-src/transcripts/reflog.md
@@ -16,6 +16,7 @@ y = 2
 ```
 ```ucm
 .> reflog
+.> reflog.verbose
 ```
 
 If we `reset-root` to its previous value, `y` disappears.

--- a/unison-src/transcripts/reflog.output.md
+++ b/unison-src/transcripts/reflog.output.md
@@ -72,8 +72,8 @@ y = 2
                               its history to that of the
                               specified namespace.
   
-  1. #n23evntj7s : add
-  2. #kih4ch6383 : add
+  1. #kih4ch6383 -> #n23evntj7s : add
+  2. #itm5ganb1o -> #kih4ch6383 : add
 
 ```
 If we `reset-root` to its previous value, `y` disappears.

--- a/unison-src/transcripts/reflog.output.md
+++ b/unison-src/transcripts/reflog.output.md
@@ -72,8 +72,26 @@ y = 2
                               its history to that of the
                               specified namespace.
   
-  1. #kih4ch6383 -> #n23evntj7s : add
-  2. #itm5ganb1o -> #kih4ch6383 : add
+  Use `reflog.verbose` if you need the "old" hashes from before
+  one of the commands.
+  
+  1. #n23evntj7s : add
+  2. #kih4ch6383 : add
+
+.> reflog.verbose
+
+  Here is a log of the root namespace hashes, starting with the
+  most recent, along with the command that got us there. Try:
+  
+    `fork #kih4ch6383 .old`   to make an old namespace
+                              accessible again,
+                              
+    `reset-root #kih4ch6383`  to reset the root namespace and
+                              its history to that of the
+                              specified namespace.
+  
+  #kih4ch6383 -> #n23evntj7s : add
+  #itm5ganb1o -> #kih4ch6383 : add
 
 ```
 If we `reset-root` to its previous value, `y` disappears.


### PR DESCRIPTION
The "old" hash is needed in order to revert the first action, or to revert to a codebase state that was caused out-of-band.

![image](https://user-images.githubusercontent.com/538571/67626948-2206f000-f821-11e9-99e9-1997ee51067e.png)

Initially I had just planned to add the "old" hash to the `reflog` message, but once there were two hashes on each line, I  didn't know how to populate the LoopState numbered entries (I'm open to suggestions).  I ended up creating a second `.verbose` variant instead, with old and new hashes, but no numbering:

![image](https://user-images.githubusercontent.com/538571/67627308-947ace80-f827-11e9-9d1c-ce2c1ba45a6f.png)

Another option would be for `reflog.verbose` to have numbering, but the number refers to the old hash, 
 which would be the hash adjacent to the number, but it's a little weird.

I tried to reuse logic in `OutputMessages.hs`, but it got pretty hairy in the end.   I could split it into totally separate cases if desired.