### PR TITLE
correct annotation of match cases to always include the case body

### DIFF
--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -137,9 +137,11 @@ match = do
 matchCase :: Var v => P v (Term.MatchCase Ann (Term v Ann))
 matchCase = do
   (p, boundVars) <- parsePattern
+  let boundVars' = snd <$> boundVars
   guard <- optional $ reserved "|" *> infixAppOrBooleanOp
   t <- block "->"
-  pure . Term.MatchCase p (fmap (ABT.absChain' boundVars) guard) . ABT.annotate (ann t) $ ABT.absChain' boundVars t
+  let absChain vs t = foldr (\v t -> ABT.abs' (ann t) v t) t vs
+  pure . Term.MatchCase p (fmap (absChain boundVars') guard) $ absChain boundVars' t
 
 parsePattern :: forall v. Var v => P v (Pattern Ann, [(Ann, v)])
 parsePattern =

--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -139,7 +139,7 @@ matchCase = do
   (p, boundVars) <- parsePattern
   guard <- optional $ reserved "|" *> infixAppOrBooleanOp
   t <- block "->"
-  pure . Term.MatchCase p (fmap (ABT.absChain' boundVars) guard) $ ABT.absChain' boundVars t
+  pure . Term.MatchCase p (fmap (ABT.absChain' boundVars) guard) . ABT.annotate (ann t) $ ABT.absChain' boundVars t
 
 parsePattern :: forall v. Var v => P v (Pattern Ann, [(Ann, v)])
 parsePattern =


### PR DESCRIPTION
## Overview

Fixes #1329.

## Implementation notes

Explicitly sets the annotation for the case body of each match case, rather than relying on `ABT.absChain'` (which was annotating the case body term with the annotation for a bound variable from the case pattern).

## Test coverage

The change can be tested by adding the following to a scratch file and typechecking with/without the patch:
```
foo : Nat -> Text
foo x = match x with x -> x
```
Before the PR, the `-> x` at the end will not be highlighted in the typechecking output. With the PR, it will be highlighted.

Test coverage could be improved by adding tests in TermParser that explicitly check the annotations. This PR does not do that.