### PR TITLE
Make names0ToNames more generic

### DIFF
--- a/unison-core/src/Unison/Names2.hs
+++ b/unison-core/src/Unison/Names2.hs
@@ -45,7 +45,7 @@ import Unison.Prelude
 
 import qualified Data.Set                     as Set
 import           Prelude                      hiding (filter)
-import           Unison.HashQualified'        (HashQualified)
+import           Unison.HashQualified'        (HashQualified, HashQualified')
 import qualified Unison.HashQualified'        as HQ
 import           Unison.Name                  (Name)
 import qualified Unison.Name                  as Name
@@ -70,7 +70,7 @@ data Names' n = Names
 type Names = Names' HashQualified
 type Names0 = Names' Name
 
-names0ToNames :: Names0 -> Names
+names0ToNames :: Ord n => Names' n -> Names' (HashQualified' n)
 names0ToNames names0 = Names terms' types' where
   terms' = R.map doTerm (terms names0)
   types' = R.map doType (types names0)


### PR DESCRIPTION
This function was pinned to `Name`s but it doesn't have to me. (Most functions in this module are generic over `n`)