### PR TITLE
Add SomeSqliteException, SqliteConnectException

### DIFF
--- a/lib/unison-sqlite/src/Unison/Sqlite.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite.hs
@@ -81,6 +81,8 @@ module Unison.Sqlite
     withStatement,
 
     -- * Exceptions
+    SomeSqliteException (..),
+    SqliteConnectException (..),
     SqliteQueryException (..),
     SqliteExceptionReason,
     SomeSqliteExceptionReason (..),
@@ -98,7 +100,13 @@ import Unison.Sqlite.Connection
   )
 import Unison.Sqlite.DB
 import Unison.Sqlite.DataVersion (DataVersion (..), getDataVersion)
-import Unison.Sqlite.Exception (SomeSqliteExceptionReason (..), SqliteExceptionReason, SqliteQueryException (..))
+import Unison.Sqlite.Exception
+  ( SomeSqliteException (..),
+    SomeSqliteExceptionReason (..),
+    SqliteConnectException (..),
+    SqliteExceptionReason,
+    SqliteQueryException (..),
+  )
 import Unison.Sqlite.JournalMode (JournalMode (..), SetJournalModeException (..), trySetJournalMode)
 import Unison.Sqlite.Sql (Sql (..))
 

--- a/lib/unison-sqlite/src/Unison/Sqlite/Connection.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Connection.hs
@@ -93,26 +93,29 @@ withConnection ::
   (Connection -> m a) ->
   m a
 withConnection name file =
-  bracket (openConnection name file) closeConnection
+  bracket (liftIO (openConnection name file)) (liftIO . closeConnection)
 
 -- Open a connection to a SQLite database.
 openConnection ::
-  MonadIO m =>
   -- Connection name, for debugging.
   String ->
   -- Path to SQLite database file.
   FilePath ->
-  m Connection
+  IO Connection
 openConnection name file = do
-  conn0 <- liftIO (Sqlite.open file)
+  conn0 <- Sqlite.open file `catch` rethrowAsSqliteConnectException name file
   let conn = Connection {conn = conn0, file, name}
-  liftIO (execute_ conn "PRAGMA foreign_keys = ON")
+  execute_ conn "PRAGMA foreign_keys = ON"
   pure conn
 
 -- Close a connection opened with 'openConnection'.
-closeConnection :: MonadIO m => Connection -> m ()
+closeConnection :: Connection -> IO ()
 closeConnection (Connection _ _ conn) =
-  liftIO (Sqlite.close conn)
+  -- FIXME if this throws an exception, it won't be under `SomeSqliteException`
+  -- Possible fixes:
+  --   1. Add close exception to the hierarchy, e.g. `SqliteCloseException`
+  --   2. Always ignore exceptions thrown by `close` (Mitchell prefers this one)
+  Sqlite.close conn
 
 -- Without results, with parameters
 

--- a/lib/unison-sqlite/src/Unison/Sqlite/Exception.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Exception.hs
@@ -1,25 +1,111 @@
--- | Sqlite exception utils
+-- | Sqlite exception utils.
 module Unison.Sqlite.Exception
