### PR TITLE
Update welcome message with ui command

### DIFF
--- a/parser-typechecker/src/Unison/CommandLine/Main.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Main.hs
@@ -135,14 +135,21 @@ welcomeMessage dir version =
     <> P.newline
     <> P.newline
     <> P.linesSpaced
-         [ P.wrap "Welcome to Unison!"
-         , P.wrap ("You are running version: " <> P.string version)
-         , P.wrap
-           (  "I'm currently watching for changes to .u files under "
-           <> (P.group . P.blue $ fromString dir)
-           )
-         , P.wrap ("Type " <> P.hiBlue "help" <> " to get help. 😎")
-         ]
+      [ P.wrap "👋 Welcome to Unison!",
+        P.wrap ("You are running version: " <> P.bold (P.string version)) <> P.newline,
+        P.wrap "Get started:",
+        P.indentN
+          2
+          ( P.column2
+              [ ("📖", "Type " <> P.hiBlue "help" <> " to get help"),
+                ("🎨", "Type " <> P.hiBlue "ui" <> " to open the Codebase UI in your default browser"),
+                ("📚", "Read the official docs at " <> P.blue "https://unisonweb.org/docs"),
+                ("🌎", "Visit Unison Share at " <> P.blue "https://share.unison-lang.org" <> " to discover libraries"),
+                ("👀", "I'm watching for changes to " <> P.bold ".u" <> " files under " <> (P.group . P.blue $ fromString dir))
+              ]
+          )
+      ]
+
 
 hintFreshCodebase :: ReadRemoteNamespace -> P.Pretty P.ColorText
 hintFreshCodebase ns =

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -110,12 +110,16 @@ main = do
        (closeCodebase, theCodebase) <- getCodebaseOrExit mcodepath
        runtime <- RTI.startRuntime
        Server.startServer codebaseServerOpts runtime theCodebase $ \baseUrl -> do
-         PT.putPrettyLn $ P.lines
-           ["The Unison Codebase UI is running at", P.string $ Server.urlFor Server.UI baseUrl]
          case isHeadless of
              Headless -> do
-                 PT.putPrettyLn $ P.lines
-                    ["I've started the codebase API server at" , P.string $ Server.urlFor Server.Api baseUrl]
+                 PT.putPrettyLn $
+                   P.lines
+                     [ "I've started the Codebase API server at",
+                       P.string $ Server.urlFor Server.Api baseUrl,
+                       "and the Codebase UI at",
+                       P.string $ Server.urlFor Server.UI baseUrl
+                     ]
+
                  PT.putPrettyLn $ P.string "Running the codebase manager headless with "
                      <> P.shown GHC.Conc.numCapabilities
                      <> " "
@@ -124,7 +128,7 @@ main = do
                  mvar <- newEmptyMVar
                  takeMVar mvar
              WithCLI -> do
-                 PT.putPrettyLn $ P.string "Now starting the Unison Codebase Manager..."
+                 PT.putPrettyLn $ P.string "Now starting the Unison Codebase Manager (UCM)..."
                  launch currentDir config runtime theCodebase [] (Just baseUrl)
                  closeCodebase
 


### PR DESCRIPTION
## Overview
Revamp the welcome message somewhat by including a small "get started" section that displays hints about the `help` command, the `ui` command and links to docs and Unison Share before finally telling the user about the files being watched.

Example:
<img width="866" alt="Screen Shot 2021-09-08 at 10 58 38" src="https://user-images.githubusercontent.com/2371/132693679-0b98b1b4-9473-49ed-b025-94ab2ee18129.png">

The main motivator behind this was to remove the UI URL (still shown in headless mode) and show a hint about the `ui` command instead. This turned into a fun design tangent :)

## Implementation notes
Augment the existing welcome message, nothing new here.