### PR TITLE
make the "latest" prerelease contain both arches like the tagged rele…

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -7,34 +7,17 @@ on:
     types:
       - completed
 jobs:
-  pre-release:
-    name: ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+  build_linux:
 
-    strategy:
-      # Run each build to completion, regardless of if any have failed
-      fail-fast: false
-
-      matrix:
-        os:
-          - ubuntu-20.04
-          - macOS-10.15
+    name: "build_linux"
+    runs-on: ubuntu-18.04
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: install stack (Linux)
-        if: runner.os == 'Linux'
+      - name: install stack
         run: |
           curl -L https://github.com/commercialhaskell/stack/releases/download/v2.5.1/stack-2.5.1-linux-x86_64.tar.gz | tar -xz
           echo "$HOME/stack-2.5.1-linux-x86_64/" >> $GITHUB_PATH
-      - name: install stack (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.5.1/stack-2.5.1-osx-x86_64.tar.gz | tar -xz
-          echo "$HOME/stack-2.5.1-osx-x86_64/" >> $GITHUB_PATH
-
 
       # One of the transcripts fails if the user's git name hasn't been set.
       - name: set git user info
@@ -42,13 +25,8 @@ jobs:
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
 
-      - name: remove ~/.stack/setup-exe-cache on macOS
-        if: runner.os == 'macOS'
-        run: rm -rf ~/.stack/setup-exe-cache
-
       - name: build
-        run: stack --no-terminal build --ghc-options -O2
-
+        run: stack --no-terminal build --flag unison-parser-typechecker:optimized
 
       - name: fetch latest codebase-ui and package with ucm
         run: |
@@ -57,12 +35,77 @@ jobs:
           cp $UCM /tmp/ucm/ucm
           wget -O/tmp/ucm.zip https://github.com/unisonweb/codebase-ui/releases/download/latest/ucm.zip
           unzip -d /tmp/ucm/ui /tmp/ucm.zip
-          tar -c -z -f unison-${{runner.os}}.tar.gz -C /tmp/ucm .
+          tar -c -z -f ucm-linux.tar.gz -C /tmp/ucm .
 
+      - name: Upload linux artifact
+        uses: actions/upload-artifact@v2
+        with:
+          if-no-files-found: error
+          name: build-linux
+          path: ucm-linux.tar.gz
+
+  build_macos:
+    name: "build_macos"
+    runs-on: macos-10.15
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: install stack
+        run: |
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.5.1/stack-2.5.1-osx-x86_64.tar.gz | tar -xz
+          echo "$HOME/stack-2.5.1-osx-x86_64/" >> $GITHUB_PATH
+
+      # One of the transcripts fails if the user's git name hasn't been set.
+      - name: set git user info
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+
+      - name: remove ~/.stack/setup-exe-cache on macOS
+        run: rm -rf ~/.stack/setup-exe-cache
+
+      - name: build
+        run: stack --no-terminal build --flag unison-parser-typechecker:optimized
+
+      - name: fetch latest codebase-ui and package with ucm
+        run: |
+          mkdir -p /tmp/ucm/ui
+          UCM=$(stack path | awk '/local-install-root/{print $2}')/bin/unison
+          cp $UCM /tmp/ucm/ucm
+          wget -O/tmp/ucm.zip https://github.com/unisonweb/codebase-ui/releases/download/latest/ucm.zip
+          unzip -d /tmp/ucm/ui /tmp/ucm.zip
+          tar -c -z -f ucm-macos.tar.gz -C /tmp/ucm .
+
+      - name: Upload macos artifact
+        uses: actions/upload-artifact@v2
+        with:
+          if-no-files-found: error
+          name: build-macos
+          path: ucm-macos.tar.gz
+
+
+  release:
+    name: "create_release"
+    runs-on: "ubuntu-latest"
+    needs:
+      - build_linux
+      - build_macos
+
+    steps:
+      - name: make download dir
+        run: "mkdir /tmp/ucm"
+
+      - name: "download artifacts"
+        uses: actions/download-artifact@v2
+        with:
+          path: /tmp/ucm
+
+
+      - uses: actions/checkout@v2
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "latest-${{runner.os}}"
+          automatic_release_tag: "latest"
           prerelease: true
           title: "Development Build"
-          files: "unison-${{runner.os}}.tar.gz"
+          files: /tmp/ucm/**/*.tar.gz

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,72 +19,37 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
-          tag_name: "${{github.ref}}"
-          release_name: "${{github.ref}}"
-
-  build:
-    name: "build ${{ matrix.os }}"
-    runs-on: ${{ matrix.os }}
-    needs: "release"
-
-    strategy:
-      # Run each build to completion, regardless of if any have failed
-      fail-fast: false
-
-      matrix:
-        os:
-          - ubuntu-18.04
-          - macOS-10.15
-        include:
-          - os: ubuntu-20.04
-            archive: ucm-linux.tar.gz
-          - os: macOS-10.15
-            archive: ucm-macos.tar.gz
+          if-no-files-found: error
+          name: build-linux
+          path: ucm-linux.tar.gz
+  
+  release:
+    name: "create_release"
+    runs-on: "ubuntu-latest"
+    needs:
+      - build_linux
+      - build_macos
 
     steps:
       - uses: actions/checkout@v2
+      - name: echo upload_url
+        run: "echo ${{ steps.create_release.outputs.upload_url }}"
 
-      - name: install stack (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.5.1/stack-2.5.1-linux-x86_64.tar.gz | tar -xz
-          echo "$HOME/stack-2.5.1-linux-x86_64/" >> $GITHUB_PATH
-      - name: install stack (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.5.1/stack-2.5.1-osx-x86_64.tar.gz | tar -xz
-          echo "$HOME/stack-2.5.1-osx-x86_64/" >> $GITHUB_PATH
+      - name: make download dir
+        run: "mkdir /tmp/ucm"
 
-
-      # One of the transcripts fails if the user's git name hasn't been set.
-      - name: set git user info
-        run: |
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "actions@github.com"
-
-      - name: remove ~/.stack/setup-exe-cache on macOS
-        if: runner.os == 'macOS'
-        run: rm -rf ~/.stack/setup-exe-cache
-
-      - name: build
-        run: stack --no-terminal build --flag unison-parser-typechecker:optimized
-
-      - name: fetch latest codebase-ui and package with ucm
-        run: |
-          mkdir -p /tmp/ucm/ui
-          UCM=$(stack path | awk '/local-install-root/{print $2}')/bin/unison
-          cp $UCM /tmp/ucm/ucm
-          wget -O/tmp/ucm.zip https://github.com/unisonweb/codebase-ui/releases/download/latest/ucm.zip
-          unzip -d /tmp/ucm/ui /tmp/ucm.zip
-          tar -c -z -f ${{matrix.archive}} -C /tmp/ucm .
-
-      - name: "Upload ${{matrix.archive}}"
-        uses: "actions/upload-release-asset@v1"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: "download artifacts"
+        uses: actions/download-artifact@v2
         with:
-          asset_path: "${{ matrix.archive }}"
-          asset_name: "${{ matrix.archive }}"
-          upload_url: ${{ needs.release.outputs.upload_url }}
-          asset_content_type: "application/gzip"
+          path: /tmp/ucm
+
+      - name: "see what we got"
+        run: "ls -R /tmp/ucm"
+
+      - name: make a release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: /tmp/ucm/**/*.tar.gz
 


### PR DESCRIPTION
This uses what we learned yesterday about GHA in order to make the automated `latest` releases be multi-arch like our tagged releases