### PR TITLE
add `debug.clear-cache` ucm command

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
@@ -717,6 +717,9 @@ saveWatch w r t = do
   let bytes = S.putBytes S.putWatchResultFormat (uncurry S.Term.WatchResult wterm)
   Q.saveWatch w rs bytes
 
+clearWatches :: DB m => m ()
+clearWatches = Q.clearWatches
+
 c2wTerm :: EDB m => C.Term Symbol -> m (WatchLocalIds, S.Term.Term)
 c2wTerm tm = c2xTerm Q.saveText Q.saveHashHash tm Nothing <&> \(w, tm, _) -> (w, tm)
 

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -431,6 +431,7 @@ clearWatches :: DB m => m ()
 clearWatches = do
   execute_ "DELETE FROM watch_result"
   execute_ "DELETE FROM watch"
+  execute_ "VACUUM"
 
 -- * Index-building
 addToTypeIndex :: DB m => Reference' TextId HashId -> Referent.Id -> m ()

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -427,6 +427,11 @@ loadWatchesByWatchKind k = query sql (Only k) where sql = [here|
   SELECT hash_id, component_index FROM watch WHERE watch_kind_id = ?
 |]
 
+clearWatches :: DB m => m ()
+clearWatches = do
+  execute_ "DELETE FROM watch_result"
+  execute_ "DELETE FROM watch"
+
 -- * Index-building
 addToTypeIndex :: DB m => Reference' TextId HashId -> Referent.Id -> m ()
 addToTypeIndex tp tm = execute sql (tp :. tm) where sql = [here|

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -95,6 +95,7 @@ data Codebase m v a =
            , watches            :: UF.WatchKind -> m [Reference.Id]
            , getWatch           :: UF.WatchKind -> Reference.Id -> m (Maybe (Term v a))
            , putWatch           :: UF.WatchKind -> Reference.Id -> Term v a -> m ()
+           , clearWatches       :: m ()
 
            , getReflog          :: m [Reflog.Entry]
            , appendReflog       :: Text -> Branch m -> Branch m -> m ()

--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -231,6 +231,8 @@ data Command m i v a where
   RuntimeMain :: Command m i v (Type v Ann)
   RuntimeTest :: Command m i v (Type v Ann)
 
+  ClearWatchCache :: Command m i v ()
+
 type UseCache = Bool
 
 type EvalResult v =
@@ -290,3 +292,4 @@ commandName = \case
   LoadSearchResults{}         -> "LoadSearchResults"
   GetDefinitionsBySuffixes{}  -> "GetDefinitionsBySuffixes"
   FindShallow{}               -> "FindShallow"
+  ClearWatchCache{}           -> "ClearWatchCache"

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -177,6 +177,7 @@ commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSour
     GetDefinitionsBySuffixes mayPath branch query ->
       lift . runExceptT $ Backend.definitionsBySuffixes mayPath branch codebase query
     FindShallow path -> lift . runExceptT $ Backend.findShallow codebase path
+    ClearWatchCache -> lift $ Codebase.clearWatches codebase
 
   watchCache (Reference.DerivedId h) = do
     m1 <- Codebase.getWatch codebase UF.RegularWatch h

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -466,6 +466,7 @@ loop = do
           DebugBranchHistoryI{} -> wat
           DebugTypecheckedUnisonFileI{} -> wat
           DebugDumpNamespacesI{} -> wat
+          DebugClearWatchI {} -> wat
           QuitI{} -> wat
           DeprecateTermI{} -> undefined
           DeprecateTypeI{} -> undefined
@@ -1822,6 +1823,7 @@ loop = do
                 prettyDefn renderR (r, (Foldable.toList -> names, Foldable.toList -> links)) =
                   P.lines (P.shown <$> if null names then [NameSegment "<unnamed>"] else names) <> P.newline <> prettyLinks renderR r links
         void . eval . Eval . flip State.execStateT mempty $ goCausal [getCausal root']
+      DebugClearWatchI {} -> eval ClearWatchCache
       DeprecateTermI {} -> notImplemented
       DeprecateTypeI {} -> notImplemented
       RemoveTermReplacementI from patchPath ->

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -137,6 +137,7 @@ data Input
   | DebugBranchHistoryI
   | DebugTypecheckedUnisonFileI
   | DebugDumpNamespacesI
+  | DebugClearWatchI
   | QuitI
   deriving (Eq, Show)
 

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -67,7 +67,7 @@ import Unison.Codebase.FileCodebase.Common
     typeMentionsIndexDir,
     typeReferencesByPrefix,
     updateCausalHead,
-    watchesDir,
+    watchesDir, codebasePath
   )
 import qualified Unison.Codebase.FileCodebase.Common as Common
 import qualified Unison.Codebase.FileCodebase.SlimCopyRegenerateIndex as Sync
@@ -90,7 +90,7 @@ import qualified Unison.Util.Pretty as P
 import qualified Unison.Util.TQueue as TQueue
 import U.Util.Timing (time)
 import Unison.Var (Var)
-import UnliftIO.Directory (createDirectoryIfMissing, doesDirectoryExist)
+import UnliftIO.Directory (createDirectoryIfMissing, doesDirectoryExist, removeDirectoryRecursive)
 import UnliftIO.STM (atomically)
 
 init :: (MonadIO m, MonadCatch m) => Codebase.Init m Symbol Ann
@@ -169,6 +169,7 @@ codebase1' syncToDirectory branchCache fmtV@(S.Format getV putV) fmtA@(S.Format 
           watches
           (getWatch getV getA path)
           (putWatch putV putA path)
+          (removeDirectoryRecursive $ path </> codebasePath </> "watches")
           getReflog
           appendReflog
           getTermsOfType

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -623,6 +623,9 @@ sqliteCodebase debugName root = do
                   (Cv.term1to2 h tm)
           putWatch _unknownKind _ _ = pure ()
 
+          clearWatches :: MonadIO m => m ()
+          clearWatches = runDB conn Ops.clearWatches
+
           getReflog :: MonadIO m => m [Reflog.Entry]
           getReflog =
             liftIO $
@@ -755,6 +758,7 @@ sqliteCodebase debugName root = do
             watches
             getWatch
             putWatch
+            clearWatches
             getReflog
             appendReflog
             termsOfTypeImpl

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -1309,6 +1309,12 @@ debugDumpNamespace = InputPattern
   "Dump the namespace to a text file"
   (const $ Right Input.DebugDumpNamespacesI)
 
+debugClearWatchCache :: InputPattern
+debugClearWatchCache = InputPattern
+  "debug.clear-cache" [] [(Required, noCompletions)]
+  "Clear the watch expression cache"
+  (const $ Right Input.DebugClearWatchI)
+
 test :: InputPattern
 test = InputPattern "test" [] []
     "`test` runs unit tests for the current branch."
@@ -1437,6 +1443,7 @@ validInputs =
   , debugBranchHistory
   , debugFileHashes
   , debugDumpNamespace
+  , debugClearWatchCache
   ]
 
 commandNames :: [String]

