### PR TITLE
`ucm transcript` default behavior deletes the codebase that the transcript runner created

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
@@ -13,6 +13,7 @@ import Control.Exception (finally)
 import Control.Monad.State (runStateT)
 import Data.IORef
 import Prelude hiding (readFile, writeFile)
+import System.Directory ( doesFileExist )
 import System.Exit (die)
 import System.IO.Error (catchIOError)
 import Unison.Codebase (Codebase)
@@ -88,8 +89,12 @@ instance Show Stanza where
 
 parseFile :: FilePath -> IO (Either Err [Stanza])
 parseFile filePath = do
-  txt <- readUtf8 filePath
-  pure $ parse filePath txt
+  exists <- doesFileExist filePath
+  if exists then do
+    txt <- readUtf8 filePath
+    pure $ parse filePath txt
+  else
+    pure $ Left $ show filePath ++ " does not exist"
 
 parse :: String -> Text -> Either Err [Stanza]
 parse srcName txt = case P.parse (stanzas <* P.eof) srcName txt of

--- a/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
@@ -232,9 +232,8 @@ run dir configFile stanzas codebase = do
         output "\n```\n\n"
         transcriptFailure out $ Text.unlines [
           "\128721", "",
-          "Transcript failed due to the message above.",
-          "Codebase as of the point of failure is in:", "",
-          "  " <> Text.pack dir ]
+          "Transcript failed due to the message above.", "",
+          "Run `ucm -codebase" <> Text.pack dir <> "` " <> "to do more work with it."]
 
       loop state = do
         writeIORef pathRef (HandleInput._currentPath state)

--- a/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
@@ -233,7 +233,7 @@ run dir configFile stanzas codebase = do
         transcriptFailure out $ Text.unlines [
           "\128721", "",
           "Transcript failed due to the message above.", "",
-          "Run `ucm -codebase" <> Text.pack dir <> "` " <> "to do more work with it."]
+          "Run `ucm -codebase " <> Text.pack dir <> "` " <> "to do more work with it."]
 
       loop state = do
         writeIORef pathRef (HandleInput._currentPath state)

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -54,10 +54,10 @@ usage = P.callout "🌻" $ P.lines [
         <> "Multiple transcript files may be provided; they are processed in sequence"
         <> "starting from the same codebase.",
   "",
-  P.bold "ucm transcript -preserve mytranscript.md",
+  P.bold "ucm transcript -save-codebase mytranscript.md",
   P.wrap $ "Executes the `mytranscript.md` transcript and creates"
-        <> "`mytranscript.output.md` if successful. Exits after completion, and maintains"
-        <> "the temporary directory created."
+        <> "`mytranscript.output.md` if successful. Exits after completion, and saves"
+        <> "the resulting codebase to a new directory on disk."
         <> "Multiple transcript files may be provided; they are processed in sequence"
         <> "starting from the same codebase.",
   "",
@@ -67,10 +67,10 @@ usage = P.callout "🌻" $ P.lines [
         <> "Multiple transcript files may be provided; they are processed in sequence"
         <> "starting from the same codebase.",
   "",
-  P.bold "ucm transcript.fork -preserve mytranscript.md",
+  P.bold "ucm transcript.fork -save-codebase mytranscript.md",
   P.wrap $ "Executes the `mytranscript.md` transcript in a copy of the current codebase"
         <> "and creates `mytranscript.output.md` if successful. Exits after completion,"
-        <> "and maintains the temporary directory created."  
+        <> "and saves the resulting codebase to a new directory on disk."  
         <> "Multiple transcript files may be provided; they are processed in sequence"
         <> "starting from the same codebase.",
   "",
@@ -139,12 +139,12 @@ main = do
           launch currentDir configFilePath theCodebase [Left fileEvent, Right $ Input.ExecuteI mainName, Right Input.QuitI]
     "transcript" : args' -> 
       case args' of
-      "-preserve" : transcripts -> runTranscripts False True mcodepath transcripts
-      _                         -> runTranscripts False False mcodepath args'
+      "-save-codebase" : transcripts -> runTranscripts False True mcodepath transcripts
+      _                              -> runTranscripts False False mcodepath args'
     "transcript.fork" : args' -> 
       case args' of
-      "-preserve" : transcripts -> runTranscripts True True mcodepath transcripts
-      _                         -> runTranscripts True False mcodepath args'
+      "-save-codebase" : transcripts -> runTranscripts True True mcodepath transcripts
+      _                              -> runTranscripts True False mcodepath args'
     _ -> do
       PT.putPrettyLn usage
       Exit.exitWith (Exit.ExitFailure 1)

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -188,7 +188,11 @@ runTranscripts' mcodepath transcriptDir args = do
         md | isMarkdown md -> do
           parsed <- TR.parseFile arg
           case parsed of
-            Left err -> putStrLn $ "Parse error: \n" <> show err
+            Left err ->
+              PT.putPrettyLn $ P.callout "❓" (
+                P.lines [
+                  P.indentN 2 "A parsing error occurred while reading a file:", "",
+                  P.indentN 2 $ P.string err])
             Right stanzas -> do
               configFilePath <- getConfigFilePath mcodepath
               mdOut <- TR.run currentDir configFilePath stanzas theCodebase
@@ -197,7 +201,11 @@ runTranscripts' mcodepath transcriptDir args = do
                                          (FP.takeExtension md)
               writeUtf8 out mdOut
               putStrLn $ "💾  Wrote " <> out
-        wat -> putStrLn $ "Unrecognized command, skipping: " <> wat
+        wat -> 
+              PT.putPrettyLn $ P.callout "❓" (
+                P.lines [
+                  P.indentN 2 "Unrecognized command, skipping:", "",
+                  P.indentN 2 $ P.string wat])
       pure True
     [] -> 
       pure False

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -187,7 +187,7 @@ runTranscripts' mcodepath transcriptDir args = do
                   P.indentN 2 $ P.string err])
             Right stanzas -> do
               configFilePath <- getConfigFilePath mcodepath
