### PR TITLE
Add vim completion support.

### DIFF
--- a/editor-support/vim/autoload/unison.vim
+++ b/editor-support/vim/autoload/unison.vim
@@ -1,0 +1,104 @@
+" Unison functionality for Vim, including type/term omnicompletion.
+"
+" Maintainer: Unison Computing
+" Original Author: Cody Allen (ceedubs)
+
+if exists('g:autoloaded_unison')
+  finish
+endif
+let g:autoloaded_unison = 1
+
+let s:required_config_value = "!REQUIRED!"
+
+" adapted from https://github.com/rust-lang/rust.vim/blob/4aa69b84c8a58fcec6b6dad6fe244b916b1cf830/autoload/rust.vim#L9-L18
+function! s:config(name, default) abort
+  let name = 'unison_' . a:name
+  " Local buffer variable with same name takes predeence over global
+  if has_key(b:, name)
+    return get(b:, name)
+  elseif has_key(g:, name)
+    return get(g:, name)
+  elseif a:default == s:required_config_value
+    throw 'Missing required configuration value: ' . name
+  else
+    return a:default
+  endif
+endfunction
+
+function! s:curl_path() abort
+  return s:config('curl_path', "curl")
+endfunction
+
+function! s:jq_path() abort
+  return s:config('jq_path', "jq")
+endfunction
+
+function! unison#SetBufferDefaults() abort
+  if s:config('set_buffer_defaults', 1)
+    " Since Unison completion is fuzzy and not prefix-based, 'longest' doesn't
+    " work well, and 'noinsert' behaves a little better.
+    setlocal completeopt=menuone,noinsert,preview
+
+    setlocal omnifunc=unison#Complete
+  endif
+endfunction
+
+" Unison completion satisfying the standard vim completion signature, such
+" that it can be assigned to omnifunc.
+" vim will first call this to find the base input that should be completed,
+" and then will call it again with the base input.
+function! unison#Complete(findstart, base) abort
+  if a:findstart
+    " locate the start of the word
+    let line = getline('.')
+    let start = col('.') - 1
+    while start > 0 && line[start - 1] !~ '\s' && line[start - 1] != '(' && line[start - 1] != ')'
+      let start -= 1
+    endwhile
+    return start
+  else
+    return unison#CompleteForBase(a:base)
+  endif
+endfunction
+
+" Return an array of completion items for the provided base input. For example
+" base could be 'List.foldL', in which case the top result would probably be
+" 'List.foldLeft'.
+function! unison#CompleteForBase(base) abort
+  let resultLimit = s:config('complete_result_limit', 20)
+  let apiHost = s:config('api_host', 'localhost')
+  let apiPort = s:config('api_port', s:required_config_value)
+  let apiToken = s:config('api_token', s:required_config_value)
+  let apiUri = 'http://' . apiHost . ':' . apiPort . '/' . apiToken . '/api/find'
+
+  let curlCommand = s:curl_path() . " -Gfs
+        \ --data-urlencode 'limit=" . resultLimit . "'
+        \ --data-urlencode 'query=" . a:base . "' "
+        \ . apiUri
+
+  let jqFilter = '
+        \ def prettyTermType: .termType|[(.[] | .segment)]|add;
+        \ def prettyTypeDef: if .tag == "BuiltinObject" then "builtin type " else "" end + (.contents|[(.[] | .segment)]|add);
+        \ def termToMatch: {
+        \   word: .bestFoundTermName,
+        \   info: (.namedTerm.termName + " : " + (.namedTerm|prettyTermType)),
+        \   menu: .namedTerm|prettyTermType
+        \ };
+        \ def typeToMatch: {
+        \   word: .bestFoundTypeName,
+        \   info: (.namedType.typeName + " : " + (.typeDef|prettyTypeDef)),
+        \   menu: .typeDef|prettyTypeDef
+        \ };
+        \ .[][1]|(
+        \   (select(.tag == "FoundTermResult")|.contents|termToMatch),
+        \   (select(.tag == "FoundTypeResult")|.contents|typeToMatch)
+        \ )'
+
+  let command = curlCommand . " | " . s:jq_path() . " -c '" . jqFilter . "'"
+  let lines = system(command)
+  let resultObjects = split(lines, "\n")
+  call map(resultObjects, {_, val -> json_decode(val)})
+  return resultObjects
+endfunction
+
+" vim: set et sw=2 sts=2 ts=2:

