### PR TITLE
Updates version-parser for release tags

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/VersionParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/VersionParser.hs
@@ -11,16 +11,18 @@ import qualified Data.Text as Text
 import qualified Unison.Codebase.Path as Path
 import Data.Void (Void)
 
--- |"release/M1j.2" -> "releases._M1j"
---  "latest-*" -> "trunk"
+-- | Parse git version strings into valid unison namespaces.
+--   "release/M1j" -> "releases._M1j"
+--   "release/M1j.2" -> "releases._M1j_2"
+--   "latest-*" -> "trunk"
 defaultBaseLib :: Parsec Void Text ReadRemoteNamespace
 defaultBaseLib = fmap makeNS $ latest <|> release
   where
   latest, release, version :: Parsec Void Text Text
   latest = "latest-" *> many anyChar *> eof $> "trunk"
   release = fmap ("releases._" <>) $ "release/" *> version <* eof
-  version = fmap Text.pack $
-              try (someTill anyChar "." <* many anyChar) <|> many anyChar
+  version = do
+    Text.pack <$> some (alphaNumChar <|> ('_' <$ oneOf ['.', '_', '-']))
   makeNS :: Text -> ReadRemoteNamespace
   makeNS t = ( ReadGitRepo "https://github.com/unisonweb/base"
              , Nothing

--- a/parser-typechecker/src/Unison/CommandLine/Welcome.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Welcome.hs
@@ -49,11 +49,11 @@ welcome initStatus downloadBase filePath unisonVersion =
   Welcome (Init initStatus) downloadBase filePath unisonVersion
 
 pullBase :: ReadRemoteNamespace -> Either Event Input
-pullBase _ns = let
+pullBase ns = let
     seg = NameSegment "base"
     rootPath = Path.Path { Path.toSeq = singleton seg }
     abs = Path.Absolute {Path.unabsolute = rootPath}
-    pullRemote = PullRemoteBranchI (Just _ns) (Path.Path' {Path.unPath' = Left abs}) SyncMode.Complete Verbosity.Silent
+    pullRemote = PullRemoteBranchI (Just ns) (Path.Path' {Path.unPath' = Left abs}) SyncMode.Complete Verbosity.Silent
   in Right pullRemote
 
 run :: Codebase IO v a -> Welcome -> IO [Either Event Input]

--- a/parser-typechecker/tests/Unison/Test/VersionParser.hs
+++ b/parser-typechecker/tests/Unison/Test/VersionParser.hs
@@ -12,8 +12,10 @@ import Text.Megaparsec
 test :: Test ()
 test = scope "versionparser" . tests . fmap makeTest $
   [ ("release/M1j", "releases._M1j")
-  , ("release/M1j.2", "releases._M1j")
+  , ("release/M1j.2", "releases._M1j_2")
   , ("latest-abc", "trunk")
+  , ("release/M2i_3", "releases._M2i_3")
+  , ("release/M2i-HOTFIX", "releases._M2i_HOTFIX")
   ]
 
 makeTest :: (Text, Text) -> Test ()

--- a/parser-typechecker/unison/Main.hs
+++ b/parser-typechecker/unison/Main.hs
@@ -66,7 +66,7 @@ main = do
   -- hSetBuffering stdout NoBuffering -- cool
 
   void installSignalHandlers
-  (renderUsageInfo, globalOptions, command) <- parseCLIArgs progName Version.gitDescribe
+  (renderUsageInfo, globalOptions, command) <- parseCLIArgs progName Version.gitDescribeWithDate
   let GlobalOptions{codebasePathOption=mCodePathOption} = globalOptions
   let mcodepath = fmap codebasePathOptionToPath mCodePathOption
 
@@ -77,7 +77,7 @@ main = do
       Exit.die "Your .unisonConfig could not be loaded. Check that it's correct!"
   case command of
      PrintVersion ->
