### PR TITLE
`{-#COMPLETE#-}` seems to have been fixed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,9 +41,9 @@ jobs:
             unison-core/.stack-work
             yaks/easytest/.stack-work
             # Main cache key: commit hash. This should always result in a cache miss...
-          key: stack-work-0_${{matrix.os}}-${{github.sha}}
+          key: stack-work-1_${{matrix.os}}-${{github.sha}}
           # ...but then fall back on the latest cache stored (on this branch)
-          restore-keys: stack-work-0_${{matrix.os}}-
+          restore-keys: stack-work-1_${{matrix.os}}-
 
       # Install stack by downloading the binary from GitHub. The installation process is different for Linux and macOS,
       # so this is split into two steps, only one of which will run on any particular build.

--- a/parser-typechecker/src/Unison/Codebase/Serialization/V1.hs
+++ b/parser-typechecker/src/Unison/Codebase/Serialization/V1.hs
@@ -239,7 +239,6 @@ putReference r = case r of
     putHash hash
     putLength i
     putLength n
-  _ -> error "unpossible"
 
 getReference :: MonadGet m => m Reference
 getReference = do

--- a/parser-typechecker/src/Unison/Codecs.hs
+++ b/parser-typechecker/src/Unison/Codecs.hs
@@ -315,7 +315,6 @@ serializeReference ref = case ref of
     putByteString bs
     putLength i
     putLength n
-  _ -> error "impossible"
 
 serializeConstructorArities :: MonadPut m => Reference -> [Int] -> m ()
 serializeConstructorArities r constructorArities = do

--- a/unison-core/src/Unison/Reference.hs
+++ b/unison-core/src/Unison/Reference.hs
@@ -57,8 +57,7 @@ data Reference
 pattern Derived :: H.Hash -> Pos -> Size -> Reference
 pattern Derived h i n = DerivedId (Id h i n)
 
--- A good idea, but causes a weird problem with view patterns in PatternP.hs in ghc 8.4.3
---{-# COMPLETE Builtin, Derived #-}
+{-# COMPLETE Builtin, Derived #-}
 
 -- | @Pos@ is a position into a cycle of size @Size@, as cycles are hashed together.
 data Id = Id H.Hash Pos Size deriving (Generic)
@@ -80,7 +79,6 @@ toShortHash (Derived h i n) = SH.ShortHash (H.base32Hex h) index Nothing
   where
     -- todo: remove `n` parameter; must also update readSuffix
     index = Just $ showSuffix i n
-toShortHash (DerivedId _) = error "this should be covered above"
 
 -- toShortHash . fromJust . fromShortHash == id and
 -- fromJust . fromShortHash . toShortHash == id
@@ -127,11 +125,9 @@ newtype Component = Component { members :: Set Reference }
 
 -- Gives the component (dependency cycle) that the reference is a part of
 componentFor :: Reference -> Component
-componentFor b@(Builtin        _         ) = Component (Set.singleton b)
-componentFor (  DerivedId (Id h _ n)) = Component
-  (Set.fromList
-    [ DerivedId (Id h i n) | i <- take (fromIntegral n) [0 ..] ]
-  )
+componentFor b@Builtin {} = Component (Set.singleton b)
+componentFor (Derived h _ n) =
+  Component $ Set.fromList [Derived h i n | i <- take (fromIntegral n) [0 ..]]
 
 derivedBase32Hex :: Text -> Pos -> Size -> Reference
 derivedBase32Hex b32Hex i n = DerivedId (Id (fromMaybe msg h) i n)

--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -1093,8 +1093,6 @@ instance Var v => Hashable1 (F v a p) where
                   Or     x y -> [tag 17, hashed $ hash x, hashed $ hash y]
                   TermLink r -> [tag 18, accumulateToken r]
                   TypeLink r -> [tag 19, accumulateToken r]
-                  _ ->
-                    error $ "unhandled case in hash: " <> show (void e)
 
 -- mostly boring serialization code below ...
 


### PR DESCRIPTION
Until recently we weren't able to make use of the `COMPLETE` pragma for `Reference` pattern synonyms; but now we can, apparently.

https://github.com/unisonweb/unison/blob/a166d718c01bec43bc2590b21a5daacab31f4613/unison-core/src/Unison/Reference.hs#L60-L61