### PR TITLE
Numbered list backend doc rendering fix

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/IOSource.hs
+++ b/parser-typechecker/src/Unison/Runtime/IOSource.hs
@@ -153,6 +153,7 @@ pattern Doc2Table ds <- Term.App' (Term.Constructor' Doc2Ref ((==) doc2TableId -
 pattern Doc2Folded isFolded d d2 <- Term.Apps' (Term.Constructor' Doc2Ref ((==) doc2FoldedId -> True)) [Term.Boolean' isFolded, d, d2]
 pattern Doc2Paragraph ds <- Term.App' (Term.Constructor' Doc2Ref ((==) doc2ParagraphId -> True)) (Term.List' (toList -> ds))
 pattern Doc2BulletedList ds <- Term.App' (Term.Constructor' Doc2Ref ((==) doc2BulletedListId -> True)) (Term.List' (toList -> ds))
+pattern Doc2NumberedList n ds <- Term.Apps' (Term.Constructor' Doc2Ref ((==) doc2NumberedListId -> True)) [Term.Nat' n, Term.List' (toList -> ds)]
 pattern Doc2Section title ds <- Term.Apps' (Term.Constructor' Doc2Ref ((==) doc2SectionId -> True)) [title, Term.List' (toList -> ds)]
 pattern Doc2NamedLink name dest <- Term.Apps' (Term.Constructor' Doc2Ref ((==) doc2NamedLinkId -> True)) [name, dest]
 pattern Doc2Image alt link caption <- Term.Apps' (Term.Constructor' Doc2Ref ((==) doc2ImageId -> True)) [alt, link, caption]

--- a/parser-typechecker/src/Unison/Server/Doc.hs
+++ b/parser-typechecker/src/Unison/Server/Doc.hs
@@ -138,6 +138,7 @@ renderDoc pped terms typeOf eval types tm = eval tm >>= \case
     DD.Doc2Folded isFolded d d2 -> Folded isFolded <$> go d <*> go d2
     DD.Doc2Paragraph ds -> Paragraph <$> traverse go ds
     DD.Doc2BulletedList ds -> BulletedList <$> traverse go ds
+    DD.Doc2NumberedList n ds -> NumberedList n <$> traverse go ds
     DD.Doc2Section title ds -> Section <$> go title <*> traverse go ds
     DD.Doc2NamedLink d1 d2 -> NamedLink <$> go d1 <*> go d2
     DD.Doc2Image d1 d2 Decls.OptionalNone' -> Image <$> go d1 <*> go d2 <*> pure Nothing


### PR DESCRIPTION
I think this fixes https://github.com/unisonweb/codebase-ui/issues/229 but can someone test it out? I have something messed up with my UI install where I'm not able to actually open any definitions. I think `./dev-ui-install.sh` might be busted somehow since that's usually how I refresh the UI code.