### PR TITLE
TermPrinter: Use Referent for terms

### DIFF
--- a/parser-typechecker/src/Unison/CommandLine/DisplayValues.hs
+++ b/parser-typechecker/src/Unison/CommandLine/DisplayValues.hs
@@ -316,10 +316,10 @@ displayDoc pped terms typeOf evaluated types = go
 
 termName :: PPE.PrettyPrintEnv -> Referent -> Pretty
 termName ppe r = P.syntaxToColor $
-  NP.styleHashQualified'' (NP.fmt $ S.Referent r) name
+  NP.styleHashQualified'' (NP.fmt $ S.TermReference r) name
   where name = PPE.termName ppe r
 
 typeName :: PPE.PrettyPrintEnv -> Reference -> Pretty
 typeName ppe r = P.syntaxToColor $
-  NP.styleHashQualified'' (NP.fmt $ S.Reference r) name
+  NP.styleHashQualified'' (NP.fmt $ S.TypeReference r) name
   where name = PPE.typeName ppe r

--- a/parser-typechecker/src/Unison/DeclPrinter.hs
+++ b/parser-typechecker/src/Unison/DeclPrinter.hs
@@ -80,7 +80,7 @@ prettyPattern
   -> Int
   -> Pretty SyntaxText
 prettyPattern env ctorType ref namespace cid = styleHashQualified''
-  (fmt (S.Referent conRef))
+  (fmt (S.TermReference conRef))
   ( HQ.stripNamespace (fromMaybe "" $ Name.toText <$> HQ.toName namespace)
   $ PPE.termName env conRef
   )
@@ -110,7 +110,7 @@ prettyDataDecl (PrettyPrintEnvDecl unsuffixifiedPPE suffixifiedPPE) r name dd =
                         <> P.sep ((fmt S.DelimiterChar ",") <> " " `P.orElse` "\n      ")
                                  (field <$> zip fs (init ts))
                         <> (fmt S.DelimiterChar " }")
-  field (fname, typ) = P.group $ styleHashQualified'' (fmt (S.Reference r)) fname <>
+  field (fname, typ) = P.group $ styleHashQualified'' (fmt (S.TypeReference r)) fname <>
     (fmt S.TypeAscriptionColon " :") `P.hang` TypePrinter.prettyRaw suffixifiedPPE Map.empty (-1) typ
   header = prettyDataHeader name dd <> (fmt S.DelimiterChar (" = " `P.orElse` "\n  = "))
 

--- a/parser-typechecker/src/Unison/Server/Doc.hs
+++ b/parser-typechecker/src/Unison/Server/Doc.hs
@@ -189,9 +189,9 @@ renderDoc pped terms typeOf eval types tm = eval tm >>= \case
     DD.Doc2SpecialFormLink e -> let
       ppe = PPE.suffixifiedPPE pped
       tm :: Referent -> P.Pretty SSyntaxText
-      tm r = (NP.styleHashQualified'' (NP.fmt (S.Referent r)) . PPE.termName ppe) r
+      tm r = (NP.styleHashQualified'' (NP.fmt (S.TermReference r)) . PPE.termName ppe) r
       ty :: Reference -> P.Pretty SSyntaxText
-      ty r = (NP.styleHashQualified'' (NP.fmt (S.Reference r)) . PPE.typeName ppe) r
+      ty r = (NP.styleHashQualified'' (NP.fmt (S.TypeReference r)) . PPE.typeName ppe) r
       in Link <$> case e of
         DD.EitherLeft' (Term.TypeLink' r) -> (pure . formatPretty . ty) r
         DD.EitherRight' (DD.Doc2Term (Term.Referent' r)) -> (pure . formatPretty . tm) r
@@ -236,7 +236,7 @@ renderDoc pped terms typeOf eval types tm = eval tm >>= \case
         goType :: Reference -> m (Ref (UnisonHash, DisplayObject SyntaxText Src))
         goType r@(Reference.Builtin _) =
           pure (Type (Reference.toText r, DO.BuiltinObject name))
-          where name = formatPretty . NP.styleHashQualified (NP.fmt (S.Reference r))
+          where name = formatPretty . NP.styleHashQualified (NP.fmt (S.TypeReference r))
                      . PPE.typeName ppe $ r
         goType r = Type . (Reference.toText r,) <$> do
           d <- types r

