### PR TITLE
simplify .gitignore to project-specific entries per

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,46 +1,8 @@
 # Unison
-.unison*/
 .unisonHistory
 test-output
-
-# Haskell
-dist
-cabal-dev
-*.o
-*.hi
-*.chi
-*.chs.h
-*.swp
-*.un~
-**/cache/**
-**/build/**
-tags
-ctags
-unison-src/.loaded
-**/cabal.sandbox.config
-.cabal-sandbox/**
-blockstore
-blockstore.leveldb
-target
-htags
-scala-tags
-haskell-tags
-out
+transcript-*
 
 # Stack
 .stack-work
 stack.yaml.lock
-
-# IntelliJ
-.idea
-*.iml
-
-# Misc
-*~
-.DS_Store
-.virtualenv
-.vagrant
-.bloop
-.floo
-.flooignore
-tmp/


### PR DESCRIPTION
per http://stratus3d.com/blog/2018/06/03/stop-excluding-editor-temp-files-in-gitignore/

tl;dr: If your favorite editor or tool creates temp files you don't want to version,
include them in your personal, global .gitignore, rather than in Unison's.