### PR TITLE
Use Text.IO functions to remove unnecessary intermediate String types

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Rt1IO.hs
+++ b/parser-typechecker/src/Unison/Runtime/Rt1IO.hs
@@ -43,6 +43,7 @@ import           Data.GUID                      ( genText )
 import qualified Data.Map                      as Map
 import qualified Data.Sequence as Seq
 import           Data.Text                     as Text
+import qualified Data.Text.IO                  as TextIO
 import           Data.Time.Clock.POSIX         as Time
 import qualified Network.Simple.TCP            as Net
 import qualified Network.Socket                as Sock
@@ -53,13 +54,10 @@ import           System.IO                      ( Handle
                                                 , BufferMode(..)
                                                 , openFile
                                                 , hClose
-                                                , hPutStr
                                                 , stdin
                                                 , stdout
                                                 , stderr
                                                 , hIsEOF
-                                                , hGetLine
-                                                , hGetContents
                                                 , hIsSeekable
                                                 , hSeek
                                                 , hTell
@@ -303,15 +301,15 @@ handleIO cenv cid = go (IOSrc.constructorName IOSrc.ioReference cid)
     IR.B . isJust <$> getHaskellHandle handle
   go "io.IO.getLine_" [IR.Data _ 0 [IR.T handle]] = do
     hh   <- getHaskellHandleOrThrow handle
-    line <- reraiseIO $ hGetLine hh
-    pure . IR.T $ Text.pack line
+    line <- reraiseIO $ TextIO.hGetLine hh
+    pure . IR.T $ line
   go "io.IO.getText_" [IR.Data _ 0 [IR.T handle]] = do
     hh   <- getHaskellHandleOrThrow handle
-    text <- reraiseIO $ hGetContents hh
-    pure . IR.T $ Text.pack text
+    text <- reraiseIO $ TextIO.hGetContents hh
+    pure . IR.T $ text
   go "io.IO.putText_" [IR.Data _ 0 [IR.T handle], IR.T string] = do
     hh <- getHaskellHandleOrThrow handle
-    reraiseIO . hPutStr hh $ Text.unpack string
+    reraiseIO . TextIO.hPutStr hh $ string
     pure IR.unit
   go "io.IO.throw" [IR.Data _ _ [IR.Data _ _ [], IR.T message]] =
     liftIO . throwIO $ UnisonRuntimeException message

--- a/parser-typechecker/tests/Suite.hs
+++ b/parser-typechecker/tests/Suite.hs
@@ -17,6 +17,7 @@ import qualified Unison.Test.DataDeclaration as DataDeclaration
 import qualified Unison.Test.FileParser as FileParser
 import qualified Unison.Test.Git as Git
 import qualified Unison.Test.Lexer as Lexer
+import qualified Unison.Test.IO as TestIO
 import qualified Unison.Test.Range as Range
 import qualified Unison.Test.Referent as Referent
 import qualified Unison.Test.Term as Term
@@ -60,6 +61,7 @@ test = tests
   , UriParser.test
   , Context.test
   , Git.test
+  , TestIO.test
   , Name.test
   , VersionParser.test
  ]

