### PR TITLE
follow-up revisions for handle-with syntax

### DIFF
--- a/editor-support/atom/language-unison/grammars/unison.cson
+++ b/editor-support/atom/language-unison/grammars/unison.cson
@@ -45,7 +45,7 @@ repository:
     captures:
       2: {name: 'keyword.control.case.unison'}
   unsorted_keywords:
-    match: '(\\s|^)(let|alias|handle|in|namespace|type|ability|where)(?=\\s|$)'
+    match: '(\\s|^)(let|alias|handle|with|namespace|type|ability|where)(?=\\s|$)'
     captures:
       2: {name: 'keyword.control.unison'}
 

--- a/editor-support/vim/syntax/unison.vim
+++ b/editor-support/vim/syntax/unison.vim
@@ -66,7 +66,7 @@ syn match uModule		"\<module\>"
 syn match uImport		"\<use\>"
 syn match uInfix		"\<\(infix\|infixl\|infixr\)\>"
 syn match uTypedef		"\<\(∀\|forall\)\>"
-syn match uStatement		"\<\(unique\|ability\|type\|where\|case\|of\|;\|let\|in\|handle\)\>"
+syn match uStatement		"\<\(unique\|ability\|type\|where\|case\|of\|;\|let\|with\|handle\)\>"
 syn match uConditional		"\<\(if\|else\|then\)\>"
 
 " Not real keywords, but close.

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -121,7 +121,7 @@ data DocLiteralContext
 
      >=2
        if 0a then 0b else 0c
-       handle 2h in 2b
+       handle 0b with 0h
        case 2x of
          a | 2g -> 0b
 

--- a/parser-typechecker/tests/Unison/Test/TermPrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/TermPrinter.hs
@@ -428,6 +428,14 @@ test = scope "termprinter" . tests $
                  \    use A.Y c\n\
                  \    g c c\n\
                  \with bar"
+  , tcBreaks 20 "let\n\
+                 \  a = 2\n\
+                 \  handle baz\n\
+                 \  with\n\
+                 \    use A.X c\n\
+                 \    if foo then\n\
+                 \      f c c\n\
+                 \    else g c c"
   , tcBreaks 28 "if foo then\n\
                  \  f (x : (∀ t. Pair t t))\n\
                  \else\n\


### PR DESCRIPTION
This is a minor update that includes:
* code comment revisions to reflect the pretty-printing precedence rules that should have been included in #1159.
* syntax highlighting support for `with` keyword
* fixes for use statement emission (contributed by @atacratic)