### PR TITLE
Refactor: replace _ patterns with DerivedId{}

### DIFF
--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -89,8 +89,8 @@ data Codebase m v a =
            , branchHashesByPrefix :: ShortBranchHash -> m (Set Branch.Hash)
            }
 
-bootstrapNames :: Names.Names0 
-bootstrapNames = 
+bootstrapNames :: Names.Names0
+bootstrapNames =
   Builtin.names0 <> UF.typecheckedToNames0 IOSource.typecheckedFile
 
 -- | Write all of the builtins types and IO types into the codebase. Returns the names of builtins
@@ -129,7 +129,7 @@ addDefsToCodebase c uf = do
     goType :: (t -> Decl v a) -> (Reference.Reference, t) -> m ()
     goType f (ref, decl) = case ref of
       Reference.DerivedId id -> putTypeDeclaration c id (f decl)
-      _                      -> pure ()
+      Reference.Builtin{}    -> pure ()
 
 getTypeOfConstructor ::
   (Monad m, Ord v) => Codebase m v a -> Reference -> Int -> m (Maybe (Type v a))
@@ -155,7 +155,7 @@ typeLookupForDependencies codebase = foldM go mempty
         Just (Right dd) ->
           pure $ TypeLookup mempty (Map.singleton ref dd) mempty
         Nothing -> pure mempty
-  go tl _builtin = pure tl -- codebase isn't consulted for builtins
+  go tl Reference.Builtin{} = pure tl -- codebase isn't consulted for builtins
 
 -- todo: can this be implemented in terms of TransitiveClosure.transitiveClosure?
 -- todo: add some tests on this guy?
@@ -186,7 +186,7 @@ transitiveDependencies code seen0 r = if Set.member r seen0
                 Just (Right dd) -> foldM (transitiveDependencies code)
                                          seen
                                          (DD.dependencies dd)
-        _ -> pure seen
+        Reference.Builtin{} -> pure seen
 
 toCodeLookup :: Codebase m v a -> CL.CodeLookup v m a
 toCodeLookup c = CL.CodeLookup (getTerm c) (getTypeDeclaration c)
@@ -205,12 +205,12 @@ makeSelfContained' code uf = do
   deps <- foldM (transitiveDependencies code) Set.empty (Set.unions deps0)
   decls <- fmap catMaybes . forM (toList deps) $ \case
     r@(Reference.DerivedId rid) -> fmap (r, ) <$> CL.getTypeDeclaration code rid
-    _                           -> pure Nothing
+    Reference.Builtin{}         -> pure Nothing
   let (es1, ds1) = partitionEithers [ bimap (r,) (r,) d | (r, d) <- decls ]
   bs1 <- fmap catMaybes . forM (toList deps) $ \case
     r@(Reference.DerivedId rid) ->
       fmap (r, ) <$> CL.getTerm code rid
