### PR TITLE
Resolve Issue #1585 - unison --help` hard-codes the string "ucm"

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -43,3 +43,4 @@ The format for this list: name, GitHub handle, and then optional blurb about wha
 * Stew O'Connor (@stew)
 * Dave Nicponski (@virusdave)
 * Cody Allen (@ceedubs)
+* Ludvig Sundström (@lsund)


### PR DESCRIPTION
## Overview

With this patch, typing `<executable> --help` in the command line shows <executable> not the hard-coded string "ucm" in the help-text. It should close issue #1585.

Before this patch, the help text would always show "ucm" as example command, not the actual executable name.

This is a screenshot from my prompt:
![unison](https://user-images.githubusercontent.com/5222589/83380471-5279c280-a3de-11ea-9b6f-b9f99c5d1c29.png)

## Implementation notes

I used the first thing that came to mind, using `getProgName` from System.Environment. I read the program name in 2 places and pass it  as an extra parameter to the usage function. 

## Test coverage

According to its very brief documentation, `getProgName` should return something sensible for all OS's, even windows.
I have tested this on Linux  5.6.15-arch1-1. When my wife comes home from work, I can test it on Mac as well :) 

Stack version was `Version 2.3.1, Git revision de2a7b694f07de7e6cf17f8c92338c16286b2878 (dirty) (8103 commits) x86_64` and the executable was built with `stack install`

## Note

Basically, I don't know anything about the unison codebase (yet), I just looked at the first "help wanted" issue in the repository. Thank you for considering this!

BR,

Ludvig
