### PR TITLE
Move LCA calculation to the codebase where possible

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -17,6 +17,7 @@
 {-# LANGUAGE TypeOperators #-}
 module U.Codebase.Sqlite.Queries where
 
+import qualified Control.Exception as Exception
 import Control.Monad (when)
 import Control.Monad.Except (MonadError)
 import qualified Control.Monad.Except as Except
@@ -33,6 +34,7 @@ import qualified Data.List.Extra as List
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as Nel
 import Data.Maybe (fromJust)
+import qualified Data.Set as Set
 import Data.String (fromString)
 import Data.String.Here.Uninterpolated (here, hereFile)
 import Data.Text (Text)
@@ -48,7 +50,7 @@ import Database.SQLite.Simple.FromField (FromField (..))
 import Database.SQLite.Simple.ToField (ToField (..))
 import Debug.Trace (trace, traceM)
 import GHC.Stack (HasCallStack)
-import U.Codebase.HashTags (BranchHash, CausalHash, unBranchHash, unCausalHash)
+import U.Codebase.HashTags (BranchHash (..), CausalHash (..))
 import U.Codebase.Reference (Reference')
 import U.Codebase.Sqlite.DbId
   ( BranchHashId (..),
@@ -167,6 +169,9 @@ loadCausalByCausalHash ch = runMaybeT do
 
 expectHashIdByHash :: EDB m => Hash -> m HashId
 expectHashIdByHash h = loadHashIdByHash h >>= orError (UnknownHash h)
+
+loadHashHashById :: EDB m => HashId -> m Hash
+loadHashHashById h = Hash.fromBase32Hex <$> loadHashById h
 
 loadHashById :: EDB m => HashId -> m Base32Hex
 loadHashById h = queryAtom sql (Only h) >>= orError (UnknownHashId h)
@@ -302,6 +307,9 @@ saveCausal self value = execute sql (self, value) where sql = [here|
 loadCausalValueHashId :: EDB m => CausalHashId -> m BranchHashId
 loadCausalValueHashId chId@(CausalHashId id) =
   loadMaybeCausalValueHashId (id) >>= orError (UnknownCausalHashId chId)
+
+loadCausalHash :: EDB m => CausalHashId -> m CausalHash
+loadCausalHash (CausalHashId id) = CausalHash <$> loadHashHashById id
 
 loadMaybeCausalValueHashId :: DB m => HashId -> m (Maybe BranchHashId)
 loadMaybeCausalValueHashId id =
@@ -557,6 +565,36 @@ namespaceHashIdByBase32Prefix prefix = queryAtoms sql (Only $ prefix <> "%") whe
   WHERE base32 LIKE ?
 |]
 {- ORMOLU_ENABLE -}
+
+-- the `Connection` arguments come second to fit the shape of Exception.bracket + uncurry curry
+lca :: CausalHashId -> CausalHashId -> Connection -> Connection -> IO (Maybe CausalHashId)
+lca x y cx cy = Exception.bracket open close \(sx,sy) -> do
+    SQLite.bind sx (Only x)
+    SQLite.bind sy (Only y)
+    let getNext = (,) <$> SQLite.nextRow sx <*> SQLite.nextRow sy
+        loop seenX seenY = getNext >>= \case
+          (Just (Only px), Just (Only py)) ->
+            if px == py || Set.member px seenY then pure (Just px)
+            else if Set.member py seenX then pure (Just py)
+            else loop (Set.insert px seenX) (Set.insert py seenY)
+          _ -> pure Nothing
+    loop mempty mempty
+  where
+    open = (,) <$> SQLite.openStatement cx sql <*> SQLite.openStatement cy sql
+    close (cx, cy) = SQLite.closeStatement cx *> SQLite.closeStatement cy
+    sql = [here|
+      WITH RECURSIVE
+        found(id) AS (
+          SELECT self_hash_id
+            FROM causal
+            WHERE self_hash_id = ?
+          UNION ALL
+          SELECT parent_id
+            FROM causal_parent
+            INNER JOIN found ON found.id = causal_id
+        )
+      SELECT * FROM found;
+    |]
 
 -- * helper functions
 

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -110,8 +110,8 @@ data Codebase m v a =
 
            , branchHashLength   :: m Int
            , branchHashesByPrefix :: ShortBranchHash -> m (Set Branch.Hash)
+           , lca :: Branch m -> Branch m -> m (Maybe (Branch m))
            }
-
 
 data GetRootBranchError
   = NoRootBranch

--- a/parser-typechecker/src/Unison/Codebase/Causal.hs
+++ b/parser-typechecker/src/Unison/Codebase/Causal.hs
@@ -237,14 +237,23 @@ squashMerge combine c1 c2 = do
 
       | otherwise -> done <$> combine (Just $ head lca) (head c1) (head c2)
 
-threeWayMerge
-  :: forall m h e
+threeWayMerge :: forall m h e
    . (Monad m, Hashable e)
   => (Maybe e -> e -> e -> m e)
   -> Causal m h e
   -> Causal m h e
   -> m (Causal m h e)
-threeWayMerge combine c1 c2 = do
+threeWayMerge = threeWayMerge' lca
+
+threeWayMerge'
+  :: forall m h e
+   . (Monad m, Hashable e)
+  => (Causal m h e -> Causal m h e -> m (Maybe (Causal m h e)))
+  -> (Maybe e -> e -> e -> m e)
+  -> Causal m h e
+  -> Causal m h e
+  -> m (Causal m h e)
+threeWayMerge' lca combine c1 c2 = do
   theLCA <- lca c1 c2
   case theLCA of
     Nothing -> done <$> combine Nothing (head c1) (head c2)

--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -174,7 +174,7 @@ data Command m i v a where
   LoadLocalBranch :: Branch.Hash -> Command m i v (Branch m)
 
   -- Merge two branches, using the codebase for the LCA calculation where possible.
-  Merge :: Branch m -> Branch m -> Command m i v (Branch m)
+  Merge :: Branch.MergeMode -> Branch m -> Branch m -> Command m i v (Branch m)
 
   ViewRemoteBranch ::
     RemoteNamespace -> Command m i v (Either GitError (m (), Branch m))

--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -173,6 +173,9 @@ data Command m i v a where
   -- Like `LoadLocalRootBranch`.
   LoadLocalBranch :: Branch.Hash -> Command m i v (Branch m)
 
+  -- Merge two branches, using the codebase for the LCA calculation where possible.
+  Merge :: Branch m -> Branch m -> Command m i v (Branch m)
+
   ViewRemoteBranch ::
     RemoteNamespace -> Command m i v (Either GitError (m (), Branch m))
 
@@ -262,6 +265,7 @@ commandName = \case
   LoadWatches{}               -> "LoadWatches"
   LoadLocalRootBranch         -> "LoadLocalRootBranch"
   LoadLocalBranch{}           -> "LoadLocalBranch"
+  Merge{}                     -> "Merge"
   ViewRemoteBranch{}          -> "ViewRemoteBranch"
   ImportRemoteBranch{}        -> "ImportRemoteBranch"
   SyncLocalRootBranch{}       -> "SyncLocalRootBranch"

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -115,8 +115,8 @@ commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSour
     Evaluate1 ppe useCache term    -> lift $ eval1 ppe useCache term
     LoadLocalRootBranch        -> lift $ either (const Branch.empty) id <$> Codebase.getRootBranch codebase
     LoadLocalBranch h          -> lift $ fromMaybe Branch.empty <$> Codebase.getBranchForHash codebase h
-    Merge b1 b2 ->
-      lift $ Branch.merge'' (Codebase.lca codebase) Branch.RegularMerge b1 b2
+    Merge mode b1 b2 ->
+      lift $ Branch.merge'' (Codebase.lca codebase) mode b1 b2
     SyncLocalRootBranch branch -> lift $ do
       setBranchRef branch
       Codebase.putRootBranch codebase branch

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -115,6 +115,8 @@ commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSour
     Evaluate1 ppe useCache term    -> lift $ eval1 ppe useCache term
     LoadLocalRootBranch        -> lift $ either (const Branch.empty) id <$> Codebase.getRootBranch codebase
     LoadLocalBranch h          -> lift $ fromMaybe Branch.empty <$> Codebase.getBranchForHash codebase h
+    Merge b1 b2 ->
+      lift $ Branch.merge'' (Codebase.lca codebase) Branch.RegularMerge b1 b2
     SyncLocalRootBranch branch -> lift $ do
       setBranchRef branch
       Codebase.putRootBranch codebase branch

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -180,6 +180,7 @@ codebase1' syncToDirectory branchCache fmtV@(S.Format getV putV) fmtA@(S.Format 
           (termReferentsByPrefix (getDecl getV getA) path)
           (pure 10)
           (branchHashesByPrefix path)
+          lca
    in pure c
   where
     dependents :: Reference -> m (Set Reference.Id)
@@ -188,6 +189,7 @@ codebase1' syncToDirectory branchCache fmtV@(S.Format getV putV) fmtA@(S.Format 
     getTermsOfType r = listDirAsReferents (typeIndexDir path r)
     getTermsMentioningType :: Reference -> m (Set Referent.Id)
     getTermsMentioningType r = listDirAsReferents (typeMentionsIndexDir path r)
+    lca b1 b2 = Branch.lca b1 b2
   -- todo: revisit these
     listDirAsIds :: FilePath -> m (Set Reference.Id)
     listDirAsIds d = do


### PR DESCRIPTION
Lowest common ancestor calculations are used for computing merge results. This PR moves the lowest common ancestor calculation into the codebase where possible, so it's computed by SQL without having to deserialize any of the branches. This should be a lot faster.

Before this change, merging two branches with unrelated histories or with a common ancestor far in the past would require deserializing all the intermediate points in history back to their common ancestor.

To use, there's a new `Command`:

```Haskell
  -- Merge two branches, using the codebase for the LCA calculation where possible.
  Merge :: Branch.MergeMode -> Branch m -> Branch m -> Command m i v (Branch m)
```

There's one loose end: #1958. Until #1958, `push` will probably still be slow.

@aryairani did all the SQL wizardry and I just wrote some of the plumbing code.

@runarorama you can give this a shot on your copy of base that you're working on.