### PR TITLE
Render doc html files

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -89,6 +89,11 @@ data Command
 
   UI :: Command m i v ()
 
+  DocsToHtml
+    :: Branch m -- ^ namespace source
+    -> FilePath -- ^ file destination
+    -> Command m i v ()
+
   HQNameQuery
     :: Maybe Path
     -> Branch m
@@ -267,6 +272,7 @@ commandName :: Command m i v a -> String
 commandName = \case
   Eval{}                      -> "Eval"
   UI                          -> "UI"
+  DocsToHtml{}                -> "DocsToHtml"
   ConfigLookup{}              -> "ConfigLookup"
   Input                       -> "Input"
   Notify{}                    -> "Notify"

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -103,6 +103,10 @@ commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSour
       case serverBaseUrl of
         Just url -> lift . void $ openBrowser (Server.urlFor Server.UI url)
         Nothing -> lift (return ())
+
+    DocsToHtml sourceBranch destination ->
+      liftIO $ Backend.docsInBranchToHtmlFiles rt codebase sourceBranch destination
+
     Input         -> lift awaitInput
     Notify output -> lift $ notifyUser output
     NotifyNumbered output -> lift $ notifyNumbered output

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -412,6 +412,7 @@ loop = do
           PropagatePatchI p scope -> "patch " <> ps' p <> " " <> p' scope
           UndoI{} -> "undo"
           UiI -> "ui"
+          DocsToHtmlI path dir -> "docs.to-html " <> Path.toText' path <> " " <> Text.pack dir
           ExecuteI s -> "execute " <> Text.pack s
           IOTestI hq -> "io.test " <> HQ.toText hq
           LinkI md defs ->
@@ -904,6 +905,11 @@ loop = do
               respondNumbered . uncurry Output.ShowDiffAfterUndo
 
       UiI -> eval UI
+
+      DocsToHtmlI namespacePath' sourceDirectory -> do
+        let absPath = resolveToAbsolute namespacePath'
+        let namespaceBranch = Branch.getAt' (Path.unabsolute absPath) root'
+        eval (DocsToHtml namespaceBranch sourceDirectory)
 
       AliasTermI src dest -> do
         referents <- resolveHHQS'Referents src

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -108,50 +108,51 @@ data Input
     | ReplaceI (HQ.HashQualified Name) (HQ.HashQualified Name) (Maybe PatchPath)
     | RemoveTermReplacementI (HQ.HashQualified Name) (Maybe PatchPath)
     | RemoveTypeReplacementI (HQ.HashQualified Name) (Maybe PatchPath)
