### PR TITLE
More name refactoring

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -325,3 +325,16 @@ toText' :: Path' -> Text
 toText' = \case
   Path' (Left (Absolute path)) -> Text.cons '.' (toText path)
   Path' (Right (Relative path)) -> toText path
+
+-- | Given a path (naming context), fully qualify a name.
+--
+-- > qualifyName ["foo"] "bar" = "foo.bar"
+-- > qualifyName []      "bar" = "bar"
+qualifyName :: Absolute -> Name -> Name
+qualifyName path name =
+  if Name.isAbsolute name then
+    Name.asRelative name
+  else if isRoot path then
+    name
+  else
+    Name.joinDot (toName . unabsolute $ path) name

--- a/parser-typechecker/src/Unison/Util/Find.hs
+++ b/parser-typechecker/src/Unison/Util/Find.hs
@@ -116,14 +116,12 @@ fuzzyFindMatchArray query items render =
 prefixFindInBranch ::
   Names0 -> HashQualified -> [(SearchResult, P.Pretty P.ColorText)]
 prefixFindInBranch b hq = fmap getName $
-  case HQ.toName hq of
-    -- query string includes a name component, so do a prefix find on that
-    (Name.toString -> n) ->
-      filter (filterName n) (candidates b hq)
+  -- query string includes a name component, so do a prefix find on that
+  filter (filterName (HQ.toName hq)) (candidates b hq)
   where
   filterName n sr =
     -- fromJust is safe here because entries from the namespace will have names.
-    fromString n `Name.isPrefixOf` (HQ.toName . SR.name) sr
+    n `Name.isPrefixOf` (HQ.toName . SR.name) sr
 
 -- only search before the # before the # and after the # after the #
 fuzzyFindInBranch :: Names0

--- a/unison-core/src/Unison/Name.hs
+++ b/unison-core/src/Unison/Name.hs
@@ -28,6 +28,7 @@ module Unison.Name
   , isAbsolute
   , splits
   , oldSplits
+  , asRelative
   )
 where
 
@@ -171,6 +172,14 @@ oldSplits :: Name -> [([Text], Text)]
 oldSplits (Name n) = let ns = Text.splitOn "." n
                      in dropEnd 1 (inits ns `zip` (map dotConcat $ tails ns))
   where dotConcat = Text.concat . intersperse "."
+
+-- | Drop the leading '.' from a name if it's an absolute name.
+asRelative :: Name -> Name
+asRelative name =
+  if isAbsolute name then
+    Name (Text.drop 1 (toText name))
+  else
+    name
 
 instance Show Name where
   show = toString


### PR DESCRIPTION
- Delete unused `resolveHQName`
- Move your `preprocess` into `Path` and rename it `qualifyName`
  - I also deleted the comment because the function is now implemented with more of `Name`'s API, less texty parsing
- Remove a couple uses of `Name` to/from `String`