### PR TITLE
add multiple ubuntu and osx build images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,17 @@
 # https://docs.haskellstack.org/en/stable/travis_ci/
-# run on containerized infrastructure hopefully
-dist: trusty
-sudo: false
+jobs:
+  include:
+    - os: linux
+      dist: xenial
+    - os: linux
+      dist: trusty
+    - os: linux
+      dist: bionic
+    - os: osx
+      osx_image: xcode11.6
+    - os: osx
+      osx_image: xcode11.3
+
 language: generic
 
 # Caching so the next build will be fast too.
@@ -16,7 +26,7 @@ before_install:
 # Download and unpack the stack executable
 - mkdir -p ~/.local/bin
 - export PATH=$HOME/.local/bin:$PATH
-- travis_retry curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+- travis_retry curl -sSL https://get.haskellstack.org/ | sh
 
 install:
 - stack ghc -- --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,10 @@ cache:
   directories:
   - $HOME/.stack
 
-before_cache:
 # Do any cleanup here to avoid caching junk.
+before_cache:
+  # this was getting corrupted in the cache for osx ??
+  - rm -rf /Users/travis/.stack/setup-exe-cache
 
 before_install:
 # Download and unpack the stack executable


### PR DESCRIPTION
Closes #1616.

This matrix provides builds for:
macOS 10.15.4, Xcode 11.6
macOS 10.14.6, Xcode 11.3.1
Ubuntu Bionic 18.04
Ubuntu Xenial 16.04
Ubuntu Trusty 14.04 (the one we'd been using so far)

This may be overboard, and I wouldn't object to removing some if requested.  We can run 5 jobs in parallel on the Travis OSS plan (across all branches).





