### PR TITLE
Add single argument form of diff.namespace

### DIFF
--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -926,11 +926,15 @@ diffNamespace :: InputPattern
 diffNamespace = InputPattern
   "diff.namespace"
   []
-  [(Required, pathArg), (Required, pathArg)]
+  [(Required, pathArg), (Optional, pathArg)]
   (P.column2
     [ ( "`diff.namespace before after`"
       , P.wrap
         "shows how the namespace `after` differs from the namespace `before`"
+      )
+    , ( "`diff.namespace before`"
+      , P.wrap
+        "shows how the namespace `before` differs from the current namespace"
       )
     ]
   )
@@ -939,6 +943,9 @@ diffNamespace = InputPattern
       before <- Path.parsePath' before
       after <- Path.parsePath' after
       pure $ Input.DiffNamespaceI before after
+    [before] -> first fromString $ do
+      before <- Path.parsePath' before
+      pure $ Input.DiffNamespaceI before Path.currentPath
     _ -> Left $ I.help diffNamespace
   )
 

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -934,7 +934,7 @@ diffNamespace = InputPattern
       )
     , ( "`diff.namespace before`"
       , P.wrap
-        "shows how the namespace `before` differs from the current namespace"
+        "shows how the current namespace differs from the namespace `before`"
       )
     ]
   )

--- a/unison-src/transcripts/diff.md
+++ b/unison-src/transcripts/diff.md
@@ -19,6 +19,7 @@ fslkdjflskdjflksjdf = 663
 .b0> add
 .> merge b0 b1
 .> diff.namespace b1 b2
+.b2> diff.namespace b1
 ```
 Things we want to test:
 

--- a/unison-src/transcripts/diff.md
+++ b/unison-src/transcripts/diff.md
@@ -19,7 +19,7 @@ fslkdjflskdjflksjdf = 663
 .b0> add
 .> merge b0 b1
 .> diff.namespace b1 b2
-.b2> diff.namespace b1
+.b2> diff.namespace .b1
 ```
 Things we want to test:
 

--- a/unison-src/transcripts/diff.output.md
+++ b/unison-src/transcripts/diff.output.md
@@ -69,6 +69,14 @@ fslkdjflskdjflksjdf = 663
     6. fslkdjflskdjflksjdf#4kipsv2tm6 ┘  7. fslkdjflskdjflksjdf (added)
                                          8. fslkdjflskdjflksjdf#4kipsv2tm6 (removed)
 
+.b2> diff.namespace b1
+
+  Added definitions:
+  
+    1. ┌ abc                 : Nat
+    2. │ fslkdjflskdjflksjdf : Nat
+    3. └ x                   : Nat
+
 ```
 Things we want to test:
 

--- a/unison-src/transcripts/diff.output.md
+++ b/unison-src/transcripts/diff.output.md
@@ -69,13 +69,21 @@ fslkdjflskdjflksjdf = 663
     6. fslkdjflskdjflksjdf#4kipsv2tm6 ┘  7. fslkdjflskdjflksjdf (added)
                                          8. fslkdjflskdjflksjdf#4kipsv2tm6 (removed)
 
-.b2> diff.namespace b1
+.b2> diff.namespace .b1
 
-  Added definitions:
+  Resolved name conflicts:
   
-    1. ┌ abc                 : Nat
-    2. │ fslkdjflskdjflksjdf : Nat
-    3. └ x                   : Nat
+    1. ┌ fslkdjflskdjflksjdf#4kipsv2tm6 : Nat
+    2. └ fslkdjflskdjflksjdf#s5tu4n7rlb : Nat
+       ↓
+    3. fslkdjflskdjflksjdf#4kipsv2tm6 : Nat
+  
+  Name changes:
+  
+    Original                             Changes
+    4. x                              ┐  5. abc (added)
+    6. fslkdjflskdjflksjdf#4kipsv2tm6 ┘  7. fslkdjflskdjflksjdf (added)
+                                         8. fslkdjflskdjflksjdf#4kipsv2tm6 (removed)
 
 ```
 Things we want to test:


### PR DESCRIPTION
## Overview

You can now do

`.> diff.namespace before`

to diff `before` with the current namespace.

Closes #1531

## Implementation notes

Modifies the appropriate `InputPattern`

## Interesting/controversial decisions

None, fairly straightforward change

## Test coverage

Added a line to `diff.md` to check for same output as two argument form.

## Loose ends

none.
