### PR TITLE
Fix a boolean in the new runtime

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/ANF.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF.hs
@@ -1016,7 +1016,7 @@ anfHandled body = anfBlock body >>= \case
 
 fls, tru :: Var v => ANormal v
 fls = TCon Ty.booleanRef 0 []
-tru = TCon Ty.booleanRef 0 []
+tru = TCon Ty.booleanRef 1 []
 
 anfBlock :: Var v => Term v a -> ANFM v (Ctx v, DNormal v)
 anfBlock (Var' v) = pure (mempty, pure $ TVar v)

--- a/unison-src/transcripts-using-base/builtins.md
+++ b/unison-src/transcripts-using-base/builtins.md
@@ -145,6 +145,33 @@ test> Nat.tests.conversions =
 .> add
 ```
 
+## `Boolean` functions
+```unison:hide
+test> Boolean.tests.orTable =
+      checks [
+        true || true == true,
+        true || false == true,
+        false || true == true,
+        false || false == false
+      ]
+test> Boolean.tests.andTable =
+      checks [
+        true && true == true,
+        false && true == false,
+        true && false == false,
+        false && false == false
+      ]
+test> Boolean.tests.notTable =
+      checks [
+        not true == false,
+        not false == true
+      ]
+```
+
+```ucm:hide
+.> add
+```
+
 ## `Text` functions
 
 ```unison:hide

--- a/unison-src/transcripts-using-base/builtins.output.md
+++ b/unison-src/transcripts-using-base/builtins.output.md
@@ -137,6 +137,29 @@ test> Nat.tests.conversions =
         ]
 ```
 
+## `Boolean` functions
+```unison
+test> Boolean.tests.orTable =
+      checks [
+        true || true == true,
+        true || false == true,
+        false || true == true,
+        false || false == false
+      ]
+test> Boolean.tests.andTable =
+      checks [
+        true && true == true,
+        false && true == false,
+        true && false == false,
+        false && false == false
+      ]
+test> Boolean.tests.notTable =
+      checks [
+        not true == false,
+        not false == true
+      ]
+```
+
 ## `Text` functions
 
 ```unison
@@ -224,6 +247,9 @@ Now that all the tests have been added to the codebase, let's view the test repo
   
   ◉ Any.test1                   Passed
   ◉ Any.test2                   Passed
+  ◉ Boolean.tests.andTable      Passed
+  ◉ Boolean.tests.notTable      Passed
+  ◉ Boolean.tests.orTable       Passed
   ◉ Bytes.tests.at              Passed
   ◉ Int.tests.arithmetic        Passed
   ◉ Int.tests.bitTwiddling      Passed
@@ -235,7 +261,7 @@ Now that all the tests have been added to the codebase, let's view the test repo
   ◉ Text.tests.repeat           Passed
   ◉ Text.tests.takeDropAppend   Passed
   
-  ✅ 12 test(s) passing
+  ✅ 15 test(s) passing
   
   Tip: Use view Any.test1 to view the source of a test.
 


### PR DESCRIPTION
The ANF code had a the literal for `true` defined the same way as `false`. In that file it was only used in `||`, but I think it might also be used for some other builtins.

This does seem to fix the duplicate-key issue in #1901, although I'm unsure exactly which of its dependencies was broken. This also gets base's tests working.

I added a few truth table tests to a transcript.