### PR TITLE
Allow constructor replacement during update propagation

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1980,16 +1980,21 @@ propagatePatchNoSync
   => Patch
   -> Path.Absolute
   -> Action' m v Bool
-propagatePatchNoSync patch scopePath = stepAtMNoSync'
-  (Path.unabsolute scopePath, lift . lift . Propagate.propagateAndApply patch)
+propagatePatchNoSync patch scopePath = do
+  r <- use root
+  let nroot = Branch.toNames0 (Branch.head r)
+  stepAtMNoSync' (Path.unabsolute scopePath,
+                  lift . lift . Propagate.propagateAndApply nroot patch)
 
 -- Returns True if the operation changed the namespace, False otherwise.
 propagatePatch :: (Monad m, Var v) =>
   InputDescription -> Patch -> Path.Absolute -> Action' m v Bool
-propagatePatch inputDescription patch scopePath =
+propagatePatch inputDescription patch scopePath = do
+  r <- use root
+  let nroot = Branch.toNames0 (Branch.head r)
   stepAtM' (inputDescription <> " (applying patch)")
            (Path.unabsolute scopePath,
-              lift . lift . Propagate.propagateAndApply patch)
+              lift . lift . Propagate.propagateAndApply nroot patch)
 
 -- | Create the args needed for showTodoOutput and call it
 doShowTodoOutput :: Monad m => Patch -> Path.Absolute -> Action' m v ()

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -287,7 +287,7 @@ isFailure o = case o of
   Typechecked{} -> False
   DisplayDefinitions _ _ m1 m2 -> null m1 && null m2
   DisplayRendered{} -> False
-  TodoOutput _ todo -> TO.todoScore todo /= 0 && not (TO.noConflicts todo)
+  TodoOutput _ todo -> TO.todoScore todo > 0 || not (TO.noConflicts todo)
   TestIncrementalOutputStart{} -> False
   TestIncrementalOutputEnd{} -> False
   TestResults _ _ _ _ _ fails -> not (null fails)

--- a/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
@@ -560,8 +560,6 @@ applyDeprecations patch = deleteDeprecatedTerms deprecatedTerms
 applyPropagate
   :: Var v => Applicative m => Patch -> Edits v -> F m i v (Branch0 m -> Branch0 m)
 applyPropagate patch Edits {..} = do
-  -- let termRefs = Map.mapMaybe TermEdit.toReference termEdits
-  --     typeRefs = Map.mapMaybe TypeEdit.toReference typeEdits
   let termTypes = Map.map (Type.toReference . snd) newTerms
   -- recursively update names and delete deprecated definitions
   pure $ Branch.stepEverywhere (updateLevel termReplacements typeReplacements termTypes)

--- a/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
@@ -504,8 +504,17 @@ applyPropagate patch Edits {..} = do
     isPropagatedReferent (Referent.Ref r) = isPropagated r
 
     terms0 = Star3.replaceFacts replaceConstructor constructorReplacements _terms
-    terms = Star3.replaceFacts replaceTerm termEdits terms0
-    types = Star3.replaceFacts replaceType typeEdits _types
+    terms = updateMetadatas
+          $ Star3.replaceFacts replaceTerm termEdits terms0
+    types = updateMetadatas
+          $ Star3.replaceFacts replaceType typeEdits _types
+
+    updateMetadatas s = Star3.mapD3 go s
+      where
+      go (tp,v) = case Map.lookup (Referent.Ref v) termEdits of
+        Just (Referent.Ref r) -> (typeOf r tp, r)
+        _ -> (tp,v)
+      typeOf r t = fromMaybe t $ Map.lookup r termTypes
 
     updateMetadata (Referent.Ref r) (Referent.Ref r') (tp, v) =
       if v == r then (typeOf r' tp, r') else (tp, v)

--- a/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Unison.Codebase.Editor.Propagate where
+module Unison.Codebase.Editor.Propagate (propagateAndApply) where
 
 import           Control.Error.Util             ( hush )
 import           Control.Lens
@@ -186,11 +186,6 @@ genInitialCtorMapping rootNames initialTypeReplacements = do
       , oldR /= newR
       ]
     in if debugMode then traceShow ("constructorMappings", r) r else r
-
-
-watch :: Show a => String -> a -> a
-watch msg a | debugMode = traceShow (msg, show a) a
-            | otherwise = a
 
 debugMode :: Bool
 debugMode = False

--- a/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
@@ -70,11 +70,12 @@ noEdits = Edits mempty mempty mempty mempty mempty mempty mempty
 propagateAndApply
   :: forall m i v
    . (Applicative m, Var v)
-  => Patch
+  => Names0
+  -> Patch
   -> Branch0 m
   -> F m i v (Branch0 m)
-propagateAndApply patch branch = do
-  edits <- propagate patch branch
+propagateAndApply rootNames patch branch = do
+  edits <- propagate rootNames patch branch
   f     <- applyPropagate patch edits
   (pure . f . applyDeprecations patch) branch
 
