### PR TITLE
Add @typecheck block for including code snippets that are typechecked but not evaluated

### DIFF
--- a/parser-typechecker/src/Unison/CommandLine/DisplayValues.hs
+++ b/parser-typechecker/src/Unison/CommandLine/DisplayValues.hs
@@ -142,6 +142,11 @@ displayPretty pped terms typeOf eval types tm = go tm
       P.backticked <$> displayTerm pped terms typeOf eval types ex
       where ex = Term.lam' (ABT.annotation body) (drop (fromIntegral n) vs) body
 
+    DD.Doc2SpecialFormExampleBlock n (DD.Doc2Example vs body) ->
+      -- todo: maybe do something with `vs` to indicate the variables are free
+      P.indentN 4 <$> displayTerm pped terms typeOf eval types ex
+      where ex = Term.lam' (ABT.annotation body) (drop (fromIntegral n) vs) body
+
     -- Link (Either Link.Type Doc2.Term)
     DD.Doc2SpecialFormLink e -> let
       ppe = PPE.suffixifiedPPE pped

--- a/parser-typechecker/src/Unison/CommandLine/DisplayValues.hs
+++ b/parser-typechecker/src/Unison/CommandLine/DisplayValues.hs
@@ -43,10 +43,20 @@ displayTerm :: (Var v, Monad m)
            -> m Pretty
 displayTerm = displayTerm' False
 
+-- Whether to elide printing of `()` at the end of a block
+-- For instance, in:
+--
+--   id x = x
+--   ()
+--
+-- We could render it as above, with the `()` explicit, or just as:
+--
+--   id x = x
+--
 type ElideUnit = Bool
 
 displayTerm' :: (Var v, Monad m)
-           => ElideUnit -- whether to elide printing of `()` from the end of the block
+           => ElideUnit
            -> PPE.PrettyPrintEnvDecl
            -> (Reference -> m (Maybe (Term v ())))
            -> (Referent -> m (Maybe (Type v ())))

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -269,6 +269,17 @@ lexemes = lexemes' eof
     l <- S.gets layout
     pure $ replicate (length l + n) (Token Close p p)
 
