### PR TITLE
pull.without-history - smaller pulls

### DIFF
--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -74,6 +74,7 @@ module Unison.Codebase
     -- ** Remote sync
     viewRemoteBranch,
     importRemoteBranch,
+    Preprocessing(..),
     pushGitBranch,
     PushGitBranchOpts (..),
 
@@ -332,6 +333,12 @@ isBlank codebase = do
 
 -- * Git stuff
 
+-- | An optional preprocessing step to run on branches
+-- before they're imported into the local codebase.
+data Preprocessing m
+  = Unmodified
+  | Preprocessed (Branch m -> m (Branch m))
+
 -- | Sync elements as needed from a remote codebase into the local one.
 -- If `sbh` is supplied, we try to load the specified branch hash;
 -- otherwise we try to load the root branch.
@@ -341,12 +348,12 @@ importRemoteBranch ::
   Codebase m v a ->
   ReadRemoteNamespace ->
   SyncMode ->
-  (Branch m -> m (Branch m)) ->
+  Preprocessing m ->
   m (Either GitError (Branch m))
 importRemoteBranch codebase ns mode preprocess = runExceptT $ do
   branchHash <- ExceptT . viewRemoteBranch' codebase ns $ \(branch, cacheDir) -> do
          withStatus "Importing downloaded files into local codebase..." $ do
-           branch <- preprocess branch
+           branch <- preprocessOp branch
            time "SyncFromDirectory" $
              syncFromDirectory codebase cacheDir mode branch
          pure $ Branch.headHash branch
@@ -354,6 +361,11 @@ importRemoteBranch codebase ns mode preprocess = runExceptT $ do
     lift (getBranchForHash codebase branchHash) >>= \case
       Nothing -> throwE . GitCodebaseError $ GitError.CouldntLoadSyncedBranch ns branchHash
       Just result -> pure $ result
+  where
+    preprocessOp :: Branch m -> m (Branch m)
+    preprocessOp = case preprocess of
+      Preprocessed f -> f
+      Unmodified -> pure
 
 -- | Pull a git branch and view it from the cache, without syncing into the
 -- local codebase.

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -345,8 +345,8 @@ importRemoteBranch ::
   m (Either GitError (Branch m))
 importRemoteBranch codebase ns mode preprocess = runExceptT $ do
   branchHash <- ExceptT . viewRemoteBranch' codebase ns $ \(branch, cacheDir) -> do
-         branch <- preprocess branch
          withStatus "Importing downloaded files into local codebase..." $ do
+           branch <- preprocess branch
            time "SyncFromDirectory" $
              syncFromDirectory codebase cacheDir mode branch
          pure $ Branch.headHash branch

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -341,10 +341,12 @@ importRemoteBranch ::
   Codebase m v a ->
   ReadRemoteNamespace ->
   SyncMode ->
+  (Branch m -> m (Branch m)) ->
   m (Either GitError (Branch m))
-importRemoteBranch codebase ns mode = runExceptT $ do
+importRemoteBranch codebase ns mode preprocess = runExceptT $ do
   branchHash <- ExceptT . viewRemoteBranch' codebase ns $ \(branch, cacheDir) -> do
-         withStatus "Importing downloaded files into local codebase..." $
+         branch <- preprocess branch
+         withStatus "Importing downloaded files into local codebase..." $ do
            time "SyncFromDirectory" $
              syncFromDirectory codebase cacheDir mode branch
          pure $ Branch.headHash branch

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -78,7 +78,7 @@ module Unison.Codebase.Branch
   , Cache
   , sync
 
-  , consSnapshot
+  , consBranchSnapshot
   ) where
 
 import Unison.Prelude hiding (empty)
@@ -548,7 +548,7 @@ stepManyAt actions startBranch =
 stepManyAtM :: (Monad m, Monad n, Foldable f)
             => f (Path, Branch0 m -> n (Branch0 m)) -> Branch m -> n (Branch m)
 stepManyAtM actions startBranch =
-  (\changes -> startBranch `consSnapshot` changes) <$> (startBranch & head_ %%~ batchUpdatesM actions)
+  (\changes -> startBranch `consBranchSnapshot` changes) <$> (startBranch & head_ %%~ batchUpdatesM actions)
 
 -- starting at the leaves, apply `f` to every level of the branch.
 stepEverywhere
@@ -772,20 +772,20 @@ children0 :: IndexedTraversal' NameSegment (Branch0 m) (Branch0 m)
 children0 = children .> itraversed <. (history . Causal.head_)
 
 
--- | @base `consSnapshot` head@ Cons's the current state of @head@ onto @base@ as-is.
+-- | @base `consBranchSnapshot` head@ Cons's the current state of @head@ onto @base@ as-is.
 -- Consider whether you really want this behaviour or the behaviour of 'Causal.squashMerge'
 -- That is, it does not perform any common ancestor detection, or change reconciliation, it
 -- sets the current state of the base branch to the new state as a new causal step (or returns
 -- the existing base if there are no)
-consSnapshot ::
+consBranchSnapshot ::
   forall m.
   Monad m =>
   Branch m ->
   Branch m ->
   Branch m
 -- If the target branch is empty we just replace it.
-consSnapshot Empty headBranch = discardHistory headBranch
-consSnapshot baseBranch headBranch =
+consBranchSnapshot Empty headBranch = discardHistory headBranch
+consBranchSnapshot baseBranch headBranch =
   Branch $
     Causal.consDistinct
       (head headBranch & children .~ combinedChildren)
@@ -795,9 +795,9 @@ consSnapshot baseBranch headBranch =
     combineChildren = \case
       -- If we have a matching child in both base and head, squash the child head onto the
       -- child base recursively.
-      (These base head) -> base `consSnapshot` head
+      (These base head) -> base `consBranchSnapshot` head
       -- This child has been deleted, recursively replace children with an empty branch.
-      (This base) -> base `consSnapshot` empty
+      (This base) -> base `consBranchSnapshot` empty
       -- This child didn't exist in the base, we add any changes as a single commit
       (That head) -> discardHistory head
     combinedChildren :: Map NameSegment (Branch m)

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -77,6 +77,8 @@ module Unison.Codebase.Branch
   , cachedRead
   , Cache
   , sync
+
+  , consBranch
   ) where
 
 import Unison.Prelude hiding (empty)

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -78,7 +78,7 @@ module Unison.Codebase.Branch
   , Cache
   , sync
 
-  , consBranch
+  , consSnapshot
   ) where
 
 import Unison.Prelude hiding (empty)
@@ -548,7 +548,7 @@ stepManyAt actions startBranch =
 stepManyAtM :: (Monad m, Monad n, Foldable f)
             => f (Path, Branch0 m -> n (Branch0 m)) -> Branch m -> n (Branch m)
 stepManyAtM actions startBranch =
-  (\changes -> startBranch `consBranch` changes) <$> (startBranch & head_ %%~ batchUpdatesM actions)
+  (\changes -> startBranch `consSnapshot` changes) <$> (startBranch & head_ %%~ batchUpdatesM actions)
 
 -- starting at the leaves, apply `f` to every level of the branch.
 stepEverywhere
@@ -772,20 +772,20 @@ children0 :: IndexedTraversal' NameSegment (Branch0 m) (Branch0 m)
 children0 = children .> itraversed <. (history . Causal.head_)
 
 
