### PR TITLE
Don't ignore UCM_PORT environment variable

### DIFF
--- a/parser-typechecker/src/Unison/Server/CodebaseServer.hs
+++ b/parser-typechecker/src/Unison/Server/CodebaseServer.hs
@@ -6,88 +6,103 @@
 
 module Unison.Server.CodebaseServer where
 
-import           Data.Aeson                     ( )
-import qualified Data.ByteString.Lazy          as Lazy
-import qualified Data.ByteString               as Strict
-import qualified Data.ByteString.Char8         as C8
-import           Data.Monoid                    ( Endo(..), appEndo )
-import           Data.OpenApi                   ( URL(..)
-                                                , Info(..)
-                                                , License(..)
-                                                , OpenApi
-                                                )
-import           Data.Proxy                     ( Proxy(..) )
-import           GHC.Generics                   ( )
-import           Network.HTTP.Types.Status      ( ok200 )
-import           Network.Wai                    ( responseLBS
-                                                , Request
-                                                , queryString
-                                                )
-import           Network.Wai.Handler.Warp       ( withApplicationSettings
-                                                , defaultSettings
-                                                , Port
-                                                , setPort
-                                                , setHost
-                                                )
-import           Servant.API                    (Headers,  Get
-                                                , JSON
-                                                , Raw
-                                                , (:>)
-                                                , type (:<|>)(..)
-                                                )
-import           Servant.API.Experimental.Auth  ( AuthProtect )
-import           Servant.Server.Experimental.Auth
-                                                ( AuthHandler
-                                                , AuthServerData
-                                                , mkAuthHandler
-                                                )
-import           Servant.Docs                   ( DocIntro(DocIntro)
-                                                , docsWithIntros
-                                                , markdown
-                                                )
-import           Servant.Server                 ( Application
-                                                , Context(..)
-                                                , Server
-                                                , ServerError(..)
-                                                , Tagged(Tagged)
-                                                , err401
-                                                )
-import           Unison.Codebase                ( Codebase )
-import           Unison.Parser                  ( Ann )
-import           Unison.Server.Endpoints.ListNamespace
-                                                ( NamespaceAPI
-                                                , serveNamespace
-                                                )
-import           Unison.Server.Endpoints.GetDefinitions
-                                                ( DefinitionsAPI
-                                                , serveDefinitions
-                                                )
-import           Unison.Server.Endpoints.FuzzyFind
-                                                ( FuzzyFindAPI
-                                                , serveFuzzyFind
-                                                )
-import           Unison.Server.Types            ( mungeString )
-import           Unison.Var                     ( Var )
-import           Servant.OpenApi                ( HasOpenApi(toOpenApi) )
-import           Servant                        ( Header
-                                                , addHeader
-                                                , throwError
-                                                , serveWithContext
-                                                )
-import           Control.Lens                   ( (&)
-                                                , (.~)
-                                                )
-import           Data.OpenApi.Lens              ( info )
-import qualified Data.Text                     as Text
-import           Text.Read                      (readMaybe)
-import           Data.Foldable                  ( Foldable(toList) )
-import           System.Environment             (lookupEnv)
-import           System.Random.Stateful         ( getStdGen
-                                                , newAtomicGenM
-                                                , uniformByteStringM
-                                                )
-import qualified Data.ByteString.Base64        as Base64
-import           Data.String                    (fromString)
+import Control.Concurrent (newEmptyMVar, putMVar, readMVar)
+import Control.Concurrent.Async (race)
+import Control.Exception (throwIO, ErrorCall(..))
+import Control.Lens
+  ( (&),
+    (.~),
+  )
+import Data.Aeson ()
+import qualified Data.ByteString as Strict
+import qualified Data.ByteString.Base64 as Base64
+import qualified Data.ByteString.Char8 as C8
+import qualified Data.ByteString.Lazy as Lazy
+import Data.Foldable (Foldable (toList))
+import Data.Monoid (Endo (..), appEndo)
+import Data.OpenApi
+  ( Info (..),
+    License (..),
+    OpenApi,
+    URL (..),
+  )
+import Data.OpenApi.Lens (info)
+import Data.Proxy (Proxy (..))
+import Data.String (fromString)
+import qualified Data.Text as Text
+import GHC.Generics ()
+import Network.HTTP.Types.Status (ok200)
+import Network.Wai
+  ( Request,
+    queryString,
+    responseLBS,
+  )
+import Network.Wai.Handler.Warp
+  ( Port,
+    defaultSettings,
+    setHost,
+    setPort,
+    withApplicationSettings,
+    runSettings,
+    setBeforeMainLoop
+  )
+import Servant
+  ( Header,
+    addHeader,
+    serveWithContext,
+    throwError,
+  )
+import Servant.API
+  ( Get,
+    Headers,
+    JSON,
+    Raw,
+    (:>),
+    type (:<|>) (..),
+  )
+import Servant.API.Experimental.Auth (AuthProtect)
+import Servant.Docs
+  ( DocIntro (DocIntro),
+    docsWithIntros,
+    markdown,
+  )
+import Servant.OpenApi (HasOpenApi (toOpenApi))
+import Servant.Server
+  ( Application,
+    Context (..),
+    Server,
+    ServerError (..),
+    Tagged (Tagged),
+    err401,
+  )
+import Servant.Server.Experimental.Auth
+  ( AuthHandler,
+    AuthServerData,
+    mkAuthHandler,
+  )
+import System.Environment (lookupEnv)
+import System.Random.Stateful
+  ( getStdGen,
+    newAtomicGenM,
+    uniformByteStringM,
+  )
+import Text.Read (readMaybe)
+import Unison.Codebase (Codebase)
+import Unison.Parser (Ann)
+import Unison.Server.Endpoints.FuzzyFind
+  ( FuzzyFindAPI,
+    serveFuzzyFind,
+  )
+import Unison.Server.Endpoints.GetDefinitions
+  ( DefinitionsAPI,
+    serveDefinitions,
+  )
+import Unison.Server.Endpoints.ListNamespace
+  ( NamespaceAPI,
+    serveNamespace,
+  )
+import Unison.Server.Types (mungeString)
+import Unison.Var (Var)
 
 type OpenApiJSON = "openapi.json"
   :> Get '[JSON] (Headers '[Header "Access-Control-Allow-Origin" String] OpenApi)
