### PR TITLE
Add hie.yaml

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,37 @@
+cradle:
+  multi:
+    - path: "./"
+      config:
+        cradle:
+          stack:
+            - path: "./parser-typechecker/src"
+              component: "unison-parser-typechecker:lib"
+            - path: "./parser-typechecker/unison"
+              component: "unison-parser-typechecker:exe:unison"
+            - path: "./parser-typechecker/prettyprintdemo"
+              component: "unison-parser-typechecker:exe:prettyprintdemo"
+            - path: "./parser-typechecker/tests"
+              component: "unison-parser-typechecker:exe:tests"
+            - path: "./parser-typechecker/transcripts"
+              component: "unison-parser-typechecker:exe:transcripts"
+
+            - path: "./unison-core/src"
+              component: "unison-core:lib"
+
+            - path: "./yaks/easytest/src"
+              component: "easytest:lib"
+            - path: "./yaks/easytest/tests"
+              component: "easytest:exe:runtests"
+
+    # Attempt to skip ./unison-src/parser-tests/GenerateErrors.hs
+    # which doesn't have a corresponding cabal file.
+    #
+    # This is the skipping strategy suggested by:
+    # https://github.com/mpickering/hie-bios/tree/7f298424e30e0453dc21062ffa543998a2145ab6#ignoring-directories
+    # but it isn't working for some reason.
+    #
+    # Until it does you can expect to see "1 file failed" in the ghcide output.
+    - path: "./unison-src"
+      config:
+        cradle:
+          none:


### PR DESCRIPTION
This gets ghcide working.

```
$ ghcide
...
Completed (183 files worked, 1 file failed)
```

The 1 file failed is because of ./unison-src/parser-tests/GenerateErrors.hs, and shouldn't affect anything.

ghcide details:
+ compiled from ghcide `master`
+ using commit 6a72d99bfb0b4c407ada9f36f9367f1523063a84
+ using the `./stack88.yaml` config file, with the resolver changed to `lts-16.6`
