### PR TITLE
Fix bad failure references in builtins

### DIFF
--- a/parser-typechecker/src/Unison/Builtin/Decls.hs
+++ b/parser-typechecker/src/Unison/Builtin/Decls.hs
@@ -41,8 +41,11 @@ pairRef = lookupDeclRef "Tuple"
 optionalRef = lookupDeclRef "Optional"
 eitherRef = lookupDeclRef "Either"
 
-testResultRef, linkRef, docRef, ioErrorRef, stdHandleRef, failureRef, tlsSignedCertRef, tlsPrivateKeyRef :: Reference
+testResultRef, linkRef, docRef, ioErrorRef, stdHandleRef :: Reference
+failureRef, ioFailureRef, tlsFailureRef :: Reference
+tlsSignedCertRef, tlsPrivateKeyRef :: Reference
 isPropagatedRef, isTestRef :: Reference
+
 isPropagatedRef = lookupDeclRef "IsPropagated"
 isTestRef = lookupDeclRef "IsTest"
 testResultRef = lookupDeclRef "Test.Result"
@@ -51,6 +54,8 @@ docRef = lookupDeclRef "Doc"
 ioErrorRef = lookupDeclRef "io2.IOError"
 stdHandleRef = lookupDeclRef "io2.StdHandle"
 failureRef = lookupDeclRef "io2.Failure"
+ioFailureRef = lookupDeclRef "io2.IOFailure"
+tlsFailureRef = lookupDeclRef "io2.TlsFailure"
 tlsSignedCertRef = lookupDeclRef "io2.Tls.SignedCert"
 tlsPrivateKeyRef = lookupDeclRef "io2.Tls.PrivateKey"
 

--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -32,7 +32,7 @@ import Unison.Runtime.Foreign
     ( Foreign(Wrap), HashAlgorithm(..), pattern Failure)
 import qualified Unison.Runtime.Foreign as F
 import Unison.Runtime.Foreign.Function
-import Unison.Runtime.IOSource (ioFailureReference, tlsFailureReference, eitherReference, failureReference)
+import Unison.Runtime.IOSource (eitherReference)
 
 import qualified Unison.Type as Ty
 import qualified Unison.Builtin as Ty (builtinTypes)
@@ -904,7 +904,7 @@ outIoFail stack1 stack2 fail result =
   TMatch result . MatchSum $ mapFromList
   [ (0, ([BX, BX],)
         . TAbss [stack1, stack2]
-        . TLetD fail BX (TCon failureReference 0 [stack1, stack2])
+        . TLetD fail BX (TCon Ty.failureRef 0 [stack1, stack2])
         $ TCon eitherReference 0 [fail])
   , (1, ([BX], TAbs stack1 $ TCon eitherReference 1 [stack1]))
   ]
