### PR TITLE
Make transcript tests depend on building unison exe

### DIFF
--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -203,6 +203,8 @@ executables:
       - text
       - unison-core1
       - unison-parser-typechecker
+    build-tools:
+      - unison-parser-typechecker:unison
 
 benchmarks:
   runtime:

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -404,6 +404,8 @@ executable transcripts
       TupleSections
       TypeApplications
   ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -threaded -rtsopts -with-rtsopts=-N -v0
+  build-tools:
+      unison
   build-depends:
       base
     , directory


### PR DESCRIPTION
HPack seems to be using the deprecated way of specifying this in cabal. Hopefully that doesn't cause a problem.