### PR TITLE
WIP: Increase type-safety, decrease number of "Path" types.

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -396,7 +396,7 @@ toCausalRaw = \case
 getAt :: Path pos
       -> Branch m
       -> Maybe (Branch m)
-getAt path root = case Path.uncons (Path.unsafeToRelative path) of
+getAt path root = case Path.uncons path of
   Nothing -> if isEmpty root then Nothing else Just root
   Just (seg, path) -> case Map.lookup seg (_children $ head root) of
     Just b -> getAt path b
@@ -406,7 +406,7 @@ getAt' :: Path pos -> Branch m -> Branch m
 getAt' p b = fromMaybe empty $ getAt p b
 
 getAt0 :: Path pos -> Branch0 m -> Branch0 m
-getAt0 p b = case Path.uncons (Path.unsafeToRelative p) of
+getAt0 p b = case Path.uncons p of
   Nothing -> b
   Just (seg, path) -> case Map.lookup seg (_children b) of
     Just c -> getAt0 path (head c)

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -98,7 +98,7 @@ import           Unison.Codebase.Causal         ( Causal
                                                 , pattern RawMerge
                                                 )
 import           Unison.Codebase.Position       ( Position(..) )
-import           Unison.Codebase.Path           ( Path(..) )
+import           Unison.Codebase.Path           ( Path )
 import qualified Unison.Codebase.Path          as Path
 import           Unison.NameSegment             ( NameSegment )
 import qualified Unison.Codebase.Metadata      as Metadata

--- a/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
+++ b/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
@@ -28,6 +28,7 @@ import Unison.Codebase.Patch (Patch)
 import Unison.NameSegment (NameSegment)
 import Control.Lens (view)
 import Unison.Codebase.Position
+import Basement.Compat.Bifunctor (first)
 
 fromNames :: Monad m => Names -> Branch m
 fromNames names0 = Branch.one $ addFromNames names0 Branch.empty0
@@ -40,23 +41,23 @@ hashesFromNames = deepHashes . fromNames where
     <> (foldMap deepHashes . view Branch.children . Branch.head) b
 
 addFromNames :: Monad m => Names -> Branch0 m -> Branch0 m
-addFromNames names0 = Branch.stepManyAt0 (typeActions <> termActions)
+addFromNames names0 = Branch.stepManyAt0 (first Path.unsafeToAbsolute <$> typeActions <> termActions)
   where
   typeActions = map doType . R.toList $ Names.types names0
   termActions = map doTerm . R.toList $ Names.terms names0
 --  doTerm :: (Name, Referent) -> (Path, Branch0 m -> Branch0 m)
   doTerm (n, r) = case Path.splitFromName n of
     Nothing -> errorEmptyName
-    Just (Path.unsafeToRelative -> p, ns) ->
+    Just (p, ns) ->
       makeAddTermName (p, ns) r mempty -- no metadata
 --  doType :: (Name, Reference) -> (Path, Branch0 m -> Branch0 m)
   doType (n, r) = case Path.splitFromName n of
              Nothing -> errorEmptyName
-             Just (Path.unsafeToRelative -> p, ns) -> 
+             Just (p, ns) -> 
                makeAddTypeName (p, ns) r mempty -- no metadata
   errorEmptyName = error "encountered an empty name"
 
-getTerm :: Path.HQSplit 'Relative -> Branch0 m -> Set Referent
+getTerm :: Path.HQSplit pos -> Branch0 m -> Set Referent
 getTerm (p, hq) b = case hq of
     NameOnly n -> Star3.lookupD1 n terms
     HashQualified n sh -> filter sh $ Star3.lookupD1 n terms
@@ -80,14 +81,14 @@ getTypeMetadataHQNamed (path, hqseg) b =
 
 -- todo: audit usages and maybe eliminate!
 -- Only returns metadata for the term at the exact level given
-getTermMetadataAt :: (Path.Path 'Relative, a) -> Referent -> Branch0 m -> Metadata
+getTermMetadataAt :: (Path.Path pos, a) -> Referent -> Branch0 m -> Metadata
 getTermMetadataAt (path,_) r b = Set.fromList <$> List.multimap mdList
   where
   mdList :: [(Metadata.Type, Metadata.Value)]
   mdList = Set.toList . R.ran . Star3.d3 . Star3.selectFact (Set.singleton r) $ terms
   terms = Branch._terms $ Branch.getAt0 path b
 
-getType :: Path.HQSplit 'Relative -> Branch0 m -> Set Reference
+getType :: Path.HQSplit pos -> Branch0 m -> Set Reference
 getType (p, hq) b = case hq of
     NameOnly n -> Star3.lookupD1 n types
     HashQualified n sh -> filter sh $ Star3.lookupD1 n types
@@ -100,40 +101,40 @@ getTypeByShortHash sh b = filter sh $ Branch.deepTypeReferences b
   where
   filter sh = Set.filter (SH.isPrefixOf sh . Reference.toShortHash)
 
-getTypeMetadataAt :: (Path 'Relative, a) -> Reference -> Branch0 m -> Metadata
+getTypeMetadataAt :: (Path pos, a) -> Reference -> Branch0 m -> Metadata
 getTypeMetadataAt (path,_) r b = Set.fromList <$> List.multimap mdList
   where
   mdList :: [(Metadata.Type, Metadata.Value)]
   mdList = Set.toList . R.ran . Star3.d3 . Star3.selectFact (Set.singleton r) $ types
   types = Branch._types $ Branch.getAt0 path b
 
-getBranch :: Path.Split 'Relative -> Branch0 m -> Maybe (Branch m)
-getBranch (p, seg) b = case Path.uncons p of
+getBranch :: Path.Split any -> Branch0 m -> Maybe (Branch m)
+getBranch (p, seg) b = case Path.uncons (Path.unsafeToRelative p) of
   Nothing -> Map.lookup seg (Branch._children b)
   Just (h, p) ->
     (Branch.head <$> Map.lookup h (Branch._children b)) >>=
       getBranch (p, seg)
 
 
-makeAddTermName :: Path.Split 'Relative -> Referent -> Metadata -> (Path 'Relative, Branch0 m -> Branch0 m)
+makeAddTermName :: Path.Split pos -> Referent -> Metadata -> (Path pos, Branch0 m -> Branch0 m)
 makeAddTermName (p, name) r md = (p, Branch.addTermName r name md)
 
-makeDeleteTermName :: Path.Split 'Relative -> Referent -> (Path 'Relative, Branch0 m -> Branch0 m)
+makeDeleteTermName :: Path.Split pos -> Referent -> (Path pos, Branch0 m -> Branch0 m)
 makeDeleteTermName (p, name) r = (p, Branch.deleteTermName r name)
 
-makeReplacePatch :: Applicative m => Path.Split 'Relative -> Patch -> (Path 'Relative, Branch0 m -> Branch0 m)
+makeReplacePatch :: Applicative m => Path.Split pos -> Patch -> (Path pos, Branch0 m -> Branch0 m)
 makeReplacePatch (p, name) patch = (p, Branch.replacePatch name patch)
 
-makeDeletePatch :: Path.Split 'Relative -> (Path 'Relative, Branch0 m -> Branch0 m)
+makeDeletePatch :: Path.Split pos -> (Path pos, Branch0 m -> Branch0 m)
 makeDeletePatch (p, name) = (p, Branch.deletePatch name)
 
-makeAddTypeName :: Path.Split 'Relative -> Reference -> Metadata -> (Path 'Relative, Branch0 m -> Branch0 m)
+makeAddTypeName :: Path.Split pos -> Reference -> Metadata -> (Path pos, Branch0 m -> Branch0 m)
 makeAddTypeName (p, name) r md = (p, Branch.addTypeName r name md)
 
-makeDeleteTypeName :: Path.Split 'Relative -> Reference -> (Path 'Relative, Branch0 m -> Branch0 m)
+makeDeleteTypeName :: Path.Split pos -> Reference -> (Path pos, Branch0 m -> Branch0 m)
 makeDeleteTypeName (p, name) r = (p, Branch.deleteTypeName r name)
 
 -- to delete, just set with Branch.empty
 makeSetBranch ::
-  Path.Split 'Relative -> Branch m -> (Path 'Relative, Branch0 m -> Branch0 m)
+  Path.Split pos -> Branch m -> (Path pos, Branch0 m -> Branch0 m)
 makeSetBranch (p, name) b = (p, Branch.setChildBranch name b)

--- a/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
+++ b/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
@@ -47,12 +47,12 @@ addFromNames names0 = Branch.stepManyAt0 (typeActions <> termActions)
 --  doTerm :: (Name, Referent) -> (Path, Branch0 m -> Branch0 m)
   doTerm (n, r) = case Path.splitFromName n of
     Nothing -> errorEmptyName
-    Just (Path.intoRelative -> p, ns) ->
+    Just (Path.unsafeToRelative -> p, ns) ->
       makeAddTermName (p, ns) r mempty -- no metadata
 --  doType :: (Name, Reference) -> (Path, Branch0 m -> Branch0 m)
   doType (n, r) = case Path.splitFromName n of
              Nothing -> errorEmptyName
-             Just (Path.intoRelative -> p, ns) -> 
+             Just (Path.unsafeToRelative -> p, ns) -> 
                makeAddTypeName (p, ns) r mempty -- no metadata
   errorEmptyName = error "encountered an empty name"
 

--- a/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
+++ b/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
@@ -66,13 +66,13 @@ getTerm (p, hq) b = case hq of
   terms = Branch._terms (Branch.getAt0 p b)
 
 getTermMetadataHQNamed
