### PR TITLE
Fix #1402: Only display watch message if there're watch expressions

### DIFF
--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -25,7 +25,7 @@ import           Control.Lens
 import qualified Control.Monad.State.Strict    as State
 import           Data.Bifunctor                (bimap, first)
 import           Data.List                     (sort, sortOn, stripPrefix)
-import           Data.List.Extra               (nubOrdOn, nubOrd)
+import           Data.List.Extra               (nubOrdOn, nubOrd, notNull)
 import qualified Data.Map                      as Map
 import qualified Data.Set                      as Set
 import qualified Data.Sequence                 as Seq
@@ -561,9 +561,10 @@ notifyUser dir o = case o of
     -- if we ever allow users to edit hashes directly.
   Typechecked sourceName ppe slurpResult uf -> do
     let fileStatusMsg = SlurpResult.pretty False ppe slurpResult
+    let containsWatchExpressions = notNull $ UF.watchComponents uf
     if UF.nonEmpty uf then do
       fileName <- renderFileName $ Text.unpack sourceName
-      pure $ P.linesNonEmpty [
+      pure $ P.linesNonEmpty ([
         if fileStatusMsg == mempty then
           P.okCallout $ fileName <> " changed."
         else if  SlurpResult.isAllDuplicates slurpResult then
@@ -584,12 +585,12 @@ notifyUser dir o = case o of
              <> "change:"
             , P.indentN 2 $ SlurpResult.pretty False ppe slurpResult
             ]
-          ,
-         " ",
-         P.wrap $ "Now evaluating any watch expressions"
-               <> "(lines starting with `>`)... "
-               <> P.group (P.hiBlack "Ctrl+C cancels.")
-        ]
+        ] ++ if containsWatchExpressions then [
+          "",
+          P.wrap $ "Now evaluating any watch expressions"
+                 <> "(lines starting with `>`)... "
+                 <> P.group (P.hiBlack "Ctrl+C cancels.")
+          ] else [])
     else if (null $ UF.watchComponents uf) then pure . P.wrap $
       "I loaded " <> P.text sourceName <> " and didn't find anything."
     else pure mempty

--- a/unison-src/transcripts/addupdatemessages.output.md
+++ b/unison-src/transcripts/addupdatemessages.output.md
@@ -22,9 +22,6 @@ type Y = Two Nat Nat
       type Y
       x : Nat
       y : Nat
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 Expected: `x` and `y`, `X`, and `Y` exist as above. UCM tells you this.
@@ -62,9 +59,6 @@ type Z = One Nat
         (also named X)
       z : Nat
         (also named x)
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 Expected: `z` is now `1`. UCM tells you that this definition is also called `x`.
@@ -103,9 +97,6 @@ type X = Three Nat Nat Nat
       x : Nat
         (The old definition is also named z. I'll update this
         name too.)
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 Expected: `x` is now `3` and `X` has constructor `Three`. UCM tells you the old definitions were also called `z` and `Z` and these names have also been updated.
@@ -147,9 +138,6 @@ type X = Two Nat Nat
         (The old definition is also named z. I'll update this
         name too.)
         (The new definition is already named y as well.)
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 Expected: `x` is now `2` and `X` is `Two`. UCM says the old definition was also named `z/Z`, and was also updated. And it says the new definition is also named `y/Y`. 

--- a/unison-src/transcripts/blocks.output.md
+++ b/unison-src/transcripts/blocks.output.md
@@ -24,7 +24,7 @@ ex thing =
     ⍟ These new definitions are ok to `add`:
     
       ex : thing -> Nat
-   
+  
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.
 
@@ -55,7 +55,7 @@ ex thing =
     ⍟ These new definitions are ok to `add`:
     
       ex : thing -> Nat
-   
+  
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.
 
@@ -88,7 +88,7 @@ ex thing =
     ⍟ These new definitions are ok to `add`:
     
       ex : (Nat ->{𝕖} Nat) ->{𝕖} Nat
-   
+  
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.
 
@@ -118,7 +118,7 @@ ex thing =
     ⍟ These new definitions are ok to `add`:
     
       ex : (Nat ->{𝕖} Nat) ->{𝕖} Nat
-   
+  
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.
 
