### PR TITLE
Implement numbering for `showDiffNamespace` with new `NotifyNumbered` `Command`

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -60,6 +60,7 @@ data Command m i v a where
 
   -- Presents some output to the user
   Notify :: Output v -> Command m i v ()
+  NotifyNumbered :: NumberedOutput v -> Command m i v NumberedArgs
 
   -- literally just write some terms and types .unison/{terms,types}
   AddDefsToCodebase :: UF.TypecheckedUnisonFile v Ann -> Command m i v ()

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -94,10 +94,11 @@ commandLine
   -> (Branch IO -> IO ())
   -> Runtime v
   -> (Output v -> IO ())
+  -> (NumberedOutput v -> IO NumberedArgs)
   -> Codebase IO v Ann
   -> Free (Command IO i v) a
   -> IO a
-commandLine config awaitInput setBranchRef rt notifyUser codebase =
+commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered codebase =
  Free.fold go
  where
   go :: forall x . Command IO i v x -> IO x
@@ -106,6 +107,7 @@ commandLine config awaitInput setBranchRef rt notifyUser codebase =
     Eval m        -> m
     Input         -> awaitInput
     Notify output -> notifyUser output
+    NotifyNumbered output -> notifyNumbered output
     ConfigLookup name -> Config.lookup config name
     Typecheck ambient names sourceName source -> do
       -- todo: if guids are being shown to users,

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -158,7 +158,7 @@ data LoopState m v
       -- A 1-indexed list of strings that can be referenced by index at the
       -- CLI prompt.  e.g. Given ["Foo.bat", "Foo.cat"],
       -- `rename 2 Foo.foo` will rename `Foo.cat` to `Foo.foo`.
-      , _numberedArgs :: [String]
+      , _numberedArgs :: NumberedArgs
       }
 
 type SkipNextUpdate = Bool
@@ -507,8 +507,7 @@ loop = do
                         (Branch.toNames0 after)
                         ppe
                         diff
-        numberedArgs .= numberOutputDiff outputDiff
-        respond $ ShowDiffNamespace ppe outputDiff
+        respondNumbered $ ShowDiffNamespace ppe beforep afterp outputDiff
 
       -- move the root to a sub-branch
       MoveBranchI Nothing dest -> do
@@ -1671,6 +1670,11 @@ searchBranchExact len names queries = let
 
 respond :: Output v -> Action m i v ()
 respond output = eval $ Notify output
+
+respondNumbered :: NumberedOutput v -> Action m i v ()
+respondNumbered output = do
+  args <- eval $ NotifyNumbered output
+  numberedArgs .= toList args
 
 -- Merges the specified remote branch into the specified local absolute path.
 -- Implementation detail of PullRemoteBranchI

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -2,6 +2,8 @@
 
 module Unison.Codebase.Editor.Output
   ( Output(..)
+  , NumberedOutput(..)
+  , NumberedArgs
   , ListDetailed
   , ShallowListEntry(..)
   , HistoryTail(..)
@@ -11,6 +13,7 @@ module Unison.Codebase.Editor.Output
   , ReflogEntry(..)
   , pushPull
   , isFailure
+  , isNumberedFailure
   ) where
 
 import Unison.Prelude
@@ -57,6 +60,7 @@ import Unison.Codebase.Editor.Output.BranchDiff (BranchDiffOutput)
 type Term v a = Term.AnnotatedTerm v a
 type ListDetailed = Bool
 type SourceName = Text
+type NumberedArgs = [String]
 
 data PushPull = Push | Pull deriving (Eq, Ord, Show)
 
@@ -64,6 +68,9 @@ pushPull :: a -> a -> PushPull -> a
 pushPull push pull p = case p of
   Push -> push
   Pull -> pull
+
+data NumberedOutput v
+  = ShowDiffNamespace PPE.PrettyPrintEnv Path.Absolute Path.Absolute (BranchDiffOutput v Ann)
 
 data Output v
   -- Generic Success response; we might consider deleting this.
@@ -162,7 +169,6 @@ data Output v
   | PatchInvolvesExternalDependents PPE.PrettyPrintEnv (Set Reference)
   | WarnIncomingRootBranch (Set ShortBranchHash)
   | ShowDiff Input Names.Diff
-  | ShowDiffNamespace PPE.PrettyPrintEnv (BranchDiffOutput v Ann)
   | History (Maybe Int) [(ShortBranchHash, Names.Diff)] HistoryTail
   | ShowReflog [ReflogEntry]
   | NothingTodo Input
