### PR TITLE
Implement crypto.hash and crypto.hmac

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/ANF.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF.hs
@@ -52,6 +52,7 @@ module Unison.Runtime.ANF
   , GroupRef(..)
   , Value(..)
   , Cont(..)
+  , BLit(..)
   , packTags
   , unpackTags
   , ANFM
@@ -80,7 +81,7 @@ import Data.Functor.Compose (Compose(..))
 import Data.List hiding (and,or)
 import Prelude hiding (abs,and,or,seq)
 import qualified Prelude
-import Unison.Term hiding (resolve, fresh, float)
+import Unison.Term hiding (resolve, fresh, float, Text, Ref)
 import Unison.Var (Var, typed)
 import Unison.Util.EnumContainers as EC
 import qualified Data.Map as Map
@@ -96,7 +97,7 @@ import Unison.Typechecker.Components (minimize')
 import Unison.Pattern (SeqOp(..))
 import qualified Unison.Pattern as P
 import Unison.Reference (Reference(..))
-import Unison.Referent (Referent)
+import Unison.Referent (Referent, pattern Ref, pattern Con)
 
 newtype ANF v a = ANF_ { term :: Term v a }
 
@@ -887,11 +888,18 @@ data Value
   = Partial GroupRef [Word64] [Value]
   | Data Reference Word64 [Word64] [Value]
   | Cont [Word64] [Value] Cont
+  | BLit BLit
 
 data Cont
   = KE
   | Mark [Reference] (Map Reference Value) Cont
   | Push Word64 Word64 Word64 Word64 GroupRef Cont
+
+data BLit
+  = Text Text
+  | List (Seq Value)
+  | TmLink Referent
+  | TyLink Reference
 
 groupVars :: ANFM v (Set v)
 groupVars = ask
@@ -1246,6 +1254,7 @@ valueLinks f (Data dr _ _ bs)
   = f True dr <> foldMap (valueLinks f) bs
 valueLinks f (Cont _ bs k)
   = foldMap (valueLinks f) bs <> contLinks f k
+valueLinks f (BLit l) = litLinks f l
 
 contLinks :: Monoid a => (Bool -> Reference -> a) -> Cont -> a
 contLinks f (Push _ _ _ _ (GR cr _ _) k)
@@ -1255,6 +1264,13 @@ contLinks f (Mark ps de k)
   <> Map.foldMapWithKey (\k c -> f True k <> valueLinks f c) de
   <> contLinks f k
 contLinks _ KE = mempty
+
+litLinks :: Monoid a => (Bool -> Reference -> a) -> BLit -> a
+litLinks _ (Text _) = mempty
+litLinks f (List s) = foldMap (valueLinks f) s
+litLinks f (TmLink (Ref r)) = f False r
+litLinks f (TmLink (Con r _ _)) = f True r
+litLinks f (TyLink r) = f True r
 
 groupTermLinks :: SuperGroup v -> [Reference]
 groupTermLinks = Set.toList . groupLinks f

--- a/parser-typechecker/src/Unison/Runtime/ANF/Serialize.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF/Serialize.hs
@@ -13,9 +13,11 @@ import Data.ByteString (ByteString)
 import Data.Foldable (traverse_)
 import Data.Functor ((<&>))
 import Data.Map as Map (Map, fromList, lookup)
+import Data.Serialize.Put (runPutLazy)
 import Data.Word (Word8, Word16, Word64)
 
 import qualified Data.Sequence as Seq
+import qualified Data.ByteString.Lazy as L
 
 import GHC.Stack
 
@@ -594,3 +596,7 @@ serializeValue :: Value -> ByteString
 serializeValue v = runPutS (putVersion *> putValue v)
   where
   putVersion = putWord32be 1
+
+serializeValueLazy :: Value -> L.ByteString
+serializeValueLazy v = runPutLazy (putVersion *> putValue v)
+  where putVersion = putWord32be 1

--- a/unison-src/new-runtime-transcripts/hashing.md
+++ b/unison-src/new-runtime-transcripts/hashing.md
@@ -74,9 +74,17 @@ ex3 = fromHex "50d3ab"
         |> crypto.hmacBytes Sha2_256 mysecret
         |> hex
 
+f x = x
+
+ex4 = crypto.hash Sha2_256 f |> hex
+
+ex5 = crypto.hmac Sha2_256 mysecret f |> hex
+
 > ex1
 > ex2
 > ex3
+> ex4
+> ex5
 ```
 
 And here's the full API:

--- a/unison-src/new-runtime-transcripts/hashing.output.md
+++ b/unison-src/new-runtime-transcripts/hashing.output.md
@@ -91,9 +91,17 @@ ex3 = fromHex "50d3ab"
         |> crypto.hmacBytes Sha2_256 mysecret
         |> hex
 
+f x = x
+
+ex4 = crypto.hash Sha2_256 f |> hex
+
+ex5 = crypto.hmac Sha2_256 mysecret f |> hex
+
 > ex1
 > ex2
 > ex3
+> ex4
+> ex5
 ```
 
 ```ucm
@@ -107,22 +115,33 @@ ex3 = fromHex "50d3ab"
       ex1      : Text
       ex2      : Text
       ex3      : Text
+      ex4      : Text
+      ex5      : Text
+      f        : x -> x
       mysecret : Bytes
   
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.
 
-    16 | > ex1
+    22 | > ex1
            ⧩
            "f3c342040674c50ab45cb1874b6dbc81447af5958201ed4127e03b56725664d7cc44b88b9afadb371898fcaf5d0adeff60837ef93b514f99da43539d79820c99"
   
-    17 | > ex2
+    23 | > ex2
            ⧩
            "84bb437497f26fc33c51e57e64c37958c3918d50dfe75b91c661a85c2f8f8304"
   
-    18 | > ex3
+    24 | > ex3
            ⧩
            "c692fc54df921f7fa51aad9178327c5a097784b02212d571fb40facdfff881fd"
+  
+    25 | > ex4
+           ⧩
+           "30eb272078faa05fec07601353cb007c90977778965bb31d0c097c7191deb22f"
+  
+    26 | > ex5
+           ⧩
+           "978e69198db0ff7b2b17a976a681eceae26d5ed5642f96987b5ee7b10ca01274"
 
 ```
 And here's the full API:


### PR DESCRIPTION
This uses the serialization operation to get a bytes suitable for hashing from an arbitrary value. The implementations are otherwise quite similar to `hashBytes` and `hmacBytes`. The serialization is done to a lazy byte string so that cases where the value is large can be chunked.

Serialization for some missing builtin 'foreign' values has been implemented (text, lists, ...), since otherwise they wouldn't be hashable.

Examples have been added to the transcripts. I only added one call to each, since they're entirely uniform except for the output of the serialization, which can be tested separately. There's also no standard list of reference tests for unison values like there is for the raw bytes.