### PR TITLE
Upgraded `stack` from 2.5.1 to 2.7.1

### DIFF
--- a/codebase2/codebase-sqlite/unison-codebase-sqlite.cabal
+++ b/codebase2/codebase-sqlite/unison-codebase-sqlite.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 08b634642723a41ec97773c7481d4d7af6a31e527b06c0e800001677e64a955d
+-- hash: f891db08f545b5212d1a97c8eebc547c5f8bdd3f95020ff05af7f7fd3113a1b6
 
 name:           unison-codebase-sqlite
 version:        0.0.0
@@ -43,7 +43,7 @@ library
   other-modules:
       Paths_unison_codebase_sqlite
   hs-source-dirs:
-      ./.
+      ./
   build-depends:
       base
     , bytes

--- a/codebase2/codebase-sync/unison-codebase-sync.cabal
+++ b/codebase2/codebase-sync/unison-codebase-sync.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5aecf5175bad0ac9cc461173d87d0fc00be36065974348d8541bf14ff451370c
+-- hash: 3bad1e2687a54aa39423bfd2dc30d8c1ccc8a42b88eb9e10f78cb4c858e92340
 
 name:           unison-codebase-sync
 version:        0.0.0
@@ -22,7 +22,7 @@ library
   other-modules:
       Paths_unison_codebase_sync
   hs-source-dirs:
-      ./.
+      ./
   build-depends:
       base
     , bytes

--- a/codebase2/codebase/unison-codebase.cabal
+++ b/codebase2/codebase/unison-codebase.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 143e303e5857e697f54b99302f3b1ddf2c44f27d5373dad588243be2034caeb2
+-- hash: 007d5ba1a9afa5423c79bb923619ab440794eb2496188191ac82b66ee645901c
 
 name:           unison-codebase
 version:        0.0.0
@@ -35,7 +35,7 @@ library
   other-modules:
       Paths_unison_codebase
   hs-source-dirs:
-      ./.
+      ./
   build-depends:
       base
     , containers

--- a/codebase2/core/unison-core.cabal
+++ b/codebase2/core/unison-core.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 40c5460ecd0a04d3f1012c9848d442e889805f339ee3f9a20d46932e843d116d
+-- hash: 0bf63b27f45cff424f3fe8db50af886c47b614dee705f88e4f95d96a91efe6b7
 
 name:           unison-core
 version:        0.0.0
@@ -23,7 +23,7 @@ library
   other-modules:
       Paths_unison_core
   hs-source-dirs:
-      ./.
+      ./
   build-depends:
       base
     , containers

--- a/codebase2/util-serialization/unison-util-serialization.cabal
+++ b/codebase2/util-serialization/unison-util-serialization.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f313cfc57110dcc277ac24eb79210d1dc8071221e3452971ad26e8a3e1d8abc4
+-- hash: a3d15e9e483a852609dc7b9c2177cdb29eca32e730651dbbbaac7247b615774b
 
 name:           unison-util-serialization
 version:        0.0.0
@@ -16,7 +16,7 @@ library
   other-modules:
       Paths_unison_util_serialization
   hs-source-dirs:
-      ./.
+      ./
   build-depends:
       base
     , bytes

--- a/codebase2/util-term/unison-util-term.cabal
+++ b/codebase2/util-term/unison-util-term.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4ffe80ec3d93d2c069c06e4713c6a630d11e01d99b29ce073a6ae0b79fffaa5e
+-- hash: 655ca1a695b9a272d6b440b74fe2b6717f710a543d7ddb7639366d4233961bf8
 
 name:           unison-util-term
 version:        0.0.0
@@ -23,7 +23,7 @@ library
   other-modules:
       Paths_unison_util_term
   hs-source-dirs:
-      ./.
+      ./
   build-depends:
       base
     , containers

--- a/codebase2/util/unison-util.cabal
+++ b/codebase2/util/unison-util.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: eb553f8d44e26dc6e4cf34d13fe54b626164d7c5c60146b417e27d6ece43c03f
+-- hash: 0babc973f878580f183d822979573027957f5eb855df002e8be9d7871c4a672a
 
 name:           unison-util
 version:        0.0.0
@@ -34,7 +34,7 @@ library
   other-modules:
       Paths_unison_util
   hs-source-dirs:
-      ./.
+      ./
   build-depends:
       base
     , bytestring

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -1,10 +1,8 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: 5e77fbdaa4e4dd9e6c0340ce6e920cdfa53278403b79c0082cf4d16f1249c479
 
 name:           unison-parser-typechecker
 version:        0.0.0
@@ -165,7 +163,19 @@ library
       Paths_unison_parser_typechecker
   hs-source-dirs:
       src
-  default-extensions: ApplicativeDo BlockArguments DeriveFunctor DerivingStrategies DoAndIfThenElse FlexibleContexts FlexibleInstances LambdaCase MultiParamTypeClasses ScopedTypeVariables TupleSections TypeApplications
+  default-extensions:
+      ApplicativeDo
+      BlockArguments
+      DeriveFunctor
+      DerivingStrategies
+      DoAndIfThenElse
+      FlexibleContexts
+      FlexibleInstances
+      LambdaCase
+      MultiParamTypeClasses
+      ScopedTypeVariables
+      TupleSections
+      TypeApplications
   ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
   build-depends:
       ListLike
@@ -276,7 +286,19 @@ executable prettyprintdemo
       Paths_unison_parser_typechecker
   hs-source-dirs:
       prettyprintdemo