-              mdOut <- TR.run currentDir configFilePath stanzas theCodebase
+              mdOut <- TR.run transcriptDir configFilePath stanzas theCodebase
               let out = currentDir FP.</>
                          FP.addExtension (FP.dropExtension arg ++ ".output")
                                          (FP.takeExtension md)

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -170,14 +170,6 @@ prepareTranscriptDir inFork mcodepath = do
 
   pure tmp
 
-cleanup :: FilePath -> IO ()
-cleanup transcriptDir = do
-  PT.putPrettyLn $ P.lines [
-    P.wrap "Deleting temporary directory: ", "",
-    P.indentN 2 (P.string transcriptDir)
-    ]
-  removeDirectoryRecursive transcriptDir
-
 runTranscripts' :: Maybe FilePath -> FilePath -> [String] -> IO Bool
 runTranscripts' mcodepath transcriptDir args = do
   currentDir <- getCurrentDirectory
@@ -215,7 +207,7 @@ runTranscripts inFork keepTemp mcodepath args = do
   transcriptDir <- prepareTranscriptDir inFork mcodepath
   completed <- runTranscripts' mcodepath transcriptDir args
   when completed $ do
-    unless keepTemp $ cleanup transcriptDir
+    unless keepTemp $ removeDirectoryRecursive transcriptDir
     when keepTemp $ PT.putPrettyLn $
         P.callout "🌸" (
           P.lines [
@@ -226,7 +218,7 @@ runTranscripts inFork keepTemp mcodepath args = do
                   <> "to do more work with it."])
 
   unless completed $ do 
-      unless keepTemp $ cleanup transcriptDir
+      unless keepTemp $ removeDirectoryRecursive transcriptDir
       PT.putPrettyLn usage
       Exit.exitWith (Exit.ExitFailure 1)
 

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -7,7 +7,7 @@ module Main where
 import Unison.Prelude
 import           Control.Concurrent             ( mkWeakThreadId, myThreadId )
 import           Control.Exception              ( throwTo, AsyncException(UserInterrupt) )
-import           System.Directory               ( getCurrentDirectory, getHomeDirectory )
+import           System.Directory               ( getCurrentDirectory, removeDirectoryRecursive )
 import           System.Environment             ( getArgs )
 import           System.Mem.Weak                ( deRefWeak )
 import           Unison.Codebase.Execute        ( execute )
