### PR TITLE
Move Unison.Codebase.SearchResult from unison-core to unison-parser-typechecker

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -382,9 +382,9 @@ loop = do
             if failed == mempty then stepManyAt . fmap (makeDelete resolvedPath) . toList $ rs
             else do
               failed <-
-                loadSearchResults $ Names.asSearchResults failed
+                loadSearchResults $ SR.fromNames failed
               failedDependents <-
-                loadSearchResults $ Names.asSearchResults failedDependents
+                loadSearchResults $ SR.fromNames failedDependents
               ppe <- prettyPrintEnv =<<
                 makePrintNamesFromLabeled'
                   (foldMap SR'.labeledDependencies $ failed <> failedDependents)
@@ -546,8 +546,8 @@ loop = do
                 diff = Names3.diff0 deletedNames mempty
             respond $ ShowDiff input diff
           else do
-            failed <- loadSearchResults $ Names.asSearchResults failed
-            failedDependents <- loadSearchResults $ Names.asSearchResults failedDependents
+            failed <- loadSearchResults $ SR.fromNames failed
+            failedDependents <- loadSearchResults $ SR.fromNames failedDependents
             ppe <- prettyPrintEnv =<<
               makePrintNamesFromLabeled'
                 (foldMap SR'.labeledDependencies $ failed <> failedDependents)
@@ -1525,7 +1525,7 @@ confirmedCommand i = do
 
 listBranch :: Branch0 m -> [SearchResult]
 listBranch (Branch.toNames0 -> b) =
-  List.sortOn (\s -> (SR.name s, s)) (Names.asSearchResults b)
+  List.sortOn (\s -> (SR.name s, s)) (SR.fromNames b)
 
 -- | restores the full hash to these search results, for _numberedArgs purposes
 searchResultToHQString :: SearchResult -> String
@@ -1545,7 +1545,7 @@ _searchBranchPrefix b n = case Path.unsnoc (Path.fromName n) of
   Nothing -> []
   Just (init, last) -> case Branch.getAt init b of
     Nothing -> []
-    Just b -> Names.asSearchResults . Names.prefix0 n $ names0
+    Just b -> SR.fromNames . Names.prefix0 n $ names0
       where
       lastName = Path.toName (Path.singleton last)
       subnames = Branch.toNames0 . Branch.head $
@@ -1557,8 +1557,8 @@ _searchBranchPrefix b n = case Path.unsnoc (Path.fromName n) of
 
 searchResultsFor :: Names0 -> [Referent] -> [Reference] -> [SearchResult]
 searchResultsFor ns terms types =
-  [ Names.termSearchResult ns (Names.termName ns ref) ref | ref <- terms ] <>
-  [ Names.typeSearchResult ns (Names.typeName ns ref) ref | ref <- types ]
+  [ SR.termSearchResult ns (Names.termName ns ref) ref | ref <- terms ] <>
+  [ SR.typeSearchResult ns (Names.typeName ns ref) ref | ref <- types ]
 
 searchBranchScored :: forall score. (Ord score)
               => Names0
@@ -1582,7 +1582,7 @@ searchBranchScored names0 score queries =
         Set.singleton (Nothing, result)
       _ -> mempty
       where
-      result = Names.termSearchResult names0 name ref
+      result = SR.termSearchResult names0 name ref
       pair qn = case score qn name of
         Just score -> Set.singleton (Just score, result)
         Nothing -> mempty
@@ -1600,7 +1600,7 @@ searchBranchScored names0 score queries =
         Set.singleton (Nothing, result)
       _ -> mempty
       where
-      result = Names.typeSearchResult names0 name ref
+      result = SR.typeSearchResult names0 name ref
       pair qn = case score qn name of
         Just score -> Set.singleton (Just score, result)
         Nothing -> mempty

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -66,6 +66,7 @@ library
     Unison.Codebase.Patch
     Unison.Codebase.Reflog
     Unison.Codebase.Runtime
+    Unison.Codebase.SearchResult
     Unison.Codebase.Serialization
     Unison.Codebase.Serialization.PutT
     Unison.Codebase.Serialization.V1

--- a/unison-core/unison-core.cabal
+++ b/unison-core/unison-core.cabal
@@ -36,7 +36,6 @@ library
   exposed-modules:
     Unison.ABT
     Unison.Blank
-    Unison.Codebase.SearchResult
     Unison.ConstructorType
     Unison.DataDeclaration
     Unison.Hash


### PR DESCRIPTION
This patch moves `Unison.Codebase.SearchResult` out of core and back into parser-typechecker.

`Names2` used to depend on it; those functions have been moved and renamed (e.g. `Names.asSearchResult` -> `SearchResult.fromNames`