### PR TITLE
repeat the user-provided path back to them in `init` tip.

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -141,15 +141,14 @@ getNoCodebaseErrorMsg :: IsString s => P.Pretty s -> Maybe FilePath -> P.Pretty 
 getNoCodebaseErrorMsg prettyDir mdir =
   let secondLine =
         case mdir of
-          Just _  -> "Run `ucm -codebase "
-                     <> prettyDir
+          Just dir  -> "Run `ucm -codebase " <> fromString dir
                      <> " init` to create one, then try again!"
           Nothing -> "Run `ucm init` to create one there,"
                      <> " then try again;"
                      <> " or `ucm -codebase <dir>` to load a codebase from someplace else!"
   in
     P.lines
-        [ "No codebase exists in " <> prettyDir
+        [ "No codebase exists in " <> prettyDir <> "."
         , secondLine ]
 
 getCodebaseDir :: Maybe FilePath -> IO FilePath


### PR DESCRIPTION
Before:
```
$ ucm -codebase c
No codebase exists in /Users/arya/unison7/c
Run `ucm -codebase /Users/arya/unison7/c init` to create one, then try again!
```

After:
```
$ stack exec unison -- -codebase c
No codebase exists in /Users/arya/unison7/c.
Run `ucm -codebase c init` to create one, then try again!
```