### PR TITLE
Avoid rebuilding term and type relations on each call to fuzzy find

### DIFF
--- a/unison-core/src/Unison/Names2.hs
+++ b/unison-core/src/Unison/Names2.hs
@@ -86,8 +86,9 @@ fuzzyFind query names =
   fmap flatten
     .  fuzzyFinds (Name.toString . fst) query
     .  Map.toList
-    $  R.toMultimap (R.mapRan Left $ terms names)
-    <> R.toMultimap (R.mapRan Right $ types names)
+    -- `mapMonotonic` is safe here and saves a log n factor
+    $  (Set.mapMonotonic Left <$> R.toMultimap (terms names))
+    <> (Set.mapMonotonic Right <$> R.toMultimap (types names))
  where
   flatten (a, (b, c)) = (a, b, c)
   fuzzyFinds :: (a -> String) -> [String] -> [a] -> [(FZF.Alignment, a)]


### PR DESCRIPTION
Noticed this randomly, see the diff. Similar idea to #2170 

We were rebuilding the term and type relations on each call into the fuzzy find code, but with a slight rephrasing, you can use the existing relations. 

With this change, there are no relation operations happening in the fuzzy find code, and the only `Map` operation being used is functor mapping over the values and `toList`, neither of which does any rebalancing. (Caveat is that relations are currently still built from scratch from the branch before the fuzzy find gets called... so this PR is just avoiding an extra rebuilding)

I couldn't exactly tell if this made a performance difference with the debouncing that's being done.

Tested manually, just by using the local codebase UI.
