### PR TITLE
Fix to pretty-printing of 

### DIFF
--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -1299,9 +1299,10 @@ prettyDoc2 ppe ac tm = case tm of
           go (Left r, _anns) = "type " <> tyName r
           go (Right r, _anns) = tmName r
       (toDocSignatureInline ppe -> Just tm) ->
-        PP.group $ "@signature{" <> tmName tm <> "}"
+        PP.group $ "@inlineSignature{" <> tmName tm <> "}"
       (toDocSignature ppe -> Just tms) ->
-        PP.group $ "    @signatures{" <> intercalateMap ", " tmName tms <> "}"
+        let name = if length tms == 1 then "@signature" else "@signatures"
+        in PP.group $ "    " <> name <> "{" <> intercalateMap ", " tmName tms <> "}"
       (toDocCodeBlock ppe -> Just (typ, txt)) ->
         PP.group $
           PP.lines

--- a/unison-src/transcripts-using-base/doc.md.files/syntax.u
+++ b/unison-src/transcripts-using-base/doc.md.files/syntax.u
@@ -99,7 +99,11 @@ Some rendering targets also support folded source:
 You can also include just a signature, inline, with @inlineSignature{sqr},
 or you can include one or more signatures as a block:
 
-@signature{sqr, Nat.+}
+@signatures{sqr, Nat.+}
+
+Or alternately:
+
+@signature{List.map}
 
 ## Inline snippets
 

--- a/unison-src/transcripts-using-base/doc.output.md
+++ b/unison-src/transcripts-using-base/doc.output.md
@@ -305,10 +305,14 @@ and the rendered output using `display`:
           @foldedSource{type Optional, sqr}
       
       You can also include just a signature, inline, with
-      @signature{sqr}, or you can include one or more signatures
-      as a block:
+      @inlineSignature{sqr}, or you can include one or more
+      signatures as a block:
       
           @signatures{sqr, +}
+      
+      Or alternately:
+      
+          @signature{List.map}
       
       ## Inline snippets
       
@@ -352,6 +356,10 @@ and the rendered output using `display`:
         sqr : Nat -> Nat
     
         Nat.+ : Nat -> Nat -> Nat
+  
+    Or alternately:
+  
+        List.map : (a ->{e} b) -> [a] ->{e} [b]
   
     # Inline snippets
     
@@ -650,6 +658,10 @@ Lastly, it's common to build longer documents including subdocuments via `{{ sub
           sqr : Nat -> Nat
       
           Nat.+ : Nat -> Nat -> Nat
+    
+      Or alternately:
+    
+          List.map : (a ->{e} b) -> [a] ->{e} [b]
     
       # Inline snippets
       

--- a/unison-src/transcripts/bug-strange-closure.output.md
+++ b/unison-src/transcripts/bug-strange-closure.output.md
@@ -110,6 +110,10 @@ We can display the guide before and after adding it to the codebase:
       
           Nat.+ : Nat -> Nat -> Nat
     
+      Or alternately:
+    
+          List.map : (a ->{e} b) -> [a] ->{e} [b]
+    
       # Inline snippets
       
         You can include typechecked code snippets inline, for
@@ -306,6 +310,10 @@ We can display the guide before and after adding it to the codebase:
           sqr : Nat -> Nat
       
           Nat.+ : Nat -> Nat -> Nat
+    
+      Or alternately:
+    
+          List.map : (a ->{e} b) -> [a] ->{e} [b]
     
       # Inline snippets
       
@@ -510,6 +518,10 @@ rendered = Pretty.get (docFormatConsole doc.guide)
       
           Nat.+ : Nat -> Nat -> Nat
     
+      Or alternately:
+    
+          List.map : (a ->{e} b) -> [a] ->{e} [b]
+    
       # Inline snippets
       
         You can include typechecked code snippets inline, for
@@ -699,6 +711,10 @@ rendered = Pretty.get (docFormatConsole doc.guide)
           sqr : Nat -> Nat
       
           Nat.+ : Nat -> Nat -> Nat
+    
+      Or alternately:
+    
+          List.map : (a ->{e} b) -> [a] ->{e} [b]
     
       # Inline snippets
       
@@ -1963,6 +1979,29 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                                     [ Term.Term (Any (_ -> sqr)),
                                       Term.Term
                                       (Any (_ -> (Nat.+))) ]))))),
+                          !Lit (Right (Plain "\n")),
+                          !Lit (Right (Plain "\n")),
+                          !Indent
+                          (!Lit (Right (Plain "  ")))
+                          (!Lit (Right (Plain "  ")))
+                          (!Annotated.Group
+                            (!Wrap
+                              (!Annotated.Append
+                                [ !Lit (Right (Plain "Or")),
+                                  !Lit
+                                  (Right (Plain "alternately:")) ]))),
+                          !Lit (Right (Plain "\n")),
+                          !Lit (Right (Plain "\n")),
+                          !Indent
+                          (!Lit (Right (Plain "  ")))
+                          (!Lit (Right (Plain "  ")))
+                          (!Annotated.Group
+                            (!Wrap
+                              (!Lit
+                                (Left
+                                  (SpecialForm.Signature
+                                    [ Term.Term
+                                      (Any (_ -> List.map)) ]))))),
                           !Lit (Right (Plain "\n")),
                           !Lit (Right (Plain "\n")),
                           !Indent


### PR DESCRIPTION
Oversight from #2007 - the parser was updated but the pretty-printer wasn't updated to match!

We could use round trip tests for the doc syntax - that would have caught this bug. I've created https://github.com/unisonweb/unison/issues/2009 to track that.