### PR TITLE
Fix to `squash a b` to properly short circuit in the case where `b <= a`

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -397,10 +397,8 @@ merge'' _ mode b1 b2 | isEmpty b2 = case mode of
     pure $ cons (discardHistory0 (head b1)) b2
 merge'' lca mode (Branch x) (Branch y) =
   Branch <$> case mode of
-               RegularMerge -> Causal.threeWayMerge' lca' combine x y
-               SquashMerge  -> do
-                 traceM "Squashin' ..."
-                 Causal.squashMerge' lca' combine x y
+    RegularMerge -> Causal.threeWayMerge' lca' combine x y
+    SquashMerge  -> Causal.squashMerge' lca' (pure . discardHistory0) combine x y
  where
   lca' c1 c2 = fmap _history <$> lca (Branch c1) (Branch c2)
   combine :: Maybe (Branch0 m) -> Branch0 m -> Branch0 m -> m (Branch0 m)
@@ -408,9 +406,6 @@ merge'' lca mode (Branch x) (Branch y) =
   combine (Just ca) l r = do
     dl <- diff0 ca l
     dr <- diff0 ca r
-    traceM $ show (ca == l, ca == r, dl == mempty, dr == mempty)
-    traceM $ "\ndl: " ++ show dl
-    traceM $ "\ndr: " ++ show dr
     head0 <- apply ca (dl <> dr)
     children <- Map.mergeA
                   (Map.traverseMaybeMissing $ combineMissing ca)

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -393,11 +393,14 @@ merge'' :: forall m . Monad m
 merge'' _ _ b1 b2      | isEmpty b1 = pure b2
 merge'' _ mode b1 b2 | isEmpty b2 = case mode of
   RegularMerge -> pure b1
-  SquashMerge -> pure $ cons (discardHistory0 (head b1)) b2
+  SquashMerge ->
+    pure $ cons (discardHistory0 (head b1)) b2
 merge'' lca mode (Branch x) (Branch y) =
   Branch <$> case mode of
                RegularMerge -> Causal.threeWayMerge' lca' combine x y
-               SquashMerge  -> Causal.squashMerge' lca' combine x y
+               SquashMerge  -> do
+                 traceM "Squashin' ..."
+                 Causal.squashMerge' lca' combine x y
  where
   lca' c1 c2 = fmap _history <$> lca (Branch c1) (Branch c2)
   combine :: Maybe (Branch0 m) -> Branch0 m -> Branch0 m -> m (Branch0 m)
@@ -405,6 +408,9 @@ merge'' lca mode (Branch x) (Branch y) =
   combine (Just ca) l r = do
     dl <- diff0 ca l
     dr <- diff0 ca r
+    traceM $ show (ca == l, ca == r, dl == mempty, dr == mempty)
+    traceM $ "\ndl: " ++ show dl
+    traceM $ "\ndr: " ++ show dr
     head0 <- apply ca (dl <> dr)
     children <- Map.mergeA
                   (Map.traverseMaybeMissing $ combineMissing ca)

--- a/parser-typechecker/src/Unison/Codebase/Causal.hs
+++ b/parser-typechecker/src/Unison/Codebase/Causal.hs
@@ -218,25 +218,19 @@ squashMerge'
   :: forall m h e
    . (Monad m, Hashable e, Eq e)
   => (Causal m h e -> Causal m h e -> m (Maybe (Causal m h e)))
+  -> (e -> m e)
   -> (Maybe e -> e -> e -> m e)
   -> Causal m h e
   -> Causal m h e
   -> m (Causal m h e)
-squashMerge' lca combine c1 c2 = do
+squashMerge' lca discardHistory combine c1 c2 = do
   theLCA <- lca c1 c2
   let done newHead = consDistinct newHead c2
   case theLCA of
     Nothing -> done <$> combine Nothing (head c1) (head c2)
     Just lca
       | lca == c1 -> pure c2
-
-      -- Pretty subtle: if we were to add this short circuit, then
-      -- the history of c1's children would still make it into the result
-      -- Calling `combine` will recursively call into `squashMerge`
-      -- for the children, discarding their history before calling `done`
-      -- on the parent.
-      --   | lca == c2 -> pure $ done c1
-
+      | lca == c2 -> done <$> discardHistory (head c1)
       | otherwise -> done <$> combine (Just $ head lca) (head c1) (head c2)
 
 threeWayMerge :: forall m h e

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -286,7 +286,7 @@ isFailure o = case o of
   Typechecked{} -> False
   DisplayDefinitions _ _ m1 m2 -> null m1 && null m2
   DisplayRendered{} -> False
