### PR TITLE
Improve error messaging for missing fzf command

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -62,6 +62,7 @@ import qualified Unison.Util.Pretty as P
 import Unison.Util.Relation (Relation)
 import qualified Unison.WatchKind as WK
 import Data.Set.NonEmpty (NESet)
+import qualified Unison.CommandLine.InputPattern as Input
 
 type ListDetailed = Bool
 
@@ -231,12 +232,12 @@ data Output v
   | BadRootBranch GetRootBranchError
   | CouldntLoadBranch Branch.Hash
   | NamespaceEmpty (Either Path.Absolute (Path.Absolute, Path.Absolute))
+  | HelpMessage Input.InputPattern
   | NoOp
   | -- Refused to push, either because a `push` targeted an empty namespace, or a `push.create` targeted a non-empty namespace.
     RefusedToPush PushBehavior
   | -- | @GistCreated repo hash@ means causal @hash@ was just published to @repo@.
     GistCreated Int WriteRepo Branch.Hash
-  deriving (Show)
 
 data ReflogEntry = ReflogEntry {hash :: ShortBranchHash, reason :: Text}
   deriving (Show)
@@ -350,6 +351,7 @@ isFailure o = case o of
   ShowReflog {} -> False
   LoadPullRequest {} -> False
   DefaultMetadataNotification -> False
+  HelpMessage{} -> True
   NoOp -> False
   ListDependencies {} -> False
   ListDependents {} -> False

--- a/unison-cli/src/Unison/CommandLine/FuzzySelect.hs
+++ b/unison-cli/src/Unison/CommandLine/FuzzySelect.hs
@@ -66,7 +66,7 @@ fuzzySelect opts intoSearchText choices =
     . restoreBuffering
     . runExceptT $ do
     fzfPath <- liftIO (findExecutable "fzf") >>= \case
-      Nothing -> throwError "fzf not found. Consider installing fzf to improve your experience with unison."
+      Nothing -> throwError "I couldn't find the `fzf` executable on your path, consider installing `fzf` to enable fuzzy searching."
       Just fzfPath -> pure fzfPath
     let fzfArgs :: [String]
           = optsToArgs opts

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -300,7 +300,11 @@ view =
     "view"
     []
     [(ZeroPlus, definitionQueryArg)]
-    "`view foo` prints the definition of `foo`."
+    ( P.lines
+        [ "`view foo` prints the definition of `foo`.",
+          "`view` without arguments invokes a search to select definitions to view. `fzf` must be found on your PATH."
+        ]
+    )
     ( fmap (Input.ShowDefinitionI Input.ConsoleLocation)
         . traverse parseHashQualifiedName
     )
@@ -311,7 +315,11 @@ display =
     "display"
     []
     [(ZeroPlus, definitionQueryArg)]
-    "`display foo` prints a rendered version of the term `foo`."
+    ( P.lines
+        [ "`display foo` prints a rendered version of the term `foo`.",
+          "`display` without arguments invokes a search to select a definition to display. `fzf` must be found on your PATH."
+        ]
+    )
     ( \xs -> Input.DisplayI Input.ConsoleLocation <$> (traverse parseHashQualifiedName xs)
     )
 
@@ -337,7 +345,11 @@ docs =
     "docs"
     []
     [(ZeroPlus, definitionQueryArg)]
