### PR TITLE
Unabbreviate pr.{create,load}

### DIFF
--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -683,14 +683,16 @@ push = InputPattern
   )
 
 createPullRequest :: InputPattern
-createPullRequest = InputPattern "pr.create" []
+createPullRequest = InputPattern "pull-request.create" ["pr.create"]
   [(Required, gitUrlArg), (Required, gitUrlArg), (Optional, pathArg)]
   (P.group $ P.lines
     [ P.wrap $ makeExample createPullRequest ["base", "head"]
         <> "will generate a request to merge the remote repo `head`"
         <> "into the remote repo `base`."
     , ""
-    , "example: pr.create https://github.com/unisonweb/base https://github.com/me/unison:.libs.pr.base"
+    , "example: " <> 
+      makeExampleNoBackticks createPullRequest ["https://github.com/unisonweb/base", 
+                                                "https://github.com/me/unison:.libs.pr.base" ]
     ])
   (\case
     [baseUrl, headUrl] -> first fromString $ do
@@ -701,7 +703,7 @@ createPullRequest = InputPattern "pr.create" []
   )
 
 loadPullRequest :: InputPattern
-loadPullRequest = InputPattern "pr.load" []
+loadPullRequest = InputPattern "pull-request.load" ["pr.load"]
   [(Required, gitUrlArg), (Required, gitUrlArg), (Optional, pathArg)]
   (P.lines
    [P.wrap $ makeExample loadPullRequest ["base", "head"]


### PR DESCRIPTION
This just changes the command name `pr.create` to `pull-request.create` and `pr.load` to `pull-request.load`. The `pr.create` and `pr.load` names are kept as aliases.

<img width="1232" alt="Screen Shot 2020-03-08 at 10 04 07 PM" src="https://user-images.githubusercontent.com/11074/76177080-691acf80-6189-11ea-9e2a-e83d7c6f7b40.png">
