### PR TITLE
Add NEW_NAME env switch for constructing new names

### DIFF
--- a/unison-core/src/Unison/Name.hs
+++ b/unison-core/src/Unison/Name.hs
@@ -46,6 +46,8 @@ import           Data.List.Extra                ( dropEnd )
 import           Data.List.NonEmpty             ( NonEmpty((:|)) )
 import qualified Data.List.NonEmpty            as NonEmpty
 import qualified Data.Text                     as Text
+import           System.IO.Unsafe               ( unsafePerformIO )
+import           System.Environment             ( lookupEnv )
 import           Unison.Codebase.NameSegment    ( NameSegment )
 import qualified Unison.Codebase.NameSegment   as NameSegment
 import qualified Unison.Hashable               as H
@@ -53,6 +55,11 @@ import           Unison.Var                     ( Var )
 import qualified Unison.Var                    as Var
 import qualified Data.RFC5051                  as RFC5051
 import           Data.List                      ( sortBy, tails )
+
+-- | Use the new name when constructing names?
+useNewName :: Bool
+useNewName = unsafePerformIO (isJust <$> lookupEnv "NEW_NAME")
+{-# NOINLINE useNewName #-}
 
 data Name
   = Name Text
@@ -75,7 +82,11 @@ toText (Name' placement names) =
         Relative -> id
 
 fromNameSegment :: NameSegment -> Name
-fromNameSegment = unsafeFromText . NameSegment.toText
+fromNameSegment =
+  if useNewName then
+    undefined
+  else
+    unsafeFromText . NameSegment.toText
 
 sortNamed :: (a -> Name) -> [a] -> [a]
 sortNamed by as = let
@@ -93,7 +104,10 @@ sortNamed' by by2 as = let
 
 unsafeFromText :: Text -> Name
 unsafeFromText t =
-  if Text.any (== '#') t then error $ "not a name: " <> show t else Name t
+  if useNewName then
+    undefined
+  else
+    if Text.any (== '#') t then error $ "not a name: " <> show t else Name t
 
 toVar :: Var v => Name -> v
 toVar (Name t) = Var.named t


### PR DESCRIPTION
This patch adds a switch on the existence of a `NEW_NAME` env var for constructing new names (`Name'`) instead of old names (`Name`) in functions like `Name.unsafeFromText`.