### PR TITLE
Avoid building the complete FQN mapping when only a few keys are needed

### DIFF
--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -554,22 +554,19 @@ prettyDefinitionsBySuffixes relativeTo root renderWidth suffixifyBindings codeba
         getCurrentParseNames (fromMaybe Path.empty relativeTo) branch
       ppe   = PPE.fromNamesDecl hqLength printNames
       width = mayDefault renderWidth
+      isAbsolute (Name.toText -> n) = "." `Text.isPrefixOf` n && n /= "."
       termFqns :: Map Reference (Set Text)
       termFqns = Map.mapWithKey f terms
        where
-        rel = R.filterDom (\n -> "." `Text.isPrefixOf` n && n /= ".")
-            . R.mapDom Name.toText
-            . Names.terms
-            $ currentNames parseNames
-        f k _ = R.lookupRan (Referent.Ref' k) rel
+        rel = Names.terms $ currentNames parseNames
+        f k _ = Set.fromList . fmap Name.toText . filter isAbsolute . toList
+              $ R.lookupRan (Referent.Ref' k) rel
       typeFqns :: Map Reference (Set Text)
       typeFqns = Map.mapWithKey f types
        where
-        rel = R.filterDom (\n -> "." `Text.isPrefixOf` n && n /= ".")
-            . R.mapDom Name.toText
-            . Names.types
-            $ currentNames parseNames
-        f k _ = R.lookupRan k rel
+        rel = Names.types $ currentNames parseNames
+        f k _ = Set.fromList . fmap Name.toText . filter isAbsolute . toList
+              $ R.lookupRan k rel
       flatten = Set.toList . fromMaybe Set.empty
       mkTermDefinition r tm = do
         ts <- lift (Codebase.getTypeOfTerm codebase r)


### PR DESCRIPTION
Noticed this while working on `Backend`. One of the things done when fetching a definition is to return all the fully-qualified names for that definition. Currently, that's done by building a `Map Reference (Set Text)` for ALL references in the `Branch`, even though we only ever do one (or a few) lookups in that `Map` for the references we're actually returning.

This tweak avoids building any map at all - it just does the relational lookup and filters on the way out to just include the FQNs.

Manually tested just by loading some definitions in the codebase UI.