### PR TITLE
finer-grained types for `RemoteRepo`

### DIFF
--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -16,7 +16,7 @@ import Unison.Codebase.Branch (Branch)
 import qualified Unison.Codebase.Branch as Branch
 import qualified Unison.Codebase.CodeLookup as CL
 import Unison.Codebase.Editor.Git (withStatus)
-import Unison.Codebase.Editor.RemoteRepo (RemoteNamespace, RemoteRepo)
+import Unison.Codebase.Editor.RemoteRepo (ReadRemoteNamespace, WriteRepo)
 import Unison.Codebase.GitError (GitError)
 import Unison.Codebase.Patch (Patch)
 import qualified Unison.Codebase.Reflog as Reflog
@@ -86,8 +86,8 @@ data Codebase m v a =
            , syncFromDirectory  :: CodebasePath -> SyncMode -> Branch m -> m ()
            -- This copies all the dependencies of `b` from this Codebase
            , syncToDirectory    :: CodebasePath -> SyncMode -> Branch m -> m ()
-           , viewRemoteBranch' :: RemoteNamespace -> m (Either GitError (m (), Branch m, CodebasePath))
-           , pushGitRootBranch :: Branch m -> RemoteRepo -> SyncMode -> m (Either GitError ())
+           , viewRemoteBranch' :: ReadRemoteNamespace -> m (Either GitError (m (), Branch m, CodebasePath))
+           , pushGitRootBranch :: Branch m -> WriteRepo -> SyncMode -> m (Either GitError ())
 
            -- Watch expressions are part of the codebase, the `Reference.Id` is
            -- the hash of the source of the watch expression, and the `Term v a`
@@ -373,7 +373,7 @@ importRemoteBranch ::
   forall m v a.
   MonadIO m =>
   Codebase m v a ->
-  RemoteNamespace ->
+  ReadRemoteNamespace ->
   SyncMode ->
   m (Either GitError (Branch m))
 importRemoteBranch codebase ns mode = runExceptT do
@@ -392,7 +392,7 @@ importRemoteBranch codebase ns mode = runExceptT do
 viewRemoteBranch ::
   MonadIO m =>
   Codebase m v a ->
-  RemoteNamespace ->
+  ReadRemoteNamespace ->
   m (Either GitError (m (), Branch m))
 viewRemoteBranch codebase ns = runExceptT do
   (cleanup, branch, _) <- ExceptT $ viewRemoteBranch' codebase ns

--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -177,13 +177,13 @@ data Command m i v a where
   Merge :: Branch.MergeMode -> Branch m -> Branch m -> Command m i v (Branch m)
 
   ViewRemoteBranch ::
-    RemoteNamespace -> Command m i v (Either GitError (m (), Branch m))
+    ReadRemoteNamespace -> Command m i v (Either GitError (m (), Branch m))
 
   -- we want to import as little as possible, so we pass the SBH/path as part
   -- of the `RemoteNamespace`.  The Branch that's returned should be fully
   -- imported and not retain any resources from the remote codebase
   ImportRemoteBranch ::
-    RemoteNamespace -> SyncMode -> Command m i v (Either GitError (Branch m))
+    ReadRemoteNamespace -> SyncMode -> Command m i v (Either GitError (Branch m))
 
   -- Syncs the Branch to some codebase and updates the head to the head of this causal.
   -- Any definitions in the head of the supplied branch that aren't in the target
@@ -191,7 +191,7 @@ data Command m i v a where
   SyncLocalRootBranch :: Branch m -> Command m i v ()
 
   SyncRemoteRootBranch ::
-    RemoteRepo -> Branch m -> SyncMode -> Command m i v (Either GitError ())
+    WriteRepo -> Branch m -> SyncMode -> Command m i v (Either GitError ())
 
   AppendToReflog :: Text -> Branch m -> Branch m -> Command m i v ()
 

--- a/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
@@ -10,7 +10,7 @@ import Control.Monad.Except (MonadError, throwError)
 import qualified Data.Text as Text
 import Shellmet (($?), ($^), ($|))
 import System.FilePath ((</>))
-import Unison.Codebase.Editor.RemoteRepo (RemoteRepo (GitRepo))
+import Unison.Codebase.Editor.RemoteRepo (ReadRepo (ReadGitRepo))
 import Unison.Codebase.GitError (GitError)
 import qualified Unison.Codebase.GitError as GitError
 import qualified Unison.Util.Exception as Ex
@@ -56,12 +56,8 @@ withStatus str ma = do
 
 -- | Given a remote git repo url, and branch/commit hash (currently
 -- not allowed): checks for git, clones or updates a cached copy of the repo
-pullBranch :: (MonadIO m, MonadCatch m, MonadError GitError m) => RemoteRepo -> m CodebasePath
-pullBranch (GitRepo _uri (Just t)) = error $
-  "Pulling a specific commit isn't fully implemented or tested yet.\n" ++
-  "InputPatterns.parseUri was expected to have prevented you " ++
-  "from supplying the git treeish `" ++ Text.unpack t ++ "`!"
-pullBranch repo@(GitRepo uri Nothing) = do
+pullBranch :: (MonadIO m, MonadCatch m, MonadError GitError m) => ReadRepo -> m CodebasePath
+pullBranch repo@(ReadGitRepo uri) = do
   checkForGit
   localPath <- tempGitDir uri
   ifM (doesDirectoryExist localPath)

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -35,7 +35,7 @@ import Unison.Codebase.Editor.SlurpResult (SlurpResult(..))
 import qualified Unison.Codebase.Editor.SlurpResult as Slurp
 import Unison.Codebase.Editor.SlurpComponent (SlurpComponent(..))
 import qualified Unison.Codebase.Editor.SlurpComponent as SC
-import Unison.Codebase.Editor.RemoteRepo (RemoteNamespace, printNamespace)
+import Unison.Codebase.Editor.RemoteRepo (printNamespace, WriteRemotePath, writeToRead, writePathToRead)
 import qualified Unison.CommandLine.InputPattern as InputPattern
 import qualified Unison.CommandLine.InputPatterns as InputPatterns
 
