### PR TITLE
allow `add`/`update` to create aliases

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -2098,7 +2098,7 @@ toSlurpResult currentPath uf existingNames =
     terms = R.intersection (Names.terms existingNames) (Names.terms fileNames0)
     types = R.intersection (Names.types existingNames) (Names.types fileNames0)
 
-  -- update (n,r) if (n,r' /= r) exists in names0 and r, r' are Ref
+  -- update (n,r) if (n,r' /= r) exists in existingNames and r, r' are Ref
   updates :: SlurpComponent v
   updates = SlurpComponent (Set.fromList types) (Set.fromList terms) where
     terms =
@@ -2149,7 +2149,7 @@ toSlurpResult currentPath uf existingNames =
                              (R.mapRan (Referent.Ref) $ Names.types fileNames0)
                              (SC.types dups)
 
-  -- add (n,r) if n doesn't exist and r doesn't exist in names0
+  -- (n,r) is in `adds` if n isn't in existingNames
   adds = sc terms types where
     terms = addTerms (Names.terms existingNames) (Names.terms fileNames0)
     types = addTypes (Names.types existingNames) (Names.types fileNames0)

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -2103,15 +2103,13 @@ toSlurpResult currentPath uf existingNames =
   updates = SlurpComponent (Set.fromList types) (Set.fromList terms) where
     terms =
       [ var n
-      | (n, r'@Referent.Ref{}) <- R.toList (Names.terms fileNames0)
-      , [r@Referent.Ref{}]     <- [toList $ Names.termsNamed existingNames n]
-      , r' /= r
+      | (n, Referent.Ref{}) <- R.toList (Names.terms fileNames0)
+      , [Referent.Ref{}]     <- [toList $ Names.termsNamed existingNames n]
       ]
     types =
       [ var n
-      | (n, r') <- R.toList (Names.types fileNames0)
-      , [r]     <- [toList $ Names.typesNamed existingNames n]
-      , r' /= r
+      | (n, _) <- R.toList (Names.types fileNames0)
+      , [_]    <- [toList $ Names.typesNamed existingNames n]
       ]
 
   -- alias (n, r) if (n' /= n, r) exists in names0
@@ -2152,14 +2150,10 @@ toSlurpResult currentPath uf existingNames =
     terms = addTerms (Names.terms existingNames) (Names.terms fileNames0)
     types = addTypes (Names.types existingNames) (Names.types fileNames0)
     addTerms existingNames = R.filter go where
-      go (n, r@Referent.Ref{}) = (not . R.memberDom n) existingNames
-                              && (not . R.memberRan r) existingNames
+      go (n, Referent.Ref{}) = (not . R.memberDom n) existingNames
       go _ = False
     addTypes existingNames = R.filter go where
-      go (n, r) = (not . R.memberDom n) existingNames
-               && (not . R.memberRan r) existingNames
-
-
+      go (n, _) = (not . R.memberDom n) existingNames
 
 filterBySlurpResult :: Ord v
            => SlurpResult v

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -2112,7 +2112,8 @@ toSlurpResult currentPath uf existingNames =
       , [_]    <- [toList $ Names.typesNamed existingNames n]
       ]
 
-  -- alias (n, r) if (n' /= n, r) exists in names0
+  -- alias (n, r) if (n', r) exists in names0
+  -- the `NameExists` field is True if `n == n'`
   termAliases :: Map v (NameExists, Set Name)
   termAliases = Map.fromList
     [ (var n, (isExistingName, aliases))

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -2118,15 +2118,13 @@ toSlurpResult currentPath uf existingNames =
   termAliases = Map.fromList
     [ (var n, (isExistingName, aliases))
     | (n, r@Referent.Ref{}) <- R.toList $ Names.terms fileNames0
-    , aliases               <-
-      [ Set.map (Path.unprefixName currentPath) . Set.delete n $ R.lookupRan
-          r
-          (Names.terms existingNames)
-      ]
+    , let aliases =
+            Set.map (Path.unprefixName currentPath) . Set.delete n $ R.lookupRan
+              r
+              (Names.terms existingNames)
     , not (null aliases)
-    , let v = var n
-    , let isExistingName =
-            NameExists . R.memberDom n $ Names.terms existingNames
+    , let v              = var n
+    , let isExistingName = NameExists . R.memberDom n $ Names.terms existingNames
     , Set.notMember v (SC.terms dups)
     ]
 
@@ -2422,8 +2420,8 @@ makeHistoricalParsingNames lexedHQs = do
 basicParseNames0, basicPrettyPrintNames0, slurpResultNames0 :: Functor m => Action' m v Names0
 basicParseNames0 = fst <$> basicNames0'
 basicPrettyPrintNames0 = snd <$> basicNames0'
--- we check the file against everything we can reference during parsing
-slurpResultNames0 = basicParseNames0
+-- we check the file against everything in the current path
+slurpResultNames0 = currentPathNames0
 
 currentPathNames0 :: Functor m => Action' m v Names0
 currentPathNames0 = do

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -2130,14 +2130,12 @@ toSlurpResult currentPath uf existingNames =
     , let
       refs = Set.delete r $ R.lookupDom n existingNames
       aliasesOfNew =
-        Set.map (Path.unprefixName currentPath) . Set.delete n $ R.lookupRan
-          r
-          existingNames
+        Set.map (Path.unprefixName currentPath) . Set.delete n $
+          R.lookupRan r existingNames
       aliasesOfOld =
-        Set.map (Path.unprefixName currentPath) . R.dom $ R.restrictRan
-          existingNames
-          refs
-    , not (null aliasesOfNew)
+        Set.map (Path.unprefixName currentPath) . Set.delete n . R.dom $
+          R.restrictRan existingNames refs
+    , not (null aliasesOfNew && null aliasesOfOld)
     , Set.notMember (var n) duplicates
     ]
 

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -2103,17 +2103,17 @@ toSlurpResult currentPath uf existingNames =
   updates = SlurpComponent (Set.fromList types) (Set.fromList terms) where
     terms =
       [ var n
-      | (n, Referent.Ref{}) <- R.toList (Names.terms fileNames0)
-      , [Referent.Ref{}]     <- [toList $ Names.termsNamed existingNames n]
+      | (n, r'@Referent.Ref{}) <- R.toList (Names.terms fileNames0)
+      , [r@Referent.Ref{}]     <- [toList $ Names.termsNamed existingNames n]
+      , r' /= r
       ]
     types =
       [ var n
-      | (n, _) <- R.toList (Names.types fileNames0)
-      , [_]    <- [toList $ Names.typesNamed existingNames n]
+      | (n, r') <- R.toList (Names.types fileNames0)
+      , [r]     <- [toList $ Names.typesNamed existingNames n]
+      , r' /= r
       ]
 
-  -- alias (n, r) if (n', r) exists in names0
-  -- the `NameExists` field is True if `n == n'`
   termAliases :: Map v (NameExists, Set Name)
   termAliases = Map.fromList
     [ (var n, (isExistingName, aliases))

--- a/parser-typechecker/src/Unison/Codebase/Editor/SlurpResult.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/SlurpResult.hs
@@ -168,11 +168,6 @@ pretty
 pretty isPast ppe sr =
   let
     tms      = UF.hashTerms (originalFile sr)
-    --termAlias', typeAlias' :: [v]
-    --termAlias' =
-    --filter (`Set.notMember` (terms $ duplicates sr)) (Map.keys (termAlias sr))
-    --typeAlias' =
-    --  filter (`Set.notMember` (types $ duplicates sr)) (Map.keys (typeAlias sr))
     goodIcon = P.green "⍟ "
     badIcon  = P.red "x "
     plus     = P.green "  "
@@ -183,7 +178,7 @@ pretty isPast ppe sr =
         P.syntaxToColor (DeclPrinter.prettyDeclHeader (HQ.unsafeFromVar v) dd)
           <> aliases       where
         aliases = case Map.lookup v (typeAlias sr) of
-          Nothing -> ""
+          Nothing      -> ""
           Just (_, ns) -> P.newline <> P.indentN
             2
             (P.wrap
@@ -253,7 +248,7 @@ pretty isPast ppe sr =
            where
             lhs = case Map.lookup v (termAlias sr) of
               Nothing -> P.bold (P.text $ Var.name v)
-              Just ns ->
+              Just (_, ns) ->
                 P.sep ", " (P.bold (prettyVar v) : (P.shown <$> toList ns))
           Nothing -> (prettyStatus status, P.text (Var.name v), "")
         termMsgs =
@@ -302,23 +297,16 @@ pretty isPast ppe sr =
                                          " "
                                          (P.hiBlack . prettyVar <$> dups)
                  )
-      , oks
-        (P.green "I've added these definitions:")
-        (P.green "These new definitions are ok to `add`:")
-        (  adds sr
-        <> aliasToTermComponent (NameExists False) (termAlias sr)
-        <> aliasToTypeComponent (NameExists False) (typeAlias sr)
-        )
+      , oks (P.green "I've added these definitions:")
+            (P.green "These new definitions are ok to `add`:")
+            (adds sr)
       , oks
         (P.green "I've updated to these definitions:")
         (P.green
         $ "These new definitions will replace existing ones of the same name and "
         <> "are ok to `update`:"
         )
-        (  updates sr
-        <> aliasToTermComponent (NameExists True) (termAlias sr)
-        <> aliasToTypeComponent (NameExists True) (typeAlias sr)
-        )
+        (updates sr)
       , notOks
         (P.red "These definitions failed:")
         (P.wrap $ P.red "These definitions would fail on `add` or `update`:")

--- a/parser-typechecker/src/Unison/Codebase/Editor/SlurpResult.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/SlurpResult.hs
@@ -125,7 +125,7 @@ isNonempty :: Ord v => SlurpResult v -> Bool
 isNonempty s = Monoid.nonEmpty (adds s) || Monoid.nonEmpty (updates s)
 
 data Status =
-  Add | Update | Duplicate | Alias | Collision | Conflicted |
+  Add | Update | Duplicate | Collision | Conflicted |
   TermExistingConstructorCollision | ConstructorExistingTermCollision |
   ExtraDefinition | BlockedDependency
   deriving (Ord,Eq,Show)
@@ -150,7 +150,6 @@ prettyStatus s = case s of
   ConstructorExistingTermCollision -> "ctor/term collision"
   BlockedDependency                -> "blocked"
   ExtraDefinition                  -> "extra dependency"
-  Alias                            -> "created alias"
 
 type IsPastTense = Bool
 

--- a/parser-typechecker/src/Unison/Codebase/Editor/SlurpResult.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/SlurpResult.hs
@@ -177,8 +177,6 @@ pretty isPast ppe sr =
       P.oxfordCommasWith end $ (P.shown <$> shown) ++ case sz of
         0 -> []
         n -> [P.shown n <> " more"]
-    -- TODO: This is not rendering the way we want or expect.
-    -- Indentation doesn't work correctly in columns. Suspect a bug in Pretty.
     okType v = (plus <>) $ case UF.lookupDecl v (originalFile sr) of
       Just (_, dd) ->
         P.syntaxToColor (DeclPrinter.prettyDeclHeader (HQ.unsafeFromVar v) dd)

--- a/parser-typechecker/src/Unison/Codebase/Editor/SlurpResult.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/SlurpResult.hs
@@ -313,7 +313,7 @@ pretty isPast ppe sr =
       , oks
         (P.green "I've updated to these definitions:")
         (P.green
-        $ "These names will be redefined to match "
+        $ "These new definitions will replace existing ones of the same name and "
         <> "are ok to `update`:"
         )
         (updates sr)

--- a/parser-typechecker/src/Unison/Codebase/Editor/SlurpResult.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/SlurpResult.hs
@@ -186,10 +186,10 @@ pretty isPast ppe sr =
               (P.wrap
                 (  P.hiBlack "(also named "
                 <> P.oxfordCommas
-                     ((P.shown <$> shown) ++ map
-                       (const (P.shown (length rest) <> " more"))
-                       (take 1 rest)
-                     )
+                     ((P.shown <$> shown) ++
+                       case length rest of
+                         0 -> []
+                         n -> [P.shown n <> " more"])
                 <> P.hiBlack ")"
                 )
               )
@@ -313,7 +313,7 @@ pretty isPast ppe sr =
       , oks
         (P.green "I've updated to these definitions:")
         (P.green
-        $ "These new definitions will replace existing ones of the same name and "
+        $ "These names will be redefined to match "
         <> "are ok to `update`:"
         )
         (updates sr)

--- a/parser-typechecker/src/Unison/Codebase/Editor/SlurpResult.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/SlurpResult.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -178,15 +179,20 @@ pretty isPast ppe sr =
         P.syntaxToColor (DeclPrinter.prettyDeclHeader (HQ.unsafeFromVar v) dd)
           <> aliases       where
         aliases = case Map.lookup v (typeAlias sr) of
-          Nothing      -> ""
-          Just (_, ns) -> P.newline <> P.indentN
-            2
-            (P.wrap
-              (  P.hiBlack "(also named "
-              <> P.oxfordCommas (P.shown <$> toList ns)
-              <> P.hiBlack ")"
+          Nothing -> ""
+          Just (_, splitAt 5 . toList -> (shown, rest)) ->
+            P.newline <> P.indentN
+              2
+              (P.wrap
+                (  P.hiBlack "(also named "
+                <> P.oxfordCommas
+                     ((P.shown <$> shown) ++ map
+                       (const (P.shown (length rest) <> " more"))
+                       (take 1 rest)
+                     )
+                <> P.hiBlack ")"
+                )
               )
-            )
       Nothing -> P.bold (prettyVar v) <> P.red " (Unison bug, unknown type)"
     okTerm :: v -> [(P.Pretty P.ColorText, Maybe (P.Pretty P.ColorText))]
     okTerm v = case Map.lookup v tms of
@@ -200,10 +206,14 @@ pretty isPast ppe sr =
        where
         aliases = case Map.lookup v (termAlias sr) of
           Nothing -> []
-          Just (_, ns) ->
+          Just (_, splitAt 5 . toList -> (shown, rest)) ->
             [ ( P.indentN 2
                 $  P.hiBlack "(also named "
-                <> P.oxfordCommas (P.shown <$> toList ns)
+                <> P.oxfordCommas
+                     ((P.shown <$> shown) ++ map
+                       (const (P.shown (length rest) <> " more"))
+                       (take 1 rest)
+                     )
                 <> P.hiBlack ")"
               , Nothing
               )

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -912,11 +912,6 @@ helpTopicsMap = Map.fromList [
        "same as an existing term. Rename that term or your constructor" <>
        "before trying again to `add` or `update`."),
       blankline,
-      (P.bold $ SR.prettyStatus SR.Alias,
-       "A definition in the file already has another name." <>
-       "You can use the `alias.term` or `alias.type` commands" <>
-       "to create new names for existing definitions."),
-      blankline,
       (P.bold $ SR.prettyStatus SR.BlockedDependency,
        "This definition was blocked because it dependended on " <>
        "a definition with a failed status."),

--- a/parser-typechecker/src/Unison/Util/Pretty.hs
+++ b/parser-typechecker/src/Unison/Util/Pretty.hs
@@ -313,8 +313,8 @@ oxfordCommasWith
   :: (Foldable f, IsString s) => Pretty s -> f (Pretty s) -> Pretty s
 oxfordCommasWith end xs = case toList xs of
   []     -> ""
-  [x]    -> x
-  [x, y] -> x <> " and " <> y
+  [x]    -> group (x <> end)
+  [x, y] -> x <> " and " <> group (y <> end)
   xs ->
     intercalateMap ("," <> softbreak) id (init xs)
       <> ","

--- a/parser-typechecker/src/Unison/Util/Pretty.hs
+++ b/parser-typechecker/src/Unison/Util/Pretty.hs
@@ -35,6 +35,7 @@ module Unison.Util.Pretty (
    commas,
    commented,
    oxfordCommas,
+   oxfordCommasWith,
    plural,
    dashed,
    flatMap,
@@ -304,7 +305,13 @@ commas :: (Foldable f, IsString s) => f (Pretty s) -> Pretty s
 commas = intercalateMap ("," <> softbreak) id
 
 oxfordCommas :: (Foldable f, IsString s) => f (Pretty s) -> Pretty s
-oxfordCommas xs = case toList xs of
+oxfordCommas = oxfordCommasWith ""
+
+-- Like `oxfordCommas`, but attaches `end` at the end (without a space).
+-- For example, `oxfordCommasWith "."` will attach a period.
+oxfordCommasWith
+  :: (Foldable f, IsString s) => Pretty s -> f (Pretty s) -> Pretty s
+oxfordCommasWith end xs = case toList xs of
   []     -> ""
   [x]    -> x
   [x, y] -> x <> " and " <> y
@@ -314,7 +321,7 @@ oxfordCommas xs = case toList xs of
       <> softbreak
       <> "and"
       <> softbreak
-      <> last xs
+      <> group (last xs <> end)
 
 parenthesizeCommas :: (Foldable f, IsString s) => f (Pretty s) -> Pretty s
 parenthesizeCommas = surroundCommas "(" ")"

--- a/unison-src/transcripts/addupdatemessages.md
+++ b/unison-src/transcripts/addupdatemessages.md
@@ -2,24 +2,34 @@
 
 Let's set up some definitions to start:
 
+```ucm:hide
+.> builtins.merge
+```
+
 ```unison
 x = 1
 y = 2
+
+type X = One Nat
+type Y = Two Nat Nat
 ```
 
-Expected: `x` and `y` exist as above. UCM tells you this.
+Expected: `x` and `y`, `X`, and `Y` exist as above. UCM tells you this.
 
 ```ucm
 .scratch> add
 ```
 
-Let's add an alias for `1`:
+Let's add an alias for `1` and `One`:
 
 ```unison
 z = 1
+
+type Z = One Nat
 ```
 
 Expected: `z` is now `1`. UCM tells you that this definition is also called `x`.
+Also, `Z` is an alias for `X`.
 
 ```ucm
 .scratch> add
@@ -29,9 +39,10 @@ Let's update something that has an alias (to a value that doesn't have a name al
 
 ```unison
 x = 3
+type X = Three Nat Nat Nat
 ```
 
-Expected: `x` is now `3`. UCM tells you the old definition was also called `z` and this name has also been updated.
+Expected: `x` is now `3` and `X` has constructor `Three`. UCM tells you the old definitions were also called `z` and `Z` and these names have also been updated.
 
 ```ucm
 .scratch> update
@@ -41,9 +52,10 @@ Update it to something that already exists with a different name:
 
 ```unison
 x = 2
+type X = Two Nat Nat
 ```
 
-Expected: `x` is now `2`. UCM says the old definition was also named `z`, and was also updated. And it says the new definition is also named `y`. 
+Expected: `x` is now `2` and `X` is `Two`. UCM says the old definition was also named `z/Z`, and was also updated. And it says the new definition is also named `y/Y`. 
 
 ```ucm
 .scratch> update

--- a/unison-src/transcripts/addupdatemessages.md
+++ b/unison-src/transcripts/addupdatemessages.md
@@ -1,0 +1,51 @@
+# Adds and updates
+
+Let's set up some definitions to start:
+
+```unison
+x = 1
+y = 2
+```
+
+Expected: `x` and `y` exist as above. UCM tells you this.
+
+```ucm
+.scratch> add
+```
+
+Let's add an alias for `1`:
+
+```unison
+z = 1
+```
+
+Expected: `z` is now `1`. UCM tells you that this definition is also called `x`.
+
+```ucm
+.scratch> add
+```
+
+Let's update something that has an alias (to a value that doesn't have a name already):
+
+```unison
+x = 3
+```
+
+Expected: `x` is now `3`. UCM tells you the old definition was also called `z` and this name has also been updated.
+
+```ucm
+.scratch> update
+```
+
+Update it to something that already exists with a different name:
+
+```unison
+x = 2
+```
+
+Expected: `x` is now `2`. UCM says the old definition was also named `z`, and was also updated. And it says the new definition is also named `y`. 
+
+```ucm
+.scratch> update
+```
+

--- a/unison-src/transcripts/addupdatemessages.output.md
+++ b/unison-src/transcripts/addupdatemessages.output.md
@@ -1,0 +1,171 @@
+# Adds and updates
+
+Let's set up some definitions to start:
+
+```unison
+x = 1
+y = 2
+
+type X = One Nat
+type Y = Two Nat Nat
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      type X
+      type Y
+      x : Nat
+      y : Nat
+   
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+```
+Expected: `x` and `y`, `X`, and `Y` exist as above. UCM tells you this.
+
+```ucm
+  ☝️  The namespace .scratch is empty.
+
+.scratch> add
+
+  ⍟ I've added these definitions:
+  
+    type X
+    type Y
+    x : Nat
+    y : Nat
+
+```
+Let's add an alias for `1` and `One`:
+
+```unison
+z = 1
+
+type Z = One Nat
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      type Z
+        (also named X)
+      z : Nat
+        (also named x)
+   
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+```
+Expected: `z` is now `1`. UCM tells you that this definition is also called `x`.
+Also, `Z` is an alias for `X`.
+
+```ucm
+.scratch> add
+
+  ⍟ I've added these definitions:
+  
+    type Z
+      (also named X)
+    z : Nat
+      (also named x)
+
+```
+Let's update something that has an alias (to a value that doesn't have a name already):
+
+```unison
+x = 3
+type X = Three Nat Nat Nat
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      type X
+        (The old definition is also named Z. I'll update this
+        name too.)
+      x : Nat
+        (The old definition is also named z. I'll update this
+        name too.)
+   
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+```
+Expected: `x` is now `3` and `X` has constructor `Three`. UCM tells you the old definitions were also called `z` and `Z` and these names have also been updated.
+
+```ucm
+.scratch> update
+
+  ⍟ I've updated these names to your new definition:
+  
+    type X
+      (The old definition was also named Z. I updated this name
+      too.)
+    x : .builtin.Nat
+      (The old definition was also named z. I updated this name
+      too.)
+
+```
+Update it to something that already exists with a different name:
+
+```unison
+x = 2
+type X = Two Nat Nat
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      type X
+        (The old definition is also named Z. I'll update this
+        name too.)
+        (The new definition is already named Y as well.)
+      x : Nat
+        (The old definition is also named z. I'll update this
+        name too.)
+        (The new definition is already named y as well.)
+   
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+```
+Expected: `x` is now `2` and `X` is `Two`. UCM says the old definition was also named `z/Z`, and was also updated. And it says the new definition is also named `y/Y`. 
+
+```ucm
+.scratch> update
+
+  ⍟ I've updated these names to your new definition:
+  
+    type X
+      (The old definition was also named Z. I updated this name
+      too.)
+      (The new definition is already named Y as well.)
+    x : .builtin.Nat
+      (The old definition was also named z. I updated this name
+      too.)
+      (The new definition is already named y as well.)
+
+```

--- a/unison-src/transcripts/diff.output.md
+++ b/unison-src/transcripts/diff.output.md
@@ -209,6 +209,8 @@ unique type Y a b = Y a b
   
     b        : .builtin.Text
     fromJust : .builtin.Nat
+      (The old definition was also named fromJust'. I updated
+      this name too.)
 
 .ns2> links fromJust
 

--- a/unison-src/transcripts/diff.output.md
+++ b/unison-src/transcripts/diff.output.md
@@ -205,7 +205,7 @@ unique type Y a b = Y a b
     e : .builtin.Nat
     f : .builtin.Nat
   
-  ⍟ I've updated to these definitions:
+  ⍟ I've updated these names to your new definition:
   
     b        : .builtin.Text
     fromJust : .builtin.Nat
@@ -460,7 +460,7 @@ bdependent = "banana"
 ```ucm
 .ns3> update
 
-  ⍟ I've updated to these definitions:
+  ⍟ I've updated these names to your new definition:
   
     bdependent : .builtin.Text
 
@@ -515,7 +515,7 @@ a = 444
 ```ucm
 .nsy> update
 
-  ⍟ I've updated to these definitions:
+  ⍟ I've updated these names to your new definition:
   
     a : .builtin.Nat
 
@@ -527,7 +527,7 @@ a = 555
 ```ucm
 .nsz> update
 
-  ⍟ I've updated to these definitions:
+  ⍟ I've updated these names to your new definition:
   
     a : .builtin.Nat
 

--- a/unison-src/transcripts/find-patch.output.md
+++ b/unison-src/transcripts/find-patch.output.md
@@ -46,8 +46,8 @@ hey = "hello"
   I found and typechecked these definitions in test.u. If you do
   an `add` or `update`, here's how your codebase would change:
   
-    ⍟ These new definitions will replace existing ones of the
-      same name and are ok to `update`:
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
     
       hey : Text
    
@@ -60,7 +60,7 @@ Update
 ```ucm
 .> update
 
-  ⍟ I've updated to these definitions:
+  ⍟ I've updated these names to your new definition:
   
     hey : builtin.Text
 

--- a/unison-src/transcripts/fix942.output.md
+++ b/unison-src/transcripts/fix942.output.md
@@ -44,8 +44,8 @@ x = 7
   do an `add` or `update`, here's how your codebase would
   change:
   
-    ⍟ These new definitions will replace existing ones of the
-      same name and are ok to `update`:
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
     
       x : Nat
    
@@ -56,7 +56,7 @@ x = 7
 ```ucm
 .> update
 
-  ⍟ I've updated to these definitions:
+  ⍟ I've updated these names to your new definition:
   
     x : builtin.Nat
 

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -392,9 +392,11 @@ master.frobnicate n = n + 1
   
     master.frobnicate : builtin.Nat -> builtin.Nat
   
-  ⍟ I've updated to these definitions:
+  ⍟ I've updated these names to your new definition:
   
     master.y : builtin.Text
+      (The old definition was also named feature2.y. I updated
+      this name too.)
 
 .> view master.y
 

--- a/unison-src/transcripts/propagate.output.md
+++ b/unison-src/transcripts/propagate.output.md
@@ -69,8 +69,8 @@ unique type Foo = Foo | Bar
   do an `add` or `update`, here's how your codebase would
   change:
   
-    ⍟ These new definitions will replace existing ones of the
-      same name and are ok to `update`:
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
     
       unique type Foo
    
@@ -83,7 +83,7 @@ and update the codebase to use the new type `Foo`...
 ```ucm
 .subpath> update
 
-  ⍟ I've updated to these definitions:
+  ⍟ I've updated these names to your new definition:
   
     unique type Foo
 
@@ -155,8 +155,8 @@ someTerm _ = None
   do an `add` or `update`, here's how your codebase would
   change:
   
-    ⍟ These new definitions will replace existing ones of the
-      same name and are ok to `update`:
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
     
       someTerm : Optional x -> Optional x
    
@@ -169,7 +169,7 @@ Update...
 ```ucm
 .subpath.preserve> update
 
-  ⍟ I've updated to these definitions:
+  ⍟ I've updated these names to your new definition:
   
     someTerm : .builtin.Optional x -> .builtin.Optional x
 
@@ -282,7 +282,7 @@ someTerm _ = None
 ```ucm
 .subpath.one> update
 
-  ⍟ I've updated to these definitions:
+  ⍟ I've updated these names to your new definition:
   
     someTerm : .builtin.Optional x -> .builtin.Optional x
 

--- a/unison-src/transcripts/resolve.output.md
+++ b/unison-src/transcripts/resolve.output.md
@@ -70,8 +70,8 @@ foo = 43
   do an `add` or `update`, here's how your codebase would
   change:
   
-    ⍟ These new definitions will replace existing ones of the
-      same name and are ok to `update`:
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
     
       foo : Nat
    
@@ -82,7 +82,7 @@ foo = 43
 ```ucm
 .example.resolve.a> update
 
-  ⍟ I've updated to these definitions:
+  ⍟ I've updated these names to your new definition:
   
     foo : .builtin.Nat
 
@@ -103,8 +103,8 @@ foo = 44
   do an `add` or `update`, here's how your codebase would
   change:
   
-    ⍟ These new definitions will replace existing ones of the
-      same name and are ok to `update`:
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
     
       foo : Nat
    
@@ -115,7 +115,7 @@ foo = 44
 ```ucm
 .example.resolve.b> update
 
-  ⍟ I've updated to these definitions:
+  ⍟ I've updated these names to your new definition:
   
     foo : .builtin.Nat
 


### PR DESCRIPTION
### Overview

This PR allows `add` and `update` in UCM to create aliases instead of annoyingly failing with "needs alias" and asking the user to create the aliases manually.

After this PR is merged, both of these commands simply create the aliases you need, and tell you they've done so.

Before:

![image](https://user-images.githubusercontent.com/538571/75285028-2581a680-5816-11ea-8c93-76bd9c1aa541.png)

After:

![image](https://user-images.githubusercontent.com/538571/75285063-36321c80-5816-11ea-9550-2f44de31ad85.png)

Another example (couldn't get this far in `master`):
![image](https://user-images.githubusercontent.com/538571/75284816-c91e8700-5815-11ea-8806-b83f49da9993.png)

### Implementation notes

Most of the meat of this change is in `SlurpResult.hs`, the code that handles the result of saving a scratch file when working in UCM. Some changes are also in `HandleInput` where we call into `SlurpResult`.

### Controversial and interesting decisions

We made the decision that the user only really wants to get notified about aliases in the current namespace (and subnamespaces). If `foo` exists somewhere as `.my.cool.branch.2020.nov4.foo` or whatever, we thought it would just be unnecessary noise to tell you about it if you're currently in some totally unrelated location in the codebase.

### Loose ends

Tangentially related issues created in the course of this PR: #1275, #1273, #1265, #1264


- [x] Filter out aliases that are for absolute names outside the current namespace.
- [x] Do add all the (local) aliases for a name inside the current namespace. Currently only shows one of the names.
- [x] Don't count duplicates (defs already in codebase) as updates.
- [x] Don't show both `x` and `currentNamespace.x` in names.
- [x] Only show the first n aliases, where n is some small number.
- [x] Close #990? — let's try reproducing the issue in master and then checking against the PR.
- [x] Close #1004
- [x] Close #1253 
- [x] Close #1267
