### PR TITLE
fix missing-deps calculation for syncing branches that only exist in memory

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1712,12 +1712,13 @@ loop = do
             resolveConfiguredGitUrl Push path (fmap expandRepo mayRepo)
           case sbh of
             Nothing -> lift $ unlessGitError do
-              (cleanup, remoteRoot) <- viewRemoteBranch (repo, Nothing, Path.empty)
+              (cleanup, remoteRoot) <- unsafeTime "Push viewRemoteBranch" $
+                viewRemoteBranch (repo, Nothing, Path.empty)
               -- todo : this needs rethinking - should do the work inside the
               -- staged repo after calling syncToDirectory
-              newRemoteRoot <- lift . eval . Eval $
+              newRemoteRoot <- unsafeTime "Push merge" $ lift . eval . Eval $
                 Branch.modifyAtM remotePath (Branch.merge srcb) remoteRoot
-              syncRemoteRootBranch repo newRemoteRoot syncMode
+              unsafeTime "Push syncRemoteRootBranch" $ syncRemoteRootBranch repo newRemoteRoot syncMode
               lift . eval $ Eval cleanup
               lift $ respond Success
             Just{} ->

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -890,7 +890,7 @@ emptySyncProgressState = SyncProgressState (Just mempty) (Right mempty) (Right m
 syncProgress :: MonadState SyncProgressState m => MonadIO m => Sync.Progress m Sync22.Entity
 syncProgress = Sync.Progress need done warn allDone
   where
-    quiet = True
+    quiet = False
     maxTrackedHashCount = 1024 * 1024
     size :: SyncProgressState -> Int
     size = \case

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -752,8 +752,9 @@ sqliteCodebase root = do
                     ExceptT Sync22.Error m ()
                   processBranches _ _ [] = pure ()
                   processBranches sync progress (b0@(B h mb) : rest) = do
-                    when debugProcessBranches $ traceM $ "processBranches " ++ show b0
-                    when debugProcessBranches $ traceM $ " queue: " ++ show rest
+                    when debugProcessBranches do
+                      traceM $ "processBranches " ++ show b0
+                      traceM $ " queue: " ++ show rest
                     ifM @(ExceptT Sync22.Error m)
                       (lift . runDB destConn $ isCausalHash' h)
                       do
@@ -771,10 +772,11 @@ sqliteCodebase root = do
                             lift mb >>= \b -> do
                               when debugProcessBranches $ traceM $ "  " ++ show b0 ++ " doesn't exist in either db, so delegating to Codebase.putBranch"
                               let (branchDeps, BD.to' -> BD.Dependencies' es ts ds) = BD.fromBranch b
-                              when debugProcessBranches $ traceM $ "  branchDeps: " ++ show (fst <$> branchDeps)
-                              when debugProcessBranches $ traceM $ "  terms: " ++ show ts
-                              when debugProcessBranches $ traceM $ "  decls: " ++ show ds
-                              when debugProcessBranches $ traceM $ "  edits: " ++ show es
+                              when debugProcessBranches do
+                                traceM $ "  branchDeps: " ++ show (fst <$> branchDeps)
+                                traceM $ "  terms: " ++ show ts
+                                traceM $ "  decls: " ++ show ds
+                                traceM $ "  edits: " ++ show es
                               (cs, es, ts, ds) <- lift $ runDB destConn do
                                 cs <- filterM (fmap not . runDB destConn . isCausalHash' . fst) branchDeps
                                 es <- filterM (fmap not . runDB destConn . patchExists) es


### PR DESCRIPTION
All dependencies of memory-only branches were being treated as missing dependencies, causing an infinite loop during a push that merges.  This PR filters them and adds some more debug output.

I couldn't find a Github issue for the push hang @runarorama and I had been seeing, but if there is one, this closes it.

## Interesting/controversial decisions

`termExists` and `declExists` in `SqliteCodebase` share an implementation, continuing with the assumption that we won't have hash collisions between terms and decls.

## Test coverage

I haven't added a minimized transcript to demonstrate the failure, but would if requested.
