### PR TITLE
New runtime builtin fixes/tweaks

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -444,7 +444,7 @@ ioBuiltins =
   , ("IO.socketSend", socket --> bytes --> ioe unit)
   , ("IO.socketReceive", socket --> nat --> ioe bytes)
   , ("IO.forkComp"
-    , forall1 "a" $ \a -> (unit --> ioe a) --> ioe threadId)
+    , forall1 "a" $ \a -> (unit --> ioe a) --> io threadId)
   , ("IO.stdHandle", nat --> optionalt handle)
   , ("IO.delay", nat --> ioe unit)
   , ("IO.kill", threadId --> ioe unit)

--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -411,12 +411,12 @@ io2List bs = bs >>= \(n,ty) -> [B n ty, Rename n ("io2." <> n)]
 
 ioBuiltins :: Var v => [(Text, Type v)]
 ioBuiltins =
-  [ ("IO.openFile", text --> ioe handle)
+  [ ("IO.openFile", text --> fmode --> ioe handle)
   , ("IO.closeFile", handle --> ioe unit)
   , ("IO.isFileEOF", handle --> ioe boolean)
   , ("IO.isFileOpen", handle --> ioe boolean)
   , ("IO.isSeekable", handle --> ioe boolean)
-  , ("IO.seekHandle", handle --> fmode --> int --> ioe unit)
+  , ("IO.seekHandle", handle --> smode --> int --> ioe unit)
   , ("IO.handlePosition", handle --> ioe int)
   , ("IO.getBuffering", handle --> ioe bmode)
   , ("IO.setBuffering", handle --> bmode --> ioe unit)
@@ -505,9 +505,10 @@ threadId = Type.threadId ()
 handle = Type.fileHandle ()
 unit = DD.unitType ()
 
-fmode, bmode, stdhandle :: Var v => Type v
+fmode, bmode, smode, stdhandle :: Var v => Type v
 fmode = DD.fileModeType ()
 bmode = DD.bufferModeType ()
+smode = DD.seekModeType ()
 stdhandle = DD.stdHandleType ()
 
 int, nat, bytes, text, boolean, float, char :: Var v => Type v

--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -445,7 +445,7 @@ ioBuiltins =
   , ("IO.socketReceive", socket --> nat --> ioe bytes)
   , ("IO.forkComp"
     , forall1 "a" $ \a -> (unit --> ioe a) --> io threadId)
-  , ("IO.stdHandle", nat --> optionalt handle)
+  , ("IO.stdHandle", stdhandle --> handle)
   , ("IO.delay", nat --> ioe unit)
   , ("IO.kill", threadId --> ioe unit)
   ]
@@ -505,9 +505,10 @@ threadId = Type.threadId ()
 handle = Type.fileHandle ()
 unit = DD.unitType ()
 
-fmode, bmode :: Var v => Type v
+fmode, bmode, stdhandle :: Var v => Type v
 fmode = DD.fileModeType ()
 bmode = DD.bufferModeType ()
+stdhandle = DD.stdHandleType ()
 
 int, nat, bytes, text, boolean, float, char :: Var v => Type v
 int = Type.int ()

--- a/parser-typechecker/src/Unison/Builtin/Decls.hs
+++ b/parser-typechecker/src/Unison/Builtin/Decls.hs
@@ -28,9 +28,9 @@ import           Unison.Var                     (Var)
 
 
 unitRef, pairRef, optionalRef, eitherRef :: Reference
-testResultRef, linkRef, docRef, ioErrorRef :: Reference
+testResultRef, linkRef, docRef, ioErrorRef, stdHandleRef :: Reference
 fileModeRef, bufferModeRef, seqViewRef :: Reference
-(unitRef, pairRef, optionalRef, testResultRef, linkRef, docRef, eitherRef, ioErrorRef, fileModeRef, bufferModeRef, seqViewRef) =
+(unitRef, pairRef, optionalRef, testResultRef, linkRef, docRef, eitherRef, ioErrorRef, stdHandleRef, fileModeRef, bufferModeRef, seqViewRef) =
   let decls          = builtinDataDecls @Symbol
       [(_, unit, _)] = filter (\(v, _, _) -> v == Var.named "Unit") decls
       [(_, pair, _)] = filter (\(v, _, _) -> v == Var.named "Tuple") decls
@@ -42,11 +42,12 @@ fileModeRef, bufferModeRef, seqViewRef :: Reference
 
       [(_,ethr,_)] = filter (\(v,_,_) -> v == Var.named "Either") decls
       [(_,ioerr,_)] = filter (\(v,_,_) -> v == Var.named "io2.IOError") decls
+      [(_,stdhnd,_)] = filter (\(v,_,_) -> v == Var.named "io2.StdHandle") decls
       [(_,fmode,_)] = filter (\(v,_,_) -> v == Var.named "io2.FileMode") decls
       [(_,bmode,_)] = filter (\(v,_,_) -> v == Var.named "io2.BufferMode") decls
       [(_,seqv,_)] = filter (\(v,_,_) -> v == Var.named "SeqView") decls
       r = Reference.DerivedId
-  in (r unit, r pair, r opt, r testResult, r link, r doc, r ethr, r ioerr, r fmode, r bmode, r seqv)
+  in (r unit, r pair, r opt, r testResult, r link, r doc, r ethr, r ioerr, r stdhnd, r fmode, r bmode, r seqv)
 
 pairCtorRef, unitCtorRef :: Referent
 pairCtorRef = Referent.Con pairRef 0 CT.Data
@@ -93,6 +94,7 @@ builtinDataDecls = rs1 ++ rs
     , (v "SeqView"        , seqview)
 
     , (v "io2.IOError"    , ioerr)
+    , (v "io2.StdHandle"  , stdhnd)
     ] of Right a -> a; Left e -> error $ "builtinDataDecls: " <> show e
   [(_, linkRef, _)] = rs1
   v = Var.named
