### PR TITLE
Update pull-request.create help example text

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -42,3 +42,4 @@ The format for this list: name, GitHub handle, and then optional blurb about wha
 * Daniël Heres (@Dandandan)
 * Stew O'Connor (@stew)
 * Dave Nicponski (@virusdave)
+* Cody Allen (@ceedubs)

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -788,8 +788,8 @@ createPullRequest = InputPattern "pull-request.create" ["pr.create"]
         <> "into the remote repo `base`."
     , ""
     , "example: " <>
-      makeExampleNoBackticks createPullRequest ["https://github.com/unisonweb/base",
-                                                "https://github.com/me/unison:.libs.pr.base" ]
+      makeExampleNoBackticks createPullRequest ["https://github.com/unisonweb/base:.trunk",
+                                                "https://github.com/me/unison:.prs.base._myFeature" ]
     ])
   (\case
     [baseUrl, headUrl] -> do


### PR DESCRIPTION
## Overview

What does this change accomplish and why? i.e. How does it change the user experience?

I think that this help text better reflects that `base` now follows the
`trunk` convention and that a `.prs` namespace is now encouraged.

I think that it would be good to use consistent conventions across docs,
because currently some of them are subtly different, which makes it
tougher to get started with the day-to-day development workflow.

## Test coverage

I haven't added any tests for this. I'm not sure if copy/pasting the
example string into a test is useful, but I'm happy to add something if
it would be desired.