### PR TITLE
In-line handlers were not being enclosed before floating

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/ANF.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF.hs
@@ -203,7 +203,7 @@ enclose keep rec t@(LamsNamed' vs body)
   lamb = lam' a (evs ++ vs) lbody
 enclose keep rec t@(Handle' h body)
   | isStructured body
-  = Just . handle (ABT.annotation t) h $ apps' lamb args
+  = Just . handle (ABT.annotation t) (rec keep h) $ apps' lamb args
   where
   fvs = ABT.freeVars body
   evs = Set.toList $ Set.difference fvs keep

--- a/unison-src/tests/methodical/nesting.u
+++ b/unison-src/tests/methodical/nesting.u
@@ -1,0 +1,9 @@
+
+h0 x s = handle !x with cases
+  { _ } -> s
+
+h1 x s = cases
+  { _ } -> handle !x with cases
+    { _ } -> s
+
+> (h0 (_ -> 5) 6, handle 8 with h1 (_ -> 5) 7)


### PR DESCRIPTION
This should fix some issues that crop up when handlers are nested under things in the new runtime.