### PR TITLE
Series/m2

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -17,7 +17,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           draft: ${{ github.workflow }}-CHANGELOG.txt
+

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -24,5 +24,5 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
-          draft: ${{ github.workflow }}-CHANGELOG.txt
+          draft: true
 

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -1,0 +1,23 @@
+name: "create-release"
+
+on:
+  push:
+    tags:
+      - "release/*"
+
+jobs:
+  release:
+    name: "create-release"
+    runs-on: "ubuntu-latest"
+
+    strategy:
+      # Run each build to completion, regardless of if any have failed
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: ${{ github.workflow }}-CHANGELOG.txt

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,7 @@ jobs:
           tar -c -z -f unison-${{runner.os}}.tar.gz -C /tmp/ucm .
 
       - name: Set env
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/release/*/}" >> $GITHUB_ENV
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/release/*}" >> $GITHUB_ENV
 
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "${{ env.RELEASE_VERSION }}-${{runner.os}}"
-          prerelease: true
-          title: "Development Build"
+          automatic_release_tag: "release/${{ env.RELEASE_VERSION }}-${{runner.os}}"
+          prerelease: false
+          title: "Release Build"
           files: "unison-${{runner.os}}.tar.gz"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,6 @@ jobs:
   release:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     strategy:
       # Run each build to completion, regardless of if any have failed

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
+          - ubuntu-18.04
           - macOS-10.15
 
     steps:
@@ -46,7 +47,6 @@ jobs:
       - name: build
         run: stack --no-terminal build --flag unison-parser-typechecker:optimized
 
-
       - name: fetch latest codebase-ui and package with ucm
         run: |
           mkdir -p /tmp/ucm/ui
@@ -57,12 +57,17 @@ jobs:
           tar -c -z -f unison-${{runner.os}}.tar.gz -C /tmp/ucm .
 
       - name: Set env
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/release/*}" >> $GITHUB_ENV
+        if: runner.os == 'macOS'
+        run: echo "RELEASE_VERSION=release/${GITHUB_REF#refs/tags/release/*}-${{runner.os}}" >> $GITHUB_ENV
+
+      - name: Set env
+        if: runner.os != 'macOS'
+        run: echo "RELEASE_VERSION=release/${GITHUB_REF#refs/tags/release/*}-${{matrix.os}}" >> $GITHUB_ENV
 
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "release/${{ env.RELEASE_VERSION }}-${{runner.os}}"
+          automatic_release_tag: "${{ env.RELEASE_VERSION }}"
           prerelease: false
-          title: "Release Build"
+          title: "Release Build for ${{runner.os}}"
           files: "unison-${{runner.os}}.tar.gz"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: "release"
 on:
   push:
     tags:
-      - "v*"
+      - "release*"
 jobs:
   release:
     name: ${{ matrix.os }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,69 @@
+name: "release"
+
+on:
+  push:
+    tags:
+      - "v*"
+jobs:
+  release:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    strategy:
+      # Run each build to completion, regardless of if any have failed
+      fail-fast: false
+
+      matrix:
+        os:
+          - ubuntu-20.04
+          - macOS-10.15
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install stack (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.5.1/stack-2.5.1-linux-x86_64.tar.gz | tar -xz
+          echo "$HOME/stack-2.5.1-linux-x86_64/" >> $GITHUB_PATH
+      - name: install stack (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.5.1/stack-2.5.1-osx-x86_64.tar.gz | tar -xz
+          echo "$HOME/stack-2.5.1-osx-x86_64/" >> $GITHUB_PATH
+
+
+      # One of the transcripts fails if the user's git name hasn't been set.
+      - name: set git user info
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+
+      - name: remove ~/.stack/setup-exe-cache on macOS
+        if: runner.os == 'macOS'
+        run: rm -rf ~/.stack/setup-exe-cache
+
+      - name: build
+        run: stack --no-terminal build --ghc-options -O2
+
+
+      - name: fetch latest codebase-ui and package with ucm
+        run: |
+          mkdir -p /tmp/ucm/ui
+          UCM=$(stack path | awk '/local-install-root/{print $2}')/bin/unison
+          cp $UCM /tmp/ucm/ucm
+          wget -O/tmp/ucm.zip https://github.com/unisonweb/codebase-ui/releases/download/latest/ucm.zip
+          unzip -d /tmp/ucm/ui /tmp/ucm.zip
+          tar -c -z -f unison-${{runner.os}}.tar.gz -C /tmp/ucm .
+
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "${{ env.RELEASE_VERSION }}-${{runner.os}}"
+          prerelease: true
+          title: "Development Build"
+          files: "unison-${{runner.os}}.tar.gz"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: "release"
 on:
   push:
     tags:
-      - "v*"
+      - "release/*"
 jobs:
   release:
     name: ${{ matrix.os }}
@@ -45,7 +45,7 @@ jobs:
         run: rm -rf ~/.stack/setup-exe-cache
 
       - name: build
-        run: stack --no-terminal build --ghc-options -O2
+        run: stack --no-terminal build --flag unison-parser-typechecker:optimized
 
 
       - name: fetch latest codebase-ui and package with ucm
@@ -58,7 +58,7 @@ jobs:
           tar -c -z -f unison-${{runner.os}}.tar.gz -C /tmp/ucm .
 
       - name: Set env
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/release/*/}" >> $GITHUB_ENV
 
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:

