### PR TITLE
Make lookupWatchCache take a Reference.Id rather than a Reference

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,8 +60,8 @@ jobs:
           # recent branch cache.
           # Then it will save a new cache at this commit sha, which should be used by
           # the next build on this branch.
-          key: stack-work-2_${{matrix.os}}-${{github.sha}}
-          restore-keys: stack-work-2_${{matrix.os}}
+          key: stack-work-3_${{matrix.os}}-${{github.sha}}
+          restore-keys: stack-work-3_${{matrix.os}}
 
       # Install stack by downloading the binary from GitHub. The installation process is different for Linux and macOS,
       # so this is split into two steps, only one of which will run on any particular build.

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -143,11 +143,10 @@ getTypeOfConstructor codebase (Reference.DerivedId r) cid = do
 getTypeOfConstructor _ r cid =
   error $ "Don't know how to getTypeOfConstructor " ++ show r ++ " " ++ show cid
 
-lookupWatchCache :: (Monad m) => Codebase m v a -> Reference -> m (Maybe (Term v a))
-lookupWatchCache codebase (Reference.DerivedId h) = do
+lookupWatchCache :: (Monad m) => Codebase m v a -> Reference.Id -> m (Maybe (Term v a))
+lookupWatchCache codebase h = do
   m1 <- getWatch codebase WK.RegularWatch h
   maybe (getWatch codebase WK.TestWatch h) (pure . Just) m1
-lookupWatchCache _ Reference.Builtin{} = pure Nothing
 
 typeLookupForDependencies
   :: (Monad m, Var v, BuiltinAnnotation a)

--- a/parser-typechecker/src/Unison/Codebase/Runtime.hs
+++ b/parser-typechecker/src/Unison/Codebase/Runtime.hs
@@ -47,14 +47,14 @@ data Runtime v = Runtime
 
 type IsCacheHit = Bool
 
-noCache :: Reference -> IO (Maybe (Term v))
+noCache :: Reference.Id -> IO (Maybe (Term v))
 noCache _ = pure Nothing
 
 type WatchResults v a = (Either Error
          -- Bindings:
        ( [(v, Term v)]
          -- Map watchName (loc, hash, expression, value, isHit)
-       , Map v (a, WatchKind, Reference, Term v, Term v, IsCacheHit)
+       , Map v (a, WatchKind, Reference.Id, Term v, Term v, IsCacheHit)
        ))
 
 -- Evaluates the watch expressions in the file, returning a `Map` of their
@@ -70,14 +70,14 @@ evaluateWatches
    . Var v
   => CL.CodeLookup v IO a
   -> PPE.PrettyPrintEnv
-  -> (Reference -> IO (Maybe (Term v)))
+  -> (Reference.Id -> IO (Maybe (Term v)))
   -> Runtime v
   -> TypecheckedUnisonFile v a
   -> IO (WatchResults v a)
 evaluateWatches code ppe evaluationCache rt tuf = do
   -- 1. compute hashes for everything in the file
-  let m :: Map v (Reference, Term.Term v a)
-      m = fmap (\(id, _wk, tm, _tp) -> (Reference.DerivedId id, tm)) (UF.hashTermsId tuf)
+  let m :: Map v (Reference.Id, Term.Term v a)
+      m = fmap (\(id, _wk, tm, _tp) -> (id, tm)) (UF.hashTermsId tuf)
       watches :: Set v = Map.keysSet watchKinds
       watchKinds :: Map v WatchKind
       watchKinds =
@@ -91,7 +91,7 @@ evaluateWatches code ppe evaluationCache rt tuf = do
       Nothing -> pure (v, (r, ABT.annotation t, unann t, False))
       Just t' -> pure (v, (r, ABT.annotation t, t', True))
   -- 3. create a big ol' let rec whose body is a big tuple of all watches
