### PR TITLE
easytest.pending runs hidden tests and reports accordingly

### DIFF
--- a/yaks/easytest/tests/Suite.hs
+++ b/yaks/easytest/tests/Suite.hs
@@ -12,6 +12,12 @@ suite1 = tests
   , scope "b" . scope "c" . scope "d" $ ok
   , scope "c" ok ]
 
+suite2 :: Test ()
+suite2 = tests
+  [ scope "pending.failure" (pending (expectEqual True False))
+  --, scope "pending.success" (pending ok) 
+  ]
+
 reverseTest :: Test ()
 reverseTest = scope "list reversal" $ do
   nums <- listsOf [0..100] (int' 0 99)
@@ -25,3 +31,4 @@ main = do
   runOnly "b" $ tests [suite1, scope "xyz" (crash "never run")]
   runOnly "b.c" $ tests [suite1, scope "b" (crash "never run")]
   run reverseTest
+  run suite2


### PR DESCRIPTION
## Overview

This PR aims to change the behaviour of the `pending` test wrapper.
When using `pending` from now on:
* the test being wrapped will actually be run, with logging switched off, and not showing any output
* If the inner test fails, `pending` reports a success
* If the inner test passes, this is unexpected, and `pending` reports a failure

fix #928 

## Implementation notes

I have implemented "switch off logging" and "run hidden in a new scope" as two functions, for the sake of granularity.

## Interesting/controversial decisions

I have allowed a commented out `pending` test that produces an `inner success`
When uncommented this will produce the following output:

```
🦄  pending.failure
pending.success FAILURE This pending test should not pass! CallStack (from HasCallStack):
  crash, called at src/EasyTest.hs:377:7 in easytest-0.1-GHUNtMcGbspKNzFvNGkuQU:EasyTest
  pending, called at tests/Suite.hs:18:30 in main:Main
💥  pending.success
------------------------------------------------------------


  1 passed
  1 FAILED (failed scopes below)
    "pending.success"

  To rerun with same random seed:

    EasyTest.rerun 3851235856694737643
    EasyTest.rerunOnly 3851235856694737643 "pending.success"
```

## Test coverage

Yes

## Loose ends
Maybe remove `Pending` from `Status` altogether?
