### PR TITLE
Simplify regression test to not pull all of base

### DIFF
--- a/unison-src/transcripts-using-base/fix2027.md
+++ b/unison-src/transcripts-using-base/fix2027.md
@@ -2,10 +2,18 @@
 
 ```ucm:hide
 .> builtins.mergeio
-.> pull https://github.com/unisonweb/base_v2:.trunk .base
 ```
 
 ```unison
+ability Exception where raise : Failure -> x
+
+reraise = cases
+  Left e -> raise e
+  Right a -> a
+
+type Either a b = Left a | Right b
+
+putBytes h bs = reraise (putBytes.impl h bs)
 
 toException : Either Failure a ->{Exception} a
 toException = cases
@@ -19,25 +27,29 @@ bugFail = cases
   Failure typ _ _ -> bug (Failure typ "problem" (Any ()))
 
 Exception.unsafeRun! : '{Exception, g} a -> '{g} a
-Exception.unsafeRun! e _ = 
-    h : Request {Exception} a -> a 
-    h = cases 
-        {Exception.raise fail -> _ } -> 
+Exception.unsafeRun! e _ =
+    h : Request {Exception} a -> a
+    h = cases
+        {Exception.raise fail -> _ } ->
             bugFail fail
-        {a} -> a 
-    handle !e with h 
+        {a} -> a
+    handle !e with h
+
+socketSend s bytes = reraise (socketSend.impl s bytes)
+closeSocket s = reraise (closeSocket.impl s)
+serverSocket host port = reraise (serverSocket.impl host port)
 
 hello : Text -> Text -> {IO, Exception} ()
-hello host port = 
+hello host port =
     socket = serverSocket (Some host) port
-    msg = toUtf8 "Hello there" 
+    msg = toUtf8 "Hello there"
     socketSend socket msg
-    closeSocket socket 
+    closeSocket socket
 
 myServer = unsafeRun! '(hello "127.0.0.1" "0")
 
 ```
 
 ```ucm:error
-.> run myServer 
+.> run myServer
 ```

--- a/unison-src/transcripts-using-base/fix2027.output.md
+++ b/unison-src/transcripts-using-base/fix2027.output.md
@@ -52,28 +52,34 @@ myServer = unsafeRun! '(hello "127.0.0.1" "0")
   do an `add` or `update`, here's how your codebase would
   change:
   
+    ⊡ Previously added definitions will be ignored: Exception
+      Exception.raise
+    
     ⍟ These new definitions are ok to `add`:
     
       type Either a b
         (also named builtin.Either)
-      ability Exception
       Exception.unsafeRun! : '{g, Exception} a -> '{g} a
       bugFail              : Failure -> r
-      closeSocket          : Socket ->{IO, Exception} ()
       hello                : Text -> Text ->{IO, Exception} ()
       myServer             : '{IO} ()
-      putBytes             : Handle
-                             -> Bytes
-                             ->{IO, Exception} ()
       putText              : Handle -> Text ->{IO, Exception} ()
       reraise              : Either Failure b ->{Exception} b
-      serverSocket         : Optional Text
-                             -> Text
-                             ->{IO, Exception} Socket
+        (also named Exception.reraise)
       socketSend           : Socket
                              -> Bytes
                              ->{IO, Exception} ()
       toException          : Either Failure a ->{Exception} a
+        (also named Exception.reraise)
+    
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      closeSocket  : Socket ->{IO, Exception} ()
+      putBytes     : Handle -> Bytes ->{IO, Exception} ()
+      serverSocket : Optional Text
+                     -> Text
+                     ->{IO, Exception} Socket
 
 ```
 ```ucm

--- a/unison-src/transcripts-using-base/fix2027.output.md
+++ b/unison-src/transcripts-using-base/fix2027.output.md
@@ -1,6 +1,16 @@
 
 
 ```unison
+ability Exception where raise : Failure -> x
+
+reraise = cases
+  Left e -> raise e
+  Right a -> a
+
+type Either a b = Left a | Right b
+
+putBytes h bs = reraise (putBytes.impl h bs)
+
 toException : Either Failure a ->{Exception} a
 toException = cases
   Left e -> raise e
@@ -13,20 +23,24 @@ bugFail = cases
   Failure typ _ _ -> bug (Failure typ "problem" (Any ()))
 
 Exception.unsafeRun! : '{Exception, g} a -> '{g} a
-Exception.unsafeRun! e _ = 
-    h : Request {Exception} a -> a 
-    h = cases 
-        {Exception.raise fail -> _ } -> 
+Exception.unsafeRun! e _ =
+    h : Request {Exception} a -> a
+    h = cases
+        {Exception.raise fail -> _ } ->
             bugFail fail
-        {a} -> a 
-    handle !e with h 
+        {a} -> a
+    handle !e with h
+
+socketSend s bytes = reraise (socketSend.impl s bytes)
+closeSocket s = reraise (closeSocket.impl s)
+serverSocket host port = reraise (serverSocket.impl host port)
 
 hello : Text -> Text -> {IO, Exception} ()
-hello host port = 
+hello host port =
     socket = serverSocket (Some host) port
-    msg = toUtf8 "Hello there" 
+    msg = toUtf8 "Hello there"
     socketSend socket msg
-    closeSocket socket 
+    closeSocket socket
 
 myServer = unsafeRun! '(hello "127.0.0.1" "0")
 
@@ -40,26 +54,40 @@ myServer = unsafeRun! '(hello "127.0.0.1" "0")
   
     ⍟ These new definitions are ok to `add`:
     
+      type Either a b
+        (also named builtin.Either)
+      ability Exception
       Exception.unsafeRun! : '{g, Exception} a -> '{g} a
       bugFail              : Failure -> r
+      closeSocket          : Socket ->{IO, Exception} ()
       hello                : Text -> Text ->{IO, Exception} ()
       myServer             : '{IO} ()
+      putBytes             : Handle
+                             -> Bytes
+                             ->{IO, Exception} ()
       putText              : Handle -> Text ->{IO, Exception} ()
+      reraise              : Either Failure b ->{Exception} b
+      serverSocket         : Optional Text
+                             -> Text
+                             ->{IO, Exception} Socket
+      socketSend           : Socket
+                             -> Bytes
+                             ->{IO, Exception} ()
       toException          : Either Failure a ->{Exception} a
-        (also named Exception.reraise , base.Either.toException
-        , and base.Exception.reraise)
 
 ```
 ```ucm
-.> run myServer 
+.> run myServer
 
   💔💥
   
   I've encountered a call to builtin.bug with the following
   value:
   
-    base.io.Failure.Failure
-      (typeLink base.io.IOFailure) "problem" !base.Any.Any
+    builtin.io2.Failure.Failure
+      (typeLink builtin.io2.IOFailure)
+      "problem"
+      !builtin.Any.Any
   
   I'm sorry this message doesn't have more detail about the
   location of the failure. My makers plan to fix this in a


### PR DESCRIPTION
Minor cleanup. I noticed the regression test for #2027 was downloading all of base every time it was run. I just made the transcript self-contained so it includes exactly those parts of base that are needed to reproduce the original test case.