### PR TITLE
Add `MVar` and some associated operations, with a document on adding builtins

### DIFF
--- a/docs/adding-builtins.markdown
+++ b/docs/adding-builtins.markdown
@@ -1,0 +1,181 @@
+This document explains how to add builtins to the language by working
+through the example of adding `MVar` and some associated functions.
+
+## Builtin Data
+
+The logical first step for this example is to add a built-in `MVar`
+type, whose values will simply be wrapped values of the Haskell type
+with the same name. The 'old' runtime deviates from this approach for
+several types, but this is how e.g. `Text` works even there.
+
+Data types, including opaque pseudo data types of this sort are
+referred to by `Reference`. Builtin, opaque data types use the
+`Builtin` constructor with an appropriate name. The ones in actual
+use are listed in the `Unison.Type` module, so we'll add a definition
+there:
+
+> mvarRef :: Reference
+> mvarRef = Reference.Builtin "MVar"
+
+This definition alone won't do anything, however. It is merely
+something for other definitions to refer to. If the reference is used
+in e.g. the type of a function definitions without giving it an actual
+name in the codebase, the type will be displayed with the raw hash,
+which looks like `#MVar`.
+
+The builtin reference can be given a name during the `builtins.merge`
+ucm command. To make this happen, we must modify the `builtinTypesSrc`
+definition in the `Unison.Builtin` module. This is just a list of
+values that describe various builtin type related actions to be
+performed during that command. In this case, we will add two values to
+the list:
+
+> B' "MVar" CT.Data
+
+This specifies that there should be a builtin data type referring to
+the `Builtin "MVar"` reference. The codebase name assigned to this is
+the same as the reference (MVar here), but nested in the `builtin`
+namespace. However, we will also add the value:
+
+> Rename' "MVar" "io2.MVar"
+
+because this is a type to be used with the new IO functions, which are
+currently nested under the `io2` namespace. With both of these added
+to the list, running `builtins.merge` should have a `builtin.io2.MVar`
+type referring to the `Builtin "MVar"` reference.
+
+The reason for both a `B'` and a `Rename'` is that eventually one
+would expect the IO functionality to be moved from the `io2`
+namespace. However, the builtin reference name may not be changed
+easily, so it is preferable to have it named in the eventual expected
+way, rather than permanently named `io2.MVar` internally.
+
+## Builtin function declarations
+
+The next step is to declare builtin functions that make use of the new
+type. These are declared in a similar way to the type names above.
+There is another list in `Unison.Builtin`, `builtinsSrc`, that defines
+values specifying what builtin functions should exist.
+
+Like the builtin type list, there are declarations for adding a
+builtin function with a given name, and declarations for renaming from
+the given name to a different namespace location. For the `MVar`
+functions, we'll again give them their intended names as the original,
+and rename them to the `io2` namespace for the time being.
+
+Builtin functions also have an associated type as part of the initial
+declaration. So for the complete specification of a function, we will
+add declarations similar to:
+
+> B "MVar.new" $ forall1 "a" (\a -> a --> io (mvar a))
+> Rename "MVar.new" "io2.MVar.new"
+> B "MVar.take" $ forall1 "a" (\a -> mvar a --> ioe a)
+> Rename "MVar.take" "io2.MVar.take"
+
+The `forall1`, `io`, `ioe` and `-->` functions are local definitions
+in `Unison.Builtin` for assistance in writing the types. `ioe`
+indicates that an error result may be returned, while `io` should
+always succeed.  `mvar` can be defined locally using some other
+helpers in scope:
+
+> mvar :: Var v => Type v -> Type v
+> mvar a = Type.ref () Type.mvarRef `app` a
+
+For the actual `MVar` implementation, we'll be doing many definitions
+followed by renames, so it'll be factored into a list of the name and
+type, together with a function that generates the declaration and the
+rename.
+
+## Builtin function implementation -- new runtime
+
+What we have done so far only declares the functions and their types.
+There is nothing yet implementing them. This section will proceed
+through the implementation backing the declaration of the `MVar.new`
+declared above.
+
+The first step is to add to the builtin operations list in
+`Unison.Runtime.Builtin`. This is a list associating the name chosen
+in `Unison.Builtin` with intermediate code forms that the new runtime
+should use. In this case we can add:
+
+> ("MVar.new", ioComb mvar'new)
+> ("MVar.take", ioComb mvar'take)
+
+and plan to implement `mvar'new` and `mvar'take`. `ioComb` is a helper
+function that factors out some of the repetitive aspects of dealing
+with IO builtins, which `MVar` functions will need.
+
+To actually implement the intermediate code, we will need to add
+constructors to the `IOp` type in `Unison.Runtime.ANF`, which lists
+all the builtin operations that will compile to the runtime's 'foreign
+function' format, which is less efficient than e.g. arithemtic
+operations, but is very flexible. The convention for this type is to
+make constructors look sort of like opcode names, so we'll pick
+`MVNEWF` for allocating a new filled `MVar`, and `MVTAKE` for taking
+an `MVar`.
+
+Then we must wrap these 'opcodes' like so:
+
+> mvar'new :: IOOP
+> mvar'new avoid
+>   = ([BX],)
+>   . TAbs init
+>   $ TIOp MVNEWF [init]
+>   where
+>   [init] = freshes' avoid 1
+
+> mvar'take :: IOOP
+> mvar'take avoid
+>   = ([BX],)
+>   . TAbs mv
+>   $ io'error'result'direct MVTAKE [mv] ior e r
+>   where
+>   [mv,ior,e,r] = freshes' avoid 4
+
+The breakdown of what is happening here is as follows:
+- `avoid` is a set of variables that are not fresh, and should be
+  avoided
+- An `IOOP` may take many arguments, and the list in the tuple section
+  specifies the calling convention for them. `[BX]` means one boxed
+  argument, which in this case is the value of type `a`. `[BX,BX]`
+  would be two boxed arguments, and `[BX,UN]` would be one boxed and
+  one unboxed argument.
+- `TAbs init` abstracts the argument variable, which we got from
+  `freshes'` at the bottom. Multiple arguments may be abstracted with
+  e.g. `TAbss [x,y,z]`
+- `io'error'result'direct` is a helper function for calling an `IOp`
+  and wrapping up a possible error result. The first argument is the
+  `IOp` to call, the list is the arguments, and the last three
+  arguments are variables used in the common result handling code.
+
+Other builtins use slightly different implementations, so looking at
+other parts of the file may be instructive, depending on what is being
+added.
+
+Finally, we need to provide an implementation for the 'opcode' we
+defined. In this case, we need to add a case to `iopToForeign` also in
+`Unison.Runtime.Builtin`. This will be simple, just:
+
+> iopToForeign ANF.MVNEWF = mkForeign $ \(c :: Closure) -> newMVar c
+> iopToForeign ANF.MVTAKE
+>   = mkForeignIOE $ \(mv :: MVar Closure) -> takeMVar mv
+
+The `mkForeignIOE` function inserts some code for catching exceptions
+and explicitly returning them from the function.
+
+However, at first this will cause an error, because some of the
+automatic machinery for creating builtin 'foreign' functions does not
+exist for `MVar`. To rectify this, we can add a `ForeignConvention`
+instance in `Unison.Runtime.Foreign.Function` that specifies how to
+automatically marshal `MVar Closure`, which is the representation
+we'll be using.
+
+> instance ForeignConvention (MVar Closure) where
+>   readForeign = readForeignAs (unwrapForeign . marshalToForeign)
+>   writeForeign = writeForeignAs (Foreign . Wrap mvarRef)
+
+This takes advantage of the `Closure` instance, and uses helper
+functions that apply (un)wrappers from another convention.
+
+With these in place, the functions should now be usable in the new
+runtime.

--- a/docs/adding-builtins.markdown
+++ b/docs/adding-builtins.markdown
@@ -179,3 +179,11 @@ functions that apply (un)wrappers from another convention.
 
 With these in place, the functions should now be usable in the new
 runtime.
+
+## Transcripts
+
+One last thing remains. The additional builtin operations will have
+changed some of the transcript output. The transcript runner should be
+executed, and modified files should be checked and committed, so that
+CI tests will pass (which check transcripts against an expected
+result).

--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -160,6 +160,7 @@ builtinTypesSrc =
   , B' "Handle" CT.Data, Rename' "Handle" "io2.Handle"
   , B' "Socket" CT.Data, Rename' "Socket" "io2.Socket"
   , B' "ThreadId" CT.Data, Rename' "ThreadId" "io2.ThreadId"
+  , B' "MVar" CT.Data, Rename' "MVar" "io2.MVar"
   ]
 
 -- rename these to "builtin" later, when builtin means intrinsic as opposed to
@@ -251,7 +252,7 @@ builtinsSrc =
   , B "Int.shiftRight" $ int --> nat --> int
   , B "Int.truncate0" $ int --> nat
   , B "Int.toText" $ int --> text
-  , B "Int.fromText" $ text --> optional int
+  , B "Int.fromText" $ text --> optionalt int
   , B "Int.toFloat" $ int --> float
   , B "Int.trailingZeros" $ int --> nat
 
@@ -268,7 +269,7 @@ builtinsSrc =
   , B "Nat.xor" $ nat --> nat --> nat
   , B "Nat.complement" $ nat --> nat
   , B "Nat.drop" $ nat --> nat --> nat
-  , B "Nat.fromText" $ text --> optional nat
+  , B "Nat.fromText" $ text --> optionalt nat
   , B "Nat.increment" $ nat --> nat
   , B "Nat.isEven" $ nat --> boolean
   , B "Nat.isOdd" $ nat --> boolean
@@ -330,7 +331,7 @@ builtinsSrc =
   , B "Float.max" $ float --> float --> float
   , B "Float.min" $ float --> float --> float
   , B "Float.toText" $ float --> text
-  , B "Float.fromText" $ text --> optional float
+  , B "Float.fromText" $ text --> optionalt float
 
   , B "Universal.==" $ forall1 "a" (\a -> a --> a --> boolean)
   -- Don't we want a Universal.!= ?
@@ -363,8 +364,8 @@ builtinsSrc =
   , B "Text.>=" $ text --> text --> boolean
   , B "Text.<" $ text --> text --> boolean
   , B "Text.>" $ text --> text --> boolean
-  , B "Text.uncons" $ text --> optional (tuple [char, text])
-  , B "Text.unsnoc" $ text --> optional (tuple [text, char])
+  , B "Text.uncons" $ text --> optionalt (tuple [char, text])
+  , B "Text.unsnoc" $ text --> optionalt (tuple [text, char])
 
   , B "Text.toCharList" $ text --> list char
   , B "Text.fromCharList" $ list char --> text
@@ -377,7 +378,7 @@ builtinsSrc =
   , B "Bytes.++" $ bytes --> bytes --> bytes
   , B "Bytes.take" $ nat --> bytes --> bytes
   , B "Bytes.drop" $ nat --> bytes --> bytes
-  , B "Bytes.at" $ nat --> bytes --> optional nat
+  , B "Bytes.at" $ nat --> bytes --> optionalt nat
   , B "Bytes.toList" $ bytes --> list nat
   , B "Bytes.size" $ bytes --> nat
   , B "Bytes.flatten" $ bytes --> bytes
@@ -391,7 +392,7 @@ builtinsSrc =
   , B "List.drop" $ forall1 "a" (\a -> nat --> list a --> list a)
   , B "List.++" $ forall1 "a" (\a -> list a --> list a --> list a)
   , B "List.size" $ forall1 "a" (\a -> list a --> nat)
-  , B "List.at" $ forall1 "a" (\a -> nat --> list a --> optional a)
+  , B "List.at" $ forall1 "a" (\a -> nat --> list a --> optionalt a)
 
   , B "Debug.watch" $ forall1 "a" (\a -> text --> a --> a)
   ] ++
