### PR TITLE
Make dependents and dependencies commands produce numbered args.

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1687,7 +1687,9 @@ loop = do
               tm (Referent.Con r _i _ct) = eval $ GetDependents r
               in LD.fold tp tm ld
             (missing, names0) <- eval . Eval $ Branch.findHistoricalRefs' dependents root'
-            let names = getTypesAndTerms names0
+            let types = R.toList $ Names3.types0 names0
+            let terms = fmap (second Referent.toReference) $ R.toList $ Names.terms names0
+            let names = types <> terms
             numberedArgs .= fmap (Text.unpack . Reference.toText) ((fmap snd names) <> toList missing)
             respond $ ListDependents hqLength ld names missing
       ListDependenciesI hq -> do -- todo: add flag to handle transitive efficiently
@@ -1711,7 +1713,9 @@ loop = do
               tm _ = pure mempty
               in LD.fold tp tm ld
             (missing, names0) <- eval . Eval $ Branch.findHistoricalRefs' dependencies root'
-            let names = getTypesAndTerms names0
+            let types = R.toList $ Names3.types0 names0
+            let terms = fmap (second Referent.toReference) $ R.toList $ Names.terms names0
+            let names = types <> terms
             numberedArgs .= fmap (Text.unpack . Reference.toText) ((fmap snd names) <> toList missing)
             respond $ ListDependencies hqLength ld names missing
       DebugNumberedArgsI -> use numberedArgs >>= respond . DumpNumberedArgs
@@ -1739,12 +1743,6 @@ loop = do
      where
       notImplemented = eval $ Notify NotImplemented
       success = respond Success
-
-      getTypesAndTerms :: Names0 -> [(Name, Reference)]
-      getTypesAndTerms names0 = types <> terms
-        where
-          types = R.toList $ Names3.types0 names0
-          terms = fmap (second Referent.toReference) $ R.toList $ Names.terms names0
 
       resolveDefaultMetadata :: Path.Absolute -> Action' m v [String]
       resolveDefaultMetadata path = do

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1688,7 +1688,7 @@ loop = do
               in LD.fold tp tm ld
             (missing, names0) <- eval . Eval $ Branch.findHistoricalRefs' dependents root'
             let names = getTypesAndTerms names0
-            numberedArgs .= fmap (Name.toString . fst) names
+            numberedArgs .= fmap (Text.unpack . Reference.toText) ((fmap snd names) <> toList missing)
             respond $ ListDependents hqLength ld names missing
       ListDependenciesI hq -> do -- todo: add flag to handle transitive efficiently
         resolveHQToLabeledDependencies hq >>= \lds ->
@@ -1712,7 +1712,7 @@ loop = do
               in LD.fold tp tm ld
             (missing, names0) <- eval . Eval $ Branch.findHistoricalRefs' dependencies root'
             let names = getTypesAndTerms names0
-            numberedArgs .= fmap (Name.toString . fst) names
+            numberedArgs .= fmap (Text.unpack . Reference.toText) ((fmap snd names) <> toList missing)
             respond $ ListDependencies hqLength ld names missing
       DebugNumberedArgsI -> use numberedArgs >>= respond . DumpNumberedArgs
       DebugBranchHistoryI ->

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -24,7 +24,7 @@ import Unison.Codebase.GitError
 import Unison.Codebase.Path (Path', Path)
 import Unison.Codebase.Patch (Patch)
 import Unison.Name ( Name )
-import Unison.Names2 ( Names, Names0 )
+import Unison.Names2 ( Names )
 import Unison.Parser ( Ann )
 import qualified Unison.Reference as Reference
 import Unison.Reference ( Reference )
@@ -196,8 +196,8 @@ data Output v
   | NoConflictsOrEdits
   | NotImplemented
   | NoBranchWithHash ShortBranchHash
-  | ListDependencies Int LabeledDependency Names0 (Set Reference)
-  | ListDependents Int LabeledDependency Names0 (Set Reference)
+  | ListDependencies Int LabeledDependency [(Name, Reference)] (Set Reference)
+  | ListDependents Int LabeledDependency [(Name, Reference)] (Set Reference)
   | DumpNumberedArgs NumberedArgs
   | DumpBitBooster Branch.Hash (Map Branch.Hash [Branch.Hash])
   | DumpUnisonFileHashes Int [(Name, Reference.Id)] [(Name, Reference.Id)] [(Name, Reference.Id)]

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -999,30 +999,34 @@ notifyUser dir o = case o of
       "",
       "Paste that output into http://bit-booster.com/graph.html"
       ]
