### PR TITLE
Fix delete.term-replacement to only check requested type/term exists

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -289,15 +289,15 @@ loop e = do
           doRemoveReplacement from patchPath isTerm = do
             let patchPath' = fromMaybe Cli.defaultPatchPath patchPath
             patch <- Cli.getPatchAt patchPath'
-            QueryResult misses' hits <- hqNameQuery [from]
-            let tpRefs = Set.fromList $ typeReferences hits
-                tmRefs = Set.fromList $ termReferences hits
-                misses =
-                  Set.difference
-                    (Set.fromList misses')
-                    if isTerm
-                      then Set.fromList $ SR.termName <$> termResults hits
-                      else Set.fromList $ SR.typeName <$> typeResults hits
+            QueryResult misses allHits <- hqNameQuery [from]
+            let tpRefs = Set.fromList $ typeReferences allHits
+                tmRefs = Set.fromList $ termReferences allHits
+                (hits, opHits) =
+                  let tmResults = Set.fromList $ SR.termName <$> termResults allHits
+                      tpResults = Set.fromList $ SR.typeName <$> typeResults allHits
+                   in case isTerm of
+                        True -> (tmResults, tpResults)
+                        False -> (tpResults, tmResults)
                 go :: Text -> Reference -> Cli r ()
                 go description fr = do
                   let termPatch = over Patch.termEdits (R.deleteDom fr) patch
@@ -314,8 +314,8 @@ loop e = do
                     )
                   -- Say something
                   Cli.respond Success
