### PR TITLE
Further decompiling improvements in the new runtime

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Decompile.hs
+++ b/parser-typechecker/src/Unison/Runtime/Decompile.hs
@@ -8,11 +8,11 @@ module Unison.Runtime.Decompile
 
 import Unison.Prelude
 
-import Unison.ABT (absChain, substs, pattern AbsN')
+import Unison.ABT (substs)
 import Unison.Term
   ( Term
   , nat, int, char, float, boolean, constructor, app, apps', text, ref
-  , list, list', builtin, termLink, typeLink
+  , list, list', builtin, termLink, typeLink, pattern LamNamed'
   )
 import Unison.Type
   ( natRef, intRef, charRef, floatRef, booleanRef, listRef
@@ -76,14 +76,12 @@ tag2bool 1 = Right True
 tag2bool _ = err "bad boolean tag"
 
 substitute :: Var v => Term v () -> [Term v ()] -> Term v ()
-substitute (AbsN' vs bd) ts = align [] vs ts
+substitute = align []
   where
-  align vts (v:vs) (t:ts) = align ((v,t):vts) vs ts
-  align vts vs [] = substs vts (absChain vs bd)
+  align vts (LamNamed' v bd) (t:ts) = align ((v,t):vts) bd ts
+  align vts tm [] = substs vts tm
   -- this should not happen
-  align vts [] ts = apps' (substs vts bd) ts
--- TODO: these aliases are not actually very conveniently written
-substitute _ _ = error "impossible"
+  align vts tm ts = apps' (substs vts tm) ts
 
 decompileUnboxed
   :: Var v => Reference -> Word64 -> Int -> Either Error (Term v ())

--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -196,7 +196,7 @@ backrefLifted tm@(Tm.LetRecNamed' bs _) dcmp
   = Map.fromList . ((0,tm):) $
   [ (ix, dc)
   | ix <- ixs
-  | (v, _) <- bs
+  | (v, _) <- reverse bs
   , dc <- maybeToList $ Prelude.lookup v dcmp
   ]
   where

--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -48,7 +48,6 @@ import Unison.PrettyPrintEnv
 import Unison.Util.Pretty as P
 import Unison.Symbol (Symbol)
 import Unison.TermPrinter
-import Unison.Var as Var
 
 import Unison.Runtime.ANF
 import Unison.Runtime.Builtin

--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -11,7 +11,7 @@ module Unison.Runtime.Interface
 
 import GHC.Stack (HasCallStack)
 
-import Unison.Prelude (reportBug)
+import Unison.Prelude (reportBug, maybeToList)
 import Control.Concurrent.STM as STM
 import Control.Exception (try)
 import Control.Monad
@@ -188,17 +188,20 @@ loadDeps cl ctx tm = do
       tyAdd = Set.fromList $ fst <$> tyrs
   backrefAdd rbkr ctx <$ cacheAdd0 tyAdd rgrp (ccache ctx)
 
-backrefLifted :: Term Symbol -> Map.Map Word64 (Term Symbol)
-backrefLifted tm@(Tm.LetRecNamed' bs _)
+backrefLifted
+  :: Term Symbol
+  -> [(Symbol, Term Symbol)]
+  -> Map.Map Word64 (Term Symbol)
+backrefLifted tm@(Tm.LetRecNamed' bs _) dcmp
   = Map.fromList . ((0,tm):) $
-  [ (ix, b)
+  [ (ix, dc)
   | ix <- ixs
-  | (v, b) <- bs
-  , Var.typeOf v == Float
+  | (v, _) <- bs
+  , dc <- maybeToList $ Prelude.lookup v dcmp
   ]
   where
   ixs = fmap (`shiftL` 16) [1..]
-backrefLifted tm = Map.singleton 0 tm
+backrefLifted tm _ = Map.singleton 0 tm
 
 intermediateTerms
   :: HasCallStack
@@ -223,7 +226,7 @@ intermediateTerm ctx tm
   . saturate (uncurryDspec $ dspec ctx)
   $ tm
   where
-  final ll = (superNormalize ll, backrefLifted ll)
+  final (ll, dcmp) = (superNormalize ll, backrefLifted ll dcmp)
 
 prepareEvaluation
   :: HasCallStack => Term Symbol -> EvalCtx -> IO (EvalCtx, Word64)

--- a/parser-typechecker/tests/Unison/Test/ANF.hs
+++ b/parser-typechecker/tests/Unison/Test/ANF.hs
@@ -58,6 +58,7 @@ testLift s = case cs of !_ -> ok
   where
   cs = emitCombs (RN (const 0) (const 0)) 0
      . superNormalize
+     . fst
      . lamLift
      $ tm s
 

--- a/parser-typechecker/tests/Unison/Test/MCode.hs
+++ b/parser-typechecker/tests/Unison/Test/MCode.hs
@@ -94,6 +94,7 @@ testEval s = testEval0 (env aux) main
   aux
     = emitCombs numbering (bit 24)
     . superNormalize
+    . fst
     . lamLift
     . splitPatterns builtinDataSpec
     . unannotate


### PR DESCRIPTION
This pull request fixes some bugs and makes it significantly more likely for values to be decompilable in the new runtime.

Partially applied lambdas weren't being decompiled very nicely. There was code that was supposed to substitute under the lambda, but it used the wrong pattern, and ended up never actually substituting. This is now fixed.

The binding group order ends up getting reversed when translating to supercombinators, so the last attempt to decompile local bindings was getting the numbering backwards. This turns out to still be relevant even with the changes below.

The floating pass now keeps track of original definitions for many floated bindings, and these are used for decompiling. The full floating pass now works as follows:

  1. Add arguments to all lambda expressions corresponding to their non-recursive free variables, together with applying the expanded lambda expression to the local variable
  2. Float every lambda expression to a top-level recursive let, remembering _closed_ lambda terms for decompilation

The latter part of step 2 works because step 1 has ensured that the only free variables in a lambda term correspond to (local, mutually) recursive functions. So every non-recursive local function is eligible for decompilation. The decompiled terms have already had step 1 performed, so they may have some redundant beta redexes. But those are equivalent to the original term, and it eliminates the decompilation causing ill scoped terms (I believe).