### PR TITLE
separate `push` and `push.create` commands

### DIFF
--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -86,7 +86,11 @@ data Codebase m v a =
            -- This copies all the dependencies of `b` from this Codebase
            , syncToDirectory    :: CodebasePath -> SyncMode -> Branch m -> m ()
            , viewRemoteBranch' :: RemoteNamespace -> m (Either GitError (m (), Branch m, CodebasePath))
-           , pushGitRootBranch :: Branch m -> RemoteRepo -> SyncMode -> m (Either GitError ())
+           -- `Bool` is whether to allow pushes to an empty branch;
+           -- these are technically fast-forward merges but you often want
+           -- to be explicit about when you're creating new remote branches,
+           -- to avoid typos making a mess of your remote repo.
+           , pushGitRootBranch :: Bool -> Branch m -> RemoteRepo -> SyncMode -> m (Either GitError ())
 
            -- Watch expressions are part of the codebase, the `Reference.Id` is
            -- the hash of the source of the watch expression, and the `Term v a`

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -18,6 +18,7 @@ import Unison.Codebase.Editor.Git (withStatus)
 import Unison.Codebase.Editor.RemoteRepo (RemoteNamespace, RemoteRepo)
 import Unison.Codebase.GitError (GitError)
 import Unison.Codebase.Patch (Patch)
+import Unison.Codebase.PushOnEmptyDest (PushOnEmptyDest)
 import qualified Unison.Codebase.Reflog as Reflog
 import Unison.Codebase.ShortBranchHash (ShortBranchHash)
 import Unison.Codebase.SyncMode (SyncMode)
@@ -90,8 +91,7 @@ data Codebase m v a =
            -- these are technically fast-forward merges but you often want
            -- to be explicit about when you're creating new remote branches,
            -- to avoid typos making a mess of your remote repo.
-           , pushGitRootBranch :: Bool -> Branch m -> RemoteRepo -> SyncMode -> m (Either GitError ())
-
+           , pushGitRootBranch :: PushOnEmptyDest -> Branch m -> RemoteRepo -> SyncMode -> m (Either GitError ())
            -- Watch expressions are part of the codebase, the `Reference.Id` is
            -- the hash of the source of the watch expression, and the `Term v a`
            -- is the evaluated result of the expression, decompiled to a term.

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -59,6 +59,7 @@ module Unison.Codebase.Branch
   , stepManyAt0
   , stepManyAtM
   , modifyAtM
+  , modifyAt
 
     -- * Branch terms/types/edits
     -- ** Term/type/edits lenses

--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -190,8 +190,9 @@ data Command m i v a where
   -- codebase are copied there.
   SyncLocalRootBranch :: Branch m -> Command m i v ()
 
+  -- `Bool` is `True` if the push can be to an empty remote namespace
   SyncRemoteRootBranch ::
-    RemoteRepo -> Branch m -> SyncMode -> Command m i v (Either GitError ())
+    Bool -> RemoteRepo -> Branch m -> SyncMode -> Command m i v (Either GitError ())
 
   AppendToReflog :: Text -> Branch m -> Branch m -> Command m i v ()
 

--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -32,6 +32,7 @@ import           Unison.Codebase.Editor.RemoteRepo
 import           Unison.Codebase.Branch         ( Branch )
 import qualified Unison.Codebase.Branch        as Branch
 import           Unison.Codebase.GitError
+import Unison.Codebase.PushOnEmptyDest (PushOnEmptyDest)
 import qualified Unison.Codebase.Reflog        as Reflog
 import           Unison.Codebase.SyncMode       ( SyncMode )
 import           Unison.Names3                  ( Names, Names0 )
@@ -192,7 +193,7 @@ data Command m i v a where
 
   -- `Bool` is `True` if the push can be to an empty remote namespace
   SyncRemoteRootBranch ::
