### PR TITLE
Add ":hide:all" option for unison and ucm fences in transcripts

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
@@ -3,7 +3,7 @@
 {-# Language ViewPatterns #-}
 
 module Unison.Codebase.TranscriptParser (
-  Stanza(..), FenceType, ExpectingError, HideOutput, Err, UcmCommand(..),
+  Stanza(..), FenceType, ExpectingError, Hidden, Err, UcmCommand(..),
   run, parse, parseFile)
   where
 
@@ -45,7 +45,7 @@ import qualified Unison.Util.TQueue as Q
 import qualified Unison.Codebase.Editor.Output as Output
 
 type ExpectingError = Bool
-type HideOutput = Bool
+data Hidden = Shown | HideOutput | HideAll
 type Err = String
 type ScratchFileName = Text
 
@@ -54,8 +54,8 @@ type FenceType = Text
 data UcmCommand = UcmCommand Path.Absolute Text
 
 data Stanza
-  = Ucm HideOutput ExpectingError [UcmCommand]
-  | Unison HideOutput ExpectingError (Maybe ScratchFileName) Text
+  = Ucm Hidden ExpectingError [UcmCommand]
+  | Unison Hidden ExpectingError (Maybe ScratchFileName) Text
   | UnprocessedFence FenceType Text
   | Unfenced Text
 
@@ -119,7 +119,7 @@ run dir configFile stanzas codebase = do
     cmdQueue                 <- Q.newIO
     unisonFiles              <- newIORef Map.empty
     out                      <- newIORef mempty
-    hidden                   <- newIORef False
+    hidden                   <- newIORef Shown
     allowErrors              <- newIORef False
     hasErrors                <- newIORef False
     (config, cancelConfig)   <-
@@ -131,17 +131,26 @@ run dir configFile stanzas codebase = do
             $   validInputs
             >>= (\p -> (patternName p, p) : ((, p) <$> aliases p))
     let
-      output :: String -> IO ()
-      output msg = do
+      output' :: Bool -> String -> IO ()
+      output' inputEcho msg = do
         hide <- readIORef hidden
-        unless hide $ modifyIORef' out (\acc -> acc <> pure msg)
+        unless (hideOutput inputEcho hide) $ modifyIORef' out (\acc -> acc <> pure msg)
+
+      hideOutput :: Bool -> Hidden -> Bool
+      hideOutput inputEcho = \case
+        Shown      -> False
+        HideOutput -> True && (not inputEcho)
+        HideAll    -> True
+
+      output = output' False
+      outputEcho = output' True
 
       awaitInput = do
         cmd <- atomically (Q.tryDequeue cmdQueue)
         case cmd of
           Just Nothing -> do
             output "\n```\n" -- this ends the ucm block
-            writeIORef hidden False
+            writeIORef hidden Shown
             awaitInput
           Just (Just p@(UcmCommand path lineTxt)) -> do
             curPath <- readIORef pathRef
@@ -172,7 +181,7 @@ run dir configFile stanzas codebase = do
                 "\128721", "",
                 "Transcript failed due to an unexpected success above.",
                 "Run `ucm -codebase " <> Text.pack dir <> "` " <> "to do more work with it."]
-            writeIORef hidden False
+            writeIORef hidden Shown
             writeIORef allowErrors False
             maybeStanza <- atomically (Q.tryDequeue inputQueue)
 
@@ -192,9 +201,8 @@ run dir configFile stanzas codebase = do
                     output $ show s
                     awaitInput
                   Unison hide errOk filename txt -> do
-                    -- TODO note the order of the next two lines
-                    output $ show s
                     writeIORef hidden hide
+                    outputEcho $ show s
                     writeIORef allowErrors errOk
                     output "```ucm\n"
                     atomically . Q.enqueue cmdQueue $ Nothing
@@ -297,21 +305,21 @@ fenced = do
   fenceType <- lineToken (word "ucm" <|> word "unison" <|> lineUntilSpace)
   stanza <-
     if fenceType == "ucm" then do
-      hideOutput <- hideOutput
+      hide <- hidden
       err <- expectingError
       _ <- spaces
       cmds <- many ucmCommand
-      pure $ Ucm hideOutput err cmds
+      pure $ Ucm hide err cmds
     else if fenceType == "unison" then do
       -- todo: this has to be more interesting
       -- ```unison:hide
       -- ```unison
-      -- ```unison:hide scratch.u
-      hideOutput <- lineToken hideOutput
+      -- ```unison:hide:all scratch.u
+      hide <- lineToken hidden
       err <- lineToken expectingError
       fileName <- optional untilSpace1
       blob <- spaces *> untilFence
