### PR TITLE
wrapper type for DB connection provenance

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Connection.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Connection.hs
@@ -1,0 +1,15 @@
+module U.Codebase.Sqlite.Connection where
+
+import qualified Database.SQLite.Simple as Sqlite
+
+data Connection = Connection {name :: String, file :: FilePath, underlying :: Sqlite.Connection}
+
+instance Show Connection where
+  show (Connection name file underlying) =
+    "Connection " ++ show name
+      ++ (if showFile then " " ++ file else mempty)
+      ++ (if showHandle then " " ++ show (Sqlite.connectionHandle underlying) else mempty)
+
+showFile, showHandle :: Bool
+showFile = False
+showHandle = False

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
@@ -48,7 +48,6 @@ import Data.Traversable (for)
 import Data.Tuple.Extra (uncurry3)
 import qualified Data.Vector as Vector
 import Data.Word (Word64)
-import Database.SQLite.Simple (Connection)
 import Debug.Trace
 import GHC.Stack (HasCallStack)
 import qualified U.Codebase.Branch as C.Branch
@@ -71,6 +70,7 @@ import qualified U.Codebase.Sqlite.Branch.Format as S.BranchFormat
 import qualified U.Codebase.Sqlite.Branch.Full as S
 import qualified U.Codebase.Sqlite.Branch.Full as S.Branch.Full
 import qualified U.Codebase.Sqlite.Branch.Full as S.MetadataSet
+import U.Codebase.Sqlite.Connection (Connection)
 import qualified U.Codebase.Sqlite.DbId as Db
 import qualified U.Codebase.Sqlite.Decl.Format as S.Decl
 import U.Codebase.Sqlite.LocalIds

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Sync22.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Sync22.hs
@@ -29,10 +29,10 @@ import Data.List.Extra (nubOrd)
 import Data.Maybe (catMaybes, fromMaybe)
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Database.SQLite.Simple (Connection)
 import Debug.Trace (traceM, trace)
 import qualified U.Codebase.Reference as Reference
 import qualified U.Codebase.Sqlite.Branch.Format as BL
+import U.Codebase.Sqlite.Connection (Connection)
 import U.Codebase.Sqlite.DbId
 import qualified U.Codebase.Sqlite.LocalIds as L
 import qualified U.Codebase.Sqlite.ObjectType as OT

--- a/codebase2/codebase-sqlite/unison-codebase-sqlite.cabal
+++ b/codebase2/codebase-sqlite/unison-codebase-sqlite.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1ebfb83fff5576c08030523940c272f5edfa0f42248d67da4edc9aa6d887cf5f
+-- hash: 3106bd32bedf162883882818669a81a3e1ca7c60af26ec9cd945fadb39f0d5aa
 
 name:           unison-codebase-sqlite
 version:        0.0.0
@@ -23,6 +23,7 @@ library
       U.Codebase.Sqlite.Branch.Diff
       U.Codebase.Sqlite.Branch.Format
       U.Codebase.Sqlite.Branch.Full
+      U.Codebase.Sqlite.Connection
       U.Codebase.Sqlite.DbId
       U.Codebase.Sqlite.Decl.Format
       U.Codebase.Sqlite.JournalMode

--- a/parser-typechecker/src/Unison/Codebase/Conversion/Sync12.hs
+++ b/parser-typechecker/src/Unison/Codebase/Conversion/Sync12.hs
@@ -33,10 +33,10 @@ import qualified Data.Map as Map
 import Data.Maybe (catMaybes)
 import qualified Data.Set as Set
 import Data.Traversable (for)
-import Database.SQLite.Simple (Connection)
 import Debug.Trace (traceM)
 import System.IO (stdout)
 import System.IO.Extra (hFlush)
+import U.Codebase.Sqlite.Connection (Connection)
 import U.Codebase.Sync (Sync (Sync), TrySyncResult)
 import qualified U.Codebase.Sync as Sync
 import qualified U.Util.Monoid as Monoid

--- a/parser-typechecker/src/Unison/Codebase/Conversion/Upgrade12.hs
+++ b/parser-typechecker/src/Unison/Codebase/Conversion/Upgrade12.hs
@@ -34,9 +34,9 @@ syncWatchKinds = [WK.TestWatch]
 upgradeCodebase :: forall m. (MonadIO m, MonadCatch m) => CodebasePath -> m ()
 upgradeCodebase root = do
   either (liftIO . CT.putPrettyLn) pure =<< runExceptT do
