### PR TITLE
use -O2 by default?  can always use `stack build --fast` for `-O0`

### DIFF
--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -21,15 +21,6 @@ source-repository head
   type: git
   location: git://github.com/unisonweb/unison.git
 
--- `cabal install -foptimized` enables optimizations
-flag optimized
-  manual: True
-  default: False
-
-flag quiet
-  manual: True
-  default: False
-
 library
   hs-source-dirs: src
 
@@ -198,7 +189,7 @@ library
     util,
     vector
 
-  ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
+  ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
   default-extensions:
     ApplicativeDo,
     DeriveFunctor,
@@ -213,12 +204,6 @@ library
     TupleSections
     TypeApplications
     -- ViewPatterns
-
-  if flag(optimized)
-    ghc-options: -funbox-strict-fields
-
-  if flag(quiet)
-    ghc-options: -v0
 
 executable unison
   main-is: Main.hs

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,3 @@
-flags: {}
-
 allow-newer: true # async package has needlessly strict upper bound
 
 allow-different-user: true
@@ -27,4 +25,4 @@ extra-deps:
 
 ghc-options:
  # All packages
- "$locals": -Werror -Wno-type-defaults #-freverse-errors
+ "$locals": -Werror -Wno-type-defaults -O2 #-freverse-errors

--- a/unison-core/unison-core.cabal
+++ b/unison-core/unison-core.cabal
@@ -21,15 +21,6 @@ source-repository head
   type: git
   location: git://github.com/unisonweb/unison.git
 
--- `cabal install -foptimized` enables optimizations
-flag optimized
-  manual: True
-  default: False
-
-flag quiet
-  manual: True
-  default: False
-
 library
   hs-source-dirs: src
 
@@ -88,7 +79,7 @@ library
     util,
     vector
 
-  ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
+  ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
 
   default-extensions:
     DeriveFunctor
@@ -98,9 +89,3 @@ library
     ScopedTypeVariables
     TupleSections
     TypeSynonymInstances
-
-  if flag(optimized)
-    ghc-options: -funbox-strict-fields
-
-  if flag(quiet)
-    ghc-options: -v0

--- a/yaks/easytest/easytest.cabal
+++ b/yaks/easytest/easytest.cabal
@@ -20,15 +20,6 @@ source-repository head
   type: git
   location: git://github.com/unisonweb/unison.git
 
--- `cabal install -foptimized` enables optimizations
-flag optimized
-  manual: True
-  default: False
-
-flag quiet
-  manual: True
-  default: False
-
 library
   hs-source-dirs: src
 
@@ -45,12 +36,6 @@ library
     random                    >= 1.1
 
   ghc-options: -Wall -fno-warn-name-shadowing
-
-  if flag(optimized)
-    ghc-options: -funbox-strict-fields -O2
-
-  if flag(quiet)
-    ghc-options: -v0
 
 -- Preferred way to run EasyTest-based test suite
 executable runtests


### PR DESCRIPTION
I guess I should time the build each way, and put the result here.