### PR TITLE
Do not set latestFile in doDisplay

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1835,10 +1835,6 @@ doDisplay outputLoc names r = do
     loadDecl _ = pure Nothing
   rendered <- DisplayValues.displayTerm ppe loadTerm loadTypeOfTerm evalTerm loadDecl tm
   respond $ DisplayRendered loc rendered
-  -- We set latestFile to be programmatically generated, if we
-  -- are viewing these definitions to a file - this will skip the
-  -- next update for that file (which will happen immediately)
-  latestFile .= ((, True) <$> loc)
 
 getLinks :: (Var v, Monad m)
          => Input


### PR DESCRIPTION
Resolves #1634 per suggestion by @pchiusano

A similar `ucm` session to the one presented in #1634 now does what I
would expect.

```
.> cd _base
._base> edit Boolean.and

  ☝️

  I added these definitions to the top of /Users/cody/code/unison/scratch.u

    Boolean.and : Boolean -> Boolean -> Boolean
    Boolean.and x y = x && y

  You can edit them there, then do `update` to replace the definitions currently in this namespace.

._base>
._base> display.to doc.md Boolean.and.doc

  ☝️

  I added this to the top of /Users/cody/code/unison/doc.md

    Boolean 'and'. Note that this function cannot short-circuit, as it's strict in both arguments. For
    a short-cirquiting version, use the built-in syntax `&&`.

._base> edit Boolean.and

  ☝️

  I added these definitions to the top of /Users/cody/code/unison/scratch.u

    Boolean.and : Boolean -> Boolean -> Boolean
    Boolean.and x y = x && y

  You can edit them there, then do `update` to replace the definitions currently in this namespace.
```