### PR TITLE
Hide empty namespaces from ucm output

### DIFF
--- a/lib/unison-util-relation/src/Unison/Util/Relation3.hs
+++ b/lib/unison-util-relation/src/Unison/Util/Relation3.hs
@@ -128,6 +128,9 @@ fromList xs = insertAll xs empty
 empty :: (Ord a, Ord b, Ord c) => Relation3 a b c
 empty = mempty
 
+null :: Relation3 a b c -> Bool
+null r = Map.null $ d1 r
+
 insert, delete
   :: (Ord a, Ord b, Ord c)
   => a -> b -> c -> Relation3 a b c -> Relation3 a b c

--- a/lib/unison-util-relation/src/Unison/Util/Relation4.hs
+++ b/lib/unison-util-relation/src/Unison/Util/Relation4.hs
@@ -47,6 +47,9 @@ toList = fmap (\(a,(b,(c,d))) -> (a,b,c,d)) . toNestedList
 empty :: (Ord a, Ord b, Ord c, Ord d) => Relation4 a b c d
 empty = mempty
 
+null :: Relation4 a b c d -> Bool
+null r = Map.null $ d1 r
+
 fromList :: (Ord a, Ord b, Ord c, Ord d) => [(a,b,c,d)] -> Relation4 a b c d
 fromList xs = insertAll xs empty
 

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -120,7 +120,6 @@ import qualified Unison.Util.List as List
 import qualified Data.Semialign as Align
 import Data.These (These(..))
 import qualified Unison.Util.Relation as Relation
-import qualified Unison.Util.Relation4 as Relation4
 
 -- | A node in the Unison namespace hierarchy
 -- along with its history.

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -509,7 +509,8 @@ empty0 :: Branch0 m
 empty0 =
   Branch0 mempty mempty mempty mempty mempty mempty mempty mempty mempty mempty
 
--- | Checks whether a Branch0 is empty.
+-- | Checks whether a Branch0 is empty, which means that the branch contains no terms or
+-- types, and that the heads of all children are empty by the same definition.
 -- This is not as easy as checking whether the branch is equal to the `empty0` branch
 -- because child branches may be empty, but still have history.
 isEmpty0 :: Branch0 m -> Bool

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -513,12 +513,9 @@ empty0 =
 -- This is not as easy as checking whether the branch is equal to the `empty0` branch
 -- because child branches may be empty, but still have history.
 isEmpty0 :: Branch0 m -> Bool
-isEmpty0 (Branch0 _terms _types _children _edits deepTerms deepTypes deepTermMetadata deepTypeMetadata deepPaths deepEdits) =
+isEmpty0 (Branch0 _terms _types _children _edits deepTerms deepTypes _deepTermMetadata _deepTypeMetadata _deepPaths deepEdits) =
   Relation.null deepTerms
     && Relation.null deepTypes
-    && Relation4.null deepTermMetadata
-    && Relation4.null deepTypeMetadata
-    && Set.null deepPaths
     && Map.null deepEdits
 
 -- | Checks whether a branch is empty AND has no history.

