### PR TITLE
Some nice cleanup of `stepManyAt0` and friends

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
+++ b/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
@@ -26,7 +26,7 @@ import qualified Unison.Util.List as List
 import Unison.Codebase.Patch (Patch)
 import Unison.Codebase.NameSegment (HQSegment, NameSegment)
 
-addFromNames0 :: Applicative m => Names0 -> Branch0 m -> Branch0 m
+addFromNames0 :: Monad m => Names0 -> Branch0 m -> Branch0 m
 addFromNames0 names0 = Branch.stepManyAt0 (typeActions <> termActions)
   where
   typeActions = map doType . R.toList $ Names.types names0

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1920,7 +1920,7 @@ updateAtM reason (Path.Absolute p) f = do
   updateRoot b b' reason
   pure $ b /= b'
 
-stepAt :: forall m i v. Applicative m
+stepAt :: forall m i v. Monad m
        => InputDescription
        -> (Path, Branch0 m -> Branch0 m)
        -> Action m i v ()
@@ -1938,7 +1938,7 @@ stepAtM' :: forall m i v. Monad m
         -> Action m i v Bool
 stepAtM' cause = stepManyAtM' @m @[] cause . pure
 
-stepManyAt :: (Applicative m, Foldable f)
+stepManyAt :: (Monad m, Foldable f)
            => InputDescription
            -> f (Path, Branch0 m -> Branch0 m)
            -> Action m i v ()
@@ -2189,7 +2189,7 @@ filterBySlurpResult SlurpResult{..} UF.TypecheckedUnisonFile{..} =
   filterTLC (v,_,_) = Set.member v keepTerms
 
 -- updates the namespace for adding `slurp`
-doSlurpAdds :: forall m v. (Applicative m, Var v)
+doSlurpAdds :: forall m v. (Monad m, Var v)
             => SlurpComponent v
             -> UF.TypecheckedUnisonFile v Ann
             -> (Branch0 m -> Branch0 m)
@@ -2223,7 +2223,7 @@ doSlurpAdds slurp uf = Branch.stepManyAt0 (typeActions <> termActions)
   errorEmptyVar = error "encountered an empty var name"
   errorMissingVar v = error $ "expected to find " ++ show v ++ " in " ++ show uf
 
-doSlurpUpdates :: Applicative m
+doSlurpUpdates :: Monad m
                => Map Name (Reference, Reference)
                -> Map Name (Reference, Reference)
                -> [(Name, Referent)]


### PR DESCRIPTION
@aryairani suggested these improvements, see discussion [here](https://github.com/unisonweb/unison/pull/1333#pullrequestreview-372819650). 

It worked out very nicely, except one downside is various functions picked up a `Monad m` constraint where before they could get away with `Applicative m`. I don't think this was a big deal at all as `m` is always a `Monad` anyway. Here's the new implementation:

https://github.com/unisonweb/unison/blob/de5261a81c67e37a4322ff77ba50ab7234fbb60c/parser-typechecker/src/Unison/Codebase/Branch.hs#L729-L755

## Test coverage

Existing tests cover this quite well and it's just an implementation change.