-            when (not (Set.null misses)) do
-              Cli.respond (SearchTermsNotFound (Set.toList misses))
+            when (Set.null hits) do
+              Cli.respond (SearchTermsNotFound' isTerm misses (Set.toList opHits))
             description <- inputDescription input
             traverse_ (go description) (if isTerm then tmRefs else tpRefs)
           saveAndApplyPatch :: Path -> NameSegment -> Patch -> Cli r ()

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -315,7 +315,7 @@ loop e = do
                   -- Say something
                   Cli.respond Success
             when (Set.null hits) do
-              Cli.respond (SearchTermsNotFound' isTerm misses (Set.toList opHits))
+              Cli.respond (SearchTermsNotFoundDetailed isTerm misses (Set.toList opHits))
             description <- inputDescription input
             traverse_ (go description) (if isTerm then tmRefs else tpRefs)
           saveAndApplyPatch :: Path -> NameSegment -> Patch -> Cli r ()

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -153,7 +153,17 @@ data Output
   | NoLastRunResult
   | SaveTermNameConflict Name
   | SearchTermsNotFound [HQ.HashQualified Name]
-  | SearchTermsNotFound' Bool [HQ.HashQualified Name] [HQ.HashQualified Name]
+  | -- Like 'SearchTermsNotFound' but additionally contains term hits
+    -- if we are searching for types or type hits if we are searching
+    -- for terms. This additional info is used to provide an enhanced
+    -- error message.
+    SearchTermsNotFoundDetailed
+      Bool
+      -- ^ @True@ if we are searching for a term, @False@ if we are searching for a type
+      [HQ.HashQualified Name]
+      -- ^ Misses (search terms that returned no hits for terms or types)
+      [HQ.HashQualified Name]
+      -- ^ Hits for types if we are searching for terms or terms if we are searching for types
   | -- ask confirmation before deleting the last branch that contains some defns
     -- `Path` is one of the paths the user has requested to delete, and is paired
     -- with whatever named definitions would not have any remaining names if
@@ -340,7 +350,7 @@ isFailure o = case o of
   TermNotFound' {} -> True
   TypeTermMismatch {} -> True
   SearchTermsNotFound ts -> not (null ts)
-  SearchTermsNotFound' _ misses otherHits -> not (null misses && null otherHits)
+  SearchTermsNotFoundDetailed _ misses otherHits -> not (null misses && null otherHits)
   DeleteBranchConfirmation {} -> False
   DeleteEverythingConfirmation -> False
   MoveRootBranchConfirmation -> False

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -153,6 +153,7 @@ data Output
   | NoLastRunResult
   | SaveTermNameConflict Name
   | SearchTermsNotFound [HQ.HashQualified Name]
+  | SearchTermsNotFound' Bool [HQ.HashQualified Name] [HQ.HashQualified Name]
   | -- ask confirmation before deleting the last branch that contains some defns
     -- `Path` is one of the paths the user has requested to delete, and is paired
     -- with whatever named definitions would not have any remaining names if
@@ -339,6 +340,7 @@ isFailure o = case o of
   TermNotFound' {} -> True
   TypeTermMismatch {} -> True
   SearchTermsNotFound ts -> not (null ts)
+  SearchTermsNotFound' _ misses otherHits -> not (null misses && null otherHits)
   DeleteBranchConfirmation {} -> False
   DeleteEverythingConfirmation -> False
   MoveRootBranchConfirmation -> False

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -745,7 +745,7 @@ notifyUser dir o = case o of
       P.warnCallout "The following names were not found in the codebase. Check your spelling."
         <> P.newline
         <> (P.syntaxToColor $ P.indent "  " (P.lines (prettyHashQualified <$> hqs)))
-  SearchTermsNotFound' wasTerm hqMisses otherHits ->
+  SearchTermsNotFoundDetailed wasTerm hqMisses otherHits ->
     pure (missMsg <> hitMsg)
     where
       typeOrTermMsg =

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -745,6 +745,25 @@ notifyUser dir o = case o of
       P.warnCallout "The following names were not found in the codebase. Check your spelling."
         <> P.newline
         <> (P.syntaxToColor $ P.indent "  " (P.lines (prettyHashQualified <$> hqs)))
+  SearchTermsNotFound' wasTerm hqMisses otherHits ->
+    pure (missMsg <> hitMsg)
+    where
+      typeOrTermMsg =
+        if wasTerm
+          then "I was expecting the following names to be terms, though I found types instead."
+          else "I was expecting the following names to be types, though I found terms instead."
+      missMsg = case null hqMisses of
+        True -> mempty
+        False ->
+          P.warnCallout "The following names were not found in the codebase. Check your spelling."
+            <> P.newline
+            <> P.syntaxToColor (P.indent "  " (P.lines (prettyHashQualified <$> hqMisses)))
+      hitMsg = case null otherHits of
+        True -> mempty
+        False ->
+          P.warnCallout typeOrTermMsg
+            <> P.newline
+            <> P.syntaxToColor (P.indent "  " (P.lines (prettyHashQualified <$> otherHits)))
   PatchNotFound _ ->
     pure . P.warnCallout $ "I don't know about that patch."
   NameNotFound _ ->

--- a/unison-src/transcripts/deleteReplacements.md
+++ b/unison-src/transcripts/deleteReplacements.md
@@ -63,3 +63,32 @@ unique[bb] type bar = Foo | Bar
 .> delete.type-replacement 1
 .> view.patch
 ```
+
+we get an error when attempting to delete something that is neither a type nor a term
+```ucm:error
+.> view.patch
+.> delete.type-replacement not-here
+.> view.patch
+```
+
+When attempting to delete a type/term that doesn't exist, but a term/type exists
+with that name, alert the user.
+```unison
+baz = 0
+```
+
+```ucm:error
+.> add baz
+.> delete.type-replacement baz
+.> view.patch
+```
+
+```unison
+unique type qux = Qux
+```
+
+```ucm:error
+.> add qux
+.> delete.term-replacement qux
+.> view.patch
+```

--- a/unison-src/transcripts/deleteReplacements.output.md
+++ b/unison-src/transcripts/deleteReplacements.output.md
@@ -196,3 +196,91 @@ unique[bb] type bar = Foo | Bar
   This patch is empty.
 
 ```
+we get an error when attempting to delete something that is neither a type nor a term
+```ucm
+.> view.patch
+
+  This patch is empty.
+
+.> delete.type-replacement not-here
+
+  ⚠️
+  
+  The following names were not found in the codebase. Check your spelling.
+    not-here
+
+.> view.patch
+
+  This patch is empty.
+
+```
+When attempting to delete a type/term that doesn't exist, but a term/type exists
+with that name, alert the user.
+```unison
+baz = 0
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      baz : ##Nat
+
+```
+```ucm
+.> add baz
+
+  ⍟ I've added these definitions:
+  
+    baz : ##Nat
+
+.> delete.type-replacement baz
+
+  ⚠️
+  
+  I was expecting the following names to be types, though I found terms instead.
+    .baz
+
+.> view.patch
+
+  This patch is empty.
+
+```
+```unison
+unique type qux = Qux
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique type qux
+
+```
+```ucm
+.> add qux
+
+  ⍟ I've added these definitions:
+  
+    unique type qux
+
+.> delete.term-replacement qux
+
+  ⚠️
+  
+  I was expecting the following names to be terms, though I found types instead.
+    .qux
+
+.> view.patch
+
+  This patch is empty.
+
+```


### PR DESCRIPTION
## Overview

Resolves #1804

Only checks that the requested type/term exists, then utilise misses and unrequested type/term for error messaging only.

## Implementation notes

This changes to only make use of the hits for the requested term/type, rather than previously checking for the absence of misses.

A new output message is also introduced that makes use of the misses and unrequested hits to report errors.

## Interesting/controversial decisions

n/a

## Test coverage

The existing test coverage is utilised.

From a comment by @dolio on Slack:
> * Try a delete for something that is neither a term nor a type. Should get a 'missing' error.
> * Try a delete for a term/type that is actually a type/term. That should give an error about finding the opposite thing.
> * Try a delete where there is a term and a type with the same name. That should no longer display an error.

It would be great to get some advice on how to get achieve and include this coverage, as it is currently lacking from this PR.

## Loose ends

See above note on test coverage.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/1810)
<!-- Reviewable:end -->
