### PR TITLE
Add a transcript testing the ambiguous metadata error

### DIFF
--- a/unison-src/transcripts/ambiguous-metadata.md
+++ b/unison-src/transcripts/ambiguous-metadata.md
@@ -1,0 +1,17 @@
+
+## An example scenario that surfaces an 'ambiguous metadata' error.
+
+```unison:hide
+foo.doc = [: a :] 
+boo.doc = [: b :]
+x = 1
+```
+
+```ucm:hide:all
+.> add
+```
+
+```ucm:error
+.> merge foo boo
+.> link boo.doc x
+```

--- a/unison-src/transcripts/ambiguous-metadata.output.md
+++ b/unison-src/transcripts/ambiguous-metadata.output.md
@@ -1,0 +1,40 @@
+
+## An example scenario that surfaces an 'ambiguous metadata' error.
+
+```unison
+foo.doc = [: a :] 
+boo.doc = [: b :]
+x = 1
+```
+
+```ucm
+.> merge foo boo
+
+  Here's what's changed in boo after the merge:
+  
+  New name conflicts:
+  
+    1. doc#tj3gfqdnje : #v00j3buk6m
+       ↓
+    2. ┌ doc#d4ormokpf9 : #v00j3buk6m
+    3. └ doc#tj3gfqdnje : #v00j3buk6m
+  
+  Tip: You can use `todo` to see if this generated any work to
+       do in this namespace and `test` to run the tests. Or you
+       can use `undo` or `reflog` to undo the results of this
+       merge.
+
+.> link boo.doc x
+
+  ⚠️
+  
+  I'm not sure which metadata value you're referring to since
+  there are multiple matches:
+  
+    foo.doc
+    boo.doc#tj3gfqdnje
+  
+  Tip: Try again and supply one of the above definitions
+       explicitly.
+
+```


### PR DESCRIPTION
## Overview

There is currently no testing of the ambiguous metadata error message, meaning a contributor might not be aware of when/where/how to trigger and test.

This PR adds a transcript that shows how to trigger the error 

## Implementation notes

With help from @pchiusano and @aryairani over slack

## Interesting/controversial decisions

N/A

## Test coverage

This PR adds an integration test.

## Loose ends

N/A
