### PR TITLE
provide more helpful error message when `run`ning an improperly-typed term

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -48,3 +48,4 @@ The format for this list: name, GitHub handle, and then optional blurb about wha
 * Jared Forsyth (@jaredly) - Documentation generation
 * Hakim Cassimally (@osfameron) - vim support
 * Will Badart (@wbadart)
+* Sam Roberts (@samgqroberts)

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -94,6 +94,8 @@ data Output v
   | SourceLoadFailed String
   -- No main function, the [Type v Ann] are the allowed types
   | NoMainFunction String PPE.PrettyPrintEnv [Type v Ann]
+  -- Main function found, but has improper type
+  | BadMainFunction String (Type v Ann) PPE.PrettyPrintEnv [Type v Ann]
   | BranchEmpty (Either ShortBranchHash Path')
   | BranchNotEmpty Path'
   | LoadPullRequest RemoteNamespace RemoteNamespace Path' Path' Path' Path'
@@ -262,6 +264,7 @@ isFailure o = case o of
   InvalidSourceName{} -> True
   SourceLoadFailed{} -> True
   NoMainFunction{} -> True
+  BadMainFunction{} -> True
   CreatedNewBranch{} -> False
   BranchAlreadyExists{} -> True
   PatchAlreadyExists{} -> True

--- a/parser-typechecker/src/Unison/Codebase/Execute.hs
+++ b/parser-typechecker/src/Unison/Codebase/Execute.hs
@@ -49,7 +49,7 @@ execute codebase runtime mainName =
     case mt of
       MainTerm.NotAFunctionName s -> die ("Not a function name: " ++ s)
       MainTerm.NotFound s -> die ("Not found: " ++ s)
-      MainTerm.BadType s -> die (s ++ " is not of type '{IO} ()")
+      MainTerm.BadType s _ -> die (s ++ " is not of type '{IO} ()")
       MainTerm.Success _ tm _ -> do
         let codeLookup = Codebase.toCodeLookup codebase
             ppe = PPE.PrettyPrintEnv (const Nothing) (const Nothing)

--- a/parser-typechecker/src/Unison/Codebase/MainTerm.hs
+++ b/parser-typechecker/src/Unison/Codebase/MainTerm.hs
@@ -27,7 +27,7 @@ import           Unison.Runtime.IOSource        ( ioReference )
 data MainTerm v
   = NotAFunctionName String
   | NotFound String
-  | BadType String
+  | BadType String (Maybe (Type v Ann))
   | Success HQ.HashQualified (Term v Ann) (Type v Ann)
 
 getMainTerm
@@ -49,10 +49,12 @@ getMainTerm loadTypeOfTerm parseNames0 mainName mainType =
           typ <- loadTypeOfTerm ref
           traceShowM typ
           case typ of
-            Just typ | Typechecker.isSubtype mainType typ -> do
-              let tm = DD.forceTerm a a (Term.ref a ref)
-              return (Success hq tm typ)
-            _ -> pure (BadType mainName)
+            Just typ ->
+              if Typechecker.isSubtype mainType typ then do
+                let tm = DD.forceTerm a a (Term.ref a ref)
+                return (Success hq tm typ)
+              else pure (BadType mainName $ Just typ)
+            _ -> pure (BadType mainName Nothing)
         _ -> pure (NotFound mainName)
 
 -- forall a. '{IO} a

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -410,6 +410,15 @@ notifyUser dir o = case o of
     "",
     P.indentN 2 $ P.lines [ P.string main <> " : " <> TypePrinter.pretty ppe t | t <- ts ]
     ]
+  BadMainFunction main ty ppe ts -> pure . P.callout "😶" $ P.lines [
+    P.string "I found this function:",
+    "",
+    P.indentN 2 $ P.string main <> " : " <> TypePrinter.pretty ppe ty,
+    "",
+    P.wrap $ P.string "but in order for me to" <> P.backticked (P.string "run") <> "it it needs to have the type:",
+    "",
+    P.indentN 2 $ P.lines [ P.string main <> " : " <> TypePrinter.pretty ppe t | t <- ts ]
+    ]
   NoUnisonFile -> do
     dir' <- canonicalizePath dir
     fileName <- renderFileName dir'

