### PR TITLE
In makeSelfContained, freshen the invented RefNamed vars.

### DIFF
--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -186,7 +186,7 @@ makeSelfContained'
 makeSelfContained' code uf = do
   let deps0 = Term.dependencies . snd <$> (UF.allWatches uf <> UF.terms uf)
   deps <- foldM (transitiveDependencies code) Set.empty (Set.unions deps0)
-  let refVar r = Var.typed (Var.RefNamed r)
+  let refVar r = Var.refNamed r
 --  let termName r = PPE.termName pp (Referent.Ref r)
 --      typeName r = PPE.typeName pp r
   decls <- fmap catMaybes . forM (toList deps) $ \case

--- a/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
@@ -326,7 +326,7 @@ propagate errorPPE patch b = case validatePatch patch of
           Reference.DerivedId id -> do
             mtm <- eval $ LoadTerm id
             tm  <- maybe (fail $ "Missing term with id " <> show id) pure mtm
-            pure $ Just (Var.typed (Var.RefNamed termRef), (termRef, tm, tp))
+            pure $ Just (Var.refNamed termRef, (termRef, tm, tp))
           _ -> pure Nothing
       unhash m =
         let f (ref, _oldTm, oldTyp) (_ref, newTm) = (ref, newTm, oldTyp)
@@ -348,7 +348,7 @@ propagate errorPPE patch b = case validatePatch patch of
           decl  <- maybe (fail $ "Missing type declaration " <> show typeRef)
                          pure
                          declm
-          pure $ Just (Var.typed (Var.RefNamed typeRef), (typeRef, decl))
+          pure $ Just (Var.refNamed typeRef, (typeRef, decl))
         _ -> pure Nothing
       unhash m =
         let f (ref, _oldDecl) (_ref, newDecl) = (ref, newDecl)

--- a/parser-typechecker/src/Unison/DataDeclaration.hs
+++ b/parser-typechecker/src/Unison/DataDeclaration.hs
@@ -175,6 +175,17 @@ constructorVars dd = fst <$> constructors dd
 constructorNames :: Var v => DataDeclaration' v a -> [Text]
 constructorNames dd = Var.name <$> constructorVars dd
 
+-- | All variables mentioned in the given data declaration.
+-- Includes both term and type variables, both free and bound.
+allVars :: Ord v => DataDeclaration' v a -> Set v
+allVars (DataDeclaration _ _ bound ctors) = Set.unions $
+  Set.fromList bound : [ Set.insert v (Set.fromList $ ABT.allVars tp) | (_,v,tp) <- ctors ]
+
+-- | All variables mentioned in the given declaration.
+-- Includes both term and type variables, both free and bound.
+allVars' :: Ord v => Decl v a -> Set v
+allVars' = allVars . either toDataDecl id
+
 bindNames :: Var v
           => Set v
           -> Names0

--- a/parser-typechecker/src/Unison/Term.hs
+++ b/parser-typechecker/src/Unison/Term.hs
@@ -284,6 +284,16 @@ unannotate = go
 wrapV :: Ord v => AnnotatedTerm v a -> AnnotatedTerm (ABT.V v) a
 wrapV = vmap ABT.Bound
 
+-- | All variables mentioned in the given term.
+-- Includes both term and type variables, both free and bound.
+allVars :: Ord v => AnnotatedTerm v a -> Set v
+allVars tm = Set.fromList $
+  ABT.allVars tm ++ [ v | tp <- allTypes tm, v <- ABT.allVars tp ]
+  where
+  allTypes tm = case tm of
+    Ann' e tp -> tp : allTypes e
+    _ -> foldMap allTypes $ ABT.out tm
+
 freeVars :: AnnotatedTerm' vt v a -> Set v
 freeVars = ABT.freeVars
 

--- a/parser-typechecker/src/Unison/UnisonFile.hs
+++ b/parser-typechecker/src/Unison/UnisonFile.hs
@@ -309,3 +309,13 @@ environmentFor names dataDecls0 effectDecls0 = do
     if null overlaps && null unknownTypeRefs
     then pure $ Env dataDecls' effectDecls' names'
     else Left (unknownTypeRefs ++ overlaps)
