### PR TITLE
tag release whenever we merge to trunk

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,6 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - ubuntu-18.04
-          # - ubuntu-16.04
           - macOS-11.0
           - macOS-10.15
     steps:

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -1,0 +1,68 @@
+name: "pre-release"
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    branches: [ trunk ]
+    types:
+      - completed
+jobs:
+  pre-release:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    strategy:
+      # Run each build to completion, regardless of if any have failed
+      fail-fast: false
+
+      matrix:
+        os:
+          - ubuntu-20.04
+          - macOS-10.15
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install stack (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.5.1/stack-2.5.1-linux-x86_64.tar.gz | tar -xz
+          echo "$HOME/stack-2.5.1-linux-x86_64/" >> $GITHUB_PATH
+      - name: install stack (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.5.1/stack-2.5.1-osx-x86_64.tar.gz | tar -xz
+          echo "$HOME/stack-2.5.1-osx-x86_64/" >> $GITHUB_PATH
+
+
+      # One of the transcripts fails if the user's git name hasn't been set.
+      - name: set git user info
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+
+      - name: remove ~/.stack/setup-exe-cache on macOS
+        if: runner.os == 'macOS'
+        run: rm -rf ~/.stack/setup-exe-cache
+
+      - name: build
+        run: stack --no-terminal build --ghc-options -O2
+
+
+      - name: fetch latest codebase-ui and package with ucm
+        run: |
+          mkdir -p /tmp/ucm/ui
+          UCM=$(stack path | awk '/local-install-root/{print $2}')/bin/unison
+          cp $UCM /tmp/ucm/ucm
+          wget -O/tmp/ucm.zip https://github.com/unisonweb/codebase-ui/releases/download/latest/ucm.zip
+          unzip -d /tmp/ucm/ui /tmp/ucm.zip
+          tar -c -z -f unison-${{runner.os}}.tar.gz -C /tmp/ucm .
+
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest-${{runner.os}}"
+          prerelease: true
+          title: "Development Build"
+          files: "unison-${{runner.os}}.tar.gz"


### PR DESCRIPTION


## Overview

Adds another GHA to upload and tag releases for macos and Linux

## Implementation notes

I am only building for macos-10, I was never able to get a working macos-11 build to work in my repo, no idea why.

## Interesting/controversial decisions

This maintains two different tagged releases: latest-Linux and latest-macOS