@@ -176,6 +178,14 @@ builtinDataDecls = rs1 ++ rs
     , ((), v "io2.IOError.PermissionDenied", var "io2.IOError")
     , ((), v "io2.IOError.UserError", var "io2.IOError")
     ]
+  stdhnd = DataDeclaration
+    (Unique "67bf7a8e517cbb1e9f42bc078e35498212d3be3c")
+    ()
+    []
+    [ ((), v "io2.StdHandle.StdIn", var "io2.StdHandle")
+    , ((), v "io2.StdHandle.StdOut", var "io2.StdHandle")
+    , ((), v "io2.StdHandle.StdErr", var "io2.StdHandle")
+    ]
   seqview = DataDeclaration
     Structural
     ()
@@ -250,7 +260,7 @@ pattern LinkTerm tm <- Term.App' (Term.Constructor' LinkRef LinkTermId) tm
 pattern LinkType ty <- Term.App' (Term.Constructor' LinkRef LinkTypeId) ty
 
 unitType, pairType, optionalType, testResultType,
-  eitherType, ioErrorType, fileModeType, bufferModeType
+  eitherType, ioErrorType, fileModeType, bufferModeType, stdHandleType
     :: Ord v => a -> Type v a
 unitType a = Type.ref a unitRef
 pairType a = Type.ref a pairRef
@@ -260,6 +270,7 @@ eitherType a = Type.ref a eitherRef
 ioErrorType a = Type.ref a ioErrorRef
 fileModeType a = Type.ref a fileModeRef
 bufferModeType a = Type.ref a bufferModeRef
+stdHandleType a = Type.ref a stdHandleRef
 
 unitTerm :: Var v => a -> Term v a
 unitTerm ann = Term.constructor ann unitRef 0

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -172,7 +172,10 @@ commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSour
 --    Propagate b -> do
 --      b0 <- Codebase.propagate codebase (Branch.head b)
 --      pure $ Branch.append b0 b
-    Execute ppe uf -> void $ evalUnisonFile ppe uf
+    Execute ppe uf ->
+      evalUnisonFile ppe uf >>= \case
+        Left e -> notifyUser (EvaluationFailure e) 
+        _ -> pure ()
     AppendToReflog reason old new -> Codebase.appendReflog codebase reason old new
     LoadReflog -> Codebase.getReflog codebase
     CreateAuthorInfo t -> AuthorInfo.createAuthorInfo Parser.External t

--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -717,16 +717,11 @@ is'seekable avoid
 standard'handle :: IOOP
 standard'handle avoid
   = ([BX],)
-  . TAbss [n0]
-  . unbox n0 Ty.natRef n
-  . TLet r UN (AIOp STDHND [n])
-  . TMatch r . MatchSum
-  $ mapFromList
-  [ (0, ([], TCon optionTag 0 []))
-  , (1, ([BX], TAbs h $ TCon optionTag 1 [h]))
-  ]
+  . TAbss [h0]
+  . unenum 3 h0 Ty.stdHandleRef h
+  $ TIOp STDHND [h]
   where
-  [n0,n,h,r] = freshes' avoid 4
+  [h0,h] = freshes' avoid 2
 
 seek'handle :: IOOP
 seek'handle avoid

--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -1023,7 +1023,7 @@ fork'comp avoid
   . TAbs lz
   $ TPrm FORK [lz]
   where
-  [lz] = freshes' avoid 3
+  [lz] = freshes' avoid 1
 
 delay'thread :: IOOP
 delay'thread avoid

--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -1020,10 +1020,12 @@ socket'receive avoid
 fork'comp :: IOOP
 fork'comp avoid
   = ([BX],)
-  . TAbs lz
+  . TAbs act
+  . TLet unit BX (ACon (rtag Ty.unitRef) 0 [])
+  . TName lz (Right act) [unit]
   $ TPrm FORK [lz]
   where
-  [lz] = freshes' avoid 1
+  [act,unit,lz] = freshes' avoid 3
 
 delay'thread :: IOOP
 delay'thread avoid

--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -727,7 +727,7 @@ seek'handle :: IOOP
 seek'handle avoid
   = ([BX,BX,BX],)
   . TAbss [h,sm0,po0]
-  . unenum 3 sm0 seekModeReference sm
+  . unenum 3 sm0 Ty.seekModeRef sm
   . unbox po0 Ty.natRef po
   $ io'error'result'unit SEEKFI [h,sm,po] ior e r
   where

--- a/parser-typechecker/src/Unison/Runtime/MCode.hs
+++ b/parser-typechecker/src/Unison/Runtime/MCode.hs
@@ -411,7 +411,7 @@ data Instr
   -- Put a delimiter on the continuation
   | Reset !(EnumSet Word64) -- prompt ids
 
-  | Fork !Section
+  | Fork !Int
   | Seq !Args
   deriving (Show, Eq, Ord)
 
@@ -950,7 +950,7 @@ emitPOp ANF.EROR = emitBP1 THRO
 -- non-prim translations
 emitPOp ANF.BLDS = Seq
 emitPOp ANF.FORK = \case
-  BArg1 i -> Fork $ App True (Stk i) ZArgs
+  BArg1 i -> Fork i
   _ -> error "fork takes exactly one boxed argument"
 emitPOp ANF.PRNT = \case
   BArg1 i -> Print i

--- a/parser-typechecker/src/Unison/Runtime/Machine.hs
+++ b/parser-typechecker/src/Unison/Runtime/Machine.hs
@@ -56,8 +56,6 @@ data SEnv
   , tagRefs :: !(EnumMap RTag Reference)
   }
 
-type Unmask = forall a. IO a -> IO a
-
 info :: Show a => String -> a -> IO ()
 info ctx x = infos ctx (show x)
 infos :: String -> String -> IO ()
