### PR TITLE
implement `dependents <x>`, `dependencies <x>`, and `debug.file`

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -31,6 +31,7 @@ module Unison.Codebase.Branch
   , before
   , findHistoricalHQs
   , findHistoricalRefs
+  , findHistoricalRefs'
   , namesDiff
     -- ** History updates
   , step
@@ -237,6 +238,12 @@ findHistoricalRefs :: Monad m => Set LabeledDependency -> Branch m
 findHistoricalRefs = findInHistory
   (\query r _n -> LD.fold (const False) (==r) query)
   (\query r _n -> LD.fold (==r) (const False) query)
+
+findHistoricalRefs' :: Monad m => Set Reference -> Branch m
+                    -> m (Set Reference, Names0)
+findHistoricalRefs' = findInHistory
+  (\queryRef r _n -> r == Referent.Ref queryRef)
+  (\queryRef r _n -> r == queryRef)
 
 findInHistory :: forall m q. (Monad m, Ord q)
   => (q -> Referent -> Name -> Bool)

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1590,16 +1590,16 @@ loop = do
           then respond $ LabeledReferenceNotFound hq
           else for_ lds $ \ld -> do
             dependencies :: Set Reference <- let
-              tp (Reference.DerivedId r) = eval (LoadType r) <&> \case
-                Nothing -> error $ "What happened to " ++ show r ++ "?"
-                Just decl -> DD.dependencies $ DD.asDataDecl decl
+              tp r@(Reference.DerivedId i) = eval (LoadType i) <&> \case
+                Nothing -> error $ "What happened to " ++ show i ++ "?"
+                Just decl -> Set.delete r . DD.dependencies $ DD.asDataDecl decl
               tp _ = pure mempty
-              tm (Referent.Ref (Reference.DerivedId r)) = eval (LoadTerm r) <&> \case
-                Nothing -> error $ "What happened to " ++ show r ++ "?"
-                Just tm -> Term.dependencies tm
-              tm con@(Referent.Con (Reference.DerivedId r) i _ct) = eval (LoadType r) <&> \case
-                Nothing -> error $ "What happened to " ++ show r ++ "?"
-                Just decl ->  case DD.typeOfConstructor (DD.asDataDecl decl) i of
+              tm (Referent.Ref r@(Reference.DerivedId i)) = eval (LoadTerm i) <&> \case
+                Nothing -> error $ "What happened to " ++ show i ++ "?"
+                Just tm -> Set.delete r $ Term.dependencies tm
+              tm con@(Referent.Con (Reference.DerivedId i) cid _ct) = eval (LoadType i) <&> \case
+                Nothing -> error $ "What happened to " ++ show i ++ "?"
+                Just decl -> case DD.typeOfConstructor (DD.asDataDecl decl) cid of
                   Nothing -> error $ "What happened to " ++ show con ++ "?"
                   Just tp -> Type.dependencies tp
               tm _ = pure mempty

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -310,7 +310,7 @@ loop = do
         typeNotFound' = respond . TypeNotFound'
         termNotFound = respond . TermNotFound
         termNotFound' = respond . TermNotFound'
-        nameConflicted src tms tys = respond (NameAmbiguous hqLength src tms tys)
+        nameConflicted src tms tys = respond (DeleteNameAmbiguous hqLength src tms tys)
         typeConflicted src = nameConflicted src Set.empty
         termConflicted src tms = nameConflicted src tms Set.empty
         hashConflicted src = respond . HashAmbiguous src
@@ -431,6 +431,8 @@ loop = do
           NamesI{} -> wat
           TodoI{} -> wat
           ListEditsI{} -> wat
+          ListDependenciesI{} -> wat
+          ListDependentsI{} -> wat
           HistoryI{} -> wat
           TestI{} -> wat
           LinksI{} -> wat
@@ -444,6 +446,7 @@ loop = do
           ShowReflogI{} -> wat
           DebugNumberedArgsI{} -> wat
           DebugBranchHistoryI{} -> wat
