### PR TITLE
Fix `copy.patch` so it actually copies instead of moving.

### DIFF
--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -604,13 +604,19 @@ movePatch src dest = first fromString $ do
   dest <- Path.parseSplit' Path.wordyNameSegment dest
   pure $ Input.MovePatchI src dest
 
+copyPatch' :: String -> String -> Either (P.Pretty CT.ColorText) Input
+copyPatch' src dest = first fromString $ do
+  src <- Path.parseSplit' Path.wordyNameSegment src
+  dest <- Path.parseSplit' Path.wordyNameSegment dest
+  pure $ Input.CopyPatchI src dest
+
 copyPatch :: InputPattern
 copyPatch = InputPattern "copy.patch"
    []
    [(Required, patchArg), (Required, newNameArg)]
-   "`copy.patch foo bar` copies the patch `bar` to `foo`."
+   "`copy.patch foo bar` copies the patch `foo` to `bar`."
     (\case
-      [src, dest] -> movePatch src dest
+      [src, dest] -> copyPatch' src dest
       _ -> Left (I.help copyPatch)
     )
 
@@ -618,7 +624,7 @@ renamePatch :: InputPattern
 renamePatch = InputPattern "move.patch"
    ["rename.patch"]
    [(Required, patchArg), (Required, newNameArg)]
-   "`move.patch foo bar` renames the patch `bar` to `foo`."
+   "`move.patch foo bar` renames the patch `foo` to `bar`."
     (\case
       [src, dest] -> movePatch src dest
       _ -> Left (I.help renamePatch)
@@ -1212,12 +1218,12 @@ debugBranchHistory = InputPattern "debug.history" []
   [(Optional, noCompletions)]
   "Dump codebase history, compatible with bit-booster.com/graph.html"
   (const $ Right Input.DebugBranchHistoryI)
-  
+
 debugFileHashes :: InputPattern
 debugFileHashes = InputPattern "debug.file" [] []
   "View details about the most recent succesfully typechecked file."
   (const $ Right Input.DebugTypecheckedUnisonFileI)
-   
+
 test :: InputPattern
 test = InputPattern "test" [] []
     "`test` runs unit tests for the current branch."

--- a/unison-src/transcripts/copy-patch.md
+++ b/unison-src/transcripts/copy-patch.md
@@ -1,0 +1,39 @@
+# Test that copying a patch works as expected
+
+```unison
+x = 1
+```
+
+```ucm
+.> add
+```
+
+Change the definition of `x` so something goes in our patch:
+
+```unison
+x = 2
+```
+
+```ucm
+.> update foo.patch
+```
+
+Copy the patch and make sure it's still there.
+
+```ucm
+.> copy.patch foo.patch bar.patch
+.> view.patch foo.patch
+.> view.patch bar.patch
+```
+
+Now move the patch.
+
+```ucm
+.> move.patch foo.patch qux.patch
+```
+
+The moved patch should be gone.
+
+```ucm
+.> view.patch foo.patch
+```

--- a/unison-src/transcripts/copy-patch.output.md
+++ b/unison-src/transcripts/copy-patch.output.md
@@ -1,0 +1,91 @@
+# Test that copying a patch works as expected
+
+```unison
+x = 1
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      x : ##Nat
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    x : ##Nat
+
+```
+Change the definition of `x` so something goes in our patch:
+
+```unison
+x = 2
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      x : ##Nat
+
+```
+```ucm
+.> update foo.patch
+
+  ⍟ I've updated these names to your new definition:
+  
+    x : ##Nat
+
+```
+Copy the patch and make sure it's still there.
+
+```ucm
+.> copy.patch foo.patch bar.patch
+
+  Done.
+
+.> view.patch foo.patch
+
+  Edited Terms: x#jk19sm5bf8 -> x
+  
+  Tip: To remove entries from a patch, use
+       delete.term-replacement or delete.type-replacement, as
+       appropriate.
+
+.> view.patch bar.patch
+
+  Edited Terms: x#jk19sm5bf8 -> x
+  
+  Tip: To remove entries from a patch, use
+       delete.term-replacement or delete.type-replacement, as
+       appropriate.
+
+```
+Now move the patch.
+
+```ucm
+.> move.patch foo.patch qux.patch
+
+  Done.
+
+```
+The moved patch should be gone.
+
+```ucm
+.> view.patch foo.patch
+
+  This patch is empty.
+
+```


### PR DESCRIPTION
Also switches the argument order in `help` for both `copy.patch` and `move.patch` to match the order in which these commands actually take their arguments.
