### PR TITLE
Rewritten lexer using Megaparsec supporting hex and bytes literals

### DIFF
--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -345,7 +345,15 @@ lexemes = P.optional space >> do
         matchWith = openKw "match" <|> close' (Just "match-with") withOpens "with"
         ifElse = openKw "if" <|> close' (Just "then") ["if"] "then" <|> close' (Just "else") ["then"] "else"
         handle = openKw "handle" <|> close' (Just "with") withOpens "with"
-        typ = openKw1 "unique" <|> openKw1 "type" <|> openKw1 "ability"
+        typ = openKw1 "unique" <|> openTypeKw1 "type" <|> openTypeKw1 "ability"
+
+        -- In `unique type` and `unique ability`, only the `unique` opens a layout block,
+        -- and `ability` and `type` are just keywords.
+        openTypeKw1 t = do
+          b <- S.gets (topBlockName . layout)
+          case b of
+            Just "unique" -> wordyKw t
+            _ -> openKw1 t
 
         -- layout keyword which bumps the layout column by 1, rather than looking ahead
         -- to the next token to determine the layout column

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -159,8 +159,14 @@ token' tok p = LP.lexeme space $ do
 
     topHasClosePair :: Layout -> Bool
     topHasClosePair [] = False
-    topHasClosePair ((name,_):_) =
-      name == "{" || name == "(" || name == "match" || name == "handle" || name == "if" || name == "then"
+    topHasClosePair ((name,_):_) = case name of
+      "{" -> True
+      "(" -> True
+      "handle" -> True
+      "match" -> True
+      "if" -> True
+      "then" -> True
+      _ -> False
 
 -- todo: implement function with same signature as the existing lexer function
 -- to set up initial state, run the parser, etc
@@ -428,8 +434,9 @@ lexemes = P.optional space >> do
   eof :: P [Token Lexeme]
   eof = P.try $ do
     p <- P.eof >> pos
+    n <- maybe 0 (const 1) <$> S.gets opening
     l <- S.gets layout
-    pure $ replicate (length l) (Token Close p p)
+    pure $ replicate (length l + n) (Token Close p p)
 
 simpleWordyId :: String -> Lexeme
 simpleWordyId = flip WordyId Nothing

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -241,9 +241,9 @@ lexemes = P.optional space >> do
   tl <- eof
   pure $ hd <> tl
   where
-  toks = doc <|> token numeric <|> token symbolyId <|> token character
+  toks = doc <|> token numeric <|> token character <|> reserved <|> token symbolyId
      <|> token blank <|> token wordyId
-     <|> reserved <|> (asum . map token) [ semi, textual, backticks, hash ]
+     <|> (asum . map token) [ semi, textual, backticks, hash ]
 
   wordySep c = isSpace c || not (isAlphaNum c)
   positioned p = do start <- pos; a <- p; stop <- pos; pure (start, a, stop)
@@ -419,7 +419,7 @@ lexemes = P.optional space >> do
         typ = openKw1 "unique" <|> openTypeKw1 "type" <|> openTypeKw1 "ability"
 
         withKw = do
-          (pos1, with, pos2) <- positioned $ lit "with"
+          [Token _ pos1 pos2] <- wordyKw "with"
           env <- S.get
           let l = layout env
           case findClose ["handle","match"] l of
@@ -428,7 +428,7 @@ lexemes = P.optional space >> do
             Just (withBlock, n) -> do
               let b = withBlock <> "-with"
               S.put (env { layout = drop n l, opening = Just b })
-              let opens = [Token (Open with) pos1 pos2]
+              let opens = [Token (Open "with") pos1 pos2]
               pure $ replicate n (Token Close pos1 pos2) ++ opens
 
         -- In `unique type` and `unique ability`, only the `unique` opens a layout block,

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -292,20 +292,24 @@ lexemes = P.optional space >> do
     else pure id
 
   wordyIdSeg :: P String
