### PR TITLE
Allow `view` and `display` commands to resolve any unique suffix

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -945,7 +945,8 @@ loop = do
       DeleteTermI hq -> delete getHQ'Terms       (const Set.empty) hq
 
       DisplayI outputLoc (HQ.unsafeFromString -> hq) -> do
-        parseNames <- (`Names3.Names` mempty) <$> basicPrettyPrintNames0
+        parseNames0 <- (`Names3.Names` mempty) <$> basicPrettyPrintNames0
+        let parseNames = Names3.suffixify parseNames0
         let results = Names3.lookupHQTerm hq parseNames
         if Set.null results then
           respond $ SearchTermsNotFound [hq]

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -947,12 +947,14 @@ loop = do
       DisplayI outputLoc (HQ.unsafeFromString -> hq) -> do
         parseNames0 <- (`Names3.Names` mempty) <$> basicPrettyPrintNames0
         let parseNames = Names3.suffixify parseNames0
+        -- use suffixed names for resolving the argument to display
         let results = Names3.lookupHQTerm hq parseNames
         if Set.null results then
           respond $ SearchTermsNotFound [hq]
         else if Set.size results > 1 then
           respond $ TermAmbiguous hq results
-        else doDisplay outputLoc parseNames (Set.findMin results)
+        -- ... but use the unsuffixed names for display
+        else doDisplay outputLoc parseNames0 (Set.findMin results)
 
       ShowDefinitionI outputLoc (fmap HQ.unsafeFromString -> hqs) -> do
         parseNames0 <- makeHistoricalParsingNames $ Set.fromList hqs

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -954,7 +954,8 @@ loop = do
         else doDisplay outputLoc parseNames (Set.findMin results)
 
       ShowDefinitionI outputLoc (fmap HQ.unsafeFromString -> hqs) -> do
-        parseNames <- makeHistoricalParsingNames $ Set.fromList hqs
+        parseNames0 <- makeHistoricalParsingNames $ Set.fromList hqs
+        let parseNames = Names3.suffixify parseNames0
         let resultss = searchBranchExact hqLength parseNames hqs
             (misses, hits) = partition (\(_, results) -> null results) (zip hqs resultss)
             results = List.sort . uniqueBy SR.toReferent $ hits >>= snd

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -1212,8 +1212,8 @@ exactDefinitionOrPathArg =
 exactDefinitionQueryArg :: ArgumentType
 exactDefinitionQueryArg =
   ArgumentType "definition query" $
-    bothCompletors (termCompletor exactComplete)
-                   (typeCompletor exactComplete)
+    bothCompletors (termCompletor fuzzyComplete)
+                   (typeCompletor fuzzyComplete)
 
 exactDefinitionTypeQueryArg :: ArgumentType
 exactDefinitionTypeQueryArg =

--- a/unison-src/transcripts/merge.md
+++ b/unison-src/transcripts/merge.md
@@ -89,13 +89,13 @@ and `quux` namespaces.
 These test that things we expect to be deleted are still deleted.
 
 ```ucm:error
-.P0> view foo.w
+.> view P0.foo.w
 ```
 
 ```ucm:error
-.P0> view baz.x
+.> view P0.baz.x
 ```
 
 ```ucm:error
-.P0> view quux.x
+.> view P0.quux.x
 ```

--- a/unison-src/transcripts/merge.output.md
+++ b/unison-src/transcripts/merge.output.md
@@ -199,29 +199,29 @@ and `quux` namespaces.
 These test that things we expect to be deleted are still deleted.
 
 ```ucm
-.P0> view foo.w
+.> view P0.foo.w
 
   ⚠️
   
   The following names were not found in the codebase. Check your spelling.
-    foo.w
+    P0.foo.w
 
 ```
 ```ucm
-.P0> view baz.x
+.> view P0.baz.x
 
   ⚠️
   
   The following names were not found in the codebase. Check your spelling.
-    baz.x
+    P0.baz.x
 
 ```
 ```ucm
-.P0> view quux.x
+.> view P0.quux.x
 
   ⚠️
   
   The following names were not found in the codebase. Check your spelling.
-    quux.x
+    P0.quux.x
 
 ```

