### PR TITLE
Removes empty string at the end of Name.suffixes output and unittests

### DIFF
--- a/parser-typechecker/tests/Suite.hs
+++ b/parser-typechecker/tests/Suite.hs
@@ -29,6 +29,7 @@ import qualified Unison.Test.Codebase as Codebase
 import qualified Unison.Test.Codebase.FileCodebase as FileCodebase
 import qualified Unison.Test.UriParser as UriParser
 import qualified Unison.Test.Git as Git
+import qualified Unison.Core.Test.Name as Name
 
 test :: Test ()
 test = tests
@@ -56,6 +57,7 @@ test = tests
   , UriParser.test
   , Context.test
   , Git.test
+  , Name.test
  ]
 
 main :: IO ()

--- a/parser-typechecker/tests/Unison/Core/Test/Name.hs
+++ b/parser-typechecker/tests/Unison/Core/Test/Name.hs
@@ -6,14 +6,14 @@ import           EasyTest
 import           Unison.Name                   as Name
 
 test :: Test ()
-test = scope "name" $ tests [ 
-  scope "suffixes" $ 
+test = scope "name" $ tests [
+  scope "suffixes" $
     tests
-      [ scope "empty" $ expectEqual (suffixes "") [""]
-      , scope "one namespace" $ expectEqual (suffixes "bar") ["bar", ""]
+      [ scope "empty" $ expectEqual (suffixes "") []
+      , scope "one namespace" $ expectEqual (suffixes "bar") ["bar"]
       , scope "two namespaces"
-        $ expectEqual (suffixes "foo.bar") ["foo.bar", "bar", ""]
-      , scope "multiple namespaces" 
-        $ expectEqual (suffixes "foo.bar.baz") ["foo.bar.baz", "bar.baz", "baz", ""]
+        $ expectEqual (suffixes "foo.bar") ["foo.bar", "bar"]
+      , scope "multiple namespaces"
+        $ expectEqual (suffixes "foo.bar.baz") ["foo.bar.baz", "bar.baz", "baz"]
       ]
   ]

--- a/parser-typechecker/tests/Unison/Core/Test/Name.hs
+++ b/parser-typechecker/tests/Unison/Core/Test/Name.hs
@@ -1,0 +1,19 @@
+{-# Language OverloadedStrings #-}
+
+module Unison.Core.Test.Name where
+
+import           EasyTest
+import           Unison.Name                   as Name
+
+test :: Test ()
+test = scope "name" $ tests [ 
+  scope "suffixes" $ 
+    tests
+      [ scope "empty" $ expectEqual (suffixes "") [""]
+      , scope "one namespace" $ expectEqual (suffixes "bar") ["bar", ""]
+      , scope "two namespaces"
+        $ expectEqual (suffixes "foo.bar") ["foo.bar", "bar", ""]
+      , scope "multiple namespaces" 
+        $ expectEqual (suffixes "foo.bar.baz") ["foo.bar.baz", "bar.baz", "baz", ""]
+      ]
+  ]

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -281,6 +281,7 @@ executable tests
     Unison.Test.UriParser
     Unison.Test.Util.Bytes
     Unison.Test.Var
+    Unison.Core.Test.Name
 
   build-depends:
     base,

--- a/unison-core/src/Unison/Name.hs
+++ b/unison-core/src/Unison/Name.hs
@@ -114,9 +114,13 @@ parent (Name txt) = case unsnoc (Text.splitOn "." txt) of
   Just ([],_) -> Nothing
   Just (init,_) -> Just $ Name (Text.intercalate "." init)
 
+-- suffixes "" -> [] 
+-- suffixes bar -> [bar]
+-- suffixes foo.bar -> [foo.bar, bar]
+-- suffixes foo.bar.baz -> [foo.bar.baz, bar.baz, baz]
 suffixes :: Name -> [Name]
-suffixes (Name n) =
-  fmap up . tails . dropWhile (== "") $ Text.splitOn "." n
+suffixes (Name "") = []
+suffixes (Name n) = fmap up $ filter (not . null) $ tails $ Text.splitOn "." n
   where
   up ns = Name (Text.intercalate "." ns)
 

--- a/unison-src/transcripts/fix1334.md
+++ b/unison-src/transcripts/fix1334.md
@@ -6,16 +6,14 @@ Let's make some hash-only aliases, now that we can. :mad-with-power-emoji:
 
 ```ucm
 .> alias.type ##Nat Cat
-.> alias.type ##Boolean Twoolean
 .> alias.term ##Nat.+ please_fix_763.+
-.> alias.term ##Universal.== please_fix_763.==
 ```
 
 And some functions that use them:
 ```unison
 f = 3
 g = 4
-h = f + 1 == 5
+h = f + 1
 
 > h
 ```

--- a/unison-src/transcripts/fix1334.output.md
+++ b/unison-src/transcripts/fix1334.output.md
@@ -9,15 +9,7 @@ Let's make some hash-only aliases, now that we can. :mad-with-power-emoji:
 
   Done.
 
-.> alias.type ##Boolean Twoolean
-
-  Done.
-
 .> alias.term ##Nat.+ please_fix_763.+
-
-  Done.
-
-.> alias.term ##Universal.== please_fix_763.==
 
   Done.
 
@@ -26,7 +18,7 @@ And some functions that use them:
 ```unison
 f = 3
 g = 4
-h = f + 1 == 5
+h = f + 1
 
 > h
 ```
@@ -41,14 +33,14 @@ h = f + 1 == 5
     
       f : Cat
       g : Cat
-      h : Twoolean
+      h : Cat
    
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.
 
     5 | > h
           ⧩
-          false
+          4
 
 ```
 ```ucm
@@ -58,7 +50,7 @@ h = f + 1 == 5
   
     f : Cat
     g : Cat
-    h : Twoolean
+    h : Cat
 
 ```
 We used to have to know the full hash for a definition to be able to use the `replace.*` commands, but now we don't:
@@ -100,6 +92,6 @@ The value of `h` should have been updated too:
 
     1 | > h
           ⧩
-          true
+          5
 
 ```


### PR DESCRIPTION
## Overview

Updates Name.suffixes and adds relevant unit tests

* The before behaviour can be seen in the first commit: `suffixes` adds an empty string at the end of the list.
* The after behaviour can be seen in the unit tests: `suffixes` no longer adds the empty string.

fix #1339

## Implementation notes

* Input `""` is unexpected and should return an empty list of names
* Otherwise split, get all tails, remove empty string, then put back together with `.` in the middle

## Interesting/controversial decisions

There were no unit tests for `unison-core/`. I have added the tests for `Name` as part of the `tests` binary, but under a `Unison.Core.` namespace, on purpose so future `unison-core` unit tests can be grouped together.

## Test coverage

Covered.

## Loose ends

Not that I am aware of.
