### PR TITLE
Fixes rogue names being displayed in Codebase server

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -47,6 +47,7 @@ import qualified Unison.Util.Free as Free
 import Unison.Var (Var)
 import qualified Unison.WatchKind as WK
 import Web.Browser (openBrowser)
+import qualified Unison.Codebase.Path as Path
 
 typecheck
   :: (Monad m, Var v)
@@ -178,11 +179,13 @@ commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSour
     AppendToReflog reason old new -> lift $ Codebase.appendReflog codebase reason old new
     LoadReflog -> lift $ Codebase.getReflog codebase
     CreateAuthorInfo t -> AuthorInfo.createAuthorInfo Ann.External t
-    HQNameQuery mayPath branch query ->
-      lift $ Backend.hqNameQuery mayPath branch codebase query
+    HQNameQuery mayPath branch query -> do
+      let namingScope = Backend.AllNames $ fromMaybe Path.empty mayPath
+      lift $ Backend.hqNameQuery namingScope branch codebase query
     LoadSearchResults srs -> lift $ Backend.loadSearchResults codebase srs
-    GetDefinitionsBySuffixes mayPath branch query ->
-      lift . runExceptT $ Backend.definitionsBySuffixes mayPath branch codebase query
+    GetDefinitionsBySuffixes mayPath branch query -> do
+      let namingScope = Backend.AllNames $ fromMaybe Path.empty mayPath
+      lift . runExceptT $ Backend.definitionsBySuffixes namingScope branch codebase query
     FindShallow path -> lift . runExceptT $ Backend.findShallow codebase path
     MakeStandalone ppe ref out -> lift $ do
       let cl = Codebase.toCodeLookup codebase

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -243,7 +243,7 @@ loop = do
       getHQ'Types p = BranchUtil.getType (resolveSplit' p) root0
 
       basicPrettyPrintNames =
-        Backend.basicPrettyPrintNames root' (Path.unabsolute currentPath')
+        Backend.basicPrettyPrintNames root' (Backend.AllNames $ Path.unabsolute currentPath')
 
       resolveHHQS'Types :: HashOrHQSplit' -> Action' m v (Set Reference)
       resolveHHQS'Types = either
@@ -274,7 +274,7 @@ loop = do
             L.Hash sh -> Just (HQ.HashOnly sh)
             _         -> Nothing
           hqs = Set.fromList . mapMaybe (getHQ . L.payload) $ tokens
-        let parseNames = Backend.getCurrentParseNames currentPath'' root'
+        let parseNames = Backend.getCurrentParseNames (Backend.AllNames currentPath'') root'
         latestFile .= Just (Text.unpack sourceName, False)
         latestTypecheckedFile .= Nothing
         Result notes r <- eval $ Typecheck ambient parseNames sourceName lexed
@@ -1172,7 +1172,7 @@ loop = do
                   LatestFileLocation ->
                     fmap fst latestFile' <|> Just "scratch.u"
                 printNames =
-                  Backend.getCurrentPrettyNames currentPath'' root'
+                  Backend.getCurrentPrettyNames (Backend.AllNames currentPath'') root'
                 ppe = PPE.fromNamesDecl hqLength printNames
             unless (null types && null terms) $
               eval . Notify $
@@ -1196,7 +1196,7 @@ loop = do
             ppe = Backend.basicSuffixifiedNames
                            sbhLength
                            root'
