### PR TITLE
Clarify naming of "Names"

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -43,7 +43,7 @@ import qualified Unison.Var                    as Var
 import           Unison.Name                    ( Name )
 import qualified Unison.Name                   as Name
 import           Unison.NamesWithHistory (NamesWithHistory(..))
-import           Unison.Names            (UnqualifiedNames)
+import           Unison.Names            (Names)
 import qualified Unison.NamesWithHistory as NamesWithHistory
 import qualified Unison.Typechecker.TypeLookup as TL
 import qualified Unison.Util.Relation          as Rel
@@ -56,7 +56,7 @@ type Type v = Type.Type v ()
 names :: NamesWithHistory
 names = NamesWithHistory names0 mempty
 
-names0 :: UnqualifiedNames
+names0 :: Names
 names0 = NamesWithHistory.names0 terms types where
   terms = Rel.mapRan Referent.Ref (Rel.fromMap termNameRefs) <>
     Rel.fromList [ (Name.fromVar vc, Referent.Con (R.DerivedId r) cid ct)

--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -43,8 +43,7 @@ import qualified Unison.Var                    as Var
 import           Unison.Name                    ( Name )
 import qualified Unison.Name                   as Name
 import           Unison.NamesWithHistory (NamesWithHistory(..))
-import           Unison.Names            (Names)
-import qualified Unison.NamesWithHistory as NamesWithHistory
+import           Unison.Names            (Names (Names))
 import qualified Unison.Typechecker.TypeLookup as TL
 import qualified Unison.Util.Relation          as Rel
 import qualified Unison.Hashing.V2.Convert as H
@@ -57,7 +56,7 @@ names :: NamesWithHistory
 names = NamesWithHistory names0 mempty
 
 names0 :: Names
-names0 = NamesWithHistory.names0 terms types where
+names0 = Names terms types where
   terms = Rel.mapRan Referent.Ref (Rel.fromMap termNameRefs) <>
     Rel.fromList [ (Name.fromVar vc, Referent.Con (R.DerivedId r) cid ct)
                  | (ct, (_,(r,decl))) <- ((CT.Data,) <$> builtinDataDecls @Symbol) <>

--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -42,8 +42,8 @@ import           Unison.Var                     ( Var )
 import qualified Unison.Var                    as Var
 import           Unison.Name                    ( Name )
 import qualified Unison.Name                   as Name
-import           Unison.Names3 (NamesWithHistory(..), Names0)
-import qualified Unison.Names3 as Names3
+import           Unison.NamesWithHistory (NamesWithHistory(..), Names0)
+import qualified Unison.NamesWithHistory as NamesWithHistory
 import qualified Unison.Typechecker.TypeLookup as TL
 import qualified Unison.Util.Relation          as Rel
 import qualified Unison.Hashing.V2.Convert as H
@@ -56,7 +56,7 @@ names :: NamesWithHistory
 names = NamesWithHistory names0 mempty
 
 names0 :: Names0
-names0 = Names3.names0 terms types where
+names0 = NamesWithHistory.names0 terms types where
   terms = Rel.mapRan Referent.Ref (Rel.fromMap termNameRefs) <>
     Rel.fromList [ (Name.fromVar vc, Referent.Con (R.DerivedId r) cid ct)
                  | (ct, (_,(r,decl))) <- ((CT.Data,) <$> builtinDataDecls @Symbol) <>

--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -42,7 +42,8 @@ import           Unison.Var                     ( Var )
 import qualified Unison.Var                    as Var
 import           Unison.Name                    ( Name )
 import qualified Unison.Name                   as Name
-import           Unison.NamesWithHistory (NamesWithHistory(..), Names0)
+import           Unison.NamesWithHistory (NamesWithHistory(..))
+import           Unison.Names            (UnqualifiedNames)
 import qualified Unison.NamesWithHistory as NamesWithHistory
 import qualified Unison.Typechecker.TypeLookup as TL
 import qualified Unison.Util.Relation          as Rel
@@ -55,7 +56,7 @@ type Type v = Type.Type v ()
 names :: NamesWithHistory
 names = NamesWithHistory names0 mempty
 
-names0 :: Names0
+names0 :: UnqualifiedNames
 names0 = NamesWithHistory.names0 terms types where
   terms = Rel.mapRan Referent.Ref (Rel.fromMap termNameRefs) <>
     Rel.fromList [ (Name.fromVar vc, Referent.Con (R.DerivedId r) cid ct)

--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -42,7 +42,7 @@ import           Unison.Var                     ( Var )
 import qualified Unison.Var                    as Var
 import           Unison.Name                    ( Name )
 import qualified Unison.Name                   as Name
-import           Unison.Names3 (Names(Names), Names0)
+import           Unison.Names3 (NamesWithHistory(..), Names0)
 import qualified Unison.Names3 as Names3
 import qualified Unison.Typechecker.TypeLookup as TL
 import qualified Unison.Util.Relation          as Rel
@@ -52,8 +52,8 @@ type DataDeclaration v = DD.DataDeclaration v Ann
 type EffectDeclaration v = DD.EffectDeclaration v Ann
 type Type v = Type.Type v ()
 
-names :: Names
-names = Names names0 mempty
+names :: NamesWithHistory
+names = NamesWithHistory names0 mempty
 
 names0 :: Names0
 names0 = Names3.names0 terms types where

--- a/parser-typechecker/src/Unison/Codebase/Branch/Names.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch/Names.hs
@@ -9,7 +9,7 @@ module Unison.Codebase.Branch.Names
     findHistoricalRefs,
     findHistoricalRefs',
     namesDiff,
-    toNames0,
+    toUnqualifiedNames,
   )
 where
 
@@ -21,7 +21,7 @@ import qualified Unison.HashQualified as HQ
 import Unison.LabeledDependency (LabeledDependency)
 import qualified Unison.LabeledDependency as LD
 import Unison.Name (Name (..))
-import Unison.Names (Names' (Names), Names0)
+import Unison.Names (Names' (Names), UnqualifiedNames)
 import qualified Unison.Names as Names
 import qualified Unison.NamesWithHistory as Names
 import Unison.Prelude hiding (empty)
@@ -31,8 +31,8 @@ import qualified Unison.Referent as Referent
 import qualified Unison.Util.Relation as R
 import Prelude hiding (head, read, subtract)
 
-toNames0 :: Branch0 m -> Names0
-toNames0 b = Names (R.swap . deepTerms $ b)
+toUnqualifiedNames :: Branch0 m -> UnqualifiedNames
+toUnqualifiedNames b = Names (R.swap . deepTerms $ b)
                    (R.swap . deepTypes $ b)
 
 -- This stops searching for a given HashQualified once it encounters
@@ -40,19 +40,19 @@ toNames0 b = Names (R.swap . deepTerms $ b)
 findHistoricalHQs :: Monad m
                   => Set (HashQualified Name)
                   -> Branch m
-                  -> m (Set (HashQualified Name), Names0)
+                  -> m (Set (HashQualified Name), UnqualifiedNames)
 findHistoricalHQs = findInHistory
   (\hq r n -> HQ.matchesNamedReferent n r hq)
   (\hq r n -> HQ.matchesNamedReference n r hq)
 
 findHistoricalRefs :: Monad m => Set LabeledDependency -> Branch m
-                   -> m (Set LabeledDependency, Names0)
+                   -> m (Set LabeledDependency, UnqualifiedNames)
 findHistoricalRefs = findInHistory
   (\query r _n -> LD.fold (const False) (==r) query)
   (\query r _n -> LD.fold (==r) (const False) query)
 
 findHistoricalRefs' :: Monad m => Set Reference -> Branch m
-                    -> m (Set Reference, Names0)
+                    -> m (Set Reference, UnqualifiedNames)
 findHistoricalRefs' = findInHistory
   (\queryRef r _n -> r == Referent.Ref queryRef)
   (\queryRef r _n -> r == queryRef)
@@ -60,7 +60,7 @@ findHistoricalRefs' = findInHistory
 findInHistory :: forall m q. (Monad m, Ord q)
   => (q -> Referent -> Name -> Bool)
   -> (q -> Reference -> Name -> Bool)
-  -> Set q -> Branch m -> m (Set q, Names0)
+  -> Set q -> Branch m -> m (Set q, UnqualifiedNames)
 findInHistory termMatches typeMatches queries b =
   (Causal.foldHistoryUntil f (queries, mempty) . _history) b <&> \case
     -- could do something more sophisticated here later to report that some SH
@@ -76,7 +76,7 @@ findInHistory termMatches typeMatches queries b =
   f acc@(remainingQueries, _) b0 = (acc', null remainingQueries')
     where
     acc'@(remainingQueries', _) = foldl' findQ acc remainingQueries
-    findQ :: (Set q, Names0) -> q -> (Set q, Names0)
+    findQ :: (Set q, UnqualifiedNames) -> q -> (Set q, UnqualifiedNames)
     findQ acc sh =
       foldl' (doType sh) (foldl' (doTerm sh) acc
                             (R.toList $ deepTerms b0))
@@ -87,4 +87,4 @@ findInHistory termMatches typeMatches queries b =
       then (Set.delete q remainingSHs, Names.addType n r names0) else acc
 
 namesDiff :: Branch m -> Branch m -> Names.Diff
-namesDiff b1 b2 = Names.diff0 (toNames0 (head b1)) (toNames0 (head b2))
+namesDiff b1 b2 = Names.diff0 (toUnqualifiedNames (head b1)) (toUnqualifiedNames (head b2))

--- a/parser-typechecker/src/Unison/Codebase/Branch/Names.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch/Names.hs
@@ -21,8 +21,8 @@ import qualified Unison.HashQualified as HQ
 import Unison.LabeledDependency (LabeledDependency)
 import qualified Unison.LabeledDependency as LD
 import Unison.Name (Name (..))
-import Unison.Names2 (Names' (Names), Names0)
-import qualified Unison.Names2 as Names
+import Unison.Names (Names' (Names), Names0)
+import qualified Unison.Names as Names
 import qualified Unison.NamesWithHistory as Names
 import Unison.Prelude hiding (empty)
 import Unison.Reference (Reference)

--- a/parser-typechecker/src/Unison/Codebase/Branch/Names.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch/Names.hs
@@ -21,7 +21,7 @@ import qualified Unison.HashQualified as HQ
 import Unison.LabeledDependency (LabeledDependency)
 import qualified Unison.LabeledDependency as LD
 import Unison.Name (Name (..))
-import Unison.Names (Names' (Names), Names)
+import Unison.Names (Names (..))
 import qualified Unison.Names as Names
 import qualified Unison.NamesWithHistory as Names
 import Unison.Prelude hiding (empty)

--- a/parser-typechecker/src/Unison/Codebase/Branch/Names.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch/Names.hs
@@ -87,4 +87,4 @@ findInHistory termMatches typeMatches queries b =
       then (Set.delete q remainingSHs, Names.addType n r names0) else acc
 
 namesDiff :: Branch m -> Branch m -> Names.Diff
-namesDiff b1 b2 = Names.diff0 (toNames (head b1)) (toNames (head b2))
+namesDiff b1 b2 = Names.diff (toNames (head b1)) (toNames (head b2))

--- a/parser-typechecker/src/Unison/Codebase/Branch/Names.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch/Names.hs
@@ -23,7 +23,7 @@ import qualified Unison.LabeledDependency as LD
 import Unison.Name (Name (..))
 import Unison.Names2 (Names' (Names), Names0)
 import qualified Unison.Names2 as Names
-import qualified Unison.Names3 as Names
+import qualified Unison.NamesWithHistory as Names
 import Unison.Prelude hiding (empty)
 import Unison.Reference (Reference)
 import Unison.Referent (Referent)

--- a/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
+++ b/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
@@ -8,8 +8,8 @@ import Unison.Codebase.Path (Path)
 import qualified Unison.Codebase.Path as Path
 import qualified Unison.Codebase.Branch as Branch
 import Unison.Codebase.Branch (Branch, Branch0)
-import qualified Unison.Names2 as Names
-import Unison.Names2 (Names0)
+import qualified Unison.Names as Names
+import Unison.Names (Names0)
 import qualified Unison.Referent as Referent
 import qualified Unison.Reference as Reference
 import Unison.Referent (Referent)

--- a/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
+++ b/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
@@ -9,7 +9,7 @@ import qualified Unison.Codebase.Path as Path
 import qualified Unison.Codebase.Branch as Branch
 import Unison.Codebase.Branch (Branch, Branch0)
 import qualified Unison.Names as Names
-import Unison.Names (Names0)
+import Unison.Names (UnqualifiedNames)
 import qualified Unison.Referent as Referent
 import qualified Unison.Reference as Reference
 import Unison.Referent (Referent)
@@ -27,18 +27,18 @@ import Unison.Codebase.Patch (Patch)
 import Unison.NameSegment (NameSegment)
 import Control.Lens (view)
 
-fromNames0 :: Monad m => Names0 -> Branch m
-fromNames0 names0 = Branch.one $ addFromNames0 names0 Branch.empty0
+fromUnqualifiedNames :: Monad m => UnqualifiedNames -> Branch m
+fromUnqualifiedNames names0 = Branch.one $ addFromUnqualifiedNames names0 Branch.empty0
 
 -- can produce a pure value because there's no history to traverse
-hashesFromNames0 :: Monad m => Names0 -> Map Branch.Hash (Branch m)
-hashesFromNames0 = deepHashes . fromNames0 where
+hashesFromUnqualifiedNames :: Monad m => UnqualifiedNames -> Map Branch.Hash (Branch m)
+hashesFromUnqualifiedNames = deepHashes . fromUnqualifiedNames where
   deepHashes :: Branch m -> Map Branch.Hash (Branch m)
   deepHashes b = Map.singleton (Branch.headHash b) b
     <> (foldMap deepHashes . view Branch.children . Branch.head) b
 
-addFromNames0 :: Monad m => Names0 -> Branch0 m -> Branch0 m
-addFromNames0 names0 = Branch.stepManyAt0 (typeActions <> termActions)
+addFromUnqualifiedNames :: Monad m => UnqualifiedNames -> Branch0 m -> Branch0 m
+addFromUnqualifiedNames names0 = Branch.stepManyAt0 (typeActions <> termActions)
   where
   typeActions = map doType . R.toList $ Names.types names0
   termActions = map doTerm . R.toList $ Names.terms names0

--- a/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
+++ b/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
@@ -9,7 +9,7 @@ import qualified Unison.Codebase.Path as Path
 import qualified Unison.Codebase.Branch as Branch
 import Unison.Codebase.Branch (Branch, Branch0)
 import qualified Unison.Names as Names
-import Unison.Names (UnqualifiedNames)
+import Unison.Names (Names)
 import qualified Unison.Referent as Referent
 import qualified Unison.Reference as Reference
 import Unison.Referent (Referent)
@@ -27,18 +27,18 @@ import Unison.Codebase.Patch (Patch)
 import Unison.NameSegment (NameSegment)
 import Control.Lens (view)
 
-fromUnqualifiedNames :: Monad m => UnqualifiedNames -> Branch m
-fromUnqualifiedNames names0 = Branch.one $ addFromUnqualifiedNames names0 Branch.empty0
+fromNames :: Monad m => Names -> Branch m
+fromNames names0 = Branch.one $ addFromNames names0 Branch.empty0
 
 -- can produce a pure value because there's no history to traverse
-hashesFromUnqualifiedNames :: Monad m => UnqualifiedNames -> Map Branch.Hash (Branch m)
-hashesFromUnqualifiedNames = deepHashes . fromUnqualifiedNames where
+hashesFromNames :: Monad m => Names -> Map Branch.Hash (Branch m)
+hashesFromNames = deepHashes . fromNames where
   deepHashes :: Branch m -> Map Branch.Hash (Branch m)
   deepHashes b = Map.singleton (Branch.headHash b) b
     <> (foldMap deepHashes . view Branch.children . Branch.head) b
 
-addFromUnqualifiedNames :: Monad m => UnqualifiedNames -> Branch0 m -> Branch0 m
-addFromUnqualifiedNames names0 = Branch.stepManyAt0 (typeActions <> termActions)
+addFromNames :: Monad m => Names -> Branch0 m -> Branch0 m
+addFromNames names0 = Branch.stepManyAt0 (typeActions <> termActions)
   where
   typeActions = map doType . R.toList $ Names.types names0
   termActions = map doTerm . R.toList $ Names.terms names0

--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -34,7 +34,7 @@ import qualified Unison.Codebase.Branch        as Branch
 import qualified Unison.Codebase.Branch.Merge as Branch
 import qualified Unison.Codebase.Reflog        as Reflog
 import           Unison.Codebase.SyncMode       ( SyncMode )
-import           Unison.Names3                  ( NamesWithHistory, Names0 )
+import           Unison.NamesWithHistory                  ( NamesWithHistory, Names0 )
 import Unison.Parser.Ann (Ann)
 import           Unison.Referent                ( Referent )
 import           Unison.Reference               ( Reference )

--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -35,7 +35,7 @@ import qualified Unison.Codebase.Branch.Merge as Branch
 import qualified Unison.Codebase.Reflog        as Reflog
 import           Unison.Codebase.SyncMode       ( SyncMode )
 import           Unison.NamesWithHistory        ( NamesWithHistory )
-import           Unison.Names                   ( UnqualifiedNames )
+import           Unison.Names                   ( Names )
 import Unison.Parser.Ann (Ann)
 import           Unison.Referent                ( Referent )
 import           Unison.Reference               ( Reference )
@@ -75,7 +75,7 @@ data LoadSourceResult = InvalidSourceNameError
 
 type TypecheckingResult v =
   Result (Seq (Note v Ann))
-         (Either UnqualifiedNames (UF.TypecheckedUnisonFile v Ann))
+         (Either Names (UF.TypecheckedUnisonFile v Ann))
 
 data Command m i v a where
   -- Escape hatch.

--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -34,7 +34,7 @@ import qualified Unison.Codebase.Branch        as Branch
 import qualified Unison.Codebase.Branch.Merge as Branch
 import qualified Unison.Codebase.Reflog        as Reflog
 import           Unison.Codebase.SyncMode       ( SyncMode )
-import           Unison.Names3                  ( Names, Names0 )
+import           Unison.Names3                  ( NamesWithHistory, Names0 )
 import Unison.Parser.Ann (Ann)
 import           Unison.Referent                ( Referent )
 import           Unison.Reference               ( Reference )
@@ -124,13 +124,13 @@ data Command m i v a where
 
   BranchHashesByPrefix :: ShortBranchHash -> Command m i v (Set Branch.Hash)
 
-  ParseType :: Names -> LexedSource
+  ParseType :: NamesWithHistory -> LexedSource
             -> Command m i v (Either (Parser.Err v) (Type v Ann))
 
   LoadSource :: SourceName -> Command m i v LoadSourceResult
 
   Typecheck :: AmbientAbilities v
-            -> Names
+            -> NamesWithHistory
             -> SourceName
             -> LexedSource
             -> Command m i v (TypecheckingResult v)

--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -34,7 +34,8 @@ import qualified Unison.Codebase.Branch        as Branch
 import qualified Unison.Codebase.Branch.Merge as Branch
 import qualified Unison.Codebase.Reflog        as Reflog
 import           Unison.Codebase.SyncMode       ( SyncMode )
-import           Unison.NamesWithHistory                  ( NamesWithHistory, Names0 )
+import           Unison.NamesWithHistory        ( NamesWithHistory )
+import           Unison.Names                   ( UnqualifiedNames )
 import Unison.Parser.Ann (Ann)
 import           Unison.Referent                ( Referent )
 import           Unison.Reference               ( Reference )
@@ -74,7 +75,7 @@ data LoadSourceResult = InvalidSourceNameError
 
 type TypecheckingResult v =
   Result (Seq (Note v Ann))
-         (Either Names0 (UF.TypecheckedUnisonFile v Ann))
+         (Either UnqualifiedNames (UF.TypecheckedUnisonFile v Ann))
 
 data Command m i v a where
   -- Escape hatch.

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -86,7 +86,7 @@ import qualified Unison.HashQualified'         as HQ'
 import qualified Unison.Name                   as Name
 import           Unison.Name                    ( Name )
 import           Unison.NamesWithHistory        ( NamesWithHistory(..) )
-import Unison.Names                             (Names, pattern Names )
+import Unison.Names                             (Names(Names))
 import qualified Unison.Names                 as Names
 import qualified Unison.NamesWithHistory      as NamesWithHistory
 import Unison.Parser.Ann (Ann(..))

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -85,10 +85,10 @@ import qualified Unison.HashQualified          as HQ
 import qualified Unison.HashQualified'         as HQ'
 import qualified Unison.Name                   as Name
 import           Unison.Name                    ( Name )
-import           Unison.NamesWithHistory                  ( NamesWithHistory(..), Names0
-                                                , pattern Names0 )
+import           Unison.NamesWithHistory        ( NamesWithHistory(..) )
+import Unison.Names                             (UnqualifiedNames, pattern UnqualifiedNames )
 import qualified Unison.Names                 as Names
-import qualified Unison.NamesWithHistory                 as NamesWithHistory
+import qualified Unison.NamesWithHistory      as NamesWithHistory
 import Unison.Parser.Ann (Ann(..))
 import           Unison.Reference               ( Reference(..) )
 import qualified Unison.Reference              as Reference
@@ -242,8 +242,8 @@ loop = do
       getHQ'Types :: Path.HQSplit' -> Set Reference
       getHQ'Types p = BranchUtil.getType (resolveSplit' p) root0
 
-      basicPrettyPrintNames0 =
-        Backend.basicPrettyPrintNames0 root' (Path.unabsolute currentPath')
+      basicPrettyPrintUnqualifiedNames =
+        Backend.basicPrettyPrintUnqualifiedNames root' (Path.unabsolute currentPath')
 
       resolveHHQS'Types :: HashOrHQSplit' -> Action' m v (Set Reference)
       resolveHHQS'Types = either
@@ -296,7 +296,7 @@ loop = do
       loadUnisonFile sourceName text = do
         let lexed = L.lexer (Text.unpack sourceName) (Text.unpack text)
         withFile [] sourceName (text, lexed) $ \unisonFile -> do
-          sr <- toSlurpResult currentPath' unisonFile <$> slurpResultNames0
+          sr <- toSlurpResult currentPath' unisonFile <$> slurpResultUnqualifiedNames
           names <- displayNames unisonFile
           pped <- prettyPrintEnvDecl names
           let ppe = PPE.suffixifiedPPE pped
@@ -616,12 +616,12 @@ loop = do
           where
           resolvedPath = resolveSplit' (HQ'.toName <$> hq)
           goMany tms tys = do
-            let rootNames = Branch.toNames0 root0
+            let rootNames = Branch.toUnqualifiedNames root0
                 name = Path.toName (Path.unsplit resolvedPath)
                 toRel :: Ord ref => Set ref -> R.Relation Name ref
                 toRel = R.fromList . fmap (name,) . toList
                 -- these names are relative to the root
-                toDelete = Names0 (toRel tms) (toRel tys)
+                toDelete = UnqualifiedNames (toRel tms) (toRel tys)
             (failed, failedDependents) <-
               getEndangeredDependents (eval . GetDependents) toDelete rootNames
             if failed == mempty then do
@@ -637,8 +637,8 @@ loop = do
           uf <- use latestTypecheckedFile >>= addWatch (HQ.toString hq)
           case uf of
             Nothing -> do
-              let parseNames0 = (`NamesWithHistory.NamesWithHistory` mempty) basicPrettyPrintNames0
-                  results = NamesWithHistory.lookupHQTerm hq parseNames0
+              let parseUnqualifiedNames = (`NamesWithHistory.NamesWithHistory` mempty) basicPrettyPrintUnqualifiedNames
+                  results = NamesWithHistory.lookupHQTerm hq parseUnqualifiedNames
               if Set.null results then
                 respond $ SearchTermsNotFound [hq]
               else if Set.size results > 1 then
@@ -646,11 +646,11 @@ loop = do
               -- ... but use the unsuffixed names for display
               else do
                 let tm = Term.fromReferent External $ Set.findMin results
-                pped <- prettyPrintEnvDecl parseNames0
+                pped <- prettyPrintEnvDecl parseUnqualifiedNames
                 tm <- eval $ Evaluate1 (PPE.suffixifiedPPE pped) True tm
                 case tm of
                   Left e -> respond (EvaluationFailure e)
-                  Right tm -> doDisplay outputLoc parseNames0 (Term.unannotate tm)
+                  Right tm -> doDisplay outputLoc parseUnqualifiedNames (Term.unannotate tm)
             Just (toDisplay, unisonFile) -> do
               ppe <- executePPE unisonFile
               unlessError' EvaluationFailure do
@@ -853,10 +853,10 @@ loop = do
         where
         go (Branch.head -> b) = do
           (failed, failedDependents) <-
-            let rootNames = Branch.toNames0 root0
+            let rootNames = Branch.toUnqualifiedNames root0
                 toDelete = Names.prefix0
                   (Path.toName . Path.unsplit . resolveSplit' $ p) -- resolveSplit' incorporates currentPath
-                  (Branch.toNames0 b)
+                  (Branch.toUnqualifiedNames b)
             in getEndangeredDependents (eval . GetDependents) toDelete rootNames
           if failed == mempty then do
             stepAt $ BranchUtil.makeSetBranch (resolveSplit' p) Branch.empty
@@ -1014,11 +1014,11 @@ loop = do
         fixupOutput = fmap Path.toName . HQ'.toHQ . Path.unsplitHQ
 
       NamesI thing -> do
-        ns0 <- basicParseNames0
+        ns0 <- basicParseUnqualifiedNames
         let ns = NamesWithHistory ns0 mempty
             terms = NamesWithHistory.lookupHQTerm thing ns
             types = NamesWithHistory.lookupHQType thing ns
-            printNames = NamesWithHistory basicPrettyPrintNames0 mempty
+            printNames = NamesWithHistory basicPrettyPrintUnqualifiedNames mempty
             terms' :: Set (Referent, Set (HQ'.HashQualified Name))
             terms' = Set.map go terms where
               go r = (r, NamesWithHistory.termName hqLength r printNames)
@@ -1060,7 +1060,7 @@ loop = do
         dotDoc = hq <&> \n -> Name.joinDot n "doc"
 
         fileByName = do
-          ns <- maybe mempty UF.typecheckedToNames0 <$> use latestTypecheckedFile
+          ns <- maybe mempty UF.typecheckedToUnqualifiedNames <$> use latestTypecheckedFile
           fnames <- pure $ NamesWithHistory.NamesWithHistory ns mempty
           case NamesWithHistory.lookupHQTerm dotDoc fnames of
             s | Set.size s == 1 -> do
@@ -1076,7 +1076,7 @@ loop = do
             [] -> codebaseByName
             [(_name, ref, _tm)] -> do
               len <- eval BranchHashLength
-              let names = NamesWithHistory.NamesWithHistory basicPrettyPrintNames0 mempty
+              let names = NamesWithHistory.NamesWithHistory basicPrettyPrintUnqualifiedNames mempty
               let tm = Term.ref External ref
               tm <- eval $ Evaluate1 (PPE.fromNames len names) True tm
               case tm of
@@ -1087,7 +1087,7 @@ loop = do
               respond $ ListOfLinks ppe out
 
         codebaseByName = do
-          parseNames <- basicParseNames0
+          parseNames <- basicParseUnqualifiedNames
           case NamesWithHistory.lookupHQTerm dotDoc (NamesWithHistory.NamesWithHistory parseNames mempty) of
             s | Set.size s == 1 -> displayI ConsoleLocation dotDoc
               | Set.size s == 0 -> respond $ ListOfLinks mempty []
@@ -1216,7 +1216,7 @@ loop = do
                 pathArgStr = show pathArg
 
       SearchByNameI isVerbose _showAll ws -> do
-        let prettyPrintNames0 = basicPrettyPrintNames0
+        let prettyPrintUnqualifiedNames = basicPrettyPrintUnqualifiedNames
         unlessError do
           results <- case ws of
             -- no query, list everything
@@ -1241,12 +1241,12 @@ loop = do
                       -- aliases to a single search result; in non-verbose mode,
                       -- a separate result may be shown for each alias
                         (if isVerbose then uniqueBy SR.toReferent else id) $
-                        searchResultsFor prettyPrintNames0 matches []
+                        searchResultsFor prettyPrintUnqualifiedNames matches []
                   pure . pure $ results
 
             -- name query
             (map HQ.unsafeFromString -> qs) -> do
-              let ns = basicPrettyPrintNames0
+              let ns = basicPrettyPrintUnqualifiedNames
               let srs = searchBranchScored ns fuzzyNameDistance qs
               pure $ uniqueBy SR.toReferent srs
           lift do
@@ -1383,7 +1383,7 @@ loop = do
           sr <- Slurp.disallowUpdates
               . applySelection hqs uf
               . toSlurpResult currentPath' uf
-             <$> slurpResultNames0
+             <$> slurpResultUnqualifiedNames
           let adds = Slurp.adds sr
           when (Slurp.isNonempty sr) $ do
             stepAtNoSync ( Path.unabsolute currentPath'
@@ -1399,7 +1399,7 @@ loop = do
           sr <-  Slurp.disallowUpdates
                     .  applySelection hqs uf
                     .  toSlurpResult currentPath' uf
-                   <$> slurpResultNames0
+                   <$> slurpResultUnqualifiedNames
           previewResponse sourceName sr uf
         _ -> respond NoUnisonFile
 
@@ -1407,18 +1407,18 @@ loop = do
         Nothing -> respond NoUnisonFile
         Just uf -> do
           let patchPath = fromMaybe defaultPatchPath maybePatchPath
-          slurpCheckNames0 <- slurpResultNames0
-          currentPathNames0 <- currentPathNames0
+          slurpCheckUnqualifiedNames <- slurpResultUnqualifiedNames
+          currentPathUnqualifiedNames <- currentPathUnqualifiedNames
           let sr = applySelection hqs uf
                  . toSlurpResult currentPath' uf
-                 $ slurpCheckNames0
+                 $ slurpCheckUnqualifiedNames
               addsAndUpdates = Slurp.updates sr <> Slurp.adds sr
-              fileNames0 = UF.typecheckedToNames0 uf
+              fileUnqualifiedNames = UF.typecheckedToUnqualifiedNames uf
               -- todo: display some error if typeEdits or termEdits itself contains a loop
               typeEdits :: Map Name (Reference, Reference)
               typeEdits = Map.fromList $ map f (toList $ SC.types (updates sr)) where
-                f v = case (toList (Names.typesNamed slurpCheckNames0 n)
-                           ,toList (Names.typesNamed fileNames0 n)) of
+                f v = case (toList (Names.typesNamed slurpCheckUnqualifiedNames n)
+                           ,toList (Names.typesNamed fileUnqualifiedNames n)) of
                   ([old],[new]) -> (n, (old, new))
                   _ -> error $ "Expected unique matches for "
                                   ++ Var.nameStr v ++ " but got: "
@@ -1429,8 +1429,8 @@ loop = do
                 hashTerms0 = (\(r, _wk, _tm, typ) -> (r, typ)) <$> UF.hashTerms uf
               termEdits :: Map Name (Reference, Reference)
               termEdits = Map.fromList $ map g (toList $ SC.terms (updates sr)) where
-                g v = case ( toList (Names.refTermsNamed slurpCheckNames0 n)
-                           , toList (Names.refTermsNamed fileNames0 n)) of
+                g v = case ( toList (Names.refTermsNamed slurpCheckUnqualifiedNames n)
+                           , toList (Names.refTermsNamed fileUnqualifiedNames n)) of
                   ([old], [new]) -> (n, (old, new))
                   _ -> error $ "Expected unique matches for "
                                  ++ Var.nameStr v ++ " but got: "
@@ -1439,7 +1439,7 @@ loop = do
               termDeprecations :: [(Name, Referent)]
               termDeprecations =
                 [ (n, r) | (oldTypeRef,_) <- Map.elems typeEdits
-                         , (n, r) <- NamesWithHistory.constructorsForType0 oldTypeRef currentPathNames0 ]
+                         , (n, r) <- NamesWithHistory.constructorsForType0 oldTypeRef currentPathUnqualifiedNames ]
 
           ye'ol'Patch <- getPatchAt patchPath
           -- If `uf` updates a -> a', we want to replace all (a0 -> a) in patch
@@ -1503,7 +1503,7 @@ loop = do
         (Just (sourceName, _), Just uf) -> do
           sr <-  applySelection hqs uf
                     .  toSlurpResult currentPath' uf
-                   <$> slurpResultNames0
+                   <$> slurpResultUnqualifiedNames
           previewResponse sourceName sr uf
         _ -> respond NoUnisonFile
 
@@ -1580,11 +1580,11 @@ loop = do
 
       ExecuteI main -> addRunMain main uf >>= \case
         NoTermWithThatName -> do
-          ppe <- suffixifiedPPE (NamesWithHistory.NamesWithHistory basicPrettyPrintNames0 mempty)
+          ppe <- suffixifiedPPE (NamesWithHistory.NamesWithHistory basicPrettyPrintUnqualifiedNames mempty)
           mainType <- eval RuntimeMain
           respond $ NoMainFunction main ppe [mainType]
         TermHasBadType ty -> do
-          ppe <- suffixifiedPPE (NamesWithHistory.NamesWithHistory basicPrettyPrintNames0 mempty)
+          ppe <- suffixifiedPPE (NamesWithHistory.NamesWithHistory basicPrettyPrintUnqualifiedNames mempty)
           mainType <- eval RuntimeMain
           respond $ BadMainFunction main ty ppe [mainType]
         RunMainSuccess unisonFile -> do
@@ -1598,7 +1598,7 @@ loop = do
       MakeStandaloneI output main -> do
         mainType <- eval RuntimeMain
         parseNames <-
-          flip NamesWithHistory.NamesWithHistory mempty <$> basicPrettyPrintNames0A
+          flip NamesWithHistory.NamesWithHistory mempty <$> basicPrettyPrintUnqualifiedNamesA
         ppe <- suffixifiedPPE parseNames
         let resolved = toList $ NamesWithHistory.lookupHQTerm main parseNames
             smain = HQ.toString main
@@ -1617,7 +1617,7 @@ loop = do
       IOTestI main -> do
         -- todo - allow this to run tests from scratch file, using addRunMain
         testType <- eval RuntimeTest
-        parseNames <- (`NamesWithHistory.NamesWithHistory` mempty) <$> basicPrettyPrintNames0A
+        parseNames <- (`NamesWithHistory.NamesWithHistory` mempty) <$> basicPrettyPrintUnqualifiedNamesA
         ppe <- suffixifiedPPE parseNames
         -- use suffixed names for resolving the argument to display
         let
@@ -1663,7 +1663,7 @@ loop = do
         eval $ AddDefsToCodebase uf
         -- add the names; note, there are more names than definitions
         -- due to builtin terms; so we don't just reuse `uf` above.
-        let srcb = BranchUtil.fromNames0 Builtin.names0
+        let srcb = BranchUtil.fromUnqualifiedNames Builtin.names0
         _ <- updateAtM (currentPath' `snoc` "builtin") $ \destb ->
                eval $ Merge Branch.RegularMerge srcb destb
         success
@@ -1682,8 +1682,8 @@ loop = do
         -- add the names; note, there are more names than definitions
         -- due to builtin terms; so we don't just reuse `uf` above.
         let names0 = Builtin.names0
-                     <> UF.typecheckedToNames0 @v IOSource.typecheckedFile'
-        let srcb = BranchUtil.fromNames0 names0
+                     <> UF.typecheckedToUnqualifiedNames @v IOSource.typecheckedFile'
+        let srcb = BranchUtil.fromUnqualifiedNames names0
         _ <- updateAtM (currentPath' `snoc` "builtin") $ \destb ->
                eval $ Merge Branch.RegularMerge srcb destb
 
@@ -1884,7 +1884,7 @@ loop = do
 resolveHQToLabeledDependencies :: Functor m => HQ.HashQualified Name -> Action' m v (Set LabeledDependency)
 resolveHQToLabeledDependencies = \case
   HQ.NameOnly n -> do
-    parseNames <- basicParseNames0
+    parseNames <- basicParseUnqualifiedNames
     let terms, types :: Set LabeledDependency
         terms = Set.map LD.referent . Name.searchBySuffix n $ NamesWithHistory.terms0 parseNames
         types = Set.map LD.typeRef  . Name.searchBySuffix n $ NamesWithHistory.types0 parseNames
@@ -1988,7 +1988,7 @@ propagatePatchNoSync
   -> Action' m v Bool
 propagatePatchNoSync patch scopePath = do
   r <- use root
-  let nroot = Branch.toNames0 (Branch.head r)
+  let nroot = Branch.toUnqualifiedNames (Branch.head r)
   stepAtMNoSync' (Path.unabsolute scopePath,
                   lift . lift . Propagate.propagateAndApply nroot patch)
 
@@ -1997,7 +1997,7 @@ propagatePatch :: (Monad m, Var v) =>
   InputDescription -> Patch -> Path.Absolute -> Action' m v Bool
 propagatePatch inputDescription patch scopePath = do
   r <- use root
-  let nroot = Branch.toNames0 (Branch.head r)
+  let nroot = Branch.toUnqualifiedNames (Branch.head r)
   stepAtM' (inputDescription <> " (applying patch)")
            (Path.unabsolute scopePath,
               lift . lift . Propagate.propagateAndApply nroot patch)
@@ -2006,7 +2006,7 @@ propagatePatch inputDescription patch scopePath = do
 doShowTodoOutput :: Monad m => Patch -> Path.Absolute -> Action' m v ()
 doShowTodoOutput patch scopePath = do
   scope <- getAt scopePath
-  let names0 = Branch.toNames0 (Branch.head scope)
+  let names0 = Branch.toUnqualifiedNames (Branch.head scope)
   -- only needs the local references to check for obsolete defs
   let getPpe = do
         names <- makePrintNamesFromLabeled' (Patch.labeledDependencies patch)
@@ -2019,7 +2019,7 @@ showTodoOutput
      -- ^ Action that fetches the pretty print env. It's expensive because it
      -- involves looking up historical names, so only call it if necessary.
   -> Patch
-  -> Names0
+  -> UnqualifiedNames
   -> Action' m v ()
 showTodoOutput getPpe patch names0 = do
   todo <- checkTodo patch names0
@@ -2032,7 +2032,7 @@ showTodoOutput getPpe patch names0 = do
       ppe <- getPpe
       respond $ TodoOutput ppe todo
 
-checkTodo :: Patch -> Names0 -> Action m i v (TO.TodoOutput v Ann)
+checkTodo :: Patch -> UnqualifiedNames -> Action m i v (TO.TodoOutput v Ann)
 checkTodo patch names0 = do
   f <- computeFrontier (eval . GetDependents) patch names0
   let dirty = R.dom f
@@ -2057,7 +2057,7 @@ checkTodo patch names0 = do
       (Patch.conflicts patch)
   where
   frontierTransitiveDependents ::
-    Monad m => (Reference -> m (Set Reference)) -> Names0 -> Set Reference -> m (Set Reference)
+    Monad m => (Reference -> m (Set Reference)) -> UnqualifiedNames -> Set Reference -> m (Set Reference)
   frontierTransitiveDependents dependents names0 rs = do
     let branchDependents r = Set.filter (Names.contains names0) <$> dependents r
     tdeps <- transitiveClosure branchDependents rs
@@ -2075,7 +2075,7 @@ checkTodo patch names0 = do
 computeFrontier :: forall m . Monad m
          => (Reference -> m (Set Reference)) -- eg Codebase.dependents codebase
          -> Patch
-         -> Names0
+         -> UnqualifiedNames
          -> m (R.Relation Reference Reference)
 computeFrontier getDependents patch names = let
   edited :: Set Reference
@@ -2099,7 +2099,7 @@ confirmedCommand i = do
   pure $ Just i == i0
 
 listBranch :: Branch0 m -> [SearchResult]
-listBranch (Branch.toNames0 -> b) =
+listBranch (Branch.toUnqualifiedNames -> b) =
   List.sortOn (\s -> (SR.name s, s)) (SR.fromNames b)
 
 -- | restores the full hash to these search results, for _numberedArgs purposes
@@ -2123,14 +2123,14 @@ _searchBranchPrefix b n = case Path.unsnoc (Path.fromName n) of
     Just b -> SR.fromNames . Names.prefix0 n $ names0
       where
       lastName = Path.toName (Path.singleton last)
-      subnames = Branch.toNames0 . Branch.head $
+      subnames = Branch.toUnqualifiedNames . Branch.head $
                    Branch.getAt' (Path.singleton last) b
       rootnames =
         Names.filter (== lastName) .
-        Branch.toNames0 . set Branch.children mempty $ Branch.head b
+        Branch.toUnqualifiedNames . set Branch.children mempty $ Branch.head b
       names0 = rootnames <> Names.prefix0 lastName subnames
 
-searchResultsFor :: Names0 -> [Referent] -> [Reference] -> [SearchResult]
+searchResultsFor :: UnqualifiedNames -> [Referent] -> [Reference] -> [SearchResult]
 searchResultsFor ns terms types =
   [ SR.termSearchResult ns name ref
   | ref <- terms
@@ -2142,7 +2142,7 @@ searchResultsFor ns terms types =
   ]
 
 searchBranchScored :: forall score. (Ord score)
-              => Names0
+              => UnqualifiedNames
               -> (Name -> Name -> Maybe score)
               -> [HQ.HashQualified Name]
               -> [SearchResult]
@@ -2428,9 +2428,9 @@ zeroOneOrMore f zero one more = case toList f of
 -- `toBeDeleted`), then complain by returning (Y, X).
 getEndangeredDependents :: forall m. Monad m
                         => (Reference -> m (Set Reference))
-                        -> Names0
-                        -> Names0
-                        -> m (Names0, Names0)
+                        -> UnqualifiedNames
+                        -> UnqualifiedNames
+                        -> m (UnqualifiedNames, UnqualifiedNames)
 getEndangeredDependents getDependents toDelete root = do
   let remaining  = root `Names.difference` toDelete
       toDelete', remaining', extinct :: Set Reference
@@ -2467,14 +2467,14 @@ applySelection hqs file = \sr@SlurpResult{..} ->
      , extraDefinitions = closed `SC.difference` selection
      }
   where
-  selectedNames0 =
-    Names.filterByHQs (Set.fromList hqs) (UF.typecheckedToNames0 file)
+  selectedUnqualifiedNames =
+    Names.filterByHQs (Set.fromList hqs) (UF.typecheckedToUnqualifiedNames file)
   selection, closed :: SlurpComponent v
   selection = SlurpComponent selectedTypes selectedTerms
   closed = SC.closeWithDependencies file selection
   selectedTypes, selectedTerms :: Set v
-  selectedTypes = Set.map var $ R.dom (Names.types selectedNames0)
-  selectedTerms = Set.map var $ R.dom (Names.terms selectedNames0)
+  selectedTypes = Set.map var $ R.dom (Names.types selectedUnqualifiedNames)
+  selectedTerms = Set.map var $ R.dom (Names.terms selectedUnqualifiedNames)
 
 var :: Var v => Name -> v
 var name = Var.named (Name.toText name)
@@ -2484,7 +2484,7 @@ toSlurpResult
    . Var v
   => Path.Absolute
   -> UF.TypecheckedUnisonFile v Ann
-  -> Names0
+  -> UnqualifiedNames
   -> SlurpResult v
 toSlurpResult currentPath uf existingNames =
   Slurp.subtractComponent (conflicts <> ctorCollisions) $ SlurpResult
@@ -2501,7 +2501,7 @@ toSlurpResult currentPath uf existingNames =
     typeAliases
     mempty
   where
-  fileNames0 = UF.typecheckedToNames0 uf
+  fileUnqualifiedNames = UF.typecheckedToUnqualifiedNames uf
 
   sc :: R.Relation Name Referent -> R.Relation Name Reference -> SlurpComponent v
   sc terms types = SlurpComponent { terms = Set.map var (R.dom terms)
@@ -2511,9 +2511,9 @@ toSlurpResult currentPath uf existingNames =
   conflicts :: SlurpComponent v
   conflicts = sc terms types where
     terms = R.filterDom (conflicted . Names.termsNamed existingNames)
-                        (Names.terms fileNames0)
+                        (Names.terms fileUnqualifiedNames)
     types = R.filterDom (conflicted . Names.typesNamed existingNames)
-                        (Names.types fileNames0)
+                        (Names.types fileUnqualifiedNames)
     conflicted s = Set.size s > 1
 
   ctorCollisions :: SlurpComponent v
@@ -2525,7 +2525,7 @@ toSlurpResult currentPath uf existingNames =
   termCtorCollisions :: Set v
   termCtorCollisions = Set.fromList
     [ var n
-    | (n, Referent.Ref{}) <- R.toList (Names.terms fileNames0)
+    | (n, Referent.Ref{}) <- R.toList (Names.terms fileUnqualifiedNames)
     , [r@Referent.Con{}]  <- [toList $ Names.termsNamed existingNames n]
     -- ignore collisions w/ ctors of types being updated
     , Set.notMember (Referent.toReference r) typesToUpdate
@@ -2535,7 +2535,7 @@ toSlurpResult currentPath uf existingNames =
   typesToUpdate :: Set Reference
   typesToUpdate = Set.fromList
     [ r
-    | (n, r') <- R.toList (Names.types fileNames0)
+    | (n, r') <- R.toList (Names.types fileUnqualifiedNames)
     , r       <- toList (Names.typesNamed existingNames n)
     , r /= r'
     ]
@@ -2546,7 +2546,7 @@ toSlurpResult currentPath uf existingNames =
   ctorTermCollisions :: Set v
   ctorTermCollisions = Set.fromList
     [ var n
-    | (n, Referent.Con{}) <- R.toList (Names.terms fileNames0)
+    | (n, Referent.Con{}) <- R.toList (Names.terms fileUnqualifiedNames)
     , r                   <- toList $ Names.termsNamed existingNames n
     -- ignore collisions w/ ctors of types being updated
     , Set.notMember (Referent.toReference r) typesToUpdate
@@ -2556,21 +2556,21 @@ toSlurpResult currentPath uf existingNames =
   -- duplicate (n,r) if (n,r) exists in names0
   dups :: SlurpComponent v
   dups = sc terms types where
-    terms = R.intersection (Names.terms existingNames) (Names.terms fileNames0)
-    types = R.intersection (Names.types existingNames) (Names.types fileNames0)
+    terms = R.intersection (Names.terms existingNames) (Names.terms fileUnqualifiedNames)
+    types = R.intersection (Names.types existingNames) (Names.types fileUnqualifiedNames)
 
   -- update (n,r) if (n,r' /= r) exists in existingNames and r, r' are Ref
   updates :: SlurpComponent v
   updates = SlurpComponent (Set.fromList types) (Set.fromList terms) where
     terms =
       [ var n
-      | (n, r'@Referent.Ref{}) <- R.toList (Names.terms fileNames0)
+      | (n, r'@Referent.Ref{}) <- R.toList (Names.terms fileUnqualifiedNames)
       , [r@Referent.Ref{}]     <- [toList $ Names.termsNamed existingNames n]
       , r' /= r
       ]
     types =
       [ var n
-      | (n, r') <- R.toList (Names.types fileNames0)
+      | (n, r') <- R.toList (Names.types fileUnqualifiedNames)
       , [r]     <- [toList $ Names.typesNamed existingNames n]
       , r' /= r
       ]
@@ -2602,18 +2602,18 @@ toSlurpResult currentPath uf existingNames =
 
   termAliases :: Map v Slurp.Aliases
   termAliases = buildAliases (Names.terms existingNames)
-                             (Names.terms fileNames0)
+                             (Names.terms fileUnqualifiedNames)
                              (SC.terms dups)
 
   typeAliases :: Map v Slurp.Aliases
   typeAliases = buildAliases (R.mapRan Referent.Ref $ Names.types existingNames)
-                             (R.mapRan Referent.Ref $ Names.types fileNames0)
+                             (R.mapRan Referent.Ref $ Names.types fileUnqualifiedNames)
                              (SC.types dups)
 
   -- (n,r) is in `adds` if n isn't in existingNames
   adds = sc terms types where
-    terms = addTerms (Names.terms existingNames) (Names.terms fileNames0)
-    types = addTypes (Names.types existingNames) (Names.types fileNames0)
+    terms = addTerms (Names.terms existingNames) (Names.terms fileUnqualifiedNames)
+    types = addTypes (Names.types existingNames) (Names.types fileUnqualifiedNames)
     addTerms existingNames = R.filter go where
       go (n, Referent.Ref{}) = (not . R.memberDom n) existingNames
       go _ = False
@@ -2653,7 +2653,7 @@ doSlurpAdds slurp uf = Branch.stepManyAt0 (typeActions <> termActions)
   typeActions = map doType . toList $ SC.types slurp
   termActions = map doTerm . toList $
     SC.terms slurp <> Slurp.constructorsFor (SC.types slurp) uf
-  names = UF.typecheckedToNames0 uf
+  names = UF.typecheckedToUnqualifiedNames uf
   tests = Set.fromList $ fst <$> UF.watchesOfKind WK.TestWatch (UF.discardTypes uf)
   (isTestType, isTestValue) = isTest
   md v =
@@ -2731,7 +2731,7 @@ loadDisplayInfo refs = do
 -- e.g. if currentPath = .foo.bar
 --      then name foo.bar.baz becomes baz
 --           name cat.dog     becomes .cat.dog
-fixupNamesRelative :: Path.Absolute -> Names0 -> Names0
+fixupNamesRelative :: Path.Absolute -> UnqualifiedNames -> UnqualifiedNames
 fixupNamesRelative currentPath' = NamesWithHistory.map0 fixName where
   prefix = Path.toName (Path.unabsolute currentPath')
   fixName n = if currentPath' == Path.absoluteEmpty then n else
@@ -2741,9 +2741,9 @@ makeHistoricalParsingNames ::
   Monad m => Set (HQ.HashQualified Name) -> Action' m v NamesWithHistory
 makeHistoricalParsingNames lexedHQs = do
   rawHistoricalNames <- findHistoricalHQs lexedHQs
-  basicNames0 <- basicParseNames0
+  basicUnqualifiedNames <- basicParseUnqualifiedNames
   currentPath <- use currentPath
-  pure $ NamesWithHistory basicNames0
+  pure $ NamesWithHistory basicUnqualifiedNames
                (NamesWithHistory.makeAbsolute0 rawHistoricalNames <>
                  fixupNamesRelative currentPath rawHistoricalNames)
 
@@ -2783,7 +2783,7 @@ parseType :: (Monad m, Var v)
 parseType input src = do
   -- `show Input` is the name of the "file" being lexed
   (names0, lexed) <- lexedSource (Text.pack $ show input) (Text.pack src)
-  parseNames <- basicParseNames0
+  parseNames <- basicParseUnqualifiedNames
   let names = NamesWithHistory.push (NamesWithHistory.currentNames names0)
                           (NamesWithHistory.NamesWithHistory parseNames (NamesWithHistory.oldNames names0))
   e <- eval $ ParseType names lexed
@@ -2795,7 +2795,7 @@ parseType input src = do
       Right typ -> Right typ
 
 makeShadowedPrintNamesFromLabeled
-  :: Monad m => Set LabeledDependency -> Names0 -> Action' m v NamesWithHistory
+  :: Monad m => Set LabeledDependency -> UnqualifiedNames -> Action' m v NamesWithHistory
 makeShadowedPrintNamesFromLabeled deps shadowing =
   NamesWithHistory.shadowing shadowing <$> makePrintNamesFromLabeled' deps
 
@@ -2807,8 +2807,8 @@ makePrintNamesFromLabeled' deps = do
   (_missing, rawHistoricalNames) <- eval . Eval $ Branch.findHistoricalRefs
     deps
     root
-  basicNames0 <- basicPrettyPrintNames0A
-  pure $ NamesWithHistory basicNames0 (fixupNamesRelative currentPath rawHistoricalNames)
+  basicUnqualifiedNames <- basicPrettyPrintUnqualifiedNamesA
+  pure $ NamesWithHistory basicUnqualifiedNames (fixupNamesRelative currentPath rawHistoricalNames)
 
 getTermsIncludingHistorical
   :: Monad m => Path.HQSplit -> Branch0 m -> Action' m v (Set Referent)
@@ -2824,7 +2824,7 @@ getTermsIncludingHistorical (p, hq) b = case Set.toList refs of
 
 -- discards inputs that aren't hashqualified;
 -- I'd enforce it with finer-grained types if we had them.
-findHistoricalHQs :: Monad m => Set (HQ.HashQualified Name) -> Action' m v Names0
+findHistoricalHQs :: Monad m => Set (HQ.HashQualified Name) -> Action' m v UnqualifiedNames
 findHistoricalHQs lexedHQs0 = do
   root <- use root
   currentPath <- use currentPath
@@ -2846,38 +2846,38 @@ findHistoricalHQs lexedHQs0 = do
   (_missing, rawHistoricalNames) <- eval . Eval $ Branch.findHistoricalHQs lexedHQs root
   pure rawHistoricalNames
 
-basicPrettyPrintNames0A :: Functor m => Action' m v Names0
-basicPrettyPrintNames0A = snd <$> basicNames0'
+basicPrettyPrintUnqualifiedNamesA :: Functor m => Action' m v UnqualifiedNames
+basicPrettyPrintUnqualifiedNamesA = snd <$> basicUnqualifiedNames'
 
-makeShadowedPrintNamesFromHQ :: Monad m => Set (HQ.HashQualified Name) -> Names0 -> Action' m v NamesWithHistory
+makeShadowedPrintNamesFromHQ :: Monad m => Set (HQ.HashQualified Name) -> UnqualifiedNames -> Action' m v NamesWithHistory
 makeShadowedPrintNamesFromHQ lexedHQs shadowing = do
   rawHistoricalNames <- findHistoricalHQs lexedHQs
-  basicNames0 <- basicPrettyPrintNames0A
+  basicUnqualifiedNames <- basicPrettyPrintUnqualifiedNamesA
   currentPath <- use currentPath
   -- The basic names go into "current", but are shadowed by "shadowing".
   -- They go again into "historical" as a hack that makes them available HQ-ed.
   pure $
     NamesWithHistory.shadowing
       shadowing
-      (NamesWithHistory basicNames0 (fixupNamesRelative currentPath rawHistoricalNames))
+      (NamesWithHistory basicUnqualifiedNames (fixupNamesRelative currentPath rawHistoricalNames))
 
-basicParseNames0, slurpResultNames0 :: Functor m => Action' m v Names0
-basicParseNames0 = fst <$> basicNames0'
+basicParseUnqualifiedNames, slurpResultUnqualifiedNames :: Functor m => Action' m v UnqualifiedNames
+basicParseUnqualifiedNames = fst <$> basicUnqualifiedNames'
 -- we check the file against everything in the current path
-slurpResultNames0 = currentPathNames0
+slurpResultUnqualifiedNames = currentPathUnqualifiedNames
 
-currentPathNames0 :: Functor m => Action' m v Names0
-currentPathNames0 = do
+currentPathUnqualifiedNames :: Functor m => Action' m v UnqualifiedNames
+currentPathUnqualifiedNames = do
   currentPath' <- use currentPath
   currentBranch' <- getAt currentPath'
-  pure $ Branch.toNames0 (Branch.head currentBranch')
+  pure $ Branch.toUnqualifiedNames (Branch.head currentBranch')
 
--- implementation detail of basicParseNames0 and basicPrettyPrintNames0
-basicNames0' :: Functor m => Action' m v (Names0, Names0)
-basicNames0' = do
+-- implementation detail of basicParseUnqualifiedNames and basicPrettyPrintUnqualifiedNames
+basicUnqualifiedNames' :: Functor m => Action' m v (UnqualifiedNames, UnqualifiedNames)
+basicUnqualifiedNames' = do
   root' <- use root
   currentPath' <- use currentPath
-  pure $ Backend.basicNames0' root' (Path.unabsolute currentPath')
+  pure $ Backend.basicUnqualifiedNames' root' (Path.unabsolute currentPath')
 
 data AddRunMainResult v
   = NoTermWithThatName
@@ -2921,11 +2921,11 @@ addRunMain
   -> Maybe (TypecheckedUnisonFile v Ann)
   -> Action' m v (AddRunMainResult v)
 addRunMain mainName Nothing = do
-  parseNames0 <- basicParseNames0
+  parseUnqualifiedNames <- basicParseUnqualifiedNames
   let loadTypeOfTerm ref = eval $ LoadTypeOfTerm ref
   mainType <- eval RuntimeMain
   mainToFile <$>
-    MainTerm.getMainTerm loadTypeOfTerm parseNames0 mainName mainType
+    MainTerm.getMainTerm loadTypeOfTerm parseUnqualifiedNames mainName mainType
   where
     mainToFile (MainTerm.NotAFunctionName _) = NoTermWithThatName
     mainToFile (MainTerm.NotFound _) = NoTermWithThatName
@@ -2967,7 +2967,7 @@ displayNames unisonFile =
   -- voodoo
   makeShadowedPrintNamesFromLabeled
     (UF.termSignatureExternalLabeledDependencies unisonFile)
-    (UF.typecheckedToNames0 unisonFile)
+    (UF.typecheckedToUnqualifiedNames unisonFile)
 
 diffHelper :: Monad m
   => Branch0 m
@@ -2976,15 +2976,15 @@ diffHelper :: Monad m
 diffHelper before after = do
   hqLength <- eval CodebaseHashLength
   diff     <- eval . Eval $ BranchDiff.diff0 before after
-  names0 <- basicPrettyPrintNames0A
+  names0 <- basicPrettyPrintUnqualifiedNamesA
   ppe <- PPE.suffixifiedPPE <$> prettyPrintEnvDecl (NamesWithHistory names0 mempty)
   (ppe,) <$>
     OBranchDiff.toOutput
       loadTypeOfTerm
       declOrBuiltin
       hqLength
-      (Branch.toNames0 before)
-      (Branch.toNames0 after)
+      (Branch.toUnqualifiedNames before)
+      (Branch.toUnqualifiedNames after)
       ppe
       diff
 

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1439,7 +1439,7 @@ loop = do
               termDeprecations :: [(Name, Referent)]
               termDeprecations =
                 [ (n, r) | (oldTypeRef,_) <- Map.elems typeEdits
-                         , (n, r) <- NamesWithHistory.constructorsForType0 oldTypeRef currentPathNames ]
+                         , (n, r) <- Names.constructorsForType oldTypeRef currentPathNames ]
 
           ye'ol'Patch <- getPatchAt patchPath
           -- If `uf` updates a -> a', we want to replace all (a0 -> a) in patch
@@ -1735,7 +1735,7 @@ loop = do
               tm (Referent.Con r _i _ct) = eval $ GetDependents r
               in LD.fold tp tm ld
             (missing, names0) <- eval . Eval $ Branch.findHistoricalRefs' dependents root'
-            let types = R.toList $ NamesWithHistory.types0 names0
+            let types = R.toList $ Names.types names0
             let terms = fmap (second Referent.toReference) $ R.toList $ Names.terms names0
             let names = types <> terms
             numberedArgs .= fmap (Text.unpack . Reference.toText) ((fmap snd names) <> toList missing)
@@ -1761,7 +1761,7 @@ loop = do
               tm _ = pure mempty
               in LD.fold tp tm ld
             (missing, names0) <- eval . Eval $ Branch.findHistoricalRefs' dependencies root'
-            let types = R.toList $ NamesWithHistory.types0 names0
+            let types = R.toList $ Names.types names0
             let terms = fmap (second Referent.toReference) $ R.toList $ Names.terms names0
             let names = types <> terms
             numberedArgs .= fmap (Text.unpack . Reference.toText) ((fmap snd names) <> toList missing)
@@ -1886,8 +1886,8 @@ resolveHQToLabeledDependencies = \case
   HQ.NameOnly n -> do
     parseNames <- basicParseNames
     let terms, types :: Set LabeledDependency
-        terms = Set.map LD.referent . Name.searchBySuffix n $ NamesWithHistory.terms0 parseNames
-        types = Set.map LD.typeRef  . Name.searchBySuffix n $ NamesWithHistory.types0 parseNames
+        terms = Set.map LD.referent . Name.searchBySuffix n $ Names.terms parseNames
+        types = Set.map LD.typeRef  . Name.searchBySuffix n $ Names.types parseNames
     pure $ terms <> types
   -- rationale: the hash should be unique enough that the name never helps
   HQ.HashQualified _n sh -> resolveHashOnly sh
@@ -2732,7 +2732,7 @@ loadDisplayInfo refs = do
 --      then name foo.bar.baz becomes baz
 --           name cat.dog     becomes .cat.dog
 fixupNamesRelative :: Path.Absolute -> Names -> Names
-fixupNamesRelative currentPath' = NamesWithHistory.map0 fixName where
+fixupNamesRelative currentPath' = Names.map fixName where
   prefix = Path.toName (Path.unabsolute currentPath')
   fixName n = if currentPath' == Path.absoluteEmpty then n else
     fromMaybe (Name.makeAbsolute n) (Name.stripNamePrefix prefix n)
@@ -2744,7 +2744,7 @@ makeHistoricalParsingNames lexedHQs = do
   basicNames <- basicParseNames
   currentPath <- use currentPath
   pure $ NamesWithHistory basicNames
-               (NamesWithHistory.makeAbsolute0 rawHistoricalNames <>
+               (Names.makeAbsolute rawHistoricalNames <>
                  fixupNamesRelative currentPath rawHistoricalNames)
 
 loadTypeDisplayObject

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -86,7 +86,7 @@ import qualified Unison.HashQualified'         as HQ'
 import qualified Unison.Name                   as Name
 import           Unison.Name                    ( Name )
 import           Unison.NamesWithHistory        ( NamesWithHistory(..) )
-import Unison.Names                             (UnqualifiedNames, pattern UnqualifiedNames )
+import Unison.Names                             (Names, pattern Names )
 import qualified Unison.Names                 as Names
 import qualified Unison.NamesWithHistory      as NamesWithHistory
 import Unison.Parser.Ann (Ann(..))
@@ -242,8 +242,8 @@ loop = do
       getHQ'Types :: Path.HQSplit' -> Set Reference
       getHQ'Types p = BranchUtil.getType (resolveSplit' p) root0
 
-      basicPrettyPrintUnqualifiedNames =
-        Backend.basicPrettyPrintUnqualifiedNames root' (Path.unabsolute currentPath')
+      basicPrettyPrintNames =
+        Backend.basicPrettyPrintNames root' (Path.unabsolute currentPath')
 
       resolveHHQS'Types :: HashOrHQSplit' -> Action' m v (Set Reference)
       resolveHHQS'Types = either
@@ -296,7 +296,7 @@ loop = do
       loadUnisonFile sourceName text = do
         let lexed = L.lexer (Text.unpack sourceName) (Text.unpack text)
         withFile [] sourceName (text, lexed) $ \unisonFile -> do
-          sr <- toSlurpResult currentPath' unisonFile <$> slurpResultUnqualifiedNames
+          sr <- toSlurpResult currentPath' unisonFile <$> slurpResultNames
           names <- displayNames unisonFile
           pped <- prettyPrintEnvDecl names
           let ppe = PPE.suffixifiedPPE pped
@@ -616,12 +616,12 @@ loop = do
           where
           resolvedPath = resolveSplit' (HQ'.toName <$> hq)
           goMany tms tys = do
-            let rootNames = Branch.toUnqualifiedNames root0
+            let rootNames = Branch.toNames root0
                 name = Path.toName (Path.unsplit resolvedPath)
                 toRel :: Ord ref => Set ref -> R.Relation Name ref
                 toRel = R.fromList . fmap (name,) . toList
                 -- these names are relative to the root
-                toDelete = UnqualifiedNames (toRel tms) (toRel tys)
+                toDelete = Names (toRel tms) (toRel tys)
             (failed, failedDependents) <-
               getEndangeredDependents (eval . GetDependents) toDelete rootNames
             if failed == mempty then do
@@ -637,8 +637,8 @@ loop = do
           uf <- use latestTypecheckedFile >>= addWatch (HQ.toString hq)
           case uf of
             Nothing -> do
-              let parseUnqualifiedNames = (`NamesWithHistory.NamesWithHistory` mempty) basicPrettyPrintUnqualifiedNames
-                  results = NamesWithHistory.lookupHQTerm hq parseUnqualifiedNames
+              let parseNames = (`NamesWithHistory.NamesWithHistory` mempty) basicPrettyPrintNames
+                  results = NamesWithHistory.lookupHQTerm hq parseNames
               if Set.null results then
                 respond $ SearchTermsNotFound [hq]
               else if Set.size results > 1 then
@@ -646,11 +646,11 @@ loop = do
               -- ... but use the unsuffixed names for display
               else do
                 let tm = Term.fromReferent External $ Set.findMin results
-                pped <- prettyPrintEnvDecl parseUnqualifiedNames
+                pped <- prettyPrintEnvDecl parseNames
                 tm <- eval $ Evaluate1 (PPE.suffixifiedPPE pped) True tm
                 case tm of
                   Left e -> respond (EvaluationFailure e)
-                  Right tm -> doDisplay outputLoc parseUnqualifiedNames (Term.unannotate tm)
+                  Right tm -> doDisplay outputLoc parseNames (Term.unannotate tm)
             Just (toDisplay, unisonFile) -> do
               ppe <- executePPE unisonFile
               unlessError' EvaluationFailure do
@@ -853,10 +853,10 @@ loop = do
         where
         go (Branch.head -> b) = do
           (failed, failedDependents) <-
-            let rootNames = Branch.toUnqualifiedNames root0
+            let rootNames = Branch.toNames root0
                 toDelete = Names.prefix0
                   (Path.toName . Path.unsplit . resolveSplit' $ p) -- resolveSplit' incorporates currentPath
-                  (Branch.toUnqualifiedNames b)
+                  (Branch.toNames b)
             in getEndangeredDependents (eval . GetDependents) toDelete rootNames
           if failed == mempty then do
             stepAt $ BranchUtil.makeSetBranch (resolveSplit' p) Branch.empty
@@ -1014,11 +1014,11 @@ loop = do
         fixupOutput = fmap Path.toName . HQ'.toHQ . Path.unsplitHQ
 
       NamesI thing -> do
-        ns0 <- basicParseUnqualifiedNames
+        ns0 <- basicParseNames
         let ns = NamesWithHistory ns0 mempty
             terms = NamesWithHistory.lookupHQTerm thing ns
             types = NamesWithHistory.lookupHQType thing ns
-            printNames = NamesWithHistory basicPrettyPrintUnqualifiedNames mempty
+            printNames = NamesWithHistory basicPrettyPrintNames mempty
             terms' :: Set (Referent, Set (HQ'.HashQualified Name))
             terms' = Set.map go terms where
               go r = (r, NamesWithHistory.termName hqLength r printNames)
@@ -1060,7 +1060,7 @@ loop = do
         dotDoc = hq <&> \n -> Name.joinDot n "doc"
 
         fileByName = do
-          ns <- maybe mempty UF.typecheckedToUnqualifiedNames <$> use latestTypecheckedFile
+          ns <- maybe mempty UF.typecheckedToNames <$> use latestTypecheckedFile
           fnames <- pure $ NamesWithHistory.NamesWithHistory ns mempty
           case NamesWithHistory.lookupHQTerm dotDoc fnames of
             s | Set.size s == 1 -> do
@@ -1076,7 +1076,7 @@ loop = do
             [] -> codebaseByName
             [(_name, ref, _tm)] -> do
               len <- eval BranchHashLength
-              let names = NamesWithHistory.NamesWithHistory basicPrettyPrintUnqualifiedNames mempty
+              let names = NamesWithHistory.NamesWithHistory basicPrettyPrintNames mempty
               let tm = Term.ref External ref
               tm <- eval $ Evaluate1 (PPE.fromNames len names) True tm
               case tm of
@@ -1087,7 +1087,7 @@ loop = do
               respond $ ListOfLinks ppe out
 
         codebaseByName = do
-          parseNames <- basicParseUnqualifiedNames
+          parseNames <- basicParseNames
           case NamesWithHistory.lookupHQTerm dotDoc (NamesWithHistory.NamesWithHistory parseNames mempty) of
             s | Set.size s == 1 -> displayI ConsoleLocation dotDoc
               | Set.size s == 0 -> respond $ ListOfLinks mempty []
@@ -1216,7 +1216,7 @@ loop = do
                 pathArgStr = show pathArg
 
       SearchByNameI isVerbose _showAll ws -> do
-        let prettyPrintUnqualifiedNames = basicPrettyPrintUnqualifiedNames
+        let prettyPrintNames = basicPrettyPrintNames
         unlessError do
           results <- case ws of
             -- no query, list everything
@@ -1241,12 +1241,12 @@ loop = do
                       -- aliases to a single search result; in non-verbose mode,
                       -- a separate result may be shown for each alias
                         (if isVerbose then uniqueBy SR.toReferent else id) $
-                        searchResultsFor prettyPrintUnqualifiedNames matches []
+                        searchResultsFor prettyPrintNames matches []
                   pure . pure $ results
 
             -- name query
             (map HQ.unsafeFromString -> qs) -> do
-              let ns = basicPrettyPrintUnqualifiedNames
+              let ns = basicPrettyPrintNames
               let srs = searchBranchScored ns fuzzyNameDistance qs
               pure $ uniqueBy SR.toReferent srs
           lift do
@@ -1383,7 +1383,7 @@ loop = do
           sr <- Slurp.disallowUpdates
               . applySelection hqs uf
               . toSlurpResult currentPath' uf
-             <$> slurpResultUnqualifiedNames
+             <$> slurpResultNames
           let adds = Slurp.adds sr
           when (Slurp.isNonempty sr) $ do
             stepAtNoSync ( Path.unabsolute currentPath'
@@ -1399,7 +1399,7 @@ loop = do
           sr <-  Slurp.disallowUpdates
                     .  applySelection hqs uf
                     .  toSlurpResult currentPath' uf
-                   <$> slurpResultUnqualifiedNames
+                   <$> slurpResultNames
           previewResponse sourceName sr uf
         _ -> respond NoUnisonFile
 
@@ -1407,18 +1407,18 @@ loop = do
         Nothing -> respond NoUnisonFile
         Just uf -> do
           let patchPath = fromMaybe defaultPatchPath maybePatchPath
-          slurpCheckUnqualifiedNames <- slurpResultUnqualifiedNames
-          currentPathUnqualifiedNames <- currentPathUnqualifiedNames
+          slurpCheckNames <- slurpResultNames
+          currentPathNames <- currentPathNames
           let sr = applySelection hqs uf
                  . toSlurpResult currentPath' uf
-                 $ slurpCheckUnqualifiedNames
+                 $ slurpCheckNames
               addsAndUpdates = Slurp.updates sr <> Slurp.adds sr
-              fileUnqualifiedNames = UF.typecheckedToUnqualifiedNames uf
+              fileNames = UF.typecheckedToNames uf
               -- todo: display some error if typeEdits or termEdits itself contains a loop
               typeEdits :: Map Name (Reference, Reference)
               typeEdits = Map.fromList $ map f (toList $ SC.types (updates sr)) where
-                f v = case (toList (Names.typesNamed slurpCheckUnqualifiedNames n)
-                           ,toList (Names.typesNamed fileUnqualifiedNames n)) of
+                f v = case (toList (Names.typesNamed slurpCheckNames n)
+                           ,toList (Names.typesNamed fileNames n)) of
                   ([old],[new]) -> (n, (old, new))
                   _ -> error $ "Expected unique matches for "
                                   ++ Var.nameStr v ++ " but got: "
@@ -1429,8 +1429,8 @@ loop = do
                 hashTerms0 = (\(r, _wk, _tm, typ) -> (r, typ)) <$> UF.hashTerms uf
               termEdits :: Map Name (Reference, Reference)
               termEdits = Map.fromList $ map g (toList $ SC.terms (updates sr)) where
-                g v = case ( toList (Names.refTermsNamed slurpCheckUnqualifiedNames n)
-                           , toList (Names.refTermsNamed fileUnqualifiedNames n)) of
+                g v = case ( toList (Names.refTermsNamed slurpCheckNames n)
+                           , toList (Names.refTermsNamed fileNames n)) of
                   ([old], [new]) -> (n, (old, new))
                   _ -> error $ "Expected unique matches for "
                                  ++ Var.nameStr v ++ " but got: "
@@ -1439,7 +1439,7 @@ loop = do
               termDeprecations :: [(Name, Referent)]
               termDeprecations =
                 [ (n, r) | (oldTypeRef,_) <- Map.elems typeEdits
-                         , (n, r) <- NamesWithHistory.constructorsForType0 oldTypeRef currentPathUnqualifiedNames ]
+                         , (n, r) <- NamesWithHistory.constructorsForType0 oldTypeRef currentPathNames ]
 
           ye'ol'Patch <- getPatchAt patchPath
           -- If `uf` updates a -> a', we want to replace all (a0 -> a) in patch
@@ -1503,7 +1503,7 @@ loop = do
         (Just (sourceName, _), Just uf) -> do
           sr <-  applySelection hqs uf
                     .  toSlurpResult currentPath' uf
-                   <$> slurpResultUnqualifiedNames
+                   <$> slurpResultNames
           previewResponse sourceName sr uf
         _ -> respond NoUnisonFile
 
@@ -1580,11 +1580,11 @@ loop = do
 
       ExecuteI main -> addRunMain main uf >>= \case
         NoTermWithThatName -> do
-          ppe <- suffixifiedPPE (NamesWithHistory.NamesWithHistory basicPrettyPrintUnqualifiedNames mempty)
+          ppe <- suffixifiedPPE (NamesWithHistory.NamesWithHistory basicPrettyPrintNames mempty)
           mainType <- eval RuntimeMain
           respond $ NoMainFunction main ppe [mainType]
         TermHasBadType ty -> do
-          ppe <- suffixifiedPPE (NamesWithHistory.NamesWithHistory basicPrettyPrintUnqualifiedNames mempty)
+          ppe <- suffixifiedPPE (NamesWithHistory.NamesWithHistory basicPrettyPrintNames mempty)
           mainType <- eval RuntimeMain
           respond $ BadMainFunction main ty ppe [mainType]
         RunMainSuccess unisonFile -> do
@@ -1598,7 +1598,7 @@ loop = do
       MakeStandaloneI output main -> do
         mainType <- eval RuntimeMain
         parseNames <-
-          flip NamesWithHistory.NamesWithHistory mempty <$> basicPrettyPrintUnqualifiedNamesA
+          flip NamesWithHistory.NamesWithHistory mempty <$> basicPrettyPrintNamesA
         ppe <- suffixifiedPPE parseNames
         let resolved = toList $ NamesWithHistory.lookupHQTerm main parseNames
             smain = HQ.toString main
@@ -1617,7 +1617,7 @@ loop = do
       IOTestI main -> do
         -- todo - allow this to run tests from scratch file, using addRunMain
         testType <- eval RuntimeTest
-        parseNames <- (`NamesWithHistory.NamesWithHistory` mempty) <$> basicPrettyPrintUnqualifiedNamesA
+        parseNames <- (`NamesWithHistory.NamesWithHistory` mempty) <$> basicPrettyPrintNamesA
         ppe <- suffixifiedPPE parseNames
         -- use suffixed names for resolving the argument to display
         let
@@ -1663,7 +1663,7 @@ loop = do
         eval $ AddDefsToCodebase uf
         -- add the names; note, there are more names than definitions
         -- due to builtin terms; so we don't just reuse `uf` above.
-        let srcb = BranchUtil.fromUnqualifiedNames Builtin.names0
+        let srcb = BranchUtil.fromNames Builtin.names0
         _ <- updateAtM (currentPath' `snoc` "builtin") $ \destb ->
                eval $ Merge Branch.RegularMerge srcb destb
         success
@@ -1682,8 +1682,8 @@ loop = do
         -- add the names; note, there are more names than definitions
         -- due to builtin terms; so we don't just reuse `uf` above.
         let names0 = Builtin.names0
-                     <> UF.typecheckedToUnqualifiedNames @v IOSource.typecheckedFile'
-        let srcb = BranchUtil.fromUnqualifiedNames names0
+                     <> UF.typecheckedToNames @v IOSource.typecheckedFile'
+        let srcb = BranchUtil.fromNames names0
         _ <- updateAtM (currentPath' `snoc` "builtin") $ \destb ->
                eval $ Merge Branch.RegularMerge srcb destb
 
@@ -1884,7 +1884,7 @@ loop = do
 resolveHQToLabeledDependencies :: Functor m => HQ.HashQualified Name -> Action' m v (Set LabeledDependency)
 resolveHQToLabeledDependencies = \case
   HQ.NameOnly n -> do
-    parseNames <- basicParseUnqualifiedNames
+    parseNames <- basicParseNames
     let terms, types :: Set LabeledDependency
         terms = Set.map LD.referent . Name.searchBySuffix n $ NamesWithHistory.terms0 parseNames
         types = Set.map LD.typeRef  . Name.searchBySuffix n $ NamesWithHistory.types0 parseNames
@@ -1988,7 +1988,7 @@ propagatePatchNoSync
   -> Action' m v Bool
 propagatePatchNoSync patch scopePath = do
   r <- use root
-  let nroot = Branch.toUnqualifiedNames (Branch.head r)
+  let nroot = Branch.toNames (Branch.head r)
   stepAtMNoSync' (Path.unabsolute scopePath,
                   lift . lift . Propagate.propagateAndApply nroot patch)
 
@@ -1997,7 +1997,7 @@ propagatePatch :: (Monad m, Var v) =>
   InputDescription -> Patch -> Path.Absolute -> Action' m v Bool
 propagatePatch inputDescription patch scopePath = do
   r <- use root
-  let nroot = Branch.toUnqualifiedNames (Branch.head r)
+  let nroot = Branch.toNames (Branch.head r)
   stepAtM' (inputDescription <> " (applying patch)")
            (Path.unabsolute scopePath,
               lift . lift . Propagate.propagateAndApply nroot patch)
@@ -2006,7 +2006,7 @@ propagatePatch inputDescription patch scopePath = do
 doShowTodoOutput :: Monad m => Patch -> Path.Absolute -> Action' m v ()
 doShowTodoOutput patch scopePath = do
   scope <- getAt scopePath
-  let names0 = Branch.toUnqualifiedNames (Branch.head scope)
+  let names0 = Branch.toNames (Branch.head scope)
   -- only needs the local references to check for obsolete defs
   let getPpe = do
         names <- makePrintNamesFromLabeled' (Patch.labeledDependencies patch)
@@ -2019,7 +2019,7 @@ showTodoOutput
      -- ^ Action that fetches the pretty print env. It's expensive because it
      -- involves looking up historical names, so only call it if necessary.
   -> Patch
-  -> UnqualifiedNames
+  -> Names
   -> Action' m v ()
 showTodoOutput getPpe patch names0 = do
   todo <- checkTodo patch names0
@@ -2032,7 +2032,7 @@ showTodoOutput getPpe patch names0 = do
       ppe <- getPpe
       respond $ TodoOutput ppe todo
 
-checkTodo :: Patch -> UnqualifiedNames -> Action m i v (TO.TodoOutput v Ann)
+checkTodo :: Patch -> Names -> Action m i v (TO.TodoOutput v Ann)
 checkTodo patch names0 = do
   f <- computeFrontier (eval . GetDependents) patch names0
   let dirty = R.dom f
@@ -2057,7 +2057,7 @@ checkTodo patch names0 = do
       (Patch.conflicts patch)
   where
   frontierTransitiveDependents ::
-    Monad m => (Reference -> m (Set Reference)) -> UnqualifiedNames -> Set Reference -> m (Set Reference)
+    Monad m => (Reference -> m (Set Reference)) -> Names -> Set Reference -> m (Set Reference)
   frontierTransitiveDependents dependents names0 rs = do
     let branchDependents r = Set.filter (Names.contains names0) <$> dependents r
     tdeps <- transitiveClosure branchDependents rs
@@ -2075,7 +2075,7 @@ checkTodo patch names0 = do
 computeFrontier :: forall m . Monad m
          => (Reference -> m (Set Reference)) -- eg Codebase.dependents codebase
          -> Patch
-         -> UnqualifiedNames
+         -> Names
          -> m (R.Relation Reference Reference)
 computeFrontier getDependents patch names = let
   edited :: Set Reference
@@ -2099,7 +2099,7 @@ confirmedCommand i = do
   pure $ Just i == i0
 
 listBranch :: Branch0 m -> [SearchResult]
-listBranch (Branch.toUnqualifiedNames -> b) =
+listBranch (Branch.toNames -> b) =
   List.sortOn (\s -> (SR.name s, s)) (SR.fromNames b)
 
 -- | restores the full hash to these search results, for _numberedArgs purposes
@@ -2123,14 +2123,14 @@ _searchBranchPrefix b n = case Path.unsnoc (Path.fromName n) of
     Just b -> SR.fromNames . Names.prefix0 n $ names0
       where
       lastName = Path.toName (Path.singleton last)
-      subnames = Branch.toUnqualifiedNames . Branch.head $
+      subnames = Branch.toNames . Branch.head $
                    Branch.getAt' (Path.singleton last) b
       rootnames =
         Names.filter (== lastName) .
-        Branch.toUnqualifiedNames . set Branch.children mempty $ Branch.head b
+        Branch.toNames . set Branch.children mempty $ Branch.head b
       names0 = rootnames <> Names.prefix0 lastName subnames
 
-searchResultsFor :: UnqualifiedNames -> [Referent] -> [Reference] -> [SearchResult]
+searchResultsFor :: Names -> [Referent] -> [Reference] -> [SearchResult]
 searchResultsFor ns terms types =
   [ SR.termSearchResult ns name ref
   | ref <- terms
@@ -2142,7 +2142,7 @@ searchResultsFor ns terms types =
   ]
 
 searchBranchScored :: forall score. (Ord score)
-              => UnqualifiedNames
+              => Names
               -> (Name -> Name -> Maybe score)
               -> [HQ.HashQualified Name]
               -> [SearchResult]
@@ -2428,9 +2428,9 @@ zeroOneOrMore f zero one more = case toList f of
 -- `toBeDeleted`), then complain by returning (Y, X).
 getEndangeredDependents :: forall m. Monad m
                         => (Reference -> m (Set Reference))
-                        -> UnqualifiedNames
-                        -> UnqualifiedNames
-                        -> m (UnqualifiedNames, UnqualifiedNames)
+                        -> Names
+                        -> Names
+                        -> m (Names, Names)
 getEndangeredDependents getDependents toDelete root = do
   let remaining  = root `Names.difference` toDelete
       toDelete', remaining', extinct :: Set Reference
@@ -2467,14 +2467,14 @@ applySelection hqs file = \sr@SlurpResult{..} ->
      , extraDefinitions = closed `SC.difference` selection
      }
   where
-  selectedUnqualifiedNames =
-    Names.filterByHQs (Set.fromList hqs) (UF.typecheckedToUnqualifiedNames file)
+  selectedNames =
+    Names.filterByHQs (Set.fromList hqs) (UF.typecheckedToNames file)
   selection, closed :: SlurpComponent v
   selection = SlurpComponent selectedTypes selectedTerms
   closed = SC.closeWithDependencies file selection
   selectedTypes, selectedTerms :: Set v
-  selectedTypes = Set.map var $ R.dom (Names.types selectedUnqualifiedNames)
-  selectedTerms = Set.map var $ R.dom (Names.terms selectedUnqualifiedNames)
+  selectedTypes = Set.map var $ R.dom (Names.types selectedNames)
+  selectedTerms = Set.map var $ R.dom (Names.terms selectedNames)
 
 var :: Var v => Name -> v
 var name = Var.named (Name.toText name)
@@ -2484,7 +2484,7 @@ toSlurpResult
    . Var v
   => Path.Absolute
   -> UF.TypecheckedUnisonFile v Ann
-  -> UnqualifiedNames
+  -> Names
   -> SlurpResult v
 toSlurpResult currentPath uf existingNames =
   Slurp.subtractComponent (conflicts <> ctorCollisions) $ SlurpResult
@@ -2501,7 +2501,7 @@ toSlurpResult currentPath uf existingNames =
     typeAliases
     mempty
   where
-  fileUnqualifiedNames = UF.typecheckedToUnqualifiedNames uf
+  fileNames = UF.typecheckedToNames uf
 
   sc :: R.Relation Name Referent -> R.Relation Name Reference -> SlurpComponent v
   sc terms types = SlurpComponent { terms = Set.map var (R.dom terms)
@@ -2511,9 +2511,9 @@ toSlurpResult currentPath uf existingNames =
   conflicts :: SlurpComponent v
   conflicts = sc terms types where
     terms = R.filterDom (conflicted . Names.termsNamed existingNames)
-                        (Names.terms fileUnqualifiedNames)
+                        (Names.terms fileNames)
     types = R.filterDom (conflicted . Names.typesNamed existingNames)
-                        (Names.types fileUnqualifiedNames)
+                        (Names.types fileNames)
     conflicted s = Set.size s > 1
 
   ctorCollisions :: SlurpComponent v
@@ -2525,7 +2525,7 @@ toSlurpResult currentPath uf existingNames =
   termCtorCollisions :: Set v
   termCtorCollisions = Set.fromList
     [ var n
-    | (n, Referent.Ref{}) <- R.toList (Names.terms fileUnqualifiedNames)
+    | (n, Referent.Ref{}) <- R.toList (Names.terms fileNames)
     , [r@Referent.Con{}]  <- [toList $ Names.termsNamed existingNames n]
     -- ignore collisions w/ ctors of types being updated
     , Set.notMember (Referent.toReference r) typesToUpdate
@@ -2535,7 +2535,7 @@ toSlurpResult currentPath uf existingNames =
   typesToUpdate :: Set Reference
   typesToUpdate = Set.fromList
     [ r
-    | (n, r') <- R.toList (Names.types fileUnqualifiedNames)
+    | (n, r') <- R.toList (Names.types fileNames)
     , r       <- toList (Names.typesNamed existingNames n)
     , r /= r'
     ]
@@ -2546,7 +2546,7 @@ toSlurpResult currentPath uf existingNames =
   ctorTermCollisions :: Set v
   ctorTermCollisions = Set.fromList
     [ var n
-    | (n, Referent.Con{}) <- R.toList (Names.terms fileUnqualifiedNames)
+    | (n, Referent.Con{}) <- R.toList (Names.terms fileNames)
     , r                   <- toList $ Names.termsNamed existingNames n
     -- ignore collisions w/ ctors of types being updated
     , Set.notMember (Referent.toReference r) typesToUpdate
@@ -2556,21 +2556,21 @@ toSlurpResult currentPath uf existingNames =
   -- duplicate (n,r) if (n,r) exists in names0
   dups :: SlurpComponent v
   dups = sc terms types where
-    terms = R.intersection (Names.terms existingNames) (Names.terms fileUnqualifiedNames)
-    types = R.intersection (Names.types existingNames) (Names.types fileUnqualifiedNames)
+    terms = R.intersection (Names.terms existingNames) (Names.terms fileNames)
+    types = R.intersection (Names.types existingNames) (Names.types fileNames)
 
   -- update (n,r) if (n,r' /= r) exists in existingNames and r, r' are Ref
   updates :: SlurpComponent v
   updates = SlurpComponent (Set.fromList types) (Set.fromList terms) where
     terms =
       [ var n
-      | (n, r'@Referent.Ref{}) <- R.toList (Names.terms fileUnqualifiedNames)
+      | (n, r'@Referent.Ref{}) <- R.toList (Names.terms fileNames)
       , [r@Referent.Ref{}]     <- [toList $ Names.termsNamed existingNames n]
       , r' /= r
       ]
     types =
       [ var n
-      | (n, r') <- R.toList (Names.types fileUnqualifiedNames)
+      | (n, r') <- R.toList (Names.types fileNames)
       , [r]     <- [toList $ Names.typesNamed existingNames n]
       , r' /= r
       ]
@@ -2602,18 +2602,18 @@ toSlurpResult currentPath uf existingNames =
 
   termAliases :: Map v Slurp.Aliases
   termAliases = buildAliases (Names.terms existingNames)
-                             (Names.terms fileUnqualifiedNames)
+                             (Names.terms fileNames)
                              (SC.terms dups)
 
   typeAliases :: Map v Slurp.Aliases
   typeAliases = buildAliases (R.mapRan Referent.Ref $ Names.types existingNames)
-                             (R.mapRan Referent.Ref $ Names.types fileUnqualifiedNames)
+                             (R.mapRan Referent.Ref $ Names.types fileNames)
                              (SC.types dups)
 
   -- (n,r) is in `adds` if n isn't in existingNames
   adds = sc terms types where
-    terms = addTerms (Names.terms existingNames) (Names.terms fileUnqualifiedNames)
-    types = addTypes (Names.types existingNames) (Names.types fileUnqualifiedNames)
+    terms = addTerms (Names.terms existingNames) (Names.terms fileNames)
+    types = addTypes (Names.types existingNames) (Names.types fileNames)
     addTerms existingNames = R.filter go where
       go (n, Referent.Ref{}) = (not . R.memberDom n) existingNames
       go _ = False
@@ -2653,7 +2653,7 @@ doSlurpAdds slurp uf = Branch.stepManyAt0 (typeActions <> termActions)
   typeActions = map doType . toList $ SC.types slurp
   termActions = map doTerm . toList $
     SC.terms slurp <> Slurp.constructorsFor (SC.types slurp) uf
-  names = UF.typecheckedToUnqualifiedNames uf
+  names = UF.typecheckedToNames uf
   tests = Set.fromList $ fst <$> UF.watchesOfKind WK.TestWatch (UF.discardTypes uf)
   (isTestType, isTestValue) = isTest
   md v =
@@ -2731,7 +2731,7 @@ loadDisplayInfo refs = do
 -- e.g. if currentPath = .foo.bar
 --      then name foo.bar.baz becomes baz
 --           name cat.dog     becomes .cat.dog
-fixupNamesRelative :: Path.Absolute -> UnqualifiedNames -> UnqualifiedNames
+fixupNamesRelative :: Path.Absolute -> Names -> Names
 fixupNamesRelative currentPath' = NamesWithHistory.map0 fixName where
   prefix = Path.toName (Path.unabsolute currentPath')
   fixName n = if currentPath' == Path.absoluteEmpty then n else
@@ -2741,9 +2741,9 @@ makeHistoricalParsingNames ::
   Monad m => Set (HQ.HashQualified Name) -> Action' m v NamesWithHistory
 makeHistoricalParsingNames lexedHQs = do
   rawHistoricalNames <- findHistoricalHQs lexedHQs
-  basicUnqualifiedNames <- basicParseUnqualifiedNames
+  basicNames <- basicParseNames
   currentPath <- use currentPath
-  pure $ NamesWithHistory basicUnqualifiedNames
+  pure $ NamesWithHistory basicNames
                (NamesWithHistory.makeAbsolute0 rawHistoricalNames <>
                  fixupNamesRelative currentPath rawHistoricalNames)
 
@@ -2783,7 +2783,7 @@ parseType :: (Monad m, Var v)
 parseType input src = do
   -- `show Input` is the name of the "file" being lexed
   (names0, lexed) <- lexedSource (Text.pack $ show input) (Text.pack src)
-  parseNames <- basicParseUnqualifiedNames
+  parseNames <- basicParseNames
   let names = NamesWithHistory.push (NamesWithHistory.currentNames names0)
                           (NamesWithHistory.NamesWithHistory parseNames (NamesWithHistory.oldNames names0))
   e <- eval $ ParseType names lexed
@@ -2795,7 +2795,7 @@ parseType input src = do
       Right typ -> Right typ
 
 makeShadowedPrintNamesFromLabeled
-  :: Monad m => Set LabeledDependency -> UnqualifiedNames -> Action' m v NamesWithHistory
+  :: Monad m => Set LabeledDependency -> Names -> Action' m v NamesWithHistory
 makeShadowedPrintNamesFromLabeled deps shadowing =
   NamesWithHistory.shadowing shadowing <$> makePrintNamesFromLabeled' deps
 
@@ -2807,8 +2807,8 @@ makePrintNamesFromLabeled' deps = do
   (_missing, rawHistoricalNames) <- eval . Eval $ Branch.findHistoricalRefs
     deps
     root
-  basicUnqualifiedNames <- basicPrettyPrintUnqualifiedNamesA
-  pure $ NamesWithHistory basicUnqualifiedNames (fixupNamesRelative currentPath rawHistoricalNames)
+  basicNames <- basicPrettyPrintNamesA
+  pure $ NamesWithHistory basicNames (fixupNamesRelative currentPath rawHistoricalNames)
 
 getTermsIncludingHistorical
   :: Monad m => Path.HQSplit -> Branch0 m -> Action' m v (Set Referent)
@@ -2824,7 +2824,7 @@ getTermsIncludingHistorical (p, hq) b = case Set.toList refs of
 
 -- discards inputs that aren't hashqualified;
 -- I'd enforce it with finer-grained types if we had them.
-findHistoricalHQs :: Monad m => Set (HQ.HashQualified Name) -> Action' m v UnqualifiedNames
+findHistoricalHQs :: Monad m => Set (HQ.HashQualified Name) -> Action' m v Names
 findHistoricalHQs lexedHQs0 = do
   root <- use root
   currentPath <- use currentPath
@@ -2846,38 +2846,38 @@ findHistoricalHQs lexedHQs0 = do
   (_missing, rawHistoricalNames) <- eval . Eval $ Branch.findHistoricalHQs lexedHQs root
   pure rawHistoricalNames
 
-basicPrettyPrintUnqualifiedNamesA :: Functor m => Action' m v UnqualifiedNames
-basicPrettyPrintUnqualifiedNamesA = snd <$> basicUnqualifiedNames'
+basicPrettyPrintNamesA :: Functor m => Action' m v Names
+basicPrettyPrintNamesA = snd <$> basicNames'
 
-makeShadowedPrintNamesFromHQ :: Monad m => Set (HQ.HashQualified Name) -> UnqualifiedNames -> Action' m v NamesWithHistory
+makeShadowedPrintNamesFromHQ :: Monad m => Set (HQ.HashQualified Name) -> Names -> Action' m v NamesWithHistory
 makeShadowedPrintNamesFromHQ lexedHQs shadowing = do
   rawHistoricalNames <- findHistoricalHQs lexedHQs
-  basicUnqualifiedNames <- basicPrettyPrintUnqualifiedNamesA
+  basicNames <- basicPrettyPrintNamesA
   currentPath <- use currentPath
   -- The basic names go into "current", but are shadowed by "shadowing".
   -- They go again into "historical" as a hack that makes them available HQ-ed.
   pure $
     NamesWithHistory.shadowing
       shadowing
-      (NamesWithHistory basicUnqualifiedNames (fixupNamesRelative currentPath rawHistoricalNames))
+      (NamesWithHistory basicNames (fixupNamesRelative currentPath rawHistoricalNames))
 
-basicParseUnqualifiedNames, slurpResultUnqualifiedNames :: Functor m => Action' m v UnqualifiedNames
-basicParseUnqualifiedNames = fst <$> basicUnqualifiedNames'
+basicParseNames, slurpResultNames :: Functor m => Action' m v Names
+basicParseNames = fst <$> basicNames'
 -- we check the file against everything in the current path
-slurpResultUnqualifiedNames = currentPathUnqualifiedNames
+slurpResultNames = currentPathNames
 
-currentPathUnqualifiedNames :: Functor m => Action' m v UnqualifiedNames
-currentPathUnqualifiedNames = do
+currentPathNames :: Functor m => Action' m v Names
+currentPathNames = do
   currentPath' <- use currentPath
   currentBranch' <- getAt currentPath'
-  pure $ Branch.toUnqualifiedNames (Branch.head currentBranch')
+  pure $ Branch.toNames (Branch.head currentBranch')
 
--- implementation detail of basicParseUnqualifiedNames and basicPrettyPrintUnqualifiedNames
-basicUnqualifiedNames' :: Functor m => Action' m v (UnqualifiedNames, UnqualifiedNames)
-basicUnqualifiedNames' = do
+-- implementation detail of basicParseNames and basicPrettyPrintNames
+basicNames' :: Functor m => Action' m v (Names, Names)
+basicNames' = do
   root' <- use root
   currentPath' <- use currentPath
-  pure $ Backend.basicUnqualifiedNames' root' (Path.unabsolute currentPath')
+  pure $ Backend.basicNames' root' (Path.unabsolute currentPath')
 
 data AddRunMainResult v
   = NoTermWithThatName
@@ -2921,11 +2921,11 @@ addRunMain
   -> Maybe (TypecheckedUnisonFile v Ann)
   -> Action' m v (AddRunMainResult v)
 addRunMain mainName Nothing = do
-  parseUnqualifiedNames <- basicParseUnqualifiedNames
+  parseNames <- basicParseNames
   let loadTypeOfTerm ref = eval $ LoadTypeOfTerm ref
   mainType <- eval RuntimeMain
   mainToFile <$>
-    MainTerm.getMainTerm loadTypeOfTerm parseUnqualifiedNames mainName mainType
+    MainTerm.getMainTerm loadTypeOfTerm parseNames mainName mainType
   where
     mainToFile (MainTerm.NotAFunctionName _) = NoTermWithThatName
     mainToFile (MainTerm.NotFound _) = NoTermWithThatName
@@ -2967,7 +2967,7 @@ displayNames unisonFile =
   -- voodoo
   makeShadowedPrintNamesFromLabeled
     (UF.termSignatureExternalLabeledDependencies unisonFile)
-    (UF.typecheckedToUnqualifiedNames unisonFile)
+    (UF.typecheckedToNames unisonFile)
 
 diffHelper :: Monad m
   => Branch0 m
@@ -2976,15 +2976,15 @@ diffHelper :: Monad m
 diffHelper before after = do
   hqLength <- eval CodebaseHashLength
   diff     <- eval . Eval $ BranchDiff.diff0 before after
-  names0 <- basicPrettyPrintUnqualifiedNamesA
+  names0 <- basicPrettyPrintNamesA
   ppe <- PPE.suffixifiedPPE <$> prettyPrintEnvDecl (NamesWithHistory names0 mempty)
   (ppe,) <$>
     OBranchDiff.toOutput
       loadTypeOfTerm
       declOrBuiltin
       hqLength
-      (Branch.toUnqualifiedNames before)
-      (Branch.toUnqualifiedNames after)
+      (Branch.toNames before)
+      (Branch.toNames after)
       ppe
       diff
 

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -87,7 +87,7 @@ import qualified Unison.Name                   as Name
 import           Unison.Name                    ( Name )
 import           Unison.NamesWithHistory                  ( NamesWithHistory(..), Names0
                                                 , pattern Names0 )
-import qualified Unison.Names2                 as Names
+import qualified Unison.Names                 as Names
 import qualified Unison.NamesWithHistory                 as NamesWithHistory
 import Unison.Parser.Ann (Ann(..))
 import           Unison.Reference               ( Reference(..) )

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -25,7 +25,7 @@ import Unison.Codebase.Path (Path')
 import Unison.Codebase.Patch (Patch)
 import Unison.Codebase.Type (GitError)
 import Unison.Name ( Name )
-import Unison.Names2 ( Names )
+import Unison.Names ( Names )
 import Unison.Parser.Ann (Ann)
 import qualified Unison.Reference as Reference
 import Unison.Reference ( Reference )

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -25,7 +25,7 @@ import Unison.Codebase.Path (Path')
 import Unison.Codebase.Patch (Patch)
 import Unison.Codebase.Type (GitError)
 import Unison.Name ( Name )
-import Unison.Names ( HQNames, UnqualifiedNames )
+import Unison.Names ( UnqualifiedNames )
 import Unison.Parser.Ann (Ann)
 import qualified Unison.Reference as Reference
 import Unison.Reference ( Reference )

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -25,7 +25,7 @@ import Unison.Codebase.Path (Path')
 import Unison.Codebase.Patch (Patch)
 import Unison.Codebase.Type (GitError)
 import Unison.Name ( Name )
-import Unison.Names ( UnqualifiedNames )
+import Unison.Names ( Names )
 import Unison.Parser.Ann (Ann)
 import qualified Unison.Reference as Reference
 import Unison.Reference ( Reference )
@@ -133,7 +133,7 @@ data Output v
   -- with whatever named definitions would not have any remaining names if
   -- the path is deleted.
   | DeleteBranchConfirmation
-      [(Path', (UnqualifiedNames, [SearchResult' v Ann]))]
+      [(Path', (Names, [SearchResult' v Ann]))]
   -- CantDelete input couldntDelete becauseTheseStillReferenceThem
   | CantDelete PPE.PrettyPrintEnv [SearchResult' v Ann] [SearchResult' v Ann]
   | DeleteEverythingConfirmation

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -25,7 +25,7 @@ import Unison.Codebase.Path (Path')
 import Unison.Codebase.Patch (Patch)
 import Unison.Codebase.Type (GitError)
 import Unison.Name ( Name )
-import Unison.Names ( HQNames )
+import Unison.Names ( HQNames, UnqualifiedNames )
 import Unison.Parser.Ann (Ann)
 import qualified Unison.Reference as Reference
 import Unison.Reference ( Reference )
@@ -133,7 +133,7 @@ data Output v
   -- with whatever named definitions would not have any remaining names if
   -- the path is deleted.
   | DeleteBranchConfirmation
-      [(Path', (HQNames, [SearchResult' v Ann]))]
+      [(Path', (UnqualifiedNames, [SearchResult' v Ann]))]
   -- CantDelete input couldntDelete becauseTheseStillReferenceThem
   | CantDelete PPE.PrettyPrintEnv [SearchResult' v Ann] [SearchResult' v Ann]
   | DeleteEverythingConfirmation

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -51,7 +51,7 @@ import Unison.Server.SearchResult' (SearchResult')
 import Unison.Term (Term)
 import Unison.Type (Type)
 import qualified Unison.Names.ResolutionResult as Names
-import qualified Unison.Names3 as Names
+import qualified Unison.NamesWithHistory as Names
 import qualified Data.Set as Set
 import Unison.NameSegment (NameSegment)
 import Unison.ShortHash (ShortHash)

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -25,7 +25,7 @@ import Unison.Codebase.Path (Path')
 import Unison.Codebase.Patch (Patch)
 import Unison.Codebase.Type (GitError)
 import Unison.Name ( Name )
-import Unison.Names ( Names )
+import Unison.Names ( HQNames )
 import Unison.Parser.Ann (Ann)
 import qualified Unison.Reference as Reference
 import Unison.Reference ( Reference )
@@ -133,7 +133,7 @@ data Output v
   -- with whatever named definitions would not have any remaining names if
   -- the path is deleted.
   | DeleteBranchConfirmation
-      [(Path', (Names, [SearchResult' v Ann]))]
+      [(Path', (HQNames, [SearchResult' v Ann]))]
   -- CantDelete input couldntDelete becauseTheseStillReferenceThem
   | CantDelete PPE.PrettyPrintEnv [SearchResult' v Ann] [SearchResult' v Ann]
   | DeleteEverythingConfirmation

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output/BranchDiff.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output/BranchDiff.hs
@@ -26,7 +26,7 @@ import qualified Unison.HashQualified as HQ
 import qualified Unison.Referent as Referent
 import Unison.Referent (Referent)
 import qualified Unison.Names as Names
-import Unison.NamesWithHistory (Names0)
+import Unison.Names (UnqualifiedNames)
 import Unison.DataDeclaration (DeclOrBuiltin)
 import Unison.Runtime.IOSource (isPropagatedValue)
 
@@ -100,8 +100,8 @@ toOutput :: forall m v a
          => (Referent -> m (Maybe (Type v a)))
          -> (Reference -> m (Maybe (DeclOrBuiltin v a)))
          -> Int
-         -> Names0
-         -> Names0
+         -> UnqualifiedNames
+         -> UnqualifiedNames
          -> PPE.PrettyPrintEnv
          -> BranchDiff.BranchDiff
          -> m (BranchDiffOutput v a)

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output/BranchDiff.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output/BranchDiff.hs
@@ -26,7 +26,7 @@ import qualified Unison.HashQualified as HQ
 import qualified Unison.Referent as Referent
 import Unison.Referent (Referent)
 import qualified Unison.Names2 as Names2
-import Unison.Names3 (Names0)
+import Unison.NamesWithHistory (Names0)
 import Unison.DataDeclaration (DeclOrBuiltin)
 import Unison.Runtime.IOSource (isPropagatedValue)
 

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output/BranchDiff.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output/BranchDiff.hs
@@ -26,7 +26,7 @@ import qualified Unison.HashQualified as HQ
 import qualified Unison.Referent as Referent
 import Unison.Referent (Referent)
 import qualified Unison.Names as Names
-import Unison.Names (UnqualifiedNames)
+import Unison.Names (Names)
 import Unison.DataDeclaration (DeclOrBuiltin)
 import Unison.Runtime.IOSource (isPropagatedValue)
 
@@ -100,8 +100,8 @@ toOutput :: forall m v a
          => (Referent -> m (Maybe (Type v a)))
          -> (Reference -> m (Maybe (DeclOrBuiltin v a)))
          -> Int
-         -> UnqualifiedNames
-         -> UnqualifiedNames
+         -> Names
+         -> Names
          -> PPE.PrettyPrintEnv
          -> BranchDiff.BranchDiff
          -> m (BranchDiffOutput v a)

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output/BranchDiff.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output/BranchDiff.hs
@@ -25,7 +25,7 @@ import Unison.HashQualified' (HashQualified)
 import qualified Unison.HashQualified as HQ
 import qualified Unison.Referent as Referent
 import Unison.Referent (Referent)
-import qualified Unison.Names2 as Names2
+import qualified Unison.Names as Names
 import Unison.NamesWithHistory (Names0)
 import Unison.DataDeclaration (DeclOrBuiltin)
 import Unison.Runtime.IOSource (isPropagatedValue)
@@ -169,15 +169,15 @@ toOutput typeOf declOrBuiltin hqLen names1 names2 ppe
     loadOld :: Bool -> Name -> Reference -> m (SimpleTypeDisplay v a)
     loadOld forceHQ n r_old =
       (,,) <$> pure (if forceHQ
-                     then Names2.hqTypeName' hqLen n r_old
-                     else Names2.hqTypeName hqLen names1 n r_old)
+                     then Names.hqTypeName' hqLen n r_old
+                     else Names.hqTypeName hqLen names1 n r_old)
            <*> pure r_old
            <*> declOrBuiltin r_old
     loadNew :: Bool -> Bool -> Name -> Set Reference -> Reference -> m (TypeDisplay v a)
     loadNew hidePropagatedMd forceHQ n rs_old r_new =
       (,,,) <$> pure (if forceHQ
-                      then Names2.hqTypeName' hqLen n r_new
-                      else Names2.hqTypeName hqLen names2 n r_new)
+                      then Names.hqTypeName' hqLen n r_new
+                      else Names.hqTypeName hqLen names2 n r_new)
             <*> pure r_new
             <*> declOrBuiltin r_new
             <*> fillMetadata ppe (getNewMetadataDiff hidePropagatedMd typesDiff n rs_old r_new)
@@ -204,13 +204,13 @@ toOutput typeOf declOrBuiltin hqLen names1 names2 ppe
     -- if they were already included in `nsUpdates)
     metadataUpdates = getMetadataUpdates termsDiff
     loadOld forceHQ n r_old =
-      (,,) <$> pure (if forceHQ then Names2.hqTermName' hqLen n r_old
-                     else Names2.hqTermName hqLen names1 n r_old)
+      (,,) <$> pure (if forceHQ then Names.hqTermName' hqLen n r_old
+                     else Names.hqTermName hqLen names1 n r_old)
            <*> pure r_old
            <*> typeOf r_old
     loadNew hidePropagatedMd forceHQ n rs_old r_new =
-      (,,,) <$> pure (if forceHQ then Names2.hqTermName' hqLen n r_new
-                      else Names2.hqTermName hqLen names2 n r_new)
+      (,,,) <$> pure (if forceHQ then Names.hqTermName' hqLen n r_new
+                      else Names.hqTermName hqLen names2 n r_new)
             <*> pure r_new
             <*> typeOf r_new
             <*> fillMetadata ppe (getNewMetadataDiff hidePropagatedMd termsDiff n rs_old r_new)
@@ -248,7 +248,7 @@ toOutput typeOf declOrBuiltin hqLen names1 names2 ppe
     for typeAdds $ \(r, nsmd) -> do
       hqmds :: [(HashQualified Name, [MetadataDisplay v a])] <-
         for nsmd $ \(n, mdRefs) ->
-          (,) <$> pure (Names2.hqTypeName hqLen names2 n r)
+          (,) <$> pure (Names.hqTypeName hqLen names2 n r)
               <*> fillMetadata ppe mdRefs
       (hqmds, r, ) <$> declOrBuiltin r
 
@@ -261,7 +261,7 @@ toOutput typeOf declOrBuiltin hqLen names1 names2 ppe
           ]
     for termAdds $ \(r, nsmd) -> do
       hqmds <- for nsmd $ \(n, mdRefs) ->
-        (,) <$> pure (Names2.hqTermName hqLen names2 n r)
+        (,) <$> pure (Names.hqTermName hqLen names2 n r)
             <*> fillMetadata ppe mdRefs
       (hqmds, r, ) <$> typeOf r
 
@@ -273,7 +273,7 @@ toOutput typeOf declOrBuiltin hqLen names1 names2 ppe
     typeRemoves :: [(Reference, [Name])] = sortOn snd $
       Map.toList . fmap toList . R.toMultimap . BranchDiff.tallremoves $ typesDiff
     in for typeRemoves $ \(r, ns) ->
-      (,,) <$> pure ((\n -> Names2.hqTypeName hqLen names1 n r) <$> ns)
+      (,,) <$> pure ((\n -> Names.hqTypeName hqLen names1 n r) <$> ns)
            <*> pure r
            <*> declOrBuiltin r
 
@@ -281,7 +281,7 @@ toOutput typeOf declOrBuiltin hqLen names1 names2 ppe
     termRemoves :: [(Referent, [Name])] = sortOn snd $
       Map.toList . fmap toList . R.toMultimap . BranchDiff.tallremoves $ termsDiff
     in for termRemoves $ \(r, ns) ->
-      (,,) <$> pure ((\n -> Names2.hqTermName hqLen names1 n r) <$> ns)
+      (,,) <$> pure ((\n -> Names.hqTermName hqLen names1 n r) <$> ns)
            <*> pure r
            <*> typeOf r
 
@@ -294,16 +294,16 @@ toOutput typeOf declOrBuiltin hqLen names1 names2 ppe
         for (sortOn snd $ Map.toList renames) $ \(r, (ol'names, new'names)) ->
           (,,,) <$> pure r
                 <*> typeOf r
-                <*> pure (Set.map (\n -> Names2.hqTermName hqLen names1 n r) ol'names)
-                <*> pure (Set.map (\n -> Names2.hqTermName hqLen names2 n r) new'names)
+                <*> pure (Set.map (\n -> Names.hqTermName hqLen names1 n r) ol'names)
+                <*> pure (Set.map (\n -> Names.hqTermName hqLen names2 n r) new'names)
 
   let renamedType :: Map Reference (Set Name, Set Name) -> m [RenameTypeDisplay v a]
       renamedType renames =
         for (sortOn snd $ Map.toList renames) $ \(r, (ol'names, new'names)) ->
           (,,,) <$> pure r
                 <*> declOrBuiltin r
-                <*> pure (Set.map (\n -> Names2.hqTypeName hqLen names1 n r) ol'names)
-                <*> pure (Set.map (\n -> Names2.hqTypeName hqLen names2 n r) new'names)
+                <*> pure (Set.map (\n -> Names.hqTypeName hqLen names1 n r) ol'names)
+                <*> pure (Set.map (\n -> Names.hqTypeName hqLen names2 n r) new'names)
 
   renamedTypes :: [RenameTypeDisplay v a] <- renamedType (BranchDiff.trenames typesDiff)
   renamedTerms :: [RenameTermDisplay v a] <- renamedTerm (BranchDiff.trenames termsDiff)

--- a/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
@@ -25,7 +25,7 @@ import           Unison.DataDeclaration         ( Decl )
 import qualified Unison.DataDeclaration        as Decl
 import qualified Unison.Name                   as Name
 import           Unison.NamesWithHistory                  ( Names0 )
-import qualified Unison.Names2                 as Names
+import qualified Unison.Names                 as Names
 import Unison.Parser.Ann (Ann(..))
 import           Unison.Reference               ( Reference(..) )
 import qualified Unison.Reference              as Reference

--- a/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
@@ -24,7 +24,7 @@ import qualified Unison.Codebase.Patch         as Patch
 import           Unison.DataDeclaration         ( Decl )
 import qualified Unison.DataDeclaration        as Decl
 import qualified Unison.Name                   as Name
-import           Unison.Names                  ( UnqualifiedNames )
+import           Unison.Names                  ( Names )
 import qualified Unison.Names                 as Names
 import Unison.Parser.Ann (Ann(..))
 import           Unison.Reference               ( Reference(..) )
@@ -74,7 +74,7 @@ noEdits = Edits mempty mempty mempty mempty mempty mempty mempty
 propagateAndApply
   :: forall m i v
    . (Applicative m, Var v)
-  => UnqualifiedNames
+  => Names
   -> Patch
   -> Branch0 m
   -> F m i v (Branch0 m)
@@ -142,7 +142,7 @@ propagateCtorMapping oldComponent newComponent = let
 -- and if the number of constructors is 1, then the constructor names need not
 -- be the same.
 genInitialCtorMapping ::
-  forall v m i . Var v => UnqualifiedNames -> Map Reference Reference -> F m i v (Map Referent Referent)
+  forall v m i . Var v => Names -> Map Reference Reference -> F m i v (Map Referent Referent)
 genInitialCtorMapping rootNames initialTypeReplacements = do
   let mappings :: (Reference,Reference) -> _ (Map Referent Referent)
       mappings (old,new) = do
@@ -226,7 +226,7 @@ debugMode = False
 propagate
   :: forall m i v
    . (Applicative m, Var v)
-  => UnqualifiedNames -- TODO: this argument can be removed once patches have term replacement
+  => Names -- TODO: this argument can be removed once patches have term replacement
             -- of type `Referent -> Referent`
   -> Patch
   -> Branch0 m
@@ -252,7 +252,7 @@ propagate rootNames patch b = case validatePatch patch of
         in case toList rns of
           [] -> show r
           n : _ -> show n
-      -- this could also become show r if we're removing the dependency on UnqualifiedNames
+      -- this could also become show r if we're removing the dependency on Names
       referentName r = case toList (Names.namesForReferent rootNames r) of
         [] -> Referent.toString r
         n : _ -> show n
@@ -455,7 +455,7 @@ propagate rootNames patch b = case validatePatch patch of
       (zip (view _1 . getReference <$> Graph.topSort graph) [0 ..])
     -- vertex i precedes j whenever i has an edge to j and not vice versa.
     -- vertex i precedes j when j is a dependent of i.
-  names0 = Branch.toUnqualifiedNames b
+  names0 = Branch.toNames b
   validatePatch
     :: Patch -> Maybe (Map Reference TermEdit, Map Reference TypeEdit)
   validatePatch p =
@@ -634,7 +634,7 @@ computeFrontier
    . Monad m
   => (Reference -> m (Set Reference)) -- eg Codebase.dependents codebase
   -> Patch
-  -> UnqualifiedNames
+  -> Names
   -> m (R.Relation Reference Reference)
 computeFrontier getDependents patch names = do
       -- (r,r2) ∈ dependsOn if r depends on r2

--- a/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
@@ -24,7 +24,7 @@ import qualified Unison.Codebase.Patch         as Patch
 import           Unison.DataDeclaration         ( Decl )
 import qualified Unison.DataDeclaration        as Decl
 import qualified Unison.Name                   as Name
-import           Unison.NamesWithHistory                  ( Names0 )
+import           Unison.Names                  ( UnqualifiedNames )
 import qualified Unison.Names                 as Names
 import Unison.Parser.Ann (Ann(..))
 import           Unison.Reference               ( Reference(..) )
@@ -74,7 +74,7 @@ noEdits = Edits mempty mempty mempty mempty mempty mempty mempty
 propagateAndApply
   :: forall m i v
    . (Applicative m, Var v)
-  => Names0
+  => UnqualifiedNames
   -> Patch
   -> Branch0 m
   -> F m i v (Branch0 m)
@@ -142,7 +142,7 @@ propagateCtorMapping oldComponent newComponent = let
 -- and if the number of constructors is 1, then the constructor names need not
 -- be the same.
 genInitialCtorMapping ::
-  forall v m i . Var v => Names0 -> Map Reference Reference -> F m i v (Map Referent Referent)
+  forall v m i . Var v => UnqualifiedNames -> Map Reference Reference -> F m i v (Map Referent Referent)
 genInitialCtorMapping rootNames initialTypeReplacements = do
   let mappings :: (Reference,Reference) -> _ (Map Referent Referent)
       mappings (old,new) = do
@@ -226,7 +226,7 @@ debugMode = False
 propagate
   :: forall m i v
    . (Applicative m, Var v)
-  => Names0 -- TODO: this argument can be removed once patches have term replacement
+  => UnqualifiedNames -- TODO: this argument can be removed once patches have term replacement
             -- of type `Referent -> Referent`
   -> Patch
   -> Branch0 m
@@ -252,7 +252,7 @@ propagate rootNames patch b = case validatePatch patch of
         in case toList rns of
           [] -> show r
           n : _ -> show n
-      -- this could also become show r if we're removing the dependency on Names0
+      -- this could also become show r if we're removing the dependency on UnqualifiedNames
       referentName r = case toList (Names.namesForReferent rootNames r) of
         [] -> Referent.toString r
         n : _ -> show n
@@ -455,7 +455,7 @@ propagate rootNames patch b = case validatePatch patch of
       (zip (view _1 . getReference <$> Graph.topSort graph) [0 ..])
     -- vertex i precedes j whenever i has an edge to j and not vice versa.
     -- vertex i precedes j when j is a dependent of i.
-  names0 = Branch.toNames0 b
+  names0 = Branch.toUnqualifiedNames b
   validatePatch
     :: Patch -> Maybe (Map Reference TermEdit, Map Reference TypeEdit)
   validatePatch p =
@@ -634,7 +634,7 @@ computeFrontier
    . Monad m
   => (Reference -> m (Set Reference)) -- eg Codebase.dependents codebase
   -> Patch
-  -> Names0
+  -> UnqualifiedNames
   -> m (R.Relation Reference Reference)
 computeFrontier getDependents patch names = do
       -- (r,r2) ∈ dependsOn if r depends on r2

--- a/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Propagate.hs
@@ -24,7 +24,7 @@ import qualified Unison.Codebase.Patch         as Patch
 import           Unison.DataDeclaration         ( Decl )
 import qualified Unison.DataDeclaration        as Decl
 import qualified Unison.Name                   as Name
-import           Unison.Names3                  ( Names0 )
+import           Unison.NamesWithHistory                  ( Names0 )
 import qualified Unison.Names2                 as Names
 import Unison.Parser.Ann (Ann(..))
 import           Unison.Reference               ( Reference(..) )

--- a/parser-typechecker/src/Unison/Codebase/Editor/SlurpResult.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/SlurpResult.hs
@@ -72,7 +72,7 @@ data SlurpResult v = SlurpResult {
 -- Returns the set of constructor names for type names in the given `Set`.
 constructorsFor :: Var v => Set v -> UF.TypecheckedUnisonFile v Ann -> Set v
 constructorsFor types uf = let
-  names = UF.typecheckedToNames0 uf
+  names = UF.typecheckedToUnqualifiedNames uf
   typesRefs = Set.unions $ Names.typesNamed names . Name.fromVar <$> toList types
   ctorNames = R.filterRan isOkCtor (Names.terms names)
   isOkCtor (Referent.Con r _ _) | Set.member r typesRefs = True

--- a/parser-typechecker/src/Unison/Codebase/Editor/SlurpResult.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/SlurpResult.hs
@@ -18,7 +18,7 @@ import qualified Unison.DataDeclaration as DD
 import qualified Unison.DeclPrinter as DeclPrinter
 import qualified Unison.HashQualified as HQ
 import qualified Unison.Name as Name
-import qualified Unison.Names2 as Names
+import qualified Unison.Names as Names
 import qualified Unison.PrettyPrintEnv as PPE
 import qualified Unison.Referent as Referent
 import qualified Unison.TypePrinter as TP

--- a/parser-typechecker/src/Unison/Codebase/Editor/SlurpResult.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/SlurpResult.hs
@@ -72,7 +72,7 @@ data SlurpResult v = SlurpResult {
 -- Returns the set of constructor names for type names in the given `Set`.
 constructorsFor :: Var v => Set v -> UF.TypecheckedUnisonFile v Ann -> Set v
 constructorsFor types uf = let
-  names = UF.typecheckedToUnqualifiedNames uf
+  names = UF.typecheckedToNames uf
   typesRefs = Set.unions $ Names.typesNamed names . Name.fromVar <$> toList types
   ctorNames = R.filterRan isOkCtor (Names.terms names)
   isOkCtor (Referent.Con r _ _) | Set.member r typesRefs = True

--- a/parser-typechecker/src/Unison/Codebase/Editor/TodoOutput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/TodoOutput.hs
@@ -3,14 +3,14 @@ module Unison.Codebase.Editor.TodoOutput where
 
 import Unison.Prelude
 
-import qualified Unison.Names3 as Names
+import qualified Unison.NamesWithHistory as Names
 import qualified Unison.Type as Type
 import qualified Unison.Util.Relation as R
 import qualified Unison.Codebase.Patch as Patch
 import qualified Data.Set as Set
 import qualified Unison.DataDeclaration as DD
 import Unison.Reference (Reference)
-import Unison.Names3 (Names0)
+import Unison.NamesWithHistory (Names0)
 import Unison.Codebase.Patch (Patch)
 import Unison.Codebase.Editor.DisplayObject (DisplayObject(UserObject))
 import Unison.Type (Type)

--- a/parser-typechecker/src/Unison/Codebase/Editor/TodoOutput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/TodoOutput.hs
@@ -10,7 +10,7 @@ import qualified Unison.Codebase.Patch as Patch
 import qualified Data.Set as Set
 import qualified Unison.DataDeclaration as DD
 import Unison.Reference (Reference)
-import Unison.Names (UnqualifiedNames)
+import Unison.Names (Names)
 import Unison.Codebase.Patch (Patch)
 import Unison.Codebase.Editor.DisplayObject (DisplayObject(UserObject))
 import Unison.Type (Type)
@@ -28,7 +28,7 @@ data TodoOutput v a = TodoOutput
   , todoFrontierDependents ::
         ( [(Score, Reference, Maybe (Type v a))]
         , [(Score, Reference, DisplayObject () (Decl v a))])
-  , nameConflicts :: UnqualifiedNames
+  , nameConflicts :: Names
   , editConflicts :: Patch
   } deriving (Show)
 

--- a/parser-typechecker/src/Unison/Codebase/Editor/TodoOutput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/TodoOutput.hs
@@ -3,7 +3,7 @@ module Unison.Codebase.Editor.TodoOutput where
 
 import Unison.Prelude
 
-import qualified Unison.NamesWithHistory as Names
+import qualified Unison.Names as Names
 import qualified Unison.Type as Type
 import qualified Unison.Util.Relation as R
 import qualified Unison.Codebase.Patch as Patch
@@ -50,8 +50,8 @@ labeledDependencies TodoOutput{..} = Set.fromList (
   [LD.typeRef r | (_, _, UserObject d) <- snd todoFrontierDependents
            , r <- toList (DD.declDependencies d)]) <>
   -- name conflicts
-  Set.map LD.referent (R.ran (Names.terms0 nameConflicts)) <>
-  Set.map LD.typeRef (R.ran (Names.types0 nameConflicts)) <>
+  Set.map LD.referent (R.ran (Names.terms nameConflicts)) <>
+  Set.map LD.typeRef (R.ran (Names.types nameConflicts)) <>
   Patch.labeledDependencies editConflicts
 
 noConflicts :: TodoOutput v a -> Bool

--- a/parser-typechecker/src/Unison/Codebase/Editor/TodoOutput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/TodoOutput.hs
@@ -10,7 +10,7 @@ import qualified Unison.Codebase.Patch as Patch
 import qualified Data.Set as Set
 import qualified Unison.DataDeclaration as DD
 import Unison.Reference (Reference)
-import Unison.NamesWithHistory (Names0)
+import Unison.Names (UnqualifiedNames)
 import Unison.Codebase.Patch (Patch)
 import Unison.Codebase.Editor.DisplayObject (DisplayObject(UserObject))
 import Unison.Type (Type)
@@ -28,7 +28,7 @@ data TodoOutput v a = TodoOutput
   , todoFrontierDependents ::
         ( [(Score, Reference, Maybe (Type v a))]
         , [(Score, Reference, DisplayObject () (Decl v a))])
-  , nameConflicts :: Names0
+  , nameConflicts :: UnqualifiedNames
   , editConflicts :: Patch
   } deriving (Show)
 

--- a/parser-typechecker/src/Unison/Codebase/Execute.hs
+++ b/parser-typechecker/src/Unison/Codebase/Execute.hs
@@ -42,10 +42,10 @@ execute codebase runtime mainName =
         die ("Couldn't load root branch " ++ show h)
       Left (Codebase.CouldntParseRootBranch h) ->
         die ("Couldn't parse root branch head " ++ show h)
-    let parseNames0 = NamesWithHistory.makeAbsolute0 (Branch.toNames0 (Branch.head root))
+    let parseUnqualifiedNames = NamesWithHistory.makeAbsolute0 (Branch.toUnqualifiedNames (Branch.head root))
         loadTypeOfTerm = Codebase.getTypeOfTerm codebase
     let mainType = Runtime.mainType runtime
-    mt <- getMainTerm loadTypeOfTerm parseNames0 mainName mainType
+    mt <- getMainTerm loadTypeOfTerm parseUnqualifiedNames mainName mainType
     case mt of
       MainTerm.NotAFunctionName s -> die ("Not a function name: " ++ s)
       MainTerm.NotFound s -> die ("Not found: " ++ s)

--- a/parser-typechecker/src/Unison/Codebase/Execute.hs
+++ b/parser-typechecker/src/Unison/Codebase/Execute.hs
@@ -42,10 +42,10 @@ execute codebase runtime mainName =
         die ("Couldn't load root branch " ++ show h)
       Left (Codebase.CouldntParseRootBranch h) ->
         die ("Couldn't parse root branch head " ++ show h)
-    let parseUnqualifiedNames = NamesWithHistory.makeAbsolute0 (Branch.toUnqualifiedNames (Branch.head root))
+    let parseNames = NamesWithHistory.makeAbsolute0 (Branch.toNames (Branch.head root))
         loadTypeOfTerm = Codebase.getTypeOfTerm codebase
     let mainType = Runtime.mainType runtime
-    mt <- getMainTerm loadTypeOfTerm parseUnqualifiedNames mainName mainType
+    mt <- getMainTerm loadTypeOfTerm parseNames mainName mainType
     case mt of
       MainTerm.NotAFunctionName s -> die ("Not a function name: " ++ s)
       MainTerm.NotFound s -> die ("Not found: " ++ s)

--- a/parser-typechecker/src/Unison/Codebase/Execute.hs
+++ b/parser-typechecker/src/Unison/Codebase/Execute.hs
@@ -20,7 +20,7 @@ import qualified Unison.Codebase.Runtime       as Runtime
 import           Unison.Codebase.Runtime       ( Runtime )
 import           Unison.Var                    ( Var )
 import qualified Unison.PrettyPrintEnv         as PPE
-import qualified Unison.Names3                 as Names3
+import qualified Unison.NamesWithHistory                 as NamesWithHistory
 import qualified Unison.Codebase.Branch        as Branch
 import qualified Unison.Codebase.Branch.Names as Branch
 import           System.Exit (die)
@@ -42,7 +42,7 @@ execute codebase runtime mainName =
         die ("Couldn't load root branch " ++ show h)
       Left (Codebase.CouldntParseRootBranch h) ->
         die ("Couldn't parse root branch head " ++ show h)
-    let parseNames0 = Names3.makeAbsolute0 (Branch.toNames0 (Branch.head root))
+    let parseNames0 = NamesWithHistory.makeAbsolute0 (Branch.toNames0 (Branch.head root))
         loadTypeOfTerm = Codebase.getTypeOfTerm codebase
     let mainType = Runtime.mainType runtime
     mt <- getMainTerm loadTypeOfTerm parseNames0 mainName mainType

--- a/parser-typechecker/src/Unison/Codebase/Execute.hs
+++ b/parser-typechecker/src/Unison/Codebase/Execute.hs
@@ -20,11 +20,11 @@ import qualified Unison.Codebase.Runtime       as Runtime
 import           Unison.Codebase.Runtime       ( Runtime )
 import           Unison.Var                    ( Var )
 import qualified Unison.PrettyPrintEnv         as PPE
-import qualified Unison.NamesWithHistory                 as NamesWithHistory
 import qualified Unison.Codebase.Branch        as Branch
 import qualified Unison.Codebase.Branch.Names as Branch
 import           System.Exit (die)
 import           Control.Exception (finally)
+import qualified Unison.Names as Names
 
 execute
   :: Var v
@@ -42,7 +42,7 @@ execute codebase runtime mainName =
         die ("Couldn't load root branch " ++ show h)
       Left (Codebase.CouldntParseRootBranch h) ->
         die ("Couldn't parse root branch head " ++ show h)
-    let parseNames = NamesWithHistory.makeAbsolute0 (Branch.toNames (Branch.head root))
+    let parseNames = Names.makeAbsolute (Branch.toNames (Branch.head root))
         loadTypeOfTerm = Codebase.getTypeOfTerm codebase
     let mainType = Runtime.mainType runtime
     mt <- getMainTerm loadTypeOfTerm parseNames mainName mainType

--- a/parser-typechecker/src/Unison/Codebase/MainTerm.hs
+++ b/parser-typechecker/src/Unison/Codebase/MainTerm.hs
@@ -33,15 +33,15 @@ data MainTerm v
 getMainTerm
   :: (Monad m, Var v)
   => (Reference -> m (Maybe (Type v Ann)))
-  -> Names.UnqualifiedNames
+  -> Names.Names
   -> String
   -> Type.Type v Ann
   -> m (MainTerm v)
-getMainTerm loadTypeOfTerm parseUnqualifiedNames mainName mainType =
+getMainTerm loadTypeOfTerm parseNames mainName mainType =
   case HQ.fromString mainName of
     Nothing -> pure (NotAFunctionName mainName)
     Just hq -> do
-      let refs = NamesWithHistory.lookupHQTerm hq (NamesWithHistory.NamesWithHistory parseUnqualifiedNames mempty)
+      let refs = NamesWithHistory.lookupHQTerm hq (NamesWithHistory.NamesWithHistory parseNames mempty)
       let a = Parser.Ann.External
       case toList refs of
         [Referent.Ref ref] -> do

--- a/parser-typechecker/src/Unison/Codebase/MainTerm.hs
+++ b/parser-typechecker/src/Unison/Codebase/MainTerm.hs
@@ -16,7 +16,7 @@ import qualified Unison.Builtin.Decls          as DD
 import qualified Unison.HashQualified          as HQ
 import qualified Unison.Referent               as Referent
 import           Unison.Name                    ( Name )
-import qualified Unison.Names3                 as Names3
+import qualified Unison.NamesWithHistory                 as NamesWithHistory
 import           Unison.Reference               ( Reference )
 import qualified Unison.Type                   as Type
 import           Unison.Type                    ( Type )
@@ -32,7 +32,7 @@ data MainTerm v
 getMainTerm
   :: (Monad m, Var v)
   => (Reference -> m (Maybe (Type v Ann)))
-  -> Names3.Names0
+  -> NamesWithHistory.Names0
   -> String
   -> Type.Type v Ann
   -> m (MainTerm v)
@@ -40,7 +40,7 @@ getMainTerm loadTypeOfTerm parseNames0 mainName mainType =
   case HQ.fromString mainName of
     Nothing -> pure (NotAFunctionName mainName)
     Just hq -> do
-      let refs = Names3.lookupHQTerm hq (Names3.NamesWithHistory parseNames0 mempty)
+      let refs = NamesWithHistory.lookupHQTerm hq (NamesWithHistory.NamesWithHistory parseNames0 mempty)
       let a = Parser.Ann.External
       case toList refs of
         [Referent.Ref ref] -> do

--- a/parser-typechecker/src/Unison/Codebase/MainTerm.hs
+++ b/parser-typechecker/src/Unison/Codebase/MainTerm.hs
@@ -40,7 +40,7 @@ getMainTerm loadTypeOfTerm parseNames0 mainName mainType =
   case HQ.fromString mainName of
     Nothing -> pure (NotAFunctionName mainName)
     Just hq -> do
-      let refs = Names3.lookupHQTerm hq (Names3.Names parseNames0 mempty)
+      let refs = Names3.lookupHQTerm hq (Names3.NamesWithHistory parseNames0 mempty)
       let a = Parser.Ann.External
       case toList refs of
         [Referent.Ref ref] -> do

--- a/parser-typechecker/src/Unison/Codebase/MainTerm.hs
+++ b/parser-typechecker/src/Unison/Codebase/MainTerm.hs
@@ -22,6 +22,7 @@ import qualified Unison.Type                   as Type
 import           Unison.Type                    ( Type )
 import qualified Unison.Typechecker as Typechecker
 import qualified Unison.Parser.Ann as Parser.Ann
+import qualified Unison.Names as Names
 
 data MainTerm v
   = NotAFunctionName String
@@ -32,15 +33,15 @@ data MainTerm v
 getMainTerm
   :: (Monad m, Var v)
   => (Reference -> m (Maybe (Type v Ann)))
-  -> NamesWithHistory.Names0
+  -> Names.UnqualifiedNames
   -> String
   -> Type.Type v Ann
   -> m (MainTerm v)
-getMainTerm loadTypeOfTerm parseNames0 mainName mainType =
+getMainTerm loadTypeOfTerm parseUnqualifiedNames mainName mainType =
   case HQ.fromString mainName of
     Nothing -> pure (NotAFunctionName mainName)
     Just hq -> do
-      let refs = NamesWithHistory.lookupHQTerm hq (NamesWithHistory.NamesWithHistory parseNames0 mempty)
+      let refs = NamesWithHistory.lookupHQTerm hq (NamesWithHistory.NamesWithHistory parseUnqualifiedNames mempty)
       let a = Parser.Ann.External
       case toList refs of
         [Referent.Ref ref] -> do

--- a/parser-typechecker/src/Unison/CommandLine.hs
+++ b/parser-typechecker/src/Unison/CommandLine.hs
@@ -33,7 +33,7 @@ import qualified Unison.Codebase.Watch           as Watch
 import           Unison.CommandLine.InputPattern (InputPattern (parse))
 import qualified Unison.HashQualified            as HQ
 import qualified Unison.HashQualified'           as HQ'
-import           Unison.Names (UnqualifiedNames)
+import           Unison.Names (Names)
 import qualified Unison.Util.ColorText           as CT
 import qualified Unison.Util.Find                as Find
 import qualified Unison.Util.Pretty              as P
@@ -156,7 +156,7 @@ prettyCompletion' (s, p) = Line.Completion s (P.toAnsiUnbroken p) False
 prettyCompletion'' :: Bool -> (String, P.Pretty P.ColorText) -> Line.Completion
 prettyCompletion'' spaceAtEnd (s, p) = Line.Completion s (P.toAnsiUnbroken p) spaceAtEnd
 
-fuzzyCompleteHashQualified :: UnqualifiedNames -> String -> [Line.Completion]
+fuzzyCompleteHashQualified :: Names -> String -> [Line.Completion]
 fuzzyCompleteHashQualified b q0@(HQ'.fromString -> query) = case query of
   Nothing -> []
   Just query ->

--- a/parser-typechecker/src/Unison/CommandLine.hs
+++ b/parser-typechecker/src/Unison/CommandLine.hs
@@ -33,7 +33,7 @@ import qualified Unison.Codebase.Watch           as Watch
 import           Unison.CommandLine.InputPattern (InputPattern (parse))
 import qualified Unison.HashQualified            as HQ
 import qualified Unison.HashQualified'           as HQ'
-import           Unison.Names2 (Names0)
+import           Unison.Names (Names0)
 import qualified Unison.Util.ColorText           as CT
 import qualified Unison.Util.Find                as Find
 import qualified Unison.Util.Pretty              as P

--- a/parser-typechecker/src/Unison/CommandLine.hs
+++ b/parser-typechecker/src/Unison/CommandLine.hs
@@ -33,7 +33,7 @@ import qualified Unison.Codebase.Watch           as Watch
 import           Unison.CommandLine.InputPattern (InputPattern (parse))
 import qualified Unison.HashQualified            as HQ
 import qualified Unison.HashQualified'           as HQ'
-import           Unison.Names (Names0)
+import           Unison.Names (UnqualifiedNames)
 import qualified Unison.Util.ColorText           as CT
 import qualified Unison.Util.Find                as Find
 import qualified Unison.Util.Pretty              as P
@@ -156,7 +156,7 @@ prettyCompletion' (s, p) = Line.Completion s (P.toAnsiUnbroken p) False
 prettyCompletion'' :: Bool -> (String, P.Pretty P.ColorText) -> Line.Completion
 prettyCompletion'' spaceAtEnd (s, p) = Line.Completion s (P.toAnsiUnbroken p) spaceAtEnd
 
-fuzzyCompleteHashQualified :: Names0 -> String -> [Line.Completion]
+fuzzyCompleteHashQualified :: UnqualifiedNames -> String -> [Line.Completion]
 fuzzyCompleteHashQualified b q0@(HQ'.fromString -> query) = case query of
   Nothing -> []
   Just query ->

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -1533,7 +1533,7 @@ typeCompletor :: Applicative m
               -> Path.Absolute
               -> m [Completion]
 typeCompletor filterQuery = pathCompletor filterQuery go where
-  go = Set.map HQ'.toText . R.dom . Names.types . Names.names0ToNames . Branch.toNames0
+  go = Set.map HQ'.toText . R.dom . Names.types . Names.names0ToNames . Branch.toUnqualifiedNames
 
 termCompletor :: Applicative m
               => (String -> [String] -> [Completion])
@@ -1543,7 +1543,7 @@ termCompletor :: Applicative m
               -> Path.Absolute
               -> m [Completion]
 termCompletor filterQuery = pathCompletor filterQuery go where
-  go = Set.map HQ'.toText . R.dom . Names.terms . Names.names0ToNames . Branch.toNames0
+  go = Set.map HQ'.toText . R.dom . Names.terms . Names.names0ToNames . Branch.toUnqualifiedNames
 
 patchArg :: ArgumentType
 patchArg = ArgumentType "patch" $ pathCompletor

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -1533,7 +1533,7 @@ typeCompletor :: Applicative m
               -> Path.Absolute
               -> m [Completion]
 typeCompletor filterQuery = pathCompletor filterQuery go where
-  go = Set.map HQ'.toText . R.dom . Names.types . Names.names0ToNames . Branch.toUnqualifiedNames
+  go = Set.map Name.toText . R.dom . Names.types . Branch.toUnqualifiedNames
 
 termCompletor :: Applicative m
               => (String -> [String] -> [Completion])
@@ -1543,7 +1543,7 @@ termCompletor :: Applicative m
               -> Path.Absolute
               -> m [Completion]
 termCompletor filterQuery = pathCompletor filterQuery go where
-  go = Set.map HQ'.toText . R.dom . Names.terms . Names.names0ToNames . Branch.toUnqualifiedNames
+  go = Set.map Name.toText . R.dom . Names.types . Branch.toUnqualifiedNames
 
 patchArg :: ArgumentType
 patchArg = ArgumentType "patch" $ pathCompletor

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -1533,7 +1533,7 @@ typeCompletor :: Applicative m
               -> Path.Absolute
               -> m [Completion]
 typeCompletor filterQuery = pathCompletor filterQuery go where
-  go = Set.map Name.toText . R.dom . Names.types . Branch.toUnqualifiedNames
+  go = Set.map Name.toText . R.dom . Names.types . Branch.toNames
 
 termCompletor :: Applicative m
               => (String -> [String] -> [Completion])
@@ -1543,7 +1543,7 @@ termCompletor :: Applicative m
               -> Path.Absolute
               -> m [Completion]
 termCompletor filterQuery = pathCompletor filterQuery go where
-  go = Set.map Name.toText . R.dom . Names.types . Branch.toUnqualifiedNames
+  go = Set.map Name.toText . R.dom . Names.types . Branch.toNames
 
 patchArg :: ArgumentType
 patchArg = ArgumentType "patch" $ pathCompletor

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -1533,7 +1533,7 @@ typeCompletor :: Applicative m
               -> Path.Absolute
               -> m [Completion]
 typeCompletor filterQuery = pathCompletor filterQuery go where
-  go = Set.map Name.toText . R.dom . Names.types . Branch.toNames
+  go = Set.map HQ.toText . R.dom . Names.hashQualifyTypesRelation . Names.types . Branch.toNames
 
 termCompletor :: Applicative m
               => (String -> [String] -> [Completion])
@@ -1543,7 +1543,7 @@ termCompletor :: Applicative m
               -> Path.Absolute
               -> m [Completion]
 termCompletor filterQuery = pathCompletor filterQuery go where
-  go = Set.map Name.toText . R.dom . Names.types . Branch.toNames
+  go = Set.map HQ.toText . R.dom . Names.hashQualifyTermsRelation . Names.terms . Branch.toNames
 
 patchArg :: ArgumentType
 patchArg = ArgumentType "patch" $ pathCompletor

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -37,7 +37,7 @@ import qualified Unison.HashQualified as HQ
 import qualified Unison.HashQualified' as HQ'
 import qualified Unison.Name as Name
 import           Unison.Name ( Name )
-import qualified Unison.Names2 as Names
+import qualified Unison.Names as Names
 import qualified Unison.Util.ColorText as CT
 import qualified Unison.Util.Pretty as P
 import qualified Unison.Util.Relation as R

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -1942,21 +1942,21 @@ prettyDiff diff = let
   adds = Names.addedNames diff
   removes = Names.removedNames diff
 
-  addedTerms = [ (n,r) | (n,r) <- R.toList (Names.terms0 adds)
-                       , not $ R.memberRan r (Names.terms0 removes) ]
-  addedTypes = [ (n,r) | (n,r) <- R.toList (Names.types0 adds)
-                       , not $ R.memberRan r (Names.types0 removes) ]
+  addedTerms = [ (n,r) | (n,r) <- R.toList (Names.terms adds)
+                       , not $ R.memberRan r (Names.terms removes) ]
+  addedTypes = [ (n,r) | (n,r) <- R.toList (Names.types adds)
+                       , not $ R.memberRan r (Names.types removes) ]
   added = sort (hqTerms ++ hqTypes)
     where
       hqTerms = [ Names.hqName adds n (Right r) | (n, r) <- addedTerms ]
       hqTypes = [ Names.hqName adds n (Left r)  | (n, r) <- addedTypes ]
 
-  removedTerms = [ (n,r) | (n,r) <- R.toList (Names.terms0 removes)
-                         , not $ R.memberRan r (Names.terms0 adds)
+  removedTerms = [ (n,r) | (n,r) <- R.toList (Names.terms removes)
+                         , not $ R.memberRan r (Names.terms adds)
                          , Set.notMember n addedTermsSet ] where
     addedTermsSet = Set.fromList (map fst addedTerms)
-  removedTypes = [ (n,r) | (n,r) <- R.toList (Names.types0 removes)
-                         , not $ R.memberRan r (Names.types0 adds)
+  removedTypes = [ (n,r) | (n,r) <- R.toList (Names.types removes)
+                         , not $ R.memberRan r (Names.types adds)
                          , Set.notMember n addedTypesSet ] where
     addedTypesSet = Set.fromList (map fst addedTypes)
   removed = sort (hqTerms ++ hqTypes)
@@ -1964,20 +1964,20 @@ prettyDiff diff = let
       hqTerms = [ Names.hqName removes n (Right r) | (n, r) <- removedTerms ]
       hqTypes = [ Names.hqName removes n (Left r)  | (n, r) <- removedTypes ]
 
-  movedTerms = [ (n,n2) | (n,r) <- R.toList (Names.terms0 removes)
+  movedTerms = [ (n,n2) | (n,r) <- R.toList (Names.terms removes)
                         , n2 <- toList (R.lookupRan r (Names.terms adds)) ]
   movedTypes = [ (n,n2) | (n,r) <- R.toList (Names.types removes)
                         , n2 <- toList (R.lookupRan r (Names.types adds)) ]
   moved = Name.sortNamed fst . nubOrd $ (movedTerms <> movedTypes)
 
   copiedTerms = List.multimap [
-    (n,n2) | (n2,r) <- R.toList (Names.terms0 adds)
-           , not (R.memberRan r (Names.terms0 removes))
-           , n <- toList (R.lookupRan r (Names.terms0 orig)) ]
+    (n,n2) | (n2,r) <- R.toList (Names.terms adds)
+           , not (R.memberRan r (Names.terms removes))
+           , n <- toList (R.lookupRan r (Names.terms orig)) ]
   copiedTypes = List.multimap [
-    (n,n2) | (n2,r) <- R.toList (Names.types0 adds)
-           , not (R.memberRan r (Names.types0 removes))
-           , n <- toList (R.lookupRan r (Names.types0 orig)) ]
+    (n,n2) | (n2,r) <- R.toList (Names.types adds)
+           , not (R.memberRan r (Names.types removes))
+           , n <- toList (R.lookupRan r (Names.types orig)) ]
   copied = Name.sortNamed fst $
     Map.toList (Map.unionWith (<>) copiedTerms copiedTypes)
   in

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -73,7 +73,7 @@ import           Unison.NamePrinter            (prettyHashQualified,
                                                 styleHashQualified', prettyHashQualified')
 import           Unison.Names2                 (Names'(..), Names0)
 import qualified Unison.Names2                 as Names
-import qualified Unison.Names3                 as Names
+import qualified Unison.NamesWithHistory                 as Names
 import Unison.Parser.Ann (Ann, startingLine)
 import qualified Unison.PrettyPrintEnv         as PPE
 import qualified Unison.PrettyPrintEnv.Util as PPE

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -71,8 +71,8 @@ import           Unison.NamePrinter            (prettyHashQualified,
                                                 prettyName, prettyShortHash,
                                                 styleHashQualified,
                                                 styleHashQualified', prettyHashQualified')
-import           Unison.Names2                 (Names'(..), Names0)
-import qualified Unison.Names2                 as Names
+import           Unison.Names                 (Names'(..), Names0)
+import qualified Unison.Names                 as Names
 import qualified Unison.NamesWithHistory                 as Names
 import Unison.Parser.Ann (Ann, startingLine)
 import qualified Unison.PrettyPrintEnv         as PPE

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -71,7 +71,7 @@ import           Unison.NamePrinter            (prettyHashQualified,
                                                 prettyName, prettyShortHash,
                                                 styleHashQualified,
                                                 styleHashQualified', prettyHashQualified')
-import           Unison.Names                 (Names'(..), UnqualifiedNames)
+import           Unison.Names                 (Names'(..), Names)
 import qualified Unison.Names                 as Names
 import qualified Unison.NamesWithHistory                 as Names
 import Unison.Parser.Ann (Ann, startingLine)
@@ -1382,7 +1382,7 @@ todoOutput ppe todo =
     where
     -- If a conflict is both an edit and a name conflict, we show it in the edit
     -- conflicts section
-    c :: UnqualifiedNames
+    c :: Names
     c = removeEditConflicts (TO.editConflicts todo) (TO.nameConflicts todo)
     conflictedTypeNames = (R.dom . Names.types) c
     conflictedTermNames = (R.dom . Names.terms) c

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -71,7 +71,7 @@ import           Unison.NamePrinter            (prettyHashQualified,
                                                 prettyName, prettyShortHash,
                                                 styleHashQualified,
                                                 styleHashQualified', prettyHashQualified')
-import           Unison.Names                 (Names'(..), Names)
+import           Unison.Names                 (Names(..))
 import qualified Unison.Names                 as Names
 import qualified Unison.NamesWithHistory                 as Names
 import Unison.Parser.Ann (Ann, startingLine)
@@ -1397,7 +1397,7 @@ todoOutput ppe todo =
     -- edit conflict, so that the edit conflict will be dealt with first.
     -- For example, if hash `h` has multiple edit targets { #x, #y, #z, ...},
     -- we'll temporarily remove name conflicts pointing to { #x, #y, #z, ...}.
-    removeEditConflicts :: Ord n => Patch -> Names' n -> Names' n
+    removeEditConflicts :: Patch -> Names -> Names
     removeEditConflicts Patch{..} Names{..} = Names terms' types' where
       terms' = R.filterRan (`Set.notMember` conflictedTermEditTargets) terms
       types' = R.filterRan (`Set.notMember` conflictedTypeEditTargets) types

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -71,7 +71,7 @@ import           Unison.NamePrinter            (prettyHashQualified,
                                                 prettyName, prettyShortHash,
                                                 styleHashQualified,
                                                 styleHashQualified', prettyHashQualified')
-import           Unison.Names                 (Names'(..), Names0)
+import           Unison.Names                 (Names'(..), UnqualifiedNames)
 import qualified Unison.Names                 as Names
 import qualified Unison.NamesWithHistory                 as Names
 import Unison.Parser.Ann (Ann, startingLine)
@@ -1382,7 +1382,7 @@ todoOutput ppe todo =
     where
     -- If a conflict is both an edit and a name conflict, we show it in the edit
     -- conflicts section
-    c :: Names0
+    c :: UnqualifiedNames
     c = removeEditConflicts (TO.editConflicts todo) (TO.nameConflicts todo)
     conflictedTypeNames = (R.dom . Names.types) c
     conflictedTermNames = (R.dom . Names.terms) c

--- a/parser-typechecker/src/Unison/FileParser.hs
+++ b/parser-typechecker/src/Unison/FileParser.hs
@@ -32,7 +32,7 @@ import qualified Unison.Util.List as List
 import           Unison.Var (Var)
 import qualified Unison.Var as Var
 import qualified Unison.WatchKind as UF
-import qualified Unison.Names3 as Names
+import qualified Unison.NamesWithHistory as Names
 import qualified Unison.Names.ResolutionResult as Names
 import qualified Unison.Name as Name
 

--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -38,7 +38,7 @@ import qualified Unison.Util.List           as List
 import qualified Unison.Util.Relation       as Rel
 import           Unison.Var                 (Var)
 import qualified Unison.Var                 as Var
-import Unison.Names(UnqualifiedNames)
+import Unison.Names(Names)
 import qualified Unison.Names as Names
 
 type Term v = Term.Term v Ann
@@ -69,7 +69,7 @@ parseAndSynthesizeFile
   -> ResultT
        (Seq (Note v Ann))
        m
-       (Either UnqualifiedNames (UF.TypecheckedUnisonFile v Ann))
+       (Either Names (UF.TypecheckedUnisonFile v Ann))
 parseAndSynthesizeFile ambient typeLookupf env filePath src = do
   when debug $ traceM "parseAndSynthesizeFile"
   uf <- Result.fromParsing $ Parsers.parseFile filePath (unpack src) env
@@ -83,7 +83,7 @@ type TDNRMap v = Map Typechecker.Name [Typechecker.NamedReference v Ann]
 resolveNames
   :: (Var v, Monad m)
   => (Set Reference -> m (TL.TypeLookup v Ann))
-  -> Names.UnqualifiedNames
+  -> Names.Names
   -> UnisonFile v
   -> ResultT
        (Seq (Note v Ann))

--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -93,7 +93,7 @@ resolveNames typeLookupf preexistingNames uf = do
   let tm = UF.typecheckingTerm uf
       deps = Term.dependencies tm
       possibleDeps = [ (Name.toText name, Var.name v, r) |
-        (name, r) <- Rel.toList (NamesWithHistory.terms0 preexistingNames),
+        (name, r) <- Rel.toList (Names.terms preexistingNames),
         v <- Set.toList (Term.freeVars tm),
         name `Name.endsWithSegments` Name.fromVar v ]
       possibleRefs = Referent.toReference . view _3 <$> possibleDeps
@@ -116,7 +116,7 @@ resolveNames typeLookupf preexistingNames uf = do
           let nr = Typechecker.NamedReference name typ (Right r) ] <>
         -- local file TDNR possibilities
         [ (Var.name v, nr) |
-          (name, r) <- Rel.toList (NamesWithHistory.terms0 $ UF.toNames uf),
+          (name, r) <- Rel.toList (Names.terms $ UF.toNames uf),
           v <- Set.toList (Term.freeVars tm),
           name `Name.endsWithSegments` Name.fromVar v,
           typ <- toList $ TL.typeOfReferent tl r,

--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -20,7 +20,7 @@ import           Data.Text                  (unpack)
 import qualified Unison.ABT                 as ABT
 import qualified Unison.Blank               as Blank
 import qualified Unison.Name                as Name
-import qualified Unison.Names3              as Names
+import qualified Unison.NamesWithHistory              as Names
 import Unison.Parser.Ann (Ann)
 import qualified Unison.Parsers             as Parsers
 import qualified Unison.Referent            as Referent
@@ -38,7 +38,7 @@ import qualified Unison.Util.List           as List
 import qualified Unison.Util.Relation       as Rel
 import           Unison.Var                 (Var)
 import qualified Unison.Var                 as Var
-import Unison.Names3 (Names0)
+import Unison.NamesWithHistory (Names0)
 
 type Term v = Term.Term v Ann
 type Type v = Type.Type v Ann

--- a/parser-typechecker/src/Unison/Parser.hs
+++ b/parser-typechecker/src/Unison/Parser.hs
@@ -47,7 +47,7 @@ import qualified Unison.Var           as Var
 import qualified Unison.UnisonFile.Error as UF
 import Unison.Util.Bytes              (Bytes)
 import Unison.Name as Name
-import Unison.Names3 (NamesWithHistory)
+import Unison.NamesWithHistory (NamesWithHistory)
 import qualified Unison.Names.ResolutionResult as Names
 import Control.Monad.Reader.Class (asks)
 import qualified Unison.Hashable as Hashable

--- a/parser-typechecker/src/Unison/Parser.hs
+++ b/parser-typechecker/src/Unison/Parser.hs
@@ -47,7 +47,7 @@ import qualified Unison.Var           as Var
 import qualified Unison.UnisonFile.Error as UF
 import Unison.Util.Bytes              (Bytes)
 import Unison.Name as Name
-import Unison.Names3 (Names)
+import Unison.Names3 (NamesWithHistory)
 import qualified Unison.Names.ResolutionResult as Names
 import Control.Monad.Reader.Class (asks)
 import qualified Unison.Hashable as Hashable
@@ -65,7 +65,7 @@ type Err v = P.ParseError (Token Input) (Error v)
 
 data ParsingEnv =
   ParsingEnv { uniqueNames :: UniqueName
-             , names :: Names
+             , names :: NamesWithHistory
              }
 
 newtype UniqueName = UniqueName (L.Pos -> Int -> Maybe Text)

--- a/parser-typechecker/src/Unison/Parsers.hs
+++ b/parser-typechecker/src/Unison/Parsers.hs
@@ -5,7 +5,7 @@ import Unison.Prelude
 import qualified Data.Text                     as Text
 import           Data.Text.IO                   ( readFile )
 import           Prelude                 hiding ( readFile )
-import qualified Unison.Names3                 as Names
+import qualified Unison.NamesWithHistory                 as Names
 import qualified Unison.Builtin                as Builtin
 import qualified Unison.FileParser             as FileParser
 import Unison.Parser.Ann (Ann)

--- a/parser-typechecker/src/Unison/Parsers.hs
+++ b/parser-typechecker/src/Unison/Parsers.hs
@@ -80,7 +80,7 @@ unsafeParseFileBuiltinsOnly
 unsafeParseFileBuiltinsOnly =
   unsafeReadAndParseFile $ Parser.ParsingEnv
     mempty
-    (Names.Names Builtin.names0 mempty)
+    (Names.NamesWithHistory Builtin.names0 mempty)
 
 unsafeParseFile
   :: String -> Parser.ParsingEnv -> UnisonFile Symbol Ann

--- a/parser-typechecker/src/Unison/PrettyPrintEnv/Names.hs
+++ b/parser-typechecker/src/Unison/PrettyPrintEnv/Names.hs
@@ -7,18 +7,18 @@ import Unison.Prelude
 import qualified Data.Set as Set
 import qualified Unison.HashQualified as HQ
 import qualified Unison.Name as Name
-import Unison.Names3 (Names)
+import Unison.Names3 (NamesWithHistory)
 import qualified Unison.Names3 as Names
 import Unison.PrettyPrintEnv (PrettyPrintEnv (PrettyPrintEnv))
 import Unison.Util.List (safeHead)
 
-fromNames :: Int -> Names -> PrettyPrintEnv
+fromNames :: Int -> NamesWithHistory -> PrettyPrintEnv
 fromNames len names = PrettyPrintEnv terms' types' where
   terms' r = shortestName . Set.map Name.convert $ Names.termName len r names
   types' r = shortestName . Set.map Name.convert $ Names.typeName len r names
   shortestName ns = safeHead $ HQ.sortByLength (toList ns)
 
-fromSuffixNames :: Int -> Names -> PrettyPrintEnv
+fromSuffixNames :: Int -> NamesWithHistory -> PrettyPrintEnv
 fromSuffixNames len names = PrettyPrintEnv terms' types' where
   terms' r = safeHead $ Names.suffixedTermName len r names
   types' r = safeHead $ Names.suffixedTypeName len r names

--- a/parser-typechecker/src/Unison/PrettyPrintEnv/Names.hs
+++ b/parser-typechecker/src/Unison/PrettyPrintEnv/Names.hs
@@ -7,8 +7,8 @@ import Unison.Prelude
 import qualified Data.Set as Set
 import qualified Unison.HashQualified as HQ
 import qualified Unison.Name as Name
-import Unison.Names3 (NamesWithHistory)
-import qualified Unison.Names3 as Names
+import Unison.NamesWithHistory (NamesWithHistory)
+import qualified Unison.NamesWithHistory as Names
 import Unison.PrettyPrintEnv (PrettyPrintEnv (PrettyPrintEnv))
 import Unison.Util.List (safeHead)
 

--- a/parser-typechecker/src/Unison/PrettyPrintEnvDecl/Names.hs
+++ b/parser-typechecker/src/Unison/PrettyPrintEnvDecl/Names.hs
@@ -2,7 +2,7 @@
 
 module Unison.PrettyPrintEnvDecl.Names where
 
-import Unison.Names3 (NamesWithHistory)
+import Unison.NamesWithHistory (NamesWithHistory)
 import Unison.PrettyPrintEnvDecl (PrettyPrintEnvDecl (PrettyPrintEnvDecl))
 import Unison.PrettyPrintEnv.Names (fromNames, fromSuffixNames)
 

--- a/parser-typechecker/src/Unison/PrettyPrintEnvDecl/Names.hs
+++ b/parser-typechecker/src/Unison/PrettyPrintEnvDecl/Names.hs
@@ -2,10 +2,10 @@
 
 module Unison.PrettyPrintEnvDecl.Names where
 
-import Unison.Names3 (Names)
+import Unison.Names3 (NamesWithHistory)
 import Unison.PrettyPrintEnvDecl (PrettyPrintEnvDecl (PrettyPrintEnvDecl))
 import Unison.PrettyPrintEnv.Names (fromNames, fromSuffixNames)
 
-fromNamesDecl :: Int -> Names -> PrettyPrintEnvDecl
+fromNamesDecl :: Int -> NamesWithHistory -> PrettyPrintEnvDecl
 fromNamesDecl hashLength names =
   PrettyPrintEnvDecl (fromNames hashLength names) (fromSuffixNames hashLength names)

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -1476,7 +1476,7 @@ prettyResolutionFailures s allFailures =
 
     ppeFromNames0 :: Names3.Names0 -> PPE.PrettyPrintEnv
     ppeFromNames0 names0 =
-      PPE.fromNames PPE.todoHashLength (Names3.Names {currentNames = names0, oldNames = mempty})
+      PPE.fromNames PPE.todoHashLength (Names3.NamesWithHistory {currentNames = names0, oldNames = mempty})
 
     prettyRow :: (v, Maybe (NESet String)) -> [(Pretty ColorText, Pretty ColorText)]
     prettyRow (v, mSet) = case mSet of

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -60,6 +60,7 @@ import qualified Unison.PrettyPrintEnv.Names as PPE
 import qualified Unison.NamesWithHistory as NamesWithHistory
 import Data.Set.NonEmpty (NESet)
 import qualified Data.Set.NonEmpty as NES
+import qualified Unison.Names as Names
 
 type Env = PPE.PrettyPrintEnv
 
@@ -1466,16 +1467,16 @@ prettyResolutionFailures s allFailures =
     toAmbiguityPair :: Names.ResolutionFailure v annotation -> (v, Maybe (NESet String))
     toAmbiguityPair = \case
       (Names.TermResolutionFailure v _ (Names.Ambiguous names refs)) -> do
-        let ppe = ppeFromNames0 names
+        let ppe = ppeFromUnqualifiedNames names
          in (v, Just $ NES.map (showTermRef ppe) refs)
       (Names.TypeResolutionFailure v _ (Names.Ambiguous names refs)) -> do
-        let ppe = ppeFromNames0 names
+        let ppe = ppeFromUnqualifiedNames names
          in (v, Just $ NES.map (showTypeRef ppe) refs)
       (Names.TermResolutionFailure v _ Names.NotFound) -> (v, Nothing)
       (Names.TypeResolutionFailure v _ Names.NotFound) -> (v, Nothing)
 
-    ppeFromNames0 :: NamesWithHistory.Names0 -> PPE.PrettyPrintEnv
-    ppeFromNames0 names0 =
+    ppeFromUnqualifiedNames :: Names.UnqualifiedNames -> PPE.PrettyPrintEnv
+    ppeFromUnqualifiedNames names0 =
       PPE.fromNames PPE.todoHashLength (NamesWithHistory.NamesWithHistory {currentNames = names0, oldNames = mempty})
 
     prettyRow :: (v, Maybe (NESet String)) -> [(Pretty ColorText, Pretty ColorText)]

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -57,7 +57,7 @@ import Unison.HashQualified (HashQualified)
 import Unison.Type (Type)
 import Unison.NamePrinter (prettyHashQualified0)
 import qualified Unison.PrettyPrintEnv.Names as PPE
-import qualified Unison.Names3 as Names3
+import qualified Unison.NamesWithHistory as NamesWithHistory
 import Data.Set.NonEmpty (NESet)
 import qualified Data.Set.NonEmpty as NES
 
@@ -1474,9 +1474,9 @@ prettyResolutionFailures s allFailures =
       (Names.TermResolutionFailure v _ Names.NotFound) -> (v, Nothing)
       (Names.TypeResolutionFailure v _ Names.NotFound) -> (v, Nothing)
 
-    ppeFromNames0 :: Names3.Names0 -> PPE.PrettyPrintEnv
+    ppeFromNames0 :: NamesWithHistory.Names0 -> PPE.PrettyPrintEnv
     ppeFromNames0 names0 =
-      PPE.fromNames PPE.todoHashLength (Names3.NamesWithHistory {currentNames = names0, oldNames = mempty})
+      PPE.fromNames PPE.todoHashLength (NamesWithHistory.NamesWithHistory {currentNames = names0, oldNames = mempty})
 
     prettyRow :: (v, Maybe (NESet String)) -> [(Pretty ColorText, Pretty ColorText)]
     prettyRow (v, mSet) = case mSet of

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -1467,16 +1467,16 @@ prettyResolutionFailures s allFailures =
     toAmbiguityPair :: Names.ResolutionFailure v annotation -> (v, Maybe (NESet String))
     toAmbiguityPair = \case
       (Names.TermResolutionFailure v _ (Names.Ambiguous names refs)) -> do
-        let ppe = ppeFromUnqualifiedNames names
+        let ppe = ppeFromNames names
          in (v, Just $ NES.map (showTermRef ppe) refs)
       (Names.TypeResolutionFailure v _ (Names.Ambiguous names refs)) -> do
-        let ppe = ppeFromUnqualifiedNames names
+        let ppe = ppeFromNames names
          in (v, Just $ NES.map (showTypeRef ppe) refs)
       (Names.TermResolutionFailure v _ Names.NotFound) -> (v, Nothing)
       (Names.TypeResolutionFailure v _ Names.NotFound) -> (v, Nothing)
 
-    ppeFromUnqualifiedNames :: Names.UnqualifiedNames -> PPE.PrettyPrintEnv
-    ppeFromUnqualifiedNames names0 =
+    ppeFromNames :: Names.Names -> PPE.PrettyPrintEnv
+    ppeFromNames names0 =
       PPE.fromNames PPE.todoHashLength (NamesWithHistory.NamesWithHistory {currentNames = names0, oldNames = mempty})
 
     prettyRow :: (v, Maybe (NESet String)) -> [(Pretty ColorText, Pretty ColorText)]

--- a/parser-typechecker/src/Unison/Runtime/IOSource.hs
+++ b/parser-typechecker/src/Unison/Runtime/IOSource.hs
@@ -41,7 +41,7 @@ typecheckedFile' :: forall v. Var.Var v => UF.TypecheckedUnisonFile v Ann
 typecheckedFile' = let
   tl :: a -> Identity (TL.TypeLookup v Ann)
   tl = const $ pure (External <$ Builtin.typeLookup)
-  env = Parser.ParsingEnv mempty (Names.Names Builtin.names0 mempty)
+  env = Parser.ParsingEnv mempty (Names.NamesWithHistory Builtin.names0 mempty)
   r = parseAndSynthesizeFile [] tl env "<IO.u builtin>" source
   in case runIdentity $ Result.runResultT r of
     (Nothing, notes) -> error $ "parsing failed: " <> show notes

--- a/parser-typechecker/src/Unison/Runtime/IOSource.hs
+++ b/parser-typechecker/src/Unison/Runtime/IOSource.hs
@@ -28,7 +28,7 @@ import qualified Unison.Term as Term
 import qualified Unison.Typechecker.TypeLookup as TL
 import qualified Unison.UnisonFile as UF
 import qualified Unison.Var as Var
-import qualified Unison.Names3 as Names
+import qualified Unison.NamesWithHistory as Names
 
 debug :: Bool
 debug = False

--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -54,7 +54,7 @@ import qualified Unison.Name as Name
 import qualified Unison.NamePrinter as NP
 import Unison.NameSegment (NameSegment(..))
 import qualified Unison.NameSegment as NameSegment
-import qualified Unison.Names2 as Names
+import qualified Unison.Names as Names
 import Unison.NamesWithHistory
   ( NamesWithHistory (..),
     Names0,

--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -127,14 +127,14 @@ basicNames' root path = (parseNames0, prettyPrintNames0)
   where
     root0 = Branch.head root
     currentBranch = fromMaybe Branch.empty $ Branch.getAt path root
-    absoluteRootNames = NamesWithHistory.makeAbsolute0 (Branch.toNames root0)
+    absoluteRootNames = Names.makeAbsolute (Branch.toNames root0)
     currentBranch0 = Branch.head currentBranch
     currentPathNames = Branch.toNames currentBranch0
     -- all names, but with local names in their relative form only, rather
     -- than absolute; external names appear as absolute
     currentAndExternalNames =
       currentPathNames
-        `NamesWithHistory.unionLeft0` absDot externalNames
+        `Names.unionLeft` absDot externalNames
       where
         absDot = Names.prefix0 (Name.unsafeFromText "")
         externalNames = rootNames `Names.difference` pathPrefixed currentPathNames
@@ -458,7 +458,7 @@ getCurrentParseNames path root = NamesWithHistory (basicParseNames root path) me
 --      then name foo.bar.baz becomes baz
 --           name cat.dog     becomes .cat.dog
 fixupNamesRelative :: Path.Absolute -> Names -> Names
-fixupNamesRelative root = NamesWithHistory.map0 fixName where
+fixupNamesRelative root = Names.map fixName where
   prefix = Path.toName $ Path.unabsolute root
   fixName n = if root == Path.absoluteEmpty
     then n

--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -56,7 +56,7 @@ import Unison.NameSegment (NameSegment(..))
 import qualified Unison.NameSegment as NameSegment
 import qualified Unison.Names2 as Names
 import Unison.Names3
-  ( Names (..),
+  ( NamesWithHistory (..),
     Names0,
   )
 import qualified Unison.Names3 as Names3
@@ -152,7 +152,7 @@ basicNames0' root path = (parseNames00, prettyPrintNames00)
 basicSuffixifiedNames :: Int -> Branch m -> Path -> PPE.PrettyPrintEnv
 basicSuffixifiedNames hashLength root path =
   let names0 = basicPrettyPrintNames0 root path
-   in PPE.suffixifiedPPE . PPE.fromNamesDecl hashLength $ Names names0 mempty
+   in PPE.suffixifiedPPE . PPE.fromNamesDecl hashLength $ NamesWithHistory names0 mempty
 
 basicPrettyPrintNames0 :: Branch m -> Path -> Names0
 basicPrettyPrintNames0 root = snd . basicNames0' root
@@ -445,12 +445,12 @@ termReferentsByShortHash codebase sh = do
 -- currentPathNames0 :: Path -> Names0
 -- currentPathNames0 = Branch.toNames0 . Branch.head . Branch.getAt
 
-getCurrentPrettyNames :: Path -> Branch m -> Names
+getCurrentPrettyNames :: Path -> Branch m -> NamesWithHistory
 getCurrentPrettyNames path root =
-  Names (basicPrettyPrintNames0 root path) mempty
+  NamesWithHistory (basicPrettyPrintNames0 root path) mempty
 
-getCurrentParseNames :: Path -> Branch m -> Names
-getCurrentParseNames path root = Names (basicParseNames0 root path) mempty
+getCurrentParseNames :: Path -> Branch m -> NamesWithHistory
+getCurrentParseNames path root = NamesWithHistory (basicParseNames0 root path) mempty
 
 -- Any absolute names in the input which have `root` as a prefix
 -- are converted to names relative to current path. All other names are
@@ -477,7 +477,7 @@ data Search r = Search
   }
 
 -- | Make a type search, given a short hash length and names to search in.
-makeTypeSearch :: Int -> Names -> Search Reference
+makeTypeSearch :: Int -> NamesWithHistory -> Search Reference
 makeTypeSearch len names =
   Search
     { lookupNames = \ref -> Names3.typeName len ref names,
@@ -487,7 +487,7 @@ makeTypeSearch len names =
     }
 
 -- | Make a term search, given a short hash length and names to search in.
-makeTermSearch :: Int -> Names -> Search Referent
+makeTermSearch :: Int -> NamesWithHistory -> Search Referent
 makeTermSearch len names =
   Search
     { lookupNames = \ref -> Names3.termName len ref names,

--- a/parser-typechecker/src/Unison/Server/SearchResult.hs
+++ b/parser-typechecker/src/Unison/Server/SearchResult.hs
@@ -6,8 +6,8 @@ import qualified Data.Set              as Set
 import           Unison.HashQualified  (HashQualified)
 import qualified Unison.HashQualified' as HQ'
 import           Unison.Name           (Name)
-import           Unison.Names2         (Names'(Names), Names0)
-import qualified Unison.Names2         as Names
+import           Unison.Names         (Names'(Names), Names0)
+import qualified Unison.Names         as Names
 import           Unison.Reference      (Reference)
 import           Unison.Referent       (Referent)
 import qualified Unison.Referent       as Referent

--- a/parser-typechecker/src/Unison/Server/SearchResult.hs
+++ b/parser-typechecker/src/Unison/Server/SearchResult.hs
@@ -6,7 +6,7 @@ import qualified Data.Set              as Set
 import           Unison.HashQualified  (HashQualified)
 import qualified Unison.HashQualified' as HQ'
 import           Unison.Name           (Name)
-import           Unison.Names         (Names'(Names), UnqualifiedNames)
+import           Unison.Names         (Names'(Names), Names)
 import qualified Unison.Names         as Names
 import           Unison.Reference      (Reference)
 import           Unison.Referent       (Referent)
@@ -35,7 +35,7 @@ termResult
   :: HashQualified Name -> Referent -> Set (HQ'.HashQualified Name) -> SearchResult
 termResult hq r as = Tm (TermResult hq r as)
 
-termSearchResult :: UnqualifiedNames -> Name -> Referent -> SearchResult
+termSearchResult :: Names -> Name -> Referent -> SearchResult
 termSearchResult b n r =
   termResult (HQ'.toHQ (Names._hqTermName b n r)) r (Names._hqTermAliases b n r)
 
@@ -44,7 +44,7 @@ typeResult
   :: HashQualified Name -> Reference -> Set (HQ'.HashQualified Name) -> SearchResult
 typeResult hq r as = Tp (TypeResult hq r as)
 
-typeSearchResult :: UnqualifiedNames -> Name -> Reference -> SearchResult
+typeSearchResult :: Names -> Name -> Reference -> SearchResult
 typeSearchResult b n r =
   typeResult (HQ'.toHQ (Names._hqTypeName b n r)) r (Names._hqTypeAliases b n r)
 
@@ -69,12 +69,12 @@ truncateAliases n = \case
   Tp (TypeResult hq r as) -> typeResult hq r (Set.map (HQ'.take n) as)
 
 -- | You may want to sort this list differently afterward.
-fromNames :: UnqualifiedNames -> [SearchResult]
+fromNames :: Names -> [SearchResult]
 fromNames b =
   map (uncurry (typeSearchResult b)) (R.toList . Names.types $ b) <>
   map (uncurry (termSearchResult b)) (R.toList . Names.terms $ b)
 
-_fromNames :: UnqualifiedNames -> [SearchResult]
+_fromNames :: Names -> [SearchResult]
 _fromNames n0@(Names terms types) = typeResults <> termResults where
   typeResults =
     [ typeSearchResult n0 name r

--- a/parser-typechecker/src/Unison/Server/SearchResult.hs
+++ b/parser-typechecker/src/Unison/Server/SearchResult.hs
@@ -6,7 +6,7 @@ import qualified Data.Set              as Set
 import           Unison.HashQualified  (HashQualified)
 import qualified Unison.HashQualified' as HQ'
 import           Unison.Name           (Name)
-import           Unison.Names         (Names'(Names), Names0)
+import           Unison.Names         (Names'(Names), UnqualifiedNames)
 import qualified Unison.Names         as Names
 import           Unison.Reference      (Reference)
 import           Unison.Referent       (Referent)
@@ -35,7 +35,7 @@ termResult
   :: HashQualified Name -> Referent -> Set (HQ'.HashQualified Name) -> SearchResult
 termResult hq r as = Tm (TermResult hq r as)
 
-termSearchResult :: Names0 -> Name -> Referent -> SearchResult
+termSearchResult :: UnqualifiedNames -> Name -> Referent -> SearchResult
 termSearchResult b n r =
   termResult (HQ'.toHQ (Names._hqTermName b n r)) r (Names._hqTermAliases b n r)
 
@@ -44,7 +44,7 @@ typeResult
   :: HashQualified Name -> Reference -> Set (HQ'.HashQualified Name) -> SearchResult
 typeResult hq r as = Tp (TypeResult hq r as)
 
-typeSearchResult :: Names0 -> Name -> Reference -> SearchResult
+typeSearchResult :: UnqualifiedNames -> Name -> Reference -> SearchResult
 typeSearchResult b n r =
   typeResult (HQ'.toHQ (Names._hqTypeName b n r)) r (Names._hqTypeAliases b n r)
 
@@ -69,12 +69,12 @@ truncateAliases n = \case
   Tp (TypeResult hq r as) -> typeResult hq r (Set.map (HQ'.take n) as)
 
 -- | You may want to sort this list differently afterward.
-fromNames :: Names0 -> [SearchResult]
+fromNames :: UnqualifiedNames -> [SearchResult]
 fromNames b =
   map (uncurry (typeSearchResult b)) (R.toList . Names.types $ b) <>
   map (uncurry (termSearchResult b)) (R.toList . Names.terms $ b)
 
-_fromNames :: Names0 -> [SearchResult]
+_fromNames :: UnqualifiedNames -> [SearchResult]
 _fromNames n0@(Names terms types) = typeResults <> termResults where
   typeResults =
     [ typeSearchResult n0 name r

--- a/parser-typechecker/src/Unison/Server/SearchResult.hs
+++ b/parser-typechecker/src/Unison/Server/SearchResult.hs
@@ -6,7 +6,7 @@ import qualified Data.Set              as Set
 import           Unison.HashQualified  (HashQualified)
 import qualified Unison.HashQualified' as HQ'
 import           Unison.Name           (Name)
-import           Unison.Names         (Names'(Names), Names)
+import           Unison.Names         (Names(..))
 import qualified Unison.Names         as Names
 import           Unison.Reference      (Reference)
 import           Unison.Referent       (Referent)

--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -14,7 +14,7 @@ import           Control.Monad.Reader (asks, local)
 import           Data.Foldable (foldrM)
 import           Prelude hiding (and, or, seq)
 import           Unison.Name (Name)
-import           Unison.Names3 (Names)
+import           Unison.Names3 (NamesWithHistory)
 import           Unison.Reference (Reference)
 import           Unison.Referent (Referent)
 import           Unison.Parser hiding (seq)
@@ -993,7 +993,7 @@ instance Show v => Show (BlockElement v) where
 -- subst
 -- use Foo.Bar + blah
 -- use Bar.Baz zonk zazzle
-imports :: Var v => P v (Names, [(v,v)])
+imports :: Var v => P v (NamesWithHistory, [(v,v)])
 imports = do
   let sem = P.try (semi <* P.lookAhead (reserved "use"))
   imported <- mconcat . reverse <$> sepBy sem importp
@@ -1003,7 +1003,7 @@ imports = do
 -- A key feature of imports is we want to be able to say:
 -- `use foo.bar Baz qux` without having to specify whether `Baz` or `qux` are
 -- terms or types.
-substImports :: Var v => Names -> [(v,v)] -> Term v Ann -> Term v Ann
+substImports :: Var v => NamesWithHistory -> [(v,v)] -> Term v Ann -> Term v Ann
 substImports ns imports =
   ABT.substsInheritAnnotation [ (suffix, Term.var () full)
     | (suffix,full) <- imports ] . -- no guard here, as `full` could be bound

--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -38,7 +38,7 @@ import qualified Unison.ConstructorType as CT
 import qualified Unison.HashQualified as HQ
 import qualified Unison.Lexer as L
 import qualified Unison.Name as Name
-import qualified Unison.NamesWithHistory as Names
+import qualified Unison.Names as Names
 import qualified Unison.Parser as Parser (seq, uniqueName)
 import Unison.Parser.Ann (Ann)
 import qualified Unison.Pattern as Pattern
@@ -48,6 +48,7 @@ import qualified Unison.TypeParser as TypeParser
 import qualified Unison.Typechecker.Components as Components
 import qualified Unison.Util.Bytes as Bytes
 import qualified Unison.Var as Var
+import qualified Unison.NamesWithHistory as NamesWithHistory
 
 watch :: Show a => String -> a -> a
 watch msg a = let !_ = trace (msg ++ ": " ++ show a) () in a
@@ -85,7 +86,7 @@ typeLink' :: Var v => P v (L.Token Reference)
 typeLink' = do
   id <- hqPrefixId
   ns <- asks names
-  case Names.lookupHQType (L.payload id) ns of
+  case NamesWithHistory.lookupHQType (L.payload id) ns of
     s | Set.size s == 1 -> pure $ const (Set.findMin s) <$> id
       | otherwise       -> customFailure $ UnknownType id s
 
@@ -93,7 +94,7 @@ termLink' :: Var v => P v (L.Token Referent)
 termLink' = do
   id <- hqPrefixId
   ns <- asks names
-  case Names.lookupHQTerm (L.payload id) ns of
+  case NamesWithHistory.lookupHQTerm (L.payload id) ns of
     s | Set.size s == 1 -> pure $ const (Set.findMin s) <$> id
       | otherwise       -> customFailure $ UnknownTerm id s
 
@@ -101,7 +102,7 @@ link' :: Var v => P v (Either (L.Token Reference) (L.Token Referent))
 link' = do
   id <- hqPrefixId
   ns <- asks names
-  case (Names.lookupHQTerm (L.payload id) ns, Names.lookupHQType (L.payload id) ns) of
+  case (NamesWithHistory.lookupHQTerm (L.payload id) ns, NamesWithHistory.lookupHQType (L.payload id) ns) of
     (s, s2) | Set.size s == 1 && Set.null s2 -> pure . Right $ const (Set.findMin s) <$> id
     (s, s2) | Set.size s2 == 1 && Set.null s -> pure . Left $ const (Set.findMin s2) <$> id
     (s, s2) -> customFailure $ UnknownId id s s2
@@ -222,7 +223,7 @@ parsePattern = root
     names <- asks names
     -- probably should avoid looking up in `names` if `L.payload tok`
     -- starts with a lowercase
-    case Names.lookupHQPattern (L.payload tok) ct names of
+    case NamesWithHistory.lookupHQPattern (L.payload tok) ct names of
       s | Set.null s     -> die tok s
         | Set.size s > 1 -> die tok s
         | otherwise      -> -- matched ctor name, consume the token
@@ -359,7 +360,7 @@ resolveHashQualified tok = do
   names <- asks names
   case L.payload tok of
     HQ.NameOnly n -> pure $ Term.var (ann tok) (Name.toVar n)
-    _ -> case Names.lookupHQTerm (L.payload tok) names of
+    _ -> case NamesWithHistory.lookupHQTerm (L.payload tok) names of
       s | Set.null s     -> failCommitted $ UnknownTerm tok s
         | Set.size s > 1 -> failCommitted $ UnknownTerm tok s
         | otherwise      -> pure $ Term.fromReferent (ann tok) (Set.findMin s)
@@ -975,7 +976,7 @@ importp = do
     (Just prefix@(Left _), _) -> P.customFailure $ UseInvalidPrefixSuffix prefix suffixes
     (Just (Right prefix), Nothing) -> do -- `wildcard import`
       names <- asks names
-      pure $ Names.expandWildcardImport (L.payload prefix) (Names.currentNames names)
+      pure $ Names.expandWildcardImport (L.payload prefix) (NamesWithHistory.currentNames names)
     (Just (Right prefix), Just suffixes) -> pure $ do
       suffix <- L.payload <$> suffixes
       pure (suffix, Name.joinDot (L.payload prefix) suffix)
@@ -997,7 +998,7 @@ imports :: Var v => P v (NamesWithHistory, [(v,v)])
 imports = do
   let sem = P.try (semi <* P.lookAhead (reserved "use"))
   imported <- mconcat . reverse <$> sepBy sem importp
-  ns' <- Names.importing imported <$> asks names
+  ns' <- NamesWithHistory.importing imported <$> asks names
   pure (ns', [(Name.toVar suffix, Name.toVar full) | (suffix,full) <- imported ])
 
 -- A key feature of imports is we want to be able to say:
@@ -1009,7 +1010,7 @@ substImports ns imports =
     | (suffix,full) <- imports ] . -- no guard here, as `full` could be bound
                                    -- not in Names, but in a later term binding
   Term.substTypeVars [ (suffix, Type.var () full)
-    | (suffix, full) <- imports, Names.hasTypeNamed (Name.fromVar full) ns ]
+    | (suffix, full) <- imports, NamesWithHistory.hasTypeNamed (Name.fromVar full) ns ]
 
 block' :: Var v => IsTop -> String -> P v (L.Token ()) -> P v b -> TermP v
 block' isTop = block'' isTop False

--- a/parser-typechecker/src/Unison/TermParser.hs
+++ b/parser-typechecker/src/Unison/TermParser.hs
@@ -14,7 +14,7 @@ import           Control.Monad.Reader (asks, local)
 import           Data.Foldable (foldrM)
 import           Prelude hiding (and, or, seq)
 import           Unison.Name (Name)
-import           Unison.Names3 (NamesWithHistory)
+import           Unison.NamesWithHistory (NamesWithHistory)
 import           Unison.Reference (Reference)
 import           Unison.Referent (Referent)
 import           Unison.Parser hiding (seq)
@@ -38,7 +38,7 @@ import qualified Unison.ConstructorType as CT
 import qualified Unison.HashQualified as HQ
 import qualified Unison.Lexer as L
 import qualified Unison.Name as Name
-import qualified Unison.Names3 as Names
+import qualified Unison.NamesWithHistory as Names
 import qualified Unison.Parser as Parser (seq, uniqueName)
 import Unison.Parser.Ann (Ann)
 import qualified Unison.Pattern as Pattern

--- a/parser-typechecker/src/Unison/TypeParser.hs
+++ b/parser-typechecker/src/Unison/TypeParser.hs
@@ -14,7 +14,7 @@ import           Unison.Var (Var)
 import qualified Unison.Builtin.Decls as DD
 import qualified Unison.HashQualified as HQ
 import qualified Unison.Name as Name
-import qualified Unison.Names3 as Names
+import qualified Unison.NamesWithHistory as Names
 import qualified Data.Set as Set
 import Control.Monad.Reader (asks)
 

--- a/parser-typechecker/src/Unison/UnisonFile/Env.hs
+++ b/parser-typechecker/src/Unison/UnisonFile/Env.hs
@@ -12,7 +12,7 @@ import           Unison.DataDeclaration (DataDeclaration)
 import           Unison.DataDeclaration (EffectDeclaration(..))
 import           Unison.Reference       (Reference)
 import qualified Unison.Reference       as Reference
-import Unison.Names3 (Names0)
+import Unison.NamesWithHistory (Names0)
 
 data Env v a = Env
   -- Data declaration name to hash and its fully resolved form

--- a/parser-typechecker/src/Unison/UnisonFile/Env.hs
+++ b/parser-typechecker/src/Unison/UnisonFile/Env.hs
@@ -12,7 +12,7 @@ import           Unison.DataDeclaration (DataDeclaration)
 import           Unison.DataDeclaration (EffectDeclaration(..))
 import           Unison.Reference       (Reference)
 import qualified Unison.Reference       as Reference
-import Unison.Names (UnqualifiedNames)
+import Unison.Names (Names)
 
 data Env v a = Env
   -- Data declaration name to hash and its fully resolved form
@@ -20,7 +20,7 @@ data Env v a = Env
   -- Effect declaration name to hash and its fully resolved form
   , effectsId :: Map v (Reference.Id, EffectDeclaration v a)
   -- Naming environment
-  , names   :: UnqualifiedNames
+  , names   :: Names
 }
 
 datas :: Env v a -> Map v (Reference, DataDeclaration v a)

--- a/parser-typechecker/src/Unison/UnisonFile/Env.hs
+++ b/parser-typechecker/src/Unison/UnisonFile/Env.hs
@@ -12,7 +12,7 @@ import           Unison.DataDeclaration (DataDeclaration)
 import           Unison.DataDeclaration (EffectDeclaration(..))
 import           Unison.Reference       (Reference)
 import qualified Unison.Reference       as Reference
-import Unison.NamesWithHistory (Names0)
+import Unison.Names (UnqualifiedNames)
 
 data Env v a = Env
   -- Data declaration name to hash and its fully resolved form
@@ -20,7 +20,7 @@ data Env v a = Env
   -- Effect declaration name to hash and its fully resolved form
   , effectsId :: Map v (Reference.Id, EffectDeclaration v a)
   -- Naming environment
-  , names   :: Names0
+  , names   :: UnqualifiedNames
 }
 
 datas :: Env v a -> Map v (Reference, DataDeclaration v a)

--- a/parser-typechecker/src/Unison/UnisonFile/Names.hs
+++ b/parser-typechecker/src/Unison/UnisonFile/Names.hs
@@ -15,7 +15,7 @@ import qualified Unison.DataDeclaration.Names as DD.Names
 import qualified Unison.Hashing.V2.Convert as Hashing
 import qualified Unison.Name as Name
 import qualified Unison.Names.ResolutionResult as Names
-import Unison.NamesWithHistory (Names0)
+import Unison.Names (UnqualifiedNames)
 import qualified Unison.NamesWithHistory as Names
 import Unison.Prelude
 import qualified Unison.Reference as Reference
@@ -29,14 +29,14 @@ import qualified Unison.Util.Relation as Relation
 import Unison.Var (Var)
 import qualified Unison.WatchKind as WK
 
-toNames :: Var v => UnisonFile v a -> Names0
+toNames :: Var v => UnisonFile v a -> UnqualifiedNames
 toNames uf = datas <> effects
   where
     datas = foldMap DD.Names.dataDeclToNames' (Map.toList (UF.dataDeclarationsId uf))
     effects = foldMap DD.Names.effectDeclToNames' (Map.toList (UF.effectDeclarationsId uf))
 
-typecheckedToNames0 :: Var v => TypecheckedUnisonFile v a -> Names0
-typecheckedToNames0 uf = Names.names0 (terms <> ctors) types where
+typecheckedToUnqualifiedNames :: Var v => TypecheckedUnisonFile v a -> UnqualifiedNames
+typecheckedToUnqualifiedNames uf = Names.names0 (terms <> ctors) types where
   terms = Relation.fromList
     [ (Name.fromVar v, Referent.Ref r)
     | (v, (r, wk, _, _)) <- Map.toList $ UF.hashTerms uf, wk == Nothing || wk == Just WK.TestWatch ]
@@ -63,7 +63,7 @@ typecheckedUnisonFile0 = TypecheckedUnisonFileId Map.empty Map.empty mempty memp
 -- we are done parsing, whereas `math.sqrt#abc` can be resolved immediately
 -- as it can't refer to a local definition.
 bindNames :: Var v
-          => Names0
+          => UnqualifiedNames
           -> UnisonFile v a
           -> Names.ResolutionResult v a (UnisonFile v a)
 bindNames names (UnisonFileId d e ts ws) = do
@@ -85,7 +85,7 @@ bindNames names (UnisonFileId d e ts ws) = do
 -- left.
 environmentFor
   :: forall v a . Var v
-  => Names0
+  => UnqualifiedNames
   -> Map v (DataDeclaration v a)
   -> Map v (EffectDeclaration v a)
   -> Names.ResolutionResult v a (Either [Error v a] (Env v a))

--- a/parser-typechecker/src/Unison/UnisonFile/Names.hs
+++ b/parser-typechecker/src/Unison/UnisonFile/Names.hs
@@ -15,8 +15,8 @@ import qualified Unison.DataDeclaration.Names as DD.Names
 import qualified Unison.Hashing.V2.Convert as Hashing
 import qualified Unison.Name as Name
 import qualified Unison.Names.ResolutionResult as Names
-import Unison.Names3 (Names0)
-import qualified Unison.Names3 as Names
+import Unison.NamesWithHistory (Names0)
+import qualified Unison.NamesWithHistory as Names
 import Unison.Prelude
 import qualified Unison.Reference as Reference
 import qualified Unison.Referent as Referent

--- a/parser-typechecker/src/Unison/UnisonFile/Names.hs
+++ b/parser-typechecker/src/Unison/UnisonFile/Names.hs
@@ -15,7 +15,7 @@ import qualified Unison.DataDeclaration.Names as DD.Names
 import qualified Unison.Hashing.V2.Convert as Hashing
 import qualified Unison.Name as Name
 import qualified Unison.Names.ResolutionResult as Names
-import Unison.Names (UnqualifiedNames)
+import Unison.Names (Names)
 import qualified Unison.NamesWithHistory as Names
 import Unison.Prelude
 import qualified Unison.Reference as Reference
@@ -29,14 +29,14 @@ import qualified Unison.Util.Relation as Relation
 import Unison.Var (Var)
 import qualified Unison.WatchKind as WK
 
-toNames :: Var v => UnisonFile v a -> UnqualifiedNames
+toNames :: Var v => UnisonFile v a -> Names
 toNames uf = datas <> effects
   where
     datas = foldMap DD.Names.dataDeclToNames' (Map.toList (UF.dataDeclarationsId uf))
     effects = foldMap DD.Names.effectDeclToNames' (Map.toList (UF.effectDeclarationsId uf))
 
-typecheckedToUnqualifiedNames :: Var v => TypecheckedUnisonFile v a -> UnqualifiedNames
-typecheckedToUnqualifiedNames uf = Names.names0 (terms <> ctors) types where
+typecheckedToNames :: Var v => TypecheckedUnisonFile v a -> Names
+typecheckedToNames uf = Names.names0 (terms <> ctors) types where
   terms = Relation.fromList
     [ (Name.fromVar v, Referent.Ref r)
     | (v, (r, wk, _, _)) <- Map.toList $ UF.hashTerms uf, wk == Nothing || wk == Just WK.TestWatch ]
@@ -63,7 +63,7 @@ typecheckedUnisonFile0 = TypecheckedUnisonFileId Map.empty Map.empty mempty memp
 -- we are done parsing, whereas `math.sqrt#abc` can be resolved immediately
 -- as it can't refer to a local definition.
 bindNames :: Var v
-          => UnqualifiedNames
+          => Names
           -> UnisonFile v a
           -> Names.ResolutionResult v a (UnisonFile v a)
 bindNames names (UnisonFileId d e ts ws) = do
@@ -85,7 +85,7 @@ bindNames names (UnisonFileId d e ts ws) = do
 -- left.
 environmentFor
   :: forall v a . Var v
-  => UnqualifiedNames
+  => Names
   -> Map v (DataDeclaration v a)
   -> Map v (EffectDeclaration v a)
   -> Names.ResolutionResult v a (Either [Error v a] (Env v a))

--- a/parser-typechecker/src/Unison/UnisonFile/Names.hs
+++ b/parser-typechecker/src/Unison/UnisonFile/Names.hs
@@ -15,8 +15,7 @@ import qualified Unison.DataDeclaration.Names as DD.Names
 import qualified Unison.Hashing.V2.Convert as Hashing
 import qualified Unison.Name as Name
 import qualified Unison.Names.ResolutionResult as Names
-import Unison.Names (Names)
-import qualified Unison.NamesWithHistory as Names
+import Unison.Names (Names (Names))
 import Unison.Prelude
 import qualified Unison.Reference as Reference
 import qualified Unison.Referent as Referent
@@ -36,7 +35,7 @@ toNames uf = datas <> effects
     effects = foldMap DD.Names.effectDeclToNames' (Map.toList (UF.effectDeclarationsId uf))
 
 typecheckedToNames :: Var v => TypecheckedUnisonFile v a -> Names
-typecheckedToNames uf = Names.names0 (terms <> ctors) types where
+typecheckedToNames uf = Names (terms <> ctors) types where
   terms = Relation.fromList
     [ (Name.fromVar v, Referent.Ref r)
     | (v, (r, wk, _, _)) <- Map.toList $ UF.hashTerms uf, wk == Nothing || wk == Just WK.TestWatch ]

--- a/parser-typechecker/src/Unison/Util/Find.hs
+++ b/parser-typechecker/src/Unison/Util/Find.hs
@@ -21,7 +21,7 @@ import qualified Unison.HashQualified'        as HQ'
 import qualified Unison.Name                  as Name
 import           Unison.Name                  ( Name )
 import qualified Unison.Names                as Names
-import           Unison.Names                ( UnqualifiedNames )
+import           Unison.Names                ( Names )
 import           Unison.NamePrinter           (prettyHashQualified)
 import qualified Unison.Reference             as Reference
 import qualified Unison.Referent              as Referent
@@ -114,7 +114,7 @@ fuzzyFindMatchArray query items render =
   -- Ord MatchArray already provides a. and b.  todo: c.
 
 prefixFindInBranch ::
-  UnqualifiedNames -> HQ'.HashQualified Name -> [(SearchResult, P.Pretty P.ColorText)]
+  Names -> HQ'.HashQualified Name -> [(SearchResult, P.Pretty P.ColorText)]
 prefixFindInBranch b hq = fmap getName $
   -- query string includes a name component, so do a prefix find on that
   filter (filterName (HQ'.toName hq)) (candidates b hq)
@@ -127,7 +127,7 @@ prefixFindInBranch b hq = fmap getName $
 
 -- only search before the # before the # and after the # after the #
 fuzzyFindInBranch :: HasCallStack
-                  => UnqualifiedNames
+                  => Names
                   -> HQ'.HashQualified Name
                   -> [(SearchResult, P.Pretty P.ColorText)]
 fuzzyFindInBranch b hq =

--- a/parser-typechecker/src/Unison/Util/Find.hs
+++ b/parser-typechecker/src/Unison/Util/Find.hs
@@ -20,8 +20,8 @@ import qualified Unison.HashQualified         as HQ
 import qualified Unison.HashQualified'        as HQ'
 import qualified Unison.Name                  as Name
 import           Unison.Name                  ( Name )
-import qualified Unison.Names2                as Names
-import           Unison.Names2                ( Names0 )
+import qualified Unison.Names                as Names
+import           Unison.Names                ( Names0 )
 import           Unison.NamePrinter           (prettyHashQualified)
 import qualified Unison.Reference             as Reference
 import qualified Unison.Referent              as Referent

--- a/parser-typechecker/src/Unison/Util/Find.hs
+++ b/parser-typechecker/src/Unison/Util/Find.hs
@@ -21,7 +21,7 @@ import qualified Unison.HashQualified'        as HQ'
 import qualified Unison.Name                  as Name
 import           Unison.Name                  ( Name )
 import qualified Unison.Names                as Names
-import           Unison.Names                ( Names0 )
+import           Unison.Names                ( UnqualifiedNames )
 import           Unison.NamePrinter           (prettyHashQualified)
 import qualified Unison.Reference             as Reference
 import qualified Unison.Referent              as Referent
@@ -114,7 +114,7 @@ fuzzyFindMatchArray query items render =
   -- Ord MatchArray already provides a. and b.  todo: c.
 
 prefixFindInBranch ::
-  Names0 -> HQ'.HashQualified Name -> [(SearchResult, P.Pretty P.ColorText)]
+  UnqualifiedNames -> HQ'.HashQualified Name -> [(SearchResult, P.Pretty P.ColorText)]
 prefixFindInBranch b hq = fmap getName $
   -- query string includes a name component, so do a prefix find on that
   filter (filterName (HQ'.toName hq)) (candidates b hq)
@@ -127,7 +127,7 @@ prefixFindInBranch b hq = fmap getName $
 
 -- only search before the # before the # and after the # after the #
 fuzzyFindInBranch :: HasCallStack
-                  => Names0
+                  => UnqualifiedNames
                   -> HQ'.HashQualified Name
                   -> [(SearchResult, P.Pretty P.ColorText)]
 fuzzyFindInBranch b hq =

--- a/parser-typechecker/src/Unison/Util/Find.hs
+++ b/parser-typechecker/src/Unison/Util/Find.hs
@@ -144,7 +144,7 @@ getName :: SearchResult -> (SearchResult, P.Pretty P.ColorText)
 getName sr = (sr, P.syntaxToColor $ prettyHashQualified (SR.name sr))
 
 -- Invariant: all `SearchResult` in the output will have names, even though the type allows them to have only hashes
-candidates :: Names.Names' Name.Name -> HQ'.HashQualified Name -> [SearchResult]
+candidates :: Names.Names -> HQ'.HashQualified Name -> [SearchResult]
 candidates b hq = typeCandidates <> termCandidates
   where
   -- filter branch by hash

--- a/parser-typechecker/tests/Unison/Test/Common.hs
+++ b/parser-typechecker/tests/Unison/Test/Common.hs
@@ -27,7 +27,7 @@ import qualified Unison.Type                   as Type
 import qualified Unison.TypeParser             as TypeParser
 import qualified Unison.Util.Pretty            as Pr
 import qualified Text.Megaparsec.Error         as MPE
-import qualified Unison.Names3
+import qualified Unison.NamesWithHistory
 
 
 type Term v = Term.Term v Ann
@@ -63,7 +63,7 @@ parseAndSynthesizeAsFile
   -> String
   -> Result
        (Seq (Note v Ann))
-       (Either Unison.Names3.Names0 (TypecheckedUnisonFile v Ann))
+       (Either Unison.NamesWithHistory.Names0 (TypecheckedUnisonFile v Ann))
 parseAndSynthesizeAsFile ambient filename s = FP.parseAndSynthesizeFile
   ambient
   (\_deps -> pure B.typeLookup)

--- a/parser-typechecker/tests/Unison/Test/Common.hs
+++ b/parser-typechecker/tests/Unison/Test/Common.hs
@@ -12,12 +12,13 @@ import           Data.Sequence (Seq)
 import qualified Data.Text as Text
 import qualified Unison.Builtin as B
 import qualified Unison.FileParsers as FP
-import Unison.Parser.Ann (Ann(..))
+import           Unison.Parser.Ann (Ann(..))
 import           Unison.PrintError              ( prettyParseError )
 import           Unison.Result (Result, Note)
 import           Unison.Symbol (Symbol)
 import           Unison.Var (Var)
 import           Unison.UnisonFile (TypecheckedUnisonFile)
+import           Unison.Names (UnqualifiedNames)
 import qualified Unison.ABT                    as ABT
 import qualified Unison.Lexer                  as L
 import qualified Unison.Parser                 as Parser
@@ -27,7 +28,6 @@ import qualified Unison.Type                   as Type
 import qualified Unison.TypeParser             as TypeParser
 import qualified Unison.Util.Pretty            as Pr
 import qualified Text.Megaparsec.Error         as MPE
-import qualified Unison.NamesWithHistory
 
 
 type Term v = Term.Term v Ann
@@ -63,7 +63,7 @@ parseAndSynthesizeAsFile
   -> String
   -> Result
        (Seq (Note v Ann))
-       (Either Unison.NamesWithHistory.Names0 (TypecheckedUnisonFile v Ann))
+       (Either UnqualifiedNames (TypecheckedUnisonFile v Ann))
 parseAndSynthesizeAsFile ambient filename s = FP.parseAndSynthesizeFile
   ambient
   (\_deps -> pure B.typeLookup)

--- a/parser-typechecker/tests/Unison/Test/Common.hs
+++ b/parser-typechecker/tests/Unison/Test/Common.hs
@@ -18,7 +18,7 @@ import           Unison.Result (Result, Note)
 import           Unison.Symbol (Symbol)
 import           Unison.Var (Var)
 import           Unison.UnisonFile (TypecheckedUnisonFile)
-import           Unison.Names (UnqualifiedNames)
+import           Unison.Names (Names)
 import qualified Unison.ABT                    as ABT
 import qualified Unison.Lexer                  as L
 import qualified Unison.Parser                 as Parser
@@ -63,7 +63,7 @@ parseAndSynthesizeAsFile
   -> String
   -> Result
        (Seq (Note v Ann))
-       (Either UnqualifiedNames (TypecheckedUnisonFile v Ann))
+       (Either Names (TypecheckedUnisonFile v Ann))
 parseAndSynthesizeAsFile ambient filename s = FP.parseAndSynthesizeFile
   ambient
   (\_deps -> pure B.typeLookup)

--- a/parser-typechecker/tests/Unison/Test/UnisonSources.hs
+++ b/parser-typechecker/tests/Unison/Test/UnisonSources.hs
@@ -32,14 +32,14 @@ import qualified Unison.UnisonFile      as UF
 import           Unison.Util.Monoid     (intercalateMap)
 import           Unison.Util.Pretty     (toPlain)
 import qualified Unison.Test.Common as Common
-import qualified Unison.Names3
+import qualified Unison.NamesWithHistory
 
 type Note = Result.Note Symbol Ann
 
 type TFile = UF.TypecheckedUnisonFile Symbol Ann
 type SynthResult =
   Result (Seq Note)
-         (Either Unison.Names3.Names0 TFile)
+         (Either Unison.NamesWithHistory.Names0 TFile)
 
 type EitherResult = Either String TFile
 
@@ -101,7 +101,7 @@ decodeResult source (Result notes (Just (Left errNames))) =
   Left $ showNotes
           source
           (PPE.fromNames Common.hqLength
-            (Unison.Names3.shadowing errNames Builtin.names))
+            (Unison.NamesWithHistory.shadowing errNames Builtin.names))
           notes
 decodeResult _source (Result _notes (Just (Right uf))) =
   Right uf

--- a/parser-typechecker/tests/Unison/Test/UnisonSources.hs
+++ b/parser-typechecker/tests/Unison/Test/UnisonSources.hs
@@ -32,14 +32,15 @@ import qualified Unison.UnisonFile      as UF
 import           Unison.Util.Monoid     (intercalateMap)
 import           Unison.Util.Pretty     (toPlain)
 import qualified Unison.Test.Common as Common
-import qualified Unison.NamesWithHistory
+import qualified Unison.NamesWithHistory as NamesWithHistory
+import           Unison.Names (UnqualifiedNames)
 
 type Note = Result.Note Symbol Ann
 
 type TFile = UF.TypecheckedUnisonFile Symbol Ann
 type SynthResult =
   Result (Seq Note)
-         (Either Unison.NamesWithHistory.Names0 TFile)
+         (Either UnqualifiedNames TFile)
 
 type EitherResult = Either String TFile
 
@@ -101,7 +102,7 @@ decodeResult source (Result notes (Just (Left errNames))) =
   Left $ showNotes
           source
           (PPE.fromNames Common.hqLength
-            (Unison.NamesWithHistory.shadowing errNames Builtin.names))
+            (NamesWithHistory.shadowing errNames Builtin.names))
           notes
 decodeResult _source (Result _notes (Just (Right uf))) =
   Right uf

--- a/parser-typechecker/tests/Unison/Test/UnisonSources.hs
+++ b/parser-typechecker/tests/Unison/Test/UnisonSources.hs
@@ -33,14 +33,14 @@ import           Unison.Util.Monoid     (intercalateMap)
 import           Unison.Util.Pretty     (toPlain)
 import qualified Unison.Test.Common as Common
 import qualified Unison.NamesWithHistory as NamesWithHistory
-import           Unison.Names (UnqualifiedNames)
+import           Unison.Names (Names)
 
 type Note = Result.Note Symbol Ann
 
 type TFile = UF.TypecheckedUnisonFile Symbol Ann
 type SynthResult =
   Result (Seq Note)
-         (Either UnqualifiedNames TFile)
+         (Either Names TFile)
 
 type EitherResult = Either String TFile
 

--- a/unison-core/src/Unison/DataDeclaration/Names.hs
+++ b/unison-core/src/Unison/DataDeclaration/Names.hs
@@ -27,8 +27,8 @@ import qualified Unison.Names.ResolutionResult as Names
 import qualified Unison.ConstructorType        as CT
 
 -- implementation of dataDeclToNames and effectDeclToNames
-toNames0 :: Var v => CT.ConstructorType -> v -> Reference.Id -> DataDeclaration v a -> UnqualifiedNames
-toNames0 ct typeSymbol (Reference.DerivedId -> r) dd =
+toUnqualifiedNames :: Var v => CT.ConstructorType -> v -> Reference.Id -> DataDeclaration v a -> UnqualifiedNames
+toUnqualifiedNames ct typeSymbol (Reference.DerivedId -> r) dd =
   -- constructor names
   foldMap names (DD.constructorVars dd `zip` [0 ..])
   -- name of the type itself
@@ -38,10 +38,10 @@ toNames0 ct typeSymbol (Reference.DerivedId -> r) dd =
     Names.names0 (Rel.singleton (Name.fromVar ctor) (Referent.Con r i ct)) mempty
 
 dataDeclToNames :: Var v => v -> Reference.Id -> DataDeclaration v a -> UnqualifiedNames
-dataDeclToNames = toNames0 CT.Data
+dataDeclToNames = toUnqualifiedNames CT.Data
 
 effectDeclToNames :: Var v => v -> Reference.Id -> EffectDeclaration v a -> UnqualifiedNames
-effectDeclToNames typeSymbol r ed = toNames0 CT.Effect typeSymbol r $ DD.toDataDecl ed
+effectDeclToNames typeSymbol r ed = toUnqualifiedNames CT.Effect typeSymbol r $ DD.toDataDecl ed
 
 dataDeclToNames' :: Var v => (v, (Reference.Id, DataDeclaration v a)) -> UnqualifiedNames
 dataDeclToNames' (v, (r,d)) = dataDeclToNames v r d

--- a/unison-core/src/Unison/DataDeclaration/Names.hs
+++ b/unison-core/src/Unison/DataDeclaration/Names.hs
@@ -21,8 +21,7 @@ import qualified Unison.Reference              as Reference
 import qualified Unison.Referent               as Referent
 import qualified Unison.Type.Names             as Type.Names
 import           Unison.Var                    ( Var )
-import           Unison.Names                  (Names)
-import qualified Unison.NamesWithHistory       as Names
+import           Unison.Names                  (Names (Names))
 import qualified Unison.Names.ResolutionResult as Names
 import qualified Unison.ConstructorType        as CT
 
@@ -32,10 +31,10 @@ toNames ct typeSymbol (Reference.DerivedId -> r) dd =
   -- constructor names
   foldMap names (DD.constructorVars dd `zip` [0 ..])
   -- name of the type itself
-  <> Names.names0 mempty (Rel.singleton (Name.fromVar typeSymbol) r)
+  <> Names mempty (Rel.singleton (Name.fromVar typeSymbol) r)
   where
   names (ctor, i) =
-    Names.names0 (Rel.singleton (Name.fromVar ctor) (Referent.Con r i ct)) mempty
+    Names (Rel.singleton (Name.fromVar ctor) (Referent.Con r i ct)) mempty
 
 dataDeclToNames :: Var v => v -> Reference.Id -> DataDeclaration v a -> Names
 dataDeclToNames = toNames CT.Data

--- a/unison-core/src/Unison/DataDeclaration/Names.hs
+++ b/unison-core/src/Unison/DataDeclaration/Names.hs
@@ -21,8 +21,8 @@ import qualified Unison.Reference              as Reference
 import qualified Unison.Referent               as Referent
 import qualified Unison.Type.Names as Type.Names
 import           Unison.Var                     ( Var )
-import           Unison.Names3                 (Names0)
-import qualified Unison.Names3                 as Names
+import           Unison.NamesWithHistory                 (Names0)
+import qualified Unison.NamesWithHistory                 as Names
 import qualified Unison.Names.ResolutionResult as Names
 import qualified Unison.ConstructorType as CT
 

--- a/unison-core/src/Unison/DataDeclaration/Names.hs
+++ b/unison-core/src/Unison/DataDeclaration/Names.hs
@@ -21,14 +21,14 @@ import qualified Unison.Reference              as Reference
 import qualified Unison.Referent               as Referent
 import qualified Unison.Type.Names             as Type.Names
 import           Unison.Var                    ( Var )
-import           Unison.Names                  (UnqualifiedNames)
+import           Unison.Names                  (Names)
 import qualified Unison.NamesWithHistory       as Names
 import qualified Unison.Names.ResolutionResult as Names
 import qualified Unison.ConstructorType        as CT
 
 -- implementation of dataDeclToNames and effectDeclToNames
-toUnqualifiedNames :: Var v => CT.ConstructorType -> v -> Reference.Id -> DataDeclaration v a -> UnqualifiedNames
-toUnqualifiedNames ct typeSymbol (Reference.DerivedId -> r) dd =
+toNames :: Var v => CT.ConstructorType -> v -> Reference.Id -> DataDeclaration v a -> Names
+toNames ct typeSymbol (Reference.DerivedId -> r) dd =
   -- constructor names
   foldMap names (DD.constructorVars dd `zip` [0 ..])
   -- name of the type itself
@@ -37,21 +37,21 @@ toUnqualifiedNames ct typeSymbol (Reference.DerivedId -> r) dd =
   names (ctor, i) =
     Names.names0 (Rel.singleton (Name.fromVar ctor) (Referent.Con r i ct)) mempty
 
-dataDeclToNames :: Var v => v -> Reference.Id -> DataDeclaration v a -> UnqualifiedNames
-dataDeclToNames = toUnqualifiedNames CT.Data
+dataDeclToNames :: Var v => v -> Reference.Id -> DataDeclaration v a -> Names
+dataDeclToNames = toNames CT.Data
 
-effectDeclToNames :: Var v => v -> Reference.Id -> EffectDeclaration v a -> UnqualifiedNames
-effectDeclToNames typeSymbol r ed = toUnqualifiedNames CT.Effect typeSymbol r $ DD.toDataDecl ed
+effectDeclToNames :: Var v => v -> Reference.Id -> EffectDeclaration v a -> Names
+effectDeclToNames typeSymbol r ed = toNames CT.Effect typeSymbol r $ DD.toDataDecl ed
 
-dataDeclToNames' :: Var v => (v, (Reference.Id, DataDeclaration v a)) -> UnqualifiedNames
+dataDeclToNames' :: Var v => (v, (Reference.Id, DataDeclaration v a)) -> Names
 dataDeclToNames' (v, (r,d)) = dataDeclToNames v r d
 
-effectDeclToNames' :: Var v => (v, (Reference.Id, EffectDeclaration v a)) -> UnqualifiedNames
+effectDeclToNames' :: Var v => (v, (Reference.Id, EffectDeclaration v a)) -> Names
 effectDeclToNames' (v, (r, d)) = effectDeclToNames v r d
 
 bindNames :: Var v
           => Set v
-          -> UnqualifiedNames
+          -> Names
           -> DataDeclaration v a
           -> Names.ResolutionResult v a (DataDeclaration v a)
 bindNames keepFree names (DataDeclaration m a bound constructors) = do

--- a/unison-core/src/Unison/DataDeclaration/Names.hs
+++ b/unison-core/src/Unison/DataDeclaration/Names.hs
@@ -14,20 +14,20 @@ import Unison.DataDeclaration (DataDeclaration (DataDeclaration), EffectDeclarat
 import qualified Unison.DataDeclaration as DD
 
 
-import qualified Unison.Util.Relation as Rel
-import           Prelude                 hiding ( cycle )
+import qualified Unison.Util.Relation          as Rel
+import           Prelude                       hiding ( cycle )
 import qualified Unison.Name                   as Name
 import qualified Unison.Reference              as Reference
 import qualified Unison.Referent               as Referent
-import qualified Unison.Type.Names as Type.Names
-import           Unison.Var                     ( Var )
-import           Unison.NamesWithHistory                 (Names0)
-import qualified Unison.NamesWithHistory                 as Names
+import qualified Unison.Type.Names             as Type.Names
+import           Unison.Var                    ( Var )
+import           Unison.Names                  (UnqualifiedNames)
+import qualified Unison.NamesWithHistory       as Names
 import qualified Unison.Names.ResolutionResult as Names
-import qualified Unison.ConstructorType as CT
+import qualified Unison.ConstructorType        as CT
 
 -- implementation of dataDeclToNames and effectDeclToNames
-toNames0 :: Var v => CT.ConstructorType -> v -> Reference.Id -> DataDeclaration v a -> Names0
+toNames0 :: Var v => CT.ConstructorType -> v -> Reference.Id -> DataDeclaration v a -> UnqualifiedNames
 toNames0 ct typeSymbol (Reference.DerivedId -> r) dd =
   -- constructor names
   foldMap names (DD.constructorVars dd `zip` [0 ..])
@@ -37,21 +37,21 @@ toNames0 ct typeSymbol (Reference.DerivedId -> r) dd =
   names (ctor, i) =
     Names.names0 (Rel.singleton (Name.fromVar ctor) (Referent.Con r i ct)) mempty
 
-dataDeclToNames :: Var v => v -> Reference.Id -> DataDeclaration v a -> Names0
+dataDeclToNames :: Var v => v -> Reference.Id -> DataDeclaration v a -> UnqualifiedNames
 dataDeclToNames = toNames0 CT.Data
 
-effectDeclToNames :: Var v => v -> Reference.Id -> EffectDeclaration v a -> Names0
+effectDeclToNames :: Var v => v -> Reference.Id -> EffectDeclaration v a -> UnqualifiedNames
 effectDeclToNames typeSymbol r ed = toNames0 CT.Effect typeSymbol r $ DD.toDataDecl ed
 
-dataDeclToNames' :: Var v => (v, (Reference.Id, DataDeclaration v a)) -> Names0
+dataDeclToNames' :: Var v => (v, (Reference.Id, DataDeclaration v a)) -> UnqualifiedNames
 dataDeclToNames' (v, (r,d)) = dataDeclToNames v r d
 
-effectDeclToNames' :: Var v => (v, (Reference.Id, EffectDeclaration v a)) -> Names0
+effectDeclToNames' :: Var v => (v, (Reference.Id, EffectDeclaration v a)) -> UnqualifiedNames
 effectDeclToNames' (v, (r, d)) = effectDeclToNames v r d
 
 bindNames :: Var v
           => Set v
-          -> Names0
+          -> UnqualifiedNames
           -> DataDeclaration v a
           -> Names.ResolutionResult v a (DataDeclaration v a)
 bindNames keepFree names (DataDeclaration m a bound constructors) = do

--- a/unison-core/src/Unison/Names.hs
+++ b/unison-core/src/Unison/Names.hs
@@ -62,7 +62,7 @@ import qualified Unison.ShortHash             as SH
 import           Unison.ShortHash             (ShortHash)
 import qualified Text.FuzzyFind               as FZF
 
--- This will support the APIs of both PrettyPrintEnv and the old HQNames.
+-- This will support the APIs of both PrettyPrintEnv and the old Names.
 -- For pretty-printing, we need to look up names for References; they may have
 -- some hash-qualification, depending on the context.
 -- For parsing (both .u files and command-line args)
@@ -147,15 +147,15 @@ restrictReferences refs Names{..} = Names terms' types' where
 --
 -- For pretty-printing:
 --       Probably don't want to add new aliases, unless we don't know which
---       `HQNames` is higher priority.  So if we do have a preferred `HQNames`,
+--       `Names` is higher priority.  So if we do have a preferred `Names`,
 --       don't use `unionLeftName` or (<>).
 --       You don't want to create new conflicts either if you have a preferred
---       `HQNames`.  So in this case, don't use `unionLeftRef` either.
+--       `Names`.  So in this case, don't use `unionLeftRef` either.
 --       I guess that leaves `unionLeft`.
 --
 -- Not sure if the above is helpful or correct!
 
--- unionLeft two HQNames, including new aliases, but excluding new name conflicts.
+-- unionLeft two Names, including new aliases, but excluding new name conflicts.
 -- e.g. unionLeftName [foo -> #a, bar -> #a, cat -> #c]
 --                    [foo -> #b, baz -> #c]
 --                  = [foo -> #a, bar -> #a, baz -> #c, cat -> #c)]
@@ -164,14 +164,14 @@ restrictReferences refs Names{..} = Names terms' types' where
 unionLeftName :: Names -> Names -> Names
 unionLeftName = unionLeft' $ const . R.memberDom
 
--- unionLeft two HQNames, including new name conflicts, but excluding new aliases.
+-- unionLeft two Names, including new name conflicts, but excluding new aliases.
 -- e.g. unionLeftRef [foo -> #a, bar -> #a, cat -> #c]
 --                   [foo -> #b, baz -> #c]
 --                 = [foo -> #a, bar -> #a, foo -> #b, cat -> #c]
 _unionLeftRef :: Names -> Names -> Names
 _unionLeftRef = unionLeft' $ const R.memberRan
 
--- unionLeft two HQNames, but don't create new aliases or new name conflicts.
+-- unionLeft two Names, but don't create new aliases or new name conflicts.
 -- e.g. unionLeft [foo -> #a, bar -> #a, cat -> #c]
 --                [foo -> #b, baz -> #c]
 --              = [foo -> #a, bar -> #a, cat -> #c]
@@ -192,7 +192,7 @@ unionLeft' p a b = Names terms' types'
   go :: (Ord a, Ord b) => Relation a b -> (a, b) -> Relation a b
   go acc (n, r) = if p n r acc then acc else R.insert n r acc
 
--- could move this to a read-only field in HQNames
+-- could move this to a read-only field in Names
 -- todo: kill this function and pass thru an Int from the codebase, I suppose
 numHashChars :: Names -> Int
 numHashChars b = lenFor hashes

--- a/unison-core/src/Unison/Names.hs
+++ b/unison-core/src/Unison/Names.hs
@@ -7,8 +7,6 @@
 module Unison.Names
   ( UnqualifiedNames
   , Names'(Names)
-  , HQNames
-  , pattern HQNames
   , pattern UnqualifiedNames
   , addTerm
   , addType
@@ -30,7 +28,6 @@ module Unison.Names
   , _hqTypeName
   , _hqTermAliases
   , _hqTypeAliases
-  , names0ToNames
   , prefix0
   , restrictReferences
   , refTermsNamed
@@ -78,13 +75,6 @@ data Names' n = Names
   , types :: Relation n Reference
   } deriving (Eq,Ord)
 
-type HQNames = Names' (HashQualified Name)
-
-pattern HQNames :: Relation (HashQualified Name) Referent
-                -> Relation (HashQualified Name) Reference
-                -> HQNames
-pattern HQNames terms types = Names terms types
-
 type UnqualifiedNames = Names' Name
 
 pattern UnqualifiedNames :: Relation Name Referent
@@ -131,20 +121,6 @@ fuzzyFind query names =
                          (Just mempty)
                          query
           )
-
-names0ToNames :: UnqualifiedNames -> HQNames
-names0ToNames names0 = HQNames terms' types' where
-  terms' = R.map doTerm (terms names0)
-  types' = R.map doType (types names0)
-  length = numHashChars names0
-  doTerm (n, r) =
-    if Set.size (R.lookupDom n (terms names0)) > 1
-    then (HQ.take length $ HQ.fromNamedReferent n r, r)
-    else (HQ.NameOnly n, r)
-  doType (n, r) =
-    if Set.size (R.lookupDom n (types names0)) > 1
-    then (HQ.take length $ HQ.fromNamedReference n r, r)
-    else (HQ.NameOnly n, r)
 
 termReferences, typeReferences, allReferences :: Names' n -> Set Reference
 termReferences Names{..} = Set.map Referent.toReference $ R.ran terms

--- a/unison-core/src/Unison/Names.hs
+++ b/unison-core/src/Unison/Names.hs
@@ -66,7 +66,7 @@ import qualified Unison.Util.Relation         as R
 import qualified Unison.ShortHash             as SH
 import           Unison.ShortHash             (ShortHash)
 import qualified Text.FuzzyFind               as FZF
-import Unison.Names2 (Names'(HQNames))
+import Unison.Names (Names'(HQNames))
 
 -- This will support the APIs of both PrettyPrintEnv and the old HQNames.
 -- For pretty-printing, we need to look up names for References; they may have

--- a/unison-core/src/Unison/Names/ResolutionResult.hs
+++ b/unison-core/src/Unison/Names/ResolutionResult.hs
@@ -7,7 +7,7 @@ module Unison.Names.ResolutionResult where
 import Unison.Prelude
 import Unison.Reference as Reference ( Reference )
 import Unison.Referent as Referent ( Referent )
-import Unison.Names3 (Names0)
+import Unison.NamesWithHistory (Names0)
 import Data.Set.NonEmpty
 
 data ResolutionError ref

--- a/unison-core/src/Unison/Names/ResolutionResult.hs
+++ b/unison-core/src/Unison/Names/ResolutionResult.hs
@@ -7,14 +7,14 @@ module Unison.Names.ResolutionResult where
 import Unison.Prelude
 import Unison.Reference as Reference ( Reference )
 import Unison.Referent as Referent ( Referent )
-import Unison.Names (UnqualifiedNames)
+import Unison.Names (Names)
 import Data.Set.NonEmpty
 
 data ResolutionError ref
   = NotFound
     -- Contains the names which were in scope and which refs were possible options
     -- The NonEmpty set of refs must contain 2 or more refs (otherwise what is ambiguous?).
-  | Ambiguous UnqualifiedNames (NESet ref)
+  | Ambiguous Names (NESet ref)
   deriving (Eq, Ord, Show)
 
 -- | ResolutionFailure represents the failure to resolve a given variable.

--- a/unison-core/src/Unison/Names/ResolutionResult.hs
+++ b/unison-core/src/Unison/Names/ResolutionResult.hs
@@ -7,14 +7,14 @@ module Unison.Names.ResolutionResult where
 import Unison.Prelude
 import Unison.Reference as Reference ( Reference )
 import Unison.Referent as Referent ( Referent )
-import Unison.NamesWithHistory (Names0)
+import Unison.Names (UnqualifiedNames)
 import Data.Set.NonEmpty
 
 data ResolutionError ref
   = NotFound
     -- Contains the names which were in scope and which refs were possible options
     -- The NonEmpty set of refs must contain 2 or more refs (otherwise what is ambiguous?).
-  | Ambiguous Names0 (NESet ref)
+  | Ambiguous UnqualifiedNames (NESet ref)
   deriving (Eq, Ord, Show)
 
 -- | ResolutionFailure represents the failure to resolve a given variable.

--- a/unison-core/src/Unison/NamesWithHistory.hs
+++ b/unison-core/src/Unison/NamesWithHistory.hs
@@ -21,7 +21,7 @@ import qualified Unison.Names as Names
 import qualified Unison.Util.List as List
 import qualified Unison.Util.Relation as R
 import qualified Unison.ConstructorType as CT
-import Unison.Names (Names, pattern Names)
+import Unison.Names (Names(..) )
 
 data NamesWithHistory = NamesWithHistory
   { -- | currentNames represent references which are named in the current version of the namespace.

--- a/unison-core/src/Unison/NamesWithHistory.hs
+++ b/unison-core/src/Unison/NamesWithHistory.hs
@@ -33,10 +33,10 @@ data NamesWithHistory = NamesWithHistory
   deriving (Show)
 
 pattern Names0 :: Relation n Referent -> Relation n Reference -> Names.Names' n
-pattern Names0 terms types = Names2.HQNames terms types
+pattern Names0 terms types = Names.HQNames terms types
 
 filterTypes :: (Name -> Bool) -> Names0 -> Names0
-filterTypes = Unison.Names2.filterTypes
+filterTypes = Unison.Names.filterTypes
 
 -- Simple 2 way diff, has the property that:
 --  addedNames (diff0 n1 n2) == removedNames (diff0 n2 n1)
@@ -97,10 +97,10 @@ push n0 ns = NamesWithHistory (unionLeft0 n1 cur) (oldNames ns <> shadowed) wher
     uniqueTypes = [ (n,ref) | (n, nubOrd -> [ref]) <- Map.toList types ]
 
 unionLeft0 :: Names0 -> Names0 -> Names0
-unionLeft0 = Unison.Names2.unionLeft
+unionLeft0 = Unison.Names.unionLeft
 
 unionLeftName0 :: Names0 -> Names0 -> Names0
-unionLeftName0 = Unison.Names2.unionLeftName
+unionLeftName0 = Unison.Names.unionLeftName
 
 map0 :: (Name -> Name) -> Names0 -> Names0
 map0 f (Names.Names terms types) = Names.Names terms' types' where
@@ -108,7 +108,7 @@ map0 f (Names.Names terms types) = Names.Names terms' types' where
   types' = R.mapDom f types
 
 names0 :: Relation Name Referent -> Relation Name Reference -> Names0
-names0 = Unison.Names2.Names
+names0 = Unison.Names.Names
 
 types0 :: Names0 -> Relation Name Reference
 types0 = Names.types

--- a/unison-core/src/Unison/NamesWithHistory.hs
+++ b/unison-core/src/Unison/NamesWithHistory.hs
@@ -21,6 +21,7 @@ import qualified Unison.Names as Names
 import qualified Unison.Util.List as List
 import qualified Unison.Util.Relation as R
 import qualified Unison.ConstructorType as CT
+import Unison.Names (UnqualifiedNames, pattern UnqualifiedNames)
 
 data NamesWithHistory = NamesWithHistory
   { -- | currentNames represent references which are named in the current version of the namespace.
@@ -32,47 +33,44 @@ data NamesWithHistory = NamesWithHistory
   }
   deriving (Show)
 
-pattern Names0 :: Relation n Referent -> Relation n Reference -> Names.Names' n
-pattern Names0 terms types = Names.HQNames terms types
-
-filterTypes :: (Name -> Bool) -> Names0 -> Names0
-filterTypes = Unison.Names.filterTypes
+filterTypes :: (Name -> Bool) -> UnqualifiedNames -> UnqualifiedNames
+filterTypes = Names.filterTypes
 
 -- Simple 2 way diff, has the property that:
 --  addedNames (diff0 n1 n2) == removedNames (diff0 n2 n1)
 --
 -- `addedNames` are names in `n2` but not `n1`
 -- `removedNames` are names in `n1` but not `n2`
-diff0 :: Names0 -> Names0 -> Diff
+diff0 :: UnqualifiedNames -> UnqualifiedNames -> Diff
 diff0 n1 n2 = Diff n1 added removed where
-  added = Names0 (terms0 n2 `R.difference` terms0 n1)
+  added = UnqualifiedNames (terms0 n2 `R.difference` terms0 n1)
                  (types0 n2 `R.difference` types0 n1)
-  removed = Names0 (terms0 n1 `R.difference` terms0 n2)
+  removed = UnqualifiedNames (terms0 n1 `R.difference` terms0 n2)
                    (types0 n1 `R.difference` types0 n2)
 
 data Diff =
-  Diff { originalNames :: Names0
-       , addedNames    :: Names0
-       , removedNames  :: Names0
+  Diff { originalNames :: UnqualifiedNames
+       , addedNames    :: UnqualifiedNames
+       , removedNames  :: UnqualifiedNames
        } deriving Show
 
 isEmptyDiff :: Diff -> Bool
 isEmptyDiff d = isEmpty0 (addedNames d) && isEmpty0 (removedNames d)
 
-isEmpty0 :: Names0 -> Bool
+isEmpty0 :: UnqualifiedNames -> Bool
 isEmpty0 n = R.null (terms0 n) && R.null (types0 n)
 
 -- Add `n1` to `currentNames`, shadowing anything with the same name and
 -- moving shadowed definitions into `oldNames` so they can can still be
 -- referenced hash qualified.
-push :: Names0 -> NamesWithHistory -> NamesWithHistory
+push :: UnqualifiedNames -> NamesWithHistory -> NamesWithHistory
 push n0 ns = NamesWithHistory (unionLeft0 n1 cur) (oldNames ns <> shadowed) where
   n1 = suffixify0 n0
   cur = currentNames ns
   shadowed = names0 terms' types' where
     terms' = R.dom (terms0 n1) R.<| (terms0 cur `R.difference` terms0 n1)
     types' = R.dom (types0 n1) R.<| (types0 cur `R.difference` types0 n1)
-  unionLeft0 :: Names0 -> Names0 -> Names0
+  unionLeft0 :: UnqualifiedNames -> UnqualifiedNames -> UnqualifiedNames
   unionLeft0 n1 n2 = names0 terms' types' where
     terms' = terms0 n1 <> R.subtractDom (R.dom $ terms0 n1) (terms0 n2)
     types' = types0 n1 <> R.subtractDom (R.dom $ types0 n1) (types0 n2)
@@ -80,14 +78,14 @@ push n0 ns = NamesWithHistory (unionLeft0 n1 cur) (oldNames ns <> shadowed) wher
   -- of that name [[foo.bar.baz], [bar.baz], [baz]]. Any suffix which uniquely
   -- refers to a single definition is added as an alias
   --
-  -- If `Names` were more like a `[Names0]`, then `push` could just cons
+  -- If `Names` were more like a `[UnqualifiedNames]`, then `push` could just cons
   -- onto the list and we could get rid of all this complex logic. The
   -- complexity here is that we have to "bake the shadowing" into a single
-  -- Names0, taking into account suffix-based name resolution.
+  -- UnqualifiedNames, taking into account suffix-based name resolution.
   --
   -- We currently have `oldNames`, but that controls an unrelated axis, which
   -- is whether names are hash qualified or not.
-  suffixify0 :: Names0 -> Names0
+  suffixify0 :: UnqualifiedNames -> UnqualifiedNames
   suffixify0 ns = ns <> suffixNs
     where
     suffixNs = names0 (R.fromList uniqueTerms) (R.fromList uniqueTypes)
@@ -96,34 +94,34 @@ push n0 ns = NamesWithHistory (unionLeft0 n1 cur) (oldNames ns <> shadowed) wher
     uniqueTerms = [ (n,ref) | (n, nubOrd -> [ref]) <- Map.toList terms ]
     uniqueTypes = [ (n,ref) | (n, nubOrd -> [ref]) <- Map.toList types ]
 
-unionLeft0 :: Names0 -> Names0 -> Names0
-unionLeft0 = Unison.Names.unionLeft
+unionLeft0 :: UnqualifiedNames -> UnqualifiedNames -> UnqualifiedNames
+unionLeft0 = Names.unionLeft
 
-unionLeftName0 :: Names0 -> Names0 -> Names0
-unionLeftName0 = Unison.Names.unionLeftName
+unionLeftName0 :: UnqualifiedNames -> UnqualifiedNames -> UnqualifiedNames
+unionLeftName0 = Names.unionLeftName
 
-map0 :: (Name -> Name) -> Names0 -> Names0
+map0 :: (Name -> Name) -> UnqualifiedNames -> UnqualifiedNames
 map0 f (Names.Names terms types) = Names.Names terms' types' where
   terms' = R.mapDom f terms
   types' = R.mapDom f types
 
-names0 :: Relation Name Referent -> Relation Name Reference -> Names0
-names0 = Unison.Names.Names
+names0 :: Relation Name Referent -> Relation Name Reference -> UnqualifiedNames
+names0 = Names.Names
 
-types0 :: Names0 -> Relation Name Reference
+types0 :: UnqualifiedNames -> Relation Name Reference
 types0 = Names.types
 
-terms0 :: Names0 -> Relation Name Referent
+terms0 :: UnqualifiedNames -> Relation Name Referent
 terms0 = Names.terms
 
 -- if I push an existing name, the pushed reference should be the thing
 -- if I push a different name for the same thing, i suppose they should coexist
 -- thus, `unionLeftName0`.
-shadowing :: Names0 -> NamesWithHistory -> NamesWithHistory
+shadowing :: UnqualifiedNames -> NamesWithHistory -> NamesWithHistory
 shadowing prio (NamesWithHistory current old) =
   NamesWithHistory (prio `unionLeftName0` current) (current <> old)
 
-makeAbsolute0 :: Names0 -> Names0
+makeAbsolute0 :: UnqualifiedNames -> UnqualifiedNames
 makeAbsolute0 = map0 Name.makeAbsolute
 
 -- Find all types whose name has a suffix matching the provided `HashQualified`,
@@ -193,8 +191,8 @@ lookupHQTerm' =
 lookupHQRef ::
   forall r.
   Ord r =>
-  -- | A projection of types or terms from a Names0.
-  (Names0 -> Relation Name r) ->
+  -- | A projection of types or terms from a UnqualifiedNames.
+  (UnqualifiedNames -> Relation Name r) ->
   -- | isPrefixOf, for references or referents
   (ShortHash -> r -> Bool) ->
   -- | The name to look up
@@ -297,8 +295,8 @@ lookupHQPattern hq ctt names = Set.fromList
     , ct == ctt
     ]
 
--- Finds all the constructors for the given type in the `Names0`
-constructorsForType0 :: Reference -> Names0 -> [(Name,Referent)]
+-- Finds all the constructors for the given type in the `UnqualifiedNames`
+constructorsForType0 :: Reference -> UnqualifiedNames -> [(Name,Referent)]
 constructorsForType0 r ns = let
   -- rather than searching all of names, we use the known possible forms
   -- that the constructors can take
@@ -321,7 +319,7 @@ importing :: [(Name, Name)] -> NamesWithHistory -> NamesWithHistory
 importing shortToLongName ns =
   ns { currentNames = importing0 shortToLongName (currentNames ns) }
 
-importing0 :: [(Name, Name)] -> Names0 -> Names0
+importing0 :: [(Name, Name)] -> UnqualifiedNames -> UnqualifiedNames
 importing0 shortToLongName ns =
   Names.Names
     (foldl' go (terms0 ns) shortToLongName)
@@ -336,7 +334,7 @@ importing0 shortToLongName ns =
 -- [(suffix, full)]. Example: if `io` contains two functions, `foo` and
 -- `bar`, then `expandWildcardImport io` will produce
 -- `[(foo, io.foo), (bar, io.bar)]`.
-expandWildcardImport :: Name -> Names0 -> [(Name,Name)]
+expandWildcardImport :: Name -> UnqualifiedNames -> [(Name,Name)]
 expandWildcardImport prefix ns =
   [ (suffix, full) | Just (suffix,full) <- go <$> R.toList (terms0 ns) ] <>
   [ (suffix, full) | Just (suffix,full) <- go <$> R.toList (types0 ns) ]
@@ -351,13 +349,13 @@ expandWildcardImport prefix ns =
     -- suffix = negate
     pure (suffix, full)
 
--- Deletes from the `n0 : Names0` any definitions whose names
+-- Deletes from the `n0 : UnqualifiedNames` any definitions whose names
 -- are in `ns`. Does so using logarithmic time lookups,
 -- traversing only `ns`.
 --
 -- See usage in `FileParser` for handling precendence of symbol
 -- resolution where local names are preferred to codebase names.
-shadowTerms0 :: [Name] -> Names0 -> Names0
+shadowTerms0 :: [Name] -> UnqualifiedNames -> UnqualifiedNames
 shadowTerms0 ns n0 = names0 terms' (types0 n0)
   where
   terms' = foldl' go (terms0 n0) ns

--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -122,7 +122,7 @@ bindNames keepFreeTerms ns0 e = do
       -- !_ = traceShow $ fst <$> freeTmVars
       freeTyVars = [ (v, a) | (v,as) <- Map.toList (freeTypeVarAnnotations e)
                             , a <- as ]
-      ns = Names.Names ns0 mempty
+      ns = Names.NamesWithHistory ns0 mempty
       -- !_ = trace "bindNames.free type vars: " ()
       -- !_ = traceShow $ fst <$> freeTyVars
       okTm :: (v,a) -> Names.ResolutionResult v a (v, Term v a)

--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -24,8 +24,8 @@ import           Prelude.Extras (Eq1(..), Show1(..))
 import           Text.Show
 import qualified Unison.ABT as ABT
 import qualified Unison.Blank as B
-import           Unison.Names3 ( Names0 )
-import qualified Unison.Names3 as Names
+import           Unison.NamesWithHistory ( Names0 )
+import qualified Unison.NamesWithHistory as Names
 import qualified Unison.Names.ResolutionResult as Names
 import           Unison.Pattern (Pattern)
 import qualified Unison.Pattern as Pattern

--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -24,7 +24,7 @@ import           Prelude.Extras (Eq1(..), Show1(..))
 import           Text.Show
 import qualified Unison.ABT as ABT
 import qualified Unison.Blank as B
-import           Unison.NamesWithHistory ( Names0 )
+import           Unison.Names ( UnqualifiedNames )
 import qualified Unison.NamesWithHistory as Names
 import qualified Unison.Names.ResolutionResult as Names
 import           Unison.Pattern (Pattern)
@@ -113,7 +113,7 @@ type Term0' vt v = Term' vt v ()
 bindNames
   :: forall v a . Var v
   => Set v
-  -> Names0
+  -> UnqualifiedNames
   -> Term v a
   -> Names.ResolutionResult v a (Term v a)
 bindNames keepFreeTerms ns0 e = do
@@ -142,12 +142,12 @@ bindNames keepFreeTerms ns0 e = do
   pure . substTypeVars typeSubsts . ABT.substsInheritAnnotation termSubsts $ e
 
 -- This function replaces free term and type variables with
--- hashes found in the provided `Names0`, using suffix-based
--- lookup. Any terms not found in the `Names0` are kept free.
+-- hashes found in the provided `UnqualifiedNames`, using suffix-based
+-- lookup. Any terms not found in the `UnqualifiedNames` are kept free.
 bindSomeNames
   :: forall v a . Var v
   => Set v
-  -> Names0
+  -> UnqualifiedNames
   -> Term v a
   -> Names.ResolutionResult v a (Term v a)
 -- bindSomeNames ns e | trace "Term.bindSome" False

--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -25,6 +25,7 @@ import           Text.Show
 import qualified Unison.ABT as ABT
 import qualified Unison.Blank as B
 import           Unison.Names ( Names )
+import qualified Unison.Names as Names
 import qualified Unison.NamesWithHistory as Names
 import qualified Unison.Names.ResolutionResult as Names
 import           Unison.Pattern (Pattern)
@@ -169,7 +170,7 @@ bindSomeNames avoid ns e = bindNames (avoid <> varsToTDNR) ns e where
   -- (if a free variable is being used as a typed hole).
   varsToTDNR = Set.filter notFound (freeVars e)
   notFound var =
-    Set.size (Name.searchBySuffix (Name.fromVar var) (Names.terms0 ns)) /= 1
+    Set.size (Name.searchBySuffix (Name.fromVar var) (Names.terms ns)) /= 1
 
 -- Prepare a term for type-directed name resolution by replacing
 -- any remaining free variables with blanks to be resolved by TDNR

--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -24,7 +24,7 @@ import           Prelude.Extras (Eq1(..), Show1(..))
 import           Text.Show
 import qualified Unison.ABT as ABT
 import qualified Unison.Blank as B
-import           Unison.Names ( UnqualifiedNames )
+import           Unison.Names ( Names )
 import qualified Unison.NamesWithHistory as Names
 import qualified Unison.Names.ResolutionResult as Names
 import           Unison.Pattern (Pattern)
@@ -113,7 +113,7 @@ type Term0' vt v = Term' vt v ()
 bindNames
   :: forall v a . Var v
   => Set v
-  -> UnqualifiedNames
+  -> Names
   -> Term v a
   -> Names.ResolutionResult v a (Term v a)
 bindNames keepFreeTerms ns0 e = do
@@ -142,12 +142,12 @@ bindNames keepFreeTerms ns0 e = do
   pure . substTypeVars typeSubsts . ABT.substsInheritAnnotation termSubsts $ e
 
 -- This function replaces free term and type variables with
--- hashes found in the provided `UnqualifiedNames`, using suffix-based
--- lookup. Any terms not found in the `UnqualifiedNames` are kept free.
+-- hashes found in the provided `Names`, using suffix-based
+-- lookup. Any terms not found in the `Names` are kept free.
 bindSomeNames
   :: forall v a . Var v
   => Set v
-  -> UnqualifiedNames
+  -> Names
   -> Term v a
   -> Names.ResolutionResult v a (Term v a)
 -- bindSomeNames ns e | trace "Term.bindSome" False

--- a/unison-core/src/Unison/Type/Names.hs
+++ b/unison-core/src/Unison/Type/Names.hs
@@ -23,7 +23,7 @@ import qualified Data.Set.NonEmpty as NES
 bindNames
   :: Var v
   => Set v
-  -> Names.UnqualifiedNames
+  -> Names.Names
   -> Type v a
   -> Names.ResolutionResult v a (Type v a)
 bindNames keepFree ns0 t = let

--- a/unison-core/src/Unison/Type/Names.hs
+++ b/unison-core/src/Unison/Type/Names.hs
@@ -13,7 +13,7 @@ import Unison.Type
 import qualified Data.Set as Set
 import qualified Unison.ABT as ABT
 import Unison.Var (Var)
-import qualified Unison.Names3 as Names
+import qualified Unison.NamesWithHistory as Names
 import qualified Unison.Names.ResolutionResult as Names
 import qualified Unison.Name as Name
 import qualified Unison.Util.List as List

--- a/unison-core/src/Unison/Type/Names.hs
+++ b/unison-core/src/Unison/Type/Names.hs
@@ -26,7 +26,7 @@ bindNames
   -> Type v a
   -> Names.ResolutionResult v a (Type v a)
 bindNames keepFree ns0 t = let
-  ns = Names.Names ns0 mempty
+  ns = Names.NamesWithHistory ns0 mempty
   fvs = ABT.freeVarOccurrences keepFree t
   rs = [(v, a, Names.lookupHQType (Name.convert $ Name.fromVar v) ns) | (v,a) <- fvs ]
   ok (v, a, rs) = 

--- a/unison-core/src/Unison/Type/Names.hs
+++ b/unison-core/src/Unison/Type/Names.hs
@@ -13,6 +13,7 @@ import Unison.Type
 import qualified Data.Set as Set
 import qualified Unison.ABT as ABT
 import Unison.Var (Var)
+import qualified Unison.Names as Names
 import qualified Unison.NamesWithHistory as Names
 import qualified Unison.Names.ResolutionResult as Names
 import qualified Unison.Name as Name
@@ -22,7 +23,7 @@ import qualified Data.Set.NonEmpty as NES
 bindNames
   :: Var v
   => Set v
-  -> Names.Names0
+  -> Names.UnqualifiedNames
   -> Type v a
   -> Names.ResolutionResult v a (Type v a)
 bindNames keepFree ns0 t = let

--- a/unison-core/unison-core1.cabal
+++ b/unison-core/unison-core1.cabal
@@ -37,10 +37,10 @@ library
       Unison.Kind
       Unison.LabeledDependency
       Unison.Name
+      Unison.Names
       Unison.Names.ResolutionResult
-      Unison.Names2
-      Unison.Names3
       Unison.NameSegment
+      Unison.NamesWithHistory
       Unison.Paths
       Unison.Pattern
       Unison.Reference


### PR DESCRIPTION
## Overview
I assume there were some legacy reasons for some of the naming conventions used here; it looks like Names have gone through a few iterations, and unfortunately ended up in a confusing spot; resulting in many questions; what's a `Names0`? How's it different from a `Names'`? Why do we have a `Names2` and `Names3` module, but no `Names` module?

There's also the confusion that there were two unique types, one in Names2 and one in Names3 with the name `Names`; which made it hard to locally reason about code.

Pleasantly, it seems like there's nothing blocking us from cleaning these up a bit now 😄 

In addition to helping me keep things straight, I think this is a win for 🆕  contributors 

## Implementation notes

Here's what I did:
* `Names3.hs` -> `NamesWithHistory.hs`
* `Names2.hs` -> `Names.hs`
* `Names0` type -> `Names`
* `Names3.Names` type -> `NamesWithHistory.NamesWithHistory`
* Deleted the `Names` type which represented HashQualified names, since it appears we never use that type anymore (except two cases in completions, but they were redundant)
I've commented the only place where I've adjusted implementation details, everything else is renaming or dead-code-elimination

Negative LOC 🎉 

## Interesting/controversial decisions

I removed the HashQualified version of the Names type as I realized it was unused! I'm guessing this is fine, but something to note.
Interestingly, with the removal of Hash Qualified Names types, we never use `Names'` polymorphically.
This was a bit of a toss up, since we might want it to be polymorphic in the future, but also it makes the code a bit tougher to follow, reason about, and you have to thread constraints everywhere which is a bit annoying. I did this in a separate commit, so if we decide to revert it, no big deal 👍🏼 

I'd love a bit of context as to how things ended up where they were, especially the unused HashQualified names type.
What's our plan going forwards? Is `NamesWithHistory` meant to be used everywhere instead of `Names` eventually?

## Test coverage

No new behaviour

## Loose ends
None to my knowledge, unless we plan to migrate things over to using `NamesWithHistory` more thoroughly.