@@ -156,10 +157,11 @@ debugMode = True
 propagate
   :: forall m i v
    . (Applicative m, Var v)
-  => Patch
+  => Names0
+  -> Patch
   -> Branch0 m
   -> F m i v (Edits v)
-propagate patch b = case validatePatch patch of
+propagate _rootNames patch b = case validatePatch patch of
   Nothing -> do
     eval $ Notify PatchNeedsToBeConflictFree
     pure noEdits

--- a/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
@@ -118,7 +118,7 @@ watch msg a | debugMode = traceShow (msg, show a) a
             | otherwise = a
 
 debugMode :: Bool
-debugMode = True
+debugMode = False
 
 -- Note: this function adds definitions to the codebase as it propagates.
 -- Description:
@@ -234,7 +234,7 @@ propagate patch b = case validatePatch patch of
 
         doType :: Reference -> F m i v (Maybe (Edits v), Set Reference)
         doType r = do
-          traceM $ "Rewriting type: " <> refName r
+          when debugMode $ traceM ("Rewriting type: " <> refName r)
           componentMap <- unhashTypeComponent r
           let componentMap' =
                 over _2 (Decl.updateDependencies typeReplacements)

--- a/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
@@ -172,7 +172,7 @@ watch msg a | debugMode = traceShow (msg, show a) a
             | otherwise = a
 
 debugMode :: Bool
-debugMode = True
+debugMode = False
 
 -- Note: this function adds definitions to the codebase as it propagates.
 -- Description:

--- a/parser-typechecker/tests/Unison/Test/GitSync.hs
+++ b/parser-typechecker/tests/Unison/Test/GitSync.hs
@@ -315,6 +315,7 @@ test = scope "gitsync22" . tests $
       ```
     |])
   ,
+  -- TODO: remove the alias.type .defns.A A line once patch syncing is fixed
   pushPullTest "lightweightPatch" fmt
     (\repo -> [i|
       ```ucm
@@ -329,6 +330,7 @@ test = scope "gitsync22" . tests $
       ```ucm
       .defns> add
       .patches> replace .defns.A .defns.B
+      .patches> alias.type .defns.A  A
       .patches> replace .defns.x .defns.y
       .patches> push ${repo}
       ```

--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -938,8 +938,6 @@ updateDependencies termUpdates typeUpdates = ABT.rebuildUp go
   referent (Referent.Ref r) = Ref r
   referent (Referent.Con r cid CT.Data) = Constructor r cid
   referent (Referent.Con r cid CT.Effect) = Request r cid
-  -- todo: this function might need tweaking if we ever allow type replacements
-  -- would need to look inside pattern matching and constructor calls
   go (Ref r    ) = case Map.lookup (Referent.Ref r) termUpdates of
     Nothing -> Ref r
     Just r -> referent r

--- a/unison-src/transcripts/command-replace.md
+++ b/unison-src/transcripts/command-replace.md
@@ -27,6 +27,7 @@ Test that replace works with terms
 Test that replace works with types
 ```ucm
 .scratch> replace X Y
+.scratch> find
 .scratch> view.patch patch
 .scratch> view X
 ```

--- a/unison-src/transcripts/command-replace.md
+++ b/unison-src/transcripts/command-replace.md
@@ -27,6 +27,7 @@ Test that replace works with terms
 Test that replace works with types
 ```ucm
 .scratch> replace X Y
+.scratch> view.patch patch
 .scratch> view X
 ```
 
@@ -35,7 +36,7 @@ Try with a type/term mismatch
 .scratch> replace X x
 ```
 ```ucm:error
-.scratch> replace y Y 
+.scratch> replace y Y
 ```
 
 Try with missing references

--- a/unison-src/transcripts/command-replace.output.md
+++ b/unison-src/transcripts/command-replace.output.md
@@ -55,9 +55,29 @@ Test that replace works with types
 
   Done.
 
+.scratch> find
+
+  1. type X
+  2. X.One : Nat -> Nat -> X
+  3. type Y
+  4. Y.Two : Nat -> Nat -> X
+  5. x : Nat
+  6. y : Nat
+  
+
+.scratch> view.patch patch
+
+  Edited Types: X#d97e0jhkmd -> X
+  
+  Edited Terms: #jk19sm5bf8 -> x
+  
+  Tip: To remove entries from a patch, use
+       delete.term-replacement or delete.type-replacement, as
+       appropriate.
+
 .scratch> view X
 
-  type X = Two Nat Nat
+  type X = One Nat Nat
 
 ```
 Try with a type/term mismatch
@@ -70,7 +90,7 @@ Try with a type/term mismatch
 
 ```
 ```ucm
-.scratch> replace y Y 
+.scratch> replace y Y
 
   ⚠️
   

--- a/unison-src/transcripts/deleteReplacements.md
+++ b/unison-src/transcripts/deleteReplacements.md
@@ -23,7 +23,7 @@ x = 2
 ```
 
 ```unison