-                           (Path.fromPath' pathArg)
+                           (Backend.AllNames $ Path.fromPath' pathArg)
         res <- eval $ FindShallow pathArgAbs
         case res of
           Left e -> handleBackendError e
@@ -2281,7 +2281,7 @@ getMetadataFromName name = do
     getPPE = do
       currentPath' <- use currentPath
       sbhLength <- eval BranchHashLength
-      Backend.basicSuffixifiedNames sbhLength <$> use root <*> pure (Path.unabsolute currentPath')
+      Backend.basicSuffixifiedNames sbhLength <$> use root <*> pure (Backend.AllNames $ Path.unabsolute currentPath')
 
 -- | Get the set of terms related to a hash-qualified name.
 getHQTerms :: HQ.HashQualified Name -> Action' m v (Set Referent)
@@ -2881,7 +2881,7 @@ basicNames' :: Functor m => Action' m v (Names, Names)
 basicNames' = do
   root' <- use root
   currentPath' <- use currentPath
-  pure $ Backend.basicNames' root' (Path.unabsolute currentPath')
+  pure $ Backend.basicNames' root' (Backend.AllNames $ Path.unabsolute currentPath')
 
 data AddRunMainResult v
   = NoTermWithThatName

--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# OPTIONS_GHC -Wno-unused-local-binds #-}
 
 module Unison.Server.Backend where
 

--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -Wno-unused-local-binds #-}
 
 module Unison.Server.Backend where
 
@@ -92,6 +93,8 @@ import qualified Unison.Codebase.Editor.DisplayObject as DisplayObject
 import qualified Unison.WatchKind as WK
 import qualified Unison.PrettyPrintEnv.Util as PPE
 import qualified Unison.Hashing.V2.Convert as Hashing
+import Unison.Util.AnnotatedText (AnnotatedText)
+import qualified Unison.Util.Monoid as Monoid
 
 type SyntaxText = UST.SyntaxText' Reference
 
@@ -121,10 +124,17 @@ data BackendError
 
 type Backend m a = ExceptT BackendError m a
 
+
 -- implementation detail of basicParseNames and basicPrettyPrintNames
-basicNames' :: Branch m -> Path -> (Names, Names)
-basicNames' root path = (parseNames0, prettyPrintNames0)
+basicNames' :: Branch m -> NameScoping -> (Names, Names)
+basicNames' root scope =
+  (parseNames0, prettyPrintNames0)
   where
+    path :: Path
+    includeAllNames :: Bool
+    (path, includeAllNames) = case scope of
+      AllNamesRelativeTo   path -> (path, True)
+      OnlyNamesContainedIn path -> (path, False)
     root0 = Branch.head root
     currentBranch = fromMaybe Branch.empty $ Branch.getAt path root
     absoluteRootNames = Names.makeAbsolute (Branch.toNames root0)
@@ -142,19 +152,21 @@ basicNames' root path = (parseNames0, prettyPrintNames0)
           Path.Path (toList -> []) -> const mempty
           p -> Names.prefix0 (Path.toName p)
     -- parsing should respond to local and absolute names
-    parseNames0 = currentPathNames <> absoluteRootNames
+    parseNames0 = currentPathNames <> Monoid.whenM includeAllNames absoluteRootNames
     -- pretty-printing should use local names where available
-    prettyPrintNames0 = currentAndExternalNames
+    prettyPrintNames0 = if includeAllNames
+                           then currentAndExternalNames
+                           else currentPathNames
 
-basicSuffixifiedNames :: Int -> Branch m -> Path -> PPE.PrettyPrintEnv
-basicSuffixifiedNames hashLength root path =
-  let names0 = basicPrettyPrintNames root path
+basicSuffixifiedNames :: Int -> Branch m -> NameScoping -> PPE.PrettyPrintEnv
+basicSuffixifiedNames hashLength root nameScope =
+  let names0 = basicPrettyPrintNames root nameScope
    in PPE.suffixifiedPPE . PPE.fromNamesDecl hashLength $ NamesWithHistory names0 mempty
 
-basicPrettyPrintNames :: Branch m -> Path -> Names
+basicPrettyPrintNames :: Branch m -> NameScoping -> Names
 basicPrettyPrintNames root = snd . basicNames' root
 
-basicParseNames :: Branch m -> Path -> Names
+basicParseNames :: Branch m -> NameScoping -> Names
 basicParseNames root = fst . basicNames' root
 
 loadReferentType ::
@@ -219,7 +231,7 @@ fuzzyFind
 fuzzyFind path branch query =
   let
     printNames =
-      basicPrettyPrintNames branch path
+      basicPrettyPrintNames branch (AllNamesRelativeTo path)
 
     fzfNames =
       Names.fuzzyFind (words query) printNames
@@ -265,8 +277,7 @@ findShallowReadmeInBranchAndRender ::
   Backend IO (Maybe Doc.Doc)
 findShallowReadmeInBranchAndRender width runtime codebase branch =
   let ppe hqLen = PPE.fromNamesDecl hqLen printNames
-
-      printNames = getCurrentPrettyNames (Path.fromList []) branch
+      printNames = getCurrentPrettyNames (OnlyNamesContainedIn $ Path.fromList []) branch
 
       renderReadme ppe r = do
         res <- renderDoc ppe width runtime codebase (Referent.toReference r)
@@ -442,12 +453,16 @@ termReferentsByShortHash codebase sh = do
 -- currentPathNames :: Path -> Names
 -- currentPathNames = Branch.toNames . Branch.head . Branch.getAt
 
-getCurrentPrettyNames :: Path -> Branch m -> NamesWithHistory
-getCurrentPrettyNames path root =
-  NamesWithHistory (basicPrettyPrintNames root path) mempty
+data NameScoping =
+      AllNamesRelativeTo   Path
+    | OnlyNamesContainedIn Path
 
-getCurrentParseNames :: Path -> Branch m -> NamesWithHistory
-getCurrentParseNames path root = NamesWithHistory (basicParseNames root path) mempty
+getCurrentPrettyNames :: NameScoping -> Branch m -> NamesWithHistory
+getCurrentPrettyNames scope root =
+  NamesWithHistory (basicPrettyPrintNames root scope) mempty
+
+getCurrentParseNames :: NameScoping -> Branch m -> NamesWithHistory
+getCurrentParseNames scope root = NamesWithHistory (basicParseNames root scope) mempty
 
 -- Any absolute names in the input which have `root` as a prefix
 -- are converted to names relative to current path. All other names are
@@ -515,12 +530,12 @@ applySearch Search {lookupNames, lookupRelativeHQRefs', makeResult, matchesNamed
 
 hqNameQuery
   :: Monad m
-  => Maybe Path
+  => NameScoping
   -> Branch m
   -> Codebase m v Ann
   -> [HQ.HashQualified Name]
   -> m QueryResult
-hqNameQuery relativeTo root codebase hqs = do
+hqNameQuery namesScope root codebase hqs = do
   -- Split the query into hash-only and hash-qualified-name queries.
   let (hashes, hqnames) = partitionEithers (map HQ'.fromHQ2 hqs)
   -- Find the terms with those hashes.
@@ -535,8 +550,7 @@ hqNameQuery relativeTo root codebase hqs = do
   -- The hq-name search needs a hash-qualifier length
   hqLength <- Codebase.hashLength codebase
   -- We need to construct the names that we want to use / search by.
-  let currentPath = fromMaybe Path.empty relativeTo
-      parseNames = getCurrentParseNames currentPath root
+  let parseNames = getCurrentParseNames namesScope root
       mkTermResult sh r = SR.termResult (HQ.HashOnly sh) r Set.empty
       mkTypeResult sh r = SR.typeResult (HQ.HashOnly sh) r Set.empty
       -- Transform the hash results a bit
@@ -627,7 +641,7 @@ mungeSyntaxText = fmap Syntax.convertElement
 prettyDefinitionsBySuffixes
   :: forall v
    . Var v
-  => Maybe Path
+  => NameScoping
   -> Maybe Branch.Hash
   -> Maybe Width
   -> Suffixify
@@ -635,10 +649,10 @@ prettyDefinitionsBySuffixes
   -> Codebase IO v Ann
   -> [HQ.HashQualified Name]
   -> Backend IO DefinitionDisplayResults
-prettyDefinitionsBySuffixes relativeTo root renderWidth suffixifyBindings rt codebase query
+prettyDefinitionsBySuffixes namesScope root renderWidth suffixifyBindings rt codebase query
   = do
     branch                               <- resolveBranchHash root codebase
-    DefinitionResults terms types misses <- definitionsBySuffixes relativeTo
+    DefinitionResults terms types misses <- definitionsBySuffixes namesScope
                                                                   branch
                                                                   codebase
                                                                   query
@@ -648,9 +662,9 @@ prettyDefinitionsBySuffixes relativeTo root renderWidth suffixifyBindings rt cod
     -- doesn't.
     let
       printNames =
-        getCurrentPrettyNames (fromMaybe Path.empty relativeTo) branch
+        getCurrentPrettyNames namesScope branch
       parseNames =
-        getCurrentParseNames (fromMaybe Path.empty relativeTo) branch
+        getCurrentParseNames namesScope branch
       ppe   = PPE.fromNamesDecl hqLength printNames
       width = mayDefaultWidth renderWidth
       isAbsolute (Name.toText -> n) = "." `Text.isPrefixOf` n && n /= "."
@@ -691,6 +705,13 @@ prettyDefinitionsBySuffixes relativeTo root renderWidth suffixifyBindings rt cod
         -- render all the docs
         join <$> traverse (renderDoc ppe width rt codebase) docs
 
+      mkTermDefinition ::
+        ( Reference ->
+          DisplayObject
+            (AnnotatedText (UST.Element Reference))
+            (AnnotatedText (UST.Element Reference)) ->
+          ExceptT BackendError IO TermDefinition
+        )
       mkTermDefinition r tm = do
         ts <- lift (Codebase.getTypeOfTerm codebase r)
         let bn = bestNameForTerm @v (PPE.suffixifiedPPE ppe) width (Referent.Ref r)
@@ -814,15 +835,15 @@ definitionsBySuffixes
   :: forall m v
    . (MonadIO m)
   => Var v
-  => Maybe Path
+  => NameScoping
   -> Branch m
   -> Codebase m v Ann
   -> [HQ.HashQualified Name]
   -> Backend m (DefinitionResults v)
-definitionsBySuffixes relativeTo branch codebase query = do
+definitionsBySuffixes namesScope branch codebase query = do
   -- First find the hashes by name and note any query misses.
   QueryResult misses results <- lift
-    $ hqNameQuery relativeTo branch codebase query
+    $ hqNameQuery namesScope branch codebase query
   -- Now load the terms/types for those hashes.
   results' <- lift $ loadSearchResults codebase results
   let termTypes :: Map.Map Reference (Type v Ann)

--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -669,23 +669,30 @@ prettyDefinitionsBySuffixes namesScope root renderWidth suffixifyBindings rt cod
     let
       printNames =
         getCurrentPrettyNames namesScope branch
+
       parseNames =
         getCurrentParseNames namesScope branch
-      ppe   = PPE.fromNamesDecl hqLength printNames
-      width = mayDefaultWidth renderWidth
-      isAbsolute (Name.toText -> n) = "." `Text.isPrefixOf` n && n /= "."
+
+      ppe =
+        PPE.fromNamesDecl hqLength printNames
+
+      width =
+        mayDefaultWidth renderWidth
+
       termFqns :: Map Reference (Set Text)
       termFqns = Map.mapWithKey f terms
        where
         rel = Names.terms $ currentNames parseNames
-        f k _ = Set.fromList . fmap Name.toText . filter isAbsolute . toList
+        f k _ = Set.fromList . fmap Name.toText . toList
               $ R.lookupRan (Referent.Ref k) rel
+
       typeFqns :: Map Reference (Set Text)
       typeFqns = Map.mapWithKey f types
        where
         rel = Names.types $ currentNames parseNames
-        f k _ = Set.fromList . fmap Name.toText . filter isAbsolute . toList
+        f k _ = Set.fromList . fmap Name.toText . toList
               $ R.lookupRan k rel
+
       flatten = Set.toList . fromMaybe Set.empty
 
       docNames :: Set (HQ'.HashQualified Name) -> [Name]

--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -230,7 +230,7 @@ fuzzyFind
 fuzzyFind path branch query =
   let
     printNames =
-      basicPrettyPrintNames branch (AllNames path)
+      basicPrettyPrintNames branch (Within path)
 
     fzfNames =
       Names.fuzzyFind (words query) printNames

--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -462,6 +462,10 @@ data NameScoping =
       -- | Filter returned names to only include names within this path.
     | Within   Path
 
+toAllNames :: NameScoping -> NameScoping
+toAllNames (AllNames p) = AllNames p
+toAllNames (Within p) = AllNames p
+
 getCurrentPrettyNames :: NameScoping -> Branch m -> NamesWithHistory
 getCurrentPrettyNames scope root =
   NamesWithHistory (basicPrettyPrintNames root scope) mempty
@@ -667,8 +671,11 @@ prettyDefinitionsBySuffixes namesScope root renderWidth suffixifyBindings rt cod
     -- the names in the pretty-printer, but the current implementation
     -- doesn't.
     let
+      -- We use printNames for names in source and parseNames to lookup
+      -- definitions, thus printNames use the allNames scope, to ensure
+      -- external references aren't hashes.
       printNames =
-        getCurrentPrettyNames namesScope branch
+        getCurrentPrettyNames (toAllNames namesScope) branch
 
       parseNames =
         getCurrentParseNames namesScope branch

--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -272,11 +272,11 @@ findShallowReadmeInBranchAndRender ::
   Width ->
   Rt.Runtime v ->
   Codebase IO v Ann ->
+  NamesWithHistory ->
   Branch IO ->
   Backend IO (Maybe Doc.Doc)
-findShallowReadmeInBranchAndRender width runtime codebase branch =
+findShallowReadmeInBranchAndRender width runtime codebase printNames namespaceBranch =
   let ppe hqLen = PPE.fromNamesDecl hqLen printNames
-      printNames = getCurrentPrettyNames (Within $ Path.fromList []) branch
 
       renderReadme ppe r = do
         res <- renderDoc ppe width runtime codebase (Referent.toReference r)
@@ -289,7 +289,7 @@ findShallowReadmeInBranchAndRender width runtime codebase branch =
       readmes :: Set Referent
       readmes = foldMap lookup toCheck
         where lookup seg = R.lookupRan seg rel
-              rel = Star3.d1 (Branch._terms (Branch.head branch))
+              rel = Star3.d1 (Branch._terms (Branch.head namespaceBranch))
    in do
         hqLen <- liftIO $ Codebase.hashLength codebase
         join <$> traverse (renderReadme (ppe hqLen)) (Set.lookupMin readmes)

--- a/parser-typechecker/src/Unison/Server/Endpoints/FuzzyFind.hs
+++ b/parser-typechecker/src/Unison/Server/Endpoints/FuzzyFind.hs
@@ -140,8 +140,7 @@ serveFuzzyFind h codebase mayRoot relativePath limit typeWidth query =
   addHeaders <$> do
     h
     rel <-
-      fromMaybe mempty
-      .   fmap Path.fromPath'
+      maybe mempty Path.fromPath'
       <$> traverse (parsePath . Text.unpack) relativePath
     hashLength <- liftIO $ Codebase.hashLength codebase
     ea         <- liftIO . runExceptT $ do
@@ -150,11 +149,12 @@ serveFuzzyFind h codebase mayRoot relativePath limit typeWidth query =
       let b0 = Branch.head branch
           alignments =
             take (fromMaybe 10 limit) $ Backend.fuzzyFind rel branch (fromMaybe "" query)
-          ppe = Backend.basicSuffixifiedNames hashLength branch (Backend.Within rel)
+          -- Use AllNames to render source
+          ppe = Backend.basicSuffixifiedNames hashLength branch (Backend.AllNames rel)
       join <$> traverse (loadEntry root (Just rel) ppe b0) alignments
     errFromEither backendError ea
  where
-  loadEntry _root _rel ppe b0 (a, (HQ'.NameOnly . NameSegment) -> n, refs) =
+  loadEntry _root _rel ppe b0 (a, HQ'.NameOnly . NameSegment -> n, refs) =
     for refs $
       \case
         Backend.FoundTermRef r ->

--- a/parser-typechecker/src/Unison/Server/Endpoints/FuzzyFind.hs
+++ b/parser-typechecker/src/Unison/Server/Endpoints/FuzzyFind.hs
@@ -150,7 +150,7 @@ serveFuzzyFind h codebase mayRoot relativePath limit typeWidth query =
       let b0 = Branch.head branch
           alignments =
             take (fromMaybe 10 limit) $ Backend.fuzzyFind rel branch (fromMaybe "" query)
-          ppe = Backend.basicSuffixifiedNames hashLength branch rel
+          ppe = Backend.basicSuffixifiedNames hashLength branch (Backend.Within rel)
       join <$> traverse (loadEntry root (Just rel) ppe b0) alignments
     errFromEither backendError ea
  where

--- a/parser-typechecker/src/Unison/Server/Endpoints/GetDefinitions.hs
+++ b/parser-typechecker/src/Unison/Server/Endpoints/GetDefinitions.hs
@@ -126,7 +126,7 @@ serveDefinitions h rt codebase mayRoot relativePath hqns width suff =
       fmap Path.fromPath' <$> traverse (parsePath . Text.unpack) relativePath
     ea <- liftIO . runExceptT $ do
       root <- traverse (Backend.expandShortBranchHash codebase) mayRoot
-      Backend.prettyDefinitionsBySuffixes rel
+      Backend.prettyDefinitionsBySuffixes (Backend.Within . fromMaybe Path.empty $ rel)
                                           root
                                           width
                                           (fromMaybe (Suffixify True) suff)

--- a/parser-typechecker/src/Unison/Server/Endpoints/GetDefinitions.hs
+++ b/parser-typechecker/src/Unison/Server/Endpoints/GetDefinitions.hs
@@ -119,21 +119,26 @@ serveDefinitions
   -> Maybe Width
   -> Maybe Suffixify
   -> Handler (APIHeaders DefinitionDisplayResults)
-serveDefinitions h rt codebase mayRoot relativePath hqns width suff =
+serveDefinitions h rt codebase mayRoot relativePath rawHqns width suff =
   addHeaders <$> do
     h
     rel <-
       fmap Path.fromPath' <$> traverse (parsePath . Text.unpack) relativePath
     ea <- liftIO . runExceptT $ do
       root <- traverse (Backend.expandShortBranchHash codebase) mayRoot
-      Backend.prettyDefinitionsBySuffixes (Backend.Within . fromMaybe Path.empty $ rel)
+      let hqns = HQ.unsafeFromText <$> rawHqns
+          scope = case hqns of
+            -- TODO: Change this API to support being queried by just 1 name/hash
+            HQ.HashOnly _ : _ -> Backend.AllNames . fromMaybe Path.empty $ rel
+            _ -> Backend.Within . fromMaybe Path.empty $ rel
+
+      Backend.prettyDefinitionsBySuffixes scope
                                           root
                                           width
                                           (fromMaybe (Suffixify True) suff)
                                           rt
                                           codebase
-        $   HQ.unsafeFromText
-        <$> hqns
+                                          hqns
     errFromEither backendError ea
  where
   parsePath p = errFromEither (`badNamespace` p) $ Path.parsePath' p

--- a/parser-typechecker/src/Unison/Server/Endpoints/NamespaceDetails.hs
+++ b/parser-typechecker/src/Unison/Server/Endpoints/NamespaceDetails.hs
@@ -103,8 +103,21 @@ serve tryAuth runtime codebase namespaceName mayRoot mayWidth =
 
         namespaceDetails <- doBackend $ do
           root <- Backend.resolveRootBranchHash mayRoot codebase
+
           let namespaceBranch = Branch.getAt' namespacePath root
-          readme <- Backend.findShallowReadmeInBranchAndRender width runtime codebase namespaceBranch
+
+          -- Names used in the README should not be confined to the namespace
+          -- of the README (since it could be referencing definitions from all
+          -- over the codebase)
+          let printNames = Backend.getCurrentPrettyNames (Backend.AllNames namespacePath) root
+
+          readme <-
+            Backend.findShallowReadmeInBranchAndRender
+              width
+              runtime
+              codebase
+              printNames
+              namespaceBranch
 
           pure $ NamespaceDetails namespaceName (branchToUnisonHash namespaceBranch) readme
 

--- a/parser-typechecker/src/Unison/Server/Endpoints/NamespaceListing.hs
+++ b/parser-typechecker/src/Unison/Server/Endpoints/NamespaceListing.hs
@@ -217,7 +217,7 @@ serve tryAuth codebase mayRoot mayRelativeTo mayNamespaceName =
       let listingBranch = Branch.getAt' path root
       hashLength <- liftIO $ Codebase.hashLength codebase
 
-      let shallowPPE = Backend.basicSuffixifiedNames hashLength root $ Path.fromPath' path'
+      let shallowPPE = Backend.basicSuffixifiedNames hashLength root $ (Backend.Within $ Path.fromPath' path')
       let listingFQN = Path.toText . Path.unabsolute . either id (Path.Absolute . Path.unrelative) $ Path.unPath' path'
       let listingHash = branchToUnisonHash listingBranch
       listingEntries <- findShallow listingBranch


### PR DESCRIPTION
Paired with @hojberg 😄 

## Overview

Makes desired name scoping explicit in backend name queries.

This allows the backend server to explicitly state that it wants names from ONLY the current qualified path, or whether it wants all names, but absolutely qualified.

closes #2557 
closes #2360 
closes #2531

## Implementation notes

Adds a sum-type to the path provided to name queries to require deciding whether names outside of that path should be included.

## Interesting/controversial decisions

Nah

## Test coverage

* We should probably have some tests for the codebase server handlers at some point.