### PR TITLE
tweak delete.term-replacement/delete.type-replacement help text

### DIFF
--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -456,10 +456,13 @@ deleteReplacement isTerm = InputPattern
   [(Required, if isTerm then exactDefinitionTermQueryArg else exactDefinitionTypeQueryArg), (Optional, patchArg)]
   (  P.string
   $  commandName
-  <> " <patch>` removes any edit of the "
+  <> " <foo> <patch>` removes any edit of the "
   <> str
-  <> " `foo` "
-  <> "from the patch `patch`, or the default patch if none is specified."
+  <> " `foo` from the patch `patch`, "
+  <> "or from the default patch if none is specified.  Note that `foo` refers to the "
+  <> "original name for the "
+  <> str
+  <> " - not the one in place after the edit."
   )
   (\case
     query : patch -> do


### PR DESCRIPTION
### Overview

Old output:
```
.> help delete.term-replacement

  delete.term-replacement
  delete.term-replacement <patch>` removes any edit of the term `foo` from the patch `patch`, or
  the default patch if none is specified.

```

This misses out the `<foo>` argument.

New output:

```
.> help delete.term-replacement

  delete.term-replacement
  delete.term-replacement <foo> <patch>` removes any edit of the term `foo` from the patch `patch`,
  or from the default patch if none is specified. Note that `foo` refers to the original name for
  the term - not the one in place after the edit.

.> help delete.type-replacement

  delete.type-replacement
  delete.type-replacement <foo> <patch>` removes any edit of the type `foo` from the patch `patch`,
  or from the default patch if none is specified. Note that `foo` refers to the original name for
  the type - not the one in place after the edit.
```

### Implementation notes

none

### Interesting/controversial decisions

none

### Test coverage

none - fine

### Loose ends

none