### PR TITLE
Pull in some changes from the mobile code development

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -186,13 +186,16 @@ commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSour
   evalUnisonFile :: PPE.PrettyPrintEnv -> UF.TypecheckedUnisonFile v Ann -> _
   evalUnisonFile ppe (UF.discardTypes -> unisonFile) = do
     let codeLookup = Codebase.toCodeLookup codebase
-    selfContained <- Codebase.makeSelfContained' codeLookup unisonFile
+    evalFile <-
+      if Runtime.needsContainment rt
+        then Codebase.makeSelfContained' codeLookup unisonFile
+        else pure unisonFile
     let watchCache (Reference.DerivedId h) = do
           m1 <- Codebase.getWatch codebase UF.RegularWatch h
           m2 <- maybe (Codebase.getWatch codebase UF.TestWatch h) (pure . Just) m1
           pure $ Term.amap (const ()) <$> m2
         watchCache Reference.Builtin{} = pure Nothing
-    r <- Runtime.evaluateWatches codeLookup ppe watchCache rt selfContained
+    r <- Runtime.evaluateWatches codeLookup ppe watchCache rt evalFile
     case r of
       Left e -> pure (Left e)
       Right rs@(_,map) -> do

--- a/parser-typechecker/src/Unison/Runtime/ANF.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF.hs
@@ -64,7 +64,7 @@ module Unison.Runtime.ANF
 
 import Unison.Prelude
 
-import Control.Monad.Reader (ReaderT(..), asks, local)
+import Control.Monad.Reader (ReaderT(..), ask, local)
 import Control.Monad.State (State, runState, MonadState(..), modify, gets)
 import Control.Lens (snoc, unsnoc)
 
@@ -473,22 +473,22 @@ data Mem = UN | BX deriving (Eq,Ord,Show,Enum)
 -- Context entries with evaluation strategy
 data CTE v s
   = ST [v] [Mem] s
-  | LZ v (Either Word64 v) [v]
+  | LZ v (Either Reference v) [v]
   deriving (Show)
 
 pattern ST1 v m s = ST [v] [m] s
 
 data ANormalBF v e
   = ALet [Mem] (ANormalTF v e) e
-  | AName (Either Word64 v) [v] e
+  | AName (Either Reference v) [v] e
   | ATm (ANormalTF v e)
   deriving (Show)
 
 data ANormalTF v e
   = ALit Lit
   | AMatch v (Branched e)
-  | AShift RTag e
-  | AHnd [RTag] v e
+  | AShift Reference e
+  | AHnd [Reference] v e
   | AApp (Func v) [v]
   | AFrc v
   | AVar v
@@ -676,7 +676,7 @@ data SeqEnd = SLeft | SRight
 data Branched e
   = MatchIntegral (EnumMap Word64 e) (Maybe e)
   | MatchText (Map.Map Text e) (Maybe e)
-  | MatchRequest (EnumMap RTag (EnumMap CTag ([Mem], e))) e
+  | MatchRequest (Map Reference (EnumMap CTag ([Mem], e))) e
   | MatchEmpty
   | MatchData Reference (EnumMap CTag ([Mem], e)) (Maybe e)
   | MatchSum (EnumMap Word64 ([Mem], e))
@@ -694,7 +694,7 @@ data BranchAccum v
   | AccumDefault (ANormal v)
   | AccumPure (ANormal v)
   | AccumRequest
-      (EnumMap RTag (EnumMap CTag ([Mem],ANormal v)))
+      (Map Reference (EnumMap CTag ([Mem],ANormal v)))
       (Maybe (ANormal v))
   | AccumData
       Reference
@@ -739,7 +739,7 @@ instance Semigroup (BranchAccum v) where
   AccumRequest hl dl <> AccumRequest hr dr
     = AccumRequest hm $ dl <|> dr
     where
-    hm = EC.unionWith (<>) hl hr
+    hm = Map.unionWith (<>) hl hr
   l@(AccumSeqEmpty _) <> AccumSeqEmpty _ = l
   AccumSeqEmpty eml <> AccumSeqView er _ cnr
     = AccumSeqView er (Just eml) cnr
@@ -777,13 +777,13 @@ data Func v
   -- variable
   = FVar v
   -- top-level combinator
-  | FComb !Word64
+  | FComb !Reference
   -- continuation jump
   | FCont v
   -- data constructor
-  | FCon !RTag !CTag
+  | FCon !Reference !CTag
   -- ability request
-  | FReq !RTag !CTag
+  | FReq !Reference !CTag
   -- prim op
   | FPrim (Either POp FOp)
   deriving (Show, Functor, Foldable, Traversable)
@@ -869,22 +869,13 @@ data SuperGroup v
   , entry :: SuperNormal v
   } deriving (Show)
 
-type ANFM v
-  = ReaderT (Set v, Reference -> Word64, Reference -> RTag)
-      (State (Word64, [(v, SuperNormal v)]))
-
-resolveTerm :: Reference -> ANFM v Word64
-resolveTerm r = asks $ \(_, rtm, _) -> rtm r
-
-resolveType :: Reference -> ANFM v RTag
-resolveType r = asks $ \(_, _, rty) -> rty r
+type ANFM v = ReaderT (Set v) (State (Word64, [(v, SuperNormal v)]))
 
 groupVars :: ANFM v (Set v)
-groupVars = asks $ \(grp, _, _) -> grp
+groupVars = ask
 
 bindLocal :: Ord v => [v] -> ANFM v r -> ANFM v r
-bindLocal vs
-  = local $ \(gr, rw, rt) -> (gr Set.\\ Set.fromList vs, rw, rt)
+bindLocal vs = local (Set.\\ Set.fromList vs)
 
 freshANF :: Var v => Word64 -> v
 freshANF fr = Var.freshenId fr $ typed Var.ANFBlank
@@ -903,19 +894,14 @@ contextualize tm = fresh <&> \fv -> ([ST1 fv BX tm], fv)
 record :: Var v => (v, SuperNormal v) -> ANFM v ()
 record p = modify $ \(fr, to) -> (fr, p:to)
 
-superNormalize
-  :: Var v
-  => (Reference -> Word64)
-  -> (Reference -> RTag)
-  -> Term v a
-  -> SuperGroup v
-superNormalize rtm rty tm = Rec l c
+superNormalize :: Var v => Term v a -> SuperGroup v
+superNormalize tm = Rec l c
   where
   (bs, e) | LetRecNamed' bs e <- tm = (bs, e)
           | otherwise = ([], tm)
   grp = Set.fromList $ fst <$> bs
   comp = traverse_ superBinding bs *> toSuperNormal e
-  subc = runReaderT comp (grp, rtm, rty)
+  subc = runReaderT comp grp
   (c, (_,l)) = runState subc (0, [])
 
 superBinding :: Var v => (v, Term v a) -> ANFM v ()
