### PR TITLE
temporary downgrade to stackage 18.6

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -22,7 +22,7 @@ packages:
 - codebase2/util-term
 
 #compiler-check: match-exact
-resolver: lts-18.7
+resolver: lts-18.6
 
 extra-deps:
 - github: unisonweb/configurator


### PR DESCRIPTION
Just until there is a haskell-language-server binary release that is compatible with it. 

See https://github.com/haskell/vscode-haskell#supported-ghc-versions, https://github.com/haskell/haskell-language-server/releases/latest

/cc @hojberg @rlmark @pchiusano
