### PR TITLE
replace auto-derived Ord HQ instance which had ordered `z` before `a#x`

### DIFF
--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -28,7 +28,7 @@ import qualified Unison.Codebase.Editor.Output.BranchDiff as OBD
 import           Control.Lens
 import qualified Control.Monad.State.Strict    as State
 import           Data.Bifunctor                (bimap, first)
-import           Data.List                     (sortOn, stripPrefix)
+import           Data.List                     (sort, sortOn, stripPrefix)
 import           Data.List.Extra               (nubOrdOn, nubOrd)
 import           Data.ListLike                 (ListLike)
 import qualified Data.Map                      as Map
@@ -1741,7 +1741,7 @@ prettyDiff diff = let
                        , not $ R.memberRan r (Names.terms0 removes) ]
   addedTypes = [ (n,r) | (n,r) <- R.toList (Names.types0 adds)
                        , not $ R.memberRan r (Names.types0 removes) ]
-  added = HQ'.sort (hqTerms ++ hqTypes)
+  added = sort (hqTerms ++ hqTypes)
     where
       hqTerms = [ Names.hqName adds n (Right r) | (n, r) <- addedTerms ]
       hqTypes = [ Names.hqName adds n (Left r)  | (n, r) <- addedTypes ]
@@ -1754,7 +1754,7 @@ prettyDiff diff = let
                          , not $ R.memberRan r (Names.types0 adds)
                          , Set.notMember n addedTypesSet ] where
     addedTypesSet = Set.fromList (map fst addedTypes)
-  removed = HQ'.sort (hqTerms ++ hqTypes)
+  removed = sort (hqTerms ++ hqTypes)
     where
       hqTerms = [ Names.hqName removes n (Right r) | (n, r) <- removedTerms ]
       hqTypes = [ Names.hqName removes n (Left r)  | (n, r) <- removedTypes ]

--- a/unison-core/src/Unison/HashQualified'.hs
+++ b/unison-core/src/Unison/HashQualified'.hs
@@ -18,7 +18,7 @@ import qualified Unison.ShortHash              as SH
 import qualified Unison.HashQualified          as HQ
 
 data HashQualified' n = NameOnly n | HashQualified n ShortHash
-  deriving (Eq, Ord, Functor)
+  deriving (Eq, Functor)
 
 type HashQualified = HashQualified' Name
 
@@ -106,16 +106,10 @@ requalify hq r = case hq of
   NameOnly n        -> fromNamedReferent n r
   HashQualified n _ -> fromNamedReferent n r
 
--- | Sort a list of hash-qualified names first by name, then if those match, by
--- hash.
-sort :: [HashQualified] -> [HashQualified]
-sort =
-  Name.sortNamed' toName $ \hq1 hq2 ->
-    case (hq1, hq2) of
-      (NameOnly{}, HashQualified{}) -> LT
-      (NameOnly{}, NameOnly{}) -> EQ
-      (HashQualified{}, NameOnly{}) -> GT
-      (HashQualified _ h1, HashQualified _ h2) -> compare h1 h2
+instance Ord n => Ord (HashQualified' n) where
+  compare a b = case compare (toName a) (toName b) of
+    EQ -> compare (toHash a) (toHash b)
+    o -> o
 
 instance IsString HashQualified where
   fromString = unsafeFromText . Text.pack

--- a/unison-core/src/Unison/HashQualified.hs
+++ b/unison-core/src/Unison/HashQualified.hs
@@ -22,7 +22,7 @@ import qualified Unison.Var                    as Var
 
 data HashQualified' n
   = NameOnly n | HashOnly ShortHash | HashQualified n ShortHash
-  deriving (Eq, Ord, Functor, Show)
+  deriving (Eq, Functor, Show)
 
 type HashQualified = HashQualified' Name
 
@@ -60,7 +60,7 @@ hasName, hasHash :: HashQualified -> Bool
 hasName = isJust . toName
 hasHash = isJust . toHash
 
-toHash :: HashQualified -> Maybe ShortHash
+toHash :: HashQualified' n -> Maybe ShortHash
 toHash = \case
   NameOnly _         -> Nothing
   HashQualified _ sh -> Just sh
@@ -158,6 +158,13 @@ requalify hq r = case hq of
   NameOnly n        -> fromNamedReferent n r
   HashQualified n _ -> fromNamedReferent n r
   HashOnly _        -> fromReferent r
+
+-- this implementation shows HashOnly before the others, because None < Some. 
+-- Flip it around carefully if HashOnly should come last.
+instance Ord n => Ord (HashQualified' n) where
+  compare a b = case compare (toName a) (toName b) of
+    EQ -> compare (toHash a) (toHash b)
+    o -> o
 
 --instance Show n => Show (HashQualified' n) where
 --  show = Text.unpack . toText

--- a/unison-src/transcripts/delete.output.md
+++ b/unison-src/transcripts/delete.output.md
@@ -131,8 +131,8 @@ I can force my delete through by re-issuing the command.
   Name changes:
   
     Original               Changes
-    2. b.foo            ┐  3. a.foo#0ja1qfpej6 (removed)
-    4. a.foo#0ja1qfpej6 ┘  
+    2. a.foo#0ja1qfpej6 ┐  3. a.foo#0ja1qfpej6 (removed)
+    4. b.foo            ┘  
   
   Tip: You can use `undo` or `reflog` to undo this change.
 
@@ -219,8 +219,8 @@ type Foo = Foo Boolean
   Name changes:
   
     Original               Changes
-    2. b.Foo            ┐  3. a.Foo#gq9inhvg9h (removed)
-    4. a.Foo#gq9inhvg9h ┘  
+    2. a.Foo#gq9inhvg9h ┐  3. a.Foo#gq9inhvg9h (removed)
+    4. b.Foo            ┘  
   
   Tip: You can use `undo` or `reflog` to undo this change.
 
@@ -252,8 +252,8 @@ type Foo = Foo Boolean
   Name changes:
   
     Original                     Changes
-    2. b.Foo.Foo              ┐  3. a.Foo.Foo#gq9inhvg9h#0 (removed)
-    4. a.Foo.Foo#gq9inhvg9h#0 ┘  
+    2. a.Foo.Foo#gq9inhvg9h#0 ┐  3. a.Foo.Foo#gq9inhvg9h#0 (removed)
+    4. b.Foo.Foo              ┘  
   
   Tip: You can use `undo` or `reflog` to undo this change.
 

--- a/unison-src/transcripts/diff.output.md
+++ b/unison-src/transcripts/diff.output.md
@@ -66,8 +66,8 @@ fslkdjflskdjflksjdf = 663
   Name changes:
   
     Original                             Changes
-    4. x                              ┐  5. abc (added)
-    6. fslkdjflskdjflksjdf#4kipsv2tm6 ┘  7. fslkdjflskdjflksjdf (added)
+    4. fslkdjflskdjflksjdf#4kipsv2tm6 ┐  5. abc (added)
+    6. x                              ┘  7. fslkdjflskdjflksjdf (added)
                                          8. fslkdjflskdjflksjdf#4kipsv2tm6 (removed)
 
 ```


### PR DESCRIPTION
This PR replaces the auto-derived `Ord (HashQualified n)` instance which had ordered `z` before `a#x`. 

Possibly controversial: The new Ord HQ instance does order `#x` before `a#a`, though, because it had a simpler implementation and wasn't obviously worse than `#x` after `a#a`.

This also deletes a crazy `HQ.sort` function which claimed to sort by name, but actually ignored names and other constructor parameters.