-  let rv :: Map Reference v
+  let rv :: Map Reference.Id v
       rv = Map.fromList [ (r, v) | (v, (r, _)) <- Map.toList m ]
       bindings :: [(v, Term v)]
       bindings     = [ (v, unref rv b) | (v, (_, _, b, _)) <- Map.toList m' ]
@@ -117,10 +117,10 @@ evaluateWatches code ppe evaluationCache rt tuf = do
       pure $ Right (bindings, watchMap)
     Left e -> pure (Left e)
  where
-    -- unref :: Map Reference v -> Term.Term v a -> Term.Term v a
+    -- unref :: Map Reference.Id v -> Term.Term v a -> Term.Term v a
   unref rv t = ABT.visitPure go t
    where
-    go t@(Term.Ref' r@(Reference.DerivedId _)) = case Map.lookup r rv of
+    go t@(Term.Ref' (Reference.DerivedId r)) = case Map.lookup r rv of
       Nothing -> Nothing
       Just v  -> Just (Term.var (ABT.annotation t) v)
     go _ = Nothing
@@ -128,14 +128,13 @@ evaluateWatches code ppe evaluationCache rt tuf = do
 evaluateTerm'
   :: (Var v, Monoid a)
   => CL.CodeLookup v IO a
-  -> (Reference -> IO (Maybe (Term v)))
+  -> (Reference.Id -> IO (Maybe (Term v)))
   -> PPE.PrettyPrintEnv
   -> Runtime v
   -> Term.Term v a
   -> IO (Either Error (Term v))
 evaluateTerm' codeLookup cache ppe rt tm = do
-  let ref = Reference.DerivedId (Hashing.hashClosedTerm tm)
-  result <- cache ref
+  result <- cache (Hashing.hashClosedTerm tm)
   case result of
     Just r -> pure (Right r)
     Nothing -> do

--- a/unison-cli/src/Unison/Codebase/Editor/Command.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Command.hs
@@ -265,7 +265,7 @@ type UseCache = Bool
 
 type EvalResult v =
   ( [(v, Term v ())]
-  , Map v (Ann, WK.WatchKind, Reference, Term v (), Term v (), Runtime.IsCacheHit)
+  , Map v (Ann, WK.WatchKind, Reference.Id, Term v (), Term v (), Runtime.IsCacheHit)
   )
 
 lookupEvalResult :: Ord v => v -> EvalResult v -> Maybe (Term v ())

--- a/unison-cli/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -199,11 +199,10 @@ commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSour
     ClearWatchCache -> lift $ Codebase.clearWatches codebase
     FuzzySelect opts display choices -> liftIO $ Fuzzy.fuzzySelect opts display choices
 
-  watchCache (Reference.DerivedId h) = do
-    m1 <- Codebase.getWatch codebase WK.RegularWatch h
-    m2 <- maybe (Codebase.getWatch codebase WK.TestWatch h) (pure . Just) m1
-    pure $ Term.amap (const ()) <$> m2
-  watchCache Reference.Builtin{} = pure Nothing
+  watchCache :: Reference.Id -> IO (Maybe (Term v ()))
+  watchCache h = do
+    maybeTerm <- Codebase.lookupWatchCache codebase h
+    pure (Term.amap (const ()) <$> maybeTerm)
 
   eval1 :: PPE.PrettyPrintEnv -> UseCache -> Term v Ann -> _
   eval1 ppe useCache tm = do
@@ -225,11 +224,9 @@ commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSour
       Right rs@(_,map) -> do
         forM_ (Map.elems map) $ \(_loc, kind, hash, _src, value, isHit) ->
           if isHit then pure ()
-          else case hash of
-            Reference.DerivedId h -> do
-              let value' = Term.amap (const Ann.External) value
-              Codebase.putWatch codebase kind h value'
-            Reference.Builtin{} -> pure ()
+          else do
+            let value' = Term.amap (const Ann.External) value
+            Codebase.putWatch codebase kind hash value'
         pure $ Right rs
 
 -- doTodo :: Monad m => Codebase m v a -> Branch0 -> m (TodoOutput v a)


### PR DESCRIPTION
## Overview

This PR amends the type of `lookupWatchCache` from

```haskell
lookupWatchCache :: (Monad m) => Codebase m v a -> Reference -> m (Maybe (Term v a))
```

to

```haskell
lookupWatchCache :: (Monad m) => Codebase m v a -> Reference.Id -> m (Maybe (Term v a))
```

because attempting to look up a builtin in the watch expression cache will always result in `Nothing`.