### PR TITLE
`merge.squash` command

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -363,7 +363,7 @@ merge = merge' RegularMerge
 
 -- Discards the history of a Branch0's children, recursively
 discardHistory0 :: Applicative m => Branch0 m -> Branch0 m
-discardHistory0 b = over children (fmap tweak) $ b where
+discardHistory0 = over children (fmap tweak) where
   tweak b = cons (discardHistory0 (head b)) empty
 
 merge' :: forall m . Monad m => MergeMode -> Branch m -> Branch m -> m (Branch m)

--- a/parser-typechecker/src/Unison/Codebase/Causal.hs
+++ b/parser-typechecker/src/Unison/Codebase/Causal.hs
@@ -212,6 +212,19 @@ children (One _ _         ) = Seq.empty
 children (Cons  _ _ (_, t)) = Seq.singleton t
 children (Merge _ _ ts    ) = Seq.fromList $ Map.elems ts
 
+-- A `squashMerge combine c1 c2` gives the same resulting `e`
+-- as a merge with an LCA of `c2`, but doesn't introduce a
+-- merge node for the result. The resulting node is a simple
+-- `Cons` onto `c2` (or is equal to `c2` if `c1` changes nothing).
+squashMerge
+  :: (Monad m, Eq e, Hashable e)
+  => (Maybe e -> e -> e -> m e)
+  -> Causal m h e
+  -> Causal m h e
+  -> m (Causal m h e)
+squashMerge combine c1 c2 =
+  stepDistinctM (combine (Just $ head c2) (head c1)) c2
+
 threeWayMerge
   :: forall m h e
    . (Monad m, Hashable e)

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -45,7 +45,7 @@ data Input
     -- clone w/o merge, error if would clobber
     = ForkLocalBranchI (Either ShortBranchHash Path') Path'
     -- merge first causal into destination
-    | MergeLocalBranchI Path' Path'
+    | MergeLocalBranchI Path' Path' Branch.MergeMode
     | PreviewMergeLocalBranchI Path' Path'
     | DiffNamespaceI Path' Path' -- old new
     | PullRemoteBranchI (Maybe RemoteNamespace) Path' SyncMode

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -96,7 +96,7 @@ data Output v
   | NoMainFunction String PPE.PrettyPrintEnv [Type v Ann]
   | BranchEmpty (Either ShortBranchHash Path')
   | BranchNotEmpty Path'
-  | LoadPullRequest RemoteNamespace RemoteNamespace Path' Path' Path'
+  | LoadPullRequest RemoteNamespace RemoteNamespace Path' Path' Path' Path'
   | CreatedNewBranch Path.Absolute
   | BranchAlreadyExists Path'
   | PatchAlreadyExists Path.Split'

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -892,6 +892,22 @@ parseUri label input = do
       <> "If you need this, add your 2¢ at"
       <> P.backticked "https://github.com/unisonweb/unison/issues/1436"
 
+squashMerge :: InputPattern
+squashMerge =
+  InputPattern "merge.squash" ["squash"] [(Required, pathArg), (Required, pathArg)]
+  (P.wrap $ makeExample squashMerge ["src","dest"]
+         <> "merges `src` namespace into `dest`,"
+         <> "discarding the history of `src` in the process."
+         <> "The resulting `dest` will have (at most) 1"
+         <> "additional history entry.")
+  (\case
+     [src, dest] -> first fromString $ do
+       src <- Path.parsePath' src
+       dest <- Path.parsePath' dest
+       pure $ Input.MergeLocalBranchI src dest Branch.SquashMerge
+     _ -> Left (I.help squashMerge)
+  )
+
 mergeLocal :: InputPattern
 mergeLocal = InputPattern "merge" [] [(Required, pathArg)
                                      ,(Optional, pathArg)]
@@ -901,11 +917,11 @@ mergeLocal = InputPattern "merge" [] [(Required, pathArg)
  (\case
       [src] -> first fromString $ do
         src <- Path.parsePath' src
-        pure $ Input.MergeLocalBranchI src Path.relativeEmpty'
+        pure $ Input.MergeLocalBranchI src Path.relativeEmpty' Branch.RegularMerge
       [src, dest] -> first fromString $ do
         src <- Path.parsePath' src
         dest <- Path.parsePath' dest
-        pure $ Input.MergeLocalBranchI src dest
+        pure $ Input.MergeLocalBranchI src dest Branch.RegularMerge
       _ -> Left (I.help mergeLocal)
  )
 
@@ -1336,6 +1352,7 @@ validInputs =
   , delete
   , forkLocal
   , mergeLocal
+  , squashMerge
   , previewMergeLocal
   , diffNamespace
   , names

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -279,14 +279,18 @@ notifyUser dir o = case o of
       , P.wrap $ "Once you find one you like, you can use the"
           <> makeExample' IP.resetRoot <> "command to set it."
       ]
-  LoadPullRequest baseNS headNS basePath headPath mergedPath -> pure $ P.lines
+  LoadPullRequest baseNS headNS basePath headPath mergedPath squashedPath -> pure $ P.lines
     [ P.wrap $ "I checked out" <> prettyRemoteNamespace baseNS <> "to" <> P.group (prettyPath' basePath <> ".")
     , P.wrap $ "I checked out" <> prettyRemoteNamespace headNS <> "to" <> P.group (prettyPath' headPath <> ".")
     , ""
     , P.wrap $ "The merged result is in" <> P.group (prettyPath' mergedPath <> ".")
+    , P.wrap $ "The (squashed) merged result is in" <> P.group (prettyPath' squashedPath <> ".")
     , P.wrap $ "Use" <>
         IP.makeExample IP.diffNamespace
           [prettyPath' basePath, prettyPath' mergedPath]
+      <> "or" <>
+        IP.makeExample IP.diffNamespace
+          [prettyPath' basePath, prettyPath' squashedPath]
       <> "to see what's been updated."
     , P.wrap $ "Use" <>
         IP.makeExample IP.todo
@@ -295,7 +299,10 @@ notifyUser dir o = case o of
         <> "to see what work is remaining for the merge."
     , P.wrap $ "Use" <>
         IP.makeExample IP.push
-          [prettyRemoteNamespace baseNS, prettyPath' mergedPath]
+          [prettyRemoteNamespace baseNS, prettyPath' mergedPath] <>
+        "or" <>
+        IP.makeExample IP.push
+          [prettyRemoteNamespace baseNS, prettyPath' squashedPath]
         <> "to push the changes."
     ]
 
@@ -637,7 +644,7 @@ notifyUser dir o = case o of
       <> P.backticked (P.text uri) <> "already exists at"
       <> P.backticked' (P.string localPath) "," <> "but it doesn't seem to"
       <> "be a git repository, so I'm not sure what to do next.  Delete it?"
-    UnrecognizableCheckoutDir uri localPath -> P.wrap $ "I tried to clone" 
+    UnrecognizableCheckoutDir uri localPath -> P.wrap $ "I tried to clone"
       <> P.backticked (P.text uri) <> "into a cache directory at"
       <> P.backticked' (P.string localPath) "," <> "but I can't recognize the"
       <> "result as a git repository, so I'm not sure what to do next."

--- a/unison-src/transcripts/squash.md
+++ b/unison-src/transcripts/squash.md
@@ -1,0 +1,132 @@
+
+```ucm:hide
+.> builtins.merge
+```
+
+# Squash merges
+
+`squash src dest` merges can be used to merge from `src` to `dest`, discarding the history of `src`. It's useful when the source namespace history is irrelevant or has a bunch of churn you wish to discard. Often when merging small pull requests, you'll use a squash merge.
+
+Let's look at some examples. We'll start with a namespace with just the builtins. Let's take a look at the hash of this namespace:
+
+```ucm
+.> history builtin
+.> fork builtin builtin2
+```
+
+(We make a copy of `builtin` for use later in this transcript.)
+
+Now suppose we `fork` a copy of builtin, then rename `Nat.+` to `frobnicate`, then rename it back. Notice this produces multiple entries in the history:
+
+```ucm
+.> fork builtin mybuiltin
+.mybuiltin> rename.term Nat.+ Nat.frobnicate
+.mybuiltin> rename.term Nat.frobnicate Nat.+
+.mybuiltin> history
+```
+
+If we merge that back into `builtin`, we get that same chain of history:
+
+```ucm
+.> merge mybuiltin builtin
+.> history builtin
+```
+
+Let's try again, but using a `merge.squash` (or just `squash`) instead. The history will be unchanged:
+
+```ucm
+.> merge.squash mybuiltin builtin2
+.> history builtin2
+```
+
+The churn that happened in `mybuiltin` namespace ended up back in the same spot, so the squash merge of that namespace with our original namespace had no effect.
+
+## Another example
+
+Let's look at a more interesting example, where the two namespaces have diverged a bit. Here's our starting namespace:
+
+```unison:hide
+x = 1
+```
+
+```ucm
+.trunk> add
+.> fork trunk alice
+.> fork trunk bob
+```
+
+Alice now does some hacking:
+
+```unison:hide
+radNumber = 348
+bodaciousNumero = 2394
+neatoFun x = x
+```
+
+```ucm
+.alice> add
+.alice> rename.term radNumber superRadNumber
+.alice> rename.term neatoFun productionReadyId
+```
+
+Meanwhile, Bob does his own hacking:
+
+```unison:hide
+whatIsLove = "?"
+babyDon'tHurtMe = ".. Don't hurt me..."
+no more = no more
+```
+
+```ucm
+.bob> add
+```
+
+At this point, Alice and Bob both have some history beyond what's in trunk:
+
+```ucm
+.> history trunk
+.> history alice
+.> history bob
+```
+
+Alice then squash merges into `trunk`, as does Bob. It's as if Alice and Bob both made their changes in one single commit.
+
+```ucm
+.> merge.squash alice trunk
+.> history trunk
+.> merge.squash bob trunk
+.> history trunk
+```
+
+Since squash merges don't produce any merge nodes, we can `undo` a couple times to get back to our starting state:
+
+```ucm
+.> undo
+.> undo
+.> history trunk
+```
+
+This time, we'll first squash Alice and Bob's changes together before squashing their combined changes into `trunk`. The resulting `trunk` will have just a single entry in it, combining both Alice and Bob's changes:
+
+```ucm
+.> squash alice bob
+.> squash bob trunk
+.> history trunk
+```
+
+So, there you have it. With squashing, you can control the granularity of your history.
+
+## Throwing out all history
+
+Another thing we can do is `squash` into an empty namespace. This effectively makes a copy of the namespace, but without any of its history:
+
+```ucm
+.> squash alice nohistoryalice
+.> history nohistoryalice
+```
+
+There's nothing really special here, `squash src dest` discards `src` history that comes after the LCA of `src` and `dest`, it's just that in the case of an empty namespace, that LCA is the beginning of time (the empty namespace), so all the history of `src` is discarded.
+
+## Caveats
+
+If you `squash mystuff trunk`, you're discarding any history of `mystuff` and just cons'ing onto the history of `trunk`. Thus, don't expect to be able to `merge trunk mystuff` later and get great results. Squashing should only be used when you don't care about the history (and you know others haven't pulled and built on your line of history being discarded, so they don't care about the history either).

--- a/unison-src/transcripts/squash.output.md
+++ b/unison-src/transcripts/squash.output.md
@@ -1,0 +1,472 @@
+
+# Squash merges
+
+`squash src dest` merges can be used to merge from `src` to `dest`, discarding the history of `src`. It's useful when the source namespace history is irrelevant or has a bunch of churn you wish to discard. Often when merging small pull requests, you'll use a squash merge.
+
+Let's look at some examples. We'll start with a namespace with just the builtins. Let's take a look at the hash of this namespace:
+
+```ucm
+.> history builtin
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  
+  
+  □ #huqm38uob6 (start of history)
+
+.> fork builtin builtin2
+
+  Done.
+
+```
+(We make a copy of `builtin` for use later in this transcript.)
+
+Now suppose we `fork` a copy of builtin, then rename `Nat.+` to `frobnicate`, then rename it back. Notice this produces multiple entries in the history:
+
+```ucm
+.> fork builtin mybuiltin
+
+  Done.
+
+.mybuiltin> rename.term Nat.+ Nat.frobnicate
+
+  Done.
+
+.mybuiltin> rename.term Nat.frobnicate Nat.+
+
+  Done.
+
+.mybuiltin> history
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ #sd7g31r8v9
+  
+    > Moves:
+    
+      Original name  New name
+      Nat.frobnicate Nat.+
+  
+  ⊙ #d8qganh7nh
+  
+    > Moves:
+    
+      Original name New name
+      Nat.+         Nat.frobnicate
+  
+  □ #huqm38uob6 (start of history)
+
+```
+If we merge that back into `builtin`, we get that same chain of history:
+
+```ucm
+.> merge mybuiltin builtin
+
+  Nothing changed as a result of the merge.
+
+.> history builtin
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ #sd7g31r8v9
+  
+    > Moves:
+    
+      Original name  New name
+      Nat.frobnicate Nat.+
+  
+  ⊙ #d8qganh7nh
+  
+    > Moves:
+    
+      Original name New name
+      Nat.+         Nat.frobnicate
+  
+  □ #huqm38uob6 (start of history)
+
+```
+Let's try again, but using a `merge.squash` (or just `squash`) instead. The history will be unchanged:
+
+```ucm
+.> merge.squash mybuiltin builtin2
+
+  Nothing changed as a result of the merge.
+
+  😶
+  
+  builtin2 was already up-to-date with mybuiltin.
+
+.> history builtin2
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  
+  
+  □ #huqm38uob6 (start of history)
+
+```
+The churn that happened in `mybuiltin` namespace ended up back in the same spot, so the squash merge of that namespace with our original namespace had no effect.
+
+## Another example
+
+Let's look at a more interesting example, where the two namespaces have diverged a bit. Here's our starting namespace:
+
+```unison
+x = 1
+```
+
+```ucm
+  ☝️  The namespace .trunk is empty.
+
+.trunk> add
+
+  ⍟ I've added these definitions:
+  
+    x : Nat
+
+.> fork trunk alice
+
+  Done.
+
+.> fork trunk bob
+
+  Done.
+
+```
+Alice now does some hacking:
+
+```unison
+radNumber = 348
+bodaciousNumero = 2394
+neatoFun x = x
+```
+
+```ucm
+.alice> add
+
+  ⍟ I've added these definitions:
+  
+    bodaciousNumero : Nat
+    neatoFun        : x -> x
+    radNumber       : Nat
+
+.alice> rename.term radNumber superRadNumber
+
+  Done.
+
+.alice> rename.term neatoFun productionReadyId
+
+  Done.
+
+```
+Meanwhile, Bob does his own hacking:
+
+```unison
+whatIsLove = "?"
+babyDon'tHurtMe = ".. Don't hurt me..."
+no more = no more
+```
+
+```ucm
+.bob> add
+
+  ⍟ I've added these definitions:
+  
+    babyDon'tHurtMe : Text
+    no              : more -> 𝕣
+    whatIsLove      : Text
+
+```
+At this point, Alice and Bob both have some history beyond what's in trunk:
+
+```ucm
+.> history trunk
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ #3p3anl2oil
+  
+    + Adds / updates:
+    
+      x
+  
+  □ #7asfbtqmoj (start of history)
+
+.> history alice
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ #t85a26latn
+  
+    > Moves:
+    
+      Original name New name
+      neatoFun      productionReadyId
+  
+  ⊙ #01scl44n4i
+  
+    > Moves:
+    
+      Original name New name
+      radNumber     superRadNumber
+  
+  ⊙ #094h7rbo3m
+  
+    + Adds / updates:
+    
+      bodaciousNumero neatoFun radNumber
+  
+  ⊙ #3p3anl2oil
+  
+    + Adds / updates:
+    
+      x
+  
+  □ #7asfbtqmoj (start of history)
+
+.> history bob
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ #g0mn0tn7ap
+  
+    + Adds / updates:
+    
+      babyDon'tHurtMe no whatIsLove
+  
+  ⊙ #3p3anl2oil
+  
+    + Adds / updates:
+    
+      x
+  
+  □ #7asfbtqmoj (start of history)
+
+```
+Alice then squash merges into `trunk`, as does Bob. It's as if Alice and Bob both made their changes in one single commit.
+
+```ucm
+.> merge.squash alice trunk
+
+  Here's what's changed in trunk after the merge:
+  
+  Added definitions:
+  
+    1. bodaciousNumero   : Nat
+    2. productionReadyId : x -> x
+    3. superRadNumber    : Nat
+  
+  Tip: You can use `todo` to see if this generated any work to
+       do in this namespace and `test` to run the tests. Or you
+       can use `undo` or `reflog` to undo the results of this
+       merge.
+
+.> history trunk
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ #tcbafrhd81
+  
+    + Adds / updates:
+    
+      bodaciousNumero productionReadyId superRadNumber
+  
+  ⊙ #3p3anl2oil
+  
+    + Adds / updates:
+    
+      x
+  
+  □ #7asfbtqmoj (start of history)
+
+.> merge.squash bob trunk
+
+  Here's what's changed in trunk after the merge:
+  
+  Added definitions:
+  
+    1. babyDon'tHurtMe : Text
+    2. no              : more -> 𝕣
+    3. whatIsLove      : Text
+  
+  Tip: You can use `todo` to see if this generated any work to
+       do in this namespace and `test` to run the tests. Or you
+       can use `undo` or `reflog` to undo the results of this
+       merge.
+
+.> history trunk
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ #5grq7ao0b4
+  
+    + Adds / updates:
+    
+      babyDon'tHurtMe no whatIsLove
+  
+  ⊙ #tcbafrhd81
+  
+    + Adds / updates:
+    
+      bodaciousNumero productionReadyId superRadNumber
+  
+  ⊙ #3p3anl2oil
+  
+    + Adds / updates:
+    
+      x
+  
+  □ #7asfbtqmoj (start of history)
+
+```
+Since squash merges don't produce any merge nodes, we can `undo` a couple times to get back to our starting state:
+
+```ucm
+.> undo
+
+  Here's the changes I undid
+  
+  Name changes:
+  
+    Original                  Changes
+    1. bob.babyDon'tHurtMe    2. trunk.babyDon'tHurtMe (added)
+    
+    3. bob.no                 4. trunk.no (added)
+    
+    5. bob.whatIsLove         6. trunk.whatIsLove (added)
+
+.> undo
+
+  Here's the changes I undid
+  
+  Name changes:
+  
+    Original                      Changes
+    1. alice.bodaciousNumero      2. trunk.bodaciousNumero (added)
+    
+    3. alice.productionReadyId    4. trunk.productionReadyId (added)
+    
+    5. alice.superRadNumber       6. trunk.superRadNumber (added)
+
+.> history trunk
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ #3p3anl2oil
+  
+    + Adds / updates:
+    
+      x
+  
+  □ #7asfbtqmoj (start of history)
+
+```
+This time, we'll first squash Alice and Bob's changes together before squashing their combined changes into `trunk`. The resulting `trunk` will have just a single entry in it, combining both Alice and Bob's changes:
+
+```ucm
+.> squash alice bob
+
+  Here's what's changed in bob after the merge:
+  
+  Added definitions:
+  
+    1. bodaciousNumero   : Nat
+    2. productionReadyId : x -> x
+    3. superRadNumber    : Nat
+  
+  Tip: You can use `todo` to see if this generated any work to
+       do in this namespace and `test` to run the tests. Or you
+       can use `undo` or `reflog` to undo the results of this
+       merge.
+
+.> squash bob trunk
+
+  Here's what's changed in trunk after the merge:
+  
+  Added definitions:
+  
+    1. babyDon'tHurtMe   : Text
+    2. bodaciousNumero   : Nat
+    3. no                : more -> 𝕣
+    4. productionReadyId : x -> x
+    5. superRadNumber    : Nat
+    6. whatIsLove        : Text
+  
+  Tip: You can use `todo` to see if this generated any work to
+       do in this namespace and `test` to run the tests. Or you
+       can use `undo` or `reflog` to undo the results of this
+       merge.
+
+.> history trunk
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ #8t5skhmd1g
+  
+    + Adds / updates:
+    
+      babyDon'tHurtMe bodaciousNumero no productionReadyId
+      superRadNumber whatIsLove
+  
+  ⊙ #3p3anl2oil
+  
+    + Adds / updates:
+    
+      x
+  
+  □ #7asfbtqmoj (start of history)
+
+```
+So, there you have it. With squashing, you can control the granularity of your history.
+
+## Throwing out all history
+
+Another thing we can do is `squash` into an empty namespace. This effectively makes a copy of the namespace, but without any of its history:
+
+```ucm
+.> squash alice nohistoryalice
+
+  Here's what's changed in nohistoryalice after the merge:
+  
+  Added definitions:
+  
+    1. bodaciousNumero   : Nat
+    2. productionReadyId : x -> x
+    3. superRadNumber    : Nat
+    4. x                 : Nat
+  
+  Tip: You can use `todo` to see if this generated any work to
+       do in this namespace and `test` to run the tests. Or you
+       can use `undo` or `reflog` to undo the results of this
+       merge.
+
+.> history nohistoryalice
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ #fs1a0n3q3r
+  
+    + Adds / updates:
+    
+      bodaciousNumero productionReadyId superRadNumber x
+  
+  □ #7asfbtqmoj (start of history)
+
+```
+There's nothing really special here, `squash src dest` discards `src` history that comes after the LCA of `src` and `dest`, it's just that in the case of an empty namespace, that LCA is the beginning of time (the empty namespace), so all the history of `src` is discarded.
+
+## Caveats
+
+If you `squash mystuff trunk`, you're discarding any history of `mystuff` and just cons'ing onto the history of `trunk`. Thus, don't expect to be able to `merge trunk mystuff later and get great results. Squashing should only be used when you don't care about the history (and you know others haven't pulled and built on your line of history being discarded, so they don't care about the history either).


### PR DESCRIPTION
Closes #1465 and see #1573 

See [this writeup transcript](https://github.com/unisonweb/unison/blob/topic/squash/unison-src/transcripts/squash.output.md).

I used this to create [this repo](https://github.com/unisonweb/basereboot) which is a copy of base with no history.

## Interesting/controversial decisions

I added `squashed` to the `pr.load` output to make it easier to push the squashed result.

<img width="1024" alt="Screen Shot 2020-05-21 at 12 39 31 AM" src="https://user-images.githubusercontent.com/11074/82523955-98d84300-9afb-11ea-8d55-a170dc755d36.png">

## Test coverage

There's a transcript that exercises things reasonably well and caught some bugs.