### PR TITLE
Induce better error message when getting a codebase that doesn't exist

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -158,7 +158,11 @@ getCodebaseOrError :: forall m. MonadIO m => CodebasePath -> m (Either Codebase1
 getCodebaseOrError dir = do
   prettyDir <- liftIO $ P.string <$> canonicalizePath dir
   let prettyError v = P.wrap $ "I don't know how to handle " <> P.shown v <> "in" <> P.backticked' prettyDir "."
-  fmap (Either.mapLeft prettyError) (sqliteCodebase dir)
+  doesFileExist (dir </> codebasePath) >>= \case
+    -- If the codebase file doesn't exist, just return any string. The string is currently ignored (see
+    -- Unison.Codebase.Init.getCodebaseOrExit).
+    False -> pure (Left "codebase doesn't exist")
+    True -> fmap (Either.mapLeft prettyError) (sqliteCodebase dir)
 
 initSchemaIfNotExist :: MonadIO m => FilePath -> m ()
 initSchemaIfNotExist path = liftIO do


### PR DESCRIPTION
## Overview

Addresses part of #1915 

This PR makes a minimally-invasive improvement to the UX of running `unison` at the command line before initializing a codebase. (Previously, a SQLError would bubble up to the top level).

## Interesting/controversial decisions

@aryairani and I decided this was ok for now, but noticed a couple weird things along the way that could use some attention, such as how the `Pretty` returned from this function is actually ignored, and replaced by a (nicer) `Pretty` that recommends running some command to initialize the codebase.

Some follow-up work would be good. I recommend going down the route of (whenever in IO, anyway) carving out an exception type for such cases where the application really has no options but to print a nice error message, and just catching these at the top-level. Then, intermediate helper functions need not do any rendering themselves, nor return `Either Pretty Thing` to their callers to indicate an error has occurred.

## Test coverage

No test coverage, but I did run `unison` at the command-line and observed a better error message than prior to this patch.