### PR TITLE
Add gist command (fixes #2603)

### DIFF
--- a/lib/unison-prelude/src/Unison/Prelude.hs
+++ b/lib/unison-prelude/src/Unison/Prelude.hs
@@ -7,6 +7,12 @@ module Unison.Prelude
     uncurry4,
     reportBug,
     tShow,
+
+    -- * @Maybe@ control flow
+    onNothing,
+
+    -- * @Either@ control flow
+    whenLeft,
   )
 where
 
@@ -34,6 +40,7 @@ import Data.Sequence as X (Seq)
 import Data.Set as X (Set)
 import Data.String as X (IsString, fromString)
 import Data.Text as X (Text)
+import qualified Data.Text as Text
 import Data.Text.Encoding as X (decodeUtf8, encodeUtf8)
 import Data.Traversable as X (for)
 import Data.Word as X
@@ -42,7 +49,15 @@ import GHC.Generics as X (Generic, Generic1)
 import GHC.Stack as X (HasCallStack)
 import Safe as X (atMay, headMay, lastMay, readMay)
 import Text.Read as X (readMaybe)
-import qualified Data.Text as Text
+
+onNothing :: Applicative m => m a -> Maybe a -> m a
+onNothing x =
+  maybe x pure
+
+whenLeft :: Applicative m => Either a b -> (a -> m b) -> m b
+whenLeft = \case
+  Left a -> \f -> f a
+  Right b -> \_ -> pure b
 
 tShow :: Show a => a -> Text
 tShow = Text.pack . show

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -73,7 +73,8 @@ module Unison.Codebase
     -- ** Remote sync
     viewRemoteBranch,
     importRemoteBranch,
-    pushGitRootBranch,
+    pushGitBranch,
+    PushGitBranchOpts (..),
 
     -- * Codebase path
     getCodebaseDir,
@@ -105,7 +106,13 @@ import Unison.Codebase.Editor.Git (withStatus)
 import Unison.Codebase.Editor.RemoteRepo (ReadRemoteNamespace)
 import qualified Unison.Codebase.GitError as GitError
 import Unison.Codebase.SyncMode (SyncMode)
-import Unison.Codebase.Type (Codebase (..), GetRootBranchError (..), GitError (GitCodebaseError), SyncToDir)
+import Unison.Codebase.Type
+  ( Codebase (..),
+    GetRootBranchError (..),
+    GitError (GitCodebaseError),
+    PushGitBranchOpts (..),
+    SyncToDir,
+  )
 import Unison.CodebasePath (CodebasePath, getCodebaseDir)
 import Unison.DataDeclaration (Decl)
 import qualified Unison.DataDeclaration as DD
@@ -219,9 +226,11 @@ lookupWatchCache codebase h = do
   m1 <- getWatch codebase WK.RegularWatch h
   maybe (getWatch codebase WK.TestWatch h) (pure . Just) m1
 
-typeLookupForDependencies
-  :: (Monad m, Var v, BuiltinAnnotation a)
-  => Codebase m v a -> Set Reference -> m (TL.TypeLookup v a)
+typeLookupForDependencies ::
+  (Monad m, Var v, BuiltinAnnotation a) =>
+  Codebase m v a ->
+  Set Reference ->
+  m (TL.TypeLookup v a)
 typeLookupForDependencies codebase s = do
   when debug $ traceM $ "typeLookupForDependencies " ++ show s
   foldM go mempty s

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -1,14 +1,24 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns #-}
 
-module Unison.Codebase.Type (Codebase (..), CodebasePath, GitError(..), GetRootBranchError (..), SyncToDir) where
+module Unison.Codebase.Type
+  ( Codebase (..),
+    CodebasePath,
+    PushGitBranchOpts (..),
+    GitError (..),
+    GetRootBranchError (..),
+    SyncToDir,
+  )
+where
 
 import Unison.Codebase.Branch (Branch)
 import qualified Unison.Codebase.Branch as Branch
 import Unison.Codebase.Editor.RemoteRepo (ReadRemoteNamespace, WriteRepo)
+import Unison.Codebase.GitError (GitCodebaseError, GitProtocolError)
 import Unison.Codebase.Patch (Patch)
 import qualified Unison.Codebase.Reflog as Reflog
 import Unison.Codebase.ShortBranchHash (ShortBranchHash)
