### PR TITLE
Ensure connections are properly closed.

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -13,7 +13,6 @@ where
 
 import qualified Control.Concurrent
 import qualified Control.Exception
-import Control.Exception.Safe (MonadCatch)
 import Control.Monad (filterM, unless, when, (>=>))
 import Control.Monad.Except (ExceptT (ExceptT), MonadError (throwError), runExceptT, withExceptT)
 import qualified Control.Monad.Except as Except
@@ -122,11 +121,11 @@ codebasePath = ".unison" </> "v2" </> "unison.sqlite3"
 v2dir :: FilePath -> FilePath
 v2dir root = root </> ".unison" </> "v2"
 
-init :: HasCallStack => (MonadUnliftIO m, MonadCatch m) => Codebase.Init m Symbol Ann
+init :: HasCallStack => (MonadUnliftIO m) => Codebase.Init m Symbol Ann
 init = Codebase.Init getCodebaseOrError createCodebaseOrError v2dir
 
 createCodebaseOrError ::
-  (MonadUnliftIO m, MonadCatch m) =>
+  (MonadUnliftIO m) =>
   Codebase.DebugName ->
   CodebasePath ->
   m (Either Codebase1.CreateCodebaseError (m (), Codebase m Symbol Ann))
@@ -146,7 +145,7 @@ data CreateCodebaseError
   deriving (Show)
 
 createCodebaseOrError' ::
-  (MonadCatch m, MonadUnliftIO m) =>
+  (MonadUnliftIO m) =>
   Codebase.DebugName ->
   CodebasePath ->
   m (Either CreateCodebaseError (m (), Codebase m Symbol Ann))
@@ -179,7 +178,7 @@ openOrCreateCodebaseConnection debugName path = do
   unsafeGetConnection debugName path
 
 -- get the codebase in dir
-getCodebaseOrError :: forall m. (MonadUnliftIO m, MonadCatch m) => Codebase.DebugName -> CodebasePath -> m (Either Codebase1.Pretty (m (), Codebase m Symbol Ann))
+getCodebaseOrError :: forall m. (MonadUnliftIO m) => Codebase.DebugName -> CodebasePath -> m (Either Codebase1.Pretty (m (), Codebase m Symbol Ann))
 getCodebaseOrError debugName dir = do
   prettyDir <- liftIO $ P.string <$> canonicalizePath dir
   let prettyError v = P.wrap $ "I don't know how to handle " <> P.shown v <> "in" <> P.backticked' prettyDir "."
@@ -296,7 +295,7 @@ withConnection name root act = do
     (\(_, conn) -> act conn)
 
 sqliteCodebase ::
-  (MonadCatch m, MonadUnliftIO m) =>
+  (MonadUnliftIO m) =>
   Codebase.DebugName ->
   CodebasePath ->
   m (Either SchemaVersion (m (), Codebase m Symbol Ann))
@@ -1045,7 +1044,7 @@ syncProgress = Sync.Progress need done warn allDone
 
 viewRemoteBranch' ::
   forall m.
-  (MonadCatch m, MonadUnliftIO m) =>
+  (MonadUnliftIO m) =>
   ReadRemoteNamespace ->
   m (Either C.GitError (m (), Branch m, CodebasePath))
 viewRemoteBranch' (repo, sbh, path) = runExceptT @C.GitError do
@@ -1089,7 +1088,7 @@ viewRemoteBranch' (repo, sbh, path) = runExceptT @C.GitError do
 -- Given a branch that is "after" the existing root of a given git repo,
 -- stage and push the branch (as the new root) + dependencies to the repo.
 pushGitRootBranch ::
-  (MonadIO m, MonadCatch m, MonadUnliftIO m) =>
+  (MonadUnliftIO m) =>
   Connection ->
   Branch m ->
   WriteRepo ->

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -178,7 +178,12 @@ openOrCreateCodebaseConnection debugName path = do
   unsafeGetConnection debugName path
 
 -- get the codebase in dir