-  ( SqliteQueryException (..),
-    SqliteExceptionReason,
-    SomeSqliteExceptionReason (..),
+  ( -- * @SomeSqliteException@
+    SomeSqliteException (..),
+
+    -- ** @SqliteConnectException@
+    SqliteConnectException (..),
+    rethrowAsSqliteConnectException,
+
+    -- ** @SqliteQueryException@
+    SqliteQueryException (..),
     SqliteQueryExceptionInfo (..),
     throwSqliteQueryException,
+    SomeSqliteExceptionReason (..),
+    SqliteExceptionReason,
   )
 where
 
 import Control.Concurrent (ThreadId, myThreadId)
+import Data.Typeable (cast)
 import qualified Database.SQLite.Simple as Sqlite
 import Debug.RecoverRTTI (anythingToString)
 import Unison.Prelude
 import Unison.Sqlite.Sql
 import UnliftIO.Exception
 
+------------------------------------------------------------------------------------------------------------------------
+-- SomeSqliteException
+
+-- | The root exception for all exceptions thrown by this library.
+--
+-- @
+-- SomeException (from base)
+--   └── SomeSqliteException
+--         └── SqliteConnectException
+--         └── SqliteQueryException
+-- @
+--
+-- A @SomeSqliteException@ should not be inspected or used for control flow when run in a trusted environment, where the
+-- database can be assumed to be uncorrupt. Rather, wherever possible, the user of this library should write code that
+-- is guaranteed not to throw exceptions, by checking the necessary preconditions first. If that is not possible, it
+-- should be considered a bug in this library.
+--
+-- When actions are run on an untrusted codebase, e.g. one downloaded from a remote server, it is sufficient to catch
+-- just one exception type, @SomeSqliteException@.
+data SomeSqliteException
+  = forall e. Exception e => SomeSqliteException e
+  deriving anyclass (Exception)
+
+instance Show SomeSqliteException where
+  show (SomeSqliteException e) = show e
+
+------------------------------------------------------------------------------------------------------------------------
+-- SomeSqliteException
+--   └── SqliteConnectException
+
+-- | An exception thrown during establishing a connection.
+data SqliteConnectException = SqliteConnectException
+  { threadId :: ThreadId,
+    name :: String,
+    file :: FilePath,
+    exception :: Sqlite.SQLError
+  }
+  deriving stock (Show)
+
+instance Exception SqliteConnectException where
+  toException = toException . SomeSqliteException
+  fromException = fromException >=> \(SomeSqliteException e) -> cast e
+
+rethrowAsSqliteConnectException :: String -> FilePath -> Sqlite.SQLError -> IO a
+rethrowAsSqliteConnectException name file exception = do
+  threadId <- myThreadId
+  throwIO SqliteConnectException {exception, file, name, threadId}
+
+------------------------------------------------------------------------------------------------------------------------
+-- SomeSqliteException
+--   └── SqliteConnectException
+
+-- | A @SqliteQueryException@ represents an exception thrown during processing a query, paired with some context that
+-- resulted in the exception.
+--
+-- A @SqliteQueryException@ may result from a number of different conditions:
+--
+-- * The underlying sqlite library threw an exception.
+-- * A postcondition violation of a function like 'Unison.Sqlite.queryMaybeRow', which asserts that the resulting
+--   relation will have certain number of rows,
+-- * A postcondition violation of a function like 'Unison.Sqlite.queryListRowCheck', which takes a user-defined check as
+--   an argument.
+data SqliteQueryException = SqliteQueryException
+  { threadId :: ThreadId,
+    connection :: String,
+    sql :: Sql,
+    params :: String,
+    -- | The inner exception. It is intentionally not 'SomeException', so that calling code cannot accidentally
+    -- 'throwIO' domain-specific exception types, but must instead use a @*Check@ query variant.
+    exception :: SomeSqliteExceptionReason
+  }
+  deriving stock (Show)
+
+instance Exception SqliteQueryException where
+  toException = toException . SomeSqliteException
+  fromException = fromException >=> \(SomeSqliteException e) -> cast e
+
 data SqliteQueryExceptionInfo params connection = SqliteQueryExceptionInfo
-  { sql :: Sql,
+  { connection :: connection,
+    sql :: Sql,
     params :: Maybe params,
-    exception :: SomeSqliteExceptionReason,
-    connection :: connection
+    exception :: SomeSqliteExceptionReason
   }
 
 throwSqliteQueryException :: Show connection => SqliteQueryExceptionInfo params connection -> IO a
@@ -34,11 +120,6 @@ throwSqliteQueryException SqliteQueryExceptionInfo {connection, exception, param
         threadId
       }
 
--- | A type that is intended to be used as additional context for a sqlite-related exception.
-class (Show e, Typeable e) => SqliteExceptionReason e
-
-instance SqliteExceptionReason Sqlite.SQLError
-
 data SomeSqliteExceptionReason
   = forall e. SqliteExceptionReason e => SomeSqliteExceptionReason e
   deriving anyclass (SqliteExceptionReason)
@@ -46,32 +127,7 @@ data SomeSqliteExceptionReason
 instance Show SomeSqliteExceptionReason where
   show (SomeSqliteExceptionReason x) = show x
 
--- | A @SqliteQueryException@ represents an exception thrown during processing a query, paired with some context that
--- resulted in the exception.
---
--- A @SqliteQueryException@ may result from a number of different conditions:
---
--- * The underlying sqlite library threw an exception.
--- * A postcondition violation of a function like 'Unison.Sqlite.queryMaybeRow', which asserts that the resulting
---   relation will have certain number of rows,
--- * A postcondition violation of a function like 'Unison.Sqlite.queryListRowCheck', which takes a user-defined check as
---   an argument.
---
--- A @SqliteQueryException@ should not be inspected or used for control flow when run in a trusted environment, where
--- the database can be assumed to be uncorrupt. Rather, wherever possible, the user of this library should write code
--- that is guaranteed not to throw exceptions, by checking the necessary preconditions first. If that is not possible,
--- it should be considered a bug in this library.
---
--- When actions are run on an untrusted codebase, e.g. one downloaded from a remote server, it is sufficient to catch
--- just one exception type, @SqliteQueryException@.
-data SqliteQueryException = SqliteQueryException
-  { sql :: Sql,
-    params :: String,
-    -- | The inner exception. It is intentionally not 'SomeException', so that calling code cannot accidentally
-    -- 'throwIO' domain-specific exception types, but must instead use a @*Check@ query variant.
-    exception :: SomeSqliteExceptionReason,
-    connection :: String,
-    threadId :: ThreadId
-  }
-  deriving stock (Show)
-  deriving anyclass (Exception)
+-- | A type that is intended to be used as additional context for a sqlite-related exception.
+class (Show e, Typeable e) => SqliteExceptionReason e
+
+instance SqliteExceptionReason Sqlite.SQLError


### PR DESCRIPTION
## Overview

- [x] Depends on #2723 

This PR expands the sqlite exception hierarchy a little bit to include `SqliteConnectException`, which is thrown when an `open` call fails.

All exceptions thrown by the `unison-sqlite` library now fall under `SomeSqliteException`, whereas before, there was only one exception type - `SqliteQueryException` - which contained context about which query was attempted, and thus was not suitable for throwing when no connection could be established in the first place.