+import Unison.Codebase.SqliteCodebase.GitError (GitSqliteCodebaseError)
 import Unison.Codebase.SyncMode (SyncMode)
 import Unison.CodebasePath (CodebasePath)
 import Unison.DataDeclaration (Decl)
@@ -20,8 +30,6 @@ import Unison.ShortHash (ShortHash)
 import Unison.Term (Term)
 import Unison.Type (Type)
 import qualified Unison.WatchKind as WK
-import Unison.Codebase.GitError (GitProtocolError, GitCodebaseError)
-import Unison.Codebase.SqliteCodebase.GitError (GitSqliteCodebaseError)
 
 type SyncToDir m =
   CodebasePath -> -- dest codebase
@@ -82,8 +90,8 @@ data Codebase m v a = Codebase
     -- | Copy a branch and all of its dependencies from this codebase into the given codebase.
     syncToDirectory :: CodebasePath -> SyncMode -> Branch m -> m (),
     viewRemoteBranch' :: ReadRemoteNamespace -> m (Either GitError (m (), Branch m, CodebasePath)),
-    -- | Push the given branch to the given repo, and set it as the root branch.
-    pushGitRootBranch :: Branch m -> WriteRepo -> SyncMode -> m (Either GitError ()),
+    -- | Push the given branch to the given repo, and optionally set it as the root branch.
+    pushGitBranch :: Branch m -> WriteRepo -> PushGitBranchOpts -> m (Either GitError ()),
     -- | @watches k@ returns all of the references @r@ that were previously put by a @putWatch k r t@. @t@ can be
     -- retrieved by @getWatch k r@.
     watches :: WK.WatchKind -> m [Reference.Id],
@@ -140,14 +148,20 @@ data Codebase m v a = Codebase
     beforeImpl :: Maybe (Branch.Hash -> Branch.Hash -> m Bool)
   }
 
+data PushGitBranchOpts = PushGitBranchOpts
+  { -- | Set the branch as root?
+    setRoot :: Bool,
+    syncMode :: SyncMode
+  }
+
 data GetRootBranchError
   = NoRootBranch
   | CouldntParseRootBranch String
   | CouldntLoadRootBranch Branch.Hash
-  deriving Show
+  deriving (Show)
 
 data GitError
   = GitProtocolError GitProtocolError
   | GitCodebaseError (GitCodebaseError Branch.Hash)
   | GitSqliteCodebaseError GitSqliteCodebaseError
-  deriving Show
+  deriving (Show)

--- a/unison-cli/src/Unison/Codebase/Editor/Command.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Command.hs
@@ -52,6 +52,7 @@ import qualified Unison.Lexer                  as L
 import qualified Unison.Parser                 as Parser
 import           Unison.ShortHash               ( ShortHash )
 import           Unison.Type                    ( Type )
+import           Unison.Codebase (PushGitBranchOpts)
 import           Unison.Codebase.ShortBranchHash
                                                 ( ShortBranchHash )
 import Unison.Codebase.Editor.AuthorInfo (AuthorInfo)
@@ -209,8 +210,7 @@ data Command
   -- codebase are copied there.
   SyncLocalRootBranch :: Branch m -> Command m i v ()
 
-  SyncRemoteRootBranch ::
-    WriteRepo -> Branch m -> SyncMode -> Command m i v (Either GitError ())
+  SyncRemoteBranch :: Branch m -> WriteRepo -> PushGitBranchOpts -> Command m i v (Either GitError ())
 
   AppendToReflog :: Text -> Branch m -> Branch m -> Command m i v ()
 
@@ -301,7 +301,7 @@ commandName = \case
   ViewRemoteBranch {} -> "ViewRemoteBranch"
   ImportRemoteBranch {} -> "ImportRemoteBranch"
   SyncLocalRootBranch {} -> "SyncLocalRootBranch"
-  SyncRemoteRootBranch {} -> "SyncRemoteRootBranch"
+  SyncRemoteBranch {} -> "SyncRemoteBranch"
   AppendToReflog {} -> "AppendToReflog"
   LoadReflog -> "LoadReflog"
   LoadTerm {} -> "LoadTerm"

--- a/unison-cli/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -138,7 +138,8 @@ commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSour
       lift $ Codebase.viewRemoteBranch codebase ns
     ImportRemoteBranch ns syncMode ->
       lift $ Codebase.importRemoteBranch codebase ns syncMode
