### PR TITLE
Add note to development.markdown on running the pretty-printing round trip tests

### DIFF
--- a/development.markdown
+++ b/development.markdown
@@ -21,6 +21,7 @@ On startup, Unison prints a url for the codebase UI. If you did step 3 above, th
 * `stack exec tests` runs the tests
 * `stack exec transcripts` runs all the integration tests, found in `unison-src/transcripts`. You can add more tests to this directory.
 * `stack exec tests -- prefix-of-test` and `stack exec transcripts -- prefix-of-test` only run tests with a matching prefix.
+* `stack exec unison -- transcript unison-src/transcripts-round-trip/main.md` runs the pretty-printing round trip tests
 
 ### What if you want a profiled build?
 


### PR DESCRIPTION
Forgot to include in #2385 Please rubber stamp.

```
stack exec unison -- transcript unison-src/transcripts-round-trip/main.md
```

runs the pretty-printing round trip tests. Added a note to this effect in `development.markdown`.

This was split out into a separate target because the `edit` command talks about absolute paths and absolute paths differ in CI and locally, leading to spurious CI failures when output differed from what's checked in. It's fine if output differs, we just care that the transcript passes.