### PR TITLE
Fix #1225

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -735,7 +735,8 @@ stepManyAt0 actions b = go (first Path.toList <$> toList actions) b where
     stepChildren :: Map NameSegment (Branch m) -> Map NameSegment (Branch m)
     stepChildren m0 = foldl' g Map.empty (Map.keysSet m0 <> Map.keysSet childActions)
       where
-      g m seg = Map.insert seg child m where
+      insert seg child m = if isEmpty child then m else Map.insert seg child m 
+      g m seg = insert seg child m where
         child = case Map.lookup seg childActions of
           Just actions -> step (go actions) (Map.findWithDefault empty seg m0) 
           Nothing -> Map.findWithDefault empty seg m0 
@@ -755,11 +756,12 @@ stepManyAt0M actions b = go (first Path.toList <$> toList actions) b where
     stepChildren :: Map NameSegment (Branch m) -> n (Map NameSegment (Branch m))
     stepChildren m0 = foldM g Map.empty (Map.keysSet m0 <> Map.keysSet childActions)
       where
+      insert seg child m = if isEmpty child then m else Map.insert seg child m 
       g m seg = do
         child <- case Map.lookup seg childActions of
           Just actions -> stepM (go actions) (Map.findWithDefault empty seg m0) 
           Nothing -> pure $ Map.findWithDefault empty seg m0 
-        pure $ Map.insert seg child m
+        pure $ insert seg child m
     in do
       c2 <- stepChildren (view children b)
       currentAction (set children c2 b)

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -105,9 +105,9 @@ import Unison.Prelude hiding (empty)
 import           Prelude                  hiding (head,read,subtract)
 
 import           Control.Lens            hiding ( children, cons, transform, uncons )
-import qualified Control.Monad                 as Monad
 import qualified Control.Monad.State           as State
 import           Control.Monad.State            ( StateT )
+import           Data.Bifunctor                 ( first )
 import qualified Data.Map                      as Map
 import qualified Data.Map.Merge.Lazy           as Map
 import qualified Data.Set                      as Set
@@ -140,6 +140,7 @@ import qualified Unison.Reference              as Reference
 import qualified Unison.Util.Relation          as R
 import           Unison.Util.Relation            ( Relation )
 import qualified Unison.Util.Relation4         as R4
+import qualified Unison.Util.List              as List
 import           Unison.Util.Map                ( unionWithM )
 import qualified Unison.Util.Star3             as Star3
 import Unison.ShortHash (ShortHash)
