### PR TITLE
Fix a TDNR case for non-function effect references

### DIFF
--- a/unison-src/transcripts/fix2268.md
+++ b/unison-src/transcripts/fix2268.md
@@ -1,0 +1,20 @@
+Tests for a TDNR case that wasn't working. The code wasn't 'relaxing'
+inferred types that didn't contain arrows, so effects that just yield
+a value weren't getting disambiguated.
+
+```ucm:hide
+.> builtins.merge
+```
+
+```unison
+unique ability A where
+  a : Nat
+
+unique ability B where
+  a : Char
+
+test : 'Nat
+test _ =
+  x = a
+  toNat x
+```

--- a/unison-src/transcripts/fix2268.output.md
+++ b/unison-src/transcripts/fix2268.output.md
@@ -1,0 +1,30 @@
+Tests for a TDNR case that wasn't working. The code wasn't 'relaxing'
+inferred types that didn't contain arrows, so effects that just yield
+a value weren't getting disambiguated.
+
+```unison
+unique ability A where
+  a : Nat
+
+unique ability B where
+  a : Char
+
+test : 'Nat
+test _ =
+  x = a
+  toNat x
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique ability A
+      unique ability B
+      test : '{B} Nat
+
+```


### PR DESCRIPTION
This fixes a TDNR failure when you had a reference that needed a type like `Nat`, and the effect had type like `{A} Nat`.

Hopefully fixes the remaining issue with #2268 