### PR TITLE
Remove Name.fromString, Name.unsafeFromString

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -215,11 +215,11 @@ loop = do
         let
           getHQ = \case
             L.Backticks s (Just sh) ->
-              Just (HQ.HashQualified (Name.unsafeFromString s) sh)
+              Just (HQ.HashQualified (Name.unsafeFromText (Text.pack s)) sh)
             L.WordyId s (Just sh) ->
-              Just (HQ.HashQualified (Name.unsafeFromString s) sh)
+              Just (HQ.HashQualified (Name.unsafeFromText (Text.pack s)) sh)
             L.SymbolyId s (Just sh) ->
-              Just (HQ.HashQualified (Name.unsafeFromString s) sh)
+              Just (HQ.HashQualified (Name.unsafeFromText (Text.pack s)) sh)
             L.Hash sh -> Just (HQ.HashOnly sh)
             _         -> Nothing
           hqs = Set.fromList . mapMaybe (getHQ . L.payload) $ tokens
@@ -2089,9 +2089,9 @@ lexedSource :: Monad m => SourceName -> Source -> Action' m v (Names, LexedSourc
 lexedSource name src = do
   let tokens = L.lexer (Text.unpack name) (Text.unpack src)
       getHQ = \case
-        L.Backticks s (Just sh) -> Just (HQ.HashQualified (Name.unsafeFromString s) sh)
-        L.WordyId   s (Just sh) -> Just (HQ.HashQualified (Name.unsafeFromString s) sh)
-        L.SymbolyId s (Just sh) -> Just (HQ.HashQualified (Name.unsafeFromString s) sh)
+        L.Backticks s (Just sh) -> Just (HQ.HashQualified (Name.unsafeFromText (Text.pack s)) sh)
+        L.WordyId   s (Just sh) -> Just (HQ.HashQualified (Name.unsafeFromText (Text.pack s)) sh)
+        L.SymbolyId s (Just sh) -> Just (HQ.HashQualified (Name.unsafeFromText (Text.pack s)) sh)
         L.Hash      sh          -> Just (HQ.HashOnly sh)
         _                       -> Nothing
       hqs = Set.fromList . mapMaybe (getHQ . L.payload) $ tokens

--- a/unison-core/src/Unison/Name.hs
+++ b/unison-core/src/Unison/Name.hs
@@ -5,7 +5,6 @@
 
 module Unison.Name
   ( Name
-  , fromString
   , fromNameSegment
   , isPrefixOf
   , joinDot
@@ -20,7 +19,6 @@ module Unison.Name
   , toVar
   , unqualified
   , unsafeFromText
-  , unsafeFromString
   , fromVar
   , countDots
   , segments
@@ -81,9 +79,6 @@ sortNamed' by by2 as = let
 unsafeFromText :: Text -> Name
 unsafeFromText t =
   if Text.any (== '#') t then error $ "not a name: " <> show t else Name t
-
-unsafeFromString :: String -> Name
-unsafeFromString = unsafeFromText . Text.pack
 
 toVar :: Var v => Name -> v
 toVar (Name t) = Var.named t
@@ -183,9 +178,6 @@ asRelative name =
 
 instance Show Name where
   show = toString
-
-instance IsString Name where
-  fromString = unsafeFromText . Text.pack
 
 instance H.Hashable Name where
   tokens s = [H.Text (toText s)]


### PR DESCRIPTION
The goal here is to make `Name.unsafeFromText` the one unsafe function to construct a name. I imagine it should only be called by `Name` parsers, and everyone else should work with the abstract type.