### PR TITLE
make conversion from Text to Bytes explicit 

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -371,7 +371,7 @@ builtinsSrc =
   , B "Text.toCharList" $ text --> list char
   , B "Text.fromCharList" $ list char --> text
   , B "Text.toUtf8" $ text --> bytes
-  , B "Text.tryFromUtf8" $ bytes --> eithert text text
+  , B "Text.fromUtf8" $ bytes --> eithert text text
 
   , B "Char.toNat" $ char --> nat
   , B "Char.fromNat" $ nat --> char
@@ -391,7 +391,7 @@ builtinsSrc =
       you are doing with the bytes is dumping them to a file or a
       network socket.
 
-      You can always `Text.tryFromUtf8` the results of these functions
+      You can always `Text.fromUtf8` the results of these functions
       to get some `Text`.
     -}
   , B "Bytes.toBase16" $ bytes --> bytes

--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -367,9 +367,10 @@ builtinsSrc =
   , B "Text.>" $ text --> text --> boolean
   , B "Text.uncons" $ text --> optionalt (tuple [char, text])
   , B "Text.unsnoc" $ text --> optionalt (tuple [text, char])
-
   , B "Text.toCharList" $ text --> list char
   , B "Text.fromCharList" $ list char --> text
+  , B "Text.toUtf8" $ text --> bytes
+  , B "Text.tryFromUtf8" $ bytes --> eithert text text
 
   , B "Char.toNat" $ char --> nat
   , B "Char.fromNat" $ nat --> char
@@ -422,8 +423,8 @@ ioBuiltins =
   , ("IO.getBuffering", handle --> ioe bmode)
   , ("IO.setBuffering", handle --> bmode --> ioe unit)
   , ("IO.getLine", handle --> ioe text)
-  , ("IO.getText", handle --> ioe text)
-  , ("IO.putText", handle --> text --> ioe unit)
+  , ("IO.getBytes", handle --> nat --> ioe text)
+  , ("IO.putBytes", handle --> bytes --> ioe unit)
   , ("IO.systemTime", unit --> ioe nat)
   , ("IO.getTempDirectory", unit --> ioe text)
   , ("IO.getCurrentDirectory", unit --> ioe text)
@@ -482,6 +483,9 @@ list arg = Type.vector () `app` arg
 
 optionalt :: Ord v => Type v -> Type v
 optionalt arg = DD.optionalType () `app` arg
+
+eithert :: Ord v => Type v -> Type v -> Type v
+eithert l r = DD.eitherType () `app` l `app` r
 
 tuple :: Ord v => [Type v] -> Type v
 tuple [t] = t

--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -1438,7 +1438,7 @@ declareForeigns = do
     . mkForeign $ \(mv :: MVar Closure) -> tryReadMVar mv
 
   declareForeign "Text.toUtf8" pfopb . mkForeign $ pure . Bytes.fromArray . encodeUtf8
-  declareForeign "Text.tryFromUtf8" pfopb_ebb . mkForeign $ pure . mapLeft (pack . show) . decodeUtf8' . Bytes.toArray
+  declareForeign "Text.fromUtf8" pfopb_ebb . mkForeign $ pure . mapLeft (pack . show) . decodeUtf8' . Bytes.toArray
 
   -- Hashing functions
   let declareHashAlgorithm :: forall v alg . Var v => Hash.HashAlgorithm alg => Text -> alg -> FDecl v ()

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -190,6 +190,7 @@ library
     configurator,
     cryptonite,
     directory,
+    either,
     guid,
     data-memocombinators,
     edit-distance,

--- a/unison-src/new-runtime-transcripts/hashing.md
+++ b/unison-src/new-runtime-transcripts/hashing.md
@@ -15,7 +15,7 @@ You can skip this section, which is just needed to make the transcript self-cont
 .builtin> ls Bytes
 ```
 
-Notice the `fromBase16` and `toBase16` functions. Here's some (somewhat inefficient) convenience functions for converting `Bytes` to and from base-16 `Text`. These could be replaced by use of `Text.toUtf8` and `Text.tryFromUtf8`.
+Notice the `fromBase16` and `toBase16` functions. Here's some (somewhat inefficient) convenience functions for converting `Bytes` to and from base-16 `Text`. These could be replaced by use of `Text.toUtf8` and `Text.fromUtf8`.
 
 ```unison:hide
 a |> f = f a

--- a/unison-src/new-runtime-transcripts/hashing.md
+++ b/unison-src/new-runtime-transcripts/hashing.md
@@ -47,18 +47,18 @@ check b = if b then [Result.Ok "Passed."]
 Here's a few usage examples:
 
 ```unison
-ex1 = toUtf8 "2947db"
+ex1 = Bytes.fromList [41, 71, 219]
         |> crypto.hashBytes Sha3_512
         |> hex
 
-ex2 = toUtf8 "02f3ab"
+ex2 = Bytes.fromList [2, 243, 171]
         |> crypto.hashBytes Blake2b_256
         |> hex
 
 mysecret : Bytes
-mysecret = toUtf8 "237be2"
+mysecret = Bytes.fromList [35, 123, 226]
 
-ex3 = toUtf8 "50d3ab"
+ex3 = Bytes.fromList [80, 211, 171]
         |> crypto.hmacBytes Sha2_256 mysecret
         |> hex
 

--- a/unison-src/new-runtime-transcripts/hashing.md
+++ b/unison-src/new-runtime-transcripts/hashing.md
@@ -15,7 +15,7 @@ You can skip this section, which is just needed to make the transcript self-cont
 .builtin> ls Bytes
 ```
 