-getCodebaseOrError :: forall m. (MonadUnliftIO m) => Codebase.DebugName -> CodebasePath -> m (Either Codebase1.Pretty (m (), Codebase m Symbol Ann))
+getCodebaseOrError ::
+  forall m.
+  (MonadUnliftIO m) =>
+  Codebase.DebugName ->
+  CodebasePath ->
+  m (Either Codebase1.Pretty (m (), Codebase m Symbol Ann))
 getCodebaseOrError debugName dir = do
   prettyDir <- liftIO $ P.string <$> canonicalizePath dir
   let prettyError v = P.wrap $ "I don't know how to handle " <> P.shown v <> "in" <> P.backticked' prettyDir "."

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -656,7 +656,6 @@ sqliteCodebase debugName root = do
               flip State.evalStateT emptySyncProgressState $ do
                 initSchemaIfNotExist destRoot
                 syncInternal syncProgress conn destConn $ Branch.transform lift b
-                liftIO closeConn
 
           watches :: MonadIO m => UF.WatchKind -> m [Reference.Id]
           watches w =

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -107,7 +107,6 @@ import UnliftIO (MonadIO, catchIO, finally, liftIO, MonadUnliftIO)
 import UnliftIO.Directory (canonicalizePath, createDirectoryIfMissing, doesDirectoryExist, doesFileExist)
 import UnliftIO.STM
 import UnliftIO.Exception (bracket)
-import Control.Concurrent.Extra (once)
 import Control.Monad.Trans.Except (mapExceptT)
 
 debug, debugProcessBranches, debugCommitFailedTransaction :: Bool
@@ -276,9 +275,7 @@ unsafeGetConnection name root = do
   Monad.when debug $ traceM $ "unsafeGetconnection " ++ name ++ " " ++ root ++ " -> " ++ path
   (Connection name path -> conn) <- liftIO $ Sqlite.open path
   runReaderT Q.setFlags conn
-  -- Closing the connection more than once is a no-op
-  cleanup <- liftIO $ once (shutdownConnection conn)
-  pure (liftIO cleanup, conn)
+  pure (shutdownConnection conn, conn)
   where
     shutdownConnection :: MonadIO m => Connection -> m ()
     shutdownConnection conn = do

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -648,7 +648,7 @@ sqliteCodebase debugName root = do
 
           syncToDirectory :: MonadUnliftIO m => Codebase1.CodebasePath -> SyncMode -> Branch m -> m ()
           syncToDirectory destRoot _syncMode b =
-            withConnection (debugName ++ ".sync.dest") destRoot $ \destConn->
+            withConnection (debugName ++ ".sync.dest") destRoot $ \destConn ->
               flip State.evalStateT emptySyncProgressState $ do
                 initSchemaIfNotExist destRoot
                 syncInternal syncProgress conn destConn $ Branch.transform lift b
@@ -1136,8 +1136,8 @@ pushGitRootBranch srcConn branch repo = runExceptT @C.GitError do
               Q.release "push"
 
       Q.setJournalMode JournalMode.DELETE
-    liftIO do
-      void $ push remotePath repo
+  liftIO do
+    void $ push remotePath repo
   where
     repoString = Text.unpack $ printWriteRepo repo
     setRepoRoot :: Q.DB m => Branch.Hash -> m ()
@@ -1215,5 +1215,3 @@ pushGitRootBranch srcConn branch repo = runExceptT @C.GitError do
             -- Push our changes to the repo
             gitIn remotePath ["push", "--quiet", url]
             pure True
-
-

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -106,9 +106,12 @@ import Unison.Type (Type)
 import qualified Unison.Type as Type
 import qualified Unison.Util.Pretty as P
 import qualified Unison.WatchKind as UF
-import UnliftIO (MonadIO, catchIO, finally, liftIO)
+import UnliftIO (MonadIO, catchIO, finally, liftIO, MonadUnliftIO)
 import UnliftIO.Directory (canonicalizePath, createDirectoryIfMissing, doesDirectoryExist, doesFileExist)
 import UnliftIO.STM
