### PR TITLE
Show aliases when searching by type

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1567,8 +1567,14 @@ _searchBranchPrefix b n = case Path.unsnoc (Path.fromName n) of
 
 searchResultsFor :: Names0 -> [Referent] -> [Reference] -> [SearchResult]
 searchResultsFor ns terms types =
-  [ SR.termSearchResult ns (Names.termName ns ref) ref | ref <- terms ] <>
-  [ SR.typeSearchResult ns (Names.typeName ns ref) ref | ref <- types ]
+  [ SR.termSearchResult ns name ref
+  | ref <- terms
+  , name <- toList (Names.namesForReferent ns ref)
+  ] <>
+  [ SR.typeSearchResult ns name ref
+  | ref <- types
+  , name <- toList (Names.namesForReference ns ref)
+  ]
 
 searchBranchScored :: forall score. (Ord score)
               => Names0

--- a/unison-core/src/Unison/Names2.hs
+++ b/unison-core/src/Unison/Names2.hs
@@ -27,8 +27,6 @@ module Unison.Names2
   , prefix0
   , restrictReferences
   , refTermsNamed
-  , termName
-  , typeName
   , terms
   , types
   , termReferences
@@ -39,6 +37,7 @@ module Unison.Names2
   , unionLeft
   , unionLeftName
   , namesForReference
+  , namesForReferent
   )
 where
 
@@ -174,20 +173,6 @@ numHashChars b = lenFor hashes
         hashes = foldl' f (foldl' g mempty (R.ran $ types b)) (R.ran $ terms b)
         g s r = Set.insert r s
         f s r = Set.insert (Referent.toReference r) s
-
-typeName :: Ord n => Names' n -> Reference -> n
-typeName names r =
-  case toList $ R.lookupRan r (types names) of
-    hq : _ -> hq
-    _ -> error
-      ("Names construction should have included something for " <> show r)
-
-termName :: Ord n => Names' n -> Referent -> n
-termName names r =
-  case toList $ R.lookupRan r (terms names) of
-    hq : _ -> hq
-    _ -> error
-      ("Names construction should have included something for " <> show r)
 
 termsNamed :: Ord n => Names' n -> n -> Set Referent
 termsNamed = flip R.lookupDom . terms


### PR DESCRIPTION
This patch makes `find :` work like it suggests it should in a comment - by showing aliases on separate lines.

<img width="1251" alt="Screen Shot 2020-01-05 at 4 44 26 PM" src="https://user-images.githubusercontent.com/1074598/71786571-af618000-2fda-11ea-8147-e14e3a4be18d.png">
