### PR TITLE
Let more places use Reference.Id

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -24,7 +24,7 @@ module Unison.Builtin
 
 import Unison.Prelude
 
-import           Data.Bifunctor                 ( second )
+import           Data.Bifunctor                 ( second, first )
 import qualified Data.Map                      as Map
 import qualified Data.Set                      as Set
 import qualified Data.Text                     as Text
@@ -33,6 +33,7 @@ import           Unison.Codebase.CodeLookup     ( CodeLookup(..) )
 import           Unison.DataDeclaration         ( DataDeclaration'
                                                 , EffectDeclaration'
                                                 )
+import qualified Unison.Builtin.Decls          as DD
 import qualified Unison.DataDeclaration        as DD
 import           Unison.Parser                  ( Ann(..) )
 import qualified Unison.Reference              as R
@@ -58,13 +59,15 @@ names = Names names0 mempty
 names0 :: Names0
 names0 = Names3.names0 terms types where
   terms = Rel.mapRan Referent.Ref (Rel.fromMap termNameRefs) <>
-    Rel.fromList [ (Name.fromVar vc, Referent.Con r cid ct)
+    Rel.fromList [ (Name.fromVar vc, Referent.Con (R.DerivedId r) cid ct)
                  | (ct, (_,(r,decl))) <- ((CT.Data,) <$> builtinDataDecls @Symbol) <>
                     ((CT.Effect,) . (second . second) DD.toDataDecl <$> builtinEffectDecls)
                  , ((_,vc,_), cid) <- DD.constructors' decl `zip` [0..]]
   types = Rel.fromList builtinTypes <>
-    Rel.fromList [ (Name.fromVar v, r) | (v,(r,_)) <- builtinDataDecls @Symbol ] <>
-    Rel.fromList [ (Name.fromVar v, r) | (v,(r,_)) <- builtinEffectDecls @Symbol ]
+    Rel.fromList [ (Name.fromVar v, R.DerivedId r)
+                 | (v,(r,_)) <- builtinDataDecls @Symbol ] <>
+    Rel.fromList [ (Name.fromVar v, R.DerivedId r)
+                 | (v,(r,_)) <- builtinEffectDecls @Symbol ]
 
 -- note: this function is really for deciding whether `r` is a term or type,
 -- but it can only answer correctly for Builtins.
@@ -75,27 +78,25 @@ typeLookup :: Var v => TL.TypeLookup v Ann
 typeLookup =
   TL.TypeLookup
     (fmap (const Intrinsic) <$> termRefTypes)
-    (Map.fromList $ map snd builtinDataDecls)
-    (Map.fromList $ map snd builtinEffectDecls)
+    (Map.fromList . map (first R.DerivedId) $ map snd builtinDataDecls)
+    (Map.fromList . map (first R.DerivedId) $ map snd builtinEffectDecls)
 
 constructorType :: R.Reference -> Maybe CT.ConstructorType
 constructorType r = TL.constructorType (typeLookup @Symbol) r
                 <|> Map.lookup r builtinConstructorType
 
--- | parse some builtin data types, and resolve their free variables using
--- | builtinTypes' and those types defined herein
-builtinDataDecls :: Var v => [(v, (R.Reference, DataDeclaration v))]
+builtinDataDecls :: Var v => [(v, (R.Id, DataDeclaration v))]
 builtinDataDecls =
   [ (v, (r, Intrinsic <$ d)) | (v, r, d) <- DD.builtinDataDecls ]
 
-builtinEffectDecls :: Var v => [(v, (R.Reference, EffectDeclaration v))]
-builtinEffectDecls = []
+builtinEffectDecls :: Var v => [(v, (R.Id, EffectDeclaration v))]
+builtinEffectDecls = [ (v, (r, Intrinsic <$ d)) | (v, r, d) <- DD.builtinEffectDecls ]
 
 codeLookup :: (Applicative m, Var v) => CodeLookup v m Ann
 codeLookup = CodeLookup (const $ pure Nothing) $ \r ->
   pure
-    $ lookup r [ (r, Right x) | (R.DerivedId r, x) <- snd <$> builtinDataDecls ]
-  <|> lookup r [ (r, Left x)  | (R.DerivedId r, x) <- snd <$> builtinEffectDecls ]
+    $ lookup r [ (r, Right x) | (r, x) <- snd <$> builtinDataDecls ]
+  <|> lookup r [ (r, Left x)  | (r, x) <- snd <$> builtinEffectDecls ]
 
 -- Relation predicate: Domain depends on range.
 builtinDependencies :: Rel.Relation R.Reference R.Reference

--- a/parser-typechecker/src/Unison/Builtin/Decls.hs
+++ b/parser-typechecker/src/Unison/Builtin/Decls.hs
@@ -1,0 +1,235 @@
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Unison.Builtin.Decls where
+
+import           Data.List                      ( elemIndex, find )
+import qualified Data.Map                       as Map
+import           Data.Text                      (Text)
+import qualified Unison.ABT as ABT
+import qualified Unison.ConstructorType         as CT
+import qualified Unison.DataDeclaration as DD
+import           Unison.DataDeclaration         ( DataDeclaration'
+                                                    (DataDeclaration)
+                                                , Modifier
+                                                    (Structural, Unique)
+                                                , hashDecls )
+import qualified Unison.Pattern                 as Pattern
+import           Unison.Reference               (Reference)
+import qualified Unison.Reference               as Reference
+import           Unison.Referent                (Referent)
+import qualified Unison.Referent                as Referent
+import           Unison.Symbol                  (Symbol)
+import           Unison.Term                    (ConstructorId, Term, Term2)
+import qualified Unison.Term                    as Term
+import qualified Unison.Type                    as Type
+import           Unison.Type                    (Type)
+import qualified Unison.Var                     as Var
+import           Unison.Var                     (Var)
+
+
+unitRef, pairRef, optionalRef, testResultRef, linkRef, docRef :: Reference
+(unitRef, pairRef, optionalRef, testResultRef, linkRef, docRef) =
+  let decls          = builtinDataDecls @Symbol
+      [(_, unit, _)] = filter (\(v, _, _) -> v == Var.named "Unit") decls
+      [(_, pair, _)] = filter (\(v, _, _) -> v == Var.named "Tuple") decls
+      [(_, opt , _)] = filter (\(v, _, _) -> v == Var.named "Optional") decls
+      [(_, testResult, _)] =
+        filter (\(v, _, _) -> v == Var.named "Test.Result") decls
+      [(_, link , _)] = filter (\(v, _, _) -> v == Var.named "Link") decls
+      [(_, doc , _)] = filter (\(v, _, _) -> v == Var.named "Doc") decls
+      r = Reference.DerivedId
+  in  (r unit, r pair, r opt, r testResult, r link, r doc)
+
+pairCtorRef, unitCtorRef :: Referent
+pairCtorRef = Referent.Con pairRef 0 CT.Data
+unitCtorRef = Referent.Con unitRef 0 CT.Data
+
+constructorId :: Reference -> Text -> Maybe Int
+constructorId ref name = do
+  (_,_,dd) <- find (\(_,r,_) -> Reference.DerivedId r == ref) (builtinDataDecls @Symbol)
+  elemIndex name $ DD.constructorNames dd
+
+okConstructorId, failConstructorId, docBlobId, docLinkId, docSignatureId, docSourceId, docEvaluateId, docJoinId, linkTermId, linkTypeId :: ConstructorId
+Just okConstructorId = constructorId testResultRef "Test.Result.Ok"
+Just failConstructorId = constructorId testResultRef "Test.Result.Fail"
+Just docBlobId = constructorId docRef "Doc.Blob"
+Just docLinkId = constructorId docRef "Doc.Link"
+Just docSignatureId = constructorId docRef "Doc.Signature"
+Just docSourceId = constructorId docRef "Doc.Source"
+Just docEvaluateId = constructorId docRef "Doc.Evaluate"
+Just docJoinId = constructorId docRef "Doc.Join"
+Just linkTermId = constructorId linkRef "Link.Term"
+Just linkTypeId = constructorId linkRef "Link.Type"
+
+okConstructorReferent, failConstructorReferent :: Referent.Referent
+okConstructorReferent = Referent.Con testResultRef okConstructorId CT.Data
+failConstructorReferent = Referent.Con testResultRef failConstructorId CT.Data
+
+failResult :: (Ord v, Monoid a) => a -> Text -> Term v a
+failResult ann msg =
+  Term.app ann (Term.request ann testResultRef failConstructorId)
+               (Term.text ann msg)
+
+-- | parse some builtin data types, and resolve their free variables using
+-- | builtinTypes' and those types defined herein
+builtinDataDecls :: Var v => [(v, Reference.Id, DataDeclaration' v ())]
+builtinDataDecls = rs1 ++ rs
+ where
+  rs1 = case hashDecls $ Map.fromList
+    [ (v "Link"           , link)
+    ] of Right a -> a; Left e -> error $ "builtinDataDecls: " <> show e
+  rs = case hashDecls $ Map.fromList
+    [ (v "Unit"           , unit)
+    , (v "Tuple"          , tuple)
+    , (v "Optional"       , opt)
+    , (v "Test.Result"    , tr)
+    , (v "Doc"            , doc)
+    ] of Right a -> a; Left e -> error $ "builtinDataDecls: " <> show e
+  [(_, linkRef, _)] = rs1
+  v = Var.named
+  var name = Type.var () (v name)
+  arr  = Type.arrow'
+  -- see note on `hashDecls` above for why ctor must be called `Unit.Unit`.
+  unit = DataDeclaration Structural () [] [((), v "Unit.Unit", var "Unit")]
+  tuple = DataDeclaration
+    Structural
+    ()
+    [v "a", v "b"]
+    [ ( ()
+      , v "Tuple.Cons"
+      , Type.foralls
+        ()
+        [v "a", v "b"]
+        (     var "a"
+        `arr` (var "b" `arr` Type.apps' (var "Tuple") [var "a", var "b"])
+        )
+      )
+    ]
+  opt = DataDeclaration
+    Structural
+    ()
+    [v "a"]
+    [ ( ()
+      , v "Optional.None"
+      , Type.foralls () [v "a"] (Type.app' (var "Optional") (var "a"))
+      )
+    , ( ()
+      , v "Optional.Some"
+      , Type.foralls ()
+                     [v "a"]
+                     (var "a" `arr` Type.app' (var "Optional") (var "a"))
+      )
+    ]
+  tr = DataDeclaration
+    (Unique "70621e539cd802b2ad53105697800930411a3ebc")
+    ()
+    []
+    [ ((), v "Test.Result.Fail", Type.text () `arr` var "Test.Result")
+    , ((), v "Test.Result.Ok"  , Type.text () `arr` var "Test.Result")
+    ]
+  doc = DataDeclaration
+    (Unique "c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004")
+    ()
+    []
+    [ ((), v "Doc.Blob", Type.text () `arr` var "Doc")
+    , ((), v "Doc.Link", Type.refId () linkRef `arr` var "Doc")
+    , ((), v "Doc.Signature", Type.termLink () `arr` var "Doc")
+    , ((), v "Doc.Source", Type.refId () linkRef `arr` var "Doc")
+    , ((), v "Doc.Evaluate", Type.termLink () `arr` var "Doc")
+    , ((), v "Doc.Join", Type.app () (Type.vector()) (var "Doc") `arr` var "Doc")
+    ]
+  link = DataDeclaration
+    (Unique "a5803524366ead2d7f3780871d48771e8142a3b48802f34a96120e230939c46bd5e182fcbe1fa64e9bff9bf741f3c04")
+    ()
+    []
+    [ ((), v "Link.Term", Type.termLink () `arr` var "Link")
+    , ((), v "Link.Type", Type.typeLink () `arr` var "Link")
+    ]
+
+builtinEffectDecls :: [(v, Reference.Id, DD.EffectDeclaration' v ())]
+builtinEffectDecls = []
+
+pattern UnitRef <- (unUnitRef -> True)
+pattern PairRef <- (unPairRef -> True)
+pattern OptionalRef <- (unOptionalRef -> True)
+pattern TupleType' ts <- (unTupleType -> Just ts)
+pattern TupleTerm' xs <- (unTupleTerm -> Just xs)
+pattern TuplePattern ps <- (unTuplePattern -> Just ps)
+
+-- some pattern synonyms to make pattern matching on some of these constants more pleasant
+pattern DocRef <- ((== docRef) -> True)
+pattern DocJoin segs <- Term.App' (Term.Constructor' DocRef DocJoinId) (Term.Sequence' segs)
+pattern DocBlob txt <- Term.App' (Term.Constructor' DocRef DocBlobId) (Term.Text' txt)
+pattern DocLink link <- Term.App' (Term.Constructor' DocRef DocLinkId) link
+pattern DocSource link <- Term.App' (Term.Constructor' DocRef DocSourceId) link
+pattern DocSignature link <- Term.App' (Term.Constructor' DocRef DocSignatureId) link
+pattern DocEvaluate link <- Term.App' (Term.Constructor' DocRef DocEvaluateId) link
+pattern Doc <- Term.App' (Term.Constructor' DocRef _) _
+pattern DocSignatureId <- ((== docSignatureId) -> True)
+pattern DocBlobId <- ((== docBlobId) -> True)
+pattern DocLinkId <- ((== docLinkId) -> True)
+pattern DocSourceId <- ((== docSourceId) -> True)
+pattern DocEvaluateId <- ((== docEvaluateId) -> True)
+pattern DocJoinId <- ((== docJoinId) -> True)
+pattern LinkTermId <- ((== linkTermId) -> True)
+pattern LinkTypeId <- ((== linkTypeId) -> True)
+pattern LinkRef <- ((== linkRef) -> True)
+pattern LinkTerm tm <- Term.App' (Term.Constructor' LinkRef LinkTermId) tm
+pattern LinkType ty <- Term.App' (Term.Constructor' LinkRef LinkTypeId) ty
+
+unitType, pairType, optionalType, testResultType
+  :: Ord v => a -> Type v a
+unitType a = Type.ref a unitRef
+pairType a = Type.ref a pairRef
+testResultType a = Type.app a (Type.vector a) (Type.ref a testResultRef)
+optionalType a = Type.ref a optionalRef
+
+unitTerm :: Var v => a -> Term v a
+unitTerm ann = Term.constructor ann unitRef 0
+
+tupleConsTerm :: (Ord v, Semigroup a)
+              => Term2 vt at ap v a
+              -> Term2 vt at ap v a
+              -> Term2 vt at ap v a
+tupleConsTerm hd tl =
+  Term.apps' (Term.constructor (ABT.annotation hd) pairRef 0) [hd, tl]
+
+tupleTerm :: (Var v, Monoid a) => [Term v a] -> Term v a
+tupleTerm = foldr tupleConsTerm (unitTerm mempty)
+
+-- delayed terms are just lambdas that take a single `()` arg
+-- `force` calls the function
+forceTerm :: Var v => a -> a -> Term v a -> Term v a
+forceTerm a au e = Term.app a e (unitTerm au)
+
+delayTerm :: Var v => a -> Term v a -> Term v a
+delayTerm a = Term.lam a $ Var.named "()"
+
+unTupleTerm
+  :: Term.Term2 vt at ap v a
+  -> Maybe [Term.Term2 vt at ap v a]
+unTupleTerm t = case t of
+  Term.Apps' (Term.Constructor' PairRef 0) [fst, snd] ->
+    (fst :) <$> unTupleTerm snd
+  Term.Constructor' UnitRef 0 -> Just []
+  _                           -> Nothing
+
+unTupleType :: Var v => Type v a -> Maybe [Type v a]
+unTupleType t = case t of
+  Type.Apps' (Type.Ref' PairRef) [fst, snd] -> (fst :) <$> unTupleType snd
+  Type.Ref' UnitRef -> Just []
+  _ -> Nothing
+
+unTuplePattern :: Pattern.PatternP loc -> Maybe [Pattern.PatternP loc]
+unTuplePattern p = case p of
+  Pattern.ConstructorP _ PairRef 0 [fst, snd] -> (fst : ) <$> unTuplePattern snd
+  Pattern.ConstructorP _ UnitRef 0 [] -> Just []
+  _ -> Nothing
+
+unUnitRef,unPairRef,unOptionalRef:: Reference -> Bool
+unUnitRef = (== unitRef)
+unPairRef = (== pairRef)
+unOptionalRef = (== optionalRef)
+

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -4,7 +4,6 @@ module Unison.Codebase where
 
 import Unison.Prelude
 
