### PR TITLE
Add snapshot.yaml to speed up CI

### DIFF
--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -1,0 +1,15 @@
+resolver: lts-15.15
+
+packages:
+  - github: unisonweb/configurator
+    commit: e47e9e9fe1f576f8c835183b9def52d73c01327a
+  - github: unisonweb/haskeline
+    commit: 2944b11d19ee034c48276edc991736105c9d6143
+  - github: unisonweb/megaparsec
+    commit: c4463124c578e8d1074c04518779b5ce5957af6b
+  - base16-0.2.1.0@sha256:62e9abde29287913a775ec658b62ecba20270b9e1ac0a008e6acb4616b79a22d,2183
+  - concurrent-supply-0.1.8@sha256:9373f4868ad28936a7b93781b214ef4afdeacf377ef4ac729583073491c9f9fb,1627
+  - guid-0.1.0@sha256:a7c975be473f6f142d5cc1b39bc807a99043d20b1bb0873fdfe7a3ce84d2faf1,1078
+  - prelude-extras-0.4.0.3@sha256:1c10b0123ea13a6423d74a8fcbaeb2d5249b472588abde418a36b47b7c4f48c8,1163
+  - sandi-0.5@sha256:b278d072ca717706ea38f9bd646e023f7f2576a778fb43565b434f93638849aa,3010
+  - strings-1.1@sha256:0285dec4c8ab262359342b3e5ef1eb567074669461b9b38404f1cb870c881c5c,1617

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,21 +10,7 @@ packages:
 - unison-core
 
 #compiler-check: match-exact
-resolver: lts-15.15
-
-extra-deps:
-- github: unisonweb/configurator
-  commit: e47e9e9fe1f576f8c835183b9def52d73c01327a
-- github: unisonweb/haskeline
-  commit: 2944b11d19ee034c48276edc991736105c9d6143
-- github: unisonweb/megaparsec
-  commit: c4463124c578e8d1074c04518779b5ce5957af6b
-- base16-0.2.1.0@sha256:62e9abde29287913a775ec658b62ecba20270b9e1ac0a008e6acb4616b79a22d,2183
-- concurrent-supply-0.1.8@sha256:9373f4868ad28936a7b93781b214ef4afdeacf377ef4ac729583073491c9f9fb,1627
-- guid-0.1.0@sha256:a7c975be473f6f142d5cc1b39bc807a99043d20b1bb0873fdfe7a3ce84d2faf1,1078
-- prelude-extras-0.4.0.3@sha256:1c10b0123ea13a6423d74a8fcbaeb2d5249b472588abde418a36b47b7c4f48c8,1163
-- sandi-0.5@sha256:b278d072ca717706ea38f9bd646e023f7f2576a778fb43565b434f93638849aa,3010
-- strings-1.1@sha256:0285dec4c8ab262359342b3e5ef1eb567074669461b9b38404f1cb870c881c5c,1617
+resolver: snapshot.yaml
 
 ghc-options:
  # All packages


### PR DESCRIPTION
This patch adds a "custom stack snapshot", which you can read about here: https://docs.haskellstack.org/en/stable/pantry/

This doesn't change the build at all, only where stack puts things: all of these dependencies are now cached in `~/.stack`, rather than `.stack-work/`, so CI should be a bit faster.