### PR TITLE
Ignore ctor/term collisions for dupes

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -2102,6 +2102,7 @@ toSlurpResult currentPath uf existingNames =
     , r                   <- toList $ Names.termsNamed existingNames n
     -- ignore collisions w/ ctors of types being updated
     , Set.notMember (Referent.toReference r) typesToUpdate
+    , Set.notMember (var n) (terms dups)
     ]
 
   -- duplicate (n,r) if (n,r) exists in names0


### PR DESCRIPTION
Fixes #660 

Before this fix, saving a file that contains an ability already in the codebase would fail with a cryptic error message.

After this fix, abilities already in the codebase are just ignored.
