### PR TITLE
Remove dead prettyAliases function

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -37,3 +37,4 @@ The format for this list: name, GitHub handle, and then optional blurb about wha
 * Aaron Novstrup (@anovstrup)
 * Pete Tsamouris (@pete-ts)
 * Ian Davidson (@bontaq)
+* Moses Alexander (@moses-alexander)

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -1121,13 +1121,6 @@ prettyTypeResultHeaderFull' (SR'.TypeResult' (HQ'.toHQ -> name) dt r (Set.map HQ
            (name : toList aliases)
     where greyHash = styleHashQualified' id P.hiBlack
 
-
--- todo: maybe delete this
-prettyAliases ::
-  (Foldable t, ListLike s Char, IsString s) => t HQ.HashQualified -> P.Pretty s
-prettyAliases aliases = if length aliases < 2 then mempty else error "todo"
-  -- (P.commented . (:[]) . P.wrap . P.commas . fmap prettyHashQualified' . toList) aliases <> P.newline
-
 prettyDeclTriple :: Var v =>
   (HQ.HashQualified, Reference.Reference, DisplayThing (DD.Decl v a))
   -> Pretty


### PR DESCRIPTION
hey, saw that there was a 'todo' to remove this function. `grep`d for any other instances of `prettyAliases` in the codebase and found none.