### PR TITLE
Add TermSummary endpoint

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -2174,6 +2174,8 @@ handleBackendError :: Backend.BackendError -> Action m i v ()
 handleBackendError = \case
   Backend.NoSuchNamespace path ->
     respond . BranchNotFound $ Path.absoluteToPath' path
+  Backend.BadNamespacePath _ p ->
+    respond . BadName $ p
   Backend.BadRootBranch   e -> respond $ BadRootBranch e
   Backend.NoBranchForHash h -> do
     sbhLength <- eval BranchHashLength

--- a/parser-typechecker/src/Unison/Server/CodebaseServer.hs
+++ b/parser-typechecker/src/Unison/Server/CodebaseServer.hs
@@ -85,6 +85,7 @@ import Unison.Server.Endpoints.GetDefinitions
   ( DefinitionsAPI,
     serveDefinitions,
   )
+import qualified Unison.Server.Endpoints.Definitions.Terms.TermSummary as TermSummary
 import qualified Unison.Server.Endpoints.NamespaceDetails as NamespaceDetails
 import qualified Unison.Server.Endpoints.NamespaceListing as NamespaceListing
 import Unison.Server.Types (mungeString)
@@ -109,6 +110,7 @@ type UnisonAPI =
   NamespaceListing.NamespaceListingAPI
     :<|> NamespaceDetails.NamespaceDetailsAPI
     :<|> DefinitionsAPI
+    :<|> TermSummary.TermSummaryAPI
     :<|> FuzzyFindAPI
 
 
@@ -300,4 +302,5 @@ server rt codebase uiPath token =
       NamespaceListing.serve (tryAuth t) codebase
         :<|> NamespaceDetails.serve (tryAuth t) rt codebase
         :<|> serveDefinitions (tryAuth t) rt codebase
+        :<|> TermSummary.serve (tryAuth t) codebase
         :<|> serveFuzzyFind (tryAuth t) codebase

