### PR TITLE
Add information to SyntaxText to enable hyperlinked source

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -45,3 +45,4 @@ The format for this list: name, GitHub handle, and then optional blurb about wha
 * Cody Allen (@ceedubs)
 * Ludvig Sundström (@lsund)
 * Mohamed Elsharnouby (@sharno)
+* Jared Forsyth (@jaredly) - Documentation generation

--- a/parser-typechecker/src/Unison/CommandLine/DisplayValues.hs
+++ b/parser-typechecker/src/Unison/CommandLine/DisplayValues.hs
@@ -87,10 +87,10 @@ displayDoc pped terms typeOf evaluated types = go
 
 termName :: PPE.PrettyPrintEnv -> Referent -> Pretty
 termName ppe r = P.syntaxToColor $
-  NP.styleHashQualified'' (NP.fmt S.Reference) name
+  NP.styleHashQualified'' (NP.fmt $ S.Referent r) name
   where name = PPE.termName ppe r
 
 typeName :: PPE.PrettyPrintEnv -> Reference -> Pretty
 typeName ppe r = P.syntaxToColor $
-  NP.styleHashQualified'' (NP.fmt S.Reference) name
+  NP.styleHashQualified'' (NP.fmt $ S.Reference r) name
   where name = PPE.typeName ppe r

--- a/parser-typechecker/src/Unison/DeclPrinter.hs
+++ b/parser-typechecker/src/Unison/DeclPrinter.hs
@@ -155,14 +155,14 @@ prettyDataHeader name dd =
   P.sepNonEmpty " " [
     prettyModifier (DD.modifier dd),
     fmt S.DataTypeKeyword "type",
-    styleHashQualified'' (fmt S.DataType) name,
+    styleHashQualified'' (fmt $ S.HashQualifier name) name,
     P.sep " " (fmt S.DataTypeParams . P.text . Var.name <$> DD.bound dd) ]
 
 prettyEffectHeader :: Var v => HashQualified -> DD.EffectDeclaration' v a -> Pretty SyntaxText
 prettyEffectHeader name ed = P.sepNonEmpty " " [
   prettyModifier (DD.modifier (DD.toDataDecl ed)),
   fmt S.DataTypeKeyword "ability",
-  styleHashQualified'' (fmt S.DataType) name,
+  styleHashQualified'' (fmt $ S.HashQualifier name) name,
   P.sep " " (fmt S.DataTypeParams . P.text . Var.name <$> DD.bound (DD.toDataDecl ed)) ]
 
 prettyDeclHeader
@@ -179,8 +179,8 @@ prettyDeclOrBuiltinHeader
   -> DD.DeclOrBuiltin v a
   -> Pretty SyntaxText
 prettyDeclOrBuiltinHeader name (DD.Builtin ctype) = case ctype of
-  CT.Data -> fmt S.DataTypeKeyword "builtin type " <> styleHashQualified'' (fmt S.DataType) name
-  CT.Effect -> fmt S.DataTypeKeyword "builtin ability " <> styleHashQualified'' (fmt S.DataType) name
+  CT.Data -> fmt S.DataTypeKeyword "builtin type " <> styleHashQualified'' (fmt $ S.HashQualifier name) name
+  CT.Effect -> fmt S.DataTypeKeyword "builtin ability " <> styleHashQualified'' (fmt $ S.HashQualifier name) name
 prettyDeclOrBuiltinHeader name (DD.Decl e) = prettyDeclHeader name e
 
 fmt :: S.Element -> Pretty S.SyntaxText -> Pretty S.SyntaxText

--- a/parser-typechecker/src/Unison/NamePrinter.hs
+++ b/parser-typechecker/src/Unison/NamePrinter.hs
@@ -21,7 +21,7 @@ prettyName :: IsString s => Name -> Pretty s
 prettyName = PP.text . Name.toText
 
 prettyHashQualified :: HQ.HashQualified -> Pretty SyntaxText
-prettyHashQualified = styleHashQualified' id (fmt S.HashQualifier)
+prettyHashQualified hq = styleHashQualified' id (fmt $ S.HashQualifier hq) hq
 
 prettyHashQualified' :: HQ'.HashQualified -> Pretty SyntaxText
 prettyHashQualified' = prettyHashQualified . HQ'.toHQ
@@ -75,7 +75,7 @@ styleHashQualified' nameStyle hashStyle = \case
 styleHashQualified'' :: (Pretty SyntaxText -> Pretty SyntaxText)
                      -> HQ.HashQualified
                      -> Pretty SyntaxText
