### PR TITLE
Regression test for new LCA calculation

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -583,7 +583,22 @@ namespaceHashIdByBase32Prefix prefix = queryAtoms sql (Only $ prefix <> "%") whe
 
 before :: DB m => CausalHashId -> CausalHashId -> m Bool
 before chId1 chId2 = fmap fromOnly . queryOne $ queryMaybe sql (chId2, chId1)
-  where sql = fromString $ "SELECT EXISTS (" ++ ancestorSql ++ " WHERE ancestor.id = ?)"
+  where sql = [here|
+    SELECT EXISTS (
+      WITH RECURSIVE
+        ancestor(id) AS (
+          SELECT self_hash_id
+            FROM causal
+            WHERE self_hash_id = ?
+          UNION ALL
+          SELECT parent_id
+            FROM causal_parent
+            JOIN ancestor ON ancestor.id = causal_id
+        )
+      SELECT * FROM ancestor
+      WHERE ancestor.id = ?
+    )
+  |]
 
 -- the `Connection` arguments come second to fit the shape of Exception.bracket + uncurry curry
 lca :: CausalHashId -> CausalHashId -> Connection -> Connection -> IO (Maybe CausalHashId)
@@ -613,22 +628,23 @@ lca x y cx cy = Exception.bracket open close \(sx, sy) -> do
     open = (,) <$>
       SQLite.openStatement cx sql <*> SQLite.openStatement cy sql
     close (cx, cy) = SQLite.closeStatement cx *> SQLite.closeStatement cy
-    sql = fromString ancestorSql
-
-ancestorSql :: String
-ancestorSql = [here|
-    WITH RECURSIVE
-      ancestor(id) AS (
-        SELECT self_hash_id
-          FROM causal
-          WHERE self_hash_id = ?
-        UNION ALL
-        SELECT parent_id
-          FROM causal_parent
-          JOIN ancestor ON ancestor.id = causal_id
-      )
-    SELECT * FROM ancestor
-  |]
+    sql = [here|
+      WITH RECURSIVE
+        non_one_ancestor(id) AS (
+          SELECT self_hash_id
+            FROM causal
+            WHERE self_hash_id = ?
+          UNION ALL
+          SELECT near.parent_id
+            FROM causal_parent near
+            JOIN non_one_ancestor ON non_one_ancestor.id = near.causal_id
+            WHERE EXISTS (
+              SELECT * FROM causal_parent
+              WHERE causal_parent.causal_id = near.parent_id
+            )
+        )
+      SELECT * FROM non_one_ancestor
+    |]
 
 -- * helper functions
 

--- a/unison-src/transcripts/fix2004.md
+++ b/unison-src/transcripts/fix2004.md
@@ -61,6 +61,8 @@ Meanwhile, `a2` adds some other unrelated terms, some via merging in namespaces 
 .> squash a2 asquash
 ```
 
+At this point, all the things that `a` has deleted (`delete1`, `delete2`, etc) should be deleted in both the merged and squashed results. Let's verify this:
+
 ```ucm
 .a> find
 .asquash> find

--- a/unison-src/transcripts/fix2004.md
+++ b/unison-src/transcripts/fix2004.md
@@ -1,0 +1,58 @@
+
+```ucm:hide
+.> builtins.merge
+```
+
+First, we create some common history before a fork:
+
+```ucm
+.a> alias.term .builtin.Nat.+ Nat.add
+.a> alias.term .builtin.Nat.* Nat.times
+.a> alias.term .builtin.Nat.drop Nat.subtract
+.a> alias.type .builtin.Nat Nonneg
+```
+
+Now we fork `a2` off of `a`. `a` continues on, deleting the terms it added previously and then adding one unrelated term via a merge with little history.
+
+```ucm
+.> fork a a2
+.a> delete.term Nat.add
+.a> delete.term Nat.times
+.a> delete.term Nat.subtract
+.a> delete.type Nonneg
+.newbranchA> alias.term .builtin.Float.+ addSomeFloats
+.> merge newbranchA a
+.a> find
+```
+
+Meanwhile, `a2` adds some other unrelated terms, some via merging in namespaces with little history. When merging `a2` back into `a`, the deletes from their common history should be respected.
+
+```ucm
+.a2> alias.term .builtin.Text.drop drop1
+.a2> alias.term .builtin.Text.drop drop2
+.a2> alias.term .builtin.Text.drop drop3
+.a2> alias.term .builtin.Text.drop drop4
+.a2> alias.term .builtin.Text.drop drop5
+.newbranchA2> alias.term .builtin.Text.drop drop6
+.> merge newbranchA2 a2
+.a2> find
+```
+
+```ucm
+.> fork a asquash
+.> merge a2 a
+.> squash a2 asquash
+```
+
+```ucm
+.a> find
+.asquash> find
+```
+
+```ucm:error
+.> view a.Nonneg
+```
+
+```ucm:error
+.> view asquash.Nat.add
+```

