### PR TITLE
Include commit-date in version command

### DIFF
--- a/parser-typechecker/unison/Version.hs
+++ b/parser-typechecker/unison/Version.hs
@@ -8,10 +8,12 @@ import Language.Haskell.TH.Syntax (Exp(LitE), Lit(StringL))
 import Shellmet
 import Data.Text
 
+-- | Uses Template Haskell to embed a git descriptor of the commit 
+--   which was used to build the executable.
 gitDescribe :: String
 gitDescribe = $( fmap (LitE . StringL . unpack) . runIO $ do
+  let formatDate d = " (built on " <> d <> ")"
   -- Outputs date of current commit; E.g. 2021-08-06
-  let formatDate d = "(" <> d <> ") "
   let getDate = "git" $| ["show", "-s", "--format=%cs"]
   date <- (formatDate <$> getDate) $? pure ""
   -- Fetches a unique tag-name to represent the current commit.
@@ -19,5 +21,5 @@ gitDescribe = $( fmap (LitE . StringL . unpack) . runIO $ do
   -- Marks version with a `'` suffix if building on a dirty worktree.
   let getTag = "git" $| ["describe", "--tags", "--always", "--dirty='"]
   tag <- getTag $? pure "unknown"
-  pure (date <> tag)
+  pure (tag <> date)
   )

--- a/parser-typechecker/unison/Version.hs
+++ b/parser-typechecker/unison/Version.hs
@@ -9,8 +9,15 @@ import Shellmet
 import Data.Text
 
 gitDescribe :: String
-gitDescribe = $( fmap (LitE . StringL . unpack) . runIO $
-  "git" $| ["describe", "--tags", "--always", "--dirty='"]
-        $? pure "unknown"
+gitDescribe = $( fmap (LitE . StringL . unpack) . runIO $ do
+  -- Outputs date of current commit; E.g. 2021-08-06
+  let formatDate d = "(" <> d <> ") "
+  let getDate = "git" $| ["show", "-s", "--format=%cs"]
+  date <- (formatDate <$> getDate) $? pure ""
+  -- Fetches a unique tag-name to represent the current commit.
+  -- Uses human-readable names whenever possible.
+  -- Marks version with a `'` suffix if building on a dirty worktree.
+  let getTag = "git" $| ["describe", "--tags", "--always", "--dirty='"]
+  tag <- getTag $? pure "unknown"
+  pure (date <> tag)
   )
-


### PR DESCRIPTION
Just a quick one; **if this doesn't align with your goals, feel free to close it.** 😄 

## Overview

Including the date with the version should make it much easier to tell when a version is out-of-date and should be upgraded; also just helps me keep track of which local binaries I have 🙃 

E.g. if you get a bug report for something like `unison version: latest-201-g408d4174c`, do you know how out of date that version is at a glance? You know it was based on `latest` at some point; but since that's a moving target that doesn't give you much additional information. You need to go look it up in your local git to be sure.

Something like `unison version: (2021-08-06) latest-201-g408d4174c` can tell you immediately how old the binary is, and should also reduce redundant bug reports since someone who sees that their version is 6 months out of date is likely to update their unison first rather than immediately file a bug 😄 

### Before

```
unison version: latest-201-g408d4174c
```

### After

```
unison version: ( 2021-08-07 ) latest-202-gc4f97e8df
```

## Implementation notes

None

## Interesting/controversial decisions

Not too controversial

## Test coverage

Unneeded

## Loose ends

Nope.