### PR TITLE
Use consistent disambiguation table for all ambiguous type/term errors.

### DIFF
--- a/parser-typechecker/src/Unison/Hashing/V1/Convert.hs
+++ b/parser-typechecker/src/Unison/Hashing/V1/Convert.hs
@@ -39,12 +39,13 @@ import qualified Unison.Term as Memory.Term
 import qualified Unison.Type as Memory.Type
 import Unison.Var (Var)
 import qualified Data.Set as Set
+import qualified Unison.Names3 as Names3
 
 data ResolutionFailure v a
-  = TermResolutionFailure v a (Names.ResolutionError Memory.Referent.Referent)
-  | TypeResolutionFailure v a (Names.ResolutionError Memory.Reference.Reference)
+  = TermResolutionFailure v a Names3.Names (Set.Set Memory.Referent.Referent)
+  | TypeResolutionFailure v a Names3.Names (Set.Set Memory.Reference.Reference)
   | CycleResolutionFailure Hash
-  deriving (Eq, Ord, Show)
+  deriving (Show)
 
 type ResolutionResult v a r = Validate (Seq (ResolutionFailure v a)) r
 
@@ -56,8 +57,8 @@ convertResolutionResult = \case
   Right a -> pure a
   where
     f = \case
-      Names.TermResolutionFailure v a err -> TermResolutionFailure v a err
-      Names.TypeResolutionFailure v a err -> TypeResolutionFailure v a err
+      Names.TermResolutionFailure v a names refs -> TermResolutionFailure v a refs names
+      Names.TypeResolutionFailure v a names refs -> TypeResolutionFailure v a refs names
 
 typeToReference ::
   Var v =>

--- a/parser-typechecker/src/Unison/Hashing/V1/Type.hs
+++ b/parser-typechecker/src/Unison/Hashing/V1/Type.hs
@@ -71,7 +71,7 @@ bindReferences keepFree ns t = let
   fvs = ABT.freeVarOccurrences keepFree t
   rs = [(v, a, Map.lookup (Name.fromVar v) ns) | (v, a) <- fvs]
   ok (v, _a, Just r) = pure (v, r)
-  ok (v, a, Nothing) = Left (pure (Names.TypeResolutionFailure v a Names.NotFound))
+  ok (v, a, Nothing) = Left (pure (Names.TypeResolutionFailure v a mempty mempty))
   in List.validate ok rs <&> \es -> bindExternal es t
 
 bindNames
@@ -84,7 +84,7 @@ bindNames keepFree ns t = let
   fvs = ABT.freeVarOccurrences keepFree t
   rs = [(v, a, Map.lookup (Name.fromVar v) ns) | (v, a) <- fvs]
   ok (v, _a, Just r) = pure (v, r)
-  ok (v, a, Nothing) = Left (pure (Names.TypeResolutionFailure v a Names.NotFound))
+  ok (v, a, Nothing) = Left (pure (Names.TypeResolutionFailure v a mempty mempty))
   in List.validate ok rs <&> \es -> bindExternal es t
 
 newtype Monotype v a = Monotype { getPolytype :: Type v a } deriving Eq

--- a/parser-typechecker/src/Unison/Hashing/V2/Type.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Type.hs
@@ -71,7 +71,7 @@ bindReferences keepFree ns t = let
   fvs = ABT.freeVarOccurrences keepFree t
   rs = [(v, a, Map.lookup (Name.fromVar v) ns) | (v, a) <- fvs]
   ok (v, _a, Just r) = pure (v, r)
-  ok (v, a, Nothing) = Left (pure (Names.TypeResolutionFailure v a Names.NotFound))
+  ok (v, a, Nothing) = Left (pure (Names.TypeResolutionFailure v a mempty mempty))
   in List.validate ok rs <&> \es -> bindExternal es t
 
 bindNames
@@ -84,7 +84,7 @@ bindNames keepFree ns t = let
   fvs = ABT.freeVarOccurrences keepFree t
   rs = [(v, a, Map.lookup (Name.fromVar v) ns) | (v, a) <- fvs]
   ok (v, _a, Just r) = pure (v, r)
-  ok (v, a, Nothing) = Left (pure (Names.TypeResolutionFailure v a Names.NotFound))
+  ok (v, a, Nothing) = Left (pure (Names.TypeResolutionFailure v a mempty mempty))
   in List.validate ok rs <&> \es -> bindExternal es t
 
 newtype Monotype v a = Monotype { getPolytype :: Type v a } deriving Eq