-Notice the `fromBase16` and `toBase16` functions. Here's some (somewhat inefficient) convenience functions for converting `Bytes` to and from base-16 `Text`. These could be replaced by use of `Text.toUtf8` and `Text.tryFromUtf8` once those builtins exist:
+Notice the `fromBase16` and `toBase16` functions. Here's some (somewhat inefficient) convenience functions for converting `Bytes` to and from base-16 `Text`. These could be replaced by use of `Text.toUtf8` and `Text.tryFromUtf8`.
 
 ```unison:hide
 a |> f = f a

--- a/unison-src/new-runtime-transcripts/hashing.output.md
+++ b/unison-src/new-runtime-transcripts/hashing.output.md
@@ -56,18 +56,18 @@ check b = if b then [Result.Ok "Passed."]
 Here's a few usage examples:
 
 ```unison
-ex1 = toUtf8 "2947db"
+ex1 = Bytes.fromList [41, 71, 219]
         |> crypto.hashBytes Sha3_512
         |> hex
 
-ex2 = toUtf8 "02f3ab"
+ex2 = Bytes.fromList [2, 243, 171]
         |> crypto.hashBytes Blake2b_256
         |> hex
 
 mysecret : Bytes
-mysecret = toUtf8 "237be2"
+mysecret = Bytes.fromList [35, 123, 226]
 
-ex3 = toUtf8 "50d3ab"
+ex3 = Bytes.fromList [80, 211, 171]
         |> crypto.hmacBytes Sha2_256 mysecret
         |> hex
 
@@ -94,15 +94,15 @@ ex3 = toUtf8 "50d3ab"
 
     16 | > ex1
            ⧩
-           "fe09ff8ec1f14508f4c8dfce68ad21fc62492ea5698cdd6bf0df92f1cc8f5e2ee011b0653aa7775395724051e57e6e08217b2c5e05a0e1c894baa69ae6109f16"
+           "f3c342040674c50ab45cb1874b6dbc81447af5958201ed4127e03b56725664d7cc44b88b9afadb371898fcaf5d0adeff60837ef93b514f99da43539d79820c99"
   
     17 | > ex2
            ⧩
-           "a9d3ac6df178e4b4f59be8a36c30e8ff91b4fa04c766560ada002683d3013c59"
+           "84bb437497f26fc33c51e57e64c37958c3918d50dfe75b91c661a85c2f8f8304"
   
     18 | > ex3
            ⧩
-           "f453d8343a7a33730a1bd2b84e826ec957e8a91074a2370f3d56770d5846990b"
+           "c692fc54df921f7fa51aad9178327c5a097784b02212d571fb40facdfff881fd"
 
 ```
 And here's the full API:

--- a/unison-src/new-runtime-transcripts/hashing.output.md
+++ b/unison-src/new-runtime-transcripts/hashing.output.md
@@ -28,7 +28,7 @@ You can skip this section, which is just needed to make the transcript self-cont
   17. toList                (Bytes -> [Nat])
 
 ```
-Notice the `fromBase16` and `toBase16` functions. Here's some (somewhat inefficient) convenience functions for converting `Bytes` to and from base-16 `Text`. These could be replaced by use of `Text.toUtf8` and `Text.tryFromUtf8`.
+Notice the `fromBase16` and `toBase16` functions. Here's some (somewhat inefficient) convenience functions for converting `Bytes` to and from base-16 `Text`. These could be replaced by use of `Text.toUtf8` and `Text.fromUtf8`.
 
 ```unison
 a |> f = f a

--- a/unison-src/new-runtime-transcripts/hashing.output.md
+++ b/unison-src/new-runtime-transcripts/hashing.output.md
@@ -28,7 +28,7 @@ You can skip this section, which is just needed to make the transcript self-cont
   17. toList                (Bytes -> [Nat])
 
 ```
-Notice the `fromBase16` and `toBase16` functions. Here's some (somewhat inefficient) convenience functions for converting `Bytes` to and from base-16 `Text`. These could be replaced by use of `Text.toUtf8` and `Text.tryFromUtf8` once those builtins exist:
+Notice the `fromBase16` and `toBase16` functions. Here's some (somewhat inefficient) convenience functions for converting `Bytes` to and from base-16 `Text`. These could be replaced by use of `Text.toUtf8` and `Text.tryFromUtf8`.
 
 ```unison
 a |> f = f a

--- a/unison-src/new-runtime-transcripts/utf8.md
+++ b/unison-src/new-runtime-transcripts/utf8.md
@@ -36,7 +36,7 @@ We can check that encoding and then decoding should give us back the same `Text`
 checkRoundTrip: Text -> [Result]
 checkRoundTrip t = 
   bytes = toUtf8 t
-  match tryFromUtf8 bytes with 
+  match fromUtf8 bytes with 
     Left e -> [Result.Fail "could not decode"]
     Right t' -> if t == t' then [Result.Ok "Passed"] else [Result.Fail ("Got: " ++ t' ++ " Expected: " ++ t)]
 
@@ -52,6 +52,6 @@ greek_bytes = Bytes.fromList [206, 145, 206, 146, 206, 147, 206, 148, 206]
 
 
 -- Its an error if we drop the first byte
-> tryFromUtf8 (drop 1 greek_bytes)
+> fromUtf8 (drop 1 greek_bytes)
 
 ```

