### PR TITLE
Use mainline haskeline (0.8.1.1 instead of forked version)

### DIFF
--- a/parser-typechecker/src/Unison/CommandLine/Main.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Main.hs
@@ -9,6 +9,7 @@ import Unison.Prelude
 import Control.Concurrent.STM (atomically)
 import Control.Exception (finally, catch, AsyncException(UserInterrupt), asyncExceptionFromException)
 import Control.Monad.State (runStateT)
+import Control.Monad.Catch (MonadMask)
 import Data.Configurator.Types (Config)
 import Data.IORef
 import Data.Tuple.Extra (uncurry3)
@@ -67,7 +68,7 @@ expandNumber numberedArgs s =
           _ -> Nothing
 
 getUserInput
-  :: (MonadIO m, Line.MonadException m)
+  :: (MonadIO m, MonadMask m)
   => Map String InputPattern
   -> Codebase m v a
   -> Branch m

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,8 +18,6 @@ resolver: nightly-2021-01-02
 extra-deps:
 - github: unisonweb/configurator
   commit: e47e9e9fe1f576f8c835183b9def52d73c01327a
-- github: unisonweb/haskeline
-  commit: 2944b11d19ee034c48276edc991736105c9d6143
 - github: unisonweb/megaparsec
   commit: c4463124c578e8d1074c04518779b5ce5957af6b
 - github: biocad/openapi3
@@ -38,6 +36,7 @@ extra-deps:
 - servant-docs-0.11.6
 - ListLike-4.7.3
 - random-1.2.0
+- haskeline-0.8.1.1
 # remove these when stackage upgrades containers
 - containers-0.6.4.1
 - text-1.2.4.1


### PR DESCRIPTION
## Overview

Not needing to maintain a custom fork seems like a good thing. Also this is a step toward getting a Nix build of Unison that builds from source instead of simply wrapping a pre-built binary.

## Implementation notes

After fixing one minor change related to haskeline switching to using
`Control.Monad.Catch`, the tests are passing. I'm not sure whether there
was a more subtle reason that a custom haskeline was being used.

cc @maralorn who had brought this up