### PR TITLE
new pr bundle process

### DIFF
--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -129,6 +129,7 @@ library:
     - unison-core
     - unison-core1
     - unison-util
+    - zip
 
 executables:
   unison:

--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -193,8 +193,8 @@ data Command m i v a where
   SyncRemoteRootBranch ::
     RemoteRepo -> Branch m -> SyncMode -> Command m i v (Either GitError ())
 
-  SyncPrBundle ::
-    FilePath -> Branch.Hash -> Branch m -> Command m i v ()
+  CreatePrBundle ::
+    FilePath -> Branch m -> Branch.Hash -> Command m i v ()
 
   AppendToReflog :: Text -> Branch m -> Branch m -> Command m i v ()
 
@@ -275,7 +275,7 @@ commandName = \case
   ImportRemoteBranch{}        -> "ImportRemoteBranch"
   SyncLocalRootBranch{}       -> "SyncLocalRootBranch"
   SyncRemoteRootBranch{}      -> "SyncRemoteRootBranch"
-  SyncPrBundle{}              -> "SyncPrBundle"
+  CreatePrBundle{}            -> "CreatePrBundle"
   AppendToReflog{}            -> "AppendToReflog"
   LoadReflog                  -> "LoadReflog"
   LoadTerm{}                  -> "LoadTerm"

--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -193,6 +193,9 @@ data Command m i v a where
   SyncRemoteRootBranch ::
     RemoteRepo -> Branch m -> SyncMode -> Command m i v (Either GitError ())
 
+  SyncPrBundle ::
+    FilePath -> Branch.Hash -> Branch m -> Command m i v ()
+
   AppendToReflog :: Text -> Branch m -> Branch m -> Command m i v ()
 
   -- load the reflog in file (chronological) order
@@ -272,6 +275,7 @@ commandName = \case
   ImportRemoteBranch{}        -> "ImportRemoteBranch"
   SyncLocalRootBranch{}       -> "SyncLocalRootBranch"
   SyncRemoteRootBranch{}      -> "SyncRemoteRootBranch"
+  SyncPrBundle{}              -> "SyncPrBundle"
   AppendToReflog{}            -> "AppendToReflog"
   LoadReflog                  -> "LoadReflog"
   LoadTerm{}                  -> "LoadTerm"

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -134,13 +134,13 @@ commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSour
       lift $ Codebase.importRemoteBranch codebase ns syncMode
     SyncRemoteRootBranch repo branch syncMode ->
       lift $ Codebase.pushGitRootBranch codebase branch repo syncMode
-    SyncPrBundle file baseHash headBranch -> liftIO do
+    CreatePrBundle file srcBranch destBranchHash -> liftIO do
       -- todo: abort if `file` or `file.upr` already exist
       createDirectoryIfMissing True file
       LBS.writeFile (file </> "pr.json") $
-        Aeson.encode (PrBundle1.Header 1 $ Hash.base32Hex $ Causal.unRawHash baseHash)
+        Aeson.encode (PrBundle1.Header 1 (Hash.base32Hex $ Causal.unRawHash destBranchHash))
       let syncModeGripe = error "what even is a sync mode here; it probably should've been a separate API"
-      Codebase.syncToDirectory codebase file syncModeGripe headBranch
+      Codebase.syncToDirectory codebase file syncModeGripe srcBranch
       Zip.createArchive (file ++ ".upr") do
         Zip.packDirRecur Zip.Deflate Zip.mkEntrySelector file
       removeDirectoryRecursive file

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -767,14 +767,14 @@ loop = do
             cleanupBase
             cleanupHead
 
-      CreatePullRequest2I filePath basePath headPath -> unlessGitError do
+      CreatePullRequest2I filePath srcPath destPath -> unlessGitError do
         lift do
