### PR TITLE
Add -haddock flag to help haskell-language-server

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -36,3 +36,6 @@ extra-deps:
 ghc-options:
  # All packages
  "$locals": -Werror -Wno-type-defaults #-freverse-errors
+
+ # See https://github.com/haskell/haskell-language-server/issues/208
+ "$everything": -haddock


### PR DESCRIPTION
(See this issue: https://github.com/haskell/haskell-language-server/issues/208)

Adding -haddock gives doc-on-hover for 3rd party libraries like megaparsec.

I tested this on a big codebase (>20k SLOC) and compile times stayed the same.