### PR TITLE
Measure integration test times

### DIFF
--- a/unison-cli/integration-tests/IntegrationTests/ArgumentParsing.hs
+++ b/unison-cli/integration-tests/IntegrationTests/ArgumentParsing.hs
@@ -5,11 +5,11 @@ module IntegrationTests.ArgumentParsing where
 import Data.List (intercalate)
 
 import Data.Text (pack)
+import Data.Time (getCurrentTime, diffUTCTime)
 import EasyTest
 import Shellmet (($|))
 import System.Exit (ExitCode (ExitSuccess))
 import System.Process (readProcessWithExitCode)
-import System.CPUTime
 import Text.Printf
 
 uFile :: String
@@ -64,11 +64,11 @@ test =
 
 expectExitCode :: ExitCode -> FilePath -> [String] -> [String] -> String -> Test ()
 expectExitCode expected cmd defArgs args stdin = scope (intercalate " " (cmd : args <> defArgs)) do
-  start <- io $ getCPUTime
+  start <- io $ getCurrentTime
   (code, _, _) <- io $ readProcessWithExitCode cmd args stdin
-  end <- io $ getCPUTime
-  let diff = (fromIntegral (end - start)) / (10^12)
-  note $ printf "\n[Time: %0.3f sec]" (diff :: Double)
+  end <- io $ getCurrentTime
+  let diff = diffUTCTime end start
+  note $ printf "\n[Time: %s sec]" $ show diff 
   expectEqual code expected
 
 defaultArgs :: [String]

--- a/unison-cli/integration-tests/IntegrationTests/ArgumentParsing.hs
+++ b/unison-cli/integration-tests/IntegrationTests/ArgumentParsing.hs
@@ -9,6 +9,8 @@ import EasyTest
 import Shellmet (($|))
 import System.Exit (ExitCode (ExitSuccess))
 import System.Process (readProcessWithExitCode)
+import System.CPUTime
+import Text.Printf
 
 uFile :: String
 uFile = "unison-cli/integration-tests/IntegrationTests/print.u"
@@ -62,7 +64,11 @@ test =
 
 expectExitCode :: ExitCode -> FilePath -> [String] -> [String] -> String -> Test ()
 expectExitCode expected cmd defArgs args stdin = scope (intercalate " " (cmd : args <> defArgs)) do
+  start <- io $ getCPUTime
   (code, _, _) <- io $ readProcessWithExitCode cmd args stdin
+  end <- io $ getCPUTime
+  let diff = (fromIntegral (end - start)) / (10^12)
+  note $ printf "\n[Time: %0.3f sec]" (diff :: Double)
   expectEqual code expected
 
 defaultArgs :: [String]

--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -77,6 +77,7 @@ executables:
       - process
       - shellmet
       - text
+      - time
       - unison-core1
       - unison-parser-typechecker
       - unison-prelude

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -48,6 +48,7 @@ executable integration-tests
     , process
     , shellmet
     , text
+    , time
     , unison-core1
     , unison-parser-typechecker
     , unison-prelude


### PR DESCRIPTION
## Overview

We added `integration-tests` in #2543 .
Some tests can be slow (#2559) .
We should monitor durations to judge if we need to improve or not.
Simple time measuring was added in this PR.


## Interesting/controversial decisions

It may be better to use criterion. But I think it will be too much.

## Loose ends

- #2543 
- #2559
