### PR TITLE
Change `inputStringFromInput` to return correct string when remote is ahead of local

### DIFF
--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -1570,7 +1570,7 @@ inputStringFromInput = \case
   Input.PushRemoteBranchI rh p' _ ->
     (P.string . I.patternName $ pull)
       <> (" " <> maybe mempty (P.text . uncurry RemoteRepo.printHead) rh)
-      <> (if null $ show p' then "" else " " <> P.shown p')
+      <> (if Path.isCurrentPath p' then "" else " " <> P.shown p')
   i@(Input.PullRemoteBranchI ns p' _) ->
     (P.string . I.patternName $ patternFromInput i)
       <> (" " <> maybe mempty (P.text . uncurry3 RemoteRepo.printNamespace) ns)

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -1567,12 +1567,12 @@ patternFromInput = \case
 
 inputStringFromInput :: IsString s => Input -> P.Pretty s
 inputStringFromInput = \case
-  i@(Input.PushRemoteBranchI rh p' _) ->
-    (P.string . I.patternName $ patternFromInput i)
+  Input.PushRemoteBranchI rh p' _ ->
+    (P.string . I.patternName $ pull)
       <> (" " <> maybe mempty (P.text . uncurry RemoteRepo.printHead) rh)
-      <> " " <> P.shown p'
+      <> (if null $ show p' then "" else " " <> P.shown p')
   i@(Input.PullRemoteBranchI ns p' _) ->
     (P.string . I.patternName $ patternFromInput i)
       <> (" " <> maybe mempty (P.text . uncurry3 RemoteRepo.printNamespace) ns)
-      <> " " <> P.shown p'
+      <> (if null $ show p' then "" else " " <> P.shown p')
   _ -> error "todo: finish this function"


### PR DESCRIPTION
This change makes it so that `inputStringFromInput` uses "pull"
in the return string instead of "push" when it recieves the
value `PushRemoteBranchI repoHead path mode :: Input`.

## Overview

What does this change accomplish and why? i.e. How does it change the user experience?

Feel free to include "before and after" examples if appropriate. (You can copy/paste screenshots directly into this editor.)

If relevant, which Github issues does it close? (See [closing-issues-using-keywords](https://help.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords).)

## Implementation notes

How does it accomplish it, in broad strokes? i.e. How does it change the Haskell codebase?

## Interesting/controversial decisions

Include anything that you thought twice about, debated, chose arbitrarily, etc. 
What could have been done differently, but wasn't? And why?

## Test coverage

Have you included tests (which could be a transcript) for this change, or is it somehow covered by existing tests? 

Would you recommend improving the test coverage (either as part of this PR or as a separate issue) or do you think it’s adequate?

## Loose ends

Link to related issues that address things you didn't get to. Stuff you encountered on the way and decided not to include in this PR.
