### PR TITLE
Update mergify.yml to work with new build matrix

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,7 @@ pull_request_rules:
   - name: automatic merge on CI success and review
     conditions:
       - status-success=ubuntu-20.04
-      - status-success=ubuntu-18.04
+      # - status-success=ubuntu-18.04
       - status-success=macOS-11.0
       - status-success=macOS-10.15
       - label=ready-to-merge


### PR DESCRIPTION
CI isn't building Ubuntu 18 anymore, so Mergify shouldn't check for it.

I've already applied ready-to-merge to this PR so I think approving it will cause Mergify to merge it's own update to the Mergify config. 🤯