### PR TITLE
Modify the behavior of "delete" to remove all terms/types associated with a name.

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -610,12 +610,7 @@ loop = do
           let matchingTypes = toList (getHQ'Types hq)
           case (matchingTerms, matchingTypes) of
             ([], []) -> respond (NameNotFound hq)
-            -- delete one term
-            ([r], []) -> goMany (Set.singleton r) Set.empty
-            -- delete one type
-            ([], [r]) -> goMany Set.empty (Set.singleton r)
-            (Set.fromList -> tms, Set.fromList -> tys) ->
-              ifConfirmed (goMany tms tys) (nameConflicted hq tms tys)
+            (Set.fromList -> tms, Set.fromList -> tys) -> goMany tms tys
           where
           resolvedPath = resolveSplit' (HQ'.toName <$> hq)
           goMany tms tys = do

--- a/unison-src/transcripts/delete.md
+++ b/unison-src/transcripts/delete.md
@@ -4,8 +4,7 @@
 .> builtins.merge
 ```
 
-The delete command can delete both terms and types, as long as it's given an
-unambiguous name.
+The delete command can delete both terms and types.
 
 First, let's make sure it complains when we try to delete a name that doesn't
 exist.
@@ -48,11 +47,7 @@ foo = 2
 .a> merge .b
 ```
 
-```ucm:error
-.a> delete foo
-```
-
-I can force my delete through by re-issuing the command.
+A delete should remove both versions of the term.
 
 ```ucm
 .a> delete foo
@@ -81,16 +76,8 @@ type Foo = Foo Boolean
 .a> merge .b
 ```
 
-```ucm:error
-.a> delete Foo
-```
-
 ```ucm
 .a> delete Foo
-```
-
-```ucm:error
-.a> delete Foo.Foo
 ```
 
 ```ucm
@@ -106,10 +93,6 @@ type foo = Foo Nat
 
 ```ucm
 .> add
-```
-
-```ucm:error
-.> delete foo
 ```
 
 ```ucm

--- a/unison-src/transcripts/delete.output.md
+++ b/unison-src/transcripts/delete.output.md
@@ -1,7 +1,6 @@
 # Delete
 
-The delete command can delete both terms and types, as long as it's given an
-unambiguous name.
+The delete command can delete both terms and types.
 
 First, let's make sure it complains when we try to delete a name that doesn't
 exist.
@@ -102,24 +101,7 @@ foo = 2
        merge.
 
 ```
-```ucm
-.a> delete foo
-
-  🤔
-  
-  That name is ambiguous. It could refer to any of the following
-  definitions:
-  
-    foo#0ja1qfpej6
-    foo#jk19sm5bf8
-  
-  You may:
-  
-    * Delete one by an unambiguous name, given above.
-    * Delete them all by re-issuing the previous command.
-
-```
-I can force my delete through by re-issuing the command.
+A delete should remove both versions of the term.
 
 ```ucm
 .a> delete foo
@@ -197,23 +179,6 @@ type Foo = Foo Boolean
 ```ucm
 .a> delete Foo
 
-  🤔
-  
-  That name is ambiguous. It could refer to any of the following
-  definitions:
-  
-    Foo#d97e0jhkmd
-    Foo#gq9inhvg9h
-  
-  You may:
-  
-    * Delete one by an unambiguous name, given above.
-    * Delete them all by re-issuing the previous command.
-
-```
-```ucm
-.a> delete Foo
-
   Removed definitions:
   
     1. type a.Foo#d97e0jhkmd
@@ -225,23 +190,6 @@ type Foo = Foo Boolean
     4. b.Foo            ┘  
   
   Tip: You can use `undo` or `reflog` to undo this change.
-
-```
-```ucm
-.a> delete Foo.Foo
-
-  🤔
-  
-  That name is ambiguous. It could refer to any of the following
-  definitions:
-  
-    Foo.Foo#d97e0jhkmd#0
-    Foo.Foo#gq9inhvg9h#0
-  
-  You may:
-  
-    * Delete one by an unambiguous name, given above.
-    * Delete them all by re-issuing the previous command.
 
 ```
 ```ucm
@@ -274,23 +222,6 @@ type foo = Foo Nat
   
     type foo
     foo : Nat
-
-```
-```ucm
-.> delete foo
-
-  🤔
-  
-  That name is ambiguous. It could refer to any of the following
-  definitions:
-  
-    foo#jk19sm5bf8
-    foo#d97e0jhkmd
-  
-  You may:
-  
-    * Delete one by an unambiguous name, given above.
-    * Delete them all by re-issuing the previous command.
 
 ```
 ```ucm


### PR DESCRIPTION
## Overview

When a user runs the `delete` command for a name associated with multiple terms/types, `ucm` will display a warning and ask them to enter the command a second time if they want to delete everything associated
with the name.

In Issue #1070, @mitchellwrosen proposed changing the behavior of `delete` so that all terms/types associated with a name are deleted. This change implements the behavior requested in that issue.

## Implementation Notes / Test Coverage

Mostly this appears to be an exercise in making some slight adjustments to existing logic and bringing the existing transcript tests (which verify the current warning behavior) up to date.

## Other Notes

This is my first unison PR, so apologies in advance if I missed something.

It looks like this issue hasn't been discussed since December of 2019 and I'm not sure if the consensus about the right behavior for `delete` might have changed since then. For my part, working on this PR was mostly an opportunity to learn more about the code-base, tests, etc.
