### PR TITLE
Make Name an abstract type

### DIFF
--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -17,7 +17,7 @@ import qualified Unison.Codebase.Branch        as Branch
 import qualified Unison.Codebase.CodeLookup    as CL
 import qualified Unison.Codebase.Reflog        as Reflog
 import qualified Unison.DataDeclaration        as DD
-import           Unison.Name                    ( Name(..) )
+import qualified Unison.Name                   as Name
 import qualified Unison.Names2                 as Names
 import           Unison.Reference               ( Reference )
 import qualified Unison.Reference              as Reference
@@ -110,7 +110,7 @@ initializeCodebase :: forall m. Monad m => Codebase m Symbol Parser.Ann -> m ()
 initializeCodebase c = do
   initializeBuiltinCode c
   let b0 = BranchUtil.addFromNames0
-            (Names.prefix0 (Name "builtin") bootstrapNames)
+            (Names.prefix0 (Name.unsafeFromText "builtin") bootstrapNames)
             Branch.empty0
   putRootBranch c (Branch.one b0)
 

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -195,7 +195,7 @@ branch0 terms types children edits =
   Branch0 terms types children edits
           deepTerms' deepTypes' deepPaths' deepEdits'
   where
-  nameSegToName = Name . NameSegment.toText
+  nameSegToName = Name.unsafeFromText . NameSegment.toText
   deepTerms' = Star3.mapD1 nameSegToName terms
     <> foldMap go (Map.toList children)
    where

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -72,7 +72,7 @@ import qualified Unison.DataDeclaration        as DD
 import qualified Unison.HashQualified          as HQ
 import qualified Unison.HashQualified'         as HQ'
 import qualified Unison.Name                   as Name
-import           Unison.Name                    ( Name(Name) )
+import           Unison.Name                    ( Name )
 import           Unison.Names3                  ( Names(..), Names0
                                                 , pattern Names0 )
 import qualified Unison.Names2                 as Names
@@ -2137,7 +2137,7 @@ getTermsIncludingHistorical (p, hq) b = case Set.toList refs of
   [] -> case hq of
     HQ'.HashQualified n hs -> do
       names <- findHistoricalHQs
-        $ Set.fromList [HQ.HashQualified (Name (NameSegment.toText n)) hs]
+        $ Set.fromList [HQ.HashQualified (Name.unsafeFromText (NameSegment.toText n)) hs]
       pure . R.ran $ Names.terms names
     _ -> pure Set.empty
   _ -> pure refs
@@ -2156,9 +2156,9 @@ findHistoricalHQs lexedHQs0 = do
     -- Anyway, this function takes a name, tries to determine whether it is
     -- relative or absolute, and tries to return the corresponding name that is
     -- /relative/ to the root.
-    preprocess n@(Name (Text.unpack -> t)) = case t of
+    preprocess n = case Name.toString n of
       -- some absolute name that isn't just "."
-      '.' : t@(_:_)  -> Name . Text.pack $ t
+      '.' : t@(_:_)  -> Name.unsafeFromString t
       -- something in current path
       _ ->  if Path.isRoot currentPath then n
             else Name.joinDot (Path.toName . Path.unabsolute $ currentPath) n
@@ -2247,7 +2247,7 @@ basicNames0' = do
       -- all names, but with local names in their relative form only, rather
       -- than absolute; external names appear as absolute
       currentAndExternalNames0 = currentPathNames0 `Names3.unionLeft0` absDot externalNames where
-        absDot = Names.prefix0 (Name.Name "")
+        absDot = Names.prefix0 (Name.unsafeFromText "")
         externalNames = rootNames `Names.difference` pathPrefixed currentPathNames0
         rootNames = Branch.toNames0 root0
         pathPrefixed = case Path.unabsolute currentPath' of

--- a/parser-typechecker/src/Unison/Codebase/NameSegment.hs
+++ b/parser-typechecker/src/Unison/Codebase/NameSegment.hs
@@ -27,7 +27,7 @@ toString :: NameSegment -> String
 toString = Text.unpack . toText
 
 toName :: NameSegment -> Name.Name
-toName = Name.Name . toText
+toName = Name.unsafeFromText . toText
 
 segments :: Name.Name -> [NameSegment]
 segments name = NameSegment <$> Text.splitOn "." (Name.toText name)

--- a/unison-core/src/Unison/HashQualified.hs
+++ b/unison-core/src/Unison/HashQualified.hs
@@ -9,7 +9,7 @@ import           Data.Maybe                     ( fromJust
                                                 )
 import qualified Data.Text                     as Text
 import           Prelude                 hiding ( take )
-import           Unison.Name                    ( Name(Name) )
+import           Unison.Name                    ( Name )
 import qualified Unison.Name                   as Name
 import           Unison.Reference               ( Reference )
 import qualified Unison.Reference              as Reference
@@ -33,7 +33,7 @@ stripNamespace namespace hq = case hq of
   ho                    -> ho
  where
   strip name =
-    fromMaybe name $ Name.stripNamePrefix (Name namespace) name
+    fromMaybe name $ Name.stripNamePrefix (Name.unsafeFromText namespace) name
 
 toName :: HashQualified' n -> Maybe n
 toName = \case
@@ -41,7 +41,7 @@ toName = \case
   HashQualified name _ -> Just name
   HashOnly _           -> Nothing
 
--- Sort the list of names by length of segments: smaller number of 
+-- Sort the list of names by length of segments: smaller number of
 -- segments is listed first. NameOnly < Hash qualified < Hash only
 --
 -- Examples:

--- a/unison-core/src/Unison/Name.hs
+++ b/unison-core/src/Unison/Name.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings   #-}
 
 module Unison.Name
-  ( Name(..)
+  ( Name
   , fromString
   , isPrefixOf
   , joinDot
@@ -13,6 +13,7 @@ module Unison.Name
   , stripPrefixes
   , suffixes
   , toString
+  , toText
   , toVar
   , unqualified
   , unqualified'
@@ -105,7 +106,7 @@ parent (Name txt) = case unsnoc (Text.splitOn "." txt) of
   Just (init,_) -> Just $ Name (Text.intercalate "." init)
 
 suffixes :: Name -> [Name]
-suffixes (Name n) = 
+suffixes (Name n) =
   fmap up . tails . dropWhile (== "") $ Text.splitOn "." n
   where
   up ns = Name (Text.intercalate "." ns)


### PR DESCRIPTION
This patch hides the `Name` constructor from the world (goal: possibly refactor `Name` to something with more structure like `[Text]` or `NonEmpty Text`; see #741)