### PR TITLE
Add multi-argument `cases` lambdas

### DIFF
--- a/parser-typechecker/src/Unison/Parser.hs
+++ b/parser-typechecker/src/Unison/Parser.hs
@@ -102,6 +102,7 @@ data Error v
   | ResolutionFailures [Names.ResolutionFailure v Ann]
   | DuplicateTypeNames [(v, [Ann])]
   | DuplicateTermNames [(v, [Ann])]
+  | PatternArityMismatch Int Int Ann -- PatternArityMismatch expectedArity actualArity location
   deriving (Show, Eq, Ord)
 
 data Ann

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -932,6 +932,14 @@ prettyParseError s = \case
   errorVar v = style ErrorSite . fromString . Text.unpack $ Var.name v
   go :: Parser.Error v -> Pretty ColorText
   -- | UseInvalidPrefixSuffix (Either (L.Token Name) (L.Token Name)) (Maybe [L.Token Name])
+  go (Parser.PatternArityMismatch expected actual loc) = msg where
+    msg = Pr.indentN 2 . Pr.callout "😶" $ Pr.lines [
+      Pr.wrap $ "Not all the branches of this pattern matching have"
+             <> "the same number of arguments. I was assuming they'd all have "
+             <> Pr.hiBlue (Pr.shown expected) <> "arguments (based on the previous patterns)"
+             <> "but this one has " <> Pr.hiRed (Pr.shown actual) <> "arguments:",
+      annotatedAsErrorSite s loc
+      ]
   go (Parser.UseEmpty tok) = msg where
     msg = Pr.indentN 2 . Pr.callout "😶" $ Pr.lines [
       Pr.wrap $ "I was expecting something after the " <> Pr.hiRed "use" <> "keyword", "",

--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -289,7 +289,9 @@ lamCase = do
   -- TODO: Add error for empty match list
   _ <- closeBlock
   lamvars <- replicateM arity (Parser.uniqueName 10)
-  let vars = Var.named <$> lamvars
+  let vars = Var.named <$> [ tweak v i | (v,i) <- lamvars `zip` [(1::Int)..] ]
+      tweak v 0 = v
+      tweak v i = v <> Text.pack (show i)
       lamvarTerms = Term.var (ann start) <$> vars
       lamvarTerm = case lamvarTerms of
         [e] -> e

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -1115,7 +1115,10 @@ pattern LamsNamedMatch' vs branches <- (unLamsMatch' -> Just (vs, branches))
 --     (h +: t) -> "nonempty"
 --
 -- this function will return Just ([x,y], [[] -> "empty", (h +: t) -> "nonempty"])
--- and it would be rendered as `x y -> cases [] -> "empty"`
+-- and it would be rendered as
+--
+--   x y -> cases []     -> "empty"
+--                h +: t -> "nonempty"
 --
 -- Given this term
 --

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -286,7 +286,7 @@ pretty0
        ]
       else ((fmt S.ControlKeyword "match ") <> ps <> (fmt S.ControlKeyword " with")) `PP.hang` pbs
       where ps = pretty0 n (ac 2 Normal im doc) scrutinee
-            pbs = printCase n im doc branches
+            pbs = printCase n im doc (arity1Branches branches) -- don't print with `cases` syntax
 
     t -> l "error: " <> l (show t)
  where
@@ -456,12 +456,17 @@ prettyPattern n c@(AmbientContext { imports = im }) p vs patt = case patt of
   patternsSep p sep vs pats = case patterns p vs pats of
     (printed, tail_vs) -> (PP.sep sep printed, tail_vs)
 
