### PR TITLE
Add a ucm `ui` command to open the Codebase UI

### DIFF
--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -114,6 +114,8 @@ library:
     - unison-core
     - unison-core1
     - unison-util
+    - open-browser
+    - uri-encode
 
 executables:
   unison:

--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -78,6 +78,8 @@ data Command m i v a where
   -- Escape hatch.
   Eval :: m a -> Command m i v a
 
+  UI :: Command m i v ()
+
   HQNameQuery
     :: Maybe Path
     -> Branch m
@@ -246,6 +248,7 @@ lookupEvalResult v (_, m) = view _5 <$> Map.lookup v m
 commandName :: Command m i v a -> String
 commandName = \case
   Eval{}                      -> "Eval"
+  UI                          -> "UI"
   ConfigLookup{}              -> "ConfigLookup"
   Input                       -> "Input"
   Notify{}                    -> "Notify"

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -408,6 +408,7 @@ loop = do
           UpdateI p _selection -> "update " <> opatch p
           PropagatePatchI p scope -> "patch " <> ps' p <> " " <> p' scope
           UndoI{} -> "undo"
+          UiI -> "ui"
           ExecuteI s -> "execute " <> Text.pack s
           IOTestI hq -> "io.test " <> HQ.toText hq
           LinkI md defs ->
@@ -905,6 +906,8 @@ loop = do
             updateRoot prev
             diffHelper (Branch.head prev) (Branch.head root') >>=
               respondNumbered . uncurry Output.ShowDiffAfterUndo
+
+      UiI -> eval UI 
 
       AliasTermI src dest -> do
         referents <- resolveHHQS'Referents src

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -139,6 +139,7 @@ data Input
   | DebugDumpNamespaceSimpleI
   | DebugClearWatchI
   | QuitI
+  | UiI
   deriving (Eq, Show)
 
 -- Some commands, like `view`, can dump output to either console or a file.

--- a/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
@@ -298,6 +298,7 @@ run dir configFile stanzas codebase = do
                                      printNumbered
                                      loadPreviousUnisonBlock
                                      codebase
+                                     Nothing
                                      rng
                                      free
         case o of

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -308,6 +308,11 @@ docs = InputPattern "docs" [] [(Required, definitionQueryArg)]
         [s] -> first fromString $ Input.DocsI <$> Path.parseHQSplit' s
         _ -> Left (I.help docs))
 
+ui :: InputPattern
+ui = InputPattern "ui" [] []
+      "`ui` opens the Codebase UI in the default browser."
+      (const $ pure Input.UiI)
+
 undo :: InputPattern
 undo = InputPattern "undo" [] []
       "`undo` reverts the most recent change to the codebase."
@@ -1406,6 +1411,7 @@ validInputs =
   , view
   , display
   , displayTo
+  , ui
   , docs
   , findPatch
   , viewPatch

--- a/parser-typechecker/src/Unison/CommandLine/Main.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Main.hs
@@ -17,6 +17,7 @@ import System.IO.Error (isDoesNotExistError)
 import Unison.Codebase.Branch (Branch)
 import qualified Unison.Codebase.Branch as Branch
 import Unison.Codebase.Editor.Input (Input (..), Event)
+import qualified Unison.Server.CodebaseServer as Server
 import qualified Unison.Codebase.Editor.HandleInput as HandleInput
 import qualified Unison.Codebase.Editor.HandleCommand as HandleCommand
 import Unison.Codebase.Editor.Command (LoadSourceResult(..))
@@ -159,8 +160,9 @@ main
   -> Runtime.Runtime Symbol
   -> Codebase IO Symbol Ann
   -> String
+  -> Maybe Server.BaseUrl
   -> IO ()
-main dir defaultBaseLib initialPath (config,cancelConfig) initialInputs runtime codebase version = do
+main dir defaultBaseLib initialPath (config, cancelConfig) initialInputs runtime codebase version serverBaseUrl = do
   dir' <- shortenDirectory dir
   root <- fromMaybe Branch.empty . rightMay <$> Codebase.getRootBranch codebase
   putPrettyLn $ case defaultBaseLib of
@@ -240,6 +242,7 @@ main dir defaultBaseLib initialPath (config,cancelConfig) initialInputs runtime 
                                       putPrettyNonempty p $> args)
                                      loadSourceFile
                                      codebase
+                                     serverBaseUrl
                                      (const Random.getSystemDRG)
                                      free
         case o of

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -219,6 +219,7 @@ library
     , network
     , network-simple
     , nonempty-containers
+    , open-browser
     , openapi3
     , optparse-applicative >=0.16.1.0
     , pem
@@ -253,6 +254,7 @@ library
     , unison-core1
     , unison-util
     , unliftio
+    , uri-encode
     , utf8-string
     , vector
     , wai

--- a/unison-core/unison-core1.cabal
+++ b/unison-core/unison-core1.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 632fcb6d170a800081d7ac77914d64c97a52d1bb72a4939636e5880dbf853157
+-- hash: cef34d9302306093bb4280d9edb3ef4819cb15687e8542dfd977dd83b72ecf13
 
 name:           unison-core1
 version:        0.0.0


### PR DESCRIPTION
## Overview
Add a command, `ui`, that opens the Codebase UI with the current
codebase server URL.

Part of https://github.com/unisonweb/unison/issues/2150

## Interesting/controversial decisions
It's likely that there could be a better separation of concerns here. The way the URL is moved throughout the various functions is a bit annoying. Any suggestions?

## Test coverage
Not sure how we normally do tests for commands, or even how to best test something that has an external side effect like this?

## Loose ends
I definitely want to support giving this command arguments for opening a definition or namespace, but plan to tackle that in a subsequent effort.