### PR TITLE
Fix wrapper code for putBytes

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -1410,7 +1410,7 @@ declareForeigns = do
 
   declareForeign "IO.getBytes.impl.v3" boxNatToEFBox .  mkForeignIOF $ \(h,n) -> Bytes.fromArray <$> hGet h n
 
-  declareForeign "IO.putBytes.impl.v3" boxBoxToEFBox .  mkForeignIOF $ \(h,bs) -> hPut h (Bytes.toArray bs)
+  declareForeign "IO.putBytes.impl.v3" boxBoxToEF0 .  mkForeignIOF $ \(h,bs) -> hPut h (Bytes.toArray bs)
   declareForeign "IO.systemTime.impl.v3" unitToEFNat
     $ mkForeignIOF $ \() -> getPOSIXTime
 

--- a/parser-typechecker/src/Unison/Runtime/Decompile.hs
+++ b/parser-typechecker/src/Unison/Runtime/Decompile.hs
@@ -110,7 +110,7 @@ decompileForeign topTerms f
   = Right $ typeLink () l
   | Just s <- unwrapSeq f
   = list' () <$> traverse (decompile topTerms) s
-decompileForeign _ _ = err "cannot decompile Foreign"
+decompileForeign _ f = err $ "cannot decompile Foreign: " ++ show f
 
 decompileBytes :: Var v => By.Bytes -> Term v ()
 decompileBytes

--- a/unison-src/transcripts/fix2026.md
+++ b/unison-src/transcripts/fix2026.md
@@ -1,0 +1,44 @@
+```ucm:hide
+.> builtins.mergeio
+```
+
+```unison
+ability Exception where raise : Failure -> x
+
+ex = unsafeRun! '(printLine "hello world")
+
+printLine : Text ->{IO, Exception} ()
+printLine t =
+    putText stdOut t
+    putText stdOut "\n"
+
+stdOut : Handle
+stdOut = stdHandle StdOut
+
+compose2 : (c ->{𝕖} d) -> (a ->{𝕖} b ->{𝕖} c) -> a -> b ->{𝕖} d
+compose2 f g x y = f (g x y)
+
+putBytes : Handle -> Bytes ->{IO, Exception} ()
+putBytes = compose2 toException putBytes.impl
+
+toException : Either Failure a ->{Exception} a
+toException = cases
+  Left e -> raise e
+  Right a -> a
+
+putText : Handle -> Text ->{IO, Exception} ()
+putText h t = putBytes h (toUtf8 t)
+
+Exception.unsafeRun! : '{Exception, g} a -> '{g} a
+Exception.unsafeRun! e _ = 
+    h : Request {Exception} a -> a 
+    h = cases 
+        {Exception.raise fail -> _ } -> 
+            bug fail 
+        {a} -> a 
+    handle !e with h 
+```
+
+```ucm 
+.> run ex 
+```

--- a/unison-src/transcripts/fix2026.output.md
+++ b/unison-src/transcripts/fix2026.output.md
@@ -1,0 +1,66 @@
+```unison
+ability Exception where raise : Failure -> x
+
+ex = unsafeRun! '(printLine "hello world")
+
+printLine : Text ->{IO, Exception} ()
+printLine t =
+    putText stdOut t
+    putText stdOut "\n"
+
+stdOut : Handle
+stdOut = stdHandle StdOut
+
+compose2 : (c ->{𝕖} d) -> (a ->{𝕖} b ->{𝕖} c) -> a -> b ->{𝕖} d
+compose2 f g x y = f (g x y)
+
+putBytes : Handle -> Bytes ->{IO, Exception} ()
+putBytes = compose2 toException putBytes.impl
+
+toException : Either Failure a ->{Exception} a
+toException = cases
+  Left e -> raise e
+  Right a -> a
+
+putText : Handle -> Text ->{IO, Exception} ()
+putText h t = putBytes h (toUtf8 t)
+
+Exception.unsafeRun! : '{Exception, g} a -> '{g} a
+Exception.unsafeRun! e _ = 
+    h : Request {Exception} a -> a 
+    h = cases 
+        {Exception.raise fail -> _ } -> 
+            bug fail 
+        {a} -> a 
+    handle !e with h 
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      ability Exception
+      Exception.unsafeRun! : '{g, Exception} a -> '{g} a
+      compose2             : (c ->{𝕖} d)
+                             -> (a ->{𝕖} b ->{𝕖} c)
+                             -> a
+                             -> b
+                             ->{𝕖} d
+      ex                   : '{IO} ()
+      printLine            : Text ->{IO, Exception} ()
+      putBytes             : Handle
+                             -> Bytes
+                             ->{IO, Exception} ()
+      putText              : Handle -> Text ->{IO, Exception} ()
+      stdOut               : Handle
+      toException          : Either Failure a ->{Exception} a
+
+```
+```ucm
+.> run ex 
+
+```


### PR DESCRIPTION
The wrapper code used for `putBytes` was causing it to return the handle in successful cases instead of a unit value.

Should fix #2026. I wasn't able to pull base to check for certain, but I think I replicated the relevant definitions locally.