### PR TITLE
View/edit multiple definitions

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1176,7 +1176,11 @@ loop = do
         branch <- getAt $ Path.toAbsolutePath currentPath' branchPath'
         let names0 = Branch.toNames0 (Branch.head branch)
         -- checkTodo only needs the local references to check for obsolete defs
-        respond . TodoOutput ppe =<< checkTodo patch names0
+        todo <- checkTodo patch names0
+        numberedArgs .=
+          (Text.unpack . Reference.toText . view _2 <$>
+             fst (TO.todoFrontierDependents todo))
+        respond $ TodoOutput ppe todo
 
       TestI showOk showFail -> do
         let

--- a/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
@@ -26,7 +26,7 @@ import Unison.Parser (Ann)
 import Unison.Prelude
 import Unison.PrettyTerminal
 import Unison.Symbol (Symbol)
-import Unison.CommandLine.Main (asciiartUnison)
+import Unison.CommandLine.Main (asciiartUnison, expandNumber)
 import qualified Data.Char as Char
 import qualified Data.Map as Map
 import qualified Data.Text as Text
@@ -126,7 +126,7 @@ run dir stanzas codebase = do
       output :: String -> IO ()
       output msg = do
         hide <- readIORef hidden
-        when (not hide) $ modifyIORef' out (\acc -> acc <> pure msg)
+        unless hide $ modifyIORef' out (\acc -> acc <> pure msg)
 
       awaitInput = do
         cmd <- atomically (Q.tryDequeue cmdQueue)
@@ -138,13 +138,11 @@ run dir stanzas codebase = do
           Just (Just p@(UcmCommand path lineTxt)) -> do
             curPath <- readIORef pathRef
             numberedArgs <- readIORef numberedArgsRef
-            let expandNumber s = case readMay s of
-                  Just i -> fromMaybe (show i) . atMay numberedArgs $ i - 1
-                  Nothing -> s
-            if (curPath /= path) then do
+            if curPath /= path then do
               atomically $ Q.undequeue cmdQueue (Just p)
               pure $ Right (SwitchBranchI (Path.absoluteToPath' path))
-            else case fmap expandNumber . words . Text.unpack $ lineTxt of
+            else case (>>= expandNumber numberedArgs)
+                       . words . Text.unpack $ lineTxt of
               [] -> awaitInput
               cmd:args -> do
                 output ("\n" <> show p <> "\n")
@@ -184,7 +182,7 @@ run dir stanzas codebase = do
                   Ucm hide errOk cmds -> do
                     writeIORef hidden hide
                     writeIORef allowErrors errOk
-                    output $ "```ucm"
+                    output "```ucm"
                     traverse_ (atomically . Q.enqueue cmdQueue . Just) cmds
                     atomically . Q.enqueue cmdQueue $ Nothing
                     awaitInput
@@ -304,9 +302,9 @@ untilFence = do
         txt <- P.takeWhileP (Just "unfenced") (/= '`')
         eof <- P.lookAhead (P.optional P.eof)
         case eof of
-          Just _ -> pure $ foldMap id (acc <> pure txt)
+          Just _ -> pure $ fold (acc <> pure txt)
           Nothing -> go (acc <> pure start <> pure txt)
-      Just _ -> pure $ foldMap id acc
+      Just _ -> pure $ fold acc
 
 word' :: Text -> P Text
 word' txt = P.try $ do
@@ -315,7 +313,7 @@ word' txt = P.try $ do
   pure txt
 
 word :: Text -> P Text
-word txt = word' txt
+word = word'
 
 -- token :: P a -> P a
 -- token p = p <* spaces

--- a/parser-typechecker/src/Unison/CommandLine/Main.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Main.hs
@@ -41,6 +41,26 @@ import qualified Unison.Util.Pretty as P
 import qualified Unison.Util.TQueue as Q
 import Text.Regex.TDFA
 
+-- Expand a numeric argument like `1` or a range like `3-9`
+expandNumber :: [String] -> String -> [String]
+expandNumber numberedArgs s =
+  maybe [s]
+        (map (\i -> fromMaybe (show i) . atMay numberedArgs $ i - 1))
+        expandedNumber
+ where
+  rangeRegex = "([0-9]+)-([0-9]+)" :: String
+  (junk,_,moreJunk, ns) =
+    s =~ rangeRegex :: (String, String, String, [String])
+  expandedNumber =
+    case readMay s of
+      Just i -> Just [i]
+      Nothing ->
+        -- check for a range
+        case (junk, moreJunk, ns) of
+          ("", "", [from, to]) ->
+            (\x y -> [x..y]) <$> readMay from <*> readMay to
+          _ -> Nothing
+
 getUserInput
   :: (MonadIO m, Line.MonadException m)
   => Map String InputPattern
@@ -57,28 +77,12 @@ getUserInput patterns codebase branch currentPath numberedArgs =
       P.toANSI 80 ((P.green . P.shown) currentPath <> fromString prompt)
     case line of
       Nothing -> pure QuitI
-      Just l -> case parseInput patterns . (>>= expandNumber) . words $ l of
-        Left msg -> do
-          liftIO $ putPrettyLn msg
-          go
-        Right i -> pure i
-  expandNumber s =
-    maybe [s]
-          (map (\i -> fromMaybe (show i) . atMay numberedArgs $ i - 1))
-          expandedNumber
-   where
-    rangeRegex = "([0-9]+)-([0-9]+)" :: String
-    (junk,_,moreJunk, ns) =
-      s =~ rangeRegex :: (String, String, String, [String])
-    expandedNumber =
-      case readMay s of
-        Just i -> Just [i]
-        Nothing ->
-          -- check for a range
-          case (junk, moreJunk, ns) of
-            ("", "", [from, to]) ->
-              (\x y -> [x..y]) <$> readMay from <*> readMay to
-            _ -> Nothing
+      Just l ->
+        case parseInput patterns . (>>= expandNumber numberedArgs) . words $ l of
+          Left msg -> do
+            liftIO $ putPrettyLn msg
+            go
+          Right i -> pure i
   settings    = Line.Settings tabComplete (Just ".unisonHistory") True
   tabComplete = Line.completeWordWithPrev Nothing " " $ \prev word ->
     -- User hasn't finished a command name, complete from command names
@@ -198,7 +202,7 @@ main dir initialPath initialInputs startRuntime codebase = do
         (o, state') <- HandleCommand.commandLine config awaitInput
                                      (writeIORef rootRef)
                                      runtime
-                                     (\out -> notifyUser dir out >>= putPrettyNonempty)
+                                     (notifyUser dir >=> putPrettyNonempty)
                                      codebase
                                      free
         case o of

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -598,10 +598,8 @@ notifyUser dir o = case o of
          <> "namespace.")
     ],
     "",
-    P.numbered (\i -> P.hiBlack . fromString $ show i <> ".")
-         . fmap renderEntry
-         $ entries
-         ]
+    P.numberedList . fmap renderEntry $ entries
+    ]
     where
     renderEntry :: Output.ReflogEntry -> P.Pretty CT.ColorText
     renderEntry (Output.ReflogEntry hash reason) = P.wrap $
