### PR TITLE
removes init command, replaces with --codebase-create flag

### DIFF
--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -144,6 +144,7 @@ executables:
       - unison-parser-typechecker
       - unison-codebase-sync
       - uri-encode
+      - unliftio
     when:
       - condition: '!os(windows)'
         dependencies: unix

--- a/parser-typechecker/src/Unison/Codebase/Init.hs
+++ b/parser-typechecker/src/Unison/Codebase/Init.hs
@@ -5,14 +5,14 @@ module Unison.Codebase.Init
   ( Init (..),
     DebugName,
     InitError (..),
-    CodebaseDir (..),
+    CodebaseInitOptions (..),
     InitResult (..),
+    SpecifiedCodebase (..),
     Pretty,
     createCodebase,
     initCodebaseAndExit,
     openOrCreateCodebase,
     openNewUcmCodebaseOrExit,
-    homeOrSpecifiedDir
   )
 where
 
@@ -25,21 +25,23 @@ import Unison.Prelude
 import qualified Unison.PrettyTerminal as PT
 import Unison.Symbol (Symbol)
 import qualified Unison.Util.Pretty as P
-import UnliftIO.Directory (canonicalizePath, getHomeDirectory)
+import UnliftIO.Directory (canonicalizePath)
 import Unison.Codebase.Init.CreateCodebaseError 
 
--- CodebaseDir is used to help pass around a Home directory that isn't the
+-- CodebaseInitOptions is used to help pass around a Home directory that isn't the
 -- actual home directory of the user. Useful in tests.
-data CodebaseDir = Home CodebasePath | Specified CodebasePath
+data CodebaseInitOptions 
+  = Home CodebasePath
+  | Specified SpecifiedCodebase
 
-homeOrSpecifiedDir :: Maybe CodebasePath -> IO CodebaseDir
-homeOrSpecifiedDir specifiedDir = do
-  homeDir <- getHomeDirectory
-  pure $ maybe (Home homeDir) Specified specifiedDir
+data SpecifiedCodebase 
+  = CreateWhenMissing CodebasePath 
+  | DontCreateWhenMissing CodebasePath
 
-codebaseDirToCodebasePath :: CodebaseDir -> CodebasePath
-codebaseDirToCodebasePath (Home dir) = dir
-codebaseDirToCodebasePath (Specified dir) = dir
+initOptionsToDir :: CodebaseInitOptions -> CodebasePath
+initOptionsToDir (Home dir ) = dir
+initOptionsToDir (Specified (CreateWhenMissing dir)) = dir
+initOptionsToDir (Specified (DontCreateWhenMissing dir)) = dir
 
 type DebugName = String
 
@@ -65,28 +67,42 @@ data InitResult m v a
   | CreatedCodebase CodebasePath (FinalizerAndCodebase m v a) 
   | Error CodebasePath InitError 
 
-openOrCreateCodebase :: MonadIO m => Init m v a -> DebugName -> CodebaseDir -> m (InitResult m v a)
-openOrCreateCodebase cbInit debugName codebaseDir = do
-  let resolvedPath = (codebaseDirToCodebasePath codebaseDir)  
+createCodebaseWithResult :: MonadIO m => Init m v a -> DebugName -> CodebasePath -> m (InitResult m v a)
+createCodebaseWithResult cbInit debugName dir = 
+  createCodebase cbInit debugName dir >>= \case
+    Left errorMessage -> do
+      pure (Error dir (CouldntCreateCodebase errorMessage))
+    Right cb -> do
+      pure (CreatedCodebase dir cb)
+
+whenNoV1Codebase :: MonadIO m => CodebasePath -> m (InitResult m v a) -> m (InitResult m v a )
+whenNoV1Codebase dir initResult =
+  ifM (FCC.codebaseExists dir)
+    (pure (Error dir FoundV1Codebase))
+    initResult
+
+openOrCreateCodebase :: MonadIO m => Init m v a -> DebugName -> CodebaseInitOptions -> m (InitResult m v a)
+openOrCreateCodebase cbInit debugName initOptions = do
+  let resolvedPath = initOptionsToDir initOptions
   openCodebase cbInit debugName resolvedPath >>= \case 
     Right cb -> pure (OpenedCodebase resolvedPath cb)
     Left _ ->
