### PR TITLE
Implement STM builtins

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -590,6 +590,7 @@ stmBuiltins =
   , ("TVar.read", forall1 "a" $ \a -> tvar a --> stm a)
   , ("TVar.readIO", forall1 "a" $ \a -> tvar a --> io a)
   , ("TVar.write", forall1 "a" $ \a -> tvar a --> a --> stm unit)
+  , ("TVar.swap", forall1 "a" $ \a -> tvar a --> a --> stm a)
   , ("STM.retry", forall1 "a" $ \a -> unit --> stm a)
   , ("STM.atomically", forall1 "a" $ \a -> (unit --> stm a) --> io a)
   ]

--- a/parser-typechecker/src/Unison/Runtime/ANF.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF.hs
@@ -839,6 +839,8 @@ data POp
   | VALU                      -- value
   -- Debug
   | PRNT | INFO
+  -- STM
+  | ATOM
   deriving (Show,Eq,Ord)
 
 type ANormal = ABTN.Term ANormalF

--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -1454,6 +1454,9 @@ declareForeigns = do
   declareForeign "TVar.readIO" boxDirect . mkForeign
     $ \(v :: STM.TVar Closure) -> STM.readTVarIO v
 
+  declareForeign "TVar.swap" boxBoxDirect . mkForeign
+    $ \(v, c :: Closure) -> unsafeSTMToIO $ STM.swapTVar v c
+
   declareForeign "STM.retry" unitDirect . mkForeign
     $ \() -> unsafeSTMToIO STM.retry :: IO Closure
 

--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -1253,7 +1253,7 @@ builtinLookup
 
   , ("jumpCont", jumpk)
 
