### PR TITLE
Add delay and kill threading operations for new runtime

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -446,6 +446,8 @@ ioBuiltins =
   , ("IO.forkComp"
     , forall1 "a" $ \a -> (unit --> ioe a) --> ioe threadId)
   , ("IO.stdHandle", nat --> optionalt handle)
+  , ("IO.delay", nat --> ioe unit)
+  , ("IO.kill", threadId --> ioe unit)
   ]
 
 mvarBuiltins :: forall v. Var v => [(Text, Type v)]

--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -1025,6 +1025,23 @@ fork'comp avoid
   where
   [lz] = freshes' avoid 3
 
+delay'thread :: IOOP
+delay'thread avoid
+  = ([BX],)
+  . TAbs n0
+  . unbox n0 Ty.natRef n
+  $ io'error'result'unit THDELY [n] ior e r
+  where
+  [n0,n,ior,e,r] = freshes' avoid 5
+
+kill'thread :: IOOP
+kill'thread avoid
+  = ([BX],)
+  . TAbs tid
+  $ io'error'result'unit THKILL [tid] ior e r
+  where
+  [tid,ior,e,r] = freshes' avoid 4
+
 mvar'new :: IOOP
 mvar'new avoid
   = ([BX],)
@@ -1301,6 +1318,8 @@ builtinLookup
   , ("IO.socketSend", ioComb socket'send)
   , ("IO.socketReceive", ioComb socket'receive)
   , ("IO.forkComp", ioComb fork'comp)
+  , ("IO.delay", ioComb delay'thread)
+  , ("IO.kill", ioComb kill'thread)
   , ("IO.stdHandle", ioComb standard'handle)
 
   , ("MVar.new", ioComb mvar'new)

--- a/unison-src/transcripts/alias-many.output.md
+++ b/unison-src/transcripts/alias-many.output.md
@@ -209,75 +209,77 @@ Let's try it!
   187. io2.IO.closeFile : Handle ->{IO} Either IOError ()
   188. io2.IO.closeSocket : Socket ->{IO} Either IOError ()
   189. io2.IO.createDirectory : Text ->{IO} Either IOError ()
-  190. io2.IO.fileExists : Text ->{IO} Either IOError Boolean
-  191. io2.IO.forkComp : '{IO} Either IOError a
+  190. io2.IO.delay : Nat ->{IO} Either IOError ()
+  191. io2.IO.fileExists : Text ->{IO} Either IOError Boolean
+  192. io2.IO.forkComp : '{IO} Either IOError a
                          ->{IO} Either IOError ThreadId
-  192. io2.IO.getBuffering : Handle
+  193. io2.IO.getBuffering : Handle
                              ->{IO} Either IOError BufferMode
-  193. io2.IO.getCurrentDirectory : '{IO} Either IOError Text
-  194. io2.IO.getFileSize : Text ->{IO} Either IOError Nat
-  195. io2.IO.getFileTimestamp : Text ->{IO} Either IOError Nat
-  196. io2.IO.getLine : Handle ->{IO} Either IOError Text
-  197. io2.IO.getTempDirectory : '{IO} Either IOError Text
-  198. io2.IO.getText : Handle ->{IO} Either IOError Text
-  199. io2.IO.handlePosition : Handle ->{IO} Either IOError Int
-  200. io2.IO.isDirectory : Text ->{IO} Either IOError Boolean
-  201. io2.IO.isFileEOF : Handle ->{IO} Either IOError Boolean
-  202. io2.IO.isFileOpen : Handle ->{IO} Either IOError Boolean
-  203. io2.IO.isSeekable : Handle ->{IO} Either IOError Boolean
-  204. io2.IO.listen : Socket ->{IO} Either IOError ()
-  205. io2.IO.openFile : Text ->{IO} Either IOError Handle
-  206. io2.IO.putText : Handle -> Text ->{IO} Either IOError ()
-  207. io2.IO.removeDirectory : Text ->{IO} Either IOError ()
-  208. io2.IO.removeFile : Text ->{IO} Either IOError ()
-  209. io2.IO.renameDirectory : Text
+  194. io2.IO.getCurrentDirectory : '{IO} Either IOError Text
+  195. io2.IO.getFileSize : Text ->{IO} Either IOError Nat
+  196. io2.IO.getFileTimestamp : Text ->{IO} Either IOError Nat
+  197. io2.IO.getLine : Handle ->{IO} Either IOError Text
+  198. io2.IO.getTempDirectory : '{IO} Either IOError Text
+  199. io2.IO.getText : Handle ->{IO} Either IOError Text
+  200. io2.IO.handlePosition : Handle ->{IO} Either IOError Int
+  201. io2.IO.isDirectory : Text ->{IO} Either IOError Boolean
+  202. io2.IO.isFileEOF : Handle ->{IO} Either IOError Boolean
+  203. io2.IO.isFileOpen : Handle ->{IO} Either IOError Boolean
+  204. io2.IO.isSeekable : Handle ->{IO} Either IOError Boolean
+  205. io2.IO.kill : ThreadId ->{IO} Either IOError ()
+  206. io2.IO.listen : Socket ->{IO} Either IOError ()
+  207. io2.IO.openFile : Text ->{IO} Either IOError Handle
+  208. io2.IO.putText : Handle -> Text ->{IO} Either IOError ()
+  209. io2.IO.removeDirectory : Text ->{IO} Either IOError ()
+  210. io2.IO.removeFile : Text ->{IO} Either IOError ()
+  211. io2.IO.renameDirectory : Text
                                 -> Text
                                 ->{IO} Either IOError ()
-  210. io2.IO.renameFile : Text -> Text ->{IO} Either IOError ()
-  211. io2.IO.seekHandle : Handle
+  212. io2.IO.renameFile : Text -> Text ->{IO} Either IOError ()
+  213. io2.IO.seekHandle : Handle
                            -> FileMode
                            -> Int
                            ->{IO} Either IOError ()
-  212. io2.IO.serverSocket : Text
+  214. io2.IO.serverSocket : Text
                              -> Text
                              ->{IO} Either IOError Socket
-  213. io2.IO.setBuffering : Handle
+  215. io2.IO.setBuffering : Handle
                              -> BufferMode
                              ->{IO} Either IOError ()
-  214. io2.IO.setCurrentDirectory : Text
+  216. io2.IO.setCurrentDirectory : Text
                                     ->{IO} Either IOError ()
-  215. io2.IO.socketAccept : Socket ->{IO} Either IOError Socket
-  216. io2.IO.socketReceive : Socket
+  217. io2.IO.socketAccept : Socket ->{IO} Either IOError Socket
+  218. io2.IO.socketReceive : Socket
                               -> Nat
                               ->{IO} Either IOError Bytes
-  217. io2.IO.socketSend : Socket
+  219. io2.IO.socketSend : Socket
                            -> Bytes
                            ->{IO} Either IOError ()
-  218. io2.IO.stdHandle : Nat -> Optional Handle
-  219. io2.IO.systemTime : '{IO} Either IOError Nat
-  220. unique type io2.IOError
-  221. io2.IOError.AlreadyExists : IOError
-  222. io2.IOError.EOF : IOError
-  223. io2.IOError.IllegalOperation : IOError
-  224. io2.IOError.NoSuchThing : IOError
-  225. io2.IOError.PermissionDenied : IOError
-  226. io2.IOError.ResourceBusy : IOError
-  227. io2.IOError.ResourceExhausted : IOError
-  228. io2.IOError.UserError : IOError
-  229. builtin type io2.MVar
-  230. io2.MVar.isEmpty : MVar a ->{IO} Boolean
-  231. io2.MVar.new : a ->{IO} MVar a
-  232. io2.MVar.newEmpty : {IO} (MVar a)
-  233. io2.MVar.put : MVar a -> a ->{IO} Either IOError ()
-  234. io2.MVar.read : MVar a ->{IO} Either IOError a
-  235. io2.MVar.swap : MVar a -> a ->{IO} Either IOError a
-  236. io2.MVar.take : MVar a ->{IO} Either IOError a
-  237. io2.MVar.tryPut : MVar a -> a ->{IO} Boolean
-  238. io2.MVar.tryRead : MVar a ->{IO} Optional a
-  239. io2.MVar.tryTake : MVar a ->{IO} Optional a
-  240. builtin type io2.Socket
-  241. builtin type io2.ThreadId
-  242. todo : a -> b
+  220. io2.IO.stdHandle : Nat -> Optional Handle
+  221. io2.IO.systemTime : '{IO} Either IOError Nat
+  222. unique type io2.IOError
+  223. io2.IOError.AlreadyExists : IOError
+  224. io2.IOError.EOF : IOError
+  225. io2.IOError.IllegalOperation : IOError
+  226. io2.IOError.NoSuchThing : IOError
+  227. io2.IOError.PermissionDenied : IOError
+  228. io2.IOError.ResourceBusy : IOError
+  229. io2.IOError.ResourceExhausted : IOError
+  230. io2.IOError.UserError : IOError
+  231. builtin type io2.MVar
+  232. io2.MVar.isEmpty : MVar a ->{IO} Boolean
+  233. io2.MVar.new : a ->{IO} MVar a
+  234. io2.MVar.newEmpty : {IO} (MVar a)
+  235. io2.MVar.put : MVar a -> a ->{IO} Either IOError ()
+  236. io2.MVar.read : MVar a ->{IO} Either IOError a
+  237. io2.MVar.swap : MVar a -> a ->{IO} Either IOError a
+  238. io2.MVar.take : MVar a ->{IO} Either IOError a
+  239. io2.MVar.tryPut : MVar a -> a ->{IO} Boolean
+  240. io2.MVar.tryRead : MVar a ->{IO} Optional a
+  241. io2.MVar.tryTake : MVar a ->{IO} Optional a
+  242. builtin type io2.Socket
+  243. builtin type io2.ThreadId
+  244. todo : a -> b
   
 
 .builtin> alias.many 94-104 .mylib

--- a/unison-src/transcripts/builtins-merge.output.md
+++ b/unison-src/transcripts/builtins-merge.output.md
@@ -44,7 +44,7 @@ The `builtins.merge` command adds the known builtins to a `builtin` subnamespace
   33. Unit/      (1 definition)
   34. Universal/ (6 definitions)
   35. bug        (a -> b)
-  36. io2/       (68 definitions)
+  36. io2/       (70 definitions)
   37. todo       (a -> b)
 
 ```

--- a/unison-src/transcripts/emptyCodebase.output.md
+++ b/unison-src/transcripts/emptyCodebase.output.md
@@ -23,7 +23,7 @@ Technically, the definitions all exist, but they have no names. `builtins.merge`
 
 .foo> ls
 
-  1. builtin/ (242 definitions)
+  1. builtin/ (244 definitions)
 
 ```
 And for a limited time, you can get even more builtin goodies:
@@ -35,7 +35,7 @@ And for a limited time, you can get even more builtin goodies:
 
 .foo> ls
 
-  1. builtin/ (405 definitions)
+  1. builtin/ (407 definitions)
 
 ```
 More typically, you'd start out by pulling `base.

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -112,13 +112,13 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #mbok83u09o
+  ⊙ #bof7ljhk4e
   
     - Deletes:
     
       feature1.y
   
-  ⊙ #u53od2so90
+  ⊙ #f10e7ivnt7
   
     + Adds / updates:
     
@@ -129,26 +129,26 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
       Original name New name(s)
       feature1.y    master.y
   
-  ⊙ #drgfm4pkk8
+  ⊙ #ckoq0pumq4
   
     + Adds / updates:
     
       feature1.y
   
-  ⊙ #kt6vuoajil
+  ⊙ #hjs0h1o8po
   
     > Moves:
     
       Original name New name
       x             master.x
   
-  ⊙ #n187cml1um
+  ⊙ #qhckem9e6s
   
     + Adds / updates:
     
       x
   
-  ⊙ #r3il860k10
+  ⊙ #7v5brelc5r
   
     + Adds / updates:
     
@@ -226,19 +226,21 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
       builtin.io2.FileMode.Write builtin.io2.Handle
       builtin.io2.IO builtin.io2.IO.clientSocket
       builtin.io2.IO.closeFile builtin.io2.IO.closeSocket
-      builtin.io2.IO.createDirectory builtin.io2.IO.fileExists
-      builtin.io2.IO.forkComp builtin.io2.IO.getBuffering
+      builtin.io2.IO.createDirectory builtin.io2.IO.delay
+      builtin.io2.IO.fileExists builtin.io2.IO.forkComp
+      builtin.io2.IO.getBuffering
       builtin.io2.IO.getCurrentDirectory
       builtin.io2.IO.getFileSize builtin.io2.IO.getFileTimestamp
       builtin.io2.IO.getLine builtin.io2.IO.getTempDirectory
       builtin.io2.IO.getText builtin.io2.IO.handlePosition
       builtin.io2.IO.isDirectory builtin.io2.IO.isFileEOF
       builtin.io2.IO.isFileOpen builtin.io2.IO.isSeekable
-      builtin.io2.IO.listen builtin.io2.IO.openFile
-      builtin.io2.IO.putText builtin.io2.IO.removeDirectory
-      builtin.io2.IO.removeFile builtin.io2.IO.renameDirectory
-      builtin.io2.IO.renameFile builtin.io2.IO.seekHandle
-      builtin.io2.IO.serverSocket builtin.io2.IO.setBuffering
+      builtin.io2.IO.kill builtin.io2.IO.listen
+      builtin.io2.IO.openFile builtin.io2.IO.putText
+      builtin.io2.IO.removeDirectory builtin.io2.IO.removeFile
+      builtin.io2.IO.renameDirectory builtin.io2.IO.renameFile
+      builtin.io2.IO.seekHandle builtin.io2.IO.serverSocket
+      builtin.io2.IO.setBuffering
       builtin.io2.IO.setCurrentDirectory
       builtin.io2.IO.socketAccept builtin.io2.IO.socketReceive
       builtin.io2.IO.socketSend builtin.io2.IO.stdHandle

--- a/unison-src/transcripts/reflog.output.md
+++ b/unison-src/transcripts/reflog.output.md
@@ -59,16 +59,16 @@ y = 2
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #lchpgti2ff .old`   to make an old namespace
+    `fork #02v51724u1 .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #lchpgti2ff`  to reset the root namespace and
+    `reset-root #02v51724u1`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
-  1. #enithaeg0q : add
-  2. #lchpgti2ff : add
-  3. #r3il860k10 : builtins.merge
+  1. #98g5co2hlc : add
+  2. #02v51724u1 : add
+  3. #7v5brelc5r : builtins.merge
   4. #7asfbtqmoj : (initial reflogged namespace)
 
 ```

--- a/unison-src/transcripts/squash.output.md
+++ b/unison-src/transcripts/squash.output.md
@@ -13,7 +13,7 @@ Let's look at some examples. We'll start with a namespace with just the builtins
   
   
   
-  □ #ogcg4avrjh (start of history)
+  □ #ph82ki1r6t (start of history)
 
 .> fork builtin builtin2
 
@@ -42,21 +42,21 @@ Now suppose we `fork` a copy of builtin, then rename `Nat.+` to `frobnicate`, th
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #o0pk9hok61
+  ⊙ #0m45ccf7re
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ #1u7jcv7ptk
+  ⊙ #5ntoo4d3qh
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ #ogcg4avrjh (start of history)
+  □ #ph82ki1r6t (start of history)
 
 ```
 If we merge that back into `builtin`, we get that same chain of history:
@@ -71,21 +71,21 @@ If we merge that back into `builtin`, we get that same chain of history:
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #o0pk9hok61
+  ⊙ #0m45ccf7re
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ #1u7jcv7ptk
+  ⊙ #5ntoo4d3qh
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ #ogcg4avrjh (start of history)
+  □ #ph82ki1r6t (start of history)
 
 ```
 Let's try again, but using a `merge.squash` (or just `squash`) instead. The history will be unchanged:
@@ -106,7 +106,7 @@ Let's try again, but using a `merge.squash` (or just `squash`) instead. The hist
   
   
   
-  □ #ogcg4avrjh (start of history)
+  □ #ph82ki1r6t (start of history)
 
 ```
 The churn that happened in `mybuiltin` namespace ended up back in the same spot, so the squash merge of that namespace with our original namespace had no effect.


### PR DESCRIPTION
The instructions for these were implemented previously, but the wrapping to make them available was missing.