### PR TITLE
Improved three-way merge

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Causal.hs
+++ b/parser-typechecker/src/Unison/Codebase/Causal.hs
@@ -9,11 +9,8 @@ import           Prelude                 hiding ( head
                                                 , tail
                                                 , read
                                                 )
-import           Control.Lens                   ( (<&>) )
-import           Control.Monad.Loops            ( anyM )
 import qualified Control.Monad.State           as State
 import           Control.Monad.State            ( StateT )
-import           Data.List                      ( foldl1' )
 import           Data.Sequence                  ( ViewL(..) )
 import qualified Data.Sequence                 as Seq
 import           Unison.Hash                    ( Hash )
@@ -21,7 +18,6 @@ import qualified Unison.Hashable               as Hashable
 import           Unison.Hashable                ( Hashable )
 import qualified Data.Map                      as Map
 import qualified Data.Set                      as Set
-import           Util                           ( bind2 )
 
 {-
 `Causal a` has 5 operations, specified algebraically here:
@@ -34,7 +30,7 @@ import           Util                           ( bind2 )
 * `cons : a -> Causal a -> Causal a`, satisfying `head (cons hd tl) == hd` and
           also `before tl (cons hd tl)`.
 * `merge : CommutativeSemigroup a => Causal a -> Causal a -> Causal a`, which is
-           associative and commutative and satisfies:
+           commutative (but not associative) and satisfies:
   * `before c1 (merge c1 c2)`
   * `before c2 (merge c1 c2)`
 * `sequence : Causal a -> Causal a -> Causal a`, which is defined as
@@ -210,79 +206,23 @@ threeWayMerge
   -> Causal m h e
   -> Causal m h e
   -> m (Causal m h e)
-threeWayMerge combine = mergeInternal merge0
+threeWayMerge combine c1 c2 = do
+  theLCA <- lca c1 c2
+  case theLCA of
+    Nothing -> done <$> combine Nothing (head c1) (head c2)
+    Just lca
+      | lca == c1 -> pure c2
+      | lca == c2 -> pure c1
+      | otherwise -> done <$> combine (Just $ head lca) (head c1) (head c2)
  where
-  merge0 :: Map (RawHash h) (m (Causal m h e)) -> m (Causal m h e)
-  merge0 m = case Map.elems m of
-    []       -> error "Causal.threeWayMerge empty map"
-    me : mes -> do
-      e            <- me
-      (newHead, _) <- foldM k (head e, Seq.singleton (pure e)) mes
-      pure $ Merge (RawHash (hash (newHead, Map.keys m))) newHead m
-   where
-    k (e, acc) new = do
-      n           <- new
-      -- We call `lca'` here since we don't want to merge using the n-way LCA of
-      -- all children. Note for example that some of the children might have
-      -- totally unrelated histories. We want the LCA of any two children.
-      mayAncestor <- lca' acc (Seq.singleton (pure n))
-      newHead     <- combine (head <$> mayAncestor) e (head n)
-      pure (newHead, pure n Seq.<| acc)
+  children =
+    Map.fromList [(currentHash c1, pure c1), (currentHash c2, pure c2)]
+  done :: e -> Causal m h e
+  done newHead =
+    Merge (RawHash (hash (newHead, Map.keys children))) newHead children
 
-mergeInternal
-  :: forall m h e
-   . Monad m
-  => (Map (RawHash h) (m (Causal m h e)) -> m (Causal m h e))
-  -> Causal m h e
-  -> Causal m h e
-  -> m (Causal m h e)
-mergeInternal f a b =
-  ifM (before a b) (pure b) . ifM (before b a) (pure a) $ case (a, b) of
-    (Merge _ _ tls, Merge _ _ tls2) -> f $ Map.union tls tls2
-    (Merge _ _ tls, b) -> f $ Map.insert (currentHash b) (pure b) tls
-    (b, Merge _ _ tls) -> f $ Map.insert (currentHash b) (pure b) tls
-    (a, b) ->
-      f $ Map.fromList [(currentHash a, pure a), (currentHash b, pure b)]
-
-mergeWithM
-  :: forall m h e
-   . Monad m
-  => (e -> e -> m e)
-  -> Causal m h e
-  -> Causal m h e
-  -> m (Causal m h e)
-mergeWithM f = mergeInternal merge0
- where
-  -- implementation detail, form a `Merge`
-  merge0 :: Map (RawHash h) (m (Causal m h e)) -> m (Causal m h e)
-  merge0 m =
-    let e :: m e
-        e = if Map.null m
-          then error "Causal.merge0 empty map"
-          else foldl1' (bind2 f) (fmap head <$> Map.elems m)
-        h = hash (Map.keys m) -- sorted order
-    in  e <&> \e -> Merge (RawHash h) e m
-
--- Does `h2` incorporate all of `h1`?
 before :: Monad m => Causal m h e -> Causal m h e -> m Bool
-before = go
- where
-  -- stopping condition if both are equal
-  go h1 h2 | h1 == h2 = pure True
-  -- otherwise look through tails if they exist
-  go _  (One _ _    ) = pure False
-  go h1 (Cons _ _ tl) = snd tl >>= go h1
-  -- `m1` is a submap of `m2`
-  go (Merge _ _ m1) (Merge _ _ m2) | all (`Map.member` m2) (Map.keys m1) =
-    pure True
-  -- if not, see if `h1` is a subgraph of one of the tails
-  go h1 (Merge _ _ tls) =
-    (||) <$> pure (Map.member (currentHash h1) tls) <*> anyM (>>= go h1)
-                                                             (Map.elems tls)
-  -- Exponential algorithm of checking that all paths are present
-  -- in `h2` isn't necessary because of how merges are flattened
-  --go (Merge _ _ m1) h2@(Merge _ _ _)
-  --  all (\h1 -> go h1 h2) (Map.elems m1)
+before a b = (== Just a) <$> lca a b
 
 hash :: Hashable e => e -> Hash
 hash = Hashable.accumulate'

--- a/unison-src/transcripts/mergeloop.output.md
+++ b/unison-src/transcripts/mergeloop.output.md
@@ -136,9 +136,8 @@ b = 2
   namespace hash.
   
   #0lf1cvdccp
-  #2quan5n72t
-  #gjfovomom2
+  #ofcsecdak0
   ⑂
-  ⊙ #bpfcuip0ru
+  ⊙ #0ucrusr0bl
 
 ```


### PR DESCRIPTION
This improves `threeWayMerge` on namespaces, as well as the `before` function on namespace histories. Namely, the new `threeWayMerge` doesn't waste time calling `before`, and the new `before` is simply implemented in terms of `lca` (lowest common ancestor).

These implementations are significantly simpler and should be somewhat faster.

## Test coverage

No new tests are added, but a number of tests on `threeWayMerge` are passing.

