### PR TITLE
Fix typo in README (`op` -> `reduce` in the code example)

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -12,7 +12,7 @@ The format for this list: name, GitHub handle, and then optional blurb about wha
 * Arya Irani (@aryairani) - Ditto
 * Rúnar Bjarnason (@runarorama) - Typechecker, runtime, parser, code serialization
 * Chris Gibbs (@atacratic) - Pretty-printer
-* Noah Haasis (@noahhaasis) - Tool that makes improving the error messages easier
+* Noah Haasis (@noahhaasis)
 * Francis De Brabandere (@francisdb)
 * Matt Dziuban (@mrdziuban)
 * Ben Fradet (@BenFradet)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ mapReduce loc fn ifEmpty reduce data = match split data with
   Two left right ->
     fl = at loc '(mapReduce loc fn ifEmpty reduce !left)
     fr = at loc '(mapReduce loc fn ifEmpty reduce !right)
-    op !fl !fr
+    reduce !fl !fr
 ```
 
 This function can be either simulated locally (possibly with faults injected for testing purposes), or run atop a distributed pool of compute. 


### PR DESCRIPTION
Found a little typo, while checking up on unison after some time :^)

(And used the opportunity to take out the pretentious line from the CONTRIBUTORS.md)