--- a/parser-typechecker/src/Unison/Parser.hs
+++ b/parser-typechecker/src/Unison/Parser.hs
@@ -108,8 +108,8 @@ data Error v
   | EmptyBlock (L.Token String)
   | UnknownAbilityConstructor (L.Token (HQ.HashQualified Name)) (Set (Reference, Int))
   | UnknownDataConstructor (L.Token (HQ.HashQualified Name)) (Set (Reference, Int))
-  | UnknownTerm (L.Token (HQ.HashQualified Name)) (Set Referent)
-  | UnknownType (L.Token (HQ.HashQualified Name)) (Set Reference)
+  | UnknownTerm Names (L.Token (HQ.HashQualified Name)) (Set Referent)
+  | UnknownType Names (L.Token (HQ.HashQualified Name)) (Set Reference)
   | UnknownId (L.Token (HQ.HashQualified Name)) (Set Referent) (Set Reference)
   | ExpectedBlockOpen String (L.Token L.Lexeme)
   | EmptyMatch

--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -87,7 +87,7 @@ typeLink' = do
   ns <- asks names
   case Names.lookupHQType (L.payload id) ns of
     s | Set.size s == 1 -> pure $ const (Set.findMin s) <$> id
-      | otherwise       -> customFailure $ UnknownType id s
+      | otherwise       -> customFailure $ UnknownType ns id s
 
 termLink' :: Var v => P v (L.Token Referent)
 termLink' = do
@@ -95,7 +95,7 @@ termLink' = do
   ns <- asks names
   case Names.lookupHQTerm (L.payload id) ns of
     s | Set.size s == 1 -> pure $ const (Set.findMin s) <$> id
-      | otherwise       -> customFailure $ UnknownTerm id s
+      | otherwise       -> customFailure $ UnknownTerm ns id s
 
 link' :: Var v => P v (Either (L.Token Reference) (L.Token Referent))
 link' = do
@@ -360,8 +360,8 @@ resolveHashQualified tok = do
   case L.payload tok of
     HQ.NameOnly n -> pure $ Term.var (ann tok) (Name.toVar n)
     _ -> case Names.lookupHQTerm (L.payload tok) names of
-      s | Set.null s     -> failCommitted $ UnknownTerm tok s
-        | Set.size s > 1 -> failCommitted $ UnknownTerm tok s
+      s | Set.null s     -> failCommitted $ UnknownTerm names tok s
+        | Set.size s > 1 -> failCommitted $ UnknownTerm names tok s
         | otherwise      -> pure $ Term.fromReferent (ann tok) (Set.findMin s)
 
 termLeaf :: forall v . Var v => TermP v

--- a/parser-typechecker/src/Unison/TypeParser.hs
+++ b/parser-typechecker/src/Unison/TypeParser.hs
@@ -45,7 +45,7 @@ typeAtom = hqPrefixId >>= \tok -> case L.payload tok of
     names <- asks names
     let matches = Names.lookupHQType hq names
     if Set.size matches /= 1
-    then P.customFailure (UnknownType tok matches)
+    then P.customFailure (UnknownType names tok matches)
     else pure $ Type.ref (ann tok) (Set.findMin matches)
 
 type1 :: Var v => TypeP v

