### PR TITLE
Allow boolean operators to be used in sequence

### DIFF
--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -63,7 +63,7 @@ term2 = lam term2 <|> term3
 
 term3 :: Var v => TermP v
 term3 = do
-  t <- and <|> or <|> infixApp
+  t <- infixAppOrBooleanOp
   ot <- optional (reserved ":" *> TypeParser.computationType)
   pure $ case ot of
     Nothing -> t
@@ -75,7 +75,7 @@ keywordBlock = letBlock <|> handle <|> ifthen <|> match
 -- We disallow type annotations and lambdas,
 -- just function application and operators
 blockTerm :: Var v => TermP v
-blockTerm = and <|> or <|> lam term <|> infixApp
+blockTerm = lam term <|> infixAppOrBooleanOp
 
 match :: Var v => TermP v
 match = do
@@ -92,7 +92,7 @@ match = do
 matchCase :: Var v => P v (Term.MatchCase Ann (AnnotatedTerm v Ann))
 matchCase = do
   (p, boundVars) <- parsePattern
-  guard <- optional $ reserved "|" *> (and <|> or <|> infixApp)
+  guard <- optional $ reserved "|" *> infixAppOrBooleanOp
   t <- block "->"
   pure . Term.MatchCase p (fmap (ABT.absChain' boundVars) guard) $ ABT.absChain' boundVars t
 
@@ -194,7 +194,7 @@ lam p = label "lambda" $ mkLam <$> P.try (some prefixDefinitionName <* reserved 
   where
     mkLam vs b = Term.lam' (ann (head vs) <> ann b) (map L.payload vs) b
 
-letBlock, handle, ifthen, and, or, infixApp :: Var v => TermP v
+letBlock, handle, ifthen :: Var v => TermP v
 letBlock = label "let" $ block "let"
 
 handle = label "handle" $ do
@@ -276,12 +276,6 @@ bang = P.label "bang" $ do
   e <- termLeaf
   pure $ DD.forceTerm (ann start <> ann e) (ann start) e
 
-and = label "and" $ P.try (f <$>termLeaf <*> reserved "&&" <*> termLeaf)
-  where f x kw y = Term.and (ann kw <> ann y) x y
-
-or = label "or" $ P.try (f <$> termLeaf <*> reserved "||" <*> termLeaf)
-  where f x kw y = Term.or (ann kw <> ann y) x y
-
 var :: Var v => L.Token v -> AnnotatedTerm v Ann
 var t = Term.var (ann t) (L.payload t)
 
@@ -298,9 +292,15 @@ term4 = f <$> some termLeaf
     f [] = error "'some' shouldn't produce an empty list"
 
 -- e.g. term4 + term4 - term4
-infixApp = label "infixApp"
-  $ chainl1 term4 (f <$> (hashQualifiedInfixTerm <* optional semi))
-  where f op lhs rhs = Term.apps op [(ann lhs, lhs), (ann rhs, rhs)]
+-- or term4 || term4 && term4
+infixAppOrBooleanOp :: Var v => TermP v
+infixAppOrBooleanOp = chainl1 term4 (or <|> and <|> infixApp)
+    where or = orf <$> label "or" (reserved "||")
+          orf op lhs rhs =  Term.or (ann op <> ann rhs) lhs rhs
+          and = andf <$> label "and" (reserved "&&")
+          andf op lhs rhs = Term.and (ann op <> ann rhs) lhs rhs
+          infixApp = infixAppf <$> label "infixApp" (hashQualifiedInfixTerm <* optional semi)
+          infixAppf op lhs rhs = Term.apps op [(ann lhs, lhs), (ann rhs, rhs)]
 
 typedecl :: Var v => P v (L.Token v, Type v Ann)
 typedecl =

--- a/unison-src/tests/boolean-ops-in-sequence.u
+++ b/unison-src/tests/boolean-ops-in-sequence.u
@@ -1,0 +1,1 @@
+test = true || false && true


### PR DESCRIPTION
Allows boolean operators to be parsed like infix applications.
`true || false && true` does now parse. Before it would throw a parse error.
Boolean operators and infix applications still have the same precedence