### PR TITLE
Use liftIO instead of MonadUnliftIO

### DIFF
--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -57,7 +57,7 @@ data Codebase m v a =
 
            , getRootBranch      :: m (Either GetRootBranchError (Branch m))
            , putRootBranch      :: Branch m -> m ()
-           , rootBranchUpdates  :: m (m (), m (Set Branch.Hash))
+           , rootBranchUpdates  :: m (IO (), IO (Set Branch.Hash))
            , getBranchForHash   :: Branch.Hash -> m (Maybe (Branch m))
 
            , dependentsImpl     :: Reference -> m (Set Reference.Id)

--- a/parser-typechecker/src/Unison/Codebase/Watch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Watch.hs
@@ -1,18 +1,16 @@
 {-# LANGUAGE PatternSynonyms   #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
 
 module Unison.Codebase.Watch where
 
 import Unison.Prelude
 
-import qualified UnliftIO                       as UnliftIO
-import           UnliftIO.Concurrent            ( forkIO
+import           Control.Concurrent             ( forkIO
                                                 , threadDelay
                                                 , killThread
                                                 )
-import           UnliftIO                       ( MonadUnliftIO
-                                                , withRunInIO
-                                                , unliftIO )
 import           UnliftIO.Directory             ( getModificationTime
                                                 , listDirectory
                                                 , doesPathExist
@@ -40,10 +38,10 @@ untilJust :: Monad m => m (Maybe a) -> m a
 untilJust act = act >>= maybe (untilJust act) return
 
 watchDirectory'
-  :: forall m. MonadUnliftIO m => FilePath -> m (m (), m (FilePath, UTCTime))
+  :: forall m. MonadIO m => FilePath -> m (IO (), IO (FilePath, UTCTime))
 watchDirectory' d = do
     mvar <- newEmptyMVar
-    let handler :: Event -> m ()
+    let handler :: Event -> IO ()
         handler e = case e of
           Added    fp t False -> doIt fp t
           Modified fp t False -> doIt fp t
@@ -57,21 +55,21 @@ watchDirectory' d = do
     -- we don't like FSNotify's debouncing (it seems to drop later events)
     -- so we will be doing our own instead
     let config = FSNotify.defaultConfig { FSNotify.confDebounce = FSNotify.NoDebounce }
-    cancel <- forkIO $ withRunInIO $ \inIO ->
+    cancel <- liftIO $ forkIO $
       FSNotify.withManagerConf config $ \mgr -> do
-        cancelInner <- FSNotify.watchDir mgr d (const True) (inIO . handler) <|> (pure (pure ()))
+        cancelInner <- FSNotify.watchDir mgr d (const True) handler <|> (pure (pure ()))
         putMVar cleanupRef $ liftIO cancelInner
         forever $ threadDelay 1000000
-    let cleanup :: m ()
+    let cleanup :: IO ()
         cleanup = join (takeMVar cleanupRef) >> killThread cancel
     pure (cleanup, takeMVar mvar)
 
-collectUntilPause :: forall m a. MonadIO m => TQueue a -> Int -> m [a]
+collectUntilPause :: forall a. TQueue a -> Int -> IO [a]
 collectUntilPause queue minPauseµsec = do
 -- 1. wait for at least one element in the queue
   void . atomically $ TQueue.peek queue
 
-  let go :: MonadIO m => m [a]
+  let go :: IO [a]
       go = do
         before <- atomically $ TQueue.enqueueCount queue
         threadDelay minPauseµsec
@@ -82,8 +80,8 @@ collectUntilPause queue minPauseµsec = do
           else go
   go
 
-watchDirectory :: forall m. MonadUnliftIO m
-  => FilePath -> (FilePath -> Bool) -> m (m (), m (FilePath, Text))
+watchDirectory :: forall m. MonadIO m
+  => FilePath -> (FilePath -> Bool) -> m (IO (), IO (FilePath, Text))
 watchDirectory dir allow = do
   previousFiles <- newIORef Map.empty
   (cancelWatch, watcher) <- watchDirectory' dir
@@ -94,14 +92,14 @@ watchDirectory dir allow = do
       filtered <- filterM doesPathExist files
       let withTime file = (file,) <$> getModificationTime file
       sortOn snd <$> mapM withTime filtered
-    process :: MonadIO m => FilePath -> UTCTime -> m (Maybe (FilePath, Text))
+    process :: FilePath -> UTCTime -> IO (Maybe (FilePath, Text))
     process file t =
       if allow file then let
-        handle :: IOException -> m ()
+        handle :: IOException -> IO ()
         handle e = do
           liftIO $ putStrLn $ "‼  Got an exception while reading: " <> file
           liftIO $ print (e :: IOException)
-        go :: MonadUnliftIO m => m (Maybe (FilePath, Text))
+        go :: IO (Maybe (FilePath, Text))
         go = liftIO $ do
           contents <- Data.Text.IO.readFile file
           prevs    <- readIORef previousFiles
@@ -118,18 +116,17 @@ watchDirectory dir allow = do
       else return Nothing
   queue <- TQueue.newIO
   gate <- liftIO newEmptyMVar
-  ctx <- UnliftIO.askUnliftIO
   -- We spawn a separate thread to siphon the file change events
   -- into a queue, which can be debounced using `collectUntilPause`
   enqueuer <- liftIO . forkIO $ do
     takeMVar gate -- wait until gate open before starting
     forever $ do
-      event@(file, _) <- UnliftIO.unliftIO ctx watcher
+      event@(file, _) <- watcher
       when (allow file) $
         STM.atomically $ TQueue.enqueue queue event
   pending <- newIORef =<< existingFiles
   let
-    await :: MonadIO m => m (FilePath, Text)
+    await :: IO (FilePath, Text)
     await = untilJust $ readIORef pending >>= \case
       [] -> do
         -- open the gate

--- a/parser-typechecker/src/Unison/Util/TQueue.hs
+++ b/parser-typechecker/src/Unison/Util/TQueue.hs
@@ -2,9 +2,8 @@ module Unison.Util.TQueue where
 
 import Unison.Prelude
 
-import UnliftIO (MonadUnliftIO)
 import UnliftIO.STM hiding (TQueue)
-import qualified UnliftIO.Async as Async
+import qualified Control.Concurrent.Async as Async
 
 import qualified Data.Sequence as S
 import Data.Sequence (Seq((:<|)), (|>))
@@ -64,8 +63,8 @@ enqueue (TQueue v count) a = do
   modifyTVar' v (|> a)
   modifyTVar' count (+1)
 
-raceIO :: MonadUnliftIO m => STM a -> STM b -> m (Either a b)
-raceIO a b = do
+raceIO :: MonadIO m => STM a -> STM b -> m (Either a b)
+raceIO a b = liftIO do
   aa <- Async.async $ atomically a
   ab <- Async.async $ atomically b
   Async.waitEitherCancel aa ab

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -141,7 +141,7 @@ library
     Unison.Runtime.Stack
     Unison.Server.Backend
     Unison.Server.CodebaseServer
-    Unison.Server.Endpoints.GetDefinitions 
+    Unison.Server.Endpoints.GetDefinitions
     Unison.Server.Endpoints.ListNamespace
     Unison.Server.Errors
     Unison.Server.QueryResult
@@ -243,6 +243,7 @@ library
     regex-base,
     regex-tdfa,
     safe,
+    safe-exceptions,
     servant,
     servant-docs,
     servant-openapi3,


### PR DESCRIPTION
## Overview

By changing the Codebase function `rootBranchUpdates  :: m (m (), m (Set Branch.Hash))` to `m (IO (), IO (Set Branch.Hash))`, we can generalize our constraints from `MonadUnliftIO m`, of which there aren't a ton of instances, to `(MonadIO m, MonadCatch m)`, of which there are.

## History
IIRC, we had originally introduced `MonadUnliftIO` because the file-watching library wanted us to pass in a handler in `IO` when we only had `m` at that point.  So we asked “How do we go `m ~> IO`?” and the answer was `MonadUnliftIO`.

## Interesting/controversial decisions

I autoformatted all of the imports in `FileCodebase.hs` using ormolu.

I didn’t remove the `unliftio` package dependency, because it also provides a bunch of wrappers around common `IO` functions, lifted to `MonadIO`.