-    (cleanupSrc, srcCB) <- ExceptT $ Codebase.openCodebase FC.init root
-    (cleanupDest, destCB) <- ExceptT $ Codebase.createCodebase SC.init root
-    destDB <- SC.unsafeGetConnection root
+    (cleanupSrc, srcCB) <- ExceptT $ Codebase.openCodebase FC.init "upgradeCodebase srcCB" root
+    (cleanupDest, destCB) <- ExceptT $ Codebase.createCodebase SC.init "upgradeCodebase destCB" root
+    destDB <- SC.unsafeGetConnection "upgradeCodebase destDB" root
     let env = Sync12.Env srcCB destCB destDB
     let initialState = (Sync12.emptyDoneCount, Sync12.emptyErrorCount, Sync12.emptyStatus)
     rootEntity <-
@@ -62,6 +62,7 @@ upgradeCodebase root = do
           Just (Sync12.BranchReplaced _h' c') -> pure c'
           Nothing -> error "We didn't sync the root?"
         _ -> error "The root wasn't a causal?"
+    SC.shutdownConnection destDB
     lift cleanupSrc
     lift cleanupDest
     pure ()

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -9,6 +9,7 @@ module Unison.Codebase.FileCodebase
   (
     codebase1', -- used by Test/Git
     Unison.Codebase.FileCodebase.init,
+    openCodebase -- since init requires a bunch of irrelevant args now
   )
 where
 
@@ -94,8 +95,8 @@ import UnliftIO.STM (atomically)
 
 init :: (MonadIO m, MonadCatch m) => Codebase.Init m Symbol Ann
 init = Codebase.Init
-  ((fmap . fmap) (pure (),) . openCodebase)
-  ((fmap . fmap) (pure (),) . createCodebase)
+  (const $ (fmap . fmap) (pure (),) . openCodebase)
+  (const $ (fmap . fmap) (pure (),) . createCodebase)
   (</> Common.codebasePath)
 
 

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -6,7 +6,12 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
 
-module Unison.Codebase.SqliteCodebase (Unison.Codebase.SqliteCodebase.init, unsafeGetConnection) where
+module Unison.Codebase.SqliteCodebase
+  ( Unison.Codebase.SqliteCodebase.init,
+    unsafeGetConnection,
+    shutdownConnection,
+  )
+where
 
 import qualified Control.Concurrent
 import qualified Control.Exception
@@ -36,7 +41,6 @@ import qualified Data.Text as Text
 import qualified Data.Text.IO as TextIO
 import Data.Traversable (for)
 import Data.Word (Word64)
-import Database.SQLite.Simple (Connection)
 import qualified Database.SQLite.Simple as Sqlite
 import GHC.Stack (HasCallStack)
 import qualified System.Console.ANSI as ANSI
@@ -45,6 +49,8 @@ import qualified System.FilePath as FilePath
 import U.Codebase.HashTags (CausalHash (CausalHash, unCausalHash))
 import U.Codebase.Sqlite.Operations (EDB)
 import qualified U.Codebase.Reference as C.Reference
+import U.Codebase.Sqlite.Connection (Connection (Connection))
+import qualified U.Codebase.Sqlite.Connection as Connection
 import qualified U.Codebase.Sqlite.JournalMode as JournalMode
 import qualified U.Codebase.Sqlite.ObjectType as OT
 import qualified U.Codebase.Sqlite.Operations as Ops
@@ -116,9 +122,10 @@ init = Codebase.Init getCodebaseOrError createCodebaseOrError v2dir
 
 createCodebaseOrError ::
   MonadIO m =>
+  Codebase.DebugName ->
   CodebasePath ->
   m (Either Codebase1.CreateCodebaseError (m (), Codebase m Symbol Ann))
-createCodebaseOrError dir = do
+createCodebaseOrError debugName dir = do
   prettyDir <- P.string <$> canonicalizePath dir
   let convertError = \case
         CreateCodebaseAlreadyExists -> Codebase1.CreateCodebaseAlreadyExists
@@ -126,7 +133,7 @@ createCodebaseOrError dir = do
       prettyError :: SchemaVersion -> Codebase1.Pretty
       prettyError v = P.wrap $
         "I don't know how to handle " <> P.shown v <> "in" <> P.backticked' prettyDir "."
