### PR TITLE
add a version of `Branch.before` that can use a custom LCA implementation

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -32,6 +32,7 @@ module Unison.Codebase.Branch
   , head
   , headHash
   , before
+  , before'
   , findHistoricalHQs
   , findHistoricalRefs
   , findHistoricalRefs'
@@ -444,9 +445,17 @@ merge'' lca mode (Branch x) (Branch y) =
           }
     pure (H.accumulate' np, pure np)
 
+-- `before' lca b1 b2` is true if `b2` incorporates all of `b1`
+-- It's defined as: lca b1 b2 == Just b1
+before' :: Monad m => (Branch m -> Branch m -> m (Maybe (Branch m)))
+                   -> Branch m -> Branch m -> m Bool
+before' lca (Branch x) (Branch y) = Causal.before' lca' x y
+  where
+    lca' c1 c2 = fmap _history <$> lca (Branch c1) (Branch c2)
+
 -- `before b1 b2` is true if `b2` incorporates all of `b1`
 before :: Monad m => Branch m -> Branch m -> m Bool
-before (Branch x) (Branch y) = Causal.before x y
+before (Branch b1) (Branch b2) = Causal.before b1 b2
 
 merge0 :: forall m. Monad m => (Branch m -> Branch m -> m (Maybe (Branch m)))
                             -> MergeMode -> Branch0 m -> Branch0 m -> m (Branch0 m)

--- a/parser-typechecker/src/Unison/Codebase/Causal.hs
+++ b/parser-typechecker/src/Unison/Codebase/Causal.hs
@@ -268,6 +268,13 @@ threeWayMerge' lca combine c1 c2 = do
   done newHead =
     Merge (RawHash (hash (newHead, Map.keys children))) newHead children
 
+before' :: Monad m
+        => (Causal m h e -> Causal m h e -> m (Maybe (Causal m h e)))
+        -> Causal m h e
+        -> Causal m h e
+        -> m Bool
+before' lca a b = (== Just a) <$> lca a b
+
 before :: Monad m => Causal m h e -> Causal m h e -> m Bool
 before a b = (== Just a) <$> lca a b
 

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -940,7 +940,7 @@ viewRemoteBranch' (repo, sbh, path) = runExceptT do
           branch <- time "Git fetch (sbh)" $ case sbh of
             -- no sub-branch was specified, so use the root.
             Nothing ->
-              lift (Codebase1.getRootBranch codebase) >>= \case
+              lift (time "Get Root Branch" $ Codebase1.getRootBranch codebase) >>= \case
                 -- this NoRootBranch case should probably be an error too.
                 Left Codebase1.NoRootBranch -> pure Branch.empty
                 Left (Codebase1.CouldntLoadRootBranch h) ->
@@ -976,7 +976,8 @@ pushGitRootBranch syncToDirectory branch repo syncMode = runExceptT do
   -- Pull the remote repo into a staging directory
   (cleanup, remoteRoot, remotePath) <- Except.ExceptT $ viewRemoteBranch' (repo, Nothing, Path.empty)
   (ifM
-    ((pure (remoteRoot == Branch.empty) ||^ lift (remoteRoot `Branch.before` branch)) <*
+    ((pure (remoteRoot == Branch.empty) ||^
+      lift (time "pushGitRootBranch Branch.before" $ remoteRoot `Branch.before` branch)) <*
       lift cleanup)
     -- ours is newer 👍, meaning this is a fast-forward push,
     -- so sync branch to staging area

--- a/parser-typechecker/src/Unison/Util/Timing.hs
+++ b/parser-typechecker/src/Unison/Util/Timing.hs
@@ -10,7 +10,7 @@ import Data.Time.Clock.TAI (diffAbsoluteTime)
 import Data.Time.Clock (picosecondsToDiffTime)
 
 enabled :: Bool
-enabled = True
+enabled = False
 
 time :: MonadIO m => String -> m a -> m a
 time _ ma | not enabled = ma

--- a/parser-typechecker/src/Unison/Util/Timing.hs
+++ b/parser-typechecker/src/Unison/Util/Timing.hs
@@ -10,7 +10,7 @@ import Data.Time.Clock.TAI (diffAbsoluteTime)
 import Data.Time.Clock (picosecondsToDiffTime)
 
 enabled :: Bool
-enabled = False
+enabled = True
 
 time :: MonadIO m => String -> m a -> m a
 time _ ma | not enabled = ma


### PR DESCRIPTION
Then it uses that new function `Branch.before'` in `SqliteCodebase.pushGitRootBranch` to use the sql lca implementation, speeding up the `before` operation by ~50% apparently.  I'm surprised it wasn't by more, but this is still nice.