### PR TITLE
stop doc literal normalization unindenting lines that start with @[...]

### DIFF
--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -480,10 +480,9 @@ docNormalize tm = case tm of
             ++ ", firstIsCandidate = " ++ (show firstIsCandidate) ++ "\n\n"
         -- remove trailing whitespace
         -- ls is non-empty thanks to the Text.null check above
-        -- Don't cut the last line's trailing whitespace if it's followed by something
-        -- which will put more text on the same line.
-        ls = mapExceptLast Text.stripEnd onLast $ Text.lines txt
-          where onLast = if nextIsCandidate then id else Text.stripEnd
+        -- Don't cut the last line's trailing whitespace - there's an assumption here
+        -- that it's followed by something which will put more text on the same line.
+        ls = mapExceptLast Text.stripEnd id $ Text.lines txt
         -- Work out which lines are candidates to be joined as part of a paragraph, i.e.
         -- are not indented.
         candidate l = case Text.uncons l of

--- a/unison-src/transcripts/doc-formatting.md
+++ b/unison-src/transcripts/doc-formatting.md
@@ -204,6 +204,9 @@ para line lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolo
 
 @[include] doc1
 
+-- note the leading space below
+  @[signature] List.take
+
 :]
 ```
 ```ucm:hide

--- a/unison-src/transcripts/doc-formatting.output.md
+++ b/unison-src/transcripts/doc-formatting.output.md
@@ -390,6 +390,9 @@ para line lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolo
 
 @[include] doc1
 
+-- note the leading space below
+  @[signature] List.take
+
 :]
 ```
 
@@ -463,6 +466,9 @@ para line lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolo
     @[evaluate] expr
     
     @[include] doc1
+    
+    -- note the leading space below
+      @[signature] List.take
     
     :]
 


### PR DESCRIPTION
Unison was wrongly removing some leading spaces from some lines of doc literals.

The langref includes the following example:

```
List.take.apiDocs : Doc
List.take.apiDocs = [:
`@List.take n [1,2,3]` returns the first `n` elements of
a list. This is efficient and takes just `O(log n)` operations.

## Example

  @[source]   examples.List.take.ex1
  ⧩
  @[evaluate] examples.List.take.ex1

## Also see

  * The `@List` type
  * The `@[signature] List.drop` function
  * More about finger trees (used to implement `@List`) here: `@docs.fingerTrees`
:]
```

Unison was removing the spaces at the start of the `@[source]` and `@[evaluate]` lines.

I'll merge this sometime soon.