### PR TITLE
Fix caching issue in CI that affects macOS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,10 +23,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # The random number towards the beginning of the cache keys below are meant to be bumped as a crude means to clear
+      # a cache. GitHub will automatically delete caches that haven't been accessed in 7 days, but there is no way to
+      # purge one manually.
+
+      # Cache ghc installed by ghcup
+      - uses: actions/cache@v2
+        name: cache ghc installed by ghcup
+        id: cache-ghc
+        with:
+          path: |
+            ~/.ghcup/bin/ghc-8.8.3
+            ~/.ghcup/ghc/8.8.3/bin/ghc
+          key: ghcup-0_${{matrix.os}}
+
       # Cache ~/.stack, keyed by the contents of 'stack.yaml'.
-      # The "0" in "stack-0" is meant to be bumped as a crude means to clear a cache, in case it's misbehaving.
-      # GitHub will automatically delete caches that haven't been accessed in 7 days, but there is no way to purge one
-      # manually.
       - uses: actions/cache@v2
         name: cache ~/.stack
         with:
@@ -34,7 +45,6 @@ jobs:
           key: stack-0_${{matrix.os}}-${{hashFiles('stack.yaml')}}
 
       # Cache each local package's ~/.stack-work for fast incremental builds in CI.
-      # See note above about "0" in "stack-work-0..."
       - uses: actions/cache@v2
         name: cache .stack-work
         with:
@@ -43,10 +53,28 @@ jobs:
             parser-typechecker/.stack-work
             unison-core/.stack-work
             yaks/easytest/.stack-work
-          # Main hash key: the branch + commit hash. This should always result in a cache miss...
-          key: stack-work-0_${{matrix.os}}-${{github.ref}}-${{github.sha}}
-          # ...but then fall back on the latest cache stored on that branch.
-          restore-keys: stack-work-0_${{matrix.os}}-${{github.ref}}-
+            # Main cache key: commit hash. This should always result in a cache miss...
+          key: stack-work-0_${{matrix.os}}-${{github.sha}}
+          # ...but then fall back on the latest cache stored (on this branch)
+          restore-keys: stack-work-0_${{matrix.os}}-
+
+      # Install ghcup on Linux only, because apparently it's pre-installed on the macOS runners.
+      - name: install ghcup (Linux)
+        if: runner.os == 'Linux' && steps.cache-ghc.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          curl -L https://downloads.haskell.org/~ghcup/x86_64-linux-ghcup > "$HOME/.local/bin/ghcup"
+          chmod +x "$HOME/.local/bin/ghcup"
+
+      # Install ghc 8.8.3 with ghcup
+      - name: install ghc 8.8.3
+        if: steps.cache-ghc.outputs.cache-hit != 'true'
+        run: ghcup install ghc 8.8.3
+
+      # Add ~/.ghcup/ghc/8.8.3/bin to path
+      - name: add ghc to path
+        run: echo "$HOME/.ghcup/ghc/8.8.3/bin" >> $GITHUB_PATH
 
       # Install stack by downloading the binary from GitHub. The installation process is different for Linux and macOS,
       # so this is split into two steps, only one of which will run on any particular build.
@@ -65,25 +93,29 @@ jobs:
       - name: set git username
         run: git config --global user.name "GitHub Actions"
 
+      - name: remove ~/.stack/setup-exe-cache on macOS
+        if: runner.os == 'macOS'
+        run: rm -rf ~/.stack/setup-exe-cache
+
       # Build deps, then build local code. Splitting it into two steps just allows us to see how much time each step
       # takes.
       - name: build dependencies
-        run: stack --no-terminal build --fast --only-dependencies
+        run: stack --no-terminal --system-ghc build --fast --only-dependencies
       - name: build
-        run: stack --no-terminal build --fast
+        run: stack --no-terminal --system-ghc build --fast
 
       # Run each test suite (tests and transcripts) on each runtime
       - name: tests
-        run: stack --no-terminal exec tests
+        run: stack --no-terminal --system-ghc exec tests
       - name: tests (new runtime)
-        run: stack --no-terminal exec tests -- --new-runtime
+        run: stack --no-terminal --system-ghc exec tests -- --new-runtime
       - name: transcripts
         run: |
-          stack --no-terminal exec transcripts
+          stack --no-terminal --system-ghc exec transcripts
           git diff
           x=`git status --porcelain -uno` bash -c 'if [[ -n $x ]]; then echo "$x" && false; fi'
       - name: transcripts (new runtime)
         run: |
-          stack --no-terminal exec transcripts -- --new-runtime
+          stack --no-terminal --system-ghc exec transcripts -- --new-runtime
           git diff
           x=`git status --porcelain -uno` bash -c 'if [[ -n $x ]]; then echo "$x" && false; fi'


### PR DESCRIPTION
## Overview

This patch does two things:
- Use `ghcup` to install GHC, rather than relying on `stack`'s ability to do so
- Delete a folder in `~/.stack` to fix a weird caching issue that only affects macOS builds

The first change is unrelated to the bug; I only implemented it as a first attempt to diagnose the bug, but it turned out not to be necessary. However, I figured it doesn't hurt to include, as it may be helpful some day for installing GHC for a `cabal`-based build, which of course can't install GHC by itself as `stack` can.