### PR TITLE
resolve.{term,type} => replace.{term,type}

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -294,11 +294,11 @@ loop = do
           DeleteBranchI opath -> "delete.namespace " <> ops' opath
           DeletePatchI path -> "delete.patch " <> ps' path
           ReplaceTermI srcH targetH p ->
-            "resolve.term " <> SH.toText srcH <> " "
+            "replace.term " <> SH.toText srcH <> " "
                             <> SH.toText targetH <> " "
                             <> opatch p
           ReplaceTypeI srcH targetH p ->
-            "resolve.type " <> SH.toText srcH <> " "
+            "replace.type " <> SH.toText srcH <> " "
                             <> SH.toText targetH <> " "
                             <> opatch p
           ResolveTermNameI path -> "resolve.termName " <> hqs' path

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -293,11 +293,11 @@ loop = do
           DeleteTypeI def -> "delete.type" <> hqs' def
           DeleteBranchI opath -> "delete.namespace " <> ops' opath
           DeletePatchI path -> "delete.patch " <> ps' path
-          ResolveTermI srcH targetH p ->
+          ReplaceTermI srcH targetH p ->
             "resolve.term " <> SH.toText srcH <> " "
                             <> SH.toText targetH <> " "
                             <> opatch p
-          ResolveTypeI srcH targetH p ->
+          ReplaceTypeI srcH targetH p ->
             "resolve.type " <> SH.toText srcH <> " "
                             <> SH.toText targetH <> " "
                             <> opatch p
@@ -965,7 +965,7 @@ loop = do
           BranchUtil.makeDeleteTermName (resolveSplit' (HQ'.toName <$> hq))
         go r = stepManyAt . fmap makeDelete . toList . Set.delete r $ conflicted
 
-      ResolveTermI from to patchPath -> do
+      ReplaceTermI from to patchPath -> do
         let patchPath' = fromMaybe defaultPatchPath patchPath
         patch <- getPatchAt patchPath'
         fromRefs <- eval $ ReferencesByShortHash from
@@ -1010,7 +1010,7 @@ loop = do
           (hashConflicted from .
             Set.map (Referent.Ref . DerivedId))
 
-      ResolveTypeI from to patchPath -> do
+      ReplaceTypeI from to patchPath -> do
         let patchPath' = fromMaybe defaultPatchPath patchPath
         patch <- getPatchAt patchPath'
         fromRefs <- eval $ ReferencesByShortHash from

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -89,8 +89,8 @@ data Input
     | AddTypeReplacementI PatchPath Reference Reference
     | RemoveTermReplacementI PatchPath Reference Reference
     | RemoveTypeReplacementI PatchPath Reference Reference
-    | ResolveTermI ShortHash ShortHash (Maybe PatchPath)
-    | ResolveTypeI ShortHash ShortHash (Maybe PatchPath)
+    | ReplaceTermI ShortHash ShortHash (Maybe PatchPath)
+    | ReplaceTypeI ShortHash ShortHash (Maybe PatchPath)
   | UndoI
   -- First `Maybe Int` is cap on number of results, if any
   -- Second `Maybe Int` is cap on diff elements shown, if any

--- a/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
@@ -148,12 +148,14 @@ run dir stanzas codebase = do
               [] -> awaitInput
               cmd:args -> do
                 output ("\n" <> show p <> "\n")
+                -- invalid command is treated as a failure
                 case Map.lookup cmd patternMap of
-                  Nothing -> awaitInput
+                  Nothing -> 
+                    die
                   Just pat -> case IP.parse pat args of
                     Left msg -> do
                       output $ P.toPlain 65 (P.indentN 2 msg <> P.newline <> P.newline)
-                      awaitInput
+                      die 
                     Right input -> pure $ Right input
           Nothing -> do
             errOk <- readIORef allowErrors
@@ -208,13 +210,16 @@ run dir stanzas codebase = do
         output rendered
         when (errOk && Output.isFailure o) $ 
           writeIORef hasErrors True
-        when (not errOk && Output.isFailure o) $ do
-          output "\n```\n\n"
-          transcriptFailure out $ Text.unlines [
-            "\128721", "",
-            "Transcript failed due to the message above.",
-            "Codebase as of the point of failure is in:", "",
-            "  " <> Text.pack dir ]
+        when (not errOk && Output.isFailure o) 
+          die
+
+      die = do 
+        output "\n```\n\n"
+        transcriptFailure out $ Text.unlines [
+          "\128721", "",
+          "Transcript failed due to the message above.",
+          "Codebase as of the point of failure is in:", "",
+          "  " <> Text.pack dir ]
 
       loop state = do
         writeIORef pathRef (HandleInput._currentPath state)

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -617,14 +617,14 @@ previewMergeLocal = InputPattern
     _ -> Left (I.help previewMergeLocal)
   )
 
