### PR TITLE
Update links when propagating changes to metadata

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -552,7 +552,7 @@ loop = do
                     -> [(Path', HQ'.HQSegment)]
                     -> [HQ.HashQualified]
                     -> (forall r. Ord r
-                        => (r, Reference, Reference)
+                        => (r, Metadata.Type, Metadata.Value)
                         ->  Branch.Star r NameSegment
                         ->  Branch.Star r NameSegment)
                     -> Action m (Either Event Input) v ()
@@ -2588,6 +2588,8 @@ doSlurpUpdates typeEdits termEdits deprecated b0 =
     Just split -> [ BranchUtil.makeDeleteTermName split (Referent.Ref old)
                   , BranchUtil.makeAddTermName split (Referent.Ref new) oldMd ]
       where
+      -- oldMd is the metadata linked to the old definition
+      -- we relink it to the new definition
       oldMd = BranchUtil.getTermMetadataAt split (Referent.Ref old) b0
   errorEmptyVar = error "encountered an empty var name"
 

--- a/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
@@ -44,6 +44,7 @@ import           Unison.UnisonFile              ( UnisonFile(..) )
 import qualified Unison.UnisonFile             as UF
 import qualified Unison.Util.Star3             as Star3
 import           Unison.Type                    ( Type )
+import qualified Unison.Type                   as Type
 import qualified Unison.Typechecker            as Typechecker
 import           Unison.ConstructorType         ( ConstructorType )
 import qualified Unison.Runtime.IOSource       as IOSource
@@ -436,19 +437,21 @@ applyDeprecations patch = deleteDeprecatedTerms deprecatedTerms
 -- definition that is created by the `Edits` which is passed in is marked as
 -- a propagated change.
 applyPropagate
-  :: Show v => Applicative m => Patch -> Edits v -> F m i v (Branch0 m -> Branch0 m)
+  :: Var v => Applicative m => Patch -> Edits v -> F m i v (Branch0 m -> Branch0 m)
 applyPropagate patch Edits {..} = do
   let termRefs = Map.mapMaybe TermEdit.toReference termEdits
       typeRefs = Map.mapMaybe TypeEdit.toReference typeEdits
+      termTypes = Map.map (Type.toReference . snd) newTerms
   -- recursively update names and delete deprecated definitions
-  pure $ Branch.stepEverywhere (updateLevel termRefs typeRefs)
+  pure $ Branch.stepEverywhere (updateLevel termRefs typeRefs termTypes)
  where
   updateLevel
     :: Map Reference Reference
     -> Map Reference Reference
+    -> Map Reference Reference
     -> Branch0 m
     -> Branch0 m
-  updateLevel termEdits typeEdits Branch0 {..} =
+  updateLevel termEdits typeEdits termTypes Branch0 {..} =
     Branch.branch0 termsWithCons types _children _edits
    where
     isPropagated = (`Set.notMember` allPatchTargets) where
@@ -456,6 +459,9 @@ applyPropagate patch Edits {..} = do
 
     terms = foldl' replaceTerm _terms (Map.toList termEdits)
     types = foldl' replaceType _types (Map.toList typeEdits)
+
+    updateMetadata r r' (tp, v) = if v == r then (typeOf r' tp, r') else (tp, v)
+      where typeOf r t = fromMaybe t $ Map.lookup r termTypes
 
     propagatedMd :: r -> (r, Metadata.Type, Metadata.Value)
     propagatedMd r = (r, IOSource.isPropagatedReference, IOSource.isPropagatedValue)
