### PR TITLE
fix #2053 by using Var.rawName to produce text for synthetic vars

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Conversions.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Conversions.hs
@@ -242,8 +242,7 @@ symbol2to1 :: V2.Symbol -> V1.Symbol
 symbol2to1 (V2.Symbol i t) = V1.Symbol i (Var.User t)
 
 symbol1to2 :: V1.Symbol -> V2.Symbol
-symbol1to2 (V1.Symbol i (Var.User t)) = V2.Symbol i t
-symbol1to2 x = error $ "unimplemented: symbol1to2 " ++ show x
+symbol1to2 (V1.Symbol i varType) = V2.Symbol i (Var.rawName varType)
 
 shortHashSuffix1to2 :: Text -> V1.Reference.Pos
 shortHashSuffix1to2 =

--- a/unison-src/transcripts/fix2053.md
+++ b/unison-src/transcripts/fix2053.md
@@ -1,0 +1,7 @@
+```ucm:hide
+.> builtins.mergeio
+```
+
+```ucm
+.> display List.map
+```

--- a/unison-src/transcripts/fix2053.output.md
+++ b/unison-src/transcripts/fix2053.output.md
@@ -1,0 +1,13 @@
+```ucm
+.> display List.map
+
+  go f i as acc =
+    _pattern = List.at i as
+    match _pattern with
+      None           -> acc
+      Some _pattern1 ->
+        use Nat +
+        go f (i + 1) as (acc :+ f _pattern)
+  f a -> go f 0 a []
+
+```


### PR DESCRIPTION
`display <foo>` stores results in the watch expression cache, which doesn't currently model the synthetic `Var`s that can come out of the runtime.  This PR just flattens them down to `Text`.