### PR TITLE
Include self-references in dependents index

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
@@ -524,8 +524,8 @@ saveTermComponent h terms = do
                   getTermSRef :: S.Term.TermRef -> S.Reference
                   getTermSRef = \case
                     C.ReferenceBuiltin t -> C.ReferenceBuiltin (tIds Vector.! fromIntegral t)
-                    C.Reference.Derived mh i ->
-                      C.Reference.Derived (maybe oId (\h -> oIds Vector.! fromIntegral h) mh) i
+                    C.Reference.Derived Nothing i -> C.Reference.Derived oId i -- index self-references
+                    C.Reference.Derived (Just h) i -> C.Reference.Derived (oIds Vector.! fromIntegral h) i
                   getTypeSRef :: S.Term.TypeRef -> S.Reference
                   getTypeSRef = \case
                     C.ReferenceBuiltin t -> C.ReferenceBuiltin (tIds Vector.! fromIntegral t)
@@ -822,7 +822,8 @@ saveDeclComponent h decls = do
             getSRef :: C.Reference.Reference' LocalTextId (Maybe LocalDefnId) -> S.Reference.Reference
             getSRef = \case
               C.ReferenceBuiltin t -> C.ReferenceBuiltin (tIds Vector.! fromIntegral t)
-              C.Reference.Derived mh i -> C.Reference.Derived (maybe oId (\h -> oIds Vector.! fromIntegral h) mh) i
+              C.Reference.Derived Nothing i -> C.Reference.Derived oId i -- index self-references
+              C.Reference.Derived (Just h) i -> C.Reference.Derived (oIds Vector.! fromIntegral h) i
          in Set.map ((,self) . getSRef) dependencies
   traverse_ (uncurry Q.addToDependentsIndex) dependencies
 

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
@@ -817,11 +817,11 @@ saveDeclComponent h decls = do
       unlocalizeRefs ((LocalIds tIds oIds, decl), i) =
         let self = C.Reference.Id oId i
             dependencies :: Set S.Decl.TypeRef = C.Decl.dependencies decl
-            getSRef :: C.Reference.Reference' LocalTextId (Maybe LocalDefnId) -> Maybe S.Reference.Reference
-            getSRef (C.ReferenceBuiltin t) = Just (C.ReferenceBuiltin (tIds Vector.! fromIntegral t))
-            getSRef (C.Reference.Derived (Just h) i) = Just (C.Reference.Derived (oIds Vector.! fromIntegral h) i)
-            getSRef _selfCycleRef@(C.Reference.Derived Nothing _) = Nothing
-         in Set.mapMaybe (fmap (,self) . getSRef) dependencies
+            getSRef :: C.Reference.Reference' LocalTextId (Maybe LocalDefnId) -> S.Reference.Reference
+            getSRef = \case
+              C.ReferenceBuiltin t -> C.ReferenceBuiltin (tIds Vector.! fromIntegral t)
+              C.Reference.Derived mh i -> C.Reference.Derived (maybe oId (\h -> oIds Vector.! fromIntegral h) mh) i
+         in Set.map ((,self) . getSRef) dependencies
   traverse_ (uncurry Q.addToDependentsIndex) dependencies
 
   pure oId

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -154,7 +154,8 @@ import Debug.Trace (trace, traceM)
 import GHC.Stack (HasCallStack)
 import Safe (headMay)
 import U.Codebase.HashTags (BranchHash (..), CausalHash (..))
