### PR TITLE
Improve namespace completion

### DIFF
--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -153,6 +153,7 @@ executables:
       - extra
       - filepath
       - filemanip
+      - haskeline
       - here
       - lens
       - megaparsec

--- a/parser-typechecker/src/Unison/CommandLine.hs
+++ b/parser-typechecker/src/Unison/CommandLine.hs
@@ -40,6 +40,8 @@ import qualified Unison.Util.Pretty              as P
 import           Unison.Util.TQueue              (TQueue)
 import qualified Unison.Util.TQueue              as Q
 import qualified Data.Configurator as Config
+import qualified Data.List as List
+import Data.List.Extra (nubOrd)
 
 disableWatchConfig :: Bool
 disableWatchConfig = False
@@ -143,18 +145,20 @@ completion s = Line.Completion s s True
 completion' :: String -> Line.Completion
 completion' s = Line.Completion s s False
 
-prettyCompletion :: (String, P.Pretty P.ColorText) -> Line.Completion
--- -- discards formatting in favor of better alignment
+-- discards formatting in favor of better alignment
 -- prettyCompletion (s, p) = Line.Completion s (P.toPlainUnbroken p) True
 -- preserves formatting, but Haskeline doesn't know how to align
-prettyCompletion (s, p) = Line.Completion s (P.toAnsiUnbroken p) True
+prettyCompletion :: Bool -> (String, P.Pretty P.ColorText) -> Line.Completion
+prettyCompletion endWithSpace (s, p) = Line.Completion s (P.toAnsiUnbroken p) endWithSpace
 
