### PR TITLE
display synthetic reflog entries for initial and external changes

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -370,7 +370,7 @@ loop = do
         convertEntries Nothing acc entries@(Reflog.Entry old _ _ : _) =
           convertEntries
             (Just old)
-            (Output.ReflogEntry (SBH.fromHash sbhLength old) "(initial reflogged branch)" : acc)
+            (Output.ReflogEntry (SBH.fromHash sbhLength old) "(initial reflogged namespace)" : acc)
             entries
         convertEntries (Just lastHash) acc entries@(Reflog.Entry old new reason : rest) =
           if lastHash /= old then

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -160,7 +160,7 @@ data Output v
 --  deriving (Show)
 
 data ReflogEntry =
-  ReflogEntry { old :: ShortBranchHash, new :: ShortBranchHash, reason :: Text }
+  ReflogEntry { hash :: ShortBranchHash, reason :: Text }
 
 data ShallowListEntry v a
   = ShallowTermEntry Referent HQSegment (Maybe (Type v a))

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -577,20 +577,21 @@ notifyUser dir o = case o of
     pure "That patch involves external dependents."
   ShowReflog [] ->  pure . P.warnCallout $ "The reflog appears to be empty!"
   ShowReflog entries -> pure $ 
-    P.lines [ 
+    P.lines [
     P.wrap $ "Here is a log of the root namespace hashes,"
           <> "starting with the most recent,"
           <> "along with the command that got us there."
           <> "Try:",
     "",
+    -- `head . tail` is safe: entries never has 1 entry, and [] is handled above
+    let e2 = head . tail $ entries in
     P.indentN 2 . P.wrapColumn2 $ [
       (IP.makeExample IP.forkLocal ["2", ".old"],
         ""),
-      (IP.makeExample IP.forkLocal [prettySBH . Output.old $ head entries
-                                   , ".old"],
+      (IP.makeExample IP.forkLocal [prettySBH . Output.hash $ e2, ".old"],
        "to make an old namespace accessible again,"),
       (mempty,mempty),
-      (IP.makeExample IP.resetRoot [prettySBH . Output.old $ head entries],
+      (IP.makeExample IP.resetRoot [prettySBH . Output.hash $ e2],
         "to reset the root namespace and its history to that of the specified"
          <> "namespace.")
     ],
@@ -601,8 +602,8 @@ notifyUser dir o = case o of
          ]
     where
     renderEntry :: Output.ReflogEntry -> P.Pretty CT.ColorText
-    renderEntry (Output.ReflogEntry old new reason) = P.wrap $
-      P.blue (prettySBH new) <> " : " <> P.text reason
+    renderEntry (Output.ReflogEntry hash reason) = P.wrap $
+      P.blue (prettySBH hash) <> " : " <> P.text reason
   History cap history tail -> pure $
     P.lines [
       note $ "The most recent namespace hash is immediately below this message.", "",

--- a/unison-src/transcripts/reflog.output.md
+++ b/unison-src/transcripts/reflog.output.md
@@ -74,7 +74,7 @@ y = 2
   
   1. #n23evntj7s : add
   2. #kih4ch6383 : add
-  3. #itm5ganb1o : (initial reflogged branch)
+  3. #itm5ganb1o : (initial reflogged namespace)
 
 ```
 If we `reset-root` to its previous value, `y` disappears.

--- a/unison-src/transcripts/reflog.output.md
+++ b/unison-src/transcripts/reflog.output.md
@@ -74,6 +74,7 @@ y = 2
   
   1. #n23evntj7s : add
   2. #kih4ch6383 : add
+  3. #itm5ganb1o : (initial reflogged branch)
 
 ```
 If we `reset-root` to its previous value, `y` disappears.


### PR DESCRIPTION
The reflog works by logging the branch the namespace hash before and after each user change.  The current reflog output just displays the "after" hash, under the assumption that the "before" hash will be available on the previous line (i.e. is the previous "after" hash).  When this assumption doesn't hold (e.g. an external change occurs, or when there is no previous line), we miss seeing the relevant "before" hash.

Current output:
![image](https://user-images.githubusercontent.com/538571/67626948-2206f000-f821-11e9-99e9-1997ee51067e.png)

This PR output:
![image](https://user-images.githubusercontent.com/538571/67708151-0b33db00-f992-11e9-9da9-1891fd60ef08.png)

This PR would close / replace PR #897, which lists "before" and "after" hashes in a new `reflog.verbose` command, which looks nice, but creates a hairy situation wrt LoopState numbering, since each line has two hashes on it.  It also doesn't call out the external change, though it might not be important to do so.

Compare to #897 output:
![image](https://user-images.githubusercontent.com/538571/67627308-947ace80-f827-11e9-9d1c-ce2c1ba45a6f.png)

I guess we could have two numbers per line, but it's never been done before!!!
```
  2.  #5bnuu08nik -> 1. #0h32n0ihd3 : add
  4.  #5bnuu08nik -> 3. #0h32n0ihd3 : add
  6.  #5bnuu08nik -> 5. #c3k2p9uhgk : delete.namespace .sheepshead.Suit
```
If we want to do that later, we might borrow from the implementation in #897.  

In any case, I think this is ready to merge.
