### PR TITLE
Add cabal support via cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -25,5 +25,41 @@ source-repository-package
   location: https://github.com/unisonweb/megaparsec.git
   tag: c4463124c578e8d1074c04518779b5ce5957af6b
 
+constraints: haskeline -terminfo
+
 allow-newer: 
   haskeline:base
+
+-- For now there is no way to apply ghc-options for all local packages
+-- See https://cabal.readthedocs.io/en/latest/cabal-project.html#package-configuration-options
+
+package easytest
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+
+package parser-typechecker
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+
+package codebase
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+
+package codebase-sqlite
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+
+package codebase-sync
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+
+package core
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+
+package util
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+
+package util-serialization
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+
+package util-term
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+
+-- This options are applied to all packages, local ones and also external dependencies.
+package *
+  ghc-options: -haddock

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,29 @@
+packages:
+    yaks/easytest
+    parser-typechecker
+    unison-core
+    codebase2/codebase
+    codebase2/codebase-sqlite
+    codebase2/codebase-sync
+    codebase2/core
+    codebase2/util
+    codebase2/util-serialization
+    codebase2/util-term
+
+source-repository-package
+  type: git
+  location: https://github.com/unisonweb/configurator.git
+  tag: e47e9e9fe1f576f8c835183b9def52d73c01327a
+
+source-repository-package
+  type: git
+  location: https://github.com/unisonweb/haskeline.git
+  tag: 2944b11d19ee034c48276edc991736105c9d6143
+
+source-repository-package
+  type: git
+  location: https://github.com/unisonweb/megaparsec.git
+  tag: c4463124c578e8d1074c04518779b5ce5957af6b
+
+allow-newer: 
+  haskeline:base


### PR DESCRIPTION
## Overview

This is a development oriented change, to make easy start to contribute for cabal users.

## Implementation notes

Adding a `cabal.project` has been enough.

## Interesting/controversial decisions

The main drawback is the project has to maintain two build config files.
One of the advantages of cabal is `allow-newer` is fine grained and you can set it per `package:dependency`.
The allow-newer i had to add does not correspond with the comment in the coarse grained `allow-newer` of stack: 
https://github.com/unisonweb/unison/blob/ef1b25af7b2fae38cd311f94b958781d045b021a/stack.yaml#L5

## Test coverage

I've tested the buid locally in windows and it has generated the executable: https://github.com/jneira/unison/releases/download/2d96be-windows/unison.exe
Ideally a job in ci using cabal should be added, to check it is in sync with stack.yaml