-  default-extensions: ApplicativeDo BlockArguments DeriveFunctor DerivingStrategies DoAndIfThenElse FlexibleContexts FlexibleInstances LambdaCase MultiParamTypeClasses ScopedTypeVariables TupleSections TypeApplications
+  default-extensions:
+      ApplicativeDo
+      BlockArguments
+      DeriveFunctor
+      DerivingStrategies
+      DoAndIfThenElse
+      FlexibleContexts
+      FlexibleInstances
+      LambdaCase
+      MultiParamTypeClasses
+      ScopedTypeVariables
+      TupleSections
+      TypeApplications
   ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
   build-depends:
       base
@@ -330,7 +352,19 @@ executable tests
       Paths_unison_parser_typechecker
   hs-source-dirs:
       tests
-  default-extensions: ApplicativeDo BlockArguments DeriveFunctor DerivingStrategies DoAndIfThenElse FlexibleContexts FlexibleInstances LambdaCase MultiParamTypeClasses ScopedTypeVariables TupleSections TypeApplications
+  default-extensions:
+      ApplicativeDo
+      BlockArguments
+      DeriveFunctor
+      DerivingStrategies
+      DoAndIfThenElse
+      FlexibleContexts
+      FlexibleInstances
+      LambdaCase
+      MultiParamTypeClasses
+      ScopedTypeVariables
+      TupleSections
+      TypeApplications
   ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -W -threaded -rtsopts "-with-rtsopts=-N -T" -v0
   build-depends:
       async
@@ -369,7 +403,19 @@ executable transcripts
       Paths_unison_parser_typechecker
   hs-source-dirs:
       transcripts
-  default-extensions: ApplicativeDo BlockArguments DeriveFunctor DerivingStrategies DoAndIfThenElse FlexibleContexts FlexibleInstances LambdaCase MultiParamTypeClasses ScopedTypeVariables TupleSections TypeApplications
+  default-extensions:
+      ApplicativeDo
+      BlockArguments
+      DeriveFunctor
+      DerivingStrategies
+      DoAndIfThenElse
+      FlexibleContexts
+      FlexibleInstances
+      LambdaCase
+      MultiParamTypeClasses
+      ScopedTypeVariables
+      TupleSections
+      TypeApplications
   ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -threaded -rtsopts -with-rtsopts=-N -v0
   build-depends:
       base
@@ -393,7 +439,19 @@ executable unison
       Paths_unison_parser_typechecker
   hs-source-dirs:
       unison
-  default-extensions: ApplicativeDo BlockArguments DeriveFunctor DerivingStrategies DoAndIfThenElse FlexibleContexts FlexibleInstances LambdaCase MultiParamTypeClasses ScopedTypeVariables TupleSections TypeApplications
+  default-extensions:
+      ApplicativeDo
+      BlockArguments
+      DeriveFunctor
+      DerivingStrategies
+      DoAndIfThenElse
+      FlexibleContexts
+      FlexibleInstances
+      LambdaCase
+      MultiParamTypeClasses
+      ScopedTypeVariables
+      TupleSections
+      TypeApplications
   ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -threaded -rtsopts -with-rtsopts=-I0 -optP-Wno-nonportable-include-path
   build-depends:
       base
@@ -429,7 +487,19 @@ benchmark runtime
       Paths_unison_parser_typechecker
   hs-source-dirs:
       benchmarks/runtime
-  default-extensions: ApplicativeDo BlockArguments DeriveFunctor DerivingStrategies DoAndIfThenElse FlexibleContexts FlexibleInstances LambdaCase MultiParamTypeClasses ScopedTypeVariables TupleSections TypeApplications
+  default-extensions:
+      ApplicativeDo
+      BlockArguments
+      DeriveFunctor
+      DerivingStrategies
+      DoAndIfThenElse
+      FlexibleContexts
+      FlexibleInstances
+      LambdaCase
+      MultiParamTypeClasses
+      ScopedTypeVariables
+      TupleSections
+      TypeApplications
   ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
   build-depends:
       base

--- a/unison-core/unison-core1.cabal
+++ b/unison-core/unison-core1.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 362988cc0b4fcb2d0837196a3dfe72c8d5905b654c52b8f82552a1bbcc879214
+-- hash: 25e073d1bb732e90d3e1d3999ec516185669150701345da4fcd35cb20389334d
 
 name:           unison-core1
 version:        0.0.0
@@ -64,7 +64,19 @@ library
       Paths_unison_core1
   hs-source-dirs:
       src
-  default-extensions: ApplicativeDo BlockArguments DeriveFunctor DerivingStrategies DoAndIfThenElse FlexibleContexts FlexibleInstances LambdaCase MultiParamTypeClasses ScopedTypeVariables TupleSections TypeApplications
+  default-extensions:
+      ApplicativeDo
+      BlockArguments
+      DeriveFunctor
+      DerivingStrategies
+      DoAndIfThenElse
+      FlexibleContexts
+      FlexibleInstances
+      LambdaCase
+      MultiParamTypeClasses
+      ScopedTypeVariables
+      TupleSections
+      TypeApplications
   ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -funbox-strict-fields
   build-depends:
       base


### PR DESCRIPTION
caused some minor hpack output diffs; hopefully re-running on an older version doesn't unmake them, but I didn't have an easy way to find out.

If desired, you can upgrade your local version of `stack` as well with `stack upgrade`.