### PR TITLE
Path segments can be named `()`

### DIFF
--- a/unison-src/transcripts/unitnamespace.md
+++ b/unison-src/transcripts/unitnamespace.md
@@ -1,0 +1,9 @@
+```unison
+foo = "bar"
+```
+
+```ucm
+.> cd ()
+.()> add
+.> delete.namespace ()
+```

--- a/unison-src/transcripts/unitnamespace.output.md
+++ b/unison-src/transcripts/unitnamespace.output.md
@@ -1,0 +1,35 @@
+```unison
+foo = "bar"
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      foo : ##Text
+
+```
+```ucm
+.> cd ()
+
+  ☝️  The namespace .() is empty.
+
+.()> add
+
+  ⍟ I've added these definitions:
+  
+    foo : ##Text
+
+.> delete.namespace ()
+
+  Removed definitions:
+  
+    1. foo : ##Text
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
+
+```


### PR DESCRIPTION
Adds the ability for path segments to be named `()`. The main purpose of this change is to be able to delete the empty namespace `.base.()` which currently exists in Base.

## Implementation notes

Adds a special case to the path parser. If the segment is neither a symboly or wordy identifier, we check if it's literally "()".

Depends on #1591 

##  Test coverage

There is a transcript provided.

