### PR TITLE
`todo` and `pull` tab completion crashes

### DIFF
--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -95,7 +95,7 @@ todo :: InputPattern
 todo = InputPattern
   "todo"
   []
-  [(Optional, patchArg), (Optional, pathArg)]
+  [(Required, patchArg), (Optional, pathArg)]
   (P.wrapColumn2
     [ ( makeExample' todo
       , "lists the refactor work remaining in the default patch for the current"

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -686,7 +686,7 @@ pull :: InputPattern
 pull = InputPattern
   "pull"
   []
-  [(Optional, gitUrlArg), (Optional, pathArg)]
+  [(Required, gitUrlArg), (Optional, pathArg)]
   (P.lines
     [ P.wrap
       "The `pull` command merges a remote namespace into a local namespace."


### PR DESCRIPTION
## Overview

Before: When using `todo` and `pull` an attempt to auto complete the second argument crashes `ucm`.
After: `todo` and `pull` work as expected. 

fix #1445 

## Implementation notes

Updates the first argument in both cases to `Requred`.
A quick scan seems to show that these are the last 2 cases where this was happening.

## Interesting/controversial decisions

 N/A

## Test coverage

Manual

Before:
![Screenshot from 2020-04-20 23-00-38](https://user-images.githubusercontent.com/22328152/79804924-edea3300-835c-11ea-89ce-91c652af9511.png)

![Screenshot from 2020-04-20 23-07-12](https://user-images.githubusercontent.com/22328152/79804935-f2165080-835c-11ea-99b4-658b213e8509.png)

After:
![Screenshot from 2020-04-20 23-13-04](https://user-images.githubusercontent.com/22328152/79804944-f7739b00-835c-11ea-87dd-b4454015f25c.png)
![Screenshot from 2020-04-20 23-13-09](https://user-images.githubusercontent.com/22328152/79804956-fe021280-835c-11ea-8f48-73e70bf1fa10.png)


## Loose ends

N/A