+import UnliftIO.Exception (bracket)
+import Control.Concurrent.Extra (once)
+import Control.Monad.Trans.Except (mapExceptT)
 
 debug, debugProcessBranches, debugCommitFailedTransaction :: Bool
 debug = False
@@ -121,11 +124,11 @@ codebasePath = ".unison" </> "v2" </> "unison.sqlite3"
 v2dir :: FilePath -> FilePath
 v2dir root = root </> ".unison" </> "v2"
 
-init :: HasCallStack => (MonadIO m, MonadCatch m) => Codebase.Init m Symbol Ann
+init :: HasCallStack => (MonadUnliftIO m, MonadCatch m) => Codebase.Init m Symbol Ann
 init = Codebase.Init getCodebaseOrError createCodebaseOrError v2dir
 
 createCodebaseOrError ::
-  (MonadIO m, MonadCatch m) =>
+  (MonadUnliftIO m, MonadCatch m) =>
   Codebase.DebugName ->
   CodebasePath ->
   m (Either Codebase1.CreateCodebaseError (m (), Codebase m Symbol Ann))
@@ -145,7 +148,7 @@ data CreateCodebaseError
   deriving (Show)
 
 createCodebaseOrError' ::
-  (MonadIO m, MonadCatch m) =>
+  (MonadCatch m, MonadUnliftIO m) =>
   Codebase.DebugName ->
   CodebasePath ->
   m (Either CreateCodebaseError (m (), Codebase m Symbol Ann))
@@ -156,19 +159,21 @@ createCodebaseOrError' debugName path = do
     do
       createDirectoryIfMissing True (path </> FilePath.takeDirectory codebasePath)
       liftIO $
-        Control.Exception.bracket
-          (unsafeGetConnection (debugName ++ ".createSchema") path)
-          shutdownConnection
-          (runReaderT do
-            Q.createSchema
-            runExceptT (void . Ops.saveRootBranch $ Cv.causalbranch1to2 Branch.empty) >>= \case
-              Left e -> error $ show e
-              Right () -> pure ()
-            )
+        withConnection (debugName ++ ".createSchema") path $
+          ( runReaderT do
+              Q.createSchema
+              runExceptT (void . Ops.saveRootBranch $ Cv.causalbranch1to2 Branch.empty) >>= \case
+                Left e -> error $ show e
+                Right () -> pure ()
+          )
 
       fmap (Either.mapLeft CreateCodebaseUnknownSchemaVersion) (sqliteCodebase debugName path)
 
-openOrCreateCodebaseConnection :: MonadIO m => Codebase.DebugName -> FilePath -> m Connection
+openOrCreateCodebaseConnection ::
+  MonadIO m =>
+  Codebase.DebugName ->
+  FilePath ->
+  m (IO (), Connection)
 openOrCreateCodebaseConnection debugName path = do
   unlessM
     (doesFileExist $ path </> codebasePath)
@@ -176,7 +181,7 @@ openOrCreateCodebaseConnection debugName path = do
   unsafeGetConnection debugName path
 
 -- get the codebase in dir
-getCodebaseOrError :: forall m. (MonadIO m, MonadCatch m) => Codebase.DebugName -> CodebasePath -> m (Either Codebase1.Pretty (m (), Codebase m Symbol Ann))
+getCodebaseOrError :: forall m. (MonadUnliftIO m, MonadCatch m) => Codebase.DebugName -> CodebasePath -> m (Either Codebase1.Pretty (m (), Codebase m Symbol Ann))
 getCodebaseOrError debugName dir = do
   prettyDir <- liftIO $ P.string <$> canonicalizePath dir
   let prettyError v = P.wrap $ "I don't know how to handle " <> P.shown v <> "in" <> P.backticked' prettyDir "."
@@ -191,10 +196,7 @@ initSchemaIfNotExist path = liftIO do
   unlessM (doesDirectoryExist $ path </> FilePath.takeDirectory codebasePath) $
     createDirectoryIfMissing True (path </> FilePath.takeDirectory codebasePath)
   unlessM (doesFileExist $ path </> codebasePath) $
