### PR TITLE
Eliminate second prompt and codebase sync between add/update and default metadata

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -997,11 +997,15 @@ loop = do
 --                      | r <- toList $ Names.typesNamed ns name ]
 --              in (terms, types)
 
-      LinkI mdValue srcs ->
+      LinkI mdValue srcs -> do
         manageLinks False srcs [mdValue] Metadata.insert
+        r <- use root
+        updateRoot r
 
-      UnlinkI mdValue srcs ->
+      UnlinkI mdValue srcs -> do
         manageLinks False srcs [mdValue] Metadata.delete
+        r <- use root
+        updateRoot r
 
       -- > links List.map (.Docs .English)
       -- > links List.map -- give me all the

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -531,14 +531,15 @@ loop = do
           traverse_ go mdValuels
           after  <- Branch.head <$> use root
           (ppe, outputDiff) <- diffHelper before after
-          unless silent if OBranchDiff.isEmpty outputDiff
+          if not silent then
+            if OBranchDiff.isEmpty outputDiff
             then respond NoOp
             else respondNumbered $ ShowDiffNamespace Path.absoluteEmpty
                                                      Path.absoluteEmpty
                                                      ppe
                                                      outputDiff
-          when (silent && not (OBranchDiff.isEmpty outputDiff)) $
-            respond DefaultMetadataNotification
+          else unless (OBranchDiff.isEmpty outputDiff) $
+                 respond DefaultMetadataNotification
           where
             go (mdl, hqn) = do
               newRoot <- use root


### PR DESCRIPTION
## Overview

This eliminates a second UCM prompt printing to the screen when calling `add` or `update` with default metadata configured. This is done by stopping these commands syncing the root branch until they're really finished.

Also prevents UCM printing "I added some default metadata" when it actually didn't.

## Implementation notes

Created `stepManyAtNoSync` and friends which acts like `stepManyAt`, but doesn't call `updateRoot`. Tracking two separate root states now, `root` and `lastSyncedRoot`. The latter gets updated only when `updateRoot` is called.

## Test coverage

This gets some coverage from the `diff.md` transcript.