-styleHashQualified'' nameStyle = styleHashQualified' nameStyle (fmt S.HashQualifier)
+styleHashQualified'' nameStyle hq = styleHashQualified' nameStyle (fmt $ S.HashQualifier hq) hq
 
 fmt :: S.Element -> Pretty S.SyntaxText -> Pretty S.SyntaxText
 fmt = PP.withSyntax

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -410,7 +410,7 @@ prettyPattern n c@(AmbientContext { imports = im }) p vs patt = case patt of
   Pattern.SequenceOp _ l op r ->
     let (pl, lvs) = prettyPattern n c p vs l
         (pr, rvs) = prettyPattern n c (p + 1) lvs r
-        f i s = (paren (p >= i) (pl <> " " <> (fmt S.Op s) <> " " <> pr), rvs)
+        f i s = (paren (p >= i) (pl <> " " <> (fmt (S.Op op) s) <> " " <> pr), rvs)
     in case op of
       Pattern.Cons -> f 9 "+:"
       Pattern.Snoc -> f 9 ":+"

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -522,7 +522,7 @@ prettyBinding0 env a@AmbientContext { imports = im, docContext = doc } v term = 
         x : y : _ -> PP.sep
           " "
           [ fmt S.Var $ PP.text (Var.name x)
-          , styleHashQualified'' (fmt $ S.HashQualified v) $ elideFQN im v
+          , styleHashQualified'' (fmt $ S.HashQualifier v) $ elideFQN im v
           , fmt S.Var $ PP.text (Var.name y)
           ]
         _ -> l "error"
@@ -531,7 +531,7 @@ prettyBinding0 env a@AmbientContext { imports = im, docContext = doc } v term = 
     args = PP.spacedMap $ fmt S.Var . PP.text . Var.name
     renderName n =
       let n' = elideFQN im n
-      in  parenIfInfix n' NonInfix $ styleHashQualified'' (fmt $ S.HashQualified n') n'
+      in  parenIfInfix n' NonInfix $ styleHashQualified'' (fmt $ S.HashQualifier n') n'
   symbolic = isSymbolic v
   isBinary = \case
     Ann'              tm _ -> isBinary tm
