### PR TITLE
Fix various ability checking issues

### DIFF
--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -595,6 +595,9 @@ renderTypeError e env src = case e of
   simplePath' :: C.PathElement v loc -> Pretty ColorText
   simplePath' = \case
     C.InSynthesize e -> "InSynthesize e=" <> renderTerm env e
+    C.InEquate t1 t2 ->
+      "InEquate t1=" <> renderType' env t1 <>
+      ", t2=" <> renderType' env t2
     C.InSubtype t1 t2 ->
       "InSubtype t1=" <> renderType' env t1 <> ", t2=" <> renderType' env t2
     C.InCheck e t ->

--- a/parser-typechecker/src/Unison/Typechecker/Extractor.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Extractor.hs
@@ -164,6 +164,7 @@ inSynthesize = asPathExtractor $ \case
 inSubtype :: SubseqExtractor v loc (C.Type v loc, C.Type v loc)
 inSubtype = asPathExtractor $ \case
   C.InSubtype found expected -> Just (found, expected)
+  C.InEquate  found expected -> Just (found, expected)
   _                          -> Nothing
 
 inCheck :: SubseqExtractor v loc (C.Term v loc, C.Type v loc)

--- a/unison-src/transcripts/fix2350.md
+++ b/unison-src/transcripts/fix2350.md
@@ -1,0 +1,26 @@
+
+This tests an issue where ability variables were being defaulted over
+eagerly. In general, we want to avoid collecting up variables from the
+use of definitions with types like:
+
+    T ->{e} U
+
+Since this type works for every `e`, it is, 'pure;' and we might as
+well have `e = {}`, since `{}` is a subrow of every other row.
+However, if `e` isn't just a quantified variable, but one involved in
+ongoing inference, it's undesirable to default it. Previously there
+was a check to see if `e` occurred in the context. However, the wanted
+abilities being collected aren't in the context, so types like:
+
+    T ->{S e} U ->{e} V
+
+were a corner case. We would add `S e` to the wanted abilities, then
+not realize that `e` shouldn't be defaulted.
+
+```unison
+unique ability Storage d g where
+  save.impl : a ->{Storage d g} ('{g} (d a))
+
+save : a ->{Storage d g, g} (d a)
+save a = !(save.impl a)
+```

--- a/unison-src/transcripts/fix2350.output.md
+++ b/unison-src/transcripts/fix2350.output.md
@@ -1,0 +1,39 @@
+
+This tests an issue where ability variables were being defaulted over
+eagerly. In general, we want to avoid collecting up variables from the
+use of definitions with types like:
+
+    T ->{e} U
+
+Since this type works for every `e`, it is, 'pure;' and we might as
+well have `e = {}`, since `{}` is a subrow of every other row.
+However, if `e` isn't just a quantified variable, but one involved in
+ongoing inference, it's undesirable to default it. Previously there
+was a check to see if `e` occurred in the context. However, the wanted
+abilities being collected aren't in the context, so types like:
+
+    T ->{S e} U ->{e} V
+
+were a corner case. We would add `S e` to the wanted abilities, then
+not realize that `e` shouldn't be defaulted.
+
+```unison
+unique ability Storage d g where
+  save.impl : a ->{Storage d g} ('{g} (d a))
+
+save : a ->{Storage d g, g} (d a)
+save a = !(save.impl a)
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique ability Storage d g
+      save : a ->{g, Storage d g} d a
+
+```

