### PR TITLE
fix  Nat.complement and Int.complement builtins

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -238,7 +238,7 @@ builtinsSrc =
   , B "Int.and" $ int --> int --> int
   , B "Int.or" $ int --> int --> int
   , B "Int.xor" $ int --> int --> int
-  , B "Int.complement" $ int --> int --> int
+  , B "Int.complement" $ int --> int
   , B "Int.increment" $ int --> int
   , B "Int.isEven" $ int --> boolean
   , B "Int.isOdd" $ int --> boolean
@@ -267,7 +267,7 @@ builtinsSrc =
   , B "Nat.and" $ nat --> nat --> nat
   , B "Nat.or" $ nat --> nat --> nat
   , B "Nat.xor" $ nat --> nat --> nat
-  , B "Nat.complement" $ nat --> nat --> nat
+  , B "Nat.complement" $ nat --> nat
   , B "Nat.drop" $ nat --> nat --> nat
   , B "Nat.fromText" $ text --> optional nat
   , B "Nat.increment" $ nat --> nat

--- a/unison-src/transcripts/alias-many.output.md
+++ b/unison-src/transcripts/alias-many.output.md
@@ -84,7 +84,7 @@ Let's try it!
   64.  Int.- : Int -> Int -> Int
   65.  Int./ : Int -> Int -> Int
   66.  Int.and : Int -> Int -> Int
-  67.  Int.complement : Int -> Int -> Int
+  67.  Int.complement : Int -> Int
   68.  Int.eq : Int -> Int -> Boolean
   69.  Int.fromText : Text -> Optional Int
   70.  Int.gt : Int -> Int -> Boolean
@@ -128,7 +128,7 @@ Let's try it!
   108. Nat.+ : Nat -> Nat -> Nat
   109. Nat./ : Nat -> Nat -> Nat
   110. Nat.and : Nat -> Nat -> Nat
-  111. Nat.complement : Nat -> Nat -> Nat
+  111. Nat.complement : Nat -> Nat
   112. Nat.drop : Nat -> Nat -> Nat
   113. Nat.eq : Nat -> Nat -> Boolean
   114. Nat.fromText : Text -> Optional Nat


### PR DESCRIPTION
## Overview

The builtin `Nat.complement` was being treated as if it had signature `Nat -> Nat -> Nat` for typechecking purposes, when it should be `Nat -> Nat`.  Similarly `Int.complement`.

## Implementation notes

2 line fix to Builtin.hs.

## Interesting/controversial decisions

None.  

## Test coverage

Sometime soon I'll PR adding some stuff to base that will depend on these, so we should be OK.  

## Loose ends

Nothing.