### PR TITLE
Fix so that parens are printed around the compose operator for editing

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -36,3 +36,4 @@ The format for this list: name, GitHub handle, and then optional blurb about wha
 * Vladislav Zavialov (@int-index)
 * Aaron Novstrup (@anovstrup)
 * Pete Tsamouris (@pete-ts)
+* Ian Davidson (@bontaq)

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -641,9 +641,11 @@ isEmoji :: Char -> Bool
 isEmoji c = c >= '\x1F300' && c <= '\x1FAFF'
 
 symbolyId :: String -> Either Err (String, String)
-symbolyId r@('.':ch:_) | isSpace ch || isDelimeter ch
-                       = symbolyId0 r -- lone dot treated as an operator
-symbolyId ('.':s) = (\(s,rem) -> ('.':s,rem)) <$> symbolyId' s
+symbolyId r@('.':s)
+  | s == ""              = symbolyId0 r --
+  | isSpace (head s)     = symbolyId0 r -- lone dot treated as an operator
+  | isDelimeter (head s) = symbolyId0 r --
+  | otherwise            = (\(s, rem) -> ('.':s, rem)) <$> symbolyId' s
 symbolyId s = symbolyId' s
 
 -- Is a '.' delimited list of wordyId, with a final segment of `symbolyId0`

--- a/parser-typechecker/tests/Unison/Test/TermPrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/TermPrinter.hs
@@ -335,6 +335,7 @@ test = scope "termprinter" . tests $
                                                                              \(+) a b c = foo a b c"
   , tcBinding 50 "+" Nothing "a b -> foo a b" "a + b = foo a b"
   , tcBinding 50 "+" Nothing "a b c -> foo a b c" "(+) a b c = foo a b c"
+  , tcBinding 50 "." Nothing "f g x -> f (g x)" "(.) f g x = f (g x)"
   , tcBreaks 32 "let\n\
                  \  go acc a b =\n\
                  \    case List.at 0 a of\n\


### PR DESCRIPTION
This seems to fix https://github.com/unisonweb/unison/issues/1139 for me locally, it's outputting the proper 
```
(.) : (b ->{𝕖} c) -> (a ->{𝕖} b) -> a ->{𝕖} c
(.) f g x = f (g x)
```
when I do `edit .`  