### PR TITLE
Don’t use `less` to display ucm output triggered by external events (#1027)

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -34,3 +34,4 @@ The format for this list: name, GitHub handle, and then optional blurb about wha
 * Evan Burchard (@evanburchard)
 * Alvaro Carrasco (@alvaroc1)
 * Vladislav Zavialov (@int-index)
+* Aaron Novstrup (@anovstrup)

--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -61,6 +61,9 @@ data Command m i v a where
   -- Presents some output to the user
   Notify :: Output v -> Command m i v ()
 
+  -- Presents output to the user (non-modal/paged)
+  Notify' :: Output v -> Command m i v ()
+
   -- literally just write some terms and types .unison/{terms,types}
   AddDefsToCodebase :: UF.TypecheckedUnisonFile v Ann -> Command m i v ()
 
@@ -129,8 +132,8 @@ data Command m i v a where
 
   LoadRemoteRootBranch ::
     BranchLoadMode -> RemoteRepo -> Command m i v (Either GitError (Branch m))
-  
-  -- returns NoRemoteNamespaceWithHash or RemoteNamespaceHashAmbiguous 
+
+  -- returns NoRemoteNamespaceWithHash or RemoteNamespaceHashAmbiguous
   -- if no exact match.
   LoadRemoteShortBranch ::
     RemoteRepo -> ShortBranchHash -> Command m i v (Either GitError (Branch m))

--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -61,8 +61,8 @@ data Command m i v a where
   -- Presents some output to the user
   Notify :: Output v -> Command m i v ()
 
-  -- Presents output to the user (non-modal/paged)
-  Notify' :: Output v -> Command m i v ()
+  -- Presents some output to the user without any paging
+  NotifyUnpaged :: Output v -> Command m i v ()
 
   -- literally just write some terms and types .unison/{terms,types}
   AddDefsToCodebase :: UF.TypecheckedUnisonFile v Ann -> Command m i v ()

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -94,10 +94,11 @@ commandLine
   -> (Branch IO -> IO ())
   -> Runtime v
   -> (Output v -> IO ())
+  -> (Output v -> IO ())
   -> Codebase IO v Ann
   -> Free (Command IO i v) a
   -> IO a
-commandLine config awaitInput setBranchRef rt notifyUser codebase =
+commandLine config awaitInput setBranchRef rt notifyUser notifyUserNonmodal codebase =
  Free.fold go
  where
   go :: forall x . Command IO i v x -> IO x
@@ -106,6 +107,7 @@ commandLine config awaitInput setBranchRef rt notifyUser codebase =
     Eval m        -> m
     Input         -> awaitInput
     Notify output -> notifyUser output
+    Notify' output -> notifyUserNonmodal output
     ConfigLookup name -> Config.lookup config name
     Typecheck ambient names sourceName source -> do
       -- todo: if guids are being shown to users,

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -98,7 +98,7 @@ commandLine
   -> Codebase IO v Ann
   -> Free (Command IO i v) a
   -> IO a
-commandLine config awaitInput setBranchRef rt notifyUser notifyUserNonmodal codebase =
+commandLine config awaitInput setBranchRef rt notifyUser notifyUserUnpaged codebase =
  Free.fold go
  where
   go :: forall x . Command IO i v x -> IO x
@@ -107,7 +107,7 @@ commandLine config awaitInput setBranchRef rt notifyUser notifyUserNonmodal code
     Eval m        -> m
     Input         -> awaitInput
     Notify output -> notifyUser output
-    Notify' output -> notifyUserNonmodal output
+    NotifyUnpaged output -> notifyUserUnpaged output
     ConfigLookup name -> Config.lookup config name
     Typecheck ambient names sourceName source -> do
       -- todo: if guids are being shown to users,

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -237,7 +237,7 @@ loop = do
 
   case e of
     Left (IncomingRootBranch hashes) ->
-      eval . Notify' . WarnIncomingRootBranch $ Set.map (SBH.fromHash sbhLength) hashes
+      eval . NotifyUnpaged . WarnIncomingRootBranch $ Set.map (SBH.fromHash sbhLength) hashes
     Left (UnisonFileChanged sourceName text) ->
       -- We skip this update if it was programmatically generated
       if maybe False snd latestFile'
@@ -250,15 +250,15 @@ loop = do
                         (UF.termSignatureExternalLabeledDependencies unisonFile)
                         (UF.typecheckedToNames0 unisonFile)
             ppe <- PPE.suffixifiedPPE <$> prettyPrintEnvDecl names
-            eval . Notify' $ Typechecked sourceName ppe sr unisonFile
+            eval . NotifyUnpaged $ Typechecked sourceName ppe sr unisonFile
             r <- eval . Evaluate ppe $ unisonFile
             case r of
-              Left e -> eval . Notify' $ EvaluationFailure e
+              Left e -> eval . NotifyUnpaged $ EvaluationFailure e
               Right (bindings, e) -> do
                 let e' = Map.map go e
                     go (ann, kind, _hash, _uneval, eval, isHit) = (ann, kind, eval, isHit)
                 when (not $ null e') $
-                  eval . Notify' $ Evaluated text ppe bindings e'
+                  eval . NotifyUnpaged $ Evaluated text ppe bindings e'
                 latestFile .= Just (Text.unpack sourceName, False)
                 latestTypecheckedFile .= Just unisonFile
     Right input ->

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -237,7 +237,7 @@ loop = do
 
   case e of
     Left (IncomingRootBranch hashes) ->
-      respond . WarnIncomingRootBranch $ Set.map (SBH.fromHash sbhLength) hashes
+      eval . Notify' . WarnIncomingRootBranch $ Set.map (SBH.fromHash sbhLength) hashes
     Left (UnisonFileChanged sourceName text) ->
       -- We skip this update if it was programmatically generated
       if maybe False snd latestFile'
@@ -250,15 +250,15 @@ loop = do
                         (UF.termSignatureExternalLabeledDependencies unisonFile)
                         (UF.typecheckedToNames0 unisonFile)
             ppe <- PPE.suffixifiedPPE <$> prettyPrintEnvDecl names
-            eval (Notify $ Typechecked sourceName ppe sr unisonFile)
+            eval . Notify' $ Typechecked sourceName ppe sr unisonFile
             r <- eval . Evaluate ppe $ unisonFile
             case r of
-              Left e -> respond $ EvaluationFailure e
+              Left e -> eval . Notify' $ EvaluationFailure e
               Right (bindings, e) -> do
                 let e' = Map.map go e
                     go (ann, kind, _hash, _uneval, eval, isHit) = (ann, kind, eval, isHit)
                 when (not $ null e') $
-                  eval . Notify $ Evaluated text ppe bindings e'
+                  eval . Notify' $ Evaluated text ppe bindings e'
                 latestFile .= Just (Text.unpack sourceName, False)
                 latestTypecheckedFile .= Just unisonFile
     Right input ->

--- a/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
@@ -149,12 +149,12 @@ run dir configFile stanzas codebase = do
                 output ("\n" <> show p <> "\n")
                 -- invalid command is treated as a failure
                 case Map.lookup cmd patternMap of
-                  Nothing -> 
+                  Nothing ->
                     die
                   Just pat -> case IP.parse pat args of
                     Left msg -> do
                       output $ P.toPlain 65 (P.indentN 2 msg <> P.newline <> P.newline)
-                      die 
+                      die
                     Right input -> pure $ Right input
           Nothing -> do
             errOk <- readIORef allowErrors
@@ -207,12 +207,12 @@ run dir configFile stanzas codebase = do
         errOk <- readIORef allowErrors
         let rendered = P.toPlain 65 (P.border 2 msg)
         output rendered
-        when (errOk && Output.isFailure o) $ 
+        when (errOk && Output.isFailure o) $
           writeIORef hasErrors True
-        when (not errOk && Output.isFailure o) 
+        when (not errOk && Output.isFailure o)
           die
 
-      die = do 
+      die = do
         output "\n```\n\n"
         transcriptFailure out $ Text.unlines [
           "\128721", "",
@@ -226,6 +226,7 @@ run dir configFile stanzas codebase = do
         (o, state') <- HandleCommand.commandLine config awaitInput
                                      (const $ pure ())
                                      runtime
+                                     print
                                      print
                                      codebase
                                      free

--- a/parser-typechecker/src/Unison/CommandLine/Main.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Main.hs
@@ -209,6 +209,7 @@ main dir initialPath configFile initialInputs startRuntime codebase = do
                                      (writeIORef rootRef)
                                      runtime
                                      (notifyUser dir >=> putPrettyNonempty)
+                                     (notifyUser dir >=> putPrettyLnUnpaged)
                                      codebase
                                      free
         case o of
@@ -218,4 +219,3 @@ main dir initialPath configFile initialInputs startRuntime codebase = do
             loop state'
     (`finally` cleanup)
       $ loop (HandleInput.loopState0 root initialPath)
-


### PR DESCRIPTION
This PR implements a fix for #1027 as originally specified (i.e., avoiding the use of `less` for ucm output triggered by external events).  

It would arguably be preferable to use `less` for all long output but kill any running `less` process (and cancel any pending outputs) when an external event occurs. However, I ran into various snags implementing that solution (see my comments on #1027 for details). This fix is thus a temporary workaround. Combined with #1028 (which would provide a way to view the typechecking output in `less` on demand), it may suffice for now.