### PR TITLE
Add -rtsopts to unison ghc-options

### DIFF
--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -237,7 +237,7 @@ executable unison
   main-is: Main.hs
   hs-source-dirs: unison
   default-language: Haskell2010
-  ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
+  ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -rtsopts
   other-modules:
     System.Path
     Version


### PR DESCRIPTION
This PR just adds `-rtsopts` to the unison executable, so a greater number of runtime knobs can be tweaked with command-line options