### PR TITLE
Allow blocks to appear as elements in lists and tuples

### DIFF
--- a/parser-typechecker/src/Unison/FileParser.hs
+++ b/parser-typechecker/src/Unison/FileParser.hs
@@ -230,7 +230,7 @@ modifier = do
     unique = do
       tok <- openBlockWith "unique"
       uid <- do
-        o <- optional (reserved "[" *> wordyIdString <* reserved "]")
+        o <- optional (openBlockWith "[" *> wordyIdString <* closeBlock)
         case o of
           Nothing -> uniqueName 32
           Just uid -> pure (fromString . L.payload $ uid)

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -917,8 +917,8 @@ lexemes' eof = P.optional space >> do
           where quote s = "'" <> s <> "'"
         Just (block, n) -> do
           S.put (env { layout = drop (n-1) (layout env) })
-          let opens = [Token (Reserved close) pos1 pos2]
-          pure $ replicate (n-1) (Token Close pos1 pos2) ++ opens
+          let delims = [Token (Reserved close) pos1 pos2]
+          pure $ replicate (n-1) (Token Close pos1 pos2) ++ delims
 
     close' :: Maybe String -> [String] -> P String -> P [Token Lexeme]
     close' reopenBlockname open closeP = do

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -916,7 +916,7 @@ lexemes' eof = P.optional space >> do
         Nothing -> err pos1 (UnexpectedDelimiter (quote close))
           where quote s = "'" <> s <> "'"
         Just (block, n) -> do
-          S.put (env { layout = drop n (layout env), opening = Just block })
+          S.put (env { layout = drop (n-1) (layout env) })
           let opens = [Token (Reserved close) pos1 pos2]
           pure $ replicate (n-1) (Token Close pos1 pos2) ++ opens
 

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -920,7 +920,7 @@ lexemes' eof = P.optional space >> do
       case findClose open (layout env) of
         Nothing -> err pos1 (UnexpectedDelimiter (quote close))
           where quote s = "'" <> s <> "'"
-        Just (block, n) -> do
+        Just (_, n) -> do
           S.put (env { layout = drop (n-1) (layout env) })
           let delims = [Token (Reserved close) pos1 pos2]
           pure $ replicate (n-1) (Token Close pos1 pos2) ++ delims

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -90,6 +90,7 @@ data Err
   | InvalidEscapeCharacter Char
   | LayoutError
   | CloseWithoutMatchingOpen String String -- open, close
+  | UnexpectedDelimiter String
   | Opaque String -- Catch-all failure type, generally these will be
                   -- automatically generated errors coming from megaparsec
                   -- Try to avoid this for common errors a user is likely to see.
@@ -214,7 +215,8 @@ token'' tok p = do
 
     topHasClosePair :: Layout -> Bool
     topHasClosePair [] = False
-    topHasClosePair ((name,_):_) = name `elem` ["{", "(", "handle", "match", "if", "then"]
+    topHasClosePair ((name,_):_) =
+      name `elem` ["{", "(", "[", "handle", "match", "if", "then"]
 
 lexer0' :: String -> String -> [Token Lexeme]
 lexer0' scope rem =
@@ -771,13 +773,29 @@ lexemes' eof = P.optional space >> do
 
   reserved :: P [Token Lexeme]
   reserved =
-    token' (\ts _ _ -> ts) $
-    braces <|> parens <|> delim <|> delayOrForce <|> keywords <|> layoutKeywords
-    where
-    keywords = symbolyKw ":" <|> symbolyKw "@" <|> symbolyKw "||" <|> symbolyKw "|" <|> symbolyKw "&&"
-           <|> wordyKw "true" <|> wordyKw "false"
-           <|> wordyKw "use" <|> wordyKw "forall" <|> wordyKw "∀"
-           <|> wordyKw "termLink" <|> wordyKw "typeLink"
+    token' (\ts _ _ -> ts)
+      $   braces
+      <|> parens
+      <|> brackets
+      <|> commaSeparator
+      <|> delim
+      <|> delayOrForce
+      <|> keywords
+      <|> layoutKeywords
+   where
+    keywords =
+      symbolyKw ":"
+        <|> symbolyKw "@"
+        <|> symbolyKw "||"
+        <|> symbolyKw "|"
+        <|> symbolyKw "&&"
+        <|> wordyKw "true"
+        <|> wordyKw "false"
+        <|> wordyKw "use"
+        <|> wordyKw "forall"
+        <|> wordyKw "∀"
+        <|> wordyKw "termLink"
+        <|> wordyKw "typeLink"
 
     wordyKw s = separated wordySep (kw s)
     symbolyKw s = separated (not . symbolyIdChar) (kw s)
