### PR TITLE
finally rename AnnotatedTerm to Term

### DIFF
--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -34,6 +34,7 @@ import           Unison.Var                     ( Var )
 import qualified Unison.Runtime.IOSource       as IOSource
 import           Unison.Symbol                  ( Symbol )
 import Unison.DataDeclaration (Decl)
+import Unison.Term (Term)
 import Unison.Type (Type)
 import Unison.Codebase.ShortBranchHash (ShortBranchHash)
 
@@ -41,7 +42,6 @@ import Unison.Codebase.ShortBranchHash (ShortBranchHash)
 
 type DataDeclaration v a = DD.DataDeclaration' v a
 type EffectDeclaration v a = DD.EffectDeclaration' v a
-type Term v a = Term.AnnotatedTerm v a
 
 data Codebase m v a =
   Codebase { getTerm            :: Reference.Id -> m (Maybe (Term v a))

--- a/parser-typechecker/src/Unison/Codebase/CodeLookup.hs
+++ b/parser-typechecker/src/Unison/Codebase/CodeLookup.hs
@@ -7,7 +7,7 @@ import qualified Data.Map                      as Map
 import           Unison.UnisonFile              ( UnisonFile )
 import qualified Unison.UnisonFile              as UF
 import qualified Unison.Term                    as Term
-import           Unison.Term                    ( AnnotatedTerm )
+import           Unison.Term                    ( Term )
 import           Unison.Var                     ( Var )
 import qualified Unison.Reference as Reference
 import           Unison.DataDeclaration (Decl)
@@ -29,7 +29,7 @@ fromUnisonFile uf = CodeLookup tm ty where
 
 data CodeLookup v m a
   = CodeLookup {
-      getTerm :: Reference.Id -> m (Maybe (AnnotatedTerm v a)),
+      getTerm :: Reference.Id -> m (Maybe (Term v a)),
       getTypeDeclaration :: Reference.Id -> m (Maybe (Decl v a))
    }
 

--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -31,7 +31,7 @@ import           Unison.DataDeclaration         ( Decl )
 import qualified Unison.Codebase.Runtime       as Runtime
 import qualified Unison.PrettyPrintEnv         as PPE
 import qualified Unison.Reference              as Reference
-import qualified Unison.Term                   as Term
+import           Unison.Term                    ( Term )
 import qualified Unison.UnisonFile             as UF
 import qualified Unison.Lexer                  as L
 import qualified Unison.Parser                 as Parser
@@ -46,7 +46,6 @@ type AmbientAbilities v = [Type v Ann]
 type SourceName = Text
 type Source = Text
 type LexedSource = (Text, [L.Token L.Lexeme])
-type Term v a = Term.AnnotatedTerm v a
 
 data LoadSourceResult = InvalidSourceNameError
                       | LoadError

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -50,6 +50,7 @@ import           Unison.FileParsers             ( parseAndSynthesizeFile
                                                 )
 import qualified Unison.PrettyPrintEnv         as PPE
 import qualified Unison.ShortHash              as SH
+import Unison.Term (Term)
 import Unison.Type (Type)
 
 typecheck
@@ -171,7 +172,7 @@ commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSour
     AppendToReflog reason old new -> Codebase.appendReflog codebase reason old new
     LoadReflog -> Codebase.getReflog codebase
 
-  eval1 :: PPE.PrettyPrintEnv -> Term.AnnotatedTerm v Ann -> _
+  eval1 :: PPE.PrettyPrintEnv -> Term v Ann -> _
   eval1 ppe tm = do
     let codeLookup = Codebase.toCodeLookup codebase
     r <- Runtime.evaluateTerm codeLookup ppe rt tm

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -115,6 +115,7 @@ import Unison.Codebase.Editor.SearchResult' (SearchResult')
 import qualified Unison.Codebase.Editor.SearchResult' as SR'
 import qualified Unison.LabeledDependency as LD
 import Unison.LabeledDependency (LabeledDependency)
+import Unison.Term (Term)
 import Unison.Type (Type)
 import qualified Unison.Builtin as Builtin
 import Unison.Codebase.NameSegment (NameSegment(..))
@@ -130,7 +131,6 @@ import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as Nel
 
 type F m i v = Free (Command m i v)
-type Term v a = Term.AnnotatedTerm v a
 
 -- type (Action m i v) a
 type Action m i v = MaybeT (StateT (LoopState m v) (F m i v))

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -40,13 +40,13 @@ import qualified Unison.HashQualified' as HQ'
 import qualified Unison.Parser as Parser
 import qualified Unison.PrettyPrintEnv as PPE
 import qualified Unison.Reference as Reference
-import qualified Unison.Term as Term
 import qualified Unison.Typechecker.Context as Context
 import qualified Unison.UnisonFile as UF
 import qualified Unison.Util.Pretty as P
 import Unison.Codebase.Editor.DisplayThing (DisplayThing)
 import qualified Unison.Codebase.Editor.TodoOutput as TO
 import Unison.Codebase.Editor.SearchResult' (SearchResult')
+import Unison.Term (Term)
 import Unison.Type (Type)
 import qualified Unison.Names3 as Names
 import qualified Data.Set as Set
@@ -57,7 +57,6 @@ import Unison.Codebase.ShortBranchHash (ShortBranchHash)
 import Unison.Codebase.Editor.RemoteRepo as RemoteRepo
 import Unison.Codebase.Editor.Output.BranchDiff (BranchDiffOutput)
 
-type Term v a = Term.AnnotatedTerm v a
 type ListDetailed = Bool
 type SourceName = Text
 type NumberedArgs = [String]

--- a/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
@@ -28,6 +28,7 @@ import qualified Unison.Reference              as Reference
 import qualified Unison.Referent               as Referent
 import qualified Unison.Result                 as Result
 import qualified Unison.Term                   as Term