@@ -147,6 +162,20 @@ genToken = do
   g   <- newAtomicGenM gen
   Base64.encode <$> uniformByteStringM 24 g
 
+data Waiter a
+  = Waiter {
+    notify :: a -> IO (),
+    waitFor :: IO a
+  }
+
+mkWaiter :: IO (Waiter a)
+mkWaiter = do
+  mvar <- newEmptyMVar
+  return Waiter {
+    notify = putMVar mvar,
+    waitFor = readMVar mvar
+  }
+
 -- The auth token required for accessing the server is passed to the function k
 start
   :: Var v => Codebase IO v Ann -> (Strict.ByteString -> Port -> IO ()) -> IO ()
@@ -163,7 +192,17 @@ start codebase k = do
         )
         defaultSettings
       a = app codebase token
-  withApplicationSettings settings (pure a) (k token)
+  case envPort of
+    Nothing -> withApplicationSettings settings (pure a) (k token)
+    Just p -> do
+      started <- mkWaiter
+      let settings' = setBeforeMainLoop (notify started ()) settings
+      result <- race
+                  (runSettings settings' a)
+                  (waitFor started *> k token p)
+      case result of
+        Left () -> throwIO $ ErrorCall "Server exited unexpectedly!"
+        Right x -> pure x
 
 server :: Var v => Codebase IO v Ann -> Server DocAPI
 server codebase _ =

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -165,6 +165,7 @@ main = do
         PT.putPrettyLn . P.string $ "I've started a codebase API server at "
         PT.putPrettyLn . P.string $ "http://127.0.0.1:"
           <> show port <> "?" <> URI.encode (unpack token)
+        PT.putPrettyLn' . P.string $ "Now starting the Unison Codebase Manager..."
         launch currentDir mNewRun config theCodebase branchCache []
     [version] | isFlag "version" version ->
       putStrLn $ progName ++ " version: " ++ Version.gitDescribe


### PR DESCRIPTION
Fixes #1878

WAI will by default ignore the `port` setting when started with the asynchronous `withApplicationSettings`. There's an alternative synchronous start `runSettings`, and this PR calls that instead, with some async wrapping and MVar sync.