### PR TITLE
Fix issue with main function detection used by `run` command

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1597,7 +1597,7 @@ loop = do
           mainType <- eval RuntimeMain
           respond $ NoMainFunction main ppe [mainType]
         TermHasBadType ty -> do
-          let names0 = basicPrettyPrintNames0
+          let names0 = Names3.suffixify0 basicPrettyPrintNames0
           ppe <- prettyPrintEnv (Names3.Names names0 mempty)
           mainType <- eval RuntimeMain
           respond $ BadMainFunction main ty ppe [mainType]
@@ -2910,7 +2910,7 @@ addRunMain mainName (Just uf) = do
       v2 = Var.freshIn (Set.fromList [v]) v
       a = ABT.annotation tm
       in
-      if Typechecker.isSubtype mainType ty then RunMainSuccess $ let
+      if Typechecker.isSubtype ty mainType then RunMainSuccess $ let
         runMain = DD.forceTerm a a (Term.var a v)
         in UF.typecheckedUnisonFile
              (UF.dataDeclarationsId' uf)

--- a/parser-typechecker/src/Unison/Codebase/MainTerm.hs
+++ b/parser-typechecker/src/Unison/Codebase/MainTerm.hs
@@ -12,7 +12,6 @@ import           Unison.Parser                  ( Ann )
 import qualified Unison.Parser                 as Parser
 import qualified Unison.Term                   as Term
 import           Unison.Term                    ( Term )
-import qualified Unison.Var                    as Var
 import           Unison.Var                     ( Var )
 import qualified Unison.Builtin.Decls          as DD
 import qualified Unison.HashQualified          as HQ
@@ -41,28 +40,24 @@ getMainTerm loadTypeOfTerm parseNames0 mainName mainType =
   case HQ.fromString mainName of
     Nothing -> pure (NotAFunctionName mainName)
     Just hq -> do
-      traceShowM hq
       let refs = Names3.lookupHQTerm hq (Names3.Names parseNames0 mempty)
       let a = Parser.External
       case toList refs of
         [Referent.Ref ref] -> do
           typ <- loadTypeOfTerm ref
-          traceShowM typ
           case typ of
             Just typ ->
-              if Typechecker.isSubtype mainType typ then do
+              if Typechecker.isSubtype typ mainType then do
                 let tm = DD.forceTerm a a (Term.ref a ref)
                 return (Success hq tm typ)
               else pure (BadType mainName $ Just typ)
             _ -> pure (BadType mainName Nothing)
         _ -> pure (NotFound mainName)
 
--- forall a. '{io2.IO} a
+-- '{io2.IO} ()
 builtinMain :: Var v => a -> Type.Type v a
-builtinMain a =
-  Type.forall a v $ Type.arrow a (Type.ref a DD.unitRef) (io a)
-  where io a = Type.effect1 a (Type.builtinIO a) (Type.var a v)
-        v = Var.named "a"
+builtinMain a = Type.arrow a (Type.ref a DD.unitRef) io
+  where io = Type.effect1 a (Type.builtinIO a) (Type.ref a DD.unitRef)
 
 -- [Result]
 resultArr :: Ord v => a -> Type.Type v a

--- a/unison-src/transcripts/fix1800.md
+++ b/unison-src/transcripts/fix1800.md
@@ -1,0 +1,21 @@
+
+```ucm:hide
+.> builtins.mergeio
+```
+
+```ucm
+.> ls builtin.io2.IO
+```
+
+```unison
+printLine : Text ->{IO} ()
+printLine msg =
+  putBytes.impl (stdHandle StdOut) (Text.toUtf8 msg)
+  ()
+
+mymain = '(printLine "hello world!")
+```
+
+```ucm
+.> run mymain
+```

--- a/unison-src/transcripts/fix1800.output.md
+++ b/unison-src/transcripts/fix1800.output.md
@@ -1,9 +1,5 @@
 
-```ucm:hide
-.> builtins.mergeio
-```
-
-```unison:hide
+```unison
 printLine : Text ->{IO} ()
 printLine msg =
   putBytes.impl (stdHandle StdOut) (Text.toUtf8 (msg ++ "\n"))
@@ -27,25 +23,46 @@ Testing a few variations here:
 
 ```ucm
 .> run main1
-.> run main2
-.> run main3
-.> add
-.> rename.term main1 code.main1
-.> rename.term main2 code.main2
-.> rename.term main3 code.main3
-```
 
+.> run main2
+
+.> run main3
+
+.> add
+
+  ⍟ I've added these definitions:
+  
+    main1     : '{IO} ()
+    main2     : ∀ _. _ ->{IO} ()
+    main3     : '{IO} ()
+    printLine : Text ->{IO} ()
+
+.> rename.term main1 code.main1
+
+  Done.
+
+.> rename.term main2 code.main2
+
+  Done.
+
+.> rename.term main3 code.main3
+
+  Done.
+
+```
 The renaming just ensures that when running `code.main1`, it has to get that main from the codebase rather than the scratch file:
 
 ```ucm
 .> run code.main1
-.> run code.main2
-.> run code.main3
-```
 
+.> run code.main2
+
+.> run code.main3
+
+```
 Now testing a few variations that should NOT typecheck.
 
-```unison:hide
+```unison
 main4 : Nat ->{IO} Nat
 main4 n = n
 
@@ -55,10 +72,31 @@ main5 _ = ()
 
 This shouldn't work since `main4` and `main5` don't have the right type.
 
-```ucm:error
+```ucm
 .> run main4
-```
 
-```ucm:error
+  😶
+  
+  I found this function:
+  
+    main4 : Nat ->{IO} Nat
+  
+  but in order for me to `run` it it needs to have the type:
+  
+    main4 : '{IO} ()
+
+```
+```ucm
 .> run main5
+
+  😶
+  
+  I found this function:
+  
+    main5 : Nat ->{IO} ()
+  
+  but in order for me to `run` it it needs to have the type:
+  
+    main5 : '{IO} ()
+
 ```


### PR DESCRIPTION
Fixes #1800 

Added a regression test and transcript that exercises all the variations of running main functions, as well as expected errors.

Minor thing: spotted use of unsuffixed names in the `BadMainType` error message and cleaned that up. You can see that in [the transcript](https://github.com/unisonweb/unison/blob/6a4e5826802a5594417e854770c20eaee2b64e76/unison-src/transcripts/fix1800.output.md). Note that transcript output doesn't capture standard out, but things get printed as expected.

Main detection just checks that the requested type is a subtype of the main type, which is `'{IO} ()`.

### Controversial decisions

Main functions have to return `()` now. Previously they could return any type, and then the result would just be discarded, so this "feature" wasn't really buying us anything anyway.

It might be cool to allow main functions to return other types, and then have it print out the result much like watch expressions. I'll leave that to future work. Supporting this could be done with a subtyping check the `'{IO} a` upper bound has a free existential `a` there.

I'm also intrigued by idea of having a more general staging / partial evaluation story but the `run` command isn't the place for this IMO.