-type Foo = Foo
+unique[a] type Foo = Foo
 ```
 
 ```ucm
@@ -31,7 +31,7 @@ type Foo = Foo
 ```
 
 ```unison
-type Foo = Foo | Bar
+unique[b] type Foo = Foo | Bar
 ```
 
 ```ucm
@@ -40,13 +40,13 @@ type Foo = Foo | Bar
 ```
 
 ```ucm
-.> delete.type-replacement #568rsi7o3g
+.> delete.type-replacement #hsk1l8232e
 .> view.patch
 ```
 
 ```unison
 bar = 3
-type bar = Foo
+unique[aa] type bar = Foo
 ```
 
 ```ucm
@@ -54,12 +54,12 @@ type bar = Foo
 ```
 
 ```unison
-type bar = Foo | Bar
+unique[bb] type bar = Foo | Bar
 ```
 
 ```ucm
 .> update
 .> view.patch
-.> delete.type-replacement bar
+.> delete.type-replacement #b1ct5ub6du
 .> view.patch
 ```

--- a/unison-src/transcripts/deleteReplacements.output.md
+++ b/unison-src/transcripts/deleteReplacements.output.md
@@ -113,7 +113,7 @@ unique[b] type Foo = Foo | Bar
 
 .> view.patch
 
-  Edited Types: #hsk1l8232e -> Foo
+  Edited Types: Foo#hsk1l8232e -> Foo
   
   Tip: To remove entries from a patch, use
        delete.term-replacement or delete.type-replacement, as
@@ -181,7 +181,7 @@ unique[bb] type bar = Foo | Bar
 
 .> view.patch
 
-  Edited Types: #b1ct5ub6du -> bar
+  Edited Types: bar#b1ct5ub6du -> bar
   
   Tip: To remove entries from a patch, use
        delete.term-replacement or delete.type-replacement, as

--- a/unison-src/transcripts/deleteReplacements.output.md
+++ b/unison-src/transcripts/deleteReplacements.output.md
@@ -66,7 +66,7 @@ x = 2
 
 ```
 ```unison
-type Foo = Foo
+unique[a] type Foo = Foo
 ```
 
 ```ucm
@@ -77,7 +77,7 @@ type Foo = Foo
   
     ⍟ These new definitions are ok to `add`:
     
-      type Foo
+      unique type Foo
 
 ```
 ```ucm
@@ -85,11 +85,11 @@ type Foo = Foo
 
   ⍟ I've added these definitions:
   
-    type Foo
+    unique type Foo
 
 ```
 ```unison
-type Foo = Foo | Bar
+unique[b] type Foo = Foo | Bar
 ```
 
 ```ucm
@@ -101,7 +101,7 @@ type Foo = Foo | Bar
     ⍟ These names already exist. You can `update` them to your
       new definition:
     
-      type Foo
+      unique type Foo
 
 ```
 ```ucm
@@ -109,11 +109,11 @@ type Foo = Foo | Bar
 
   ⍟ I've updated these names to your new definition:
   
-    type Foo
+    unique type Foo
 
 .> view.patch
 
-  Edited Types: Foo#568rsi7o3g -> Foo
+  Edited Types: #hsk1l8232e -> Foo
   
   Tip: To remove entries from a patch, use
        delete.term-replacement or delete.type-replacement, as
@@ -121,7 +121,7 @@ type Foo = Foo | Bar
 
 ```
 ```ucm
-.> delete.type-replacement #568rsi7o3g
+.> delete.type-replacement #hsk1l8232e
 
   Done.
 
@@ -132,7 +132,7 @@ type Foo = Foo | Bar
 ```
 ```unison
 bar = 3
-type bar = Foo
+unique[aa] type bar = Foo
 ```
 
 ```ucm
@@ -143,7 +143,7 @@ type bar = Foo
   
     ⍟ These new definitions are ok to `add`:
     
-      type bar
+      unique type bar
       bar : ##Nat
 
 ```
@@ -152,12 +152,12 @@ type bar = Foo
 
   ⍟ I've added these definitions:
   
-    type bar
+    unique type bar
     bar : ##Nat
 
 ```
 ```unison
-type bar = Foo | Bar
+unique[bb] type bar = Foo | Bar
 ```
 
 ```ucm
@@ -169,8 +169,7 @@ type bar = Foo | Bar
     ⍟ These names already exist. You can `update` them to your
       new definition:
     
-      type bar
-        (also named Foo)
+      unique type bar
 
 ```
 ```ucm
@@ -178,27 +177,22 @@ type bar = Foo | Bar
 
   ⍟ I've updated these names to your new definition:
   
-    type bar
-      (also named Foo)
+    unique type bar
 
 .> view.patch
 
-  Edited Types: bar#568rsi7o3g -> Foo
+  Edited Types: #b1ct5ub6du -> bar
   
   Tip: To remove entries from a patch, use
        delete.term-replacement or delete.type-replacement, as
        appropriate.
 
