### PR TITLE
Avoid a loop caused by inferring cyclic abilities

### DIFF
--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -364,6 +364,30 @@ renderTypeError e env src = case e of
     , debugSummary note
     ]
   AbilityCheckFailure {..}
+    | [tv@(Type.Var' ev)] <- ambient
+    , ev `Set.member` foldMap Type.freeVars requested -> mconcat
+    [ "I tried to infer a cyclic ability."
+    , "\n\n"
+    , "The expression "
+    , describeStyle ErrorSite
+    , " was inferred to require the "
+    , case length requested of
+        1 -> "ability: "
+        _ -> "abilities: "
+    , "\n\n    {"
+    , commas (renderType' env) requested
+    , "}"
+    , "\n\n"
+    , "where `"
+    , renderType' env tv
+    , "` is its overall abilities."
+    , "\n\n"
+    , "I need a type signature to help figure this out."
+    , "\n\n"
+    , annotatedAsErrorSite src abilityCheckFailureSite
+    , debugSummary note
+    ]
+  AbilityCheckFailure {..}
     | C.InSubtype{} :<| _ <- C.path note -> mconcat
     [ "The expression "
     , describeStyle ErrorSite

--- a/unison-src/transcripts/fix2355.md
+++ b/unison-src/transcripts/fix2355.md
@@ -1,0 +1,25 @@
+
+Tests for a loop that was previously occurring in the type checker.
+
+```ucm:hide
+.> builtins.merge
+```
+
+```unison:error
+structural ability A t g where 
+  fork : '{g, A t g} a -> t a
+  await : t a -> a
+  empty! : t a
+  put : a -> t a -> ()
+
+example : '{A t {}} Nat
+example = 'let
+  r = A.empty!
+  go u = 
+    t = A.fork '(go (u + 1))
+    A.await t
+  
+  go 0
+  t2 = A.fork '(A.put 10 r)
+  A.await r
+```

--- a/unison-src/transcripts/fix2355.output.md
+++ b/unison-src/transcripts/fix2355.output.md
@@ -1,0 +1,40 @@
+
+Tests for a loop that was previously occurring in the type checker.
+
+```unison
+structural ability A t g where 
+  fork : '{g, A t g} a -> t a
+  await : t a -> a
+  empty! : t a
+  put : a -> t a -> ()
+
+example : '{A t {}} Nat
+example = 'let
+  r = A.empty!
+  go u = 
+    t = A.fork '(go (u + 1))
+    A.await t
+  
+  go 0
+  t2 = A.fork '(A.put 10 r)
+  A.await r
+```
+
+```ucm
+
+  I tried to infer a cyclic ability.
+  
+  The expression in red was inferred to require the ability: 
+  
+      {A t25 {𝕖39, 𝕖18}}
+  
+  where `𝕖18` is its overall abilities.
+  
+  I need a type signature to properly figure this out.
+  
+     10 |   go u = 
+     11 |     t = A.fork '(go (u + 1))
+     12 |     A.await t
+  
+
+```

--- a/unison-src/transcripts/fix2355.output.md
+++ b/unison-src/transcripts/fix2355.output.md
@@ -30,7 +30,7 @@ example = 'let
   
   where `𝕖18` is its overall abilities.
   
-  I need a type signature to properly figure this out.
+  I need a type signature to help figure this out.
   
      10 |   go u = 
      11 |     t = A.fork '(go (u + 1))


### PR DESCRIPTION
Gives an error with a new error message in that case.

Addresses #2355 