@@ -1357,7 +1357,7 @@ loop = do
               in  case t of
                     HQ.HashOnly h ->
                       hashConflicted h rs'
-                    (Path.parseHQSplit' . HQ.toString -> Right n) -> 
+                    (Path.parseHQSplit' . HQ.toString -> Right n) ->
                       termConflicted n rs'
                     _ -> respond . BadName $ HQ.toString t
 
@@ -1697,7 +1697,7 @@ loop = do
         respond $ ListEdits patch ppe
 
       PullRemoteBranchI mayRepo path syncMode -> unlessError do
-        ns <- resolveConfiguredGitUrl Pull path mayRepo
+        ns <- maybe (writePathToRead <$> resolveConfiguredGitUrl Pull path) pure mayRepo
         lift $ unlessGitError do
           b <- importRemoteBranch ns syncMode
           let msg = Just $ PullAlreadyUpToDate ns path
@@ -1707,26 +1707,19 @@ loop = do
       PushRemoteBranchI mayRepo path syncMode -> do
         let srcAbs = resolveToAbsolute path
         srcb <- getAt srcAbs
-        let expandRepo (r, rp) = (r, Nothing, rp)
         unlessError do
-          (repo, sbh, remotePath) <-
-            resolveConfiguredGitUrl Push path (fmap expandRepo mayRepo)
-          case sbh of
-            Nothing -> lift $ unlessGitError do
-              (cleanup, remoteRoot) <- unsafeTime "Push viewRemoteBranch" $
-                viewRemoteBranch (repo, Nothing, Path.empty)
-              -- We don't merge `srcb` with the remote namespace, `r`, we just
-              -- replace it. The push will be rejected if this rewinds time
-              -- or misses any new updates in `r` that aren't in `srcb` already.
-              let newRemoteRoot = Branch.modifyAt remotePath (const srcb) remoteRoot
-              unsafeTime "Push syncRemoteRootBranch" $
-                syncRemoteRootBranch repo newRemoteRoot syncMode
-              lift . eval $ Eval cleanup
-              lift $ respond Success
-            Just{} ->
-              error $ "impossible match, resolveConfiguredGitUrl shouldn't return"
-                  <> " `Just` unless it was passed `Just`; and here it is passed"
-                  <> " `Nothing` by `expandRepo`."
+          (repo, remotePath) <- maybe (resolveConfiguredGitUrl Push path) pure mayRepo
+          lift $ unlessGitError do
+            (cleanup, remoteRoot) <- unsafeTime "Push viewRemoteBranch" $
+              viewRemoteBranch (writeToRead repo, Nothing, Path.empty)
+            -- We don't merge `srcb` with the remote namespace, `r`, we just
+            -- replace it. The push will be rejected if this rewinds time
+            -- or misses any new updates in `r` that aren't in `srcb` already.
+            let newRemoteRoot = Branch.modifyAt remotePath (const srcb) remoteRoot
+            unsafeTime "Push syncRemoteRootBranch" $
+              syncRemoteRootBranch repo newRemoteRoot syncMode
+            lift . eval $ Eval cleanup
+            lift $ respond Success
       ListDependentsI hq -> -- todo: add flag to handle transitive efficiently
         resolveHQToLabeledDependencies hq >>= \lds ->
           if null lds
@@ -1860,26 +1853,20 @@ loop = do
       resolveConfiguredGitUrl
         :: PushPull
         -> Path'
-        -> Maybe RemoteNamespace
-        -> ExceptT (Output v) (Action' m v) RemoteNamespace
-      resolveConfiguredGitUrl pushPull destPath' = \case
-        Just ns -> pure ns
-        Nothing -> ExceptT do
-          let destPath = resolveToAbsolute destPath'
-          let configKey = gitUrlKey destPath
-          (eval . ConfigLookup) configKey >>= \case
-            Just url ->
-              case P.parse UriParser.repoPath (Text.unpack configKey) url of
-                Left e ->
-                  pure . Left $
-                    ConfiguredGitUrlParseError pushPull destPath' url (show e)
-                Right (repo, Just sbh, remotePath) ->
-                  pure . Left $
-                    ConfiguredGitUrlIncludesShortBranchHash pushPull repo sbh remotePath
-                Right ns ->
-                  pure . Right $ ns
-            Nothing ->
-              pure . Left $ NoConfiguredGitUrl pushPull destPath'
+        -> ExceptT (Output v) (Action' m v) WriteRemotePath
+      resolveConfiguredGitUrl pushPull destPath' = ExceptT do
+        let destPath = resolveToAbsolute destPath'
+        let configKey = gitUrlKey destPath
+        (eval . ConfigLookup) configKey >>= \case
+          Just url ->
+            case P.parse UriParser.writeRepoPath (Text.unpack configKey) url of
+              Left e ->
+                pure . Left $
+                  ConfiguredGitUrlParseError pushPull destPath' url (show e)
+              Right ns ->
+                pure . Right $ ns
+          Nothing ->
+            pure . Left $ NoConfiguredGitUrl pushPull destPath'
 
       gitUrlKey = configKey "GitUrl"
 

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -50,10 +50,10 @@ data Input
     | MergeLocalBranchI Path' Path' Branch.MergeMode
     | PreviewMergeLocalBranchI Path' Path'
     | DiffNamespaceI Path' Path' -- old new
-    | PullRemoteBranchI (Maybe RemoteNamespace) Path' SyncMode
-    | PushRemoteBranchI (Maybe RemoteHead) Path' SyncMode
-    | CreatePullRequestI RemoteNamespace RemoteNamespace
-    | LoadPullRequestI RemoteNamespace RemoteNamespace Path'
+    | PullRemoteBranchI (Maybe ReadRemoteNamespace) Path' SyncMode
+    | PushRemoteBranchI (Maybe WriteRemotePath) Path' SyncMode
+    | CreatePullRequestI ReadRemoteNamespace ReadRemoteNamespace
+    | LoadPullRequestI ReadRemoteNamespace ReadRemoteNamespace Path'
     | ResetRootI (Either ShortBranchHash Path')
     -- todo: Q: Does it make sense to publish to not-the-root of a Github repo?
     --          Does it make sense to fork from not-the-root of a Github repo?

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -22,7 +22,7 @@ import Unison.Codebase.Editor.Input
 import Unison.Codebase (GetRootBranchError)
 import Unison.Codebase.Editor.SlurpResult (SlurpResult(..))
 import Unison.Codebase.GitError
-import Unison.Codebase.Path (Path', Path)
+import Unison.Codebase.Path (Path')
 import Unison.Codebase.Patch (Patch)
 import Unison.Name ( Name )
 import Unison.Names2 ( Names )
@@ -79,7 +79,7 @@ data NumberedOutput v
   | ShowDiffAfterMergePropagate Path.Path' Path.Absolute Path.Path' PPE.PrettyPrintEnv (BranchDiffOutput v Ann)
   | ShowDiffAfterMergePreview Path.Path' Path.Absolute PPE.PrettyPrintEnv (BranchDiffOutput v Ann)
   | ShowDiffAfterPull Path.Path' Path.Absolute PPE.PrettyPrintEnv (BranchDiffOutput v Ann)
-  | ShowDiffAfterCreatePR RemoteNamespace RemoteNamespace PPE.PrettyPrintEnv (BranchDiffOutput v Ann)
+  | ShowDiffAfterCreatePR ReadRemoteNamespace ReadRemoteNamespace PPE.PrettyPrintEnv (BranchDiffOutput v Ann)
   -- <authorIdentifier> <authorPath> <relativeBase>
   | ShowDiffAfterCreateAuthor NameSegment Path.Path' Path.Absolute PPE.PrettyPrintEnv (BranchDiffOutput v Ann)
 
@@ -98,7 +98,7 @@ data Output v
   | BadMainFunction String (Type v Ann) PPE.PrettyPrintEnv [Type v Ann]
   | BranchEmpty (Either ShortBranchHash Path')
   | BranchNotEmpty Path'
-  | LoadPullRequest RemoteNamespace RemoteNamespace Path' Path' Path' Path'
+  | LoadPullRequest ReadRemoteNamespace ReadRemoteNamespace Path' Path' Path' Path'
   | CreatedNewBranch Path.Absolute
   | BranchAlreadyExists Path'
   | PatchAlreadyExists Path.Split'
@@ -179,7 +179,6 @@ data Output v
   | ConfiguredMetadataParseError Path' String (P.Pretty P.ColorText)
   | NoConfiguredGitUrl PushPull Path'
   | ConfiguredGitUrlParseError PushPull Path' Text String
-  | ConfiguredGitUrlIncludesShortBranchHash PushPull RemoteRepo ShortBranchHash Path
   | DisplayLinks PPE.PrettyPrintEnvDecl Metadata.Metadata
                (Map Reference (DisplayObject (Decl v Ann)))
                (Map Reference (DisplayObject (Term v Ann)))
@@ -194,7 +193,7 @@ data Output v
   | StartOfCurrentPathHistory
   | History (Maybe Int) [(ShortBranchHash, Names.Diff)] HistoryTail
   | ShowReflog [ReflogEntry]
-  | PullAlreadyUpToDate RemoteNamespace Path'
+  | PullAlreadyUpToDate ReadRemoteNamespace Path'
   | MergeAlreadyUpToDate Path' Path'
   | PreviewMergeAlreadyUpToDate Path' Path'
   -- | No conflicts or edits remain for the current patch.
@@ -299,7 +298,6 @@ isFailure o = case o of
   ConfiguredMetadataParseError{} -> True
   NoConfiguredGitUrl{} -> True
   ConfiguredGitUrlParseError{} -> True
-  ConfiguredGitUrlIncludesShortBranchHash{} -> True
   DisplayLinks{} -> False
   MetadataMissingType{} -> True
   MetadataAmbiguous{} -> True

--- a/parser-typechecker/src/Unison/Codebase/Editor/RemoteRepo.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/RemoteRepo.hs
@@ -3,30 +3,38 @@
 module Unison.Codebase.Editor.RemoteRepo where
 
 import Unison.Prelude
-import Unison.Util.Monoid as Monoid 
-import Data.Text as Text
 import qualified Unison.Codebase.Path as Path
 import Unison.Codebase.Path (Path)
 import Unison.Codebase.ShortBranchHash (ShortBranchHash)
 import qualified Unison.Codebase.ShortBranchHash as SBH
 
-data RemoteRepo = GitRepo { url :: Text, commit :: Maybe Text }
-  deriving (Eq, Ord, Show)
+data ReadRepo = ReadGitRepo { url :: Text {-, commitish :: Maybe Text -}} deriving (Eq, Ord, Show)
+data WriteRepo = WriteGitRepo { url' :: Text {-, branch :: Maybe Text -}} deriving (Eq, Ord, Show)
 
-printRepo :: RemoteRepo -> Text
-printRepo GitRepo{..} = url <> Monoid.fromMaybe (Text.cons ':' <$> commit)
+writeToRead :: WriteRepo -> ReadRepo
+writeToRead (WriteGitRepo url) = ReadGitRepo url
 
-printNamespace :: RemoteRepo -> Maybe ShortBranchHash -> Path -> Text
+writePathToRead :: WriteRemotePath -> ReadRemoteNamespace
+writePathToRead (w, p) = (writeToRead w, Nothing, p)
+
+printReadRepo :: ReadRepo -> Text
+printReadRepo ReadGitRepo{..} = url -- <> Monoid.fromMaybe (Text.cons ':' <$> commit)
+printWriteRepo :: WriteRepo -> Text
+printWriteRepo WriteGitRepo{..} = url' -- <> Monoid.fromMaybe (Text.cons ':' <$> branch)
+
+printNamespace :: ReadRepo -> Maybe ShortBranchHash -> Path -> Text
 printNamespace repo sbh path =
-  printRepo repo <> case sbh of
+  printReadRepo repo <> case sbh of
     Nothing -> if path == Path.empty then mempty
       else ":." <> Path.toText path
     Just sbh -> ":#" <> SBH.toText sbh <>
       if path == Path.empty then mempty
       else "." <> Path.toText path
-      
-printHead :: RemoteRepo -> Path -> Text
-printHead repo path = printNamespace repo Nothing path      
 
-type RemoteNamespace = (RemoteRepo, Maybe ShortBranchHash, Path)
-type RemoteHead = (RemoteRepo, Path)
+printHead :: WriteRepo -> Path -> Text
+printHead repo path =
+  printWriteRepo repo
+    <> if path == Path.empty then mempty else ":." <> Path.toText path
+
+type ReadRemoteNamespace = (ReadRepo, Maybe ShortBranchHash, Path)
+type WriteRemotePath = (WriteRepo, Path)

--- a/parser-typechecker/src/Unison/Codebase/Editor/VersionParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/VersionParser.hs
@@ -13,7 +13,7 @@ import Data.Void (Void)
 
 -- |"release/M1j.2" -> "releases._M1j"
 --  "devel/*" -> "trunk"
-defaultBaseLib :: Parsec Void Text RemoteNamespace
+defaultBaseLib :: Parsec Void Text ReadRemoteNamespace
 defaultBaseLib = fmap makeNS $ devel <|> release
   where
   devel, release, version :: Parsec Void Text Text
@@ -21,7 +21,7 @@ defaultBaseLib = fmap makeNS $ devel <|> release
   release = fmap ("releases._" <>) $ "release/" *> version <* eof
   version = fmap Text.pack $
               try (someTill anyChar "." <* many anyChar) <|> many anyChar
-  makeNS :: Text -> RemoteNamespace
-  makeNS t = ( GitRepo "https://github.com/unisonweb/base" Nothing
+  makeNS :: Text -> ReadRemoteNamespace
+  makeNS t = ( ReadGitRepo "https://github.com/unisonweb/base"
              , Nothing
              , Path.fromText t)

--- a/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/FileCodebase.hs
@@ -31,7 +31,7 @@ import qualified U.Util.Cache as Cache
 import qualified Unison.Codebase.Init as Codebase
 import Unison.Codebase.Branch (headHash)
 import Unison.Codebase.Editor.Git (gitIn, gitTextIn, pullBranch, withIOError, withStatus)
-import Unison.Codebase.Editor.RemoteRepo (RemoteNamespace, RemoteRepo (GitRepo), printRepo)
+import Unison.Codebase.Editor.RemoteRepo (ReadRemoteNamespace, WriteRepo (WriteGitRepo), writeToRead, printWriteRepo)
 import Unison.Codebase.FileCodebase.Common
   ( Err (CantParseBranchHead),
     branchFromFiles,
@@ -263,7 +263,7 @@ branchHeadUpdates root = do
 -- * Git stuff
 
 viewRemoteBranch' :: forall m. (MonadIO m, MonadCatch m)
-  => Branch.Cache m -> RemoteNamespace -> ExceptT GitError m (Branch m, CodebasePath)
+  => Branch.Cache m -> ReadRemoteNamespace -> ExceptT GitError m (Branch m, CodebasePath)
 viewRemoteBranch' cache (repo, sbh, path) = do
   -- set up the cache dir
   remotePath <- time "Git fetch" $ pullBranch repo
@@ -295,12 +295,12 @@ pushGitRootBranch
   => Codebase.SyncToDir m
   -> Branch.Cache m
   -> Branch m
-  -> RemoteRepo
+  -> WriteRepo
   -> SyncMode
   -> ExceptT GitError m ()
 pushGitRootBranch syncToDirectory cache branch repo syncMode = do
   -- Pull the remote repo into a staging directory
-  (remoteRoot, remotePath) <- viewRemoteBranch' cache (repo, Nothing, Path.empty)
+  (remoteRoot, remotePath) <- viewRemoteBranch' cache (writeToRead repo, Nothing, Path.empty)
   ifM (pure (remoteRoot == Branch.empty)
         ||^ lift (remoteRoot `Branch.before` branch))
     -- ours is newer 👍, meaning this is a fast-forward push,
@@ -309,7 +309,7 @@ pushGitRootBranch syncToDirectory cache branch repo syncMode = do
     (throwError $ GitError.PushDestinationHasNewStuff repo)
   where
   stageAndPush remotePath = do
-    let repoString = Text.unpack $ printRepo repo
+    let repoString = Text.unpack $ printWriteRepo repo
     withStatus ("Staging files for upload to " ++ repoString ++ " ...") $
       lift (syncToDirectory remotePath syncMode branch)
     updateCausalHead (branchHeadDir remotePath) (Branch._history branch)
@@ -320,8 +320,8 @@ pushGitRootBranch syncToDirectory cache branch repo syncMode = do
           `withIOError` (throwError . GitError.PushException repo . show))
         (throwError $ GitError.PushNoOp repo)
   -- Commit our changes
-  push :: CodebasePath -> RemoteRepo -> IO Bool -- withIOError needs IO
-  push remotePath (GitRepo url gitbranch) = do
+  push :: CodebasePath -> WriteRepo -> IO Bool -- withIOError needs IO
+  push remotePath (WriteGitRepo url) = do
     -- has anything changed?
     status <- gitTextIn remotePath ["status", "--short"]
     if Text.null status then
@@ -331,11 +331,5 @@ pushGitRootBranch syncToDirectory cache branch repo syncMode = do
       gitIn remotePath
         ["commit", "-q", "-m", "Sync branch " <> Text.pack (show $ headHash branch)]
       -- Push our changes to the repo
-      case gitbranch of
-        Nothing        -> gitIn remotePath ["push", "--quiet", url]
-        Just gitbranch -> error $
-          "Pushing to a specific branch isn't fully implemented or tested yet.\n"
-          ++ "InputPatterns.parseUri was expected to have prevented you "
-          ++ "from supplying the git treeish `" ++ Text.unpack gitbranch ++ "`!"
-          -- gitIn remotePath ["push", "--quiet", url, gitbranch]
+      gitIn remotePath ["push", "--quiet", url]
       pure True

--- a/parser-typechecker/src/Unison/Codebase/GitError.hs
+++ b/parser-typechecker/src/Unison/Codebase/GitError.hs
@@ -4,7 +4,7 @@ import Unison.Prelude
 
 import Unison.Codebase.ShortBranchHash (ShortBranchHash)
 import qualified Unison.Codebase.Branch as Branch
-import Unison.Codebase.Editor.RemoteRepo (RemoteRepo)
+import Unison.Codebase.Editor.RemoteRepo (ReadRepo, WriteRepo)
 import U.Codebase.Sqlite.DbId (SchemaVersion)
 
 type CodebasePath = FilePath
@@ -12,17 +12,17 @@ type CodebasePath = FilePath
 data GitError = NoGit
               | UnrecognizableCacheDir Text CodebasePath
               | UnrecognizableCheckoutDir Text CodebasePath
-              | CloneException RemoteRepo String
-              | PushException RemoteRepo String
-              | PushNoOp RemoteRepo
+              | CloneException ReadRepo String
+              | PushException WriteRepo String
+              | PushNoOp WriteRepo
               -- url commit Diff of what would change on merge with remote
-              | PushDestinationHasNewStuff RemoteRepo
-              | NoRemoteNamespaceWithHash RemoteRepo ShortBranchHash
-              | RemoteNamespaceHashAmbiguous RemoteRepo ShortBranchHash (Set Branch.Hash)
-              | CouldntLoadRootBranch RemoteRepo Branch.Hash
-              | CouldntParseRootBranch RemoteRepo String
-              | CouldntOpenCodebase RemoteRepo CodebasePath
-              | UnrecognizedSchemaVersion RemoteRepo CodebasePath SchemaVersion
+              | PushDestinationHasNewStuff WriteRepo
+              | NoRemoteNamespaceWithHash ReadRepo ShortBranchHash
+              | RemoteNamespaceHashAmbiguous ReadRepo ShortBranchHash (Set Branch.Hash)
+              | CouldntLoadRootBranch ReadRepo Branch.Hash
+              | CouldntParseRootBranch ReadRepo String
+              | CouldntOpenCodebase ReadRepo CodebasePath
+              | UnrecognizedSchemaVersion ReadRepo CodebasePath SchemaVersion
               | SomeOtherError String
               | CouldntLoadSyncedBranch Branch.Hash
               deriving Show

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -7,7 +7,6 @@ module Unison.CommandLine.InputPatterns where
 import Unison.Prelude
 
 import qualified Control.Lens.Cons as Cons
-import qualified Control.Lens as Lens
 import Data.Bifunctor (first)
 import Data.List (intercalate, isPrefixOf)
 import Data.List.Extra (nubOrdOn)
@@ -41,7 +40,7 @@ import qualified Unison.Util.Pretty as P
 import qualified Unison.Util.Relation as R
 import qualified Unison.Codebase.Editor.SlurpResult as SR
 import qualified Unison.Codebase.Editor.UriParser as UriParser
-import Unison.Codebase.Editor.RemoteRepo (RemoteNamespace)
+import Unison.Codebase.Editor.RemoteRepo (ReadRemoteNamespace, WriteRemotePath, WriteRepo)
 import qualified Unison.Codebase.Editor.RemoteRepo as RemoteRepo
 import Data.Tuple.Extra (uncurry3)
 
@@ -798,9 +797,7 @@ push = InputPattern
     []    ->
       Right $ Input.PushRemoteBranchI Nothing Path.relativeEmpty' SyncMode.ShortCircuit
     url : rest -> do
-      (repo, sbh, path) <- parseUri "url" url
-      when (isJust sbh)
-        $ Left "Can't push to a particular remote namespace hash."
+      (repo, path) <- parsePushPath "url" url
       p <- case rest of
         [] -> Right Path.relativeEmpty'
         [path] -> first fromString $ Path.parsePath' path
@@ -825,9 +822,7 @@ pushExhaustive = InputPattern
     []    ->
       Right $ Input.PushRemoteBranchI Nothing Path.relativeEmpty' SyncMode.Complete
     url : rest -> do
-      (repo, sbh, path) <- parseUri "url" url
-      when (isJust sbh)
-        $ Left "Can't push to a particular remote namespace hash."
+      (repo, path) <- parsePushPath "url" url
       p <- case rest of
         [] -> Right Path.relativeEmpty'
         [path] -> first fromString $ Path.parsePath' path
@@ -879,17 +874,20 @@ loadPullRequest = InputPattern "pull-request.load" ["pr.load"]
       pure $ Input.LoadPullRequestI baseRepo headRepo destPath
     _ -> Left (I.help loadPullRequest)
   )
-parseUri :: String -> String -> Either (P.Pretty P.ColorText) RemoteNamespace
+parseUri :: String -> String -> Either (P.Pretty P.ColorText) ReadRemoteNamespace
 parseUri label input = do
-  ns <- first (fromString . show) -- turn any parsing errors into a Pretty.
+  first (fromString . show) -- turn any parsing errors into a Pretty.
     (P.parse UriParser.repoPath label (Text.pack input))
-  case (RemoteRepo.commit . Lens.view Lens._1) ns of
-    Nothing -> pure ns
-    Just commit -> Left . P.wrap $
-      "I don't totally know how to address specific git commits (e.g. "
-      <> P.group (P.text commit <> ")") <> " yet."
-      <> "If you need this, add your 2¢ at"
-      <> P.backticked "https://github.com/unisonweb/unison/issues/1436"
+
+parseWriteRepo :: String -> String -> Either (P.Pretty P.ColorText) WriteRepo
+parseWriteRepo label input = do
+  first (fromString . show) -- turn any parsing errors into a Pretty.
+    (P.parse UriParser.writeRepo label (Text.pack input))
+
+parsePushPath :: String -> String -> Either (P.Pretty P.ColorText) WriteRemotePath
+parsePushPath label input = do
+  first (fromString . show) -- turn any parsing errors into a Pretty.
+    (P.parse UriParser.writeRepoPath label (Text.pack input))
 
 squashMerge :: InputPattern
 squashMerge =

--- a/parser-typechecker/src/Unison/CommandLine/Main.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Main.hs
@@ -20,7 +20,7 @@ import Unison.Codebase.Editor.Input (Input (..), Event)
 import qualified Unison.Codebase.Editor.HandleInput as HandleInput
 import qualified Unison.Codebase.Editor.HandleCommand as HandleCommand
 import Unison.Codebase.Editor.Command (LoadSourceResult(..))
-import Unison.Codebase.Editor.RemoteRepo (RemoteNamespace, printNamespace)
+import Unison.Codebase.Editor.RemoteRepo (ReadRemoteNamespace, printNamespace)
 import Unison.Codebase (Codebase)
 import Unison.CommandLine
 import Unison.PrettyTerminal
@@ -144,7 +144,7 @@ welcomeMessage dir version =
          , P.wrap ("Type " <> P.hiBlue "help" <> " to get help. 😎")
          ]
 
-hintFreshCodebase :: RemoteNamespace -> P.Pretty P.ColorText
+hintFreshCodebase :: ReadRemoteNamespace -> P.Pretty P.ColorText
 hintFreshCodebase ns =
   P.wrap $ "Enter "
     <> (P.hiBlue . P.group)
@@ -153,7 +153,7 @@ hintFreshCodebase ns =
 
 main
   :: FilePath
-  -> Maybe RemoteNamespace
+  -> Maybe ReadRemoteNamespace
   -> Path.Absolute
   -> (Config, IO ())
   -> [Either Event Input]

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -106,12 +106,11 @@ import qualified Unison.Hash as Hash
 import qualified Unison.Codebase.Causal as Causal
 import qualified Unison.Codebase.Editor.RemoteRepo as RemoteRepo
 import qualified Unison.Util.List              as List
-import qualified Unison.Util.Monoid            as Monoid
 import Data.Tuple (swap)
 import Unison.Codebase.ShortBranchHash (ShortBranchHash)
 import qualified Unison.ShortHash as SH
 import Unison.LabeledDependency as LD
-import Unison.Codebase.Editor.RemoteRepo (RemoteRepo)
+import Unison.Codebase.Editor.RemoteRepo (ReadRepo, WriteRepo)
 import U.Codebase.Sqlite.DbId (SchemaVersion(SchemaVersion))
 
 type Pretty = P.Pretty P.ColorText
@@ -243,7 +242,7 @@ notifyNumbered o = case o of
                  <> "or" <> IP.makeExample' IP.viewReflog
                  <> "to undo this change."
 
-prettyRemoteNamespace :: (RemoteRepo.RemoteRepo,
+prettyRemoteNamespace :: (RemoteRepo.ReadRepo,
                           Maybe ShortBranchHash, Path.Path)
                          -> P.Pretty P.ColorText
 prettyRemoteNamespace =
@@ -671,26 +670,26 @@ notifyUser dir o = case o of
   TodoOutput names todo -> pure (todoOutput names todo)
   GitError input e -> pure $ case e of
     CouldntOpenCodebase repo localPath -> P.wrap $ "I couldn't open the repository at"
-      <> prettyRepoBranch repo <> "in the cache directory at"
+      <> prettyReadRepo repo <> "in the cache directory at"
       <> P.backticked' (P.string localPath) "."
     UnrecognizedSchemaVersion repo localPath (SchemaVersion v) -> P.wrap
       $ "I don't know how to interpret schema version " <> P.shown v
-      <> "in the repository at" <> prettyRepoBranch repo
+      <> "in the repository at" <> prettyReadRepo repo
       <> "in the cache directory at" <> P.backticked' (P.string localPath) "."
     CouldntParseRootBranch repo s -> P.wrap $ "I couldn't parse the string"
       <> P.red (P.string s) <> "into a namespace hash, when opening the repository at"
-      <> P.group (prettyRepoBranch repo <> ".")
+      <> P.group (prettyReadRepo repo <> ".")
     CouldntLoadSyncedBranch h -> P.wrap $ "I just finished importing the branch"
       <> P.red (P.shown h) <> "but now I can't find it."
     NoGit -> P.wrap $
       "I couldn't find git. Make sure it's installed and on your path."
     CloneException repo msg -> P.wrap $
-      "I couldn't clone the repository at" <> prettyRepoBranch repo <> ";"
+      "I couldn't clone the repository at" <> prettyReadRepo repo <> ";"
       <> "the error was:" <> (P.indentNAfterNewline 2 . P.group . P.string) msg
     PushNoOp repo -> P.wrap $
-      "The repository at" <> prettyRepoBranch repo <> "is already up-to-date."
+      "The repository at" <> prettyWriteRepo repo <> "is already up-to-date."
     PushException repo msg -> P.wrap $
-      "I couldn't push to the repository at" <> prettyRepoRevision repo <> ";"
+      "I couldn't push to the repository at" <> prettyWriteRepo repo <> ";"
       <> "the error was:" <> (P.indentNAfterNewline 2 . P.group . P.string) msg
     UnrecognizableCacheDir uri localPath -> P.wrap $ "A cache directory for"
       <> P.backticked (P.text uri) <> "already exists at"
@@ -702,7 +701,7 @@ notifyUser dir o = case o of
       <> "result as a git repository, so I'm not sure what to do next."
     PushDestinationHasNewStuff repo ->
       P.callout "⏸" . P.lines $ [
-      P.wrap $ "The repository at" <> prettyRepoRevision repo
+      P.wrap $ "The repository at" <> prettyWriteRepo repo
             <> "has some changes I don't know about.",
       "",
       P.wrap $ "If you want to " <> push <> "you can do:", "",
@@ -717,14 +716,14 @@ notifyUser dir o = case o of
     CouldntLoadRootBranch repo hash -> P.wrap
       $ "I couldn't load the designated root hash"
       <> P.group ("(" <> fromString (Hash.showBase32Hex hash) <> ")")
-      <> "from the repository at" <> prettyRepoRevision repo
+      <> "from the repository at" <> prettyReadRepo repo
     NoRemoteNamespaceWithHash repo sbh -> P.wrap
-      $ "The repository at" <> prettyRepoRevision repo
+      $ "The repository at" <> prettyReadRepo repo
       <> "doesn't contain a namespace with the hash prefix"
       <> (P.blue . P.text . SBH.toText) sbh
     RemoteNamespaceHashAmbiguous repo sbh hashes -> P.lines [
       P.wrap $ "The namespace hash" <> prettySBH sbh
-            <> "at" <> prettyRepoRevision repo
+            <> "at" <> prettyReadRepo repo
             <> "is ambiguous."
             <> "Did you mean one of these hashes?",
       "",
@@ -838,30 +837,6 @@ notifyUser dir o = case o of
       , P.wrap $ "Type" <> P.backticked ("help " <> pushPull "push" "pull" pp)
         <> "for more information."
       ]
---  | ConfiguredGitUrlIncludesShortBranchHash ShortBranchHash
-  ConfiguredGitUrlIncludesShortBranchHash pp repo sbh remotePath ->
-    pure . P.lines $
-    [ P.wrap
-    $ "The `GitUrl.` entry in .unisonConfig for the current path has the value"
-    <> (P.group . (<>",") . P.blue . P.text)
-        (RemoteRepo.printNamespace repo (Just sbh) remotePath)
-    <> "which specifies a namespace hash"
-    <> P.group (P.blue (prettySBH sbh) <> ".")
-    , ""
-    , P.wrap $
-      pushPull "I can't push to a specific hash, because it's immutable."
-      ("It's no use for repeated pulls,"
-      <> "because you would just get the same immutable namespace each time.")
-      pp
-    , ""
-    , P.wrap $ "You can use"
-    <> P.backticked (
-        pushPull "push" "pull" pp
-        <> " "
-        <> P.text (RemoteRepo.printNamespace repo Nothing remotePath))
-    <> "if you want to" <> pushPull "push onto" "pull from" pp
-    <> "the latest."
-    ]
   NoBranchWithHash _h -> pure . P.callout "😶" $
     P.wrap $ "I don't know of a namespace with that hash."
   NotImplemented -> pure $ P.wrap "That's not implemented yet. Sorry! 😬"
@@ -2034,21 +2009,11 @@ prettyTermName :: PPE.PrettyPrintEnv -> Referent -> Pretty
 prettyTermName ppe r = P.syntaxToColor $
   prettyHashQualified (PPE.termName ppe r)
 
-prettyRepoRevision :: RemoteRepo -> Pretty
-prettyRepoRevision (RemoteRepo.GitRepo url treeish) =
-  P.blue (P.text url) <> prettyRevision treeish
-  where
-  prettyRevision treeish =
-    Monoid.fromMaybe $
-      treeish <&> \treeish -> "at revision" <> P.blue (P.text treeish)
+prettyReadRepo :: ReadRepo -> Pretty
+prettyReadRepo (RemoteRepo.ReadGitRepo url) = P.blue (P.text url)
 
-prettyRepoBranch :: RemoteRepo -> Pretty
-prettyRepoBranch (RemoteRepo.GitRepo url treeish) =
-  P.blue (P.text url) <> prettyRevision treeish
-  where
-  prettyRevision treeish =
-    Monoid.fromMaybe $
-      treeish <&> \treeish -> "at branch" <> P.blue (P.text treeish)
+prettyWriteRepo :: WriteRepo -> Pretty
+prettyWriteRepo (RemoteRepo.WriteGitRepo url) = P.blue (P.text url)
 
 isTestOk :: Term v Ann -> Bool
 isTestOk tm = case tm of

--- a/parser-typechecker/tests/Unison/Test/UriParser.hs
+++ b/parser-typechecker/tests/Unison/Test/UriParser.hs
@@ -3,7 +3,7 @@
 module Unison.Test.UriParser where
 
 import EasyTest
-import Unison.Codebase.Editor.RemoteRepo (RemoteRepo(..))
+import Unison.Codebase.Editor.RemoteRepo (ReadRepo(..))
 import Unison.Codebase.Path (Path(..))
 import qualified Unison.Codebase.Path as Path
 import qualified Text.Megaparsec as P
@@ -24,54 +24,54 @@ testAugmented = scope "augmented" . tests $
 --  $ git clone /srv/git/project.git[:treeish][:[#hash][.path]]
   [ scope "local-protocol" . tests . map parseAugmented $
     [ ("/srv/git/project.git",
-      (GitRepo "/srv/git/project.git" Nothing, Nothing, Path.empty))
-    , ("/srv/git/project.git:abc:#def.hij.klm",
-      (GitRepo "/srv/git/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
+      (ReadGitRepo "/srv/git/project.git", Nothing, Path.empty))
+    -- , ("/srv/git/project.git:abc:#def.hij.klm",
+    --   (ReadGitRepo "/srv/git/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
     , ("srv/git/project.git",
-      (GitRepo "srv/git/project.git" Nothing, Nothing, Path.empty))
-    , ("srv/git/project.git:abc:#def.hij.klm",
-      (GitRepo "srv/git/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
+      (ReadGitRepo "srv/git/project.git", Nothing, Path.empty))
+    -- , ("srv/git/project.git:abc:#def.hij.klm",
+    --   (ReadGitRepo "srv/git/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
     ],
 -- File Protocol
 --  $ git clone file:///srv/git/project.git[:treeish][:[#hash][.path]] <- imagined
     scope "file-protocol" . tests . map parseAugmented $
     [ ("file:///srv/git/project.git",
-      (GitRepo "file:///srv/git/project.git" Nothing, Nothing, Path.empty))
-    , ("file:///srv/git/project.git:abc:#def.hij.klm",
-      (GitRepo "file:///srv/git/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
+      (ReadGitRepo "file:///srv/git/project.git", Nothing, Path.empty))
+    -- , ("file:///srv/git/project.git:abc:#def.hij.klm",
+    --   (ReadGitRepo "file:///srv/git/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
     , ("file://srv/git/project.git",
-      (GitRepo "file://srv/git/project.git" Nothing, Nothing, Path.empty))
-    , ("file://srv/git/project.git:abc:#def.hij.klm",
-      (GitRepo "file://srv/git/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
+      (ReadGitRepo "file://srv/git/project.git", Nothing, Path.empty))
+    -- , ("file://srv/git/project.git:abc:#def.hij.klm",
+    --   (ReadGitRepo "file://srv/git/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
     ],
 -- Smart / Dumb HTTP protocol
 --  $ git clone https://example.com/gitproject.git[:treeish][:[#hash][.path]] <- imagined
     scope "http-protocol" . tests . map parseAugmented $
     [ ("https://example.com/git/project.git",
-      (GitRepo "https://example.com/git/project.git" Nothing, Nothing, Path.empty))
-    , ("https://user@example.com/git/project.git:abc:#def.hij.klm]",
-      (GitRepo "https://user@example.com/git/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
+      (ReadGitRepo "https://example.com/git/project.git", Nothing, Path.empty))
+    -- , ("https://user@example.com/git/project.git:abc:#def.hij.klm]",
+    --   (ReadGitRepo "https://user@example.com/git/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
     ],
 -- SSH Protocol
 --  $ git clone ssh://[user@]server/project.git[:treeish][:[#hash][.path]]
     scope "ssh-protocol" . tests . map parseAugmented $
     [ ("ssh://git@8.8.8.8:222/user/project.git",
-      (GitRepo "ssh://git@8.8.8.8:222/user/project.git" Nothing, Nothing, Path.empty))
-    , ("ssh://git@github.com/user/project.git:abc:#def.hij.klm",
-      (GitRepo "ssh://git@github.com/user/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
+      (ReadGitRepo "ssh://git@8.8.8.8:222/user/project.git", Nothing, Path.empty))
+    -- , ("ssh://git@github.com/user/project.git:abc:#def.hij.klm",
+    --   (ReadGitRepo "ssh://git@github.com/user/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
     ],
 --  $ git clone [user@]server:project.git[:treeish][:[#hash][.path]]
     scope "scp-protocol" . tests . map parseAugmented $
     [ ("git@github.com:user/project.git",
-      (GitRepo "git@github.com:user/project.git" Nothing, Nothing, Path.empty))
+      (ReadGitRepo "git@github.com:user/project.git", Nothing, Path.empty))
     , ("github.com:user/project.git",
-      (GitRepo "github.com:user/project.git" Nothing, Nothing, Path.empty))
-    , ("git@github.com:user/project.git:abc:#def.hij.klm",
-      (GitRepo "git@github.com:user/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
+      (ReadGitRepo "github.com:user/project.git", Nothing, Path.empty))
+    -- , ("git@github.com:user/project.git:abc:#def.hij.klm",
+    --   (ReadGitRepo "git@github.com:user/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
     ]
   ]
 
-parseAugmented :: (Text, (RemoteRepo, Maybe ShortBranchHash, Path)) -> Test ()
+parseAugmented :: (Text, (ReadRepo, Maybe ShortBranchHash, Path)) -> Test ()
 parseAugmented (s, r) = scope (Text.unpack s) $
   case P.parse UriParser.repoPath "test case" s of
     Left x -> crash $ show x

--- a/parser-typechecker/tests/Unison/Test/VersionParser.hs
+++ b/parser-typechecker/tests/Unison/Test/VersionParser.hs
@@ -21,6 +21,6 @@ makeTest (version, path) =
   scope (unpack version) $ expectEqual
     (rightMay $ runParser defaultBaseLib "versionparser" version)
     (Just
-      ( GitRepo "https://github.com/unisonweb/base" Nothing
+      ( ReadGitRepo "https://github.com/unisonweb/base"
       , Nothing
       , Path.fromText path ))

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -34,7 +34,7 @@ import Text.Megaparsec (runParser)
 import qualified Unison.Codebase as Codebase
 import qualified Unison.Codebase.Init as Codebase
 import qualified Unison.Codebase.Editor.Input as Input
-import Unison.Codebase.Editor.RemoteRepo (RemoteNamespace)
+import Unison.Codebase.Editor.RemoteRepo (ReadRemoteNamespace)
 import qualified Unison.Codebase.Editor.VersionParser as VP
 import Unison.Codebase.Execute (execute)
 import qualified Unison.Codebase.FileCodebase as FC
@@ -361,7 +361,7 @@ isFlag f arg = arg == f || arg == "-" ++ f || arg == "--" ++ f
 getConfigFilePath :: Maybe FilePath -> IO FilePath
 getConfigFilePath mcodepath = (FP.</> ".unisonConfig") <$> Codebase.getCodebaseDir mcodepath
 
-defaultBaseLib :: Maybe RemoteNamespace
+defaultBaseLib :: Maybe ReadRemoteNamespace
 defaultBaseLib = rightMay $
   runParser VP.defaultBaseLib "version" (Text.pack Version.gitDescribe)
 


### PR DESCRIPTION
This PR is just a refactor, with no changes in functionality expected.

## Overview

Refines the model in [`RemoteRepo.hs`](https://github.com/unisonweb/unison/pull/2246/files#diff-79fe1181f9c8a3b44873791ea43e78ad64f11ee8b2238a42f3750187308c6f89) to distinguish between `Read`able namespace URIs we can pull from vs `Write`able ones we can push to, and then propagates those changes.

As a bonus, the PR eliminates a lot of dead/error code, even if it also adds code (more, distinct functions to deal with the new distinct types).

This yak came to a head while working on #2213 (pr revamp) which changes the argument types for `pr.create` and `pr.load`.

## Implementation notes

You can convert a `WriteRepo` to a `ReadRepo` which reads the root of the same repository, but you can't convert a `ReadRepo` to a `WriteRepo` (without throwing out information recklessly).

## Interesting/controversial decisions (not very interesting)

The configurator file `Path -> RemoteRepo` parser must find at most a `WriteRemotePath`, or it will complain.  

Why not the other way around, `ReadRemoteNamespace`?  It seems safe to rule out that a user wants to create a permanent URI association between a local path and an immutable remote one specified by hash, not path.  You can't push to a hash, and you shouldn't need to pull from one more than once.

I could change the type or constructor names.

## Test coverage

Existing tests seem enough for most of these changes, and I added #2245 to track that we don't have any testing for anything controlled by configurator afaik.