--- a/unison-src/transcripts/run.md
+++ b/unison-src/transcripts/run.md
@@ -1,0 +1,53 @@
+```ucm:hide
+.> builtins.merge
+.> builtins.mergeio
+```
+
+In a scratch file, we'll define two terms.
+- `runnable`: a properly typed term that can be `run`
+- `badtype`: an improperly typed term that cannot be `run`
+
+```unison scratch.u
+runnable = '(printLine "hello!")
+badtype = 'printLine "hello!"
+```
+
+We'll see when we `run` the `runnable` term, we get the successful "hello!" we expect:
+
+**There is a bug here! https://github.com/unisonweb/unison/issues/1800**
+(this should not error)
+
+```ucm:error
+.> run runnable
+```
+
+When we run the term with the bad type, we get an error message that lets us know that Unison found the term, but the type is not `run`able:
+
+```ucm:error
+.> run badtype
+```
+
+When we run a term that Unison cannot find at all, we get an error message that the term could not be found:
+
+```ucm:error
+.> run notfound
+```
+
+Now let's add these terms to the codebase and clear our scratchfile, to show that the behavior is consistent if the terms are found inside the codebase.
+
+```ucm
+.> add
+```
+
+```unison scratch.u
+```
+
+**(The bug again!)**
+
+```ucm:error
+.> run runnable
+```
+
+```ucm:error
+.> run badtype
+```

--- a/unison-src/transcripts/run.output.md
+++ b/unison-src/transcripts/run.output.md
@@ -1,0 +1,129 @@
+In a scratch file, we'll define two terms.
+- `runnable`: a properly typed term that can be `run`
+- `badtype`: an improperly typed term that cannot be `run`
+
+```unison
+---
+title: scratch.u
+---
+runnable = '(printLine "hello!")
+badtype = 'printLine "hello!"
+
+```
+
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      badtype  : Text ->{io.IO} ()
+      runnable : '{io.IO} ()
+
+```
+We'll see when we `run` the `runnable` term, we get the successful "hello!" we expect:
+
+**There is a bug here! https://github.com/unisonweb/unison/issues/1800**
+(this should not error)
+
+```ucm
+.> run runnable
+
+  😶
+  
+  I found this function:
+  
+    runnable : '{builtin.io.IO} ()
+  
+  but in order for me to `run` it it needs to have the type:
+  
+    runnable : '{builtin.io.IO} a
+
+```
+When we run the term with the bad type, we get an error message that lets us know that Unison found the term, but the type is not `run`able:
+
+```ucm
+.> run badtype
+
+  😶
+  
+  I found this function:
+  
+    badtype : builtin.Text ->{builtin.io.IO} ()
+  
+  but in order for me to `run` it it needs to have the type:
+  
+    badtype : '{builtin.io.IO} a
+
+```
+When we run a term that Unison cannot find at all, we get an error message that the term could not be found:
+
+```ucm
+.> run notfound
+
+  😶
+  
+  I looked for a function `notfound` in the most recently
+  typechecked file and codebase but couldn't find one. It has to
+  have the type:
+  
+    notfound : '{builtin.io.IO} a
+
+```
+Now let's add these terms to the codebase and clear our scratchfile, to show that the behavior is consistent if the terms are found inside the codebase.
+
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    badtype  : Text ->{io.IO} ()
+    runnable : '{io.IO} ()
+
+```
+```unison
+---
+title: scratch.u
+---
+
+```
+
+
+```ucm
+
+  I loaded scratch.u and didn't find anything.
+
+```
+**(The bug again!)**
+
+```ucm
+.> run runnable
+
+  😶
+  
+  I found this function:
+  
+    runnable : '{builtin.io.IO} ()
+  
+  but in order for me to `run` it it needs to have the type:
+  
+    runnable : '{builtin.io.IO} a
+
+```
+```ucm
+.> run badtype
+
+  😶
+  
+  I found this function:
+  
+    badtype : builtin.Text ->{builtin.io.IO} ()
+  
+  but in order for me to `run` it it needs to have the type:
+  
+    badtype : '{builtin.io.IO} a
+
+```


### PR DESCRIPTION
## Overview

Endeavoring to fix #1747 - see the output of the new transcript for what the new error message is and when it is shown.

## Implementation notes

Instead of `HandleInput.addRunMain` just returning a `Maybe` (I could do it, or I couldn't), it now returns a type that disambiguates whether it couldn't due to not being able to find the term, or whether the term has a bad type. That new case is subsequently handled in the error reporting module `OutputMessages.hs` to produce the new error message.

## Interesting/controversial decisions

## Test coverage

I've included a new transcript `run.md` that attempts to `run` properly-typed, improperly-typed, and nonexistent terms to show the differences in behavior / error messages.

## Loose ends

- **This PR is obfuscated by another bug** - you'll see me call this out in the new transcript. I believe I'm running into #1800, and I've confirmed that without my changes that `runnable` function still fails to be found. I wanted to put this PR up optimistically to gather feedback while that issue is resolved.
- I didn't update the error reporting in `Execute.hs` to provide this distinction (partly due to my lack of familiarity of what experience that file is part of..)

In general, this being my first contribution, I'm not confident at all that the changes I've provided are idiomatic / sufficient. I'd be more than happy to add tests, move code, rename types. Thank you!
