### PR TITLE
Use suffixed names inside ability declarations in codebase UI

### DIFF
--- a/parser-typechecker/src/Unison/DeclPrinter.hs
+++ b/parser-typechecker/src/Unison/DeclPrinter.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Unison.DeclPrinter where
+module Unison.DeclPrinter (prettyDecl, prettyDeclHeader, prettyDeclOrBuiltinHeader) where
 
 import Unison.Prelude
 
@@ -41,8 +41,8 @@ prettyDecl
   -> HashQualified Name
   -> DD.Decl v a
   -> Pretty SyntaxText
-prettyDecl ppe@(PrettyPrintEnvDecl unsuffixifiedPPE _) r hq d = case d of
-  Left e -> prettyEffectDecl unsuffixifiedPPE r hq e
+prettyDecl ppe r hq d = case d of
+  Left e -> prettyEffectDecl (suffixifiedPPE ppe) r hq e
   Right dd -> prettyDataDecl ppe r hq dd
 
 prettyEffectDecl

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1451,9 +1451,7 @@ displayDefinitions' ppe0 types terms = P.syntaxToColor $ P.sep "\n\n" (prettyTyp
       case dt of
         MissingObject r -> missing n r
         BuiltinObject _ -> builtin n
-        UserObject decl -> case decl of
-          Left d -> DeclPrinter.prettyEffectDecl (ppeBody r) r n d
-          Right d -> DeclPrinter.prettyDataDecl (PPE.declarationPPEDecl ppe0 r) r n d
+        UserObject decl -> DeclPrinter.prettyDecl (PPE.declarationPPEDecl ppe0 r) r n decl
     builtin n = P.wrap $ "--" <> prettyHashQualified n <> " is built-in."
     missing n r =
       P.wrap
@@ -1559,9 +1557,7 @@ displayDefinitions outputLoc ppe types terms =
           case dt of
             MissingObject r -> missing n r
             BuiltinObject _ -> builtin n
-            UserObject decl -> case decl of
-              Left d -> DeclPrinter.prettyEffectDecl (ppeBody r) r n d
-              Right d -> DeclPrinter.prettyDataDecl (PPE.declarationPPEDecl ppe r) r n d
+            UserObject decl -> DeclPrinter.prettyDecl (PPE.declarationPPEDecl ppe r) r n decl
         builtin n = P.wrap $ "--" <> prettyHashQualified n <> " is built-in."
         missing n r =
           P.wrap
@@ -1674,9 +1670,7 @@ prettyDeclTriple ::
 prettyDeclTriple (name, _, displayDecl) = case displayDecl of
   BuiltinObject _ -> P.hiBlack "builtin " <> P.hiBlue "type " <> P.blue (P.syntaxToColor $ prettyHashQualified name)
   MissingObject _ -> mempty -- these need to be handled elsewhere
-  UserObject decl -> case decl of
-    Left ed -> P.syntaxToColor $ DeclPrinter.prettyEffectHeader name ed
-    Right dd -> P.syntaxToColor $ DeclPrinter.prettyDataHeader name dd
+  UserObject decl -> P.syntaxToColor $ DeclPrinter.prettyDeclHeader name decl
 
 prettyDeclPair ::
   Var v =>

--- a/unison-src/transcripts/fix2567.md
+++ b/unison-src/transcripts/fix2567.md
@@ -1,0 +1,18 @@
+Regression test for https://github.com/unisonweb/unison/issues/2567
+
+```ucm:hide
+.> alias.type ##Nat .foo.bar.Nat
+```
+
+```unison:hide
+structural ability Foo where
+  blah : Nat -> Nat
+  zing.woot : Nat -> (Nat,Nat) -> Nat
+```
+
+```ucm
+.some.subnamespace> add
+.some.subnamespace> alias.term Foo.zing.woot Foo.woot
+.> view Foo
+.somewhere> view Foo
+```

--- a/unison-src/transcripts/fix2567.output.md
+++ b/unison-src/transcripts/fix2567.output.md
@@ -1,0 +1,36 @@
+Regression test for https://github.com/unisonweb/unison/issues/2567
+
+```unison
+structural ability Foo where
+  blah : Nat -> Nat
+  zing.woot : Nat -> (Nat,Nat) -> Nat
+```
+
+```ucm
+  ☝️  The namespace .some.subnamespace is empty.
+
+.some.subnamespace> add
+
+  ⍟ I've added these definitions:
+  
+    structural ability Foo
+
+.some.subnamespace> alias.term Foo.zing.woot Foo.woot
+
+  Done.
+
+.> view Foo
+
+  structural ability some.subnamespace.Foo where
+    woot : Nat -> (Nat, Nat) ->{some.subnamespace.Foo} Nat
+    blah : Nat ->{some.subnamespace.Foo} Nat
+
+  ☝️  The namespace .somewhere is empty.
+
+.somewhere> view Foo
+
+  structural ability .some.subnamespace.Foo where
+    woot : Nat -> (Nat, Nat) ->{.some.subnamespace.Foo} Nat
+    blah : Nat ->{.some.subnamespace.Foo} Nat
+
+```


### PR DESCRIPTION
Fixes #2567 

Due to an implementation quirk, this weirdness was only present in the codebase UI (and on Unison Share). I modified the code so that both UCM and the codebase UI go through an identical code path, and added an explict export list to `DeclPrinter`.

To get the output of `ability` declarations further cleaned up, I think the pretty-printer could really use the ability to emit top-level `use` clauses https://github.com/unisonweb/unison/issues/939 which @atacratic has mentioned.