### PR TITLE
Codebase server default ui path is relative to the UCM executable now

### DIFF
--- a/dev-ui-install.sh
+++ b/dev-ui-install.sh
@@ -1,0 +1,10 @@
+echo "This script downloads the latest codebase UI release"
+echo "and puts it in the correct spot next to the unison"
+echo "executable built by stack."
+echo ""
+
+stack build
+curl -L https://github.com/unisonweb/codebase-ui/releases/download/latest/ucm.zip --output ucm.zip
+parent_dir="$(dirname -- $(stack exec which unison))"
+mkdir -p "$parent_dir/ui"
+unzip -o ucm.zip -d "$parent_dir/ui"

--- a/development.markdown
+++ b/development.markdown
@@ -8,9 +8,13 @@ _Disclaimer_ If you have trouble getting started, please get in touch via [Slack
 
 To get cracking with Unison:
 
-* [Install `stack`](https://docs.haskellstack.org/en/stable/README/#how-to-install).
-* Build the project with `stack build`. This builds all executables.
-* After building, `stack exec unison` will fire up the codebase editor, create a codebase in the current directory, and watch for `.u` file changes.  If you want to run it in a different directory, just add `unison` to your `PATH`, after finding it with `find .stack-work -name unison -type f`.  (For me, this finds two, they both work, but have different contents.  ¯\\\_(ツ)\_/¯ )
+1. [Install `stack`](https://docs.haskellstack.org/en/stable/README/#how-to-install).
+2. Build the project with `stack build`. This builds all executables.
+3. (Optional) Run `./dev-ui-install.hs` to fetch the latest release of the codebase UI. If you don't care about running the codebase UI locally you can ignore this step.
+4. After building do `stack exec unison -- init` will initialize a codebase in your home directory (in `~/.unison`). This only needs to be done once.
+5. `stack exec unison` starts Unison and watches for `.u` file changes in the current directory. If you want to run it in a different directory, just add `unison` to your `PATH`, after finding it with `stack exec which unison`.
+
+On startup, Unison prints a url for the codebase UI. If you did step 3 above, then visiting that URL in a browser will give you a nice interface to your codebase.
 
 ## Running Tests
 


### PR DESCRIPTION
Previously it was relative to the current directory, which was not very useful.

To help with my manual testing, I also added a script, `dev-ui-install.sh` which fetches the latest release of the codebase UI and puts it in the correct spot relative to the executable. After running this script, the URL that UCM prints on startup can be visited in the browser and it works. This script can be run as often as you like whenever new goodies land in the codebase UI and should streamline the dev workflow.

Both the `/ui` path and the executable path get symlinks resolved now as well. The thinking here is that you can now have a low tech install method - just unzip the release anywhere, and add a symlink to the executable in `/usr/local/bin` or wherever.

This just got manual testing.