--- a/unison-src/transcripts/fix2004.md
+++ b/unison-src/transcripts/fix2004.md
@@ -3,24 +3,41 @@
 .> builtins.merge
 ```
 
+Here's the scenario that can produce bad empty namespace LCAs:
+
+```
+                              deletes of v4
+j1: ... - v1 - v2 - v3 - v4 - v4a - v5 - v6 - v7
+                                              /
+                                  <empty> - v5a
+
+                               adds of unrelated
+j2: ... - v1 - v2 - v3 - v4 - x0 - x1 - x2 - x3
+                                            /
+                                <empty> - z1
+
+```
+
+So `j1` and `j2` have common history up through `v4`, then `j1` deletes some definitions while `j2` adds some definitions via shallow merges. These shallow merges then result in the LCA being the empty namespace rather than `v4`.
+
 First, we create some common history before a fork:
 
 ```ucm
-.a> alias.term .builtin.Nat.+ Nat.add
-.a> alias.term .builtin.Nat.* Nat.times
-.a> alias.term .builtin.Nat.drop Nat.subtract
-.a> alias.type .builtin.Nat Nonneg
+.a> alias.term .builtin.Nat.+ delete1
+.a> alias.term .builtin.Nat.* delete2
+.a> alias.term .builtin.Nat.drop delete3
+.a> alias.type .builtin.Nat Delete4
 ```
 
-Now we fork `a2` off of `a`. `a` continues on, deleting the terms it added previously and then adding one unrelated term via a merge with little history.
+Now we fork `a2` off of `a`. `a` continues on, deleting the terms it added previously and then adding one unrelated term via a merge with little history. It's this short history merge which will become a bad LCA of the empty namespace.
 
 ```ucm
 .> fork a a2
-.a> delete.term Nat.add
-.a> delete.term Nat.times
-.a> delete.term Nat.subtract
-.a> delete.type Nonneg
-.newbranchA> alias.term .builtin.Float.+ addSomeFloats
+.a> delete.term delete1
+.a> delete.term delete2
+.a> delete.term delete3
+.a> delete.type Delete4
+.newbranchA> alias.term .builtin.Float.+ dontDelete
 .> merge newbranchA a
 .a> find
 ```
@@ -28,12 +45,12 @@ Now we fork `a2` off of `a`. `a` continues on, deleting the terms it added previ
 Meanwhile, `a2` adds some other unrelated terms, some via merging in namespaces with little history. When merging `a2` back into `a`, the deletes from their common history should be respected.
 
 ```ucm
-.a2> alias.term .builtin.Text.drop drop1
-.a2> alias.term .builtin.Text.drop drop2
-.a2> alias.term .builtin.Text.drop drop3
-.a2> alias.term .builtin.Text.drop drop4
-.a2> alias.term .builtin.Text.drop drop5
-.newbranchA2> alias.term .builtin.Text.drop drop6
+.a2> alias.term .builtin.Text.take keep1
+.a2> alias.term .builtin.Text.take keep2
+.a2> alias.term .builtin.Text.take keep3
+.a2> alias.term .builtin.Text.take keep4
+.a2> alias.term .builtin.Text.take keep5
+.newbranchA2> alias.term .builtin.Text.take keep6
 .> merge newbranchA2 a2
 .a2> find
 ```
@@ -49,10 +66,15 @@ Meanwhile, `a2` adds some other unrelated terms, some via merging in namespaces 
 .asquash> find
 ```
 
-```ucm:error
-.> view a.Nonneg
+```ucm:hide
+.> view a.keep1 a.keep2 a.keep3
+.> view asquash.keep1 asquash.keep2 asquash.keep3
 ```
 
 ```ucm:error
