### PR TITLE
Docs.AsHtml Improve syntax names for html files

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Command.hs
@@ -90,7 +90,8 @@ data Command
   UI :: Command m i v ()
 
   DocsToHtml
-    :: Branch m -- ^ namespace source
+    :: Branch m -- Root branch
+    -> Path -- ^ namespace source
     -> FilePath -- ^ file destination
     -> Command m i v ()
 

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -104,8 +104,8 @@ commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSour
         Just url -> lift . void $ openBrowser (Server.urlFor Server.UI url)
         Nothing -> lift (return ())
 
-    DocsToHtml sourceBranch destination ->
-      liftIO $ Backend.docsInBranchToHtmlFiles rt codebase sourceBranch destination
+    DocsToHtml root sourcePath destination ->
+      liftIO $ Backend.docsInBranchToHtmlFiles rt codebase root sourcePath destination
 
     Input         -> lift awaitInput
     Notify output -> lift $ notifyUser output

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -907,9 +907,8 @@ loop = do
       UiI -> eval UI
 
       DocsToHtmlI namespacePath' sourceDirectory -> do
-        let absPath = resolveToAbsolute namespacePath'
-        let namespaceBranch = Branch.getAt' (Path.unabsolute absPath) root'
-        eval (DocsToHtml namespaceBranch sourceDirectory)
+        let absPath = Path.unabsolute $ resolveToAbsolute namespacePath'
+        eval (DocsToHtml root' absPath sourceDirectory)
 
       AliasTermI src dest -> do
         referents <- resolveHHQS'Referents src

--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -835,13 +835,15 @@ docsInBranchToHtmlFiles
   => Rt.Runtime v
   -> Codebase IO v Ann
   -> Branch IO
+  -> Path
   -> FilePath
   -> IO ()
-docsInBranchToHtmlFiles runtime codebase currentBranch directory = do
+docsInBranchToHtmlFiles runtime codebase root currentPath directory = do
+  let currentBranch = Branch.getAt' currentPath root
   let allTerms = (R.toList . Branch.deepTerms . Branch.head) currentBranch
   docTermsWithNames <- filterM (isDoc codebase . fst) allTerms
   hqLength <- Codebase.hashLength codebase
-  let printNames = getCurrentPrettyNames (AllNames Path.empty) currentBranch
+  let printNames = getCurrentPrettyNames (AllNames currentPath) root
   let ppe = PPE.fromNamesDecl hqLength printNames
   docs <- for docTermsWithNames (renderDoc' ppe runtime codebase)
   liftIO $ traverse_ (renderDocToHtmlFile directory) docs


### PR DESCRIPTION
## Overview
We were not correctly choosing the names of the codebase as a whole
when rendering syntax in docs for html files. Fix that by passing in
root and a path to correctly construct the names.

Paired with @pchiusano 