### PR TITLE
Add missing Eq case for Pattern.Char

### DIFF
--- a/unison-core/src/Unison/Pattern.hs
+++ b/unison-core/src/Unison/Pattern.hs
@@ -125,6 +125,7 @@ instance H.Hashable (Pattern p) where
 instance Eq (Pattern loc) where
   Unbound _ == Unbound _ = True
   Var _ == Var _ = True
+  Char _ c == Char _ d = c == d
   Boolean _ b == Boolean _ b2 = b == b2
   Int _ n == Int _ m = n == m
   Nat _ n == Nat _ m = n == m

--- a/unison-src/transcripts/pattern-pretty-print-2345.md
+++ b/unison-src/transcripts/pattern-pretty-print-2345.md
@@ -1,0 +1,73 @@
+Regression test for https://github.com/unisonweb/unison/pull/2377
+
+
+```ucm:hide
+.> builtins.merge
+```
+
+```unison
+structural ability Ab where
+  a: Nat -> ()
+
+dopey = cases
+  ?0 -> ()
+
+grumpy = cases
+  d -> ()
+
+happy = cases
+  true -> ()
+
+sneezy = cases
+  +1 -> ()
+
+bashful = cases
+  Some a -> ()
+
+mouthy = cases
+  [] -> ()
+
+pokey = cases
+  h +: t -> ()
+
+sleepy = cases
+  i :+ l -> ()
+
+demure = cases
+  [0] -> ()
+
+angry = cases
+  a ++ [] -> ()
+
+tremulous = cases
+  (0,1) -> ()
+
+throaty = cases
+  { Ab.a a -> k } -> ()
+  
+agitated = cases
+  a | a == 2 -> ()
+
+doc = cases
+  y@4 -> () 
+```
+
+```ucm
+.> add
+.> view dopey
+.> view grumpy
+.> view happy
+.> view sneezy
+.> view bashful
+.> view mouthy
+.> view pokey
+.> view sleepy
+.> view demure
+.> view angry
+.> view tremulous
+.> view throaty
+.> view agitated
+.> view doc
+
+```
+

--- a/unison-src/transcripts/pattern-pretty-print-2345.output.md
+++ b/unison-src/transcripts/pattern-pretty-print-2345.output.md
@@ -1,0 +1,167 @@
+Regression test for https://github.com/unisonweb/unison/pull/2377
+
+
+```unison
+structural ability Ab where
+  a: Nat -> ()
+
+dopey = cases
+  ?0 -> ()
+
+grumpy = cases
+  d -> ()
+
+happy = cases
+  true -> ()
+
+sneezy = cases
+  +1 -> ()
+
+bashful = cases
+  Some a -> ()
+
+mouthy = cases
+  [] -> ()
+
+pokey = cases
+  h +: t -> ()
+
+sleepy = cases
+  i :+ l -> ()
+
+demure = cases
+  [0] -> ()
+
+angry = cases
+  a ++ [] -> ()
+
+tremulous = cases
+  (0,1) -> ()
+
+throaty = cases
+  { Ab.a a -> k } -> ()
+  
+agitated = cases
+  a | a == 2 -> ()
+
+doc = cases
+  y@4 -> () 
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      structural ability Ab
+      agitated  : Nat -> ()
+      angry     : [t] -> ()
+      bashful   : Optional a -> ()
+      demure    : [Nat] -> ()
+      doc       : Nat -> ()
+      dopey     : Char -> ()
+      grumpy    : p4kl4dn7b41 -> ()
+      happy     : Boolean -> ()
+      mouthy    : [t] -> ()
+      pokey     : [t] -> ()
+      sleepy    : [t] -> ()
+      sneezy    : Int -> ()
+      throaty   : Request {Ab} x -> ()
+      tremulous : (Nat, Nat) -> ()
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    structural ability Ab
+    agitated  : Nat -> ()
+    angry     : [t] -> ()
+    bashful   : Optional a -> ()
+    demure    : [Nat] -> ()
+    doc       : Nat -> ()
+    dopey     : Char -> ()
+    grumpy    : p4kl4dn7b41 -> ()
+    happy     : Boolean -> ()
+    mouthy    : [t] -> ()
+    pokey     : [t] -> ()
+    sleepy    : [t] -> ()
+    sneezy    : Int -> ()
+    throaty   : Request {Ab} x -> ()
+    tremulous : (Nat, Nat) -> ()
+
+.> view dopey
+
+  dopey : Char -> ()
+  dopey = cases ?0 -> ()
+
+.> view grumpy
+
+  grumpy : p4kl4dn7b41 -> ()
+  grumpy = cases d -> ()
+
+.> view happy
+
+  happy : Boolean -> ()
+  happy = cases true -> ()
+
+.> view sneezy
+
+  sneezy : Int -> ()
+  sneezy = cases +1 -> ()
+
+.> view bashful
+
+  bashful : Optional a -> ()
+  bashful = cases Some a -> ()
+
+.> view mouthy
+
+  mouthy : [t] -> ()
+  mouthy = cases [] -> ()
+
+.> view pokey
+
+  pokey : [t] -> ()
+  pokey = cases h +: t -> ()
+
+.> view sleepy
+
+  sleepy : [t] -> ()
+  sleepy = cases i :+ l -> ()
+
+.> view demure
+
+  demure : [Nat] -> ()
+  demure = cases [0] -> ()
+
+.> view angry
+
+  angry : [t] -> ()
+  angry = cases a ++ [] -> ()
+
+.> view tremulous
+
+  tremulous : (Nat, Nat) -> ()
+  tremulous = cases (0, 1) -> ()
+
+.> view throaty
+
+  throaty : Request {Ab} x -> ()
+  throaty = cases {a a -> k} -> ()
+
+.> view agitated
+
+  agitated : Nat -> ()
+  agitated = cases a | a == 2 -> ()
+
+.> view doc
+
+  doc : Nat -> ()
+  doc = cases y@4 -> ()
+
+```


### PR DESCRIPTION
fixes: #2345

## Overview

A missing Eq case for Pattern.Char caused an infinite loop when pretty printing Pattern matches on char literals such as:

```
foo = match ?0 with 
  ?0 -> ()

```