-    _ -> pure Nothing
+    Reference.Builtin{} -> pure Nothing
   let
     allVars = Set.unions
       [ UF.allVars uf

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -183,7 +183,7 @@ commandLine config awaitInput setBranchRef rt notifyUser codebase =
           m1 <- Codebase.getWatch codebase UF.RegularWatch h
           m2 <- maybe (Codebase.getWatch codebase UF.TestWatch h) (pure . Just) m1
           pure $ Term.amap (const ()) <$> m2
-        watchCache _ = pure Nothing
+        watchCache Reference.Builtin{} = pure Nothing
     r <- Runtime.evaluateWatches codeLookup ppe watchCache rt selfContained
     case r of
       Left e -> pure (Left e)
@@ -194,7 +194,7 @@ commandLine config awaitInput setBranchRef rt notifyUser codebase =
             Reference.DerivedId h -> do
               let value' = Term.amap (const Parser.External) value
               Codebase.putWatch codebase kind h value'
-            _ -> pure ()
+            Reference.Builtin{} -> pure ()
         pure $ Right rs
 
 -- doTodo :: Monad m => Codebase m v a -> Branch0 -> m (TodoOutput v a)

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -794,11 +794,11 @@ loop = do
         loadedDerivedTerms <-
           fmap (Map.fromList . catMaybes) . for (toList collatedTerms) $ \case
             Reference.DerivedId i -> fmap (i,) <$> eval (LoadTerm i)
-            _ -> pure Nothing
+            Reference.Builtin{} -> pure Nothing
         loadedDerivedTypes <-
           fmap (Map.fromList . catMaybes) . for (toList collatedTypes) $ \case
             Reference.DerivedId i -> fmap (i,) <$> eval (LoadType i)
-            _ -> pure Nothing
+            Reference.Builtin{} -> pure Nothing
         -- Populate DisplayThings for the search results, in anticipation of
         -- displaying the definitions.
         loadedDisplayTerms :: Map Reference (DisplayThing (Term v Ann)) <-

--- a/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
@@ -353,7 +353,7 @@ propagate patch b = case validatePatch patch of
               mtm <- eval $ LoadTerm id
               tm  <- maybe (fail $ "Missing term with id " <> show id) pure mtm
               pure $ Just (termRef, (tm, tp))
-            _ -> pure Nothing
+            Reference.Builtin{} -> pure Nothing
         unhash m =
           let f (_oldTm, oldTyp) (v, newTm) = (v, newTm, oldTyp)
               m' = Map.intersectionWith f m (Term.unhashComponent (fst <$> m))
@@ -376,7 +376,7 @@ propagate patch b = case validatePatch patch of
                          pure
                          declm
           pure $ Just (typeRef, decl)
-        _ -> pure Nothing
+        Reference.Builtin{} -> pure Nothing
       unhash =
         Map.fromList . map reshuffle . Map.toList . Decl.unhashComponent
         where reshuffle (r, (v, decl)) = (v, (r, decl))

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -312,7 +312,7 @@ branchFromFiles loadMode rootDir h@(RawHash h') = do
           Right edits -> pure edits
 
 -- returns Nothing if `root` has no root branch (in `branchHeadDir root`)
-getRootBranch :: 
+getRootBranch ::
   MonadIO m => BranchLoadMode -> CodebasePath -> m (Branch m)
 getRootBranch loadMode root = do
   ifM (exists root)
@@ -322,7 +322,7 @@ getRootBranch loadMode root = do
       conflict -> traverse go conflict >>= \case
         x : xs -> foldM Branch.merge x xs
         []     -> missing
-    ) 
+    )
     missing
  where
   go single = case hashFromString single of
@@ -402,7 +402,7 @@ referentToString = Text.unpack . Referent.toText
 copyDir :: (FilePath -> Bool) -> FilePath -> FilePath -> IO ()
 copyDir predicate from to = do
   createDirectoryIfMissing True to
-  -- createDir doesn't create a new directory on disk, 
+  -- createDir doesn't create a new directory on disk,
   -- it creates a description of an existing directory,
   -- and it crashes if `from` doesn't exist.
   d <- createDir from
@@ -414,8 +414,8 @@ copyDir predicate from to = do
       unless exists . copyFile path $ replaceRoot from to path
 
 copyFromGit :: MonadIO m => FilePath -> FilePath -> m ()
-copyFromGit to from = liftIO . whenM (doesDirectoryExist from) $ 
-  copyDir (\x -> not ((".git" `isSuffixOf` x) || ("_head" `isSuffixOf` x))) 
+copyFromGit to from = liftIO . whenM (doesDirectoryExist from) $
+  copyDir (\x -> not ((".git" `isSuffixOf` x) || ("_head" `isSuffixOf` x)))
           from to
 
 -- Create a codebase structure at `localPath` if none exists, and
@@ -462,7 +462,7 @@ syncToDirectory fmtV fmtA codebase localPath branch = do
         unless alreadyExists $ do
           mayDecl <- Codebase.getTypeDeclaration codebase i
           maybe (calamity i) (putDecl (S.put fmtV) (S.put fmtA) localPath i) mayDecl
-      _ -> pure ()
+      Reference.Builtin{} -> pure ()
     -- Write all terms
     for_ (toList $ Star3.fact terms) $ \case
       Ref r@(Reference.DerivedId i) -> do
@@ -475,7 +475,8 @@ syncToDirectory fmtV fmtA codebase localPath branch = do
           -- If the term is a test, write the cached value too.
           mayTest <- Codebase.getWatch codebase UF.TestWatch i
           maybe (pure ()) (putWatch (S.put fmtV) (S.put fmtA) localPath UF.TestWatch i) mayTest
-      _ -> pure ()
+      Ref Reference.Builtin{} -> pure ()
+      Con{} -> pure ()
 
 putTerm
   :: MonadIO m

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -148,8 +148,8 @@ notifyUser dir o = case o of
 
   DisplayDefinitions outputLoc ppe types terms ->
     displayDefinitions outputLoc ppe types terms
-  DisplayRendered outputLoc pp -> 
-    displayRendered outputLoc pp 
+  DisplayRendered outputLoc pp ->
+    displayRendered outputLoc pp
   DisplayLinks ppe md types terms ->
     if Map.null md then pure $ P.wrap "Nothing to show here. Use the "
       <> IP.makeExample' IP.link <> " command to add links from this definition."
