### PR TITLE
implement 3 easy items from #1281

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Unison.Codebase.Editor.Git where
+module Unison.Codebase.Editor.Git
+  ( pullGitRootBranch
+  , pullGitBranch
+  , pushGitRootBranch
+  ) where
 
 import Unison.Prelude
 
@@ -33,40 +37,23 @@ import qualified Unison.Names3                 as Names
 import Unison.Codebase.ShortBranchHash (ShortBranchHash)
 
 -- Given a local path, a remote git repo url, and branch/commit hash,
--- pulls the HEAD of that remote repo into the local path.
-pullFromGit
+-- checks for git, the repo path, performs a clone, and verifies resulting repo
+pullBranch
   :: MonadIO m
   => MonadError GitError m => FilePath -> Text -> Maybe Text -> m ()
-pullFromGit localPath url treeish = do
-  prepGitPull localPath url
-  pull localPath url treeish
-
--- checks for git, the repo path, performs a clone, and verifies resulting repo
-prepGitPull
-  :: MonadIO m => MonadError GitError m => FilePath -> Text -> m ()
-prepGitPull localPath uri = do
+pullBranch localPath uri treeish = do
   checkForGit
   e <- liftIO . Ex.tryAny . whenM (doesDirectoryExist localPath) $
     removeDirectoryRecursive localPath
   case e of
     Left e -> throwError (SomeOtherError (Text.pack (show e)))
     Right _ -> pure ()
-  clone uri localPath
+  "git" (["clone"] ++ ["--depth", "1"]
+     ++ maybe [] (\t -> ["--branch", t]) treeish
+     ++ [uri, Text.pack localPath])
+    `onError` throwError (NoRemoteRepoAt uri)
   isGitDir <- liftIO $ checkGitDir localPath
   unless isGitDir . throwError $ NoLocalRepoAt localPath
-
--- Shallow pull in preparation for a push
-shallowPullFromGit
-  :: MonadIO m
-  => MonadError GitError m => FilePath -> Text -> Maybe Text -> m ()
-shallowPullFromGit localPath url gitBranch = do
-  prepGitPull localPath url
-  for_ gitBranch $ \gitBranch ->
-    gitIn localPath ["checkout", gitBranch]
-      -- creates a new branch in prep for pushing,
-      -- not sure what happens if the branch has the same name as a commit 😬
-      `onError` gitIn localPath ["checkout", "-b", gitBranch]
-      `onError` throwError (CheckoutFailed gitBranch)
 
 -- Given a local path, a remote repo url, and branch/commit hash, pulls the
 -- HEAD of that remote repo into the local path and attempts to load it as a
@@ -94,7 +81,7 @@ pullGitBranch
   -> Either BranchLoadMode ShortBranchHash
   -> ExceptT GitError m (Branch m)
 pullGitBranch localPath codebase url treeish loadInfo = do
-  pullFromGit localPath url treeish
+  pullBranch localPath url treeish
   branch <- case loadInfo of
     Left loadMode -> lift $ FC.getRootBranch loadMode gitCodebasePath
     Right sbh -> do
@@ -121,15 +108,6 @@ onError x k = liftIO ((const True <$> x) $? pure False) >>= \case
   True  -> pure ()
   False -> k
 
-clone :: MonadError GitError m => MonadIO m => Text -> FilePath -> m ()
-clone uri localPath = "git" ["clone", uri, Text.pack localPath]
-  `onError` throwError (NoRemoteRepoAt uri)
-
-pull :: MonadError GitError m => MonadIO m => FilePath -> Text -> Maybe Text -> m ()
-pull localPath _uri treeish = do
-  for_ treeish $ \treeish ->
-    liftIO $ gitIn localPath ["checkout", treeish]
-
 gitIn :: FilePath -> [Text] -> IO ()
 gitIn localPath args = "git" (["-C", Text.pack localPath] <> args)
 
@@ -150,7 +128,7 @@ pushGitRootBranch
   -> ExceptT GitError m ()
 pushGitRootBranch localPath codebase branch url gitbranch = do
   -- Clone and pull the remote repo
-  shallowPullFromGit localPath url gitbranch
+  pullBranch localPath url gitbranch
   -- Stick our changes in the checked-out copy
   merged <- lift $ syncToDirectory codebase (localPath </> codebasePath) branch
   isBefore <- lift $ Branch.before merged branch