--- a/parser-typechecker/src/Unison/Server/Backend.hs
+++ b/parser-typechecker/src/Unison/Server/Backend.hs
@@ -431,7 +431,7 @@ findShallowInBranch codebase b = do
       [ ShallowBranchEntry ns
                            (SBH.fullFromHash $ Branch.headHash b)
                            (defnCount b)
-      | (ns, b) <- Map.toList $ Branch._children b0
+      | (ns, b) <- Map.toList $ Branch.nonEmptyChildren b0
       ]
     patchEntries =
       [ ShallowPatchEntry ns

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -848,7 +848,7 @@ loop = do
                   let path = resolveToAbsolute path'
                   LoopState.currentPathStack %= Nel.cons path
                   branch' <- getAt path
-                  when (Branch.isEmpty branch') (respond $ CreatedNewBranch path)
+                  when (Branch.isEmpty0 $ Branch.head branch') (respond $ CreatedNewBranch path)
             UpI ->
               use LoopState.currentPath >>= \p -> case Path.unsnoc (Path.unabsolute p) of
                 Nothing -> pure ()

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2057,7 +2057,7 @@ bothCompletors c1 c2 q code b currentPath = do
     . nubOrdOn Completion.display
     $ suggestions1 ++ suggestions2
 
--- |
+-- | A completer for namespace paths.
 pathCompletor ::
   Applicative f =>
   -- | Turns a query and list of possible completions into a 'Completion'.
@@ -2092,7 +2092,7 @@ namespaceArg =
 -- | Recursively collects all names of namespaces which are children of the branch.
 allSubNamespaces :: Branch.Branch0 m -> [Text]
 allSubNamespaces b =
-  flip Map.foldMapWithKey (Branch._children b) $
+  flip Map.foldMapWithKey (Branch.nonEmptyChildren b) $
     \(NameSegment k) (Branch.head -> b') ->
       (k : fmap (\sn -> k <> "." <> sn) (allSubNamespaces b'))
 

--- a/unison-src/transcripts/empty-namespaces.md
+++ b/unison-src/transcripts/empty-namespaces.md
@@ -19,3 +19,11 @@ The deleted namespace shouldn't appear in `ls` output.
 ```ucm:error
 .> find mynamespace
 ```
+
+
+The history of the namespace should still exist if requested explicitly.
+
+```ucm
+.> history mynamespace
+```
+

--- a/unison-src/transcripts/empty-namespaces.md
+++ b/unison-src/transcripts/empty-namespaces.md
@@ -27,3 +27,10 @@ The history of the namespace should still exist if requested explicitly.
 .> history mynamespace
 ```
 
+Merging an empty namespace should still copy its history if it has some.
+
+```ucm
+.empty> history
+.empty> merge .mynamespace
+.empty> history
+```

--- a/unison-src/transcripts/empty-namespaces.md
+++ b/unison-src/transcripts/empty-namespaces.md
@@ -1,0 +1,19 @@
+# Empty namespace behaviours
+
+```ucm:hide
+.> builtins.merge
+```
+
+```unison
+mynamespace.x = 1
+```
+
+```ucm:hide
+.> add
+.> delete.namespace mynamespace
+```
+
+The deleted namespace shouldn't appear in `ls` output.
+```ucm
+.> ls
+```

--- a/unison-src/transcripts/empty-namespaces.md
+++ b/unison-src/transcripts/empty-namespaces.md
@@ -1,10 +1,6 @@
 # Empty namespace behaviours
 
-```ucm:hide
-.> builtins.merge
-```
-
-```unison
+```unison:hide
 mynamespace.x = 1
 ```
 
@@ -14,6 +10,12 @@ mynamespace.x = 1
 ```
 
 The deleted namespace shouldn't appear in `ls` output.
-```ucm
+```ucm:error
 .> ls
+```
+```ucm:error
+.> ls.verbose
+```
+```ucm:error
+.> find mynamespace
 ```

--- a/unison-src/transcripts/empty-namespaces.output.md
+++ b/unison-src/transcripts/empty-namespaces.output.md
@@ -29,3 +29,20 @@ The deleted namespace shouldn't appear in `ls` output.
   to supply command arguments.
 
 ```
+The history of the namespace should still exist if requested explicitly.
+
+```ucm
+.> history mynamespace
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ #qjc20aua9h
+  
+    - Deletes:
+    
+      x
+  
+  □ #hkrqt3tm05 (start of history)
+
+```

--- a/unison-src/transcripts/empty-namespaces.output.md
+++ b/unison-src/transcripts/empty-namespaces.output.md
@@ -46,3 +46,30 @@ The history of the namespace should still exist if requested explicitly.
   □ #hkrqt3tm05 (start of history)
 
 ```
+Merging an empty namespace should still copy its history if it has some.
+
+```ucm
+  ☝️  The namespace .empty is empty.
+
+.empty> history
+
+  ☝️  The namespace .empty is empty.
+
+.empty> merge .mynamespace
+
+  Nothing changed as a result of the merge.
+
+.empty> history
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ #qjc20aua9h
+  
+    - Deletes:
+    
+      x
+  
+  □ #hkrqt3tm05 (start of history)
+
+```

--- a/unison-src/transcripts/empty-namespaces.output.md
+++ b/unison-src/transcripts/empty-namespaces.output.md
@@ -4,22 +4,28 @@
 mynamespace.x = 1
 ```
 
-```ucm
-
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-  
-    ⍟ These new definitions are ok to `add`:
-    
-      mynamespace.x : Nat
-
-```
 The deleted namespace shouldn't appear in `ls` output.
 ```ucm
 .> ls
 
-  1. builtin/     (381 definitions)
-  2. mynamespace/ (0 definitions)
+  nothing to show
+
+```
+```ucm
+.> ls.verbose
+
+  😶
+  
+  No results. Check your spelling, or try using tab completion
+  to supply command arguments.
+
+```
+```ucm
+.> find mynamespace
+
+  😶
+  
+  No results. Check your spelling, or try using tab completion
+  to supply command arguments.
 
 ```

--- a/unison-src/transcripts/empty-namespaces.output.md
+++ b/unison-src/transcripts/empty-namespaces.output.md
@@ -1,0 +1,25 @@
+# Empty namespace behaviours
+
+```unison
+mynamespace.x = 1
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      mynamespace.x : Nat
+
+```
+The deleted namespace shouldn't appear in `ls` output.
+```ucm
+.> ls
+
+  1. builtin/     (381 definitions)
+  2. mynamespace/ (0 definitions)
+
+```


### PR DESCRIPTION
## Overview

Child namespaces may exist in a state where the `Branch0` is empty, but the node still has history. In this case we still want to propagate those nodes around in _most_ cases, but they shouldn't appear in the output of `ls` or `find` and the like.

This PR just hides the empty child namespaces from searches/display,
I'll add another PR separately which allows forking, pulling, etc. over empty namespaces.

## Implementation notes

* Makes the distinction between children and nonEmptyChildren. (This is a bit annoying to need to worry about, but unless we plan to change our history model it's an important distinction to make).
* Use `nonEmptyChildren` in the appropriate display and autocomplete locations.

## Interesting/controversial decisions

I changed the `isEmpty0` logic, so that's likely worth checking out.

## Test coverage

Added a transcript which walks through a bunch of situations with deleted branches. I'll expand this transcript when I add forking/pull/etc logic.

## Loose ends

Upcoming PR for forking/pull/etc logic.

@ceedubs 
