### PR TITLE
Codebase server: indicate in namespace listing whether a term is a doc or a test, and if a type is an ability

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1156,10 +1156,10 @@ loop = do
               entryToHQString :: ShallowListEntry v Ann -> String
               entryToHQString e =
                 fixup $ case e of
-                  ShallowTypeEntry _ hq     -> HQ'.toString hq
-                  ShallowTermEntry _ hq _   -> HQ'.toString hq
-                  ShallowBranchEntry ns _ _ -> NameSegment.toString ns
-                  ShallowPatchEntry ns      -> NameSegment.toString ns
+                  ShallowTypeEntry _ hq _    -> HQ'.toString hq
+                  ShallowTermEntry _ hq _ _  -> HQ'.toString hq
+                  ShallowBranchEntry ns _ _  -> NameSegment.toString ns
+                  ShallowPatchEntry ns       -> NameSegment.toString ns
                where
                 fixup s = case pathArgStr of
                            "" -> s

--- a/parser-typechecker/src/Unison/Codebase/Metadata.hs
+++ b/parser-typechecker/src/Unison/Codebase/Metadata.hs
@@ -32,6 +32,9 @@ starToR4 = R4.fromList . fmap (\(r,n,_,(t,v)) -> (r,n,t,v)) . Star3.toList
 hasMetadata :: Ord a => a -> Type -> Value -> Star a n -> Bool
 hasMetadata a t v = Set.member (t, v) . R.lookupDom a . Star3.d3
 
