### PR TITLE
restore syncing of cached test watches

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/FileCodebase/SlimCopyRegenerateIndex.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase/SlimCopyRegenerateIndex.hs
@@ -39,6 +39,7 @@ import qualified Unison.Term                   as Term
 import           Unison.Type                    ( Type )
 import qualified Unison.Type                   as Type
 import           Unison.Var                     ( Var )
+import qualified Unison.UnisonFile             as UF
 import qualified Unison.Util.Relation          as Relation
 import           Unison.Util.Relation           ( Relation )
 import           Unison.Util.Monoid (foldMapM)
@@ -271,6 +272,9 @@ syncToDirectory' getV getA srcPath destPath newRoot =
           Just typ -> do
             copyFileWithParents (termPath srcPath h) (termPath destPath h)
             copyFileWithParents (typePath srcPath h) (typePath destPath h)
+            whenM (doesFileExist $ watchPath srcPath UF.TestWatch h) $
+              copyFileWithParents (watchPath srcPath UF.TestWatch h)
+                                  (watchPath destPath UF.TestWatch h)
             let typeDeps' = toList (Type.dependencies typ)
             let typeForIndexing = Type.removeAllEffectVars typ
             let typeReference = Type.toReference typeForIndexing

--- a/parser-typechecker/tests/Unison/Test/Git.hs
+++ b/parser-typechecker/tests/Unison/Test/Git.hs
@@ -1,6 +1,7 @@
 {-# Language OverloadedStrings #-}
 {-# Language QuasiQuotes #-}
 {-# Language TypeApplications #-}
+{-# LANGUAGE LambdaCase #-}
 
 module Unison.Test.Git where
 
@@ -16,8 +17,10 @@ import System.FilePath ((</>))
 import System.Directory (doesFileExist, removeDirectoryRecursive)
 
 import Unison.Codebase (Codebase, CodebasePath)
+import qualified Unison.Codebase as Codebase
 import qualified Unison.Codebase.Branch as Branch
 import qualified Unison.Codebase.FileCodebase as FC
+import Unison.Codebase.Path (Path(..))
 import qualified Unison.Codebase.TranscriptParser as TR
 import Unison.Codebase.FileCodebase.Reserialize as Reserialize
 import Unison.Codebase.FileCodebase.CopyFilterIndex as CopyFilterIndex
@@ -29,9 +32,64 @@ import Unison.Parser (Ann)
 import Unison.Symbol (Symbol)
 import Unison.Var (Var)
 import Unison.Codebase (BuiltinAnnotation)
+import qualified Unison.Util.Cache as Cache
 
 test :: Test ()
-test = scope "git" . tests $ [testPull, testPush]
+test = scope "git" . tests $ [testPull, testPush, syncTestResults]
+
+traceTranscriptOutput = False
+
+syncTestResults :: Test ()
+syncTestResults = scope "syncTestResults" $ do
+  -- put all our junk into here
+  tmp <- io $ Temp.getCanonicalTemporaryDirectory >>= flip Temp.createTempDirectory "syncTestResults"
+
+  targetDir <- io $ Temp.createTempDirectory tmp "target"
+  cache <- io Cache.nullCache
+  codebase <- io $ snd <$> initCodebase cache tmp "codebase"
+
+  runTranscript_ tmp codebase cache [iTrim|
+```ucm
+.> builtins.merge
+```
+```unison
+test> tests.x = [Ok "Great!"]
+```
+```ucm
+.> add
+```
+|]
+
+{-
+  .> history tests
+    ⊙ #0bnfrk7cu4
+  .> debug.file
+    tests.x#2c2hpa2jm1
+  .>
+-}
+
+  b <- io (Codebase.getRootBranch codebase) >>= \case
+    Left e -> crash $ show e
+    Right b -> pure b
+
+  io $ Codebase.syncToDirectory codebase targetDir
+        (Branch.getAt' (Path $ pure "tests") b)
+
+  let makeTitle :: String -> String
+      makeTitle = intercalate "/" . map (take 20) . drop 2 . splitOn "/"
+  scope "target-should-have" $
+    for targetShouldHave $ \path ->
+      scope (makeTitle path) $ io (doesFileExist $ targetDir </> path) >>= expect
+
+  -- if we haven't crashed, clean up!
+  io $ removeDirectoryRecursive tmp
+  where
+  targetShouldHave =
+    [ ".unison/v1/paths/0bnfrk7cu44q0vvaj7a0osl90huv6nj01nkukplcsbgn3i09h6ggbthhrorm01gpqc088673nom2i491fh9rtbqcc6oud6iqq6oam88.ub"
+    , ".unison/v1/terms/#2c2hpa2jm1101sq10k4jqhpmv5cvvgtqm8sf9710kl8mlrum5b6i2d0rdtrrpg3k1ned5ljna1rvomjte7rcbpd9ouaqcsit1n1np3o/type.ub"
+    , ".unison/v1/terms/#2c2hpa2jm1101sq10k4jqhpmv5cvvgtqm8sf9710kl8mlrum5b6i2d0rdtrrpg3k1ned5ljna1rvomjte7rcbpd9ouaqcsit1n1np3o/compiled.ub"
+    , ".unison/v1/watches/test/#2c2hpa2jm1101sq10k4jqhpmv5cvvgtqm8sf9710kl8mlrum5b6i2d0rdtrrpg3k1ned5ljna1rvomjte7rcbpd9ouaqcsit1n1np3o.ub"
+    ]
 
 -- goal of this test is to make sure that pull doesn't grab a ton of unneeded
 -- dependencies
@@ -193,7 +251,8 @@ runTranscript_ tmpDir c branchCache transcript = do
 
   -- parse and run the transcript
   flip (either err) (TR.parse "transcript" (Text.pack transcript)) $ \stanzas ->
-    void . liftIO $ TR.run cwd configFile stanzas c branchCache >>= traceM . Text.unpack
+    void . liftIO $ TR.run cwd configFile stanzas c branchCache >>= 
+                      when traceTranscriptOutput . traceM . Text.unpack
 
 -- goal of this test is to make sure that push works correctly:
 -- the destination should contain the right definitions from the namespace,


### PR DESCRIPTION
## Overview

I forgot to include test watch cache in the slim sync algo. This adds it, and a regression test.

Closes #1563
## Implementation notes

When copying a term, if a corresponding test result exists, it gets copied as well.

## Test coverage

Added the test `"git.syncTestResults"`

## Loose ends

Need #1564 to fix up earlier, busted pushes.