### PR TITLE
Rename Referent' -> GReferent to get `'` out of the filename

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Branch/Diff.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Branch/Diff.hs
@@ -11,7 +11,7 @@ import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Set (Set)
 import U.Codebase.Reference (Reference')
-import U.Codebase.Referent (Referent')
+import U.Codebase.Referent (GReferent)
 import U.Codebase.Sqlite.DbId (BranchObjectId, CausalHashId, ObjectId, PatchObjectId, TextId)
 import U.Codebase.Sqlite.LocalIds (LocalBranchChildId, LocalDefnId, LocalPatchObjectId, LocalTextId)
 import qualified U.Util.Map as Map
@@ -39,10 +39,10 @@ addsRemoves map = (adds, removes)
   where
     (fmap fst -> adds, fmap fst -> removes) = List.partition snd (Map.toList map)
 
-type Referent'' t h = Referent' (Reference' t h) (Reference' t h)
+type GReferent' t h = GReferent (Reference' t h) (Reference' t h)
 
 data Diff' t h p c = Diff
-  { terms :: Map t (Map (Referent'' t h) (DefinitionOp' (Metadata t h))),
+  { terms :: Map t (Map (GReferent' t h) (DefinitionOp' (Metadata t h))),
     types :: Map t (Map (Reference' t h) (DefinitionOp' (Metadata t h))),
     patches :: Map t (PatchOp' p),
     children :: Map t (ChildOp' c)

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Branch/Full.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Branch/Full.hs
@@ -6,7 +6,7 @@ module U.Codebase.Sqlite.Branch.Full where
 import Data.Map (Map)
 import Data.Set (Set)
 import U.Codebase.Reference (Reference')
-import U.Codebase.Referent (Referent')
+import U.Codebase.Referent (GReferent)
 import U.Codebase.Sqlite.DbId (BranchObjectId, CausalHashId, ObjectId, PatchObjectId, TextId)
 import U.Codebase.Sqlite.LocalIds (LocalBranchChildId, LocalDefnId, LocalPatchObjectId, LocalTextId)
 import qualified U.Util.Map as Map
@@ -17,10 +17,10 @@ type LocalBranch = Branch' LocalTextId LocalDefnId LocalPatchObjectId LocalBranc
 
 type DbBranch = Branch' TextId ObjectId PatchObjectId (BranchObjectId, CausalHashId)
 
-type Referent'' t h = Referent' (Reference' t h) (Reference' t h)
+type GReferent' t h = GReferent (Reference' t h) (Reference' t h)
 
 data Branch' t h p c = Branch
-  { terms :: Map t (Map (Referent'' t h) (MetadataSetFormat' t h)),
+  { terms :: Map t (Map (GReferent' t h) (MetadataSetFormat' t h)),
     types :: Map t (Map (Reference' t h) (MetadataSetFormat' t h)),
     patches :: Map t p,
     children :: Map t c

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Patch/Diff.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Patch/Diff.hs
@@ -5,7 +5,7 @@ import Data.Map (Map)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import U.Codebase.Reference (Reference')
-import U.Codebase.Referent (Referent')
+import U.Codebase.Referent (GReferent)
 import qualified U.Codebase.Sqlite.DbId as Db
 import U.Codebase.Sqlite.LocalIds (LocalDefnId, LocalHashId, LocalTextId)
 import U.Codebase.Sqlite.Patch.TermEdit (TermEdit')
@@ -16,15 +16,15 @@ type PatchDiff = PatchDiff' Db.TextId Db.HashId Db.ObjectId
 
 type LocalPatchDiff = PatchDiff' LocalTextId LocalHashId LocalDefnId
 
-type Referent'' t h = Referent' (Reference' t h) (Reference' t h)
+type GReferent' t h = GReferent (Reference' t h) (Reference' t h)
 
 -- | diff. = min. - sub.
 data PatchDiff' t h d = PatchDiff
   { -- | elements present in min. but absent in sub.
-    addedTermEdits :: Map (Referent'' t h) (Set (TermEdit' t d)),
+    addedTermEdits :: Map (GReferent' t h) (Set (TermEdit' t d)),
     addedTypeEdits :: Map (Reference' t h) (Set (TypeEdit' t d)),
     -- | elements missing in min. but present in sub.
-    removedTermEdits :: Map (Referent'' t h) (Set (TermEdit' t d)),
+    removedTermEdits :: Map (GReferent' t h) (Set (TermEdit' t d)),
     removedTypeEdits :: Map (Reference' t h) (Set (TypeEdit' t d))
   }
   deriving (Eq, Ord, Show)

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Patch/Full.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Patch/Full.hs
@@ -5,7 +5,7 @@ import Data.Map (Map)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import U.Codebase.Reference (Reference')
-import U.Codebase.Referent (Referent')
+import U.Codebase.Referent (GReferent)
 import qualified U.Codebase.Sqlite.DbId as Db
 import U.Codebase.Sqlite.LocalIds (LocalDefnId, LocalHashId, LocalTextId)
 import U.Codebase.Sqlite.Patch.TermEdit (TermEdit')
@@ -16,10 +16,10 @@ type Patch = Patch' Db.TextId Db.HashId Db.ObjectId
 
 type LocalPatch = Patch' LocalTextId LocalHashId LocalDefnId
 
-type Referent'' t h = Referent' (Reference' t h) (Reference' t h)
+type GReferent' t h = GReferent (Reference' t h) (Reference' t h)
 
 data Patch' t h o = Patch
-  { termEdits :: Map (Referent'' t h) (Set (TermEdit' t o)),
+  { termEdits :: Map (GReferent' t h) (Set (TermEdit' t o)),
     typeEdits :: Map (Reference' t h) (Set (TypeEdit' t o))
   }
 

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Patch/TermEdit.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Patch/TermEdit.hs
@@ -12,9 +12,9 @@ type TermEdit = TermEdit' Db.TextId Db.ObjectId
 
 type LocalTermEdit = TermEdit' LocalTextId LocalDefnId
 
-type Referent' t h = Referent.Referent' (Reference' t h) (Reference' t h)
+type GReferent t h = Referent.GReferent (Reference' t h) (Reference' t h)
 
-data TermEdit' t h = Replace (Referent' t h) Typing | Deprecate
+data TermEdit' t h = Replace (GReferent t h) Typing | Deprecate
   deriving (Eq, Ord, Show)
 
 -- Replacements with the Same type can be automatically propagated.

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Referent.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Referent.hs
@@ -8,19 +8,19 @@ module U.Codebase.Sqlite.Referent where
 import Control.Applicative (liftA3)
 import Database.SQLite.Simple (FromRow (..), Only (..), SQLData (..), ToRow (..), field)
 import qualified U.Codebase.Reference as Reference
-import U.Codebase.Referent (Id', Referent')
+import U.Codebase.Referent (Id', GReferent)
 import qualified U.Codebase.Referent as Referent
 import U.Codebase.Sqlite.DbId (ObjectId)
 import qualified U.Codebase.Sqlite.Reference as Sqlite
 
-type Referent = Referent' Sqlite.Reference Sqlite.Reference
+type Referent = GReferent Sqlite.Reference Sqlite.Reference
 
-type ReferentH = Referent' Sqlite.ReferenceH Sqlite.ReferenceH
+type ReferentH = GReferent Sqlite.ReferenceH Sqlite.ReferenceH
 
 type Id = Id' ObjectId ObjectId
 
-type LocalReferent = Referent' Sqlite.LocalReference Sqlite.LocalReference
-type LocalReferentH = Referent' Sqlite.LocalReferenceH Sqlite.LocalReferenceH
+type LocalReferent = GReferent Sqlite.LocalReference Sqlite.LocalReference
+type LocalReferentH = GReferent Sqlite.LocalReferenceH Sqlite.LocalReferenceH
 
 instance ToRow Id where
   toRow = \case

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Term/Format.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Term/Format.hs
@@ -5,7 +5,7 @@ module U.Codebase.Sqlite.Term.Format where
 import Data.ByteString (ByteString)
 import Data.Vector (Vector)
 import U.Codebase.Reference (Reference')
-import U.Codebase.Referent (Referent')
+import U.Codebase.Referent (GReferent)
 import U.Codebase.Sqlite.LocalIds
     ( LocalIds', LocalTextId, LocalDefnId, WatchLocalIds )
 import U.Codebase.Sqlite.Symbol ( Symbol )
@@ -17,7 +17,7 @@ import U.Codebase.Sqlite.DbId (ObjectId, TextId)
 
 type TermRef = Reference' LocalTextId (Maybe LocalDefnId)
 type TypeRef = Reference' LocalTextId LocalDefnId
-type TermLink = Referent' TermRef TypeRef
+type TermLink = GReferent TermRef TypeRef
 type TypeLink = TypeRef
 
 type LocallyIndexedComponent = LocallyIndexedComponent' TextId ObjectId

--- a/codebase2/codebase/U/Codebase/Referent.hs
+++ b/codebase2/codebase/U/Codebase/Referent.hs
@@ -13,10 +13,10 @@ import Data.Bifoldable (Bifoldable(..))
 import Data.Bitraversable (Bitraversable(..))
 import U.Codebase.Decl (ConstructorId)
 
-type Referent = Referent' Reference Reference
-type ReferentH = Referent' (Reference' Text (Maybe Hash)) (Reference' Text Hash)
+type Referent = GReferent Reference Reference
+type ReferentH = GReferent (Reference' Text (Maybe Hash)) (Reference' Text Hash)
 
-data Referent' rTm rTp
+data GReferent rTm rTp
   = Ref rTm
   | Con rTp ConstructorId
   deriving (Eq, Ord, Show)
@@ -27,17 +27,17 @@ data Id' hTm hTp
   | ConId (Reference.Id' hTp) ConstructorId
   deriving (Eq, Ord, Show)
 
-instance Bifunctor Referent' where
+instance Bifunctor GReferent where
   bimap f g = \case
     Ref r -> Ref (f r)
     Con r i -> Con (g r) i
 
-instance Bifoldable Referent' where
+instance Bifoldable GReferent where
   bifoldMap f g = \case
     Ref r -> f r
     Con r _ -> g r
 
-instance Bitraversable Referent' where
+instance Bitraversable GReferent where
   bitraverse f g = \case
     Ref r -> Ref <$> f r
     Con r c -> flip Con c <$> g r

--- a/codebase2/codebase/U/Codebase/Term.hs
+++ b/codebase2/codebase/U/Codebase/Term.hs
@@ -25,7 +25,7 @@ import Data.Text (Text)
 import Data.Word (Word64)
 import GHC.Generics (Generic, Generic1)
 import U.Codebase.Reference (Reference, Reference')
-import U.Codebase.Referent (Referent')
+import U.Codebase.Referent (GReferent)
 import U.Codebase.Type (TypeR)
 import qualified U.Codebase.Type as Type
 import qualified U.Core.ABT as ABT
@@ -41,7 +41,7 @@ type TermRef = Reference' Text (Maybe Hash)
 
 type TypeRef = Reference
 
-type TermLink = Referent' (Reference' Text (Maybe Hash)) (Reference' Text Hash)
+type TermLink = GReferent (Reference' Text (Maybe Hash)) (Reference' Text Hash)
 
 type TypeLink = Reference
 

--- a/parser-typechecker/src/Unison/Hashing/V2/Referent.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Referent.hs
@@ -5,7 +5,7 @@ module Unison.Hashing.V2.Referent where
 
 import Unison.Prelude
 import Unison.ConstructorReference (GConstructorReference(..))
-import Unison.Referent' ( Referent'(..), toReference' )
+import Unison.GReferent ( GReferent(..), toReference' )
 
 import qualified Data.Char              as Char
 import qualified Data.Text              as Text
@@ -23,7 +23,7 @@ import qualified Unison.ConstructorType as CT
 --
 -- Slightly odd naming. This is the "referent of term name in the codebase",
 -- rather than the target of a Reference.
-type Referent = Referent' Reference
+type Referent = GReferent Reference
 type ConstructorId = Int
 pattern Ref :: Reference -> Referent
 pattern Ref r = Ref' r
@@ -32,7 +32,7 @@ pattern Con r i t = Con' (ConstructorReference r i) t
 {-# COMPLETE Ref, Con #-}
 
 -- | Cannot be a builtin.
-type Id = Referent' R.Id
+type Id = GReferent R.Id
 
 -- todo: move these to ShortHash module
 toShortHash :: Referent -> ShortHash
@@ -115,7 +115,7 @@ fromText t = either (const Nothing) Just $
     cidPart' = Text.takeWhileEnd (/= '#') t
     cidPart = Text.drop 1 cidPart'
 
-fold :: (r -> a) -> (r -> ConstructorId -> ConstructorType -> a) -> Referent' r -> a
+fold :: (r -> a) -> (r -> ConstructorId -> ConstructorType -> a) -> GReferent r -> a
 fold fr fc = \case
   Ref' r -> fr r
   Con' (ConstructorReference r i) ct -> fc r i ct

--- a/parser-typechecker/src/Unison/Server/Doc.hs
+++ b/parser-typechecker/src/Unison/Server/Doc.hs
@@ -196,15 +196,15 @@ renderDoc pped terms typeOf eval types tm = eval tm >>= \case
       ty r = (NP.styleHashQualified'' (NP.fmt (S.TypeReference r)) . PPE.typeName ppe) r
       in Link <$> case e of
         DD.EitherLeft' (Term.TypeLink' r) -> (pure . formatPretty . ty) r
-        DD.EitherRight' (DD.Doc2Term (Term.Referent' r)) -> (pure . formatPretty . tm) r
+        DD.EitherRight' (DD.Doc2Term (Term.GReferent r)) -> (pure . formatPretty . tm) r
         _ -> source e
 
     DD.Doc2SpecialFormSignature (Term.List' tms) ->
-      let rs = [ r | DD.Doc2Term (Term.Referent' r) <- toList tms ]
+      let rs = [ r | DD.Doc2Term (Term.GReferent r) <- toList tms ]
       in goSignatures rs <&> \s -> Signature (map formatPretty s)
 
     -- SignatureInline Doc2.Term
-    DD.Doc2SpecialFormSignatureInline (DD.Doc2Term (Term.Referent' r)) ->
+    DD.Doc2SpecialFormSignatureInline (DD.Doc2Term (Term.GReferent r)) ->
       goSignatures [r] <&> \s -> SignatureInline (formatPretty (P.lines s))
 
     -- Eval Doc2.Term

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -1556,7 +1556,7 @@ toDocParagraph ppe (App' (Ref' r) (List' tms))
 toDocParagraph _ _ = Nothing
 
 toDocEmbedTermLink :: Ord v => PrettyPrintEnv -> Term3 v PrintAnnotation -> Maybe Referent
-toDocEmbedTermLink ppe (App' (Ref' r) (Delay' (Referent' tm)))
+toDocEmbedTermLink ppe (App' (Ref' r) (Delay' (GReferent tm)))
   | nameEndsWith ppe ".docEmbedTermLink" r = Just tm
 toDocEmbedTermLink _ _ = Nothing
 
@@ -1606,7 +1606,7 @@ toDocSignatureInline ppe (App' (Ref' r) (toDocEmbedSignatureLink ppe -> Just tm)
 toDocSignatureInline _ _ = Nothing
 
 toDocEmbedSignatureLink :: Ord v => PrettyPrintEnv -> Term3 v PrintAnnotation -> Maybe Referent
-toDocEmbedSignatureLink ppe (App' (Ref' r) (Delay' (Referent' tm)))
+toDocEmbedSignatureLink ppe (App' (Ref' r) (Delay' (GReferent tm)))
   | nameEndsWith ppe ".docEmbedSignatureLink" r = Just tm
 toDocEmbedSignatureLink _ _ = Nothing
 

--- a/parser-typechecker/src/Unison/Util/SyntaxText.hs
+++ b/parser-typechecker/src/Unison/Util/SyntaxText.hs
@@ -4,7 +4,7 @@ module Unison.Util.SyntaxText where
 
 import Unison.Prelude
 import Unison.Name (Name)
-import Unison.Referent' (Referent')
+import Unison.GReferent (GReferent)
 import Unison.HashQualified (HashQualified)
 import Unison.Pattern (SeqOp)
 
@@ -21,7 +21,7 @@ data Element r = NumericLiteral
              | Blank
              | Var
              | TypeReference r
-             | TermReference (Referent' r)
+             | TermReference (GReferent r)
              | Op SeqOp
              | AbilityBraces
              -- let|handle|in|where|match|with|cases|->|if|then|else|and|or

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -103,7 +103,7 @@ import Unison.Reference (Reference)
 import qualified Unison.Reference as Reference
 import Unison.Referent (Referent)
 import qualified Unison.Referent as Referent
-import qualified Unison.Referent' as Referent
+import qualified Unison.GReferent as Referent
 import qualified Unison.Result as Result
 import Unison.Server.Backend (ShallowListEntry (..), TermEntry (..), TypeEntry (..))
 import qualified Unison.Server.SearchResult' as SR'

--- a/unison-core/src/Unison/DataDeclaration.hs
+++ b/unison-core/src/Unison/DataDeclaration.hs
@@ -53,7 +53,7 @@ import qualified Unison.Pattern as Pattern
 import Unison.Reference (Reference)
 import qualified Unison.Reference as Reference
 import qualified Unison.Referent as Referent
-import qualified Unison.Referent' as Referent'
+import qualified Unison.GReferent as GReferent
 import Unison.Term (Term)
 import qualified Unison.Term as Term
 import Unison.Type (Type)
@@ -185,7 +185,7 @@ constructorNames dd = Var.name <$> constructorVars dd
 -- reliable way of doing that. —AI
 declConstructorReferents :: Reference.Id -> Decl v a -> [Referent.Id]
 declConstructorReferents rid decl =
-  [ Referent'.Con' (ConstructorReference rid i) ct | i <- constructorIds (asDataDecl decl) ]
+  [ GReferent.Con' (ConstructorReference rid i) ct | i <- constructorIds (asDataDecl decl) ]
   where ct = constructorType decl
 
 constructorIds :: DataDeclaration v a -> [ConstructorId]

--- a/unison-core/src/Unison/GReferent.hs
+++ b/unison-core/src/Unison/GReferent.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 
-module Unison.Referent'
-  ( Referent' (..),
+module Unison.GReferent
+  ( GReferent (..),
 
     -- * Basic queries
     isConstructor,
@@ -36,41 +36,41 @@ import Unison.Prelude (Word64)
 -- | When @Ref'@ then @r@ represents a term.
 --
 -- When @Con'@ then @r@ is a type declaration.
-data Referent' r = Ref' r | Con' (GConstructorReference r) ConstructorType
+data GReferent r = Ref' r | Con' (GConstructorReference r) ConstructorType
   deriving (Show, Ord, Eq, Functor)
 
 -- | A lens onto the reference in a referent.
-reference_ :: Lens (Referent' r) (Referent' r') r r'
+reference_ :: Lens (GReferent r) (GReferent r') r r'
 reference_ =
   lens toReference' \rt rc ->
     case rt of
       Ref' _ -> Ref' rc
       Con' (ConstructorReference _ cid) ct -> Con' (ConstructorReference rc cid) ct
 
-isConstructor :: Referent' r -> Bool
+isConstructor :: GReferent r -> Bool
 isConstructor Con' {} = True
 isConstructor _ = False
 
-toTermReference :: Referent' r -> Maybe r
+toTermReference :: GReferent r -> Maybe r
 toTermReference = \case
   Ref' r -> Just r
   _ -> Nothing
 
-toReference' :: Referent' r -> r
+toReference' :: GReferent r -> r
 toReference' = \case
   Ref' r -> r
   Con' (ConstructorReference r _i) _t -> r
 
-toTypeReference :: Referent' r -> Maybe r
+toTypeReference :: GReferent r -> Maybe r
 toTypeReference = \case
   Con' (ConstructorReference r _i) _t -> Just r
   _ -> Nothing
 
-fold :: (r -> a) -> (r -> ConstructorId -> ConstructorType -> a) -> Referent' r -> a
+fold :: (r -> a) -> (r -> ConstructorId -> ConstructorType -> a) -> GReferent r -> a
 fold fr fc = \case
   Ref' r -> fr r
   Con' (ConstructorReference r i) ct -> fc r i ct
 
-instance Hashable r => Hashable (Referent' r) where
+instance Hashable r => Hashable (GReferent r) where
   tokens (Ref' r) = [H.Tag 0] ++ H.tokens r
   tokens (Con' (ConstructorReference r i) dt) = [H.Tag 2] ++ H.tokens r ++ H.tokens (fromIntegral i :: Word64) ++ H.tokens dt

--- a/unison-core/src/Unison/Referent.hs
+++ b/unison-core/src/Unison/Referent.hs
@@ -37,7 +37,7 @@ import Unison.DataDeclaration.ConstructorId (ConstructorId)
 import Unison.Prelude hiding (fold)
 import Unison.Reference (Reference, TermReference)
 import qualified Unison.Reference as R
-import Unison.Referent' (Referent' (..), toReference', reference_)
+import Unison.GReferent (GReferent (..), toReference', reference_)
 import Unison.ShortHash (ShortHash)
 import qualified Unison.ShortHash as SH
 import qualified Unison.Reference as Reference
@@ -48,7 +48,7 @@ import qualified Unison.Reference as Reference
 --
 -- Slightly odd naming. This is the "referent of term name in the codebase",
 -- rather than the target of a Reference.
-type Referent = Referent' Reference
+type Referent = GReferent Reference
 
 pattern Ref :: TermReference -> Referent
 pattern Ref r = Ref' r
@@ -59,7 +59,7 @@ pattern Con r t = Con' r t
 {-# COMPLETE Ref, Con #-}
 
 -- | By definition, cannot be a builtin.
-type Id = Referent' R.Id
+type Id = GReferent R.Id
 
 pattern RefId :: R.Id -> Unison.Referent.Id
 pattern RefId r = Ref' r
@@ -133,7 +133,7 @@ fromText t = either (const Nothing) Just $
     cidPart' = Text.takeWhileEnd (/= '#') t
     cidPart = Text.drop 1 cidPart'
 
-fold :: (r -> a) -> (r -> Int -> ConstructorType -> a) -> Referent' r -> a
+fold :: (r -> a) -> (r -> Int -> ConstructorType -> a) -> GReferent r -> a
 fold fr fc = \case
   Ref' r -> fr r
   Con' (ConstructorReference r i) ct -> fc r i ct

--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -475,7 +475,7 @@ var' = var() . Var.named
 ref :: Ord v => a -> Reference -> Term2 vt at ap v a
 ref a r = ABT.tm' a (Ref r)
 
-pattern Referent' r <- (unReferent -> Just r)
+pattern GReferent r <- (unReferent -> Just r)
 
 unReferent :: Term2 vt at ap v a -> Maybe Referent
 unReferent (Ref' r) = Just $ Referent.Ref r

--- a/unison-core/unison-core1.cabal
+++ b/unison-core/unison-core1.cabal
@@ -31,6 +31,7 @@ library
       Unison.DataDeclaration
       Unison.DataDeclaration.ConstructorId
       Unison.DataDeclaration.Names
+      Unison.GReferent
       Unison.Hash
       Unison.Hashable
       Unison.HashQualified
@@ -46,7 +47,6 @@ library
       Unison.Reference
       Unison.Reference.Util
       Unison.Referent
-      Unison.Referent'
       Unison.Settings
       Unison.ShortHash
       Unison.Symbol


### PR DESCRIPTION
## Overview

Having `'` in a filename gets in the way of a bunch of my shell tooling, and every time I want to script something, I'm sure I'm not the only one. It took me 4 seconds to make this PR which will save me a lot of annoyance for me and others in the future.

In addition, `Referent'` isn't descriptive of the difference from `Referent.

We talked about using `G` as a prefix to indicate the polymorphic version of something, so this follows that convention.

## Implementation notes

Literally just renames `Referent'` to `GReferent` everywhere.