--- | @base `consBranch` head@ Cons's the current state of @head@ onto @base@ as-is.
+-- | @base `consSnapshot` head@ Cons's the current state of @head@ onto @base@ as-is.
 -- Consider whether you really want this behaviour or the behaviour of 'Causal.squashMerge'
 -- That is, it does not perform any common ancestor detection, or change reconciliation, it
 -- sets the current state of the base branch to the new state as a new causal step (or returns
 -- the existing base if there are no)
-consBranch ::
+consSnapshot ::
   forall m.
   Monad m =>
   Branch m ->
   Branch m ->
   Branch m
 -- If the target branch is empty we just replace it.
-consBranch Empty headBranch = discardHistory headBranch
-consBranch baseBranch headBranch =
+consSnapshot Empty headBranch = discardHistory headBranch
+consSnapshot baseBranch headBranch =
   Branch $
     Causal.consDistinct
       (head headBranch & children .~ combinedChildren)
@@ -795,9 +795,9 @@ consBranch baseBranch headBranch =
     combineChildren = \case
       -- If we have a matching child in both base and head, squash the child head onto the
       -- child base recursively.
-      (These base head) -> base `consBranch` head
+      (These base head) -> base `consSnapshot` head
       -- This child has been deleted, recursively replace children with an empty branch.
-      (This base) -> base `consBranch` empty
+      (This base) -> base `consSnapshot` empty
       -- This child didn't exist in the base, we add any changes as a single commit
       (That head) -> discardHistory head
     combinedChildren :: Map NameSegment (Branch m)

--- a/unison-cli/src/Unison/Codebase/Editor/Command.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Command.hs
@@ -53,7 +53,7 @@ import qualified Unison.Lexer                  as L
 import qualified Unison.Parser                 as Parser
 import           Unison.ShortHash               ( ShortHash )
 import           Unison.Type                    ( Type )
-import           Unison.Codebase (PushGitBranchOpts)
+import           Unison.Codebase (PushGitBranchOpts, Preprocessing)
 import           Unison.Codebase.ShortBranchHash
                                                 ( ShortBranchHash )
 import Unison.Codebase.Editor.AuthorInfo (AuthorInfo)
@@ -213,7 +213,7 @@ data Command
     -- | A preprocessing step to perform on the branch before it's imported.
     -- This is sometimes useful for minimizing the number of definitions to sync.
     -- Simply pass 'pure' if you don't need to do any pre-processing.
-    (Branch m -> m (Branch m)) ->
+    Preprocessing m ->
     Command m i v (Either GitError (Branch m))
 
   -- Syncs the Branch to some codebase and updates the head to the head of this causal.

--- a/unison-cli/src/Unison/Codebase/Editor/Command.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Command.hs
@@ -208,7 +208,13 @@ data Command
   -- of the `RemoteNamespace`.  The Branch that's returned should be fully
   -- imported and not retain any resources from the remote codebase
   ImportRemoteBranch ::
-    ReadRemoteNamespace -> SyncMode -> Command m i v (Either GitError (Branch m))
+    ReadRemoteNamespace ->
+    SyncMode ->
+    -- | A preprocessing step to perform on the branch before it's imported.
+    -- This is sometimes useful for minimizing the number of definitions to sync.
+    -- Simply pass 'pure' if you don't need to do any pre-processing.
+    (Branch m -> m (Branch m)) ->
+    Command m i v (Either GitError (Branch m))
 
   -- Syncs the Branch to some codebase and updates the head to the head of this causal.
   -- Any definitions in the head of the supplied branch that aren't in the target

--- a/unison-cli/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -147,8 +147,8 @@ commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSour
       -- abstraction.
       toIO <- UnliftIO.askRunInIO
       lift $ Codebase.viewRemoteBranch codebase ns (toIO . Free.fold go . action)
-    ImportRemoteBranch ns syncMode ->
-      lift $ Codebase.importRemoteBranch codebase ns syncMode
+    ImportRemoteBranch ns syncMode preprocess ->
+      lift $ Codebase.importRemoteBranch codebase ns syncMode preprocess
     SyncRemoteBranch branch repo opts ->
       lift $ Codebase.pushGitBranch codebase branch repo opts
     LoadTerm r -> lift $ Codebase.getTerm codebase r

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1684,7 +1684,7 @@ loop = do
                   Input.PullWithoutHistory -> do
                     didUpdate <- updateAtM
                                    destAbs
-                                   (\destBranch -> pure $ destBranch `Branch.consBranchSnapshot` remoteBranch)
+                                   (\destBranch -> pure $ remoteBranch `Branch.consBranchSnapshot` destBranch )
                     if didUpdate
                        then respond $ PullSuccessful ns path
                        else respond unchangedMsg

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -32,7 +32,7 @@ import qualified Unison.ABT as ABT
 import qualified Unison.Builtin as Builtin
 import qualified Unison.Builtin.Decls as DD
 import qualified Unison.Builtin.Terms as Builtin
-import Unison.Codebase (PushGitBranchOpts (..))
+import Unison.Codebase (PushGitBranchOpts (..), Preprocessing (..))
 import Unison.Codebase.Branch (Branch (..), Branch0 (..))
 import qualified Unison.Codebase.Branch as Branch
 import qualified Unison.Codebase.Branch.Merge as Branch
@@ -732,8 +732,8 @@ loop = do
               destb <- getAt desta
               if Branch.isEmpty0 (Branch.head destb)
                 then unlessGitError do
-                  baseb <- importRemoteBranch baseRepo SyncMode.ShortCircuit pure
-                  headb <- importRemoteBranch headRepo SyncMode.ShortCircuit pure
+                  baseb <- importRemoteBranch baseRepo SyncMode.ShortCircuit Unmodified
+                  headb <- importRemoteBranch headRepo SyncMode.ShortCircuit Unmodified
                   lift $ do
                     mergedb <- eval $ Merge Branch.RegularMerge baseb headb
                     squashedb <- eval $ Merge Branch.SquashMerge headb baseb
@@ -1664,8 +1664,8 @@ loop = do
               respond $ ListEdits patch ppe
             PullRemoteBranchI mayRepo path syncMode pullMode verbosity -> unlessError do
               let preprocess = case pullMode of
-                    Input.PullWithHistory -> pure
-                    Input.PullWithoutHistory -> pure . Branch.discardHistory
+                    Input.PullWithHistory -> Unmodified
+                    Input.PullWithoutHistory -> Preprocessed $ pure . Branch.discardHistory
               ns <- maybe (writePathToRead <$> resolveConfiguredGitUrl Pull path) pure mayRepo
               lift $ unlessGitError do
                 remoteBranch <- importRemoteBranch ns syncMode preprocess

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1684,7 +1684,7 @@ loop = do
                   Input.PullWithoutHistory -> do
                     didUpdate <- updateAtM
                                    destAbs
-                                   (\destBranch -> pure $ destBranch `Branch.consSnapshot` remoteBranch)
+                                   (\destBranch -> pure $ destBranch `Branch.consBranchSnapshot` remoteBranch)
                     if didUpdate
                        then respond $ PullSuccessful ns path
                        else respond unchangedMsg

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -149,6 +149,7 @@ import Unison.Util.Free (Free)
 import UnliftIO (MonadUnliftIO)
 import qualified Data.Set.NonEmpty as NESet
 import Data.Set.NonEmpty (NESet)