+type MatchCase' ann tm = ([Pattern ann], Maybe tm, tm)
+
+arity1Branches :: [MatchCase ann tm] -> [MatchCase' ann tm]
+arity1Branches bs = [ ([pat], guard, body) | MatchCase pat guard body <- bs ]
+
 printCase
   :: Var v
   => PrettyPrintEnv
   -> Imports
   -> DocLiteralContext
-  -> [MatchCase () (Term3 v PrintAnnotation)]
+  -> [MatchCase' () (Term3 v PrintAnnotation)]
   -> Pretty SyntaxText
 printCase env im doc ms = PP.lines $ map each gridArrowsAligned where
   each (lhs, arrow, body) = PP.group $ (lhs <> arrow) `PP.hang` body
@@ -469,10 +474,12 @@ printCase env im doc ms = PP.lines $ map each gridArrowsAligned where
   gridArrowsAligned = tidy <$> zip (PP.align' (f <$> grid)) grid where
     f (a, b, _) = (a, Just b)
     tidy ((a', b'), (_, _, c)) = (a', b', c)
-  go (MatchCase pat guard (AbsN' vs body)) =
+  go (pats, guard, (AbsN' vs body)) =
     (lhs, arrow, (uses [pretty0 env (ac 0 Block im' doc) body]))
     where
-    lhs = PP.group (fst (prettyPattern env (ac 0 Block im doc) (-1) vs pat))
+    lhs = (case pats of
+            [pat] -> PP.group (fst (prettyPattern env (ac 0 Block im doc) (-1) vs pat))
+            pats  -> PP.group $ PP.spaced [p | (p, _) <- prettyPattern env (ac 0 Block im doc) 10 vs <$> pats])
        <> printGuard guard
     arrow = fmt S.ControlKeyword "->"
     printGuard (Just g') = let (_, g) = ABT.unabs g' in
@@ -1087,3 +1094,78 @@ unLetBlock t = rec t where
         Just (innerBindings, innerBody) | dontIntersect bindings innerBindings ->
           Just (bindings ++ innerBindings, innerBody)
         _ -> Just (bindings, body)
+
+pattern LamsNamedMatch' vs branches <- (unLamsMatch' -> Just (vs, branches))
+
+-- This function is used to detect places where lambda case syntax can be used.
+-- When given lambdas of a form that corresponds to a lambda case, it returns
+-- `Just (varsBeforeCases, branches)`. Leading vars are the vars that should be
+-- shown to the left of the `-> cases`.
+--
+-- For instance, if given this term:
+--
+--   x y z -> match z with
+--     [] -> "empty"
+--     (h +: t) -> "nonempty"
+--
+-- this function will return Just ([x,y], [[] -> "empty", (h +: t) -> "nonempty"])
+-- and it would be rendered as `x y -> cases [] -> "empty"`
+--
+-- Given this term
+--
+--   x y z -> match (y, z) with
+--     ("a", "b") -> "abba"
+--     (x, y) -> y ++ x
+--
+-- this function will return Just ([x], [ "a" "b" -> "abba", x y -> y ++ x])
+-- and it would be rendered as `x -> cases "a" "b" -> "abba"
+--                                         x    y  -> y ++ x
+--
+-- This function returns `Nothing` in cases where the term it is given isn't
+-- a lambda, or when the lambda isn't in the correct form for lambda cases.
+-- (For instance, `x -> match (x, 42) with ...` can't be written using
+-- lambda case)
+unLamsMatch'
+  :: Var v
+  => Term2 vt at ap v a
+  -> Maybe ([v], [([Pattern ap], Maybe (Term2 vt at ap v a), Term2 vt at ap v a)])
+unLamsMatch' t = case unLamsUntilDelay' t of
+    -- x -> match x with pat -> ...
+    --   becomes
+    -- cases pat -> ...
+    Just (reverse -> (v1:vs), Match' (Var' v1') branches) |
+      -- if `v1'` is referenced in any of the branches, we can't use lambda case
+      -- syntax as we need to keep the `v1'` name that was introduced
+      (v1 == v1') && Set.notMember v1' (Set.unions $ freeVars <$> branches) ->
+        Just (reverse vs, [ ([p], guard, body) | MatchCase p guard body <- branches ])
+    -- x y z -> match (x,y,z) with (pat1, pat2, pat3) -> ...
+    --   becomes
+    -- cases pat1 pat2 pat3 -> ...`
+    Just (reverse -> vs@(_:_), Match' (TupleTerm' scrutes) branches) |
+      multiway vs (reverse scrutes) &&
+      -- (as above) if any of the vars are referenced in any of the branches,
+      -- we need to keep the names introduced by the lambda and can't use
+      -- lambda case syntax
+      all notFree (take len vs) &&
+      all isRightArity branches && -- all patterns need to match arity of scrutes
+      len /= 0 ->
+        Just (reverse (drop len vs), branches')
+        where
+          isRightArity (MatchCase (TuplePattern ps) _ _) = length ps == len
+          isRightArity (MatchCase {}) = False
+          len = length scrutes
+          fvs = Set.unions $ freeVars <$> branches
+          notFree v = Set.notMember v fvs
+          branches' = [ (ps, guard, body) | MatchCase (TuplePattern ps) guard body <- branches ]
+    _ -> Nothing
+  where
+    -- multiway vs tms checks that length tms <= length vs, and their common prefix
+    -- is all matching variables
+    multiway _ [] = True
+    multiway (h:t) (Var' h2:t2) | h == h2 = multiway t t2
+    multiway _ _ = False
+    freeVars (MatchCase _ g rhs) =
+      let guardVars = (fromMaybe Set.empty $ ABT.freeVars <$> g)
+          rhsVars = (ABT.freeVars rhs)
+      in Set.union guardVars rhsVars
+

--- a/parser-typechecker/tests/Unison/Test/TermPrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/TermPrinter.hs
@@ -162,6 +162,17 @@ test = scope "termprinter" $ tests
         \    0 -> 0\n\
         \    x -> x\n\
         \  !f 1"
+  , tc "let\n\
+        \  f = cases\n\
+        \    0 x -> 0\n\
+        \    x 0 -> x\n\
+        \  f y"
+  , tc "let\n\
+        \  interleave = cases\n\
+        \    [] x                -> x\n\
+        \    x []                -> y\n\
+        \    (h +: t) (h2 +: t2) -> [h, h2] ++ interleave t t2\n\
+        \  f y"
   , pending $ tc "match x with Pair t 0 -> foo t" -- TODO hitting UnknownDataConstructor when parsing pattern
   , pending $ tc "match x with Pair t 0 | pred t -> foo t" -- ditto
   , pending $ tc "match x with Pair t 0 | pred t -> foo t; Pair t 0 -> foo' t; Pair t u -> bar;" -- ditto

--- a/unison-src/transcripts/lambdacase.md
+++ b/unison-src/transcripts/lambdacase.md
@@ -1,0 +1,74 @@
+# Lambda case syntax
+
+```ucm:hide
+.> builtins.merge
+```
+
+This function takes a single argument and immediately pattern matches on it. As we'll see below, it can be written using `cases` syntax:
+
+```unison
+isEmpty x = match x with
+  [] -> true
+  _ -> false
+```
+
+```ucm:hide
+.> add
+```
+
+Here's the same function written using `cases` syntax:
+
+```unison
+isEmpty2 = cases
+  [] -> true
+  _ -> false
+```
+
+Notice that Unison detects this as an alias of `isEmpty`, and if we view `isEmpty`
+
+```ucm
+.> view isEmpty
+```
+
+it shows the definition using `cases` syntax opportunistically, even if the code was originally written without that syntax.
+
+## Multi-argument cases
+
+Functions that take multiple arguments and immediately match on a tuple of arguments can also be rewritten to use `cases`:
+
+```unison:hide
+merge : [a] -> [a] -> [a]
+merge xs ys = match (xs, ys) with
+  ([], ys) -> ys
+  (xs, []) -> xs
+  (h +: t, h2 +: t2) ->
+    if h <= h2 then h  +: merge t (h2 +: t2)
+    else            h2 +: merge (h +: t) t2
+```
+
+```ucm
+.> add
+```
+
+Here's a version using `cases`:
+
+```unison
+merge2 : [a] -> [a] -> [a]
+merge2 = cases
+  [] ys -> ys
+  xs [] -> xs
+  (h +: t) (h2 +: t2) ->
+    if h <= h2 then h  +: merge2 t (h2 +: t2)
+    else            h2 +: merge2 (h +: t) t2
+```
+
+Notice that Unison detects this as an alias of `merge` (it doesn't, but should), and if we view `merge`
+
+```ucm
+.> add
+.> names merge
+.> names merge2
+.> view merge2 merge
+```
+
+it again shows the definition using the multi-argument `cases` syntax opportunistically, even though the code was originally written without that syntax.

--- a/unison-src/transcripts/lambdacase.md
+++ b/unison-src/transcripts/lambdacase.md
@@ -30,7 +30,7 @@ Notice that Unison detects this as an alias of `isEmpty`, and if we view `isEmpt
 .> view isEmpty
 ```
 
-it shows the definition using `cases` syntax opportunistically, even if the code was originally written without that syntax.
+it shows the definition using `cases` syntax opportunistically, even though the code was originally written without that syntax.
 
 ## Multi-argument cases
 
@@ -62,13 +62,10 @@ merge2 = cases
     else            h2 +: merge2 (h +: t) t2
 ```
 
-Notice that Unison detects this as an alias of `merge` (it doesn't, but should), and if we view `merge`
+Notice that Unison detects this as an alias of `merge`, and if we view `merge`
 
 ```ucm
-.> add
-.> names merge
-.> names merge2
-.> view merge2 merge
+.> view merge
 ```
 
 it again shows the definition using the multi-argument `cases` syntax opportunistically, even though the code was originally written without that syntax.

--- a/unison-src/transcripts/lambdacase.output.md
+++ b/unison-src/transcripts/lambdacase.output.md
@@ -1,0 +1,140 @@
+# Lambda case syntax
+
+This function takes a single argument and immediately pattern matches on it. As we'll see below, it can be written using `cases` syntax:
+
+```unison
+isEmpty x = match x with
+  [] -> true
+  _ -> false
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      isEmpty : [𝕩] -> Boolean
+
+```
+Here's the same function written using `cases` syntax:
+
+```unison
+isEmpty2 = cases
+  [] -> true
+  _ -> false
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      isEmpty2 : [𝕩] -> Boolean
+        (also named isEmpty)
+
+```
+Notice that Unison detects this as an alias of `isEmpty`, and if we view `isEmpty`
+
+```ucm
+.> view isEmpty
+
+  isEmpty : [𝕩] -> Boolean
+  isEmpty = cases
+    [] -> true
+    _  -> false
+
+```
+it shows the definition using `cases` syntax opportunistically, even if the code was originally written without that syntax.
+
+## Multi-argument cases
+
+Functions that take multiple arguments and immediately match on a tuple of arguments can also be rewritten to use `cases`:
+
+```unison
+merge : [a] -> [a] -> [a]
+merge xs ys = match (xs, ys) with
+  ([], ys) -> ys
+  (xs, []) -> xs
+  (h +: t, h2 +: t2) ->
+    if h <= h2 then h  +: merge t (h2 +: t2)
+    else            h2 +: merge (h +: t) t2
+```
+
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    merge : [a] ->{𝕖} [a] ->{𝕖} [a]
+
+```
+Here's a version using `cases`:
+
+```unison
+merge2 : [a] -> [a] -> [a]
+merge2 = cases
+  [] ys -> ys
+  xs [] -> xs
+  (h +: t) (h2 +: t2) ->
+    if h <= h2 then h  +: merge2 t (h2 +: t2)
+    else            h2 +: merge2 (h +: t) t2
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      merge2 : [a] ->{𝕖} [a] ->{𝕖} [a]
+
+```
+Notice that Unison detects this as an alias of `merge` (it doesn't, but should), and if we view `merge`
+
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    merge2 : [a] ->{𝕖} [a] ->{𝕖} [a]
+
+.> names merge
+
+  Term
+  Hash:   #eesob77j7q
+  Names:  merge
+
+.> names merge2
+
+  Term
+  Hash:   #ouo7ronu9q
+  Names:  merge2
+
+.> view merge2 merge
+
+  merge : [a] -> [a] -> [a]
+  merge = cases
+    [] ys               -> ys
+    xs []               -> xs
+    (h +: t) (h2 +: t2) ->
+      if h <= h2 then h +: merge t (h2 +: t2)
+      else h2 +: merge (h +: t) t2
+  
+  merge2 : [a] -> [a] -> [a]
+  merge2 = cases
+    [] ys               -> ys
+    xs []               -> xs
+    (h +: t) (h2 +: t2) ->
+      if h <= h2 then h +: merge2 t (h2 +: t2)
+      else h2 +: merge2 (h +: t) t2
+
+```
+it again shows the definition using the multi-argument `cases syntax opportunistically, even though the code was originally written without that syntax.

--- a/unison-src/transcripts/lambdacase.output.md
+++ b/unison-src/transcripts/lambdacase.output.md
@@ -50,7 +50,7 @@ Notice that Unison detects this as an alias of `isEmpty`, and if we view `isEmpt
     _  -> false
 
 ```
-it shows the definition using `cases` syntax opportunistically, even if the code was originally written without that syntax.
+it shows the definition using `cases` syntax opportunistically, even though the code was originally written without that syntax.
 
 ## Multi-argument cases
 
@@ -95,30 +95,13 @@ merge2 = cases
     ⍟ These new definitions are ok to `add`:
     
       merge2 : [a] ->{𝕖} [a] ->{𝕖} [a]
+        (also named merge)
 
 ```
-Notice that Unison detects this as an alias of `merge` (it doesn't, but should), and if we view `merge`
+Notice that Unison detects this as an alias of `merge`, and if we view `merge`
 
 ```ucm
-.> add
-
-  ⍟ I've added these definitions:
-  
-    merge2 : [a] ->{𝕖} [a] ->{𝕖} [a]
-
-.> names merge
-
-  Term
-  Hash:   #eesob77j7q
-  Names:  merge
-
-.> names merge2
-
-  Term
-  Hash:   #ouo7ronu9q
-  Names:  merge2
-
-.> view merge2 merge
+.> view merge
 
   merge : [a] -> [a] -> [a]
   merge = cases
@@ -127,14 +110,6 @@ Notice that Unison detects this as an alias of `merge` (it doesn't, but should),
     (h +: t) (h2 +: t2) ->
       if h <= h2 then h +: merge t (h2 +: t2)
       else h2 +: merge (h +: t) t2
-  
-  merge2 : [a] -> [a] -> [a]
-  merge2 = cases
-    [] ys               -> ys
-    xs []               -> xs
-    (h +: t) (h2 +: t2) ->
-      if h <= h2 then h +: merge2 t (h2 +: t2)
-      else h2 +: merge2 (h +: t) t2
 
 ```
 it again shows the definition using the multi-argument `cases syntax opportunistically, even though the code was originally written without that syntax.


### PR DESCRIPTION
This PR adds syntax for defining multi-argument functions using `cases`:

```Haskell
merge : [a] -> [a] -> [a]
merge = cases
  []       ys         -> ys
  xs       []         -> xs
  (h +: t) (h2 +: t2) ->
    if h <= h2 then h  +: merge t (h2 +: t2)
    else            h2 +: merge (h +: t) t2
```

See [the transcript](https://github.com/unisonweb/unison/tree/topic/multiarg-cases/unison-src/transcripts/lambdacase.output.md) for usage and explanation of the desugaring. Like destructuring bind (#1700), this is just syntax sugar which is mirrored by the pretty-printer.

Testing coverage is pretty decent: the existing parser and pretty printer share 95% of the same codepath, so the fact that existing tests pass is a good sign, and I added some unit tests as well as the transcript.

@atacratic, I moved a couple pretty-printer specific stuff out of `Term` and into `TermPrinter`. I'd like your review on the `TermPrinter` changes if you have a chance.

@dolio, I could imagine supporting multi-argument pattern matching more natively in the runtime or AST. I don't think it matters too much what's in the AST but it might be nice if the runtime could eventually have a more optimized implementation of this. Not high priority I don't think though.

/cc @anovstrup 