### PR TITLE
Improve delete term/type feedback

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -82,9 +82,10 @@ data Output v
   | ParseResolutionFailures Input String [Names.ResolutionFailure v Ann]
   | TypeHasFreeVars Input (Type v Ann)
   | TermAlreadyExists Input Path.Split' (Set Referent)
-  | NameAmbiguous Input Path.HQSplit' (Set Referent) (Set Reference)
-  | TypeAmbiguous Input Path.HQSplit' (Set Reference)
-  | TermAmbiguous Input (Either Path.HQSplit' HQ.HashQualified) (Set Referent)
+  | NameAmbiguous
+      Int -- codebase hash length
+      Input Path.HQSplit' (Set Referent) (Set Reference)
+  | TermAmbiguous Input HQ.HashQualified (Set Referent)
   | HashAmbiguous Input ShortHash (Set Referent)
   | BranchHashAmbiguous Input ShortBranchHash (Set ShortBranchHash)
   | BadDestinationBranch Input Path'
@@ -231,7 +232,6 @@ isFailure o = case o of
   TypeHasFreeVars{} -> True
   TermAlreadyExists{} -> True
   NameAmbiguous{} -> True
-  TypeAmbiguous{} -> True
   TermAmbiguous{} -> True
   BranchHashAmbiguous{} -> True
   BadDestinationBranch{} -> True

--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -63,8 +63,14 @@ unsplit' :: Split' -> Path'
 unsplit' (Path' (Left (Absolute p)), seg) = Path' (Left (Absolute (unsplit (p, seg))))
 unsplit' (Path' (Right (Relative p)), seg) = Path' (Right (Relative (unsplit (p, seg))))
 
-unsplit :: (Path, NameSegment) -> Path
+unsplit :: Split -> Path
 unsplit (Path p, a) = Path (p :|> a)
+
+unsplitHQ :: HQSplit -> HQ'.HashQualified' Path
+unsplitHQ (p, a) = fmap (snoc p) a
+
+unsplitHQ' :: HQSplit' -> HQ'.HashQualified' Path'
+unsplitHQ' (p, a) = fmap (snoc' p) a
 
 type Split = (Path, NameSegment)
 type HQSplit = (Path, HQSegment)

--- a/parser-typechecker/src/Unison/NamePrinter.hs
+++ b/parser-typechecker/src/Unison/NamePrinter.hs
@@ -6,6 +6,8 @@ import qualified Unison.HashQualified as HQ
 import qualified Unison.HashQualified' as HQ'
 import           Unison.Name          (Name)
 import qualified Unison.Name          as Name
+import           Unison.Reference     (Reference)
+import           Unison.Referent      (Referent)
 import           Unison.ShortHash     (ShortHash)
 import qualified Unison.ShortHash     as SH
 import           Unison.Util.SyntaxText (SyntaxText)
@@ -24,6 +26,28 @@ prettyHashQualified' = prettyHashQualified . HQ'.toHQ
 
 prettyHashQualified0 :: IsString s => HQ.HashQualified -> Pretty s
 prettyHashQualified0 = PP.text . HQ.toText
+
+-- | Pretty-print a reference as a name and the given number of characters of
+-- its hash.
+prettyNamedReference :: Int -> Name -> Reference -> Pretty SyntaxText
+prettyNamedReference len name =
+  prettyHashQualified . HQ.take len . HQ.fromNamedReference name
+
+-- | Pretty-print a referent as a name and the given number of characters of its
+-- hash.
+prettyNamedReferent :: Int -> Name -> Referent -> Pretty SyntaxText
+prettyNamedReferent len name =
+  prettyHashQualified . HQ.take len . HQ.fromNamedReferent name
+
+-- | Pretty-print a reference as the given number of characters of its hash.
+prettyReference :: Int -> Reference -> Pretty SyntaxText
+prettyReference len =
+  prettyHashQualified . HQ.take len . HQ.fromReference
+
+-- | Pretty-print a referent as the given number of characters of its hash.
+prettyReferent :: Int -> Referent -> Pretty SyntaxText
+prettyReferent len =
+  prettyHashQualified . HQ.take len . HQ.fromReferent
 
 prettyShortHash :: IsString s => ShortHash -> Pretty s
 prettyShortHash = fromString . SH.toString

--- a/unison-src/transcripts/delete.md
+++ b/unison-src/transcripts/delete.md
@@ -15,7 +15,7 @@ unambiguous type.
 
 ```unison
 foo = 1
-unique type Foo = Foo Nat
+type Foo = Foo Nat
 ```
 
 ```ucm
@@ -57,7 +57,7 @@ I can force my delete through by re-issuing the command.
 Let's repeat all that on a type, for completeness.
 
 ```unison
-unique type Foo = Foo Nat
+type Foo = Foo Nat
 ```
 
 ```ucm
@@ -65,7 +65,7 @@ unique type Foo = Foo Nat
 ```
 
 ```unison
-unique type Foo = Foo Nat
+type Foo = Foo Boolean
 ```
 
 ```ucm