-    Control.Exception.bracket
-      (unsafeGetConnection "initSchemaIfNotExist" path)
-      shutdownConnection
-      (runReaderT Q.createSchema)
+    withConnection "initSchemaIfNotExist" path $ runReaderT Q.createSchema
 
 -- checks if a db exists at `path` with the minimum schema
 codebaseExists :: MonadIO m => CodebasePath -> m Bool
@@ -256,23 +258,54 @@ type TermBufferEntry = BufferEntry (Term Symbol Ann, Type Symbol Ann)
 
 type DeclBufferEntry = BufferEntry (Decl Symbol Ann)
 
-unsafeGetConnection :: MonadIO m => Codebase.DebugName -> CodebasePath -> m Connection
+-- | Create a new sqlite connection to the database at the given path.
+-- the caller is responsible for calling the returned cleanup method once finished with the
+-- connection.
+-- The connection may not be used after it has been cleaned up.
+-- Prefer using `withConnection` if you can, as it guarantees the connection will be properly
+-- closed for you.
+unsafeGetConnection ::
+  MonadIO m =>
+  Codebase.DebugName ->
+  CodebasePath ->
+  m (IO (), Connection)
 unsafeGetConnection name root = do
   let path = root </> codebasePath
   Monad.when debug $ traceM $ "unsafeGetconnection " ++ name ++ " " ++ root ++ " -> " ++ path
   (Connection name path -> conn) <- liftIO $ Sqlite.open path
   runReaderT Q.setFlags conn
-  pure conn
+  -- Closing the connection more than once is a no-op
+  cleanup <- liftIO $ once (shutdownConnection conn)
+  pure (liftIO cleanup, conn)
+
+
+-- Run an action with a connection to the codebase, closing the connection on completion or
+-- failure.
+withConnection ::
+  MonadUnliftIO m =>
+  Codebase.DebugName ->
+  CodebasePath ->
+  (Connection -> m a) ->
+  m a
+withConnection name root act = do
+  bracket
+    (unsafeGetConnection name root)
+    (\(closeConn, _) -> liftIO closeConn)
+    (\(_, conn) -> act conn)
 
 shutdownConnection :: MonadIO m => Connection -> m ()
 shutdownConnection conn = do
   Monad.when debug $ traceM $ "shutdown connection " ++ show conn
   liftIO $ Sqlite.close (Connection.underlying conn)
 
-sqliteCodebase :: (MonadIO m, MonadCatch m) => Codebase.DebugName -> CodebasePath -> m (Either SchemaVersion (m (), Codebase m Symbol Ann))
+sqliteCodebase ::
+  (MonadIO m, MonadCatch m, MonadUnliftIO m) =>
+  Codebase.DebugName ->
+  CodebasePath ->
+  m (Either SchemaVersion (m (), Codebase m Symbol Ann))
 sqliteCodebase debugName root = do
   Monad.when debug $ traceM $ "sqliteCodebase " ++ debugName ++ " " ++ root
-  conn <- unsafeGetConnection debugName root
+  (closeConn, conn) <- unsafeGetConnection debugName root
   termCache <- Cache.semispaceCache 8192 -- pure Cache.nullCache -- to disable
   typeOfTermCache <- Cache.semispaceCache 8192
   declCache <- Cache.semispaceCache 1024
@@ -290,7 +323,7 @@ sqliteCodebase debugName root = do
           getTerm (Reference.Id h1@(Cv.hash1to2 -> h2) i _n) =
             runDB' conn do
               term2 <- Ops.loadTermByReference (C.Reference.Id h2 i)
-              Cv.term2to1 h1 (getCycleLen "getTerm") getDeclType term2
+              lift $ Cv.term2to1 h1 (getCycleLen "getTerm") getDeclType term2
 
           getCycleLen :: EDB m => String -> Hash -> m Reference.Size
           getCycleLen source = Cache.apply cycleLengthCache \h ->