--- a/editor-support/vim/doc/unison.txt
+++ b/editor-support/vim/doc/unison.txt
@@ -1,0 +1,90 @@
+*ft_unison.txt* Filetype plugin for the Unison programming language
+
+==============================================================================
+CONTENTS                                                              *unison*
+
+1. Installation                                          |unison-installation|
+2. Configuration                                        |unison-configuration|
+3. Recommended Settings                          |unison-recommended-settings|
+
+==============================================================================
+INSTALLATION                                           *unison-installation*
+
+Install with your plugin manager of choice.
+
+Make sure that you also set all of the required configuration fields:
+|unison-configuration-required|
+
+Note: This plugin requires both `curl` and `jq` to be installed.  If they are
+installed but not on the `PATH` of the running vim process, you can set them
+explicitly with |unison_curl_path| and |unison_jq_path|.
+
+==============================================================================
+CONFIGURATION                                           *unison-configuration*
+
+All Unison configuration values allow buffer-local settings (ex:
+`b:unison_api_port`) to override an global configuration (ex:
+`g:unison_api_port`).
+
+
+Required configuration values:                 *unison-configuration-required*
+
+                                                           *g:unison_api_port*
+g:unison_api_port~
+
+  Example: >
+    let g:unison_api_port='5862'
+<
+
+                                                          *g:unison_api_token*
+g:unison_api_token~
+
+  Example: >
+    let g:unison_api_token='z8123l_acv2'
+<
+
+Optional configuration values:                 *unison-configuration-optional*
+
+                                                           *g:unison_api_host*
+g:unison_api_host~
+
+  Example: >
+    let g:unison_api_host='localhost'
+<
+
+                                                 *g:unison_set_buffer_defaults*
+g:unison_set_buffer_defaults~
+  Set to 0 to disable default settings (such as 'omnifunc')
+
+  Example: >
+    let g:unison_set_buffer_defaults=0
+<
+                                                          *g:unison_curl_path*
+g:unison_curl_path~
+  The path to the `curl` executable.
+
+  Example: >
+    let g:unison_curl_path='/usr/bin/curl'
+<
+
+                                                            *g:unison_jq_path*
+g:unison_jq_path~
+  The path to the `jq` executable.
+
+  Example: >
+    let g:unison_jq_path='/usr/local/bin/jq'
+<
+
+==============================================================================
+RECOMMENDED SETTINGS                             *unison-recommended-settings*
+
+These settings aren't specific to Unison, but they will likely improve the
+experience of the Unison support.
+
+>
+  " close preview window when completion is finished
+  autocmd CompleteDone * silent! pclose!
+<
+
+==============================================================================
+ vim:tw=78:et:ft=help:norl:

--- a/editor-support/vim/ftplugin/unison.vim
+++ b/editor-support/vim/ftplugin/unison.vim
@@ -1,0 +1,7 @@
+" Only do this when not done yet for this buffer
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+call unison#SetBufferDefaults()


### PR DESCRIPTION
## Overview

This adds Vim completion (by default omnicomplete) for Unison. It also fleshes out the vim support a bit with some docs.

See demo [here](https://asciinema.org/a/Oa50pRFO8JpIQFvg7ZzWg3cel).

## Implementation notes

Calls into the codebase API with `curl` and parses the output with `jq`.

## Interesting/controversial decisions

Configuring the API port and token is a hassle. Right now I have my vimrc configure these to static values that I'm passing in via the `--port` and `--token` parameters to `ucm`.

## Test coverage

lol I have no idea how to test a vim plugin

## Loose ends

This only looks at the "word" that you are calling complete on, so it won't respect `use` statements. It arguably would be better to insert fully-qualified names so they are resilient to contextual `use` statements. It would be an easy change to make, but will make the completed items more verbose most of the time. We might want to expose a flag for FQN completion.
