### PR TITLE
Case insensitive substring matching used as pre-filter to fzf

### DIFF
--- a/unison-core/src/Unison/Names2.hs
+++ b/unison-core/src/Unison/Names2.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE PatternSynonyms     #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ViewPatterns        #-}
 
 module Unison.Names2
   ( Names0
@@ -49,7 +50,9 @@ import Unison.Prelude
 
 import qualified Data.Map                     as Map
 import qualified Data.Set                     as Set
+import qualified Data.Text                    as Text
 import           Prelude                      hiding (filter)
+import qualified Prelude
 import           Unison.HashQualified'        (HashQualified)
 import qualified Unison.HashQualified'        as HQ
 import           Unison.Name                  (Name)
@@ -85,11 +88,25 @@ fuzzyFind
 fuzzyFind query names =
   fmap flatten
     .  fuzzyFinds (Name.toString . fst) query
+    .  Prelude.filter prefilter
     .  Map.toList
     -- `mapMonotonic` is safe here and saves a log n factor
     $  (Set.mapMonotonic Left <$> R.toMultimap (terms names))
     <> (Set.mapMonotonic Right <$> R.toMultimap (types names))
  where
+  lowerqueryt = Text.toLower . Text.pack <$> query
+  -- For performance, case-insensitive substring matching as a pre-filter
+  -- This finds fewer matches than subsequence matching, but is
+  -- (currently) way faster even on large name sets.
+  prefilter (Name.toText -> name, _) = case lowerqueryt of
+    -- Special cases here just to help optimizer, since
+    -- not sure if `all` will get sufficiently unrolled for
+    -- Text fusion to work out.
+    [q] -> q `Text.isInfixOf` lowername
+    [q1,q2] -> q1 `Text.isInfixOf` lowername && q2 `Text.isInfixOf` lowername
+    query -> all (`Text.isInfixOf` lowername) query
+    where
+    lowername = Text.toLower name
   flatten (a, (b, c)) = (a, b, c)
   fuzzyFinds :: (a -> String) -> [String] -> [a] -> [(FZF.Alignment, a)]
   fuzzyFinds f query d =


### PR DESCRIPTION
Right now, the fuzzy find implementation can take several seconds to return results (though sometimes it is fast...) This PR adds a case-insensitive substring match as a pre-filter before consulting the fuzzy-find implementation. This returns fewer results but returns instantly, as it uses `Text.isInfixOf` which is highly optimized.

The stuff that matches the filter is still passed to fuzzy find to deal with alignment and ranking.

I'm not sure if this PR should be merged, but including some videos for comparison. 

The hope is that the pre-filter could be removed later once there's a more optimized implementation. 

One thing that seems like low-hanging fruit @runarorama is that the implementation currently converts all the names to strings before passing that to the FZF implementation. Then I'm guessing that FZF copies that into some unboxed arrays before doing its thing. Could it instead go directly from `Text` into the unboxed arrays used by the implementation?

__Before:__

https://user-images.githubusercontent.com/11074/128216558-b6442eca-29cf-4c38-a080-67de8d21f7b6.mov

__After:__

https://user-images.githubusercontent.com/11074/128217397-a53164f6-fd89-4218-b824-7257d2821405.mov

## Other ideas

I was thinking - is there some other _conservative_ pre-filter we could do? Like if `fast q name` returns `False`, then there is no way `q` can be a subsequence of `name`?

One really simple one - does `name` contain all the characters of `q`?

Are there others?