@@ -68,7 +66,7 @@ eval0 :: SEnv -> Section -> IO ()
 eval0 !env !co = do
   ustk <- alloc
   bstk <- alloc
-  mask $ \unmask -> eval unmask env mempty ustk bstk KE co
+  eval env mempty ustk bstk KE co
 
 -- Entry point for evaluating a numbered combinator.
 -- An optional callback for the base of the stack may be supplied.
@@ -82,9 +80,8 @@ apply0 !callback !env !i
   | Just cmb <- EC.lookup i (combs env) = do
     ustk <- alloc
     bstk <- alloc
-    mask $ \unmask ->
-      apply unmask env mempty ustk bstk k0 True ZArgs
-        $ PAp (IC i cmb) unull bnull
+    apply env mempty ustk bstk k0 True ZArgs
+      $ PAp (IC i cmb) unull bnull
   | otherwise = die $ "apply0: unknown combinator: " ++ show i
   where
   k0 = maybe KE (CB . Hook) callback
@@ -93,11 +90,11 @@ apply0 !callback !env !i
 -- necessary to evaluate a closure with the provided information.
 apply1
   :: (Stack 'UN -> Stack 'BX -> IO ())
-  -> Unmask -> SEnv -> Closure -> IO ()
-apply1 callback unmask env clo = do
+  -> SEnv -> Closure -> IO ()
+apply1 callback env clo = do
   ustk <- alloc
   bstk <- alloc
-  apply unmask env mempty ustk bstk k0 True ZArgs clo
+  apply env mempty ustk bstk k0 True ZArgs clo
   where
   k0 = CB $ Hook callback
 
@@ -106,36 +103,36 @@ lookupDenv :: Word64 -> DEnv -> Closure
 lookupDenv p denv = fromMaybe BlackHole $ EC.lookup p denv
 
 exec
-  :: Unmask -> SEnv -> DEnv
+  :: SEnv -> DEnv
   -> Stack 'UN -> Stack 'BX -> K
   -> Instr
   -> IO (DEnv, Stack 'UN, Stack 'BX, K)
-exec _      !_   !denv !ustk !bstk !k (Info tx) = do
+exec !_   !denv !ustk !bstk !k (Info tx) = do
   info tx ustk
   info tx bstk
   info tx k
   pure (denv, ustk, bstk, k)
-exec _      !env !denv !ustk !bstk !k (Name r args) = do
+exec !env !denv !ustk !bstk !k (Name r args) = do
   bstk <- name ustk bstk args =<< resolve env denv bstk r
   pure (denv, ustk, bstk, k)
-exec _      !_   !denv !ustk !bstk !k (SetDyn p i) = do
+exec !_   !denv !ustk !bstk !k (SetDyn p i) = do
   clo <- peekOff bstk i
   pure (EC.mapInsert p clo denv, ustk, bstk, k)
-exec _      !_   !denv !ustk !bstk !k (Capture p) = do
+exec !_   !denv !ustk !bstk !k (Capture p) = do
   (sk,denv,ustk,bstk,useg,bseg,k) <- splitCont denv ustk bstk k p
   bstk <- bump bstk
   poke bstk $ Captured sk useg bseg
   pure (denv, ustk, bstk, k)
-exec _      !_   !denv !ustk !bstk !k (UPrim1 op i) = do
+exec !_   !denv !ustk !bstk !k (UPrim1 op i) = do
   ustk <- uprim1 ustk op i
   pure (denv, ustk, bstk, k)
-exec _      !_   !denv !ustk !bstk !k (UPrim2 op i j) = do
+exec !_   !denv !ustk !bstk !k (UPrim2 op i j) = do
   ustk <- uprim2 ustk op i j
   pure (denv, ustk, bstk, k)
-exec _      !_   !denv !ustk !bstk !k (BPrim1 op i) = do
+exec !_   !denv !ustk !bstk !k (BPrim1 op i) = do
   (ustk,bstk) <- bprim1 ustk bstk op i
   pure (denv, ustk, bstk, k)
-exec _      !env !denv !ustk !bstk !k (BPrim2 EQLU i j) = do
+exec !env !denv !ustk !bstk !k (BPrim2 EQLU i j) = do
   x <- peekOff bstk i
   y <- peekOff bstk j
   ustk <- bump ustk
@@ -149,7 +146,7 @@ exec _      !env !denv !ustk !bstk !k (BPrim2 EQLU i j) = do
         | otherwise = error $ "exec: unknown combinator: " ++ show w
   tag t | Just r <- EC.lookup t (tagRefs env) = r
         | otherwise = error $ "exec: unknown data: " ++ show t
-exec _      !env !denv !ustk !bstk !k (BPrim2 CMPU i j) = do
+exec !env !denv !ustk !bstk !k (BPrim2 CMPU i j) = do
   x <- peekOff bstk i
   y <- peekOff bstk j
   ustk <- bump ustk
@@ -160,57 +157,57 @@ exec _      !env !denv !ustk !bstk !k (BPrim2 CMPU i j) = do
         | otherwise = error $ "exec: unknown combinator: " ++ show w
   tag t | Just r <- EC.lookup t (tagRefs env) = r
         | otherwise = error $ "exec: unknown data: " ++ show t
-exec _      !_   !denv !ustk !bstk !k (BPrim2 op i j) = do
+exec !_   !denv !ustk !bstk !k (BPrim2 op i j) = do
   (ustk,bstk) <- bprim2 ustk bstk op i j
   pure (denv, ustk, bstk, k)
-exec _      !_   !denv !ustk !bstk !k (Pack t args) = do
+exec !_   !denv !ustk !bstk !k (Pack t args) = do
   clo <- buildData ustk bstk t args
   bstk <- bump bstk
   poke bstk clo
   pure (denv, ustk, bstk, k)