-      case codebaseDir of
+      case initOptions of
         Home homeDir -> do
           ifM (FCC.codebaseExists homeDir)
             (do pure (Error homeDir FoundV1Codebase))
             (do
               -- Create V2 codebase if neither a V1 or V2 exists
-              createCodebase cbInit debugName homeDir >>= \case
-                Left errorMessage -> do
-                  pure (Error homeDir (CouldntCreateCodebase errorMessage))
-                Right cb -> do
-                  pure (CreatedCodebase homeDir cb)
+              createCodebaseWithResult cbInit debugName homeDir
             )
-        Specified specifiedDir -> do
-          ifM (FCC.codebaseExists specifiedDir)
-            (pure (Error specifiedDir FoundV1Codebase))
-            (pure (Error specifiedDir NoCodebaseFoundAtSpecifiedDir))
+
+        Specified specificed ->
+          whenNoV1Codebase (initOptionsToDir initOptions) $ do 
+            case specificed of
+              DontCreateWhenMissing dir ->
+                pure (Error dir NoCodebaseFoundAtSpecifiedDir)
+              CreateWhenMissing dir ->
+                createCodebaseWithResult cbInit debugName dir
 
 createCodebase :: MonadIO m => Init m v a -> DebugName -> CodebasePath -> m (Either Pretty (m (), Codebase m v a))
 createCodebase cbInit debugName path = do
@@ -123,6 +139,6 @@ openNewUcmCodebaseOrExit cbInit debugName path = do
       pure x
 
 -- | try to init a codebase where none exists and then exit regardless (i.e. `ucm -codebase dir init`)
-initCodebaseAndExit :: MonadIO m => Init m Symbol Ann -> DebugName -> Maybe CodebasePath -> m ()
+initCodebaseAndExit :: MonadIO m => Init m Symbol Ann -> DebugName -> Maybe CodebasePath -> m () -- RLM : or could change here 
 initCodebaseAndExit i debugName mdir =
   void $ openNewUcmCodebaseOrExit i debugName =<< Codebase.getCodebaseDir mdir

--- a/parser-typechecker/src/Unison/CommandLine/Main.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Main.hs
@@ -46,7 +46,6 @@ import Text.Regex.TDFA
 import Control.Lens (view)
 import Control.Error (rightMay)
 
-
 -- Expand a numeric argument like `1` or a range like `3-9`
 expandNumber :: [String] -> String -> [String]
 expandNumber numberedArgs s =

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -478,6 +478,7 @@ executable unison
     , unison-codebase-sync
     , unison-core1
     , unison-parser-typechecker
+    , unliftio
     , uri-encode
   if flag(optimized)
     ghc-options: -funbox-strict-fields -O2

--- a/parser-typechecker/unison/ArgParse.hs
+++ b/parser-typechecker/unison/ArgParse.hs
@@ -74,6 +74,11 @@ data ShouldSaveCodebase
     | DontSaveCodebase
     deriving (Show, Eq)
 
+data CodebasePathOption 
+  = CreateCodebaseWhenMissing FilePath 
+  | DontCreateCodebaseWhenMissing FilePath
+  deriving (Show, Eq)
+
 data IsHeadless = Headless | WithCLI
   deriving (Show, Eq)
 
@@ -84,6 +89,7 @@ data IsHeadless = Headless | WithCLI
 data Command
   = Launch IsHeadless CodebaseServerOpts
   | PrintVersion
+  -- @deprecated in trunk after M2g. Remove the Init command completely after M2h has been released
   | Init
   | Run RunSource
   | Transcript ShouldForkCodebase ShouldSaveCodebase (NonEmpty FilePath )
@@ -91,7 +97,7 @@ data Command
 
 -- | Options shared by sufficiently many subcommands.
 data GlobalOptions = GlobalOptions
