### PR TITLE
Fix blank version string in compiled output from transcript runner

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
+++ b/parser-typechecker/src/Unison/Codebase/TranscriptParser.hs
@@ -120,8 +120,8 @@ parse srcName txt = case P.parse (stanzas <* P.eof) srcName txt of
   Right a -> Right a
   Left e -> Left (show e)
 
-run :: FilePath -> FilePath -> [Stanza] -> Codebase IO Symbol Ann -> IO Text
-run dir configFile stanzas codebase = do
+run :: String -> FilePath -> FilePath -> [Stanza] -> Codebase IO Symbol Ann -> IO Text
+run version dir configFile stanzas codebase = do
   let initialPath = Path.absoluteEmpty
   putPrettyLn $ P.lines [
     asciiartUnison, "",
@@ -144,7 +144,7 @@ run dir configFile stanzas codebase = do
     (config, cancelConfig)   <-
       catchIOError (watchConfig configFile) $ \_ ->
         die "Your .unisonConfig could not be loaded. Check that it's correct!"
-    runtime                  <- RTI.startRuntime ""
+    runtime                  <- RTI.startRuntime version
     traverse_ (atomically . Q.enqueue inputQueue) (stanzas `zip` [1..])
     let patternMap =
           Map.fromList

--- a/parser-typechecker/tests/Unison/Test/Ucm.hs
+++ b/parser-typechecker/tests/Unison/Test/Ucm.hs
@@ -79,7 +79,7 @@ runTranscript (Codebase codebasePath fmt) transcript = do
   output <-
     flip (either err) (TR.parse "transcript" (Text.pack . stripMargin $ unTranscript transcript)) $ \stanzas ->
       fmap Text.unpack $
-        TR.run
+        TR.run "Unison.Test.Ucm.runTranscript Invalid Version String"
           codebasePath
           configFile
           stanzas

--- a/unison-cli/integration-tests/IntegrationTests/ArgumentParsing.hs
+++ b/unison-cli/integration-tests/IntegrationTests/ArgumentParsing.hs
@@ -54,12 +54,10 @@ test =
       , expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison", "--token", "MY_TOKEN"] "" -- ?
       , expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison"] ""
       , expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison", "--ui", tempCodebase] ""
-      -- run.compiled appears to be broken at the moment, these should be added back once it's
-      -- fixed to ensure it keeps working.
-      -- , scope "can compile, then run compiled artifact" $ tests
-      --   [ expectExitCode ExitSuccess "stack" defaultArgs [] ["exec", "--", "unison", "transcript", transcriptFile] ""
-      --   , expectExitCode ExitSuccess "stack" defaultArgs [] ["exec", "--", "unison", "run.compiled", "./unison-cli/integration-tests/IntegrationTests/main"] ""
-      --   ]
+      , scope "can compile, then run compiled artifact" $ tests
+        [ expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison", "transcript", transcriptFile] ""
+        , expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison", "run.compiled", "./unison-cli/integration-tests/IntegrationTests/main.uc"] ""
+        ]
       ]
 
 expectExitCode :: ExitCode -> FilePath -> [String] -> [String] -> String -> Test ()

--- a/unison-cli/unison/Main.hs
+++ b/unison-cli/unison/Main.hs
@@ -248,7 +248,7 @@ runTranscripts' mcodepath transcriptDir args = do
         configFilePath <- getConfigFilePath mcodepath
         -- We don't need to create a codebase through `getCodebaseOrExit` as we've already done so previously.
         ((closeCodebase, theCodebase),_) <- getCodebaseOrExit (Just (DontCreateCodebaseWhenMissing transcriptDir))
-        mdOut <- TR.run transcriptDir configFilePath stanzas theCodebase
+        mdOut <- TR.run Version.gitDescribeWithDate transcriptDir configFilePath stanzas theCodebase
         closeCodebase
         let out = currentDir FP.</>
                    FP.addExtension (FP.dropExtension fileName ++ ".output")


### PR DESCRIPTION
Some calls into the transcript runner are still given an invalid version string, but they are in the parser-typecheker's unit tests, not the main transcript runner. I put in a more explicit invalid message that will be displayed on version mismatch, though, not just a blank string.