--- a/unison-src/transcripts/fix2474.md
+++ b/unison-src/transcripts/fix2474.md
@@ -1,0 +1,35 @@
+
+Tests an issue with a lack of generality of handlers.
+
+In general, a set of cases:
+
+  { e ... -> k }
+
+should be typed in the following way:
+
+  1. The scrutinee has type `Request {E, g} r -> s` where `E` is all
+     the abilities being handled. `g` is a slack variable, because all
+     abilities that are used in the handled expression pass through
+     the handler. Previously this was being inferred as merely
+     `Request {E} r -> s`
+  2. The continuation variable `k` should have type `o ->{E, g} r`,
+     matching the above types (`o` is the result type of `e`).
+     Previously this was being checked as `o ->{E0} r`, where `E0` is
+     the ability that contains `e`.
+
+```ucm
+.> builtins.mergeio
+```
+
+```unison
+structural ability Stream a where 
+  emit : a -> ()
+
+Stream.uncons : '{Stream a, g} r ->{g} Either r (a, '{Stream a, g} r)
+Stream.uncons s = 
+  go : Request {Stream a,g} r -> Either r (a, '{Stream a,g} r)
+  go = cases 
+    { r } -> Left r
+    { Stream.emit a -> tl } -> Right (a, tl : '{Stream a,g} r)
+  handle !s with go
+```

--- a/unison-src/transcripts/fix2474.output.md
+++ b/unison-src/transcripts/fix2474.output.md
@@ -1,0 +1,51 @@
+
+Tests an issue with a lack of generality of handlers.
+
+In general, a set of cases:
+
+  { e ... -> k }
+
+should be typed in the following way:
+
+  1. The scrutinee has type `Request {E, g} r -> s` where `E` is all
+     the abilities being handled. `g` is a slack variable, because all
+     abilities that are used in the handled expression pass through
+     the handler. Previously this was being inferred as merely
+     `Request {E} r -> s`
+  2. The continuation variable `k` should have type `o ->{E, g} r`,
+     matching the above types (`o` is the result type of `e`).
+     Previously this was being checked as `o ->{E0} r`, where `E0` is
+     the ability that contains `e`.
+
+```ucm
+.> builtins.mergeio
+
+  Done.
+
+```
+```unison
+structural ability Stream a where 
+  emit : a -> ()
+
+Stream.uncons : '{Stream a, g} r ->{g} Either r (a, '{Stream a, g} r)
+Stream.uncons s = 
+  go : Request {Stream a,g} r -> Either r (a, '{Stream a,g} r)
+  go = cases 
+    { r } -> Left r
+    { Stream.emit a -> tl } -> Right (a, tl : '{Stream a,g} r)
+  handle !s with go
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      structural ability Stream a
+      Stream.uncons : '{g, Stream a} r
+                      ->{g} Either r (a, '{g, Stream a} r)
+
+```

--- a/unison-src/transcripts/pattern-pretty-print-2345.output.md
+++ b/unison-src/transcripts/pattern-pretty-print-2345.output.md
@@ -69,7 +69,7 @@ doc = cases
       pokey     : [t] -> ()
       sleepy    : [t] -> ()
       sneezy    : Int -> ()
-      throaty   : Request {Ab} x -> ()
+      throaty   : Request {g, Ab} x -> ()
       tremulous : (Nat, Nat) -> ()
 
 ```
@@ -91,7 +91,7 @@ doc = cases
     pokey     : [t] -> ()
     sleepy    : [t] -> ()
     sneezy    : Int -> ()
-    throaty   : Request {Ab} x -> ()
+    throaty   : Request {g, Ab} x -> ()
     tremulous : (Nat, Nat) -> ()
 
 .> view dopey
@@ -151,7 +151,7 @@ doc = cases
 
 .> view throaty
 
-  throaty : Request {Ab} x -> ()
+  throaty : Request {g, Ab} x -> ()
   throaty = cases {a a -> k} -> ()
 
 .> view agitated


### PR DESCRIPTION
This PR includes work for a couple fixes.

- A dedicated equality procedure is implemented so that invariant types are less prone to causing issues with ability defaulting
- Handler typing was incorrect in a couple ways, causing it to have overly specific/wrong types
- There was a corner case where ability variable defaulting happened in a situation it shouldn't.

Test cases for associated issues. Fixes #2350 #2474 and #2424. I'm pretty sure the latter two were both related to the wrong handler typing.