### PR TITLE
queue-copy sync algorithm

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Branch/Dependencies.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch/Dependencies.hs
@@ -33,6 +33,7 @@ data Dependencies = Dependencies
   , terms :: Set Reference.Id
   , decls :: Set Reference.Id
   }
+  deriving Show
   deriving Generic
   deriving Semigroup via GenericSemigroup Dependencies
   deriving Monoid via GenericMonoid Dependencies
@@ -41,10 +42,11 @@ data Dependencies' = Dependencies'
   { patches' :: [EditHash]
   , terms' :: [Reference.Id]
   , decls' :: [Reference.Id]
-  }
+  } deriving Show
 
 to' :: Dependencies -> Dependencies'
 to' Dependencies{..} = Dependencies' (toList patches) (toList terms) (toList decls)
+
 fromBranch :: Applicative m => Branch m -> (Branches m, Dependencies)
 fromBranch (Branch c) = case c of
   Causal.One _hh e         -> fromBranch0 e

--- a/parser-typechecker/src/Unison/Codebase/Branch/Dependencies.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch/Dependencies.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Unison.Codebase.Branch.Dependencies where
+
+import Data.Set (Set)
+import Data.Foldable (toList)
+import qualified Data.Set as Set
+import qualified Data.Map as Map
+import Unison.Codebase.Branch (Branch(Branch), Branch0, EditHash)
+import qualified Unison.Codebase.Causal as Causal
+import qualified Unison.Codebase.Branch as Branch
+import qualified Unison.Reference as Reference
+import qualified Unison.Referent as Referent
+import GHC.Generics (Generic)
+import Data.Monoid.Generic
+import Data.Map (Map)
+import Unison.Codebase.NameSegment (NameSegment)
+import Unison.Referent (Referent)
+import Unison.Reference (Reference)
+import Unison.Codebase.Patch (Patch)
+import qualified Unison.Util.Star3 as Star3
+import qualified Unison.Util.Relation as R
+import Unison.Reference (Reference(DerivedId))
+
+type Branches m = [(Branch.Hash, Maybe (m (Branch m)))]
+
+data Dependencies = Dependencies
+  { patches :: Set EditHash
+  , terms :: Set Reference.Id
+  , decls :: Set Reference.Id
+  }
+  deriving Generic
+  deriving Semigroup via GenericSemigroup Dependencies
+  deriving Monoid via GenericMonoid Dependencies
+
+data Dependencies' = Dependencies'
+  { patches' :: [EditHash]
+  , terms' :: [Reference.Id]
+  , decls' :: [Reference.Id]
+  }
+
+to' :: Dependencies -> Dependencies'
+to' Dependencies{..} = Dependencies' (toList patches) (toList terms) (toList decls)
+fromBranch :: Applicative m => Branch m -> (Branches m, Dependencies)
+fromBranch (Branch c) = case c of
+  Causal.One _hh e         -> fromBranch0 e
+  Causal.Cons _hh e (h, m) -> fromBranch0 e <> fromTails (Map.singleton h m)
+  Causal.Merge _hh e tails -> fromBranch0 e <> fromTails tails
+  where
+  fromTails m = ([(h, Just (Branch <$> mc)) | (h, mc) <- Map.toList m], mempty)
+
+fromRawCausal :: Causal.Raw Branch.Raw (Branches m, Dependencies)
+              -> (Branches m, Dependencies)
+fromRawCausal = \case
+  Causal.RawOne e -> e
+  Causal.RawCons e h -> e <> fromTails [h]
+  Causal.RawMerge e hs -> e <> fromTails (toList hs)
+  where
+  fromTails ts = (fmap (,Nothing) ts, mempty)
+
+fromBranch0 :: Applicative m => Branch0 m -> (Branches m, Dependencies)
+fromBranch0 b =
+  ( fromChildren (Branch._children b)
+  , fromTermsStar (Branch._terms b)
+    <> fromTypesStar (Branch._types b)
+    <> fromEdits (Branch._edits b) )
+  where
+  fromChildren :: Applicative m => Map NameSegment (Branch m) -> Branches m
+  fromChildren m = [ (Branch.headHash b, Just (pure b)) | b <- toList m ]
+  mdReferences = unzip . toList . R.ran . Star3.d3
+  fromTermsStar :: Branch.Star Referent NameSegment -> Dependencies
+  fromTermsStar s = Dependencies mempty terms decls where
+    referents = toList . R.dom . Star3.d1 $ s
+    (mdTypes, mdValues) = mdReferences s
+    terms = Set.fromList $
+      [ i | Referent.Ref (DerivedId i) <- referents] ++
+      [ i | DerivedId i <- mdValues]
+    decls = Set.fromList $
+      [ i | Referent.Con (DerivedId i) _ _ <- referents ] ++
+      [ i | DerivedId i <- mdTypes ]
+  fromTypesStar :: Branch.Star Reference NameSegment -> Dependencies
+  fromTypesStar s = Dependencies mempty terms decls where
+    references = toList . R.dom . Star3.d1 $ s
+    (mdTypes, mdValues) = mdReferences s
+    terms = Set.fromList [ i | DerivedId i <- mdValues ]
+    decls = Set.fromList [ i | DerivedId i <- references ++ mdTypes ]
+  fromEdits :: Map NameSegment (EditHash, m Patch) -> Dependencies
+  fromEdits m = Dependencies (Set.fromList . fmap fst $ toList m) mempty mempty

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -95,6 +95,7 @@ import qualified Unison.Util.Free              as Free
 import           Unison.Util.List               ( uniqueBy )
 import qualified Unison.Util.Relation          as R
 import qualified Unison.Util.Relation4          as R4
