### PR TITLE
use custom direct-sqlite with extended error codes

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -47,8 +47,10 @@ extra-deps:
 - servant-auth-0.4.0.0@sha256:01d02dfb7df4747fc96442517146d7d4ab0e575e597a124e238e8763036ea4ff,2125
 - ListLike-4.7.4
 - sqlite-simple-0.4.18.0@sha256:3ceea56375c0a3590c814e411a4eb86943f8d31b93b110ca159c90689b6b39e5,3002
-- direct-sqlite-2.3.26@sha256:04e835402f1508abca383182023e4e2b9b86297b8533afbd4e57d1a5652e0c23,3718
 - random-1.2.0
+# remove this when direct-sqlite includes extended error codes
+- github: unisonweb/direct-sqlite
+  commit: b9cc9c9b7deeab76f521314f9d2a1b7af8d996b9
 # remove these when stackage upgrades containers
 - containers-0.6.4.1
 - text-1.2.4.1


### PR DESCRIPTION
The [direct-sqlite](https://hackage.haskell.org/package/direct-sqlite) package doesn't report sqlite extended error codes, so this PR switches us to a fork that does (https://github.com/unisonweb/direct-sqlite/commit/b9cc9c9b7deeab76f521314f9d2a1b7af8d996b9). 

Hopefully it will help diagnose issues like https://github.com/unisonweb/unison/pull/2014#issuecomment-850929064 and [another one I've seen on an experimental branch but don't have a ticket for](https://sqlite.org/forum/forumpost/ab37b8ed32).

I don't actually know if it works until I can reproduce one of these crashes and see if sqlite newly provides any additional detail.