### PR TITLE
Lambda-case `cases` syntax

### DIFF
--- a/editor-support/atom/language-unison/grammars/unison.cson
+++ b/editor-support/atom/language-unison/grammars/unison.cson
@@ -41,7 +41,7 @@ repository:
       1: {name: 'keyword.other.forall.unison'}
       2: {name: 'keyword.other.arrow.unison'}
   match_with:
-    match: '(\\s|^)(match|with|->)(?=\\s|$)'
+    match: '(\\s|^)(match|with|->|cases)(?=\\s|$)'
     captures:
       2: {name: 'keyword.control.match.unison'}
   unsorted_keywords:

--- a/editor-support/vim/syntax/unison.vim
+++ b/editor-support/vim/syntax/unison.vim
@@ -66,7 +66,7 @@ syn match uModule		"\<module\>"
 syn match uImport		"\<use\>"
 syn match uInfix		"\<\(infix\|infixl\|infixr\)\>"
 syn match uTypedef		"\<\(∀\|forall\)\>"
-syn match uStatement		"\<\(unique\|ability\|type\|where\|match\|;\|let\|with\|handle\)\>"
+syn match uStatement		"\<\(unique\|ability\|type\|where\|match\|cases\|;\|let\|with\|handle\)\>"
 syn match uConditional		"\<\(if\|else\|then\)\>"
 
 " Not real keywords, but close.

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -405,6 +405,8 @@ lexer0 scope rem =
           in case topBlockName l of
               Just "match-with" -> -- `->` opens a block when pattern-matching only
                 Token (Open "->") pos end : pushLayout "->" l end rem
+              Just "cases" -> -- `->` opens a block when pattern-matching only
+                Token (Open "->") pos end : pushLayout "->" l end rem
               Just _ -> Token (Reserved "->") pos end : goWhitespace l end rem
               Nothing -> Token (Err LayoutError) pos pos : recover l pos rem
 
@@ -704,13 +706,13 @@ keywords = Set.fromList [
   "where", "use",
   "true", "false",
   "type", "ability", "alias", "typeLink", "termLink",
-  "let", "namespace", "match"]
+  "let", "namespace", "match", "cases"]
 
 -- These keywords introduce a layout block
 layoutKeywords :: Set String
 layoutKeywords =
   Set.fromList [
-    "if", "handle", "let", "where", "match"
+    "if", "handle", "let", "where", "match", "cases"
   ]
 
 -- These keywords end a layout block and begin another layout block

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -284,6 +284,9 @@ pretty0
         paren (p >= 10) $ pretty0 n (ac 10 Normal im doc) f `PP.hang`
           PP.spacedMap (pretty0 n (ac 10 Normal im doc)) args
       _ -> case (term, nonUnitArgPred) of
+        (LamsNamedMatch' [] branches, _) ->
+          paren (p >= 3) $
+            PP.group (fmt S.ControlKeyword "cases") `PP.hang` PP.lines (map printCase branches)
         LamsNamedPred' vs body ->
           paren (p >= 3) $
             PP.group (varList vs <> fmt S.ControlKeyword " ->") `PP.hang` pretty0 n (ac 2 Block im doc) body
@@ -545,6 +548,7 @@ prettyBinding0 env a@AmbientContext { imports = im, docContext = doc } v term = 
   symbolic = isSymbolic v
   isBinary = \case
     Ann'              tm _ -> isBinary tm
+    LamsNamedMatch'   vs _ -> length vs == 1
     LamsNamedOrDelay' vs _ -> length vs == 2
     _                      -> False -- unhittable
 

--- a/parser-typechecker/src/Unison/Util/SyntaxText.hs
+++ b/parser-typechecker/src/Unison/Util/SyntaxText.hs
@@ -17,7 +17,7 @@ data Element = NumericLiteral
              | Constructor
              | Request
              | AbilityBraces
-             -- let|handle|in|where|case|of|->|if|then|else|and|or
+             -- let|handle|in|where|match|with|cases|->|if|then|else|and|or
              | ControlKeyword
              -- forall|->
              | TypeOperator

--- a/parser-typechecker/tests/Unison/Test/TermParser.hs
+++ b/parser-typechecker/tests/Unison/Test/TermParser.hs
@@ -91,6 +91,8 @@ test1 = scope "termparser" . tests . map parses $
     "  x\n" ++
     "with foo"
   , "handle x with foo"
+  , "handle foo with cases\n" ++
+    " { x } -> x"
 
   -- Patterns
   , "match x with x -> x"
@@ -122,6 +124,15 @@ test1 = scope "termparser" . tests . map parses $
     " [4] ++ _ -> 4\n" ++
     " _ ++ [5] -> 5\n" ++
     " _ -> -1"
+  , "cases x -> x"
+  , "cases\n" ++
+    " [] -> 0\n" ++
+    " [x] -> 1\n" ++
+    " _ -> 2"
+  , "cases\n" ++
+    " 0 ->\n" ++
+    "   z = 0\n" ++
+    "   z"
 
   -- Conditionals
   , "if x then y else z"

--- a/parser-typechecker/tests/Unison/Test/TermPrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/TermPrinter.hs
@@ -136,6 +136,11 @@ test = scope "termprinter" . tests $
                  \  x = 1\n\
                  \  y = 2\n\
                  \  f x y"
+  , tc "let\n\
+        \  f = cases\n\
+        \    0 -> 0\n\
+        \    x -> x\n\
+        \  f y"
   , pending $ tc "match x with Pair t 0 -> foo t" -- TODO hitting UnknownDataConstructor when parsing pattern
   , pending $ tc "match x with Pair t 0 | pred t -> foo t" -- ditto
   , pending $ tc "match x with Pair t 0 | pred t -> foo t; Pair t 0 -> foo' t; Pair t u -> bar;" -- ditto
@@ -159,6 +164,7 @@ test = scope "termprinter" . tests $
   , tc "match e with { a } -> z"
   , pending $ tc "match e with { () -> k } -> z" -- TODO doesn't parse since 'many leaf' expected before the "-> k"
                                                  -- need an actual effect constructor to test this with
+  , pending $ tc "cases x -> x" -- TODO handle cases terms outside of let bindings
   , tc "if a then if b then c else d else e"
   , tc "handle handle foo with bar with baz"
   , tcBreaks 16 "match (if a then\n\

--- a/parser-typechecker/tests/Unison/Test/TermPrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/TermPrinter.hs
@@ -141,6 +141,16 @@ test = scope "termprinter" . tests $
         \    0 -> 0\n\
         \    x -> x\n\
         \  f y"
+  , tc "let\n\
+        \  f z = cases\n\
+        \    0 -> z\n\
+        \    y -> g y\n\
+        \  f \"\" 1"
+  , tc "let\n\
+        \  f _ = cases\n\
+        \    0 -> 0\n\
+        \    x -> x\n\
+        \  !f 1"
   , pending $ tc "match x with Pair t 0 -> foo t" -- TODO hitting UnknownDataConstructor when parsing pattern
   , pending $ tc "match x with Pair t 0 | pred t -> foo t" -- ditto
   , pending $ tc "match x with Pair t 0 | pred t -> foo t; Pair t 0 -> foo' t; Pair t u -> bar;" -- ditto
@@ -164,7 +174,11 @@ test = scope "termprinter" . tests $
   , tc "match e with { a } -> z"
   , pending $ tc "match e with { () -> k } -> z" -- TODO doesn't parse since 'many leaf' expected before the "-> k"
                                                  -- need an actual effect constructor to test this with
-  , pending $ tc "cases x -> x" -- TODO handle cases terms outside of let bindings
+  , tc "cases x -> x"
+  , tc "cases\n\
+        \  [] -> 0\n\
+        \  [x] -> 1\n\
+        \  _ -> 2"
   , tc "if a then if b then c else d else e"
   , tc "handle handle foo with bar with baz"
   , tcBreaks 16 "match (if a then\n\

--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -443,6 +443,7 @@ pattern LamsNamed' vs body <- (unLams' -> Just (vs, body))
 pattern LamsNamedOpt' vs body <- (unLamsOpt' -> Just (vs, body))
 pattern LamsNamedPred' vs body <- (unLamsPred' -> Just (vs, body))
 pattern LamsNamedOrDelay' vs body <- (unLamsUntilDelay' -> Just (vs, body))