@@ -288,7 +294,8 @@ isFailure o = case o of
   ListShallow _ es -> null es
   HashAmbiguous{} -> True
   ShowReflog{} -> False
+
+isNumberedFailure :: NumberedOutput v -> Bool
+isNumberedFailure = \case
   ShowDiffNamespace{} -> False
-
-
 

--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -88,6 +88,12 @@ unprefix :: Absolute -> Path' -> Path
 unprefix (Absolute prefix) (Path' p) = case p of
   Left abs -> unabsolute abs
   Right (unrelative -> rel) -> fromList $ dropPrefix (toList prefix) (toList rel)
+  
+-- too many types
+prefix :: Absolute -> Path' -> Path
+prefix (Absolute (Path prefix)) (Path' p) = case p of
+  Left (unabsolute -> abs) -> abs
+  Right (unrelative -> rel) -> Path $ prefix <> toSeq rel  
 
 -- .libs.blah.poo is Absolute
 -- libs.blah.poo is Relative
@@ -233,6 +239,9 @@ splitFromName = unsnoc . fromName
 
 unprefixName :: Absolute -> Name -> Name
 unprefixName prefix = toName . unprefix prefix . fromName'
+
+prefixName :: Absolute -> Name -> Name
+prefixName p = toName . prefix p . fromName'
 
 singleton :: NameSegment -> Path
 singleton n = fromList [n]

--- a/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
@@ -20,7 +20,7 @@ import Unison.Codebase.Editor.Input (Input (..), Event(UnisonFileChanged))
 import Unison.CommandLine
 import Unison.CommandLine.InputPattern (InputPattern (aliases, patternName))
 import Unison.CommandLine.InputPatterns (validInputs)
-import Unison.CommandLine.OutputMessages (notifyUser)
+import Unison.CommandLine.OutputMessages (notifyUser, notifyNumbered)
 import Unison.Parser (Ann)
 import Unison.Prelude
 import Unison.PrettyTerminal
@@ -207,10 +207,19 @@ run dir configFile stanzas codebase = do
         errOk <- readIORef allowErrors
         let rendered = P.toPlain 65 (P.border 2 msg)
         output rendered
-        when (errOk && Output.isFailure o) $ 
-          writeIORef hasErrors True
-        when (not errOk && Output.isFailure o) 
-          die
+        when (Output.isFailure o) $
+          if errOk then writeIORef hasErrors True
+          else die
+          
+      printNumbered o = do
+        let (msg, numberedArgs) = notifyNumbered o
+        errOk <- readIORef allowErrors
+        let rendered = P.toPlain 65 (P.border 2 msg)
+        output rendered
+        when (Output.isNumberedFailure o) $ 
+          if errOk then writeIORef hasErrors True
+          else die
+        pure numberedArgs
 
       die = do 
         output "\n```\n\n"
@@ -227,6 +236,7 @@ run dir configFile stanzas codebase = do
                                      (const $ pure ())
                                      runtime
                                      print
+                                     printNumbered
                                      codebase
                                      free
         case o of

--- a/parser-typechecker/src/Unison/CommandLine/Main.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Main.hs
@@ -209,8 +209,8 @@ main dir initialPath configFile initialInputs startRuntime codebase = do
                                      (writeIORef rootRef)
                                      runtime
                                      (notifyUser dir >=> putPrettyNonempty)
-                                     (\o -> let (p, args) = notifyNumbered o in 
-                                      putPrettyNonempty p >> pure args)
+                                     (\o -> let (p, args) = notifyNumbered o in
+                                      putPrettyNonempty p $> args)
                                      codebase
                                      free
         case o of

--- a/parser-typechecker/src/Unison/CommandLine/Main.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Main.hs
@@ -27,7 +27,7 @@ import Unison.CommandLine
 import Unison.PrettyTerminal
 import Unison.CommandLine.InputPattern (ArgumentType (suggestions), InputPattern (aliases, patternName))
 import Unison.CommandLine.InputPatterns (validInputs)
-import Unison.CommandLine.OutputMessages (notifyUser, shortenDirectory)
+import Unison.CommandLine.OutputMessages (notifyUser, notifyNumbered, shortenDirectory)
 import Unison.Parser (Ann)
 import Unison.Var (Var)
 import qualified Control.Concurrent.Async as Async
@@ -209,6 +209,8 @@ main dir initialPath configFile initialInputs startRuntime codebase = do
                                      (writeIORef rootRef)
                                      runtime
                                      (notifyUser dir >=> putPrettyNonempty)
+                                     (\o -> let (p, args) = notifyNumbered o in 
+                                      putPrettyNonempty p >> pure args)
                                      codebase
                                      free
         case o of

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -27,12 +27,13 @@ import qualified Unison.Codebase.Editor.Output.BranchDiff as OBD
 
 
 import qualified Control.Monad.State.Strict    as State
-import           Data.Bifunctor                (bimap, first, second)
+import           Data.Bifunctor                (bimap, first)
 import           Data.List                     (sortOn, stripPrefix)
 import           Data.List.Extra               (nubOrdOn, nubOrd)
 import           Data.ListLike                 (ListLike)
 import qualified Data.Map                      as Map
 import qualified Data.Set                      as Set
+import qualified Data.Sequence                 as Seq
 import qualified Data.Text                     as Text
 import           Data.Text.IO                  (readFile, writeFile)
 import           Data.Tuple.Extra              (dupe)
@@ -110,7 +111,7 @@ import qualified Unison.Util.List              as List
 import qualified Unison.Util.Monoid            as Monoid
 import Data.Tuple (swap)
 import Unison.Codebase.ShortBranchHash (ShortBranchHash)
-import Control.Lens (view, _1, _3)
+import Control.Lens (view, over, _1, _3)
 
 type Pretty = P.Pretty P.ColorText
 
@@ -123,6 +124,11 @@ shortenDirectory dir = do
 
 renderFileName :: FilePath -> IO (Pretty)
 renderFileName dir = P.group . P.blue . fromString <$> shortenDirectory dir
+
+notifyNumbered :: Var v => NumberedOutput v -> (Pretty, NumberedArgs)
+notifyNumbered o = case o of
+  ShowDiffNamespace ppe oldPath rightPath diffOutput ->
+    showDiffNamespace ppe oldPath rightPath diffOutput
 
 notifyUser :: forall v . Var v => FilePath -> Output v -> IO Pretty
 notifyUser dir o = case o of
@@ -781,7 +787,6 @@ notifyUser dir o = case o of
             <> P.shown dest <> "is at or ahead of the source"
             <> P.group (P.shown src <> ".")
     _ -> "Nothing to do."
-  ShowDiffNamespace ppe diffOutput -> pure $ showDiffNamespace ppe diffOutput
   DumpBitBooster head map -> let
     go output []          = output
     go output (head : queue) = case Map.lookup head map of
@@ -1097,7 +1102,7 @@ renderEditConflicts ppe Patch{..} =
       P.oxfordCommas [ termName r | TermEdit.Replace r _ <- es ]
     formatConflict = either formatTypeEdits formatTermEdits
 
-type Numbered a = State.State Int a
+type Numbered a = State.State (Int, Seq.Seq String) a
 todoOutput :: Var v => PPE.PrettyPrintEnvDecl -> TO.TodoOutput v a -> IO Pretty
 todoOutput ppe todo =
   if noConflicts && noEdits
@@ -1195,9 +1200,15 @@ listOfLinks ppe results = pure $ P.lines [
   prettyType Nothing = "❓ (missing a type for this definition)"
   prettyType (Just t) = TypePrinter.pretty ppe t
 
-showDiffNamespace :: forall v . Var v => PPE.PrettyPrintEnv -> OBD.BranchDiffOutput v Ann -> Pretty
-showDiffNamespace ppe d@OBD.BranchDiffOutput{..} =
-  P.sepNonEmpty "\n\n" . (`State.evalState` (0::Int)) . sequence $ [
+showDiffNamespace :: forall v . Var v
+                  => PPE.PrettyPrintEnv
+                  -> Path.Absolute
+                  -> Path.Absolute
+                  -> OBD.BranchDiffOutput v Ann
+                  -> (Pretty, NumberedArgs)
+showDiffNamespace ppe oldPath newPath OBD.BranchDiffOutput{..} =
+  let wrangleResult (p,(_n,args)) = (P.sepNonEmpty "\n\n" p, toList args) in
+  wrangleResult . (`State.runState` (1::Int, Seq.empty)) . sequence $ [
     if (not . null) updatedTypes
     || (not . null) updatedTerms
     || propagatedUpdates > 0
@@ -1280,20 +1291,21 @@ showDiffNamespace ppe d@OBD.BranchDiffOutput{..} =
                      -> [OBD.RenameTermDisplay v a]
                      -> Numbered [Pretty]
   prettyRenameGroups types terms =
-    (<>) <$> traverse prettyGroup types
+    (<>) <$> traverse (prettyGroup . (over _1 Referent.Ref)) types
          <*> traverse prettyGroup terms
     where
         leftNamePad :: Int = foldl1' max $
           map (foldl1' max . map HQ'.nameLength . toList . view _3) terms <>
           map (foldl1' max . map HQ'.nameLength . toList . view _3) types
-        prettyGroup :: (a, b, Set HQ'.HashQualified, Set HQ'.HashQualified)
+        prettyGroup :: (Referent, b, Set HQ'.HashQualified, Set HQ'.HashQualified)
                     -> Numbered Pretty
-        prettyGroup (_, _, olds, news) = let
+        prettyGroup (r, _, olds, news) = let
           -- [ "peach  ┐"
           -- , "peach' ┘"]
           olds' :: [Numbered Pretty] =
-            map (\old -> num <&> (\n -> n <> old))
-              . P.boxRight' P.rBoxStyle2
+            map (\(oldhq, oldp) -> numHQ oldPath oldhq r <&> (\n -> n <> oldp))
+              . (zip (toList olds))
+              . (P.boxRight' P.rBoxStyle2)
               . map (P.rightPad leftNamePad . phq')
               $ toList olds
           -- [  "┌  14. moved.peach"
@@ -1301,7 +1313,7 @@ showDiffNamespace ppe d@OBD.BranchDiffOutput{..} =
           -- ,  "└  17. ooga.booga2" ]
           news' :: [Numbered Pretty] =
             P.boxLeftM' P.lBoxStyle2
-              . map (\new -> num <&> (\n -> n <> phq' new))
+              . map (\new -> numHQ newPath new r <&> (\n -> n <> phq' new))
               $ toList news
           buildTable lefts rights = go arrow lefts rights where
             go :: Monad m => String -> [m Pretty] -> [m Pretty] -> m [Pretty]
@@ -1327,7 +1339,8 @@ showDiffNamespace ppe d@OBD.BranchDiffOutput{..} =
         5. - apiDocs : License
         6. + MIT     : License
   -}
-  prettyUpdateType (Nothing, mdUps) = P.column2 <$> traverse mdTypeLine mdUps
+  prettyUpdateType (Nothing, mdUps) =
+    P.column2 <$> traverse (mdTypeLine newPath) mdUps
   {-
       1. ┌ ability Foo#pqr x y
       2. └ ability Foo#xyz a b
@@ -1347,8 +1360,8 @@ showDiffNamespace ppe d@OBD.BranchDiffOutput{..} =
   -}
   prettyUpdateType (Just olds, news) =
     do
-      olds <- traverse mdTypeLine [ (name,r,decl,mempty) | (name,r,decl) <- olds ]
-      news <- traverse mdTypeLine news
+      olds <- traverse (mdTypeLine oldPath) [ (name,r,decl,mempty) | (name,r,decl) <- olds ]
+      news <- traverse (mdTypeLine newPath) news
       let (oldnums, olddatas) = unzip olds
       let (newnums, newdatas) = unzip news
       pure . P.column2 $
@@ -1362,34 +1375,36 @@ showDiffNamespace ppe d@OBD.BranchDiffOutput{..} =
   prettyAddTypes :: [OBD.AddedTypeDisplay v a] -> Numbered Pretty
   prettyAddTypes = fmap P.lines . traverse prettyGroup where
     prettyGroup :: OBD.AddedTypeDisplay v a -> Numbered Pretty
-    prettyGroup (hqmds, _r, odecl) = do
-      pairs <- traverse (prettyLine odecl) hqmds
+    prettyGroup (hqmds, r, odecl) = do
+      pairs <- traverse (prettyLine r odecl) hqmds
       let (nums, decls) = unzip pairs
       let boxLeft = case hqmds of _:_:_ -> P.boxLeft; _ -> id
       pure . P.column2 $ zip nums (boxLeft decls)
-    prettyLine :: Maybe (DD.DeclOrBuiltin v a) -> (HQ'.HashQualified, [OBD.MetadataDisplay v a]) -> Numbered (Pretty, Pretty)
-    prettyLine odecl (hq, mds) = do
-      n <- num
+    prettyLine :: Reference -> Maybe (DD.DeclOrBuiltin v a) -> (HQ'.HashQualified, [OBD.MetadataDisplay v a]) -> Numbered (Pretty, Pretty)
+    prettyLine r odecl (hq, mds) = do
+      n <- numHQ newPath hq (Referent.Ref r)
       pure . (n,) $ prettyDecl hq odecl <> case length mds of
         0 -> mempty
-        c -> "(+" <> P.shown c <> " metadata)"
+        c -> " (+" <> P.shown c <> " metadata)"
 
   prettyAddTerms :: [OBD.AddedTermDisplay v a] -> Numbered Pretty
   prettyAddTerms = fmap (P.column3 . mconcat) . traverse prettyGroup where
     prettyGroup :: OBD.AddedTermDisplay v a -> Numbered [(Pretty, Pretty, Pretty)]
-    prettyGroup (hqmds, _r, otype) = do
-      pairs <- traverse (prettyLine otype) hqmds
+    prettyGroup (hqmds, r, otype) = do
+      pairs <- traverse (prettyLine r otype) hqmds
       let (nums, names, decls) = unzip3 pairs
           boxLeft = case hqmds of _:_:_ -> P.boxLeft; _ -> id
       pure $ zip3 nums (boxLeft names) decls
-    prettyLine otype (hq, mds) = do
-      n <- num
-      pure . (n, phq' hq, ) $ " : " <> prettyType otype
+    prettyLine r otype (hq, mds) = do
+      n <- numHQ newPath hq r
+      pure . (n, phq' hq, ) $ " : " <> prettyType otype <> case length mds of
+        0 -> mempty
+        c -> " (+" <> P.shown c <> " metadata)"
 
   prettySummarizePatch, prettyNamePatch :: OBD.PatchDisplay -> Numbered Pretty
   --  12. patch p (added 3 updates, deleted 1)
   prettySummarizePatch (name, patchDiff) = do
-    n <- num
+    n <- numPatch name
     let addCount = (R.size . view Patch.addedTermEdits) patchDiff +
                    (R.size . view Patch.addedTypeEdits) patchDiff
         delCount = (R.size . view Patch.removedTermEdits) patchDiff +
@@ -1402,8 +1417,8 @@ showDiffNamespace ppe d@OBD.BranchDiffOutput{..} =
           x : ys -> " (" <> P.commas (x <> " updates" : ys) <> ")"
     pure $ n <> "patch " <> prettyName name <> message
   --	18. patch q
-  prettyNamePatch (name, patchDiff) = do
-    n <- num
+  prettyNamePatch (name, _patchDiff) = do
+    n <- numPatch name
     pure $ n <> "patch " <> prettyName name
 
   {-
@@ -1414,26 +1429,26 @@ showDiffNamespace ppe d@OBD.BranchDiffOutput{..} =
     12.  patch defunctThingy
 	-}
   prettyRemoveTypes :: [OBD.TypeDisplay v a] -> Numbered Pretty
-  prettyRemoveTypes types = fmap P.lines . for types $ \(hq, _, odecl, _) -> do
-    n <- num
+  prettyRemoveTypes types = fmap P.lines . for types $ \(hq, r, odecl, _) -> do
+    n <- numHQ oldPath hq (Referent.Ref r)
     pure $ n <> prettyDecl hq odecl
 
   prettyRemoveTerms :: [OBD.TermDisplay v a] -> Numbered Pretty
-  prettyRemoveTerms terms = fmap P.lines . for terms $ \(hq, _, otype, _) -> do
-    n <- num
+  prettyRemoveTerms terms = fmap P.lines . for terms $ \(hq, r, otype, _) -> do
+    n <- numHQ oldPath hq r
     pure $ n <> P.rightPad namesWidth (phq' hq) <> " : " <> prettyType otype
     where namesWidth = foldl1' max $ fmap (HQ'.nameLength . view _1) terms
 
   downArrow = P.bold "⧩ replaced with"
-  mdTypeLine :: OBD.TypeDisplay v a -> Numbered (Pretty, Pretty)
-  mdTypeLine (hq, _r, odecl, mddiff) = do
-    n <- num
+  mdTypeLine :: Path.Absolute -> OBD.TypeDisplay v a -> Numbered (Pretty, Pretty)
+  mdTypeLine p (hq, r, odecl, mddiff) = do
+    n <- numHQ p hq (Referent.Ref r)
     fmap ((n,) . P.linesNonEmpty) . sequence $
       [ pure $ prettyDecl hq odecl
       , P.indentN leftNumsWidth <$> prettyMetadataDiff mddiff ]
-  mdTermLine :: Int -> OBD.TermDisplay v a -> Numbered (Pretty, Pretty)
-  mdTermLine namesWidth (hq, _r, otype, mddiff) = do
-    n <- num
+  mdTermLine :: Path.Absolute -> Int -> OBD.TermDisplay v a -> Numbered (Pretty, Pretty)
+  mdTermLine p namesWidth (hq, r, otype, mddiff) = do
+    n <- numHQ p hq r
     fmap ((n,) . P.linesNonEmpty) . sequence $
       [ pure $ P.rightPad namesWidth (phq' hq) <> " : " <> prettyType otype
       , P.indentN leftNumsWidth <$> prettyMetadataDiff mddiff ]
@@ -1441,12 +1456,12 @@ showDiffNamespace ppe d@OBD.BranchDiffOutput{..} =
   prettyUpdateTerm :: OBD.UpdateTermDisplay v a -> Numbered Pretty
   prettyUpdateTerm (Nothing, newTerms) =
     if null newTerms then error "Super invalid UpdateTermDisplay" else
-    fmap P.column2 $ traverse (mdTermLine namesWidth) newTerms
+    fmap P.column2 $ traverse (mdTermLine newPath namesWidth) newTerms
     where namesWidth = foldl1' max $ fmap (HQ'.nameLength . view _1) newTerms
   prettyUpdateTerm (Just olds, news) =
     fmap P.column2 $ do
-      olds <- traverse (mdTermLine namesWidth) [ (name,r,typ,mempty) | (name,r,typ) <- olds ]
-      news <- traverse (mdTermLine namesWidth) news
+      olds <- traverse (mdTermLine oldPath namesWidth) [ (name,r,typ,mempty) | (name,r,typ) <- olds ]
+      news <- traverse (mdTermLine newPath namesWidth) news
       let (oldnums, olddatas) = unzip olds
       let (newnums, newdatas) = unzip news
       pure $ zip (oldnums <> [""] <> newnums)
@@ -1456,11 +1471,11 @@ showDiffNamespace ppe d@OBD.BranchDiffOutput{..} =
 
   prettyMetadataDiff :: OBD.MetadataDiff (OBD.MetadataDisplay v a) -> Numbered Pretty
   prettyMetadataDiff OBD.MetadataDiff{..} = P.column2M $
-    map (elem " - ") removedMetadata <>
-    map (elem " + ") addedMetadata
+    map (elem oldPath " - ") removedMetadata <>
+    map (elem newPath " + ") addedMetadata
     where
-    elem x (hq, _r, otype) = do
-      num <- num
+    elem p x (hq, r, otype) = do
+      num <- numHQ p hq r
       pure (x <> num <> phq' hq, " : " <> prettyType otype)
 
   prettyType = maybe (P.red "type not found") (TypePrinter.pretty ppe)
@@ -1470,11 +1485,19 @@ showDiffNamespace ppe d@OBD.BranchDiffOutput{..} =
   phq' :: _ -> Pretty = P.syntaxToColor . prettyHashQualified'
   --
   -- DeclPrinter.prettyDeclHeader : HQ -> Either
-  num :: Numbered Pretty
-  num = do
-    n <- State.get
-    State.put (n+1)
+  numPatch :: Name -> Numbered Pretty
+  numPatch name = do
+    (n, args) <- State.get
+    State.put (n+1, args Seq.|> Name.toString name)
     pure $ padNumber n
+
+  numHQ :: Path.Absolute -> HQ'.HashQualified -> Referent -> Numbered Pretty
+  numHQ path hq r = do
+    (n,args) <- State.get
+    State.put (n+1, args Seq.|> HQ'.toString hq')
+    pure $ padNumber n
+    where
+    hq' = HQ'.requalify (fmap (Path.prefixName path) hq) r
 
   padNumber :: Int -> Pretty
   padNumber n = P.hiBlack . P.rightPad leftNumsWidth $ P.shown n <> ". "


### PR DESCRIPTION
This PR adds a `NotifyNumbered` `Command`, which expects the output layer to produce `numberedArgs`, and updates the implementation of `OutputMessages.showDiffNamespace` to use it.

Prior to this, I tried:
* Computing `numberedArgs` independently [in `HandleInput.hs`](https://github.com/unisonweb/unison/blob/diff.namespace/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs#L2370-L2413).  It wasn't correct, and although it could be corrected, it would be a nightmare to maintain IMO.
* Changing the original `Command.Notify` to produce `numberedArgs` for all `Output`s, but it introduced way too much noise for the cases that don't need it.

Self-review is attached; I tried to have it make sense if read in the order presented on the "Files changed" tab.