@@ -156,9 +156,6 @@ ex n =
     
       ex    : n -> 𝕣
       sumTo : Nat -> Nat
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 The `go` function is a one-element cycle (it reference itself), and `ping` and `pong` form a two-element cycle.
@@ -183,9 +180,6 @@ ex n =
     ⍟ These new definitions are ok to `add`:
     
       ex : n -> Nat
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 Since the forward reference to `pong` appears inside `ping`.
@@ -239,9 +233,6 @@ ex n =
     ⍟ These new definitions are ok to `add`:
     
       ex : n -> 𝕣
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 Just don't try to run it as it's an infinite loop!
@@ -292,9 +283,6 @@ ex n =
     
       ability SpaceAttack
       ex : n ->{SpaceAttack} Nat
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ### Unrelated definitions not part of a cycle and are moved after the cycle
@@ -322,9 +310,6 @@ ex n =
     
       ability SpaceAttack
       ex : n ->{SpaceAttack} 𝕣
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 This is actually parsed as if you moved `zap` after the cycle it find itself a part of:
@@ -350,8 +335,5 @@ ex n =
     
       ability SpaceAttack
       ex : n ->{SpaceAttack} 𝕣
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```

--- a/unison-src/transcripts/check873.output.md
+++ b/unison-src/transcripts/check873.output.md
@@ -13,9 +13,6 @@ See [this ticket](https://github.com/unisonweb/unison/issues/873); the point bei
     ⍟ These new definitions are ok to `add`:
     
       - : Nat -> Nat -> Int
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -39,8 +36,5 @@ baz x = x - 1
     ⍟ These new definitions are ok to `add`:
     
       baz : Nat -> Int
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```

--- a/unison-src/transcripts/deleteReplacements.output.md
+++ b/unison-src/transcripts/deleteReplacements.output.md
@@ -13,9 +13,6 @@ x = 1
     ⍟ These new definitions are ok to `add`:
     
       x : ##Nat
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -40,9 +37,6 @@ x = 2
       new definition:
     
       x : ##Nat
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -84,9 +78,6 @@ type Foo = Foo
     ⍟ These new definitions are ok to `add`:
     
       type Foo
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -111,9 +102,6 @@ type Foo = Foo | Bar
       new definition:
     
       type Foo
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm

--- a/unison-src/transcripts/diff.output.md
+++ b/unison-src/transcripts/diff.output.md
@@ -636,9 +636,6 @@ a = 777
       conflicted   a   : Nat
     
       Tip: Use `help filestatus` to learn more.
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm

