### PR TITLE
Remove Intput from GitError Output, fix up some misleading output

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -415,8 +415,7 @@ loop = do
           MakeStandaloneI out nm ->
             "compile.output " <> Text.pack out <> " " <> HQ.toText nm
           PullRemoteBranchI orepo dest _syncMode _ ->
-            (Text.pack . InputPattern.patternName
-              $ InputPatterns.patternFromInput input)
+            (Text.pack . InputPattern.patternName $ InputPatterns.pull)
               <> " "
               -- todo: show the actual config-loaded namespace
               <> maybe "(remote namespace from .unisonConfig)"
@@ -489,7 +488,7 @@ loop = do
         updateRoot = flip Unison.Codebase.Editor.HandleInput.updateRoot inputDescription
         syncRoot = use root >>= updateRoot
         updateAtM = Unison.Codebase.Editor.HandleInput.updateAtM inputDescription
-        unlessGitError = unlessError' (Output.GitError input)
+        unlessGitError = unlessError' Output.GitError
         importRemoteBranch ns mode = ExceptT . eval $ ImportRemoteBranch ns mode
         viewRemoteBranch ns = ExceptT . eval $ ViewRemoteBranch ns
         syncRemoteRootBranch repo b mode =

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -179,7 +179,7 @@ data Output v
   -- todo: eventually replace these sets with [SearchResult' v Ann]
   -- and a nicer render.
   | BustedBuiltins (Set Reference) (Set Reference)
-  | GitError Input GitError
+  | GitError GitError
   | ConfiguredMetadataParseError Path' String (P.Pretty P.ColorText)
   | NoConfiguredGitUrl PushPull Path'
   | ConfiguredGitUrlParseError PushPull Path' Text String

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -47,8 +47,6 @@ import qualified Unison.Util.Relation as R
 import qualified Unison.Codebase.Editor.SlurpResult as SR
 import qualified Unison.Codebase.Editor.UriParser as UriParser
 import Unison.Codebase.Editor.RemoteRepo (ReadRemoteNamespace, WriteRemotePath, WriteRepo)
-import qualified Unison.Codebase.Editor.RemoteRepo as RemoteRepo
-import Data.Tuple.Extra (uncurry3)
 import Unison.Codebase.Verbosity (Verbosity)
 import qualified Unison.Codebase.Verbosity as Verbosity
 import qualified Unison.CommandLine.Globbing as Globbing
@@ -1683,24 +1681,3 @@ gitUrlArg = ArgumentType
 
 collectNothings :: (a -> Maybe b) -> [a] -> [a]
 collectNothings f as = [ a | (Nothing, a) <- map f as `zip` as ]
-
-patternFromInput :: Input -> InputPattern
-patternFromInput = \case
-  Input.PushRemoteBranchI _ _ SyncMode.ShortCircuit -> push
-  Input.PushRemoteBranchI _ _ SyncMode.Complete -> pushExhaustive
-  Input.PullRemoteBranchI _ _ SyncMode.ShortCircuit Verbosity.Default -> pull
-  Input.PullRemoteBranchI _ _ SyncMode.ShortCircuit Verbosity.Silent -> pullSilent
-  Input.PullRemoteBranchI _ _ SyncMode.Complete _ -> pushExhaustive
-  _ -> error "todo: finish this function"
-
-inputStringFromInput :: IsString s => Input -> P.Pretty s
-inputStringFromInput = \case
-  i@(Input.PushRemoteBranchI rh p' _) ->
-    (P.string . I.patternName $ patternFromInput i)
-      <> (" " <> maybe mempty (P.text . uncurry RemoteRepo.printHead) rh)
-      <> " " <> P.shown p'
-  i@(Input.PullRemoteBranchI ns p' _ _) ->
-    (P.string . I.patternName $ patternFromInput i)
-      <> (" " <> maybe mempty (P.text . uncurry3 RemoteRepo.printNamespace) ns)
-      <> " " <> P.shown p'
-  _ -> error "todo: finish this function"

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -53,7 +53,6 @@ import           Unison.CommandLine             ( bigproblem
 import           Unison.PrettyTerminal          ( clearCurrentLine
                                                 , putPretty'
                                                 )
-import qualified Unison.CommandLine.InputPattern as IP1
 import           Unison.CommandLine.InputPatterns (makeExample, makeExample')
 import qualified Unison.CommandLine.InputPatterns as IP
 import qualified Unison.Builtin.Decls          as DD
@@ -670,7 +669,7 @@ notifyUser dir o = case o of
     else pure mempty
 
   TodoOutput names todo -> pure (todoOutput names todo)
-  GitError input e -> pure $ case e of
+  GitError e -> pure $ case e of
     GitSqliteCodebaseError e -> case e of
       UnrecognizedSchemaVersion repo localPath (SchemaVersion v) -> P.wrap
         $ "I don't know how to interpret schema version " <> P.shown v
@@ -706,15 +705,11 @@ notifyUser dir o = case o of
         P.wrap $ "The repository at" <> prettyWriteRepo repo
               <> "has some changes I don't know about.",
         "",
-        P.wrap $ "If you want to " <> push <> "you can do:", "",
-        P.indentN 2 pull, "",
-        P.wrap $
-          "to merge these changes locally," <>
-          "then try your" <> push <> "again."
+        P.wrap $ "Try" <> pull <> "to merge these changes locally, then" <> push <> "again."
         ]
         where
-        push = P.group . P.backticked . P.string . IP1.patternName $ IP.patternFromInput input
-        pull = P.group . P.backticked $ IP.inputStringFromInput input
+        push = P.group . P.backticked . IP.patternName $ IP.push
+        pull = P.group . P.backticked . IP.patternName $ IP.pull
     GitCodebaseError e -> case e of
       CouldntLoadRootBranch repo hash -> P.wrap
         $ "I couldn't load the designated root hash"


### PR DESCRIPTION
## Overview

This PR removes the `Input` from the `GitError` output;

After a chat with @aryairani we decided it's a bit weird to pass the `Input` along to an `Output`, for the purpose of recovering the thing that was originally typed in, which is not really known by the main CLI loop that only processes abstract `Input`s.

One specific error message to do with a `git pull` failing was adjusted accordingly. (It also had a bug where it tried to suggest you `pull`, but it actually suggested you `push`.