### PR TITLE
By default build with optimization off in trunk

### DIFF
--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -21,7 +21,7 @@ ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synony
 flags:
   optimized:
     manual: true
-    default: true
+    default: false
 
 when:
   - condition: flag(optimized)


### PR DESCRIPTION
I noticed compile times on trunk were super slow and then spotted that we're building with `-O2` by default on trunk. Guessing this happened during the shuffle of building M2 releases.