-  { codebasePath :: Maybe FilePath
+  { codebasePathOption :: Maybe CodebasePathOption
   } deriving (Show, Eq)
 
 -- | The root-level 'ParserInfo'.
@@ -138,7 +144,8 @@ versionCommand = command "version" (info versionParser (fullDesc <> progDesc "Pr
 initCommand :: Mod CommandFields Command
 initCommand = command "init" (info initParser (progDesc initHelp))
   where
-    initHelp = "Initialise a unison codebase"
+    initHelp = 
+        "This command is has been removed. Use --codebase-create instead to create a codebase in the specified directory when starting the UCM."
 
 runSymbolCommand :: Mod CommandFields Command
 runSymbolCommand =
@@ -190,18 +197,28 @@ commandParser envOpts =
            , transcriptForkCommand
            , launchHeadlessCommand envOpts
            ]
-
+           
 globalOptionsParser :: Parser GlobalOptions
 globalOptionsParser = do -- ApplicativeDo
-    codebasePath <- codebasePathParser
-    pure GlobalOptions{..}
+    codebasePathOption <- codebasePathParser <|> codebaseCreateParser
 
-codebasePathParser :: Parser (Maybe FilePath)
-codebasePathParser =
-    optional . strOption $
+    pure GlobalOptions{codebasePathOption = codebasePathOption}
+
+codebasePathParser :: Parser (Maybe CodebasePathOption)
+codebasePathParser = do 
+    optString <- optional . strOption $
          long "codebase"
-      <> metavar "path/to/codebase"
-      <> help "The path to the codebase, defaults to the home directory"
+      <> metavar "codebase/path"
+      <> help "The path to an existing codebase"
+    pure (fmap DontCreateCodebaseWhenMissing optString)
+       
+codebaseCreateParser :: Parser (Maybe CodebasePathOption)
+codebaseCreateParser = do
+    path <- optional . strOption $
+         long "codebase-create"
+      <> metavar "codebase/path"
+      <> help "The path to a new or existing codebase (one will be created if there isn't one)"
+    pure (fmap CreateCodebaseWhenMissing path)
 
 launchHeadlessCommand :: CodebaseServerOpts -> Mod CommandFields Command
 launchHeadlessCommand envOpts =
@@ -249,7 +266,7 @@ launchParser envOpts isHeadless = do -- ApplicativeDo
   pure (Launch isHeadless codebaseServerOpts)
 
 initParser :: Parser Command
-initParser = pure Init
+initParser = pure Init 
 
 versionParser :: Parser Command
 versionParser = pure PrintVersion

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -22,7 +22,7 @@ import qualified System.IO.Temp as Temp
 import qualified System.Path as Path
 import Text.Megaparsec (runParser)
 import qualified Unison.Codebase as Codebase
-import Unison.Codebase.Init (InitResult(..), InitError(..))
+import Unison.Codebase.Init (InitResult(..), InitError(..), CodebaseInitOptions(..), SpecifiedCodebase(..))
 import qualified Unison.Codebase.Init as CodebaseInit
 import qualified Unison.Codebase.Editor.Input as Input
 import Unison.Codebase.Editor.RemoteRepo (ReadRemoteNamespace)
@@ -42,14 +42,16 @@ import qualified Unison.Server.CodebaseServer as Server
 import Unison.Symbol (Symbol)
 import qualified Unison.Util.Pretty as P
 import qualified Version
+import UnliftIO.Directory ( getHomeDirectory )
 import Compat ( installSignalHandlers )
 import ArgParse
     ( UsageRenderer,
-      GlobalOptions(GlobalOptions, codebasePath),
+      GlobalOptions(GlobalOptions, codebasePathOption),
       Command(Launch, PrintVersion, Init, Run, Transcript),
       IsHeadless(WithCLI, Headless),
       ShouldSaveCodebase(..),
       ShouldForkCodebase(..),
+      CodebasePathOption(..),
       RunSource(RunFromPipe, RunFromSymbol, RunFromFile),
       parseCLIArgs )
 import Data.List.NonEmpty (NonEmpty)
@@ -62,8 +64,9 @@ main = do
 
   void installSignalHandlers
   (renderUsageInfo, globalOptions, command) <- parseCLIArgs progName Version.gitDescribe
-  let GlobalOptions{codebasePath=mcodepath} = globalOptions
-  let cbInit = SC.init
+  let GlobalOptions{codebasePathOption=mCodePathOption} = globalOptions
+  let mcodepath = fmap codebasePathOptionToPath mCodePathOption
+
   currentDir <- getCurrentDirectory
   configFilePath <- getConfigFilePath mcodepath
   config <-
@@ -72,10 +75,21 @@ main = do
   case command of
      PrintVersion ->
        putStrLn $ progName ++ " version: " ++ Version.gitDescribe
-     Init ->
-       CodebaseInit.initCodebaseAndExit cbInit "main.init" mcodepath
+     Init -> do 
+      PT.putPrettyLn $ 
+        P.callout 
+          "⚠️"
+          (P.lines ["The Init command has been removed"
+                  , P.newline 
+                  , P.wrap "Use --codebase-create to create a codebase at a specified location and open it:"
+                  , P.indentN 2 (P.hiBlue "$ ucm --codebase-create myNewCodebase")
+                  , "Running UCM without the --codebase-create flag: "
+                  , P.indentN 2 (P.hiBlue "$ ucm")
+                  , P.wrap ("will " <> P.bold "always" <> " create a codebase in your home directory if one does not already exist.")
+                  ])
+
      Run (RunFromSymbol mainName) -> do
-      (closeCodebase, theCodebase) <- getCodebaseOrExit mcodepath
+      (closeCodebase, theCodebase) <- getCodebaseOrExit mCodePathOption
       runtime <- RTI.startRuntime
       execute theCodebase runtime mainName
       closeCodebase
@@ -86,7 +100,7 @@ main = do
             case e of
               Left _ -> PT.putPrettyLn $ P.callout "⚠️" "I couldn't find that file or it is for some reason unreadable."
               Right contents -> do
-                (closeCodebase, theCodebase) <- getCodebaseOrExit mcodepath
+                (closeCodebase, theCodebase) <- getCodebaseOrExit mCodePathOption
                 rt <- RTI.startRuntime
                 let fileEvent = Input.UnisonFileChanged (Text.pack file) contents
                 launch currentDir config rt theCodebase [Left fileEvent, Right $ Input.ExecuteI mainName, Right Input.QuitI] Nothing
@@ -96,7 +110,7 @@ main = do
       case e of
         Left _ -> PT.putPrettyLn $ P.callout "⚠️" "I had trouble reading this input."
         Right contents -> do
-          (closeCodebase, theCodebase) <- getCodebaseOrExit mcodepath
+          (closeCodebase, theCodebase) <- getCodebaseOrExit mCodePathOption
           rt <- RTI.startRuntime
           let fileEvent = Input.UnisonFileChanged (Text.pack "<standard input>") contents
           launch
@@ -105,9 +119,9 @@ main = do
             Nothing
           closeCodebase
      Transcript shouldFork shouldSaveCodebase transcriptFiles ->
-       runTranscripts renderUsageInfo shouldFork shouldSaveCodebase mcodepath transcriptFiles
+       runTranscripts renderUsageInfo shouldFork shouldSaveCodebase mCodePathOption transcriptFiles
      Launch isHeadless codebaseServerOpts -> do
-       (closeCodebase, theCodebase) <- getCodebaseOrExit mcodepath
+       (closeCodebase, theCodebase) <- getCodebaseOrExit mCodePathOption
        runtime <- RTI.startRuntime
        Server.startServer codebaseServerOpts runtime theCodebase $ \baseUrl -> do
          case isHeadless of
@@ -132,15 +146,16 @@ main = do
                  launch currentDir config runtime theCodebase [] (Just baseUrl)
                  closeCodebase
 
-prepareTranscriptDir :: ShouldForkCodebase -> Maybe FilePath -> IO FilePath
-prepareTranscriptDir shouldFork mcodepath = do
+prepareTranscriptDir :: ShouldForkCodebase -> Maybe CodebasePathOption -> IO FilePath
+prepareTranscriptDir shouldFork mCodePathOption = do
   tmp <- Temp.getCanonicalTemporaryDirectory >>= (`Temp.createTempDirectory` "transcript")
   let cbInit = SC.init
   case shouldFork of
     UseFork -> do
-      getCodebaseOrExit mcodepath
-      path <- Codebase.getCodebaseDir mcodepath
-      PT.putPrettyLn $ P.lines [
+      -- A forked codebase does not need to Create a codebase, because it already exists
+      getCodebaseOrExit mCodePathOption
+      path <- Codebase.getCodebaseDir (fmap codebasePathOptionToPath mCodePathOption)
+      PT.putPrettyLn $ P.lines [ 
         P.wrap "Transcript will be run on a copy of the codebase at: ", "",
         P.indentN 2 (P.string path)
         ]
@@ -168,7 +183,8 @@ runTranscripts' mcodepath transcriptDir args = do
             P.indentN 2 $ P.string err])
       Right stanzas -> do
         configFilePath <- getConfigFilePath mcodepath
-        (closeCodebase, theCodebase) <- getCodebaseOrExit $ Just transcriptDir
+        -- We don't need to create a codebase through `getCodebaseOrExit` as we've already done so previously.
+        (closeCodebase, theCodebase) <- getCodebaseOrExit (Just (DontCreateCodebaseWhenMissing transcriptDir))
         mdOut <- TR.run transcriptDir configFilePath stanzas theCodebase
         closeCodebase
         let out = currentDir FP.</>
@@ -191,12 +207,12 @@ runTranscripts
   :: UsageRenderer
   -> ShouldForkCodebase
   -> ShouldSaveCodebase
-  -> Maybe FilePath
+  -> Maybe CodebasePathOption
   -> NonEmpty String
   -> IO ()
-runTranscripts renderUsageInfo shouldFork shouldSaveTempCodebase mcodepath args = do
+runTranscripts renderUsageInfo shouldFork shouldSaveTempCodebase mCodePathOption args = do
   progName <- getProgName
-  transcriptDir <- prepareTranscriptDir shouldFork mcodepath
+  transcriptDir <- prepareTranscriptDir shouldFork mCodePathOption
   completed <-
     runTranscripts' (Just transcriptDir) transcriptDir args
   case shouldSaveTempCodebase of
@@ -260,13 +276,10 @@ defaultBaseLib :: Maybe ReadRemoteNamespace
 defaultBaseLib = rightMay $
   runParser VP.defaultBaseLib "version" (Text.pack Version.gitDescribe)
 
-getCodebaseOrExit :: Maybe Codebase.CodebasePath -> IO (IO (), Codebase.Codebase IO Symbol Ann)
-getCodebaseOrExit maybeSpecifiedDir = do
-  -- Likely we should only change codebase format 2? Or both? 
-  -- Notes for selves: create a function 'openOrCreateCodebase' which handles v1/v2 codebase provided / no codebase specified
-  -- encode error messages as types. Our spike / idea is below:   
-  codebaseDir <- CodebaseInit.homeOrSpecifiedDir maybeSpecifiedDir
-  CodebaseInit.openOrCreateCodebase SC.init "main" codebaseDir >>= \case
+getCodebaseOrExit :: Maybe CodebasePathOption -> IO (IO (), Codebase.Codebase IO Symbol Ann)
+getCodebaseOrExit codebasePathOption = do
+  initOptions <- codebasePathOptionToCodebaseInitOptions codebasePathOption
+  CodebaseInit.openOrCreateCodebase SC.init "main" initOptions >>= \case
     Error dir error ->
       let
         message = do
@@ -275,10 +288,9 @@ getCodebaseOrExit maybeSpecifiedDir = do
 
           case error of
             NoCodebaseFoundAtSpecifiedDir -> 
-              -- TODO: Perhaps prompt the user to create a codebase in that directory right away?
               pure (P.lines
                 [ "No codebase exists in " <> pDir <> ".", 
-                  "Run `" <> executableName <> " --codebase " <> P.string dir <> " init` to create one, then try again!"
+                  "Run `" <> executableName <> " --codebase-create" <> P.string dir <> " to create one, then try again!"
                 ])
 
             FoundV1Codebase ->
@@ -305,3 +317,16 @@ getCodebaseOrExit maybeSpecifiedDir = do
 
   where
     prettyDir dir = P.string <$> canonicalizePath dir
+
+codebasePathOptionToCodebaseInitOptions :: Maybe CodebasePathOption -> IO CodebaseInit.CodebaseInitOptions
+codebasePathOptionToCodebaseInitOptions option = 
+  case option of 
+    Just (CreateCodebaseWhenMissing path)     -> pure $ Specified (CreateWhenMissing path)
+    Just (DontCreateCodebaseWhenMissing path) -> pure $ Specified (DontCreateWhenMissing path)
+    Nothing                                   -> do Home <$> getHomeDirectory
+
+codebasePathOptionToPath :: CodebasePathOption -> FilePath
+codebasePathOptionToPath codebasePathOption = 
+  case codebasePathOption of
+    CreateCodebaseWhenMissing p -> p
+    DontCreateCodebaseWhenMissing p -> p


### PR DESCRIPTION
Coauthored with @hojberg 

## Overview

General onboarding improvement: https://github.com/unisonweb/unison/issues/2348 
We removed the separate `init` command, in favor of a `--codebase-create` flag when running the ucm. The user no longer needs a two step process to create and start the ucm. 

The new --help text describes this change: 

```
Use unison [command] --help to show help for a command.

Usage: unison [--codebase codebase/path | --codebase-create codebase/path] 
              [COMMAND | [--token STRING] [--host STRING] [--port NUMBER] [--ui DIR]]

Available options:
  --codebase codebase/path The path to an existing codebase
  --codebase-create codebase/path
                           The path to a new or existing codebase (one will be created if there
                           isn't one)
```

## Implementation notes

Flag was added to the UCM lunch command. 
We contemplated having a --codebase flag and an additional --create flag but having two separate flags which each took the codebase path as their argument ended up making the combination a little simpler. 

## Test coverage

We have added tests to reflect this change
