### PR TITLE
add `debug.dump-namespace-simple` command

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -135,6 +135,7 @@ import qualified Control.Error.Util as ErrorUtil
 import Unison.Util.Monoid (intercalateMap)
 import qualified Unison.Util.Star3 as Star3
 import qualified Unison.Util.Pretty as P
+import qualified Unison.Util.Relation as Relation
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as Nel
 import Unison.Codebase.Editor.AuthorInfo (AuthorInfo(..))
@@ -462,6 +463,7 @@ loop = do
           DebugBranchHistoryI{} -> wat
           DebugTypecheckedUnisonFileI{} -> wat
           DebugDumpNamespacesI{} -> wat
+          DebugDumpNamespaceSimpleI{} -> wat
           DebugClearWatchI {} -> wat
           QuitI{} -> wat
           DeprecateTermI{} -> undefined
@@ -1817,6 +1819,11 @@ loop = do
                 prettyDefn renderR (r, (Foldable.toList -> names, Foldable.toList -> links)) =
                   P.lines (P.shown <$> if null names then [NameSegment "<unnamed>"] else names) <> P.newline <> prettyLinks renderR r links
         void . eval . Eval . flip State.execStateT mempty $ goCausal [getCausal root']
+      DebugDumpNamespaceSimpleI -> do
+        for_ (Relation.toList . Branch.deepTypes . Branch.head $ root') \(r, name) ->
+          traceM $ show name ++ ",Type," ++ Text.unpack (Reference.toText r)
+        for_ (Relation.toList . Branch.deepTerms . Branch.head $ root') \(r, name) ->
+          traceM $ show name ++ ",Term," ++ Text.unpack (Referent.toText r)
       DebugClearWatchI {} -> eval ClearWatchCache
       DeprecateTermI {} -> notImplemented
       DeprecateTypeI {} -> notImplemented

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -136,6 +136,7 @@ data Input
   | DebugBranchHistoryI
   | DebugTypecheckedUnisonFileI
   | DebugDumpNamespacesI
+  | DebugDumpNamespaceSimpleI
   | DebugClearWatchI
   | QuitI
   deriving (Eq, Show)

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -1296,6 +1296,12 @@ debugDumpNamespace = InputPattern
   "Dump the namespace to a text file"
   (const $ Right Input.DebugDumpNamespacesI)
 
+debugDumpNamespaceSimple :: InputPattern
+debugDumpNamespaceSimple = InputPattern
+  "debug.dump-namespace-simple" [] [(Required, noCompletions)]
+  "Dump the namespace to a text file"
+  (const $ Right Input.DebugDumpNamespaceSimpleI)
+
 debugClearWatchCache :: InputPattern
 debugClearWatchCache = InputPattern
   "debug.clear-cache" [] [(Required, noCompletions)]
@@ -1429,6 +1435,7 @@ validInputs =
   , debugBranchHistory
   , debugFileHashes
   , debugDumpNamespace
+  , debugDumpNamespaceSimple
   , debugClearWatchCache
   ]
 


### PR DESCRIPTION
This PR adds a command that dumps the root namespace terms and types (no history) in a format that's approximately like what goes to the UI during search, i.e.

```
<name>,<Term|Type>,<hash>
```

It dumps it to stderr instead of a file, which is not great, but it didn’t feel permanent enough to be worth generating `Output` for. I captured stderr instead, with
`stack exec -- unison 2|& tee shared.namespace` and then edited `shared.namespace` after to throw out the ucm preamble. The result is linked [here](https://gist.github.com/aryairani/34d4b6cf65a7cb6117880c65d642a587).

This is definitely a feature we can adjust or drop at any time.

___
I used the command-line fzf tool to search the result with `time fzf -n 1 -d, -q M.tL < shared.namespace`, which means search the first column `-n 1`, comma-delimited `-d,` for the query string `M.tL` which matches `Map.toList` in ~0.02s on my machine.