--- a/unison-src/new-runtime-transcripts/utf8.md
+++ b/unison-src/new-runtime-transcripts/utf8.md
@@ -1,0 +1,57 @@
+Test for new Text -> Bytes conversions explicitly using UTF-8 as the encoding
+
+```ucm:hide
+.> builtins.merge
+.> cd builtin
+```
+
+Unison has function for converting between `Text` and a UTF-8 `Bytes` encoding of the Text.
+
+```ucm
+.> find Utf8
+```
+
+ascii characters are encoded as single bytes (in the range 0-127).
+
+```unison
+ascii: Text
+ascii = "ABCDE"
+
+> toUtf8 ascii
+
+```
+
+non-ascii characters are encoded as multiple bytes.
+
+```unison
+greek: Text
+greek = "ΑΒΓΔΕ"
+
+> toUtf8 greek
+```
+
+We can check that encoding and then decoding should give us back the same `Text` we started with 
+
+```unison
+checkRoundTrip: Text -> [Result]
+checkRoundTrip t = 
+  bytes = toUtf8 t
+  match tryFromUtf8 bytes with 
+    Left e -> [Result.Fail "could not decode"]
+    Right t' -> if t == t' then [Result.Ok "Passed"] else [Result.Fail ("Got: " ++ t' ++ " Expected: " ++ t)]
+
+greek = "ΑΒΓΔΕ"
+
+test> checkRoundTrip greek
+```
+
+If we try to decode an invalid set of bytes, we get back `Text` explaining the decoding error:
+
+```unison
+greek_bytes = Bytes.fromList [206, 145, 206, 146, 206, 147, 206, 148, 206]
+
+
+-- Its an error if we drop the first byte
+> tryFromUtf8 (drop 1 greek_bytes)
+
+```

--- a/unison-src/new-runtime-transcripts/utf8.output.md
+++ b/unison-src/new-runtime-transcripts/utf8.output.md
@@ -1,0 +1,133 @@
+Test for new Text -> Bytes conversions explicitly using UTF-8 as the encoding
+
+Unison has function for converting between `Text` and a UTF-8 `Bytes` encoding of the Text.
+
+```ucm
+.> find Utf8
+
+  1. builtin.Text.toUtf8 : Text -> Bytes
+  2. builtin.Text.tryFromUtf8 : Bytes -> Either Text Text
+  
+
+```
+ascii characters are encoded as single bytes (in the range 0-127).
+
+```unison
+ascii: Text
+ascii = "ABCDE"
+
+> toUtf8 ascii
+
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      ascii : Text
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    4 | > toUtf8 ascii
+          ⧩
+          fromList [65, 66, 67, 68, 69]
+
+```
+non-ascii characters are encoded as multiple bytes.
+
+```unison
+greek: Text
+greek = "ΑΒΓΔΕ"
+
+> toUtf8 greek
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      greek : Text
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    4 | > toUtf8 greek
+          ⧩
+          fromList
+            [206, 145, 206, 146, 206, 147, 206, 148, 206, 149]
+
+```
+We can check that encoding and then decoding should give us back the same `Text` we started with 
+
+```unison
+checkRoundTrip: Text -> [Result]
+checkRoundTrip t = 
+  bytes = toUtf8 t
+  match tryFromUtf8 bytes with 
+    Left e -> [Result.Fail "could not decode"]
+    Right t' -> if t == t' then [Result.Ok "Passed"] else [Result.Fail ("Got: " ++ t' ++ " Expected: " ++ t)]
+
+greek = "ΑΒΓΔΕ"
+
+test> checkRoundTrip greek
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      checkRoundTrip : Text -> [Result]
+      greek          : Text
+    test.kqfpde2g5a  (Unison bug, unknown term)
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    10 | test> checkRoundTrip greek
+    
+    ✅ Passed Passed
+
+```
+If we try to decode an invalid set of bytes, we get back `Text` explaining the decoding error:
+
+```unison
+greek_bytes = Bytes.fromList [206, 145, 206, 146, 206, 147, 206, 148, 206]
+
+
+-- Its an error if we drop the first byte
+> tryFromUtf8 (drop 1 greek_bytes)
+
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      greek_bytes : Bytes
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    5 | > tryFromUtf8 (drop 1 greek_bytes)
+          ⧩
+          Left
+            "Cannot decode byte '\\x91': Data.Text.Internal.Encoding.decodeUtf8: Invalid UTF-8 stream"
+
+```

--- a/unison-src/new-runtime-transcripts/utf8.output.md
+++ b/unison-src/new-runtime-transcripts/utf8.output.md
@@ -5,8 +5,8 @@ Unison has function for converting between `Text` and a UTF-8 `Bytes` encoding o
 ```ucm
 .> find Utf8
 
-  1. builtin.Text.toUtf8 : Text -> Bytes
-  2. builtin.Text.tryFromUtf8 : Bytes -> Either Text Text
+  1. builtin.Text.fromUtf8 : Bytes -> Either Text Text
+  2. builtin.Text.toUtf8 : Text -> Bytes
   
 
 ```
@@ -72,7 +72,7 @@ We can check that encoding and then decoding should give us back the same `Text`
 checkRoundTrip: Text -> [Result]
 checkRoundTrip t = 
   bytes = toUtf8 t
