### PR TITLE
drop Reference.Id cycle length from Eq/Ord instances

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -258,7 +258,7 @@ sqliteCodebase root = do
           getCycleLen :: EDB m => String -> Hash -> m Reference.Size
           getCycleLen source h = do
             (Ops.getCycleLen . Cv.hash1to2) h `Except.catchError` \case
-              e@(Ops.DatabaseIntegrityError (Q.NoObjectForPrimaryHashId {})) -> error $ show e ++ " in " ++ source
+              e@(Ops.DatabaseIntegrityError (Q.NoObjectForPrimaryHashId {})) -> pure . error $ show e ++ " in " ++ source
               e -> Except.throwError e
 
           getDeclType :: EDB m => C.Reference.Reference -> m CT.ConstructorType

--- a/unison-core/src/Unison/Reference.hs
+++ b/unison-core/src/Unison/Reference.hs
@@ -191,9 +191,6 @@ instance Hashable.Hashable Reference where
   tokens (Builtin txt) = [Hashable.Tag 0, Hashable.Text txt]
   tokens (DerivedId (Id h i n)) = [Hashable.Tag 1, Hashable.Bytes (H.toBytes h), Hashable.Nat i, Hashable.Nat n]
 
--- | A simpler version of `Id` that we'll use for some derived instances.
-data Id' = Id' H.Hash Pos deriving (Eq, Ord)
-toId' :: Id -> Id'
-toId' (Id h p _) = Id' h p
+-- | Two references mustn't differ in cycle length only.
 instance Eq Id where x == y = compare x y == EQ
 instance Ord Id where Id h i _ `compare` Id h2 i2 _  = compare h h2 <> compare i i2

--- a/unison-core/src/Unison/Reference.hs
+++ b/unison-core/src/Unison/Reference.hs
@@ -195,5 +195,5 @@ instance Hashable.Hashable Reference where
 data Id' = Id' H.Hash Pos deriving (Eq, Ord)
 toId' :: Id -> Id'
 toId' (Id h p _) = Id' h p
-instance Eq Id where x == y = toId' x == toId' y
-instance Ord Id where x `compare` y = toId' x `compare` toId' y
+instance Eq Id where x == y = compare x y == EQ
+instance Ord Id where Id h i _ `compare` Id h2 i2 _  = compare h h2 <> compare i i2

--- a/unison-core/src/Unison/Reference.hs
+++ b/unison-core/src/Unison/Reference.hs
@@ -61,7 +61,7 @@ pattern Derived h i n = DerivedId (Id h i n)
 --{-# COMPLETE Builtin, Derived #-}
 
 -- | @Pos@ is a position into a cycle of size @Size@, as cycles are hashed together.
-data Id = Id H.Hash Pos Size deriving (Eq,Ord,Generic)
+data Id = Id H.Hash Pos Size deriving (Generic)
 
 unsafeId :: Reference -> Id
 unsafeId (Builtin b) =
@@ -190,3 +190,10 @@ instance Show Reference where show = SH.toString . SH.take 5 . toShortHash
 instance Hashable.Hashable Reference where
   tokens (Builtin txt) = [Hashable.Tag 0, Hashable.Text txt]
   tokens (DerivedId (Id h i n)) = [Hashable.Tag 1, Hashable.Bytes (H.toBytes h), Hashable.Nat i, Hashable.Nat n]
+
+-- | A simpler version of `Id` that we'll use for some derived instances.
+data Id' = Id' H.Hash Pos deriving (Eq, Ord)
+toId' :: Id -> Id'
+toId' (Id h p _) = Id' h p
+instance Eq Id where x == y = toId' x == toId' y
+instance Ord Id where x `compare` y = toId' x `compare` toId' y

--- a/unison-src/transcripts/fix1926.md
+++ b/unison-src/transcripts/fix1926.md
@@ -1,0 +1,19 @@
+```ucm
+.> builtins.merge
+```
+
+```unison
+> 'let
+   id x = sq x
+   ()
+
+sq x = x Nat.* x
+```
+
+```unison
+> 'let
+   id x = sq x
+   ()
+
+sq x = x Nat.* x
+```

--- a/unison-src/transcripts/fix1926.md
+++ b/unison-src/transcripts/fix1926.md
@@ -3,17 +3,13 @@
 ```
 
 ```unison
-> 'let
-   id x = sq x
-   ()
+> 'sq
 
-sq x = x Nat.* x
+sq = 2934892384
 ```
 
 ```unison
-> 'let
-   id x = sq x
-   ()
+> 'sq
 
-sq x = x Nat.* x
+sq = 2934892384
 ```


### PR DESCRIPTION
## Overview

This PR takes the cycle length field out of the `Eq` and `Ord` instances for `Reference.Id`, so that they can be found in a collection even if the cycle size isn't known at query time.

## Interesting/controversial decisions

I still produce an `error` when looking up an unknown cycle length in the v2 codebase (though only if the value is bound and then forced), so that will be something to keep an eye on going forward.

## Test coverage

It includes the previously-failing transcript that inspired #1926.

