### PR TITLE
Prevent CI builds from triggering twice

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,5 @@
 name: CI
 
-
 on:
   # Build on every pull request (and new PR commit)
   pull_request:
@@ -46,7 +45,6 @@ jobs:
           path: |
             .stack-work
             parser-typechecker/.stack-work
-            cli/.stack-work
             unison-core/.stack-work
             yaks/easytest/.stack-work
             # Main cache key: commit hash. This should always result in a cache miss...

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,15 @@
 name: CI
 
-# Build on every push and every pull request (which tests the merge commit).
+
 on:
+  # Build on every pull request (and new PR commit)
   pull_request:
+  # Build on new pushes to trunk (E.g. Merge commits)
+  # Without the branch filter, each commit on a branch with a PR is triggered twice.
+  # See: https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662
   push:
+    branches:
+      - trunk
 
 jobs:
   build:
@@ -38,6 +44,7 @@ jobs:
           path: |
             .stack-work
             parser-typechecker/.stack-work
+            cli/.stack-work
             unison-core/.stack-work
             yaks/easytest/.stack-work
             # Main cache key: commit hash. This should always result in a cache miss...

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,8 @@ on:
   push:
     branches:
       - trunk
+    tags:
+      - release/*
 
 jobs:
   build:


### PR DESCRIPTION
## Overview

Currently, every commit on a branch which is being PR'd triggers two duplicate builds; resulting in 6 builds on every commit instead of 3. This is a bit of a waste of resources, and also potentially bogs down the queue for other builds.

![image](https://user-images.githubusercontent.com/6439644/137028335-d459d2d8-77d7-40b1-83e8-f0bae290b625.png)

## Implementation notes

See this note on how triggers work:
https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662

## Interesting/controversial decisions

After this change:

* Builds will NOT be run on new commits/pushes to branches UNTIL a PR is created. This seems fine to me, but if you use this functionality let me know. I figure if you're ready to test against CI but don't want reviews, you can create a Draft PR.
* Builds should still be run upon a merge into trunk
* Merges/pushes to a release tag should still work.