### PR TITLE
Fixes the type of the newly added ##IO.systemTimeMicroseconds.v1

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -561,7 +561,7 @@ ioBuiltins =
   , ("IO.putBytes.impl.v3", handle --> bytes --> iof unit)
   , ("IO.getLine.impl.v1", handle --> iof text)
   , ("IO.systemTime.impl.v3", unit --> iof nat)
-  , ("IO.systemTimeMicroseconds.v1", unit --> iof int)
+  , ("IO.systemTimeMicroseconds.v1", unit --> io int)
   , ("IO.getTempDirectory.impl.v3", unit --> iof text)
   , ("IO.createTempDirectory.impl.v3", text --> iof text)
   , ("IO.getCurrentDirectory.impl.v3", unit --> iof text)

--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -1573,7 +1573,7 @@ declareForeigns = do
     $ mkForeignIOF $ \() -> getPOSIXTime 
 
   declareForeign "IO.systemTimeMicroseconds.v1" unitToInt
-    $ mkForeignIOF $ \() -> fmap (1e6 *) getPOSIXTime 
+    $ mkForeign $ \() -> fmap (1e6 *) getPOSIXTime 
 
   declareForeign "IO.getTempDirectory.impl.v3" unitToEFBox
     $ mkForeignIOF $ \() -> getTemporaryDirectory

--- a/unison-src/transcripts/alias-many.output.md
+++ b/unison-src/transcripts/alias-many.output.md
@@ -263,7 +263,7 @@ Let's try it!
                                 ->{IO} Either Failure ()
   199. io2.IO.stdHandle : StdHandle -> Handle
   200. io2.IO.systemTime.impl : '{IO} Either Failure Nat
-  201. io2.IO.systemTimeMicroseconds : '{IO} Either Failure Int
+  201. io2.IO.systemTimeMicroseconds : '{IO} Int
   202. unique type io2.IOError
   203. io2.IOError.AlreadyExists : IOError
   204. io2.IOError.EOF : IOError


### PR DESCRIPTION
Previous PR: https://github.com/unisonweb/unison/pull/2418 was registering the wrong type, this corrects it.

Resolves #2359
