### PR TITLE
Fix delete.term-replacement to support coinciding type and term names

### DIFF
--- a/unison-src/transcripts/deleteReplacements.md
+++ b/unison-src/transcripts/deleteReplacements.md
@@ -44,3 +44,22 @@ type Foo = Foo | Bar
 .> view.patch
 ```
 
+```unison
+bar = 3
+type bar = Foo
+```
+
+```ucm
+.> add
+```
+
+```unison
+type bar = Foo | Bar
+```
+
+```ucm
+.> update
+.> view.patch
+.> delete.type-replacement bar
+.> view.patch
+```

--- a/unison-src/transcripts/deleteReplacements.output.md
+++ b/unison-src/transcripts/deleteReplacements.output.md
@@ -130,3 +130,75 @@ type Foo = Foo | Bar
   This patch is empty.
 
 ```
+```unison
+bar = 3
+type bar = Foo
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      type bar
+      bar : ##Nat
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    type bar
+    bar : ##Nat
+
+```
+```unison
+type bar = Foo | Bar
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      type bar
+        (also named Foo)
+
+```
+```ucm
+.> update
+
+  ⍟ I've updated these names to your new definition:
+  
+    type bar
+      (also named Foo)
+
+.> view.patch
+
+  Edited Types: bar#568rsi7o3g -> Foo
+  
+  Tip: To remove entries from a patch, use
+       delete.term-replacement or delete.type-replacement, as
+       appropriate.
+
+.> delete.type-replacement bar
+
+  Done.
+
+.> view.patch
+
+  Edited Types: bar#568rsi7o3g -> Foo
+  
+  Tip: To remove entries from a patch, use
+       delete.term-replacement or delete.type-replacement, as
+       appropriate.
+
+```


### PR DESCRIPTION
## Overview

(hopefully) resolves #1804

## Implementation notes

Removes names from `hqNameQuery` misses in `doRemoveReplacement` when the relevant type or term exists in both.

## Interesting/controversial decisions

While the change implemented satisfies the new and existing transcripts, I'm not 100% confident that the behavior is what is desired and would welcome someone familiar with the issue to cast a critical eye over it.

## Test coverage

Extended existing `deleteReplacements.md` to include the transcript from #1804 

## Loose ends

n/a