@@ -914,7 +914,7 @@ outIoFailNat stack1 stack2 stack3 fail nat result =
   TMatch result . MatchSum $ mapFromList
   [ (0, ([BX, BX],)
         . TAbss [stack1, stack2]
-        . TLetD fail BX (TCon failureReference 0 [stack1, stack2])
+        . TLetD fail BX (TCon Ty.failureRef 0 [stack1, stack2])
         $ TCon eitherReference 0 [fail])
   , (1, ([UN],)
         . TAbs stack3
@@ -927,7 +927,7 @@ outIoFailBox stack1 stack2 fail result =
   TMatch result . MatchSum  $ mapFromList
   [ (0, ([BX, BX],)
         . TAbss [stack1, stack2]
-        . TLetD fail BX (TCon failureReference 0 [stack1, stack2])
+        . TLetD fail BX (TCon Ty.failureRef 0 [stack1, stack2])
         $ TCon eitherReference 0 [fail])
   , (1, ([BX],)
         . TAbs stack1
@@ -940,7 +940,7 @@ outIoFailUnit stack1 stack2 stack3 unit fail result =
   $ mapFromList
   [ (0, ([BX, BX],)
         . TAbss [stack1, stack2]
-        . TLetD fail BX (TCon failureReference 0 [stack1, stack2])
+        . TLetD fail BX (TCon Ty.failureRef 0 [stack1, stack2])
         $ TCon eitherReference 0 [fail])
   , (1, ([BX],)
         . TAbss [stack3]
@@ -954,7 +954,7 @@ outIoFailBool stack1 stack2 stack3 bool fail result =
   $ mapFromList
   [ (0, ([BX, BX],)
         . TAbss [stack1, stack2]
-        . TLetD fail BX (TCon failureReference 0 [stack1, stack2])
+        . TLetD fail BX (TCon Ty.failureRef 0 [stack1, stack2])
         $ TCon eitherReference 0 [fail])
   , (1, ([UN],)
         . TAbs stack3
@@ -1358,7 +1358,7 @@ mkForeignIOF f = mkForeign $ \a -> tryIOE (f a)
   tryIOE :: IO a -> IO (Either Failure a)
   tryIOE = fmap handleIOE . try
   handleIOE :: Either IOException a -> Either Failure a
-  handleIOE (Left e) = Left $ Failure ioFailureReference (pack (show e)) unitValue
+  handleIOE (Left e) = Left $ Failure Ty.ioFailureRef (pack (show e)) unitValue
   handleIOE (Right a) = Right a
 
 unitValue :: Closure
@@ -1374,8 +1374,8 @@ mkForeignTls f = mkForeign $ \a -> fmap flatten (tryIO2 (tryIO1 (f a)))
   tryIO2 :: IO (Either TLS.TLSException r) -> IO (Either IOException (Either TLS.TLSException r))
   tryIO2 = try
   flatten :: Either IOException (Either TLS.TLSException r) -> Either (Failure ) r
-  flatten (Left e) = Left (Failure ioFailureReference (pack (show e)) unitValue)
-  flatten (Right (Left e)) = Left (Failure tlsFailureReference (pack (show e)) (unitValue))
+  flatten (Left e) = Left (Failure Ty.ioFailureRef (pack (show e)) unitValue)
+  flatten (Right (Left e)) = Left (Failure Ty.tlsFailureRef (pack (show e)) (unitValue))
   flatten (Right (Right a)) = Right a
 
 declareForeigns :: Var v => FDecl v ()
@@ -1536,7 +1536,7 @@ declareForeigns = do
     $ pure . Bytes.fromArray . encodeUtf8
 
   declareForeign "Text.fromUtf8.impl.v3" boxToEFBox . mkForeign
-    $ pure . mapLeft (\t -> Failure ioFailureReference (pack ( show t)) unitValue) . decodeUtf8' . Bytes.toArray
+    $ pure . mapLeft (\t -> Failure Ty.ioFailureRef (pack ( show t)) unitValue) . decodeUtf8' . Bytes.toArray
 
   declareForeign "Tls.ClientConfig.default" boxBoxDirect .  mkForeign
     $ \(hostName::Text, serverId:: Bytes.Bytes) ->
@@ -1615,7 +1615,7 @@ declareForeigns = do
     \(tls :: TLS.Context,
       bytes :: Bytes.Bytes) -> TLS.sendData tls (Bytes.toLazyByteString bytes)
 
-  let wrapFailure t = Failure tlsFailureReference (pack t) unitValue
+  let wrapFailure t = Failure Ty.tlsFailureRef (pack t) unitValue
       decoded :: Bytes.Bytes -> Either String PEM
       decoded bytes = fmap head $ pemParseLBS  $ Bytes.toLazyByteString bytes
       asCert :: PEM -> Either String X.SignedCertificate

--- a/parser-typechecker/src/Unison/Runtime/IOSource.hs
+++ b/parser-typechecker/src/Unison/Runtime/IOSource.hs
@@ -72,16 +72,12 @@ abilityNamedId s =
     Nothing -> error $ "No builtin ability called: " <> s
     Just (r, _) -> r
 
-eitherReference, optionReference, isTestReference, isPropagatedReference, failureReference, tlsFailureReference, ioFailureReference
+eitherReference, optionReference, isTestReference, isPropagatedReference
   :: R.Reference
 eitherReference = typeNamed "Either"
 optionReference = typeNamed "Optional"
 isTestReference = typeNamed "IsTest"
 isPropagatedReference = typeNamed "IsPropagated"
-
-failureReference = typeNamed "io2.Failure"
-tlsFailureReference = typeNamed "io2.TlsFailure"
-ioFailureReference = typeNamed "io2.IOFailure"
 
 isTest :: (R.Reference, R.Reference)
 isTest = (isTestReference, termNamed "metadata.isTest")

--- a/unison-src/transcripts-using-base/fix2027.md
+++ b/unison-src/transcripts-using-base/fix2027.md
@@ -1,0 +1,40 @@
+
+
+```ucm:hide
+.> builtins.mergeio
+.> pull https://github.com/unisonweb/base_v2:.trunk .base
+```
+
+```unison
+
+toException : Either Failure a ->{Exception} a
+toException = cases
+  Left e -> raise e
+  Right a -> a
+
+putText : Handle -> Text ->{IO, Exception} ()
+putText h t = putBytes h (toUtf8 t)
+
+Exception.unsafeRun! : '{Exception, g} a -> '{g} a
+Exception.unsafeRun! e _ = 
+    h : Request {Exception} a -> a 
+    h = cases 
+        {Exception.raise fail -> _ } -> 
+            bug fail 
+        {a} -> a 
+    handle !e with h 
+
+hello : Text -> Text -> {IO, Exception} ()
+hello host port = 
+    socket = serverSocket (Some host) port
+    msg = toUtf8 "Hello there" 
+    socketSend socket msg
+    closeSocket socket 
+
+myServer = unsafeRun! '(hello "127.0.0.1" "0")
+
+```
+
+```ucm:error
+.> run myServer 
+```

--- a/unison-src/transcripts-using-base/fix2027.md
+++ b/unison-src/transcripts-using-base/fix2027.md
@@ -15,12 +15,15 @@ toException = cases
 putText : Handle -> Text ->{IO, Exception} ()
 putText h t = putBytes h (toUtf8 t)
 
+bugFail = cases
+  Failure typ _ _ -> bug (Failure typ "problem" (Any ()))
+
 Exception.unsafeRun! : '{Exception, g} a -> '{g} a
 Exception.unsafeRun! e _ = 
     h : Request {Exception} a -> a 
     h = cases 
         {Exception.raise fail -> _ } -> 
-            bug fail 
+            bugFail fail
         {a} -> a 
     handle !e with h 
 

--- a/unison-src/transcripts-using-base/fix2027.output.md
+++ b/unison-src/transcripts-using-base/fix2027.output.md
@@ -1,0 +1,65 @@
+
+
+```unison
+toException : Either Failure a ->{Exception} a
+toException = cases
+  Left e -> raise e
+  Right a -> a
+
+putText : Handle -> Text ->{IO, Exception} ()
+putText h t = putBytes h (toUtf8 t)
+
+Exception.unsafeRun! : '{Exception, g} a -> '{g} a
+Exception.unsafeRun! e _ = 
+    h : Request {Exception} a -> a 
+    h = cases 
+        {Exception.raise fail -> _ } -> 
+            bug fail 
+        {a} -> a 
+    handle !e with h 
+
+hello : Text -> Text -> {IO, Exception} ()
+hello host port = 
+    socket = serverSocket (Some host) port
+    msg = toUtf8 "Hello there" 
+    socketSend socket msg
+    closeSocket socket 
+
+myServer = unsafeRun! '(hello "127.0.0.1" "0")
+
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      Exception.unsafeRun! : '{g, Exception} a -> '{g} a
+      hello                : Text -> Text ->{IO, Exception} ()
+      myServer             : '{IO} ()
+      putText              : Handle -> Text ->{IO, Exception} ()
+      toException          : Either Failure a ->{Exception} a
+        (also named Exception.reraise , base.Either.toException
+        , and base.Exception.reraise)
+
+```
+```ucm
+.> run myServer 
+
+  💔💥
+  
+  I've encountered a call to builtin.bug with the following
+  value:
+  
+    base.io.Failure.Failure
+      typeLink base.io.IOFailure
+      "Network.Socket.sendBuf: resource vanished (Broken pipe)"
+  
+  I'm sorry this message doesn't have more detail about the
+  location of the failure. My makers plan to fix this in a
+  future release. 😢
+
+```

--- a/unison-src/transcripts-using-base/fix2027.output.md
+++ b/unison-src/transcripts-using-base/fix2027.output.md
@@ -9,12 +9,15 @@ toException = cases
 putText : Handle -> Text ->{IO, Exception} ()
 putText h t = putBytes h (toUtf8 t)
 
+bugFail = cases
+  Failure typ _ _ -> bug (Failure typ "problem" (Any ()))
+
 Exception.unsafeRun! : '{Exception, g} a -> '{g} a
 Exception.unsafeRun! e _ = 
     h : Request {Exception} a -> a 
     h = cases 
         {Exception.raise fail -> _ } -> 
-            bug fail 
+            bugFail fail
         {a} -> a 
     handle !e with h 
 
@@ -38,6 +41,7 @@ myServer = unsafeRun! '(hello "127.0.0.1" "0")
     ⍟ These new definitions are ok to `add`:
     
       Exception.unsafeRun! : '{g, Exception} a -> '{g} a
+      bugFail              : Failure -> r
       hello                : Text -> Text ->{IO, Exception} ()
       myServer             : '{IO} ()
       putText              : Handle -> Text ->{IO, Exception} ()
@@ -55,8 +59,7 @@ myServer = unsafeRun! '(hello "127.0.0.1" "0")
   value:
   
     base.io.Failure.Failure
-      typeLink base.io.IOFailure
-      "Network.Socket.sendBuf: resource vanished (Broken pipe)"
+      typeLink base.io.IOFailure "problem" !base.Any.Any
   
   I'm sorry this message doesn't have more detail about the
   location of the failure. My makers plan to fix this in a


### PR DESCRIPTION
- When originally written, various builtins were referencing data types
  defined in IOSource. However, those no longer exist there.
- Instead, they are defined in Unison.Builtin.Decls
- This switches the builtins to the Decls values, some of which weren't
  exported yet.
- Also eliminates them from IOSource, since the ones there didn't
  actually work.
- Transcript testing the behavior added.

Fixes #2027, inasmuch as it now gives a proper failure condition.