### PR TITLE
use hpack package.yaml to generate .cabal files

### DIFF
--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -1,0 +1,198 @@
+name: unison-parser-typechecker
+github: unisonweb/unison
+copyright: Copyright (C) 2013-2018 Unison Computing, PBC and contributors
+
+default-extensions:
+  - ApplicativeDo
+  - BlockArguments
+  - DeriveFunctor
+  - DerivingStrategies
+  - DoAndIfThenElse
+  - FlexibleContexts
+  - FlexibleInstances
+  - LambdaCase
+  - MultiParamTypeClasses
+  - ScopedTypeVariables
+  - TupleSections
+  - TypeApplications
+
+ghc-options: -Wall -funbox-strict-fields -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
+executables:
+  unison:
+    source-dirs: unison
+    main: Main.hs
+    ghc-options: -threaded -rtsopts -with-rtsopts=-I0 -optP-Wno-nonportable-include-path
+    dependencies:
+      - base
+      - bytestring
+      - containers
+      - configurator
+      - directory
+      - errors
+      - filepath
+      - megaparsec
+      - mtl
+      - safe
+      - shellmet
+      - template-haskell
+      - temporary
+      - text
+      - unison-core
+      - unison-parser-typechecker
+      - uri-encode
+    when:
+      - condition: '!os(windows)'
+        dependencies: unix
+
+  prettyprintdemo:
+    source-dirs: prettyprintdemo
+    main: Main.hs
+    dependencies:
+      - base
+      - safe
+      - text
+      - unison-parser-typechecker
+
+  tests:
+    source-dirs: tests
+    main: Suite.hs
+    ghc-options: -W -threaded -rtsopts "-with-rtsopts=-N -T" -v0
+    dependencies:
+      - async
+      - base
+      - bytestring
+      - containers
+      - directory
+      - easytest
+      - errors
+      - extra
+      - filepath
+      - filemanip
+      - here
+      - lens
+      - megaparsec
+      - mtl
+      - raw-strings-qq
+      - stm
+      - shellmet
+      - split
+      - temporary
+      - text
+      - transformers
+      - unliftio
+      - unison-core
+      - unison-parser-typechecker
+
+  transcripts:
+    source-dirs: transcripts
+    main: Transcripts.hs
+    ghc-options: -threaded -rtsopts -with-rtsopts=-N -v0
+    dependencies:
+      - base
+      - directory
+      - easytest
+      - filepath
+      - shellmet
+      - process
+      - text
+      - unison-core
+      - unison-parser-typechecker
+
+benchmarks:
+  runtime:
+    source-dirs: benchmarks/runtime
+    main: Main.hs
+    dependencies:
+      - base
+      - criterion
+      - containers
+      - unison-core
+      - unison-parser-typechecker
+
+library:
+  source-dirs: src
+  dependencies:
+    - aeson
+    - ansi-terminal
+    - async
+    - base
+    - base16 >= 0.2.1.0
+    - base64-bytestring
+    - basement
+    - bifunctors
+    - bytes
+    - bytestring
+    - cereal
+    - containers >= 0.6.3
+    - comonad
+    - concurrent-supply
+    - configurator
+    - cryptonite
+    - data-default
+    - directory
+    - either
+    - guid
+    - data-memocombinators
+    - edit-distance
+    - errors
+    - exceptions
+    - extra
+    - filepath
+    - filepattern
+    - fingertree
+    - free
+    - fsnotify
+    - generic-monoid
+    - hashable
+    - hashtables
+    - haskeline
+    - http-types
+    - io-streams
+    - lens
+    - ListLike
+    - megaparsec >= 5.0.0 && < 7.0.0
+    - memory
+    - mmorph
+    - monad-loops
+    - mtl
+    - murmur-hash
+    - mutable-containers
+    - network
+    - network-simple
+    - nonempty-containers
+    - openapi3
+    - pem
+    - process
+    - primitive
+    - random >= 1.2.0
+    - raw-strings-qq
+    - regex-base
+    - regex-tdfa
+    - safe
+    - servant
+    - servant-docs
+    - servant-openapi3
+    - servant-server
+    - shellmet
+    - split
+    - stm
+    - strings
+    - tagged
+    - temporary
+    - terminal-size
+    - text
+    - time
+    - tls
+    - transformers
+    - unison-core
+    - unliftio
+    - unliftio-core
+    - util
+    - unicode-show
+    - vector
+    - wai
+    - warp
+    - unicode-show
+    - x509
+    - x509-store
+    - x509-system

--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -1,6 +1,6 @@
 name: unison-parser-typechecker
 github: unisonweb/unison
-copyright: Copyright (C) 2013-2018 Unison Computing, PBC and contributors
+copyright: Copyright (C) 2013-2021 Unison Computing, PBC and contributors
 
 default-extensions:
   - ApplicativeDo
@@ -16,7 +16,17 @@ default-extensions:
   - TupleSections
   - TypeApplications
 
-ghc-options: -Wall -funbox-strict-fields -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
+ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
+
+flags:
+  optimized:
+    manual: true
+    default: false
+
+when:
+  - condition: flag(optimized)
+    ghc-options: -funbox-strict-fields -02
+
 executables:
   unison:
     source-dirs: unison

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -4,13 +4,13 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a5bd96db227ad234a060c8f363dd5cc47376a71d164fc6405123907f3b4b537d
+-- hash: 87668300fadfc9e31396ec2b581e6deefb0e4cc2d8264f8c608a3eb0f53fd073
 
 name:           unison-parser-typechecker
 version:        0.0.0
 homepage:       https://github.com/unisonweb/unison#readme
 bug-reports:    https://github.com/unisonweb/unison/issues
