### PR TITLE
Multi-argument `cases` now uses commas to separate patterns

### DIFF
--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -135,16 +135,16 @@ match = do
 -- Returns the arity of the pattern and the `MatchCase`. Examples:
 --
 --   (a, b) -> a - b -- arity 1
---   foo (hd +: tl) -> foo tl -- arity 2
+--   foo, hd +: tl -> foo tl -- arity 2
 --
 -- Cases with arity greater than 1 are desugared to matching on tuples,
 -- so the following are parsed the same:
 --
---   42 x -> ...
+--   42, x -> ...
 --   (42, x) -> ...
 matchCase :: Var v => P v (Int, Term.MatchCase Ann (Term v Ann))
 matchCase = do
-  pats <- some parsePattern
+  pats <- sepBy1 (reserved ",") parsePattern
   let boundVars' = [ v | (_,vs) <- pats, (_ann,v) <- vs ]
       pat = case fst <$> pats of
         [p] -> p

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -481,9 +481,9 @@ printCase env im doc ms = PP.lines $ map each gridArrowsAligned where
     where
     lhs = (case pats of
             [pat] -> PP.group (fst (prettyPattern env (ac 0 Block im doc) (-1) vs pat))
-            pats  -> PP.group . PP.spaced . (`evalState` vs) . for pats $ \pat -> do
+            pats  -> PP.group . PP.sep ("," <> PP.softbreak) . (`evalState` vs) . for pats $ \pat -> do
               vs <- State.get
-              let (p, rem) = prettyPattern env (ac 0 Block im doc) 10 vs pat
+              let (p, rem) = prettyPattern env (ac 0 Block im doc) (-1) vs pat
               State.put rem
               pure p)
        <> printGuard guard
@@ -1127,8 +1127,8 @@ pattern LamsNamedMatch' vs branches <- (unLamsMatch' -> Just (vs, branches))
 --     (x, y) -> y ++ x
 --
 -- this function will return Just ([x], [ "a" "b" -> "abba", x y -> y ++ x])
--- and it would be rendered as `x -> cases "a" "b" -> "abba"
---                                         x    y  -> y ++ x
+-- and it would be rendered as `x -> cases "a", "b" -> "abba"
+--                                         x,    y  -> y ++ x
 --
 -- This function returns `Nothing` in cases where the term it is given isn't
 -- a lambda, or when the lambda isn't in the correct form for lambda cases.

--- a/parser-typechecker/tests/Unison/Test/TermPrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/TermPrinter.hs
@@ -164,14 +164,14 @@ test = scope "termprinter" $ tests
         \  !f 1"
   , tc "let\n\
         \  f = cases\n\
-        \    0 x -> 0\n\
-        \    x 0 -> x\n\
+        \    0, x -> 0\n\
+        \    x, 0 -> x\n\
         \  f y"
   , tc "let\n\
         \  interleave = cases\n\
-        \    [] x                -> x\n\
-        \    x []                -> y\n\
-        \    (h +: t) (h2 +: t2) -> [h, h2] ++ interleave t t2\n\
+        \    [], x            -> x\n\
+        \    x, []            -> y\n\
+        \    h +: t, h2 +: t2 -> [h, h2] ++ interleave t t2\n\
         \  f y"
   , pending $ tc "match x with Pair t 0 -> foo t" -- TODO hitting UnknownDataConstructor when parsing pattern
   , pending $ tc "match x with Pair t 0 | pred t -> foo t" -- ditto

--- a/unison-src/transcripts/lambdacase.md
+++ b/unison-src/transcripts/lambdacase.md
@@ -34,7 +34,7 @@ it shows the definition using `cases` syntax opportunistically, even though the 
 
 ## Multi-argument cases
 
-Functions that take multiple arguments and immediately match on a tuple of arguments can also be rewritten to use `cases`:
+Functions that take multiple arguments and immediately match on a tuple of arguments can also be rewritten to use `cases`. Here's a version using regular `match` syntax on a tuple:
 
 ```unison:hide
 merge : [a] -> [a] -> [a]
@@ -50,14 +50,14 @@ merge xs ys = match (xs, ys) with
 .> add
 ```
 
