### PR TITLE
Read .unisonConfig from where the codebase is

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -20,6 +20,7 @@ module Unison.Codebase.FileCodebase
 , initCodebaseAndExit
 , initCodebase
 , getCodebaseOrExit
+, getCodebaseDir
 ) where
 
 import Unison.Prelude
@@ -117,8 +118,7 @@ formatAnn = S.Format (pure External) (\_ -> pure ())
 
 initCodebaseAndExit :: Maybe FilePath -> IO ()
 initCodebaseAndExit mdir = do
-  dir <- case mdir of Just dir -> pure dir
-                      Nothing  -> getHomeDirectory
+  dir <- getCodebaseDir mdir
   _ <- initCodebase dir
   exitSuccess
 
@@ -167,6 +167,11 @@ getCodebaseOrExit mdir = do
     PT.putPrettyLn'. P.warnCallout . P.wrap $ errMsg
     exitFailure
   pure theCodebase
+
+getCodebaseDir :: Maybe FilePath -> IO FilePath
+getCodebaseDir mdir =
+  case mdir of Just dir -> pure dir
+               Nothing  -> getHomeDirectory
 
 termsDir, typesDir, branchesDir, branchHeadDir, editsDir
   :: CodebasePath -> FilePath

--- a/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
@@ -14,7 +14,6 @@ import Control.Monad.State (runStateT)
 import Data.IORef
 import Prelude hiding (readFile, writeFile)
 import System.Exit (die)
-import System.FilePath ((</>))
 import System.IO.Error (catchIOError)
 import Unison.Codebase (Codebase)
 import Unison.Codebase.Editor.Input (Input (..), Event(UnisonFileChanged))
@@ -96,8 +95,8 @@ parse srcName txt = case P.parse (stanzas <* P.eof) srcName txt of
   Right a -> Right a
   Left e -> Left (show e)
 
