### PR TITLE
Fix a corner case in abilityCheck'

### DIFF
--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -1738,6 +1738,10 @@ abilityCheck' ambient0 requested0 = go ambient0 requested0 where
       Just amb -> do
         subtype amb r `orElse` die r
         go ambient rs
+      -- Corner case where a unification caused `r` to expand to a
+      -- list of effects. This whole function should be restructured
+      -- such that this can go in a better spot.
+      Nothing | Type.Effects' es <- r -> go ambient (es ++ rs)
       -- 2b. If no:
       Nothing -> case r of
         -- It's an unsolved existential, instantiate it to all of ambient

--- a/unison-src/tests/fix1779.u
+++ b/unison-src/tests/fix1779.u
@@ -1,0 +1,10 @@
+unique ability S a where
+  s : a
+
+unique type R g = R ('{g} ())
+
+run : '{S (R g), g} ()
+run _ = todo ()
+
+run' : '{S (R {})} ()
+run' = run


### PR DESCRIPTION
It was possible to write code that would unify a variable to e.g. `{}`, while `abilityCheck'` was written under the premise that the check runs on a completely flattened list. This code catches that corner case.

Fixes #1779 