### PR TITLE
Allow fork'ing/pulling/etc. over a branch with an empty HEAD.

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -677,7 +677,7 @@ loop = do
             MergeLocalBranchI src0 dest0 mergeMode -> do
               let [src, dest] = resolveToAbsolute <$> [src0, dest0]
               srcb <- getAt src
-              if Branch.isEmpty0 (Branch.head srcb)
+              if Branch.isEmpty srcb
                 then branchNotFound src0
                 else do
                   let err = Just $ MergeAlreadyUpToDate src0 dest0
@@ -685,7 +685,7 @@ loop = do
             PreviewMergeLocalBranchI src0 dest0 -> do
               let [src, dest] = resolveToAbsolute <$> [src0, dest0]
               srcb <- getAt src
-              if Branch.isEmpty0 (Branch.head srcb)
+              if Branch.isEmpty srcb
                 then branchNotFound src0
                 else do
                   destb <- getAt dest

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -660,7 +660,7 @@ loop = do
                     let dest = resolveToAbsolute dest0
                     -- if dest isn't empty: leave dest unchanged, and complain.
                     destb <- getAt dest
-                    if Branch.isEmpty destb
+                    if Branch.isEmpty0 (Branch.head destb)
                       then do
                         ok <- updateAtM dest (const $ pure srcb)
                         if ok then success else respond $ BranchEmpty src0
@@ -677,7 +677,7 @@ loop = do
             MergeLocalBranchI src0 dest0 mergeMode -> do
               let [src, dest] = resolveToAbsolute <$> [src0, dest0]
               srcb <- getAt src
-              if Branch.isEmpty srcb
+              if Branch.isEmpty0 (Branch.head srcb)
                 then branchNotFound src0
                 else do
                   let err = Just $ MergeAlreadyUpToDate src0 dest0
@@ -685,7 +685,7 @@ loop = do
             PreviewMergeLocalBranchI src0 dest0 -> do
               let [src, dest] = resolveToAbsolute <$> [src0, dest0]
               srcb <- getAt src
-              if Branch.isEmpty srcb
+              if Branch.isEmpty0 (Branch.head srcb)
                 then branchNotFound src0
                 else do
                   destb <- getAt dest
@@ -1903,8 +1903,8 @@ doPushRemoteBranch repo localPath syncMode remoteTarget = do
     shouldPushTo :: PushBehavior -> Branch m -> Bool
     shouldPushTo pushBehavior remoteBranch =
       case pushBehavior of
-        PushBehavior.RequireEmpty -> Branch.isEmpty remoteBranch
-        PushBehavior.RequireNonEmpty -> not (Branch.isEmpty remoteBranch)
+        PushBehavior.RequireEmpty -> Branch.isEmpty0 (Branch.head remoteBranch)
+        PushBehavior.RequireNonEmpty -> not (Branch.isEmpty0 (Branch.head remoteBranch))
 
 -- | Handle a @ShowDefinitionI@ input command, i.e. `view` or `edit`.
 handleShowDefinition ::

