### PR TITLE
Fix issue with `putSymbol` which resulted in extra numbers getting appended to the name on each round trip

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Serialization/V1.hs
+++ b/parser-typechecker/src/Unison/Codebase/Serialization/V1.hs
@@ -395,7 +395,7 @@ getType getVar getA = getABT getVar getA go where
     _ -> unknownTag "getType" tag
 
 putSymbol :: MonadPut m => Symbol -> m ()
-putSymbol v@(Symbol id _) = putLength id *> putText (Var.name v)
+putSymbol (Symbol id typ) = putLength id *> putText (Var.rawName typ)
 
 getSymbol :: MonadGet m => m Symbol
 getSymbol = Symbol <$> getLength <*> (Var.User <$> getText)

--- a/parser-typechecker/tests/Unison/Test/ABT.hs
+++ b/parser-typechecker/tests/Unison/Test/ABT.hs
@@ -7,6 +7,8 @@ import EasyTest
 import Unison.ABT as ABT
 import Unison.Symbol (Symbol(..))
 import Unison.Var as Var
+import           Unison.Codebase.Serialization    ( getFromBytes, putBytes )
+import qualified Unison.Codebase.Serialization.V1 as V1
 
 test :: Test ()
 test = scope "abt" $ tests [
@@ -20,5 +22,11 @@ test = scope "abt" $ tests [
     in tests
       [ scope "first"  $ expect (not $ Set.member fresh (ABT.freeVars t1))
       , scope "second" $ expect (not $ Set.member fresh (ABT.freeVars t2))
-      ]
+      ],
+  -- confirmation of fix for https://github.com/unisonweb/unison/issues/1388
+  -- where symbols with nonzero freshIds did not round trip
+  scope "putSymbol" $ let
+    v = Symbol 10 (User "hi")
+    v' = getFromBytes V1.getSymbol (putBytes V1.putSymbol v)
+    in expectEqual (Just v) v'
   ]

