### PR TITLE
add gitsync22.*.lightweightPatch test

### DIFF
--- a/parser-typechecker/tests/Unison/Test/GitSync.hs
+++ b/parser-typechecker/tests/Unison/Test/GitSync.hs
@@ -317,11 +317,14 @@ test = scope "gitsync22" . tests $
       .> builtins.merge
       ```
       ```unison
+      type A = A Nat
+      type B = B Int
       x = 3
       y = 4
       ```
       ```ucm
       .defns> add
+      .patches> replace.type .defns.A .defns.B
       .patches> replace.term .defns.x .defns.y
       .patches> push ${repo}
       ```

--- a/parser-typechecker/tests/Unison/Test/GitSync.hs
+++ b/parser-typechecker/tests/Unison/Test/GitSync.hs
@@ -311,6 +311,29 @@ test = scope "gitsync22" . tests $
       ```
     |])
   ,
+  pushPullTest "lightweightPatch" fmt
+    (\repo -> [i|
+      ```ucm
+      .> builtins.merge
+      ```
+      ```unison
+      x = 3
+      y = 4
+      ```
+      ```ucm
+      .defns> add
+      .patches> replace.term .defns.x .defns.y
+      .patches> push ${repo}
+      ```
+    |])
+    (\repo -> [i|
+      ```ucm
+      .> builtins.merge
+      .> pull ${repo} patches
+      .> view.patch patches.patch
+      ```
+    |])
+  ,
   watchPushPullTest "test-watches" fmt
     (\repo -> [i|
         ```ucm


### PR DESCRIPTION
This adds a test that pushes and pulls a branch containing a patch but not explicitly containing the new or old definitions.  

This will be a sanity check once we quit explicitly syncing the old definitions along with a patch.  

I tried reverting the workaround that made old definitions full dependencies of patches (bd949334a759d8a931bdbeed0dd0969ddc2b97b7), hoping that #1928 would make it unnecessary, but it wasn't immediately the case.