+import           Unison.Term                    ( Term )
 import           Unison.Util.Free               ( Free
                                                 , eval
                                                 )
@@ -48,7 +49,6 @@ import           Unison.ConstructorType         ( ConstructorType )
 import qualified Unison.Runtime.IOSource       as IOSource
 
 type F m i v = Free (Command m i v)
-type Term v a = Term.AnnotatedTerm v a
 
 data Edits v = Edits
   { termEdits :: Map Reference TermEdit

--- a/parser-typechecker/src/Unison/Codebase/Editor/SlurpComponent.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/SlurpComponent.hs
@@ -75,7 +75,7 @@ closeWithDependencies uf inputs = seenDefns where
   resolveTypes :: Set Reference -> [v]
   resolveTypes rs = [ v | r <- Set.toList rs, Just v <- [Map.lookup r typeNames]]
 
-  findTerm :: v -> Maybe (Term.AnnotatedTerm v a)
+  findTerm :: v -> Maybe (Term.Term v a)
   findTerm v = Map.lookup v allTerms
 
   allTerms = UF.allTerms uf

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -86,6 +86,7 @@ import           Unison.Reference               ( Reference )
 import qualified Unison.Reference              as Reference
 import           Unison.Referent                ( Referent(..) )
 import qualified Unison.Referent               as Referent
+import           Unison.Term                    ( Term )
 import qualified Unison.Term                   as Term
 import           Unison.Type                    ( Type )
 import qualified Unison.Type                   as Type
@@ -493,7 +494,7 @@ putTerm
   -> S.Put a
   -> FilePath
   -> Reference.Id
-  -> Term.AnnotatedTerm v a
+  -> Term v a
   -> Type v a
   -> m ()
 putTerm putV putA path h e typ = liftIO $ do
@@ -549,7 +550,7 @@ putWatch
   -> FilePath
   -> UF.WatchKind
   -> Reference.Id
-  -> Codebase.Term v a
+  -> Term v a
   -> m ()
 putWatch putV putA path k id e = liftIO $ S.putWithParentDirs
   (V1.putTerm putV putA)
@@ -654,7 +655,7 @@ codebase1 fmtV@(S.Format getV putV) fmtA@(S.Format getA putA) path =
         createDirectoryIfMissing True wp
         ls <- listDirectory wp
         pure $ ls >>= (toList . componentIdFromString . takeFileName)
-    getWatch :: UF.WatchKind -> Reference.Id -> m (Maybe (Codebase.Term v a))
+    getWatch :: UF.WatchKind -> Reference.Id -> m (Maybe (Term v a))
     getWatch k id =
       liftIO $ do
         let wp = watchesDir path (Text.pack k)

--- a/parser-typechecker/src/Unison/Codebase/MainTerm.hs
+++ b/parser-typechecker/src/Unison/Codebase/MainTerm.hs
@@ -13,6 +13,7 @@ import Unison.Prelude
 import           Unison.Parser                  ( Ann )
 import qualified Unison.Parser                 as Parser
 import qualified Unison.Term                   as Term
+import           Unison.Term                    ( Term )
 import           Unison.Var                     ( Var )
 import qualified Unison.DataDeclaration        as DD
 import qualified Unison.HashQualified          as HQ
@@ -28,7 +29,7 @@ data MainTerm v
   = NotAFunctionName String
   | NotFound String
   | BadType String
-  | Success HQ.HashQualified (Term.AnnotatedTerm v Ann) (Type v Ann)
+  | Success HQ.HashQualified (Term v Ann) (Type v Ann)
 
 getMainTerm
   :: (Monad m, Var v)

--- a/parser-typechecker/src/Unison/Codebase/Serialization/V1.hs
+++ b/parser-typechecker/src/Unison/Codebase/Serialization/V1.hs
@@ -45,7 +45,7 @@ import           Unison.Hash                    ( Hash )
 import           Unison.Kind                    ( Kind )
 import           Unison.Reference               ( Reference )
 import           Unison.Symbol                  ( Symbol(..) )
-import           Unison.Term                    ( AnnotatedTerm )
+import           Unison.Term                    ( Term )
 import qualified Data.ByteString               as B
 import qualified Data.Sequence                 as Sequence
 import qualified Data.Set                      as Set
@@ -478,7 +478,7 @@ getPattern getA = getWord8 >>= \tag -> case tag of
 
 putTerm :: (MonadPut m, Ord v)
         => (v -> m ()) -> (a -> m ())
-        -> AnnotatedTerm v a
+        -> Term v a
         -> m ()
 putTerm putVar putA = putABT putVar putA go where
   go putChild t = case t of
@@ -534,7 +534,7 @@ putTerm putVar putA = putABT putVar putA go where
     putPattern putA pat *> putMaybe guard putChild *> putChild body
 
 getTerm :: (MonadGet m, Ord v)
-        => m v -> m a -> m (Term.AnnotatedTerm v a)
+        => m v -> m a -> m (Term v a)
 getTerm getVar getA = getABT getVar getA go where
   go getChild = getWord8 >>= \tag -> case tag of
     0 -> Term.Int <$> getInt

--- a/parser-typechecker/src/Unison/Codecs.hs
+++ b/parser-typechecker/src/Unison/Codecs.hs
@@ -35,7 +35,7 @@ import qualified Unison.PatternP as Pattern
 type Pos = Word64
 
 serializeTerm :: (MonadPut m, MonadState Pos m, Var v)
-              => AnnotatedTerm v a
+              => Term v a
               -> m Pos
 serializeTerm x = do
   let putTag = do putWord8 111; putWord8 0
@@ -260,7 +260,7 @@ serializeCase2 (MatchCase p guard body) = do
   putBackref body
 
 serializeCase1 :: (Var v, MonadPut m, MonadState Pos m)
-               => MatchCase p (AnnotatedTerm v a) -> m (MatchCase p Pos)
+               => MatchCase p (Term v a) -> m (MatchCase p Pos)
 serializeCase1 (MatchCase p guard body) = do
   posg <- traverse serializeTerm guard
   posb <- serializeTerm body
@@ -325,7 +325,7 @@ serializeConstructorArities r constructorArities = do
 
 serializeFile
   :: (MonadPut m, MonadState Pos m, Monoid a, Var v)
-  => UnisonFile v a -> AnnotatedTerm v a -> m ()
+  => UnisonFile v a -> Term v a -> m ()
 serializeFile uf@(UnisonFile dataDecls effectDecls _ _) tm = do
   let body = UF.uberTerm' uf tm
   let dataDecls' = second DD.constructorArities <$> toList dataDecls

--- a/parser-typechecker/src/Unison/CommandLine/DisplayValues.hs
+++ b/parser-typechecker/src/Unison/CommandLine/DisplayValues.hs
@@ -6,7 +6,7 @@ module Unison.CommandLine.DisplayValues where
 
 import Unison.Reference (Reference)
 import Unison.Referent (Referent)
-import Unison.Term (AnnotatedTerm)
+import Unison.Term (Term)
 import Unison.Type (Type)
 import Unison.Var (Var)
 import qualified Unison.DataDeclaration as DD
@@ -25,11 +25,11 @@ type Pretty = P.Pretty P.ColorText
 
 displayTerm :: (Var v, Monad m)
            => PPE.PrettyPrintEnvDecl
-           -> (Reference -> m (Maybe (AnnotatedTerm v a)))
+           -> (Reference -> m (Maybe (Term v a)))
            -> (Referent -> m (Maybe (Type v a)))
-           -> (Reference -> m (Maybe (AnnotatedTerm v a)))
+           -> (Reference -> m (Maybe (Term v a)))
            -> (Reference -> m (Maybe (DD.Decl v a)))
-           -> AnnotatedTerm v a 
+           -> Term v a 
            -> m Pretty
 displayTerm pped terms typeOf eval types tm = case tm of
   -- todo: can dispatch on other things with special rendering
@@ -40,11 +40,11 @@ displayTerm pped terms typeOf eval types tm = case tm of
 
 displayDoc :: (Var v, Monad m)
            => PPE.PrettyPrintEnvDecl 
-           -> (Reference -> m (Maybe (AnnotatedTerm v a)))
+           -> (Reference -> m (Maybe (Term v a)))
            -> (Referent  -> m (Maybe (Type v a)))
-           -> (Reference -> m (Maybe (AnnotatedTerm v a)))
+           -> (Reference -> m (Maybe (Term v a)))
            -> (Reference -> m (Maybe (DD.Decl v a)))
-           -> AnnotatedTerm v a 
+           -> Term v a 
            -> m Pretty
 displayDoc pped terms typeOf evaluated types t = go t
   where

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -87,7 +87,7 @@ import qualified Unison.Referent               as Referent
 import           Unison.Referent               ( Referent )
 import qualified Unison.Result                 as Result
 import qualified Unison.Term                   as Term
-import           Unison.Term                   (AnnotatedTerm)
+import           Unison.Term                   (Term)
 import           Unison.Type                   (Type)
 import qualified Unison.TermPrinter            as TermPrinter
 import qualified Unison.TypePrinter            as TypePrinter
@@ -972,7 +972,7 @@ formatMissingStuff terms types =
 displayDefinitions' :: Var v => Ord a1
   => PPE.PrettyPrintEnvDecl
   -> Map Reference.Reference (DisplayThing (DD.Decl v a1))
-  -> Map Reference.Reference (DisplayThing (Unison.Term.AnnotatedTerm v a1))
+  -> Map Reference.Reference (DisplayThing (Term v a1))
   -> Pretty
 displayDefinitions' ppe0 types terms = P.syntaxToColor $ P.sep "\n\n" (prettyTypes <> prettyTerms)
   where
@@ -1030,7 +1030,7 @@ displayDefinitions :: Var v => Ord a1 =>
   Maybe FilePath
   -> PPE.PrettyPrintEnvDecl
   -> Map Reference.Reference (DisplayThing (DD.Decl v a1))
-  -> Map Reference.Reference (DisplayThing (Unison.Term.AnnotatedTerm v a1))
+  -> Map Reference.Reference (DisplayThing (Term v a1))
   -> IO Pretty
 displayDefinitions outputLoc ppe types terms | Map.null types && Map.null terms =
   pure $ P.callout "😶" "No results to display."
@@ -1699,7 +1699,7 @@ watchPrinter
   -> PPE.PrettyPrintEnv
   -> Ann
   -> UF.WatchKind
-  -> Codebase.Term v ()
+  -> Term v ()
   -> Runtime.IsCacheHit
   -> Pretty
 watchPrinter src ppe ann kind term isHit =
@@ -1825,7 +1825,7 @@ prettyDiff diff = let
      else mempty
    ]
 
