### PR TITLE
minor update to `run.md` transcript

### DIFF
--- a/unison-src/transcripts/run.md
+++ b/unison-src/transcripts/run.md
@@ -8,16 +8,15 @@ In a scratch file, we'll define two terms.
 - `badtype`: an improperly typed term that cannot be `run`
 
 ```unison scratch.u
+runnable : '{builtin.io.IO} ()
 runnable = '(printLine "hello!")
+
+badtype : Text ->{builtin.io.IO} ()
 badtype = 'printLine "hello!"
 ```
 
-We'll see when we `run` the `runnable` term, we get the successful "hello!" we expect:
-
-**There is a bug here! https://github.com/unisonweb/unison/issues/1800**
-(this should not error)
-
-```ucm:error
+Since `runnable` is properly typed, Unison will successfully `run` it (the "hello" output does not show up in this transcript):
+```ucm
 .> run runnable
 ```
 
@@ -42,9 +41,7 @@ Now let's add these terms to the codebase and clear our scratchfile, to show tha
 ```unison scratch.u
 ```
 
-**(The bug again!)**
-
-```ucm:error
+```ucm
 .> run runnable
 ```
 

--- a/unison-src/transcripts/run.output.md
+++ b/unison-src/transcripts/run.output.md
@@ -6,7 +6,10 @@ In a scratch file, we'll define two terms.
 ---
 title: scratch.u
 ---
+runnable : '{builtin.io.IO} ()
 runnable = '(printLine "hello!")
+
+badtype : Text ->{builtin.io.IO} ()
 badtype = 'printLine "hello!"
 
 ```
@@ -24,23 +27,9 @@ badtype = 'printLine "hello!"
       runnable : '{io.IO} ()
 
 ```
-We'll see when we `run` the `runnable` term, we get the successful "hello!" we expect:
-
-**There is a bug here! https://github.com/unisonweb/unison/issues/1800**
-(this should not error)
-
+Since `runnable` is properly typed, Unison will successfully `run` it (the "hello" output does not show up in this transcript):
 ```ucm
 .> run runnable
-
-  😶
-  
-  I found this function:
-  
-    runnable : '{builtin.io.IO} ()
-  
-  but in order for me to `run` it it needs to have the type:
-  
-    runnable : '{builtin.io.IO} a
 
 ```
 When we run the term with the bad type, we get an error message that lets us know that Unison found the term, but the type is not `run`able:
@@ -97,20 +86,8 @@ title: scratch.u
   I loaded scratch.u and didn't find anything.
 
 ```
-**(The bug again!)**
-
 ```ucm
 .> run runnable
-
-  😶
-  
-  I found this function:
-  
-    runnable : '{builtin.io.IO} ()
-  
-  but in order for me to `run` it it needs to have the type:
-  
-    runnable : '{builtin.io.IO} a
 
 ```
 ```ucm


### PR DESCRIPTION
## Overview

The `run.md` transcript was originally created (in #1814) assuming that #1800 meant that no terms could be `run` on `trunk` currently. Now it looks like terms can be run, but they need explicit type signatures (see https://github.com/unisonweb/unison/issues/1800#issuecomment-796820111). So this PR removes the #1800 concession from the `run.md` transcript.

Worthy to note though: the actual `printLine` output of the command in `run.md` is not showing up in `run.output.md`. Perhaps special treatment of IO output is required in the transcript runner for this.