@@ -1042,7 +1040,7 @@ todoOutput ppe todo =
           TypePrinter.prettySignatures' ppe (goodTerms frontierTerms)
           )
       , P.wrap "I recommend working on them in the following order:"
-      , P.indentN 2 . P.lines $
+      , P.numberedList $
           let unscore (_score,a,b) = (a,b)
           in (prettyDeclPair ppe . unscore <$> toList dirtyTypes) ++
              TypePrinter.prettySignatures'
@@ -1079,8 +1077,7 @@ listOfDefinitions' ppe detailed results =
     ]
   where
   len = length results
-  prettyNumberedResults =
-    P.numbered (\i -> P.hiBlack . fromString $ show i <> ".") prettyResults
+  prettyNumberedResults = P.numberedList prettyResults
   -- todo: group this by namespace
   prettyResults =
     map (SR'.foldResult' renderTerm renderType)

--- a/parser-typechecker/src/Unison/Name.hs
+++ b/parser-typechecker/src/Unison/Name.hs
@@ -107,10 +107,9 @@ unqualified' :: Text -> Text
 unqualified' = last . Text.splitOn "."
 
 makeAbsolute :: Name -> Name
-makeAbsolute n =
-  if toText n == "." then Name ".."
-  else if Text.isPrefixOf "." (toText n) then n
-  else Name ("." <> toText n)
+makeAbsolute n | toText n == "."                = Name ".."
+               | Text.isPrefixOf "." (toText n) = n
+               | otherwise                      = Name ("." <> toText n)
 
 instance Show Name where
   show = toString

--- a/parser-typechecker/src/Unison/Reference.hs
+++ b/parser-typechecker/src/Unison/Reference.hs
@@ -138,7 +138,7 @@ component h ks = let
   in [ (k, DerivedId (Id h i size)) | (k, i) <- ks `zip` [0..]]
 
 components :: [(H.Hash, [k])] -> [(k, Reference)]
-components sccs = join $ uncurry component <$> sccs
+components sccs = uncurry component =<< sccs
 
 groupByComponent :: [(k, Reference)] -> [[(k, Reference)]]
 groupByComponent refs = done $ foldl' insert Map.empty refs

