### PR TITLE
Greatly speed up `pull` command by short-circuiting merge

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -351,6 +351,8 @@ deepEdits' b = go id b where
     f (c, b) =  go (addPrefix . Name.joinDot (NameSegment.toName c)) (head b)
 
 merge :: forall m . Monad m => Branch m -> Branch m -> m (Branch m)
+merge b1 b2 | isEmpty b1 = pure b2
+merge b1 b2 | isEmpty b2 = pure b1
 merge (Branch x) (Branch y) =
   Branch <$> Causal.threeWayMerge combine x y
  where

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -112,13 +112,13 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #ll42hbp60e
+  ⊙ #1pdgtsicq9
   
     - Deletes:
     
       feature1.y
   
-  ⊙ #h72ma1qlnk
+  ⊙ #9e8gvv7r3e
   
     + Adds / updates:
     
@@ -129,26 +129,26 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
       Original name New name(s)
       feature1.y    master.y
   
-  ⊙ #km35ctvltc
+  ⊙ #6sqsddkikv
   
     + Adds / updates:
     
       feature1.y
   
-  ⊙ #nbiibp60kj
+  ⊙ #loe9apjdis
   
     > Moves:
     
       Original name New name
       x             master.x
   
-  ⊙ #d3oe0kr57t
+  ⊙ #p90pbjip7l
   
     + Adds / updates:
     
       x
   
-  ⊙ #gectfnld64
+  ⊙ #givahf3f6f
   
     + Adds / updates:
     

--- a/unison-src/transcripts/reflog.output.md
+++ b/unison-src/transcripts/reflog.output.md
@@ -59,16 +59,16 @@ y = 2
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #q6dct4uv2g .old`   to make an old namespace
+    `fork #akq10qch4d .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #q6dct4uv2g`  to reset the root namespace and
+    `reset-root #akq10qch4d`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
-  1. #0lntipbdvf : add
-  2. #q6dct4uv2g : add
-  3. #gectfnld64 : builtins.merge
+  1. #c7f5p7bir3 : add
+  2. #akq10qch4d : add
+  3. #givahf3f6f : builtins.merge
   4. #7asfbtqmoj : (initial reflogged namespace)
 
 ```


### PR DESCRIPTION
Before this change, this would take about a minute, even if all the code was in the git cache and in the codebase:

```ucm
.> pull git@github.com:runarorama/mybase .runarbase
```

Now it takes a couple seconds, and I think most of that might be printing out the diff.

Pretty simple change, using the fact that `Branch.merge empty b == b`. The old code didn't have this. As a result, for the very common case of pulling to an empty namespace (which is done, for instance, by `pr.load` and `pr.create`), it would be computing the LCA of a namespace, `b`, and `Branch.empty`, which will involve a full scan of `b` history, only to determine that `Branch.empty` is the LCA. :)

I speculate that this might also fix other sources of slowness in `push` / `pull`. Basically, there are a lot of times where you can end up doing a merge of an empty `Branch` and a non-empty one. I can sort of imagine there being some quadratic behavior, where for each point in history, you look for the LCA with the empty namespace (requiring a search all the way back in history).

## Interesting stuff

A couple of the transcript outputs changed. Since we no longer create pointless merge nodes when merging with the empty namespace, this affects namespace hashes.

## Test coverage

No new tests, though any of the tests that do `pull` will exercise.

## Loose ends

None.