### PR TITLE
Update stack resolver to LTS Haskell 18.7

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -22,7 +22,7 @@ packages:
 - codebase2/util-term
 
 #compiler-check: match-exact
-resolver: lts-17.15
+resolver: lts-18.7
 
 extra-deps:
 - github: unisonweb/configurator


### PR DESCRIPTION
## Overview
Update LTS Haskell 18.7 (the newest, released on 2021-08-20) which
includes ghc-8.10.6.

More details: https://www.stackage.org/lts-18.7

## Notes

The motivation behind this was to get the Haskell Language Server working with vim.
There was a version mismatch where HLS expected ghc 8.10.5 and the latest resolver was ghc 8.10.4 (It appears that 8.10.5 was entirely skipped over in Stack)