### PR TITLE
Add 'delete' command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,5 @@ install:
 - stack --no-terminal exec tests
 - stack --no-terminal exec transcripts
 # fail if running transcripts modified any versioned files
-- x=`git status --porcelain -uno` bash -c 'if [[ -n $x ]]; then echo "$x" && false; fi' 
+- git diff
+- x=`git status --porcelain -uno` bash -c 'if [[ -n $x ]]; then echo "$x" && false; fi'

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -66,7 +66,7 @@ data Input
     | MovePatchI Path.Split' Path.Split'
     | CopyPatchI Path.Split' Path.Split'
     -- delete = unname
-    -- | DeleteDefnI [Path.HQSplit']
+    | DeleteI Path.HQSplit'
     | DeleteTermI Path.HQSplit'
     | DeleteTypeI Path.HQSplit'
     | DeleteBranchI (Maybe Path.Split')

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -82,12 +82,14 @@ data Output v
   | ParseResolutionFailures Input String [Names.ResolutionFailure v Ann]
   | TypeHasFreeVars Input (Type v Ann)
   | TermAlreadyExists Input Path.Split' (Set Referent)
+  | NameAmbiguous Input Path.HQSplit' (Set Referent) (Set Reference)
   | TypeAmbiguous Input Path.HQSplit' (Set Reference)
   | TermAmbiguous Input (Either Path.HQSplit' HQ.HashQualified) (Set Referent)
   | HashAmbiguous Input ShortHash (Set Referent)
   | BranchHashAmbiguous Input ShortBranchHash (Set ShortBranchHash)
   | BadDestinationBranch Input Path'
   | BranchNotFound Input Path'
+  | NameNotFound Input Path.HQSplit'
   | PatchNotFound Input Path.Split'
   | TypeNotFound Input Path.HQSplit'
   | TermNotFound Input Path.HQSplit'
@@ -228,11 +230,13 @@ isFailure o = case o of
   ParseResolutionFailures{} -> True
   TypeHasFreeVars{} -> True
   TermAlreadyExists{} -> True
+  NameAmbiguous{} -> True
   TypeAmbiguous{} -> True
   TermAmbiguous{} -> True
   BranchHashAmbiguous{} -> True
   BadDestinationBranch{} -> True
   BranchNotFound{} -> True
+  NameNotFound{} -> True
   PatchNotFound{} -> True
   TypeNotFound{} -> True
   TermNotFound{} -> True

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -200,22 +200,22 @@ view = InputPattern "view" [] [(OnePlus, exactDefinitionQueryArg)]
 display :: InputPattern
 display = InputPattern "display" ["show"] [(Required, exactDefinitionQueryArg)]
       "`display foo` prints a rendered version of the term `foo`."
-      (\case 
+      (\case
         [s] -> pure (Input.DisplayI Input.ConsoleLocation s)
         _ -> Left (I.help display))
 
 displayTo :: InputPattern
 displayTo = InputPattern "display.to" [] [(Required, noCompletions), (Required, exactDefinitionQueryArg)]
-      (P.wrap $ makeExample displayTo ["<filename>", "foo"] 
+      (P.wrap $ makeExample displayTo ["<filename>", "foo"]
              <> "prints a rendered version of the term `foo` to the given file.")
-      (\case 
+      (\case
         [file,s] -> pure (Input.DisplayI (Input.FileLocation file) s)
         _ -> Left (I.help displayTo))
 
-docs :: InputPattern 
+docs :: InputPattern
 docs = InputPattern "docs" [] [(Required, exactDefinitionQueryArg)]
       ("`docs foo` shows documentation for the definition `foo`.")
-      (\case 
+      (\case
         [s] -> first fromString $ Input.DocsI <$> Path.parseHQSplit' s
         _ -> Left (I.help docs))
 
@@ -314,6 +314,18 @@ renameType = InputPattern "move.type" ["rename.type"]
       _ -> Left . P.warnCallout $ P.wrap
         "`rename.type` takes two arguments, like `rename.type oldname newname`.")
 
+delete :: InputPattern
+delete = InputPattern "delete" []
+    [(OnePlus, exactDefinitionTermQueryArg)]
+    "`delete foo` removes the term or type name `foo` from the namespace."
+    (\case
+      [query] -> first fromString $ do
+        p <- Path.parseHQSplit' query
+        pure $ Input.DeleteI p
+      _ -> Left . P.warnCallout $ P.wrap
+        "`delete` takes an argument, like `delete name`."
+    )
+
 deleteTerm :: InputPattern
 deleteTerm = InputPattern "delete.term" []
     [(OnePlus, exactDefinitionTermQueryArg)]
@@ -323,7 +335,7 @@ deleteTerm = InputPattern "delete.term" []
         p <- Path.parseHQSplit' query
         pure $ Input.DeleteTermI p
       _ -> Left . P.warnCallout $ P.wrap
-        "`delete.term` takes one or more arguments, like `delete.term name`."
+        "`delete.term` takes an argument, like `delete.term name`."
     )
 
 deleteType :: InputPattern
@@ -335,7 +347,7 @@ deleteType = InputPattern "delete.type" []
         p <- Path.parseHQSplit' query
         pure $ Input.DeleteTypeI p
       _ -> Left . P.warnCallout $ P.wrap
-        "`delete.type` takes one or more arguments, like `delete.type name`."
+        "`delete.type` takes an argument, like `delete.type name`."
     )
 
 aliasTerm :: InputPattern
@@ -568,10 +580,10 @@ push = InputPattern
         (P.parse UriParser.repoPath "url" (Text.pack url))
       when (isJust sbh)
         $ Left "Can't push to a particular remote namespace hash."
-      p <- case rest of 
+      p <- case rest of
         [] -> Right Path.relativeEmpty'
-        [path] -> first fromString $ Path.parsePath' path 
-        _ -> Left (I.help push) 
+        [path] -> first fromString $ Path.parsePath' path
+        _ -> Left (I.help push)
       Right $ Input.PushRemoteBranchI (Just (repo, path)) p
   )
 
@@ -926,6 +938,7 @@ validInputs =
   [ help
   , add
   , update
+  , delete
   , forkLocal
   , mergeLocal
   , previewMergeLocal

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -148,8 +148,8 @@ notifyUser dir o = case o of
 
   DisplayDefinitions outputLoc ppe types terms ->
     displayDefinitions outputLoc ppe types terms
-  DisplayRendered outputLoc pp -> 
-    displayRendered outputLoc pp 
+  DisplayRendered outputLoc pp ->
+    displayRendered outputLoc pp
   DisplayLinks ppe md types terms ->
     if Map.null md then pure $ P.wrap "Nothing to show here. Use the "
       <> IP.makeExample' IP.link <> " command to add links from this definition."
@@ -198,6 +198,8 @@ notifyUser dir o = case o of
       <> (P.syntaxToColor $ P.indent "  " (P.lines (prettyHashQualified <$> hqs)))
   PatchNotFound input _ ->
     pure . P.warnCallout $ "I don't know about that patch."
+  NameNotFound _ _ ->
+    pure . P.warnCallout $ "I don't know about that name."
   TermNotFound input _ ->
     pure . P.warnCallout $ "I don't know about that term."
   TypeNotFound input _ ->
@@ -448,7 +450,7 @@ notifyUser dir o = case o of
       <> "Make sure there's a branch or commit with that name."
     PushDestinationHasNewStuff url treeish diff -> P.callout "⏸" . P.lines $ [
       P.wrap $ "The repository at" <> P.blue (P.text url)
-            <> (Monoid.fromMaybe $ treeish <&> \treeish -> 
+            <> (Monoid.fromMaybe $ treeish <&> \treeish ->
                   "at revision" <> P.blue (P.text treeish))
             <> "has some changes I don't know about:",
       "", P.indentN 2 (prettyDiff diff), "",
@@ -467,9 +469,9 @@ notifyUser dir o = case o of
           IP.patternName IP.pull,
           P.text (RemoteRepo.url r),
           P.shown p,
-          case RemoteRepo.commit r of 
+          case RemoteRepo.commit r of
             Just s -> P.text s
-            Nothing -> mempty 
+            Nothing -> mempty
           ]
         _ -> "⁉️ Unison bug - push command expected"
     NoRemoteNamespaceWithHash url treeish sbh -> P.wrap
@@ -592,10 +594,10 @@ notifyUser dir o = case o of
     $ "The `GitUrl.` entry in .unisonConfig for the current path has the value"
     <> (P.group . (<>",") . P.blue . P.text)
         (RemoteRepo.printNamespace repo (Just sbh) remotePath)
-    <> "which specifies a namespace hash" 
+    <> "which specifies a namespace hash"
     <> P.group (P.blue (prettySBH sbh) <> ".")
     , ""
-    , P.wrap $ 
+    , P.wrap $
       pushPull "I can't push to a specific hash, because it's immutable."
       ("It's no use for repeated pulls,"
       <> "because you would just get the same immutable namespace each time.")
@@ -604,7 +606,7 @@ notifyUser dir o = case o of
     , P.wrap $ "You can use"
     <> P.backticked (
         pushPull "push" "pull" pp
-        <> " " 
+        <> " "
         <> P.text (RemoteRepo.printNamespace repo Nothing remotePath))
     <> "if you want to" <> pushPull "push onto" "pull from" pp
     <> "the latest."
@@ -613,6 +615,7 @@ notifyUser dir o = case o of
     P.wrap $ "I don't know of a namespace with that hash."
   NotImplemented -> pure $ P.wrap "That's not implemented yet. Sorry! 😬"
   BranchAlreadyExists _ _ -> pure "That namespace already exists."
+  NameAmbiguous _ _ _ _ -> pure "That name is ambiguous."
   TypeAmbiguous _ _ _ -> pure "That type is ambiguous."
   TermAmbiguous _ _ _ -> pure "That term is ambiguous."
   HashAmbiguous _ h rs -> pure . P.callout "\129300" . P.lines $ [
@@ -866,7 +869,7 @@ displayDefinitions' ppe0 types terms = P.syntaxToColor $ P.sep "\n\n" (prettyTyp
     <> tip "You might need to repair the codebase manually."
 
 displayRendered :: Maybe FilePath -> Pretty -> IO Pretty
-displayRendered outputLoc pp = 
+displayRendered outputLoc pp =
   maybe (pure pp) scratchAndDisplay outputLoc
   where
   scratchAndDisplay path = do
@@ -1150,15 +1153,15 @@ listOfDefinitions ppe detailed results =
 listOfLinks ::
   Var v => PPE.PrettyPrintEnv -> [(HQ.HashQualified, Maybe (Type v a))] -> IO Pretty
 listOfLinks _ [] = pure . P.callout "😶" . P.wrap $
-  "No results. Try using the " <> 
-  IP.makeExample IP.link [] <> 
+  "No results. Try using the " <>
+  IP.makeExample IP.link [] <>
   "command to add outgoing links to a definition."
 listOfLinks ppe results = pure $ P.lines [
     P.numberedColumn2 num [
     (P.syntaxToColor $ prettyHashQualified hq, ": " <> prettyType typ) | (hq,typ) <- results
     ], "",
-    tip $ "Try using" <> IP.makeExample IP.display ["1"] 
-       <> "to display the first result or" 
+    tip $ "Try using" <> IP.makeExample IP.display ["1"]
+       <> "to display the first result or"
        <> IP.makeExample IP.view ["1"] <> "to view its source."
     ]
   where

--- a/unison-src/transcripts/delete.md
+++ b/unison-src/transcripts/delete.md
@@ -1,0 +1,109 @@
+# Delete
+
+The delete command can delete both terms and types, as long as it's given an
+unambiguous name.
+
+First, let's make sure it complains when we try to delete a name that doesn't
+exist.
+
+```ucm:error
+.> delete foo
+```
+
+Now for some easy cases. Deleting an unambiguous term, then deleting an
+unambiguous type.
+
+```unison
+foo = 1
+unique type Foo = Foo Nat
+```
+
+```ucm
+.> add
+.> delete foo
+.> delete Foo
+.> delete Foo.Foo
+```
+
+How about an ambiguous term?
+
+```unison
+foo = 1
+```
+
+```ucm
+.a> add
+```
+
+```unison
+foo = 2
+```
+
+```ucm
+.b> add
+.a> merge .b
+```
+
+```ucm:error
+.a> delete foo
+```
+
+I can force my delete through by re-issuing the command.
+
+```ucm
+.a> delete foo
+```
+
+Let's repeat all that on a type, for completeness.
+
+```unison
+unique type Foo = Foo Nat
+```
+
+```ucm
+.a> add
+```
+
+```unison
+unique type Foo = Foo Nat
+```
+
+```ucm
+.b> add
+.a> merge .b
+```
+
+```ucm:error
+.a> delete Foo
+```
+
+```ucm
+.a> delete Foo
+```
+
+```ucm:error
+.a> delete Foo.Foo
+```
+
+```ucm
+.a> delete Foo.Foo
+```
+
+Finally, let's try to delete a term and a type with the same name.
+
+```unison
+foo = 1
+unique type foo = Foo Nat
+```
+
+```ucm
+.> add
+```
+
+```ucm:error
+.> delete foo
+```
+
+```ucm
+.> delete foo
+```

--- a/unison-src/transcripts/delete.output.md
+++ b/unison-src/transcripts/delete.output.md
@@ -1,0 +1,269 @@
+# Delete
+
+The delete command can delete both terms and types, as long as it's given an
+unambiguous name.
+
+First, let's make sure it complains when we try to delete a name that doesn't
+exist.
+
+```ucm
+.> delete foo
+
+  ⚠️
+  
+  I don't know about that name.
+
+```
+Now for some easy cases. Deleting an unambiguous term, then deleting an
+unambiguous type.
+
+```unison
+foo = 1
+unique type Foo = Foo Nat
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique type Foo
+      foo : Nat
+   
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    unique type Foo
+    foo : Nat
+
+.> delete foo
+
+.> delete Foo
+
+.> delete Foo.Foo
+
+```
+How about an ambiguous term?
+
+```unison
+foo = 1
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      foo : Nat
+   
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+```
+```ucm
+  ☝️  The namespace .a is empty.
+
+.a> add
+
+  ⍟ I've added these definitions:
+  
+    foo : Nat
+
+```
+```unison
+foo = 2
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions will replace existing ones of the
+      same name and are ok to `update`:
+    
+      foo : Nat
+   
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+```
+```ucm
+  ☝️  The namespace .b is empty.
+
+.b> add
+
+  ⍟ I've added these definitions:
+  
+    foo : Nat
+
+.a> merge .b
+
+  🆕
+  
+  Here's what's changed in the current namespace after the merge:
+  
+  + Adds / updates:
+  
+    foo
+  
+  Tip: You can always `undo` if this wasn't what you wanted.
+
+```
+```ucm
+.a> delete foo
+
+  That name is ambiguous.
+
+```
+I can force my delete through by re-issuing the command.
+
+```ucm
+.a> delete foo
+
+```
+Let's repeat all that on a type, for completeness.
+
+```unison
+unique type Foo = Foo Nat
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique type Foo
+   
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+```
+```ucm
+.a> add
+
+  ⍟ I've added these definitions:
+  
+    unique type Foo
+
+```
+```unison
+unique type Foo = Foo Nat
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions will replace existing ones of the
+      same name and are ok to `update`:
+    
+      unique type Foo
+   
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+```
+```ucm
+.b> add
+
+  ⍟ I've added these definitions:
+  
+    unique type Foo
+
+.a> merge .b
+
+  🆕
+  
+  Here's what's changed in the current namespace after the merge:
+  
+  + Adds / updates:
+  
+    Foo foo Foo.Foo
+  
+  Tip: You can always `undo` if this wasn't what you wanted.
+
+```
+```ucm
+.a> delete Foo
+
+  That name is ambiguous.
+
+```
+```ucm
+.a> delete Foo
+
+```
+```ucm
+.a> delete Foo.Foo
+
+  That name is ambiguous.
+
+```
+```ucm
+.a> delete Foo.Foo
+
+```
+Finally, let's try to delete a term and a type with the same name.
+
+```unison
+foo = 1
+unique type foo = Foo Nat
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique type foo
+    
+    ⍟ These new definitions will replace existing ones of the
+      same name and are ok to `update`:
+    
+      foo : Nat
+   
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    unique type foo
+    foo : Nat
+
+```
+```ucm
+.> delete foo
+
+  That name is ambiguous.
+
+```
+```ucm
+.> delete foo
+
+```


### PR DESCRIPTION
This patch adds `delete`, which sort of combines `delete.term` and `delete.type`. If there are any ambiguities, it bails. Transcript test included!

Fixes #662 