-  Either.mapLeft convertError <$> createCodebaseOrError' dir
+  Either.mapLeft convertError <$> createCodebaseOrError' debugName dir
 
 data CreateCodebaseError
   = CreateCodebaseAlreadyExists
@@ -135,9 +142,10 @@ data CreateCodebaseError
 
 createCodebaseOrError' ::
   MonadIO m =>
+  Codebase.DebugName ->
   CodebasePath ->
   m (Either CreateCodebaseError (m (), Codebase m Symbol Ann))
-createCodebaseOrError' path = do
+createCodebaseOrError' debugName path = do
   ifM
     (doesFileExist $ path </> codebasePath)
     (pure $ Left CreateCodebaseAlreadyExists)
@@ -145,8 +153,8 @@ createCodebaseOrError' path = do
       createDirectoryIfMissing True (path </> FilePath.takeDirectory codebasePath)
       liftIO $
         Control.Exception.bracket
-          (unsafeGetConnection path)
-          Sqlite.close
+          (unsafeGetConnection (debugName ++ ".createSchema") path)
+          shutdownConnection
           (runReaderT do
             Q.createSchema
             runExceptT (void . Ops.saveRootBranch $ Cv.causalbranch1to2 Branch.empty) >>= \case
@@ -154,26 +162,25 @@ createCodebaseOrError' path = do
               Right () -> pure ()
             )
 
-      fmap (Either.mapLeft CreateCodebaseUnknownSchemaVersion) (sqliteCodebase path)
+      fmap (Either.mapLeft CreateCodebaseUnknownSchemaVersion) (sqliteCodebase debugName path)
 
-openOrCreateCodebaseConnection :: MonadIO m => FilePath -> m Connection
-openOrCreateCodebaseConnection path = do
+openOrCreateCodebaseConnection :: MonadIO m => Codebase.DebugName -> FilePath -> m Connection
+openOrCreateCodebaseConnection debugName path = do
   unlessM
     (doesFileExist $ path </> codebasePath)
     (initSchemaIfNotExist path)
-  unsafeGetConnection path
-
+  unsafeGetConnection debugName path
 
 -- get the codebase in dir
-getCodebaseOrError :: forall m. MonadIO m => CodebasePath -> m (Either Codebase1.Pretty (m (), Codebase m Symbol Ann))
-getCodebaseOrError dir = do
+getCodebaseOrError :: forall m. MonadIO m => Codebase.DebugName -> CodebasePath -> m (Either Codebase1.Pretty (m (), Codebase m Symbol Ann))
+getCodebaseOrError debugName dir = do
   prettyDir <- liftIO $ P.string <$> canonicalizePath dir
   let prettyError v = P.wrap $ "I don't know how to handle " <> P.shown v <> "in" <> P.backticked' prettyDir "."
   doesFileExist (dir </> codebasePath) >>= \case
     -- If the codebase file doesn't exist, just return any string. The string is currently ignored (see
     -- Unison.Codebase.Init.getCodebaseOrExit).
     False -> pure (Left "codebase doesn't exist")
-    True -> fmap (Either.mapLeft prettyError) (sqliteCodebase dir)
+    True -> fmap (Either.mapLeft prettyError) (sqliteCodebase debugName dir)
 
 initSchemaIfNotExist :: MonadIO m => FilePath -> m ()
 initSchemaIfNotExist path = liftIO do
@@ -181,8 +188,8 @@ initSchemaIfNotExist path = liftIO do
     createDirectoryIfMissing True (path </> FilePath.takeDirectory codebasePath)
   unlessM (doesFileExist $ path </> codebasePath) $
     Control.Exception.bracket
-      (unsafeGetConnection path)
-      Sqlite.close
+      (unsafeGetConnection "initSchemaIfNotExist" path)
+      shutdownConnection
       (runReaderT Q.createSchema)
 
 -- checks if a db exists at `path` with the minimum schema
@@ -190,9 +197,9 @@ codebaseExists :: MonadIO m => CodebasePath -> m Bool
 codebaseExists root = liftIO do
   Monad.when debug $ traceM $ "codebaseExists " ++ root
   Control.Exception.catch @Sqlite.SQLError