-exec _      !_   !denv !ustk !bstk !k (Unpack i) = do
+exec !_   !denv !ustk !bstk !k (Unpack i) = do
   (ustk, bstk) <- dumpData ustk bstk =<< peekOff bstk i
   pure (denv, ustk, bstk, k)
-exec _      !_   !denv !ustk !bstk !k (Print i) = do
+exec !_   !denv !ustk !bstk !k (Print i) = do
   t <- peekOffBi bstk i
   Tx.putStrLn t
   pure (denv, ustk, bstk, k)
-exec _      !_   !denv !ustk !bstk !k (Lit (MI n)) = do
+exec !_   !denv !ustk !bstk !k (Lit (MI n)) = do
   ustk <- bump ustk
   poke ustk n
   pure (denv, ustk, bstk, k)
-exec _      !_   !denv !ustk !bstk !k (Lit (MD d)) = do
+exec !_   !denv !ustk !bstk !k (Lit (MD d)) = do
   ustk <- bump ustk
   pokeD ustk d
   pure (denv, ustk, bstk, k)
-exec _      !_   !denv !ustk !bstk !k (Lit (MT t)) = do
+exec !_   !denv !ustk !bstk !k (Lit (MT t)) = do
   bstk <- bump bstk
   poke bstk (Foreign (Wrap Rf.textRef t))
   pure (denv, ustk, bstk, k)
-exec _      !_   !denv !ustk !bstk !k (Lit (MM r)) = do
+exec !_   !denv !ustk !bstk !k (Lit (MM r)) = do
   bstk <- bump bstk
   poke bstk (Foreign (Wrap Rf.termLinkRef r))
   pure (denv, ustk, bstk, k)
-exec _      !_   !denv !ustk !bstk !k (Lit (MY r)) = do
+exec !_   !denv !ustk !bstk !k (Lit (MY r)) = do
   bstk <- bump bstk
   poke bstk (Foreign (Wrap Rf.typeLinkRef r))
   pure (denv, ustk, bstk, k)
-exec _      !_   !denv !ustk !bstk !k (Reset ps) = do
+exec !_   !denv !ustk !bstk !k (Reset ps) = do
   pure (denv, ustk, bstk, Mark ps clos k)
  where clos = EC.restrictKeys denv ps
-exec _      !_   !denv !ustk !bstk !k (Seq as) = do
+exec !_   !denv !ustk !bstk !k (Seq as) = do
   l <- closureArgs bstk as
   bstk <- bump bstk
   pokeS bstk $ Sq.fromList l
   pure (denv, ustk, bstk, k)
-exec unmask !env !denv !ustk !bstk !k (ForeignCall _ w args)
+exec !env !denv !ustk !bstk !k (ForeignCall _ w args)
   | Just (FF arg res ev) <- EC.lookup w (foreignFuncs env)
   = uncurry (denv,,,k) <$>
-      unmask (arg ustk bstk args >>= ev >>= res ustk bstk)
+      (arg ustk bstk args >>= ev >>= res ustk bstk)
   | otherwise
   = die $ "reference to unknown foreign function: " ++ show w
-exec unmask !env !denv !ustk !bstk !k (Fork i) = do
-  tid <- unmask . forkEval env =<< peekOff bstk i
+exec !env !denv !ustk !bstk !k (Fork i) = do
+  tid <- forkEval env =<< peekOff bstk i
   bstk <- bump bstk
   poke bstk . Foreign . Wrap Rf.threadIdReference $ tid
   pure (denv, ustk, bstk, k)
@@ -219,46 +216,46 @@ exec unmask !env !denv !ustk !bstk !k (Fork i) = do
 maskTag :: Word64 -> Word64
 maskTag i = i .&. 0xFFFF
 
-eval :: Unmask -> SEnv -> DEnv
+eval :: SEnv -> DEnv
      -> Stack 'UN -> Stack 'BX -> K -> Section -> IO ()
-eval unmask !env !denv !ustk !bstk !k (Match i (TestT df cs)) = do
+eval !env !denv !ustk !bstk !k (Match i (TestT df cs)) = do
   t <- peekOffBi bstk i
-  eval unmask env denv ustk bstk k $ selectTextBranch t df cs
-eval unmask !env !denv !ustk !bstk !k (Match i br) = do
+  eval env denv ustk bstk k $ selectTextBranch t df cs
+eval !env !denv !ustk !bstk !k (Match i br) = do
   n <- peekOffN ustk i
-  eval unmask env denv ustk bstk k $ selectBranch n br
-eval unmask !env !denv !ustk !bstk !k (Yield args)
+  eval env denv ustk bstk k $ selectBranch n br
+eval !env !denv !ustk !bstk !k (Yield args)
   | asize ustk + asize bstk > 0 , BArg1 i <- args = do
-    peekOff bstk i >>= apply unmask env denv ustk bstk k False ZArgs
+    peekOff bstk i >>= apply env denv ustk bstk k False ZArgs
   | otherwise = do
     (ustk, bstk) <- moveArgs ustk bstk args
     ustk <- frameArgs ustk
     bstk <- frameArgs bstk
-    yield unmask env denv ustk bstk k
-eval unmask !env !denv !ustk !bstk !k (App ck r args) =
+    yield env denv ustk bstk k
+eval !env !denv !ustk !bstk !k (App ck r args) =
   resolve env denv bstk r
-    >>= apply unmask env denv ustk bstk k ck args
-eval unmask !env !denv !ustk !bstk !k (Call ck n args)
+    >>= apply env denv ustk bstk k ck args
+eval !env !denv !ustk !bstk !k (Call ck n args)
   | Just cmb <- EC.lookup n (combs env)
-  = enter unmask env denv ustk bstk k ck args cmb
+  = enter env denv ustk bstk k ck args cmb
   | otherwise = die $ "eval: unknown combinator: " ++ show n