--- a/parser-typechecker/tests/Suite.hs
+++ b/parser-typechecker/tests/Suite.hs
@@ -9,6 +9,7 @@ import           System.IO
 import qualified Unison.Core.Test.Name as Name
 import qualified Unison.Test.ABT as ABT
 import qualified Unison.Test.Cache as Cache
+import qualified Unison.Test.ClearCache as ClearCache
 import qualified Unison.Test.Codebase as Codebase
 import qualified Unison.Test.Codebase.Causal as Causal
 import qualified Unison.Test.Codebase.FileCodebase as FileCodebase
@@ -65,6 +66,7 @@ test = tests
   , MCode.test
   , Var.test
   , Codebase.test
+  , ClearCache.test
   , Typechecker.test
   , UriParser.test
   , Context.test

--- a/parser-typechecker/tests/Unison/Test/ClearCache.hs
+++ b/parser-typechecker/tests/Unison/Test/ClearCache.hs
@@ -12,7 +12,7 @@ import qualified Unison.Var as WatchKind
 
 test :: Test ()
 test = scope "clearWatchCache" $
-  for_ [minBound .. maxBound] \fmt -> scope (show fmt) do
+  for_ [minBound @Ucm.CodebaseFormat ..] \fmt -> scope (show fmt) do
     c <- io $ Ucm.initCodebase fmt
     let listWatches = io $ Ucm.lowLevel c \c ->
           Codebase.watches c WatchKind.RegularWatch

