### PR TITLE
Bugfix: `Name.cons` is not monotonic wrt. Name ordering

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -232,40 +232,38 @@ branch0 terms types children edits =
       where
         go :: (NameSegment, Branch m) -> Relation Referent Name
         go (n, b) =
-          R.mapRanMonotonic (Name.cons n) (deepTerms $ head b)
+          R.mapRan (Name.cons n) (deepTerms $ head b)
     deepTypes' :: Relation Reference Name
     deepTypes' =
       R.mapRanMonotonic Name.fromSegment (Star3.d1 types) <> foldMap go children'
       where
         go :: (NameSegment, Branch m) -> Relation Reference Name
         go (n, b) =
-          R.mapRanMonotonic (Name.cons n) (deepTypes $ head b)
+          R.mapRan (Name.cons n) (deepTypes $ head b)
     deepTermMetadata' :: Metadata.R4 Referent Name
     deepTermMetadata' =
       R4.mapD2Monotonic Name.fromSegment (Metadata.starToR4 terms) <> foldMap go children'
       where
         go (n, b) =
-          R4.mapD2Monotonic (Name.cons n) (deepTermMetadata $ head b)
+          R4.mapD2 (Name.cons n) (deepTermMetadata $ head b)
     deepTypeMetadata' :: Metadata.R4 Reference Name
     deepTypeMetadata' =
       R4.mapD2Monotonic Name.fromSegment (Metadata.starToR4 types) <> foldMap go children'
       where
         go (n, b) =
-          R4.mapD2Monotonic (Name.cons n) (deepTypeMetadata $ head b)
+          R4.mapD2 (Name.cons n) (deepTypeMetadata $ head b)
     deepPaths' :: Set Path
     deepPaths' =
       Set.mapMonotonic Path.singleton (Map.keysSet children) <> foldMap go children'
       where
         go (n, b) =
-          -- N.B. (Path.cons n) is not monotonic wrt. Path ordering, because Path, unlike Name, does not compare in
-          -- reverse segment order.
           Set.map (Path.cons n) (deepPaths $ head b)
     deepEdits' :: Map Name EditHash
     deepEdits' =
       Map.mapKeysMonotonic Name.fromSegment (Map.map fst edits) <> foldMap go children'
       where
         go (n, b) =
-          Map.mapKeysMonotonic (Name.cons n) (deepEdits $ head b)
+          Map.mapKeys (Name.cons n) (deepEdits $ head b)
 
 head :: Branch m -> Branch0 m
 head (Branch c) = Causal.head c
@@ -279,7 +277,7 @@ deepEdits' = go id where
   -- can change this to an actual prefix once Name is a [NameSegment]
   go :: (Name -> Name) -> Branch0 m -> Map Name (EditHash, m Patch)
   go addPrefix Branch0{_children, _edits} =
-    Map.mapKeysMonotonic (addPrefix . Name.fromSegment) _edits
+    Map.mapKeys (addPrefix . Name.fromSegment) _edits
       <> foldMap f (Map.toList _children)
     where
     f :: (NameSegment, Branch m) -> Map Name (EditHash, m Patch)

--- a/parser-typechecker/tests/Suite.hs
+++ b/parser-typechecker/tests/Suite.hs
@@ -10,6 +10,7 @@ import qualified Unison.Core.Test.Name as Name
 import qualified Unison.Test.ABT as ABT
 import qualified Unison.Test.Cache as Cache
 import qualified Unison.Test.ClearCache as ClearCache
+import qualified Unison.Test.Codebase.Branch as Branch
 import qualified Unison.Test.Codebase.Causal as Causal
 import qualified Unison.Test.Codebase.Path as Path
 import qualified Unison.Test.ColorText as ColorText
@@ -76,6 +77,7 @@ test = tests
   , PinBoard.test
   , CodebaseInit.test
   , CommandLine.test
+  , Branch.test
  ]
 
 main :: IO ()

