### PR TITLE
Improve catching of Ctrl-C and logging of Async exceptions in UCM

### DIFF
--- a/parser-typechecker/src/Unison/CommandLine/Main.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Main.hs
@@ -45,6 +45,7 @@ import Text.Regex.TDFA
 import Control.Lens (view)
 import Control.Error (rightMay)
 import UnliftIO (catchSyncOrAsync, throwIO, withException)
+import System.IO (hPutStrLn, stderr)
 
 -- Expand a numeric argument like `1` or a range like `3-9`
 expandNumber :: [String] -> String -> [String]
@@ -178,7 +179,7 @@ main dir welcome initialPath (config, cancelConfig) initialInputs runtime codeba
                 writeIORef pageOutput True
                 pure x) `catchSyncOrAsync` interruptHandler
       interruptHandler (asyncExceptionFromException -> Just UserInterrupt) = awaitInput
-      interruptHandler e = putStrLn ("Exception: " <> show e) *> throwIO e
+      interruptHandler e = hPutStrLn stderr ("Exception: " <> show e) *> throwIO e
       cleanup = do
         Runtime.terminate runtime
         cancelConfig
@@ -206,5 +207,5 @@ main dir welcome initialPath (config, cancelConfig) initialInputs runtime codeba
     -- Run the main program loop, always run cleanup, 
     -- If an exception occurred, print it before exiting.
     (loop (HandleInput.loopState0 root initialPath)
-      `withException` \e -> putStrLn ("Exception: " <> show (e :: SomeException)))
+      `withException` \e -> hPutStrLn stderr ("Exception: " <> show (e :: SomeException)))
       `finally` cleanup


### PR DESCRIPTION
## Overview

Previously ctrl-c on the UCM prompt would just exit, which is really annoying and out-of-line with how shells typically handle things. In most shells, ctrl-c simply clears the prompt and re-prompts. This PR makes that the default behaviour.

You can still exit the CLI using `ctrl-d`.

Before:

```
.> cd .base
.base>
$ echo $?
130
```

After:

```
.base>
Interrupt.
.base>
```

## Implementation notes

* I installed the recommended ctrl-c handler from haskeline.
* The awaitInput action wasn't catching async exceptions, and UserInterrupt is an async exception (catch ignores them), so I adjusted to `catchSyncOrAsync` to allow it to catch User Interrupts.

## Interesting/controversial decisions

We have to be careful using `catchSyncOrAsync`, using it incorrectly can make a process unkillable. It's important that we rethrow on all exceptions OTHER than UserInterrupt

We might not actually need the `catchSyncOrAsync` if the haskeline catch is enough.

## Loose ends

A ctrl-c during intensive operations (e.g. if you run a slow `find` command and ctrl-c, UCM will still exit with an async exception).
I tried to catch this in multiple spots, but it seems that some async operation inside UCM is converting UserInterrupt into an `AsyncCancelled` somewhere. I'd like to track that down eventually, but this is an incremental improvement for now.