--- a/parser-typechecker/src/Unison/Util/Pretty.hs
+++ b/parser-typechecker/src/Unison/Util/Pretty.hs
@@ -33,6 +33,7 @@ module Unison.Util.Pretty (
    column2M,
    column2UnzippedM,
    column3,
+   column3Header,
    column3M,
    column3UnzippedM,
    column3sep,
@@ -575,6 +576,16 @@ column3
   => [(Pretty s, Pretty s, Pretty s)]
   -> Pretty s
 column3 = column3sep ""
+
+-- | Construct a 3 column table with the provided headers.
+column3Header ::
+  Pretty ColorText ->
+  Pretty ColorText ->
+  Pretty ColorText ->
+  [(Pretty ColorText, Pretty ColorText, Pretty ColorText)] ->
+  Pretty ColorText
+column3Header left middle right = 
+  column3sep "  " . ((hiBlack left, hiBlack middle, hiBlack right):)
 
 column3M
   :: (LL.ListLike s Char, IsString s, Monad m)

--- a/unison-core/src/Unison/Names/ResolutionResult.hs
+++ b/unison-core/src/Unison/Names/ResolutionResult.hs
@@ -7,30 +7,23 @@ module Unison.Names.ResolutionResult where
 import Unison.Prelude
 import Unison.Reference as Reference ( Reference )
 import Unison.Referent as Referent ( Referent )
-import Unison.Names3 (Names0)
-import Data.Set.NonEmpty
-
-data ResolutionError ref
-  = NotFound
-    -- Contains the names which were in scope and which refs were possible options
-    -- The NonEmpty set of refs must contain 2 or more refs (otherwise what is ambiguous?).
-  | Ambiguous Names0 (NESet ref)
-  deriving (Eq, Ord, Show)
+import qualified Data.Set as Set
+import Unison.Names3 (Names)
 
 -- | ResolutionFailure represents the failure to resolve a given variable.
 data ResolutionFailure var annotation
-  = TypeResolutionFailure var annotation (ResolutionError Reference)
-  | TermResolutionFailure var annotation (ResolutionError Referent)
-  deriving (Eq, Ord, Show)
+  = TypeResolutionFailure var annotation (Set.Set Reference) Names
+  | TermResolutionFailure var annotation (Set.Set Referent) Names
+  deriving (Show, Eq, Ord)
 
 getAnnotation :: ResolutionFailure v a -> a
 getAnnotation = \case
-  TypeResolutionFailure _ a _ -> a
-  TermResolutionFailure _ a _ -> a
+  TypeResolutionFailure _ a _ _ -> a
+  TermResolutionFailure _ a _ _ -> a
 
 getVar :: ResolutionFailure v a -> v
 getVar = \case
-  TypeResolutionFailure v _ _ -> v
-  TermResolutionFailure v _ _ -> v
+  TypeResolutionFailure v _ _ _ -> v
+  TermResolutionFailure v _ _ _ -> v
 
 type ResolutionResult v a r = Either (Seq (ResolutionFailure v a)) r

--- a/unison-core/src/Unison/Names3.hs
+++ b/unison-core/src/Unison/Names3.hs
@@ -33,7 +33,13 @@ data Names = Names
     -- context to users rather than just a hash.
     oldNames :: Names0
   }
-  deriving (Show)
+  deriving (Show, Eq, Ord)
+
+instance Semigroup Names where
+  Names a1 b1 <> Names a2 b2  = Names (a1 <> a2) (b1 <> b2)
+
+instance Monoid Names where
+  mempty = Names mempty mempty
 
 type Names0 = Unison.Names2.Names0
 pattern Names0 :: Relation n Referent -> Relation n Reference -> Names.Names' n

--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -44,7 +44,6 @@ import Unsafe.Coerce (unsafeCoerce)
 import qualified Unison.Name as Name
 import qualified Unison.LabeledDependency as LD
 import Unison.LabeledDependency (LabeledDependency)
-import qualified Data.Set.NonEmpty as NES
 
 data MatchCase loc a = MatchCase (Pattern loc) (Maybe a) a
   deriving (Show,Eq,Foldable,Functor,Generic,Generic1,Traversable)
@@ -129,14 +128,10 @@ bindNames keepFreeTerms ns0 e = do
       okTm (v,a) = case Names.lookupHQTerm (Name.convert $ Name.fromVar v) ns of
         rs | Set.size rs == 1 ->
                pure (v, fromReferent a $ Set.findMin rs)
-           | otherwise -> case NES.nonEmptySet rs of
-               Nothing -> Left (pure (Names.TermResolutionFailure v a Names.NotFound))
-               Just refs -> Left (pure (Names.TermResolutionFailure v a (Names.Ambiguous ns0 refs)))
+           | otherwise -> Left (pure (Names.TermResolutionFailure v a rs ns))
       okTy (v,a) = case Names.lookupHQType (Name.convert $ Name.fromVar v) ns of
         rs | Set.size rs == 1 -> pure (v, Type.ref a $ Set.findMin rs)
-           | otherwise -> case NES.nonEmptySet rs of
-               Nothing -> Left (pure (Names.TypeResolutionFailure v a Names.NotFound))
-               Just refs -> Left (pure (Names.TypeResolutionFailure v a (Names.Ambiguous ns0 refs)))
+           | otherwise -> Left (pure (Names.TypeResolutionFailure v a rs ns))
   termSubsts <- validate okTm freeTmVars
   typeSubsts <- validate okTy freeTyVars
   pure . substTypeVars typeSubsts . ABT.substsInheritAnnotation termSubsts $ e

