### PR TITLE
Add equality check to speed up consBranch

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -784,10 +784,13 @@ consBranch ::
 -- If the target branch is empty we just replace it.
 consBranch Empty headBranch = discardHistory headBranch
 consBranch baseBranch headBranch =
-  Branch $
-    Causal.consDistinct
-      (head headBranch & children .~ combinedChildren)
-      (_history baseBranch)
+  if baseBranch == headBranch
+    then baseBranch
+    else
+      Branch $
+        Causal.consDistinct
+          (head headBranch & children .~ combinedChildren)
+          (_history baseBranch)
   where
     combineChildren :: These (Branch m) (Branch m) -> Branch m
     combineChildren = \case


### PR DESCRIPTION
## Overview

This PR adds a short-circuit to `consBranch` which prevents recurring past equal children. In my limited experimentation at the command line, this seems to have reduced the runtime of `update` by 10-12%.