### PR TITLE
fix getCurrentDirectory

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -58,3 +58,4 @@ The format for this list: name, GitHub handle, and then optional blurb about wha
 * David Smith (@shmish111)
 * Chris Penner (@ChrisPenner)
 * Rebecca Mark (@rlmark)
+* Evan Minsk (@iamevn)

--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -1596,7 +1596,7 @@ declareForeigns = do
        temp <- getTemporaryDirectory
        createTempDirectory temp prefix
 
-  declareForeign "IO.getCurrentDirectory.impl.v3" direct
+  declareForeign "IO.getCurrentDirectory.impl.v3" unitToEFBox
     . mkForeignIOF $ \() -> getCurrentDirectory
 
   declareForeign "IO.setCurrentDirectory.impl.v3" boxToEF0

--- a/unison-src/transcripts/io.md
+++ b/unison-src/transcripts/io.md
@@ -201,6 +201,40 @@ testSystemTime _ =
 .> io.test testSystemTime
 ```
 
+### Get temp directory
+
+```unison:hide
+testGetTempDirectory : '{io2.IO} [Result]
+testGetTempDirectory _ =
+  test = 'let
+    tempDir = reraise !getTempDirectory.impl
+    check "Temp directory is directory" (isDirectory tempDir)
+    check "Temp directory should exist" (fileExists tempDir)
+  runTest test
+```
+
+```ucm
+.> add
+.> io.test testGetTempDirectory
+```
+
+### Get current directory
+
+```unison:hide
+testGetCurrentDirectory : '{io2.IO} [Result]
+testGetCurrentDirectory _ =
+  test = 'let
+    currentDir = reraise !getCurrentDirectory.impl
+    check "Current directory is directory" (isDirectory currentDir)
+    check "Current directory should exist" (fileExists currentDir)
+  runTest test
+```
+
+```ucm
+.> add
+.> io.test testGetCurrentDirectory
+```
+
 ### Get directory contents
 
 ```unison:hide

--- a/unison-src/transcripts/io.output.md
+++ b/unison-src/transcripts/io.output.md
@@ -312,6 +312,70 @@ testSystemTime _ =
   Tip: Use view testSystemTime to view the source of a test.
 
 ```
+### Get temp directory
+
+```unison
+testGetTempDirectory : '{io2.IO} [Result]
+testGetTempDirectory _ =
+  test = 'let
+    tempDir = reraise !getTempDirectory.impl
+    check "Temp directory is directory" (isDirectory tempDir)
+    check "Temp directory should exist" (fileExists tempDir)
+  runTest test
+```
+
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    testGetTempDirectory : '{IO} [Result]
+
+.> io.test testGetTempDirectory
+
+    New test results:
+  
+  ◉ testGetTempDirectory   Temp directory is directory
+  ◉ testGetTempDirectory   Temp directory should exist
+  
+  ✅ 2 test(s) passing
+  
+  Tip: Use view testGetTempDirectory to view the source of a
+       test.
+
+```
+### Get current directory
+
+```unison
+testGetCurrentDirectory : '{io2.IO} [Result]
+testGetCurrentDirectory _ =
+  test = 'let
+    currentDir = reraise !getCurrentDirectory.impl
+    check "Current directory is directory" (isDirectory currentDir)
+    check "Current directory should exist" (fileExists currentDir)
+  runTest test
+```
+
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    testGetCurrentDirectory : '{IO} [Result]
+
+.> io.test testGetCurrentDirectory
+
+    New test results:
+  
+  ◉ testGetCurrentDirectory   Current directory is directory
+  ◉ testGetCurrentDirectory   Current directory should exist
+  
+  ✅ 2 test(s) passing
+  
+  Tip: Use view testGetCurrentDirectory to view the source of a
+       test.
+
+```
 ### Get directory contents
 
 ```unison


### PR DESCRIPTION
Trying to use `base.io.getCurrentDirectory` results in the following before this change:

```
.> view getCurrentDirectory

  base.io.getCurrentDirectory : '{IO, Exception} FilePath
  base.io.getCurrentDirectory = compose (compose FilePath reraise) getCurrentDirectory.impl

.> view printCurrentDir

  printCurrentDir : '{IO, Exception} ()
  printCurrentDir = compose (compose printLine FilePath.toText) getCurrentDirectory

.> run printCurrentDir

  applying non-function: Foreign (Wrap ##Text "/home/evan/unison")
```

After this change:
```
.> run printCurrentDir
/home/evan/unison
```

Not sure what tests to write, could I get some pointers for what would be most useful here?