@@ -49,13 +49,28 @@ usage = P.callout "🌻" $ P.lines [
   "",
   P.bold "ucm transcript mytranscript.md",
   P.wrap $ "Executes the `mytranscript.md` transcript and creates"
-        <> "`mytranscript.output.md` if successful. Exits after completion."
+        <> "`mytranscript.output.md` if successful. Exits after completion, and deletes"
+        <> "the temporary directory created."
+        <> "Multiple transcript files may be provided; they are processed in sequence"
+        <> "starting from the same codebase.",
+  "",
+  P.bold "ucm transcript -preserve mytranscript.md",
+  P.wrap $ "Executes the `mytranscript.md` transcript and creates"
+        <> "`mytranscript.output.md` if successful. Exits after completion, and maintains"
+        <> "the temporary directory created."
         <> "Multiple transcript files may be provided; they are processed in sequence"
         <> "starting from the same codebase.",
   "",
   P.bold "ucm transcript.fork mytranscript.md",
   P.wrap $ "Executes the `mytranscript.md` transcript in a copy of the current codebase"
         <> "and creates `mytranscript.output.md` if successful. Exits after completion."
+        <> "Multiple transcript files may be provided; they are processed in sequence"
+        <> "starting from the same codebase.",
+  "",
+  P.bold "ucm transcript.fork -preserve mytranscript.md",
+  P.wrap $ "Executes the `mytranscript.md` transcript in a copy of the current codebase"
+        <> "and creates `mytranscript.output.md` if successful. Exits after completion,"
+        <> "and maintains the temporary directory created."  
         <> "Multiple transcript files may be provided; they are processed in sequence"
         <> "starting from the same codebase.",
   "",
@@ -122,32 +137,50 @@ main = do
           theCodebase <- FileCodebase.getCodebaseOrExit mcodepath
           let fileEvent = Input.UnisonFileChanged (Text.pack "<standard input>") contents
           launch currentDir configFilePath theCodebase [Left fileEvent, Right $ Input.ExecuteI mainName, Right Input.QuitI]
-    "transcript" : args -> runTranscripts False mcodepath args
-    "transcript.fork" : args -> runTranscripts True mcodepath args
+    "transcript" : args' -> 
+      case args' of
+      "-preserve" : transcripts -> runTranscripts False True mcodepath transcripts
+      _                         -> runTranscripts False False mcodepath args'
+    "transcript.fork" : args' -> 
+      case args' of
+      "-preserve" : transcripts -> runTranscripts True True mcodepath transcripts
+      _                         -> runTranscripts True False mcodepath args'
     _ -> do
       PT.putPrettyLn usage
       Exit.exitWith (Exit.ExitFailure 1)
 
-runTranscripts :: Bool -> Maybe FilePath -> [String] -> IO ()
-runTranscripts inFork mcodepath args = do
+prepareTranscriptDir :: Bool -> Maybe FilePath -> IO FilePath
+prepareTranscriptDir inFork mcodepath = do
   currentDir <- getCurrentDirectory
-  transcriptDir <- do
-    tmp <- Temp.createTempDirectory currentDir "transcript"
-    when (not inFork) $ do
-      PT.putPrettyLn . P.wrap $ "Transcript will be run on a new, empty codebase."
-      _ <- FileCodebase.initCodebase tmp
-      pure ()
-    when inFork $ FileCodebase.getCodebaseOrExit mcodepath >> do
-      origCodePath <- case mcodepath of
-        Just codepath -> pure codepath
-        Nothing       -> getHomeDirectory
-      let path = (origCodePath FP.</> FileCodebase.codebasePath)
-      PT.putPrettyLn $ P.lines [
-        P.wrap "Transcript will be run on a copy of the codebase at: ", "",
-        P.indentN 2 (P.string path)
-        ]
-      Path.copyDir path (tmp FP.</> FileCodebase.codebasePath)
-    pure tmp
+  tmp <- Temp.createTempDirectory currentDir "transcript"
+
+  unless inFork $ do 
+    PT.putPrettyLn . P.wrap $ "Transcript will be run on a new, empty codebase."
+    _ <- FileCodebase.initCodebase tmp
+    pure()
+
+  when inFork $ FileCodebase.getCodebaseOrExit mcodepath >> do
+    origCodePath <- FileCodebase.getCodebaseDir mcodepath
+    let path = origCodePath FP.</> FileCodebase.codebasePath
+    PT.putPrettyLn $ P.lines [
+      P.wrap "Transcript will be run on a copy of the codebase at: ", "",
+      P.indentN 2 (P.string path)
+      ]
+    Path.copyDir path (tmp FP.</> FileCodebase.codebasePath)
+
+  pure tmp
+
+cleanup :: FilePath -> IO ()
+cleanup transcriptDir = do
+  PT.putPrettyLn $ P.lines [
+    P.wrap "Deleting temporary directory: ", "",
+    P.indentN 2 (P.string transcriptDir)
+    ]
+  removeDirectoryRecursive transcriptDir
+
+runTranscripts' :: Maybe FilePath -> FilePath -> [String] -> IO Bool
+runTranscripts' mcodepath transcriptDir args = do
+  currentDir <- getCurrentDirectory
   theCodebase <- FileCodebase.getCodebaseOrExit $ Just transcriptDir
   case args of
     args@(_:_) -> do
@@ -165,7 +198,17 @@ runTranscripts inFork mcodepath args = do
               writeUtf8 out mdOut
               putStrLn $ "💾  Wrote " <> out
         wat -> putStrLn $ "Unrecognized command, skipping: " <> wat
-      PT.putPrettyLn $
+      pure True
+    [] -> 
+      pure False
+
+runTranscripts :: Bool -> Bool -> Maybe FilePath -> [String] -> IO ()
+runTranscripts inFork keepTemp mcodepath args = do
+  transcriptDir <- prepareTranscriptDir inFork mcodepath
+  completed <- runTranscripts' mcodepath transcriptDir args
+  when completed $ do
+    unless keepTemp $ cleanup transcriptDir
+    when keepTemp $ PT.putPrettyLn $
         P.callout "🌸" (
           P.lines [
             "I've finished running the transcript(s) in this codebase:", "",
@@ -173,7 +216,9 @@ runTranscripts inFork mcodepath args = do
             P.wrap $ "You can run"
                   <> P.backticked ("ucm -codebase " <> P.string transcriptDir)
                   <> "to do more work with it."])
-    [] -> do
+
+  unless completed $ do 
+      unless keepTemp $ cleanup transcriptDir
       PT.putPrettyLn usage
       Exit.exitWith (Exit.ExitFailure 1)
 


### PR DESCRIPTION
[#975](https://github.com/unisonweb/unison/issues/975)

Running `ucm -transcript` or `ucm -transcript.fork` will cleanup the temporary `transcript-hash` directory used for running the transcript in the following circumstances:
1. transcript exists successfully
2. transcript file does not exist
3. command not recognised.

The change does not affect transcripts that fail inside the call to the `TranscriptParser.run` method.