-    ( sqliteCodebase root >>= \case
+    ( sqliteCodebase "codebaseExists" root >>= \case
         Left _ -> pure False
-        Right (close, _codebase) -> close >> pure True
+        Right (close, _codebase) -> close $> True
     )
     (const $ pure False)
 
@@ -245,17 +252,23 @@ type TermBufferEntry = BufferEntry (Term Symbol Ann, Type Symbol Ann)
 
 type DeclBufferEntry = BufferEntry (Decl Symbol Ann)
 
-unsafeGetConnection :: MonadIO m => CodebasePath -> m Sqlite.Connection
-unsafeGetConnection root = do
-  Monad.when debug $ traceM $ "unsafeGetconnection " ++ root ++ " -> " ++ (root </> codebasePath)
-  conn <- liftIO . Sqlite.open $ root </> codebasePath
+unsafeGetConnection :: MonadIO m => Codebase.DebugName -> CodebasePath -> m Connection
+unsafeGetConnection name root = do
+  let path = root </> codebasePath
+  Monad.when debug $ traceM $ "unsafeGetconnection " ++ name ++ " " ++ root ++ " -> " ++ path
+  (Connection name path -> conn) <- liftIO $ Sqlite.open path
   runReaderT Q.setFlags conn
   pure conn
 
-sqliteCodebase :: MonadIO m => CodebasePath -> m (Either SchemaVersion (m (), Codebase m Symbol Ann))
-sqliteCodebase root = do
-  Monad.when debug $ traceM $ "sqliteCodebase " ++ root
-  conn <- unsafeGetConnection root
+shutdownConnection :: MonadIO m => Connection -> m ()
+shutdownConnection conn = do
+  Monad.when debug $ traceM $ "shutdown connection " ++ show conn
+  liftIO $ Sqlite.close (Connection.underlying conn)
+
+sqliteCodebase :: MonadIO m => Codebase.DebugName -> CodebasePath -> m (Either SchemaVersion (m (), Codebase m Symbol Ann))
+sqliteCodebase debugName root = do
+  Monad.when debug $ traceM $ "sqliteCodebase " ++ debugName ++ " " ++ root
+  conn <- unsafeGetConnection debugName root
   termCache <- Cache.semispaceCache 8192 -- pure Cache.nullCache -- to disable
   typeOfTermCache <- Cache.semispaceCache 8192
   declCache <- Cache.semispaceCache 1024
@@ -573,14 +586,14 @@ sqliteCodebase root = do
           syncFromDirectory :: MonadIO m => Codebase1.CodebasePath -> SyncMode -> Branch m -> m ()
           syncFromDirectory srcRoot _syncMode b =
             flip State.evalStateT emptySyncProgressState $ do
-              srcConn <- unsafeGetConnection srcRoot
+              srcConn <- unsafeGetConnection (debugName ++ ".sync.src") srcRoot
               syncInternal syncProgress srcConn conn $ Branch.transform lift b
 
           syncToDirectory :: MonadIO m => Codebase1.CodebasePath -> SyncMode -> Branch m -> m ()
           syncToDirectory destRoot _syncMode b =
             flip State.evalStateT emptySyncProgressState $ do
               initSchemaIfNotExist destRoot
-              destConn <- unsafeGetConnection destRoot
+              destConn <- unsafeGetConnection (debugName ++ ".sync.dest") destRoot
               syncInternal syncProgress conn destConn $ Branch.transform lift b
 
           watches :: MonadIO m => UF.WatchKind -> m [Reference.Id]
@@ -698,12 +711,13 @@ sqliteCodebase root = do
               . (fmap . fmap) Cv.causalHash2to1
               $ Ops.lca (Cv.causalHash1to2 h1) (Cv.causalHash1to2 h2) c1 c2
             where
-              open = (,) <$> unsafeGetConnection root <*> unsafeGetConnection root
-              close (c1, c2) = Sqlite.close c1 *> Sqlite.close c2
+              open = (,) <$> unsafeGetConnection (debugName ++ ".lca.left") root
+                         <*> unsafeGetConnection (debugName ++ ".lca.left") root
+              close (c1, c2) = shutdownConnection c1 *> shutdownConnection c2
 
       let finalizer :: MonadIO m => m ()
           finalizer = do
-            liftIO $ Sqlite.close conn
+            shutdownConnection conn
             decls <- readTVarIO declBuffer
             terms <- readTVarIO termBuffer
             let printBuffer header b =
@@ -754,7 +768,7 @@ sqliteCodebase root = do
             (Just \l r -> runDB conn $ fromJust <$> before l r)
           in code
         )
-    v -> liftIO $ Sqlite.close conn $> Left v
+    v -> shutdownConnection conn $> Left v
 
 -- well one or the other. :zany_face: the thinking being that they wouldn't hash-collide
 termExists', declExists' :: MonadIO m => Hash -> ReaderT Connection (ExceptT Ops.Error m) Bool
