### PR TITLE
Update cabal.project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,8 @@ scratch.u
 .stack-work
 stack.yaml.lock
 
+# Cabal
+dist-newstyle
+
 # GHC
 *.hie

--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -53,3 +53,4 @@ The format for this list: name, GitHub handle, and then optional blurb about wha
 * Johannes Huster (@JohannesHuster)
 * Joseph Morag (@jmorag)
 * Tavish Pegram (@tapegram)
+* Javier Neira (@jneira)

--- a/contrib/cabal.project
+++ b/contrib/cabal.project
@@ -1,10 +1,29 @@
-packages: unison-core/ parser-typechecker/ yaks/easytest/ yaks/haskeline/
+packages:
+    yaks/easytest
+    parser-typechecker
+    unison-core
+    codebase2/codebase
+    codebase2/codebase-sqlite
+    codebase2/codebase-sync
+    codebase2/core
+    codebase2/util
+    codebase2/util-serialization
+    codebase2/util-term
 
-allow-newer: base, directory, filepath
+source-repository-package
+  type: git
+  location: https://github.com/unisonweb/configurator.git
+  tag: e47e9e9fe1f576f8c835183b9def52d73c01327a
 
-package unison-core
-  ghc-options: -Werror -Wno-type-defaults
+source-repository-package
+  type: git
+  location: https://github.com/unisonweb/haskeline.git
+  tag: 2944b11d19ee034c48276edc991736105c9d6143
 
-package unison-parser-typechecker
-  ghc-options: -Werror -Wno-type-defaults
+source-repository-package
+  type: git
+  location: https://github.com/unisonweb/megaparsec.git
+  tag: c4463124c578e8d1074c04518779b5ce5957af6b
 
+allow-newer: 
+  haskeline:base

--- a/contrib/cabal.project
+++ b/contrib/cabal.project
@@ -27,3 +27,36 @@ source-repository-package
 
 allow-newer: 
   haskeline:base
+
+-- For now there is no way to apply ghc-options for all local packages
+-- See https://cabal.readthedocs.io/en/latest/cabal-project.html#package-configuration-options
+package easytest
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+
+package parser-typechecker
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+
+package codebase
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+
+package codebase-sqlite
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+
+package codebase-sync
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+
+package core
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+
+package util
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+
+package util-serialization
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+
+package util-term
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+
+-- This options are applied to all packages, local ones and also external dependencies.
+package *
+  ghc-options: -haddock

--- a/contrib/cabal.project
+++ b/contrib/cabal.project
@@ -31,31 +31,31 @@ allow-newer:
 -- For now there is no way to apply ghc-options for all local packages
 -- See https://cabal.readthedocs.io/en/latest/cabal-project.html#package-configuration-options
 package easytest
-  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
 package parser-typechecker
-  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
 package codebase
-  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
 package codebase-sqlite
-  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
 package codebase-sync
-  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
 package core
-  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
 package util
-  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
 package util-serialization
-  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
 package util-term
-  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info #-freverse-errors
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
 -- This options are applied to all packages, local ones and also external dependencies.
 package *

--- a/development.markdown
+++ b/development.markdown
@@ -36,16 +36,21 @@ That will generate a `<executable-name>.prof` plain text file with profiling dat
 
 ## Building with cabal
 
-Unison can also be built/installed with cabal. You'll need ghc 8.6.x to
-successfully build its dependencies. The provided project file is also in
-contrib/ so you'll need to specify its location on the command line.
+Unison can also be built/installed with cabal. You'll need the same ghc
+used by `stack.yaml` to successfully build its dependencies.
+The provided project file is also in contrib/ so you'll need to specify
+its location on the command line.
 
-* To configure the build, you can use e.g. `cabal v2-configure
-  --project-file=contrib/cabal.project --with-ghc=ghc-8.6.5` if you have
-  multiple versions of GHC installed
-* To build all projects use `cabal v2-build --project-file=contrib/cabal.project all`
-* Tests can be run with e.g. `cabal v2-run --project-file=contrib/cabal.project
-  parser-typechecker:tests`
-* The executable can be installed with `cabal v2-install
-  --project-file=contrib/cabal.project unison` the install directory can be
-  modified by setting `installdir: ...` in `.cabal/config`
+* To build all projects use
+
+    `cabal v2-build --project-file=contrib/cabal.project all`
+
+* Tests can be run with e.g.
+
+    `cabal v2-test --project-file=contrib/cabal.project all`
+
+* The executable can be installed with
+
+    `cabal v2-install --project-file=contrib/cabal.project unison`
+
+* The install directory can be modified with the option `--installdir: ...`


### PR DESCRIPTION
## Overview

Update cabal.project taking as example stack.yaml.

## Implementation notes

## Interesting/controversial decisions

I am afraid that cabal still does not have an equivalent for stack $locals so ghc-options has to be duplicated for every local package 😟
Other projects choose putting that options in each .cabal file, to make it available for every possible installation method (including nix). Usually a common stanza is used to apply them to all package components, to only have them once for each .cabal file.

## Test coverage

Tested building the project with cabal locally

