### PR TITLE
Make `link`, `unlink`, and `diff.namespace` work with unnamed metadata (fix for #1356)

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -42,7 +42,6 @@ import           Data.Configurator              ()
 import qualified Data.List                      as List
 import           Data.List                      ( partition, sortOn )
 import           Data.List.Extra                ( nubOrd, sort )
-import           Data.Maybe                     ( fromJust )
 import qualified Data.Map                      as Map
 import qualified Data.Text                     as Text
 import qualified Text.Megaparsec               as P
@@ -220,7 +219,7 @@ loop = do
       getHQ'Types :: Path.HQSplit' -> Set Reference
       getHQ'Types p = BranchUtil.getType (resolveSplit' p) root0
       resolveHHQS'Types :: HashOrHQSplit' -> Action' m v (Set Reference)
-      resolveHHQS'Types = either 
+      resolveHHQS'Types = either
         (eval . TypeReferencesByShortHash)
         (pure . getHQ'Types)
       -- Term Refs only
@@ -1327,7 +1326,8 @@ loop = do
 
           allTypes :: Map Reference (Type v Ann) <-
             fmap Map.fromList . for (toList neededTypes) $ \r ->
-              (r,) . fromJust <$> (eval . LoadTypeOfTerm) r
+              (r,) . fromMaybe (Type.builtin External "unknown type")
+              <$> (eval . LoadTypeOfTerm) r
 
           let typing r1 r2 = case (Map.lookup r1 allTypes, Map.lookup r2 hashTerms) of
                 (Just t1, Just t2)

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -435,18 +435,14 @@ loop = do
                         ->  Branch.Star r NameSegment)
                     -> MaybeT (StateT (LoopState m v) (F m (Either Event Input) v)) ()
         manageLinks srcs mdValue2 op = do
-          traceM "In manage links, before srcle"
           let !srcle = toList . getHQ'Terms =<< srcs
               !srclt = toList . getHQ'Types =<< srcs
-          traceM "In manage links, AFTER srcle"
           mdValuel <- toList <$> getHQTerms mdValue2
-          traceM "Got mdValuel"
           names0 <- basicPrettyPrintNames0
           ppe <- PPE.suffixifiedPPE <$> prettyPrintEnvDecl (Names names0 mempty)
           case (srcle, srclt, mdValuel) of
             (srcle, srclt, [r@(Referent.Ref mdValue)]) -> do
               mdType <- eval $ LoadTypeOfTerm mdValue
-              traceM $ "Loaded type for " <> show mdValue
               case mdType of
                 Nothing -> respond $ MetadataMissingType ppe r
                 Just ty -> do

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -360,9 +360,9 @@ loop = do
           PropagatePatchI p scope -> "patch " <> ps' p <> " " <> p' scope
           UndoI{} -> "undo"
           ExecuteI s -> "execute " <> Text.pack s
-          LinkI defs md ->
+          LinkI md defs ->
             "link " <> HQ.toText md <> " " <> intercalateMap " " hqs' defs
-          UnlinkI defs md ->
+          UnlinkI md defs ->
             "unlink " <> HQ.toText md <> " " <> intercalateMap " " hqs' defs
           UpdateBuiltinsI -> "builtins.update"
           MergeBuiltinsI -> "builtins.merge"
@@ -902,10 +902,10 @@ loop = do
 --                      | r <- toList $ Names.typesNamed ns name ]
 --              in (terms, types)
 
-      LinkI srcs mdValue ->
+      LinkI mdValue srcs ->
         manageLinks srcs mdValue Metadata.insert
 
-      UnlinkI srcs mdValue ->
+      UnlinkI mdValue srcs ->
         manageLinks srcs mdValue Metadata.delete
 
       -- > links List.map (.Docs .English)

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -109,10 +109,10 @@ data Input
   | ExecuteI String
   | TestI Bool Bool -- TestI showSuccesses showFailures
   -- metadata
