### PR TITLE
Fix #1203 — useless numbers in pr.create output

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1824,7 +1824,8 @@ respond output = eval $ Notify output
 respondNumbered :: NumberedOutput v -> Action m i v ()
 respondNumbered output = do
   args <- eval $ NotifyNumbered output
-  numberedArgs .= toList args
+  unless (null args) $
+    numberedArgs .= toList args
 
 -- Merges the specified remote branch into the specified local absolute path.
 -- Implementation detail of PullRemoteBranchI

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -127,21 +127,21 @@ renderFileName dir = P.group . P.blue . fromString <$> shortenDirectory dir
 notifyNumbered :: Var v => NumberedOutput v -> (Pretty, NumberedArgs)
 notifyNumbered o = case o of
   ShowDiffNamespace oldPrefix newPrefix ppe diffOutput ->
-    showDiffNamespace ppe oldPrefix newPrefix diffOutput
+    showDiffNamespace ShowNumbers ppe oldPrefix newPrefix diffOutput
 
   ShowDiffAfterDeleteDefinitions ppe diff ->
     first (\p -> P.lines
       [ p
       , ""
       , undoTip
-      ]) (showDiffNamespace ppe e e diff)
+      ]) (showDiffNamespace ShowNumbers ppe e e diff)
 
   ShowDiffAfterDeleteBranch bAbs ppe diff ->
     first (\p -> P.lines
       [ p
       , ""
       , undoTip
-      ]) (showDiffNamespace ppe bAbs bAbs diff)
+      ]) (showDiffNamespace ShowNumbers ppe bAbs bAbs diff)
 
   ShowDiffAfterModifyBranch b' _ _ (OBD.isEmpty -> True) ->
     (P.wrap $ "Nothing changed in" <> prettyPath' b' <> ".", mempty)
@@ -152,7 +152,7 @@ notifyNumbered o = case o of
       , p
       , ""
       , undoTip
-      ]) (showDiffNamespace ppe bAbs bAbs diff)
+      ]) (showDiffNamespace ShowNumbers ppe bAbs bAbs diff)
 
   ShowDiffAfterMerge _ _ _ (OBD.isEmpty -> True) ->
     (P.wrap $ "Nothing changed as a result of the merge.", mempty)
@@ -167,7 +167,7 @@ notifyNumbered o = case o of
            <> "and " <> IP.makeExample' IP.test <> "to run the tests."
            <> "Or you can use" <> IP.makeExample' IP.undo <> " or"
            <> IP.makeExample' IP.viewReflog <> " to undo the results of this merge."
-      ]) (showDiffNamespace ppe destAbs destAbs diffOutput)
+      ]) (showDiffNamespace ShowNumbers ppe destAbs destAbs diffOutput)
 
   ShowDiffAfterMergePropagate dest' destAbs patchPath' ppe diffOutput ->
     first (\p -> P.lines [
@@ -182,18 +182,18 @@ notifyNumbered o = case o of
            <> "and " <> IP.makeExample' IP.test <> "to run the tests."
            <> "Or you can use" <> IP.makeExample' IP.undo <> " or"
            <> IP.makeExample' IP.viewReflog <> " to undo the results of this merge."
-      ]) (showDiffNamespace ppe destAbs destAbs diffOutput)
+      ]) (showDiffNamespace ShowNumbers ppe destAbs destAbs diffOutput)
 
   ShowDiffAfterMergePreview dest' destAbs ppe diffOutput ->
     first (\p -> P.lines [
       P.wrap $ "Here's what would change in " <> prettyPath' dest' <> "after the merge:"
       , ""
       , p
-      ]) (showDiffNamespace ppe destAbs destAbs diffOutput)
+      ]) (showDiffNamespace ShowNumbers ppe destAbs destAbs diffOutput)
 
   ShowDiffAfterUndo ppe diffOutput ->
     first (\p -> P.lines ["Here's the changes I undid", "", p ])
-      (showDiffNamespace ppe e e diffOutput)
+      (showDiffNamespace ShowNumbers ppe e e diffOutput)
 
   ShowDiffAfterPull dest' destAbs ppe diff ->
     if OBD.isEmpty diff then
@@ -204,7 +204,7 @@ notifyNumbered o = case o of
           p, "",
           undoTip
         ])