@@ -465,8 +471,8 @@ applyPropagate patch Edits {..} = do
       (if isPropagated r'
        then Metadata.insert (propagatedMd (Referent.Ref r'))
        else Metadata.delete (propagatedMd (Referent.Ref r'))) .
-      Star3.replaceFact (Referent.Ref r) (Referent.Ref r') .
-        Star3.mapD3 (\(tp, v) -> if v == r then (tp, r') else (tp, v)) $ s
+      Star3.replaceFact (Referent.Ref r) (Referent.Ref r') $
+        Star3.mapD3 (updateMetadata r r') s
 
     replaceConstructor s ((oldr, oldc, oldt), (newr, newc, newt)) =
       -- always insert the metadata since patches can't contain ctor mappings (yet)

--- a/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
@@ -465,11 +465,12 @@ applyPropagate patch Edits {..} = do
       (if isPropagated r'
        then Metadata.insert (propagatedMd (Referent.Ref r'))
        else Metadata.delete (propagatedMd (Referent.Ref r'))) .
-      Star3.replaceFact (Referent.Ref r) (Referent.Ref r') $ s
+      Star3.replaceFact (Referent.Ref r) (Referent.Ref r') .
+        Star3.mapD3 (\(tp, v) -> if v == r then (tp, r') else (tp, v)) $ s
 
     replaceConstructor s ((oldr, oldc, oldt), (newr, newc, newt)) =
       -- always insert the metadata since patches can't contain ctor mappings (yet)
-      (Metadata.insert (propagatedMd con')) .
+      Metadata.insert (propagatedMd con') .
       Star3.replaceFact (Referent.Con oldr oldc oldt) con' $ s
       where
       con' = Referent.Con newr newc newt

--- a/unison-src/transcripts/diff.output.md
+++ b/unison-src/transcripts/diff.output.md
@@ -214,7 +214,7 @@ unique type Y a b = Y a b
 
 .ns2> links fromJust
 
-  1. .ns1.b : Nat
+  1. b : Text
   
   Tip: Try using `display 1` to display the first result or
        `view 1` to view its source.
@@ -227,30 +227,32 @@ unique type Y a b = Y a b
     2.  └ fromJust#jk19sm5bf8 : Nat
         ↓
     3.  fromJust#1o1iq26cq7 : Nat
-        + 4.  ns1.b : Nat
+        - 4.  ns1.b : Nat
+        + 5.  ns2.b : Text
   
   Updates:
   
-    5.  b : Nat
+    6.  b : Nat
         ↓
-    6.  b : Text
+    7.  b : Text
     
-    7.  fromJust' : Nat
-        ↓
     8.  fromJust' : Nat
-        + 9.  ns1.b : Nat
+        ↓
+    9.  fromJust' : Nat
+        - 10. ns1.b : Nat
+        + 11. ns2.b : Text
   
     There were 1 auto-propagated updates.
   
   Added definitions:
   
-    10. unique type Y a b
-    11. Y.Y : a -> b -> Y a b
-    12. d   : Nat
-    13. e   : Nat
-    14. f   : Nat
+    12. unique type Y a b
+    13. Y.Y : a -> b -> Y a b
+    14. d   : Nat
+    15. e   : Nat
+    16. f   : Nat
   
-    15. patch patch (added 2 updates)
+    17. patch patch (added 2 updates)
 
 .> alias.term ns2.d ns2.d'
 
@@ -272,38 +274,40 @@ unique type Y a b = Y a b
     2.  └ fromJust#jk19sm5bf8 : Nat
         ↓
     3.  fromJust#1o1iq26cq7 : Nat
-        + 4.  ns1.b : Nat
+        - 4.  ns1.b : Nat
+        + 5.  ns2.b : Text
   
   Updates:
   
-    5.  b : Nat
+    6.  b : Nat
         ↓
-    6.  b : Text
+    7.  b : Text
     
-    7.  fromJust' : Nat
-        ↓
     8.  fromJust' : Nat
-        + 9.  ns1.b : Nat
+        ↓
+    9.  fromJust' : Nat
+        - 10. ns1.b : Nat
+        + 11. ns2.b : Text
   
     There were 1 auto-propagated updates.
   
   Added definitions:
   
-    10. unique type Y a b
-    11. Y.Y  : a -> b -> Y a b
-    12. ┌ d  : Nat
-    13. └ d' : Nat
-    14. e    : Nat
-    15. f    : Nat
+    12. unique type Y a b
+    13. Y.Y  : a -> b -> Y a b
+    14. ┌ d  : Nat
+    15. └ d' : Nat
+    16. e    : Nat
+    17. f    : Nat
   
-    16. patch patch (added 2 updates)
+    18. patch patch (added 2 updates)
   
   Name changes:
   
     Original  Changes
-    17. A     18. A' (added)
+    19. A     20. A' (added)
     
-    19. X    20. X' (added)
+    21. X    22. X' (added)
 
 .> link ns1.c ns2.f
 
@@ -327,41 +331,43 @@ unique type Y a b = Y a b
     2.  └ fromJust#jk19sm5bf8 : Nat
         ↓
     3.  fromJust#1o1iq26cq7 : Nat
-        + 4.  ns1.b : Nat
+        - 4.  ns1.b : Nat
+        + 5.  ns2.b : Text
   
   Updates:
   
-    5.  b : Nat
+    6.  b : Nat
         ↓
-    6.  b : Text
+    7.  b : Text
     
-    7.  c : Nat
-        + 8.  c : Nat
+    8.  c : Nat
+        + 9.  c : Nat
     
-    9.  fromJust' : Nat
-        ↓
     10. fromJust' : Nat
-        + 11. ns1.b : Nat
+        ↓
+    11. fromJust' : Nat
+        - 12. ns1.b : Nat
+        + 13. ns2.b : Text
   
     There were 1 auto-propagated updates.
   
   Added definitions:
   
-    12. unique type Y a b
-    13. Y.Y  : a -> b -> Y a b
-    14. ┌ d  : Nat
-    15. └ d' : Nat
-    16. e    : Nat
-    17. f    : Nat (+1 metadata)
+    14. unique type Y a b
+    15. Y.Y  : a -> b -> Y a b
+    16. ┌ d  : Nat
+    17. └ d' : Nat
+    18. e    : Nat
+    19. f    : Nat (+1 metadata)
   
-    18. patch patch (added 2 updates)
+    20. patch patch (added 2 updates)
   
   Name changes:
   
     Original  Changes
-    19. A     20. A' (added)
+    21. A     22. A' (added)
     
-    21. X    22. X' (added)
+    23. X    24. X' (added)
 
 .> unlink ns2.b ns2.fromJust
 
@@ -375,41 +381,43 @@ unique type Y a b = Y a b
     2.  └ fromJust#jk19sm5bf8 : Nat
         ↓
     3.  fromJust#1o1iq26cq7 : Nat
-        + 4.  ns1.b : Nat
+        - 4.  ns1.b : Nat
+        + 5.  ns2.b : Text
   
   Updates:
   
-    5.  b : Nat
+    6.  b : Nat
         ↓
-    6.  b : Text
+    7.  b : Text
     
-    7.  c : Nat
-        + 8.  c : Nat
+    8.  c : Nat
+        + 9.  c : Nat
     
-    9.  fromJust' : Nat
-        ↓
     10. fromJust' : Nat
-        + 11. ns1.b : Nat
+        ↓
+    11. fromJust' : Nat
+        - 12. ns1.b : Nat
+        + 13. ns2.b : Text
   
     There were 1 auto-propagated updates.
   
   Added definitions:
   
-    12. unique type Y a b
-    13. Y.Y  : a -> b -> Y a b
-    14. ┌ d  : Nat
-    15. └ d' : Nat
-    16. e    : Nat
-    17. f    : Nat (+1 metadata)
+    14. unique type Y a b
+    15. Y.Y  : a -> b -> Y a b
+    16. ┌ d  : Nat
+    17. └ d' : Nat
+    18. e    : Nat
+    19. f    : Nat (+1 metadata)
   
-    18. patch patch (added 2 updates)
+    20. patch patch (added 2 updates)
   
   Name changes:
   
     Original  Changes
-    19. A     20. A' (added)
+    21. A     22. A' (added)
     
-    21. X    22. X' (added)
+    23. X    24. X' (added)
 
 .> alias.type ns1.X ns1.X2
 

--- a/unison-src/transcripts/fix1356.md
+++ b/unison-src/transcripts/fix1356.md
@@ -27,30 +27,14 @@ Step 4: I add it and expect to see it
 .> update
 .> docs x
 ```
-But I don't see an update, so from here on I am in panic mode and have no clue what I am doing!
 
-Step 5: maybe re-link it?
-```ucm
-.> link x.doc x
-```
-
-Step 6: Great that seems to have worked but let me check just in case
+That works great. Let's relink the old doc too.
 
 ```ucm
-.> docs x
-.> display 1
+.> link #v8f1hhvs57 x
 ```
 
-Step 7: I have been guided to check `display 1`, so now let's try and unlink to get rid of the second link. We can remove by number, or by hash:
-
-```ucm
-.> unlink 2 x
-.> view 2
-.> undo
-.> unlink #v8f1hhvs57 x
-```
-
-We expect that after the `unlink`, the `docs` command now works as there's a single `Doc` again:
+Let's check that we see both docs:
 
 ```ucm
 .> docs x

--- a/unison-src/transcripts/fix1356.output.md
+++ b/unison-src/transcripts/fix1356.output.md
@@ -66,22 +66,21 @@ Step 4: I add it and expect to see it
 
 .> docs x
 
-  I am the documentation for x
+  I am the documentation for x, and I now look better
 
 ```
-But I don't see an update, so from here on I am in panic mode and have no clue what I am doing!
+That works great. Let's relink the old doc too.
 
-Step 5: maybe re-link it?
 ```ucm
-.> link x.doc x
+.> link #v8f1hhvs57 x
 
   Updates:
   
     1. x : Nat
-       + 2. doc : Doc
+       + 2. #v8f1hhvs57 : Doc
 
 ```
-Step 6: Great that seems to have worked but let me check just in case
+Let's check that we see both docs:
 
 ```ucm
 .> docs x
@@ -91,49 +90,5 @@ Step 6: Great that seems to have worked but let me check just in case
   
   Tip: Try using `display 1` to display the first result or
        `view 1` to view its source.
-
-.> display 1
-
-  I am the documentation for x, and I now look better
-
-```
-Step 7: I have been guided to check `display 1`, so now let's try and unlink to get rid of the second link. We can remove by number, or by hash:
-
-```ucm
-.> unlink 2 x
-
-  Updates:
-  
-    1. x : Nat
-       - 2. #v8f1hhvs57 : Doc
-
-.> view 2
-
-  x.doc#v8f1hhvs57 : Doc
-  x.doc#v8f1hhvs57 = [: I am the documentation for x :]
-
-.> undo
-
-  Here's the changes I undid
-  
-  Updates:
-  
-    1. x : Nat
-       - 2. #v8f1hhvs57 : Doc
-
-.> unlink #v8f1hhvs57 x
-
-  Updates:
-  
-    1. x : Nat
-       - 2. #v8f1hhvs57 : Doc
-
-```
-We expect that after the `unlink`, the `docs` command now works as there's a single `Doc` again:
-
-```ucm
-.> docs x
-
-  I am the documentation for x, and I now look better
 
 ```


### PR DESCRIPTION
## Overview

Fixes #1349 and #1497 

This is a slight change to the `propagate` code so that when an `update` occurs, not only is the name updated to point to the new reference, but also if the old reference participates in any links somewhere under the current namespace, those links are updated to use the new reference.

## Implementation notes

This is a tiny change to the code that updates the `Star3` for the relevant branch during `propagate`.

## Test coverage

A couple of existing transcripts relied on the old behaviour. I've updated them so they now test the new behaviour.