+          DebugTypecheckedUnisonFileI{} -> wat
           QuitI{} -> wat
           DeprecateTermI{} -> undefined
           DeprecateTypeI{} -> undefined
@@ -1569,10 +1572,52 @@ loop = do
             error $ "impossible match, resolveConfiguredGitUrl shouldn't return"
                 <> " `Just` unless it was passed `Just`; and here it is passed"
                 <> " `Nothing` by `expandRepo`."
+      ListDependentsI hq -> do -- todo: add flag to handle transitive efficiently
+        resolveHQToLabeledDependencies hq >>= \lds ->
+          if null lds
+          then respond $ LabeledReferenceNotFound hq
+          else for_ lds $ \ld -> do
+            dependents <- let
+              tp r = eval $ GetDependents r
+              tm (Referent.Ref r) = eval $ GetDependents r
+              tm (Referent.Con r _i _ct) = eval $ GetDependents r
+              in LD.fold tp tm ld
+            (missing, names0) <- eval . Eval $ Branch.findHistoricalRefs' dependents root'
+            respond $ ListDependents hqLength ld names0 missing
+      ListDependenciesI hq -> do -- todo: add flag to handle transitive efficiently
+        resolveHQToLabeledDependencies hq >>= \lds ->
+          if null lds
+          then respond $ LabeledReferenceNotFound hq
+          else for_ lds $ \ld -> do
+            dependencies :: Set Reference <- let
+              tp (Reference.DerivedId r) = eval (LoadType r) <&> \case
+                Nothing -> error $ "What happened to " ++ show r ++ "?"
+                Just decl -> DD.dependencies $ DD.asDataDecl decl
+              tp _ = pure mempty
+              tm (Referent.Ref (Reference.DerivedId r)) = eval (LoadTerm r) <&> \case
+                Nothing -> error $ "What happened to " ++ show r ++ "?"
+                Just tm -> Term.dependencies tm
+              tm con@(Referent.Con (Reference.DerivedId r) i _ct) = eval (LoadType r) <&> \case
+                Nothing -> error $ "What happened to " ++ show r ++ "?"
+                Just decl ->  case DD.typeOfConstructor (DD.asDataDecl decl) i of
+                  Nothing -> error $ "What happened to " ++ show con ++ "?"
+                  Just tp -> Type.dependencies tp
+              tm _ = pure mempty
+              in LD.fold tp tm ld
+            (missing, names0) <- eval . Eval $ Branch.findHistoricalRefs' dependencies root'
+            respond $ ListDependencies hqLength ld names0 missing
       DebugNumberedArgsI -> use numberedArgs >>= respond . DumpNumberedArgs
       DebugBranchHistoryI ->
         eval . Notify . DumpBitBooster (Branch.headHash currentBranch') =<<
           (eval . Eval $ Causal.hashToRaw (Branch._history currentBranch'))
+      DebugTypecheckedUnisonFileI -> case uf of
+        Nothing -> respond NoUnisonFile
+        Just uf -> let
+          datas, effects, terms :: [(Name, Reference.Id)]
+          datas = [ (Name.fromVar v, r) | (v, (r, _d)) <- Map.toList $ UF.dataDeclarationsId' uf ]
+          effects = [ (Name.fromVar v, r) | (v, (r, _e)) <- Map.toList $ UF.effectDeclarationsId' uf ]
+          terms = [ (Name.fromVar v, r) | (v, (r, _tm, _tp)) <- Map.toList $ UF.hashTermsId uf ]
+          in eval . Notify $ DumpUnisonFileHashes hqLength datas effects terms
 
       DeprecateTermI {} -> notImplemented
       DeprecateTypeI {} -> notImplemented
@@ -1638,6 +1683,24 @@ loop = do
       <> " disappeared from storage. "
       <> "I tried to put it back, but couldn't. Everybody panic!"
   -}
+
+-- todo: compare to `getHQTerms` / `getHQTypes`.  Is one universally better?
+resolveHQToLabeledDependencies :: Functor m => HQ.HashQualified -> Action' m v (Set LabeledDependency)
+resolveHQToLabeledDependencies = \case
+  HQ.NameOnly n -> do
+    parseNames <- Names3.suffixify0 <$> basicParseNames0
+    let terms, types :: Set LabeledDependency
+        terms = Set.map LD.referent . R.lookupDom n $ Names3.terms0 parseNames
+        types = Set.map LD.typeRef . R.lookupDom n $ Names3.types0 parseNames
+    pure $ terms <> types
+  -- rationale: the hash should be unique enough that the name never helps
+  HQ.HashQualified _n sh -> resolveHashOnly sh
+  HQ.HashOnly sh -> resolveHashOnly sh
+  where
+  resolveHashOnly sh = do
+    terms <- eval $ TermReferentsByShortHash sh
+    types <- eval $ TypeReferencesByShortHash sh
+    pure $ Set.map LD.referent terms <> Set.map LD.typeRef types
 
 doDisplay :: Var v => OutputLocation -> Names -> Referent -> Action' m v ()
 doDisplay outputLoc names r = do

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -123,8 +123,11 @@ data Input
   | ShowReflogI
   | UpdateBuiltinsI
   | MergeBuiltinsI
+  | ListDependenciesI HQ.HashQualified
+  | ListDependentsI HQ.HashQualified
   | DebugNumberedArgsI
   | DebugBranchHistoryI
+  | DebugTypecheckedUnisonFileI
   | QuitI
   deriving (Eq, Show)
 

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -594,9 +594,14 @@ termReferentsByPrefix :: MonadIO m
   -> CodebasePath
   -> ShortHash
   -> m (Set Referent.Id)
-termReferentsByPrefix getDecl root sh = do
+termReferentsByPrefix _ root sh@SH.Builtin{} =
+  Set.map Referent.Ref' <$> termReferencesByPrefix root sh
+  -- builtin types don't provide any referents we could match against,
+  -- only decl types do.  
+termReferentsByPrefix getDecl root sh@SH.ShortHash{} = do
   terms <- termReferencesByPrefix root sh
   ctors <- do
+    -- clear out any CID from the SH, so we can use it to find a type decl
     types <- typeReferencesByPrefix root sh { SH.cid = Nothing }
     foldMapM collectCtors types
   pure (Set.map Referent.Ref' terms <> ctors)

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -1179,6 +1179,18 @@ names = InputPattern "names" []
     _ -> Left (I.help names)
   )
 
+dependents, dependencies :: InputPattern
+dependents = InputPattern "dependents" [] []
+  "List the dependents of the specified definition."
+  (\case
+    [thing] -> fmap Input.ListDependentsI $ parseHashQualifiedName thing
+    _ -> Left (I.help names))
+dependencies = InputPattern "dependencies" [] []
+  "List the dependencies of the specified definition."
+  (\case
+    [thing] -> fmap Input.ListDependenciesI $ parseHashQualifiedName thing
+    _ -> Left (I.help names))
+
 debugNumberedArgs :: InputPattern
 debugNumberedArgs = InputPattern "debug.numberedArgs" [] []
   "Dump the contents of the numbered args state."
@@ -1189,7 +1201,12 @@ debugBranchHistory = InputPattern "debug.history" []
   [(Optional, noCompletions)]
   "Dump codebase history, compatible with bit-booster.com/graph.html"
   (const $ Right Input.DebugBranchHistoryI)
-
+  
+debugFileHashes :: InputPattern
+debugFileHashes = InputPattern "debug.file" [] []
+  "View details about the most recent succesfully typechecked file."
+  (const $ Right Input.DebugTypecheckedUnisonFileI)
+   
 test :: InputPattern
 test = InputPattern "test" [] []
     "`test` runs unit tests for the current branch."
@@ -1273,8 +1290,10 @@ validInputs =
   , quit
   , updateBuiltins
   , mergeBuiltins
+  , dependents, dependencies
   , debugNumberedArgs
   , debugBranchHistory
+  , debugFileHashes
   ]
 
 commandNames :: [String]

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -1184,12 +1184,12 @@ dependents = InputPattern "dependents" [] []
   "List the dependents of the specified definition."
   (\case
     [thing] -> fmap Input.ListDependentsI $ parseHashQualifiedName thing
-    _ -> Left (I.help names))
+    _ -> Left (I.help dependents))
 dependencies = InputPattern "dependencies" [] []
   "List the dependencies of the specified definition."
   (\case
     [thing] -> fmap Input.ListDependenciesI $ parseHashQualifiedName thing
-    _ -> Left (I.help names))
+    _ -> Left (I.help dependencies))
 
 debugNumberedArgs :: InputPattern
 debugNumberedArgs = InputPattern "debug.numberedArgs" [] []

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -23,7 +23,7 @@ import qualified Unison.Codebase.Editor.Output.BranchDiff as OBD
 
 import           Control.Lens
 import qualified Control.Monad.State.Strict    as State
-import           Data.Bifunctor                (bimap, first)
+import           Data.Bifunctor                (bimap, first, second)
 import           Data.List                     (sort, sortOn, stripPrefix)
 import           Data.List.Extra               (nubOrdOn, nubOrd)
 import qualified Data.Map                      as Map
@@ -975,28 +975,32 @@ notifyUser dir o = case o of
       "",
       "Paste that output into http://bit-booster.com/graph.html"
       ]
