### PR TITLE
Print Unison version in welcome message

### DIFF
--- a/parser-typechecker/src/Unison/CommandLine/Main.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Main.hs
@@ -132,13 +132,14 @@ asciiartUnison =
     <> P.cyan "|___|"
     <> P.purple "_|_|"
 
-welcomeMessage :: FilePath -> P.Pretty P.ColorText
-welcomeMessage dir =
+welcomeMessage :: FilePath -> String -> P.Pretty P.ColorText
+welcomeMessage dir version =
   asciiartUnison
     <> P.newline
     <> P.newline
     <> P.linesSpaced
          [ P.wrap "Welcome to Unison!"
+         , P.wrap ("You are running version: " <> P.string version)
          , P.wrap
            (  "I'm currently watching for changes to .u files under "
            <> (P.group . P.blue $ fromString dir)
@@ -164,14 +165,15 @@ main
   -> IO (Runtime v)
   -> Codebase IO v Ann
   -> Branch.Cache IO
+  -> String
   -> IO ()
-main dir defaultBaseLib initialPath (config,cancelConfig) initialInputs startRuntime codebase branchCache = do
+main dir defaultBaseLib initialPath (config,cancelConfig) initialInputs startRuntime codebase branchCache version = do
   dir' <- shortenDirectory dir
   root <- fromMaybe Branch.empty . rightMay <$> Codebase.getRootBranch codebase
   putPrettyLn $ case defaultBaseLib of
       Just ns | Branch.isOne root ->
-        welcomeMessage dir' <> P.newline <> P.newline <> hintFreshCodebase ns
-      _ -> welcomeMessage dir'
+        welcomeMessage dir' version <> P.newline <> P.newline <> hintFreshCodebase ns
+      _ -> welcomeMessage dir' version
   eventQueue <- Q.newIO
   do
     runtime                  <- startRuntime

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -242,7 +242,7 @@ initialPath = Path.absoluteEmpty
 
 launch :: FilePath -> (Config, IO ()) -> _ -> Branch.Cache IO -> [Either Input.Event Input.Input] -> IO ()
 launch dir config code branchCache inputs =
-  CommandLine.main dir defaultBaseLib initialPath config inputs (pure Rt1.runtime) code branchCache
+  CommandLine.main dir defaultBaseLib initialPath config inputs (pure Rt1.runtime) code branchCache Version.gitDescribe
 
 isMarkdown :: String -> Bool
 isMarkdown md = case FP.takeExtension md of


### PR DESCRIPTION
## Overview

This changes the `ucm` welcome message to include the Unison version.

**Before**

```
   _____     _
  |  |  |___|_|___ ___ ___
  |  |  |   | |_ -| . |   |
  |_____|_|_|_|___|___|_|_|

  Welcome to Unison!

  I'm currently watching for changes to .u files under ~/code/unison

  Type help to get help. 😎

```

**After**

(after running `git tag ceedubs-testing -m "nothing to see here"`)

```
   _____     _
  |  |  |___|_|___ ___ ___
  |  |  |   | |_ -| . |   |
  |_____|_|_|_|___|___|_|_|

  Welcome to Unison!

  You are running version: ceedubs-testing

  I'm currently watching for changes to .u files under ~/code/unison

  Type help to get help. 😎
```

It's possible to use `ucm version` to display your `ucm` version, but
with Unison evolving pretty quickly, I've found myself accidentally
using the wrong version without realizing it several times. This seems like it
would make it more obvious if someone is using a version that they don't intend.

## Implementation notes

This threads a `String` through a couple of functions, since that's what
`Version.gitDescribe` returns. I'm open to using a newtype for the version if
that would be preferred.

## Test coverage

I haven't added tests. I'm not sure what a useful test would be that wouldn't
break with every single tag 😬.

## Loose ends

One motivation for this was that running `ucm version` requires dropping out of
`ucm` if you are already in it. It might make sense to add a command from within
`ucm` that prints the version.