### PR TITLE
Use codebase LCA for squash merges

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -397,7 +397,7 @@ merge'' _ mode b1 b2 | isEmpty b2 = case mode of
 merge'' lca mode (Branch x) (Branch y) =
   Branch <$> case mode of
                RegularMerge -> Causal.threeWayMerge' lca' combine x y
-               SquashMerge  -> Causal.squashMerge combine x y
+               SquashMerge  -> Causal.squashMerge' lca' combine x y
  where
   lca' c1 c2 = fmap _history <$> lca (Branch c1) (Branch c2)
   combine :: Maybe (Branch0 m) -> Branch0 m -> Branch0 m -> m (Branch0 m)

--- a/parser-typechecker/src/Unison/Codebase/Causal.hs
+++ b/parser-typechecker/src/Unison/Codebase/Causal.hs
@@ -213,14 +213,15 @@ children (Merge _ _ ts    ) = Seq.fromList $ Map.elems ts
 -- as a `threeWayMerge`, but doesn't introduce a merge node for the
 -- result. Instead, the resulting causal is a simple `Cons` onto `c2`
 -- (or is equal to `c2` if `c1` changes nothing).
-squashMerge
+squashMerge'
   :: forall m h e
    . (Monad m, Hashable e, Eq e)
-  => (Maybe e -> e -> e -> m e)
+  => (Causal m h e -> Causal m h e -> m (Maybe (Causal m h e)))
+  -> (Maybe e -> e -> e -> m e)
   -> Causal m h e
   -> Causal m h e
   -> m (Causal m h e)
-squashMerge combine c1 c2 = do
+squashMerge' lca combine c1 c2 = do
   theLCA <- lca c1 c2
   let done newHead = consDistinct newHead c2
   case theLCA of

--- a/unison-src/transcripts/squash.md
+++ b/unison-src/transcripts/squash.md
@@ -127,6 +127,31 @@ Another thing we can do is `squash` into an empty namespace. This effectively ma
 
 There's nothing really special here, `squash src dest` discards `src` history that comes after the LCA of `src` and `dest`, it's just that in the case of an empty namespace, that LCA is the beginning of time (the empty namespace), so all the history of `src` is discarded.
 
+## Checking for handling of deletes
+
+This checks to see that squashing correctly preserves deletions:
+
+```ucm
+.delete> builtins.merge
+.delete> fork builtin builtin2
+.delete> delete.term builtin2.Nat.+
+.delete> delete.term builtin2.Nat.*
+.delete> squash builtin2 builtin
+.delete> history builtin
+```
+
+Notice that `Nat.+` and `Nat.*` are deleted by the squash, and we see them deleted in one atomic step in the history.
+
+Just confirming that those two definitions are in fact removed:
+
+```ucm:error
+.delete> view .delete.builtin.Nat.+
+```
+
+```ucm:error
+.delete> view .delete.builtin.Nat.*
+```
+
 ## Caveats
 
 If you `squash mystuff trunk`, you're discarding any history of `mystuff` and just cons'ing onto the history of `trunk`. Thus, don't expect to be able to `merge trunk mystuff` later and get great results. Squashing should only be used when you don't care about the history (and you know others haven't pulled and built on your line of history being discarded, so they don't care about the history either).

--- a/unison-src/transcripts/squash.output.md
+++ b/unison-src/transcripts/squash.output.md
@@ -467,6 +467,97 @@ Another thing we can do is `squash` into an empty namespace. This effectively ma
 ```
 There's nothing really special here, `squash src dest` discards `src` history that comes after the LCA of `src` and `dest`, it's just that in the case of an empty namespace, that LCA is the beginning of time (the empty namespace), so all the history of `src` is discarded.
 
+## Checking for handling of deletes
+
+This checks to see that squashing correctly preserves deletions:
+
+```ucm
+  ☝️  The namespace .delete is empty.
+
+.delete> builtins.merge
+
+  Done.
+
+.delete> fork builtin builtin2
+
+  Done.
+
+.delete> delete.term builtin2.Nat.+
+
+  Name changes:
+  
+    Original                    Changes
+    1. builtin.Nat.+         ┐  2. delete.builtin2.Nat.+ (removed)
+    3. builtin2.Nat.+        │  
+    4. delete.builtin.Nat.+  │  
+    5. delete.builtin2.Nat.+ │  
+    6. mybuiltin.Nat.+       ┘  
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
+
+.delete> delete.term builtin2.Nat.*
+
+  Name changes:
+  
+    Original                    Changes
+    1. builtin.Nat.*         ┐  2. delete.builtin2.Nat.* (removed)
+    3. builtin2.Nat.*        │  
+    4. delete.builtin.Nat.*  │  
+    5. delete.builtin2.Nat.* │  
+    6. mybuiltin.Nat.*       ┘  
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
+
+.delete> squash builtin2 builtin
+
+  Here's what's changed in builtin after the merge:
+  
+  Removed definitions:
+  
+    1. Nat.* : Nat -> Nat -> Nat
+    2. Nat.+ : Nat -> Nat -> Nat
+  
+  Tip: You can use `todo` to see if this generated any work to
+       do in this namespace and `test` to run the tests. Or you
+       can use `undo` or `reflog` to undo the results of this
+       merge.
+
+.delete> history builtin
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ #tq22u82aah
+  
+    - Deletes:
+    
+      Nat.* Nat.+
+  
+  □ #klkpbos013 (start of history)
+
+```
+Notice that `Nat.+` and `Nat.*` are deleted by the squash, and we see them deleted in one atomic step in the history.
+
+Just confirming that those two definitions are in fact removed:
+
+```ucm
+.delete> view .delete.builtin.Nat.+
+
+  ⚠️
+  
+  The following names were not found in the codebase. Check your spelling.
+    .delete.builtin.Nat.+
+
+```
+```ucm
+.delete> view .delete.builtin.Nat.*
+
+  ⚠️
+  
+  The following names were not found in the codebase. Check your spelling.
+    .delete.builtin.Nat.*
+
+```
 ## Caveats
 
 If you `squash mystuff trunk`, you're discarding any history of `mystuff` and just cons'ing onto the history of `trunk`. Thus, don't expect to be able to `merge trunk mystuff later and get great results. Squashing should only be used when you don't care about the history (and you know others haven't pulled and built on your line of history being discarded, so they don't care about the history either).


### PR DESCRIPTION
Prior to this PR, squash merges wouldn't use the fast codebase LCA calculation introduced by #1948. This PR fixes that, which should speed up squash merges a LOT if the namespace being squashed has a lot of history.

Also improved the transcript for squashing, [to test that squashing correctly handles deletions](https://github.com/unisonweb/unison/blob/feature/squash-lca/unison-src/transcripts/squash.output.md#checking-for-handling-of-deletes), though this didn't surface a possible bug with squashing that @runarorama noticed.

Independent of possible squashing bug with deletions, I think this PR is a straight improvement over the current implementation, which is needlessly slow.