### PR TITLE
Create `replace` command instead of `replace.term` and `replace.type`

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -398,17 +398,9 @@ loop = do
           DeleteBranchI opath -> "delete.namespace " <> ops' opath
           DeletePatchI path -> "delete.patch " <> ps' path
           ReplaceI src target p ->
-            "replace.any "  <> HQ.toText src <> " "
-                            <> HQ.toText target <> " "
-                            <> opatch p
-          ReplaceTermI src target p ->
-            "replace.term " <> HQ.toText src <> " "
-                            <> HQ.toText target <> " "
-                            <> opatch p
-          ReplaceTypeI src target p ->
-            "replace.type " <> HQ.toText src <> " "
-                            <> HQ.toText target <> " "
-                            <> opatch p
+            "replace "  <> HQ.toText src <> " "
+                        <> HQ.toText target <> " "
+                        <> opatch p
           ResolveTermNameI path -> "resolve.termName " <> hqs' path
           ResolveTypeNameI path -> "resolve.typeName " <> hqs' path
           AddI _selection -> "add"
@@ -1381,95 +1373,6 @@ loop = do
           ([], [], [_], tos)   -> ambiguous to tos
           (_, _, _, _)         -> error "unpossible"
 
-      ReplaceTermI from to patchPath -> do
-        let patchPath' = fromMaybe defaultPatchPath patchPath
-        patch <- getPatchAt patchPath'
-        QueryResult fromMisses' fromHits <- hqNameQuery [from]
-        QueryResult toMisses' toHits <- hqNameQuery [to]
-        let fromRefs = termReferences fromHits
-            toRefs = termReferences toHits
-            -- Type hits are term misses
-            fromMisses = fromMisses'
-                       <> (HQ'.toHQ . SR.typeName <$> typeResults fromHits)
-            toMisses = toMisses'
-                       <> (HQ'.toHQ . SR.typeName <$> typeResults fromHits)
-            go :: Reference
-               -> Reference
-               -> Action m (Either Event Input) v ()
-            go fr tr = do
-              mft <- eval $ LoadTypeOfTerm fr
-              mtt <- eval $ LoadTypeOfTerm tr
-              let termNotFound = respond . TermNotFound'
-                                         . SH.take hqLength
-                                         . Reference.toShortHash
-              case (mft, mtt) of
-                (Nothing, _) -> termNotFound fr
-                (_, Nothing) -> termNotFound tr
-                (Just ft, Just tt) -> do
-                  let
-                      patch' =
-                        -- The modified patch
-                        over Patch.termEdits
-                          (R.insert fr (Replace tr (TermEdit.typing tt ft))
-                           . R.deleteDom fr)
-                          patch
-                      (patchPath'', patchName) = resolveSplit' patchPath'
-                  saveAndApplyPatch patchPath'' patchName patch'
-            misses = fromMisses <> toMisses
-            ambiguous t rs =
-              let rs' = Set.map Referent.Ref $ Set.fromList rs
-              in  case t of
-                    HQ.HashOnly h ->
-                      hashConflicted h rs'
-                    (Path.parseHQSplit' . HQ.toString -> Right n) ->
-                      termConflicted n rs'
-                    _ -> respond . BadName $ HQ.toString t
-        unless (null misses) $
-          respond $ SearchTermsNotFound misses
-        case (fromRefs, toRefs) of
-          ([fr], [tr]) -> go fr tr
-          ([_], tos) -> ambiguous to tos
-          (frs, _) -> ambiguous from frs
-      ReplaceTypeI from to patchPath -> do
-        let patchPath' = fromMaybe defaultPatchPath patchPath
-        QueryResult fromMisses' fromHits <- hqNameQuery [from]
-        QueryResult toMisses' toHits <- hqNameQuery [to]
-        patch <- getPatchAt patchPath'
-        let fromRefs = typeReferences fromHits
-            toRefs = typeReferences toHits
-            -- Term hits are type misses
-            fromMisses = fromMisses'
-                       <> (HQ'.toHQ . SR.termName <$> termResults fromHits)
-            toMisses = toMisses'
-                       <> (HQ'.toHQ . SR.termName <$> termResults fromHits)
-            go :: Reference
-               -> Reference
-               -> Action m (Either Event Input) v ()
-            go fr tr = do
-              let patch' =
-                    -- The modified patch
-                    over Patch.typeEdits
-                      (R.insert fr (TypeEdit.Replace tr) . R.deleteDom fr) patch
-                  (patchPath'', patchName) = resolveSplit' patchPath'
-              saveAndApplyPatch patchPath'' patchName patch'
-            misses = fromMisses <> toMisses
-            ambiguous t rs =
-              let rs' = Set.map Referent.Ref $ Set.fromList rs
-              in  case t of
-                    HQ.HashOnly h ->
-                      hashConflicted h rs'
-                    (Path.parseHQSplit' . HQ.toString -> Right n) ->
-                      typeConflicted n $ Set.fromList rs
-                    -- This is unlikely to happen, as t has to be a parsed
-                    -- hash-qualified name already.
-                    -- Still, the types say we need to handle this case.
-                    _ -> respond . BadName $ HQ.toString t
-        unless (null misses) $
-          respond $ SearchTermsNotFound misses
-        case (fromRefs, toRefs) of
-          ([fr], [tr]) -> go fr tr
-          ([_], tos) -> ambiguous to tos
-          (frs, _) -> ambiguous from frs
       LoadI maybePath ->
         case maybePath <|> (fst <$> latestFile') of
           Nothing   -> respond NoUnisonFile

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1340,6 +1340,7 @@ loop = do
                           patch
                       (patchPath'', patchName) = resolveSplit' patchPath'
                   saveAndApplyPatch patchPath'' patchName patch'
+
             replaceTypes :: Reference
                -> Reference
                -> Action m (Either Event Input) v ()
@@ -1350,6 +1351,7 @@ loop = do
                       (R.insert fr (TypeEdit.Replace tr) . R.deleteDom fr) patch
                   (patchPath'', patchName) = resolveSplit' patchPath'
               saveAndApplyPatch patchPath'' patchName patch'
+
             ambiguous t rs =
               let rs' = Set.map Referent.Ref $ Set.fromList rs
               in  case t of
@@ -1359,8 +1361,13 @@ loop = do
                       termConflicted n rs'
                     _ -> respond . BadName $ HQ.toString t
 
+            mismatch typeName termName = respond $ TypeTermMismatch typeName termName
+
+
         case (termsFromRefs, termsToRefs, typesFromRefs, typesToRefs) of
           ([], [], [], [])     -> respond $ SearchTermsNotFound termMisses
+          ([_], [], [], [_])   -> mismatch to from
+          ([], [_], [_], [])   -> mismatch from to
           ([_], [], _, _)      -> respond $ SearchTermsNotFound termMisses
           ([], [_], _, _)      -> respond $ SearchTermsNotFound termMisses
           (_, _, [_], [])      -> respond $ SearchTermsNotFound typeMisses

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -398,7 +398,7 @@ loop = do
           DeleteBranchI opath -> "delete.namespace " <> ops' opath
           DeletePatchI path -> "delete.patch " <> ps' path
           ReplaceI src target p ->
-            "replace "      <> HQ.toText src <> " "
+            "replace.any "  <> HQ.toText src <> " "
                             <> HQ.toText target <> " "
                             <> opatch p
           ReplaceTermI src target p ->

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1317,7 +1317,7 @@ loop = do
                        <> (HQ'.toHQ . SR.typeName <$> typeResults fromHits)
             termToMisses = toMisses'
                        <> (HQ'.toHQ . SR.typeName <$> typeResults toHits)
-            -- -- Term hits are type misses
+            -- Term hits are type misses
             typeFromMisses = fromMisses'
                        <> (HQ'.toHQ . SR.termName <$> termResults fromHits)
             typeToMisses = toMisses'
@@ -1368,18 +1368,18 @@ loop = do
                     _ -> respond . BadName $ HQ.toString t
 
         case (termsFromRefs, termsToRefs, typesFromRefs, typesToRefs) of
-          ([], [], [], []) -> respond $ SearchTermsNotFound termMisses
-          ([_], [], _, _) -> respond $ SearchTermsNotFound termMisses
-          ([], [_], _, _) -> respond $ SearchTermsNotFound termMisses
-          (_, _, [_], []) -> respond $ SearchTermsNotFound typeMisses
-          (_, _, [], [_]) -> respond $ SearchTermsNotFound typeMisses
+          ([], [], [], [])     -> respond $ SearchTermsNotFound termMisses
+          ([_], [], _, _)      -> respond $ SearchTermsNotFound termMisses
+          ([], [_], _, _)      -> respond $ SearchTermsNotFound termMisses
+          (_, _, [_], [])      -> respond $ SearchTermsNotFound typeMisses
+          (_, _, [], [_])      -> respond $ SearchTermsNotFound typeMisses
           ([fr], [tr], [], []) -> replaceTerms fr tr
           ([], [], [fr], [tr]) -> replaceTypes fr tr
           (froms, [_], [], []) -> ambiguous from froms
           ([], [], froms, [_]) -> ambiguous from froms
-          ([_], tos, [], []) -> ambiguous to tos
-          ([], [], [_], tos) -> ambiguous to tos
-          (_, _, _, _) -> error "shouldn't happen but just in case!"
+          ([_], tos, [], [])   -> ambiguous to tos
+          ([], [], [_], tos)   -> ambiguous to tos
+          (_, _, _, _)         -> error "unpossible"
 
       ReplaceTermI from to patchPath -> do
         let patchPath' = fromMaybe defaultPatchPath patchPath

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1312,12 +1312,12 @@ loop = do
             termFromMisses = fromMisses'
                        <> (HQ'.toHQ . SR.typeName <$> typeResults fromHits)
             termToMisses = toMisses'
-                       <> (HQ'.toHQ . SR.typeName <$> typeResults fromHits)
+                       <> (HQ'.toHQ . SR.typeName <$> typeResults toHits)
             -- -- Term hits are type misses
             typeFromMisses = fromMisses'
                        <> (HQ'.toHQ . SR.termName <$> termResults fromHits)
             typeToMisses = toMisses'
-                       <> (HQ'.toHQ . SR.termName <$> termResults fromHits)
+                       <> (HQ'.toHQ . SR.termName <$> termResults toHits)
 
             termMisses = termFromMisses <> termToMisses
             typeMisses = typeFromMisses <> typeToMisses

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -99,8 +99,6 @@ data Input
     | DeprecateTermI PatchPath Path.HQSplit'
     | DeprecateTypeI PatchPath Path.HQSplit'
     | ReplaceI (HQ.HashQualified Name) (HQ.HashQualified Name) (Maybe PatchPath)
-    | ReplaceTermI (HQ.HashQualified Name) (HQ.HashQualified Name) (Maybe PatchPath)
-    | ReplaceTypeI (HQ.HashQualified Name) (HQ.HashQualified Name) (Maybe PatchPath)
     | RemoveTermReplacementI (HQ.HashQualified Name) (Maybe PatchPath)
     | RemoveTypeReplacementI (HQ.HashQualified Name) (Maybe PatchPath)
   | UndoI

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -98,6 +98,7 @@ data Input
     -- -- create and remove update directives
     | DeprecateTermI PatchPath Path.HQSplit'
     | DeprecateTypeI PatchPath Path.HQSplit'
+    | ReplaceI (HQ.HashQualified Name) (HQ.HashQualified Name) (Maybe PatchPath)
     | ReplaceTermI (HQ.HashQualified Name) (HQ.HashQualified Name) (Maybe PatchPath)
     | ReplaceTypeI (HQ.HashQualified Name) (HQ.HashQualified Name) (Maybe PatchPath)
     | RemoveTermReplacementI (HQ.HashQualified Name) (Maybe PatchPath)

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -121,6 +121,7 @@ data Output v
   | TermNotFound Path.HQSplit'
   | TypeNotFound' ShortHash
   | TermNotFound' ShortHash
+  | TypeTermMismatch (HQ.HashQualified Name) (HQ.HashQualified Name)
   | SearchTermsNotFound [HQ.HashQualified Name]
   -- ask confirmation before deleting the last branch that contains some defns
   -- `Path` is one of the paths the user has requested to delete, and is paired
@@ -267,6 +268,7 @@ isFailure o = case o of
   TypeNotFound'{} -> True
   TermNotFound{} -> True
   TermNotFound'{} -> True
+  TypeTermMismatch{} -> True
   SearchTermsNotFound ts -> not (null ts)
   DeleteBranchConfirmation{} -> False
   CantDelete{} -> True

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -1014,6 +1014,9 @@ replaceEdit f s = self
       _ -> Left $ I.help self
     )
 
+replace :: InputPattern
+replace = replaceEdit Input.ReplaceI "any"
+
 replaceType :: InputPattern
 replaceType = replaceEdit Input.ReplaceTypeI "type"
 
@@ -1425,6 +1428,7 @@ validInputs =
   , unlink
   , links
   , createAuthor
+  , replace
   , replaceTerm
   , replaceType
   , deleteTermReplacement

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -975,12 +975,11 @@ replaceEdit
      -> Maybe Input.PatchPath
      -> Input
      )
-  -> String
   -> InputPattern
-replaceEdit f s = self
+replaceEdit f = self
  where
   self = InputPattern
-    ("replace." <> s)
+    "replace"
     []
     [ (Required, definitionQueryArg)
     , (Required, definitionQueryArg)
@@ -988,17 +987,10 @@ replaceEdit f s = self
     ]
     (P.wrapColumn2
       [ ( makeExample self ["<from>", "<to>", "<patch>"]
-        , "Replace the "
-        <> P.string s
-        <> " <from> in the given patch "
-        <> "with the "
-        <> P.string s
-        <> " <to>."
+        , "Replace the term/type <from> in the given patch with the term/type <to>."
         )
       , ( makeExample self ["<from>", "<to>"]
-        , "Replace the "
-        <> P.string s
-        <> "<from> with <to> in the default patch."
+        , "Replace the term/type <from> with <to> in the default patch."
         )
       ]
     )
@@ -1015,13 +1007,7 @@ replaceEdit f s = self
     )
 
 replace :: InputPattern
-replace = replaceEdit Input.ReplaceI "any"
-
-replaceType :: InputPattern
-replaceType = replaceEdit Input.ReplaceTypeI "type"
-
-replaceTerm :: InputPattern
-replaceTerm = replaceEdit Input.ReplaceTermI "term"
+replace = replaceEdit Input.ReplaceI
 
 viewReflog :: InputPattern
 viewReflog = InputPattern
@@ -1429,8 +1415,6 @@ validInputs =
   , links
   , createAuthor
   , replace
-  , replaceTerm
-  , replaceType
   , deleteTermReplacement
   , deleteTypeReplacement
   , test

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -395,6 +395,13 @@ notifyUser dir o = case o of
     ]
 
   EvaluationFailure err -> pure err
+  TypeTermMismatch typeName termName ->
+    pure
+      $  P.warnCallout "I was expecting either two types or two terms but was given a type "
+      <> P.syntaxToColor (prettyHashQualified typeName)
+      <> " and a term "
+      <> P.syntaxToColor (prettyHashQualified termName)
+      <> "."
   SearchTermsNotFound hqs | null hqs -> pure mempty
   SearchTermsNotFound hqs ->
     pure

--- a/parser-typechecker/tests/Unison/Test/GitSync.hs
+++ b/parser-typechecker/tests/Unison/Test/GitSync.hs
@@ -328,8 +328,8 @@ test = scope "gitsync22" . tests $
       ```
       ```ucm
       .defns> add
-      .patches> replace.type .defns.A .defns.B
-      .patches> replace.term .defns.x .defns.y
+      .patches> replace .defns.A .defns.B
+      .patches> replace .defns.x .defns.y
       .patches> push ${repo}
       ```
     |])

--- a/parser-typechecker/tests/Unison/Test/GitSync.hs
+++ b/parser-typechecker/tests/Unison/Test/GitSync.hs
@@ -328,7 +328,7 @@ test = scope "gitsync22" . tests $
       ```
       ```ucm
       .defns> add
-      .patches> replace.term .defns.A .defns.B
+      .patches> replace.type .defns.A .defns.B
       .patches> replace.term .defns.x .defns.y
       .patches> push ${repo}
       ```

--- a/parser-typechecker/tests/Unison/Test/GitSync.hs
+++ b/parser-typechecker/tests/Unison/Test/GitSync.hs
@@ -328,7 +328,7 @@ test = scope "gitsync22" . tests $
       ```
       ```ucm
       .defns> add
-      .patches> replace.type .defns.A .defns.B
+      .patches> replace.term .defns.A .defns.B
       .patches> replace.term .defns.x .defns.y
       .patches> push ${repo}
       ```

--- a/unison-src/transcripts/command-replace.md
+++ b/unison-src/transcripts/command-replace.md
@@ -20,37 +20,37 @@ type Y = Two Nat Nat
 
 Test that replace works with terms
 ```ucm
-.scratch> replace.any x y
+.scratch> replace x y
 .scratch> view x
 ```
 
 Test that replace works with types
 ```ucm
-.scratch> replace.any X Y
+.scratch> replace X Y
 .scratch> view X
 ```
 
 Try with a type/term mismatch
 ```ucm:error
-.scratch> replace.any X x
+.scratch> replace X x
 ```
 ```ucm:error
-.scratch> replace.any y Y 
+.scratch> replace y Y 
 ```
 
 Try with missing references
 ```ucm:error
-.scratch> replace.any X NOPE
+.scratch> replace X NOPE
 ```
 ```ucm:error
-.scratch> replace.any y nope
+.scratch> replace y nope
 ```
 ```ucm:error
-.scratch> replace.any nope X
+.scratch> replace nope X
 ```
 ```ucm:error
-.scratch> replace.any nope y
+.scratch> replace nope y
 ```
 ```ucm:error
-.scratch> replace.any nope nope
+.scratch> replace nope nope
 ```

--- a/unison-src/transcripts/command-replace.md
+++ b/unison-src/transcripts/command-replace.md
@@ -20,37 +20,37 @@ type Y = Two Nat Nat
 
 Test that replace works with terms
 ```ucm
-.scratch> replace.term x y
+.scratch> replace.any x y
 .scratch> view x
 ```
 
 Test that replace works with types
 ```ucm
-.scratch> replace.term X Y
+.scratch> replace.any X Y
 .scratch> view X
 ```
 
 Try with a type/term mismatch
 ```ucm:error
-.scratch> replace.term X x
+.scratch> replace.any X x
 ```
 ```ucm:error
-.scratch> replace.term y Y 
+.scratch> replace.any y Y 
 ```
 
 Try with missing references
 ```ucm:error
-.scratch> replace.term X NOPE
+.scratch> replace.any X NOPE
 ```
 ```ucm:error
-.scratch> replace.term y nope
+.scratch> replace.any y nope
 ```
 ```ucm:error
-.scratch> replace.term nope X
+.scratch> replace.any nope X
 ```
 ```ucm:error
-.scratch> replace.term nope y
+.scratch> replace.any nope y
 ```
 ```ucm:error
-.scratch> replace.term nope nope
+.scratch> replace.any nope nope
 ```

--- a/unison-src/transcripts/command-replace.md
+++ b/unison-src/transcripts/command-replace.md
@@ -1,0 +1,56 @@
+# Replace with terms and types
+
+Let's set up some definitions to start:
+
+```ucm:hide
+.> builtins.merge
+```
+
+```unison
+x = 1
+y = 2
+
+type X = One Nat
+type Y = Two Nat Nat
+```
+
+```ucm
+.scratch> add
+```
+
+Test that replace works with terms
+```ucm
+.scratch> replace.term x y
+.scratch> view x
+```
+
+Test that replace works with types
+```ucm
+.scratch> replace.term X Y
+.scratch> view X
+```
+
+Try with a type/term mismatch
+```ucm:error
+.scratch> replace.term X x
+```
+```ucm:error
+.scratch> replace.term y Y 
+```
+
+Try with missing references
+```ucm:error
+.scratch> replace.term X NOPE
+```
+```ucm:error
+.scratch> replace.term y nope
+```
+```ucm:error
+.scratch> replace.term nope X
+```
+```ucm:error
+.scratch> replace.term nope y
+```
+```ucm:error
+.scratch> replace.term nope nope
+```

--- a/unison-src/transcripts/command-replace.output.md
+++ b/unison-src/transcripts/command-replace.output.md
@@ -39,7 +39,7 @@ type Y = Two Nat Nat
 ```
 Test that replace works with terms
 ```ucm
-.scratch> replace.any x y
+.scratch> replace x y
 
   Done.
 
@@ -51,7 +51,7 @@ Test that replace works with terms
 ```
 Test that replace works with types
 ```ucm
-.scratch> replace.any X Y
+.scratch> replace X Y
 
   Done.
 
@@ -62,7 +62,7 @@ Test that replace works with types
 ```
 Try with a type/term mismatch
 ```ucm
-.scratch> replace.any X x
+.scratch> replace X x
 
   ⚠️
   
@@ -71,7 +71,7 @@ Try with a type/term mismatch
 
 ```
 ```ucm
-.scratch> replace.any y Y 
+.scratch> replace y Y 
 
   ⚠️
   
@@ -81,7 +81,7 @@ Try with a type/term mismatch
 ```
 Try with missing references
 ```ucm
-.scratch> replace.any X NOPE
+.scratch> replace X NOPE
 
   ⚠️
   
@@ -90,7 +90,7 @@ Try with missing references
 
 ```
 ```ucm
-.scratch> replace.any y nope
+.scratch> replace y nope
 
   ⚠️
   
@@ -99,7 +99,7 @@ Try with missing references
 
 ```
 ```ucm
-.scratch> replace.any nope X
+.scratch> replace nope X
 
   ⚠️
   
@@ -108,7 +108,7 @@ Try with missing references
 
 ```
 ```ucm
-.scratch> replace.any nope y
+.scratch> replace nope y
 
   ⚠️
   
@@ -117,7 +117,7 @@ Try with missing references
 
 ```
 ```ucm
-.scratch> replace.any nope nope
+.scratch> replace nope nope
 
   ⚠️
   

--- a/unison-src/transcripts/command-replace.output.md
+++ b/unison-src/transcripts/command-replace.output.md
@@ -39,7 +39,7 @@ type Y = Two Nat Nat
 ```
 Test that replace works with terms
 ```ucm
-.scratch> replace.term x y
+.scratch> replace.any x y
 
   Done.
 
@@ -51,7 +51,7 @@ Test that replace works with terms
 ```
 Test that replace works with types
 ```ucm
-.scratch> replace.term X Y
+.scratch> replace.any X Y
 
   Done.
 
@@ -62,7 +62,7 @@ Test that replace works with types
 ```
 Try with a type/term mismatch
 ```ucm
-.scratch> replace.term X x
+.scratch> replace.any X x
 
   ⚠️
   
@@ -71,7 +71,7 @@ Try with a type/term mismatch
 
 ```
 ```ucm
-.scratch> replace.term y Y 
+.scratch> replace.any y Y 
 
   ⚠️
   
@@ -81,7 +81,7 @@ Try with a type/term mismatch
 ```
 Try with missing references
 ```ucm
-.scratch> replace.term X NOPE
+.scratch> replace.any X NOPE
 
   ⚠️
   
@@ -90,7 +90,7 @@ Try with missing references
 
 ```
 ```ucm
-.scratch> replace.term y nope
+.scratch> replace.any y nope
 
   ⚠️
   
@@ -99,7 +99,7 @@ Try with missing references
 
 ```
 ```ucm
-.scratch> replace.term nope X
+.scratch> replace.any nope X
 
   ⚠️
   
@@ -108,7 +108,7 @@ Try with missing references
 
 ```
 ```ucm
-.scratch> replace.term nope y
+.scratch> replace.any nope y
 
   ⚠️
   
@@ -117,7 +117,7 @@ Try with missing references
 
 ```
 ```ucm
-.scratch> replace.term nope nope
+.scratch> replace.any nope nope
 
   ⚠️
   

--- a/unison-src/transcripts/command-replace.output.md
+++ b/unison-src/transcripts/command-replace.output.md
@@ -66,8 +66,7 @@ Try with a type/term mismatch
 
   ⚠️
   
-  The following names were not found in the codebase. Check your spelling.
-    X
+  I was expecting either two types or two terms but was given a type X and a term x.
 
 ```
 ```ucm
@@ -75,8 +74,7 @@ Try with a type/term mismatch
 
   ⚠️
   
-  The following names were not found in the codebase. Check your spelling.
-    Y
+  I was expecting either two types or two terms but was given a type Y and a term y.
 
 ```
 Try with missing references

--- a/unison-src/transcripts/command-replace.output.md
+++ b/unison-src/transcripts/command-replace.output.md
@@ -1,0 +1,128 @@
+# Replace with terms and types
+
+Let's set up some definitions to start:
+
+```unison
+x = 1
+y = 2
+
+type X = One Nat
+type Y = Two Nat Nat
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      type X
+      type Y
+      x : Nat
+      y : Nat
+
+```
+```ucm
+  ☝️  The namespace .scratch is empty.
+
+.scratch> add
+
+  ⍟ I've added these definitions:
+  
+    type X
+    type Y
+    x : Nat
+    y : Nat
+
+```
+Test that replace works with terms
+```ucm
+.scratch> replace.term x y
+
+  Done.
+
+.scratch> view x
+
+  x : Nat
+  x = 2
+
+```
+Test that replace works with types
+```ucm
+.scratch> replace.term X Y
+
+  Done.
+
+.scratch> view X
+
+  type X = Two Nat Nat
+
+```
+Try with a type/term mismatch
+```ucm
+.scratch> replace.term X x
+
+  ⚠️
+  
+  The following names were not found in the codebase. Check your spelling.
+    X
+
+```
+```ucm
+.scratch> replace.term y Y 
+
+  ⚠️
+  
+  The following names were not found in the codebase. Check your spelling.
+    Y
+
+```
+Try with missing references
+```ucm
+.scratch> replace.term X NOPE
+
+  ⚠️
+  
+  The following names were not found in the codebase. Check your spelling.
+    NOPE
+
+```
+```ucm
+.scratch> replace.term y nope
+
+  ⚠️
+  
+  The following names were not found in the codebase. Check your spelling.
+    nope
+
+```
+```ucm
+.scratch> replace.term nope X
+
+  ⚠️
+  
+  The following names were not found in the codebase. Check your spelling.
+    nope
+
+```
+```ucm
+.scratch> replace.term nope y
+
+  ⚠️
+  
+  The following names were not found in the codebase. Check your spelling.
+    nope
+
+```
+```ucm
+.scratch> replace.term nope nope
+
+  ⚠️
+  
+  The following names were not found in the codebase. Check your spelling.
+    nope
+    nope
+
+```

--- a/unison-src/transcripts/fix1334.md
+++ b/unison-src/transcripts/fix1334.md
@@ -2,6 +2,8 @@ Previously, the `alias.term` and `alias.type` would fail if the source argument 
 
 With this PR, the source of an alias can be a short hash (even of a definition that doesn't currently have a name in the namespace) along with a name or hash-qualified name from the current namespace as usual, and the arguments to `replace.term` and `replace.type` can be a short hash, a name, or a hash-qualified name.
 
+Note: `replace.term` and `replace.type` have since been replaced with just `replace`.
+
 Let's make some hash-only aliases, now that we can. :mad-with-power-emoji:
 
 ```ucm
@@ -22,10 +24,10 @@ h = f + 1
 .> add
 ```
 
-We used to have to know the full hash for a definition to be able to use the `replace.*` commands, but now we don't:
+We used to have to know the full hash for a definition to be able to use the `replace` commands, but now we don't:
 ```ucm
 .> names g
-.> replace.term f g
+.> replace f g
 .> names g
 .> view.patch
 ```

--- a/unison-src/transcripts/fix1334.output.md
+++ b/unison-src/transcripts/fix1334.output.md
@@ -2,6 +2,8 @@ Previously, the `alias.term` and `alias.type` would fail if the source argument 
 
 With this PR, the source of an alias can be a short hash (even of a definition that doesn't currently have a name in the namespace) along with a name or hash-qualified name from the current namespace as usual, and the arguments to `replace.term` and `replace.type` can be a short hash, a name, or a hash-qualified name.
 
+Note: `replace.term` and `replace.type` have since been replaced with just `replace`.
+
 Let's make some hash-only aliases, now that we can. :mad-with-power-emoji:
 
 ```ucm
@@ -53,7 +55,7 @@ h = f + 1
     h : Cat
 
 ```
-We used to have to know the full hash for a definition to be able to use the `replace.*` commands, but now we don't:
+We used to have to know the full hash for a definition to be able to use the `replace` commands, but now we don't:
 ```ucm
 .> names g
 
@@ -61,7 +63,7 @@ We used to have to know the full hash for a definition to be able to use the `re
   Hash:   #52addbrohu
   Names:  g
 
-.> replace.term f g
+.> replace f g
 
   Done.
 

--- a/unison-src/transcripts/resolve.md
+++ b/unison-src/transcripts/resolve.md
@@ -4,7 +4,7 @@
 .> builtins.merge
 ```
 
-The `ucm` tool tracks edits to hashes in an object called a _patch_. When patches get merged, sometimes those patches will have conflicting edits. The `replace.term` command helps resolve such conflicts.
+The `ucm` tool tracks edits to hashes in an object called a _patch_. When patches get merged, sometimes those patches will have conflicting edits. The `replace` command helps resolve such conflicts.
 
 First, let's make a new namespace, `example.resolve`:
 
@@ -91,7 +91,7 @@ We see that `#44954ulpdf` (the original hash of `a.foo`) got replaced with _both
 We can resolve this conflict by picking one of the terms as the "winner":
 
 ```ucm
-.example.resolve.c> replace.term #44954ulpdf #8e68dvpr0a
+.example.resolve.c> replace #44954ulpdf #8e68dvpr0a
 ```
 
 This changes the merged `c.patch` so that only the edit from #44954ulpdf to  #8e68dvpr0a remains:

--- a/unison-src/transcripts/resolve.output.md
+++ b/unison-src/transcripts/resolve.output.md
@@ -1,6 +1,6 @@
 # Resolving edit conflicts in `ucm`
 
-The `ucm` tool tracks edits to hashes in an object called a _patch_. When patches get merged, sometimes those patches will have conflicting edits. The `replace.term` command helps resolve such conflicts.
+The `ucm` tool tracks edits to hashes in an object called a _patch_. When patches get merged, sometimes those patches will have conflicting edits. The `replace` command helps resolve such conflicts.
 
 First, let's make a new namespace, `example.resolve`:
 
@@ -203,7 +203,7 @@ We see that `#44954ulpdf` (the original hash of `a.foo`) got replaced with _both
 We can resolve this conflict by picking one of the terms as the "winner":
 
 ```ucm
-.example.resolve.c> replace.term #44954ulpdf #8e68dvpr0a
+.example.resolve.c> replace #44954ulpdf #8e68dvpr0a
 
   Done.
 


### PR DESCRIPTION
https://github.com/unisonweb/unison/issues/318
Paired with @bontaq 

## Overview

1) This PR creates a new command `ReplaceI` that combines the behaviors of `ReplaceTermI` and `ReplaceTypeI`. It also exposes this to the repl as `replace`.
2) `replace.term` and `replace.type` are removed.
3) Adds a new error message for type/term mismatches.

## Implementation notes

Basically just mashed the existing code together. Would appreciate suggestions on how to factor out these behaviors into smaller functions. Decided not to do that right now because so many dependencies are declared at the top of the function and I wasn't finding a clean way to pass them around (without big weird function types).

## Interesting/controversial decisions

1) Ideally, this should be refactored into smaller reusable functions
2) Removed `replace.term` and `replace.type`

## Test coverage

Added a transcript test for happy path and failure cases.
Updated existing tests that depended on `replace.term` or `replace.type`.

## Loose ends

1) Returns an error in the big case block. I'm not sure what could actually be matched there -- but if you can think of something please let me know!