--- a/parser-typechecker/src/Unison/Server/Endpoints/Definitions/Terms/TermSummary.hs
+++ b/parser-typechecker/src/Unison/Server/Endpoints/Definitions/Terms/TermSummary.hs
@@ -1,0 +1,140 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Unison.Server.Endpoints.Definitions.Terms.TermSummary where
+
+import Control.Error (runExceptT)
+import Data.Aeson
+import Data.OpenApi (ToSchema)
+import qualified Data.Set as Set
+import qualified Data.Text as Text
+import Servant (Capture, QueryParam, throwError, (:>))
+import Servant.Docs (DocCapture (..), ToCapture (..), ToSample (..), noSamples)
+import Servant.OpenApi ()
+import Servant.Server (Handler)
+import Unison.Codebase (Codebase)
+import qualified Unison.Codebase as Codebase
+import qualified Unison.Codebase.Branch as Branch
+import Unison.Codebase.Editor.DisplayObject (DisplayObject (..))
+import qualified Unison.Codebase.Path as Path
+import Unison.Codebase.Path.Parse (parsePath')
+import Unison.Codebase.ShortBranchHash (ShortBranchHash)
+import qualified Unison.Name as Name
+import Unison.Parser.Ann (Ann)
+import Unison.Prelude
+import Unison.PrettyPrintEnvDecl (PrettyPrintEnvDecl (..))
+import qualified Unison.Reference as Reference
+import qualified Unison.Referent as Referent
+import qualified Unison.Server.Backend as Backend
+import Unison.Server.Errors (backendError)
+import Unison.Server.Syntax (SyntaxText)
+import Unison.Server.Types
+  ( APIGet,
+    APIHeaders,
+    NamespaceFQN,
+    TermTag (..),
+    UnisonHash,
+    UnisonName,
+    addHeaders,
+    mayDefaultWidth,
+  )
+import Unison.Util.Pretty (Width)
+import qualified Unison.Util.Relation as Relation
+import Unison.Var (Var)
+
+type TermSummaryAPI =
+  "definitions" :> "terms" :> "by_name" :> Capture "fqn" UnisonName :> "summary"
+    :> QueryParam "rootBranch" ShortBranchHash
+    :> QueryParam "relativeTo" NamespaceFQN
+    :> QueryParam "renderWidth" Width
+    :> APIGet TermSummary
+
+instance ToCapture (Capture "fqn" Text) where
+  toCapture _ =
+    DocCapture
+      "fqn"
+      "The fully qualified name of a definition. The leading `.` is optional."
+
+instance ToSample TermSummary where
+  toSamples _ = noSamples
+
+data TermSummary = TermSummary
+  { fqn :: UnisonName,
+    hash :: UnisonHash,
+    summary :: DisplayObject SyntaxText SyntaxText,
+    tag :: TermTag
+  }
+  deriving (Generic, Show)
+
+instance ToJSON TermSummary where
+  toEncoding = genericToEncoding defaultOptions
+
+deriving instance ToSchema TermSummary
+
+-- TODO: Should this be using Backend.TermEntry as a way to get to TermSummary?
+serve ::
+  Var v =>
+  Handler () ->
+  Codebase IO v Ann ->
+  UnisonName ->
+  Maybe ShortBranchHash ->
+  Maybe NamespaceFQN ->
+  Maybe Width ->
+  Handler (APIHeaders TermSummary)
+serve tryAuth codebase rawTermName mayRoot namespaceName mayWidth =
+  let inBackend a = do
+        ea <- liftIO $ runExceptT a
+        errFromEither backendError ea
+
+      errFromEither f = either (throwError . f) pure
+
+      fqnToNamespacePath fqn = do
+        let fqnS = Text.unpack fqn
+        path' <- errFromEither (`Backend.BadNamespacePath` fqnS) $ parsePath' fqnS
+        pure (Path.fromPath' path')
+
+      width = mayDefaultWidth mayWidth
+
+      mkSummary reference termSig =
+        if Reference.isBuiltin reference
+          then BuiltinObject termSig
+          else UserObject termSig
+   in do
+        -- TODO: Should servant do this Name.unsafeFromString?
+        let termName = Name.unsafeFromText rawTermName
+
+        termSummary <- inBackend $ do
+          branch <- case namespaceName of
+            Nothing ->
+              Backend.resolveRootBranchHash mayRoot codebase
+            Just n -> do
+              namespacePath <- fqnToNamespacePath n
+              root <- Backend.resolveRootBranchHash mayRoot codebase
+              pure $ Branch.getAt' namespacePath root
+
+          let branch0 = Branch.head branch
+          let rel = Branch.deepTerms branch0
+          -- TODO: Map exception of missing element in set to 404 - noSuchDefinition
+          let termReferent = Set.elemAt 0 (Relation.lookupRan termName rel)
+          let termReference = Referent.toReference termReferent
+          let hash = Referent.toText termReferent
+          sig <- lift (Codebase.getTypeOfTerm codebase termReference)
+          case sig of
+            Nothing ->
+              throwError (Backend.MissingSignatureForTerm termReference)
+            Just typeSig -> do
+              hashLength <- liftIO $ Codebase.hashLength codebase
+              let ppe = Backend.basicSuffixifiedNames hashLength branch Path.empty
+              let formattedTermSig = Backend.formatSuffixedType (PrettyPrintEnvDecl ppe ppe) width typeSig
+              let summary = mkSummary termReference formattedTermSig
+              tag <- Backend.getTermTag branch0 termReferent sig
+
+              pure $ TermSummary rawTermName hash summary tag
+
+        addHeaders <$> (tryAuth $> termSummary)

--- a/parser-typechecker/src/Unison/Server/Errors.hs
+++ b/parser-typechecker/src/Unison/Server/Errors.hs
@@ -34,6 +34,8 @@ backendError :: Backend.BackendError -> ServerError
 backendError = \case
   Backend.NoSuchNamespace n ->
     noSuchNamespace . Path.toText $ Path.unabsolute n
+  Backend.BadNamespacePath err path ->
+    badNamespace err path
   Backend.BadRootBranch e -> rootBranchError e
   Backend.NoBranchForHash h ->
     noSuchNamespace . Text.toStrict . Text.pack $ show h
@@ -57,7 +59,7 @@ rootBranchError rbe = err500
 
 badNamespace :: String -> String -> ServerError
 badNamespace err namespace = err400
-  { errBody = "Malformed namespace: "
+  { errBody = "Malformed namespace name: "
               <> mungeString namespace
               <> ". "
               <> mungeString err
@@ -66,6 +68,10 @@ badNamespace err namespace = err400
 noSuchNamespace :: HashQualifiedName -> ServerError
 noSuchNamespace namespace =
   err404 { errBody = "The namespace " <> munge namespace <> " does not exist." }
+
+noSuchDefinition :: HashQualifiedName -> ServerError
+noSuchDefinition definition  =
+  err404 { errBody = "The definition " <> munge definition  <> " does not exist." }
 
 couldntLoadBranch :: Branch.Hash -> ServerError
 couldntLoadBranch h =

--- a/parser-typechecker/src/Unison/Server/Types.hs
+++ b/parser-typechecker/src/Unison/Server/Types.hs
@@ -119,7 +119,7 @@ newtype Suffixify = Suffixify { suffixified :: Bool }
 data TermDefinition = TermDefinition
   { termNames :: [HashQualifiedName]
   , bestTermName :: HashQualifiedName
-  , defnTermTag :: Maybe TermTag
+  , defnTermTag :: TermTag
   , termDefinition :: DisplayObject SyntaxText SyntaxText
   , signature :: SyntaxText
   , termDocs :: [(HashQualifiedName, UnisonHash, Doc)]
@@ -140,7 +140,7 @@ data DefinitionDisplayResults =
     , missingDefinitions :: [HashQualifiedName]
     } deriving (Eq, Show, Generic)
 
-data TermTag = Doc | Test
+data TermTag = Doc | Test | Plain
   deriving (Eq, Ord, Show, Generic)
 
 data TypeTag = Ability | Data
@@ -170,7 +170,7 @@ data NamedTerm = NamedTerm
   { termName :: HashQualifiedName
   , termHash :: UnisonHash
   , termType :: Maybe SyntaxText
-  , termTag :: Maybe TermTag
+  , termTag :: TermTag
   }
   deriving (Eq, Generic, Show)
 

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -127,6 +127,7 @@ library
       Unison.Server.Backend
       Unison.Server.CodebaseServer
       Unison.Server.Doc
+      Unison.Server.Endpoints.Definitions.Terms.TermSummary
       Unison.Server.Endpoints.FuzzyFind
       Unison.Server.Endpoints.GetDefinitions
       Unison.Server.Endpoints.NamespaceDetails

--- a/unison-core/src/Unison/Reference.hs
+++ b/unison-core/src/Unison/Reference.hs
@@ -19,6 +19,7 @@ module Unison.Reference
    unsafeFromText,
    idFromText,
    isPrefixOf,
+   isBuiltin,
    fromShortHash,
    fromText,
    readSuffix,
@@ -179,6 +180,10 @@ groupByComponent refs = done $ foldl' insert Map.empty refs
     insert m (k, r) =
       Map.unionWith (<>) m (Map.fromList [(Left r, [(k,r)])])
     done m = sortOn snd <$> toList m
+
+isBuiltin :: Reference -> Bool
+isBuiltin (Builtin _) = True
+isBuiltin _ = False
 
 instance Show Id where show = SH.toString . SH.take 5 . toShortHash . DerivedId
 instance Show Reference where show = SH.toString . SH.take 5 . toShortHash


### PR DESCRIPTION
## Overview
Add a new endpoint: `/definitions/terms/by_name/:fqn/summary` that will
return a term if one is found in this shape:

```js
{
  "fqn" : "base.List.map",
  "hash" : "#asdf1234",
  "summary" : {
    "tag": "UserObject",
    "contents": [/* ... */ ]
  },
  "tag" : "Plain"
}
```

This will help support hover operations in the Codebase UI and other
similar UIs like the recent VS Code extension work by Tom Sherman.

One part of https://github.com/unisonweb/unison/issues/2175

## Implementation notes

### URL Design
The URL scheme is designed such that it is as RESTful as possible.
The main outlier in that is the `by_name` prefix. This is done to
ensure sub resources doesn't clash with fqns:

`/definitions/terms/:fqn` with a term name like `histories` would prevent `/definitions/terms/histories` to be a specific sub resource

### Various

This adds a few helper functions to Backend for things like getting the tag of a term (`Doc` vs `Test` vs `Plain`) and also makes termTag a non-maybe field on all definition entities by adding the `Plain` variant.

## Interesting/controversial decisions

I only found out about `TermEntry` and `TypeEntry` 90% of the way through this and I think I should likely use that as an intermediate before constructing a `TermSummary`. What do you think @runarorama ?

## Loose ends

* There's another half of this, notably a `TypeSummary` endpoint, that still needs to be done.
* There's quite a few minor helper functions we use on every endpoint that would be nice to put somewhere, like `inBackend`, but not sure where they belong?