### PR TITLE
Swaps the arguments and output sequence of ListNames

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -927,7 +927,7 @@ loop = do
             types' :: Set (Reference, Set HQ'.HashQualified)
             types' = (`Set.map` Names.typeReferences filtered) $
                         \r -> (r, Names3.typeName hqLength r printNames)
-        respond $ ListNames hqLength (toList terms') (toList types')
+        respond $ ListNames hqLength (toList types') (toList terms') 
 --          let (p, hq) = p0
 --              namePortion = HQ'.toName hq
 --          case hq of

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -131,8 +131,8 @@ data Output v
   | DeleteEverythingConfirmation
   | DeletedEverything
   | ListNames Int -- hq length to print References
-              [(Referent, Set HQ'.HashQualified)] -- term match, term names
               [(Reference, Set HQ'.HashQualified)] -- type match, type names
+              [(Referent, Set HQ'.HashQualified)] -- term match, term names
   -- list of all the definitions within this branch
   | ListOfDefinitions PPE.PrettyPrintEnv ListDetailed [SearchResult' v Ann]
   | ListOfLinks PPE.PrettyPrintEnv [(HQ.HashQualified, Reference, Maybe (Type v Ann))]
@@ -287,7 +287,7 @@ isFailure o = case o of
   CantDelete{} -> True
   DeleteEverythingConfirmation -> False
   DeletedEverything -> False
-  ListNames _ tms tys -> null tms && null tys
+  ListNames _ tys tms -> null tms && null tys
   ListOfLinks _ ds -> null ds
   ListOfDefinitions _ _ ds -> null ds
   ListOfPatches s -> Set.null s

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -454,8 +454,8 @@ notifyUser dir o = case o of
      listOfLinks ppe [ (name,tm) | (name,_ref,tm) <- results ]
   ListNames _len [] [] -> pure . P.callout "😶" $
     P.wrap "I couldn't find anything by that name."
-  ListNames len terms types -> pure . P.sepNonEmpty "\n\n" $ [
-    formatTerms terms, formatTypes types ]
+  ListNames len types terms -> pure . P.sepNonEmpty "\n\n" $ [
+    formatTypes types, formatTerms terms ]
     where
     formatTerms tms =
       P.lines . P.nonEmpty $ P.plural tms (P.blue "Term") : (go <$> tms) where

--- a/unison-src/transcripts/names.md
+++ b/unison-src/transcripts/names.md
@@ -1,0 +1,20 @@
+ Example uses of the `names` command and output
+```ucm:hide
+.> builtins.mergeio
+```
+
+```unison:hide
+type IntTriple = IntTriple (Int, Int, Int)
+intTriple = IntTriple(+1, +1, +1)
+```
+
+```ucm:hide
+.> add
+```
+
+```ucm
+.> alias.type IntTriple namespc.another.TripleInt
+.> alias.term intTriple namespc.another.tripleInt
+.> names IntTriple
+.> names intTriple
+```

--- a/unison-src/transcripts/names.md
+++ b/unison-src/transcripts/names.md
@@ -1,6 +1,6 @@
  Example uses of the `names` command and output
 ```ucm:hide
-.> builtins.mergeio
+.> alias.type ##Int .builtins.Int
 ```
 
 ```unison:hide

--- a/unison-src/transcripts/names.output.md
+++ b/unison-src/transcripts/names.output.md
@@ -1,0 +1,32 @@
+ Example uses of the `names` command and output
+```unison
+type IntTriple = IntTriple (Int, Int, Int)
+intTriple = IntTriple(+1, +1, +1)
+```
+
+```ucm
+.> alias.type IntTriple namespc.another.TripleInt
+
+  Done.
+
+.> alias.term intTriple namespc.another.tripleInt
+
+  Done.
+
+.> names IntTriple
+
+  Type
+  Hash:  #170h4ackk7
+  Names: IntTriple namespc.another.TripleInt
+  
+  Term
+  Hash:   #170h4ackk7#0
+  Names:  IntTriple.IntTriple
+
+.> names intTriple
+
+  Term
+  Hash:   #uif14vd2oj
+  Names:  intTriple namespc.another.tripleInt
+
+```


### PR DESCRIPTION
## Overview

Before: `names` shows terms before types
After: `names` shows types first, then terms

This PR aims to close #1394

## Implementation notes

Swaps the constructor arguments, and swaps the sequence of content being serialised.

## Interesting/controversial decisions

Changing the sequence of arguments not strictly needed; but the constructor fits in in a more uniform manner with the rest of the constructors.

## Test coverage

Transcript added, further future changes can thus be tracked.

## Loose ends

N/A
