### PR TITLE
Do transitive dependency resolution in the new runtime

### DIFF
--- a/unison-src/transcripts/fix1709.md
+++ b/unison-src/transcripts/fix1709.md
@@ -1,0 +1,15 @@
+```unison
+id x = x
+
+id2 x =
+  z = 384849
+  id x
+```
+
+```ucm
+.scratch> add
+```
+
+```unison
+> id2 "hi"
+```

--- a/unison-src/transcripts/fix1709.output.md
+++ b/unison-src/transcripts/fix1709.output.md
@@ -1,0 +1,49 @@
+```unison
+id x = x
+
+id2 x =
+  z = 384849
+  id x
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      id  : x -> x
+      id2 : x -> x
+
+```
+```ucm
+  ☝️  The namespace .scratch is empty.
+
+.scratch> add
+
+  ⍟ I've added these definitions:
+  
+    id  : x -> x
+    id2 : x -> x
+
+```
+```unison
+> id2 "hi"
+```
+
+```ucm
+
+  ✅
+  
+  scratch.u changed.
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    1 | > id2 "hi"
+          ⧩
+          "hi"
+
+```


### PR DESCRIPTION
The existing code was only loading the immediate child dependencies.

Fixes #1709 