### PR TITLE
supporting hashes in `alias`; and names and builtins in `replace`

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -15,6 +15,8 @@ module Unison.Builtin
   ,builtinTypeDependents
   ,builtinTermsByType
   ,builtinTermsByTypeMention
+  ,intrinsicTermReferences
+  ,intrinsicTypeReferences
   ,isBuiltinType
   ,typeLookup
   ,termRefTypes
@@ -24,6 +26,7 @@ import Unison.Prelude
 
 import           Data.Bifunctor                 ( second )
 import qualified Data.Map                      as Map
+import qualified Data.Set                      as Set
 import qualified Data.Text                     as Text
 import qualified Unison.ConstructorType        as CT
 import           Unison.Codebase.CodeLookup     ( CodeLookup(..) )
@@ -158,6 +161,18 @@ builtinTypesSrc =
   , B' "Link.Term" CT.Data
   , B' "Link.Type" CT.Data
   ]
+
+-- rename these to "builtin" later, when builtin means intrinsic as opposed to
+-- stuff that intrinsics depend on.
+intrinsicTypeReferences :: Set R.Reference
+intrinsicTypeReferences = foldl' go mempty builtinTypesSrc where
+  go acc = \case
+    B' r _ -> Set.insert (R.Builtin r) acc
+    D' r -> Set.insert (R.Builtin r) acc
+    _ -> acc
+
+intrinsicTermReferences :: Set R.Reference
+intrinsicTermReferences = Map.keysSet (termRefTypes @Symbol)
 
 builtinConstructorType :: Map R.Reference CT.ConstructorType
 builtinConstructorType = Map.fromList [ (R.Builtin r, ct) | B' r ct <- builtinTypesSrc ]

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -21,7 +21,7 @@ import qualified Unison.Names2                 as Names
 import           Unison.Reference               ( Reference )
 import qualified Unison.Reference              as Reference
 import qualified Unison.Referent as Referent
-import Unison.Referent (Referent)
+import Unison.Referent (Referent, Referent')
 import qualified Unison.Term                   as Term
 import qualified Unison.Type                   as Type
 import           Unison.Typechecker.TypeLookup  (TypeLookup(TypeLookup))
@@ -37,6 +37,7 @@ import Unison.DataDeclaration (Decl)
 import Unison.Term (Term)
 import Unison.Type (Type)
 import Unison.Codebase.ShortBranchHash (ShortBranchHash)
+import Unison.ShortHash (ShortHash)
 
 --import Debug.Trace
 
@@ -81,7 +82,9 @@ data Codebase m v a =
            , termsMentioningTypeImpl :: Reference -> m (Set Referent)
            -- number of base58 characters needed to distinguish any two references in the codebase
            , hashLength         :: m Int
-           , referencesByPrefix :: Text -> m (Set Reference.Id)
+           , termReferencesByPrefix :: ShortHash -> m (Set Reference.Id)
+           , typeReferencesByPrefix :: ShortHash -> m (Set Reference.Id)
+           , termReferentsByPrefix :: ShortHash -> m (Set (Referent' Reference.Id))
 
            , branchHashLength   :: m Int
            , branchHashesByPrefix :: ShortBranchHash -> m (Set Branch.Hash)

--- a/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
+++ b/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
@@ -49,11 +49,6 @@ getTerm (p, hq) b = case hq of
   filter sh = Set.filter (SH.isPrefixOf sh . Referent.toShortHash)
   terms = Branch._terms (Branch.getAt0 p b)
 
-getTermByShortHash :: SH.ShortHash -> Branch0 m -> Set Referent
-getTermByShortHash sh b = filter sh $ Branch.deepReferents b
-  where
-  filter sh = Set.filter (SH.isPrefixOf sh . Referent.toShortHash)
-
 getTermMetadataHQNamed :: (Path.Path, HQSegment) -> Branch0 m -> Metadata.R4 Referent NameSegment
 getTermMetadataHQNamed (path, hqseg) b =
   R4.filter (\(r,n,_t,_v) -> HQ'.matchesNamedReferent n r hqseg) terms

--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -72,7 +72,9 @@ data Command m i v a where
   -- the hash length needed to disambiguate any definition in the codebase
   CodebaseHashLength :: Command m i v Int
 
-  ReferencesByShortHash :: ShortHash -> Command m i v (Set Reference.Id)
+  TypeReferencesByShortHash :: ShortHash -> Command m i v (Set Reference)
+  TermReferencesByShortHash :: ShortHash -> Command m i v (Set Reference)
+  TermReferentsByShortHash :: ShortHash -> Command m i v (Set Referent)
 
   -- the hash length needed to disambiguate any branch in the codebase
   BranchHashLength :: Command m i v Int

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -212,29 +212,24 @@ loop = do
       getHQ'TermsIncludingHistorical p =
         getTermsIncludingHistorical (resolveSplit' p) root0
 
-      -- HHQS' -> Term References (for `replace`)
       getHQ'TermReferences :: Path.HQSplit' -> Set Reference
       getHQ'TermReferences p =
         Set.fromList [ r | Referent.Ref r <- toList (getHQ'Terms p) ]
-      -- HHQS' -> Term Referents (for `alias`)
       getHQ'Terms :: Path.HQSplit' -> Set Referent
       getHQ'Terms p = BranchUtil.getTerm (resolveSplit' p) root0
-      -- HHQS' -> Type References (for `replace` & `alias`)
       getHQ'Types :: Path.HQSplit' -> Set Reference
       getHQ'Types p = BranchUtil.getType (resolveSplit' p) root0
       resolveHHQS'Types :: HashOrHQSplit' -> Action' m v (Set Reference)
       resolveHHQS'Types = either 
         (eval . TypeReferencesByShortHash)
-        (pure . getHQ'Types)        
+        (pure . getHQ'Types)
+      -- Term Refs only
       resolveHHQS'Terms = either
         (eval . TermReferencesByShortHash)
         (pure . getHQ'TermReferences)
+      -- Term Refs and Cons
       resolveHHQS'Referents = either
-        (\h ->
-          (<>) <$> eval (TermReferentsByShortHash h)
-               <*> fmap (Set.map Referent.Ref)
-                        (eval (TermReferencesByShortHash h))
-               )
+        (eval . TermReferentsByShortHash)
         (pure . getHQ'Terms)
       getTypes :: Path.Split' -> Set Reference
       getTypes = getHQ'Types . fmap HQ'.NameOnly

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -211,8 +211,31 @@ loop = do
         eval . Eval $ Branch.getMaybePatch seg (Branch.head b)
       getHQ'TermsIncludingHistorical p =
         getTermsIncludingHistorical (resolveSplit' p) root0
+
+      -- HHQS' -> Term References (for `replace`)
+      getHQ'TermReferences :: Path.HQSplit' -> Set Reference
+      getHQ'TermReferences p =
+        Set.fromList [ r | Referent.Ref r <- toList (getHQ'Terms p) ]
+      -- HHQS' -> Term Referents (for `alias`)
+      getHQ'Terms :: Path.HQSplit' -> Set Referent
       getHQ'Terms p = BranchUtil.getTerm (resolveSplit' p) root0
+      -- HHQS' -> Type References (for `replace` & `alias`)
+      getHQ'Types :: Path.HQSplit' -> Set Reference
       getHQ'Types p = BranchUtil.getType (resolveSplit' p) root0
+      resolveHHQS'Types :: HashOrHQSplit' -> Action' m v (Set Reference)
+      resolveHHQS'Types = either 
+        (eval . TypeReferencesByShortHash)
+        (pure . getHQ'Types)        
+      resolveHHQS'Terms = either
+        (eval . TermReferencesByShortHash)
+        (pure . getHQ'TermReferences)
+      resolveHHQS'Referents = either
+        (\h ->
+          (<>) <$> eval (TermReferentsByShortHash h)
+               <*> fmap (Set.map Referent.Ref)
+                        (eval (TermReferencesByShortHash h))
+               )
+        (pure . getHQ'Terms)
       getTypes :: Path.Split' -> Set Reference
       getTypes = getHQ'Types . fmap HQ'.NameOnly
       getTerms :: Path.Split' -> Set Referent
@@ -284,7 +307,9 @@ loop = do
         patchExists :: Path.Split' -> _
         patchExists s = respond $ PatchAlreadyExists s
         typeNotFound = respond . TypeNotFound
+        typeNotFound' = respond . TypeNotFound'
         termNotFound = respond . TermNotFound
+        termNotFound' = respond . TermNotFound'
         nameConflicted src tms tys = respond (NameAmbiguous hqLength src tms tys)
         typeConflicted src = nameConflicted src Set.empty
         termConflicted src tms = nameConflicted src tms Set.empty
@@ -299,8 +324,8 @@ loop = do
           ForkLocalBranchI src dest -> "fork " <> hp' src <> " " <> p' dest
           MergeLocalBranchI src dest -> "merge " <> p' src <> " " <> p' dest
           ResetRootI src -> "reset-root " <> hp' src
-          AliasTermI src dest -> "alias.term " <> hqs' src <> " " <> ps' dest
-          AliasTypeI src dest -> "alias.type " <> hqs' src <> " " <> ps' dest
+          AliasTermI src dest -> "alias.term " <> hhqs' src <> " " <> ps' dest
+          AliasTypeI src dest -> "alias.type " <> hhqs' src <> " " <> ps' dest
           AliasManyI srcs dest ->
             "alias.many " <> intercalateMap " " hqs srcs <> " " <> p' dest
           MoveTermI src dest -> "move.term " <> hqs' src <> " " <> ps' dest
@@ -314,12 +339,12 @@ loop = do
           DeleteBranchI opath -> "delete.namespace " <> ops' opath
           DeletePatchI path -> "delete.patch " <> ps' path
           ReplaceTermI srcH targetH p ->
-            "replace.term " <> SH.toText srcH <> " "
-                            <> SH.toText targetH <> " "
+            "replace.term " <> hhqs' srcH <> " "
+                            <> hhqs' targetH <> " "
                             <> opatch p
           ReplaceTypeI srcH targetH p ->
-            "replace.type " <> SH.toText srcH <> " "
-                            <> SH.toText targetH <> " "
+            "replace.type " <> hhqs' srcH <> " "
+                            <> hhqs' targetH <> " "
                             <> opatch p
           ResolveTermNameI path -> "resolve.termName " <> hqs' path
           ResolveTypeNameI path -> "resolve.typeName " <> hqs' path
@@ -385,6 +410,8 @@ loop = do
           ops' = maybe "." ps'
           opatch = ps' . fromMaybe defaultPatchPath
           wat = error $ show input ++ " is not expected to alter the branch"
+          hhqs' (Left sh) = SH.toText sh
+          hhqs' (Right x) = hqs' x
           hqs' (p, hq) =
             Monoid.unlessM (Path.isRoot' p) (p' p) <> "." <> Text.pack (show hq)
           hqs (p, hq) = hqs' (Path' . Right . Path.Relative $ p, hq)
@@ -729,27 +756,46 @@ loop = do
             diffHelper (Branch.head prev) (Branch.head root') >>=
               respondNumbered . uncurry Output.ShowDiffAfterUndo
 
-      AliasTermI src dest -> case (toList (getHQ'Terms src), toList (getTerms dest)) of
-        ([r],       []) -> do
-          stepAt (BranchUtil.makeAddTermName (resolveSplit' dest) r (oldMD r))
-          success
-        ([_], rs@(_:_)) -> termExists dest (Set.fromList rs)
-        ([],         _) -> termNotFound src
-        (rs,         _) -> termConflicted src (Set.fromList rs)
-        where
-        p = resolveSplit' src
-        oldMD r = BranchUtil.getTermMetadataAt p r root0
+      AliasTermI src dest -> do
+        referents <- resolveHHQS'Referents src
+        case (toList referents, toList (getTerms dest)) of
+          ([r],       []) -> do
+            stepAt (BranchUtil.makeAddTermName (resolveSplit' dest) r (oldMD r))
+            success
+          ([_], rs@(_:_)) -> termExists dest (Set.fromList rs)
+          ([],         _) -> either termNotFound' termNotFound src
+          (rs,         _) ->
+            either hashConflicted termConflicted src (Set.fromList rs)
+          where
+          oldMD r = either (const mempty)
+                           (\src ->
+                            let p = resolveSplit' src in
+                            BranchUtil.getTermMetadataAt p r root0)
+                           src
 
-      AliasTypeI src dest -> case (toList (getHQ'Types src), toList (getTypes dest)) of
-        ([r],       []) -> do
-          stepAt (BranchUtil.makeAddTypeName (resolveSplit' dest) r (oldMD r))
-          success
-        ([_], rs@(_:_)) -> typeExists dest (Set.fromList rs)
-        ([],         _) -> typeNotFound src
-        (rs,         _) -> typeConflicted src (Set.fromList rs)
-        where
-        p = resolveSplit' src
-        oldMD r = BranchUtil.getTypeMetadataAt p r root0
+      AliasTypeI src dest -> do
+        refs <- resolveHHQS'Types src
+        case (toList refs, toList (getTypes dest)) of
+          ([r],       []) -> do
+            stepAt (BranchUtil.makeAddTypeName (resolveSplit' dest) r (oldMD r))
+            success
+          ([_], rs@(_:_)) -> typeExists dest (Set.fromList rs)
+          ([],         _) -> either typeNotFound' typeNotFound src
+          (rs,         _) ->
+            either
+              (\src -> hashConflicted src . Set.map Referent.Ref)
+              typeConflicted
+              src
+              (Set.fromList rs)
+
+
+          where
+          oldMD r =
+            either (const mempty)
+                   (\src ->
+                    let p = resolveSplit' src in
+                    BranchUtil.getTypeMetadataAt p r root0)
+                   src
 
       -- this implementation will happily produce name conflicts,
       -- but will surface them in a normal diff at the end of the operation.
@@ -1102,19 +1148,20 @@ loop = do
       ReplaceTermI from to patchPath -> do
         let patchPath' = fromMaybe defaultPatchPath patchPath
         patch <- getPatchAt patchPath'
-        fromRefs <- eval $ ReferencesByShortHash from
-        toRefs <- eval $ ReferencesByShortHash to
-        let go :: Reference.Id
-               -> Reference.Id
+        fromRefs <- resolveHHQS'Terms from
+        toRefs <- resolveHHQS'Terms to
+        let go :: Reference
+               -> Reference
                -> Action m (Either Event Input) v ()
-            go fid tid = do
-              let fr = DerivedId fid
-                  tr = DerivedId tid
+            go fr tr = do
               mft <- eval $ LoadTypeOfTerm fr
               mtt <- eval $ LoadTypeOfTerm tr
+              let termNotFound = respond . TermNotFound'
+                                         . SH.take hqLength
+                                         . Reference.toShortHash
               case (mft, mtt) of
-                (Nothing, _) -> respond $ TermNotFound' fid
-                (_, Nothing) -> respond $ TermNotFound' tid
+                (Nothing, _) -> termNotFound fr
+                (_, Nothing) -> termNotFound tr
                 (Just ft, Just tt) -> do
                   let
                       patch' =
@@ -1133,29 +1180,33 @@ loop = do
                   void $ propagatePatch inputDescription patch' currentPath'
                   -- Say something
                   success
+            sayNotFound = respond
+              . SearchTermsNotFound
+              . pure
+              . either
+                  HQ.HashOnly
+                  (fmap Path.toName' . HQ'.toHQ . Path.unsplitHQ')
+            sayHashConflicted t = hashConflicted t . Set.map Referent.Ref
+            sayTermConflicted t = termConflicted t . Set.map Referent.Ref
         zeroOneOrMore
           fromRefs
-          (respond $ SearchTermsNotFound [HQ.HashOnly from])
+          (sayNotFound from)
           (\r -> zeroOneOrMore toRefs
-                               (respond $ SearchTermsNotFound [HQ.HashOnly to])
+                               (sayNotFound to)
                                (go r)
-                               (hashConflicted to .
-                                 Set.map (Referent.Ref . DerivedId)))
-          (hashConflicted from .
-            Set.map (Referent.Ref . DerivedId))
+                               (either sayHashConflicted sayTermConflicted to))
+          (either sayHashConflicted sayTermConflicted from)
 
       ReplaceTypeI from to patchPath -> do
         let patchPath' = fromMaybe defaultPatchPath patchPath
         patch <- getPatchAt patchPath'
-        fromRefs <- eval $ ReferencesByShortHash from
-        toRefs <- eval $ ReferencesByShortHash to
-        let go :: Reference.Id
-               -> Reference.Id
+        fromRefs <- resolveHHQS'Types from
+        toRefs <- resolveHHQS'Types to
+        let go :: Reference
+               -> Reference
                -> Action m (Either Event Input) v ()
-            go fid tid = do
-              let fr = DerivedId fid
-                  tr = DerivedId tid
-                  patch' =
+            go fr tr = do
+              let patch' =
                     -- The modified patch
                     over Patch.typeEdits
                       (R.insert fr (TypeEdit.Replace tr) . R.deleteDom fr) patch
@@ -1168,16 +1219,21 @@ loop = do
               void $ propagatePatch inputDescription patch' currentPath'
               -- Say something
               success
+            sayNotFound = respond
+              . SearchTermsNotFound
+              . pure
+              . either
+                  HQ.HashOnly
+                  (fmap Path.toName' . HQ'.toHQ . Path.unsplitHQ')
+            sayHashConflicted t = hashConflicted t . Set.map Referent.Ref
         zeroOneOrMore
           fromRefs
-          (respond $ SearchTermsNotFound [HQ.HashOnly from])
+          (sayNotFound from)
           (\r -> zeroOneOrMore toRefs
-                               (respond $ SearchTermsNotFound [HQ.HashOnly to])
+                               (sayNotFound to)
                                (go r)
-                               (hashConflicted to .
-                                 Set.map (Referent.Ref . DerivedId)))
-          (hashConflicted from .
-            Set.map (Referent.Ref . DerivedId))
+                               (either sayHashConflicted typeConflicted to))
+          (either sayHashConflicted typeConflicted from)
 
       LoadI maybePath ->
         case maybePath <|> (fst <$> latestFile') of
@@ -1361,7 +1417,7 @@ loop = do
               Reference.DerivedId rid -> do
                 tm <- eval $ LoadTerm rid
                 case tm of
-                  Nothing -> [] <$ respond (TermNotFound' rid)
+                  Nothing -> [] <$ respond (TermNotFound' . SH.take hqLength . Reference.toShortHash $ Reference.DerivedId rid)
                   Just tm -> do
                     respond $ TestIncrementalOutputStart ppe (n,total) r tm
                     tm' <- eval (Evaluate1 ppe tm) <&> \case

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -4,6 +4,7 @@ module Unison.Codebase.Editor.Input
   , OutputLocation(..)
   , PatchPath
   , BranchId, parseBranchId
+  , HashOrHQSplit'
   ) where
 
 import Unison.Prelude
@@ -28,6 +29,7 @@ type Source = Text -- "id x = x\nconst a b = a"
 type SourceName = Text -- "foo.u" or "buffer 7"
 type PatchPath = Path.Split'
 type BranchId = Either ShortBranchHash Path'
+type HashOrHQSplit' = Either ShortHash Path.HQSplit'
 
 parseBranchId :: String -> Either String BranchId
 parseBranchId ('#':s) = case SBH.fromText (Text.pack s) of
@@ -61,8 +63,8 @@ data Input
     -- > names .foo.bar#asdflkjsdf
     -- > names #sdflkjsdfhsdf
     | NamesI HQ.HashQualified
-    | AliasTermI Path.HQSplit' Path.Split'
-    | AliasTypeI Path.HQSplit' Path.Split'
+    | AliasTermI HashOrHQSplit' Path.Split'
+    | AliasTypeI HashOrHQSplit' Path.Split'
     | AliasManyI [Path.HQSplit] Path'
     -- Move = Rename; It's an HQSplit' not an HQSplit', meaning the arg has to have a name.
     | MoveTermI Path.HQSplit' Path.Split'
@@ -97,8 +99,8 @@ data Input
     | AddTypeReplacementI PatchPath Reference Reference
     | RemoveTermReplacementI PatchPath Reference Reference
     | RemoveTypeReplacementI PatchPath Reference Reference
-    | ReplaceTermI ShortHash ShortHash (Maybe PatchPath)
-    | ReplaceTypeI ShortHash ShortHash (Maybe PatchPath)
+    | ReplaceTermI HashOrHQSplit' HashOrHQSplit' (Maybe PatchPath)
+    | ReplaceTypeI HashOrHQSplit' HashOrHQSplit' (Maybe PatchPath)
   | UndoI
   -- First `Maybe Int` is cap on number of results, if any
   -- Second `Maybe Int` is cap on diff elements shown, if any

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -39,7 +39,6 @@ import qualified Unison.HashQualified as HQ
 import qualified Unison.HashQualified' as HQ'
 import qualified Unison.Parser as Parser
 import qualified Unison.PrettyPrintEnv as PPE
-import qualified Unison.Reference as Reference
 import qualified Unison.Typechecker.Context as Context
 import qualified Unison.UnisonFile as UF
 import qualified Unison.Util.Pretty as P
@@ -114,7 +113,8 @@ data Output v
   | PatchNotFound Path.Split'
   | TypeNotFound Path.HQSplit'
   | TermNotFound Path.HQSplit'
-  | TermNotFound' Reference.Id
+  | TypeNotFound' ShortHash
+  | TermNotFound' ShortHash
   | SearchTermsNotFound [HQ.HashQualified]
   -- ask confirmation before deleting the last branch that contains some defns
   -- `Path` is one of the paths the user has requested to delete, and is paired
@@ -267,6 +267,7 @@ isFailure o = case o of
   NameNotFound{} -> True
   PatchNotFound{} -> True
   TypeNotFound{} -> True
+  TypeNotFound'{} -> True
   TermNotFound{} -> True
   TermNotFound'{} -> True
   SearchTermsNotFound ts -> not (null ts)

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -84,7 +84,10 @@ import qualified Unison.Hash                   as Hash
 import           Unison.Parser                  ( Ann(External) )
 import           Unison.Reference               ( Reference )
 import qualified Unison.Reference              as Reference
-import           Unison.Referent                ( Referent(..) )
+import           Unison.Referent                ( Referent
+                                                , pattern Ref
+                                                , pattern Con
+                                                , Referent' )
 import qualified Unison.Referent               as Referent
 import           Unison.Term                    ( Term )
 import qualified Unison.Term                   as Term
@@ -99,6 +102,10 @@ import qualified Unison.PrettyTerminal         as PT
 import           Unison.Symbol                  ( Symbol )
 import Unison.Codebase.ShortBranchHash (ShortBranchHash(..))
 import qualified Unison.Codebase.ShortBranchHash as SBH
+import Unison.ShortHash (ShortHash)
+import qualified Unison.ShortHash as SH
+import qualified Unison.ConstructorType as CT
+import Unison.Util.Monoid (foldMapM)
 
 type CodebasePath = FilePath
 
@@ -557,13 +564,43 @@ putWatch putV putA path k id e = liftIO $ S.putWithParentDirs
   (watchesDir path (Text.pack k) </> componentIdToString id <> ".ub")
   e
 
-referencesByPrefix :: MonadIO m => CodebasePath -> Text -> m (Set Reference.Id)
-referencesByPrefix codebasePath p =
-  liftIO $ fmap (Set.fromList . join) . for [termsDir, typesDir] $ \f -> do
-    let dir = f codebasePath
-    paths <- filter (isPrefixOf $ Text.unpack p) <$> listDirectory dir
-    let refs = paths >>= (toList . componentIdFromString)
-    pure refs
+loadReferencesByPrefix
+  :: MonadIO m => FilePath -> ShortHash -> m (Set Reference.Id)
+loadReferencesByPrefix dir sh = liftIO $ do
+    refs <- mapMaybe Reference.fromShortHash
+             . filter (SH.isPrefixOf sh)
+             . mapMaybe SH.fromString
+            <$> listDirectory dir
+    pure $ Set.fromList [ i | Reference.DerivedId i <- refs]
+
+termReferencesByPrefix, typeReferencesByPrefix
+  :: MonadIO m => CodebasePath -> ShortHash -> m (Set Reference.Id)
+termReferencesByPrefix root = loadReferencesByPrefix (termsDir root)
+typeReferencesByPrefix root = loadReferencesByPrefix (typesDir root)
+
+-- returns all the derived terms and derived constructors
+termReferentsByPrefix :: MonadIO m
+  => Codebase m v a
+  -> CodebasePath
+  -> ShortHash
+  -> m (Set (Referent' Reference.Id))
+termReferentsByPrefix c root sh = do
+  terms <- termReferencesByPrefix root sh
+  ctors <- do
+    types <- typeReferencesByPrefix root sh
+    foldMapM collect types
+  pure (Set.map Referent.Ref' terms <> ctors)
+  where
+  -- load up the Decl for `ref` to see how many constructors it has,
+  -- and what constructor type
+  collect ref =
+   Codebase.getTypeDeclaration c ref <&> (\case
+    Nothing -> mempty
+    Just decl ->
+      Set.fromList [ Referent.Con' ref i ct
+                   | i <- [0 .. ctorCount-1]]
+      where ct = either (const CT.Effect) (const CT.Data) decl
+            ctorCount = length . DD.constructors' $ DD.asDataDecl decl)
 
 branchHashesByPrefix :: MonadIO m => CodebasePath -> ShortBranchHash -> m (Set Branch.Hash)
 branchHashesByPrefix codebasePath p =
@@ -613,7 +650,9 @@ codebase1 fmtV@(S.Format getV putV) fmtA@(S.Format getA putA) path =
    -- todo: maintain a trie of references to come up with this number
           (pure 10)
    -- The same trie can be used to make this lookup fast:
-          (referencesByPrefix path)
+          (termReferencesByPrefix path)
+          (typeReferencesByPrefix path)
+          (termReferentsByPrefix c path)
           (pure 10)
           (branchHashesByPrefix path)
    in c

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -799,9 +799,12 @@ notifyUser dir o = case o of
     P.wrap "Try again with a few more hash characters to disambiguate."
     ]
   BadDestinationBranch _ -> pure "That destination namespace is bad."
-  TermNotFound' h ->
+  TermNotFound' sh ->
     pure $ "I could't find a term with hash "
-         <> (prettyShortHash $ Reference.toShortHash (Reference.DerivedId h))
+         <> (prettyShortHash sh)
+  TypeNotFound' sh ->
+    pure $ "I could't find a type with hash "
+         <> (prettyShortHash sh)
   NothingToPatch _patchPath dest -> pure $
     P.callout "😶" . P.wrap
        $ "This had no effect. Perhaps the patch has already been applied"

--- a/unison-core/src/Unison/LabeledDependency.hs
+++ b/unison-core/src/Unison/LabeledDependency.hs
@@ -1,10 +1,12 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 module Unison.LabeledDependency (derivedTerm, derivedType, termRef, typeRef, referent, dataConstructor, effectConstructor, fold, referents, LabeledDependency) where
 
 import Unison.Prelude hiding (fold)
 
 import Unison.ConstructorType (ConstructorType(Data, Effect))
 import Unison.Reference (Reference(DerivedId), Id)
-import Unison.Referent (Referent(Ref, Con))
+import Unison.Referent (Referent, pattern Ref, pattern Con)
 import qualified Data.Set as Set
 
 -- dumb constructor name is private

--- a/unison-core/src/Unison/Names2.hs
+++ b/unison-core/src/Unison/Names2.hs
@@ -55,7 +55,7 @@ import           Unison.Name                  (Name)
 import qualified Unison.Name                  as Name
 import           Unison.Reference             (Reference)
 import qualified Unison.Reference             as Reference
-import           Unison.Referent              (Referent (..))
+import           Unison.Referent              (Referent)
 import qualified Unison.Referent              as Referent
 import           Unison.Util.Relation         (Relation)
 import qualified Unison.Util.Relation         as R

--- a/unison-core/src/Unison/Referent.hs
+++ b/unison-core/src/Unison/Referent.hs
@@ -19,8 +19,15 @@ import qualified Unison.ConstructorType as CT
 
 -- Slightly odd naming. This is the "referent of term name in the codebase",
 -- rather than the target of a Reference.
-data Referent = Ref Reference | Con Reference Int ConstructorType
-  deriving (Show, Ord, Eq)
+type Referent = Referent' Reference
+pattern Ref :: Reference -> Referent
+pattern Ref r = Ref' r
+pattern Con :: Reference -> Int -> ConstructorType -> Referent
+pattern Con r i t = Con' r i t
+{-# COMPLETE Ref, Con #-}
+
+data Referent' r = Ref' r | Con' r Int ConstructorType
+  deriving (Show, Ord, Eq, Functor)
 
 type Pos = Word64
 type Size = Word64

--- a/unison-src/transcripts/fix1334.md
+++ b/unison-src/transcripts/fix1334.md
@@ -1,0 +1,38 @@
+Previously, `alias.term` / `alias.type` would fail if the source argument was hash-only. Also, `replace.term` / `replace.type` only worked on full hashes.
+
+With the PR, the source of an alias can be a shorthash, and the arguments to `replace.term` / `replace.type` can be hash-qualified or names-only.
+
+Let's make some hash-only aliases, now that we can.
+
+```ucm
+.> alias.type ##Nat Cat
+.> alias.type ##Boolean Twoolean
+.> alias.term ##Nat.+ please_fix_763.+
+.> alias.term ##Universal.== please_fix_763.==
+```
+
+And some functions that use them:
+```unison
+f = 3
+g = 4
+h = f + 1 == 5
+
+> h
+```
+
+```ucm
+.> add
+```
+
+We used to have to know the full hash for a definition to be able to use the `replace.*` commands, but now we don't:
+```ucm
+.> names g
+.> replace.term f g
+.> names g
+.> view.patch
+```
+
+The value of `h` should have been updated too:
+```unison
+> h
+```

--- a/unison-src/transcripts/fix1334.md
+++ b/unison-src/transcripts/fix1334.md
@@ -1,8 +1,8 @@
-Previously, `alias.term` / `alias.type` would fail if the source argument was hash-only. Also, `replace.term` / `replace.type` only worked on full hashes.
+Previously, the `alias.term` and `alias.type` would fail if the source argument was hash-only, and there was no way to create an alias for a definition that didn't already have a name.  Also, the `replace.term` and `replace.type` _only_ worked on hashes, and they had to be _full_ hashes.
 
-With the PR, the source of an alias can be a shorthash, and the arguments to `replace.term` / `replace.type` can be hash-qualified or names-only.
+With this PR, the source of an alias can be a short hash (even of a definition that doesn't currently have a name in the namespace) along with a name or hash-qualified name from the current namespace as usual, and the arguments to `replace.term` and `replace.type` can be a short hash, a name, or a hash-qualified name.
 
-Let's make some hash-only aliases, now that we can.
+Let's make some hash-only aliases, now that we can. :mad-with-power-emoji:
 
 ```ucm
 .> alias.type ##Nat Cat

--- a/unison-src/transcripts/fix1334.output.md
+++ b/unison-src/transcripts/fix1334.output.md
@@ -1,0 +1,105 @@
+Previously, `alias.term` / `alias.type` would fail if the source argument was hash-only. Also, `replace.term` / `replace.type` only worked on full hashes.
+
+With the PR, the source of an alias can be a shorthash, and the arguments to `replace.term` / `replace.type` can be hash-qualified or names-only.
+
+Let's make some hash-only aliases, now that we can.
+
+```ucm
+.> alias.type ##Nat Cat
+
+  Done.
+
+.> alias.type ##Boolean Twoolean
+
+  Done.
+
+.> alias.term ##Nat.+ please_fix_763.+
+
+  Done.
+
+.> alias.term ##Universal.== please_fix_763.==
+
+  Done.
+
+```
+And some functions that use them:
+```unison
+f = 3
+g = 4
+h = f + 1 == 5
+
+> h
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      f : Cat
+      g : Cat
+      h : Twoolean
+   
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    5 | > h
+          ⧩
+          false
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    f : Cat
+    g : Cat
+    h : Twoolean
+
+```
+We used to have to know the full hash for a definition to be able to use the `replace.*` commands, but now we don't:
+```ucm
+.> names g
+
+  Term
+  Hash:   #52addbrohu
+  Names:  g
+
+.> replace.term f g
+
+  Done.
+
+.> names g
+
+  Term
+  Hash:   #52addbrohu
+  Names:  f g
+
+.> view.patch
+
+  Edited Terms: f#msp7bv40rv -> f
+
+```
+The value of `h` should have been updated too:
+```unison
+> h
+```
+
+```ucm
+
+  ✅
+  
+  scratch.u changed.
+   
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    1 | > h
+          ⧩
+          true
+
+```

--- a/unison-src/transcripts/fix1334.output.md
+++ b/unison-src/transcripts/fix1334.output.md
@@ -1,8 +1,8 @@
-Previously, `alias.term` / `alias.type` would fail if the source argument was hash-only. Also, `replace.term` / `replace.type` only worked on full hashes.
+Previously, the `alias.term` and `alias.type` would fail if the source argument was hash-only, and there was no way to create an alias for a definition that didn't already have a name.  Also, the `replace.term` and `replace.type` _only_ worked on hashes, and they had to be _full_ hashes.
 
-With the PR, the source of an alias can be a shorthash, and the arguments to `replace.term` / `replace.type` can be hash-qualified or names-only.
+With this PR, the source of an alias can be a short hash (even of a definition that doesn't currently have a name in the namespace) along with a name or hash-qualified name from the current namespace as usual, and the arguments to `replace.term` and `replace.type` can be a short hash, a name, or a hash-qualified name.
 
-Let's make some hash-only aliases, now that we can.
+Let's make some hash-only aliases, now that we can. :mad-with-power-emoji:
 
 ```ucm
 .> alias.type ##Nat Cat


### PR DESCRIPTION
## Overview

Previously, the `alias.term` and `alias.type` would fail if the source argument was hash-only, and there was no way to create an alias for a definition that didn't already have a name.  Also, the `replace.term` and `replace.type` _only_ worked on hashes, and they had to be _full_ hashes.

With this PR, the source of an alias can be a short hash (even of a definition that doesn't currently have a name in the namespace) along with a name or hash-qualified name from the current namespace as usual, and the arguments to `replace.term` and `replace.type` can be a short hash, a name, or a hash-qualified name.

Closes #780 
Closes #1047

## Implementation notes

* Exploded Codebase.referencesByPrefix into three functions:
  ```
  - referencesByPrefix :: Text -> m (Set Reference.Id)
  + termReferencesByPrefix :: ShortHash -> m (Set Reference.Id)
  + typeReferencesByPrefix :: ShortHash -> m (Set Reference.Id)
  + termReferentsByPrefix :: ShortHash -> m (Set (Referent' Reference.Id))
  ```
  for top-level terms, top-level types, and for Ref/Con mix.

* Exploded Command.ReferencesByShortHash into three functions
  ```
  - ReferencesByShortHash :: ShortHash -> Command m i v (Set Reference.Id)
  + TypeReferencesByShortHash :: ShortHash -> Command m i v (Set Reference)
  + TermReferencesByShortHash :: ShortHash -> Command m i v (Set Reference)
  + TermReferentsByShortHash :: ShortHash -> Command m i v (Set Referent)
  ```

## Interesting/controversial decisions

*  **Note:** As it stands, the types in the Codebase API can only returns `Derived` references; `Builtin` references get added by the Command API.

* By design, the current implementation doesn't let you abbreviate `Builtin` references, but you can abbreviate hash references.

- I added a type arg `r` to Referent, to have a reusable representation for Referents based on `Reference.Id` (i.e. those which are not builtins), and added type alias and patterns for backwards compatibility.
  ```
  data Referent' r = Ref' r | Con' r Int ConstructorType
    deriving (Show, Ord, Eq, Functor)

  type Referent = Referent' Reference
  pattern Ref :: Reference -> Referent
  pattern Ref r = Ref' r
  pattern Con :: Reference -> Int -> ConstructorType -> Referent
  pattern Con r i t = Con' r i t
  {-# COMPLETE Ref, Con #-}
  ```

## Test coverage

Transcript output is [here](https://github.com/unisonweb/unison/blob/6b5d60cb20f9dd1eccbe12fff1b4fa23892f49f3/unison-src/transcripts/fix1334.output.md).
