### PR TITLE
Add 'api' command.

### DIFF
--- a/cli/unison/ArgParse.hs
+++ b/cli/unison/ArgParse.hs
@@ -99,6 +99,7 @@ data Command
   | Init
   | Run RunSource
   | Transcript ShouldForkCodebase ShouldSaveCodebase (NonEmpty FilePath )
+  | Api CodebaseServerOpts
   deriving (Show, Eq)
 
 -- | Options shared by sufficiently many subcommands.
@@ -207,8 +208,9 @@ commandParser envOpts =
            , transcriptCommand
            , transcriptForkCommand
            , launchHeadlessCommand envOpts
+           , apiCommand envOpts
            ]
-           
+
 globalOptionsParser :: Parser GlobalOptions
 globalOptionsParser = do -- ApplicativeDo
     codebasePathOption <- codebasePathParser <|> codebaseCreateParser
@@ -222,7 +224,7 @@ codebasePathParser = do
       <> metavar "codebase/path"
       <> help "The path to an existing codebase"
     pure (fmap DontCreateCodebaseWhenMissing optString)
-       
+
 codebaseCreateParser :: Parser (Maybe CodebasePathOption)
 codebaseCreateParser = do
     path <- optional . strOption $
@@ -236,6 +238,12 @@ launchHeadlessCommand envOpts =
     command "headless" (info (launchParser envOpts Headless) (progDesc headlessHelp))
   where
     headlessHelp = "Runs the codebase server without the command-line interface."
+
+apiCommand :: CodebaseServerOpts -> Mod CommandFields Command
+apiCommand envOpts =
+    command "api" (info (pure (Api envOpts)) (progDesc apiHelp))
+  where
+    apiHelp = "Provides details about the API."
 
 codebaseServerOptsParser :: CodebaseServerOpts -> Parser CodebaseServerOpts
 codebaseServerOptsParser envOpts = do -- ApplicativeDo


### PR DESCRIPTION
## Overview

This PR adds an 'api' command, which will inform users of API information. Closes #2452.

## Implementation notes

We want to display the same information to the user that would (or was) used to create the server. As a result, I extracted a function `resolveCodebaseServerOpts :: CodebaseServerOpts -> IO ResolvedCodebaseServerOpts` so that the interpretation of `CodebaseServerOpts` is consistent between the `api` command and commands that start the server.

## Interesting/controversial decisions

The `urlFor` function was used to extract a string that can be displayed to the user from a `BaseUrl`. If we were unable to obtain a token from the `CodebaseServerOpts`, then we display a dummy string of "not_available" in place of the token. The reason for this is that when the user does not supply a token, a token is randomly generated. We cannot predict in the `api` command what token will actually be used to start the server when the user does not provide one. I imagine there is a better way to deal with this situation than the "dummy token". Maybe an "alert" message that says that the given token is for illustration purposes only?

There are two other areas of the codebase that are concerning to me, but I do not know enough about the domain or the inner-workings of `warp` to make a decision.

1. In the `startServer` function, the `BaseUrl` data type does not seem to be using `envUI` nor `host`. If the user sets these via the ucm env vars, it seems to me that `BaseUrl` will have the wrong information.
2. Again in the `startServer` function, we modify `defaultSettings` with a port (after resolving the port), and then we check the data in `CodebaseServerOpts` again. This double-checking of `CodebaseServerOpts` might lead to inconsistencies in the future (if there is not one already). 

If the above items are problems, I would like new issues to be opened to address (rather than address in this PR).

## Test coverage

No tests were added for this change.