### PR TITLE
Disable idle GC, to avoid high CPU usage when ucm is idle (and has a large codebase loaded)

### DIFF
--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -238,7 +238,7 @@ executable unison
   import: unison-common
   main-is: Main.hs
   hs-source-dirs: unison
-  ghc-options: -Wall -threaded -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -rtsopts -optP-Wno-nonportable-include-path
+  ghc-options: -Wall -threaded -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -rtsopts -with-rtsopts=-I0 -optP-Wno-nonportable-include-path
   other-modules:
     System.Path
     Version


### PR DESCRIPTION
## Overview

Fixes #1660 - using 40-60% of one core when ucm is idle, due to a garbage collection running every second.

The GHC runtime system's 'idle GC' mechanism (described [here](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/runtime_control.html#rts-flag--I%20%E2%9F%A8seconds%E2%9F%A9)) tries to get ahead with garbage collection while the program is idle, to reduce GC work at peak time.  It defaults to doing this by running a GC after 0.3 seconds of idleness.

But since recently, ucm has done work on a repeating 1 second timer (configurator checking for config file updates), so this ends up meaning a GC every second.  That can burn a lot of CPU depending on the amount of state in memory.  See [this note](https://gitlab.haskell.org/ghc/ghc/-/issues/4322#note_44361) from the GHC team from 9 years ago, which describes the problem.

There's no point bumping the idle timer value up from 0.3 to say 2 seconds, because then idle GC will never happen.  

So this PR switches off idle GC, so ucm uses more like zero CPU when not being actively used.  It may make it slightly less responsive, as more GC work will be done during the first few fractions of a second of each user interaction.  *I have not tried to test or measure this.*

[This note](https://gitlab.haskell.org/ghc/ghc/-/issues/3408#note_35438) suggests there is a drawback to do with this approach making the RTS unable to catch deadlocks (or run finalizers?) - I don't know if that means common-or-garden thread deadlocks in ucm.  I suggest we don't worry.  

## Implementation notes

Pass `-with-rtsopts=-I0` in the ghc-options for the ucm build.

## Interesting/controversial decisions

An alternative would be to use `-with-rtsopts=-Iw60` to keep doing idle GCs, but at most one a minute.  But I still don't much like an idle program consuming CPU; it could still generate future confusion/questions/problems; and it massively dilutes any responsiveness benefit anyway.  

## Test coverage

None.  And I haven't even done manual testing of command responsiveness.  Would need finding some command that uses, say, half a second ish of CPU, and seeing how much slower it goes when run repeatedly at intervals of say a couple of seconds.  But the main issue with ucm responsiveness is clamping down on commands that use many seconds of CPU, not saving a small constant increment on commands that use significant but sub-second CPU.  So I propose not to bother.  

## Loose ends

Didn't actually pin it on configurator being the trigger for definite, but it does seem likely and anyway this PR does fix the problem.