### PR TITLE
Fixed built-in IO ability to be reported as Ability on Server

### DIFF
--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -308,6 +308,10 @@ termListEntry codebase b0 r n = do
       tag = if isDoc then Just Doc else if isTest then Just Test else Nothing
   pure $ TermEntry r n ot tag
 
+
+builtInIoAbility :: Reference
+builtInIoAbility = Reference.unsafeFromText "##IO"
+
 typeListEntry
   :: Monad m
   => Var v
@@ -323,7 +327,8 @@ typeListEntry codebase r n = do
       pure $ case decl of
         Just (Left _) -> Ability
         _             -> Data
-    _ -> pure Data
+    -- IO is the only built-in ability
+    _ -> pure (if r == builtInIoAbility then Ability else Data)
   pure $ TypeEntry r n tag
 
 typeDeclHeader

--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -323,7 +323,6 @@ typeListEntry codebase r n = do
       pure $ case decl of
         Just (Left _) -> Ability
         _             -> Data
-    -- IO is the only built-in ability
     _ -> pure (if Set.member r Type.builtinAbilities then Ability else Data)
   pure $ TypeEntry r n tag
 

--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -324,7 +324,7 @@ typeListEntry codebase r n = do
         Just (Left _) -> Ability
         _             -> Data
     -- IO is the only built-in ability
-    _ -> pure (if r == Type.builtinIORef then Ability else Data)
+    _ -> pure (if Set.member r Type.builtinAbilities then Ability else Data)
   pure $ TypeEntry r n tag
 
 typeDeclHeader

--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -308,10 +308,6 @@ termListEntry codebase b0 r n = do
       tag = if isDoc then Just Doc else if isTest then Just Test else Nothing
   pure $ TermEntry r n ot tag
 
-
-builtInIoAbility :: Reference
-builtInIoAbility = Reference.unsafeFromText "##IO"
-
 typeListEntry
   :: Monad m
   => Var v
@@ -328,7 +324,7 @@ typeListEntry codebase r n = do
         Just (Left _) -> Ability
         _             -> Data
     -- IO is the only built-in ability
-    _ -> pure (if r == builtInIoAbility then Ability else Data)
+    _ -> pure (if r == Type.builtinIORef then Ability else Data)
   pure $ TypeEntry r n tag
 
 typeDeclHeader

--- a/unison-core/src/Unison/Type.hs
+++ b/unison-core/src/Unison/Type.hs
@@ -688,6 +688,9 @@ hashComponents
   :: Var v => Map v (Type v a) -> Map v (Reference.Id, Type v a)
 hashComponents = ReferenceUtil.hashComponents $ refId ()
 
+builtinAbilities :: Set Reference
+builtinAbilities = Set.fromList [builtinIORef, stmRef]
+
 instance Hashable1 F where
   hash1 hashCycle hash e =
     let


### PR DESCRIPTION
Fixes #2325 

Not sure if I am doing this right, but it seems to work:
http://127.0.0.1:50120/RVo7z7c4KYLtSIobQ5n6QozbtpVIoGMU/api/getDefinition?names=base.IO&rootBranch=%23jev7fp8580qth12tmf68f221ir5a3ahbvvl54d4f200q3nk1dln0dnhla4f72clu3fm0dni1ubj9ossgucq7mqvmnciepemm2kopuhg
```
{"termDefinitions":{},"typeDefinitions":{"##IO":{"typeNames":[".base.IO"],"bestTypeName":"IO","defnTypeTag":"Ability","typeDefinition":{"tag":"BuiltinObject","contents":[{"annotation":null,"segment":"IO"}]},"typeDocs":[]}},"missingDefinitions":[]}
```