### PR TITLE
bump schema version for new codebases from 1 to 2

### DIFF
--- a/codebase2/codebase-sqlite/sql/create.sql
+++ b/codebase2/codebase-sqlite/sql/create.sql
@@ -3,7 +3,7 @@
 CREATE TABLE schema_version (
   version INTEGER NOT NULL
 );
-INSERT INTO schema_version (version) VALUES (1);
+INSERT INTO schema_version (version) VALUES (2);
 
 -- actually stores the 512-byte hashes
 CREATE TABLE hash (


### PR DESCRIPTION
Before:
```
% stack exec unison -- --codebase-create /tmp/cc --no-base
I backed up your codebase to /tmp/cc/.unison/v2/unison.sqlite3.1638651932
Need: BranchE (ObjectId 1)
Done: BranchE (ObjectId 1)
Done: CausalE CausalHashId (HashId 1)
Finished migrating, initiating cleanup.

  I created a new codebase for you at /private/tmp/cc

  Now starting the Unison Codebase Manager (UCM)...
```

After:
```
% stack exec unison -- --codebase-create /tmp/cc2 --no-base 

  I created a new codebase for you at /private/tmp/cc2

  Now starting the Unison Codebase Manager (UCM)...
```