### PR TITLE
don't overwrite root on sync

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
@@ -35,7 +35,7 @@ import qualified Unison.Util.Exception         as Ex
 import qualified Unison.Codebase.Branch        as Branch
 import UnliftIO.IO (hFlush, stdout)
 import UnliftIO.Directory (getXdgDirectory, XdgDirectory(XdgCache), doesDirectoryExist, findExecutable, removeDirectoryRecursive)
-import Unison.Codebase.FileCodebase.Common (encodeFileName)
+import Unison.Codebase.FileCodebase.Common (encodeFileName, updateCausalHead, branchHeadDir)
 
 tempGitDir :: MonadIO m => Text -> m FilePath
 tempGitDir url =
@@ -213,6 +213,7 @@ pushGitRootBranch codebase branch repo = do
     let repoString = Text.unpack $ printRepo repo
     withStatus ("Staging files for upload to " ++ repoString ++ " ...") $
       lift (Codebase.syncToDirectory codebase remotePath branch)
+    updateCausalHead (branchHeadDir remotePath) (Branch._history branch)
     -- push staging area to remote
     withStatus ("Uploading to " ++ repoString ++ " ...") $
       unlessM

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase/CopyFilterIndex.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase/CopyFilterIndex.hs
@@ -18,7 +18,7 @@ import           System.FilePath                ( FilePath
                                                 )
 import           Unison.Codebase                ( CodebasePath )
 import qualified Unison.Codebase.Causal        as Causal
-import           Unison.Codebase.Branch         ( Branch(Branch) )
+import           Unison.Codebase.Branch         ( Branch )
 import qualified Unison.Codebase.Branch        as Branch
 import           Unison.Reference               ( Reference )
 import qualified Unison.Reference              as Reference
@@ -55,8 +55,8 @@ syncToDirectory :: MonadIO m => v -> a
                 -> CodebasePath -> CodebasePath -> Branch m -> m ()
 syncToDirectory _ _ = syncToDirectory'
 
--- Copy (merge) all dependent codebase elements of `branch` from `srcPath` into 
--- `destPath`, and set `branch` as the new root in `destPath`.
+-- Copy all dependent codebase elements of `branch` from `srcPath` into
+-- `destPath`.
 --
 -- As a refresher, in the normal course of using `ucm` and updating the
 -- namespace, we call Branch.sync to write the updated root to disk.
@@ -85,7 +85,7 @@ syncToDirectory' :: forall m
   -> CodebasePath
   -> Branch m
   -> m ()
-syncToDirectory' srcPath destPath newRemoteRoot@(Branch c) =
+syncToDirectory' srcPath destPath newRemoteRoot =
   flip State.evalStateT mempty $ do
     Branch.sync
       (hashExists destPath)
@@ -103,7 +103,6 @@ syncToDirectory' srcPath destPath newRemoteRoot@(Branch c) =
     -- in processing x and y, we distill them to a direct form:
     knownReferents <- copyTypeIndex x y
     copyTypeMentionsIndex knownReferents
-    updateCausalHead (branchHeadDir destPath) c
   where
   -- Loads the entire dependents index from disk, copies the appropriate subset
   -- to `destPath`, then uses it to compute transitive dependents, and copy

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase/CopyRegenerateIndex.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase/CopyRegenerateIndex.hs
@@ -15,7 +15,7 @@ import Unison.Prelude
 import           UnliftIO.Directory             ( doesFileExist )
 import           Unison.Codebase                ( CodebasePath )
 import qualified Unison.Codebase.Causal        as Causal
-import           Unison.Codebase.Branch         ( Branch(Branch) )
+import           Unison.Codebase.Branch         ( Branch )
 import qualified Unison.Codebase.Branch        as Branch
 import qualified Unison.Codebase.Serialization as S
 import qualified Unison.DataDeclaration        as DD
@@ -62,8 +62,8 @@ syncToDirectory :: forall m v a
   -> m ()
 syncToDirectory fmtV fmtA = syncToDirectory' (S.get fmtV) (S.get fmtA)
 
--- Copy (merge) all dependent codebase elements of `branch` from `srcPath` into 
--- `destPath`, and set `branch` as the new root in `destPath`.
+-- Copy all dependent codebase elements of `branch` from `srcPath` into
+-- `destPath`.
 --
 -- As a refresher, in the normal course of using `ucm` and updating the
 -- namespace, we call Branch.sync to write the updated root to disk.
