### PR TITLE
Guard against improper eta reductions

### DIFF
--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -968,7 +968,8 @@ etaNormalForm :: Ord v => Term0 v -> Term0 v
 etaNormalForm tm = case tm of
   LamNamed' v body -> step . lam (ABT.annotation tm) v $ etaNormalForm body
     where
-      step (LamNamed' v (App' f (Var' v'))) | v == v' = f
+      step (LamNamed' v (App' f (Var' v')))
+        | v == v' , v `Set.notMember` freeVars f = f
       step tm = tm
   _ -> tm
 
@@ -977,8 +978,9 @@ etaReduceEtaVars :: Var v => Term0 v -> Term0 v
 etaReduceEtaVars tm = case tm of
   LamNamed' v body -> step . lam (ABT.annotation tm) v $ etaReduceEtaVars body
     where
-      ok v v' = v == v' && Var.typeOf v == Var.Eta
-      step (LamNamed' v (App' f (Var' v'))) | ok v v' = f
+      ok v v' f = v == v' && Var.typeOf v == Var.Eta
+        && v `Set.notMember` freeVars f
+      step (LamNamed' v (App' f (Var' v'))) | ok v v' f = f
       step tm = tm
   _ -> tm
 

--- a/unison-src/transcripts/fix2156.md
+++ b/unison-src/transcripts/fix2156.md
@@ -1,0 +1,14 @@
+
+Tests for a case where bad eta reduction was causing erroneous watch
+output/caching.
+
+```ucm:hide
+.> builtins.merge
+```
+
+```unison
+sqr : Nat -> Nat
+sqr n = n * n
+
+> sqr
+```

--- a/unison-src/transcripts/fix2156.output.md
+++ b/unison-src/transcripts/fix2156.output.md
@@ -1,0 +1,29 @@
+
+Tests for a case where bad eta reduction was causing erroneous watch
+output/caching.
+
+```unison
+sqr : Nat -> Nat
+sqr n = n * n
+
+> sqr
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      sqr : Nat -> Nat
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    4 | > sqr
+          ⧩
+          n -> n Nat.* n
+
+```


### PR DESCRIPTION
The eta reducer was converting `x -> f x x` to `f x`

Fixes #2156 