### PR TITLE
Allow identifiers to start with `type` or `ability`

### DIFF
--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -296,7 +296,7 @@ lexemes' eof = P.optional space >> do
      <|> token symbolyId <|> token blank <|> token wordyId
      <|> (asum . map token) [ semi, textual, backticks, hash ]
 
-  wordySep c = isSpace c || not (isAlphaNum c)
+  wordySep c = isSpace c || not (wordyIdChar c)
   positioned p = do start <- pos; a <- p; stop <- pos; pure (start, a, stop)
 
   tok :: P a -> P [Token a]

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -327,9 +327,10 @@ lexemes' eof = P.optional space >> do
           isTopLevel = length (layout env0) + maybe 0 (const 1) (opening env0) == 1
       _ -> docToks <> endToks
     where
+    wordyKw kw = separated wordySep (lit kw)
     subsequentTypeName = P.lookAhead . P.optional $ do
       let lit' s = lit s <* sp
-      _ <- P.optional (lit' "unique") *> (lit' "type" <|> lit' "ability")
+      _ <- P.optional (lit' "unique") *> (wordyKw "type" <|> wordyKw "ability") <* sp
       wordyId
     ignore _ _ _ = []
     body = join <$> P.many (sectionElem <* CP.space)
@@ -791,7 +792,7 @@ lexemes' eof = P.optional space >> do
       where
         ifElse = openKw "if" <|> close' (Just "then") ["if"] (lit "then")
                              <|> close' (Just "else") ["then"] (lit "else")
-        typ = openKw1 "unique" <|> openTypeKw1 "type" <|> openTypeKw1 "ability"
+        typ = openKw1 wordySep "unique" <|> openTypeKw1 "type" <|> openTypeKw1 "ability"
 
         withKw = do
           [Token _ pos1 pos2] <- wordyKw "with"
@@ -811,13 +812,13 @@ lexemes' eof = P.optional space >> do
         openTypeKw1 t = do
           b <- S.gets (topBlockName . layout)
           case b of Just "unique" -> wordyKw t
-                    _             -> openKw1 t
+                    _             -> openKw1 wordySep t
 
         -- layout keyword which bumps the layout column by 1, rather than looking ahead
         -- to the next token to determine the layout column
-        openKw1 :: String -> P [Token Lexeme]
-        openKw1 kw = do
-          (pos0, kw, pos1) <- positioned $ lit kw
+        openKw1 :: (Char -> Bool) -> String -> P [Token Lexeme]
+        openKw1 sep kw = do
+          (pos0, kw, pos1) <- positioned $ separated sep (lit kw)
           S.modify (\env -> env { layout = (kw, column $ inc pos0) : layout env })
           pure [Token (Open kw) pos0 pos1]
 

--- a/unison-src/transcripts/fix2091.md
+++ b/unison-src/transcripts/fix2091.md
@@ -8,4 +8,11 @@ type! = 3943
 type' = 238448
 ability! = 384
 ability'' = 90
+
+-- this type is the same as `type Either a b = Left a | Right b`
+-- but with very confusing names
+-- seriously don't ever do this
+type type! type_ ability_ = ability' type_ | type! type_
+
+unique type type!!! type_ ability_ = ability' type_ | type! type_
 ```

--- a/unison-src/transcripts/fix2091.md
+++ b/unison-src/transcripts/fix2091.md
@@ -1,4 +1,5 @@
 
 ```unison
 typesAndTerms = "I am a variable"
+ability1 = 99
 ```

--- a/unison-src/transcripts/fix2091.md
+++ b/unison-src/transcripts/fix2091.md
@@ -2,4 +2,10 @@
 ```unison
 typesAndTerms = "I am a variable"
 ability1 = 99
+type_ = 292
+ability_1 = 30394
+type! = 3943
+type' = 238448
+ability! = 384
+ability'' = 90
 ```

--- a/unison-src/transcripts/fix2091.md
+++ b/unison-src/transcripts/fix2091.md
@@ -1,0 +1,4 @@
+
+```unison
+typesAndTerms = "I am a variable"
+```

--- a/unison-src/transcripts/fix2091.output.md
+++ b/unison-src/transcripts/fix2091.output.md
@@ -1,6 +1,7 @@
 
 ```unison
 typesAndTerms = "I am a variable"
+ability1 = 99
 ```
 
 ```ucm
@@ -11,6 +12,7 @@ typesAndTerms = "I am a variable"
   
     ⍟ These new definitions are ok to `add`:
     
+      ability1      : ##Nat
       typesAndTerms : ##Text
 
 ```

--- a/unison-src/transcripts/fix2091.output.md
+++ b/unison-src/transcripts/fix2091.output.md
@@ -1,0 +1,16 @@
+
+```unison
+typesAndTerms = "I am a variable"
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      typesAndTerms : ##Text
+
+```

--- a/unison-src/transcripts/fix2091.output.md
+++ b/unison-src/transcripts/fix2091.output.md
@@ -2,6 +2,12 @@
 ```unison
 typesAndTerms = "I am a variable"
 ability1 = 99
+type_ = 292
+ability_1 = 30394
+type! = 3943
+type' = 238448
+ability! = 384
+ability'' = 90
 ```
 
 ```ucm
@@ -12,7 +18,13 @@ ability1 = 99
   
     ⍟ These new definitions are ok to `add`:
     
+      ability!      : ##Nat
+      ability''     : ##Nat
       ability1      : ##Nat
+      ability_1     : ##Nat
+      type!         : ##Nat
+      type'         : ##Nat
+      type_         : ##Nat
       typesAndTerms : ##Text
 
 ```

--- a/unison-src/transcripts/fix2091.output.md
+++ b/unison-src/transcripts/fix2091.output.md
@@ -8,6 +8,13 @@ type! = 3943
 type' = 238448
 ability! = 384
 ability'' = 90
+
+-- this type is the same as `type Either a b = Left a | Right b`
+-- but with very confusing names
+-- seriously don't ever do this
+type type! type_ ability_ = ability' type_ | type! type_
+
+unique type type!!! type_ ability_ = ability' type_ | type! type_
 ```
 
 ```ucm
@@ -18,6 +25,8 @@ ability'' = 90
   
     ⍟ These new definitions are ok to `add`:
     
+      type type! type_ ability_
+      unique type type!!! type_ ability_
       ability!      : ##Nat
       ability''     : ##Nat
       ability1      : ##Nat


### PR DESCRIPTION
Fixes #2091. 

The lexer was prematurely committing to the keyword branch even when it was followed by more identifier characters. Checking that the next character isn't an identifier character fixes it. 

I added a few more tests to the transcript that were also failing previously.

```Haskell
-- technically legal Unison syntax
-- this type is the same as `type Either a b = Left a | Right b`
type type! type_ ability_ = ability' type_ | type! type_
```