-  ListDependents hqLength ld names0 missing -> pure . P.syntaxToColor $
+  ListDependents hqLength ld names0 missing -> pure $
     if names0 == mempty && missing == mempty
-    then prettyLabeledDependency hqLength ld <> " doesn't have any dependents."
+    then c (prettyLabeledDependency hqLength ld) <> " doesn't have any dependents."
     else
-      "Dependents of " <> prettyLabeledDependency hqLength ld <> ":\n\n" <>
-      (P.indentN 2 . P.column2 $
+      "Dependents of " <> c (prettyLabeledDependency hqLength ld) <> ":\n\n" <>
+      (P.indentN 2 . P.column2Header "Reference" "Name" $ fmap (first c . second c) $
         [ (p $ Reference.toShortHash r, prettyName n) | (n, r) <- R.toList $ Names.types0 names0 ] ++
         [ (p $ Referent.toShortHash r, prettyName n) | (n, r) <- R.toList $ Names.terms names0 ] ++
         [ (p $ Reference.toShortHash r, "(no name available)") | r <- toList missing ])
-    where p = prettyShortHash . SH.take hqLength
+    where
+    p = prettyShortHash . SH.take hqLength
+    c = P.syntaxToColor
   -- this definition is identical to the previous one, apart from the word
   -- "Dependencies", but undecided about whether or how to refactor
-  ListDependencies hqLength ld names0 missing -> pure . P.syntaxToColor $
+  ListDependencies hqLength ld names0 missing -> pure $
     if names0 == mempty && missing == mempty
-    then prettyLabeledDependency hqLength ld <> " doesn't have any dependencies."
+    then c (prettyLabeledDependency hqLength ld) <> " doesn't have any dependencies."
     else
-      "Dependencies of " <> prettyLabeledDependency hqLength ld <> ":\n\n" <>
-      (P.indentN 2 . P.column2 $
+      "Dependencies of " <> c (prettyLabeledDependency hqLength ld) <> ":\n\n" <>
+      (P.indentN 2 . P.column2Header "Reference" "Name" $ fmap (first c . second c) $
         [ (p $ Reference.toShortHash r, prettyName n) | (n, r) <- R.toList $ Names.types0 names0 ] ++
         [ (p $ Referent.toShortHash r, prettyName n) | (n, r) <- R.toList $ Names.terms names0 ] ++
         [ (p $ Reference.toShortHash r, "(no name available)") | r <- toList missing ])
-    where p = prettyShortHash . SH.take hqLength
+    where
+    p = prettyShortHash . SH.take hqLength
+    c = P.syntaxToColor
   DumpUnisonFileHashes hqLength datas effects terms ->
     pure . P.syntaxToColor . P.lines $
       (effects <&> \(n,r) -> "ability " <>

--- a/parser-typechecker/src/Unison/NamePrinter.hs
+++ b/parser-typechecker/src/Unison/NamePrinter.hs
@@ -4,6 +4,8 @@ import Unison.Prelude
 
 import qualified Unison.HashQualified as HQ
 import qualified Unison.HashQualified' as HQ'
+import           Unison.LabeledDependency (LabeledDependency)
+import qualified Unison.LabeledDependency as LD
 import           Unison.Name          (Name)
 import qualified Unison.Name          as Name
 import           Unison.Reference     (Reference)
@@ -48,6 +50,9 @@ prettyReference len =
 prettyReferent :: Int -> Referent -> Pretty SyntaxText
 prettyReferent len =
   prettyHashQualified . HQ.take len . HQ.fromReferent
+
+prettyLabeledDependency :: Int -> LabeledDependency -> Pretty SyntaxText
+prettyLabeledDependency len = LD.fold (prettyReference len) (prettyReferent len)
 
 prettyShortHash :: IsString s => ShortHash -> Pretty s
 prettyShortHash = fromString . SH.toString

--- a/parser-typechecker/src/Unison/Util/Pretty.hs
+++ b/parser-typechecker/src/Unison/Util/Pretty.hs
@@ -27,6 +27,8 @@ module Unison.Util.Pretty (
    excerptColumn2Headed,
    warnCallout, blockedCallout, fatalCallout, okCallout,
    column2,
+   column2sep,
+   column2Header,
    column2M,
    column2UnzippedM,
    column3,
@@ -461,7 +463,15 @@ excerptColumn2 max cols = case max of
 
 column2
   :: (LL.ListLike s Char, IsString s) => [(Pretty s, Pretty s)] -> Pretty s
-column2 = lines . (group <$>) . align
+column2 = column2sep ""
+
+column2Header
+  :: Pretty ColorText -> Pretty ColorText -> [(Pretty ColorText, Pretty ColorText)] -> Pretty ColorText
+column2Header left right = column2sep "  " . ((fmap CT.hiBlack left, fmap CT.hiBlack right):)
+
+column2sep
+  :: (LL.ListLike s Char, IsString s) => Pretty s -> [(Pretty s, Pretty s)] -> Pretty s
+column2sep sep rows = lines . (group <$>) . align $ [(a, sep <> b) | (a, b) <- rows]
 
 column2M
   :: (Applicative m, LL.ListLike s Char, IsString s)

--- a/unison-core/src/Unison/LabeledDependency.hs
+++ b/unison-core/src/Unison/LabeledDependency.hs
@@ -1,6 +1,18 @@
 {-# LANGUAGE PatternSynonyms #-}
 
-module Unison.LabeledDependency (derivedTerm, derivedType, termRef, typeRef, referent, dataConstructor, effectConstructor, fold, referents, LabeledDependency) where
+module Unison.LabeledDependency 
+  ( derivedTerm
+  , derivedType
+  , termRef
+  , typeRef
+  , referent
+  , dataConstructor
+  , effectConstructor
+  , fold
+  , referents
+  , LabeledDependency
+  , partition
+  ) where
 
 import Unison.Prelude hiding (fold)
 
@@ -31,3 +43,6 @@ referents rs = Set.fromList (map referent $ toList rs)
 
 fold :: (Reference -> a) -> (Referent -> a) -> LabeledDependency -> a
 fold f g (X e) = either f g e
+
+partition :: Foldable t => t LabeledDependency -> ([Reference], [Referent])
+partition = partitionEithers . map (\(X e) -> e) . toList 

--- a/unison-core/src/Unison/Referent.hs
+++ b/unison-core/src/Unison/Referent.hs
@@ -42,6 +42,9 @@ toShortHash :: Referent -> ShortHash
 toShortHash = \case
   Ref r -> R.toShortHash r
   Con r i _ -> patternShortHash r i
+  
+toShortHashId :: Id -> ShortHash
+toShortHashId = toShortHash . fromId
 
 -- also used by HashQualified.fromPattern
 patternShortHash :: Reference -> Int -> ShortHash
@@ -81,6 +84,9 @@ toReference' :: Referent' r -> r
 toReference' = \case
   Ref' r -> r
   Con' r _i _t -> r
+  
+fromId :: Id -> Referent
+fromId = fmap R.DerivedId  
 
 toTypeReference :: Referent -> Maybe Reference
 toTypeReference = \case

--- a/unison-src/transcripts/dependents-dependencies-debugfile.md
+++ b/unison-src/transcripts/dependents-dependencies-debugfile.md
@@ -1,0 +1,38 @@
+```ucm:hide
+.> builtins.merge
+```
+
+### `debug.file`
+I can use `debug.file` to see the hashes of the last typechecked file.
+
+Given this .u file:
+```unison:hide
+type outside.A = A Nat outside.B
+type outside.B = B Int
+outside.c = 3
+outside.d = c < (p + 1)
+
+type inside.M = M outside.A
+inside.p = c
+inside.q x = x + p * p
+inside.r = d
+```
+```ucm
+.> debug.file
+```
+
+This will help me make progress in some situations when UCM is being deficient or broken.
+
+### `dependents` / `dependencies`
+But wait, there's more.  I can check the dependencies and dependents of a definition:
+```ucm
+.> add
+.> dependents q
+.> dependencies q
+.> dependencies B
+.> dependencies d
+.> dependents d
+.>
+```
+
+We don't have an index for dependents of constructors, but iirc if you ask for that, it will show you dependents of the type that provided the constructor.

--- a/unison-src/transcripts/dependents-dependencies-debugfile.output.md
+++ b/unison-src/transcripts/dependents-dependencies-debugfile.output.md
@@ -1,0 +1,93 @@
+### `debug.file`
+I can use `debug.file` to see the hashes of the last typechecked file.
+
+Given this .u file:
+```unison
+type outside.A = A Nat outside.B
+type outside.B = B Int
+outside.c = 3
+outside.d = c < (p + 1)
+
+type inside.M = M outside.A
+inside.p = c
+inside.q x = x + p * p
+inside.r = d
+```
+
+```ucm
+.> debug.file
+
+  type inside.M#4idrjau939
+  type outside.A#0n4pbd0q9u
+  type outside.B#muulibntaq
+  inside.p#fiupm7pl7o
+  inside.q#l5pndeifuh
+  inside.r#im2kiu2hmn
+  outside.c#msp7bv40rv
+  outside.d#6cdi7g1oi2
+
+```
+This will help me make progress in some situations when UCM is being deficient or broken.
+
+### `dependents` / `dependencies`
+But wait, there's more.  I can check the dependencies and dependents of a definition:
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    type inside.M
+    type outside.A
+    type outside.B
+    inside.p  : Nat
+    inside.q  : Nat -> Nat
+    inside.r  : Boolean
+    outside.c : Nat
+    outside.d : Boolean
+
+.> dependents q
+
+  #l5pndeifuh doesn't have any dependents.
+
+.> dependencies q
+
+  Dependencies of #l5pndeifuh:
+  
+    Reference     Name
+    ##Nat.*       builtin.Nat.*
+    ##Nat.+       builtin.Nat.+
+    #fiupm7pl7o   inside.p
+
+.> dependencies B
+
+  Dependencies of #muulibntaq:
+  
+    Reference   Name
+    ##Int       builtin.Int
+
+  Dependencies of #muulibntaq#0:
+  
+    Reference     Name
+    ##Int         builtin.Int
+    #muulibntaq   outside.B
+
+.> dependencies d
+
+  Dependencies of #6cdi7g1oi2:
+  
+    Reference       Name
+    ##Nat           builtin.Nat
+    ##Nat.+         builtin.Nat.+
+    ##Universal.<   builtin.Universal.<
+    #fiupm7pl7o     inside.p
+    #msp7bv40rv     outside.c
+
+.> dependents d
+
+  Dependents of #6cdi7g1oi2:
+  
+    Reference     Name
+    #im2kiu2hmn   inside.r
+
+```
+We don't have an index for dependents of constructors, but iirc if you ask for that, it will show you dependents of the type that provided the constructor.


### PR DESCRIPTION
## Overview

This PR adds three commands.

### `debug.file`
I can use `debug.file` to see the hashes of the last typechecked file.

Given this .u file:
```haskell
type outside.A = A Nat outside.B
type outside.B = B Int
outside.c = 3
outside.d = c < (p + 1)

type inside.M = M outside.A
inside.p = c
inside.q x = x + p * p
inside.r = d
```

```
.> 

  I found and typechecked these definitions in u.u. If you do an `add` or `update`, here's how your
  codebase would change:
  
    ⍟ These new definitions are ok to `add`:
    
      type inside.M
      type outside.A
      type outside.B
      inside.p  : Nat
      inside.q  : Nat -> Nat
      inside.r  : Boolean
      outside.c : Nat
      outside.d : Boolean
   
  Now evaluating any watch expressions (lines starting with `>`)... Ctrl+C cancels.

.> debug.file

  type inside.M#4idrjau939
  type outside.A#0n4pbd0q9u
  type outside.B#muulibntaq
  inside.p#fiupm7pl7o
  inside.q#l5pndeifuh
  inside.r#im2kiu2hmn
  outside.c#msp7bv40rv
  outside.d#6cdi7g1oi2
```

This will help me make progress in some situations when UCM is being deficient or broken.

### `dependents` / `dependencies`
But wait, there's more.  I can check the dependencies and dependents of a definition:
```
.> add

  ⍟ I've added these definitions:
  
    type inside.M
    type outside.A
    type outside.B
    inside.p  : Nat
    inside.q  : Nat -> Nat
    inside.r  : Boolean
    outside.c : Nat
    outside.d : Boolean

.> dependents q

  #l5pndeifuh doesn't have any dependents.

.> dependencies q

  Dependencies of #l5pndeifuh:
  
    Hash          Name
    ##Nat.*       base.Nat.*
    ##Nat.+       base.Nat.+
    #fiupm7pl7o   inside.p

.> dependencies B

  Dependencies of #muulibntaq:
  
    Hash    Name
    ##Int   base.Int


  Dependencies of #muulibntaq#0:
  
    Hash          Name
    ##Int         base.Int
    #muulibntaq   outside.B

.> dependencies d

  Dependencies of #6cdi7g1oi2:
  
    Hash            Name
    ##Nat           base.Nat
    ##Nat.+         base.Nat.+
    ##Universal.<   base.Universal.<
    #fiupm7pl7o     inside.p
    #msp7bv40rv     outside.c

.> dependents d

  Dependents of #6cdi7g1oi2:
  
    Hash          Name
    #im2kiu2hmn   inside.r

.> 
```

I guess this will close #451, which asks for dependencies _and/or_ transitive dependencies.

## Implementation notes

We don't have an index for dependents of constructors, but iirc if you ask for that, it will show you dependents of the type that provided the constructor.

Working on this reminded me that `LabeledDependency` exists, and we could probably use it in more places to clean up implementations.  `LabeledReference` would probably be a better name now.
```
-- constructor name is private, the module just exposes `fold`
newtype LabeledDependency = X (Either Reference Referent) deriving (Eq, Ord, Show)
```

I added the following function in `HandleInput.hs`, which looks similar to many others in there.  It might be the best one ever, or it might be a duplicate, we'll have to take a look when we clean up that file.
```haskell
resolveHQToLabeledDependencies 
  :: Functor m => HQ.HashQualified -> Action' m v (Set LabeledDependency)`
```

## Testing

I caught some bugs through manual testing (e.g. fixed #1399), but it would be good to add some tests in not too long, to prevent regression.  I haven't thought too much about what they'd look like, though.

## Loose ends

- It might be nice if a query name was in the output too, but I am not too worried about it.
- It might be nice to have a flag to include transitive dependencies, but I am not too worried about it.