### PR TITLE
Create a `flush` builtin

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/IOSource.hs
+++ b/parser-typechecker/src/Unison/Runtime/IOSource.hs
@@ -265,6 +265,10 @@ namespace io where
   setBuffering : Handle -> Optional BufferMode ->{IO} ()
   setBuffering h bm = rethrow (io.IO.setBuffering_ h bm)
 
+  -- Send any items buffered for output to the Operating system
+  flush : Handle ->{IO} ()
+  flush h = rethrow (io.IO.flush_ h)
+
   -- Get the path to a temporary directory managed by the operating system
   getTemporaryDirectory : '{IO} FilePath
   getTemporaryDirectory = '(rethrow (io.IO.getTemporaryDirectory_))
@@ -448,6 +452,7 @@ ability io.IO where
   -- File buffering
   getBuffering_ : io.Handle -> Either io.Error (Optional io.BufferMode)
   setBuffering_ : io.Handle -> Optional io.BufferMode -> (Either io.Error ())
+  flush_ : io.Handle -> (Either io.Error ())
 
   -- Should we expose mutable arrays for byte buffering?
   -- Inclined to say no, although that sounds a lot like

--- a/parser-typechecker/src/Unison/Runtime/Rt1IO.hs
+++ b/parser-typechecker/src/Unison/Runtime/Rt1IO.hs
@@ -65,6 +65,7 @@ import           System.IO                      ( Handle
                                                 , hTell
                                                 , hGetBuffering
                                                 , hSetBuffering
+                                                , hFlush
                                                 )
 import           System.Directory               ( getCurrentDirectory
                                                 , setCurrentDirectory
@@ -335,6 +336,10 @@ handleIO cenv cid = go (IOSrc.constructorName IOSrc.ioReference cid)
   go "io.IO.setBuffering_" [IR.Data _ 0 [IR.T handle], o] = do
     hh <- getHaskellHandleOrThrow handle
     reraiseIO . hSetBuffering hh $ haskellBufferMode o
+    pure IR.unit
+  go "io.IO.flush_" [IR.Data _ 0 [IR.T handle]] = do
+    hh <- getHaskellHandleOrThrow handle
+    reraiseIO $ hFlush hh
     pure IR.unit
   go "io.IO.systemTime_" [] = do
     t <- reraiseIO $ fmap round Time.getPOSIXTime


### PR DESCRIPTION
```
use .builtin.io IO

prog : '{IO} ()
prog = 'let
  use base.Text ++
  print "> "
  flush stdout
  line = !readLine
  printLine ("You entered '" ++ line ++ "'")

print t = putText stdout t
```

Todo: probably need to add a test or something? Will have a look tomorrow.