### PR TITLE
Use cases to inform ability matching type.

### DIFF
--- a/unison-src/transcripts/fix1696.md
+++ b/unison-src/transcripts/fix1696.md
@@ -1,0 +1,22 @@
+
+```ucm:hide
+.> builtins.merge
+```
+
+```unison:error
+ability Ask where ask : Nat
+
+unique ability Zoot where
+  zoot : Nat
+
+Ask.provide : '{Zoot} Nat -> '{Ask} r -> r
+Ask.provide answer asker =
+  h = cases
+    {r}                 -> r
+    {Ask.ask -> resume} -> handle resume !answer with h
+  handle !asker with h
+
+dialog = Ask.provide 'zoot '("Awesome number: " ++ Nat.toText Ask.ask ++ "!")
+
+> dialog
+```

--- a/unison-src/transcripts/fix1696.output.md
+++ b/unison-src/transcripts/fix1696.output.md
@@ -1,0 +1,49 @@
+
+```unison
+ability Ask where ask : Nat
+
+unique ability Zoot where
+  zoot : Nat
+
+Ask.provide : '{Zoot} Nat -> '{Ask} r -> r
+Ask.provide answer asker =
+  h = cases
+    {r}                 -> r
+    {Ask.ask -> resume} -> handle resume !answer with h
+  handle !asker with h
+
+dialog = Ask.provide 'zoot '("Awesome number: " ++ Nat.toText Ask.ask ++ "!")
+
+> dialog
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      ability Ask
+      unique ability Zoot
+      Ask.provide : '{Zoot} Nat -> '{Ask} r -> r
+      dialog      : Text
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+  💔💥
+  
+  I stopped evaluation after encountering an unhandled request:
+  
+    zoot
+  
+  This happens when using a handler that doesn't handle all
+  possible requests.
+  
+  I'm sorry this message doesn't have more detail about the
+  location of the failure. My makers plan to fix this in a
+  future release. 😢
+
+```

--- a/unison-src/transcripts/fix1696.output.md
+++ b/unison-src/transcripts/fix1696.output.md
@@ -19,31 +19,9 @@ dialog = Ask.provide 'zoot '("Awesome number: " ++ Nat.toText Ask.ask ++ "!")
 
 ```ucm
 
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
+  The expression in red  needs these abilities: {Zoot, 𝕖45}, but this location does not have access to any abilities.
   
-    ⍟ These new definitions are ok to `add`:
-    
-      ability Ask
-      unique ability Zoot
-      Ask.provide : '{Zoot} Nat -> '{Ask} r -> r
-      dialog      : Text
+     13 | dialog = Ask.provide 'zoot '("Awesome number: " ++ Nat.toText Ask.ask ++ "!")
   
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
-
-  💔💥
-  
-  I stopped evaluation after encountering an unhandled request:
-  
-    zoot
-  
-  This happens when using a handler that doesn't handle all
-  possible requests.
-  
-  I'm sorry this message doesn't have more detail about the
-  location of the failure. My makers plan to fix this in a
-  future release. 😢
 
 ```


### PR DESCRIPTION
This change inspects the patterns all at once to determine all the abilities being matched on in a case analysis, and uses it to inform the scrutinee type before checking any of the case bodies. Previously ability matching actually had no influence on the scrutinee type, which is clearly erroneous.

I implemented this as a sort of separate behavior that only applies to well-formed sets of `Request` matches. If some weird situation is checked, like a mix of ability and data matches against the same value, it will just have the old behavior. It could probably be factored a bit more if desired, but I made more of a minimal change so far.

This also prevents code like the following from working:

```
unsafePerformIO : Request {IO} a -> a
unsafePerformIO = cases
  { x } -> x
```

Since there are no `IO` cases being matched against, the type checker decides the `Request` is not actually handling `IO`, I guess. Incomplete matching would still give erroneous results, though.

Fixes #1696 at least, assuming the transcript output is expected.