-.> delete.type-replacement bar
+.> delete.type-replacement #b1ct5ub6du
 
   Done.
 
 .> view.patch
 
-  Edited Types: bar#568rsi7o3g -> Foo
-  
-  Tip: To remove entries from a patch, use
-       delete.term-replacement or delete.type-replacement, as
-       appropriate.
+  This patch is empty.
 
 ```

--- a/unison-src/transcripts/diff.output.md
+++ b/unison-src/transcripts/diff.output.md
@@ -482,17 +482,15 @@ bdependent = "banana"
 
   Updates:
   
-    1. bdependent : Text
-       ↓
-    2. bdependent : Text
+    There were 1 auto-propagated updates.
   
-    3. patch patch (added 1 updates)
+    1. patch patch (added 1 updates)
   
   Name changes:
   
     Original       Changes
-    4. fromJust ┐  5. fromJust' (added)
-    6. yoohoo   ┘  7. yoohoo (removed)
+    2. fromJust ┐  3. fromJust' (added)
+    4. yoohoo   ┘  5. yoohoo (removed)
 
 ```
 ## Two different auto-propagated changes creating a name conflict

--- a/unison-src/transcripts/diff.output.md
+++ b/unison-src/transcripts/diff.output.md
@@ -482,15 +482,17 @@ bdependent = "banana"
 
   Updates:
   
-    There were 1 auto-propagated updates.
+    1. bdependent : Text
+       ↓
+    2. bdependent : Text
   
-    1. patch patch (added 1 updates)
+    3. patch patch (added 1 updates)
   
   Name changes:
   
     Original       Changes
-    2. fromJust ┐  3. fromJust' (added)
-    4. yoohoo   ┘  5. yoohoo (removed)
+    4. fromJust ┐  5. fromJust' (added)
+    6. yoohoo   ┘  7. yoohoo (removed)
 
 ```
 ## Two different auto-propagated changes creating a name conflict

--- a/unison-src/transcripts/fix2254.md
+++ b/unison-src/transcripts/fix2254.md
@@ -30,7 +30,7 @@ g = cases
 .> fork a a2
 ```
 
-```unison:hide
+```unison
 type A a b c d
   = A a
   | B b

--- a/unison-src/transcripts/fix2254.md
+++ b/unison-src/transcripts/fix2254.md
@@ -4,7 +4,7 @@
 ```
 
 ```unison:hide
-type A a b c d
+unique type A a b c d
   = A a
   | B b
   | C c
@@ -37,7 +37,7 @@ g = cases
 ```
 
 ```unison
-type A a b c d
+unique type A a b c d
   = A a
   | B b
   | C c
@@ -47,7 +47,8 @@ type A a b c d
 
 ```ucm
 .a2> update
-.a2> view A NeedsA f f2 f3
+.a2> names A.A
+.a2> view A NeedsA f f2 f3 g
 .a2> todo
 ```
 

--- a/unison-src/transcripts/fix2254.md
+++ b/unison-src/transcripts/fix2254.md
@@ -10,6 +10,8 @@ type A a b c d
   | C c
   | D d
 
+type NeedsA a b = NeedsA (A a b Nat Nat)
+
 f : A Nat Nat Nat Nat -> Nat
 f = cases
   A n -> n
@@ -18,6 +20,10 @@ f = cases
 f2 a =
   n = f a
   n + 1
+
+f3 : NeedsA Nat Nat -> Nat
+f3 = cases
+  NeedsA a -> f a + 20
 
 g : A Nat Nat Nat Nat -> Nat
 g = cases
@@ -41,6 +47,7 @@ type A a b c d
 
 ```ucm
 .a2> update
+.a2> view A NeedsA
 .a2> todo
 ```
 

--- a/unison-src/transcripts/fix2254.md
+++ b/unison-src/transcripts/fix2254.md
@@ -1,0 +1,45 @@
+
+```ucm:hide
+.> builtins.merge
+```
+
+```unison:hide
+type A a b c d
+  = A a
+  | B b
+  | C c
+  | D d
+
+f : A Nat Nat Nat Nat -> Nat
+f = cases
+  A n -> n
+  _ -> 42
+
+f2 a =
+  n = f a
+  n + 1
+
+g : A Nat Nat Nat Nat -> Nat
+g = cases
+  D n -> n
+  _ -> 43
+```
+
+```ucm
+.a> add
+.> fork a a2
+```
+
+```unison:hide
+type A a b c d
+  = A a
+  | B b
+  | C c
+  | D d
+  | E a d
+```
+
+```ucm
+.a2> update
+.a2> todo
+```

--- a/unison-src/transcripts/fix2254.md
+++ b/unison-src/transcripts/fix2254.md
@@ -47,7 +47,7 @@ type A a b c d
 
 ```ucm
 .a2> update
-.a2> view A NeedsA
+.a2> view A NeedsA f f2 f3
 .a2> todo
 ```
 

