### PR TITLE
Remove more calls to Name.toVar

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1853,9 +1853,9 @@ toSlurpResult currentPath uf existingNames =
   -- r is Ref and r' is Con
   termCtorCollisions :: Set v
   termCtorCollisions = Set.fromList
-    [ n
-    | (n, Referent.Ref{}) <- R.toList (Names.terms fileNames)
-    , [r@Referent.Con{}]  <- [toList $ Names.termsNamed existingNames (Name.fromVar n)]
+    [ v
+    | (v, Referent.Ref{}) <- R.toList (Names.terms fileNames)
+    , [r@Referent.Con{}]  <- [toList $ Names.termsNamed existingNames (Name.fromVar v)]
     -- ignore collisions w/ ctors of types being updated
     , Set.notMember (Referent.toReference r) typesToUpdate
     ]
@@ -1864,8 +1864,8 @@ toSlurpResult currentPath uf existingNames =
   typesToUpdate :: Set Reference
   typesToUpdate = Set.fromList
     [ r
-    | (n, r') <- R.toList (Names.types fileNames)
-    , r       <- toList (Names.typesNamed existingNames (Name.fromVar n))
+    | (v, r') <- R.toList (Names.types fileNames)
+    , r       <- toList (Names.typesNamed existingNames (Name.fromVar v))
     , r /= r'
     ]
 
@@ -1874,9 +1874,9 @@ toSlurpResult currentPath uf existingNames =
   -- what if (n,r) and (n,r' /= r) exists in names and r, r' are Con
   ctorTermCollisions :: Set v
   ctorTermCollisions = Set.fromList
-    [ n
-    | (n, Referent.Con{}) <- R.toList (Names.terms fileNames)
-    , r                   <- toList $ Names.termsNamed existingNames (Name.fromVar n)
+    [ v
+    | (v, Referent.Con{}) <- R.toList (Names.terms fileNames)
+    , r                   <- toList $ Names.termsNamed existingNames (Name.fromVar v)
     -- ignore collisions w/ ctors of types being updated
     , Set.notMember (Referent.toReference r) typesToUpdate
     ]
@@ -1886,54 +1886,54 @@ toSlurpResult currentPath uf existingNames =
   dups = sc terms types where
     terms =
       R.filter
-        (\(n, r) -> R.member (Name.fromVar n) r (Names.terms existingNames))
+        (\(v, r) -> R.member (Name.fromVar v) r (Names.terms existingNames))
         (Names.terms fileNames)
     types =
       R.filter
-        (\(n, r) -> R.member (Name.fromVar n) r (Names.types existingNames))
+        (\(v, r) -> R.member (Name.fromVar v) r (Names.types existingNames))
         (Names.types fileNames)
 
   -- update (n,r) if (n,r' /= r) exists in names0 and r, r' are Ref
   updates :: SlurpComponent v
   updates = SlurpComponent (Set.fromList types) (Set.fromList terms) where
     terms =
-      [ n
-      | (n, r'@Referent.Ref{}) <- R.toList (Names.terms fileNames)
-      , [r@Referent.Ref{}]     <- [toList $ Names.termsNamed existingNames (Name.fromVar n)]
+      [ v
+      | (v, r'@Referent.Ref{}) <- R.toList (Names.terms fileNames)
+      , [r@Referent.Ref{}]     <- [toList $ Names.termsNamed existingNames (Name.fromVar v)]
       , r' /= r
       ]
     types =
-      [ n
-      | (n, r') <- R.toList (Names.types fileNames)
-      , [r]     <- [toList $ Names.typesNamed existingNames (Name.fromVar n)]
+      [ v
+      | (v, r') <- R.toList (Names.types fileNames)
+      , [r]     <- [toList $ Names.typesNamed existingNames (Name.fromVar v)]
       , r' /= r
       ]
 
   -- alias (n, r) if (n' /= n, r) exists in names0
   termAliases :: Map v (Set Name)
   termAliases = Map.fromList
-    [ (n, aliases)
-    | (n, r@Referent.Ref{}) <- R.toList $ Names.terms fileNames
+    [ (v, aliases)
+    | (v, r@Referent.Ref{}) <- R.toList $ Names.terms fileNames
     , aliases               <-
-      [ Set.map (Path.unprefixName currentPath) . Set.delete (Name.fromVar n) $ R.lookupRan
+      [ Set.map (Path.unprefixName currentPath) . Set.delete (Name.fromVar v) $ R.lookupRan
           r
           (Names.terms existingNames)
       ]
     , not (null aliases)
-    , Set.notMember n (SC.terms dups)
+    , Set.notMember v (SC.terms dups)
     ]
 
   typeAliases :: Map v (Set Name)
   typeAliases = Map.fromList
-    [ (n, aliases)
-    | (n, r) <- R.toList $ Names.types fileNames
+    [ (v, aliases)
+    | (v, r) <- R.toList $ Names.types fileNames
     , aliases <-
-      [ Set.map (Path.unprefixName currentPath) . Set.delete (Name.fromVar n) $ R.lookupRan
+      [ Set.map (Path.unprefixName currentPath) . Set.delete (Name.fromVar v) $ R.lookupRan
           r
           (Names.types existingNames)
       ]
     , not (null aliases)
-    , Set.notMember n (SC.types dups)
+    , Set.notMember v (SC.types dups)
     ]
 
   -- add (n,r) if n doesn't exist and r doesn't exist in names0
@@ -1941,11 +1941,11 @@ toSlurpResult currentPath uf existingNames =
     terms = addTerms (Names.terms existingNames) (Names.terms fileNames)
     types = addTypes (Names.types existingNames) (Names.types fileNames)
     addTerms existingNames = R.filter go where
-      go (n, r@Referent.Ref{}) = (not . R.memberDom (Name.fromVar n)) existingNames
+      go (v, r@Referent.Ref{}) = (not . R.memberDom (Name.fromVar v)) existingNames
                               && (not . R.memberRan r) existingNames
       go _ = False
     addTypes existingNames = R.filter go where
-      go (n, r) = (not . R.memberDom (Name.fromVar n)) existingNames
+      go (v, r) = (not . R.memberDom (Name.fromVar v)) existingNames
                && (not . R.memberRan r) existingNames
 
 

--- a/parser-typechecker/src/Unison/Parser.hs
+++ b/parser-typechecker/src/Unison/Parser.hs
@@ -88,11 +88,11 @@ data Error v
   = SignatureNeedsAccompanyingBody (L.Token v)
   | DisallowedAbsoluteName (L.Token Name)
   | EmptyBlock (L.Token String)
-  | UnknownAbilityConstructor (L.Token HQ.HashQualified) (Set (Reference, Int))
-  | UnknownDataConstructor (L.Token HQ.HashQualified) (Set (Reference, Int))
-  | UnknownTerm (L.Token HQ.HashQualified) (Set Referent)
-  | UnknownType (L.Token HQ.HashQualified) (Set Reference)
-  | UnknownId (L.Token HQ.HashQualified) (Set Referent) (Set Reference)
+  | UnknownAbilityConstructor (L.Token (HQ.HashQualified' v)) (Set (Reference, Int))
+  | UnknownDataConstructor (L.Token (HQ.HashQualified' v)) (Set (Reference, Int))
+  | UnknownTerm (L.Token (HQ.HashQualified' v)) (Set Referent)
+  | UnknownType (L.Token (HQ.HashQualified' v)) (Set Reference)
+  | UnknownId (L.Token (HQ.HashQualified' v)) (Set Referent) (Set Reference)
   | ExpectedBlockOpen String (L.Token L.Lexeme)
   | EmptyWatch
   | UseInvalidPrefixSuffix (Either (L.Token Name) (L.Token Name)) (Maybe [L.Token Name])
@@ -341,33 +341,33 @@ symbolyDefinitionName = queryToken $ \case
 parenthesize :: Ord v => P v a -> P v a
 parenthesize p = P.try (openBlockWith "(" *> p) <* closeBlock
 
-hqPrefixId, hqInfixId :: Ord v => P v (L.Token HQ.HashQualified)
+hqPrefixId, hqInfixId :: Var v => P v (L.Token (HQ.HashQualified' v))
 hqPrefixId = hqWordyId_ <|> parenthesize hqSymbolyId_
-hqInfixId = hqSymbolyId_ <|> hqBacktickedId_
+hqInfixId= hqSymbolyId_ <|> hqBacktickedId_
 
 -- Parse a hash-qualified alphanumeric identifier
-hqWordyId_ :: Ord v => P v (L.Token HQ.HashQualified)
+hqWordyId_ :: Var v => P v (L.Token (HQ.HashQualified' v))
 hqWordyId_ = queryToken $ \case
   L.WordyId "" (Just h) -> Just $ HQ.HashOnly h
-  L.WordyId s  (Just h) -> Just $ HQ.HashQualified (Name.unsafeFromText (Text.pack s)) h
-  L.WordyId s  Nothing  -> Just $ HQ.NameOnly (Name.unsafeFromText (Text.pack s))
+  L.WordyId s  (Just h) -> Just $ HQ.HashQualified (Var.named (Text.pack s)) h
+  L.WordyId s  Nothing  -> Just $ HQ.NameOnly (Var.named (Text.pack s))
   L.Hash h              -> Just $ HQ.HashOnly h
-  L.Blank s | not (null s) -> Just $ HQ.NameOnly (Name.unsafeFromText (Text.pack ("_" <> s)))
+  L.Blank s | not (null s) -> Just $ HQ.NameOnly (Var.named (Text.pack ("_" <> s)))
   _ -> Nothing
 
 -- Parse a hash-qualified symboly ID like >>=#foo or &&
-hqSymbolyId_ :: Ord v => P v (L.Token HQ.HashQualified)
+hqSymbolyId_ :: Var v => P v (L.Token (HQ.HashQualified' v))
 hqSymbolyId_ = queryToken $ \case
   L.SymbolyId "" (Just h) -> Just $ HQ.HashOnly h
-  L.SymbolyId s  (Just h) -> Just $ HQ.HashQualified (Name.unsafeFromText (Text.pack s)) h
-  L.SymbolyId s  Nothing  -> Just $ HQ.NameOnly (Name.unsafeFromText (Text.pack s))
+  L.SymbolyId s  (Just h) -> Just $ HQ.HashQualified (Var.named (Text.pack s)) h
+  L.SymbolyId s  Nothing  -> Just $ HQ.NameOnly (Var.named (Text.pack s))
   _ -> Nothing
 
-hqBacktickedId_ :: Ord v => P v (L.Token HQ.HashQualified)
+hqBacktickedId_ :: Var v => P v (L.Token (HQ.HashQualified' v))
 hqBacktickedId_ = queryToken $ \case
   L.Backticks "" (Just h) -> Just $ HQ.HashOnly h
-  L.Backticks s  (Just h) -> Just $ HQ.HashQualified (Name.unsafeFromText (Text.pack s)) h
-  L.Backticks s  Nothing  -> Just $ HQ.NameOnly (Name.unsafeFromText (Text.pack s))
+  L.Backticks s  (Just h) -> Just $ HQ.HashQualified (Var.named (Text.pack s)) h
+  L.Backticks s  Nothing  -> Just $ HQ.NameOnly (Var.named (Text.pack s))
   _ -> Nothing
 
 -- Parse a reserved word

--- a/parser-typechecker/src/Unison/Parser.hs
+++ b/parser-typechecker/src/Unison/Parser.hs
@@ -95,7 +95,7 @@ data Error v
   | UnknownId (L.Token (HQ.HashQualified' v)) (Set Referent) (Set Reference)
   | ExpectedBlockOpen String (L.Token L.Lexeme)
   | EmptyWatch
-  | UseInvalidPrefixSuffix (Either (L.Token Name) (L.Token Name)) (Maybe [L.Token Name])
+  | UseInvalidPrefixSuffix (Either (L.Token v) (L.Token v)) (Maybe [L.Token v])
   | UseEmpty (L.Token String) -- an empty `use` statement
   | DidntExpectExpression (L.Token L.Lexeme) (Maybe (L.Token L.Lexeme))
   | TypeDeclarationErrors [UF.Error v Ann]
@@ -264,9 +264,9 @@ matchToken :: Ord v => L.Lexeme -> P v (L.Token L.Lexeme)
 matchToken x = P.satisfy ((==) x . L.payload)
 
 -- The package name that refers to the root, literally just `.`
-importDotId :: Ord v => P v (L.Token Name)
+importDotId :: Var v => P v (L.Token v)
 importDotId = queryToken go where
-  go (L.SymbolyId "." Nothing) = Just (Name.unsafeFromText ".")
+  go (L.SymbolyId "." Nothing) = Just (Var.named ".")
   go _ = Nothing
 
 -- Consume a virtual semicolon
@@ -306,13 +306,13 @@ wordyIdString = queryToken $ \case
 wordyIdText :: Ord v => P v (L.Token Text)
 wordyIdText = (fmap . fmap) Text.pack wordyIdString
 
--- Parse a wordyId as a Name, rejecting any hash
-importWordyId :: Ord v => P v (L.Token Name)
-importWordyId = (fmap . fmap) Name.unsafeFromText wordyIdText
+-- Parse a wordyId as a var
+importWordyId :: Var v => P v (L.Token v)
+importWordyId = (fmap . fmap) Var.named wordyIdText
 
--- The `+` in: use Foo.bar + as a Name
-importSymbolyId :: Ord v => P v (L.Token Name)
-importSymbolyId = (fmap . fmap) Name.unsafeFromText symbolyIdText
+-- The `+` in: use Foo.bar + as a var
+importSymbolyId :: Var v => P v (L.Token v)
+importSymbolyId = (fmap . fmap) Var.named symbolyIdText
 
 -- Parse a symbolyId as a String, rejecting any hash
 symbolyIdString :: Ord v => P v (L.Token String)

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -949,17 +949,20 @@ prettyParseError s = \case
         tokenAsErrorSite s tok,
         useExamples
         ]
-      (tok0, Nothing) -> let tok = either id id tok0 in [
+      (tok0, Nothing) -> let tok = either id id tok0 in
+                         let n = Name.fromVar (L.payload tok) in [
         Pr.wrap $ "I was expecting something after " <> Pr.hiRed "here:", "",
         tokenAsErrorSite s tok,
-        case Name.parent (Name.fromVar (L.payload tok)) of
+        case Name.parent n of
           Nothing -> useExamples
+          -- This is an error message for when you say "use Nat.++"; it suggests
+          -- "use Nat ++"
           Just parent -> Pr.wrap $
             "You can write" <>
             Pr.group (Pr.blue $ "use " <> Pr.text (Name.toText parent) <> " "
-                                       <> Pr.text (Name.toText (Name.unqualified (Name.fromVar (L.payload tok))))) <>
-            "to introduce " <> Pr.backticked (Pr.text (Name.toText (Name.unqualified (Name.fromVar (L.payload tok))))) <>
-            "as a local alias for " <> Pr.backticked (Pr.text (Name.toText (Name.fromVar (L.payload tok))))
+                                       <> Pr.text (Name.toText (Name.unqualified n))) <>
+            "to introduce " <> Pr.backticked (Pr.text (Name.toText (Name.unqualified n))) <>
+            "as a local alias for " <> Pr.backticked (Pr.text (Name.toText n))
         ]
       (Right tok, _) -> [ -- this is unpossible but rather than bomb, nice msg
         "You found a Unison bug 🐞  here:", "",

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -952,14 +952,14 @@ prettyParseError s = \case
       (tok0, Nothing) -> let tok = either id id tok0 in [
         Pr.wrap $ "I was expecting something after " <> Pr.hiRed "here:", "",
         tokenAsErrorSite s tok,
-        case Name.parent (L.payload tok) of
+        case Name.parent (Name.fromVar (L.payload tok)) of
           Nothing -> useExamples
           Just parent -> Pr.wrap $
             "You can write" <>
             Pr.group (Pr.blue $ "use " <> Pr.text (Name.toText parent) <> " "
-                                       <> Pr.text (Name.toText (Name.unqualified (L.payload tok)))) <>
-            "to introduce " <> Pr.backticked (Pr.text (Name.toText (Name.unqualified (L.payload tok)))) <>
-            "as a local alias for " <> Pr.backticked (Pr.text (Name.toText (L.payload tok)))
+                                       <> Pr.text (Name.toText (Name.unqualified (Name.fromVar (L.payload tok))))) <>
+            "to introduce " <> Pr.backticked (Pr.text (Name.toText (Name.unqualified (Name.fromVar (L.payload tok))))) <>
+            "as a local alias for " <> Pr.backticked (Pr.text (Name.toText (Name.fromVar (L.payload tok))))
         ]
       (Right tok, _) -> [ -- this is unpossible but rather than bomb, nice msg
         "You found a Unison bug 🐞  here:", "",

--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -76,7 +76,7 @@ typeLink' :: Var v => P v (L.Token Reference)
 typeLink' = do
   id <- hqPrefixId
   ns <- asks names
-  case Names.lookupHQType (L.payload id) ns of
+  case Names.lookupHQType (Name.fromVar <$> L.payload id) ns of
     s | Set.size s == 1 -> pure $ const (Set.findMin s) <$> id
       | otherwise       -> customFailure $ UnknownType id s
 
@@ -84,7 +84,7 @@ termLink' :: Var v => P v (L.Token Referent)
 termLink' = do
   id <- hqPrefixId
   ns <- asks names
-  case Names.lookupHQTerm (L.payload id) ns of
+  case Names.lookupHQTerm (Name.fromVar <$> L.payload id) ns of
     s | Set.size s == 1 -> pure $ const (Set.findMin s) <$> id
       | otherwise       -> customFailure $ UnknownTerm id s
 
@@ -92,7 +92,7 @@ link' :: Var v => P v (Either (L.Token Reference) (L.Token Referent))
 link' = do
   id <- hqPrefixId
   ns <- asks names
-  case (Names.lookupHQTerm (L.payload id) ns, Names.lookupHQType (L.payload id) ns) of
+  case (Names.lookupHQTerm (Name.fromVar <$> L.payload id) ns, Names.lookupHQType (Name.fromVar <$> L.payload id) ns) of
     (s, s2) | Set.size s == 1 && Set.null s2 -> pure . Right $ const (Set.findMin s) <$> id
     (s, s2) | Set.size s2 == 1 && Set.null s -> pure . Left $ const (Set.findMin s2) <$> id
     (s, s2) -> customFailure $ UnknownId id s s2
@@ -175,7 +175,7 @@ parsePattern =
     -- this might be a var, so we avoid consuming it at first
     tok <- P.try (P.lookAhead hqPrefixId)
     names <- asks names
-    case Names.lookupHQPattern (L.payload tok) names of
+    case Names.lookupHQPattern (Name.fromVar <$> L.payload tok) names of
       s | Set.null s     -> die tok s
         | Set.size s > 1 -> die tok s
         | otherwise      -> -- matched ctor name, consume the token
@@ -185,7 +185,7 @@ parsePattern =
       -- if token not hash qualified or uppercase,
       -- fail w/out consuming it to allow backtracking
       HQ.NameOnly n | Set.null s &&
-                      Name.isLower n -> fail $ "not a constructor name: " <> Name.toString n
+                      Name.isLower (Name.fromVar n) -> fail $ "not a constructor name: " <> Name.toString (Name.fromVar n)
       -- it was hash qualified, and wasn't found in the env, that's a failure!
       _ -> failCommitted $ err hq s
 
@@ -268,12 +268,12 @@ hashQualifiedInfixTerm = resolveHashQualified =<< hqInfixId
 -- If the hash qualified is name only, it is treated as a var, if it
 -- has a short hash, we resolve that short hash immediately and fail
 -- committed if that short hash can't be found in the current environment
-resolveHashQualified :: Var v => L.Token HQ.HashQualified -> TermP v
+resolveHashQualified :: Var v => L.Token (HQ.HashQualified' v) -> TermP v
 resolveHashQualified tok = do
   names <- asks names
   case L.payload tok of
-    HQ.NameOnly n -> pure $ Term.var (ann tok) (Name.toVar n)
-    _ -> case Names.lookupHQTerm (L.payload tok) names of
+    HQ.NameOnly n -> pure $ Term.var (ann tok) n
+    _ -> case Names.lookupHQTerm (Name.fromVar <$> L.payload tok) names of
       s | Set.null s     -> failCommitted $ UnknownTerm tok s
         | Set.size s > 1 -> failCommitted $ UnknownTerm tok s
         | otherwise      -> pure $ Term.fromReferent (ann tok) (Set.findMin s)

--- a/parser-typechecker/src/Unison/TypeParser.hs
+++ b/parser-typechecker/src/Unison/TypeParser.hs
@@ -39,10 +39,10 @@ valueTypeLeaf =
 -- Examples: Optional, Optional#abc, woot, #abc
 typeAtom :: Var v => TypeP v
 typeAtom = hqPrefixId >>= \tok -> case L.payload tok of
-  HQ.NameOnly n -> pure $ Type.var (ann tok) (Name.toVar n)
+  HQ.NameOnly n -> pure $ Type.var (ann tok) n
   hq -> do
     names <- asks names
-    let matches = Names.lookupHQType hq names
+    let matches = Names.lookupHQType (Name.fromVar <$> hq) names
     if Set.size matches /= 1
     then P.customFailure (UnknownType tok matches)
     else pure $ Type.ref (ann tok) (Set.findMin matches)

--- a/parser-typechecker/src/Unison/UnisonFile.hs
+++ b/parser-typechecker/src/Unison/UnisonFile.hs
@@ -244,7 +244,7 @@ bindNames names (UnisonFile d e ts ws) = do
   --    so that you don't weirdly have free vars to tiptoe around.
   --    The free vars should just be the things that need to be bound externally.
   let termVars = (fst <$> ts) ++ (Map.elems ws >>= map fst)
-      termVarsSet = Set.fromList termVars
+      termVarsSet = Set.fromList (map Name.fromVar termVars)
   -- todo: can we clean up this lambda using something like `second`
   ts' <- traverse (\(v,t) -> (v,) <$> Term.bindNames termVarsSet names t) ts
   ws' <- traverse (traverse (\(v,t) -> (v,) <$> Term.bindNames termVarsSet names t)) ws
@@ -308,7 +308,7 @@ environmentFor names dataDecls0 effectDecls0 = do
     okVars = Map.keysSet allDecls0
     unknownTypeRefs = Map.elems allDecls0 >>= \dd ->
       let cts = DD.constructorTypes dd
-      in cts >>= \ct -> [ UnknownType v a | (v,a) <- ABT.freeVarOccurrences mempty ct
+      in cts >>= \ct -> [ UnknownType v a | (v,a) <- ABT.freeVarOccurrences (const False) ct
                                           , not (Set.member v okVars) ]
   pure $
     if null overlaps && null unknownTypeRefs

--- a/unison-core/src/Unison/ABT.hs
+++ b/unison-core/src/Unison/ABT.hs
@@ -381,9 +381,9 @@ rebuildUp' f (Term _ ann body) = case body of
   Abs x e -> f $ abs' ann x (rebuildUp' f e)
   Tm body -> f $ tm' ann (fmap (rebuildUp' f) body)
 
-freeVarOccurrences :: (Traversable f, Ord v) => Set v -> Term f v a -> [(v, a)]
-freeVarOccurrences except t =
-  [ (v, a) | (v,a) <- go $ annotateBound t, not (Set.member v except) ]
+freeVarOccurrences :: (Traversable f, Ord v) => (v -> Bool) -> Term f v a -> [(v, a)]
+freeVarOccurrences isBound t =
+  [ (v, a) | (v,a) <- go $ annotateBound t, not (isBound v) ]
   where
   go e = case out e of
     Var v -> if Set.member v (snd $ annotation e)
@@ -559,16 +559,16 @@ components :: Var v => [(v, Term f v a)] -> [[(v, Term f v a)]]
 components = Components.components freeVars
 
 -- Converts to strongly connected components while preserving the
--- order of definitions. Satisfies `join (orderedComponents bs) == bs`. 
+-- order of definitions. Satisfies `join (orderedComponents bs) == bs`.
 orderedComponents' :: Var v => [(v, Term f v a)] -> [[(v, Term f v a)]]
-orderedComponents' tms = go [] Set.empty tms 
+orderedComponents' tms = go [] Set.empty tms
   where
   go [] _ [] = []
   go [] deps (hd:rem) = go [hd] (deps <> freeVars (snd hd)) rem
   go cur deps rem = case findIndex isDep rem of
     Nothing -> reverse cur : let (hd,tl) = splitAt 1 rem
                              in go hd (depsFor hd) tl
-    Just i  -> go (reverse newMembers ++ cur) deps' (drop (i+1) rem) 
+    Just i  -> go (reverse newMembers ++ cur) deps' (drop (i+1) rem)
                where deps' = deps <> depsFor newMembers
                      newMembers = take (i+1) rem
     where
@@ -576,7 +576,7 @@ orderedComponents' tms = go [] Set.empty tms
     isDep (v, _) = Set.member v deps
 
 -- Like `orderedComponents'`, but further break up cycles and move
--- cyclic subcycles before other components in the same cycle. 
+-- cyclic subcycles before other components in the same cycle.
 -- Tweak suggested by @aryairani.
 --
 -- Example: given `[[x],[ping,r,s,pong]]`, where `ping` and `pong`
@@ -587,7 +587,7 @@ orderedComponents bs0 = tweak =<< orderedComponents' bs0 where
   tweak :: Var v => [(v,Term f v a)] -> [[(v,Term f v a)]]
   tweak bs@(_:_:_) = case takeWhile isCyclic (components bs) of
     [] -> [bs]
-    cycles -> cycles <> orderedComponents rest 
+    cycles -> cycles <> orderedComponents rest
       where
       rest = [ (v,b) | (v,b) <- bs, Set.notMember v cycleVars ]
       cycleVars = Set.fromList (fst <$> join cycles)

--- a/unison-core/src/Unison/Names2.hs
+++ b/unison-core/src/Unison/Names2.hs
@@ -16,6 +16,7 @@ module Unison.Names2
   , difference
   , filter
   , filterByHQs
+  , filterByHQsOn
   , filterBySHs
   , filterTypes
   , hqName
@@ -283,13 +284,21 @@ filter f (Names terms types) = Names (R.filterDom f terms) (R.filterDom f types)
 
 -- currently used for filtering before a conditional `add`
 filterByHQs :: Ord n => Set (HashQualified' n) -> Names' n -> Names' n
-filterByHQs hqs Names{..} = Names terms' types' where
+filterByHQs = filterByHQsOn id
+
+filterByHQsOn
+  :: (Ord m, Eq n)
+  => (m -> n)
+  -> Set (HashQualified' n)
+  -> Names' m
+  -> Names' m
+filterByHQsOn p hqs Names{..} = Names terms' types' where
   terms' = R.filter f terms
   types' = R.filter g types
-  f (n, r) = any (HQ.matchesNamedReferent n r) hqs
-  g (n, r) = any (HQ.matchesNamedReference n r) hqs
+  f (n, r) = any (HQ.matchesNamedReferent (p n) r) hqs
+  g (n, r) = any (HQ.matchesNamedReference (p n) r) hqs
 
-filterBySHs :: Set ShortHash -> Names0 -> Names0
+filterBySHs :: Ord n => Set ShortHash -> Names' n -> Names' n
 filterBySHs shs Names{..} = Names terms' types' where
   terms' = R.filter f terms
   types' = R.filter g types

--- a/unison-core/src/Unison/Names3.hs
+++ b/unison-core/src/Unison/Names3.hs
@@ -212,11 +212,11 @@ importing :: [(Name, Name)] -> Names -> Names
 importing shortToLongName ns =
   ns { currentNames = importing0 shortToLongName (currentNames ns) }
 
-importing0 :: [(Name, Name)] -> Names0 -> Names0
+importing0 :: Ord n => [(n, n)] -> Names.Names' n -> Names.Names' n
 importing0 shortToLongName ns =
   Names.Names
-    (foldl' go (terms0 ns) shortToLongName)
-    (foldl' go (types0 ns) shortToLongName)
+    (foldl' go (Names.terms ns) shortToLongName)
+    (foldl' go (Names.types ns) shortToLongName)
   where
   go :: (Ord a, Ord b) => Relation a b -> (a, a) -> Relation a b
   go m (shortname, qname) = case R.lookupDom qname m of

--- a/unison-core/src/Unison/Type.hs
+++ b/unison-core/src/Unison/Type.hs
@@ -75,7 +75,7 @@ bindNames
   -> Type v a
   -> Names.ResolutionResult v a (Type v a)
 bindNames keepFree ns t = let
-  fvs = ABT.freeVarOccurrences keepFree t
+  fvs = ABT.freeVarOccurrences (`elem` keepFree) t
   rs = [(v, a, R.lookupDom (Name.fromVar v) (Names.types0 ns)) | (v,a) <- fvs ]
   ok (v, a, rs) = if Set.size rs == 1 then pure (v, Set.findMin rs)
                   else Left (pure (Names.TypeResolutionFailure v a rs))


### PR DESCRIPTION
I'm not very confident about this one because I don't really understand the relationship between `Name` and `Var v => v` especially as it relates to pluggable syntax.

This patch is based on the assumption that calling `Name.toVar` is weird/smelly:

- "Names" start out life as `User` vars.
- However, we are often parsing directly as `Name` and then calling `Name.toVar` as necessary, especially around the "unison file" boundary where we are cross-referencing data structures full of `Name`s (like `Names0`) and the freshly parsed/typechecked code.
- It seems better to delay conversion from `Var v => v` to `Name` until as late as possible, and treat the other direction (`Name` to `Var v => v` via `Name.toVar`) as a code smell that's currently everywhere simply due to convenience (and lack of a second syntax to worry about)