@@ -403,43 +404,10 @@ builtinsSrc =
                   ,("<=", "lteq")
                   ,(">" , "gt")
                   ,(">=", "gteq")]
-  ] ++
-  (ioBuiltins >>= \(n,ty) -> [B n ty, Rename n ("io2." <> n)])
-  where
-    int = Type.int ()
-    nat = Type.nat ()
-    boolean = Type.boolean ()
-    float = Type.float ()
-    text = Type.text ()
-    bytes = Type.bytes ()
-    char = Type.char ()
+  ] ++ io2List ioBuiltins ++ io2List mvarBuiltins
 
-    (-->) :: Ord v => Type v -> Type v -> Type v
-    a --> b = Type.arrow () a b
-
-    infixr -->
-
-    forall1 :: Var v => Text -> (Type v -> Type v) -> Type v
-    forall1 name body =
-      let
-        a = Var.named name
-      in Type.forall () a (body $ Type.var () a)
-
-    app :: Ord v => Type v -> Type v -> Type v
-    app = Type.app ()
-
-    list :: Ord v => Type v -> Type v
-    list arg = Type.vector () `app` arg
-
-    optional :: Ord v => Type v -> Type v
-    optional arg = DD.optionalType () `app` arg
-
-    tuple :: Ord v => [Type v] -> Type v
-    tuple [t] = t
-    tuple ts = foldr pair (DD.unitType ()) ts
-
-    pair :: Ord v => Type v -> Type v -> Type v
-    pair l r = DD.pairType () `app` l `app` r
+io2List :: [(Text, Type v)] -> [BuiltinDSL v]
+io2List bs = bs >>= \(n,ty) -> [B n ty, Rename n ("io2." <> n)]
 
 ioBuiltins :: Var v => [(Text, Type v)]
 ioBuiltins =