--- a/unison-src/transcripts/fix2254.md
+++ b/unison-src/transcripts/fix2254.md
@@ -11,6 +11,7 @@ unique type A a b c d
   | D d
 
 type NeedsA a b = NeedsA (A a b Nat Nat)
+                | Zoink Text
 
 f : A Nat Nat Nat Nat -> Nat
 f = cases
@@ -24,6 +25,7 @@ f2 a =
 f3 : NeedsA Nat Nat -> Nat
 f3 = cases
   NeedsA a -> f a + 20
+  _ -> 0
 
 g : A Nat Nat Nat Nat -> Nat
 g = cases

--- a/unison-src/transcripts/fix2254.md
+++ b/unison-src/transcripts/fix2254.md
@@ -43,3 +43,22 @@ type A a b c d
 .a2> update
 .a2> todo
 ```
+
+```unison
+type Rec = { uno : Nat, dos : Nat }
+
+combine r = uno r + dos r
+```
+
+```ucm
+.a3> add
+```
+
+```unison
+type Rec = { uno : Nat, dos : Nat, tres : Text }
+```
+
+```ucm
+.a3> update
+.a3> todo
+```

--- a/unison-src/transcripts/fix2254.md
+++ b/unison-src/transcripts/fix2254.md
@@ -3,6 +3,8 @@
 .> builtins.merge
 ```
 
+This transcript checks that updates to data types propagate successfully to dependent types and dependent terms that do pattern matching. First let's create some types and terms:
+
 ```unison:hide
 unique type A a b c d
   = A a
@@ -33,12 +35,16 @@ g = cases
   _ -> 43
 ```
 
+We'll make our edits in a fork of the `a` namespace:
+
 ```ucm
 .a> add
 .> fork a a2
 ```
 
-```unison
+First let's edit the `A` type, adding another constructor `E`. Note that the functions written against the old type have a wildcard in their pattern match, so they should work fine after the update.
+
+```unison:hide
 unique type A a b c d
   = A a
   | B b
@@ -47,12 +53,17 @@ unique type A a b c d
   | E a d
 ```
 
+Let's do the update now, and verify that the definitions all look good and there's nothing `todo`:
+
 ```ucm
 .a2> update
-.a2> names A.A
 .a2> view A NeedsA f f2 f3 g
 .a2> todo
 ```
+
+## Record updates
+
+Here's a test of updating a record:
 
 ```unison
 type Rec = { uno : Nat, dos : Nat }
@@ -68,7 +79,10 @@ combine r = uno r + dos r
 type Rec = { uno : Nat, dos : Nat, tres : Text }
 ```
 
+And checking that after updating this record, there's nothing `todo`:
+
 ```ucm
-.a3> update
-.a3> todo
+.> fork a3 a4
+.a4> update
+.a4> todo
 ```

--- a/unison-src/transcripts/fix2254.output.md
+++ b/unison-src/transcripts/fix2254.output.md
@@ -1,4 +1,6 @@
 
+This transcript checks that updates to data types propagate successfully to dependent types and dependent terms that do pattern matching. First let's create some types and terms:
+
 ```unison
 unique type A a b c d
   = A a
@@ -29,6 +31,8 @@ g = cases
   _ -> 43
 ```
 
+We'll make our edits in a fork of the `a` namespace:
+
 ```ucm
   ☝️  The namespace .a is empty.
 
@@ -48,6 +52,8 @@ g = cases
   Done.
 
 ```
+First let's edit the `A` type, adding another constructor `E`. Note that the functions written against the old type have a wildcard in their pattern match, so they should work fine after the update.
+
 ```unison
 unique type A a b c d
   = A a
@@ -57,29 +63,14 @@ unique type A a b c d
   | E a d
 ```
 
-```ucm
+Let's do the update now, and verify that the definitions all look good and there's nothing `todo`:
 
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-  
-    ⍟ These new definitions are ok to `add`:
-    
-      unique type A a b c d
-
-```
 ```ucm
 .a2> update
 
   ⍟ I've updated these names to your new definition:
   
     unique type A a b c d
-
-.a2> names A.A
-
-  Term
-  Hash:   #jcqo2q0h1i#2
-  Names:  A.A
 
 .a2> view A NeedsA f f2 f3 g
 
@@ -117,6 +108,10 @@ unique type A a b c d
   No conflicts or edits in progress.
 
 ```
+## Record updates
+
+Here's a test of updating a record:
+
 ```unison
 type Rec = { uno : Nat, dos : Nat }
 
@@ -186,8 +181,14 @@ type Rec = { uno : Nat, dos : Nat, tres : Text }
       Rec.uno.set    : Nat -> Rec -> Rec
 
 ```
+And checking that after updating this record, there's nothing `todo`:
+
 ```ucm
-.a3> update
+.> fork a3 a4
+
+  Done.
+
+.a4> update
 
   ⍟ I've added these definitions:
   
@@ -205,7 +206,7 @@ type Rec = { uno : Nat, dos : Nat, tres : Text }
     Rec.uno.modify : (Nat ->{g} Nat) -> Rec ->{g} Rec
     Rec.uno.set    : Nat -> Rec -> Rec
 
