### PR TITLE
Allow multiple guards to be attached to a case a `cases` or `match` expression

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,9 +41,9 @@ jobs:
             unison-core/.stack-work
             yaks/easytest/.stack-work
             # Main cache key: commit hash. This should always result in a cache miss...
-          key: stack-work-1_${{matrix.os}}-${{github.sha}}
+          key: stack-work-2_${{matrix.os}}-${{github.sha}}
           # ...but then fall back on the latest cache stored (on this branch)
-          restore-keys: stack-work-1_${{matrix.os}}-
+          restore-keys: stack-work-2_${{matrix.os}}-
 
       # Install stack by downloading the binary from GitHub. The installation process is different for Linux and macOS,
       # so this is split into two steps, only one of which will run on any particular build.

--- a/parser-typechecker/src/Unison/Runtime/Pattern.hs
+++ b/parser-typechecker/src/Unison/Runtime/Pattern.hs
@@ -671,8 +671,6 @@ mkRow sv (MatchCase (normalizeSeqP -> p0) g0 (AbsN' vs b))
           | otherwise ->
               internalBug "mkRow: guard variables do not match body"
         Nothing -> Nothing
-        _ -> internalBug "mkRow: impossible"
-mkRow _ _ = internalBug "mkRow: impossible"
 
 initialize
   :: Var v

--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -129,12 +129,16 @@ match = do
   _         <- P.try (openBlockWith "with") <|> do
     t <- anyToken
     P.customFailure (ExpectedBlockOpen "with" t)
-  (_arities, cases) <- unzip <$> sepBy1 semi matchCase
+  (_arities, cases) <- unzip <$> matchCases
   when (null cases) $ P.customFailure EmptyMatch
   _ <- closeBlock
   pure $ Term.match (ann start <> maybe (ann start) ann (lastMay cases))
                     scrutinee
                     cases
+
+matchCases :: Var v => P v [(Int, Term.MatchCase Ann (Term v Ann))]
+matchCases = sepBy1 semi matchCase
+         <&> \cases -> [ (n,c) | (n,cs) <- cases, c <- cs ]
 
 -- Returns the arity of the pattern and the `MatchCase`. Examples:
 --
@@ -146,7 +150,7 @@ match = do
 --
 --   42, x -> ...
 --   (42, x) -> ...
-matchCase :: Var v => P v (Int, Term.MatchCase Ann (Term v Ann))
+matchCase :: Var v => P v (Int, [Term.MatchCase Ann (Term v Ann)])
 matchCase = do
   pats <- sepBy1 (reserved ",") parsePattern
   let boundVars' = [ v | (_,vs) <- pats, (_ann,v) <- vs ]
@@ -155,10 +159,14 @@ matchCase = do
         pats -> foldr pair (unit (ann . last $ pats)) pats
       unit ann = Pattern.Constructor ann DD.unitRef 0 []
       pair p1 p2 = Pattern.Constructor (ann p1 <> ann p2) DD.pairRef 0 [p1, p2]
-  guard <- optional $ reserved "|" *> infixAppOrBooleanOp
-  t <- block "->"
+  guardsAndBlocks <- many $ do
+    guard <- asum [ Nothing <$ P.try (reserved "|" *> quasikeyword "otherwise")
+                  , optional $ reserved "|" *> infixAppOrBooleanOp ]
+    t <- block "->"
+    pure (guard, t)
   let absChain vs t = foldr (\v t -> ABT.abs' (ann t) v t) t vs
-  pure $ (length pats, Term.MatchCase pat (fmap (absChain boundVars') guard) (absChain boundVars' t))
+  let mk (guard,t) = Term.MatchCase pat (fmap (absChain boundVars') guard) (absChain boundVars' t)
+  pure $ (length pats, mk <$> guardsAndBlocks)
 
 parsePattern :: forall v. Var v => P v (Pattern Ann, [(Ann, v)])
 parsePattern = root
@@ -290,7 +298,7 @@ checkCasesArities cases = go Nothing cases where
 
 lamCase = do
   start          <- openBlockWith "cases"
-  cases          <- sepBy1 semi matchCase
+  cases          <- matchCases
   (arity, cases) <- checkCasesArities cases
   when (null cases) (P.customFailure EmptyMatch)
   _       <- closeBlock
@@ -331,6 +339,11 @@ hashQualifiedPrefixTerm = resolveHashQualified =<< hqPrefixId
 
 hashQualifiedInfixTerm :: Var v => TermP v
 hashQualifiedInfixTerm = resolveHashQualified =<< hqInfixId
+
+quasikeyword :: Ord v => String -> P v (L.Token ())
+quasikeyword kw = queryToken $ \case
+  L.WordyId s Nothing | s == kw -> Just ()
+  _ -> Nothing
 
 -- If the hash qualified is name only, it is treated as a var, if it
 -- has a short hash, we resolve that short hash immediately and fail

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -486,6 +486,16 @@ type MatchCase' ann tm = ([Pattern ann], Maybe tm, tm)
 arity1Branches :: [MatchCase ann tm] -> [MatchCase' ann tm]
 arity1Branches bs = [ ([pat], guard, body) | MatchCase pat guard body <- bs ]
 
+groupCases :: Ord v => [MatchCase' () (Term3 v ann)]
+           -> [([Pattern ()], [v], [(Maybe (Term3 v ann), Term3 v ann)])]
+groupCases ms = go0 ms where
+  go0 [] = []
+  go0 ms@((p1, _, AbsN' vs1 _) : _) = go2 (p1,vs1) [] ms
+  go2 (p0,vs0) acc [] = [(p0,vs0,reverse acc)]
+  go2 (p0, vs0) acc ms@((p1, g1, AbsN' vs body) : tl)
+    | p0 == p1 && vs == vs0 = go2 (p0, vs0) ((g1,body):acc) tl
+    | otherwise             = (p0,vs0,reverse acc) : go0 ms
+
 printCase
   :: Var v
   => PrettyPrintEnv
@@ -493,31 +503,46 @@ printCase
   -> DocLiteralContext
   -> [MatchCase' () (Term3 v PrintAnnotation)]
   -> Pretty SyntaxText
-printCase env im doc ms = PP.lines $ map each gridArrowsAligned where
+printCase env im doc ms0 = PP.lines $ map each gridArrowsAligned where
+  ms = groupCases ms0
   each (lhs, arrow, body) = PP.group $ (lhs <> arrow) `PP.hang` body
-  grid = go <$> ms
+  grid = go =<< ms
   gridArrowsAligned = tidy <$> zip (PP.align' (f <$> grid)) grid where
     f (a, b, _) = (a, Just b)
     tidy ((a', b'), (_, _, c)) = (a', b', c)
-  go (pats, guard, (AbsN' vs body)) =
-    (lhs, arrow, (uses [pretty0 env (ac 0 Block im' doc) body]))
+
+  patLhs vs pats = case pats of
+    [pat] -> PP.group (fst (prettyPattern env (ac 0 Block im doc) (-1) vs pat))
+    pats  -> PP.group . PP.sep ("," <> PP.softbreak) . (`evalState` vs) . for pats $ \pat -> do
+      vs <- State.get
+      let (p, rem) = prettyPattern env (ac 0 Block im doc) (-1) vs pat
+      State.put rem
+      pure p
+
+  arrow = fmt S.ControlKeyword "->"
+  goBody im' uses body = uses [pretty0 env (ac 0 Block im' doc) body]
+  printGuard (Just (ABT.AbsN' _ g)) =
+    -- strip off any Abs-chain around the guard, guard variables are rendered
+    -- like any other variable, ex: case Foo x y | x < y -> ...
+    PP.group $ PP.spaced [(fmt S.DelimiterChar " |"), pretty0 env (ac 2 Normal im doc) g]
+  printGuard Nothing  = mempty
+
+  go (pats, vs, [(guard, body)]) =
+    [(lhs, arrow, goBody im' uses body)]
     where
-    lhs = (case pats of
-            [pat] -> PP.group (fst (prettyPattern env (ac 0 Block im doc) (-1) vs pat))
-            pats  -> PP.group . PP.sep ("," <> PP.softbreak) . (`evalState` vs) . for pats $ \pat -> do
-              vs <- State.get
-              let (p, rem) = prettyPattern env (ac 0 Block im doc) (-1) vs pat
-              State.put rem
-              pure p)
-       <> printGuard guard
-    arrow = fmt S.ControlKeyword "->"
-    printGuard (Just g') = let (_, g) = ABT.unabs g' in
-      -- strip off any Abs-chain around the guard, guard variables are rendered
-      -- like any other variable, ex: case Foo x y | x < y -> ...
-      PP.group $ PP.spaced [(fmt S.DelimiterChar " |"), pretty0 env (ac 2 Normal im doc) g]
-    printGuard Nothing  = mempty
+    lhs = patLhs vs pats <> printGuard guard
     (im', uses) = calcImports im body
-  go _ = (l "error", mempty, mempty)
+  go (pats, vs, unzip -> (guards, bodies)) =
+    (patLhs vs pats, mempty, mempty)
+      : zip3 (PP.indentN 2 . printGuard <$> guards)
+             (repeat arrow)
+             (printBody <$> bodies)
+    where
+    printGuard Nothing = (fmt S.DelimiterChar " |") <> fmt S.ControlKeyword " otherwise"
+    printGuard (Just (ABT.AbsN' _ g)) =
+      PP.group $ PP.spaced [(fmt S.DelimiterChar " |"), pretty0 env (ac 2 Normal im doc) g]
+    printBody b = let (im', uses) = calcImports im b
+                  in goBody im' uses b
 
 {- Render a binding, producing output of the form
 
@@ -1069,7 +1094,6 @@ immediateChildBlockTerms = \case
     _ -> []
   where
     doCase (MatchCase _ _ (AbsN' _ body)) = [body]
-    doCase _ = error "bad match" []
     doLet (v, Ann' tm _) = doLet (v, tm)
     doLet (v, LamsNamedOpt' _ body) = if isBlank $ Var.nameStr v
                                       then []

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -1165,7 +1165,6 @@ checkCase scrutineeType outputType (Term.MatchCase pat guard rhs) = do
   markThenRetractWanted Var.inferOther $ do
     let peel t = case t of
                   ABT.AbsN' vars bod -> (vars, bod)
-                  _ -> ([], t)
         (rhsvs, rhsbod) = peel rhs
         mayGuard = snd . peel <$> guard
     (substs, remains) <- runStateT (checkPattern scrutineeType pat) rhsvs

--- a/unison-core/src/Unison/ABT.hs
+++ b/unison-core/src/Unison/ABT.hs
@@ -175,6 +175,7 @@ pattern Cycle' vs t <- Term _ _ (Cycle (AbsN' vs t))
 -- pattern Abs' v body <- Term _ _ (Abs v body)
 pattern Abs' subst <- (unabs1 -> Just subst)
 pattern AbsN' vs body <- (unabs -> (vs, body))
+{-# COMPLETE AbsN' #-}
 pattern Tm' f <- Term _ _ (Tm f)
 pattern CycleA' a avs t <- Term _ a (Cycle (AbsNA' avs t))
 pattern AbsNA' avs body <- (unabsA -> (avs, body))
@@ -719,7 +720,7 @@ hash = hash' [] where
             die = error $ "unknown var in environment: " ++ show v
                         ++ " environment = " ++ show env
     Cycle (AbsN' vs t) -> hash' (Left vs : env) t
-    Cycle t -> hash' env t
+    -- Cycle t -> hash' env t
     Abs v t -> hash' (Right v : env) t
     Tm t -> Hashable.hash1 (hashCycle env) (hash' env) t
 

--- a/unison-src/tests/pattern-matching.u
+++ b/unison-src/tests/pattern-matching.u
@@ -44,4 +44,10 @@ foo = cases
 
   List.Nil -> 0
 
-> (w, w2 (Foo3 1 4 "bye"), len (List.Cons 1 List.Nil), foo (List.Cons 0 List.Nil))
+foo2 = cases
+  List.Cons h t | h > 10 -> 1
+                | h < 10 -> 2
+                | otherwise -> 3
+  List.Nil -> 0
+
+> (w, w2 (Foo3 1 4 "bye"), len (List.Cons 1 List.Nil), foo (List.Cons 0 List.Nil), foo2 List.Nil)

--- a/unison-src/tests/pattern-matching.u
+++ b/unison-src/tests/pattern-matching.u
@@ -33,4 +33,15 @@ len = cases
   List.Nil -> 0
   List.Cons _ t -> len t + 1
 
-> (w, w2, len)
+foo = cases
+  List.Cons h t 
+    | h > 10 ->
+      x = 3124
+      y = 230
+      x + y
+    | h < 10 -> 10
+    | otherwise -> 11
+
+  List.Nil -> 0
+
+> (w, w2 (Foo3 1 4 "bye"), len (List.Cons 1 List.Nil), foo (List.Cons 0 List.Nil))

--- a/unison-src/tests/pattern-matching.ur
+++ b/unison-src/tests/pattern-matching.ur
@@ -1,0 +1,1 @@
+("byebye", "byebye", 1, 10)

--- a/unison-src/tests/pattern-matching.ur
+++ b/unison-src/tests/pattern-matching.ur
@@ -1,1 +1,1 @@
-("byebye", "byebye", 1, 10)
+("byebye", "byebye", 1, 10, 0)

--- a/unison-src/transcripts/lambdacase.md
+++ b/unison-src/transcripts/lambdacase.md
@@ -87,3 +87,22 @@ blorf = cases
 > blah F F
 > blorf T F
 ```
+
+## Patterns with multiple guards
+
+
+```unison
+merge3 : [a] -> [a] -> [a]
+merge3 = cases
+  [], ys -> ys
+  xs, [] -> xs
+  h +: t, h2 +: t2
+    | h <= h2   -> h  +: merge3 t (h2 +: t2)
+    | otherwise -> h2 +: merge3 (h +: t) t2
+```
+
+```ucm
+.> add
+.> view merge3
+```
+

--- a/unison-src/transcripts/lambdacase.md
+++ b/unison-src/transcripts/lambdacase.md
@@ -90,19 +90,29 @@ blorf = cases
 
 ## Patterns with multiple guards
 
-
 ```unison
 merge3 : [a] -> [a] -> [a]
 merge3 = cases
   [], ys -> ys
   xs, [] -> xs
-  h +: t, h2 +: t2
-    | h <= h2   -> h  +: merge3 t (h2 +: t2)
-    | otherwise -> h2 +: merge3 (h +: t) t2
+  h +: t, h2 +: t2 | h <= h2   -> h  +: merge3 t (h2 +: t2)
+                   | otherwise -> h2 +: merge3 (h +: t) t2
 ```
 
 ```ucm
 .> add
 .> view merge3
 ```
+
+This is the same definition written with multiple patterns and not using the `cases` syntax; notice it is considered an alias of `merge3` above.
+
+```unison
+merge4 : [a] -> [a] -> [a]
+merge4 a b = match (a,b) with
+  [], ys -> ys
+  xs, [] -> xs
+  h +: t, h2 +: t2 | h <= h2   -> h  +: merge4 t (h2 +: t2)
+  h +: t, h2 +: t2 | otherwise -> h2 +: merge4 (h +: t) t2
+```
+
 

--- a/unison-src/transcripts/lambdacase.output.md
+++ b/unison-src/transcripts/lambdacase.output.md
@@ -162,15 +162,13 @@ blorf = cases
 ```
 ## Patterns with multiple guards
 
-
 ```unison
 merge3 : [a] -> [a] -> [a]
 merge3 = cases
   [], ys -> ys
   xs, [] -> xs
-  h +: t, h2 +: t2
-    | h <= h2   -> h  +: merge3 t (h2 +: t2)
-    | otherwise -> h2 +: merge3 (h +: t) t2
+  h +: t, h2 +: t2 | h <= h2   -> h  +: merge3 t (h2 +: t2)
+                   | otherwise -> h2 +: merge3 (h +: t) t2
 ```
 
 ```ucm
@@ -200,5 +198,28 @@ merge3 = cases
     h +: t, h2 +: t2  
        | h <= h2     -> h +: merge3 t (h2 +: t2)
        | otherwise   -> h2 +: merge3 (h +: t) t2
+
+```
+This is the same definition written with multiple patterns and not using the `cases` syntax; notice it is considered an alias of `merge3` above.
+
+```unison
+merge4 : [a] -> [a] -> [a]
+merge4 a b = match (a,b) with
+  [], ys -> ys
+  xs, [] -> xs
+  h +: t, h2 +: t2 | h <= h2   -> h  +: merge4 t (h2 +: t2)
+  h +: t, h2 +: t2 | otherwise -> h2 +: merge4 (h +: t) t2
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      merge4 : [a] -> [a] -> [a]
+        (also named merge3)
 
 ```

--- a/unison-src/transcripts/lambdacase.output.md
+++ b/unison-src/transcripts/lambdacase.output.md
@@ -160,3 +160,45 @@ blorf = cases
            F
 
 ```
+## Patterns with multiple guards
+
+
+```unison
+merge3 : [a] -> [a] -> [a]
+merge3 = cases
+  [], ys -> ys
+  xs, [] -> xs
+  h +: t, h2 +: t2
+    | h <= h2   -> h  +: merge3 t (h2 +: t2)
+    | otherwise -> h2 +: merge3 (h +: t) t2
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      merge3 : [a] -> [a] -> [a]
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    merge3 : [a] -> [a] -> [a]
+
+.> view merge3
+
+  merge3 : [a] -> [a] -> [a]
+  merge3 = cases
+    [], ys           -> ys
+    xs, []           -> xs
+    h +: t, h2 +: t2  
+       | h <= h2     -> h +: merge3 t (h2 +: t2)
+       | otherwise   -> h2 +: merge3 (h +: t) t2
+
+```

--- a/unison-src/transcripts/lambdacase.output.md
+++ b/unison-src/transcripts/lambdacase.output.md
@@ -196,8 +196,8 @@ merge3 = cases
     [], ys           -> ys
     xs, []           -> xs
     h +: t, h2 +: t2  
-       | h <= h2     -> h +: merge3 t (h2 +: t2)
-       | otherwise   -> h2 +: merge3 (h +: t) t2
+      | h <= h2      -> h +: merge3 t (h2 +: t2)
+      | otherwise    -> h2 +: merge3 (h +: t) t2
 
 ```
 This is the same definition written with multiple patterns and not using the `cases` syntax; notice it is considered an alias of `merge3` above.


### PR DESCRIPTION
Example:

```Haskell
foo2 = cases
  List.Cons h t | h > 10 -> 1
                | h < 10 -> 2
                | otherwise -> 3
  List.Nil -> 0
```

Can be used in `match` expressions as well as `cases`. The pretty-printer will use this syntax opportunistically. See the [lambdacase.md](https://github.com/unisonweb/unison/pull/2250/files#diff-48f6a2913613ff639e1bef34af1506b27ab94f5fa5e3995dc4015ec9895eda65) diff.

Added some unit tests and transcript tests.

## Implementation notes

`AbsN'` is now a complete pattern. This cleaned up the implementation some and caught a few redundant pattern matches elsewhere.