### PR TITLE
Refactor pull / merge / pr.load

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -37,6 +37,7 @@ module Unison.Codebase.Branch
   , stepEverywhere
   , uncons
   , merge
+  , adjustHeadMN
 
     -- * Branch children
     -- ** Children lenses
@@ -211,6 +212,13 @@ makeLenses ''Raw
 toNames0 :: Branch0 m -> Names0
 toNames0 b = Names (R.swap . deepTerms $ b)
                    (R.swap . deepTypes $ b)
+
+adjustHeadMN :: (Monad m, Monad n)
+  => (Branch0 m -> n (Branch0 m))
+  -> (forall a. m a -> n a)
+  -> Branch m
+  -> n (Maybe (Branch m))
+adjustHeadMN f g = (fmap . fmap) Branch . Causal.adjustHeadMN f g . _history
 
 -- This stops searching for a given ShortHash once it encounters
 -- any term or type in any Branch0 that satisfies that ShortHash.
@@ -562,7 +570,7 @@ isEmpty = (== empty)
 step :: Applicative m => (Branch0 m -> Branch0 m) -> Branch m -> Branch m
 step f = over history (Causal.stepDistinct f)
 
-stepM :: Monad m => (Branch0 m -> m (Branch0 m)) -> Branch m -> m (Branch m)
+stepM :: (Monad m, Monad n) => (Branch0 m -> n (Branch0 m)) -> Branch m -> n (Branch m)
 stepM f = mapMOf history (Causal.stepDistinctM f)
 
 cons :: Applicative m => Branch0 m -> Branch m -> Branch m
@@ -600,8 +608,8 @@ stepAtM p f = modifyAtM p g where
     b0' <- f (Causal.head b)
     pure $ Branch . Causal.consDistinct b0' $ b
 
-stepManyAtM :: (Monad m, Foldable f)
-            => f (Path, Branch0 m -> m (Branch0 m)) -> Branch m -> m (Branch m)
+stepManyAtM :: (Monad m, Monad n, Foldable f)
+            => f (Path, Branch0 m -> n (Branch0 m)) -> Branch m -> n (Branch m)
 stepManyAtM actions = stepM (stepManyAt0M actions)
 
 -- starting at the leaves, apply `f` to every level of the branch.
@@ -691,9 +699,9 @@ stepManyAt0 :: (Applicative m, Foldable f)
            -> Branch0 m -> Branch0 m
 stepManyAt0 actions b = foldl' (\b (p, f) -> stepAt0 p f b) b actions
 
-stepManyAt0M :: (Monad m, Foldable f)
-             => f (Path, Branch0 m -> m (Branch0 m))
-             -> Branch0 m -> m (Branch0 m)
+stepManyAt0M :: (Monad m, Monad n, Foldable f)
+             => f (Path, Branch0 m -> n (Branch0 m))
+             -> Branch0 m -> n (Branch0 m)
 stepManyAt0M actions b = Monad.foldM (\b (p, f) -> stepAt0M p f b) b actions
 
 stepAt0M :: forall n m. (Functor n, Applicative m)

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -37,7 +37,6 @@ module Unison.Codebase.Branch
   , stepEverywhere
   , uncons
   , merge
-  , adjustHeadMN
 
     -- * Branch children
     -- ** Children lenses
@@ -212,13 +211,6 @@ makeLenses ''Raw
 toNames0 :: Branch0 m -> Names0
 toNames0 b = Names (R.swap . deepTerms $ b)
                    (R.swap . deepTypes $ b)
-
-adjustHeadMN :: (Monad m, Monad n)
-  => (Branch0 m -> n (Branch0 m))
-  -> (forall a. m a -> n a)
-  -> Branch m
-  -> n (Maybe (Branch m))
-adjustHeadMN f g = (fmap . fmap) Branch . Causal.adjustHeadMN f g . _history
 
 -- This stops searching for a given ShortHash once it encounters
 -- any term or type in any Branch0 that satisfies that ShortHash.

