### PR TITLE
Uncontroversial fix to rendering of tables in docs

### DIFF
--- a/parser-typechecker/src/Unison/Util/Pretty.hs
+++ b/parser-typechecker/src/Unison/Util/Pretty.hs
@@ -542,7 +542,7 @@ table' rows = case maximum (Prelude.length <$> rows) of
   _ -> let
     colHd = [ h | (h:_) <- rows ]
     colTl = [ t | (_:t) <- rows ]
-    in align (colHd `zip` (("  " <>) <$> table' colTl))
+    in align (fmap (<> "  ") colHd `zip` (table' colTl))
 
 column2
   :: (LL.ListLike s Char, IsString s) => [(Pretty s, Pretty s)] -> Pretty s

--- a/unison-src/transcripts-using-base/doc.md.files/syntax.u
+++ b/unison-src/transcripts-using-base/doc.md.files/syntax.u
@@ -164,7 +164,8 @@ This is an aside. {{ docAside {{ Some extra detail that doesn't belong in main t
 
 {{ 
   docTable 
-    [ [{{a}}, {{b}}, {{c}}]
+    [ [{{a}}, {{b}}, {{A longer paragraph that will split onto multiple lines, such
+                       that this row occupies multiple lines in the rendered table.}}]
     , [{{Some text}}, {{More text}}, {{ Zounds! }}] ] 
 }} 
 

--- a/unison-src/transcripts-using-base/doc.output.md
+++ b/unison-src/transcripts-using-base/doc.output.md
@@ -451,7 +451,17 @@ and the rendered output using `display`:
     
     {{
     docTable
-      [ [{{ a }}, {{ b }}, {{ c }}],
+      [ [ {{
+      a
+      }},
+        {{
+      b
+      }},
+        {{
+      A longer paragraph that will split onto multiple lines,
+      such that this row occupies multiple lines in the rendered
+      table.
+      }} ],
         [{{ Some text }}, {{ More text }}, {{ Zounds! }}] ] }}
     }}
 
@@ -488,7 +498,10 @@ and the rendered output using `display`:
   
   Hover over me
   
-  a           b           c
+  a           b           A longer paragraph that will split
+                          onto multiple lines, such that this
+                          row occupies multiple lines in the
+                          rendered table.
   Some text   More text   Zounds!
 
 ```
@@ -684,7 +697,10 @@ Lastly, it's common to build longer documents including subdocuments via `{{ sub
     
     Hover over me
     
-    a           b           c
+    a           b           A longer paragraph that will split
+                            onto multiple lines, such that this
+                            row occupies multiple lines in the
+                            rendered table.
     Some text   More text   Zounds!
 
 ```


### PR DESCRIPTION
I noticed a bug with plain text rendering of tables with that span multiple lines -

```
  # Functions for lookahead and backtracking
  
    `_mark`       Pushes the current parser state onto a stack.
    `_reset i`    Pops the mark stack up to and including `i` and resets
                the parse state to what it was at mark `i`.
    `_unmark i`   Pops the mark stack up to and including `i`.
```

Notice the multi-line row second line is 2 characters off from being aligned. This PR fixes that and adds a regression test for it.

Looking at the diff, I did notice some weirdness in pretty-printing of lists of docs which is unrelated to this fix. I'd like to do a more thorough audit of pretty-printing. There are a number of cases where it produces weird or unparseable results.