### PR TITLE
Allow filtering of transcript tests by prefix

### DIFF
--- a/development.markdown
+++ b/development.markdown
@@ -11,8 +11,12 @@ To get cracking with Unison:
 * [Install `stack`](https://docs.haskellstack.org/en/stable/README/#how-to-install).
 * Build the project with `stack build`. This builds all executables.
 * After building, `stack exec unison` will fire up the codebase editor, create a codebase in the current directory, and watch for `.u` file changes.  If you want to run it in a different directory, just add `unison` to your `PATH`, after finding it with `find .stack-work -name unison -type f`.  (For me, this finds two, they both work, but have different contents.  ¯\\\_(ツ)\_/¯ )
+
+## Running Tests
+
 * `stack exec tests` runs the tests
 * `stack exec transcripts` runs all the integration tests, found in `unison-src/transcripts`. You can add more tests to this directory.
+* `stack exec tests -- prefix-of-test` and `stack exec transcripts -- prefix-of-test` only run tests with a matching prefix.
 
 ### What if you want a profiled build?
 

--- a/parser-typechecker/transcripts/Transcripts.hs
+++ b/parser-typechecker/transcripts/Transcripts.hs
@@ -20,27 +20,32 @@ import           Data.List
 
 import System.Environment (getArgs)
 
+data TestConfig = TestConfig
+  { useNewRuntime  :: Bool
+  , matchPrefix    :: Maybe String
+  } deriving Show
+
 type TestBuilder = FilePath -> FilePath -> [String] -> String -> Test ()
 
 testBuilder
-  :: Bool -> FilePath -> FilePath -> [String] -> String -> Test ()
-testBuilder new ucm dir prelude transcript = scope transcript $ do
+  :: TestConfig -> FilePath -> FilePath -> [String] -> String -> Test ()
+testBuilder config ucm dir prelude transcript = scope transcript $ do
   io $ fromString ucm args
   ok
   where
     files = fmap (pack . (dir </>)) (prelude ++ [transcript])
-    args | new = ["--new-runtime", "transcript"] ++ files
+    args | useNewRuntime config = ["--new-runtime", "transcript"] ++ files
          | otherwise = ["transcript"] ++ files
 
 testBuilder'
-  :: Bool -> FilePath -> FilePath -> [String] -> String -> Test ()
-testBuilder' new ucm dir prelude transcript = scope transcript $ do
+  :: TestConfig -> FilePath -> FilePath -> [String] -> String -> Test ()
+testBuilder' config ucm dir prelude transcript = scope transcript $ do
   let output = dir </> takeBaseName transcript <> ".output.md"
   io $ runAndCaptureError ucm args output
   ok
   where
     files = fmap (pack . (dir </>)) (prelude ++ [transcript])
-    args | new = ["--new-runtime", "transcript"] ++ files
+    args | useNewRuntime config = ["--new-runtime", "transcript"] ++ files
          | otherwise = ["transcript"] ++ files
     -- Given a command and arguments, run it and capture the standard error to a file
     -- regardless of success or failure.
@@ -55,8 +60,8 @@ testBuilder' new ucm dir prelude transcript = scope transcript $ do
     dropRunMessage = unlines . reverse . drop 3 . reverse . lines
 
 
-buildTests :: TestBuilder -> FilePath -> Test ()
-buildTests testBuilder dir = do
+buildTests :: TestConfig -> TestBuilder -> FilePath -> Test ()
+buildTests config testBuilder dir = do
   io
      . putStrLn
      . unlines
@@ -69,6 +74,8 @@ buildTests testBuilder dir = do
     (prelude, transcripts) =
       partition ((isPrefixOf "_") . snd . splitFileName)
       . sort
+        -- if there is a matchPrefix set, check for a prefix match - or return True
+      . filter (\f -> maybe True (`isPrefixOf` f) (matchPrefix config))
       . filter (\f -> takeExtensions f == ".md") $ files
 
   ucm <- io $ unpack <$> "stack" $| ["exec", "--", "which", "unison"] -- todo: what is it in windows?
@@ -94,19 +101,30 @@ cleanup = do
         , "the `test-output` directory. Feel free to delete it."
         ]
 
-test :: Bool -> Test ()
-test new = do
-  buildTests (testBuilder new) $ "unison-src" </> "transcripts"
-  buildTests (testBuilder True)
+test :: TestConfig -> Test ()
+test config = do
+  buildTests config (testBuilder config)
+    $ "unison-src" </> "transcripts"
+  buildTests config (testBuilder (config { useNewRuntime = True }))
     $ "unison-src" </> "new-runtime-transcripts"