-.a3> todo
+.a4> todo
 
   ✅
   

--- a/unison-src/transcripts/fix2254.output.md
+++ b/unison-src/transcripts/fix2254.output.md
@@ -72,3 +72,98 @@ type A a b c d
   No conflicts or edits in progress.
 
 ```
+```unison
+type Rec = { uno : Nat, dos : Nat }
+
+combine r = uno r + dos r
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      type Rec
+      Rec.dos        : Rec -> Nat
+      Rec.dos.modify : (Nat ->{g} Nat) -> Rec ->{g} Rec
+      Rec.dos.set    : Nat -> Rec -> Rec
+      Rec.uno        : Rec -> Nat
+      Rec.uno.modify : (Nat ->{g} Nat) -> Rec ->{g} Rec
+      Rec.uno.set    : Nat -> Rec -> Rec
+      combine        : Rec -> Nat
+
+```
+```ucm
+  ☝️  The namespace .a3 is empty.
+
+.a3> add
+
+  ⍟ I've added these definitions:
+  
+    type Rec
+    Rec.dos        : Rec -> Nat
+    Rec.dos.modify : (Nat ->{g} Nat) -> Rec ->{g} Rec
+    Rec.dos.set    : Nat -> Rec -> Rec
+    Rec.uno        : Rec -> Nat
+    Rec.uno.modify : (Nat ->{g} Nat) -> Rec ->{g} Rec
+    Rec.uno.set    : Nat -> Rec -> Rec
+    combine        : Rec -> Nat
+
+```
+```unison
+type Rec = { uno : Nat, dos : Nat, tres : Text }
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      Rec.tres        : Rec -> Text
+      Rec.tres.modify : (Text ->{g} Text) -> Rec ->{g} Rec
+      Rec.tres.set    : Text -> Rec -> Rec
+    
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      type Rec
+      Rec.dos        : Rec -> Nat
+      Rec.dos.modify : (Nat ->{g} Nat) -> Rec ->{g} Rec
+      Rec.dos.set    : Nat -> Rec -> Rec
+      Rec.uno        : Rec -> Nat
+      Rec.uno.modify : (Nat ->{g} Nat) -> Rec ->{g} Rec
+      Rec.uno.set    : Nat -> Rec -> Rec
+
+```
+```ucm
+.a3> update
+
+  ⍟ I've added these definitions:
+  
+    Rec.tres        : Rec -> Text
+    Rec.tres.modify : (Text ->{g} Text) -> Rec ->{g} Rec
+    Rec.tres.set    : Text -> Rec -> Rec
+  
+  ⍟ I've updated these names to your new definition:
+  
+    type Rec
+    Rec.dos        : Rec -> Nat
+    Rec.dos.modify : (Nat ->{g} Nat) -> Rec ->{g} Rec
+    Rec.dos.set    : Nat -> Rec -> Rec
+    Rec.uno        : Rec -> Nat
+    Rec.uno.modify : (Nat ->{g} Nat) -> Rec ->{g} Rec
+    Rec.uno.set    : Nat -> Rec -> Rec
+
+.a3> todo
+
+  ✅
+  
+  No conflicts or edits in progress.
+
+```

--- a/unison-src/transcripts/fix2254.output.md
+++ b/unison-src/transcripts/fix2254.output.md
@@ -48,6 +48,17 @@ type A a b c d
 ```
 
 ```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      type A a b c d
+
+```
+```ucm
 .a2> update
 
   ⍟ I've updated these names to your new definition:
@@ -56,19 +67,8 @@ type A a b c d
 
 .a2> todo
 
-  🚧
+  ✅
   
-  The namespace has 3 transitive dependent(s) left to upgrade.
-  Your edit frontier is the dependents of these definitions:
-  
-    type .a.A a b c d
-  
-  I recommend working on them in the following order:
-  
-  1. g  : a.A Nat Nat Nat Nat -> Nat
-  2. f  : a.A Nat Nat Nat Nat -> Nat
-  3. f2 : a.A Nat Nat Nat Nat -> Nat
-  
-  
+  No conflicts or edits in progress.
 
 ```

--- a/unison-src/transcripts/fix2254.output.md
+++ b/unison-src/transcripts/fix2254.output.md
@@ -6,6 +6,8 @@ type A a b c d
   | C c
   | D d
 
+type NeedsA a b = NeedsA (A a b Nat Nat)
+
 f : A Nat Nat Nat Nat -> Nat
 f = cases
   A n -> n
@@ -14,6 +16,10 @@ f = cases
 f2 a =
   n = f a
   n + 1
+
+f3 : NeedsA Nat Nat -> Nat
+f3 = cases
+  NeedsA a -> f a + 20
 
 g : A Nat Nat Nat Nat -> Nat
 g = cases
@@ -29,8 +35,10 @@ g = cases
   ⍟ I've added these definitions:
   
     type A a b c d
