### PR TITLE
Avoid another variable-renaming let case

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/MCode.hs
+++ b/parser-typechecker/src/Unison/Runtime/MCode.hs
@@ -916,7 +916,7 @@ emitLet _   grp _   _ _   ctx (TApp (FPrim p) args)
   = fmap (Ins . either emitPOp emitFOp p $ emitArgs grp ctx args)
 emitLet rns grp rec d vcs ctx bnd
   | Direct <- d
-  = internalBug $ "unsupported compound direct let" ++ show bnd
+  = internalBug $ "unsupported compound direct let: " ++ show bnd
   | Indirect w <- d
   = \esect ->
       f <$> emitSection rns grp rec (Block ctx) bnd

--- a/unison-src/transcripts/fix2187.md
+++ b/unison-src/transcripts/fix2187.md
@@ -1,0 +1,19 @@
+```ucm:hide
+.> builtins.mergeio
+```
+
+```unison 
+
+lexicalScopeEx: [Text]
+lexicalScopeEx = 
+  parent = "outer"
+  inner1 = let 
+    child1 = "child1"
+    inner2 : [Text]
+    inner2 = let 
+      child2 = "child2"
+      [parent, child1, child2]
+    inner2
+  inner1
+
+```

--- a/unison-src/transcripts/fix2187.output.md
+++ b/unison-src/transcripts/fix2187.output.md
@@ -1,0 +1,26 @@
+```unison
+lexicalScopeEx: [Text]
+lexicalScopeEx = 
+  parent = "outer"
+  inner1 = let 
+    child1 = "child1"
+    inner2 : [Text]
+    inner2 = let 
+      child2 = "child2"
+      [parent, child1, child2]
+    inner2
+  inner1
+
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      lexicalScopeEx : [Text]
+
+```


### PR DESCRIPTION
This was another corner case where you could get an unexpected

    v = u

in part of the compiler that didn't expect to have to deal with it.

Fixes #2187 