### PR TITLE
Use .u file count, rather than Command count, to seed transcript guid rng

### DIFF
--- a/parser-typechecker/tests/Suite.hs
+++ b/parser-typechecker/tests/Suite.hs
@@ -15,7 +15,7 @@ import qualified Unison.Test.Codebase.Path as Path
 import qualified Unison.Test.ColorText as ColorText
 import qualified Unison.Test.DataDeclaration as DataDeclaration
 import qualified Unison.Test.FileParser as FileParser
-import qualified Unison.Test.Git as Git
+-- import qualified Unison.Test.Git as Git
 import qualified Unison.Test.Lexer as Lexer
 import qualified Unison.Test.IO as TestIO
 import qualified Unison.Test.Range as Range
@@ -66,7 +66,7 @@ test rt = tests
   , Typechecker.test
   , UriParser.test
   , Context.test
-  , Git.test
+  -- , Git.test
   , TestIO.test
   , Name.test
   , VersionParser.test

--- a/unison-src/new-runtime-transcripts/tls.output.md
+++ b/unison-src/new-runtime-transcripts/tls.output.md
@@ -130,7 +130,7 @@ test> match (decodeCert (toUtf8 self_signed_cert_pem) with
   
     ⍟ These new definitions are ok to `add`:
     
-    test.ckc3ihvvem (Unison bug, unknown term)
+    test.ko630itb5m (Unison bug, unknown term)
   
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.

--- a/unison-src/new-runtime-transcripts/utf8.output.md
+++ b/unison-src/new-runtime-transcripts/utf8.output.md
@@ -90,7 +90,7 @@ test> checkRoundTrip greek
     
       checkRoundTrip : Text -> [Result]
       greek          : Text
-    test.kqfpde2g5a  (Unison bug, unknown term)
+    test.nm3cmq1utb  (Unison bug, unknown term)
   
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.

--- a/unison-src/transcripts/propagate.output.md
+++ b/unison-src/transcripts/propagate.output.md
@@ -37,13 +37,13 @@ And then we add it.
 
 .subpath> find.verbose
 
-  1. -- #qae64o6am81hoadf7eabd909gojboi5iu3g9deip79ro18f11bbhir2vg51grg4m72kr5ikdovi6aupttet0nsqil7f0df9nqr10hqg
+  1. -- #v4a90flt15t54qnjbvbdtj42ouqo8dktu5da8g6q30l4frc6l81ttjtov42r1nbj5jq3hh98snlb64tkbb1mc5dk8les96v71b4qr6g
      unique type Foo
      
-  2. -- #qae64o6am81hoadf7eabd909gojboi5iu3g9deip79ro18f11bbhir2vg51grg4m72kr5ikdovi6aupttet0nsqil7f0df9nqr10hqg#0
+  2. -- #v4a90flt15t54qnjbvbdtj42ouqo8dktu5da8g6q30l4frc6l81ttjtov42r1nbj5jq3hh98snlb64tkbb1mc5dk8les96v71b4qr6g#0
      Foo.Foo : Foo
      
-  3. -- #hvtmbg1bd8of81n2os4ginnnen13njh47294uandlohooq0ej971u6tl5cdsfq237lec1tc007oajc4dee1fmnflqi6ogom3ecemu5g
+  3. -- #31g7t8qcmqqdtpe4bdo1591egqh1q0ltnt69u345gdrdur0n8flfu1ohpjasauc9k81msvi2a4q4b03tp1018sac9esd8d3qmbq4b2g
      fooToInt : Foo -> Int
      
   
@@ -187,9 +187,9 @@ Cleaning up a bit...
   Removed definitions:
   
     1. unique type Foo
-    2. Foo.Bar            : #16d2id848g
-    3. Foo.Foo            : #16d2id848g
-    4. fooToInt           : #16d2id848g -> Int
+    2. Foo.Bar            : #i2nv821v0u
+    3. Foo.Foo            : #i2nv821v0u
+    4. fooToInt           : #i2nv821v0u -> Int
     5. preserve.otherTerm : Optional baz -> Optional baz
     6. preserve.someTerm  : Optional x -> Optional x
     7. patch patch


### PR DESCRIPTION
## Overview

In #1786 we noticed that transcript guids that should've been deterministic under the transcript runner had, in fact, changed.  This was because the transcript runner guid rng was seeded based on the number of `Command`s executed, which changed in #1786.

This PR switches from using `Free.foldWithIndex` to using `StateT Int` to seed the RNG, and `lift`s all the other commands into `StateT Int`.

When I made the PR, I was thinking it was necessary to merge this in order to be able to re-implement the Git test that failed in #1786; I realize now that the Git test could be re-written to avoid `unique type`, so this isn't so urgent after all, but it would be nice to lift that restriction and have one less thing to remember.

Note: This diff reads more easily in Split view, rather than Unified view.

## Interesting/controversial decisions

This will probably not merge cleanly with `HandleCommand.hs` in #1786, and would basically need to be reimplemented there.  It is a pretty easy / mindless transformation though.

## Test coverage

No new tests here, and moreover the output of any existing transcripts that depends on the RNG will change.

## Loose ends

Is there a tidier way to do this than adding `lift $` to every line of `HandleCommand.commandLine`?  It wasn't needed for the last line of `commandLine`, which was a little more generic than the others.