### PR TITLE
Fix `fzf` opening during transcript runs, also print "No matches" error on failed glob.

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -91,6 +91,9 @@ data NumberedOutput v
 data Output v
   -- Generic Success response; we might consider deleting this.
   = Success
+  -- A glob failed to match anything
+  --            v Glob pattern
+  | GlobFailure String
   -- User did `add` or `update` before typechecking a file?
   | NoUnisonFile
   -- Used in Welcome module to instruct user
@@ -243,6 +246,7 @@ type SourceFileContents = Text
 isFailure :: Ord v => Output v -> Bool
 isFailure o = case o of
   Success{} -> False
+  GlobFailure{} -> True
   PrintMessage{} -> False
   BadRootBranch{} -> True
   CouldntLoadBranch{} -> True

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -91,9 +91,6 @@ data NumberedOutput v
 data Output v
   -- Generic Success response; we might consider deleting this.
   = Success
-  -- A glob failed to match anything
-  --            v Glob pattern
-  | GlobFailure String
   -- User did `add` or `update` before typechecking a file?
   | NoUnisonFile
   -- Used in Welcome module to instruct user
@@ -246,7 +243,6 @@ type SourceFileContents = Text
 isFailure :: Ord v => Output v -> Bool
 isFailure o = case o of
   Success{} -> False
-  GlobFailure{} -> True
   PrintMessage{} -> False
   BadRootBranch{} -> True
   CouldntLoadBranch{} -> True

--- a/parser-typechecker/src/Unison/CommandLine.hs
+++ b/parser-typechecker/src/Unison/CommandLine.hs
@@ -80,6 +80,7 @@ import qualified Unison.Codebase.Path as Path
 import Text.Regex.TDFA ((=~))
 import qualified Data.List as List
 import Data.List.Extra (nubOrd)
+import Unison.Codebase.Editor.Output (Output)
 
 disableWatchConfig :: Bool
 disableWatchConfig = False
@@ -268,7 +269,7 @@ parseInput ::
   Map String InputPattern ->
   -- | command:arguments
   [String] ->
-  Either (P.Pretty CT.ColorText) Input
+  Either (Output v) Input
 parseInput rootBranch currentPath numberedArgs patterns segments = do
   case segments of
     [] -> Left ""

--- a/parser-typechecker/src/Unison/CommandLine.hs
+++ b/parser-typechecker/src/Unison/CommandLine.hs
@@ -283,7 +283,7 @@ parseInput rootBranch currentPath numberedArgs patterns segments = do
           case Globbing.expandGlobs targets rootBranch currentPath arg of
             -- No globs encountered
             Nothing -> pure [arg]
-            Just [] -> Left "No matches."
+            Just [] -> Left $ "No matches for: " <> fromString arg
             Just matches -> pure matches
         parse (concat expandedGlobs)
       Nothing ->

--- a/parser-typechecker/src/Unison/CommandLine.hs
+++ b/parser-typechecker/src/Unison/CommandLine.hs
@@ -80,7 +80,6 @@ import qualified Unison.Codebase.Path as Path
 import Text.Regex.TDFA ((=~))
 import qualified Data.List as List
 import Data.List.Extra (nubOrd)
-import Unison.Codebase.Editor.Output (Output)
 
 disableWatchConfig :: Bool
 disableWatchConfig = False
@@ -269,7 +268,7 @@ parseInput ::
   Map String InputPattern ->
   -- | command:arguments
   [String] ->
-  Either (Output v) Input
+  Either (P.Pretty CT.ColorText) Input
 parseInput rootBranch currentPath numberedArgs patterns segments = do
   case segments of
     [] -> Left ""

--- a/unison-src/transcripts/globbing.md
+++ b/unison-src/transcripts/globbing.md
@@ -15,12 +15,13 @@ Add some definitions which we can match over:
 ```unison:hide
 convertToThing = 1
 convertFromThing = 2
+otherTerm = 3
 
 -- Nested definitions
-nested.toList = 3
-nested.toMap = 4
-othernest.toList = 5
-othernest.toMap = 6
+nested.toList = 4
+nested.toMap = 5
+othernest.toList = 6
+othernest.toMap = 7
 ```
 
 ```ucm:hide
@@ -52,9 +53,9 @@ You may have up to one glob per name segment.
 Globbing only expands to the appropriate argument type.
 
 E.g. `view` should not see glob expansions for namespaces.
-This should expand to the empty argument and silently succeed.
+This should expand to only the otherTerm.
 
-```ucm:error
+```ucm
 .> view other?
 ```
 

