### PR TITLE
add parens around termLink and typeLink, according to ambient precedence

### DIFF
--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -122,6 +122,8 @@ data DocLiteralContext
 
      >=10
        10f 10x 10y ...
+       termLink t
+       typeLink t
 
      >=3
        x -> 2y
@@ -177,11 +179,13 @@ pretty0
       where name = elideFQN im $ HQ.unsafeFromVar (Var.reset v)
     Ref' r -> parenIfInfix name ic $ styleHashQualified'' (fmt $ S.Reference r) name
       where name = elideFQN im $ PrettyPrintEnv.termName n (Referent.Ref r)
-    TermLink' r -> parenIfInfix name ic $
-      fmt S.LinkKeyword "termLink " <> styleHashQualified'' (fmt $ S.Referent r) name
+    TermLink' r -> paren (p >= 10) $
+      fmt S.LinkKeyword "termLink " <>
+      (parenIfInfix name ic $ styleHashQualified'' (fmt $ S.Referent r) name)
       where name = elideFQN im $ PrettyPrintEnv.termName n r
-    TypeLink' r -> parenIfInfix name ic $
-      fmt S.LinkKeyword "typeLink " <> styleHashQualified'' (fmt $ S.Reference r) name
+    TypeLink' r -> paren (p >= 10) $
+      fmt S.LinkKeyword "typeLink " <>
+      (parenIfInfix name ic $ styleHashQualified'' (fmt $ S.Reference r) name)
       where name = elideFQN im $ PrettyPrintEnv.typeName n r
     Ann' tm t ->
       paren (p >= 0)

--- a/unison-src/transcripts-using-base/fix2027.output.md
+++ b/unison-src/transcripts-using-base/fix2027.output.md
@@ -59,7 +59,7 @@ myServer = unsafeRun! '(hello "127.0.0.1" "0")
   value:
   
     base.io.Failure.Failure
-      typeLink base.io.IOFailure "problem" !base.Any.Any
+      (typeLink base.io.IOFailure) "problem" !base.Any.Any
   
   I'm sorry this message doesn't have more detail about the
   location of the failure. My makers plan to fix this in a

--- a/unison-src/transcripts/bug-strange-closure.output.md
+++ b/unison-src/transcripts/bug-strange-closure.output.md
@@ -1028,7 +1028,7 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                                         (Left
                                           (SpecialForm.Link
                                             (Left
-                                              typeLink Optional))),
+                                              (typeLink Optional)))),
                                         !Lit
                                         (Right (Plain "is")),
                                         !Lit (Right (Plain "a")),
@@ -1890,7 +1890,7 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                               (!Lit
                                 (Left
                                   (SpecialForm.Source
-                                    [ (Left typeLink Optional,
+                                    [ (Left (typeLink Optional),
                                     []),
                                       (Right
                                       (Term.Term
@@ -1922,7 +1922,7 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                               (!Lit
                                 (Left
                                   (FoldedSource
-                                    [ (Left typeLink Optional,
+                                    [ (Left (typeLink Optional),
                                     []),
                                       (Right
                                       (Term.Term


### PR DESCRIPTION
## Overview

Change the pretty-printer so that it produces, for example:

```haskell
  t : ()
  t =
    t1 = termLink foo
    t2 = id (termLink foo)
    t3 = termLink (+++)
    ty1 = typeLink List
    ty2 = id (typeLink List)
    ()
```
whereas previously it would have produced
```haskell
  t : ()
  t =
    t1 = termLink foo
    t2 = id termLink foo
    t3 = (termLink +++)
    ty1 = typeLink List
    ty2 = id typeLink List
    ()
```
fixes #2050 

## Implementation notes

Tweak to termPrinter.

## Interesting/controversial decisions

None.

## Test coverage

Alas, none.  The termPrinter test harness can't furnish me with actual terms to get links to.  I have checked the example above as a one-off though. 

## Loose ends

None.
