### PR TITLE
Fix a bug in isSubtype

### DIFF
--- a/parser-typechecker/tests/Suite.hs
+++ b/parser-typechecker/tests/Suite.hs
@@ -19,6 +19,7 @@ import qualified Unison.Test.TermParser as TermParser
 import qualified Unison.Test.TermPrinter as TermPrinter
 import qualified Unison.Test.Type as Type
 import qualified Unison.Test.TypePrinter as TypePrinter
+import qualified Unison.Test.Typechecker as Typechecker
 import qualified Unison.Test.Typechecker.TypeError as TypeError
 import qualified Unison.Test.UnisonSources as UnisonSources
 import qualified Unison.Test.Util.Bytes as Bytes
@@ -48,6 +49,7 @@ test = tests
   , ABT.test
   , Var.test
   , Codebase.test
+  , Typechecker.test
  ]
 
 main :: IO ()

--- a/parser-typechecker/tests/Unison/Test/Typechecker.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker.hs
@@ -14,7 +14,7 @@ test = scope "typechecker" $ tests
   ]
 
 isSubtypeTest :: Test ()
-isSubtypeTest = pending $
+isSubtypeTest =
   let
     symbol i n = Symbol i (Var.User n)
     forall v t = Type.forall () v t
@@ -25,8 +25,7 @@ isSubtypeTest = pending $
     lhs = forall a (var a) -- ∀a. a
     rhs_ i = var (a_ i)    -- a_i
   in
-    -- check that `∀a. a <: a_i`
-    -- (At the time of writing, the test fails for i = 2, 3.)
+    -- check that `∀a. a <: a_i` (used to fail for i = 2, 3)
     tests [ expectSubtype lhs (rhs_ i) | i <- [0 .. 5] ]
   where
     expectSubtype t1 t2 =

--- a/parser-typechecker/tests/Unison/Test/Typechecker.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker.hs
@@ -1,0 +1,34 @@
+{-# Language OverloadedStrings #-}
+
+module Unison.Test.Typechecker where
+
+import           EasyTest
+import           Unison.Symbol       ( Symbol(..) )
+import qualified Unison.Type        as Type
+import qualified Unison.Typechecker as Typechecker
+import qualified Unison.Var         as Var
+
+test :: Test ()
+test = scope "typechecker" $ tests
+  [ scope "isSubtype" isSubtypeTest
+  ]
+
+isSubtypeTest :: Test ()
+isSubtypeTest = pending $
+  let
+    symbol i n = Symbol i (Var.User n)
+    forall v t = Type.forall () v t
+    var v = Type.var () v
+
+    a = symbol 0 "a"
+    a_ i = symbol i "a"
+    lhs = forall a (var a) -- ∀a. a
+    rhs_ i = var (a_ i)    -- a_i
+  in
+    -- check that `∀a. a <: a_i`
+    -- (At the time of writing, the test fails for i = 2, 3.)
+    tests [ expectSubtype lhs (rhs_ i) | i <- [0 .. 5] ]
+  where
+    expectSubtype t1 t2 =
+     scope ("isSubtype (" <> show t1 <> ") (" <> show t2 <> ")")
+           (expect $ Typechecker.isSubtype t1 t2)

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -295,6 +295,7 @@ executable tests
     Unison.Test.TermPrinter
     Unison.Test.Type
     Unison.Test.TypePrinter
+    Unison.Test.Typechecker
     Unison.Test.Typechecker.Components
     Unison.Test.Typechecker.TypeError
     Unison.Test.UnisonSources


### PR DESCRIPTION
Checking that

```
∀a. a  <:  a_2
```

where `a_2` is a variable with name `"a"` and id `2` (not a variable with name `"a_2"`) used to incorrectly return `false`.

The issue was that `Context.freshenVar` could have returned as fresh a variable that was already present in the context.

The implemented fix is to _"reserve"_ variables before adding them to the context if the variables were not themselves returned by `freshenVar`. Reserving a variable ensures it can't be returned from `freshenVar` later.

The actual fix is 5 lines of code: the line `reserveAll (TypeVar.underlying <$> vars)` in `isSubtype'` plus 4 lines of `reserveAll` implementation. However, it was quite hard to track down the issue. Therefore, I took additional measures to detect such bugs earlier. The commits go as follows:
 1. Add a pending test demonstrating the issue.
 2. Instead of `isSubtype` returning `false`, make the compiler crash because of creating an ill-formed context (#887 bearing fruit, after a small tweak 😎). Had to also tweak `Context.succeeds` to not swallow `CompilerBug`s.
 3. Be even more cautious: even if the context extension does not immediately result in an ill-formed context, crash if the added vars are not "reserved".
 4. Implement the fix.