-       putStrLn $ progName ++ " version: " ++ Version.gitDescribe
+       putStrLn $ progName ++ " version: " ++ Version.gitDescribeWithDate
      Init -> do 
       PT.putPrettyLn $ 
         P.callout 
@@ -259,7 +259,8 @@ launch dir config runtime codebase inputs serverBaseUrl shouldDownloadBase initR
       CreatedCodebase{} -> NewlyCreatedCodebase
       _ -> PreviouslyCreatedCodebase 
       
-    welcome = Welcome.welcome isNewCodebase downloadBase dir Version.gitDescribe
+    (gitRef, _date) = Version.gitDescribe
+    welcome = Welcome.welcome isNewCodebase downloadBase dir gitRef
   in
     CommandLine.main
       dir
@@ -290,7 +291,9 @@ getConfigFilePath mcodepath = (FP.</> ".unisonConfig") <$> Codebase.getCodebaseD
 
 defaultBaseLib :: Maybe ReadRemoteNamespace
 defaultBaseLib = rightMay $
-  runParser VP.defaultBaseLib "version" (Text.pack Version.gitDescribe)
+  runParser VP.defaultBaseLib "version" (Text.pack gitRef)
+  where
+    (gitRef, _date) = Version.gitDescribe
 -- (Unison.Codebase.Init.FinalizerAndCodebase IO Symbol Ann, InitResult IO Symbol Ann)
 getCodebaseOrExit :: Maybe CodebasePathOption -> IO ((IO (), Codebase.Codebase IO Symbol Ann), InitResult IO Symbol Ann)
 getCodebaseOrExit codebasePathOption = do

--- a/parser-typechecker/unison/Version.hs
+++ b/parser-typechecker/unison/Version.hs
@@ -3,23 +3,37 @@
 
 module Version where
 
-import Language.Haskell.TH (runIO)
+import Language.Haskell.TH (runIO, Exp(TupE))
 import Language.Haskell.TH.Syntax (Exp(LitE), Lit(StringL))
 import Shellmet
 import Data.Text
 
+-- | A formatted descriptor of when and against which commit this unison executable was built
+-- E.g. latest-149-g5cef8f851 (built on 2021-10-04)
+--      release/M2i (built on 2021-10-05)
+gitDescribeWithDate :: String
+gitDescribeWithDate = 
+  let formatDate d = " (built on " <> d <> ")"
+      (gitRef, date) = gitDescribe
+  in gitRef <> formatDate date
+
+
+type CommitDate = String
+type GitRef = String
+
 -- | Uses Template Haskell to embed a git descriptor of the commit 
 --   which was used to build the executable.
-gitDescribe :: String
-gitDescribe = $( fmap (LitE . StringL . unpack) . runIO $ do
-  let formatDate d = " (built on " <> d <> ")"
+-- E.g. latest-149-g5cef8f851 (built on 2021-10-04)
+--      release/M2i (built on 2021-10-05)
+gitDescribe :: (GitRef, CommitDate)
+gitDescribe = $( runIO $ do
   -- Outputs date of current commit; E.g. 2021-08-06
   let getDate = "git" $| ["show", "-s", "--format=%cs"]
-  date <- (formatDate <$> getDate) $? pure ""
+  date <- getDate $? pure ""
   -- Fetches a unique tag-name to represent the current commit.
   -- Uses human-readable names whenever possible.
   -- Marks version with a `'` suffix if building on a dirty worktree.
   let getTag = "git" $| ["describe", "--tags", "--always", "--dirty='"]
   tag <- getTag $? pure "unknown"
-  pure (tag <> date)
+  pure (TupE [Just . LitE . StringL . unpack $ tag, Just . LitE . StringL . unpack $ date])
   )


### PR DESCRIPTION
Changes to the version-parser to support base-downloads when given official release versions. 
With author: @ChrisPenner🚀  ⭐ 

## Overview

Stops including the date built in the base version passed to base download. 

## Implementation notes

Parser changes - returning a tuple instead of a concatenated string with date.

## Test coverage

Tests were updated/added
