### PR TITLE
Align the arrows when pretty-printing match cases

### DIFF
--- a/parser-typechecker/tests/Unison/Test/TermPrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/TermPrinter.hs
@@ -162,11 +162,14 @@ test = scope "termprinter" . tests $
   , tc "match x with -1 -> foo"
   , tc "match x with 3.14159 -> foo"
   , tcDiffRtt False "match x with\n\
-                      \  true -> foo\n\
+                      \  true  -> foo\n\
                       \  false -> bar"
-                      "match x with\n  true -> foo\n  false -> bar" 0
+                      "match x with\n\
+                      \  true  -> foo\n\
+                      \  false -> bar"
+                      0
   , tcBreaks 50 "match x with\n\
-                 \  true -> foo\n\
+                 \  true  -> foo\n\
                  \  false -> bar"
   , tc "match x with false -> foo"
   , tc "match x with y@() -> y"
@@ -176,9 +179,9 @@ test = scope "termprinter" . tests $
                                                  -- need an actual effect constructor to test this with
   , tc "cases x -> x"
   , tc "cases\n\
-        \  [] -> 0\n\
+        \  []  -> 0\n\
         \  [x] -> 1\n\
-        \  _ -> 2"
+        \  _   -> 2"
   , tc "if a then if b then c else d else e"
   , tc "handle handle foo with bar with baz"
   , tcBreaks 16 "match (if a then\n\
@@ -209,8 +212,8 @@ test = scope "termprinter" . tests $
                  \  13 -> y\n\
                  \  14 -> z"
   , tcBreaks 21 "match x with\n\
-                 \  12 | p x -> x\n\
-                 \  13 | q x -> y\n\
+                 \  12 | p x   -> x\n\
+                 \  13 | q x   -> y\n\
                  \  14 | r x y -> z"
   , tcBreaks 9 "match x with\n\
                 \  112 ->\n\
@@ -276,7 +279,7 @@ test = scope "termprinter" . tests $
                  \  false\n\
                  \with foo"
   , tcBreaks 50 "match x with\n\
-                 \  true ->\n\
+                 \  true  ->\n\
                  \    d = 1\n\
                  \    false\n\
                  \  false ->\n\
@@ -360,7 +363,7 @@ test = scope "termprinter" . tests $
   , tcBreaks 32 "let\n\
                  \  go acc a b =\n\
                  \    match List.at 0 a with\n\
-                 \      Optional.None -> 0\n\
+                 \      Optional.None     -> 0\n\
                  \      Optional.Some hd1 -> 0\n\
                  \  go [] a b"
   , tcBreaks 30 "match x with\n\
@@ -500,7 +503,7 @@ test = scope "termprinter" . tests $
                  \        foo\n\
                  \      with foo\n\
                  \    bar\n\
-                 \  _ ->\n\
+                 \  _  ->\n\
                  \    b =\n\
                  \      use A.C x\n\
                  \      g x x\n\


### PR DESCRIPTION
Before this change:

```haskell
eg1 x = cases
  1 -> 1
  2 | x -> 2
  3 -> 3

eg2 x = cases
  1 -> 1
  2 | x ->
    use Nat +
    2 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0
  3 -> 3
```

After this change:

```haskell
eg1 x = cases
  1     -> 1
  2 | x -> 2
  3     -> 3

eg2 x = cases
  1     -> 1
  2 | x ->
    use Nat +
    2 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0
  3     -> 3
```

If all the actual match bodies are line-broken (like the `2 | x` case above) then we still align the arrows even though it's maybe a bit weird, but I think it's OK:

```haskell
  eg2 x = cases
    1     ->
      use Nat +
      1 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0
    2 | x ->
      use Nat +
      2 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0
    3     ->
      use Nat +
      3 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0 + 0
```

Proximate cause for PR: https://twitter.com/phonytope/status/1232769219881652224 :smile: 