### PR TITLE
`Bytes` values should decompile to `Bytes.fromList`, not `Bytes.fromSequence`

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/IR.hs
+++ b/parser-typechecker/src/Unison/Runtime/IR.hs
@@ -603,7 +603,7 @@ decompileImpl v = case v of
   B b -> pure $ Term.boolean () b
   T t -> pure $ Term.text () t
   C c -> pure $ Term.char () c
-  Bs bs -> pure $ Term.builtin() "Bytes.fromSequence" `Term.apps'` [bsv] where
+  Bs bs -> pure $ Term.builtin() "Bytes.fromList" `Term.apps'` [bsv] where
     bsv = Term.seq'() . Sequence.fromList $
             [ Term.nat() (fromIntegral w8) | w8 <- Bytes.toWord8s bs ]
   Lam _ f _ -> decompileUnderapplied f

--- a/unison-src/transcripts/bytesFromList.md
+++ b/unison-src/transcripts/bytesFromList.md
@@ -1,0 +1,11 @@
+
+```ucm:hide
+.> builtins.merge
+```
+
+This should render as `Bytes.fromList [1,2,3,4]`, not `##Bytes.fromSequence [1,2,3,4]`:
+
+```unison
+> Bytes.fromList [1,2,3,4]
+```
+

--- a/unison-src/transcripts/bytesFromList.output.md
+++ b/unison-src/transcripts/bytesFromList.output.md
@@ -1,0 +1,21 @@
+
+This should render as `Bytes.fromList [1,2,3,4]`, not `##Bytes.fromSequence [1,2,3,4]`:
+
+```unison
+> Bytes.fromList [1,2,3,4]
+```
+
+```ucm
+
+  ✅
+  
+  scratch.u changed.
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    1 | > Bytes.fromList [1,2,3,4]
+          ⧩
+          fromList [1, 2, 3, 4]
+
+```


### PR DESCRIPTION
The builtin is called `Bytes.fromList`, but due to a typo, the string `Bytes.fromSequence` was used when decompiling (and `Bytes.fromSequence` is not a builtin that exists). It now decompiles properly and to confirm I added a transcript which previously gave wacky results.

## Controversial decisions

I considered consolidating all the builtin string names, declaring Haskell values for each, to avoid this sort of thing. But didn't do that yet, partially due to lack of time and also because I think new runtime integration would be a better time to do this sort of thing.