### PR TITLE
Add title guidelines to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+> Reminder: Please make your pull request's title more descriptive than "Fix #1203".  Fixed issues can be listed in the "Overview" section.
+
 ## Overview
 
 What does this change accomplish and why? i.e. How does it change the user experience?


### PR DESCRIPTION
When reviewing the list of merged PRs for documenting a new binary release, I disliked following links to identify PRs with non-descriptive titles.  This PR adds a note to the top of the template with a request for a meaningful PR title.