-  wordyIdSeg = litSeg <|> (P.try do
+  -- wordyIdSeg = litSeg <|> (P.try do -- todo
+  wordyIdSeg = P.try do
     ch <- CP.satisfy wordyIdStartChar
     rest <- P.many (CP.satisfy wordyIdChar)
     when (Set.member (ch : rest) keywords) $ fail "identifier segment can't be a keyword"
-    pure (ch : rest))
+    pure (ch : rest)
 
+  {-
   -- ``an-identifier-with-dashes``
-  -- ```an identifier with dashes```
+  -- ```an identifier with spaces```
   litSeg :: P String
   litSeg = P.try $ do
     ticks1 <- lit "``"
     ticks2 <- P.many (char '`')
     let ticks = ticks1 <> ticks2
-    P.manyTill (CP.satisfy (const True)) (lit ticks)
+    let escTick = lit "\\`" $> '`'
+    P.manyTill (LP.charLiteral <|> escTick) (lit ticks)
+  -}
 
   hashMsg = "hash (ex: #af3sj3)"
   shorthash = P.label hashMsg $ do

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -232,7 +232,7 @@ lexemes = P.optional space >> do
   wordyId :: P Lexeme
   wordyId = P.label wordyMsg . P.try $ do
     dot <- P.optional (lit ".")
-    segs <- P.sepBy1 wordyIdSeg (char '.')
+    segs <- P.sepBy1 wordyIdSeg (P.try (char '.' <* P.lookAhead (CP.satisfy wordyIdChar)))
     shorthash <- P.optional shorthash
     pure $ WordyId (fromMaybe "" dot <> intercalate "." segs) shorthash
     where

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -159,7 +159,8 @@ token' tok p = LP.lexeme space $ do
 
     topHasClosePair :: Layout -> Bool
     topHasClosePair [] = False
-    topHasClosePair ((name,_):_) = name == "{" || name == "(" || name == "match" || name == "handle"
+    topHasClosePair ((name,_):_) =
+      name == "{" || name == "(" || name == "match" || name == "handle" || name == "if" || name == "then"
 
 -- todo: implement function with same signature as the existing lexer function
 -- to set up initial state, run the parser, etc
@@ -398,7 +399,7 @@ lexemes = P.optional space >> do
       pure [Token (Open s) pos1 pos2]
       where
         ok :: Char -> Bool
-        ok c = isSpace c || Set.member c delimiters
+        ok c = not (isAlphaNum c)
 
     close = close' False
 

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -126,14 +126,13 @@ token' tok p = LP.lexeme space $ do
       else
         pure []
 
+-- todo: implement function with same signature as the existing lexer function
+-- to set up initial state, run the parser, etc
 lexer0' :: P [Token Lexeme]
 lexer0' = do
   toks <- P.many lexemes
   pure (join toks)
 
--- todo: fill in the rest of the lexemes
--- suggest commenting out a bunch of this and dealing with the errors one
--- at a time
 lexemes :: P [Token Lexeme]
 lexemes = reserved
       <|> eof

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -130,7 +130,7 @@ token' tok p = LP.lexeme space $ do
       -- special case - handling of empty blocks, as in:
       --   foo =
       --   bar = 42
-      if column start <= top l && not (null l) then do
+      if column start <= top l && not (null l) && blockname /= "else" then do
         S.put (env { layout = (blockname, column start + 1) : l, opening = Nothing })
         pops start
       else [] <$ S.put (env { layout = layout', opening = Nothing })

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -323,7 +323,7 @@ lexemes = P.optional space >> do
   separated :: (Char -> Bool) -> P a -> P a
   separated ok p = P.try $ p <* P.lookAhead (void (CP.satisfy ok) <|> P.eof)
 
-  numeric = sep (float <|> intOrNat <|> bytes <|> otherbase)
+  numeric = sep (bytes <|> otherbase <|> float <|> intOrNat)
     where
       sep = separated (\c -> isSpace c || not (isAlphaNum c))
       intOrNat = P.try $ num <$> sign <*> LP.decimal

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -127,8 +127,15 @@ token' tok p = LP.lexeme space $ do
     -- character to determine the leftmost column of the `cases` block.
     -- That will be the column of the `0`.
     Just blockname ->
-      [] <$ S.put (env { layout = layout', opening = Nothing })
-      where layout' = (blockname, column start) : layout env
+      -- special case - handling of empty blocks, as in:
+      --   foo =
+      --   bar = 42
+      if column start <= top l && not (null l) then do
+        S.put (env { layout = (blockname, column start + 1) : l, opening = Nothing })
+        pops start
+      else [] <$ S.put (env { layout = layout', opening = Nothing })
+      where layout' = (blockname, column start) : l
+            l = layout env
     -- If we're not opening a block, we potentially pop from
     -- the layout stack and/or emit virtual semicolons.
     Nothing -> pops start

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -317,14 +317,14 @@ lexemes = P.optional space >> do
   symbolMsg = "operator (ex: +, Float./, List.++#xyz)"
 
   symbolyIdSeg :: P String
-  symbolyIdSeg = P.try $ do
+  symbolyIdSeg = do
     id <- P.takeWhile1P (Just symbolMsg) symbolyIdChar
     if Set.member id reservedOperators then fail "reserved operator"
     else pure id
 
   wordyIdSeg :: P String
   -- wordyIdSeg = litSeg <|> (P.try do -- todo
-  wordyIdSeg = P.try do
+  wordyIdSeg = do
     ch <- CP.satisfy wordyIdStartChar
     rest <- P.many (CP.satisfy wordyIdChar)
     when (Set.member (ch : rest) keywords) $ fail "identifier segment can't be a keyword"
@@ -473,7 +473,7 @@ lexemes = P.optional space >> do
       pos <- pos
       pure [Token (Reserved [ch]) pos (inc pos)]
 
-    delayOrForce = separated ok . P.try $ do
+    delayOrForce = separated ok $ do
       (start, op, end) <- positioned $ CP.satisfy isDelayOrForce
       pure [Token (Reserved [op]) start end]
       where ok c = isDelayOrForce c || isSpace c || isAlphaNum c || Set.member c delimiters

--- a/parser-typechecker/src/Unison/Parser.hs
+++ b/parser-typechecker/src/Unison/Parser.hs
@@ -30,6 +30,7 @@ import           Unison.Term          (MatchCase (..))
 import           Unison.Var           (Var)
 import qualified Unison.Var           as Var
 import qualified Unison.UnisonFile    as UF
+import Unison.Util.Bytes              (Bytes)
 import Unison.Name as Name
 import Unison.Names3 (Names)
 import qualified Unison.Names3 as Names
@@ -379,6 +380,11 @@ numeric :: Ord v => P v (L.Token String)
 numeric = queryToken getNumeric
   where getNumeric (L.Numeric s) = Just s
         getNumeric _             = Nothing
+
+bytesToken :: Ord v => P v (L.Token Bytes)
+bytesToken = queryToken getBytes
+  where getBytes (L.Bytes bs) = Just bs
+        getBytes _ = Nothing
 
 sepBy :: Ord v => P v a -> P v b -> P v [b]
 sepBy sep pb = P.sepBy pb sep

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -908,31 +908,31 @@ prettyParseError s = \case
         excerpt
       L.InvalidWordyId _id -> Pr.lines [
         "This identifier isn't valid syntax: ", "",
-        excerpt, "",
+        excerpt,
         "Here's a few examples of valid syntax: " <>
         style Code "abba1', snake_case, Foo.zoink!, 🌻" ]
       L.InvalidSymbolyId _id -> Pr.lines [
         "This infix identifier isn't valid syntax: ", "",
-        excerpt, "",
+        excerpt,
         "Here's a few valid examples: " <>
         style Code "++, Float./, `List.map`" ]
       L.InvalidBytesLiteral bs -> Pr.lines [
         "This bytes literal isn't valid syntax: " <> style ErrorSite (fromString bs), "",
-        excerpt, "",
+        excerpt,
         Pr.wrap $ "I was expecting an even number of hexidecimal characters"
                <> "(one of" <> Pr.group (style Code "0123456789abcdefABCDEF" <> ")")
                <> "after the" <> Pr.group (style ErrorSite "0xs" <> ".")
         ]
       L.InvalidHexLiteral -> Pr.lines [
         "This number isn't valid syntax: ", "",
-        excerpt, "",
+        excerpt,
         Pr.wrap $ "I was expecting only hexidecimal characters"
                <> "(one of" <> Pr.group (style Code "0123456789abcdefABCDEF" <> ")")
                <> "after the" <> Pr.group (style ErrorSite "0x" <> ".")
         ]
       L.InvalidOctalLiteral -> Pr.lines [
         "This number isn't valid syntax: ", "",
-        excerpt, "",
+        excerpt,
         Pr.wrap $ "I was expecting only octal characters"
                <> "(one of" <> Pr.group (style Code "01234567" <> ")")
                <> "after the" <> Pr.group (style ErrorSite "0o" <> ".")
@@ -944,17 +944,16 @@ prettyParseError s = \case
       L.UnknownLexeme -> Pr.lines [ "I couldn't parse this.", "", excerpt ]
       L.MissingFractional n -> Pr.lines [
         "This number isn't valid syntax: ", "",
-        excerpt, "",
+        excerpt,
         Pr.wrap $ "I was expecting some digits after the '.',"
                <> "for example: " <> style Code (n <> "0")
                <> "or" <> Pr.group (style Code (n <> "1e37") <> ".")
         ]
       L.MissingExponent n -> Pr.lines [
         "This number isn't valid syntax: ", "",
-        excerpt, "",
+        excerpt,
         Pr.wrap $ "I was expecting some digits for the exponent,"
-               <> "for example: " <> style Code (n <> "-14")
-               <> "or" <> Pr.group (style Code (n <> "37") <> ".")
+               <> "for example: " <> Pr.group (style Code (n <> "37") <> ".")
         ]
       L.TextLiteralMissingClosingQuote _txt -> Pr.lines [
         "This text is missing a closing quote:", "",

--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -41,8 +41,9 @@ import qualified Unison.Parser as Parser (seq, uniqueName)
 import qualified Unison.Pattern as Pattern
 import qualified Unison.Term as Term
 import qualified Unison.Type as Type
-import qualified Unison.Typechecker.Components as Components
 import qualified Unison.TypeParser as TypeParser
+import qualified Unison.Typechecker.Components as Components
+import qualified Unison.Util.Bytes as Bytes
 import qualified Unison.Var as Var
 
 watch :: Show a => String -> a -> a
@@ -345,6 +346,7 @@ termLeaf =
     , text
     , char
     , number
+    , bytes
     , boolean
     , link
     , tupleOrParenthesizedTerm
@@ -899,6 +901,13 @@ block' isTop s openBlock closeBlock = do
 
 number :: Var v => TermP v
 number = number' (tok Term.int) (tok Term.nat) (tok Term.float)
+
+bytes :: Var v => TermP v
+bytes = do
+  b <- bytesToken
+  let a = ann b
+  pure $ Term.app a (Term.builtin a "Bytes.fromList")
+                    (Term.seq a $ Term.nat a . fromIntegral <$> Bytes.toWord8s (L.payload b))
 
 number'
   :: Ord v

--- a/parser-typechecker/src/Unison/Util/Bytes.hs
+++ b/parser-typechecker/src/Unison/Util/Bytes.hs
@@ -3,6 +3,7 @@
 
 module Unison.Util.Bytes where
 
+import Data.Char
 import Data.Memory.PtrMethods (memCompare, memEqual)
 import Data.Monoid (Sum(..))
 import Foreign.Ptr (plusPtr)
@@ -126,7 +127,7 @@ instance T.Measured (Sum Int) (View ByteString) where
   measure b = Sum (B.length b)
 
 instance Show Bytes where
-  show bs = show (toWord8s bs)
+  show bs = toWord8s (toBase16 bs) >>= \w -> [chr (fromIntegral w)]
 
 -- Produces two lists where the chunks have the same length
 alignChunks :: B.ByteArrayAccess ba => [View ba] -> [View ba] -> ([View ba], [View ba])

--- a/parser-typechecker/src/Unison/Util/ColorText.hs
+++ b/parser-typechecker/src/Unison/Util/ColorText.hs
@@ -99,6 +99,7 @@ defaultColors :: ST.Element -> Maybe Color
 defaultColors = \case
   ST.NumericLiteral      -> Nothing
   ST.TextLiteral         -> Nothing
+  ST.BytesLiteral        -> Just Blue
   ST.CharLiteral         -> Nothing
   ST.BooleanLiteral      -> Nothing
   ST.Blank               -> Nothing

--- a/parser-typechecker/src/Unison/Util/ColorText.hs
+++ b/parser-typechecker/src/Unison/Util/ColorText.hs
@@ -99,7 +99,7 @@ defaultColors :: ST.Element -> Maybe Color
 defaultColors = \case
   ST.NumericLiteral      -> Nothing
   ST.TextLiteral         -> Nothing
-  ST.BytesLiteral        -> Just Blue
+  ST.BytesLiteral        -> Just HiBlack
   ST.CharLiteral         -> Nothing
   ST.BooleanLiteral      -> Nothing
   ST.Blank               -> Nothing

--- a/parser-typechecker/src/Unison/Util/SyntaxText.hs
+++ b/parser-typechecker/src/Unison/Util/SyntaxText.hs
@@ -13,6 +13,7 @@ type SyntaxText = AnnotatedText Element
 -- The elements of the Unison grammar, for syntax highlighting purposes
 data Element = NumericLiteral
              | TextLiteral
+             | BytesLiteral
              | CharLiteral
              | BooleanLiteral
              | Blank

--- a/parser-typechecker/tests/Unison/Test/Lexer.hs
+++ b/parser-typechecker/tests/Unison/Test/Lexer.hs
@@ -172,7 +172,8 @@ test =
         , simpleWordyId "x"
         , Close
         , Open "then"
-        , Reserved "else"
+        , Close
+        , Open "else"
         , Close
         ]
   -- Empty `else` clause

--- a/parser-typechecker/tests/Unison/Test/TermParser.hs
+++ b/parser-typechecker/tests/Unison/Test/TermParser.hs
@@ -43,7 +43,7 @@ test1 = scope "termparser" . tests . map parses $
   , "-1.2e+3"
   , "-1.2e-3"
 
-  , "-4th"
+  , "-4 th"
   , "()"
   , "(0)"
   , "forty"

--- a/parser-typechecker/tests/Unison/Test/TermPrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/TermPrinter.hs
@@ -118,6 +118,7 @@ test = scope "termprinter" $ tests
   , tc "if _something then _foo else _blah"
   , tc "3.14159"
   , tc "+0"
+  , tc "0xsabba1234"
   , tc "\"some text\""
   , tc "\"they said \\\"hi\\\"\""
   , pending $ tc "\'they said \\\'hi\\\'\'" -- TODO lexer doesn't support strings with single quotes in

--- a/parser-typechecker/tests/Unison/Test/TermPrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/TermPrinter.hs
@@ -119,6 +119,12 @@ test = scope "termprinter" $ tests
   , tc "3.14159"
   , tc "+0"
   , tc "0xsabba1234"
+  , tcDiff "0x00000001" "1"
+  , tcDiff "+0x00001" "+1"
+  , tcDiff "-0x0001" "-1"
+  , tcDiff "0xff" "255"
+  , tcDiff "+0xff" "+255"
+  , tcDiff "0o77777777" "16777215" -- Each octal digit is 3 bits, 8 7s is 2^(8*3) - 1
   , tc "\"some text\""
   , tc "\"they said \\\"hi\\\"\""
   , pending $ tc "\'they said \\\'hi\\\'\'" -- TODO lexer doesn't support strings with single quotes in

--- a/unison-src/new-runtime-transcripts/utf8.output.md
+++ b/unison-src/new-runtime-transcripts/utf8.output.md
@@ -35,7 +35,7 @@ ascii = "ABCDE"
 
     4 | > toUtf8 ascii
           ⧩
-          fromList [65, 66, 67, 68, 69]
+          0xs4142434445
 
 ```
 non-ascii characters are encoded as multiple bytes.
@@ -62,8 +62,7 @@ greek = "ΑΒΓΔΕ"
 
     4 | > toUtf8 greek
           ⧩
-          fromList
-            [206, 145, 206, 146, 206, 147, 206, 148, 206, 149]
+          0xsce91ce92ce93ce94ce95
 
 ```
 We can check that encoding and then decoding should give us back the same `Text` we started with 

--- a/unison-src/transcripts/bytesFromList.output.md
+++ b/unison-src/transcripts/bytesFromList.output.md
@@ -16,6 +16,6 @@ This should render as `Bytes.fromList [1,2,3,4]`, not `##Bytes.fromSequence [1,2
 
     1 | > Bytes.fromList [1,2,3,4]
           ⧩
-          fromList [1, 2, 3, 4]
+          0xs01020304
 
 ```

--- a/unison-src/transcripts/doc-formatting.output.md
+++ b/unison-src/transcripts/doc-formatting.output.md
@@ -82,11 +82,9 @@ commented = [:
 
   commented : Doc
   commented =
-    [: 
-    example:
+    [: example:
     
-      -- a comment
-      f x = x + 1
+    -- a comment f x = x + 1
      :]
 
 ```
@@ -291,8 +289,7 @@ doc6 = [:
 
   doc6 : Doc
   doc6 =
-    [: 
-      - foo
+    [: - foo
       - bar
     and the rest.
      :]
@@ -382,9 +379,8 @@ para line lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolo
 
   test1 : Doc
   test1 =
-    [: 
-    The internal logic starts to get hairy when you use the \@ features,
-    for example referencing a name like @List.take.  Internally,
+    [: The internal logic starts to get hairy when you use the \@
+    features, for example referencing a name like @List.take.  Internally,
     the text between each such usage is its own blob (blob ends here
     --> @List.take), so paragraph reflow has to be aware of multiple
     blobs to do paragraph reflow (or, more accurately, to do the
@@ -491,8 +487,7 @@ View is fine.
 
   test2 : Doc
   test2 =
-    [: 
-    Take a look at this:
+    [: Take a look at this:
     @[source] foo    ▶    bar
      :]
 
@@ -501,7 +496,6 @@ But note it's not obvious how display should best be handling this.  At the mome
 ```ucm
 .> display test2
 
-  
   Take a look at this:
   foo n =
     use Nat +

--- a/unison-src/transcripts/docs.output.md
+++ b/unison-src/transcripts/docs.output.md
@@ -140,7 +140,6 @@ Now that documentation is linked to the definition. We can view it if we like:
 
 .> display 1
 
-  
   `builtin.List.take n xs` returns the first `n` elements of `xs`.
   (No need to add line breaks manually. The display command will
   do wrapping of text for you.  Indent any lines where you don't
@@ -164,7 +163,6 @@ Or there's also a convenient function, `docs`, which shows the `Doc` values that
 ```ucm
 .> docs builtin.List.take
 
-  
   `builtin.List.take n xs` returns the first `n` elements of `xs`.
   (No need to add line breaks manually. The display command will
   do wrapping of text for you.  Indent any lines where you don't
@@ -190,11 +188,10 @@ Note that if we view the source of the documentation, the various references are
 
   docs.List.take : Doc
   docs.List.take =
-    [: 
-    `@builtin.List.take n xs` returns the first `n` elements of `xs`.
-    (No need to add line breaks manually. The display command will
-    do wrapping of text for you.  Indent any lines where you don't
-    want it to do this.)
+    [: `@builtin.List.take n xs` returns the first `n` elements of
+    `xs`. (No need to add line breaks manually. The display command
+    will do wrapping of text for you.  Indent any lines where you
+    don't want it to do this.)
     
     ## Examples:
     

--- a/unison-src/transcripts/error-messages.md
+++ b/unison-src/transcripts/error-messages.md
@@ -1,0 +1,60 @@
+
+```ucm:hide
+.> builtins.merge
+```
+
+This file contains programs with parse errors and type errors, for visual inspection of error message quality and to check for regressions or changes to error reporting.
+
+## Parse errors
+
+Some basic errors of literals.
+
+### Floating point literals
+
+```unison:error
+x = 1. -- missing some digits after the decimal
+```
+
+```unison:error
+x = 1e -- missing an exponent
+```
+
+```unison:error
+x = 1e- -- missing an exponent
+```
+
+```unison:error
+x = 1E+ -- missing an exponent
+```
+
+### Hex, octal, and bytes literals
+
+```unison:error
+x = 0xoogabooga -- invalid hex chars
+```
+
+```unison:error
+x = 0o987654321 -- 9 and 8 are not valid octal char
+```
+
+```unison:error
+x = 0xsf -- odd number of hex chars in a bytes literal
+```
+
+```unison:error
+x = 0xsnotvalidhexchars -- invalid hex chars in a bytes literal
+```
+
+### Layout errors
+
+```unison:error
+foo = else -- not matching if
+```
+
+```unison:error
+foo = then -- unclosed
+```
+
+```unison:error
+foo = with -- unclosed
+```

--- a/unison-src/transcripts/error-messages.output.md
+++ b/unison-src/transcripts/error-messages.output.md
@@ -1,0 +1,161 @@
+
+This file contains programs with parse errors and type errors, for visual inspection of error message quality and to check for regressions or changes to error reporting.
+
+## Parse errors
+
+Some basic errors of literals.
+
+### Floating point literals
+
+```unison
+x = 1. -- missing some digits after the decimal
+```
+
+```ucm
+
+  This number isn't valid syntax: 
+  
+      1 | x = 1. -- missing some digits after the decimal
+  
+  I was expecting some digits after the '.', for example: 1.0 or
+  1.1e37.
+
+```
+```unison
+x = 1e -- missing an exponent
+```
+
+```ucm
+
+  This number isn't valid syntax: 
+  
+      1 | x = 1e -- missing an exponent
+  
+  I was expecting some digits for the exponent, for example:
+  1e37.
+
+```
+```unison
+x = 1e- -- missing an exponent
+```
+
+```ucm
+
+  This number isn't valid syntax: 
+  
+      1 | x = 1e- -- missing an exponent
+  
+  I was expecting some digits for the exponent, for example:
+  1e-37.
+
+```
+```unison
+x = 1E+ -- missing an exponent
+```
+
+```ucm
+
+  This number isn't valid syntax: 
+  
+      1 | x = 1E+ -- missing an exponent
+  
+  I was expecting some digits for the exponent, for example:
+  1e+37.
+
+```
+### Hex, octal, and bytes literals
+
+```unison
+x = 0xoogabooga -- invalid hex chars
+```
+
+```ucm
+
+  This number isn't valid syntax: 
+  
+      1 | x = 0xoogabooga -- invalid hex chars
+  
+  I was expecting only hexidecimal characters (one of
+  0123456789abcdefABCDEF) after the 0x.
+
+```
+```unison
+x = 0o987654321 -- 9 and 8 are not valid octal char
+```
+
+```ucm
+
+  This number isn't valid syntax: 
+  
+      1 | x = 0o987654321 -- 9 and 8 are not valid octal char
+  
+  I was expecting only octal characters (one of 01234567) after
+  the 0o.
+
+```
+```unison
+x = 0xsf -- odd number of hex chars in a bytes literal
+```
+
+```ucm
+
+  This bytes literal isn't valid syntax: 0xsf
+  
+      1 | x = 0xsf -- odd number of hex chars in a bytes literal
+  
+  I was expecting an even number of hexidecimal characters (one
+  of 0123456789abcdefABCDEF) after the 0xs.
+
+```
+```unison
+x = 0xsnotvalidhexchars -- invalid hex chars in a bytes literal
+```
+
+```ucm
+
+  This bytes literal isn't valid syntax: 0xsnotvalidhexchars
+  
+      1 | x = 0xsnotvalidhexchars -- invalid hex chars in a bytes literal
+  
+  I was expecting an even number of hexidecimal characters (one
+  of 0123456789abcdefABCDEF) after the 0xs.
+
+```
+### Layout errors
+
+```unison
+foo = else -- not matching if
+```
+
+```ucm
+
+  I found a closing 'else' here without a matching 'then'.
+  
+      1 | foo = else -- not matching if
+  
+
+```
+```unison
+foo = then -- unclosed
+```
+
+```ucm
+
+  I found a closing 'then' here without a matching 'if'.
+  
+      1 | foo = then -- unclosed
+  
+
+```
+```unison
+foo = with -- unclosed
+```
+
+```ucm
+
+  I found a closing 'with' here without a matching 'handle' or 'match'.
+  
+      1 | foo = with -- unclosed
+  
+
+```


### PR DESCRIPTION
(You can start reviewing, but hold off on merging: I have one todo left, making lexer errors print out nicely.)

This is a drop in replacement for the old lexer, totally rewritten using Megaparsec. This was done to support new documentation syntax which will require some lexer fanciness. The code isn't really much shorter, but it's now more straightforward parser combinator code. The layout handling, however, is still pretty finicky.

I added a couple features during the rewrite:

* Hexadecimal and octal literals, like `0xdeadbeef` or `0o012723`, which are parsed as the corresponding `Nat`.
* Bytes literals, which start with `0xs`, for instance `0xs9ab38bcf83ffabb9012`, which are used by the pretty-printer.

## Interesting/controversial decisions

I was going to add a syntax for identifiers that include spaces or other special characters, using surrounding double backticks (or any number of enclosing backticks that's greater than 1). The lexer change was very easy, but the pretty-printer change seemed annoying and hard to do properly because of how names are just an opaque text value currently. So I left this feature commented out for now.

## Test coverage

There's good coverage from all the existing tests and transcripts. The new bytes literals feature has some testing from existing transcripts. I added some tests of the hex and octal literals as well to the term printer test suite.

I added a new transcript (`error-messages.md`) demonstrating some of the new error messages.

## Loose ends

I wasn't able to delete some of the old wordy and symboly id parsers which are currently being used in path parsing which I didn't want to mess with for this PR. But I'd like to clean that up at some point.