### PR TITLE
Fix transcript runner to show the actual error when it fails

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
@@ -267,8 +267,8 @@ run newRt dir configFile stanzas codebase branchCache = do
         appendFailingStanza
         transcriptFailure out $ Text.unlines [
           "\128721", "",
-          "The transcript failed due to an error encountered in the stanza above.", "",
-          "The error is:", "", Text.pack msg, "",
+          "The transcript failed due to an error in the stanza above. The error is:", "",
+          Text.pack msg, "",
           "Run `" <> Text.pack executable <> " -codebase " <> Text.pack dir <> "` " <> "to do more work with it."]
 
       dieUnexpectedSuccess :: IO ()

--- a/unison-src/transcripts/errors/ucm-hide-all.output.md
+++ b/unison-src/transcripts/errors/ucm-hide-all.output.md
@@ -14,4 +14,10 @@ and surface a helpful message.
 
 🛑
 
-The transcript failed due to an error encountered in the stanza above.
+The transcript failed due to an error in the stanza above. The error is:
+
+
+  ⚠️
+  
+  The namespace foo doesn't exist.
+

--- a/unison-src/transcripts/errors/ucm-hide.output.md
+++ b/unison-src/transcripts/errors/ucm-hide.output.md
@@ -14,4 +14,10 @@ and surface a helpful message.
 
 🛑
 
-The transcript failed due to an error encountered in the stanza above.
+The transcript failed due to an error in the stanza above. The error is:
+
+
+  ⚠️
+  
+  The namespace foo doesn't exist.
+

--- a/unison-src/transcripts/errors/unison-hide-all.output.md
+++ b/unison-src/transcripts/errors/unison-hide-all.output.md
@@ -13,4 +13,21 @@ g 3
 
 🛑
 
-The transcript failed due to an error encountered in the stanza above.
+The transcript failed due to an error in the stanza above. The error is:
+
+
+  This looks like the start of an expression here 
+  
+      1 | g 3
+  
+  but at the file top-level, I expect one of the following:
+  
+    - A binding, like g = 42 OR
+                      g : Nat
+                      g = 42
+    - A watch expression, like > g + 1
+    - An `ability` declaration, like ability Foo where ...
+    - A `type` declaration, like type Optional a = None | Some a
+    - A `namespace` declaration, like namespace Seq where ...
+  
+

--- a/unison-src/transcripts/errors/unison-hide.output.md
+++ b/unison-src/transcripts/errors/unison-hide.output.md
@@ -13,4 +13,21 @@ g 3
 
 🛑
 
-The transcript failed due to an error encountered in the stanza above.
+The transcript failed due to an error in the stanza above. The error is:
+
+
+  This looks like the start of an expression here 
+  
+      1 | g 3
+  
+  but at the file top-level, I expect one of the following:
+  
+    - A binding, like g = 42 OR
+                      g : Nat
+                      g = 42
+    - A watch expression, like > g + 1
+    - An `ability` declaration, like ability Foo where ...
+    - A `type` declaration, like type Optional a = None | Some a
+    - A `namespace` declaration, like namespace Seq where ...
+  
+


### PR DESCRIPTION
This was bugging me. When the transcript failed, it wouldn't report the error, it would only tell you that "The transcript failed due to an error encountered in the stanza above." Um, okay, but what was the error?? Now it fails with a nice message, for instance:

```
The transcript failed due to an error in the stanza above. The error is:


  This looks like the start of an expression here 
  
      3 | List.map f as sldkfj;;; jklljf; =
  
  but at the file top-level, I expect one of the following:
  
    - A binding, like List.map = 42 OR
                      List.map : Nat
                      List.map = 42
    - A watch expression, like > List.map + 1
    - An `ability` declaration, like ability Foo where ...
    - A `type` declaration, like type Optional a = None | Some a
    - A `namespace` declaration, like namespace Seq where ...
```

Previously, "the error is: ..." part wouldn't be shown.

## Implementation notes and testing

Nothing interesting. All the transcripts pass still so we can be pretty confident this hasn't broken anything. The code I added only kicks in when the transcript is about to die anyway.