### PR TITLE
Minor nit: don't show the API url unless launching UCM in headless mode

### DIFF
--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -201,8 +201,9 @@ main = do
       Server.start theCodebase $ \token port -> do
         let url =
              "http://127.0.0.1:" <> show port <> "/" <> URI.encode (unpack token)
-        PT.putPrettyLn $ P.lines
-          ["I've started the codebase API server at" , P.string $ url <> "/api"]
+        when headless $
+          PT.putPrettyLn $ P.lines
+            ["I've started the codebase API server at" , P.string $ url <> "/api"]
         PT.putPrettyLn $ P.lines
           ["The Unison Codebase UI is running at", P.string $ url <> "/ui"]
         if headless then do


### PR DESCRIPTION
Suggested by @aryairani 

The thinking here is that people launching UCM don't need to see the api url as that's just an implementation detail of the codebase ui which can be got by visiting the /ui url.

When launching ucm in headless mode, it shows both urls, since this is the mode that will be used when doing front end development most likely.

Also you can still obtain the api url from UCM non-headless just by replacing `/ui` with `/api`.

```
~/unison [feature/only-ui-url●] » stack exec unison -- headless

  I've started the codebase API server at
  http://127.0.0.1:49717/k4BNW3s6XZRShW2yOXGV6hQ1lxeWAten/api


  The Unison Codebase UI is running at
  http://127.0.0.1:49717/k4BNW3s6XZRShW2yOXGV6hQ1lxeWAten/ui


  Running the codebase manager in headless mode.
```

```
~/unison [feature/only-ui-url●] » stack exec unison

  The Unison Codebase UI is running at
  http://127.0.0.1:49709/FUDGVCXj4aY7DWN3auMXCiZW3q%2FI67tk/ui


  Now starting the Unison Codebase Manager...
```

## Loose ends

I often have some random scratch files laying around, which by default get typechecked on startup, but then I miss the codebase UI url unless I scroll back.

I don't think I like the feature of typechecking the scratch files you have sitting around on startup. While it does make it easier sometimes to pick right back up where you were, it only works if you have literally one such scratch file. If you've got more than one, it runs them in a random order (or maybe it's alphabetical, but in any case, not necessarily the order you want) and becomes useless and spammy.