-run :: FilePath -> [Stanza] -> Codebase IO Symbol Ann -> IO Text
-run dir stanzas codebase = do
+run :: FilePath -> FilePath -> [Stanza] -> Codebase IO Symbol Ann -> IO Text
+run dir configFile stanzas codebase = do
   let initialPath = Path.absoluteEmpty
   let startRuntime = pure Rt1.runtime
   putPrettyLn $ P.lines [
@@ -117,7 +116,7 @@ run dir stanzas codebase = do
     allowErrors              <- newIORef False
     hasErrors                <- newIORef False
     (config, cancelConfig)   <-
-      catchIOError (watchConfig $ dir </> ".unisonConfig") $ \_ ->
+      catchIOError (watchConfig configFile) $ \_ ->
         die "Your .unisonConfig could not be loaded. Check that it's correct!"
     traverse_ (atomically . Q.enqueue inputQueue) (stanzas `zip` [1..])
     let patternMap =

--- a/parser-typechecker/src/Unison/CommandLine/Main.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Main.hs
@@ -13,7 +13,6 @@ import Control.Exception (finally)
 import Control.Monad.State (runStateT)
 import Data.IORef
 import Prelude hiding (readFile, writeFile)
-import System.FilePath ((</>))
 import System.IO.Error (catchIOError)
 import System.Exit (die)
 import Unison.Codebase.Branch (Branch)
@@ -145,11 +144,12 @@ main
   . Var v
   => FilePath
   -> Path.Absolute
+  -> FilePath
   -> [Either Event Input]
   -> IO (Runtime v)
   -> Codebase IO v Ann
   -> IO ()
-main dir initialPath initialInputs startRuntime codebase = do
+main dir initialPath configFile initialInputs startRuntime codebase = do
   dir' <- shortenDirectory dir
   root <- Codebase.getRootBranch codebase
   putPrettyLn $ if Branch.isOne root
@@ -164,7 +164,7 @@ main dir initialPath initialInputs startRuntime codebase = do
     initialInputsRef         <- newIORef initialInputs
     numberedArgsRef          <- newIORef []
     (config, cancelConfig)   <-
-      catchIOError (watchConfig $ dir </> ".unisonConfig") $ \_ ->
+      catchIOError (watchConfig configFile) $ \_ ->
         die "Your .unisonConfig could not be loaded. Check that it's correct!"
     cancelFileSystemWatch    <- watchFileSystem eventQueue dir
     cancelWatchBranchUpdates <- watchBranchUpdates (Branch.headHash <$>

--- a/parser-typechecker/tests/Unison/Test/Git.hs
+++ b/parser-typechecker/tests/Unison/Test/Git.hs
@@ -31,12 +31,14 @@ testBareRepo = scope "testBareRepo" $ do
     let codebase = tmp </> "codebase"
     FC.initCodebase codebase
 
+    let configFile = tmp </> ".unisonConfig"
+
     case TR.parse "transcript" transcript of
       Left err -> error $ "Parse error: \n" <> show err
       Right stanzas -> void $ do
         currentDir <- getCurrentDirectory
         theCodebase <- FC.getCodebaseOrExit $ Just codebase
-        TR.run currentDir stanzas theCodebase
+        TR.run currentDir configFile stanzas theCodebase
   ok
 
 makeTranscript :: FilePath -> Text

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -74,17 +74,18 @@ main = do
            "-codebase" : codepath : restargs -> (Just codepath, restargs)
            _                                 -> (Nothing, args)
   currentDir <- getCurrentDirectory
+  configFilePath <- getConfigFilePath mcodepath
   case restargs of
     [] -> do
       theCodebase <- FileCodebase.getCodebaseOrExit mcodepath
-      launch currentDir theCodebase []
+      launch currentDir configFilePath theCodebase []
     [version] | isFlag "version" version ->
       putStrLn $ "ucm version: " ++ Version.gitDescribe
     [help] | isFlag "help" help -> PT.putPrettyLn usage
     ["init"] -> FileCodebase.initCodebaseAndExit mcodepath
     "run" : [mainName] -> do
       theCodebase <- FileCodebase.getCodebaseOrExit mcodepath
-      launch currentDir theCodebase [Right $ Input.ExecuteI mainName, Right Input.QuitI]
+      launch currentDir configFilePath theCodebase [Right $ Input.ExecuteI mainName, Right Input.QuitI]
     "run.file" : file : [mainName] | isDotU file -> do
       e <- safeReadUtf8 file
       case e of
@@ -92,7 +93,7 @@ main = do
         Right contents -> do
           theCodebase <- FileCodebase.getCodebaseOrExit mcodepath
           let fileEvent = Input.UnisonFileChanged (Text.pack file) contents
-          launch currentDir theCodebase [Left fileEvent, Right $ Input.ExecuteI mainName, Right Input.QuitI]
+          launch currentDir configFilePath theCodebase [Left fileEvent, Right $ Input.ExecuteI mainName, Right Input.QuitI]
     "run.pipe" : [mainName] -> do
       e <- safeReadUtf8StdIn
       case e of
@@ -100,7 +101,7 @@ main = do
         Right contents -> do
           theCodebase <- FileCodebase.getCodebaseOrExit mcodepath
           let fileEvent = Input.UnisonFileChanged (Text.pack "<standard input>") contents
-          launch currentDir theCodebase [Left fileEvent, Right $ Input.ExecuteI mainName, Right Input.QuitI]
+          launch currentDir configFilePath theCodebase [Left fileEvent, Right $ Input.ExecuteI mainName, Right Input.QuitI]
     "transcript" : args -> runTranscripts False mcodepath args
     "transcript.fork" : args -> runTranscripts True mcodepath args
     _ -> do
@@ -136,7 +137,8 @@ runTranscripts inFork mcodepath args = do
           case parsed of
             Left err -> putStrLn $ "Parse error: \n" <> show err
             Right stanzas -> do
-              mdOut <- TR.run currentDir stanzas theCodebase
+              configFilePath <- getConfigFilePath mcodepath
+              mdOut <- TR.run currentDir configFilePath stanzas theCodebase
               let out = currentDir FP.</>
                          FP.addExtension (FP.dropExtension arg ++ ".output")
                                          (FP.takeExtension md)
@@ -158,9 +160,9 @@ runTranscripts inFork mcodepath args = do
 initialPath :: Path.Absolute
 initialPath = Path.absoluteEmpty
 
-launch :: FilePath -> _ -> [Either Input.Event Input.Input] -> IO ()
-launch dir code inputs =
-  CommandLine.main dir initialPath inputs (pure Rt1.runtime) code
+launch :: FilePath -> FilePath -> _ -> [Either Input.Event Input.Input] -> IO ()
+launch dir configFile code inputs =
+  CommandLine.main dir initialPath configFile inputs (pure Rt1.runtime) code
 
 isMarkdown :: String -> Bool
 isMarkdown md = case FP.takeExtension md of
@@ -175,3 +177,6 @@ isDotU file = FP.takeExtension file == ".u"
 -- having to remember which one is supported)
 isFlag :: String -> String -> Bool
 isFlag f arg = arg == f || arg == "-" ++ f || arg == "--" ++ f
+
+getConfigFilePath :: Maybe FilePath -> IO FilePath
+getConfigFilePath mcodepath = (FP.</> ".unisonConfig") <$> FileCodebase.getCodebaseDir mcodepath


### PR DESCRIPTION
Fix #917

This PR basically passes the config file path to the functions where we watch it.