### PR TITLE
Add an option for running codebase server in headless mode

### DIFF
--- a/parser-typechecker/src/Unison/Server/CodebaseServer.hs
+++ b/parser-typechecker/src/Unison/Server/CodebaseServer.hs
@@ -42,16 +42,19 @@ import Network.Wai.Handler.Warp
     withApplicationSettings,
   )
 import Options.Applicative
-  ( auto,
+  ( argument,
+    auto,
     defaultPrefs,
     execParserPure,
     forwardOptions,
     getParseResult,
     help,
     info,
+    internal,
     long,
     metavar,
     option,
+    str,
     strOption,
   )
 import Servant
@@ -214,8 +217,9 @@ start codebase k = do
   args     <- getArgs
   let
     p =
-      (,,,)
-        <$> (   (<|> envToken)
+      (,,,,)
+        <$> ( many $ argument str internal )
+        <*> (   (<|> envToken)
             <$> (  optional
                 .  strOption
                 $  long "token"
@@ -247,7 +251,7 @@ start codebase k = do
     mayOpts =
       getParseResult $ execParserPure defaultPrefs (info p forwardOptions) args
   case mayOpts of
-    Just (token, host, port, ui) -> startServer codebase k token host port ui
+    Just (_, token, host, port, ui) -> startServer codebase k token host port ui
     Nothing -> startServer codebase k Nothing Nothing Nothing Nothing
 
 startServer

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -99,6 +99,9 @@ usage executableStr = P.callout "🌻" $ P.lines [
         <> "Multiple transcript files may be provided; they are processed in sequence"
         <> "starting from the same codebase.",
   "",
+  P.bold $ exetutable <> " headless",
+  "Runs the codebase server without the command-line interface.",
+  "",
   P.bold $ executable <> " version",
   "Prints version of Unison then quits.",
   "",

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -99,6 +99,9 @@ usage executableStr = P.callout "🌻" $ P.lines [
         <> "Multiple transcript files may be provided; they are processed in sequence"
         <> "starting from the same codebase.",
   "",
+  P.bold $ executable <> " headless",
+  "Runs the codebase server without the command-line interface.",
+  "",
   P.bold $ executable <> " version",
   "Prints version of Unison then quits.",
   "",

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -99,9 +99,6 @@ usage executableStr = P.callout "🌻" $ P.lines [
         <> "Multiple transcript files may be provided; they are processed in sequence"
         <> "starting from the same codebase.",
   "",
-  P.bold $ exetutable <> " headless",
-  "Runs the codebase server without the command-line interface.",
-  "",
   P.bold $ executable <> " version",
   "Prints version of Unison then quits.",
   "",


### PR DESCRIPTION
This adds the option to pass `headless` to UCM to run the codebase manager without the CLI.

e.g:

```
$ ucm headless

  I've started the codebase API server at
  http://127.0.0.1:8081/foo/api


  The Unison Codebase UI is running at
  http://127.0.0.1:8081/foo/ui


  Running the codebase manager in headless mode.

```