-isTestOk :: Codebase.Term v Ann -> Bool
+isTestOk :: Term v Ann -> Bool
 isTestOk tm = case tm of
   Term.Sequence' ts -> all isSuccess ts where
     isSuccess (Term.App' (Term.Constructor' ref cid) _) =

--- a/parser-typechecker/src/Unison/FileParser.hs
+++ b/parser-typechecker/src/Unison/FileParser.hs
@@ -19,7 +19,7 @@ import           Unison.DataDeclaration (DataDeclaration', EffectDeclaration')
 import qualified Unison.DataDeclaration as DD
 import qualified Unison.Lexer as L
 import           Unison.Parser
-import           Unison.Term (AnnotatedTerm)
+import           Unison.Term (Term)
 import qualified Unison.Term as Term
 import qualified Unison.TermParser as TermParser
 import           Unison.Type (Type)
@@ -107,7 +107,7 @@ getVars = \case
   Binding ((_,v), _) -> [v]
   Bindings bs -> [ v | ((_,v), _) <- bs ]
 
-stanza :: Var v => P v (Stanza v (AnnotatedTerm v Ann))
+stanza :: Var v => P v (Stanza v (Term v Ann))
 stanza = watchExpression <|> unexpectedAction <|> binding <|> namespace
   where
   unexpectedAction = failureIf (TermParser.blockTerm $> getErr) binding