+pattern LamsNamedMatch' vs branches <- (unLamsMatch' -> Just (vs, branches))
 pattern Let1' b subst <- (unLet1 -> Just (_, b, subst))
 pattern Let1Top' top b subst <- (unLet1 -> Just (top, b, subst))
 pattern Let1Named' v b e <- (ABT.Tm' (Let _ b (ABT.out -> ABT.Abs v e)))
@@ -781,6 +782,21 @@ unLamsUntilDelay' t = case unLamsPred' (t, (/=) $ Var.named "()") of
   r@(Just _) -> r
   Nothing    -> Just ([], t)
 
+unLamsMatch'
+  :: Var v
+  => AnnotatedTerm2 vt at ap v a
+  -> Maybe ([v], [MatchCase ap (AnnotatedTerm2 vt at ap v a)])
+unLamsMatch' t = case unLamsUntilDelay' t of
+    Just (reverse -> (v1:vs), Match' (Var' v1') branches) |
+      (v1 == v1') && not (Set.member v1' (Set.unions $ freeVars <$> branches)) ->
+        Just (reverse vs, branches)
+    _ -> Nothing
+  where
+    freeVars (MatchCase _ g rhs) =
+      let guardVars = (fromMaybe Set.empty $ ABT.freeVars <$> g)
+          rhsVars = (ABT.freeVars rhs)
+      in Set.union guardVars rhsVars
+
 -- Same as unLams' but taking a predicate controlling whether we match on a given binary function.
 unLamsPred' :: (AnnotatedTerm2 vt at ap v a, v -> Bool) ->
                  Maybe ([v], AnnotatedTerm2 vt at ap v a)
@@ -1093,4 +1109,3 @@ instance (Show v, Show a) => Show (F v a0 p a) where
       showParen (p > 0) $ s "or " <> shows x <> s " " <> shows y
     (<>) = (.)
     s    = showString
-

--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -782,6 +782,8 @@ unLamsUntilDelay' t = case unLamsPred' (t, (/=) $ Var.named "()") of
   r@(Just _) -> r
   Nothing    -> Just ([], t)
 
+-- Same as unLamsUntilDelay', but only matches if the lambda body is a match
+-- expression, where the scrutinee is also the last argument of the lambda
 unLamsMatch'
   :: Var v
   => AnnotatedTerm2 vt at ap v a


### PR DESCRIPTION
This PR provides support for syntax like the following:
```
store : a -> Request {Store a} v -> v
store init = cases
  { x }                -> x
  { Store.get   -> k } -> handle k init with store init
  { Store.put v -> k } -> handle !k with store v
```

Changes:
- [x] Parse lambda-case syntax (`cases` keyword)
- [x] Pretty-print using the new syntax when appropriate
- [x] Update tests 
- [x] Update editor support

Before the next release:
- [ ] Update docs
