### PR TITLE
Fix to anonymous doc name selection

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1074,9 +1074,11 @@ loop = do
 
         fileByName = do
           ns <- maybe mempty UF.typecheckedToNames0 <$> use latestTypecheckedFile
-          fnames <- pure $ Names3.Names ns mempty
+          fnames <- pure $ Names3.suffixify (Names3.Names ns mempty)
           case Names3.lookupHQTerm dotDoc fnames of
-            s | Set.size s == 1 -> displayI ConsoleLocation dotDoc
+            s | Set.size s == 1 -> do
+              fname' <- pure $ Names3.longestTermName 10 (Set.findMin s) fnames
+              displayI ConsoleLocation fname'
             _ -> codebaseByMetadata
 
         codebaseByMetadata = unlessError do

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1077,6 +1077,8 @@ loop = do
           fnames <- pure $ Names3.suffixify (Names3.Names ns mempty)
           case Names3.lookupHQTerm dotDoc fnames of
             s | Set.size s == 1 -> do
+              -- the displayI command expects full term names, so we resolve
+              -- the hash back to its full name in the file
               fname' <- pure $ Names3.longestTermName 10 (Set.findMin s) fnames
               displayI ConsoleLocation fname'
             _ -> codebaseByMetadata

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -301,7 +301,7 @@ lexemes' eof = P.optional space >> do
     --   ability Foo where      =>   ability Foo where
     tn <- subsequentTypeName
     pure $ case (tn, docToks) of
-      (Just tname, ht:_) | isTopLevel ->
+      (Just (WordyId tname _), ht:_) | isTopLevel ->
           startToks
           <> [WordyId (tname <> ".doc") Nothing <$ ht, Open "=" <$ ht]
           <> docToks0
@@ -314,8 +314,7 @@ lexemes' eof = P.optional space >> do
     subsequentTypeName = P.lookAhead . P.optional $ do
       let lit' s = lit s <* sp
       _ <- P.optional (lit' "unique") *> (lit' "type" <|> lit' "ability")
-      name <- P.takeWhile1P Nothing wordyIdChar
-      pure name
+      wordyId
     ignore _ _ _ = []
     body = join <$> P.many (sectionElem <* CP.space)
     sectionElem = section <|> fencedBlock <|> list <|> paragraph

--- a/unison-core/src/Unison/Name.hs
+++ b/unison-core/src/Unison/Name.hs
@@ -21,6 +21,7 @@ module Unison.Name
   , stripNamePrefix
   , stripPrefixes
   , segments
+  , countSegments
   , segments'
   , suffixes
   , toString
@@ -176,6 +177,9 @@ fromSegment = unsafeFromText . NameSegment.toText
 -- e.g. split `base..` into `[base,.]`
 segments :: Name -> [NameSegment]
 segments (Name n) = NameSegment <$> segments' n
+
+countSegments :: Name -> Int
+countSegments n = length (segments n)
 
 class Convert a b where
   convert :: a -> b

--- a/unison-core/src/Unison/Names3.hs
+++ b/unison-core/src/Unison/Names3.hs
@@ -169,6 +169,20 @@ typeName length r Names{..} =
   where hq n = HQ'.take length (HQ'.fromNamedReference n r)
         isConflicted n = R.manyDom n (Names.types currentNames)
 
+-- List of names for a referent, longer names (by number of segments) first.
+termNamesByLength :: Int -> Referent -> Names -> [HQ'.HashQualified Name]
+termNamesByLength length r ns =
+  sortOn len (toList $ termName length r ns)
+  where len (HQ'.NameOnly n) = Name.countSegments n
+        len (HQ'.HashQualified n _) = Name.countSegments n
+
+-- The longest term name (by segment count) for a `Referent`.
+longestTermName :: Int -> Referent -> Names -> HQ.HashQualified Name
+longestTermName length r ns =
+  case reverse (termNamesByLength length r ns) of
+    [] -> HQ.take length (HQ.fromReferent r)
+    (h : _) -> Name.convert h
+
 termName :: Int -> Referent -> Names -> Set (HQ'.HashQualified Name)
 termName length r Names{..} =
   if R.memberRan r . Names.terms $ currentNames

--- a/unison-src/new-runtime-transcripts/doc.md
+++ b/unison-src/new-runtime-transcripts/doc.md
@@ -29,7 +29,7 @@ The 7 days of the week, defined as:
 
   @source{type DayOfWeek}
 }}
-unique type DayOfWeek = Sun | Mon | Tue | Wed | Thu | Fri | Sat
+unique type time.DayOfWeek = Sun | Mon | Tue | Wed | Thu | Fri | Sat
 ```
 
 Notice that an anonymous documentation block `{{ ... }}` before a definition `ImportantConstant` is just syntax sugar for `ImportantConstant.doc = {{ ... }}`.

--- a/unison-src/new-runtime-transcripts/doc.output.md
+++ b/unison-src/new-runtime-transcripts/doc.output.md
@@ -25,7 +25,7 @@ The 7 days of the week, defined as:
 
   @source{type DayOfWeek}
 }}
-unique type DayOfWeek = Sun | Mon | Tue | Wed | Thu | Fri | Sat
+unique type time.DayOfWeek = Sun | Mon | Tue | Wed | Thu | Fri | Sat
 ```
 
 ```ucm
@@ -36,12 +36,12 @@ unique type DayOfWeek = Sun | Mon | Tue | Wed | Thu | Fri | Sat
   
     ⍟ These new definitions are ok to `add`:
     
-      unique type DayOfWeek
-      DayOfWeek.doc         : Doc2
+      unique type time.DayOfWeek
       ImportantConstant     : Nat
       ImportantConstant.doc : Doc2
       d1                    : Doc2
       name                  : Doc2
+      time.DayOfWeek.doc    : Doc2
 
 ```
 Notice that an anonymous documentation block `{{ ... }}` before a definition `ImportantConstant` is just syntax sugar for `ImportantConstant.doc = {{ ... }}`.


### PR DESCRIPTION
Uncontroversial fix for a thing I noticed with new docs (#1853). Prior to this PR, an anonymous documentation block attached to a type `foo.Bar` in the file would get incorrectly called `foo.doc` instead of `foo.Bar.doc`:

```Haskell
{{ Some docs }}
type foo.Bar = Blah
```

Also `.> docs Bar` wouldn't work for definitions in the file, you'd need to say `docs foo.Bar`, using the full relative name. 

This PR fixes both these issues and tweaks the docs transcript to exercise the new behavior.