### PR TITLE
Add cycle length cache for 7.8x speedup loading branches

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Sync22.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Sync22.hs
@@ -104,10 +104,10 @@ sync22 = do
 trySync ::
   forall m.
   (MonadIO m, MonadError Error m, MonadReader Env m) =>
-  Cache m TextId TextId ->
-  Cache m HashId HashId ->
-  Cache m ObjectId ObjectId ->
-  Cache m CausalHashId CausalHashId ->
+  Cache TextId TextId ->
+  Cache HashId HashId ->
+  Cache ObjectId ObjectId ->
+  Cache CausalHashId CausalHashId ->
   Entity ->
   m (TrySyncResult Entity)
 trySync tCache hCache oCache cCache = \case

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -510,13 +510,13 @@ numHashChars _b = 3
 
 -- This type is a little ugly, so we wrap it up with a nice type alias for
 -- use outside this module.
-type Cache m = Cache.Cache m (Causal.RawHash Raw) (UnwrappedBranch m)
+type Cache m = Cache.Cache (Causal.RawHash Raw) (UnwrappedBranch m)
 
-boundedCache :: MonadIO m => Word -> m (Cache m)
+boundedCache :: MonadIO m => Word -> m (Cache m2)
 boundedCache = Cache.semispaceCache
 
 -- Can use `Cache.nullCache` to disable caching if needed
-cachedRead :: forall m . Monad m
+cachedRead :: forall m . MonadIO m
            => Cache m
            -> Causal.Deserialize m Raw Raw
            -> (EditHash -> m Patch)

--- a/parser-typechecker/src/Unison/Codebase/Causal.hs
+++ b/parser-typechecker/src/Unison/Codebase/Causal.hs
@@ -106,8 +106,8 @@ data Tails h
 
 type Deserialize m h e = RawHash h -> m (Raw h e)
 
-cachedRead :: Monad m
-           => Cache.Cache m (RawHash h) (Causal m h e)
+cachedRead :: MonadIO m
+           => Cache.Cache (RawHash h) (Causal m h e)
            -> Deserialize m h e
            -> RawHash h -> m (Causal m h e)
 cachedRead cache deserializeRaw h = Cache.lookup cache h >>= \case


### PR DESCRIPTION
We discovered that looking up cycle lengths for `Reference` was responsible for much of the branch decoding time and initial syncing of base. 

This PR adds a cache  length and revamps the `Cache` type to be easily callable within any `MonadIO` context. The speedup is remarkable: from 19.5s to 2.5s for loading a branch.

__Before:__

```
Timing Git fetch...
Finished Git fetch in 0.015799s (cpu), 1.669391s (system)  
Timing Git fetch (sbh)...
Timing Get Root Branch...
Finished Get Root Branch in 19.530541s (cpu), 19.503142s (system)
Finished Git fetch (sbh) in 19.530633s (cpu), 19.503232s (system)
Timing SyncFromDirectory...s into local codebase...
Timing syncInternal...
Done syncing 12171 entities.Finished syncInternal in 7.198921s (cpu), 7.239756s (system)
Finished SyncFromDirectory in 7.199439s (cpu), 7.240287s (system)
Timing Merge Branch...                             
<snip>
Finished Merge Branch in 5.124624s (cpu), 7.684525s (system)
Timing Propagate Default Patch...
Finished Propagate Default Patch in 0.090544s (cpu), 0.086378s (system)
```

__After:__

```
.> pull https://github.com/unisonweb/base_v2 _base
Timing Git fetch...
Finished Git fetch in 0.025706s (cpu), 0.644038s (system)         
Timing Git fetch (sbh)...
Timing Get Root Branch...
Finished Get Root Branch in 2.559314s (cpu), 2.543234s (system)
Finished Git fetch (sbh) in 2.559383s (cpu), 2.543299s (system)
Timing SyncFromDirectory...s into local codebase...
Timing syncInternal...
Done syncing 12171 entities.Finished syncInternal in 7.088721s (cpu), 7.142479s (system)
Finished SyncFromDirectory in 7.089241s (cpu), 7.143s (system)
Timing load fresh local branch after sync...       
Finished load fresh local branch after sync in 2.412371s (cpu), 2.397157s (system)
Timing Merge Branch...
<snip>
Finished Merge Branch in 0s (cpu), 0s (system)
Timing Propagate Default Patch...
Finished Propagate Default Patch in 0s (cpu), 0s (system)
```

Adding a cache for the decl type (ability or data type) shaves off another .3s. I went ahead and included that as well.

```
.> pull https://github.com/unisonweb/base_v2 _base
Timing Git fetch...
Finished Git fetch in 0.023367s (cpu), 0.705386s (system)         
Timing Git fetch (sbh)...
Timing Get Root Branch...
Finished Get Root Branch in 2.195077s (cpu), 2.179893s (system)
Finished Git fetch (sbh) in 2.195148s (cpu), 2.179966s (system)
Timing SyncFromDirectory...s into local codebase...
Timing syncInternal...

Done syncing 12171 entities.Finished syncInternal in 7.162694s (cpu), 7.196252s (system)
Finished SyncFromDirectory in 7.163221s (cpu), 7.196795s (system)
Timing load fresh local branch after sync...       
Finished load fresh local branch after sync in 2.035271s (cpu), 2.020823s (system)
Timing Merge Branch... <snip>
Finished Merge Branch in 0s (cpu), 0s (system)
Timing Propagate Default Patch...
Finished Propagate Default Patch in 0s (cpu), 0s (system)
```