### PR TITLE
add debug.dump-namespace command

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -7,6 +7,7 @@
 module Unison.Codebase.Branch
   ( -- * Branch types
     Branch(..)
+  , UnwrappedBranch
   , Branch0(..)
   , MergeMode(..)
   , Raw(..)
@@ -160,8 +161,9 @@ import Unison.LabeledDependency (LabeledDependency)
 
 -- | A node in the Unison namespace hierarchy
 -- along with its history.
-newtype Branch m = Branch { _history :: Causal m Raw (Branch0 m) }
+newtype Branch m = Branch { _history :: UnwrappedBranch m }
   deriving (Eq, Ord)
+type UnwrappedBranch m = Causal m Raw (Branch0 m)
 
 type Hash = Causal.RawHash Raw
 type EditHash = Hash.Hash
@@ -488,7 +490,7 @@ numHashChars _b = 3
 
 -- This type is a little ugly, so we wrap it up with a nice type alias for
 -- use outside this module.
-type Cache m = Cache.Cache m (Causal.RawHash Raw) (Causal m Raw (Branch0 m))
+type Cache m = Cache.Cache m (Causal.RawHash Raw) (UnwrappedBranch m)
 
 boundedCache :: MonadIO m => Word -> m (Cache m)
 boundedCache = Cache.semispaceCache

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -136,6 +136,7 @@ data Input
   | DebugNumberedArgsI
   | DebugBranchHistoryI
   | DebugTypecheckedUnisonFileI
+  | DebugDumpNamespacesI
   | QuitI
   deriving (Eq, Show)
 

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -54,8 +54,9 @@ import qualified Data.Set as Set
 import Unison.NameSegment (NameSegment)
 import Unison.ShortHash (ShortHash)
 import Unison.Codebase.ShortBranchHash (ShortBranchHash)
-import Unison.Codebase.Editor.RemoteRepo as RemoteRepo
+import Unison.Codebase.Editor.RemoteRepo
 import Unison.Codebase.Editor.Output.BranchDiff (BranchDiffOutput)
+import Unison.Codebase.Editor.Output.DumpNamespace (DumpNamespace)
 import Unison.LabeledDependency (LabeledDependency)
 
 type ListDetailed = Bool
@@ -205,6 +206,7 @@ data Output v
   | DumpNumberedArgs NumberedArgs
   | DumpBitBooster Branch.Hash (Map Branch.Hash [Branch.Hash])
   | DumpUnisonFileHashes Int [(Name, Reference.Id)] [(Name, Reference.Id)] [(Name, Reference.Id)]
+  | DumpNamespace (Map Branch.Hash DumpNamespace)
   | BadName String
   | DefaultMetadataNotification
   | BadRootBranch GetRootBranchError
@@ -325,6 +327,7 @@ isFailure o = case o of
   ListDependents{} -> False
   TermMissingType{} -> True
   DumpUnisonFileHashes _ x y z -> x == mempty && y == mempty && z == mempty
+  DumpNamespace _ -> False
 
 isNumberedFailure :: NumberedOutput v -> Bool
 isNumberedFailure = \case

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output/DumpNamespace.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output/DumpNamespace.hs
@@ -1,0 +1,17 @@
+module Unison.Codebase.Editor.Output.DumpNamespace where
+
+import Data.Map (Map)
+import Unison.NameSegment (NameSegment)
+import Unison.Referent (Referent)
+import Data.Set (Set)
+import Unison.Reference (Reference)
+import qualified Unison.Codebase.Branch as Branch
+
+data DumpNamespace = DumpNamespace {
+  terms :: Map Referent (Set NameSegment, Set Reference),
+  types :: Map Reference (Set NameSegment, Set Reference),
+  patches :: Map NameSegment Branch.EditHash,
+  children :: Map NameSegment Branch.Hash,
+  causalParents :: Set Branch.Hash
+} deriving Show
+

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -1303,6 +1303,12 @@ debugFileHashes = InputPattern "debug.file" [] []
   "View details about the most recent succesfully typechecked file."
   (const $ Right Input.DebugTypecheckedUnisonFileI)
 
+debugDumpNamespace :: InputPattern
+debugDumpNamespace = InputPattern
+  "debug.dump-namespace" [] [(Required, noCompletions)]
+  "Dump the namespace to a text file"
+  (const $ Right Input.DebugDumpNamespacesI)
+
 test :: InputPattern
 test = InputPattern "test" [] []
     "`test` runs unit tests for the current branch."
@@ -1430,6 +1436,7 @@ validInputs =
   , debugNumberedArgs
   , debugBranchHistory
   , debugFileHashes
+  , debugDumpNamespace
   ]
 
 commandNames :: [String]

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -23,6 +23,7 @@ import Unison.Server.Backend (ShallowListEntry(..), TermEntry(..), TypeEntry(..)
 import           Control.Lens
 import qualified Control.Monad.State.Strict    as State
 import           Data.Bifunctor                (first, second)
+import qualified Data.Foldable as Foldable
 import           Data.List                     (sort, stripPrefix)
 import           Data.List.Extra               (nubOrdOn, nubOrd, notNull)
 import qualified Data.Map                      as Map
@@ -62,6 +63,7 @@ import qualified Unison.HashQualified          as HQ
 import qualified Unison.HashQualified'         as HQ'
 import           Unison.Name                   (Name)
 import qualified Unison.Name                   as Name
+import Unison.NameSegment (NameSegment(NameSegment))
 import           Unison.NamePrinter            (prettyHashQualified,
                                                 prettyReference, prettyReferent,
                                                 prettyLabeledDependency,
@@ -101,6 +103,7 @@ import           Unison.Var                    (Var)
 import qualified Unison.Var                    as Var
 import qualified Unison.Codebase.Editor.SlurpResult as SlurpResult
 import Unison.Codebase.Editor.DisplayObject (DisplayObject(MissingObject, BuiltinObject, UserObject))
+import qualified Unison.Codebase.Editor.Output.DumpNamespace as DN
 import qualified Unison.Codebase.Editor.Input as Input
 import qualified Unison.Hash as Hash
 import qualified Unison.Codebase.Causal as Causal
@@ -1030,6 +1033,22 @@ notifyUser dir o = case o of
       "",
       "Paste that output into http://bit-booster.com/graph.html"
       ]
+  -- DumpNamespace m -> pure $ P.shown m
+  DumpNamespace m -> let
+    prettyDump (h, DN.DumpNamespace terms types patches children causalParents) =
+      P.lit "Namespace " <> P.shown h <> P.newline <> (P.indentN 2 $ P.linesNonEmpty [
+        Monoid.unlessM (null causalParents) $ P.lit "Causal Parents:" <> P.newline <> P.indentN 2 (P.lines (map P.shown $ Set.toList causalParents))
+      , Monoid.unlessM (null terms) $ P.lit "Terms:" <> P.newline <> P.indentN 2 (P.lines (map (prettyDefn Referent.toText) $ Map.toList terms))
+      , Monoid.unlessM (null types) $ P.lit "Types:" <> P.newline <> P.indentN 2 (P.lines (map (prettyDefn Reference.toText) $ Map.toList types))
+      , Monoid.unlessM (null patches) $ P.lit "Patches:" <> P.newline <> P.indentN 2 (P.column2 (map (bimap P.shown P.shown) $ Map.toList patches))
+      , Monoid.unlessM (null children) $ P.lit "Children:" <> P.newline <> P.indentN 2 (P.column2 (map (bimap P.shown P.shown) $ Map.toList children))
+      ])
+      where
+        prettyLinks renderR r [] = P.indentN 2 $ P.text (renderR r)
+        prettyLinks renderR r links = P.indentN 2 (P.lines (P.text (renderR r) : (links <&> \r -> "+ " <> P.text (Reference.toText r))))
+        prettyDefn renderR (r, (Foldable.toList -> names, Foldable.toList -> links)) =
+          P.lines (P.shown <$> if null names then [NameSegment "<unnamed>"] else names) <> P.newline <> prettyLinks renderR r links
+    in pure $ P.lines (map prettyDump $ Map.toList m)
   ListDependents hqLength ld names missing -> pure $
     if names == mempty && missing == mempty
     then c (prettyLabeledDependency hqLength ld) <> " doesn't have any dependents."

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 26cd32e792c7cce84c43a71156c58cbf0053505a80762d095736979b231055da
+-- hash: 53969d6f6add359ef978b603882723e65adf9d4ee9dfc274567ea63c37c4ec7f
 
 name:           unison-parser-typechecker
 version:        0.0.0
@@ -45,6 +45,7 @@ library
       Unison.Codebase.Editor.Input
       Unison.Codebase.Editor.Output
       Unison.Codebase.Editor.Output.BranchDiff
+      Unison.Codebase.Editor.Output.DumpNamespace
       Unison.Codebase.Editor.Propagate
       Unison.Codebase.Editor.RemoteRepo
       Unison.Codebase.Editor.SlurpComponent


### PR DESCRIPTION
The `debug.dump-namespace` command dumps everything in the root namespace and recursive history to stdout as text (no patch contents yet, or definitions).

Controversial decision?
It uses `traceM` to print each individual namespace instead of generating an `IO Pretty` in `OutputMessages` like normal, because it was crashing when I did that.  Possibly due to the `Pretty` being too big?  That implementation is still here though.
I guess I don't care too much since it's a `debug.<...>` command.

Loose ends:
The things that are References are displayed with `#`, but the things that are just hashes (namespaces and patches) don't.

Sample output:
```
Namespace agu597jbfndk724etrdcd6r7u3b1ua7cvtk3n70dk3qtv6psfhldofrq8d2v7nbjdb56vfbk7vuentmjepqvg0i8phlha3u5k4sep7o
  Causal Parents:
    7asfbtqmoj56pq7b053v2jc1spgb8g5j4cg1tj97ausi3scveqa50ktv4b2ofoclnkqmnl18vnt5d83jrh85qd43nnrsh6qetbksb70
  Children:
    _base jh8ecig8at8tehvcgt3n2rjd1lf90s0pl9tsu18n30233h0ks9tkf1r3kjvbg49ide03ngso618k7lpm19t2h9818eefqau730rugkg
Namespace jh8ecig8at8tehvcgt3n2rjd1lf90s0pl9tsu18n30233h0ks9tkf1r3kjvbg49ide03ngso618k7lpm19t2h9818eefqau730rugkg
  Causal Parents:
    ug7grqhdmdl1n2cgsq3oppc4p68joqrmi050fr5a8oo25bmhv95t8sptov04mmv6l39stbgf3dgiae8sdc1q2gbugkco37licb5suu0
  Children:
    releases q7v595v9tbh0qs3t5ocl6vo2b3it9oenptu7kqgr4tdpmopfl6d2joelg2tga2vb3dcpvdlhdg98j0bc7t73ceefvchvksv5gmbdni0
    series   7ip67a0f1vn1n4vfujrh2veam7qrp6nfaa43hbvopsaoe841or0pitnn8ebbcqq2cpisd9nnc1r4sqligr53aqh22q7ed3rkb8iij68
    trunk    1fd5tlm9hq4n6qror5dch6kgj0kk1uoe42u65pe9v264fpm9jff228l3u3j0adgh6jivu6upti4b9piueraf7j8ufopbml7mkcm1qfo
Namespace q7v595v9tbh0qs3t5ocl6vo2b3it9oenptu7kqgr4tdpmopfl6d2joelg2tga2vb3dcpvdlhdg98j0bc7t73ceefvchvksv5gmbdni0
  Causal Parents:
    7ip67a0f1vn1n4vfujrh2veam7qrp6nfaa43hbvopsaoe841or0pitnn8ebbcqq2cpisd9nnc1r4sqligr53aqh22q7ed3rkb8iij68
  Children:
    _M1m    atln3qt5l34gpugulg1rjv6v318fl8h1g5a3dn7vl09qkn9v5bbpspumhlbl4j4h6n1ilp12lj0h80hd60q1lpj6iti977sn9s4qs7g
    _latest atln3qt5l34gpugulg1rjv6v318fl8h1g5a3dn7vl09qkn9v5bbpspumhlbl4j4h6n1ilp12lj0h80hd60q1lpj6iti977sn9s4qs7g
Namespace atln3qt5l34gpugulg1rjv6v318fl8h1g5a3dn7vl09qkn9v5bbpspumhlbl4j4h6n1ilp12lj0h80hd60q1lpj6iti977sn9s4qs7g
  Causal Parents:
    7asfbtqmoj56pq7b053v2jc1spgb8g5j4cg1tj97ausi3scveqa50ktv4b2ofoclnkqmnl18vnt5d83jrh85qd43nnrsh6qetbksb70
  Terms:
    bug
      ##bug
    todo
      ##todo
    <unnamed>
      #036dh126aoj6teannro7i689shik9k1nppm9d3img9rj5ub3ea0ee8on12haj7og4pquqncau85qjci0q7qpqelai8i5tbep25at6cg
      + #uqdd5t2fgn50t7f7s8n60k7qqp6s9uqce93uhtuam0i0bks0o9pdt8p6cj4qrbusq15vkqvfq8dooecmclp3r7s2k7krthk9etotqe8
    <unnamed>
      #0fbpmk2kq5udttfrn3fm07pn8s0hl030b1iht1umfcon9vihlptctfkcj5kunhli8igboh45bt8qlfnti526lju08mlkb48vdhj580g
      + #uqdd5t2fgn50t7f7s8n60k7qqp6s9uqce93uhtuam0i0bks0o9pdt8p6cj4qrbusq15vkqvfq8dooecmclp3r7s2k7krthk9etotqe8
    .
      #0hoa6tis7604fo17o91lfjflsvd843uvm7sueu5rfqqn5nbneajoh9fldfbmmjnhh1h2690ktfflrbb96q9lksesuh3t5amcc1ph92g
    <unnamed>
      #0i631k5do46t9fo6h315660j15qt8bh9b6v6qe721afo7eqjoa9vppou6mpetpbiu6s7s2s0heorncu08s60hmhifeikhngd8k9dloo
      + #uqdd5t2fgn50t7f7s8n60k7qqp6s9uqce93uhtuam0i0bks0o9pdt8p6cj4qrbusq15vkqvfq8dooecmclp3r7s2k7krthk9etotqe8
    <unnamed>
      #0kfc43voktd0n5lpogsd16al987qjbkusca0mgr2b2n8e0b4962s7cqpfd1b0ihhapja4sv0444s0gph8t8n0en6rfaqaltbnbmkum8.0c3
      + #uqdd5t2fgn50t7f7s8n60k7qqp6s9uqce93uhtuam0i0bks0o9pdt8p6cj4qrbusq15vkqvfq8dooecmclp3r7s2k7krthk9etotqe8
...
```