--- a/unison-src/transcripts/doc-formatting.output.md
+++ b/unison-src/transcripts/doc-formatting.output.md
@@ -18,9 +18,6 @@ foo n =
     ⍟ These new definitions are ok to `add`:
     
       foo : Nat -> Nat
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -48,9 +45,6 @@ escaping = [: Docs look [: like \@this \:] :]
     ⍟ These new definitions are ok to `add`:
     
       escaping : Doc
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -81,9 +75,6 @@ commented = [:
     ⍟ These new definitions are ok to `add`:
     
       commented : Doc
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -119,9 +110,6 @@ doc1 = [:   hi   :]
     ⍟ These new definitions are ok to `add`:
     
       doc1 : Doc
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -152,9 +140,6 @@ doc2 = [: hello
     ⍟ These new definitions are ok to `add`:
     
       doc2 : Doc
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -192,9 +177,6 @@ Note that because of the special treatment of the first line mentioned above, wh
     ⍟ These new definitions are ok to `add`:
     
       doc3 : Doc
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -239,9 +221,6 @@ doc4 = [: Here's another example of some paragraphs.
     ⍟ These new definitions are ok to `add`:
     
       doc4 : Doc
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -275,9 +254,6 @@ doc5 = [:   - foo
     ⍟ These new definitions are ok to `add`:
     
       doc5 : Doc
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -308,9 +284,6 @@ doc6 = [:
     ⍟ These new definitions are ok to `add`:
     
       doc6 : Doc
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -344,9 +317,6 @@ expr = foo 1
     
       empty : Doc
       expr  : Nat
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -405,9 +375,6 @@ para line lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolo
     ⍟ These new definitions are ok to `add`:
     
       test1 : Doc
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm

--- a/unison-src/transcripts/docs.output.md
+++ b/unison-src/transcripts/docs.output.md
@@ -37,9 +37,6 @@ Can link to definitions like @List.drop or @List
     ⍟ These new definitions are ok to `add`:
     
       doc1 : Doc
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 Syntax:
@@ -71,9 +68,6 @@ List.take.ex2 = take 2 [1,2,3,4,5]
     
       List.take.ex1 : [Nat]
       List.take.ex2 : [Nat]
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -115,9 +109,6 @@ docs.List.take = [:
     ⍟ These new definitions are ok to `add`:
     
       docs.List.take : Doc
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 Let's add it to the codebase, and link it to the definition:

--- a/unison-src/transcripts/find-patch.output.md
+++ b/unison-src/transcripts/find-patch.output.md
@@ -17,9 +17,6 @@ hey = "yello"
     ⍟ These new definitions are ok to `add`:
     
       hey : Text
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -50,9 +47,6 @@ hey = "hello"
       new definition:
     
       hey : Text
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 Update

--- a/unison-src/transcripts/fix-big-list-crash.output.md
+++ b/unison-src/transcripts/fix-big-list-crash.output.md
@@ -18,8 +18,5 @@ x = [(R,1005),(U,563),(R,417),(U,509),(L,237),(U,555),(R,397),(U,414),(L,490),(U
     
       unique type Direction
       x : [(Direction, Nat)]
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```

--- a/unison-src/transcripts/fix1334.output.md
+++ b/unison-src/transcripts/fix1334.output.md
@@ -34,7 +34,7 @@ h = f + 1
       f : Cat
       g : Cat
       h : Cat
-   
+  
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.
 
@@ -90,7 +90,7 @@ The value of `h` should have been updated too:
   ✅
   
   scratch.u changed.
-   
+  
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.
 

--- a/unison-src/transcripts/fix1356.output.md
+++ b/unison-src/transcripts/fix1356.output.md
@@ -16,9 +16,6 @@ x.doc = [: I am the documentation for x:]
     
       x     : Nat
       x.doc : Doc
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 Step 2: add term and documentation, link, and check the documentation
@@ -57,9 +54,6 @@ x.doc = [: I am the documentation for x, and I now look better:]
       new definition:
     
       x.doc : Doc
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 Step 4: I add it and expect to see it

--- a/unison-src/transcripts/fix849.output.md
+++ b/unison-src/transcripts/fix849.output.md
@@ -16,7 +16,7 @@ x = 42
     ⍟ These new definitions are ok to `add`:
     
       x : Nat
-   
+  
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.
 

--- a/unison-src/transcripts/fix942.output.md
+++ b/unison-src/transcripts/fix942.output.md
@@ -17,9 +17,6 @@ z = y + 2
       x : Nat
       y : Nat
       z : Nat
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -48,9 +45,6 @@ x = 7
       new definition:
     
       x : Nat
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -91,7 +85,7 @@ test> t1 = if z == 3 then [Fail "nooo!!!"] else [Ok "great"]
     ⍟ These new definitions are ok to `add`:
     
       t1 : [Result]
-   
+  
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.
 

--- a/unison-src/transcripts/fix987.output.md
+++ b/unison-src/transcripts/fix987.output.md
@@ -21,9 +21,6 @@ spaceAttack1 x =
     
       ability DeathStar
       spaceAttack1 : x ->{DeathStar} Text
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 Add it to the codebase:
@@ -55,9 +52,6 @@ spaceAttack2 x =
     ⍟ These new definitions are ok to `add`:
     
       spaceAttack2 : x ->{DeathStar} Text
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm

--- a/unison-src/transcripts/hello.output.md
+++ b/unison-src/transcripts/hello.output.md
@@ -41,9 +41,6 @@ x = 42
     ⍟ These new definitions are ok to `add`:
     
       x : Nat
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 Let's go ahead and add that to the codebase, then make sure it's there:

--- a/unison-src/transcripts/link.output.md
+++ b/unison-src/transcripts/link.output.md
@@ -20,9 +20,6 @@ coolFunction.doc = [: This is a cool function. :]
     
       coolFunction     : Nat -> Nat
       coolFunction.doc : Doc
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -72,9 +69,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
       coolFunction.license : License
       licenses.mit         : LicenseType
       toCopyrightHolder    : Author -> CopyrightHolder
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -134,9 +128,6 @@ myLibrary.h x = x + 3
       myLibrary.f : Nat -> Nat
       myLibrary.g : Nat -> Nat
       myLibrary.h : Nat -> Nat
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm

--- a/unison-src/transcripts/mergeloop.output.md
+++ b/unison-src/transcripts/mergeloop.output.md
@@ -17,9 +17,6 @@ a = 1
     ⍟ These new definitions are ok to `add`:
     
       a : ##Nat
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -45,9 +42,6 @@ b = 2
     ⍟ These new definitions are ok to `add`:
     
       b : ##Nat
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -66,9 +60,6 @@ b = 2
 
   I found and typechecked the definitions in scratch.u. This
   file has been previously added to the codebase.
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -94,9 +85,6 @@ a = 1
     ⍟ These new definitions are ok to `add`:
     
       a : ##Nat
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -116,9 +104,6 @@ b = 2
 
   I found and typechecked the definitions in scratch.u. This
   file has been previously added to the codebase.
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -15,9 +15,6 @@ x = 42
     ⍟ These new definitions are ok to `add`:
     
       x : Nat
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -64,9 +61,6 @@ y = "hello"
     ⍟ These new definitions are ok to `add`:
     
       y : Text
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -340,9 +334,6 @@ z = 99
     ⍟ These new definitions are ok to `add`:
     
       z : Nat
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -380,9 +371,6 @@ master.frobnicate n = n + 1
     
       master.frobnicate : Nat -> Nat
       master.y          : Text
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm

--- a/unison-src/transcripts/numbered-args.output.md
+++ b/unison-src/transcripts/numbered-args.output.md
@@ -25,9 +25,6 @@ corge = "corge"
       foo   : Text
       quux  : Text
       qux   : Text
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm

--- a/unison-src/transcripts/propagate.output.md
+++ b/unison-src/transcripts/propagate.output.md
@@ -21,9 +21,6 @@ fooToInt _ = +42
     
       unique type Foo
       fooToInt : Foo -> Int
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 And then we add it.
@@ -73,9 +70,6 @@ unique type Foo = Foo | Bar
       new definition:
     
       unique type Foo
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 and update the codebase to use the new type `Foo`...
@@ -122,9 +116,6 @@ otherTerm y = someTerm y
     
       otherTerm : Optional baz -> Optional baz
       someTerm  : Optional foo -> Optional foo
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 Add that to the codebase:
@@ -159,9 +150,6 @@ someTerm _ = None
       new definition:
     
       someTerm : Optional x -> Optional x
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 Update...
@@ -232,9 +220,6 @@ otherTerm y = someTerm y
     
       otherTerm : Optional baz -> Optional baz
       someTerm  : Optional foo -> Optional foo
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 We'll make two copies of this namespace.
@@ -272,9 +257,6 @@ someTerm _ = None
     ⍟ These new definitions are ok to `add`:
     
       someTerm : Optional x -> Optional x
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ... in one of the namespaces...

--- a/unison-src/transcripts/reflog.output.md
+++ b/unison-src/transcripts/reflog.output.md
@@ -14,9 +14,6 @@ x = 1
     ⍟ These new definitions are ok to `add`:
     
       x : Nat
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -40,9 +37,6 @@ y = 2
     ⍟ These new definitions are ok to `add`:
     
       y : Nat
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm

--- a/unison-src/transcripts/resolve.output.md
+++ b/unison-src/transcripts/resolve.output.md
@@ -25,9 +25,6 @@ a.foo = 42
     ⍟ These new definitions are ok to `add`:
     
       a.foo : Nat
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -74,9 +71,6 @@ foo = 43
       new definition:
     
       foo : Nat
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm
@@ -107,9 +101,6 @@ foo = 44
       new definition:
     
       foo : Nat
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm

--- a/unison-src/transcripts/todo-bug-builtins.output.md
+++ b/unison-src/transcripts/todo-bug-builtins.output.md
@@ -10,7 +10,7 @@
   ✅
   
   scratch.u changed.
-   
+  
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.
 
@@ -35,7 +35,7 @@
   ✅
   
   scratch.u changed.
-   
+  
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.
 
@@ -66,9 +66,6 @@ complicatedMathStuff x = todo "Come back and to something with x here"
     ⍟ These new definitions are ok to `add`:
     
       complicatedMathStuff : x -> 𝕣
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ## Bug
@@ -88,8 +85,5 @@ test = match true with
     ⍟ These new definitions are ok to `add`:
     
       test : Text
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```

--- a/unison-src/transcripts/transcript-parser-commands.output.md
+++ b/unison-src/transcripts/transcript-parser-commands.output.md
@@ -15,9 +15,6 @@ x = 1
     ⍟ These new definitions are ok to `add`:
     
       x : Nat
-   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
 
 ```
 ```ucm


### PR DESCRIPTION
Closes #1402  and only displays a message about watch expressions if there are any.