-  , ("IO.forkComp", fork'comp)
+  , ("IO.forkComp.v2", fork'comp)
 
   , ("Code.isMissing", code'missing)
   , ("Code.cache_", code'cache)

--- a/parser-typechecker/src/Unison/Runtime/Foreign/Function.hs
+++ b/parser-typechecker/src/Unison/Runtime/Foreign/Function.hs
@@ -15,6 +15,7 @@ import GHC.IO.Exception (IOException(..), IOErrorType(..))
 
 import Control.Concurrent (ThreadId)
 import Control.Concurrent.MVar (MVar)
+import Control.Concurrent.STM (TVar)
 import Data.Foldable (toList)
 import Data.Text (Text, pack, unpack)
 import Data.Time.Clock.POSIX (POSIXTime)
@@ -25,7 +26,7 @@ import System.IO (BufferMode(..), SeekMode, Handle, IOMode)
 import Unison.Util.Bytes (Bytes)
 
 import Unison.Reference (Reference)
-import Unison.Type (mvarRef, typeLinkRef)
+import Unison.Type (mvarRef, tvarRef, typeLinkRef)
 import Unison.Symbol (Symbol)
 
 import Unison.Runtime.ANF (SuperGroup, Mem(..), Value)
@@ -319,6 +320,10 @@ instance ForeignConvention [Foreign] where
 instance ForeignConvention (MVar Closure) where
   readForeign = readForeignAs (unwrapForeign . marshalToForeign)
   writeForeign = writeForeignAs (Foreign . Wrap mvarRef)
+
+instance ForeignConvention (TVar Closure) where
+  readForeign = readForeignAs (unwrapForeign . marshalToForeign)
+  writeForeign = writeForeignAs (Foreign . Wrap tvarRef)
 
 instance ForeignConvention (SuperGroup Symbol) where
   readForeign = readForeignBuiltin

--- a/parser-typechecker/src/Unison/Runtime/MCode.hs
+++ b/parser-typechecker/src/Unison/Runtime/MCode.hs
@@ -417,7 +417,13 @@ data Instr
   -- Put a delimiter on the continuation
   | Reset !(EnumSet Word64) -- prompt ids
 
+  -- Fork thread evaluating delayed computation on boxed stack
   | Fork !Int
+
+  -- Atomic transaction evaluating delayed computation on boxed stack
+  | Atomically !Int
+
+  -- Build a sequence consisting of a variable number of arguments
   | Seq !Args
   deriving (Show, Eq, Ord)
 
@@ -1059,6 +1065,9 @@ emitPOp ANF.BLDS = Seq
 emitPOp ANF.FORK = \case
   BArg1 i -> Fork i
   _ -> error "fork takes exactly one boxed argument"
+emitPOp ANF.ATOM = \case
+  BArg1 i -> Atomically i
+  _ -> error "atomically takes exactly one boxed argument"
 emitPOp ANF.PRNT = \case
   BArg1 i -> Print i
   _ -> error "print takes exactly one boxed argument"

--- a/parser-typechecker/src/Unison/Runtime/Machine.hs
+++ b/parser-typechecker/src/Unison/Runtime/Machine.hs
@@ -306,8 +306,9 @@ exec !env !denv !ustk !bstk !k (Fork i) = do
   poke bstk . Foreign . Wrap Rf.threadIdReference $ tid
   pure (denv, ustk, bstk, k)
 exec !env !denv !ustk !bstk !k (Atomically i) = do
+  c <- peekOff bstk i
   bstk <- bump bstk
-  atomicEval env (poke bstk) =<< peekOff bstk i
+  atomicEval env (poke bstk) c
   pure (denv, ustk, bstk, k)
 {-# inline exec #-}
 

--- a/parser-typechecker/src/Unison/Runtime/Machine.hs
+++ b/parser-typechecker/src/Unison/Runtime/Machine.hs
@@ -10,6 +10,7 @@ module Unison.Runtime.Machine where
 import GHC.Stack
 
 import Control.Concurrent.STM as STM
+import GHC.Conc as STM (unsafeIOToSTM)
 
 import Data.Maybe (fromMaybe)
 
@@ -304,6 +305,10 @@ exec !env !denv !ustk !bstk !k (Fork i) = do
   bstk <- bump bstk
   poke bstk . Foreign . Wrap Rf.threadIdReference $ tid
   pure (denv, ustk, bstk, k)
+exec !env !denv !ustk !bstk !k (Atomically i) = do
+  bstk <- bump bstk
+  atomicEval env (poke bstk) =<< peekOff bstk i
+  pure (denv, ustk, bstk, k)
 {-# inline exec #-}
 
 eval :: CCache -> DEnv
@@ -355,6 +360,14 @@ forkEval env clo
     DataB1 _ 0 e -> throwIO $ BU e
     _ -> pure ()
 {-# inline forkEval #-}
+
+atomicEval :: CCache -> (Closure -> IO ()) -> Closure -> IO ()
+atomicEval env write clo
+  = atomically . unsafeIOToSTM $ apply1 readBack env clo
+  where
+  readBack :: Stack 'UN -> Stack 'BX -> IO ()
+  readBack _ bstk = peek bstk >>= write
+{-# inline atomicEval #-}
 
 -- fast path application
 enter

--- a/unison-core/src/Unison/Type.hs
+++ b/unison-core/src/Unison/Type.hs
@@ -227,11 +227,15 @@ filePathRef = Reference.Builtin "FilePath"
 threadIdRef = Reference.Builtin "ThreadId"
 socketRef = Reference.Builtin "Socket"
 
-mvarRef :: Reference
+mvarRef, tvarRef :: Reference
 mvarRef = Reference.Builtin "MVar"
+tvarRef = Reference.Builtin "TVar"
 
 tlsRef :: Reference
 tlsRef = Reference.Builtin "Tls"
+
+stmRef :: Reference
+stmRef = Reference.Builtin "STM"
 
 tlsClientConfigRef :: Reference
 tlsClientConfigRef = Reference.Builtin "Tls.ClientConfig"

--- a/unison-src/new-runtime-transcripts/stm.md
+++ b/unison-src/new-runtime-transcripts/stm.md
@@ -1,0 +1,103 @@
+
+```ucm
+.> builtins.merge
+```
+
+Standard helpful definitions
+
+```unison
+use io2
+
+stdout : Handle
+stdout = stdHandle StdOut
+
+putLn : Text ->{IO} ()
+putLn t =
+  putBytes stdout (toUtf8 (t ++ "\n"))
+  ()
+
+map : (a ->{e} b) -> [a] ->{e} [b]
+map f l = let
+  go acc = cases
+    [] -> acc
+    x +: xs -> go (acc :+ f x) xs
+  go [] l
+```
+
+```ucm
+.> add
+```
+
+Loops that access a shared counter variable, accessed in transactions.
+Some thread delaying is just accomplished by counting in a loop.
+```unison
+use io2
+
+count : Nat -> ()
+count = cases
+  0 -> ()
+  n -> count (drop n 1)
+
+inc : TVar Nat ->{IO} Nat
+inc v =
+  atomically 'let
+    x = TVar.read v
+    TVar.write v (x+1)
+    x
+
+loop : '{IO} Nat -> Nat -> Nat ->{IO} Nat
+loop grab acc = cases
+  0 -> acc
+  n ->
+    m = !grab
+    count (m*10)
+    loop grab (acc+m) (drop n 1)
+
+body : Nat -> TVar (Optional Nat) -> TVar Nat ->{IO} ()
+body k out v =
+  n = loop '(inc v) 0 k
+  atomically '(TVar.write out (Some n))
+```
+
+```ucm
+.> add
+```
+
+Test case.
+
+```unison
+spawn : Nat ->{IO} Result
+spawn k = let
+  out1 = TVar.newIO None
+  out2 = TVar.newIO None
+  counter = TVar.newIO 0
+  forkComp '(Right (body k out1 counter))
+  forkComp '(Right (body k out2 counter))
+  p = atomically 'let
+    r1 = TVar.read out1
+    r2 = TVar.read out2
+    match (r1, r2) with
+      (Some m, Some n) -> (m, n)
+      _ -> !STM.retry
+  match p with (m, n) ->
+    sum : Nat
+    sum = k * drop (2*k) 1
+    if m+n == sum
+    then Ok "verified"
+    else Fail (display m n sum)
+
+display : Nat -> Nat -> Nat -> Text
+display m n s =
+  "mismatch: " ++ toText m ++ " + " ++ toText n ++ " /= " ++ toText s
+
+nats : [Nat]
+nats = [89,100,116,144,169,188,200,233,256,300]
+
+tests : '{IO} [Result]
+tests = '(map spawn nats)
+```
+
+```ucm
+.> add
+.> io.test tests
+```

--- a/unison-src/new-runtime-transcripts/stm.md
+++ b/unison-src/new-runtime-transcripts/stm.md
@@ -70,18 +70,19 @@ spawn : Nat ->{IO} Result
 spawn k = let
   out1 = TVar.newIO None
   out2 = TVar.newIO None
-  counter = TVar.newIO 0
+  counter = atomically '(TVar.new 0)
   forkComp '(Right (body k out1 counter))
   forkComp '(Right (body k out2 counter))
   p = atomically 'let
     r1 = TVar.read out1
-    r2 = TVar.read out2
+    r2 = TVar.swap out2 None
     match (r1, r2) with
       (Some m, Some n) -> (m, n)
       _ -> !STM.retry
+  max = TVar.readIO counter
   match p with (m, n) ->
     sum : Nat
-    sum = k * drop (2*k) 1
+    sum = max * drop max 1 / 2
     if m+n == sum
     then Ok "verified"
     else Fail (display m n sum)

--- a/unison-src/new-runtime-transcripts/stm.output.md
+++ b/unison-src/new-runtime-transcripts/stm.output.md
@@ -1,0 +1,185 @@
+
+```ucm
+.> builtins.merge
+
+  Done.
+
+```
+Standard helpful definitions
+
+```unison
+use io2
+
+stdout : Handle
+stdout = stdHandle StdOut
+
+putLn : Text ->{IO} ()
+putLn t =
+  putBytes stdout (toUtf8 (t ++ "\n"))
+  ()
+
+map : (a ->{e} b) -> [a] ->{e} [b]
+map f l = let
+  go acc = cases
+    [] -> acc
+    x +: xs -> go (acc :+ f x) xs
+  go [] l
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      map    : (a ->{e} b) -> [a] ->{e} [b]
+      putLn  : Text ->{IO} ()
+      stdout : Handle
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    map    : (a ->{e} b) -> [a] ->{e} [b]
+    putLn  : Text ->{IO} ()
+    stdout : Handle
+
+```
+Loops that access a shared counter variable, accessed in transactions.
+Some thread delaying is just accomplished by counting in a loop.
+```unison
+use io2
+
+count : Nat -> ()
+count = cases
+  0 -> ()
+  n -> count (drop n 1)
+
+inc : TVar Nat ->{IO} Nat
+inc v =
+  atomically 'let
+    x = TVar.read v
+    TVar.write v (x+1)
+    x
+
+loop : '{IO} Nat -> Nat -> Nat ->{IO} Nat
+loop grab acc = cases
+  0 -> acc
+  n ->
+    m = !grab
+    count (m*10)
+    loop grab (acc+m) (drop n 1)
+
+body : Nat -> TVar (Optional Nat) -> TVar Nat ->{IO} ()
+body k out v =
+  n = loop '(inc v) 0 k
+  atomically '(TVar.write out (Some n))
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      body  : Nat -> TVar (Optional Nat) -> TVar Nat ->{IO} ()
+      count : Nat -> ()
+      inc   : TVar Nat ->{IO} Nat
+      loop  : '{IO} Nat ->{IO} Nat ->{IO} Nat ->{IO} Nat
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    body  : Nat -> TVar (Optional Nat) -> TVar Nat ->{IO} ()
+    count : Nat -> ()
+    inc   : TVar Nat ->{IO} Nat
+    loop  : '{IO} Nat ->{IO} Nat ->{IO} Nat ->{IO} Nat
+
+```
+Test case.
+
+```unison
+spawn : Nat ->{IO} Result
+spawn k = let
+  out1 = TVar.newIO None
+  out2 = TVar.newIO None
+  counter = TVar.newIO 0
+  forkComp '(Right (body k out1 counter))
+  forkComp '(Right (body k out2 counter))
+  p = atomically 'let
+    r1 = TVar.read out1
+    r2 = TVar.read out2
+    match (r1, r2) with
+      (Some m, Some n) -> (m, n)
+      _ -> !STM.retry
+  match p with (m, n) ->
+    sum : Nat
+    sum = k * drop (2*k) 1
+    if m+n == sum
+    then Ok "verified"
+    else Fail (display m n sum)
+
+display : Nat -> Nat -> Nat -> Text
+display m n s =
+  "mismatch: " ++ toText m ++ " + " ++ toText n ++ " /= " ++ toText s
+
+nats : [Nat]
+nats = [89,100,116,144,169,188,200,233,256,300]
+
+tests : '{IO} [Result]
+tests = '(map spawn nats)
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      display : Nat -> Nat -> Nat -> Text
+      nats    : [Nat]
+      spawn   : Nat ->{IO} Result
+      tests   : '{IO} [Result]
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    display : Nat -> Nat -> Nat -> Text
+    nats    : [Nat]
+    spawn   : Nat ->{IO} Result
+    tests   : '{IO} [Result]
+
+.> io.test tests
+
+    New test results:
+  
+  ◉ tests   verified
+  ◉ tests   verified
+  ◉ tests   verified
+  ◉ tests   verified
+  ◉ tests   verified
+  ◉ tests   verified
+  ◉ tests   verified
+  ◉ tests   verified
+  ◉ tests   verified
+  ◉ tests   verified
+  
+  ✅ 10 test(s) passing
+  
+  Tip: Use view tests to view the source of a test.
+
+```

--- a/unison-src/transcripts/alias-many.output.md
+++ b/unison-src/transcripts/alias-many.output.md
@@ -327,35 +327,45 @@ Let's try it!
   280. io2.MVar.tryPut : MVar a -> a ->{IO} Boolean
   281. io2.MVar.tryRead : MVar a ->{IO} Optional a
   282. io2.MVar.tryTake : MVar a ->{IO} Optional a
-  283. unique type io2.SeekMode
-  284. io2.SeekMode.AbsoluteSeek : SeekMode
-  285. io2.SeekMode.RelativeSeek : SeekMode
-  286. io2.SeekMode.SeekFromEnd : SeekMode
-  287. builtin type io2.Socket
-  288. unique type io2.StdHandle
-  289. io2.StdHandle.StdErr : StdHandle
-  290. io2.StdHandle.StdIn : StdHandle
-  291. io2.StdHandle.StdOut : StdHandle
-  292. builtin type io2.ThreadId
-  293. builtin type io2.Tls
-  294. builtin type io2.Tls.ClientConfig
-  295. io2.Tls.Config.defaultClient : Text
+  283. builtin type io2.STM
+  284. io2.STM.atomically : '{STM} a ->{IO} a
+  285. io2.STM.retry : '{STM} a
+  286. unique type io2.SeekMode
+  287. io2.SeekMode.AbsoluteSeek : SeekMode
+  288. io2.SeekMode.RelativeSeek : SeekMode
+  289. io2.SeekMode.SeekFromEnd : SeekMode
+  290. builtin type io2.Socket
+  291. unique type io2.StdHandle
+  292. io2.StdHandle.StdErr : StdHandle
+  293. io2.StdHandle.StdIn : StdHandle
+  294. io2.StdHandle.StdOut : StdHandle
+  295. builtin type io2.TVar
+  296. io2.TVar.new : a ->{STM} TVar a
+  297. io2.TVar.newIO : a ->{IO} TVar a
+  298. io2.TVar.read : TVar a ->{STM} a
+  299. io2.TVar.readIO : TVar a ->{IO} a
+  300. io2.TVar.swap : TVar a -> a ->{STM} a
+  301. io2.TVar.write : TVar a -> a ->{STM} ()
+  302. builtin type io2.ThreadId
+  303. builtin type io2.Tls
+  304. builtin type io2.Tls.ClientConfig
+  305. io2.Tls.Config.defaultClient : Text
                                       -> Bytes
                                       -> ClientConfig
-  296. io2.Tls.Config.defaultServer : ServerConfig
-  297. builtin type io2.Tls.ServerConfig
-  298. io2.Tls.handshake : Tls ->{IO} Either Failure ()
-  299. io2.Tls.newClient : ClientConfig
+  306. io2.Tls.Config.defaultServer : ServerConfig
+  307. builtin type io2.Tls.ServerConfig
+  308. io2.Tls.handshake : Tls ->{IO} Either Failure ()
+  309. io2.Tls.newClient : ClientConfig
                            -> Socket
                            ->{IO} Either Failure Tls
-  300. io2.Tls.newServer : ServerConfig
+  310. io2.Tls.newServer : ServerConfig
                            -> Socket
                            ->{IO} Either Failure Tls
-  301. io2.Tls.receive : Tls ->{IO} Either Failure Bytes
-  302. io2.Tls.send : Tls -> Bytes ->{IO} Either Failure ()
-  303. io2.Tls.terminate : Tls ->{IO} Either Failure ()
-  304. unique type io2.TlsFailure
-  305. todo : a -> b
+  311. io2.Tls.receive : Tls ->{IO} Either Failure Bytes
+  312. io2.Tls.send : Tls -> Bytes ->{IO} Either Failure ()
+  313. io2.Tls.terminate : Tls ->{IO} Either Failure ()
+  314. unique type io2.TlsFailure
+  315. todo : a -> b
   
 
 .builtin> alias.many 94-104 .mylib

--- a/unison-src/transcripts/builtins-merge.output.md
+++ b/unison-src/transcripts/builtins-merge.output.md
@@ -51,7 +51,7 @@ The `builtins.merge` command adds the known builtins to a `builtin` subnamespace
   40. Value/     (5 definitions)
   41. bug        (a -> b)
   42. crypto/    (12 definitions)
-  43. io2/       (92 definitions)
+  43. io2/       (102 definitions)
   44. todo       (a -> b)
 
 ```

--- a/unison-src/transcripts/emptyCodebase.output.md
+++ b/unison-src/transcripts/emptyCodebase.output.md
@@ -23,7 +23,7 @@ Technically, the definitions all exist, but they have no names. `builtins.merge`
 
 .foo> ls
 
-  1. builtin/ (305 definitions)
+  1. builtin/ (315 definitions)
 
 ```
 And for a limited time, you can get even more builtin goodies:
@@ -35,7 +35,7 @@ And for a limited time, you can get even more builtin goodies:
 
 .foo> ls
 
-  1. builtin/ (468 definitions)
+  1. builtin/ (478 definitions)
 
 ```
 More typically, you'd start out by pulling `base.

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -112,13 +112,13 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #aokhru3upu
+  ⊙ #jveabemtq1
   
     - Deletes:
     
       feature1.y
   
-  ⊙ #07lio3nger
+  ⊙ #7b9hnqhg1a
   
     + Adds / updates:
     
@@ -129,26 +129,26 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
       Original name New name(s)
       feature1.y    master.y
   
-  ⊙ #jh0ai3ctth
+  ⊙ #9uq6gq1qom
   
     + Adds / updates:
     
       feature1.y
   
-  ⊙ #srgjtgfm9a
+  ⊙ #ud99pde6kg
   
     > Moves:
     
       Original name New name
       x             master.x
   
-  ⊙ #p7j317tb68
+  ⊙ #p2oj9d11gn
   
     + Adds / updates:
     
       x
   
-  ⊙ #ce9gjk322r
+  ⊙ #68eq6ets4v
   
     + Adds / updates:
     
@@ -278,13 +278,18 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
       builtin.io2.MVar.read builtin.io2.MVar.swap
       builtin.io2.MVar.take builtin.io2.MVar.tryPut
       builtin.io2.MVar.tryRead builtin.io2.MVar.tryTake
-      builtin.io2.SeekMode builtin.io2.SeekMode.AbsoluteSeek
+      builtin.io2.STM builtin.io2.STM.atomically
+      builtin.io2.STM.retry builtin.io2.SeekMode
+      builtin.io2.SeekMode.AbsoluteSeek
       builtin.io2.SeekMode.RelativeSeek
       builtin.io2.SeekMode.SeekFromEnd builtin.io2.Socket
       builtin.io2.StdHandle builtin.io2.StdHandle.StdErr
       builtin.io2.StdHandle.StdIn builtin.io2.StdHandle.StdOut
-      builtin.io2.ThreadId builtin.io2.Tls
-      builtin.io2.Tls.ClientConfig
+      builtin.io2.TVar builtin.io2.TVar.new
+      builtin.io2.TVar.newIO builtin.io2.TVar.read
+      builtin.io2.TVar.readIO builtin.io2.TVar.swap
+      builtin.io2.TVar.write builtin.io2.ThreadId
+      builtin.io2.Tls builtin.io2.Tls.ClientConfig
       builtin.io2.Tls.Config.defaultClient
       builtin.io2.Tls.Config.defaultServer
       builtin.io2.Tls.ServerConfig builtin.io2.Tls.handshake

--- a/unison-src/transcripts/reflog.output.md
+++ b/unison-src/transcripts/reflog.output.md
@@ -59,16 +59,16 @@ y = 2
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #40kdvebdr6 .old`   to make an old namespace
+    `fork #vm5f8ujott .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #40kdvebdr6`  to reset the root namespace and
+    `reset-root #vm5f8ujott`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
-  1. #ootu4soq9i : add
-  2. #40kdvebdr6 : add
-  3. #ce9gjk322r : builtins.merge
+  1. #dho1pkd1h5 : add
+  2. #vm5f8ujott : add
+  3. #68eq6ets4v : builtins.merge
   4. #7asfbtqmoj : (initial reflogged namespace)
 
 ```

--- a/unison-src/transcripts/squash.output.md
+++ b/unison-src/transcripts/squash.output.md
@@ -13,7 +13,7 @@ Let's look at some examples. We'll start with a namespace with just the builtins
   
   
   
-  □ #m40j6qtka9 (start of history)
+  □ #iq200jf0rh (start of history)
 
 .> fork builtin builtin2
 
@@ -42,21 +42,21 @@ Now suppose we `fork` a copy of builtin, then rename `Nat.+` to `frobnicate`, th
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #mlkvjjn8bi
+  ⊙ #kiip85su26
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ #vo8lt4lm8m
+  ⊙ #8dp13blhfc
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ #m40j6qtka9 (start of history)
+  □ #iq200jf0rh (start of history)
 
 ```
 If we merge that back into `builtin`, we get that same chain of history:
@@ -71,21 +71,21 @@ If we merge that back into `builtin`, we get that same chain of history:
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #mlkvjjn8bi
+  ⊙ #kiip85su26
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ #vo8lt4lm8m
+  ⊙ #8dp13blhfc
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ #m40j6qtka9 (start of history)
+  □ #iq200jf0rh (start of history)
 
 ```
 Let's try again, but using a `merge.squash` (or just `squash`) instead. The history will be unchanged:
@@ -106,7 +106,7 @@ Let's try again, but using a `merge.squash` (or just `squash`) instead. The hist
   
   
   
-  □ #m40j6qtka9 (start of history)
+  □ #iq200jf0rh (start of history)
 
 ```
 The churn that happened in `mybuiltin` namespace ended up back in the same spot, so the squash merge of that namespace with our original namespace had no effect.


### PR DESCRIPTION
This merge adds `STM` and `TVar` stuff to the new runtime. The implementation is a pretty direct wrapping of GHC's API, and was more or less straight forward. Most operations are 'foreign' functions calling the GHC analogue while coercing the `STM` into `IO` if applicable. `atomically` is the only new primop, and is implemented by evaluating a closure with a temporary stack inside GHC's `atomically` implementation. This uses `unsafeIOToSTM` to do all the runtime operations necessary, but this should not be a problem as long as the unison code is well typed, because the only mutable state is local to the transaction.

There is a test transcript that should use all the operations currently implemented. I didn't try very hard to trigger transaction issues, but I think the implementation is sound.