### PR TITLE
A few improvements to the typechecking result

### DIFF
--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -28,7 +28,7 @@ import           Unison.Parser              (Ann)
 import qualified Unison.Parsers             as Parsers
 import qualified Unison.Referent            as Referent
 import           Unison.Reference           (Reference)
-import           Unison.Result              (Note (..), Result, pattern Result, ResultT)
+import           Unison.Result              (Note (..), Result, pattern Result, ResultT, CompilerBug(..))
 import qualified Unison.Result              as Result
 import           Unison.Term                (AnnotatedTerm)
 import qualified Unison.Term                as Term
@@ -52,8 +52,8 @@ type NamedReference v = Typechecker.NamedReference v Ann
 type Result' v = Result (Seq (Note v Ann))
 
 convertNotes :: Ord v => Typechecker.Notes v ann -> Seq (Note v ann)
-convertNotes (Typechecker.Notes es is) =
-  (TypeError <$> es) <> (TypeInfo <$> Seq.fromList is') where
+convertNotes (Typechecker.Notes bugs es is) =
+  (CompilerBug . TypecheckerBug <$> bugs) <> (TypeError <$> es) <> (TypeInfo <$> Seq.fromList is') where
   is' = snd <$> List.uniqueBy' f ([(1::Word)..] `zip` Foldable.toList is)
   f (_, Context.TopLevelComponent cs) = Right [ v | (v,_,_) <- cs ]
   f (i, _) = Left i

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -598,7 +598,6 @@ renderTypeError e env src = case e of
       , "Type: "
       , renderType' env typ
       ]
-    C.CompilerBug c -> "CompilerBug: " <> fromString (show c)
     C.AbilityCheckFailure ambient requested c -> mconcat
       [ "AbilityCheckFailure: "
       , "ambient={"

--- a/parser-typechecker/src/Unison/Typechecker.hs
+++ b/parser-typechecker/src/Unison/Typechecker.hs
@@ -21,12 +21,14 @@ import           Control.Monad.State        (State, StateT, execState, get,
                                              modify)
 import           Control.Monad.Writer
 import qualified Data.Map                   as Map
+import           Data.Sequence.NonEmpty     (nonEmptySeqToSeq)
 import qualified Data.Text                  as Text
 import qualified Unison.ABT                 as ABT
 import qualified Unison.Blank               as B
 import           Unison.Referent            (Referent)
 import           Unison.Result              (pattern Result, Result,
                                              ResultT, runResultT)
+import qualified Unison.Result              as Result
 import           Unison.Term                (AnnotatedTerm)
 import qualified Unison.Term                as Term
 import           Unison.Type                (Type)
@@ -43,18 +45,22 @@ type Name = Text
 type Term v loc = AnnotatedTerm v loc
 
 data Notes v loc = Notes {
+  bugs   :: Seq (Context.CompilerBug v loc),
   errors :: Seq (Context.ErrorNote v loc),
   infos  :: Seq (Context.InfoNote v loc)
 }
 
 instance Semigroup (Notes v loc) where
-  Notes es is <> Notes es' is' = Notes (es <> es') (is <> is')
+  Notes bs es is <> Notes bs' es' is' = Notes (bs <> bs') (es <> es') (is <> is')
 
 instance Monoid (Notes v loc) where
-  mempty = Notes mempty mempty
+  mempty = Notes mempty mempty mempty
 
 convertResult :: Context.Result v loc a -> Result (Notes v loc) a
-convertResult (Context.Result es is ma) = Result (Notes es is) ma
+convertResult = \case
+  Context.Success is a          -> Result (Notes mempty mempty is) (Just a)
+  Context.TypeError es is       -> Result (Notes mempty (nonEmptySeqToSeq es) is) Nothing
+  Context.CompilerBug bug es is -> Result (Notes [bug] es is) Nothing
 
 data NamedReference v loc =
   NamedReference { fqn :: Name, fqnType :: Type v loc
@@ -142,18 +148,17 @@ synthesize
   -> Term v loc
   -> ResultT (Notes v loc) f (Type v loc)
 synthesize env t = let
-  (Context.Result es is ot) = Context.synthesizeClosed
+  result = convertResult $ Context.synthesizeClosed
     (ABT.vmap TypeVar.Universal <$> view ambientAbilities env)
     (view typeLookup env)
     (Term.vtmap TypeVar.Universal t)
-  in tell (Notes es is) *> MaybeT (pure $ fmap lowerType ot)
+  in Result.hoist (pure . runIdentity) $ fmap lowerType result
 
 isSubtype :: Var v => Type v loc -> Type v loc -> Bool
 isSubtype t1 t2 =
   case Context.isSubtype (tvar $ void t1) (tvar $ void t2) of
-    Context.Result es _ ob -> fromMaybe
-      (error $ "some errors occurred during subtype checking " ++ show es)
-      ob
+    Left bug -> error $ "compiler bug encountered: " ++ show bug
+    Right b -> b
   where tvar = ABT.vmap TypeVar.Universal
 
 isEqual :: Var v => Type v loc -> Type v loc -> Bool
@@ -181,13 +186,18 @@ synthesizeAndResolve env = do
   (tp, notes) <- listen . lift $ synthesize env tm
   typeDirectedNameResolution notes tp env
 
+compilerBug :: Context.CompilerBug v loc -> Result (Notes v loc) ()
+compilerBug bug = do
+  tell $ Notes [bug] mempty mempty
+  Control.Monad.Fail.fail ""
+
 typeError :: Context.ErrorNote v loc -> Result (Notes v loc) ()
 typeError note = do
-  tell $ Notes [note] mempty
+  tell $ Notes mempty [note] mempty
   Control.Monad.Fail.fail ""
 
 btw :: Monad f => Context.InfoNote v loc -> ResultT (Notes v loc) f ()
-btw note = tell $ Notes mempty [note]
+btw note = tell $ Notes mempty mempty [note]
 
 liftResult :: Monad f => Result (Notes v loc) a -> TDNR f v loc a
 liftResult = lift . MaybeT . WriterT . pure . runIdentity . runResultT
@@ -287,19 +297,16 @@ typeDirectedNameResolution oldNotes oldType env = do
     -> Result (Notes v loc) [Context.Suggestion v loc]
   resolve inferredType (NamedReference fqn foundType replace) =
     -- We found a name that matches. See if the type matches too.
-    let Result subNotes subResult = convertResult
-          $ Context.isSubtype (Type.toTypeVar foundType) inferredType
-    in  case subResult of
-                  -- Something unexpected went wrong with the subtype check
-          Nothing -> const [] <$> traverse_ typeError (errors subNotes)
-          -- Suggest the import if the type matches.
-          Just b  -> pure
-            [ Context.Suggestion
-                fqn
-                (Type.toTypeVar foundType)
-                replace
-                (if b then Context.Exact else Context.WrongType)
-            ]
+    case Context.isSubtype (Type.toTypeVar foundType) inferredType of
+      Left bug -> const [] <$> compilerBug bug
+      -- Suggest the import if the type matches.
+      Right b  -> pure
+        [ Context.Suggestion
+            fqn
+            (Type.toTypeVar foundType)
+            replace
+            (if b then Context.Exact else Context.WrongType)
+        ]
 
 -- | Check whether a term matches a type, using a
 -- function to resolve the type of @Ref@ constructors

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -50,7 +50,6 @@ import           Control.Monad.State            ( get
                                                 , StateT
                                                 , runStateT
                                                 )
-import           Control.Monad.Writer           ( MonadWriter(..) )
 import           Data.Bifunctor                 ( first
                                                 , second
                                                 )
@@ -59,6 +58,10 @@ import           Data.List
 import           Data.List.NonEmpty             ( NonEmpty )
 import qualified Data.Map                      as Map
 import qualified Data.Sequence                 as Seq
+import           Data.Sequence.NonEmpty         ( NonEmptySeq
+                                                , appendSeq
+                                                , nonEmptySeqToSeq
+                                                )
 import qualified Data.Set                      as Set
 import qualified Data.Text                     as Text
 import qualified Unison.ABT                    as ABT
@@ -112,51 +115,65 @@ data Env v loc = Env { freshId :: Word64, ctx :: Context v loc }
 type DataDeclarations v loc = Map Reference (DataDeclaration' v loc)
 type EffectDeclarations v loc = Map Reference (EffectDeclaration' v loc)
 
-data Result v loc a = Result { errors :: Seq (ErrorNote v loc)
-                             , infos :: Seq (InfoNote v loc)
-                             , resultValue :: Maybe a
-                             } deriving (Functor)
+data Result v loc a = Success (Seq (InfoNote v loc)) a
+                    | TypeError (NonEmptySeq (ErrorNote v loc)) (Seq (InfoNote v loc))
+                    | CompilerBug (CompilerBug v loc)
+                                  (Seq (ErrorNote v loc)) -- type errors before hitting the bug
+                                  (Seq (InfoNote v loc))  -- info notes before hitting the bug
+                    deriving (Functor)
 
 instance Applicative (Result v loc) where
-  pure = Result mempty mempty . Just
-  Result es is a <*> Result es' is' a' =
-    Result (es <> es') (is <> is') (a <*> a')
-
-instance Alternative (Result v loc) where
-  empty = Result mempty mempty Nothing
-  a <|> b = if isJust $ resultValue a then a else b
+  pure = Success mempty
+  CompilerBug bug es is <*> _                       = CompilerBug bug es is
+  r                     <*> CompilerBug bug es' is' = CompilerBug bug (typeErrors r <> es') (infoNotes r <> is')
+  TypeError es is       <*> r'                      = TypeError (appendSeq es (typeErrors r')) (is <> infoNotes r')
+  Success is _          <*> TypeError es' is'       = TypeError es' (is <> is')
+  Success is f          <*> Success is' a           = Success (is <> is') (f a)
 
 instance Monad (Result v loc) where
-  Result es is a >>= f =
-    let Result es' is' b = traverse f a
-     in joinMaybe $ Result (es <> es') (is <> is') b
-
-instance MonadWriter
-           (Seq (ErrorNote v loc), Seq (InfoNote v loc))
-           (Result v loc)
-  where
-    tell (es, is) = Result es is (Just ())
-    listen (Result es is ma) = Result es is ((, (es, is)) <$> ma)
-    pass (Result es is maf) =
-      joinMaybe $ traverse (\(a, f) -> tell (f (es, is)) *> pure a) maf
-
-joinMaybe :: Result v loc (Maybe a) -> Result v loc a
-joinMaybe (Result v loc ma) = Result v loc (join ma)
-
--- Emit an errorNote without failing
--- errorNote' :: Cause v loc -> Result v loc ()
--- errorNote' cause = tell (pure (ErrorNote cause mempty), mempty)
+  s@(Success _ a)       >>= f = s *> f a
+  TypeError es is       >>= _ = TypeError es is
+  CompilerBug bug es is >>= _ = CompilerBug bug es is
 
 btw' :: InfoNote v loc -> Result v loc ()
-btw' note = tell (mempty, pure note)
+btw' note = Success (Seq.singleton note) ()
 
--- | Typechecking monad
-newtype M v loc a = M {
-  runM :: MEnv v loc -> Result v loc (a, Env v loc)
+typeErrors :: Result v loc a -> Seq (ErrorNote v loc)
+typeErrors = \case
+  TypeError es _     -> nonEmptySeqToSeq es
+  CompilerBug _ es _ -> es
+  Success _ _        -> mempty
+
+infoNotes :: Result v loc a -> Seq (InfoNote v loc)
+infoNotes = \case
+  TypeError _ is     -> is
+  CompilerBug _ _ is -> is
+  Success is _       -> is
+
+mapErrors :: (ErrorNote v loc -> ErrorNote v loc) -> Result v loc a -> Result v loc a
+mapErrors f r = case r of
+  TypeError es is -> TypeError (f <$> es) is
+  CompilerBug bug es is -> CompilerBug bug (f <$> es) is
+  s@(Success _ _) -> s
+
+newtype MT v loc f a = MT {
+  runM :: MEnv v loc -> f (a, Env v loc)
 }
 
+-- | Typechecking monad
+type M v loc = MT v loc (Result v loc)
+
+-- | Typechecking computation that, unless it crashes
+-- with a compiler bug, always produces a value.
+type TotalM v loc = MT v loc (Either (CompilerBug v loc))
+
 liftResult :: Result v loc a -> M v loc a
-liftResult r = M (\m -> (, env m) <$> r)
+liftResult r = MT (\m -> (, env m) <$> r)
+
+liftTotalM :: TotalM v loc a -> M v loc a
+liftTotalM (MT m) = MT $ \menv -> case m menv of
+  Left bug -> CompilerBug bug mempty mempty
+  Right a  -> Success mempty a
 
 -- errorNote :: Cause v loc -> M v loc ()
 -- errorNote = liftResult . errorNote
@@ -168,7 +185,7 @@ modEnv :: (Env v loc -> Env v loc) -> M v loc ()
 modEnv f = modEnv' $ ((), ) . f
 
 modEnv' :: (Env v loc -> (a, Env v loc)) -> M v loc a
-modEnv' f = M (\menv -> pure . f $ env menv)
+modEnv' f = MT (\menv -> pure . f $ env menv)
 
 data Unknown = Data | Effect deriving Show
 
@@ -188,6 +205,7 @@ data CompilerBug v loc
   -- `IllegalContextExtension ctx elem msg`
   --     extending `ctx` with `elem` would make `ctx` ill-formed, as explained by `msg`
   | IllegalContextExtension (Context v loc) (Element v loc) String
+  | OtherBug String
   deriving Show
 
 data PathElement v loc
@@ -244,7 +262,6 @@ data Cause v loc
   | IllFormedType (Context v loc)
   | UnknownSymbol loc v
   | UnknownTerm loc v [Suggestion v loc] (Type v loc)
-  | CompilerBug (CompilerBug v loc)
   | AbilityCheckFailure [Type v loc] [Type v loc] (Context v loc) -- ambient, requested
   | EffectConstructorWrongArgCount ExpectedArgCount ActualArgCount Reference ConstructorId
   | MalformedEffectBind (Type v loc) (Type v loc) [Type v loc] -- type of ctor, type of ctor result
@@ -277,11 +294,7 @@ scope' p (ErrorNote cause path) = ErrorNote cause (path `mappend` pure p)
 
 -- Add `p` onto the end of the `path` of any `ErrorNote`s emitted by the action
 scope :: PathElement v loc -> M v loc a -> M v loc a
-scope p (M m) = M go
- where
-  go menv =
-    let (Result errors infos r) = m menv
-    in  Result (scope' p <$> errors) infos r
+scope p (MT m) = MT (mapErrors (scope' p) . m)
 
 -- | The typechecking environment
 data MEnv v loc = MEnv {
@@ -572,16 +585,13 @@ extendN ctx es = foldM (flip extend) ctx es
 
 -- | doesn't combine notes
 orElse :: M v loc a -> M v loc a -> M v loc a
-orElse m1 m2 = M go where
+orElse m1 m2 = MT go where
   go menv = runM m1 menv <|> runM m2 menv
-
--- If the action fails, preserve all the notes it emitted and then return the
--- provided `a`; if the action succeeds, we're good, just use its result
-recover :: a -> M v loc a -> M v loc a
-recover ifFail (M action) = M go where
-  go menv = case action menv of
-    Result es is Nothing -> Result es is $ Just (ifFail, env menv)
-    r -> r
+  s@(Success _ _)         <|> _ = s
+  TypeError _ _           <|> r = r
+  CompilerBug _ _ _       <|> r = r -- swallowing bugs for now: when checking whether a type annotation
+                                    -- is redundant, typechecking without that annotation might result in
+                                    -- a CompilerBug that we want `orElse` to recover from
 
 -- getMaybe :: Result v loc a -> Result v loc (Maybe a)
 -- getMaybe = hoistMaybe Just
@@ -606,18 +616,14 @@ shouldPerformAbilityCheck t = do
   pure $ all (/= t) skip
 
 compilerCrash :: CompilerBug v loc -> M v loc a
-compilerCrash bug = failWith $ CompilerBug bug
+compilerCrash bug = liftResult $ CompilerBug bug mempty mempty
 
 failWith :: Cause v loc -> M v loc a
 failWith cause =
-  M (const $ Result (pure $ ErrorNote cause mempty) mempty Nothing)
+  liftResult $ TypeError (pure $ ErrorNote cause mempty) mempty
 
 compilerCrashResult :: CompilerBug v loc -> Result v loc a
-compilerCrashResult bug =
-  Result (pure $ ErrorNote (CompilerBug bug) mempty) mempty Nothing
-
-failSecretlyAndDangerously :: M v loc a
-failSecretlyAndDangerously = empty
+compilerCrashResult bug = CompilerBug bug mempty mempty
 
 getDataDeclaration :: Reference -> M v loc (DataDeclaration' v loc)
 getDataDeclaration r = do
@@ -707,12 +713,12 @@ loc = ABT.annotation
 -- Prepends the provided abilities onto the existing ambient for duration of `m`
 withEffects :: [Type v loc] -> M v loc a -> M v loc a
 withEffects abilities' m =
-  M (\menv -> runM m (menv { abilities = abilities' ++ abilities menv }))
+  MT (\menv -> runM m (menv { abilities = abilities' ++ abilities menv }))
 
 -- Replaces the ambient abilities with the provided for duration of `m`
 withEffects0 :: [Type v loc] -> M v loc a -> M v loc a
 withEffects0 abilities' m =
-  M (\menv -> runM m (menv { abilities = abilities' }))
+  MT (\menv -> runM m (menv { abilities = abilities' }))
 
 
 synthesizeApps :: (Foldable f, Var v, Ord loc) => Type v loc -> f (Term v loc) -> M v loc (Type v loc)
@@ -1632,15 +1638,15 @@ verifyClosedTerm t = do
   ok1 <- verifyClosed t id
   let freeTypeVars = Map.toList $ Term.freeTypeVarAnnotations t
       reportError (v, locs) = for_ locs $ \loc ->
-        recover () (failWith (UnknownSymbol loc (TypeVar.underlying v)))
+        failWith (UnknownSymbol loc (TypeVar.underlying v))
   for_ freeTypeVars reportError
-  when (not ok1 || (not . null) freeTypeVars) $ failSecretlyAndDangerously
+  when (not ok1 || (not . null) freeTypeVars) $ compilerCrash (OtherBug "impossible")
 
 verifyClosed :: (Traversable f, Ord v) => ABT.Term f v a -> (v -> v2) -> M v2 a Bool
 verifyClosed t toV2 =
   let isBoundIn v t = Set.member v (snd (ABT.annotation t))
       loc t = fst (ABT.annotation t)
-      go t@(ABT.Var' v) | not (isBoundIn v t) = recover False $ failWith (UnknownSymbol (loc t) $ toV2 v)
+      go t@(ABT.Var' v) | not (isBoundIn v t) = failWith (UnknownSymbol (loc t) $ toV2 v)
       go _ = pure True
   in all id <$> ABT.foreachSubterm go (ABT.annotateBound t)
 
@@ -1655,12 +1661,12 @@ annotateRefs synth = ABT.visit f where
   f _ = Nothing
 
 run
-  :: (Var v, Ord loc)
+  :: (Var v, Ord loc, Functor f)
   => [Type v loc]
   -> DataDeclarations v loc
   -> EffectDeclarations v loc
-  -> M v loc a
-  -> Result v loc a
+  -> MT v loc f a
+  -> f a
 run ambient datas effects m =
   fmap fst
     . runM m
@@ -1681,24 +1687,22 @@ synthesizeClosed' abilities term = do
   setContext ctx0 -- restore the initial context
   pure $ generalizeExistentials ctx t
 
--- Check if the given typechecking action succeeds
-succeeds :: M v loc a -> M v loc Bool
+-- Check if the given typechecking action succeeds.
+succeeds :: M v loc a -> TotalM v loc Bool
 succeeds m = do
   e <- ask
-  let Result es is r = runM m e
-      bugs = Seq.filter isBug es where
-        isBug = \case ErrorNote (CompilerBug _) _ -> True
-                      _                           -> False
-  if Seq.null bugs then pure $ isJust r
-  else liftResult (Result bugs is Nothing)
+  case runM m e of
+    Success _ _ -> pure True
+    TypeError _ _ -> pure False
+    CompilerBug bug _ _ -> MT (\_ -> Left bug)
 
 -- Check if `t1` is a subtype of `t2`. Doesn't update the typechecking context.
-isSubtype' :: (Var v, Ord loc) => Type v loc -> Type v loc -> M v loc Bool
-isSubtype' type1 type2 = do
+isSubtype' :: (Var v, Ord loc) => Type v loc -> Type v loc -> TotalM v loc Bool
+isSubtype' type1 type2 = succeeds $ do
   let vars = Set.toList $ Set.union (ABT.freeVars type1) (ABT.freeVars type2)
   reserveAll (TypeVar.underlying <$> vars)
   appendContext (Var <$> vars)
-  succeeds $ subtype type1 type2
+  subtype type1 type2
 
 -- `isRedundant userType inferredType` returns `True` if the `userType`
 -- is equal "up to inferred abilities" to `inferredType`.
@@ -1727,16 +1731,16 @@ isRedundant userType0 inferredType0 = do
   -- type would have caused the program not to typecheck! Ex: if user writes
   -- `: Nat -> Nat` when it has an inferred type of `a -> a`. So we only
   -- need to check the other direction to determine redundancy.
-  isSubtype' userType inferredType <* setContext ctx0
+  (liftTotalM $ isSubtype' userType inferredType) <* setContext ctx0
 
 -- Public interface to `isSubtype`
 isSubtype
-  :: (Var v, Ord loc) => Type v loc -> Type v loc -> Result v loc Bool
+  :: (Var v, Ord loc) => Type v loc -> Type v loc -> Either (CompilerBug v loc) Bool
 isSubtype t1 t2 =
   run [] Map.empty Map.empty (isSubtype' t1 t2)
 
 isEqual
-  :: (Var v, Ord loc) => Type v loc -> Type v loc -> Result v loc Bool
+  :: (Var v, Ord loc) => Type v loc -> Type v loc -> Either (CompilerBug v loc) Bool
 isEqual t1 t2 =
   (&&) <$> isSubtype t1 t2 <*> isSubtype t2 t1
 
@@ -1760,27 +1764,23 @@ instance (Ord loc, Var v) => Show (Context v loc) where
     showElem _ (Marker v) = "|"++Text.unpack (Var.name v)++"|"
 
 -- MEnv v loc -> (Seq (ErrorNote v loc), (a, Env v loc))
-instance Monad (M v loc) where
-  return a = M (\menv -> pure (a, env menv))
-  m >>= f = M go where
+instance Monad f => Monad (MT v loc f) where
+  return a = MT (\menv -> pure (a, env menv))
+  m >>= f = MT go where
     go menv = do
       (a, env1) <- runM m menv
       runM (f a) (menv { env = env1 })
 
-instance MonadFail.MonadFail (M v loc) where
+instance Monad f => MonadFail.MonadFail (MT v loc f) where
   fail = error
 
-instance Applicative (M v loc) where
-  pure = return
+instance Monad f => Applicative (MT v loc f) where
+  pure a = MT (\menv -> pure (a, env menv))
   (<*>) = ap
 
-instance Functor (M v loc) where
-  fmap = liftM
+instance Functor f => Functor (MT v loc f) where
+  fmap f (MT m) = MT (\menv -> fmap (first f) (m menv))
 
-instance MonadReader (MEnv v loc) (M v loc) where
-  ask = M (\e -> pure (e, env e))
-  local f m = M $ runM m . f
-
-instance Alternative (M v loc) where
-  empty = liftResult empty
-  a <|> b = a `orElse` b
+instance Monad f => MonadReader (MEnv v loc) (MT v loc f) where
+  ask = MT (\e -> pure (e, env e))
+  local f m = MT $ runM m . f

--- a/parser-typechecker/tests/Suite.hs
+++ b/parser-typechecker/tests/Suite.hs
@@ -20,6 +20,7 @@ import qualified Unison.Test.TermPrinter as TermPrinter
 import qualified Unison.Test.Type as Type
 import qualified Unison.Test.TypePrinter as TypePrinter
 import qualified Unison.Test.Typechecker as Typechecker
+import qualified Unison.Test.Typechecker.Context as Context
 import qualified Unison.Test.Typechecker.TypeError as TypeError
 import qualified Unison.Test.UnisonSources as UnisonSources
 import qualified Unison.Test.Util.Bytes as Bytes
@@ -50,6 +51,7 @@ test = tests
   , Var.test
   , Codebase.test
   , Typechecker.test
+  , Context.test
  ]
 
 main :: IO ()

--- a/parser-typechecker/tests/Unison/Test/Typechecker/Context.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker/Context.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Unison.Test.Typechecker.Context ( test )
+where
+
+import           Data.Foldable               ( for_ )
+import           EasyTest
+import           Unison.Symbol               ( Symbol )
+import qualified Unison.Typechecker.Context as Context
+import qualified Unison.Term                as Term
+import qualified Unison.Type                as Type
+import qualified Unison.Var                 as Var
+
+test :: Test ()
+test = scope "context" $ tests
+  [ scope "verifyClosedTerm" verifyClosedTermTest
+  ]
+
+type TV = Context.TypeVar Symbol ()
+
+verifyClosedTermTest :: Test ()
+verifyClosedTermTest = tests
+  [ scope "report-all-free-vars" $
+      let
+        a = Var.named @Symbol "a"
+        b = Var.named @Symbol "b"
+        a' = Var.named @TV "a'"
+        b' = Var.named @TV "b'"
+        -- (a : a')(b : b')
+        t = Term.app()
+              (Term.ann() (Term.var() a) (Type.var() a'))
+              (Term.ann() (Term.var() b) (Type.var() b'))
+        res = Context.synthesizeClosed [] mempty t
+        errors = Context.typeErrors res
+        expectUnknownSymbol (Context.ErrorNote cause _) = case cause of
+          Context.UnknownSymbol _ _ -> ok
+          e -> crash $ "Unexpected type error " <> show e
+      in do
+        expectEqual 4 (length errors) -- there are 4 unknown symbols: a, a', b, b'
+        for_ errors expectUnknownSymbol
+  ]

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -299,6 +299,7 @@ executable tests
     Unison.Test.TypePrinter
     Unison.Test.Typechecker
     Unison.Test.Typechecker.Components
+    Unison.Test.Typechecker.Context
     Unison.Test.Typechecker.TypeError
     Unison.Test.UnisonSources
     Unison.Test.Util.Bytes

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -202,6 +202,7 @@ library
     mutable-containers,
     network,
     network-simple,
+    non-empty-sequence,
     process,
     prelude-extras,
     random,


### PR DESCRIPTION
1. A bug in the typechecker is not a type error, so don't treat it like one. Make `CompilerBug` a separate case of `Context.Result`.
   - This makes it immediately obvious that `Context.orElse` is swallowing typechecker bugs and, indeed, there are some ~bugs~ failing tests that surface after changing `orElse` to not swallow bugs. ~I might investigate those later.~ See the comment below.
2. Make `Context.Result` more precise: don't allow it to represent illegal state, like producing an error and at the same time returning a value, or returning neither a value nor an error.
   - This, for example, made the implementation of the unsafe method `failSecretlyAndDangerously` impossible.
3. In addition to the typechecking computation `M` that may succeed, fail with a type error or fail with a bug, add and use `TotalM` for computations that may not fail with a type error, like `isSubtype`.
   - Callers of `isSubtype` then don't have to handle the impossible case.
   - Implementation-wise, both `M` and `TotalM` are just instantiations of a more general `MT`.