-eval unmask !env !denv !ustk !bstk !k (Jump i args) =
-  peekOff bstk i >>= jump unmask env denv ustk bstk k args
-eval unmask !env !denv !ustk !bstk !k (Let nw nx) = do
+eval !env !denv !ustk !bstk !k (Jump i args) =
+  peekOff bstk i >>= jump env denv ustk bstk k args
+eval !env !denv !ustk !bstk !k (Let nw nx) = do
   (ustk, ufsz, uasz) <- saveFrame ustk
   (bstk, bfsz, basz) <- saveFrame bstk
-  eval unmask env denv ustk bstk (Push ufsz bfsz uasz basz nx k) nw
-eval unmask !env !denv !ustk !bstk !k (Ins i nx) = do
-  (denv, ustk, bstk, k) <- exec unmask env denv ustk bstk k i
-  eval unmask env denv ustk bstk k nx
-eval _      !_   !_    !_    !_    !_ Exit = pure ()
-eval _      !_   !_    !_    !_    !_ (Die s) = die s
+  eval env denv ustk bstk (Push ufsz bfsz uasz basz nx k) nw
+eval !env !denv !ustk !bstk !k (Ins i nx) = do
+  (denv, ustk, bstk, k) <- exec env denv ustk bstk k i
+  eval env denv ustk bstk k nx
+eval !_   !_    !_    !_    !_ Exit = pure ()
+eval !_   !_    !_    !_    !_ (Die s) = die s
 {-# noinline eval #-}
 
 forkEval :: SEnv -> Closure -> IO ThreadId
 forkEval env clo
   = forkIOWithUnmask $ \unmask ->
-      unmask (apply1 err unmask env clo) `catch` \case
+      unmask (apply1 err env clo) `catch` \case
         PE e -> putStrLn "runtime exception"
              >> print (Pr.render 70 e)
         BU _ -> putStrLn $ "unison exception reached top level"
@@ -272,15 +269,15 @@ forkEval env clo
 
 -- fast path application
 enter
-  :: Unmask -> SEnv -> DEnv -> Stack 'UN -> Stack 'BX -> K
+  :: SEnv -> DEnv -> Stack 'UN -> Stack 'BX -> K
   -> Bool -> Args -> Comb -> IO ()
-enter unmask !env !denv !ustk !bstk !k !ck !args !comb = do
+enter !env !denv !ustk !bstk !k !ck !args !comb = do
   ustk <- if ck then ensure ustk uf else pure ustk
   bstk <- if ck then ensure bstk bf else pure bstk
   (ustk, bstk) <- moveArgs ustk bstk args
   ustk <- acceptArgs ustk ua
   bstk <- acceptArgs bstk ba
-  eval unmask env denv ustk bstk k entry
+  eval env denv ustk bstk k entry
   where
   Lam ua ba uf bf entry = comb
 {-# inline enter #-}
@@ -298,9 +295,9 @@ name !ustk !bstk !args clo = case clo of
 
 -- slow path application
 apply
-  :: Unmask -> SEnv -> DEnv -> Stack 'UN -> Stack 'BX -> K
+  :: SEnv -> DEnv -> Stack 'UN -> Stack 'BX -> K
   -> Bool -> Args -> Closure -> IO ()
-apply unmask !env !denv !ustk !bstk !k !ck !args clo = case clo of
+apply !env !denv !ustk !bstk !k !ck !args clo = case clo of
   PAp comb@(Lam_ ua ba uf bf entry) useg bseg
     | ck || ua <= uac && ba <= bac -> do
       ustk <- ensure ustk uf
@@ -310,14 +307,14 @@ apply unmask !env !denv !ustk !bstk !k !ck !args clo = case clo of
       bstk <- dumpSeg bstk bseg A
       ustk <- acceptArgs ustk ua
       bstk <- acceptArgs bstk ba
-      eval unmask env denv ustk bstk k entry
+      eval env denv ustk bstk k entry
     | otherwise -> do
       (useg, bseg) <- closeArgs C ustk bstk useg bseg args
       ustk <- discardFrame =<< frameArgs ustk
       bstk <- discardFrame =<< frameArgs bstk
       bstk <- bump bstk
       poke bstk $ PAp comb useg bseg
-      yield unmask env denv ustk bstk k
+      yield env denv ustk bstk k
    where
    uac = asize ustk + ucount args + uscount useg
    bac = asize bstk + bcount args + bscount bseg
@@ -326,31 +323,31 @@ apply unmask !env !denv !ustk !bstk !k !ck !args clo = case clo of
         bstk <- discardFrame bstk
         bstk <- bump bstk
         poke bstk clo
-        yield unmask env denv ustk bstk k
+        yield env denv ustk bstk k
       | otherwise -> die $ "applying non-function: " ++ show clo
 {-# inline apply #-}
 
 jump
-  :: Unmask -> SEnv -> DEnv
+  :: SEnv -> DEnv
   -> Stack 'UN -> Stack 'BX -> K
   -> Args -> Closure -> IO ()
-jump unmask !env !denv !ustk !bstk !k !args clo = case clo of
+jump !env !denv !ustk !bstk !k !args clo = case clo of
   Captured sk useg bseg -> do
     (useg, bseg) <- closeArgs K ustk bstk useg bseg args
     ustk <- discardFrame ustk
     bstk <- discardFrame bstk
     ustk <- dumpSeg ustk useg . F $ ucount args
     bstk <- dumpSeg bstk bseg . F $ bcount args
-    repush unmask env ustk bstk denv sk k
+    repush env ustk bstk denv sk k
   _ -> die "jump: non-cont"
 {-# inline jump #-}
 
 repush
-  :: Unmask -> SEnv
+  :: SEnv
   -> Stack 'UN -> Stack 'BX -> DEnv -> K -> K -> IO ()
-repush unmask !env !ustk !bstk = go
+repush !env !ustk !bstk = go
  where
- go !denv KE !k = yield unmask env denv ustk bstk k
+ go !denv KE !k = yield env denv ustk bstk k
  go !denv (Mark ps cs sk) !k = go denv' sk $ Mark ps cs' k
   where
   denv' = cs <> EC.withoutKeys denv ps
@@ -1200,19 +1197,19 @@ bprim2 !ustk !bstk CMPU _ _ = pure (ustk, bstk) -- impossible
 {-# inline bprim2 #-}
 
 yield
-  :: Unmask -> SEnv -> DEnv
+  :: SEnv -> DEnv
   -> Stack 'UN -> Stack 'BX -> K -> IO ()
-yield unmask !env !denv !ustk !bstk !k = leap denv k
+yield !env !denv !ustk !bstk !k = leap denv k
  where
  leap !denv0 (Mark ps cs k) = do
    let denv = cs <> EC.withoutKeys denv0 ps
        clo = denv0 EC.! EC.findMin ps
    poke bstk . DataB1 0 =<< peek bstk
-   apply unmask env denv ustk bstk k False (BArg1 0) clo
+   apply env denv ustk bstk k False (BArg1 0) clo
  leap !denv (Push ufsz bfsz uasz basz nx k) = do
    ustk <- restoreFrame ustk ufsz uasz
    bstk <- restoreFrame bstk bfsz basz
-   eval unmask env denv ustk bstk k nx
+   eval env denv ustk bstk k nx
  leap _ (CB (Hook f)) = f ustk bstk
  leap _ KE = pure ()
 {-# inline yield #-}

--- a/unison-src/transcripts/alias-many.output.md
+++ b/unison-src/transcripts/alias-many.output.md
@@ -227,7 +227,9 @@ Let's try it!
   204. io2.IO.isSeekable : Handle ->{IO} Either IOError Boolean
   205. io2.IO.kill : ThreadId ->{IO} Either IOError ()
   206. io2.IO.listen : Socket ->{IO} Either IOError ()
-  207. io2.IO.openFile : Text ->{IO} Either IOError Handle
+  207. io2.IO.openFile : Text
+                         -> FileMode
+                         ->{IO} Either IOError Handle
   208. io2.IO.putText : Handle -> Text ->{IO} Either IOError ()
   209. io2.IO.removeDirectory : Text ->{IO} Either IOError ()
   210. io2.IO.removeFile : Text ->{IO} Either IOError ()
@@ -236,7 +238,7 @@ Let's try it!
                                 ->{IO} Either IOError ()
   212. io2.IO.renameFile : Text -> Text ->{IO} Either IOError ()
   213. io2.IO.seekHandle : Handle
-                           -> FileMode
+                           -> SeekMode
                            -> Int
                            ->{IO} Either IOError ()
   214. io2.IO.serverSocket : Text
@@ -276,13 +278,17 @@ Let's try it!
   239. io2.MVar.tryPut : MVar a -> a ->{IO} Boolean
   240. io2.MVar.tryRead : MVar a ->{IO} Optional a
   241. io2.MVar.tryTake : MVar a ->{IO} Optional a
-  242. builtin type io2.Socket
-  243. unique type io2.StdHandle
-  244. io2.StdHandle.StdErr : StdHandle
-  245. io2.StdHandle.StdIn : StdHandle
-  246. io2.StdHandle.StdOut : StdHandle
-  247. builtin type io2.ThreadId
-  248. todo : a -> b
+  242. unique type io2.SeekMode
+  243. io2.SeekMode.AbsoluteSeek : SeekMode
+  244. io2.SeekMode.RelativeSeek : SeekMode
+  245. io2.SeekMode.SeekFromEnd : SeekMode
+  246. builtin type io2.Socket
+  247. unique type io2.StdHandle
+  248. io2.StdHandle.StdErr : StdHandle
+  249. io2.StdHandle.StdIn : StdHandle
+  250. io2.StdHandle.StdOut : StdHandle
+  251. builtin type io2.ThreadId
+  252. todo : a -> b
   
 
 .builtin> alias.many 94-104 .mylib

--- a/unison-src/transcripts/alias-many.output.md
+++ b/unison-src/transcripts/alias-many.output.md
@@ -211,8 +211,7 @@ Let's try it!
   189. io2.IO.createDirectory : Text ->{IO} Either IOError ()
   190. io2.IO.delay : Nat ->{IO} Either IOError ()
   191. io2.IO.fileExists : Text ->{IO} Either IOError Boolean
-  192. io2.IO.forkComp : '{IO} Either IOError a
-                         ->{IO} Either IOError ThreadId
+  192. io2.IO.forkComp : '{IO} Either IOError a ->{IO} ThreadId
   193. io2.IO.getBuffering : Handle
                              ->{IO} Either IOError BufferMode
   194. io2.IO.getCurrentDirectory : '{IO} Either IOError Text
@@ -255,7 +254,7 @@ Let's try it!
   219. io2.IO.socketSend : Socket
                            -> Bytes
                            ->{IO} Either IOError ()
-  220. io2.IO.stdHandle : Nat -> Optional Handle
+  220. io2.IO.stdHandle : StdHandle -> Handle
   221. io2.IO.systemTime : '{IO} Either IOError Nat
   222. unique type io2.IOError
   223. io2.IOError.AlreadyExists : IOError
@@ -278,8 +277,12 @@ Let's try it!
   240. io2.MVar.tryRead : MVar a ->{IO} Optional a
   241. io2.MVar.tryTake : MVar a ->{IO} Optional a
   242. builtin type io2.Socket
-  243. builtin type io2.ThreadId
-  244. todo : a -> b
+  243. unique type io2.StdHandle
+  244. io2.StdHandle.StdErr : StdHandle
+  245. io2.StdHandle.StdIn : StdHandle
+  246. io2.StdHandle.StdOut : StdHandle
+  247. builtin type io2.ThreadId
+  248. todo : a -> b
   
 
 .builtin> alias.many 94-104 .mylib

--- a/unison-src/transcripts/builtins-merge.output.md
+++ b/unison-src/transcripts/builtins-merge.output.md
@@ -44,7 +44,7 @@ The `builtins.merge` command adds the known builtins to a `builtin` subnamespace
   33. Unit/      (1 definition)
   34. Universal/ (6 definitions)
   35. bug        (a -> b)
-  36. io2/       (70 definitions)
+  36. io2/       (74 definitions)
   37. todo       (a -> b)
 
 ```

--- a/unison-src/transcripts/builtins-merge.output.md
+++ b/unison-src/transcripts/builtins-merge.output.md
@@ -44,7 +44,7 @@ The `builtins.merge` command adds the known builtins to a `builtin` subnamespace
   33. Unit/      (1 definition)
   34. Universal/ (6 definitions)
   35. bug        (a -> b)
-  36. io2/       (74 definitions)
+  36. io2/       (78 definitions)
   37. todo       (a -> b)
 
 ```

--- a/unison-src/transcripts/emptyCodebase.output.md
+++ b/unison-src/transcripts/emptyCodebase.output.md
@@ -23,7 +23,7 @@ Technically, the definitions all exist, but they have no names. `builtins.merge`
 
 .foo> ls
 
-  1. builtin/ (248 definitions)
+  1. builtin/ (252 definitions)
 
 ```
 And for a limited time, you can get even more builtin goodies:
@@ -35,7 +35,7 @@ And for a limited time, you can get even more builtin goodies:
 
 .foo> ls
 
-  1. builtin/ (411 definitions)
+  1. builtin/ (415 definitions)
 
 ```
 More typically, you'd start out by pulling `base.

--- a/unison-src/transcripts/emptyCodebase.output.md
+++ b/unison-src/transcripts/emptyCodebase.output.md
@@ -23,7 +23,7 @@ Technically, the definitions all exist, but they have no names. `builtins.merge`
 
 .foo> ls
 
-  1. builtin/ (244 definitions)
+  1. builtin/ (248 definitions)
 
 ```
 And for a limited time, you can get even more builtin goodies:
@@ -35,7 +35,7 @@ And for a limited time, you can get even more builtin goodies:
 
 .foo> ls
 
-  1. builtin/ (407 definitions)
+  1. builtin/ (411 definitions)
 
 ```
 More typically, you'd start out by pulling `base.

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -112,13 +112,13 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #ntbr7f6ppm
+  ⊙ #0njtem0mcm
   
     - Deletes:
     
       feature1.y
   
-  ⊙ #0h6am45pvd
+  ⊙ #itl1uomklh
   
     + Adds / updates:
     
@@ -129,26 +129,26 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
       Original name New name(s)
       feature1.y    master.y
   
-  ⊙ #5l1bo7srpn
+  ⊙ #94tplgq85t
   
     + Adds / updates:
     
       feature1.y
   
-  ⊙ #2c0uj33ads
+  ⊙ #fr2k0al9mk
   
     > Moves:
     
       Original name New name
       x             master.x
   
-  ⊙ #m85pufflci
+  ⊙ #p8dvir508b
   
     + Adds / updates:
     
       x
   
-  ⊙ #i4g24av44u
+  ⊙ #bc44avko8b
   
     + Adds / updates:
     
@@ -257,10 +257,12 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
       builtin.io2.MVar.read builtin.io2.MVar.swap
       builtin.io2.MVar.take builtin.io2.MVar.tryPut
       builtin.io2.MVar.tryRead builtin.io2.MVar.tryTake
-      builtin.io2.Socket builtin.io2.StdHandle
-      builtin.io2.StdHandle.StdErr builtin.io2.StdHandle.StdIn
-      builtin.io2.StdHandle.StdOut builtin.io2.ThreadId
-      builtin.todo
+      builtin.io2.SeekMode builtin.io2.SeekMode.AbsoluteSeek
+      builtin.io2.SeekMode.RelativeSeek
+      builtin.io2.SeekMode.SeekFromEnd builtin.io2.Socket
+      builtin.io2.StdHandle builtin.io2.StdHandle.StdErr
+      builtin.io2.StdHandle.StdIn builtin.io2.StdHandle.StdOut
+      builtin.io2.ThreadId builtin.todo
   
   □ #7asfbtqmoj (start of history)
 

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -112,13 +112,13 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #bof7ljhk4e
+  ⊙ #ntbr7f6ppm
   
     - Deletes:
     
       feature1.y
   
-  ⊙ #f10e7ivnt7
+  ⊙ #0h6am45pvd
   
     + Adds / updates:
     
@@ -129,26 +129,26 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
       Original name New name(s)
       feature1.y    master.y
   
-  ⊙ #ckoq0pumq4
+  ⊙ #5l1bo7srpn
   
     + Adds / updates:
     
       feature1.y
   
-  ⊙ #hjs0h1o8po
+  ⊙ #2c0uj33ads
   
     > Moves:
     
       Original name New name
       x             master.x
   
-  ⊙ #qhckem9e6s
+  ⊙ #m85pufflci
   
     + Adds / updates:
     
       x
   
-  ⊙ #7v5brelc5r
+  ⊙ #i4g24av44u
   
     + Adds / updates:
     
@@ -257,7 +257,10 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
       builtin.io2.MVar.read builtin.io2.MVar.swap
       builtin.io2.MVar.take builtin.io2.MVar.tryPut
       builtin.io2.MVar.tryRead builtin.io2.MVar.tryTake
-      builtin.io2.Socket builtin.io2.ThreadId builtin.todo
+      builtin.io2.Socket builtin.io2.StdHandle
+      builtin.io2.StdHandle.StdErr builtin.io2.StdHandle.StdIn
+      builtin.io2.StdHandle.StdOut builtin.io2.ThreadId
+      builtin.todo
   
   □ #7asfbtqmoj (start of history)
 

--- a/unison-src/transcripts/reflog.output.md
+++ b/unison-src/transcripts/reflog.output.md
@@ -59,16 +59,16 @@ y = 2
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #02v51724u1 .old`   to make an old namespace
+    `fork #pf8v7pjo52 .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #02v51724u1`  to reset the root namespace and
+    `reset-root #pf8v7pjo52`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
-  1. #98g5co2hlc : add
-  2. #02v51724u1 : add
-  3. #7v5brelc5r : builtins.merge
+  1. #bmi9gocpjf : add
+  2. #pf8v7pjo52 : add
+  3. #i4g24av44u : builtins.merge
   4. #7asfbtqmoj : (initial reflogged namespace)
 
 ```

--- a/unison-src/transcripts/reflog.output.md
+++ b/unison-src/transcripts/reflog.output.md
@@ -59,16 +59,16 @@ y = 2
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #pf8v7pjo52 .old`   to make an old namespace
+    `fork #g7jr88lour .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #pf8v7pjo52`  to reset the root namespace and
+    `reset-root #g7jr88lour`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
-  1. #bmi9gocpjf : add
-  2. #pf8v7pjo52 : add
-  3. #i4g24av44u : builtins.merge
+  1. #2shti04k63 : add
+  2. #g7jr88lour : add
+  3. #bc44avko8b : builtins.merge
   4. #7asfbtqmoj : (initial reflogged namespace)
 
 ```

--- a/unison-src/transcripts/squash.output.md
+++ b/unison-src/transcripts/squash.output.md
@@ -13,7 +13,7 @@ Let's look at some examples. We'll start with a namespace with just the builtins
   
   
   
-  □ #ph82ki1r6t (start of history)
+  □ #0v288ov4go (start of history)
 
 .> fork builtin builtin2
 
@@ -42,21 +42,21 @@ Now suppose we `fork` a copy of builtin, then rename `Nat.+` to `frobnicate`, th
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #0m45ccf7re
+  ⊙ #c1segmmn41
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ #5ntoo4d3qh
+  ⊙ #i373k09mj9
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ #ph82ki1r6t (start of history)
+  □ #0v288ov4go (start of history)
 
 ```
 If we merge that back into `builtin`, we get that same chain of history:
@@ -71,21 +71,21 @@ If we merge that back into `builtin`, we get that same chain of history:
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #0m45ccf7re
+  ⊙ #c1segmmn41
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ #5ntoo4d3qh
+  ⊙ #i373k09mj9
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ #ph82ki1r6t (start of history)
+  □ #0v288ov4go (start of history)
 
 ```
 Let's try again, but using a `merge.squash` (or just `squash`) instead. The history will be unchanged:
@@ -106,7 +106,7 @@ Let's try again, but using a `merge.squash` (or just `squash`) instead. The hist
   
   
   
-  □ #ph82ki1r6t (start of history)
+  □ #0v288ov4go (start of history)
 
 ```
 The churn that happened in `mybuiltin` namespace ended up back in the same spot, so the squash merge of that namespace with our original namespace had no effect.

--- a/unison-src/transcripts/squash.output.md
+++ b/unison-src/transcripts/squash.output.md
@@ -13,7 +13,7 @@ Let's look at some examples. We'll start with a namespace with just the builtins
   
   
   
-  □ #0v288ov4go (start of history)
+  □ #k8copc0k4o (start of history)
 
 .> fork builtin builtin2
 
@@ -42,21 +42,21 @@ Now suppose we `fork` a copy of builtin, then rename `Nat.+` to `frobnicate`, th
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #c1segmmn41
+  ⊙ #0t5ab1tch1
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ #i373k09mj9
+  ⊙ #tdsaupr80g
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ #0v288ov4go (start of history)
+  □ #k8copc0k4o (start of history)
 
 ```
 If we merge that back into `builtin`, we get that same chain of history:
@@ -71,21 +71,21 @@ If we merge that back into `builtin`, we get that same chain of history:
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #c1segmmn41
+  ⊙ #0t5ab1tch1
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ #i373k09mj9
+  ⊙ #tdsaupr80g
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ #0v288ov4go (start of history)
+  □ #k8copc0k4o (start of history)
 
 ```
 Let's try again, but using a `merge.squash` (or just `squash`) instead. The history will be unchanged:
@@ -106,7 +106,7 @@ Let's try again, but using a `merge.squash` (or just `squash`) instead. The hist
   
   
   
-  □ #0v288ov4go (start of history)
+  □ #k8copc0k4o (start of history)
 
 ```
 The churn that happened in `mybuiltin` namespace ended up back in the same spot, so the squash merge of that namespace with our original namespace had no effect.


### PR DESCRIPTION
This is a pull request to rework some of the new builtin IO related stuff.

- Fork was broken in multiple ways, but it was difficult to test when it was written. Now it should work.
- An enumeration type `StdHandle` has been added to serve as the argument of `stdHandle`, so that it can't be called with incorrect arguments, and doesn't need to return an optional result.

Those are the user facing changes. Some additional implementation details are as follows:
- One of the ways that fork was broken was that it was trying to manipulate the stack in a complicated way, with the assumption that an IO handler was at the bottom, and that it might be running arbitrary code that accessed the current 'frame'. This has been completely eliminated, and now it just creates new stacks to run a closure in, which is much simpler.
- I've also removed a bunch of mask/unmask stuff from the runtime. At the time it was written, I thought maybe it was appropriate to only unmask at points where exceptions could be caught and explicitly returned, but I think we actually only mediate synchronous exceptions into unison anyway. So it was just adding complication and dubious behavior.

It might be good not to merge this immediately, since maybe Stew will have some additional feedback or find additional bugs now that fork can actually be used. Or that could just be a separate merge. Either way is fine with me.