### PR TITLE
Add PinBoard for canonicalizing strings

### DIFF
--- a/parser-typechecker/src/Unison/Util/PinBoard.hs
+++ b/parser-typechecker/src/Unison/Util/PinBoard.hs
@@ -47,7 +47,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import Data.Tuple (swap)
 import System.Mem.Weak (Weak, deRefWeak, mkWeakPtr)
-import Unison.Prelude hiding (empty)
+import Unison.Prelude
 
 -- | A "pin board" is a place to pin values; semantically, it's a set, but differs in a few ways:
 --

--- a/parser-typechecker/src/Unison/Util/PinBoard.hs
+++ b/parser-typechecker/src/Unison/Util/PinBoard.hs
@@ -1,0 +1,95 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Unison.Util.PinBoard
+  ( PinBoard,
+    new,
+    pin,
+
+    -- * For debugging
+    debugDump,
+  )
+where
+
+import Control.Concurrent.MVar
+import Data.Foldable (find)
+import Data.Functor.Compose
+import Data.Hashable (Hashable, hash)
+import qualified Data.IntMap as IntMap
+import Data.IntMap.Strict (IntMap)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import Data.Tuple (swap)
+import System.Mem.Weak (Weak, deRefWeak, mkWeakPtr)
+import Unison.Prelude hiding (empty)
+
+-- | A "pin board" is a place to pin values, with the following properties:
+--
+--   * Pinned values aren't kept alive by the pin board, they might be garbage collected at any time.
+--   * If you try to pin a value that's already pinned (per its Eq instance), the pinned one will be returned instead.
+newtype PinBoard a
+  = PinBoard (MVar (IntMap (Bucket a)))
+
+new :: IO (PinBoard a)
+new =
+  PinBoard <$> newMVar IntMap.empty
+
+pin :: (Eq a, Hashable a) => PinBoard a -> a -> IO a
+pin (PinBoard boardVar) x =
+  modifyMVar boardVar \board -> pin_ board x
+
+pin_ :: forall a. (Eq a, Hashable a) => IntMap (Bucket a) -> a -> IO (IntMap (Bucket a), a)
+pin_ board x =
+  swap <$> getCompose (IntMap.alterF (fmap Just . Compose . maybe miss hit) (hash x) board)
+  where
+    miss :: IO (a, Bucket a)
+    miss = do
+      bucket <- bucketAdd emptyBucket x
+      pure (x, bucket)
+    hit :: Bucket a -> IO (a, Bucket a)
+    hit bucket =
+      bucketFind bucket x >>= \case
+        (Nothing, bucket') -> do
+          bucket'' <- bucketAdd bucket' x
+          pure (x, bucket'')
+        (Just y, bucket') -> pure (y, bucket')
+
+debugDump :: (a -> Text) -> PinBoard a -> IO ()
+debugDump f (PinBoard boardVar) = do
+  board <- readMVar boardVar
+  contents <- traverse bucketToList (toList board)
+  Text.putStrLn (Text.unlines ("PinBoard" : map (("  " <>) . f) (concat contents)))
+
+-- | A bucket of values. Semantically, it's a set, but differs in a few ways:
+--
+--   * It has a very limited API.
+--   * It doesn't keep the values contained within alive; they might be garbage collected at any time.
+--   * Looking up a value mutates the bucket in IO; specifically, it drops all values that have been garbage collected.
+newtype Bucket a
+  = Bucket [Weak a] -- Invariant: values are non-empty lists
+
+-- | An empty bucket.
+emptyBucket :: Bucket a
+emptyBucket =
+  Bucket []
+
+-- | Add a value to a bucket.
+bucketAdd :: Bucket a -> a -> IO (Bucket a)
+bucketAdd (Bucket weaks) x = do
+  weak <- mkWeakPtr x Nothing
+  pure (Bucket (weak : weaks))
+
+-- | Look up a value in a bucket, per its Eq instance.
+bucketFind :: Eq a => Bucket a -> a -> IO (Maybe a, Bucket a)
+bucketFind (Bucket weaks) x = do
+  (ys, weaks') <- unzip <$> dereferenceWeaks weaks
+  pure (find (== x) ys, Bucket weaks')
+  where
+
+bucketToList :: Bucket a -> IO [a]
+bucketToList (Bucket weaks) =
+  map fst <$> dereferenceWeaks weaks
+
+-- Dereference a list of weak pointers, returning the alive ones along with their values.
+dereferenceWeaks :: [Weak a] -> IO [(a, Weak a)]
+dereferenceWeaks =
+  mapMaybeM \w -> fmap (,w) <$> deRefWeak w

--- a/parser-typechecker/src/Unison/Util/PinBoard.hs
+++ b/parser-typechecker/src/Unison/Util/PinBoard.hs
@@ -25,7 +25,6 @@
 --
 --                                     board
 --     z ───── "d2518f260535b927b" ┄┄┄┄┄┘
---
 module Unison.Util.PinBoard
   ( PinBoard,
     new,
@@ -57,12 +56,12 @@ import Unison.Prelude hiding (empty)
 newtype PinBoard a
   = PinBoard (MVar (IntMap (Bucket a)))
 
-new :: IO (PinBoard a)
+new :: MonadIO m => m (PinBoard a)
 new =
-  PinBoard <$> newMVar IntMap.empty
+  liftIO (PinBoard <$> newMVar IntMap.empty)
 
-pin :: forall a. (Eq a, Hashable a) => PinBoard a -> a -> IO a
-pin (PinBoard boardVar) x =
+pin :: forall a m. (Eq a, Hashable a, MonadIO m) => PinBoard a -> a -> m a
+pin (PinBoard boardVar) x = liftIO do
   modifyMVar boardVar \board ->
     swap <$> getCompose (IntMap.alterF alter n board)
   where

--- a/parser-typechecker/tests/Suite.hs
+++ b/parser-typechecker/tests/Suite.hs
@@ -31,6 +31,7 @@ import qualified Unison.Test.Typechecker.TypeError as TypeError
 import qualified Unison.Test.UnisonSources as UnisonSources
 import qualified Unison.Test.UriParser as UriParser
 import qualified Unison.Test.Util.Bytes as Bytes
+import qualified Unison.Test.Util.PinBoard as PinBoard
 import qualified Unison.Test.Util.Pretty as Pretty
 import qualified Unison.Test.Var as Var
 import qualified Unison.Test.VersionParser as VersionParser
@@ -66,6 +67,7 @@ test = tests
   , Name.test
   , VersionParser.test
   , Pretty.test
+  , PinBoard.test
  ]
 
 main :: IO ()

--- a/parser-typechecker/tests/Unison/Test/Util/PinBoard.hs
+++ b/parser-typechecker/tests/Unison/Test/Util/PinBoard.hs
@@ -6,8 +6,6 @@ module Unison.Test.Util.PinBoard
   )
 where
 
-import Control.DeepSeq (NFData, force)
-import Control.Exception (evaluate)
 import qualified Data.ByteString as ByteString
 import EasyTest
 import GHC.Exts (reallyUnsafePtrEquality#, isTrue#)
@@ -17,8 +15,8 @@ test :: Test ()
 test =
   scope "util.pinboard" . tests $
     [ scope "pinning equal values stores only one" $ do
-        b0 <- nf (ByteString.singleton 0)
-        b1 <- nf (ByteString.copy b0)
+        let b0 = ByteString.singleton 0
+        let b1 = ByteString.copy b0
 
         board <- PinBoard.new
 
@@ -40,7 +38,3 @@ test =
 expectSamePointer :: a -> a -> Test ()
 expectSamePointer x y =
   expect' (isTrue# (reallyUnsafePtrEquality# x y))
-
-nf :: NFData a => a -> Test a
-nf =
-  io . evaluate . force

--- a/parser-typechecker/tests/Unison/Test/Util/PinBoard.hs
+++ b/parser-typechecker/tests/Unison/Test/Util/PinBoard.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedTuples #-}
+
+module Unison.Test.Util.PinBoard
+  ( test,
+  )
+where
+
+import Control.DeepSeq (force)
+import Control.Exception (evaluate)
+import qualified Data.ByteString as ByteString
+import EasyTest
+import GHC.Exts (touch#)
+import GHC.IO (IO (IO))
+import qualified GHC.Stats as GHC
+import System.Mem (performGC)
+import Unison.Prelude
+import qualified Unison.Util.PinBoard as PinBoard
+
+test :: Test ()
+test =
+  scope "util.pinboard" . tests $
+    [ scope "pinning equal values stores only one" $ do
+        -- Allocate 2*1mb bytestrings, pin them both, and assert less than 2mb live memory
+        w0 <- getLiveHeapSize
+        bytes <- io $ evaluate (force (take 2 (iterate ByteString.copy (ByteString.replicate (2 ^ 20) 0))))
+        board <- PinBoard.new
+        for_ bytes (PinBoard.pin board)
+        w1 <- getLiveHeapSize
+        expect' (w1 - w0 < 2 ^ 20)
+        io (touch board)
+        ok
+    ]
+
+getLiveHeapSize :: MonadIO m => m Word64
+getLiveHeapSize = liftIO do
+  performGC
+  stats <- GHC.getRTSStats
+  pure (GHC.gcdetails_live_bytes (GHC.gc stats))
+
+touch :: a -> IO ()
+touch x =
+  IO \s -> (# touch# x s, () #)

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -316,7 +316,6 @@ executable tests
     base,
     bytestring,
     containers,
-    deepseq,
     directory,
     easytest,
     errors,

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -132,6 +132,7 @@ library
     Unison.Util.Logger
     Unison.Util.Map
     Unison.Util.Menu
+    Unison.Util.PinBoard
     Unison.Util.Pretty
     Unison.Util.Range
     Unison.Util.Star3
@@ -209,6 +210,7 @@ library
   ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
   default-extensions:
     ApplicativeDo,
+    BlockArguments,
     DeriveFunctor,
     DerivingStrategies,
     DoAndIfThenElse,

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -273,7 +273,7 @@ executable tests
   main-is:        Suite.hs
   hs-source-dirs: tests
   default-language: Haskell2010
-  ghc-options:    -W -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -threaded -rtsopts -with-rtsopts=-N -v0
+  ghc-options:    -W -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -threaded -rtsopts "-with-rtsopts=-N -T" -v0
   build-depends:
     base,
     easytest
@@ -305,6 +305,7 @@ executable tests
     Unison.Test.UnisonSources
     Unison.Test.UriParser
     Unison.Test.Util.Bytes
+    Unison.Test.Util.PinBoard
     Unison.Test.Util.Pretty
     Unison.Test.Var
     Unison.Test.VersionParser
@@ -315,6 +316,7 @@ executable tests
     base,
     bytestring,
     containers,
+    deepseq,
     directory,
     easytest,
     errors,
@@ -334,6 +336,9 @@ executable tests
     transformers,
     unison-core,
     unison-parser-typechecker
+
+  default-extensions:
+    BlockArguments
 
 executable transcripts
   main-is:        Transcripts.hs

--- a/unison-core/src/Unison/Prelude.hs
+++ b/unison-core/src/Unison/Prelude.hs
@@ -5,7 +5,7 @@ module Unison.Prelude
 import Control.Applicative as X
 import Control.Exception as X (Exception, SomeException, IOException, try)
 import Control.Monad as X
-import Control.Monad.Extra as X (ifM, unlessM, whenM)
+import Control.Monad.Extra as X (ifM, mapMaybeM, unlessM, whenM)
 import Control.Monad.IO.Class as X (MonadIO(liftIO))
 import Control.Monad.Trans as X (MonadTrans(lift))
 import Control.Monad.Trans.Maybe as X (MaybeT(MaybeT, runMaybeT))


### PR DESCRIPTION
## Overview

This PR adds a `PinBoard` type, as described by @aryairani in #1597, which is useful for de-duping values in memory (like hashes).

I'll copy the module doc here:

```
A utility type for saving memory in the presence of many duplicate ByteStrings, etc. If you have data that may be
a redundant duplicate, try pinning it to a pin board, and use the result of that operation instead.

  Without a pin board:

    x ───── "38dce848c8c829c62"
    y ───── "38dce848c8c829c62"
    z ───── "d2518f260535b927b"

  With a pin board:

    x ───── "38dce848c8c829c62" ┄┄┄┄┄┐
    y ────────┘                     board
    z ───── "d2518f260535b927b" ┄┄┄┄┄┘

  ... and after x is garbage collected:

            "38dce848c8c829c62" ┄┄┄┄┄┐
    y ────────┘                     board
    z ───── "d2518f260535b927b" ┄┄┄┄┄┘

  ... and after y is garbage collected:

                                    board
    z ───── "d2518f260535b927b" ┄┄┄┄┄┘
```

and here's the API:

```haskell
new :: IO (PinBoard a)
pin :: (Eq a, Hashable a) => PinBoard a -> a -> IO a
```

When you `pin` something, either you'll get a pointer-equal value back (hasn't been pinned before) or an `Eq`ual-but-not-pointer-equal value back (was pinned already).

## Implementation notes

It's implemented exactly as @aryairani described in #1597, using an `IntMap`.

## Interesting/controversial decisions

Data structure: it's currently `IntMap [Weak a]`, but could be `HashMap`, `HashTable`, something else? It wouldn't be hard to change.

Name: I picked `PinBoard` because this abstraction reminded me of a bulletin board, but `BulletinBoard` seemed long.

API: there's no implicit global pin board defined (I didn't know exactly how this thing would be used), but it's simple enough to add. That'd reduce the API to just one function per type, e.g.

```haskell
pinByteString :: ByteString -> IO ByteString
pinText :: Text -> IO Text
```
 
## Test coverage

One test was added that (I believe) covers the entire API.