### PR TITLE
Tests: explicit branch name in git init

### DIFF
--- a/parser-typechecker/tests/Unison/Test/Git.hs
+++ b/parser-typechecker/tests/Unison/Test/Git.hs
@@ -175,7 +175,7 @@ testPull = scope "pull" $ do
 
   -- initialize git repo
   let repo = tmp </> "repo.git"
-  io $ "git" ["init", "--bare", Text.pack repo]
+  io $ "git" ["init", "--bare", "--initial-branch=master", Text.pack repo]
 
   -- run author/push transcript
   runTranscript_ tmp authorCodebase branchCache [iTrim|
@@ -330,7 +330,7 @@ testPush = scope "push" $ do
   for_ pushImplementations $ \(implName, impl) -> scope implName $ do
     -- initialize git repo
     let repoGit = tmp </> (implName ++ ".git")
-    io $ "git" ["init", "--bare", Text.pack repoGit]
+    io $ "git" ["init", "--bare", "--initial-branch=master", Text.pack repoGit]
 
     -- push one way!
     codebase <- io $ FC.codebase1' impl branchCache V1.formatSymbol formatAnn codebasePath


### PR DESCRIPTION
## Overview

Before this change, when I ran the tests I got the following "hints"
printed to the console:

```
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint:
hint:   git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint:
hint:   git branch -m <name>
```

I think that this means that the tests could potentially fail, depending
on the user's local git config and/or version.

I tried using the `trunk` branch and the tests failed. It seems that
the tests are dependent on the `master` branch being used, so I figured
it was probably be best to explicitly specify that branch name.

## Loose ends

This PR makes the dependency on the `master` branch name explicit, but is that the branch name that Unison wants to use? `trunk` is used elsewhere. Also I'm not sure whether this change will be relevant once the new repo format is released.
