### PR TITLE
Fix typechecking of patterns for polymorphic effects

### DIFF
--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -1215,6 +1215,13 @@ checkPattern scrutineeType0 p =
         -- an effect ctor should have exactly 1 effect!
         Type.Effect'' [et] it -> do
           -- expecting scrutineeType to be `Effect et vt`
+
+          -- ensure that the variables in `et` unify with those from
+          -- the scrutinee.
+          lift $ do
+            res <- Type.flattenEffects <$> applyM (existentialp loc e)
+            abilityCheck' res [et]
+
           st <- lift $ applyM scrutineeType
           case st of
             Type.App' _ vt ->

--- a/parser-typechecker/tests/Unison/Test/Typechecker/TypeError.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker/TypeError.hs
@@ -40,7 +40,7 @@ test = scope "> extractor" . tests $
         "  {a} -> 3\n" ++
         "  {Abort.abort -> k} ->\n" ++
         "    handle k 100 with xyz default\n"
-      ) Err.matchBody
+      ) Err.generalMismatch
   ]
   where y, n :: String -> ErrorExtractor Symbol Ann a -> Test ()
         y s ex = scope s $ expect $ yieldsError s ex

--- a/unison-src/transcripts/fix693.md
+++ b/unison-src/transcripts/fix693.md
@@ -1,0 +1,19 @@
+
+```ucm:hide
+.> builtins.merge
+```
+
+This code should not type check. The match on X.x ought to introduce
+a skolem variable `a` such that `c : a` and the continuation has type
+`a ->{X} b`. Thus, `handle c with h : Optional a`, which is not the
+correct result type.
+
+```unison:error
+ability X where
+  x : a -> a
+
+h : Request X b -> Optional b
+h req = match req with
+  { X.x c -> _ } -> handle c with h
+  { d } -> Some d
+```

--- a/unison-src/transcripts/fix693.md
+++ b/unison-src/transcripts/fix693.md
@@ -3,17 +3,55 @@
 .> builtins.merge
 ```
 
-This code should not type check. The match on X.x ought to introduce
-a skolem variable `a` such that `c : a` and the continuation has type
+```unison
+ability X t where
+  x : t -> a -> a
+
+ability Abort where
+  abort : a
+```
+
+```ucm
+.> add
+```
+
+This code should not type check. The match on X.x ought to introduce a
+skolem variable `a` such that `c : a` and the continuation has type
 `a ->{X} b`. Thus, `handle c with h : Optional a`, which is not the
 correct result type.
 
 ```unison:error
-ability X where
-  x : a -> a
-
-h : Request X b -> Optional b
-h req = match req with
-  { X.x c -> _ } -> handle c with h
+h0 : Request {X t} b -> Optional b
+h0 req = match req with
+  { X.x _ c -> _ } -> handle c with h0
   { d } -> Some d
+```
+
+This code should not check because `t` does not match `b`.
+
+```unison:error
+h1 : Request {X t} b -> Optional b
+h1 req = match req with
+  { X.x t _ -> _ } -> handle t with h1
+  { d } -> Some d
+```
+
+This code should not check for reasons similar to the first example,
+but with the continuation rather than a parameter.
+
+```unison:error
+h2 : Request {Abort} r -> r
+h2 req = match req with
+  { Abort.abort -> k } -> handle k 5 with h2
+  { r } -> r
+```
+
+This should work fine.
+
+```unison
+h3 : Request {X b, Abort} b -> Optional b
+h3 = cases
+  { r } -> Some r
+  { Abort.abort -> _ } -> None
+  { X.x b _ -> _ } -> Some b
 ```

--- a/unison-src/transcripts/fix693.output.md
+++ b/unison-src/transcripts/fix693.output.md
@@ -1,0 +1,119 @@
+
+```unison
+ability X t where
+  x : t -> a -> a
+
+ability Abort where
+  abort : a
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      ability Abort
+      ability X t
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    ability Abort
+    ability X t
+
+```
+This code should not type check. The match on X.x ought to introduce a
+skolem variable `a` such that `c : a` and the continuation has type
+`a ->{X} b`. Thus, `handle c with h : Optional a`, which is not the
+correct result type.
+
+```unison
+h0 : Request {X t} b -> Optional b
+h0 req = match req with
+  { X.x _ c -> _ } -> handle c with h0
+  { d } -> Some d
+```
+
+```ucm
+
+  I found a value of type builtin.Optional a1 where I expected to find one of type builtin.Optional a:
+  
+      1 | h0 : Request {X t} b -> Optional b
+      2 | h0 req = match req with
+      3 |   { X.x _ c -> _ } -> handle c with h0
+  
+    from right here:
+  
+      1 | h0 : Request {X t} b -> Optional b
+  
+
+```
+This code should not check because `t` does not match `b`.
+
+```unison
+h1 : Request {X t} b -> Optional b
+h1 req = match req with
+  { X.x t _ -> _ } -> handle t with h1
+  { d } -> Some d
+```
+
+```ucm
+
+  Each case of a match / with expression need to have the same
+  type. Here, one is builtin.Optional t and another is
+  builtin.Optional b :
+  
+      3 |   { X.x t _ -> _ } -> handle t with h1
+      4 |   { d } -> Some d
+  
+    from right here:
+  
+      1 | h1 : Request {X t} b -> Optional b
+  
+
+```
+This code should not check for reasons similar to the first example,
+but with the continuation rather than a parameter.
+
+```unison
+h2 : Request {Abort} r -> r
+h2 req = match req with
+  { Abort.abort -> k } -> handle k 5 with h2
+  { r } -> r
+```
+
+```ucm
+
+  The 1st argument to the function k is builtin.Nat, but I was expecting a:
+  
+      3 |   { Abort.abort -> k } -> handle k 5 with h2
+  
+
+```
+This should work fine.
+
+```unison
+h3 : Request {X b, Abort} b -> Optional b
+h3 = cases
+  { r } -> Some r
+  { Abort.abort -> _ } -> None
+  { X.x b _ -> _ } -> Some b
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      h3 : Request {X b, Abort} b -> Optional b
+
+```


### PR DESCRIPTION
Fixes #693 

This actually fixes an additional problem I noticed while experimenting with the 693 example, which is that code like the following would work:

```
ability A t where
  a : t -> r

h : Request {A t} u -> u
h = cases
  { a x -> _ } -> x
  { y } -> y
```

because nothing was ensuring that `x` had type `t`, and its type was just allowed to unify with `u`. This case is covered in the test transcript.

Skolemization is done properly for data types as well, but I don't think it's possible to create a type where this matters yet.