-import U.Codebase.Reference (Reference')
+import U.Codebase.Reference (Reference' (..))
+import qualified U.Codebase.Reference as C.Reference
 import U.Codebase.Sqlite.Connection (Connection)
 import qualified U.Codebase.Sqlite.Connection as Connection
 import U.Codebase.Sqlite.DbId
@@ -645,31 +646,60 @@ addToDependentsIndex dependency dependent = execute sql (dependency :. dependent
     ON CONFLICT DO NOTHING
   |]
 
+-- | Get non-self, user-defined dependents of a dependency.
 getDependentsForDependency :: DB m => Reference.Reference -> m [Reference.Id]
-getDependentsForDependency dependency = query sql dependency where sql = [here|
-  SELECT dependent_object_id, dependent_component_index
-  FROM dependents_index
-  WHERE dependency_builtin IS ?
-    AND dependency_object_id IS ?
-    AND dependency_component_index IS ?
-|]
+getDependentsForDependency dependency =
+  filter isNotSelfReference <$> query sql dependency
+  where
+    sql =
+      [here|
+        SELECT dependent_object_id, dependent_component_index
+        FROM dependents_index
+        WHERE dependency_builtin IS ?
+          AND dependency_object_id IS ?
+          AND dependency_component_index IS ?
+      |]
 
+    isNotSelfReference :: Reference.Id -> Bool
+    isNotSelfReference =
+      case dependency of
+        ReferenceBuiltin _ -> const True
+        ReferenceDerived (C.Reference.Id oid0 _pos0) -> \(C.Reference.Id oid1 _pos1) -> oid0 /= oid1
+
+-- | Get non-self dependencies of a user-defined dependent.
 getDependenciesForDependent :: DB m => Reference.Id -> m [Reference.Reference]
-getDependenciesForDependent dependent = query sql dependent where sql = [here|
-  SELECT dependency_builtin, dependency_object_id, dependency_component_index
-  FROM dependents_index
-  WHERE dependent_object_id IS ?
-    AND dependent_component_index IS ?
-|]
+getDependenciesForDependent dependent@(C.Reference.Id oid0 _) =
+  filter isNotSelfReference <$> query sql dependent
+  where
+    sql = [here|
+      SELECT dependency_builtin, dependency_object_id, dependency_component_index
+      FROM dependents_index
+      WHERE dependent_object_id IS ?
+        AND dependent_component_index IS ?
+    |]
 
+    isNotSelfReference :: Reference.Reference -> Bool
+    isNotSelfReference = \case
+      ReferenceBuiltin _ -> True
+      ReferenceDerived (C.Reference.Id oid1 _) -> oid0 /= oid1
+
+-- | Get non-self, user-defined dependencies of a user-defined dependent.
 getDependencyIdsForDependent :: DB m => Reference.Id -> m [Reference.Id]
-getDependencyIdsForDependent dependent = query sql dependent where sql = [here|
-  SELECT dependency_object_id, dependency_component_index
-  FROM dependents_index
-  WHERE dependency_builtin IS NULL
-    AND dependent_object_id = ?
-    AND dependen_component_index = ?
-|]
+getDependencyIdsForDependent dependent@(C.Reference.Id oid0 _) =
+  filter isNotSelfReference <$> query sql dependent
+  where
+    sql =
+      [here|
+        SELECT dependency_object_id, dependency_component_index
+        FROM dependents_index
+        WHERE dependency_builtin IS NULL
+          AND dependent_object_id = ?
+          AND dependen_component_index = ?
+      |]
+
+    isNotSelfReference :: Reference.Id -> Bool
+    isNotSelfReference (C.Reference.Id oid1 _) =
+      oid0 /= oid1
 
 objectIdByBase32Prefix :: DB m => ObjectType -> Text -> m [ObjectId]
 objectIdByBase32Prefix objType prefix = queryAtoms sql (objType, prefix <> "%") where sql = [here|


### PR DESCRIPTION
## Overview

This PR amends the logic of `saveDeclComponent`/`saveTermComponent` to include self-references in the dependents index, for both literal self-references (e.g. `foo = foo`), and self-component-references (e.g. `foo = bar; bar = foo`).

This is an initial step towards resolving #2649.  

To preserve the behavior of existing code that is querying the index for dependencies/dependents, this PR adds a post-processing step in Haskell that filters the self-references out.

The next step we have planned is to generalize the API of getting dependencies/dependents to allow the caller to choose whether they want self-references back or not, and continue from there. 