### PR TITLE
Fix #1640 caused by incorrect parsing of nested patterns that mention nullary constructors

### DIFF
--- a/unison-src/tests/fix1640.u
+++ b/unison-src/tests/fix1640.u
@@ -2,10 +2,24 @@
 unique type Color = Red | Black
 unique type RBTree a = Leaf | Tree Color (RBTree a) a (RBTree a)
 
+-- interesting, this typechecks fine
 isRed = cases
   Color.Red -> true
   Color.Black -> false
 
+-- as does this 
+RBTree.isRed1 = cases
+  RBTree.Tree _ _ _ _ -> true
+  _ -> false
+
+-- but this did not (before this fix)
 RBTree.isRed = cases
   RBTree.Tree Color.Red _ _ _ -> true
   _ -> false
+
+-- In fixing this bug, I noticed that the parser would previously reject
+-- this perfectly cromulent pattern match, so I fixed that too.
+thisIsTotallyLegit = cases
+  [RBTree.Tree _ _ _ _] -> true
+  _ -> false
+

--- a/unison-src/tests/fix1640.u
+++ b/unison-src/tests/fix1640.u
@@ -1,0 +1,11 @@
+
+unique type Color = Red | Black
+unique type RBTree a = Leaf | Tree Color (RBTree a) a (RBTree a)
+
+isRed = cases
+  Color.Red -> true
+  Color.Black -> false
+
+RBTree.isRed = cases
+  RBTree.Tree Color.Red _ _ _ -> true
+  _ -> false


### PR DESCRIPTION
The issue was actually in the parser, not the typechecker. A pattern like `Foo Bar a b c` was actually being parsed as `Foo (Bar a b c)`. Whoops. The pattern parser just needed to be tweaked a bit to handle this correctly. I also fixed an unreported pattern parse bug and added a test for that too.

Fixes #1640 

/cc @chiroptical