--- avoids adding a space after successful completion
-prettyCompletion' :: (String, P.Pretty P.ColorText) -> Line.Completion
-prettyCompletion' (s, p) = Line.Completion s (P.toAnsiUnbroken p) False
-
-prettyCompletion'' :: Bool -> (String, P.Pretty P.ColorText) -> Line.Completion
-prettyCompletion'' spaceAtEnd (s, p) = Line.Completion s (P.toAnsiUnbroken p) spaceAtEnd
+-- | Renders a completion option with the prefix matching the query greyed out.
+prettyCompletionWithQueryPrefix :: Bool
+                                -> String -- ^ query
+                                -> String  -- ^ completion
+                                -> Line.Completion
+prettyCompletionWithQueryPrefix endWithSpace query s =
+   let coloredMatch = P.hiBlack (P.string query) <> P.string (drop (length query) s)
+    in Line.Completion s (P.toAnsiUnbroken coloredMatch) endWithSpace
 
 fuzzyCompleteHashQualified :: Names0 -> String -> [Line.Completion]
 fuzzyCompleteHashQualified b q0@(HQ'.fromString -> query) = case query of
@@ -164,20 +168,36 @@ fuzzyCompleteHashQualified b q0@(HQ'.fromString -> query) = case query of
       makeCompletion <$> Find.fuzzyFindInBranch b query
   where
   makeCompletion (sr, p) =
-    prettyCompletion' (HQ.toString . SR.name $ sr, p)
+    prettyCompletion False (HQ.toString . SR.name $ sr, p)
 
 fuzzyComplete :: String -> [String] -> [Line.Completion]
 fuzzyComplete q ss =
-  fixupCompletion q (prettyCompletion' <$> Find.simpleFuzzyFinder q ss id)
+  fixupCompletion q (prettyCompletion False <$> Find.simpleFuzzyFinder q ss id)
 
+-- | Constructs a list of 'Completion's from a query and completion options by
+-- filtering them for prefix matches. A completion will be selected if it's an exact match for
+-- a provided option.
 exactComplete :: String -> [String] -> [Line.Completion]
 exactComplete q ss = go <$> filter (isPrefixOf q) ss where
-  go s = prettyCompletion'' (s == q)
-           (s, P.hiBlack (P.string q) <> P.string (drop (length q) s))
+  go s = prettyCompletionWithQueryPrefix (s == q) q s
+
+
+-- | Completes a list of options, limiting options to the same namespace as the query, or the
+-- namespaces children if the query is itself a namespace.
+completeWithinQueryNamespace :: String -> [String] -> [Line.Completion]
+completeWithinQueryNamespace q ss = (go <$> (limitToQueryNamespace q $ ss))
+  where
+    go s = prettyCompletionWithQueryPrefix (s == q) q s
+    limitToQueryNamespace :: String -> [String] -> [String]
+    limitToQueryNamespace query xs =
+      nubOrd $ catMaybes (fmap ((query <>) . thing) . List.stripPrefix query <$> xs)
+        where
+          thing ('.':rest) = '.' : takeWhile (/= '.') rest
+          thing other = takeWhile (/= '.') other
 
 prefixIncomplete :: String -> [String] -> [Line.Completion]
 prefixIncomplete q ss = go <$> filter (isPrefixOf q) ss where
-  go s = prettyCompletion'' False
+  go s = prettyCompletion False
            (s, P.hiBlack (P.string q) <> P.string (drop (length q) s))
 
 -- workaround for https://github.com/judah/haskeline/issues/100

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -48,6 +48,7 @@ import qualified Unison.Codebase.Editor.RemoteRepo as RemoteRepo
 import Data.Tuple.Extra (uncurry3)
 import Unison.Codebase.Verbosity (Verbosity)
 import qualified Unison.Codebase.Verbosity as Verbosity
+import Unison.NameSegment (NameSegment(NameSegment))
 
 showPatternHelp :: InputPattern -> P.Pretty CT.ColorText
 showPatternHelp i = P.lines [
@@ -102,7 +103,7 @@ todo :: InputPattern
 todo = InputPattern
   "todo"
   []
-  [(Optional, patchArg), (Optional, pathArg)]
+  [(Optional, patchArg), (Optional, namespaceArg)]
   (P.wrapColumn2
     [ ( makeExample' todo
       , "lists the refactor work remaining in the default patch for the current"
@@ -248,7 +249,7 @@ patch :: InputPattern
 patch = InputPattern
   "patch"
   []
-  [(Required, patchArg), (Optional, pathArg)]
+  [(Required, patchArg), (Optional, namespaceArg)]
   (  P.wrap
   $  makeExample' patch
   <> "rewrites any definitions that depend on "
@@ -356,7 +357,7 @@ findShallow :: InputPattern
 findShallow = InputPattern
   "list"
   ["ls"]
-  [(Optional, pathArg)]
+  [(Optional, namespaceArg)]
   (P.wrapColumn2
     [ ("`list`", "lists definitions and namespaces at the current level of the current namespace.")
     , ( "`list foo`", "lists the 'foo' namespace." )
@@ -572,7 +573,7 @@ up = InputPattern "up" [] []
     )
 
 cd :: InputPattern
-cd = InputPattern "namespace" ["cd", "j"] [(Required, pathArg)]
+cd = InputPattern "namespace" ["cd", "j"] [(Required, namespaceArg)]
     (P.wrapColumn2
       [ (makeExample cd ["foo.bar"],
           "descends into foo.bar from the current namespace.")
@@ -598,7 +599,7 @@ back = InputPattern "back" ["popd"] []
     )
 
 deleteBranch :: InputPattern
-deleteBranch = InputPattern "delete.namespace" [] [(Required, pathArg)]
+deleteBranch = InputPattern "delete.namespace" [] [(Required, namespaceArg)]
   "`delete.namespace <foo>` deletes the namespace `foo`"
    (\case
         ["."] -> first fromString .
@@ -654,7 +655,7 @@ renamePatch = InputPattern "move.patch"
 renameBranch :: InputPattern
 renameBranch = InputPattern "move.namespace"
    ["rename.namespace"]
-   [(Required, pathArg), (Required, newNameArg)]
+   [(Required, namespaceArg), (Required, newNameArg)]
    "`move.namespace foo bar` renames the path `bar` to `foo`."
     (\case
       [".", dest] -> first fromString $ do
@@ -669,7 +670,7 @@ renameBranch = InputPattern "move.namespace"
 
 history :: InputPattern
 history = InputPattern "history" []
-   [(Optional, pathArg)]
+   [(Optional, namespaceArg)]
    (P.wrapColumn2 [
      (makeExample history [], "Shows the history of the current path."),
      (makeExample history [".foo"], "Shows history of the path .foo."),
@@ -686,7 +687,7 @@ history = InputPattern "history" []
     )
 
 forkLocal :: InputPattern
-forkLocal = InputPattern "fork" ["copy.namespace"] [(Required, pathArg)
+forkLocal = InputPattern "fork" ["copy.namespace"] [(Required, namespaceArg)
                                    ,(Required, newNameArg)]
     (makeExample forkLocal ["src", "dest"] <> "creates the namespace `dest` as a copy of `src`.")
     (\case
@@ -698,7 +699,7 @@ forkLocal = InputPattern "fork" ["copy.namespace"] [(Required, pathArg)
     )
 
 resetRoot :: InputPattern
-resetRoot = InputPattern "reset-root" [] [(Required, pathArg)]
+resetRoot = InputPattern "reset-root" [] [(Required, namespaceArg)]
   (P.wrapColumn2 [
     (makeExample resetRoot [".foo"],
       "Reset the root namespace (along with its history) to that of the `.foo` namespace."),
@@ -722,11 +723,11 @@ pullImpl :: String -> Verbosity -> InputPattern
 pullImpl name verbosity = do
   self
   where
-    addendum = if Verbosity.isSilent verbosity then "without listing the merged entities" else "" 
+    addendum = if Verbosity.isSilent verbosity then "without listing the merged entities" else ""
     self = InputPattern
       name
       []
-      [(Optional, gitUrlArg), (Optional, pathArg)]
+      [(Optional, gitUrlArg), (Optional, namespaceArg)]
       (P.lines
         [ P.wrap
           "The" <> makeExample' self <> "command merges a remote namespace into a local namespace" <> addendum
@@ -770,7 +771,7 @@ pullExhaustive :: InputPattern
 pullExhaustive = InputPattern
   "debug.pull-exhaustive"
   []
-  [(Required, gitUrlArg), (Optional, pathArg)]
+  [(Required, gitUrlArg), (Optional, namespaceArg)]
   (P.lines
     [ P.wrap $
       "The " <> makeExample' pullExhaustive <> "command can be used in place of"
@@ -796,7 +797,7 @@ push :: InputPattern
 push = InputPattern
   "push"
   []
-  [(Required, gitUrlArg), (Optional, pathArg)]
+  [(Required, gitUrlArg), (Optional, namespaceArg)]
   (P.lines
     [ P.wrap
       "The `push` command merges a local namespace into a remote namespace."
@@ -838,7 +839,7 @@ pushExhaustive :: InputPattern
 pushExhaustive = InputPattern
   "debug.push-exhaustive"
   []
-  [(Required, gitUrlArg), (Optional, pathArg)]
+  [(Required, gitUrlArg), (Optional, namespaceArg)]
   (P.lines
     [ P.wrap $
       "The " <> makeExample' pushExhaustive <> "command can be used in place of"
@@ -861,7 +862,7 @@ pushExhaustive = InputPattern
 
 createPullRequest :: InputPattern
 createPullRequest = InputPattern "pull-request.create" ["pr.create"]
-  [(Required, gitUrlArg), (Required, gitUrlArg), (Optional, pathArg)]
+  [(Required, gitUrlArg), (Required, gitUrlArg), (Optional, namespaceArg)]
   (P.group $ P.lines
     [ P.wrap $ makeExample createPullRequest ["base", "head"]
         <> "will generate a request to merge the remote repo `head`"
@@ -881,7 +882,7 @@ createPullRequest = InputPattern "pull-request.create" ["pr.create"]
 
 loadPullRequest :: InputPattern
 loadPullRequest = InputPattern "pull-request.load" ["pr.load"]
-  [(Required, gitUrlArg), (Required, gitUrlArg), (Optional, pathArg)]
+  [(Required, gitUrlArg), (Required, gitUrlArg), (Optional, namespaceArg)]
   (P.lines
    [P.wrap $ makeExample loadPullRequest ["base", "head"]
     <> "will load a pull request for merging the remote repo `head` into the"
@@ -920,7 +921,7 @@ parsePushPath label input = do
 
 squashMerge :: InputPattern
 squashMerge =
-  InputPattern "merge.squash" ["squash"] [(Required, pathArg), (Required, pathArg)]
+  InputPattern "merge.squash" ["squash"] [(Required, namespaceArg), (Required, namespaceArg)]
   (P.wrap $ makeExample squashMerge ["src","dest"]
          <> "merges `src` namespace into `dest`,"
          <> "discarding the history of `src` in the process."
@@ -935,8 +936,8 @@ squashMerge =
   )
 
 mergeLocal :: InputPattern
-mergeLocal = InputPattern "merge" [] [(Required, pathArg)
-                                     ,(Optional, pathArg)]
+mergeLocal = InputPattern "merge" [] [(Required, namespaceArg)
+                                     ,(Optional, namespaceArg)]
  (P.column2 [
    ("`merge src`", "merges `src` namespace into the current namespace"),
    ("`merge src dest`", "merges `src` namespace into the `dest` namespace")])
@@ -955,7 +956,7 @@ diffNamespace :: InputPattern
 diffNamespace = InputPattern
   "diff.namespace"
   []
-  [(Required, pathArg), (Optional, pathArg)]
+  [(Required, namespaceArg), (Optional, namespaceArg)]
   (P.column2
     [ ( "`diff.namespace before after`"
       , P.wrap
@@ -982,7 +983,7 @@ previewMergeLocal :: InputPattern
 previewMergeLocal = InputPattern
   "merge.preview"
   []
-  [(Required, pathArg), (Optional, pathArg)]
+  [(Required, namespaceArg), (Optional, namespaceArg)]
   (P.column2
     [ ( "`merge.preview src`"
       , "shows how the current namespace will change after a `merge src`."
@@ -1562,11 +1563,16 @@ bothCompletors c1 c2 q code b currentPath = do
        . nubOrdOn Completion.display
        $ suggestions1 ++ suggestions2
 
+-- |
 pathCompletor
   :: Applicative f
   => (String -> [String] -> [Completion])
+     -- ^ Turns a query and list of possible completions into a 'Completion'.
   -> (Branch.Branch0 m -> Set Text)
+     -- ^ Construct completions given ucm's current branch context, or the root namespace if
+     -- the query is absolute.
   -> String
+     -- ^ The portion of this arg that the user has already typed.
   -> codebase
   -> Branch.Branch m
   -> Path.Absolute
@@ -1582,9 +1588,16 @@ pathCompletor filterQuery getNames query _code b p = let
        else
          []
 
-pathArg :: ArgumentType
-pathArg = ArgumentType "namespace" $
-  pathCompletor exactComplete (Set.map Path.toText . Branch.deepPaths)
+namespaceArg :: ArgumentType
+namespaceArg = ArgumentType "namespace" $
+    pathCompletor completeWithinQueryNamespace  (Set.fromList . allSubNamespaces)
+
+-- | Recursively collects all names of namespaces which are children of the branch.
+allSubNamespaces :: Branch.Branch0 m -> [Text]
+allSubNamespaces b =
+  flip Map.foldMapWithKey (Branch._children b) $
+    \(NameSegment k) (Branch.head -> b') ->
+      (k : fmap (\sn -> k <> "." <> sn) (allSubNamespaces b'))
 
 newNameArg :: ArgumentType
 newNameArg = ArgumentType "new-name" $

--- a/parser-typechecker/tests/Suite.hs
+++ b/parser-typechecker/tests/Suite.hs
@@ -38,6 +38,7 @@ import qualified Unison.Test.MCode as MCode
 import qualified Unison.Test.VersionParser as VersionParser
 import qualified Unison.Test.GitSync as GitSync
 import qualified Unison.Test.CodebaseInit as CodebaseInit
+import qualified Unison.Test.CommandLine as CommandLine
 -- import qualified Unison.Test.BaseUpgradePushPullTest as BaseUpgradePushPullTest
 
 test :: Test ()
@@ -74,6 +75,7 @@ test = tests
   , Pretty.test
   , PinBoard.test
   , CodebaseInit.test
+  , CommandLine.test
  ]
 
 main :: IO ()

--- a/parser-typechecker/tests/Unison/Test/CommandLine.hs
+++ b/parser-typechecker/tests/Unison/Test/CommandLine.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE RecordWildCards #-}
+module Unison.Test.CommandLine where
+
+import EasyTest
+import qualified System.Console.Haskeline        as Line
+import Unison.CommandLine (completeWithinQueryNamespace)
+
+data CompletionTest = CT {query :: String, expected :: [(String, Bool)], options :: [String]}
+testCompletion :: (String -> [String] -> [Line.Completion]) -> CompletionTest -> Test ()
+testCompletion compl CT{..}=
+  expectEqual expected ((\(Line.Completion{..}) -> (replacement, isFinished)) <$> compl query options)
+
+test :: Test ()
+test = scope "commandline" $ do
+  scope "completion" $ do
+    scope "completeWithinQueryNamespace" $ do
+      scope "only completes up to a single namespace boundary" $ do
+        testCompletion completeWithinQueryNamespace $ CT { query=".ba"
+                                                       , expected=[(".base", False)]
+                                                       , options=[".base", ".base.List", ".base.Map"]
+                                                       }
+      scope "completes into the next namespace if query is a complete namespace" $ do
+        testCompletion completeWithinQueryNamespace $ CT { query=".base"
+                                                       , expected=[(".base", True), (".base.List", False), (".base.Map", False)]
+                                                       , options=[".base", ".base.List", ".base.Map"]
+                                                       }
+
+      scope "completes " $ do
+        testCompletion completeWithinQueryNamespace $ CT { query=".f"
+                                                       , expected=[(".function", False), (".facade", False), (".fellows", False)]
+                                                       , options=[".function", ".facade", ".fellows"]}

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -346,6 +346,7 @@ executable tests
       Unison.Test.Codebase.Path
       Unison.Test.CodebaseInit
       Unison.Test.ColorText
+      Unison.Test.CommandLine
       Unison.Test.Common
       Unison.Test.DataDeclaration
       Unison.Test.FileParser
@@ -403,6 +404,7 @@ executable tests
     , extra
     , filemanip
     , filepath
+    , haskeline
     , here
     , lens
     , megaparsec


### PR DESCRIPTION
## Overview

Related to https://github.com/unisonweb/unison/issues/2490;
but this PR is only for namespace completion, not terms.
I'll open a separate PR for addressing Terms in a similar fashion.

## Before

```
.> cd .bas<TAB>
Display all 945 possibilities? (y or n) y
.base                                            .base.List.all                                   .base.Natural.docs                               .base.io.FilePath
.base.ANSI                                       .base.List.all.tests                             .base.Natural.fromNat                            .base.io.HostName
.base.ANSI.Color                                 .base.List.any                                   .base.Natural.internal                           .base.io.IOError
.base.Abort                                      .base.List.any.tests                             .base.Natural.isZero                             .base.io.MVar
.base.Abort.abortWhen                            .base.List.concatOptional                        .base.Natural.mod                                .base.io.MVar.isEmpty
.base.Abort.tests                                .base.List.concatOptional.tests                  .base.Natural.mod!                               .base.io.MVar.new
.base.Abort.toBug                                .base.List.contains                              .base.Natural.one                                .base.io.MVar.newEmpty
.base.Abort.toDefault                            .base.List.contains.tests                        .base.Natural.parse                              .base.io.MVar.put
.base.Abort.toDefault!                           .base.List.deleteAt                              .base.Natural.parse!                             .base.io.MVar.read
.base.Abort.toOptional                           .base.List.deleteFirst                           .base.Natural.parse!.tests                       .base.io.MVar.swap
.base.Abort.toOptional!                          .base.List.deleteFirst.tests                     .base.Natural.parse.tests                        .base.io.MVar.take
.base.Any                                        .base.List.distinctBy                            .base.Natural.pow                                .base.io.MVar.tryPut
.base.Ask                                        .base.List.distinctBy.tests                      .base.Natural.pow.tests                          .base.io.MVar.tryRead
.base.Ask.provide                                .base.List.docs                                  .base.Natural.tests                              .base.io.MVar.tryTake
.base.Ask.tests                                  .base.List.dropRightWhile                        .base.Natural.tests.gen                          .base.io.STM
.base.Author                                     .base.List.dropWhile                             .base.Natural.toDecimalText                      .base.io.STM.TQueue
.base.Author.guid                                .base.List.dropWhile.examples                    .base.Natural.toNat                              .base.io.STM.TQueue.boundedEnqueue
.base.Author.name                                .base.List.dropWhile.examples.ex1                .base.Natural.toNat.tests                        .base.io.STM.TQueue.dequeue
.base.Bag                                        .base.List.dropWhile.tests                       .base.Natural.toText                             .base.io.STM.TQueue.dequeueNonce
.base.Bag.add                                    .base.List.fill                                  .base.Natural.zero                               .base.io.STM.TQueue.elements
.base.Bag.add.tests                              .base.List.fill.examples                         .base.Optional                                   .base.io.STM.TQueue.empty
.base.Bag.addAll                                 .base.List.fill.tests                            .base.Optional.contains                          .base.io.STM.TQueue.enqueue
.base.Bag.addAll.tests                           .base.List.filter                                .base.Optional.exists                            .base.io.STM.TQueue.enqueueAll
.base.Bag.addN                                   .base.List.filter.tests                          .base.Optional.filter                            .base.io.STM.TQueue.fromList
.base.Bag.all                                    .base.List.filterMap                             .base.Optional.fold                              .base.io.STM.TQueue.peek
.base.Bag.any                                    .base.List.filterMap.examples                    .base.Optional.forAll                            .base.io.STM.TQueue.pushback
.base.Bag.contains                               .base.List.filterMap.tests                       .base.Optional.getOrElse                         .base.io.STM.TQueue.size
.base.Bag.convolve                               .base.List.find                                  .base.Optional.isNone                            .base.io.STM.TQueue.tests
.base.Bag.convolve.tests                         .base.List.find!                                 .base.Optional.isSome                            .base.io.STM.TQueue.tryBoundedEnqueue
.base.Bag.count                                  .base.List.find.tests                            .base.Optional.mapOptional                       .base.io.STM.TQueue.tryBoundedEnqueueAll
...
```

## After:

```
.> cd .bas<TAB>
.> cd .base
---
.> cd .base<TAB>
.base                  .base.Either           .base.Map              .base.Test             .base.forever'
.base.ANSI             .base.Exception        .base.Multimap         .base.Text             .base.ignore
.base.Abort            .base.Float            .base.Nat              .base.Throw            .base.io
.base.Any              .base.Function         .base.Natural          .base.Trie             .base.metadata
.base.Ask              .base.GUID             .base.Optional         .base.Tuple            .base.prs
.base.Author           .base.Hash             .base.Ordering         .base.Unit             .base.repeat
.base.Bag              .base.Heap             .base.Pretty           .base.Universal        .base.syntax
.base.Boolean          .base.IO               .base.Random           .base.Value            .base.test
.base.Bytes            .base.Int              .base.Ref              .base.Void             .base.unsafe
.base.Char             .base.IsPropagated     .base.Scope            .base.Weighted         .base.until
.base.Code             .base.IsTest           .base.Search           .base.Year             .base.when
.base.ConsoleText      .base.License          .base.SeqView          .base.absurd           .base.while
.base.CopyrightHolder  .base.LicenseType      .base.Set              .base.crypto
.base.Debug            .base.Link             .base.Store            .base.force
.base.Doc              .base.List             .base.Stream           .base.forever
---
.> cd .base.A<TAB>
.base.ANSI    .base.Abort   .base.Any     .base.Ask     .base.Author
```

## Implementation notes

How does it accomplish it, in broad strokes? i.e. How does it change the Haskell codebase?

## Interesting/controversial decisions

Include anything that you thought twice about, debated, chose arbitrarily, etc. 
What could have been done differently, but wasn't? And why?

## Test coverage

✅ 

Would you recommend improving the test coverage (either as part of this PR or as a separate issue) or do you think it’s adequate?

It may be helpful to add tests for the fuzzy completion helpers in the future if we make changes to them.

## Loose ends

Matching in fuzzy contexts is still slow, even when an absolute query is passed, but at least the output is filtered. We can fix this by filtering when generating the matches (and short-circuiting) rather than generating EVERYTHING then filtering.

Might be nice to get zsh's behaviour where mashing tab will start selecting completion options one-by-one. Would save users from typing long namespaces when running a `view` or w/e