### PR TITLE
Fix some uses of throwing in the new runtime

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -276,6 +276,26 @@ evalInContext ppe ctx w = do
   pure $ decom =<< result
 
 bugMsg :: PrettyPrintEnv -> Text -> Term Symbol -> Pretty ColorText
+
+bugMsg ppe name tm
+  | name == "blank expression" = P.callout icon . P.lines $
+  [ P.wrap ("I encountered a" <> P.red (P.text name)
+      <> "with the following name/message:")
+  , ""
+  , P.indentN 2 $ pretty ppe tm
+  , ""
+  , sorryMsg
+  ]
+  | name == "pattern match failure" = P.callout icon . P.lines $
+  [ P.wrap ("I've encountered a" <> P.red (P.text name)
+      <> "while scrutinizing:")
+  , ""
+  , P.indentN 2 $ pretty ppe tm
+  , ""
+  , "This happens when calling a function that doesn't handle all \
+    \possible inputs"
+  , sorryMsg
+  ]
 bugMsg ppe name tm = P.callout icon . P.lines $
   [ P.wrap ("I've encountered a call to" <> P.red (P.text name)
       <> "with the following value:")

--- a/parser-typechecker/src/Unison/Runtime/Pattern.hs
+++ b/parser-typechecker/src/Unison/Runtime/Pattern.hs
@@ -562,7 +562,7 @@ lookupAbil rf (Map.lookup rf -> Just econs)
 lookupAbil rf _ = Left $ "unknown ability reference: " ++ show rf
 
 compile :: Var v => DataSpec -> Ctx v -> PatternMatrix v -> Term v
-compile _ _ (PM []) = blank ()
+compile _ _ (PM []) = placeholder () "pattern match failure"
 compile spec ctx m@(PM (r:rs))
   | rowIrrefutable r
   = case guard r of


### PR DESCRIPTION
When adding arguments to the instruction for bug/todo output, some other
uses of throwing errors were neglected and passed the wrong number of
arguments. This change also customizes the error messages a bit
(although they do not quite match the old messages).
