### PR TITLE
ignore all .unison stuff in the build dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Unison
-.unisonHistory
+.unison*
 test-output
 transcript-*
 


### PR DESCRIPTION
e.g.
`.unison`
`.unison-old`
`.unisonConfig`
`stray-transcript/.unison`

Stuff that ended up in the build dir in the past but we're scared to delete, or that we dumped here for convenience but it's not convenient.