### PR TITLE
Part of #598: Fix frozen windows executable

### DIFF
--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -237,7 +237,7 @@ executable unison
   main-is: Main.hs
   hs-source-dirs: unison
   default-language: Haskell2010
-  ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -rtsopts
+  ghc-options: -Wall -threaded -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -rtsopts
   other-modules:
     System.Path
     Version


### PR DESCRIPTION
Apparently FSNotify requires `-threaded` flag to work properly. And I think it's best to use the flag anyway to use the multi-threaded runtime

Part of #598