### PR TITLE
Add new server endpoint: /namespaces/:fqn

### DIFF
--- a/parser-typechecker/src/Unison/Server/CodebaseServer.hs
+++ b/parser-typechecker/src/Unison/Server/CodebaseServer.hs
@@ -85,7 +85,8 @@ import Unison.Server.Endpoints.GetDefinitions
   ( DefinitionsAPI,
     serveDefinitions,
   )
-import Unison.Server.Endpoints.ListNamespace (NamespaceAPI, serveNamespace)
+import qualified Unison.Server.Endpoints.NamespaceDetails as NamespaceDetails
+import qualified Unison.Server.Endpoints.NamespaceListing as NamespaceListing
 import Unison.Server.Types (mungeString)
 import Unison.Var (Var)
 
@@ -104,7 +105,12 @@ type OpenApiJSON = "openapi.json" :> Get '[JSON] OpenApi
 
 type DocAPI = UnisonAPI :<|> OpenApiJSON :<|> Raw
 
-type UnisonAPI = NamespaceAPI :<|> DefinitionsAPI :<|> FuzzyFindAPI
+type UnisonAPI =
+  NamespaceListing.NamespaceListingAPI
+    :<|> NamespaceDetails.NamespaceDetailsAPI
+    :<|> DefinitionsAPI
+    :<|> FuzzyFindAPI
+
 
 type WebUI = CaptureAll "route" Text :> Get '[HTML] RawHtml
 
@@ -270,30 +276,28 @@ serveIndex path = do
 serveUI :: Handler () -> FilePath -> Server WebUI
 serveUI tryAuth path _ = tryAuth *> serveIndex path
 
-server
-  :: Var v
-  => Rt.Runtime v
-  -> Codebase IO v Ann
-  -> FilePath
-  -> Strict.ByteString
-  -> Server AuthedServerAPI
+server ::
+  Var v =>
+  Rt.Runtime v ->
+  Codebase IO v Ann ->
+  FilePath ->
+  Strict.ByteString ->
+  Server AuthedServerAPI
 server rt codebase uiPath token =
   serveDirectoryWebApp (uiPath </> "static")
-    :<|> ((\t ->
-            serveUI (tryAuth t) uiPath
-              :<|> (    (    (serveNamespace (tryAuth t) codebase)
-                        :<|> (serveDefinitions (tryAuth t) rt codebase)
-                        :<|> (serveFuzzyFind (tryAuth t) codebase)
-                        )
-                   :<|> serveOpenAPI
-                   :<|> Tagged serveDocs
-                   )
-          )
+    :<|> ( \token ->
+             serveUI (tryAuth token) uiPath
+               :<|> unisonApi token
+               :<|> serveOpenAPI
+               :<|> Tagged serveDocs
          )
-
- where
-  serveDocs _ respond = respond $ responseLBS ok200 [plain] docsBS
-  serveOpenAPI = pure openAPI
-  plain        = ("Content-Type", "text/plain")
-  tryAuth      = handleAuth token
-
+  where
+    serveDocs _ respond = respond $ responseLBS ok200 [plain] docsBS
+    serveOpenAPI = pure openAPI
+    plain = ("Content-Type", "text/plain")
+    tryAuth = handleAuth token
+    unisonApi t =
+      NamespaceListing.serve (tryAuth t) codebase
+        :<|> NamespaceDetails.serve (tryAuth t) rt codebase
+        :<|> serveDefinitions (tryAuth t) rt codebase
+        :<|> serveFuzzyFind (tryAuth t) codebase

--- a/parser-typechecker/src/Unison/Server/Endpoints/FuzzyFind.hs
+++ b/parser-typechecker/src/Unison/Server/Endpoints/FuzzyFind.hs
@@ -53,7 +53,7 @@ import Unison.Server.Types
     NamedTerm,
     NamedType,
     addHeaders,
-    mayDefault,
+    mayDefaultWidth,
   )
 import Unison.Util.Pretty (Width)
 import Unison.Var (Var)
