### PR TITLE
Make the first argument of push required

### DIFF
--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -725,7 +725,7 @@ push :: InputPattern
 push = InputPattern
   "push"
   []
-  [(Optional, gitUrlArg), (Optional, pathArg)]
+  [(Required, gitUrlArg), (Optional, pathArg)]
   (P.lines
     [ P.wrap
       "The `push` command merges a local namespace into a remote namespace."


### PR DESCRIPTION
## Overview

This PR aims to fix #1324

Before: upon attempting to code complete the second argument of `push`, `ucm` dies immediately.
After: with the first argument entered, code complete works for the second argument.

## Implementation notes

As per the description of #1324 corrects the breakage by making the first argument required.

## Test coverage

Manually tested :muscle: 

![Screenshot from 2020-03-20 21-03-18](https://user-images.githubusercontent.com/22328152/77206519-10cfc000-6aef-11ea-8060-5513205a470f.png)

![Screenshot from 2020-03-20 21-03-23](https://user-images.githubusercontent.com/22328152/77206507-09101b80-6aef-11ea-92d6-fac73bf54783.png)