--- a/parser-typechecker/src/Unison/Codebase/Causal.hs
+++ b/parser-typechecker/src/Unison/Codebase/Causal.hs
@@ -172,20 +172,6 @@ children (One _ _         ) = Seq.empty
 children (Cons  _ _ (_, t)) = Seq.singleton t
 children (Merge _ _ ts    ) = Seq.fromList $ Map.elems ts
 
-adjustHeadMN :: (Monad m, Monad n, Hashable e)
-  => (e -> n e)
-  -> (forall a. m a -> n a)
-  -> Causal m h e
-  -> n (Maybe (Causal m h e))
-adjustHeadMN f g = \case
-  One{} -> pure Nothing
-  Cons _ e (_, tl) ->
-    fmap Just . cons <$> f e <*> g tl
-  Merge _ e tails -> do
-    e' <- f e
-    let h' = RawHash $ hash (e', Map.keys tails)
-    pure . Just $ Merge h' e' tails
-
 threeWayMerge
   :: forall m h e d
    . (Show d, Monad m, Hashable e, Semigroup d)

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -48,7 +48,7 @@ data Input
     | PullRemoteBranchI (Maybe RemoteNamespace) Path'
     | PushRemoteBranchI (Maybe RemoteHead) Path'
     | CreatePullRequestI RemoteNamespace RemoteNamespace
-    | LoadPullRequestI RemoteNamespace RemoteNamespace
+    | LoadPullRequestI RemoteNamespace RemoteNamespace Path'
     | ResetRootI (Either ShortBranchHash Path')
     -- todo: Q: Does it make sense to publish to not-the-root of a Github repo?
     --          Does it make sense to fork from not-the-root of a Github repo?

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -75,6 +75,7 @@ data NumberedOutput v
   | ShowDiffAfterDeleteDefinitions PPE.PrettyPrintEnv (BranchDiffOutput v Ann)
   | ShowDiffAfterDeleteBranch Path.Absolute PPE.PrettyPrintEnv (BranchDiffOutput v Ann)
   | ShowDiffAfterMerge Path.Path' Path.Absolute PPE.PrettyPrintEnv (BranchDiffOutput v Ann)
+  | ShowDiffAfterMergePropagate Path.Path' Path.Absolute Path.Path' PPE.PrettyPrintEnv (BranchDiffOutput v Ann)
   | ShowDiffAfterMergePreview Path.Path' Path.Absolute PPE.PrettyPrintEnv (BranchDiffOutput v Ann)
   | ShowDiffAfterPull Path.Path' Path.Absolute PPE.PrettyPrintEnv (BranchDiffOutput v Ann)
   | ShowDiffAfterCreatePR RemoteNamespace RemoteNamespace PPE.PrettyPrintEnv (BranchDiffOutput v Ann)
@@ -318,6 +319,7 @@ isNumberedFailure = \case
   ShowDiffAfterDeleteDefinitions{} -> False
   ShowDiffAfterDeleteBranch{} -> False
   ShowDiffAfterMerge{} -> False
+  ShowDiffAfterMergePropagate{} -> False
   ShowDiffAfterMergePreview{} -> False
   ShowDiffAfterUndo{} -> False
   ShowDiffAfterPull{} -> False

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -91,8 +91,8 @@ data Output v
   | SourceLoadFailed String
   -- No main function, the [Type v Ann] are the allowed types
   | NoMainFunction String PPE.PrettyPrintEnv [Type v Ann]
-  | BranchNotEmpty Path.Path'
-  | LoadPullRequest RemoteNamespace RemoteNamespace Path.Relative Path.Relative Path.Relative
+  | BranchNotEmpty Path'
+  | LoadPullRequest RemoteNamespace RemoteNamespace Path' Path' Path'
   | CreatedNewBranch Path.Absolute
   | BranchAlreadyExists Path'
   | PatchAlreadyExists Path.Split'
@@ -182,7 +182,9 @@ data Output v
   | WarnIncomingRootBranch (Set ShortBranchHash)
   | History (Maybe Int) [(ShortBranchHash, Names.Diff)] HistoryTail
   | ShowReflog [ReflogEntry]
-  | NothingTodo Input
+  | PullAlreadyUpToDate RemoteNamespace Path'
+  | MergeAlreadyUpToDate Path' Path'
+  | PreviewMergeAlreadyUpToDate Path' Path'
   -- | No conflicts or edits remain for the current patch.
   | NoConflictsOrEdits
   | NotImplemented
@@ -306,7 +308,9 @@ isFailure o = case o of
   DumpNumberedArgs{} -> False
   DumpBitBooster{} -> False
   NoBranchWithHash{} -> True
-  NothingTodo{} -> False
+  PullAlreadyUpToDate{} -> False
+  MergeAlreadyUpToDate{} -> False
+  PreviewMergeAlreadyUpToDate{} -> False
   NoConflictsOrEdits{} -> False
   ListShallow _ es -> null es
   HashAmbiguous{} -> True

--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -203,7 +203,7 @@ parseHQSplit' s =
   shError s = "couldn't parse shorthash from " <> s
 
 toAbsoluteSplit :: Absolute -> (Path', a) -> (Absolute, a)
-toAbsoluteSplit a (p, s) = (toAbsolutePath a p, s)
+toAbsoluteSplit a (p, s) = (resolve a p, s)
 
 fromSplit' :: (Path', a) -> (Path, a)
 fromSplit' (Path' (Left (Absolute p)), a) = (p, a)
