### PR TITLE
Fix some order dependence in `pruneAbilities`

### DIFF
--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -2220,6 +2220,37 @@ expandWanted
   . (traverse.traverse) applyM
 
 
+pruneConcrete
+  :: Var v
+  => Ord loc
+  => (Maybe (Term v loc) -> Type v loc -> M v loc ())
+  -> Wanted v loc
+  -> Wanted v loc
+  -> [Type v loc]
+  -> M v loc (Wanted v loc)
+pruneConcrete _ acc [] _ = pure (reverse acc)
+pruneConcrete missing acc ((loc, w):ws) have
+  | Just v <- find (headMatch w) have = do
+    subtype v w `orElse` missing loc w
+    ws <- expandWanted ws
+    have <- expandAbilities have
+    pruneConcrete missing acc ws have
+  | otherwise = pruneConcrete missing ((loc,w):acc) ws have
+
+pruneVariables
+  :: Var v
+  => Ord loc
+  => Wanted v loc
+  -> Wanted v loc
+  -> M v loc (Wanted v loc)
+pruneVariables acc [] = pure $ reverse acc
+pruneVariables acc ((loc,v):vs) = do
+  discard <- defaultAbility v
+  vs <- expandWanted vs
+  if discard
+    then pruneVariables acc vs
+    else pruneVariables ((loc,v):acc) vs
+
 pruneAbilities
   :: Var v
   => Ord loc
@@ -2228,8 +2259,17 @@ pruneAbilities
   -> M v loc (Wanted v loc)
 pruneAbilities want0 have0
   | debugShow ("pruneAbilities", want0, have0) = undefined
-pruneAbilities want0 have0
-  = go [] (sortBy (comparing (isVar.snd)) want0) have0
+pruneAbilities want0 have0 = do
+  pwant <- pruneConcrete missing [] want0 have0
+  if pwant /= want0
+  then do
+    want <- expandWanted pwant
+    have <- expandAbilities have0
+    pruneAbilities want have
+  else -- fixed point
+    if dflt
+      then expandWanted =<< pruneVariables [] pwant
+      else pure pwant
   where
   isVar (Type.Var' _) = True
   isVar _ = False
@@ -2245,22 +2285,6 @@ pruneAbilities want0 have0
                  ctx
 
   dflt = not $ any isExistential have0
-
-  go acc [] _    = pure acc
-  go acc ((loc, w):want) have
-    | Just v <- find (headMatch w) have = do
-      subtype v w `orElse` missing loc w
-      want <- expandWanted want
-      have <- expandAbilities have
-      go acc want have
-    | dflt = do
-      discard <- defaultAbility w
-      want <- expandWanted want
-      have <- expandAbilities have
-      if discard
-        then go acc want have
-        else go ((loc, w):acc) want have
-    | otherwise = go ((loc, w):acc) want have
 
 subAbilities
   :: Var v

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -57,7 +57,6 @@ import           Data.Functor.Compose           ( Compose(..) )
 import           Data.List
 import           Data.List.NonEmpty             ( NonEmpty )
 import qualified Data.Map                      as Map
-import           Data.Ord                       ( comparing )
 import qualified Data.Sequence                 as Seq
 import           Data.Sequence.NonEmpty         ( NESeq )
 import qualified Data.Sequence.NonEmpty        as NESeq
@@ -2271,9 +2270,6 @@ pruneAbilities want0 have0 = do
       then expandWanted =<< pruneVariables [] pwant
       else pure pwant
   where
-  isVar (Type.Var' _) = True
-  isVar _ = False
-
   isExistential (Type.Var' TypeVar.Existential{}) = True
   isExistential _ = False
 

--- a/unison-src/transcripts/fix2378.md
+++ b/unison-src/transcripts/fix2378.md
@@ -1,0 +1,44 @@
+
+Tests for an ability failure that was caused by order dependence of
+checking wanted vs. provided abilities. It was necessary to re-check
+rows until a fixed point is reached.
+
+```ucm:hide
+.> builtins.merge
+```
+
+```unison
+unique ability C c where 
+  new : c a
+  receive : c a -> a
+  send : a -> c a -> ()
+
+unique ability A t g where 
+  fork : '{A t g, g, Exception} a -> t a
+  await : t a -> a
+
+unique ability Ex where raise : () -> x
+
+Ex.catch : '{Ex, g} a ->{g} Either () a
+Ex.catch _ = todo "Exception.catch"
+
+C.pure.run : (forall c . '{C c, g} r) ->{Ex, g} r
+C.pure.run _ = todo "C.pure.run"
+
+A.pure.run : (forall t . '{A t g, g} a) ->{Ex,g} a
+A.pure.run _ = todo "A.pure.run"
+
+ex : '{C c, A t {C c}} Nat
+ex _ = 
+  c = C.new
+  x = A.fork 'let
+    a = receive c 
+    a + 10 
+  y = A.fork 'let
+    send 0 c
+    ()
+  A.await x
+
+x : '{} (Either () Nat)
+x _ = Ex.catch '(C.pure.run '(A.pure.run ex))
+```

--- a/unison-src/transcripts/fix2378.output.md
+++ b/unison-src/transcripts/fix2378.output.md
@@ -1,0 +1,59 @@
+
+Tests for an ability failure that was caused by order dependence of
+checking wanted vs. provided abilities. It was necessary to re-check
+rows until a fixed point is reached.
+
+```unison
+unique ability C c where 
+  new : c a
+  receive : c a -> a
+  send : a -> c a -> ()
+
+unique ability A t g where 
+  fork : '{A t g, g, Exception} a -> t a
+  await : t a -> a
+
+unique ability Ex where raise : () -> x
+
+Ex.catch : '{Ex, g} a ->{g} Either () a
+Ex.catch _ = todo "Exception.catch"
+
+C.pure.run : (forall c . '{C c, g} r) ->{Ex, g} r
+C.pure.run _ = todo "C.pure.run"
+
+A.pure.run : (forall t . '{A t g, g} a) ->{Ex,g} a
+A.pure.run _ = todo "A.pure.run"
+
+ex : '{C c, A t {C c}} Nat
+ex _ = 
+  c = C.new
+  x = A.fork 'let
+    a = receive c 
+    a + 10 
+  y = A.fork 'let
+    send 0 c
+    ()
+  A.await x
+
+x : '{} (Either () Nat)
+x _ = Ex.catch '(C.pure.run '(A.pure.run ex))
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique ability A t g
+      unique ability C c
+      unique ability Ex
+      A.pure.run : (∀ t. '{g, A t g} a) ->{g, Ex} a
+      C.pure.run : (∀ c. '{g, C c} r) ->{g, Ex} r
+      Ex.catch   : '{g, Ex} a ->{g} Either () a
+      ex         : '{C c, A t {C c}} Nat
+      x          : 'Either () Nat
+
+```


### PR DESCRIPTION
Previously the results could depend on the order that wanted abilities were tested against provided abilities. The new approach runs until a fixed point is reached, allowing some unifications on concrete abilities to better inform the overall process.

Fixes #2378