@@ -968,12 +954,12 @@ anfBlock (If' c t f) = do
 anfBlock (And' l r) = do
   (lctx, vl) <- anfArg l
   (rctx, vr) <- anfArg r
-  i <- resolveTerm $ Builtin "Boolean.and"
+  let i = Builtin "Boolean.and"
   pure (lctx ++ rctx, ACom i [vl, vr])
 anfBlock (Or' l r) = do
   (lctx, vl) <- anfArg l
   (rctx, vr) <- anfArg r
-  i <- resolveTerm $ Builtin "Boolean.or"
+  let i = Builtin "Boolean.or"
   pure (lctx ++ rctx, ACom i [vl, vr])
 anfBlock (Handle' h body)
   = anfArg h >>= \(hctx, vh) ->
@@ -1019,7 +1005,7 @@ anfBlock (Match' scrut cas) = do
               | [ST _ _ _] <- cx = error "anfBlock: impossible"
               | otherwise = AFrc v
       pure ( sctx ++ [LZ hv (Right r) vs]
-           , AHnd (EC.keys abr) hv . TTm $ msc
+           , AHnd (Map.keys abr) hv . TTm $ msc
            )
     AccumText df cs ->
       pure (sctx ++ cx, AMatch v $ MatchText cs df)
@@ -1036,9 +1022,8 @@ anfBlock (Match' scrut cas) = do
       error "anfBlock: non-exhaustive AccumSeqEmpty"
     AccumSeqView en (Just em) bd -> do
       r <- fresh
-      op <- case en of
-       SLeft -> resolveTerm $ Builtin "List.viewl"
-       _ -> resolveTerm $ Builtin "List.viewr"
+      let op | SLeft <- en = Builtin "List.viewl"
+             | otherwise   = Builtin "List.viewr"
       pure ( sctx ++ cx ++ [ST1 r BX (ACom op [v])]
            , AMatch r
            $ MatchData Ty.seqViewRef
@@ -1080,21 +1065,16 @@ anfBlock (Apps' f args) = do
   (actx, cas) <- anfArgs args
   pure (fctx ++ actx, AApp cf cas)
 anfBlock (Constructor' r t)
-  = resolveType r <&> \rt -> ([], ACon rt (toEnum t) [])
-anfBlock (Request' r t) = do
-  r <- resolveType r
-  pure ([], AReq r (toEnum t) [])
-anfBlock (Boolean' b) =
-  resolveType Ty.booleanRef <&> \rt -> 
-    ([], ACon rt (if b then 1 else 0) [])
+  = pure ([], ACon r (toEnum t) [])
+anfBlock (Request' r t) = pure ([], AReq r (toEnum t) [])
+anfBlock (Boolean' b)
+  = pure ([], ACon Ty.booleanRef (if b then 1 else 0) [])
 anfBlock (Lit' l@(T _)) =
   pure ([], ALit l)
 anfBlock (Lit' l) = do
   lv <- fresh
-  rt <- resolveType $ litRef l
-  pure ([ST1 lv UN $ ALit l], ACon rt 0 [lv])
-anfBlock (Ref' r) =
-  resolveTerm r <&> \n -> ([], ACom n [])
+  pure ([ST1 lv UN $ ALit l], ACon (litRef l) 0 [lv])
+anfBlock (Ref' r) = pure ([], ACom r [])
 anfBlock (Blank' _) = do
   ev <- fresh
   pure ([ST1 ev BX (ALit (T "Blank"))], APrm EROR [ev])
@@ -1153,15 +1133,14 @@ anfInitCase u (MatchCase p guard (ABT.AbsN' vs bd))
     let (us, uk)
           = maybe (error "anfInitCase: unsnoc impossible") id
           $ unsnoc exp
-    n <- resolveType r
-    jn <- resolveTerm $ Builtin "jumpCont"
+    let jn = Builtin "jumpCont"
     kf <- fresh
     flip AccumRequest Nothing
-       . EC.mapSingleton n
+       . Map.singleton r
        . EC.mapSingleton (toEnum t)
        . (BX<$us,)
        . ABTN.TAbss us
-       . TShift n kf
+       . TShift r kf
        . TName uk (Left jn) [kf]
       <$> anfBody bd
   | P.SequenceLiteral _ [] <- p
@@ -1223,12 +1202,9 @@ anfCases u = fmap fold . traverse (anfInitCase u)
 
 anfFunc :: Var v => Term v a -> ANFM v (Ctx v, Func v)
 anfFunc (Var' v) = pure ([], FVar v)
-anfFunc (Ref' r)
-  = resolveTerm r <&> \n -> ([], FComb n)
-anfFunc (Constructor' r t)
-  = resolveType r <&> \rt -> ([], FCon rt $ toEnum t)
-anfFunc (Request' r t)
-  = resolveType r <&> \rt -> ([], FReq rt $ toEnum t)
+anfFunc (Ref' r) = pure ([], FComb r)
+anfFunc (Constructor' r t) = pure ([], FCon r $ toEnum t)
+anfFunc (Request' r t) = pure ([], FReq r $ toEnum t)
 anfFunc tm = do
   (fctx, ctm) <- anfBlock tm
   (cx, v) <- contextualize ctm
@@ -1358,17 +1334,17 @@ prettyANFT m ind tm = prettySpace m ind . case tm of
        . prettyVars vs . showString "."
        . prettyANF False (ind+1) bo
     AHnd rs v bo
-      -> showString "handle" . prettyTags rs
+      -> showString "handle" . prettyRefs rs
        . prettyANF False (ind+1) bo
        . showString " with " . pvar v
 
-prettyLZF :: Var v => Either Word64 v -> ShowS
+prettyLZF :: Var v => Either Reference v -> ShowS
 prettyLZF (Left w) = showString "ENV(" . shows w . showString ") "
 prettyLZF (Right v) = pvar v . showString " "
 
-prettyTags :: [RTag] -> ShowS
-prettyTags [] = showString "{}"
-prettyTags (r:rs)
+prettyRefs :: [Reference] -> ShowS
+prettyRefs [] = showString "{}"
+prettyRefs (r:rs)
   = showString "{" . shows r
   . foldr (\t r -> shows t . showString "," . r) id rs
   . showString "}"
@@ -1404,7 +1380,7 @@ prettyBranches ind bs = case bs of
     -> foldr (\(r,m) s ->
          foldr (\(c,e) -> prettyCase ind (prettyReq r c) e)
            s (mapToList $ snd <$> m))
-         (prettyCase ind (prettyReq 0 0) df id) (mapToList bs)
+         (prettyCase ind (prettyReq 0 0) df id) (Map.toList bs)
   MatchSum bs
     -> foldr (uncurry $ prettyCase ind . shows) id
          (mapToList $ snd <$> bs)

--- a/parser-typechecker/src/Unison/Runtime/ANF.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF.hs
@@ -1289,9 +1289,9 @@ sink v mtm tm = dive $ freeVarsT tm
 indent :: Int -> ShowS
 indent ind = showString (replicate (ind*2) ' ')
 
-prettyGroup :: Var v => SuperGroup v -> ShowS
-prettyGroup (Rec grp ent)
-  = showString "let rec\n"
+prettyGroup :: Var v => String -> SuperGroup v -> ShowS
+prettyGroup s (Rec grp ent)
+  = showString ("let rec[" ++ s ++ "]\n")
   . foldr f id grp
   . showString "entry"
   . prettySuperNormal 1 ent

--- a/parser-typechecker/src/Unison/Runtime/Debug.hs
+++ b/parser-typechecker/src/Unison/Runtime/Debug.hs
@@ -24,14 +24,15 @@ type Term v = Tm.Term v ()
 
 traceComb :: Bool -> Word64 -> Comb -> Bool
 traceComb False _ _ = True
-traceComb True  w c = trace (prettyComb w c "\n") True
+traceComb True  w c = trace (prettyComb w 0 c "\n") True
 
 traceCombs
-  :: Bool
-  -> (Comb, EnumMap Word64 Comb, Word64)
-  -> (Comb, EnumMap Word64 Comb, Word64)
-traceCombs False c = c
-traceCombs True  c = trace (prettyCombs c "") c
+  :: Word64
+  -> Bool
+  -> EnumMap Word64 Comb
+  -> EnumMap Word64 Comb
+traceCombs _ False c = c
+traceCombs w True  c = trace (prettyCombs w c "") c
 
 tracePretty
   :: Var v
@@ -44,9 +45,10 @@ tracePretty ppe True tm = trace (toANSI 50 $ pretty ppe tm) tm
 
 tracePrettyGroup
   :: Var v
-  => Bool
+  => Word64
+  -> Bool
   -> SuperGroup v
   -> SuperGroup v
-tracePrettyGroup False g = g
-tracePrettyGroup True g = trace (prettyGroup g "") g
+tracePrettyGroup _ False g = g
+tracePrettyGroup w True g = trace (prettyGroup (show w) g "") g
 

--- a/parser-typechecker/src/Unison/Runtime/Decompile.hs
+++ b/parser-typechecker/src/Unison/Runtime/Decompile.hs
@@ -53,7 +53,9 @@ decompile _ (DataC rf ct [i] [])
   = decompileUnboxed rf ct i
 decompile topTerms (DataC rf ct [] bs)
   = apps' (con rf ct) <$> traverse (decompile topTerms) bs
-decompile topTerms (PApV (CIx _ rt _) [] bs)
+decompile _ (PApV (CIx _ _ n) _ _) | n > 0
+  = err "cannot decompile an application to a local recusive binding"
+decompile topTerms (PApV (CIx _ rt 0) [] bs)
   | Just t <- topTerms rt
   = substitute t <$> traverse (decompile topTerms) bs
   | otherwise

--- a/parser-typechecker/src/Unison/Runtime/Decompile.hs
+++ b/parser-typechecker/src/Unison/Runtime/Decompile.hs
@@ -27,7 +27,7 @@ import Unison.Runtime.ANF (RTag, CTag, Tag(..))
 import Unison.Runtime.Foreign
   (Foreign, maybeUnwrapBuiltin, maybeUnwrapForeign)
 import Unison.Runtime.Stack
-  (Closure(..), pattern DataC, pattern PApV, IComb(..))
+  (Closure(..), pattern DataC, pattern PApV, CombIx(..))
 
 import Unison.Codebase.Runtime (Error)
 import Unison.Util.Pretty (lit)
@@ -58,7 +58,7 @@ decompile tyRef _ (DataC rt ct [i] [])
 decompile tyRef topTerms (DataC rt ct [] bs)
   | Just rf <- tyRef rt
   = apps' (con rf ct) <$> traverse (decompile tyRef topTerms) bs
-decompile tyRef topTerms (PApV (IC rt _) [] bs)
+decompile tyRef topTerms (PApV (CIx rt _) [] bs)
   | Just t <- topTerms rt
   = substitute t <$> traverse (decompile tyRef topTerms) bs
   | otherwise

--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -6,6 +6,8 @@ module Unison.Runtime.Interface
   ( startRuntime
   ) where
 
+import GHC.Stack (HasCallStack)
+
 import Control.Exception (try)
 import Control.Monad (foldM, (<=<))
 
@@ -16,6 +18,7 @@ import Data.Word (Word64)
 
 import qualified Data.Map.Strict as Map
 
+import qualified Unison.ABT as Tm (substs)
 import qualified Unison.Term as Tm
 import Unison.Var (Var)
 
@@ -51,7 +54,7 @@ data EvalCtx v
   , freshTm :: Word64
   , refTy :: Map.Map RF.Reference RTag
   , refTm :: Map.Map RF.Reference Word64
-  , combs :: EnumMap Word64 Comb
+  , combs :: EnumMap Word64 Combs
   , dspec :: DataSpec
   , backrefTy :: EnumMap RTag RF.Reference
   , backrefTm :: EnumMap Word64 (Term v)
@@ -63,11 +66,6 @@ uncurryDspec = Map.fromList . concatMap f . Map.toList
   where
   f (r,l) = zipWith (\n c -> ((r,n),c)) [0..] $ either id id l
 
-numberLetRec :: Word64 -> Term v -> EnumMap Word64 (Term v)
-numberLetRec frsh (Tm.LetRecNamed' bs e)
-  = mapFromList . zip [frsh..] $ e : map snd bs
-numberLetRec _ _ = error "impossible"
-
 baseContext :: forall v. Var v => EvalCtx v
 baseContext
   = ECtx
@@ -75,7 +73,7 @@ baseContext
   , freshTm = ftm
   , refTy = builtinTypeNumbering
   , refTm = builtinTermNumbering
-  , combs = emitComb @v mempty <$> numberedTermLookup
+  , combs = mapSingleton 0 . emitComb @v 0 mempty <$> numberedTermLookup
   , dspec = builtinDataSpec
   , backrefTy = builtinTypeBackref
   , backrefTm = Tm.ref () <$> builtinTermBackref
@@ -85,16 +83,35 @@ baseContext
   ftm = 1 + maximum builtinTermNumbering
   fty = (1+) . fromEnum $ maximum builtinTypeNumbering
 
--- allocTerm
---   :: Var v
---   => CodeLookup v m ()
---   -> EvalCtx v
---   -> RF.Reference
---   -> IO (EvalCtx v)
--- allocTerm _  _   b@(RF.Builtin _)
---   = die $ "Unknown builtin term reference: " ++ show b
--- allocTerm _  _   (RF.DerivedId _)
---   = die $ "TODO: allocTerm: hash reference"
+allocTerm
+  :: Var v
+  => EvalCtx v
+  -> RF.Reference
+  -> Term v
+  -> EvalCtx v
+allocTerm ctx r tm
+  | Nothing <- Map.lookup r (refTm ctx)
+  , rt <- freshTm ctx
+  = ctx
+  { refTm = Map.insert r rt $ refTm ctx
+  , backrefTm = mapInsert rt tm $ backrefTm ctx
+  , backrefComb = mapInsert rt r $ backrefComb ctx
+  , freshTm = rt+1
+  }
+  | otherwise = ctx
+
+allocTermRef
+  :: Var v
+  => CodeLookup v IO ()
+  -> EvalCtx v
+  -> RF.Reference
+  -> IO (EvalCtx v)
+allocTermRef _  _   b@(RF.Builtin _)
+  = die $ "Unknown builtin term reference: " ++ show b
+allocTermRef cl ctx r@(RF.DerivedId i)
+  = getTerm cl i >>= \case
+      Nothing -> die $ "Unknown term reference: " ++ show r
+      Just tm -> pure $ allocTerm ctx r tm
 
 allocType
   :: EvalCtx v
@@ -138,49 +155,70 @@ loadDeps
   -> Term v
   -> IO (EvalCtx v)
 loadDeps cl ctx tm = do
-  (tys, _  ) <- collectDeps cl tm
+  (tys, tms) <- collectDeps cl tm
   -- TODO: terms
-  foldM (uncurry . allocType) ctx $ filter p tys
+  ctx <- foldM (uncurry . allocType) ctx $ filter p tys
+  ctx <- foldM (allocTermRef cl) ctx $ filter q tms
+  pure $ foldl' compileAllocated ctx $ filter q tms
   where
   p (r@RF.DerivedId{},_)
     =  r `Map.notMember` dspec ctx
     || r `Map.notMember` refTy ctx
   p _ = False
 
-addCombs :: EnumMap Word64 Comb -> EvalCtx v -> EvalCtx v
-addCombs m ctx = ctx { combs = m <> combs ctx }
+  q r@RF.DerivedId{} = r `Map.notMember` refTm ctx
+  q _ = False
 
-addTermBackrefs :: EnumMap Word64 (Term v) -> EvalCtx v -> EvalCtx v
-addTermBackrefs refs ctx = ctx { backrefTm = refs <> backrefTm ctx }
+compileAllocated
+  :: HasCallStack => Var v => EvalCtx v -> Reference -> EvalCtx v
+compileAllocated ctx r
+  | Just w <- Map.lookup r (refTm ctx)
+  , Just tm <- EC.lookup w (backrefTm ctx)
+  = compileTerm w tm ctx
+  | otherwise
+  = error "compileAllocated: impossible"
 
-refresh :: Word64 -> EvalCtx v -> EvalCtx v
-refresh w ctx = ctx { freshTm = w }
+addCombs :: EvalCtx v -> Word64 -> Combs -> EvalCtx v
+addCombs ctx w m = ctx { combs = mapInsert w m $ combs ctx }
 
-ref :: Ord k => Show k => Map.Map k v -> k -> v
+-- addTermBackrefs :: EnumMap Word64 (Term v) -> EvalCtx v -> EvalCtx v
+-- addTermBackrefs refs ctx = ctx { backrefTm = refs <> backrefTm ctx }
+
+-- refresh :: Word64 -> EvalCtx v -> EvalCtx v
+-- refresh w ctx = ctx { freshTm = w }
+
+ref :: HasCallStack => Ord k => Show k => Map.Map k v -> k -> v
 ref m k
   | Just x <- Map.lookup k m = x
   | otherwise = error $ "unknown reference: " ++ show k
 
 compileTerm
-  :: Var v => Word64 -> Term v -> EvalCtx v -> EvalCtx v
+  :: HasCallStack => Var v => Word64 -> Term v -> EvalCtx v -> EvalCtx v
 compileTerm w tm ctx
-  = finish
-  . fmap
-      ( emitCombs frsh
-      . superNormalize (ref $ refTm ctx) (ref $ refTy ctx))
-  . bkrf
+  = addCombs ctx w
+  . emitCombs w
+  . superNormalize (ref $ refTm ctx) (ref $ refTy ctx)
   . lamLift
   . splitPatterns (dspec ctx)
   . saturate (uncurryDspec $ dspec ctx)
   $ tm
+
+prepareEvaluation
+  :: HasCallStack => Var v => Term v -> EvalCtx v -> (EvalCtx v, Word64)
+prepareEvaluation (Tm.LetRecNamed' bs mn0) ctx0 = (ctx3, mid)
   where
-  frsh = freshTm ctx
-  bkrf tm = (numberLetRec frsh tm, tm)
-  finish (recs, (main, aux, frsh'))
-    = refresh frsh'
-    . addTermBackrefs recs
-    . addCombs (mapInsert w main aux)
-    $ ctx
+  hcs = fmap (first RF.DerivedId) . Tm.hashComponents $ Map.fromList bs
+  mn = Tm.substs (Map.toList $ Tm.ref () . fst <$> hcs) mn0
+
+  ctx1 = foldl (uncurry . allocTerm) ctx0 hcs
+  ctx2 = foldl (\ctx (r, _) -> compileAllocated ctx r) ctx1 hcs
+  mid = freshTm ctx2
+  ctx3 = compileTerm mid mn (ctx2 { freshTm = mid+1 })
+prepareEvaluation mn ctx0 = (ctx1, mid)
+  where
+  mid = freshTm ctx0
+  ctx1 = compileTerm mid mn (ctx0 { freshTm = mid+1 })
+
 
 watchHook :: IORef Closure -> Stack 'UN -> Stack 'BX -> IO ()
 watchHook r _ bstk = peek bstk >>= writeIORef r
@@ -217,10 +255,8 @@ startRuntime = do
            ctx <- readIORef ctxVar
            ctx <- loadDeps cl ctx tm
            writeIORef ctxVar ctx
-           let init = freshTm ctx
-           ctx <- pure $ refresh (init+1) ctx
-           ctx <- pure $ compileTerm init tm ctx
+           (ctx, init) <- pure $ prepareEvaluation tm ctx
            evalInContext ppe ctx init
        , mainType = builtinMain External
-       , needsContainment = True
+       , needsContainment = False
        }

--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -222,4 +222,5 @@ startRuntime = do
            ctx <- pure $ compileTerm init tm ctx
            evalInContext ppe ctx init
        , mainType = builtinMain External
+       , needsContainment = True
        }

--- a/parser-typechecker/src/Unison/Runtime/MCode.hs
+++ b/parser-typechecker/src/Unison/Runtime/MCode.hs
@@ -12,6 +12,7 @@ module Unison.Runtime.MCode
   , Instr(..)
   , Section(.., MatchT, MatchW)
   , Comb(..)
+  , Combs
   , Ref(..)
   , UPrim1(..)
   , UPrim2(..)
@@ -238,6 +239,7 @@ data Args'
   -- frame index of each argument to the function
   | ArgN {-# unpack #-} !(PrimArray Int)
   | ArgR !Int !Int
+  deriving (Show)
 
 data Args
   = ZArgs
@@ -471,9 +473,12 @@ data Comb
         !Section -- Entry
   deriving (Show, Eq, Ord)
 
+type Combs = EnumMap Word64 Comb
+
 data Ref
   = Stk !Int    -- stack reference to a closure
   | Env !Word64 -- global environment reference to a combinator
+        !Word64 -- section
   | Dyn !Word64 -- dynamic scope reference to a closure
   deriving (Show, Eq, Ord)
 
@@ -567,18 +572,20 @@ rctxResolve :: Var v => RCtx v -> v -> Maybe Word64
 rctxResolve ctx u = M.lookup u ctx
 
 -- Compile a top-level definition group to a collection of combinators.
--- The values in the recursive group are numbered according to the
--- provided word.
+-- The provided word refers to the numbering for the overall group,
+-- and intra-group calls are numbered locally, with 0 specifying
+-- the global entry point.
 emitCombs
-  :: Var v => Word64 -> SuperGroup v
-  -> (Comb, EnumMap Word64 Comb, Word64)
-emitCombs frsh (Rec grp ent)
-  = (emitComb rec ent, EC.mapFromList aux, frsh')
+  :: Var v
+  => Word64
+  -> SuperGroup v
+  -> EnumMap Word64 Comb
+emitCombs lcl (Rec grp ent)
+  = mapInsert 0 (emitComb lcl rec ent) (EC.mapFromList aux)
   where
-  frsh' = frsh + fromIntegral (length grp)
   (rvs, cmbs) = unzip grp
-  rec = M.fromList $ zip rvs [frsh..]
-  aux = zip [frsh..] $ emitComb rec <$> cmbs
+  rec = M.fromList $ zip rvs [1..]
+  aux = zip [1..] $ emitComb lcl rec <$> cmbs
 
 -- Type for aggregating the necessary stack frame size. First field is
 -- unboxed size, second is boxed. The Applicative instance takes the
@@ -602,10 +609,10 @@ countCtx = go 0 0
   go  ui  bi (Block ctx) = go ui bi ctx
   go  ui  bi ECtx = C ui bi
 
-emitComb :: Var v => RCtx v -> SuperNormal v -> Comb
-emitComb rec (Lambda ccs (TAbss vs bd))
+emitComb :: Var v => Word64 -> RCtx v -> SuperNormal v -> Comb
+emitComb lcl rec (Lambda ccs (TAbss vs bd))
   = Lam 0 (length vs) u b s
-  where C u b s = emitSection rec (ctx vs ccs) bd
+  where C u b s = emitSection lcl rec (ctx vs ccs) bd
 
 addCount :: Int -> Int -> Counted a -> Counted a
 addCount i j (C u b x) = C (u+i) (b+j) x
@@ -613,68 +620,69 @@ addCount i j (C u b x) = C (u+i) (b+j) x
 -- Emit a machine code section from an ANF term
 emitSection
   :: Var v
-  => RCtx v -> Ctx v -> ANormal v
+  => Word64 -> RCtx v -> Ctx v -> ANormal v
   -> Counted Section
-emitSection rec ctx (TLets us ms bu bo)
-  = emitLet rec ctx bu $ emitSection rec ectx bo
+emitSection lcl rec ctx (TLets us ms bu bo)
+  = emitLet lcl rec ctx bu $ emitSection lcl rec ectx bo
   where
   ectx = pushCtx (zip us ms) ctx
-emitSection rec ctx (TName u (Left f) args bo)
-  = emitClosures rec ctx args $ \ctx as
- -> Ins (Name (Env f) as) <$> emitSection rec (Var u BX ctx) bo
-emitSection rec ctx (TName u (Right v) args bo)
+emitSection lcl rec ctx (TName u (Left f) args bo)
+  = emitClosures lcl rec ctx args $ \ctx as
+ -> Ins (Name (Env f 0) as) <$> emitSection lcl rec (Var u BX ctx) bo
+emitSection lcl rec ctx (TName u (Right v) args bo)
   | Just (i,BX) <- ctxResolve ctx v
-  = emitClosures rec ctx args $ \ctx as
- -> Ins (Name (Stk i) as) <$> emitSection rec (Var u BX ctx) bo
+  = emitClosures lcl rec ctx args $ \ctx as
+ -> Ins (Name (Stk i) as) <$> emitSection lcl rec (Var u BX ctx) bo
   | Just n <- rctxResolve rec v
-  = emitClosures rec ctx args $ \ctx as
- -> Ins (Name (Env n) as) <$> emitSection rec (Var u BX ctx) bo
+  = emitClosures lcl rec ctx args $ \ctx as
+ -> Ins (Name (Env lcl n) as) <$> emitSection lcl rec (Var u BX ctx) bo
   | otherwise = emitSectionVErr v
-emitSection rec ctx (TVar v)
+emitSection lcl rec ctx (TVar v)
   | Just (i,BX) <- ctxResolve ctx v = countCtx ctx . Yield $ BArg1 i
   | Just (i,UN) <- ctxResolve ctx v = countCtx ctx . Yield $ UArg1 i
-  | Just j <- rctxResolve rec v = countCtx ctx $ App False (Env j) ZArgs
+  | Just j <- rctxResolve rec v
+  = countCtx ctx $ App False (Env lcl j) ZArgs
   | otherwise = emitSectionVErr v
-emitSection _   ctx (TPrm p args)
+emitSection _   _   ctx (TPrm p args)
   -- 3 is a conservative estimate of how many extra stack slots
   -- a prim op will need for its results.
   = addCount 3 3 . countCtx ctx
   . Ins (emitPOp p $ emitArgs ctx args) . Yield $ DArgV i j
   where
   (i, j) = countBlock ctx
-emitSection _   ctx (TIOp p args)
+emitSection _   _   ctx (TIOp p args)
   = addCount 3 3 . countCtx ctx
   . Ins (emitIOp p $ emitArgs ctx args) . Yield $ DArgV i j
   where
   (i, j) = countBlock ctx
-emitSection rec ctx (TApp f args)
-  = emitClosures rec ctx args $ \ctx as
- -> countCtx ctx $ emitFunction rec ctx f as
-emitSection _   ctx (TLit l)
+emitSection lcl rec ctx (TApp f args)
+  = emitClosures lcl rec ctx args $ \ctx as
+ -> countCtx ctx $ emitFunction lcl rec ctx f as
+emitSection _   _   ctx (TLit l)
   = c . countCtx ctx . Ins (emitLit l) . Yield $ litArg l
   where
   c | ANF.T{} <- l = addCount 0 1
     | ANF.LM{} <- l = addCount 0 1
     | ANF.LY{} <- l = addCount 0 1
     | otherwise = addCount 1 0
-emitSection rec ctx (TMatch v bs)
+emitSection lcl rec ctx (TMatch v bs)
   | Just (i,BX) <- ctxResolve ctx v
   , MatchData _ cs df <- bs
   =  Ins (Unpack i)
- <$> emitDataMatching rec ctx cs df
+ <$> emitDataMatching lcl rec ctx cs df
   | Just (i,BX) <- ctxResolve ctx v
   , MatchRequest hs df <- bs
   =  Ins (Unpack i)
- <$> emitRequestMatching rec ctx hs df
+ <$> emitRequestMatching lcl rec ctx hs df
   | Just (i,UN) <- ctxResolve ctx v
   , MatchIntegral cs df <- bs
-  = emitIntegralMatching rec ctx i cs df
+  = emitIntegralMatching lcl rec ctx i cs df
   | Just (i,BX) <- ctxResolve ctx v
   , MatchText cs df <- bs
-  = emitTextMatching rec ctx i cs df
+  = emitTextMatching lcl rec ctx i cs df
   | Just (i,UN) <- ctxResolve ctx v
   , MatchSum cs <- bs
-  = emitSumMatching rec ctx v i cs
+  = emitSumMatching lcl rec ctx v i cs
   | Just (_,cc) <- ctxResolve ctx v
   = error
   $ "emitSection: mismatched calling convention for match: "
@@ -682,54 +690,56 @@ emitSection rec ctx (TMatch v bs)
   | otherwise
   = error
   $ "emitSection: could not resolve match variable: " ++ show (ctx,v)
-emitSection rec ctx (THnd rts h b)
+emitSection lcl rec ctx (THnd rts h b)
   | Just (i,BX) <- ctxResolve ctx h
   =  Ins (Reset (EC.setFromList rs))
   .  flip (foldr (\r -> Ins (SetDyn r i))) rs
- <$> emitSection rec ctx b
+ <$> emitSection lcl rec ctx b
   | otherwise = emitSectionVErr h
   where
   rs = rawTag <$> rts
 
-emitSection rec ctx (TShift i v e)
+emitSection lcl rec ctx (TShift i v e)
   =  Ins (Capture $ rawTag i)
- <$> emitSection rec (Var v BX ctx) e
-emitSection _   ctx (TFrc v)
+ <$> emitSection lcl rec (Var v BX ctx) e
+emitSection _   _   ctx (TFrc v)
   | Just (i,BX) <- ctxResolve ctx v
   = countCtx ctx $ App False (Stk i) ZArgs
   | Just _ <- ctxResolve ctx v = error
   $ "emitSection: values to be forced must be boxed: " ++ show v
   | otherwise = emitSectionVErr v
-emitSection _ _ tm = error $ "emitSection: unhandled code: " ++ show tm
+emitSection _ _ _ tm
+  = error $ "emitSection: unhandled code: " ++ show tm
 
 -- Emit the code for a function call
-emitFunction :: Var v => RCtx v -> Ctx v -> Func v -> Args -> Section
-emitFunction rec ctx (FVar v) as
+emitFunction
+  :: Var v => Word64 -> RCtx v -> Ctx v -> Func v -> Args -> Section
+emitFunction lcl rec ctx (FVar v) as
   | Just (i,BX) <- ctxResolve ctx v
   = App False (Stk i) as
   | Just j <- rctxResolve rec v
-  = App False (Env j) as
+  = App False (Env lcl j) as
   | otherwise = emitSectionVErr v
-emitFunction _   _   (FComb n) as
+emitFunction _   _   _   (FComb n) as
   | False -- known saturated call
   = Call False n as
   | False -- known unsaturated call
-  = Ins (Name (Env n) as) $ Yield (BArg1 0)
+  = Ins (Name (Env n 0) as) $ Yield (BArg1 0)
   | otherwise -- slow path
-  = App False (Env n) as
-emitFunction _   _   (FCon r t) as
+  = App False (Env n 0) as
+emitFunction _   _   _   (FCon r t) as
   = Ins (Pack (packTags r t) as)
   . Yield $ BArg1 0
-emitFunction _   _   (FReq a e) as
+emitFunction _   _   _   (FReq a e) as
   -- Currently implementing packed calling convention for abilities
   = Ins (Lit (MI . fromIntegral $ rawTag e))
   . Ins (Pack (rawTag a) (reqArgs as))
   . App True (Dyn $ rawTag a) $ BArg1 0
-emitFunction _   ctx (FCont k) as
+emitFunction _   _   ctx (FCont k) as
   | Just (i, BX) <- ctxResolve ctx k = Jump i as
   | Nothing <- ctxResolve ctx k = emitFunctionVErr k
   | otherwise = error $ "emitFunction: continuations are boxed"
-emitFunction _ _ (FPrim _) _
+emitFunction _ _ _ (FPrim _) _
   = error "emitFunction: impossible"
 
 -- Modify function arguments for packing into a request
@@ -802,22 +812,22 @@ litArg _       = UArg1 0
 -- manipulation.
 emitLet
   :: Var v
-  => RCtx v -> Ctx v -> ANormalT v
+  => Word64 -> RCtx v -> Ctx v -> ANormalT v
   -> Counted Section
   -> Counted Section
-emitLet _   _   (ALit l)
+emitLet _   _   _   (ALit l)
   = fmap (Ins $ emitLit l)
-emitLet _    ctx (AApp (FComb n) args)
+emitLet _   _    ctx (AApp (FComb n) args)
   -- We should be able to tell if we are making a saturated call
   -- or not here. We aren't carrying the information here yet, though.
   | False -- not saturated
-  = fmap (Ins . Name (Env n) $ emitArgs ctx args)
-emitLet _   ctx (AApp (FCon r n) args)
+  = fmap (Ins . Name (Env n 0) $ emitArgs ctx args)
+emitLet _   _   ctx (AApp (FCon r n) args)
   = fmap (Ins . Pack (packTags r n) $ emitArgs ctx args)
-emitLet _   ctx (AApp (FPrim p) args)
+emitLet _   _   ctx (AApp (FPrim p) args)
   = fmap (Ins . either emitPOp emitIOp p $ emitArgs ctx args)
-emitLet rec ctx bnd
-  = liftA2 Let (emitSection rec (Block ctx) (TTm bnd))
+emitLet lcl rec ctx bnd
+  = liftA2 Let (emitSection lcl rec (Block ctx) (TTm bnd))
 
 -- Translate from ANF prim ops to machine code operations. The
 -- machine code operations are divided with respect to more detailed
@@ -998,18 +1008,19 @@ emitBP2 p a
 
 emitDataMatching
   :: Var v
-  => RCtx v
+  => Word64
+  -> RCtx v
   -> Ctx v
   -> EnumMap CTag ([Mem], ANormal v)
   -> Maybe (ANormal v)
   -> Counted Section
-emitDataMatching rec ctx cs df
-  = MatchW 0 <$> edf <*> traverse (emitCase rec ctx) (coerce cs)
+emitDataMatching lcl rec ctx cs df
+  = MatchW 0 <$> edf <*> traverse (emitCase lcl rec ctx) (coerce cs)
   where
   -- Note: this is not really accurate. A default data case needs
   -- stack space corresponding to the actual data that shows up there.
   -- However, we currently don't use default cases for data.
-  edf | Just co <- df = emitSection rec ctx co
+  edf | Just co <- df = emitSection lcl rec ctx co
       | otherwise = countCtx ctx $ Die "missing data case"
 
 -- Emits code corresponding to an unboxed sum match.
@@ -1019,73 +1030,77 @@ emitDataMatching rec ctx cs df
 -- branching on the tag.
 emitSumMatching
   :: Var v
-  => RCtx v
+  => Word64
+  -> RCtx v
   -> Ctx v
   -> v
   -> Int
   -> EnumMap Word64 ([Mem], ANormal v)
   -> Counted Section
-emitSumMatching rec ctx v i cs
-  = MatchW i edf <$> traverse (emitSumCase rec ctx v) cs
+emitSumMatching lcl rec ctx v i cs
+  = MatchW i edf <$> traverse (emitSumCase lcl rec ctx v) cs
   where
   edf = Die "uncovered unboxed sum case"
 
 emitRequestMatching
   :: Var v
-  => RCtx v
+  => Word64
+  -> RCtx v
   -> Ctx v
   -> EnumMap RTag (EnumMap CTag ([Mem], ANormal v))
   -> ANormal v
   -> Counted Section
-emitRequestMatching rec ctx hs df = MatchW 0 edf <$> tops
+emitRequestMatching lcl rec ctx hs df = MatchW 0 edf <$> tops
   where
   tops = mapInsert 0
-           <$> emitCase rec ctx ([BX], df)
+           <$> emitCase lcl rec ctx ([BX], df)
            <*> traverse f (coerce hs)
-  f cs = MatchW 1 edf <$> traverse (emitCase rec ctx) cs
+  f cs = MatchW 1 edf <$> traverse (emitCase lcl rec ctx) cs
   edf = Die "unhandled ability"
 
 emitIntegralMatching
   :: Var v
-  => RCtx v
+  => Word64
+  -> RCtx v
   -> Ctx v
   -> Int
   -> EnumMap Word64 (ANormal v)
   -> Maybe (ANormal v)
   -> Counted Section
-emitIntegralMatching rec ctx i cs df
-  = MatchW i <$> edf <*> traverse (emitCase rec ctx . ([],)) cs
+emitIntegralMatching lcl rec ctx i cs df
+  = MatchW i <$> edf <*> traverse (emitCase lcl rec ctx . ([],)) cs
   where
-  edf | Just co <- df = emitSection rec ctx co
+  edf | Just co <- df = emitSection lcl rec ctx co
       | otherwise = countCtx ctx $ Die "missing integral case"
 
 emitTextMatching
   :: Var v
-  => RCtx v
+  => Word64
+  -> RCtx v
   -> Ctx v
   -> Int
   -> M.Map Text (ANormal v)
   -> Maybe (ANormal v)
   -> Counted Section
-emitTextMatching rec ctx i cs df
-  = MatchT i <$> edf <*> traverse (emitCase rec ctx . ([],)) cs
+emitTextMatching lcl rec ctx i cs df
+  = MatchT i <$> edf <*> traverse (emitCase lcl rec ctx . ([],)) cs
   where
-  edf | Just co <- df = emitSection rec ctx co
+  edf | Just co <- df = emitSection lcl rec ctx co
       | otherwise = countCtx ctx $ Die "missing text case"
 
 emitCase
   :: Var v
-  => RCtx v -> Ctx v -> ([Mem], ANormal v)
+  => Word64 -> RCtx v -> Ctx v -> ([Mem], ANormal v)
   -> Counted Section
-emitCase rec ctx (ccs, TAbss vs bo)
-  = emitSection rec (Tag $ pushCtx (zip vs ccs) ctx) bo
+emitCase lcl rec ctx (ccs, TAbss vs bo)
+  = emitSection lcl rec (Tag $ pushCtx (zip vs ccs) ctx) bo
 
 emitSumCase
   :: Var v
-  => RCtx v -> Ctx v -> v -> ([Mem], ANormal v)
+  => Word64 -> RCtx v -> Ctx v -> v -> ([Mem], ANormal v)
   -> Counted Section
-emitSumCase rec ctx v (ccs, TAbss vs bo)
-  = emitSection rec (sumCtx ctx v $ zip vs ccs) bo
+emitSumCase lcl rec ctx v (ccs, TAbss vs bo)
+  = emitSection lcl rec (sumCtx ctx v $ zip vs ccs) bo
 
 emitLit :: ANF.Lit -> Instr
 emitLit l = Lit $ case l of
@@ -1106,17 +1121,17 @@ emitLit l = Lit $ case l of
 -- provided continuation.
 emitClosures
   :: Var v
-  => RCtx v -> Ctx v -> [v]
+  => Word64 -> RCtx v -> Ctx v -> [v]
   -> (Ctx v -> Args -> Counted Section)
   -> Counted Section
-emitClosures rec ctx args k
+emitClosures lcl rec ctx args k
   = allocate ctx args $ \ctx -> k ctx $ emitArgs ctx args
   where
   allocate ctx [] k = k ctx
   allocate ctx (a:as) k
     | Just _ <- ctxResolve ctx a = allocate ctx as k
     | Just n <- rctxResolve rec a
-    = Ins (Name (Env n) ZArgs) <$> allocate (Var a BX ctx) as k
+    = Ins (Name (Env lcl n) ZArgs) <$> allocate (Var a BX ctx) as k
     | otherwise
     = error $ "emitClosures: unknown reference: " ++ show a
 
@@ -1146,16 +1161,16 @@ indent :: Int -> ShowS
 indent ind = showString (replicate (ind*2) ' ')
 
 prettyCombs
-  :: (Comb, EnumMap Word64 Comb, Word64)
+  :: Word64
+  -> EnumMap Word64 Comb
   -> ShowS
-prettyCombs (c, es, w)
-  = foldr (\(w,c) r -> prettyComb w c . showString "\n" . r)
+prettyCombs w es
+  = foldr (\(i,c) r -> prettyComb w i c . showString "\n" . r)
       id (mapToList es)
-  . showString "\n" . prettyComb w c
 
-prettyComb :: Word64 -> Comb -> ShowS
-prettyComb w (Lam ua ba _ _ s)
-  = shows w . shows [ua,ba]
+prettyComb :: Word64 -> Word64 -> Comb -> ShowS
+prettyComb w i (Lam ua ba _ _ s)
+  = shows w . showString ":" . shows i . shows [ua,ba]
   . showString ":\n" . prettySection 2 s
 
 prettySection :: Int -> Section -> ShowS

--- a/parser-typechecker/src/Unison/Runtime/Rt1IO.hs
+++ b/parser-typechecker/src/Unison/Runtime/Rt1IO.hs
@@ -456,7 +456,7 @@ lamToHask cenv s ir val = RT.run (handleIO' cenv s) cenv $ task val
   where task x = IR.Let (Var.named "_") (IR.Leaf (IR.Val x)) ir mempty
 
 runtime :: Runtime Symbol
-runtime = Runtime terminate eval (nullaryMain External)
+runtime = Runtime terminate eval (nullaryMain External) True
  where
   terminate :: IO ()
   terminate = pure ()

--- a/parser-typechecker/src/Unison/Runtime/Stack.hs
+++ b/parser-typechecker/src/Unison/Runtime/Stack.hs
@@ -60,7 +60,7 @@ import Data.Word
 
 import Unison.Reference (Reference)
 
-import Unison.Runtime.ANF (Mem(..), unpackTags, RTag)
+import Unison.Runtime.ANF (Mem(..))
 import Unison.Runtime.MCode
 import Unison.Runtime.Foreign
 
@@ -94,34 +94,35 @@ data K
   deriving (Eq, Ord)
 
 data CombIx
-  = CIx !Word64 -- top level
-        !Word64 -- section
+  = CIx !Reference -- top reference
+        !Word64    -- top level
+        !Word64    -- section
   deriving (Eq, Ord, Show)
 
 data Closure
   = PAp {-# unpack #-} !CombIx    -- reference
         {-# unpack #-} !(Seg 'UN) -- unboxed args
         {-  unpack  -} !(Seg 'BX) -- boxed args
-  | Enum !Word64
-  | DataU1 !Word64 !Int
-  | DataU2 !Word64 !Int !Int
-  | DataB1 !Word64 !Closure
-  | DataB2 !Word64 !Closure !Closure
-  | DataUB !Word64 !Int !Closure
-  | DataG !Word64 !(Seg 'UN) !(Seg 'BX)
+  | Enum !Reference !Word64
+  | DataU1 !Reference !Word64 !Int
+  | DataU2 !Reference !Word64 !Int !Int
+  | DataB1 !Reference !Word64 !Closure
+  | DataB2 !Reference !Word64 !Closure !Closure
+  | DataUB !Reference !Word64 !Int !Closure
+  | DataG !Reference !Word64 !(Seg 'UN) !(Seg 'BX)
   | Captured !K {-# unpack #-} !(Seg 'UN) !(Seg 'BX)
   | Foreign !Foreign
   | BlackHole
   deriving (Show, Eq, Ord)
 
-splitData :: Closure -> Maybe (Word64, [Int], [Closure])
-splitData (Enum t) = Just (t, [], [])
-splitData (DataU1 t i) = Just (t, [i], [])
-splitData (DataU2 t i j) = Just (t, [i,j], [])
-splitData (DataB1 t x) = Just (t, [], [x])
-splitData (DataB2 t x y) = Just (t, [], [x,y])
-splitData (DataUB t i y) = Just (t, [i], [y])
-splitData (DataG t us bs) = Just (t, ints us, toList bs)
+splitData :: Closure -> Maybe (Reference, Word64, [Int], [Closure])
+splitData (Enum r t) = Just (r, t, [], [])
+splitData (DataU1 r t i) = Just (r, t, [i], [])
+splitData (DataU2 r t i j) = Just (r, t, [i,j], [])
+splitData (DataB1 r t x) = Just (r, t, [], [x])
+splitData (DataB2 r t x y) = Just (r, t, [], [x,y])
+splitData (DataUB r t i y) = Just (r, t, [i], [y])
+splitData (DataG r t us bs) = Just (r, t, ints us, toList bs)
 splitData _ = Nothing
 
 ints :: ByteArray -> [Int]
@@ -129,8 +130,8 @@ ints ba = fmap (indexByteArray ba) [0..n-1]
   where
   n = sizeofByteArray ba `div` 8
 
-pattern DataC rt ct us bs <-
-  (splitData -> Just (unpackTags -> (rt, ct), us, bs))
+pattern DataC rf ct us bs <-
+  (splitData -> Just (rf, ct, us, bs))
 
 pattern PApV ic us bs <- PAp ic (ints -> us) (toList -> bs)
 pattern CapV k us bs <- Captured k (ints -> us) (toList -> bs)
@@ -147,35 +148,33 @@ closureNum Foreign{} = 3
 closureNum BlackHole{} = error "BlackHole"
 
 universalCompare
-  :: (Word64 -> Reference)
-  -> (RTag -> Reference)
-  -> (Foreign -> Foreign -> Ordering)
+  :: (Foreign -> Foreign -> Ordering)
   -> Closure
   -> Closure
   -> Ordering
-universalCompare _    tag frn = cmpc
+universalCompare frn = cmpc False
   where
   cmpl cm l r
     = compare (length l) (length r) <> fold (zipWith cm l r)
-  cmpc (DataC rt1 ct1 us1 bs1) (DataC rt2 ct2 us2 bs2)
-    = compare (tag rt1) (tag rt2)
+  cmpc tyEq (DataC rf1 ct1 us1 bs1) (DataC rf2 ct2 us2 bs2)
+    = (if tyEq then compare rf1 rf2 else EQ)
    <> compare ct1 ct2
    <> cmpl compare us1 us2
-   <> cmpl cmpc bs1 bs2
-  cmpc (PApV i1 us1 bs1) (PApV i2 us2 bs2)
+   <> cmpl (cmpc tyEq) bs1 bs2
+  cmpc tyEq (PApV i1 us1 bs1) (PApV i2 us2 bs2)
     = compare i1 i2
    <> cmpl compare us1 us2
-   <> cmpl cmpc bs1 bs2
-  cmpc (CapV k1 us1 bs1) (CapV k2 us2 bs2)
+   <> cmpl (cmpc tyEq) bs1 bs2
+  cmpc _ (CapV k1 us1 bs1) (CapV k2 us2 bs2)
     = compare k1 k2
    <> cmpl compare us1 us2
-   <> cmpl cmpc bs1 bs2
-  cmpc (Foreign fl) (Foreign fr)
+   <> cmpl (cmpc True) bs1 bs2
+  cmpc tyEq (Foreign fl) (Foreign fr)
     | Just sl <- maybeUnwrapForeign Ty.vectorRef fl
     , Just sr <- maybeUnwrapForeign Ty.vectorRef fr
-    = comparing Sq.length sl sr <> fold (Sq.zipWith cmpc sl sr)
+    = comparing Sq.length sl sr <> fold (Sq.zipWith (cmpc tyEq) sl sr)
     | otherwise = frn fl fr
-  cmpc c d = comparing closureNum c d
+  cmpc _ c d = comparing closureNum c d
 
 marshalToForeign :: HasCallStack => Closure -> Foreign
 marshalToForeign (Foreign x) = x

--- a/parser-typechecker/src/Unison/Runtime/Stack.hs
+++ b/parser-typechecker/src/Unison/Runtime/Stack.hs
@@ -402,7 +402,7 @@ instance MEM 'UN where
   augSeg mode (US ap fp sp stk) seg margs = do
     cop <- newByteArray $ ssz+psz+asz
     copyByteArray cop soff seg 0 ssz
-    copyMutableByteArray cop 0 stk ap psz
+    copyMutableByteArray cop 0 stk (bytes $ ap+1) psz
     for_ margs $ uargOnto stk sp cop (words poff + pix - 1)
     unsafeFreezeByteArray cop
    where
@@ -600,7 +600,7 @@ instance MEM 'BX where
   augSeg mode (BS ap fp sp stk) seg margs = do
     cop <- newArray (ssz+psz+asz) BlackHole
     copyArray cop soff seg 0 ssz
-    copyMutableArray cop poff stk ap psz
+    copyMutableArray cop poff stk (ap+1) psz
     for_ margs $ bargOnto stk sp cop (poff+psz-1)
     unsafeFreezeArray cop
    where

--- a/parser-typechecker/src/Unison/Runtime/Stack.hs
+++ b/parser-typechecker/src/Unison/Runtime/Stack.hs
@@ -37,6 +37,7 @@ module Unison.Runtime.Stack
   , peekOffS
   , pokeS
   , pokeOffS
+  , frameView
   , uscount
   , bscount
   ) where
@@ -631,6 +632,24 @@ instance MEM 'BX where
   {-# inline fsize #-}
 
   asize (BS ap fp _ _) = fp-ap
+
+frameView :: MEM b => Show (Elem b) => Stack b -> IO ()
+frameView stk = putStr "|" >> gof False 0
+  where
+  fsz = fsize stk
+  asz = asize stk
+  gof delim n
+    | n >= fsz = putStr "|" >> goa False 0
+    | otherwise = do
+      when delim $ putStr ","
+      putStr . show =<< peekOff stk n
+      gof True (n+1)
+  goa delim n
+    | n >= asz = putStrLn "|.."
+    | otherwise = do
+      when delim $ putStr ","
+      putStr . show =<< peekOff stk (fsz+n)
+      goa True (n+1)
 
 uscount :: Seg 'UN -> Int
 uscount seg = words $ sizeofByteArray seg

--- a/parser-typechecker/tests/Unison/Test/ANF.hs
+++ b/parser-typechecker/tests/Unison/Test/ANF.hs
@@ -9,11 +9,13 @@ import Unison.ABT.Normalized (Term(TAbs))
 import qualified Unison.Pattern as P
 import Unison.Reference (Reference)
 import Unison.Runtime.ANF as ANF
-import Unison.Runtime.MCode (emitCombs)
+import Unison.Runtime.MCode (emitCombs, RefNums(..))
 import Unison.Type as Ty
 import Unison.Var as Var
 
 import Unison.Util.EnumContainers as EC
+
+import Data.Word (Word64)
 
 import qualified Data.Set as Set
 import qualified Data.Map as Map
@@ -41,9 +43,7 @@ simpleRefs r
   | otherwise = 100
 
 runANF :: Var v => ANFM v a -> a
-runANF m = evalState (runReaderT m env) (0, [])
- where
- env = (Set.empty, const 0, simpleRefs)
+runANF m = evalState (runReaderT m Set.empty) (0, [])
 
 testANF :: String -> Test ()
 testANF s
@@ -56,7 +56,10 @@ testANF s
 testLift :: String -> Test ()
 testLift s = case cs of !_ -> ok
   where
-  cs = emitCombs 0 . superNormalize (const 0) (const 0) . lamLift $ tm s
+  cs = emitCombs (RN (const 0) (const 0)) 0
+     . superNormalize
+     . lamLift
+     $ tm s
 
 denormalize :: Var v => ANormal v -> Term.Term0 v
 denormalize (TVar v) = Term.var () v
@@ -84,8 +87,7 @@ denormalize (TName _ _ _ _)
 denormalize (TMatch v cs)
   = Term.match () (ABT.var v) $ denormalizeMatch cs
 denormalize (TApp f args)
-  | FCon rt 0 <- f
-  , r <- denormalizeRef rt
+  | FCon r 0 <- f
   , r `elem` [Ty.natRef, Ty.intRef]
   , [v] <- args
   = Term.var () v
@@ -95,9 +97,9 @@ denormalize (TApp f args) = Term.apps' df (Term.var () <$> args)
     FVar v -> Term.var () v
     FComb _ -> error "FComb"
     FCon r n ->
-      Term.constructor () (denormalizeRef r) (fromIntegral $ rawTag n)
+      Term.constructor () r (fromIntegral $ rawTag n)
     FReq r n ->
-      Term.request () (denormalizeRef r) (fromIntegral $ rawTag n)
+      Term.request () r (fromIntegral $ rawTag n)
     FPrim _ -> error "FPrim"
     FCont _ -> error "denormalize FCont"
 denormalize (TFrc _) = error "denormalize TFrc"
@@ -112,7 +114,7 @@ denormalizeRef r
   | 5 <- rawTag r = Ty.charRef
   | otherwise = error "denormalizeRef"
 
-backReference :: RTag -> Reference
+backReference :: Word64 -> Reference
 backReference _ = error "backReference"
 
 denormalizeMatch
@@ -151,19 +153,19 @@ denormalizeBranch tm = (0, denormalize tm)
 
 denormalizeHandler
   :: Var v
-  => EnumMap RTag (EnumMap CTag ([Mem], ANormal v))
+  => Map.Map Reference (EnumMap CTag ([Mem], ANormal v))
   -> ANormal v
   -> [Term.MatchCase () (Term.Term0 v)]
 denormalizeHandler cs df = dcs
   where
-  dcs = foldMapWithKey rf cs <> dfc
+  dcs = Map.foldMapWithKey rf cs <> dfc
   dfc = [ Term.MatchCase
             (P.EffectPure () (P.Var ()))
             Nothing
             db
         ]
    where (_, db) = denormalizeBranch df
-  rf r rcs = foldMapWithKey (cf $ backReference r) rcs
+  rf r rcs = foldMapWithKey (cf r) rcs
   cf r t b = [ Term.MatchCase
                  (P.EffectBind () r (fromEnum t)
                    (replicate n $ P.Var ()) (P.Var ()))

--- a/parser-typechecker/tests/Unison/Test/ANF.hs
+++ b/parser-typechecker/tests/Unison/Test/ANF.hs
@@ -54,7 +54,7 @@ testANF s
   anf = runANF $ anfTerm t0
 
 testLift :: String -> Test ()
-testLift s = case cs of (!_, !_, _) -> ok
+testLift s = case cs of !_ -> ok
   where
   cs = emitCombs 0 . superNormalize (const 0) (const 0) . lamLift $ tm s
 

--- a/parser-typechecker/tests/Unison/Test/MCode.hs
+++ b/parser-typechecker/tests/Unison/Test/MCode.hs
@@ -90,6 +90,20 @@ nested
     \        m@n -> n\n\
     \  ##todo (##Nat.== x 2)"
 
+matching'arguments :: String
+matching'arguments
+  = "let\n\
+    \  f x y z = y\n\
+    \  g x = f x\n\
+    \  blorf = let\n\
+    \    a = 0\n\
+    \    b = 1\n\
+    \    d = 2\n\
+    \    h = g a b\n\
+    \    c = 2\n\
+    \    h c\n\
+    \  ##todo (##Nat.== blorf 1)"
+
 test :: Test ()
 test = scope "mcode" . tests $
   [ scope "2=2" $ testEval "##todo (##Nat.== 2 2)"
@@ -102,4 +116,6 @@ test = scope "mcode" . tests $
   , scope "5*1000=5000 rec" $ testEval multRec
   , scope "nested"
   $ testEval nested
+  , scope "matching arguments"
+  $ testEval matching'arguments
   ]

--- a/parser-typechecker/tests/Unison/Test/UnisonSources.hs
+++ b/parser-typechecker/tests/Unison/Test/UnisonSources.hs
@@ -3,6 +3,7 @@
 
 module Unison.Test.UnisonSources where
 
+import           Control.Exception      (throwIO)
 import           Control.Lens           ( view )
 import           Control.Lens.Tuple     ( _5 )
 import           Control.Monad          (void)
@@ -37,6 +38,7 @@ import           Unison.Test.Common     (parseAndSynthesizeAsFile, parsingEnv)
 import           Unison.Type            ( Type )
 import qualified Unison.UnisonFile      as UF
 import           Unison.Util.Monoid     (intercalateMap)
+import           Unison.Util.Pretty     (toPlain)
 import qualified Unison.Var             as Var
 import qualified Unison.Test.Common as Common
 import qualified Unison.Names3
@@ -137,7 +139,8 @@ resultTest rt uf filepath = do
       values <- io $ unpack <$> Data.Text.IO.readFile valueFile
       let untypedFile = UF.discardTypes uf
       let term        = Parsers.parseTerm values parsingEnv
-      (bindings, watches) <- io $ either undefined id <$>
+      let report e = throwIO (userError $ toPlain 10000 e)
+      (bindings, watches) <- io $ either report pure =<<
         evaluateWatches Builtin.codeLookup
                         mempty
                         (const $ pure Nothing)

--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -939,6 +939,9 @@ hashComponents
   :: Var v => Map v (Term v a) -> Map v (Reference.Id, Term v a)
 hashComponents = ReferenceUtil.hashComponents $ refId ()
 
+hashClosedTerm :: Var v => Term v a -> Reference.Id
+hashClosedTerm tm = Reference.Id (ABT.hash tm) 0 1
+
 -- The hash for a constructor
 hashConstructor'
   :: (Reference -> ConstructorId -> Term0 Symbol) -> Reference -> ConstructorId -> Reference


### PR DESCRIPTION
This pull request pulls in some work done in preparation of being able to send code between machines. I'm submitting this because it is useful on its own right now. There is also a bugfix included.

- I've added a flag that changes how UCM will submit code to a runtime. The runtime can say that it requires code to be self-contained, or doesn't care. The old runtime requires self-contained code, while the new one doesn't anymore.
- Even for the new runtime, UCM will put things in a let rec block unless they've been added to the codebase (or something along those lines). So the new runtime also hashes these to break things down further. Things already referenced in the codebase are figured out using the `CodeLookup`
- Hashing the top-level let rec doesn't get rid of all cycles. These are lifted after hashing, possibly causing a new top-level let rec for each hashed reference. These are then represented in the runtime as different numbered sections of a single referenced definition. There is a 'main entry point' that corresponds to the original definition, and 'local' sections that are only referred to from within the definition.
- Work on this revealed a problem with how the new runtime was handling some stack management. This has been fixed.
- `PAp` closures have been modified to not store the machine code they will execute. Rather, it stores the numbering necessary to look up that code. This means that the closures can be serialized independently of the code. Continuations need the same treatment, but they are a bit trickier.
- ANF code has been reworked to use `Reference` rather than a machine-specific numbering. It seems like something close to ANF could be transportable, but it isn't safe to be including ephemeral numbering schemes in it in that case.
- Some tagging in the runtime used to be able to recover `References` has been swapped with just storing the reference. This is simpler for some applications, but we'll need to investigate the performance of stuff a bit, to make sure it isn't a problem.
- The new code scheme probably made decompilation of partially applied functions a bit worse. I haven't had time to work out how to do that well.

There's also a tweak for better failing test output in UnisonSources, and a helper function for hashing closed terms.

This branch isn't complete, but I think this work is useful enough to be merged back (and Paul is waiting on the second-last bullet point).