-Here's a version using `cases`:
+And here's a version using `cases`. The patterns are separated by commas:
 
 ```unison
 merge2 : [a] -> [a] -> [a]
 merge2 = cases
-  [] ys -> ys
-  xs [] -> xs
-  (h +: t) (h2 +: t2) ->
+  [], ys -> ys
+  xs, [] -> xs
+  h +: t, h2 +: t2 ->
     if h <= h2 then h  +: merge2 t (h2 +: t2)
     else            h2 +: merge2 (h +: t) t2
 ```
@@ -69,3 +69,16 @@ Notice that Unison detects this as an alias of `merge`, and if we view `merge`
 ```
 
 it again shows the definition using the multi-argument `cases` syntax opportunistically, even though the code was originally written without that syntax.
+
+Here's another example:
+
+```unison
+type B = T | F
+
+blah = cases
+  T, x -> "hi"
+  x, F -> "bye"
+
+> blah T F
+> blah F F
+```

--- a/unison-src/transcripts/lambdacase.output.md
+++ b/unison-src/transcripts/lambdacase.output.md
@@ -54,7 +54,7 @@ it shows the definition using `cases` syntax opportunistically, even though the 
 
 ## Multi-argument cases
 
-Functions that take multiple arguments and immediately match on a tuple of arguments can also be rewritten to use `cases`:
+Functions that take multiple arguments and immediately match on a tuple of arguments can also be rewritten to use `cases`. Here's a version using regular `match` syntax on a tuple:
 
 ```unison
 merge : [a] -> [a] -> [a]
@@ -74,14 +74,14 @@ merge xs ys = match (xs, ys) with
     merge : [a] ->{g} [a] ->{g} [a]
 
 ```
-Here's a version using `cases`:
+And here's a version using `cases`. The patterns are separated by commas:
 
 ```unison
 merge2 : [a] -> [a] -> [a]
 merge2 = cases
-  [] ys -> ys
-  xs [] -> xs
-  (h +: t) (h2 +: t2) ->
+  [], ys -> ys
+  xs, [] -> xs
+  h +: t, h2 +: t2 ->
     if h <= h2 then h  +: merge2 t (h2 +: t2)
     else            h2 +: merge2 (h +: t) t2
 ```
@@ -105,11 +105,48 @@ Notice that Unison detects this as an alias of `merge`, and if we view `merge`
 
   merge : [a] -> [a] -> [a]
   merge = cases
-    [] ys               -> ys
-    xs []               -> xs
-    (h +: t) (h2 +: t2) ->
+    [], ys           -> ys
+    xs, []           -> xs
+    h +: t, h2 +: t2 ->
       if h <= h2 then h +: merge t (h2 +: t2)
       else h2 +: merge (h +: t) t2
 
 ```
-it again shows the definition using the multi-argument `cases syntax opportunistically, even though the code was originally written without that syntax.
+it again shows the definition using the multi-argument `cases` syntax opportunistically, even though the code was originally written without that syntax.
+
+Here's another example:
+
+```unison
+type B = T | F
+
+blah = cases
+  T, x -> "hi"
+  x, F -> "bye"
+
+> blah T F
+> blah F F
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      type B
+      blah : B -> B -> Text
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    7 | > blah T F
+          ⧩
+          "hi"
+  
+    8 | > blah F F
+          ⧩
+          "bye"
+
+```


### PR DESCRIPTION
This PR updates the syntax for multi-argument `cases` to use commas to separate the patterns:

```Haskell
merge = cases
  -- previously, the comma wasn't needed between patterns, but this led to 
  -- ambiguity when parsing `Foo x -> ...` 
  -- is that a two argument lambda with nullary `Foo` or a 1 arg lambda `(Foo x) -> ...` 
  [], x -> x
  x, [] -> x
  h1 +: t1, h2 +: t2 -> 
    if h1 <= h2 then h1 +: merge t1 (h2 +: t2)
    else h2 +: merge (h1 +: t1) t2
```

See [the transcript](https://github.com/unisonweb/unison/blob/e721fc7d6fec3cec551fc77903747968cc7705be/unison-src/transcripts/lambdacase.output.md). 

I updated the unit tests and also added the original motivating test case from #1737 to the lambda cases transcript.

This fixes #1737 and see discussion there.