+
+allVars :: Ord v => UnisonFile v a -> Set v
+allVars (UnisonFile ds es ts ws) = Set.unions
+  [ Map.keysSet ds
+  , foldMap (DD.allVars . snd) ds
+  , Map.keysSet es
+  , foldMap (DD.allVars . toDataDecl . snd) es
+  , Set.unions [ Set.insert v (Term.allVars t) | (v, t) <- ts ]
+  , Set.unions [ Set.insert v (Term.allVars t) | (v, t) <- join . Map.elems $ ws ]
+  ]

--- a/parser-typechecker/src/Unison/Var.hs
+++ b/parser-typechecker/src/Unison/Var.hs
@@ -33,6 +33,9 @@ freshIn = ABT.freshIn
 named :: Var v => Text -> v
 named n = typed (User n)
 
+refNamed :: Var v => Reference -> v
+refNamed = typed . RefNamed
+
 name :: Var v => v -> Text
 name v = case typeOf v of
   User n -> n <> showid v

--- a/parser-typechecker/tests/Suite.hs
+++ b/parser-typechecker/tests/Suite.hs
@@ -23,6 +23,7 @@ import qualified Unison.Test.Typechecker.TypeError as TypeError
 import qualified Unison.Test.UnisonSources as UnisonSources
 import qualified Unison.Test.Util.Bytes as Bytes
 import qualified Unison.Test.Var as Var
+import qualified Unison.Test.Codebase as Codebase
 import qualified Unison.Test.Codebase.FileCodebase as FileCodebase
 
 test :: Test ()
@@ -46,6 +47,7 @@ test = tests
   , FileCodebase.test
   , ABT.test
   , Var.test
+  , Codebase.test
  ]
 
 main :: IO ()

--- a/parser-typechecker/tests/Unison/Test/Codebase.hs
+++ b/parser-typechecker/tests/Unison/Test/Codebase.hs
@@ -1,0 +1,41 @@
+{-# Language OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Unison.Test.Codebase where
+
+import           Data.Functor.Identity
+import qualified Data.Map                   as Map
+import           Data.Map                    ( (!) )
+import           EasyTest
+import qualified Unison.Codebase            as Codebase
+import           Unison.Codebase.CodeLookup  ( CodeLookup(..) )
+import qualified Unison.Hash                as Hash
+import qualified Unison.Reference           as R
+import           Unison.Symbol               ( Symbol )
+import qualified Unison.Term                as Term
+import qualified Unison.UnisonFile          as UF
+import qualified Unison.Var                 as Var
+
+test :: Test ()
+test = scope "codebase" $ tests
+  [ scope "makeSelfContained" $
+    let h = Hash.unsafeFromBase32Hex "abcd"
+        ref = R.Derived h 0 1
+        v1 = Var.refNamed @Symbol ref
+        foo = Var.named "foo"
+        -- original binding: `foo = \v1 -> ref`
+        binding = (foo, Term.lam () v1 (Term.ref () ref))
+        uf = UF.UnisonFile mempty mempty [binding] mempty
+        code :: CodeLookup Symbol Identity ()
+        code = CodeLookup
+          { getTerm = \rid -> pure $
+              if R.DerivedId rid == ref then Just (Term.int () 42)
+              else Nothing
+          , getTypeDeclaration = \_ -> pure Nothing
+          }
+        -- expected binding after makeSelfContained: `foo = \v1 -> v2`, where `v2 /= v1`
+        UF.UnisonFile _ _ (Map.fromList -> bindings) _ = runIdentity $ Codebase.makeSelfContained' code uf
+        Term.LamNamed' _ (Term.Var' v2) = bindings ! foo
+      in expect $ v2 /= v1
+  ]

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -279,6 +279,7 @@ executable tests
   hs-source-dirs: tests
   other-modules:
     Unison.Test.ABT
+    Unison.Test.Codebase
     Unison.Test.Codebase.Causal
     Unison.Test.Codebase.FileCodebase
     Unison.Test.Codebase.Path


### PR DESCRIPTION
Do not simply assume `RefNamed` vars to automatically be fresh, but freshen them appropriately, i.e. wrt. all vars in the `UnisonFile` and its dependencies.

A test is added that would have failed previously.

---
This is a step towards [simplifying the `Var` typeclass](https://github.com/unisonweb/unison/issues/899). It will allow to eliminate `RefNamed` vars altogether.