### PR TITLE
Doc.AsHtml: Ensure we render emojis in callouts

### DIFF
--- a/parser-typechecker/src/Unison/Server/Doc/AsHtml.hs
+++ b/parser-typechecker/src/Unison/Server/Doc/AsHtml.hs
@@ -230,9 +230,9 @@ toHtml docNamesByRef document =
               Callout icon content ->
                 let (cls, ico) =
                       case icon of
-                        Just (Word emoji) ->
-                          (class_ "callout callout-with-icon", div_ [class_ "callout-icon"] $ L.toHtml emoji)
-                        _ ->
+                        Just emoji ->
+                          (class_ "callout callout-with-icon", div_ [class_ "callout-icon"] $ L.toHtml . toText "" $ emoji)
+                        Nothing ->
                           (class_ "callout", "")
                  in div_ [cls] $ do
                       ico


### PR DESCRIPTION
## Overview
Callouts seems to have emojis inside of a paragraph. Use the toText
function to grab the text out of any doc element that is textural in
nature regardless of depth.

Related Codebase UI PR: https://github.com/unisonweb/codebase-ui/pull/273