### PR TITLE
A couple fixes to ability unification

### DIFF
--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -894,12 +894,10 @@ synthesize e = scope (InSynthesize e) $
       existentializeArrows t
     s -> compilerCrash $ FreeVarsInTypeAnnotation s
   go (Term.Ref' h) = compilerCrash $ UnannotatedReference h
-  go (Term.Constructor' r cid) = do
-    t <- getDataConstructorType r cid
-    existentializeArrows t
-  go (Term.Request' r cid) = do
-    t <- ungeneralize =<< getEffectConstructorType r cid
-    existentializeArrows t
+  go (Term.Constructor' r cid) =
+    Type.purifyArrows <$> getDataConstructorType r cid
+  go (Term.Request' r cid) =
+    ungeneralize . Type.purifyArrows =<< getEffectConstructorType r cid
   go (Term.Ann' e t) = do
     t <- existentializeArrows t
     t <$ checkScoped e t

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -898,9 +898,7 @@ synthesize e = scope (InSynthesize e) $
     Type.purifyArrows <$> getDataConstructorType r cid
   go (Term.Request' r cid) =
     ungeneralize . Type.purifyArrows =<< getEffectConstructorType r cid
-  go (Term.Ann' e t) = do
-    t <- existentializeArrows t
-    t <$ checkScoped e t
+  go (Term.Ann' e t) = checkScoped e t
   go (Term.Float' _) = pure $ Type.float l -- 1I=>
   go (Term.Int' _) = pure $ Type.int l -- 1I=>
   go (Term.Nat' _) = pure $ Type.nat l -- 1I=>
@@ -1406,36 +1404,58 @@ forcedData ty = Type.freeVars ty
 -- | Apply the context to the input type, then convert any unsolved existentials
 -- to universals.
 generalizeExistentials :: (Var v, Ord loc) => [Element v loc] -> Type v loc -> Type v loc
-generalizeExistentials ctx t =
-  foldr gen (applyCtx ctx t) unsolvedExistentials
+generalizeExistentials = generalizeP existentialP
+
+generalizeP
+  :: Var v
+  => Ord loc
+  => (Element v loc -> Maybe (TypeVar v loc, v))
+  -> [Element v loc]
+  -> Type v loc
+  -> Type v loc
+generalizeP p ctx0 ty = foldr gen (applyCtx ctx0 ty) ctx
   where
-    unsolvedExistentials = [ v | Var (TypeVar.Existential _ v) <- ctx ]
-    gen e t =
-      if TypeVar.Existential B.Blank e `ABT.isFreeIn` t
-      -- location of the forall is just the location of the input type
-      -- and the location of each quantified variable is just inherited from
-      -- its source location
-      then Type.forall (loc t)
-                       (TypeVar.Universal e)
-                       (ABT.substInheritAnnotation
-                           (TypeVar.Existential B.Blank e)
-                           (universal' () e)
-                           t)
-      else t -- don't bother introducing a forall if type variable is unused
+  ctx = mapMaybe p ctx0
+
+  gen (tv, v) t
+    | tv `ABT.isFreeIn` t
+    -- location of the forall is just the location of the input type
+    -- and the location of each quantified variable is just inherited
+    -- from its source location
+    = Type.forall (loc t) (TypeVar.Universal v)
+        (ABT.substInheritAnnotation tv (universal' () v) t)
+   -- don't bother introducing a forall if type variable is unused
+    | otherwise = t
+
+existentialP :: Element v loc -> Maybe (TypeVar v loc, v)
+existentialP (Var (TypeVar.Existential _ v))
+  = Just (TypeVar.Existential B.Blank v, v)
+existentialP _ = Nothing
+
+variableP :: Element v loc -> Maybe (TypeVar v loc, v)
+variableP (Var (TypeVar.Existential _ v))
+  = Just (TypeVar.Existential B.Blank v, v)
+variableP (Var tv@(TypeVar.Universal v)) = Just (tv, v)
+variableP _ = Nothing
 
 -- This checks `e` against the type `t`, but if `t` is a `∀`, any ∀-quantified
 -- variables are freshened and substituted into `e`. This should be called whenever
 -- a term is being checked against a type due to a user-provided signature on `e`.
 -- See its usage in `synthesize` and `annotateLetRecBindings`.
-checkScoped :: forall v loc . (Var v, Ord loc) => Term v loc -> Type v loc -> M v loc ()
-checkScoped e t = case t of
-  Type.Forall' body -> do -- ForallI
-    v <- ABT.freshen body freshenTypeVar
-    markThenRetract0 v $ do
-      x <- extendUniversal v
-      let e' = Term.substTypeVar (ABT.variable body) (universal' () x) e
-      checkScoped e' (ABT.bindInheritAnnotation body (universal' () x))
-  _ -> check e t
+checkScoped
+  :: forall v loc
+   . (Var v, Ord loc)
+  => Term v loc -> Type v loc -> M v loc (Type v loc)
+checkScoped e (Type.Forall' body) = do
+  v <- ABT.freshen body freshenTypeVar
+  (ty, pop) <- markThenRetract v $ do
+    x <- extendUniversal v
+    let e' = Term.substTypeVar (ABT.variable body) (universal' () x) e
+    checkScoped e' (ABT.bindInheritAnnotation body (universal' () x))
+  pure $ generalizeP variableP pop ty
+checkScoped e t = do
+  t <- existentializeArrows t
+  t <$ check e t
 
 -- | Check that under the given context, `e` has type `t`,
 -- updating the context in the process.

--- a/unison-core/src/Unison/Type.hs
+++ b/unison-core/src/Unison/Type.hs
@@ -463,6 +463,15 @@ existentializeArrows freshVar = ABT.visit go
       pure $ arrow ann a (effect ann [var ann e] b)
   go _ = Nothing
 
+purifyArrows :: (Ord v) => Type v a -> Type v a
+purifyArrows = ABT.visitPure go
+  where
+  go t@(Arrow' a b) = case b of
+    Effect1' _ _ -> Nothing
+    _ -> Just $ arrow ann a (effect ann [] b)
+    where ann = ABT.annotation t
+  go _ = Nothing
+
 -- Remove free effect variables from the type that are in the set
 removeEffectVars :: ABT.Var v => Set v -> Type v a -> Type v a
 removeEffectVars removals t =

--- a/unison-src/transcripts/fix1696.output.md
+++ b/unison-src/transcripts/fix1696.output.md
@@ -19,7 +19,7 @@ dialog = Ask.provide 'zoot '("Awesome number: " ++ Nat.toText Ask.ask ++ "!")
 
 ```ucm
 
-  The expression in red  needs these abilities: {Zoot, 𝕖45}, but this location does not have access to any abilities.
+  The expression in red  needs these abilities: {Zoot, 𝕖46}, but this location does not have access to any abilities.
   
      13 | dialog = Ask.provide 'zoot '("Awesome number: " ++ Nat.toText Ask.ask ++ "!")
   


### PR DESCRIPTION
This PR contains some code to improve the behavior of unification and inference of abilities.

The first fix avoids making up unification variables on arrows for data constructors and requests. Unrelated variables were made up at every use site for these, leading to unsoundness.

Fixes #1457
Fixes #1184 

The second fix delays making up unification variables on a type annotation until the outermost universal variables have been peeled off, so that the effects can be unified to types involving the universal variables. This isn't a complete fix for all cases, but it should handle simple signatures that people commonly write.

Fixes #1500 