### PR TITLE
Add caching layer to avoid hitting disk for namespace, term, and type loads from codebase

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -519,8 +519,8 @@ sync
   -> Branch m
   -> m ()
 sync exists serializeRaw serializeEdits b = do
-  written <- State.execStateT (sync' exists serializeRaw serializeEdits b) mempty
-  traceM $ "Branch.sync wrote " <> show (Set.size written) <> " namespace files."
+  _written <- State.execStateT (sync' exists serializeRaw serializeEdits b) mempty
+  -- traceM $ "Branch.sync wrote " <> show (Set.size written) <> " namespace files."
   pure ()
 
 -- serialize a `Branch m` indexed by the hash of its corresponding Raw

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -83,6 +83,8 @@ module Unison.Codebase.Branch
     -- * Branch serialization
   , read
   , cachedRead
+  , boundedCache
+  , Cache
   , sync
 
     -- * Unused
@@ -457,10 +459,16 @@ data ForkFailure = SrcNotFound | DestExists
 numHashChars :: Branch m -> Int
 numHashChars _b = 3
 
+-- This type is a little ugly, so we wrap it up with a nice type alias for
+-- use outside this module.
+type Cache m = Cache.Cache m (Causal.RawHash Raw) (Causal m Raw (Branch0 m))
+
+boundedCache :: MonadIO m => Word -> m (Cache m)
+boundedCache = Cache.semispaceCache
+
 -- todo: can delete old `read` once we are confident in this
 cachedRead :: forall m . Monad m
-           => Cache.Cache m (Causal.RawHash Raw)
-                            (Causal m Raw (Branch0 m))
+           => Cache m
            -> Causal.Deserialize m Raw Raw
            -> (EditHash -> m Patch)
            -> Hash

--- a/parser-typechecker/src/Unison/Codebase/Causal.hs
+++ b/parser-typechecker/src/Unison/Codebase/Causal.hs
@@ -127,14 +127,6 @@ cachedRead cache deserializeRaw h = Cache.lookup cache h >>= \case
   where
     read = cachedRead cache deserializeRaw
 
-read :: Functor m => Deserialize m h e -> RawHash h -> m (Causal m h e)
-read d h = go <$> d h where
-  go = \case
-    RawOne e -> One h e
-    RawCons e tailHash -> Cons h e (tailHash, read d tailHash)
-    RawMerge e tailHashes ->
-      Merge h e (Map.fromList [(h, read d h) | h <- toList tailHashes ])
-
 type Serialize m h e = RawHash h -> Raw h e -> m ()
 
 -- Sync a causal to some persistent store, stopping when hitting a Hash which

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -88,9 +88,10 @@ commandLine
   -> (SourceName -> IO LoadSourceResult)
   -> Codebase IO v Ann
   -> (Int -> IO gen)
+  -> Branch.Cache IO
   -> Free (Command IO i v) a
   -> IO a
-commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSource codebase rngGen =
+commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSource codebase rngGen branchCache =
  Free.foldWithIndex go
  where
   go :: forall x . Int -> Command IO i v x -> IO x
@@ -119,10 +120,10 @@ commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSour
     SyncLocalRootBranch branch -> do
       setBranchRef branch
       Codebase.putRootBranch codebase branch
-    ViewRemoteBranch ns -> runExceptT $ Git.viewRemoteBranch ns
-    ImportRemoteBranch ns -> runExceptT $ Git.importRemoteBranch codebase ns
+    ViewRemoteBranch ns -> runExceptT $ Git.viewRemoteBranch branchCache ns
+    ImportRemoteBranch ns -> runExceptT $ Git.importRemoteBranch codebase branchCache ns
     SyncRemoteRootBranch repo branch ->
-      runExceptT $ Git.pushGitRootBranch codebase branch repo
+      runExceptT $ Git.pushGitRootBranch codebase branchCache branch repo
     LoadTerm r -> Codebase.getTerm codebase r
     LoadType r -> Codebase.getTypeDeclaration codebase r
     LoadTypeOfTerm r -> Codebase.getTypeOfTerm codebase r

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -56,6 +56,7 @@ import qualified Unison.Referent               as Referent
 import qualified Unison.Util.TQueue            as TQueue
 import           Unison.Var                     ( Var )
 import qualified Unison.UnisonFile             as UF
+import qualified Unison.Util.Cache             as Cache
 import qualified Unison.Util.Pretty            as P
 import qualified Unison.PrettyTerminal         as PT
 import           Unison.Symbol                  ( Symbol )
@@ -102,13 +103,14 @@ import qualified Unison.Codebase.FileCodebase.Reserialize as Sync
 initCodebaseAndExit :: Maybe FilePath -> IO ()
 initCodebaseAndExit mdir = do
   dir <- getCodebaseDir mdir
-  _ <- initCodebase dir
+  cache <- Cache.cache
+  _ <- initCodebase cache dir
   exitSuccess
 
 -- initializes a new codebase here (i.e. `ucm -codebase dir init`)
-initCodebase :: FilePath -> IO (Codebase IO Symbol Ann)
-initCodebase path = do
-  theCodebase <- codebase1 V1.formatSymbol Common.formatAnn path
+initCodebase :: Branch.Cache IO -> FilePath -> IO (Codebase IO Symbol Ann)
+initCodebase cache path = do
+  theCodebase <- codebase1 cache V1.formatSymbol Common.formatAnn path
   prettyDir <- P.string <$> canonicalizePath path
 
   whenM (codebaseExists path) $
@@ -126,12 +128,12 @@ initCodebase path = do
   pure theCodebase
 
 -- get the codebase in dir, or in the home directory if not provided.
-getCodebaseOrExit :: Maybe FilePath -> IO (Codebase IO Symbol Ann)
-getCodebaseOrExit mdir = do
+getCodebaseOrExit :: Branch.Cache IO -> Maybe FilePath -> IO (Codebase IO Symbol Ann)
+getCodebaseOrExit cache mdir = do
   dir <- getCodebaseDir mdir
   prettyDir <- P.string <$> canonicalizePath dir
   let errMsg = getNoCodebaseErrorMsg prettyDir mdir
-  let theCodebase = codebase1 V1.formatSymbol formatAnn dir
+  let theCodebase = codebase1 cache V1.formatSymbol formatAnn dir
   unlessM (codebaseExists dir) $ do
     PT.putPrettyLn' errMsg
     exitFailure
@@ -162,18 +164,16 @@ codebase1
    . MonadUnliftIO m
   => Var v
   => BuiltinAnnotation a
-  => S.Format v -> S.Format a -> CodebasePath -> m (Codebase m v a)
+  => Branch.Cache m -> S.Format v -> S.Format a -> CodebasePath -> m (Codebase m v a)
 codebase1 = codebase1' Sync.syncToDirectory
-
--- cache :: (MonadIO m, Ord k) => (k -> m (Maybe v)) -> m (k -> m (Maybe v))
 
 codebase1'
   :: forall m v a
    . MonadUnliftIO m
   => Var v
   => BuiltinAnnotation a
-  => Common.SyncToDir m v a -> S.Format v -> S.Format a -> CodebasePath -> m (Codebase m v a)
-codebase1' syncToDirectory fmtV@(S.Format getV putV) fmtA@(S.Format getA putA) path = do
+  => Common.SyncToDir m v a -> Branch.Cache m -> S.Format v -> S.Format a -> CodebasePath -> m (Codebase m v a)
+codebase1' syncToDirectory branchCache fmtV@(S.Format getV putV) fmtA@(S.Format getA putA) path = do
   let c =
         Codebase
           (getTerm getV getA path)
@@ -181,10 +181,10 @@ codebase1' syncToDirectory fmtV@(S.Format getV putV) fmtA@(S.Format getA putA) p
           (getDecl getV getA path)
           (putTerm putV putA path)
           (putDecl putV putA path)
-          (getRootBranch path)
+          (getRootBranch branchCache path)
           (putRootBranch path)
           (branchHeadUpdates path)
-          (branchFromFiles path)
+          (branchFromFiles branchCache path)
           dependents
           (flip (syncToDirectory fmtV fmtA) path)
           (syncToDirectory fmtV fmtA path)

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -174,11 +174,14 @@ codebase1'
   => BuiltinAnnotation a
   => Common.SyncToDir m v a -> Branch.Cache m -> S.Format v -> S.Format a -> CodebasePath -> m (Codebase m v a)
 codebase1' syncToDirectory branchCache fmtV@(S.Format getV putV) fmtA@(S.Format getA putA) path = do
+  termCache <- Cache.semispaceCache 8192
+  typeOfTermCache <- Cache.semispaceCache 8192
+  declCache <- Cache.semispaceCache 1024
   let c =
         Codebase
-          (getTerm getV getA path)
-          (getTypeOfTerm getV getA path)
-          (getDecl getV getA path)
+          (Cache.applyDefined termCache $ getTerm getV getA path)
+          (Cache.applyDefined typeOfTermCache $ getTypeOfTerm getV getA path)
+          (Cache.applyDefined declCache $ getDecl getV getA path)
           (putTerm putV putA path)
           (putDecl putV putA path)
           (getRootBranch branchCache path)

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase/Reserialize.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase/Reserialize.hs
@@ -31,7 +31,6 @@ import Unison.DataDeclaration as DD
 import Unison.Codebase (BuiltinAnnotation, CodebasePath)
 import qualified Unison.Term as Term
 import qualified Unison.Type as Type
-import qualified Data.Set as Set
 
 data SyncedEntities = SyncedEntities
   { _syncedTerms :: Set Reference.Id
@@ -71,16 +70,13 @@ syncToDirectory
   -> Branch m
   -> m ()
 syncToDirectory fmtV fmtA srcPath destPath branch = do
-  written <- flip execStateT mempty $
+  _written <- flip execStateT mempty $
     Branch.sync
       (hashExists destPath)
       serialize
       (serializeEdits destPath)
       (Branch.transform lift branch)
-  traceM $ "syncToDirectory: wrote " <> show (Set.size (_syncedTerms written))
-        <> " terms"
-  traceM $ "syncToDirectory: wrote " <> show (Set.size (_syncedDecls written))
-        <> " decls"
+  pure ()
  where
   serialize rh rawBranch = do
     writeBranch $ Causal.rawHead rawBranch

--- a/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
@@ -106,8 +106,8 @@ parse srcName txt = case P.parse (stanzas <* P.eof) srcName txt of
   Right a -> Right a
   Left e -> Left (show e)
 
-run :: FilePath -> FilePath -> [Stanza] -> Codebase IO Symbol Ann -> IO Text
-run dir configFile stanzas codebase = do
+run :: FilePath -> FilePath -> [Stanza] -> Codebase IO Symbol Ann -> Branch.Cache IO -> IO Text
+run dir configFile stanzas codebase branchCache = do
   let initialPath = Path.absoluteEmpty
   let startRuntime = pure Rt1.runtime
   putPrettyLn $ P.lines [
@@ -266,7 +266,7 @@ run dir configFile stanzas codebase = do
           "\128721", "",
           "The transcript failed due to an error encountered in the stanza above.", "",
           "Run `ucm -codebase " <> Text.pack dir <> "` " <> "to do more work with it."]
-        
+
       dieUnexpectedSuccess :: IO ()
       dieUnexpectedSuccess = do
         errOk <- readIORef allowErrors
@@ -291,6 +291,7 @@ run dir configFile stanzas codebase = do
                                      loadPreviousUnisonBlock
                                      codebase
                                      rng
+                                     branchCache
                                      free
         case o of
           Nothing -> do

--- a/parser-typechecker/src/Unison/CommandLine/Main.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Main.hs
@@ -163,8 +163,9 @@ main
   -> [Either Event Input]
   -> IO (Runtime v)
   -> Codebase IO v Ann
+  -> Branch.Cache IO
   -> IO ()
-main dir defaultBaseLib initialPath configFile initialInputs startRuntime codebase = do
+main dir defaultBaseLib initialPath configFile initialInputs startRuntime codebase branchCache = do
   dir' <- shortenDirectory dir
   root <- fromMaybe Branch.empty . rightMay <$> Codebase.getRootBranch codebase
   putPrettyLn $ case defaultBaseLib of
@@ -251,6 +252,7 @@ main dir defaultBaseLib initialPath configFile initialInputs startRuntime codeba
                                      loadSourceFile
                                      codebase
                                      (const Random.getSystemDRG)
+                                     branchCache
                                      free
         case o of
           Nothing -> pure ()

--- a/parser-typechecker/src/Unison/Util/Cache.hs
+++ b/parser-typechecker/src/Unison/Util/Cache.hs
@@ -2,6 +2,7 @@
 
 module Unison.Util.Cache where
 
+import Unison.Prelude
 import UnliftIO (MonadIO, newTVarIO, modifyTVar, atomically, readTVarIO)
 import qualified Data.Map as Map
 
@@ -16,3 +17,18 @@ cache f = do
          atomically $ modifyTVar t (Map.insert k v)
          pure v
        Just v -> pure v
+
+cacheDefined
+  :: (MonadIO m, Applicative g, Traversable g, Ord k)
+  => (k -> m (g v)) -> m (k -> m (g v))
+cacheDefined f = do
+  t <- newTVarIO Map.empty
+  pure $ \k -> do
+     m <- readTVarIO t
+     case Map.lookup k m of
+       Nothing -> do
+         v <- f k
+         -- we only populate the cache if f returns `Just`
+         for_ v $ \v -> atomically $ modifyTVar t (Map.insert k v)
+         pure v
+       Just v -> pure (pure v)

--- a/parser-typechecker/src/Unison/Util/Cache.hs
+++ b/parser-typechecker/src/Unison/Util/Cache.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE BlockArguments #-}
+
+module Unison.Util.Cache where
+
+import UnliftIO (MonadIO, newTVarIO, modifyTVar, atomically, readTVarIO)
+import qualified Data.Map as Map
+
+cache :: (MonadIO m, Ord k) => (k -> m v) -> m (k -> m v)
+cache f = do
+  t <- newTVarIO Map.empty
+  pure $ \k -> do
+     m <- readTVarIO t
+     case Map.lookup k m of
+       Nothing -> do
+         v <- f k
+         atomically $ modifyTVar t (Map.insert k v)
+         pure v
+       Just v -> pure v

--- a/parser-typechecker/src/Unison/Util/Cache.hs
+++ b/parser-typechecker/src/Unison/Util/Cache.hs
@@ -26,12 +26,16 @@ cache = do
 
   pure $ Cache lookup insert
 
+nullCache :: (MonadIO m, Ord k) => m (Cache m k v)
+nullCache = pure $ Cache (const (pure Nothing)) (\_ _ -> pure ())
+
 -- Create a cache of bounded size. Once the cache
 -- reaches a size of `maxSize`, older unused entries
 -- are evicted from the cache. Unlike LRU caching,
 -- where cache hits require updating LRU info,
 -- cache hits here are read-only and contention free.
 semispaceCache :: (MonadIO m, Ord k) => Word -> m (Cache m k v)
+semispaceCache 0 = nullCache
 semispaceCache maxSize = do
   -- Analogous to semispace GC, keep 2 maps: gen0 and gen1
   -- `insert k v` is done in gen0

--- a/parser-typechecker/src/Unison/Util/Cache.hs
+++ b/parser-typechecker/src/Unison/Util/Cache.hs
@@ -4,7 +4,7 @@ module Unison.Util.Cache where
 
 import Prelude hiding (lookup)
 import Unison.Prelude
-import UnliftIO (MonadIO, newTVarIO, modifyTVar, writeTVar, atomically, readTVar, readTVarIO)
+import UnliftIO (MonadIO, newTVarIO, modifyTVar', writeTVar, atomically, readTVar, readTVarIO)
 import qualified Data.Map as Map
 
 data Cache m k v =
@@ -21,7 +21,7 @@ cache = do
     insert k v = do
       m <- readTVarIO t
       case Map.lookup k m of
-        Nothing -> atomically $ modifyTVar t (Map.insert k v)
+        Nothing -> atomically $ modifyTVar' t (Map.insert k v)
         _ -> pure ()
 
   pure $ Cache lookup insert
@@ -51,7 +51,7 @@ semispaceCache maxSize = do
             Just v -> insert k v $> Just v
         just -> pure just
     insert k v = atomically $ do
-      modifyTVar gen0 (Map.insert k v)
+      modifyTVar' gen0 (Map.insert k v)
       m0 <- readTVar gen0
       when (fromIntegral (Map.size m0) >= maxSize) $ do
         writeTVar gen1 m0

--- a/parser-typechecker/src/Unison/Util/Cache.hs
+++ b/parser-typechecker/src/Unison/Util/Cache.hs
@@ -34,9 +34,9 @@ cache = do
 semispaceCache :: (MonadIO m, Ord k) => Word -> m (Cache m k v)
 semispaceCache maxSize = do
   -- Analogous to semispace GC, keep 2 maps: gen0 and gen1
-  -- `lookup k` is done in gen0;
+  -- `insert k v` is done in gen0
   --   if full, gen1 = gen0; gen0 = Map.empty
-  -- `insert k v` is done in gen0, then gen1
+  -- `lookup k` is done in gen0; then gen1
   --   if found in gen0, return immediately
   --   if found in gen1, `insert k v`, then return
   -- Thus, older keys not recently looked up are forgotten

--- a/parser-typechecker/src/Unison/Util/Timing.hs
+++ b/parser-typechecker/src/Unison/Util/Timing.hs
@@ -9,7 +9,11 @@ import Data.Time.Clock.System (getSystemTime, systemToTAITime)
 import Data.Time.Clock.TAI (diffAbsoluteTime)
 import Data.Time.Clock (picosecondsToDiffTime)
 
+enabled :: Bool
+enabled = False
+
 time :: MonadIO m => String -> m a -> m a
+time _ ma | not enabled = ma
 time label ma = do
   systemStart <- liftIO getSystemTime
   cpuPicoStart <- liftIO getCPUTime
@@ -23,6 +27,7 @@ time label ma = do
   pure a
 
 unsafeTime :: Monad m => String -> m a -> m a
+unsafeTime _ ma | not enabled = ma
 unsafeTime label ma = do
   let !systemStart = unsafePerformIO getSystemTime
       !cpuPicoStart = unsafePerformIO getCPUTime

--- a/parser-typechecker/tests/Suite.hs
+++ b/parser-typechecker/tests/Suite.hs
@@ -5,12 +5,17 @@ module Main where
 import           EasyTest
 import           System.Environment (getArgs)
 import           System.IO
+import qualified Unison.Core.Test.Name as Name
 import qualified Unison.Test.ABT as ABT
+import qualified Unison.Test.Cache as Cache
+import qualified Unison.Test.Codebase as Codebase
 import qualified Unison.Test.Codebase.Causal as Causal
+import qualified Unison.Test.Codebase.FileCodebase as FileCodebase
 import qualified Unison.Test.Codebase.Path as Path
 import qualified Unison.Test.ColorText as ColorText
 import qualified Unison.Test.DataDeclaration as DataDeclaration
 import qualified Unison.Test.FileParser as FileParser
+import qualified Unison.Test.Git as Git
 import qualified Unison.Test.Lexer as Lexer
 import qualified Unison.Test.Range as Range
 import qualified Unison.Test.Referent as Referent
@@ -23,18 +28,15 @@ import qualified Unison.Test.Typechecker as Typechecker
 import qualified Unison.Test.Typechecker.Context as Context
 import qualified Unison.Test.Typechecker.TypeError as TypeError
 import qualified Unison.Test.UnisonSources as UnisonSources
+import qualified Unison.Test.UriParser as UriParser
 import qualified Unison.Test.Util.Bytes as Bytes
 import qualified Unison.Test.Var as Var
 import qualified Unison.Test.VersionParser as VersionParser
-import qualified Unison.Test.Codebase as Codebase
-import qualified Unison.Test.Codebase.FileCodebase as FileCodebase
-import qualified Unison.Test.UriParser as UriParser
-import qualified Unison.Test.Git as Git
-import qualified Unison.Core.Test.Name as Name
 
 test :: Test ()
 test = tests
-  [ Lexer.test
+  [ Cache.test
+  , Lexer.test
   , Term.test
   , TermParser.test
   , TermPrinter.test

--- a/parser-typechecker/tests/Unison/Test/Cache.hs
+++ b/parser-typechecker/tests/Unison/Test/Cache.hs
@@ -1,0 +1,80 @@
+module Unison.Test.Cache where
+
+import EasyTest
+import Control.Monad
+import Control.Concurrent.STM
+import Control.Concurrent.Async
+import qualified Unison.Util.Cache as Cache
+
+test :: Test ()
+test = scope "util.cache" $ tests [
+    scope "ex1" $ fits Cache.cache
+  , scope "ex2" $ fits (Cache.semispaceCache n)
+  , scope "ex3" $ doesn'tFit (Cache.semispaceCache n)
+  , scope "ex4" $ do
+    replicateM_ 10 $ concurrent (Cache.semispaceCache n)
+    ok
+  ]
+  where
+    n :: Word
+    n = 1000
+
+    -- This checks that items properly expire from the cache
+    doesn'tFit mkCache = do
+      cache <- io $ mkCache
+      misses <- io $ newTVarIO 0
+      let f x = do
+            atomically $ modifyTVar misses (+1)
+            pure x
+      -- populate the cache, all misses (n*2), but first 1-n will have expired by the end
+      results1 <- io $ traverse (Cache.apply cache f) [1..n*2]
+      -- should be half hits, so an additional `n` misses
+      results2 <- io $ traverse (Cache.apply cache f) (reverse [1..n*2])
+      misses <- io $ readTVarIO misses
+      expect' (results1 == [1..n*2])
+      expect' (results2 == reverse [1..n*2])
+      expect (misses == n * 3)
+
+    -- This checks the simple case that everything fits in the cache
+    fits mkCache = do
+      cache <- io $ mkCache
+      misses <- io $ newTVarIO 0
+      let f x = do
+            atomically $ modifyTVar misses (+1)
+            pure x
+      -- populate the cache
+      results1 <- io $ traverse (Cache.apply cache f) [1..n]
+      -- should be all hits
+      results2 <- io $ traverse (Cache.apply cache f) [1..n]
+      misses <- io $ readTVarIO misses
+      expect' (results1 == [1..n])
+      expect' (results2 == [1..n])
+      expect (misses == n)
+
+    -- A simple smoke test of concurrent access. The cache doesn't
+    -- try to linearize all reads / writes so the number of misses
+    -- during concurrent access is unpredictable, but once the cache is
+    -- fully populated, concurrent reads should generate no further misses
+    concurrent mkCache = do
+      cache <- io $ mkCache
+      misses <- io $ newTVarIO 0
+      let f x = do
+            atomically $ modifyTVar misses (+1)
+            pure x
+      -- we're populating the cache in parallel
+      results1 <- io $ async $ traverse (Cache.apply cache f) [1 .. (n `div` 2)]
+      results2 <- io $ async $ traverse (Cache.apply cache f) [(n `div` 2 + 1) .. n]
+      (results1, results2) <- io $ waitBoth results1 results2
+      -- now the cache should be fully populated, so no further misses
+      misses1 <- io $ readTVarIO misses
+
+      -- these should be all hits
+      results3 <- io $ async $ traverse (Cache.apply cache f) [1 .. (n `div` 2)]
+      results4 <- io $ async $ traverse (Cache.apply cache f) [(n `div` 2 + 1) .. n]
+      (results3, results4) <- io $ waitBoth results3 results4
+
+      misses2 <- io $ readTVarIO misses
+      expect' (results1 ++ results2 == [1..n])
+      expect' (results3 ++ results4 == [1..n])
+      expect' (misses1 == misses2)
+

--- a/parser-typechecker/tests/Unison/Test/Git.hs
+++ b/parser-typechecker/tests/Unison/Test/Git.hs
@@ -216,9 +216,8 @@ testPush = scope "push" $ do
     io $ "git" ["init", "--bare", Text.pack repoGit]
 
     -- push one way!
-    runTranscript_ tmp
-      (FC.codebase1' impl V1.formatSymbol formatAnn codebasePath)
-      (pushTranscript repoGit)
+    codebase <- io $ FC.codebase1' impl V1.formatSymbol formatAnn codebasePath
+    runTranscript_ tmp codebase (pushTranscript repoGit)
 
     -- check out the resulting repo so we can inspect it
     io $ "git" ["clone", Text.pack repoGit, Text.pack $ tmp </> implName ]

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -123,6 +123,7 @@ library
     Unison.UnisonFile
     Unison.Util.AnnotatedText
     Unison.Util.Bytes
+    Unison.Util.Cache
     Unison.Util.ColorText
     Unison.Util.Exception
     Unison.Util.Free

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -238,6 +238,7 @@ executable unison
   build-depends:
     base,
     containers,
+    configurator,
     directory,
     errors,
     filepath,

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -272,6 +272,7 @@ executable tests
     easytest
   other-modules:
     Unison.Test.ABT
+    Unison.Test.Cache
     Unison.Test.Codebase
     Unison.Test.Codebase.Causal
     Unison.Test.Codebase.FileCodebase
@@ -301,6 +302,7 @@ executable tests
     Unison.Core.Test.Name
 
   build-depends:
+    async,
     base,
     bytestring,
     containers,
@@ -315,6 +317,7 @@ executable tests
     megaparsec,
     mtl,
     raw-strings-qq,
+    stm,
     shellmet,
     split,
     temporary,

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -1,5 +1,6 @@
 {-# Language OverloadedStrings #-}
 {-# Language PartialTypeSignatures #-}
+{-# Language ScopedTypeVariables #-}
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 
 module Main where
@@ -8,16 +9,20 @@ import Unison.Prelude
 import           Control.Concurrent             ( mkWeakThreadId, myThreadId )
 import           Control.Error.Safe             (rightMay)
 import           Control.Exception              ( throwTo, AsyncException(UserInterrupt) )
+import           Data.Configurator.Types        ( Config )
 import           System.Directory               ( getCurrentDirectory, removeDirectoryRecursive )
 import           System.Environment             ( getArgs )
 import           System.Mem.Weak                ( deRefWeak )
+import qualified Unison.Codebase.Branch        as Branch
 import qualified Unison.Codebase.Editor.VersionParser as VP
 import           Unison.Codebase.Execute        ( execute )
 import qualified Unison.Codebase.FileCodebase  as FileCodebase
 import           Unison.Codebase.Editor.RemoteRepo (RemoteNamespace)
+import           Unison.CommandLine             ( watchConfig )
 import qualified Unison.CommandLine.Main       as CommandLine
 import qualified Unison.Runtime.Rt1IO          as Rt1
 import qualified Unison.Codebase.Path          as Path
+import qualified Unison.Util.Cache             as Cache
 import qualified Version
 import qualified Unison.Codebase.TranscriptParser as TR
 import qualified System.Path as Path
@@ -25,10 +30,12 @@ import qualified System.Posix.Signals as Sig
 import qualified System.FilePath as FP
 import qualified System.IO.Temp as Temp
 import qualified System.Exit as Exit
+import System.IO.Error (catchIOError)
 import qualified Unison.Codebase.Editor.Input as Input
 import qualified Unison.Util.Pretty as P
 import qualified Unison.PrettyTerminal as PT
 import qualified Data.Text as Text
+import qualified Data.Configurator as Config
 import Text.Megaparsec (runParser)
 
 usage :: P.Pretty P.ColorText
@@ -114,56 +121,61 @@ main = do
            _                                 -> (Nothing, args)
   currentDir <- getCurrentDirectory
   configFilePath <- getConfigFilePath mcodepath
+  config@(config_, _cancelConfig) <-
+    catchIOError (watchConfig configFilePath) $ \_ ->
+      Exit.die "Your .unisonConfig could not be loaded. Check that it's correct!"
+  branchCacheSize :: Word <- Config.lookupDefault 4096 config_ "NamespaceCacheSize"
+  branchCache <- Cache.semispaceCache branchCacheSize
   case restargs of
     [] -> do
-      theCodebase <- FileCodebase.getCodebaseOrExit mcodepath
-      launch currentDir configFilePath theCodebase []
+      theCodebase <- FileCodebase.getCodebaseOrExit branchCache mcodepath
+      launch currentDir config theCodebase branchCache []
     [version] | isFlag "version" version ->
       putStrLn $ "ucm version: " ++ Version.gitDescribe
     [help] | isFlag "help" help -> PT.putPrettyLn usage
     ["init"] -> FileCodebase.initCodebaseAndExit mcodepath
     "run" : [mainName] -> do
-      theCodebase <- FileCodebase.getCodebaseOrExit mcodepath
+      theCodebase <- FileCodebase.getCodebaseOrExit branchCache mcodepath
       execute theCodebase Rt1.runtime mainName
     "run.file" : file : [mainName] | isDotU file -> do
       e <- safeReadUtf8 file
       case e of
         Left _ -> PT.putPrettyLn $ P.callout "⚠️" "I couldn't find that file or it is for some reason unreadable."
         Right contents -> do
-          theCodebase <- FileCodebase.getCodebaseOrExit mcodepath
+          theCodebase <- FileCodebase.getCodebaseOrExit branchCache mcodepath
           let fileEvent = Input.UnisonFileChanged (Text.pack file) contents
-          launch currentDir configFilePath theCodebase [Left fileEvent, Right $ Input.ExecuteI mainName, Right Input.QuitI]
+          launch currentDir config theCodebase branchCache [Left fileEvent, Right $ Input.ExecuteI mainName, Right Input.QuitI]
     "run.pipe" : [mainName] -> do
       e <- safeReadUtf8StdIn
       case e of
         Left _ -> PT.putPrettyLn $ P.callout "⚠️" "I had trouble reading this input."
         Right contents -> do
-          theCodebase <- FileCodebase.getCodebaseOrExit mcodepath
+          theCodebase <- FileCodebase.getCodebaseOrExit branchCache mcodepath
           let fileEvent = Input.UnisonFileChanged (Text.pack "<standard input>") contents
-          launch currentDir configFilePath theCodebase [Left fileEvent, Right $ Input.ExecuteI mainName, Right Input.QuitI]
+          launch currentDir config theCodebase branchCache [Left fileEvent, Right $ Input.ExecuteI mainName, Right Input.QuitI]
     "transcript" : args' ->
       case args' of
-      "-save-codebase" : transcripts -> runTranscripts False True mcodepath transcripts
-      _                              -> runTranscripts False False mcodepath args'
+      "-save-codebase" : transcripts -> runTranscripts branchCache False True mcodepath transcripts
+      _                              -> runTranscripts branchCache False False mcodepath args'
     "transcript.fork" : args' ->
       case args' of
-      "-save-codebase" : transcripts -> runTranscripts True True mcodepath transcripts
-      _                              -> runTranscripts True False mcodepath args'
+      "-save-codebase" : transcripts -> runTranscripts branchCache True True mcodepath transcripts
+      _                              -> runTranscripts branchCache True False mcodepath args'
     _ -> do
       PT.putPrettyLn usage
       Exit.exitWith (Exit.ExitFailure 1)
 
-prepareTranscriptDir :: Bool -> Maybe FilePath -> IO FilePath
-prepareTranscriptDir inFork mcodepath = do
+prepareTranscriptDir :: Branch.Cache IO -> Bool -> Maybe FilePath -> IO FilePath
+prepareTranscriptDir branchCache inFork mcodepath = do
   currentDir <- getCurrentDirectory
   tmp <- Temp.createTempDirectory currentDir "transcript"
 
   unless inFork $ do
     PT.putPrettyLn . P.wrap $ "Transcript will be run on a new, empty codebase."
-    _ <- FileCodebase.initCodebase tmp
+    _ <- FileCodebase.initCodebase branchCache tmp
     pure()
 
-  when inFork $ FileCodebase.getCodebaseOrExit mcodepath >> do
+  when inFork $ FileCodebase.getCodebaseOrExit branchCache mcodepath >> do
     path <- FileCodebase.getCodebaseDir mcodepath
     PT.putPrettyLn $ P.lines [
       P.wrap "Transcript will be run on a copy of the codebase at: ", "",
@@ -173,10 +185,10 @@ prepareTranscriptDir inFork mcodepath = do
 
   pure tmp
 
-runTranscripts' :: Maybe FilePath -> FilePath -> [String] -> IO Bool
-runTranscripts' mcodepath transcriptDir args = do
+runTranscripts' :: Branch.Cache IO -> Maybe FilePath -> FilePath -> [String] -> IO Bool
+runTranscripts' branchCache mcodepath transcriptDir args = do
   currentDir <- getCurrentDirectory
-  theCodebase <- FileCodebase.getCodebaseOrExit $ Just transcriptDir
+  theCodebase <- FileCodebase.getCodebaseOrExit branchCache $ Just transcriptDir
   case args of
     args@(_:_) -> do
       for_ args $ \arg -> case arg of
@@ -190,7 +202,7 @@ runTranscripts' mcodepath transcriptDir args = do
                   P.indentN 2 $ P.string err])
             Right stanzas -> do
               configFilePath <- getConfigFilePath mcodepath
-              mdOut <- TR.run transcriptDir configFilePath stanzas theCodebase
+              mdOut <- TR.run transcriptDir configFilePath stanzas theCodebase branchCache
               let out = currentDir FP.</>
                          FP.addExtension (FP.dropExtension arg ++ ".output")
                                          (FP.takeExtension md)
@@ -205,10 +217,10 @@ runTranscripts' mcodepath transcriptDir args = do
     [] ->
       pure False
 
-runTranscripts :: Bool -> Bool -> Maybe FilePath -> [String] -> IO ()
-runTranscripts inFork keepTemp mcodepath args = do
-  transcriptDir <- prepareTranscriptDir inFork mcodepath
-  completed <- runTranscripts' (Just transcriptDir) transcriptDir args
+runTranscripts :: Branch.Cache IO -> Bool -> Bool -> Maybe FilePath -> [String] -> IO ()
+runTranscripts branchCache inFork keepTemp mcodepath args = do
+  transcriptDir <- prepareTranscriptDir branchCache inFork mcodepath
+  completed <- runTranscripts' branchCache (Just transcriptDir) transcriptDir args
   when completed $ do
     unless keepTemp $ removeDirectoryRecursive transcriptDir
     when keepTemp $ PT.putPrettyLn $
@@ -228,9 +240,9 @@ runTranscripts inFork keepTemp mcodepath args = do
 initialPath :: Path.Absolute
 initialPath = Path.absoluteEmpty
 
-launch :: FilePath -> FilePath -> _ -> [Either Input.Event Input.Input] -> IO ()
-launch dir configFile code inputs =
-  CommandLine.main dir defaultBaseLib initialPath configFile inputs (pure Rt1.runtime) code
+launch :: FilePath -> (Config, IO ()) -> _ -> Branch.Cache IO -> [Either Input.Event Input.Input] -> IO ()
+launch dir config code branchCache inputs =
+  CommandLine.main dir defaultBaseLib initialPath config inputs (pure Rt1.runtime) code branchCache
 
 isMarkdown :: String -> Bool
 isMarkdown md = case FP.takeExtension md of


### PR DESCRIPTION
## Overview

This PR adds caching to the Unison codebase, so that operations like `merge`, `pull`, and `push` hit the disk much less often, and similarly adds adds caching for terms, type of term, and decls.

It's pretty easy to come up with examples that are wildly faster (like a `merge` is now imperceptible where before it took 7-8s), but I want to call attention to a couple points that aren't necessarily obvious:

* Before this PR, when you do a `pr.load`, you're doing two pulls, followed by a merge. During the merge, you're doing a bunch of I/O to load the branches back to the LCA. Now, the initial pulls will populate and use the cache, and the merge will have everything cached and be super fast.
* A Unison namespace is actually a DAG, not a tree, since the same namespace may appear at multiple locations at a single point in history, and can also appear at multiple points in history. Our old `Branch.read` would read that DAG as a tree, leading to both duplicated I/O work (because the namespace was loaded from disk N times for each place it appears, rather than once) and additional memory usage (because each such I/O produced an unrelated in-memory value rather than sharing). 

There's a new config setting you can add to `.unisonConfig`: 

```
NamespaceCacheSize = 4096
```

4096 is the current default - that's 4096 namespaces in the cache before it starts cleaning up old ones.

## Implementation notes

The `Cache` implementation is in `Unison.Util.Cache`. There's a simple interface:

https://github.com/unisonweb/unison/blob/386bdc754a1e06079114424618fe003a2fb2f7c7/parser-typechecker/src/Unison/Util/Cache.hs#L10-L13

And then an interesting implementation:

https://github.com/unisonweb/unison/blob/386bdc754a1e06079114424618fe003a2fb2f7c7/parser-typechecker/src/Unison/Util/Cache.hs#L29-L59

And some helper functions for populating the cache in various ways:

https://github.com/unisonweb/unison/blob/386bdc754a1e06079114424618fe003a2fb2f7c7/parser-typechecker/src/Unison/Util/Cache.hs#L61-L69

There's a single "branch cache" created on startup and threaded ultimately to `Causal.cachedRead`:

https://github.com/unisonweb/unison/blob/386bdc754a1e06079114424618fe003a2fb2f7c7/parser-typechecker/src/Unison/Codebase/Causal.hs#L116-L140

Also see `Branch.cachedRead`, which calls `Causal.cachedRead`:

https://github.com/unisonweb/unison/blob/386bdc754a1e06079114424618fe003a2fb2f7c7/parser-typechecker/src/Unison/Codebase/Branch.hs#L470-L489

The rest of the changes are basically plumbing to get the single branch cache threaded to those points.

## Interesting/controversial decisions

I left the timing logging messages in, but disabled, with a static flag in `Unison.Util.Timing` re-enable.

## Test coverage

The transcripts hit the cache now so getting some decent coverage there.

~~I think the `Cache` module could use unit tests.~~ This is done now.

## Loose ends

Not exactly a loose end, but I would be curious to spend some time looking at cache hit rates for various operations.