### PR TITLE
Fix to TDNR to verify that the suffix matches for any TDNR replacement 

### DIFF
--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -89,7 +89,7 @@ resolveNames typeLookupf preexistingNames uf = do
       possibleDeps = [ (Name.toText name, Var.name v, r) |
         (name, r) <- Rel.toList (Names.terms0 preexistingNames),
         v <- Set.toList (Term.freeVars tm),
-        Name.unqualified name == Name.unqualified (Name.fromVar v) ]
+        name `Name.endsWithSegments` Name.fromVar v ]
       possibleRefs = Referent.toReference . view _3 <$> possibleDeps
   tl <- lift . lift . fmap (UF.declsToTypeLookup uf <>)
       $ typeLookupf (deps <> Set.fromList possibleRefs)
@@ -98,10 +98,11 @@ resolveNames typeLookupf preexistingNames uf = do
           (name, shortname, r) <- possibleDeps,
           typ <- toList $ TL.typeOfReferent tl r,
           let nr = Typechecker.NamedReference name typ (Right r) ] <>
-        [ (shortname, nr) |
+        [ (Var.name v, nr) |
           (name, r) <- Rel.toList (Names.terms0 $ UF.toNames uf),
+          v <- Set.toList (Term.freeVars tm),
+          name `Name.endsWithSegments` Name.fromVar v,
           typ <- toList $ TL.typeOfReferent tl r,
-          let shortname = Name.toText $ Name.unqualified name,
           let nr = Typechecker.NamedReference (Name.toText name) typ (Right r) ]
   pure (tm, fqnsByShortName, tl)
 

--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -93,11 +93,22 @@ resolveNames typeLookupf preexistingNames uf = do
       possibleRefs = Referent.toReference . view _3 <$> possibleDeps
   tl <- lift . lift . fmap (UF.declsToTypeLookup uf <>)
       $ typeLookupf (deps <> Set.fromList possibleRefs)
+  -- For populating the TDNR environment, we pick definitions
+  -- from the namespace and from the local file whose full name
+  -- has a suffix that equals one of the free variables in the file.
+  -- Example, the namespace has [foo.bar.baz, qux.quaffle] and
+  -- the file has definitons [utils.zonk, utils.blah] and
+  -- the file has free variables [bar.baz, zonk].
+  --
+  -- In this case, [foo.bar.baz, utils.zonk] are used to create
+  -- the TDNR environment.
   let fqnsByShortName = List.multimap $
+        -- external TDNR possibilities
         [ (shortname, nr) |
           (name, shortname, r) <- possibleDeps,
           typ <- toList $ TL.typeOfReferent tl r,
           let nr = Typechecker.NamedReference name typ (Right r) ] <>
+        -- local file TDNR possibilities
         [ (Var.name v, nr) |
           (name, r) <- Rel.toList (Names.terms0 $ UF.toNames uf),
           v <- Set.toList (Term.freeVars tm),

--- a/parser-typechecker/src/Unison/Runtime/IOSource.hs
+++ b/parser-typechecker/src/Unison/Runtime/IOSource.hs
@@ -166,9 +166,9 @@ unique[b28d929d0a73d2c18eac86341a3bb9399f8550c11b5f35eabb2751e6803ccc20] type
 d1 Doc.++ d2 =
   use Doc
   match (d1,d2) with
-    (Join ds, Join ds2) -> Join (ds Sequence.++ ds2)
-    (Join ds, _) -> Join (ds `Sequence.snoc` d2)
-    (_, Join ds) -> Join (d1 `Sequence.cons` ds)
+    (Join ds, Join ds2) -> Join (ds List.++ ds2)
+    (Join ds, _) -> Join (ds `List.snoc` d2)
+    (_, Join ds) -> Join (d1 `List.cons` ds)
     _ -> Join [d1,d2]
 
 unique[q1905679b27a97a4098bc965574da880c1074183a2c55ff1d481619c7fb8a1e1] type

--- a/parser-typechecker/tests/Unison/Test/IO.hs
+++ b/parser-typechecker/tests/Unison/Test/IO.hs
@@ -52,19 +52,19 @@ main = 'let
   expected = ${expectedText}
 
   -- Write to myFile
-  h1 = builtins.io.openFile (FilePath fp) Write
+  h1 = io.openFile (FilePath fp) Write
   putText h1 expected
-  builtins.io.closeFile h1
+  io.closeFile h1
 
   -- Read from myFile
-  h2 = builtins.io.openFile (FilePath fp) Read
+  h2 = builtin.io.openFile (FilePath fp) Read
   myC = getText h2
-  builtins.io.closeFile h2
+  io.closeFile h2
 
   -- Write what we read from myFile to resultFile
-  h3 = builtins.io.openFile (FilePath res) Write
+  h3 = io.openFile (FilePath res) Write
   putText h3 myC
-  builtins.io.closeFile h3
+  builtin.io.closeFile h3
 ```
 
 ```ucm

--- a/unison-core/src/Unison/Name.hs
+++ b/unison-core/src/Unison/Name.hs
@@ -5,6 +5,7 @@
 
 module Unison.Name
   ( Name(Name)
+  , endsWithSegments
   , fromString
   , isPrefixOf
   , joinDot
@@ -86,6 +87,14 @@ toString = Text.unpack . toText
 
 isPrefixOf :: Name -> Name -> Bool
 a `isPrefixOf` b = toText a `Text.isPrefixOf` toText b
+
+-- foo.bar.baz `endsWithSegments` bar.baz == True
+-- foo.bar.baz `endsWithSegments` baz == True
+-- foo.bar.baz `endsWithSegments` az == False (not a full segment)
+-- foo.bar.baz `endsWithSegments` zonk == False (doesn't match any segment)
+-- foo.bar.baz `endsWithSegments` foo == False (matches a segment, but not at the end)
+endsWithSegments :: Name -> Name -> Bool
+endsWithSegments n ending = any (== ending) (suffixes n)
 
 -- stripTextPrefix a.b. a.b.c = Just c
 -- stripTextPrefix a.b  a.b.c = Just .c;  you probably don't want to do this

--- a/unison-src/tests/324.u
+++ b/unison-src/tests/324.u
@@ -1,5 +1,5 @@
 foo a b =
-  if a Text.== "" then
+  if a `Text.eq` "" then
     match Text.size b with
       1 -> false
       _ -> true

--- a/unison-src/tests/handler-stacking.u
+++ b/unison-src/tests/handler-stacking.u
@@ -11,7 +11,7 @@ main = '(tell get)
 
 replicate : Nat -> '{e} () -> {e} ()
 replicate n x =
-  if n Nat.== 0 then () else
+  if n `Nat.eq` 0 then () else
     !x
     replicate (n `drop` 1) x
 

--- a/unison-src/tests/inner-lambda1.u
+++ b/unison-src/tests/inner-lambda1.u
@@ -1,4 +1,4 @@
-use Nat drop >=
+use Nat drop
 use Optional None Some
 
 search : (Nat -> Int) -> Nat -> Nat -> Optional Nat

--- a/unison-src/tests/inner-lambda2.u
+++ b/unison-src/tests/inner-lambda2.u
@@ -1,5 +1,5 @@
 
-use Nat drop >=
+use Nat drop
 use Optional None Some
 
 search : (Nat -> Int) -> Nat -> Nat -> Optional Nat

--- a/unison-src/tests/lambda-closing-over-effectful-fn.u
+++ b/unison-src/tests/lambda-closing-over-effectful-fn.u
@@ -7,4 +7,4 @@ unfold s f =
     Some (hd, s) -> go s (acc `List.snoc` hd)
   go s []
 
-> unfold 0 (n -> if n Nat.< 5 then Some (n, n + 1) else None)
+> unfold 0 (n -> if n < 5 then Some (n, n + 1) else None)

--- a/unison-src/tests/methodical/builtin-nat-to-float.u
+++ b/unison-src/tests/methodical/builtin-nat-to-float.u
@@ -1,1 +1,1 @@
-> .builtin.Nat.toFloat 4
+> Nat.toFloat 4

--- a/unison-src/tests/stream.u
+++ b/unison-src/tests/stream.u
@@ -30,7 +30,7 @@ from n = unfold n (n -> Some (n, n + 1))
 take n s =
   step n = cases
     {Emit.emit a -> k} ->
-      if n Nat.== 0 then ()
+      if n == 0 then ()
       else
         Emit.emit a
         handle k () with step (n `drop` 1)

--- a/unison-src/tests/suffix-resolve.u
+++ b/unison-src/tests/suffix-resolve.u
@@ -6,17 +6,17 @@
 foo : Int
 foo = +1
 
--- no imports needed here, even though FQNs are builtin.Optional.{None,Some}
+-- no imports needed here, even though FQNs are Optional.{None,Some}
 ex1 = cases
   None -> 0
   Some a -> a + 1
 
--- you can still use the
+-- you can still use the FQN
 ex2 = cases
   Optional.None -> 99
   Optional.Some _ -> 0
 
-ex3 = builtin.Optional.None
+ex3 = List.at 0 [ 1, 2, 3, 4 ]
 
 -- TDNR would have handled this one before, but TDNR can't do
 -- type resolution or pattern resolution

--- a/unison-src/transcripts/fix845.md
+++ b/unison-src/transcripts/fix845.md
@@ -1,0 +1,22 @@
+
+```ucm:hide
+.> builtins.merge
+```
+
+Add `List.zonk` to the codebase:
+
+```unison
+List.zonk : [a] -> [a]
+List.zonk xs = xs
+```
+
+```ucm:hide
+.> add
+```
+
+Now, typecheck a file with a reference to `Blah.zonk` (which doesn't exist in the codebase). This should fail:
+
+```unison:error
+-- should not typecheck as there's no `Blah.zonk` in the codebase
+> Blah.zonk [1,2,3]
+```

--- a/unison-src/transcripts/fix845.md
+++ b/unison-src/transcripts/fix845.md
@@ -8,6 +8,9 @@ Add `List.zonk` to the codebase:
 ```unison
 List.zonk : [a] -> [a]
 List.zonk xs = xs
+
+Text.zonk : Text -> Text
+Text.zonk txt = txt ++ "!! "
 ```
 
 ```ucm:hide
@@ -19,4 +22,36 @@ Now, typecheck a file with a reference to `Blah.zonk` (which doesn't exist in th
 ```unison:error
 -- should not typecheck as there's no `Blah.zonk` in the codebase
 > Blah.zonk [1,2,3]
+```
+
+Here's another example, just checking that TDNR works for definitions in the same file:
+
+```unison
+foo.bar.baz = 42
+
+qux.baz = "hello"
+
+ex = baz ++ ", world!"
+
+> ex
+```
+
+Here's another example, checking that TDNR works when multiple codebase definitions have matching names:
+
+```unison
+ex = zonk "hi"
+
+> ex
+```
+
+Last example, showing that TDNR works when there are multiple matching names in both the file and the codebase:
+
+```unison
+woot.zonk = "woot"
+woot2.zonk = 9384
+
+ex = zonk "hi" -- should resolve to Text.zonk, from the codebase
+      ++ zonk   -- should resolve to the local `woot.zonk` from this file
+
+> ex
 ```

--- a/unison-src/transcripts/fix845.output.md
+++ b/unison-src/transcripts/fix845.output.md
@@ -1,0 +1,36 @@
+
+Add `List.zonk` to the codebase:
+
+```unison
+List.zonk : [a] -> [a]
+List.zonk xs = xs
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      List.zonk : [a] -> [a]
+
+```
+Now, typecheck a file with a reference to `Blah.zonk` (which doesn't exist in the codebase). This should fail:
+
+```unison
+-- should not typecheck as there's no `Blah.zonk` in the codebase
+> Blah.zonk [1,2,3]
+```
+
+```ucm
+
+  I'm not sure what Blah.zonk means at line 2, columns 3-12
+  
+      2 | > Blah.zonk [1,2,3]
+  
+  Whatever it is, it has a type that conforms to [builtin.Nat] -> o.
+  
+
+```

--- a/unison-src/transcripts/fix845.output.md
+++ b/unison-src/transcripts/fix845.output.md
@@ -4,6 +4,9 @@ Add `List.zonk` to the codebase:
 ```unison
 List.zonk : [a] -> [a]
 List.zonk xs = xs
+
+Text.zonk : Text -> Text
+Text.zonk txt = txt ++ "!! "
 ```
 
 ```ucm
@@ -15,6 +18,7 @@ List.zonk xs = xs
     ⍟ These new definitions are ok to `add`:
     
       List.zonk : [a] -> [a]
+      Text.zonk : Text -> Text
 
 ```
 Now, typecheck a file with a reference to `Blah.zonk` (which doesn't exist in the codebase). This should fail:
@@ -32,5 +36,95 @@ Now, typecheck a file with a reference to `Blah.zonk` (which doesn't exist in th
   
   Whatever it is, it has a type that conforms to [builtin.Nat] -> o.
   
+
+```
+Here's another example, just checking that TDNR works for definitions in the same file:
+
+```unison
+foo.bar.baz = 42
+
+qux.baz = "hello"
+
+ex = baz ++ ", world!"
+
+> ex
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      ex          : Text
+      foo.bar.baz : Nat
+      qux.baz     : Text
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    7 | > ex
+          ⧩
+          "hello, world!"
+
+```
+Here's another example, checking that TDNR works when multiple codebase definitions have matching names:
+
+```unison
+ex = zonk "hi"
+
+> ex
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      ex : Text
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    3 | > ex
+          ⧩
+          "hi!! "
+
+```
+Last example, showing that TDNR works when there are multiple matching names in both the file and the codebase:
+
+```unison
+woot.zonk = "woot"
+woot2.zonk = 9384
+
+ex = zonk "hi" -- should resolve to Text.zonk, from the codebase
+      ++ zonk   -- should resolve to the local `woot.zonk` from this file
+
+> ex
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      ex         : Text
+      woot.zonk  : Text
+      woot2.zonk : Nat
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    7 | > ex
+          ⧩
+          "hi!! woot"
 
 ```


### PR DESCRIPTION
Previously, `Nat.zoink` could actually be resolved by TDNR to `Float.zoink`. Fixes #845 

This fixes that. There were a number of tests accidentally relying on the old behavior which have been updated.

Updates a small amount of code in the TDNR setup and implementation. The key idea is to populate the TDNR environment with definitions whose full name has a suffix which corresponds to a free term variable in the file. So if the namespace has `Float.zoink` in it, and the file has `zoink` as a free variable, `Float.zoink` gets added to the TDNR environment. But if the free variable is `Nat.zoink`, then that's not a suffix of `Float.zoink`, so `Float.zoink` shouldn't be considered.

Test coverage is probably pretty decent just from existing transcripts and the regression test I added but I'm going to noodle on some more subtle tests.