### PR TITLE
CI to check for unexpected transcript changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ install:
 script:
 - stack --no-terminal exec tests
 - stack --no-terminal exec transcripts
-- [[ -z $(git status -uno --porcelain) ]] # look for modified files, e.g. altered transcript output
+- bash -c '[[ -z $(git status -uno --porcelain) ]]' # look for modified files, e.g. altered transcript output

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,3 @@ script:
 - stack --no-terminal exec transcripts
 # fail if running transcripts modified any versioned files
 - x=`git status --porcelain -uno` bash -c 'if [[ -n $x ]]; then echo $x; false; fi' 
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,5 @@ install:
 script:
 - stack --no-terminal exec tests
 - stack --no-terminal exec transcripts
-- git status-uno --porcelain
+- git status -uno --porcelain
 - bash -c '[[ -z $(git status -uno --porcelain) ]]'

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,4 @@ install:
 script:
 - stack --no-terminal exec tests
 - stack --no-terminal exec transcripts
+- [[ -z $(git status -uno --porcelain) ]] # look for modified files, e.g. altered transcript output

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,5 @@ install:
 script:
 - stack --no-terminal exec tests
 - stack --no-terminal exec transcripts
-- bash -c '[[ -z $(git status -uno --porcelain) ]]' # look for modified files, e.g. altered transcript output
+- git status-uno --porcelain
+- bash -c '[[ -z $(git status -uno --porcelain) ]]'

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ script:
 - stack --no-terminal exec tests
 - stack --no-terminal exec transcripts
 # fail if running transcripts modified any versioned files
-- x=`git status --porcelain -uno` bash -c 'if [[ -n $x ]]; then echo $x; false; fi' 
+- x=`git status --porcelain -uno` bash -c 'if [[ -n $x ]]; then echo "$x" && false; fi' 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,5 @@ install:
 script:
 - stack --no-terminal exec tests
 - stack --no-terminal exec transcripts
-- git status -uno --porcelain
-- bash -c '[[ -z $(git status -uno --porcelain) ]]'
+- git status -uno --porcelain # did running transcripts modify any versioned files?
+- bash -c '[[ -z $(git status -uno --porcelain) ]]' # abort if it did

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,6 @@ install:
 script:
 - stack --no-terminal exec tests
 - stack --no-terminal exec transcripts
-- git status -uno --porcelain # did running transcripts modify any versioned files?
-- bash -c '[[ -z $(git status -uno --porcelain) ]]' # abort if it did
+# fail if running transcripts modified any versioned files
+- x=`git status --porcelain -uno` bash -c 'if [[ -n $x ]]; then echo $x; false; fi' 
+


### PR DESCRIPTION
Updates the CI script to `git status` to make sure that no versioned files (e.g. `transcript.output.md`) are changed in the course of running tests.