-copyright:      Copyright (C) 2013-2018 Unison Computing, PBC and contributors
+copyright:      Copyright (C) 2013-2021 Unison Computing, PBC and contributors
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple
@@ -18,6 +18,10 @@ build-type:     Simple
 source-repository head
   type: git
   location: https://github.com/unisonweb/unison
+
+flag optimized
+  manual: True
+  default: False
 
 library
   exposed-modules:
@@ -157,7 +161,7 @@ library
   hs-source-dirs:
       src
   default-extensions: ApplicativeDo BlockArguments DeriveFunctor DerivingStrategies DoAndIfThenElse FlexibleContexts FlexibleInstances LambdaCase MultiParamTypeClasses ScopedTypeVariables TupleSections TypeApplications
-  ghc-options: -Wall -funbox-strict-fields -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
+  ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
   build-depends:
       ListLike
     , aeson
@@ -242,6 +246,8 @@ library
     , x509
     , x509-store
     , x509-system
+  if flag(optimized)
+    ghc-options: -funbox-strict-fields -02
   default-language: Haskell2010
 
 executable prettyprintdemo
@@ -251,12 +257,14 @@ executable prettyprintdemo
   hs-source-dirs:
       prettyprintdemo
   default-extensions: ApplicativeDo BlockArguments DeriveFunctor DerivingStrategies DoAndIfThenElse FlexibleContexts FlexibleInstances LambdaCase MultiParamTypeClasses ScopedTypeVariables TupleSections TypeApplications
-  ghc-options: -Wall -funbox-strict-fields -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
+  ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
   build-depends:
       base
     , safe
     , text
     , unison-parser-typechecker
+  if flag(optimized)
+    ghc-options: -funbox-strict-fields -02
   default-language: Haskell2010
 
 executable tests
@@ -300,7 +308,7 @@ executable tests
   hs-source-dirs:
       tests
   default-extensions: ApplicativeDo BlockArguments DeriveFunctor DerivingStrategies DoAndIfThenElse FlexibleContexts FlexibleInstances LambdaCase MultiParamTypeClasses ScopedTypeVariables TupleSections TypeApplications
-  ghc-options: -Wall -funbox-strict-fields -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -W -threaded -rtsopts "-with-rtsopts=-N -T" -v0
+  ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -W -threaded -rtsopts "-with-rtsopts=-N -T" -v0
   build-depends:
       async
     , base
@@ -326,6 +334,8 @@ executable tests
     , unison-core
     , unison-parser-typechecker
     , unliftio
+  if flag(optimized)
+    ghc-options: -funbox-strict-fields -02
   default-language: Haskell2010
 
 executable transcripts
@@ -335,7 +345,7 @@ executable transcripts
   hs-source-dirs:
       transcripts
   default-extensions: ApplicativeDo BlockArguments DeriveFunctor DerivingStrategies DoAndIfThenElse FlexibleContexts FlexibleInstances LambdaCase MultiParamTypeClasses ScopedTypeVariables TupleSections TypeApplications
-  ghc-options: -Wall -funbox-strict-fields -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -threaded -rtsopts -with-rtsopts=-N -v0
+  ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -threaded -rtsopts -with-rtsopts=-N -v0
   build-depends:
       base
     , directory
@@ -346,6 +356,8 @@ executable transcripts
     , text
     , unison-core
     , unison-parser-typechecker
+  if flag(optimized)
+    ghc-options: -funbox-strict-fields -02
   default-language: Haskell2010
 
 executable unison
@@ -357,7 +369,7 @@ executable unison
   hs-source-dirs:
       unison
   default-extensions: ApplicativeDo BlockArguments DeriveFunctor DerivingStrategies DoAndIfThenElse FlexibleContexts FlexibleInstances LambdaCase MultiParamTypeClasses ScopedTypeVariables TupleSections TypeApplications
-  ghc-options: -Wall -funbox-strict-fields -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -threaded -rtsopts -with-rtsopts=-I0 -optP-Wno-nonportable-include-path
+  ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -threaded -rtsopts -with-rtsopts=-I0 -optP-Wno-nonportable-include-path
   build-depends:
       base
     , bytestring
@@ -376,6 +388,8 @@ executable unison
     , unison-core
     , unison-parser-typechecker
     , uri-encode
+  if flag(optimized)
+    ghc-options: -funbox-strict-fields -02
   if !os(windows)
     build-depends:
         unix
@@ -389,11 +403,13 @@ benchmark runtime
   hs-source-dirs:
       benchmarks/runtime
   default-extensions: ApplicativeDo BlockArguments DeriveFunctor DerivingStrategies DoAndIfThenElse FlexibleContexts FlexibleInstances LambdaCase MultiParamTypeClasses ScopedTypeVariables TupleSections TypeApplications
-  ghc-options: -Wall -funbox-strict-fields -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
+  ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
   build-depends:
       base
     , containers
     , criterion
     , unison-core
     , unison-parser-typechecker
+  if flag(optimized)
+    ghc-options: -funbox-strict-fields -02
   default-language: Haskell2010

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -1,419 +1,399 @@
-cabal-version: 2.2
-name:          unison-parser-typechecker
-category:      Compiler
-version:       0.1
-license:       MIT
-license-file:  LICENSE
-author:        Unison Computing, public benefit corp
-maintainer:    Paul Chiusano <paul.chiusano@gmail.com>, Runar Bjarnason <runarorama@gmail.com>, Arya Irani <arya.irani@gmail.com>
-stability:     provisional
-homepage:      http://unisonweb.org
-bug-reports:   https://github.com/unisonweb/unison/issues
-copyright:     Copyright (C) 2013-2018 Unison Computing, PBC and contributors
-synopsis:      Parser and typechecker for the Unison language
-description:
+cabal-version: 1.12
 