-  | UndoI
-  -- First `Maybe Int` is cap on number of results, if any
-  -- Second `Maybe Int` is cap on diff elements shown, if any
-  | HistoryI (Maybe Int) (Maybe Int) BranchId
-  -- execute an IO thunk
-  | ExecuteI String
-  -- execute an IO [Result]
-  | IOTestI (HQ.HashQualified Name)
-  -- make a standalone binary file
-  | MakeStandaloneI String (HQ.HashQualified Name)
-  | TestI Bool Bool -- TestI showSuccesses showFailures
-  -- metadata
-  -- `link metadata definitions` (adds metadata to all of `definitions`)
-  | LinkI (HQ.HashQualified Name) [Path.HQSplit']
-  -- `unlink metadata definitions` (removes metadata from all of `definitions`)
-  | UnlinkI (HQ.HashQualified Name) [Path.HQSplit']
-  -- links from <type>
-  | LinksI Path.HQSplit' (Maybe String)
-  | CreateAuthorI NameSegment {- identifier -} Text {- name -}
-    -- Display provided definitions. If list is empty, prompt a fuzzy search.
-  | DisplayI OutputLocation [HQ.HashQualified Name]
-    -- Display docs for provided terms. If list is empty, prompt a fuzzy search.
-  | DocsI [Path.HQSplit']
-  -- other
-  | SearchByNameI Bool Bool [String] -- SearchByName isVerbose showAll query
-  | FindShallowI Path'
-  | FindPatchI
-    -- Show provided definitions. If list is empty, prompt a fuzzy search.
-  | ShowDefinitionI OutputLocation [HQ.HashQualified Name]
-  | ShowDefinitionByPrefixI OutputLocation [HQ.HashQualified Name]
-  | ShowReflogI
-  | UpdateBuiltinsI
-  | MergeBuiltinsI
-  | MergeIOBuiltinsI
-  | ListDependenciesI (HQ.HashQualified Name)
-  | ListDependentsI (HQ.HashQualified Name)
-  | DebugNumberedArgsI
-  | DebugTypecheckedUnisonFileI
-  | DebugDumpNamespacesI
-  | DebugDumpNamespaceSimpleI
-  | DebugClearWatchI
-  | QuitI
-  | UiI
-  deriving (Eq, Show)
+    | UndoI
+    -- First `Maybe Int` is cap on number of results, if any
+    -- Second `Maybe Int` is cap on diff elements shown, if any
+    | HistoryI (Maybe Int) (Maybe Int) BranchId
+    -- execute an IO thunk
+    | ExecuteI String
+    -- execute an IO [Result]
+    | IOTestI (HQ.HashQualified Name)
+    -- make a standalone binary file
+    | MakeStandaloneI String (HQ.HashQualified Name)
+    | TestI Bool Bool -- TestI showSuccesses showFailures
+    -- metadata
+    -- `link metadata definitions` (adds metadata to all of `definitions`)
+    | LinkI (HQ.HashQualified Name) [Path.HQSplit']
+    -- `unlink metadata definitions` (removes metadata from all of `definitions`)
+    | UnlinkI (HQ.HashQualified Name) [Path.HQSplit']
+    -- links from <type>
+    | LinksI Path.HQSplit' (Maybe String)
+    | CreateAuthorI NameSegment {- identifier -} Text {- name -}
+      -- Display provided definitions. If list is empty, prompt a fuzzy search.
+    | DisplayI OutputLocation [HQ.HashQualified Name]
+      -- Display docs for provided terms. If list is empty, prompt a fuzzy search.
+    | DocsI [Path.HQSplit']
+    -- other
+    | SearchByNameI Bool Bool [String] -- SearchByName isVerbose showAll query
+    | FindShallowI Path'
+    | FindPatchI
+      -- Show provided definitions. If list is empty, prompt a fuzzy search.
+    | ShowDefinitionI OutputLocation [HQ.HashQualified Name]
+    | ShowDefinitionByPrefixI OutputLocation [HQ.HashQualified Name]
+    | ShowReflogI
+    | UpdateBuiltinsI
+    | MergeBuiltinsI
+    | MergeIOBuiltinsI
+    | ListDependenciesI (HQ.HashQualified Name)
+    | ListDependentsI (HQ.HashQualified Name)
+    | DebugNumberedArgsI
+    | DebugTypecheckedUnisonFileI
+    | DebugDumpNamespacesI
+    | DebugDumpNamespaceSimpleI
+    | DebugClearWatchI
+    | QuitI
+    | UiI
+    | DocsToHtmlI Path' FilePath
+    deriving (Eq, Show)
 
 -- Some commands, like `view`, can dump output to either console or a file.
 data OutputLocation

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -1349,6 +1349,26 @@ test = InputPattern "test" [] []
     "`test` runs unit tests for the current branch."
     (const $ pure $ Input.TestI True True)
 
+docsToHtml :: InputPattern
+docsToHtml = InputPattern
+  "docs.to-html"
+  []
+  []
+  (P.wrapColumn2
+    [ ( "`docs.to-html .path.to.namespace ~/path/to/file/output`"
+      , "Render all docs contained within a namespace, no matter how deep,"
+        <> "to html files on a file path"
+      )
+    ]
+  )
+  (\case
+    [namespacePath, destinationFilePath] -> first fromString $ do
+      np <- Path.parsePath' namespacePath
+      pure $ Input.DocsToHtmlI np destinationFilePath
+    _   -> Left $ showPatternHelp docsToHtml
+  )
+
+
 execute :: InputPattern
 execute = InputPattern
   "run"
@@ -1458,6 +1478,7 @@ validInputs =
   , displayTo
   , ui
   , docs
+  , docsToHtml
   , findPatch
   , viewPatch
   , undo

--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -859,7 +859,7 @@ docsInBranchToHtmlFiles runtime codebase currentBranch directory = do
     docFilePath directory rawHqn =
       let
         (path, docName) =
-          fromRight (error "Broken path... make this better") $ PathParse.parseHQSplit $ Text.unpack rawHqn
+          fromRight (error "Could not parse doc name") $ PathParse.parseHQSplit $ Text.unpack rawHqn
 
         directoryPath =
           directory </> joinPath (map NameSegment.toString $ Path.toList path)

--- a/parser-typechecker/src/Unison/Server/Syntax.hs
+++ b/parser-typechecker/src/Unison/Server/Syntax.hs
@@ -208,7 +208,7 @@ segmentToHtml (Segment segmentText element) =
 
       isFQN =
         let isFQN_ =
-              Text.isInfixOf "." sText
+              Text.isInfixOf "." sText && not (Text.isInfixOf "#" sText)
          in case el of
               TypeReference {} ->
                 isFQN_


### PR DESCRIPTION
## Overview
Add a new ucm command to render docs in a namespace to html files

Authored with @ChrisPenner 

## Implementation notes
* Add a `Backend` (down the line, perhaps this should live somewhere else?) function to render all docs in a branch to html files
* Add a new ucm command `docs.to-html` that takes a namespace path and a directory path and calls the `Backend` function to render docs to html files.

## Test coverage
Since there's a side-effect of output files, i'm not sure how we can best test this?

## Loose ends
There's a not so great crash that happens when we try and write /to a file thats not within the cwd.
We should perhaps catch Lucid's error and translate it somehow?