### PR TITLE
Adds punctuation to error messages

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -35,3 +35,4 @@ The format for this list: name, GitHub handle, and then optional blurb about wha
 * Alvaro Carrasco (@alvaroc1)
 * Vladislav Zavialov (@int-index)
 * Aaron Novstrup (@anovstrup)
+* Pete Tsamouris (@pete-ts)

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -131,13 +131,13 @@ initCodebase dir = do
          .  P.warnCallout
          .  P.wrap
          $  "It looks like there's already a codebase in: "
-         <> P.string dir
+         <> P.endSentence dir
        exitFailure
   PT.putPrettyLn'
     .  P.warnCallout
     .  P.wrap
     $  "Initializing a new codebase in: "
-    <> P.string dir
+    <> P.endSentence dir
   initialize path
   Codebase.initializeCodebase theCodebase
   pure theCodebase
@@ -149,14 +149,14 @@ getCodebaseOrExit mdir = do
     Just dir -> pure
       ( dir
       , "No codebase exists in "
-          <> P.string dir
+          <> P.endSentence dir
           <> P.newline
           <> "Run `ucm -codebase "
           <> P.string dir
           <> " init` to create one, then try again!" )
     Nothing -> do
       dir <- getHomeDirectory
-      let errMsg = P.lines [ "No codebase exists in " <> P.string dir
+      let errMsg = P.lines [ "No codebase exists in " <> P.endSentence dir
                            , "Run `ucm init` to create one, then try again!" ]
       pure (dir, errMsg)
 

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -126,18 +126,19 @@ initCodebase :: FilePath -> IO (Codebase IO Symbol Ann)
 initCodebase dir = do
   let path = dir </> codebasePath
   let theCodebase = codebase1 V1.formatSymbol formatAnn path
+  let prettyDir = P.endSentence . P.string $ dir
   whenM (exists path) $
     do PT.putPrettyLn'
          .  P.warnCallout
          .  P.wrap
          $  "It looks like there's already a codebase in: "
-         <> P.endSentence dir
+         <> prettyDir
        exitFailure
   PT.putPrettyLn'
     .  P.warnCallout
     .  P.wrap
     $  "Initializing a new codebase in: "
-    <> P.endSentence dir
+    <> prettyDir
   initialize path
   Codebase.initializeCodebase theCodebase
   pure theCodebase
@@ -149,14 +150,14 @@ getCodebaseOrExit mdir = do
     Just dir -> pure
       ( dir
       , "No codebase exists in "
-          <> P.endSentence dir
+          <> (P.endSentence . P.string $ dir)
           <> P.newline
           <> "Run `ucm -codebase "
           <> P.string dir
           <> " init` to create one, then try again!" )
     Nothing -> do
       dir <- getHomeDirectory
-      let errMsg = P.lines [ "No codebase exists in " <> P.endSentence dir
+      let errMsg = P.lines [ "No codebase exists in " <> (P.endSentence . P.string $ dir)
                            , "Run `ucm init` to create one, then try again!" ]
       pure (dir, errMsg)
 

--- a/parser-typechecker/src/Unison/Util/Pretty.hs
+++ b/parser-typechecker/src/Unison/Util/Pretty.hs
@@ -449,8 +449,8 @@ num n = fromString (show n)
 string :: IsString s => String -> Pretty s
 string = fromString
 
-endSentence :: IsString s => String -> Pretty s
-endSentence p = group (fromString p <> ".")
+endSentence :: IsString s => Pretty s -> Pretty s
+endSentence p = group (p <> ".")
 
 shown :: (Show a, IsString s) => a -> Pretty s
 shown = fromString . show

--- a/parser-typechecker/src/Unison/Util/Pretty.hs
+++ b/parser-typechecker/src/Unison/Util/Pretty.hs
@@ -450,7 +450,7 @@ string :: IsString s => String -> Pretty s
 string = fromString
 
 endSentence :: IsString s => String -> Pretty s
-endSentence str = fromString (str ++ ".")
+endSentence p = group (fromString p <> ".")
 
 shown :: (Show a, IsString s) => a -> Pretty s
 shown = fromString . show

--- a/parser-typechecker/src/Unison/Util/Pretty.hs
+++ b/parser-typechecker/src/Unison/Util/Pretty.hs
@@ -72,6 +72,7 @@ module Unison.Util.Pretty (
    spacedMap,
    spacesIfBreak,
    string,
+   endSentence,
    surroundCommas,
    syntaxToColor,
    text,
@@ -447,6 +448,9 @@ num n = fromString (show n)
 
 string :: IsString s => String -> Pretty s
 string = fromString
+
+endSentence :: IsString s => String -> Pretty s
+endSentence str = fromString (str ++ ".")
 
 shown :: (Show a, IsString s) => a -> Pretty s
 shown = fromString . show


### PR DESCRIPTION
There was no fullstop added after the first sentence in these cases:
- running `ucm` with no codebase initialised in $HOME
- running `ucm -codebase x` with no codebase initialised in "x"
- running `ucm init` a second time