### PR TITLE
Fix slowness on viewing docs

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Causal.hs
+++ b/parser-typechecker/src/Unison/Codebase/Causal.hs
@@ -339,25 +339,39 @@ unsafeMapHashPreserving f c = case c of
   Cons h e (ht, tl) -> Cons h (f e) (ht, unsafeMapHashPreserving f <$> tl)
   Merge h e tls -> Merge h (f e) $ Map.map (fmap $ unsafeMapHashPreserving f) tls
 
+data FoldHistoryResult a = Satisfied a | Unsatisfied a deriving (Eq,Ord,Show)
+
 -- foldHistoryUntil some condition on the accumulator is met,
 -- attempting to work backwards fairly through merge nodes
 -- (rather than following one back all the way to its root before working
 -- through others).  Returns Unsatisfied if the condition was never satisfied,
 -- otherwise Satisfied.
-data FoldHistoryResult a = Satisfied a | Unsatisfied a deriving (Eq,Ord,Show)
-foldHistoryUntil :: forall m h e a. (Monad m) => --(Show a, Show e) =>
-  (a -> e -> (a, Bool)) -> a -> Causal m h e -> m (FoldHistoryResult a)
+foldHistoryUntil
+  :: forall m h e a
+   . (Monad m)
+  => (a -> e -> (a, Bool))
+  -> a
+  -> Causal m h e
+  -> m (FoldHistoryResult a)
 foldHistoryUntil f a c = step a mempty (pure c) where
   step :: a -> Set (RawHash h) -> Seq (Causal m h e) -> m (FoldHistoryResult a)
-  --step a seen rest | trace ("step a=" ++ show a ++ " seen=" ++ (show . fmap (take 3 . show) . toList) seen ++ " rest=" ++ show rest) False = undefined
   step a _seen Seq.Empty = pure (Unsatisfied a)
+  step a seen (c Seq.:<| rest) | currentHash c `Set.member` seen =
+    step a seen rest
   step a seen (c Seq.:<| rest) = case f a (head c) of
-    (a, True) -> pure (Satisfied a)
+    (a, True ) -> pure (Satisfied a)
     (a, False) -> do
       tails <- case c of
         One{} -> pure mempty
-        Cons{} -> Seq.singleton <$> snd (tail c)
-        Merge{} -> Seq.fromList <$> (sequenceA . toList . tails) c
+        Cons{} ->
+          let (h, t) = tail c
+          in  if h `Set.member` seen then pure mempty else Seq.singleton <$> t
+        Merge{} ->
+          fmap Seq.fromList
+            . traverse snd
+            . filter (\(h, _) -> Set.notMember h seen)
+            . Map.toList
+            $ tails c
       step a (Set.insert (currentHash c) seen) (rest <> tails)
 
 hashToRaw ::

--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -851,7 +851,12 @@ generalizedDependencies
 generalizedDependencies termRef typeRef literalType dataConstructor dataType effectConstructor effectType
   = Set.fromList . Writer.execWriter . ABT.visit' f where
   f t@(Ref r) = Writer.tell [termRef r] $> t
-  f t@(TermLink r) = Writer.tell [termRef $ Referent.toReference r] $> t
+  f t@(TermLink (Referent.Ref r)) =
+    Writer.tell [termRef r] $> t
+  f t@(TermLink (Referent.Con r id CT.Data))
+    = Writer.tell [dataConstructor r id] $> t
+  f t@(TermLink (Referent.Con r id CT.Effect))
+    = Writer.tell [effectConstructor r id] $> t
   f t@(TypeLink r) = Writer.tell [typeRef r] $> t
   f t@(Ann _ typ) =
     Writer.tell (map typeRef . toList $ Type.dependencies typ) $> t
@@ -875,10 +880,15 @@ generalizedDependencies termRef typeRef literalType dataConstructor dataType eff
                                                            effectType
                                                            pat
 
-labeledDependencies :: (Ord v, Ord vt)
-                    => Term2 vt at ap v a
-                    -> Set LabeledDependency
-labeledDependencies = generalizedDependencies LD.termRef LD.typeRef LD.typeRef LD.dataConstructor LD.typeRef LD.effectConstructor LD.typeRef
+labeledDependencies
+  :: (Ord v, Ord vt) => Term2 vt at ap v a -> Set LabeledDependency
+labeledDependencies = generalizedDependencies LD.termRef
+                                              LD.typeRef
+                                              LD.typeRef
+                                              LD.dataConstructor
+                                              LD.typeRef
+                                              LD.effectConstructor
+                                              LD.typeRef
 
 updateDependencies
   :: Ord v

--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -851,12 +851,10 @@ generalizedDependencies
 generalizedDependencies termRef typeRef literalType dataConstructor dataType effectConstructor effectType
   = Set.fromList . Writer.execWriter . ABT.visit' f where
   f t@(Ref r) = Writer.tell [termRef r] $> t
-  f t@(TermLink (Referent.Ref r)) =
-    Writer.tell [termRef r] $> t
-  f t@(TermLink (Referent.Con r id CT.Data))
-    = Writer.tell [dataConstructor r id] $> t
-  f t@(TermLink (Referent.Con r id CT.Effect))
-    = Writer.tell [effectConstructor r id] $> t
+  f t@(TermLink r) = case r of
+    Referent.Ref r -> Writer.tell [termRef r] $> t
+    Referent.Con r id CT.Data -> Writer.tell [dataConstructor r id] $> t
+    Referent.Con r id CT.Effect -> Writer.tell [effectConstructor r id] $> t
   f t@(TypeLink r) = Writer.tell [typeRef r] $> t
   f t@(Ann _ typ) =
     Writer.tell (map typeRef . toList $ Type.dependencies typ) $> t


### PR DESCRIPTION
Fixes #1481 

## Implementation notes

1. `generalizedDependencies` was just doing the wrong thing for `TermLink`, so foldHistoryUntil had no hope of finding some of the terms coming out of that. Fixed.
2. Made `foldHistoryUntil` skip nodes it doesn't need to load (or already has loaded). Avoids loading the causals from disk that have hashes it has already seen.

## Test coverage

This is hard to test unless you have a codebase with a lot of history. And even then, the test "fails" by just not terminating. Would love to hear ideas about how to test this kind of thing in general.


