### PR TITLE
Flush the WAL files on `push`

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -1100,16 +1100,16 @@ pushGitRootBranch srcConn branch repo = runExceptT @GitError do
       else Nothing
       where
         statusLines = Text.unpack <$> Text.lines status
-        okLine ('?':'?':(trimStart -> ".unison/v2/unison.sqlite3")) = True
-        okLine ('M':(trimStart -> ".unison/v2/unison.sqlite3")) = True
+        t = dropWhile Char.isSpace
+        okLine (t -> '?':'?':(t -> ".unison/v2/unison.sqlite3")) = True
+        okLine (t -> 'M':(t -> ".unison/v2/unison.sqlite3")) = True
         okLine line = isWalDelete line || isShmDelete line
-        isWalDelete ('D':(trimStart -> ".unison/v2/unison.sqlite3-wal")) = True
+        isWalDelete (t -> 'D':(t -> ".unison/v2/unison.sqlite3-wal")) = True
         isWalDelete _ = False
-        isShmDelete ('D':(trimStart -> ".unison/v2/unison.sqlite3-shm")) = True
+        isShmDelete (t -> 'D':(t -> ".unison/v2/unison.sqlite3-shm")) = True
         isShmDelete _ = False
         hasDeleteWal = any isWalDelete statusLines
         hasDeleteShm = any isShmDelete statusLines
-        trimStart = dropWhile Char.isSpace
 
     -- Commit our changes
     push :: CodebasePath -> RemoteRepo -> IO Bool -- withIOError needs IO

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -1115,6 +1115,10 @@ pushGitRootBranch srcConn branch repo = runExceptT @GitError do
     push :: CodebasePath -> RemoteRepo -> IO Bool -- withIOError needs IO
     push remotePath (GitRepo url gitbranch) = time "SqliteCodebase.pushGitRootBranch.push" $ do
       -- has anything changed?
+      -- note: -uall recursively shows status for all files in untracked directories
+      --   we want this so that we see
+      --     `??  .unison/v2/unison.sqlite3` and not
+      --     `??  .unison/`
       status <- gitTextIn remotePath ["status", "--short", "-uall"]
       if Text.null status
         then pure False

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -22,6 +22,7 @@ import Control.Monad.Trans (MonadTrans (lift))
 import Control.Monad.Trans.Maybe (MaybeT (MaybeT))
 import Data.Bifunctor (Bifunctor (bimap, first), second)
 import qualified Data.Either.Combinators as Either
+import qualified Data.Char as Char
 import Data.Foldable (Foldable (toList), for_, traverse_)
 import Data.Functor (void, (<&>), ($>))
 import qualified Data.List as List
@@ -1072,27 +1073,76 @@ pushGitRootBranch srcConn branch repo = runExceptT @GitError do
       chId <- fromMaybe err <$> Q.loadCausalHashIdByCausalHash h2
       Q.setNamespaceRoot chId
 
+    -- This function makes sure that the result of git status is valid.
+    -- Valid lines are any of:
+    --
+    --   ?? .unison/v2/unison.sqlite3 (initial commit to an empty repo)
+    --   M .unison/v2/unison.sqlite3  (updating an existing repo)
+    --   D .unison/v2/unison.sqlite3-wal (cleaning up the WAL from before bugfix)
+    --   D .unison/v2/unison.sqlite3-shm (ditto)
+    --
+    -- Invalid lines are like:
+    --
+    --   ?? .unison/v2/unison.sqlite3-wal
+    --
+    -- Which will only happen if the write-ahead log hasn't been
+    -- fully folded into the unison.sqlite3 file.
+    --
+    -- Returns `Just (hasDeleteWal, hasDeleteShm)` on success,
+    -- `Nothing` otherwise. hasDeleteWal means there's the line:
+    --   D .unison/v2/unison.sqlite3-wal
+    -- and hasDeleteShm is `True` if there's the line:
+    --   D .unison/v2/unison.sqlite3-shm
+    --
+    parseStatus :: Text -> Maybe (Bool, Bool)
+    parseStatus status =
+      if all okLine statusLines then Just (hasDeleteWal, hasDeleteShm)
+      else Nothing
+      where
+        statusLines = Text.unpack <$> Text.lines status
+        okLine ('?':'?':(trimStart -> ".unison/v2/unison.sqlite3")) = True
+        okLine ('M':(trimStart -> ".unison/v2/unison.sqlite3")) = True
+        okLine line = isWalDelete line || isShmDelete line
+        isWalDelete ('D':(trimStart -> ".unison/v2/unison.sqlite3-wal")) = True
+        isWalDelete _ = False
+        isShmDelete ('D':(trimStart -> ".unison/v2/unison.sqlite3-shm")) = True
+        isShmDelete _ = False
+        hasDeleteWal = any isWalDelete statusLines
+        hasDeleteShm = any isShmDelete statusLines
+        trimStart = dropWhile Char.isSpace
+
     -- Commit our changes
     push :: CodebasePath -> RemoteRepo -> IO Bool -- withIOError needs IO
     push remotePath (GitRepo url gitbranch) = time "SqliteCodebase.pushGitRootBranch.push" $ do
       -- has anything changed?