+hasMetadataWithType :: Ord a => a -> Type -> Star a n -> Bool
+hasMetadataWithType a t = any (\(t', _) -> t' == t) . R.lookupDom a . Star3.d3
+
 inserts :: (Ord a, Ord n) => [(a, Type, Value)] -> Star a n -> Star a n
 inserts tups s = foldl' (flip insert) s tups
 

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -541,10 +541,10 @@ notifyUser dir o = case o of
       f (i, (p1, p2)) = (P.hiBlack . fromString $ show i <> ".", p1, p2)
     formatEntry :: ShallowListEntry v a -> (P.Pretty P.ColorText, P.Pretty P.ColorText)
     formatEntry = \case
-      ShallowTermEntry _r hq ot ->
+      ShallowTermEntry _r hq ot _ ->
         (P.syntaxToColor . prettyHashQualified' . fmap Name.fromSegment $ hq
         , P.lit "(" <> maybe "type missing" (TypePrinter.pretty ppe) ot <> P.lit ")" )
-      ShallowTypeEntry r hq ->
+      ShallowTypeEntry r hq _ ->
         (P.syntaxToColor . prettyHashQualified' . fmap Name.fromSegment $ hq
         ,isBuiltin r)
       ShallowBranchEntry ns _ count ->

--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -204,14 +204,17 @@ findShallowInBranch codebase b = do
       b0 = Branch.head b
   termEntries <- for (R.toList . Star3.d1 $ Branch._terms b0) $ \(r, ns) -> do
     ot <- lift $ loadReferentType codebase r
+    -- A term is a doc if its type conforms to the `Doc` type.
     let isDoc = case ot of
           Just t  -> Typechecker.isSubtype t $ Type.ref mempty Decls.docRef
           Nothing -> False
+        -- A term is a test if it has a link of type `IsTest`.
         isTest =
           Metadata.hasMetadataWithType r (Decls.isTestRef) $ Branch._terms b0
         tag = if isDoc then Just Doc else if isTest then Just Test else Nothing
     pure $ ShallowTermEntry r (hqTerm b0 ns r) ot tag
   typeEntries <- for (R.toList . Star3.d1 $ Branch._types b0) $ \(r, ns) -> do
+    -- The tag indicates whether the type is a data declaration or an ability.
     tag <- case Reference.toId r of
       Just r -> do
         decl <- lift $ Codebase.getTypeDeclaration codebase r

--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -179,7 +179,6 @@ findShallow codebase path' = do
   let mayb = Branch.getAt path root
   case mayb of
     Nothing -> pure []
-<<<<<<< HEAD
     Just b0 -> do
       let hqTerm b0 ns r =
             let refs = Star3.lookupD1 ns . Branch._terms $ b0

--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -5,7 +5,7 @@
 
 module Unison.Server.Backend where
 
-import           Control.Error.Util
+import           Control.Error.Util             ( (??) )
 import           Control.Monad.Except           ( ExceptT(..)
                                                 , throwError
                                                 )
@@ -15,12 +15,14 @@ import qualified Data.List                     as List
 import qualified Data.Map                      as Map
 import qualified Data.Set                      as Set
 import qualified Unison.Builtin                as B
+import qualified Unison.Builtin.Decls          as Decls
 import           Unison.Codebase                ( Codebase )
 import qualified Unison.Codebase               as Codebase
 import           Unison.Codebase.Branch         ( Branch )
 import qualified Unison.Codebase.Branch        as Branch
 import           Unison.Codebase.Path           ( Path )
 import           Unison.Codebase.Editor.DisplayObject
+import qualified Unison.Codebase.Metadata      as Metadata
 import qualified Unison.Codebase.Path          as Path
 import qualified Unison.DataDeclaration        as DD
 import qualified Unison.Server.SearchResult    as SR
@@ -51,6 +53,7 @@ import           Unison.Referent                ( Referent )
 import qualified Unison.Referent               as Referent
 import           Unison.Type                    ( Type )
 import qualified Unison.Type                   as Type
+import qualified Unison.Typechecker            as Typechecker
 import qualified Unison.Util.Relation          as R
 import qualified Unison.Util.Star3             as Star3
 import           Unison.Var                     ( Var )
@@ -71,9 +74,15 @@ import           Unison.Util.Pretty             ( Width )
 import qualified Data.Text                     as Text
 import qualified Unison.Server.Syntax          as Syntax
 
+data TermTag = Doc | Test
+  deriving (Eq, Ord, Show, Generic)
+
+data TypeTag = Ability | Data
+  deriving (Eq, Ord, Show, Generic)
+
 data ShallowListEntry v a
-  = ShallowTermEntry Referent HQ'.HQSegment (Maybe (Type v a))
-  | ShallowTypeEntry Reference HQ'.HQSegment
+  = ShallowTermEntry Referent HQ'.HQSegment (Maybe (Type v a)) (Maybe TermTag)
+  | ShallowTypeEntry Reference HQ'.HQSegment TypeTag
   -- The integer here represents the number of children
   | ShallowBranchEntry NameSegment ShortBranchHash Int
   | ShallowPatchEntry NameSegment
@@ -81,8 +90,8 @@ data ShallowListEntry v a
 
 listEntryName :: ShallowListEntry v a -> Text
 listEntryName = \case
-  ShallowTermEntry _ s _   -> HQ'.toText s
-  ShallowTypeEntry _ s     -> HQ'.toText s
+  ShallowTermEntry _ s _ _ -> HQ'.toText s
+  ShallowTypeEntry   _ s _ -> HQ'.toText s
   ShallowBranchEntry n _ _ -> NameSegment.toText n
   ShallowPatchEntry n      -> NameSegment.toText n
 
@@ -188,12 +197,26 @@ findShallow codebase path' = do
       termEntries <- for (R.toList . Star3.d1 $ Branch._terms b0) $ \(r, ns) ->
         do
           ot <- lift $ loadReferentType codebase r
-          pure $ ShallowTermEntry r (hqTerm b0 ns r) ot
+          let
+            isDoc = case ot of
+              Just t  -> Typechecker.isSubtype t $ Type.ref mempty Decls.docRef
+              Nothing -> False
+            isTest = Metadata.hasMetadataWithType r (Decls.isTestRef)
+              $ Branch._terms b0
+            tag =
+              if isDoc then Just Doc else if isTest then Just Test else Nothing
+          pure $ ShallowTermEntry r (hqTerm b0 ns r) ot tag
+      typeEntries <-
+          for (R.toList . Star3.d1 $ Branch._types b0) $ \(r, ns) -> do
+            tag <- case Reference.toId r of
+              Just r -> do
+                decl <- lift $ Codebase.getTypeDeclaration codebase r
+                pure $ case decl of
+                  Just (Left _) -> Ability
+                  _ -> Data
+              _ -> pure Data
+            pure $ ShallowTypeEntry r (hqType b0 ns r) tag
       let
-        typeEntries =
-          [ ShallowTypeEntry r (hqType b0 ns r)
-          | (r, ns) <- R.toList . Star3.d1 $ Branch._types b0
-          ]
         branchEntries =
           [ ShallowBranchEntry ns
                                (SBH.fullFromHash $ Branch.headHash b)


### PR DESCRIPTION
## Overview

This adds new fields `termTag` and `typeTag` on namespace objects in the `list` endpoint. The term tag is optional and can be either `Doc` or `Test`. The type tag is non-optional and is always either `Ability` or `Data`.

## Interesting/controversial decisions

This actually goes and retrieves the type declarations in order to determine if they're abilities or data types, so this is doing a lot more work now than it used to.