--- a/parser-typechecker/tests/Unison/Test/ClearCache.hs
+++ b/parser-typechecker/tests/Unison/Test/ClearCache.hs
@@ -1,0 +1,39 @@
+{-# Language OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Unison.Test.ClearCache where
+
+import Data.Foldable (for_)
+import Data.String.Here (i)
+import EasyTest
+import qualified Unison.Test.Ucm as Ucm
+import qualified Unison.Codebase as Codebase
+import qualified Unison.Var as WatchKind
+
+test :: Test ()
+test = scope "clearWatchCache" $
+  for_ [minBound .. maxBound] \fmt -> scope (show fmt) do
+    c <- io $ Ucm.initCodebase fmt
+    let listWatches = io $ Ucm.lowLevel c \c ->
+          Codebase.watches c WatchKind.RegularWatch
+
+    io $ Ucm.runTranscript c [i|
+      ```ucm
+      .> alias.term ##Nat.+ +
+      ```
+      ```unison
+      > 1 + 1
+      ```
+    |]
+
+    beforeClear <- listWatches
+    expectNotEqual beforeClear []
+
+    io $ Ucm.runTranscript c [i|
+      ```ucm
+      .> debug.clear-cache
+      ```
+    |]
+
+    afterClear <- listWatches
+    expectEqual afterClear []

--- a/parser-typechecker/tests/Unison/Test/ClearCache.hs
+++ b/parser-typechecker/tests/Unison/Test/ClearCache.hs
@@ -4,16 +4,17 @@
 module Unison.Test.ClearCache where
 
 import Data.Foldable (for_)
+import Data.List.Extra (enumerate)
 import Data.String.Here (i)
 import EasyTest
-import qualified Unison.Test.Ucm as Ucm
 import qualified Unison.Codebase as Codebase
+import qualified Unison.Test.Ucm as Ucm
 import qualified Unison.Var as WatchKind
 
 test :: Test ()
 test = scope "clearWatchCache" $
-  for_ [minBound @Ucm.CodebaseFormat ..] \fmt -> scope (show fmt) do
-    c <- io $ Ucm.initCodebase fmt
+  for_ enumerate \codebaseFormat -> scope (show codebaseFormat) do
+    c <- io $ Ucm.initCodebase codebaseFormat
     let listWatches = io $ Ucm.lowLevel c \c ->
           Codebase.watches c WatchKind.RegularWatch
 

--- a/parser-typechecker/tests/Unison/Test/Ucm.hs
+++ b/parser-typechecker/tests/Unison/Test/Ucm.hs
@@ -33,7 +33,7 @@ import qualified Unison.Util.Pretty as P
 import Unison.Parser (Ann)
 import Unison.Symbol (Symbol)
 
-data CodebaseFormat = CodebaseFormat1 | CodebaseFormat2 deriving (Show)
+data CodebaseFormat = CodebaseFormat1 | CodebaseFormat2 deriving (Show, Enum, Bounded)
 
 data Codebase = Codebase CodebasePath CodebaseFormat deriving (Show)
 

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -316,6 +316,7 @@ executable tests
       Unison.Test.ANF
       Unison.Test.BaseUpgradePushPullTest
       Unison.Test.Cache
+      Unison.Test.ClearCache
       Unison.Test.Codebase
       Unison.Test.Codebase.Causal
       Unison.Test.Codebase.FileCodebase


### PR DESCRIPTION
Adds a new command that clears all (Regular & Test) watches from the codebase.

## Test coverage

There is a test that confirms that the new command clears the `RegularWatch` cache; it could be expanded to populate and clear the `TestWatch` cache too.

## Loose ends

#2100 In general, the forcing the result of the existing
```haskell
Codebase.watches :: Codebase m v a -> UF.WatchKind -> m [Reference.Id]
```
function may crash, because the codebase generally doesn't contain the watch expressions, and thus can't supply a reference cycle length.  Just don't look at the results too hard though, and you'll be fine.  Not sure how far removing the size from `Reference.showSuffix` would get us, though I suspect that `Show` instance is how the cycle lengths are recorded into the V1 codebase, for reconstructing the field when converting a `FilePath` to a `Reference`.