### PR TITLE
Remove builtin.List.empty term

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -426,7 +426,7 @@ builtinsSrc =
   , B "Bytes.fromBase64" $ bytes --> eithert text bytes
   , B "Bytes.fromBase64UrlUnpadded" $ bytes --> eithert text bytes
 
-  , B "List.empty" $ forall1 "a" list
+  , D "List.empty" $ forall1 "a" list
   , B "List.cons" $ forall1 "a" (\a -> a --> list a --> list a)
   , Alias "List.cons" "List.+:"
   , B "List.snoc" $ forall1 "a" (\a -> list a --> a --> list a)


### PR DESCRIPTION
This deprecates `builtin.List.empty`, since it's defined in `base` as `base.List.empty = []`