-import           Control.Category               ( (>>>) )
 import           Control.Lens                   ( _1, _2, (%=) )
 import           Control.Monad.State            ( State, evalState, get )
 import           Data.Bifunctor                 ( bimap )
@@ -21,7 +20,6 @@ import qualified Unison.Names2                 as Names
 import           Unison.Reference               ( Reference )
 import qualified Unison.Reference              as Reference
 import qualified Unison.Referent as Referent
-import Unison.Referent (Referent, Referent')
 import qualified Unison.Term                   as Term
 import qualified Unison.Type                   as Type
 import           Unison.Typechecker.TypeLookup  (TypeLookup(TypeLookup))
@@ -29,6 +27,7 @@ import qualified Unison.Typechecker.TypeLookup as TL
 import qualified Unison.Parser                 as Parser
 import qualified Unison.UnisonFile             as UF
 import qualified Unison.Util.Relation          as Rel
+import qualified Unison.Util.Set               as Set
 import qualified Unison.Var                    as Var
 import           Unison.Var                     ( Var )
 import qualified Unison.Runtime.IOSource       as IOSource
@@ -38,8 +37,6 @@ import Unison.Term (Term)
 import Unison.Type (Type)
 import Unison.Codebase.ShortBranchHash (ShortBranchHash)
 import Unison.ShortHash (ShortHash)
-
---import Debug.Trace
 
 type DataDeclaration v a = DD.DataDeclaration' v a
 type EffectDeclaration v a = DD.EffectDeclaration' v a
@@ -52,10 +49,10 @@ data Codebase m v a =
            , putTerm            :: Reference.Id -> Term v a -> Type v a -> m ()
            , putTypeDeclaration :: Reference.Id -> Decl v a -> m ()
 
-           , getRootBranch      :: m (Branch m)
+           , getRootBranch      :: m (Either GetRootBranchError (Branch m))
            , putRootBranch      :: Branch m -> m ()
            , rootBranchUpdates  :: m (m (), m (Set Branch.Hash))
-           , getBranchForHash   :: Branch.Hash -> m (Branch m)
+           , getBranchForHash   :: Branch.Hash -> m (Maybe (Branch m))
 
            , dependentsImpl     :: Reference -> m (Set Reference.Id)
            -- This copies all codebase elements (except _head) from the
@@ -77,18 +74,20 @@ data Codebase m v a =
            , appendReflog       :: Text -> Branch m -> Branch m -> m ()
 
            -- list of terms of the given type
-           , termsOfTypeImpl    :: Reference -> m (Set Referent)
+           , termsOfTypeImpl    :: Reference -> m (Set Referent.Id)
            -- list of terms that mention the given type anywhere in their signature
-           , termsMentioningTypeImpl :: Reference -> m (Set Referent)
+           , termsMentioningTypeImpl :: Reference -> m (Set Referent.Id)
            -- number of base58 characters needed to distinguish any two references in the codebase
            , hashLength         :: m Int
            , termReferencesByPrefix :: ShortHash -> m (Set Reference.Id)
            , typeReferencesByPrefix :: ShortHash -> m (Set Reference.Id)
-           , termReferentsByPrefix :: ShortHash -> m (Set (Referent' Reference.Id))
+           , termReferentsByPrefix :: ShortHash -> m (Set Referent.Id)
 
            , branchHashLength   :: m Int
            , branchHashesByPrefix :: ShortBranchHash -> m (Set Branch.Hash)
            }
+
+data GetRootBranchError = NoRootBranch | CouldntLoadRootBranch Branch.Hash
 
 bootstrapNames :: Names.Names0
 bootstrapNames =
@@ -117,17 +116,14 @@ initializeCodebase c = do
 addDefsToCodebase :: forall m v a. (Monad m, Var v)
   => Codebase m v a -> UF.TypecheckedUnisonFile v a -> m ()
 addDefsToCodebase c uf = do
-  traverse_ (goType Right) (UF.dataDeclarations' uf)
-  traverse_ (goType Left)  (UF.effectDeclarations' uf)
+  traverse_ (goType Right) (UF.dataDeclarationsId' uf)
+  traverse_ (goType Left)  (UF.effectDeclarationsId' uf)
   -- put terms
-  traverse_ goTerm (UF.hashTerms uf)
+  traverse_ goTerm (UF.hashTermsId uf)
   where
-    goTerm (Reference.DerivedId r, tm, tp) = putTerm c r tm tp
-    goTerm b = error $ "tried to write builtin term to codebase: " ++ show b
-    goType :: (t -> Decl v a) -> (Reference.Reference, t) -> m ()
-    goType f (ref, decl) = case ref of
-      Reference.DerivedId id -> putTypeDeclaration c id (f decl)
-      Reference.Builtin{}    -> pure ()
+    goTerm (r, tm, tp) = putTerm c r tm tp
+    goType :: (t -> Decl v a) -> (Reference.Id, t) -> m ()
+    goType f (ref, decl) = putTypeDeclaration c ref (f decl)
 
 getTypeOfConstructor ::
   (Monad m, Ord v) => Codebase m v a -> Reference -> Int -> m (Maybe (Type v a))
@@ -160,31 +156,26 @@ typeLookupForDependencies codebase = foldM go mempty
 transitiveDependencies
   :: (Monad m, Var v)
   => CL.CodeLookup v m a
-  -> Set Reference
-  -> Reference
-  -> m (Set Reference)
-transitiveDependencies code seen0 r = if Set.member r seen0
+  -> Set Reference.Id
+  -> Reference.Id
+  -> m (Set Reference.Id)
+transitiveDependencies code seen0 rid = if Set.member rid seen0
   then pure seen0
   else
-    let seen = Set.insert r seen0
-    in
-      case r of
-        Reference.DerivedId id -> do
-          t <- CL.getTerm code id
-          case t of
-            Just t ->
-              foldM (transitiveDependencies code) seen (Term.dependencies t)
-            Nothing -> do
-              t <- CL.getTypeDeclaration code id
-              case t of
-                Nothing        -> pure seen
-                Just (Left ed) -> foldM (transitiveDependencies code)
-                                        seen
-                                        (DD.dependencies (DD.toDataDecl ed))
-                Just (Right dd) -> foldM (transitiveDependencies code)
-                                         seen
-                                         (DD.dependencies dd)
-        Reference.Builtin{} -> pure seen
+    let seen = Set.insert rid seen0
+        getIds = Set.mapMaybe Reference.toId
+    in CL.getTerm code rid >>= \case
+      Just t ->
+        foldM (transitiveDependencies code) seen (getIds $ Term.dependencies t)
+      Nothing -> 
+        CL.getTypeDeclaration code rid >>= \case 
+          Nothing        -> pure seen
+          Just (Left ed) -> foldM (transitiveDependencies code)
+                                  seen
+                                  (getIds $ DD.dependencies (DD.toDataDecl ed))
+          Just (Right dd) -> foldM (transitiveDependencies code)
+                                   seen
+                                   (getIds $ DD.dependencies dd)
 
 toCodeLookup :: Codebase m v a -> CL.CodeLookup v m a
 toCodeLookup c = CL.CodeLookup (getTerm c) (getTypeDeclaration c)
@@ -198,47 +189,59 @@ makeSelfContained'
   -> UF.UnisonFile v a
   -> m (UF.UnisonFile v a)
 makeSelfContained' code uf = do
-  let UF.UnisonFile ds0 es0 bs0 ws0 = uf
-      deps0 = Term.dependencies . snd <$> (UF.allWatches uf <> bs0)
+  let UF.UnisonFileId ds0 es0 bs0 ws0 = uf
+      deps0 = getIds . Term.dependencies . snd <$> (UF.allWatches uf <> bs0)
+        where getIds = Set.mapMaybe Reference.toId
+  -- transitive dependencies (from codebase) of all terms (including watches) in the UF
   deps <- foldM (transitiveDependencies code) Set.empty (Set.unions deps0)
-  decls <- fmap catMaybes . forM (toList deps) $ \case
-    r@(Reference.DerivedId rid) -> fmap (r, ) <$> CL.getTypeDeclaration code rid
-    Reference.Builtin{}         -> pure Nothing
-  let (es1, ds1) = partitionEithers [ bimap (r,) (r,) d | (r, d) <- decls ]
-  bs1 <- fmap catMaybes . forM (toList deps) $ \case
-    r@(Reference.DerivedId rid) ->
-      fmap (r, ) <$> CL.getTerm code rid
-    Reference.Builtin{} -> pure Nothing
+  -- load all decls from deps list
+  decls <- fmap catMaybes
+         . forM (toList deps)
+         $ \rid -> fmap (rid, ) <$> CL.getTypeDeclaration code rid
+  -- partition the decls into effects and data
+  let es1 :: [(Reference.Id, DD.EffectDeclaration' v a)]
+      ds1 :: [(Reference.Id, DD.DataDeclaration' v a)]
+      (es1, ds1) = partitionEithers [ bimap (r,) (r,) d | (r, d) <- decls ]
+  -- load all terms from deps list
+  bs1 <- fmap catMaybes
+       . forM (toList deps)
+       $ \rid -> fmap (rid, ) <$> CL.getTerm code rid
   let
+    allVars :: Set v
     allVars = Set.unions
       [ UF.allVars uf
       , Set.unions [ DD.allVars dd | (_, dd) <- ds1 ]
       , Set.unions [ DD.allVars (DD.toDataDecl ed) | (_, ed) <- es1 ]
       , Set.unions [ Term.allVars tm | (_, tm) <- bs1 ]
       ]
-    refVar :: Reference -> State (Set v, Map Reference v) v
-    refVar r = (get >>=) $ snd >>> Map.lookup r >>> \case
-      Just v -> pure v
-      Nothing -> do
-        v <- ABT.freshenS' _1 (Var.refNamed r)
-        _2 %=  Map.insert r v
-        pure v
-    assignVars :: [(Reference, b)] -> State (Set v, Map Reference v) [(v, (Reference, b))]
-    assignVars es = traverse (\e@(r, _) -> (,e) <$> refVar r) es
-    unref :: Term v a -> State (Set v, Map Reference v) (Term v a)
+    refVar :: Reference.Id -> State (Set v, Map Reference.Id v) v
+    refVar r = do
+      m <- snd <$> get
+      case Map.lookup r m of
+        Just v -> pure v
+        Nothing -> do
+          v <- ABT.freshenS' _1 (Var.refNamed (Reference.DerivedId r))
+          _2 %=  Map.insert r v
+          pure v
+    assignVars :: [(Reference.Id, b)] -> State (Set v, Map Reference.Id v) [(v, (Reference.Id, b))]
+    assignVars = traverse (\e@(r, _) -> (,e) <$> refVar r)
+    unref :: Term v a -> State (Set v, Map Reference.Id v) (Term v a)
     unref = ABT.visit go where
-      go t@(Term.Ref' r@(Reference.DerivedId _)) =
+      go t@(Term.Ref' (Reference.DerivedId r)) =
         Just (Term.var (ABT.annotation t) <$> refVar r)
       go _ = Nothing
-    unrefb bs = traverse (\(v, tm) -> (v,) <$> unref tm) bs
+    unrefb = traverse (\(v, tm) -> (v,) <$> unref tm)
+    pair :: forall f a b. Applicative f => f a -> f b -> f (a,b)
     pair = liftA2 (,)
     uf' = flip evalState (allVars, Map.empty) $ do
       datas' <- Map.union ds0 . Map.fromList <$> assignVars ds1
       effects' <- Map.union es0 . Map.fromList <$> assignVars es1
+      -- bs0 is terms from the input file
       bs0' <- unrefb bs0
       ws0' <- traverse unrefb ws0
+      -- bs1 is dependency terms
       bs1' <- traverse (\(r, tm) -> refVar r `pair` unref tm) bs1
-      pure $ UF.UnisonFile datas' effects' (bs1' ++ bs0') ws0'
+      pure $ UF.UnisonFileId datas' effects' (bs1' ++ bs0') ws0'
   pure uf'
 
 getTypeOfTerm :: (Applicative m, Var v, BuiltinAnnotation a) =>
@@ -258,13 +261,16 @@ dependents c r
 
 termsOfType :: (Var v, Functor m) => Codebase m v a -> Type v a -> m (Set Referent.Referent)
 termsOfType c ty =
-  Set.union (Rel.lookupDom r Builtin.builtinTermsByType) <$> termsOfTypeImpl c r
+  Set.union (Rel.lookupDom r Builtin.builtinTermsByType)
+    . Set.map (fmap Reference.DerivedId)
+    <$> termsOfTypeImpl c r
   where
   r = Type.toReference ty
 
 termsMentioningType :: (Var v, Functor m) => Codebase m v a -> Type v a -> m (Set Referent.Referent)
 termsMentioningType c ty =
   Set.union (Rel.lookupDom r Builtin.builtinTermsByTypeMention)
+    . Set.map (fmap Reference.DerivedId)
     <$> termsMentioningTypeImpl c r
   where
   r = Type.toReference ty

--- a/parser-typechecker/src/Unison/Codebase/BranchLoadMode.hs
+++ b/parser-typechecker/src/Unison/Codebase/BranchLoadMode.hs
@@ -1,9 +1,0 @@
-module Unison.Codebase.BranchLoadMode where
-
--- When loading a nonexistent branch, what should happen?
--- Could bomb (`FailIfMissing`) or return the empty branch (`EmptyIfMissing`).
---
--- `EmptyIfMissing` mode is used when attempting to load a user-specified
--- branch. `FailIfMissing` is used when loading the root branch - if the root
--- does not exist, that's a serious problem.
-data BranchLoadMode = FailIfMissing | EmptyIfMissing deriving (Eq, Show)

--- a/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
+++ b/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
@@ -25,6 +25,17 @@ import qualified Unison.Codebase.Metadata as Metadata
 import qualified Unison.Util.List as List
 import Unison.Codebase.Patch (Patch)
 import Unison.Codebase.NameSegment (HQSegment, NameSegment)
+import Control.Lens (view)
+
+fromNames0 :: Monad m => Names0 -> Branch m
+fromNames0 names0 = Branch.one $ addFromNames0 names0 Branch.empty0
+
+-- can produce a pure value because there's no history to traverse
+hashesFromNames0 :: Monad m => Names0 -> Map Branch.Hash (Branch m)
+hashesFromNames0 = deepHashes . fromNames0 where 
+  deepHashes :: Branch m -> Map Branch.Hash (Branch m)
+  deepHashes b = Map.singleton (Branch.headHash b) b 
+    <> (foldMap deepHashes . view Branch.children . Branch.head) b
 
 addFromNames0 :: Monad m => Names0 -> Branch0 m -> Branch0 m
 addFromNames0 names0 = Branch.stepManyAt0 (typeActions <> termActions)

--- a/parser-typechecker/src/Unison/Codebase/CodeLookup.hs
+++ b/parser-typechecker/src/Unison/Codebase/CodeLookup.hs
@@ -24,7 +24,7 @@ fromUnisonFile uf = CodeLookup tm ty where
                             Map.toList (UF.effectDeclarations uf) ]
   tmm = Map.fromList (UF.terms uf)
   termMap = Map.fromList [ (id, e) |
-                            (_, (Reference.DerivedId id, e)) <-
+                            (_, (id, e)) <-
                             Map.toList (Term.hashComponents tmm) ]
 
 data CodeLookup v m a

--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -39,7 +39,6 @@ import           Unison.ShortHash               ( ShortHash )
 import           Unison.Type                    ( Type )
 import           Unison.Codebase.ShortBranchHash
                                                 ( ShortBranchHash )
-import Unison.Codebase.BranchLoadMode (BranchLoadMode)
 
 
 type AmbientAbilities v = [Type v Ann]
@@ -137,7 +136,7 @@ data Command m i v a where
   LoadLocalBranch :: Branch.Hash -> Command m i v (Branch m)
 
   LoadRemoteRootBranch ::
-    BranchLoadMode -> RemoteRepo -> Command m i v (Either GitError (Branch m))
+    RemoteRepo -> Command m i v (Either GitError (Branch m))
 
   -- returns NoRemoteNamespaceWithHash or RemoteNamespaceHashAmbiguous
   -- if no exact match.

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -55,7 +55,6 @@ import           Unison.Codebase.Branch         ( Branch(..)
                                                 , Branch0(..)
                                                 )
 import qualified Unison.Codebase.Branch        as Branch
-import           Unison.Codebase.BranchLoadMode ( BranchLoadMode(FailIfMissing, EmptyIfMissing) )
 import qualified Unison.Codebase.BranchUtil    as BranchUtil
 import qualified Unison.Codebase.Causal        as Causal
 import qualified Unison.Codebase.Metadata      as Metadata
@@ -69,6 +68,7 @@ import qualified Unison.Codebase.Reflog        as Reflog
 import           Unison.Codebase.SearchResult   ( SearchResult )
 import qualified Unison.Codebase.SearchResult  as SR
 import qualified Unison.Codebase.ShortBranchHash as SBH
+import qualified Unison.Builtin.Decls          as DD
 import qualified Unison.DataDeclaration        as DD
 import qualified Unison.HashQualified          as HQ
 import qualified Unison.HashQualified'         as HQ'
@@ -1509,8 +1509,7 @@ loop = do
       MergeBuiltinsI -> do
           let names0 = Builtin.names0
                        <> UF.typecheckedToNames0 IOSource.typecheckedFile
-          let b0 = BranchUtil.addFromNames0 names0 Branch.empty0
-          let srcb = Branch.one b0
+          let srcb = BranchUtil.fromNames0 names0
           _ <- updateAtM (currentPath' `snoc` "builtin") $ \destb ->
                  eval . Eval $ Branch.merge srcb destb
           success
@@ -1539,7 +1538,7 @@ loop = do
           Left e -> eval . Notify $ e
           Right (repo, Nothing, remotePath) -> do
               -- push from srcb to repo's remotePath
-              eval (LoadRemoteRootBranch EmptyIfMissing repo) >>= \case
+              eval (LoadRemoteRootBranch repo) >>= \case
                 Left e -> eval . Notify $ GitError input e
                 Right remoteRoot -> do
                   newRemoteRoot <- eval . Eval $
@@ -1991,7 +1990,7 @@ loadPropagateDiffDefaultPatch inputDescription dest0 dest = do
 
 loadRemoteBranch :: RemoteNamespace -> Action' m v (Either GitError (Branch m))
 loadRemoteBranch (repo, sbh, remotePath) = do
-  eroot <-  eval (maybe (LoadRemoteRootBranch FailIfMissing repo)
+  eroot <-  eval (maybe (LoadRemoteRootBranch repo)
                         (LoadRemoteShortBranch repo) sbh)
   pure $ Branch.getAt' remotePath <$> eroot
 
@@ -2275,8 +2274,14 @@ filterBySlurpResult :: Ord v
            => SlurpResult v
            -> UF.TypecheckedUnisonFile v Ann
            -> UF.TypecheckedUnisonFile v Ann
-filterBySlurpResult SlurpResult{..} UF.TypecheckedUnisonFile{..} =
-  UF.TypecheckedUnisonFile datas effects tlcs watches hashTerms'
+filterBySlurpResult SlurpResult{..}
+                    (UF.TypecheckedUnisonFileId
+                      dataDeclarations'
+                      effectDeclarations'
+                      topLevelComponents'
+                      watchComponents
+                      hashTerms) =
+  UF.TypecheckedUnisonFileId datas effects tlcs watches hashTerms'
   where
   keep = updates <> adds
   keepTerms = SC.terms keep
@@ -2604,8 +2609,8 @@ addRunMain mainName (Just uf) = do
       if Typechecker.isSubtype ty (nullaryMain a) then Just $ let
         runMain = DD.forceTerm a a (Term.var a v)
         in UF.typecheckedUnisonFile
-             (UF.dataDeclarations' uf)
-             (UF.effectDeclarations' uf)
+             (UF.dataDeclarationsId' uf)
+             (UF.effectDeclarationsId' uf)
              (UF.topLevelComponents' uf <> [[(v2, runMain, nullaryMain a)]])
              (UF.watchComponents uf)
       else Nothing

--- a/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
@@ -201,7 +201,9 @@ propagate patch b = case validatePatch patch of
                   <$> componentMap
               declMap = over _2 (either Decl.toDataDecl id) <$> componentMap'
               -- TODO: kind-check the new components
-              hashedDecls = Decl.hashDecls $ view _2 <$> declMap
+              hashedDecls = (fmap . fmap) (over _2 DerivedId)
+                          . Decl.hashDecls
+                          $ view _2 <$> declMap
           hashedComponents' <- case hashedDecls of
             Left _ ->
               fail
@@ -404,7 +406,7 @@ propagate patch b = case validatePatch patch of
          oldTypes
       then pure Nothing
       else do
-        let file = UnisonFile
+        let file = UnisonFileId
               mempty
               mempty
               (Map.toList $ (\(_, tm, _) -> tm) <$> componentMap)

--- a/parser-typechecker/src/Unison/Codebase/Execute.hs
+++ b/parser-typechecker/src/Unison/Codebase/Execute.hs
@@ -36,7 +36,12 @@ execute
   -> IO ()
 execute codebase runtime mainName =
   (`finally` Runtime.terminate runtime) $ do
-    root <- Codebase.getRootBranch codebase
+    root <- Codebase.getRootBranch codebase >>= \case
+      Right r -> pure r
+      Left Codebase.NoRootBranch ->
+        die ("Couldn't identify a root namespace.")
+      Left (Codebase.CouldntLoadRootBranch h) ->
+        die ("Couldn't load root branch " ++ show h)
     let parseNames0 = Names3.makeAbsolute0 (Branch.toNames0 (Branch.head root))
         loadTypeOfTerm = Codebase.getTypeOfTerm codebase
     mt <- getMainTerm loadTypeOfTerm parseNames0 mainName

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -4,12 +4,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Unison.Codebase.FileCodebase
 ( getRootBranch        -- used by Git module
 , branchHashesByPrefix -- used by Git module
 , branchFromFiles      -- used by Git module
-, BranchLoadMode(..)   -- used by Git module
 , codebase1  -- used by Main
 , exists     -- used by Main
 , initialize -- used by Main
@@ -74,7 +74,6 @@ import           Unison.Codebase.Causal         ( Causal
 import qualified Unison.Codebase.Causal        as Causal
 import           Unison.Codebase.Branch         ( Branch )
 import qualified Unison.Codebase.Branch        as Branch
-import           Unison.Codebase.BranchLoadMode ( BranchLoadMode(FailIfMissing, EmptyIfMissing) )
 import qualified Unison.Codebase.Reflog        as Reflog
 import qualified Unison.Codebase.Serialization as S
 import qualified Unison.Codebase.Serialization.V1
@@ -90,7 +89,7 @@ import qualified Unison.Reference              as Reference
 import           Unison.Referent                ( Referent
                                                 , pattern Ref
                                                 , pattern Con
-                                                , Referent' )
+                                                )
 import qualified Unison.Referent               as Referent
 import           Unison.Term                    ( Term )
 import qualified Unison.Term                   as Term
@@ -109,6 +108,7 @@ import Unison.ShortHash (ShortHash)
 import qualified Unison.ShortHash as SH
 import qualified Unison.ConstructorType as CT
 import Unison.Util.Monoid (foldMapM)
+import Control.Error (rightMay, runExceptT, ExceptT(..))
 
 type CodebasePath = FilePath
 
@@ -133,6 +133,7 @@ initCodebaseAndExit mdir = do
   _ <- initCodebase dir
   exitSuccess
 
+-- initializes a new codebase here (i.e. `ucm -codebase dir init`)
 initCodebase :: FilePath -> IO (Codebase IO Symbol Ann)
 initCodebase dir = do
   let path = dir </> codebasePath
@@ -157,18 +158,12 @@ initCodebase dir = do
 -- get the codebase in dir, or in the home directory if not provided.
 getCodebaseOrExit :: Maybe FilePath -> IO (Codebase IO Symbol Ann)
 getCodebaseOrExit mdir = do
-  (dir, errMsg) <- case mdir of
-    Just dir -> do
-      dir' <- P.string <$> canonicalizePath dir
-      let errMsg = P.lines ["No codebase exists in " <> dir'
-                           , "Run `ucm -codebase " <> P.string dir <> " init` to create one, then try again!"]
-      pure ( dir, errMsg)
-    Nothing -> do
-      dir <- getHomeDirectory
-      let errMsg = P.lines [ "No codebase exists in " <> P.string dir
-                           , "Run `ucm init` to create one, then try again!" ]
-      pure (dir, errMsg)
-
+  dir <- getCodebaseDir mdir
+  prettyDir <- P.string <$> canonicalizePath dir
+  let errMsg = P.lines
+        [ "No codebase exists in " <> prettyDir
+        , "Run `ucm -codebase " <> prettyDir
+          <> " init` to create one, then try again!"]
   let path = dir </> codebasePath
   let theCodebase = codebase1 V1.formatSymbol formatAnn path
   Codebase.initializeBuiltinCode theCodebase
@@ -303,15 +298,15 @@ initialize :: CodebasePath -> IO ()
 initialize path =
   traverse_ (createDirectoryIfMissing True) (minimalCodebaseStructure path)
 
-branchFromFiles :: MonadIO m => BranchLoadMode -> FilePath -> Branch.Hash -> m (Branch m)
-branchFromFiles loadMode rootDir h@(RawHash h') = do
+branchFromFiles :: MonadIO m => FilePath -> Branch.Hash -> m (Maybe (Branch m))
+branchFromFiles rootDir h@(RawHash h') = do
   fileExists <- doesFileExist (branchPath rootDir h')
-  if fileExists || loadMode == FailIfMissing then
+  if fileExists then Just <$>
     Branch.read (deserializeRawBranch rootDir)
                 (deserializeEdits rootDir)
                 h
   else
-    pure Branch.empty
+    pure Nothing
  where
   deserializeRawBranch
     :: MonadIO m => CodebasePath -> Causal.Deserialize m Branch.Raw Branch.Raw
@@ -328,25 +323,28 @@ branchFromFiles loadMode rootDir h@(RawHash h') = do
           Right edits -> pure edits
 
 -- returns Nothing if `root` has no root branch (in `branchHeadDir root`)
-getRootBranch ::
-  MonadIO m => BranchLoadMode -> CodebasePath -> m (Branch m)
-getRootBranch loadMode root = do
+getRootBranch :: forall m.
+  MonadIO m => CodebasePath -> m (Either Codebase.GetRootBranchError (Branch m))
+getRootBranch root =
   ifM (exists root)
-    (liftIO (listDirectory $ branchHeadDir root) >>= \case
-      []       -> missing
-      [single] -> go single
-      conflict -> traverse go conflict >>= \case
-        x : xs -> foldM Branch.merge x xs
-        []     -> missing
-    )
-    missing
+    (liftIO (listDirectory $ branchHeadDir root) >>= go')
+    (pure $ Left Codebase.NoRootBranch)
  where
+  go' :: [String] -> m (Either Codebase.GetRootBranchError (Branch m))
+  go' = \case
+              []       -> pure $ Left Codebase.NoRootBranch
+              [single] -> runExceptT $ go single
+              conflict -> runExceptT (traverse go conflict) >>= \case
+                Right (x : xs) -> Right <$> foldM Branch.merge x xs
+                Right _ -> error "FileCodebase.getRootBranch.conflict can't be empty."
+                Left e -> Left <$> pure e
+
+  go :: String -> ExceptT Codebase.GetRootBranchError m (Branch m)
   go single = case hashFromString single of
     Nothing -> failWith $ CantParseBranchHead single
-    Just h  -> branchFromFiles FailIfMissing root (RawHash h)
-  missing = case loadMode of
-    FailIfMissing -> failWith . NoBranchHead $ branchHeadDir root
-    EmptyIfMissing -> pure $ Branch.empty
+    Just (Branch.Hash -> h)  -> ExceptT $ branchFromFiles root h <&> \case
+      Just b -> Right b
+      Nothing -> Left $ Codebase.CouldntLoadRootBranch h
 
 putRootBranch :: MonadIO m => CodebasePath -> Branch m -> m ()
 putRootBranch root b = do
@@ -409,6 +407,12 @@ componentIdFromString = Reference.idFromText . Text.pack
 referentFromString :: String -> Maybe Referent
 referentFromString = Referent.fromText . Text.pack
 
+referentIdFromString :: String -> Maybe Referent.Id
+referentIdFromString s = referentFromString s >>= \case
+  Referent.Ref (Reference.DerivedId r) -> Just $ Referent.Ref' r
+  Referent.Con (Reference.DerivedId r) i t -> Just $ Referent.Con' r i t
+  _ -> Nothing
+
 -- here
 referentToString :: Referent -> String
 referentToString = Text.unpack . Referent.toText
@@ -451,7 +455,7 @@ syncToDirectory fmtV fmtA codebase localPath branch = do
   b <- (liftIO . exists) localPath
   if b then do
     let code = codebase1 fmtV fmtA localPath
-    remoteRoot <- Codebase.getRootBranch code
+    remoteRoot <- fromMaybe Branch.empty . rightMay <$> Codebase.getRootBranch code
     Branch.sync (hashExists localPath) serialize (serializeEdits localPath) branch
     merged <- Branch.merge branch remoteRoot
     Codebase.putRootBranch code merged
@@ -590,7 +594,7 @@ termReferentsByPrefix :: MonadIO m
   => (CodebasePath -> Reference.Id -> m (Maybe (DD.Decl v a)))
   -> CodebasePath
   -> ShortHash
-  -> m (Set (Referent' Reference.Id))
+  -> m (Set Referent.Id)
 termReferentsByPrefix getDecl root sh = do
   terms <- termReferencesByPrefix root sh
   ctors <- do
@@ -636,10 +640,10 @@ codebase1 fmtV@(S.Format getV putV) fmtA@(S.Format getA putA) path =
           (getDecl getV getA path)
           (putTerm putV putA path)
           (putDecl putV putA path)
-          (getRootBranch FailIfMissing path)
+          (getRootBranch path)
           (putRootBranch path)
           (branchHeadUpdates path)
-          (branchFromFiles EmptyIfMissing path)
+          (branchFromFiles path)
           dependents
           -- Just copies all the files from a to-be-supplied path to `path`.
           (copyFromGit path)
@@ -667,9 +671,9 @@ codebase1 fmtV@(S.Format getV putV) fmtA@(S.Format getA putA) path =
     getTypeOfTerm h = liftIO $ S.getFromFile (V1.getType getV getA) (typePath path h)
     dependents :: Reference -> m (Set Reference.Id)
     dependents r = listDirAsIds (dependentsDir path r)
-    getTermsOfType :: Reference -> m (Set Referent)
+    getTermsOfType :: Reference -> m (Set Referent.Id)
     getTermsOfType r = listDirAsReferents (typeIndexDir path r)
-    getTermsMentioningType :: Reference -> m (Set Referent)
+    getTermsMentioningType :: Reference -> m (Set Referent.Id)
     getTermsMentioningType r = listDirAsReferents (typeMentionsIndexDir path r)
   -- todo: revisit these
     listDirAsIds :: FilePath -> m (Set Reference.Id)
@@ -680,13 +684,13 @@ codebase1 fmtV@(S.Format getV putV) fmtA@(S.Format getA putA) path =
           ls <- fmap decodeFileName <$> listDirectory d
           pure . Set.fromList $ ls >>= (toList . componentIdFromString)
         else pure Set.empty
-    listDirAsReferents :: FilePath -> m (Set Referent)
+    listDirAsReferents :: FilePath -> m (Set Referent.Id)
     listDirAsReferents d = do
       e <- doesDirectoryExist d
       if e
         then do
           ls <- fmap decodeFileName <$> listDirectory d
-          pure . Set.fromList $ ls >>= (toList . referentFromString)
+          pure . Set.fromList $ ls >>= (toList . referentIdFromString)
         else pure Set.empty
     watches :: UF.WatchKind -> m [Reference.Id]
     watches k =

--- a/parser-typechecker/src/Unison/Codebase/GitError.hs
+++ b/parser-typechecker/src/Unison/Codebase/GitError.hs
@@ -14,6 +14,7 @@ data GitError = NoGit
               | PushDestinationHasNewStuff Text (Maybe Text) Names.Diff
               | NoRemoteNamespaceWithHash Text (Maybe Text) ShortBranchHash
               | RemoteNamespaceHashAmbiguous Text (Maybe Text) ShortBranchHash (Set Branch.Hash)
+              | Couldn'tLoadRootBranch Text (Maybe Text) (Maybe ShortBranchHash) Branch.Hash
               | SomeOtherError Text
               deriving Show
 

--- a/parser-typechecker/src/Unison/Codebase/MainTerm.hs
+++ b/parser-typechecker/src/Unison/Codebase/MainTerm.hs
@@ -1,9 +1,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE PartialTypeSignatures #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 -- | Find a computation of type '{IO} () in the codebase.
 module Unison.Codebase.MainTerm where
@@ -15,7 +12,7 @@ import qualified Unison.Parser                 as Parser
 import qualified Unison.Term                   as Term
 import           Unison.Term                    ( Term )
 import           Unison.Var                     ( Var )
-import qualified Unison.DataDeclaration        as DD
+import qualified Unison.Builtin.Decls          as DD
 import qualified Unison.HashQualified          as HQ
 import qualified Unison.Referent               as Referent
 import qualified Unison.Names3                 as Names3

--- a/parser-typechecker/src/Unison/Codebase/ShortBranchHash.hs
+++ b/parser-typechecker/src/Unison/Codebase/ShortBranchHash.hs
@@ -21,6 +21,9 @@ fromHash :: Int -> Branch.Hash -> ShortBranchHash
 fromHash len =
   ShortBranchHash . Text.take len . Hash.base32Hex . Causal.unRawHash
 
+fullFromHash :: Branch.Hash -> ShortBranchHash
+fullFromHash = ShortBranchHash . Hash.base32Hex . Causal.unRawHash
+
 -- abc -> SBH abc
 -- #abc -> SBH abc
 fromText :: Text -> Maybe ShortBranchHash

--- a/parser-typechecker/src/Unison/Codecs.hs
+++ b/parser-typechecker/src/Unison/Codecs.hs
@@ -25,7 +25,7 @@ import           Unison.Reference (Reference, pattern Builtin, pattern Derived)
 import qualified Unison.Referent as Referent
 import qualified Unison.ConstructorType as ConstructorType 
 import           Unison.Term
-import           Unison.UnisonFile (UnisonFile(..))
+import           Unison.UnisonFile (UnisonFile, pattern UnisonFile)
 import qualified Unison.UnisonFile as UF
 import           Unison.Var (Var)
 import qualified Unison.Var as Var

--- a/parser-typechecker/src/Unison/CommandLine/DisplayValues.hs
+++ b/parser-typechecker/src/Unison/CommandLine/DisplayValues.hs
@@ -11,6 +11,7 @@ import Unison.Referent (Referent)
 import Unison.Term (Term)
 import Unison.Type (Type)
 import Unison.Var (Var)
+import qualified Unison.Builtin.Decls as DD
 import qualified Unison.DataDeclaration as DD
 import qualified Unison.DeclPrinter as DP
 import qualified Unison.NamePrinter as NP

--- a/parser-typechecker/src/Unison/CommandLine/Main.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Main.hs
@@ -46,6 +46,7 @@ import qualified Unison.Util.Pretty as P
 import qualified Unison.Util.TQueue as Q
 import Text.Regex.TDFA
 import Control.Lens (view)
+import Control.Error (rightMay)
 
 -- Expand a numeric argument like `1` or a range like `3-9`
 expandNumber :: [String] -> String -> [String]
@@ -161,7 +162,7 @@ main
   -> IO ()
 main dir initialPath configFile initialInputs startRuntime codebase = do
   dir' <- shortenDirectory dir
-  root <- Codebase.getRootBranch codebase
+  root <- fromMaybe Branch.empty . rightMay <$> Codebase.getRootBranch codebase
   putPrettyLn $ if Branch.isOne root
     then welcomeMessage dir' <> P.newline <> P.newline <> hintFreshCodebase
     else welcomeMessage dir'

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -57,6 +57,7 @@ import           Unison.PrettyTerminal          ( clearCurrentLine
                                                 )
 import           Unison.CommandLine.InputPatterns (makeExample, makeExample')
 import qualified Unison.CommandLine.InputPatterns as IP
+import qualified Unison.Builtin.Decls          as DD
 import qualified Unison.DataDeclaration        as DD
 import qualified Unison.DeclPrinter            as DeclPrinter
 import qualified Unison.HashQualified          as HQ
@@ -620,6 +621,19 @@ notifyUser dir o = case o of
             Nothing -> mempty
           ]
         _ -> "⁉️ Unison bug - push command expected"
+    Couldn'tLoadRootBranch url treeish (Just sbh) hash -> P.wrap
+      $ "I couldn't load the specified root hash"
+      <> prettySBH sbh <> (if SBH.fullFromHash hash == sbh then mempty else
+      "(which expands to" <> fromString (Hash.showBase32Hex hash) <> ")")
+      <> "from the repository at" <> P.blue (P.text url)
+      <> (Monoid.fromMaybe $ treeish <&> \treeish ->
+          "at revision" <> P.blue (P.text treeish))
+    Couldn'tLoadRootBranch url treeish Nothing hash -> P.wrap
+      $ "I couldn't load the designated root hash"
+      <> P.group ("(" <> fromString (Hash.showBase32Hex hash) <> ")")
+      <> "from the repository at" <> P.blue (P.text url)
+      <> (Monoid.fromMaybe $ treeish <&> \treeish ->
+          "at revision" <> P.blue (P.text treeish))
     NoRemoteNamespaceWithHash url treeish sbh -> P.wrap
       $ "The repository at" <> P.blue (P.text url)
       <> (Monoid.fromMaybe $ treeish <&> \treeish ->

--- a/parser-typechecker/src/Unison/DeclPrinter.hs
+++ b/parser-typechecker/src/Unison/DeclPrinter.hs
@@ -22,7 +22,7 @@ import           Unison.NamePrinter             ( styleHashQualified'' )
 import           Unison.PrettyPrintEnv          ( PrettyPrintEnv )
 import qualified Unison.PrettyPrintEnv         as PPE
 import qualified Unison.Referent               as Referent
-import           Unison.Reference               ( Reference )
+import           Unison.Reference               ( Reference(DerivedId) )
 import qualified Unison.Util.SyntaxText        as S
 import           Unison.Util.SyntaxText         ( SyntaxText )
 import qualified Unison.Term                   as Term
@@ -130,7 +130,7 @@ fieldNames env r name dd = case DD.constructors dd of
     vars = [ Var.freshenId (fromIntegral n) (Var.named "_") | n <- [0..Type.arity typ - 1]]
     accessors = DD.generateRecordAccessors (map (,()) vars) (HQ.toVar name) r
     hashes = Term.hashComponents (Map.fromList accessors)
-    names = [ (r, HQ.toString . PPE.termName env . Referent.Ref $ r)
+    names = [ (r, HQ.toString . PPE.termName env . Referent.Ref $ DerivedId r)
             | r <- fst <$> Map.elems hashes ]
     fieldNames = Map.fromList
       [ (r, f) | (r, n) <- names

--- a/parser-typechecker/src/Unison/FileParser.hs
+++ b/parser-typechecker/src/Unison/FileParser.hs
@@ -78,7 +78,7 @@ file = do
           | (typ, fields) <- parsedAccessors
           , Just (r,_) <- [Map.lookup (L.payload typ) (UF.datas env)]
           ]
-        uf = UnisonFile (UF.datas env) (UF.effects env) (terms <> join accessors)
+        uf = UnisonFileId (UF.datasId env) (UF.effectsId env) (terms <> join accessors)
                         (List.multimap watches)
     pure uf
 

--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -171,8 +171,8 @@ synthesizeFile ambient tl fqnsByShortName uf term = do
                Nothing -> error "wat"
                Just kind -> (kind, tlc)
     pure $ UF.typecheckedUnisonFile
-             (UF.dataDeclarations uf)
-             (UF.effectDeclarations uf)
+             (UF.dataDeclarationsId uf)
+             (UF.effectDeclarationsId uf)
              terms'
              (map tlcKind watches')
  where

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -23,7 +23,7 @@ import qualified Data.Text                    as Text
 import           Data.Void                    (Void)
 import qualified Text.Megaparsec              as P
 import qualified Unison.ABT                   as ABT
-import Unison.DataDeclaration (pattern TupleType')
+import Unison.Builtin.Decls                   (pattern TupleType')
 import qualified Unison.HashQualified         as HQ
 import           Unison.Kind                  (Kind)
 import qualified Unison.Kind                  as Kind

--- a/parser-typechecker/src/Unison/Runtime/IOSource.hs
+++ b/parser-typechecker/src/Unison/Runtime/IOSource.hs
@@ -48,26 +48,27 @@ termNamed s = fromMaybe (error $ "No builtin term called: " <> s)
 codeLookup :: CodeLookup Symbol Identity Ann
 codeLookup = CL.fromUnisonFile $ UF.discardTypes typecheckedFile
 
-typeNamed :: String -> R.Reference
-typeNamed s =
-  case Map.lookup (Var.nameds s) (UF.dataDeclarations' typecheckedFile) of
+typeNamedId :: String -> R.Id
+typeNamedId s =
+  case Map.lookup (Var.nameds s) (UF.dataDeclarationsId' typecheckedFile) of
     Nothing -> error $ "No builtin type called: " <> s
     Just (r, _) -> r
 
-abilityNamed :: String -> R.Reference
-abilityNamed s =
-  case Map.lookup (Var.nameds s) (UF.effectDeclarations' typecheckedFile) of
+typeNamed :: String -> R.Reference
+typeNamed = R.DerivedId . typeNamedId
+  
+abilityNamedId :: String -> R.Id
+abilityNamedId s =
+  case Map.lookup (Var.nameds s) (UF.effectDeclarationsId' typecheckedFile) of
     Nothing -> error $ "No builtin ability called: " <> s
     Just (r, _) -> r
 
-ioHash, eitherHash, ioModeHash :: R.Id
-ioHash = R.unsafeId ioReference
-eitherHash = R.unsafeId eitherReference
-ioModeHash = R.unsafeId ioModeReference
+ioHash :: R.Id
+ioHash = abilityNamedId "io.IO"
 
 ioReference, bufferModeReference, eitherReference, ioModeReference, optionReference, errorReference, errorTypeReference, seekModeReference, threadIdReference, socketReference, handleReference, epochTimeReference, isTestReference, isPropagatedReference, filePathReference
   :: R.Reference
-ioReference = abilityNamed "io.IO"
+ioReference = R.DerivedId ioHash
 bufferModeReference = typeNamed "io.BufferMode"
 eitherReference = typeNamed "Either"
 ioModeReference = typeNamed "io.Mode"

--- a/parser-typechecker/src/Unison/Runtime/IR.hs
+++ b/parser-typechecker/src/Unison/Runtime/IR.hs
@@ -29,7 +29,7 @@ import qualified Data.Map as Map
 import qualified Data.Sequence as Sequence
 import qualified Data.Set as Set
 import qualified Unison.ABT as ABT
-import qualified Unison.DataDeclaration as DD
+import qualified Unison.Builtin.Decls as DD
 import qualified Unison.Pattern as Pattern
 import qualified Unison.PrettyPrintEnv as PPE
 import qualified Unison.Reference as R

--- a/parser-typechecker/src/Unison/Runtime/Rt1IO.hs
+++ b/parser-typechecker/src/Unison/Runtime/Rt1IO.hs
@@ -82,7 +82,7 @@ import           System.Directory               ( getCurrentDirectory
                                                 )
 import qualified System.IO.Error               as SysError
 import           Type.Reflection                ( Typeable )
-import           Unison.DataDeclaration        as DD
+import           Unison.Builtin.Decls          as DD
 import           Unison.Symbol
 import qualified Unison.Reference              as R
 import qualified Unison.Runtime.Rt1            as RT

--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -34,7 +34,7 @@ import qualified Data.Tuple.Extra as TupleE
 import qualified Data.Sequence as Sequence
 import qualified Text.Megaparsec as P
 import qualified Unison.ABT as ABT
-import qualified Unison.DataDeclaration as DD
+import qualified Unison.Builtin.Decls as DD
 import qualified Unison.HashQualified as HQ
 import qualified Unison.Lexer as L
 import qualified Unison.Name as Name

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -43,8 +43,8 @@ import qualified Unison.Util.Pretty             as PP
 import           Unison.Util.Pretty             ( Pretty, ColorText )
 import           Unison.PrettyPrintEnv          ( PrettyPrintEnv, Suffix, Prefix, Imports, elideFQN )
 import qualified Unison.PrettyPrintEnv         as PrettyPrintEnv
-import qualified Unison.DataDeclaration        as DD
-import Unison.DataDeclaration (pattern TuplePattern, pattern TupleTerm')
+import qualified Unison.Builtin.Decls          as DD
+import Unison.Builtin.Decls (pattern TuplePattern, pattern TupleTerm')
 import qualified Unison.ConstructorType as CT
 
 pretty :: Var v => PrettyPrintEnv -> Term v a -> Pretty ColorText

--- a/parser-typechecker/src/Unison/TypeParser.hs
+++ b/parser-typechecker/src/Unison/TypeParser.hs
@@ -10,7 +10,7 @@ import           Unison.Parser
 import           Unison.Type (Type)
 import qualified Unison.Type as Type
 import           Unison.Var (Var)
-import qualified Unison.DataDeclaration as DD
+import qualified Unison.Builtin.Decls as DD
 import qualified Unison.HashQualified as HQ
 import qualified Unison.Name as Name
 import qualified Unison.Names3 as Names

--- a/parser-typechecker/src/Unison/TypePrinter.hs
+++ b/parser-typechecker/src/Unison/TypePrinter.hs
@@ -21,7 +21,7 @@ import           Unison.Util.SyntaxText (SyntaxText)
 import qualified Unison.Util.Pretty    as PP
 import           Unison.Var            (Var)
 import qualified Unison.Var            as Var
-import qualified Unison.DataDeclaration as DD
+import qualified Unison.Builtin.Decls as DD
 
 pretty :: forall v a . (Var v) => PrettyPrintEnv -> Type v a -> Pretty ColorText
 pretty ppe = PP.syntaxToColor . pretty0 ppe mempty (-1)

--- a/parser-typechecker/src/Unison/Typechecker/TypeError.hs
+++ b/parser-typechecker/src/Unison/Typechecker/TypeError.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE BangPatterns        #-}
 
 module Unison.Typechecker.TypeError where
 

--- a/parser-typechecker/src/Unison/UnisonFile.hs
+++ b/parser-typechecker/src/Unison/UnisonFile.hs
@@ -9,7 +9,7 @@ module Unison.UnisonFile where
 import Unison.Prelude
 
 import Control.Lens
-import           Data.Bifunctor         (second)
+import           Data.Bifunctor         (second, first)
 import qualified Data.Map               as Map
 import qualified Data.Set               as Set
 import qualified Unison.ABT as ABT
@@ -18,10 +18,11 @@ import           Unison.DataDeclaration (DataDeclaration')
 import           Unison.DataDeclaration (EffectDeclaration' (..))
 import           Unison.DataDeclaration (hashDecls, toDataDecl)
 import qualified Unison.DataDeclaration as DD
+import qualified Unison.Builtin.Decls   as DD
 import qualified Unison.Name            as Name
 import qualified Unison.Names3          as Names
 import           Unison.Reference       (Reference)
-import           Unison.Referent        (Referent)
+import qualified Unison.Reference       as Reference
 import qualified Unison.Referent        as Referent
 import           Unison.Term            (Term)
 import qualified Unison.Term            as Term
@@ -38,12 +39,25 @@ import qualified Unison.LabeledDependency as LD
 import Unison.LabeledDependency (LabeledDependency)
 -- import qualified Unison.Typechecker.Components as Components
 
-data UnisonFile v a = UnisonFile {
-  dataDeclarations   :: Map v (Reference, DataDeclaration' v a),
-  effectDeclarations :: Map v (Reference, EffectDeclaration' v a),
+data UnisonFile v a = UnisonFileId {
+  dataDeclarationsId   :: Map v (Reference.Id, DataDeclaration' v a),
+  effectDeclarationsId :: Map v (Reference.Id, EffectDeclaration' v a),
   terms :: [(v, Term v a)],
   watches :: Map WatchKind [(v, Term v a)]
 } deriving Show
+
+pattern UnisonFile ds es tms ws <-
+  UnisonFileId (fmap (first Reference.DerivedId) -> ds)
+               (fmap (first Reference.DerivedId) -> es)
+               tms
+               ws
+{-# COMPLETE UnisonFile #-}
+
+dataDeclarations :: UnisonFile v a -> Map v (Reference, DataDeclaration' v a)
+dataDeclarations = fmap (first Reference.DerivedId) . dataDeclarationsId
+
+effectDeclarations :: UnisonFile v a -> Map v (Reference, EffectDeclaration' v a)
+effectDeclarations = fmap (first Reference.DerivedId) . effectDeclarationsId
 
 watchesOfKind :: WatchKind -> UnisonFile v a -> [(v, Term v a)]
 watchesOfKind kind uf = Map.findWithDefault [] kind (watches uf)
@@ -78,24 +92,43 @@ uberTerm' uf body =
 -- A UnisonFile after typechecking. Terms are split into groups by
 -- cycle and the type of each term is known.
 data TypecheckedUnisonFile v a =
-  TypecheckedUnisonFile {
-    dataDeclarations'   :: Map v (Reference, DataDeclaration' v a),
-    effectDeclarations' :: Map v (Reference, EffectDeclaration' v a),
+  TypecheckedUnisonFileId {
+    dataDeclarationsId'   :: Map v (Reference.Id, DataDeclaration' v a),
+    effectDeclarationsId' :: Map v (Reference.Id, EffectDeclaration' v a),
     topLevelComponents' :: [[(v, Term v a, Type v a)]],
     watchComponents     :: [(WatchKind, [(v, Term v a, Type v a)])],
-    hashTerms           :: Map v (Reference, Term v a, Type v a)
+    hashTermsId           :: Map v (Reference.Id, Term v a, Type v a)
   } deriving Show
 
+-- backwards compatibility with the old data type
+dataDeclarations' :: TypecheckedUnisonFile v a -> Map v (Reference, DataDeclaration' v a)
+dataDeclarations' = fmap (first Reference.DerivedId) . dataDeclarationsId'
+effectDeclarations' :: TypecheckedUnisonFile v a -> Map v (Reference, EffectDeclaration' v a)
+effectDeclarations' = fmap (first Reference.DerivedId) . effectDeclarationsId'
+hashTerms :: TypecheckedUnisonFile v a -> Map v (Reference, Term v a, Type v a)
+hashTerms = fmap (over _1 Reference.DerivedId) . hashTermsId
+
+{-# COMPLETE TypecheckedUnisonFile #-}
+pattern TypecheckedUnisonFile ds es tlcs wcs hts <-
+  TypecheckedUnisonFileId (fmap (first Reference.DerivedId) -> ds)
+                          (fmap (first Reference.DerivedId) -> es)
+                          tlcs
+                          wcs
+                          (fmap (over _1 Reference.DerivedId) -> hts)
+
+-- todo: this is confusing, right?
+-- currently: create a degenerate TypecheckedUnisonFile
+--            multiple definitions of "top-level components" non-watch vs w/ watch
 typecheckedUnisonFile :: Var v
-                      => Map v (Reference, DataDeclaration' v a)
-                      -> Map v (Reference, EffectDeclaration' v a)
+                      => Map v (Reference.Id, DataDeclaration' v a)
+                      -> Map v (Reference.Id, EffectDeclaration' v a)
                       -> [[(v, Term v a, Type v a)]]
                       -> [(WatchKind, [(v, Term v a, Type v a)])]
                       -> TypecheckedUnisonFile v a
 typecheckedUnisonFile datas effects tlcs watches =
-  file0 { hashTerms = hashImpl file0 }
+  file0 { hashTermsId = hashImpl file0 }
   where
-  file0 = TypecheckedUnisonFile datas effects tlcs watches mempty
+  file0 = TypecheckedUnisonFileId datas effects tlcs watches mempty
   hashImpl file = let
     -- test watches are added to the codebase also
     -- todo: maybe other kinds of watches too
@@ -107,10 +140,10 @@ typecheckedUnisonFile datas effects tlcs watches =
                                        Just t <- [Map.lookup v types] ]
 
 lookupDecl :: Ord v => v -> TypecheckedUnisonFile v a
-           -> Maybe (Reference, Either (EffectDeclaration' v a) (DataDeclaration' v a))
+           -> Maybe (Reference.Id, DD.Decl v a)
 lookupDecl v uf =
-  over _2 Right <$> (Map.lookup v (dataDeclarations' uf)  ) <|>
-  over _2 Left  <$> (Map.lookup v (effectDeclarations' uf))
+  over _2 Right <$> (Map.lookup v (dataDeclarationsId' uf)) <|>
+  over _2 Left  <$> (Map.lookup v (effectDeclarationsId' uf))
 
 allTerms :: Ord v => TypecheckedUnisonFile v a -> Map v (Term v a)
 allTerms uf =
@@ -129,7 +162,8 @@ getDecl' uf v =
 -- External type references that appear in the types of the file's terms
 termSignatureExternalLabeledDependencies
   :: Ord v => TypecheckedUnisonFile v a -> Set LabeledDependency
-termSignatureExternalLabeledDependencies TypecheckedUnisonFile{..} =
+termSignatureExternalLabeledDependencies 
+    (TypecheckedUnisonFile dataDeclarations' effectDeclarations' _ _ hashTerms) =
   Set.difference
     (Set.map LD.typeRef
       . foldMap Type.dependencies
@@ -146,13 +180,13 @@ termSignatureExternalLabeledDependencies TypecheckedUnisonFile{..} =
 -- `R.lookupDom r (dependencies file)` returns the set of dependencies
 -- of the reference `r`.
 dependencies' ::
-  forall v a. Var v => TypecheckedUnisonFile v a -> Relation Reference Reference
+  forall v a. Var v => TypecheckedUnisonFile v a -> Relation Reference.Id Reference
 dependencies' file = let
-  terms :: Map v (Reference, Term v a, Type v a)
-  terms = hashTerms file
-  decls :: Map v (Reference, DataDeclaration' v a)
-  decls = dataDeclarations' file <>
-          fmap (second toDataDecl) (effectDeclarations' file )
+  terms :: Map v (Reference.Id, Term v a, Type v a)
+  terms = hashTermsId file
+  decls :: Map v (Reference.Id, DataDeclaration' v a)
+  decls = dataDeclarationsId' file <>
+          fmap (second toDataDecl) (effectDeclarationsId' file )
   termDeps = foldl' f Relation.empty $ toList terms
   allDeps = foldl' g termDeps $ toList decls
   f acc (r, tm, tp) = acc <> termDeps <> typeDeps
@@ -170,13 +204,17 @@ dependencies' file = let
 -- Returns the dependencies of the `UnisonFile` input. Needed so we can
 -- load information about these dependencies before starting typechecking.
 dependencies :: (Monoid a, Var v) => UnisonFile v a -> Set Reference
-dependencies uf = Term.dependencies (typecheckingTerm uf)
+dependencies (UnisonFile ds es ts ws) =
+  foldMap (DD.dependencies . snd) ds
+  <> foldMap (DD.dependencies . DD.toDataDecl . snd) es
+  <> foldMap (Term.dependencies . snd) ts
+  <> foldMap (foldMap (Term.dependencies . snd)) ws
 
 discardTypes :: TypecheckedUnisonFile v a -> UnisonFile v a
-discardTypes (TypecheckedUnisonFile datas effects terms watches _) = let
+discardTypes (TypecheckedUnisonFileId datas effects terms watches _) = let
   watches' = g . mconcat <$> List.multimap watches
   g tup3s = [(v,e) | (v,e,_t) <- tup3s ]
-  in UnisonFile datas effects [ (a,b) | (a,b,_) <- join terms ] watches'
+  in UnisonFileId datas effects [ (a,b) | (a,b,_) <- join terms ] watches'
 
 declsToTypeLookup :: Var v => UnisonFile v a -> TL.TypeLookup v a
 declsToTypeLookup uf = TL.TypeLookup mempty
@@ -185,10 +223,10 @@ declsToTypeLookup uf = TL.TypeLookup mempty
   where wrangle = Map.fromList . Map.elems
 
 toNames :: Var v => UnisonFile v a -> Names0
-toNames (UnisonFile {..}) = datas <> effects
+toNames uf = datas <> effects
   where
-    datas = foldMap DD.dataDeclToNames' (Map.toList dataDeclarations)
-    effects = foldMap DD.effectDeclToNames' (Map.toList effectDeclarations)
+    datas = foldMap DD.dataDeclToNames' (Map.toList (dataDeclarationsId uf))
+    effects = foldMap DD.effectDeclToNames' (Map.toList (effectDeclarationsId uf))
 
 typecheckedToNames0 :: Var v => TypecheckedUnisonFile v a -> Names0
 typecheckedToNames0 uf = Names.names0 (terms <> ctors) types where
@@ -199,10 +237,14 @@ typecheckedToNames0 uf = Names.names0 (terms <> ctors) types where
     [ (Name.fromVar v, r)
     | (v, r) <- Map.toList $ fmap fst (dataDeclarations' uf)
                           <> fmap fst (effectDeclarations' uf) ]
-  ctors = Relation.fromMap . Map.mapKeys Name.fromVar . hashConstructors $ uf
+  ctors = Relation.fromMap
+        . Map.mapKeys Name.fromVar
+        . fmap (fmap Reference.DerivedId)
+        . hashConstructors
+        $ uf
 
 typecheckedUnisonFile0 :: Ord v => TypecheckedUnisonFile v a
-typecheckedUnisonFile0 = TypecheckedUnisonFile Map.empty Map.empty mempty mempty mempty
+typecheckedUnisonFile0 = TypecheckedUnisonFileId Map.empty Map.empty mempty mempty mempty
 
 -- Returns true if the file has any definitions or watches
 nonEmpty :: TypecheckedUnisonFile v a -> Bool
@@ -213,12 +255,12 @@ nonEmpty uf =
   any (not . null) (watchComponents uf)
 
 hashConstructors
-  :: forall v a. Ord v => TypecheckedUnisonFile v a -> Map v Referent
+  :: forall v a. Ord v => TypecheckedUnisonFile v a -> Map v Referent.Id
 hashConstructors file =
-  let ctors1 = Map.elems (dataDeclarations' file) >>= \(ref, dd) ->
-        [ (v, Referent.Con ref i CT.Data) | (v,i) <- DD.constructorVars dd `zip` [0 ..] ]
-      ctors2 = Map.elems (effectDeclarations' file) >>= \(ref, dd) ->
-        [ (v, Referent.Con ref i CT.Effect) | (v,i) <- DD.constructorVars (DD.toDataDecl dd) `zip` [0 ..] ]
+  let ctors1 = Map.elems (dataDeclarationsId' file) >>= \(ref, dd) ->
+        [ (v, Referent.Con' ref i CT.Data) | (v,i) <- DD.constructorVars dd `zip` [0 ..] ]
+      ctors2 = Map.elems (effectDeclarationsId' file) >>= \(ref, dd) ->
+        [ (v, Referent.Con' ref i CT.Effect) | (v,i) <- DD.constructorVars (DD.toDataDecl dd) `zip` [0 ..] ]
   in Map.fromList (ctors1 ++ ctors2)
 
 type CtorLookup = Map String (Reference, Int)
@@ -235,7 +277,7 @@ bindNames :: Var v
           => Names0
           -> UnisonFile v a
           -> Names.ResolutionResult v a (UnisonFile v a)
-bindNames names (UnisonFile d e ts ws) = do
+bindNames names (UnisonFileId d e ts ws) = do
   -- todo: consider having some kind of binding structure for terms & watches
   --    so that you don't weirdly have free vars to tiptoe around.
   --    The free vars should just be the things that need to be bound externally.
@@ -244,7 +286,7 @@ bindNames names (UnisonFile d e ts ws) = do
   -- todo: can we clean up this lambda using something like `second`
   ts' <- traverse (\(v,t) -> (v,) <$> Term.bindNames termVarsSet names t) ts
   ws' <- traverse (traverse (\(v,t) -> (v,) <$> Term.bindNames termVarsSet names t)) ws
-  pure $ UnisonFile d e ts' ws'
+  pure $ UnisonFileId d e ts' ws'
 
 constructorType ::
   Var v => UnisonFile v a -> Reference -> Maybe CT.ConstructorType
@@ -252,12 +294,18 @@ constructorType = TL.constructorType . declsToTypeLookup
 
 data Env v a = Env
   -- Data declaration name to hash and its fully resolved form
-  { datas   :: Map v (Reference, DataDeclaration' v a)
+  { datasId   :: Map v (Reference.Id, DataDeclaration' v a)
   -- Effect declaration name to hash and its fully resolved form
-  , effects :: Map v (Reference, EffectDeclaration' v a)
+  , effectsId :: Map v (Reference.Id, EffectDeclaration' v a)
   -- Naming environment
   , names   :: Names0
 }
+
+datas :: Env v a -> Map v (Reference, DataDeclaration' v a)
+datas = fmap (first Reference.DerivedId) . datasId
+
+effects :: Env v a -> Map v (Reference, EffectDeclaration' v a)
+effects = fmap (first Reference.DerivedId) . effectsId
 
 data Error v a
   -- A free type variable that couldn't be resolved
@@ -287,7 +335,7 @@ environmentFor names dataDecls0 effectDecls0 = do
     traverse (DD.withEffectDeclM (DD.bindNames locallyBoundTypes names)) effectDecls0
   let allDecls0 :: Map v (DataDeclaration' v a)
       allDecls0 = Map.union dataDecls (toDataDecl <$> effectDecls)
-  hashDecls' :: [(v, Reference, DataDeclaration' v a)] <-
+  hashDecls' :: [(v, Reference.Id, DataDeclaration' v a)] <-
       hashDecls allDecls0
     -- then we have to pick out the dataDecls from the effectDecls
   let

--- a/parser-typechecker/tests/Unison/Test/Codebase.hs
+++ b/parser-typechecker/tests/Unison/Test/Codebase.hs
@@ -26,7 +26,7 @@ test = scope "codebase" $ tests
         foo = Var.named "foo"
         -- original binding: `foo = \v1 -> ref`
         binding = (foo, Term.lam () v1 (Term.ref () ref))
-        uf = UF.UnisonFile mempty mempty [binding] mempty
+        uf = UF.UnisonFileId mempty mempty [binding] mempty
         code :: CodeLookup Symbol Identity ()
         code = CodeLookup
           { getTerm = \rid -> pure $

--- a/parser-typechecker/tests/Unison/Test/DataDeclaration.hs
+++ b/parser-typechecker/tests/Unison/Test/DataDeclaration.hs
@@ -20,7 +20,7 @@ import qualified Unison.Var             as Var
 
 test :: Test ()
 test = scope "datadeclaration" $
-  let Right hashes = hashDecls . (snd <$>) . dataDeclarations $ file
+  let Right hashes = hashDecls . (snd <$>) . dataDeclarationsId $ file
       hashMap = Map.fromList $ fmap (\(a,b,_) -> (a,b)) hashes
       hashOf k = Map.lookup (Var.named k) hashMap
   in tests [

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -35,11 +35,11 @@ library
 
   exposed-modules:
     Unison.Builtin
+    Unison.Builtin.Decls
     Unison.Codecs
     Unison.Codebase
     Unison.Codebase.Branch
     Unison.Codebase.BranchDiff
-    Unison.Codebase.BranchLoadMode
     Unison.Codebase.BranchUtil
     Unison.Codebase.Causal
     Unison.Codebase.Classes

--- a/unison-core/src/Unison/DataDeclaration.hs
+++ b/unison-core/src/Unison/DataDeclaration.hs
@@ -17,7 +17,7 @@ import Control.Monad.State (evalState)
 
 import Data.Bifunctor (first, second)
 import qualified Unison.Util.Relation as Rel
-import           Data.List                      ( sortOn, elemIndex, find )
+import           Data.List                      ( sortOn )
 import           Unison.Hash                    ( Hash )
 import qualified Data.Map                      as Map
 import qualified Data.Set                      as Set
@@ -32,19 +32,15 @@ import qualified Unison.Name                   as Name
 import           Unison.Reference               ( Reference )
 import qualified Unison.Reference              as Reference
 import qualified Unison.Reference.Util         as Reference.Util
-import           Unison.Referent                ( Referent )
 import qualified Unison.Referent               as Referent
 import qualified Unison.Term                   as Term
-import           Unison.Term                    ( Term
-                                                , Term2
-                                                )
+import           Unison.Term                    ( Term )
 import           Unison.Type                    ( Type )
 import qualified Unison.Type                   as Type
 import           Unison.Var                     ( Var )
 import qualified Unison.Var                    as Var
 import           Unison.Names3                 (Names0)
 import qualified Unison.Names3                 as Names
-import           Unison.Symbol                  ( Symbol )
 import qualified Unison.Pattern                as Pattern
 import qualified Unison.ConstructorType as CT
 
@@ -184,6 +180,14 @@ constructorVars dd = fst <$> constructors dd
 constructorNames :: Var v => DataDeclaration' v a -> [Text]
 constructorNames dd = Var.name <$> constructorVars dd
 
+declConstructorReferents :: Reference.Id -> Decl v a -> [Referent.Id]
+declConstructorReferents rid decl =
+  [ Referent.Con' rid i ct | i <- constructorIds (asDataDecl decl) ]
+  where ct = constructorType decl
+
+constructorIds :: DataDeclaration' v a -> [Int]
+constructorIds dd = [0 .. length (constructors dd) - 1]
+
 -- | All variables mentioned in the given data declaration.
 -- Includes both term and type variables, both free and bound.
 allVars :: Ord v => DataDeclaration' v a -> Set v
@@ -213,8 +217,8 @@ third :: (a -> b) -> (x,y,a) -> (x,y,b)
 third f (x,y,a) = (x, y, f a)
 
 -- implementation of dataDeclToNames and effectDeclToNames
-toNames0 :: Var v => CT.ConstructorType -> v -> Reference -> DataDeclaration' v a -> Names0
-toNames0 ct typeSymbol r dd =
+toNames0 :: Var v => CT.ConstructorType -> v -> Reference.Id -> DataDeclaration' v a -> Names0
+toNames0 ct typeSymbol (Reference.DerivedId -> r) dd =
   -- constructor names
   foldMap names (constructorVars dd `zip` [0 ..])
   -- name of the type itself
@@ -223,16 +227,16 @@ toNames0 ct typeSymbol r dd =
   names (ctor, i) =
     Names.names0 (Rel.singleton (Name.fromVar ctor) (Referent.Con r i ct)) mempty
 
-dataDeclToNames :: Var v => v -> Reference -> DataDeclaration' v a -> Names0
+dataDeclToNames :: Var v => v -> Reference.Id -> DataDeclaration' v a -> Names0
 dataDeclToNames = toNames0 CT.Data
 
-effectDeclToNames :: Var v => v -> Reference -> EffectDeclaration' v a -> Names0
+effectDeclToNames :: Var v => v -> Reference.Id -> EffectDeclaration' v a -> Names0
 effectDeclToNames typeSymbol r ed = toNames0 CT.Effect typeSymbol r $ toDataDecl ed
 
-dataDeclToNames' :: Var v => (v, (Reference, DataDeclaration' v a)) -> Names0
+dataDeclToNames' :: Var v => (v, (Reference.Id, DataDeclaration' v a)) -> Names0
 dataDeclToNames' (v,(r,d)) = dataDeclToNames v r d
 
-effectDeclToNames' :: Var v => (v, (Reference, EffectDeclaration' v a)) -> Names0
+effectDeclToNames' :: Var v => (v, (Reference.Id, EffectDeclaration' v a)) -> Names0
 effectDeclToNames' (v, (r, d)) = effectDeclToNames v r d
 
 type EffectDeclaration v = EffectDeclaration' v ()
@@ -370,10 +374,10 @@ unhashComponent m
       second unhash2 <$> m'
 
 -- Implementation detail of `hashDecls`, works with unannotated data decls
-hashDecls0 :: (Eq v, Var v) => Map v (DataDeclaration' v ()) -> [(v, Reference)]
+hashDecls0 :: (Eq v, Var v) => Map v (DataDeclaration' v ()) -> [(v, Reference.Id)]
 hashDecls0 decls =
   let abts = toABT <$> decls
-      ref r = ABT.tm (Type (Type.Ref r))
+      ref r = ABT.tm (Type (Type.Ref (Reference.DerivedId r)))
       cs = Reference.Util.hashComponents ref abts
   in  [ (v, r) | (v, (r, _)) <- Map.toList cs ]
 
@@ -391,216 +395,17 @@ hashDecls0 decls =
 hashDecls
   :: (Eq v, Var v)
   => Map v (DataDeclaration' v a)
-  -> Names.ResolutionResult v a [(v, Reference, DataDeclaration' v a)]
+  -> Names.ResolutionResult v a [(v, Reference.Id, DataDeclaration' v a)]
 hashDecls decls = do
   -- todo: make sure all other external references are resolved before calling this
   let varToRef = hashDecls0 (void <$> decls)
+      varToRef' = second Reference.DerivedId <$> varToRef
       decls'   = bindTypes <$> decls
-      bindTypes dd = dd { constructors' = over _3 (Type.bindExternal varToRef) <$> constructors' dd }
+      bindTypes dd = dd { constructors' = over _3 (Type.bindExternal varToRef') <$> constructors' dd }
       typeNames0 = Names.names0 mempty
-                 $ Rel.fromList (first Name.fromVar <$> varToRef)
+                 $ Rel.fromList (first Name.fromVar <$> varToRef')
       -- normalize the order of the constructors based on a hash of their types
       sortCtors dd = dd { constructors' = sortOn hash3 $ constructors' dd }
       hash3 (_, _, typ) = ABT.hash typ :: Hash
   decls' <- fmap sortCtors <$> traverse (bindNames mempty typeNames0) decls'
   pure  [ (v, r, dd) | (v, r) <- varToRef, Just dd <- [Map.lookup v decls'] ]
-
-
-unitRef, pairRef, optionalRef, testResultRef, linkRef, docRef :: Reference
-(unitRef, pairRef, optionalRef, testResultRef, linkRef, docRef) =
-  let decls          = builtinDataDecls @Symbol
-      [(_, unit, _)] = filter (\(v, _, _) -> v == Var.named "Unit") decls
-      [(_, pair, _)] = filter (\(v, _, _) -> v == Var.named "Tuple") decls
-      [(_, opt , _)] = filter (\(v, _, _) -> v == Var.named "Optional") decls
-      [(_, testResult, _)] =
-        filter (\(v, _, _) -> v == Var.named "Test.Result") decls
-      [(_, link , _)] = filter (\(v, _, _) -> v == Var.named "Link") decls
-      [(_, doc , _)] = filter (\(v, _, _) -> v == Var.named "Doc") decls
-  in  (unit, pair, opt, testResult, link, doc)
-
-pairCtorRef, unitCtorRef :: Referent
-pairCtorRef = Referent.Con pairRef 0 CT.Data
-unitCtorRef = Referent.Con unitRef 0 CT.Data
-
-constructorId :: Reference -> Text -> Maybe Int
-constructorId ref name = do
-  (_,_,dd) <- find (\(_,r,_) -> r == ref) (builtinDataDecls @Symbol)
-  elemIndex name $ constructorNames dd
-
-okConstructorId, failConstructorId, docBlobId, docLinkId, docSignatureId, docSourceId, docEvaluateId, docJoinId, linkTermId, linkTypeId :: ConstructorId
-Just okConstructorId = constructorId testResultRef "Test.Result.Ok"
-Just failConstructorId = constructorId testResultRef "Test.Result.Fail"
-Just docBlobId = constructorId docRef "Doc.Blob"
-Just docLinkId = constructorId docRef "Doc.Link"
-Just docSignatureId = constructorId docRef "Doc.Signature"
-Just docSourceId = constructorId docRef "Doc.Source"
-Just docEvaluateId = constructorId docRef "Doc.Evaluate"
-Just docJoinId = constructorId docRef "Doc.Join"
-Just linkTermId = constructorId linkRef "Link.Term"
-Just linkTypeId = constructorId linkRef "Link.Type"
-
-okConstructorReferent, failConstructorReferent :: Referent.Referent
-okConstructorReferent = Referent.Con testResultRef okConstructorId CT.Data
-failConstructorReferent = Referent.Con testResultRef failConstructorId CT.Data
-
-failResult :: (Ord v, Monoid a) => a -> Text -> Term v a
-failResult ann msg =
-  Term.app ann (Term.request ann testResultRef failConstructorId)
-               (Term.text ann msg)
-
-builtinDataDecls :: Var v => [(v, Reference, DataDeclaration' v ())]
-builtinDataDecls = rs1 ++ rs
- where
-  rs1 = case hashDecls $ Map.fromList
-    [ (v "Link"           , link)
-    ] of Right a -> a; Left e -> error $ "builtinDataDecls: " <> show e
-  rs = case hashDecls $ Map.fromList
-    [ (v "Unit"           , unit)
-    , (v "Tuple"          , tuple)
-    , (v "Optional"       , opt)
-    , (v "Test.Result"    , tr)
-    , (v "Doc"            , doc)
-    ] of Right a -> a; Left e -> error $ "builtinDataDecls: " <> show e
-  [(_, linkRef, _)] = rs1
-  v = Var.named
-  var name = Type.var () (v name)
-  arr  = Type.arrow'
-  -- see note on `hashDecls` above for why ctor must be called `Unit.Unit`.
-  unit = DataDeclaration Structural () [] [((), v "Unit.Unit", var "Unit")]
-  tuple = DataDeclaration
-    Structural
-    ()
-    [v "a", v "b"]
-    [ ( ()
-      , v "Tuple.Cons"
-      , Type.foralls
-        ()
-        [v "a", v "b"]
-        (     var "a"
-        `arr` (var "b" `arr` Type.apps' (var "Tuple") [var "a", var "b"])
-        )
-      )
-    ]
-  opt = DataDeclaration
-    Structural
-    ()
-    [v "a"]
-    [ ( ()
-      , v "Optional.None"
-      , Type.foralls () [v "a"] (Type.app' (var "Optional") (var "a"))
-      )
-    , ( ()
-      , v "Optional.Some"
-      , Type.foralls ()
-                     [v "a"]
-                     (var "a" `arr` Type.app' (var "Optional") (var "a"))
-      )
-    ]
-  tr = DataDeclaration
-    (Unique "70621e539cd802b2ad53105697800930411a3ebc")
-    ()
-    []
-    [ ((), v "Test.Result.Fail", Type.text () `arr` var "Test.Result")
-    , ((), v "Test.Result.Ok"  , Type.text () `arr` var "Test.Result")
-    ]
-  doc = DataDeclaration
-    (Unique "c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004")
-    ()
-    []
-    [ ((), v "Doc.Blob", Type.text () `arr` var "Doc")
-    , ((), v "Doc.Link", Type.ref() linkRef `arr` var "Doc")
-    , ((), v "Doc.Signature", Type.termLink() `arr` var "Doc")
-    , ((), v "Doc.Source", Type.ref() linkRef `arr` var "Doc")
-    , ((), v "Doc.Evaluate", Type.termLink() `arr` var "Doc")
-    , ((), v "Doc.Join", Type.app() (Type.vector()) (var "Doc") `arr` var "Doc")
-    ]
-  link = DataDeclaration
-    (Unique "a5803524366ead2d7f3780871d48771e8142a3b48802f34a96120e230939c46bd5e182fcbe1fa64e9bff9bf741f3c04")
-    ()
-    []
-    [ ((), v "Link.Term", Type.termLink () `arr` var "Link")
-    , ((), v "Link.Type", Type.typeLink () `arr` var "Link")
-    ]
-
-pattern UnitRef <- (unUnitRef -> True)
-pattern PairRef <- (unPairRef -> True)
-pattern OptionalRef <- (unOptionalRef -> True)
-pattern TupleType' ts <- (unTupleType -> Just ts)
-pattern TupleTerm' xs <- (unTupleTerm -> Just xs)
-pattern TuplePattern ps <- (unTuplePattern -> Just ps)
-
--- some pattern synonyms to make pattern matching on some of these constants more pleasant
-pattern DocRef <- ((== docRef) -> True)
-pattern DocJoin segs <- Term.App' (Term.Constructor' DocRef DocJoinId) (Term.Sequence' segs)
-pattern DocBlob txt <- Term.App' (Term.Constructor' DocRef DocBlobId) (Term.Text' txt)
-pattern DocLink link <- Term.App' (Term.Constructor' DocRef DocLinkId) link
-pattern DocSource link <- Term.App' (Term.Constructor' DocRef DocSourceId) link
-pattern DocSignature link <- Term.App' (Term.Constructor' DocRef DocSignatureId) link
-pattern DocEvaluate link <- Term.App' (Term.Constructor' DocRef DocEvaluateId) link
-pattern Doc <- Term.App' (Term.Constructor' DocRef _) _
-pattern DocSignatureId <- ((== docSignatureId) -> True)
-pattern DocBlobId <- ((== docBlobId) -> True)
-pattern DocLinkId <- ((== docLinkId) -> True)
-pattern DocSourceId <- ((== docSourceId) -> True)
-pattern DocEvaluateId <- ((== docEvaluateId) -> True)
-pattern DocJoinId <- ((== docJoinId) -> True)
-pattern LinkTermId <- ((== linkTermId) -> True)
-pattern LinkTypeId <- ((== linkTypeId) -> True)
-pattern LinkRef <- ((== linkRef) -> True)
-pattern LinkTerm tm <- Term.App' (Term.Constructor' LinkRef LinkTermId) tm
-pattern LinkType ty <- Term.App' (Term.Constructor' LinkRef LinkTypeId) ty
-
-unitType, pairType, optionalType, testResultType
-  :: Ord v => a -> Type v a
-unitType a = Type.ref a unitRef
-pairType a = Type.ref a pairRef
-testResultType a = Type.app a (Type.vector a) (Type.ref a testResultRef)
-optionalType a = Type.ref a optionalRef
-
-unitTerm :: Var v => a -> Term v a
-unitTerm ann = Term.constructor ann unitRef 0
-
-tupleConsTerm :: (Ord v, Semigroup a)
-              => Term2 vt at ap v a
-              -> Term2 vt at ap v a
-              -> Term2 vt at ap v a
-tupleConsTerm hd tl =
-  Term.apps' (Term.constructor (ABT.annotation hd) pairRef 0) [hd, tl]
-
-tupleTerm :: (Var v, Monoid a) => [Term v a] -> Term v a
-tupleTerm = foldr tupleConsTerm (unitTerm mempty)
-
--- delayed terms are just lambdas that take a single `()` arg
--- `force` calls the function
-forceTerm :: Var v => a -> a -> Term v a -> Term v a
-forceTerm a au e = Term.app a e (unitTerm au)
-
-delayTerm :: Var v => a -> Term v a -> Term v a
-delayTerm a = Term.lam a $ Var.named "()"
-
-unTupleTerm
-  :: Term.Term2 vt at ap v a
-  -> Maybe [Term.Term2 vt at ap v a]
-unTupleTerm t = case t of
-  Term.Apps' (Term.Constructor' PairRef 0) [fst, snd] ->
-    (fst :) <$> unTupleTerm snd
-  Term.Constructor' UnitRef 0 -> Just []
-  _                           -> Nothing
-
-unTupleType :: Var v => Type v a -> Maybe [Type v a]
-unTupleType t = case t of
-  Type.Apps' (Type.Ref' PairRef) [fst, snd] -> (fst :) <$> unTupleType snd
-  Type.Ref' UnitRef -> Just []
-  _ -> Nothing
-
-unTuplePattern :: Pattern.PatternP loc -> Maybe [Pattern.PatternP loc]
-unTuplePattern p = case p of
-  Pattern.ConstructorP _ PairRef 0 [fst, snd] -> (fst : ) <$> unTuplePattern snd
-  Pattern.ConstructorP _ UnitRef 0 [] -> Just []
-  _ -> Nothing
-
-unUnitRef,unPairRef,unOptionalRef:: Reference -> Bool
-unUnitRef = (== unitRef)
-unPairRef = (== pairRef)
-unOptionalRef = (== optionalRef)
-

--- a/unison-core/src/Unison/Reference.hs
+++ b/unison-core/src/Unison/Reference.hs
@@ -22,6 +22,7 @@ module Unison.Reference
    readSuffix,
    showShort,
    showSuffix,
+   toId,
    toText,
    unsafeId,
    toShortHash) where
@@ -134,6 +135,10 @@ idFromText s = case fromText s of
   Right (Builtin _) -> Nothing
   Right (DerivedId id) -> pure id
 
+toId :: Reference -> Maybe Id
+toId (DerivedId id) = Just id
+toId Builtin{} = Nothing
+
 -- examples:
 -- `##Text.take` — builtins don’t have cycles
 -- `#2tWjVAuc7` — derived, no cycle
@@ -149,12 +154,12 @@ fromText t = case Text.split (=='#') t of
   _ -> bail
   where bail = Left $ "couldn't parse a Reference from " <> Text.unpack t
 
-component :: H.Hash -> [k] -> [(k, Reference)]
+component :: H.Hash -> [k] -> [(k, Id)]
 component h ks = let
   size = fromIntegral (length ks)
-  in [ (k, DerivedId (Id h i size)) | (k, i) <- ks `zip` [0..]]
+  in [ (k, (Id h i size)) | (k, i) <- ks `zip` [0..]]
 
-components :: [(H.Hash, [k])] -> [(k, Reference)]
+components :: [(H.Hash, [k])] -> [(k, Id)]
 components sccs = uncurry component =<< sccs
 
 groupByComponent :: [(k, Reference)] -> [[(k, Reference)]]

--- a/unison-core/src/Unison/Reference/Util.hs
+++ b/unison-core/src/Unison/Reference/Util.hs
@@ -3,6 +3,7 @@ module Unison.Reference.Util where
 import Unison.Prelude
 
 import Unison.Reference
+import qualified Unison.Reference as Reference
 import Unison.Hashable (Hashable1)
 import Unison.ABT (Var)
 import qualified Unison.ABT as ABT
@@ -10,12 +11,12 @@ import qualified Data.Map as Map
 
 hashComponents ::
      (Functor f, Hashable1 f, Foldable f, Eq v, Show v, Var v)
-  => (Reference -> ABT.Term f v ())
+  => (Reference.Id -> ABT.Term f v ())
   -> Map v (ABT.Term f v a)
-  -> Map v (Reference, ABT.Term f v a)
+  -> Map v (Reference.Id, ABT.Term f v a)
 hashComponents embedRef tms =
   Map.fromList [ (v, (r,e)) | ((v,e), r) <- cs ]
   where cs = components $ ABT.hashComponents ref tms
-        ref h i n = embedRef (DerivedId (Id h i n))
+        ref h i n = embedRef (Id h i n)
 
 

--- a/unison-core/src/Unison/Referent.hs
+++ b/unison-core/src/Unison/Referent.hs
@@ -26,6 +26,8 @@ pattern Con :: Reference -> Int -> ConstructorType -> Referent
 pattern Con r i t = Con' r i t
 {-# COMPLETE Ref, Con #-}
 
+type Id = Referent' R.Id 
+
 data Referent' r = Ref' r | Con' r Int ConstructorType
   deriving (Show, Ord, Eq, Functor)
 
@@ -73,9 +75,12 @@ toTermReference = \case
   _ -> Nothing
 
 toReference :: Referent -> Reference
-toReference = \case
-  Ref r -> r
-  Con r _i _t -> r
+toReference = toReference'
+
+toReference' :: Referent' r -> r
+toReference' = \case
+  Ref' r -> r
+  Con' r _i _t -> r
 
 toTypeReference :: Referent -> Maybe Reference
 toTypeReference = \case

--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -470,6 +470,9 @@ var' = var() . Var.named
 ref :: Ord v => a -> Reference -> Term2 vt at ap v a
 ref a r = ABT.tm' a (Ref r)
 
+refId :: Ord v => a -> Reference.Id -> Term2 vt at ap v a
+refId a = ref a . Reference.DerivedId
+
 termLink :: Ord v => a -> Referent -> Term2 vt at ap v a
 termLink a r = ABT.tm' a (TermLink r)
 
@@ -926,8 +929,8 @@ unhashComponent m = let
   in second unhash1 <$> m'
 
 hashComponents
-  :: Var v => Map v (Term v a) -> Map v (Reference, Term v a)
-hashComponents = ReferenceUtil.hashComponents $ ref ()
+  :: Var v => Map v (Term v a) -> Map v (Reference.Id, Term v a)
+hashComponents = ReferenceUtil.hashComponents $ refId ()
 
 -- The hash for a constructor
 hashConstructor'
@@ -938,7 +941,7 @@ hashConstructor' f r cid =
 -- ensure the hashing is always done in the same way
       m = hashComponents (Map.fromList [(Var.named "_" :: Symbol, f r cid)])
   in  case toList m of
-        [(r, _)] -> r
+        [(r, _)] -> Reference.DerivedId r
         _        -> error "unpossible"
 
 hashConstructor :: Reference -> Int -> Reference

--- a/unison-core/src/Unison/Type.hs
+++ b/unison-core/src/Unison/Type.hs
@@ -197,6 +197,9 @@ isArrow _ = False
 ref :: Ord v => a -> Reference -> Type v a
 ref a = ABT.tm' a . Ref
 
+refId :: Ord v => a -> Reference.Id -> Type v a
+refId a = ref a . Reference.DerivedId
+
 termLink :: Ord v => a -> Type v a
 termLink a = ABT.tm' a . Ref $ termLinkRef
 
@@ -580,8 +583,8 @@ toReferenceMentions ty =
   in Set.fromList $ toReference . gen <$> ABT.subterms ty
 
 hashComponents
-  :: Var v => Map v (Type v a) -> Map v (Reference, Type v a)
-hashComponents = ReferenceUtil.hashComponents $ ref ()
+  :: Var v => Map v (Type v a) -> Map v (Reference.Id, Type v a)
+hashComponents = ReferenceUtil.hashComponents $ refId ()
 
 instance Hashable1 F where
   hash1 hashCycle hash e =

--- a/unison-core/src/Unison/Util/Set.hs
+++ b/unison-core/src/Unison/Util/Set.hs
@@ -1,6 +1,10 @@
+{-# LANGUAGE ViewPatterns #-}
 module Unison.Util.Set where
 
 import Data.Set
 
 symmetricDifference :: Ord a => Set a -> Set a -> Set a
 symmetricDifference a b = (a `difference` b) `union` (b `difference` a)
+
+mapMaybe :: (Ord a, Ord b) => (a -> Maybe b) -> Set a -> Set b
+mapMaybe f s = fromList [ r | (f -> Just r) <- toList s ]


### PR DESCRIPTION
- `Codebase` functions are now parameterized by `Reference.Id` or `Referent.Id`
  where appropriate, to
  enforce at the type level that Codebases can't contain builtins, and
  to eliminate jank that was enforcing or assuming this at runtime.  
  (A `Referent.Id` is a `Referent` that doesn't refer to a built-in.)

  Ditto for `CodeLookup`.

  Ditto for `UnisonFile`, `UnisonFile.Env`, and `TypecheckedUnisonFile`; with some backwards-
  compatible functions and pattern synonyms to support the old types,
  and some new functions for the new types.

- Off-topic: `Codebase.getRootBranch` and `.getBranchForHash` now return a sum type instead
  of a magic value (`Branch.empty`) on error. `BranchLoadMode` goes away.

  `getRootBranch`'s result distinguishes between "I don't know what the
  head is supposed to be" vs "I do know what it is supposed to be but
  couldn't find it".

- Even more off-topic (oops), I moved the actual
  builtin `Decl`s from `unison-core/Unison.DataDeclaration` to
  `unison-parser-typechecker/Unison.Builtin.Decls`.

  I let this new module be qualified as `DD` to minimize diffs, although it may
  make it harder to know which module a `DD.` definition is coming from.