### PR TITLE
Remove token auth from static portion of UI

### DIFF
--- a/parser-typechecker/src/Unison/Server/CodebaseServer.hs
+++ b/parser-typechecker/src/Unison/Server/CodebaseServer.hs
@@ -141,15 +141,15 @@ instance MimeRender HTML RawHtml where
 type OpenApiJSON = "openapi.json"
   :> Get '[JSON] (Headers '[Header "Access-Control-Allow-Origin" String] OpenApi)
 
-type DocAPI = UnisonAPI :<|> OpenApiJSON :<|> Raw
+type DocAPI = AuthProtect "token-auth" :> (UnisonAPI :<|> OpenApiJSON :<|> Raw)
 
 type UnisonAPI = NamespaceAPI :<|> DefinitionsAPI :<|> FuzzyFindAPI
 
 type instance AuthServerData (AuthProtect "token-auth") = ()
 
-type WebUI = ("static" :> Raw) :<|> (Get '[HTML] RawHtml)
+type WebUI = ("static" :> Raw) :<|> (AuthProtect "token-auth" :> Get '[HTML] RawHtml)
 
-type ServerAPI = AuthProtect "token-auth" :> (("ui" :> WebUI) :<|> ("api" :> DocAPI))
+type ServerAPI = (("ui" :> WebUI) :<|> ("api" :> DocAPI))
 
 genAuthServerContext
   :: Strict.ByteString -> Context (AuthHandler Request ()': '[])
@@ -326,22 +326,20 @@ serveIndex path = do
 serveUI :: Maybe FilePath -> Server WebUI
 serveUI p =
   let path = fromMaybe "ui" p
-  in  serveDirectoryWebApp (path </> "static") :<|> serveIndex path
+  in  serveDirectoryWebApp (path </> "static") :<|> (\_ -> serveIndex path)
 
 server :: Var v => Codebase IO v Ann -> Maybe FilePath -> Server ServerAPI
 server codebase uiPath =
-  (\_ ->
-    serveUI uiPath
-      :<|> (    (    serveNamespace codebase
-                :<|> serveDefinitions codebase
-                :<|> serveFuzzyFind codebase
-                )
-           :<|> addHeader "*"
-           <$>  serveOpenAPI
-           :<|> Tagged serveDocs
-           )
-  )
-
+  serveUI uiPath
+    :<|> (\_ ->
+           (    serveNamespace codebase
+             :<|> serveDefinitions codebase
+             :<|> serveFuzzyFind codebase
+             )
+             :<|> addHeader "*"
+             <$>  serveOpenAPI
+             :<|> Tagged serveDocs
+         )
  where
   serveDocs _ respond = respond $ responseLBS ok200 [plain] docsBS
   serveOpenAPI = pure openAPI


### PR DESCRIPTION
Removes the token authentication from the `/ui/static` portion of the API, allowing the web GUI to serve static files (icons, etc.) without having the token.