@@ -809,12 +827,12 @@ lexemes' eof = P.optional space >> do
               let opens = [Token (Open "with") pos1 pos2]
               pure $ replicate n (Token Close pos1 pos2) ++ opens
 
-        -- In `structural/unique type` and `structural/unique ability`, 
+        -- In `structural/unique type` and `structural/unique ability`,
         -- only the `structural` or `unique` opens a layout block,
         -- and `ability` and `type` are just keywords.
         openTypeKw1 t = do
           b <- S.gets (topBlockName . layout)
-          case b of 
+          case b of
             Just mod | Set.member mod typeModifiers -> wordyKw t
             _                                       -> openKw1 wordySep t
 
@@ -840,7 +858,7 @@ lexemes' eof = P.optional space >> do
           env <- S.get
           -- -> introduces a layout block if we're inside a `match with` or `cases`
           case topBlockName (layout env) of
-            Just match | match == "match-with" || match == "cases" -> do
+            Just match | match `elem` matchWithBlocks -> do
               S.put (env { opening = Just "->" })
               pure [Token (Open "->") start end]
             _ -> pure [Token (Reserved "->") start end]
@@ -854,7 +872,15 @@ lexemes' eof = P.optional space >> do
         inLayout <- S.gets inLayout
         when (not inLayout) $ void $ P.lookAhead (CP.satisfy (/= '}'))
         pure l
+    matchWithBlocks = ["match-with", "cases"]
     parens = open "(" <|> close ["("] (lit ")")
+    brackets = open "[" <|> close ["["] (lit "]")
+    commaSeparator = do
+      env <- S.get
+      case topBlockName (layout env) of
+        Just match | not (match `elem` matchWithBlocks) ->
+          blockDelimiter ["[", "("] (lit ",")
+        _ -> fail "this comma is a pattern separator"
 
     delim = P.try $ do
       ch <- CP.satisfy (\ch -> ch /= ';' && Set.member ch delimiters)
@@ -881,6 +907,18 @@ lexemes' eof = P.optional space >> do
       pure [Token (Open s) pos1 pos2]
 
     close = close' Nothing
+
+    blockDelimiter :: [String] -> P String -> P [Token Lexeme]
+    blockDelimiter open closeP = do
+      (pos1, close, pos2) <- positioned $ closeP
+      env <- S.get
+      case findClose open (layout env) of
+        Nothing -> err pos1 (UnexpectedDelimiter (quote close))
+          where quote s = "'" <> s <> "'"
+        Just (block, n) -> do
+          S.put (env { layout = drop n (layout env), opening = Just block })
+          let opens = [Token (Open block) pos1 pos2]
+          pure $ replicate n (Token Close pos1 pos2) ++ opens
 
     close' :: Maybe String -> [String] -> P String -> P [Token Lexeme]
     close' reopenBlockname open closeP = do
