### PR TITLE
Highlight below the fold as a comment

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -46,3 +46,4 @@ The format for this list: name, GitHub handle, and then optional blurb about wha
 * Ludvig Sundström (@lsund)
 * Mohamed Elsharnouby (@sharno)
 * Jared Forsyth (@jaredly) - Documentation generation
+* Hakim Cassimally (@osfameron) - vim support

--- a/editor-support/vim/syntax/unison.vim
+++ b/editor-support/vim/syntax/unison.vim
@@ -95,7 +95,7 @@ endif
 syn match   uLineComment      "---*\([^-!#$%&\*\+./<=>\?@\\^|~].*\)\?$"
 syn region  uBlockComment     start="{-"  end="-}" contains=uBlockComment
 syn region  uPragma	       start="{-#" end="#-}"
-syn region  uBelowFold	       start="^---- " skip="." end="." contains=uBelowFold
+syn region  uBelowFold	       start="^---" skip="." end="." contains=uBelowFold
 
 " Docs
 syn region  uDocBlock         start="\[:" end=":]" contains=uLink,uDocDirective

--- a/editor-support/vim/syntax/unison.vim
+++ b/editor-support/vim/syntax/unison.vim
@@ -95,6 +95,7 @@ endif
 syn match   uLineComment      "---*\([^-!#$%&\*\+./<=>\?@\\^|~].*\)\?$"
 syn region  uBlockComment     start="{-"  end="-}" contains=uBlockComment
 syn region  uPragma	       start="{-#" end="#-}"
+syn region  uBelowFold	       start="^---- " skip="." end="." contains=uBelowFold
 
 " Docs
 syn region  uDocBlock         start="\[:" end=":]" contains=uLink,uDocDirective
@@ -132,6 +133,7 @@ if version >= 508 || !exists("did_u_syntax_inits")
   HiLink uBlockComment		  uComment
   HiLink uLineComment			  uComment
   HiLink uComment			  Comment
+  HiLink uBelowFold			  Comment
   HiLink uDocBlock                String
   HiLink uLink                    uType
   HiLink uDocDirective            uImport
@@ -145,6 +147,7 @@ if version >= 508 || !exists("did_u_syntax_inits")
 
   delcommand HiLink
 endif
+
 
 let b:current_syntax = "unison"
 


### PR DESCRIPTION
Add a `uBelowFold` syntax region, highlighted as a comment.

## Overview

As Unison itself ignores everything below the fold, it makes sense to format the contents as a comment, rather than Unison highlighted.

## Implementation notes

This uses the Syntax Region highlighting feature in Vim.
I'm not 100% how the `skip` and `end` features work, but I copied it from `perl.vim` as Perl has an analogous `__END__` marker construct.

## Interesting/controversial decisions

Don't think so.

## Test coverage

None provided, I don't know how to test Vim syntax files.

## Loose ends

Could potentially add folding support?