-          baseBranch <- getAt $ resolveToAbsolute basePath
-          headBranch <- getAt $ resolveToAbsolute headPath
-          merged <- eval $ Merge Branch.RegularMerge baseBranch headBranch
+          srcBranch <- getAt $ resolveToAbsolute srcPath
+          destBranch <- getAt $ resolveToAbsolute destPath
+          merged <- eval $ Merge Branch.RegularMerge srcBranch destBranch
           unlessGitError $ ExceptT do
-            eval $ SyncPrBundle filePath (Branch.headHash baseBranch) headBranch
-            (ppe, diff) <- diffHelper (Branch.head baseBranch) (Branch.head merged)
+            eval $ CreatePrBundle filePath srcBranch (Branch.headHash destBranch)
+            (ppe, diff) <- diffHelper (Branch.head destBranch) (Branch.head merged)
             error "print a nice diff" $ respondNumbered $ ShowDiffAfterCreatePR undefined undefined ppe diff
 
       LoadPullRequestI baseRepo headRepo dest0 -> do

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -53,6 +53,7 @@ data Input
     | PullRemoteBranchI (Maybe RemoteNamespace) Path' SyncMode
     | PushRemoteBranchI (Maybe RemoteHead) Path' SyncMode
     | CreatePullRequestI RemoteNamespace RemoteNamespace
