### PR TITLE
Properly render calls to functions named (.)

### DIFF
--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -9,7 +9,6 @@ module Unison.TermPrinter where
 import Unison.Prelude
 
 import           Data.List
-import           Data.List.Extra                ( dropEnd )
 import qualified Data.Map                      as Map
 import qualified Data.Set                      as Set
 import           Data.Text                      ( splitOn, unpack )
@@ -820,8 +819,10 @@ countName n = let f = \(p, s) -> (s, Map.singleton p 1)
               in PrintAnnotation { usages = Map.fromList $ map f $ splitName n}
 
 splitName :: Name -> [(Prefix, Suffix)]
-splitName n = let ns = splitOn "." (Name.toText n)
-              in dropEnd 1 ((inits ns) `zip` (map dotConcat $ tails ns))
+splitName n =
+  let ns = splitOn "." (Name.toText n)
+  in  filter (not . Text.null . snd) $ inits ns `zip` map dotConcat (tails ns)
+
 -- > splitName "x" == [([], "x")]
 -- > splitName "A.x" == [(["A"], "x")]
 -- > splitName "A.B.x" == [(["A"], "B.x"), (["A.B"], "x")]

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -818,14 +818,12 @@ countName :: Name -> PrintAnnotation
 countName n = let f = \(p, s) -> (s, Map.singleton p 1)
               in PrintAnnotation { usages = Map.fromList $ map f $ splitName n}
 
+-- Generates all valid splits of a name into a prefix and suffix.
+-- See examples in Unison.Test.TermPrinter
 splitName :: Name -> [(Prefix, Suffix)]
 splitName n =
   let ns = splitOn "." (Name.toText n)
   in  filter (not . Text.null . snd) $ inits ns `zip` map dotConcat (tails ns)
-
--- > splitName "x" == [([], "x")]
--- > splitName "A.x" == [(["A"], "x")]
--- > splitName "A.B.x" == [(["A"], "B.x"), (["A.B"], "x")]
 
 joinName :: Prefix -> Suffix -> Name
 joinName p s = Name.unsafeFromText $ dotConcat $ p ++ [s]

--- a/parser-typechecker/tests/Unison/Core/Test/Name.hs
+++ b/parser-typechecker/tests/Unison/Core/Test/Name.hs
@@ -15,5 +15,7 @@ test = scope "name" $ tests [
         $ expectEqual (suffixes "foo.bar") ["foo.bar", "bar"]
       , scope "multiple namespaces"
         $ expectEqual (suffixes "foo.bar.baz") ["foo.bar.baz", "bar.baz", "baz"]
+      , scope "terms named `.`"
+        $ expectEqual (suffixes "base..") ["base..", "."]
       ]
   ]

--- a/parser-typechecker/tests/Unison/Test/TermPrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/TermPrinter.hs
@@ -101,8 +101,14 @@ tcBinding width v mtp tm expected
         ]
 
 test :: Test ()
-test = scope "termprinter" . tests $
-  [ tc "if true then +2 else -2"
+test = scope "termprinter" $ tests
+  [ scope "splitName" $ tests
+      [ scope "x" $ expectEqual (splitName "x") [([], "x")]
+      , scope "A.x" $ expectEqual (splitName "A.x") [([],"A.x"),(["A"],"x")]
+      , scope "A.B.x"
+        $ expectEqual (splitName "A.B.x") [([],"A.B.x"),(["A"],"B.x"),(["A","B"],"x")]
+      ]
+  , tc "if true then +2 else -2"
   , tc "[2, 3, 4]"
   , tc "[2]"
   , tc "[]"

--- a/unison-core/src/Unison/Name.hs
+++ b/unison-core/src/Unison/Name.hs
@@ -114,14 +114,19 @@ parent (Name txt) = case unsnoc (Text.splitOn "." txt) of
   Just ([],_) -> Nothing
   Just (init,_) -> Just $ Name (Text.intercalate "." init)
 
--- suffixes "" -> [] 
+-- suffixes "" -> []
 -- suffixes bar -> [bar]
 -- suffixes foo.bar -> [foo.bar, bar]
 -- suffixes foo.bar.baz -> [foo.bar.baz, bar.baz, baz]
+-- suffixes ".base.." -> [base.., .]
 suffixes :: Name -> [Name]
 suffixes (Name "") = []
-suffixes (Name n) = fmap up $ filter (not . null) $ tails $ Text.splitOn "." n
-  where
+suffixes (Name n ) = go n
+ where
+  go n | Text.last n == '.' =
+    (addDot <$> go (Text.dropWhileEnd ('.' ==) n)) ++ [Name "."]
+  go n = fmap up . filter (not . null) . tails $ Text.splitOn "." n
+  addDot (Name n) = Name (n <> "..")
   up ns = Name (Text.intercalate "." ns)
 
 unqualified' :: Text -> Text


### PR DESCRIPTION
This changes the `suffixes` of a `Name` such that the shortest suffix can be `.` if the definition has that name (which some definitions do).

## Overview

Before, the definition `noop = not . not` would be rendered as:

```unison
noop =  not not
```

With this change, it gets rendered as defined.

Fixes #1063 

## Test coverage

It's actually impossible to test this in a transcript at the moment, since the name `.` is rejected by `add` because of #1586

## Loose ends

* A fix for #1586 would allow this to be tested.
* A more comprehensive solution to names with `.` in them requires hunting down places where we're segmenting
* Consider disallowing `.` as a name. See #1587.