### PR TITLE
Serve backend API from `/api` and frontend from `/ui`

### DIFF
--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -202,6 +202,7 @@ library:
     - unison-core
     - unliftio
     - unliftio-core
+    - utf8-string
     - util
     - unicode-show
     - vector

--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -158,6 +158,7 @@ library:
     - hashtables
     - haskeline
     - http-types
+    - http-media
     - io-streams
     - lens
     - ListLike
@@ -185,6 +186,7 @@ library:
     - servant-docs
     - servant-openapi3
     - servant-server
+    - servant-auth-server
     - shellmet
     - split
     - stm

--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -173,6 +173,7 @@ library:
     - network-simple
     - nonempty-containers
     - openapi3
+    - optparse-applicative
     - pem
     - process
     - primitive

--- a/parser-typechecker/src/Unison/Server/CodebaseServer.hs
+++ b/parser-typechecker/src/Unison/Server/CodebaseServer.hs
@@ -8,11 +8,12 @@ module Unison.Server.CodebaseServer where
 
 import Control.Concurrent (newEmptyMVar, putMVar, readMVar)
 import Control.Concurrent.Async (race)
-import Control.Exception (throwIO, ErrorCall(..))
+import Control.Exception (ErrorCall (..), throwIO)
 import Control.Lens
   ( (&),
     (.~),
   )
+import Control.Monad.IO.Class (liftIO)
 import Data.Aeson ()
 import qualified Data.ByteString as Strict
 import qualified Data.ByteString.Base64 as Base64
@@ -31,6 +32,7 @@ import Data.Proxy (Proxy (..))
 import Data.String (fromString)
 import qualified Data.Text as Text
 import GHC.Generics ()
