### PR TITLE
Remove call to Name.unsafeFromText

### DIFF
--- a/parser-typechecker/src/Unison/DeclPrinter.hs
+++ b/parser-typechecker/src/Unison/DeclPrinter.hs
@@ -5,7 +5,7 @@
 
 module Unison.DeclPrinter where
 
-import Unison.Prelude
+-- import Unison.Prelude
 
 import           Data.List                      ( isPrefixOf )
 import qualified Data.Map                      as Map
@@ -16,7 +16,6 @@ import           Unison.DataDeclaration         ( DataDeclaration'
 import qualified Unison.DataDeclaration        as DD
 import           Unison.HashQualified           ( HashQualified )
 import qualified Unison.HashQualified          as HQ
-import qualified Unison.Name                   as Name
 import           Unison.NamePrinter             ( styleHashQualified'' )
 import           Unison.PrettyPrintEnv          ( PrettyPrintEnv )
 import qualified Unison.PrettyPrintEnv         as PPE
@@ -39,7 +38,7 @@ prettyDecl
   -> HashQualified
   -> DD.Decl v a
   -> Pretty SyntaxText
-prettyDecl ppe r hq d = case d of 
+prettyDecl ppe r hq d = case d of
   Left e -> prettyEffectDecl ppe r hq e
   Right dd -> prettyDataDecl ppe r hq dd
 
@@ -72,7 +71,7 @@ prettyGADT env r name dd = P.hang header . P.lines $ constructor <$> zip
 prettyPattern
   :: PrettyPrintEnv -> Reference -> HashQualified -> Int -> Pretty SyntaxText
 prettyPattern env r namespace n = styleHashQualified'' (fmt S.Constructor)
-  ( HQ.stripNamespace (fromMaybe "" $ Name.toText <$> HQ.toName namespace)
+  ( maybe id HQ.stripNamespace (HQ.toName namespace)
   $ PPE.patternName env r n
   )
 

--- a/unison-core/src/Unison/HashQualified.hs
+++ b/unison-core/src/Unison/HashQualified.hs
@@ -26,14 +26,14 @@ data HashQualified' n
 
 type HashQualified = HashQualified' Name
 
-stripNamespace :: Text -> HashQualified -> HashQualified
+stripNamespace :: Name -> HashQualified -> HashQualified
 stripNamespace namespace hq = case hq of
   NameOnly name         -> NameOnly $ strip name
   HashQualified name sh -> HashQualified (strip name) sh
   ho                    -> ho
  where
   strip name =
-    fromMaybe name $ Name.stripNamePrefix (Name.unsafeFromText namespace) name
+    fromMaybe name $ Name.stripNamePrefix namespace name
 
 toName :: HashQualified' n -> Maybe n
 toName = \case


### PR DESCRIPTION
Goal: audit/refactor uses of the to/from String/Text/Var functions of `Name`, because they potentially break the invariants of the `Text` contained within, so it would be better if they go through other parts of the name API.