### PR TITLE
Add Configurator as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,4 @@
 	path = yaks/configurator
 	url = https://github.com/unisonweb/configurator.git
 	branch = master
+	ignore = untracked

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = yaks/haskeline
 	url = https://github.com/aryairani/haskeline.git
 	branch = topic/align-ansi-completions
+[submodule "yaks/configurator"]
+	path = yaks/configurator
+	url = https://github.com/unisonweb/configurator.git
+	branch = master

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,6 +7,7 @@ allow-different-user: true
 packages:
 - yaks/easytest
 - yaks/haskeline
+- yaks/configurator
 - parser-typechecker
 - unison-core
 


### PR DESCRIPTION
This adds a submodule for `Data.Configurator` which points to [our own fork](https://github.com/unisonweb/configurator) of that project.

I've added support for underscores at the beginning of identifiers in our fork, which for no good reason was disallowed by Configurator's parser.

Fixes #1467 

