### PR TITLE
Don't just assume RefNamed vars not to occur in input to Term.unhashComponent

### DIFF
--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -186,7 +186,7 @@ makeSelfContained'
 makeSelfContained' code uf = do
   let deps0 = Term.dependencies . snd <$> (UF.allWatches uf <> UF.terms uf)
   deps <- foldM (transitiveDependencies code) Set.empty (Set.unions deps0)
-  let refVar r = Var.typed (Var.RefNamed r)
+  let refVar r = Var.refNamed r
 --  let termName r = PPE.termName pp (Referent.Ref r)
 --      typeName r = PPE.typeName pp r
   decls <- fmap catMaybes . forM (toList deps) $ \case

--- a/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
@@ -326,7 +326,7 @@ propagate errorPPE patch b = case validatePatch patch of
           Reference.DerivedId id -> do
             mtm <- eval $ LoadTerm id
             tm  <- maybe (fail $ "Missing term with id " <> show id) pure mtm
-            pure $ Just (Var.typed (Var.RefNamed termRef), (termRef, tm, tp))
+            pure $ Just (Var.refNamed termRef, (termRef, tm, tp))
           _ -> pure Nothing
       unhash m =
         let f (ref, _oldTm, oldTyp) (_ref, newTm) = (ref, newTm, oldTyp)
@@ -348,7 +348,7 @@ propagate errorPPE patch b = case validatePatch patch of
           decl  <- maybe (fail $ "Missing type declaration " <> show typeRef)
                          pure
                          declm
-          pure $ Just (Var.typed (Var.RefNamed typeRef), (typeRef, decl))
+          pure $ Just (Var.refNamed typeRef, (typeRef, decl))
         _ -> pure Nothing
       unhash m =
         let f (ref, _oldDecl) (_ref, newDecl) = (ref, newDecl)

--- a/parser-typechecker/src/Unison/DataDeclaration.hs
+++ b/parser-typechecker/src/Unison/DataDeclaration.hs
@@ -175,6 +175,17 @@ constructorVars dd = fst <$> constructors dd
 constructorNames :: Var v => DataDeclaration' v a -> [Text]
 constructorNames dd = Var.name <$> constructorVars dd
 
+-- | All variables mentioned in the given data declaration.
+-- Includes both term and type variables, both free and bound.
+allVars :: Ord v => DataDeclaration' v a -> Set v
+allVars (DataDeclaration _ _ bound ctors) = Set.unions $
+  Set.fromList bound : [ Set.insert v (Set.fromList $ ABT.allVars tp) | (_,v,tp) <- ctors ]
+
+-- | All variables mentioned in the given declaration.
+-- Includes both term and type variables, both free and bound.
+allVars' :: Ord v => Decl v a -> Set v
+allVars' = allVars . either toDataDecl id
+
 bindNames :: Var v
           => Set v
           -> Names0

--- a/parser-typechecker/src/Unison/Term.hs
+++ b/parser-typechecker/src/Unison/Term.hs
@@ -16,6 +16,7 @@ import Unison.Prelude
 
 import Prelude hiding (and,or)
 import qualified Control.Monad.Writer.Strict as Writer
+import           Data.Bifunctor (second)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Text as Text
@@ -874,17 +875,19 @@ etaNormalForm t = t
 
 -- This converts `Reference`s it finds that are in the input `Map`
 -- back to free variables
-unhashComponent :: Var v
-                => Map v (Reference, AnnotatedTerm v a)
-                -> Map v (Reference, AnnotatedTerm v a)
+unhashComponent :: forall v a. Var v
+                => Map Reference (AnnotatedTerm v a)
+                -> Map Reference (v, AnnotatedTerm v a)
 unhashComponent m = let
-  refToVar = Map.fromList [ (r, v) | (v, (r,_)) <- Map.toList m ]
+  m' :: Map Reference (v, AnnotatedTerm v a)
+  m' = Map.mapWithKey assignVar m where
+    assignVar r t = (Var.refNamed r, t)
   unhash1 = ABT.rebuildUp' go where
