### PR TITLE
fix Star3.replaceFact

### DIFF
--- a/parser-typechecker/src/Unison/Util/Star3.hs
+++ b/parser-typechecker/src/Unison/Util/Star3.hs
@@ -185,7 +185,11 @@ deleteFact facts Star3{..} =
 replaceFact :: (Ord fact, Ord d1, Ord d2, Ord d3)
             => fact -> fact -> Star3 fact d1 d2 d3 -> Star3 fact d1 d2 d3
 replaceFact f f' Star3{..} =
-  Star3 ((Set.insert f' . Set.delete f) fact)
+  let updateFact fact = 
+        if Set.member f fact
+        then (Set.insert f' . Set.delete f) fact
+        else fact
+  in Star3 (updateFact fact)
         (R.replaceDom f f' d1)
         (R.replaceDom f f' d2)
         (R.replaceDom f f' d3)

--- a/unison-src/transcripts/fix-1381-excess-propagate.md
+++ b/unison-src/transcripts/fix-1381-excess-propagate.md
@@ -1,0 +1,28 @@
+We were seeing an issue where (it seemed) that every namespace that was visited during a propagate would get a new history node, even when it didn't contain any dependents.
+
+Example:
+```unison:hide
+a = "a term"
+X.foo = "a namespace"
+```
+
+```ucm
+.> add
+```
+
+Here is an update which should not affect `X`:
+```unison:hide
+a = "an update"
+```
+```ucm
+.> update
+```
+
+As of the time of this writing, the history for `X` should be a single node, `#4eeuo5bsfr`;
+```ucm
+.> history X
+```
+however, as of release/M1i, we saw an extraneous node appear.  If your `ucm` is fixed, you won't see it below:
+```ucm:error
+.> history #7nl6ppokhg
+```

--- a/unison-src/transcripts/fix-1381-excess-propagate.output.md
+++ b/unison-src/transcripts/fix-1381-excess-propagate.output.md
@@ -1,0 +1,55 @@
+We were seeing an issue where (it seemed) that every namespace that was visited during a propagate would get a new history node, even when it didn't contain any dependents.
+
+Example:
+```unison
+a = "a term"
+X.foo = "a namespace"
+```
+
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    X.foo : ##Text
+    a     : ##Text
+
+```
+Here is an update which should not affect `X`:
+```unison
+a = "an update"
+```
+
+```ucm
+.> update
+
+  ⍟ I've updated these names to your new definition:
+  
+    a : ##Text
+
+```
+As of the time of this writing, the history for `X` should be a single node, `#4eeuo5bsfr`;
+```ucm
+.> history X
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ #4eeuo5bsfr
+  
+    + Adds / updates:
+    
+      foo
+  
+  □ #7asfbtqmoj (start of history)
+
+```
+however, as of release/M1i, we saw an extraneous node appear.  If your `ucm` is fixed, you won't see it below:
+```ucm
+.> history #7nl6ppokhg
+
+  😶
+  
+  I don't know of a namespace with that hash.
+
+```


### PR DESCRIPTION
## Overview

We had noticed in unisonweb/base#10 that the commit contained a greater number of updated namespaces than we could explain.  We found that `Star3.replaceFact` had a bug that caused `update` propagation to invisibly alter every branch in the namespace.

Fixes #1381

## Test coverage

https://github.com/unisonweb/unison/blob/5c081a525373a87906fef259827542d73f74bc3d/unison-src/transcripts/fix-1381-excess-propagate.output.md

## Interesting/controversial decisions

We debated whether to just patch `Star3.replaceFact` or whether to eliminate `Star3.fact` as a stored field altogether (i.e. 803110af17f3e49bd693df1f53ff2ea8a9a76fdf). 

---
TL;DR: 

I ended just patching `replaceFact`, but I convinced myself that the other option is also fine, apart from the uncomfortable feeling you might get from producing branch binaries whose contents don't hash to their filename.

If we switch to a fully file-copy-based git sync (I still think we can easily), then that wouldn't happen either, because we would never be re-serializing a previously-serialized entity.

---
Long version:

Simply eliminating `Star3.fact` eliminates a potential family of potentially undiscovered consistency bugs, but @pchiusano raised a concern over the consequences of this "normalizing on load", which forgets any inconsistencies in the `fact` index may currently exist on disk.  (a) Would this lead to a situation where `ucm` would write a branch file `<hash>.ub` with contents don't hash to `<hash>`, and (b) if it did, could this cause any kind of problem?

So here (for posterity?) is a review of how `ucm` works with branch files and the codebase.

* **Reading the local codebase**
To read a branch from the local codebase, we already have a hash in mind.
  * Reading the root branch — the hash comes from `_head`.
  * Reading child branches — the hash comes from `children`.
  
  Given the hash,
  ```haskell
  FileCodebase.branchFromFiles
  	:: CodebasePath -> Branch.Hash -> m (Maybe (Branch m))
  ```
  computes a filename and calls `Branch.read` with this `Branch.Raw` deserializer:
  ```haskell
  FileCodebase.deserializeRawBranch :: RawHash h -> m (Raw h e)
  ```
  which loads a `Branch.Raw` and a list of causal ancestor hashes.  It never computes any hashes on its own!

* **Writing the local codebase** (`Branch.sync`)
  ```haskell
  sync :: Monad m
       => (Hash -> m Bool)
       -> (Branch.Hash -> Branch.Raw -> m ())
       -> (EditHash -> m Patch -> m ())
       -> Branch m
       -> m ()
  ``` 
  This won’t overwrite any existing files, so we are good!

  Note: This call to `Branch.sync` only writes `Branch`es and `Patch`es; terms, decls, and the various indices are assumed to already have been written.
* **Ingesting a git repo**
Currently, ingesting a git repo means copying over all of its files that we don’t already have, and then loading those pieces from the local codebase.  Nothing special here.

* **Staging a git commit** (i.e. pushing a `Branch m` to a git repo)
We have two ways to do this. 
	1. Current implementation: 
		* pull a shallow copy of the target repo
		* call `FileCodebase.syncToDirectory`, which does some preliminaries before making a call to `Branch.sync` with different serializer arguments to write definitions and indices (via `FileCodebase.putDecl` and `FileCodebase.putTerm`).
	 This uses the `V1` serializers to write missing branches to the target repo, meaning that normalized contents would be written to a branch file with a name that matched the old hash, and contents that would produce a new hash. (This could result in a merge conflict if we were using git merges, but we aren't.)
	2. Experimental file-copy based implementation
		* pull a shallow copy of the target repo
		* call `Branch.sync` but serializer arguments just copy the existing branch, patch, term, decl, edits.  The serializer uses `StateT` to keep track of what definitions and referents were synced, and uses that info to copy parts of the dependents, referents' type, and referents' type mentions indices.
	This never constructs a new file, so it can't produce conflicting contents.