### PR TITLE
Start of fix for confused find-by-type (issue #2140)

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Conversions.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Conversions.hs
@@ -386,15 +386,14 @@ type2to1' convertRef =
           V2.Kind.Arrow i o -> V1.Kind.Arrow (convertKind i) (convertKind o)
 
 dtype1to2 :: Hash -> V1.Type.Type V1.Symbol a -> V2.Type.TypeD V2.Symbol
-dtype1to2 h = type1to2' (rreference1to2 h)
+dtype1to2 h = V2.ABT.vmap symbol1to2 . type1to2' (rreference1to2 h)
 
 ttype1to2 :: V1.Type.Type V1.Symbol a -> V2.Type.TypeT V2.Symbol
-ttype1to2 = type1to2' reference1to2
+ttype1to2 = V2.ABT.vmap symbol1to2 . type1to2' reference1to2
 
-type1to2' :: (V1.Reference -> r) -> V1.Type.Type V1.Symbol a -> V2.Type.TypeR r V2.Symbol
+type1to2' :: Ord v => (V1.Reference -> r) -> V1.Type.Type v a -> V2.Type.TypeR r v
 type1to2' convertRef =
   V2.ABT.transform (typeF1to2' convertRef)
-    . V2.ABT.vmap symbol1to2
     . V2.ABT.amap (const ())
     . abt1to2
   where


### PR DESCRIPTION
There's inconsistency between hashing for V1 and V2 versions of the
codebase. The incoming search reference is constructed from the V1
version type, while the V2 types are indexed. This means we couldn't
find results for things like:

    find : [a] -> Optional a

This commit fixes the above but it's both messy and probably not
correct. It's also missing changes in various other places which have
this same issue (e.g. the "docs" command)

**Choose your PR title well:** Your pull request title is what's used to create release notes, so please make it descriptive of the change itself, which may be different from the initial motivation to make the change.

## Overview

What does this change accomplish and why? i.e. How does it change the user experience?

Feel free to include "before and after" examples if appropriate. (You can copy/paste screenshots directly into this editor.)

If relevant, which Github issues does it close? (See [closing-issues-using-keywords](https://help.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords).)

## Implementation notes

How does it accomplish it, in broad strokes? i.e. How does it change the Haskell codebase?

## Interesting/controversial decisions

Include anything that you thought twice about, debated, chose arbitrarily, etc. 
What could have been done differently, but wasn't? And why?

## Test coverage

Have you included tests (which could be a transcript) for this change, or is it somehow covered by existing tests? 

Would you recommend improving the test coverage (either as part of this PR or as a separate issue) or do you think it’s adequate?

## Loose ends

Link to related issues that address things you didn't get to. Stuff you encountered on the way and decided not to include in this PR.
