### PR TITLE
Create CREDITS.md

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,179 @@
+# Credits
+
+Unison is open source (see [LICENSE](./LICENSE))
+and is the work of [many excellent contributors](./CONTRIBUTORS.markdown).
+
+Unison also depends on open source software written by others.
+Below we list all transitive dependencies of Unison,
+with links to each project and its license.
+
+A big thank you to everyone who has helped build the ecosystem
+that Unison relies on! 🙏
+
+If you notice any broken links or know of a dependency that should
+be listed here, please [file a ticket](https://github.com/unisonweb/unison/issues/new/choose).
+
+This file was generated using [unisonweb/credits-generator](http://github.com/unisonweb/credits-generator).
+
+### Listing 
+These are listed in alphabetical order.
+
+| Package name | License  |
+| ------------ | -------- |
+| [Cabal-3.0.1.0](https://hackage.haskell.org/package/Cabal-3.0.1.0) | [BSD3](https://hackage.haskell.org/package/Cabal-3.0.1.0/src/LICENSE) |
+| [ListLike-4.6.3](https://hackage.haskell.org/package/ListLike-4.6.3) | [BSD3](https://hackage.haskell.org/package/ListLike-4.6.3/src/COPYRIGHT) |
+| [QuickCheck-2.13.2](https://hackage.haskell.org/package/QuickCheck-2.13.2) | [BSD3](https://hackage.haskell.org/package/QuickCheck-2.13.2/src/LICENSE) |
+| [StateVar-1.2](https://hackage.haskell.org/package/StateVar-1.2) | [BSD3](https://hackage.haskell.org/package/StateVar-1.2/src/LICENSE) |
+| [adjunctions-4.4](https://hackage.haskell.org/package/adjunctions-4.4) | [BSD3](https://hackage.haskell.org/package/adjunctions-4.4/src/LICENSE) |
+| [aeson-1.4.7.1](https://hackage.haskell.org/package/aeson-1.4.7.1) | [BSD3](https://hackage.haskell.org/package/aeson-1.4.7.1/src/LICENSE) |
+| [ansi-terminal-0.10.3](https://hackage.haskell.org/package/ansi-terminal-0.10.3) | [BSD3](https://hackage.haskell.org/package/ansi-terminal-0.10.3/src/LICENSE) |
+| [array-0.5.4.0](https://hackage.haskell.org/package/array-0.5.4.0) | [BSD3](https://hackage.haskell.org/package/array-0.5.4.0/src/LICENSE) |
+| [assoc-1.0.1](https://hackage.haskell.org/package/assoc-1.0.1) | [BSD3](https://hackage.haskell.org/package/assoc-1.0.1/src/LICENSE) |
+| [async-2.2.2](https://hackage.haskell.org/package/async-2.2.2) | [BSD3](https://hackage.haskell.org/package/async-2.2.2/src/LICENSE) |
+| [attoparsec-0.13.2.4](https://hackage.haskell.org/package/attoparsec-0.13.2.4) | [BSD3](https://hackage.haskell.org/package/attoparsec-0.13.2.4/src/LICENSE) |
+| [base-4.13.0.0](https://hackage.haskell.org/package/base-4.13.0.0) | [BSD3](https://hackage.haskell.org/package/base-4.13.0.0/src/LICENSE) |
+| [base-compat-0.11.1](https://hackage.haskell.org/package/base-compat-0.11.1) | [MIT](https://hackage.haskell.org/package/base-compat-0.11.1/src/LICENSE) |
+| [base-compat-batteries-0.11.1](https://hackage.haskell.org/package/base-compat-batteries-0.11.1) | [MIT](https://hackage.haskell.org/package/base-compat-batteries-0.11.1/src/LICENSE) |
+| [base-orphans-0.8.2](https://hackage.haskell.org/package/base-orphans-0.8.2) | [MIT](https://hackage.haskell.org/package/base-orphans-0.8.2/src/LICENSE) |
+| [base16-0.2.1.0](https://hackage.haskell.org/package/base16-0.2.1.0) | [BSD3](https://hackage.haskell.org/package/base16-0.2.1.0/src/LICENSE) |
+| [basement-0.0.11](https://hackage.haskell.org/package/basement-0.0.11) | [BSD3](https://hackage.haskell.org/package/basement-0.0.11/src/LICENSE) |
+| [bifunctors-5.5.7](https://hackage.haskell.org/package/bifunctors-5.5.7) | [BSD3](https://hackage.haskell.org/package/bifunctors-5.5.7/src/LICENSE) |
+| [binary-0.8.7.0](https://hackage.haskell.org/package/binary-0.8.7.0) | [BSD3](https://hackage.haskell.org/package/binary-0.8.7.0/src/LICENSE) |
+| [binary-orphans-1.0.1](https://hackage.haskell.org/package/binary-orphans-1.0.1) | [BSD3](https://hackage.haskell.org/package/binary-orphans-1.0.1/src/LICENSE) |
+| [bytes-0.17](https://hackage.haskell.org/package/bytes-0.17) | [BSD3](https://hackage.haskell.org/package/bytes-0.17/src/LICENSE) |
+| [bytestring-0.10.10.0](https://hackage.haskell.org/package/bytestring-0.10.10.0) | [BSD3](https://hackage.haskell.org/package/bytestring-0.10.10.0/src/LICENSE) |
+| [bytestring-builder-0.10.8.2.0](https://hackage.haskell.org/package/bytestring-builder-0.10.8.2.0) | [BSD3](https://hackage.haskell.org/package/bytestring-builder-0.10.8.2.0/src/LICENSE) |
+| [cabal-doctest-1.0.8](https://hackage.haskell.org/package/cabal-doctest-1.0.8) | [BSD3](https://hackage.haskell.org/package/cabal-doctest-1.0.8/src/LICENSE) |
+| [call-stack-0.2.0](https://hackage.haskell.org/package/call-stack-0.2.0) | [MIT](https://hackage.haskell.org/package/call-stack-0.2.0/src/LICENSE) |
+| [case-insensitive-1.2.1.0](https://hackage.haskell.org/package/case-insensitive-1.2.1.0) | [BSD3](https://hackage.haskell.org/package/case-insensitive-1.2.1.0/src/LICENSE) |
+| [cereal-0.5.8.1](https://hackage.haskell.org/package/cereal-0.5.8.1) | [BSD3](https://hackage.haskell.org/package/cereal-0.5.8.1/src/LICENSE) |
+| [clock-0.8](https://hackage.haskell.org/package/clock-0.8) | [BSD3](https://hackage.haskell.org/package/clock-0.8/src/LICENSE) |
+| [colour-2.3.5](https://hackage.haskell.org/package/colour-2.3.5) | [MIT](https://hackage.haskell.org/package/colour-2.3.5/src/LICENSE) |
+| [comonad-5.0.6](https://hackage.haskell.org/package/comonad-5.0.6) | [BSD3](https://hackage.haskell.org/package/comonad-5.0.6/src/LICENSE) |
+| [concurrent-supply-0.1.8](https://hackage.haskell.org/package/concurrent-supply-0.1.8) | [BSD3](https://hackage.haskell.org/package/concurrent-supply-0.1.8/src/LICENSE) |
+| [conduit-1.3.2](https://hackage.haskell.org/package/conduit-1.3.2) | [MIT](https://hackage.haskell.org/package/conduit-1.3.2/src/LICENSE) |
+| [configurator-0.3.0.0](https://hackage.haskell.org/package/configurator-0.3.0.0) | [BSD3](https://hackage.haskell.org/package/configurator-0.3.0.0/src/LICENSE) |
+| [containers-0.6.2.1](https://hackage.haskell.org/package/containers-0.6.2.1) | [BSD3](https://hackage.haskell.org/package/containers-0.6.2.1/src/LICENSE) |
+| [contravariant-1.5.2](https://hackage.haskell.org/package/contravariant-1.5.2) | [BSD3](https://hackage.haskell.org/package/contravariant-1.5.2/src/LICENSE) |
+| [cryptohash-md5-0.11.100.1](https://hackage.haskell.org/package/cryptohash-md5-0.11.100.1) | [BSD3](https://hackage.haskell.org/package/cryptohash-md5-0.11.100.1/src/LICENSE) |
+| [cryptohash-sha1-0.11.100.1](https://hackage.haskell.org/package/cryptohash-sha1-0.11.100.1) | [BSD3](https://hackage.haskell.org/package/cryptohash-sha1-0.11.100.1/src/LICENSE) |
+| [cryptonite-0.26](https://hackage.haskell.org/package/cryptonite-0.26) | [BSD3](https://hackage.haskell.org/package/cryptonite-0.26/src/LICENSE) |
+| [data-inttrie-0.1.4](https://hackage.haskell.org/package/data-inttrie-0.1.4) | [BSD3](https://hackage.haskell.org/package/data-inttrie-0.1.4/src/LICENSE) |
+| [data-memocombinators-0.5.1](https://hackage.haskell.org/package/data-memocombinators-0.5.1) | [BSD3](https://hackage.haskell.org/package/data-memocombinators-0.5.1/src/LICENSE) |
+| [deepseq-1.4.4.0](https://hackage.haskell.org/package/deepseq-1.4.4.0) | [BSD3](https://hackage.haskell.org/package/deepseq-1.4.4.0/src/LICENSE) |
+| [directory-1.3.6.0](https://hackage.haskell.org/package/directory-1.3.6.0) | [BSD3](https://hackage.haskell.org/package/directory-1.3.6.0/src/LICENSE) |
+| [distributive-0.6.2](https://hackage.haskell.org/package/distributive-0.6.2) | [BSD3](https://hackage.haskell.org/package/distributive-0.6.2/src/LICENSE) |
+| [dlist-0.8.0.8](https://hackage.haskell.org/package/dlist-0.8.0.8) | [BSD3](https://hackage.haskell.org/package/dlist-0.8.0.8/src/LICENSE) |
+| [easytest-0.1](https://hackage.haskell.org/package/easytest-0.1) | [MIT](https://hackage.haskell.org/package/easytest-0.1/src/LICENSE) |
+| [edit-distance-0.2.2.1](https://hackage.haskell.org/package/edit-distance-0.2.2.1) | [BSD3](https://hackage.haskell.org/package/edit-distance-0.2.2.1/src/LICENSE) |
+| [either-5.0.1.1](https://hackage.haskell.org/package/either-5.0.1.1) | [BSD3](https://hackage.haskell.org/package/either-5.0.1.1/src/LICENSE) |
+| [entropy-0.4.1.6](https://hackage.haskell.org/package/entropy-0.4.1.6) | [BSD3](https://hackage.haskell.org/package/entropy-0.4.1.6/src/LICENSE) |
+| [errors-2.3.0](https://hackage.haskell.org/package/errors-2.3.0) | [BSD3](https://hackage.haskell.org/package/errors-2.3.0/src/LICENSE) |
+| [exceptions-0.10.4](https://hackage.haskell.org/package/exceptions-0.10.4) | [BSD3](https://hackage.haskell.org/package/exceptions-0.10.4/src/LICENSE) |
+| [extra-1.6.21](https://hackage.haskell.org/package/extra-1.6.21) | [BSD3](https://hackage.haskell.org/package/extra-1.6.21/src/LICENSE) |
+| [filemanip-0.3.6.3](https://hackage.haskell.org/package/filemanip-0.3.6.3) | [BSD3](https://hackage.haskell.org/package/filemanip-0.3.6.3/src/LICENSE) |
+| [filepath-1.4.2.1](https://hackage.haskell.org/package/filepath-1.4.2.1) | [BSD3](https://hackage.haskell.org/package/filepath-1.4.2.1/src/LICENSE) |
+| [filepattern-0.1.2](https://hackage.haskell.org/package/filepattern-0.1.2) | [BSD3](https://hackage.haskell.org/package/filepattern-0.1.2/src/LICENSE) |
+| [fingertree-0.1.4.2](https://hackage.haskell.org/package/fingertree-0.1.4.2) | [BSD3](https://hackage.haskell.org/package/fingertree-0.1.4.2/src/LICENSE) |
+| [fmlist-0.9.3](https://hackage.haskell.org/package/fmlist-0.9.3) | [BSD3](https://hackage.haskell.org/package/fmlist-0.9.3/src/LICENSE) |
+| [free-5.1.3](https://hackage.haskell.org/package/free-5.1.3) | [BSD3](https://hackage.haskell.org/package/free-5.1.3/src/LICENSE) |
+| [fsnotify-0.3.0.1](https://hackage.haskell.org/package/fsnotify-0.3.0.1) | [BSD3](https://hackage.haskell.org/package/fsnotify-0.3.0.1/src/LICENSE) |
+| [generic-monoid-0.1.0.0](https://hackage.haskell.org/package/generic-monoid-0.1.0.0) | [BSD3](https://hackage.haskell.org/package/generic-monoid-0.1.0.0/src/LICENSE) |
+| [ghc-boot-th-8.8.3](https://hackage.haskell.org/package/ghc-boot-th-8.8.3) | [BSD3](https://hackage.haskell.org/package/ghc-boot-th-8.8.3/src/LICENSE) |
+| [ghc-prim-0.5.3](https://hackage.haskell.org/package/ghc-prim-0.5.3) | [BSD3](https://hackage.haskell.org/package/ghc-prim-0.5.3/src/LICENSE) |
+| [guid-0.1.0](https://hackage.haskell.org/package/guid-0.1.0) | [MIT](https://hackage.haskell.org/package/guid-0.1.0/src/LICENSE) |
+| [happy-1.19.12](https://hackage.haskell.org/package/happy-1.19.12) | [BSD2](https://hackage.haskell.org/package/happy-1.19.12/src/LICENSE) |
+| [hashable-1.3.0.0](https://hackage.haskell.org/package/hashable-1.3.0.0) | [BSD3](https://hackage.haskell.org/package/hashable-1.3.0.0/src/LICENSE) |
+| [hashtables-1.2.3.4](https://hackage.haskell.org/package/hashtables-1.2.3.4) | [BSD3](https://hackage.haskell.org/package/hashtables-1.2.3.4/src/LICENSE) |
+| [haskeline-0.7.5.0](https://hackage.haskell.org/package/haskeline-0.7.5.0) | [BSD3](https://hackage.haskell.org/package/haskeline-0.7.5.0/src/LICENSE) |
+| [haskell-src-exts-1.22.0](https://hackage.haskell.org/package/haskell-src-exts-1.22.0) | [BSD3](https://hackage.haskell.org/package/haskell-src-exts-1.22.0/src/LICENSE) |
+| [haskell-src-meta-0.8.5](https://hackage.haskell.org/package/haskell-src-meta-0.8.5) | [BSD3](https://hackage.haskell.org/package/haskell-src-meta-0.8.5/src/LICENSE) |
+| [here-1.2.13](https://hackage.haskell.org/package/here-1.2.13) | [BSD3](https://hackage.haskell.org/package/here-1.2.13/src/LICENSE) |
+| [hfsevents-0.1.6](https://hackage.haskell.org/package/hfsevents-0.1.6) | [BSD3](https://hackage.haskell.org/package/hfsevents-0.1.6/src/LICENSE) |
+| [integer-gmp-1.0.2.0](https://hackage.haskell.org/package/integer-gmp-1.0.2.0) | [BSD3](https://hackage.haskell.org/package/integer-gmp-1.0.2.0/src/LICENSE) |
+| [integer-logarithms-1.0.3](https://hackage.haskell.org/package/integer-logarithms-1.0.3) | [MIT](https://hackage.haskell.org/package/integer-logarithms-1.0.3/src/LICENSE) |
+| [invariant-0.5.3](https://hackage.haskell.org/package/invariant-0.5.3) | [BSD2](https://hackage.haskell.org/package/invariant-0.5.3/src/LICENSE) |
+| [io-streams-1.5.1.0](https://hackage.haskell.org/package/io-streams-1.5.1.0) | [BSD3](https://hackage.haskell.org/package/io-streams-1.5.1.0/src/LICENSE) |
+| [kan-extensions-5.2](https://hackage.haskell.org/package/kan-extensions-5.2) | [BSD3](https://hackage.haskell.org/package/kan-extensions-5.2/src/LICENSE) |
+| [lens-4.18.1](https://hackage.haskell.org/package/lens-4.18.1) | [BSD2](https://hackage.haskell.org/package/lens-4.18.1/src/LICENSE) |
+| [markdown-unlit-0.5.0](https://hackage.haskell.org/package/markdown-unlit-0.5.0) | [MIT](https://hackage.haskell.org/package/markdown-unlit-0.5.0/src/LICENSE) |
+| [megaparsec-6.5.0](https://hackage.haskell.org/package/megaparsec-6.5.0) | [BSD2](https://hackage.haskell.org/package/megaparsec-6.5.0/src/LICENSE) |
+| [memory-0.15.0](https://hackage.haskell.org/package/memory-0.15.0) | [BSD3](https://hackage.haskell.org/package/memory-0.15.0/src/LICENSE) |
+| [mmorph-1.1.3](https://hackage.haskell.org/package/mmorph-1.1.3) | [BSD3](https://hackage.haskell.org/package/mmorph-1.1.3/src/LICENSE) |
+| [monad-loops-0.4.3](https://hackage.haskell.org/package/monad-loops-0.4.3) | [PublicDomain](https://hackage.haskell.org/package/monad-loops-0.4.3/src/LICENSE) |
+| [mono-traversable-1.0.15.1](https://hackage.haskell.org/package/mono-traversable-1.0.15.1) | [MIT](https://hackage.haskell.org/package/mono-traversable-1.0.15.1/src/LICENSE) |
+| [mtl-2.2.2](https://hackage.haskell.org/package/mtl-2.2.2) | [BSD3](https://hackage.haskell.org/package/mtl-2.2.2/src/LICENSE) |
+| [murmur-hash-0.1.0.9](https://hackage.haskell.org/package/murmur-hash-0.1.0.9) | [BSD3](https://hackage.haskell.org/package/murmur-hash-0.1.0.9/src/LICENSE) |
+| [mutable-containers-0.3.4](https://hackage.haskell.org/package/mutable-containers-0.3.4) | [MIT](https://hackage.haskell.org/package/mutable-containers-0.3.4/src/LICENSE) |
+| [network-3.1.1.1](https://hackage.haskell.org/package/network-3.1.1.1) | [BSD3](https://hackage.haskell.org/package/network-3.1.1.1/src/LICENSE) |
+| [network-bsd-2.8.1.0](https://hackage.haskell.org/package/network-bsd-2.8.1.0) | [BSD3](https://hackage.haskell.org/package/network-bsd-2.8.1.0/src/LICENSE) |
+| [network-info-0.2.0.10](https://hackage.haskell.org/package/network-info-0.2.0.10) | [BSD3](https://hackage.haskell.org/package/network-info-0.2.0.10/src/LICENSE) |
+| [network-simple-0.4.5](https://hackage.haskell.org/package/network-simple-0.4.5) | [BSD3](https://hackage.haskell.org/package/network-simple-0.4.5/src/LICENSE) |
+| [nonempty-containers-0.3.3.0](https://hackage.haskell.org/package/nonempty-containers-0.3.3.0) | [BSD3](https://hackage.haskell.org/package/nonempty-containers-0.3.3.0/src/LICENSE) |
+| [nonempty-vector-0.2.0.2](https://hackage.haskell.org/package/nonempty-vector-0.2.0.2) | [BSD3](https://hackage.haskell.org/package/nonempty-vector-0.2.0.2/src/LICENSE) |
+| [parallel-3.2.2.0](https://hackage.haskell.org/package/parallel-3.2.2.0) | [BSD3](https://hackage.haskell.org/package/parallel-3.2.2.0/src/LICENSE) |
+| [parsec-3.1.14.0](https://hackage.haskell.org/package/parsec-3.1.14.0) | [BSD3](https://hackage.haskell.org/package/parsec-3.1.14.0/src/LICENSE) |
+| [parser-combinators-1.2.1](https://hackage.haskell.org/package/parser-combinators-1.2.1) | [BSD3](https://hackage.haskell.org/package/parser-combinators-1.2.1/src/LICENSE) |
+| [prelude-extras-0.4.0.3](https://hackage.haskell.org/package/prelude-extras-0.4.0.3) | [BSD3](https://hackage.haskell.org/package/prelude-extras-0.4.0.3/src/LICENSE) |
+| [pretty-1.1.3.6](https://hackage.haskell.org/package/pretty-1.1.3.6) | [BSD3](https://hackage.haskell.org/package/pretty-1.1.3.6/src/LICENSE) |
+| [primitive-0.7.0.1](https://hackage.haskell.org/package/primitive-0.7.0.1) | [BSD3](https://hackage.haskell.org/package/primitive-0.7.0.1/src/LICENSE) |
+| [process-1.6.8.0](https://hackage.haskell.org/package/process-1.6.8.0) | [BSD3](https://hackage.haskell.org/package/process-1.6.8.0/src/LICENSE) |
+| [profunctors-5.5.2](https://hackage.haskell.org/package/profunctors-5.5.2) | [BSD3](https://hackage.haskell.org/package/profunctors-5.5.2/src/LICENSE) |
+| [random-1.1](https://hackage.haskell.org/package/random-1.1) | [BSD3](https://hackage.haskell.org/package/random-1.1/src/LICENSE) |
+| [raw-strings-qq-1.1](https://hackage.haskell.org/package/raw-strings-qq-1.1) | [BSD3](https://hackage.haskell.org/package/raw-strings-qq-1.1/src/LICENSE) |
+| [reflection-2.1.6](https://hackage.haskell.org/package/reflection-2.1.6) | [BSD3](https://hackage.haskell.org/package/reflection-2.1.6/src/LICENSE) |
+| [regex-base-0.94.0.0](https://hackage.haskell.org/package/regex-base-0.94.0.0) | [BSD3](https://hackage.haskell.org/package/regex-base-0.94.0.0/src/LICENSE) |
+| [regex-tdfa-1.3.1.0](https://hackage.haskell.org/package/regex-tdfa-1.3.1.0) | [BSD3](https://hackage.haskell.org/package/regex-tdfa-1.3.1.0/src/LICENSE) |
+| [resourcet-1.2.4](https://hackage.haskell.org/package/resourcet-1.2.4) | [BSD3](https://hackage.haskell.org/package/resourcet-1.2.4/src/LICENSE) |
+| [rfc5051-0.1.0.4](https://hackage.haskell.org/package/rfc5051-0.1.0.4) | [BSD3](https://hackage.haskell.org/package/rfc5051-0.1.0.4/src/LICENSE) |
+| [rts-1.0](https://hackage.haskell.org/package/rts-1.0) | [BSD3](https://hackage.haskell.org/package/rts-1.0/src/LICENSE) |
+| [safe-0.3.19](https://hackage.haskell.org/package/safe-0.3.19) | [BSD3](https://hackage.haskell.org/package/safe-0.3.19/src/LICENSE) |
+| [safe-exceptions-0.1.7.0](https://hackage.haskell.org/package/safe-exceptions-0.1.7.0) | [MIT](https://hackage.haskell.org/package/safe-exceptions-0.1.7.0/src/LICENSE) |
+| [sandi-0.5](https://hackage.haskell.org/package/sandi-0.5) | [BSD3](https://hackage.haskell.org/package/sandi-0.5/src/LICENSE) |
+| [scientific-0.3.6.2](https://hackage.haskell.org/package/scientific-0.3.6.2) | [BSD3](https://hackage.haskell.org/package/scientific-0.3.6.2/src/LICENSE) |
+| [semigroupoids-5.3.4](https://hackage.haskell.org/package/semigroupoids-5.3.4) | [BSD3](https://hackage.haskell.org/package/semigroupoids-5.3.4/src/LICENSE) |
+| [semigroups-0.19.1](https://hackage.haskell.org/package/semigroups-0.19.1) | [BSD3](https://hackage.haskell.org/package/semigroups-0.19.1/src/LICENSE) |
+| [shellmet-0.0.3.1](https://hackage.haskell.org/package/shellmet-0.0.3.1) | [MPL-2.0](https://hackage.haskell.org/package/shellmet-0.0.3.1/src/LICENSE) |
+| [socks-0.6.1](https://hackage.haskell.org/package/socks-0.6.1) | [BSD3](https://hackage.haskell.org/package/socks-0.6.1/src/LICENSE) |
+| [split-0.2.3.4](https://hackage.haskell.org/package/split-0.2.3.4) | [BSD3](https://hackage.haskell.org/package/split-0.2.3.4/src/LICENSE) |
+| [splitmix-0.0.5](https://hackage.haskell.org/package/splitmix-0.0.5) | [BSD3](https://hackage.haskell.org/package/splitmix-0.0.5/src/LICENSE) |
+| [stm-2.5.0.0](https://hackage.haskell.org/package/stm-2.5.0.0) | [BSD3](https://hackage.haskell.org/package/stm-2.5.0.0/src/LICENSE) |
+| [strings-1.1](https://hackage.haskell.org/package/strings-1.1) | [MIT](https://hackage.haskell.org/package/strings-1.1/src/LICENSE) |
+| [syb-0.7.1](https://hackage.haskell.org/package/syb-0.7.1) | [BSD3](https://hackage.haskell.org/package/syb-0.7.1/src/LICENSE) |
+| [tagged-0.8.6](https://hackage.haskell.org/package/tagged-0.8.6) | [BSD3](https://hackage.haskell.org/package/tagged-0.8.6/src/LICENSE) |
+| [template-haskell-2.15.0.0](https://hackage.haskell.org/package/template-haskell-2.15.0.0) | [BSD3](https://hackage.haskell.org/package/template-haskell-2.15.0.0/src/LICENSE) |
+| [temporary-1.3](https://hackage.haskell.org/package/temporary-1.3) | [BSD3](https://hackage.haskell.org/package/temporary-1.3/src/LICENSE) |
+| [terminal-size-0.3.2.1](https://hackage.haskell.org/package/terminal-size-0.3.2.1) | [BSD3](https://hackage.haskell.org/package/terminal-size-0.3.2.1/src/LICENSE) |
+| [terminfo-0.4.1.4](https://hackage.haskell.org/package/terminfo-0.4.1.4) | [BSD3](https://hackage.haskell.org/package/terminfo-0.4.1.4/src/LICENSE) |
+| [text-1.2.4.0](https://hackage.haskell.org/package/text-1.2.4.0) | [BSD2](https://hackage.haskell.org/package/text-1.2.4.0/src/LICENSE) |
+| [text-short-0.1.3](https://hackage.haskell.org/package/text-short-0.1.3) | [BSD3](https://hackage.haskell.org/package/text-short-0.1.3/src/LICENSE) |
+| [th-abstraction-0.3.2.0](https://hackage.haskell.org/package/th-abstraction-0.3.2.0) | [ISC](https://hackage.haskell.org/package/th-abstraction-0.3.2.0/src/LICENSE) |
+| [th-expand-syns-0.4.6.0](https://hackage.haskell.org/package/th-expand-syns-0.4.6.0) | [BSD3](https://hackage.haskell.org/package/th-expand-syns-0.4.6.0/src/LICENSE) |
+| [th-lift-0.8.1](https://hackage.haskell.org/package/th-lift-0.8.1) | [BSD3](https://hackage.haskell.org/package/th-lift-0.8.1/src/LICENSE) |
+| [th-lift-instances-0.1.16](https://hackage.haskell.org/package/th-lift-instances-0.1.16) | [BSD3](https://hackage.haskell.org/package/th-lift-instances-0.1.16/src/LICENSE) |
+| [th-orphans-0.13.10](https://hackage.haskell.org/package/th-orphans-0.13.10) | [BSD3](https://hackage.haskell.org/package/th-orphans-0.13.10/src/LICENSE) |
+| [th-reify-many-0.1.9](https://hackage.haskell.org/package/th-reify-many-0.1.9) | [BSD3](https://hackage.haskell.org/package/th-reify-many-0.1.9/src/LICENSE) |
+| [these-1.0.1](https://hackage.haskell.org/package/these-1.0.1) | [BSD3](https://hackage.haskell.org/package/these-1.0.1/src/LICENSE) |
+| [time-1.9.3](https://hackage.haskell.org/package/time-1.9.3) | [BSD3](https://hackage.haskell.org/package/time-1.9.3/src/LICENSE) |
+| [time-compat-1.9.3](https://hackage.haskell.org/package/time-compat-1.9.3) | [BSD3](https://hackage.haskell.org/package/time-compat-1.9.3/src/LICENSE) |
+| [transformers-0.5.6.2](https://hackage.haskell.org/package/transformers-0.5.6.2) | [BSD3](https://hackage.haskell.org/package/transformers-0.5.6.2/src/LICENSE) |
+| [transformers-base-0.4.5.2](https://hackage.haskell.org/package/transformers-base-0.4.5.2) | [BSD3](https://hackage.haskell.org/package/transformers-base-0.4.5.2/src/LICENSE) |
+| [transformers-compat-0.6.5](https://hackage.haskell.org/package/transformers-compat-0.6.5) | [BSD3](https://hackage.haskell.org/package/transformers-compat-0.6.5/src/LICENSE) |
+| [type-equality-1](https://hackage.haskell.org/package/type-equality-1) | [BSD3](https://hackage.haskell.org/package/type-equality-1/src/LICENSE) |
+| [unicode-show-0.1.0.4](https://hackage.haskell.org/package/unicode-show-0.1.0.4) | [BSD3](https://hackage.haskell.org/package/unicode-show-0.1.0.4/src/LICENSE) |
+| [unison-core-0.1](https://hackage.haskell.org/package/unison-core-0.1) | [MIT](https://hackage.haskell.org/package/unison-core-0.1/src/LICENSE) |
+| [unison-parser-typechecker-0.1](https://hackage.haskell.org/package/unison-parser-typechecker-0.1) | [MIT](https://hackage.haskell.org/package/unison-parser-typechecker-0.1/src/LICENSE) |
+| [unix-2.7.2.2](https://hackage.haskell.org/package/unix-2.7.2.2) | [BSD3](https://hackage.haskell.org/package/unix-2.7.2.2/src/LICENSE) |
+| [unix-compat-0.5.2](https://hackage.haskell.org/package/unix-compat-0.5.2) | [BSD3](https://hackage.haskell.org/package/unix-compat-0.5.2/src/LICENSE) |
+| [unliftio-0.2.13](https://hackage.haskell.org/package/unliftio-0.2.13) | [MIT](https://hackage.haskell.org/package/unliftio-0.2.13/src/LICENSE) |
+| [unliftio-core-0.1.2.0](https://hackage.haskell.org/package/unliftio-core-0.1.2.0) | [MIT](https://hackage.haskell.org/package/unliftio-core-0.1.2.0/src/LICENSE) |
+| [unordered-containers-0.2.10.0](https://hackage.haskell.org/package/unordered-containers-0.2.10.0) | [BSD3](https://hackage.haskell.org/package/unordered-containers-0.2.10.0/src/LICENSE) |
+| [utf8-string-1.0.1.1](https://hackage.haskell.org/package/utf8-string-1.0.1.1) | [BSD3](https://hackage.haskell.org/package/utf8-string-1.0.1.1/src/LICENSE) |
+| [util-0.1.17.1](https://hackage.haskell.org/package/util-0.1.17.1) | [BSD3](https://hackage.haskell.org/package/util-0.1.17.1/src/LICENSE) |
+| [uuid-1.3.13](https://hackage.haskell.org/package/uuid-1.3.13) | [BSD3](https://hackage.haskell.org/package/uuid-1.3.13/src/LICENSE) |
+| [uuid-types-1.0.3](https://hackage.haskell.org/package/uuid-types-1.0.3) | [BSD3](https://hackage.haskell.org/package/uuid-types-1.0.3/src/LICENSE) |
+| [vector-0.12.1.2](https://hackage.haskell.org/package/vector-0.12.1.2) | [BSD3](https://hackage.haskell.org/package/vector-0.12.1.2/src/LICENSE) |
+| [vector-algorithms-0.8.0.3](https://hackage.haskell.org/package/vector-algorithms-0.8.0.3) | [BSD3](https://hackage.haskell.org/package/vector-algorithms-0.8.0.3/src/LICENSE) |
+| [void-0.7.3](https://hackage.haskell.org/package/void-0.7.3) | [BSD3](https://hackage.haskell.org/package/void-0.7.3/src/LICENSE) |
+| [zlib-0.6.2.1](https://hackage.haskell.org/package/zlib-0.6.2.1) | [BSD3](https://hackage.haskell.org/package/zlib-0.6.2.1/src/LICENSE) |
+| [zlib-bindings-0.1.1.5](https://hackage.haskell.org/package/zlib-bindings-0.1.1.5) | [BSD3](https://hackage.haskell.org/package/zlib-bindings-0.1.1.5/src/LICENSE) |


### PR DESCRIPTION
Added a [CREDITS.md](/unisonweb/unison/tree/topic/credits/CREDITS.md) file which lists all transitive dependencies of the project and their licenses. This is a nice way to recognize other work that Unison builds on and is I believe needed for proper attribution (as per the terms of the licenses of other open source code used by Unison).

The file is generated by a [(currently somewhat hacky) script](/unisonweb/credits-generator) that uses the [licensor package](https://hackage.haskell.org/package/licensor).