### PR TITLE
remove backticks from pr.load example for github issue happiness

### DIFF
--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -55,9 +55,11 @@ patternName :: InputPattern -> P.Pretty P.ColorText
 patternName = fromString . I.patternName
 
 -- `example list ["foo", "bar"]` (haskell) becomes `list foo bar` (pretty)
-makeExample :: InputPattern -> [P.Pretty CT.ColorText] -> P.Pretty CT.ColorText
-makeExample p args = P.group $
-  backtick (intercalateMap " " id (P.nonEmpty $ fromString (I.patternName p) : args))
+makeExample, makeExampleNoBackticks :: InputPattern -> [P.Pretty CT.ColorText] -> P.Pretty CT.ColorText
+makeExample p args = P.group . backtick $ makeExampleNoBackticks p args
+
+makeExampleNoBackticks p args =
+  P.group $ intercalateMap " " id (P.nonEmpty $ fromString (I.patternName p) : args)
 
 makeExample' :: InputPattern -> P.Pretty CT.ColorText
 makeExample' p = makeExample p []

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -218,8 +218,9 @@ notifyNumbered o = case o of
                  <> "using the following command:"
         ,""
         ,P.indentN 2 $
-          IP.makeExample IP.loadPullRequest [(prettyRemoteNamespace baseRepo)
-                                            ,(prettyRemoteNamespace headRepo)]
+          IP.makeExampleNoBackticks
+            IP.loadPullRequest [(prettyRemoteNamespace baseRepo)
+                               ,(prettyRemoteNamespace headRepo)]
         ,""
         ,p])) (showDiffNamespace ppe e e diff)
         -- todo: these numbers aren't going to work,


### PR DESCRIPTION
```
  The changes summarized below are available for you to review, using the following
  command:
  
    pr.load https://github.com/unisonweb/base https://github.com/puffnfresh/base
  
  Added definitions:
  
    1. Either.swap      : Either a b -> Either b a
    2. Tuple.swap       : Tuple a b -> Tuple b a
    3. Weighted.eithers : Weighted a -> Weighted b -> Weighted (Either a b)
    4. Weighted.tuples  : Weighted a -> Weighted b -> Weighted (Tuple a b)
```
Closes #1258