### PR TITLE
addresses the typo in 'delimiter'

### DIFF
--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -644,7 +644,7 @@ symbolyId :: String -> Either Err (String, String)
 symbolyId r@('.':s)
   | s == ""              = symbolyId0 r --
   | isSpace (head s)     = symbolyId0 r -- lone dot treated as an operator
-  | isDelimeter (head s) = symbolyId0 r --
+  | isDelimiter (head s) = symbolyId0 r --
   | otherwise            = (\(s, rem) -> ('.':s, rem)) <$> symbolyId' s
 symbolyId s = symbolyId' s
 
@@ -722,8 +722,8 @@ layoutCloseOnlyKeywords = Set.fromList ["}"]
 delimiters :: Set Char
 delimiters = Set.fromList "()[]{},?;"
 
-isDelimeter :: Char -> Bool
-isDelimeter ch = Set.member ch delimiters
+isDelimiter :: Char -> Bool
+isDelimiter ch = Set.member ch delimiters
 
 reservedOperators :: Set String
 reservedOperators = Set.fromList ["->", ":", "&&", "||"]

--- a/unison-src/tests/methodical/dots.u
+++ b/unison-src/tests/methodical/dots.u
@@ -7,7 +7,7 @@ id x = x
 
 id2 = id . id
 
--- You need a space or delimeter char after the dot,
+-- You need a space or delimiter char after the dot,
 -- otherwise Unison assumes it's a rooted name - this will look for
 -- a term called `zonk` in the root:
 --


### PR DESCRIPTION
Small PR for the typo in https://github.com/unisonweb/unison/issues/1176