-  match tryFromUtf8 bytes with 
+  match fromUtf8 bytes with 
     Left e -> [Result.Fail "could not decode"]
     Right t' -> if t == t' then [Result.Ok "Passed"] else [Result.Fail ("Got: " ++ t' ++ " Expected: " ++ t)]
 
@@ -108,7 +108,7 @@ greek_bytes = Bytes.fromList [206, 145, 206, 146, 206, 147, 206, 148, 206]
 
 
 -- Its an error if we drop the first byte
-> tryFromUtf8 (drop 1 greek_bytes)
+> fromUtf8 (drop 1 greek_bytes)
 
 ```
 
@@ -125,7 +125,7 @@ greek_bytes = Bytes.fromList [206, 145, 206, 146, 206, 147, 206, 148, 206]
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.
 
-    5 | > tryFromUtf8 (drop 1 greek_bytes)
+    5 | > fromUtf8 (drop 1 greek_bytes)
           ⧩
           Left
             "Cannot decode byte '\\x91': Data.Text.Internal.Encoding.decodeUtf8: Invalid UTF-8 stream"

--- a/unison-src/transcripts/alias-many.output.md
+++ b/unison-src/transcripts/alias-many.output.md
@@ -179,15 +179,15 @@ Let's try it!
   159. Text.empty : Text
   160. Text.eq : Text -> Text -> Boolean
   161. Text.fromCharList : [Char] -> Text
-  162. Text.gt : Text -> Text -> Boolean
-  163. Text.gteq : Text -> Text -> Boolean
-  164. Text.lt : Text -> Text -> Boolean
-  165. Text.lteq : Text -> Text -> Boolean
-  166. Text.size : Text -> Nat
-  167. Text.take : Nat -> Text -> Text
-  168. Text.toCharList : Text -> [Char]
-  169. Text.toUtf8 : Text -> Bytes
-  170. Text.tryFromUtf8 : Bytes -> Either Text Text
+  162. Text.fromUtf8 : Bytes -> Either Text Text
+  163. Text.gt : Text -> Text -> Boolean
+  164. Text.gteq : Text -> Text -> Boolean
+  165. Text.lt : Text -> Text -> Boolean
+  166. Text.lteq : Text -> Text -> Boolean
+  167. Text.size : Text -> Nat
+  168. Text.take : Nat -> Text -> Text
+  169. Text.toCharList : Text -> [Char]
+  170. Text.toUtf8 : Text -> Bytes
   171. Text.uncons : Text -> Optional (Char, Text)
   172. Text.unsnoc : Text -> Optional (Text, Char)
   173. type Tuple a b

--- a/unison-src/transcripts/alias-many.output.md
+++ b/unison-src/transcripts/alias-many.output.md
@@ -186,132 +186,138 @@ Let's try it!
   166. Text.size : Text -> Nat
   167. Text.take : Nat -> Text -> Text
   168. Text.toCharList : Text -> [Char]
-  169. Text.uncons : Text -> Optional (Char, Text)
-  170. Text.unsnoc : Text -> Optional (Text, Char)
-  171. type Tuple a b
-  172. Tuple.Cons : a -> b -> Tuple a b
-  173. type Unit
-  174. Unit.Unit : ()
-  175. Universal.< : a -> a -> Boolean
-  176. Universal.<= : a -> a -> Boolean
-  177. Universal.== : a -> a -> Boolean
-  178. Universal.> : a -> a -> Boolean
-  179. Universal.>= : a -> a -> Boolean
-  180. Universal.compare : a -> a -> Int
-  181. bug : a -> b
-  182. builtin type crypto.HashAlgorithm
-  183. crypto.HashAlgorithm.Blake2b_256 : HashAlgorithm
-  184. crypto.HashAlgorithm.Blake2b_512 : HashAlgorithm
-  185. crypto.HashAlgorithm.Blake2s_256 : HashAlgorithm
-  186. crypto.HashAlgorithm.Sha2_256 : HashAlgorithm
-  187. crypto.HashAlgorithm.Sha2_512 : HashAlgorithm
-  188. crypto.HashAlgorithm.Sha3_256 : HashAlgorithm
-  189. crypto.HashAlgorithm.Sha3_512 : HashAlgorithm
-  190. crypto.hash : HashAlgorithm -> a -> Bytes
-  191. crypto.hashBytes : HashAlgorithm -> Bytes -> Bytes
-  192. crypto.hmac : HashAlgorithm -> Bytes -> a -> Bytes
-  193. crypto.hmacBytes : HashAlgorithm
+  169. Text.toUtf8 : Text -> Bytes
+  170. Text.tryFromUtf8 : Bytes -> Either Text Text
+  171. Text.uncons : Text -> Optional (Char, Text)
+  172. Text.unsnoc : Text -> Optional (Text, Char)
+  173. type Tuple a b
+  174. Tuple.Cons : a -> b -> Tuple a b
+  175. type Unit
+  176. Unit.Unit : ()
+  177. Universal.< : a -> a -> Boolean
+  178. Universal.<= : a -> a -> Boolean
+  179. Universal.== : a -> a -> Boolean
+  180. Universal.> : a -> a -> Boolean
+  181. Universal.>= : a -> a -> Boolean
+  182. Universal.compare : a -> a -> Int
+  183. bug : a -> b
+  184. builtin type crypto.HashAlgorithm
+  185. crypto.HashAlgorithm.Blake2b_256 : HashAlgorithm
+  186. crypto.HashAlgorithm.Blake2b_512 : HashAlgorithm
+  187. crypto.HashAlgorithm.Blake2s_256 : HashAlgorithm
+  188. crypto.HashAlgorithm.Sha2_256 : HashAlgorithm
+  189. crypto.HashAlgorithm.Sha2_512 : HashAlgorithm
+  190. crypto.HashAlgorithm.Sha3_256 : HashAlgorithm
+  191. crypto.HashAlgorithm.Sha3_512 : HashAlgorithm
+  192. crypto.hash : HashAlgorithm -> a -> Bytes
+  193. crypto.hashBytes : HashAlgorithm -> Bytes -> Bytes
+  194. crypto.hmac : HashAlgorithm -> Bytes -> a -> Bytes
+  195. crypto.hmacBytes : HashAlgorithm
                           -> Bytes
                           -> Bytes
                           -> Bytes
-  194. unique type io2.BufferMode
-  195. io2.BufferMode.BlockBuffering : BufferMode
-  196. io2.BufferMode.LineBuffering : BufferMode
-  197. io2.BufferMode.NoBuffering : BufferMode
-  198. io2.BufferMode.SizedBlockBuffering : Nat -> BufferMode
-  199. unique type io2.FileMode
-  200. io2.FileMode.Append : FileMode
-  201. io2.FileMode.Read : FileMode
-  202. io2.FileMode.ReadWrite : FileMode
-  203. io2.FileMode.Write : FileMode
-  204. builtin type io2.Handle
-  205. builtin type io2.IO
-  206. io2.IO.clientSocket : Text
+  196. unique type io2.BufferMode
+  197. io2.BufferMode.BlockBuffering : BufferMode
+  198. io2.BufferMode.LineBuffering : BufferMode
+  199. io2.BufferMode.NoBuffering : BufferMode
+  200. io2.BufferMode.SizedBlockBuffering : Nat -> BufferMode
+  201. unique type io2.FileMode
+  202. io2.FileMode.Append : FileMode
+  203. io2.FileMode.Read : FileMode
+  204. io2.FileMode.ReadWrite : FileMode
+  205. io2.FileMode.Write : FileMode
+  206. builtin type io2.Handle
+  207. builtin type io2.IO
+  208. io2.IO.clientSocket : Text
                              -> Text
                              ->{IO} Either IOError Socket
-  207. io2.IO.closeFile : Handle ->{IO} Either IOError ()
-  208. io2.IO.closeSocket : Socket ->{IO} Either IOError ()
-  209. io2.IO.createDirectory : Text ->{IO} Either IOError ()
-  210. io2.IO.delay : Nat ->{IO} Either IOError ()
-  211. io2.IO.fileExists : Text ->{IO} Either IOError Boolean
-  212. io2.IO.forkComp : '{IO} Either IOError a ->{IO} ThreadId
-  213. io2.IO.getBuffering : Handle
+  209. io2.IO.closeFile : Handle ->{IO} Either IOError ()
+  210. io2.IO.closeSocket : Socket ->{IO} Either IOError ()
+  211. io2.IO.createDirectory : Text ->{IO} Either IOError ()
+  212. io2.IO.delay : Nat ->{IO} Either IOError ()
+  213. io2.IO.fileExists : Text ->{IO} Either IOError Boolean
+  214. io2.IO.forkComp : '{IO} Either IOError a ->{IO} ThreadId
+  215. io2.IO.getBuffering : Handle
                              ->{IO} Either IOError BufferMode
-  214. io2.IO.getCurrentDirectory : '{IO} Either IOError Text
-  215. io2.IO.getFileSize : Text ->{IO} Either IOError Nat
-  216. io2.IO.getFileTimestamp : Text ->{IO} Either IOError Nat
-  217. io2.IO.getLine : Handle ->{IO} Either IOError Text
-  218. io2.IO.getTempDirectory : '{IO} Either IOError Text
-  219. io2.IO.getText : Handle ->{IO} Either IOError Text
-  220. io2.IO.handlePosition : Handle ->{IO} Either IOError Int
-  221. io2.IO.isDirectory : Text ->{IO} Either IOError Boolean
-  222. io2.IO.isFileEOF : Handle ->{IO} Either IOError Boolean
-  223. io2.IO.isFileOpen : Handle ->{IO} Either IOError Boolean
-  224. io2.IO.isSeekable : Handle ->{IO} Either IOError Boolean
-  225. io2.IO.kill : ThreadId ->{IO} Either IOError ()
-  226. io2.IO.listen : Socket ->{IO} Either IOError ()
-  227. io2.IO.openFile : Text
+  216. io2.IO.getBytes : Handle
+                         -> Nat
+                         ->{IO} Either IOError Text
+  217. io2.IO.getCurrentDirectory : '{IO} Either IOError Text
+  218. io2.IO.getFileSize : Text ->{IO} Either IOError Nat
+  219. io2.IO.getFileTimestamp : Text ->{IO} Either IOError Nat
+  220. io2.IO.getLine : Handle ->{IO} Either IOError Text
+  221. io2.IO.getTempDirectory : '{IO} Either IOError Text
+  222. io2.IO.handlePosition : Handle ->{IO} Either IOError Int
+  223. io2.IO.isDirectory : Text ->{IO} Either IOError Boolean
+  224. io2.IO.isFileEOF : Handle ->{IO} Either IOError Boolean
+  225. io2.IO.isFileOpen : Handle ->{IO} Either IOError Boolean
+  226. io2.IO.isSeekable : Handle ->{IO} Either IOError Boolean
+  227. io2.IO.kill : ThreadId ->{IO} Either IOError ()
+  228. io2.IO.listen : Socket ->{IO} Either IOError ()
+  229. io2.IO.openFile : Text
                          -> FileMode
                          ->{IO} Either IOError Handle
-  228. io2.IO.putText : Handle -> Text ->{IO} Either IOError ()
-  229. io2.IO.removeDirectory : Text ->{IO} Either IOError ()
-  230. io2.IO.removeFile : Text ->{IO} Either IOError ()
-  231. io2.IO.renameDirectory : Text
+  230. io2.IO.putBytes : Handle
+                         -> Bytes
+                         ->{IO} Either IOError ()
+  231. io2.IO.removeDirectory : Text ->{IO} Either IOError ()
+  232. io2.IO.removeFile : Text ->{IO} Either IOError ()
+  233. io2.IO.renameDirectory : Text
                                 -> Text
                                 ->{IO} Either IOError ()
-  232. io2.IO.renameFile : Text -> Text ->{IO} Either IOError ()
-  233. io2.IO.seekHandle : Handle
+  234. io2.IO.renameFile : Text -> Text ->{IO} Either IOError ()
+  235. io2.IO.seekHandle : Handle
                            -> SeekMode
                            -> Int
                            ->{IO} Either IOError ()
-  234. io2.IO.serverSocket : Text
+  236. io2.IO.serverSocket : Text
                              -> Text
                              ->{IO} Either IOError Socket
-  235. io2.IO.setBuffering : Handle
+  237. io2.IO.setBuffering : Handle
                              -> BufferMode
                              ->{IO} Either IOError ()
-  236. io2.IO.setCurrentDirectory : Text
+  238. io2.IO.setCurrentDirectory : Text
                                     ->{IO} Either IOError ()
-  237. io2.IO.socketAccept : Socket ->{IO} Either IOError Socket
-  238. io2.IO.socketReceive : Socket
+  239. io2.IO.socketAccept : Socket ->{IO} Either IOError Socket
+  240. io2.IO.socketReceive : Socket
                               -> Nat
                               ->{IO} Either IOError Bytes
-  239. io2.IO.socketSend : Socket
+  241. io2.IO.socketSend : Socket
                            -> Bytes
                            ->{IO} Either IOError ()
-  240. io2.IO.stdHandle : StdHandle -> Handle
-  241. io2.IO.systemTime : '{IO} Either IOError Nat
-  242. unique type io2.IOError
-  243. io2.IOError.AlreadyExists : IOError
-  244. io2.IOError.EOF : IOError
-  245. io2.IOError.IllegalOperation : IOError
-  246. io2.IOError.NoSuchThing : IOError
-  247. io2.IOError.PermissionDenied : IOError
-  248. io2.IOError.ResourceBusy : IOError
-  249. io2.IOError.ResourceExhausted : IOError
-  250. io2.IOError.UserError : IOError
-  251. builtin type io2.MVar
-  252. io2.MVar.isEmpty : MVar a ->{IO} Boolean
-  253. io2.MVar.new : a ->{IO} MVar a
-  254. io2.MVar.newEmpty : {IO} (MVar a)
-  255. io2.MVar.put : MVar a -> a ->{IO} Either IOError ()
-  256. io2.MVar.read : MVar a ->{IO} Either IOError a
-  257. io2.MVar.swap : MVar a -> a ->{IO} Either IOError a
-  258. io2.MVar.take : MVar a ->{IO} Either IOError a
-  259. io2.MVar.tryPut : MVar a -> a ->{IO} Boolean
-  260. io2.MVar.tryRead : MVar a ->{IO} Optional a
-  261. io2.MVar.tryTake : MVar a ->{IO} Optional a
-  262. unique type io2.SeekMode
-  263. io2.SeekMode.AbsoluteSeek : SeekMode
-  264. io2.SeekMode.RelativeSeek : SeekMode
-  265. io2.SeekMode.SeekFromEnd : SeekMode
-  266. builtin type io2.Socket
-  267. unique type io2.StdHandle
-  268. io2.StdHandle.StdErr : StdHandle
-  269. io2.StdHandle.StdIn : StdHandle
-  270. io2.StdHandle.StdOut : StdHandle
-  271. builtin type io2.ThreadId
-  272. todo : a -> b
+  242. io2.IO.stdHandle : StdHandle -> Handle
+  243. io2.IO.systemTime : '{IO} Either IOError Nat
+  244. unique type io2.IOError
+  245. io2.IOError.AlreadyExists : IOError
+  246. io2.IOError.EOF : IOError
+  247. io2.IOError.IllegalOperation : IOError
+  248. io2.IOError.NoSuchThing : IOError
+  249. io2.IOError.PermissionDenied : IOError
+  250. io2.IOError.ResourceBusy : IOError
+  251. io2.IOError.ResourceExhausted : IOError
+  252. io2.IOError.UserError : IOError
+  253. builtin type io2.MVar
+  254. io2.MVar.isEmpty : MVar a ->{IO} Boolean
+  255. io2.MVar.new : a ->{IO} MVar a
+  256. io2.MVar.newEmpty : {IO} (MVar a)
+  257. io2.MVar.put : MVar a -> a ->{IO} Either IOError ()
+  258. io2.MVar.read : MVar a ->{IO} Either IOError a
+  259. io2.MVar.swap : MVar a -> a ->{IO} Either IOError a
+  260. io2.MVar.take : MVar a ->{IO} Either IOError a
+  261. io2.MVar.tryPut : MVar a -> a ->{IO} Boolean
+  262. io2.MVar.tryRead : MVar a ->{IO} Optional a
+  263. io2.MVar.tryTake : MVar a ->{IO} Optional a
+  264. unique type io2.SeekMode
+  265. io2.SeekMode.AbsoluteSeek : SeekMode
+  266. io2.SeekMode.RelativeSeek : SeekMode
+  267. io2.SeekMode.SeekFromEnd : SeekMode
+  268. builtin type io2.Socket
+  269. unique type io2.StdHandle
+  270. io2.StdHandle.StdErr : StdHandle
+  271. io2.StdHandle.StdIn : StdHandle
+  272. io2.StdHandle.StdOut : StdHandle
+  273. builtin type io2.ThreadId
+  274. todo : a -> b
   
 
 .builtin> alias.many 94-104 .mylib

--- a/unison-src/transcripts/builtins-merge.output.md
+++ b/unison-src/transcripts/builtins-merge.output.md
@@ -37,7 +37,7 @@ The `builtins.merge` command adds the known builtins to a `builtin` subnamespace
   26. SeqView/   (2 definitions)
   27. Test/      (3 definitions)
   28. Text       (builtin type)
-  29. Text/      (15 definitions)
+  29. Text/      (17 definitions)
   30. Tuple      (type)
   31. Tuple/     (1 definition)
   32. Unit       (type)

--- a/unison-src/transcripts/emptyCodebase.output.md
+++ b/unison-src/transcripts/emptyCodebase.output.md
@@ -23,7 +23,7 @@ Technically, the definitions all exist, but they have no names. `builtins.merge`
 
 .foo> ls
 
-  1. builtin/ (272 definitions)
+  1. builtin/ (274 definitions)
 
 ```
 And for a limited time, you can get even more builtin goodies:
@@ -35,7 +35,7 @@ And for a limited time, you can get even more builtin goodies:
 
 .foo> ls
 
-  1. builtin/ (435 definitions)
+  1. builtin/ (437 definitions)
 
 ```
 More typically, you'd start out by pulling `base.

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -112,13 +112,13 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #6okt309aca
+  ⊙ #p1bbbaaimg
   
     - Deletes:
     
       feature1.y
   
-  ⊙ #innun3vu4h
+  ⊙ #6lfehn18aq
   
     + Adds / updates:
     
@@ -129,26 +129,26 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
       Original name New name(s)
       feature1.y    master.y
   
-  ⊙ #bkebrou185
+  ⊙ #l2ogfn128u
   
     + Adds / updates:
     
       feature1.y
   
-  ⊙ #huvrakmaan
+  ⊙ #k47m5dspdm
   
     > Moves:
     
       Original name New name
       x             master.x
   
-  ⊙ #pl6dcjov1v
+  ⊙ #hu33p33ksi
   
     + Adds / updates:
     
       x
   
-  ⊙ #dk4cmj83el
+  ⊙ #m29q8q72c3
   
     + Adds / updates:
     
@@ -212,16 +212,15 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
       builtin.Test.Result.Fail builtin.Test.Result.Ok
       builtin.Text builtin.Text.!= builtin.Text.++
       builtin.Text.drop builtin.Text.empty builtin.Text.eq
-      builtin.Text.fromCharList builtin.Text.gt
-      builtin.Text.gteq builtin.Text.lt builtin.Text.lteq
-      builtin.Text.size builtin.Text.take
+      builtin.Text.fromCharList builtin.Text.fromUtf8
+      builtin.Text.gt builtin.Text.gteq builtin.Text.lt
+      builtin.Text.lteq builtin.Text.size builtin.Text.take
       builtin.Text.toCharList builtin.Text.toUtf8
-      builtin.Text.tryFromUtf8 builtin.Text.uncons
-      builtin.Text.unsnoc builtin.Tuple builtin.Tuple.Cons
-      builtin.Unit builtin.Unit.Unit builtin.Universal.<
-      builtin.Universal.<= builtin.Universal.==
-      builtin.Universal.> builtin.Universal.>=
-      builtin.Universal.compare builtin.bug
+      builtin.Text.uncons builtin.Text.unsnoc builtin.Tuple
+      builtin.Tuple.Cons builtin.Unit builtin.Unit.Unit
+      builtin.Universal.< builtin.Universal.<=
+      builtin.Universal.== builtin.Universal.>
+      builtin.Universal.>= builtin.Universal.compare builtin.bug
       builtin.crypto.HashAlgorithm
       builtin.crypto.HashAlgorithm.Blake2b_256
       builtin.crypto.HashAlgorithm.Blake2b_512

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -112,13 +112,13 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #70soik1og2
+  ⊙ #6okt309aca
   
     - Deletes:
     
       feature1.y
   
-  ⊙ #hm2opil978
+  ⊙ #innun3vu4h
   
     + Adds / updates:
     
@@ -129,26 +129,26 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
       Original name New name(s)
       feature1.y    master.y
   
-  ⊙ #v66fup9qub
+  ⊙ #bkebrou185
   
     + Adds / updates:
     
       feature1.y
   
-  ⊙ #gspgkkujs4
+  ⊙ #huvrakmaan
   
     > Moves:
     
       Original name New name
       x             master.x
   
-  ⊙ #bmg3t60dhp
+  ⊙ #pl6dcjov1v
   
     + Adds / updates:
     
       x
   
-  ⊙ #mj9vgnc1ro
+  ⊙ #dk4cmj83el
   
     + Adds / updates:
     
@@ -215,7 +215,8 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
       builtin.Text.fromCharList builtin.Text.gt
       builtin.Text.gteq builtin.Text.lt builtin.Text.lteq
       builtin.Text.size builtin.Text.take
-      builtin.Text.toCharList builtin.Text.uncons
+      builtin.Text.toCharList builtin.Text.toUtf8
+      builtin.Text.tryFromUtf8 builtin.Text.uncons
       builtin.Text.unsnoc builtin.Tuple builtin.Tuple.Cons
       builtin.Unit builtin.Unit.Unit builtin.Universal.<
       builtin.Universal.<= builtin.Universal.==
@@ -242,19 +243,18 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
       builtin.io2.IO.closeFile builtin.io2.IO.closeSocket
       builtin.io2.IO.createDirectory builtin.io2.IO.delay
       builtin.io2.IO.fileExists builtin.io2.IO.forkComp
-      builtin.io2.IO.getBuffering
+      builtin.io2.IO.getBuffering builtin.io2.IO.getBytes
       builtin.io2.IO.getCurrentDirectory
       builtin.io2.IO.getFileSize builtin.io2.IO.getFileTimestamp
       builtin.io2.IO.getLine builtin.io2.IO.getTempDirectory
-      builtin.io2.IO.getText builtin.io2.IO.handlePosition
-      builtin.io2.IO.isDirectory builtin.io2.IO.isFileEOF
-      builtin.io2.IO.isFileOpen builtin.io2.IO.isSeekable
-      builtin.io2.IO.kill builtin.io2.IO.listen
-      builtin.io2.IO.openFile builtin.io2.IO.putText
-      builtin.io2.IO.removeDirectory builtin.io2.IO.removeFile
-      builtin.io2.IO.renameDirectory builtin.io2.IO.renameFile
-      builtin.io2.IO.seekHandle builtin.io2.IO.serverSocket
-      builtin.io2.IO.setBuffering
+      builtin.io2.IO.handlePosition builtin.io2.IO.isDirectory
+      builtin.io2.IO.isFileEOF builtin.io2.IO.isFileOpen
+      builtin.io2.IO.isSeekable builtin.io2.IO.kill
+      builtin.io2.IO.listen builtin.io2.IO.openFile
+      builtin.io2.IO.putBytes builtin.io2.IO.removeDirectory
+      builtin.io2.IO.removeFile builtin.io2.IO.renameDirectory
+      builtin.io2.IO.renameFile builtin.io2.IO.seekHandle
+      builtin.io2.IO.serverSocket builtin.io2.IO.setBuffering
       builtin.io2.IO.setCurrentDirectory
       builtin.io2.IO.socketAccept builtin.io2.IO.socketReceive
       builtin.io2.IO.socketSend builtin.io2.IO.stdHandle

--- a/unison-src/transcripts/reflog.output.md
+++ b/unison-src/transcripts/reflog.output.md
@@ -59,16 +59,16 @@ y = 2
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #474ose9n6r .old`   to make an old namespace
+    `fork #dvi5rjbtia .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #474ose9n6r`  to reset the root namespace and
+    `reset-root #dvi5rjbtia`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
-  1. #70gl9rvh18 : add
-  2. #474ose9n6r : add
-  3. #dk4cmj83el : builtins.merge
+  1. #2nhqt4t7bg : add
+  2. #dvi5rjbtia : add
+  3. #m29q8q72c3 : builtins.merge
   4. #7asfbtqmoj : (initial reflogged namespace)
 
 ```

--- a/unison-src/transcripts/reflog.output.md
+++ b/unison-src/transcripts/reflog.output.md
@@ -59,16 +59,16 @@ y = 2
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #aeg2cssfqi .old`   to make an old namespace
+    `fork #474ose9n6r .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #aeg2cssfqi`  to reset the root namespace and
+    `reset-root #474ose9n6r`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
-  1. #l2s90e9ce6 : add
-  2. #aeg2cssfqi : add
-  3. #mj9vgnc1ro : builtins.merge
+  1. #70gl9rvh18 : add
+  2. #474ose9n6r : add
+  3. #dk4cmj83el : builtins.merge
   4. #7asfbtqmoj : (initial reflogged namespace)
 
 ```

--- a/unison-src/transcripts/squash.output.md
+++ b/unison-src/transcripts/squash.output.md
@@ -13,7 +13,7 @@ Let's look at some examples. We'll start with a namespace with just the builtins
   
   
   
-  □ #ttlhvqf3s4 (start of history)
+  □ #8npfd2k318 (start of history)
 
 .> fork builtin builtin2
 
@@ -42,21 +42,21 @@ Now suppose we `fork` a copy of builtin, then rename `Nat.+` to `frobnicate`, th
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #v024k3597g
+  ⊙ #1r8tns0vp3
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ #ci3d83ckgf
+  ⊙ #850oic6dhv
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ #ttlhvqf3s4 (start of history)
+  □ #8npfd2k318 (start of history)
 
 ```
 If we merge that back into `builtin`, we get that same chain of history:
@@ -71,21 +71,21 @@ If we merge that back into `builtin`, we get that same chain of history:
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #v024k3597g
+  ⊙ #1r8tns0vp3
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ #ci3d83ckgf
+  ⊙ #850oic6dhv
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ #ttlhvqf3s4 (start of history)
+  □ #8npfd2k318 (start of history)
 
 ```
 Let's try again, but using a `merge.squash` (or just `squash`) instead. The history will be unchanged:
@@ -106,7 +106,7 @@ Let's try again, but using a `merge.squash` (or just `squash`) instead. The hist
   
   
   
-  □ #ttlhvqf3s4 (start of history)
+  □ #8npfd2k318 (start of history)
 
 ```
 The churn that happened in `mybuiltin` namespace ended up back in the same spot, so the squash merge of that namespace with our original namespace had no effect.

--- a/unison-src/transcripts/squash.output.md
+++ b/unison-src/transcripts/squash.output.md
@@ -13,7 +13,7 @@ Let's look at some examples. We'll start with a namespace with just the builtins
   
   
   
-  □ #8npfd2k318 (start of history)
+  □ #qcbft8a6lf (start of history)
 
 .> fork builtin builtin2
 
@@ -42,21 +42,21 @@ Now suppose we `fork` a copy of builtin, then rename `Nat.+` to `frobnicate`, th
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #1r8tns0vp3
+  ⊙ #ecn6hkk9l1
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ #850oic6dhv
+  ⊙ #tokdbn3dd4
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ #8npfd2k318 (start of history)
+  □ #qcbft8a6lf (start of history)
 
 ```
 If we merge that back into `builtin`, we get that same chain of history:
@@ -71,21 +71,21 @@ If we merge that back into `builtin`, we get that same chain of history:
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #1r8tns0vp3
+  ⊙ #ecn6hkk9l1
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ #850oic6dhv
+  ⊙ #tokdbn3dd4
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ #8npfd2k318 (start of history)
+  □ #qcbft8a6lf (start of history)
 
 ```
 Let's try again, but using a `merge.squash` (or just `squash`) instead. The history will be unchanged:
@@ -106,7 +106,7 @@ Let's try again, but using a `merge.squash` (or just `squash`) instead. The hist
   
   
   
-  □ #8npfd2k318 (start of history)
+  □ #qcbft8a6lf (start of history)
 
 ```
 The churn that happened in `mybuiltin` namespace ended up back in the same spot, so the squash merge of that namespace with our original namespace had no effect.


### PR DESCRIPTION
This gets rid of two builtins:

IO.getText : Handle -> {IO} Either IOError Text
IO.putText : Handle -> Text -> {IO} Either IOError ()

and add's 4 new builtins:

IO.getBytes : Handle -> Nat -> {IO} Either IOError Bytes
IO.putBytes : Handle -> Bytes -> {IO} Either IOError ()
Text.toUtf8 : Text -> Bytes
Text.fromUtf8 : Bytes -> Either Text Text

This is so that we are explicit about how we convert from Text ->
Bytes, instead of relying on the system locale to decide on a Char

Fixes #1697