-    SyncRemoteBranch branch repo opts -> lift $ Codebase.pushGitBranch codebase branch repo opts
+    SyncRemoteBranch branch repo opts ->
+      lift $ Codebase.pushGitBranch codebase branch repo opts
     LoadTerm r -> lift $ Codebase.getTerm codebase r
     LoadType r -> lift $ Codebase.getTypeDeclaration codebase r
     LoadTypeOfTerm r -> lift $ Codebase.getTypeOfTerm codebase r

--- a/unison-cli/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -138,8 +138,7 @@ commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSour
       lift $ Codebase.viewRemoteBranch codebase ns
     ImportRemoteBranch ns syncMode ->
       lift $ Codebase.importRemoteBranch codebase ns syncMode
-    SyncRemoteRootBranch repo branch syncMode ->
-      lift $ Codebase.pushGitRootBranch codebase branch repo syncMode
+    SyncRemoteBranch branch repo opts -> lift $ Codebase.pushGitBranch codebase branch repo opts
     LoadTerm r -> lift $ Codebase.getTerm codebase r
     LoadType r -> lift $ Codebase.getTypeDeclaration codebase r
     LoadTypeOfTerm r -> lift $ Codebase.getTypeOfTerm codebase r

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1847,7 +1847,7 @@ handlePushRemoteBranch ::
   -- | The local path to push. If relative, it's resolved relative to the current path (`cd`).
   Path' ->
   SyncMode.SyncMode ->