@@ -220,13 +220,6 @@ relativeEmpty' = Path' (Right (Relative empty))
 
 relativeSingleton :: NameSegment -> Relative
 relativeSingleton = Relative . Path . Seq.singleton
-
-toAbsolutePath :: Absolute -> Path' -> Absolute
-toAbsolutePath cur (Path' p) = either id (relativeToAbsolutePath cur) p
-
-relativeToAbsolutePath :: Absolute -> Relative -> Absolute
-relativeToAbsolutePath (Absolute cur) (Relative rel) =
-  Absolute (Path $ toSeq cur <> toSeq rel)
 
 toPath' :: Path -> Path'
 toPath' = \case
@@ -251,23 +244,20 @@ prefixName p = toName . prefix p . fromName'
 singleton :: NameSegment -> Path
 singleton n = fromList [n]
 
+cons :: NameSegment -> Path -> Path
+cons = Lens.cons
+
 snoc :: Path -> NameSegment -> Path
-snoc (Path p) ns = Path (p <> pure ns)
+snoc = Lens.snoc
 
 snoc' :: Path' -> NameSegment -> Path'
-snoc' (Path' e) n = case e of
-  Left abs -> Path' (Left . Absolute $ snoc (unabsolute abs) n)
-  Right rel -> Path' (Right . Relative $ snoc (unrelative rel) n)
+snoc' = Lens.snoc
 
 unsnoc :: Path -> Maybe (Path, NameSegment)
-unsnoc p = case p of
-  Path (init :|> last) -> Just (Path init, last)
-  _ -> Nothing
+unsnoc = Lens.unsnoc
 
 uncons :: Path -> Maybe (NameSegment, Path)
-uncons p = case p of
-  Path (hd :<| tl) -> Just (hd, Path tl)
-  _ -> Nothing
+uncons = Lens.uncons
 
 --asDirectory :: Path -> Text
 --asDirectory p = case toList p of
@@ -318,15 +308,6 @@ pattern Parent h t = Path (NameSegment h :<| t)
 empty :: Path
 empty = Path mempty
 