-  TodoOutput _ todo -> TO.todoScore todo /= 0
+  TodoOutput _ todo -> TO.todoScore todo /= 0 && not (TO.noConflicts todo)
   TestIncrementalOutputStart{} -> False
   TestIncrementalOutputEnd{} -> False
   TestResults _ _ _ _ _ fails -> not (null fails)

--- a/parser-typechecker/tests/Unison/Test/Codebase/Causal.hs
+++ b/parser-typechecker/tests/Unison/Test/Codebase/Causal.hs
@@ -159,7 +159,8 @@ extend n ca = do
 
 lcaPair :: Test (Causal Identity Hash Int64, Causal Identity Hash Int64)
 lcaPair = do
-  base <- one <$> int64
+  h <- int64
+  let base = Causal.cons h (one 0)
   ll <- int' 0 20
   lr <- int' 0 20
   (,) <$> extend ll base <*> extend lr base
@@ -211,10 +212,9 @@ setPatch :: Applicative m => Ord a => Set a -> (Set a, Set a) -> m (Set a)
 setPatch s (added, removed) = pure (added <> Set.difference s removed)
 
 -- merge x x == x, should not add a new head, and also the value at the head should be the same of course
-testIdempotent :: Causal Identity Hash (Set Int64) -> Bool -- Causal Identity Hash (Set Int64)
+testIdempotent :: Causal Identity Hash (Set Int64) -> Bool
 testIdempotent causal =
