### PR TITLE
re-export U.Util.Hash(Hash) as Unison.Hash(Hash)

### DIFF
--- a/codebase2/util/bench/Main.hs
+++ b/codebase2/util/bench/Main.hs
@@ -12,7 +12,7 @@ import qualified U.Util.Base32Hex as U.Base32Hex
 
 main :: IO ()
 main = do
-  let textual = U.Base32Hex.UnsafeBase32Hex "kccnret7m1895ta8ncs3ct5pqmguqntvjlcsr270ug8mbqvkh07v983i12obpgsii0gbga2esk1423t6evr03f62hkkfllrrj7iil30"
+  let textual = U.Base32Hex.UnsafeFromText "kccnret7m1895ta8ncs3ct5pqmguqntvjlcsr270ug8mbqvkh07v983i12obpgsii0gbga2esk1423t6evr03f62hkkfllrrj7iil30"
   let binary = "\163\EM}\187\167\176P\146\245H\187\&86t\185\213\161\237_\191\157Y\205\136\224\244\DC1e\235\244\136\SI\244\160r\b\176\188\195\146\144 \184(N\229\STXA\SI\166w\246\SOH\188\194\141(\250\215{\153\229*\140"
 
   defaultMain
@@ -29,7 +29,7 @@ sandi_fromByteString bs =
 
 -- The old implementation of `toByteString` which used `sandi`
 sandi_toByteString :: U.Base32Hex.Base32Hex -> ByteString
-sandi_toByteString (U.Base32Hex.UnsafeBase32Hex txt) =
+sandi_toByteString (U.Base32Hex.UnsafeFromText txt) =
   case Sandi.decode (Text.encodeUtf8 (Text.toUpper txt <> paddingChars)) of
     Left (_, _rem) -> error ("not base32: " <> Text.unpack txt)
     Right h -> h

--- a/codebase2/util/package.yaml
+++ b/codebase2/util/package.yaml
@@ -19,6 +19,7 @@ dependencies:
   - bytestring
   - containers
   - cryptonite
+  - extra
   - lens
   - memory
   - safe