@@ -477,42 +445,65 @@ ioBuiltins =
   , ("IO.socketReceive", socket --> nat --> ioe bytes)
   , ("IO.forkComp"
     , forall1 "a" $ \a -> (unit --> ioe a) --> ioe threadId)
-  , ("IO.stdHandle", nat --> optional handle)
+  , ("IO.stdHandle", nat --> optionalt handle)
+  ]
+
+mvarBuiltins :: forall v. Var v => [(Text, Type v)]
+mvarBuiltins =
+  [ ("MVar.new", forall1 "a" $ \a -> a --> io (mvar a))
+  , ("MVar.take", forall1 "a" $ \a -> mvar a --> ioe a)
   ]
   where
-  (-->) :: Ord v => Type v -> Type v -> Type v
-  a --> b = Type.arrow () a b
-  infixr -->
+  mvar :: Type v -> Type v
+  mvar a = Type.ref () Type.mvarRef `app` a
 
-  forall1 :: Var v => Text -> (Type v -> Type v) -> Type v
-  forall1 name body =
-    let
-      a = Var.named name
-    in Type.forall () a (body $ Type.var () a)
+forall1 :: Var v => Text -> (Type v -> Type v) -> Type v
+forall1 name body =
+  let
+    a = Var.named name
+  in Type.forall () a (body $ Type.var () a)
 
+app :: Ord v => Type v -> Type v -> Type v
+app = Type.app ()
 
-  either :: Ord v => Type v -> Type v -> Type v
+list :: Ord v => Type v -> Type v
+list arg = Type.vector () `app` arg
+
+optionalt :: Ord v => Type v -> Type v
+optionalt arg = DD.optionalType () `app` arg
+
+tuple :: Ord v => [Type v] -> Type v
+tuple [t] = t
+tuple ts = foldr pair (DD.unitType ()) ts
+
+pair :: Ord v => Type v -> Type v -> Type v
+pair l r = DD.pairType () `app` l `app` r
+
+(-->) :: Ord v => Type v -> Type v -> Type v
+a --> b = Type.arrow () a b
+infixr -->
+
+io, ioe :: Var v => Type v -> Type v
+io = Type.effect1 () (Type.builtinIO ())
+ioe = io . either (DD.ioErrorType ())
+  where
   either l r = DD.eitherType () `app` l `app` r
 
-  ioe = Type.effect1 () (Type.builtinIO ())
-      . either (DD.ioErrorType ())
+socket, threadId, handle, unit :: Var v => Type v
+socket = Type.socket ()
+threadId = Type.threadId ()
+handle = Type.fileHandle ()
+unit = DD.unitType ()
 
-  socket = Type.socket ()
-  threadId = Type.threadId ()
-  handle = Type.fileHandle ()
-  unit = DD.unitType ()
+fmode, bmode :: Var v => Type v
+fmode = DD.fileModeType ()
+bmode = DD.bufferModeType ()
 
-  fmode = DD.fileModeType ()
-  bmode = DD.bufferModeType ()
-
-  app :: Ord v => Type v -> Type v -> Type v
-  app = Type.app ()
-
-  int = Type.int ()
-  nat = Type.nat ()
-  bytes = Type.bytes ()
-  text = Type.text ()
-  boolean = Type.boolean ()
-
-  optional :: Ord v => Type v -> Type v
-  optional arg = DD.optionalType () `app` arg
+int, nat, bytes, text, boolean, float, char :: Var v => Type v
+int = Type.int ()
+nat = Type.nat ()
+bytes = Type.bytes ()
+text = Type.text ()
+boolean = Type.boolean ()
+float = Type.float ()
+char = Type.char ()

--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -451,7 +451,15 @@ ioBuiltins =
 mvarBuiltins :: forall v. Var v => [(Text, Type v)]
 mvarBuiltins =
   [ ("MVar.new", forall1 "a" $ \a -> a --> io (mvar a))
+  , ("MVar.newEmpty", forall1 "a" $ \a -> io (mvar a))
   , ("MVar.take", forall1 "a" $ \a -> mvar a --> ioe a)
+  , ("MVar.tryTake", forall1 "a" $ \a -> mvar a --> io (optionalt a))
+  , ("MVar.put", forall1 "a" $ \a -> mvar a --> a --> ioe unit)
+  , ("MVar.tryPut", forall1 "a" $ \a -> mvar a --> a --> io boolean)
+  , ("MVar.swap", forall1 "a" $ \a -> mvar a --> a --> ioe a)
+  , ("MVar.isEmpty", forall1 "a" $ \a -> mvar a --> io boolean)
+  , ("MVar.read", forall1 "a" $ \a -> mvar a --> ioe a)
+  , ("MVar.tryRead", forall1 "a" $ \a -> mvar a --> io (optionalt a))
   ]
   where
   mvar :: Type v -> Type v

--- a/parser-typechecker/src/Unison/Runtime/ANF.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF.hs
@@ -857,6 +857,7 @@ data IOp
   | SRVSCK | LISTEN | CLISCK | CLOSCK
   | SKACPT | SKSEND | SKRECV
   | THKILL | THDELY
+  | MVNEWF | MVTAKE
   deriving (Show,Eq,Ord,Enum,Bounded)
 
 type ANormal = ABTN.Term ANormalBF

--- a/parser-typechecker/src/Unison/Runtime/ANF.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF.hs
@@ -857,7 +857,7 @@ data IOp
   | SRVSCK | LISTEN | CLISCK | CLOSCK
   | SKACPT | SKSEND | SKRECV
   | THKILL | THDELY
