### PR TITLE
Suffixify binding names in the definitions API

### DIFF
--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -601,7 +601,7 @@ prettyDefinitionsBySuffixes relativeTo root renderWidth suffixifyBindings codeba
           mungeSyntaxText
           tp
     typeDefinitions <- Map.traverseWithKey mkTypeDefinition
-      $ typesToSyntax width ppe types
+      $ typesToSyntax suffixifyBindings width ppe types
     termDefinitions <- Map.traverseWithKey mkTermDefinition
       $ termsToSyntax suffixifyBindings width ppe terms
     let renderedDisplayTerms = Map.mapKeys Reference.toText termDefinitions
@@ -703,7 +703,9 @@ termsToSyntax suff width ppe0 terms =
     (first (PPE.termName ppeDecl . Referent.Ref) . dupe)
     terms
  where
-  ppeBody r = PPE.declarationPPE ppe0 r
+  ppeBody r = if suffixified suff
+    then PPE.suffixifiedPPE ppe0
+    else PPE.declarationPPE ppe0 r
   ppeDecl =
     (if suffixified suff then PPE.suffixifiedPPE else PPE.unsuffixifiedPPE) ppe0
   go ((n, r), dt) =
@@ -712,17 +714,22 @@ termsToSyntax suff width ppe0 terms =
 typesToSyntax
   :: Var v
   => Ord a
-  => Width
+  => Suffixify
+  -> Width
   -> PPE.PrettyPrintEnvDecl
   -> Map Reference.Reference (DisplayObject (DD.Decl v a))
   -> Map Reference.Reference (DisplayObject SyntaxText)
-typesToSyntax width ppe0 types =
+typesToSyntax suff width ppe0 types =
   Map.fromList $ map go . Map.toList $ Map.mapKeys
     (first (PPE.typeName ppeDecl) . dupe)
     types
  where
