### PR TITLE
Added tracing facility to the runtime

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -348,8 +348,9 @@ builtinsSrc =
   , B "Universal.>=" $ forall1 "a" (\a -> a --> a --> boolean)
   , B "Universal.<=" $ forall1 "a" (\a -> a --> a --> boolean)
 
-  , B "bug" $ forall1 "a" (\a -> forall1 "b" (\b -> a --> b))
-  , B "todo" $ forall1 "a" (\a -> forall1 "b" (\b -> a --> b))
+  , B "bug" $ forall1 "a" (\a -> forall1 "b" (a -->))
+  , B "todo" $ forall1 "a" (\a -> forall1 "b" (a -->))
+  , B "trace" $ forall1 "a" (\a -> forall1 "b" (\b -> a --> b --> b))
 
   , B "Boolean.not" $ boolean --> boolean
 

--- a/parser-typechecker/src/Unison/Runtime/IR.hs
+++ b/parser-typechecker/src/Unison/Runtime/IR.hs
@@ -227,6 +227,7 @@ data IR' ann z
   -- Debugging/Utilities
   | Todo z
   | Bug z
+  | Trace z z
   -- Control flow
 
   -- `Let` has an `ann` associated with it, e.g `ann = Set Int` which is the
@@ -327,6 +328,7 @@ prettyIR ppe prettyE prettyCont = pir
     CompareU a b -> P.parenthesize $ "CompareU" `P.hang` P.spaced [pz a, pz b]
     Bug a -> P.parenthesize $ "Bug" `P.hang` P.spaced [pz a]
     Todo a -> P.parenthesize $ "Todo" `P.hang` P.spaced [pz a]
+    Trace a b -> P.parenthesize $ "Trace" `P.hang` P.spaced [pz a, pz b]
     ir@Let{} ->
       P.group $ "let" `P.hang` P.lines (blockElem <$> block)
       where
@@ -739,6 +741,7 @@ boundVarsIR = \case
   CompareU _ _ -> mempty
   Bug _ -> mempty
   Todo _ -> mempty
+  Trace _ _ -> mempty
   MakeSequence _ -> mempty
   Construct{} -> mempty
   Request{} -> mempty
@@ -809,6 +812,7 @@ decompileIR stack = \case
   CompareU x y -> builtin "Universal.compare" [x,y]
   Bug x -> builtin "bug" [x]
   Todo x -> builtin "todo" [x]
+  Trace x y -> builtin "trace" [x,y]
   Let v b body _ -> do
     b' <- decompileIR stack b
     body' <- decompileIR (v:stack) body
@@ -1016,6 +1020,7 @@ builtins = Map.fromList $ arity0 <> arityN
         , ("Boolean.not", 1, Not (Slot 0))
         , ("bug", 1, Bug (Slot 0))
         , ("todo", 1, Todo (Slot 0))
+        , ("trace", 2, Trace (Slot 1) (Slot 0))
         ]]
 
 -- boring instances

--- a/unison-src/transcripts/trace.md
+++ b/unison-src/transcripts/trace.md
@@ -1,0 +1,16 @@
+# Tracing Unison programs
+
+```ucm:hide
+.> builtins.merge
+```
+
+```unison
+fac n = 
+  if n < 2 then
+    trace "done" 1
+  else 
+    trace "next" ()
+    fac (drop 1 n) * n
+
+> fac 10
+```

--- a/unison-src/transcripts/trace.output.md
+++ b/unison-src/transcripts/trace.output.md
@@ -1,0 +1,31 @@
+# Tracing Unison programs
+
+```unison
+fac n = 
+  if n < 2 then
+    trace "done" 1
+  else 
+    trace "next" ()
+    n * fac (drop 1 n)
+
+> fac 10
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      fac : Nat -> Nat
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    8 | > fac 10
+          ⧩
+          10
+
+```


### PR DESCRIPTION
This adds a builtin called `trace: a -> b -> b` which prints out the value of `a` before returning the value of `b`. Note that `b` is evaluated before `trace` is even called, as usual.

This helps with debugging Unison programs.

