### PR TITLE
uncomment and improve the WarnIncomingRootBranch message

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -291,7 +291,9 @@ loop = do
 
   case e of
     Left (IncomingRootBranch hashes) ->
-      eval . Notify . WarnIncomingRootBranch $ Set.map (SBH.fromHash sbhLength) hashes
+      eval . Notify $ WarnIncomingRootBranch
+                        (SBH.fromHash sbhLength $ Branch.headHash root')
+                        (Set.map (SBH.fromHash sbhLength) hashes)
     Left (UnisonFileChanged sourceName text) ->
       -- We skip this update if it was programmatically generated
       if maybe False snd latestFile'

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -185,7 +185,7 @@ data Output v
   | NothingToPatch PatchPath Path'
   | PatchNeedsToBeConflictFree
   | PatchInvolvesExternalDependents PPE.PrettyPrintEnv (Set Reference)
-  | WarnIncomingRootBranch (Set ShortBranchHash)
+  | WarnIncomingRootBranch ShortBranchHash (Set ShortBranchHash)
   | StartOfCurrentPathHistory
   | History (Maybe Int) [(ShortBranchHash, Names.Diff)] HistoryTail
   | ShowReflog [ReflogEntry]

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -264,7 +264,7 @@ notifyUser dir o = case o of
       , ""
       , P.wrap $ "but I'm not sure what to do about it."
           <> "If you're feeling lucky, you can try deleting one of the heads"
-          <> "from `.unison/v1/branches/head/`, but please make a backup first."
+          <> "from `.unison/v1/paths/head/`, but please make a backup first."
           <> "There will be a better way of handling this in the future. 😅"
       , ""
       , P.wrap $ "For what it's worth, the hash of the root namespace that's"

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -250,25 +250,27 @@ prettyRemoteNamespace =
 notifyUser :: forall v . Var v => FilePath -> Output v -> IO Pretty
 notifyUser dir o = case o of
   Success     -> pure $ P.bold "Done."
-  WarnIncomingRootBranch _hashes -> mempty
-  -- todo: resurrect this code once it's not triggered by update+propagate
---  WarnIncomingRootBranch hashes -> putPrettyLn $
---    if null hashes then P.wrap $
---      "Please let someone know I generated an empty IncomingRootBranch"
---                 <> " event, which shouldn't be possible!"
---    else P.lines
---      [ P.wrap $ (if length hashes == 1 then "A" else "Some")
---         <> "codebase" <> P.plural hashes "root" <> "appeared unexpectedly"
---         <> "with" <> P.group (P.plural hashes "hash" <> ":")
---      , ""
---      , (P.indentN 2 . P.oxfordCommas)
---                (map (P.text . Hash.base32Hex . Causal.unRawHash) $ toList hashes)
---      , ""
---      , P.wrap $ "but I'm not sure what to do about it."
---          <> "If you're feeling lucky, you can try deleting one of the heads"
---          <> "from `.unison/v1/branches/head/`, but please make a backup first."
---          <> "There will be a better way of handling this in the future. 😅"
---      ]
+  WarnIncomingRootBranch current hashes -> pure $
+    if null hashes then P.wrap $
+      "Please let someone know I generated an empty IncomingRootBranch"
+                 <> " event, which shouldn't be possible!"
+    else P.lines
+      [ P.wrap $ (if length hashes == 1 then "A" else "Some")
+         <> "codebase" <> P.plural hashes "root" <> "appeared unexpectedly"
+         <> "with" <> P.group (P.plural hashes "hash" <> ":")
+      , ""
+      , (P.indentN 2 . P.oxfordCommas)
+                (map prettySBH $ toList hashes)
+      , ""
+      , P.wrap $ "but I'm not sure what to do about it."
+          <> "If you're feeling lucky, you can try deleting one of the heads"
+          <> "from `.unison/v1/branches/head/`, but please make a backup first."
+          <> "There will be a better way of handling this in the future. 😅"
+      , ""
+      , P.wrap $ "For what it's worth, the hash of the root namespace that's"
+          <> "loaded right now is:"
+          <> prettySBH current
+      ]
   LoadPullRequest baseNS headNS basePath headPath mergedPath -> pure $ P.lines
     [ P.wrap $ "I checked out" <> prettyRemoteNamespace baseNS <> "to" <> P.group (prettyPath' basePath <> ".")
     , P.wrap $ "I checked out" <> prettyRemoteNamespace headNS <> "to" <> P.group (prettyPath' headPath <> ".")

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -270,6 +270,12 @@ notifyUser dir o = case o of
       , P.wrap $ "For what it's worth, the hash of the root namespace that's"
           <> "loaded right now is:"
           <> prettySBH current
+      , ""
+      , P.wrap $ "The" <> makeExample' IP.viewReflog <> "command may be useful here"
+          <> "too. Remember that the hash to the left of each command represents"
+          <> "the namespace that" <> P.bold "results" <> "from that command,"
+          <> "so when restoring, you will typicall want to use the"
+          <> P.bold "next" <> "hash after the command you want to undo."
       ]
   LoadPullRequest baseNS headNS basePath headPath mergedPath -> pure $ P.lines
     [ P.wrap $ "I checked out" <> prettyRemoteNamespace baseNS <> "to" <> P.group (prettyPath' basePath <> ".")

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -262,20 +262,21 @@ notifyUser dir o = case o of
       , (P.indentN 2 . P.oxfordCommas)
                 (map prettySBH $ toList hashes)
       , ""
-      , P.wrap $ "but I'm not sure what to do about it."
-          <> "If you're feeling lucky, you can try deleting one of the heads"
-          <> "from `.unison/v1/paths/head/`, but please make a backup first."
-          <> "There will be a better way of handling this in the future. 😅"
+      , P.wrap $ "and I'm not sure what to do about it."
+          <> "The last root namespace hash that I knew about was:"
       , ""
-      , P.wrap $ "For what it's worth, the hash of the root namespace that's"
-          <> "loaded right now is:"
-          <> prettySBH current
+      , P.indentN 2 $ prettySBH current
       , ""
-      , P.wrap $ "The" <> makeExample' IP.viewReflog <> "command may be useful here"
-          <> "too. Remember that the hash to the left of each command represents"
-          <> "the namespace that" <> P.bold "results" <> "from that command,"
-          <> "so when restoring, you will typicall want to use the"
-          <> P.bold "next" <> "hash after the command you want to undo."
+      , P.wrap $ "Now might be a good time to make a backup of your codebase. 😬"
+      , ""
+      , P.wrap $ "After that, you might try using the" <> makeExample' IP.forkLocal
+          <> "command to inspect the namespaces listed above, and decide which"
+          <> "one you want as your root."
+          <> "You can also use" <> makeExample' IP.viewReflog <> "to see the"
+          <> "last few root namespace hashes on record."
+      , ""
+      , P.wrap $ "Once you find one you like, you can use the"
+          <> makeExample' IP.resetRoot <> "command to set it."
       ]
   LoadPullRequest baseNS headNS basePath headPath mergedPath -> pure $ P.lines
     [ P.wrap $ "I checked out" <> prettyRemoteNamespace baseNS <> "to" <> P.group (prettyPath' basePath <> ".")


### PR DESCRIPTION
## Overview

Uncommented this message to give the user a little more warning and info to be able to deal with issues like #1484 / #1488.  Anecdotally it seems to work, but I'm not confident that it avoids false positives.  I don't remember why we/I had commented it out to begin with.

![image](https://user-images.githubusercontent.com/538571/80866524-1deadd80-8c5d-11ea-8e26-e90eb33e70ad.png)

## Test coverage

A transcript to trigger this would require leaving `ucm` open while simultaneously changing some files.  I guess this could be done using pure Unison, the `{IO}` ability.  I suppose we could write a bunch of trickier tests that way.
