### PR TITLE
filters listed directories preventing getModificationTime from throwing

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Watch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Watch.hs
@@ -16,6 +16,7 @@ import           UnliftIO                       ( MonadUnliftIO
                                                 , unliftIO )
 import           UnliftIO.Directory             ( getModificationTime
                                                 , listDirectory
+                                                , doesPathExist
                                                 )
 import           UnliftIO.MVar                  ( newEmptyMVar, takeMVar
                                                 , tryTakeMVar, tryPutMVar, putMVar )
@@ -92,8 +93,9 @@ watchDirectory dir allow = do
     existingFiles :: MonadIO m => m [(FilePath, UTCTime)]
     existingFiles = do
       files <- listDirectory dir
+      filtered <- filterM doesPathExist files
       let withTime file = (file,) <$> getModificationTime file
-      sortOn snd <$> mapM withTime files
+      sortOn snd <$> mapM withTime filtered
     process :: MonadIO m => FilePath -> UTCTime -> m (Maybe (FilePath, Text))
     process file t =
       if allow file then let


### PR DESCRIPTION
[This comment](https://github.com/unisonweb/unison/issues/1021#issuecomment-574742378) describes the failure mechanism, or at least what I think is the cause of the failure.