### PR TITLE
update error message to match cli flag: "-codebase" -> "--codebase"

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Init.hs
+++ b/parser-typechecker/src/Unison/Codebase/Init.hs
@@ -138,7 +138,7 @@ openNewUcmCodebaseOrExit cbInit debugName path = do
       Codebase.installUcmDependencies codebase
       pure x
 
--- | try to init a codebase where none exists and then exit regardless (i.e. `ucm -codebase dir init`)
+-- | try to init a codebase where none exists and then exit regardless (i.e. `ucm --codebase dir init`)
 initCodebaseAndExit :: MonadIO m => Init m Symbol Ann -> DebugName -> Maybe CodebasePath -> m () 
 initCodebaseAndExit i debugName mdir =
   void $ openNewUcmCodebaseOrExit i debugName =<< Codebase.getCodebaseDir mdir

--- a/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
@@ -289,7 +289,7 @@ run dir configFile stanzas codebase = do
           "\128721", "",
           "The transcript failed due to an error in the stanza above. The error is:", "",
           Text.pack msg, "",
-          "Run `" <> Text.pack executable <> " -codebase " <> Text.pack dir <> "` " <> "to do more work with it."]
+          "Run `" <> Text.pack executable <> " --codebase " <> Text.pack dir <> "` " <> "to do more work with it."]
 
       dieUnexpectedSuccess :: IO ()
       dieUnexpectedSuccess = do
@@ -302,7 +302,7 @@ run dir configFile stanzas codebase = do
           transcriptFailure out $ Text.unlines [
             "\128721", "",
             "The transcript was expecting an error in the stanza above, but did not encounter one.", "",
-            "Run `" <> Text.pack executable <> " -codebase " <> Text.pack dir <> "` " <> "to do more work with it."]
+            "Run `" <> Text.pack executable <> " --codebase " <> Text.pack dir <> "` " <> "to do more work with it."]
 
       loop state = do
         writeIORef pathRef (view HandleInput.currentPath state)

--- a/unison-src/transcripts/hello.md
+++ b/unison-src/transcripts/hello.md
@@ -13,7 +13,7 @@ The format is just a regular markdown file with some fenced code blocks that are
 $ ucm transcript hello.md
 ```
 
-This runs it on a freshly generated empty codebase. Alternately `ucm transcript.fork -codebase /path/to/code hello.md` runs the transcript on a freshly generated copy of the provided codebase. Do `ucm help` to learn more about usage.
+This runs it on a freshly generated empty codebase. Alternately `ucm transcript.fork --codebase /path/to/code hello.md` runs the transcript on a freshly generated copy of the provided codebase. Do `ucm help` to learn more about usage.
 
 Fenced code blocks of type `unison` and `ucm` are treated specially:
 

--- a/unison-src/transcripts/hello.output.md
+++ b/unison-src/transcripts/hello.output.md
@@ -10,7 +10,7 @@ $ ucm transcript hello.md
 
 ```
 
-This runs it on a freshly generated empty codebase. Alternately `ucm transcript.fork -codebase /path/to/code hello.md` runs the transcript on a freshly generated copy of the provided codebase. Do `ucm help` to learn more about usage.
+This runs it on a freshly generated empty codebase. Alternately `ucm transcript.fork --codebase /path/to/code hello.md` runs the transcript on a freshly generated copy of the provided codebase. Do `ucm help` to learn more about usage.
 
 Fenced code blocks of type `unison` and `ucm` are treated specially:
 


### PR DESCRIPTION
When an transcript errors, an error message is printed that ends in:
```
Run `ucm -codebase /tmp/transcript-18a0ab44dc0f8f92` to do more work with it.
```

Trying to run that command results in:
```
Invalid option `-codebase'
```

This PR changes "-codebase" -> "--codebase" in this error message, in comments, and in transcripts. I couldn't find any other flags that need a similar update.