### PR TITLE
Limit copy to codebase path in transcript.fork

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/FileCodebase/Common.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase/Common.hs
@@ -10,6 +10,7 @@ module Unison.Codebase.FileCodebase.Common
   , SyncToDir
   , SimpleLens
   , codebaseExists
+  , codebasePath
   , hashExists
   -- dirs (parent of all the files)
   , branchHeadDir

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -18,6 +18,7 @@ import qualified Unison.Codebase.Branch        as Branch
 import qualified Unison.Codebase.Editor.VersionParser as VP
 import           Unison.Codebase.Execute        ( execute )
 import qualified Unison.Codebase.FileCodebase  as FileCodebase
+import           Unison.Codebase.FileCodebase.Common ( codebasePath )
 import           Unison.Codebase.Editor.RemoteRepo (RemoteNamespace)
 import           Unison.CommandLine             ( watchConfig )
 import qualified Unison.CommandLine.Main       as CommandLine
@@ -195,7 +196,7 @@ prepareTranscriptDir branchCache inFork mcodepath = do
       P.wrap "Transcript will be run on a copy of the codebase at: ", "",
       P.indentN 2 (P.string path)
       ]
-    Path.copyDir path tmp
+    Path.copyDir (path FP.</> codebasePath) (tmp FP.</> codebasePath)
 
   pure tmp
 


### PR DESCRIPTION

## Overview

Resolves #1541 as suggested by @aryairani .

## Test coverage

I'm not sure whether there's a good way to add a test for this to the repo itself, but I tested it with `stack exec -- unison -codebase /my/codebase transcript.fork test.md` where `test.md` is a simple transcript that I wrote, and it resolved the issue for me.
