### PR TITLE
Fix an issue pattern matching on multiple builtins

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Pattern.hs
+++ b/parser-typechecker/src/Unison/Runtime/Pattern.hs
@@ -411,7 +411,19 @@ splitMatrixBuiltin v (PM rs)
   . toList
   . fmap buildMatrix
   . fromListWith (flip (++))
+  . expandIrrefutable
   $ splitRowBuiltin v =<< rs
+
+expandIrrefutable
+  :: Var v
+  => [(P.Pattern (), [([P.Pattern v], PatternRow v)])]
+  -> [(P.Pattern (), [([P.Pattern v], PatternRow v)])]
+expandIrrefutable rss = concatMap expand rss
+  where
+  specific = filter refutable $ fst <$> rss
+  expand tup@(p, rs)
+    | not (refutable p) = fmap (,rs) specific ++ [tup]
+  expand tup = [tup]
 
 matchPattern :: [(v,PType)] -> SeqMatch -> P.Pattern ()
 matchPattern vrs = \case

--- a/unison-src/transcripts/fix2334.md
+++ b/unison-src/transcripts/fix2334.md
@@ -1,0 +1,20 @@
+
+Tests an issue where pattern matching matrices involving built-in
+types was discarding default cases in some branches.
+
+```ucm:hide
+.> builtins.mergeio
+```
+
+```unison
+f = cases
+  0, 0 -> 0
+  _, 1 -> 2
+  1, _ -> 3
+  _, _ -> 1
+
+> f 0 0
+> f 1 0
+> f 0 1
+> f 1 1
+```

--- a/unison-src/transcripts/fix2334.output.md
+++ b/unison-src/transcripts/fix2334.output.md
@@ -1,0 +1,47 @@
+
+Tests an issue where pattern matching matrices involving built-in
+types was discarding default cases in some branches.
+
+```unison
+f = cases
+  0, 0 -> 0
+  _, 1 -> 2
+  1, _ -> 3
+  _, _ -> 1
+
+> f 0 0
+> f 1 0
+> f 0 1
+> f 1 1
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      f : Nat -> Nat -> Nat
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    7 | > f 0 0
+          ⧩
+          0
+  
+    8 | > f 1 0
+          ⧩
+          3
+  
+    9 | > f 0 1
+          ⧩
+          2
+  
+    10 | > f 1 1
+           ⧩
+           2
+
+```


### PR DESCRIPTION
Default cases were not propagated into specific case branches as they should have been.

Fixes #2334 