### PR TITLE
fix/1160

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
@@ -225,13 +225,13 @@ run dir configFile stanzas codebase = do
         when (Output.isFailure o) $
           if errOk then writeIORef hasErrors True
           else die
-          
+
       printNumbered o = do
         let (msg, numberedArgs) = notifyNumbered o
         errOk <- readIORef allowErrors
         let rendered = P.toPlain 65 (P.border 2 msg)
         output rendered
-        when (Output.isNumberedFailure o) $ 
+        when (Output.isNumberedFailure o) $
           if errOk then writeIORef hasErrors True
           else die
         pure numberedArgs
@@ -293,7 +293,7 @@ ucmCommand = do
 fenced :: P Stanza
 fenced = do
   fence
-  fenceType <- lineToken (word "ucm" <|> word "unison" <|> lineUntilSpace)
+  fenceType <- lineToken(word "ucm" <|> word "unison" <|> language)
   stanza <-
     if fenceType == "ucm" then do
       hideOutput <- hideOutput
@@ -370,8 +370,8 @@ expectingError = isJust <$> optional (word ":error")
 untilSpace1 :: P Text
 untilSpace1 = P.takeWhile1P Nothing (not . Char.isSpace)
 
-lineUntilSpace :: P Text
-lineUntilSpace = P.takeWhileP Nothing (\ch -> ch `elem` (" \t" :: String))
+language :: P Text
+language = P.takeWhileP Nothing (\ch -> Char.isDigit ch || Char.isLower ch || ch == '_' )
 
 spaces :: P ()
 spaces = void $ P.takeWhileP (Just "spaces") Char.isSpace

--- a/unison-src/transcripts/transcript-parser-commands.md
+++ b/unison-src/transcripts/transcript-parser-commands.md
@@ -1,0 +1,33 @@
+### Transcript parser operations
+
+The transcript parser is meant to parse `ucm` and `unison` blocks.
+
+```unison
+x = 1
+```
+
+```ucm
+.> add
+```
+
+```unison:hide:error
+z
+```
+
+```ucm:error
+.> delete foo
+```
+
+However handling of blocks of other languages should be supported.
+
+```python
+some python code
+```
+
+```c_cpp
+some C++ code
+```
+
+```c9search
+some cloud9 code
+```

--- a/unison-src/transcripts/transcript-parser-commands.md
+++ b/unison-src/transcripts/transcript-parser-commands.md
@@ -10,12 +10,16 @@ x = 1
 .> add
 ```
 
-```unison:hide:error
+```unison:hide:error:scratch.u
 z
 ```
 
 ```ucm:error
 .> delete foo
+```
+
+```ucm :error
+.> delete lineToken.call
 ```
 
 However handling of blocks of other languages should be supported.

--- a/unison-src/transcripts/transcript-parser-commands.output.md
+++ b/unison-src/transcripts/transcript-parser-commands.output.md
@@ -29,8 +29,13 @@ x = 1
 
 ```
 ```unison
+---
+title: :scratch.u
+---
 z
+
 ```
+
 
 ```ucm
 .> delete foo
@@ -40,22 +45,30 @@ z
   I don't know about that name.
 
 ```
-However handling of blocks of other languages should be supported.
+```ucm
+.> delete lineToken.call
+
+  ⚠️
+  
+  I don't know about that name.
 
 ```
-python
+However handling of blocks of other languages should be supported.
+
+```python
+
 some python code
 
 ```
 
-```
-c_cpp
+```c_cpp
+
 some C++ code
 
 ```
 
-```
-c9search
+```c9search
+
 some cloud9 code
 
 ```

--- a/unison-src/transcripts/transcript-parser-commands.output.md
+++ b/unison-src/transcripts/transcript-parser-commands.output.md
@@ -1,0 +1,62 @@
+### Transcript parser operations
+
+The transcript parser is meant to parse `ucm` and `unison` blocks.
+
+```unison
+x = 1
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      x : Nat
+   
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    x : Nat
+
+```
+```unison
+z
+```
+
+```ucm
+.> delete foo
+
+  ⚠️
+  
+  I don't know about that name.
+
+```
+However handling of blocks of other languages should be supported.
+
+```
+python
+some python code
+
+```
+
+```
+c_cpp
+some C++ code
+
+```
+
+```
+c9search
+some cloud9 code
+
+```
+


### PR DESCRIPTION
I am aware that @atacratic has [a PR](https://github.com/unisonweb/unison/pull/1167) for the transcript parser already. This can wait for 1167 to be merged, and I will revisit after a rebase.


In the first commit you can see how the TranscriptParser behaves at the moment: an attempt to get `fenceType` is not firing correctly, and as a result `fenceType` is an empty string, meaning the word directly next to the triple quote ends up being part of the body, which is why it gets printed in the next line after the triple quote is `shown`, in the excerpt below:

https://github.com/unisonweb/unison/blob/260e18296f323240bbcb73cf01a9cd6ba3970707/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs#L84-L87


If there is no need to support `ucm<space>:error`, `lineToken` can be removed too.