### PR TITLE
Output fewer blank lines when only whitespace is input

### DIFF
--- a/parser-typechecker/src/Unison/CommandLine/Main.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Main.hs
@@ -78,11 +78,14 @@ getUserInput patterns codebase branch currentPath numberedArgs =
     case line of
       Nothing -> pure QuitI
       Just l ->
-        case parseInput patterns . (>>= expandNumber numberedArgs) . words $ l of
-          Left msg -> do
-            liftIO $ putPrettyLn msg
-            go
-          Right i -> pure i
+        case words l of
+          [] -> go
+          ws ->
+            case parseInput patterns . (>>= expandNumber numberedArgs) $ ws  of
+              Left msg -> do
+                liftIO $ putPrettyLn msg
+                go
+              Right i -> pure i
   settings    = Line.Settings tabComplete (Just ".unisonHistory") True
   tabComplete = Line.completeWordWithPrev Nothing " " $ \prev word ->
     -- User hasn't finished a command name, complete from command names


### PR DESCRIPTION
Before (when pressing Enter at the prompt):
```
.>



.>
```
After:
```
.>
.>
```