### PR TITLE
name.segments test: don't pick from an empty list

### DIFF
--- a/parser-typechecker/tests/Unison/Core/Test/Name.hs
+++ b/parser-typechecker/tests/Unison/Core/Test/Name.hs
@@ -20,10 +20,8 @@ test = scope "name" $ tests
     , scope "terms named `.`" $ expectEqual (suffixes "base..") ["base..", "."]
     ]
   , scope "segments" $ do
-    numDots <- int' 0 10
-    numSegs <- int' 0 10
-    n       <- int' 0 10
-    segs <- listOf n . pick $ replicate numDots "." ++ replicate numSegs "foo"
+    n    <- int' 0 10
+    segs <- listOf n $ pick [".", "foo"]
     expectEqual (segments $ Name . pack $ intercalate "." segs)
                 (NameSegment . pack <$> segs)
   ]

--- a/yaks/easytest/src/EasyTest.hs
+++ b/yaks/easytest/src/EasyTest.hs
@@ -259,6 +259,7 @@ word8' = random'
 -- | Sample uniformly from the given list of possibilities
 pick :: [a] -> Test a
 pick as = let n = length as; ind = picker n as in do
+  _ <- if (n > 0) then ok else crash "pick called with empty list"
   i <- int' 0 (n - 1)
   Just a <- pure (ind i)
   pure a


### PR DESCRIPTION
Resolves #1648.

Technically I think that this has slightly different RNG characteristics
than the old implementation, but I wouldn't expect it to matter for
the sake of the test.