--- a/unison-src/transcripts/suffixes.md
+++ b/unison-src/transcripts/suffixes.md
@@ -23,6 +23,12 @@ This also affects commands like find. Notice lack of qualified names in output:
 .> find take
 ```
 
+The `view` command also benefits from this:
+
+```ucm
+.> view List.drop
+```
+
 In the signature, we don't see `base.Nat`, just `Nat`. The full declaration name is still shown for each search result though.
 
 Type-based search also benefits from this, we can just say `Nat` rather than `.base.Nat`:

--- a/unison-src/transcripts/suffixes.md
+++ b/unison-src/transcripts/suffixes.md
@@ -6,7 +6,7 @@
 
 Any unique name suffix can be used to refer to a definition. For instance:
 
-```unison
+```unison:hide
 -- No imports needed even though FQN is `builtin.{Int,Nat}`
 foo.bar.a : Int
 foo.bar.a = +99
@@ -20,13 +20,15 @@ optional.isNone = cases
 This also affects commands like find. Notice lack of qualified names in output:
 
 ```ucm
+.> add
 .> find take
 ```
 
-The `view` command also benefits from this:
+The `view` and `display` commands also benefit from this:
 
 ```ucm
 .> view List.drop
+.> display bar.a
 ```
 
 In the signature, we don't see `base.Nat`, just `Nat`. The full declaration name is still shown for each search result though.

--- a/unison-src/transcripts/suffixes.output.md
+++ b/unison-src/transcripts/suffixes.output.md
@@ -13,24 +13,16 @@ optional.isNone = cases
   Some _ -> false
 ```
 
-```ucm
-
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-  
-    ⍟ These new definitions are ok to `add`:
-    
-      foo.bar.a       : Int
-      optional.isNone : Optional a -> Boolean
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
-
-```
 This also affects commands like find. Notice lack of qualified names in output:
 
 ```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    foo.bar.a       : Int
+    optional.isNone : Optional a -> Boolean
+
 .> find take
 
   1. builtin.Bytes.take : Nat -> Bytes -> Bytes
@@ -39,12 +31,16 @@ This also affects commands like find. Notice lack of qualified names in output:
   
 
 ```
-The `view` command also benefits from this:
+The `view` and `display` commands also benefit from this:
 
 ```ucm
 .> view List.drop
 
   -- builtin.List.drop is built-in.
+
+.> display bar.a
+
+  +99
 
 ```
 In the signature, we don't see `base.Nat`, just `Nat`. The full declaration name is still shown for each search result though.

--- a/unison-src/transcripts/suffixes.output.md
+++ b/unison-src/transcripts/suffixes.output.md
@@ -39,6 +39,14 @@ This also affects commands like find. Notice lack of qualified names in output:
   
 
 ```
+The `view` command also benefits from this:
+
+```ucm
+.> view List.drop
+
+  -- builtin.List.drop is built-in.
+
+```
 In the signature, we don't see `base.Nat`, just `Nat`. The full declaration name is still shown for each search result though.
 
 Type-based search also benefits from this, we can just say `Nat` rather than `.base.Nat`:


### PR DESCRIPTION
## Overview

`view List.map` now works, regardless of where in the tree you are. Likewise for `display myMagicConstant`. This isn't a comprehensive rethink as suggested in #1298 but was a simple change and a nice quality of life improvement IMO.

Here's `view |>` in action - 

<img width="406" alt="Screen Shot 2020-03-19 at 3 04 49 PM" src="https://user-images.githubusercontent.com/11074/77104831-05976a00-69f3-11ea-8cbe-45b40f2c1448.png">

## Implementation notes

This was very straightforward.

## Interesting/controversial decisions

I left autocomplete alone but switched to fuzzy matching for `exactDefinitionQueryArg`. This has the effect that `List.zip` will autocomplete to `base.List.zip` - that is, the completions still show the full names, which seemed better to me.

This approach of leaving autocomplete alone means existing commands aren't required to accept suffixes, which gives me more confidence this won't break anything. :)

I discovered that you have to prepend `.` to get autocomplete to look outside the current namespace. I didn't change that behavior. So if you do `.zoink> view List.<tab>`, it won't complete all the `List` functions, but if you do `.zoink> view .List.<tab>` then it will. This seemed OK to me but we might have more of an opinion on this after spending some time with it.

## Test coverage

I added a couple tests to the suffixes.md transcript, exercising `view` and `display`. Existing transcripts still pass. There was one transcript that was relying on `view` NOT looking outside the namespace (to detect a deletion), which I adjusted.