@@ -1086,7 +1124,7 @@ symbolyIdChars = Set.fromList "!$%^&*-=+<>.~\\/|:"
 keywords :: Set String
 keywords = Set.fromList [
   "if", "then", "else", "forall", "∀",
-  "handle", "with", 
+  "handle", "with",
   "where", "use",
   "true", "false",
   "alias", "typeLink", "termLink",

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -878,7 +878,7 @@ lexemes' eof = P.optional space >> do
     commaSeparator = do
       env <- S.get
       case topBlockName (layout env) of
-        Just match | not (match `elem` matchWithBlocks) ->
+        Just match | not (match `elem` matchWithBlocks || match == "{") ->
           blockDelimiter ["[", "("] (lit ",")
         _ -> fail "this comma is a pattern separator"
 

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -875,10 +875,15 @@ lexemes' eof = P.optional space >> do
     matchWithBlocks = ["match-with", "cases"]
     parens = open "(" <|> close ["("] (lit ")")
     brackets = open "[" <|> close ["["] (lit "]")
+    -- `allowCommaToClose` determines if a comma should close inner blocks.
+    -- Currently there is a set of blocks where `,` is not treated specially
+    -- and it just emits a Reserved ",". There are currently only three:
+    -- `cases`, `match-with`, and `{`
+    allowCommaToClose match = not $ match `elem` ("{" : matchWithBlocks)
     commaSeparator = do
       env <- S.get
       case topBlockName (layout env) of
-        Just match | not (match `elem` matchWithBlocks || match == "{") ->
+        Just match | allowCommaToClose match ->
           blockDelimiter ["[", "("] (lit ",")
         _ -> fail "this comma is a pattern separator"
 

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -911,14 +911,14 @@ lexemes' eof = P.optional space >> do
     blockDelimiter :: [String] -> P String -> P [Token Lexeme]
     blockDelimiter open closeP = do
       (pos1, close, pos2) <- positioned $ closeP
-      env <- S.get
+      env                 <- S.get
       case findClose open (layout env) of
         Nothing -> err pos1 (UnexpectedDelimiter (quote close))
           where quote s = "'" <> s <> "'"
         Just (block, n) -> do
           S.put (env { layout = drop n (layout env), opening = Just block })
-          let opens = [Token (Open block) pos1 pos2]
-          pure $ replicate n (Token Close pos1 pos2) ++ opens
+          let opens = [Token (Reserved close) pos1 pos2]
+          pure $ replicate (n-1) (Token Close pos1 pos2) ++ opens
 
     close' :: Maybe String -> [String] -> P String -> P [Token Lexeme]
     close' reopenBlockname open closeP = do

--- a/parser-typechecker/src/Unison/Parser.hs
+++ b/parser-typechecker/src/Unison/Parser.hs
@@ -417,7 +417,7 @@ seq = seq' "["
 seq' :: Ord v => String -> (Ann -> [a] -> a) -> P v a -> P v a
 seq' openStr f p = do
   open  <- openBlockWith openStr <* redundant
-  es    <- sepEndBy (reserved ",") p
+  es    <- sepEndBy (P.try $ optional semi *> reserved "," <* redundant) p
   close <- redundant *> closeBlock
   pure $ go open es close
   where go open elems close = f (ann open <> ann close) elems

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -1031,6 +1031,10 @@ prettyParseError s = \case
     where
     excerpt = showSource s ((\t -> (rangeForToken t, ErrorSite)) <$> ts)
     go = \case
+      L.UnexpectedDelimiter s ->
+        "I found a " <> style ErrorSite (fromString s) <>
+        " here, but I didn't see a list or tuple that it might be a separator for.\n\n" <>
+        excerpt
       L.CloseWithoutMatchingOpen open close ->
         "I found a closing " <> style ErrorSite (fromString close) <>
         " here without a matching " <> style ErrorSite (fromString open) <> ".\n\n" <>

--- a/parser-typechecker/src/Unison/TypeParser.hs
+++ b/parser-typechecker/src/Unison/TypeParser.hs
@@ -84,9 +84,9 @@ effectList = do
 
 sequenceTyp :: Var v => TypeP v
 sequenceTyp = do
-  open <- reserved "["
+  open <- openBlockWith "["
   t <- valueType
-  close <- reserved "]"
+  close <- closeBlock
   let a = ann open <> ann close
   pure $ Type.app a (Type.list a) t
 

--- a/parser-typechecker/tests/Unison/Test/Lexer.hs
+++ b/parser-typechecker/tests/Unison/Test/Lexer.hs
@@ -64,10 +64,10 @@ test =
       , t "woot;(woot)" [simpleWordyId "woot", Semi False, Open "(", simpleWordyId "woot", Close]
       , t
         "[+1,+1]"
-        [Reserved "[", Numeric "+1", Reserved ",", Numeric "+1", Reserved "]"]
+        [Open "[", Numeric "+1", Reserved ",", Numeric "+1", Close ]
       , t
         "[ +1 , +1 ]"
-        [Reserved "[", Numeric "+1", Reserved ",", Numeric "+1", Reserved "]"]
+        [Open "[", Numeric "+1", Reserved ",", Numeric "+1", Close ]
       , t "-- a comment 1.0" []
       , t "\"woot\" -- a comment 1.0" [Textual "woot"]
       , t "0:Int" [Numeric "0", Reserved ":", simpleWordyId "Int"]

--- a/unison-src/transcripts/fix-2258-if-as-list-element.md
+++ b/unison-src/transcripts/fix-2258-if-as-list-element.md
@@ -1,0 +1,10 @@
+Tests that `if` statements can appear as list elements.
+
+```ucm:hide
+.> builtins.merge
+```
+
+```unison:hide
+> [ if true then 1 else 0 ]
+```
+

--- a/unison-src/transcripts/fix-2258-if-as-list-element.md
+++ b/unison-src/transcripts/fix-2258-if-as-list-element.md
@@ -1,4 +1,4 @@
-Tests that `if` statements can appear as list elements.
+Tests that `if` statements can appear as list and tuple elements.
 
 ```ucm:hide
 .> builtins.merge
@@ -6,5 +6,30 @@ Tests that `if` statements can appear as list elements.
 
 ```unison:hide
 > [ if true then 1 else 0 ]
+
+> [ if true then 1 else 0, 1]
+
+> [1, if true then 1 else 0]
+
+> (if true then 1 else 0, 0)
+
+> (0, if true then 1 else 0)
+
+> (1)
+
+> (1,2)
+
+> (1,2,3)
+
+> [1,2,3]
+
+> []
+
+> [1]
+
+> [1,2]
+
+> [1,2,3]
+
 ```
 

--- a/unison-src/transcripts/fix-2258-if-as-list-element.md
+++ b/unison-src/transcripts/fix-2258-if-as-list-element.md
@@ -31,5 +31,21 @@ Tests that `if` statements can appear as list and tuple elements.
 
 > [1,2,3]
 
+> [
+  1,
+  2,
+  3
+  ]
+
+> [
+  1,
+  2,
+  3,]
+
+> (1,2,3,)
+
+> (1,
+   2,)
+
 ```
 

--- a/unison-src/transcripts/fix-2258-if-as-list-element.md
+++ b/unison-src/transcripts/fix-2258-if-as-list-element.md
@@ -47,5 +47,20 @@ Tests that `if` statements can appear as list and tuple elements.
 > (1,
    2,)
 
+structural ability Zoot where zoot : ()
+
+Zoot.handler : Request {Zoot} a -> a
+Zoot.handler = cases
+  { a } -> a
+  { zoot -> k } -> handle !k with Zoot.handler
+
+fst = cases (x,_) -> x
+
+> List.size
+    [ if true then (x y -> y)
+      else handle (x y -> x) with fst (Zoot.handler, 42),
+      cases a, b -> a Nat.+ b, -- multi-arg cases lambda
+      cases x, y -> x Nat.+ y
+    ]
 ```
 

--- a/unison-src/transcripts/fix-2258-if-as-list-element.output.md
+++ b/unison-src/transcripts/fix-2258-if-as-list-element.output.md
@@ -1,0 +1,7 @@
+Tests that `if` statements can appear as list elements.
+
+```unison
+> [ if true then 1 else 0
+  ]
+```
+

--- a/unison-src/transcripts/fix-2258-if-as-list-element.output.md
+++ b/unison-src/transcripts/fix-2258-if-as-list-element.output.md
@@ -1,7 +1,31 @@
-Tests that `if` statements can appear as list elements.
+Tests that `if` statements can appear as list and tuple elements.
 
 ```unison
-> [ if true then 1 else 0
-  ]
+> [ if true then 1 else 0 ]
+
+> [ if true then 1 else 0, 1]
+
+> [1, if true then 1 else 0]
+
+> (if true then 1 else 0, 0)
+
+> (0, if true then 1 else 0)
+
+> (1)
+
+> (1,2)
+
+> (1,2,3)
+
+> [1,2,3]
+
+> []
+
+> [1]
+
+> [1,2]
+
+> [1,2,3]
+
 ```
 

--- a/unison-src/transcripts/fix-2258-if-as-list-element.output.md
+++ b/unison-src/transcripts/fix-2258-if-as-list-element.output.md
@@ -27,5 +27,21 @@ Tests that `if` statements can appear as list and tuple elements.
 
 > [1,2,3]
 
+> [
+  1,
+  2,
+  3
+  ]
+
+> [
+  1,
+  2,
+  3,]
+
+> (1,2,3,)
+
+> (1,
+   2,)
+
 ```
 

--- a/unison-src/transcripts/fix-2258-if-as-list-element.output.md
+++ b/unison-src/transcripts/fix-2258-if-as-list-element.output.md
@@ -43,5 +43,20 @@ Tests that `if` statements can appear as list and tuple elements.
 > (1,
    2,)
 
+structural ability Zoot where zoot : ()
+
+Zoot.handler : Request {Zoot} a -> a
+Zoot.handler = cases
+  { a } -> a
+  { zoot -> k } -> handle !k with Zoot.handler
+
+fst = cases (x,_) -> x
+
+> List.size
+    [ if true then (x y -> y)
+      else handle (x y -> x) with fst (Zoot.handler, 42),
+      cases a, b -> a Nat.+ b, -- multi-arg cases lambda
+      cases x, y -> x Nat.+ y
+    ]
 ```
 


### PR DESCRIPTION
Fixes #2258.

This changes and unifies the way the parser handles brackets—namely parentheses (`()`) and square brackets (`[]`)—and commas (`,`) inside them. A bracket now opens a block, and the corresponding closing bracket closes it. Any comma between brackets also closes any inner blocks that were opened inside the brackets.

As a result, blocks can now appear as elements in lists and tuples, so this is valid syntax:

```
[if true then 0 else 1]
```

as is

```
(if true then 0 else 1, "hi")
```

This incidentally also adds support for redundant commas in tuples, like `(,"one",,"two",)`, making that syntax consistent with lists.