### PR TITLE
Fix to subtle name resolution bug that results in using TDNR unexpectedly

### DIFF
--- a/parser-typechecker/src/Unison/FileParser.hs
+++ b/parser-typechecker/src/Unison/FileParser.hs
@@ -76,7 +76,7 @@ file = do
     -- suffixified local term bindings shadow any same-named thing from the outer codebase scope
     -- example: `foo.bar` in local file scope will shadow `foo.bar` and `bar` in codebase scope
     let (curNames, resolveLocals) =
-          ( Names.shadowSuffixedTerms0 locals (Names.currentNames names)
+          ( Names.shadowTerms0 locals (Names.currentNames names)
           , resolveLocals )
           where
           -- All locally declared term variables, running example:

--- a/parser-typechecker/src/Unison/FileParser.hs
+++ b/parser-typechecker/src/Unison/FileParser.hs
@@ -1,5 +1,6 @@
 {-# Language DeriveTraversable #-}
 {-# Language OverloadedStrings #-}
+{-# Language ViewPatterns #-}
 
 module Unison.FileParser where
 
@@ -8,7 +9,9 @@ import Unison.Prelude
 import qualified Unison.ABT as ABT
 import Control.Lens
 import           Control.Monad.Reader (local, asks)
+import Data.List.Extra (nubOrd)
 import qualified Data.Map as Map
+import qualified Data.Set as Set
 import           Prelude hiding (readFile)
 import qualified Text.Megaparsec as P
 import           Unison.DataDeclaration (DataDeclaration, EffectDeclaration)
@@ -92,8 +95,9 @@ file = do
           -- suffix, but `bob` is. `foo.alice` and `bob.alice` are both unique suffixes but
           -- they map to themselves, so we ignore them. In our example, we'll just be left with
           --   [(bob, Term.var() zonk.bob)]
-          replacements = [ (Name.toVar n, Term.var() v') | (n,[v']) <- Map.toList varsBySuffix
-                                                         , Name.toVar n /= v' ]
+          replacements = [ (Name.toVar n, Term.var() v')
+                         | (n, nubOrd -> [v']) <- Map.toList varsBySuffix
+                         , Name.toVar n /= v' ]
           locals = Map.keys varsBySuffix
           -- This will perform the actual variable replacements for suffixes
           -- that uniquely identify definitions in the file. It will avoid
@@ -101,10 +105,12 @@ file = do
           -- `bob -> bob * 42`, `bob` will correctly refer to the lambda parameter.
           -- and not the `zonk.bob` declared in the file.
           resolveLocals = ABT.substsInheritAnnotation replacements
-    terms <- case List.validate (traverse $ Term.bindSomeNames curNames . resolveLocals) terms of
+    let bindNames = Term.bindSomeNames avoid curNames . resolveLocals
+                    where avoid = Set.fromList (stanzas0 >>= getVars)
+    terms <- case List.validate (traverse bindNames) terms of
       Left es -> resolutionFailures (toList es)
       Right terms -> pure terms
-    watches <- case List.validate (traverse . traverse $ Term.bindSomeNames curNames . resolveLocals) watches of
+    watches <- case List.validate (traverse . traverse $ bindNames) watches of
       Left es -> resolutionFailures (toList es)
       Right ws -> pure ws
     let toPair (tok, _) = (L.payload tok, ann tok)

--- a/unison-core/src/Unison/Names3.hs
+++ b/unison-core/src/Unison/Names3.hs
@@ -311,13 +311,13 @@ expandWildcardImport prefix ns =
     pure (suffix, full)
 
 -- Deletes from the `n0 : Names0` any definitions whose names
--- share a suffix with a name in `ns`. Does so using logarithmic
--- time lookups, traversing only `ns`.
+-- are in `ns`. Does so using logarithmic time lookups,
+-- traversing only `ns`.
 --
 -- See usage in `FileParser` for handling precendence of symbol
 -- resolution where local names are preferred to codebase names.
 shadowSuffixedTerms0 :: [Name] -> Names0 -> Names0
 shadowSuffixedTerms0 ns n0 = names0 terms' (types0 n0)
   where
-  shadowedBy name = Name.searchBySuffix name (terms0 n0)
-  terms' = R.subtractRan (foldMap shadowedBy ns) (terms0 n0)
+  terms' = foldl' go (terms0 n0) ns
+  go ts name = R.deleteDom name ts

--- a/unison-core/src/Unison/Names3.hs
+++ b/unison-core/src/Unison/Names3.hs
@@ -316,8 +316,8 @@ expandWildcardImport prefix ns =
 --
 -- See usage in `FileParser` for handling precendence of symbol
 -- resolution where local names are preferred to codebase names.
-shadowSuffixedTerms0 :: [Name] -> Names0 -> Names0
-shadowSuffixedTerms0 ns n0 = names0 terms' (types0 n0)
+shadowTerms0 :: [Name] -> Names0 -> Names0
+shadowTerms0 ns n0 = names0 terms' (types0 n0)
   where
   terms' = foldl' go (terms0 n0) ns
   go ts name = R.deleteDom name ts

--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -146,7 +146,8 @@ bindNames keepFreeTerms ns0 e = do
 -- lookup. Any terms not found in the `Names0` are kept free.
 bindSomeNames
   :: forall v a . Var v
-  => Names0
+  => Set v
+  -> Names0
   -> Term v a
   -> Names.ResolutionResult v a (Term v a)
 -- bindSomeNames ns e | trace "Term.bindSome" False
@@ -158,7 +159,7 @@ bindSomeNames
 --                   || traceShow (freeVars e) False
 --                   || traceShow e False
 --                   = undefined
-bindSomeNames ns e = bindNames varsToTDNR ns e where
+bindSomeNames avoid ns e = bindNames (avoid <> varsToTDNR) ns e where
   -- `Term.bindNames` takes a set of variables that are not substituted.
   -- These should be the variables that will be subject to TDNR, which
   -- we compute as the set of variables whose names cannot be found in `ns`.

--- a/unison-src/transcripts/fix2353.md
+++ b/unison-src/transcripts/fix2353.md
@@ -1,0 +1,16 @@
+```ucm:hide
+.> builtins.merge
+```
+
+```unison
+use builtin Scope
+unique ability Async t g where async : Nat
+unique ability Exception where raise : Nat -> x
+
+pure.run : a -> (forall t . '{Async t g} a) ->{Exception, g} a
+pure.run a0 a =
+  a' : forall s . '{Scope s, Exception, g} a
+  a' = 'a0 -- typechecks
+  -- make sure this builtin can still be referenced
+  Scope.run a'
+```

--- a/unison-src/transcripts/fix2353.output.md
+++ b/unison-src/transcripts/fix2353.output.md
@@ -1,0 +1,26 @@
+```unison
+use builtin Scope
+unique ability Async t g where async : Nat
+unique ability Exception where raise : Nat -> x
+
+pure.run : a -> (forall t . '{Async t g} a) ->{Exception, g} a
+pure.run a0 a =
+  a' : forall s . '{Scope s, Exception, g} a
+  a' = 'a0 -- typechecks
+  -- make sure this builtin can still be referenced
+  Scope.run a'
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique ability Async t g
+      unique ability Exception
+      pure.run : a -> (∀ t. '{Async t g} a) ->{g, Exception} a
+
+```


### PR DESCRIPTION
Fixes #2353 and adds a regression test.

The bug was resulting in use of the TDNR code path for more cases than expected. I'm still not totally sure what the implications are of the old behavior, since the TDNR code path has a short circuit if a definition has a unique suffix and the right type.

This fix avoids TDNR for the use case that was given and all the other transcripts are unchanged, including [this one](https://github.com/unisonweb/unison/blob/trunk/unison-src/transcripts/fix1578.output.md) which checks various subtle cases of name resolution.

Filed a separate bug for https://github.com/unisonweb/unison/issues/2381