### PR TITLE
Inline simple `x = y` lets during compilation.

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/ANF.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF.hs
@@ -342,7 +342,7 @@ saturate dat = ABT.visitPure $ \case
 
 inlineAlias :: Var v => Monoid a => Term v a -> Term v a
 inlineAlias = ABT.visitPure $ \case
-  Let1Named' v b@(Var' u) e -> Just . inlineAlias $ ABT.subst v b e
+  Let1Named' v b@(Var' _) e -> Just . inlineAlias $ ABT.subst v b e
   _ -> Nothing
 
 minimizeCyclesOrCrash :: Var v => Term v a -> Term v a

--- a/parser-typechecker/src/Unison/Runtime/ANF.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF.hs
@@ -39,6 +39,7 @@ module Unison.Runtime.ANF
   , saturate
   , float
   , lamLift
+  , inlineAlias
   , ANormalF(.., AApv, ACom, ACon, AKon, AReq, APrm, AFOp)
   , ANormal
   , RTag
@@ -338,6 +339,11 @@ saturate dat = ABT.visitPure $ \case
     m = length args
     fvs = foldMap freeVars args
     args' = saturate dat <$> args
+
+inlineAlias :: Var v => Monoid a => Term v a -> Term v a
+inlineAlias = ABT.visitPure $ \case
+  Let1Named' v b@(Var' u) e -> Just . inlineAlias $ ABT.subst v b e
+  _ -> Nothing
 
 minimizeCyclesOrCrash :: Var v => Term v a -> Term v a
 minimizeCyclesOrCrash t = case minimize' t of

--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -223,6 +223,7 @@ intermediateTerm ctx tm
   . lamLift
   . splitPatterns (dspec ctx)
   . saturate (uncurryDspec $ dspec ctx)
+  . inlineAlias
   $ tm
   where
   final (ll, dcmp) = (superNormalize ll, backrefLifted ll dcmp)


### PR DESCRIPTION
Some parts of the new runtime's code generation assume that no trivial lets like `x = y` occur. The intermediate stages avoid introducing these sort of things, but they can still occur when manually written by a user.

Fixes #1959 and #1951.