### PR TITLE
Use namespace diff in link output

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -580,8 +580,8 @@ loop = do
                     (Branch.toNames0 b)
                 diff = Names3.diff0 deletedNames mempty
             diffHelper b Branch.empty0 >>=
-              respondNumbered 
-                . uncurry (ShowDiffAfterDeleteBranch 
+              respondNumbered
+                . uncurry (ShowDiffAfterDeleteBranch
                             $ resolveToAbsolute (Path.unsplit' p))
           else do
             failed <- loadSearchResults $ SR.fromNames failed
@@ -698,7 +698,6 @@ loop = do
       LinkI src mdValue -> do
         let srcle = toList (getHQ'Terms src)
             srclt = toList (getHQ'Types src)
-            (parent, _last) = resolveSplit' src
             mdValuel = toList (getHQ'Terms mdValue)
         case (srcle, srclt, mdValuel) of
           (srcle, srclt, [Referent.Ref mdValue])
@@ -707,8 +706,13 @@ loop = do
               case mdType of
                 Nothing -> respond $ LinkFailure input
                 Just ty -> do
-                  stepAt (parent, step (Type.toReference ty))
-                  success
+                  let parent = Path.toAbsolutePath currentPath' (fst src)
+                  let get = Branch.head <$> getAt parent
+                  before <- get
+                  stepAt (Path.unabsolute parent, step (Type.toReference ty))
+                  after <- get
+                  (ppe, outputDiff) <- diffHelper before after
+                  respondNumbered $ ShowDiffNamespace parent parent ppe outputDiff
                 where
                 step mdType b0 = let
                   tmUpdates terms = foldl' go terms srcle where

--- a/unison-src/transcripts/diff.output.md
+++ b/unison-src/transcripts/diff.output.md
@@ -119,7 +119,13 @@ ability X a1 a2 where x : Nat
 
 .ns1> link fromJust b
 
-  Done.
+  Updates:
+  
+    1. fromJust : Nat
+       + 2. b : Nat
+    
+    3. fromJust' : Nat
+       + 4. b : Nat
 
 .ns1> fork .ns1 .ns2
 
@@ -304,11 +310,17 @@ unique type Y a b = Y a b
 
 .> link ns2.f ns1.c
 
-  Done.
+  Updates:
+  
+    1. f : Nat
+       + 2. c : Nat
 
 .> link ns2.c ns2.c
 
-  Done.
+  Updates:
+  
+    1. c : Nat
+       + 2. c : Nat
 
 .> diff.namespace ns1 ns2
 

--- a/unison-src/transcripts/docs.output.md
+++ b/unison-src/transcripts/docs.output.md
@@ -131,7 +131,10 @@ Let's add it to the codebase, and link it to the definition:
 
 .> link builtin.List.take docs.List.take
 
-  Done.
+  Updates:
+  
+    1. take : Nat -> [a] -> [a]
+       + 2. docs.List.take : Doc
 
 ```
 Now that documentation is linked to the definition. We can view it if we like:


### PR DESCRIPTION
Here's a screenshot of linking, then undoing (previously `link` would just say `Done.`):

<img width="427" alt="Screen Shot 2020-01-20 at 2 29 27 PM" src="https://user-images.githubusercontent.com/1074598/72752852-4f013f80-3b91-11ea-8d11-08de59c7cc2d.png">

I'm a bit confused by the output... note that `contains` is called `lib.contains` when the link is undone. 🤷‍♂ 