--- a/parser-typechecker/tests/Unison/Test/IO.hs
+++ b/parser-typechecker/tests/Unison/Test/IO.hs
@@ -1,0 +1,103 @@
+{-# Language OverloadedStrings #-}
+{-# Language QuasiQuotes #-}
+{-# Language TypeApplications #-}
+
+module Unison.Test.IO where
+
+import Unison.Prelude
+import EasyTest
+import qualified System.IO.Temp as Temp
+import qualified Data.Text as Text
+import qualified Data.Text.IO as TextIO
+import Shellmet ()
+import Data.String.Here (iTrim)
+import System.FilePath ((</>))
+import System.Directory (removeDirectoryRecursive)
+
+import Unison.Codebase (Codebase, CodebasePath)
+import qualified Unison.Codebase.Branch as Branch
+import qualified Unison.Codebase.FileCodebase as FC
+import qualified Unison.Codebase.TranscriptParser as TR
+import Unison.Parser (Ann)
+import Unison.Symbol (Symbol)
+
+-- * IO Tests
+
+test :: Test ()
+test = scope "IO" . tests $ [ testHandleOps ]
+
+-- * Implementation
+
+-- | Test reading from and writing to a handle
+--
+-- The transcript writes expectedText to a file, reads the same file and
+-- writes the read text to the result file which is then checked by the haskell.
+testHandleOps :: Test ()
+testHandleOps = withScopeAndTempDir "handleOps" $ \workdir codebase cache -> do
+  let myFile = workdir </> "handleOps.txt"
+      resultFile = workdir </> "handleOps.result"
+      expectedText = "Good Job!" :: Text.Text
+  runTranscript_ workdir codebase cache [iTrim|
+```ucm:hide
+.> builtins.mergeio
+```
+
+```unison
+main : '{IO} ()
+main = 'let
+  fp = ${Text.pack myFile}
+  res = ${Text.pack resultFile}
+  expected = ${expectedText}
+
+  -- Write to myFile
+  h1 = builtins.io.openFile (FilePath fp) Write
+  putText h1 expected
+  builtins.io.closeFile h1
+
+  -- Read from myFile
+  h2 = builtins.io.openFile (FilePath fp) Read
+  myC = getText h2
+  builtins.io.closeFile h2
+
+  -- Write what we read from myFile to resultFile
+  h3 = builtins.io.openFile (FilePath res) Write
+  putText h3 myC
+  builtins.io.closeFile h3
+```
+
+```ucm
+.> run main
+```
+|]
+
+  res <- io $ TextIO.readFile (resultFile)
+  if res == expectedText
+    then ok
+    else crash $ "Failed to read expectedText from file: " ++ show myFile
+
+-- * Utilities
+
+initCodebase :: Branch.Cache IO -> FilePath -> String -> IO (CodebasePath, Codebase IO Symbol Ann)
+initCodebase branchCache tmpDir name = do
+  let codebaseDir = tmpDir </> name
+  c <- FC.initCodebase branchCache codebaseDir
+  pure (codebaseDir, c)
+
+-- run a transcript on an existing codebase
+runTranscript_ :: MonadIO m => FilePath -> Codebase IO Symbol Ann -> Branch.Cache IO -> String -> m ()
+runTranscript_ tmpDir c branchCache transcript = do
+  let configFile = tmpDir </> ".unisonConfig"
+  let cwd = tmpDir </> "cwd"
+  let err err = error $ "Parse error: \n" <> show err
+
+  -- parse and run the transcript
+  flip (either err) (TR.parse "transcript" (Text.pack transcript)) $ \stanzas ->
+    void . liftIO $ TR.run cwd configFile stanzas c branchCache >>= traceM . Text.unpack
+
+withScopeAndTempDir :: String -> (FilePath -> Codebase IO Symbol Ann -> Branch.Cache IO -> Test ()) -> Test ()
+withScopeAndTempDir name body = scope name $ do
+  tmp <- io (Temp.getCanonicalTemporaryDirectory >>= flip Temp.createTempDirectory name)
+  cache <- io $ Branch.boundedCache 4096
+  (_, codebase) <- io $ initCodebase cache tmp "user"
+  body tmp codebase cache
+  io $ removeDirectoryRecursive tmp

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -283,6 +283,7 @@ executable tests
     Unison.Test.FileParser
     Unison.Test.Git
     Unison.Test.Lexer
+    Unison.Test.IO
     Unison.Test.Range
     Unison.Test.Referent
     Unison.Test.Term


### PR DESCRIPTION
# Overview

This removes unnecessary conversion between `Text` and `String` types when doing IO at Runtime. It should speed up string based IO operations (get and put strings) significantly and reduce memory overhead. 

## Implementation notes

We simply use corresponding functions from Text.IO module and remove packing, unpacking stuff.
