### PR TITLE
Save transcript codebases to `/tmp`

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -36,10 +36,12 @@ import           System.FilePath                ( takeFileName
 import           System.Directory               ( getHomeDirectory
                                                 , canonicalizePath
                                                 )
+import           System.Environment             ( getProgName )
 import           System.Exit                    ( exitFailure, exitSuccess )
 import qualified Unison.Codebase               as Codebase
 import           Unison.Codebase                ( Codebase(Codebase)
                                                 , BuiltinAnnotation
+                                                , CodebasePath
                                                 )
 import           Unison.Codebase.Branch         ( Branch )
 import qualified Unison.Codebase.Branch        as Branch
@@ -60,7 +62,6 @@ import qualified Unison.Util.Pretty            as P
 import qualified Unison.PrettyTerminal         as PT
 import           Unison.Symbol                  ( Symbol )
 import qualified Unison.Codebase.FileCodebase.Common as Common
-import           Unison.Codebase                (CodebasePath)
 import Unison.Codebase.FileCodebase.Common
   ( Err(CantParseBranchHead)
   , codebaseExists
@@ -130,32 +131,31 @@ initCodebase cache path = do
 getCodebaseOrExit :: Branch.Cache IO -> Maybe FilePath -> IO (Codebase IO Symbol Ann)
 getCodebaseOrExit cache mdir = do
   dir <- getCodebaseDir mdir
+  progName <- getProgName
   prettyDir <- P.string <$> canonicalizePath dir
-  let errMsg = getNoCodebaseErrorMsg prettyDir mdir
+  let errMsg = getNoCodebaseErrorMsg ((P.text . Text.pack) progName) prettyDir mdir
   let theCodebase = codebase1 cache V1.formatSymbol formatAnn dir
   unlessM (codebaseExists dir) $ do
     PT.putPrettyLn' errMsg
     exitFailure
   theCodebase
 
-getNoCodebaseErrorMsg :: IsString s => P.Pretty s -> Maybe FilePath -> P.Pretty s
-getNoCodebaseErrorMsg prettyDir mdir =
+getNoCodebaseErrorMsg :: IsString s => P.Pretty s -> P.Pretty s -> Maybe FilePath -> P.Pretty s
+getNoCodebaseErrorMsg executable prettyDir mdir =
   let secondLine =
         case mdir of
-          Just dir  -> "Run `ucm -codebase " <> fromString dir
+          Just dir  -> "Run `" <> executable <> " -codebase " <> fromString dir
                      <> " init` to create one, then try again!"
-          Nothing -> "Run `ucm init` to create one there,"
+          Nothing -> "Run `" <> executable <> " init` to create one there,"
                      <> " then try again;"
-                     <> " or `ucm -codebase <dir>` to load a codebase from someplace else!"
+                     <> " or `" <> executable <> " -codebase <dir>` to load a codebase from someplace else!"
   in
     P.lines
         [ "No codebase exists in " <> prettyDir <> "."
         , secondLine ]
 
 getCodebaseDir :: Maybe FilePath -> IO FilePath
-getCodebaseDir mdir =
-  case mdir of Just dir -> pure dir
-               Nothing  -> getHomeDirectory
+getCodebaseDir = maybe getHomeDirectory pure
 
 -- builds a `Codebase IO v a`, given serializers for `v` and `a`
 codebase1

--- a/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
@@ -17,6 +17,7 @@ import Prelude hiding (readFile, writeFile)
 import System.Directory ( doesFileExist )
 import System.Exit (die)
 import System.IO.Error (catchIOError)
+import System.Environment (getProgName)
 import Unison.Codebase (Codebase)
 import Unison.Codebase.Editor.Command (LoadSourceResult (..))
 import Unison.Codebase.Editor.Input (Input (..), Event(UnisonFileChanged))
@@ -260,15 +261,17 @@ run dir configFile stanzas codebase branchCache = do
       -- output ``` and new lines then call transcriptFailure
       dieWithMsg :: forall a. IO a
       dieWithMsg = do
+        executable <- getProgName
         output "\n```\n\n"
         appendFailingStanza
         transcriptFailure out $ Text.unlines [
           "\128721", "",
           "The transcript failed due to an error encountered in the stanza above.", "",
-          "Run `ucm -codebase " <> Text.pack dir <> "` " <> "to do more work with it."]
+          "Run `" <> Text.pack executable <> " -codebase " <> Text.pack dir <> "` " <> "to do more work with it."]
 
       dieUnexpectedSuccess :: IO ()
       dieUnexpectedSuccess = do
+        executable <- getProgName
         errOk <- readIORef allowErrors
         hasErr <- readIORef hasErrors
         when (errOk && not hasErr) $ do
@@ -277,7 +280,7 @@ run dir configFile stanzas codebase branchCache = do
           transcriptFailure out $ Text.unlines [
             "\128721", "",
             "The transcript was expecting an error in the stanza above, but did not encounter one.", "",
-            "Run `ucm -codebase " <> Text.pack dir <> "` " <> "to do more work with it."]
+            "Run `" <> Text.pack executable <> " -codebase " <> Text.pack dir <> "` " <> "to do more work with it."]
 
       loop state = do
         writeIORef pathRef (view HandleInput.currentPath state)

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -168,9 +168,7 @@ main = do
 
 prepareTranscriptDir :: Branch.Cache IO -> Bool -> Maybe FilePath -> IO FilePath
 prepareTranscriptDir branchCache inFork mcodepath = do