@@ -448,7 +448,7 @@ notifyUser dir o = case o of
       <> "Make sure there's a branch or commit with that name."
     PushDestinationHasNewStuff url treeish diff -> P.callout "⏸" . P.lines $ [
       P.wrap $ "The repository at" <> P.blue (P.text url)
-            <> (Monoid.fromMaybe $ treeish <&> \treeish -> 
+            <> (Monoid.fromMaybe $ treeish <&> \treeish ->
                   "at revision" <> P.blue (P.text treeish))
             <> "has some changes I don't know about:",
       "", P.indentN 2 (prettyDiff diff), "",
@@ -467,9 +467,9 @@ notifyUser dir o = case o of
           IP.patternName IP.pull,
           P.text (RemoteRepo.url r),
           P.shown p,
-          case RemoteRepo.commit r of 
+          case RemoteRepo.commit r of
             Just s -> P.text s
-            Nothing -> mempty 
+            Nothing -> mempty
           ]
         _ -> "⁉️ Unison bug - push command expected"
     NoRemoteNamespaceWithHash url treeish sbh -> P.wrap
@@ -592,10 +592,10 @@ notifyUser dir o = case o of
     $ "The `GitUrl.` entry in .unisonConfig for the current path has the value"
     <> (P.group . (<>",") . P.blue . P.text)
         (RemoteRepo.printNamespace repo (Just sbh) remotePath)
-    <> "which specifies a namespace hash" 
+    <> "which specifies a namespace hash"
     <> P.group (P.blue (prettySBH sbh) <> ".")
     , ""
-    , P.wrap $ 
+    , P.wrap $
       pushPull "I can't push to a specific hash, because it's immutable."
       ("It's no use for repeated pulls,"
       <> "because you would just get the same immutable namespace each time.")
@@ -604,7 +604,7 @@ notifyUser dir o = case o of
     , P.wrap $ "You can use"
     <> P.backticked (
         pushPull "push" "pull" pp
-        <> " " 
+        <> " "
         <> P.text (RemoteRepo.printNamespace repo Nothing remotePath))
     <> "if you want to" <> pushPull "push onto" "pull from" pp
     <> "the latest."
@@ -866,7 +866,7 @@ displayDefinitions' ppe0 types terms = P.syntaxToColor $ P.sep "\n\n" (prettyTyp
     <> tip "You might need to repair the codebase manually."
 
 displayRendered :: Maybe FilePath -> Pretty -> IO Pretty
-displayRendered outputLoc pp = 
+displayRendered outputLoc pp =
   maybe (pure pp) scratchAndDisplay outputLoc
   where
   scratchAndDisplay path = do
@@ -1150,15 +1150,15 @@ listOfDefinitions ppe detailed results =
 listOfLinks ::
   Var v => PPE.PrettyPrintEnv -> [(HQ.HashQualified, Maybe (Type v a))] -> IO Pretty
 listOfLinks _ [] = pure . P.callout "😶" . P.wrap $
-  "No results. Try using the " <> 
-  IP.makeExample IP.link [] <> 
+  "No results. Try using the " <>
+  IP.makeExample IP.link [] <>
   "command to add outgoing links to a definition."
 listOfLinks ppe results = pure $ P.lines [
     P.numberedColumn2 num [
     (P.syntaxToColor $ prettyHashQualified hq, ": " <> prettyType typ) | (hq,typ) <- results
     ], "",
-    tip $ "Try using" <> IP.makeExample IP.display ["1"] 
-       <> "to display the first result or" 
+    tip $ "Try using" <> IP.makeExample IP.display ["1"]
+       <> "to display the first result or"
        <> IP.makeExample IP.view ["1"] <> "to view its source."
     ]
   where

--- a/parser-typechecker/src/Unison/Runtime/Rt1.hs
+++ b/parser-typechecker/src/Unison/Runtime/Rt1.hs
@@ -239,7 +239,7 @@ compilationEnv env t = do
         Just (Right dd) -> pure $
           let arities = DD.constructorArities dd
           in [ ((r, i), arity) | (arity, i) <- arities `zip` [0..] ]
-    _ -> pure []
+    R.Builtin{} -> pure []
   let cenv = CompilationEnv mempty arityMap
 
     -- deps = Term.dependencies t


### PR DESCRIPTION
This one is arguable, but overall I think avoiding `_` is smart because:

- It allows you to add new constructors to `Reference` more safely (though that is probably not likely to happen)
- It is a nice reminder of the complete shape of `Reference`