### PR TITLE
Show names from merged namespace after merge

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -2166,10 +2166,11 @@ mergeBranchAndPropagateDefaultPatch mode inputDescription unchangedMessage srcb 
   mergeBranch mode inputDescription srcb dest0 dest = unsafeTime "Merge Branch" $ do
     destb <- getAt dest
     merged <- eval . Eval $ Branch.merge' mode srcb destb
+    b <- updateAtM inputDescription dest (const $ pure merged)
     for_ dest0 $ \dest0 ->
       diffHelper (Branch.head destb) (Branch.head merged) >>=
         respondNumbered . uncurry (ShowDiffAfterMerge dest0 dest)
-    updateAtM inputDescription dest (const $ pure merged)
+    pure b
 
 loadPropagateDiffDefaultPatch :: (Monad m, Var v) =>
   InputDescription -> Maybe Path.Path' -> Path.Absolute -> Action' m v ()

--- a/unison-src/transcripts/delete.output.md
+++ b/unison-src/transcripts/delete.output.md
@@ -183,10 +183,10 @@ type Foo = Foo Boolean
     3. └ type Foo#gq9inhvg9h
            
     
-    4. Foo.Foo#d97e0jhkmd#0 : Nat -> Foo
+    4. Foo.Foo#d97e0jhkmd#0 : Nat -> Foo#d97e0jhkmd
        ↓
-    5. ┌ Foo.Foo#d97e0jhkmd#0 : Nat -> Foo
-    6. └ Foo.Foo#gq9inhvg9h#0 : Boolean -> b.Foo
+    5. ┌ Foo.Foo#d97e0jhkmd#0 : Nat -> Foo#d97e0jhkmd
+    6. └ Foo.Foo#gq9inhvg9h#0 : Boolean -> Foo#gq9inhvg9h
   
   Tip: You can use `todo` to see if this generated any work to
        do in this namespace and `test` to run the tests. Or you


### PR DESCRIPTION
Fixes #1574 

This PR changes the order of operations on a merge, so that the output is generated after the merge is complete. That way, the pretty-print environment is populated with the post-merge names.

This has e.g. the effect that pulling `base` into an empty codebase shows the newly added names rather than hashes in the type signatures of the added definitions.

**Before**

    63.   Abort.abort                                       : {#oup50kgmqv} a (+2 metadata)
    64.   Ask.ask                                           : {#q4pjprlin9 a} a (+2 metadata)
    65.   Author.Author                                     : #rc29vdqe01
                                                            -> ##Text
                                                            -> #5hi1vvs5t1

**After**

    63.   Abort.abort                                       : {Abort} a (+2 metadata)
    64.   Ask.ask                                           : {Ask a} a (+2 metadata)
    65.   Author.Author                                     : GUID
                                                            -> Text
                                                            -> Author
