### PR TITLE
Fix nonsense polytype rendered by delayed computations and allow multiple delays in types

### DIFF
--- a/parser-typechecker/src/Unison/TypeParser.hs
+++ b/parser-typechecker/src/Unison/TypeParser.hs
@@ -56,7 +56,7 @@ type2a = delayed <|> type2
 delayed :: Var v => TypeP v
 delayed = do
   q <- reserved "'"
-  t <- effect <|> type2
+  t <- effect <|> type2a
   pure $ Type.arrow (Ann (L.start q) (end $ ann t))
                     (DD.unitType (ann q))
                     t

--- a/parser-typechecker/src/Unison/TypePrinter.hs
+++ b/parser-typechecker/src/Unison/TypePrinter.hs
@@ -89,16 +89,22 @@ prettyRaw n im p tp = go n im p tp
     Effect1' e t ->
       PP.parenthesizeIf (p >= 10) $ go n im 9 e <> " " <> go n im 10 t
     Effects' es         -> effects (Just es)
-    ForallsNamed' vs body -> if (p < 0 && all Var.universallyQuantifyIfFree vs)
-      then go n im p body
-      else paren (p >= 0) $
-        let vformatted = PP.sep " " (fmt S.Var . PP.text . Var.name <$> vs)
-        in ((fmt S.TypeOperator "∀ ") <> vformatted <> (fmt S.TypeOperator "."))
-           `PP.hang` go n im (-1) body
+    ForallsNamed' vs' body ->
+      let vs = filter (\v -> Var.name v /= "()") vs'
+      in if p < 0 && all Var.universallyQuantifyIfFree vs
+         then go n im p body
+         else paren (p >= 0) $
+           let vformatted = PP.sep " " (fmt S.Var . PP.text . Var.name <$> vs)
+           in (fmt S.TypeOperator "∀ " <> vformatted <> fmt S.TypeOperator ".")
+              `PP.hang` go n im (-1) body
     t@(Arrow' _ _) -> case t of
       EffectfulArrows' (Ref' DD.UnitRef) rest -> arrows True True rest
       EffectfulArrows' fst rest ->
-        PP.parenthesizeIf (p >= 0) $ go n im 0 fst <> arrows False False rest
+        case fst of
+          Var' v | Var.name v == "()"
+            -> fmt S.DelayForceChar "'" <> arrows False True rest
+          _ -> PP.parenthesizeIf (p >= 0) $
+                 go n im 0 fst <> arrows False False rest
       _ -> "error"
     _ -> "error"
   effects Nothing   = mempty

--- a/parser-typechecker/tests/Unison/Test/TypePrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/TypePrinter.hs
@@ -139,8 +139,8 @@ test = scope "typeprinter" . tests $
   , tc "'(a -> 'a)"
   , tc "'()"
   , tc "'('a)"
-  , pending $ tc "''a"  -- issue #249
-  , pending $ tc "'''a" -- issue #249
+  , tc_diff "''a" "'('a)"
+  , tc_diff "'''a" "'('('a))"
   , tc_diff "∀ a . a" $ "a"
   , tc_diff "∀ a. a" $ "a"
   , tc_diff "∀ a . 'a" $ "'a"

--- a/unison-src/transcripts/diff.output.md
+++ b/unison-src/transcripts/diff.output.md
@@ -106,7 +106,7 @@ ability X a1 a2 where x : Nat
     bdependent : Nat
     c          : Nat
     fromJust   : Nat
-    helloWorld : ∀ (). () ->{IO} ()
+    helloWorld : '{IO} ()
 
 .ns1> alias.term fromJust fromJust'
 
@@ -148,8 +148,8 @@ Here's what we've done so far:
     7.  c             : Nat
     8.  ┌ fromJust    : Nat (+1 metadata)
     9.  └ fromJust'   : Nat (+1 metadata)
-    10. ┌ helloWorld  : ∀ (). () ->{IO} ()
-    11. └ helloWorld2 : ∀ (). () ->{IO} ()
+    10. ┌ helloWorld  : '{IO} ()
+    11. └ helloWorld2 : '{IO} ()
 
 .> diff.namespace ns1 ns2
 

--- a/unison-src/transcripts/fix689.md
+++ b/unison-src/transcripts/fix689.md
@@ -1,0 +1,13 @@
+Tests the fix for https://github.com/unisonweb/unison/issues/689
+
+```ucm:hide
+.> builtins.merge
+```
+
+``` unison
+ability SystemTime where
+  systemTime : ##Nat
+
+tomorrow = '(SystemTime.systemTime + 24 * 60 * 60)
+```
+

--- a/unison-src/transcripts/fix689.output.md
+++ b/unison-src/transcripts/fix689.output.md
@@ -1,0 +1,21 @@
+Tests the fix for https://github.com/unisonweb/unison/issues/689
+
+```unison
+ability SystemTime where
+  systemTime : ##Nat
+
+tomorrow = '(SystemTime.systemTime + 24 * 60 * 60)
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      ability SystemTime
+      tomorrow : '{SystemTime} Nat
+
+```


### PR DESCRIPTION
This adds a special case to the `TypePrinter` to handle types of the form `forall (). () -> x`, which are sometimes generated by the delay syntax `'x`.

Also slightly modifies the type parser to allow types of the form `''x`, which would previously fail the parser.

## Overview

Fixes #689 
Fixes #249

## Implementation notes

Adds a special case to the type printer, doubling down on a horrible hack.

A better implementation of `'x` would be `(_ : () -> x)`, but since the new runtime will likely have a completely different implementation of delayed computations, it seems like overkill especially since it would require a change to the term language (adding type annotations for arguments).

## Test coverage

A transcript is included

## Loose ends

An alternative, much more comprehensive approach is drafted in the branch `/topic/bug689`, which turns all function types of the form `forall a. a -> x`, where `x` does not involve `a`, into `'x`.