-    go e@(Ref' r) = case Map.lookup r refToVar of
+    go e@(Ref' r) = case Map.lookup r m' of
       Nothing -> e
-      Just v -> var (ABT.annotation e) v
+      Just (v, _) -> var (ABT.annotation e) v
     go e = e
-  in Map.fromList [ (v, (r, unhash1 e)) | (v, (r,e)) <- Map.toList m ]
+  in second unhash1 <$> m'
 
 hashComponents
   :: Var v => Map v (AnnotatedTerm v a) -> Map v (Reference, AnnotatedTerm v a)

--- a/parser-typechecker/src/Unison/Var.hs
+++ b/parser-typechecker/src/Unison/Var.hs
@@ -33,6 +33,9 @@ freshIn = ABT.freshIn
 named :: Var v => Text -> v
 named n = typed (User n)
 
+refNamed :: Var v => Reference -> v
+refNamed = typed . RefNamed
+
 name :: Var v => v -> Text
 name v = case typeOf v of
   User n -> n <> showid v

--- a/parser-typechecker/tests/Unison/Test/DataDeclaration.hs
+++ b/parser-typechecker/tests/Unison/Test/DataDeclaration.hs
@@ -2,16 +2,21 @@
 
 module Unison.Test.DataDeclaration where
 
-import qualified Unison.Test.Common as Common
-import EasyTest
-import Text.RawString.QQ
-import Unison.UnisonFile (UnisonFile(..))
-import Unison.Symbol (Symbol)
-import qualified Unison.Var as Var
-import qualified Data.Map as Map
-import Unison.Parser (Ann)
-import Unison.Parsers (unsafeParseFile)
-import Unison.DataDeclaration (hashDecls)
+import qualified Data.Map               as Map
+import           Data.Map                ( Map, (!) )
+import           EasyTest
+import           Text.RawString.QQ
+import qualified Unison.DataDeclaration as DD
+import           Unison.DataDeclaration  ( DataDeclaration'(..), Decl, hashDecls )
+import qualified Unison.Hash            as Hash
+import           Unison.Parser           ( Ann )
+import           Unison.Parsers          ( unsafeParseFile )
+import qualified Unison.Reference       as R
+import           Unison.Symbol           ( Symbol )
+import qualified Unison.Test.Common     as Common
+import qualified Unison.Type            as Type
+import           Unison.UnisonFile       ( UnisonFile(..) )
+import qualified Unison.Var             as Var
 
 test :: Test ()
 test = scope "datadeclaration" $
@@ -26,7 +31,8 @@ test = scope "datadeclaration" $
     scope "List != SnocList" . expect $ hashOf "List" /= hashOf "SnocList",
     scope "Ping != Pong" . expect $ hashOf "Ping" /= hashOf "Pong",
     scope "Ping == Ling'" . expect $ hashOf "Ping" == hashOf "Ling'",
-    scope "Pong == Long'" . expect $ hashOf "Pong" == hashOf "Long'"
+    scope "Pong == Long'" . expect $ hashOf "Pong" == hashOf "Long'",
+    scope "unhashComponent" unhashComponentTest
   ]
 
 file :: UnisonFile Symbol Ann
@@ -67,3 +73,49 @@ type Ling' a = Ling' a (Long' a)
 --   let p = unsafeParseTerm s builtins :: Term Symbol
 --   noteScoped $ "parsing: " ++ s ++ "\n  " ++ show p
 --   ok
+
+unhashComponentTest :: Test ()
+unhashComponentTest = tests
+  [ scope "invented-vars-are-fresh" inventedVarsFreshnessTest
+  ]
+  where
+    inventedVarsFreshnessTest =
+      let
+        var = Type.var ()
+        app = Type.app ()
+        forall = Type.forall ()
+        (-->) = Type.arrow ()
+        h = Hash.unsafeFromBase32Hex "abcd"
+        ref = R.Derived h 0 1
+        a = Var.refNamed ref
+        b = Var.named "b"
+        nil = Var.named "Nil"
+        cons = Var.refNamed ref
+        listRef = ref
+        listType = Type.ref () listRef
+        listDecl = DataDeclaration {
+          modifier = DD.Structural,
+          annotation = (),
+          bound = [],
+          constructors' =
+           [ ((), nil, forall a (listType `app` var a))
+           , ((), cons, forall b (var b --> listType `app` var b --> listType `app` var b))
+           ]
+        }
+        component :: Map R.Reference (Decl Symbol ())
+        component = Map.singleton listRef (Right listDecl)
+        component' :: Map R.Reference (Symbol, Decl Symbol ())
+        component' = DD.unhashComponent component
+        (listVar, Right listDecl') = component' ! listRef
+        listType' = var listVar
+        constructors = Map.fromList $ DD.constructors listDecl'
+        nilType' = constructors ! nil
+        z = Var.named "z"
+      in tests
+        [ -- check that `nil` constructor's type did not collapse to `forall a. a a`,
+          -- which would happen if the var invented for `listRef` was simply `Var.refNamed listRef`
+          expectEqual (forall z (listType' `app` var z)) nilType'
+        , -- check that the variable assigned to `listRef` is different from `cons`,
+          -- which would happen if the var invented for `listRef` was simply `Var.refNamed listRef`
+          expectNotEqual cons listVar
+        ]

--- a/parser-typechecker/tests/Unison/Test/Term.hs
+++ b/parser-typechecker/tests/Unison/Test/Term.hs
@@ -1,37 +1,54 @@
 {-# Language OverloadedStrings #-}
+{-# Language TypeApplications #-}
 
 module Unison.Test.Term where
 
 import EasyTest
-import           Unison.Symbol ( Symbol )
-import qualified Unison.Term   as Term
-import qualified Unison.Type   as Type
-import qualified Unison.Var    as Var
+import qualified Data.Map         as Map
+import           Data.Map         ( (!) )
+import qualified Unison.Hash      as Hash
+import qualified Unison.Reference as R
+import           Unison.Symbol    ( Symbol )
+import qualified Unison.Term      as Term
+import qualified Unison.Type      as Type
+import qualified Unison.Var       as Var
 
 test :: Test ()
-test = scope "term" $ tests [
-  scope "Term.substTypeVar" $ do
-    -- check that capture avoidance works in substTypeVar
-    let v s = Var.nameds s :: Symbol
-        tv s = Type.var() (v s)
-        v1 s = Var.freshenId 1 (v s)
-        tm :: Term.Term Symbol
-        tm = Term.ann() (Term.ann()
-                           (Term.nat() 42)
-                           (Type.introOuter() (v "a") $
-                             Type.arrow() (tv "a") (tv "x")))
-                        (Type.forall() (v "a") (tv "a"))
-        tm' = Term.substTypeVar (v "x") (tv "a") tm
-        expected =
-          Term.ann() (Term.ann()
-                        (Term.nat() 42)
-                        (Type.introOuter() (v1 "a") $
-                          Type.arrow() (Type.var() $ v1 "a") (tv "a")))
-                     (Type.forall() (v1 "a") (Type.var() $ v1 "a"))
-    note $ show tm'
-    note $ show expected
-    expect $ tm == tm
-    expect $ tm' == tm'
-    expect $ tm' == expected
-    ok
+test = scope "term" $ tests
+  [ scope "Term.substTypeVar" $ do
+      -- check that capture avoidance works in substTypeVar
+      let v s = Var.nameds s :: Symbol
+          tv s = Type.var() (v s)
+          v1 s = Var.freshenId 1 (v s)
+          tm :: Term.Term Symbol
+          tm = Term.ann() (Term.ann()
+                             (Term.nat() 42)
+                             (Type.introOuter() (v "a") $
+                               Type.arrow() (tv "a") (tv "x")))
+                          (Type.forall() (v "a") (tv "a"))
+          tm' = Term.substTypeVar (v "x") (tv "a") tm
+          expected =
+            Term.ann() (Term.ann()
+                          (Term.nat() 42)
+                          (Type.introOuter() (v1 "a") $
+                            Type.arrow() (Type.var() $ v1 "a") (tv "a")))
+                       (Type.forall() (v1 "a") (Type.var() $ v1 "a"))
+      note $ show tm'
+      note $ show expected
+      expect $ tm == tm
+      expect $ tm' == tm'
+      expect $ tm' == expected
+      ok
+  , scope "Term.unhashComponent" $
+      let h = Hash.unsafeFromBase32Hex "abcd"
+          ref = R.Derived h 0 1
+          v1 = Var.refNamed @Symbol ref
+          -- input component: `ref = \v1 -> ref`
+          component = Map.singleton ref (Term.lam () v1 (Term.ref () ref))
+          component' = Term.unhashComponent component
+          -- expected unhashed component: `v2 = \v1 -> v2`, where `v2 /= v1`,
+          -- i.e. `v2` cannot be just `ref` converted to a ref-named variable,
+          -- since that would collide with `v1`
+          (v2, _) = component' ! ref
+      in expect $ v2 /= v1
   ]

--- a/yaks/easytest/src/EasyTest.hs
+++ b/yaks/easytest/src/EasyTest.hs
@@ -65,6 +65,11 @@ expectEqual :: (Eq a, Show a) => a -> a -> Test ()
 expectEqual expected actual = if expected == actual then ok
                   else crash $ unlines ["", (show actual), "** did not equal expected value **", (show expected)]
 
+expectNotEqual :: (Eq a, Show a) => a -> a -> Test ()
+expectNotEqual forbidden actual =
+  if forbidden /= actual then ok
+  else crash $ unlines ["", show actual, "** did equal the forbidden value **", show forbidden]
+
 expectJust :: HasCallStack => Maybe a -> Test a
 expectJust Nothing = crash "expected Just, got Nothing"
 expectJust (Just a) = ok >> pure a


### PR DESCRIPTION
`Term.unhashComponent` used to accept some variables and just assumed that they do not appear in the terms of the component. Such assumption is not captured by the type signature of `unhashComponent`.

To drop the assumption:
 1. let `unhashComponent` make up (`RefNamed`) variables itself instead of taking them as part of input;
 2. freshen the made up `RefNamed` variables appropriately (don't just assume that no one else used `RefNamed` variables).

Add a test that previously would have failed.

---
Also, this is a step towards #899 that will later allow to eliminate `RefNamed` vars altogether.