### PR TITLE
add catalog of Unison libraries in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,12 @@ In the `parser-typechecker/` project:
 * `Unison.Term` and `Unison.Type` have the syntax trees for terms and types. In both `Term` and `Type`, the same pattern is used. Each defines a 'base functor' type, `F a`, which is nonrecursive, and the actual thing we use is an _abstract binding tree_ over this base functor, an `ABT F`. `ABT` (for 'abstract binding tree') is defined in `Unison.ABT`. If you aren't familiar with abstract binding trees, [here is a nice blog post explaining one formulation of the idea](http://semantic-domain.blogspot.com/2015/03/abstract-binding-trees.html), which inspired the `Unison.ABT` module. A lot of operations on terms and types just delegate to generic `ABT` operations.
 * `Unison.Parsers` has the main entry point for the parser.
 * `Unison.Typechecker.Context` is the implementation of the typechecker, and `Unison.Typechecker` has the "public interface to the typechecker" and some convenience functions. There isn't a lot of code here (about 700 LOC presently), since the typechecking algorithm is pretty simple. Unlike a unification-based typechecker, where the typechecking state is an unordered bag of unification constraints and higher-rank polymorphism is usually bolted on awkwardly later, [Dunfield and Krishnaswami's algorithm](http://www.mpi-sws.org/~neelk/bidir.pdf) keeps the typechecking state as a nicely tidy _ordered context_, represented as a regular list manipulated in a stack-like fashion, and the algorithm handles higher-rank polymorphism very cleanly. They've also [extended this work to include features like GADTs](http://semantic-domain.blogspot.com/2015/03/new-draft-sound-and-complete.html), though this new algorithm hasn't been incorporated into Unison yet.
+
+Unison libraries under development
+-----
+
+Unison is currently in public alpha and not quite ready for production use. Nonetheless, some awesome community members are hard at work building the ecosystem's first libraries! Here are some of the ongoing projects that we're aware of:
+
+* unison-parsers -- https://github.com/zenhack/unison-parsers -- a parser combinator library
+
+Note: if you're currently working on a Unison library and would like it added to this list, we'd love to hear about it! Please submit a pull request, adding your project to this list in the README.md file.


### PR DESCRIPTION
This patch adds a section to the project's README.md for cataloging Unison libraries under development and is intended as a quick, short-term solution.

Long-term, it may be better to store the catalog in a web-accessible database, as [suggested by @theduke](https://unisonlanguage.slack.com/archives/CLKV43YE4/p1578682688029300?thread_ts=1578682456.026500&cid=CLKV43YE4). The database could be as simple as a github repo containing a json "database", like [Nim's package database](https://github.com/nim-lang/packages). A simple web client, similar to Nim's [nimble.directory](https://nimble.directory/) package viewer, would make it possible to view/browse the database in a developer-friendly way.

A more Unison-y long-term solution would be to store the package database as a value in a Unison codebase [as exemplified here](https://github.com/anovstrup/unison-packages) or in a typed, distributed data store (once such a Unison-native capability has been developed).