-  buildTests (testBuilder False)
+  buildTests config (testBuilder (config { useNewRuntime = False }))
     $ "unison-src" </> "old-runtime-transcripts"
-  buildTests (testBuilder' new)
+  buildTests config (testBuilder' config)
     $ "unison-src" </> "transcripts" </> "errors"
   cleanup
 
+handleArgs :: [String] -> TestConfig
+handleArgs args =
+  let
+    (useNewRuntime, remainingArgs) =
+      ("--new-runtime" `elem` args, delete "--new-runtime" args)
+    matchPrefix = case remainingArgs of
+      [prefix] -> Just prefix
+      _        -> Nothing
+  in
+    TestConfig useNewRuntime matchPrefix
+
 main :: IO ()
-main =
-  getArgs >>= \case
-    "--new-runtime" : _ -> run (test True)
-    _ -> run (test False)
+main = do
+  testConfig <- handleArgs <$> getArgs
+  run (test testConfig)

--- a/parser-typechecker/transcripts/Transcripts.hs
+++ b/parser-typechecker/transcripts/Transcripts.hs
@@ -79,7 +79,12 @@ buildTests config testBuilder dir = do
       . filter (\f -> takeExtensions f == ".md") $ files
 
   ucm <- io $ unpack <$> "stack" $| ["exec", "--", "which", "unison"] -- todo: what is it in windows?
-  tests (testBuilder ucm dir prelude <$> transcripts)
+  case length transcripts of
+    0 -> pure ()  -- EasyTest exits early with "no test results recorded"
+                  -- if you don't give it any tests, this keeps it going
+                  -- till the end so we can search all transcripts for
+                  -- prefix matches.
+    _ -> tests (testBuilder ucm dir prelude <$> transcripts)
 
 -- Transcripts that exit successfully get cleaned-up by the transcript parser.
 -- Any remaining folders matching "transcript-.*" are output directories


### PR DESCRIPTION
## Overview

This allows people to use `stack exec transcripts -- prefix-of-test` to only run transcripts which match the prefix.

## Implementation notes

Adds a `TestConfig` and parses arguments into it.  Order for `--new-runtime` and `somePrefix` shouldn't matter, 
`stack exec transcripts -- --new-runtime prefix` and `stack exec transcripts -- prefix --new-runtime` both work.

I made a slight change to `buildTests` because, if in the first directory it searched there were no matching transcripts, it would exit early and skip searching the rest of the transcript folders.  So now we just `pure ()` if there are no matches, which allows it to continue.

## Interesting/controversial decisions

Nothing too controversial, code-style wise it's up to whichever is preferred for passing around configs.  It'd be easy to destructure the `TestConfig` and pass in only `matchPrefix` and `useNewRuntime` to `buildTests` and `testBuilder`, respectively.

I also wasn't sure if I should hoist `handleArgs` somewhere so that `parser-typechecker/tests/Suite.hs` and `parser-typechecker/transcripts/Transcripts.hs` can share the same args parsing.  Since it's only in two places, I left it local.

## Test coverage

Tested locally with 
* `stack exec transcripts`

![image](https://user-images.githubusercontent.com/1423526/111914217-7d093a80-8a47-11eb-8b9a-4bd7b6e67630.png)
... the usual ... and:
![image](https://user-images.githubusercontent.com/1423526/111914192-6531b680-8a47-11eb-86ad-e9342451f200.png)

* `stack exec transcripts -- todo`

![image](https://user-images.githubusercontent.com/1423526/111914132-27349280-8a47-11eb-8409-2f186043e9bc.png)

* `stack exec transcripts -- ucm --new-runtime`

![image](https://user-images.githubusercontent.com/1423526/111914068-f5bbc700-8a46-11eb-9f40-05e09e9d6be1.png)

* `stack exec transcripts -- --new-runtime ucm`

![image](https://user-images.githubusercontent.com/1423526/111914097-108e3b80-8a47-11eb-81b9-ed539860f0c8.png)


* `stack exec transcripts -- wigwam` (to see how it looks if nothing matches)

![image](https://user-images.githubusercontent.com/1423526/111914048-de7cd980-8a46-11eb-96c7-36d8fdcad80d.png)


Would you recommend improving the test coverage (either as part of this PR or as a separate issue) or do you think it’s adequate?

I think it's currently untested, so it'd be good to test, but tricky to implement.