+import           Unison.Util.Timing             (unsafeTime)
 import           Unison.Util.TransitiveClosure  (transitiveClosure)
 import           Unison.Var                     ( Var )
 import qualified Unison.Var                    as Var
@@ -2140,7 +2141,7 @@ mergeBranchAndPropagateDefaultPatch inputDescription unchangedMessage srcb dest0
   where
   mergeBranch :: (Monad m, Var v) =>
     InputDescription -> Branch m -> Maybe Path.Path' -> Path.Absolute -> Action' m v Bool
-  mergeBranch inputDescription srcb dest0 dest = do
+  mergeBranch inputDescription srcb dest0 dest = unsafeTime "Merge Branch" $ do
     destb <- getAt dest
     merged <- eval . Eval $ Branch.merge srcb destb
     for_ dest0 $ \dest0 ->
@@ -2150,7 +2151,7 @@ mergeBranchAndPropagateDefaultPatch inputDescription unchangedMessage srcb dest0
 
 loadPropagateDiffDefaultPatch :: (Monad m, Var v) =>
   InputDescription -> Maybe Path.Path' -> Path.Absolute -> Action' m v ()
-loadPropagateDiffDefaultPatch inputDescription dest0 dest = do
+loadPropagateDiffDefaultPatch inputDescription dest0 dest = unsafeTime "Propagate Default Patch" $ do
     original <- getAt dest
     patch <- eval . Eval $ Branch.getPatch defaultPatchNameSegment (Branch.head original)
     patchDidChange <- propagatePatch inputDescription patch dest

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -97,7 +97,7 @@ import Unison.Codebase.FileCodebase.Common
   , listDirectory
   )
 