-build-type:    Simple
-extra-source-files:
-data-files:
+-- This file has been generated from package.yaml by hpack version 0.33.0.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: a5bd96db227ad234a060c8f363dd5cc47376a71d164fc6405123907f3b4b537d
+
+name:           unison-parser-typechecker
+version:        0.0.0
+homepage:       https://github.com/unisonweb/unison#readme
+bug-reports:    https://github.com/unisonweb/unison/issues
+copyright:      Copyright (C) 2013-2018 Unison Computing, PBC and contributors
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
 
 source-repository head
   type: git
-  location: git://github.com/unisonweb/unison.git
-
--- `cabal install -foptimized` enables optimizations
-flag optimized
-  manual: True
-  default: False
-
-flag quiet
-  manual: True
-  default: False
-
--- NOTE: Keep in sync throughout repo.
-common unison-common
-  default-language: Haskell2010
-  default-extensions:
-    ApplicativeDo,
-    BlockArguments,
-    DeriveFunctor,
-    DerivingStrategies,
-    DoAndIfThenElse,
-    FlexibleContexts,
-    FlexibleInstances,
-    LambdaCase,
-    MultiParamTypeClasses,
-    ScopedTypeVariables,
-    TupleSections,
-    TypeApplications
+  location: https://github.com/unisonweb/unison
 
 library
-  import: unison-common
-
-  hs-source-dirs: src
-
   exposed-modules:
-    Unison.Builtin
-    Unison.Builtin.Decls
-    Unison.Builtin.Terms
-    Unison.Codecs
-    Unison.Codebase
-    Unison.Codebase.Branch
-    Unison.Codebase.Branch.Dependencies
-    Unison.Codebase.BranchDiff
-    Unison.Codebase.BranchUtil
-    Unison.Codebase.Causal
-    Unison.Codebase.Classes
-    Unison.Codebase.CodeLookup
-    Unison.Codebase.Editor.AuthorInfo
-    Unison.Codebase.Editor.Command
-    Unison.Codebase.Editor.DisplayObject
-    Unison.Codebase.Editor.Git
-    Unison.Codebase.Editor.HandleInput
-    Unison.Codebase.Editor.HandleCommand
-    Unison.Codebase.Editor.Input
-    Unison.Codebase.Editor.Output
-    Unison.Codebase.Editor.Output.BranchDiff
-    Unison.Codebase.Editor.Propagate
-    Unison.Codebase.Editor.RemoteRepo
-    Unison.Codebase.Editor.SlurpResult
-    Unison.Codebase.Editor.SlurpComponent
-    Unison.Codebase.Editor.TodoOutput
-    Unison.Codebase.Editor.UriParser
-    Unison.Codebase.Editor.VersionParser
-    Unison.Codebase.FileCodebase
-    Unison.Codebase.FileCodebase.Common
-    Unison.Codebase.FileCodebase.SlimCopyRegenerateIndex
-    Unison.Codebase.GitError
-    Unison.Codebase.Metadata
-    Unison.Codebase.NameEdit
-    Unison.Codebase.Path
-    Unison.Codebase.Patch
-    Unison.Codebase.Reflog
-    Unison.Codebase.Runtime
-    Unison.Codebase.Serialization
-    Unison.Codebase.Serialization.PutT
-    Unison.Codebase.Serialization.V1
-    Unison.Codebase.ShortBranchHash
-    Unison.Codebase.SyncMode
-    Unison.Codebase.TermEdit
-    Unison.Codebase.TranscriptParser
-    Unison.Codebase.TypeEdit
-    Unison.Codebase.Watch
-    Unison.Codebase.Execute
-    Unison.Codebase.MainTerm
-    Unison.CommandLine
-    Unison.CommandLine.DisplayValues
-    Unison.CommandLine.InputPattern
-    Unison.CommandLine.InputPatterns
-    Unison.CommandLine.Main
-    Unison.CommandLine.OutputMessages
-    Unison.DeclPrinter
-    Unison.FileParser
-    Unison.FileParsers
-    Unison.Lexer
-    Unison.NamePrinter
-    Unison.Parser
-    Unison.Parsers
-    Unison.Path
-    Unison.PrettyPrintEnv
-    Unison.PrettyTerminal
-    Unison.PrintError
-    Unison.Result
-    Unison.Runtime.ANF
-    Unison.Runtime.ANF.Serialize
-    Unison.Runtime.Builtin
-    Unison.Runtime.Debug
-    Unison.Runtime.Decompile
-    Unison.Runtime.Exception
-    Unison.Runtime.Foreign
-    Unison.Runtime.Foreign.Function
-    Unison.Runtime.Interface
-    Unison.Runtime.IR
-    Unison.Runtime.MCode
-    Unison.Runtime.Machine
-    Unison.Runtime.Pattern
-    Unison.Runtime.Rt1
-    Unison.Runtime.Rt1IO
-    Unison.Runtime.IOSource
-    Unison.Runtime.Vector
-    Unison.Runtime.SparseVector
-    Unison.Runtime.Stack
-    Unison.Server.Backend
-    Unison.Server.CodebaseServer
-    Unison.Server.Endpoints.GetDefinitions 
-    Unison.Server.Endpoints.ListNamespace
-    Unison.Server.Errors
-    Unison.Server.QueryResult
-    Unison.Server.SearchResult
-    Unison.Server.SearchResult'
-    Unison.Server.Syntax
-    Unison.Server.Types
-    Unison.TermParser
-    Unison.TermPrinter
-    Unison.TypeParser
-    Unison.TypePrinter
-    Unison.Typechecker
-    Unison.Typechecker.Components
-    Unison.Typechecker.Context
-    Unison.Typechecker.Extractor
-    Unison.Typechecker.TypeError
-    Unison.Typechecker.TypeLookup
-    Unison.Typechecker.TypeVar
-    Unison.UnisonFile
-    Unison.Util.AnnotatedText
-    Unison.Util.Bytes
-    Unison.Util.Cache
-    Unison.Util.ColorText
-    Unison.Util.EnumContainers
-    Unison.Util.Exception
-    Unison.Util.Free
-    Unison.Util.Find
-    Unison.Util.Less
-    Unison.Util.Logger
-    Unison.Util.Map
-    Unison.Util.Menu
-    Unison.Util.PinBoard
-    Unison.Util.Pretty
-    Unison.Util.Range
-    Unison.Util.Star3
-    Unison.Util.SyntaxText
-    Unison.Util.Timing
-    Unison.Util.TQueue
-    Unison.Util.TransitiveClosure
-    Unison.Util.CycleTable
-    Unison.Util.CyclicEq
-    Unison.Util.CyclicOrd
-
-  build-depends:
-    aeson,
-    ansi-terminal,
-    async,
-    base,
-    base16 >= 0.2.1.0,
-    base64-bytestring,
-    basement,
-    bifunctors,
-    bytes,
-    bytestring,
-    cereal,
-    containers >= 0.6.3,
-    comonad,
-    concurrent-supply,
-    configurator,
-    cryptonite,
-    data-default,
-    directory,
-    either,
-    guid,
-    data-memocombinators,
-    edit-distance,
-    errors,
-    exceptions,
-    extra,
-    filepath,
-    filepattern,
-    fingertree,
-    free,
-    fsnotify,
-    generic-monoid,
-    hashable,
-    hashtables,
-    haskeline,
-    http-types,
-    io-streams,
-    lens,
-    ListLike,
-    megaparsec >= 5.0.0 && < 7.0.0,
-    memory,
-    mmorph,
-    monad-loops,
-    mtl,
-    murmur-hash,
-    mutable-containers,
-    network,
-    network-simple,
-    nonempty-containers,
-    openapi3,
-    pem,
-    process,
-    primitive,
-    random >= 1.2.0,
-    raw-strings-qq,
-    regex-base,
-    regex-tdfa,
-    safe,
-    servant,
-    servant-docs,
-    servant-openapi3,
-    servant-server,
-    shellmet,
-    split,
-    stm,
-    strings,
-    tagged,
-    temporary,
-    terminal-size,
-    text,
-    time,
-    tls,
-    transformers,
-    unison-core,
-    unliftio,
-    unliftio-core,
-    util,
-    unicode-show,
-    vector,
-    wai,
-    warp,
-    unicode-show,
-    x509,
-    x509-store,
-    x509-system
-
-  ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
-
-  if flag(optimized)
-    ghc-options: -funbox-strict-fields -O2
-
-  if flag(quiet)
-    ghc-options: -v0
-
-executable unison
-  import: unison-common
-  main-is: Main.hs
-  hs-source-dirs: unison
-  ghc-options: -Wall -threaded -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -rtsopts -with-rtsopts=-I0 -optP-Wno-nonportable-include-path
+      Unison.Builtin
+      Unison.Builtin.Decls
+      Unison.Builtin.Terms
+      Unison.Codebase
+      Unison.Codebase.Branch
+      Unison.Codebase.Branch.Dependencies
+      Unison.Codebase.BranchDiff
+      Unison.Codebase.BranchUtil
+      Unison.Codebase.Causal
+      Unison.Codebase.Classes
+      Unison.Codebase.CodeLookup
+      Unison.Codebase.Editor.AuthorInfo
+      Unison.Codebase.Editor.Command
+      Unison.Codebase.Editor.DisplayObject
+      Unison.Codebase.Editor.Git
+      Unison.Codebase.Editor.HandleCommand
+      Unison.Codebase.Editor.HandleInput
+      Unison.Codebase.Editor.Input
+      Unison.Codebase.Editor.Output
+      Unison.Codebase.Editor.Output.BranchDiff
+      Unison.Codebase.Editor.Propagate
+      Unison.Codebase.Editor.RemoteRepo
+      Unison.Codebase.Editor.SlurpComponent
+      Unison.Codebase.Editor.SlurpResult
+      Unison.Codebase.Editor.TodoOutput
+      Unison.Codebase.Editor.UriParser
+      Unison.Codebase.Editor.VersionParser
+      Unison.Codebase.Execute
+      Unison.Codebase.FileCodebase
+      Unison.Codebase.FileCodebase.Common
+      Unison.Codebase.FileCodebase.SlimCopyRegenerateIndex
+      Unison.Codebase.GitError
+      Unison.Codebase.MainTerm
+      Unison.Codebase.Metadata
+      Unison.Codebase.NameEdit
+      Unison.Codebase.Patch
+      Unison.Codebase.Path
+      Unison.Codebase.Reflog
+      Unison.Codebase.Runtime
+      Unison.Codebase.Serialization
+      Unison.Codebase.Serialization.PutT
+      Unison.Codebase.Serialization.V1
+      Unison.Codebase.ShortBranchHash
+      Unison.Codebase.SyncMode
+      Unison.Codebase.TermEdit
+      Unison.Codebase.TranscriptParser
+      Unison.Codebase.TypeEdit
+      Unison.Codebase.Watch
+      Unison.Codecs
+      Unison.CommandLine
+      Unison.CommandLine.DisplayValues
+      Unison.CommandLine.InputPattern
+      Unison.CommandLine.InputPatterns
+      Unison.CommandLine.Main
+      Unison.CommandLine.OutputMessages
+      Unison.DeclPrinter
+      Unison.FileParser
+      Unison.FileParsers
+      Unison.Lexer
+      Unison.NamePrinter
+      Unison.Parser
+      Unison.Parsers
+      Unison.Path
+      Unison.PrettyPrintEnv
+      Unison.PrettyTerminal
+      Unison.PrintError
+      Unison.Result
+      Unison.Runtime.ANF
+      Unison.Runtime.ANF.Serialize
+      Unison.Runtime.Builtin
+      Unison.Runtime.Debug
+      Unison.Runtime.Decompile
+      Unison.Runtime.Exception
+      Unison.Runtime.Foreign
+      Unison.Runtime.Foreign.Function
+      Unison.Runtime.Interface
+      Unison.Runtime.IOSource
+      Unison.Runtime.IR
+      Unison.Runtime.Machine
+      Unison.Runtime.MCode
+      Unison.Runtime.Pattern
+      Unison.Runtime.Rt1
+      Unison.Runtime.Rt1IO
+      Unison.Runtime.SparseVector
+      Unison.Runtime.Stack
+      Unison.Runtime.Vector
+      Unison.Server.Backend
+      Unison.Server.CodebaseServer
+      Unison.Server.Endpoints.GetDefinitions
+      Unison.Server.Endpoints.ListNamespace
+      Unison.Server.Errors
+      Unison.Server.QueryResult
+      Unison.Server.SearchResult
+      Unison.Server.SearchResult'
+      Unison.Server.Syntax
+      Unison.Server.Types
+      Unison.TermParser
+      Unison.TermPrinter
+      Unison.Typechecker
+      Unison.Typechecker.Components
+      Unison.Typechecker.Context
+      Unison.Typechecker.Extractor
+      Unison.Typechecker.TypeError
+      Unison.Typechecker.TypeLookup
+      Unison.Typechecker.TypeVar
+      Unison.TypeParser
+      Unison.TypePrinter
+      Unison.UnisonFile
+      Unison.Util.AnnotatedText
+      Unison.Util.Bytes
+      Unison.Util.Cache
+      Unison.Util.ColorText
+      Unison.Util.CycleTable
+      Unison.Util.CyclicEq
+      Unison.Util.CyclicOrd
+      Unison.Util.EnumContainers
+      Unison.Util.Exception
+      Unison.Util.Find
+      Unison.Util.Free
+      Unison.Util.Less
+      Unison.Util.Logger
+      Unison.Util.Map
+      Unison.Util.Menu
+      Unison.Util.PinBoard
+      Unison.Util.Pretty
+      Unison.Util.Range
+      Unison.Util.Star3
+      Unison.Util.SyntaxText
+      Unison.Util.Timing
+      Unison.Util.TQueue
+      Unison.Util.TransitiveClosure
   other-modules:
-    System.Path
-    Version
+      Paths_unison_parser_typechecker
+  hs-source-dirs:
+      src
+  default-extensions: ApplicativeDo BlockArguments DeriveFunctor DerivingStrategies DoAndIfThenElse FlexibleContexts FlexibleInstances LambdaCase MultiParamTypeClasses ScopedTypeVariables TupleSections TypeApplications
+  ghc-options: -Wall -funbox-strict-fields -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
   build-depends:
-    base,
-    bytestring,
-    containers,
-    configurator,
-    directory,
-    errors,
-    filepath,
-    megaparsec,
-    safe,
-    shellmet,
-    template-haskell,
-    temporary,
-    text,
-    unison-core,
-    unison-parser-typechecker,
-    uri-encode
-  if !os(windows)
-    build-depends:
-      unix
+      ListLike
+    , aeson
+    , ansi-terminal
+    , async
+    , base
+    , base16 >=0.2.1.0
+    , base64-bytestring
+    , basement
+    , bifunctors
+    , bytes
+    , bytestring
+    , cereal
+    , comonad
+    , concurrent-supply
+    , configurator
+    , containers >=0.6.3
+    , cryptonite
+    , data-default
+    , data-memocombinators
+    , directory
+    , edit-distance
+    , either
+    , errors
+    , exceptions
+    , extra
+    , filepath
+    , filepattern
+    , fingertree
+    , free
+    , fsnotify
+    , generic-monoid
+    , guid
+    , hashable
+    , hashtables
+    , haskeline
+    , http-types
+    , io-streams
+    , lens
+    , megaparsec >=5.0.0 && <7.0.0
+    , memory
+    , mmorph
+    , monad-loops
+    , mtl
+    , murmur-hash
+    , mutable-containers
+    , network
+    , network-simple
+    , nonempty-containers
+    , openapi3
+    , pem
+    , primitive
+    , process
+    , random >=1.2.0
+    , raw-strings-qq
+    , regex-base
+    , regex-tdfa
+    , safe
+    , servant
+    , servant-docs
+    , servant-openapi3
+    , servant-server
+    , shellmet
+    , split
+    , stm
+    , strings
+    , tagged
+    , temporary
+    , terminal-size
+    , text
+    , time
+    , tls
+    , transformers
+    , unicode-show
+    , unison-core
+    , unliftio
+    , unliftio-core
+    , util
+    , vector
+    , wai
+    , warp
+    , x509
+    , x509-store
+    , x509-system
+  default-language: Haskell2010
 
 executable prettyprintdemo