@@ -162,7 +162,7 @@ serveFuzzyFind h codebase mayRoot relativePath limit typeWidth query =
               ( a
               , FoundTermResult
                 . FoundTerm
-                    (Backend.bestNameForTerm @v ppe (mayDefault typeWidth) r)
+                    (Backend.bestNameForTerm @v ppe (mayDefaultWidth typeWidth) r)
                 $ Backend.termEntryToNamedTerm ppe typeWidth te
               )
             )
@@ -170,7 +170,7 @@ serveFuzzyFind h codebase mayRoot relativePath limit typeWidth query =
         Backend.FoundTypeRef r -> do
           te <- Backend.typeListEntry codebase r n
           let namedType = Backend.typeEntryToNamedType te
-          let typeName = Backend.bestNameForType @v ppe (mayDefault typeWidth) r
+          let typeName = Backend.bestNameForType @v ppe (mayDefaultWidth typeWidth) r
           typeHeader <- Backend.typeDeclHeader codebase ppe r
           let ft = FoundType typeName typeHeader namedType
           pure (a, FoundTypeResult ft)

--- a/parser-typechecker/src/Unison/Server/Endpoints/NamespaceDetails.hs
+++ b/parser-typechecker/src/Unison/Server/Endpoints/NamespaceDetails.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Unison.Server.Endpoints.NamespaceDetails where
+
+import Control.Error (runExceptT)
+import Data.Aeson
+import Data.OpenApi (ToSchema)
+import qualified Data.Text as Text
+import Servant (Capture, QueryParam, throwError, (:>))
+import Servant.Docs (DocCapture (..), ToCapture (..), ToSample (..))
+import Servant.OpenApi ()
+import Servant.Server (Handler)
+import Unison.Codebase (Codebase)
+import qualified Unison.Codebase.Branch as Branch
+import qualified Unison.Codebase.Path as Path
+import Unison.Codebase.Path.Parse (parsePath')
+import qualified Unison.Codebase.Runtime as Rt
+import Unison.Codebase.ShortBranchHash (ShortBranchHash)
+import Unison.Parser.Ann (Ann)
+import Unison.Prelude
+import qualified Unison.Server.Backend as Backend
+import Unison.Server.Doc (Doc)
+import Unison.Server.Errors (backendError, badNamespace)
+import Unison.Server.Types
+  ( APIGet,
+    APIHeaders,
+    NamespaceFQN,
+    UnisonHash,
+    UnisonName,
+    addHeaders,
+    branchToUnisonHash,
+    mayDefaultWidth,
+  )
+import Unison.Util.Pretty (Width)
+import Unison.Var (Var)
+
+type NamespaceDetailsAPI =
+  "namespaces" :> Capture "namespace" NamespaceFQN
+    :> QueryParam "rootBranch" ShortBranchHash
+    :> QueryParam "renderWidth" Width
+    :> APIGet NamespaceDetails
+
+instance ToCapture (Capture "namespace" Text) where
+  toCapture _ =
+    DocCapture
+      "namespace"
+      "The fully qualified name of a namespace. The leading `.` is optional."
+
+instance ToSample NamespaceDetails where
+  toSamples _ =
+    [ ( "When no value is provided for `namespace`, the root namespace `.` is "
+          <> "listed by default",
+        NamespaceDetails
+          "."
+          "#gjlk0dna8dongct6lsd19d1o9hi5n642t8jttga5e81e91fviqjdffem0tlddj7ahodjo5"
+          Nothing
+      )
+    ]
+
+data NamespaceDetails = NamespaceDetails
+  { fqn :: UnisonName,
+    hash :: UnisonHash,
+    readme :: Maybe Doc
+  }
+  deriving (Generic, Show)
+
+instance ToJSON NamespaceDetails where
+  toEncoding = genericToEncoding defaultOptions
+
+deriving instance ToSchema NamespaceDetails
+
+serve ::
+  Var v =>
+  Handler () ->
+  Rt.Runtime v ->
+  Codebase IO v Ann ->
+  NamespaceFQN ->
+  Maybe ShortBranchHash ->
+  Maybe Width ->
+  Handler (APIHeaders NamespaceDetails)
+serve tryAuth runtime codebase namespaceName mayRoot mayWidth =
+  let doBackend a = do
+        ea <- liftIO $ runExceptT a
+        errFromEither backendError ea
+
+      errFromEither f = either (throwError . f) pure
+
+      fqnToPath fqn = do
+        let fqnS = Text.unpack fqn
+        path' <- errFromEither (`badNamespace` fqnS) $ parsePath' fqnS
+        pure (Path.fromPath' path')
+
+      width = mayDefaultWidth mayWidth
+   in do
+        namespacePath <- fqnToPath namespaceName
+
+        namespaceDetails <- doBackend $ do
+          root <- Backend.resolveRootBranchHash mayRoot codebase
+          let namespaceBranch = Branch.getAt' namespacePath root
+          readme <- Backend.findShallowReadmeInBranchAndRender width runtime codebase namespaceBranch
+
+          pure $ NamespaceDetails namespaceName (branchToUnisonHash namespaceBranch) readme
+
+        addHeaders <$> (tryAuth $> namespaceDetails)

--- a/parser-typechecker/src/Unison/Server/Types.hs
+++ b/parser-typechecker/src/Unison/Server/Types.hs
@@ -30,6 +30,9 @@ import Unison.Codebase.Editor.DisplayObject
   ( DisplayObject,
   )
 import qualified Unison.Codebase.ShortBranchHash as SBH
+import qualified Unison.Codebase.Branch as Branch
+import qualified Unison.Hash as Hash
+import qualified Unison.Codebase.Causal as Causal
 import Unison.Codebase.ShortBranchHash
   ( ShortBranchHash (..),
   )
@@ -207,6 +210,8 @@ instance ToSchema Doc.SpecialForm where
 instance ToSchema Doc.Src where
 instance ToSchema a => ToSchema (Doc.Ref a) where
 
+-- Helpers
+
 munge :: Text -> LZ.ByteString
 munge = Text.encodeUtf8 . Text.fromStrict
 
@@ -222,8 +227,12 @@ defaultWidth = 80
 discard :: Applicative m => a -> m ()
 discard = const $ pure ()
 
-mayDefault :: Maybe Width -> Width
-mayDefault = fromMaybe defaultWidth
+mayDefaultWidth :: Maybe Width -> Width
+mayDefaultWidth = fromMaybe defaultWidth
 
 addHeaders :: v -> APIHeaders v
 addHeaders = addHeader "*" . addHeader "public"
+
+branchToUnisonHash :: Branch.Branch m -> UnisonHash
+branchToUnisonHash b =
+  ("#" <>) . Hash.base32Hex . Causal.unRawHash $ Branch.headHash b

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -128,7 +128,8 @@ library
       Unison.Server.Doc
       Unison.Server.Endpoints.FuzzyFind
       Unison.Server.Endpoints.GetDefinitions
-      Unison.Server.Endpoints.ListNamespace
+      Unison.Server.Endpoints.NamespaceDetails
+      Unison.Server.Endpoints.NamespaceListing
       Unison.Server.Errors
       Unison.Server.QueryResult
       Unison.Server.SearchResult


### PR DESCRIPTION
## Overview
Add a new server endpoint for fetching the details of a namespace:
`/namespaces/:namespaceFQN`, can be used like so `/namespaces/base.List`.

This is served by the `NamespaceDetails` API which looks for a readme
(any capitalization) in the namespace and renders it.

This address part of https://github.com/unisonweb/unison/issues/2172.

## Implementation notes
The readme is looked up shallowly in the namespace branch and if found, is rendered.

Additionally I cleaned up a few things with regards to naming of the
previous `ListNamespace` module to match what it was returning. Down the
line the 2 APIs might be merged into a single `Namespaces` API.

## Interesting/controversial decisions
`Backend.renderDoc` returns a `List` and i'm not sure why. @pchiusano do you know the details of that?

## Test coverage
Tested the API and its giving the right results. We still need a better story for testing server endpoints.

## Loose ends
This is kinda slow? I'm not sure how best to debug that.

I think there's a separate effort related to working through these endpoints to make them more RESTful now that rootBranch is almost always used. I could imagine a set of endpoints like so (rough):

* `/:rootBranch/definitions/find/:query`
* `/:rootBranch/definitions/:definitionFQN`
* `/:rootBranch/namespaces/list`
* `/:rootBranch/namespaces/:namespaceFQN`

