### PR TITLE
Call `minimize'` underneath each destructuring bind

### DIFF
--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -11,6 +11,7 @@ module Unison.TermParser where
 import Unison.Prelude
 
 import           Control.Monad.Reader (asks, local)
+import           Data.Foldable (foldrM)
 import           Prelude hiding (and, or, seq)
 import           Unison.Name (Name)
 import           Unison.Names3 (Names)
@@ -1038,21 +1039,23 @@ block'' isTop implicitUnitAtEnd s openBlock closeBlock = do
             Right tm -> pure tm
           toTm bs = do
             (bs, body) <- body bs
-            finish $ foldr step body bs
+            finish =<< foldrM step body bs
             where
-            step :: BlockElement v -> Term v Ann -> Term v Ann
             step elem body = case elem of
-              Binding ((a,v), tm) -> Term.consLetRec
-                isTop
-                (ann a <> ann body)
-                (a,v,tm)
-                body
-              Action tm -> Term.consLetRec
-                isTop
-                (ann tm <> ann body)
-                (ann tm, positionalVar (ann tm) (Var.named "_"), tm)
-                body
-              DestructuringBind (_, f) -> f body
+              Binding ((a,v), tm) -> pure $
+                Term.consLetRec
+                  isTop
+                  (ann a <> ann body)
+                  (a,v,tm)
+                  body
+              Action tm -> pure $
+                Term.consLetRec
+                  isTop
+                  (ann tm <> ann body)
+                  (ann tm, positionalVar (ann tm) (Var.named "_"), tm)
+                  body
+              DestructuringBind (_, f) ->
+                f <$> finish body
           body bs = case reverse bs of
             Binding ((a, _v), _) : _ -> pure $
               if implicitUnitAtEnd then (bs, DD.unitTerm a)

--- a/unison-src/transcripts/fix2344.md
+++ b/unison-src/transcripts/fix2344.md
@@ -1,0 +1,22 @@
+
+Checks a corner case with type checking involving destructuring binds.
+
+The binds were causing some sequences of lets to be unnecessarily
+recursive.
+
+```ucm:hide
+.> builtins.merge
+```
+
+```unison
+unique ability Nate where
+  nate: (Boolean, Nat)
+  antiNate: ()
+
+
+sneezy: (Nat -> {d} a) -> '{Nate,d} a
+sneezy dee _ =
+  (_,_) = nate
+  antiNate
+  dee 1
+```


### PR DESCRIPTION
Destructuring binds do not actually produce/add to `let rec` terms from the parser, so they were causing the final `minimize'` call to only operate on a subset of bindings including a destructuring bind. If the destructuring bind was first, that subset was empty. This would cause the other bindings to be unnecessarily recursive, and have unexpected ability limitations (and possibly other issues that went unnoticed).

Fixes #2344