-  import: unison-common
   main-is: Main.hs
-  hs-source-dirs: prettyprintdemo
-  ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
+  other-modules:
+      Paths_unison_parser_typechecker
+  hs-source-dirs:
+      prettyprintdemo
+  default-extensions: ApplicativeDo BlockArguments DeriveFunctor DerivingStrategies DoAndIfThenElse FlexibleContexts FlexibleInstances LambdaCase MultiParamTypeClasses ScopedTypeVariables TupleSections TypeApplications
+  ghc-options: -Wall -funbox-strict-fields -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
   build-depends:
-    base,
-    safe,
-    text,
-    unison-parser-typechecker
+      base
+    , safe
+    , text
+    , unison-parser-typechecker
+  default-language: Haskell2010
 
 executable tests
-  import:         unison-common
-  main-is:        Suite.hs
-  hs-source-dirs: tests
-  ghc-options:    -W -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -threaded -rtsopts "-with-rtsopts=-N -T" -v0
-  build-depends:
-    base,
-    easytest
+  main-is: Suite.hs
   other-modules:
-    Unison.Test.ABT
-    Unison.Test.ANF
-    Unison.Test.Cache
-    Unison.Test.Codebase
-    Unison.Test.Codebase.Causal
-    Unison.Test.Codebase.FileCodebase
-    Unison.Test.Codebase.Path
-    Unison.Test.ColorText
-    Unison.Test.Common
-    Unison.Test.DataDeclaration
-    Unison.Test.FileParser
-    Unison.Test.Git
-    Unison.Test.Lexer
-    Unison.Test.IO
-    Unison.Test.MCode
-    Unison.Test.Range
-    Unison.Test.Referent
-    Unison.Test.Term
-    Unison.Test.TermParser
-    Unison.Test.TermPrinter
-    Unison.Test.Type
-    Unison.Test.TypePrinter
-    Unison.Test.Typechecker
-    Unison.Test.Typechecker.Components
-    Unison.Test.Typechecker.Context
-    Unison.Test.Typechecker.TypeError
-    Unison.Test.UnisonSources
-    Unison.Test.UriParser
-    Unison.Test.Util.Bytes
-    Unison.Test.Util.PinBoard
-    Unison.Test.Util.Pretty
-    Unison.Test.Var
-    Unison.Test.VersionParser
-    Unison.Core.Test.Name
-
+      Unison.Core.Test.Name
+      Unison.Test.ABT
+      Unison.Test.ANF
+      Unison.Test.Cache
+      Unison.Test.Codebase
+      Unison.Test.Codebase.Causal
+      Unison.Test.Codebase.FileCodebase
+      Unison.Test.Codebase.Path
+      Unison.Test.ColorText
+      Unison.Test.Common
+      Unison.Test.DataDeclaration
+      Unison.Test.FileParser
+      Unison.Test.Git
+      Unison.Test.IO
+      Unison.Test.Lexer
+      Unison.Test.MCode
+      Unison.Test.Range
+      Unison.Test.Referent
+      Unison.Test.Term
+      Unison.Test.TermParser
+      Unison.Test.TermPrinter
+      Unison.Test.Type
+      Unison.Test.Typechecker
+      Unison.Test.Typechecker.Components
+      Unison.Test.Typechecker.Context
+      Unison.Test.Typechecker.TypeError
+      Unison.Test.TypePrinter
+      Unison.Test.UnisonSources
+      Unison.Test.UriParser
+      Unison.Test.Util.Bytes
+      Unison.Test.Util.PinBoard
+      Unison.Test.Util.Pretty
+      Unison.Test.Var
+      Unison.Test.VersionParser
+      Paths_unison_parser_typechecker
+  hs-source-dirs:
+      tests
+  default-extensions: ApplicativeDo BlockArguments DeriveFunctor DerivingStrategies DoAndIfThenElse FlexibleContexts FlexibleInstances LambdaCase MultiParamTypeClasses ScopedTypeVariables TupleSections TypeApplications
+  ghc-options: -Wall -funbox-strict-fields -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -W -threaded -rtsopts "-with-rtsopts=-N -T" -v0
   build-depends:
-    async,
-    base,
-    bytestring,
-    containers,
-    directory,
-    easytest,
-    errors,
-    extra,
-    filepath,
-    filemanip,
-    here,
-    lens,
-    megaparsec,
-    mtl,
-    raw-strings-qq,
-    stm,
-    shellmet,
-    split,
-    temporary,
-    text,
-    transformers,
-    unison-core,
-    unison-parser-typechecker
+      async
+    , base
+    , bytestring
+    , containers
+    , directory
+    , easytest
+    , errors
+    , extra
+    , filemanip
+    , filepath
+    , here
+    , lens
+    , megaparsec
+    , mtl
+    , raw-strings-qq
+    , shellmet
+    , split
+    , stm
+    , temporary
+    , text
+    , transformers
+    , unison-core
+    , unison-parser-typechecker
+    , unliftio
+  default-language: Haskell2010
 
 executable transcripts
-  import:         unison-common
-  main-is:        Transcripts.hs
-  ghc-options:    -W -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -threaded -rtsopts -with-rtsopts=-N -v0
-  hs-source-dirs: transcripts
+  main-is: Transcripts.hs
   other-modules:
+      Paths_unison_parser_typechecker
+  hs-source-dirs:
+      transcripts
+  default-extensions: ApplicativeDo BlockArguments DeriveFunctor DerivingStrategies DoAndIfThenElse FlexibleContexts FlexibleInstances LambdaCase MultiParamTypeClasses ScopedTypeVariables TupleSections TypeApplications
+  ghc-options: -Wall -funbox-strict-fields -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -threaded -rtsopts -with-rtsopts=-N -v0
   build-depends:
-    base,
-    directory,
-    easytest,
-    filepath,
-    shellmet,
-    process,
-    text,
-    unison-core,
-    unison-parser-typechecker
+      base
+    , directory
+    , easytest
+    , filepath
+    , process
+    , shellmet
+    , text
+    , unison-core
+    , unison-parser-typechecker
+  default-language: Haskell2010
+
+executable unison
+  main-is: Main.hs
+  other-modules:
+      System.Path
+      Version
+      Paths_unison_parser_typechecker
+  hs-source-dirs:
+      unison
+  default-extensions: ApplicativeDo BlockArguments DeriveFunctor DerivingStrategies DoAndIfThenElse FlexibleContexts FlexibleInstances LambdaCase MultiParamTypeClasses ScopedTypeVariables TupleSections TypeApplications
+  ghc-options: -Wall -funbox-strict-fields -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -threaded -rtsopts -with-rtsopts=-I0 -optP-Wno-nonportable-include-path
+  build-depends:
+      base
+    , bytestring
+    , configurator
+    , containers
+    , directory
+    , errors
+    , filepath
+    , megaparsec
+    , mtl
+    , safe
+    , shellmet
+    , template-haskell
+    , temporary
+    , text
+    , unison-core
+    , unison-parser-typechecker
+    , uri-encode
+  if !os(windows)
+    build-depends:
+        unix
+  default-language: Haskell2010
 
 benchmark runtime
-  import: unison-common
   type: exitcode-stdio-1.0
   main-is: Main.hs
-  ghc-options: -O2
-  hs-source-dirs: benchmarks/runtime
+  other-modules:
+      Paths_unison_parser_typechecker
+  hs-source-dirs:
+      benchmarks/runtime
+  default-extensions: ApplicativeDo BlockArguments DeriveFunctor DerivingStrategies DoAndIfThenElse FlexibleContexts FlexibleInstances LambdaCase MultiParamTypeClasses ScopedTypeVariables TupleSections TypeApplications
+  ghc-options: -Wall -funbox-strict-fields -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
   build-depends:
-    base,
-    criterion,
-    containers,
-    unison-core,
-    unison-parser-typechecker
+      base
+    , containers
+    , criterion
+    , unison-core
+    , unison-parser-typechecker
+  default-language: Haskell2010

--- a/unison-core/package.yaml
+++ b/unison-core/package.yaml
@@ -1,0 +1,40 @@
+name: unison-core
+github: unisonweb/unison
+copyright: Copyright (C) 2013-2018 Unison Computing, PBC and contributors
+
+library:
+  source-dirs: src
+  ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -funbox-strict-fields
+  dependencies:
+    - base
+    - bytestring
+    - containers >= 0.6.3
+    - cryptonite
+    - either
+    - extra
+    - lens
+    - prelude-extras
+    - memory
+    - mtl
+    - rfc5051
+    - safe
+    - sandi
+    - text
+    - transformers
+    - util
+    - vector
+
+default-extensions:
+  - ApplicativeDo
+  - BlockArguments
+  - DeriveFunctor
+  - DerivingStrategies
+  - DoAndIfThenElse
+  - FlexibleContexts
+  - FlexibleInstances
+  - LambdaCase
+  - MultiParamTypeClasses
+  - ScopedTypeVariables
+  - TupleSections
+  - TypeApplications
+

--- a/unison-core/package.yaml
+++ b/unison-core/package.yaml
@@ -38,3 +38,11 @@ default-extensions:
   - TupleSections
   - TypeApplications
 
+flags:
+  optimized:
+    manual: true
+    default: false
+
+when:
+  - condition: flag(optimized)
+    ghc-options: -funbox-strict-fields

--- a/unison-core/unison-core.cabal
+++ b/unison-core/unison-core.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f9567863c52090b848072234aa1e89e9dafbe416cb27556e15a26f8f57cb56d0
+-- hash: d2e2ed6fd71e1577534326f1856abc09e370c160c02bcab3902feee2e2bd8f8e
 
 name:           unison-core
 version:        0.0.0
@@ -18,6 +18,10 @@ build-type:     Simple
 source-repository head
   type: git
   location: https://github.com/unisonweb/unison
+
+flag optimized
+  manual: True
+  default: False
 
 library
   exposed-modules:
@@ -80,4 +84,6 @@ library
     , transformers
     , util
     , vector
+  if flag(optimized)
+    ghc-options: -funbox-strict-fields
   default-language: Haskell2010

--- a/unison-core/unison-core.cabal
+++ b/unison-core/unison-core.cabal
@@ -1,117 +1,83 @@
-cabal-version: 2.2
-name:          unison-core
-category:      Compiler
-version:       0.1
-license:       MIT
-license-file:  LICENSE
-author:        Unison Computing, public benefit corp
-maintainer:    Paul Chiusano <paul.chiusano@gmail.com>, Runar Bjarnason <runarorama@gmail.com>, Arya Irani <arya.irani@gmail.com>
-stability:     provisional
-homepage:      http://unisonweb.org
-bug-reports:   https://github.com/unisonweb/unison/issues
-copyright:     Copyright (C) 2013-2018 Unison Computing, PBC and contributors
-synopsis:      Parser and typechecker for the Unison language
-description:
+cabal-version: 1.12
 