-  ListDependents hqLength ld names0 missing -> pure $
-    if names0 == mempty && missing == mempty
+  ListDependents hqLength ld names missing -> pure $
+    if names == mempty && missing == mempty
     then c (prettyLabeledDependency hqLength ld) <> " doesn't have any dependents."
     else
       "Dependents of " <> c (prettyLabeledDependency hqLength ld) <> ":\n\n" <>
-      (P.indentN 2 . P.column2Header "Reference" "Name" $ fmap (first c . second c) $
-        [ (p $ Reference.toShortHash r, prettyName n) | (n, r) <- R.toList $ Names.types0 names0 ] ++
-        [ (p $ Referent.toShortHash r, prettyName n) | (n, r) <- R.toList $ Names.terms names0 ] ++
-        [ (p $ Reference.toShortHash r, "(no name available)") | r <- toList missing ])
+      (P.indentN 2 (P.numberedColumn2Header num pairs))
     where
+    num n = P.hiBlack $ P.shown n <> "."
+    header = (P.hiBlack "Reference", P.hiBlack "Name")
+    pairs = header : (fmap (first c . second c) $
+        [ (p $ Reference.toShortHash r, prettyName n) | (n, r) <- names ] ++
+        [ (p $ Reference.toShortHash r, "(no name available)") | r <- toList missing ])
     p = prettyShortHash . SH.take hqLength
     c = P.syntaxToColor
   -- this definition is identical to the previous one, apart from the word
   -- "Dependencies", but undecided about whether or how to refactor
-  ListDependencies hqLength ld names0 missing -> pure $
-    if names0 == mempty && missing == mempty
+  ListDependencies hqLength ld names missing -> pure $
+    if names == mempty && missing == mempty
     then c (prettyLabeledDependency hqLength ld) <> " doesn't have any dependencies."
     else
       "Dependencies of " <> c (prettyLabeledDependency hqLength ld) <> ":\n\n" <>
-      (P.indentN 2 . P.column2Header "Reference" "Name" $ fmap (first c . second c) $
-        [ (p $ Reference.toShortHash r, prettyName n) | (n, r) <- R.toList $ Names.types0 names0 ] ++
-        [ (p $ Referent.toShortHash r, prettyName n) | (n, r) <- R.toList $ Names.terms names0 ] ++
-        [ (p $ Reference.toShortHash r, "(no name available)") | r <- toList missing ])
+      (P.indentN 2 (P.numberedColumn2Header num pairs))
     where
+    num n = P.hiBlack $ P.shown n <> "."
+    header = (P.hiBlack "Reference", P.hiBlack "Name")
+    pairs = header : (fmap (first c . second c) $
+        [ (p $ Reference.toShortHash r, prettyName n) | (n, r) <- names ] ++
+        [ (p $ Reference.toShortHash r, "(no name available)") | r <- toList missing ])
     p = prettyShortHash . SH.take hqLength
     c = P.syntaxToColor
   DumpUnisonFileHashes hqLength datas effects terms ->