+restoreStack :: String -> P [Token Lexeme] -> P [Token Lexeme]
+restoreStack lbl p = do
+  layout1 <- S.gets layout
+  p <- p
+  s2 <- S.get
+  let
+    (pos1,pos2) = foldl' (\_ b -> (start b, end b)) mempty p
+    unclosed = takeWhile (\(lbl',_) -> lbl' /= lbl) (layout s2)
+    closes = replicate (length unclosed) (Token Close pos1 pos2)
+  S.put (s2 { layout = layout1 })
+  pure $ p <> closes
 
 lexemes' :: P [Token Lexeme] -> P [Token Lexeme]
 lexemes' eof = P.optional space >> do
@@ -334,7 +345,7 @@ lexemes' eof = P.optional space >> do
 
     leafy ok = groupy ok gs
           where
-          gs = link <|> externalLink <|> example <|> expr
+          gs = link <|> externalLink <|> exampleInline <|> expr
            <|> boldOrItalicOrStrikethrough ok <|> verbatim
            <|> atDoc <|> wordy ok
 
@@ -414,23 +425,14 @@ lexemes' eof = P.optional space >> do
       dropNl ('\n':t) = t
       dropNl as = as
 
-    example = do
-      ts@(Token (Open "syntax.docExample") start stop : rest) <- ticked
-      spaces <- P.lookAhead (P.takeWhileP Nothing isSpace)
-      let hasBlank s = length (filter (== '\n') s) >= 2
-      if hasBlank spaces then
-        pure (Token (Open "syntax.docExampleBlock") start stop : rest)
-      else
-        pure ts
-      where
-        ticked =
-          P.label "inline code (examples: ``List.map f xs``, ``[1] :+ 2``)" $
-          wrap "syntax.docExample" $ do
-            n <- P.try $ do _ <- lit "`"
-                            length <$> P.takeWhile1P (Just "backticks") (== '`')
-            let end :: P [Token Lexeme] = [] <$ lit (replicate (n+1) '`')
-            ex <- CP.space *> lexemes' end
-            pure ex
+    exampleInline =
+      P.label "inline code (examples: ``List.map f xs``, ``[1] :+ 2``)" $
+      wrap "syntax.docExample" $ do
+        n <- P.try $ do _ <- lit "`"
+                        length <$> P.takeWhile1P (Just "backticks") (== '`')
+        let end :: P [Token Lexeme] = [] <$ lit (replicate (n+1) '`')
+        ex <- CP.space *> lexemes' end
+        pure ex
 
     docClose = [] <$ lit "}}"
     docOpen  = [] <$ lit "{{"
@@ -450,9 +452,9 @@ lexemes' eof = P.optional space >> do
 
     fencedBlock =
       P.label "block eval (syntax: a fenced code block)" $
-      unison <|> other
+      evalUnison <|> typecheckUnison <|> other
       where
-        unison = wrap "syntax.docEval" $ do
+        evalUnison = wrap "syntax.docEval" $ do
           -- commit after seeing that ``` is on its own line
           fence <- P.try $ do
             fence <- lit "```" <+> P.many (CP.satisfy (== '`'))
@@ -461,6 +463,12 @@ lexemes' eof = P.optional space >> do
           CP.space *>
             local (\env -> env { inLayout = True, opening = Just "docEval" })
                   (lexemes' ([] <$ lit fence))
+
+        typecheckUnison = wrap "syntax.docExampleBlock" $ do
+          void $ lit "@typecheck" <* CP.space
+          fence <- lit "```" <+> P.many (CP.satisfy (== '`'))
+          local (\env -> env { inLayout = True, opening = Just "docExampleBlock" })
+                (restoreStack "docExampleBlock" $ lexemes' ([] <$ lit fence))
 
         other = wrap "syntax.docCodeBlock" $ do
           fence <- lit "```" <+> P.many (CP.satisfy (== '`'))

--- a/parser-typechecker/src/Unison/Runtime/IOSource.hs
+++ b/parser-typechecker/src/Unison/Runtime/IOSource.hs
@@ -111,6 +111,7 @@ pattern Doc2SpecialFormRef <- ((== doc2SpecialFormRef) -> True)
 doc2SpecialFormSourceId = constructorNamed doc2SpecialFormRef "Doc2.SpecialForm.Source"
 doc2SpecialFormFoldedSourceId = constructorNamed doc2SpecialFormRef "Doc2.SpecialForm.FoldedSource"
 doc2SpecialFormExampleId = constructorNamed doc2SpecialFormRef "Doc2.SpecialForm.Example"
+doc2SpecialFormExampleBlockId = constructorNamed doc2SpecialFormRef "Doc2.SpecialForm.ExampleBlock"
 doc2SpecialFormLinkId = constructorNamed doc2SpecialFormRef "Doc2.SpecialForm.Link"
 doc2SpecialFormSignatureId = constructorNamed doc2SpecialFormRef "Doc2.SpecialForm.Signature"
 doc2SpecialFormSignatureInlineId = constructorNamed doc2SpecialFormRef "Doc2.SpecialForm.SignatureInline"
@@ -122,6 +123,7 @@ doc2SpecialFormEmbedInlineId = constructorNamed doc2SpecialFormRef "Doc2.Special
 pattern Doc2SpecialFormSource tm <- Term.App' (Term.Constructor' Doc2SpecialFormRef ((==) doc2SpecialFormSourceId -> True)) tm
 pattern Doc2SpecialFormFoldedSource tm <- Term.App' (Term.Constructor' Doc2SpecialFormRef ((==) doc2SpecialFormFoldedSourceId -> True)) tm
 pattern Doc2SpecialFormExample n tm <- Term.Apps' (Term.Constructor' Doc2SpecialFormRef ((==) doc2SpecialFormExampleId -> True)) [Term.Nat' n, tm]
+pattern Doc2SpecialFormExampleBlock n tm <- Term.Apps' (Term.Constructor' Doc2SpecialFormRef ((==) doc2SpecialFormExampleBlockId -> True)) [Term.Nat' n, tm]
 pattern Doc2SpecialFormLink tm <- Term.App' (Term.Constructor' Doc2SpecialFormRef ((==) doc2SpecialFormLinkId -> True)) tm
 pattern Doc2SpecialFormSignature tm <- Term.App' (Term.Constructor' Doc2SpecialFormRef ((==) doc2SpecialFormSignatureId -> True)) tm
 pattern Doc2SpecialFormSignatureInline tm <- Term.App' (Term.Constructor' Doc2SpecialFormRef ((==) doc2SpecialFormSignatureInlineId -> True)) tm
