### PR TITLE
Fix #1338: adds the missing "List.empty" to the builtins Map

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/IR.hs
+++ b/parser-typechecker/src/Unison/Runtime/IR.hs
@@ -872,6 +872,7 @@ builtins = Map.fromList $ arity0 <> arityN
   var = Var.named "x"
   arity0 = [ (R.Builtin name, val value) | (name, value) <-
         [ ("Text.empty", T "")
+        , ("List.empty", Sequence mempty)
         , ("Sequence.empty", Sequence mempty)
         , ("Bytes.empty", Bs mempty)
         ] ]

--- a/unison-src/transcripts/empty-list.md
+++ b/unison-src/transcripts/empty-list.md
@@ -1,0 +1,10 @@
+
+```ucm:hide:all
+.> pull https://github.com/unisonweb/base .base
+```
+
+```unison
+x = []
+y = List.empty
+```
+

--- a/unison-src/transcripts/empty-list.md
+++ b/unison-src/transcripts/empty-list.md
@@ -1,6 +1,6 @@
 
 ```ucm:hide:all
-.> pull https://github.com/unisonweb/base .base
+.> alias.term ##List.empty List.empty
 ```
 
 ```unison

--- a/unison-src/transcripts/empty-list.output.md
+++ b/unison-src/transcripts/empty-list.output.md
@@ -1,0 +1,21 @@
+
+```unison
+x = []
+y = List.empty
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      x : [elem]
+      y : [a]
+   
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+```


### PR DESCRIPTION
## Overview

This PR aims to fix #1338 by adding `List.empty` to the `builtins` compilation environment

Before:
Attempting to use List.empty directly crashes `ucm` as per the bug.

After:
Using `List.empty` typechecks as `[a]`.

## Implementation notes

By adding the entry to the `CompilationEnv` the call `toIR env r` now finds the builtin, instead of failing and erroring out.

## Test coverage

Transcript attached.