### PR TITLE
cleanup outdated defns in IOSource

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/IOSource.hs
+++ b/parser-typechecker/src/Unison/Runtime/IOSource.hs
@@ -65,7 +65,7 @@ ioHash = R.unsafeId ioReference
 eitherHash = R.unsafeId eitherReference
 ioModeHash = R.unsafeId ioModeReference
 
-ioReference, bufferModeReference, eitherReference, ioModeReference, optionReference, errorReference, errorTypeReference, seekModeReference, threadIdReference, socketReference, handleReference, epochTimeReference, isTestReference, filePathReference, docReference, linkReference
+ioReference, bufferModeReference, eitherReference, ioModeReference, optionReference, errorReference, errorTypeReference, seekModeReference, threadIdReference, socketReference, handleReference, epochTimeReference, isTestReference, filePathReference
   :: R.Reference
 ioReference = abilityNamed "io.IO"
 bufferModeReference = typeNamed "io.BufferMode"
@@ -81,8 +81,6 @@ handleReference = typeNamed "io.Handle"
 epochTimeReference = typeNamed "io.EpochTime"
 isTestReference = typeNamed "IsTest"
 filePathReference = typeNamed "io.FilePath"
-docReference = typeNamed "Doc"
-linkReference = typeNamed "Link"
 
 isTest :: (R.Reference, R.Reference)
 isTest = (isTestReference, termNamed "metadata.isTest")


### PR DESCRIPTION
Deleted these two definitions because:
* `typeNamed "Link"` no longer exists; it's been replaced with `"Link.Term"` / `"Link.Type"` in `Builtin.hs`.
* `typeNamed "Doc"` I think is still a thing, but it's no longer defined in `IOSource.hs`, and this defn wasn't being used anywhere anyway.
