### PR TITLE
updates missed error message

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
@@ -171,8 +171,7 @@ run dir configFile stanzas codebase = do
               transcriptFailure out $ Text.unlines [
                 "\128721", "",
                 "Transcript failed due to an unexpected success above.",
-                "Codebase as of the point of failure is in:", "",
-                "  " <> Text.pack dir ]
+                "Run `ucm -codebase " <> Text.pack dir <> "` " <> "to do more work with it."]
             writeIORef hidden False
             writeIORef allowErrors False
             maybeStanza <- atomically (Q.tryDequeue inputQueue)


### PR DESCRIPTION
My previous PR missed this error message, produced when an expected failure in a `ucm` block does not materialize.

Original
```
🛑

Transcript failed due to an unexpected success above.
Codebase as of the point of failure is in:

  /...dir.../test
```

After fix
```
🛑

Transcript failed due to an unexpected success above.
Run `ucm -codebase /...dir.../test/transcript-033bae54b2e460b1` to do more work with it.
```