### PR TITLE
Don't fetch unnecessary history when pulling a remote.

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
@@ -93,7 +93,9 @@ pullBranch repo@(ReadGitRepo uri) = do
       -- Otherwise proceed!
       (catchIO
         (withStatus ("Updating cached copy of " ++ Text.unpack uri ++ " ...") $ do
-          gitIn localPath ["reset", "--hard", "--quiet", "HEAD"]
+          -- Fetch only the latest 
+          gitIn localPath (["fetch", "origin", "HEAD"] ++ ["--depth", "1"])
+          gitIn localPath ["reset", "--hard", "--quiet", "origin/HEAD"]
           gitIn localPath ["clean", "-d", "--force", "--quiet"]
           gitIn localPath ["pull", "--force", "--quiet"])
         (const $ goFromScratch))

--- a/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
@@ -63,7 +63,7 @@ pullBranch repo@(ReadGitRepo uri) = do
   ifM (doesDirectoryExist localPath)
     -- try to update existing directory
     (ifM (isGitRepo localPath)
-      (checkoutExisting localPath)
+      (checkoutExisting localPath Nothing)
       (throwError (GitError.UnrecognizableCacheDir repo localPath)))
     -- directory doesn't exist, so clone anew
     (checkOutNew localPath Nothing)
@@ -83,8 +83,11 @@ pullBranch repo@(ReadGitRepo uri) = do
     unless isGitDir . throwError $ GitError.UnrecognizableCheckoutDir repo localPath
 
   -- | Do a `git pull` on a cached repo.
-  checkoutExisting :: (MonadIO m, MonadCatch m, MonadError GitProtocolError m) => FilePath -> m ()
-  checkoutExisting localPath =
+  checkoutExisting :: (MonadIO m, MonadCatch m, MonadError GitProtocolError m)
+                   => FilePath
+                   -> Maybe Text
+                   -> m ()
+  checkoutExisting localPath maybeRemoteRef =
     ifM (isEmptyGitRepo localPath)
       -- I don't know how to properly update from an empty remote repo.
       -- As a heuristic, if this cached copy is empty, then the remote might
@@ -94,7 +97,7 @@ pullBranch repo@(ReadGitRepo uri) = do
       (catchIO
         (withStatus ("Updating cached copy of " ++ Text.unpack uri ++ " ...") $ do
           -- Fetch only the latest commit, we don't need history.
-          gitIn localPath (["fetch", "origin", "HEAD", "--quiet"] ++ ["--depth", "1"])
+          gitIn localPath (["fetch", "origin", remoteRef, "--quiet"] ++ ["--depth", "1"])
           -- Reset our branch to point at the latest code from the remote.
           gitIn localPath ["reset", "--hard", "--quiet", "FETCH_HEAD"]
           -- Wipe out any unwanted files which might be sitting around, but aren't in the commit.
@@ -102,6 +105,8 @@ pullBranch repo@(ReadGitRepo uri) = do
         (const $ goFromScratch))
 
     where
+      remoteRef :: Text
+      remoteRef = fromMaybe "HEAD" maybeRemoteRef
       goFromScratch :: (MonadIO m, MonadError GitProtocolError m) => m  ()
       goFromScratch = do wipeDir localPath; checkOutNew localPath Nothing
 

--- a/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
@@ -93,11 +93,12 @@ pullBranch repo@(ReadGitRepo uri) = do
       -- Otherwise proceed!
       (catchIO
         (withStatus ("Updating cached copy of " ++ Text.unpack uri ++ " ...") $ do
-          -- Fetch only the latest 
-          gitIn localPath (["fetch", "origin", "HEAD"] ++ ["--depth", "1"])
-          gitIn localPath ["reset", "--hard", "--quiet", "origin/HEAD"]
-          gitIn localPath ["clean", "-d", "--force", "--quiet"]
-          gitIn localPath ["pull", "--force", "--quiet"])
+          -- Fetch only the latest commit, we don't need history.
+          gitIn localPath (["fetch", "origin", "HEAD", "--quiet"] ++ ["--depth", "1"])
+          -- Reset our branch to point at the latest code from the remote.
+          gitIn localPath ["reset", "--hard", "--quiet", "FETCH_HEAD"]
+          -- Wipe out any unwanted files which might be sitting around, but aren't in the commit.
+          gitIn localPath ["clean", "-d", "--force", "--quiet"])
         (const $ goFromScratch))
 
     where


### PR DESCRIPTION
## Overview

On trunk at the moment, if a git repo is found in the cache it will pull all the history from the current commit up to where the remote is at, when really we only care about the remote's HEAD, so we should just fetch that directly.

## Implementation notes

Rather than running a pull, we git fetch the latest commit only (`--depth 1`)

Because this also does a `git reset --hard` I think it'll also handle changing history better if someone rewrites history on the remote; I think the existing implementation might fail to pull & merge on non-fastforwards.

## Interesting/controversial decisions

Include anything that you thought twice about, debated, chose arbitrarily, etc. 
What could have been done differently, but wasn't? And why?

## Test coverage

Tested manually with both no repo, a repo with updates, and a dirty local repo.