+    type NeedsA a b
     f  : A Nat Nat Nat Nat -> Nat
     f2 : A Nat Nat Nat Nat -> Nat
+    f3 : NeedsA Nat Nat -> Nat
     g  : A Nat Nat Nat Nat -> Nat
 
 .> fork a a2
@@ -64,6 +72,12 @@ type A a b c d
   ⍟ I've updated these names to your new definition:
   
     type A a b c d
+
+.a2> view A NeedsA
+
+  type A a b c d = C c | A a | B b | D d | E a d
+  
+  type NeedsA a b = NeedsA (A a b Nat Nat)
 
 .a2> todo
 

--- a/unison-src/transcripts/fix2254.output.md
+++ b/unison-src/transcripts/fix2254.output.md
@@ -1,6 +1,6 @@
 
 ```unison
-type A a b c d
+unique type A a b c d
   = A a
   | B b
   | C c
@@ -34,7 +34,7 @@ g = cases
 
   ⍟ I've added these definitions:
   
-    type A a b c d
+    unique type A a b c d
     type NeedsA a b
     f  : A Nat Nat Nat Nat -> Nat
     f2 : A Nat Nat Nat Nat -> Nat
@@ -47,7 +47,7 @@ g = cases
 
 ```
 ```unison
-type A a b c d
+unique type A a b c d
   = A a
   | B b
   | C c
@@ -63,7 +63,7 @@ type A a b c d
   
     ⍟ These new definitions are ok to `add`:
     
-      type A a b c d
+      unique type A a b c d
 
 ```
 ```ucm
@@ -71,17 +71,23 @@ type A a b c d
 
   ⍟ I've updated these names to your new definition:
   
-    type A a b c d
+    unique type A a b c d
 
-.a2> view A NeedsA f f2 f3
+.a2> names A.A
 
-  type A a b c d = C c | A a | B b | D d | E a d
+  Term
+  Hash:   #jcqo2q0h1i#2
+  Names:  A.A
+
+.a2> view A NeedsA f f2 f3 g
+
+  unique type A a b c d = E a d | C c | A a | B b | D d
   
   type NeedsA a b = NeedsA (A a b Nat Nat)
   
   f : A Nat Nat Nat Nat -> Nat
   f = cases
-    A.B n -> n
+    A.A n -> n
     _     -> 42
   
   f2 : A Nat Nat Nat Nat -> Nat
@@ -95,6 +101,11 @@ type A a b c d
     NeedsA.NeedsA a ->
       use Nat +
       f a + 20
+  
+  g : A Nat Nat Nat Nat -> Nat
+  g = cases
+    A.D n -> n
+    _     -> 43
 
 .a2> todo
 

--- a/unison-src/transcripts/fix2254.output.md
+++ b/unison-src/transcripts/fix2254.output.md
@@ -1,0 +1,74 @@
+
+```unison
+type A a b c d
+  = A a
+  | B b
+  | C c
+  | D d
+
+f : A Nat Nat Nat Nat -> Nat
+f = cases
+  A n -> n
+  _ -> 42
+
+f2 a =
+  n = f a
+  n + 1
+
+g : A Nat Nat Nat Nat -> Nat
+g = cases
+  D n -> n
+  _ -> 43
+```
+
+```ucm
+  ☝️  The namespace .a is empty.
+
+.a> add
+
+  ⍟ I've added these definitions:
+  
+    type A a b c d
+    f  : A Nat Nat Nat Nat -> Nat
+    f2 : A Nat Nat Nat Nat -> Nat
+    g  : A Nat Nat Nat Nat -> Nat
+
+.> fork a a2
+
+  Done.
+
+```
+```unison
+type A a b c d
+  = A a
+  | B b
+  | C c
+  | D d
+  | E a d
+```
+
+```ucm
+.a2> update
+
+  ⍟ I've updated these names to your new definition:
+  
+    type A a b c d
+
+.a2> todo
+
+  🚧
+  
+  The namespace has 3 transitive dependent(s) left to upgrade.
+  Your edit frontier is the dependents of these definitions:
+  
+    type .a.A a b c d
+  
+  I recommend working on them in the following order:
+  
+  1. g  : a.A Nat Nat Nat Nat -> Nat
+  2. f  : a.A Nat Nat Nat Nat -> Nat
+  3. f2 : a.A Nat Nat Nat Nat -> Nat
+  
+  
+
+```

--- a/unison-src/transcripts/fix2254.output.md
+++ b/unison-src/transcripts/fix2254.output.md
@@ -7,6 +7,7 @@ unique type A a b c d
   | D d
 
 type NeedsA a b = NeedsA (A a b Nat Nat)
+                | Zoink Text
 
 f : A Nat Nat Nat Nat -> Nat
 f = cases
@@ -20,6 +21,7 @@ f2 a =
 f3 : NeedsA Nat Nat -> Nat
 f3 = cases
   NeedsA a -> f a + 20
+  _ -> 0
 
 g : A Nat Nat Nat Nat -> Nat
 g = cases
@@ -83,7 +85,7 @@ unique type A a b c d
 
   unique type A a b c d = E a d | C c | A a | B b | D d
   
-  type NeedsA a b = NeedsA (A a b Nat Nat)
+  type NeedsA a b = Zoink Text | NeedsA (A a b Nat Nat)
   
   f : A Nat Nat Nat Nat -> Nat
   f = cases
@@ -101,6 +103,7 @@ unique type A a b c d
     NeedsA.NeedsA a ->
       use Nat +
       f a + 20
+    _               -> 0
   
   g : A Nat Nat Nat Nat -> Nat
   g = cases

--- a/unison-src/transcripts/fix2254.output.md
+++ b/unison-src/transcripts/fix2254.output.md
@@ -73,11 +73,28 @@ type A a b c d
   
     type A a b c d
 
-.a2> view A NeedsA
+.a2> view A NeedsA f f2 f3
 
   type A a b c d = C c | A a | B b | D d | E a d
   
   type NeedsA a b = NeedsA (A a b Nat Nat)
+  
+  f : A Nat Nat Nat Nat -> Nat
+  f = cases
+    A.B n -> n
+    _     -> 42
+  
+  f2 : A Nat Nat Nat Nat -> Nat
+  f2 a =
+    use Nat +
+    n = f a
+    n + 1
+  
+  f3 : NeedsA Nat Nat -> Nat
+  f3 = cases
+    NeedsA.NeedsA a ->
+      use Nat +
+      f a + 20
 
 .a2> todo
 

--- a/unison-src/transcripts/resolve.md
+++ b/unison-src/transcripts/resolve.md
@@ -81,7 +81,7 @@ Let's now merge these namespaces into `c`:
 
 The namespace `c` now has an edit conflict, since the term `foo` was edited in two different ways.
 
-```ucm
+```ucm:error
 .example.resolve> cd c
 .example.resolve.c> todo
 ```