@@ -306,6 +308,8 @@ unique[da70bff6431da17fa515f3d18ded11852b6a745f] type Doc2.SpecialForm
   -- Ex: `Example 2 '(x y -> foo x y)` should render as `foo x y`.
   -- Ex: `Example 0 '(1 + 1)` should render as `42`.
   | Example Nat Doc2.Term
+  -- Same as `Example`, but as a block rather than inline element
+  | ExampleBlock Nat Doc2.Term
   -- {type Optional} or {List.map}
   | Link (Either Link.Type Doc2.Term)
   -- @signatures{List.map, List.filter, List.foldLeft}
@@ -538,6 +542,7 @@ syntax.docVerbatim c = CodeBlock "raw" c
 syntax.docEval d = Special (Eval (Doc2.term d))
 syntax.docEvalInline a = Special (EvalInline (Doc2.term a))
 syntax.docExample n a = Special (Example n (Doc2.term a))
+syntax.docExampleBlock n a = Special (ExampleBlock n (Doc2.term a))
 syntax.docLink t = Special (Link t)
 syntax.docTransclude d =
   guid = "b7a4fb87e34569319591130bf3ec6e24"

--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -488,7 +488,7 @@ doc2Block =
       "syntax.docEvalInline" -> evalLike addDelay
       "syntax.docExampleBlock" -> do
         tm <- block'' False True "syntax.docExampleBlock" (pure (void t)) closeBlock
-        pure $ Term.apps' f [addDelay tm]
+        pure $ Term.apps' f [Term.nat (ann tm) 0, addDelay tm]
       "syntax.docEval" -> do
         tm <- block' False "syntax.docEval" (pure (void t)) closeBlock
         pure $ Term.apps' f [addDelay tm]
@@ -965,6 +965,11 @@ data BlockElement v
   = Binding ((Ann, v), Term v Ann)
   | DestructuringBind (Ann, Term v Ann -> Term v Ann)
   | Action (Term v Ann)
+
+instance Show v => Show (BlockElement v) where
+  show (Binding ((pos,name), _)) = show ("binding: ", pos, name)
+  show (DestructuringBind (pos, _)) = show ("destructuring bind: ", pos)
+  show (Action tm) = show ("action: ", ann tm)
 
 -- subst
 -- use Foo.Bar + blah

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -1279,6 +1279,8 @@ prettyDoc2 ppe ac tm = case tm of
         "@eval{" <> pretty0 ppe ac tm <> "}"
       (toDocExample ppe -> Just tm) ->
         PP.group $ "``" <> pretty0 ppe ac tm <> "``"
