### PR TITLE
Docs.AsHtml: Support linking between docs

### DIFF
--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -842,11 +842,12 @@ docsInBranchToHtmlFiles runtime codebase root currentPath directory = do
   let currentBranch = Branch.getAt' currentPath root
   let allTerms = (R.toList . Branch.deepTerms . Branch.head) currentBranch
   docTermsWithNames <- filterM (isDoc codebase . fst) allTerms
+  let docNamesByRef = Map.fromList docTermsWithNames
   hqLength <- Codebase.hashLength codebase
   let printNames = getCurrentPrettyNames (AllNames currentPath) root
   let ppe = PPE.fromNamesDecl hqLength printNames
   docs <- for docTermsWithNames (renderDoc' ppe runtime codebase)
-  liftIO $ traverse_ (renderDocToHtmlFile directory) docs
+  liftIO $ traverse_ (renderDocToHtmlFile docNamesByRef directory) docs
 
   where
     renderDoc' ppe runtime codebase (ref, name) = do
@@ -877,15 +878,15 @@ docsInBranchToHtmlFiles runtime codebase root currentPath directory = do
 
       in dir </> fileName
 
-    renderDocToHtmlFile :: FilePath -> (Name, UnisonHash, Doc.Doc) -> IO ()
-    renderDocToHtmlFile destination (docName, _, doc) =
+    renderDocToHtmlFile :: Map Referent Name -> FilePath -> (Name, UnisonHash, Doc.Doc) -> IO ()
+    renderDocToHtmlFile docNamesByRef destination (docName, _, doc) =
       let
         fullPath = docFilePath destination docName
         directoryPath = takeDirectory fullPath
        in do
         -- Ensure all directories exists
         _ <- createDirectoryIfMissing True directoryPath
-        Lucid.renderToFile fullPath (DocHtml.toHtml doc)
+        Lucid.renderToFile fullPath (DocHtml.toHtml docNamesByRef doc)
 
 bestNameForTerm
   :: forall v . Var v => PPE.PrettyPrintEnv -> Width -> Referent -> Text

--- a/parser-typechecker/src/Unison/Server/Syntax.hs
+++ b/parser-typechecker/src/Unison/Server/Syntax.hs
@@ -12,6 +12,7 @@ module Unison.Server.Syntax where
 
 import Data.Aeson (ToJSON)
 import qualified Data.List as List
+import Data.List.Extra
 import qualified Data.List.NonEmpty as List.NonEmpty
 import Data.OpenApi (ToSchema (..))
 import Data.Proxy (Proxy (..))
@@ -34,7 +35,6 @@ import Unison.Util.AnnotatedText
     segment,
   )
 import qualified Unison.Util.SyntaxText as SyntaxText
-import Data.List.Extra
 
 type SyntaxText = AnnotatedText Element
 
@@ -196,13 +196,13 @@ segmentToHtml (Segment segmentText element) =
       ref =
         case el of
           TypeReference h ->
-            Just h
+            Just (h, "type")
           TermReference h ->
-            Just h
+            Just (h, "term")
           AbilityConstructorReference h ->
-            Just h
+            Just (h, "ability-constructor")
           DataConstructorReference h ->
-            Just h
+            Just (h, "data-constructor")
           _ ->
             Nothing
 
@@ -231,8 +231,8 @@ segmentToHtml (Segment segmentText element) =
         | isFQN = nameToHtml (Name.unsafeFromText sText)
         | otherwise = L.toHtml sText
    in case ref of
-        Just r ->
-          span_ [class_ className, data_ "ref" r] content
+        Just (r, refType) ->
+          span_ [class_ className, data_ "ref" r, data_ "ref-type" refType] content
         _ ->
           span_ [class_ className] content
 


### PR DESCRIPTION
## Problem
HTML Docs were referencing each other by reference, but the files generated are based on names and namespaces.

## Solution
* Add a way for docs to lookup a referent, get a name and convert it to
  a html href.
* Add a reference type as a data attribute to syntax refs

## Notes
* Also ran the codeformatter