-resolveEdit
+replaceEdit
   :: (ShortHash -> ShortHash -> Maybe Input.PatchPath -> Input)
   -> String
   -> InputPattern
-resolveEdit f s = self
+replaceEdit f s = self
  where
   self = InputPattern
-    ("resolve." <> s)
+    ("replace." <> s)
     []
     [ (Required, exactDefinitionQueryArg)
     , (Required, exactDefinitionQueryArg)
@@ -632,17 +632,17 @@ resolveEdit f s = self
     ]
     (P.wrapColumn2
       [ ( makeExample self ["<from>", "<to>", "<patch>"]
-        , "Resolves any edit conflict for the "
+        , "Replace the "
         <> P.string s
         <> " <from> in the given patch "
-        <> "by globally replacing it with the "
+        <> "with the "
         <> P.string s
         <> " <to>."
         )
       , ( makeExample self ["<from>", "<to>"]
-        , "Resolves edit conflicts in the default patch by replacing the "
+        , "Replace the "
         <> P.string s
-        <> "<from> with <to>."
+        <> "<from> with <to> in the default patch."
         )
       ]
     )
@@ -665,11 +665,11 @@ resolveEdit f s = self
   toHash (Left  h      ) = Just h
   toHash (Right (_, hq)) = HQ'.toHash hq
 
-resolveType :: InputPattern
-resolveType = resolveEdit Input.ResolveTypeI "type"
+replaceType :: InputPattern
+replaceType = replaceEdit Input.ReplaceTypeI "type"
 
-resolveTerm :: InputPattern
-resolveTerm = resolveEdit Input.ResolveTermI "term"
+replaceTerm :: InputPattern
+replaceTerm = replaceEdit Input.ReplaceTermI "term"
 
 viewReflog :: InputPattern
 viewReflog = InputPattern
@@ -961,8 +961,8 @@ validInputs =
   , link
   , unlink
   , links
-  , resolveTerm
-  , resolveType
+  , replaceTerm
+  , replaceType
   , test
   , execute
   , viewReflog

--- a/unison-src/transcripts/resolve.md
+++ b/unison-src/transcripts/resolve.md
@@ -1,6 +1,6 @@
 # Resolving edit conflicts in `ucm`
 
-The `ucm` tool tracks edits to hashes in an object called a _patch_. When patches get merged, sometimes those patches will have conflicting edits. The `resolve.term` command helps resolve such conflicts.
+The `ucm` tool tracks edits to hashes in an object called a _patch_. When patches get merged, sometimes those patches will have conflicting edits. The `replace.term` command helps resolve such conflicts.
 
 First, let's make a new namespace, `example.resolve`:
 
@@ -85,7 +85,7 @@ We see that `#44954ulpdf` (the original hash of `a.foo`) got replaced with _both
 We can resolve this conflict by picking one of the terms as the "winner":
 
 ```ucm
-.example.resolve.c> resolve.term #44954ulpdf #8e68dvpr0a
+.example.resolve.c> replace.term #44954ulpdf #8e68dvpr0a
 ```
 
 This changes the merged `c.patch` so that only the edit from #44954ulpdf to  #8e68dvpr0a remains:

--- a/unison-src/transcripts/resolve.output.md
+++ b/unison-src/transcripts/resolve.output.md
@@ -1,6 +1,6 @@
 # Resolving edit conflicts in `ucm`
 
-The `ucm` tool tracks edits to hashes in an object called a _patch_. When patches get merged, sometimes those patches will have conflicting edits. The `resolve.term` command helps resolve such conflicts.
+The `ucm` tool tracks edits to hashes in an object called a _patch_. When patches get merged, sometimes those patches will have conflicting edits. The `replace.term` command helps resolve such conflicts.
 
 First, let's make a new namespace, `example.resolve`:
 
@@ -184,7 +184,7 @@ We see that `#44954ulpdf` (the original hash of `a.foo`) got replaced with _both
 We can resolve this conflict by picking one of the terms as the "winner":
 
 ```ucm
-.example.resolve.c> resolve.term #44954ulpdf #8e68dvpr0a
+.example.resolve.c> replace.term #44954ulpdf #8e68dvpr0a
 
   Done.
 


### PR DESCRIPTION
This PR renames the commands `resolve.term` to `replace.term` and `resolve.type` to `replace.type`. Motivation for this is I'm doing some docs for the refactoring process (as a Unison transcript actually) and want to improve the nomenclature. The "resolve" nomenclature was overly specific to one use case of those commands, so that nomenclature has now been sacked. 😀 You can resolve edit conflicts by using the `replace.*` commands, but you can also just issue `replace` commands to establish that the patch should replace `<old>` with `<new>`. "Replace" is more neutral terminology that still reflects what's happening.

This PR also has a fix: previously, transcripts with invalid commands would just silently noop. Now they fail the transcript as expected. Transcripts and output have been updated too.