### PR TITLE
Fix/1320

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -51,12 +51,11 @@ import           UnliftIO.Directory             ( createDirectoryIfMissing
 import           System.FilePath                ( FilePath
                                                 , takeBaseName
                                                 , takeFileName
-                                                , takeDirectory
                                                 , (</>)
                                                 )
 import           System.Directory               ( copyFile
                                                 , getHomeDirectory
-                                                , makeAbsolute
+                                                , canonicalizePath
                                                 )
 import           System.Path                    ( replaceRoot
                                                 , createDir
@@ -128,10 +127,8 @@ initCodebaseAndExit mdir = do
   exitSuccess
 
 absDir :: FilePath -> IO FilePath
-absDir dir 
-  | dir == "." = makeAbsolute dir
-  | dir == ".." = takeDirectory <$> makeAbsolute "."
-  | otherwise = pure dir
+absDir dir =
+  if dir == "." || dir == ".." then canonicalizePath dir else pure dir
 
 initCodebase :: FilePath -> IO (Codebase IO Symbol Ann)
 initCodebase dir = do

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -126,15 +126,11 @@ initCodebaseAndExit mdir = do
   _ <- initCodebase dir
   exitSuccess
 
-absDir :: FilePath -> IO FilePath
-absDir dir =
-  if dir == "." || dir == ".." then canonicalizePath dir else pure dir
-
 initCodebase :: FilePath -> IO (Codebase IO Symbol Ann)
 initCodebase dir = do
   let path = dir </> codebasePath
   let theCodebase = codebase1 V1.formatSymbol formatAnn path
-  prettyDir <- P.string <$> absDir dir
+  prettyDir <- P.string <$> canonicalizePath dir
 
   whenM (exists path) $
     do PT.putPrettyLn'
@@ -156,7 +152,7 @@ getCodebaseOrExit :: Maybe FilePath -> IO (Codebase IO Symbol Ann)
 getCodebaseOrExit mdir = do
   (dir, errMsg) <- case mdir of
     Just dir -> do
-      dir' <- P.string <$> absDir dir
+      dir' <- P.string <$> canonicalizePath dir
       let errMsg = P.lines ["No codebase exists in " <> dir'
                            , "Run `ucm -codebase " <> P.string dir <> " init` to create one, then try again!"]
       pure ( dir, errMsg)

--- a/parser-typechecker/src/Unison/PrettyTerminal.hs
+++ b/parser-typechecker/src/Unison/PrettyTerminal.hs
@@ -28,7 +28,7 @@ putPrettyLn' :: P.Pretty CT.ColorText -> IO ()
 putPrettyLn' p | p == mempty = pure ()
 putPrettyLn' p = do
   width <- getAvailableWidth
-  less . P.toANSI width $ P.indentN 2 p
+  less . P.toANSI width $ p
 
 clearCurrentLine :: IO ()
 clearCurrentLine = do

--- a/parser-typechecker/src/Unison/Util/Pretty.hs
+++ b/parser-typechecker/src/Unison/Util/Pretty.hs
@@ -86,7 +86,6 @@ module Unison.Util.Pretty (
    spacedMap,
    spacesIfBreak,
    string,
-   endSentence,
    surroundCommas,
    syntaxToColor,
    text,
@@ -571,9 +570,6 @@ num n = fromString (show n)
 
 string :: IsString s => String -> Pretty s
 string = fromString
-
-endSentence :: IsString s => Pretty s -> Pretty s
-endSentence p = group (p <> ".")
 
 shown :: (Show a, IsString s) => a -> Pretty s
 shown = fromString . show


### PR DESCRIPTION
## Overview

This change aims to fix #1320 

When interacting with the `-codebase` flag a user might select `.` or `..` as a target directory both for an existing code base and for initialising a codebase.

## Implementation notes

* Removes warning triangle and extra lines.
* Removes the punctuation
* Removes indentation
* Translates `.` and `..`

## Interesting/controversial decisions

* I had previously added `Pretty.endSentence` to achieve punctuation after a path. No longer needed, removed.
* `PrettyTerminal.putPrettyLn'` is only used for these messages in `FileCodebase`, removing the "indentN 2" to prevent indentation.
* When `.` or `..` is used as the target directory only the error message translates it to the full path. Since the user requested `-codebase .` the  suggestion after the error is to `run -codebase . init`  

## Test coverage + Loose Ends

None of this is covered by automation as there are no tests that currently track changes to `ucm` output.

This can be achieved by :
* adding a new project (`stack exec output-tests`, along the lines of `stack exec transcripts`)
* creating a test structure parallel to the transcript tester using `easytest` and tests consisting of shell commands  to keep track of changes.