--- a/parser-typechecker/src/Unison/Util/Pretty.hs
+++ b/parser-typechecker/src/Unison/Util/Pretty.hs
@@ -49,6 +49,7 @@ module Unison.Util.Pretty (
    lineSkip,
    nonEmpty,
    numbered,
+   numberedList,
    orElse,
    orElses,
    parenthesize,
@@ -339,6 +340,10 @@ numbered
   -> f (Pretty s)
   -> Pretty s
 numbered num ps = column2 (fmap num [1 ..] `zip` toList ps)
+
+-- Opinionated `numbered` that uses bold numbers in front
+numberedList :: Foldable f => f (Pretty ColorText) -> Pretty ColorText
+numberedList = numbered (\i -> hiBlack . fromString $ show i <> ".")
 
 leftPad, rightPad :: IsString s => Int -> Pretty s -> Pretty s
 leftPad n p =

--- a/unison-src/transcripts/numbered-args.md
+++ b/unison-src/transcripts/numbered-args.md
@@ -1,0 +1,52 @@
+# Using numbered arguments in UCM
+
+First lets add some contents to our codebase.
+
+```unison
+foo = "foo"
+bar = "bar"
+baz = "baz"
+qux = "qux"
+quux = "quux"
+corge = "corge"
+```
+
+```ucm
+.temp> add
+```
+
+We can get the list of things in the namespace, and UCM will give us a numbered
+list:
+
+```ucm
+.temp> find
+```
+
+We can ask to `view` the second element of this list:
+
+```ucm
+.temp> find
+.temp> view 2
+```
+
+And we can `view` multiple elements by separating with spaces:
+
+```ucm
+.temp> find
+.temp> view 2 3 5
+```
+
+We can also ask for a range:
+
+```ucm
+.temp> find
+.temp> view 2-4
+```
+
+And we can ask for multiple ranges and use mix of ranges and numbers:
+
+```ucm
+.temp> find
+.temp> view 1-3 4 5-6
+```
+

--- a/unison-src/transcripts/numbered-args.output.md
+++ b/unison-src/transcripts/numbered-args.output.md
@@ -1,0 +1,165 @@
+# Using numbered arguments in UCM
+
+First lets add some contents to our codebase.
+
+```unison
+foo = "foo"
+bar = "bar"
+baz = "baz"
+qux = "qux"
+quux = "quux"
+corge = "corge"
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bar   : builtin.Text
+      baz   : builtin.Text
+      corge : builtin.Text
+      foo   : builtin.Text
+      quux  : builtin.Text
+      qux   : builtin.Text
+   
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+```
+```ucm
+  ☝️  The namespace .temp is empty.
+
+.temp> add
+
+  ⍟ I've added these definitions:
+  
+    bar   : .builtin.Text
+    baz   : .builtin.Text
+    corge : .builtin.Text
+    foo   : .builtin.Text
+    quux  : .builtin.Text
+    qux   : .builtin.Text
+
+```
+We can get the list of things in the namespace, and UCM will give us a numbered
+list:
+
+```ucm
+.temp> find
+
+  1. bar : .builtin.Text
+  2. baz : .builtin.Text
+  3. corge : .builtin.Text
+  4. foo : .builtin.Text
+  5. quux : .builtin.Text
+  6. qux : .builtin.Text
+  
+
+```
+We can ask to `view` the second element of this list:
+
+```ucm
+.temp> find
+
+  1. bar : .builtin.Text
+  2. baz : .builtin.Text
+  3. corge : .builtin.Text
+  4. foo : .builtin.Text
+  5. quux : .builtin.Text
+  6. qux : .builtin.Text
+  
+
+.temp> view 2
+
+  baz : .builtin.Text
+  baz = "baz"
+
+```
+And we can `view` multiple elements by separating with spaces:
+
+```ucm
+.temp> find
+
+  1. bar : .builtin.Text
+  2. baz : .builtin.Text
+  3. corge : .builtin.Text
+  4. foo : .builtin.Text
+  5. quux : .builtin.Text
+  6. qux : .builtin.Text
+  
+
+.temp> view 2 3 5
+
+  baz : .builtin.Text
+  baz = "baz"
+  
+  corge : .builtin.Text
+  corge = "corge"
+  
+  quux : .builtin.Text
+  quux = "quux"
+
+```
+We can also ask for a range:
+
+```ucm
+.temp> find
+
+  1. bar : .builtin.Text
+  2. baz : .builtin.Text
+  3. corge : .builtin.Text
+  4. foo : .builtin.Text
+  5. quux : .builtin.Text
+  6. qux : .builtin.Text
+  
+
+.temp> view 2-4
+
+  baz : .builtin.Text
+  baz = "baz"
+  
+  corge : .builtin.Text
+  corge = "corge"
+  
+  foo : .builtin.Text
+  foo = "foo"
+
+```
+And we can ask for multiple ranges and use mix of ranges and numbers:
+
+```ucm
+.temp> find
+
+  1. bar : .builtin.Text
+  2. baz : .builtin.Text
+  3. corge : .builtin.Text
+  4. foo : .builtin.Text
+  5. quux : .builtin.Text
+  6. qux : .builtin.Text
+  
+
+.temp> view 1-3 4 5-6
+
+  bar : .builtin.Text
+  bar = "bar"
+  
+  baz : .builtin.Text
+  baz = "baz"
+  
+  corge : .builtin.Text
+  corge = "corge"
+  
+  foo : .builtin.Text
+  foo = "foo"
+  
+  quux : .builtin.Text
+  quux = "quux"
+  
+  qux : .builtin.Text
+  qux = "qux"
+
+```


### PR DESCRIPTION
Adds syntax to `ucm` for viewing/editing ranges of numbered arguments. See [the transcript](https://github.com/unisonweb/unison/compare/topic/edit.all?expand=1#diff-d59ca61233c712bafdb0d33680b6f1ca) for details.

Also adds numbers to the frontier output by the `todo` command so you can edit your entire frontier in one go.