+      (toDocExampleBlock ppe -> Just tm) ->
+        PP.lines ["@typecheck ```", pretty0 ppe ac tm, "```"]
       (toDocSource ppe -> Just es) ->
         PP.group $ "    @source{" <> intercalateMap ", " go es <> "}"
         where

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -1382,7 +1382,7 @@ toDocExample' suffix ppe (Apps' (Ref' r) [Nat' n, l@(LamsNamed' vs tm)])
   | nameEndsWith ppe suffix r,
     ABT.freeVars l == mempty,
     ok tm =
-    Just (lam' (ABT.annotation l) (drop (fromIntegral n) vs) tm)
+    Just (lam' (ABT.annotation l) (drop (fromIntegral n + 1) vs) tm)
   where
     ok (Apps' f _) = ABT.freeVars f == mempty
     ok tm = ABT.freeVars tm == mempty

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -50,8 +50,10 @@ import qualified Unison.ConstructorType as CT
 pretty :: Var v => PrettyPrintEnv -> Term v a -> Pretty ColorText
 pretty env = PP.syntaxToColor . pretty0 env emptyAc . printAnnotate env
 
-prettyBlock :: Var v => PrettyPrintEnv -> Term v a -> Pretty ColorText
-prettyBlock env = PP.syntaxToColor . pretty0 env emptyBlockAc . printAnnotate env
+prettyBlock :: Var v => Bool -> PrettyPrintEnv -> Term v a -> Pretty ColorText
+prettyBlock elideUnit env =
+  PP.syntaxToColor . pretty0 env (emptyBlockAc { elideUnit = elideUnit })
+                   . printAnnotate env
 
 pretty' :: Var v => Maybe Width -> PrettyPrintEnv -> Term v a -> ColorText
 pretty' (Just width) n t =

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -1371,16 +1371,20 @@ toDocEvalInline ppe (App' (Ref' r) (Delay' tm))
   | nameEndsWith ppe ".docEvalInline" r = Just tm
 toDocEvalInline _ _ = Nothing
 
-toDocExample :: Ord v => PrettyPrintEnv -> Term3 v PrintAnnotation -> Maybe (Term3 v PrintAnnotation)
-toDocExample ppe (Apps' (Ref' r) [Nat' n, l@(LamsNamed' vs tm)])
-  | nameEndsWith ppe ".docExample" r,
+toDocExample, toDocExampleBlock :: Ord v => PrettyPrintEnv -> Term3 v PrintAnnotation -> Maybe (Term3 v PrintAnnotation)
+toDocExample = toDocExample' ".docExample"
+toDocExampleBlock = toDocExample' ".docExampleBlock"
+
+toDocExample' :: Ord v => Text -> PrettyPrintEnv -> Term3 v PrintAnnotation -> Maybe (Term3 v PrintAnnotation)
+toDocExample' suffix ppe (Apps' (Ref' r) [Nat' n, l@(LamsNamed' vs tm)])
+  | nameEndsWith ppe suffix r,
     ABT.freeVars l == mempty,
     ok tm =
     Just (lam' (ABT.annotation l) (drop (fromIntegral n) vs) tm)
   where
     ok (Apps' f _) = ABT.freeVars f == mempty
     ok tm = ABT.freeVars tm == mempty
-toDocExample _ _ = Nothing
+toDocExample' _ _ _ = Nothing
 
 toDocTransclude :: PrettyPrintEnv -> Term3 v PrintAnnotation -> Maybe (Term3 v PrintAnnotation)
 toDocTransclude ppe (App' (Ref' r) tm)

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -71,6 +71,7 @@ data AmbientContext = AmbientContext
   , infixContext :: InfixContext
   , imports :: Imports
   , docContext :: DocLiteralContext
+  , elideUnit :: Bool -- `True` if a `()` at the end of a block should be elided
   }
 
 -- Description of the position of this ABT node, when viewed in the
@@ -162,6 +163,7 @@ pretty0
   , infixContext = ic
   , imports = im
   , docContext = doc
+  , elideUnit = elideUnit
   }
   term
   -- Note: the set of places in this function that call calcImports has to be kept in sync
@@ -258,7 +260,7 @@ pretty0
       ]
     LetBlock bs e ->
       let (im', uses) = calcImports im term
-      in printLet bc bs e im' uses
+      in printLet elideUnit bc bs e im' uses
     -- Some matches are rendered as a destructuring bind, like
     --   match foo with (a,b) -> blah
     -- becomes
@@ -334,18 +336,20 @@ pretty0
   commaList = sepList (fmt S.DelimiterChar (l ",") <> PP.softbreak)
 
   printLet :: Var v
-           => BlockContext
+           => Bool -- elideUnit
+           -> BlockContext
            -> [(v, Term3 v PrintAnnotation)]
            -> Term3 v PrintAnnotation
            -> Imports
            -> ([Pretty SyntaxText] -> Pretty SyntaxText)
            -> Pretty SyntaxText
-  printLet sc bs e im uses =
+  printLet elideUnit sc bs e im uses =
     paren ((sc /= Block) && p >= 12)
       $  letIntro
-      $  (uses [(PP.lines (map printBinding bs ++
-                            [PP.group $ pretty0 n (ac 0 Normal im doc) e]))])
+      $  uses [PP.lines (map printBinding bs ++ body e)]
    where
+    body (Constructor' DD.UnitRef 0) | elideUnit = []
+    body e = [PP.group $ pretty0 n (ac 0 Normal im doc) e]
     printBinding (v, binding) = if isBlank $ Var.nameStr v
       then pretty0 n (ac (-1) Normal im doc) binding
       else prettyBinding0 n (ac (-1) Normal im doc) (HQ.unsafeFromVar v) binding
@@ -392,7 +396,7 @@ pretty0
       _ -> error "??"
     ps = join $ [r a f | (a, f) <- reverse xs ]
     r a f = [pretty0 n (ac 3 Normal im doc) a,
-             pretty0 n (AmbientContext 10 Normal Infix im doc) f]
+             pretty0 n (AmbientContext 10 Normal Infix im doc False) f]
 
 prettyPattern
   :: forall v loc . Var v
@@ -675,7 +679,7 @@ emptyBlockAc :: AmbientContext
 emptyBlockAc = ac (-1) Block Map.empty MaybeDoc
 
 ac :: Int -> BlockContext -> Imports -> DocLiteralContext -> AmbientContext
-ac prec bc im doc = AmbientContext prec bc NonInfix im doc
+ac prec bc im doc = AmbientContext prec bc NonInfix im doc False
 
 fmt :: (S.Element r) -> Pretty (S.SyntaxText' r) -> Pretty (S.SyntaxText' r)
 fmt = PP.withSyntax
@@ -1280,7 +1284,8 @@ prettyDoc2 ppe ac tm = case tm of
       (toDocExample ppe -> Just tm) ->
         PP.group $ "``" <> pretty0 ppe ac tm <> "``"
       (toDocExampleBlock ppe -> Just tm) ->
-        PP.lines ["@typecheck ```", pretty0 ppe ac tm, "```"]
+        PP.lines ["@typecheck ```", pretty0 ppe ac' tm, "```"]
+        where ac' = ac { elideUnit = True }
       (toDocSource ppe -> Just es) ->
         PP.group $ "    @source{" <> intercalateMap ", " go es <> "}"
         where

--- a/unison-src/transcripts-using-base/doc.md.files/syntax.u
+++ b/unison-src/transcripts-using-base/doc.md.files/syntax.u
@@ -73,6 +73,13 @@ id x = x
 id (sqr 10)
 ``` 
 
+Use two backticks if you just want to include a snippet of code without evaluating it. 
+
+``
+cube : Nat -> Nat
+cube x = x * x * x
+``
+
 }}
 
 sqr x = x Nat.* x

--- a/unison-src/transcripts-using-base/doc.md.files/syntax.u
+++ b/unison-src/transcripts-using-base/doc.md.files/syntax.u
@@ -73,12 +73,12 @@ id x = x
 id (sqr 10)
 ``` 
 
-Use two backticks if you just want to include a snippet of code without evaluating it. 
+To include a typechecked snippet of code without evaluating it, you can do:
 
-``
+@typecheck ```
 cube : Nat -> Nat
 cube x = x * x * x
-``
+```
 
 }}
 

--- a/unison-src/transcripts-using-base/doc.output.md
+++ b/unison-src/transcripts-using-base/doc.output.md
@@ -287,7 +287,6 @@ and the rendered output using `display`:
         cube x =
           use Nat *
           x * x * x
-        ()
 
 .> view includingSource
 
@@ -625,7 +624,6 @@ Lastly, it's common to build longer documents including subdocuments via `{{ sub
           cube x =
             use Nat *
             x * x * x
-          ()
   
     # Including Unison source code
     

--- a/unison-src/transcripts-using-base/doc.output.md
+++ b/unison-src/transcripts-using-base/doc.output.md
@@ -261,7 +261,7 @@ and the rendered output using `display`:
       evaluating it, you can do:
       
       @typecheck ```
-      _ -> ()
+      ()
       ```
     }}
 
@@ -316,7 +316,7 @@ and the rendered output using `display`:
            be clickable.
          * If your snippet expression is just a single function
            application, you can put it in double backticks, like
-           so: ``x -> sqr x``. This is equivalent to
+           so: ``sqr x``. This is equivalent to
            {{ docExample 1 '(x -> sqr x) }}.
     }}
 

--- a/unison-src/transcripts-using-base/doc.output.md
+++ b/unison-src/transcripts-using-base/doc.output.md
@@ -256,6 +256,13 @@ and the rendered output using `display`:
       id x = x
       id (sqr 10)
       ```
+      
+      To include a typechecked snippet of code without
+      evaluating it, you can do:
+      
+      @typecheck ```
+      _ -> ()
+      ```
     }}
 
 .> display evaluation
@@ -270,6 +277,11 @@ and the rendered output using `display`:
         id (sqr 10)
         ⧨
         100
+  
+    To include a typechecked snippet of code without evaluating
+    it, you can do:
+  
+        ()
 
 .> view includingSource
 
@@ -600,6 +612,11 @@ Lastly, it's common to build longer documents including subdocuments via `{{ sub
           id (sqr 10)
           ⧨
           100
+    
+      To include a typechecked snippet of code without
+      evaluating it, you can do:
+    
+          ()
   
     # Including Unison source code
     

--- a/unison-src/transcripts-using-base/doc.output.md
+++ b/unison-src/transcripts-using-base/doc.output.md
@@ -265,7 +265,6 @@ and the rendered output using `display`:
       cube x =
         use Nat *
         x * x * x
-      ()
       ```
     }}
 

--- a/unison-src/transcripts-using-base/doc.output.md
+++ b/unison-src/transcripts-using-base/doc.output.md
@@ -261,6 +261,10 @@ and the rendered output using `display`:
       evaluating it, you can do:
       
       @typecheck ```
+      cube : Nat -> Nat
+      cube x =
+        use Nat *
+        x * x * x
       ()
       ```
     }}
@@ -281,6 +285,9 @@ and the rendered output using `display`:
     To include a typechecked snippet of code without evaluating
     it, you can do:
   
+        cube x =
+          use Nat *
+          x * x * x
         ()
 
 .> view includingSource
@@ -616,6 +623,9 @@ Lastly, it's common to build longer documents including subdocuments via `{{ sub
       To include a typechecked snippet of code without
       evaluating it, you can do:
     
+          cube x =
+            use Nat *
+            x * x * x
           ()
   
     # Including Unison source code

--- a/unison-src/transcripts/emptyCodebase.output.md
+++ b/unison-src/transcripts/emptyCodebase.output.md
@@ -35,7 +35,7 @@ And for a limited time, you can get even more builtin goodies:
 
 .foo> ls
 
-  1. builtin/ (503 definitions)
+  1. builtin/ (505 definitions)
 
 ```
 More typically, you'd start out by pulling `base.


### PR DESCRIPTION
This addresses the first item of #1912. It adds a new block element type:

````
@typecheck ```
foo : Nat -> Nat
foo x = x + 1
```
````

Which just typechecks the above but doesn't evaluate it. Added a test to the `doc.md` transcript.

This syntax can be changed easily later if anyone has strong feelings about it.

I decided not to try either of the other items from #1912 for now.