### PR TITLE
Add COMPLETE pragma to Reference

### DIFF
--- a/unison-core/src/Unison/Reference.hs
+++ b/unison-core/src/Unison/Reference.hs
@@ -48,6 +48,8 @@ data Reference
 
 pattern Derived h i n = DerivedId (Id h i n)
 
+{-# COMPLETE Builtin, Derived #-}
+
 -- A good idea, but causes a weird problem with view patterns in PatternP.hs in ghc 8.4.3
 --{-# COMPLETE Builtin, Derived #-}
 
@@ -67,7 +69,6 @@ toShortHash (Derived h i n) = SH.ShortHash (H.base32Hex h) index Nothing
   where
     -- todo: remove `n` parameter; must also update readSuffix
     index = Just $ showSuffix i n
-toShortHash (DerivedId _) = error "this should be covered above"
 
 -- (3,10) encoded as "3c10"
 -- (0,93) encoded as "0c93"

--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -982,8 +982,6 @@ instance Var v => Hashable1 (F v a p) where
                     B.Recorded (B.Resolve _ s) ->
                       [tag 2, Hashable.Text (Text.pack s)]
                   Ref (Reference.Builtin name) -> [tag 2, accumulateToken name]
-                  Ref Reference.Derived {} ->
-                    error "handled above, but GHC can't figure this out"
                   App a a2  -> [tag 3, hashed (hash a), hashed (hash a2)]
                   Ann a t   -> [tag 4, hashed (hash a), hashed (ABT.hash t)]
                   Sequence as -> tag 5 : varint (Sequence.length as) : map


### PR DESCRIPTION
Removes two calls to `error`