### PR TITLE
Run integration tests in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,5 +103,7 @@ jobs:
           x=`git status --porcelain -uno` bash -c 'if [[ -n $x ]]; then echo "$x" && false; fi'
       - name: prettyprint-round-trip
         run: stack --no-terminal exec unison transcript unison-src/transcripts-round-trip/main.md
+      - name: integration-tests
+        run: stack --no-terminal exec integration-tests
       - name: other test suites
         run: stack --no-terminal test unison-util-relation


### PR DESCRIPTION
This has CI run the integration tests added in https://github.com/unisonweb/unison/pull/2543 by @satotake. Thanks @satotake. 

The tests take 130 seconds to run on my machine. I'm guessing that could be sped up, either by trimming the transcripts to rely on less code, or having multiple tests share a codebase rather than recreating it every time.

Regardless, I think this is a good thing to add to CI.