### PR TITLE
four git ux fixes

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
@@ -107,7 +107,7 @@ checkForGit = do
 
 checkGitDir :: FilePath -> IO Bool
 checkGitDir dir =
-  (const True <$> gitIn dir ["rev-parse", "--git-dir"]) $? pure False
+  (const True <$> gitIn dir ["rev-parse"]) $? pure False
 
 onError :: MonadError e m => MonadIO m => IO () -> m () -> m ()
 onError x k = liftIO ((const True <$> x) $? pure False) >>= \case

--- a/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
@@ -114,11 +114,16 @@ onError x k = liftIO ((const True <$> x) $? pure False) >>= \case
   True  -> pure ()
   False -> k
 
+setupGitDir :: FilePath -> [Text]
+setupGitDir localPath = 
+  ["--git-dir", Text.pack $ localPath </> ".git"
+  ,"--work-tree", Text.pack localPath]
+
 gitIn :: FilePath -> [Text] -> IO ()
-gitIn localPath args = "git" (["-C", Text.pack localPath] <> args)
+gitIn localPath args = "git" (setupGitDir localPath <> args)
 
 gitTextIn :: FilePath -> [Text] -> IO Text
-gitTextIn localPath args = "git" $| ["-C", Text.pack localPath] <> args
+gitTextIn localPath args = "git" $| setupGitDir localPath <> args
 
 -- Clone the given remote repo and commit to the given local path.
 -- Then given a codebase and a branch, write the branch and all its

--- a/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
@@ -16,7 +16,7 @@ import           Control.Monad.Except           ( MonadError
                                                 , ExceptT
                                                 )
 import qualified Data.Text                     as Text
-import           Shellmet                       ( ($?), ($|) )
+import           Shellmet                       ( ($?), ($|), ($^))
 import           System.Directory               ( doesDirectoryExist
                                                 , findExecutable
                                                 , removeDirectoryRecursive
@@ -120,7 +120,7 @@ setupGitDir localPath =
   ,"--work-tree", Text.pack localPath]
 
 gitIn :: FilePath -> [Text] -> IO ()
-gitIn localPath args = "git" (setupGitDir localPath <> args)
+gitIn localPath args = "git" $^ (setupGitDir localPath <> args)
 
 gitTextIn :: FilePath -> [Text] -> IO Text
 gitTextIn localPath args = "git" $| setupGitDir localPath <> args

--- a/stack.yaml
+++ b/stack.yaml
@@ -16,7 +16,7 @@ resolver: lts-14.7
 extra-deps:
 - base58-bytestring-0.1.0
 - relation-0.2.1
-- shellmet-0.0.1
+- shellmet-0.0.3.0
 - filepattern-0.1.1
 - strings-1.1@sha256:0285dec4c8ab262359342b3e5ef1eb567074669461b9b38404f1cb870c881c5c
 - guid-0.1.0@sha256:a7c975be473f6f142d5cc1b39bc807a99043d20b1bb0873fdfe7a3ce84d2faf1


### PR DESCRIPTION
## Overview

Check out this screencast, or scrutinize the still image:
[![asciicast](https://asciinema.org/a/EMV7jGA1nCfvV0QIN1V76PqsW.svg)](https://asciinema.org/a/EMV7jGA1nCfvV0QIN1V76PqsW)
(Too bad it can't play inline from a GH issue!)

**From here, you can probably skip over to my self-review.**

---
### 1. Fix an issue preventing use of local, relative-path git repos.

`push repo1.git bar` _should_ work, but ended up resulting in an error like:
```
fatal: 'repo1.git' does not appear to be a git repository
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.

  I couldn't access a git repository at repo1.git. Make sure the repo exists and that you
  have access to it.
```

The only workaround was to specify an absolute path:
```
.> push /Users/arya/unison7/repo1.git bar
```
which, in addition to being annoying, made it a bit harder to create bug reports that involve git repos — a bug-fixer would have to adjust the absolute paths for their machine.

This was occurring because `git` was resolving the relative path _relative to_ a random temp directory, rather than ucm's current path.

This PR uses `--git-dir` and `--work-tree` to indicate where `git` should work, instead of having it change directories (`git -C`).

### 2. Avoid the output from `git rev-parse --git-dir`.

The `git` docs sort of make it sound like you must pass `--git-dir` if you want `git rev-parse` to exit with an error when it can't find a local `.git` dir, but the primary effect of passing `--git-dir` is that git _prints_ the git dir it finds to stdout.

But it turns out we don't need to pass `--git-dir` to get the exit codes we want, and we don't want to print the git dir anyway, so I removed the flag.

### 3. Eliminate Shellmet output.

With an updated Shellmet, I could turn off the printing of git commands.

### 4. Added some progress messages.

Well, without the git output, it pretty much just looked like ucm was frozen. So I added some status messages to keep you hopeful.

## Test coverage

`push` / `pull` could use some better regression tests in general; this PR doesn't change that.

## Loose ends

At the end of the screencast, you see these annoying warnings from `git` about stuff I know about and don't need to see:
```
.prs.puffnfresh> push repo.git merged
warning: --depth is ignored in local clones; use file:// instead.
warning: You appear to have cloned an empty repository.
warning: --depth is ignored in local clones; use file:// instead.
warning: You appear to have cloned an empty repository.
                                          
  Done.
```

One way to hide these would be to redirect stderr.

Another way would be to not pass `--depth 1` for local repos, but the function that passes `--depth 1` doesn't know how to parse the url to know if it's a local repo.  https://github.com/unisonweb/unison/compare/713a746...topic/more-remoterepo-structure does the first part of bringing this structure forward.