### PR TITLE
wrap SqliteCodebase.syncInternal in an immediate transaction

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -721,6 +721,14 @@ headMay :: [a] -> Maybe a
 headMay [] = Nothing
 headMay (a : _) = Just a
 
+-- | low-level transaction stuff
+beginTransaction, beginImmediateTransaction, beginExclusiveTransaction, commitTransaction, rollbackTransaction :: DB m => m ()
+beginTransaction = execute_ "BEGIN TRANSACTION"
+beginImmediateTransaction = execute_ "BEGIN IMMEDIATE TRANSACTION"
+beginExclusiveTransaction = execute_ "BEGIN EXCLUSIVE TRANSACTION"
+commitTransaction   = execute_ "COMMIT TRANSACTION"
+rollbackTransaction = execute_ "ROLLBACK TRANSACTION"
+
 -- * orphan instances
 
 deriving via Text instance ToField Base32Hex

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -784,9 +784,11 @@ sqliteCodebase root = do
               se . r $ Sync.sync sync progress' testWatchRefs
             let
               onSuccess a = runDB destConn Q.commitTransaction *> pure a
-              onFailure e = if debugCommitFailedTransaction
-                then runDB destConn Q.commitTransaction
-                else runDB destConn Q.rollbackTransaction *> error (show e)
+              onFailure e = do
+                if debugCommitFailedTransaction
+                  then runDB destConn Q.commitTransaction
+                  else runDB destConn Q.rollbackTransaction
+                error (show e)
             runDB srcConn Q.rollbackTransaction -- (we don't write to the src anyway)
             either onFailure onSuccess result
       let finalizer :: MonadIO m => m ()


### PR DESCRIPTION
I was thinking that sqlite could keep more work in RAM if it knows that it's expected to be an atomic operation, and it seems it can.  Syncing base was 39% faster with this.

## Loose ends

I wondered if `PRAGMA read_only` would help too, and I stop trying when I got an error about not being able to "prepare" the statement `PRAGMA read_only = ?` for some reason.  You could just have constant statements for `= TRUE" and `= FALSE"` but I stopped trying.  One could also just ask the sqlite mailing list if this would speed things up, they seem to be very knowledgeable.

## Timing data

Using this transcript, where `base_v2` is a local clone of  unisonweb/base_v2@de5f04d3fcab4100cbdda8e2c1477e93aa78751e and not in the ucm git cache, and `repo` is an empty repo.
````
```ucm:hide
.> builtins.merge
.> builtins.mergeio
.> pull /root/base_v2:.trunk base
.> fork base newbase
.> merge builtin newbase
.> cd newbase
.newbase> push /root/unison-slim/repo
.newbase> delete.term Either.mapRight#jruvg9gh6q
.newbase> delete.term List.map#j1ejquc7so
.newbase> push /root/unison-slim/repo
```
````
**Pre-PR (avg of 3 runs)**
| stage | time |
| --- | --- |
| pull | 14.05 s |
| push 1 | 14.37 s |
| push 2 | 0.85 s |

**With transaction on dest DB (avg of 3)**
stage | time
-- | -
pull | 8.99 s (-36%)
push 1 | 9.27 s (-36%)
push 2 | 0.85 s

**With transaction on src and dest DBs (avg of 7)**
stage | time
-- | -
pull | 8.53 s (-39%)
push 1 | 8.90 s (-38%)
push 2 | 0.68 s (-20%)
