### PR TITLE
Improve the performance of `add` with default metadata

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -241,18 +241,6 @@ loop = do
       getHQ'Terms p = BranchUtil.getTerm (resolveSplit' p) root0
       getHQ'Types :: Path.HQSplit' -> Set Reference
       getHQ'Types p = BranchUtil.getType (resolveSplit' p) root0
-      getHQTerms :: HQ.HashQualified Name -> Action' m v (Set Referent)
-      getHQTerms hq = case hq of
-        HQ.NameOnly n -> let
-          -- absolute-ify the name, then lookup in deepTerms of root
-          path :: Path.Path'
-          path = Path.fromName' n
-          Path.Absolute absPath = resolveToAbsolute path
-          in pure $ R.lookupRan (Path.toName absPath) (Branch.deepTerms root0)
-        HQ.HashOnly sh -> hashOnly sh
-        HQ.HashQualified _ sh -> hashOnly sh
-        where
-        hashOnly sh = eval $ TermReferentsByShortHash sh
 
       basicPrettyPrintNames0 =
         Backend.basicPrettyPrintNames0 root' (Path.unabsolute currentPath')
@@ -560,61 +548,57 @@ loop = do
         -- `mdValues` is (names of the) metadata to pass to `op`
         -- `op` is the operation to add/remove/alter metadata mappings.
         --   e.g. `Metadata.insert` is passed to add metadata links.
-        manageLinks :: Bool
-                    -> [(Path', HQ'.HQSegment)]
-                    -> [HQ.HashQualified Name]
-                    -> (forall r. Ord r
-                        => (r, Metadata.Type, Metadata.Value)
-                        ->  Branch.Star r NameSegment
-                        ->  Branch.Star r NameSegment)
-                    -> Action m (Either Event Input) v ()
+        manageLinks ::
+          Bool ->
+          [(Path', HQ'.HQSegment)] ->
+          [HQ.HashQualified Name] ->
+          ( forall r.
+            Ord r =>
+            (r, Metadata.Type, Metadata.Value) ->
+            Branch.Star r NameSegment ->
+            Branch.Star r NameSegment
+          ) ->
+          Action m (Either Event Input) v ()
         manageLinks silent srcs mdValues op = do
-          mdValuels <- fmap (first toList) <$>
-            traverse (\x -> fmap (,x) (getHQTerms x)) mdValues
-          before <- Branch.head <$> use root
-          traverse_ go mdValuels
-          after  <- Branch.head <$> use root
-          (ppe, outputDiff) <- diffHelper before after
-          if not silent then
-            if OBranchDiff.isEmpty outputDiff
-            then respond NoOp
-            else respondNumbered $ ShowDiffNamespace Path.absoluteEmpty
-                                                     Path.absoluteEmpty
-                                                     ppe
-                                                     outputDiff
-          else unless (OBranchDiff.isEmpty outputDiff) $
-                 respond DefaultMetadataNotification
+          runExceptT (for mdValues \val -> ExceptT (getMetadataFromName val)) >>= \case
+            Left output -> respond output
+            Right metadata -> do
+              before <- Branch.head <$> use root
+              traverse_ go metadata
+              if silent
+                then respond DefaultMetadataNotification
+                else do
+                  after <- Branch.head <$> use root
+                  (ppe, outputDiff) <- diffHelper before after
+                  if OBranchDiff.isEmpty outputDiff
+                    then respond NoOp
+                    else
+                      respondNumbered $
+                        ShowDiffNamespace
+                          Path.absoluteEmpty
+                          Path.absoluteEmpty
+                          ppe
+                          outputDiff
           where