-  deriving (Show,Eq,Ord)
+  deriving (Show,Eq,Ord,Enum,Bounded)
 
 type ANormal = ABTN.Term ANormalBF
 type ANormalT v = ANormalTF v (ANormal v)

--- a/parser-typechecker/src/Unison/Runtime/ANF.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF.hs
@@ -857,7 +857,9 @@ data IOp
   | SRVSCK | LISTEN | CLISCK | CLOSCK
   | SKACPT | SKSEND | SKRECV
   | THKILL | THDELY
-  | MVNEWF | MVTAKE
+  | MVNEWF | MVNEWE | MVTAKE | MVTAKT -- new,new empty,take,trytake
+  | MVPUTB | MVPUTT | MVSWAP | MVEMPT -- put,tryput,swap,isempty
+  | MVREAD | MVREAT                   -- read,tryread
   deriving (Show,Eq,Ord,Enum,Bounded)
 
 type ANormal = ABTN.Term ANormalBF

--- a/parser-typechecker/src/Unison/Runtime/Decompile.hs
+++ b/parser-typechecker/src/Unison/Runtime/Decompile.hs
@@ -25,7 +25,7 @@ import Unison.Reference (Reference)
 
 import Unison.Runtime.ANF (RTag, CTag, Tag(..))
 import Unison.Runtime.Foreign
-  (Foreign, unwrapText, unwrapBytes, maybeUnwrapForeign)
+  (Foreign, maybeUnwrapBuiltin, maybeUnwrapForeign)
 import Unison.Runtime.Stack
   (Closure(..), pattern DataC, pattern PApV, IComb(..))
 
@@ -105,8 +105,8 @@ decompileForeign
   -> Foreign
   -> Either Error (Term v ())
 decompileForeign tyRef topTerms f
-  | Just t <- unwrapText f = Right $ text () t
-  | Just b <- unwrapBytes f = Right $ decompileBytes b
+  | Just t <- maybeUnwrapBuiltin f = Right $ text () t
+  | Just b <- maybeUnwrapBuiltin f = Right $ decompileBytes b
   | Just s <- unwrapSeq f
   = seq' () <$> traverse (decompile tyRef topTerms) s
 decompileForeign _ _ _ = err "cannot decompile Foreign"

--- a/parser-typechecker/src/Unison/Runtime/Exception.hs
+++ b/parser-typechecker/src/Unison/Runtime/Exception.hs
@@ -1,0 +1,18 @@
+
+module Unison.Runtime.Exception where
+
+import Control.Exception
+import Data.String (fromString)
+
+import Unison.Runtime.Stack
+import Unison.Util.Pretty as P
+
+data RuntimeExn
+  = PE (P.Pretty P.ColorText)
+  | BU Closure
+  deriving (Show)
+instance Exception RuntimeExn
+
+die :: String -> IO a
+die = throwIO . PE . P.lit . fromString
+

