### PR TITLE
Fix possible quadratic performance bug in Backend.hs

### DIFF
--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -557,21 +557,19 @@ prettyDefinitionsBySuffixes relativeTo root renderWidth suffixifyBindings codeba
       termFqns :: Map Reference (Set Text)
       termFqns = Map.mapWithKey f terms
        where
-        f k _ =
-          R.lookupRan (Referent.Ref' k)
-            . R.filterDom (\n -> "." `Text.isPrefixOf` n && n /= ".")
+        rel = R.filterDom (\n -> "." `Text.isPrefixOf` n && n /= ".")
             . R.mapDom Name.toText
             . Names.terms
             $ currentNames parseNames
+        f k _ = R.lookupRan (Referent.Ref' k) rel
       typeFqns :: Map Reference (Set Text)
       typeFqns = Map.mapWithKey f types
        where
-        f k _ =
-          R.lookupRan k
-            . R.filterDom (\n -> "." `Text.isPrefixOf` n && n /= ".")
+        rel = R.filterDom (\n -> "." `Text.isPrefixOf` n && n /= ".")
             . R.mapDom Name.toText
             . Names.types
             $ currentNames parseNames
+        f k _ = R.lookupRan k rel
       flatten = Set.toList . fromMaybe Set.empty
       mkTermDefinition r tm = do
         ts <- lift (Codebase.getTypeOfTerm codebase r)


### PR DESCRIPTION
@runarorama Randomly spotted this. The previous code would build a new relation for each entry in the map, rather than building it just once and doing multiple lookups into the relation. 

This would be more noticeable when the query returns many terms and types. I'm not exactly sure how often that would be but still seemed worth fixing.

Laziness might help somewhat but even with laziness, it will have to force a lot of the relation in order to do a `lookupRan`. It's also possible that with optimizations turned on that common subexpression elimination hoists this out of the loop but I wouldn't necessarily count on that.