--- a/unison-core/src/Unison/Type.hs
+++ b/unison-core/src/Unison/Type.hs
@@ -68,7 +68,7 @@ bindReferences keepFree ns t = let
   fvs = ABT.freeVarOccurrences keepFree t
   rs = [(v, a, Map.lookup (Name.fromVar v) ns) | (v, a) <- fvs]
   ok (v, _a, Just r) = pure (v, r)
-  ok (v, a, Nothing) = Left (pure (Names.TypeResolutionFailure v a Names.NotFound))
+  ok (v, a, Nothing) = Left (pure (Names.TypeResolutionFailure v a mempty mempty))
   in List.validate ok rs <&> \es -> bindExternal es t
 
 newtype Monotype v a = Monotype { getPolytype :: Type v a } deriving Eq

--- a/unison-core/src/Unison/Type/Names.hs
+++ b/unison-core/src/Unison/Type/Names.hs
@@ -17,7 +17,6 @@ import qualified Unison.Names3 as Names
 import qualified Unison.Names.ResolutionResult as Names
 import qualified Unison.Name as Name
 import qualified Unison.Util.List as List
-import qualified Data.Set.NonEmpty as NES
 
 bindNames
   :: Var v
@@ -32,8 +31,5 @@ bindNames keepFree ns0 t = let
   ok (v, a, rs) = 
     if Set.size rs == 1 
        then pure (v, Set.findMin rs)
-       else 
-         case NES.nonEmptySet rs of
-           Nothing -> Left (pure (Names.TypeResolutionFailure v a Names.NotFound))
-           Just rs' -> Left (pure (Names.TypeResolutionFailure v a (Names.Ambiguous ns0 rs')))
+       else Left (pure (Names.TypeResolutionFailure v a rs ns))
   in List.validate ok rs <&> \es -> bindExternal es t

--- a/unison-src/transcripts/resolution-failures.md
+++ b/unison-src/transcripts/resolution-failures.md
@@ -16,8 +16,15 @@ Now let's add a term named `a.foo`:
 unique type one.AmbiguousType = one.AmbiguousType
 unique type two.AmbiguousType = two.AmbiguousType
 
-one.ambiguousTerm = "term one"
-two.ambiguousTerm = "term two"
+one.ambiguousTextTerm = "term one"
+two.ambiguousTextTerm = "term two"
+
+unique type A = One | Two
+unique type B = B
+
+one.ambiguousTermWithDifferingTypes = One
+two.ambiguousTermWithDifferingTypes = Two
+three.ambiguousTermWithDifferingTypes = B
 ```
 
 ```ucm
@@ -52,5 +59,15 @@ Currently, ambiguous terms are caught and handled by type directed name resoluti
 but expect it to eventually be handled by the above machinery.
 
 ```unison:error
-useAmbiguousTerm = ambiguousTerm
+useAmbiguousTextTermNoTypeHint = ambiguousTextTerm
+```
+
+```unison:error
+useAmbiguousTermWithDifferingTypes = ambiguousTermWithDifferingTypes
+```
+
+```unison:error
+useAmbiguousTermWithDifferingTypesWithTypeHint : A
+useAmbiguousTermWithDifferingTypesWithTypeHint 
+  = ambiguousTermWithDifferingTypes
 ```

--- a/unison-src/transcripts/resolution-failures.output.md
+++ b/unison-src/transcripts/resolution-failures.output.md
@@ -18,8 +18,15 @@ Now let's add a term named `a.foo`:
 unique type one.AmbiguousType = one.AmbiguousType
 unique type two.AmbiguousType = two.AmbiguousType
 
-one.ambiguousTerm = "term one"
-two.ambiguousTerm = "term two"
+one.ambiguousTextTerm = "term one"
+two.ambiguousTextTerm = "term two"
+
+unique type A = One | Two
+unique type B = B
+
+one.ambiguousTermWithDifferingTypes = One
+two.ambiguousTermWithDifferingTypes = Two
+three.ambiguousTermWithDifferingTypes = B
 ```
 
 ```ucm
@@ -30,10 +37,15 @@ two.ambiguousTerm = "term two"
   
     ⍟ These new definitions are ok to `add`:
     
+      unique type A
+      unique type B
       unique type one.AmbiguousType
       unique type two.AmbiguousType