@@ -613,15 +646,17 @@ sqliteCodebase debugName root = do
           syncFromDirectory :: MonadIO m => Codebase1.CodebasePath -> SyncMode -> Branch m -> m ()
           syncFromDirectory srcRoot _syncMode b =
             flip State.evalStateT emptySyncProgressState $ do
-              srcConn <- unsafeGetConnection (debugName ++ ".sync.src") srcRoot
+              (closeConn, srcConn) <- unsafeGetConnection (debugName ++ ".sync.src") srcRoot
               syncInternal syncProgress srcConn conn $ Branch.transform lift b
+              liftIO closeConn
 
           syncToDirectory :: MonadIO m => Codebase1.CodebasePath -> SyncMode -> Branch m -> m ()
           syncToDirectory destRoot _syncMode b =
             flip State.evalStateT emptySyncProgressState $ do
               initSchemaIfNotExist destRoot
-              destConn <- unsafeGetConnection (debugName ++ ".sync.dest") destRoot
+              (closeConn, destConn) <- unsafeGetConnection (debugName ++ ".sync.dest") destRoot
               syncInternal syncProgress conn destConn $ Branch.transform lift b
+              liftIO closeConn
 
           watches :: MonadIO m => UF.WatchKind -> m [Reference.Id]
           watches w =
@@ -736,18 +771,15 @@ sqliteCodebase debugName root = do
             pure $ Set.map (Causal.RawHash . Cv.hash2to1 . unCausalHash) cs
 
           sqlLca :: MonadIO m => Branch.Hash -> Branch.Hash -> m (Maybe Branch.Hash)
-          sqlLca h1 h2 = liftIO $ Control.Exception.bracket open close \(c1, c2) ->
-            runDB conn
-              . (fmap . fmap) Cv.causalHash2to1
-              $ Ops.lca (Cv.causalHash1to2 h1) (Cv.causalHash1to2 h2) c1 c2
-            where
-              open = (,) <$> unsafeGetConnection (debugName ++ ".lca.left") root
-                         <*> unsafeGetConnection (debugName ++ ".lca.left") root
-              close (c1, c2) = shutdownConnection c1 *> shutdownConnection c2
-
+          sqlLca h1 h2 =
+            liftIO $ withConnection  (debugName ++ ".lca.left") root $ \c1 -> do
+                     withConnection  (debugName ++ ".lca.right") root $ \c2 -> do
+                       runDB conn
+                         . (fmap . fmap) Cv.causalHash2to1
+                         $ Ops.lca (Cv.causalHash1to2 h1) (Cv.causalHash1to2 h2) c1 c2
       let finalizer :: MonadIO m => m ()
           finalizer = do
-            shutdownConnection conn
+            liftIO $ closeConn
             decls <- readTVarIO declBuffer
             terms <- readTVarIO termBuffer
             let printBuffer header b =
@@ -1017,7 +1049,7 @@ syncProgress = Sync.Progress need done warn allDone
 
 viewRemoteBranch' ::
   forall m.
-  (MonadIO m, MonadCatch m) =>
+  (MonadCatch m, MonadUnliftIO m) =>
   ReadRemoteNamespace ->
   m (Either C.GitError (m (), Branch m, CodebasePath))
 viewRemoteBranch' (repo, sbh, path) = runExceptT @C.GitError do
@@ -1061,7 +1093,7 @@ viewRemoteBranch' (repo, sbh, path) = runExceptT @C.GitError do
 -- Given a branch that is "after" the existing root of a given git repo,
 -- stage and push the branch (as the new root) + dependencies to the repo.
 pushGitRootBranch ::
-  (MonadIO m, MonadCatch m) =>
+  (MonadIO m, MonadCatch m, MonadUnliftIO m) =>
   Connection ->
   Branch m ->
   WriteRepo ->
@@ -1077,41 +1109,39 @@ pushGitRootBranch srcConn branch repo = runExceptT @C.GitError do
 
   -- set up the cache dir
   remotePath <- time "Git fetch" $ withExceptT C.GitProtocolError $ pullBranch (writeToRead repo)
