### PR TITLE
Fix Delta semigroup instance

### DIFF
--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -197,7 +197,7 @@ pretty0
     Request' ref i -> styleHashQualified'' (fmt S.Request) $
       elideFQN im $ PrettyPrintEnv.termName n (Referent.Con ref i CT.Effect)
     Handle' h body -> paren (p >= 2) $
-      if height > 0 then PP.lines [
+      if PP.isMultiLine pb || PP.isMultiLine ph then PP.lines [
         (fmt S.ControlKeyword "handle") `PP.hang` pb,
         (fmt S.ControlKeyword "with") `PP.hang` ph
        ]
@@ -207,7 +207,6 @@ pretty0
           <> (fmt S.ControlKeyword "with") `PP.hang` ph
       ]
       where
-        height = PP.preferredHeight pb `max` PP.preferredHeight ph
         pb = pblock body
         ph = pblock h
         pblock tm = let (im', uses) = calcImports im tm
@@ -224,16 +223,15 @@ pretty0
           <> optSpace <> (fmt S.DelimiterChar $ l "]")
       where optSpace = PP.orElse "" " "
     If' cond t f -> paren (p >= 2) $
-      if height > 0 then PP.lines [
+      if PP.isMultiLine pt || PP.isMultiLine pf then PP.lines [
         (fmt S.ControlKeyword "if ") <> pcond <> (fmt S.ControlKeyword " then") `PP.hang` pt,
         (fmt S.ControlKeyword "else") `PP.hang` pf
        ]
       else PP.spaced [
-        (fmt S.ControlKeyword "if") `PP.hang` pcond <> ((fmt S.ControlKeyword " then") `PP.hang` pt),
+        ((fmt S.ControlKeyword "if") `PP.hang` pcond) <> ((fmt S.ControlKeyword " then") `PP.hang` pt),
         (fmt S.ControlKeyword "else") `PP.hang` pf
        ]
      where
-       height = PP.preferredHeight pt `max` PP.preferredHeight pf
        pcond  = pretty0 n (ac 2 Block im doc) cond
        pt     = branch t
        pf     = branch f
@@ -253,13 +251,12 @@ pretty0
       ]
     LetBlock bs e -> printLet bc bs e im' uses
     Match' scrutinee branches -> paren (p >= 2) $
-      if height > 0 then PP.lines [
+      if PP.isMultiLine ps then PP.lines [
         (fmt S.ControlKeyword "match ") `PP.hang` ps,
         (fmt S.ControlKeyword " with") `PP.hang` pbs
        ]
       else ((fmt S.ControlKeyword "match ") <> ps <> (fmt S.ControlKeyword " with")) `PP.hang` pbs
-      where height = PP.preferredHeight ps
-            ps = pretty0 n (ac 2 Normal im doc) scrutinee
+      where ps = pretty0 n (ac 2 Normal im doc) scrutinee
             pbs = printCase n im doc branches
 
     t -> l "error: " <> l (show t)

--- a/parser-typechecker/tests/Suite.hs
+++ b/parser-typechecker/tests/Suite.hs
@@ -30,6 +30,7 @@ import qualified Unison.Test.Typechecker.TypeError as TypeError
 import qualified Unison.Test.UnisonSources as UnisonSources
 import qualified Unison.Test.UriParser as UriParser
 import qualified Unison.Test.Util.Bytes as Bytes
+import qualified Unison.Test.Util.Pretty as Pretty
 import qualified Unison.Test.Var as Var
 import qualified Unison.Test.VersionParser as VersionParser
 
@@ -62,6 +63,7 @@ test = tests
   , Git.test
   , Name.test
   , VersionParser.test
+  , Pretty.test
  ]
 
 main :: IO ()

--- a/parser-typechecker/tests/Unison/Test/Util/Pretty.hs
+++ b/parser-typechecker/tests/Unison/Test/Util/Pretty.hs
@@ -1,0 +1,33 @@
+module Unison.Test.Util.Pretty
+  ( test
+  ) where
+
+import Control.Monad
+import Data.String (fromString)
+import EasyTest
+import qualified Unison.Util.Pretty as Pretty
+
+test :: Test ()
+test =
+  scope "util.pretty" . tests $ [
+    scope "Delta.Semigroup.<>.associative" $ do
+      replicateM_ 100 $ do
+        d1 <- randomDelta
+        d2 <- randomDelta
+        d3 <- randomDelta
+        expect' $ (d1 <> d2) <> d3 == d1 <> (d2 <> d3)
+      ok
+  ]
+
+randomDelta :: Test Pretty.Delta
+randomDelta =
+  Pretty.delta <$> randomPretty
+
+  where
+    randomPretty :: Test (Pretty.Pretty String)
+    randomPretty =
+      fromString <$> randomString
+
+    randomString :: Test String
+    randomString =
+      replicateM 3 (pick ['x', 'y', 'z', '\n'])

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -2,7 +2,7 @@ name:          unison-parser-typechecker
 category:      Compiler
 version:       0.1
 license:       MIT
-cabal-version: >= 1.8
+cabal-version: >= 1.10
 license-file:  LICENSE
 author:        Unison Computing, public benefit corp
 maintainer:    Paul Chiusano <paul.chiusano@gmail.com>, Runar Bjarnason <runarorama@gmail.com>, Arya Irani <arya.irani@gmail.com>
@@ -211,6 +211,7 @@ library
   default-extensions:
     ApplicativeDo,
     DeriveFunctor,
+    DerivingStrategies,
     DoAndIfThenElse,
     FlexibleContexts,
     FlexibleInstances,
@@ -223,6 +224,8 @@ library
     TypeApplications
     -- ViewPatterns
 
+  default-language: Haskell2010
+
   if flag(optimized)
     ghc-options: -funbox-strict-fields
 
@@ -232,6 +235,7 @@ library
 executable unison
   main-is: Main.hs
   hs-source-dirs: unison
+  default-language: Haskell2010
   ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
   other-modules:
     Version
@@ -256,6 +260,7 @@ executable unison
 executable prettyprintdemo
   main-is: Main.hs
   hs-source-dirs: prettyprintdemo
+  default-language: Haskell2010
   ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
   build-depends:
     base,
@@ -266,6 +271,7 @@ executable prettyprintdemo
 executable tests
   main-is:        Suite.hs
   hs-source-dirs: tests
+  default-language: Haskell2010
   ghc-options:    -W -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -threaded -rtsopts -with-rtsopts=-N -v0
   build-depends:
     base,
@@ -297,6 +303,7 @@ executable tests
     Unison.Test.UnisonSources
     Unison.Test.UriParser
     Unison.Test.Util.Bytes
+    Unison.Test.Util.Pretty
     Unison.Test.Var
     Unison.Test.VersionParser
     Unison.Core.Test.Name
@@ -330,6 +337,7 @@ executable transcripts
   main-is:        Transcripts.hs
   ghc-options:    -W -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -threaded -rtsopts -with-rtsopts=-N -v0
   hs-source-dirs: transcripts
+  default-language: Haskell2010
   other-modules:
   build-depends:
     base,


### PR DESCRIPTION
##  Overview

This patch amends `Pretty.Delta` to better model what it's meant to keep track of: the rectangular region that a `Pretty` fits in.

Previously, it kept track of

- Number of newlines
- Width of widest column
- Width of last column

But missing (crucially) was the width of the _first_ column. This is necessary for appending `Delta`s together: the first column of the right hand side is appended to the last column of the left hand side, and this new column may also now be the widest column.

Because this info was missing from `Delta` before, some things ended up overflowing (like #424) when they shouldn't have. This patch does fix #424, though due to an unrelated change in the term printer, the actual example given in that issue description no longer overflows. Still, I cherry-picked this work on top of `67a72c77263c0072cc0c99a190d73b6b9f23f0e9` (a random commit from around that time that exhibited the issue) and saw that it was fixed.

Another problem, also addressed: `Delta`'s `<>` implementation wasn't associative.

## Implementation notes

Before:

```haskell
-- lines, first col, max col
data Delta = Delta Int Int Int
```

Now:

```haskell
data Delta = 
    -- col
    SingleLine Int
    -- first col, last col, max col 
  | MultiLine Int Int Int
```

The switch to a sum type was just motivated by the observation that we don't care how many newlines a `Delta` contains, only whether it's `> 0`.

## Test coverage

The associativity of `Delta` is now under test.