@@ -575,7 +575,7 @@ prettyDoc n im term = mconcat [ fmt S.DocDelimiter $ l "[: "
     atKeyword "evaluate" <> fmtTerm r
   go (Ref' r) = atKeyword "include" <> fmtTerm (Referent.Ref r)
   go _ = l $ "(invalid doc literal: " ++ show term ++ ")"
-  fmtName s = styleHashQualified'' (fmt $ S.HashQualified s) $ elideFQN im s
+  fmtName s = styleHashQualified'' (fmt $ S.HashQualifier s) $ elideFQN im s
   fmtTerm r = fmtName $ PrettyPrintEnv.termName n r
   fmtType r = fmtName $ PrettyPrintEnv.typeName n r
   atKeyword w =

--- a/parser-typechecker/src/Unison/TypePrinter.hs
+++ b/parser-typechecker/src/Unison/TypePrinter.hs
@@ -76,7 +76,7 @@ prettyRaw n im p tp = go n im p tp
     Var' v     -> fmt S.Var $ PP.text (Var.name v)
     DD.TupleType' xs | length xs /= 1 -> PP.parenthesizeCommas $ map (go n im 0) xs
     -- Would be nice to use a different SyntaxHighlights color if the reference is an ability.
-    Ref' r     -> styleHashQualified'' (fmt S.DataType) $ elideFQN im (PrettyPrintEnv.typeName n r)
+    Ref' r     -> styleHashQualified'' (fmt $ S.Reference r) $ elideFQN im (PrettyPrintEnv.typeName n r)
     Cycle' _ _ -> fromString "error: TypeParser does not currently emit Cycle"
     Abs' _     -> fromString "error: TypeParser does not currently emit Abs"
     Ann' _ _   -> fromString "error: TypeParser does not currently emit Ann"
@@ -113,7 +113,7 @@ prettyRaw n im p tp = go n im p tp
       <> effects mes
       <> if (isJust mes) || (not delay) && (not first) then " " else mempty
 
-  arrows delay first [(mes, Ref' DD.UnitRef)] = arrow delay first mes <> (fmt S.DataType "()")
+  arrows delay first [(mes, Ref' DD.UnitRef)] = arrow delay first mes <> (fmt S.Unit "()")
   arrows delay first ((mes, Ref' DD.UnitRef) : rest) =
     arrow delay first mes <> (parenNoGroup delay $ arrows True True rest)
   arrows delay first ((mes, arg) : rest) =
@@ -141,7 +141,7 @@ prettySignatures'
   -> [(HashQualified, Type v a)]
   -> [Pretty ColorText]
 prettySignatures' env ts = map PP.syntaxToColor $ PP.align
-  [ ( styleHashQualified'' (fmt S.DataType) name
+  [ ( styleHashQualified'' (fmt $ S.HashQualifier name) name
     , (fmt S.TypeAscriptionColon ": " <> pretty0 env Map.empty (-1) typ)
       `PP.orElse` (  fmt S.TypeAscriptionColon ": "
                   <> PP.indentNAfterNewline 2 (pretty0 env Map.empty (-1) typ)
@@ -156,7 +156,7 @@ prettySignaturesAlt'
   -> [([HashQualified], Type v a)]
   -> [Pretty ColorText]
 prettySignaturesAlt' env ts = map PP.syntaxToColor $ PP.align
-  [ ( PP.commas . fmap (styleHashQualified'' (fmt S.DataType)) $ names
+  [ ( PP.commas . fmap (\name -> styleHashQualified'' (fmt $ S.HashQualifier name) name) $ names
     , (fmt S.TypeAscriptionColon ": " <> pretty0 env Map.empty (-1) typ)
       `PP.orElse` (  fmt S.TypeAscriptionColon ": "
                   <> PP.indentNAfterNewline 2 (pretty0 env Map.empty (-1) typ)

--- a/parser-typechecker/src/Unison/Util/AnnotatedText.hs
+++ b/parser-typechecker/src/Unison/Util/AnnotatedText.hs
@@ -86,6 +86,7 @@ annotate' a (AnnotatedText at) =
 deannotate :: AnnotatedText a -> AnnotatedText b
 deannotate = annotate' Nothing
 
+-- Replace the annotation (whether existing or no) with the given annotation
 annotate :: a -> AnnotatedText a -> AnnotatedText a
 annotate a (AnnotatedText at) =
   AnnotatedText $ (\(s,_) -> (s,Just a)) <$> at

--- a/parser-typechecker/src/Unison/Util/ColorText.hs
+++ b/parser-typechecker/src/Unison/Util/ColorText.hs
@@ -105,8 +105,8 @@ defaultColors = \case
   ST.Var                 -> Nothing
   ST.Reference _         -> Nothing
   ST.Referent _          -> Nothing
-  ST.HashQualified _     -> Nothing
   ST.Op _                -> Nothing
+  ST.Unit                -> Nothing
   ST.Constructor         -> Nothing
   ST.Request             -> Nothing
   ST.AbilityBraces       -> Just HiBlack
@@ -116,13 +116,12 @@ defaultColors = \case
   ST.BindingEquals       -> Nothing
   ST.TypeAscriptionColon -> Just Blue
   ST.DataTypeKeyword     -> Nothing
-  ST.DataType            -> Nothing
   ST.DataTypeParams      -> Nothing
   ST.DataTypeModifier    -> Nothing
   ST.UseKeyword          -> Just HiBlack
   ST.UsePrefix           -> Just HiBlack
   ST.UseSuffix           -> Just HiBlack
-  ST.HashQualifier       -> Just HiBlack
+  ST.HashQualifier _     -> Just HiBlack
   ST.DelayForceChar      -> Just Yellow
   ST.DelimiterChar       -> Nothing
   ST.Parenthesis         -> Nothing

--- a/parser-typechecker/src/Unison/Util/ColorText.hs
+++ b/parser-typechecker/src/Unison/Util/ColorText.hs
@@ -106,7 +106,7 @@ defaultColors = \case
   ST.Reference _         -> Nothing
   ST.Referent _          -> Nothing
   ST.HashQualified _     -> Nothing
-  ST.Op                  -> Nothing
+  ST.Op _                -> Nothing
   ST.Constructor         -> Nothing
   ST.Request             -> Nothing
   ST.AbilityBraces       -> Just HiBlack

--- a/parser-typechecker/src/Unison/Util/ColorText.hs
+++ b/parser-typechecker/src/Unison/Util/ColorText.hs
@@ -103,7 +103,10 @@ defaultColors = \case
   ST.BooleanLiteral      -> Nothing
   ST.Blank               -> Nothing
   ST.Var                 -> Nothing
-  ST.Reference           -> Nothing
+  ST.Reference _         -> Nothing
+  ST.Referent _          -> Nothing
+  ST.HashQualified _     -> Nothing
+  ST.Op                  -> Nothing
   ST.Constructor         -> Nothing
   ST.Request             -> Nothing
   ST.AbilityBraces       -> Just HiBlack

--- a/parser-typechecker/src/Unison/Util/Pretty.hs
+++ b/parser-typechecker/src/Unison/Util/Pretty.hs
@@ -259,6 +259,7 @@ toPlainUnbroken p = CT.toPlain (renderUnbroken p)
 syntaxToColor :: Pretty ST.SyntaxText -> Pretty ColorText
 syntaxToColor = fmap $ annotateMaybe . fmap CT.defaultColors
 
+-- set the syntax, overriding any present syntax
 withSyntax :: ST.Element -> Pretty ST.SyntaxText -> Pretty ST.SyntaxText
 withSyntax e = fmap $ ST.syntax e
 

--- a/parser-typechecker/src/Unison/Util/SyntaxText.hs
+++ b/parser-typechecker/src/Unison/Util/SyntaxText.hs
@@ -4,6 +4,7 @@ import Unison.Prelude
 import Unison.Reference (Reference)
 import Unison.Referent (Referent)
 import Unison.HashQualified (HashQualified)
+import Unison.Pattern (SeqOp)
 
 import Unison.Util.AnnotatedText      ( AnnotatedText(..), annotate )
 
@@ -19,7 +20,7 @@ data Element = NumericLiteral
              | Reference Reference
              | Referent Referent
              | HashQualified HashQualified
-             | Op
+             | Op SeqOp
              | Constructor
              | Request
              | AbilityBraces

--- a/parser-typechecker/src/Unison/Util/SyntaxText.hs
+++ b/parser-typechecker/src/Unison/Util/SyntaxText.hs
@@ -19,7 +19,6 @@ data Element = NumericLiteral
              | Var
              | Reference Reference
              | Referent Referent
-             | HashQualified HashQualified
              | Op SeqOp
              | Constructor
              | Request
@@ -33,14 +32,14 @@ data Element = NumericLiteral
              -- type|ability
              | DataTypeKeyword
              | DataTypeParams
-             | DataType
+             | Unit
              -- unique
              | DataTypeModifier
              -- `use Foo bar` is keyword, prefix, suffix
              | UseKeyword
              | UsePrefix
              | UseSuffix
-             | HashQualifier
+             | HashQualifier HashQualified
              | DelayForceChar
              -- ? , ` [ ] @ |
              -- Currently not all commas in the pretty-print output are marked up as DelimiterChar - we miss

--- a/parser-typechecker/src/Unison/Util/SyntaxText.hs
+++ b/parser-typechecker/src/Unison/Util/SyntaxText.hs
@@ -1,6 +1,9 @@
 module Unison.Util.SyntaxText where
 
 import Unison.Prelude
+import Unison.Reference (Reference)
+import Unison.Referent (Referent)
+import Unison.HashQualified (HashQualified)
 
 import Unison.Util.AnnotatedText      ( AnnotatedText(..), annotate )
 
@@ -13,7 +16,10 @@ data Element = NumericLiteral
              | BooleanLiteral
              | Blank
              | Var
-             | Reference
+             | Reference Reference
+             | Referent Referent
+             | HashQualified HashQualified
+             | Op
              | Constructor
              | Request
              | AbilityBraces
@@ -46,7 +52,7 @@ data Element = NumericLiteral
              | DocDelimiter
              -- the 'include' in @[include], etc
              | DocKeyword
-             deriving (Eq, Ord, Bounded, Enum, Show, Read)
+             deriving (Eq, Ord, Show)
 
 syntax :: Element -> SyntaxText -> SyntaxText
 syntax = annotate

--- a/unison-core/src/Unison/Pattern.hs
+++ b/unison-core/src/Unison/Pattern.hs
@@ -35,7 +35,7 @@ data Pattern loc
 data SeqOp = Cons
            | Snoc
            | Concat
-           deriving (Eq, Show)
+           deriving (Eq, Show, Ord)
 
 instance H.Hashable SeqOp where
   tokens Cons = [H.Tag 0]


### PR DESCRIPTION
I had to remove a couple of derivings from SyntaxText, but it looks like they weren't used? lmk if there's a better way to do it.

The changes seemed pretty straightforward, but I'm quite new to haskell, so suggestions are very welcome!

fixes #1332