-      one.ambiguousTerm : ##Text
-      two.ambiguousTerm : ##Text
+      one.ambiguousTermWithDifferingTypes   : A
+      one.ambiguousTextTerm                 : ##Text
+      three.ambiguousTermWithDifferingTypes : B
+      two.ambiguousTermWithDifferingTypes   : A
+      two.ambiguousTextTerm                 : ##Text
 
 ```
 ```ucm
@@ -41,10 +53,15 @@ two.ambiguousTerm = "term two"
 
   ⍟ I've added these definitions:
   
+    unique type A
+    unique type B
     unique type one.AmbiguousType
     unique type two.AmbiguousType
-    one.ambiguousTerm : ##Text
-    two.ambiguousTerm : ##Text
+    one.ambiguousTermWithDifferingTypes   : A
+    one.ambiguousTextTerm                 : ##Text
+    three.ambiguousTermWithDifferingTypes : B
+    two.ambiguousTermWithDifferingTypes   : A
+    two.ambiguousTextTerm                 : ##Text
 
 ```
 ## Tests
@@ -88,12 +105,12 @@ separateAmbiguousTypeUsage _ = ()
        10 | separateAmbiguousTypeUsage : AmbiguousType -> ()
     
     
-    Symbol          Suggestions
-                    
-    AmbiguousType   one.AmbiguousType
-                    two.AmbiguousType
-                    
-    UnknownType     No matches
+    Symbol          Suggestions         
+                                        
+    AmbiguousType   one.AmbiguousType   
+                    two.AmbiguousType   
+                                        
+    UnknownType     No matches          
   
 
 ```
@@ -101,18 +118,59 @@ Currently, ambiguous terms are caught and handled by type directed name resoluti
 but expect it to eventually be handled by the above machinery.
 
 ```unison
-useAmbiguousTerm = ambiguousTerm
+useAmbiguousTextTermNoTypeHint = ambiguousTextTerm
 ```
 
 ```ucm
 
-  I'm not sure what ambiguousTerm means at line 1, columns 20-33
+  I'm not sure what ambiguousTextTerm means at line 1, columns 34-51
   
-      1 | useAmbiguousTerm = ambiguousTerm
+      1 | useAmbiguousTextTermNoTypeHint = ambiguousTextTerm
   
-  There are no constraints on its type.I found some terms in scope that have matching names and types. Maybe you meant one of these:
+  There are no constraints on its type.
   
-    - one.ambiguousTerm : ##Text
-    - two.ambiguousTerm : ##Text
+  Symbol              Suggestions             Type
+                                              
+  ambiguousTextTerm   one.ambiguousTextTerm   ##Text
+                      two.ambiguousTextTerm   ##Text
+
+```
+```unison
+useAmbiguousTermWithDifferingTypes = ambiguousTermWithDifferingTypes
+```
+
+```ucm
+
+  I'm not sure what ambiguousTermWithDifferingTypes means at line 1, columns 38-69
+  
+      1 | useAmbiguousTermWithDifferingTypes = ambiguousTermWithDifferingTypes
+  
+  There are no constraints on its type.
+  
+  Symbol                            Suggestions                             Type
+                                                                            
+  ambiguousTermWithDifferingTypes   one.ambiguousTermWithDifferingTypes     A
+                                    three.ambiguousTermWithDifferingTypes   B
+                                    two.ambiguousTermWithDifferingTypes     A
+
+```
+```unison
+useAmbiguousTermWithDifferingTypesWithTypeHint : A
+useAmbiguousTermWithDifferingTypesWithTypeHint 
+  = ambiguousTermWithDifferingTypes
+```
+
+```ucm
+
+  I'm not sure what ambiguousTermWithDifferingTypes means at line 3, columns 5-36
+  
+      3 |   = ambiguousTermWithDifferingTypes
+  
+  Whatever it is, it has a type that conforms to A.
+  
+  Symbol                            Suggestions                           Type
+                                                                          
+  ambiguousTermWithDifferingTypes   one.ambiguousTermWithDifferingTypes   A
+                                    two.ambiguousTermWithDifferingTypes   A
 
 ```


### PR DESCRIPTION
## Overview

### Before

### After

## Implementation notes

I pulled out a separate helper for printing an "ambiguity table", which can be used to print errors for all terms which are either not found, or have multiple options.

## Test coverage

- [ ] Update Transcript

## Loose ends

I plan to test out spelling suggestions in a separate PR, which will then auto-magically kick in for all error sites using this table 👌🏼 