-        (showDiffNamespace ppe destAbs destAbs diff)
+        (showDiffNamespace ShowNumbers ppe destAbs destAbs diff)
   ShowDiffAfterCreatePR baseRepo headRepo ppe diff ->
     if OBD.isEmpty diff then
       (P.wrap $ "Looks like there's no difference between "
@@ -221,7 +221,7 @@ notifyNumbered o = case o of
           IP.makeExample IP.loadPullRequest [(prettyRemoteNamespace baseRepo)
                                             ,(prettyRemoteNamespace headRepo)]
         ,""
-        ,p])) (showDiffNamespace ppe e e diff)
+        ,p])) (showDiffNamespace HideNumbers ppe e e diff)
         -- todo: these numbers aren't going to work,
         --  since the content isn't necessarily here.
         -- Should we have a mode with no numbers? :P
@@ -1291,18 +1291,20 @@ listOfLinks ppe results = pure $ P.lines [
   prettyType Nothing = "❓ (missing a type for this definition)"
   prettyType (Just t) = TypePrinter.pretty ppe t
 
+data ShowNumbers = ShowNumbers | HideNumbers
 -- | `ppe` is just for rendering type signatures
 --   `oldPath, newPath :: Path.Absolute` are just for producing fully-qualified
 --                                       numbered args
 showDiffNamespace :: forall v . Var v
-                  => PPE.PrettyPrintEnv
+                  => ShowNumbers
+                  -> PPE.PrettyPrintEnv
                   -> Path.Absolute
                   -> Path.Absolute
                   -> OBD.BranchDiffOutput v Ann
                   -> (Pretty, NumberedArgs)
-showDiffNamespace _ _ _ diffOutput | OBD.isEmpty diffOutput =
+showDiffNamespace _ _ _ _ diffOutput | OBD.isEmpty diffOutput =
   ("The namespaces are identical.", mempty)
-showDiffNamespace ppe oldPath newPath OBD.BranchDiffOutput{..} =
+showDiffNamespace sn ppe oldPath newPath OBD.BranchDiffOutput{..} =
   (P.sepNonEmpty "\n\n" p, toList args)
   where
   (p, (menuSize, args)) = (`State.runState` (0::Int, Seq.empty)) $ sequence [
@@ -1627,10 +1629,12 @@ showDiffNamespace ppe oldPath newPath OBD.BranchDiffOutput{..} =
     hq' = HQ'.requalify (fmap (Name.makeAbsolute . Path.prefixName prefix) hq) r
 
   addNumberedArg :: String -> Numbered Pretty
-  addNumberedArg s = do
+  addNumberedArg s = case sn of
+   ShowNumbers -> do
     (n, args) <- State.get
     State.put (n+1, args Seq.|> s)
     pure $ padNumber (n+1)
+   HideNumbers -> pure mempty
 
   padNumber :: Int -> Pretty
   padNumber n = P.hiBlack . P.rightPad leftNumsWidth $ P.shown n <> "."


### PR DESCRIPTION
Fixes #1203 but I didn't spend any thinking through the other cases (e.g. #1234) but it will be easy enough to change now by switching `ShowNumbers` to `HideNumbers`, or adding the field to the `NumberedOutput` constructor if we need more fine-grained control.

Before:
```
  The changes summarized below are available for you to review, using the following command:
  
    `pr.load https://github.com/unisonweb/base https://github.com/puffnfresh/base`
  
  Added definitions:
  
    1. Either.swap      : Either a b -> Either b a
    2. Tuple.swap       : Tuple a b -> Tuple b a
    3. Weighted.eithers : Weighted a -> Weighted b -> Weighted (Either a b)
    4. Weighted.tuples  : Weighted a -> Weighted b -> Weighted (Tuple a b)

.> view 1

  ⚠️
  
  The following names were not found in the codebase. Check your spelling.
    .Either.swap#8hr15i0otmkr4npjlva0c06lgvif4qagktr9tl4cls6och8uellgtoef614rivqj9d3s27ajilc6i0b2fpu4j3ol2n4hutc0ok1727g
```

After:
```
  The changes summarized below are available for you to review, using the following command:
  
    `pr.load https://github.com/unisonweb/base https://github.com/puffnfresh/base`
  
  Added definitions:
  
     Either.swap      : Either a b -> Either b a
     Tuple.swap       : Tuple a b -> Tuple b a
     Weighted.eithers : Weighted a -> Weighted b -> Weighted (Either a b)
     Weighted.tuples  : Weighted a -> Weighted b -> Weighted (Tuple a b)
```