-      pure $ Unison hideOutput err fileName blob
+      pure $ Unison hide err fileName blob
     else UnprocessedFence fenceType <$> untilFence
   fence
   pure stanza
@@ -362,8 +370,10 @@ lineToken p = p <* nonNewlineSpaces
 nonNewlineSpaces :: P ()
 nonNewlineSpaces = void $ P.takeWhileP Nothing (\ch -> ch `elem` (" \t" :: String))
 
-hideOutput :: P HideOutput
-hideOutput = isJust <$> optional (word ":hide")
+hidden :: P Hidden
+hidden = (\case Just x -> x; Nothing -> Shown) <$> optional go where
+  go = ((\_ -> HideAll) <$> (word ":hide:all")) <|>
+       ((\_ -> HideOutput) <$> (word ":hide"))
 
 expectingError :: P ExpectingError
 expectingError = isJust <$> optional (word ":error")

--- a/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
@@ -192,6 +192,7 @@ run dir configFile stanzas codebase = do
                     output $ show s
                     awaitInput
                   Unison hide errOk filename txt -> do
+                    -- TODO note the order of the next two lines
                     output $ show s
                     writeIORef hidden hide
                     writeIORef allowErrors errOk
@@ -225,13 +226,13 @@ run dir configFile stanzas codebase = do
         when (Output.isFailure o) $
           if errOk then writeIORef hasErrors True
           else die
-          
+
       printNumbered o = do
         let (msg, numberedArgs) = notifyNumbered o
         errOk <- readIORef allowErrors
         let rendered = P.toPlain 65 (P.border 2 msg)
         output rendered
-        when (Output.isNumberedFailure o) $ 
+        when (Output.isNumberedFailure o) $
           if errOk then writeIORef hasErrors True
           else die
         pure numberedArgs

--- a/unison-src/transcripts/hello.md
+++ b/unison-src/transcripts/hello.md
@@ -37,7 +37,7 @@ If `view` returned no results, the transcript would fail at this point.
 
 ## Hiding output
 
-You may not always want to view the output of typechecking and evaluaion every time, in which case, you can add `:hide` to the block. For instance:
+You may not always want to view the output of typechecking and evaluation every time, in which case, you can add `:hide` to the block. For instance:
 
 ```unison:hide
 y = 99
@@ -48,6 +48,8 @@ This works for `ucm` blocks as well.
 ```ucm:hide
 .> rename.term x answerToUltimateQuestionOfLife
 ```
+
+Adding `:hide:all` hides the block altogether, both input and output - this is useful for doing behind-the-scenes control of `ucm`'s state.
 
 ## Expecting failures
 

--- a/unison-src/transcripts/hello.md
+++ b/unison-src/transcripts/hello.md
@@ -49,7 +49,11 @@ This works for `ucm` blocks as well.
 .> rename.term x answerToUltimateQuestionOfLife
 ```
 
-Adding `:hide:all` hides the block altogether, both input and output - this is useful for doing behind-the-scenes control of `ucm`'s state.
+Doing `unison:hide:all` hides the block altogether, both input and output - this is useful for doing behind-the-scenes control of `ucm`'s state.
+
+```unison:hide:all
+> [: you won't see me :]
+```
 
 ## Expecting failures
 

--- a/unison-src/transcripts/hello.output.md
+++ b/unison-src/transcripts/hello.output.md
@@ -65,13 +65,15 @@ If `view` returned no results, the transcript would fail at this point.
 
 ## Hiding output
 
-You may not always want to view the output of typechecking and evaluaion every time, in which case, you can add `:hide` to the block. For instance:
+You may not always want to view the output of typechecking and evaluation every time, in which case, you can add `:hide` to the block. For instance:
 
 ```unison
 y = 99
 ```
 
 This works for `ucm` blocks as well.
+
+Doing `unison:hide:all` hides the block altogether, both input and output - this is useful for doing behind-the-scenes control of `ucm`'s state.
 
 ## Expecting failures
 


### PR DESCRIPTION
Add "unison:hide:all" option for fences in transcripts.

Hides not only the output, but also suppresses the echo of the input as well.  Indistinguishable from the fenced block not being there, except for any effect that fenced code has on the codebase's state.

Useful for behind-the-scenes tinkering with the codebase during a transcript - say to add supporting dependencies that aren't an important part of the story being told.

This should help me finish https://github.com/unisonweb/unisonweb-org/pull/26 (an ability tutorial).