### PR TITLE
make initial pull tip `git describe`-specific

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/VersionParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/VersionParser.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Unison.Codebase.Editor.VersionParser where
+
+import Text.Megaparsec
+import Unison.Codebase.Editor.RemoteRepo
+import Text.Megaparsec.Char
+import Data.Functor (($>))
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Unison.Codebase.Path as Path
+import Data.Void (Void)
+
+-- |"release/M1j.2" -> "releases._M1j"
+--  "devel/*" -> "trunk"
+defaultBaseLib :: Parsec Void Text RemoteNamespace
+defaultBaseLib = fmap makeNS $ devel <|> release
+  where
+  devel, release, version :: Parsec Void Text Text
+  devel = "devel/" *> many anyChar *> eof $> "trunk"
+  release = fmap ("releases._" <>) $ "release/" *> version <* eof
+  version = fmap Text.pack $
+              try (someTill anyChar "." <* many anyChar) <|> many anyChar
+  makeNS :: Text -> RemoteNamespace
+  makeNS t = ( GitRepo "https://github.com/unisonweb/base" Nothing
+             , Nothing
+             , Path.fromText t)

--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -328,6 +328,11 @@ instance Show Path where
 toText :: Path -> Text
 toText (Path nss) = intercalateMap "." NameSegment.toText nss
 
+fromText :: Text -> Path
+fromText = \case
+  "" -> empty
+  t -> fromList $ NameSegment <$> Text.splitOn "." t
+
 toText' :: Path' -> Text
 toText' = \case
   Path' (Left (Absolute path)) -> Text.cons '.' (toText path)

--- a/parser-typechecker/tests/Suite.hs
+++ b/parser-typechecker/tests/Suite.hs
@@ -25,6 +25,7 @@ import qualified Unison.Test.Typechecker.TypeError as TypeError
 import qualified Unison.Test.UnisonSources as UnisonSources
 import qualified Unison.Test.Util.Bytes as Bytes
 import qualified Unison.Test.Var as Var
+import qualified Unison.Test.VersionParser as VersionParser
 import qualified Unison.Test.Codebase as Codebase
 import qualified Unison.Test.Codebase.FileCodebase as FileCodebase
 import qualified Unison.Test.UriParser as UriParser
@@ -58,6 +59,7 @@ test = tests
   , Context.test
   , Git.test
   , Name.test
+  , VersionParser.test
  ]
 
 main :: IO ()

--- a/parser-typechecker/tests/Unison/Test/VersionParser.hs
+++ b/parser-typechecker/tests/Unison/Test/VersionParser.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Unison.Test.VersionParser where
+
+import EasyTest
+import Data.Text
+import Unison.Codebase.Editor.VersionParser
+import qualified Unison.Codebase.Path as Path
+import Control.Error.Safe (rightMay)
+import Unison.Codebase.Editor.RemoteRepo
+import Text.Megaparsec
+
+test :: Test ()
+test = scope "versionparser" . tests . fmap makeTest $
+  [ ("release/M1j", "releases._M1j")
+  , ("release/M1j.2", "releases._M1j")
+  , ("devel/M1k", "trunk")
+  ]
+
+makeTest :: (Text, Text) -> Test ()
+makeTest (version, path) =
+  scope (unpack version) $ expectEqual
+    (rightMay $ runParser defaultBaseLib "versionparser" version)
+    (Just
+      ( GitRepo "https://github.com/unisonweb/base" Nothing
+      , Nothing
+      , Path.fromText path ))

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -60,6 +60,7 @@ library
     Unison.Codebase.Editor.SlurpComponent
     Unison.Codebase.Editor.TodoOutput
     Unison.Codebase.Editor.UriParser
+    Unison.Codebase.Editor.VersionParser
     Unison.Codebase.FileCodebase
     Unison.Codebase.FileCodebase.Common
     Unison.Codebase.FileCodebase.Reserialize
@@ -236,8 +237,10 @@ executable unison
     base,
     containers,
     directory,
+    errors,
     filepath,
     fsutils,
+    megaparsec,
     safe,
     shellmet,
     template-haskell,
@@ -291,6 +294,7 @@ executable tests
     Unison.Test.UriParser
     Unison.Test.Util.Bytes
     Unison.Test.Var
+    Unison.Test.VersionParser
     Unison.Core.Test.Name
 
   build-depends:


### PR DESCRIPTION
## Overview

### Before:

![image](https://user-images.githubusercontent.com/538571/80279826-ed8bc800-86cd-11ea-98c7-ec428832ac70.png)

### After:

![image](https://user-images.githubusercontent.com/538571/80279735-6dfdf900-86cd-11ea-9764-6875ebf9aa38.png)

![image](https://user-images.githubusercontent.com/538571/80279781-a9002c80-86cd-11ea-9807-d17d8c0fab79.png)

## Implementation notes

Adds `VersionParser.hs` which parses a `git describe` string (like the one we use in `ucm version`) to a `RepoNamespace`.

`Main.hs` calls this parser; if it succeeds, the resulting `RepoNamespace` is used in the pull tip; otherwise none is shown.

For `devel/` tags (I'm planning to add these on `master` corresponding to releases), it returns `.trunk` for base.

## Test coverage

EasyTest

## Loose ends

This exercise makes me want to structure the tags, build settings, and Azure release process differently; so there can just be a single tag kicking off a release (instead of 2), and Azure will still apply the right optimization flags.