### PR TITLE
Fix linebreaking in long binary op chains

### DIFF
--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -413,10 +413,7 @@ pretty0
   binaryApps xs last = unbroken `PP.orElse` broken
    where
     unbroken = PP.spaced (ps ++ [last])
-    broken   = case take 2 ps of
-      [x, y] -> PP.hang (x <> " " <> y) . PP.column2 . psCols $ (drop 2 ps ++ [last])
-      []     -> last
-      _      -> undefined
+    broken   = PP.hang (head ps) . PP.column2 . psCols $ (tail ps ++ [last])
     psCols ps = case take 2 ps of
       [x, y] -> (x, y) : psCols (drop 2 ps)
       [x]    -> [(x, "")]

--- a/unison-src/transcripts-round-trip/main.md
+++ b/unison-src/transcripts-round-trip/main.md
@@ -138,7 +138,7 @@ Regression test for https://github.com/unisonweb/unison/issues/1035
 ```unison:hide
 foo : Text
 foo =
-  "aaaaaaaaaaaaaaaaaaaaaa" ++ "bbbbbbbbbbbbbbbbbbbbbb" ++ "cccccccccccccccccccccc" ++ "dddddddddddddddd"
+  "aaaaaaaaaaaaaaaaaaaaaa" ++ "bbbbbbbbbbbbbbbbbbbbbb" ++ "cccccccccccccccccccccc" ++ "dddddddddddddddddddddd"
 ```
 
 ```ucm

--- a/unison-src/transcripts-round-trip/main.md
+++ b/unison-src/transcripts-round-trip/main.md
@@ -130,3 +130,25 @@ foo n _ = n
 ``` ucm
 .> load scratch.u
 ```
+
+## Long lines with repeated operators
+
+Regression test for https://github.com/unisonweb/unison/issues/1035
+
+```unison:hide
+foo : Text
+foo =
+  "aaaaaaaaaaaaaaaaaaaaaa" ++ "bbbbbbbbbbbbbbbbbbbbbb" ++ "cccccccccccccccccccccc" ++ "dddddddddddddddd"
+```
+
+```ucm
+.> add
+.> edit foo
+.> reflog
+.> reset-root 2
+```
+
+``` ucm
+.> load scratch.u
+```
+

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -391,3 +391,82 @@ foo n _ = n
       foo : Nat -> Foo ('{Zonk} a) ('{Zonk} b) -> Nat
 
 ```
+## Long lines with repeated operators
+
+Regression test for https://github.com/unisonweb/unison/issues/1035
+
+```unison
+foo : Text
+foo =
+  "aaaaaaaaaaaaaaaaaaaaaa" ++ "bbbbbbbbbbbbbbbbbbbbbb" ++ "cccccccccccccccccccccc" ++ "dddddddddddddddd"
+```
+
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    foo : Text
+
+.> edit foo
+
+  ☝️
+  
+  I added these definitions to the top of
+  /Users/runar/work/unison/scratch.u
+  
+    foo : Text
+    foo =
+      use Text ++
+      "aaaaaaaaaaaaaaaaaaaaaa" ++
+        "bbbbbbbbbbbbbbbbbbbbbb" ++
+        "cccccccccccccccccccccc" ++
+        "dddddddddddddddd"       
+  
+  You can edit them there, then do `update` to replace the
+  definitions currently in this namespace.
+
+.> reflog
+
+  Here is a log of the root namespace hashes, starting with the
+  most recent, along with the command that got us there. Try:
+  
+    `fork 2 .old`             
+    `fork #pqvd5behc2 .old`   to make an old namespace
+                              accessible again,
+                              
+    `reset-root #pqvd5behc2`  to reset the root namespace and
+                              its history to that of the
+                              specified namespace.
+  
+  1.  #2hheevu1j3 : add
+  2.  #pqvd5behc2 : reset-root #pqvd5behc2
+  3.  #j32i1remee : add
+  4.  #pqvd5behc2 : reset-root #pqvd5behc2
+  5.  #acngtb04a8 : add
+  6.  #pqvd5behc2 : reset-root #pqvd5behc2
+  7.  #clsum27pr1 : add
+  8.  #pqvd5behc2 : reset-root #pqvd5behc2
+  9.  #dbvse9969b : add
+  10. #pqvd5behc2 : reset-root #pqvd5behc2
+  11. #8rn1an5gj8 : add
+  12. #pqvd5behc2 : builtins.mergeio
+  13. #sjg2v58vn2 : (initial reflogged namespace)
+
+.> reset-root 2
+
+  Done.
+
+```
+```ucm
+.> load scratch.u
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      foo : Text
+
+```

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -398,7 +398,7 @@ Regression test for https://github.com/unisonweb/unison/issues/1035
 ```unison
 foo : Text
 foo =
