### PR TITLE
Prevent caching of runtime errors during tests

### DIFF
--- a/parser-typechecker/src/Unison/Builtin/Decls.hs
+++ b/parser-typechecker/src/Unison/Builtin/Decls.hs
@@ -67,11 +67,6 @@ okConstructorReferent, failConstructorReferent :: Referent.Referent
 okConstructorReferent = Referent.Con testResultRef okConstructorId CT.Data
 failConstructorReferent = Referent.Con testResultRef failConstructorId CT.Data
 
-failResult :: (Ord v, Monoid a) => a -> Text -> Term v a
-failResult ann msg =
-  Term.app ann (Term.constructor ann testResultRef failConstructorId)
-               (Term.text ann msg)
-
 -- | parse some builtin data types, and resolve their free variables using
 -- | builtinTypes' and those types defined herein
 builtinDataDecls :: Var v => [(v, Reference.Id, DataDeclaration' v ())]

--- a/parser-typechecker/src/Unison/Builtin/Decls.hs
+++ b/parser-typechecker/src/Unison/Builtin/Decls.hs
@@ -69,7 +69,7 @@ failConstructorReferent = Referent.Con testResultRef failConstructorId CT.Data
 
 failResult :: (Ord v, Monoid a) => a -> Text -> Term v a
 failResult ann msg =
-  Term.app ann (Term.request ann testResultRef failConstructorId)
+  Term.app ann (Term.constructor ann testResultRef failConstructorId)
                (Term.text ann msg)
 
 -- | parse some builtin data types, and resolve their free variables using


### PR DESCRIPTION
# Overview

Fixes #1627 

This change prints an error when a test fails due to a runtime error, rather than returning it as a test failure. This prevents caching spurious runtime errors (such as cancellation due to CTRL-C).