-    Bool -> RemoteRepo -> Branch m -> SyncMode -> Command m i v (Either GitError ())
+    PushOnEmptyDest -> RemoteRepo -> Branch m -> SyncMode -> Command m i v (Either GitError ())
 
   AppendToReflog :: Text -> Branch m -> Branch m -> Command m i v ()
 

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -124,8 +124,8 @@ commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSour
       lift $ Codebase.viewRemoteBranch codebase ns
     ImportRemoteBranch ns syncMode ->
       lift $ Codebase.importRemoteBranch codebase ns syncMode
-    SyncRemoteRootBranch repo branch syncMode ->
-      lift $ Codebase.pushGitRootBranch codebase branch repo syncMode
+    SyncRemoteRootBranch allowCreate repo branch syncMode ->
+      lift $ Codebase.pushGitRootBranch codebase allowCreate branch repo syncMode
     LoadTerm r -> lift $ Codebase.getTerm codebase r
     LoadType r -> lift $ Codebase.getTypeDeclaration codebase r
     LoadTypeOfTerm r -> lift $ Codebase.getTypeOfTerm codebase r

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -51,7 +51,7 @@ data Input
     | PreviewMergeLocalBranchI Path' Path'
     | DiffNamespaceI Path' Path' -- old new
     | PullRemoteBranchI (Maybe RemoteNamespace) Path' SyncMode