--- a/unison-cli/tests/Unison/Test/GitSync.hs
+++ b/unison-cli/tests/Unison/Test/GitSync.hs
@@ -40,6 +40,53 @@ test = scope "gitsync22" . tests $
   destroyedRemote :
   flip map [(Ucm.CodebaseFormat2, "sc")]
   \(fmt, name) -> scope name $ tests [
+  pushPullTest  "pull-over-deleted-namespace" fmt
+    (\repo -> [i|
+      ```unison:hide
+      x = 1
+      ```
+      ```ucm:hide
+      .> add
+      .> push.create ${repo}
+      ```
+    |])
+    (\repo -> [i|
+      ```unison:hide
+      child.y = 2
+      ```
+
+      Should be able to pull a branch from the repo over top of our deleted local branch.
+      ```ucm
+      .> add
+      .> delete.namespace child
+      .> pull ${repo} child
+      ```
+    |])
+  ,
+  pushPullTest  "push-over-deleted-namespace" fmt
+    (\repo -> [i|
+      ```unison:hide
+      child.x = 1
+      y = 2
+      ```
+      ```ucm:hide
+      .> add
+      .> delete.namespace child
+      .> push.create ${repo}
+      ```
+    |])
+    (\repo -> [i|
+      ```unison:hide
+      child.z = 3
+      ```
+
+      Should be able to push a branch over top of a deleted remote branch.
+      ```ucm
+      .> add
+      .> push.create ${repo}:.child child
+      ```
+    |])
+  ,
   pushPullTest  "typeAlias" fmt
     (\repo -> [i|
       ```ucm

--- a/unison-src/transcripts/empty-namespaces.md
+++ b/unison-src/transcripts/empty-namespaces.md
@@ -1,0 +1,36 @@
+# Empty namespace behaviours
+
+```unison:hide
+mynamespace.x = 1
+```
+
+```ucm:hide
+.> add
+.> delete.namespace mynamespace
+```
+
+The deleted namespace shouldn't appear in `ls` output.
+```ucm:error
+.> ls
+```
+```ucm:error
+.> ls.verbose
+```
+```ucm:error
+.> find mynamespace
+```
+
+
+The history of the namespace should still exist if requested explicitly.
+
+```ucm
+.> history mynamespace
+```
+
+Merging an empty namespace should still copy its history if it has some.
+
+```ucm
+.empty> history
+.empty> merge .mynamespace
+.empty> history
+```

--- a/unison-src/transcripts/empty-namespaces.md
+++ b/unison-src/transcripts/empty-namespaces.md
@@ -1,36 +1,28 @@
 # Empty namespace behaviours
 
+## Operations on empty namespaces
+
+Add and then delete a term to add some history to a deleted namespace.
+
 ```unison:hide
-mynamespace.x = 1
+deleted.x = 1
+stuff.thing = 2
 ```
 
 ```ucm:hide
 .> add
-.> delete.namespace mynamespace
+.> delete.namespace .deleted
 ```
 
-The deleted namespace shouldn't appear in `ls` output.
-```ucm:error
-.> ls
-```
-```ucm:error
-.> ls.verbose
-```
-```ucm:error
-.> find mynamespace
-```
-
-
-The history of the namespace should still exist if requested explicitly.
+I should be allowed to fork over a deleted namespace
 
 ```ucm
-.> history mynamespace
+.> fork stuff deleted
 ```
 
-Merging an empty namespace should still copy its history if it has some.
+The history from the `deleted` namespace should have been overwritten by the history from `stuff`.
 
 ```ucm
-.empty> history
-.empty> merge .mynamespace
-.empty> history
+.> history stuff
+.> history deleted
 ```

--- a/unison-src/transcripts/empty-namespaces.output.md
+++ b/unison-src/transcripts/empty-namespaces.output.md
@@ -1,0 +1,75 @@
+# Empty namespace behaviours
+
+```unison
+mynamespace.x = 1
+```
+
+The deleted namespace shouldn't appear in `ls` output.
+```ucm
+.> ls
+
+  nothing to show
+
+```
+```ucm
+.> ls.verbose
+
+  😶
+  
+  No results. Check your spelling, or try using tab completion
+  to supply command arguments.
+
+```
+```ucm
+.> find mynamespace
+
+  😶
+  
+  No results. Check your spelling, or try using tab completion
+  to supply command arguments.
+
+```
+The history of the namespace should still exist if requested explicitly.
+
+```ucm
+.> history mynamespace
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ #qjc20aua9h
+  
+    - Deletes:
+    
+      x
+  
+  □ #hkrqt3tm05 (start of history)
+
+```
+Merging an empty namespace should still copy its history if it has some.
+
+```ucm
+  ☝️  The namespace .empty is empty.
+
+.empty> history
+
+  ☝️  The namespace .empty is empty.
+
+.empty> merge .mynamespace
+
+  Nothing changed as a result of the merge.
+
+.empty> history
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ #qjc20aua9h
+  
+    - Deletes:
+    
+      x
+  
+  □ #hkrqt3tm05 (start of history)
+
+```

--- a/unison-src/transcripts/empty-namespaces.output.md
+++ b/unison-src/transcripts/empty-namespaces.output.md
@@ -1,47 +1,3 @@
-<<<<<<< HEAD
-# Empty namespace behaviours
-
-## Operations on empty namespaces
-
-Add and then delete a term to add some history to a deleted namespace.
-
-```unison
-deleted.x = 1
-stuff.thing = 2
-```
-
-I should be allowed to fork over a deleted namespace
-
-```ucm
-.> fork stuff deleted
-
-  Done.
-
-```
-The history from the `deleted` namespace should have been overwritten by the history from `stuff`.
-
-```ucm
-.> history stuff
-
-  Note: The most recent namespace hash is immediately below this
-        message.
-  
-  
-  
-  □ #3bm1524lb7 (start of history)
-
-.> history deleted
-
-  Note: The most recent namespace hash is immediately below this
-        message.
-  
-  
-  
-  □ #3bm1524lb7 (start of history)
-
-```
-||||||| 138799f92
-=======
 # Empty namespace behaviours
 
 ```unison
@@ -73,6 +29,8 @@ The deleted namespace shouldn't appear in `ls` output.
   to supply command arguments.
 
 ```
+## history
+
 The history of the namespace should still exist if requested explicitly.
 
 ```ucm
@@ -117,4 +75,40 @@ Merging an empty namespace should still copy its history if it has some.
   □ #hkrqt3tm05 (start of history)
 
 ```
->>>>>>> trunk
+Add and then delete a term to add some history to a deleted namespace.
+
+```unison
+deleted.x = 1
+stuff.thing = 2
+```
+
+I should be allowed to fork over a deleted namespace
+
+```ucm
+.> fork stuff deleted
+
+  Done.
+
+```
+The history from the `deleted` namespace should have been overwritten by the history from `stuff`.
+
+```ucm
+.> history stuff
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  
+  
+  □ #3bm1524lb7 (start of history)
+
+.> history deleted
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  
+  
+  □ #3bm1524lb7 (start of history)
+
+```

--- a/unison-src/transcripts/empty-namespaces.output.md
+++ b/unison-src/transcripts/empty-namespaces.output.md
@@ -1,75 +1,41 @@
 # Empty namespace behaviours
 
+## Operations on empty namespaces
+
+Add and then delete a term to add some history to a deleted namespace.
+
 ```unison
-mynamespace.x = 1
+deleted.x = 1
+stuff.thing = 2
 ```
 
-The deleted namespace shouldn't appear in `ls` output.
-```ucm
-.> ls
+I should be allowed to fork over a deleted namespace
 
-  nothing to show
+```ucm
+.> fork stuff deleted
+
+  Done.
 
 ```
-```ucm
-.> ls.verbose
-
-  😶
-  
-  No results. Check your spelling, or try using tab completion
-  to supply command arguments.
-
-```
-```ucm
-.> find mynamespace
-
-  😶
-  
-  No results. Check your spelling, or try using tab completion
-  to supply command arguments.
-
-```
-The history of the namespace should still exist if requested explicitly.
+The history from the `deleted` namespace should have been overwritten by the history from `stuff`.
 
 ```ucm
-.> history mynamespace
+.> history stuff
 
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #qjc20aua9h
   
-    - Deletes:
-    
-      x
   
-  □ #hkrqt3tm05 (start of history)
+  □ #3bm1524lb7 (start of history)
 
-```
-Merging an empty namespace should still copy its history if it has some.
-
-```ucm
-  ☝️  The namespace .empty is empty.
-
-.empty> history
-
-  ☝️  The namespace .empty is empty.
-
-.empty> merge .mynamespace
-
-  Nothing changed as a result of the merge.
-
-.empty> history
+.> history deleted
 
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #qjc20aua9h
   
-    - Deletes:
-    
-      x
   
-  □ #hkrqt3tm05 (start of history)
+  □ #3bm1524lb7 (start of history)
 
 ```


### PR DESCRIPTION
## Overview

We now keep branch history when the contents of that branch is deleted. This requires updating a few commands to understand the difference between a branch with no history and a branch which has an "empty" HEAD.

Before this change, deleting a namespace meant you can't pull or fork over that namespace since there's still a history there.

After this change, pull/fork over a namespace with an empty head just overwrites the history at that location with the new branch's history.

## Implementation notes

Just required updating a few checks to use use `Branch.isEmpty0` instead.

Note, this must be merged after #2729  since that PR updates the behaviour of `isEmpty0` to be more correct for nested deletions.

## Interesting/controversial decisions

It's a bit annoying to always need to make this distinction between types of "empty". I think we can probably address that in our branch abstraction somehow, but branches with an empty head state that still have history is an important state that branches can be in, so we can't just pretend that state doesn't exist 😋 

## Test coverage

Added a transcript which tests the new behaviours.

@ceedubs 