-  :: (Path.Path 'Relative, HQ'.HQSegment) -> Branch0 m -> Metadata.R4 Referent NameSegment
+  :: (Path.Path pos, HQ'.HQSegment) -> Branch0 m -> Metadata.R4 Referent NameSegment
 getTermMetadataHQNamed (path, hqseg) b =
   R4.filter (\(r,n,_t,_v) -> HQ'.matchesNamedReferent n r hqseg) terms
   where terms = Metadata.starToR4 . Branch._terms $ Branch.getAt0 path b
 
 getTypeMetadataHQNamed
-  :: (Path.Path 'Relative, HQ'.HQSegment)
+  :: (Path.Path pos, HQ'.HQSegment)
   -> Branch0 m
   -> Metadata.R4 Reference NameSegment
 getTypeMetadataHQNamed (path, hqseg) b =

--- a/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
+++ b/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
@@ -27,7 +27,6 @@ import qualified Unison.Util.List as List
 import Unison.Codebase.Patch (Patch)
 import Unison.NameSegment (NameSegment)
 import Control.Lens (view)
-import Unison.Codebase.Position
 import Basement.Compat.Bifunctor (first)
 
 fromNames :: Monad m => Names -> Branch m

--- a/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
+++ b/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
@@ -27,7 +27,6 @@ import qualified Unison.Util.List as List
 import Unison.Codebase.Patch (Patch)
 import Unison.NameSegment (NameSegment)
 import Control.Lens (view)
-import Basement.Compat.Bifunctor (first)
 
 fromNames :: Monad m => Names -> Branch m
 fromNames names0 = Branch.one $ addFromNames names0 Branch.empty0
@@ -40,7 +39,7 @@ hashesFromNames = deepHashes . fromNames where
     <> (foldMap deepHashes . view Branch.children . Branch.head) b
 
 addFromNames :: Monad m => Names -> Branch0 m -> Branch0 m
-addFromNames names0 = Branch.stepManyAt0 (first Path.unsafeToAbsolute <$> typeActions <> termActions)
+addFromNames names0 = Branch.stepManyAt0 (typeActions <> termActions)
   where
   typeActions = map doType . R.toList $ Names.types names0
   termActions = map doTerm . R.toList $ Names.terms names0
@@ -107,8 +106,8 @@ getTypeMetadataAt (path,_) r b = Set.fromList <$> List.multimap mdList
   mdList = Set.toList . R.ran . Star3.d3 . Star3.selectFact (Set.singleton r) $ types
   types = Branch._types $ Branch.getAt0 path b
 
-getBranch :: Path.Split any -> Branch0 m -> Maybe (Branch m)
-getBranch (p, seg) b = case Path.uncons (Path.unsafeToRelative p) of
+getBranch :: Path.Split pos -> Branch0 m -> Maybe (Branch m)
+getBranch (p, seg) b = case Path.uncons p of
   Nothing -> Map.lookup seg (Branch._children b)
   Just (h, p) ->
     (Branch.head <$> Map.lookup h (Branch._children b)) >>=

--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -100,7 +100,7 @@ data Command
     :: [SR.SearchResult] -> Command m i v [SR'.SearchResult' v Ann]
 
   GetDefinitionsBySuffixes
-    :: Maybe (Path 'Relative)
+    :: Maybe (Path 'Absolute)
     -> Branch m
     -> [HQ.HashQualified Name]
     -> Command m i v (Either BackendError (DefinitionResults v))

--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -91,7 +91,7 @@ data Command
   UI :: Command m i v ()
 
   HQNameQuery
-    :: Maybe (Path 'Relative)
+    :: Maybe (Path 'Unchecked)
     -> Branch m
     -> [HQ.HashQualified Name]
     -> Command m i v QueryResult

--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE DataKinds #-}
 
 module Unison.Codebase.Editor.Command (
   Command(..),
@@ -55,7 +56,6 @@ import           Unison.Codebase.ShortBranchHash
                                                 ( ShortBranchHash )
 import Unison.Codebase.Editor.AuthorInfo (AuthorInfo)
 import Unison.Codebase.Path (Path)
-import qualified Unison.Codebase.Path as Path
 import qualified Unison.HashQualified as HQ
 import Unison.Name (Name)
 import Unison.Server.QueryResult (QueryResult)
@@ -64,6 +64,7 @@ import qualified Unison.Server.SearchResult' as SR'
 import qualified Unison.WatchKind as WK
 import Unison.Codebase.Type (GitError)
 import qualified Unison.CommandLine.FuzzySelect as Fuzzy
+import Unison.Codebase.Position
 
 type AmbientAbilities v = [Type v Ann]
 type SourceName = Text
@@ -90,7 +91,7 @@ data Command
   UI :: Command m i v ()
 
   HQNameQuery
-    :: Maybe Path
+    :: Maybe (Path 'Relative)
     -> Branch m
     -> [HQ.HashQualified Name]
     -> Command m i v QueryResult
@@ -99,13 +100,13 @@ data Command
     :: [SR.SearchResult] -> Command m i v [SR'.SearchResult' v Ann]
 
   GetDefinitionsBySuffixes
-    :: Maybe Path
+    :: Maybe (Path 'Relative)
     -> Branch m
     -> [HQ.HashQualified Name]
     -> Command m i v (Either BackendError (DefinitionResults v))
 
   FindShallow
-    :: Path.Absolute
+    :: Path 'Absolute
     -> Command m i v (Either BackendError [ShallowListEntry v Ann])
 
   ConfigLookup :: Configured a => Text -> Command m i v (Maybe a)

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -181,11 +181,11 @@ commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSour
     LoadReflog -> lift $ Codebase.getReflog codebase
     CreateAuthorInfo t -> AuthorInfo.createAuthorInfo Ann.External t
     HQNameQuery mayPath branch query -> do
-      let namingScope = Backend.AllNames $ fromMaybe Path.empty mayPath
+      let namingScope = Backend.AllNames $ fromMaybe Path.currentPath mayPath
       lift $ Backend.hqNameQuery namingScope branch codebase query
     LoadSearchResults srs -> lift $ Backend.loadSearchResults codebase srs
     GetDefinitionsBySuffixes mayPath branch query -> do
-      let namingScope = Backend.AllNames $ fromMaybe Path.empty mayPath
+      let namingScope = Backend.AllNames $ maybe Path.currentPath Path.unsafeToRelative mayPath
       lift . runExceptT $ Backend.definitionsBySuffixes namingScope branch codebase query
     FindShallow path -> lift . runExceptT $ Backend.findShallow codebase path
     MakeStandalone ppe ref out -> lift $ do

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -181,11 +181,11 @@ commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSour
     LoadReflog -> lift $ Codebase.getReflog codebase
     CreateAuthorInfo t -> AuthorInfo.createAuthorInfo Ann.External t
     HQNameQuery mayPath branch query -> do
-      let namingScope = Backend.AllNames $ fromMaybe Path.currentPath mayPath
+      let namingScope = Backend.AllNames $ fromMaybe (Path.unchecked Path.currentPath) mayPath
       lift $ Backend.hqNameQuery namingScope branch codebase query
     LoadSearchResults srs -> lift $ Backend.loadSearchResults codebase srs
     GetDefinitionsBySuffixes mayPath branch query -> do
-      let namingScope = Backend.AllNames $ maybe Path.currentPath Path.unsafeToRelative mayPath
+      let namingScope = Backend.AllNames $ fromMaybe Path.root mayPath
       lift . runExceptT $ Backend.definitionsBySuffixes namingScope branch codebase query
     FindShallow path -> lift . runExceptT $ Backend.findShallow codebase path
     MakeStandalone ppe ref out -> lift $ do

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE DataKinds #-}
 
 module Unison.Codebase.Editor.HandleInput
   ( loop
@@ -68,8 +69,7 @@ import qualified Unison.Codebase.Editor.Output.DumpNamespace as Output.DN
 import qualified Unison.Codebase.Metadata      as Metadata
 import           Unison.Codebase.Patch          ( Patch(..) )
 import qualified Unison.Codebase.Patch         as Patch
-import           Unison.Codebase.Path           ( Path
-                                                , Path'(..) )
+import           Unison.Codebase.Path           ( Path )
 import qualified Unison.Codebase.Path          as Path
 import qualified Unison.Codebase.Path.Parse as Path
 import qualified Unison.Codebase.Reflog        as Reflog
@@ -153,6 +153,7 @@ import qualified Unison.Hashing.V2.Convert as Hashing
 import qualified Unison.Codebase.Verbosity as Verbosity
 import qualified Unison.CommandLine.FuzzySelect as Fuzzy
 import Data.Either.Extra (eitherToMaybe)
+import Unison.Codebase.Position
 
 type F m i v = Free (Command m i v)
 
@@ -164,7 +165,7 @@ data LoopState m v
       { _root :: Branch m
       , _lastSavedRoot :: Branch m
       -- the current position in the namespace
-      , _currentPathStack :: NonEmpty Path.Absolute
+      , _currentPathStack :: NonEmpty (Path 'Absolute)
 
       -- TBD
       -- , _activeEdits :: Set Branch.EditGuid

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -244,7 +244,7 @@ loop = do
 
       basicPrettyPrintNames :: Names
       basicPrettyPrintNames =
-        Backend.basicPrettyPrintNames root' (Backend.AllNames currentPath')
+        Backend.basicPrettyPrintNames root' (Backend.AllNames . Path.unsafeToRelative $ currentPath')
 
       resolveHHQS'Types :: HashOrHQSplit' -> Action' m v (Set Reference)
       resolveHHQS'Types = either
@@ -275,7 +275,7 @@ loop = do
             L.Hash sh -> Just (HQ.HashOnly sh)
             _         -> Nothing
           hqs = Set.fromList . mapMaybe (getHQ . L.payload) $ tokens
-        let parseNames = Backend.getCurrentParseNames (Backend.AllNames currentPath') root'
+        let parseNames = Backend.getCurrentParseNames (Backend.AllNames . Path.unsafeToRelative $ currentPath') root'
         latestFile .= Just (Text.unpack sourceName, False)
         latestTypecheckedFile .= Nothing
         Result notes r <- eval $ Typecheck ambient parseNames sourceName lexed
@@ -1125,7 +1125,7 @@ loop = do
                   LatestFileLocation ->
                     fmap fst latestFile' <|> Just "scratch.u"
                 printNames =
-                  Backend.getCurrentPrettyNames (Backend.AllNames currentPath') root'
+                  Backend.getCurrentPrettyNames (Backend.AllNames . Path.unsafeToRelative $ currentPath') root'
                 ppe = PPE.fromNamesDecl hqLength printNames
             unless (null types && null terms) $
               eval . Notify $
@@ -1149,7 +1149,7 @@ loop = do
             ppe = Backend.basicSuffixifiedNames
                            sbhLength
                            root'
-                           (Backend.AllNames . resolveToAbsolute $ pathArg)
+                           (Backend.AllNames . Path.unsafeToRelative . resolveToAbsolute $ pathArg)
         res <- eval $ FindShallow pathArgAbs
         case res of
           Left e -> handleBackendError e
@@ -2229,7 +2229,7 @@ getMetadataFromName name = do
     getPPE = do
       currentPath' <- use currentPath
       sbhLength <- eval BranchHashLength
-      Backend.basicSuffixifiedNames sbhLength <$> use root <*> pure (Backend.AllNames currentPath')
+      Backend.basicSuffixifiedNames sbhLength <$> use root <*> pure (Backend.AllNames . Path.unsafeToRelative $ currentPath')
 
 -- | Get the set of terms related to a hash-qualified name.
 getHQTerms :: HQ.HashQualified Name -> Action' m v (Set Referent)
@@ -2921,7 +2921,7 @@ basicNames' :: Functor m => Action' m v (Names, Names)
 basicNames' = do
   root' <- use root
   currentPath' <- use currentPath
-  pure $ Backend.basicNames' root' (Backend.AllNames currentPath')
+  pure $ Backend.basicNames' root' (Backend.AllNames . Path.unsafeToRelative $ currentPath')
 
 data AddRunMainResult v
   = NoTermWithThatName

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -2619,7 +2619,7 @@ docsI srcLoc prettyPrintNames src = do
     hq :: HQ.HashQualified Name
     hq = let
       hq' :: HQ'.HashQualified Name
-      hq' = Name.convert @(Path 'Unchecked) @Name <$> Name.convert src
+      hq' = Path.toName <$> Path.unsplitHQ src
       in Name.convert hq'
 
     dotDoc :: HQ.HashQualified Name

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -960,17 +960,15 @@ loop = do
         go :: ([Path.HQSplit 'Absolute], [(Path 'Absolute, Branch0 m -> Branch0 m)])
            -> Path.HQSplit 'Absolute
            -> ([Path.HQSplit 'Absolute], [(Path 'Absolute, Branch0 m -> Branch0 m)])
-        go (missingSrcs, actions) hqsrc =
+        go (missingSrcs, actions) hqProposedDest =
           let
             src :: Path.Split 'Absolute
-            src = second HQ'.toName hqsrc
+            src = second HQ'.toName hqProposedDest
             proposedDest :: Path.Split 'Absolute
             proposedDest = second HQ'.toName hqProposedDest
-            hqProposedDest :: Path.HQSplit 'Absolute
-            hqProposedDest = Path.resolve destAbs hqsrc
             -- `Nothing` if src doesn't exist
             doType :: Maybe [(Path 'Absolute, Branch0 m -> Branch0 m)]
-            doType = case ( BranchUtil.getType hqsrc currentBranch0
+            doType = case ( BranchUtil.getType hqProposedDest currentBranch0
                           , BranchUtil.getType hqProposedDest root0
                           ) of
               (null -> True, _) -> Nothing -- missing src
@@ -980,7 +978,7 @@ loop = do
                 addAlias r = BranchUtil.makeAddTypeName proposedDest r (oldMD r)
                 oldMD r = BranchUtil.getTypeMetadataAt src r currentBranch0
             doTerm :: Maybe [(Path 'Absolute, Branch0 m -> Branch0 m)]
-            doTerm = case ( BranchUtil.getTerm hqsrc currentBranch0
+            doTerm = case ( BranchUtil.getTerm hqProposedDest currentBranch0
                           , BranchUtil.getTerm hqProposedDest root0
                           ) of
               (null -> True, _) -> Nothing -- missing src
@@ -990,7 +988,7 @@ loop = do
                 addAlias r = BranchUtil.makeAddTermName proposedDest r (oldMD r)
                 oldMD r = BranchUtil.getTermMetadataAt src r currentBranch0
           in case (doType, doTerm) of
-            (Nothing, Nothing) -> (missingSrcs :> hqsrc, actions)
+            (Nothing, Nothing) -> (missingSrcs :> hqProposedDest, actions)
             (Just as, Nothing) -> (missingSrcs, actions ++ as)
             (Nothing, Just as) -> (missingSrcs, actions ++ as)
             (Just as1, Just as2) -> (missingSrcs, actions ++ as1 ++ as2)

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -217,7 +217,7 @@ loop = do
   hqLength    <- eval CodebaseHashLength
   sbhLength   <- eval BranchHashLength
   let
-      hqNameQuery q = eval $ HQNameQuery (Just $ Path.unsafeToRelative currentPath') root' q
+      hqNameQuery q = eval $ HQNameQuery (Just $ Path.unchecked currentPath') root' q
       sbh = SBH.fromHash sbhLength
       root0 = Branch.head root'
       currentBranch0 = Branch.head currentBranch'

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -77,7 +77,7 @@ data Input
     | NamesI (HQ.HashQualified Name)
     | AliasTermI HashOrHQSplit' (Path.Split 'Unchecked)
     | AliasTypeI HashOrHQSplit' (Path.Split 'Unchecked)
-    | AliasManyI [Path.HQSplit 'Unchecked] (Path 'Unchecked)
+    | AliasManyI [Path.HQSplit 'Relative] (Path 'Unchecked)
     -- Move = Rename; It's an HQSplit' not an HQSplit', meaning the arg has to have a name.
     | MoveTermI (Path.HQSplit 'Unchecked) (Path.Split 'Unchecked)
     | MoveTypeI (Path.HQSplit 'Unchecked) (Path.Split 'Unchecked)

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -36,9 +36,9 @@ data Event
 
 type Source = Text -- "id x = x\nconst a b = a"
 type SourceName = Text -- "foo.u" or "buffer 7"
-type PatchPath = (Path.Split 'Relative)
+type PatchPath = (Path.Split 'Absolute)
 type BranchId = Either ShortBranchHash (Path 'Unchecked)
-type HashOrHQSplit' = Either ShortHash (Path.HQSplit 'Relative)
+type HashOrHQSplit' = Either ShortHash (Path.HQSplit 'Unchecked)
 
 parseBranchId :: String -> Either String BranchId
 parseBranchId ('#':s) = case SBH.fromText (Text.pack s) of
@@ -77,7 +77,7 @@ data Input
     | NamesI (HQ.HashQualified Name)
     | AliasTermI HashOrHQSplit' (Path.Split 'Unchecked)
     | AliasTypeI HashOrHQSplit' (Path.Split 'Unchecked)
-    | AliasManyI [Path.HQSplit 'Relative] (Path 'Unchecked)
+    | AliasManyI [Path.HQSplit 'Unchecked] (Path 'Unchecked)
     -- Move = Rename; It's an HQSplit' not an HQSplit', meaning the arg has to have a name.
     | MoveTermI (Path.HQSplit 'Unchecked) (Path.Split 'Unchecked)
     | MoveTypeI (Path.HQSplit 'Unchecked) (Path.Split 'Unchecked)

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -36,9 +36,9 @@ data Event
 
 type Source = Text -- "id x = x\nconst a b = a"
 type SourceName = Text -- "foo.u" or "buffer 7"
-type PatchPath = (Path.Split 'Unchecked)
+type PatchPath = (Path.Split 'Relative)
 type BranchId = Either ShortBranchHash (Path 'Unchecked)
-type HashOrHQSplit' = Either ShortHash (Path.HQSplit 'Unchecked)
+type HashOrHQSplit' = Either ShortHash (Path.HQSplit 'Relative)
 
 parseBranchId :: String -> Either String BranchId
 parseBranchId ('#':s) = case SBH.fromText (Text.pack s) of

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -36,7 +36,7 @@ data Event
 
 type Source = Text -- "id x = x\nconst a b = a"
 type SourceName = Text -- "foo.u" or "buffer 7"
-type PatchPath = (Path.Split 'Absolute)
+type PatchPath pos = (Path.Split pos)
 type BranchId = Either ShortBranchHash (Path 'Unchecked)
 type HashOrHQSplit' = Either ShortHash (Path.HQSplit 'Unchecked)
 
@@ -99,17 +99,17 @@ data Input
     | LoadI (Maybe FilePath)
     | AddI [HQ'.HashQualified Name]
     | PreviewAddI [HQ'.HashQualified Name]
-    | UpdateI (Maybe PatchPath) [HQ'.HashQualified Name]
+    | UpdateI (Maybe (PatchPath 'Unchecked)) [HQ'.HashQualified Name]
     | PreviewUpdateI [HQ'.HashQualified Name]
-    | TodoI (Maybe PatchPath) (Path 'Unchecked)
-    | PropagatePatchI PatchPath (Path 'Unchecked)
-    | ListEditsI (Maybe PatchPath)
+    | TodoI (Maybe (PatchPath 'Unchecked)) (Path 'Unchecked)
+    | PropagatePatchI (PatchPath 'Unchecked) (Path 'Unchecked)
+    | ListEditsI (Maybe (PatchPath 'Unchecked))
     -- -- create and remove update directives
-    | DeprecateTermI PatchPath (Path.HQSplit 'Unchecked)
-    | DeprecateTypeI PatchPath (Path.HQSplit 'Unchecked)
-    | ReplaceI (HQ.HashQualified Name) (HQ.HashQualified Name) (Maybe PatchPath)
-    | RemoveTermReplacementI (HQ.HashQualified Name) (Maybe PatchPath)
-    | RemoveTypeReplacementI (HQ.HashQualified Name) (Maybe PatchPath)
+    | DeprecateTermI (PatchPath 'Unchecked) (Path.HQSplit 'Unchecked)
+    | DeprecateTypeI (PatchPath 'Unchecked) (Path.HQSplit 'Unchecked)
+    | ReplaceI (HQ.HashQualified Name) (HQ.HashQualified Name) (Maybe (PatchPath 'Unchecked))
+    | RemoveTermReplacementI (HQ.HashQualified Name) (Maybe (PatchPath 'Unchecked))
+    | RemoveTypeReplacementI (HQ.HashQualified Name) (Maybe (PatchPath 'Unchecked))
   | UndoI
   -- First `Maybe Int` is cap on number of results, if any
   -- Second `Maybe Int` is cap on diff elements shown, if any

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -193,7 +193,7 @@ data Output v
   | TermMissingType Reference
   | MetadataAmbiguous (HQ.HashQualified Name) PPE.PrettyPrintEnv [Referent]
   -- todo: tell the user to run `todo` on the same patch they just used
-  | NothingToPatch PatchPath (Path 'Unchecked)
+  | NothingToPatch (PatchPath 'Unchecked) (Path 'Unchecked)
   | PatchNeedsToBeConflictFree
   | PatchInvolvesExternalDependents PPE.PrettyPrintEnv (Set Reference)
   | WarnIncomingRootBranch ShortBranchHash (Set ShortBranchHash)

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -86,7 +86,7 @@ data NumberedOutput v
   | ShowDiffAfterPull (Path 'Unchecked) (Path 'Absolute) PPE.PrettyPrintEnv (BranchDiffOutput v Ann)
   | ShowDiffAfterCreatePR ReadRemoteNamespace ReadRemoteNamespace PPE.PrettyPrintEnv (BranchDiffOutput v Ann)
   -- <authorIdentifier> <authorPath> <relativeBase>
-  | ShowDiffAfterCreateAuthor NameSegment (Path 'Unchecked) (Path 'Absolute) PPE.PrettyPrintEnv (BranchDiffOutput v Ann)
+  | ShowDiffAfterCreateAuthor NameSegment (Path 'Relative) (Path 'Absolute) PPE.PrettyPrintEnv (BranchDiffOutput v Ann)
 
 --  | ShowDiff
 
@@ -184,7 +184,7 @@ data Output v
   | BustedBuiltins (Set Reference) (Set Reference)
   | GitError Input GitError
   | ConfiguredMetadataParseError (Path 'Unchecked) String (P.Pretty P.ColorText)
-  | NoConfiguredGitUrl PushPull (Path 'Absolute)
+  | NoConfiguredGitUrl PushPull (Path 'Unchecked)
   | ConfiguredGitUrlParseError PushPull (Path 'Unchecked) Text String
   | DisplayLinks PPE.PrettyPrintEnvDecl Metadata.Metadata
                (Map Reference (DisplayObject () (Decl v Ann)))

--- a/parser-typechecker/src/Unison/Codebase/Editor/RemoteRepo.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/RemoteRepo.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DataKinds #-}
 module Unison.Codebase.Editor.RemoteRepo where
 
 import Unison.Prelude
@@ -22,19 +23,19 @@ printReadRepo ReadGitRepo{..} = url -- <> Monoid.fromMaybe (Text.cons ':' <$> co
 printWriteRepo :: WriteRepo -> Text
 printWriteRepo WriteGitRepo{..} = url' -- <> Monoid.fromMaybe (Text.cons ':' <$> branch)
 
-printNamespace :: ReadRepo -> Maybe ShortBranchHash -> Path -> Text
+printNamespace :: ReadRepo -> Maybe ShortBranchHash -> Path 'Path.Absolute -> Text
 printNamespace repo sbh path =
   printReadRepo repo <> case sbh of
-    Nothing -> if path == Path.empty then mempty
-      else ":." <> Path.toText path
+    Nothing -> if Path.isRoot path then mempty
+      else ":" <> Path.toText path
     Just sbh -> ":#" <> SBH.toText sbh <>
-      if path == Path.empty then mempty
+      if Path.isRoot path then mempty
       else "." <> Path.toText path
 
-printHead :: WriteRepo -> Path -> Text
+printHead :: WriteRepo -> Path 'Path.Absolute -> Text
 printHead repo path =
   printWriteRepo repo
-    <> if path == Path.empty then mempty else ":." <> Path.toText path
+    <> if Path.isRoot path then mempty else ":" <> Path.toText path
 
-type ReadRemoteNamespace = (ReadRepo, Maybe ShortBranchHash, Path)
-type WriteRemotePath = (WriteRepo, Path)
+type ReadRemoteNamespace = (ReadRepo, Maybe ShortBranchHash, Path 'Path.Absolute)
+type WriteRemotePath = (WriteRepo, Path 'Path.Absolute)

--- a/parser-typechecker/src/Unison/Codebase/Editor/UriParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/UriParser.hs
@@ -6,19 +6,19 @@ module Unison.Codebase.Editor.UriParser (repoPath,writeRepo,writeRepoPath) where
 import qualified Text.Megaparsec as P
 import qualified Text.Megaparsec.Char.Lexer as L
 import qualified Text.Megaparsec.Char as C
-import Data.Text as Text
+import Data.Text as Text ( Text, unpack, pack, cons )
 
-import Unison.Codebase.Path (Path(..))
+import Unison.Codebase.Path (Path)
 import qualified Unison.Codebase.Path as Path
 import Unison.Codebase.Editor.RemoteRepo (ReadRemoteNamespace, ReadRepo (ReadGitRepo), WriteRemotePath, WriteRepo (WriteGitRepo))
 import Unison.Codebase.ShortBranchHash (ShortBranchHash(..))
-import Unison.Prelude
+import Unison.Prelude ( void, Alternative((<|>)), fromMaybe )
 import qualified Unison.Hash as Hash
 import qualified Unison.Lexer
 import Unison.NameSegment (NameSegment(..))
-import Data.Sequence as Seq
+import Data.Sequence as Seq ()
 import Data.Char (isAlphaNum, isSpace, isDigit)
-import Unison.Codebase.Position
+import Unison.Codebase.Position ( Position(Absolute) )
 
 type P = P.Parsec () Text
 
@@ -162,7 +162,7 @@ namespaceHashPath = do
 absolutePath :: P (Path 'Absolute)
 absolutePath = do
   void $ C.char '.'
-  AbsoluteP . Seq.fromList . fmap (NameSegment . Text.pack) <$>
+  Path.absoluteFromSegments . fmap (NameSegment . Text.pack) <$>
     P.sepBy1
       ((:) <$> C.satisfy Unison.Lexer.wordyIdStartChar
            <*> P.many (C.satisfy Unison.Lexer.wordyIdChar))

--- a/parser-typechecker/src/Unison/Codebase/Editor/VersionParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/VersionParser.hs
@@ -26,4 +26,4 @@ defaultBaseLib = fmap makeNS $ latest <|> release
   makeNS :: Text -> ReadRemoteNamespace
   makeNS t = ( ReadGitRepo "https://github.com/unisonweb/base"
              , Nothing
-             , Path.fromText t)
+             , Path.unsafeToAbsolute $ Path.fromText t)

--- a/parser-typechecker/src/Unison/Codebase/GitError.hs
+++ b/parser-typechecker/src/Unison/Codebase/GitError.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 module Unison.Codebase.GitError where
 
 import Unison.Prelude
@@ -25,5 +26,5 @@ data GitCodebaseError h
   | RemoteNamespaceHashAmbiguous ReadRepo ShortBranchHash (Set h)
   | CouldntLoadRootBranch ReadRepo h
   | CouldntLoadSyncedBranch ReadRemoteNamespace h
-  | CouldntFindRemoteBranch ReadRepo Path
+  | CouldntFindRemoteBranch ReadRepo (Path 'Absolute)
   deriving Show

--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -144,8 +144,9 @@ root :: Path 'Absolute
 root = AbsoluteP mempty
 
 toText :: Path pos -> Text
-toText = match (("." <>) . segmentsToText)
-                segmentsToText
+toText = \case
+  AbsolutePath p -> ("." <> segmentsToText p)
+  RelativePath p -> segmentsToText p
   where
     segmentsToText = (intercalateMap "." NameSegment.toText . view segments_)
 

--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -45,6 +45,7 @@ module Unison.Codebase.Path
     -- toList,
     toName,
     toText,
+    intoRelative,
     unsplit,
     unsplitHQ,
 
@@ -201,6 +202,9 @@ hqSplitFromName = fmap (fmap HQ'.fromName) . Lens.unsnoc . fromName
 
 splitFromName :: Name -> Maybe (Split 'Unchecked)
 splitFromName = Lens.unsnoc . fromName
+
+intoRelative :: Path pos -> Path 'Relative
+intoRelative = match (\(AbsoluteP ns) -> RelativeP ns) id
 
 -- | what is this? —AI
 -- unprefixName :: Absolute -> Name -> Name

--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -3,65 +3,56 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms   #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
 
 module Unison.Codebase.Path
   ( Path (..),
-    Path' (..),
-    Absolute (..),
-    Relative (..),
-    Resolve (..),
-    pattern Empty,
-    singleton,
-    Unison.Codebase.Path.uncons,
-    empty,
-    absoluteEmpty,
-    relativeEmpty',
+    -- Resolve (..),
+    -- pattern Empty,
+    -- singleton,
+    -- Unison.Codebase.Path.uncons,
+    -- absoluteEmpty,
+    -- relativeEmpty',
     currentPath,
     prefix,
-    unprefix,
-    prefixName,
-    unprefixName,
+    -- This seems semantically invalid
+    -- unprefix,
+    -- prefixName,
+    -- unprefixName,
     HQSplit,
     Split,
-    Split',
-    HQSplit',
     ancestors,
 
     -- * tests
     isCurrentPath,
     isRoot,
-    isRoot',
 
     -- * things that could be replaced with `Convert` instances
-    absoluteToPath',
-    fromAbsoluteSplit,
-    fromList,
+    -- fromAbsoluteSplit,
+    -- fromList,
     fromName,
-    fromName',
-    fromPath',
+    -- fromPath',
     fromText,
-    toAbsoluteSplit,
-    toList,
+    -- toAbsoluteSplit,
+    -- Should this be exposed?
+    -- toList,
     toName,
-    toName',
-    toPath',
     toText,
-    toText',
     unsplit,
-    unsplit',
     unsplitHQ,
-    unsplitHQ',
 
     -- * things that could be replaced with `Parse` instances
-    splitFromName,
-    hqSplitFromName',
+    -- splitFromName,
+    hqSplitFromName,
 
     -- * things that could be replaced with `Cons` instances
-    cons,
+    -- cons,
 
     -- * things that could be replaced with `Snoc` instances
-    snoc,
-    unsnoc,
+    Lens.snoc,
+    Lens.unsnoc,
 
   -- This should be moved to a common util module, or we could use the 'witch' package.
   Convert(..)
@@ -71,153 +62,145 @@ import Unison.Prelude hiding (empty, toList)
 
 import Control.Lens hiding (Empty, cons, snoc, unsnoc)
 import qualified Control.Lens as Lens
-import qualified Data.Foldable as Foldable
-import Data.List.Extra (dropPrefix)
 import qualified Data.List.NonEmpty as List.NonEmpty
-import Data.Sequence (Seq ((:<|), (:|>)))
+import Data.Sequence (Seq ((:<|)))
 import qualified Data.Sequence as Seq
 import qualified Data.Text as Text
 import qualified Unison.HashQualified' as HQ'
 import Unison.Name (Convert(..), Name, Parse)
 import qualified Unison.Name as Name
-import Unison.NameSegment (NameSegment (NameSegment))
+import Unison.NameSegment (NameSegment)
 import qualified Unison.NameSegment as NameSegment
 import Unison.Util.Monoid (intercalateMap)
+import Data.Function (on)
 
--- `Foo.Bar.baz` becomes ["Foo", "Bar", "baz"]
-newtype Path = Path { toSeq :: Seq NameSegment } deriving (Eq, Ord, Semigroup, Monoid)
+data Position = Relative | Absolute | Unchecked
 
-newtype Absolute = Absolute { unabsolute :: Path } deriving (Eq,Ord)
-newtype Relative = Relative { unrelative :: Path } deriving (Eq,Ord)
-newtype Path' = Path' { unPath' :: Either Absolute Relative }
-  deriving (Eq,Ord)
+data Path (pos :: Position) where
+  AbsoluteP :: Seq NameSegment -> Path 'Absolute
+  RelativeP :: Seq NameSegment -> Path 'Relative
+  UncheckedP :: Either (Path 'Absolute) (Path 'Relative) -> Path 'Unchecked
 
-isCurrentPath :: Path' -> Bool
-isCurrentPath p = p == currentPath
+instance Eq (Path pos) where
+  (==) = (==) `on` (view segments_)
 
-currentPath :: Path'
-currentPath = Path' (Right (Relative (Path mempty)))
+instance Ord (Path pos) where
+  compare = compare `on` (view segments_)
 
-isRoot' :: Path' -> Bool
-isRoot' = either isRoot (const False) . unPath'
+unchecked :: Path pos -> Path 'Unchecked
+unchecked = match (UncheckedP . Left) (UncheckedP . Right)
 
-isRoot :: Absolute -> Bool
-isRoot = Seq.null . toSeq . unabsolute
+  -- = Path { toSeq :: Seq NameSegment } deriving (Eq, Ord, Semigroup, Monoid)
 
-absoluteToPath' :: Absolute -> Path'
-absoluteToPath' abs = Path' (Left abs)
+-- newtype Absolute = Absolute { unabsolute :: Path } deriving (Eq,Ord)
+-- newtype Relative = Relative { unrelative :: Path } deriving (Eq,Ord)
+-- newtype Path' = Path' { unPath' :: Either Absolute Relative }
+  -- deriving (Eq,Ord)
 
+segments_ :: Lens' (Path pos) (Seq NameSegment)
+segments_ = lens getter setter
+  where
+    getter p = match (\(AbsoluteP p) -> p) (\(RelativeP p) -> p) p
+    setter :: Path pos -> Seq NameSegment -> Path pos
+    setter p segments = case p of
+      AbsoluteP{} -> AbsoluteP segments
+      RelativeP{} -> RelativeP segments
+      UncheckedP (Left p) -> UncheckedP (Left $ setter p segments)
+      UncheckedP (Right p) -> UncheckedP (Right $ setter p segments)
 
+match :: (Path 'Absolute -> r) -> (Path 'Relative -> r) -> Path pos -> r
+match onAbs onRel = \case
+  p@AbsoluteP{} -> onAbs p
+  p@RelativeP{} -> onRel p
+  (UncheckedP (Left p)) -> onAbs p
+  (UncheckedP (Right p)) -> onRel p
 
-instance Show Path' where
-  show (Path' (Left abs)) = show abs
-  show (Path' (Right rel)) = show rel
+isCurrentPath :: Path 'Relative -> Bool
+isCurrentPath = (== currentPath)
 
-instance Show Absolute where
-  show s = "." ++ show (unabsolute s)
+currentPath :: Path 'Relative
+currentPath = RelativeP mempty
 
-instance Show Relative where
-  show = show . unrelative
+isRoot :: Path 'Absolute -> Bool
+isRoot = (== rootPath)
 
-unsplit' :: Split' -> Path'
-unsplit' (Path' (Left (Absolute p)), seg) = Path' (Left (Absolute (unsplit (p, seg))))
-unsplit' (Path' (Right (Relative p)), seg) = Path' (Right (Relative (unsplit (p, seg))))
+rootPath :: Path 'Absolute
+rootPath = AbsoluteP mempty
 
-unsplit :: Split -> Path
-unsplit (Path p, a) = Path (p :|> a)
+toText :: Path pos -> Text
+toText = match (("." <>) . segmentsToText)
+                segmentsToText
+  where
+    segmentsToText = (intercalateMap "." NameSegment.toText . view segments_)
 
-unsplitHQ :: HQSplit -> HQ'.HashQualified Path
-unsplitHQ (p, a) = fmap (snoc p) a
+instance Show (Path pos) where
+  show = Text.unpack . toText
 
-unsplitHQ' :: HQSplit' -> HQ'.HashQualified Path'
-unsplitHQ' (p, a) = fmap (snoc' p) a
+type Split pos = (Path pos, NameSegment)
+type HQSplit pos = (Path pos, HQ'.HQSegment)
 
-type Split = (Path, NameSegment)
-type HQSplit = (Path, HQ'.HQSegment)
+unsplit :: Split pos -> Path pos
+unsplit (p, a) = p & segments_ %~ Lens.cons a
 
-type Split' = (Path', NameSegment)
-type HQSplit' = (Path', HQ'.HQSegment)
-
-type HQSplitAbsolute = (Absolute, HQ'.HQSegment)
+unsplitHQ :: HQSplit pos -> HQ'.HashQualified (Path pos)
+unsplitHQ (p, a) = fmap (Lens.snoc p) a
 
 -- | examples:
 --   unprefix .foo.bar .blah == .blah (absolute paths left alone)
 --   unprefix .foo.bar id    == id    (relative paths starting w/ nonmatching prefix left alone)
 --   unprefix .foo.bar foo.bar.baz == baz (relative paths w/ common prefix get stripped)
-unprefix :: Absolute -> Path' -> Path
-unprefix (Absolute prefix) (Path' p) = case p of
-  Left abs -> unabsolute abs
-  Right (unrelative -> rel) -> fromList $ dropPrefix (toList prefix) (toList rel)
+-- unprefix :: Path 'Absolute -> Path pos -> Path 'Unchecked
+-- unprefix (Absolute prefix) (Path' p) = case p of
+--   Left abs -> unabsolute abs
+--   Right (unrelative -> rel) -> fromList $ dropPrefix (toList prefix) (toList rel)
 
--- too many types
-prefix :: Absolute -> Path' -> Path
-prefix (Absolute (Path prefix)) (Path' p) = case p of
-  Left (unabsolute -> abs) -> abs
-  Right (unrelative -> rel) -> Path $ prefix <> toSeq rel
+-- unprefix :: Path 'Absolute -> Path 'Relative -> Path 'Relative'
+
+-- Attach a relative path to another path.
+prefix :: Path pos -> Path 'Relative -> Path pos
+prefix pref suff = pref & segments_ %~ (<> (suff ^. segments_))
+-- prefix (Absolute (Path prefix)) (Path' p) = case p of
+--   Left (unabsolute -> abs) -> abs
+--   Right (unrelative -> rel) -> Path $ prefix <> toSeq rel
 
 
-toAbsoluteSplit :: Absolute -> (Path', a) -> (Absolute, a)
-toAbsoluteSplit a (p, s) = (resolve a p, s)
+-- toAbsoluteSplit :: Absolute -> (Path', a) -> (Absolute, a)
+-- toAbsoluteSplit a (p, s) = (resolve a p, s)
 
-fromAbsoluteSplit :: (Absolute, a) -> (Path, a)
-fromAbsoluteSplit (Absolute p, a) = (p, a)
+-- fromAbsoluteSplit :: (Absolute, a) -> (Path, a)
+-- fromAbsoluteSplit (Absolute p, a) = (p, a)
 
-absoluteEmpty :: Absolute
-absoluteEmpty = Absolute empty
+-- absoluteEmpty :: Absolute
+-- absoluteEmpty = Absolute empty
 
-relativeEmpty' :: Path'
-relativeEmpty' = Path' (Right (Relative empty))
+-- relativeEmpty' :: Path'
+-- relativeEmpty' = Path' (Right (Relative empty))
 
-toPath' :: Path -> Path'
-toPath' = \case
-  Path (NameSegment "" :<| tail) -> Path' . Left . Absolute . Path $ tail
-  p -> Path' . Right . Relative $ p
+-- Should these be exposed??
+-- toList :: Path -> [NameSegment]
+-- toList = Foldable.toList . toSeq
 
--- Forget whether the path is absolute or relative
-fromPath' :: Path' -> Path
-fromPath' (Path' e) = case e of
-  Left  (Absolute p) -> p
-  Right (Relative p) -> p
+-- fromList :: [NameSegment] -> Path
+-- fromList = Path . Seq.fromList
 
-toList :: Path -> [NameSegment]
-toList = Foldable.toList . toSeq
+ancestors :: Path 'Absolute -> Seq (Path 'Absolute)
+ancestors p = AbsoluteP <$> Seq.inits (view segments_ p)
 
-fromList :: [NameSegment] -> Path
-fromList = Path . Seq.fromList
+hqSplitFromName :: Name -> Maybe (HQSplit 'Unchecked)
+hqSplitFromName = fmap (fmap HQ'.fromName) . Lens.unsnoc . fromName
 
-ancestors :: Absolute -> Seq Absolute
-ancestors (Absolute (Path segments)) = Absolute . Path <$> Seq.inits segments
-
-hqSplitFromName' :: Name -> Maybe HQSplit'
-hqSplitFromName' = fmap (fmap HQ'.fromName) . Lens.unsnoc . fromName'
-
-splitFromName :: Name -> Maybe Split
-splitFromName = unsnoc . fromName
+splitFromName :: Name -> Maybe (Split 'Unchecked)
+splitFromName = Lens.unsnoc . fromName
 
 -- | what is this? —AI
-unprefixName :: Absolute -> Name -> Name
-unprefixName prefix = toName . unprefix prefix . fromName'
+-- unprefixName :: Absolute -> Name -> Name
+-- unprefixName prefix = toName . unprefix prefix . fromName'
 
-prefixName :: Absolute -> Name -> Name
-prefixName p = toName . prefix p . fromName'
+-- prefixName :: Absolute -> Name -> Name
+-- prefixName p = toName . prefix p . fromName'
 
-singleton :: NameSegment -> Path
-singleton n = fromList [n]
-
-cons :: NameSegment -> Path -> Path
-cons = Lens.cons
-
-snoc :: Path -> NameSegment -> Path
-snoc = Lens.snoc
-
-snoc' :: Path' -> NameSegment -> Path'
-snoc' = Lens.snoc
-
-unsnoc :: Path -> Maybe (Path, NameSegment)
-unsnoc = Lens.unsnoc
-
-uncons :: Path -> Maybe (NameSegment, Path)
-uncons = Lens.uncons
+-- singleton :: NameSegment -> Path
+-- singleton n = fromList [n]
 
 -- > Path.fromName . Name.unsafeFromText $ ".Foo.bar"
 -- /Foo/bar
@@ -228,139 +211,83 @@ uncons = Lens.uncons
 --                      and "Int" / "" / "foo" is not a valid path (internal "")
 -- todo: fromName needs to be a little more complicated if we want to allow
 --       identifiers called Function.(.)
-fromName :: Name -> Path
-fromName = fromList . List.NonEmpty.toList . Name.segments
+fromName :: Name -> Path 'Unchecked
+fromName n = 
+  let segments = Seq.fromList . List.NonEmpty.toList . Name.segments $ n
+   in if Name.isAbsolute n 
+         then unchecked $ AbsoluteP segments
+         else unchecked $ RelativeP segments
 
-fromName' :: Name -> Path'
-fromName' n = case take 1 (Name.toString n) of
-  "." -> Path' . Left . Absolute $ Path seq
-  _   -> Path' . Right $ Relative path
- where
-  path = fromName n
-  seq  = toSeq path
-
-toName :: Path -> Name
+toName :: Path pos -> Name
 toName = Name.unsafeFromText . toText
 
--- | Convert a Path' to a Name
-toName' :: Path' -> Name
-toName' = Name.unsafeFromText . toText'
+fromText :: Text -> Path 'Unchecked
+fromText t = case NameSegment.splitText t of
+  (True, segments) -> unchecked . AbsoluteP $ Seq.fromList segments
+  (False, segments)-> unchecked . RelativeP $ Seq.fromList segments
 
-pattern Empty = Path Seq.Empty
-
-empty :: Path
-empty = Path mempty
-
-instance Show Path where
-  show = Text.unpack . toText
-
--- | Note: This treats the path as relative.
-toText :: Path -> Text
-toText (Path nss) = intercalateMap "." NameSegment.toText nss
-
-fromText :: Text -> Path
-fromText = \case
-  "" -> empty
-  t -> fromList $ NameSegment <$> NameSegment.segments' t
-
-toText' :: Path' -> Text
-toText' = \case
-  Path' (Left (Absolute path)) -> Text.cons '.' (toText path)
-  Path' (Right (Relative path)) -> toText path
-
-instance Cons Path Path NameSegment NameSegment where
+instance Cons (Path 'Relative) (Path 'Relative) NameSegment NameSegment where
   _Cons = prism (uncurry cons) uncons where
-    cons :: NameSegment -> Path -> Path
-    cons ns (Path p) = Path (ns :<| p)
-    uncons :: Path -> Either Path (NameSegment, Path)
-    uncons p = case p of
-      Path (hd :<| tl) -> Right (hd, Path tl)
+    cons :: NameSegment -> Path 'Relative -> Path 'Relative
+    cons ns = over segments_ (Lens.cons ns)
+    uncons :: Path 'Relative -> Either (Path 'Relative) (NameSegment, Path 'Relative)
+    uncons p = case p ^. segments_ of
+      (hd :<| tl) -> Right (hd, p & segments_ .~ tl)
       _ -> Left p
 
-instance Snoc Relative Relative NameSegment NameSegment where
-  _Snoc = prism (uncurry snocRelative) $ \case
-    Relative (Lens.unsnoc -> Just (s,a)) -> Right (Relative s,a)
-    e -> Left e
-    where
-    snocRelative :: Relative -> NameSegment -> Relative
-    snocRelative r n = Relative . (`Lens.snoc` n) $ unrelative r
-
-instance Snoc Absolute Absolute NameSegment NameSegment where
-  _Snoc = prism (uncurry snocAbsolute) $ \case
-    Absolute (Lens.unsnoc -> Just (s,a)) -> Right (Absolute s, a)
-    e -> Left e
-    where
-    snocAbsolute :: Absolute -> NameSegment -> Absolute
-    snocAbsolute a n = Absolute . (`Lens.snoc` n) $ unabsolute a
-
-instance Snoc Path Path NameSegment NameSegment where
+instance Snoc (Path pos) (Path pos) NameSegment NameSegment where
   _Snoc = prism (uncurry snoc) unsnoc
     where
-    unsnoc :: Path -> Either Path (Path, NameSegment)
-    unsnoc = \case
-      Path (s Seq.:|> a) -> Right (Path s, a)
-      e -> Left e
-    snoc :: Path -> NameSegment -> Path
-    snoc (Path p) ns = Path (p <> pure ns)
+      snoc :: Path pos -> NameSegment -> Path pos
+      snoc p ns = p & segments_ %~ (Lens.|> ns)
+      unsnoc :: Path pos -> Either (Path pos) (Path pos, NameSegment)
+      unsnoc p = case p ^. segments_ of
+        (pref :> ns) -> Right (p & segments_ .~ pref, ns)
+        _ -> Left p
 
-instance Snoc Path' Path' NameSegment NameSegment where
-  _Snoc = prism (uncurry snoc') $ \case
-    Path' (Left (Lens.unsnoc -> Just (s,a))) -> Right (Path' (Left s), a)
-    Path' (Right (Lens.unsnoc -> Just (s,a))) -> Right (Path' (Right s), a)
-    e -> Left e
-    where
-    snoc' :: Path' -> NameSegment -> Path'
-    snoc' (Path' e) n = case e of
-      Left abs -> Path' (Left . Absolute $ Lens.snoc (unabsolute abs) n)
-      Right rel -> Path' (Right . Relative $ Lens.snoc (unrelative rel) n)
+-- instance Snoc Split' Split' NameSegment NameSegment where
+--   _Snoc = prism (uncurry snoc') $ \case -- unsnoc
+--     (Lens.unsnoc -> Just (s, a), ns) -> Right ((s, a), ns)
+--     e -> Left e
+--     where
+--     snoc' :: Split' -> NameSegment -> Split'
+--     snoc' (p, a) n = (Lens.snoc p a, n)
 
-instance Snoc Split' Split' NameSegment NameSegment where
-  _Snoc = prism (uncurry snoc') $ \case -- unsnoc
-    (Lens.unsnoc -> Just (s, a), ns) -> Right ((s, a), ns)
-    e -> Left e
-    where
-    snoc' :: Split' -> NameSegment -> Split'
-    snoc' (p, a) n = (Lens.snoc p a, n)
+-- class Resolve l r o where
+--   resolve :: l -> r -> o
 
-class Resolve l r o where
-  resolve :: l -> r -> o
+-- instance Resolve Path Path Path where
+--   resolve (Path l) (Path r) = Path (l <> r)
 
-instance Resolve Path Path Path where
-  resolve (Path l) (Path r) = Path (l <> r)
+-- instance Resolve Relative Relative Relative where
+--   resolve (Relative (Path l)) (Relative (Path r)) = Relative (Path (l <> r))
 
-instance Resolve Relative Relative Relative where
-  resolve (Relative (Path l)) (Relative (Path r)) = Relative (Path (l <> r))
+-- instance Resolve Absolute Relative Absolute where
+--   resolve (Absolute l) (Relative r) = Absolute (resolve l r)
 
-instance Resolve Absolute Relative Absolute where
-  resolve (Absolute l) (Relative r) = Absolute (resolve l r)
+-- instance Resolve Path' Path' Path' where
+--   resolve _ a@(Path' Left{}) = a
+--   resolve (Path' (Left a)) (Path' (Right r)) = Path' (Left (resolve a r))
+--   resolve (Path' (Right r1)) (Path' (Right r2)) = Path' (Right (resolve r1 r2))
 
-instance Resolve Path' Path' Path' where
-  resolve _ a@(Path' Left{}) = a
-  resolve (Path' (Left a)) (Path' (Right r)) = Path' (Left (resolve a r))
-  resolve (Path' (Right r1)) (Path' (Right r2)) = Path' (Right (resolve r1 r2))
+-- instance Resolve Path' Split' Path' where
+--   resolve l r = resolve l (unsplit' r)
 
-instance Resolve Path' Split' Path' where
-  resolve l r = resolve l (unsplit' r)
+-- instance Resolve Path' Split' Split' where
+--   resolve l (r, ns) = (resolve l r, ns)
 
-instance Resolve Path' Split' Split' where
-  resolve l (r, ns) = (resolve l r, ns)
+-- instance Resolve Absolute HQSplit HQSplitAbsolute where
+--   resolve l (r, hq) = (resolve l (Relative r), hq)
 
-instance Resolve Absolute HQSplit HQSplitAbsolute where
-  resolve l (r, hq) = (resolve l (Relative r), hq)
+-- instance Resolve Absolute Path' Absolute where
+--   resolve _ (Path' (Left a)) = a
+--   resolve a (Path' (Right r)) = resolve a r
 
-instance Resolve Absolute Path' Absolute where
-  resolve _ (Path' (Left a)) = a
-  resolve a (Path' (Right r)) = resolve a r
-
-instance Convert Absolute Text where convert = toText' . absoluteToPath'
-instance Convert Relative Text where convert = toText . unrelative
-instance Convert Absolute String where convert = Text.unpack . convert
-instance Convert Relative String where convert = Text.unpack . convert
-instance Convert [NameSegment] Path where convert = fromList
-instance Convert Path [NameSegment] where convert = toList
-instance Convert HQSplit (HQ'.HashQualified Path) where convert = unsplitHQ
-instance Convert Path Name where convert = toName
-instance Convert Path' Name where convert = toName'
-instance Convert HQSplit' (HQ'.HashQualified Path') where convert = unsplitHQ'
-instance Parse Name HQSplit' where parse = hqSplitFromName'
-instance Parse Name Split where parse = splitFromName
+instance Convert (Path pos) Text where convert = toText
+instance Convert (Path pos) String where convert = show
+-- instance Convert [NameSegment] Path where convert = fromList
+-- instance Convert Path [NameSegment] where convert = toList
+instance Convert (Path pos) Name where convert = toName
+instance Convert (HQSplit pos) (HQ'.HashQualified (Path pos)) where convert = unsplitHQ
+instance Parse Name (HQSplit 'Unchecked) where parse = hqSplitFromName
+instance Parse Name (Split 'Unchecked) where parse = splitFromName

--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -51,7 +51,6 @@ module Unison.Codebase.Path
     Lens.uncons,
     Lens.snoc,
     Lens.unsnoc,
-    unconsAbsolute,
     segments_,
 
     pattern Empty,
@@ -220,11 +219,6 @@ fromText :: Text -> Path 'Unchecked
 fromText t = case NameSegment.splitText t of
   (True, segments) -> unchecked . AbsoluteP $ Seq.fromList segments
   (False, segments)-> unchecked . RelativeP $ Seq.fromList segments
-
-unconsAbsolute :: Path 'Absolute -> Maybe (NameSegment, Path 'Relative)
-unconsAbsolute = \case
-  AbsoluteP (ns :< p) -> Just (ns, RelativeP p)
-  _ -> Nothing
 
 instance Cons (Path pos) (Path pos) NameSegment NameSegment where
   _Cons = prism (uncurry cons) uncons where

--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -295,6 +295,11 @@ instance AsEmpty (Path 'Relative) where
     RelativeP Lens.Empty -> Just ()
     _ -> Nothing
 
+instance AsEmpty (Path 'Absolute) where
+  _Empty = prism' (const $ AbsoluteP mempty) \case
+    AbsoluteP Lens.Empty -> Just ()
+    _ -> Nothing
+
 instance Snoc (Split pos) (Split pos) NameSegment NameSegment where
   _Snoc = prism (uncurry snoc') $ \case -- unsnoc
     (Lens.unsnoc -> Just (s, a), ns) -> Right ((s, a), ns)

--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -54,7 +54,7 @@ module Unison.Codebase.Path
     unconsAbsolute,
     segments_,
 
-    pattern Lens.Empty,
+    pattern Empty,
 
   -- This should be moved to a common util module, or we could use the 'witch' package.
   Convert(..)
@@ -89,6 +89,9 @@ pattern AbsolutePath p <- (match Just (const Nothing) -> Just p)
 pattern RelativePath :: Path 'Relative -> Path pos
 pattern RelativePath p <- (match (const Nothing) Just -> Just p)
 {-# COMPLETE AbsolutePath, RelativePath #-}
+
+pattern Empty :: Path pos
+pattern Empty <- (match (nullOf segments_) (nullOf segments_) -> True)
 
 instance Eq (Path pos) where
   (==) = (==) `on` (view segments_)
@@ -223,11 +226,11 @@ unconsAbsolute = \case
   AbsoluteP (ns :< p) -> Just (ns, RelativeP p)
   _ -> Nothing
 
-instance Cons (Path 'Relative) (Path 'Relative) NameSegment NameSegment where
+instance Cons (Path pos) (Path pos) NameSegment NameSegment where
   _Cons = prism (uncurry cons) uncons where
-    cons :: NameSegment -> Path 'Relative -> Path 'Relative
+    cons :: NameSegment -> Path pos -> Path pos
     cons ns = over segments_ (Lens.cons ns)
-    uncons :: Path 'Relative -> Either (Path 'Relative) (NameSegment, Path 'Relative)
+    uncons :: Path pos -> Either (Path pos) (NameSegment, Path pos)
     uncons p = case p ^. segments_ of
       (hd :<| tl) -> Right (hd, p & segments_ .~ tl)
       _ -> Left p

--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -12,9 +12,11 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Unison.Codebase.Path
-  ( Path (..),
+  ( Path,
     pattern AbsolutePath,
     pattern RelativePath,
+    absoluteFromSegments,
+    relativeFromSegments,
     Position(..),
     singleton,
     unchecked,
@@ -88,6 +90,11 @@ pattern AbsolutePath p <- (match Just (const Nothing) -> Just p)
 pattern RelativePath :: Path 'Relative -> Path pos
 pattern RelativePath p <- (match (const Nothing) Just -> Just p)
 {-# COMPLETE AbsolutePath, RelativePath #-}
+
+absoluteFromSegments :: [NameSegment] -> Path 'Absolute
+absoluteFromSegments = AbsoluteP . Seq.fromList
+relativeFromSegments :: [NameSegment] -> Path 'Relative
+relativeFromSegments = RelativeP . Seq.fromList
 
 pattern Empty :: Path pos
 pattern Empty <- (match (nullOf segments_) (nullOf segments_) -> True)

--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -28,7 +28,7 @@ module Unison.Codebase.Path
     -- This seems semantically invalid
     stripPrefix,
     -- prefixName,
-    -- unprefixName,
+    unprefixName,
     HQSplit,
     Split,
     ancestors,
@@ -179,8 +179,11 @@ unsplitHQ (p, a) = fmap (Lens.snoc p) a
 asList_ :: Iso (Seq a) (Seq b) [a] [b]
 asList_ = iso Foldable.toList Seq.fromList 
 
-stripPrefix :: Path 'Absolute -> Path 'Relative -> Path 'Relative
-stripPrefix p r = r & segments_ . asList_ %~ List.dropPrefix (p ^. segments_ . asList_)
+stripPrefix :: Path 'Absolute -> Path any -> Path 'Relative
+stripPrefix p r = 
+  let prefixSegments = p ^. segments_ . asList_
+      otherSegments = r ^. segments_ . asList_
+   in RelativeP (Seq.fromList $ List.dropPrefix prefixSegments otherSegments)
 
 -- toAbsoluteSplit :: Absolute -> (Path', a) -> (Absolute, a)
 -- toAbsoluteSplit a (p, s) = (resolve a p, s)
@@ -217,7 +220,7 @@ splitFromName = Lens.unsnoc . fromName
 
 -- | what is this? —AI
 unprefixName :: Path 'Absolute -> Name -> Name
-unprefixName prefix = toName . unprefix prefix . fromName
+unprefixName prefix = toName . stripPrefix prefix . fromName
 
 
 -- prefixName :: Absolute -> Name -> Name

--- a/parser-typechecker/src/Unison/Codebase/Path/Parse.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path/Parse.hs
@@ -24,7 +24,7 @@ import Unison.Codebase.Path
 import Control.Lens (_1, over)
 import qualified Control.Lens as Lens
 import Data.Bifunctor (first)
-import Data.List.Extra (stripPrefix)
+import qualified Data.List.Extra as List
 import qualified Data.Text as Text
 import qualified Unison.HashQualified' as HQ'
 import qualified Unison.Lexer as Lexer
@@ -87,7 +87,7 @@ wordyNameSegment s = case Lexer.wordyId0 s of
 
 -- Parse a name segment like "()"
 unit' :: String -> Either String (String, String)
-unit' s = case stripPrefix "()" s of
+unit' s = case List.stripPrefix "()" s of
   Nothing  -> Left $ "Expected () but found: " <> s
   Just rem -> Right ("()", rem)
 

--- a/parser-typechecker/src/Unison/Codebase/Path/Parse.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path/Parse.hs
@@ -163,6 +163,5 @@ parseHQSplit' s = case Text.breakOn "#" $ Text.pack s of
   parsePath n = do
     x <- parsePathImpl' $ Text.unpack n
     pure $ case x of
-      -- TODO: What is this doing?
-      -- (Path' (Left e), "") | e == absoluteEmpty -> (relativeEmpty', ".")
+      (AbsolutePath Empty, "") -> (unchecked currentPath, ".")
       x -> x

--- a/parser-typechecker/src/Unison/Codebase/Path/Parse.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path/Parse.hs
@@ -31,7 +31,6 @@ import qualified Unison.Lexer as Lexer
 import qualified Unison.NameSegment as NameSegment
 import Unison.NameSegment (NameSegment (NameSegment))
 import qualified Unison.ShortHash as SH
-import qualified Data.Sequence as Seq
 
 -- .libs.blah.poo is Absolute
 -- libs.blah.poo is Relative
@@ -55,8 +54,8 @@ parsePath' p = case parsePathImpl' p of
 parsePathImpl' :: String -> Either String (Path 'Unchecked, String)
 parsePathImpl' p = case p of
   "."     -> Right (unchecked root, "")
-  '.' : p -> over _1 (unchecked . AbsoluteP . Seq.fromList) <$> segs p
-  p       -> over _1 (unchecked . RelativeP . Seq.fromList) <$> segs p
+  '.' : p -> over _1 (unchecked . absoluteFromSegments) <$> segs p
+  p       -> over _1 (unchecked . relativeFromSegments) <$> segs p
  where
   go f p = case f p of
     Right (a, "") -> case Lens.unsnoc (NameSegment.segments' $ Text.pack a) of

--- a/parser-typechecker/src/Unison/Codebase/Position.hs
+++ b/parser-typechecker/src/Unison/Codebase/Position.hs
@@ -1,0 +1,5 @@
+module Unison.Codebase.Position
+  (Position(..))
+  where
+
+data Position = Relative | Absolute | Unchecked

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -1052,7 +1052,7 @@ viewRemoteBranch' (repo, sbh, path) = runExceptT @C.GitError do
                     Just b -> pure b
                     Nothing -> throwError . C.GitCodebaseError $ GitError.NoRemoteNamespaceWithHash repo sbh
                 _ -> throwError . C.GitCodebaseError $ GitError.RemoteNamespaceHashAmbiguous repo sbh branchCompletions
-          case Branch.getAt (Path.unsafeToRelative path) branch of
+          case Branch.getAt path branch of
             Just b -> pure (closeCodebase, b, remotePath)
             Nothing -> throwError . C.GitCodebaseError $ GitError.CouldntFindRemoteBranch repo path
     -- else there's no initialized codebase at this repo; we pretend there's an empty one.

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -109,7 +109,6 @@ import qualified Unison.WatchKind as UF
 import UnliftIO (MonadIO, catchIO, finally, liftIO)
 import UnliftIO.Directory (canonicalizePath, createDirectoryIfMissing, doesDirectoryExist, doesFileExist)
 import UnliftIO.STM
-import qualified Unison.Codebase.Path as Path
 
 debug, debugProcessBranches, debugCommitFailedTransaction :: Bool
 debug = False

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -109,6 +109,7 @@ import qualified Unison.WatchKind as UF
 import UnliftIO (MonadIO, catchIO, finally, liftIO)
 import UnliftIO.Directory (canonicalizePath, createDirectoryIfMissing, doesDirectoryExist, doesFileExist)
 import UnliftIO.STM
+import qualified Unison.Codebase.Path as Path
 
 debug, debugProcessBranches, debugCommitFailedTransaction :: Bool
 debug = False
@@ -1051,7 +1052,7 @@ viewRemoteBranch' (repo, sbh, path) = runExceptT @C.GitError do
                     Just b -> pure b
                     Nothing -> throwError . C.GitCodebaseError $ GitError.NoRemoteNamespaceWithHash repo sbh
                 _ -> throwError . C.GitCodebaseError $ GitError.RemoteNamespaceHashAmbiguous repo sbh branchCompletions
-          case Branch.getAt path branch of
+          case Branch.getAt (Path.unsafeToRelative path) branch of
             Just b -> pure (closeCodebase, b, remotePath)
             Nothing -> throwError . C.GitCodebaseError $ GitError.CouldntFindRemoteBranch repo path
     -- else there's no initialized codebase at this repo; we pretend there's an empty one.

--- a/parser-typechecker/src/Unison/CommandLine.hs
+++ b/parser-typechecker/src/Unison/CommandLine.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ViewPatterns        #-}
+{-# LANGUAGE DataKinds #-}
 
 
 module Unison.CommandLine
@@ -76,10 +77,11 @@ import Control.Lens (ifoldMap)
 import qualified Unison.CommandLine.Globbing as Globbing
 import qualified Unison.CommandLine.InputPattern as InputPattern
 import Unison.Codebase.Branch (Branch0)
-import qualified Unison.Codebase.Path as Path
 import Text.Regex.TDFA ((=~))
 import qualified Data.List as List
 import Data.List.Extra (nubOrd)
+import Unison.Codebase.Path (Path)
+import Unison.Codebase.Position
 
 disableWatchConfig :: Bool
 disableWatchConfig = False
@@ -259,7 +261,7 @@ fixupCompletion q cs@(h:t) = let
 
 parseInput
   :: Branch0 m -- ^ Root branch, used to expand globs
-  -> Path.Absolute -- ^ Current path from root, used to expand globs
+  -> Path 'Absolute -- ^ Current path from root, used to expand globs
   -> [String] -- ^ Numbered arguments
   -> Map String InputPattern -- ^ Input Pattern Map
   -> [String] -- ^ command:arguments

--- a/parser-typechecker/src/Unison/CommandLine/Globbing.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Globbing.hs
@@ -112,7 +112,7 @@ expandGlobs targets rootBranch currentPath s = Maybe.fromMaybe [s] $ do
         | otherwise = Branch.getAt0 (Path.unsafeToRelative currentPath) rootBranch
   let paths = expandGlobToPaths targets globPath currentBranch
   let relocatedPaths | isAbsolute = Path.unsafeToAbsolute <$> paths
-                     | otherwise = Path.prefix currentPath <$> paths
+                     | otherwise = Path.resolve currentPath <$> paths
   pure (Path.convert <$> relocatedPaths)
 
 

--- a/parser-typechecker/src/Unison/CommandLine/Globbing.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Globbing.hs
@@ -54,7 +54,7 @@ globPredicate globArg (NameSegment.toText -> ns') =
 -- | Expands a glob into a list of paths which lead to valid targets.
 expandGlobToPaths :: Set TargetType -> GlobPath -> Branch0 m -> [Path 'Relative]
 expandGlobToPaths targets globPath branch =
-  Path.relativePathFromNameSegments <$> expandGlobToNameSegments targets branch globPath
+  Path.relativeFromSegments <$> expandGlobToNameSegments targets branch globPath
 
 -- | Helper for 'expandGlobToPaths'
 expandGlobToNameSegments :: forall m. Set TargetType -> Branch0 m -> GlobPath -> [[NameSegment]]
@@ -113,7 +113,7 @@ expandGlobs targets rootBranch currentPath s = Maybe.fromMaybe [s] $ do
   let paths = expandGlobToPaths targets globPath currentBranch
   let relocatedPaths | isAbsolute = Path.unsafeToAbsolute <$> paths
                      | otherwise = Path.resolve currentPath <$> paths
-  pure (Path.convert <$> relocatedPaths)
+  pure (Text.unpack . Path.toText <$> relocatedPaths)
 
 
 -- | Parses a single name segment into a GlobArg or a bare segment according to whether

--- a/parser-typechecker/src/Unison/CommandLine/Globbing.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Globbing.hs
@@ -109,7 +109,7 @@ expandGlobs targets rootBranch currentPath s = Maybe.fromMaybe [s] $ do
   let currentBranch :: Branch0 m
       currentBranch
         | isAbsolute = rootBranch
-        | otherwise = Branch.getAt0 (Path.unsafeToRelative currentPath) rootBranch
+        | otherwise = Branch.getAt0 currentPath rootBranch
   let paths = expandGlobToPaths targets globPath currentBranch
   let relocatedPaths | isAbsolute = Path.unsafeToAbsolute <$> paths
                      | otherwise = Path.resolve currentPath <$> paths

--- a/parser-typechecker/src/Unison/CommandLine/InputPattern.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPattern.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ViewPatterns        #-}
+{-# LANGUAGE DataKinds #-}
 
 
 module Unison.CommandLine.InputPattern where
@@ -39,7 +40,7 @@ data ArgumentType = ArgumentType
                 => String
                 -> Codebase m v a
                 -> Branch m -- Root Branch
-                -> Path.Absolute -- Current path
+                -> Path 'Absolute -- Current path
                 -> m [Line.Completion]
   -- | Select which targets glob patterns may expand into for this argument.
   -- An empty set disables globbing.
@@ -91,7 +92,7 @@ noSuggestions
   => String
   -> Codebase m v a
   -> Branch m
-  -> Path.Absolute
+  -> Path 'Absolute
   -> m [Line.Completion]
 noSuggestions _ _ _ _ = pure []
 

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -563,7 +563,7 @@ aliasMany = InputPattern "alias.many" ["copy"]
     srcs@(_:_) Cons.:> dest -> first fromString $ do
       sourceDefinitions <- traverse Path.parseHQSplit srcs
       destNamespace <- Path.parsePath' dest
-      pure $ Input.AliasManyI (first Path.unchecked <$> sourceDefinitions) destNamespace
+      pure $ Input.AliasManyI sourceDefinitions destNamespace
     _ -> Left (I.help aliasMany)
   )
 

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -1608,7 +1608,7 @@ pathCompletor
   -> f [Completion]
 pathCompletor filterQuery getNames query _code b p = let
   b0root = Branch.head b
-  b0local = Branch.getAt0 (Path.unsafeToRelative p) b0root
+  b0local = Branch.getAt0 p b0root
   -- todo: if these sets are huge, maybe trim results
   in pure . filterQuery query . map Text.unpack $
        toList (getNames b0local) ++

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -563,7 +563,7 @@ aliasMany = InputPattern "alias.many" ["copy"]
     srcs@(_:_) Cons.:> dest -> first fromString $ do
       sourceDefinitions <- traverse Path.parseHQSplit srcs
       destNamespace <- Path.parsePath' dest
-      pure $ Input.AliasManyI sourceDefinitions destNamespace
+      pure $ Input.AliasManyI (first Path.unchecked <$> sourceDefinitions) destNamespace
     _ -> Left (I.help aliasMany)
   )
 
@@ -1012,7 +1012,7 @@ previewMergeLocal = InputPattern
 replaceEdit
   :: (  HQ.HashQualified Name
      -> HQ.HashQualified Name
-     -> Maybe Input.PatchPath
+     -> Maybe (Input.PatchPath 'Unchecked)
      -> Input
      )
   -> InputPattern

--- a/parser-typechecker/src/Unison/CommandLine/Main.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Main.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ViewPatterns        #-}
+{-# LANGUAGE DataKinds #-}
 
 module Unison.CommandLine.Main 
   ( main
@@ -36,7 +37,6 @@ import qualified Data.Text as Text
 import qualified Data.Text.IO
 import qualified System.Console.Haskeline as Line
 import qualified Crypto.Random        as Random
-import qualified Unison.Codebase.Path as Path
 import qualified Unison.Codebase.Runtime as Runtime
 import qualified Unison.Codebase as Codebase
 import qualified Unison.CommandLine.InputPattern as IP
@@ -48,6 +48,8 @@ import Control.Error (rightMay)
 import UnliftIO (catchSyncOrAsync, throwIO, withException)
 import System.IO (hPutStrLn, stderr)
 import Unison.Codebase.Editor.Output (Output)
+import Unison.Codebase.Position
+import Unison.Codebase.Path (Path)
 
 getUserInput
   :: forall m v a
@@ -55,7 +57,7 @@ getUserInput
   => Map String InputPattern
   -> Codebase m v a
   -> Branch m
-  -> Path.Absolute
+  -> Path 'Absolute
   -> [String]
   -> m Input
 getUserInput patterns codebase rootBranch currentPath numberedArgs = Line.runInputT
@@ -102,7 +104,7 @@ getUserInput patterns codebase rootBranch currentPath numberedArgs = Line.runInp
 main
   :: FilePath
   -> Welcome.Welcome
-  -> Path.Absolute
+  -> Path 'Absolute
   -> (Config, IO ())
   -> [Either Event Input]
   -> Runtime.Runtime Symbol

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -1463,13 +1463,13 @@ listOfLinks ppe results = pure $ P.lines [
 
 data ShowNumbers = ShowNumbers | HideNumbers
 -- | `ppe` is just for rendering type signatures
---   `oldPath, newPath :: (Path 'Absolute)` are just for producing fully-qualified
+--   `oldPath, newPath :: Path 'Absolute` are just for producing fully-qualified
 --                                       numbered args
 showDiffNamespace :: forall v . Var v
                   => ShowNumbers
                   -> PPE.PrettyPrintEnv
                   -> Path 'Absolute
-                  -> (Path 'Absolute)
+                  -> Path 'Absolute
                   -> OBD.BranchDiffOutput v Ann
                   -> (Pretty, NumberedArgs)
 showDiffNamespace _ _ _ _ diffOutput | OBD.isEmpty diffOutput =
@@ -1686,7 +1686,7 @@ showDiffNamespace sn ppe oldPath newPath OBD.BranchDiffOutput{..} =
         0 -> mempty
         c -> " (+" <> P.shown c <> " metadata)"
 
-  prettySummarizePatch, prettyNamePatch :: (Path 'Absolute) -> OBD.PatchDisplay -> Numbered Pretty
+  prettySummarizePatch, prettyNamePatch :: Path 'Absolute -> OBD.PatchDisplay -> Numbered Pretty
   --  12. patch p (added 3 updates, deleted 1)
   prettySummarizePatch prefix (name, patchDiff) = do
     n <- numPatch prefix name
@@ -1746,7 +1746,7 @@ showDiffNamespace sn ppe oldPath newPath OBD.BranchDiffOutput{..} =
       pure (n, phq' hq, mempty)
 
   downArrow = P.bold "↓"
-  mdTypeLine :: (Path 'Absolute) -> OBD.TypeDisplay v a -> Numbered (Pretty, Pretty)
+  mdTypeLine :: Path 'Absolute -> OBD.TypeDisplay v a -> Numbered (Pretty, Pretty)
   mdTypeLine p (hq, r, odecl, mddiff) = do
     n <- numHQ' p hq (Referent.Ref r)
     fmap ((n,) . P.linesNonEmpty) . sequence $
@@ -1756,7 +1756,7 @@ showDiffNamespace sn ppe oldPath newPath OBD.BranchDiffOutput{..} =
   -- + 2. MIT               : License
   -- - 3. AllRightsReserved : License
   mdTermLine
-    :: (Path 'Absolute)
+    :: Path 'Absolute
     -> P.Width
     -> OBD.TermDisplay v a
     -> Numbered (Pretty, Pretty)
@@ -1805,16 +1805,16 @@ showDiffNamespace sn ppe oldPath newPath OBD.BranchDiffOutput{..} =
   phq  :: _ -> Pretty = P.syntaxToColor . prettyHashQualified
   --
   -- DeclPrinter.prettyDeclHeader : HQ -> Either
-  numPatch :: (Path 'Absolute) -> Name -> Numbered Pretty
+  numPatch :: Path 'Absolute -> Name -> Numbered Pretty
   numPatch prefix name =
     addNumberedArg . Name.toString . Name.makeAbsolute . Path.toName . Path.resolve prefix . Path.fromName $ name
 
-  numHQ :: (Path 'Absolute) -> HQ.HashQualified Name -> Referent -> Numbered Pretty
+  numHQ :: Path 'Absolute -> HQ.HashQualified Name -> Referent -> Numbered Pretty
   numHQ prefix hq r = addNumberedArg (HQ.toString hq')
     where
     hq' = HQ.requalify (fmap (Name.makeAbsolute . Path.toName . Path.resolve prefix . Path.fromName) hq) r
 
-  numHQ' :: (Path 'Absolute) -> HQ'.HashQualified Name -> Referent -> Numbered Pretty
+  numHQ' :: Path 'Absolute -> HQ'.HashQualified Name -> Referent -> Numbered Pretty
   numHQ' prefix hq r = addNumberedArg (HQ'.toString hq')
     where
     hq' = HQ'.requalify (fmap (Name.makeAbsolute . Path.toName . Path.resolve prefix . Path.fromName) hq) r

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -121,6 +121,7 @@ import qualified Unison.WatchKind as WK
 import qualified Unison.Codebase.Editor.Input as Input
 import Unison.Codebase.Position
 import Unison.Codebase.Path (Path)
+import qualified Control.Lens as Lens
 
 type Pretty = P.Pretty P.ColorText
 
@@ -1108,9 +1109,9 @@ notifyUser dir o = case o of
 --      ns targets = P.oxfordCommas $
 --        map (fromString . Names.renderNameTarget) (toList targets)
 
-prettyPath' :: Path.Path 'Unchecked -> Pretty
+prettyPath' :: Path.Path any -> Pretty
 prettyPath' p' = case p' of
-  Path.Empty -> "the current namespace"
+  Path.RelativePath Lens.Empty -> "the current namespace"
   _ -> P.blue (P.shown p')
 
 prettyRelative :: Path 'Relative -> Pretty

--- a/parser-typechecker/src/Unison/CommandLine/Welcome.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Welcome.hs
@@ -16,7 +16,7 @@ import Unison.NameSegment (NameSegment(NameSegment))
 
 import Unison.Codebase.Editor.RemoteRepo (ReadRemoteNamespace)
 import qualified Unison.Codebase.Verbosity as Verbosity
-import qualified Data.Sequence as Seq
+import qualified Control.Lens as Lens
 
 data Welcome = Welcome
   { onboarding :: Onboarding -- Onboarding States
@@ -51,7 +51,7 @@ welcome initStatus downloadBase filePath unisonVersion =
 pullBase :: ReadRemoteNamespace -> Either Event Input
 pullBase ns = let
     seg = NameSegment "base"
-    rootPath = Path.AbsoluteP (Seq.singleton seg)
+    rootPath = Path.root Lens.|> seg
     pullRemote = PullRemoteBranchI (Just ns) (Path.unchecked rootPath) SyncMode.Complete Verbosity.Silent
   in Right pullRemote
 

--- a/parser-typechecker/src/Unison/CommandLine/Welcome.hs
+++ b/parser-typechecker/src/Unison/CommandLine/Welcome.hs
@@ -12,11 +12,11 @@ import Unison.Codebase.Path (Path)
 import qualified Unison.Codebase.Path as Path
 import qualified Unison.Codebase.SyncMode as SyncMode
 import Unison.Codebase.Editor.Input
-import Data.Sequence (singleton)
 import Unison.NameSegment (NameSegment(NameSegment))
 
 import Unison.Codebase.Editor.RemoteRepo (ReadRemoteNamespace)
 import qualified Unison.Codebase.Verbosity as Verbosity
+import qualified Data.Sequence as Seq
 
 data Welcome = Welcome
   { onboarding :: Onboarding -- Onboarding States
@@ -51,9 +51,8 @@ welcome initStatus downloadBase filePath unisonVersion =
 pullBase :: ReadRemoteNamespace -> Either Event Input
 pullBase ns = let
     seg = NameSegment "base"
-    rootPath = Path.Path { Path.toSeq = singleton seg }
-    abs = Path.Absolute {Path.unabsolute = rootPath}
-    pullRemote = PullRemoteBranchI (Just ns) (Path.Path' {Path.unPath' = Left abs}) SyncMode.Complete Verbosity.Silent
+    rootPath = Path.AbsoluteP (Seq.singleton seg)
+    pullRemote = PullRemoteBranchI (Just ns) (Path.unchecked rootPath) SyncMode.Complete Verbosity.Silent
   in Right pullRemote
 
 run :: Codebase IO v a -> Welcome -> IO [Either Event Input]
@@ -127,7 +126,7 @@ asciiartUnison =
     <> P.purple "_|_|"
 
 
-downloading :: Path -> P.Pretty P.ColorText
+downloading :: Path pos -> P.Pretty P.ColorText
 downloading path =
   P.lines
     [ P.group (P.wrap "🐣 Since this is a fresh codebase, let me download the base library for you." <> P.newline ), 

--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -128,11 +128,11 @@ type Backend m a = ExceptT BackendError m a
 
 
 -- implementation detail of basicParseNames and basicPrettyPrintNames
-basicNames' :: Branch m -> NameScoping 'Relative -> (Names, Names)
+basicNames' :: forall m pos. Branch m -> NameScoping pos -> (Names, Names)
 basicNames' root scope =
   (parseNames0, prettyPrintNames0)
   where
-    path :: Path 'Relative
+    path :: Path pos
     includeAllNames :: Bool
     (path, includeAllNames) = case scope of
       AllNames   path -> (path, True)
@@ -170,7 +170,7 @@ basicSuffixifiedNames hashLength root nameScope =
 basicPrettyPrintNames :: Branch m -> NameScoping 'Relative -> Names
 basicPrettyPrintNames root = snd . basicNames' root
 
-basicParseNames :: Branch m -> NameScoping  'Relative -> Names
+basicParseNames :: Branch m -> NameScoping  pos -> Names
 basicParseNames root = fst . basicNames' root
 
 loadReferentType ::
@@ -262,7 +262,7 @@ fuzzyFind path branch query =
 findShallow
   :: (Monad m, Var v)
   => Codebase m v Ann
-  -> Path 'Absolute
+  -> Path pos
   -> Backend m [ShallowListEntry v Ann]
 findShallow codebase path' = do
   let path = Path.unsafeToRelative path'
@@ -475,7 +475,7 @@ getCurrentPrettyNames :: NameScoping 'Relative -> Branch m -> NamesWithHistory
 getCurrentPrettyNames scope root =
   NamesWithHistory (basicPrettyPrintNames root scope) mempty
 
-getCurrentParseNames :: NameScoping 'Relative -> Branch m -> NamesWithHistory
+getCurrentParseNames :: NameScoping pos -> Branch m -> NamesWithHistory
 getCurrentParseNames scope root =
   NamesWithHistory (basicParseNames root scope) mempty
 
@@ -545,7 +545,7 @@ applySearch Search {lookupNames, lookupRelativeHQRefs', makeResult, matchesNamed
 
 hqNameQuery
   :: Monad m
-  => NameScoping 'Relative
+  => NameScoping pos
   -> Branch m
   -> Codebase m v Ann
   -> [HQ.HashQualified Name]
@@ -857,10 +857,10 @@ resolveRootBranchHash mayRoot codebase = case mayRoot of
 
 
 definitionsBySuffixes
-  :: forall m v
+  :: forall m v pos
    . (MonadIO m)
   => Var v
-  => NameScoping 'Relative
+  => NameScoping pos
   -> Branch m
   -> Codebase m v Ann
   -> [HQ.HashQualified Name]

--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -131,7 +131,7 @@ basicNames' :: Branch m -> NameScoping -> (Names, Names)
 basicNames' root scope =
   (parseNames0, prettyPrintNames0)
   where
-    path :: Path 'Relative
+    path :: Path 'Absolute
     includeAllNames :: Bool
     (path, includeAllNames) = case scope of
       AllNames   path -> (path, True)
@@ -225,7 +225,7 @@ data FoundRef = FoundTermRef Referent
 --      definition with different names in the result set.
 fuzzyFind
   :: Monad m
-  => Path 'Relative
+  => Path 'Absolute
   -> Branch m
   -> String
   -> [(FZF.Alignment, UnisonName, [FoundRef])]

--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -460,9 +460,9 @@ termReferentsByShortHash codebase sh = do
 data NameScoping =
       -- | Find all names, making any names which are children of this path,
       -- otherwise leave them absolute.
-      AllNames (Path 'Relative)
+      AllNames (Path 'Absolute)
       -- | Filter returned names to only include names within this path.
-    | Within   (Path 'Relative)
+    | Within   (Path 'Absolute)
 
 toAllNames :: NameScoping -> NameScoping
 toAllNames (AllNames p) = AllNames p

--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -162,12 +162,12 @@ basicNames' root scope =
                            then currentAndExternalNames
                            else currentPathNames
 
-basicSuffixifiedNames :: Int -> Branch m -> NameScoping 'Relative -> PPE.PrettyPrintEnv
+basicSuffixifiedNames :: Int -> Branch m -> NameScoping pos -> PPE.PrettyPrintEnv
 basicSuffixifiedNames hashLength root nameScope =
   let names0 = basicPrettyPrintNames root nameScope
    in PPE.suffixifiedPPE . PPE.fromNamesDecl hashLength $ NamesWithHistory names0 mempty
 
-basicPrettyPrintNames :: Branch m -> NameScoping 'Relative -> Names
+basicPrettyPrintNames :: Branch m -> NameScoping pos -> Names
 basicPrettyPrintNames root = snd . basicNames' root
 
 basicParseNames :: Branch m -> NameScoping  pos -> Names
@@ -235,7 +235,7 @@ fuzzyFind
 fuzzyFind path branch query =
   let
     printNames =
-      basicPrettyPrintNames branch (Within . Path.unsafeToRelative $ path)
+      basicPrettyPrintNames branch (Within path)
 
     fzfNames =
       Names.fuzzyFind (words query) printNames
@@ -264,8 +264,7 @@ findShallow
   => Codebase m v Ann
   -> Path pos
   -> Backend m [ShallowListEntry v Ann]
-findShallow codebase path' = do
-  let path = Path.unsafeToRelative path'
+findShallow codebase path = do
   root <- getRootBranch codebase
   let mayb = Branch.getAt path root
   case mayb of
@@ -471,7 +470,7 @@ toAllNames :: NameScoping pos -> NameScoping pos
 toAllNames (AllNames p) = AllNames p
 toAllNames (Within p) = AllNames p
 
-getCurrentPrettyNames :: NameScoping 'Relative -> Branch m -> NamesWithHistory
+getCurrentPrettyNames :: NameScoping pos -> Branch m -> NamesWithHistory
 getCurrentPrettyNames scope root =
   NamesWithHistory (basicPrettyPrintNames root scope) mempty
 
@@ -654,9 +653,9 @@ mungeSyntaxText
 mungeSyntaxText = fmap Syntax.convertElement
 
 prettyDefinitionsBySuffixes
-  :: forall v
+  :: forall v pos
    . Var v
-  => NameScoping 'Relative
+  => NameScoping pos
   -> Maybe Branch.Hash
   -> Maybe Width
   -> Suffixify

--- a/parser-typechecker/src/Unison/Server/Endpoints/FuzzyFind.hs
+++ b/parser-typechecker/src/Unison/Server/Endpoints/FuzzyFind.hs
@@ -150,7 +150,7 @@ serveFuzzyFind h codebase mayRoot relativePath limit typeWidth query =
           alignments =
             take (fromMaybe 10 limit) $ Backend.fuzzyFind rel branch (fromMaybe "" query)
           -- Use AllNames to render source
-          ppe = Backend.basicSuffixifiedNames hashLength branch (Backend.AllNames . Path.unsafeToRelative $ rel)
+          ppe = Backend.basicSuffixifiedNames hashLength branch (Backend.AllNames rel)
       join <$> traverse (loadEntry root (Just rel) ppe b0) alignments
     errFromEither backendError ea
  where

--- a/parser-typechecker/src/Unison/Server/Endpoints/FuzzyFind.hs
+++ b/parser-typechecker/src/Unison/Server/Endpoints/FuzzyFind.hs
@@ -140,7 +140,7 @@ serveFuzzyFind h codebase mayRoot relativePath limit typeWidth query =
   addHeaders <$> do
     h
     rel <-
-      maybe mempty Path.fromPath'
+      fromMaybe (Path.unchecked Path.currentPath)
       <$> traverse (parsePath . Text.unpack) relativePath
     hashLength <- liftIO $ Codebase.hashLength codebase
     ea         <- liftIO . runExceptT $ do
@@ -150,7 +150,7 @@ serveFuzzyFind h codebase mayRoot relativePath limit typeWidth query =
           alignments =
             take (fromMaybe 10 limit) $ Backend.fuzzyFind rel branch (fromMaybe "" query)
           -- Use AllNames to render source
-          ppe = Backend.basicSuffixifiedNames hashLength branch (Backend.AllNames rel)
+          ppe = Backend.basicSuffixifiedNames hashLength branch (Backend.AllNames . Path.unsafeToRelative $ rel)
       join <$> traverse (loadEntry root (Just rel) ppe b0) alignments
     errFromEither backendError ea
  where

--- a/parser-typechecker/src/Unison/Server/Endpoints/GetDefinitions.hs
+++ b/parser-typechecker/src/Unison/Server/Endpoints/GetDefinitions.hs
@@ -122,15 +122,14 @@ serveDefinitions
 serveDefinitions h rt codebase mayRoot relativePath rawHqns width suff =
   addHeaders <$> do
     h
-    rel <-
-      fmap Path.fromPath' <$> traverse (parsePath . Text.unpack) relativePath
+    rel <- traverse (parsePath . Text.unpack) relativePath
     ea <- liftIO . runExceptT $ do
       root <- traverse (Backend.expandShortBranchHash codebase) mayRoot
       let hqns = HQ.unsafeFromText <$> rawHqns
           scope = case hqns of
             -- TODO: Change this API to support being queried by just 1 name/hash
-            HQ.HashOnly _ : _ -> Backend.AllNames . fromMaybe Path.empty $ rel
-            _ -> Backend.Within . fromMaybe Path.empty $ rel
+            HQ.HashOnly _ : _ -> Backend.AllNames . maybe Path.currentPath Path.unsafeToRelative $ rel
+            _ -> Backend.Within . maybe Path.currentPath Path.unsafeToRelative $ rel
 
       Backend.prettyDefinitionsBySuffixes scope
                                           root

--- a/parser-typechecker/src/Unison/Server/Endpoints/GetDefinitions.hs
+++ b/parser-typechecker/src/Unison/Server/Endpoints/GetDefinitions.hs
@@ -128,8 +128,8 @@ serveDefinitions h rt codebase mayRoot relativePath rawHqns width suff =
       let hqns = HQ.unsafeFromText <$> rawHqns
           scope = case hqns of
             -- TODO: Change this API to support being queried by just 1 name/hash
-            HQ.HashOnly _ : _ -> Backend.AllNames . maybe Path.currentPath Path.unsafeToRelative $ rel
-            _ -> Backend.Within . maybe Path.currentPath Path.unsafeToRelative $ rel
+            HQ.HashOnly _ : _ -> Backend.AllNames . fromMaybe (Path.unchecked Path.currentPath) $ rel
+            _ -> Backend.Within . fromMaybe (Path.unchecked Path.currentPath) $ rel
 
       Backend.prettyDefinitionsBySuffixes scope
                                           root

--- a/parser-typechecker/src/Unison/Server/Endpoints/NamespaceDetails.hs
+++ b/parser-typechecker/src/Unison/Server/Endpoints/NamespaceDetails.hs
@@ -19,7 +19,6 @@ import Servant.OpenApi ()
 import Servant.Server (Handler)
 import Unison.Codebase (Codebase)
 import qualified Unison.Codebase.Branch as Branch
-import qualified Unison.Codebase.Path as Path
 import Unison.Codebase.Path.Parse (parsePath')
 import qualified Unison.Codebase.Runtime as Rt
 import Unison.Codebase.ShortBranchHash (ShortBranchHash)
@@ -109,7 +108,7 @@ serve tryAuth runtime codebase namespaceName mayRoot mayWidth =
           -- Names used in the README should not be confined to the namespace
           -- of the README (since it could be referencing definitions from all
           -- over the codebase)
-          let printNames = Backend.getCurrentPrettyNames (Backend.AllNames . Path.unsafeToRelative $ namespacePath) root
+          let printNames = Backend.getCurrentPrettyNames (Backend.AllNames namespacePath) root
 
           readme <-
             Backend.findShallowReadmeInBranchAndRender

--- a/parser-typechecker/src/Unison/Server/Endpoints/NamespaceDetails.hs
+++ b/parser-typechecker/src/Unison/Server/Endpoints/NamespaceDetails.hs
@@ -95,7 +95,7 @@ serve tryAuth runtime codebase namespaceName mayRoot mayWidth =
       fqnToPath fqn = do
         let fqnS = Text.unpack fqn
         path' <- errFromEither (`badNamespace` fqnS) $ parsePath' fqnS
-        pure (Path.fromPath' path')
+        pure path'
 
       width = mayDefaultWidth mayWidth
    in do
@@ -109,7 +109,7 @@ serve tryAuth runtime codebase namespaceName mayRoot mayWidth =
           -- Names used in the README should not be confined to the namespace
           -- of the README (since it could be referencing definitions from all
           -- over the codebase)
-          let printNames = Backend.getCurrentPrettyNames (Backend.AllNames namespacePath) root
+          let printNames = Backend.getCurrentPrettyNames (Backend.AllNames . Path.unsafeToRelative $ namespacePath) root
 
           readme <-
             Backend.findShallowReadmeInBranchAndRender

--- a/parser-typechecker/src/Unison/Server/Endpoints/NamespaceListing.hs
+++ b/parser-typechecker/src/Unison/Server/Endpoints/NamespaceListing.hs
@@ -216,8 +216,8 @@ serve tryAuth codebase mayRoot mayRelativeTo mayNamespaceName =
       let listingBranch = Branch.getAt' path root
       hashLength <- liftIO $ Codebase.hashLength codebase
 
-      let shallowPPE = Backend.basicSuffixifiedNames hashLength root $ (Backend.Within . Path.unsafeToRelative $ path)
-      let listingFQN = Path.toText . Path.unsafeToAbsolute $ path
+      let shallowPPE = Backend.basicSuffixifiedNames hashLength root $ (Backend.Within path)
+      let listingFQN = Path.toText path
       let listingHash = branchToUnisonHash listingBranch
       listingEntries <- findShallow listingBranch
 

--- a/parser-typechecker/src/Unison/Server/Endpoints/NamespaceListing.hs
+++ b/parser-typechecker/src/Unison/Server/Endpoints/NamespaceListing.hs
@@ -209,16 +209,15 @@ serve tryAuth codebase mayRoot mayRelativeTo mayNamespaceName =
       relativeToPath' <- (parsePath . Text.unpack) $ fromMaybe "." mayRelativeTo
       namespacePath' <- (parsePath . Text.unpack) $ fromMaybe "." mayNamespaceName
 
-      let path = Path.fromPath' relativeToPath' <>  Path.fromPath' namespacePath'
-      let path' = Path.toPath' path
+      let path = Path.resolve relativeToPath' namespacePath'
 
       -- Actually construct the NamespaceListing
 
       let listingBranch = Branch.getAt' path root
       hashLength <- liftIO $ Codebase.hashLength codebase
 
-      let shallowPPE = Backend.basicSuffixifiedNames hashLength root $ (Backend.Within $ Path.fromPath' path')
-      let listingFQN = Path.toText . Path.unabsolute . either id (Path.Absolute . Path.unrelative) $ Path.unPath' path'
+      let shallowPPE = Backend.basicSuffixifiedNames hashLength root $ (Backend.Within . Path.unsafeToRelative $ path)
+      let listingFQN = Path.toText . Path.unsafeToAbsolute $ path
       let listingHash = branchToUnisonHash listingBranch
       listingEntries <- findShallow listingBranch
 

--- a/parser-typechecker/src/Unison/Server/Errors.hs
+++ b/parser-typechecker/src/Unison/Server/Errors.hs
@@ -33,7 +33,7 @@ badHQN hqn = err400
 backendError :: Backend.BackendError -> ServerError
 backendError = \case
   Backend.NoSuchNamespace n ->
-    noSuchNamespace . Path.toText $ Path.unabsolute n
+    noSuchNamespace . Path.toText $ n
   Backend.BadRootBranch e -> rootBranchError e
   Backend.NoBranchForHash h ->
     noSuchNamespace . Text.toStrict . Text.pack $ show h

--- a/parser-typechecker/tests/Unison/Test/Codebase/Path.hs
+++ b/parser-typechecker/tests/Unison/Test/Codebase/Path.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DataKinds #-}
 
 module Unison.Test.Codebase.Path where
@@ -6,7 +6,6 @@ module Unison.Test.Codebase.Path where
 import EasyTest
 import Unison.Codebase.Path
 import Unison.Codebase.Path.Parse
-import Data.Sequence
 import Data.Text
 import Unison.NameSegment
 import Data.Either
@@ -64,5 +63,5 @@ test = scope "path" . tests $
   ]
 
 
-relative :: Seq Text -> Path 'Unchecked
-relative = unchecked . RelativeP . fmap NameSegment
+relative :: [Text] -> Path 'Unchecked
+relative = unchecked . relativeFromSegments . fmap NameSegment

--- a/parser-typechecker/tests/Unison/Test/Codebase/Path.hs
+++ b/parser-typechecker/tests/Unison/Test/Codebase/Path.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings, OverloadedLists #-}
+{-# LANGUAGE DataKinds #-}
 
 module Unison.Test.Codebase.Path where
 
@@ -63,5 +64,5 @@ test = scope "path" . tests $
   ]
 
 
-relative :: Seq Text -> Path'
-relative = Path' . Right . Relative . Path . fmap NameSegment
+relative :: Seq Text -> Path 'Unchecked
+relative = unchecked . RelativeP . fmap NameSegment

--- a/parser-typechecker/tests/Unison/Test/UriParser.hs
+++ b/parser-typechecker/tests/Unison/Test/UriParser.hs
@@ -5,7 +5,7 @@ module Unison.Test.UriParser where
 
 import EasyTest
 import Unison.Codebase.Editor.RemoteRepo (ReadRepo(..))
-import Unison.Codebase.Path (Path(..))
+import Unison.Codebase.Path (Path)
 import qualified Unison.Codebase.Path as Path
 import qualified Text.Megaparsec as P
 import qualified Unison.Codebase.Editor.UriParser as UriParser

--- a/parser-typechecker/tests/Unison/Test/VersionParser.hs
+++ b/parser-typechecker/tests/Unison/Test/VersionParser.hs
@@ -25,4 +25,4 @@ makeTest (version, path) =
     (Just
       ( ReadGitRepo "https://github.com/unisonweb/base"
       , Nothing
-      , Path.fromText path ))
+      , Path.unsafeToAbsolute . Path.fromText $ path ))

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -65,6 +65,7 @@ library
       Unison.Codebase.Patch
       Unison.Codebase.Path
       Unison.Codebase.Path.Parse
+      Unison.Codebase.Position
       Unison.Codebase.Reflog
       Unison.Codebase.Runtime
       Unison.Codebase.Serialization

--- a/unison-cli/unison/Main.hs
+++ b/unison-cli/unison/Main.hs
@@ -3,8 +3,8 @@
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ApplicativeDo #-}
-{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE DataKinds #-}
 
 module Main where
 
@@ -62,6 +62,8 @@ import ArgParse
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
 import Unison.CommandLine.Welcome (CodebaseInitStatus(..))
+import Unison.Codebase.Path (Path)
+import Unison.Codebase.Position
 
 main :: IO ()
 main = do
@@ -295,8 +297,8 @@ runTranscripts renderUsageInfo shouldFork shouldSaveTempCodebase mCodePathOption
           putStrLn (renderUsageInfo $ Just "transcript")
           Exit.exitWith (Exit.ExitFailure 1)
 
-initialPath :: Path.Absolute
-initialPath = Path.absoluteEmpty
+initialPath :: Path 'Absolute
+initialPath = Path.root
 
 launch
   :: FilePath

--- a/unison-core/src/Unison/NameSegment.hs
+++ b/unison-core/src/Unison/NameSegment.hs
@@ -27,6 +27,14 @@ segments' n = go split
     go ("" : z) = go z
     go (x : y) = x : go y
 
+
+-- | Splits a textual name into name segments, returns a boolean indicating whether the
+-- name was absolute.
+splitText :: Text -> (Bool, [NameSegment])
+splitText t = case Text.stripPrefix "." t of
+  Just absPath -> (True, NameSegment <$> Text.splitOn "." absPath)
+  Nothing -> (False, NameSegment <$> Text.splitOn "." t)
+
 -- Same as reverse . segments', but produces the output as a
 -- lazy list, suitable for suffix-based ordering purposes or
 -- building suffix tries. Examples:


### PR DESCRIPTION
Currently we have:

- `Relative`: Represents relative paths
- `Absolute`: Represents absolute paths
- `Path'`: Represents a path which might be relative OR absolute
-  `Path`: an ambiguous path type, is it relative? Is it absolute? Who knows 🤷🏼‍♂️ 

This makes wrangling paths into the right shape a bit of work, and also means we need (4!) versions of many of our combinators.

In addition, it makes it tough to tell which path is expected where, and can easily lead to mistakes by accidentally treating one as another.

## Overview

This crushes all of these types down to a single type parameterized by a `p :: Position` parameter.
a Position is one of:

* `Relative`
* `Absolute`
* `Unchecked`

This allows us to:

* Specify a specific path type when we want, e.g. the `getAt` combinator must get an `Absolute` path since it starts from the root.
* Allow any path type we want, e.g. `Path.toText :: Path any -> Text`
* Parse into either path type until the caller case-matches on them: `parsePath :: String -> Maybe (Path 'Unchecked)`
* Write most utility functions over the generic `Path pos` variant and handle all possible cases.
* We can still write type-class instances over individual 'kinds' of paths, e.g. a Monoid instance only makes sense for `Relative` paths.

## Implementation notes

Uses a GADT with a DataKind to indicate which path has been chosen. See [this post](https://chrispenner.ca/posts/gadt-design) for a guide on this approach; it's worked out well for me in the past.

## Interesting/controversial decisions

GADTs add another thing to the codebase, but IMO it's better to have 1 GADT than 4 path types.

## Loose ends

There are many areas in the codebase which are using a `Path 'Unchecked` which should probably case-match on their path and throw an error much earlier.

---

There are a lot of combinators where neither Relative nor Absolute make a ton of sense, particularly command which accept BOTH a branch AND a path, since the branch might be the root, requiring absolute paths, or it might be a different branch, requiring Relative paths... I think the right way to solve this might actually be to move away from our current branch abstraction and normalize passing around the Codebase with Absolute paths wherever possible.

TODO:
* [ ] Fix tests
* [ ] Check and handle merge conflicts on the long running branch 😨 