### PR TITLE
Add .github/workflows/ci.yaml for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  build:
+    name: build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest] # , macOS-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        name: cache ~/.stack
+        with:
+          path: ~/.stack
+          key: x-${{runner.os}}-stack-${{hashFiles('stack.yaml')}}
+      - uses: actions/cache@v2
+        name: cache .stack-work
+        with:
+          path: |
+            .stack-work
+            parser-typechecker/.stack-work
+            unison-core/.stack-work
+            yaks/easytest/.stack-work
+          key: x-${{runner.os}}-stack_work-${{hashFiles('stack.yaml')}}-${{github.sha}}
+          restore-keys: x-${{runner.os}}-stack_work-${{hashFiles('stack.yaml')}}-
+      - name: install stack
+        run: |
+          echo $PATH
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.5.1/stack-2.5.1-linux-x86_64.tar.gz | tar -xz
+          echo "$HOME/stack-2.5.1-linux-x86_64/" >> $GITHUB_PATH
+      - name: set git username
+        run: git config --global user.name "GitHub Actions"
+      - name: build dependencies
+        run: stack --no-terminal --system-ghc build --fast --only-dependencies
+      - name: build
+        run: stack --no-terminal --system-ghc build --fast
+      - name: tests
+        run: stack --no-terminal --system-ghc exec tests
+      - name: tests (new runtime)
+        run: stack --no-terminal --system-ghc exec tests -- --new-runtime
+      - name: transcripts
+        run: |
+          stack --no-terminal --system-ghc exec transcripts
+          git diff
+          x=`git status --porcelain -uno` bash -c 'if [[ -n $x ]]; then echo "$x" && false; fi'
+      - name: transcripts (new runtime)
+        run: |
+          stack --no-terminal --system-ghc exec transcripts -- --new-runtime
+          git diff
+          x=`git status --porcelain -uno` bash -c 'if [[ -n $x ]]; then echo "$x" && false; fi'


### PR DESCRIPTION
## Overview

This PR adds a .github/workflows/ci.yaml file for GitHub actions. I tried to make it perform roughly the same actions as the Travis CI config (build and run tests with both runtimes, then cache stuff).

## Interesting/controversial decisions

I cached the local packages' build artifacts in `.stack-work` their directories, in addition to `~/.stack`, which caches dependencies. The intention here is for CI to be similar in speed to locally editing a file and rebuilding - presumably not every local module will need to be recompiled.

However, there may be some downsides to caching `.stack-work` that I haven't thought of, and I didn't measure whether caching it actually produced a measurable speedup.

## Loose ends

Only an Ubuntu build is configured at the moment, but macOS shouldn't be too hard to add. The main reason I didn't add it in this first pass is I had to download `stack` manually as part of the build, because the official `setup-haskell` action is broken right now (it uses a deprecated mechanism for setting environment variables). So, the build explicitly downloads a `linux` flavor of `stack`, but that could switch on the runner's OS instead.