### PR TITLE
Fix misspelling of definition

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -54,3 +54,4 @@ The format for this list: name, GitHub handle, and then optional blurb about wha
 * Joseph Morag (@jmorag)
 * Tavish Pegram (@tapegram)
 * Javier Neira (@jneira)
+* Simon Højberg (@hojberg)

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -1328,7 +1328,7 @@ renderNameConflicts conflictedTypeNames conflictedTermNames =
     showConflictedNames "terms" conflictedTermNames,
     tip $ "This occurs when merging branches that both independently introduce the same name. Use "
         <> makeExample IP.view (prettyName <$> take 3 allNames)
-        <> "to see the conflicting defintions, then use "
+        <> "to see the conflicting definitions, then use "
         <> makeExample' (if (not . null) conflictedTypeNames
                          then IP.renameType else IP.renameTerm)
         <> "to resolve the conflicts."

--- a/unison-src/transcripts-using-base/doc.md
+++ b/unison-src/transcripts-using-base/doc.md
@@ -9,7 +9,7 @@ Unison documentation is written in Unison and has some neat features:
 * The documentation type provides a rich vocabulary of elements that go beyond markdown, including asides, callouts, tooltips, and more.
 * Docs may contain Unison code which is parsed and typechecked to ensure validity. No more out of date examples that don't compile or assume a bunch of implicit context!
 * Embeded examples are live and can show the results of evaluation. This uses the same evaluation cache as Unison's scratch files, allowing Unison docs to function like well-commented spreadsheets or notebooks.
-* Links to other definitions are typechecked to ensure they point to valid defintions. The links are resolved to hashes and won't be broken by name changes or moving definitions around.
+* Links to other definitions are typechecked to ensure they point to valid definitions. The links are resolved to hashes and won't be broken by name changes or moving definitions around.
 * Docs can be included in other docs and you can assemble documentation programmatically, using Unison code.
 * There's a powerful textual syntax for all of the above, which we'll introduce next.
 

--- a/unison-src/transcripts-using-base/doc.output.md
+++ b/unison-src/transcripts-using-base/doc.output.md
@@ -5,7 +5,7 @@ Unison documentation is written in Unison and has some neat features:
 * The documentation type provides a rich vocabulary of elements that go beyond markdown, including asides, callouts, tooltips, and more.
 * Docs may contain Unison code which is parsed and typechecked to ensure validity. No more out of date examples that don't compile or assume a bunch of implicit context!
 * Embeded examples are live and can show the results of evaluation. This uses the same evaluation cache as Unison's scratch files, allowing Unison docs to function like well-commented spreadsheets or notebooks.
-* Links to other definitions are typechecked to ensure they point to valid defintions. The links are resolved to hashes and won't be broken by name changes or moving definitions around.
+* Links to other definitions are typechecked to ensure they point to valid definitions. The links are resolved to hashes and won't be broken by name changes or moving definitions around.
 * Docs can be included in other docs and you can assemble documentation programmatically, using Unison code.
 * There's a powerful textual syntax for all of the above, which we'll introduce next.
 

--- a/unison-src/transcripts/resolve.output.md
+++ b/unison-src/transcripts/resolve.output.md
@@ -231,7 +231,7 @@ We still have a remaining _name conflict_ since it just so happened that both of
   
   Tip: This occurs when merging branches that both independently
        introduce the same name. Use `view foo` to see the
-       conflicting defintions, then use `move.term` to resolve
+       conflicting definitions, then use `move.term` to resolve
        the conflicts.
 
 ```


### PR DESCRIPTION
## Overview

Very simple change: there was a few misspellings of definition with related to the docs help and conflicts.

## Loose Ends
~~I'm not sure which transcripts gets generated and how to deal with that? There are 2 more misspellings that I didn't fix since they were in an `*.output.*` transcript.~~ Edit: I ran transcripts locally with `stack exec transcripts` and that seems to have done the trick.