### PR TITLE
Make fzf commands respect relative/absolute paths

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -87,6 +87,7 @@ import Unison.LabeledDependency (LabeledDependency)
 import qualified Unison.LabeledDependency as LD
 import qualified Unison.Lexer as L
 import Unison.Name (Name)
+import Unison.Position (Position(..))
 import qualified Unison.Name as Name
 import Unison.NameSegment (NameSegment (..))
 import qualified Unison.NameSegment as NameSegment
@@ -826,7 +827,7 @@ loop = do
             SwitchBranchI maybePath' -> do
               mpath' <- case maybePath' of
                 Nothing ->
-                  fuzzySelectNamespace root0 <&> \case
+                  fuzzySelectNamespace Absolute root0 <&> \case
                     [] -> Nothing
                     -- Shouldn't be possible to get multiple paths here, we can just take
                     -- the first.
@@ -1019,7 +1020,7 @@ loop = do
             DocsI srcs -> do
               srcs' <- case srcs of
                 [] ->
-                  fuzzySelectTermsAndTypes root0
+                  fuzzySelectDefinition Absolute root0
                     -- HQ names should always parse as a valid split, so we just discard any
                     -- that don't to satisfy the type-checker.
                     <&> mapMaybe (eitherToMaybe . Path.parseHQSplit' . HQ.toString)
@@ -1089,7 +1090,7 @@ loop = do
             DeleteTermI hq -> delete getHQ'Terms (const Set.empty) hq
             DisplayI outputLoc names' -> do
               names <- case names' of
-                [] -> fuzzySelectTermsAndTypes root0
+                [] -> fuzzySelectDefinition Absolute root0
                 ns -> pure ns
               traverse_ (displayI basicPrettyPrintNames outputLoc) names
             ShowDefinitionI outputLoc query -> handleShowDefinition outputLoc query
@@ -1868,7 +1869,7 @@ handleShowDefinition outputLoc inputQuery = do
     if null inputQuery
       then do
         branch <- fuzzyBranch
-        fuzzySelectTermsAndTypes branch
+        fuzzySelectDefinition Relative branch
       else pure inputQuery
   currentPath' <- Path.unabsolute <$> use LoopState.currentPath
   root' <- use LoopState.root
@@ -3321,21 +3322,39 @@ declOrBuiltin r = case r of
   Reference.DerivedId id ->
     fmap DD.Decl <$> eval (LoadType id)
 
-fuzzySelectTermsAndTypes :: Branch0 m -> Action m (Either Event Input) v [HQ.HashQualified Name]
-fuzzySelectTermsAndTypes searchBranch0 = do
+-- | Select a definition from the given branch.
+-- Returned names will match the provided 'Position' type.
+fuzzySelectDefinition :: Position -> Branch0 m -> Action m (Either Event Input) v [HQ.HashQualified Name]
+fuzzySelectDefinition pos searchBranch0 = do
   let termsAndTypes =
         Relation.dom (Names.hashQualifyTermsRelation (Relation.swap $ Branch.deepTerms searchBranch0))
           <> Relation.dom (Names.hashQualifyTypesRelation (Relation.swap $ Branch.deepTypes searchBranch0))
-  fromMaybe [] <$> eval (FuzzySelect Fuzzy.defaultOptions HQ.toText (Set.toList termsAndTypes))
+  let inputs :: [HQ.HashQualified Name]
+      inputs =
+          termsAndTypes
+        & Set.toList
+        & map (fmap (Name.setPosition pos))
+  eval (FuzzySelect Fuzzy.defaultOptions HQ.toText inputs) >>= \case
+    Nothing -> pure []
+    Just results -> pure results
 
-fuzzySelectNamespace :: Branch0 m -> Action m (Either Event Input) v [Path']
-fuzzySelectNamespace searchBranch0 =
-  do
-    fmap Path.toPath'
-    . fromMaybe []
-    <$> eval
-      ( FuzzySelect
-          Fuzzy.defaultOptions {Fuzzy.allowMultiSelect = False}
-          Path.toText
-          (Set.toList $ Branch.deepPaths searchBranch0)
-      )
+-- | Select a namespace from the given branch.
+-- Returned Path's will match the provided 'Position' type.
+fuzzySelectNamespace :: Position -> Branch0 m -> Action m (Either Event Input) v [Path']
+fuzzySelectNamespace pos searchBranch0 = do
+  let intoPath' :: Path -> Path'
+      intoPath' = case pos of
+        Relative -> Path' . Right . Path.Relative
+        Absolute -> Path' . Left . Path.Absolute
+  let inputs :: [Path']
+      inputs =
+          searchBranch0
+        & Branch.deepPaths
+        & Set.toList
+        & map intoPath'
+  fromMaybe [] <$> eval
+                    ( FuzzySelect
+                        Fuzzy.defaultOptions {Fuzzy.allowMultiSelect = False}
+                        tShow
+                        inputs
+                    )

--- a/unison-core/src/Unison/Name.hs
+++ b/unison-core/src/Unison/Name.hs
@@ -218,7 +218,7 @@ joinDot n1@(Name p0 ss0) n2@(Name p1 ss1) =
 --
 -- /O(1)/.
 makeAbsolute :: Name -> Name
-makeAbsolute = setPosition Relative
+makeAbsolute = setPosition Absolute
 
 -- | Make a name relative. No-op if the name is already relative.
 --

--- a/unison-core/src/Unison/Name.hs
+++ b/unison-core/src/Unison/Name.hs
@@ -28,6 +28,7 @@ module Unison.Name
     -- * Basic manipulation
     makeAbsolute,
     makeRelative,
+    setPosition,
     parent,
     stripNamePrefix,
     unqualified,
@@ -67,6 +68,7 @@ import qualified Data.Text.Lazy.Builder as Text.Builder
 import Unison.NameSegment (NameSegment (NameSegment))
 import qualified Unison.NameSegment as NameSegment
 import Unison.Prelude
+import Unison.Position (Position(..))
 import Unison.Util.Alphabetical (Alphabetical, compareAlphabetical)
 import qualified Unison.Util.Relation as R
 import Unison.Var (Var)
@@ -104,12 +106,6 @@ instance Ord Name where
 instance Show Name where
   show =
     Text.unpack . toText
-
--- Whether a name is absolute, e.g. ".foo.bar", or relative, e.g. "foo.bar"
-data Position
-  = Absolute
-  | Relative
-  deriving stock (Eq, Ord, Show)
 
 -- | @compareSuffix x y@ compares the suffix of @y@ (in reverse segment order) that is as long as @x@ to @x@ (in reverse
 -- segment order).
@@ -222,15 +218,22 @@ joinDot n1@(Name p0 ss0) n2@(Name p1 ss1) =
 --
 -- /O(1)/.
 makeAbsolute :: Name -> Name
-makeAbsolute (Name _ ss) =
-  Name Absolute ss
+makeAbsolute = setPosition Relative
 
 -- | Make a name relative. No-op if the name is already relative.
 --
 -- /O(1)/.
 makeRelative :: Name -> Name
-makeRelative (Name _ ss) =
-  Name Relative ss
+makeRelative = setPosition Relative
+
+-- | Overwrite a name's position.
+-- This only changes the name's tag, it performs no manipulations to
+-- the segments of the name.
+--
+-- /O(1)/.
+setPosition :: Position -> Name -> Name
+setPosition pos (Name _ ss) =
+  Name pos ss
 
 -- | Compute the "parent" of a name, unless the name is only a single segment, in which case it has no parent.
 --

--- a/unison-core/src/Unison/Position.hs
+++ b/unison-core/src/Unison/Position.hs
@@ -1,0 +1,10 @@
+module Unison.Position (
+  Position(..)
+  ) where
+
+-- | An indicator of whether something is absolute, e.g. ".foo.bar", or relative, e.g. "foo.bar"
+data Position
+  = Absolute
+  | Relative
+  deriving stock (Eq, Ord, Show)
+

--- a/unison-core/unison-core1.cabal
+++ b/unison-core/unison-core1.cabal
@@ -43,6 +43,7 @@ library
       Unison.NameSegment
       Unison.NamesWithHistory
       Unison.Pattern
+      Unison.Position
       Unison.Reference
       Unison.Reference.Util
       Unison.Referent


### PR DESCRIPTION
## Overview

closes #2679 

Before: 

Running fzf in a sub-namespace should use absolute paths for everything outside of our current namespace.

```ucm
.conway> cd
-- select 'base.List'

  ☝️  The namespace .conway.base.List is empty.

```

After (now we list paths as absolute for cd):

```ucm
.conway> cd
-- select '.base.List'
.base.List>
```


## Implementation notes

Let's the caller to the fuzzy finder specify whether the provided branch is as the current branch (Relative) or whether it's the root (Absolute)

## Interesting/controversial decisions

I find myself talking about relative/absolute a lot, so I pulled the type into `Unison.Position` so we have a single enum for it.


## Test coverage

It's tough to test the fuzzy finder, I functionally tested it.

## Loose ends

Unrelated to this issue, but it seems inelegant to me to always be passing around Branches without knowing whether they should be displayed relative or absolute, seems like we should come up with some sort of tag for that; or maybe make a type which pairs branches with their path? Something like that.