+import qualified Unison.Codebase.Editor.Input as Input
 
 defaultPatchNameSegment :: NameSegment
 defaultPatchNameSegment = "patch"
@@ -389,8 +390,12 @@ loop = do
             MergeIOBuiltinsI -> "builtins.mergeio"
             MakeStandaloneI out nm ->
               "compile.output " <> Text.pack out <> " " <> HQ.toText nm
-            PullRemoteBranchI orepo dest _syncMode _ ->
-              (Text.pack . InputPattern.patternName $ InputPatterns.pull)
+            PullRemoteBranchI orepo dest _syncMode pullMode _ ->
+              (Text.pack . InputPattern.patternName $
+                case pullMode of
+                  PullWithoutHistory -> InputPatterns.pullWithoutHistory
+                  PullWithHistory -> InputPatterns.pull
+              )
                 <> " "
                 -- todo: show the actual config-loaded namespace
                 <> maybe
@@ -468,7 +473,8 @@ loop = do
           syncRoot = use LoopState.root >>= updateRoot
           updateAtM = Unison.Codebase.Editor.HandleInput.updateAtM inputDescription
           unlessGitError = unlessError' Output.GitError
-          importRemoteBranch ns mode = ExceptT . eval $ ImportRemoteBranch ns mode
+          importRemoteBranch ns mode preprocess =
+            ExceptT . eval $ ImportRemoteBranch ns mode preprocess
           loadSearchResults = eval . LoadSearchResults
           saveAndApplyPatch patchPath'' patchName patch' = do
             stepAtM
@@ -726,8 +732,8 @@ loop = do
               destb <- getAt desta
               if Branch.isEmpty0 (Branch.head destb)
                 then unlessGitError do
-                  baseb <- importRemoteBranch baseRepo SyncMode.ShortCircuit
-                  headb <- importRemoteBranch headRepo SyncMode.ShortCircuit
+                  baseb <- importRemoteBranch baseRepo SyncMode.ShortCircuit pure
+                  headb <- importRemoteBranch headRepo SyncMode.ShortCircuit pure
                   lift $ do
                     mergedb <- eval $ Merge Branch.RegularMerge baseb headb
                     squashedb <- eval $ Merge Branch.SquashMerge headb baseb
@@ -1656,14 +1662,31 @@ loop = do
                 suffixifiedPPE
                   =<< makePrintNamesFromLabeled' (Patch.labeledDependencies patch)
               respond $ ListEdits patch ppe
-            PullRemoteBranchI mayRepo path syncMode verbosity -> unlessError do
+            PullRemoteBranchI mayRepo path syncMode pullMode verbosity -> unlessError do
+              let preprocess = case pullMode of
+                    Input.PullWithHistory -> pure -- Pull the whole branch
+                    Input.PullWithoutHistory -> pure . Branch.discardHistory
               ns <- maybe (writePathToRead <$> resolveConfiguredGitUrl Pull path) pure mayRepo
               lift $ unlessGitError do
-                b <- importRemoteBranch ns syncMode
-                let msg = Just $ PullAlreadyUpToDate ns path
+                remoteBranch <- importRemoteBranch ns syncMode preprocess
+                let unchangedMsg = PullAlreadyUpToDate ns path
                 let destAbs = resolveToAbsolute path
                 let printDiffPath = if Verbosity.isSilent verbosity then Nothing else Just path
