### PR TITLE
Use write-ahead-logging mode in sqlite

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -120,9 +120,18 @@ createSchema = do
   withImmediateTransaction . traverse_ (execute_ . fromString) $
     List.splitOn ";" [hereFile|sql/create.sql|]
 
-setFlags :: DB m => m ()
-setFlags = execute_ "PRAGMA foreign_keys = ON;"
+useWAL :: Bool
+useWAL = True
 
+setFlags :: DB m => m ()
+setFlags = do
+  execute_ "PRAGMA foreign_keys = ON;"
+  when useWAL $
+    query_ "PRAGMA journal_mode=WAL;" >>= \case
+      [Only ("wal" :: String)] -> pure ()
+      x ->
+        liftIO . putStrLn $
+          "I couldn't set the codebase journal mode to WAL; it's set to " ++ show x ++ "."
 {- ORMOLU_DISABLE -}
 schemaVersion :: DB m => m SchemaVersion
 schemaVersion = queryAtoms sql () >>= \case


### PR DESCRIPTION
Enables write-ahead logging, described in detail [here](https://sqlite.org/wal.html), for the sqlite database.
In practice, this brings the "sync" portion of a `base_v2` push/pull operation down from ~25sec to ~10sec on my laptop.

`useWAL = True`:
```
Finished SyncFromDirectory in 10.13761s (cpu), 11.821805s (system)
Finished SyncFromDirectory in 10.010869s (cpu), 11.658951s (system)
Finished SyncFromDirectory in 10.104863s (cpu), 11.3947s (system)
Finished SyncFromDirectory in 10.218595s (cpu), 11.844128s (system)
Finished SyncFromDirectory in 10.32628s (cpu), 12.441098s (system)
Finished SyncFromDirectory in 10.089623s (cpu), 11.697179s (system)
Finished SyncFromDirectory in 10.064101s (cpu), 11.482562s (system)
Finished SyncFromDirectory in 10.519981s (cpu), 12.356198s (system)
Finished SyncFromDirectory in 10.475041s (cpu), 12.467764s (system)
Finished SyncFromDirectory in 10.307745s (cpu), 12.218877s (system)
```

`useWAL = False`:
```
Finished SyncFromDirectory in 25.664011s (cpu), 30.636484s (system)
Finished SyncFromDirectory in 25.236705s (cpu), 30.640319s (system)
Finished SyncFromDirectory in 23.9394s (cpu), 29.143512s (system)
Finished SyncFromDirectory in 24.079667s (cpu), 28.356588s (system)
Finished SyncFromDirectory in 24.107136s (cpu), 28.650247s (system)
Finished SyncFromDirectory in 24.328741s (cpu), 29.099112s (system)
Finished SyncFromDirectory in 24.696937s (cpu), 29.303359s (system)
Finished SyncFromDirectory in 24.08241s (cpu), 28.594801s (system)
Finished SyncFromDirectory in 23.501619s (cpu), 27.519297s (system)
Finished SyncFromDirectory in 25.384414s (cpu), 84.551719s (system)
```

Some caveats that caught my eye:
> 2. All processes using a database must be on the same host computer; WAL does not work over a network filesystem.

(I'm not sure if this is a true limitation or if it simply falls back to the normal journal mode when opened over NFS.)

> 7. There is an additional quasi-persistent "-wal" file and "-shm" shared memory file associated with each database, which can make SQLite less appealing for use as an application file-format.

(I believe these go away, folded back into the db appropriately, on a call to `close`, hence the need for #1949.  They also get cleaned up on the next subsequent db use, but you want to make sure to do it before publishing the database somewhere like on github.)
