### PR TITLE
Adds missing dependencies to cabal.project

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -62,3 +62,4 @@ The format for this list: name, GitHub handle, and then optional blurb about wha
 * Karthik Ravikanti (@plumenator)
 * Alberto Flores (@albertoefguerrero)
 * Shawn Bachlet (@shawn-bachlet)
+* Solomon Bothwell (@solomon-b)

--- a/contrib/cabal.project
+++ b/contrib/cabal.project
@@ -2,6 +2,7 @@ packages:
     yaks/easytest
     parser-typechecker
     unison-core
+    unison-cli
     lib/unison-prelude
     lib/unison-util-relation
     codebase2/codebase

--- a/contrib/cabal.project
+++ b/contrib/cabal.project
@@ -2,6 +2,8 @@ packages:
     yaks/easytest
     parser-typechecker
     unison-core
+    lib/unison-prelude
+    lib/unison-util-relation
     codebase2/codebase
     codebase2/codebase-sqlite
     codebase2/codebase-sync


### PR DESCRIPTION
## Overview
There were a few missing dependencies in the `cabal.project`. This PR allows unison to be build using `cabal`.

## Implementation notes

Nothing special here, just updates to the `cabal.project` file. 

## Interesting/controversial decisions

This was a pretty mechanical update.

## Test coverage

No added test coverage.

## Loose ends

Link to related issues that address things you didn't get to. Stuff you encountered on the way and decided not to include in this PR.