--- a/unison-src/transcripts/globbing.md
+++ b/unison-src/transcripts/globbing.md
@@ -54,7 +54,7 @@ Globbing only expands to the appropriate argument type.
 E.g. `view` should not see glob expansions for namespaces.
 This should expand to the empty argument and silently succeed.
 
-```ucm
+```ucm:error
 .> view other?
 ```
 

--- a/unison-src/transcripts/globbing.output.md
+++ b/unison-src/transcripts/globbing.output.md
@@ -15,12 +15,13 @@ Add some definitions which we can match over:
 ```unison
 convertToThing = 1
 convertFromThing = 2
+otherTerm = 3
 
 -- Nested definitions
-nested.toList = 3
-nested.toMap = 4
-othernest.toList = 5
-othernest.toMap = 6
+nested.toList = 4
+nested.toMap = 5
+othernest.toList = 6
+othernest.toMap = 7
 ```
 
 Globbing as a prefix, infix, or suffix wildcard.
@@ -57,18 +58,18 @@ Globbing can occur in any name segment.
 .> view ?.toList
 
   nested.toList : ##Nat
-  nested.toList = 3
+  nested.toList = 4
   
   othernest.toList : ##Nat
-  othernest.toList = 5
+  othernest.toList = 6
 
 .> view nested.to?
 
   nested.toList : ##Nat
-  nested.toList = 3
+  nested.toList = 4
   
   nested.toMap : ##Nat
-  nested.toMap = 4
+  nested.toMap = 5
 
 ```
 You may have up to one glob per name segment.
@@ -77,25 +78,28 @@ You may have up to one glob per name segment.
 .> view ?.to?
 
   nested.toList : ##Nat
-  nested.toList = 3
+  nested.toList = 4
   
   nested.toMap : ##Nat
-  nested.toMap = 4
+  nested.toMap = 5
   
   othernest.toList : ##Nat
-  othernest.toList = 5
+  othernest.toList = 6
   
   othernest.toMap : ##Nat
-  othernest.toMap = 6
+  othernest.toMap = 7
 
 ```
 Globbing only expands to the appropriate argument type.
 
 E.g. `view` should not see glob expansions for namespaces.
-This should expand to the empty argument and silently succeed.
+This should expand to only the otherTerm.
 
 ```ucm
 .> view other?
+
+  otherTerm : ##Nat
+  otherTerm = 3
 
 ```
 Globbing should work from within a namespace with both absolute and relative patterns.
@@ -104,17 +108,17 @@ Globbing should work from within a namespace with both absolute and relative pat
 .nested> view .othernest.to?
 
   .othernest.toList : ##Nat
-  .othernest.toList = 5
+  .othernest.toList = 6
   
   .othernest.toMap : ##Nat
-  .othernest.toMap = 6
+  .othernest.toMap = 7
 
 .nested> view to?
 
   toList : ##Nat
-  toList = 3
+  toList = 4
   
   toMap : ##Nat
-  toMap = 4
+  toMap = 5
 
 ```


### PR DESCRIPTION
## Overview

One of the transcript globs expanded to no arguments and would pop open `fzf` during a transcript run haha. I think CI didn't catch it because it's not an interactive terminal maybe?

## Implementation notes

I changed that transcript tests and also made input parsing fail if a glob is provided, but doesn't match anything, rather than falling back to fzf which might be unexpected.

## Test coverage

Updated the transcript

## Loose ends

I discovered during this that errors during input parsing are NOT caught by `ucm:error` in transcripts.

Likely in the future we should investigate changing input parsing failures to result in an `Output` and properly allowing failures on input parses in Transcripts (with the appropriate `ucm:error` clause)