--- a/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
@@ -48,7 +48,7 @@ pullBranch localPath uri treeish = do
   case e of
     Left e -> throwError (SomeOtherError (Text.pack (show e)))
     Right _ -> pure ()
-  "git" (["clone"] ++ ["--depth", "1"]
+  "git" (["clone", "--quiet"] ++ ["--depth", "1"]
      ++ maybe [] (\t -> ["--branch", t]) treeish
      ++ [uri, Text.pack localPath])
     `onError` throwError (NoRemoteRepoAt uri)
@@ -144,10 +144,10 @@ pushGitRootBranch localPath codebase branch url gitbranch = do
       unless (Text.null status) $ do
         gitIn localPath ["add", "--all", "."]
         gitIn localPath
-          ["commit", "-m", "Sync branch " <> Text.pack (show $ headHash branch)]
-      -- Push our changes to the repo
-      case gitbranch of
-        Nothing        -> gitIn localPath ["push", "--all", url]
-        Just gitbranch -> gitIn localPath ["push", url, gitbranch]
+          ["commit", "-q", "-m", "Sync branch " <> Text.pack (show $ headHash branch)]
+        -- Push our changes to the repo
+        case gitbranch of
+          Nothing        -> gitIn localPath ["push", "--quiet", "--all", url]
+          Just gitbranch -> gitIn localPath ["push", "--quiet", url, gitbranch]
   liftIO push `onException` throwError (NoRemoteRepoAt url)
 

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -269,7 +269,8 @@ touchIdFile id fp = do
   -- note: contents of the file are equal to the name, rather than empty, to
   -- hopefully avoid git getting clever about treating deletions as renames
   let n = componentIdToString id
-  writeFile (fp </> encodeFileName n) n
+  writeFile
+    (fp </> encodeFileName n) ""
 
 touchReferentFile :: Referent -> FilePath -> IO ()
 touchReferentFile id fp = do
@@ -277,7 +278,8 @@ touchReferentFile id fp = do
   -- note: contents of the file are equal to the name, rather than empty, to
   -- hopefully avoid git getting clever about treating deletions as renames
   let n = referentToString id
-  writeFile (fp </> encodeFileName n) n
+  writeFile
+    (fp </> encodeFileName n) ""
 
 -- checks if `path` looks like a unison codebase
 minimalCodebaseStructure :: CodebasePath -> [FilePath]
@@ -371,7 +373,7 @@ updateCausalHead headDir c = do
   -- write new head
   exists <- doesDirectoryExist headDir
   unless exists $ createDirectory headDir
-  liftIO $ writeFile (headDir </> hs) hs
+  liftIO $ writeFile (headDir </> hs) ""
   -- delete existing heads
   liftIO $ fmap (filter (/= hs)) (listDirectory headDir)
        >>= traverse_ (removeFile . (headDir </>))


### PR DESCRIPTION
## Overview

This PR simplifies `Git.hs` slightly and implements a couple of changes proposed in https://github.com/unisonweb/unison/issues/1281#issuecomment-592940657, speeding up push of `base` to an empty local repo by ~35%.  It's still too slow though.

There are some proposals in that comment (and some rambling context in that thread) that will give bigger speedups, but would be more work to implement.

* use `git clone --depth 1`

  We're just doing linear merges, so we don't need the whole history.  This saved about 10% time, but there's a limit in that Unison codebase histories are currently append-only, so you end up getting all of the objects anyway, if not all of the trees.

* use `git --quiet`

  This reduces the amount of output `git` produces; saving a small chunk of time when there is a lot for `git` to produce.  Not sure if this completely satisfies #1194, but it's a good start.

  I couldn't create a before & after gist because the "before" was too big and makes gist time out.

* let "touched" refs be blank files instead of files containing their hash

  Since we're just doing unconditional, linear git updates now, controlled by `ucm`, not by external `git merge`, I don't think we care whether git identifies something as a rename.  

  This reduces the disk size of a checked-out `base` by ~65%, and the transfer size (compressed) by ~10%.  

  Since we are currently writing each new commit from scratch, this reduction will automatically apply to existing repos when they're pushed to next.

## Loose ends

It would be helpful for ucm to print a message before writing the specified branch to the git staging directory; this is the slowest part, and leaves you wondering what's happening for maybe minutes. (#1292)

I noticed that there is an issue pushing to as-of-yet nonexistent git branches (#1291), not sure if this is an old or new issue, but it doesn't seem like a high priority.