### PR TITLE
Allow globs/wildcarding in UCM commands

### DIFF
--- a/cli/transcripts/Transcripts.hs
+++ b/cli/transcripts/Transcripts.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Main where
+{- This module kicks off the Transcript Tests.
+   It doesn't do the transcript parsing itself.
+-}
+module Main (main) where
 
 import           Unison.Prelude
 import           EasyTest

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -62,7 +62,7 @@ module Unison.Codebase.Branch
   , getAt0
   , modifyAt
   , modifyAtM
-  , currentChildren
+  , children0
   -- * Branch terms/types/edits
   -- ** Term/type/edits lenses
   , terms
@@ -612,5 +612,5 @@ transform f b = case _history b of
 
 -- | Traverse the head branch of all direct children.
 -- The index of the traversal is the name of that child branch according to the parent.
-currentChildren :: IndexedTraversal' NameSegment (Branch0 m) (Branch0 m)
-currentChildren = children .> itraversed <. (history . Causal.head_)
+children0 :: IndexedTraversal' NameSegment (Branch0 m) (Branch0 m)
+children0 = children .> itraversed <. (history . Causal.head_)

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -34,6 +34,7 @@ module Unison.Codebase.Branch
   -- * diff
   , diff0
   -- * properties
+  , history
   , head
   , headHash
   , children
@@ -61,6 +62,7 @@ module Unison.Codebase.Branch
   , getAt0
   , modifyAt
   , modifyAtM
+  , currentChildren
   -- * Branch terms/types/edits
   -- ** Term/type/edits lenses
   , terms
@@ -606,3 +608,7 @@ transform f b = case _history b of
                -> Causal m Raw (Branch0 m)
                -> Causal m Raw (Branch0 n)
   transformB0s f = Causal.unsafeMapHashPreserving (transformB0 f)
+
+
+currentChildren :: IndexedTraversal' NameSegment (Branch0 m) (Branch0 m)
+currentChildren = children .> itraversed <. (history . Causal.head_)

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -610,5 +610,7 @@ transform f b = case _history b of
   transformB0s f = Causal.unsafeMapHashPreserving (transformB0 f)
 
 
+-- | Traverse the head branch of all direct children.
+-- The index of the traversal is the name of that child branch according to the parent.
 currentChildren :: IndexedTraversal' NameSegment (Branch0 m) (Branch0 m)
 currentChildren = children .> itraversed <. (history . Causal.head_)

--- a/parser-typechecker/src/Unison/Codebase/Causal.hs
+++ b/parser-typechecker/src/Unison/Codebase/Causal.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Unison.Codebase.Causal
   ( Causal (..),
     Raw (..),
     RawHash (..),
+    head_,
     one,
     cons,
     cons',
@@ -41,6 +43,7 @@ import Unison.Hash (Hash)
 import Unison.Hashable (Hashable)
 import qualified Unison.Hashable as Hashable
 import Prelude hiding (head, read, tail)
+import qualified Control.Lens as Lens
 
 {-
 `Causal a` has 5 operations, specified algebraically here:
@@ -89,6 +92,8 @@ data Causal m h e
           , head :: e
           , tails :: Map (RawHash h) (m (Causal m h e))
           }
+
+Lens.makeLensesFor [("head", "head_")] ''Causal
 
 -- A serializer `Causal m h e`. Nonrecursive -- only responsible for
 -- writing a single node of the causal structure.

--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -61,6 +61,9 @@ module Unison.Codebase.Path
     -- * things that could be replaced with `Snoc` instances
     snoc,
     unsnoc,
+
+  -- This should be moved to a common util module, or we could use the 'witch' package.
+  Convert(..)
   )
 where
 import Unison.Prelude hiding (empty, toList)
@@ -73,7 +76,7 @@ import Data.Sequence (Seq ((:<|), (:|>)))
 import qualified Data.Sequence as Seq
 import qualified Data.Text as Text
 import qualified Unison.HashQualified' as HQ'
-import Unison.Name (Convert, Name, Parse)
+import Unison.Name (Convert(..), Name, Parse)
 import qualified Unison.Name as Name
 import Unison.NameSegment (NameSegment (NameSegment))
 import qualified Unison.NameSegment as NameSegment
@@ -249,6 +252,7 @@ empty = Path mempty
 instance Show Path where
   show = Text.unpack . toText
 
+-- | Note: This treats the path as relative.
 toText :: Path -> Text
 toText (Path nss) = intercalateMap "." NameSegment.toText nss
 
