### PR TITLE
[Issue 1367]: Report a warning on empty diff.namespace

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -61,3 +61,4 @@ The format for this list: name, GitHub handle, and then optional blurb about wha
 * Evan Minsk (@iamevn)
 * Karthik Ravikanti (@plumenator)
 * Alberto Flores (@albertoefguerrero)
+* Shawn Bachlet (@shawn-bachlet)

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -721,8 +721,13 @@ loop = do
               resolveToAbsolute <$> [before0, after0]
         before <- Branch.head <$> getAt beforep
         after <- Branch.head <$> getAt afterp
-        (ppe, outputDiff) <- diffHelper before after
-        respondNumbered $ ShowDiffNamespace beforep afterp ppe outputDiff
+        case (Branch.isEmpty0 before, Branch.isEmpty0 after) of
+          (True, True) -> respond . NamespaceEmpty $ Right (beforep, afterp)
+          (True, False) -> respond . NamespaceEmpty $ Left beforep
+          (False, True) -> respond . NamespaceEmpty $ Left afterp
+          _ -> do
+            (ppe, outputDiff) <- diffHelper before after
+            respondNumbered $ ShowDiffNamespace beforep afterp ppe outputDiff
 
       CreatePullRequestI baseRepo headRepo -> unlessGitError do
         (cleanupBase, baseBranch) <- viewRemoteBranch baseRepo

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -210,6 +210,7 @@ data Output v
   | DefaultMetadataNotification
   | BadRootBranch GetRootBranchError
   | CouldntLoadBranch Branch.Hash
+  | NamespaceEmpty (Either Path.Absolute (Path.Absolute, Path.Absolute))
   | NoOp
   deriving (Show)
 
@@ -328,6 +329,7 @@ isFailure o = case o of
   ListDependents{} -> False
   TermMissingType{} -> True
   DumpUnisonFileHashes _ x y z -> x == mempty && y == mempty && z == mempty
+  NamespaceEmpty _ -> False
 
 isNumberedFailure :: NumberedOutput v -> Bool
 isNumberedFailure = \case

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -278,6 +278,22 @@ notifyUser dir o = case o of
     pure . P.fatalCallout . P.wrap $ "I have reason to believe that"
       <> P.shown h <> "exists in the codebase, but there was a failure"
       <> "when I tried to load it."
+  NamespaceEmpty p ->
+    case p of
+      Right (p0, p1) ->
+        pure
+          . P.warnCallout
+          $ "The namespaces "
+          <> P.string (show p0)
+          <> " and "
+          <> P.string (show p1)
+          <> " are empty. Was there a typo?"
+      Left p0 ->
+        pure
+          . P.warnCallout
+          $ "The namespace "
+          <> P.string (show p0)
+          <> " is empty. Was there a typo?"
   WarnIncomingRootBranch current hashes -> pure $
     if null hashes then P.wrap $
       "Please let someone know I generated an empty IncomingRootBranch"

--- a/unison-src/transcripts/diff.output.md
+++ b/unison-src/transcripts/diff.output.md
@@ -153,19 +153,9 @@ Here's what we've done so far:
 ```ucm
 .> diff.namespace nothing ns1
 
-  Added definitions:
+  ⚠️
   
-    1.  structural type A a
-    2.  structural ability X a1 a2
-    3.  A.A           : Nat -> A a
-    4.  X.x           : {X a1 a2} Nat
-    5.  b             : Nat
-    6.  bdependent    : Nat
-    7.  c             : Nat
-    8.  ┌ fromJust    : Nat (+1 metadata)
-    9.  └ fromJust'   : Nat (+1 metadata)
-    10. ┌ helloWorld  : Text
-    11. └ helloWorld2 : Text
+  The namespace .nothing is empty. Was there a typo?
 
 .> diff.namespace ns1 ns2
 


### PR DESCRIPTION
## Overview
This PR is a targeted to fix #1367. The changes are small and localized. All tests are passing locally and the warnings printed exactly match those listed in the issue. 

## Implementation notes

This PR checks if either branch in a diff is empty and reports a warning if either (or both) are empty.

## Interesting/controversial decisions

I'm not crazy about the type of the constructor. I think there may be a more semantically clear type but, I couldn't think of it.

## Test coverage

I tested this manually by running the commands listed in the PR as well as making sure non-empty diffs still succeeded as well.

## Loose ends

The issue list a possible further improvement. This seemed like an additional improvement possibly beyond the scope of this issue? 
> Maybe some heuristic too for rejecting pushes with unrelated* histories. *Our histories are always related by the empty Branch, but maybe they wouldn't have to be?

