### PR TITLE
Fix #2261

### DIFF
--- a/parser-typechecker/src/Unison/Server/Doc.hs
+++ b/parser-typechecker/src/Unison/Server/Doc.hs
@@ -262,9 +262,12 @@ renderDoc pped terms typeOf eval types tm = eval tm >>= \case
                   Just tm -> do
                     typ <- fromMaybe (Type.builtin() "unknown") <$> typeOf (Referent.Ref ref)
                     let name = PPE.termName ppe (Referent.Ref ref)
-                    let full = formatPretty (TermPrinter.prettyBinding ppe name tm)
                     let folded = formatPretty . P.lines $ TypePrinter.prettySignatures'' ppe [(name, typ)]
-                    pure (DO.UserObject (Src folded full))
+                    let full tm@(Term.Ann' _ _) _ =
+                          formatPretty (TermPrinter.prettyBinding ppe name tm)
+                        full tm typ =
+                          formatPretty (TermPrinter.prettyBinding ppe name (Term.ann() tm typ))
+                    pure (DO.UserObject (Src folded (full tm typ)))
               Term.RequestOrCtor' r _ | Set.notMember r seen -> (:acc) <$> goType r
               _ -> pure acc
           DD.TupleTerm' [DD.EitherLeft' (Term.TypeLink' ref), _anns]


### PR DESCRIPTION
After this PR, all term source embedded in docs will include a type signature, so the front-end should just toggle between the folded and unfolded source rather than treating those two docs as "summary" and "detail" and attempting to concatenate the two to produce the unfolded view. 

Manually tested.

Here's what it currently looks like:

<img width="547" alt="Screen Shot 2021-07-27 at 11 45 48 PM" src="https://user-images.githubusercontent.com/11074/127260387-dadc709c-fd8c-482b-ac51-f4265b8ce0f5.png">