### PR TITLE
Fix #947

### DIFF
--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -1555,12 +1555,13 @@ abilityCheck' ambient0 requested0 = go ambient0 requested0 where
       -- 2b. If no:
       Nothing -> case r of
         -- It's an unsolved existential, instantiate it to all of ambient
-        Type.Existential' b v ->
+        Type.Existential' b v -> do
           let et2 = Type.effects (loc r) ambient
           -- instantiate it to `{}` if can't cover all of ambient
-          in instantiateR et2 b v `orElse`
-             instantiateR (Type.effects (loc r) []) b v `orElse`
-             die1
+          instantiateR et2 b v 
+            `orElse` instantiateR (Type.effects (loc r) []) b v 
+            `orElse` die1
+          go ambient rs
         _ -> -- find unsolved existential, 'e, that appears in ambient
           let unsolveds = (ambient >>= Type.flattenEffects >>= vars)
               vars (Type.Var' (TypeVar.Existential b v)) = [(b,v)]

--- a/parser-typechecker/tests/Unison/Test/Type.hs
+++ b/parser-typechecker/tests/Unison/Test/Type.hs
@@ -5,6 +5,11 @@ module Unison.Test.Type where
 import EasyTest
 import Unison.Type
 import Unison.Symbol (Symbol)
+import qualified Unison.Var as Var
+import qualified Unison.Typechecker as Typechecker
+
+infixr 1 --> 
+(-->) a b = arrow() a b
 
 test :: Test ()
 test = scope "type" $ tests [
@@ -14,4 +19,13 @@ test = scope "type" $ tests [
          Arrows' [i,o] ->
            expect (i == builtin() "a" && o == builtin() "b")
          _ -> crash "unArrows (a -> b) did not return a spine of [a,b]"
+  ,
+  scope "subtype" $ do
+    let v = Var.named "a" 
+        v2 = Var.named "b" 
+        vt = var() v
+        vt2 = var() v2
+        x = forall() v (nat() --> effect() [vt, builtin() "eff"] (nat())) :: Type Symbol ()
+        y = forall() v2 (nat() --> effect() [vt2] (nat())) :: Type Symbol ()
+    expect . not $ Typechecker.isSubtype x y
   ]


### PR DESCRIPTION
This was an amazing bug. Given an ability check for `{e, Other}`, and ambient of `{e2}`, we were bailing with a successful ability check after just the first `e` request, but not even checking the `Other` request against ambient. `e` had to be an unsolved existential to trigger this.

See the note below.