### PR TITLE
Use `LANGUAGE Strict` and `fmap B.copy . getBytes` in `V1.hs`

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/FileCodebase/SlimCopyRegenerateIndex.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase/SlimCopyRegenerateIndex.hs
@@ -16,9 +16,9 @@ import Unison.Prelude
 
 import qualified Data.Set                      as Set
 import           Control.Lens
-import           Control.Monad.State            ( MonadState, evalStateT )
-import           Control.Monad.Writer           ( MonadWriter, execWriterT )
-import qualified Control.Monad.Writer          as Writer
+import           Control.Monad.State.Strict     ( MonadState, evalStateT )
+import           Control.Monad.Writer.Strict    ( MonadWriter, execWriterT )
+import qualified Control.Monad.Writer.Strict   as Writer
 import           UnliftIO.Directory             ( doesFileExist )
 import           Unison.Codebase                ( CodebasePath )
 import qualified Unison.Codebase.Causal        as Causal

--- a/parser-typechecker/src/Unison/Codebase/Serialization/V1.hs
+++ b/parser-typechecker/src/Unison/Codebase/Serialization/V1.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE FlexibleContexts, RankNTypes #-}
 
@@ -181,7 +182,7 @@ putText text = do
 getText :: MonadGet m => m Text
 getText = do
   len <- getLength
-  bs <- getBytes len
+  bs <- B.copy <$> getBytes len
   pure $ decodeUtf8 bs
 
 skipText :: MonadGet m => m ()
@@ -226,7 +227,7 @@ putHash h = do
 getHash :: MonadGet m => m Hash
 getHash = do
   len <- getLength
-  bs <- getBytes len
+  bs <- B.copy <$> getBytes len
   pure $ Hash.fromBytes bs
 
 putReference :: MonadPut m => Reference -> m ()


### PR DESCRIPTION
Closes #1560 for now.  This PR improves the memory * time usage (area under the curve) for pulling `base:.trunk` by about 65%.  

Almost all of that improvement comes from just using `LANGUAGE Strict` and `fmap B.copy . getBytes` in `V1.hs`.  I had some timing data that is now probably lost in a browser buffer that said that `B.copy` alone made things a little worse, that `LANGUAGE Strict` made them about 60% better, and `B.copy` on top of `LANGUAGE Strict` was a bit better than that.

A couple percent more improvement came by making `SlimCopy..hs` use `Writer.Strict` and `State.Strict`; I guess they need to be completely evaluated and consumed by the end of the operation anyway.  I almost didn't bother to include them, but went ahead since it seemed to help a little bit. https://docs.google.com/spreadsheets/d/1iBYfVORtHGeUU6ioXU3YXSBNDdQt1KtGt2xRLyFhnXE/edit#gid=0 has some timing numbers.

I also tried timing with just a 1-way relation index instead of an unnecessarily 2-way https://github.com/unisonweb/unison/commit/845bd6a344f4f2728982544aab75096ec39f694, but I was doing timing experiments on my laptop on base.List and the numbers were just too all over the place to tell if it helped, so I left it out for now.

#### Further work

We still hang on to a lot of data during the sync:
![image](https://user-images.githubusercontent.com/538571/82212319-5850ad80-98e0-11ea-8b31-5724a583bec2.png)

`ARR_WORDS` is `Text` and `ByteArray`s, so we should find a way to share those that isn't locked in a cache forever.  And then I don't really know what the rest are.  I'm hoping that when we update to ghc 8.8 (#1562), that we can use some of the other profiling modes for clues without it segfaulting.  

Honestly I still don't see how we can get 400MB of bytestrings out of a 200MB codebase when the implementation shouldn't be holding more than one entitity (raw branch, patch, term, or decl) at a time. 512 bits per hash * 15723 distinct elements in `base` is less than 1MB.

Compare to before the PR though:
![image](https://user-images.githubusercontent.com/538571/82212382-774f3f80-98e0-11ea-9b58-3377a029d674.png)
