### PR TITLE
Fix duplicate find_type(_mentions)_index entries

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Sync22.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Sync22.hs
@@ -341,7 +341,7 @@ trySync tCache hCache oCache cCache = \case
 
     -- Assert that a reference's component is already synced, and return the corresponding reference.
     expectSyncedObjectReference :: Sqlite.Reference -> m Sqlite.Reference
-    expectSyncedObjectReference ref = undefined
+    expectSyncedObjectReference ref =
       isSyncedObjectReference ref <&> \case
         Nothing -> error (reportBug "E452280" ("unsynced object reference " ++ show ref))
         Just ref' -> ref'

--- a/codebase2/codebase-sqlite/package.yaml
+++ b/codebase2/codebase-sqlite/package.yaml
@@ -26,6 +26,7 @@ dependencies:
   - unison-codebase
   - unison-codebase-sync
   - unison-core
+  - unison-prelude
   - unison-util
   - unison-util-serialization
   - unison-util-term

--- a/codebase2/codebase-sqlite/unison-codebase-sqlite.cabal
+++ b/codebase2/codebase-sqlite/unison-codebase-sqlite.cabal
@@ -3,8 +3,6 @@ cabal-version: 1.12
 -- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: 3106bd32bedf162883882818669a81a3e1ca7c60af26ec9cd945fadb39f0d5aa
 
 name:           unison-codebase-sqlite
 version:        0.0.0
@@ -63,6 +61,7 @@ library
     , unison-codebase
     , unison-codebase-sync
     , unison-core
+    , unison-prelude
     , unison-util
     , unison-util-serialization
     , unison-util-term


### PR DESCRIPTION
## Overview

This PR fixes #2332.

We had duplicate rows in the `find_type_index` and `find_type_mentions_index` due to code that looked like:

```
for each member of a component,
  do some per-member stuff
  copy over the whole component's index rows
```

which was de-dented to become

```
for each member of a component,
  do some per-member stuff
copy over the whole component's index rows
```

Additionally, to guard against syncing from old databases that have this property, we now `nubOrd` the list index rows before copying over. As mentioned in a comment in the source, this could also be accomplished by putting a unique index on the index tables for the whole 6-tuple, if we want to do that some day.

## Test coverage

No automated tests were added. I did manually confirm this PR passes the Stew Test from #2332:

```
sqlite> select count(*) from find_type_index;
19206
sqlite> select count(*) from (select distinct type_reference_builtin,type_reference_hash_id,type_reference_component_index, term_referent_object_id,term_referent_component_index ,term_referent_constructor_index from find_type_index);
19206
sqlite> select count(*) from find_type_mentions_index;
112326
sqlite> select count(*) from (select distinct type_reference_builtin,type_reference_hash_id,type_reference_component_index, term_referent_object_id,term_referent_component_index ,term_referent_constructor_index from find_type_mentions_index);
112326
```

Note we have two pairs of equal numbers. Previously, the `count(*)` was far greater than the distinct `count(*)` on this database I'm testing against.
