### PR TITLE
Sort test results by name instead of by hash

### DIFF
--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -1185,23 +1185,26 @@ displayTestResults :: Bool -- whether to show the tip
                    -> [(Reference, Text)]
                    -> [(Reference, Text)]
                    -> Pretty
-displayTestResults showTip ppe oks fails = let
-  name r = P.text (HQ.toText $ PPE.termName ppe (Referent.Ref r))
+displayTestResults showTip ppe oksUnsorted failsUnsorted = let
+  oks   = Name.sortByText fst [ (name r, msg) | (r, msg) <- oksUnsorted ]
+  fails = Name.sortByText fst [ (name r, msg) | (r, msg) <- failsUnsorted ]
+  name r = HQ.toText $ PPE.termName ppe (Referent.Ref r)
   okMsg =
     if null oks then mempty
-    else P.column2 [ (P.green "◉ " <> name r, "  " <> P.green (P.text msg)) | (r, msg) <- oks ]
+    else P.column2 [ (P.green "◉ " <> P.text r, "  " <> P.green (P.text msg)) | (r, msg) <- oks ]
   okSummary =
     if null oks then mempty
     else "✅ " <> P.bold (P.num (length oks)) <> P.green " test(s) passing"
   failMsg =
     if null fails then mempty
-    else P.column2 [ (P.red "✗ " <> name r, "  " <> P.red (P.text msg)) | (r, msg) <- fails ]
+    else P.column2 [ (P.red "✗ " <> P.text r, "  " <> P.red (P.text msg)) | (r, msg) <- fails ]
   failSummary =
     if null fails then mempty
     else "🚫 " <> P.bold (P.num (length fails)) <> P.red " test(s) failing"
   tipMsg =
     if not showTip || (null oks && null fails) then mempty
