### PR TITLE
Better duplicate definitions error message

### DIFF
--- a/parser-typechecker/src/Unison/Parser.hs
+++ b/parser-typechecker/src/Unison/Parser.hs
@@ -237,7 +237,7 @@ run' p s name env =
             then L.lexer name (trace (L.debugLex''' "lexer receives" s) s)
             else L.lexer name s
       pTraced = traceRemainingTokens "parser receives" *> p
-      env' = env { names = Names.suffixify (names env) } 
+      env' = env { names = Names.suffixify (names env) }
   in runParserT pTraced name (Input lex) env'
 
 run :: Ord v => P v a -> String -> ParsingEnv -> Either (Err v) a

--- a/parser-typechecker/src/Unison/Typechecker/Extractor.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Extractor.hs
@@ -8,6 +8,7 @@ import Unison.Prelude hiding (whenM)
 import           Control.Monad.Fail             ( MonadFail, fail )
 import           Control.Monad.Reader
 import qualified Data.List                     as List
+import           Data.List.NonEmpty            ( NonEmpty )
 import qualified Data.Set                      as Set
 import           Unison.Reference               ( Reference )
 import qualified Unison.Term                   as Term
@@ -222,6 +223,11 @@ inIfBody = asPathExtractor $ \case
 -- Causes --
 cause :: ErrorExtractor v loc (C.Cause v loc)
 cause = extractor $ pure . C.cause
+
+duplicateDefinitions :: ErrorExtractor v loc (NonEmpty (v, [loc]))
+duplicateDefinitions = cause >>= \case
+  C.DuplicateDefinitions vs -> pure vs
+  _                         -> mzero
 
 typeMismatch :: ErrorExtractor v loc (C.Context v loc)
 typeMismatch = cause >>= \case


### PR DESCRIPTION
Example output, first add is

```
a = 1
a = 2
```

and the second is

```
a = 1
a = 2
b = 3
b = 4
```

<img width="496" alt="Screen Shot 2019-12-15 at 11 35 08 PM" src="https://user-images.githubusercontent.com/1074598/70879784-aad61880-1f94-11ea-8ecb-c105dde434c1.png">

It could be improved (like a lot)... but is better than nothing. I tried putting some source info alongside the names; verdict: didn't look that great and the spans were kind of inaccurate. But feedback welcome on how to style this message, of course.