### PR TITLE
Move unionWithM to Unison.Util.Map

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -46,6 +46,7 @@ import           Unison.Referent                ( Referent )
 import qualified Unison.Referent              as Referent
 import qualified Unison.Reference              as Reference
 
+import           Unison.Util.Map                ( unionWithM )
 import qualified Unison.Util.Relation         as R
 import           Unison.Util.Relation           ( Relation )
 import qualified Unison.Util.Star3             as Star3
@@ -268,14 +269,6 @@ merge0 b1 b2 = do
     e2 <- m2
     let e3 = e1 <> e2
     pure (H.accumulate' e3, pure e3)
-
-unionWithM :: forall m k a.
-  (Monad m, Ord k) => (a -> a -> m a) -> Map k a -> Map k a -> m (Map k a)
-unionWithM f m1 m2 = Monad.foldM go m1 $ Map.toList m2 where
-  go :: Map k a -> (k, a) -> m (Map k a)
-  go m1 (k, a2) = case Map.lookup k m1 of
-    Just a1 -> do a <- f a1 a2; pure $ Map.insert k a m1
-    Nothing -> pure $ Map.insert k a2 m1
 
 pattern Hash h = Causal.RawHash h
 

--- a/parser-typechecker/src/Unison/Util/Map.hs
+++ b/parser-typechecker/src/Unison/Util/Map.hs
@@ -1,0 +1,16 @@
+module Unison.Util.Map
+  ( unionWithM
+  ) where
+
+import qualified Control.Monad as Monad
+import qualified Data.Map as Map
+
+import Unison.Prelude
+
+unionWithM :: forall m k a.
+  (Monad m, Ord k) => (a -> a -> m a) -> Map k a -> Map k a -> m (Map k a)
+unionWithM f m1 m2 = Monad.foldM go m1 $ Map.toList m2 where
+  go :: Map k a -> (k, a) -> m (Map k a)
+  go m1 (k, a2) = case Map.lookup k m1 of
+    Just a1 -> do a <- f a1 a2; pure $ Map.insert k a m1
+    Nothing -> pure $ Map.insert k a2 m1

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -121,6 +121,7 @@ library
     Unison.Util.Find
     Unison.Util.Less
     Unison.Util.Logger
+    Unison.Util.Map
     Unison.Util.Menu
     Unison.Util.Pretty
     Unison.Util.Range


### PR DESCRIPTION
This patch just moves `unionWithM` from `Unison.Codebase.Branch` to `Unison.Util.Map`