### PR TITLE
Issue 1015: find by type is affected by the var names chosen.

### DIFF
--- a/unison-core/src/Unison/Type.hs
+++ b/unison-core/src/Unison/Type.hs
@@ -509,8 +509,9 @@ functionResult = go False
 generalizeLowercase :: Var v => Set v -> Type v a -> Type v a
 generalizeLowercase except t = foldr (forall (ABT.annotation t)) t vars
  where
+  excluded = Set.toList except
   vars =
-    [ v | v <- Set.toList (freeVars t `Set.difference` except), Var.universallyQuantifyIfFree v ]
+    [ v | v <- filter (`notElem` excluded) (ABT.orderedFreeVars t), Var.universallyQuantifyIfFree v ]
 
 -- Convert all free variables in `allowed` to variables bound by an `introOuter`.
 freeVarsToOuters :: Ord v => Set v -> Type v a -> Type v a

--- a/unison-core/src/Unison/Var.hs
+++ b/unison-core/src/Unison/Var.hs
@@ -145,4 +145,4 @@ universallyQuantifyIfFree :: forall v . Var v => v -> Bool
 universallyQuantifyIfFree v =
   ok (name $ reset v) && unqualified v == v
   where
-  ok n = (all isLower . take 1 . Text.unpack) n
+  ok = all isLower . take 1 . Text.unpack

--- a/unison-src/transcripts/find-by-type.md
+++ b/unison-src/transcripts/find-by-type.md
@@ -1,0 +1,57 @@
+##### Find by type support
+
+`find : a -> b` should find the `bug` and `todo` functions.
+
+```ucm
+.> find : a -> b
+```
+
+`find : b -> a` should also find the `bug` and `todo` functions.
+
+```ucm
+.> find : b -> a
+```
+
+```unison:hide:all
+foldl : (b ->{𝕖} a ->{𝕖} b) -> b -> [a] ->{𝕖} b
+foldl f b as =
+  go b i =
+    case List.at i as of
+      None -> b
+      Some a ->
+        use Nat +
+        go (f b a) (i + 1)
+  go b 0
+```
+
+```ucm:hide
+.> add
+```
+
+`foldl` should be found if `a` and `b` are swapped.
+
+```ucm
+.> find : (b -> a -> b) -> b -> [a] -> b
+```
+
+```ucm
+.> find : (a -> b -> a) -> a -> [b] -> a
+```
+
+```unison:hide:all
+flip: (a -> b -> c) -> b -> a -> c
+flip f b a = f a b
+```
+
+```ucm:hide
+.> add
+```
+
+The `flip` function should be found regardless of the naming of the types.
+
+```ucm
+.> find : (a -> b -> c) -> (b -> a -> c)
+.> find : (b -> a -> c) -> (a -> b -> c)
+.> find : (c -> b -> a) -> (b -> c -> a)
+.> find : (d -> e -> f) -> (e -> d -> f)
+```

--- a/unison-src/transcripts/find-by-type.output.md
+++ b/unison-src/transcripts/find-by-type.output.md
@@ -1,0 +1,62 @@
+##### Find by type support
+
+`find : a -> b` should find the `bug` and `todo` functions.
+
+```ucm
+.> find : a -> b
+
+  1. builtin.bug : a -> b
+  2. builtin.todo : a -> b
+  
+
+```
+`find : b -> a` should also find the `bug` and `todo` functions.
+
+```ucm
+.> find : b -> a
+
+  1. builtin.bug : a -> b
+  2. builtin.todo : a -> b
+  
+
+```
+`foldl` should be found if `a` and `b` are swapped.
+
+```ucm
+.> find : (b -> a -> b) -> b -> [a] -> b
+
+  1. foldl : (b ->{𝕖} a ->{𝕖} b) -> b -> [a] ->{𝕖} b
+  
+
+```
+```ucm
+.> find : (a -> b -> a) -> a -> [b] -> a
+
+  1. foldl : (b ->{𝕖} a ->{𝕖} b) -> b -> [a] ->{𝕖} b
+  
+
+```
+The `flip` function should be found regardless of the naming of the types.
+
+```ucm
+.> find : (a -> b -> c) -> (b -> a -> c)
+
+  1. flip : (a ->{𝕖} b ->{𝕖} c) -> b -> a ->{𝕖} c
+  
+
+.> find : (b -> a -> c) -> (a -> b -> c)
+
+  1. flip : (a ->{𝕖} b ->{𝕖} c) -> b -> a ->{𝕖} c
+  
+
+.> find : (c -> b -> a) -> (b -> c -> a)
+
+  1. flip : (a ->{𝕖} b ->{𝕖} c) -> b -> a ->{𝕖} c
+  
+
+.> find : (d -> e -> f) -> (e -> d -> f)
+
+  1. flip : (a ->{𝕖} b ->{𝕖} c) -> b -> a ->{𝕖} c
+  
+
+```


### PR DESCRIPTION
1. my editor seems to have picked up a number of trailing whitespaces and removed them :man_facepalming: 
2. `unison-core/src/Unison/Type.hs` has a local definition of `freeVars` which is calling ABT.freeVars, so I removed the `ABT.` part
3. I have added a transcript that shows that `find` does indeed work as expected, if `generalizeLowercase` respects the ordering of the Term that contains the `freeVars` set.

However I doubt my fix is actually sound: ideally `freeVars` should be an `Ordered.Set` so that it respects the order of free variable in the Arrow in this instance. :thinking: 