@@ -100,7 +100,7 @@ syncToDirectory' :: forall m v a
   -> CodebasePath
   -> Branch m
   -> m ()
-syncToDirectory' getV getA srcPath destPath newRemoteRoot@(Branch c) =
+syncToDirectory' getV getA srcPath destPath newRemoteRoot =
   flip State.evalStateT mempty $ do
     Branch.sync
       (hashExists destPath)
@@ -110,7 +110,6 @@ syncToDirectory' getV getA srcPath destPath newRemoteRoot@(Branch c) =
     writeDependentsIndex =<< use dependentsIndex
     writeTypeIndex =<< use typeIndex
     writeTypeMentionsIndex =<< use typeMentionsIndex
-    updateCausalHead (branchHeadDir destPath) c
   where
   writeDependentsIndex :: Relation Reference Reference.Id -> StateT SyncedEntities m ()
   writeDependentsIndex = writeIndexHelper (\k v -> touchIdFile v (dependentsDir destPath k))

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase/Reserialize.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase/Reserialize.hs
@@ -41,9 +41,8 @@ data SyncedEntities = SyncedEntities
 
 makeLenses ''SyncedEntities
 
--- Copy (merge) all dependents of `branch` from `srcPath` into `destPath`,
--- and set `branch` as the new root in `destPath`.
--- 
+-- Copy all dependents of `branch` from `srcPath` into `destPath`.
+--
 -- As a refresher, in the normal course of using `ucm` and updating the 
 -- namespace, we call Branch.sync to write the updated root to disk.
 -- Branch.sync takes a few parameters:
@@ -70,14 +69,13 @@ syncToDirectory
   -> CodebasePath
   -> Branch m
   -> m ()
-syncToDirectory fmtV fmtA srcPath destPath branch@(Branch c) = do
+syncToDirectory fmtV fmtA srcPath destPath branch = do
   flip evalStateT mempty $
     Branch.sync
       (hashExists destPath)
       serialize
       (serializeEdits destPath)
       (Branch.transform lift branch)
-  updateCausalHead (branchHeadDir destPath) c
  where
   serialize rh rawBranch = do
     writeBranch $ Causal.rawHead rawBranch


### PR DESCRIPTION
## Overview

For background: when we do a `push`, we have been doing fetch from git, loading its root `Branch`, and doing an `updateAtM` on it to update it at the target path, which also produces a new root `Branch`, which we pass to `syncToDirectory`, which writes the branch's dependencies to the staging dir, and then does `updateCausalHead` on the target, to actually set it as its new root branch.

When I reused this same code for `syncFromDirectory`, I forgot to remove the call to `updateCausalHead`, as that is not something we want to do when ingesting a remote repo; that potentially deeply-nested Branch we are ingesting is not likely to be what we want for the new root of our local codebase.

This PR shuffles that call around so that it is not called during sync, but rather after the call to `syncToDirectory` when doing a `push`.

Although the call to `importRemoteBranch` will mess up our local causal head as described above, the final call to `mergeBranchAndPropagateDefaultPatch` was fixing it again, if it was the sort of merge that would cause us to update our root.  As @runarorama suspected, when the merge is a no-op, then this coincidentally corrective step is skipped, and the paths _head is left in the wrong state.

### How to fix your messed up codebase if you encounter this bug

Although when I tried to fix my messed up codebase after #1484, my reflog was mysteriously empty, and although @runarorama had seemed to recall that his reflog was also empty, I have not been able to replicate the "missing reflog" symptom, which leads me to believe that this bug does not impact the reflog, and the reflog can therefore be used to restore your previous head.  

![image](https://user-images.githubusercontent.com/538571/80822701-49ac8b80-8ba9-11ea-8fc2-010a23e46f79.png)

You can then re-issue the `pull` with this patch — or maybe even without this patch? (see next section).

## Implementation notes

Just don't call `updateCausalHead` in `syncToDir`:

![image](https://user-images.githubusercontent.com/538571/80821696-3b5d7000-8ba7-11ea-9cce-66a5e38b7fa5.png)
![image](https://user-images.githubusercontent.com/538571/80821740-516b3080-8ba7-11ea-8c27-0cdf0668c4d5.png)

## Test coverage

I could try to figure out what the root namespace is supposed to be after a `push` in the git test, and then check for the file, but haven't.

## Loose ends

- [ ] try to fully understand and/or improve the code that does detection of external changes? (`CommandLine.watchBranchUpdates`, `Input.IncomingRootBranch`)
- [ ] update tests to check _head?