--- a/parser-typechecker/src/Unison/Server/Syntax.hs
+++ b/parser-typechecker/src/Unison/Server/Syntax.hs
@@ -67,8 +67,8 @@ convertElement = \case
   SyntaxText.BooleanLiteral -> BooleanLiteral
   SyntaxText.Blank -> Blank
   SyntaxText.Var -> Var
-  SyntaxText.Referent r -> TermReference $ Referent.toText r
-  SyntaxText.Reference r -> TypeReference $ Reference.toText r
+  SyntaxText.TermReference r -> TermReference $ Referent.toText r
+  SyntaxText.TypeReference r -> TypeReference $ Reference.toText r
   SyntaxText.Op s -> Op s
   SyntaxText.AbilityBraces -> AbilityBraces
   SyntaxText.ControlKeyword -> ControlKeyword

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -182,7 +182,7 @@ pretty0
     Var' v -> parenIfInfix name ic $ styleHashQualified'' (fmt S.Var) name
       -- OK since all term vars are user specified, any freshening was just added during typechecking
       where name = elideFQN im $ HQ.unsafeFromVar (Var.reset v)
-    Ref' r -> parenIfInfix name ic $ styleHashQualified'' (fmt $ S.Reference r) name
+    Ref' r -> parenIfInfix name ic $ styleHashQualified'' (fmt $ S.Referent (Referent.Ref r)) name
       where name = elideFQN im $ PrettyPrintEnv.termName n (Referent.Ref r)
     TermLink' r -> paren (p >= 10) $
       fmt S.LinkKeyword "termLink " <>

--- a/parser-typechecker/src/Unison/TypePrinter.hs
+++ b/parser-typechecker/src/Unison/TypePrinter.hs
@@ -84,7 +84,7 @@ prettyRaw n im p tp = go n im p tp
     Var' v     -> fmt S.Var $ PP.text (Var.name v)
     DD.TupleType' xs | length xs /= 1 -> PP.parenthesizeCommas $ map (go n im 0) xs
     -- Would be nice to use a different SyntaxHighlights color if the reference is an ability.
-    Ref' r     -> styleHashQualified'' (fmt $ S.Reference r) $ elideFQN im (PrettyPrintEnv.typeName n r)
+    Ref' r     -> styleHashQualified'' (fmt $ S.TypeReference r) $ elideFQN im (PrettyPrintEnv.typeName n r)
     Cycle' _ _ -> fromString "error: TypeParser does not currently emit Cycle"
     Abs' _     -> fromString "error: TypeParser does not currently emit Abs"
     Ann' _ _   -> fromString "error: TypeParser does not currently emit Ann"

--- a/parser-typechecker/src/Unison/Util/ColorText.hs
+++ b/parser-typechecker/src/Unison/Util/ColorText.hs
@@ -130,8 +130,8 @@ defaultColors = \case
   ST.BooleanLiteral      -> Nothing
   ST.Blank               -> Nothing
   ST.Var                 -> Nothing
-  ST.Reference _         -> Nothing
-  ST.Referent _          -> Nothing
+  ST.TypeReference _     -> Nothing
+  ST.TermReference _     -> Nothing
   ST.Op _                -> Nothing
   ST.Unit                -> Nothing
   ST.AbilityBraces       -> Just HiBlack

--- a/parser-typechecker/src/Unison/Util/SyntaxText.hs
+++ b/parser-typechecker/src/Unison/Util/SyntaxText.hs
@@ -20,8 +20,8 @@ data Element r = NumericLiteral
              | BooleanLiteral
              | Blank
              | Var
-             | Reference r
-             | Referent (Referent' r)
+             | TypeReference r
+             | TermReference (Referent' r)
              | Op SeqOp
              | AbilityBraces
              -- let|handle|in|where|match|with|cases|->|if|then|else|and|or


### PR DESCRIPTION
## Overview
Fix a bug which manifested itself in the SyntaxText of the Codebase
server where references to terms, where using TypeReference instead of
TermReference. 

Fixes: https://github.com/unisonweb/unison/issues/2154

## Implementation notes
This was due to using a Reference instead of a Referent.

## Loose ends
@pchiusano you'd mentioned on https://github.com/unisonweb/unison/issues/2154 to change the constructors to be more explicit, but I wasn't sure exactly which constructors might change.