-      status <- gitTextIn remotePath ["status", "--short"]
+      status <- gitTextIn remotePath ["status", "--short", "-uall"]
       if Text.null status
         then pure False
-        else do
-          gitIn remotePath ["add", "--all", "."]
-          gitIn
-            remotePath
-            ["commit", "-q", "-m", "Sync branch " <> Text.pack (show $ Branch.headHash branch)]
-          -- Push our changes to the repo
-          case gitbranch of
-            Nothing -> gitIn remotePath ["push", "--quiet", url]
-            Just gitbranch ->
-              error $
-                "Pushing to a specific branch isn't fully implemented or tested yet.\n"
-                  ++ "InputPatterns.parseUri was expected to have prevented you "
-                  ++ "from supplying the git treeish `"
-                  ++ Text.unpack gitbranch
-                  ++ "`!"
-              -- gitIn remotePath ["push", "--quiet", url, gitbranch]
-          pure True
+        else case parseStatus status of
+          Nothing ->
+            error $ "An error occurred during push.\n"
+                 <> "I was expecting only to see .unison/v2/unison.sqlite3 modified, but saw:\n\n"
+                 <> Text.unpack status <> "\n\n"
+                 <> "Please visit https://github.com/unisonweb/unison/issues/2063\n"
+                 <> "and add any more details about how you encountered this!\n"
+          Just (hasDeleteWal, hasDeleteShm) -> do
+            -- Only stage files we're expecting; don't `git add --all .`
+            -- which could accidentally commit some garbage
+            gitIn remotePath ["add", ".unison/v2/unison.sqlite3"]
+            when hasDeleteWal $ gitIn remotePath ["rm", ".unison/v2/unison.sqlite3-wal"]
+            when hasDeleteShm $ gitIn remotePath ["rm", ".unison/v2/unison.sqlite3-shm"]
+            gitIn
+              remotePath
+              ["commit", "-q", "-m", "Sync branch " <> Text.pack (show $ Branch.headHash branch)]
+            -- Push our changes to the repo
+            case gitbranch of
+              Nothing -> gitIn remotePath ["push", "--quiet", url]
+              Just gitbranch ->
+                error $
+                  "Pushing to a specific branch isn't fully implemented or tested yet.\n"
+                    ++ "InputPatterns.parseUri was expected to have prevented you "
+                    ++ "from supplying the git treeish `"
+                    ++ Text.unpack gitbranch
+                    ++ "`!"
+                -- gitIn remotePath ["push", "--quiet", url, gitbranch]
+            pure True

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -44,6 +44,7 @@ import qualified System.FilePath as FilePath
 import U.Codebase.HashTags (CausalHash (CausalHash, unCausalHash))
 import U.Codebase.Sqlite.Operations (EDB)
 import qualified U.Codebase.Reference as C.Reference
+import qualified U.Codebase.Sqlite.JournalMode as JournalMode
 import qualified U.Codebase.Sqlite.ObjectType as OT
 import qualified U.Codebase.Sqlite.Operations as Ops
 import qualified U.Codebase.Sqlite.Queries as Q
@@ -1055,6 +1056,8 @@ pushGitRootBranch srcConn branch repo = runExceptT @GitError do
           Just True -> do
             setRepoRoot newRootHash
             Q.release "push"
+
+    Q.setJournalMode JournalMode.DELETE
 
   liftIO do
     Sqlite.close destConn


### PR DESCRIPTION
This PR addresses #2063, ensuring that no stray WAL files get added to a commit, and (hopefully) forcing these files to get flushed before `push` (folded into the `unison.sqlite3` file then deleted). @aryairani spoon fed me the fix for this.

However, since we didn't have a reliable reproduction of the issue that resulted in those WAL files making it into a commit, it's unclear if the fix in this PR has actually worked. This PR should be understood as "here's a plausible fix, and a reliable failure detection if the issue is still present and ever arises again".