-     runIdentity (threeWayMerge' causal causal)
-  == causal
+     runIdentity (threeWayMerge' causal causal) == causal
 
 -- prop_mergeIdempotent :: Bool
 -- prop_mergeIdempotent = and (map testIdempotent (take 1000 generateRandomCausals))

--- a/unison-src/transcripts/fix1926.output.md
+++ b/unison-src/transcripts/fix1926.output.md
@@ -1,0 +1,54 @@
+```ucm
+.> builtins.merge
+
+  Done.
+
+```
+```unison
+> 'sq
+
+sq = 2934892384
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      sq : Nat
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    1 | > 'sq
+          ⧩
+          'sq
+
+```
+```unison
+> 'sq
+
+sq = 2934892384
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      sq : Nat
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    1 | > 'sq
+          ⧩
+          'sq
+
+```

--- a/unison-src/transcripts/fix2000.md
+++ b/unison-src/transcripts/fix2000.md
@@ -1,0 +1,40 @@
+Checks that squash and merge do the same thing, with nontrivial history that
+includes a merge conflict.
+
+```ucm:hide
+.> builtins.merge
+```
+
+```unison
+x.a.a = "af"
+```
+
+```ucm
+.> add
+.> fork x y
+.> fork x s
+.> fork x m
+.> delete y.a.a
+```
+
+```unison
+y.a.a = "fij"
+```
+
+```ucm
+.> add
+```
+
+```unison
+y.b.a = "wie"
+```
+
+```ucm
+.> add
+.> merge y.b y.a
+.> delete.term 1
+.> merge y m
+.> squash y s
+.s> todo
+```
+

--- a/unison-src/transcripts/fix2000.md
+++ b/unison-src/transcripts/fix2000.md
@@ -6,7 +6,8 @@ includes a merge conflict.
 ```
 
 ```unison
-x.a.a = "af"
+x.a.p = "af"
+x.a.q = "ef"
 ```
 
 ```ucm
@@ -14,11 +15,11 @@ x.a.a = "af"
 .> fork x y
 .> fork x s
 .> fork x m
-.> delete y.a.a
+.> delete y.a.p
 ```
 
 ```unison
-y.a.a = "fij"
+y.a.p = "fij"
 ```
 
 ```ucm
@@ -26,13 +27,19 @@ y.a.a = "fij"
 ```
 
 ```unison
-y.b.a = "wie"
+y.b.p = "wie"
 ```
+
+Merge back into the ancestor.
 
 ```ucm
 .> add
 .> merge y.b y.a
 .> delete.term 1
+.> history x.a
+.> history y.a
+.> history #0530pbcaqe
+.> history #oe3qde4k0g
 .> merge y m
 .> squash y s
 .s> todo

--- a/unison-src/transcripts/fix2000.output.md
+++ b/unison-src/transcripts/fix2000.output.md
@@ -2,7 +2,8 @@ Checks that squash and merge do the same thing, with nontrivial history that
 includes a merge conflict.
 
 ```unison
-x.a.a = "af"
+x.a.p = "af"
+x.a.q = "ef"
 ```
 
 ```ucm
@@ -13,7 +14,8 @@ x.a.a = "af"
   
     ⍟ These new definitions are ok to `add`:
     
-      x.a.a : Text
+      x.a.p : Text
+      x.a.q : Text
 
 ```
 ```ucm
@@ -21,7 +23,8 @@ x.a.a = "af"
 
   ⍟ I've added these definitions:
   
-    x.a.a : Text
+    x.a.p : Text
+    x.a.q : Text
 
 .> fork x y
 
@@ -35,21 +38,21 @@ x.a.a = "af"
 
   Done.
 
-.> delete y.a.a
+.> delete y.a.p
 
   Name changes:
   
     Original    Changes
-    1. m.a.a ┐  2. y.a.a (removed)
-    3. s.a.a │  
-    4. x.a.a │  
-    5. y.a.a ┘  
+    1. m.a.p ┐  2. y.a.p (removed)
+    3. s.a.p │  
+    4. x.a.p │  
+    5. y.a.p ┘  
   
   Tip: You can use `undo` or `reflog` to undo this change.
 
 ```
 ```unison
-y.a.a = "fij"
+y.a.p = "fij"
 ```
 
 ```ucm
@@ -60,7 +63,7 @@ y.a.a = "fij"
   
     ⍟ These new definitions are ok to `add`:
     
-      y.a.a : Text
+      y.a.p : Text
 
 ```
 ```ucm
@@ -68,11 +71,11 @@ y.a.a = "fij"
 
   ⍟ I've added these definitions:
   
-    y.a.a : Text
+    y.a.p : Text
 
 ```
 ```unison
-y.b.a = "wie"
+y.b.p = "wie"
 ```
 
 ```ucm
@@ -83,15 +86,17 @@ y.b.a = "wie"
   
     ⍟ These new definitions are ok to `add`:
     
-      y.b.a : Text
+      y.b.p : Text
 
 ```
+Merge back into the ancestor.
+
 ```ucm
 .> add
 
   ⍟ I've added these definitions:
   
-    y.b.a : Text
+    y.b.p : Text
 
 .> merge y.b y.a
 
@@ -99,10 +104,10 @@ y.b.a = "wie"
   
   New name conflicts:
   
-    1. a#a3ef1630bu : Text
+    1. p#a3ef1630bu : Text
        ↓
-    2. ┌ a#a3ef1630bu : Text
-    3. └ a#fjqpdmdeqi : Text
+    2. ┌ p#a3ef1630bu : Text
+    3. └ p#fjqpdmdeqi : Text
   
   Tip: You can use `todo` to see if this generated any work to
        do in this namespace and `test` to run the tests. Or you
@@ -113,12 +118,83 @@ y.b.a = "wie"
 
   Resolved name conflicts:
   
-    1. ┌ y.a.a#a3ef1630bu : Text
-    2. └ y.a.a#fjqpdmdeqi : Text
+    1. ┌ y.a.p#a3ef1630bu : Text
+    2. └ y.a.p#fjqpdmdeqi : Text
        ↓
-    3. y.a.a#fjqpdmdeqi : Text
+    3. y.a.p#fjqpdmdeqi : Text
   
   Tip: You can use `undo` or `reflog` to undo this change.
+
+.> history x.a
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ #mt9jsk344h
+  
+    + Adds / updates:
+    
+      p q
+  
+  □ #7asfbtqmoj (start of history)
+
+.> history y.a
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ #bbfih4a2g4
+  
+    - Deletes:
+    
+      p
+  
+  This segment of history starts with a merge. Use
+  `history #som3n4m3space` to view history starting from a given
+  namespace hash.
+  
+  ⊙ #6vg166teag
+  ⑃
+  #0530pbcaqe
+  #oe3qde4k0g
+
+.> history #0530pbcaqe
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ #0530pbcaqe
+  
+    + Adds / updates:
+    
+      p
+  
+  ⊙ #2mqnhg89fi
+  
+    - Deletes:
+    
+      p
+  
+  ⊙ #mt9jsk344h
+  
+    + Adds / updates:
+    
+      p q
+  
+  □ #7asfbtqmoj (start of history)
+
+.> history #oe3qde4k0g
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ #oe3qde4k0g
+  
+    + Adds / updates:
+    
+      p
+  
+  □ #7asfbtqmoj (start of history)
 
 .> merge y m
 
@@ -126,14 +202,14 @@ y.b.a = "wie"
   
   Updates:
   
-    1. a.a : Text
+    1. a.p : Text
        ↓
-    2. a.a : Text
+    2. a.p : Text
   
   Added definitions:
   
-    3. ┌ a.a : Text
-    4. └ b.a : Text
+    3. ┌ a.p : Text
+    4. └ b.p : Text
   
   Tip: You can use `todo` to see if this generated any work to
        do in this namespace and `test` to run the tests. Or you
@@ -146,15 +222,15 @@ y.b.a = "wie"
   
   New name conflicts:
   
-    1. a.a#0gr1q8f2jk : Text
+    1. a.p#0gr1q8f2jk : Text
        ↓
-    2. ┌ a.a#0gr1q8f2jk : Text
-    3. └ a.a#fjqpdmdeqi : Text
+    2. ┌ a.p#0gr1q8f2jk : Text
+    3. └ a.p#fjqpdmdeqi : Text
   
   Added definitions:
   
-    4. ┌ a.a#fjqpdmdeqi : Text
-    5. └ b.a            : Text
+    4. ┌ a.p#fjqpdmdeqi : Text
+    5. └ b.p            : Text
   
   Tip: You can use `todo` to see if this generated any work to
        do in this namespace and `test` to run the tests. Or you
@@ -165,10 +241,10 @@ y.b.a = "wie"
 
   ❓
   
-  These terms have conflicting definitions: a.a
+  These terms have conflicting definitions: a.p
   
   Tip: This occurs when merging branches that both independently
-       introduce the same name. Use `view a.a` to see the
+       introduce the same name. Use `view a.p` to see the
        conflicting defintions, then use `move.term` to resolve
        the conflicts.
 

--- a/unison-src/transcripts/fix2000.output.md
+++ b/unison-src/transcripts/fix2000.output.md
@@ -1,0 +1,175 @@
+Checks that squash and merge do the same thing, with nontrivial history that
+includes a merge conflict.
+
+```unison
+x.a.a = "af"
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      x.a.a : Text
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    x.a.a : Text
+
+.> fork x y
+
+  Done.
+
+.> fork x s
+
+  Done.
+
+.> fork x m
+
+  Done.
+
+.> delete y.a.a
+
+  Name changes:
+  
+    Original    Changes
+    1. m.a.a ┐  2. y.a.a (removed)
+    3. s.a.a │  
+    4. x.a.a │  
+    5. y.a.a ┘  
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
+
+```
+```unison
+y.a.a = "fij"
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      y.a.a : Text
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    y.a.a : Text
+
+```
+```unison
+y.b.a = "wie"
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      y.b.a : Text
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    y.b.a : Text
+
+.> merge y.b y.a
+
+  Here's what's changed in y.a after the merge:
+  
+  New name conflicts:
+  
+    1. a#a3ef1630bu : Text
+       ↓
+    2. ┌ a#a3ef1630bu : Text
+    3. └ a#fjqpdmdeqi : Text
+  
+  Tip: You can use `todo` to see if this generated any work to
+       do in this namespace and `test` to run the tests. Or you
+       can use `undo` or `reflog` to undo the results of this
+       merge.
+
+.> delete.term 1
+
+  Resolved name conflicts:
+  
+    1. ┌ y.a.a#a3ef1630bu : Text
+    2. └ y.a.a#fjqpdmdeqi : Text
+       ↓
+    3. y.a.a#fjqpdmdeqi : Text
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
+
+.> merge y m
+
+  Here's what's changed in m after the merge:
+  
+  Updates:
+  
+    1. a.a : Text
+       ↓
+    2. a.a : Text
+  
+  Added definitions:
+  
+    3. ┌ a.a : Text
+    4. └ b.a : Text
+  
+  Tip: You can use `todo` to see if this generated any work to
+       do in this namespace and `test` to run the tests. Or you
+       can use `undo` or `reflog` to undo the results of this
+       merge.
+
+.> squash y s
+
+  Here's what's changed in s after the merge:
+  
+  New name conflicts:
+  
+    1. a.a#0gr1q8f2jk : Text
+       ↓
+    2. ┌ a.a#0gr1q8f2jk : Text
+    3. └ a.a#fjqpdmdeqi : Text
+  
+  Added definitions:
+  
+    4. ┌ a.a#fjqpdmdeqi : Text
+    5. └ b.a            : Text
+  
+  Tip: You can use `todo` to see if this generated any work to
+       do in this namespace and `test` to run the tests. Or you
+       can use `undo` or `reflog` to undo the results of this
+       merge.
+
+.s> todo
+
+  ❓
+  
+  These terms have conflicting definitions: a.a
+  
+  Tip: This occurs when merging branches that both independently
+       introduce the same name. Use `view a.a` to see the
+       conflicting defintions, then use `move.term` to resolve
+       the conflicts.
+
+```

--- a/unison-src/transcripts/fix2000.output.md
+++ b/unison-src/transcripts/fix2000.output.md
@@ -220,8 +220,9 @@ Merge back into the ancestor.
 
   Here's what's changed in s after the merge:
   
-  New name conflicts:
+  Updates:
   
+<<<<<<< HEAD
     1. a.p#0gr1q8f2jk : Text
        ↓
     2. ┌ a.p#0gr1q8f2jk : Text
@@ -231,6 +232,16 @@ Merge back into the ancestor.
   
     4. ┌ a.p#fjqpdmdeqi : Text
     5. └ b.p            : Text
+=======
+    1. a.a : Text
+       ↓
+    2. a.a : Text
+  
+  Added definitions:
+  
+    3. ┌ a.a : Text
+    4. └ b.a : Text
+>>>>>>> a02768d3f (Add short-circuiting for `squash`)
   
   Tip: You can use `todo` to see if this generated any work to
        do in this namespace and `test` to run the tests. Or you
@@ -239,6 +250,7 @@ Merge back into the ancestor.
 
 .s> todo
 
+<<<<<<< HEAD
   ❓
   
   These terms have conflicting definitions: a.p
@@ -247,5 +259,10 @@ Merge back into the ancestor.
        introduce the same name. Use `view a.p` to see the
        conflicting defintions, then use `move.term` to resolve
        the conflicts.
+=======
+  ✅
+  
+  No conflicts or edits in progress.
+>>>>>>> a02768d3f (Add short-circuiting for `squash`)
 
 ```

--- a/unison-src/transcripts/fix2000.output.md
+++ b/unison-src/transcripts/fix2000.output.md
@@ -222,26 +222,14 @@ Merge back into the ancestor.
   
   Updates:
   
-<<<<<<< HEAD
-    1. a.p#0gr1q8f2jk : Text
+    1. a.p : Text
        ↓
-    2. ┌ a.p#0gr1q8f2jk : Text
-    3. └ a.p#fjqpdmdeqi : Text
+    2. a.p : Text
   
   Added definitions:
   
-    4. ┌ a.p#fjqpdmdeqi : Text
-    5. └ b.p            : Text
-=======
-    1. a.a : Text
-       ↓
-    2. a.a : Text
-  
-  Added definitions:
-  
-    3. ┌ a.a : Text
-    4. └ b.a : Text
->>>>>>> a02768d3f (Add short-circuiting for `squash`)
+    3. ┌ a.p : Text
+    4. └ b.p : Text
   
   Tip: You can use `todo` to see if this generated any work to
        do in this namespace and `test` to run the tests. Or you
@@ -250,19 +238,8 @@ Merge back into the ancestor.
 
 .s> todo
 
-<<<<<<< HEAD
-  ❓
-  
-  These terms have conflicting definitions: a.p
-  
-  Tip: This occurs when merging branches that both independently
-       introduce the same name. Use `view a.p` to see the
-       conflicting defintions, then use `move.term` to resolve
-       the conflicts.
-=======
   ✅
   
   No conflicts or edits in progress.
->>>>>>> a02768d3f (Add short-circuiting for `squash`)
 
 ```

--- a/unison-src/transcripts/squash.output.md
+++ b/unison-src/transcripts/squash.output.md
@@ -527,11 +527,7 @@ This checks to see that squashing correctly preserves deletions:
   Note: The most recent namespace hash is immediately below this
         message.
   
-<<<<<<< HEAD
-  ⊙ #8jcsn0thlb
-=======
-  ⊙ #eevgoo4bf5
->>>>>>> a02768d3f (Add short-circuiting for `squash`)
+  ⊙ #sasilta77k
   
     - Deletes:
     

--- a/unison-src/transcripts/squash.output.md
+++ b/unison-src/transcripts/squash.output.md
@@ -527,7 +527,11 @@ This checks to see that squashing correctly preserves deletions:
   Note: The most recent namespace hash is immediately below this
         message.
   
+<<<<<<< HEAD
   ⊙ #8jcsn0thlb
+=======
+  ⊙ #eevgoo4bf5
+>>>>>>> a02768d3f (Add short-circuiting for `squash`)
   
     - Deletes:
     


### PR DESCRIPTION
Fixes #2000 and adds a regression test.

- [x] Possibly add special case to LCA to avoid returning the empty branch unless there really are no other possible LCAs. We started on this but it made some unit tests fail and I'm not sure we had a non-hacky fix.
- [x] Add short circuiting of `squash`.