### PR TITLE
Fix #1276 hang on push

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Causal.hs
+++ b/parser-typechecker/src/Unison/Codebase/Causal.hs
@@ -71,6 +71,7 @@ data Causal m h e
           , tails :: Map (RawHash h) (m (Causal m h e))
           }
 
+-- Convert the Causal to an adjacency matrix for debugging purposes.
 toGraph
   :: Monad m
   => Set (RawHash h)

--- a/parser-typechecker/src/Unison/Codebase/Causal.hs
+++ b/parser-typechecker/src/Unison/Codebase/Causal.hs
@@ -164,11 +164,11 @@ instance Hashable (RawHash h) where
 -- Find the lowest common ancestor of two causals.
 lca :: Monad m => Causal m h e -> Causal m h e -> m (Maybe (Causal m h e))
 lca a b =
-  lca' (Seq.singleton $ pure a) . Seq.singleton $ pure b
+  lca' (Seq.singleton $ pure a) (Seq.singleton $ pure b)
 
--- Find the lowest common ancestor of two causal-forests.
--- The convention is that the causals in a forest are the ancestors of some
--- other Causal.
+-- `lca' xs ys` finds the lowest common ancestor of any element of `xs` and any
+-- element of `ys`.
+-- This is a breadth-first search used in the implementation of `lca a b`.
 lca'
   :: Monad m
   => Seq (m (Causal m h e))
@@ -212,18 +212,21 @@ threeWayMerge
 threeWayMerge combine = mergeInternal merge0
  where
   merge0 :: Map (RawHash h) (m (Causal m h e)) -> m (Causal m h e)
-  merge0 m =
-    let k (e, acc) new = do
-          n           <- new
-          mayAncestor <- lca' acc (Seq.singleton (pure n))
-          newHead     <- combine (head <$> mayAncestor) e (head n)
-          pure (newHead, pure n Seq.<| acc)
-    in  case Map.elems m of
-          []       -> error "Causal.threeWayMerge empty map"
-          me : mes -> do
-            e            <- me
-            (newHead, _) <- foldM k (head e, Seq.singleton (pure e)) mes
-            pure $ Merge (RawHash (hash (newHead, Map.keys m))) newHead m
+  merge0 m = case Map.elems m of
+    []       -> error "Causal.threeWayMerge empty map"
+    me : mes -> do
+      e            <- me
+      (newHead, _) <- foldM k (head e, Seq.singleton (pure e)) mes
+      pure $ Merge (RawHash (hash (newHead, Map.keys m))) newHead m
+   where
+    k (e, acc) new = do
+      n           <- new
+      -- We call `lca'` here since we don't want to merge using the n-way LCA of
+      -- all children. Note for example that some of the children might have
+      -- totally unrelated histories. We want the LCA of any two children.
+      mayAncestor <- lca' acc (Seq.singleton (pure n))
+      newHead     <- combine (head <$> mayAncestor) e (head n)
+      pure (newHead, pure n Seq.<| acc)
 
 mergeInternal
   :: forall m h e

--- a/parser-typechecker/tests/Unison/Test/Codebase/Causal.hs
+++ b/parser-typechecker/tests/Unison/Test/Codebase/Causal.hs
@@ -179,8 +179,8 @@ setPatch s (added, removed) = pure (added <> Set.difference s removed)
 
 -- merge x x == x, should not add a new head, and also the value at the head should be the same of course
 testIdempotent :: Causal Identity Hash (Set Int64) -> Bool -- Causal Identity Hash (Set Int64)
