### PR TITLE
Fix a potential loop during type checking

### DIFF
--- a/unison-src/tests/fix1695.u
+++ b/unison-src/tests/fix1695.u
@@ -1,0 +1,7 @@
+
+ability G a where
+  get : a
+
+f x y =
+  g = G.get
+  g x


### PR DESCRIPTION
- `instantiateR` assumes that it will never be called in a situation
  that would create a cyclic type. However, `abilityCheck'` was doing
  so in some situations. Instead, move immediately to a fall-back
  behavior in such scenarios.

Fixes #1695