### PR TITLE
(Stalled) Allow deleting multiple terms at once

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -410,9 +410,9 @@ loop = do
           MoveBranchI src dest -> "move.namespace " <> ops' src <> " " <> ps' dest
           MovePatchI src dest -> "move.patch " <> ps' src <> " " <> ps' dest
           CopyPatchI src dest -> "copy.patch " <> ps' src <> " " <> ps' dest
-          DeleteI thing -> "delete " <> hqs' thing
-          DeleteTermI def -> "delete.term " <> hqs' def
-          DeleteTypeI def -> "delete.type " <> hqs' def
+          DeleteI things -> "delete " <> intercalateMap " " hqs' things
+          DeleteTermI defs -> "delete.term " <> intercalateMap " " hqs' defs
+          DeleteTypeI defs -> "delete.type " <> intercalateMap " " hqs' defs
           DeleteBranchI opath -> "delete.namespace " <> ops' opath
           DeletePatchI path -> "delete.patch " <> ps' path
           ReplaceTermI src target p ->
@@ -1111,9 +1111,9 @@ loop = do
         p = resolveSplit' (HQ'.toName <$> src)
         mdSrc r = BranchUtil.getTypeMetadataAt p r root0
 
-      DeleteI     hq -> delete getHQ'Terms       getHQ'Types       hq
-      DeleteTypeI hq -> delete (const Set.empty) getHQ'Types       hq
-      DeleteTermI hq -> delete getHQ'Terms       (const Set.empty) hq
+      DeleteI     hqs -> traverse_ (delete getHQ'Terms       getHQ'Types)       hqs
+      DeleteTypeI hqs -> traverse_ (delete (const Set.empty) getHQ'Types)       hqs
+      DeleteTermI hqs -> traverse_ (delete getHQ'Terms       (const Set.empty)) hqs
 
       DisplayI outputLoc hq -> do
         parseNames0 <- (`Names3.Names` mempty) <$> basicPrettyPrintNames0

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -74,9 +74,9 @@ data Input
     | MovePatchI Path.Split' Path.Split'
     | CopyPatchI Path.Split' Path.Split'
     -- delete = unname
-    | DeleteI Path.HQSplit'
-    | DeleteTermI Path.HQSplit'
-    | DeleteTypeI Path.HQSplit'
+    | DeleteI [Path.HQSplit']
+    | DeleteTermI [Path.HQSplit']
+    | DeleteTypeI [Path.HQSplit']
     | DeleteBranchI (Maybe Path.Split')
     | DeletePatchI Path.Split'
     -- resolving naming conflicts within `branchpath`

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -412,11 +412,11 @@ delete = InputPattern "delete" []
     [(OnePlus, definitionQueryArg)]
     "`delete foo` removes the term or type name `foo` from the namespace."
     (\case
-      [query] -> first fromString $ do
-        p <- Path.parseHQSplit' query
-        pure $ Input.DeleteI p
-      _ -> Left . P.warnCallout $ P.wrap
-        "`delete` takes an argument, like `delete name`."
+      [] -> Left . P.warnCallout $ P.wrap
+        "`delete` takes one or more arguments, like `delete name`."
+      queries -> first fromString $ do
+        ps <- traverse Path.parseHQSplit' queries
+        pure $ Input.DeleteI ps
     )
 
 deleteTerm :: InputPattern
@@ -424,11 +424,11 @@ deleteTerm = InputPattern "delete.term" []
     [(OnePlus, exactDefinitionTermQueryArg)]
     "`delete.term foo` removes the term name `foo` from the namespace."
     (\case
-      [query] -> first fromString $ do
-        p <- Path.parseHQSplit' query
-        pure $ Input.DeleteTermI p
-      _ -> Left . P.warnCallout $ P.wrap
-        "`delete.term` takes an argument, like `delete.term name`."
+      [] -> Left . P.warnCallout $ P.wrap
+        "`delete.term` takes one or more arguments, like `delete.term name`."
+      queries -> first fromString $ do
+        ps <- traverse Path.parseHQSplit' queries
+        pure $ Input.DeleteTermI ps
     )
 
 deleteType :: InputPattern
@@ -436,11 +436,11 @@ deleteType = InputPattern "delete.type" []
     [(OnePlus, exactDefinitionTypeQueryArg)]
     "`delete.type foo` removes the type name `foo` from the namespace."
     (\case
-      [query] -> first fromString $ do
-        p <- Path.parseHQSplit' query
-        pure $ Input.DeleteTypeI p
-      _ -> Left . P.warnCallout $ P.wrap
-        "`delete.type` takes an argument, like `delete.type name`."
+      [] -> Left . P.warnCallout $ P.wrap
+        "`delete.type` takes one or more arguments, like `delete.type name`."
+      queries -> first fromString $ do
+        ps <- traverse Path.parseHQSplit' queries
+        pure $ Input.DeleteTypeI ps
     )
 
 deleteTermReplacementCommand :: String


### PR DESCRIPTION
## Overview

Currently, it's not possible to delete multiple things in a single command:
```
  I found and typechecked these definitions in scratch.u. If you do an `add` or `update`,
  here's how your codebase would change:

    ⍟ These new definitions are ok to `add`:

      x : Nat
      y : Nat
      z : Nat -> Nat

.> add

  ⍟ I've added these definitions:

    x : Nat
    y : Nat
    z : Nat -> Nat

.> delete x y z

  ⚠️

  `delete` takes an argument, like `delete name`.
```

This will allow the delete command, as well as delete.term and delete.type, to take multiple arguments.

Closes: #1526 

## Interesting/controversial decisions

Calls `delete` from `Editor.HandleInput` once for each listed name, producing an `Output` for each. @aryairani mentioned in slack: 

> I might write a new version of delete that takes multiple HQSplit' in the 3rd argument, but produces only a single Output to the user [..]

I don't understand the implementation well enough to do so myself.

It also seems like this approach results in n entries to the reflog. This seems bad, right? I'm assuming we'd want just one?

```
.> reflog

  Here is a log of the root namespace hashes, starting with the most recent, along with
  the command that got us there. Try:

    `fork 2 .old`
    `fork #dqc1cae8re .old`   to make an old namespace accessible again,

    `reset-root #dqc1cae8re`  to reset the root namespace and its history to that of the
                              specified namespace.

  1. #cqe5netvov : delete ..x ..y ..z
  2. #dqc1cae8re : delete ..x ..y ..z
  3. #p3rtchrcmj : delete ..x ..y ..z
  4. #8jfd8nkas1 : add
  5. #lqs21dco5d : pull https://github.com/unisonweb/base:.releases._latest .base
  6. #7asfbtqmoj : (initial reflogged namespace)

.>
```

## Test coverage

### todo

## Loose ends

Yes
### todo