### PR TITLE
Fix bug in lexing hash-qualified symboly id

### DIFF
--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -440,7 +440,7 @@ lexer0 scope rem =
         Right (Just (num, rem)) ->
           let end = incBy num pos
           in Token (Numeric num) pos end : goWhitespace l end rem
-        _ -> if ['#'] `isPrefixOf` rem then
+        _ -> if ['#'] `isPrefixOf` rem' then
                case shortHash rem' of
                  Left e -> Token (Err e) pos pos : recover l pos rem'
                  Right (h, rem) ->

--- a/parser-typechecker/tests/Unison/Test/Lexer.hs
+++ b/parser-typechecker/tests/Unison/Test/Lexer.hs
@@ -1,7 +1,10 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Unison.Test.Lexer where
 
 import           EasyTest
 import           Unison.Lexer
+import qualified Unison.ShortHash as ShortHash
 
 test :: Test ()
 test =
@@ -77,6 +80,10 @@ test =
         , simpleWordyId ".foo.bar.baz"
         ]
       , t ".Foo.Bar.+" [simpleSymbolyId ".Foo.Bar.+"]
+
+      -- idents with hashes
+      , t "foo#bar" [WordyId "foo" (Just (ShortHash.unsafeFromText "#bar"))]
+      , t "+#bar" [SymbolyId "+" (Just (ShortHash.unsafeFromText "#bar"))]
 
   -- note - these are all the same, just with different spacing
       , let ex1 = "if x then y else z"


### PR DESCRIPTION
## Overview

This patch fixes a bug where `+#foo` was not being lex'd as a hash-qualified "symboly" id. 