### PR TITLE
Optimize relation Eq/Ord instances a bit

### DIFF
--- a/lib/unison-util-relation/src/Unison/Util/Relation.hs
+++ b/lib/unison-util-relation/src/Unison/Util/Relation.hs
@@ -107,10 +107,12 @@ module Unison.Util.Relation
 where
 
 import qualified Control.Monad as Monad
+import Data.Function (on)
 import qualified Data.List as List
 import qualified Data.Map as M
 import qualified Data.Map as Map
 import qualified Data.Map.Internal as Map
+import Data.Ord (comparing)
 import qualified Data.Set as S
 import Unison.Prelude hiding (empty, toList)
 import Prelude hiding (filter, map, null)
@@ -137,10 +139,15 @@ data Relation a b = Relation
   { domain :: Map a (Set b),
     range :: Map b (Set a)
   }
-  deriving (Eq, Ord)
+
+instance (Eq a, Eq b) => Eq (Relation a b) where
+  (==) = (==) `on` domain
 
 instance (NFData a, NFData b) => NFData (Relation a b) where
   rnf (Relation d r) = rnf d `seq` rnf r
+
+instance (Ord a, Ord b) => Ord (Relation a b) where
+  compare = comparing domain
 
 instance (Show a, Show b) => Show (Relation a b) where
   show = show . toList

--- a/lib/unison-util-relation/src/Unison/Util/Relation3.hs
+++ b/lib/unison-util-relation/src/Unison/Util/Relation3.hs
@@ -7,6 +7,8 @@ import Unison.Prelude hiding (empty, toList)
 import Unison.Util.Relation (Relation)
 import qualified Data.Map as Map
 import qualified Unison.Util.Relation as R
+import Data.Function (on)
+import Data.Ord (comparing)
 import Data.Semigroup (Sum(Sum, getSum))
 import Data.Tuple.Extra (uncurry3)
 
@@ -15,7 +17,13 @@ data Relation3 a b c
   { d1 :: Map a (Relation b c)
   , d2 :: Map b (Relation a c)
   , d3 :: Map c (Relation a b)
-  } deriving (Eq,Ord)
+  }
+
+instance (Eq a, Eq b, Eq c) => Eq (Relation3 a b c) where
+  (==) = (==) `on` d1
+
+instance (Ord a, Ord b, Ord c) => Ord (Relation3 a b c) where
+  compare = comparing d1
 
 instance (Show a, Show b, Show c) => Show (Relation3 a b c) where
   show = show . toList

--- a/lib/unison-util-relation/src/Unison/Util/Relation4.hs
+++ b/lib/unison-util-relation/src/Unison/Util/Relation4.hs
@@ -5,12 +5,13 @@ module Unison.Util.Relation4 where
 import Unison.Prelude hiding (toList, empty)
 import Prelude
 import qualified Data.Map as Map
---import qualified Data.Set as Set
 import qualified Unison.Util.Relation as R
 import qualified Unison.Util.Relation3 as R3
 import Unison.Util.Relation (Relation)
 import Unison.Util.Relation3 (Relation3(Relation3))
+import Data.Function (on)
 import Data.List.Extra (nubOrd)
+import Data.Ord (comparing)
 import Data.Semigroup (Sum(Sum, getSum))
 
 data Relation4 a b c d
@@ -19,7 +20,13 @@ data Relation4 a b c d
   , d2 :: Map b (Relation3 a c d)
   , d3 :: Map c (Relation3 a b d)
   , d4 :: Map d (Relation3 a b c)
-  } deriving (Eq,Ord)
+  }
+
+instance (Eq a, Eq b, Eq c, Eq d) => Eq (Relation4 a b c d) where
+  (==) = (==) `on` d1
+
+instance (Ord a, Ord b, Ord c, Ord d) => Ord (Relation4 a b c d) where
+  compare = comparing d1
 
 instance (Show a, Show b, Show c, Show d) => Show (Relation4 a b c d) where
   show = show . toList
@@ -59,7 +66,7 @@ selectD34 c d r =
            ]
 
 keys :: Relation4 a b c d -> (Set a, Set b, Set c, Set d)
-keys Relation4{d1, d2, d3, d4} = 
+keys Relation4{d1, d2, d3, d4} =
   (Map.keysSet d1, Map.keysSet d2, Map.keysSet d3, Map.keysSet d4)
 
 d1set :: Ord a => Relation4 a b c d -> Set a


### PR DESCRIPTION
## Overview

While looking over a profile of `update` I noticed `Branch.==` was taking some time, which I thought was odd. Apparently we call `Causal.consDistinct` many times, for reasons I don't yet totally understand, when doing an `update`.

Anyway, one easy win here is to just perform Eq/Ord operations on one dimension, since the others contain the same data. This PR implements that, and arbitrarily chooses the first dimension.

Memory usage drops quite a bit on this transcript, which just calls `update` 32 times in a row. Note that the numbers here include all of them cpu/mem attributed to just starting the app up and getting into the transcript file, but I'm not sure of an easy way to omit that phase when generating a report.

![Screenshot from 2021-11-24 10-33-09](https://user-images.githubusercontent.com/1074598/143268704-ad547469-5d61-4822-81fa-e52e9817ec42.png)