### PR TITLE
add guidance for choosing a PR title

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-> Reminder: Please make your pull request's title more descriptive than "Fix #1203".  Fixed issues can be listed in the "Overview" section.
+**Updated May 2:** Your pull request title is what's used to create release notes, so please make it descriptive of the change itself, which may be different from the initial motivation to make the change.
 
 ## Overview
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-**Updated May 2:** Your pull request title is what's used to create release notes, so please make it descriptive of the change itself, which may be different from the initial motivation to make the change.
+**Choose your PR title well:** Your pull request title is what's used to create release notes, so please make it descriptive of the change itself, which may be different from the initial motivation to make the change.
 
 ## Overview
 


### PR DESCRIPTION
When drafting release notes, I found the PR titles were sometimes not descriptive, or overly specific, forcing me to delve into the individual PRs to try to summarize the change.  With this PR I'm hoping that the PR creators will take on more of that work.

## Interesting/controversial decisions

I wasn't sure how to draw attention to the changed guidance. I opted for bold and a date, and this PR description.

## Test coverage

We don't have automated tests for this.