### PR TITLE
Add missing TLS builtins

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -174,6 +174,8 @@ builtinTypesSrc =
   , B' "Tls.ServerConfig" CT.Data, Rename' "Tls.ServerConfig" "io2.Tls.ServerConfig"
   , B' "Tls.SignedCert" CT.Data, Rename' "Tls.SignedCert" "io2.Tls.SignedCert"
   , B' "Tls.PrivateKey" CT.Data, Rename' "Tls.PrivateKey" "io2.Tls.PrivateKey"
+  , B' "Tls.Version" CT.Data, Rename' "Tls.Version" "io2.Tls.Version"
+  , B' "Tls.Cipher" CT.Data, Rename' "Tls.Cipher" "io2.Tls.Cipher"
   , B' "TVar" CT.Data, Rename' "TVar" "io2.TVar"
   , B' "STM" CT.Effect, Rename' "STM" "io2.STM"
   ]

--- a/unison-src/transcripts/alias-many.output.md
+++ b/unison-src/transcripts/alias-many.output.md
@@ -367,7 +367,7 @@ Let's try it!
   300. io2.StdHandle.StdErr : StdHandle
   301. io2.StdHandle.StdIn : StdHandle
   302. io2.StdHandle.StdOut : StdHandle
-  303. io2.TLS.ClientConfig.ciphers.set : [##Tls.Cipher]
+  303. io2.TLS.ClientConfig.ciphers.set : [Cipher]
                                           -> ClientConfig
                                           -> ClientConfig
   304. builtin type io2.TVar
@@ -379,50 +379,52 @@ Let's try it!
   310. io2.TVar.write : TVar a -> a ->{STM} ()
   311. builtin type io2.ThreadId
   312. builtin type io2.Tls
-  313. builtin type io2.Tls.ClientConfig
-  314. io2.Tls.ClientConfig.certificates.set : [SignedCert]
+  313. builtin type io2.Tls.Cipher
+  314. builtin type io2.Tls.ClientConfig
+  315. io2.Tls.ClientConfig.certificates.set : [SignedCert]
                                                -> ClientConfig
                                                -> ClientConfig
-  315. io2.Tls.ClientConfig.default : Text
+  316. io2.Tls.ClientConfig.default : Text
                                       -> Bytes
                                       -> ClientConfig
-  316. io2.Tls.ClientConfig.versions.set : [##Tls.Version]
+  317. io2.Tls.ClientConfig.versions.set : [Version]
                                            -> ClientConfig
                                            -> ClientConfig
-  317. builtin type io2.Tls.PrivateKey
-  318. builtin type io2.Tls.ServerConfig
-  319. io2.Tls.ServerConfig.certificates.set : [SignedCert]
+  318. builtin type io2.Tls.PrivateKey
+  319. builtin type io2.Tls.ServerConfig
+  320. io2.Tls.ServerConfig.certificates.set : [SignedCert]
                                                -> ServerConfig
                                                -> ServerConfig
-  320. io2.Tls.ServerConfig.ciphers.set : [##Tls.Cipher]
+  321. io2.Tls.ServerConfig.ciphers.set : [Cipher]
                                           -> ServerConfig
                                           -> ServerConfig
-  321. io2.Tls.ServerConfig.default : [SignedCert]
+  322. io2.Tls.ServerConfig.default : [SignedCert]
                                       -> PrivateKey
                                       -> ServerConfig
-  322. io2.Tls.ServerConfig.versions.set : [##Tls.Version]
+  323. io2.Tls.ServerConfig.versions.set : [Version]
                                            -> ServerConfig
                                            -> ServerConfig
-  323. builtin type io2.Tls.SignedCert
-  324. io2.Tls.decodeCert.impl : Bytes
+  324. builtin type io2.Tls.SignedCert
+  325. builtin type io2.Tls.Version
+  326. io2.Tls.decodeCert.impl : Bytes
                                  -> Either Failure SignedCert
-  325. io2.Tls.decodePrivateKey : Bytes -> [PrivateKey]
-  326. io2.Tls.encodeCert : SignedCert -> Bytes
-  327. io2.Tls.encodePrivateKey : PrivateKey -> Bytes
-  328. io2.Tls.handshake.impl : Tls ->{IO} Either Failure ()
-  329. io2.Tls.newClient.impl : ClientConfig
+  327. io2.Tls.decodePrivateKey : Bytes -> [PrivateKey]
+  328. io2.Tls.encodeCert : SignedCert -> Bytes
+  329. io2.Tls.encodePrivateKey : PrivateKey -> Bytes
+  330. io2.Tls.handshake.impl : Tls ->{IO} Either Failure ()
+  331. io2.Tls.newClient.impl : ClientConfig
                                 -> Socket
                                 ->{IO} Either Failure Tls
-  330. io2.Tls.newServer.impl : ServerConfig
+  332. io2.Tls.newServer.impl : ServerConfig
                                 -> Socket
                                 ->{IO} Either Failure Tls
-  331. io2.Tls.receive.impl : Tls ->{IO} Either Failure Bytes
-  332. io2.Tls.send.impl : Tls -> Bytes ->{IO} Either Failure ()
-  333. io2.Tls.terminate.impl : Tls ->{IO} Either Failure ()
-  334. unique type io2.TlsFailure
-  335. metadata.isPropagated : IsPropagated
-  336. metadata.isTest : IsTest
-  337. todo : a -> b
+  333. io2.Tls.receive.impl : Tls ->{IO} Either Failure Bytes
+  334. io2.Tls.send.impl : Tls -> Bytes ->{IO} Either Failure ()
+  335. io2.Tls.terminate.impl : Tls ->{IO} Either Failure ()
+  336. unique type io2.TlsFailure
+  337. metadata.isPropagated : IsPropagated
+  338. metadata.isTest : IsTest
+  339. todo : a -> b
   
 
 .builtin> alias.many 94-104 .mylib

--- a/unison-src/transcripts/builtins-merge.output.md
+++ b/unison-src/transcripts/builtins-merge.output.md
@@ -55,7 +55,7 @@ The `builtins.merge` command adds the known builtins to a `builtin` subnamespace
   44. Value/        (5 definitions)
   45. bug           (a -> b)
   46. crypto/       (12 definitions)
-  47. io2/          (116 definitions)
+  47. io2/          (118 definitions)
   48. metadata/     (2 definitions)
   49. todo          (a -> b)
 

--- a/unison-src/transcripts/emptyCodebase.output.md
+++ b/unison-src/transcripts/emptyCodebase.output.md
@@ -23,7 +23,7 @@ Technically, the definitions all exist, but they have no names. `builtins.merge`
 
 .foo> ls
 
-  1. builtin/ (337 definitions)
+  1. builtin/ (339 definitions)
 
 ```
 And for a limited time, you can get even more builtin goodies:
@@ -35,7 +35,7 @@ And for a limited time, you can get even more builtin goodies:
 
 .foo> ls
 
-  1. builtin/ (505 definitions)
+  1. builtin/ (507 definitions)
 
 ```
 More typically, you'd start out by pulling `base.

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -112,13 +112,13 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #dr7j21cpqp
+  ⊙ #tg218701if
   
     - Deletes:
     
       feature1.y
   
-  ⊙ #0ct10skh45
+  ⊙ #v5b0rlnuht
   
     + Adds / updates:
     
@@ -129,26 +129,26 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
       Original name New name(s)
       feature1.y    master.y
   
-  ⊙ #8sknads6vj
+  ⊙ #1e3n5kd05l
   
     + Adds / updates:
     
       feature1.y
   
-  ⊙ #hb8qfqt9ai
+  ⊙ #b2s99sn5bp
   
     > Moves:
     
       Original name New name
       x             master.x
   
-  ⊙ #73mdo6cqdj
+  ⊙ #g97hd92c33
   
     + Adds / updates:
     
       x
   
-  ⊙ #q1npn63eti
+  ⊙ #hs8pfrn2tf
   
     + Adds / updates:
     
@@ -305,7 +305,7 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
       builtin.io2.TVar.read builtin.io2.TVar.readIO
       builtin.io2.TVar.swap builtin.io2.TVar.write
       builtin.io2.ThreadId builtin.io2.Tls
-      builtin.io2.Tls.ClientConfig
+      builtin.io2.Tls.Cipher builtin.io2.Tls.ClientConfig
       builtin.io2.Tls.ClientConfig.certificates.set
       builtin.io2.Tls.ClientConfig.default
       builtin.io2.Tls.ClientConfig.versions.set
@@ -314,7 +314,8 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
       builtin.io2.Tls.ServerConfig.ciphers.set
       builtin.io2.Tls.ServerConfig.default
       builtin.io2.Tls.ServerConfig.versions.set
-      builtin.io2.Tls.SignedCert builtin.io2.Tls.decodeCert.impl
+      builtin.io2.Tls.SignedCert builtin.io2.Tls.Version
+      builtin.io2.Tls.decodeCert.impl
       builtin.io2.Tls.decodePrivateKey
       builtin.io2.Tls.encodeCert
       builtin.io2.Tls.encodePrivateKey

--- a/unison-src/transcripts/reflog.output.md
+++ b/unison-src/transcripts/reflog.output.md
@@ -59,16 +59,16 @@ y = 2
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #pknj0m8137 .old`   to make an old namespace
+    `fork #3jjeo7gn3h .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #pknj0m8137`  to reset the root namespace and
+    `reset-root #3jjeo7gn3h`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
-  1. #j376pgmitc : add
-  2. #pknj0m8137 : add
-  3. #q1npn63eti : builtins.merge
+  1. #bggegd9p4g : add
+  2. #3jjeo7gn3h : add
+  3. #hs8pfrn2tf : builtins.merge
   4. #7asfbtqmoj : (initial reflogged namespace)
 
 ```

--- a/unison-src/transcripts/squash.output.md
+++ b/unison-src/transcripts/squash.output.md
@@ -13,7 +13,7 @@ Let's look at some examples. We'll start with a namespace with just the builtins
   
   
   
-  □ #klkpbos013 (start of history)
+  □ #6hs3tdioa1 (start of history)
 
 .> fork builtin builtin2
 
@@ -42,21 +42,21 @@ Now suppose we `fork` a copy of builtin, then rename `Nat.+` to `frobnicate`, th
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #2389gjnigh
+  ⊙ #lirpkqt68j
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ #l7dr0sq1vj
+  ⊙ #p2m2k852al
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ #klkpbos013 (start of history)
+  □ #6hs3tdioa1 (start of history)
 
 ```
 If we merge that back into `builtin`, we get that same chain of history:
@@ -71,21 +71,21 @@ If we merge that back into `builtin`, we get that same chain of history:
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #2389gjnigh
+  ⊙ #lirpkqt68j
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ #l7dr0sq1vj
+  ⊙ #p2m2k852al
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ #klkpbos013 (start of history)
+  □ #6hs3tdioa1 (start of history)
 
 ```
 Let's try again, but using a `merge.squash` (or just `squash`) instead. The history will be unchanged:
@@ -106,7 +106,7 @@ Let's try again, but using a `merge.squash` (or just `squash`) instead. The hist
   
   
   
-  □ #klkpbos013 (start of history)
+  □ #6hs3tdioa1 (start of history)
 
 ```
 The churn that happened in `mybuiltin` namespace ended up back in the same spot, so the squash merge of that namespace with our original namespace had no effect.
@@ -527,13 +527,13 @@ This checks to see that squashing correctly preserves deletions:
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #tq22u82aah
+  ⊙ #8jcsn0thlb
   
     - Deletes:
     
       Nat.* Nat.+
   
-  □ #klkpbos013 (start of history)
+  □ #6hs3tdioa1 (start of history)
 
 ```
 Notice that `Nat.+` and `Nat.*` are deleted by the squash, and we see them deleted in one atomic step in the history.


### PR DESCRIPTION
This adds the builtin types `##Tls.Version` and `##Tls.Cipher`, which were missing.