### PR TITLE
more tolerant git cache

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
@@ -18,6 +18,7 @@ import UnliftIO.Directory (XdgDirectory (XdgCache), doesDirectoryExist, findExec
 import UnliftIO.IO (hFlush, stdout)
 import qualified Data.ByteString.Base16 as ByteString
 import qualified Data.Char as Char
+import Control.Exception.Safe (catchIO, MonadCatch)
 
 type CodebasePath = FilePath
 
@@ -55,7 +56,7 @@ withStatus str ma = do
 
 -- | Given a remote git repo url, and branch/commit hash (currently
 -- not allowed): checks for git, clones or updates a cached copy of the repo
-pullBranch :: (MonadIO m, MonadError GitError m) => RemoteRepo -> m CodebasePath
+pullBranch :: (MonadIO m, MonadCatch m, MonadError GitError m) => RemoteRepo -> m CodebasePath
 pullBranch (GitRepo _uri (Just t)) = error $
   "Pulling a specific commit isn't fully implemented or tested yet.\n" ++
   "InputPatterns.parseUri was expected to have prevented you " ++
@@ -86,18 +87,24 @@ pullBranch repo@(GitRepo uri Nothing) = do
     unless isGitDir . throwError $ GitError.UnrecognizableCheckoutDir uri localPath
 
   -- | Do a `git pull` on a cached repo.
-  checkoutExisting :: (MonadIO m, MonadError GitError m) => FilePath -> m ()
+  checkoutExisting :: (MonadIO m, MonadCatch m, MonadError GitError m) => FilePath -> m ()
   checkoutExisting localPath =
     ifM (isEmptyGitRepo localPath)
       -- I don't know how to properly update from an empty remote repo.
       -- As a heuristic, if this cached copy is empty, then the remote might
       -- be too, so this impl. just wipes the cached copy and starts from scratch.
-      (do wipeDir localPath; checkOutNew localPath Nothing)
-    -- Otherwise proceed!
-    (withStatus ("Updating cached copy of " ++ Text.unpack uri ++ " ...") $ do
-      gitIn localPath ["reset", "--hard", "--quiet", "HEAD"]
-      gitIn localPath ["clean", "-d", "--force", "--quiet"]
-      gitIn localPath ["pull", "--force", "--quiet"])
+      goFromScratch
+      -- Otherwise proceed!
+      (catchIO
+        (withStatus ("Updating cached copy of " ++ Text.unpack uri ++ " ...") $ do
+          gitIn localPath ["reset", "--hard", "--quiet", "HEAD"]
+          gitIn localPath ["clean", "-d", "--force", "--quiet"]
+          gitIn localPath ["pull", "--force", "--quiet"])
+        (const $ goFromScratch))
+
+    where
+      goFromScratch :: (MonadIO m, MonadError GitError m) => m  ()
+      goFromScratch = do wipeDir localPath; checkOutNew localPath Nothing
 
   isEmptyGitRepo :: MonadIO m => FilePath -> m Bool
   isEmptyGitRepo localPath = liftIO $

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -260,7 +260,7 @@ branchHeadUpdates root = do
 
 -- * Git stuff
 
-viewRemoteBranch' :: forall m. MonadIO m
+viewRemoteBranch' :: forall m. (MonadIO m, MonadCatch m)
   => Branch.Cache m -> RemoteNamespace -> ExceptT GitError m (Branch m, CodebasePath)
 viewRemoteBranch' cache (repo, sbh, path) = do
   -- set up the cache dir
@@ -289,7 +289,7 @@ viewRemoteBranch' cache (repo, sbh, path) = do
 -- Given a branch that is "after" the existing root of a given git repo,
 -- stage and push the branch (as the new root) + dependencies to the repo.
 pushGitRootBranch
-  :: MonadIO m
+  :: (MonadIO m, MonadCatch m)
   => Codebase.SyncToDir m
   -> Branch.Cache m
   -> Branch m

--- a/parser-typechecker/tests/Unison/Test/GitSync.hs
+++ b/parser-typechecker/tests/Unison/Test/GitSync.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Unison.Test.GitSync where
 
@@ -31,6 +32,7 @@ test :: Test ()
 test = scope "gitsync22" . tests $
   fastForwardPush :
   nonFastForwardPush :
+  destroyedRemote :
   flip map [(Ucm.CodebaseFormat1 , "fc"), (Ucm.CodebaseFormat2, "sc")]
   \(fmt, name) -> scope name $ tests [
   pushPullTest  "typeAlias" fmt
@@ -485,6 +487,30 @@ nonFastForwardPush = scope "non-fastforward-push" do
       ```
     |]
   ok
+
+destroyedRemote :: Test()
+destroyedRemote = scope "destroyed-remote" do
+  io do
+    repo <- initGitRepo
+    codebase <- Ucm.initCodebase Ucm.CodebaseFormat2
+    void $ Ucm.runTranscript codebase [i|
+      ```ucm
+      .lib> alias.type ##Nat Nat
+      .lib> push ${repo}
+      ```
+    |]
+    reinitRepo repo
+    void $ Ucm.runTranscript codebase [i|
+      ```ucm
+      .lib> push ${repo}
+      ```
+    |]
+  ok
+  where
+    reinitRepo (Text.pack -> repo) = do
+      "rm" ["-rf", repo]
+      "git" ["init", "--bare", repo]
+
 
 initGitRepo :: IO FilePath
 initGitRepo = do


### PR DESCRIPTION
This PR wipes away a cached git repo if there's an `IOError` when pulling to it. Closes #1962 

I don't know if there's a way to avoid adding the `MonadCatch` constraint.