### PR TITLE
Move beforeHash to Causal module

### DIFF
--- a/parser-typechecker/tests/Unison/Test/Codebase/Causal.hs
+++ b/parser-typechecker/tests/Unison/Test/Codebase/Causal.hs
@@ -24,7 +24,6 @@ import Unison.Hashable (Hashable)
 import Data.Set (Set)
 import Data.Functor.Identity
 import Unison.Hash (Hash)
-import Unison.CommandLine (beforeHash)
 
 c :: M (Causal M Int64 [Int64])
 c = merge (foldr cons (one [1]) t1)
@@ -141,7 +140,7 @@ beforeHashTests = do
   expect' . not =<< before c1 (longCausal (1000 :: Int64))
   ok
   where
-    before h c = beforeHash 10 (Causal.currentHash h) c
+    before h c = Causal.beforeHash 10 (Causal.currentHash h) c
     sillyMerge _lca l _r = pure l
     longCausal 0 = Causal.one 0
     longCausal n = Causal.cons n (longCausal (n - 1))


### PR DESCRIPTION
## Overview

Moved a causal-related function from `Unison.CommandLine` to `Unison.Codebase.Causal` to facilitate pulling more UCM modules out of `unison-parser-typechecker`.