+    | CreatePullRequest2I FilePath Path' Path'
     | LoadPullRequestI RemoteNamespace RemoteNamespace Path'
     | ResetRootI (Either ShortBranchHash Path')
     -- todo: Q: Does it make sense to publish to not-the-root of a Github repo?

--- a/parser-typechecker/src/Unison/Codebase/PrBundle1.hs
+++ b/parser-typechecker/src/Unison/Codebase/PrBundle1.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Unison.Codebase.PrBundle1 where
+
+import Data.Aeson (FromJSON, ToJSON)
+import Unison.Prelude (Generic, Text)
+
+data Header = Header {version :: Int, baseHash :: Text} deriving (Generic)
+
+instance ToJSON Header
+
+instance FromJSON Header

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -859,18 +859,18 @@ createPullRequest2 :: InputPattern
 createPullRequest2 = InputPattern "pull-request.create2" ["pr.create2"]
   [(Required, noCompletions), (Required, pathArg), (Required, pathArg)]
   (P.group $ P.lines
-    [ P.wrap $ makeExample createPullRequest2 ["file", "base", "head"]
-        <> "will generate a request to merge the namespace `head`"
-        <> "into the namespace `base`."
+    [ P.wrap $ makeExample createPullRequest2 ["file", "src", "dest"]
+        <> "will generate a request to merge the namespace `src`"
+        <> "into the namespace `dest`."
     , ""
     , "example: " <>
-      makeExampleNoBackticks createPullRequest2 [".libs.bestlib", ".forks.bestlib.mytopic"]
+      makeExampleNoBackticks createPullRequest2 [".forks.bestlib.mytopic", ".libs.bestlib"]
     ])
   (\case
-    [path, base, head] -> do
-      base <- first fromString $ Path.parsePath' base
-      head <- first fromString $ Path.parsePath' head
-      pure $ Input.CreatePullRequest2I path base head
+    [path, src, dest] -> do
+      src <- first fromString $ Path.parsePath' src
+      dest <- first fromString $ Path.parsePath' dest
+      pure $ Input.CreatePullRequest2I path src dest
     _ -> Left (I.help createPullRequest2)
   )
 

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -855,6 +855,25 @@ createPullRequest = InputPattern "pull-request.create" ["pr.create"]
     _ -> Left (I.help createPullRequest)
   )
 
+createPullRequest2 :: InputPattern
+createPullRequest2 = InputPattern "pull-request.create2" ["pr.create2"]
+  [(Required, noCompletions), (Required, pathArg), (Required, pathArg)]
+  (P.group $ P.lines
+    [ P.wrap $ makeExample createPullRequest2 ["file", "base", "head"]
+        <> "will generate a request to merge the namespace `head`"
+        <> "into the namespace `base`."
+    , ""
+    , "example: " <>
+      makeExampleNoBackticks createPullRequest2 [".libs.bestlib", ".forks.bestlib.mytopic"]
+    ])
+  (\case
+    [path, base, head] -> do
+      base <- first fromString $ Path.parsePath' base
+      head <- first fromString $ Path.parsePath' head
+      pure $ Input.CreatePullRequest2I path base head
+    _ -> Left (I.help createPullRequest2)
+  )
+
 loadPullRequest :: InputPattern
 loadPullRequest = InputPattern "pull-request.load" ["pr.load"]
   [(Required, gitUrlArg), (Required, gitUrlArg), (Optional, pathArg)]
@@ -1392,6 +1411,7 @@ validInputs =
   , pushExhaustive
   , pullExhaustive
   , createPullRequest
+  , createPullRequest2
   , loadPullRequest
   , cd
   , back

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -64,6 +64,7 @@ library
       Unison.Codebase.NameEdit
       Unison.Codebase.Patch
       Unison.Codebase.Path
+      Unison.Codebase.PrBundle1
       Unison.Codebase.Reflog
       Unison.Codebase.Runtime
       Unison.Codebase.Serialization
@@ -275,6 +276,7 @@ library
     , x509
     , x509-store
     , x509-system
+    , zip
   if flag(optimized)
     ghc-options: -funbox-strict-fields -O2
   default-language: Haskell2010


### PR DESCRIPTION
Adds a new command, `pr.create2 <file> <base namespace> <topic namespace>` that creates a self-contained codebase + some metadata in `<file>.upr` (unison pull request) and then crashes due to missing `OutputMessages` work.

Here's an example of repackaging https://github.com/unisonweb/base/issues/12.
```
.> cd .prs

  ☝️  The namespace .prs is empty.

.prs> pull-request.load https://github.com/unisonweb/base:.trunk https://github.com/pchiusano/unisoncode:.prs.random2
  Importing downloaded files into local codebase...     
  Done syncing 4500 entities.
  Importing downloaded files into local codebase...           
  Done syncing 86 entities.
                                                   
  I checked out https://github.com/unisonweb/base:.trunk to base.
  I checked out https://github.com/pchiusano/unisoncode:.prs.random2 to head.
  
  The merged result is in merged.
  The (squashed) merged result is in squashed.
  Use `diff.namespace base merged` or `diff.namespace base squashed` to see what's been updated.
  Use `todo merged.patch merged` to see what work is remaining for the merge.
  Use `push https://github.com/unisonweb/base:.trunk merged` or
  `push https://github.com/unisonweb/base:.trunk squashed` to push the changes.

.prs> ls

  1. base/     (1914 definitions)
  2. head/     (1935 definitions)
  3. merged/   (1935 definitions)
  4. squashed/ (1935 definitions)

.prs> pr.create2 random2 base squashed

  Done syncing 15433 entities.
todo: print a nice diff
```
```
% ls -lh random2.upr
-rw-------  1 arya  staff   6.4M Jun  9 23:10 random2.upr
% unzip -p random2.upr pr.json       
{"version":1,"baseHash":"agacc40npn4o3ctgo89avotts70ircdri6c40d7mm0jmrf000vrqb81bf69o4utkqu633g672eqc24c9jg40t0r7vul1kekpa8sr8f8"}
```

The rest should be pretty self explanatory:
- [ ] add a `pr.load2` command that
  - [ ] unpacks `<file>.upr` to a temp dir
  - [ ] parses a version number out of `<tmp>/pr.json`
  - [ ] branch on `version: 1`
    - [ ] check that `baseHash` is known
    - [ ] merge the root of the codebase at `<tmp>` to wherever the user wants (can't use `Codebase.syncFromCodebase` directly, because it expects a branch loaded first for some reason)
  - [ ] deletes the temp dir
  - [ ] says something nice