### PR TITLE
close sqlite connections again

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -174,10 +174,11 @@ data Command m i v a where
   LoadLocalBranch :: Branch.Hash -> Command m i v (Branch m)
 
   ViewRemoteBranch ::
-    RemoteNamespace -> Command m i v (Either GitError (Branch m))
+    RemoteNamespace -> Command m i v (Either GitError (m (), Branch m))
 
   -- we want to import as little as possible, so we pass the SBH/path as part
-  -- of the `RemoteNamespace`.
+  -- of the `RemoteNamespace`.  The Branch that's returned should be fully
+  -- imported and not retain any resources from the remote codebase
   ImportRemoteBranch ::
     RemoteNamespace -> SyncMode -> Command m i v (Either GitError (Branch m))
 

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -160,7 +160,7 @@ codebase1' syncToDirectory branchCache fmtV@(S.Format getV putV) fmtA@(S.Format 
           dependents
           (flip (syncToDirectory fmtV fmtA) path)
           (syncToDirectory fmtV fmtA path)
-          (runExceptT . viewRemoteBranch' Cache.nullCache)
+          (runExceptT . fmap (\(a,b) -> (pure (), a, b)) . viewRemoteBranch' Cache.nullCache)
           (\b r m -> runExceptT $
             pushGitRootBranch (syncToDirectory fmtV fmtA path) Cache.nullCache b r m)
           watches

--- a/parser-typechecker/src/Unison/Codebase/GitError.hs
+++ b/parser-typechecker/src/Unison/Codebase/GitError.hs
@@ -5,6 +5,7 @@ import Unison.Prelude
 import Unison.Codebase.ShortBranchHash (ShortBranchHash)
 import qualified Unison.Codebase.Branch as Branch
 import Unison.Codebase.Editor.RemoteRepo (RemoteRepo)
+import U.Codebase.Sqlite.DbId (SchemaVersion)
 
 type CodebasePath = FilePath
 
@@ -21,6 +22,7 @@ data GitError = NoGit
               | CouldntLoadRootBranch RemoteRepo Branch.Hash
               | CouldntParseRootBranch RemoteRepo String
               | CouldntOpenCodebase RemoteRepo CodebasePath
+              | UnrecognizedSchemaVersion RemoteRepo CodebasePath SchemaVersion
               | SomeOtherError String
               | CouldntLoadSyncedBranch Branch.Hash
               deriving Show

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -112,6 +112,7 @@ import Unison.Codebase.ShortBranchHash (ShortBranchHash)
 import qualified Unison.ShortHash as SH
 import Unison.LabeledDependency as LD
 import Unison.Codebase.Editor.RemoteRepo (RemoteRepo)
+import U.Codebase.Sqlite.DbId (SchemaVersion(SchemaVersion))
 
 type Pretty = P.Pretty P.ColorText
 
@@ -665,6 +666,10 @@ notifyUser dir o = case o of
     CouldntOpenCodebase repo localPath -> P.wrap $ "I couldn't open the repository at"
       <> prettyRepoBranch repo <> "in the cache directory at"
       <> P.backticked' (P.string localPath) "."
+    UnrecognizedSchemaVersion repo localPath (SchemaVersion v) -> P.wrap
+      $ "I don't know how to interpret schema version " <> P.shown v
+      <> "in the repository at" <> prettyRepoBranch repo
+      <> "in the cache directory at" <> P.backticked' (P.string localPath) "."
     CouldntParseRootBranch repo s -> P.wrap $ "I couldn't parse the string"
       <> P.red (P.string s) <> "into a namespace hash, when opening the repository at"
       <> P.group (prettyRepoBranch repo <> ".")

--- a/parser-typechecker/tests/Unison/Test/Codebase/Upgrade12.hs
+++ b/parser-typechecker/tests/Unison/Test/Codebase/Upgrade12.hs
@@ -221,17 +221,18 @@ test = scope "codebase.upgrade12" $ tests [
         .> add
         ```
       |]
-      c1' <- Ucm.lowLevel c1
-      watches1@(_:_) <- Codebase.watches c1' TestWatch
-      watchTerms1 <- traverse (Codebase.getWatch c1' TestWatch) watches1
+      (watches1, watchTerms1) <- Ucm.lowLevel c1 \c1' -> do
+        watches1@(_:_) <- Codebase.watches c1' TestWatch
+        watchTerms1 <- traverse (Codebase.getWatch c1' TestWatch) watches1
+        pure (watches1, watchTerms1)
       Ucm.runTranscript c1 [i|
         ```unison
         test> pass = [Ok "Passed"]
         ```
       |]
       c2 <- Ucm.upgradeCodebase c1
-      c2' <- Ucm.lowLevel c2
-      watchTerms2 <- traverse (Codebase.getWatch c2' TestWatch) watches1
+      watchTerms2 <- Ucm.lowLevel c2 \c2' ->
+        traverse (Codebase.getWatch c2' TestWatch) watches1
       traceShowM watches1
       traceShowM watchTerms1
       traceShowM watchTerms2

--- a/parser-typechecker/tests/Unison/Test/Git.hs
+++ b/parser-typechecker/tests/Unison/Test/Git.hs
@@ -56,7 +56,7 @@ syncComplete = scope "syncComplete" $ do
     observe title expectation files = scope title . for_ files $ \path ->
       scope (makeTitle path) $ io (doesFileExist $ targetDir </> path) >>= expectation
 
-  (_, codebase) <- io $ initCodebase tmp "codebase"
+  (_, cleanup, codebase) <- io $ initCodebase tmp "codebase"
 
   runTranscript_ tmp codebase [i|
     ```ucm:hide
@@ -100,7 +100,9 @@ syncComplete = scope "syncComplete" $ do
   observe "complete" expect files
 
   -- if we haven't crashed, clean up!
-  io $ removeDirectoryRecursive tmp
+  io do
+    cleanup
+    removeDirectoryRecursive tmp
 
   where
   files =
@@ -115,7 +117,7 @@ syncTestResults = scope "syncTestResults" $ do
   tmp <- io $ Temp.getCanonicalTemporaryDirectory >>= flip Temp.createTempDirectory "syncTestResults"
 
   targetDir <- io $ Temp.createTempDirectory tmp "target"
-  (_, codebase) <- io $ initCodebase tmp "codebase"
+  (_, cleanup, codebase) <- io $ initCodebase tmp "codebase"
 
   runTranscript_ tmp codebase [i|
 ```ucm
@@ -149,7 +151,9 @@ test> tests.x = [Ok "Great!"]
       scope (makeTitle path) $ io (doesFileExist $ targetDir </> path) >>= expect
 
   -- if we haven't crashed, clean up!
-  io $ removeDirectoryRecursive tmp
+  io do
+    cleanup
+    removeDirectoryRecursive tmp
   where
   targetShouldHave =
     [ ".unison/v1/paths/0bnfrk7cu44q0vvaj7a0osl90huv6nj01nkukplcsbgn3i09h6ggbthhrorm01gpqc088673nom2i491fh9rtbqcc6oud6iqq6oam88.ub"
@@ -170,8 +174,8 @@ testPull = scope "pull" $ do
   tmp <- io $ Temp.getCanonicalTemporaryDirectory >>= flip Temp.createTempDirectory "git-pull"
 
   -- initialize author and user codebases
-  (_authorDir, authorCodebase) <- io $ initCodebase tmp "author"
-  (userDir, userCodebase) <- io $ initCodebase tmp "user"
+  (_authorDir, cleanupAuthor, authorCodebase) <- io $ initCodebase tmp "author"
+  (userDir, cleanupUser, userCodebase) <- io $ initCodebase tmp "user"
 
   -- initialize git repo
   let repo = tmp </> "repo.git"
@@ -226,7 +230,10 @@ testPull = scope "pull" $ do
       scope (makeTitle path) $ io (doesFileExist $ userDir </> path) >>= expect . not
 
   -- if we haven't crashed, clean up!
-  io $ removeDirectoryRecursive tmp
+  io $ do
+    cleanupAuthor
+    cleanupUser
+    removeDirectoryRecursive tmp
 
   where
   gitShouldHave = userShouldHave ++ userShouldNotHave
@@ -288,11 +295,11 @@ testPull = scope "pull" $ do
     ]
 
 -- initialize a fresh codebase
-initCodebase :: FilePath -> String -> IO (CodebasePath, Codebase IO Symbol Ann)
+initCodebase :: FilePath -> String -> IO (CodebasePath, IO (), Codebase IO Symbol Ann)
 initCodebase tmpDir name = do
   let codebaseDir = tmpDir </> name
-  c <- Codebase.openNewUcmCodebaseOrExit FC.init codebaseDir
-  pure (codebaseDir, c)
+  (cleanup, c) <- Codebase.openNewUcmCodebaseOrExit FC.init codebaseDir
+  pure (codebaseDir, cleanup, c)
 
 -- run a transcript on an existing codebase
 runTranscript_ :: MonadIO m => FilePath -> Codebase IO Symbol Ann -> String -> m ()
@@ -316,7 +323,7 @@ testPush = scope "push" $ do
   tmp <- io $ Temp.getCanonicalTemporaryDirectory >>= flip Temp.createTempDirectory "git-push"
 
   -- initialize a fresh codebase named "c"
-  (codebasePath, c) <- io $ initCodebase tmp "c"
+  (codebasePath, cleanup, c) <- io $ initCodebase tmp "c"
 
   -- Run the "setup transcript" to do the adds and updates; everything short of
   -- pushing.
@@ -345,7 +352,9 @@ testPush = scope "push" $ do
         io (fmap not . doesFileExist $ tmp </> implName </> path) >>= expect
 
   -- if we haven't crashed, clean up!
-  io $ removeDirectoryRecursive tmp
+  io do
+    cleanup
+    removeDirectoryRecursive tmp
 
   where
   setupTranscript = [i|

--- a/parser-typechecker/tests/Unison/Test/Git.hs
+++ b/parser-typechecker/tests/Unison/Test/Git.hs
@@ -100,9 +100,7 @@ syncComplete = scope "syncComplete" $ do
   observe "complete" expect files
 
   -- if we haven't crashed, clean up!
-  io do
-    cleanup
-    removeDirectoryRecursive tmp
+  io do cleanup; removeDirectoryRecursive tmp
 
   where
   files =

--- a/parser-typechecker/tests/Unison/Test/GitSync.hs
+++ b/parser-typechecker/tests/Unison/Test/GitSync.hs
@@ -426,7 +426,6 @@ watchPushPullTest name fmt authorScript userScript codebaseCheck = scope name do
     removeDirectoryRecursive repo
     Ucm.deleteCodebase author
     Ucm.deleteCodebase user
-
   ok
 
 

--- a/parser-typechecker/tests/Unison/Test/GitSync.hs
+++ b/parser-typechecker/tests/Unison/Test/GitSync.hs
@@ -416,8 +416,7 @@ watchPushPullTest name fmt authorScript userScript codebaseCheck = scope name do
     authorOutput <- Ucm.runTranscript author (authorScript repo)
     user <- Ucm.initCodebase fmt
     userOutput <- Ucm.runTranscript user (userScript repo)
-    user' <- Ucm.lowLevel user
-    codebaseCheck user'
+    Ucm.lowLevel user codebaseCheck
 
     when writeTranscriptOutput $ writeFile
       ("unison-src"</>"transcripts"</>("GitSync22." ++ name ++ ".output.md"))
@@ -427,6 +426,7 @@ watchPushPullTest name fmt authorScript userScript codebaseCheck = scope name do
     removeDirectoryRecursive repo
     Ucm.deleteCodebase author
     Ucm.deleteCodebase user
+
   ok
 
 

--- a/parser-typechecker/tests/Unison/Test/Ucm.hs
+++ b/parser-typechecker/tests/Unison/Test/Ucm.hs
@@ -79,7 +79,7 @@ runTranscript (Codebase codebasePath fmt) transcript = do
     pure $ tmpDir </> ".unisonConfig"
   let err err = fail $ "Parse error: \n" <> show err
       cbInit = case fmt of CodebaseFormat1 -> FC.init; CodebaseFormat2 -> SC.init
-  codebase <-
+  (closeCodebase, codebase) <-
     Codebase.Init.openCodebase cbInit codebasePath >>= \case
       Left e -> fail $ P.toANSI 80 e
       Right x -> pure x
@@ -93,6 +93,7 @@ runTranscript (Codebase codebasePath fmt) transcript = do
           configFile
           stanzas
           codebase
+  closeCodebase
   when debugTranscriptOutput $ traceM output
   pure output
 

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -203,7 +203,7 @@ main = do
           ["The Unison Codebase UI is running at", P.string $ url <> "/ui"]
         PT.putPrettyLn . P.string $ "Now starting the Unison Codebase Manager..."
         launch currentDir config theCodebase []
-      	closeCodebase
+        closeCodebase
 
 upgradeCodebase :: Maybe Codebase.CodebasePath -> IO ()
 upgradeCodebase mcodepath =


### PR DESCRIPTION
## Overview

Adds/restores the idea of closing open codebases. It tries to finish using and then close external codebases as quickly as possible.

Closes #1922, and with #1929 should fix #1921.

## Implementation notes

It modifies `Init.createCodebase`, `Init.openCodebase`,  and `Codebase.viewRemoteBranch'` to return an extra `m ()` / `IO ()` action that should be used to close resources that are supporting an open codebase.

The helpers `Init.createCodebaseOrError`, `Init.CreateCodebaseOrError'`, `Codebase.getCodebaseOrExit`, `Codebase.openNewUcmCodebaseOrExit` also return the cleanup action.

## Test coverage

I haven't added any new tests for this, but I'm running `Unison.Test.BaseUpgradePushPullTest` (slow, not part of CI), as I write this, and that seems like it should be pretty thorough.  I guess I could make it part of CI.