@@ -719,32 +720,49 @@ modifyAtM path f b = case Path.uncons path of
     -- step the branch by updating its children according to fixup
     pure $ step (setChildBranch seg child') b
 
-stepAt0 :: Applicative m => Path
-                         -> (Branch0 m -> Branch0 m)
-                         -> Branch0 m -> Branch0 m
-stepAt0 p f = runIdentity . stepAt0M p (pure . f)
-
 -- stepManyAt0 consolidates several changes into a single step
-stepManyAt0 :: (Applicative m, Foldable f)
+stepManyAt0 :: forall f m . (Applicative m, Foldable f)
            => f (Path, Branch0 m -> Branch0 m)
            -> Branch0 m -> Branch0 m
-stepManyAt0 actions b = foldl' (\b (p, f) -> stepAt0 p f b) b actions
+stepManyAt0 actions b = go (first Path.toList <$> toList actions) b where
+  go :: [([NameSegment], Branch0 m -> Branch0 m)] -> Branch0 m -> Branch0 m
+  go actions b = let 
+    currentAction b = foldl' (\b f -> f b) b [ f | ([], f) <- actions ]
 
-stepManyAt0M :: (Monad m, Monad n, Foldable f)
+    childActions :: Map NameSegment [([NameSegment], Branch0 m -> Branch0 m)]
+    childActions = List.multimap [ (seg, (rest,f)) | ((seg:rest), f) <- actions ]
+
+    stepChildren :: Map NameSegment (Branch m) -> Map NameSegment (Branch m)
+    stepChildren m0 = foldl' g Map.empty (Map.keysSet m0 <> Map.keysSet childActions)
+      where
+      g m seg = Map.insert seg child m where
+        child = case Map.lookup seg childActions of
+          Just actions -> step (go actions) (Map.findWithDefault empty seg m0) 
+          Nothing -> Map.findWithDefault empty seg m0 
+    in currentAction $ over children stepChildren b 
+
+stepManyAt0M :: forall m n f . (Monad m, Monad n, Foldable f)
              => f (Path, Branch0 m -> n (Branch0 m))
              -> Branch0 m -> n (Branch0 m)
-stepManyAt0M actions b = Monad.foldM (\b (p, f) -> stepAt0M p f b) b actions
+stepManyAt0M actions b = go (first Path.toList <$> toList actions) b where
+  go :: [([NameSegment], Branch0 m -> n (Branch0 m))] -> Branch0 m -> n (Branch0 m)
+  go actions b = let 
+    currentAction b = foldM (\b f -> f b) b [ f | ([], f) <- actions ]
 
-stepAt0M :: forall n m. (Functor n, Applicative m)
-         => Path
-         -> (Branch0 m -> n (Branch0 m))
-         -> Branch0 m -> n (Branch0 m)
-stepAt0M p f b = case Path.uncons p of
-  Nothing -> f b
-  Just (seg, path) -> do
-    let child = getChildBranch seg b
-    child0' <- stepAt0M path f (head child)
-    pure $ setChildBranch seg (cons child0' child) b
+    childActions :: Map NameSegment [([NameSegment], Branch0 m -> n (Branch0 m))]
+    childActions = List.multimap [ (seg, (rest,f)) | ((seg:rest), f) <- actions ]
+
+    stepChildren :: Map NameSegment (Branch m) -> n (Map NameSegment (Branch m))
+    stepChildren m0 = foldM g Map.empty (Map.keysSet m0 <> Map.keysSet childActions)
+      where
+      g m seg = do
+        child <- case Map.lookup seg childActions of
+          Just actions -> stepM (go actions) (Map.findWithDefault empty seg m0) 
+          Nothing -> pure $ Map.findWithDefault empty seg m0 
+        pure $ Map.insert seg child m
+    in do
+      c2 <- stepChildren (view children b)
+      currentAction (set children c2 b)
 
 instance Hashable (Branch0 m) where
   tokens b =

--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -188,8 +188,8 @@ parseShortHashOrHQSplit' s =
 parseHQSplit :: String -> Either String HQSplit
 parseHQSplit s = case parseHQSplit' s of
   Right (Path' (Right (Relative p)), hqseg) -> Right (p, hqseg)
-  Right (Path' Left{}, _) -> 
-    Left $ "Sorry, you can't use an absolute name like " <> s <> " here." 
+  Right (Path' Left{}, _) ->
+    Left $ "Sorry, you can't use an absolute name like " <> s <> " here."
   Left e -> Left e
 
 parseHQSplit' :: String -> Either String HQSplit'
@@ -312,8 +312,6 @@ relativeToAncestor (Path a) (Path b) = case (a, b) of
   _ -> (empty, Path a, Path b)
 
 pattern Parent h t = Path (NameSegment h :<| t)
-pattern Cons h t <- Path (h :<| (Path -> t)) where 
-  Cons h (Path t) = Path (h :<| t)
 pattern Empty = Path Seq.Empty
 
 empty :: Path

--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -312,6 +312,9 @@ relativeToAncestor (Path a) (Path b) = case (a, b) of
   _ -> (empty, Path a, Path b)
 
 pattern Parent h t = Path (NameSegment h :<| t)
+pattern Cons h t <- Path (h :<| (Path -> t)) where 
+  Cons h (Path t) = Path (h :<| t)
+pattern Empty = Path Seq.Empty
 
 empty :: Path
 empty = Path mempty

--- a/unison-src/transcripts/delete.md
+++ b/unison-src/transcripts/delete.md
@@ -58,6 +58,10 @@ I can force my delete through by re-issuing the command.
 .a> delete foo
 ```
 
+```ucm:error
+.a> ls
+```
+
 Let's repeat all that on a type, for completeness.
 
 ```unison:hide

--- a/unison-src/transcripts/delete.output.md
+++ b/unison-src/transcripts/delete.output.md
@@ -137,6 +137,12 @@ I can force my delete through by re-issuing the command.
   Tip: You can use `undo` or `reflog` to undo this change.
 
 ```
+```ucm
+.a> ls
+
+  nothing to show
+
+```
 Let's repeat all that on a type, for completeness.
 
 ```unison
@@ -181,10 +187,6 @@ type Foo = Foo Boolean
        ↓
     5. ┌ Foo.Foo#d97e0jhkmd#0 : Nat -> Foo
     6. └ Foo.Foo#gq9inhvg9h#0 : Boolean -> b.Foo
-  
-  Added definitions:
-  
-    7. foo : Nat
   
   Tip: You can use `todo` to see if this generated any work to
        do in this namespace and `test` to run the tests. Or you

--- a/unison-src/transcripts/link.output.md
+++ b/unison-src/transcripts/link.output.md
@@ -196,27 +196,15 @@ myLibrary.h x = x + 3
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #jlbhn80169
+  ⊙ #mquil07fad
   
     
   
-  ⊙ #83aqs82gho
+  ⊙ #4nfhqq566a
   
     + Adds / updates:
     
-      h
-  
-  ⊙ #eisjldgdgg
-  
-    + Adds / updates:
-    
-      g
-  
-  ⊙ #seb6uuoocl
-  
-    + Adds / updates:
-    
-      f
+      f g h
   
   □ #7asfbtqmoj (start of history)
 

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -118,13 +118,13 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #ej4b7k7gup
+  ⊙ #be8v31d0lc
   
     - Deletes:
     
       feature1.y
   
-  ⊙ #t65ghfeidi
+  ⊙ #qcumplt3un
   
     + Adds / updates:
     
@@ -135,26 +135,26 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
       Original name New name(s)
       feature1.y    master.y
   
-  ⊙ #5m92mmhj69
+  ⊙ #qf8ku0e8ja
   
     + Adds / updates:
     
       feature1.y
   
-  ⊙ #tc6nvhv93h
+  ⊙ #jdd6dqbg1f
   
     > Moves:
     
       Original name New name
       x             master.x
   
-  ⊙ #3v6biscq0t
+  ⊙ #j222ocpe39
   
     + Adds / updates:
     
       x
   
-  ⊙ #upd8bubg9e
+  ⊙ #i5f8gcfb14
   
     + Adds / updates:
     

--- a/unison-src/transcripts/reflog.output.md
+++ b/unison-src/transcripts/reflog.output.md
@@ -65,16 +65,16 @@ y = 2
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #onc5fpvvb7 .old`   to make an old namespace
+    `fork #d7reeo8lc4 .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #onc5fpvvb7`  to reset the root namespace and
+    `reset-root #d7reeo8lc4`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
-  1. #bqd4d6mrnk : add
-  2. #onc5fpvvb7 : add
-  3. #upd8bubg9e : builtins.merge
+  1. #up853v4413 : add
+  2. #d7reeo8lc4 : add
+  3. #i5f8gcfb14 : builtins.merge
   4. #7asfbtqmoj : (initial reflogged namespace)
 
 ```


### PR DESCRIPTION
This is all set. To be merged after #1337.

## Overview

Fixes #1225, where a separate history entry was being created for each definition being added to a namespace. Now uses a post-order traversal of the branch as suggested by @aryairani, rebuilding from the bottom up and visiting each node exactly once. This avoids creating excessive history nodes. See the changed output for `link.md` transcript.

## Implementation notes

Change was very surgical, to `Branch.stepManyAt0` and `Branch.stepManyAt0M`.

## Interesting/controversial decisions

None that I can think of. There was an interesting change to the `delete.output.md`, but I stared at it a while and convinced myself the old output was wrong (annotated below). I don't totally understand why this change has fixed that bug though.

Also important note: this affects hashes for other transcripts just due to there being fewer steps in the history. All the transcripts still behave correctly though.

## Test coverage

Existing transcripts provide pretty good test coverage I think. I'd implemented it incorrectly at first and got lots of failures. :) 

I'll see if I can think of some more specific tests though.