### PR TITLE
Add `upgrade-codebase` to the ucm help

### DIFF
--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -62,7 +62,7 @@ usage executableStr = P.callout "🌻" $ P.lines [
   P.wrap "Starts Unison interactively, using the codebase in the home directory.",
   "",
   P.bold $ executable <> " -codebase path/to/codebase",
-  P.wrap "Starts Unison interactively, using the specified codebase. This flag can also be set for any of the below commands.",
+  P.wrap "Starts Unison interactively, using the specified codebase. This flag can also be set before any of the below commands.",
   "",
   P.bold $ executable <> " run .mylib.mymain",
   P.wrap "Executes the definition `.mylib.mymain` from the codebase, then exits.",
@@ -99,6 +99,9 @@ usage executableStr = P.callout "🌻" $ P.lines [
         <> "and saves the resulting codebase to a new directory on disk."
         <> "Multiple transcript files may be provided; they are processed in sequence"
         <> "starting from the same codebase.",
+  "",
+  P.bold $ executable <> " upgrade-codebase",
+  "Upgrades a v1 codebase to a v2 codebase.",
   "",
   P.bold $ executable <> " headless",
   "Runs the codebase server without the command-line interface.",


### PR DESCRIPTION
```
arya@jrrr unison-trunk % stack build && stack exec unison -- help

  🌻
  
  Usage instructions for the Unison Codebase Manager
  You are running version: latest-Linux-38-g6546922d6'
  
  unison
  Starts Unison interactively, using the codebase in the home directory.
  
  unison -codebase path/to/codebase
  Starts Unison interactively, using the specified codebase. This flag can also be set for any of
  the below commands.
  
  unison run .mylib.mymain
  Executes the definition `.mylib.mymain` from the codebase, then exits.
  
  unison run.file foo.u mymain
  Executes the definition called `mymain` in `foo.u`, then exits.
  
  unison run.pipe mymain
  Executes the definition called `mymain` from a `.u` file read from the standard input, then
  exits.
  
  unison transcript mytranscript.md
  Executes the `mytranscript.md` transcript and creates `mytranscript.output.md` if successful.
  Exits after completion, and deletes the temporary directory created. Multiple transcript files
  may be provided; they are processed in sequence starting from the same codebase.
  
  unison transcript -save-codebase mytranscript.md
  Executes the `mytranscript.md` transcript and creates `mytranscript.output.md` if successful.
  Exits after completion, and saves the resulting codebase to a new directory on disk. Multiple
  transcript files may be provided; they are processed in sequence starting from the same codebase.
  
  unison transcript.fork mytranscript.md
  Executes the `mytranscript.md` transcript in a copy of the current codebase and creates
  `mytranscript.output.md` if successful. Exits after completion. Multiple transcript files may be
  provided; they are processed in sequence starting from the same codebase.
  
  unison transcript.fork -save-codebase mytranscript.md
  Executes the `mytranscript.md` transcript in a copy of the current codebase and creates
  `mytranscript.output.md` if successful. Exits after completion, and saves the resulting codebase
  to a new directory on disk. Multiple transcript files may be provided; they are processed in
  sequence starting from the same codebase.
  
  unison upgrade-codebase
  Upgrades a v1 codebase to a v2 codebase.
  
  unison headless
  Runs the codebase server without the command-line interface.
  
  unison version
  Prints version of Unison then quits.
  
  unison help
  Prints this help.
```

Closes #2057.

