### PR TITLE
Speed up todo output if there is nothing to do

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1450,7 +1450,7 @@ propagatePatch input inputDescription patch scopePath = do
 
 -- | Show todo output if there are any conflicts or edits.
 showTodoOutput
-  :: _
+  :: Input
   -> Action' m v PPE.PrettyPrintEnvDecl
      -- ^ Action that fetches the pretty print env. It's expensive because it
      -- involves looking up historical names, so only call it if necessary.

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -165,6 +165,8 @@ data Output v
   | History (Maybe Int) [(ShortBranchHash, Names.Diff)] HistoryTail
   | ShowReflog [ReflogEntry]
   | NothingTodo Input
+  -- | No conflicts or edits remain for the current patch.
+  | NoConflictsOrEdits
   | NotImplemented
   | NoBranchWithHash Input ShortBranchHash
   | DumpBitBooster Branch.Hash (Map Branch.Hash [Branch.Hash])
@@ -284,6 +286,7 @@ isFailure o = case o of
   DumpBitBooster{} -> False
   NoBranchWithHash{} -> True
   NothingTodo{} -> False
+  NoConflictsOrEdits{} -> False
   ListShallow _ es -> null es
   HashAmbiguous{} -> True
   ShowReflog{} -> False

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -132,6 +132,7 @@ data Output v
                        PPE.PrettyPrintEnvDecl
                        (Map Reference (DisplayThing (Decl v Ann)))
                        (Map Reference (DisplayThing (Term v Ann)))
+  -- | Invariant: there's at least one conflict or edit in the TodoOutput.
   | TodoOutput PPE.PrettyPrintEnvDecl (TO.TodoOutput v Ann)
   | TestIncrementalOutputStart PPE.PrettyPrintEnv (Int,Int) Reference (Term v Ann)
   | TestIncrementalOutputEnd PPE.PrettyPrintEnv (Int,Int) Reference (Term v Ann)

--- a/parser-typechecker/src/Unison/Codebase/Editor/TodoOutput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/TodoOutput.hs
@@ -53,3 +53,11 @@ labeledDependencies TodoOutput{..} = Set.fromList (
   Set.map LD.referent (R.ran (Names.terms0 nameConflicts)) <>
   Set.map LD.typeRef (R.ran (Names.types0 nameConflicts)) <>
   Patch.labeledDependencies editConflicts
+
+noConflicts :: TodoOutput v a -> Bool
+noConflicts todo =
+  nameConflicts todo == mempty && editConflicts todo == Patch.empty
+
+noEdits :: TodoOutput v a -> Bool
+noEdits todo =
+  todoScore todo == 0

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -774,23 +774,18 @@ notifyUser dir o = case o of
           , ""
           , tip "You can always `undo` if this wasn't what you wanted."
           ]
-  NothingTodo input -> case input of
+  NothingTodo input -> pure . P.callout "😶" $ case input of
     Input.MergeLocalBranchI src dest ->
-      pure . P.callout "😶" $
-        P.wrap $ "The merge had no effect, since the destination"
-              <> P.shown dest <> "is at or ahead of the source"
-              <> P.group (P.shown src <> ".")
+      P.wrap $ "The merge had no effect, since the destination"
+            <> P.shown dest <> "is at or ahead of the source"
+            <> P.group (P.shown src <> ".")
     Input.PreviewMergeLocalBranchI src dest ->
-      pure . P.callout "😶" $
-        P.wrap $ "The merge will have no effect, since the destination"
-              <> P.shown dest <> "is at or ahead of the source"
-              <> P.group (P.shown src <> ".")
-    Input.TodoI{} -> noConflictsOrEdits
-    Input.UpdateI{} -> noConflictsOrEdits
-    _ -> pure "Nothing to do."
-    where
-      noConflictsOrEdits =
-        pure (P.okCallout "No conflicts or edits in progress.")
+      P.wrap $ "The merge will have no effect, since the destination"
+            <> P.shown dest <> "is at or ahead of the source"
+            <> P.group (P.shown src <> ".")
+    _ -> "Nothing to do."
+  NoConflictsOrEdits ->
+    pure (P.okCallout "No conflicts or edits in progress.")
   DumpBitBooster head map -> let
     go output []          = output
     go output (head : queue) = case Map.lookup head map of

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -785,8 +785,12 @@ notifyUser dir o = case o of
         P.wrap $ "The merge will have no effect, since the destination"
               <> P.shown dest <> "is at or ahead of the source"
               <> P.group (P.shown src <> ".")
-    Input.TodoI{} -> pure (P.okCallout "No conflicts or edits in progress.")
+    Input.TodoI{} -> noConflictsOrEdits
+    Input.UpdateI{} -> noConflictsOrEdits
     _ -> pure "Nothing to do."