--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -28,9 +28,8 @@ import qualified Unison.Referent            as Referent
 import           Unison.Reference           (Reference)
 import           Unison.Result              (Note (..), Result, pattern Result, ResultT, CompilerBug(..))
 import qualified Unison.Result              as Result
-import           Unison.Term                (AnnotatedTerm)
 import qualified Unison.Term                as Term
-import qualified Unison.Type
+import qualified Unison.Type                as Type
 import qualified Unison.Typechecker         as Typechecker
 import qualified Unison.Typechecker.TypeLookup as TL
 import qualified Unison.Typechecker.Context as Context
@@ -41,8 +40,8 @@ import           Unison.Var                 (Var)
 import qualified Unison.Var                 as Var
 import Unison.Names3 (Names0)
 
-type Term v = AnnotatedTerm v Ann
-type Type v = Unison.Type.Type v Ann
+type Term v = Term.Term v Ann
+type Type v = Type.Type v Ann
 type UnisonFile v = UF.UnisonFile v Ann
 type Result' v = Result (Seq (Note v Ann))
 
@@ -84,7 +83,7 @@ resolveNames
   -> ResultT
        (Seq (Note v Ann))
        m
-       (AnnotatedTerm v Ann, TDNRMap v, TL.TypeLookup v Ann)
+       (Term v, TDNRMap v, TL.TypeLookup v Ann)
 resolveNames typeLookupf preexistingNames uf = do
   let tm = UF.typecheckingTerm uf
       deps = Term.dependencies tm
@@ -124,7 +123,7 @@ synthesizeFile
   -> TL.TypeLookup v Ann
   -> TDNRMap v
   -> UnisonFile v
-  -> AnnotatedTerm v Ann
+  -> Term v
   -> Result (Seq (Note v Ann)) (UF.TypecheckedUnisonFile v Ann)
 synthesizeFile ambient tl fqnsByShortName uf term = do
   let -- substitute Blanks for any remaining free vars in UF body

--- a/parser-typechecker/src/Unison/Parsers.hs
+++ b/parser-typechecker/src/Unison/Parsers.hs
@@ -13,7 +13,7 @@ import qualified Unison.Parser                 as Parser
 import           Unison.PrintError              ( prettyParseError
                                                 , defaultWidth )
 import           Unison.Symbol                  ( Symbol )
-import           Unison.Term                    ( AnnotatedTerm )
+import           Unison.Term                    ( Term )
 import qualified Unison.TermParser             as TermParser
 import           Unison.Type                    ( Type )
 import qualified Unison.TypeParser             as TypeParser
@@ -37,7 +37,7 @@ parseTerm
   :: Var v
   => String
   -> Parser.ParsingEnv
-  -> Either (Parser.Err v) (AnnotatedTerm v Ann)
+  -> Either (Parser.Err v) (Term v Ann)
 parseTerm = parse TermParser.term
 
 parseType
@@ -65,7 +65,7 @@ readAndParseFile penv fileName = do
   let src = Text.unpack txt
   pure $ parseFile fileName src penv
 
-unsafeParseTerm :: Var v => String -> Parser.ParsingEnv -> AnnotatedTerm v Ann
+unsafeParseTerm :: Var v => String -> Parser.ParsingEnv -> Term v Ann
 unsafeParseTerm s = fmap (unsafeGetRightFrom s) . parseTerm $ s
 
 unsafeReadAndParseFile