-    "`docs foo` shows documentation for the definition `foo`."
+    ( P.lines
+        [ "`docs foo` shows documentation for the definition `foo`.",
+          "`docs` without arguments invokes a search to select which definition to view documentation for. `fzf` must be found on your PATH."
+        ]
+    )
     (bimap fromString Input.DocsI . traverse Path.parseHQSplit')
 
 ui :: InputPattern
@@ -669,13 +681,22 @@ cd =
     "namespace"
     ["cd", "j"]
     [(Required, namespaceArg)]
-    ( P.wrapColumn2
-        [ ( makeExample cd ["foo.bar"],
-            "descends into foo.bar from the current namespace."
-          ),
-          ( makeExample cd [".cat.dog"],
-            "sets the current namespace to the abolute namespace .cat.dog."
-          )
+    ( P.lines
+        [ "Moves your perspective to a different namespace.",
+          P.wrapColumn2
+            [ ( makeExample cd ["foo.bar"],
+                "descends into foo.bar from the current namespace."
+              ),
+              ( makeExample cd [".cat.dog"],
+                "sets the current namespace to the abolute namespace .cat.dog."
+              ),
+              ( makeExample cd [".."],
+                "moves to the parent of the current namespace. E.g. moves from '.cat.dog' to '.cat'"
+              ),
+              ( makeExample cd [],
+                "invokes a search to select which namespace to move to. `fzf` must be found on your PATH."
+              )
+            ]
         ]
     )
     ( \case
@@ -1311,8 +1332,11 @@ edit =
     "edit"
     []
     [(OnePlus, definitionQueryArg)]
-    ( "`edit foo` prepends the definition of `foo` to the top of the most "
-        <> "recently saved file."
+    ( P.lines
+        [ "`edit foo` prepends the definition of `foo` to the top of the most "
+            <> "recently saved file.",
+          "`edit` without arguments invokes a search to select a definition for editing. `fzf` must be found on your PATH."
+        ]
     )
     ( fmap (Input.ShowDefinitionI Input.LatestFileLocation)
         . traverse parseHashQualifiedName

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -302,7 +302,7 @@ view =
     [(ZeroPlus, definitionQueryArg)]
     ( P.lines
         [ "`view foo` prints the definition of `foo`.",
-          "`view` without arguments invokes a search to select definitions to view. `fzf` must be found on your PATH."
+          "`view` without arguments invokes a search to select definitions to view, which requires that `fzf` can be found within your PATH."
         ]
     )
     ( fmap (Input.ShowDefinitionI Input.ConsoleLocation)
@@ -317,7 +317,7 @@ display =
     [(ZeroPlus, definitionQueryArg)]
     ( P.lines
         [ "`display foo` prints a rendered version of the term `foo`.",
-          "`display` without arguments invokes a search to select a definition to display. `fzf` must be found on your PATH."
+          "`display` without arguments invokes a search to select a definition to display, which requires that `fzf` can be found within your PATH."
         ]
     )
     ( \xs -> Input.DisplayI Input.ConsoleLocation <$> (traverse parseHashQualifiedName xs)
@@ -347,7 +347,7 @@ docs =
     [(ZeroPlus, definitionQueryArg)]
     ( P.lines
         [ "`docs foo` shows documentation for the definition `foo`.",
-          "`docs` without arguments invokes a search to select which definition to view documentation for. `fzf` must be found on your PATH."
+          "`docs` without arguments invokes a search to select which definition to view documentation for, which requires that `fzf` can be found within your PATH."
         ]
     )
     (bimap fromString Input.DocsI . traverse Path.parseHQSplit')
@@ -695,7 +695,7 @@ cd =
                 "moves to the parent of the current namespace. E.g. moves from '.cat.dog' to '.cat'"
               ),
               ( makeExample cd [],
-                "invokes a search to select which namespace to move to. `fzf` must be found on your PATH."
+                "invokes a search to select which namespace to move to, which requires that `fzf` can be found within your PATH."
               )
             ]
         ]
@@ -1336,7 +1336,7 @@ edit =
     ( P.lines
         [ "`edit foo` prepends the definition of `foo` to the top of the most "
             <> "recently saved file.",
-          "`edit` without arguments invokes a search to select a definition for editing. `fzf` must be found on your PATH."
+          "`edit` without arguments invokes a search to select a definition for editing, which requires that `fzf` can be found within your PATH."
         ]
     )
     ( fmap (Input.ShowDefinitionI Input.LatestFileLocation)

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -683,6 +683,7 @@ cd =
     [(Required, namespaceArg)]
     ( P.lines
         [ "Moves your perspective to a different namespace.",
+          "",
           P.wrapColumn2
             [ ( makeExample cd ["foo.bar"],
                 "descends into foo.bar from the current namespace."

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1291,6 +1291,7 @@ notifyUser dir o = case o of
   DumpNumberedArgs args -> pure . P.numberedList $ fmap P.string args
   NoConflictsOrEdits ->
     pure (P.okCallout "No conflicts or edits in progress.")
+  HelpMessage pat -> pure $ IP.showPatternHelp pat
   NoOp -> pure $ P.string "I didn't make any changes."
   DefaultMetadataNotification -> pure $ P.wrap "I added some default metadata."
   DumpBitBooster head map ->


### PR DESCRIPTION
## Overview

Some folks requested better error handling for fzf commands lately.

If `fzf` is missing from the user's path and they run a command which would invoke it, we should inform them of the problem, and also print the help message of the command.

Example outputs:

```
.> view
I couldn't find the `fzf` executable on your path, consider installing `fzf` to enable fuzzy searching.

  view
  `view foo` prints the definition of `foo`. `view` without arguments invokes a search to select
  definitions to view, which requires that `fzf` can be found within your PATH.

.> cd
I couldn't find the `fzf` executable on your path, consider installing `fzf` to enable fuzzy searching.

  namespace (or cd, j)
  Moves your perspective to a different namespace.
  `namespace foo.bar`   descends into foo.bar from the current namespace.
  `namespace .cat.dog`  sets the current namespace to the abolute namespace .cat.dog.
  `namespace ..`        moves to the parent of the current namespace. E.g. moves from '.cat.dog' to
                        '.cat'
  `namespace`           invokes a search to select which namespace to move to, which requires that
                        `fzf` can be found within your PATH.

.> display
I couldn't find the `fzf` executable on your path, consider installing `fzf` to enable fuzzy searching.

  `display foo` prints a rendered version of the term `foo`. `display` without arguments invokes a
  search to select a definition to display, which requires that `fzf` can be found within your
  PATH.
```

## Implementation notes

* Adds a new Output for printing the help message of a given input pattern.
* Prints the appropriate help message if FZF fails due to missing executable.