### PR TITLE
Calculate runtime builtin types from other modules

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -11,6 +11,7 @@ module Unison.Builtin
   ,builtinEffectDecls
   ,builtinConstructorType
   ,builtinTypeDependents
+  ,builtinTypes
   ,builtinTermsByType
   ,builtinTermsByTypeMention
   ,intrinsicTermReferences

--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -30,6 +30,7 @@ import Unison.Runtime.Foreign.Function
 import Unison.Runtime.IOSource
 
 import qualified Unison.Type as Ty
+import qualified Unison.Builtin as Ty (builtinTypes)
 import qualified Unison.Builtin.Decls as Ty
 
 import Unison.Util.EnumContainers as EC
@@ -1405,25 +1406,11 @@ hostPreference Nothing = SYS.HostAny
 hostPreference (Just host) = SYS.Host $ Text.unpack host
 
 typeReferences :: [(Reference, RTag)]
-typeReferences
-  = zip
-  [ Ty.natRef
-  , Ty.optionalRef
-  , Ty.unitRef
-  , Ty.pairRef
-  , Ty.booleanRef
-  , Ty.intRef
-  , Ty.floatRef
-  , Ty.booleanRef
-  , Ty.textRef
-  , Ty.charRef
-  , eitherReference
-  , filePathReference
-  , bufferModeReference
-  , Ty.effectRef
-  , Ty.vectorRef
-  , Ty.seqViewRef
-  ] [1..]
+typeReferences = zip rs [1..]
+  where
+  rs = [ r | (_,r) <- Ty.builtinTypes ]
+    ++ [ DerivedId i | (_,i,_) <- Ty.builtinDataDecls @Symbol ]
+    ++ [ DerivedId i | (_,i,_) <- Ty.builtinEffectDecls @Symbol ]
 
 foreignDeclResults
   :: Var v


### PR DESCRIPTION
This makes it so that yet another list doesn't need to be updated in `Unison.Runtime.Builtin` every time something is added.

Some types had already been forgotten.