### PR TITLE
Optimize a few relation functions

### DIFF
--- a/lib/unison-util-relation/src/Unison/Util/Relation.hs
+++ b/lib/unison-util-relation/src/Unison/Util/Relation.hs
@@ -105,7 +105,6 @@ module Unison.Util.Relation
 where
 
 import qualified Control.Monad as Monad
-import Data.Bifunctor (first, second)
 import qualified Data.List as List
 import qualified Data.Map as M
 import qualified Data.Map as Map
@@ -628,11 +627,19 @@ map f = fromList . fmap f . toList
 
 -- aka first
 mapDom :: (Ord a, Ord a', Ord b) => (a -> a') -> Relation a b -> Relation a' b
-mapDom f = fromList . fmap (first f) . toList
+mapDom f Relation {domain, range} =
+  Relation
+    { domain = Map.mapKeysWith S.union f domain,
+      range = Map.map (S.map f) range
+    }
 
 -- aka second
 mapRan :: (Ord a, Ord b, Ord b') => (b -> b') -> Relation a b -> Relation a b'
-mapRan f = fromList . fmap (second f) . toList
+mapRan f Relation {domain, range} =
+  Relation
+    { domain = Map.map (S.map f) domain,
+      range = Map.mapKeysWith S.union f range
+    }
 
 fromMap :: (Ord a, Ord b) => Map a b -> Relation a b
 fromMap = fromList . Map.toList

--- a/lib/unison-util-relation/src/Unison/Util/Relation3.hs
+++ b/lib/unison-util-relation/src/Unison/Util/Relation3.hs
@@ -43,6 +43,22 @@ filter :: (Ord a, Ord b, Ord c)
        => ((a,b,c) -> Bool) -> Relation3 a b c -> Relation3 a b c
 filter f = fromList . Prelude.filter f . toList
 
+mapD1 :: (Ord a, Ord a', Ord b, Ord c) => (a -> a') -> Relation3 a b c -> Relation3 a' b c
+mapD1 f Relation3 {d1, d2, d3} =
+  Relation3
+    { d1 = Map.mapKeysWith R.union f d1,
+      d2 = Map.map (R.mapDom f) d2,
+      d3 = Map.map (R.mapDom f) d3
+    }
+
+mapD2 :: (Ord a, Ord b, Ord b', Ord c) => (b -> b') -> Relation3 a b c -> Relation3 a b' c
+mapD2 f Relation3 {d1, d2, d3} =
+  Relation3
+    { d1 = Map.map (R.mapDom f) d1,
+      d2 = Map.mapKeysWith R.union f d2,
+      d3 = Map.map (R.mapRan f) d3
+    }
+
 member :: (Ord a, Ord b, Ord c) => a -> b -> c -> Relation3 a b c -> Bool
 member a b c = R.member b c . lookupD1 a
 
@@ -103,6 +119,14 @@ difference (Relation3 a1 b1 c1) (Relation3 a2 b2 c2) =
     (Map.differenceWith R.difference1 a1 a2)
     (Map.differenceWith R.difference1 b1 b2)
     (Map.differenceWith R.difference1 c1 c2)
+
+-- | @union x y@ computes the union of @x@ and @y@.
+union :: (Ord a, Ord b, Ord c) => Relation3 a b c -> Relation3 a b c -> Relation3 a b c
+union (Relation3 a1 b1 c1) (Relation3 a2 b2 c2) =
+  Relation3
+    (Map.unionWith R.union a1 a2)
+    (Map.unionWith R.union b1 b2)
+    (Map.unionWith R.union c1 c2)
 
 delete a b c Relation3{..} =
   Relation3

--- a/lib/unison-util-relation/src/Unison/Util/Relation4.hs
+++ b/lib/unison-util-relation/src/Unison/Util/Relation4.hs
@@ -105,9 +105,14 @@ delete a b c d Relation4{..} =
       let r' = R3.delete x y z r
       in if r' == mempty then Nothing else Just r'
 