--- a/parser-typechecker/tests/Unison/Test/ABT.hs
+++ b/parser-typechecker/tests/Unison/Test/ABT.hs
@@ -14,8 +14,6 @@ test :: Test ()
 test = scope "abt" $ tests [
   scope "freshInBoth" $
     let
-      symbol i n = Symbol i (Var.User n)
-      var i n = ABT.var $ symbol i n
       t1 = var 1 "a"
       t2 = var 0 "a"
       fresh = ABT.freshInBoth t1 t2 $ symbol 0 "a"
@@ -23,6 +21,17 @@ test = scope "abt" $ tests [
       [ scope "first"  $ expect (not $ Set.member fresh (ABT.freeVars t1))
       , scope "second" $ expect (not $ Set.member fresh (ABT.freeVars t2))
       ],
+  scope "rename" $ do
+    -- rename x to a in \a  -> [a, x] should yield
+    --                  \a1 -> [a1, a]
+    let t1 = ABT.abs (symbol 0 "a") (ABT.tm [var 0 "a", var 0 "x"])
+        t2 = ABT.rename (symbol 0 "x") (symbol 0 "a") t1
+        fvs = toList . ABT.freeVars $ t2
+    -- make sure the variable wasn't captured
+    expectEqual fvs [symbol 0 "a"]
+    -- make sure the resulting term is alpha equiv to \a1 -> [a1, a]
+    expectEqual t2 (ABT.abs (symbol 0 "b") (ABT.tm [var 0 "b", var 0 "a"])),
+
   -- confirmation of fix for https://github.com/unisonweb/unison/issues/1388
   -- where symbols with nonzero freshIds did not round trip
   scope "putSymbol" $ let
@@ -30,3 +39,6 @@ test = scope "abt" $ tests [
     v' = getFromBytes V1.getSymbol (putBytes V1.putSymbol v)
     in expectEqual (Just v) v'
   ]
+  where
+    symbol i n = Symbol i (Var.User n)
+    var i n = ABT.var $ symbol i n

--- a/unison-core/src/Unison/ABT.hs
+++ b/unison-core/src/Unison/ABT.hs
@@ -528,14 +528,13 @@ find' :: (Ord v, Foldable f, Functor f)
 find' p = Unison.ABT.find (\t -> if p t then Found t else Continue)
 
 instance (Foldable f, Functor f, Eq1 f, Var v) => Eq (Term f v a) where
-  -- alpha equivalence, works by renaming any aligned Abs ctors to use a common fresh variable
+  -- alpha equivalence, works by renaming any aligned Abs ctors to use a common variable
   t1 == t2 = go (out t1) (out t2) where
     go (Var v) (Var v2) | v == v2 = True
     go (Cycle t1) (Cycle t2) = t1 == t2
     go (Abs v1 body1) (Abs v2 body2) =
       if v1 == v2 then body1 == body2
-      else let v3 = freshInBoth body1 body2 v1
-           in rename v1 v3 body1 == rename v2 v3 body2
+      else rename v1 v2 body1 == body2
     go (Tm f1) (Tm f2) = f1 ==# f2
     go _ _ = False
 

--- a/unison-core/src/Unison/ABT.hs
+++ b/unison-core/src/Unison/ABT.hs
@@ -257,7 +257,7 @@ rename old new t0@(Term fvs ann t) =
       -- to make that no longer true, then proceed with
       -- renaming `old` to `new`
       else if v == new then
-        let v' = freshIn (Set.insert new (freeVars body)) v
+        let v' = freshIn (Set.fromList [new,old] <> freeVars body) v
         in abs' ann v' (rename old new (rename v v' body))
 
       -- nothing special, just rename inside body of Abs

--- a/unison-core/src/Unison/Var.hs
+++ b/unison-core/src/Unison/Var.hs
@@ -37,22 +37,25 @@ named n = typed (User n)
 refNamed :: Var v => Reference -> v
 refNamed ref = named ("ℍ" <> R.toText ref)
 
+rawName :: Type -> Text
+rawName typ = case typ of
+  User n -> n
+  Inference Ability -> "𝕖"
+  Inference Input -> "𝕒"
+  Inference Output -> "𝕣"
+  Inference Other -> "𝕩"
+  Inference PatternPureE -> "𝕞"
+  Inference PatternPureV -> "𝕧"
+  Inference PatternBindE -> "𝕞"
+  Inference PatternBindV -> "𝕧"
+  Inference TypeConstructor -> "𝕗"
+  Inference TypeConstructorArg -> "𝕦"
+  MissingResult -> "_"
+  Blank -> "_"
+  UnnamedWatch k guid -> fromString k <> "." <> guid
+
 name :: Var v => v -> Text
-name v = case typeOf v of
-  User n -> n <> showid v
-  Inference Ability -> "𝕖" <> showid v
-  Inference Input -> "𝕒" <> showid v
-  Inference Output -> "𝕣" <> showid v
-  Inference Other -> "𝕩" <> showid v
-  Inference PatternPureE -> "𝕞" <> showid v
-  Inference PatternPureV -> "𝕧" <> showid v
-  Inference PatternBindE -> "𝕞" <> showid v
-  Inference PatternBindV -> "𝕧" <> showid v
-  Inference TypeConstructor -> "𝕗" <> showid v
-  Inference TypeConstructorArg -> "𝕦" <> showid v
-  MissingResult -> "_" <> showid v
-  Blank -> "_" <> showid v
-  UnnamedWatch k guid -> fromString k <> "." <> guid <> showid v
+name v = rawName (typeOf v) <> showid v
   where
   showid (freshId -> 0) = ""
   showid (freshId -> n) = pack (show n)


### PR DESCRIPTION
See self review.

## Interesting/controversial decisions

After fixing this, some serialization round trip tests started failing. This ended up being due to the Eq instance for ABT being busted due to its use of rename, which has a subtle variable capture bug that @dolio spotted a while ago https://github.com/unisonweb/unison/issues/1277 #1277 needs a proper fix but in the meantime, I've tweaked the Eq instance to be a bit more efficient and also avoid the #1277 bug in this particular case.

## Test coverage

All the existing typechecker tests get a serialization round trip, so we have some confidence that it hasn't goofed anything up. 

I also added a minimal failing test against current master. It just checks that `putSymbol` and `getSymbol` round trip successfully for symbols nonzero fresh ids.

## Loose ends

Not sure what we do about existing repositories. 

We could do a cleanup pass, or I think people can fix weird type signatures manually by deleting and re-adding the term.