@@ -981,7 +995,7 @@ viewRemoteBranch' (repo, sbh, path) = runExceptT do
   ifM
     (codebaseExists remotePath)
     do
-      lift (sqliteCodebase remotePath) >>= \case
+      lift (sqliteCodebase "viewRemoteBranch.gitCache" remotePath) >>= \case
         Left sv -> ExceptT . pure . Left $ GitError.UnrecognizedSchemaVersion repo remotePath sv
         Right (closeCodebase, codebase) -> do
           -- try to load the requested branch from it
@@ -1030,7 +1044,7 @@ pushGitRootBranch srcConn branch repo = runExceptT @GitError do
 
   -- set up the cache dir
   remotePath <- time "Git fetch" $ pullBranch repo
-  destConn <- openOrCreateCodebaseConnection remotePath
+  destConn <- openOrCreateCodebaseConnection "push.dest" remotePath
 
   flip runReaderT destConn $ Q.savepoint "push"
   lift . flip State.execStateT emptySyncProgressState $
@@ -1063,9 +1077,8 @@ pushGitRootBranch srcConn branch repo = runExceptT @GitError do
     Q.setJournalMode JournalMode.DELETE
 
   liftIO do
-    Sqlite.close destConn
+    shutdownConnection destConn
     void $ push remotePath repo
-
   where
     repoString = Text.unpack $ printRepo repo
     setRepoRoot :: Q.DB m => Branch.Hash -> m ()

--- a/parser-typechecker/tests/Unison/Test/Ucm.hs
+++ b/parser-typechecker/tests/Unison/Test/Ucm.hs
@@ -53,8 +53,8 @@ initCodebase fmt = do
   let cbInit = case fmt of CodebaseFormat1 -> FC.init; CodebaseFormat2 -> SC.init
   tmp <-
     Temp.getCanonicalTemporaryDirectory
-      >>= flip Temp.createTempDirectory ("ucm-test")
-  Codebase.Init.createCodebase cbInit tmp >>= \case
+      >>= flip Temp.createTempDirectory "ucm-test"
+  Codebase.Init.createCodebase cbInit "ucm-test" tmp >>= \case
     Left e -> fail $ P.toANSI 80 e
     Right (close, _cb) -> close
   pure $ Codebase tmp fmt
@@ -80,7 +80,7 @@ runTranscript (Codebase codebasePath fmt) transcript = do
   let err err = fail $ "Parse error: \n" <> show err
       cbInit = case fmt of CodebaseFormat1 -> FC.init; CodebaseFormat2 -> SC.init
   (closeCodebase, codebase) <-
-    Codebase.Init.openCodebase cbInit codebasePath >>= \case
+    Codebase.Init.openCodebase cbInit "transcript" codebasePath >>= \case
       Left e -> fail $ P.toANSI 80 e
       Right x -> pure x
   Codebase.installUcmDependencies codebase
@@ -100,6 +100,6 @@ runTranscript (Codebase codebasePath fmt) transcript = do
 lowLevel :: Codebase -> (Codebase.Codebase IO Symbol Ann -> IO a) -> IO a
 lowLevel (Codebase root fmt) f = do
   let cbInit = case fmt of CodebaseFormat1 -> FC.init; CodebaseFormat2 -> SC.init
-  Codebase.Init.openCodebase cbInit root >>= \case
+  Codebase.Init.openCodebase cbInit "lowLevel" root >>= \case
     Left p -> PT.putPrettyLn p *> pure (error "This really should have loaded")
     Right (close, cb) -> f cb <* close


### PR DESCRIPTION
`U.Codebase.Sqlite.Connection` replaces `Database.Sqlite.Simple.Connection` and adds a custom string identifier and the path to the database file, which are printed back to the console during debugging.

API functions that create codebases and database connections now allow/force you to provide a description for debugging.  API functions that create a codebase also allow/force you to provide a name that the codebase implementation may use for debug output.  (The V1 codebase implementation currently ignores the name.)

I used this to confirm that writes were going to the right databases when debugging #2068, though since that was _The Last Bug_, I'm not sure this is necessarily useful.

The PR also adds a centralized spot from which to close a v2 codebase db connections, which probably _is_ useful as I've implemented it twice now. (`Unison.Codebase.SqliteCodebase.shutdownConnection`).