### PR TITLE
Disable pager inside emacs

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -51,3 +51,4 @@ The format for this list: name, GitHub handle, and then optional blurb about wha
 * Sam Roberts (@samgqroberts)
 * Nigel Farrelly (@nini-faroux)
 * Johannes Huster (@JohannesHuster)
+* Joseph Morag (@jmorag)

--- a/parser-typechecker/src/Unison/Util/Less.hs
+++ b/parser-typechecker/src/Unison/Util/Less.hs
@@ -1,5 +1,6 @@
 module Unison.Util.Less where
 
+import System.Environment (lookupEnv)
 import System.Process
 import System.IO (hPutStr, hClose)
 import Control.Exception.Extra (ignore)
@@ -7,19 +8,23 @@ import Unison.Prelude (void)
 
 less :: String -> IO ()
 less str = do
-  let args = ["--no-init"            -- don't clear the screen on exit
-             ,"--raw-control-chars"  -- pass through colors and stuff
-             ,"--prompt=[less] Use space/arrow keys to navigate, or 'q' to return to ucm:"
-             ,"--quit-if-one-screen" -- self-explanatory
-             ]
-  (Just stdin, _stdout, _stderr, pid)
-    <- createProcess (proc "less" args) { std_in = CreatePipe }
+  inEmacs <- lookupEnv "INSIDE_EMACS"
+  case inEmacs of
+    Just _ -> putStr str
+    Nothing -> do
+      let args = ["--no-init"            -- don't clear the screen on exit
+                 ,"--raw-control-chars"  -- pass through colors and stuff
+                 ,"--prompt=[less] Use space/arrow keys to navigate, or 'q' to return to ucm:"
+                 ,"--quit-if-one-screen" -- self-explanatory
+                 ]
+      (Just stdin, _stdout, _stderr, pid)
+        <- createProcess (proc "less" args) { std_in = CreatePipe }
 
-  -- If `less` exits before consuming all of stdin, `hPutStr` will crash.
-  ignore $ hPutStr stdin str
+      -- If `less` exits before consuming all of stdin, `hPutStr` will crash.
+      ignore $ hPutStr stdin str
 
-  -- If `less` has already exited, hClose throws an exception.
-  ignore $ hClose stdin
+      -- If `less` has already exited, hClose throws an exception.
+      ignore $ hClose stdin
 
-  -- Wait for `less` to exit.
-  void $ waitForProcess pid
+      -- Wait for `less` to exit.
+      void $ waitForProcess pid


### PR DESCRIPTION
## Overview

Disables paging when running ucm inside emacs to prevent repeated `WARNING: terminal is not fully functional`. This is in anticipation of completing the in progress ucm emacs integration I'm working on: 

Before
![image](https://user-images.githubusercontent.com/24941170/120896672-8e96c300-c5f0-11eb-8de6-c0fa181b3e04.png)
After
![image](https://user-images.githubusercontent.com/24941170/120896695-a66e4700-c5f0-11eb-87bf-607afda7d78e.png)


## Implementation notes

Modifies the `less` function to check the `INSIDE_EMACS` environment variable, and if so, output the string directly to STDOUT without going through the `less` pager. Behavior in a normal terminal is unchanged.

## Interesting/controversial decisions

This could also be done by checking if the `TERM` environment variable is set to `dumb`, or using [hSupportsAnsi](https://hackage.haskell.org/package/ansi-terminal-0.11/docs/System-Console-ANSI.html#v:hSupportsANSI) to inspect the STDOUT handle. I'm not sure if those would cover any additional environments outside emacs, but I'm happy to change to one of those if you feel they'd be more idiomatic or robust.

## Test coverage

No additional tests, I'm not sure they'd be relevant for this change.

## Loose ends

It might be nice to disable ANSI colors as well for unsupported terminals. That's not necessary on emacs, though, and would probably require a bunch more invasive changes to the Pretty module, whereas this is a very minimal diff.