### PR TITLE
Fix bug that would cause scopes to be improperly reported in EasyTest

### DIFF
--- a/yaks/easytest/tests/Suite.hs
+++ b/yaks/easytest/tests/Suite.hs
@@ -8,9 +8,9 @@ suite1 = tests
   [ scope "a" ok
   , scope "b.c" ok
   , scope "b" ok
-  -- leaving this commented out until we have a
-  -- `expectFailure :: Scope -> Test a -> Test a` or similar function
-  , scope "b" . scope "c" $ error "oh noes! - should fail with b.c scope"
+  -- leaving this commented out until we have a function like:
+  -- `expectFailure :: Scope -> Test a -> Test a`
+  -- , scope "b" . scope "c" $ error "oh noes! - should fail with b.c scope"
   , scope "b" . scope "c" . scope "d" $ ok
   , scope "c" ok ]
 

--- a/yaks/easytest/tests/Suite.hs
+++ b/yaks/easytest/tests/Suite.hs
@@ -8,13 +8,16 @@ suite1 = tests
   [ scope "a" ok
   , scope "b.c" ok
   , scope "b" ok
+  -- leaving this commented out until we have a
+  -- `expectFailure :: Scope -> Test a -> Test a` or similar function
+  , scope "b" . scope "c" $ error "oh noes! - should fail with b.c scope"
   , scope "b" . scope "c" . scope "d" $ ok
   , scope "c" ok ]
 
 suite2 :: Test ()
 suite2 = tests
   [ scope "pending.failure" (pending (expectEqual True False))
-  --, scope "pending.success" (pending ok) 
+  --, scope "pending.success" (pending ok)
   ]
 
 reverseTest :: Test ()


### PR DESCRIPTION
Fixes #1860 

I had to test this manually since there's not currently a combinator to check that a test fails with a particular scope. It would be pretty easy to add but I didn't have time now.