### PR TITLE
Import NameSegment from Name

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -20,6 +20,7 @@ import Unison.Codebase.Editor.SlurpResult (SlurpResult(..))
 import Unison.Codebase.GitError
 import Unison.Codebase.Path (Path', Path)
 import Unison.Codebase.Patch (Patch)
+import Unison.HashQualified' (HQSegment)
 import Unison.Name ( Name )
 import Unison.Names2 ( Names )
 import Unison.Parser ( Ann )
@@ -47,7 +48,7 @@ import Unison.Codebase.Editor.SearchResult' (SearchResult')
 import Unison.Type (Type)
 import qualified Unison.Names3 as Names
 import qualified Data.Set as Set
-import Unison.Codebase.NameSegment (NameSegment, HQSegment)
+import Unison.Codebase.NameSegment (NameSegment)
 import Unison.ShortHash (ShortHash)
 import Unison.Var (Var)
 import Unison.Codebase.ShortBranchHash (ShortBranchHash)

--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -18,11 +18,11 @@ import           Unison.Name                    ( Name )
 import qualified Unison.Name                   as Name
 import Unison.Util.Monoid (intercalateMap)
 import qualified Unison.Lexer                  as Lexer
+import           Unison.HashQualified'          ( HQSegment )
 import qualified Unison.HashQualified' as HQ'
 import qualified Unison.ShortHash as SH
 
 import           Unison.Codebase.NameSegment    ( NameSegment(NameSegment)
-                                                , HQSegment
                                                 )
 import qualified Unison.Codebase.NameSegment as NameSegment
 

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -320,18 +320,18 @@ notifyUser dir o = case o of
     formatEntry :: ShallowListEntry v a -> (P.Pretty P.ColorText, P.Pretty P.ColorText)
     formatEntry = \case
       ShallowTermEntry r hq ot ->
-        (P.syntaxToColor . prettyHashQualified' . fmap NameSegment.toName $ hq
+        (P.syntaxToColor . prettyHashQualified' . fmap Name.fromNameSegment $ hq
         , P.lit "(" <> maybe "type missing" (TypePrinter.pretty ppe) ot <> P.lit ")" )
       ShallowTypeEntry r hq ->
-        (P.syntaxToColor . prettyHashQualified' . fmap NameSegment.toName $ hq
+        (P.syntaxToColor . prettyHashQualified' . fmap Name.fromNameSegment $ hq
         ,isBuiltin r)
       ShallowBranchEntry ns count ->
-        ((P.syntaxToColor . prettyName . NameSegment.toName) ns <> "/"
+        ((P.syntaxToColor . prettyName . Name.fromNameSegment) ns <> "/"
         ,case count of
           1 -> P.lit ("(1 definition)")
           n -> P.lit "(" <> P.shown count <> P.lit " definitions)")
       ShallowPatchEntry ns ->
-        ((P.syntaxToColor . prettyName . NameSegment.toName) ns
+        ((P.syntaxToColor . prettyName . Name.fromNameSegment) ns
         ,P.lit "(patch)")
     isBuiltin = \case
       Reference.Builtin{} -> P.lit "(builtin type)"

--- a/unison-core/src/Unison/Codebase/NameSegment.hs
+++ b/unison-core/src/Unison/Codebase/NameSegment.hs
@@ -5,14 +5,11 @@ module Unison.Codebase.NameSegment where
 
 import Unison.Prelude
 
-import qualified Unison.Name                   as Name
 import qualified Data.Text                     as Text
 import qualified Unison.Hashable               as H
-import qualified Unison.HashQualified'         as HQ'
 
 -- Represents the parts of a name between the `.`s
 newtype NameSegment = NameSegment { toText :: Text } deriving (Eq, Ord)
-type HQSegment = HQ'.HashQualified' NameSegment
 
 instance H.Hashable NameSegment where
   tokens s = [H.Text (toText s)]
@@ -25,12 +22,6 @@ isPrefixOf n1 n2 = Text.isPrefixOf (toText n1) (toText n2)
 
 toString :: NameSegment -> String
 toString = Text.unpack . toText
-
-toName :: NameSegment -> Name.Name
-toName = Name.unsafeFromText . toText
-
-segments :: Name.Name -> [NameSegment]
-segments name = NameSegment <$> Text.splitOn "." (Name.toText name)
 
 instance Show NameSegment where
   show = Text.unpack . toText

--- a/unison-core/src/Unison/HashQualified'.hs
+++ b/unison-core/src/Unison/HashQualified'.hs
@@ -7,6 +7,7 @@ import Unison.Prelude
 import           Data.Maybe                     ( fromJust )
 import qualified Data.Text                     as Text
 import           Prelude                 hiding ( take )
+import           Unison.Codebase.NameSegment    ( NameSegment )
 import           Unison.Name                    ( Name )
 import qualified Unison.Name                   as Name
 import           Unison.Reference               ( Reference )
@@ -21,6 +22,7 @@ data HashQualified' n = NameOnly n | HashQualified n ShortHash
   deriving (Eq, Ord, Functor)
 
 type HashQualified = HashQualified' Name
+type HQSegment = HashQualified' NameSegment
 
 toHQ :: HashQualified' n -> HQ.HashQualified' n
 toHQ = \case

--- a/unison-core/src/Unison/Name.hs
+++ b/unison-core/src/Unison/Name.hs
@@ -3,10 +3,12 @@
 module Unison.Name
   ( Name
   , fromString
+  , fromNameSegment
   , isPrefixOf
   , joinDot
   , makeAbsolute
   , parent
+  , segments
   , sortNames
   , sortNamed
   , sortNamed'
@@ -28,6 +30,8 @@ import Unison.Prelude
 
 import           Control.Lens                   ( unsnoc )
 import qualified Data.Text                     as Text
+import           Unison.Codebase.NameSegment    ( NameSegment(NameSegment) )
+import qualified Unison.Codebase.NameSegment   as NameSegment
 import qualified Unison.Hashable               as H
 import           Unison.Var                     ( Var )
 import qualified Unison.Var                    as Var
@@ -35,6 +39,12 @@ import qualified Data.RFC5051                  as RFC5051
 import           Data.List                      ( sortBy, tails )
 
 newtype Name = Name { toText :: Text } deriving (Eq, Ord)
+
+fromNameSegment :: NameSegment -> Name
+fromNameSegment = unsafeFromText . NameSegment.toText
+
+segments :: Name -> [NameSegment]
+segments name = NameSegment <$> Text.splitOn "." (toText name)
 
 sortNames :: [Name] -> [Name]
 sortNames = sortNamed id


### PR DESCRIPTION
- Import `NameSegment` from `Name` rather than the other way around (to define `Name` as a list of `NameSegment`)
- Move `HQSegment` definition into `HashQualified'` because of circular imports