--- a/parser-typechecker/src/Unison/Runtime/Foreign/Function.hs
+++ b/parser-typechecker/src/Unison/Runtime/Foreign/Function.hs
@@ -1,0 +1,305 @@
+{-# language GADTs #-}
+{-# language DataKinds #-}
+{-# language ViewPatterns #-}
+{-# language RecordWildCards #-}
+
+module Unison.Runtime.Foreign.Function
+  ( ForeignFunc(..)
+  , ForeignConvention(..)
+  , mkForeign
+  )
+  where
+
+import GHC.IO.Exception (IOException(..), IOErrorType(..))
+
+import Control.Concurrent (ThreadId)
+import Data.Foldable (toList)
+import Data.Text (Text, pack, unpack)
+import Data.Time.Clock.POSIX (POSIXTime)
+import qualified Data.Sequence as Sq
+import Data.Word (Word64)
+import Network.Socket (Socket)
+import System.IO (BufferMode(..), SeekMode, Handle, IOMode)
+import Unison.Util.Bytes (Bytes)
+
+import Unison.Runtime.ANF (Mem(..))
+import Unison.Runtime.MCode
+import Unison.Runtime.Exception
+import Unison.Runtime.Foreign
+import Unison.Runtime.Stack
+
+-- Foreign functions operating on stacks
+data ForeignFunc where
+  FF :: (Stack 'UN -> Stack 'BX -> Args -> IO a)
+     -> (Stack 'UN -> Stack 'BX -> r -> IO (Stack 'UN, Stack 'BX))
+     -> (a -> IO r)
+     -> ForeignFunc
+
+instance Show ForeignFunc where
+  show _ = "ForeignFunc"
+instance Eq ForeignFunc where
+  _ == _ = error "Eq ForeignFunc"
+instance Ord ForeignFunc where
+  compare _ _ = error "Ord ForeignFunc"
+
+class ForeignConvention a where
+  readForeign
+    :: [Int] -> [Int] -> Stack 'UN -> Stack 'BX -> IO ([Int], [Int], a)
+  writeForeign
+    :: Stack 'UN -> Stack 'BX -> a -> IO (Stack 'UN, Stack 'BX)
+
+mkForeign
+  :: (ForeignConvention a, ForeignConvention r)
+  => (a -> IO r)
+  -> ForeignFunc
+mkForeign ev = FF readArgs writeForeign ev
+  where
+  readArgs ustk bstk (argsToLists -> (us,bs))
+    = readForeign us bs ustk bstk >>= \case
+        ([], [], a) -> pure a
+        _ -> die "mkForeign: too many arguments for foreign function"
+
+instance ForeignConvention Int where
+  readForeign (i:us) bs ustk _ = (us,bs,) <$> peekOff ustk i
+  readForeign [    ] _  _    _ = foreignCCError "Int"
+  writeForeign ustk bstk i = do
+    ustk <- bump ustk
+    (ustk, bstk) <$ poke ustk i
+
+instance ForeignConvention Word64 where
+  readForeign (i:us) bs ustk _ = (us,bs,) <$> peekOffN ustk i
+  readForeign [] _ _ _ = foreignCCError "Word64"
+  writeForeign ustk bstk n = do
+    ustk <- bump ustk
+    (ustk, bstk) <$ pokeN ustk n
+
+instance ForeignConvention Closure where
+  readForeign us (i:bs) _ bstk = (us,bs,) <$> peekOff bstk i
+  readForeign _  [    ] _ _    = foreignCCError "Closure"
+  writeForeign ustk bstk c = do
+    bstk <- bump bstk
+    (ustk, bstk) <$ poke bstk c
+
+instance ForeignConvention Text where
+  readForeign = readForeignBuiltin
+  writeForeign = writeForeignBuiltin
+
+instance ForeignConvention Bytes where
+  readForeign = readForeignBuiltin
+  writeForeign = writeForeignBuiltin
+
+instance ForeignConvention Socket where
+  readForeign = readForeignBuiltin
+  writeForeign = writeForeignBuiltin
+
+instance ForeignConvention ThreadId where
+  readForeign = readForeignBuiltin
+  writeForeign = writeForeignBuiltin
+
+instance ForeignConvention Handle where
+  readForeign = readForeignBuiltin
+  writeForeign = writeForeignBuiltin
+
+instance ForeignConvention POSIXTime where
+  readForeign = readForeignAs (fromIntegral :: Int -> POSIXTime)
+  writeForeign = writeForeignAs (round :: POSIXTime -> Int)
+
+instance ForeignConvention a => ForeignConvention (Maybe a) where
+  readForeign (i:us) bs ustk bstk
+    = peekOff ustk i >>= \case
+        0 -> pure (us, bs, Nothing)
+        1 -> fmap Just <$> readForeign us bs ustk bstk
+        _ -> foreignCCError "Maybe"
+  readForeign [] _ _ _ = foreignCCError "Maybe"
+
+  writeForeign ustk bstk Nothing = do
+    ustk <- bump ustk
+    (ustk,bstk) <$ poke ustk 0
+  writeForeign ustk bstk (Just x) = do
+    (ustk,bstk) <- writeForeign ustk bstk x
+    ustk <- bump ustk
+    (ustk,bstk) <$ poke ustk 1
+
+instance (ForeignConvention a, ForeignConvention b)
+      => ForeignConvention (Either a b)
+  where
+  readForeign (i:us) bs ustk bstk
+    = peekOff ustk i >>= \case
+        0 -> readForeignAs Left us bs ustk bstk
+        1 -> readForeignAs Right us bs ustk bstk
+        _ -> foreignCCError "Either"
+  readForeign _ _ _ _ = foreignCCError "Either"
+
+  writeForeign ustk bstk (Left a) = do
+    (ustk,bstk) <- writeForeign ustk bstk a
+    ustk <- bump ustk
+    (ustk,bstk) <$ poke ustk 0
+  writeForeign ustk bstk (Right b) = do
+    (ustk,bstk) <- writeForeign ustk bstk b
+    ustk <- bump ustk
+    (ustk,bstk) <$ poke ustk 1
+
+ioeDecode :: Int -> IOErrorType
+ioeDecode 0 = AlreadyExists
+ioeDecode 1 = NoSuchThing
+ioeDecode 2 = ResourceBusy
+ioeDecode 3 = ResourceExhausted
+ioeDecode 4 = EOF
+ioeDecode 5 = IllegalOperation
+ioeDecode 6 = PermissionDenied
+ioeDecode 7 = UserError
+ioeDecode _ = error "ioeDecode"
+
+ioeEncode :: IOErrorType -> Int
+ioeEncode AlreadyExists = 0
+ioeEncode NoSuchThing = 1
+ioeEncode ResourceBusy = 2
+ioeEncode ResourceExhausted = 3
+ioeEncode EOF = 4
+ioeEncode IllegalOperation = 5
+ioeEncode PermissionDenied = 6
+ioeEncode UserError = 7
+ioeEncode _ = error "ioeDecode"
+
+instance ForeignConvention IOException where
+  readForeign = readForeignAs (bld . ioeDecode)
+    where
+    bld t = IOError Nothing t "" "" Nothing Nothing
+
+  writeForeign = writeForeignAs (ioeEncode . ioe_type)
+
+readForeignAs
+  :: ForeignConvention a
+  => (a -> b)
+  -> [Int] -> [Int]
+  -> Stack 'UN -> Stack 'BX
+  -> IO ([Int], [Int], b)
+readForeignAs f us bs ustk bstk = fmap f <$> readForeign us bs ustk bstk
+
+writeForeignAs
+  :: ForeignConvention b
+  => (a -> b)
+  -> Stack 'UN -> Stack 'BX
+  -> a -> IO (Stack 'UN, Stack 'BX)
+writeForeignAs f ustk bstk x = writeForeign ustk bstk (f x)
+
+readForeignEnum
+  :: Enum a
+  => [Int] -> [Int] -> Stack 'UN -> Stack 'BX
+  -> IO ([Int], [Int], a)
+readForeignEnum = readForeignAs toEnum
+
+writeForeignEnum
+  :: Enum a
+  => Stack 'UN -> Stack 'BX -> a
+  -> IO (Stack 'UN, Stack 'BX)
+writeForeignEnum = writeForeignAs fromEnum
+
+readForeignBuiltin
+  :: BuiltinForeign b
+  => [Int] -> [Int] -> Stack 'UN -> Stack 'BX
+  -> IO ([Int], [Int], b)
+readForeignBuiltin = readForeignAs (unwrapBuiltin . marshalToForeign)
+
+writeForeignBuiltin
+  :: BuiltinForeign b
+  => Stack 'UN -> Stack 'BX -> b
+  -> IO (Stack 'UN, Stack 'BX)
+writeForeignBuiltin = writeForeignAs (Foreign . wrapBuiltin)
+
+instance ForeignConvention Double where
+  readForeign (i:us) bs ustk _ = (us,bs,) <$> peekOffD ustk i
+  readForeign _ _ _ _ = foreignCCError "Double"
+  writeForeign ustk bstk d = bump ustk >>= \ustk ->
+    (ustk,bstk) <$ pokeD ustk d
+
+instance ForeignConvention Bool where
+  readForeign = readForeignEnum
+  writeForeign = writeForeignEnum
+instance ForeignConvention String where
+  readForeign = readForeignAs unpack
+  writeForeign = writeForeignAs pack
+
+instance ForeignConvention SeekMode where
+  readForeign = readForeignEnum
+  writeForeign = writeForeignEnum
+instance ForeignConvention IOMode where
+  readForeign = readForeignEnum
+  writeForeign = writeForeignEnum
+
+instance ForeignConvention () where
+  readForeign us bs _ _ = pure (us, bs, ())
+  writeForeign ustk bstk _ = pure (ustk, bstk)
+
+instance (ForeignConvention a, ForeignConvention b)
+      => ForeignConvention (a,b)
+  where
+  readForeign us bs ustk bstk = do
+    (us,bs,a) <- readForeign us bs ustk bstk
+    (us,bs,b) <- readForeign us bs ustk bstk
+    pure (us, bs, (a,b))
+
+  writeForeign ustk bstk (x, y) = do
+    (ustk, bstk) <- writeForeign ustk bstk y
+    writeForeign ustk bstk x
+
+instance ( ForeignConvention a
+         , ForeignConvention b
+         , ForeignConvention c
+         )
+      => ForeignConvention (a,b,c)
+  where
+  readForeign us bs ustk bstk = do
+    (us,bs,a) <- readForeign us bs ustk bstk
+    (us,bs,b) <- readForeign us bs ustk bstk
+    (us,bs,c) <- readForeign us bs ustk bstk
+    pure (us, bs, (a,b,c))
+
+  writeForeign ustk bstk (a,b,c) = do
+    (ustk,bstk) <- writeForeign ustk bstk c
+    (ustk,bstk) <- writeForeign ustk bstk b
+    writeForeign ustk bstk a
+
+instance ForeignConvention BufferMode where
+  readForeign (i:us) bs ustk bstk
+    = peekOff ustk i >>= \case
+        0 -> pure (us, bs, NoBuffering)
+        1 -> pure (us, bs, LineBuffering)
+        2 -> pure (us, bs, BlockBuffering Nothing)
+        3 -> fmap (BlockBuffering . Just)
+               <$> readForeign us bs ustk bstk
+        _ -> foreignCCError "BufferMode"
+  readForeign _ _ _ _ = foreignCCError "BufferMode"
+  writeForeign ustk bstk bm = bump ustk >>= \ustk ->
+    case bm of
+      NoBuffering -> (ustk,bstk) <$ poke ustk 0
+      LineBuffering -> (ustk,bstk) <$ poke ustk 1
+      BlockBuffering Nothing -> (ustk,bstk) <$ poke ustk 2
+      BlockBuffering (Just n) -> do
+        poke ustk n
+        ustk <- bump ustk
+        (ustk,bstk) <$ poke ustk 3
+
+instance ForeignConvention [Closure] where
+  readForeign us (i:bs) _ bstk
+    = (us,bs,) . toList <$> peekOffS bstk i
+  readForeign _ _ _ _ = foreignCCError "[Closure]"
+  writeForeign ustk bstk l = do
+    bstk <- bump bstk
+    (ustk,bstk) <$ pokeS bstk (Sq.fromList l)
+
+
+instance {-# overlappable #-} BuiltinForeign b => ForeignConvention [b]
+  where
+  readForeign us (i:bs) _ bstk
+    = (us,bs,) . fmap (unwrapForeign . marshalToForeign)
+    . toList <$> peekOffS bstk i
+  readForeign _ _ _ _ = foreignCCError "[b]"
+  writeForeign ustk bstk l = do
+    bstk <- bump bstk
+    (ustk,bstk) <$ pokeS bstk (Foreign . wrapBuiltin <$> Sq.fromList l)
+
+foreignCCError :: String -> IO a
+foreignCCError nm
+  = die $ "mismatched foreign calling convention for `" ++ nm ++ "`"
+

--- a/parser-typechecker/src/Unison/Runtime/Foreign/Function.hs
+++ b/parser-typechecker/src/Unison/Runtime/Foreign/Function.hs
@@ -13,6 +13,7 @@ module Unison.Runtime.Foreign.Function
 import GHC.IO.Exception (IOException(..), IOErrorType(..))
 
 import Control.Concurrent (ThreadId)
+import Control.Concurrent.MVar (MVar)
 import Data.Foldable (toList)
 import Data.Text (Text, pack, unpack)
 import Data.Time.Clock.POSIX (POSIXTime)
@@ -21,6 +22,8 @@ import Data.Word (Word64)
 import Network.Socket (Socket)
 import System.IO (BufferMode(..), SeekMode, Handle, IOMode)
 import Unison.Util.Bytes (Bytes)
+
+import Unison.Type (mvarRef)
 
 import Unison.Runtime.ANF (Mem(..))
 import Unison.Runtime.MCode
@@ -288,6 +291,9 @@ instance ForeignConvention [Closure] where
     bstk <- bump bstk
     (ustk,bstk) <$ pokeS bstk (Sq.fromList l)
 
+instance ForeignConvention (MVar Closure) where
+  readForeign = readForeignAs (unwrapForeign . marshalToForeign)
+  writeForeign = writeForeignAs (Foreign . Wrap mvarRef)
 
 instance {-# overlappable #-} BuiltinForeign b => ForeignConvention [b]
   where

--- a/parser-typechecker/src/Unison/Runtime/MCode.hs
+++ b/parser-typechecker/src/Unison/Runtime/MCode.hs
@@ -64,6 +64,7 @@ import Unison.Runtime.ANF
   , pattern TLit
   , pattern TApp
   , pattern TPrm
+  , pattern TIOp
   , pattern THnd
   , pattern TFrc
   , pattern TShift
@@ -639,6 +640,11 @@ emitSection _   ctx (TPrm p args)
   -- a prim op will need for its results.
   = addCount 3 3 . countCtx ctx
   . Ins (emitPOp p $ emitArgs ctx args) . Yield $ DArgV i j
+  where
+  (i, j) = countBlock ctx
+emitSection _   ctx (TIOp p args)
+  = addCount 3 3 . countCtx ctx
+  . Ins (emitIOp p $ emitArgs ctx args) . Yield $ DArgV i j
   where
   (i, j) = countBlock ctx
 emitSection rec ctx (TApp f args)

--- a/parser-typechecker/src/Unison/Runtime/Stack.hs
+++ b/parser-typechecker/src/Unison/Runtime/Stack.hs
@@ -30,13 +30,13 @@ module Unison.Runtime.Stack
   , peekOffN
   , pokeN
   , pokeOffN
+  , peekBi
+  , peekOffBi
+  , pokeBi
+  , pokeOffBi
   , peekOffS
   , pokeS
   , pokeOffS
-  , peekOffT
-  , pokeT
-  , peekOffB
-  , pokeB
   , uscount
   , bscount
   ) where
@@ -55,19 +55,17 @@ import Data.Primitive.PrimArray
 import Data.Primitive.Array
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Sq
-import Data.Text (Text)
 import Data.Word
 
 import Unison.Reference (Reference)
 
 import Unison.Runtime.ANF (Mem(..), unpackTags, RTag)
-import Unison.Runtime.Foreign
 import Unison.Runtime.MCode
+import Unison.Runtime.Foreign
 
 import qualified Unison.Type as Ty
 
 import Unison.Util.EnumContainers as EC
-import Unison.Util.Bytes (Bytes)
 
 import GHC.Stack (HasCallStack)
 
@@ -472,21 +470,21 @@ pokeOffD :: Stack 'UN -> Int -> Double -> IO ()
 pokeOffD (US _ _ sp stk) i d = writeByteArray stk (sp-i) d
 {-# inline pokeOffD #-}
 
-peekOffT :: Stack 'BX -> Int -> IO Text
-peekOffT bstk i =
-  unwrapForeign . marshalToForeign <$> peekOff bstk i
-{-# inline peekOffT #-}
+pokeBi :: BuiltinForeign b => Stack 'BX -> b -> IO ()
+pokeBi bstk x = poke bstk (Foreign $ wrapBuiltin x)
+{-# inline pokeBi #-}
 
-pokeT :: Stack 'BX -> Text -> IO ()
-pokeT bstk t = poke bstk (Foreign $ wrapText t)
-{-# inline pokeT #-}
+pokeOffBi :: BuiltinForeign b => Stack 'BX -> Int -> b -> IO ()
+pokeOffBi bstk i x = pokeOff bstk i (Foreign $ wrapBuiltin x)
+{-# inline pokeOffBi #-}
 
-peekOffB :: Stack 'BX -> Int -> IO Bytes
-peekOffB bstk i = unwrapForeign . marshalToForeign <$> peekOff bstk i
-{-# inline peekOffB #-}
+peekBi :: BuiltinForeign b => Stack 'BX -> IO b
+peekBi bstk = unwrapForeign . marshalToForeign <$> peek bstk
+{-# inline peekBi #-}
 
-pokeB :: Stack 'BX -> Bytes -> IO ()
-pokeB bstk b = poke bstk (Foreign $ wrapBytes b)
+peekOffBi :: BuiltinForeign b => Stack 'BX -> Int -> IO b
+peekOffBi bstk i = unwrapForeign . marshalToForeign <$> peekOff bstk i
+{-# inline peekOffBi #-}
 
 peekOffS :: Stack 'BX -> Int -> IO (Seq Closure)
 peekOffS bstk i =

--- a/parser-typechecker/tests/Unison/Test/MCode.hs
+++ b/parser-typechecker/tests/Unison/Test/MCode.hs
@@ -9,7 +9,6 @@ import EasyTest
 import qualified Data.Map.Strict as Map
 
 import Data.Bits (bit)
-import Data.Maybe (fromMaybe)
 import Data.Word (Word64)
 
 import Unison.Util.EnumContainers as EC
@@ -33,13 +32,13 @@ import Unison.Runtime.MCode
   )
 import Unison.Runtime.Builtin
 import Unison.Runtime.Machine
-  ( REnv(..), eval0 )
+  ( SEnv(..), eval0 )
 
 import Unison.Test.Common (tm)
 
-testEval0 :: (Word64 -> Comb) -> Section -> Test ()
+testEval0 :: EnumMap Word64 Comb -> Section -> Test ()
 testEval0 env sect = do
-  io $ eval0 (Refs mempty mempty) env sect
+  io $ eval0 (SEnv env builtinForeigns mempty mempty) sect
   ok
 
 builtins :: Reference -> Word64
@@ -51,13 +50,8 @@ builtins r
 cenv :: EnumMap Word64 Comb
 cenv = fmap (emitComb mempty) $ numberedTermLookup @Symbol
 
-benv :: Word64 -> Maybe Comb
-benv i
-  | i == bit 64 = Just $ Lam 0 1 2 1 asrt
-  | otherwise = EC.lookup i cenv
-
-env :: EnumMap Word64 Comb -> Word64 -> Comb
-env m n = fromMaybe (m ! n) $ benv n
+env :: EnumMap Word64 Comb -> EnumMap Word64 Comb
+env m = m <> mapInsert (bit 64) (Lam 0 1 2 1 asrt) cenv
 
 asrt :: Section
 asrt = Ins (Unpack 0)

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -125,7 +125,9 @@ library
     Unison.Runtime.Builtin
     Unison.Runtime.Debug
     Unison.Runtime.Decompile
+    Unison.Runtime.Exception
     Unison.Runtime.Foreign
+    Unison.Runtime.Foreign.Function
     Unison.Runtime.Interface
     Unison.Runtime.IR
     Unison.Runtime.MCode
@@ -227,6 +229,7 @@ library
     split,
     stm,
     strings,
+    tagged,
     terminal-size,
     text,
     time,

--- a/unison-core/src/Unison/Type.hs
+++ b/unison-core/src/Unison/Type.hs
@@ -226,6 +226,9 @@ fileHandleRef = Reference.Builtin "Handle"
 threadIdRef = Reference.Builtin "ThreadId"
 socketRef = Reference.Builtin "Socket"
 
+mvarRef :: Reference
+mvarRef = Reference.Builtin "MVar"
+
 builtin :: Ord v => a -> Text -> Type v a
 builtin a = ref a . Reference.Builtin
 

--- a/unison-src/transcripts/alias-many.output.md
+++ b/unison-src/transcripts/alias-many.output.md
@@ -264,9 +264,20 @@ Let's try it!
   226. io2.IOError.ResourceBusy : IOError
   227. io2.IOError.ResourceExhausted : IOError
   228. io2.IOError.UserError : IOError
-  229. builtin type io2.Socket
-  230. builtin type io2.ThreadId
-  231. todo : a -> b
+  229. builtin type io2.MVar
+  230. io2.MVar.isEmpty : MVar a ->{IO} Boolean
+  231. io2.MVar.new : a ->{IO} MVar a
+  232. io2.MVar.newEmpty : {IO} (MVar a)
+  233. io2.MVar.put : MVar a -> a ->{IO} Either IOError ()
+  234. io2.MVar.read : MVar a ->{IO} Either IOError a
+  235. io2.MVar.swap : MVar a -> a ->{IO} Either IOError a
+  236. io2.MVar.take : MVar a ->{IO} Either IOError a
+  237. io2.MVar.tryPut : MVar a -> a ->{IO} Boolean
+  238. io2.MVar.tryRead : MVar a ->{IO} Optional a
+  239. io2.MVar.tryTake : MVar a ->{IO} Optional a
+  240. builtin type io2.Socket
+  241. builtin type io2.ThreadId
+  242. todo : a -> b
   
 
 .builtin> alias.many 94-104 .mylib

--- a/unison-src/transcripts/builtins-merge.output.md
+++ b/unison-src/transcripts/builtins-merge.output.md
@@ -44,7 +44,7 @@ The `builtins.merge` command adds the known builtins to a `builtin` subnamespace
   33. Unit/      (1 definition)
   34. Universal/ (6 definitions)
   35. bug        (a -> b)
-  36. io2/       (57 definitions)
+  36. io2/       (68 definitions)
   37. todo       (a -> b)
 
 ```

--- a/unison-src/transcripts/emptyCodebase.output.md
+++ b/unison-src/transcripts/emptyCodebase.output.md
@@ -23,7 +23,7 @@ Technically, the definitions all exist, but they have no names. `builtins.merge`
 
 .foo> ls
 
-  1. builtin/ (231 definitions)
+  1. builtin/ (242 definitions)
 
 ```
 And for a limited time, you can get even more builtin goodies:
@@ -35,7 +35,7 @@ And for a limited time, you can get even more builtin goodies:
 
 .foo> ls
 
-  1. builtin/ (394 definitions)
+  1. builtin/ (405 definitions)
 
 ```
 More typically, you'd start out by pulling `base.

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -112,13 +112,13 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #krakhj8q5b
+  ⊙ #mbok83u09o
   
     - Deletes:
     
       feature1.y
   
-  ⊙ #j0lfs5asc7
+  ⊙ #u53od2so90
   
     + Adds / updates:
     
@@ -129,26 +129,26 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
       Original name New name(s)
       feature1.y    master.y
   
-  ⊙ #ej6ll3ac1h
+  ⊙ #drgfm4pkk8
   
     + Adds / updates:
     
       feature1.y
   
-  ⊙ #gidrg9pool
+  ⊙ #kt6vuoajil
   
     > Moves:
     
       Original name New name
       x             master.x
   
-  ⊙ #sdinucmq5a
+  ⊙ #n187cml1um
   
     + Adds / updates:
     
       x
   
-  ⊙ #pc4d0e58h3
+  ⊙ #r3il860k10
   
     + Adds / updates:
     
@@ -249,8 +249,13 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
       builtin.io2.IOError.PermissionDenied
       builtin.io2.IOError.ResourceBusy
       builtin.io2.IOError.ResourceExhausted
-      builtin.io2.IOError.UserError builtin.io2.Socket
-      builtin.io2.ThreadId builtin.todo
+      builtin.io2.IOError.UserError builtin.io2.MVar
+      builtin.io2.MVar.isEmpty builtin.io2.MVar.new
+      builtin.io2.MVar.newEmpty builtin.io2.MVar.put
+      builtin.io2.MVar.read builtin.io2.MVar.swap
+      builtin.io2.MVar.take builtin.io2.MVar.tryPut
+      builtin.io2.MVar.tryRead builtin.io2.MVar.tryTake
+      builtin.io2.Socket builtin.io2.ThreadId builtin.todo
   
   □ #7asfbtqmoj (start of history)
 

--- a/unison-src/transcripts/reflog.output.md
+++ b/unison-src/transcripts/reflog.output.md
@@ -59,16 +59,16 @@ y = 2
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #7eiv5s0sk9 .old`   to make an old namespace
+    `fork #lchpgti2ff .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #7eiv5s0sk9`  to reset the root namespace and
+    `reset-root #lchpgti2ff`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
-  1. #kmsvfuu78t : add
-  2. #7eiv5s0sk9 : add
-  3. #pc4d0e58h3 : builtins.merge
+  1. #enithaeg0q : add
+  2. #lchpgti2ff : add
+  3. #r3il860k10 : builtins.merge
   4. #7asfbtqmoj : (initial reflogged namespace)
 
 ```

--- a/unison-src/transcripts/squash.output.md
+++ b/unison-src/transcripts/squash.output.md
@@ -13,7 +13,7 @@ Let's look at some examples. We'll start with a namespace with just the builtins
   
   
   
-  □ #tt9sn32lfj (start of history)
+  □ #ogcg4avrjh (start of history)
 
 .> fork builtin builtin2
 
@@ -42,21 +42,21 @@ Now suppose we `fork` a copy of builtin, then rename `Nat.+` to `frobnicate`, th
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #jr4tifejsn
+  ⊙ #o0pk9hok61
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ #68dokn5l8c
+  ⊙ #1u7jcv7ptk
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ #tt9sn32lfj (start of history)
+  □ #ogcg4avrjh (start of history)
 
 ```
 If we merge that back into `builtin`, we get that same chain of history:
@@ -71,21 +71,21 @@ If we merge that back into `builtin`, we get that same chain of history:
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #jr4tifejsn
+  ⊙ #o0pk9hok61
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ #68dokn5l8c
+  ⊙ #1u7jcv7ptk
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ #tt9sn32lfj (start of history)
+  □ #ogcg4avrjh (start of history)
 
 ```
 Let's try again, but using a `merge.squash` (or just `squash`) instead. The history will be unchanged:
@@ -106,7 +106,7 @@ Let's try again, but using a `merge.squash` (or just `squash`) instead. The hist
   
   
   
-  □ #tt9sn32lfj (start of history)
+  □ #ogcg4avrjh (start of history)
 
 ```
 The churn that happened in `mybuiltin` namespace ended up back in the same spot, so the squash merge of that namespace with our original namespace had no effect.

--- a/unison-src/transcripts/suffixes.output.md
+++ b/unison-src/transcripts/suffixes.output.md
@@ -28,6 +28,8 @@ This also affects commands like find. Notice lack of qualified names in output:
   1. builtin.Bytes.take : Nat -> Bytes -> Bytes
   2. builtin.List.take : Nat -> [a] -> [a]
   3. builtin.Text.take : Nat -> Text -> Text
+  4. builtin.io2.MVar.take : MVar a ->{IO} Either IOError a
+  5. builtin.io2.MVar.tryTake : MVar a ->{IO} Optional a
   
 
 ```


### PR DESCRIPTION
This pull request adds `MVar` as a builtin type, and various operations for using `MVar` in the new builtin `IO` ability. It also adds a document specifying how this is done, so that it can hopefully be accomplished by other people.

The new runtime 'foreign function' machinery that is used for I/O stuff was reworked a fair bit as part of this, because the existing implementation was insufficient for working directly with uninspected closures like `MVar` should. This of course isn't in the document, since it was just a design change motivated by the example.

Not all GHC `MVar` functions have been wrapped, but the relatively simple ones have, and it should allow for some actual non-trivial threading to be used.