--- a/parser-typechecker/src/Unison/Util/Pretty.hs
+++ b/parser-typechecker/src/Unison/Util/Pretty.hs
@@ -67,6 +67,7 @@ module Unison.Util.Pretty (
    nonEmpty,
    numbered,
    numberedColumn2,
+   numberedColumn2Header,
    numberedList,
    orElse,
    orElses,
@@ -416,6 +417,13 @@ numbered
   -> Pretty s
 numbered num ps = column2 (fmap num [1 ..] `zip` toList ps)
 
+numberedHeader
+  :: (Foldable f, LL.ListLike s Char, IsString s)
+  => (Maybe Int -> Pretty s)
+  -> f (Pretty s)
+  -> Pretty s
+numberedHeader num ps = column2 (fmap num (Nothing : fmap Just [1 ..]) `zip` toList ps)
+
 -- Like `column2` but with the lines numbered. For instance:
 --
 -- 1. one thing     : this is a thing
@@ -427,6 +435,13 @@ numberedColumn2
   -> f (Pretty s, Pretty s)
   -> Pretty s
 numberedColumn2 num ps = numbered num (align $ toList ps)
+
+numberedColumn2Header
+  :: (Foldable f, LL.ListLike s Char, IsString s)
+  => (Int -> Pretty s)
+  -> f (Pretty s, Pretty s)
+  -> Pretty s
+numberedColumn2Header num ps = numberedHeader (maybe mempty num) (align $ toList ps)
 
 -- Opinionated `numbered` that uses bold numbers in front
 numberedList :: Foldable f => f (Pretty ColorText) -> Pretty ColorText

--- a/unison-src/transcripts/dependents-dependencies-debugfile.md
+++ b/unison-src/transcripts/dependents-dependencies-debugfile.md
@@ -29,12 +29,9 @@ But wait, there's more.  I can check the dependencies and dependents of a defini
 .> add
 .> dependents q
 .> dependencies q
-.> view 2
 .> dependencies B
 .> dependencies d
 .> dependents d
-.> dependencies 1
-.> view 1
 .>
 ```
 

--- a/unison-src/transcripts/dependents-dependencies-debugfile.md
+++ b/unison-src/transcripts/dependents-dependencies-debugfile.md
@@ -29,9 +29,12 @@ But wait, there's more.  I can check the dependencies and dependents of a defini
 .> add
 .> dependents q
 .> dependencies q
+.> view 2
 .> dependencies B
 .> dependencies d
 .> dependents d
+.> dependencies 1
+.> view 1
 .>
 ```
 

--- a/unison-src/transcripts/dependents-dependencies-debugfile.output.md
+++ b/unison-src/transcripts/dependents-dependencies-debugfile.output.md
@@ -53,41 +53,59 @@ But wait, there's more.  I can check the dependencies and dependents of a defini
 
   Dependencies of #l5pndeifuh:
   
-    Reference     Name
-    ##Nat.*       builtin.Nat.*
-    ##Nat.+       builtin.Nat.+
-    #fiupm7pl7o   inside.p
+       Reference   Name
+    1. ##Nat.*     builtin.Nat.*
+    2. ##Nat.+     builtin.Nat.+
+    3. #fiupm7pl7o inside.p
+
+.> view 2
+
+  -- builtin.Nat.+ is built-in.
 
 .> dependencies B
 
   Dependencies of #muulibntaq:
   
-    Reference   Name
-    ##Int       builtin.Int
+       Reference Name
+    1. ##Int     builtin.Int
 
   Dependencies of #muulibntaq#0:
   
-    Reference     Name
-    ##Int         builtin.Int
-    #muulibntaq   outside.B
+       Reference   Name
+    1. ##Int       builtin.Int
+    2. #muulibntaq outside.B
 
 .> dependencies d
 
   Dependencies of #6cdi7g1oi2:
   
-    Reference       Name
-    ##Nat           builtin.Nat
-    ##Nat.+         builtin.Nat.+
-    ##Universal.<   builtin.Universal.<
-    #fiupm7pl7o     inside.p
-    #msp7bv40rv     outside.c
+       Reference     Name
+    1. ##Nat         builtin.Nat
+    2. ##Nat.+       builtin.Nat.+
+    3. ##Universal.< builtin.Universal.<
+    4. #fiupm7pl7o   inside.p
+    5. #msp7bv40rv   outside.c
 
 .> dependents d
 
   Dependents of #6cdi7g1oi2:
   
-    Reference     Name
-    #im2kiu2hmn   inside.r
+       Reference   Name
+    1. #im2kiu2hmn inside.r
+
+.> dependencies 1
+
+  Dependencies of #im2kiu2hmn:
+  
+       Reference   Name
+    1. #6cdi7g1oi2 outside.d
+
+.> view 1
+
+  outside.d : Boolean
+  outside.d =
+    use Nat +
+    c < (p + 1)
 
 ```
 We don't have an index for dependents of constructors, but iirc if you ask for that, it will show you dependents of the type that provided the constructor.

--- a/unison-src/transcripts/dependents-dependencies-debugfile.output.md
+++ b/unison-src/transcripts/dependents-dependencies-debugfile.output.md
@@ -58,10 +58,6 @@ But wait, there's more.  I can check the dependencies and dependents of a defini
     2. ##Nat.+     builtin.Nat.+
     3. #fiupm7pl7o inside.p
 
-.> view 2
-
-  -- builtin.Nat.+ is built-in.
-
 .> dependencies B
 
   Dependencies of #muulibntaq:
@@ -92,20 +88,6 @@ But wait, there's more.  I can check the dependencies and dependents of a defini
   
        Reference   Name
     1. #im2kiu2hmn inside.r
-
-.> dependencies 1
-
-  Dependencies of #im2kiu2hmn:
-  
-       Reference   Name
-    1. #6cdi7g1oi2 outside.d
-
-.> view 1
-
-  outside.d : Boolean
-  outside.d =
-    use Nat +
-    c < (p + 1)
 
 ```
 We don't have an index for dependents of constructors, but iirc if you ask for that, it will show you dependents of the type that provided the constructor.


### PR DESCRIPTION
## Overview

What does this change accomplish and why? i.e. How does it change the user experience?

close #1408

<img width="300" alt="Screen Shot 2020-05-10 at 3 24 35 PM" src="https://user-images.githubusercontent.com/616399/81512121-fb973680-92d2-11ea-80d9-cdb6902ddcc5.png">

## Interesting/controversial decisions
~~I assume the number is a reference to the name not the hash and am not sure how we want to handle `missing`, `(no name available)`.~~