@@ -93,7 +93,7 @@ Finally, let's try to delete a term and a type with the same name.
 
 ```unison
 foo = 1
-unique type foo = Foo Nat
+type foo = Foo Nat
 ```
 
 ```ucm

--- a/unison-src/transcripts/delete.output.md
+++ b/unison-src/transcripts/delete.output.md
@@ -19,7 +19,7 @@ unambiguous type.
 
 ```unison
 foo = 1
-unique type Foo = Foo Nat
+type Foo = Foo Nat
 ```
 
 ```ucm
@@ -30,7 +30,7 @@ unique type Foo = Foo Nat
   
     ⍟ These new definitions are ok to `add`:
     
-      unique type Foo
+      type Foo
       foo : Nat
    
   Now evaluating any watch expressions (lines starting with
@@ -42,7 +42,7 @@ unique type Foo = Foo Nat
 
   ⍟ I've added these definitions:
   
-    unique type Foo
+    type Foo
     foo : Nat
 
 .> delete foo
@@ -126,7 +126,18 @@ foo = 2
 ```ucm
 .a> delete foo
 
-  That name is ambiguous.
+  🤔
+  
+  That name is ambiguous. It could refer to any of the following
+  definitions:
+  
+    foo#0ja1qfpej6
+    foo#jk19sm5bf8
+  
+  You may:
+  
+    * Delete one by an unambiguous name, given above.
+    * Delete them all by re-issuing the previous command.
 
 ```
 I can force my delete through by re-issuing the command.
@@ -138,7 +149,7 @@ I can force my delete through by re-issuing the command.
 Let's repeat all that on a type, for completeness.
 
 ```unison
-unique type Foo = Foo Nat
+type Foo = Foo Nat
 ```
 
 ```ucm
@@ -149,7 +160,7 @@ unique type Foo = Foo Nat
   
     ⍟ These new definitions are ok to `add`:
     
-      unique type Foo
+      type Foo
    
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.
@@ -160,11 +171,11 @@ unique type Foo = Foo Nat
 
   ⍟ I've added these definitions:
   
-    unique type Foo
+    type Foo
 
 ```
 ```unison
-unique type Foo = Foo Nat
+type Foo = Foo Boolean
 ```
 
 ```ucm
@@ -176,7 +187,7 @@ unique type Foo = Foo Nat
     ⍟ These new definitions will replace existing ones of the
       same name and are ok to `update`:
     
-      unique type Foo
+      type Foo
    
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.
@@ -187,7 +198,7 @@ unique type Foo = Foo Nat
 
   ⍟ I've added these definitions:
   
-    unique type Foo
+    type Foo
 
 .a> merge .b
 
@@ -205,7 +216,18 @@ unique type Foo = Foo Nat
 ```ucm
 .a> delete Foo
 
-  That name is ambiguous.
+  🤔
+  
+  That name is ambiguous. It could refer to any of the following
+  definitions:
+  
+    Foo#d97e0jhkmd
+    Foo#gq9inhvg9h
+  
+  You may:
+  
+    * Delete one by an unambiguous name, given above.
+    * Delete them all by re-issuing the previous command.
 
 ```
 ```ucm
@@ -215,7 +237,18 @@ unique type Foo = Foo Nat
 ```ucm
 .a> delete Foo.Foo
 
-  That name is ambiguous.
+  🤔
+  
+  That name is ambiguous. It could refer to any of the following
+  definitions:
+  
+    Foo.Foo#d97e0jhkmd#0
+    Foo.Foo#gq9inhvg9h#0
+  
+  You may:
+  
+    * Delete one by an unambiguous name, given above.
+    * Delete them all by re-issuing the previous command.
 
 ```
 ```ucm
@@ -226,7 +259,7 @@ Finally, let's try to delete a term and a type with the same name.
 
 ```unison
 foo = 1
-unique type foo = Foo Nat
+type foo = Foo Nat
 ```
 
 ```ucm
@@ -237,7 +270,7 @@ unique type foo = Foo Nat
   
     ⍟ These new definitions are ok to `add`:
     
-      unique type foo
+      type foo
     
     ⍟ These new definitions will replace existing ones of the
       same name and are ok to `update`:
@@ -253,14 +286,25 @@ unique type foo = Foo Nat
 
   ⍟ I've added these definitions:
   
-    unique type foo
+    type foo
     foo : Nat
 
 ```
 ```ucm
 .> delete foo
 
-  That name is ambiguous.
+  🤔
+  
+  That name is ambiguous. It could refer to any of the following
+  definitions:
+  
+    foo#jk19sm5bf8
+    foo#d97e0jhkmd
+  
+  You may:
+  
+    * Delete one by an unambiguous name, given above.
+    * Delete them all by re-issuing the previous command.
 
 ```
 ```ucm


### PR DESCRIPTION
This patch improves the delete term/type feedback a bit. Here's what it looks like at the moment (feedback welcome of course):

![2019-12-08-143548_1205x311_scrot](https://user-images.githubusercontent.com/1074598/70394996-78428380-19c8-11ea-9a5d-a4f87b3e48c0.png)

I did leave one case untouched: `display`ing an ambiguous hash. It still just says `That term is ambiguous.` like before. This is because it actually takes a `HashQualified` rather than a `HQSplit'`, so it didn't quite fit the new mold. Doable, for sure, but I thought I'd leave it for another patch because it brings up a separate question: why _can't_ I `delete.type #byhash`? :)