-  "aaaaaaaaaaaaaaaaaaaaaa" ++ "bbbbbbbbbbbbbbbbbbbbbb" ++ "cccccccccccccccccccccc" ++ "dddddddddddddddd"
+  "aaaaaaaaaaaaaaaaaaaaaa" ++ "bbbbbbbbbbbbbbbbbbbbbb" ++ "cccccccccccccccccccccc" ++ "dddddddddddddddddddddd"
 ```
 
 ```ucm
@@ -418,10 +418,10 @@ foo =
     foo : Text
     foo =
       use Text ++
-      "aaaaaaaaaaaaaaaaaaaaaa" ++
-        "bbbbbbbbbbbbbbbbbbbbbb" ++
-        "cccccccccccccccccccccc" ++
-        "dddddddddddddddd"       
+      "aaaaaaaaaaaaaaaaaaaaaa"
+        ++ "bbbbbbbbbbbbbbbbbbbbbb"
+        ++ "cccccccccccccccccccccc"
+        ++ "dddddddddddddddddddddd"
   
   You can edit them there, then do `update` to replace the
   definitions currently in this namespace.
@@ -439,7 +439,7 @@ foo =
                               its history to that of the
                               specified namespace.
   
-  1.  #2hheevu1j3 : add
+  1.  #o6r7803627 : add
   2.  #pqvd5behc2 : reset-root #pqvd5behc2
   3.  #j32i1remee : add
   4.  #pqvd5behc2 : reset-root #pqvd5behc2

--- a/unison-src/transcripts/bug-strange-closure.output.md
+++ b/unison-src/transcripts/bug-strange-closure.output.md
@@ -2077,9 +2077,9 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                                                     (Term.Term
                                                       (Any
                                                         '(f x ->
-                                                          f x Nat.+
-                                                            sqr
-                                                              1 ))))),
+                                                          f x
+                                                            Nat.+ sqr
+                                                                    1))))),
                                                 !Lit
                                                 (Right
                                                   (Plain "-")),

--- a/unison-src/transcripts/bug-strange-closure.output.md
+++ b/unison-src/transcripts/bug-strange-closure.output.md
@@ -2077,10 +2077,9 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                                                     (Term.Term
                                                       (Any
                                                         '(f x ->
-                                                                f
-                                                                  x
-                                                          Nat.+ sqr
-                                                                  1))))),
+                                                          f x Nat.+
+                                                            sqr
+                                                              1 ))))),
                                                 !Lit
                                                 (Right
                                                   (Plain "-")),


### PR DESCRIPTION
This changes the way the term printer splits repeated binary operations into columns, which was just wrong.

Before: 

```
foo : Text
foo =
  use Text ++
     "aaaaaaaaaaaaaaaaaaaaaa"
  ++ "bbbbbbbbbbbbbbbbbbbbbb"
  ++ "cccccccccccccccccccccc"
```

After : 

```
foo : Text
foo =
  use Text ++
  "aaaaaaaaaaaaaaaaaaaaaa"
    ++ "bbbbbbbbbbbbbbbbbbbbbb"
    ++ "cccccccccccccccccccccc"
```
Fixes #1035 and #2165.