-  currentDir <- getCurrentDirectory
-  tmp <- Temp.createTempDirectory currentDir "transcript"
-
+  tmp <- Temp.getCanonicalTemporaryDirectory >>= (`Temp.createTempDirectory` "transcript")
   unless inFork $ do
     PT.putPrettyLn . P.wrap $ "Transcript will be run on a new, empty codebase."
     _ <- FileCodebase.initCodebase branchCache tmp

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -132,7 +132,7 @@ main = do
       theCodebase <- FileCodebase.getCodebaseOrExit branchCache mcodepath
       launch currentDir config theCodebase branchCache []
     [version] | isFlag "version" version ->
-      putStrLn $ "ucm version: " ++ Version.gitDescribe
+      putStrLn $ progName ++ " version: " ++ Version.gitDescribe
     [help] | isFlag "help" help -> PT.putPrettyLn (usage progName)
     ["init"] -> FileCodebase.initCodebaseAndExit mcodepath
     "run" : [mainName] -> do
@@ -229,7 +229,7 @@ runTranscripts branchCache inFork keepTemp mcodepath args = do
             "I've finished running the transcript(s) in this codebase:", "",
             P.indentN 2 (P.string transcriptDir), "",
             P.wrap $ "You can run"
-                  <> P.backticked ("ucm -codebase " <> P.string transcriptDir)
+                  <> P.backticked (P.string progName <> " -codebase " <> P.string transcriptDir)
                   <> "to do more work with it."])
 
   unless completed $ do


### PR DESCRIPTION
Acc. to issue #1583, transcript codebases should be saved under `/tmp`. This changes the parent directory from `getCurrentDirectory` to `getCanonicalTemporaryDirectory`, which acc. to documentation
> Return the absolute and canonical path to the system temporary 

It closes issue #1583

## Test coverage

The usual CLI commands e.g

```
 unison transcript  unison-src/transcripts/hello.md
 unison transcript -save-codebase unison-src/transcripts/hello.md
 unison transcript.fork -save-codebase unison-src/transcripts/hello.md
```

Still work as intended. Tested on Linux, parent directory used for transcript directories is now `/tmp`

## Edit

The second commit that "accidentally" got into this PR is a part of  issue #1598 (that was already merged). I missed some cases and thought I'd fix them now. If you want' I can create a seperate PR for this.
The real change for issue #1583 is by 
`fc3728ca Use Temp.getCanonicalTemporaryRepository`

