### PR TITLE
Revert "Tests: explicit branch name in git init"

### DIFF
--- a/parser-typechecker/tests/Unison/Test/Git.hs
+++ b/parser-typechecker/tests/Unison/Test/Git.hs
@@ -177,7 +177,7 @@ testPull = scope "pull" $ do
 
   -- initialize git repo
   let repo = tmp </> "repo.git"
-  io $ "git" ["init", "--bare", "--initial-branch=master", Text.pack repo]
+  io $ "git" ["init", "--bare", Text.pack repo]
 
   -- run author/push transcript
   runTranscript_ tmp authorCodebase [i|
@@ -331,7 +331,7 @@ testPush = scope "push" $ do
   for_ pushImplementations $ \(implName, impl) -> scope implName $ do
     -- initialize git repo
     let repoGit = tmp </> (implName ++ ".git")
-    io $ "git" ["init", "--bare", "--initial-branch=master", Text.pack repoGit]
+    io $ "git" ["init", "--bare", Text.pack repoGit]
 
     -- push one way!
     codebase <- io $ FC.codebase1' impl Cache.nullCache V1.formatSymbol formatAnn codebasePath


### PR DESCRIPTION
Reverts unisonweb/unison#1834 to fix #1969.