-testIdempotent causal = 
-     runIdentity (threeWayMerge' causal causal) 
+testIdempotent causal =
+     runIdentity (threeWayMerge' causal causal)
   == causal
 
 -- prop_mergeIdempotent :: Bool
@@ -204,12 +204,16 @@ easyCombine _    diff appl (Just ca) l r = do
   dr <- diff ca r
   appl ca (dl <> dr)
 
+threeWayMerge'
+  :: Causal Identity Hash (Set Int64)
+  -> Causal Identity Hash (Set Int64)
+  -> Identity (Causal Identity Hash (Set Int64))
 threeWayMerge' = Causal.threeWayMerge (easyCombine setCombine setDiff setPatch)
 
 -- merge x mempty == x, merge mempty x == x
 testIdentity :: Causal Identity Hash (Set Int64) -> Causal Identity Hash (Set Int64) -> Bool
-testIdentity causal mempty = 
-     (threeWayMerge' causal mempty) 
+testIdentity causal mempty =
+     (threeWayMerge' causal mempty)
   == (threeWayMerge' mempty causal)
 
 emptyCausal :: Causal Identity Hash (Set Int64)
@@ -222,8 +226,8 @@ testCommutative hd tl = (threeWayMerge' (Causal.cons hd tl) tl)
 
 
 {-
-testCommonAncestor :: 
-testCommonAncestor = 
+testCommonAncestor ::
+testCommonAncestor =
 -}
 
 

--- a/unison-src/transcripts/mergeloop.md
+++ b/unison-src/transcripts/mergeloop.md
@@ -1,0 +1,51 @@
+# Merge loop test
+
+This tests for regressions of https://github.com/unisonweb/unison/issues/1276 where trivial merges cause loops in the history.
+
+Let's make three identical namespaces with different histories:
+
+```unison
+a = 1
+```
+
+```ucm
+.x> add
+```
+
+```unison
+b = 2
+```
+
+```ucm
+.x> add
+```
+
+```unison
+b = 2
+```
+
+```ucm
+.y> add
+```
+
+```unison
+a = 1
+```
+
+```ucm
+.y> add
+```
+
+```unison
+a = 1
+b = 2
+```
+
+```ucm
+.z> add
+.> merge x y
+.> merge y z
+.> history z
+```
+
+

--- a/unison-src/transcripts/mergeloop.output.md
+++ b/unison-src/transcripts/mergeloop.output.md
@@ -1,0 +1,159 @@
+# Merge loop test
+
+This tests for regressions of https://github.com/unisonweb/unison/issues/1276 where trivial merges cause loops in the history.
+
+Let's make three identical namespaces with different histories:
+
+```unison
+a = 1
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      a : ##Nat
+   
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+```
+```ucm
+  ☝️  The namespace .x is empty.
+
+.x> add
+
+  ⍟ I've added these definitions:
+  
+    a : ##Nat
+
+```
+```unison
+b = 2
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      b : ##Nat
+   
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+```
+```ucm
+.x> add
+
+  ⍟ I've added these definitions:
+  
+    b : ##Nat
+
+```
+```unison
+b = 2
+```
+
+```ucm
+
+  I found and typechecked the definitions in scratch.u. This
+  file has been previously added to the codebase.
+   
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+```
+```ucm
+  ☝️  The namespace .y is empty.
+
+.y> add
+
+  ⍟ I've added these definitions:
+  
+    b : ##Nat
+
+```
+```unison
+a = 1
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      a : ##Nat
+   
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+```
+```ucm
+.y> add
+
+  ⍟ I've added these definitions:
+  
+    a : ##Nat
+
+```
+```unison
+a = 1
+b = 2
+```
+
+```ucm
+
+  I found and typechecked the definitions in scratch.u. This
+  file has been previously added to the codebase.
+   
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+```
+```ucm
+  ☝️  The namespace .z is empty.
+
+.z> add
+
+  ⍟ I've added these definitions:
+  
+    a : ##Nat
+    b : ##Nat
+
+.> merge x y
+
+  Nothing changed as a result of the merge.
+
+.> merge y z
+
+  Nothing changed as a result of the merge.
+
+.> history z
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  
+  
+  This segment of history starts with a merge. Use
+  `history #som3n4m3space` to view history starting from a given
+  namespace hash.
+  
+  #0lf1cvdccp
+  #2quan5n72t
+  #gjfovomom2
+  ⑂
+  ⊙ #bpfcuip0ru
+
+```


### PR DESCRIPTION
Fixes #1276 in two ways:

1. Eliminates hangs when there are loops in the histories by tracking in memory which hashes it has queued for writing, rather than relying on the files having been written to disk.

2. Fixes a bug that caused loops in histories.