@@ -346,6 +350,10 @@ instance Resolve Absolute Path' Absolute where
   resolve _ (Path' (Left a)) = a
   resolve a (Path' (Right r)) = resolve a r
 
+instance Convert Absolute Text where convert = toText' . absoluteToPath'
+instance Convert Relative Text where convert = toText . unrelative
+instance Convert Absolute String where convert = Text.unpack . convert
+instance Convert Relative String where convert = Text.unpack . convert
 instance Convert [NameSegment] Path where convert = fromList
 instance Convert Path [NameSegment] where convert = toList
 instance Convert HQSplit (HQ'.HashQualified Path) where convert = unsplitHQ

--- a/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
@@ -189,7 +189,10 @@ run dir configFile stanzas codebase = do
               args -> do
                 output ("\n" <> show p <> "\n")
                 numberedArgs <- readIORef numberedArgsRef
-                case parseInput patternMap numberedArgs args of
+                currentRoot <- Codebase.getRootBranch codebase >>= \case
+                  Left _ -> dieWithMsg $ "Failed to get root branch of codebase."
+                  Right b -> pure (Branch.head b)
+                case parseInput currentRoot curPath numberedArgs patternMap args of
                   -- invalid command is treated as a failure
                   Left msg -> dieWithMsg $ P.toPlain terminalWidth msg
                   Right input -> pure $ Right input

--- a/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
@@ -7,7 +7,6 @@ module Unison.Codebase.TranscriptParser (
   run, parse, parseFile)
   where
 
--- import qualified Text.Megaparsec.Char as P
 import Control.Concurrent.STM (atomically)
 import Control.Exception (finally)
 import Control.Monad.State (runStateT)

--- a/parser-typechecker/src/Unison/CommandLine.hs
+++ b/parser-typechecker/src/Unison/CommandLine.hs
@@ -27,12 +27,15 @@ module Unison.CommandLine
   , prettyCompletion
   , prettyCompletion'
   , prettyCompletion''
+  , fixupCompletion
   -- * Other
   , parseInput
   , prompt
   , watchBranchUpdates
   , watchConfig
   , watchFileSystem
+  -- * Exported for testing
+  , beforeHash
   ) where
 
 import Unison.Prelude

--- a/parser-typechecker/src/Unison/CommandLine.hs
+++ b/parser-typechecker/src/Unison/CommandLine.hs
@@ -237,17 +237,17 @@ parseInput
   -> Path.Absolute -- ^ Current path from root, used to expand globs
   -> [String] -- ^ Numbered arguments
   -> Map String InputPattern -- ^ Input Pattern Map
-  -> [String] -- ^ Arguments
+  -> [String] -- ^ command:arguments
   -> Either (P.Pretty CT.ColorText) Input
-parseInput rootBranch currentPath numberedArgs patterns args = do
-  let expandedArgs :: [String]
-      expandedArgs = foldMap (expandNumber numberedArgs) args
-  case expandedArgs of
+parseInput rootBranch currentPath numberedArgs patterns segments = do
+  case segments of
     [] -> Left ""
     command : args -> case Map.lookup command patterns of
       Just pat@(InputPattern {parse}) -> do
+        let expandedArgs :: [String]
+            expandedArgs = foldMap (expandNumber numberedArgs) args
         parse $
-          flip ifoldMap args $ \i arg -> do
+          flip ifoldMap expandedArgs $ \i arg -> do
             let targets = case InputPattern.argType pat i of
                   Just argT -> InputPattern.globTargets argT
                   Nothing -> mempty

--- a/parser-typechecker/src/Unison/CommandLine.hs
+++ b/parser-typechecker/src/Unison/CommandLine.hs
@@ -211,11 +211,10 @@ parseInput rootBranch currentPath patterns ss = case ss of
   []             -> Left ""
   command : args -> case Map.lookup command patterns of
     Just pat@(InputPattern{parse}) -> do
-      parse . traceShowId $ flip ifoldMap args $ \i arg -> do
+      parse $ flip ifoldMap args $ \i arg -> do
             let targets = case InputPattern.argType pat i of
                                  Just argT -> InputPattern.globTargets argT
                                  Nothing -> mempty
-            traceShowM targets
             Globbing.expandGlobs targets rootBranch currentPath arg
     Nothing ->
       Left

--- a/parser-typechecker/src/Unison/CommandLine.hs
+++ b/parser-typechecker/src/Unison/CommandLine.hs
@@ -239,25 +239,26 @@ parseInput
   -> Map String InputPattern -- ^ Input Pattern Map
   -> [String] -- ^ Arguments
   -> Either (P.Pretty CT.ColorText) Input
-parseInput rootBranch currentPath patterns ss = do
+parseInput rootBranch currentPath numberedArgs patterns args = do
   let expandedArgs :: [String]
       expandedArgs = foldMap (expandNumber numberedArgs) args
   case expandedArgs of
-    []             -> Left ""
+    [] -> Left ""
     command : args -> case Map.lookup command patterns of
-      Just pat@(InputPattern{parse}) -> do
-        parse $ flip ifoldMap args $ \i arg -> do
-              let targets = case InputPattern.argType pat i of
-                                   Just argT -> InputPattern.globTargets argT
-                                   Nothing -> mempty
-              Globbing.expandGlobs targets rootBranch currentPath arg
+      Just pat@(InputPattern {parse}) -> do
+        parse $
+          flip ifoldMap args $ \i arg -> do
+            let targets = case InputPattern.argType pat i of
+                  Just argT -> InputPattern.globTargets argT
+                  Nothing -> mempty
+            Globbing.expandGlobs targets rootBranch currentPath arg
       Nothing ->
         Left
-          .  warn
-          .  P.wrap
-          $  "I don't know how to "
-          <> P.group (fromString command <> ".")
-          <> "Type `help` or `?` to get help."
+          . warn
+          . P.wrap
+          $ "I don't know how to "
+            <> P.group (fromString command <> ".")
+            <> "Type `help` or `?` to get help."
 
 -- Expand a numeric argument like `1` or a range like `3-9`
 expandNumber :: [String] -> String -> [String]

--- a/parser-typechecker/src/Unison/CommandLine.hs
+++ b/parser-typechecker/src/Unison/CommandLine.hs
@@ -3,7 +3,37 @@
 {-# LANGUAGE ViewPatterns        #-}
 
 
-module Unison.CommandLine where
+module Unison.CommandLine
+  ( -- * Pretty Printing
+    allow
+  , backtick
+  , aside
+  , bigproblem
+  , note
+  , nothingTodo
+  , plural
+  , plural'
+  , problem
+  , tip
+  , warn
+  , warnNote
+  -- * Completers
+  , completion
+  , completion'
+  , exactComplete
+  , fuzzyComplete
+  , fuzzyCompleteHashQualified
+  , prefixIncomplete
+  , prettyCompletion
+  , prettyCompletion'
+  , prettyCompletion''
+  -- * Other
+  , parseInput
+  , prompt
+  , watchBranchUpdates
+  , watchConfig
+  , watchFileSystem
+  ) where
 
 import Unison.Prelude
 
@@ -109,9 +139,6 @@ warnNote s = "⚠️  " <> s
 
 backtick :: IsString s => P.Pretty s -> P.Pretty s
 backtick s = P.group ("`" <> s <> "`")
-
-backtickEOS :: IsString s => P.Pretty s -> P.Pretty s
-backtickEOS s = P.group ("`" <> s <> "`.")
 
 tip :: (ListLike s Char, IsString s) => P.Pretty s -> P.Pretty s
 tip s = P.column2 [("Tip:", P.wrap s)]

--- a/parser-typechecker/src/Unison/CommandLine/Globbing.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Globbing.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ViewPatterns #-}
+module Unison.CommandLine.Globbing where
+import Unison.Codebase (Codebase)
+import Unison.NameSegment (NameSegment (NameSegment))
+import Unison.Codebase.Branch (Branch0)
+import qualified Unison.Codebase.Path as Path
+import Data.Text (Text)
+import Control.Lens as Lens
+import qualified Unison.Codebase.Branch as Branch
+import qualified Unison.NameSegment as NameSegment
+import qualified Data.Text as Text
+import Text.Megaparsec
+import Data.Void
+import Text.Megaparsec.Char
+import Control.Applicative (liftA3)
+
+-- Glob paths are always relative.
+type GlobPath = [Either NameSegment GlobArg]
+data GlobArg =
+  GlobArg {namespacePrefix :: Text, namespaceSuffix :: Text}
+
+toNamespacePredicate :: Either NameSegment GlobArg -> (NameSegment -> Bool)
+toNamespacePredicate globArg (NameSegment.toText -> ns') = 
+  case globArg of
+    Left (NameSegment.toText -> ns) -> ns == ns'
+    Right (GlobArg prefix suffix) -> prefix `Text.isPrefixOf` ns' && suffix `Text.isSuffixOf` ns'
+
+unglob :: forall m. GlobPath -> Branch0 m -> [Path.Absolute]
+unglob gp branch = Path.Absolute . Path.fromList <$> unglobToNameSegments gp branch
+
+unglobToNameSegments :: forall m. GlobPath -> Branch0 m -> [[NameSegment]]
+unglobToNameSegments [] _ = [[]]
+unglobToNameSegments (x:xs) b =
+      let nextBranches :: [(NameSegment, (Branch0 m))]
+          nextBranches = b ^@.. childBranchesByKey (toNamespacePredicate x)
+       in foldMap (\(ns, b) -> (ns:) <$> unglobToNameSegments xs b) nextBranches
+  where
+    childBranchesByKey :: (NameSegment -> Bool) -> IndexedTraversal' NameSegment (Branch0 m) (Branch0 m)
+    childBranchesByKey keyPredicate = Branch.currentChildren . indices keyPredicate
+
+parseGlobs :: [String] -> Codebase m v a -> [Either Text GlobArg]
+parseGlobs = _
+
+-- globParser :: Parsec Void String GlobPath
+-- globParser = do
+--   isAbsolute <- Maybe.isJust <$> optional "."
+--   _
+
+
+
+globArgParser :: Parsec Void String (Either NameSegment GlobArg)
+globArgParser = do
+  let nsChar = ((char '\\' *> char '*') <|> satisfy (/= '.'))
+  let globSegmentP = 
+        liftA3 (,,) (many nsChar) (char '*') (many nsChar) 
+          <&> \(prefix, _star, suffix) -> GlobArg (Text.pack prefix) (Text.pack suffix)
+  (Right <$> try globSegmentP) <|> (Left . NameSegment . Text.pack <$> some anyChar)

--- a/parser-typechecker/src/Unison/CommandLine/Globbing.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Globbing.hs
@@ -90,7 +90,7 @@ expandGlobToNameSegments targets branch globPath =
 
 -- | Find all child branches whose name matches a predicate.
 matchingChildBranches :: (NameSegment -> Bool) -> IndexedTraversal' NameSegment (Branch0 m) (Branch0 m)
-matchingChildBranches keyPredicate = Branch.currentChildren . indices keyPredicate
+matchingChildBranches keyPredicate = Branch.children0 . indices keyPredicate
 
 -- | Expand a single glob pattern into all matching targets of the specified types.
 expandGlobs :: forall m. Set TargetType

--- a/parser-typechecker/src/Unison/CommandLine/Globbing.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Globbing.hs
@@ -1,9 +1,8 @@
-{-| Provides Globbing for selecting types, terms and namespaces using wildcards.
--}
-
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns #-}
+
+{-| Provides Globbing for selecting types, terms and namespaces using wildcards.  -}
 module Unison.CommandLine.Globbing
   ( expandGlobs
   , TargetType(..)
@@ -56,35 +55,43 @@ globPredicate globArg (NameSegment.toText -> ns') =
 
 -- | Expands a glob into a list of paths which lead to valid targets.
 expandGlobToPaths :: Set TargetType -> GlobPath -> Branch0 m -> [Path.Relative]
-expandGlobToPaths targets gp branch = (Path.Relative . Path.fromList) <$> expandGlobToNameSegments targets gp branch
+expandGlobToPaths targets globPath branch =
+  (Path.Relative . Path.fromList) <$> expandGlobToNameSegments targets branch globPath
 
 -- | Helper for 'expandGlobToPaths'
-expandGlobToNameSegments :: forall m. Set TargetType -> GlobPath -> Branch0 m -> [[NameSegment]]
-expandGlobToNameSegments _targets [] _branch = []
-expandGlobToNameSegments targets [segment] branch =
-         Monoid.whenM (Set.member Term targets) matchingTerms
-      <> Monoid.whenM (Set.member Type targets) matchingTypes
-      <> Monoid.whenM (Set.member Namespace targets) matchingNamespaces
-  where
-    predicate = globPredicate segment
-    matchingNamespaces, matchingTerms, matchingTypes :: [[NameSegment]]
-    matchingNamespaces = branch ^.. matchingChildBranches predicate . asIndex . to (pure @[])
-    matchingTerms = matchingNamesInStar predicate (Branch._terms branch)
-    matchingTypes = matchingNamesInStar predicate (Branch._types branch)
-    matchingNamesInStar :: (NameSegment -> Bool) -> Branch.Star a NameSegment -> [[NameSegment]]
-    matchingNamesInStar predicate star =
-      star & Star3.d1
-           & Relation.ran
-           & Set.toList
-           & filter predicate
-           & fmap (pure @[])
-expandGlobToNameSegments targets (x:xs) b = recursiveMatches
-  where
-    nextBranches :: [(NameSegment, (Branch0 m))]
-    nextBranches = b ^@.. matchingChildBranches (globPredicate x)
-    recursiveMatches :: ([[NameSegment]])
-    recursiveMatches =
-      (foldMap (\(ns, b) -> (ns:) <$> expandGlobToNameSegments targets xs b) nextBranches)
+expandGlobToNameSegments :: forall m. Set TargetType -> Branch0 m -> GlobPath -> [[NameSegment]]
+expandGlobToNameSegments targets branch globPath =
+  case globPath of
+    -- The glob path was empty; it yields no matches.
+    [] -> []
+    -- If we're at the end of the path, add any targets which match.
+    [segment] ->
+           Monoid.whenM (Set.member Term targets)      matchingTerms
+        <> Monoid.whenM (Set.member Type targets)      matchingTypes
+        <> Monoid.whenM (Set.member Namespace targets) matchingNamespaces
+      where
+        predicate :: NameSegment -> Bool
+        predicate = globPredicate segment
+        matchingNamespaces, matchingTerms, matchingTypes :: [[NameSegment]]
+        matchingNamespaces = branch ^.. matchingChildBranches predicate . asIndex . to (pure @[])
+        matchingTerms = matchingNamesInStar predicate (Branch._terms branch)
+        matchingTypes = matchingNamesInStar predicate (Branch._types branch)
+        matchingNamesInStar :: (NameSegment -> Bool) -> Branch.Star a NameSegment -> [[NameSegment]]
+        matchingNamesInStar predicate star =
+          star & Star3.d1
+               & Relation.ran
+               & Set.toList
+               & filter predicate
+               & fmap (pure @[]) -- Embed each name segment into a path.
+    -- If we have multiple remaining segments, descend into any children matching the current
+    -- segment, then keep matching on the remainder of the path.
+    (segment:rest) -> recursiveMatches
+      where
+        nextBranches :: [(NameSegment, (Branch0 m))]
+        nextBranches = branch ^@.. matchingChildBranches (globPredicate segment)
+        recursiveMatches :: [[NameSegment]]
+        recursiveMatches =
+          foldMap (\(ns, b) -> (ns:) <$> expandGlobToNameSegments targets b rest) nextBranches
 
 -- | Find all child branches whose name matches a predicate.
 matchingChildBranches :: (NameSegment -> Bool) -> IndexedTraversal' NameSegment (Branch0 m) (Branch0 m)

--- a/parser-typechecker/src/Unison/CommandLine/Globbing.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Globbing.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns #-}
 module Unison.CommandLine.Globbing where
-import Unison.Codebase (Codebase)
 import Unison.NameSegment (NameSegment (NameSegment))
 import Unison.Codebase.Branch (Branch0)
 import qualified Unison.Codebase.Path as Path
@@ -15,45 +14,64 @@ import Text.Megaparsec
 import Data.Void
 import Text.Megaparsec.Char
 import Control.Applicative (liftA3)
+import qualified Data.Maybe as Maybe
+import Data.Bifunctor (first, second)
+import qualified Unison.Util.Star3 as Star3
+import qualified Unison.Util.Relation as Relation
+import qualified Data.Set as Set
+
+data TargetType = Type | Term | Namespace
 
 -- Glob paths are always relative.
 type GlobPath = [Either NameSegment GlobArg]
 data GlobArg =
   GlobArg {namespacePrefix :: Text, namespaceSuffix :: Text}
 
-toNamespacePredicate :: Either NameSegment GlobArg -> (NameSegment -> Bool)
-toNamespacePredicate globArg (NameSegment.toText -> ns') = 
+toPredicate :: Either NameSegment GlobArg -> (NameSegment -> Bool)
+toPredicate globArg (NameSegment.toText -> ns') =
   case globArg of
     Left (NameSegment.toText -> ns) -> ns == ns'
     Right (GlobArg prefix suffix) -> prefix `Text.isPrefixOf` ns' && suffix `Text.isSuffixOf` ns'
 
-unglob :: forall m. GlobPath -> Branch0 m -> [Path.Absolute]
-unglob gp branch = Path.Absolute . Path.fromList <$> unglobToNameSegments gp branch
+unglob :: forall m. GlobPath -> Branch0 m -> [(TargetType, Path.Absolute)]
+unglob gp branch = second (Path.Absolute . Path.fromList) <$> unglobToNameSegments gp branch
 
-unglobToNameSegments :: forall m. GlobPath -> Branch0 m -> [[NameSegment]]
-unglobToNameSegments [] _ = [[]]
-unglobToNameSegments (x:xs) b =
-      let nextBranches :: [(NameSegment, (Branch0 m))]
-          nextBranches = b ^@.. childBranchesByKey (toNamespacePredicate x)
-       in foldMap (\(ns, b) -> (ns:) <$> unglobToNameSegments xs b) nextBranches
+unglobToNameSegments :: forall m. GlobPath -> Branch0 m -> [(TargetType, [NameSegment])]
+unglobToNameSegments [] _ = [(Namespace, [])]
+unglobToNameSegments (x:xs) b = matchingTerms <>  matchingTypes <> recursiveMatches
   where
+    nextBranches :: [(NameSegment, (Branch0 m))]
+    nextBranches = b ^@.. childBranchesByKey (toPredicate x)
+    recursiveMatches, matchingTerms, matchingTypes :: ([(TargetType, [NameSegment])])
+    recursiveMatches =
+      (foldMap (\(ns, b) -> second (ns:) <$> unglobToNameSegments xs b) nextBranches)
+    matchingTerms = matchingNamesInStar Term (toPredicate x) (Branch._terms b)
+    matchingTypes = matchingNamesInStar Type (toPredicate x) (Branch._terms b)
     childBranchesByKey :: (NameSegment -> Bool) -> IndexedTraversal' NameSegment (Branch0 m) (Branch0 m)
     childBranchesByKey keyPredicate = Branch.currentChildren . indices keyPredicate
+    matchingNamesInStar :: TargetType -> (NameSegment -> Bool) -> Branch.Star a NameSegment -> [(TargetType, [NameSegment])]
+    matchingNamesInStar typ predicate star =
+      star & Star3.d1
+           & Relation.ran
+           & Set.toList
+           & filter predicate
+           & pure @[]
+           & fmap (typ,)
 
-parseGlobs :: [String] -> Codebase m v a -> [Either Text GlobArg]
-parseGlobs = _
+parseGlobs :: String -> Branch0 m -> Either String [(TargetType, Path.Absolute)]
+parseGlobs s branch = first parseErrorPretty $ do
+  globPath <- runParser globParser "arguments" s
+  pure $ unglob globPath branch
 
--- globParser :: Parsec Void String GlobPath
--- globParser = do
---   isAbsolute <- Maybe.isJust <$> optional "."
---   _
-
-
+globParser :: Parsec Void String GlobPath
+globParser = do
+  _isAbsolute <- Maybe.isJust <$> optional "."
+  globArgParser `sepBy`  "."
 
 globArgParser :: Parsec Void String (Either NameSegment GlobArg)
 globArgParser = do
   let nsChar = ((char '\\' *> char '*') <|> satisfy (/= '.'))
-  let globSegmentP = 
-        liftA3 (,,) (many nsChar) (char '*') (many nsChar) 
+  let globSegmentP =
+        liftA3 (,,) (many nsChar) (char '*') (many nsChar)
           <&> \(prefix, _star, suffix) -> GlobArg (Text.pack prefix) (Text.pack suffix)
   (Right <$> try globSegmentP) <|> (Left . NameSegment . Text.pack <$> some anyChar)

--- a/parser-typechecker/src/Unison/CommandLine/Globbing.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Globbing.hs
@@ -6,14 +6,13 @@ import Unison.NameSegment (NameSegment (NameSegment))
 import Unison.Codebase.Branch (Branch0)
 import qualified Unison.Codebase.Path as Path
 import Data.Text (Text)
-import Control.Lens as Lens
+import Control.Lens as Lens hiding (noneOf)
 import qualified Unison.Codebase.Branch as Branch
 import qualified Unison.NameSegment as NameSegment
 import qualified Data.Text as Text
 import Text.Megaparsec
 import Data.Void
 import Text.Megaparsec.Char
-import Control.Applicative (liftA3)
 import qualified Data.Maybe as Maybe
 import Data.Bifunctor (second)
 import qualified Unison.Util.Star3 as Star3
@@ -22,14 +21,17 @@ import qualified Data.Set as Set
 import Data.Set (Set)
 import qualified Unison.Util.Monoid as Monoid
 import qualified Data.Either as Either
+import Unison.Prelude (traceShowId, traceShow)
+import Control.Applicative (liftA2)
 
 data TargetType = Type | Term | Namespace
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Show)
 
 -- Glob paths are always relative.
 type GlobPath = [Either NameSegment GlobArg]
 data GlobArg =
   GlobArg {namespacePrefix :: Text, namespaceSuffix :: Text}
+  deriving (Show)
 
 toPredicate :: Either NameSegment GlobArg -> (NameSegment -> Bool)
 toPredicate globArg (NameSegment.toText -> ns') =
@@ -37,15 +39,15 @@ toPredicate globArg (NameSegment.toText -> ns') =
     Left (NameSegment.toText -> ns) -> ns == ns'
     Right (GlobArg prefix suffix) -> prefix `Text.isPrefixOf` ns' && suffix `Text.isSuffixOf` ns'
 
-unglob :: Set TargetType -> GlobPath -> Branch0 m -> [(TargetType, Path.Absolute)]
-unglob targets gp branch = second (Path.Absolute . Path.fromList) <$> unglobToNameSegments targets gp branch
+unglob :: Set TargetType -> GlobPath -> Branch0 m -> [(TargetType, Path.Relative)]
+unglob targets gp branch = second (Path.Relative . Path.fromList) <$> unglobToNameSegments targets gp branch
 
 unglobToNameSegments :: forall m. Set TargetType -> GlobPath -> Branch0 m -> [(TargetType, [NameSegment])]
 unglobToNameSegments targets [] _ =
   if Set.member Namespace targets
     then [(Namespace, [])]
     else []
-unglobToNameSegments targets (x:xs) b =
+unglobToNameSegments targets (x:xs) b = traceShow (x:xs) $ 
      Monoid.whenM (Set.member Term targets) matchingTerms
   <> Monoid.whenM (Set.member Type targets) matchingTypes
   <> recursiveMatches
@@ -56,7 +58,7 @@ unglobToNameSegments targets (x:xs) b =
     recursiveMatches =
       (foldMap (\(ns, b) -> second (ns:) <$> unglobToNameSegments targets xs b) nextBranches)
     matchingTerms = matchingNamesInStar Term (toPredicate x) (Branch._terms b)
-    matchingTypes = matchingNamesInStar Type (toPredicate x) (Branch._terms b)
+    matchingTypes = matchingNamesInStar Type (toPredicate x) (Branch._types b)
     childBranchesByKey :: (NameSegment -> Bool) -> IndexedTraversal' NameSegment (Branch0 m) (Branch0 m)
     childBranchesByKey keyPredicate = Branch.currentChildren . indices keyPredicate
     matchingNamesInStar :: TargetType -> (NameSegment -> Bool) -> Branch.Star a NameSegment -> [(TargetType, [NameSegment])]
@@ -68,25 +70,29 @@ unglobToNameSegments targets (x:xs) b =
            & pure @[]
            & fmap (typ,)
 
-expandGlobs :: Set TargetType -> Branch0 m -> String -> [String]
-expandGlobs Empty _branch s = [s]
-expandGlobs targets branch s = Either.fromRight [s] $ do
-  globPath <- runParser globParser "arguments" s
+expandGlobs :: Set TargetType -> Branch0 m -> Path.Absolute -> String -> [String]
+expandGlobs Empty _branch _currentPath s = [s]
+expandGlobs targets branch currentPath s = Either.fromRight [s] $ do
+  (isAbsolute, globPath) <- traceShowId $ runParser globParser "arguments" s
+  let relocatePath :: Path.Relative -> Path.Absolute
+      relocatePath p | isAbsolute = Path.Absolute . Path.unprefix currentPath . Path.Path' . Right $ p
+                     | otherwise = Path.resolve currentPath p
   -- If we didn't parse any globs, pass the original arg as-is
   pure $ if any Either.isRight globPath
-          then fmap (Path.convert . snd) $ unglob targets globPath branch
+            then let pathsWithType = unglob targets globPath branch
+                     relocatedPaths = Path.convert @Path.Absolute @String . relocatePath . snd <$> pathsWithType
+                in relocatedPaths
           else [s]
 
-globParser :: Parsec Void String GlobPath
+globParser :: Parsec Void String (Bool, GlobPath)
 globParser = do
-  _isAbsolute <- Maybe.isJust <$> optional "."
-  globArgParser `sepBy`  "."
+  isAbsolute <- Maybe.isJust <$> optional "."
+  (isAbsolute,) <$> (globArgParser `sepBy`  "." <* eof)
 
 -- We unintuitively use '?' for glob patterns right now since they're not valid in names.
 globArgParser :: Parsec Void String (Either NameSegment GlobArg)
 globArgParser = do
-  let nsChar = ((char '\\' *> char '?') <|> satisfy (/= '.'))
+  let nsChar = ((char '\\' *> char '?') <|> noneOf ['.', '?'] )
   let globSegmentP =
-        liftA3 (,,) (many nsChar) (char '?') (many nsChar)
-          <&> \(prefix, _star, suffix) -> GlobArg (Text.pack prefix) (Text.pack suffix)
-  (Right <$> try globSegmentP) <|> (Left . NameSegment . Text.pack <$> some anyChar)
+        liftA2 GlobArg (Text.pack <$> manyTill nsChar "?") (Text.pack <$> many nsChar)
+  (Right <$> try globSegmentP) <|> (Left . NameSegment . Text.pack <$> some (satisfy (/= '.')))

--- a/parser-typechecker/src/Unison/CommandLine/Globbing.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Globbing.hs
@@ -98,8 +98,8 @@ expandGlobs :: forall m. Set TargetType
             -> Path.Absolute -- ^ UCM's current path
             -> String -- ^ The glob string, e.g. .base.List.?.doc
             -> [String] -- ^ Fully expanded, absolute paths. E.g. [".base.List.map"]
-expandGlobs Empty _rootBranch _currentPath s = [s]
 expandGlobs targets rootBranch currentPath s = Maybe.fromMaybe [s] $ do
+  guard (not . null $ targets)
   let (isAbsolute, globPath) = globbedPathParser (Text.pack s)
   -- If we don't have any actual globs, we can fail to fall back to the original argument.
   guard (any Either.isRight globPath)

--- a/parser-typechecker/src/Unison/CommandLine/Globbing.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Globbing.hs
@@ -1,7 +1,13 @@
+{-| Provides Globbing for selecting types, terms and namespaces using wildcards.
+-}
+
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns #-}
-module Unison.CommandLine.Globbing where
+module Unison.CommandLine.Globbing
+  ( expandGlobs
+  , TargetType(..)
+  ) where
 import Unison.NameSegment (NameSegment (NameSegment))
 import Unison.Codebase.Branch (Branch0)
 import qualified Unison.Codebase.Path as Path
@@ -24,31 +30,41 @@ import Control.Applicative (liftA2)
 import Control.Monad (guard)
 import Control.Error (hush)
 
-data TargetType = Type | Term | Namespace
+-- | Possible targets which a glob may select.
+data TargetType
+  = Type
+  | Term
+  | Namespace
   deriving (Eq, Ord, Show)
 
--- Glob paths are always relative.
+-- | Glob paths are always relative to some branch.
 type GlobPath = [Either NameSegment GlobArg]
+
+-- | Represents a name segment containing a glob pattern
+--   e.g. start?end -> GlobArg "start" "end"
 data GlobArg = GlobArg
     { namespacePrefix :: Text
     , namespaceSuffix :: Text
     } deriving (Show)
 
+-- | Constructs a namespace "matcher" from a 'GlobArg'
 globPredicate :: Either NameSegment GlobArg -> (NameSegment -> Bool)
 globPredicate globArg (NameSegment.toText -> ns') =
   case globArg of
     Left (NameSegment.toText -> ns) -> ns == ns'
     Right (GlobArg prefix suffix) -> prefix `Text.isPrefixOf` ns' && suffix `Text.isSuffixOf` ns'
 
-unglob :: Set TargetType -> GlobPath -> Branch0 m -> [Path.Relative]
-unglob targets gp branch = (Path.Relative . Path.fromList) <$> unglobToNameSegments targets gp branch
+-- | Expands a glob into a list of paths which lead to valid targets.
+expandGlobToPaths :: Set TargetType -> GlobPath -> Branch0 m -> [Path.Relative]
+expandGlobToPaths targets gp branch = (Path.Relative . Path.fromList) <$> expandGlobToNameSegments targets gp branch
 
-unglobToNameSegments :: forall m. Set TargetType -> GlobPath -> Branch0 m -> [[NameSegment]]
-unglobToNameSegments targets [] _ =
+-- | Helper for 'expandGlobToPaths'
+expandGlobToNameSegments :: forall m. Set TargetType -> GlobPath -> Branch0 m -> [[NameSegment]]
+expandGlobToNameSegments targets [] _ =
   if Set.member Namespace targets
     then [[]] -- Return an empty path, which will be built up by the parents.
     else []   -- Return zero paths.
-unglobToNameSegments targets [segment] branch =
+expandGlobToNameSegments targets [segment] branch =
          Monoid.whenM (Set.member Term targets) matchingTerms
       <> Monoid.whenM (Set.member Type targets) matchingTypes
   where
@@ -62,36 +78,47 @@ unglobToNameSegments targets [segment] branch =
            & Set.toList
            & filter predicate
            & fmap (pure @[])
-unglobToNameSegments targets (x:xs) b = recursiveMatches
+expandGlobToNameSegments targets (x:xs) b = recursiveMatches
   where
     nextBranches :: [(NameSegment, (Branch0 m))]
     nextBranches = b ^@.. childBranchesByKey (globPredicate x)
     recursiveMatches :: ([[NameSegment]])
     recursiveMatches =
-      (foldMap (\(ns, b) -> (ns:) <$> unglobToNameSegments targets xs b) nextBranches)
+      (foldMap (\(ns, b) -> (ns:) <$> expandGlobToNameSegments targets xs b) nextBranches)
     childBranchesByKey :: (NameSegment -> Bool) -> IndexedTraversal' NameSegment (Branch0 m) (Branch0 m)
     childBranchesByKey keyPredicate = Branch.currentChildren . indices keyPredicate
 
-expandGlobs :: forall m. Set TargetType -> Branch0 m -> Path.Absolute -> String -> [String]
-expandGlobs Empty _branch _currentPath s = [s]
+-- | Expand a single glob pattern into all matching targets of the specified types.
+expandGlobs :: forall m. Set TargetType
+            -> Branch0 m -- ^ Root branch
+            -> Path.Absolute -- ^ UCM's current path
+            -> String -- ^ The glob string, e.g. .base.List.?.doc
+            -> [String] -- ^ Fully expanded, absolute paths. E.g. [".base.List.map"]
+expandGlobs Empty _rootBranch _currentPath s = [s]
 expandGlobs targets rootBranch currentPath s = Maybe.fromMaybe [s] $ do
-  (isAbsolute, globPath) <- hush $ runParser globParser "arguments" s
+  (isAbsolute, globPath) <- hush $ runParser globbedPathParser "arguments" s
   -- If we don't have any actual globs, we can fail to fall back to the original argument.
   guard (any Either.isRight globPath)
   let currentBranch :: Branch0 m
       currentBranch
         | isAbsolute = rootBranch
         | otherwise = Branch.getAt0 (Path.unabsolute currentPath) rootBranch
-  let paths = unglob targets globPath currentBranch
+  let paths = expandGlobToPaths targets globPath currentBranch
   let relocatedPaths | isAbsolute = (Path.Absolute . Path.unrelative) <$> paths
                      | otherwise = Path.resolve currentPath <$> paths
   pure (Path.convert <$> relocatedPaths)
 
-globParser :: Parsec Void String (Bool, GlobPath)
-globParser = do
+-- | Ad-hoc parser for paths which may contain globs in them.
+globbedPathParser :: Parsec Void String (Bool, GlobPath)
+globbedPathParser = do
   isAbsolute <- Maybe.isJust <$> optional "."
   (isAbsolute,) <$> (globArgParser `sepBy`  "." <* eof)
 
+-- | Parses a single name segment into a GlobArg or a bare segment according to whether
+-- there's a glob.
+-- E.g.
+--   "toList" -> Left (NameSegment "toList")
+--   "to?" -> Left (GlobArg "to" "")
 -- We unintuitively use '?' for glob patterns right now since they're not valid in names.
 globArgParser :: Parsec Void String (Either NameSegment GlobArg)
 globArgParser = do

--- a/parser-typechecker/src/Unison/CommandLine/InputPattern.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPattern.hs
@@ -35,8 +35,8 @@ data ArgumentType = ArgumentType
   , suggestions :: forall m v a . Monad m
                 => String
                 -> Codebase m v a
-                -> Branch m
-                -> Path.Absolute
+                -> Branch m -- Root Branch
+                -> Path.Absolute -- Current path
                 -> m [Line.Completion]
   }
 instance Show ArgumentType where

--- a/parser-typechecker/src/Unison/CommandLine/InputPattern.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPattern.hs
@@ -27,13 +27,14 @@ data IsOptional
 data InputPattern = InputPattern
   { patternName :: String
   , aliases     :: [String]
-  , argTypes        :: [(IsOptional, ArgumentType)]
+  , argTypes    :: [(IsOptional, ArgumentType)]
   , help        :: P.Pretty CT.ColorText
   , parse       :: [String] -> Either (P.Pretty CT.ColorText) Input
   }
 
 data ArgumentType = ArgumentType
-  { typeName :: String
+  { typeName    :: String
+  -- | Generate completion suggestions for this argument type
   , suggestions :: forall m v a . Monad m
                 => String
                 -> Codebase m v a

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -2,6 +2,9 @@
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ViewPatterns        #-}
 
+{-
+   This module defines 'InputPattern' values for every supported input command.
+-}
 module Unison.CommandLine.InputPatterns where
 
 import Unison.Prelude
@@ -1401,7 +1404,7 @@ createAuthor = InputPattern "create.author" []
   (makeExample createAuthor ["alicecoder", "\"Alice McGee\""]
     <> "creates" <> backtick "alicecoder" <> "values in"
     <> backtick "metadata.authors" <> "and"
-    <> backtickEOS "metadata.copyrightHolders")
+    <> backtick "metadata.copyrightHolders" <> ".")
   (\case
       symbolStr : authorStr@(_:_) -> first fromString $ do
         symbol <- Path.definitionNameSegment symbolStr

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -1562,15 +1562,12 @@ termCompletor filterQuery = pathCompletor filterQuery go where
   go = Set.map HQ'.toText . R.dom . Names.terms . Names.names0ToNames . Branch.toNames0
 
 patchArg :: ArgumentType
-patchArg =
-  ArgumentType
-    { typeName = "patch",
-      suggestions =
-        pathCompletor
-          exactComplete
-          (Set.map Name.toText . Map.keysSet . Branch.deepEdits),
-      globTargets = Set.fromList []
-    }
+patchArg = ArgumentType
+  { typeName = "patch"
+  , suggestions = pathCompletor exactComplete
+                                (Set.map Name.toText . Map.keysSet . Branch.deepEdits)
+  , globTargets = Set.fromList []
+  }
 
 
 allCompletors :: Monad m

--- a/parser-typechecker/src/Unison/CommandLine/Main.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Main.hs
@@ -2,7 +2,10 @@
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ViewPatterns        #-}
 
-module Unison.CommandLine.Main where
+module Unison.CommandLine.Main 
+  ( main
+  , expandNumber
+  ) where
 
 import Unison.Prelude
 

--- a/parser-typechecker/src/Unison/CommandLine/Main.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Main.hs
@@ -4,7 +4,6 @@
 
 module Unison.CommandLine.Main 
   ( main
-  , expandNumber
   ) where
 
 import Unison.Prelude
@@ -44,31 +43,11 @@ import qualified Unison.CommandLine.InputPattern as IP
 import qualified Unison.Util.Pretty as P
 import qualified Unison.Util.TQueue as Q
 import qualified Unison.CommandLine.Welcome as Welcome
-import Text.Regex.TDFA
 import Control.Lens (view)
 import Control.Error (rightMay)
 import UnliftIO (catchSyncOrAsync, throwIO, withException)
 import System.IO (hPutStrLn, stderr)
-
--- Expand a numeric argument like `1` or a range like `3-9`
-expandNumber :: [String] -> String -> [String]
-expandNumber numberedArgs s =
-  maybe [s]
-        (map (\i -> fromMaybe (show i) . atMay numberedArgs $ i - 1))
-        expandedNumber
- where
-  rangeRegex = "([0-9]+)-([0-9]+)" :: String
-  (junk,_,moreJunk, ns) =
-    s =~ rangeRegex :: (String, String, String, [String])
-  expandedNumber =
-    case readMay s of
-      Just i -> Just [i]
-      Nothing ->
-        -- check for a range
-        case (junk, moreJunk, ns) of
-          ("", "", [from, to]) ->
-            (\x y -> [x..y]) <$> readMay from <*> readMay to
-          _ -> Nothing
+import Unison.Codebase.Editor.Output (Output)
 
 getUserInput
   :: forall m v a
@@ -91,6 +70,7 @@ getUserInput patterns codebase branch currentPath numberedArgs = Line.runInputT
     Line.handleInterrupt (pure Nothing) (Line.withInterrupt (Just <$> act)) >>= \case
       Nothing -> haskelineCtrlCHandling act
       Just a -> pure a
+  go :: Line.InputT m Input
   go = do
     line <- Line.getInputLine
       $ P.toANSI 80 ((P.green . P.shown) currentPath <> fromString prompt)
@@ -99,12 +79,14 @@ getUserInput patterns codebase branch currentPath numberedArgs = Line.runInputT
       Just l  -> case words l of
         [] -> go
         ws ->
-          case parseInput patterns . (>>= expandNumber numberedArgs) $ ws of
+          case parseInput patterns numberedArgs $ ws of
             Left msg -> do
               liftIO $ putPrettyLn msg
               go
             Right i -> pure i
+  settings :: Line.Settings m
   settings    = Line.Settings tabComplete (Just ".unisonHistory") True
+  tabComplete :: Line.CompletionFunc m
   tabComplete = Line.completeWordWithPrev Nothing " " $ \prev word ->
     -- User hasn't finished a command name, complete from command names
     if null prev
@@ -142,16 +124,18 @@ main dir welcome initialPath (config, cancelConfig) initialInputs runtime codeba
     cancelWatchBranchUpdates <- watchBranchUpdates (readIORef rootRef)
                                                    eventQueue
                                                    codebase
-    let patternMap =
+    let patternMap :: Map String InputPattern
+        patternMap =
           Map.fromList
             $   validInputs
             >>= (\p -> (patternName p, p) : ((, p) <$> aliases p))
+    let getInput :: IO Input
         getInput = do
           root <- readIORef rootRef
           path <- readIORef pathRef
           numberedArgs <- readIORef numberedArgsRef
           getUserInput patternMap codebase root path numberedArgs
-        loadSourceFile :: Text -> IO LoadSourceResult
+    let loadSourceFile :: Text -> IO LoadSourceResult
         loadSourceFile fname =
           if allow $ Text.unpack fname
             then
@@ -165,52 +149,58 @@ main dir welcome initialPath (config, cancelConfig) initialInputs runtime codeba
                     return $ LoadSuccess contents
                   in catch go handle
             else return InvalidSourceNameError
+    let notify :: Output Symbol -> IO ()
         notify = notifyUser dir >=> (\o ->
           ifM (readIORef pageOutput)
               (putPrettyNonempty o)
               (putPrettyLnUnpaged o))
-    let
-      awaitInput = do
-        -- use up buffered input before consulting external events
-        i <- readIORef initialInputsRef
-        (case i of
-          h:t -> writeIORef initialInputsRef t >> pure h
-          [] ->
-            -- Race the user input and file watch.
-            Async.race (atomically $ Q.peek eventQueue) getInput >>= \case
-              Left _ -> do
-                let e = Left <$> atomically (Q.dequeue eventQueue)
-                writeIORef pageOutput False
-                e
-              x      -> do
-                writeIORef pageOutput True
-                pure x) `catchSyncOrAsync` interruptHandler
-      interruptHandler (asyncExceptionFromException -> Just UserInterrupt) = awaitInput
-      interruptHandler e = hPutStrLn stderr ("Exception: " <> show e) *> throwIO e
-      cleanup = do
-        Runtime.terminate runtime
-        cancelConfig
-        cancelFileSystemWatch
-        cancelWatchBranchUpdates
-      loop state = do
-        writeIORef pathRef (view HandleInput.currentPath state)
-        let free = runStateT (runMaybeT HandleInput.loop) state
-        (o, state') <- HandleCommand.commandLine config awaitInput
-                                     (writeIORef rootRef)
-                                     runtime
-                                     notify
-                                     (\o -> let (p, args) = notifyNumbered o in
-                                      putPrettyNonempty p $> args)
-                                     loadSourceFile
-                                     codebase
-                                     serverBaseUrl
-                                     (const Random.getSystemDRG)
-                                     free
-        case o of
-          Nothing -> pure ()
-          Just () -> do
-            writeIORef numberedArgsRef (HandleInput._numberedArgs state')
-            loop state'
+
+
+    let interruptHandler :: SomeException -> IO (Either Event Input)
+        interruptHandler (asyncExceptionFromException -> Just UserInterrupt) = awaitInput
+        interruptHandler e = hPutStrLn stderr ("Exception: " <> show e) *> throwIO e
+        cleanup = do
+          Runtime.terminate runtime
+          cancelConfig
+          cancelFileSystemWatch
+          cancelWatchBranchUpdates
+        awaitInput :: IO (Either Event Input)
+        awaitInput = do
+          -- use up buffered input before consulting external events
+          i <- readIORef initialInputsRef
+          (case i of
+            h:t -> writeIORef initialInputsRef t >> pure h
+            [] ->
+              -- Race the user input and file watch.
+              Async.race (atomically $ Q.peek eventQueue) getInput >>= \case
+                Left _ -> do
+                  let e = Left <$> atomically (Q.dequeue eventQueue)
+                  writeIORef pageOutput False
+                  e
+                x      -> do
+                  writeIORef pageOutput True
+                  pure x) `catchSyncOrAsync` interruptHandler
+
+    let loop :: HandleInput.LoopState IO Symbol -> IO ()
+        loop state = do
+          writeIORef pathRef (view HandleInput.currentPath state)
+          let free = runStateT (runMaybeT HandleInput.loop) state
+          (o, state') <- HandleCommand.commandLine config awaitInput
+                                       (writeIORef rootRef)
+                                       runtime
+                                       notify
+                                       (\o -> let (p, args) = notifyNumbered o in
+                                        putPrettyNonempty p $> args)
+                                       loadSourceFile
+                                       codebase
+                                       serverBaseUrl
+                                       (const Random.getSystemDRG)
+                                       free
+          case o of
+            Nothing -> pure ()
+            Just () -> do
+              writeIORef numberedArgsRef (HandleInput._numberedArgs state')
+              loop state'
     -- Run the main program loop, always run cleanup, 
     -- If an exception occurred, print it before exiting.
     (loop (HandleInput.loopState0 root initialPath)

--- a/parser-typechecker/src/Unison/CommandLine/Main.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Main.hs
@@ -103,6 +103,7 @@ getUserInput patterns codebase rootBranch currentPath numberedArgs = Line.runInp
                          (Set.fromList [Globbing.Type, Globbing.Term])
                          (Branch.head rootBranch)
                    >>= expandNumber numberedArgs
+          liftIO $ print expandedInput
           case parseInput patterns expandedInput of
             Left msg -> do
               liftIO $ putPrettyLn msg

--- a/parser-typechecker/src/Unison/CommandLine/Main.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Main.hs
@@ -46,8 +46,6 @@ import Control.Lens (view)
 import Control.Error (rightMay)
 import UnliftIO (catchSyncOrAsync, throwIO, withException)
 import System.IO (hPutStrLn, stderr)
-import qualified Unison.CommandLine.Globbing as Globbing
-import qualified Data.Set as Set
 
 -- Expand a numeric argument like `1` or a range like `3-9`
 expandNumber :: [String] -> String -> [String]
@@ -98,13 +96,8 @@ getUserInput patterns codebase rootBranch currentPath numberedArgs = Line.runInp
       Just l  -> case words l of
         [] -> go
         ws -> do
-          let expandedInput =
-                ws >>= Globbing.expandGlobs
-                         (Set.fromList [Globbing.Type, Globbing.Term])
-                         (Branch.head rootBranch)
-                   >>= expandNumber numberedArgs
-          liftIO $ print expandedInput
-          case parseInput patterns expandedInput of
+          let expandedInput = ws >>= expandNumber numberedArgs
+          case parseInput (Branch.head rootBranch) currentPath patterns expandedInput of
             Left msg -> do
               liftIO $ putPrettyLn msg
               go

--- a/parser-typechecker/src/Unison/CommandLine/Main.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Main.hs
@@ -79,7 +79,7 @@ getUserInput patterns codebase rootBranch currentPath numberedArgs = Line.runInp
       Just l  -> case words l of
         [] -> go
         ws ->
-          case parseInput (Branch.head rootBranch) currentPath patterns numberedArgs $ ws of
+          case parseInput (Branch.head rootBranch) currentPath numberedArgs patterns $ ws of
             Left msg -> do
               liftIO $ putPrettyLn msg
               go

--- a/parser-typechecker/src/Unison/CommandLine/Main.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Main.hs
@@ -76,7 +76,7 @@ getUserInput
   -> Path.Absolute
   -> [String]
   -> m Input
-getUserInput patterns codebase branch currentPath numberedArgs = Line.runInputT
+getUserInput patterns codebase rootBranch currentPath numberedArgs = Line.runInputT
   settings
   (haskelineCtrlCHandling go)
  where
@@ -111,7 +111,7 @@ getUserInput patterns codebase branch currentPath numberedArgs = Line.runInputT
         h : t -> fromMaybe (pure []) $ do
           p       <- Map.lookup h patterns
           argType <- IP.argType p (length t)
-          pure $ suggestions argType word codebase branch currentPath
+          pure $ suggestions argType word codebase rootBranch currentPath
         _ -> pure []
 
 main

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -85,6 +85,7 @@ library
       Unison.CodebasePath
       Unison.CommandLine
       Unison.CommandLine.DisplayValues
+      Unison.CommandLine.Globbing
       Unison.CommandLine.InputPattern
       Unison.CommandLine.InputPatterns
       Unison.CommandLine.Main

--- a/unison-src/transcripts/globbing.md
+++ b/unison-src/transcripts/globbing.md
@@ -12,7 +12,7 @@ This allows quickly selecting terms, types, and namespaces for any "bulk" comman
 ## Demo
 
 Add some definitions which we can match over:
-```unison
+```unison:hide
 convertToThing = 1
 convertFromThing = 2
 
@@ -56,4 +56,11 @@ This should expand to the empty argument and silently succeed.
 
 ```ucm
 .> view other?
+```
+
+Globbing should work from within a namespace with both absolute and relative patterns.
+
+```ucm
+.nested> view .othernest.to?
+.nested> view to?
 ```

--- a/unison-src/transcripts/globbing.md
+++ b/unison-src/transcripts/globbing.md
@@ -1,0 +1,22 @@
+# Globbing 
+
+## Overview
+
+This allows quickly selecting terms, types, and namespaces for any "bulk" commands.
+
+* Currently supports up to one wildcard PER SEGMENT; Each segment can have its own wildcard if you really want and it'll still be performant. E.g. `.base.?.to?`
+* Can have a prefix, suffix or infix wildcard! E.g. `to?` or `?List` or `to?With!`
+* I went with `?` instead of `*` for the wildcard symbol since `?` isn't currently a valid symbol name. This may cause some confusion since it differs from bash globbing though; so if anyone has thoughts/concerns about how to better handle this I'd love to hear them.
+* Commands can select which targets they want globs to expand to; e.g. `cd` should only glob for namespace, `view` should only glob to terms & types.
+
+## Demo
+
+```unison
+tweedleDee = 1
+tweedleDum = 2
+```
+
+```ucm
+.> add
+.> view tweedle?
+```

--- a/unison-src/transcripts/globbing.output.md
+++ b/unison-src/transcripts/globbing.output.md
@@ -23,32 +23,88 @@ othernest.toList = 5
 othernest.toMap = 6
 ```
 
-```ucm:hide
-.> add
-```
+```ucm
 
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      convertFromThing : ##Nat
+      convertToThing   : ##Nat
+      nested.toList    : ##Nat
+      nested.toMap     : ##Nat
+      othernest.toList : ##Nat
+      othernest.toMap  : ##Nat
+
+```
 Globbing as a prefix, infix, or suffix wildcard.
 
 ```ucm
 .> view convert?
-.> view convert?Thing
-.> view ?Thing
-```
 
+  convertFromThing : ##Nat
+  convertFromThing = 2
+  
+  convertToThing : ##Nat
+  convertToThing = 1
+
+.> view convert?Thing
+
+  convertFromThing : ##Nat
+  convertFromThing = 2
+  
+  convertToThing : ##Nat
+  convertToThing = 1
+
+.> view ?Thing
+
+  convertFromThing : ##Nat
+  convertFromThing = 2
+  
+  convertToThing : ##Nat
+  convertToThing = 1
+
+```
 Globbing can occur in any name segment.
 
 ```ucm
 .> view ?.toList
-.> view nested.to?
-```
 
+  nested.toList : ##Nat
+  nested.toList = 3
+  
+  othernest.toList : ##Nat
+  othernest.toList = 5
+
+.> view nested.to?
+
+  nested.toList : ##Nat
+  nested.toList = 3
+  
+  nested.toMap : ##Nat
+  nested.toMap = 4
+
+```
 You may have up to one glob per name segment.
 
 ```ucm
 .> view ?.to?
+
+  nested.toList : ##Nat
+  nested.toList = 3
+  
+  nested.toMap : ##Nat
+  nested.toMap = 4
+  
+  othernest.toList : ##Nat
+  othernest.toList = 5
+  
+  othernest.toMap : ##Nat
+  othernest.toMap = 6
+
 ```
-
-
 Globbing only expands to the appropriate argument type.
 
 E.g. `view` should not see glob expansions for namespaces.
@@ -56,4 +112,5 @@ This should expand to the empty argument and silently succeed.
 
 ```ucm
 .> view other?
+
 ```

--- a/unison-src/transcripts/globbing.output.md
+++ b/unison-src/transcripts/globbing.output.md
@@ -23,22 +23,6 @@ othernest.toList = 5
 othernest.toMap = 6
 ```
 
-```ucm
-
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-  
-    ⍟ These new definitions are ok to `add`:
-    
-      convertFromThing : ##Nat
-      convertToThing   : ##Nat
-      nested.toList    : ##Nat
-      nested.toMap     : ##Nat
-      othernest.toList : ##Nat
-      othernest.toMap  : ##Nat
-
-```
 Globbing as a prefix, infix, or suffix wildcard.
 
 ```ucm
@@ -112,5 +96,25 @@ This should expand to the empty argument and silently succeed.
 
 ```ucm
 .> view other?
+
+```
+Globbing should work from within a namespace with both absolute and relative patterns.
+
+```ucm
+.nested> view .othernest.to?
+
+  .othernest.toList : ##Nat
+  .othernest.toList = 5
+  
+  .othernest.toMap : ##Nat
+  .othernest.toMap = 6
+
+.nested> view to?
+
+  toList : ##Nat
+  toList = 3
+  
+  toMap : ##Nat
+  toMap = 4
 
 ```


### PR DESCRIPTION
## Overview

This allows quickly selecting terms, types, and namespaces for any "bulk" commands.

* Currently supports up to one wildcard PER SEGMENT; Each segment can have its own wildcard if you really want and it'll still be performant. E.g. `.base.?.to?`
* Can have a prefix, suffix or infix wildcard! E.g. `to?` or `?List` or `to?With!`
* I went with `?` instead of `*` for the wildcard symbol since `?` isn't currently a valid symbol name. This may cause some confusion since it differs from bash globbing though; so if anyone has thoughts/concerns about how to better handle this I'd love to hear them.
* Plan would be to also add `??` for recursive globs, should be pretty reasonable to add to this implementation if needed.
* Commands can select which targets they want globs to expand to; e.g. `cd` should only glob for namespace, `view` should only glob to terms & types.

closes https://github.com/unisonweb/unison/issues/2527

## Demo

```ucm
-- Edit all docs in the current namespace
.base.List> edit ?.doc 
  all.doc : Doc.Deprecated
  all.doc =
    [: `@all predicate list` returns whether `predicate` is true for every element of `list`. True if
    `list` is empty.:]

  any.doc : Doc.Deprecated
  any.doc =
    [: `@any predicate list` returns whether `predicate` is true for at least one element of `list`.
    False if `list` is empty.:]

  concatOptional.doc : Doc.Deprecated
  concatOptional.doc =
    [: Unwraps an `@Optional [a]` to an [a].  `@concatOptional None` returns []. :]

  deleteAt.doc : Doc.Deprecated
  deleteAt.doc = [: Deletes from the list the element at the given index. :]
...
-- Double Glob! View all types/terms within some child namespace of base, which start with `to` and end with `!`
.> view .base.?.to?!

  base.Abort.toDefault! : a -> '{g, Abort} a ->{g} a
  base.Abort.toDefault! default thunk = handle !thunk with toDefault!.handler default

  base.Abort.toOptional! : '{g, Abort} a ->{g} Optional a
  base.Abort.toOptional! thunk = toDefault! None '(Some !thunk)

  base.Natural.toText! : Natural -> Nat ->{Abort} Text
  base.Natural.toText! n radix = toAbort (Natural.toText n radix)

  base.Stream.to! : Nat ->{Stream Nat} ()
  base.Stream.to! n = rangeClosed! 0 n

  base.Stream.toList! : '{g, Stream a} r ->{g} [a]
  base.Stream.toList! s = at1 (toListWithResult! s)

  base.Stream.toListWithResult! : '{g, Stream a} r ->{g} ([a], r)
  base.Stream.toListWithResult! = foldWithResult! (:+) []

```

## Implementation notes

Adds glob expansion as part of the `parseInput` step, it occurs after numerical expansion (simply due to how the code was organized) but before parsing args into an Input.
This means that the Codebase, Branch, and current path are all now parts of `parseInput`.

## Interesting/controversial decisions

* I wrote a custom parser for glob expressions, perhaps I should re-use some path parser, then reparse only the name segments?
* Is this the right spot for this to trigger? Originally I tried to do it as an isolated pre-processing step, but since we can't know the desired 'type' of each arg's glob until we know the command, I moved it to allow typed globs.
* Currently the glob result is expanded into multiple arguments, so it only works with commands which accept many arguments, e.g. `view`, `edit`, etc.  We could investigate other ways of passing multiple arguments to better facilitate other commands, e.g. `link`.


## Test coverage

* [x] Add Transcripts testing globbing
* [x] Transcript currently have their own input parsing, which skips the globbing stage so we can't test it. We should adjust so transcripts follow as much of the UCM input path as possible so we can test this.

## Loose ends

It would be nice if `<tab>`'ing on a glob expanded the glob so you could preview what would happen.
It's a bit annoying to wire up this way, but is likely possible. This can be added as a future improvement.

Recursive wildcards would be nice, and should be relatively straightforward to add to this implementation.