### PR TITLE
Swap `and` and `or` with `&&` and `||` in boolean mismatch message

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -52,3 +52,4 @@ The format for this list: name, GitHub handle, and then optional blurb about wha
 * Nigel Farrelly (@nini-faroux)
 * Johannes Huster (@JohannesHuster)
 * Joseph Morag (@jmorag)
+* Tavish Pegram (@tapegram)

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -177,9 +177,9 @@ renderTypeError e env src = case e of
           <> style ErrorSite "if"
           <> "-expression has to be"
       AndMismatch ->
-        "The arguments to " <> style ErrorSite "and" <> " have to be"
+        "The arguments to " <> style ErrorSite "&&" <> " have to be"
       OrMismatch ->
-        "The arguments to " <> style ErrorSite "or" <> " have to be"
+        "The arguments to " <> style ErrorSite "||" <> " have to be"
       GuardMismatch ->
         "The guard expression for a "
           <> style ErrorSite "match"


### PR DESCRIPTION
## Overview
For issue
https://github.com/unisonweb/unison/issues/2121

Before
<img width="446" alt="Screen Shot 2021-06-16 at 6 35 24 PM" src="https://user-images.githubusercontent.com/1281274/122308241-a06e4500-ced1-11eb-8e9d-6310d6fef8cb.png">

After
<img width="442" alt="Screen Shot 2021-06-16 at 6 35 58 PM" src="https://user-images.githubusercontent.com/1281274/122308288-b2e87e80-ced1-11eb-9e96-bd2d7c8503f9.png">

## Implementation notes

Just updated some hard coded strings.

## Interesting/controversial decisions

Hopefully, this is not controversial.

## Test coverage

This doesn't appear to be tested. Is this worth testing to prevent a regression and if so how do I go about it?