@@ -102,7 +102,7 @@ This changes the merged `c.patch` so that only the edit from #44954ulpdf to  #8e
 
 We still have a remaining _name conflict_ since it just so happened that both of the definitions in the edits were named `foo`.
 
-```ucm
+```ucm:error
 .example.resolve.c> todo
 ```
 
@@ -110,6 +110,7 @@ We can resolve the name conflict by deleting one of the names.
 
 ```ucm
 .example.resolve.c> delete.term foo#jdqoenu794
+.example.resolve.c> todo
 ```
 
 And that's how you resolve edit conflicts with UCM.

--- a/unison-src/transcripts/resolve.output.md
+++ b/unison-src/transcripts/resolve.output.md
@@ -255,5 +255,11 @@ We can resolve the name conflict by deleting one of the names.
   
   Tip: You can use `undo` or `reflog` to undo this change.
 
+.example.resolve.c> todo
+
+  ✅
+  
+  No conflicts or edits in progress.
+
 ```
 And that's how you resolve edit conflicts with UCM.


### PR DESCRIPTION
Fixes #2254 which should be a huge quality of life improvement. See [this transcript](https://github.com/unisonweb/unison/blob/fix/2254/unison-src/transcripts/fix2254.output.md)

This PR has gone through several phases... at one point I was convinced the approach wasn't going to work out but I came up with a nice fix.

## Overview

This PR allows constructor replacement to happen during update propagation, so the common use case of adding or removing a constructor from a data type, or adding a field to an existing constructor or record type is now fully automatic. 

This also lays the groundwork for adding constructor replacement directly to patches.

## Implementation notes

During propagation, we now maintain a `Map Referent Referent` rather than `Map Reference Reference`. And `Term.updateDependencies` now takes such a `Map`, and will rewrite pattern matches and constructor calls.

The map is initially populated by aligning same-named types and constructors, which works out nicely as long as the namespace being updated is a fork of a namespace that already exists. If updating a namespace that's not a fork, there are no old names for the type to use for establishing the mapping.

During propagation, you need to build up new constructor mappings as types are rewritten, and the approach used in this PR is robust and works great. See the comments in `Propagate.hs`. That module is still very frightening but I added more comments.

## Interesting/controversial decisions

The existing logic doesn't check that type updates are well-kinded. It has actually been like this for a while, and I just left it that way. I'm okay with this for now until #567 - the programmer is responsible for knowing when it is safe to call `update` on a data type. You can also produce ill-kinded data types now, manually, via typing them in, so I'd say propagation should be allowed to do automatically whatever the programmer can currently do manually.

## Test coverage

I added a transcript to exercise this and caught lots of bugs this way, and also the existing transcripts caught some bugs.

I also did manual testing for a simple refactoring to the distributed library - I added some constructors to the `Location` type and it propagated automatically via multiple transitive dependents, including types and terms, as expected. (Before it totally did not work)

## Loose ends

- [x] gitsync22.fc.lightweightPatch test is currently failing, filed https://github.com/unisonweb/unison/issues/2265 to track figuring that out
