### PR TITLE
Fix issue with Bytes.at always returning `None` in new runtime

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Machine.hs
+++ b/parser-typechecker/src/Unison/Runtime/Machine.hs
@@ -1289,7 +1289,7 @@ bprim2 !ustk !bstk IDXB i j = do
     Just x -> do
       poke ustk $ fromIntegral x
       ustk <- bump ustk
-      ustk <$ poke ustk 0
+      ustk <$ poke ustk 1
   pure (ustk, bstk)
 bprim2 !ustk !bstk CATB i j = do
   l <- peekOffBi bstk i

--- a/parser-typechecker/tests/Unison/Test/Util/Bytes.hs
+++ b/parser-typechecker/tests/Unison/Test/Util/Bytes.hs
@@ -17,6 +17,11 @@ test = scope "util.bytes" . tests $ [
     ==
     Bytes.fromWord8s [0,1,2,3,4,5,6,7,8,9],
 
+  scope "at" $ do
+    expect' (Bytes.at 0 (Bytes.fromWord8s [77,13,12]) == Just 77)
+    expect' (Bytes.at 0 (Bytes.fromWord8s []) == Nothing)
+    ok,
+
   scope "consistency with ByteString" $ do
     forM_ [(1::Int)..100] $ \_ -> do
       n <- int' 0 50

--- a/parser-typechecker/tests/Unison/Test/Util/Bytes.hs
+++ b/parser-typechecker/tests/Unison/Test/Util/Bytes.hs
@@ -22,6 +22,12 @@ test = scope "util.bytes" . tests $ [
     expect' (Bytes.at 0 (Bytes.fromWord8s []) == Nothing)
     ok,
 
+  scope "at.cornerCases" $ do
+    let b = Bytes.drop 3 $ Bytes.fromWord8s [77,13,12] <> Bytes.fromWord8s [9,10,11]
+    expect' (Bytes.at 0 b == Just 9)
+    expect' (Bytes.at 0 (mempty <> Bytes.fromWord8s [1,2,3]) == Just 1)
+    ok,
+
   scope "consistency with ByteString" $ do
     forM_ [(1::Int)..100] $ \_ -> do
       n <- int' 0 50

--- a/unison-src/new-runtime-transcripts/builtins.md
+++ b/unison-src/new-runtime-transcripts/builtins.md
@@ -1,5 +1,11 @@
 # Unit tests for builtin functions
 
+```ucm:hide
+.> builtins.mergeio
+.> load unison-src/new-runtime-transcripts/base.u
+.> add
+```
+
 This transcript defines unit tests for builtin functions. There's a single `.> test` execution at the end that will fail the transcript with a nice report if any of the tests fail.
 
 ## `Int` functions
@@ -180,12 +186,16 @@ test> Text.tests.alignment =
 ## `Bytes` functions
 
 ```unison
+(===) a b =
+  if a == b then true
+  else bug ("not equal", a, b)
+
 test> Bytes.tests.at =
         bs = Bytes.fromList [77, 13, 12]
         checks [
-          Bytes.at 0 bs == Some 77,
-          Bytes.at 1 bs == Some 13,
-          Bytes.at 99 bs == None
+          Bytes.at 1 bs === Some 13,
+          Bytes.at 0 bs === Some 77,
+          Bytes.at 99 bs === None
         ]
 ```
 

--- a/unison-src/new-runtime-transcripts/builtins.md
+++ b/unison-src/new-runtime-transcripts/builtins.md
@@ -1,11 +1,5 @@
 # Unit tests for builtin functions
 
-```ucm:hide
-.> builtins.mergeio
-.> load unison-src/new-runtime-transcripts/base.u
-.> add
-```
-
 This transcript defines unit tests for builtin functions. There's a single `.> test` execution at the end that will fail the transcript with a nice report if any of the tests fail.
 
 ## `Int` functions
@@ -185,17 +179,13 @@ test> Text.tests.alignment =
 
 ## `Bytes` functions
 
-```unison
-(===) a b =
-  if a == b then true
-  else bug ("not equal", a, b)
-
+```unison:hide
 test> Bytes.tests.at =
         bs = Bytes.fromList [77, 13, 12]
         checks [
-          Bytes.at 1 bs === Some 13,
-          Bytes.at 0 bs === Some 77,
-          Bytes.at 99 bs === None
+          Bytes.at 1 bs == Some 13,
+          Bytes.at 0 bs == Some 77,
+          Bytes.at 99 bs == None
         ]
 ```
 

--- a/unison-src/new-runtime-transcripts/builtins.md
+++ b/unison-src/new-runtime-transcripts/builtins.md
@@ -177,6 +177,22 @@ test> Text.tests.alignment =
 .> add
 ```
 
+## `Bytes` functions
+
+```unison
+test> Bytes.tests.at =
+        bs = Bytes.fromList [77, 13, 12]
+        checks [
+          Bytes.at 0 bs == Some 77,
+          Bytes.at 1 bs == Some 13,
+          Bytes.at 99 bs == None
+        ]
+```
+
+```ucm:hide
+.> add
+```
+
 ## `Any` functions
 
 ```unison

--- a/unison-src/new-runtime-transcripts/builtins.output.md
+++ b/unison-src/new-runtime-transcripts/builtins.output.md
@@ -165,6 +165,18 @@ test> Text.tests.alignment =
       ]
 ```
 
+## `Bytes` functions
+
+```unison
+test> Bytes.tests.at =
+        bs = Bytes.fromList [77, 13, 12]
+        checks [
+          Bytes.at 1 bs == Some 13,
+          Bytes.at 0 bs == Some 77,
+          Bytes.at 99 bs == None
+        ]
+```
+
 ## `Any` functions
 
 ```unison
@@ -212,6 +224,7 @@ Now that all the tests have been added to the codebase, let's view the test repo
   
   ◉ Any.test1                   Passed
   ◉ Any.test2                   Passed
+  ◉ Bytes.tests.at              Passed
   ◉ Int.tests.arithmetic        Passed
   ◉ Int.tests.bitTwiddling      Passed
   ◉ Int.tests.conversions       Passed
@@ -222,7 +235,7 @@ Now that all the tests have been added to the codebase, let's view the test repo
   ◉ Text.tests.repeat           Passed
   ◉ Text.tests.takeDropAppend   Passed
   
-  ✅ 11 test(s) passing
+  ✅ 12 test(s) passing
   
   Tip: Use view Any.test1 to view the source of a test.
 


### PR DESCRIPTION
Fixes #1888 

@dolio can you review? I took a guess that the `None` tag was being written to the unboxed stack even when the index was found. But see my self review for questions on the fix.