-            go (mdl, hqn) = do
+            go :: (Metadata.Type, Metadata.Value) -> Action m (Either Event Input) v ()
+            go (mdType, mdValue) = do
               newRoot <- use root
               let r0 = Branch.head newRoot
                   getTerms p = BranchUtil.getTerm (resolveSplit' p) r0
                   getTypes p = BranchUtil.getType (resolveSplit' p) r0
                   !srcle = toList . getTerms =<< srcs
                   !srclt = toList . getTypes =<< srcs
-                  ppe = Backend.basicSuffixifiedNames
-                          sbhLength
-                          newRoot
-                          (Path.unabsolute currentPath')
-              case mdl of
-                [r@(Referent.Ref mdValue)] -> do
-                  mdType <- eval $ LoadTypeOfTerm mdValue
-                  case mdType of
-                    Nothing -> respond $ MetadataMissingType ppe r
-                    Just ty -> do
-                      let steps =
-                            bimap (Path.unabsolute . resolveToAbsolute)
-                                  (const . step $ Hashing.typeToReference ty)
-                              <$> srcs
-                      stepManyAtNoSync steps
-                 where
-                  step mdType b0 =
+              let step b0 =
                     let tmUpdates terms = foldl' go terms srcle
-                            where go terms src = op (src, mdType, mdValue) terms
+                          where
+                            go terms src = op (src, mdType, mdValue) terms
                         tyUpdates types = foldl' go types srclt
-                            where go types src = op (src, mdType, mdValue) types
-                    in  over Branch.terms tmUpdates . over Branch.types tyUpdates $ b0
-                mdValues -> respond $ MetadataAmbiguous hqn ppe mdValues
+                          where
+                            go types src = op (src, mdType, mdValue) types
+                     in over Branch.terms tmUpdates . over Branch.types tyUpdates $ b0
+                  steps = srcs <&> \(path, _hq) -> (Path.unabsolute (resolveToAbsolute path), step)
+              stepManyAtNoSync steps
+
         delete
           :: (Path.HQSplit' -> Set Referent) -- compute matching terms
           -> (Path.HQSplit' -> Set Reference) -- compute matching types
@@ -1692,8 +1676,8 @@ loop = do
           b <- importRemoteBranch ns syncMode
           let msg = Just $ PullAlreadyUpToDate ns path
           let destAbs = resolveToAbsolute path
-          let printDiffPath = if Verbosity.isSilent verbosity then Nothing else Just path 
-          lift $ mergeBranchAndPropagateDefaultPatch Branch.RegularMerge inputDescription msg b printDiffPath destAbs 
+          let printDiffPath = if Verbosity.isSilent verbosity then Nothing else Just path
+          lift $ mergeBranchAndPropagateDefaultPatch Branch.RegularMerge inputDescription msg b printDiffPath destAbs
 
       PushRemoteBranchI mayRepo path syncMode -> do
         let srcAbs = resolveToAbsolute path
@@ -2219,7 +2203,7 @@ mergeBranchAndPropagateDefaultPatch mode inputDescription unchangedMessage srcb 
     destb <- getAt dest
     merged <- eval $ Merge mode srcb destb
     b <- updateAtM inputDescription dest (const $ pure merged)
-    for_ dest0 $ \dest0 -> 
+    for_ dest0 $ \dest0 ->
       diffHelper (Branch.head destb) (Branch.head merged) >>=
         respondNumbered . uncurry (ShowDiffAfterMerge dest0 dest)
     pure b
@@ -2235,6 +2219,56 @@ loadPropagateDiffDefaultPatch inputDescription dest0 dest = unsafeTime "Propagat
       let patchPath = snoc dest0 defaultPatchNameSegment
       diffHelper (Branch.head original) (Branch.head patched) >>=
         respondNumbered . uncurry (ShowDiffAfterMergePropagate dest0 dest patchPath)
+
+-- | Get metadata type/value from a name.
+--
+-- May fail with either:
+--
+--   * 'MetadataMissingType', if the given name is associated with a single reference, but that reference doesn't have a
+--     type.
+--   * 'MetadataAmbiguous', if the given name is associated with more than one reference.
+getMetadataFromName ::
+  Var v =>
+  HQ.HashQualified Name ->
+  Action m (Either Event Input) v (Either (Output v) (Metadata.Type, Metadata.Value))
+getMetadataFromName name = do
+  (Set.toList <$> getHQTerms name) >>= \case
+    [ref@(Referent.Ref val)] ->
+      eval (LoadTypeOfTerm val) >>= \case
+        Nothing -> do
+          ppe <- getPPE
+          pure (Left (MetadataMissingType ppe ref))
+        Just ty -> pure (Right (Hashing.typeToReference ty, val))
+    -- FIXME: we want a different error message if the given name is associated with a data constructor (`Con`).
+    refs -> do
+      ppe <- getPPE
+      pure (Left (MetadataAmbiguous name ppe refs))
+  where
+    getPPE :: Action m (Either Event Input) v PPE.PrettyPrintEnv
+    getPPE = do
+      currentPath' <- use currentPath
+      sbhLength <- eval BranchHashLength
+      Backend.basicSuffixifiedNames sbhLength <$> use root <*> pure (Path.unabsolute currentPath')
+
+-- | Get the set of terms related to a hash-qualified name.
+getHQTerms :: HQ.HashQualified Name -> Action' m v (Set Referent)
+getHQTerms = \case
+  HQ.NameOnly n -> do
+    root0 <- Branch.head <$> use root
+    currentPath' <- use currentPath
+    -- absolute-ify the name, then lookup in deepTerms of root
+    let path =
+          n
+            & Path.fromName'
+            & Path.resolve currentPath'
+            & Path.unabsolute
+            & Path.toName
+    pure $ R.lookupRan path (Branch.deepTerms root0)
+  HQ.HashOnly sh -> hashOnly sh
+  HQ.HashQualified _ sh -> hashOnly sh
+  where
+    hashOnly sh = eval $ TermReferentsByShortHash sh
+
 
 getAt :: Functor m => Path.Absolute -> Action m i v (Branch m)
 getAt (Path.Absolute p) =

--- a/unison-core/src/Unison/Util/Relation.hs
+++ b/unison-core/src/Unison/Util/Relation.hs
@@ -112,23 +112,11 @@ outerJoinRanMultimaps :: (Ord a, Ord b, Ord c)
                       -> Map c (Set a, Set b)
 outerJoinRanMultimaps a b = outerJoinDomMultimaps (swap a) (swap b)
 
--- | @innerJoinDomMultimaps xs ys@ returns the "inner join" of the domains of @xs@ and @ys@.
+-- | @innerJoinDomMultimaps xs ys@ returns the "inner join" of the domains of @xs@ and @ys@, which has intersection-like
+-- semantics:
 --
--- You can think of this function as having the following, higher-level type:
---
--- @
--- innertJoinDomMultimaps
---   :: (Ord a, Ord b, Ord c)
---   => Relation a b
---   => Relation a c
---   => Relation a (Either b c)
--- @
---
--- with the invariant on the output relation that no @a@ will be related to /only/ @Left b@s or @Right c@s; rather, each
--- @a@ will be related to at least one @Left b@ and at least one @Right c@.
---
--- However, this function returns a lower-level @Map a (Set b, Set c)@ instead, for performance reasons, because the
--- calling code currently does not have a need for the higher-level relation.
+-- * @a@s that do not exist in both @xs@ and @ys@ are dropped.
+-- * The @a@s that remain are therefore associated with non-empty sets of @b@s and @c@s.
 --
 -- /O(a2 * log(a1/a2 + 1)), a1 <= a2/, where /a1/ and /a2/ are the numbers of elements in each relation's domain.
 innerJoinDomMultimaps ::
@@ -139,9 +127,10 @@ innerJoinDomMultimaps ::
 innerJoinDomMultimaps b c =
   Map.intersectionWith (,) (domain b) (domain c)
 
--- | @innerJoinRanMultimaps xs ys@ returns the "inner join" of the ranges of @xs@ and @ys@.
+-- | @innerJoinRanMultimaps xs ys@ returns the "inner join" of the ranges of @xs@ and @ys@. See 'innerJoinDomMultimaps'
+-- for more info.
 --
--- See 'innerJoinDomMultimaps'; this function has identical performance.
+-- /O(c2 * log(c1/c2 + 1)), c1 <= c2/, where /c1/ and /c2/ are the numbers of elements in each relation's range.
 innerJoinRanMultimaps :: (Ord a, Ord b, Ord c)
                       => Relation a c
                       -> Relation b c

--- a/unison-src/transcripts/ambiguous-metadata.output.md
+++ b/unison-src/transcripts/ambiguous-metadata.output.md
@@ -37,6 +37,4 @@ x = 1
   Tip: Try again and supply one of the above definitions
        explicitly.
 
-  I didn't make any changes.
-
 ```


### PR DESCRIPTION
## Overview

This PR improves the performance of `add` in the case that there is default metadata to add.

## Implementation notes

Previously, if there was any default metadata to add to each of the new types/terms, `add` would:

- For each different stringy name of metadata (e.g. ".metadata.authors.mitchell"), 
  - Resolve it to an unambiguous term, and look up that term's type.
  - If that worked, add the metadata type/value to the branch for each new type/term
- Diff the current branch with the one prior to (possibly) adding any metadata
- If anything changed, report "I added some metadata" to the terminal

Since we are (currently) just reporting whether we add any metadata at all, this algorithm could be improved by eliding the full branch diff, which is slow. Instead, we (almost) know that by calling the "add metadata" function at all, we have metadata to add to each type/term, and we can just report "I added some metadata" anyway.

## Interesting/controversial decisions

Small change in behavior: 

Previously, default metadata would be added to a type/term on a best-effort basis. For example, if I have two default metadata names "A" and "B", but only "A" names a real term whereas "B" does not, then newly-added types/terms would still be linked to metadata "A".

Now, if any of the default metadata names do not refer to a term, no metadata is added to a term.

This change was only made because it made the implementation simpler, and didn't seem significantly or semantically worse than the existing mechanism. However, if we actually intended for "partial" metadata to be added to new types/terms in the way described above, the implementation can change.

## Test coverage

No new automated tests, but I tested this manually, and I'm sure the existing tests cover any potential bugs.
