### PR TITLE
Make haddock-like comments not valid haddocks

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Causal.hs
+++ b/parser-typechecker/src/Unison/Codebase/Causal.hs
@@ -236,7 +236,7 @@ squashMerge combine c1 c2 = do
       -- Calling `combine` will recursively call into `squashMerge`
       -- for the children, discarding their history before calling `done`
       -- on the parent.
-      -- | lca == c2 -> pure $ done c1
+      --   | lca == c2 -> pure $ done c1
 
       | otherwise -> done <$> combine (Just $ head lca) (head c1) (head c2)
 

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -621,7 +621,8 @@ ac prec bc im doc = AmbientContext prec bc NonInfix im doc
 fmt :: S.Element -> Pretty S.SyntaxText -> Pretty S.SyntaxText
 fmt = PP.withSyntax
 
-{- # FQN elision
+{-
+   # FQN elision
 
    The term pretty-printer inserts `use` statements in some circumstances, to
    avoid the need for using fully-qualified names (FQNs) everywhere.  The

--- a/parser-typechecker/tests/Unison/Test/Codebase/Causal.hs
+++ b/parser-typechecker/tests/Unison/Test/Codebase/Causal.hs
@@ -95,16 +95,16 @@ test =
       , scope "threeWayMerge.idempotent"
         .  expect
         $  testIdempotent oneCausal -- == oneCausal
-        -- $  prop_mergeIdempotent
+        --  $  prop_mergeIdempotent
 
       , scope "threeWayMerge.identity"
         .  expect
         $  testIdentity oneCausal emptyCausal
-        -- $  prop_mergeIdentity
+        --  $  prop_mergeIdentity
       , scope "threeWayMerge.commutative"
         .  expect
         $  testCommutative (Set.fromList [3,4]) oneRemoved
-        -- $  prop_mergeCommutative
+        --  $  prop_mergeCommutative
           {- , scope "threeWayMerge.commonAncestor"
         .  expect
         $  testCommonAncestor

--- a/parser-typechecker/tests/Unison/Test/UriParser.hs
+++ b/parser-typechecker/tests/Unison/Test/UriParser.hs
@@ -20,8 +20,8 @@ test = scope "uriparser" . tests $ [ testAugmented ]
 testAugmented:: Test ()
 testAugmented = scope "augmented" . tests $
 -- Local Protocol
--- $ git clone /srv/git/project.git
--- $ git clone /srv/git/project.git[:treeish][:[#hash][.path]]
+--  $ git clone /srv/git/project.git
+--  $ git clone /srv/git/project.git[:treeish][:[#hash][.path]]
   [ scope "local-protocol" . tests . map parseAugmented $
     [ ("/srv/git/project.git",
       (GitRepo "/srv/git/project.git" Nothing, Nothing, Path.empty))
@@ -33,7 +33,7 @@ testAugmented = scope "augmented" . tests $
       (GitRepo "srv/git/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
     ],
 -- File Protocol
--- $ git clone file:///srv/git/project.git[:treeish][:[#hash][.path]] <- imagined
+--  $ git clone file:///srv/git/project.git[:treeish][:[#hash][.path]] <- imagined
     scope "file-protocol" . tests . map parseAugmented $
     [ ("file:///srv/git/project.git",
       (GitRepo "file:///srv/git/project.git" Nothing, Nothing, Path.empty))
@@ -45,7 +45,7 @@ testAugmented = scope "augmented" . tests $
       (GitRepo "file://srv/git/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
     ],
 -- Smart / Dumb HTTP protocol
--- $ git clone https://example.com/gitproject.git[:treeish][:[#hash][.path]] <- imagined
+--  $ git clone https://example.com/gitproject.git[:treeish][:[#hash][.path]] <- imagined
     scope "http-protocol" . tests . map parseAugmented $
     [ ("https://example.com/git/project.git",
       (GitRepo "https://example.com/git/project.git" Nothing, Nothing, Path.empty))
@@ -53,14 +53,14 @@ testAugmented = scope "augmented" . tests $
       (GitRepo "https://user@example.com/git/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
     ],
 -- SSH Protocol
--- $ git clone ssh://[user@]server/project.git[:treeish][:[#hash][.path]]
+--  $ git clone ssh://[user@]server/project.git[:treeish][:[#hash][.path]]
     scope "ssh-protocol" . tests . map parseAugmented $
     [ ("ssh://git@8.8.8.8:222/user/project.git",
       (GitRepo "ssh://git@8.8.8.8:222/user/project.git" Nothing, Nothing, Path.empty))
     , ("ssh://git@github.com/user/project.git:abc:#def.hij.klm",
       (GitRepo "ssh://git@github.com/user/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
     ],
--- $ git clone [user@]server:project.git[:treeish][:[#hash][.path]]
+--  $ git clone [user@]server:project.git[:treeish][:[#hash][.path]]
     scope "scp-protocol" . tests . map parseAugmented $
     [ ("git@github.com:user/project.git",
       (GitRepo "git@github.com:user/project.git" Nothing, Nothing, Path.empty))

--- a/unison-core/src/Unison/DataDeclaration.hs
+++ b/unison-core/src/Unison/DataDeclaration.hs
@@ -63,7 +63,7 @@ constructorType = \case
   Left{} -> CT.Effect
   Right{} -> CT.Data
 
-data Modifier = Structural | Unique Text -- | Opaque (Set Reference)
+data Modifier = Structural | Unique Text --  | Opaque (Set Reference)
   deriving (Eq, Ord, Show)
 
 data DataDeclaration' v a = DataDeclaration {


### PR DESCRIPTION
This PR adjusts a few comments to not look like haddocks. `ghcide` (and possibly other tooling) picks them up as parse failures :grimacing: 