### PR TITLE
Prefer cache when looking up rootBranch

### DIFF
--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -202,12 +202,15 @@ fuzzyFind
   -> String
   -> [(FZF.Alignment, UnisonName, [FoundRef])]
 fuzzyFind path branch query =
-  fmap (fmap (either FoundTermRef FoundTypeRef) . toList)
-    .   (over _2 Name.toText)
-    <$> fzfNames
+  sortOn rank $
+    fmap (fmap (either FoundTermRef FoundTypeRef) . toList)
+      .   over _2 Name.toText
+      <$> fzfNames
  where
   fzfNames   = Names.fuzzyFind (words query) printNames
   printNames = basicPrettyPrintNames0 branch path
+  rank (alignment, name, _) = 
+    ( Name.countSegments (Name.unsafeFromText name), negate (FZF.score alignment))
 
 -- List the immediate children of a namespace
 findShallow

--- a/parser-typechecker/src/Unison/Server/Endpoints/FuzzyFind.hs
+++ b/parser-typechecker/src/Unison/Server/Endpoints/FuzzyFind.hs
@@ -11,12 +11,8 @@
 module Unison.Server.Endpoints.FuzzyFind where
 
 import Control.Error (runExceptT)
-import Control.Lens (view, _1)
-import Data.Aeson
-import Data.Function (on)
-import Data.List (sortBy)
+import Data.Aeson ( defaultOptions, genericToEncoding, ToJSON(toEncoding) )
 import Data.OpenApi (ToSchema)
-import Data.Ord (Down (..))
 import qualified Data.Text as Text
 import Servant
   ( QueryParam,
@@ -152,9 +148,7 @@ serveFuzzyFind h codebase mayRoot relativePath limit typeWidth query =
       branch <- Backend.resolveBranchHash root codebase
       let b0 = Branch.head branch
           alignments =
-            take (fromMaybe 10 limit)
-              . sortBy (compare `on` (Down . FZF.score . (view _1)))
-              $ Backend.fuzzyFind rel branch (fromMaybe "" query)
+            take (fromMaybe 10 limit) $ Backend.fuzzyFind rel branch (fromMaybe "" query)
           ppe = Backend.basicSuffixifiedNames hashLength branch rel
       join <$> traverse (loadEntry root (Just rel) ppe b0) alignments
     errFromEither backendError ea


### PR DESCRIPTION
## Overview
Attempt to find the passed in rootBranch hash in the cache (3 levels of
children) before attempting to find it in SQLite — This improves UI performance a lot!

Also update /find sort to prefer matches with lower number of name
segments.

## Notes
Paired with @pchiusano 