### PR TITLE
Quick grammar fix in OutputMessages.hs

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -47,3 +47,4 @@ The format for this list: name, GitHub handle, and then optional blurb about wha
 * Mohamed Elsharnouby (@sharno)
 * Jared Forsyth (@jaredly) - Documentation generation
 * Hakim Cassimally (@osfameron) - vim support
+* Will Badart (@wbadart)

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -191,7 +191,7 @@ notifyNumbered o = case o of
       ]) (showDiffNamespace ShowNumbers ppe destAbs destAbs diffOutput)
 
   ShowDiffAfterUndo ppe diffOutput ->
-    first (\p -> P.lines ["Here's the changes I undid", "", p ])
+    first (\p -> P.lines ["Here are the changes I undid", "", p ])
       (showDiffNamespace ShowNumbers ppe e e diffOutput)
 
   ShowDiffAfterPull dest' destAbs ppe diff ->

--- a/unison-src/transcripts/squash.output.md
+++ b/unison-src/transcripts/squash.output.md
@@ -333,7 +333,7 @@ Since squash merges don't produce any merge nodes, we can `undo` a couple times 
 ```ucm
 .> undo
 
-  Here's the changes I undid
+  Here are the changes I undid
   
   Name changes:
   
@@ -346,7 +346,7 @@ Since squash merges don't produce any merge nodes, we can `undo` a couple times 
 
 .> undo
 
-  Here's the changes I undid
+  Here are the changes I undid
   
   Name changes:
   


### PR DESCRIPTION
Hey team-

I noticed in the language tour that `undo` outputs

> Here's the changes I undid: [...]

Since "changes" is plural, this minor tweak just makes the verb match ("is" -> "are").