### PR TITLE
does the macOS-11.0 CI image work yet?

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
           - ubuntu-18.04
           # - ubuntu-16.04
           # this build fails with "can't load framework: Cocoa (not found)"
-          # - macOS-11.10
+          - macOS-11.10
           - macOS-10.15
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,6 @@ jobs:
           - ubuntu-20.04
           - ubuntu-18.04
           # - ubuntu-16.04
-          # this build fails with "can't load framework: Cocoa (not found)"
           - macOS-11.0
           - macOS-10.15
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
           - ubuntu-18.04
           # - ubuntu-16.04
           # this build fails with "can't load framework: Cocoa (not found)"
-          - macOS-11.10
+          - macOS-11.0
           - macOS-10.15
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
inspired by #1835, we need to update CI so that we would know if such a change would break builds