-    else tip $ "Use " <> P.blue ("view " <> name (fst $ head (fails ++ oks))) <> "to view the source of a test."
+    else tip $ "Use " <> P.blue ("view " <> P.text (fst $ head (fails ++ oks)))
+            <> "to view the source of a test."
   in if null oks && null fails then "😶 No tests available."
      else P.sep "\n\n" . P.nonEmpty $ [
           okMsg, failMsg,

--- a/unison-core/src/Unison/Name.hs
+++ b/unison-core/src/Unison/Name.hs
@@ -52,13 +52,13 @@ sortNames :: [Name] -> [Name]
 sortNames = sortNamed id
 
 sortNamed :: (a -> Name) -> [a] -> [a]
-sortNamed by as = let
-  as' = [ (a, Text.unpack (toText (by a))) | a <- as ]
-  comp (_,s) (_,s2) = RFC5051.compareUnicode s s2
-  in fst <$> sortBy comp as'
+sortNamed by = sortByText (toText . by)
 
 sortByText :: (a -> Text) -> [a] -> [a]
-sortByText by = sortNamed (Name . by)
+sortByText by as = let
+  as' = [ (a, Text.unpack (by a)) | a <- as ]
+  comp (_,s) (_,s2) = RFC5051.compareUnicode s s2
+  in fst <$> sortBy comp as'
 
 -- | Like sortNamed, but takes an additional backup comparison function if two
 -- names are equal.

--- a/unison-core/src/Unison/Name.hs
+++ b/unison-core/src/Unison/Name.hs
@@ -12,6 +12,7 @@ module Unison.Name
   , parent
   , sortNames
   , sortNamed
+  , sortByText
   , sortNamed'
   , stripNamePrefix
   , stripPrefixes
@@ -55,6 +56,9 @@ sortNamed by as = let
   as' = [ (a, Text.unpack (toText (by a))) | a <- as ]
   comp (_,s) (_,s2) = RFC5051.compareUnicode s s2
   in fst <$> sortBy comp as'
+
+sortByText :: (a -> Text) -> [a] -> [a]
+sortByText by = sortNamed (Name . by)
 
 -- | Like sortNamed, but takes an additional backup comparison function if two
 -- names are equal.

--- a/unison-src/new-runtime-transcripts/hashing.output.md
+++ b/unison-src/new-runtime-transcripts/hashing.output.md
@@ -267,31 +267,31 @@ test> blake2b_512.tests.ex3 =
 
   Cached test results (`help testcache` to learn more)
   
-  ◉ blake2b_512.tests.ex3   Passed.
-  ◉ sha3_512.tests.ex1      Passed.
-  ◉ hex.tests.ex1           Passed.
-  ◉ sha2_512.tests.ex2      Passed.
-  ◉ sha2_512.tests.ex4      Passed.
-  ◉ sha3_256.tests.ex3      Passed.
-  ◉ sha2_512.tests.ex1      Passed.
-  ◉ sha2_256.tests.ex4      Passed.
-  ◉ sha3_256.tests.ex2      Passed.
   ◉ blake2b_512.tests.ex1   Passed.
-  ◉ sha3_512.tests.ex2      Passed.
-  ◉ blake2s_256.tests.ex1   Passed.
-  ◉ sha2_256.tests.ex3      Passed.
-  ◉ sha2_512.tests.ex3      Passed.
-  ◉ sha3_256.tests.ex1      Passed.
   ◉ blake2b_512.tests.ex2   Passed.
-  ◉ sha3_256.tests.ex4      Passed.
-  ◉ sha3_512.tests.ex4      Passed.
-  ◉ sha3_512.tests.ex3      Passed.
-  ◉ sha2_256.tests.ex2      Passed.
+  ◉ blake2b_512.tests.ex3   Passed.
+  ◉ blake2s_256.tests.ex1   Passed.
+  ◉ hex.tests.ex1           Passed.
   ◉ sha2_256.tests.ex1      Passed.
+  ◉ sha2_256.tests.ex2      Passed.
+  ◉ sha2_256.tests.ex3      Passed.
+  ◉ sha2_256.tests.ex4      Passed.
+  ◉ sha2_512.tests.ex1      Passed.
+  ◉ sha2_512.tests.ex2      Passed.
+  ◉ sha2_512.tests.ex3      Passed.
+  ◉ sha2_512.tests.ex4      Passed.
+  ◉ sha3_256.tests.ex1      Passed.
+  ◉ sha3_256.tests.ex2      Passed.
+  ◉ sha3_256.tests.ex3      Passed.
+  ◉ sha3_256.tests.ex4      Passed.
+  ◉ sha3_512.tests.ex1      Passed.
+  ◉ sha3_512.tests.ex2      Passed.
+  ◉ sha3_512.tests.ex3      Passed.
+  ◉ sha3_512.tests.ex4      Passed.
   
   ✅ 21 test(s) passing
   
-  Tip: Use view blake2b_512.tests.ex3 to view the source of a
+  Tip: Use view blake2b_512.tests.ex1 to view the source of a
        test.
 
 ```
@@ -372,35 +372,35 @@ test> hmac_sha2_512.tests.ex2 =
 
   Cached test results (`help testcache` to learn more)
   
-  ◉ blake2b_512.tests.ex3     Passed.
-  ◉ sha3_512.tests.ex1        Passed.
-  ◉ hex.tests.ex1             Passed.
-  ◉ hmac_sha2_256.tests.ex2   Passed.
-  ◉ hmac_sha2_512.tests.ex2   Passed.
-  ◉ sha2_512.tests.ex2        Passed.
-  ◉ sha2_512.tests.ex4        Passed.
-  ◉ sha3_256.tests.ex3        Passed.
-  ◉ sha2_512.tests.ex1        Passed.
-  ◉ sha2_256.tests.ex4        Passed.
-  ◉ sha3_256.tests.ex2        Passed.
   ◉ blake2b_512.tests.ex1     Passed.
-  ◉ sha3_512.tests.ex2        Passed.
-  ◉ blake2s_256.tests.ex1     Passed.
-  ◉ sha2_256.tests.ex3        Passed.
-  ◉ sha2_512.tests.ex3        Passed.
-  ◉ hmac_sha2_512.tests.ex1   Passed.
-  ◉ sha3_256.tests.ex1        Passed.
   ◉ blake2b_512.tests.ex2     Passed.
-  ◉ sha3_256.tests.ex4        Passed.
-  ◉ sha3_512.tests.ex4        Passed.
-  ◉ sha3_512.tests.ex3        Passed.
-  ◉ sha2_256.tests.ex2        Passed.
+  ◉ blake2b_512.tests.ex3     Passed.
+  ◉ blake2s_256.tests.ex1     Passed.
+  ◉ hex.tests.ex1             Passed.
   ◉ hmac_sha2_256.tests.ex1   Passed.
+  ◉ hmac_sha2_256.tests.ex2   Passed.
+  ◉ hmac_sha2_512.tests.ex1   Passed.
+  ◉ hmac_sha2_512.tests.ex2   Passed.
   ◉ sha2_256.tests.ex1        Passed.
+  ◉ sha2_256.tests.ex2        Passed.
+  ◉ sha2_256.tests.ex3        Passed.
+  ◉ sha2_256.tests.ex4        Passed.
+  ◉ sha2_512.tests.ex1        Passed.
+  ◉ sha2_512.tests.ex2        Passed.
+  ◉ sha2_512.tests.ex3        Passed.
+  ◉ sha2_512.tests.ex4        Passed.
+  ◉ sha3_256.tests.ex1        Passed.
+  ◉ sha3_256.tests.ex2        Passed.
+  ◉ sha3_256.tests.ex3        Passed.
+  ◉ sha3_256.tests.ex4        Passed.
+  ◉ sha3_512.tests.ex1        Passed.
+  ◉ sha3_512.tests.ex2        Passed.
+  ◉ sha3_512.tests.ex3        Passed.
+  ◉ sha3_512.tests.ex4        Passed.
   
   ✅ 25 test(s) passing
   
-  Tip: Use view blake2b_512.tests.ex3 to view the source of a
+  Tip: Use view blake2b_512.tests.ex1 to view the source of a
        test.
 
 ```


### PR DESCRIPTION
Previously, the `test` command would show the test results ordered by the hash of the test... effectively a random order and not very helpful. 🙃 Now it sorts the tests by name. 

It uses [RFC 5051](https://tools.ietf.org/html/rfc5051), a case insensitive sort that handles Unicode, which should be preferred for any sorted-by-name results that are going to be displayed to a user. I added `Name.sortByText` as a helper function for doing this sorting.

No new tests, but you can see the results nicely sorted in the hashing transcript. Here's the after:

```
  Cached test results (`help testcache` to learn more)
  
  ◉ blake2b_512.tests.ex1     Passed.
  ◉ blake2b_512.tests.ex2     Passed.
  ◉ blake2b_512.tests.ex3     Passed.
  ◉ blake2s_256.tests.ex1     Passed.
  ◉ hex.tests.ex1             Passed.
  ◉ hmac_sha2_256.tests.ex1   Passed.
  ◉ hmac_sha2_256.tests.ex2   Passed.
  ◉ hmac_sha2_512.tests.ex1   Passed.
  ◉ hmac_sha2_512.tests.ex2   Passed.
  ◉ sha2_256.tests.ex1        Passed.
  ◉ sha2_256.tests.ex2        Passed.
  ◉ sha2_256.tests.ex3        Passed.
  ◉ sha2_256.tests.ex4        Passed.
  ◉ sha2_512.tests.ex1        Passed.
  ◉ sha2_512.tests.ex2        Passed.
  ◉ sha2_512.tests.ex3        Passed.
  ◉ sha2_512.tests.ex4        Passed.
  ◉ sha3_256.tests.ex1        Passed.
  ◉ sha3_256.tests.ex2        Passed.
  ◉ sha3_256.tests.ex3        Passed.
  ◉ sha3_256.tests.ex4        Passed.
  ◉ sha3_512.tests.ex1        Passed.
  ◉ sha3_512.tests.ex2        Passed.
  ◉ sha3_512.tests.ex3        Passed.
  ◉ sha3_512.tests.ex4        Passed.
  
  ✅ 25 test(s) passing
```

The before was a scrambled mess!