### PR TITLE
`@signature{blah}` now correctly renders `blah` as a clickable link

### DIFF
--- a/parser-typechecker/src/Unison/CommandLine/DisplayValues.hs
+++ b/parser-typechecker/src/Unison/CommandLine/DisplayValues.hs
@@ -234,7 +234,7 @@ displayPretty pped terms typeOf eval types tm = go tm
     Just typ -> pure . P.group $
       TypePrinter.prettySignatures
         (PPE.suffixifiedPPE pped)
-        [(PPE.termName (PPE.suffixifiedPPE pped) r, typ)]
+        [(r, PPE.termName (PPE.suffixifiedPPE pped) r, typ)]
 
   goColor c = case c of
     DD.AnsiColorBlack -> P.black
@@ -295,7 +295,7 @@ displayDoc pped terms typeOf evaluated types = go
     Just typ -> pure . P.group $
       TypePrinter.prettySignatures
         (PPE.suffixifiedPPE pped)
-        [(PPE.termName (PPE.unsuffixifiedPPE pped) r, typ)]
+        [(r, PPE.termName (PPE.unsuffixifiedPPE pped) r, typ)]
   prettyEval terms r = case r of
     Referent.Ref (Reference.Builtin n) -> pure . P.syntaxToColor $ P.text n
     Referent.Ref ref ->

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -1259,8 +1259,8 @@ displayTestResults showTip ppe oksUnsorted failsUnsorted = let
 unsafePrettyTermResultSig' :: Var v =>
   PPE.PrettyPrintEnv -> SR'.TermResult' v a -> Pretty
 unsafePrettyTermResultSig' ppe = \case
-  SR'.TermResult' name (Just typ) _r _aliases ->
-    head (TypePrinter.prettySignatures' ppe [(name,typ)])
+  SR'.TermResult' name (Just typ) r _aliases ->
+    head (TypePrinter.prettySignatures' ppe [(r,name,typ)])
   _ -> error "Don't pass Nothing"
 
 -- produces:
@@ -1379,7 +1379,7 @@ todoOutput ppe todo =
   corruptTypes =
     [ (PPE.typeName ppeu r, r) | (r, MissingObject _) <- frontierTypes ]
   goodTerms ts =
-    [ (PPE.termName ppeu (Referent.Ref r), typ) | (r, Just typ) <- ts ]
+    [ (Referent.Ref r, PPE.termName ppeu (Referent.Ref r), typ) | (r, Just typ) <- ts ]
   todoConflicts = if TO.noConflicts todo then mempty else P.lines . P.nonEmpty $
     [ renderEditConflicts ppeu (TO.editConflicts todo)
     , renderNameConflicts conflictedTypeNames conflictedTermNames ]

--- a/parser-typechecker/src/Unison/Server/Doc.hs
+++ b/parser-typechecker/src/Unison/Server/Doc.hs
@@ -163,7 +163,7 @@ renderDoc pped terms typeOf eval types tm = eval tm >>= \case
     Just types -> pure . fmap P.group $
       TypePrinter.prettySignatures''
         (PPE.suffixifiedPPE pped)
-        [ (PPE.termName (PPE.suffixifiedPPE pped) r, ty) | (r,ty) <- zip rs types]
+        [ (r, PPE.termName (PPE.suffixifiedPPE pped) r, ty) | (r,ty) <- zip rs types]
 
   goSpecial :: Term v () -> m SpecialForm
   goSpecial = \case
@@ -266,7 +266,8 @@ renderDoc pped terms typeOf eval types tm = eval tm >>= \case
                   Just tm -> do
                     typ <- fromMaybe (Type.builtin() "unknown") <$> typeOf (Referent.Ref ref)
                     let name = PPE.termName ppe (Referent.Ref ref)
-                    let folded = formatPretty . P.lines $ TypePrinter.prettySignatures'' ppe [(name, typ)]
+                    let folded = formatPretty . P.lines 
+                               $ TypePrinter.prettySignatures'' ppe [(Referent.Ref ref, name, typ)]
                     let full tm@(Term.Ann' _ _) _ =
                           formatPretty (TermPrinter.prettyBinding ppe name tm)
                         full tm typ =


### PR DESCRIPTION
Previously this wasn't hyperlinked (see for example https://share.unison-lang.org/@mb2bmao6r5c17uu14ulp8n4ui0aoe1eaquhh59ro64oouiujaica1oh583okjdjvujogn6jjbfh4t7r1ubi6h43pl06quiajgj57g10/terms/unison/async/Async/doc) and try clicking on the signatures at the top.

`@signature` gets used frequently when writing overview docs that give the signatures of key functions in the library, and those definitions should be clickable.

`@source{blah}` should probably get the same treatment but I'm leaving that for a separate PR.

__Old n' busted__

https://user-images.githubusercontent.com/11074/139127473-583ca267-7149-4aa9-984a-2f54f3b3b714.mov

__After this PR__

https://user-images.githubusercontent.com/11074/139126888-5537fd23-96c1-4408-b531-5602baa74771.mov

