### PR TITLE
Add parens around effectful arrow special case.

### DIFF
--- a/parser-typechecker/src/Unison/TypePrinter.hs
+++ b/parser-typechecker/src/Unison/TypePrinter.hs
@@ -104,8 +104,9 @@ prettyRaw n im p tp = go n im p tp
            in (fmt S.TypeOperator "∀ " <> vformatted <> fmt S.TypeOperator ".")
               `PP.hang` go n im (-1) body
     t@(Arrow' _ _) -> case t of
-      EffectfulArrows' (Ref' DD.UnitRef) rest -> arrows True True rest
-      EffectfulArrows' fst rest ->
+      EffectfulArrows' (Ref' DD.UnitRef) rest ->
+        PP.parenthesizeIf (p >= 0) $ arrows True True rest
+      EffectfulArrows' fst rest -> PP.parenthesizeIf (p >= 0) $
         case fst of
           Var' v | Var.name v == "()"
             -> fmt S.DelayForceChar "'" <> arrows False True rest

--- a/parser-typechecker/src/Unison/TypePrinter.hs
+++ b/parser-typechecker/src/Unison/TypePrinter.hs
@@ -105,11 +105,12 @@ prettyRaw n im p tp = go n im p tp
               `PP.hang` go n im (-1) body
     t@(Arrow' _ _) -> case t of
       EffectfulArrows' (Ref' DD.UnitRef) rest ->
-        PP.parenthesizeIf (p >= 0) $ arrows True True rest
-      EffectfulArrows' fst rest -> PP.parenthesizeIf (p >= 0) $
+        PP.parenthesizeIf (p >= 10) $ arrows True True rest
+      EffectfulArrows' fst rest ->
         case fst of
-          Var' v | Var.name v == "()"
-            -> fmt S.DelayForceChar "'" <> arrows False True rest
+          Var' v | Var.name v == "()" ->
+            PP.parenthesizeIf (p >= 10) $
+              fmt S.DelayForceChar "'" <> arrows False True rest
           _ -> PP.parenthesizeIf (p >= 0) $
                  go n im 0 fst <> arrows False False rest
       _ -> "error"

--- a/parser-typechecker/tests/Unison/Test/TypePrinter.hs
+++ b/parser-typechecker/tests/Unison/Test/TypePrinter.hs
@@ -134,8 +134,7 @@ test = scope "typeprinter" . tests $
   , tc "'{e} a"
   , tc "'{e} (a -> b)"
   , tc "'{e} (a ->{f} b)"
-  , pending $ tc "Pair a '{e} b"                           -- parser hits unexpected '
-  , tc_diff_rtt False "Pair a ('{e} b)" "Pair a '{e} b" 80 -- no RTT due to the above
+  , tc "Pair a ('{e} b)"
   , tc "'(a -> 'a)"
   , tc "'()"
   , tc "'('a)"

--- a/unison-src/transcripts-round-trip/main.md
+++ b/unison-src/transcripts-round-trip/main.md
@@ -108,3 +108,25 @@ h xs = match xs with
 .> load scratch.u
 ```
 
+## Type application inserts necessary parens
+
+Regression test for https://github.com/unisonweb/unison/issues/2392
+
+```unison:hide
+unique ability Zonk where zonk : Nat
+unique type Foo x y = 
+
+foo : Nat -> Foo ('{Zonk} a) ('{Zonk} b) -> Nat
+foo n _ = n
+```
+
+```ucm
+.> add
+.> edit foo Zonk Foo
+.> reflog
+.> reset-root 2
+```
+
+``` ucm
+.> load scratch.u
+```

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -308,3 +308,86 @@ h xs = match xs with
       g : [a] -> a
 
 ```
+## Type application inserts necessary parens
+
+Regression test for https://github.com/unisonweb/unison/issues/2392
+
+```unison
+unique ability Zonk where zonk : Nat
+unique type Foo x y = 
+
+foo : Nat -> Foo ('{Zonk} a) ('{Zonk} b) -> Nat
+foo n _ = n
+```
+
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    unique type Foo x y
+    unique ability Zonk
+    foo : Nat -> Foo ('{Zonk} a) ('{Zonk} b) -> Nat
+
+.> edit foo Zonk Foo
+
+  ☝️
+  
+  I added these definitions to the top of
+  /Users/runar/work/unison/scratch.u
+  
+    unique type Foo x y
+      = 
+    
+    unique ability Zonk where zonk : {Zonk} Nat
+    
+    foo : Nat -> Foo ('{Zonk} a) ('{Zonk} b) -> Nat
+    foo n _ = n
+  
+  You can edit them there, then do `update` to replace the
+  definitions currently in this namespace.
+
+.> reflog
+
+  Here is a log of the root namespace hashes, starting with the
+  most recent, along with the command that got us there. Try:
+  
+    `fork 2 .old`             
+    `fork #pqvd5behc2 .old`   to make an old namespace
+                              accessible again,
+                              
+    `reset-root #pqvd5behc2`  to reset the root namespace and
+                              its history to that of the
+                              specified namespace.
+  
+  1.  #j32i1remee : add
+  2.  #pqvd5behc2 : reset-root #pqvd5behc2
+  3.  #acngtb04a8 : add
+  4.  #pqvd5behc2 : reset-root #pqvd5behc2
+  5.  #clsum27pr1 : add
+  6.  #pqvd5behc2 : reset-root #pqvd5behc2
+  7.  #dbvse9969b : add
+  8.  #pqvd5behc2 : reset-root #pqvd5behc2
+  9.  #8rn1an5gj8 : add
+  10. #pqvd5behc2 : builtins.mergeio
+  11. #sjg2v58vn2 : (initial reflogged namespace)
+
+.> reset-root 2
+
+  Done.
+
+```
+```ucm
+.> load scratch.u
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique type Foo x y
+      unique ability Zonk
+      foo : Nat -> Foo ('{Zonk} a) ('{Zonk} b) -> Nat
+
+```


### PR DESCRIPTION
Just adds what I think was simply a missing set of parens.

Fixes #2392 

## Controversial decision:

Previously, the expression `Pair a '({e} b)` was pretty-printing as `Pair a '{e} b`, but this would not parse.
Now it roundtrips perfectly as `Pair a '({e} b)`, and I removed the pending test for `Pair a '{e} b`. I don't think that syntax should be valid anyway (and it hasn't been valid in the past), but if we want to add support for that later, we can.