-cons :: NameSegment -> Path -> Path
-cons ns (Path p) = Path (ns :<| p)
-
-snocAbsolute :: Absolute -> NameSegment -> Absolute
-snocAbsolute a n = Absolute . (`snoc` n) $ unabsolute a
-
-snocRelative :: Relative -> NameSegment -> Relative
-snocRelative r n = Relative . (`snoc` n) $ unrelative r
-
 instance Show Path where
   show = Text.unpack . toText
 
@@ -337,3 +318,74 @@ toText' :: Path' -> Text
 toText' = \case
   Path' (Left (Absolute path)) -> Text.cons '.' (toText path)
   Path' (Right (Relative path)) -> toText path
+
+instance Cons Path Path NameSegment NameSegment where
+  _Cons = prism (uncurry cons) uncons where
+    cons :: NameSegment -> Path -> Path
+    cons ns (Path p) = Path (ns :<| p)
+    uncons :: Path -> Either Path (NameSegment, Path)
+    uncons p = case p of
+      Path (hd :<| tl) -> Right (hd, Path tl)
+      _ -> Left p
+
+instance Snoc Relative Relative NameSegment NameSegment where
+  _Snoc = prism (uncurry snocRelative) $ \case
+    Relative (Lens.unsnoc -> Just (s,a)) -> Right (Relative s,a)
+    e -> Left e
+    where
+    snocRelative :: Relative -> NameSegment -> Relative
+    snocRelative r n = Relative . (`Lens.snoc` n) $ unrelative r
+
+instance Snoc Absolute Absolute NameSegment NameSegment where
+  _Snoc = prism (uncurry snocAbsolute) $ \case
+    Absolute (Lens.unsnoc -> Just (s,a)) -> Right (Absolute s, a)
+    e -> Left e
+    where
+    snocAbsolute :: Absolute -> NameSegment -> Absolute
+    snocAbsolute a n = Absolute . (`Lens.snoc` n) $ unabsolute a
+
+instance Snoc Path Path NameSegment NameSegment where
+  _Snoc = prism (uncurry snoc) unsnoc
+    where
+    unsnoc :: Path -> Either Path (Path, NameSegment)
+    unsnoc = \case
+      Path (s Seq.:|> a) -> Right (Path s, a)
+      e -> Left e
+    snoc :: Path -> NameSegment -> Path
+    snoc (Path p) ns = Path (p <> pure ns)
+
+instance Snoc Path' Path' NameSegment NameSegment where
+  _Snoc = prism (uncurry snoc') $ \case
+    Path' (Left (Lens.unsnoc -> Just (s,a))) -> Right (Path' (Left s), a)
+    Path' (Right (Lens.unsnoc -> Just (s,a))) -> Right (Path' (Right s), a)
+    e -> Left e
+    where
+    snoc' :: Path' -> NameSegment -> Path'
+    snoc' (Path' e) n = case e of
+      Left abs -> Path' (Left . Absolute $ Lens.snoc (unabsolute abs) n)
+      Right rel -> Path' (Right . Relative $ Lens.snoc (unrelative rel) n)
+
+
+class Resolve l r where
+  resolve :: l -> r -> l
+
+instance Resolve Path Path where
+  resolve (Path l) (Path r) = Path (l <> r)
+
+instance Resolve Relative Relative where
+  resolve (Relative (Path l)) (Relative (Path r)) = Relative (Path (l <> r))
+
+instance Resolve Absolute Relative where
+  resolve (Absolute l) (Relative r) = Absolute (resolve l r)
+
+instance Resolve Path' Path' where
+  resolve _ a@(Path' Left{}) = a
+  resolve (Path' (Left a)) (Path' (Right r)) = Path' (Left (resolve a r))
+  resolve (Path' (Right r1)) (Path' (Right r2)) = Path' (Right (resolve r1 r2))
+
+instance Resolve Path' Split' where
+  resolve l r = resolve l (unsplit' r)
+
+instance Resolve Absolute Path' where
+  resolve _ (Path' (Left a)) = a
+  resolve a (Path' (Right r)) = resolve a r

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -671,15 +671,25 @@ createPullRequest = InputPattern "pr.create" []
 loadPullRequest :: InputPattern
 loadPullRequest = InputPattern "pr.load" []
   [(Required, gitUrlArg), (Required, gitUrlArg), (Optional, pathArg)]
-  (P.wrap $ makeExample loadPullRequest ["base", "head"]
+  (P.lines 
+   [P.wrap $ makeExample loadPullRequest ["base", "head"]
     <> "will load a pull request for merging the remote repo `head` into the"
     <> "remote repo `base`, staging each in the current namespace"
-    <> "(so make yourself a clean spot to work first).")
+    <> "(so make yourself a clean spot to work first)."
+   ,P.wrap $ makeExample loadPullRequest ["base", "head", "dest"]
+     <> "will load a pull request for merging the remote repo `head` into the"
+     <> "remote repo `base`, staging each in `dest`, which must be empty."
+   ])
   (\case
     [baseUrl, headUrl] -> first fromString $ do
       baseRepo <- parseUri "baseRepo" baseUrl
       headRepo <- parseUri "topicRepo" headUrl
-      pure $ Input.LoadPullRequestI baseRepo headRepo
+      pure $ Input.LoadPullRequestI baseRepo headRepo Path.relativeEmpty'
+    [baseUrl, headUrl, dest] -> first fromString $ do
+      baseRepo <- parseUri "baseRepo" baseUrl
+      headRepo <- parseUri "topicRepo" headUrl
+      destPath <- Path.parsePath' dest
+      pure $ Input.LoadPullRequestI baseRepo headRepo destPath
     _ -> Left (I.help loadPullRequest)
   )
 parseUri :: IsString b => String -> String -> Either b RemoteNamespace

--- a/unison-core/src/Unison/Codebase/NameSegment.hs
+++ b/unison-core/src/Unison/Codebase/NameSegment.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE PatternSynonyms   #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 
 module Unison.Codebase.NameSegment where
 
@@ -9,6 +11,8 @@ import qualified Unison.Name                   as Name
 import qualified Data.Text                     as Text
 import qualified Unison.Hashable               as H
 import qualified Unison.HashQualified'         as HQ'
+import qualified Control.Lens as Lens
+import Unison.Name (Name(Name))
 
 -- Represents the parts of a name between the `.`s
 newtype NameSegment = NameSegment { toText :: Text } deriving (Eq, Ord)
@@ -37,3 +41,14 @@ instance Show NameSegment where
 
 instance IsString NameSegment where
   fromString = NameSegment . Text.pack
+
+instance Lens.Snoc Name Name NameSegment NameSegment where
+  _Snoc = Lens.prism snoc unsnoc
+    where
+    snoc :: (Name, NameSegment) -> Name
+    snoc (n,s) = Name.joinDot n (toName s)
+    unsnoc :: Name -> Either Name (Name, NameSegment)
+    unsnoc n@(Name (Text.splitOn "." -> ns)) = case Lens.unsnoc ns of
+      Nothing -> Left n
+      Just ([],_) -> Left n
+      Just (init, last) -> Right $ (Name (Text.intercalate "." init), NameSegment last)

--- a/unison-core/src/Unison/Name.hs
+++ b/unison-core/src/Unison/Name.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings   #-}
 
 module Unison.Name
-  ( Name
+  ( Name(Name)
   , fromString
   , isPrefixOf
   , joinDot

--- a/unison-src/transcripts/delete.output.md
+++ b/unison-src/transcripts/delete.output.md
@@ -177,10 +177,10 @@ type Foo = Foo Boolean
     3. └ type Foo#gq9inhvg9h
            
     
-    4. Foo.Foo#d97e0jhkmd#0 : Nat -> Foo#d97e0jhkmd
+    4. Foo.Foo#d97e0jhkmd#0 : Nat -> Foo
        ↓
-    5. ┌ Foo.Foo#d97e0jhkmd#0 : Nat -> Foo#d97e0jhkmd
-    6. └ Foo.Foo#gq9inhvg9h#0 : Boolean -> Foo#gq9inhvg9h
+    5. ┌ Foo.Foo#d97e0jhkmd#0 : Nat -> Foo
+    6. └ Foo.Foo#gq9inhvg9h#0 : Boolean -> b.Foo
   
   Added definitions:
   

--- a/unison-src/transcripts/diff.md
+++ b/unison-src/transcripts/diff.md
@@ -126,7 +126,11 @@ a = 555
 ```ucm
 .nsz> update
 .> merge nsy nsw
+```
+```ucm:error
 .> merge nsz nsw
+```
+```ucm
 .> diff.namespace nsx nsw
 .nsw> view a b
 ```
@@ -134,9 +138,9 @@ a = 555
 a = 777
 ```
 
-```-ucm
+```ucm:error
 .nsw> update
-nsw> view a b
+.nsw> view a b
 ```
 
 ##

--- a/unison-src/transcripts/diff.output.md
+++ b/unison-src/transcripts/diff.output.md
@@ -211,10 +211,6 @@ unique type Y a b = Y a b
     b        : .builtin.Text
     fromJust : .builtin.Nat
 
-  ✅
-  
-  No conflicts or edits in progress.
-
 .ns2> links fromJust
 
   1. .ns1.b : Nat
@@ -469,10 +465,6 @@ bdependent = "banana"
   
     bdependent : .builtin.Text
 
-  ✅
-  
-  No conflicts or edits in progress.
-
 .> diff.namespace ns2 ns3
 
   Updates:
@@ -528,10 +520,6 @@ a = 444
   
     a : .builtin.Nat
 
-  ✅
-  
-  No conflicts or edits in progress.
-
 ```
 ```unison
 a = 555
@@ -543,10 +531,6 @@ a = 555
   ⍟ I've updated to these definitions:
   
     a : .builtin.Nat
-
-  ✅
-  
-  No conflicts or edits in progress.
 
 .> merge nsy nsw
 
@@ -564,6 +548,8 @@ a = 555
        can use `undo` or `reflog` to undo the results of this
        merge.
 
+```
+```ucm
 .> merge nsz nsw
 
   Here's what's changed in nsw after the merge:
@@ -588,6 +574,10 @@ a = 555
        can use `undo` or `reflog` to undo the results of this
        merge.
 
+  A patch needs to be conflict-free.
+
+```
+```ucm
 .> diff.namespace nsx nsw
 
   New name conflicts:
@@ -645,13 +635,37 @@ a = 777
   `>`)... Ctrl+C cancels.
 
 ```
-```
--ucm
+```ucm
 .nsw> update
-nsw> view a b
+
+  x These definitions failed:
+  
+    Reason
+    conflicted   a   : .builtin.Nat
+  
+    Tip: Use `help filestatus` to learn more.
+
+  A patch needs to be conflict-free.
+
+.nsw> view a b
+
+  a#5f8uodgrtf : Nat
+  a#5f8uodgrtf = 555
+  
+  a#ekguc9h648 : Nat
+  a#ekguc9h648 = 444
+  
+  b#be9a2abbbg : Nat
+  b#be9a2abbbg =
+    use Nat +
+    a#ekguc9h648 + 1
+  
+  b#kut4vstim7 : Nat
+  b#kut4vstim7 =
+    use Nat +
+    a#5f8uodgrtf + 1
 
 ```
-
 ##
 
 Updates:  -- 1 to 1

--- a/unison-src/transcripts/diff.output.md
+++ b/unison-src/transcripts/diff.output.md
@@ -574,7 +574,8 @@ a = 555
        can use `undo` or `reflog` to undo the results of this
        merge.
 
-  A patch needs to be conflict-free.
+  I tried to auto-apply the patch, but couldn't because it
+  contained contradictory entries.
 
 ```
 ```ucm
@@ -645,7 +646,8 @@ a = 777
   
     Tip: Use `help filestatus` to learn more.
 
-  A patch needs to be conflict-free.
+  I tried to auto-apply the patch, but couldn't because it
+  contained contradictory entries.
 
 .nsw> view a b
 

--- a/unison-src/transcripts/find-patch.output.md
+++ b/unison-src/transcripts/find-patch.output.md
@@ -64,10 +64,6 @@ Update
   
     hey : builtin.Text
 
-  ✅
-  
-  No conflicts or edits in progress.
-
 .> find.patch
 
   1. patch

--- a/unison-src/transcripts/fix942.output.md
+++ b/unison-src/transcripts/fix942.output.md
@@ -60,10 +60,6 @@ x = 7
   
     x : builtin.Nat
 
-  ✅
-  
-  No conflicts or edits in progress.
-
 .> view x y z
 
   x : Nat

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -244,10 +244,6 @@ master.frobnicate n = n + 1
   
     master.y : builtin.Text
 
-  ✅
-  
-  No conflicts or edits in progress.
-
 .> view master.y
 
   feature2.y : Text

--- a/unison-src/transcripts/propagate.output.md
+++ b/unison-src/transcripts/propagate.output.md
@@ -87,10 +87,6 @@ and update the codebase to use the new type `Foo`...
   
     unique type Foo
 
-  ✅
-  
-  No conflicts or edits in progress.
-
 ```
 ... it should automatically propagate the type to `fooToInt`.
 
@@ -176,10 +172,6 @@ Update...
   ⍟ I've updated to these definitions:
   
     someTerm : .builtin.Optional x -> .builtin.Optional x
-
-  ✅
-  
-  No conflicts or edits in progress.
 
 ```
 Now the type of `someTerm` should be `Optional x -> Optional x` and the 
@@ -293,10 +285,6 @@ someTerm _ = None
   ⍟ I've updated to these definitions:
   
     someTerm : .builtin.Optional x -> .builtin.Optional x
-
-  ✅
-  
-  No conflicts or edits in progress.
 
 ```
 The other namespace should be left alone.

--- a/unison-src/transcripts/resolve.md
+++ b/unison-src/transcripts/resolve.md
@@ -70,6 +70,8 @@ Let's now merge these namespaces into `c`:
 
 ```ucm
 .example.resolve> merge a c
+```
+```ucm:error
 .example.resolve> merge b c
 ```
 
@@ -107,4 +109,3 @@ We can resolve the name conflict by deleting one of the names.
 ```
 
 And that's how you resolve edit conflicts with UCM.
-

--- a/unison-src/transcripts/resolve.output.md
+++ b/unison-src/transcripts/resolve.output.md
@@ -156,6 +156,8 @@ Let's now merge these namespaces into `c`:
        can use `undo` or `reflog` to undo the results of this
        merge.
 
+```
+```ucm
 .example.resolve> merge b c
 
   Here's what's changed in c after the merge:
@@ -175,6 +177,9 @@ Let's now merge these namespaces into `c`:
        do in this namespace and `test` to run the tests. Or you
        can use `undo` or `reflog` to undo the results of this
        merge.
+
+  I tried to auto-apply the patch, but couldn't because it
+  contained contradictory entries.
 
 ```
 The namespace `c` now has an edit conflict, since the term `foo` was edited in two different ways.
@@ -249,4 +254,3 @@ We can resolve the name conflict by deleting one of the names.
 
 ```
 And that's how you resolve edit conflicts with UCM.
-


### PR DESCRIPTION
Welcome to my PR of spiraling scope.

### What:
* We decided not to combine merge and propagate steps after all for pull/merge (closes #1202).

  @pchiusano and I decided it's good to have these steps distinct in the reflog, and although we might like to see them combined when a user does an `undo`, that's best addressed by changing how `undo` works.

* Combine the pull/pull/merge steps of `pr.load` into one Causal update (closes #1201).  The propagate step remains separate.

* Remove automatic `todo` output after a `merge`.  We may revisit this later and print a quantitative summary, rather than the standard `todo` output, which duplicates some of the post-merge diff information.

* Added optional local staging dest arg to `pr.load` eg
  ```
  pr.load https://github.com/unisonweb/base https://github.com/puffnfresh/base .prs.puffnfresh
  ```

* Made a few helpers that do the work of pulling, merging, diffing, propagating.

### Notable changed behavior
* A merge can result in a conflicted patch, and when ucm tries to auto-propagate a conflicted patch after the merge, it will generate a `PatchNeedsToBeConflictFree` message, which must go in a `ucm:error` block for transcripts.  I think this was the expected behavior before, and although I don't see the change that changed it, it evidently wan't happening before.

### Notable codebase changes
* Added some versions of HandleInput.step* functions that return `Bool` instead of `()`

  They return `True` if they resulted in a change / distinct step; `False` otherwise.  This is needed if we want to have some output conditional on whether a command had an effect.

* Generalized some of the Branch.step functions:
  e.g.
  ```haskell
  stepDistinctM :: (Applicative m, Eq e, Hashable e)
    => (e -> m e) -> Causal m h e -> m (Causal m h e)
  ```
  became
  ```haskell
  stepDistinctM  :: (Applicative m, Functor n, Eq e, Hashable e)
    => (e -> n e) -> Causal m h e -> n (Causal m h e)
  ```
  allowing a different monad in the step function than in the `Causal`.  I didn't end up using these though, so I could back them out if desired.
* add some Lens.Cons / Lens.Snoc instances (closes #1200) to consolidate several `Path` helper functions into `Lens.cons` / `Lens.snoc` calls:

  in `module Unison.Codebase.Path`:
  ```haskell
   -- extract the top parent from a path, or nest a path one level deeper.
  instance Cons Path Path NameSegment NameSegment

  -- extract the leaf segment from a path, or descend one level deeper into one.
  -- (could probably simplify `parsePath'`, `parsePath'Impl`, `parseSplit'`, etc. with these?)
  instance Snoc Relative Relative NameSegment NameSegment
  instance Snoc Absolute Absolute NameSegment NameSegment
  instance Snoc Path Path NameSegment NameSegment
  instance Snoc Path' Path' NameSegment NameSegment
  ```
  in `module Unison.Codebase.NameSegment`:
  ```haskell
  instance Snoc Name Name NameSegment NameSegment
  ```

* add `class Path.Resolve` to consolidate several `Path` helper functions:
  ```haskell 
  where
    resolve :: l -> r -> l
  ```
  resolves one path against another, e.g.:
  ```haskell
  resolve .foo .bar == .bar
  resolve .foo  bar == .foo.bar
  resolve  foo .bar == .bar
  resolve  foo  bar ==  foo.bar
  ```
  in `module Unison.Codebase.Path`:
  ```haskell
  instance Resolve Path Path
  instance Resolve Relative Relative
  instance Resolve Absolute Relative
  instance Resolve Path' Path'
  instance Resolve Path' Split'
  instance Resolve Absolute Path'
  ```
### Misc
* removed `{-# OPTIONS_GHC -Wno-unused-top-binds #-}` and some unused top binds from `HandleInput.hs` (towards #1111).
* Added `type InputDescription = Text` and used it in places where we're passing input description for the reflog.  Could do a `newtype`.
* Eliminated `Output.NothingToDo Input` in favor of explicit cases `MergeAlreadyUpToDate` and `PreviewMergeAlreadyUpToDate` (toward #1141).
