### PR TITLE
Tweak output of merge history to not be upside down

### DIFF
--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -935,10 +935,10 @@ notifyUser dir o = case o of
       E.MergeTail h hs -> P.lines [
         P.wrap $ "This segment of history starts with a merge." <> ex,
         "",
-        P.lines (prettySBH <$> hs),
-        "⑂",
         "⊙ " <> prettySBH h
-             <> (if null history then mempty else "\n")
+             <> (if null history then mempty else "\n"),
+        "⑃",
+        P.lines (prettySBH <$> hs)
         ]
       E.PageEnd h _n -> P.lines [
         P.wrap $ "There's more history before the versions shown here." <> ex, "",

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -935,8 +935,7 @@ notifyUser dir o = case o of
       E.MergeTail h hs -> P.lines [
         P.wrap $ "This segment of history starts with a merge." <> ex,
         "",
-        "⊙ " <> prettySBH h
-             <> (if null history then mempty else "\n"),
+        "⊙ " <> prettySBH h,
         "⑃",
         P.lines (prettySBH <$> hs)
         ]

--- a/unison-src/transcripts/mergeloop.output.md
+++ b/unison-src/transcripts/mergeloop.output.md
@@ -135,9 +135,9 @@ b = 2
   `history #som3n4m3space` to view history starting from a given
   namespace hash.
   
+  ⊙ #0ucrusr0bl
+  ⑃
   #0lf1cvdccp
   #ofcsecdak0
-  ⑂
-  ⊙ #0ucrusr0bl
 
 ```


### PR DESCRIPTION
Fix a minor thing that's been bugging me, which is that the little mergefork icon in the `history` command is upside down.

```
.> history base

  Note: The most recent namespace hash is immediately below this message.  
    
  This segment of history starts with a merge. Use `history #som3n4m3space` to view history
  starting from a given namespace hash.
  
  ⊙ #7mrc1t233q
  ⑃
  #fhmcd0hd21
  #net9h2qktp
```

Previously it was flipped the other way, so the note about "the most recent namespace hash is immediately below this message" was actually incorrect.