+    where
+      noConflictsOrEdits =
+        pure (P.okCallout "No conflicts or edits in progress.")
   DumpBitBooster head map -> let
     go output []          = output
     go output (head : queue) = case Map.lookup head map of

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -436,7 +436,7 @@ notifyUser dir o = case o of
       "I loaded " <> P.text sourceName <> " and didn't find anything."
     else pure mempty
 
-  TodoOutput names todo -> todoOutput names todo
+  TodoOutput names todo -> pure (todoOutput names todo)
   GitError input e -> pure $ case e of
     NoGit -> P.wrap $
       "I couldn't find git. Make sure it's installed and on your path."
@@ -774,16 +774,19 @@ notifyUser dir o = case o of
           , ""
           , tip "You can always `undo` if this wasn't what you wanted."
           ]
-  NothingTodo input -> pure . P.callout "😶" $ case input of
+  NothingTodo input -> case input of
     Input.MergeLocalBranchI src dest ->
-      P.wrap $ "The merge had no effect, since the destination"
-            <> P.shown dest <> "is at or ahead of the source"
-            <> P.group (P.shown src <> ".")
+      pure . P.callout "😶" $
+        P.wrap $ "The merge had no effect, since the destination"
+              <> P.shown dest <> "is at or ahead of the source"
+              <> P.group (P.shown src <> ".")
     Input.PreviewMergeLocalBranchI src dest ->
-      P.wrap $ "The merge will have no effect, since the destination"
-            <> P.shown dest <> "is at or ahead of the source"
-            <> P.group (P.shown src <> ".")
-    _ -> "Nothing to do."
+      pure . P.callout "😶" $
+        P.wrap $ "The merge will have no effect, since the destination"
+              <> P.shown dest <> "is at or ahead of the source"
+              <> P.group (P.shown src <> ".")
+    Input.TodoI{} -> pure (P.okCallout "No conflicts or edits in progress.")
+    _ -> pure "Nothing to do."
   DumpBitBooster head map -> let
     go output []          = output
     go output (head : queue) = case Map.lookup head map of
@@ -1100,15 +1103,10 @@ renderEditConflicts ppe Patch{..} =
       P.oxfordCommas [ termName r | TermEdit.Replace r _ <- es ]
     formatConflict = either formatTypeEdits formatTermEdits
 
-todoOutput :: Var v => PPE.PrettyPrintEnvDecl -> TO.TodoOutput v a -> IO Pretty
+todoOutput :: Var v => PPE.PrettyPrintEnvDecl -> TO.TodoOutput v a -> Pretty
 todoOutput ppe todo =
-  if noConflicts && noEdits
-  then pure $ P.okCallout "No conflicts or edits in progress."
-  else pure (todoConflicts <> todoEdits)
+  todoConflicts <> todoEdits
   where
-  noConflicts = TO.nameConflicts todo == mempty
-             && TO.editConflicts todo == Patch.empty
-  noEdits = TO.todoScore todo == 0
   ppeu = PPE.unsuffixifiedPPE ppe
   ppes = PPE.suffixifiedPPE ppe
   (frontierTerms, frontierTypes) = TO.todoFrontier todo
@@ -1119,7 +1117,7 @@ todoOutput ppe todo =
     [ (PPE.typeName ppeu r, r) | (r, MissingThing _) <- frontierTypes ]
   goodTerms ts =
     [ (PPE.termName ppeu (Referent.Ref r), typ) | (r, Just typ) <- ts ]
-  todoConflicts = if noConflicts then mempty else P.lines . P.nonEmpty $
+  todoConflicts = if TO.noConflicts todo then mempty else P.lines . P.nonEmpty $
     [ renderEditConflicts ppeu (TO.editConflicts todo)
     , renderNameConflicts conflictedTypeNames conflictedTermNames ]
     where
@@ -1155,7 +1153,7 @@ todoOutput ppe todo =
       termEditConflicts = R.filterDom (`R.manyDom` _termEdits) _termEdits
 
 
-  todoEdits = unlessM noEdits . P.callout "🚧" . P.sep "\n\n" . P.nonEmpty $
+  todoEdits = unlessM (TO.noEdits todo) . P.callout "🚧" . P.sep "\n\n" . P.nonEmpty $
       [ P.wrap ("The namespace has" <> fromString (show (TO.todoScore todo))
               <> "transitive dependent(s) left to upgrade."
               <> "Your edit frontier is the dependents of these definitions:")


### PR DESCRIPTION
This patch speeds up `todo` output when there is nothing to do.

- `showTodoOutput` now takes an action that computes a `PrettyPrintEnv` rather than a `PrettyPrintEnv` directly (because it's slow to compute, and only needed if there are things to do)
- `NothingTodo` output message was reused for this output case (rather than making a new `NoTodoOutput` or similar)
- Calculations for whether or not a `TodoOutput` has any conflicts/edits were moved to the `TodoOutput` so they could be called from more than one place.

Maybe mostly addresses https://github.com/unisonweb/unison/issues/1029?