-import qualified Unison.Codebase.FileCodebase.Reserialize as Sync
+import qualified Unison.Codebase.FileCodebase.SlimCopyRegenerateIndex as Sync
 
 initCodebaseAndExit :: Maybe FilePath -> IO ()
 initCodebaseAndExit mdir = do

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase/Common.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase/Common.hs
@@ -8,6 +8,7 @@
 module Unison.Codebase.FileCodebase.Common
   ( Err(..)
   , SyncToDir
+  , SimpleLens
   , codebaseExists
   , hashExists
   -- dirs (parent of all the files)

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase/Common.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase/Common.hs
@@ -39,6 +39,7 @@ module Unison.Codebase.FileCodebase.Common
   , putWatch
   , updateCausalHead
   , serializeEdits
+  , deserializeEdits
   , serializeRawBranch
   , branchFromFiles
   , branchHashesByPrefix
@@ -297,12 +298,13 @@ branchFromFiles rootDir h = do
     S.getFromFile' (V1.getCausal0 V1.getRawBranch) ubf >>= \case
       Left  err -> failWith $ InvalidBranchFile ubf err
       Right c0  -> pure c0
-  deserializeEdits :: MonadIO m => CodebasePath -> Branch.EditHash -> m Patch
-  deserializeEdits root h =
-    let file = editsPath root h
-    in S.getFromFile' V1.getEdits file >>= \case
-      Left  err   -> failWith $ InvalidEditsFile file err
-      Right edits -> pure edits
+
+deserializeEdits :: MonadIO m => CodebasePath -> Branch.EditHash -> m Patch
+deserializeEdits root h =
+  let file = editsPath root h
+  in S.getFromFile' V1.getEdits file >>= \case
+    Left  err   -> failWith $ InvalidEditsFile file err
+    Right edits -> pure edits
 
 getRootBranch :: forall m.
   MonadIO m => CodebasePath -> m (Either Codebase.GetRootBranchError (Branch m))

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase/Common.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase/Common.hs
@@ -125,6 +125,7 @@ import qualified Unison.Type                   as Type
 import           Unison.Var                     ( Var )
 import qualified Unison.UnisonFile             as UF
 import           Unison.Util.Monoid (foldMapM)
+import           Unison.Util.Timing             (time)
 import Data.Either.Extra (maybeToEither)
 
 data Err
@@ -283,7 +284,7 @@ codebaseExists root =
 
 -- | load a branch w/ children from a FileCodebase
 branchFromFiles :: MonadIO m => CodebasePath -> Branch.Hash -> m (Maybe (Branch m))
-branchFromFiles rootDir h = do
+branchFromFiles rootDir h = time "FileCodebase.Common.branchFromFiles" $ do
   fileExists <- doesFileExist (branchPath rootDir h)
   if fileExists then Just <$>
     Branch.read (deserializeRawBranch rootDir)
@@ -309,7 +310,7 @@ deserializeEdits root h =
 
 getRootBranch :: forall m.
   MonadIO m => CodebasePath -> m (Either Codebase.GetRootBranchError (Branch m))
-getRootBranch root =
+getRootBranch root = time "FileCodebase.Common.getRootBranch" $
   ifM (codebaseExists root)
     (listDirectory (branchHeadDir root) >>= filesToBranch)
     (pure $ Left Codebase.NoRootBranch)

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase/SlimCopyRegenerateIndex.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase/SlimCopyRegenerateIndex.hs
@@ -95,7 +95,7 @@ syncToDirectory' :: forall m v a
   -> Branch m
   -> m ()
 syncToDirectory' getV getA srcPath destPath newRoot =
-  let warnMissingEntities = True in
+  let warnMissingEntities = False in
   flip evalStateT mempty $ do -- MonadState s m
     (deps, errors) <- time "Sync Branches" $ execWriterT $
       processBranches [(Branch.headHash newRoot

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase/SlimCopyRegenerateIndex.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase/SlimCopyRegenerateIndex.hs
@@ -1,0 +1,272 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE BlockArguments #-}
+
+
+module Unison.Codebase.FileCodebase.SlimCopyRegenerateIndex (syncToDirectory) where
+
+import Unison.Prelude
+
+import           Control.Monad.State            ( MonadState, evalStateT )
+import           Control.Monad.Writer           ( MonadWriter, execWriterT )
+import qualified Control.Monad.Writer          as Writer
+import           Control.Monad.Except           ( MonadError, runExceptT, throwError )
+import           Control.Lens
+
+import           UnliftIO.Directory             ( doesFileExist )
+import           Unison.Codebase                ( CodebasePath )
+import qualified Unison.Codebase.Causal        as Causal
+import           Unison.Codebase.Branch         ( Branch(..) )
+import qualified Unison.Codebase.Branch        as Branch
+import qualified Unison.Codebase.Branch.Dependencies as BD
+import qualified Unison.Codebase.Patch         as Patch
+import qualified Unison.Codebase.Serialization as S
+import qualified Unison.Codebase.Serialization.V1 as V1
+import qualified Unison.Codebase.TermEdit      as TermEdit
+import qualified Unison.Codebase.TypeEdit      as TypeEdit
+import qualified Unison.DataDeclaration        as DD
+import qualified Unison.LabeledDependency      as LD
+import           Unison.Reference               ( Reference )
+import qualified Unison.Reference              as Reference
+import qualified Unison.Referent               as Referent
+import qualified Unison.Term                   as Term
+import           Unison.Type                    ( Type )
+import qualified Unison.Type                   as Type
+import           Unison.Var                     ( Var )
+import qualified Unison.Util.Relation          as Relation
+import           Unison.Util.Relation           ( Relation )
+import           Unison.Util.Monoid (foldMapM)
+
+import Data.Monoid.Generic
+import Unison.Codebase.FileCodebase.Common
+
+data SyncedEntities = SyncedEntities
+  { _syncedTerms       :: Set Reference.Id
+  , _syncedDecls       :: Set Reference.Id
+  , _syncedEdits       :: Set Branch.EditHash
+  , _syncedBranches    :: Set Branch.Hash
+  , _dependentsIndex   :: Relation Reference Reference.Id
+  , _typeIndex         :: Relation Reference Referent.Id
+  , _typeMentionsIndex :: Relation Reference Referent.Id
+  } deriving Generic
+  deriving Show
+  deriving Semigroup via GenericSemigroup SyncedEntities
+  deriving Monoid via GenericMonoid SyncedEntities
+
+makeLenses ''SyncedEntities
+
+syncToDirectory :: forall m v a
+  . MonadIO m
+  => Var v
+  => S.Format v
+  -> S.Format a
+  -> CodebasePath
+  -> CodebasePath
+  -> Branch m
+  -> m ()
+syncToDirectory fmtV fmtA = syncToDirectory' (S.get fmtV) (S.get fmtA)
+
+data Error
+  = MissingBranch Branch.Hash
+  | MissingPatch Branch.EditHash
+  | MissingTerm Reference.Id
+  | MissingTypeOfTerm Reference.Id
+  | MissingDecl Reference.Id
+  | InvalidBranch Branch.Hash
+  | InvalidTerm Reference.Id
+  | InvalidTypeOfTerm Reference.Id
+  | InvalidDecl Reference.Id
+  deriving Show
+
+syncToDirectory' :: forall m v a
+  . MonadIO m
+  => Var v
+  => S.Get v
+  -> S.Get a
+  -> CodebasePath
+  -> CodebasePath
+  -> Branch m
+  -> m ()
+syncToDirectory' getV getA srcPath destPath newRoot = flip evalStateT mempty do
+  result <- runExceptT do
+    deps <- execWriterT $
+      processBranches [( Branch.headHash newRoot
+                       , ( Just
+                         . pure
+                         . Branch.transform (lift . lift . lift)
+                         ) newRoot )]
+    processDependencies (BD.to' deps)
+  either (fail . show) pure result -- todo: nicer error messages here?
+  where
+  processBranches :: forall m
+     . MonadIO m
+    => MonadState SyncedEntities m
+    => MonadWriter BD.Dependencies m
+    => MonadError Error m
+    => [(Branch.Hash, Maybe (m (Branch m)))]
+    -> m ()
+  processBranches [] = pure ()
+  -- for each branch,
+  processBranches ((h, mmb) : rest) =
+    -- if hash exists at the destination, skip it, mark it done
+    flip (doFileOnce destPath syncedBranches branchPath) h $ \h ->
+      -- else if hash exists at the source, enqueue its dependencies, copy it, mark it done
+      ifM (doesFileExist (branchPath srcPath h))
+          (do
+            (branches, deps) <-
+              BD.fromRawCausal <$> deserializeRawBranchDependencies srcPath h
+            copyFileWithParents (branchPath srcPath h) (branchPath destPath h)
+            Writer.tell deps
+            processBranches (branches ++ rest))
+      -- else if it's in memory, enqueue its dependencies, write it, mark it done
+          case mmb of
+            Just mb -> do
+              b <- mb
+              let (branches, deps) = BD.fromBranch b
+              let causalRaw = Branch.toCausalRaw b
+              serializeRawBranch destPath h causalRaw
+              Writer.tell deps
+              processBranches (branches ++ rest)
+      -- else -- error?
+            Nothing -> throwError $ MissingBranch h
+  processDependencies :: forall n
+     . MonadIO n
+    => MonadState SyncedEntities n
+    => MonadError Error n
+    => BD.Dependencies'
+    -> n ()
+  processDependencies = \case
+  -- for each patch
+    -- enqueue its target term and type references
+    BD.Dependencies' (editHash : editHashes) terms decls ->
+      -- This code assumes that patches are always available on disk,
+      -- not ever just held in memory with `pure`.  If that's not the case,
+      -- then we can do something similar to what we did  with branches.
+      flip (doFileOnce destPath syncedEdits editsPath) editHash $ \h -> do
+        patch <- deserializeEdits srcPath h
+        -- I'm calling all the replacement terms dependents of the patches.
+        -- If we're supposed to replace X with Y, we don't necessarily need X,
+        -- but we do need Y.
+        let newTerms, newDecls :: [Reference.Id]
+            newTerms = [ i | TermEdit.Replace (Reference.DerivedId i) _ <-
+                                toList . Relation.ran $ Patch._termEdits patch]
+            newDecls = [ i | TypeEdit.Replace (Reference.DerivedId i) <-
+                                toList . Relation.ran $ Patch._typeEdits patch]
+        ifM (doesFileExist (editsPath srcPath h))
+            (do
+              copyFileWithParents (editsPath srcPath h) (editsPath destPath h)
+              processDependencies $
+                BD.Dependencies' editHashes (newTerms ++ terms) (newDecls ++ decls))
+            (throwError $ MissingPatch h)
+  -- for each term id
+    BD.Dependencies' [] (termHash : termHashes) decls ->
+    -- if it exists at the destination, skip it, mark it done
+      flip (doFileOnce destPath syncedTerms termPath) termHash $ \h -> do
+    -- else if it exists at the source,
+        ifM (doesFileExist (termPath srcPath h))
+          (do
+            -- copy it,
+            -- load it,
+            -- enqueue its dependencies for syncing
+            -- enqueue its type's type dependencies for syncing
+            -- enqueue its type's dependencies, type & type mentions into respective indices
+            -- and continue
+            (newTerms, newDecls) <- enqueueTermDependencies h
+            processDependencies $
+              BD.Dependencies' [] (newTerms ++ termHashes) (newDecls ++ decls)
+          )
+    -- else -- an error?
+          (throwError $ MissingTerm h)
+  -- for each decl id
+    BD.Dependencies' [] [] (declHash : declHashes) ->
+    -- if it exists at the destination, skip it, mark it done
+      flip (doFileOnce destPath syncedDecls declPath) declHash $ \h -> do
+    -- else if it exists at the source,
+        ifM (doesFileExist (declPath srcPath h))
+          -- copy it,
+          -- load it,
+          -- enqueue its type dependencies for syncing
+          -- for each constructor,
+            -- enqueue its dependencies, type, type mentions into respective indices
+          (do
+            newDecls <- copyAndIndexDecls h
+            processDependencies $ BD.Dependencies' [] [] (newDecls ++ declHashes))
+          (throwError (MissingDecl h))
+    BD.Dependencies' [] [] [] -> pure ()
+  copyAndIndexDecls :: forall m
+     . MonadIO m
+    => MonadState SyncedEntities m
+    => MonadError Error m
+    => Reference.Id
+    -> m [Reference.Id]
+  copyAndIndexDecls h = getDecl getV getA srcPath h >>= \case
+    Just decl -> do
+      copyFileWithParents (declPath srcPath h) (declPath destPath h)
+      let referentTypes :: [(Referent.Id, Type v a)]
+          referentTypes = DD.declConstructorReferents h decl
+                          `zip` (DD.constructorTypes . DD.asDataDecl) decl
+      flip foldMapM referentTypes \(r, typ) -> do
+        let dependencies = toList (Type.dependencies typ)
+        dependentsIndex <>= Relation.fromManyDom dependencies h
+        let typeForIndexing = Type.removeAllEffectVars typ
+        let typeReference = Type.toReference typeForIndexing
+        let typeMentions = Type.toReferenceMentions typeForIndexing
+        typeIndex <>= Relation.singleton typeReference r
+        typeMentionsIndex <>= Relation.fromManyDom typeMentions r
+        pure [ i | Reference.DerivedId i <- dependencies ]
+    Nothing -> throwError (InvalidDecl h)
+
+  enqueueTermDependencies :: forall m
+     . MonadIO m
+    => MonadState SyncedEntities m
+    => MonadError Error m
+    => Reference.Id
+    -> m ([Reference.Id], [Reference.Id])
+  enqueueTermDependencies h = getTerm getV getA srcPath h >>= \case
+    Just term -> do
+      let (typeDeps, termDeps) = partitionEithers . fmap LD.toReference . toList
+                               $ Term.labeledDependencies term
+      ifM (doesFileExist (typePath srcPath h))
+        (getTypeOfTerm getV getA srcPath h >>= \case
+          Just typ -> do
+            copyFileWithParents (termPath srcPath h) (termPath destPath h)
+            copyFileWithParents (typePath srcPath h) (typePath destPath h)
+            let typeDeps' = toList (Type.dependencies typ)
+            let typeForIndexing = Type.removeAllEffectVars typ
+            let typeReference = Type.toReference typeForIndexing
+            let typeMentions = Type.toReferenceMentions typeForIndexing
+            dependentsIndex <>=
+              Relation.fromManyDom (typeDeps ++ typeDeps' ++ termDeps) h
+            typeIndex <>=
+              Relation.singleton typeReference (Referent.Ref' h)
+            typeMentionsIndex <>=
+              Relation.fromManyDom typeMentions (Referent.Ref' h)
+            let newDecls = [ i | Reference.DerivedId i <- typeDeps ++ typeDeps']
+            let newTerms = [ i | Reference.DerivedId i <- termDeps ]
+            pure (newTerms, newDecls)
+          Nothing -> throwError (InvalidTypeOfTerm h))
+        (throwError (MissingTypeOfTerm h))
+    Nothing -> throwError (InvalidTerm h)
+  deserializeRawBranchDependencies :: forall m
+    . MonadIO m
+    => MonadError Error m
+    => CodebasePath
+    -> Causal.Deserialize m Branch.Raw (BD.Branches m, BD.Dependencies)
+  deserializeRawBranchDependencies root h =
+    S.getFromFile (V1.getCausal0 V1.getBranchDependencies) (branchPath root h) >>= \case
+      Nothing -> throwError (InvalidBranch h)
+      Just results -> pure results
+
+
+-- getFromFile :: MonadIO m => Get a -> FilePath -> m (Maybe a)
+
+
+-- getCausal0 getBranchDependencies
+-- :: MonadGet m => m (Causal.Raw h (BD.Branches m, BD.Dependencies))

--- a/parser-typechecker/src/Unison/Codebase/Serialization/V1.hs
+++ b/parser-typechecker/src/Unison/Codebase/Serialization/V1.hs
@@ -22,7 +22,6 @@ import           Data.Bytes.Serial              ( serialize
                                                 )
 import           Data.Bytes.Signed              ( Unsigned )
 import           Data.Bytes.VarInt              ( VarInt(..) )
-import qualified Data.Foldable                 as Foldable
 import qualified Data.Map                      as Map
 import           Data.List                      ( elemIndex
                                                 )
@@ -721,8 +720,8 @@ getBranchDependencies :: MonadGet m => m (BD.Branches n, BD.Dependencies)
 getBranchDependencies = do
   (terms1, types1) <- getTermStarDependencies
   (terms2, types2) <- getTypeStarDependencies
-  childHashes <- fmap RawHash . Foldable.toList <$> getMap skipText getHash
-  editHashes <- Set.fromList . Foldable.toList <$> getMap skipText getHash
+  childHashes <- fmap (RawHash . snd) <$> getList (getPair skipText getHash)
+  editHashes <- Set.fromList . fmap snd <$> getList (getPair skipText getHash)
   pure ( childHashes `zip` repeat Nothing
        , BD.Dependencies editHashes (terms1 <> terms2) (types1 <> types2) )
   where

--- a/parser-typechecker/tests/Unison/Test/Git.hs
+++ b/parser-typechecker/tests/Unison/Test/Git.hs
@@ -21,6 +21,7 @@ import qualified Unison.Codebase.TranscriptParser as TR
 import Unison.Codebase.FileCodebase.Reserialize as Reserialize
 import Unison.Codebase.FileCodebase.CopyFilterIndex as CopyFilterIndex
 import Unison.Codebase.FileCodebase.CopyRegenerateIndex as CopyRegenerateIndex
+import Unison.Codebase.FileCodebase.SlimCopyRegenerateIndex as SlimCopyRegenerateIndex
 import Unison.Codebase.FileCodebase.Common (SyncToDir, formatAnn)
 import qualified Unison.Codebase.Serialization.V1 as V1
 import Unison.Parser (Ann)
@@ -209,7 +210,7 @@ testPush = scope "push" $ do
   -- pushing.
   runTranscript_ tmp c setupTranscript
 
-  -- now we'll try pushing three ways.
+  -- now we'll try pushing multiple ways.
   for_ pushImplementations $ \(implName, impl) -> scope implName $ do
     -- initialize git repo
     let repoGit = tmp </> (implName ++ ".git")
@@ -282,6 +283,7 @@ testPush = scope "push" $ do
     [ ("Reserialize", Reserialize.syncToDirectory)
     , ("CopyFilterIndex", CopyFilterIndex.syncToDirectory)
     , ("CopyRegenerateIndex", CopyRegenerateIndex.syncToDirectory)
+    , ("SlimCopyRegenerateIndex", SlimCopyRegenerateIndex.syncToDirectory)
     ]
 
   groups =

--- a/parser-typechecker/tests/Unison/Test/Git.hs
+++ b/parser-typechecker/tests/Unison/Test/Git.hs
@@ -229,6 +229,10 @@ testPush = scope "push" $ do
       for_ list $ \(title, path) -> scope title $
         io (doesFileExist $ tmp </> implName </> path) >>= expect
 
+    for_ notGroups $ \(group, list) -> scope group $
+      for_ list $ \(title, path) -> scope title $
+        io (fmap not . doesFileExist $ tmp </> implName </> path) >>= expect
+
   -- if we haven't crashed, clean up!
   io $ removeDirectoryRecursive tmp
 
@@ -295,6 +299,9 @@ testPush = scope "push" $ do
     , ("typeIndex", typeIndex)
     , ("typeMentionsIndex", typeMentionsIndex) ]
 
+  notGroups =
+    [ ("notBranches", notBranches) ]
+
   types =
     [ ("M", ".unison/v1/types/#4idrjau9395kb8lsvielcjkli6dd7kkgalsfsgq4hq1k62n3vgpd2uejfuldmnutn1uch2292cj6ebr4ebvgqopucrp2j6pmv0s5uhg/compiled.ub")
     , ("A", ".unison/v1/types/#0n4pbd0q9uh78eurgn28gkqk44gdtgttv9uuvusvm1fg6dvapdn76ui86lsn761lop466vo8m80m4is9n5qukg80vr4k8fibpo58rk8/compiled.ub")
@@ -317,11 +324,22 @@ testPush = scope "push" $ do
     ]
 
   branches =
-    [ ("_head",  ".unison/v1/paths/_head/pciob2qnondela4h4u1dtk9pvbc9up7qed0j311lkomordjah2lliddis7tdl76h5mdbs5ja10tm8kh2o3sni1bu2kdsqtm4fkv5288")
-    , (".",      ".unison/v1/paths/pciob2qnondela4h4u1dtk9pvbc9up7qed0j311lkomordjah2lliddis7tdl76h5mdbs5ja10tm8kh2o3sni1bu2kdsqtm4fkv5288.ub")
-    , (".'",     ".unison/v1/paths/0ufjqqmabderbejfhrled8i4lirgpqgimejbkdnk1m9t90ibj25oi7g1h2adougdqhv72sv939eq67ur77n3qciajh0reiuqs68th00.ub")
-    , (".M",     ".unison/v1/paths/i2p08iv1l50fc934gh6kea181kvjnt3kdgiid5c4r5016kjuliesji43u4j4mjvsne3qvmq43puk9dkm61nuc542n7pchsvg6t0v55o.ub")
-    , ("<empty>",".unison/v1/paths/7asfbtqmoj56pq7b053v2jc1spgb8g5j4cg1tj97ausi3scveqa50ktv4b2ofoclnkqmnl18vnt5d83jrh85qd43nnrsh6qetbksb70.ub")
+    [ ("_head",             ".unison/v1/paths/_head/pciob2qnondela4h4u1dtk9pvbc9up7qed0j311lkomordjah2lliddis7tdl76h5mdbs5ja10tm8kh2o3sni1bu2kdsqtm4fkv5288")
+    , (".foo.inside",       ".unison/v1/paths/pciob2qnondela4h4u1dtk9pvbc9up7qed0j311lkomordjah2lliddis7tdl76h5mdbs5ja10tm8kh2o3sni1bu2kdsqtm4fkv5288.ub")
+    , (".foo.inside'",      ".unison/v1/paths/0ufjqqmabderbejfhrled8i4lirgpqgimejbkdnk1m9t90ibj25oi7g1h2adougdqhv72sv939eq67ur77n3qciajh0reiuqs68th00.ub")
+    , (".foo.inside.M",     ".unison/v1/paths/i2p08iv1l50fc934gh6kea181kvjnt3kdgiid5c4r5016kjuliesji43u4j4mjvsne3qvmq43puk9dkm61nuc542n7pchsvg6t0v55o.ub")
+    , ("<empty>",           ".unison/v1/paths/7asfbtqmoj56pq7b053v2jc1spgb8g5j4cg1tj97ausi3scveqa50ktv4b2ofoclnkqmnl18vnt5d83jrh85qd43nnrsh6qetbksb70.ub")
+    ]
+
+  notBranches =
+    [ (".",                 ".unison/v1/paths/9r7l4k8ks1tog088fg96evunq1ednlsskf2lh0nacpe5n00khcrl8f1g5sevm7cqd3s64cj22ukvkh2fflm3rhhkn2hh2rj1n20mnm8.ub")
+    , (".'",                ".unison/v1/paths/llton7oiormlimkdmqjdr8tja12i6tebii7cmfd7545b7mt1sb02f9usjqnjd6iaisnn1ngpsl76hfg024l8dlult3s6stkt28j42sg.ub")
+    , (".''",               ".unison/v1/paths/givahf3f6fu8vv07kglsofdcoem7q5dm4rracr78a5didjc4pq2djh2rfdo5sn7nld2757oi02a4a07cv9rk4peafhh76nllcp8l1n8.ub")
+    , (".foo",              ".unison/v1/paths/a8dt4i16905fql2d4fbmtipmj35tj6qmkq176dlnsn6klh0josr255eobn0d3f0aku360h0em6oit9ftjpq3vhcdap8bgpqr79qne58.ub")
+    , (".foo'",             ".unison/v1/paths/l3r86dvdmbe2lsinh213tp9upm5qjtk17iep3n5mah7qg5bupj1e7ikpv1iqbgegp895r0krlo0u2c4nclvfvch3e6kspu766th6tqo.ub")
+    , (".foo.outside",      ".unison/v1/paths/s6iquav10f69pvrpj6rtm7vcp6fs6hgnnmjb1qs00n594ljugbf2qtls93oc4lvb3kjro8fpakoua05gqido4haj4m520rip2gu2hvo.ub")
+    , (".foo.outside.A",    ".unison/v1/paths/2i1lh7pntl3rqrtn4c10ajdg4m3al1rqm6u6ak5ak6urgsaf6nhqn2olt3rjqj5kcj042h8lqseguk3opp019hc7g8ncukds25t9r40.ub")
+    , (".foo.outside.B",    ".unison/v1/paths/jag86haq235jmifji4n8nff8dg1ithenefs2uk5ms6b4qgj9pfa9g40vs4kdn3uhm066ni0bvfb7ib9tqtdgqcn90eadl7282nqqbc0.ub")
     ]
 
   patches =

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -39,6 +39,7 @@ library
     Unison.Codecs
     Unison.Codebase
     Unison.Codebase.Branch
+    Unison.Codebase.Branch.Dependencies
     Unison.Codebase.BranchDiff
     Unison.Codebase.BranchUtil
     Unison.Codebase.Causal
@@ -66,6 +67,7 @@ library
     Unison.Codebase.FileCodebase.Reserialize
     Unison.Codebase.FileCodebase.CopyFilterIndex
     Unison.Codebase.FileCodebase.CopyRegenerateIndex
+    Unison.Codebase.FileCodebase.SlimCopyRegenerateIndex
     Unison.Codebase.GitError
     Unison.Codebase.Metadata
     Unison.Codebase.NameEdit

--- a/unison-core/src/Unison/LabeledDependency.hs
+++ b/unison-core/src/Unison/LabeledDependency.hs
@@ -54,11 +54,3 @@ toReference = \case
   X (Left r)             -> Left r
   X (Right (Ref' r))     -> Right r
   X (Right (Con' r _ _)) -> Left r
-
----- | Left Decl | Right Term
---toReferenceId :: LabeledDependency -> Maybe (Either Id Id)
---toReferenceId = \case
---  X (Left (DerivedId i))            -> Just (Left i)
---  X (Right (Ref (DerivedId i)))     -> Just (Right i)
---  X (Right (Con (DerivedId i) _ _)) -> Just (Left i)
---  _                                 -> Nothing

--- a/unison-core/src/Unison/LabeledDependency.hs
+++ b/unison-core/src/Unison/LabeledDependency.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE PatternSynonyms #-}
 
-module Unison.LabeledDependency 
+module Unison.LabeledDependency
   ( derivedTerm
   , derivedType
   , termRef
@@ -10,6 +10,7 @@ module Unison.LabeledDependency
   , effectConstructor
   , fold
   , referents
+  , toReference
   , LabeledDependency
   , partition
   ) where
@@ -18,7 +19,7 @@ import Unison.Prelude hiding (fold)
 
 import Unison.ConstructorType (ConstructorType(Data, Effect))
 import Unison.Reference (Reference(DerivedId), Id)
-import Unison.Referent (Referent, pattern Ref, pattern Con)
+import Unison.Referent (Referent, pattern Ref, pattern Con, Referent'(Ref', Con'))
 import qualified Data.Set as Set
 
 -- dumb constructor name is private
@@ -45,4 +46,19 @@ fold :: (Reference -> a) -> (Referent -> a) -> LabeledDependency -> a
 fold f g (X e) = either f g e
 
 partition :: Foldable t => t LabeledDependency -> ([Reference], [Referent])
-partition = partitionEithers . map (\(X e) -> e) . toList 
+partition = partitionEithers . map (\(X e) -> e) . toList
+
+-- | Left TypeRef | Right TermRef
+toReference :: LabeledDependency -> Either Reference Reference
+toReference = \case
+  X (Left r)             -> Left r
+  X (Right (Ref' r))     -> Right r
+  X (Right (Con' r _ _)) -> Left r
+
+---- | Left Decl | Right Term
+--toReferenceId :: LabeledDependency -> Maybe (Either Id Id)
+--toReferenceId = \case
+--  X (Left (DerivedId i))            -> Just (Left i)
+--  X (Right (Ref (DerivedId i)))     -> Just (Right i)
+--  X (Right (Con (DerivedId i) _ _)) -> Just (Left i)
+--  _                                 -> Nothing


### PR DESCRIPTION
## Overview

This replaces the `Causal.sync`-based algorithm that had underlaid ucm's git syncing.

It is way faster and uses way less memory.

The algorithm has three phases:
1. `processBranches`: Work through a queue of branches (which may be in-memory, or on-disk), loading them, aggregating referenced terms (including metadata values), decls, and patches.  Any ancestor branches or child branches encountered are pushed back onto this queue.
2. `processDependencies` Work through through a queue of patches, terms, and decls, loading each, adding its dependencies onto this queue, and building `dependent-index`, `type-index`, and `type-mentions-index` relations in memory.
3. Write the three index relations from memory to the destination codebase.

Some nice timing data at https://github.com/unisonweb/unison/issues/1535#issuecomment-628061034

Closes #1546 "`pull base:.trunk _base` hangs"
Helps #1535 "slowness with push / pull / merge"
Closes #1512 "slow push of oldish codebase"
Closes #1423 "should sync dependents of patches"

## Test coverage

I beefed up the git tests a little, but we could use a regression test to ensure that metadata is synced — although we have seen in #1547 that such metadata is noticed when missing, so it probably syncs fine; just no regression test yet.

## Loose ends

- [ ] various cleanup: docs, organization maybe?
- [x] bombs on some codebases that had been allowed to synced previously despite missing dependencies