### PR TITLE
fix a bug in watch loading, watch syncing, and watch syncing summary

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Branch/Format.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Branch/Format.hs
@@ -4,6 +4,7 @@ import Data.Vector (Vector)
 import U.Codebase.Sqlite.Branch.Diff (LocalDiff)
 import U.Codebase.Sqlite.Branch.Full (LocalBranch)
 import U.Codebase.Sqlite.DbId (CausalHashId, BranchObjectId, ObjectId, PatchObjectId, TextId)
+import Data.ByteString (ByteString)
 
 -- |you can use the exact same `BranchLocalIds` when converting between `Full` and `Diff`
 data BranchFormat
@@ -18,3 +19,7 @@ data BranchLocalIds = LocalIds
     branchChildLookup :: Vector (BranchObjectId, CausalHashId)
   }
   deriving Show
+
+data SyncBranchFormat
+  = SyncFull BranchLocalIds ByteString
+  | SyncDiff BranchObjectId BranchLocalIds ByteString

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Patch/Format.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Patch/Format.hs
@@ -4,6 +4,7 @@ import Data.Vector (Vector)
 import U.Codebase.Sqlite.DbId (HashId, ObjectId, PatchObjectId, TextId)
 import U.Codebase.Sqlite.Patch.Diff (LocalPatchDiff)
 import U.Codebase.Sqlite.Patch.Full (LocalPatch)
+import Data.ByteString (ByteString)
 
 data PatchFormat
   = Full PatchLocalIds LocalPatch
@@ -14,3 +15,7 @@ data PatchLocalIds = LocalIds
     patchHashLookup :: Vector HashId,
     patchDefnLookup :: Vector ObjectId
   }
+
+data SyncPatchFormat
+  = SyncFull PatchLocalIds ByteString
+  | SyncDiff PatchObjectId PatchLocalIds ByteString

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Term/Format.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Term/Format.hs
@@ -2,6 +2,7 @@
 
 module U.Codebase.Sqlite.Term.Format where
 
+import Data.ByteString (ByteString)
 import Data.Vector (Vector)
 import U.Codebase.Reference (Reference')
 import U.Codebase.Referent (Referent')
@@ -42,3 +43,6 @@ data TermFormat
 
 data WatchResultFormat
   = WatchResult WatchLocalIds Term
+
+data SyncWatchResultFormat
+  = SyncWatchResult WatchLocalIds ByteString

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -899,7 +899,7 @@ syncProgress = Sync.Progress need done warn allDone
         "\r" ++ prefix ++ show (Set.size done + Set.size warn)
           ++ " entities"
           ++ if Set.size warn > 0
-            then " with " ++ show warn ++ " warnings."
+            then " with " ++ show (Set.size warn) ++ " warnings."
             else "."
       SyncProgressState need done warn ->
         "invalid SyncProgressState "

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -970,7 +970,7 @@ pushGitRootBranch syncToDirectory branch repo syncMode = runExceptT do
     setRepoRoot root h = do
       conn <- unsafeGetConnection root
       let h2 = Cv.causalHash1to2 h
-          err = error "Called SqliteCodebase.setNamespaceRoot on unknown causal hash"
+          err = error $ "Called SqliteCodebase.setNamespaceRoot on unknown causal hash " ++ show h2
       flip runReaderT conn $ do
         chId <- fromMaybe err <$> Q.loadCausalHashIdByCausalHash h2
         Q.setNamespaceRoot chId


### PR DESCRIPTION
Fixes #1916 in `SqliteCodebase.hs` and an `elem` vs `notElem` bug in skipping watch results that already exist at the destination during sync in `Sync22.hs`.