--- a/.github/workflows/upload-release-artifacts.yaml
+++ b/.github/workflows/upload-release-artifacts.yaml
@@ -1,9 +1,11 @@
-name: "release"
+name: "upload-release-artifacts"
 
 on:
-  push:
-    tags:
-      - "release/*"
+  workflow_run:
+    workflows: ["create-release"]
+    types:
+      - completed
+
 jobs:
   release:
     name: ${{ matrix.os }}
@@ -64,8 +66,11 @@ jobs:
         if: runner.os != 'macOS'
         run: echo "RELEASE_VERSION=release/${GITHUB_REF#refs/tags/release/*}-${{matrix.os}}" >> $GITHUB_ENV
 
-      - uses: "marvinpinto/action-automatic-releases@latest"
+      - name: "Upload ${{matrix.os}}"
+        uses: "actions/upload-artifact@v2"
         with:
+          path: "unison-${{runner.os}}.tar.gz"
+
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "${{ env.RELEASE_VERSION }}"
           prerelease: false

--- a/.github/workflows/upload-release-artifacts.yaml
+++ b/.github/workflows/upload-release-artifacts.yaml
@@ -70,9 +70,5 @@ jobs:
         uses: "actions/upload-artifact@v2"
         with:
           path: "unison-${{runner.os}}.tar.gz"
-
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "${{ env.RELEASE_VERSION }}"
-          prerelease: false
-          title: "Release Build for ${{runner.os}}"
-          files: "unison-${{runner.os}}.tar.gz"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -21,7 +21,7 @@ ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synony
 flags:
   optimized:
     manual: true
-    default: false
+    default: true
 
 when:
   - condition: flag(optimized)

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -19,7 +19,7 @@ source-repository head
 
 flag optimized
   manual: True
-  default: False
+  default: True
 
 library
   exposed-modules:

--- a/unison-core/package.yaml
+++ b/unison-core/package.yaml
@@ -46,4 +46,4 @@ flags:
 
 when:
   - condition: flag(optimized)
-    ghc-options: -funbox-strict-fields
+    ghc-options: -O2 -funbox-strict-fields

--- a/unison-core/unison-core1.cabal
+++ b/unison-core/unison-core1.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 25e073d1bb732e90d3e1d3999ec516185669150701345da4fcd35cb20389334d
+-- hash: 6eae706c8674f4a7f22bb4bff150798cdaba8aa9186b3d94a6a8467a9cc23d06
 
 name:           unison-core1
 version:        0.0.0
@@ -98,5 +98,5 @@ library
     , util
     , vector
   if flag(optimized)
-    ghc-options: -funbox-strict-fields
+    ghc-options: -O2 -funbox-strict-fields
   default-language: Haskell2010


### PR DESCRIPTION
Merge the build updates to main

## Overview

We are trying to update our M2 release to contain images built for older ncurses5 (for ubuntu 18.04 users, for example). This update would instead of introducing yet another separate release for M2 which contains just a single tarball, this would create a single `release/M2` release containing all 3 tarballs (1 Mac, 1 Linux-ncurses5 and 1 Linux-ncurses6)

I'm requesting this merge to master, because the way these actions are setup, we have one action triggering another, and the subsequently triggered actions have to be on the default branch for that to work

## Implementation notes

This new method of creating releases first creates a draft release from the tag name, the job triggers the matrix builds which append to the draft release with their tarballs.

Then we would manually inspect the release, fix up the release notes and take away the `Draft:` flag

## Interesting/controversial decisions

We could perhaps automate the taking away of the Draft flag. But I think we want to make sure the release notes look good. One way we could more reliably accomplish that would be to check in the current release notes in the commit we tag (perhaps in `docs/release_notes.md` or something, and then the job which creates the release can be sure to publish the right data