-                lift $ mergeBranchAndPropagateDefaultPatch Branch.RegularMerge inputDescription msg b printDiffPath destAbs
+                case pullMode of
+                  Input.PullWithHistory -> do
+                    lift $ mergeBranchAndPropagateDefaultPatch
+                             Branch.RegularMerge
+                             inputDescription
+                             (Just unchangedMsg)
+                             remoteBranch
+                             printDiffPath
+                             destAbs
+                  Input.PullWithoutHistory -> lift $ do
+                    didUpdate <- updateAtM destAbs (\destBranch -> pure $ destBranch `Branch.consBranch` remoteBranch)
+                    if didUpdate
+                       then respond $ PullSuccessful ns path
+                       else respond unchangedMsg
+
             PushRemoteBranchI mayRepo path pushBehavior syncMode -> handlePushRemoteBranch mayRepo path pushBehavior syncMode
             ListDependentsI hq -> handleDependents hq
             ListDependenciesI hq ->

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -1,4 +1,3 @@
-{- ORMOLU_DISABLE -} -- Remove this when the file is ready to be auto-formatted
 module Unison.Codebase.Editor.Input
   ( Input (..),
     GistInput (..),
@@ -33,6 +32,8 @@ import Unison.NameSegment (NameSegment)
 import Unison.Prelude
 import Unison.ShortHash (ShortHash)
 import qualified Unison.Util.Pretty as P
+
+{- ORMOLU_DISABLE -} -- Remove this when the file is ready to be auto-formatted
 
 data Event
   = UnisonFileChanged SourceName Source

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -1,3 +1,4 @@
+{- ORMOLU_DISABLE -} -- Remove this when the file is ready to be auto-formatted
 module Unison.Codebase.Editor.Input
   ( Input (..),
     GistInput (..),
@@ -38,15 +39,10 @@ data Event
   | IncomingRootBranch (Set Branch.Hash)
 
 type Source = Text -- "id x = x\nconst a b = a"
-
 type SourceName = Text -- "foo.u" or "buffer 7"
-
 type PatchPath = Path.Split'
-
 type BranchId = Either ShortBranchHash Path'
-
 type AbsBranchId = Either ShortBranchHash Path.Absolute
-
 type HashOrHQSplit' = Either ShortHash Path.HQSplit'
 
 -- | Should we force the operation or not?
@@ -54,7 +50,7 @@ data Insistence = Force | Try
   deriving (Show, Eq)
 
 parseBranchId :: String -> Either String BranchId
-parseBranchId ('#' : s) = case SBH.fromText (Text.pack s) of
+parseBranchId ('#':s) = case SBH.fromText (Text.pack s) of
   Nothing -> Left "Invalid hash, expected a base32hex string."
   Just h -> pure $ Left h
 parseBranchId s = Right <$> Path.parsePath' s
@@ -65,118 +61,118 @@ data PullMode
   deriving (Eq, Show)
 
 data Input
-  = -- names stuff:
+  -- names stuff:
     -- directory ops
     -- `Link` must describe a repo and a source path within that repo.
     -- clone w/o merge, error if would clobber
-    ForkLocalBranchI (Either ShortBranchHash Path') Path'
-  | -- merge first causal into destination
-    MergeLocalBranchI Path' Path' Branch.MergeMode
-  | PreviewMergeLocalBranchI Path' Path'
-  | DiffNamespaceI BranchId BranchId -- old new
-  | PullRemoteBranchI (Maybe ReadRemoteNamespace) Path' SyncMode PullMode Verbosity
-  | PushRemoteBranchI (Maybe WriteRemotePath) Path' PushBehavior SyncMode
-  | CreatePullRequestI ReadRemoteNamespace ReadRemoteNamespace
-  | LoadPullRequestI ReadRemoteNamespace ReadRemoteNamespace Path'
-  | ResetRootI (Either ShortBranchHash Path')
-  | -- todo: Q: Does it make sense to publish to not-the-root of a Github repo?
+    = ForkLocalBranchI (Either ShortBranchHash Path') Path'
+    -- merge first causal into destination
+    | MergeLocalBranchI Path' Path' Branch.MergeMode
+    | PreviewMergeLocalBranchI Path' Path'
+    | DiffNamespaceI BranchId BranchId -- old new
+    | PullRemoteBranchI (Maybe ReadRemoteNamespace) Path' SyncMode PullMode Verbosity
+    | PushRemoteBranchI (Maybe WriteRemotePath) Path' PushBehavior SyncMode
+    | CreatePullRequestI ReadRemoteNamespace ReadRemoteNamespace
+    | LoadPullRequestI ReadRemoteNamespace ReadRemoteNamespace Path'
+    | ResetRootI (Either ShortBranchHash Path')
+    -- todo: Q: Does it make sense to publish to not-the-root of a Github repo?
     --          Does it make sense to fork from not-the-root of a Github repo?
     -- used in Welcome module to give directions to user
-    CreateMessage (P.Pretty P.ColorText)
-  | -- Change directory. If Nothing is provided, prompt an interactive fuzzy search.
-    SwitchBranchI (Maybe Path')
-  | UpI
-  | PopBranchI
-  | -- > names foo
+    | CreateMessage (P.Pretty P.ColorText)
+    -- Change directory. If Nothing is provided, prompt an interactive fuzzy search.
+    | SwitchBranchI (Maybe Path')
+    | UpI
+    | PopBranchI
+    -- > names foo
     -- > names foo.bar
     -- > names .foo.bar
     -- > names .foo.bar#asdflkjsdf
     -- > names #sdflkjsdfhsdf
-    NamesI (HQ.HashQualified Name)
-  | AliasTermI HashOrHQSplit' Path.Split'
-  | AliasTypeI HashOrHQSplit' Path.Split'
-  | AliasManyI [Path.HQSplit] Path'
-  | -- Move = Rename; It's an HQSplit' not an HQSplit', meaning the arg has to have a name.
-    MoveTermI Path.HQSplit' Path.Split'
-  | MoveTypeI Path.HQSplit' Path.Split'
-  | MoveBranchI (Maybe Path.Split') Path.Split'
-  | MovePatchI Path.Split' Path.Split'
-  | CopyPatchI Path.Split' Path.Split'
-  | -- delete = unname
-    DeleteI Path.HQSplit'
-  | DeleteTermI Path.HQSplit'
-  | DeleteTypeI Path.HQSplit'
-  | DeleteBranchI Insistence (Maybe Path.Split')
-  | DeletePatchI Path.Split'
-  | -- resolving naming conflicts within `branchpath`
-    -- Add the specified name after deleting all others for a given reference
-    -- within a given branch.
-    ResolveTermNameI Path.HQSplit'
-  | ResolveTypeNameI Path.HQSplit'
-  | -- edits stuff:
-    LoadI (Maybe FilePath)
-  | AddI [HQ'.HashQualified Name]
-  | PreviewAddI [HQ'.HashQualified Name]
-  | UpdateI (Maybe PatchPath) [HQ'.HashQualified Name]
-  | PreviewUpdateI [HQ'.HashQualified Name]
-  | TodoI (Maybe PatchPath) Path'
-  | PropagatePatchI PatchPath Path'
-  | ListEditsI (Maybe PatchPath)
-  | -- -- create and remove update directives
-    DeprecateTermI PatchPath Path.HQSplit'
-  | DeprecateTypeI PatchPath Path.HQSplit'
-  | ReplaceI (HQ.HashQualified Name) (HQ.HashQualified Name) (Maybe PatchPath)
-  | RemoveTermReplacementI (HQ.HashQualified Name) (Maybe PatchPath)
-  | RemoveTypeReplacementI (HQ.HashQualified Name) (Maybe PatchPath)
-  | UndoI
-  | -- First `Maybe Int` is cap on number of results, if any
+    | NamesI (HQ.HashQualified Name)
+    | AliasTermI HashOrHQSplit' Path.Split'
+    | AliasTypeI HashOrHQSplit' Path.Split'
+    | AliasManyI [Path.HQSplit] Path'
+    -- Move = Rename; It's an HQSplit' not an HQSplit', meaning the arg has to have a name.
+    | MoveTermI Path.HQSplit' Path.Split'
+    | MoveTypeI Path.HQSplit' Path.Split'
+    | MoveBranchI (Maybe Path.Split') Path.Split'
+    | MovePatchI Path.Split' Path.Split'
+    | CopyPatchI Path.Split' Path.Split'
+    -- delete = unname
+    | DeleteI Path.HQSplit'
+    | DeleteTermI Path.HQSplit'
+    | DeleteTypeI Path.HQSplit'
+    | DeleteBranchI Insistence (Maybe Path.Split')
+    | DeletePatchI Path.Split'
+    -- resolving naming conflicts within `branchpath`
+      -- Add the specified name after deleting all others for a given reference
+      -- within a given branch.
+    | ResolveTermNameI Path.HQSplit'
+    | ResolveTypeNameI Path.HQSplit'
+  -- edits stuff:
+    | LoadI (Maybe FilePath)
+    | AddI [HQ'.HashQualified Name]
+    | PreviewAddI [HQ'.HashQualified Name]
+    | UpdateI (Maybe PatchPath) [HQ'.HashQualified Name]
+    | PreviewUpdateI [HQ'.HashQualified Name]
+    | TodoI (Maybe PatchPath) Path'
+    | PropagatePatchI PatchPath Path'
+    | ListEditsI (Maybe PatchPath)
+    -- -- create and remove update directives
+    | DeprecateTermI PatchPath Path.HQSplit'
+    | DeprecateTypeI PatchPath Path.HQSplit'
+    | ReplaceI (HQ.HashQualified Name) (HQ.HashQualified Name) (Maybe PatchPath)
+    | RemoveTermReplacementI (HQ.HashQualified Name) (Maybe PatchPath)
+    | RemoveTypeReplacementI (HQ.HashQualified Name) (Maybe PatchPath)
+    | UndoI
+    -- First `Maybe Int` is cap on number of results, if any
     -- Second `Maybe Int` is cap on diff elements shown, if any
-    HistoryI (Maybe Int) (Maybe Int) BranchId
-  | -- execute an IO thunk with args
-    ExecuteI String [String]
-  | -- execute an IO [Result]
-    IOTestI (HQ.HashQualified Name)
-  | -- make a standalone binary file
-    MakeStandaloneI String (HQ.HashQualified Name)
-  | TestI Bool Bool -- TestI showSuccesses showFailures
-  -- metadata
-  -- `link metadata definitions` (adds metadata to all of `definitions`)
-  | LinkI (HQ.HashQualified Name) [Path.HQSplit']
-  | -- `unlink metadata definitions` (removes metadata from all of `definitions`)
-    UnlinkI (HQ.HashQualified Name) [Path.HQSplit']
-  | -- links from <type>
-    LinksI Path.HQSplit' (Maybe String)
-  | CreateAuthorI NameSegment {- identifier -} Text {- name -}
-  | -- Display provided definitions. If list is empty, prompt a fuzzy search.
-    DisplayI OutputLocation [HQ.HashQualified Name]
-  | -- Display docs for provided terms. If list is empty, prompt a fuzzy search.
-    DocsI [Path.HQSplit']
-  | -- other
-    SearchByNameI Bool Bool [String] -- SearchByName isVerbose showAll query
-  | FindShallowI Path'
-  | FindPatchI
-  | -- Show provided definitions. If list is empty, prompt a fuzzy search.
-    ShowDefinitionI OutputLocation [HQ.HashQualified Name]
-  | ShowDefinitionByPrefixI OutputLocation [HQ.HashQualified Name]
-  | ShowReflogI
-  | UpdateBuiltinsI
-  | MergeBuiltinsI
-  | MergeIOBuiltinsI
-  | ListDependenciesI (HQ.HashQualified Name)
-  | ListDependentsI (HQ.HashQualified Name)
-  | -- | List all external dependencies of a given namespace, or the current namespace if
+    | HistoryI (Maybe Int) (Maybe Int) BranchId
+    -- execute an IO thunk with args
+    | ExecuteI String [String]
+    -- execute an IO [Result]
+    | IOTestI (HQ.HashQualified Name)
+    -- make a standalone binary file
+    | MakeStandaloneI String (HQ.HashQualified Name)
+    | TestI Bool Bool -- TestI showSuccesses showFailures
+    -- metadata
+    -- `link metadata definitions` (adds metadata to all of `definitions`)
+    | LinkI (HQ.HashQualified Name) [Path.HQSplit']
+    -- `unlink metadata definitions` (removes metadata from all of `definitions`)
+    | UnlinkI (HQ.HashQualified Name) [Path.HQSplit']
+    -- links from <type>
+    | LinksI Path.HQSplit' (Maybe String)
+    | CreateAuthorI NameSegment {- identifier -} Text {- name -}
+      -- Display provided definitions. If list is empty, prompt a fuzzy search.
+    | DisplayI OutputLocation [HQ.HashQualified Name]
+      -- Display docs for provided terms. If list is empty, prompt a fuzzy search.
+    | DocsI [Path.HQSplit']
+    -- other
+    | SearchByNameI Bool Bool [String] -- SearchByName isVerbose showAll query
+    | FindShallowI Path'
+    | FindPatchI
+      -- Show provided definitions. If list is empty, prompt a fuzzy search.
+    | ShowDefinitionI OutputLocation [HQ.HashQualified Name]
+    | ShowDefinitionByPrefixI OutputLocation [HQ.HashQualified Name]
+    | ShowReflogI
+    | UpdateBuiltinsI
+    | MergeBuiltinsI
+    | MergeIOBuiltinsI
+    | ListDependenciesI (HQ.HashQualified Name)
+    | ListDependentsI (HQ.HashQualified Name)
+    -- | List all external dependencies of a given namespace, or the current namespace if
     -- no path is provided.
-    NamespaceDependenciesI (Maybe Path')
-  | DebugNumberedArgsI
-  | DebugTypecheckedUnisonFileI
-  | DebugDumpNamespacesI
-  | DebugDumpNamespaceSimpleI
-  | DebugClearWatchI
-  | QuitI
-  | UiI
-  | DocsToHtmlI Path' FilePath
-  | GistI GistInput
-  deriving (Eq, Show)
+    | NamespaceDependenciesI (Maybe Path')
+    | DebugNumberedArgsI
+    | DebugTypecheckedUnisonFileI
+    | DebugDumpNamespacesI
+    | DebugDumpNamespaceSimpleI
+    | DebugClearWatchI
+    | QuitI
+    | UiI
+    | DocsToHtmlI Path' FilePath
+    | GistI GistInput
+    deriving (Eq, Show)
 
 -- | @"gist repo"@ pushes the contents of the current namespace to @repo@.
 data GistInput = GistInput

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -1,46 +1,52 @@
-{- ORMOLU_DISABLE -} -- Remove this when the file is ready to be auto-formatted
 module Unison.Codebase.Editor.Input
-  ( Input(..)
-  , GistInput(..)
-  , Event(..)
-  , OutputLocation(..)
-  , PatchPath
-  , BranchId, AbsBranchId, parseBranchId
-  , HashOrHQSplit'
-  , Insistence(..)
-  ) where
-
-import Unison.Prelude
-
-import qualified Unison.Codebase.Branch as Branch
-import qualified Unison.Codebase.Branch.Merge as Branch
-import qualified Unison.HashQualified          as HQ
-import qualified Unison.HashQualified'         as HQ'
-import           Unison.Codebase.Path           ( Path' )
-import qualified Unison.Codebase.Path          as Path
-import qualified Unison.Codebase.Path.Parse as Path
-import           Unison.Codebase.PushBehavior (PushBehavior)
-import           Unison.Codebase.Editor.RemoteRepo
-import           Unison.ShortHash (ShortHash)
-import           Unison.Codebase.ShortBranchHash (ShortBranchHash)
-import qualified Unison.Codebase.ShortBranchHash as SBH
-import           Unison.Codebase.SyncMode       ( SyncMode )
-import           Unison.Name                    ( Name )
-import           Unison.NameSegment             ( NameSegment )
-import qualified Unison.Util.Pretty as P
-import           Unison.Codebase.Verbosity
+  ( Input (..),
+    GistInput (..),
+    Event (..),
+    OutputLocation (..),
+    PatchPath,
+    BranchId,
+    AbsBranchId,
+    parseBranchId,
+    HashOrHQSplit',
+    Insistence (..),
+    PullMode (..),
+  )
+where
 
 import qualified Data.Text as Text
+import qualified Unison.Codebase.Branch as Branch
+import qualified Unison.Codebase.Branch.Merge as Branch
+import Unison.Codebase.Editor.RemoteRepo
+import Unison.Codebase.Path (Path')
+import qualified Unison.Codebase.Path as Path
+import qualified Unison.Codebase.Path.Parse as Path
+import Unison.Codebase.PushBehavior (PushBehavior)
+import Unison.Codebase.ShortBranchHash (ShortBranchHash)
+import qualified Unison.Codebase.ShortBranchHash as SBH
+import Unison.Codebase.SyncMode (SyncMode)
+import Unison.Codebase.Verbosity
+import qualified Unison.HashQualified as HQ
+import qualified Unison.HashQualified' as HQ'
+import Unison.Name (Name)
+import Unison.NameSegment (NameSegment)
+import Unison.Prelude
+import Unison.ShortHash (ShortHash)
+import qualified Unison.Util.Pretty as P
 
 data Event
   = UnisonFileChanged SourceName Source
   | IncomingRootBranch (Set Branch.Hash)
 
 type Source = Text -- "id x = x\nconst a b = a"
+
 type SourceName = Text -- "foo.u" or "buffer 7"
+
 type PatchPath = Path.Split'
+
 type BranchId = Either ShortBranchHash Path'
+
 type AbsBranchId = Either ShortBranchHash Path.Absolute
+
 type HashOrHQSplit' = Either ShortHash Path.HQSplit'
 
 -- | Should we force the operation or not?
@@ -48,124 +54,129 @@ data Insistence = Force | Try
   deriving (Show, Eq)
 
 parseBranchId :: String -> Either String BranchId
-parseBranchId ('#':s) = case SBH.fromText (Text.pack s) of
+parseBranchId ('#' : s) = case SBH.fromText (Text.pack s) of
   Nothing -> Left "Invalid hash, expected a base32hex string."
   Just h -> pure $ Left h
 parseBranchId s = Right <$> Path.parsePath' s
 
+data PullMode
+  = PullWithHistory
+  | PullWithoutHistory
+  deriving (Eq, Show)
+
 data Input
-  -- names stuff:
+  = -- names stuff:
     -- directory ops
     -- `Link` must describe a repo and a source path within that repo.
     -- clone w/o merge, error if would clobber
-    = ForkLocalBranchI (Either ShortBranchHash Path') Path'
-    -- merge first causal into destination
-    | MergeLocalBranchI Path' Path' Branch.MergeMode
-    | PreviewMergeLocalBranchI Path' Path'
-    | DiffNamespaceI BranchId BranchId -- old new
-    | PullRemoteBranchI (Maybe ReadRemoteNamespace) Path' SyncMode Verbosity
-    | PushRemoteBranchI (Maybe WriteRemotePath) Path' PushBehavior SyncMode
-    | CreatePullRequestI ReadRemoteNamespace ReadRemoteNamespace
-    | LoadPullRequestI ReadRemoteNamespace ReadRemoteNamespace Path'
-    | ResetRootI (Either ShortBranchHash Path')
-    -- todo: Q: Does it make sense to publish to not-the-root of a Github repo?
+    ForkLocalBranchI (Either ShortBranchHash Path') Path'
+  | -- merge first causal into destination
+    MergeLocalBranchI Path' Path' Branch.MergeMode
+  | PreviewMergeLocalBranchI Path' Path'
+  | DiffNamespaceI BranchId BranchId -- old new
+  | PullRemoteBranchI (Maybe ReadRemoteNamespace) Path' SyncMode PullMode Verbosity
+  | PushRemoteBranchI (Maybe WriteRemotePath) Path' PushBehavior SyncMode
+  | CreatePullRequestI ReadRemoteNamespace ReadRemoteNamespace
+  | LoadPullRequestI ReadRemoteNamespace ReadRemoteNamespace Path'
+  | ResetRootI (Either ShortBranchHash Path')
+  | -- todo: Q: Does it make sense to publish to not-the-root of a Github repo?
     --          Does it make sense to fork from not-the-root of a Github repo?
     -- used in Welcome module to give directions to user
-    | CreateMessage (P.Pretty P.ColorText)
-    -- Change directory. If Nothing is provided, prompt an interactive fuzzy search.
-    | SwitchBranchI (Maybe Path')
-    | UpI
-    | PopBranchI
-    -- > names foo
+    CreateMessage (P.Pretty P.ColorText)
+  | -- Change directory. If Nothing is provided, prompt an interactive fuzzy search.
+    SwitchBranchI (Maybe Path')
+  | UpI
+  | PopBranchI
+  | -- > names foo
     -- > names foo.bar
     -- > names .foo.bar
     -- > names .foo.bar#asdflkjsdf
     -- > names #sdflkjsdfhsdf
-    | NamesI (HQ.HashQualified Name)
-    | AliasTermI HashOrHQSplit' Path.Split'
-    | AliasTypeI HashOrHQSplit' Path.Split'
-    | AliasManyI [Path.HQSplit] Path'
-    -- Move = Rename; It's an HQSplit' not an HQSplit', meaning the arg has to have a name.
-    | MoveTermI Path.HQSplit' Path.Split'
-    | MoveTypeI Path.HQSplit' Path.Split'
-    | MoveBranchI (Maybe Path.Split') Path.Split'
-    | MovePatchI Path.Split' Path.Split'
-    | CopyPatchI Path.Split' Path.Split'
-    -- delete = unname
-    | DeleteI Path.HQSplit'
-    | DeleteTermI Path.HQSplit'
-    | DeleteTypeI Path.HQSplit'
-    | DeleteBranchI Insistence (Maybe Path.Split')
-    | DeletePatchI Path.Split'
-    -- resolving naming conflicts within `branchpath`
-      -- Add the specified name after deleting all others for a given reference
-      -- within a given branch.
-    | ResolveTermNameI Path.HQSplit'
-    | ResolveTypeNameI Path.HQSplit'
-  -- edits stuff:
-    | LoadI (Maybe FilePath)
-    | AddI [HQ'.HashQualified Name]
-    | PreviewAddI [HQ'.HashQualified Name]
-    | UpdateI (Maybe PatchPath) [HQ'.HashQualified Name]
-    | PreviewUpdateI [HQ'.HashQualified Name]
-    | TodoI (Maybe PatchPath) Path'
-    | PropagatePatchI PatchPath Path'
-    | ListEditsI (Maybe PatchPath)
-    -- -- create and remove update directives
-    | DeprecateTermI PatchPath Path.HQSplit'
-    | DeprecateTypeI PatchPath Path.HQSplit'
-    | ReplaceI (HQ.HashQualified Name) (HQ.HashQualified Name) (Maybe PatchPath)
-    | RemoveTermReplacementI (HQ.HashQualified Name) (Maybe PatchPath)
-    | RemoveTypeReplacementI (HQ.HashQualified Name) (Maybe PatchPath)
-    | UndoI
-    -- First `Maybe Int` is cap on number of results, if any
+    NamesI (HQ.HashQualified Name)
+  | AliasTermI HashOrHQSplit' Path.Split'
+  | AliasTypeI HashOrHQSplit' Path.Split'
+  | AliasManyI [Path.HQSplit] Path'
+  | -- Move = Rename; It's an HQSplit' not an HQSplit', meaning the arg has to have a name.
+    MoveTermI Path.HQSplit' Path.Split'
+  | MoveTypeI Path.HQSplit' Path.Split'
+  | MoveBranchI (Maybe Path.Split') Path.Split'
+  | MovePatchI Path.Split' Path.Split'
+  | CopyPatchI Path.Split' Path.Split'
+  | -- delete = unname
+    DeleteI Path.HQSplit'
+  | DeleteTermI Path.HQSplit'
+  | DeleteTypeI Path.HQSplit'
+  | DeleteBranchI Insistence (Maybe Path.Split')
+  | DeletePatchI Path.Split'
+  | -- resolving naming conflicts within `branchpath`
+    -- Add the specified name after deleting all others for a given reference
+    -- within a given branch.
+    ResolveTermNameI Path.HQSplit'
+  | ResolveTypeNameI Path.HQSplit'
+  | -- edits stuff:
+    LoadI (Maybe FilePath)
+  | AddI [HQ'.HashQualified Name]
+  | PreviewAddI [HQ'.HashQualified Name]
+  | UpdateI (Maybe PatchPath) [HQ'.HashQualified Name]
+  | PreviewUpdateI [HQ'.HashQualified Name]
+  | TodoI (Maybe PatchPath) Path'
+  | PropagatePatchI PatchPath Path'
+  | ListEditsI (Maybe PatchPath)
+  | -- -- create and remove update directives
+    DeprecateTermI PatchPath Path.HQSplit'
+  | DeprecateTypeI PatchPath Path.HQSplit'
+  | ReplaceI (HQ.HashQualified Name) (HQ.HashQualified Name) (Maybe PatchPath)
+  | RemoveTermReplacementI (HQ.HashQualified Name) (Maybe PatchPath)
+  | RemoveTypeReplacementI (HQ.HashQualified Name) (Maybe PatchPath)
+  | UndoI
+  | -- First `Maybe Int` is cap on number of results, if any
     -- Second `Maybe Int` is cap on diff elements shown, if any
-    | HistoryI (Maybe Int) (Maybe Int) BranchId
-    -- execute an IO thunk with args
-    | ExecuteI String [String]
-    -- execute an IO [Result]
-    | IOTestI (HQ.HashQualified Name)
-    -- make a standalone binary file
-    | MakeStandaloneI String (HQ.HashQualified Name)
-    | TestI Bool Bool -- TestI showSuccesses showFailures
-    -- metadata
-    -- `link metadata definitions` (adds metadata to all of `definitions`)
-    | LinkI (HQ.HashQualified Name) [Path.HQSplit']
-    -- `unlink metadata definitions` (removes metadata from all of `definitions`)
-    | UnlinkI (HQ.HashQualified Name) [Path.HQSplit']
-    -- links from <type>
-    | LinksI Path.HQSplit' (Maybe String)
-    | CreateAuthorI NameSegment {- identifier -} Text {- name -}
-      -- Display provided definitions. If list is empty, prompt a fuzzy search.
-    | DisplayI OutputLocation [HQ.HashQualified Name]
-      -- Display docs for provided terms. If list is empty, prompt a fuzzy search.
-    | DocsI [Path.HQSplit']
-    -- other
-    | SearchByNameI Bool Bool [String] -- SearchByName isVerbose showAll query
-    | FindShallowI Path'
-    | FindPatchI
-      -- Show provided definitions. If list is empty, prompt a fuzzy search.
-    | ShowDefinitionI OutputLocation [HQ.HashQualified Name]
-    | ShowDefinitionByPrefixI OutputLocation [HQ.HashQualified Name]
-    | ShowReflogI
-    | UpdateBuiltinsI
-    | MergeBuiltinsI
-    | MergeIOBuiltinsI
-    | ListDependenciesI (HQ.HashQualified Name)
-    | ListDependentsI (HQ.HashQualified Name)
-    -- | List all external dependencies of a given namespace, or the current namespace if
+    HistoryI (Maybe Int) (Maybe Int) BranchId
+  | -- execute an IO thunk with args
+    ExecuteI String [String]
+  | -- execute an IO [Result]
+    IOTestI (HQ.HashQualified Name)
+  | -- make a standalone binary file
+    MakeStandaloneI String (HQ.HashQualified Name)
+  | TestI Bool Bool -- TestI showSuccesses showFailures
+  -- metadata
+  -- `link metadata definitions` (adds metadata to all of `definitions`)
+  | LinkI (HQ.HashQualified Name) [Path.HQSplit']
+  | -- `unlink metadata definitions` (removes metadata from all of `definitions`)
+    UnlinkI (HQ.HashQualified Name) [Path.HQSplit']
+  | -- links from <type>
+    LinksI Path.HQSplit' (Maybe String)
+  | CreateAuthorI NameSegment {- identifier -} Text {- name -}
+  | -- Display provided definitions. If list is empty, prompt a fuzzy search.
+    DisplayI OutputLocation [HQ.HashQualified Name]
+  | -- Display docs for provided terms. If list is empty, prompt a fuzzy search.
+    DocsI [Path.HQSplit']
+  | -- other
+    SearchByNameI Bool Bool [String] -- SearchByName isVerbose showAll query
+  | FindShallowI Path'
+  | FindPatchI
+  | -- Show provided definitions. If list is empty, prompt a fuzzy search.
+    ShowDefinitionI OutputLocation [HQ.HashQualified Name]
+  | ShowDefinitionByPrefixI OutputLocation [HQ.HashQualified Name]
+  | ShowReflogI
+  | UpdateBuiltinsI
+  | MergeBuiltinsI
+  | MergeIOBuiltinsI
+  | ListDependenciesI (HQ.HashQualified Name)
+  | ListDependentsI (HQ.HashQualified Name)
+  | -- | List all external dependencies of a given namespace, or the current namespace if
     -- no path is provided.
-    | NamespaceDependenciesI (Maybe Path')
-    | DebugNumberedArgsI
-    | DebugTypecheckedUnisonFileI
-    | DebugDumpNamespacesI
-    | DebugDumpNamespaceSimpleI
-    | DebugClearWatchI
-    | QuitI
-    | UiI
-    | DocsToHtmlI Path' FilePath
-    | GistI GistInput
-    deriving (Eq, Show)
+    NamespaceDependenciesI (Maybe Path')
+  | DebugNumberedArgsI
+  | DebugTypecheckedUnisonFileI
+  | DebugDumpNamespacesI
+  | DebugDumpNamespaceSimpleI
+  | DebugClearWatchI
+  | QuitI
+  | UiI
+  | DocsToHtmlI Path' FilePath
+  | GistI GistInput
+  deriving (Eq, Show)
 
 -- | @"gist repo"@ pushes the contents of the current namespace to @repo@.
 data GistInput = GistInput

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -211,6 +211,7 @@ data Output v
   | History (Maybe Int) [(ShortBranchHash, Names.Diff)] HistoryTail
   | ShowReflog [ReflogEntry]
   | PullAlreadyUpToDate ReadRemoteNamespace Path'
+  | PullSuccessful ReadRemoteNamespace Path'
   | MergeAlreadyUpToDate Path' Path'
   | PreviewMergeAlreadyUpToDate Path' Path'
   | -- | No conflicts or edits remain for the current patch.
@@ -344,6 +345,7 @@ isFailure o = case o of
   DumpBitBooster {} -> False
   NoBranchWithHash {} -> True
   PullAlreadyUpToDate {} -> False
+  PullSuccessful {} -> False
   MergeAlreadyUpToDate {} -> False
   PreviewMergeAlreadyUpToDate {} -> False
   NoConflictsOrEdits {} -> False

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -897,7 +897,7 @@ pull :: InputPattern
 pull = pullImpl "pull" Verbosity.Default Input.PullWithHistory
 
 pullWithoutHistory :: InputPattern
-pullWithoutHistory = pullImpl "pull.without-history" Verbosity.Default Input.PullWithHistory
+pullWithoutHistory = pullImpl "pull.without-history" Verbosity.Default Input.PullWithoutHistory
 
 pullImpl :: String -> Verbosity -> Input.PullMode -> InputPattern
 pullImpl name verbosity pullMode = do
@@ -1882,6 +1882,7 @@ validInputs =
     push,
     pushCreate,
     pull,
+    pullWithoutHistory,
     pullSilent,
     pushExhaustive,
     pullExhaustive,

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -891,19 +891,23 @@ resetRoot =
 
 pullSilent :: InputPattern
 pullSilent =
-  pullImpl "pull.silent" Verbosity.Silent Input.PullWithHistory
+  pullImpl "pull.silent" Verbosity.Silent Input.PullWithHistory "without listing the merged entities"
 
 pull :: InputPattern
-pull = pullImpl "pull" Verbosity.Default Input.PullWithHistory
+pull = pullImpl "pull" Verbosity.Default Input.PullWithHistory ""
 
 pullWithoutHistory :: InputPattern
-pullWithoutHistory = pullImpl "pull.without-history" Verbosity.Default Input.PullWithoutHistory
+pullWithoutHistory =
+  pullImpl
+    "pull.without-history"
+    Verbosity.Default
+    Input.PullWithoutHistory
+    "without including the remote's history. This usually results in smaller codebase sizes."
 
-pullImpl :: String -> Verbosity -> Input.PullMode -> InputPattern
-pullImpl name verbosity pullMode = do
+pullImpl :: String -> Verbosity -> Input.PullMode -> P.Pretty CT.ColorText -> InputPattern
+pullImpl name verbosity pullMode addendum = do
   self
   where
-    addendum = if Verbosity.isSilent verbosity then "without listing the merged entities" else ""
     self =
       InputPattern
         name

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -891,13 +891,16 @@ resetRoot =
 
 pullSilent :: InputPattern
 pullSilent =
-  pullImpl "pull.silent" Verbosity.Silent
+  pullImpl "pull.silent" Verbosity.Silent Input.PullWithHistory
 
 pull :: InputPattern
-pull = pullImpl "pull" Verbosity.Default
+pull = pullImpl "pull" Verbosity.Default Input.PullWithHistory
 
-pullImpl :: String -> Verbosity -> InputPattern
-pullImpl name verbosity = do
+pullWithoutHistory :: InputPattern
+pullWithoutHistory = pullImpl "pull.without-history" Verbosity.Default Input.PullWithHistory
+
+pullImpl :: String -> Verbosity -> Input.PullMode -> InputPattern
+pullImpl name verbosity pullMode = do
   self
   where
     addendum = if Verbosity.isSilent verbosity then "without listing the merged entities" else ""
@@ -939,14 +942,14 @@ pullImpl name verbosity = do
         )
         ( \case
             [] ->
-              Right $ Input.PullRemoteBranchI Nothing Path.relativeEmpty' SyncMode.ShortCircuit verbosity
+              Right $ Input.PullRemoteBranchI Nothing Path.relativeEmpty' SyncMode.ShortCircuit pullMode verbosity
             [url] -> do
               ns <- parseUri "url" url
-              Right $ Input.PullRemoteBranchI (Just ns) Path.relativeEmpty' SyncMode.ShortCircuit verbosity
+              Right $ Input.PullRemoteBranchI (Just ns) Path.relativeEmpty' SyncMode.ShortCircuit pullMode verbosity
             [url, path] -> do
               ns <- parseUri "url" url
               p <- first fromString $ Path.parsePath' path
-              Right $ Input.PullRemoteBranchI (Just ns) p SyncMode.ShortCircuit verbosity
+              Right $ Input.PullRemoteBranchI (Just ns) p SyncMode.ShortCircuit pullMode verbosity
             _ -> Left (I.help self)
         )
 
@@ -967,14 +970,14 @@ pullExhaustive =
     )
     ( \case
         [] ->
-          Right $ Input.PullRemoteBranchI Nothing Path.relativeEmpty' SyncMode.Complete Verbosity.Default
+          Right $ Input.PullRemoteBranchI Nothing Path.relativeEmpty' SyncMode.Complete Input.PullWithHistory Verbosity.Default
         [url] -> do
           ns <- parseUri "url" url
-          Right $ Input.PullRemoteBranchI (Just ns) Path.relativeEmpty' SyncMode.Complete Verbosity.Default
+          Right $ Input.PullRemoteBranchI (Just ns) Path.relativeEmpty' SyncMode.Complete Input.PullWithHistory Verbosity.Default
         [url, path] -> do
           ns <- parseUri "url" url
           p <- first fromString $ Path.parsePath' path
-          Right $ Input.PullRemoteBranchI (Just ns) p SyncMode.Complete Verbosity.Default
+          Right $ Input.PullRemoteBranchI (Just ns) p SyncMode.Complete Input.PullWithHistory Verbosity.Default
         _ -> Left (I.help pull)
     )
 

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1289,6 +1289,11 @@ notifyUser dir o = case o of
       P.wrap $
         prettyPath' dest <> "was already up-to-date with"
           <> P.group (prettyRemoteNamespace ns <> ".")
+  PullSuccessful ns dest ->
+    pure . P.okCallout $
+      P.wrap $
+        "Successfully updated" <> prettyPath' dest <> "from"
+          <> P.group (prettyRemoteNamespace ns <> ".")
   MergeAlreadyUpToDate src dest ->
     pure . P.callout "😶" $
       P.wrap $

--- a/unison-cli/src/Unison/CommandLine/Welcome.hs
+++ b/unison-cli/src/Unison/CommandLine/Welcome.hs
@@ -54,7 +54,7 @@ pullBase ns = let
     seg = NameSegment "base"
     rootPath = Path.Path { Path.toSeq = singleton seg }
     abs = Path.Absolute {Path.unabsolute = rootPath}
-    pullRemote = PullRemoteBranchI (Just ns) (Path.Path' {Path.unPath' = Left abs}) SyncMode.Complete PullWithoutHistory Verbosity.Silent
+    pullRemote = PullRemoteBranchI (Just ns) (Path.Path' {Path.unPath' = Left abs}) SyncMode.Complete PullWithHistory Verbosity.Silent
   in Right pullRemote
 
 run :: Codebase IO v a -> Welcome -> IO [Either Event Input]

--- a/unison-cli/src/Unison/CommandLine/Welcome.hs
+++ b/unison-cli/src/Unison/CommandLine/Welcome.hs
@@ -54,7 +54,7 @@ pullBase ns = let
     seg = NameSegment "base"
     rootPath = Path.Path { Path.toSeq = singleton seg }
     abs = Path.Absolute {Path.unabsolute = rootPath}
-    pullRemote = PullRemoteBranchI (Just ns) (Path.Path' {Path.unPath' = Left abs}) SyncMode.Complete Verbosity.Silent
+    pullRemote = PullRemoteBranchI (Just ns) (Path.Path' {Path.unPath' = Left abs}) SyncMode.Complete PullWithoutHistory Verbosity.Silent
   in Right pullRemote
 
 run :: Codebase IO v a -> Welcome -> IO [Either Event Input]


### PR DESCRIPTION
This was added for use by the git-hosted Unison Share transcript, primarily to shrink the file and download size for Share hosted on Github. Note that this command doesn't propagate any patch.
___

## Overview

Adds a new variant of the `pull` command which discards the history of a remote branch **before** importing it.
This is important, once a branch and its history is pulled in, all of its definitions throughout all of its history will be part of your local codebase, and even if you squash the branch afterwards those definitions will be floating around your codebase until a manual garbage-collect or migration step.

This avoids that problem by squashing the branch in memory BEFORE importing it,  meaning you only pay the storage cost for the HEAD of that branch.

I switched to use this mode for the `base` pull on startup as well.

Results:

```
pull.without-history https://github.com/unisonweb/base .base
- 37.7s, 6mb codebase

pull https://github.com/unisonweb/base .base
- 85.7s (some significant amount of this is likely in constructing the diff), 14mb codebase
```

closes #2696


## Implementation notes

* I add a new `pull.without-history` command
* It works by passing a **preprocessing** step to `ImportRemoteBranch`
* I swap the pull-base in the onboarding flow to use a `pull.without-history`

## Interesting/controversial decisions

The addition of this command further makes the distinction between code that you're **working on** and code that you only **depend on**. I think projects will make this more clear in the future, but for now we may want to think about what sort of language we use to refer to these things.

I'm not sold on the name `pull.without-history`, after some chats with @hojberg  we agreed that this should probably be a "default" workflow when pulling in dependencies.

Options we've thought of for names:
* `load`
* `install`
* Swap this to be `pull` and add `pull.with-history`
* ??? (your name here)