-  ppeBody r = PPE.declarationPPE ppe0 r
-  ppeDecl = PPE.unsuffixifiedPPE ppe0
+  ppeBody r = if suffixified suff
+    then PPE.suffixifiedPPE ppe0
+    else PPE.declarationPPE ppe0 r
+  ppeDecl = if suffixified suff
+    then PPE.suffixifiedPPE ppe0
+    else PPE.unsuffixifiedPPE ppe0
   go ((n, r), dt) =
     ( r
     , (\case

--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -532,20 +532,23 @@ prettyDefinitionsBySuffixes
   => Maybe Path
   -> Maybe Branch.Hash
   -> Maybe Width
+  -> Suffixify
   -> Codebase m v Ann
   -> [HQ.HashQualified Name]
   -> Backend m DefinitionDisplayResults
-prettyDefinitionsBySuffixes relativeTo root renderWidth codebase query = do
-  branch                               <- resolveBranchHash root codebase
-  DefinitionResults terms types misses <- definitionsBySuffixes relativeTo
-                                                                branch
-                                                                codebase
-                                                                query
-  hqLength <- lift $ Codebase.hashLength codebase
-  -- We might like to make sure that the user search terms get used as
-  -- the names in the pretty-printer, but the current implementation
-  -- doesn't.
-  let printNames =
+prettyDefinitionsBySuffixes relativeTo root renderWidth suffixifyBindings codebase query
+  = do
+    branch                               <- resolveBranchHash root codebase
+    DefinitionResults terms types misses <- definitionsBySuffixes relativeTo
+                                                                  branch
+                                                                  codebase
+                                                                  query
+    hqLength <- lift $ Codebase.hashLength codebase
+    -- We might like to make sure that the user search terms get used as
+    -- the names in the pretty-printer, but the current implementation
+    -- doesn't.
+    let
+      printNames =
         getCurrentPrettyNames (fromMaybe Path.empty relativeTo) branch
       parseNames =
         getCurrentParseNames (fromMaybe Path.empty relativeTo) branch
@@ -590,21 +593,23 @@ prettyDefinitionsBySuffixes relativeTo root renderWidth codebase query = do
             $ prettyType width ppe typeSig
       mkTypeDefinition r tp = do
         let bn = bestNameForType @v (PPE.suffixifiedPPE ppe) width r
-        tag <- Just . typeEntryTag
-          <$> typeListEntry codebase r (HQ'.NameOnly (NameSegment bn))
+        tag <- Just . typeEntryTag <$> typeListEntry
+          codebase
+          r
+          (HQ'.NameOnly (NameSegment bn))
         pure . TypeDefinition (flatten $ Map.lookup r typeFqns) bn tag $ fmap
           mungeSyntaxText
           tp
-  typeDefinitions <- Map.traverseWithKey mkTypeDefinition
-    $ typesToSyntax width ppe types
-  termDefinitions <- Map.traverseWithKey mkTermDefinition
-    $ termsToSyntax width ppe terms
-  let renderedDisplayTerms = Map.mapKeys Reference.toText termDefinitions
-      renderedDisplayTypes = Map.mapKeys Reference.toText typeDefinitions
-      renderedMisses       = fmap HQ.toText misses
-  pure $ DefinitionDisplayResults renderedDisplayTerms
-                                  renderedDisplayTypes
-                                  renderedMisses
+    typeDefinitions <- Map.traverseWithKey mkTypeDefinition
+      $ typesToSyntax width ppe types
+    termDefinitions <- Map.traverseWithKey mkTermDefinition
+      $ termsToSyntax suffixifyBindings width ppe terms
+    let renderedDisplayTerms = Map.mapKeys Reference.toText termDefinitions
+        renderedDisplayTypes = Map.mapKeys Reference.toText typeDefinitions
+        renderedMisses       = fmap HQ.toText misses
+    pure $ DefinitionDisplayResults renderedDisplayTerms
+                                    renderedDisplayTypes
+                                    renderedMisses
 
 bestNameForTerm
   :: forall v . Var v => PPE.PrettyPrintEnv -> Width -> Referent -> Text
@@ -688,17 +693,19 @@ definitionsBySuffixes relativeTo branch codebase query = do
 termsToSyntax
   :: Var v
   => Ord a
-  => Width
+  => Suffixify
+  -> Width
   -> PPE.PrettyPrintEnvDecl
   -> Map Reference.Reference (DisplayObject (Term v a))
   -> Map Reference.Reference (DisplayObject SyntaxText)
-termsToSyntax width ppe0 terms =
+termsToSyntax suff width ppe0 terms =
   Map.fromList . map go . Map.toList $ Map.mapKeys
     (first (PPE.termName ppeDecl . Referent.Ref) . dupe)
     terms
  where
   ppeBody r = PPE.declarationPPE ppe0 r
-  ppeDecl = PPE.unsuffixifiedPPE ppe0
+  ppeDecl =
+    (if suffixified suff then PPE.suffixifiedPPE else PPE.unsuffixifiedPPE) ppe0
   go ((n, r), dt) =
     (r, Pretty.render width . TermPrinter.prettyBinding (ppeBody r) n <$> dt)
 

--- a/parser-typechecker/src/Unison/Server/Endpoints/FuzzyFind.hs
+++ b/parser-typechecker/src/Unison/Server/Endpoints/FuzzyFind.hs
@@ -48,6 +48,7 @@ import           Unison.Server.Types            ( mayDefault
                                                 , NamedType
                                                 , DefinitionDisplayResults(..)
                                                 , TypeDefinition(..)
+                                                , Suffixify(..)
                                                 )
 import           Unison.Util.Pretty             ( Width )
 import           Unison.Var                     ( Var )
@@ -173,6 +174,7 @@ serveFuzzyFind codebase mayRoot relativePath limit typeWidth query = do
           rel
           root
           typeWidth
+          (Suffixify True)
           codebase
           [HQ.HashOnly $ Reference.toShortHash r]
         let

--- a/parser-typechecker/src/Unison/Server/Endpoints/GetDefinitions.hs
+++ b/parser-typechecker/src/Unison/Server/Endpoints/GetDefinitions.hs
@@ -46,6 +46,7 @@ type DefinitionsAPI =
                   :> QueryParam "relativeTo" HashQualifiedName
                   :> QueryParams "names" HashQualifiedName
                   :> QueryParam "renderWidth" Width
+                  :> QueryParam "suffixifyBindings" Suffixify
   :> Get '[JSON] DefinitionDisplayResults
 
 instance ToParam (QueryParam "renderWidth" Width) where
@@ -59,6 +60,16 @@ instance ToParam (QueryParam "renderWidth" Width) where
     <> "."
     )
     Normal
+
+instance ToParam (QueryParam "suffixifyBindings" Suffixify) where
+  toParam _ = DocQueryParam
+    "suffixifyBindings"
+    ["True", "False"]
+    (  "If True or absent, renders definitions using the shortest unambiguous "
+    <> "suffix. If False, uses the fully qualified name. "
+    )
+    Normal
+
 
 instance ToParam (QueryParam "relativeTo" HashQualifiedName) where
   toParam _ = DocQueryParam
@@ -95,12 +106,17 @@ serveDefinitions
   -> Maybe HashQualifiedName
   -> [HashQualifiedName]
   -> Maybe Width
+  -> Maybe Suffixify
   -> Handler DefinitionDisplayResults
-serveDefinitions codebase mayRoot relativePath hqns width = do
+serveDefinitions codebase mayRoot relativePath hqns width suff = do
   rel <- fmap Path.fromPath' <$> traverse (parsePath . Text.unpack) relativePath
   ea  <- liftIO . runExceptT $ do
     root <- traverse (Backend.expandShortBranchHash codebase) mayRoot
-    Backend.prettyDefinitionsBySuffixes rel root width (Suffixify True) codebase
+    Backend.prettyDefinitionsBySuffixes rel
+                                        root
+                                        width
+                                        (fromMaybe (Suffixify True) suff)
+                                        codebase
       $   HQ.unsafeFromText
       <$> hqns
   errFromEither backendError ea

--- a/parser-typechecker/src/Unison/Server/Endpoints/GetDefinitions.hs
+++ b/parser-typechecker/src/Unison/Server/Endpoints/GetDefinitions.hs
@@ -29,6 +29,7 @@ import qualified Unison.Server.Backend         as Backend
 import           Unison.Server.Types            ( HashQualifiedName
                                                 , DefinitionDisplayResults
                                                 , defaultWidth
+                                                , Suffixify(..)
                                                 )
 import           Unison.Server.Errors           ( backendError
                                                 , badNamespace
@@ -45,6 +46,7 @@ type DefinitionsAPI =
                   :> QueryParam "relativeTo" HashQualifiedName
                   :> QueryParams "names" HashQualifiedName
                   :> QueryParam "renderWidth" Width
+                  :> QueryParam "suffixifyBindings" Suffixify
   :> Get '[JSON] DefinitionDisplayResults
 
 instance ToParam (QueryParam "renderWidth" Width) where
@@ -58,6 +60,17 @@ instance ToParam (QueryParam "renderWidth" Width) where
     <> "."
     )
     Normal
+
+instance ToParam (QueryParam "suffixifyBindings" Suffixify) where
+  toParam _ = DocQueryParam
+    "suffixifyBindings"
+    ["True", "False"]
+    (  "If True, renders definitions using the shortest unambiguous "
+    <> "suffix. If False, uses the fully qualified name. "
+    <> "If left absent, assumed to be False."
+    )
+    Normal
+
 
 instance ToParam (QueryParam "relativeTo" HashQualifiedName) where
   toParam _ = DocQueryParam
@@ -94,12 +107,17 @@ serveDefinitions
   -> Maybe HashQualifiedName
   -> [HashQualifiedName]
   -> Maybe Width
+  -> Maybe Suffixify
   -> Handler DefinitionDisplayResults
-serveDefinitions codebase mayRoot relativePath hqns width = do
+serveDefinitions codebase mayRoot relativePath hqns width suff = do
   rel <- fmap Path.fromPath' <$> traverse (parsePath . Text.unpack) relativePath
   ea  <- liftIO . runExceptT $ do
     root <- traverse (Backend.expandShortBranchHash codebase) mayRoot
-    Backend.prettyDefinitionsBySuffixes rel root width codebase
+    Backend.prettyDefinitionsBySuffixes rel
+                                        root
+                                        width
+                                        (fromMaybe (Suffixify False) suff)
+                                        codebase
       $   HQ.unsafeFromText
       <$> hqns
   errFromEither backendError ea

--- a/parser-typechecker/src/Unison/Server/Types.hs
+++ b/parser-typechecker/src/Unison/Server/Types.hs
@@ -47,6 +47,9 @@ instance ToJSON Name where
     toEncoding = genericToEncoding defaultOptions
 deriving instance ToSchema Name
 
+deriving via Bool instance FromHttpApiData Suffixify
+deriving instance ToParamSchema Suffixify
+
 deriving via Text instance FromHttpApiData ShortBranchHash
 deriving instance ToParamSchema ShortBranchHash
 
@@ -85,6 +88,9 @@ instance ToJSON DefinitionDisplayResults where
    toEncoding = genericToEncoding defaultOptions
 
 deriving instance ToSchema DefinitionDisplayResults
+
+newtype Suffixify = Suffixify { suffixified :: Bool }
+  deriving (Eq, Ord, Show, Generic)
 
 data TermDefinition = TermDefinition
   { termNames :: [HashQualifiedName]


### PR DESCRIPTION
This uses the `bestName` as the name being defined when rendering a type or term binding on the API backend.
The endpoint includes a new parameter `suffixifyBindings`, which can be set to `False` to disable this (it defaults to `True`).