-  destConn <- openOrCreateCodebaseConnection "push.dest" remotePath
+  (closeDestConn, destConn) <- openOrCreateCodebaseConnection "push.dest" remotePath
+  mapExceptT (`finally` liftIO closeDestConn) $ do
+    flip runReaderT destConn $ Q.savepoint "push"
+    lift . flip State.execStateT emptySyncProgressState $
+      syncInternal syncProgress srcConn destConn (Branch.transform lift branch)
+    flip runReaderT destConn do
+      let newRootHash = Branch.headHash branch
+      -- the call to runDB "handles" the possible DB error by bombing
+      (fmap . fmap) Cv.branchHash2to1 (runDB destConn Ops.loadMaybeRootCausalHash) >>= \case
+        Nothing -> do
+          setRepoRoot newRootHash
+          Q.release "push"
+        Just oldRootHash -> do
+          before oldRootHash newRootHash >>= \case
+            Nothing ->
+              error $
+                "I couldn't find the hash " ++ show newRootHash
+                  ++ " that I just synced to the cached copy of "
+                  ++ repoString
+                  ++ " in "
+                  ++ show remotePath
+                  ++ "."
+            Just False -> do
+              Q.rollbackRelease "push"
+              throwError . C.GitProtocolError $ GitError.PushDestinationHasNewStuff repo
 
-  flip runReaderT destConn $ Q.savepoint "push"
-  lift . flip State.execStateT emptySyncProgressState $
-    syncInternal syncProgress srcConn destConn (Branch.transform lift branch)
-  flip runReaderT destConn do
-    let newRootHash = Branch.headHash branch
-    -- the call to runDB "handles" the possible DB error by bombing
-    (fmap . fmap) Cv.branchHash2to1 (runDB destConn Ops.loadMaybeRootCausalHash) >>= \case
-      Nothing -> do
-        setRepoRoot newRootHash
-        Q.release "push"
-      Just oldRootHash -> do
-        before oldRootHash newRootHash >>= \case
-          Nothing ->
-            error $
-              "I couldn't find the hash " ++ show newRootHash
-                ++ " that I just synced to the cached copy of "
-                ++ repoString
-                ++ " in "
-                ++ show remotePath
-                ++ "."
-          Just False -> do
-            Q.rollbackRelease "push"
-            throwError . C.GitProtocolError $ GitError.PushDestinationHasNewStuff repo
+            Just True -> do
+              setRepoRoot newRootHash
+              Q.release "push"
 
-          Just True -> do
-            setRepoRoot newRootHash
-            Q.release "push"
-
-    Q.setJournalMode JournalMode.DELETE
-
-  liftIO do
-    shutdownConnection destConn
-    void $ push remotePath repo
+      Q.setJournalMode JournalMode.DELETE
+    liftIO do
+      void $ push remotePath repo
   where
     repoString = Text.unpack $ printWriteRepo repo
     setRepoRoot :: Q.DB m => Branch.Hash -> m ()
@@ -1189,3 +1219,5 @@ pushGitRootBranch srcConn branch repo = runExceptT @C.GitError do
             -- Push our changes to the repo
             gitIn remotePath ["push", "--quiet", url]
             pure True
+
+


### PR DESCRIPTION
## Overview

Previously, certain locations were forgetting to close connections to databases on exceptions/failures, some places forgot about closing connections entirely.

## Implementation notes

* return a 'closer' from `unsafeGetConnection` so that you can't fetch a connection without remembering that it must be closed.
* Add `withConnection` as an ergonomic helper for scoped use of a connection.

## Interesting/controversial decisions

This adds MonadUnliftIO as a constraint on the SqliteCodebase, I think it gets instantiated to IO anyways, so it's not a big deal, and hopefully will encourage more use of `bracket` in the future.

Certain places made it difficult to use bracket due to the usage of ExceptT or StateT.

There's still more to do here of course, but this seems like a nice bite-size step in the right direction.