### PR TITLE
clear cached typechecked file on parsing/typechecking error

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -224,6 +224,8 @@ loop = do
             _         -> Nothing
           hqs = Set.fromList . mapMaybe (getHQ . L.payload) $ tokens
         parseNames :: Names <- makeHistoricalParsingNames hqs
+        latestFile .= Just (Text.unpack sourceName, False)
+        latestTypecheckedFile .= Nothing
         Result notes r <- eval $ Typecheck ambient parseNames sourceName lexed
         case r of
           -- Parsing failed
@@ -251,7 +253,6 @@ loop = do
                   go (ann, kind, _hash, _uneval, eval, isHit) = (ann, kind, eval, isHit)
               when (not $ null e') $
                 eval . Notify $ Evaluated text ppe bindings e'
-              latestFile .= Just (Text.unpack sourceName, False)
               latestTypecheckedFile .= Just unisonFile
 
   case e of

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -244,7 +244,7 @@ notifyUser dir o = case o of
       <> dir
       <> "directory. Make sure you've updated something there before using the"
       <> makeExample' IP.add <> "or" <> makeExample' IP.update
-      <> "commands."
+      <> "commands, or use" <> makeExample' IP.load <> "to load a file explicitly."
   InvalidSourceName name ->
     pure . P.callout "😶" $ P.wrap $  "The file "
                                    <> P.blue (P.shown name)


### PR DESCRIPTION
This patch clears the typecheck cache when a parsing or typechecking error occurs while processing a Unison file. When the cache is cleared, a subsequent `add` will result in the `NoUnisonFile` error message — the patch updates that message to help users to discover the `load` command, which they can use to parse/typecheck their scratch file again once they've resolved the issues that caused the failure (if that can be done without editing the file, e.g., by changing the namespace, adding an alias, etc.).