### PR TITLE
Syntax: Replace Constructor + Request with Referent

### DIFF
--- a/parser-typechecker/src/Unison/Server/Syntax.hs
+++ b/parser-typechecker/src/Unison/Server/Syntax.hs
@@ -59,8 +59,6 @@ convertElement = \case
   SyntaxText.Referent  r         -> TermReference $ Referent.toText r
   SyntaxText.Reference r         -> TypeReference $ Reference.toText r
   SyntaxText.Op        s         -> Op s
-  SyntaxText.Constructor         -> Constructor
-  SyntaxText.Request             -> Request
   SyntaxText.AbilityBraces       -> AbilityBraces
   SyntaxText.ControlKeyword      -> ControlKeyword
   SyntaxText.TypeOperator        -> TypeOperator

--- a/parser-typechecker/src/Unison/Util/ColorText.hs
+++ b/parser-typechecker/src/Unison/Util/ColorText.hs
@@ -134,8 +134,6 @@ defaultColors = \case
   ST.Referent _          -> Nothing
   ST.Op _                -> Nothing
   ST.Unit                -> Nothing
-  ST.Constructor         -> Nothing
-  ST.Request             -> Nothing
   ST.AbilityBraces       -> Just HiBlack
   ST.ControlKeyword      -> Just Bold
   ST.LinkKeyword         -> Just HiBlack

--- a/parser-typechecker/src/Unison/Util/SyntaxText.hs
+++ b/parser-typechecker/src/Unison/Util/SyntaxText.hs
@@ -25,8 +25,6 @@ data Element r = NumericLiteral
              | Reference r
              | Referent (Referent' r)
              | Op SeqOp
-             | Constructor
-             | Request
              | AbilityBraces
              -- let|handle|in|where|match|with|cases|->|if|then|else|and|or
              | ControlKeyword


### PR DESCRIPTION
## Overview
Constructors and Requests did not (on the server side) include
references to their terms. Merge them into the Referent variant to
preserve that data in the Codebase Server API.

Side change: Add type references to tuple parens.
Feel free to include "before and after" examples if appropriate. (You can copy/paste screenshots directly into this editor.)

Closes https://github.com/unisonweb/unison/issues/2176