-build-type:    Simple
-extra-source-files:
-data-files:
+-- This file has been generated from package.yaml by hpack version 0.33.0.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: f9567863c52090b848072234aa1e89e9dafbe416cb27556e15a26f8f57cb56d0
+
+name:           unison-core
+version:        0.0.0
+homepage:       https://github.com/unisonweb/unison#readme
+bug-reports:    https://github.com/unisonweb/unison/issues
+copyright:      Copyright (C) 2013-2018 Unison Computing, PBC and contributors
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
 
 source-repository head
   type: git
-  location: git://github.com/unisonweb/unison.git
-
--- `cabal install -foptimized` enables optimizations
-flag optimized
-  manual: True
-  default: False
-
-flag quiet
-  manual: True
-  default: False
-
--- NOTE: Keep in sync throughout repo.
-common unison-common
-  default-language: Haskell2010
-  default-extensions:
-    ApplicativeDo,
-    BlockArguments,
-    DeriveFunctor,
-    DerivingStrategies,
-    DoAndIfThenElse,
-    FlexibleContexts,
-    FlexibleInstances,
-    LambdaCase,
-    MultiParamTypeClasses,
-    ScopedTypeVariables,
-    TupleSections,
-    TypeApplications
+  location: https://github.com/unisonweb/unison
 
 library
-  import: unison-common
-
-  hs-source-dirs: src
-
   exposed-modules:
-    Unison.ABT
-    Unison.ABT.Normalized
-    Unison.Blank
-    Unison.ConstructorType
-    Unison.DataDeclaration
-    Unison.Hash
-    Unison.HashQualified
-    Unison.HashQualified'
-    Unison.Hashable
-    Unison.Kind
-    Unison.LabeledDependency
-    Unison.Name
-    Unison.Names2
-    Unison.Names3
-    Unison.NameSegment
-    Unison.Paths
-    Unison.Pattern
-    Unison.PatternCompat
-    Unison.Prelude
-    Unison.Reference
-    Unison.Reference.Util
-    Unison.Referent
-    Unison.Settings
-    Unison.ShortHash
-    Unison.Symbol
-    Unison.Term
-    Unison.Type
-    Unison.Util.Components
-    Unison.Util.List
-    Unison.Util.Monoid
-    Unison.Util.Relation
-    Unison.Util.Relation3
-    Unison.Util.Relation4
-    Unison.Util.Set
-    Unison.Var
-
+      Unison.ABT
+      Unison.ABT.Normalized
+      Unison.Blank
+      Unison.ConstructorType
+      Unison.DataDeclaration
+      Unison.Hash
+      Unison.Hashable
+      Unison.HashQualified
+      Unison.HashQualified'
+      Unison.Kind
+      Unison.LabeledDependency
+      Unison.Name
+      Unison.Names2
+      Unison.Names3
+      Unison.NameSegment
+      Unison.Paths
+      Unison.Pattern
+      Unison.PatternCompat
+      Unison.Prelude
+      Unison.Reference
+      Unison.Reference.Util
+      Unison.Referent
+      Unison.Settings
+      Unison.ShortHash
+      Unison.Symbol
+      Unison.Term
+      Unison.Type
+      Unison.Util.Components
+      Unison.Util.List
+      Unison.Util.Monoid
+      Unison.Util.Relation
+      Unison.Util.Relation3
+      Unison.Util.Relation4
+      Unison.Util.Set
+      Unison.Var
+  other-modules:
+      Paths_unison_core
+  hs-source-dirs:
+      src
+  default-extensions: ApplicativeDo BlockArguments DeriveFunctor DerivingStrategies DoAndIfThenElse FlexibleContexts FlexibleInstances LambdaCase MultiParamTypeClasses ScopedTypeVariables TupleSections TypeApplications
+  ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -funbox-strict-fields
   build-depends:
-    base,
-    bytestring,
-    containers >= 0.6.3,
-    cryptonite,
-    either,
-    extra,
-    lens,
-    prelude-extras,
-    memory,
-    mtl,
-    rfc5051,
-    safe,
-    sandi,
-    text,
-    transformers,
-    util,
-    vector
-
-  ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
-
-  if flag(optimized)
-    ghc-options: -funbox-strict-fields
-
-  if flag(quiet)
-    ghc-options: -v0
+      base
+    , bytestring
+    , containers >=0.6.3
+    , cryptonite
+    , either
+    , extra
+    , lens
+    , memory
+    , mtl
+    , prelude-extras
+    , rfc5051
+    , safe
+    , sandi
+    , text
+    , transformers
+    , util
+    , vector
+  default-language: Haskell2010


### PR DESCRIPTION
This PR switches the package definitions to hpack format, so I don't have to edit the package definitions every time I want to add a new module.  Feedback is welcome, but I hope we can merge it.

## Overview

`stack build` will automatically use [hpack](https://github.com/sol/hpack) to convert the more concise package.yaml files into .cabal files [slides](http://typeful.net/talks/hpack/#7), [blog](https://mmhaskell.com/blog/2020/1/27/hpack-a-simpler-package-format).  In particular, **this allows you to add modules to a package just by putting them on the filesystem**, without having to edit .cabal files, although you can still manual specify `exposed-modules` or `other-modules`, in which case the complementary set is inferred.

## Interesting/controversial decisions

* There's disagreement on whether to include the generated .cabal file into the git repo.  I lean slightly "no", but included them in this PR anyway, and would like to get second opinions.  
  > Both cabal2nix and stack support `package.yaml` natively. For other build tools, the `hpack` executable can be used to generate a .cabal file from package.yaml.

* > Hpack allows the inclusion of common fields from a file on GitHub or a local file.

  which might simplify some things further — e.g. copyright & license info, default-extensions, etc. — but I didn't do this yet.
