### PR TITLE
ucm run: do not set up interactive environment

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -32,3 +32,4 @@ The format for this list: name, GitHub handle, and then optional blurb about wha
 * Florian Thurm (@0xflotus)
 * Evan Burchard (@evanburchard)
 * Alvaro Carrasco (@alvaroc1)
+* Vladislav Zavialov (@int-index)

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -43,7 +43,6 @@ import qualified Unison.UnisonFile             as UF
 import           Unison.Util.Free               ( Free )
 import qualified Unison.Util.Free              as Free
 import           Unison.Var                     ( Var )
-import qualified Unison.Var                    as Var
 import qualified Unison.Result as Result
 import           Unison.FileParsers             ( parseAndSynthesizeFile
                                                 , synthesizeFile'
@@ -167,13 +166,8 @@ commandLine config awaitInput setBranchRef rt notifyUser codebase =
   eval1 :: PPE.PrettyPrintEnv -> Term.AnnotatedTerm v Ann -> _
   eval1 ppe tm = do
     let codeLookup = Codebase.toCodeLookup codebase
-    let uf = UF.UnisonFile mempty mempty mempty
-               (Map.singleton UF.RegularWatch [(Var.nameds "result", tm)])
-    selfContained <- Codebase.makeSelfContained' codeLookup uf
-    r <- Runtime.evaluateWatches codeLookup ppe Runtime.noCache rt selfContained
-    pure $ r <&> \(_,map) ->
-      let [(_loc, _kind, _hash, _src, value, _isHit)] = Map.elems map
-      in Term.amap (const Parser.External) value
+    r <- Runtime.evaluateTerm codeLookup ppe rt tm
+    pure $ r <&> Term.amap (const Parser.External)
 
   evalUnisonFile :: PPE.PrettyPrintEnv -> UF.TypecheckedUnisonFile v Ann -> _
   evalUnisonFile ppe (UF.discardTypes -> unisonFile) = do

--- a/parser-typechecker/src/Unison/Codebase/Execute.hs
+++ b/parser-typechecker/src/Unison/Codebase/Execute.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Execute a computation of type '{IO} () that has been previously added to
+-- the codebase, without setting up an interactive environment.
+--
+-- This allows one to run standalone applications implemented in the Unison
+-- language.
+
+module Unison.Codebase.Execute where
+
+import Unison.Prelude
+
+import           Unison.Codebase.MainTerm      ( getMainTerm )
+import qualified Unison.Codebase.MainTerm      as MainTerm
+import qualified Unison.Codebase               as Codebase
+import           Unison.Parser                 ( Ann )
+import qualified Unison.Codebase.Runtime       as Runtime
+import           Unison.Codebase.Runtime       ( Runtime )
+import           Unison.Var                    ( Var )
+import qualified Unison.PrettyPrintEnv         as PPE
+import qualified Unison.Names3                 as Names3
+import qualified Unison.Codebase.Branch        as Branch
+import           System.Exit (die)
+import           Control.Exception (finally)
+
+execute
+  :: Var v
+  => Codebase.Codebase IO v Ann
+  -> Runtime v
+  -> String
+  -> IO ()
+execute codebase runtime mainName =
+  (`finally` Runtime.terminate runtime) $ do
+    root <- Codebase.getRootBranch codebase
+    let parseNames0 = Names3.makeAbsolute0 (Branch.toNames0 (Branch.head root))
+        loadTypeOfTerm = Codebase.getTypeOfTerm codebase
+    mt <- getMainTerm loadTypeOfTerm parseNames0 mainName
+    case mt of
+      MainTerm.NotAFunctionName s -> die ("Not a function name: " ++ s)
+      MainTerm.NotFound s -> die ("Not found: " ++ s)
+      MainTerm.BadType s -> die (s ++ " is not of type '{IO} ()")
+      MainTerm.Success _ tm _ -> do
+        let codeLookup = Codebase.toCodeLookup codebase
+            ppe = PPE.PrettyPrintEnv (const Nothing) (const Nothing)
+        void $ Runtime.evaluateTerm codeLookup ppe runtime tm

--- a/parser-typechecker/src/Unison/Codebase/MainTerm.hs
+++ b/parser-typechecker/src/Unison/Codebase/MainTerm.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Find a computation of type '{IO} () in the codebase.
+module Unison.Codebase.MainTerm where
+
+import Unison.Prelude
+
+import           Unison.Parser                  ( Ann )
+import qualified Unison.Parser                 as Parser
+import qualified Unison.Term                   as Term
+import           Unison.Var                     ( Var )
+import qualified Unison.DataDeclaration        as DD
+import qualified Unison.HashQualified          as HQ
+import qualified Unison.Referent               as Referent
+import qualified Unison.Names3                 as Names3
+import           Unison.Reference               ( Reference )
+import qualified Unison.Type                   as Type
+import           Unison.Type                    ( Type )
+import qualified Unison.Typechecker as Typechecker
+import           Unison.Runtime.IOSource        ( ioReference )
+
+data MainTerm v
+  = NotAFunctionName String
+  | NotFound String
+  | BadType String
+  | Success HQ.HashQualified (Term.AnnotatedTerm v Ann) (Type v Ann)
+
+getMainTerm
+  :: (Monad m, Var v)
+  => (Reference -> m (Maybe (Type v Ann)))
+  -> Names3.Names0
+  -> String
+  -> m (MainTerm v)
+getMainTerm loadTypeOfTerm parseNames0 mainName =
+  case HQ.fromString mainName of
+    Nothing -> pure (NotAFunctionName mainName)
+    Just hq -> do
+      let refs = Names3.lookupHQTerm hq (Names3.Names parseNames0 mempty)
+      let a = Parser.External
+      case toList refs of
+        [Referent.Ref ref] -> do
+          typ <- loadTypeOfTerm ref
+          case typ of
+            Just typ | Typechecker.isSubtype typ (nullaryMain a) -> do
+              let tm = DD.forceTerm a a (Term.ref a ref)
+              return (Success hq tm typ)
+            _ -> pure (BadType mainName)
+        _ -> pure (NotFound mainName)
+
+-- {IO} ()
+ioUnit :: Ord v => a -> Type.Type v a
+ioUnit a = Type.effect a [Type.ref a ioReference] (Type.ref a DD.unitRef)
+
+-- '{IO} ()
+nullaryMain :: Ord v => a -> Type.Type v a
+nullaryMain a = Type.arrow a (Type.ref a DD.unitRef) (ioUnit a)
+
+mainTypes :: Ord v => a -> [Type v a]
+mainTypes a = [nullaryMain a]

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -75,6 +75,8 @@ library
     Unison.Codebase.TranscriptParser
     Unison.Codebase.TypeEdit
     Unison.Codebase.Watch
+    Unison.Codebase.Execute
+    Unison.Codebase.MainTerm
     Unison.CommandLine
     Unison.CommandLine.DisplayValues
     Unison.CommandLine.InputPattern

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -7,6 +7,7 @@ module Main where
 import Unison.Prelude
 import           System.Directory               ( getCurrentDirectory, getHomeDirectory )
 import           System.Environment             ( getArgs )
+import           Unison.Codebase.Execute        ( execute )
 import qualified Unison.Codebase.FileCodebase  as FileCodebase
 import qualified Unison.CommandLine.Main       as CommandLine
 import qualified Unison.Runtime.Rt1IO          as Rt1
@@ -85,7 +86,7 @@ main = do
     ["init"] -> FileCodebase.initCodebaseAndExit mcodepath
     "run" : [mainName] -> do
       theCodebase <- FileCodebase.getCodebaseOrExit mcodepath
-      launch currentDir configFilePath theCodebase [Right $ Input.ExecuteI mainName, Right Input.QuitI]
+      execute theCodebase Rt1.runtime mainName
     "run.file" : file : [mainName] | isDotU file -> do
       e <- safeReadUtf8 file
       case e of


### PR DESCRIPTION
This patch changes the way `ucm run` works, so that it doesn't set up an interactive environment, does not watch the current directory, does not print any messages to the user. As such, now it can be used to run applications implemented in Unison.

Before this patch, running `main = '(putText stdout "Hello, World!\n")` via `ucm run` resulted in the following output:

```
   _____     _             
  |  |  |___|_|___ ___ ___ 
  |  |  |   | |_ -| . |   |
  |_____|_|_|_|___|___|_|_|
  Welcome to Unison!
  I'm currently watching for changes to .u files under ~/Projects/unison
  Type help to get help. :sunglasses:
Hello, World!
```

Now it just prints `Hello, World!` as expected.