### PR TITLE
Fix Branch.updateChildren to not elide empty branches with history

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -691,7 +691,7 @@ updateChildren ::NameSegment
                -> Map NameSegment (Branch m)
                -> Map NameSegment (Branch m)
 updateChildren seg updatedChild =
-  if isEmpty0 (head updatedChild)
+  if isEmpty updatedChild
   then Map.delete seg
   else Map.insert seg updatedChild
 

--- a/unison-src/transcripts/delete.output.md
+++ b/unison-src/transcripts/delete.output.md
@@ -182,10 +182,6 @@ type Foo = Foo Boolean
     5. ┌ Foo.Foo#d97e0jhkmd#0 : Nat -> Foo
     6. └ Foo.Foo#gq9inhvg9h#0 : Boolean -> b.Foo
   
-  Added definitions:
-  
-    7. foo : Nat
-  
   Tip: You can use `todo` to see if this generated any work to
        do in this namespace and `test` to run the tests. Or you
        can use `undo` or `reflog` to undo the results of this


### PR DESCRIPTION
My thinking is merge this after it passes CI, then merge #1333 

## Overview

Currently, `Branch.updateChildren` deletes branches that have no definitions in them but which do have history. Use of this function caused previously deleted definitions to resurface during a merge. See the discussion [in this PR](https://github.com/unisonweb/unison/pull/1333#discussion_r390628109). 

I think the correct behavior is to only delete a child if it is being replaced with the empty `Branch` (with no history), as is done in a `delete.namespace`. That's what this PR does.

## Test coverage

The existing transcripts provide pretty good coverage along with the implementation that's in `master` which still uses `updateChildren` for various operations on `Branch`. Assuming those transcripts still pass in this PR, this is safe to merge I'd say.