--- a/parser-typechecker/src/Unison/Result.hs
+++ b/parser-typechecker/src/Unison/Result.hs
@@ -19,7 +19,7 @@ import           Control.Monad.Writer           ( WriterT(..)
 import           Unison.Name                    ( Name )
 import qualified Unison.Parser                 as Parser
 import           Unison.Paths                   ( Path )
-import           Unison.Term                    ( AnnotatedTerm )
+import           Unison.Term                    ( Term )
 import qualified Unison.Typechecker.Context    as Context
 import           Control.Error.Util             ( note)
 import qualified Unison.Names3                 as Names
@@ -27,8 +27,6 @@ import qualified Unison.Names3                 as Names
 type Result notes = ResultT notes Identity
 
 type ResultT notes f = MaybeT (WriterT notes f)
-
-type Term v loc = AnnotatedTerm v loc
 
 data Note v loc
   = Parsing (Parser.Err v)

--- a/parser-typechecker/src/Unison/Runtime/IR.hs
+++ b/parser-typechecker/src/Unison/Runtime/IR.hs
@@ -21,7 +21,6 @@ import Unison.Hash (Hash)
 import Unison.NamePrinter (prettyHashQualified0)
 import Unison.Referent (Referent)
 import Unison.Symbol (Symbol)
-import Unison.Term (AnnotatedTerm)
 import Unison.Util.CyclicEq (CyclicEq, cyclicEq)
 import Unison.Util.CyclicOrd (CyclicOrd, cyclicOrd)
 import Unison.Util.Monoid (intercalateMap)
@@ -47,7 +46,7 @@ import qualified Unison.Var as Var
 type Pos = Int
 type Arity = Int
 type ConstructorId = Int
-type Term v = AnnotatedTerm v ()
+type Term v = Term.Term v ()
 
 data CompilationEnv e cont
   = CompilationEnv { toIR' :: Map R.Reference (IR e cont)

--- a/parser-typechecker/src/Unison/Runtime/Rt1.hs
+++ b/parser-typechecker/src/Unison/Runtime/Rt1.hs
@@ -224,7 +224,7 @@ arity _ = 0
 -- types that are referenced by the given term, `t`.
 compilationEnv :: Monad m
   => CL.CodeLookup Symbol m a
-  -> Term.AnnotatedTerm Symbol a
+  -> Term.Term Symbol a
   -> m CompilationEnv
 compilationEnv env t = do
   let typeDeps = Term.typeDependencies t

--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -20,7 +20,7 @@ import           Unison.Reference (Reference)
 import           Unison.Referent (Referent)
 import           Unison.Parser hiding (seq)
 import           Unison.PatternP (Pattern)
-import           Unison.Term (AnnotatedTerm, IsTop)
+import           Unison.Term (Term, IsTop)
 import           Unison.Type (Type)
 import           Unison.Util.List (intercalateMapWith)
 import           Unison.Var (Var)
@@ -60,7 +60,7 @@ operator characters (like empty? or fold-left).
 Sections / partial application of infix operators is not implemented.
 -}
 
-type TermP v = P v (AnnotatedTerm v Ann)
+type TermP v = P v (Term v Ann)
 
 term :: Var v => TermP v
 term = term2
@@ -134,7 +134,7 @@ match = do
   _ <- closeBlock
   pure $ Term.match (ann start <> ann (last cases)) scrutinee cases
 
-matchCase :: Var v => P v (Term.MatchCase Ann (AnnotatedTerm v Ann))
+matchCase :: Var v => P v (Term.MatchCase Ann (Term v Ann))
 matchCase = do
   (p, boundVars) <- parsePattern
   guard <- optional $ reserved "|" *> infixAppOrBooleanOp
@@ -400,7 +400,7 @@ data UnbreakCase =
 --
 -- This function has some tracing which you can enable by deleting some calls to
 -- 'const id' below.
-docNormalize :: (Ord v, Show v) => AnnotatedTerm v a -> AnnotatedTerm v a
+docNormalize :: (Ord v, Show v) => Term v a -> Term v a
 docNormalize tm = case tm of
   -- This pattern is just `DD.DocJoin seqs`, but exploded in order to grab
   -- the annotations.  The aim is just to map `normalize` over it.
@@ -424,8 +424,8 @@ docNormalize tm = case tm of
   miniPreProcess seqs = zip (toList seqs) (previousLines seqs)
   unIndent
     :: Ord v
-    => [(AnnotatedTerm v a, UnbreakCase)]
-    -> [(AnnotatedTerm v a, UnbreakCase)]
+    => [(Term v a, UnbreakCase)]
+    -> [(Term v a, UnbreakCase)]
   unIndent tms = map go tms   where
     go (b, previous) =
       ((mapBlob $ (reduceIndent includeFirst minIndent)) b, previous)
@@ -476,8 +476,8 @@ docNormalize tm = case tm of
   -- be removed.
   unbreakParas
     :: (Show v, Ord v)
-    => [(AnnotatedTerm v a, UnbreakCase, Bool)]
-    -> [(AnnotatedTerm v a, UnbreakCase, Bool)]
+    => [(Term v a, UnbreakCase, Bool)]
+    -> [(Term v a, UnbreakCase, Bool)]
   unbreakParas = map go   where
     -- 'candidate' means 'candidate to be joined with an adjacent line as part of a
     -- paragraph'.
@@ -524,7 +524,7 @@ docNormalize tm = case tm of
   -- several, which we can't do perfectly, and which varies depending on
   -- whether the doc is viewed or displayed.  This can cause some glitches
   -- cutting out whitespace immediately following @[source] and @[evaluate].
-  lastLines :: Show v => Sequence.Seq (AnnotatedTerm v a) -> [Maybe UnbreakCase]
+  lastLines :: Show v => Sequence.Seq (Term v a) -> [Maybe UnbreakCase]
   lastLines tms = (flip fmap) (toList tms) $ \case
     DD.DocBlob      txt -> unbreakCase txt
     DD.DocLink      _   -> Nothing
@@ -551,7 +551,7 @@ docNormalize tm = case tm of
   -- fighting to break free - overwriting elements that are 'shadowed' by
   -- a preceding element for which the predicate is true, with a copy of
   -- that element.
-  previousLines :: Show v => Sequence.Seq (AnnotatedTerm v a) -> [UnbreakCase]
+  previousLines :: Show v => Sequence.Seq (Term v a) -> [UnbreakCase]
   previousLines tms = tr xs''   where
     tr = const id $
       trace $ "previousLines: xs = " ++ (show xs) ++ ", xss = "
@@ -574,7 +574,7 @@ docNormalize tm = case tm of
       map (Maybe.fromJust . Maybe.fromJust . (List.find isJust) . reverse) xss
     xs'' = List.Extra.dropEnd 1 xs'
   -- For each element, can it be a line-continuation of a preceding blob?
-  continuesLine :: Sequence.Seq (AnnotatedTerm v a) -> [Bool]
+  continuesLine :: Sequence.Seq (Term v a) -> [Bool]
   continuesLine tms = (flip fmap) (toList tms) $ \case
     DD.DocBlob      _ -> False -- value doesn't matter - you don't get adjacent blobs
     DD.DocLink      _ -> True
@@ -598,7 +598,7 @@ docNormalize tm = case tm of
     Term.app aa (Term.constructor ac DD.docRef DD.docBlobId) (Term.text at txt)
   join aa ac as segs =
     Term.app aa (Term.constructor ac DD.docRef DD.docJoinId) (Term.seq' as segs)
-  mapBlob :: Ord v => (Text -> Text) -> AnnotatedTerm v a -> AnnotatedTerm v a
+  mapBlob :: Ord v => (Text -> Text) -> Term v a -> Term v a
   -- this pattern is just `DD.DocBlob txt` but exploded to capture the annotations as well
   mapBlob f (aa@(Term.App' ac@(Term.Constructor' DD.DocRef DD.DocBlobId) at@(Term.Text' txt)))
     = blob (ABT.annotation aa) (ABT.annotation ac) (ABT.annotation at) (f txt)
@@ -616,7 +616,7 @@ bang = P.label "bang" $ do
   e <- termLeaf
   pure $ DD.forceTerm (ann start <> ann e) (ann start) e
 
-var :: Var v => L.Token v -> AnnotatedTerm v Ann
+var :: Var v => L.Token v -> Term v Ann
 var t = Term.var (ann t) (L.payload t)
 
 seqOp :: Ord v => P v Pattern.SeqOp
@@ -666,7 +666,7 @@ verifyRelativeName' name = do
   when (Text.isPrefixOf "." txt && txt /= ".") $
     failCommitted (DisallowedAbsoluteName name)
 
-binding :: forall v. Var v => P v ((Ann, v), AnnotatedTerm v Ann)
+binding :: forall v. Var v => P v ((Ann, v), Term v Ann)
 binding = label "binding" $ do
   typ <- optional typedecl
   -- a ++ b = ... OR
@@ -746,8 +746,8 @@ importp = do
 --  op m = case m of Monoid
 
 data BlockElement v
-  = Binding ((Ann, v), AnnotatedTerm v Ann)
-  | Action (AnnotatedTerm v Ann)
+  = Binding ((Ann, v), Term v Ann)
+  | Action (Term v Ann)
   | Namespace String [BlockElement v]
 
 namespaceBlock :: Var v => P v (BlockElement v)
@@ -761,7 +761,7 @@ namespaceBlock = do
   _ <- closeBlock
   pure $ Namespace (Name.toString $ L.payload name) elems
 
-toBindings :: forall v . Var v => [BlockElement v] -> [((Ann,v), AnnotatedTerm v Ann)]
+toBindings :: forall v . Var v => [BlockElement v] -> [((Ann,v), Term v Ann)]
 toBindings b = let
   expand (Binding ((a, v), e)) = [((a, Just v), e)]
   expand (Action e) = [((ann e, Nothing), e)]
@@ -770,8 +770,8 @@ toBindings b = let
   finishBindings bs =
     [((a, v `orBlank` i), e) | (((a,v), e), i) <- bs `zip` [(1::Int)..]]
 
-  scope :: String -> [((Ann, Maybe v), AnnotatedTerm v Ann)]
-                  -> [((Ann, Maybe v), AnnotatedTerm v Ann)]
+  scope :: String -> [((Ann, Maybe v), Term v Ann)]
+                  -> [((Ann, Maybe v), Term v Ann)]
   scope name bs = let
     vs :: [Maybe v]
     vs = snd . fst <$> bs
@@ -797,7 +797,7 @@ imports = do
 -- A key feature of imports is we want to be able to say:
 -- `use foo.bar Baz qux` without having to specify whether `Baz` or `qux` are
 -- terms or types.
-substImports :: Var v => Names -> [(v,v)] -> AnnotatedTerm v Ann -> AnnotatedTerm v Ann
+substImports :: Var v => Names -> [(v,v)] -> Term v Ann -> Term v Ann
 substImports ns imports =
   ABT.substsInheritAnnotation [ (suffix, Term.var () full)
     | (suffix,full) <- imports ] . -- no guard here, as `full` could be bound
@@ -823,7 +823,7 @@ block' isTop s openBlock closeBlock = do
   where
     statement = namespaceBlock <|>
       asum [ Binding <$> binding, Action <$> blockTerm ]
-    go :: L.Token () -> [BlockElement v] -> P v (AnnotatedTerm v Ann)
+    go :: L.Token () -> [BlockElement v] -> P v (Term v Ann)
     go open bs
       = let
           startAnnotation = (fst . fst . head $ toBindings bs)

--- a/parser-typechecker/src/Unison/Typechecker.hs
+++ b/parser-typechecker/src/Unison/Typechecker.hs
@@ -29,7 +29,7 @@ import           Unison.Referent            (Referent)
 import           Unison.Result              (pattern Result, Result,
                                              ResultT, runResultT)
 import qualified Unison.Result              as Result
-import           Unison.Term                (AnnotatedTerm)
+import           Unison.Term                (Term)
 import qualified Unison.Term                as Term
 import           Unison.Type                (Type)
 import qualified Unison.Typechecker.Context as Context
@@ -40,8 +40,6 @@ import qualified Unison.Typechecker.TypeLookup as TL
 import           Unison.Util.List           ( uniqueBy )
 
 type Name = Text
-
-type Term v loc = AnnotatedTerm v loc
 
 data Notes v loc = Notes {
   bugs   :: Seq (Context.CompilerBug v loc),

--- a/parser-typechecker/src/Unison/Typechecker/Components.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Components.hs
@@ -12,14 +12,14 @@ import qualified Data.Map as Map
 import           Data.Maybe (fromJust)
 import qualified Data.Set as Set
 import qualified Unison.ABT as ABT
-import           Unison.Term (AnnotatedTerm')
+import           Unison.Term (Term')
 import qualified Unison.Term as Term
 import           Unison.Var (Var)
 
-unordered :: Var v => [(v,AnnotatedTerm' vt v a)] -> [[(v,AnnotatedTerm' vt v a)]]
+unordered :: Var v => [(v,Term' vt v a)] -> [[(v,Term' vt v a)]]
 unordered = ABT.components 
 
-ordered :: Var v => [(v,AnnotatedTerm' vt v a)] -> [[(v,AnnotatedTerm' vt v a)]]
+ordered :: Var v => [(v,Term' vt v a)] -> [[(v,Term' vt v a)]]
 ordered = ABT.orderedComponents 
 
 -- | Algorithm for minimizing cycles of a `let rec`. This can
@@ -38,8 +38,8 @@ ordered = ABT.orderedComponents
 -- Fails on the left if there are duplicate definitions.
 minimize
   :: Var v
-  => AnnotatedTerm' vt v a
-  -> Either (NonEmpty (v, [a])) (Maybe (AnnotatedTerm' vt v a))
+  => Term' vt v a
+  -> Either (NonEmpty (v, [a])) (Maybe (Term' vt v a))
 minimize (Term.LetRecNamedAnnotatedTop' isTop ann bs e) =
   let bindings = first snd <$> bs
       group    = map (fst . head &&& map (ABT.annotation . snd)) . groupBy ((==) `on` fst) . sortBy
@@ -84,5 +84,5 @@ minimize (Term.LetRecNamedAnnotatedTop' isTop ann bs e) =
 minimize _ = Right Nothing
 
 minimize'
-  :: Var v => AnnotatedTerm' vt v a -> Either (NonEmpty (v,[a])) (AnnotatedTerm' vt v a)
+  :: Var v => Term' vt v a -> Either (NonEmpty (v,[a])) (Term' vt v a)
 minimize' term = fromMaybe term <$> minimize term

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -76,7 +76,6 @@ import           Unison.PatternP                ( Pattern )
 import qualified Unison.PatternP               as Pattern
 import           Unison.Reference               ( Reference )
 import           Unison.Referent                ( Referent )
-import           Unison.Term                    ( AnnotatedTerm' )
 import qualified Unison.Term                   as Term
 import qualified Unison.Type                   as Type
 import           Unison.Typechecker.Components  ( minimize' )
@@ -88,7 +87,7 @@ import qualified Unison.TypePrinter            as TP
 
 type TypeVar v loc = TypeVar.TypeVar (B.Blank loc) v
 type Type v loc = Type.Type (TypeVar v loc) loc
-type Term v loc = AnnotatedTerm' (TypeVar v loc) v loc
+type Term v loc = Term.Term' (TypeVar v loc) v loc
 type Monotype v loc = Type.Monotype (TypeVar v loc) loc
 type RedundantTypeAnnotation = Bool
 
@@ -270,7 +269,7 @@ data ErrorNote v loc = ErrorNote {
 -- with the fully qualified name fqn.
 data InfoNote v loc
   = SolvedBlank (B.Recorded loc) v (Type v loc)
-  | Decision v loc (Term.AnnotatedTerm v loc)
+  | Decision v loc (Term.Term v loc)
   | TopLevelComponent [(v, Type.Type v loc, RedundantTypeAnnotation)]
   deriving (Show)
 

--- a/parser-typechecker/src/Unison/Typechecker/TypeVar.hs
+++ b/parser-typechecker/src/Unison/Typechecker/TypeVar.hs
@@ -6,7 +6,7 @@ module Unison.Typechecker.TypeVar where
 import qualified Data.Set as Set
 import qualified Unison.ABT as ABT
 import qualified Unison.Term as Term
-import           Unison.Term (AnnotatedTerm, AnnotatedTerm')
+import           Unison.Term (Term, Term')
 import           Unison.Type (Type)
 import           Unison.Var (Var)
 import qualified Unison.Var as Var
@@ -47,8 +47,8 @@ liftType = ABT.vmap Universal
 lowerType :: Ord v => Type (TypeVar b v) a -> Type v a
 lowerType = ABT.vmap underlying
 
-liftTerm :: Ord v => AnnotatedTerm v a -> AnnotatedTerm' (TypeVar b v) v a
+liftTerm :: Ord v => Term v a -> Term' (TypeVar b v) v a
 liftTerm = Term.vtmap Universal
 
-lowerTerm :: Ord v => AnnotatedTerm' (TypeVar b v) v a -> AnnotatedTerm v a
+lowerTerm :: Ord v => Term' (TypeVar b v) v a -> Term v a
 lowerTerm = Term.vtmap underlying

--- a/parser-typechecker/tests/Unison/Test/Common.hs
+++ b/parser-typechecker/tests/Unison/Test/Common.hs
@@ -16,14 +16,13 @@ import           Unison.Parser (Ann(..))
 import           Unison.PrintError              ( prettyParseError )
 import           Unison.Result (Result, Note)
 import           Unison.Symbol (Symbol)
-import           Unison.Term (AnnotatedTerm)
 import           Unison.Var (Var)
 import           Unison.UnisonFile (TypecheckedUnisonFile)
 import qualified Unison.ABT                    as ABT
 import qualified Unison.Lexer                  as L
 import qualified Unison.Parser                 as Parser
+import qualified Unison.Term                   as Term
 import qualified Unison.TermParser             as TermParser
-import qualified Unison.Type
 import qualified Unison.Type                   as Type
 import qualified Unison.TypeParser             as TypeParser
 import qualified Unison.Util.Pretty            as Pr
@@ -31,8 +30,8 @@ import qualified Text.Megaparsec.Error         as MPE
 import qualified Unison.Names3
 
 
-type Term v = AnnotatedTerm v Ann
-type Type v = Unison.Type.Type v Ann
+type Term v = Term.Term v Ann
+type Type v = Type.Type v Ann
 
 hqLength :: Int
 hqLength = 10

--- a/parser-typechecker/tests/Unison/Test/Term.hs
+++ b/parser-typechecker/tests/Unison/Test/Term.hs
@@ -20,7 +20,7 @@ test = scope "term" $ tests
       let v s = Var.nameds s :: Symbol
           tv s = Type.var() (v s)
           v1 s = Var.freshenId 1 (v s)
-          tm :: Term.Term Symbol
+          tm :: Term.Term Symbol ()
           tm = Term.ann() (Term.ann()
                              (Term.nat() 42)
                              (Type.introOuter() (v "a") $

--- a/parser-typechecker/tests/Unison/Test/TermPrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/TermPrinter.hs
@@ -6,7 +6,8 @@ import EasyTest
 import qualified Data.Text as Text
 import Unison.ABT (annotation)
 import qualified Unison.HashQualified as HQ
-import Unison.Term
+import Unison.Term (Term)
+import qualified Unison.Term as Term
 import Unison.TermPrinter
 import qualified Unison.Type as Type
 import Unison.Symbol (Symbol, symbol)
@@ -29,7 +30,7 @@ getNames = PPE.fromNames Common.hqLength Unison.Builtin.names
 tcDiffRtt :: Bool -> String -> String -> Int -> Test ()
 tcDiffRtt rtt s expected width
   = let
-      inputTerm = tm s :: Unison.Term.AnnotatedTerm Symbol Ann
+      inputTerm = tm s :: Term Symbol Ann
       prettied  = CT.toPlain <$> pretty getNames inputTerm
       actual    = if width == 0
         then PP.renderUnbroken prettied
@@ -75,9 +76,9 @@ tcBinding :: Int -> String -> Maybe String -> String -> String -> Test ()
 tcBinding width v mtp tm expected
   = let
       baseTerm =
-        Unison.Test.Common.tm tm :: Unison.Term.AnnotatedTerm Symbol Ann
+        Unison.Test.Common.tm tm :: Term Symbol Ann
       inputType = fmap Unison.Test.Common.t mtp :: Maybe (Type.Type Symbol Ann)
-      inputTerm (Just tp) = ann (annotation tp) baseTerm tp
+      inputTerm (Just tp) = Term.ann (annotation tp) baseTerm tp
       inputTerm Nothing   = baseTerm
       varV     = symbol $ Text.pack v
       prettied = fmap CT.toPlain $ PP.syntaxToColor $ prettyBinding

--- a/parser-typechecker/tests/Unison/Test/UnisonSources.hs
+++ b/parser-typechecker/tests/Unison/Test/UnisonSources.hs
@@ -36,7 +36,7 @@ import qualified Unison.Result          as Result
 import qualified Unison.Runtime.Rt1IO   as RT
 import           Unison.Symbol          (Symbol)
 import qualified Unison.Term            as Term
-import           Unison.Term            ( AnnotatedTerm, Term, amap )
+import           Unison.Term            ( Term )
 import           Unison.Test.Common     (parseAndSynthesizeAsFile, parsingEnv)
 import           Unison.Type            ( Type )
 import qualified Unison.UnisonFile      as UF
@@ -153,8 +153,8 @@ resultTest rt uf filepath = do
           let [watchResult] = view _5 <$> Map.elems watches
               tm' = Term.letRec' False bindings watchResult
           -- note . show $ tm'
-          -- note . show $ amap (const ()) tm
-          expect $ tm' == amap (const ()) tm
+          -- note . show $ Term.amap (const ()) tm
+          expect $ tm' == Term.amap (const ()) tm
         Left e -> crash $ show e
     else pure ()
 
@@ -183,9 +183,9 @@ serializationTest uf = scope "serialization" . tests . concat $
           bytes = putBytes (V1.putEffectDeclaration V1.putSymbol putUnit) decl'
           decl'' = getFromBytes (V1.getEffectDeclaration V1.getSymbol getUnit) bytes
       in expectEqual decl'' (Just decl')
-    testTerm :: (Symbol, (Reference, AnnotatedTerm Symbol Ann, Type Symbol Ann)) -> Test ()
+    testTerm :: (Symbol, (Reference, Term Symbol Ann, Type Symbol Ann)) -> Test ()
     testTerm (name, (_, tm, tp)) = scope (Var.nameStr name) $
-      let tm' :: Term Symbol
+      let tm' :: Term Symbol ()
           tm' = Term.amap (const ()) tm
           tp' :: Type Symbol ()
           tp' = ABT.amap (const ()) tp

--- a/unison-core/src/Unison/Paths.hs
+++ b/unison-core/src/Unison/Paths.hs
@@ -7,7 +7,6 @@ import Unison.Prelude
 
 import Data.List
 import Unison.ABT (V)
-import Unison.Term (Term)
 import Unison.Var (Var)
 import qualified Data.Sequence as Sequence
 import qualified Unison.ABT as ABT
@@ -15,6 +14,7 @@ import qualified Unison.Term as E
 import qualified Unison.Type as T
 
 type Type v = T.Type v ()
+type Term v = E.Term v ()
 
 data Target v
   = Term (Term v)


### PR DESCRIPTION
This PR finally renames `AnnotatedTerm` to the `Term` we all know and love and alias over and over.

Specifically:
`AnnotatedTerm v a` becomes `Term v a`
`AnnotatedTerm' vt v a` becomes `Term' vt v a`
`AnnotatedTerm2 vt at ap v a` becomes `Term2 vt at ap v a`
`AnnotatedTerm3 v a` becomes `Term3 v a`

Also:
`Term v` becomes `Term0 v`
`Term' vt v` becomes `Term0' vt v`
but neither of these two is referenced outside of `Term.hs` anymore.

It doesn't close any existing issues, but it checks a box in #716.
