### PR TITLE
Suffixied `update` output

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1464,11 +1464,11 @@ loop = do
                , pure . doSlurpAdds (Slurp.updates sr <> Slurp.adds sr) uf)
               ,( Path.unabsolute p, updatePatches )]
             eval . AddDefsToCodebase . filterBySlurpResult sr $ uf
-          ppe <- prettyPrintEnv =<<
+          ppe <- prettyPrintEnvDecl =<<
             makeShadowedPrintNamesFromLabeled
               (UF.termSignatureExternalLabeledDependencies uf)
               (UF.typecheckedToNames0 uf)
-          respond $ SlurpOutput input ppe sr
+          respond $ SlurpOutput input (PPE.suffixifiedPPE ppe) sr
           -- propagatePatch prints TodoOutput
           void $ propagatePatch inputDescription (updatePatch ye'ol'Patch) currentPath'
 

--- a/unison-src/transcripts/addupdatemessages.output.md
+++ b/unison-src/transcripts/addupdatemessages.output.md
@@ -109,7 +109,7 @@ Expected: `x` is now `3` and `X` has constructor `Three`. UCM tells you the old 
     type X
       (The old definition was also named Z. I updated this name
       too.)
-    x : .builtin.Nat
+    x : Nat
       (The old definition was also named z. I updated this name
       too.)
 
@@ -151,7 +151,7 @@ Expected: `x` is now `2` and `X` is `Two`. UCM says the old definition was also 
       (The old definition was also named Z. I updated this name
       too.)
       (The new definition is already named Y as well.)
-    x : .builtin.Nat
+    x : Nat
       (The old definition was also named z. I updated this name
       too.)
       (The new definition is already named y as well.)

--- a/unison-src/transcripts/diff.output.md
+++ b/unison-src/transcripts/diff.output.md
@@ -201,14 +201,14 @@ unique type Y a b = Y a b
   ⍟ I've added these definitions:
   
     unique type Y a b
-    d : .builtin.Nat
-    e : .builtin.Nat
-    f : .builtin.Nat
+    d : Nat
+    e : Nat
+    f : Nat
   
   ⍟ I've updated these names to your new definition:
   
-    b        : .builtin.Text
-    fromJust : .builtin.Nat
+    b        : Text
+    fromJust : Nat
       (The old definition was also named fromJust'. I updated
       this name too.)
 
@@ -468,7 +468,7 @@ bdependent = "banana"
 
   ⍟ I've updated these names to your new definition:
   
-    bdependent : .builtin.Text
+    bdependent : Text
 
 .> diff.namespace ns2 ns3
 
@@ -523,7 +523,7 @@ a = 444
 
   ⍟ I've updated these names to your new definition:
   
-    a : .builtin.Nat
+    a : Nat
 
 ```
 ```unison
@@ -535,7 +535,7 @@ a = 555
 
   ⍟ I've updated these names to your new definition:
   
-    a : .builtin.Nat
+    a : Nat
 
 .> merge nsy nsw
 
@@ -644,7 +644,7 @@ a = 777
   x These definitions failed:
   
     Reason
-    conflicted   a   : .builtin.Nat
+    conflicted   a   : Nat
   
     Tip: Use `help filestatus` to learn more.
 

--- a/unison-src/transcripts/find-patch.output.md
+++ b/unison-src/transcripts/find-patch.output.md
@@ -56,7 +56,7 @@ Update
 
   ⍟ I've updated these names to your new definition:
   
-    hey : builtin.Text
+    hey : Text
 
 .> find.patch
 

--- a/unison-src/transcripts/fix1356.output.md
+++ b/unison-src/transcripts/fix1356.output.md
@@ -62,7 +62,7 @@ Step 4: I add it and expect to see it
 
   ⍟ I've updated these names to your new definition:
   
-    x.doc : builtin.Doc
+    x.doc : Doc
 
 .> docs x
 

--- a/unison-src/transcripts/fix942.output.md
+++ b/unison-src/transcripts/fix942.output.md
@@ -52,7 +52,7 @@ x = 7
 
   ⍟ I've updated these names to your new definition:
   
-    x : builtin.Nat
+    x : Nat
 
 .> view x y z
 

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -288,11 +288,11 @@ master.frobnicate n = n + 1
 
   ⍟ I've added these definitions:
   
-    master.frobnicate : builtin.Nat -> builtin.Nat
+    master.frobnicate : Nat -> Nat
   
   ⍟ I've updated these names to your new definition:
   
-    master.y : builtin.Text
+    master.y : Text
       (The old definition was also named feature2.y. I updated
       this name too.)
 

--- a/unison-src/transcripts/propagate.output.md
+++ b/unison-src/transcripts/propagate.output.md
@@ -159,7 +159,7 @@ Update...
 
   ⍟ I've updated these names to your new definition:
   
-    someTerm : .builtin.Optional x -> .builtin.Optional x
+    someTerm : Optional x -> Optional x
 
 ```
 Now the type of `someTerm` should be `Optional x -> Optional x` and the
@@ -266,7 +266,7 @@ someTerm _ = None
 
   ⍟ I've updated these names to your new definition:
   
-    someTerm : .builtin.Optional x -> .builtin.Optional x
+    someTerm : Optional x -> Optional x
 
 ```
 The other namespace should be left alone.

--- a/unison-src/transcripts/resolve.output.md
+++ b/unison-src/transcripts/resolve.output.md
@@ -78,7 +78,7 @@ foo = 43
 
   ⍟ I've updated these names to your new definition:
   
-    foo : .builtin.Nat
+    foo : Nat
 
 ```
 And make a different change in the `b` namespace:
@@ -108,7 +108,7 @@ foo = 44
 
   ⍟ I've updated these names to your new definition:
   
-    foo : .builtin.Nat
+    foo : Nat
 
 ```
 The `a` and `b` namespaces now each contain a patch named `patch`. We can view these:


### PR DESCRIPTION
## Overview

Before: The output of `update` is the the absolute namespace of the type
After: The output of `update` is suffixied and aligns with `add/add.preview/update.preview`.

fix #1273 fix #1264 

## Implementation notes

Reuses the same logic as the other commands for alignment

## Interesting/controversial decisions

N/A

## Test coverage

Via existing transcripts.

## Loose ends

N/A