--- a/codebase2/util/src/U/Util/Base32Hex.hs
+++ b/codebase2/util/src/U/Util/Base32Hex.hs
@@ -1,10 +1,11 @@
 {-# LANGUAGE ViewPatterns #-}
 
 module U.Util.Base32Hex
-  ( Base32Hex (..),
+  ( Base32Hex (UnsafeFromText),
     fromByteString,
     toByteString,
     fromText,
+    toText,
     validChars,
   )
 where
@@ -17,8 +18,11 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 
-newtype Base32Hex = UnsafeFromText {toText :: Text}
+newtype Base32Hex = UnsafeFromText Text
   deriving (Eq, Ord, Show)
+
+toText :: Base32Hex -> Text
+toText (UnsafeFromText s) = s
 
 -- | Return the lowercase unpadded base32Hex encoding of this 'ByteString'.
 -- Multibase prefix would be 'v', see https://github.com/multiformats/multibase
@@ -28,7 +32,7 @@ fromByteString =
 
 -- | Produce a 'Hash' from a base32hex-encoded version of its binary representation
 toByteString :: Base32Hex -> ByteString
-toByteString (toText -> s) =
+toByteString (UnsafeFromText s) =
   case Base32.Hex.decodeBase32Unpadded (Text.encodeUtf8 s) of
     Left _ -> error ("not base32: " <> Text.unpack s)
     Right h -> h

--- a/codebase2/util/src/U/Util/Base32Hex.hs
+++ b/codebase2/util/src/U/Util/Base32Hex.hs
@@ -1,28 +1,43 @@
+{-# LANGUAGE ViewPatterns #-}
+
 module U.Util.Base32Hex
   ( Base32Hex (..),
     fromByteString,
     toByteString,
+    fromText,
+    validChars,
   )
 where
 
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Base32.Hex as Base32.Hex
+import Data.Set (Set)
+import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 
-newtype Base32Hex = UnsafeBase32Hex {toText :: Text}
+newtype Base32Hex = UnsafeFromText {toText :: Text}
   deriving (Eq, Ord, Show)
 
 -- | Return the lowercase unpadded base32Hex encoding of this 'ByteString'.
 -- Multibase prefix would be 'v', see https://github.com/multiformats/multibase
 fromByteString :: ByteString -> Base32Hex
 fromByteString =
-  UnsafeBase32Hex . Text.toLower . Base32.Hex.encodeBase32Unpadded
+  UnsafeFromText . Text.toLower . Base32.Hex.encodeBase32Unpadded
 
 -- | Produce a 'Hash' from a base32hex-encoded version of its binary representation
 toByteString :: Base32Hex -> ByteString
-toByteString (UnsafeBase32Hex s) =
+toByteString (toText -> s) =
   case Base32.Hex.decodeBase32Unpadded (Text.encodeUtf8 s) of
     Left _ -> error ("not base32: " <> Text.unpack s)
     Right h -> h
+
+fromText :: Text -> Maybe Base32Hex
+fromText s =
+  if Base32.Hex.isBase32Hex . Text.encodeUtf8 . Text.toUpper $ s
+    then Just (UnsafeFromText s)
+    else Nothing
+
+validChars :: Set Char
+validChars = Set.fromList $ ['0' .. '9'] ++ ['a' .. 'v']

--- a/codebase2/util/src/U/Util/Hash.hs
+++ b/codebase2/util/src/U/Util/Hash.hs
@@ -1,33 +1,40 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module U.Util.Hash where
-
--- (Hash, toBytes, base32Hex, base32Hexs, fromBase32Hex, fromBytes, unsafeFromBase32Hex, showBase32Hex, validBase32HexChars) where
-
--- import Unison.Prelude
+module U.Util.Hash
+  ( Hash (Hash, toShort),
+    fromBase32Hex,
+    fromByteString,
+    toBase32Hex,
+    toByteString,
+  )
+where
 
 import Data.ByteString (ByteString)
+import Data.ByteString.Short (ShortByteString, fromShort)
 import qualified Data.ByteString.Short as B.Short
+import Data.Text (Text)
 import GHC.Generics (Generic)
-import Data.ByteString.Short (fromShort, ShortByteString)
-import qualified U.Util.Base32Hex as Base32Hex
 import U.Util.Base32Hex (Base32Hex)
+import qualified U.Util.Base32Hex as Base32Hex
 
 -- | Hash which uniquely identifies a Unison type or term
 newtype Hash = Hash {toShort :: ShortByteString} deriving (Eq, Ord, Generic)
 
 toBase32Hex :: Hash -> Base32Hex
-toBase32Hex = Base32Hex.fromByteString . toBytes
+toBase32Hex = Base32Hex.fromByteString . toByteString
+
+toBase32HexText :: Hash -> Text
+toBase32HexText = Base32Hex.toText . toBase32Hex
 
 fromBase32Hex :: Base32Hex -> Hash
 fromBase32Hex = Hash . B.Short.toShort . Base32Hex.toByteString
 
-toBytes :: Hash -> ByteString
-toBytes = fromShort . toShort
+toByteString :: Hash -> ByteString
+toByteString = fromShort . toShort
 
-fromBytes :: ByteString -> Hash
-fromBytes = Hash . B.Short.toShort
+fromByteString :: ByteString -> Hash
+fromByteString = Hash . B.Short.toShort
 
 instance Show Hash where
-  show h = "fromBase32Hex " ++ (show . Base32Hex.toText . toBase32Hex) h
+  show h = (show . toBase32HexText) h

--- a/codebase2/util/unison-util.cabal
+++ b/codebase2/util/unison-util.cabal
@@ -54,6 +54,7 @@ library
     , bytestring
     , containers
     , cryptonite
+    , extra
     , lens
     , memory
     , safe
@@ -93,6 +94,7 @@ benchmark bench
     , containers
     , criterion
     , cryptonite
+    , extra
     , lens
     , memory
     , safe

--- a/parser-typechecker/src/Unison/Parser.hs
+++ b/parser-typechecker/src/Unison/Parser.hs
@@ -28,7 +28,6 @@ import           Data.Bytes.VarInt              ( VarInt(..) )
 import           Data.Bifunctor       (bimap)
 import qualified Data.Char            as Char
 import           Data.List.NonEmpty   (NonEmpty (..))
--- import           Data.Maybe
 import qualified Data.Set             as Set
 import qualified Data.Text            as Text
 import           Data.Typeable        (Proxy (..))
@@ -45,6 +44,7 @@ import           Unison.Term          (MatchCase (..))
 import           Unison.Var           (Var)
 import qualified Unison.Var           as Var
 import qualified Unison.UnisonFile.Error as UF
+import qualified U.Util.Base32Hex as Base32Hex
 import Unison.Util.Bytes              (Bytes)
 import Unison.Name as Name
 import Unison.NamesWithHistory (NamesWithHistory)
@@ -99,7 +99,7 @@ uniqueName :: Var v => Int -> P v Text
 uniqueName lenInBase32Hex = do
   UniqueName mkName <- asks uniqueNames
   pos <- L.start <$> P.lookAhead anyToken
-  let none = Hash.base32Hex . Hash.fromBytes . encodeUtf8 . Text.pack $ show pos
+  let none = Base32Hex.toText . Base32Hex.fromByteString . encodeUtf8 . Text.pack $ show pos
   pure . fromMaybe none $ mkName pos lenInBase32Hex
 
 data Error v

--- a/parser-typechecker/src/Unison/Runtime/Serialize.hs
+++ b/parser-typechecker/src/Unison/Runtime/Serialize.hs
@@ -8,7 +8,6 @@ import Data.Foldable (traverse_)
 
 import qualified Data.Vector.Primitive as BA
 import qualified Data.ByteString as B
-import qualified Data.ByteString.Short as SBS
 import Data.Bits (Bits)
 import Data.Bytes.Put
 import Data.Bytes.Get hiding (getBytes)
@@ -28,7 +27,7 @@ import Unison.Referent (Referent, pattern Ref, pattern Con)
 import qualified Unison.Util.Bytes as Bytes
 import Unison.Util.EnumContainers as EC
 import Unison.Hash (Hash)
-import qualified Unison.Hash as Hash
+import qualified U.Util.Hash as Hash
 import qualified Unison.ConstructorType as CT
 import Unison.Runtime.Exception
 import Unison.Runtime.MCode
@@ -148,7 +147,7 @@ putBlock b = putLength (BA.length b) *> putByteString (Bytes.chunkToByteString b
 
 putHash :: MonadPut m => Hash -> m ()
 putHash h = do
-  let bs = SBS.fromShort $ Hash.toBytes h
+  let bs = Hash.toByteString h
   putLength (B.length bs)
   putByteString bs
 
@@ -156,7 +155,7 @@ getHash :: MonadGet m => m Hash
 getHash = do
   len <- getLength
   bs <- B.copy <$> Ser.getBytes len
-  pure $ Hash.fromBytes bs
+  pure $ Hash.fromByteString bs
 
 putReferent :: MonadPut m => Referent -> m ()
 putReferent = \case

--- a/parser-typechecker/tests/Unison/Test/DataDeclaration.hs
+++ b/parser-typechecker/tests/Unison/Test/DataDeclaration.hs
@@ -4,11 +4,12 @@ module Unison.Test.DataDeclaration where
 
 import Data.Map (Map, (!))
 import qualified Data.Map as Map
+import Data.Text.Encoding (encodeUtf8)
 import EasyTest
 import Text.RawString.QQ
+import qualified U.Util.Hash as Hash
 import Unison.DataDeclaration (DataDeclaration (..), Decl)
 import qualified Unison.DataDeclaration as DD
-import qualified Unison.Hash as Hash
 import qualified Unison.Hashing.V2.Convert as Hashing
 import Unison.Parser.Ann (Ann)
 import Unison.Parsers (unsafeParseFile)
@@ -87,7 +88,7 @@ unhashComponentTest = tests
         app = Type.app ()
         forall = Type.forall ()
         (-->) = Type.arrow ()
-        h = Hash.unsafeFromBase32Hex "abcd"
+        h = Hash.fromByteString (encodeUtf8 "abcd")
         ref = R.Derived h 0 1
         a = Var.refNamed ref
         b = Var.named "b"

--- a/parser-typechecker/tests/Unison/Test/Term.hs
+++ b/parser-typechecker/tests/Unison/Test/Term.hs
@@ -5,7 +5,8 @@ module Unison.Test.Term where
 import EasyTest
 import qualified Data.Map         as Map
 import           Data.Map         ( (!) )
-import qualified Unison.Hash      as Hash
+import Data.Text.Encoding (encodeUtf8)
+import qualified U.Util.Hash      as Hash
 import qualified Unison.Reference as R
 import           Unison.Symbol    ( Symbol )
 import qualified Unison.Term      as Term
@@ -40,7 +41,7 @@ test = scope "term" $ tests
       expect $ tm' == expected
       ok
   , scope "Term.unhashComponent" $
-      let h = Hash.unsafeFromBase32Hex "abcd"
+      let h = Hash.fromByteString (encodeUtf8 "abcd")
           ref = R.Derived h 0 1
           v1 = Var.refNamed @Symbol ref
           -- input component: `ref = \v1 -> ref`

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -930,7 +930,7 @@ notifyUser dir o = case o of
       CouldntLoadRootBranch repo hash ->
         P.wrap $
           "I couldn't load the designated root hash"
-            <> P.group ("(" <> fromString (Hash.showBase32Hex hash) <> ")")
+            <> P.group ("(" <> P.text (Hash.base32Hex $ Causal.unRawHash hash) <> ")")
             <> "from the repository at"
             <> prettyReadRepo repo
       CouldntLoadSyncedBranch ns h ->

--- a/unison-core/package.yaml
+++ b/unison-core/package.yaml
@@ -20,10 +20,10 @@ library:
     - mtl
     - rfc5051
     - safe
-    - sandi
     - text
     - transformers
     - unison-prelude
+    - unison-util
     - unison-util-relation
     - util
     - vector

--- a/unison-core/src/Unison/Hash.hs
+++ b/unison-core/src/Unison/Hash.hs
@@ -2,123 +2,27 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Unison.Hash
-  ( Hash(Hash)
-  , toBytes
-  , base32Hex
-  , base32Hexs
-  , fromBase32Hex
-  , fromBytes
-  , fromByteString
-  , toByteString
-  , unsafeFromBase32Hex
-  , showBase32Hex
-  , validBase32HexChars
-  ) where
+  ( Hash (Hash),
+    base32Hex,
+    fromBase32Hex,
+    Hash.toByteString,
+    validBase32HexChars,
+  )
+where
 
+import qualified U.Util.Base32Hex as Base32Hex
+import U.Util.Hash (Hash (Hash))
+import qualified U.Util.Hash as Hash
 import Unison.Prelude
-
-import Data.ByteString.Builder (doubleBE, word64BE, int64BE, toLazyByteString)
-import qualified Data.ByteArray as BA
-
-import qualified Crypto.Hash as CH
-import qualified Data.ByteString as B
-import qualified Data.ByteString.Lazy as BL
-import qualified Data.ByteString.Short as SBS
-
-import qualified Unison.Hashable as H
-import qualified Codec.Binary.Base32Hex as Base32Hex
-import qualified Data.Text as Text
-import qualified Data.Set as Set
-
--- | Hash which uniquely identifies a Unison type or term
-newtype Hash = Hash { toBytes :: SBS.ShortByteString } deriving (Eq,Ord,Generic)
-
-instance Show Hash where
-  show h = take 999 $ Text.unpack (base32Hex h)
-
-instance H.Hashable Hash where
-  tokens h = [H.Bytes (toByteString h)]
-
-fromByteString :: ByteString -> Hash
-fromByteString = fromBytes
-
-toByteString :: Hash -> ByteString
-toByteString = SBS.fromShort . toBytes
-
-instance H.Accumulate Hash where
-  accumulate = fromBytes . BA.convert . CH.hashFinalize . go CH.hashInit where
-    go :: CH.Context CH.SHA3_512 -> [H.Token Hash] -> CH.Context CH.SHA3_512
-    go acc tokens = CH.hashUpdates acc (tokens >>= toBS)
-    toBS (H.Tag b) = [B.singleton b]
-    toBS (H.Bytes bs) = [encodeLength $ B.length bs, bs]
-    toBS (H.Int i) = BL.toChunks . toLazyByteString . int64BE $ i
-    toBS (H.Nat i) = BL.toChunks . toLazyByteString . word64BE $ i
-    toBS (H.Double d) = BL.toChunks . toLazyByteString . doubleBE $ d
-    toBS (H.Text txt) =
-      let tbytes = encodeUtf8 txt
-      in [encodeLength (B.length tbytes), tbytes]
-    toBS (H.Hashed h) = [toByteString h]
-    encodeLength :: Integral n => n -> B.ByteString
-    encodeLength = BL.toStrict . toLazyByteString . word64BE . fromIntegral
-  fromBytes = fromByteString
-  toBytes = toByteString
 
 -- | Return the lowercase unpadded base32Hex encoding of this 'Hash'.
 -- Multibase prefix would be 'v', see https://github.com/multiformats/multibase
 base32Hex :: Hash -> Text
-base32Hex (Hash h)
-  -- we're using an uppercase encoder that adds padding, so we drop the
-  -- padding and convert it to lowercase
-  = Text.toLower
-  . Text.dropWhileEnd (== '=')
-  . decodeUtf8
-  . Base32Hex.encode
-  $ SBS.fromShort h
-
-validBase32HexChars :: Set Char
-validBase32HexChars = Set.fromList $ ['0' .. '9'] ++ ['a' .. 'v']
+base32Hex = Base32Hex.toText . Hash.toBase32Hex
 
 -- | Produce a 'Hash' from a base32hex-encoded version of its binary representation
 fromBase32Hex :: Text -> Maybe Hash
-fromBase32Hex txt = case Base32Hex.decode (encodeUtf8 $ Text.toUpper txt <> paddingChars) of
-  Left (_, _rem) -> Nothing
-  Right h -> pure $ Hash (SBS.toShort h)
-  where
-  -- The decoder we're using is a base32 uppercase decoder that expects padding,
-  -- so we provide it with the appropriate number of padding characters for the
-  -- expected hash length.
-  --
-  -- The decoder requires 40 bit (8 5-bit characters) chunks, so if the number
-  -- of characters of the input is not a multiple of 8, we add '=' padding chars
-  -- until it is.
-  --
-  -- See https://tools.ietf.org/html/rfc4648#page-8
-  paddingChars :: Text
-  paddingChars = case Text.length txt `mod` 8 of
-    0 -> ""
-    n -> Text.replicate (8 - n) "="
+fromBase32Hex = fmap Hash.fromBase32Hex . Base32Hex.fromText
 
-  hashLength :: Int
-  hashLength = 512
-
-  _paddingChars :: Text
-  _paddingChars = case hashLength `mod` 40 of
-    0  -> ""
-    8  -> "======"
-    16 -> "===="
-    24 -> "==="
-    32 -> "="
-    i  -> error $ "impossible hash length `mod` 40 not in {0,8,16,24,32}: " <> show i
-
-base32Hexs :: Hash -> String
-base32Hexs = Text.unpack . base32Hex
-
-unsafeFromBase32Hex :: Text -> Hash
-unsafeFromBase32Hex txt =
-  fromMaybe (error $ "invalid base32Hex value: " ++ Text.unpack txt) $ fromBase32Hex txt
-
-fromBytes :: ByteString -> Hash
-fromBytes = Hash . SBS.toShort
-
-showBase32Hex :: H.Hashable t => t -> String
-showBase32Hex = base32Hexs . H.accumulate'
+validBase32HexChars :: Set Char
+validBase32HexChars = Base32Hex.validChars

--- a/unison-core/src/Unison/Hashable.hs
+++ b/unison-core/src/Unison/Hashable.hs
@@ -2,14 +2,22 @@ module Unison.Hashable where
 
 import Unison.Prelude
 
+import qualified Crypto.Hash as CH
+import qualified Data.ByteArray as BA
+import qualified Data.ByteString as B
+import Data.ByteString.Builder (doubleBE, int64BE, toLazyByteString, word64BE)
+import qualified Data.ByteString.Lazy as BL
 import qualified Data.Map as Map
 import qualified Data.Set as Set
+import qualified U.Util.Hash as H
 import Unison.Util.Relation (Relation)
-import Unison.Util.Relation3 (Relation3)
-import Unison.Util.Relation4 (Relation4)
 import qualified Unison.Util.Relation as Relation
+import Unison.Util.Relation3 (Relation3)
 import qualified Unison.Util.Relation3 as Relation3
+import Unison.Util.Relation4 (Relation4)
 import qualified Unison.Util.Relation4 as Relation4
+import U.Util.Hash (Hash)
+import qualified U.Util.Hash as Hash
 
 data Token h
   = Tag !Word8
@@ -107,3 +115,24 @@ instance Hashable Int64 where
 
 instance Hashable Bool where
   tokens b = [Tag . fromIntegral $ fromEnum b]
+
+instance Hashable Hash where
+  tokens h = [Bytes (Hash.toByteString h)]
+
+instance Accumulate Hash where
+  accumulate = fromBytes . BA.convert . CH.hashFinalize . go CH.hashInit where
+    go :: CH.Context CH.SHA3_512 -> [Token Hash] -> CH.Context CH.SHA3_512
+    go acc tokens = CH.hashUpdates acc (tokens >>= toBS)
+    toBS (Tag b) = [B.singleton b]
+    toBS (Bytes bs) = [encodeLength $ B.length bs, bs]
+    toBS (Int i) = BL.toChunks . toLazyByteString . int64BE $ i
+    toBS (Nat i) = BL.toChunks . toLazyByteString . word64BE $ i
+    toBS (Double d) = BL.toChunks . toLazyByteString . doubleBE $ d
+    toBS (Text txt) =
+      let tbytes = encodeUtf8 txt
+      in [encodeLength (B.length tbytes), tbytes]
+    toBS (Hashed h) = [H.toByteString h]
+    encodeLength :: Integral n => n -> B.ByteString
+    encodeLength = BL.toStrict . toLazyByteString . word64BE . fromIntegral
+  fromBytes = H.fromByteString
+  toBytes = H.toByteString

--- a/unison-core/unison-core1.cabal
+++ b/unison-core/unison-core1.cabal
@@ -99,10 +99,10 @@ library
     , prelude-extras
     , rfc5051
     , safe
-    , sandi
     , text
     , transformers
     , unison-prelude
+    , unison-util
     , unison-util-relation
     , util
     , vector


### PR DESCRIPTION
This PR consolidates the two types above, as a pre-req to moving more of the hashing implementation into `Unison.Hashing.V2`, and one step towards splitting `Unison.Hashing.V2` off as a real package as opposed to the pseudo-package it is now.

Ideally this would be a smaller diff, but I made a couple of renames as well.

All of the definitions in `Unison.Hash` now forward to `U.Util.Hash` and/or `U.Util.Base32Hex`, and `sandi` is dropped as a dependency altogether.

## Interesting/controversial decisions

I changed the show instance of `U.Util.Hash`; not sure if this was wise (potentially hiding places where we are using `show` but shouldn't be), and it can be reverted, but I figured this might include a lot of debug spots where we'd be grateful to see less output.

## Loose ends

I stopped short of eliminating `Unison.Hash` altogether, because that would've produced a massive diff, and doesn't need to block the hashing cleanup.