-  -- link from to
-  | LinkI [Path.HQSplit'] Path.HQSplit'
-  -- unlink from to
-  | UnlinkI [Path.HQSplit'] Path.HQSplit'
+  -- `link definitions metadata` (adds metadata to all of `definitions`)
+  | LinkI [Path.HQSplit'] HQ.HashQualified
+  -- `unlink definitions metadata` (removes metadata from all of `definitions`)
+  | UnlinkI [Path.HQSplit'] HQ.HashQualified
   -- links from <type>
   | LinksI Path.HQSplit' (Maybe String)
   | DisplayI OutputLocation String

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -109,10 +109,10 @@ data Input
   | ExecuteI String
   | TestI Bool Bool -- TestI showSuccesses showFailures
   -- metadata
-  -- `link definitions metadata` (adds metadata to all of `definitions`)
-  | LinkI [Path.HQSplit'] HQ.HashQualified
-  -- `unlink definitions metadata` (removes metadata from all of `definitions`)
-  | UnlinkI [Path.HQSplit'] HQ.HashQualified
+  -- `link metadata definitions` (adds metadata to all of `definitions`)
+  | LinkI HQ.HashQualified [Path.HQSplit'] 
+  -- `unlink metadata definitions` (removes metadata from all of `definitions`)
+  | UnlinkI HQ.HashQualified [Path.HQSplit']
   -- links from <type>
   | LinksI Path.HQSplit' (Maybe String)
   | DisplayI OutputLocation String

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -174,7 +174,8 @@ data Output v
   | DisplayLinks PPE.PrettyPrintEnvDecl Metadata.Metadata
                (Map Reference (DisplayThing (Decl v Ann)))
                (Map Reference (DisplayThing (Term v Ann)))
-  | LinkFailure Input
+  | MetadataMissingType PPE.PrettyPrintEnv Referent
+  | MetadataAmbiguous PPE.PrettyPrintEnv [Referent]
   -- todo: tell the user to run `todo` on the same patch they just used
   | NothingToPatch PatchPath Path'
   | PatchNeedsToBeConflictFree
@@ -300,7 +301,8 @@ isFailure o = case o of
   ConfiguredGitUrlParseError{} -> True
   ConfiguredGitUrlIncludesShortBranchHash{} -> True
   DisplayLinks{} -> False
-  LinkFailure{} -> True
+  MetadataMissingType{} -> True
+  MetadataAmbiguous{} -> True
   PatchNeedsToBeConflictFree{} -> True
   PatchInvolvesExternalDependents{} -> True
   NothingToPatch{} -> False

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output/BranchDiff.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output/BranchDiff.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Unison.Codebase.Editor.Output.BranchDiff where
 
 import Control.Lens (_1,view)
 import Unison.Prelude
 import Unison.Name (Name)
+import qualified Unison.Name as Name
 import qualified Unison.Codebase.Patch as P
 import qualified Unison.PrettyPrintEnv as PPE
 import qualified Unison.Codebase.BranchDiff as BranchDiff
@@ -329,7 +331,11 @@ toOutput typeOf declOrBuiltin hqLen names1 names2 ppe
   where
   fillMetadata :: Traversable t => PPE.PrettyPrintEnv -> t Metadata.Value -> m (t (MetadataDisplay v a))
   fillMetadata ppe = traverse $ -- metadata values are all terms
-    \(Referent.Ref -> mdRef) -> (HQ'.unsafeFromHQ $ PPE.termName ppe mdRef, mdRef, ) <$> typeOf mdRef
+    \(Referent.Ref -> mdRef) -> 
+      let name = case HQ'.fromHQ (PPE.termName ppe mdRef) of  
+            Nothing -> HQ'.NameOnly (Name.unsafeFromText "(unnamed metadata)")
+            Just hq' -> hq'
+      in (name, mdRef, ) <$> typeOf mdRef
   getMetadata :: Ord r => r -> Name -> R3.Relation3 r Name Metadata.Value -> Set Metadata.Value
   getMetadata r n = R.lookupDom n . R3.lookupD1 r
 

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output/BranchDiff.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output/BranchDiff.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 module Unison.Codebase.Editor.Output.BranchDiff where
 

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output/BranchDiff.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output/BranchDiff.hs
@@ -9,7 +9,6 @@ module Unison.Codebase.Editor.Output.BranchDiff where
 import Control.Lens (_1,view)
 import Unison.Prelude
 import Unison.Name (Name)
-import qualified Unison.Name as Name
 import qualified Unison.Codebase.Patch as P
 import qualified Unison.PrettyPrintEnv as PPE
 import qualified Unison.Codebase.BranchDiff as BranchDiff
@@ -24,7 +23,7 @@ import Unison.Util.Set (symmetricDifference)
 import Unison.Reference (Reference)
 import Unison.Type (Type)
 import Unison.HashQualified' (HashQualified)
-import qualified Unison.HashQualified' as HQ'
+import qualified Unison.HashQualified as HQ
 import qualified Unison.Referent as Referent
 import Unison.Referent (Referent)
 import Data.Set (Set)
@@ -93,7 +92,7 @@ type SimpleTypeDisplay v a = (HashQualified, Reference, Maybe (DeclOrBuiltin v a
 type UpdateTermDisplay v a = (Maybe [SimpleTermDisplay v a], [TermDisplay v a])
 type UpdateTypeDisplay v a = (Maybe [SimpleTypeDisplay v a], [TypeDisplay v a])
 
-type MetadataDisplay v a = SimpleTermDisplay v a
+type MetadataDisplay v a = (HQ.HashQualified, Referent, Maybe (Type v  a))
 type RenameTermDisplay v a = (Referent, Maybe (Type v a), Set HashQualified, Set HashQualified)
 type RenameTypeDisplay v a = (Reference, Maybe (DeclOrBuiltin v a), Set HashQualified, Set HashQualified)
 type PatchDisplay = (Name, P.PatchDiff)
@@ -332,9 +331,7 @@ toOutput typeOf declOrBuiltin hqLen names1 names2 ppe
   fillMetadata :: Traversable t => PPE.PrettyPrintEnv -> t Metadata.Value -> m (t (MetadataDisplay v a))
   fillMetadata ppe = traverse $ -- metadata values are all terms
     \(Referent.Ref -> mdRef) -> 
-      let name = case HQ'.fromHQ (PPE.termName ppe mdRef) of  
-            Nothing -> HQ'.NameOnly (Name.unsafeFromText "(unnamed metadata)")
-            Just hq' -> hq'
+      let name = PPE.termName ppe mdRef
       in (name, mdRef, ) <$> typeOf mdRef
   getMetadata :: Ord r => r -> Name -> R3.Relation3 r Name Metadata.Value -> Set Metadata.Value
   getMetadata r n = R.lookupDom n . R3.lookupD1 r

--- a/parser-typechecker/src/Unison/Codebase/Metadata.hs
+++ b/parser-typechecker/src/Unison/Codebase/Metadata.hs
@@ -11,6 +11,7 @@ import Unison.Util.Relation (Relation)
 import qualified Unison.Util.Relation as R
 import Unison.Util.Relation4 (Relation4)
 import qualified Unison.Util.Relation4 as R4
+import qualified Unison.Util.List as List
 
 type Type = Reference
 type Value = Reference
@@ -43,7 +44,15 @@ insert :: (Ord a, Ord n) => (a, Type, Value) -> Star a n -> Star a n
 insert (a, ty, v) = Star3.insertD23 (a, ty, (ty,v))
 
 delete :: (Ord a, Ord n) => (a, Type, Value) -> Star a n -> Star a n
-delete (a, ty, v) = Star3.deleteD23 (a, ty, (ty,v))
+delete (a, ty, v) s = let
+  s' = Star3.deleteD3 (a, (ty,v)) s
+  -- if (ty,v) is the last metadata of type ty
+  -- we also delete (a, ty) from the d2 index
+  metadataByType = List.multimap (toList (R.lookupDom a (Star3.d3 s)))
+  in 
+  case Map.lookup ty metadataByType of
+    Just vs | all (== v) vs -> Star3.deleteD2 (a, ty) s' 
+    _ -> s'
 
 -- parallel composition - commutative and associative
 merge :: Metadata -> Metadata -> Metadata

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -1034,11 +1034,11 @@ link = InputPattern
   )
   (\case
     md : defs -> first fromString $ do
-      defs <- traverse Path.parseHQSplit' defs
       md <- case HQ.fromString md of
         Nothing -> Left "Invalid hash qualified identifier for metadata." 
         Just hq -> pure hq
-      Right $ Input.LinkI defs md
+      defs <- traverse Path.parseHQSplit' defs
+      Right $ Input.LinkI md defs
     _ -> Left (I.help link)
   )
 
@@ -1073,11 +1073,11 @@ unlink = InputPattern
     ])
   (\case
     md : defs -> first fromString $ do
-      defs <- traverse Path.parseHQSplit' defs
       md <- case HQ.fromString md of
         Nothing -> Left "Invalid hash qualified identifier for metadata." 
         Just hq -> pure hq
-      Right $ Input.UnlinkI defs md
+      defs <- traverse Path.parseHQSplit' defs
+      Right $ Input.UnlinkI md defs 
     _ -> Left (I.help unlink)
   )
 

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -1033,10 +1033,12 @@ link = InputPattern
     ]
   )
   (\case
-    dest : srcs -> first fromString $ do
-      srcs <- traverse Path.parseHQSplit' srcs
-      dest <- Path.parseHQSplit' dest
-      Right $ Input.LinkI srcs dest
+    md : defs -> first fromString $ do
+      defs <- traverse Path.parseHQSplit' defs
+      md <- case HQ.fromString md of
+        Nothing -> Left "Invalid hash qualified identifier for metadata." 
+        Just hq -> pure hq
+      Right $ Input.LinkI defs md
     _ -> Left (I.help link)
   )
 
@@ -1070,10 +1072,12 @@ unlink = InputPattern
     , "for a range of definitions listed by a prior `find` command."
     ])
   (\case
-    dest : srcs -> first fromString $ do
-      srcs <- traverse Path.parseHQSplit' srcs
-      dest <- Path.parseHQSplit' dest
-      Right $ Input.UnlinkI srcs dest
+    md : defs -> first fromString $ do
+      defs <- traverse Path.parseHQSplit' defs
+      md <- case HQ.fromString md of
+        Nothing -> Left "Invalid hash qualified identifier for metadata." 
+        Just hq -> pure hq
+      Right $ traceShowId $ Input.UnlinkI defs md
     _ -> Left (I.help unlink)
   )
 

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -1077,7 +1077,7 @@ unlink = InputPattern
       md <- case HQ.fromString md of
         Nothing -> Left "Invalid hash qualified identifier for metadata." 
         Just hq -> pure hq
-      Right $ traceShowId $ Input.UnlinkI defs md
+      Right $ Input.UnlinkI defs md
     _ -> Left (I.help unlink)
   )
 

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -1301,7 +1301,7 @@ listOfLinks ::
 listOfLinks _ [] = pure . P.callout "😶" . P.wrap $
   "No results. Try using the " <>
   IP.makeExample IP.link [] <>
-  "command to add outgoing links to a definition."
+  "command to add metadata to a definition."
 listOfLinks ppe results = pure $ P.lines [
     P.numberedColumn2 num [
     (P.syntaxToColor $ prettyHashQualified hq, ": " <> prettyType typ) | (hq,typ) <- results

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -905,13 +905,16 @@ calcImports im tm = (im', render $ getUses result)
                                                                  in ((n, l), (p, s, i)))
                                          |> Map.fromList
     -- For each k1, choose the v with the largest k2.
-    longestPrefix :: (Ord k1, Ord k2) => Map (k1, k2) v -> Map k1 v
+    longestPrefix :: (Show k1, Show k2, Ord k1, Ord k2) => Map (k1, k2) v -> Map k1 v
     longestPrefix m = let k1s = Set.map fst $ Map.keysSet m
                           k2s = k1s |> Map.fromSet (\k1' -> Map.keysSet m
                                                               |> Set.filter (\(k1, _) -> k1 == k1')
                                                               |> Set.map snd)
                           maxk2s = Map.map maximum k2s
-                          err k1 k2 = error $ "Not found " <> show (k1,k2) <> " in " <> show maxk2s
+                          err k1 k2 = error $ 
+                            "TermPrinter.longestPrefix not found " 
+                            <> show (k1,k2) 
+                            <> " in " <> show maxk2s
                       in Map.mapWithKey (\k1 k2 -> fromMaybe (err k1 k2) $ Map.lookup (k1, k2) m) maxk2s
     -- Don't do another `use` for a name for which we've already done one, unless the
     -- new suffix is shorter.

--- a/parser-typechecker/src/Unison/Typechecker/Components.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Components.hs
@@ -9,7 +9,6 @@ import           Data.List (groupBy, sortBy, sortOn)
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as Nel
 import qualified Data.Map as Map
-import           Data.Maybe (fromJust)
 import qualified Data.Set as Set
 import qualified Unison.ABT as ABT
 import           Unison.Term (Term')
@@ -17,10 +16,10 @@ import qualified Unison.Term as Term
 import           Unison.Var (Var)
 
 unordered :: Var v => [(v,Term' vt v a)] -> [[(v,Term' vt v a)]]
-unordered = ABT.components 
+unordered = ABT.components
 
 ordered :: Var v => [(v,Term' vt v a)] -> [[(v,Term' vt v a)]]
-ordered = ABT.orderedComponents 
+ordered = ABT.orderedComponents
 
 -- | Algorithm for minimizing cycles of a `let rec`. This can
 -- improve generalization during typechecking and may also be more
@@ -61,7 +60,8 @@ minimize (Term.LetRecNamedAnnotatedTop' isTop ann bs e) =
               -- loop).
               cs = sortOn (\(_,e) -> Term.arity e == 0) <$> cs0
               varAnnotations = Map.fromList ((\((a, v), _) -> (v, a)) <$> bs)
-              annotationFor v = fromJust $ Map.lookup v varAnnotations
+              msg v = error $ "Components.minimize " <> show (v, Map.keys varAnnotations)
+              annotationFor v = fromMaybe (msg v) $ Map.lookup v varAnnotations
               annotatedVar v = (annotationFor v, v)
               -- When introducing a nested let/let rec, we use the annotation
               -- of the variable that starts off that let/let rec

--- a/parser-typechecker/src/Unison/Util/Find.hs
+++ b/parser-typechecker/src/Unison/Util/Find.hs
@@ -122,7 +122,6 @@ prefixFindInBranch b hq = fmap getName $
       filter (filterName n) (candidates b hq)
   where
   filterName n sr =
-    -- fromJust is safe here because entries from the namespace will have names.
     fromString n `Name.isPrefixOf` (HQ.toName . SR.name) sr
 
 -- only search before the # before the # and after the # after the #

--- a/parser-typechecker/src/Unison/Util/Star3.hs
+++ b/parser-typechecker/src/Unison/Util/Star3.hs
@@ -160,13 +160,19 @@ insertD23 (f, x, y) s = Star3 fact' (d1 s) d2' d3' where
   d2'   = R.insert f x (d2 s)
   d3'   = R.insert f y (d3 s)
 
-deleteD23 :: (Ord fact, Ord d1, Ord d2, Ord d3)
-          => (fact, d2, d3)
+deleteD3 :: (Ord fact, Ord d1, Ord d2, Ord d3)
+          => (fact, d3)
           -> Star3 fact d1 d2 d3
           -> Star3 fact d1 d2 d3
-deleteD23 (f, x, y) s = Star3 (fact s) (d1 s) d2' d3' where
+deleteD3 (f, x) s = Star3 (fact s) (d1 s) (d2 s) d3' where
+  d3' = R.delete f x (d3 s)
+
+deleteD2 :: (Ord fact, Ord d1, Ord d2, Ord d3)
+          => (fact, d2)
+          -> Star3 fact d1 d2 d3
+          -> Star3 fact d1 d2 d3
+deleteD2 (f, x) s = Star3 (fact s) (d1 s) d2' (d3 s) where
   d2' = R.delete f x (d2 s)
-  d3' = R.delete f y (d3 s)
 
 deleteFact :: (Ord fact, Ord d1, Ord d2, Ord d3)
            => Set fact -> Star3 fact d1 d2 d3 -> Star3 fact d1 d2 d3

--- a/unison-core/src/Unison/HashQualified'.hs
+++ b/unison-core/src/Unison/HashQualified'.hs
@@ -4,7 +4,6 @@ module Unison.HashQualified' where
 
 import Unison.Prelude
 
-import           Data.Maybe                     ( fromJust )
 import qualified Data.Text                     as Text
 import           Prelude                 hiding ( take )
 import           Unison.Name                    ( Name )
@@ -34,7 +33,8 @@ fromHQ = \case
   HQ.HashOnly{} -> Nothing
 
 unsafeFromHQ :: HQ.HashQualified' n -> HashQualified' n
-unsafeFromHQ = fromJust . fromHQ
+unsafeFromHQ = fromMaybe msg . fromHQ where
+  msg = error "HashQualified'.unsafeFromHQ"
 
 toName :: HashQualified' n -> n
 toName = \case
@@ -69,7 +69,8 @@ fromText t = case Text.breakOn "#" t of
     HashQualified (Name.unsafeFromText name) <$> SH.fromText hash
 
 unsafeFromText :: Text -> HashQualified
-unsafeFromText = fromJust . fromText
+unsafeFromText txt = fromMaybe msg (fromText txt) where
+  msg = error ("HashQualified'.unsafeFromText " <> show txt)
 
 fromString :: String -> Maybe HashQualified
 fromString = fromText . Text.pack

--- a/unison-core/src/Unison/HashQualified'.hs
+++ b/unison-core/src/Unison/HashQualified'.hs
@@ -32,10 +32,6 @@ fromHQ = \case
   HQ.HashQualified n sh -> Just $ HashQualified n sh
   HQ.HashOnly{} -> Nothing
 
-unsafeFromHQ :: HQ.HashQualified' n -> HashQualified' n
-unsafeFromHQ = fromMaybe msg . fromHQ where
-  msg = error "HashQualified'.unsafeFromHQ"
-
 toName :: HashQualified' n -> n
 toName = \case
   NameOnly name        ->  name

--- a/unison-core/src/Unison/HashQualified.hs
+++ b/unison-core/src/Unison/HashQualified.hs
@@ -5,8 +5,6 @@ module Unison.HashQualified where
 import Unison.Prelude hiding (fromString)
 
 import           Data.List                      ( sortOn )
-import           Data.Maybe                     ( fromJust
-                                                )
 import qualified Data.Text                     as Text
 import           Prelude                 hiding ( take )
 import           Unison.Name                    ( Name )
@@ -89,7 +87,8 @@ fromString :: String -> Maybe HashQualified
 fromString = fromText . Text.pack
 
 unsafeFromString :: String -> HashQualified
-unsafeFromString = fromJust . fromString
+unsafeFromString s = fromMaybe msg . fromString $ s where
+  msg = error $ "HashQualified.unsafeFromString " <> show s
 
 -- Parses possibly-hash-qualified into structured type.
 -- Doesn't validate against base58 or the codebase.
@@ -102,7 +101,8 @@ fromText t = case Text.breakOn "#" t of -- breakOn leaves the '#' on the RHS
 -- Won't crash as long as SH.unsafeFromText doesn't crash on any input that
 -- starts with '#', which is true as of the time of this writing, but not great.
 unsafeFromText :: Text -> HashQualified
-unsafeFromText  = fromJust . fromText
+unsafeFromText txt = fromMaybe msg . fromText $ txt where
+  msg = error $ "HashQualified.unsafeFromText " <> show txt
 
 toText :: Show n => HashQualified' n -> Text
 toText = \case
@@ -159,7 +159,7 @@ requalify hq r = case hq of
   HashQualified n _ -> fromNamedReferent n r
   HashOnly _        -> fromReferent r
 
--- this implementation shows HashOnly before the others, because None < Some. 
+-- this implementation shows HashOnly before the others, because None < Some.
 -- Flip it around carefully if HashOnly should come last.
 instance Ord n => Ord (HashQualified' n) where
   compare a b = case compare (toName a) (toName b) of

--- a/unison-core/src/Unison/HashQualified.hs
+++ b/unison-core/src/Unison/HashQualified.hs
@@ -108,7 +108,7 @@ toText :: Show n => HashQualified' n -> Text
 toText = \case
   NameOnly name           -> Text.pack (show name)
   HashQualified name hash -> Text.pack (show name) <> SH.toText hash
-  HashOnly ref            -> Text.pack (show ref)
+  HashOnly hash           -> SH.toText hash
 
 -- Returns the full referent in the hash.  Use HQ.take to just get a prefix
 fromNamedReferent :: n -> Referent -> HashQualified' n

--- a/unison-core/src/Unison/Reference.hs
+++ b/unison-core/src/Unison/Reference.hs
@@ -29,7 +29,6 @@ module Unison.Reference
 import Unison.Prelude
 
 import qualified Data.Map        as Map
-import           Data.Maybe      (fromJust)
 import qualified Data.Set        as Set
 import qualified Data.Text       as Text
 import qualified Unison.Hash     as H
@@ -121,8 +120,9 @@ componentFor (  DerivedId (Id h _ n)) = Component
   )
 
 derivedBase32Hex :: Text -> Pos -> Size -> Reference
-derivedBase32Hex b32Hex i n = DerivedId (Id (fromJust h) i n)
+derivedBase32Hex b32Hex i n = DerivedId (Id (fromMaybe msg h) i n)
   where
+  msg = error $ "Reference.derivedBase32Hex " <> show h
   h = H.fromBase32Hex b32Hex
 
 unsafeFromText :: Text -> Reference

--- a/unison-core/src/Unison/Util/Components.hs
+++ b/unison-core/src/Unison/Util/Components.hs
@@ -4,7 +4,6 @@ import Unison.Prelude
 
 import qualified Data.Graph as Graph
 import qualified Data.Map as Map
-import           Data.Maybe (fromJust)
 import qualified Data.Set as Set
 
 -- | Order bindings by dependencies and group into components.
@@ -38,7 +37,8 @@ components freeVars bs =
   let varIds =
         Map.fromList (map fst bs `zip` reverse [(1 :: Int) .. length bs])
       -- something horribly wrong if this bombs
-      varId v = fromJust $ Map.lookup v varIds
+      msg = error "Components.components bug"
+      varId v = fromMaybe msg $ Map.lookup v varIds
 
       -- use ints as keys for graph to preserve original source order as much as
       -- possible

--- a/unison-src/transcripts/fix1356.md
+++ b/unison-src/transcripts/fix1356.md
@@ -37,13 +37,16 @@ Step 6: Great that seems to have worked but let me check just in case
 .> display 1
 ```
 
-Step 7: I have been guided to check `display 1`, so now let's try and unlink
-to get rid of the second link.
+Step 7: I have been guided to check `display 1`, so now let's try and unlink to get rid of the second link. We can remove by number, or by hash:
 
 ```ucm
-.> unlink x.doc x
+.> unlink 2 x
+.> undo
+.> unlink #v8f1hhvs57 x
 ```
 
-Issuing the `unlink x.doc x` command here breaks ucm, and no transcript output is generated.
-The captured output is `ucm: Maybe.fromJust: Nothing`
+We expect that after the `unlink`, the `docs` command now works as there's a single `Doc` again:
 
+```ucm
+.> docs x
+```

--- a/unison-src/transcripts/fix1356.md
+++ b/unison-src/transcripts/fix1356.md
@@ -1,0 +1,49 @@
+##### This transcript reproduces the failure to unlink documentation
+
+Step 1: code a term and documentation for it
+```unison
+x = 1
+x.doc = [: I am the documentation for x:]
+```
+
+Step 2: add term and documentation, link, and check the documentation
+```ucm
+.> add
+.> link x.doc x
+.> docs x
+```
+
+Step 3: Oops I don't like the doc, so I will re-code it!
+```unison
+x.doc = [: I am the documentation for x, and I now look better:]
+```
+
+Step 4: I add it and expect to see it
+```ucm
+.> update
+.> docs x
+```
+But I don't see an update, so from here on I am in panic mode and have no clue what I am doing!
+
+Step 5: maybe re-link it?
+```ucm
+.> link x.doc x
+```
+
+Step 6: Great that seems to have worked but let me check just in case
+
+```ucm
+.> docs x
+.> display 1
+```
+
+Step 7: I have been guided to check `display 1`, so now let's try and unlink
+to get rid of the second link.
+
+```ucm
+.> unlink x.doc x
+```
+
+Issuing the `unlink x.doc x` command here breaks ucm, and no transcript output is generated.
+The captured output is `ucm: Maybe.fromJust: Nothing`
+

--- a/unison-src/transcripts/fix1356.md
+++ b/unison-src/transcripts/fix1356.md
@@ -45,6 +45,7 @@ Step 7: I have been guided to check `display 1`, so now let's try and unlink to 
 
 ```ucm
 .> unlink 2 x
+.> view 2
 .> undo
 .> unlink #v8f1hhvs57 x
 ```

--- a/unison-src/transcripts/fix1356.md
+++ b/unison-src/transcripts/fix1356.md
@@ -1,5 +1,9 @@
 ##### This transcript reproduces the failure to unlink documentation
 
+```ucm:hide
+.> builtins.merge
+```
+
 Step 1: code a term and documentation for it
 ```unison
 x = 1

--- a/unison-src/transcripts/fix1356.output.md
+++ b/unison-src/transcripts/fix1356.output.md
@@ -1,0 +1,140 @@
+##### This transcript reproduces the failure to unlink documentation
+
+Step 1: code a term and documentation for it
+```unison
+x = 1
+x.doc = [: I am the documentation for x:]
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      x     : Nat
+      x.doc : Doc
+   
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+```
+Step 2: add term and documentation, link, and check the documentation
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    x     : Nat
+    x.doc : Doc
+
+.> link x.doc x
+
+  Updates:
+  
+    1. x : Nat
+       + 2. x.doc : Doc
+
+.> docs x
+
+  I am the documentation for x
+
+```
+Step 3: Oops I don't like the doc, so I will re-code it!
+```unison
+x.doc = [: I am the documentation for x, and I now look better:]
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      x.doc : Doc
+   
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+```
+Step 4: I add it and expect to see it
+```ucm
+.> update
+
+  ⍟ I've updated these names to your new definition:
+  
+    x.doc : base.Doc
+
+.> docs x
+
+  I am the documentation for x
+
+```
+But I don't see an update, so from here on I am in panic mode and have no clue what I am doing!
+
+Step 5: maybe re-link it?
+```ucm
+.> link x.doc x
+
+  Updates:
+  
+    1. x : Nat
+       + 2. x.doc : Doc
+
+```
+Step 6: Great that seems to have worked but let me check just in case
+
+```ucm
+.> docs x
+
+  1. x.doc            : Doc
+  2. x.doc#v8f1hhvs57 : Doc
+  
+  Tip: Try using `display 1` to display the first result or
+       `view 1` to view its source.
+
+.> display 1
+
+  I am the documentation for x, and I now look better
+
+```
+Step 7: I have been guided to check `display 1`, so now let's try and unlink to get rid of the second link. We can remove by number, or by hash:
+
+```ucm
+.> unlink 2 x
+
+  Updates:
+  
+    1. x : Nat
+       - 2. (unnamed metadata) : Doc
+
+.> undo
+
+  Here's the changes I undid
+  
+  Updates:
+  
+    1. x : Nat
+       - 2. (unnamed metadata) : Doc
+
+.> unlink #v8f1hhvs57 x
+
+  Updates:
+  
+    1. x : Nat
+       - 2. (unnamed metadata) : Doc
+
+```
+We expect that after the `unlink`, the `docs` command now works as there's a single `Doc` again:
+
+```ucm
+.> docs x
+
+  I am the documentation for x, and I now look better
+
+```

--- a/unison-src/transcripts/fix1356.output.md
+++ b/unison-src/transcripts/fix1356.output.md
@@ -35,7 +35,7 @@ Step 2: add term and documentation, link, and check the documentation
   Updates:
   
     1. x : Nat
-       + 2. x.doc : Doc
+       + 2. doc : Doc
 
 .> docs x
 
@@ -68,7 +68,7 @@ Step 4: I add it and expect to see it
 
   ⍟ I've updated these names to your new definition:
   
-    x.doc : base.Doc
+    x.doc : builtin.Doc
 
 .> docs x
 
@@ -84,7 +84,7 @@ Step 5: maybe re-link it?
   Updates:
   
     1. x : Nat
-       + 2. x.doc : Doc
+       + 2. doc : Doc
 
 ```
 Step 6: Great that seems to have worked but let me check just in case

--- a/unison-src/transcripts/fix1356.output.md
+++ b/unison-src/transcripts/fix1356.output.md
@@ -111,7 +111,12 @@ Step 7: I have been guided to check `display 1`, so now let's try and unlink to 
   Updates:
   
     1. x : Nat
-       - 2. (unnamed metadata) : Doc
+       - 2. #v8f1hhvs57 : Doc
+
+.> view 2
+
+  x.doc#v8f1hhvs57 : Doc
+  x.doc#v8f1hhvs57 = [: I am the documentation for x :]
 
 .> undo
 
@@ -120,14 +125,14 @@ Step 7: I have been guided to check `display 1`, so now let's try and unlink to 
   Updates:
   
     1. x : Nat
-       - 2. (unnamed metadata) : Doc
+       - 2. #v8f1hhvs57 : Doc
 
 .> unlink #v8f1hhvs57 x
 
   Updates:
   
     1. x : Nat
-       - 2. (unnamed metadata) : Doc
+       - 2. #v8f1hhvs57 : Doc
 
 ```
 We expect that after the `unlink`, the `docs` command now works as there's a single `Doc` again:


### PR DESCRIPTION
Thanks to @pete-ts for reporting original issue.

## Overview

Fixes #1356, but more generally, `link`, `unlink`, and `diff.namespace` commands all now work fine even if metadata values are unnamed in the current namespace. See [the transcript](https://github.com/unisonweb/unison/blob/083ed75f3e3b5ffe56e1da7c24a4141628419c72/unison-src/transcripts/fix1356.output.md), which previously bombed with a runtime error but now has been beefed up and works great.

`link #somehash List.map` and  `unlink #somehash my.stuff` now work, previously they were rejected by the parser.

## Implementation notes

See self review.

## Interesting/controversial decisions

When you do `unlink foo#xyzpq mydef`, the name `foo` is ignored - just the hash is used to resolve the metadata. @aryairani and I decided this was better than the alternative of doing a historical names search.

## Test coverage

It's pretty reasonable, see [the transcript](https://github.com/unisonweb/unison/blob/083ed75f3e3b5ffe56e1da7c24a4141628419c72/unison-src/transcripts/fix1356.output.md).

## Loose ends

It's kind of a bummer that the namespace diff isn't getting access to historical names, so old metadata that's been updated is just shown as its hash. (Previously it would straight up crash)

When we do #1346 it'll be nice to get those hash qualified using whatever old names exist for the hash.