+import Network.HTTP.Media ((//), (/:))
 import Network.HTTP.Types.Status (ok200)
 import Network.Wai
   ( Request,
@@ -40,20 +42,22 @@ import Network.Wai
 import Network.Wai.Handler.Warp
   ( Port,
     defaultSettings,
+    runSettings,
+    setBeforeMainLoop,
     setHost,
     setPort,
     withApplicationSettings,
-    runSettings,
-    setBeforeMainLoop
   )
 import Servant
   ( Header,
+    MimeRender (..),
     addHeader,
     serveWithContext,
     throwError,
   )
 import Servant.API
-  ( Get,
+  ( Accept (..),
+    Get,
     Headers,
     JSON,
     Raw,
@@ -61,6 +65,7 @@ import Servant.API
     type (:<|>) (..),
   )
 import Servant.API.Experimental.Auth (AuthProtect)
+import Servant.Auth.Server (throwAll)
 import Servant.Docs
   ( DocIntro (DocIntro),
     docsWithIntros,
@@ -70,17 +75,21 @@ import Servant.OpenApi (HasOpenApi (toOpenApi))
 import Servant.Server
   ( Application,
     Context (..),
+    Handler,
     Server,
     ServerError (..),
     Tagged (Tagged),
     err401,
+    err500,
   )
 import Servant.Server.Experimental.Auth
   ( AuthHandler,
     AuthServerData,
     mkAuthHandler,
   )
+import Servant.Server.StaticFiles (serveDirectoryWebApp)
 import System.Environment (lookupEnv)
+import System.FilePath.Posix ((</>))
 import System.Random.Stateful
   ( getStdGen,
     newAtomicGenM,
@@ -104,14 +113,29 @@ import Unison.Server.Endpoints.ListNamespace
 import Unison.Server.Types (mungeString)
 import Unison.Var (Var)
 
+-- HTML content type
+data HTML = HTML
+
+newtype RawHtml = RawHtml { unRaw :: Lazy.ByteString }
+
+instance Accept HTML where
+  contentType _ = "text" // "html" /: ("charset", "utf-8")
+
+instance MimeRender HTML RawHtml where
+  mimeRender _ = unRaw
+
 type OpenApiJSON = "openapi.json"
   :> Get '[JSON] (Headers '[Header "Access-Control-Allow-Origin" String] OpenApi)
 
-type DocAPI = AuthProtect "token-auth" :> (UnisonAPI :<|> OpenApiJSON :<|> Raw)
+type DocAPI = UnisonAPI :<|> OpenApiJSON :<|> Raw
 
 type UnisonAPI = NamespaceAPI :<|> DefinitionsAPI :<|> FuzzyFindAPI
 
 type instance AuthServerData (AuthProtect "token-auth") = ()
+
+type WebUI = ("static" :> Raw) :<|> (Get '[HTML] RawHtml)
+
+type ServerAPI = AuthProtect "token-auth" :> (("ui" :> WebUI) :<|> ("api" :> DocAPI))
 
 genAuthServerContext
   :: Strict.ByteString -> Context (AuthHandler Request ()': '[])
@@ -152,9 +176,18 @@ docAPI = Proxy
 api :: Proxy UnisonAPI
 api = Proxy
 
-app :: Var v => Codebase IO v Ann -> Strict.ByteString -> Application
-app codebase token =
-  serveWithContext docAPI (genAuthServerContext token) $ server codebase
+serverAPI :: Proxy ServerAPI
+serverAPI = Proxy
+
+app
+  :: Var v
+  => Codebase IO v Ann
+  -> Maybe FilePath
+  -> Strict.ByteString
+  -> Application
+app codebase uiPath token =
+  serveWithContext serverAPI (genAuthServerContext token)
+    $ server codebase uiPath
 
 genToken :: IO Strict.ByteString
 genToken = do
@@ -176,13 +209,26 @@ mkWaiter = do
     waitFor = readMVar mvar
   }
 
+ucmUIVar :: String
+ucmUIVar = "UCM_WEB_UI"
+
+ucmPortVar :: String
+ucmPortVar = "UCM_PORT"
+
+ucmHostVar :: String
+ucmHostVar = "UCM_HOST"
+
+ucmTokenVar :: String
+ucmTokenVar = "UCM_HOST"
+
 -- The auth token required for accessing the server is passed to the function k
 start
   :: Var v => Codebase IO v Ann -> (Strict.ByteString -> Port -> IO ()) -> IO ()
 start codebase k = do
-  envToken <- lookupEnv "UCM_TOKEN"
-  envHost  <- lookupEnv "UCM_HOST"
-  envPort  <- (readMaybe =<<) <$> lookupEnv "UCM_PORT"
+  envToken <- lookupEnv ucmTokenVar
+  envHost  <- lookupEnv ucmHostVar
+  envPort  <- (readMaybe =<<) <$> lookupEnv ucmPortVar
+  envUI    <- lookupEnv ucmUIVar
   token    <- case envToken of
     Just t -> return $ C8.pack t
     _      -> genToken
@@ -191,7 +237,7 @@ start codebase k = do
         <> foldMap (Endo . setHost . fromString) envHost
         )
         defaultSettings
-      a = app codebase token
+      a = app codebase envUI token
   case envPort of
     Nothing -> withApplicationSettings settings (pure a) (k token)
     Just p -> do
@@ -204,13 +250,39 @@ start codebase k = do
         Left () -> throwIO $ ErrorCall "Server exited unexpectedly!"
         Right x -> pure x
 
-server :: Var v => Codebase IO v Ann -> Server DocAPI
-server codebase _ =
-  (serveNamespace codebase :<|> serveDefinitions codebase :<|> serveFuzzyFind codebase)
-    :<|> addHeader "*"
-    <$>  serveOpenAPI
-    :<|> Tagged serveDocs
+serveIndex :: FilePath -> Handler RawHtml
+serveIndex path = fmap RawHtml . liftIO . Lazy.readFile $ path </> "index.html"
+
+serveUI :: Maybe FilePath -> Server WebUI
+serveUI = \case
+  Just path -> serveDirectoryWebApp (path </> "static") :<|> serveIndex path
+  Nothing   -> fail
+ where
+  fail = throwAll $ err500
+    { errReasonPhrase =
+      "No codebase UI configured."
+      <> " Set the "
+      <> ucmUIVar
+      <> " environment variable to the directory where the UI is installed."
+    }
+
+
+server :: Var v => Codebase IO v Ann -> Maybe FilePath -> Server ServerAPI
+server codebase uiPath =
+  (\_ ->
+    serveUI uiPath
+      :<|> (    (    serveNamespace codebase
+                :<|> serveDefinitions codebase
+                :<|> serveFuzzyFind codebase
+                )
+           :<|> addHeader "*"
+           <$>  serveOpenAPI
+           :<|> Tagged serveDocs
+           )
+  )
+
  where
   serveDocs _ respond = respond $ responseLBS ok200 [plain] docsBS
   serveOpenAPI = pure openAPI
   plain        = ("Content-Type", "text/plain")
+

--- a/parser-typechecker/src/Unison/Server/CodebaseServer.hs
+++ b/parser-typechecker/src/Unison/Server/CodebaseServer.hs
@@ -219,7 +219,7 @@ ucmHostVar :: String
 ucmHostVar = "UCM_HOST"
 
 ucmTokenVar :: String
-ucmTokenVar = "UCM_HOST"
+ucmTokenVar = "UCM_TOKEN"
 
 -- The auth token required for accessing the server is passed to the function k
 start

--- a/parser-typechecker/src/Unison/Server/CodebaseServer.hs
+++ b/parser-typechecker/src/Unison/Server/CodebaseServer.hs
@@ -92,7 +92,7 @@ import Servant.Server
     ServerError (..),
     Tagged (Tagged),
     err401,
-    err500,
+    err404,
   )
 import Servant.Server.Experimental.Auth
   ( AuthHandler,
@@ -312,7 +312,7 @@ serveUI = \case
   Just path -> serveDirectoryWebApp (path </> "static") :<|> serveIndex path
   Nothing   -> fail
  where
-  fail = throwAll $ err500
+  fail = throwAll $ err404
     { errReasonPhrase =
       "No codebase UI configured."
       <> " Set the "

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d836e6a01f959984e28535698293e15253e3d1a57d0ac5a85a38ec33001b7ae9
+-- hash: 698f520d4a0ec6ddcafd574310fd44d7793c2c33e6f4e27b4e42950d6b7881d0
 
 name:           unison-parser-typechecker
 version:        0.0.0
@@ -244,6 +244,7 @@ library
     , unison-core
     , unliftio
     , unliftio-core
+    , utf8-string
     , util
     , vector
     , wai

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b6fb5e0513e2332b458be9a249c65772c9d0b1fc0efc7732242597e073723b35
+-- hash: a523531c841ac375ddc2c173943b1650734d6f62a021bf0d2cb3585683f9ef52
 
 name:           unison-parser-typechecker
 version:        0.0.0
@@ -199,6 +199,7 @@ library
     , hashable
     , hashtables
     , haskeline
+    , http-media
     , http-types
     , io-streams
     , lens
@@ -223,6 +224,7 @@ library
     , safe
     , safe-exceptions
     , servant
+    , servant-auth-server
     , servant-docs
     , servant-openapi3
     , servant-server

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a523531c841ac375ddc2c173943b1650734d6f62a021bf0d2cb3585683f9ef52
+-- hash: d836e6a01f959984e28535698293e15253e3d1a57d0ac5a85a38ec33001b7ae9
 
 name:           unison-parser-typechecker
 version:        0.0.0
@@ -214,6 +214,7 @@ library
     , network-simple
     , nonempty-containers
     , openapi3
+    , optparse-applicative
     , pem
     , primitive
     , process

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -153,14 +153,6 @@ main = do
   branchCacheSize :: Word <- Config.lookupDefault 4096 config_ "NamespaceCacheSize"
   branchCache <- Cache.semispaceCache branchCacheSize
   case restargs of
-    [] -> do
-      theCodebase <- FileCodebase.getCodebaseOrExit branchCache mcodepath
-      Server.start theCodebase $ \token port -> do
-        PT.putPrettyLn . P.string $ "I've started a codebase API server at "
-        PT.putPrettyLn . P.string $ "http://127.0.0.1:"
-          <> show port <> "?" <> URI.encode (unpack token)
-        PT.putPrettyLn' . P.string $ "Now starting the Unison Codebase Manager..."
-        launch currentDir config theCodebase branchCache []
     [version] | isFlag "version" version ->
       putStrLn $ progName ++ " version: " ++ Version.gitDescribe
     [help] | isFlag "help" help -> PT.putPrettyLn (usage progName)
@@ -196,8 +188,13 @@ main = do
       "-save-codebase" : transcripts -> runTranscripts branchCache True True mcodepath transcripts
       _                              -> runTranscripts branchCache True False mcodepath args'
     _ -> do
-      PT.putPrettyLn (usage progName)
-      Exit.exitWith (Exit.ExitFailure 1)
+      theCodebase <- FileCodebase.getCodebaseOrExit branchCache mcodepath
+      Server.start theCodebase $ \token port -> do
+        PT.putPrettyLn . P.string $ "I've started a codebase API server at "
+        PT.putPrettyLn . P.string $ "http://127.0.0.1:"
+          <> show port <> "?" <> URI.encode (unpack token)
+        PT.putPrettyLn' . P.string $ "Now starting the Unison Codebase Manager..."
+        launch currentDir config theCodebase branchCache []
 
 prepareTranscriptDir :: Branch.Cache IO -> Bool -> Maybe FilePath -> IO FilePath
 prepareTranscriptDir branchCache inFork mcodepath = do

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -190,10 +190,15 @@ main = do
     _ -> do
       theCodebase <- FileCodebase.getCodebaseOrExit branchCache mcodepath
       Server.start theCodebase $ \token port -> do
-        PT.putPrettyLn . P.string $ "I've started a codebase API server at "
-        PT.putPrettyLn . P.string $ "http://127.0.0.1:"
-          <> show port <> "?" <> URI.encode (unpack token)
-        PT.putPrettyLn' . P.string $ "Now starting the Unison Codebase Manager..."
+        PT.putPrettyLn $ P.lines
+          ["I've started the codebase API server at "
+          , P.string $ "http://127.0.0.1:" <> show port <> "/api?"
+            <> URI.encode (unpack token)]
+        PT.putPrettyLn $ P.lines
+          ["The Unison Codebase UI is running at"
+          , P.string $ "http://127.0.0.1:" <> show port <> "/ui?"
+            <> URI.encode (unpack token)]
+        PT.putPrettyLn . P.string $ "Now starting the Unison Codebase Manager..."
         launch currentDir config theCodebase branchCache []
 
 prepareTranscriptDir :: Branch.Cache IO -> Bool -> Maybe FilePath -> IO FilePath

--- a/stack.yaml
+++ b/stack.yaml
@@ -36,6 +36,8 @@ extra-deps:
 - servant-0.18@sha256:2b5c81089540c208b1945b5ca0c3551c862138d71b224a39fa275a62852a5c75,5068
 - servant-server-0.18
 - servant-docs-0.11.6
+- servant-auth-server-0.4.6.0@sha256:b411b44f4252e91e5da2455d71a7113c8b5b8ff2d943d19b2ddedcfcf0392351,5111
+- servant-auth-0.4.0.0@sha256:01d02dfb7df4747fc96442517146d7d4ab0e575e597a124e238e8763036ea4ff,2125
 - ListLike-4.7.4
 - random-1.2.0
 # remove these when stackage upgrades containers


### PR DESCRIPTION
## Overview

Addresses #1880 as it pertains to the codebase server. The API is now served at `http://127.0.0.1/api`. The frontend is served from `http://127.0.0.1/ui`.

This also adds some configurability. The options are as follows:

### Directory containing the UI

Environment variable: `UCM_WEB_UI`
Command line option: `--ui <DIR>`

This is the path to the directory containing the UI. Any request for a resource under `/ui` will get served the file `index.html` in that directory. An exception to this is any request for a resource under`/ui/static`, which will get served the contents of `$UCM_WEB_UI/static` as if it were a static website.

If left blank, this defaults to a `ui` subdirectory under UCM's working directory. If that directory doesn't exist, the UI will not be served, and `/ui` will give a 404 error.

### Server port

Environment variable: `UCM_PORT`
Command line option: `--port <PORT>`

Controls the port that the server listens on. If not specified, the server will choose an arbitrary available port.

### Host name

Environment variable: `UCM_HOST`
Command line option: `--host <STRING>`

Controls the hostname of the server. If not specified, the server will bind to the host`127.0.0.1`.

### Authentication token

Environment variable: `UCM_TOKEN`
Command line option: `--token <STRING>`

Sets the authentication token that must be present in any request to the server. If not specified, the server will generate a random string as the token.

The token has to be given as a query parameter. For example, if the token is `foo`, then a request for the UI has to be `http://host:port/ui?foo`.

## Interesting/controversial decisions

I was not able to easily figure out how to make the token part of the URI path, e.g. `token/ui`. It was relatively easy to do with a query parameter, so I left it at that.

UCM no longer prints the `help` text if you start it with unknown arguments. Arguments not captured by `main` get forwarded to the codebase server which uses `optparse-applicative` to grab them. Therefore they're also not part of the `help` text.

## Loose ends

We should really convert all UCM command-line options to `optparse-applicative` and print a unified usage text that covers both the standard UCM options and the UCM server options.