### PR TITLE
print the number of cpus configured on headless startup

### DIFF
--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -20,6 +20,7 @@ import Control.Exception (AsyncException (UserInterrupt), throwTo)
 import Data.ByteString.Char8 (unpack)
 import Data.Configurator.Types (Config)
 import qualified Data.Text as Text
+import qualified GHC.Conc
 import qualified Network.URI.Encode as URI
 import System.Directory (getCurrentDirectory, removeDirectoryRecursive)
 import System.Environment (getArgs, getProgName)
@@ -40,7 +41,7 @@ import qualified Unison.Codebase.FileCodebase as FC
 import qualified Unison.Codebase.Path as Path
 import qualified Unison.Codebase.SqliteCodebase as SC
 import qualified Unison.Codebase.TranscriptParser as TR
-import Unison.CommandLine (watchConfig)
+import Unison.CommandLine (plural', watchConfig)
 import qualified Unison.CommandLine.Main as CommandLine
 import Unison.Parser (Ann)
 import Unison.Prelude
@@ -207,7 +208,11 @@ main = do
         PT.putPrettyLn $ P.lines
           ["The Unison Codebase UI is running at", P.string $ url <> "/ui"]
         if headless then do
-          PT.putPrettyLn $ P.string "Running the codebase manager in headless mode."
+          PT.putPrettyLn $ P.string "Running the codebase manager headless with "
+            <> P.shown GHC.Conc.numCapabilities
+            <> " "
+            <> plural' GHC.Conc.numCapabilities "cpu" "cpus"
+            <> "."
           mvar <- newEmptyMVar
           takeMVar mvar
         else do


### PR DESCRIPTION
```
arya@jrrr unison-trunk % stack exec unison -- headless

  I've started the codebase API server at
  http://127.0.0.1:57324/dUPTV5kasInKin3RzBIfaiVmaTDlVWYM/api


  The Unison Codebase UI is running at
  http://127.0.0.1:57324/dUPTV5kasInKin3RzBIfaiVmaTDlVWYM/ui


  Running the codebase manager headless with 1 cpu.
```

```
arya@jrrr unison-trunk % stack exec -- unison headless +RTS -N

  I've started the codebase API server at
  http://127.0.0.1:59467/To6yb8GPQZnWVE%2BBZDGmIC29rURP%2BYH6/api


  The Unison Codebase UI is running at
  http://127.0.0.1:59467/To6yb8GPQZnWVE%2BBZDGmIC29rURP%2BYH6/ui


  Running the codebase manager headless with 8 cpus.
```
Closes #2046.