-.> view asquash.Nat.add
+.> view a.Delete4
+```
+
+```ucm:error
+.> view asquash.delete1
 ```

--- a/unison-src/transcripts/fix2004.output.md
+++ b/unison-src/transcripts/fix2004.output.md
@@ -1,0 +1,265 @@
+
+Here's the scenario that can produce bad empty namespace LCAs:
+
+```deletes
+of v4
+j1: ... - v1 - v2 - v3 - v4 - v4a - v5 - v6 - v7
+                                              /
+                                  <empty> - v5a
+
+                               adds of unrelated
+j2: ... - v1 - v2 - v3 - v4 - x0 - x1 - x2 - x3
+                                            /
+                                <empty> - z1
+
+
+```
+
+So `j1` and `j2` have common history up through `v4`, then `j1` deletes some definitions while `j2` adds some definitions via shallow merges. These shallow merges then result in the LCA being the empty namespace rather than `v4`.
+
+First, we create some common history before a fork:
+
+```ucm
+  ☝️  The namespace .a is empty.
+
+.a> alias.term .builtin.Nat.+ delete1
+
+  Done.
+
+.a> alias.term .builtin.Nat.* delete2
+
+  Done.
+
+.a> alias.term .builtin.Nat.drop delete3
+
+  Done.
+
+.a> alias.type .builtin.Nat Delete4
+
+  Done.
+
+```
+Now we fork `a2` off of `a`. `a` continues on, deleting the terms it added previously and then adding one unrelated term via a merge with little history. It's this short history merge which will become a bad LCA of the empty namespace.
+
+```ucm
+.> fork a a2
+
+  Done.
+
+.a> delete.term delete1
+
+  Name changes:
+  
+    Original            Changes
+    1. a.delete1     ┐  2. a.delete1 (removed)
+    3. a2.delete1    │  
+    4. builtin.Nat.+ ┘  
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
+
+.a> delete.term delete2
+
+  Name changes:
+  
+    Original            Changes
+    1. a.delete2     ┐  2. a.delete2 (removed)
+    3. a2.delete2    │  
+    4. builtin.Nat.* ┘  
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
+
+.a> delete.term delete3
+
+  Name changes:
+  
+    Original               Changes
+    1. a.delete3        ┐  2. a.delete3 (removed)
+    3. a2.delete3       │  
+    4. builtin.Nat.drop ┘  
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
+
+.a> delete.type Delete4
+
+  Name changes:
+  
+    Original          Changes
+    1. a.Delete4   ┐  2. a.Delete4 (removed)
+    3. a2.Delete4  │  
+    4. builtin.Nat ┘  
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
+
+  ☝️  The namespace .newbranchA is empty.
+
+.newbranchA> alias.term .builtin.Float.+ dontDelete
+
+  Done.
+
+.> merge newbranchA a
+
+  Here's what's changed in a after the merge:
+  
+  Added definitions:
+  
+    1. dontDelete : Float -> Float -> Float
+  
+  Tip: You can use `todo` to see if this generated any work to
+       do in this namespace and `test` to run the tests. Or you
+       can use `undo` or `reflog` to undo the results of this
+       merge.
+
+.a> find
+
+  1. dontDelete : Float -> Float -> Float
+  
+
+```
+Meanwhile, `a2` adds some other unrelated terms, some via merging in namespaces with little history. When merging `a2` back into `a`, the deletes from their common history should be respected.
+
+```ucm
+.a2> alias.term .builtin.Text.take keep1
+
+  Done.
+
+.a2> alias.term .builtin.Text.take keep2
+
+  Done.
+
+.a2> alias.term .builtin.Text.take keep3
+
+  Done.
+
+.a2> alias.term .builtin.Text.take keep4
+
+  Done.
+
+.a2> alias.term .builtin.Text.take keep5
+
+  Done.
+
+  ☝️  The namespace .newbranchA2 is empty.
+
+.newbranchA2> alias.term .builtin.Text.take keep6
+
+  Done.
+
+.> merge newbranchA2 a2
+
+  Here's what's changed in a2 after the merge:
+  
+  Name changes:
+  
+    Original    Changes
+    1. keep1 ┐  2. keep6 (added)
+    3. keep2 │  
+    4. keep3 │  
+    5. keep4 │  
+    6. keep5 ┘  
+  
+  Tip: You can use `todo` to see if this generated any work to
+       do in this namespace and `test` to run the tests. Or you
+       can use `undo` or `reflog` to undo the results of this
+       merge.
+
+.a2> find
+
+  1.  builtin type Delete4
+  2.  delete1 : Delete4 -> Delete4 -> Delete4
+  3.  delete2 : Delete4 -> Delete4 -> Delete4
+  4.  delete3 : Delete4 -> Delete4 -> Delete4
+  5.  keep1 : Delete4 -> Text -> Text
+  6.  keep2 : Delete4 -> Text -> Text
+  7.  keep3 : Delete4 -> Text -> Text
+  8.  keep4 : Delete4 -> Text -> Text
+  9.  keep5 : Delete4 -> Text -> Text
+  10. keep6 : Delete4 -> Text -> Text
+  
+
+```
+```ucm
+.> fork a asquash
+
+  Done.
+
+.> merge a2 a
+
+  Here's what's changed in a after the merge:
+  
+  Added definitions:
+  
+    1. ┌ keep1 : Delete4 -> Text -> Text
+    2. │ keep2 : Delete4 -> Text -> Text
+    3. │ keep3 : Delete4 -> Text -> Text
+    4. │ keep4 : Delete4 -> Text -> Text
+    5. │ keep5 : Delete4 -> Text -> Text
+    6. └ keep6 : Delete4 -> Text -> Text
+  
+  Tip: You can use `todo` to see if this generated any work to
+       do in this namespace and `test` to run the tests. Or you
+       can use `undo` or `reflog` to undo the results of this
+       merge.
+
+.> squash a2 asquash
+
+  Here's what's changed in asquash after the merge:
+  
+  Added definitions:
+  
+    1. ┌ keep1 : Delete4 -> Text -> Text
+    2. │ keep2 : Delete4 -> Text -> Text
+    3. │ keep3 : Delete4 -> Text -> Text
+    4. │ keep4 : Delete4 -> Text -> Text
+    5. │ keep5 : Delete4 -> Text -> Text
+    6. └ keep6 : Delete4 -> Text -> Text
+  
+  Tip: You can use `todo` to see if this generated any work to
+       do in this namespace and `test` to run the tests. Or you
+       can use `undo` or `reflog` to undo the results of this
+       merge.
+
+```
+At this point, all the things that `a` has deleted (`delete1`, `delete2`, etc) should be deleted in both the merged and squashed results. Let's verify this:
+
+```ucm
+.a> find
+
+  1. dontDelete : Float -> Float -> Float
+  2. keep1 : Delete4 -> Text -> Text
+  3. keep2 : Delete4 -> Text -> Text
+  4. keep3 : Delete4 -> Text -> Text
+  5. keep4 : Delete4 -> Text -> Text
+  6. keep5 : Delete4 -> Text -> Text
+  7. keep6 : Delete4 -> Text -> Text
+  
+
+.asquash> find
+
+  1. dontDelete : Float -> Float -> Float
+  2. keep1 : Delete4 -> Text -> Text
+  3. keep2 : Delete4 -> Text -> Text
+  4. keep3 : Delete4 -> Text -> Text
+  5. keep4 : Delete4 -> Text -> Text
+  6. keep5 : Delete4 -> Text -> Text
+  7. keep6 : Delete4 -> Text -> Text
+  
+
+```
+```ucm
+.> view a.Delete4
+
+  ⚠️
+  
+  The following names were not found in the codebase. Check your spelling.
+    a.Delete4
+
+```
+```ucm
+.> view asquash.delete1
+
+  ⚠️
+  
+  The following names were not found in the codebase. Check your spelling.
+    asquash.delete1
+
+```

--- a/unison-src/transcripts/squash.output.md
+++ b/unison-src/transcripts/squash.output.md
@@ -71,21 +71,16 @@ If we merge that back into `builtin`, we get that same chain of history:
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #lirpkqt68j
   
-    > Moves:
-    
-      Original name  New name
-      Nat.frobnicate Nat.+
   
-  ⊙ #p2m2k852al
+  This segment of history starts with a merge. Use
+  `history #som3n4m3space` to view history starting from a given
+  namespace hash.
   
-    > Moves:
-    
-      Original name New name
-      Nat.+         Nat.frobnicate
-  
-  □ #6hs3tdioa1 (start of history)
+  ⊙ #ogo0j1ucnr
+  ⑃
+  #6hs3tdioa1
+  #lirpkqt68j
 
 ```
 Let's try again, but using a `merge.squash` (or just `squash`) instead. The history will be unchanged:
@@ -527,7 +522,7 @@ This checks to see that squashing correctly preserves deletions:
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #sasilta77k
+  ⊙ #8jcsn0thlb
   
     - Deletes:
     


### PR DESCRIPTION
This adds [a failing transcript that exercises the new LCA calculation](https://github.com/unisonweb/unison/blob/9277cfc399340026121060a43e2dee49bcc07b3f/unison-src/transcripts/fix2004.md). It should be fixed by #2004. I'm opening this against trunk just so we can verify it's failing against trunk (although I also did this test locally), but it should be merged into whatever branch @aryairani you are doing your work on.

Also, just to verify that the in-memory LCA calculation works correctly, I temporarily commented out the codebase LCA and that causes this transcript to succeed (by adding an `&& False` in `Codebase.lca`). I didn't check that change in, but that just gives us confidence that the codebase LCA is the only thing needing updating to fix this case.