### PR TITLE
try coaxing travis into folding test output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,12 @@ install:
 - stack --no-terminal build
 
 script:
-- echo -en 'travis_fold:start:tests\\r'
-- stack --no-terminal exec tests
-- echo -en 'travis_fold:end:tests\\r'
-- echo -en 'travis_fold:start:transcripts\\r'
-- stack --no-terminal exec transcripts
-- echo -en 'travis_fold:end:transcripts\\r'
+- travis_fold () {
+    name=$1 && \
+    shift && \
+    echo -en "travis_fold:start:$name\r" && \
+    $* && \
+    echo -en "travis_fold:end:$name\r"
+  }
+- travis_fold tests       stack --no-terminal exec tests
+- travis_fold transcripts stack --no-terminal exec transcripts

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ install:
 - stack --no-terminal build
 
 script:
-- travis_fold () {
+- |
+  travis_fold () {
     name=$1 && \
     shift && \
     echo -en "travis_fold:start:$name\r" && \

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ install:
 - stack --no-terminal build
 
 script:
-- echo travis_fold:start:tests
+- echo -en 'travis_fold:start:tests\\r'
 - stack --no-terminal exec tests
-- echo travis_fold:end:tests
-- echo travis_fold:start:transcripts
+- echo -en 'travis_fold:end:tests\\r'
+- echo -en 'travis_fold:start:transcripts\\r'
 - stack --no-terminal exec transcripts
-- echo travis_fold:end:transcripts
+- echo -en 'travis_fold:end:transcripts\\r'

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,9 @@ install:
 - stack --no-terminal build
 
 script:
+- echo travis_fold:start:tests
 - stack --no-terminal exec tests
+- echo travis_fold:end:tests
+- echo travis_fold:start:transcripts
 - stack --no-terminal exec transcripts
+- echo travis_fold:end:transcripts

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,15 +21,5 @@ before_install:
 install:
 - stack ghc -- --version
 - stack --no-terminal build
-
-script:
-- |
-  travis_fold () {
-    name=$1 && \
-    shift && \
-    echo -en "travis_fold:start:$name\r" && \
-    $* && \
-    echo -en "travis_fold:end:$name\r"
-  }
-- travis_fold tests       stack --no-terminal exec tests
-- travis_fold transcripts stack --no-terminal exec transcripts
+- stack --no-terminal exec tests
+- stack --no-terminal exec transcripts


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/538571/69278395-3fc13e00-0bb0-11ea-91a7-3b984f4fe2c9.png)

I wanted to be able to fold the individual script steps, but Github intentionally doesn't let you do that (without some undocumented antics).  Instead, I moved the testing steps into the `install:` section, which does fold automatically.  I'll make a separate draft PR to make sure that it still fails the build when appropriate.