### PR TITLE
Optimize relation subtractDom, subtractRan

### DIFF
--- a/lib/unison-prelude/src/Unison/Util/Set.hs
+++ b/lib/unison-prelude/src/Unison/Util/Set.hs
@@ -1,5 +1,6 @@
 module Unison.Util.Set
-  ( mapMaybe,
+  ( difference1,
+    mapMaybe,
     symmetricDifference,
     Unison.Util.Set.traverse,
   )
@@ -8,6 +9,13 @@ where
 import qualified Data.Maybe as Maybe
 import Data.Set (Set)
 import qualified Data.Set as Set
+
+-- | Set difference, but return @Nothing@ if the difference is empty.
+difference1 :: Ord a => Set a -> Set a -> Maybe (Set a)
+difference1 xs ys =
+  if null zs then Nothing else Just zs
+  where
+    zs = Set.difference xs ys
 
 symmetricDifference :: Ord a => Set a -> Set a -> Set a
 symmetricDifference a b = (a `Set.difference` b) `Set.union` (b `Set.difference` a)

--- a/lib/unison-util-relation/benchmarks/relation/Main.hs
+++ b/lib/unison-util-relation/benchmarks/relation/Main.hs
@@ -1,27 +1,55 @@
-{- ORMOLU_DISABLE -} -- Remove this when the file is ready to be auto-formatted
 module Main where
-import Criterion.Main
-import qualified Unison.Util.Relation as R
-import System.Random
-import Control.Monad
 
-genRelations :: (Random a, Random b, Ord a, Ord b)
-             => Int -> Int -> IO (R.Relation a b, R.Relation a b)
-genRelations numDomain rangeValuesPerDomain = do
+import Control.Monad
+import qualified Data.Set as Set
+import System.Random
+import Test.Tasty.Bench
+import Unison.Prelude
+import Unison.Util.Relation (Relation)
+import qualified Unison.Util.Relation as R
+
+main :: IO ()
+main =
+  defaultMain
+    [ env (genRelations @Char @Char 10000 20) \rs ->
+        bgroup
+          "Relation"
+          [ bench "difference" $ nf (uncurry R.difference) rs,
+            bench "intersection" $ nf (uncurry R.intersection) rs,
+            bench "union" $ nf (uncurry R.union) rs
+          ],
+      env (genRelation @Char @Char 10000 2) \r ->
+        env (genSet @Char 100) \s ->
+          bgroup
+            "Relation"
+            [ bgroup
+                "subtractDom"
+                [ bench "old implementation" (nf (oldSubtractDom s) r),
+                  bench "new implementation" (nf (R.subtractDom s) r)
+                ]
+            ]
+    ]
+
+oldSubtractDom :: (Ord a, Ord b) => Set a -> Relation a b -> Relation a b
+oldSubtractDom s r =
+  R.fromList [(a, b) | (a, b) <- R.toList r, not (a `Set.member` s)]
+
+genRelation :: (Ord a, Ord b, Random a, Random b) => Int -> Int -> IO (Relation a b)
+genRelation numDomain rangeValuesPerDomain = do
   let genPairs = do
         k <- randomIO
         vs <- replicateM rangeValuesPerDomain ((k,) <$> randomIO)
         pure vs
-  r1 <- R.fromList . concat <$> (replicateM numDomain genPairs)
-  r2 <- R.fromList . concat <$> (replicateM numDomain genPairs)
-  pure (r1, r2)
+  R.fromList . concat <$> replicateM numDomain genPairs
 
-main :: IO ()
-main = defaultMain
-  [ env (genRelations @Char @Char 10000 20) $ \rs ->
-    bgroup "Relation"
-    [ bench "difference"   $ nf (uncurry R.difference) rs
-    , bench "intersection" $ nf (uncurry R.intersection) rs
-    , bench "union"        $ nf (uncurry R.union) rs
-    ]
-  ]
+genRelations ::
+  (Random a, Random b, Ord a, Ord b) =>
+  Int ->
+  Int ->
+  IO (Relation a b, Relation a b)
+genRelations numDomain rangeValuesPerDomain =
+  (,) <$> genRelation numDomain rangeValuesPerDomain <*> genRelation numDomain rangeValuesPerDomain
+
+genSet :: (Ord a, Random a) => Int -> IO (Set a)
+genSet n =
+  Set.fromList <$> replicateM n randomIO

--- a/lib/unison-util-relation/package.yaml
+++ b/lib/unison-util-relation/package.yaml
@@ -20,10 +20,10 @@ benchmarks:
     main: Main.hs
     dependencies:
       - base
-      - criterion
       - containers
-      - unison-util-relation
       - random
+      - tasty-bench
+      - unison-util-relation
 
 dependencies:
   - base

--- a/lib/unison-util-relation/src/Unison/Util/Relation.hs
+++ b/lib/unison-util-relation/src/Unison/Util/Relation.hs
@@ -515,7 +515,7 @@ r |> t =
 Relation {domain, range} ||> t =
   Relation
     { domain = Map.mapMaybe (`Set.difference1` t) domain,
-      range = Map.restrictKeys range t
+      range = range `Map.withoutKeys` t
     }
 
 -- | Named version of ('||>').
@@ -526,7 +526,7 @@ subtractRan = flip (||>)
 (<||) :: (Ord a, Ord b) => Set a -> Relation a b -> Relation a b
 s <|| Relation {domain, range} =
   Relation
-    { domain = Map.restrictKeys domain s,
+    { domain = domain `Map.withoutKeys` s,
       range = Map.mapMaybe (`Set.difference1` s) range
     }
 

--- a/lib/unison-util-relation/unison-util-relation.cabal
+++ b/lib/unison-util-relation/unison-util-relation.cabal
@@ -1,10 +1,8 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: 04a02074ea0a2e0cf51830a146f4307ac18b44ae4f4803fe67afefba17d51943
 
 name:           unison-util-relation
 version:        0.0.0
@@ -26,7 +24,21 @@ library
       Paths_unison_util_relation
   hs-source-dirs:
       src
-  default-extensions: ApplicativeDo BlockArguments DeriveFunctor DerivingStrategies DoAndIfThenElse FlexibleContexts FlexibleInstances LambdaCase MultiParamTypeClasses NamedFieldPuns ScopedTypeVariables TupleSections TypeApplications ViewPatterns
+  default-extensions:
+      ApplicativeDo
+      BlockArguments
+      DeriveFunctor
+      DerivingStrategies
+      DoAndIfThenElse
+      FlexibleContexts
+      FlexibleInstances
+      LambdaCase
+      MultiParamTypeClasses
+      NamedFieldPuns
+      ScopedTypeVariables
+      TupleSections
+      TypeApplications
+      ViewPatterns
   ghc-options: -Wall
   build-depends:
       base
@@ -43,7 +55,21 @@ test-suite tests
       Paths_unison_util_relation
   hs-source-dirs:
       test
-  default-extensions: ApplicativeDo BlockArguments DeriveFunctor DerivingStrategies DoAndIfThenElse FlexibleContexts FlexibleInstances LambdaCase MultiParamTypeClasses NamedFieldPuns ScopedTypeVariables TupleSections TypeApplications ViewPatterns
+  default-extensions:
+      ApplicativeDo
+      BlockArguments
+      DeriveFunctor
+      DerivingStrategies
+      DoAndIfThenElse
+      FlexibleContexts
+      FlexibleInstances
+      LambdaCase
+      MultiParamTypeClasses
+      NamedFieldPuns
+      ScopedTypeVariables
+      TupleSections
+      TypeApplications
+      ViewPatterns
   ghc-options: -Wall
   build-depends:
       base
@@ -63,7 +89,21 @@ benchmark relation
       Paths_unison_util_relation
   hs-source-dirs:
       benchmarks/relation
-  default-extensions: ApplicativeDo BlockArguments DeriveFunctor DerivingStrategies DoAndIfThenElse FlexibleContexts FlexibleInstances LambdaCase MultiParamTypeClasses NamedFieldPuns ScopedTypeVariables TupleSections TypeApplications ViewPatterns
+  default-extensions:
+      ApplicativeDo
+      BlockArguments
+      DeriveFunctor
+      DerivingStrategies
+      DoAndIfThenElse
+      FlexibleContexts
+      FlexibleInstances
+      LambdaCase
+      MultiParamTypeClasses
+      NamedFieldPuns
+      ScopedTypeVariables
+      TupleSections
+      TypeApplications
+      ViewPatterns
   ghc-options: -Wall
   build-depends:
       base

--- a/lib/unison-util-relation/unison-util-relation.cabal
+++ b/lib/unison-util-relation/unison-util-relation.cabal
@@ -1,8 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
+--
+-- hash: 04a02074ea0a2e0cf51830a146f4307ac18b44ae4f4803fe67afefba17d51943
 
 name:           unison-util-relation
 version:        0.0.0
@@ -24,21 +26,7 @@ library
       Paths_unison_util_relation
   hs-source-dirs:
       src
-  default-extensions:
-      ApplicativeDo
-      BlockArguments
-      DeriveFunctor
-      DerivingStrategies
-      DoAndIfThenElse
-      FlexibleContexts
-      FlexibleInstances
-      LambdaCase
-      MultiParamTypeClasses
-      NamedFieldPuns
-      ScopedTypeVariables
-      TupleSections
-      TypeApplications
-      ViewPatterns
+  default-extensions: ApplicativeDo BlockArguments DeriveFunctor DerivingStrategies DoAndIfThenElse FlexibleContexts FlexibleInstances LambdaCase MultiParamTypeClasses NamedFieldPuns ScopedTypeVariables TupleSections TypeApplications ViewPatterns
   ghc-options: -Wall
   build-depends:
       base
@@ -55,21 +43,7 @@ test-suite tests
       Paths_unison_util_relation
   hs-source-dirs:
       test
-  default-extensions:
-      ApplicativeDo
-      BlockArguments
-      DeriveFunctor
-      DerivingStrategies
-      DoAndIfThenElse
-      FlexibleContexts
-      FlexibleInstances
-      LambdaCase
-      MultiParamTypeClasses
-      NamedFieldPuns
-      ScopedTypeVariables
-      TupleSections
-      TypeApplications
-      ViewPatterns
+  default-extensions: ApplicativeDo BlockArguments DeriveFunctor DerivingStrategies DoAndIfThenElse FlexibleContexts FlexibleInstances LambdaCase MultiParamTypeClasses NamedFieldPuns ScopedTypeVariables TupleSections TypeApplications ViewPatterns
   ghc-options: -Wall
   build-depends:
       base
@@ -89,29 +63,15 @@ benchmark relation
       Paths_unison_util_relation
   hs-source-dirs:
       benchmarks/relation
-  default-extensions:
-      ApplicativeDo
-      BlockArguments
-      DeriveFunctor
-      DerivingStrategies
-      DoAndIfThenElse
-      FlexibleContexts
-      FlexibleInstances
-      LambdaCase
-      MultiParamTypeClasses
-      NamedFieldPuns
-      ScopedTypeVariables
-      TupleSections
-      TypeApplications
-      ViewPatterns
+  default-extensions: ApplicativeDo BlockArguments DeriveFunctor DerivingStrategies DoAndIfThenElse FlexibleContexts FlexibleInstances LambdaCase MultiParamTypeClasses NamedFieldPuns ScopedTypeVariables TupleSections TypeApplications ViewPatterns
   ghc-options: -Wall
   build-depends:
       base
     , containers
-    , criterion
     , deepseq
     , extra
     , random
+    , tasty-bench
     , unison-prelude
     , unison-util-relation
   default-language: Haskell2010


### PR DESCRIPTION
- [x] Depends on #2674 

## Overview

This PR just optimizes `subtractDom` and `subtractRan` in a straightforward way. 

I also swapped out `criterion` for `tasty-bench` in the benchmark suite of `unison-util-relation`, because it's well-maintained, and delivers results much faster than `criterion`, which hard-codes every benchmark to 5s, I believe.

```
      old implementation: OK (0.15s)
         22 ms ± 1.8 ms,  44 MB allocated,  19 MB copied
      new implementation: OK (0.32s)
        5.0 ms ± 247 μs, 6.8 MB allocated, 2.5 MB copied
```