### PR TITLE
Show branch diff after delete

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -388,8 +388,11 @@ loop = do
             (failed, failedDependents) <-
               getEndangeredDependents (eval . GetDependents) toDelete rootNames
             if failed == mempty then do
-              stepManyAt . fmap (BranchUtil.makeDeleteTermName resolvedPath) . toList $ tms
-              stepManyAt . fmap (BranchUtil.makeDeleteTypeName resolvedPath) . toList $ tys
+              let makeDeleteTermNames = fmap (BranchUtil.makeDeleteTermName resolvedPath) . toList $ tms
+              let makeDeleteTypeNames = fmap (BranchUtil.makeDeleteTypeName resolvedPath) . toList $ tys
+              stepManyAt (makeDeleteTermNames ++ makeDeleteTypeNames)
+              root'' <- use root
+              respond $ ShowDiff input (Branch.namesDiff root' root'')
             else do
               failed <-
                 loadSearchResults $ SR.fromNames failed

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -759,15 +759,21 @@ notifyUser dir o = case o of
           , ""
           , prettyDiff diff
           ]
-    Input.DeleteBranchI _ -> P.callout "🆕" . P.lines $
-      [ P.wrap $
-          "Here's what's changed after the delete:"
-      , ""
-      , prettyDiff diff
-      , ""
-      , tip "You can always `undo` if this wasn't what you wanted."
-      ]
+    Input.DeleteBranchI{} -> deleteDiff
+    Input.DeleteI{}       -> deleteDiff
+    Input.DeleteTermI{}   -> deleteDiff
+    Input.DeleteTypeI{}   -> deleteDiff
     _ -> prettyDiff diff
+    where
+      deleteDiff =
+        P.callout "🆕" . P.lines $
+          [ P.wrap $
+              "Here's what's changed after the delete:"
+          , ""
+          , prettyDiff diff
+          , ""
+          , tip "You can always `undo` if this wasn't what you wanted."
+          ]
   NothingTodo input -> pure . P.callout "😶" $ case input of
     Input.MergeLocalBranchI src dest ->
       P.wrap $ "The merge had no effect, since the destination"

--- a/unison-src/transcripts/delete.output.md
+++ b/unison-src/transcripts/delete.output.md
@@ -47,9 +47,39 @@ type Foo = Foo Nat
 
 .> delete foo
 
+  🆕
+  
+  Here's what's changed after the delete:
+  
+  - Deletes:
+  
+    foo
+  
+  Tip: You can always `undo` if this wasn't what you wanted.
+
 .> delete Foo
 
+  🆕
+  
+  Here's what's changed after the delete:
+  
+  - Deletes:
+  
+    Foo
+  
+  Tip: You can always `undo` if this wasn't what you wanted.
+
 .> delete Foo.Foo
+
+  🆕
+  
+  Here's what's changed after the delete:
+  
+  - Deletes:
+  
+    Foo.Foo
+  
+  Tip: You can always `undo` if this wasn't what you wanted.
 
 ```
 How about an ambiguous term?
@@ -145,6 +175,16 @@ I can force my delete through by re-issuing the command.
 ```ucm
 .a> delete foo
 
+  🆕
+  
+  Here's what's changed after the delete:
+  
+  - Deletes:
+  
+    a.foo
+  
+  Tip: You can always `undo` if this wasn't what you wanted.
+
 ```
 Let's repeat all that on a type, for completeness.
 
@@ -233,6 +273,16 @@ type Foo = Foo Boolean
 ```ucm
 .a> delete Foo
 
+  🆕
+  
+  Here's what's changed after the delete:
+  
+  - Deletes:
+  
+    a.Foo
+  
+  Tip: You can always `undo` if this wasn't what you wanted.
+
 ```
 ```ucm
 .a> delete Foo.Foo
@@ -253,6 +303,16 @@ type Foo = Foo Boolean
 ```
 ```ucm
 .a> delete Foo.Foo
+
+  🆕
+  
+  Here's what's changed after the delete:
+  
+  - Deletes:
+  
+    a.Foo.Foo
+  
+  Tip: You can always `undo` if this wasn't what you wanted.
 
 ```
 Finally, let's try to delete a term and a type with the same name.
@@ -309,5 +369,15 @@ type foo = Foo Nat
 ```
 ```ucm
 .> delete foo
+
+  🆕
+  
+  Here's what's changed after the delete:
+  
+  - Deletes:
+  
+    foo
+  
+  Tip: You can always `undo` if this wasn't what you wanted.
 
 ```

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -204,6 +204,16 @@ z = 99
 
 .feature2> delete.term x
 
+  🆕
+  
+  Here's what's changed after the delete:
+  
+  - Deletes:
+  
+    feature2.x
+  
+  Tip: You can always `undo` if this wasn't what you wanted.
+
 ```
 And here's the other fork, where we update `y` and add a new definition, `frobnicate`:
 

--- a/unison-src/transcripts/resolve.output.md
+++ b/unison-src/transcripts/resolve.output.md
@@ -217,6 +217,16 @@ We can resolve the name conflict by deleting one of the names.
 ```ucm
 .example.resolve.c> delete.term foo#jdqoenu794
 
+  🆕
+  
+  Here's what's changed after the delete:
+  
+  - Deletes:
+  
+    example.resolve.c.foo
+  
+  Tip: You can always `undo` if this wasn't what you wanted.
+
 ```
 And that's how you resolve edit conflicts with UCM.
 


### PR DESCRIPTION
Now deleting types/terms shows a namespace diff.

<img width="671" alt="Screen Shot 2019-12-14 at 9 56 46 PM" src="https://user-images.githubusercontent.com/1074598/70857468-e56c8200-1ebc-11ea-9ec9-cae7650690c3.png">

Unfortunately when definitions with the same name, `prettyDiff` currently only reports one name:

<img width="859" alt="Screen Shot 2019-12-14 at 10 01 17 PM" src="https://user-images.githubusercontent.com/1074598/70857487-498f4600-1ebd-11ea-8239-a750148afb83.png">