-    | PushRemoteBranchI (Maybe RemoteHead) Path' SyncMode
+    | PushRemoteBranchI AllowCreate (Maybe RemoteHead) Path' SyncMode
     | CreatePullRequestI RemoteNamespace RemoteNamespace
     | LoadPullRequestI RemoteNamespace RemoteNamespace Path'
     | ResetRootI (Either ShortBranchHash Path')
@@ -139,6 +139,9 @@ data Input
   | DebugDumpNamespacesI
   | QuitI
   deriving (Eq, Show)
+
+-- Whether `push` is allowed to create a new branch / push to an empty branch.
+type AllowCreate = Bool
 
 -- Some commands, like `view`, can dump output to either console or a file.
 data OutputLocation

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -14,6 +14,7 @@ import qualified Unison.HashQualified          as HQ
 import qualified Unison.HashQualified'         as HQ'
 import           Unison.Codebase.Path           ( Path' )
 import qualified Unison.Codebase.Path          as Path
+import Unison.Codebase.PushOnEmptyDest (PushOnEmptyDest)
 import           Unison.Codebase.Editor.RemoteRepo
 import           Unison.ShortHash (ShortHash)
 import           Unison.Codebase.ShortBranchHash (ShortBranchHash)
@@ -51,7 +52,7 @@ data Input
     | PreviewMergeLocalBranchI Path' Path'
     | DiffNamespaceI Path' Path' -- old new
     | PullRemoteBranchI (Maybe RemoteNamespace) Path' SyncMode
-    | PushRemoteBranchI AllowCreate (Maybe RemoteHead) Path' SyncMode
+    | PushRemoteBranchI PushOnEmptyDest (Maybe RemoteHead) Path' SyncMode
     | CreatePullRequestI RemoteNamespace RemoteNamespace
     | LoadPullRequestI RemoteNamespace RemoteNamespace Path'
     | ResetRootI (Either ShortBranchHash Path')
@@ -139,9 +140,6 @@ data Input
   | DebugDumpNamespacesI
   | QuitI
   deriving (Eq, Show)
-
--- Whether `push` is allowed to create a new branch / push to an empty branch.
-type AllowCreate = Bool
 
 -- Some commands, like `view`, can dump output to either console or a file.
 data OutputLocation

--- a/parser-typechecker/src/Unison/Codebase/GitError.hs
+++ b/parser-typechecker/src/Unison/Codebase/GitError.hs
@@ -17,6 +17,7 @@ data GitError = NoGit
               | PushNoOp RemoteRepo
               -- url commit Diff of what would change on merge with remote
               | PushDestinationHasNewStuff RemoteRepo
+              | PushDestinationIsEmpty RemoteRepo
               | NoRemoteNamespaceWithHash RemoteRepo ShortBranchHash
               | RemoteNamespaceHashAmbiguous RemoteRepo ShortBranchHash (Set Branch.Hash)
               | CouldntLoadRootBranch RemoteRepo Branch.Hash

--- a/parser-typechecker/src/Unison/Codebase/PushOnEmptyDest.hs
+++ b/parser-typechecker/src/Unison/Codebase/PushOnEmptyDest.hs
@@ -1,0 +1,7 @@
+module Unison.Codebase.PushOnEmptyDest where
+
+-- Whether `push` is allowed to create a new branch / push to an empty branch.
+data PushOnEmptyDest
+  = PushOnEmptyDest
+  | AbortOnEmptyDest
+  deriving (Eq, Show)

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -67,6 +67,7 @@ import qualified Unison.Codebase.Init as Codebase
 import qualified Unison.Codebase.Init as Codebase1
 import Unison.Codebase.Patch (Patch)
 import qualified Unison.Codebase.Path as Path
+import Unison.Codebase.PushOnEmptyDest (PushOnEmptyDest (AbortOnEmptyDest))
 import qualified Unison.Codebase.Reflog as Reflog
 import Unison.Codebase.ShortBranchHash (ShortBranchHash)
 import qualified Unison.Codebase.SqliteCodebase.Branch.Dependencies as BD
@@ -1007,7 +1008,7 @@ pushGitRootBranch ::
   MonadIO m =>
   (Branch m -> Branch m -> m (Maybe (Branch m))) ->
   Codebase1.SyncToDir m ->
-  Bool ->
+  PushOnEmptyDest ->
   Branch m ->
   RemoteRepo ->
   SyncMode ->
@@ -1015,7 +1016,7 @@ pushGitRootBranch ::
 pushGitRootBranch lca syncToDirectory allowCreate branch repo syncMode = runExceptT do
   -- Pull the remote repo into a staging directory
   (cleanup, remoteRoot, remotePath) <- Except.ExceptT $ time "SqliteCodebase.pushGitRootBranch.viewRemoteBranch'" $ viewRemoteBranch' (repo, Nothing, Path.empty)
-  when (remoteRoot == Branch.empty && not allowCreate) $
+  when (remoteRoot == Branch.empty && allowCreate == AbortOnEmptyDest) $
     throwError $ GitError.PushDestinationIsEmpty repo
   (ifM
     ((pure (remoteRoot == Branch.empty) ||^

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -30,6 +30,7 @@ import qualified Text.Megaparsec as P
 import qualified Unison.Codebase.Branch as Branch
 import qualified Unison.Codebase.Editor.Input as Input
 import qualified Unison.Codebase.Path as Path
+import Unison.Codebase.PushOnEmptyDest (PushOnEmptyDest(PushOnEmptyDest, AbortOnEmptyDest))
 import qualified Unison.CommandLine.InputPattern as I
 import qualified Unison.HashQualified as HQ
 import qualified Unison.HashQualified' as HQ'
@@ -764,13 +765,11 @@ pullExhaustive = InputPattern
     _ -> Left (I.help pull)
   )
 
-push, pushCreate :: InputPattern
-push = push' False
-pushCreate = push' True
-
-push' :: Bool -> InputPattern
-push' allowCreate = ip where
-  name = if allowCreate then "push.create" else "push"
+push' :: PushOnEmptyDest -> InputPattern
+push' onEmpty = ip where
+  name = case onEmpty of
+    PushOnEmptyDest -> "push.create"
+    AbortOnEmptyDest -> "push"
   ip = InputPattern
     name
     []
@@ -779,8 +778,9 @@ push' allowCreate = ip where
       [ P.wrap $ makeExample ip ["remote", "local"] <> "merges a local" <>
          "namespace into a remote namespace. It will be rejected if" <>
          "the remote has changes not known locally." <>
-             (if allowCreate then mempty
-             else "The destination namespace must also be non-empty.")
+             (case onEmpty of
+               PushOnEmptyDest -> mempty
+               AbortOnEmptyDest -> "The destination namespace must also be non-empty.")
       , ""
       , P.blue $ makeExampleNoBackticks ip ["https://github.com/org/repo", "local"]
         , P.indentN 2 . P.wrap $ "merges the contents of the local namespace `local`"
@@ -798,7 +798,7 @@ push' allowCreate = ip where
     )
     (\case
       []    ->
-        Right $ Input.PushRemoteBranchI allowCreate Nothing Path.relativeEmpty' SyncMode.ShortCircuit
+        Right $ Input.PushRemoteBranchI onEmpty Nothing Path.relativeEmpty' SyncMode.ShortCircuit
       url : rest -> do
         (repo, sbh, path) <- parseUri "url" url
         when (isJust sbh)
@@ -806,8 +806,8 @@ push' allowCreate = ip where
         p <- case rest of
           [] -> Right Path.relativeEmpty'
           [path] -> first fromString $ Path.parsePath' path
-          _ -> Left (I.help push)
-        Right $ Input.PushRemoteBranchI allowCreate (Just (repo, path)) p SyncMode.ShortCircuit
+          _ -> Left (I.help (push' onEmpty))
+        Right $ Input.PushRemoteBranchI onEmpty (Just (repo, path)) p SyncMode.ShortCircuit
     )
 
 pushExhaustive :: InputPattern
@@ -818,14 +818,14 @@ pushExhaustive = InputPattern
   (P.lines
     [ P.wrap $
       "The " <> makeExample' pushExhaustive <> "command can be used in place of"
-        <> makeExample' push <> "to repair remote namespaces"
+        <> makeExample' (push' PushOnEmptyDest) <> "to repair remote namespaces"
         <> "which were pushed incompletely due to a bug in UCM"
         <> "versions M1l and earlier. It may be extra slow!"
     ]
   )
   (\case
     []    ->
-      Right $ Input.PushRemoteBranchI True Nothing Path.relativeEmpty' SyncMode.Complete
+      Right $ Input.PushRemoteBranchI PushOnEmptyDest Nothing Path.relativeEmpty' SyncMode.Complete
     url : rest -> do
       (repo, sbh, path) <- parseUri "url" url
       when (isJust sbh)
@@ -833,8 +833,8 @@ pushExhaustive = InputPattern
       p <- case rest of
         [] -> Right Path.relativeEmpty'
         [path] -> first fromString $ Path.parsePath' path
-        _ -> Left (I.help push)
-      Right $ Input.PushRemoteBranchI True (Just (repo, path)) p SyncMode.Complete
+        _ -> Left (I.help pushExhaustive)
+      Right $ Input.PushRemoteBranchI PushOnEmptyDest (Just (repo, path)) p SyncMode.Complete
   )
 
 createPullRequest :: InputPattern
@@ -1383,8 +1383,8 @@ validInputs =
   , previewMergeLocal
   , diffNamespace
   , names
-  , push
-  , pushCreate
+  , push' PushOnEmptyDest
+  , push' AbortOnEmptyDest
   , pull
   , pushExhaustive
   , pullExhaustive
@@ -1562,8 +1562,7 @@ collectNothings f as = [ a | (Nothing, a) <- map f as `zip` as ]
 
 patternFromInput :: Input -> InputPattern
 patternFromInput = \case
-  Input.PushRemoteBranchI False _ _ SyncMode.ShortCircuit -> push
-  Input.PushRemoteBranchI True _ _ SyncMode.ShortCircuit -> pushCreate
+  Input.PushRemoteBranchI onEmpty _ _ SyncMode.ShortCircuit -> push' onEmpty
   Input.PushRemoteBranchI _ _ _ SyncMode.Complete -> pushExhaustive
   Input.PullRemoteBranchI _ _ SyncMode.ShortCircuit -> pull
   Input.PullRemoteBranchI _ _ SyncMode.Complete -> pullExhaustive

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -693,6 +693,16 @@ notifyUser dir o = case o of
       <> P.backticked (P.text uri) <> "into a cache directory at"
       <> P.backticked' (P.string localPath) "," <> "but I can't recognize the"
       <> "result as a git repository, so I'm not sure what to do next."
+    PushDestinationIsEmpty repo ->
+      P.callout "⏸" . P.lines $ [
+      P.wrap $ "The destination you're pushing to at"
+            <> prettyRepoRevision repo
+            <> "is an empty namespace.",
+      "",
+      P.wrap $ "If you're trying to create a new namespace,"
+            <> "you can use the " <> IP.makeExample' IP.pushCreate
+            <> "command."
+      ]
     PushDestinationHasNewStuff repo ->
       P.callout "⏸" . P.lines $ [
       P.wrap $ "The repository at" <> prettyRepoRevision repo

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -113,6 +113,7 @@ import qualified Unison.ShortHash as SH
 import Unison.LabeledDependency as LD
 import Unison.Codebase.Editor.RemoteRepo (RemoteRepo)
 import U.Codebase.Sqlite.DbId (SchemaVersion(SchemaVersion))
+import Unison.Codebase.PushOnEmptyDest (PushOnEmptyDest(PushOnEmptyDest, AbortOnEmptyDest))
 
 type Pretty = P.Pretty P.ColorText
 
@@ -315,10 +316,10 @@ notifyUser dir o = case o of
           , prettyPath' mergedPath ]
         <> "to see what work is remaining for the merge."
     , P.wrap $ "Use" <>
-        IP.makeExample IP.push
+        IP.makeExample (IP.push' AbortOnEmptyDest)
           [prettyRemoteNamespace baseNS, prettyPath' mergedPath] <>
         "or" <>
-        IP.makeExample IP.push
+        IP.makeExample (IP.push' AbortOnEmptyDest)
           [prettyRemoteNamespace baseNS, prettyPath' squashedPath]
         <> "to push the changes."
     ]
@@ -700,7 +701,7 @@ notifyUser dir o = case o of
             <> "is an empty namespace.",
       "",
       P.wrap $ "If you're trying to create a new namespace,"
-            <> "you can use the " <> IP.makeExample' IP.pushCreate
+            <> "you can use the " <> IP.makeExample' (IP.push' PushOnEmptyDest)
             <> "command."
       ]
     PushDestinationHasNewStuff repo ->

--- a/parser-typechecker/tests/Unison/Test/Git.hs
+++ b/parser-typechecker/tests/Unison/Test/Git.hs
@@ -197,7 +197,7 @@ testPull = scope "pull" $ do
     ```ucm
     .myLib> debug.file
     .myLib> add
-    .myLib> push ${repo}
+    .myLib> push.create ${repo}
     ```
   |]
 
@@ -396,7 +396,7 @@ testPush = scope "push" $ do
 
   pushTranscript repo = [i|
     ```ucm
-    .foo.inside> push ${repo}
+    .foo.inside> push.create ${repo}
     ```
   |]
 

--- a/parser-typechecker/tests/Unison/Test/GitSync.hs
+++ b/parser-typechecker/tests/Unison/Test/GitSync.hs
@@ -37,7 +37,7 @@ test = scope "gitsync22" . tests $
       .> alias.type ##Nat builtin.Nat
       .> history
       .> history builtin
-      .> push ${repo}
+      .> push.create ${repo}
       ```
     |])
     (\repo -> [i|
@@ -58,7 +58,7 @@ test = scope "gitsync22" . tests $
       ```ucm
       .> add
       .> history
-      .> push ${repo}
+      .> push.create ${repo}
       ```
     |])
     (\repo -> [i|
@@ -83,7 +83,7 @@ test = scope "gitsync22" . tests $
           .> link doc y
           .> links y
           .> history
-          .> push ${repo}
+          .> push.create ${repo}
           ```
     |])
     (\repo -> [i|
@@ -102,7 +102,7 @@ test = scope "gitsync22" . tests $
           .> add
           .> alias.type ##Nat Nat
           .> link doc Nat
-          .> push ${repo}
+          .> push.create ${repo}
           ```
     |])
     (\repo -> [i|
@@ -123,7 +123,7 @@ test = scope "gitsync22" . tests $
           ```
           ```ucm
           .> add
-          .> push ${repo}
+          .> push.create ${repo}
           ```
     |])
     (\repo -> [i|
@@ -159,7 +159,7 @@ test = scope "gitsync22" . tests $
           ```
           ```ucm
           .> view.patch patch
-          .> push ${repo}
+          .> push.create ${repo}
           ```
     |])
     (\repo -> [i|
@@ -183,7 +183,7 @@ test = scope "gitsync22" . tests $
           ```ucm
           .> update
           .> history
-          .> push ${repo}
+          .> push.create ${repo}
           ```
     |])
     (\repo -> [i|
@@ -205,7 +205,7 @@ test = scope "gitsync22" . tests $
       ```ucm
       .> debug.file
       .> add
-      .> push ${repo}
+      .> push.create ${repo}
       ```
     |])
 -- simplest-user
@@ -228,7 +228,7 @@ test = scope "gitsync22" . tests $
       ```ucm
       .> debug.file
       .myLib> add
-      .myLib> push ${repo}
+      .myLib> push.create ${repo}
       ```
       |])
 -- simplest-user
@@ -250,7 +250,7 @@ test = scope "gitsync22" . tests $
       ```ucm
       .myLib> debug.file
       .myLib> add
-      .myLib> push ${repo}
+      .myLib> push.create ${repo}
       ```
       |])
 -- simplest-user
@@ -284,7 +284,7 @@ test = scope "gitsync22" . tests $
       ```
       ```ucm
       .workaround1552.myLib.v2> update
-      .workaround1552.myLib> push ${repo}
+      .workaround1552.myLib> push.create ${repo}
       ```
     |])
     (\repo -> [i|
@@ -326,7 +326,7 @@ test = scope "gitsync22" . tests $
       .defns> add
       .patches> replace.type .defns.A .defns.B
       .patches> replace.term .defns.x .defns.y
-      .patches> push ${repo}
+      .patches> push.create ${repo}
       ```
     |])
     (\repo -> [i|
@@ -347,7 +347,7 @@ test = scope "gitsync22" . tests $
         ```
         ```ucm
         .> add
-        .> push ${repo}
+        .> push.create ${repo}
         ```
       |])
     (\repo -> [i|

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -64,6 +64,7 @@ library
       Unison.Codebase.NameEdit
       Unison.Codebase.Patch
       Unison.Codebase.Path
+      Unison.Codebase.PushOnEmptyDest
       Unison.Codebase.Reflog
       Unison.Codebase.Runtime
       Unison.Codebase.Serialization


### PR DESCRIPTION
Separate `push` and `push.create` commands. Regular `push` won't create a new namespace at the target and will prompt the user to do `push.create` if they are intending to create a new namespace and it's not a typo.

__Todo:__
- [ ] Move the `empty` check to look at the selected sub-namespace.
- [ ] Update tests to use `push.create` as appropriate (tests are failing due to this currently)
- [ ] Update error-on-empty message to include the path that was empty
- [ ] Add a test that confirms failure when doing `push` to empty namespace
- [ ] Add a test that confirms failure when doing `push.create` to nonempty namespace?

Other random stuff:

* The `help` command was doing `Pretty.wrap` around all the command help, which mangles things badly for commands that have more structured help. It took me like an hour to track this down. Correct behavior is for the commands to use `Pretty.wrap` internally if they want wrapped text.

<img width="794" alt="Screen Shot 2021-05-20 at 11 35 09 PM" src="https://user-images.githubusercontent.com/11074/119082716-4064ab80-b9c4-11eb-8e1e-8001c0bea6c2.png">

Here's the error you get if you try to use `push` and the destination is an empty namespace:

<img width="1247" alt="Screen Shot 2021-05-20 at 11 59 15 PM" src="https://user-images.githubusercontent.com/11074/119084491-8111f400-b9c7-11eb-9993-ebe4ffc380d2.png">

* This PR was cherry-picked from another branch that will be rebased soon.  Here are the original commits in case they are needed (https://github.com/unisonweb/unison/tree/feature/push-create-archive) which I guess can be deleted once we're satisfied here.