### PR TITLE
List Endpoint: Add rootBranch & relativeTo params

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -2164,6 +2164,8 @@ handleBackendError = \case
   Backend.NoBranchForHash h -> do
     sbhLength <- eval BranchHashLength
     respond . NoBranchWithHash $ SBH.fromHash sbhLength h
+  Backend.CouldntLoadBranch h -> do
+    respond . CouldntLoadBranch $ h
   Backend.CouldntExpandBranchHash sbh -> respond $ NoBranchWithHash sbh
   Backend.AmbiguousBranchHash h hashes ->
     respond $ BranchHashAmbiguous h hashes

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -208,6 +208,7 @@ data Output v
   | BadName String
   | DefaultMetadataNotification
   | BadRootBranch GetRootBranchError
+  | CouldntLoadBranch Branch.Hash
   | NoOp
   deriving (Show)
 
@@ -238,6 +239,7 @@ isFailure :: Ord v => Output v -> Bool
 isFailure o = case o of
   Success{} -> False
   BadRootBranch{} -> True
+  CouldntLoadBranch{} -> True
   NoUnisonFile{} -> True
   InvalidSourceName{} -> True
   SourceLoadFailed{} -> True

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -266,7 +266,10 @@ notifyUser dir o = case o of
         $  "I couldn't find a root namespace with the hash "
         <> prettySBH (SBH.fullFromHash h)
         <> "."
-
+  CouldntLoadBranch h ->
+    pure . P.fatalCallout . P.wrap $ "I have reason to believe that"
+      <> P.shown h <> "exists in the codebase, but there was a failure"
+      <> "when I tried to load it."
   WarnIncomingRootBranch current hashes -> pure $
     if null hashes then P.wrap $
       "Please let someone know I generated an empty IncomingRootBranch"

--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -109,6 +109,7 @@ data BackendError
   | CouldntExpandBranchHash ShortBranchHash
   | AmbiguousBranchHash ShortBranchHash (Set ShortBranchHash)
   | NoBranchForHash Branch.Hash
+  | CouldntLoadBranch Branch.Hash
   | MissingSignatureForTerm Reference
 
 type Backend m a = ExceptT BackendError m a

--- a/parser-typechecker/src/Unison/Server/Endpoints/GetDefinitions.hs
+++ b/parser-typechecker/src/Unison/Server/Endpoints/GetDefinitions.hs
@@ -41,6 +41,7 @@ import Unison.Server.Types
     APIHeaders,
     DefinitionDisplayResults,
     HashQualifiedName,
+    NamespaceFQN,
     Suffixify (..),
     addHeaders,
     defaultWidth,
@@ -50,7 +51,7 @@ import Unison.Var (Var)
 
 type DefinitionsAPI =
   "getDefinition" :> QueryParam "rootBranch" ShortBranchHash
-                  :> QueryParam "relativeTo" HashQualifiedName
+                  :> QueryParam "relativeTo" NamespaceFQN
                   :> QueryParams "names" HashQualifiedName
                   :> QueryParam "renderWidth" Width
                   :> QueryParam "suffixifyBindings" Suffixify
@@ -78,7 +79,7 @@ instance ToParam (QueryParam "suffixifyBindings" Suffixify) where
     Normal
 
 
-instance ToParam (QueryParam "relativeTo" HashQualifiedName) where
+instance ToParam (QueryParam "relativeTo" NamespaceFQN) where
   toParam _ = DocQueryParam
     "relativeTo"
     [".", ".base", "foo.bar"]
@@ -112,7 +113,7 @@ serveDefinitions
   -> Rt.Runtime v
   -> Codebase IO v Ann
   -> Maybe ShortBranchHash
-  -> Maybe HashQualifiedName
+  -> Maybe NamespaceFQN
   -> [HashQualifiedName]
   -> Maybe Width
   -> Maybe Suffixify

--- a/parser-typechecker/src/Unison/Server/Types.hs
+++ b/parser-typechecker/src/Unison/Server/Types.hs
@@ -54,6 +54,8 @@ type APIGet c = Get '[JSON] (APIHeaders c)
 
 type HashQualifiedName = Text
 
+type NamespaceFQN = Text
+
 type Size = Int
 
 type UnisonName = Text


### PR DESCRIPTION
## Overview
Add 2 new query params to the namespace listing `/list` API:
  * `rootBranch` - a hash of the root, typically the codebase hash
  * `relativeTo` - a namespace fqn that the listing should be relative
    to.

This enables URLs that are focused into a specific namespace. For
instance if we were focused on `base.List`:

Fetch all entries in `base.List`:

  `/list?rootBranch=#mycodebasehash&relativeTo=base.List`

Fetch all `Nonempty` entries in `base.List`:

  `/list?rootBranch=#mycodebasehash&relativeTo=base.List&namespace=Nonempty`

Fetch all `Nonempty.append` entries in `base.List`:
  `/list?rootBranch=#mycodebasehash&relativeTo=base.List&namespace=Nonempty.append`

This also fixes a minor bug where the NamespaceListing were including
the root hash as the `namespaceListingHash`. This is now correctly the
hash of the returned NamespaceListing.

## Notes
* Paired with @aryairani for most of this.
* Tested with the Codebase UI
* Closes: https://github.com/unisonweb/unison/issues/2275 and https://github.com/unisonweb/unison/issues/2215