### PR TITLE
git config an email address for ubuntu 18.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,8 +61,10 @@ jobs:
           echo "$HOME/stack-2.5.1-osx-x86_64/" >> $GITHUB_PATH
 
       # One of the transcripts fails if the user's git name hasn't been set.
-      - name: set git username
-        run: git config --global user.name "GitHub Actions"
+      - name: set git user info
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
 
       - name: remove ~/.stack/setup-exe-cache on macOS
         if: runner.os == 'macOS'


### PR DESCRIPTION
Something changed in the way the Github Actions Ubuntu 18.04 image's `git` autodetects an email address, which was causing tests to fail with:

```
fatal: unable to auto-detect email address (got 'runner@fv-az181-835.(none)')
```

This PR sets one explicitly (`actions@github.com`, which hopefully won't be confusing later).