--- a/parser-typechecker/tests/Unison/Test/Codebase/Branch.hs
+++ b/parser-typechecker/tests/Unison/Test/Codebase/Branch.hs
@@ -1,0 +1,56 @@
+-- | "Unison.Codebase.Branch" tests.
+module Unison.Test.Codebase.Branch
+  ( test,
+  )
+where
+
+import Data.Functor.Identity
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import EasyTest
+import Unison.Codebase.Branch (Branch (Branch), Branch0)
+import qualified Unison.Codebase.Branch as Branch
+import qualified Unison.Codebase.Causal as Causal
+import Unison.Reference (Reference)
+import qualified Unison.Reference as Reference
+import qualified Unison.Util.Relation as Relation
+import qualified Unison.Util.Star3 as Star3
+
+test :: Test ()
+test =
+  (scope "codebase.branch" . tests)
+    [ scope "branch0" (tests branch0Tests)
+    ]
+
+branch0Tests :: [Test ()]
+branch0Tests =
+  [ scope "regression-2564" do
+      let dummy :: Reference =
+            Reference.Builtin "foo"
+      let -- b
+          b0 :: Branch0 Identity =
+            Branch.branch0
+              mempty
+              (Star3.fromList [(dummy, "b", dummy, (dummy, dummy))])
+              Map.empty
+              Map.empty
+      let -- a.b
+          -- b
+          b1 :: Branch0 Identity =
+            Branch.branch0
+              mempty
+              (Star3.fromList [(dummy, "b", dummy, (dummy, dummy))])
+              (Map.singleton "a" (Branch (Causal.one b0)))
+              Map.empty
+
+      let -- b.a.b
+          -- b.b
+          b2 :: Branch0 Identity =
+            Branch.branch0
+              mempty
+              mempty
+              (Map.singleton "b" (Branch (Causal.one b1)))
+              Map.empty
+
+      expect (Set.valid (Relation.ran (Branch.deepTypes b2)))
+  ]

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -353,6 +353,7 @@ executable tests
       Unison.Test.ANF
       Unison.Test.Cache
       Unison.Test.ClearCache
+      Unison.Test.Codebase.Branch
       Unison.Test.Codebase.Causal
       Unison.Test.Codebase.Path
       Unison.Test.CodebaseInit

--- a/unison-core/src/Unison/Name.hs
+++ b/unison-core/src/Unison/Name.hs
@@ -97,8 +97,6 @@ instance IsString Name where
     unsafeFromString
 
 instance Ord Name where
-  -- Note: there are currently parts of the code that rely on the monotonicity of `cons` wrt. this ordering. Do not
-  -- change this instance without auditing all `Map.mapMonotonic` and the like!
   compare (Name p0 ss0) (Name p1 ss1) =
     compare ss0 ss1 <> compare p0 p1
 
@@ -142,8 +140,8 @@ compareSuffix (Name _ ss0) =
       [] -> LT
       y : ys -> compare y x <> acc ys
 
--- | Cons a name segment onto the head of a relative name. Monotonic with respect to ordering: it is safe to use
--- @cons s@ as the first argument to @Map.mapKeysMonotonic@.
+-- | Cons a name segment onto the head of a relative name. Not monotonic with respect to ordering! It is not safe to use
+-- @cons s@ as the first argument to @Map.mapKeysMonotonic@!
 --
 -- /Precondition/: the name is relative
 --


### PR DESCRIPTION
In #2488 I erroneously replaced a few `Map.mapKeys` with `Map.mapKeysMonotonic` where I thought was appropriate, but it turns out `Name.cons` is not monotonic with respect to name ordering.

Here is the counterexample that @aryairani and I chased down:

- Name segment = "test"
- Name 1 = "Test"
- Name 2 = "internals.v1.Test.Test"

For `Name.cons "test"` be monotonic with respect to ordering, it must be the case that

- if `x < y`,
- then `Name.cons "test" x < Name.cons "test" y` 

However, this isn't the case.

- "Test" < "internals.v1.Test.Test"
- "test.Test" > "test.internals.v1.Test.Test"

Or, written out in reverse-segment order (which is the way names compare),

- ["Test"] < ["Test", "Test", "v1", "internals"]
- ["Test", "test"] > ["Test", "Test", "v1", "internals", "test"]
