### PR TITLE
Run CI on more machines

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   pull_request:
-  push:
 
 jobs:
   build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,9 @@
 name: CI
 
+# Build on every push and every pull request (which tests the merge commit).
 on:
   pull_request:
+  push:
 
 jobs:
   build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,22 +68,22 @@ jobs:
       # Build deps, then build local code. Splitting it into two steps just allows us to see how much time each step
       # takes.
       - name: build dependencies
-        run: stack --no-terminal --system-ghc build --fast --only-dependencies
+        run: stack --no-terminal build --fast --only-dependencies
       - name: build
-        run: stack --no-terminal --system-ghc build --fast
+        run: stack --no-terminal build --fast
 
       # Run each test suite (tests and transcripts) on each runtime
       - name: tests
-        run: stack --no-terminal --system-ghc exec tests
+        run: stack --no-terminal exec tests
       - name: tests (new runtime)
-        run: stack --no-terminal --system-ghc exec tests -- --new-runtime
+        run: stack --no-terminal exec tests -- --new-runtime
       - name: transcripts
         run: |
-          stack --no-terminal --system-ghc exec transcripts
+          stack --no-terminal exec transcripts
           git diff
           x=`git status --porcelain -uno` bash -c 'if [[ -n $x ]]; then echo "$x" && false; fi'
       - name: transcripts (new runtime)
         run: |
-          stack --no-terminal --system-ghc exec transcripts -- --new-runtime
+          stack --no-terminal exec transcripts -- --new-runtime
           git diff
           x=`git status --porcelain -uno` bash -c 'if [[ -n $x ]]; then echo "$x" && false; fi'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,9 +11,14 @@ jobs:
     strategy:
       # Run each build to completion, regardless of if any have failed
       fail-fast: false
-      # macOS-11.10 is available on GitHub Actions, but the build fails with "can't load framework: Cocoa (not found)"
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04, macOS-10.15]
+        os:
+          - ubuntu-20.04
+          - ubuntu-18.04
+          # - ubuntu-16.04
+          # this build fails with "can't load framework: Cocoa (not found)"
+          # - macOS-11.10
+          - macOS-10.15
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,13 +22,17 @@ jobs:
       - uses: actions/checkout@v2
 
       # Cache ~/.stack, keyed by the contents of 'stack.yaml'.
+      # The "0" in "stack-0" is meant to be bumped as a crude means to clear a cache, in case it's misbehaving.
+      # GitHub will automatically delete caches that haven't been accessed in 7 days, but there is no way to purge one
+      # manually.
       - uses: actions/cache@v2
         name: cache ~/.stack
         with:
           path: ~/.stack
-          key: stack_${{matrix.os}}-${{hashFiles('stack.yaml')}}
+          key: stack-0_${{matrix.os}}-${{hashFiles('stack.yaml')}}
 
       # Cache each local package's ~/.stack-work for fast incremental builds in CI.
+      # See note above about "0" in "stack-work-0..."
       - uses: actions/cache@v2
         name: cache .stack-work
         with:
@@ -38,9 +42,9 @@ jobs:
             unison-core/.stack-work
             yaks/easytest/.stack-work
           # Main hash key: the branch + commit hash. This should always result in a cache miss...
-          key: stack-work-${{matrix.os}}-${{github.ref}}-${{github.sha}}
+          key: stack-work-0_${{matrix.os}}-${{github.ref}}-${{github.sha}}
           # ...but then fall back on the latest cache stored on that branch.
-          restore-keys: stack-work_${{matrix.os}}-${{github.ref}}-
+          restore-keys: stack-work-0_${{matrix.os}}-${{github.ref}}-
 
       # Install stack by downloading the binary from GitHub. The installation process is different for Linux and macOS,
       # so this is split into two steps, only one of which will run on any particular build.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,19 +6,25 @@ on:
 
 jobs:
   build:
-    name: build (${{ matrix.os }})
+    name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      # Run each build to completion, regardless of if any have failed
       fail-fast: false
+      # macOS-11.10 is available on GitHub Actions, but the build fails with "can't load framework: Cocoa (not found)"
       matrix:
-        os: [ubuntu-latest] # , macOS-latest]
+        os: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04, macOS-10.15]
     steps:
       - uses: actions/checkout@v2
+
+      # Cache ~/.stack, keyed by the contents of 'stack.yaml'.
       - uses: actions/cache@v2
         name: cache ~/.stack
         with:
           path: ~/.stack
-          key: x-${{runner.os}}-stack-${{hashFiles('stack.yaml')}}
+          key: stack_${{matrix.os}}-${{hashFiles('stack.yaml')}}
+
+      # Cache each local package's ~/.stack-work for fast incremental builds in CI.
       - uses: actions/cache@v2
         name: cache .stack-work
         with:
@@ -27,19 +33,36 @@ jobs:
             parser-typechecker/.stack-work
             unison-core/.stack-work
             yaks/easytest/.stack-work
-          key: x-${{runner.os}}-stack_work-${{hashFiles('stack.yaml')}}-${{github.sha}}
-          restore-keys: x-${{runner.os}}-stack_work-${{hashFiles('stack.yaml')}}-
-      - name: install stack
+          # Main hash key: the branch + commit hash. This should always result in a cache miss...
+          key: stack-work-${{matrix.os}}-${{github.ref}}-${{github.sha}}
+          # ...but then fall back on the latest cache stored on that branch.
+          restore-keys: stack-work_${{matrix.os}}-${{github.ref}}-
+
+      # Install stack by downloading the binary from GitHub. The installation process is different for Linux and macOS,
+      # so this is split into two steps, only one of which will run on any particular build.
+      - name: install stack (Linux)
+        if: runner.os == 'Linux'
         run: |
-          echo $PATH
           curl -L https://github.com/commercialhaskell/stack/releases/download/v2.5.1/stack-2.5.1-linux-x86_64.tar.gz | tar -xz
           echo "$HOME/stack-2.5.1-linux-x86_64/" >> $GITHUB_PATH
+      - name: install stack (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.5.1/stack-2.5.1-osx-x86_64.tar.gz | tar -xz
+          echo "$HOME/stack-2.5.1-osx-x86_64/" >> $GITHUB_PATH
+
+      # One of the transcripts fails if the user's git name hasn't been set.
       - name: set git username
         run: git config --global user.name "GitHub Actions"
+
+      # Build deps, then build local code. Splitting it into two steps just allows us to see how much time each step
+      # takes.
       - name: build dependencies
         run: stack --no-terminal --system-ghc build --fast --only-dependencies
       - name: build
         run: stack --no-terminal --system-ghc build --fast
+
+      # Run each test suite (tests and transcripts) on each runtime
       - name: tests
         run: stack --no-terminal --system-ghc exec tests
       - name: tests (new runtime)


### PR DESCRIPTION
## Overview

This PR adds a few more machines to the CI build, fixes an issue with the `~/.stack-work` caching logic (by including the branch name in the cache key), and adds some documentation to the `ci.yaml` file so that others may find it easier to tweak in the future.