### PR TITLE
Type checker improvements to avoid ambiguous ability variable collections

### DIFF
--- a/parser-typechecker/src/Unison/Typechecker.hs
+++ b/parser-typechecker/src/Unison/Typechecker.hs
@@ -16,7 +16,6 @@ import           Control.Monad.State        (State, StateT, execState, get,
                                              modify)
 import           Control.Monad.Writer
 import qualified Data.Map                   as Map
-import qualified Data.Set                   as Set
 import qualified Data.Sequence.NonEmpty     as NESeq (toSeq)
 import qualified Data.Text                  as Text
 import qualified Unison.ABT                 as ABT
@@ -28,7 +27,6 @@ import qualified Unison.Result              as Result
 import           Unison.Term                (Term)
 import qualified Unison.Term                as Term
 import           Unison.Type                (Type)
-import qualified Unison.Type                as Type
 import qualified Unison.Typechecker.Context as Context
 import qualified Unison.Typechecker.TypeVar as TypeVar
 import           Unison.Var                 (Var)
@@ -296,7 +294,7 @@ typeDirectedNameResolution oldNotes oldType env = do
     -> Result (Notes v loc) [Context.Suggestion v loc]
   resolve inferredType (NamedReference fqn foundType replace) =
     -- We found a name that matches. See if the type matches too.
-    case Context.isSubtype (TypeVar.liftType foundType) (relax inferredType) of
+    case Context.isSubtype (TypeVar.liftType foundType) (Context.relax inferredType) of
       Left bug -> const [] <$> compilerBug bug
       -- Suggest the import if the type matches.
       Right b  -> pure
@@ -306,57 +304,6 @@ typeDirectedNameResolution oldNotes oldType env = do
             replace
             (if b then Context.Exact else Context.WrongType)
         ]
-
-  -- Ability inference prefers minimal sets of abilities when
-  -- possible. However, such inference may disqualify certain TDNR
-  -- candicates due to a subtyping check with an overly minimal type.
-  -- It may be that the candidate's type would work fine, because the
-  -- inference was overly conservative about guessing which abilities
-  -- are in play.
-  --
-  -- `relax` adds an existential variable to the final inferred
-  -- abilities for such a function type if there isn't already one,
-  -- changing:
-  --
-  --   T ->{..} U ->{..} V
-  --
-  -- into:
-  --
-  --   T ->{..} U ->{e, ..} V
-  --
-  -- (where the `..` are presumed to be concrete) so that it can
-  -- behave better in the check.
-  --
-  -- It's possible this would allow an ability set that doesn't work,
-  -- but this is only used for type directed name resolution. A
-  -- separate type check must pass if the candidate is allowed, which
-  -- will ensure that the location has the right abilities.
-  relax :: Context.Type v loc -> Context.Type v loc
-  relax t = relax' v t
-    where
-    fvs = foldMap f $ Type.freeVars t
-    f (TypeVar.Existential _ v) = Set.singleton v
-    f _ = mempty
-    v = ABT.freshIn fvs $ Var.inferAbility
-
-  -- The worker for `relax`.
-  relax' :: v -> Context.Type v loc -> Context.Type v loc
-  relax' v t
-    | Type.Arrow' i o <- t = Type.arrow' i $ relax' v o
-    | Type.ForallsNamed' vs b <- t
-    = Type.foralls loc vs $ relax' v b
-    | Type.Effect' es r <- t
-    , Type.Arrow' i o <- r
-    = Type.effect loc es . Type.arrow' i $ relax' v o
-    | Type.Effect' es r <- t
-    , not $ any open es
-    = Type.effect loc (tv : es) r
-    | otherwise = t
-    where
-    open (Type.Var' (TypeVar.Existential{})) = True
-    open _ = False
-    loc = ABT.annotation t
-    tv = Type.var loc (TypeVar.Existential B.Blank v)
 
 -- | Check whether a term matches a type, using a
 -- function to resolve the type of @Ref@ constructors

--- a/unison-src/transcripts/fix2231.md
+++ b/unison-src/transcripts/fix2231.md
@@ -1,0 +1,29 @@
+This transcript contains some cases that were problematic with the new
+type checker. They were likely not discovered earlier because they
+involve combining types inferred with the older strategy with the new
+inference algorithm. Some code can be given multiple possible types,
+and while they are all valid and some may be equivalently general,
+the choices may not work equally well with the type checking
+strategies.
+
+```ucm:hide
+.> builtins.merge
+```
+
+```unison
+(.) : (b ->{e} c) -> (a ->{e} b) -> a ->{e} c
+(.) f g x = f (g x)
+
+f = atan . tan
+
+foldl : (b ->{e} a ->{e} b) -> b -> [a] ->{e} b
+foldl f a = cases
+  [] -> a
+  x +: xs -> foldl f (f a x) xs
+
+txt = foldl (Text.++) "" ["a", "b", "c"]
+```
+
+```ucm
+.> add
+```

--- a/unison-src/transcripts/fix2231.output.md
+++ b/unison-src/transcripts/fix2231.output.md
@@ -1,0 +1,47 @@
+This transcript contains some cases that were problematic with the new
+type checker. They were likely not discovered earlier because they
+involve combining types inferred with the older strategy with the new
+inference algorithm. Some code can be given multiple possible types,
+and while they are all valid and some may be equivalently general,
+the choices may not work equally well with the type checking
+strategies.
+
+```unison
+(.) : (b ->{e} c) -> (a ->{e} b) -> a ->{e} c
+(.) f g x = f (g x)
+
+f = atan . tan
+
+foldl : (b ->{e} a ->{e} b) -> b -> [a] ->{e} b
+foldl f a = cases
+  [] -> a
+  x +: xs -> foldl f (f a x) xs
+
+txt = foldl (Text.++) "" ["a", "b", "c"]
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      .     : (b ->{e} c) -> (a ->{e} b) -> a ->{e} c
+      f     : Float -> Float
+      foldl : (b ->{e} a ->{e} b) -> b -> [a] ->{e} b
+      txt   : Text
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    .     : (b ->{e} c) -> (a ->{e} b) -> a ->{e} c
+    f     : Float -> Float
+    foldl : (b ->{e} a ->{e} b) -> b -> [a] ->{e} b
+    txt   : Text
+
+```


### PR DESCRIPTION
This PR contains some modifications to the type checker to try to avoid getting into situations where there are two possible existential ability variables to unify with in a row. When that happens, subtype checks start failing, because it isn't clear which existential variable should 'pick up the slack', and the choice matters.

The (new) type checker already avoided inferring types like `forall e. A ->{e} B`, because the `e` is unnecessary (this is the type of a 'pure' function), and the unneccessary variable leads to the above problem. However, many builtins would effectively have such types, and functions in base that were checked before the modified type checker could have such types as well. It's also possible for users to annotate types this way.

So, this patch tries to prune off such variables immediately, so that they cannot percolate through and cause problems. There are still situations that can cause the multiple-variable problem, but this common source should be eliminated at least.