### PR TITLE
Fix misspelling / typo in help docs

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -41,3 +41,4 @@ The format for this list: name, GitHub handle, and then optional blurb about wha
 * Andre Popovitch (@anchpop)
 * Daniël Heres (@Dandandan)
 * Stew O'Connor (@stew)
+* Dave Nicponski (@virusdave)

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -1169,7 +1169,7 @@ unlink = InputPattern
   ["delete.link"]
   [(Required, definitionQueryArg), (OnePlus, definitionQueryArg)]
   (fromString $ concat
-    [ "`unlink metadata defn` removes a link to `detadata` from `defn`."
+    [ "`unlink metadata defn` removes a link to `metadata` from `defn`."
     , "The `defn` can be either the "
     , "name of a term or type, multiple such names, or a range like `1-4` "
     , "for a range of definitions listed by a prior `find` command."


### PR DESCRIPTION
See title.
Fixes a misspelling / typo in the `help` docs.
