### PR TITLE
@signature is now @inlineSignature

### DIFF
--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -375,12 +375,12 @@ lexemes' eof = P.optional space >> do
           _ <- lit "}"
           pure (join s)
         signature = wrap "syntax.docSignature" $ do
-          _ <- lit "@signatures" *> (lit " {" <|> lit "{") *> CP.space
+          _ <- (lit "@signatures" <|> lit "@signature") *> (lit " {" <|> lit "{") *> CP.space
           s <- join <$> P.sepBy1 signatureLink comma
           _ <- lit "}"
           pure s
         signatureInline = wrap "syntax.docSignatureInline" $ do
-          _ <- lit "@signature" *> (lit " {" <|> lit "{") *> CP.space
+          _ <- lit "@inlineSignature" *> (lit " {" <|> lit "{") *> CP.space
           s <- signatureLink
           _ <- lit "}"
           pure s

--- a/unison-src/transcripts-using-base/doc.md.files/syntax.u
+++ b/unison-src/transcripts-using-base/doc.md.files/syntax.u
@@ -96,10 +96,10 @@ Some rendering targets also support folded source:
 
 @foldedSource{type Optional, sqr}
 
-You can also include just a signature, inline, with @signature{sqr},
+You can also include just a signature, inline, with @inlineSignature{sqr},
 or you can include one or more signatures as a block:
 
-@signatures{sqr, Nat.+}
+@signature{sqr, Nat.+}
 
 ## Inline snippets
 


### PR DESCRIPTION
This is a minor papercut fix for the documentation format. 

Previously, `@signature{List.map}` would include a signature inline in a paragraph, and `@signatures{List.map, List.filter}` could be used to include 1 or more signatures as a block element. It's confusing to have singular vs plural decide block element vs inline element. @rlmark and I spotted this.

After this change it's `@inlineSignature{List.map}` for the inline version and `@signature{List.map}` (or `@signatures{List.map, List.filter}`) for the block version. I think this is a good default since signatures often don't fit nicely in the middle of a paragraph.

Note that `@signature` vs `@signatures` mean exactly the same thing. I didn't see any reason to disallow one or the other.

For testing, I just updated the syntax guide to use all of `@signature`, `@signatures`, and `@inlineSignature`.