-  -- | The remote target. If missing, the given branch contents should be pushed to the repo repo without updating the
+  -- | The remote target. If missing, the given branch contents should be pushed to the remote repo without updating the
   -- root namespace.
   Maybe (Path, PushBehavior) ->
   Action' m v ()

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -1,5 +1,6 @@
 module Unison.Codebase.Editor.Input
   ( Input(..)
+  , GistInput(..)
   , Event(..)
   , OutputLocation(..)
   , PatchPath
@@ -156,7 +157,14 @@ data Input
     | QuitI
     | UiI
     | DocsToHtmlI Path' FilePath
+    | GistI GistInput
     deriving (Eq, Show)
+
+-- | @"gist repo"@ pushes the contents of the current namespace to @repo@.
+data GistInput = GistInput
+  { repo :: WriteRepo
+  }
+  deriving stock (Eq, Show)
 
 -- Some commands, like `view`, can dump output to either console or a file.
 data OutputLocation

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -226,8 +226,10 @@ data Output v
   | CouldntLoadBranch Branch.Hash
   | NamespaceEmpty (Either Path.Absolute (Path.Absolute, Path.Absolute))
   | NoOp
-    -- Refused to push, either because a `push` targeted an empty namespace, or a `push.create` targeted a non-empty namespace.
-  | RefusedToPush PushBehavior
+  | -- Refused to push, either because a `push` targeted an empty namespace, or a `push.create` targeted a non-empty namespace.
+    RefusedToPush PushBehavior
+  | -- | @GistCreated repo hash@ means causal @hash@ was just published to @repo@.
+    GistCreated Int WriteRepo Branch.Hash
   deriving (Show)
 
 data ReflogEntry = ReflogEntry {hash :: ShortBranchHash, reason :: Text}
@@ -349,8 +351,9 @@ isFailure o = case o of
   ListNamespaceDependencies {} -> False
   TermMissingType {} -> True
   DumpUnisonFileHashes _ x y z -> x == mempty && y == mempty && z == mempty
-  NamespaceEmpty _ -> False
-  RefusedToPush{} -> True
+  NamespaceEmpty {} -> True
+  RefusedToPush {} -> True
+  GistCreated {} -> False
 
 isNumberedFailure :: NumberedOutput v -> Bool
 isNumberedFailure = \case

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1800,8 +1800,8 @@ createAuthor =
 gist :: InputPattern
 gist =
   InputPattern
-    "gist"
-    []
+    "push.gist"
+    ["gist"]
     [(Required, gitUrlArg)]
     ( P.lines
         [ "Publish the current namespace.",

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1797,6 +1797,29 @@ createAuthor =
         _ -> Left $ showPatternHelp createAuthor
     )
 
+gist :: InputPattern
+gist =
+  InputPattern
+    "gist"
+    []
+    [(Required, gitUrlArg)]
+    ( P.lines
+        [ "Publish the current namespace.",
+          "",
+          P.wrapColumn2
+            [ ( "`gist remote`",
+                "publishes the contents of the current namespace into the repo `remote`."
+              )
+            ]
+        ]
+    )
+    ( \case
+        [repoString] -> do
+          repo <- parseWriteRepo "repo" repoString
+          pure (Input.GistI (Input.GistInput repo))
+        _ -> Left (showPatternHelp gist)
+    )
+
 validInputs :: [InputPattern]
 validInputs =
   [ help,
@@ -1876,7 +1899,8 @@ validInputs =
     debugFileHashes,
     debugDumpNamespace,
     debugDumpNamespaceSimple,
-    debugClearWatchCache
+    debugClearWatchCache,
+    gist
   ]
 
 commandNames :: [String]

--- a/unison-cli/tests/Unison/Test/GitSync.hs
+++ b/unison-cli/tests/Unison/Test/GitSync.hs
@@ -366,6 +366,7 @@ test = scope "gitsync22" . tests $
         traverse (Codebase.getWatch cb TestWatch) =<<
           Codebase.watches cb TestWatch)
   ,
+  gistTest fmt,
   pushPullTest "fix2068(a)" fmt
     -- this triggers
     {-
@@ -504,6 +505,31 @@ watchPushPullTest name fmt authorScript userScript codebaseCheck = scope name do
     Ucm.deleteCodebase author
     Ucm.deleteCodebase user
   ok
+
+gistTest :: CodebaseFormat -> Test ()
+gistTest fmt =
+  pushPullTest "gist" fmt authorScript userScript
+  where
+    authorScript repo =
+      [i|
+        ```unison:hide
+        y = 3
+        ```
+        ```ucm
+        .> add
+        .> gist ${repo}
+        ```
+      |]
+    userScript repo =
+      [i|
+        ```ucm
+        .> pull ${repo}:#n611nnppp5
+        .> find
+        ```
+        ```unison
+        > y
+        ```
+      |]
 
 fastForwardPush :: Test ()
 fastForwardPush = scope "fastforward-push" do

--- a/unison-src/transcripts/diff.md
+++ b/unison-src/transcripts/diff.md
@@ -52,9 +52,14 @@ structural ability X a1 a2 where x : Nat
 .ns1> fork .ns1 .ns2
 .ns1> cd .
 ```
+
 Here's what we've done so far:
-```ucm
+
+```ucm:error
 .> diff.namespace nothing ns1
+```
+
+```ucm
 .> diff.namespace ns1 ns2
 ```
 

--- a/unison-src/transcripts/diff.output.md
+++ b/unison-src/transcripts/diff.output.md
@@ -150,6 +150,7 @@ structural ability X a1 a2 where x : Nat
 
 ```
 Here's what we've done so far:
+
 ```ucm
 .> diff.namespace nothing ns1
 
@@ -157,6 +158,8 @@ Here's what we've done so far:
   
   The namespace .nothing is empty. Was there a typo?
 
+```
+```ucm
 .> diff.namespace ns1 ns2
 
   The namespaces are identical.


### PR DESCRIPTION
## Overview

This PR implements a `gist` command, which is like `push`, but (currently) always pushes the current namespace, and doesn't set the remote root.

Fixes #2603

![Screenshot from 2021-11-19 12-45-31](https://user-images.githubusercontent.com/1074598/142667868-9cea8945-ef1a-419e-aee9-87dfebe4160a.png)

## Implementation notes

This change is implemented by adding a boolean argument to a codebase API function, from

```haskell
-- | Push the given branch to the given repo, and set it as the root branch.
pushGitRootBranch :: Branch m -> WriteRepo -> SyncMode -> m (Either GitError ())
```

to

```haskell
-- | Push the given branch to the given repo, and optionally set it as the root branch.
pushGitBranch :: Branch m -> WriteRepo -> PushGitBranchOpts -> m (Either GitError ())

data PushGitBranchOpts = PushGitBranchOpts
  { -- | Set the branch as root?
    setRoot :: Bool,
    syncMode :: SyncMode
  }
```

The flag controls whether after pushing the branch we also want to set it as the new root.

The implementation of the `gist` and `push` commands are similar; they do a bit of pre-processing, then call out to a shared helper with different values for `setRoot` (`False` in the case of `gist`, and `True` in the case of `push`).

## Test coverage

~No tests nor transcripts have been added~, but I did test manually pushing gists and pulling them down. I would be happy to add a test but I wasn't exactly sure how to get a lot of value out of one, since much of the implementation is shared with `push`.

I've added a transcript that calls `gist`, then `pull`.