-mapD2 :: (Ord a, Ord b, Ord b', Ord c, Ord d)
-      => (b -> b') -> Relation4 a b c d -> Relation4 a b' c d
-mapD2 f = fromList . fmap (\(a,b,c,d) -> (a, f b, c, d)) . toList
+mapD2 :: (Ord a, Ord b, Ord b', Ord c, Ord d) => (b -> b') -> Relation4 a b c d -> Relation4 a b' c d
+mapD2 f Relation4 {d1, d2, d3, d4} =
+  Relation4
+    { d1 = Map.map (R3.mapD1 f) d1,
+      d2 = Map.mapKeysWith R3.union f d2,
+      d3 = Map.map (R3.mapD2 f) d3,
+      d4 = Map.map (R3.mapD2 f) d4
+    }
 
 insertAll :: Foldable f => Ord a => Ord b => Ord c => Ord d
           => f (a,b,c,d) -> Relation4 a b c d -> Relation4 a b c d

--- a/lib/unison-util-relation/test/Main.hs
+++ b/lib/unison-util-relation/test/Main.hs
@@ -1,4 +1,5 @@
 module Main where
+
 import EasyTest
 import System.Random (Random)
 import qualified Unison.Util.Relation as Relation
@@ -9,38 +10,63 @@ import qualified Unison.Util.Relation4 as Relation4
 
 main :: IO ()
 main =
-  run do
-    scope "Relation3" do
-      scope "d12 works" do
-        r3 <- randomR3 @Char @Char @Char 1000
-        let d12 = Relation.fromList . map (\(a, b, _) -> (a, b)) . Relation3.toList
-        expectEqual (Relation3.d12 r3) (d12 r3)
+  (run . tests)
+    [ (scope "Relation" . tests)
+        [ scope "mapDom works" do
+            expectEqual
+              (Relation.fromList [('c', 'a'), ('c', 'b')])
+              (Relation.mapDom (const 'c') (Relation.fromList [('a', 'a'), ('b', 'b')])),
+          scope "mapRan works" do
+            expectEqual
+              (Relation.fromList [('a', 'c'), ('b', 'c')])
+              (Relation.mapRan (const 'c') (Relation.fromList [('a', 'a'), ('b', 'b')]))
+        ],
+      (scope "Relation3" . tests)
+        [ scope "d12 works" do
+            r3 <- randomR3 @Char @Char @Char 1000
+            let d12 = Relation.fromList . map (\(a, b, _) -> (a, b)) . Relation3.toList
+            expectEqual (Relation3.d12 r3) (d12 r3),
+          scope "d13 works" do
+            r3 <- randomR3 @Char @Char @Char 1000
+            let d13 = Relation.fromList . map (\(a, _, c) -> (a, c)) . Relation3.toList
+            expectEqual (Relation3.d13 r3) (d13 r3),
+          scope "mapD1 works" do
+            expectEqual
+              (Relation3.fromList [('c', 'a', 'a'), ('c', 'b', 'b')])
+              (Relation3.mapD1 (const 'c') (Relation3.fromList [('a', 'a', 'a'), ('b', 'b', 'b')])),
+          scope "mapD2 works" do
+            expectEqual
+              (Relation3.fromList [('a', 'c', 'a'), ('b', 'c', 'b')])
+              (Relation3.mapD2 (const 'c') (Relation3.fromList [('a', 'a', 'a'), ('b', 'b', 'b')])),
+          scope "union" do
+            r1 <- randomR3 @Char @Char @Char 10
+            r2 <- randomR3 @Char @Char @Char 10
+            expectEqual (Relation3.fromList (Relation3.toList r1 ++ Relation3.toList r2)) (Relation3.union r1 r2)
+        ],
+      (scope "Relation4" . tests)
+        [ scope "d124 works" do
+            r4 <- randomR4 @Char @Char @Char @Char 1000
+            let d124 = Relation3.fromList . map (\(a, b, _, d) -> (a, b, d)) . Relation4.toList
+            expectEqual (Relation4.d124 r4) (d124 r4),
+          scope "relation operations" do
+            r1 <- randomR1 @Char @Char 1000
+            r2 <- randomR1 @Char @Char 500
+            tests
+              [ scope "a `union` (a `intersection` b) == a" do
+                  expectEqual (r1 `Relation.union` (r1 `Relation.intersection` r2)) r1,
+                scope "union a a == a" do
+                  expectEqual (Relation.union r1 r1) r1,
+                scope "intersection a a == a" do
+                  expectEqual (Relation.union r1 r1) r1
+              ],
+          scope "mapD2 works" do
+            expectEqual
+              (Relation4.fromList [('a', 'c', 'a', 'a'), ('b', 'c', 'b', 'b')])
+              (Relation4.mapD2 (const 'c') (Relation4.fromList [('a', 'a', 'a', 'a'), ('b', 'b', 'b', 'b')]))
+        ]
+    ]
 
-      scope "d13 works" do
-        r3 <- randomR3 @Char @Char @Char 1000
-        let d13 = Relation.fromList . map (\(a, _, c) -> (a, c)) . Relation3.toList
-        expectEqual (Relation3.d13 r3) (d13 r3)
-
-    scope "Relation4" do
-      scope "d124 works" do
-        r4 <- randomR4 @Char @Char @Char @Char 1000
-        let d124 = Relation3.fromList . map (\(a, b, _, d) -> (a, b, d)) . Relation4.toList
-        expectEqual (Relation4.d124 r4) (d124 r4)
-
-    scope "relation operations" do
-      r1 <- randomR1 @Char @Char 1000
-      r2 <- randomR1 @Char @Char 500
-      scope "a `union` (a `intersection` b) == a" do
-        expectEqual
-          (r1 `Relation.union` (r1 `Relation.intersection` r2))
-          r1
-      scope "union a a == a" do
-        expectEqual (Relation.union r1 r1) r1
-
-      scope "intersection a a == a" do
-        expectEqual (Relation.union r1 r1) r1
-
-randomR1 ::  (Ord a, Ord b, Random a, Random b) =>  Int -> Test (Relation.Relation a b)
+randomR1 :: (Ord a, Ord b, Random a, Random b) => Int -> Test (Relation.Relation a b)
 randomR1 n = Relation.fromList <$> listOf n tuple2
 
 randomR3 :: (Ord a, Random a, Ord b, Random b, Ord c, Random c) => Int -> Test (Relation3 a b c)


### PR DESCRIPTION
## Overview

This PR optimizes a few more relation functions.

### Performance

First, some baseline RTS statistics that are relatively stabl across trunk and this branch, which result from just starting UCM up:

```
   9,702,081,024 bytes allocated in the heap
     854,097,344 bytes copied during GC
      80,534,552 bytes maximum residency (19 sample(s))
         426,984 bytes maximum slop
             195 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      9356 colls,     0 par    0.431s   0.433s     0.0000s    0.0002s
  Gen  1        19 colls,     0 par    0.246s   0.246s     0.0129s    0.0561s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time    9.600s  (  9.409s elapsed)
  GC      time    0.677s  (  0.679s elapsed)
  EXIT    time    0.001s  (  0.002s elapsed)
  Total   time   10.279s  ( 10.090s elapsed)

  Alloc rate    1,010,603,089 bytes per MUT second

  Productivity  93.4% of total user, 93.2% of total elapsed
```

Now, for the following transcript...

```
.> link a100 a101
.> unlink a100 a101
.> link a100 a101
.> unlink a100 a101
.> link a100 a101
.> unlink a100 a101
.> link a100 a101
.> unlink a100 a101
.> link a100 a101
.> unlink a100 a101
```

... when run on a codebase that just has two copies of `base` near the top level (to make namespace diffing, which link and unlink do, more expensive), plus a couple of `a100` / `a101` int terms, I observed the following profiles.

Trunk:

```
  49,346,722,896 bytes allocated in the heap
  11,242,952,032 bytes copied during GC
   1,598,395,872 bytes maximum residency (27 sample(s))
      10,705,440 bytes maximum slop
            3858 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     47356 colls,     0 par    2.978s   2.988s     0.0001s    0.0016s
  Gen  1        27 colls,     0 par    5.479s   5.480s     0.2029s    1.5520s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time   19.852s  ( 19.884s elapsed)
  GC      time    8.457s  (  8.467s elapsed)
  EXIT    time    0.000s  (  0.009s elapsed)
  Total   time   28.310s  ( 28.360s elapsed)

  Alloc rate    2,485,679,468 bytes per MUT second

  Productivity  70.1% of total user, 70.1% of total elapsed
```

This branch:

```
  39,411,415,144 bytes allocated in the heap
   4,578,501,352 bytes copied during GC
     753,234,800 bytes maximum residency (24 sample(s))
       4,594,832 bytes maximum slop
            1646 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     37992 colls,     0 par    1.397s   1.404s     0.0000s    0.0010s
  Gen  1        24 colls,     0 par    2.275s   2.275s     0.0948s    0.7742s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time   17.232s  ( 17.271s elapsed)
  GC      time    3.672s  (  3.680s elapsed)
  EXIT    time    0.000s  (  0.009s elapsed)
  Total   time   20.905s  ( 20.960s elapsed)

  Alloc rate    2,287,083,467 bytes per MUT second

  Productivity  82.4% of total user, 82.4% of total elapsed
```

When subtracting out the numbers from the baseline initialization, I get the following summary of the above runtime profiles that are directly related to this PR's changes to the transcript above.

- 41% faster runtime
- 25% fewer allocations

And this summary, which is not affected by the baseline initialization, which only uses 80mb resident memory (compared to 1.6gb on trunk or 750mb on this branch):

- 52% lower maximum resident memory

## Implementation notes

A few functions that used to round-trip through lists were rewritten to use the corresponding map/set functions

## Test coverage

I added tests for the new functions.

## Loose ends

- [x] Add tests
