### PR TITLE
Kill forked threads when runtime evaluation completes.

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -14,6 +14,7 @@ module Unison.Runtime.Interface
   , runStandalone
   , StoredCache
   , decodeStandalone
+  , RuntimeHost(..)
   ) where
 
 import GHC.Stack (HasCallStack)
@@ -427,7 +428,7 @@ decodeStandalone b = bimap thd thd $ runGetOrFail g b
     <*> getNat
     <*> getStoredCache
 
--- | Whether the runtime is being run within a UCM session or as a standalone process.
+-- | Whether the runtime is hosted within a UCM session or as a standalone process.
 data RuntimeHost
   = Standalone
   | UCM

--- a/parser-typechecker/src/Unison/Runtime/Machine.hs
+++ b/parser-typechecker/src/Unison/Runtime/Machine.hs
@@ -136,11 +136,11 @@ infos :: String -> String -> IO ()
 infos ctx s = putStrLn $ ctx ++ ": " ++ s
 
 -- Entry point for evaluating a section
-eval0 :: CCache -> Section -> IO ()
-eval0 !env !co = do
+eval0 :: CCache -> (ThreadId -> IO ()) -> Section -> IO ()
+eval0 !env !trackThreads !co = do
   ustk <- alloc
   bstk <- alloc
-  eval env mempty ustk bstk KE co
+  eval env mempty trackThreads ustk bstk KE co
 
 topDEnv
   :: M.Map Reference Word64
@@ -162,8 +162,8 @@ topDEnv _ _ = (mempty, id)
 -- environment currently.
 apply0
   :: Maybe (Stack 'UN -> Stack 'BX -> IO ())
-  -> CCache -> Word64 -> IO ()
-apply0 !callback !env !i = do
+  -> CCache -> (ThreadId -> IO ()) -> Word64 -> IO ()
+apply0 !callback !env !threadTracker !i = do
     ustk <- alloc
     bstk <- alloc
     cmbrs <- readTVarIO $ combRefs env
@@ -172,7 +172,7 @@ apply0 !callback !env !i = do
     r <- case EC.lookup i cmbrs of
            Just r -> pure r
            Nothing -> die "apply0: missing reference to entry point"
-    apply env denv ustk bstk (kf k0) True ZArgs
+    apply env denv threadTracker ustk bstk (kf k0) True ZArgs
       $ PAp (CIx r i 0) unull bnull
   where
   k0 = maybe KE (CB . Hook) callback
@@ -181,11 +181,11 @@ apply0 !callback !env !i = do
 -- necessary to evaluate a closure with the provided information.
 apply1
   :: (Stack 'UN -> Stack 'BX -> IO ())
-  -> CCache -> Closure -> IO ()
-apply1 callback env clo = do
+  -> CCache -> (ThreadId -> IO ()) -> Closure -> IO ()
+apply1 callback env threadTracker clo = do
   ustk <- alloc
   bstk <- alloc
-  apply env mempty ustk bstk k0 True ZArgs clo
+  apply env mempty threadTracker ustk bstk k0 True ZArgs clo
   where
   k0 = CB $ Hook callback
 
@@ -211,40 +211,40 @@ lookupDenv :: Word64 -> DEnv -> Closure
 lookupDenv p denv = fromMaybe BlackHole $ EC.lookup p denv
 
 exec
-  :: CCache -> DEnv
+  :: CCache -> DEnv -> (ThreadId -> IO ())
   -> Stack 'UN -> Stack 'BX -> K
   -> Instr
   -> IO (DEnv, Stack 'UN, Stack 'BX, K)
-exec !_   !denv !ustk !bstk !k (Info tx) = do
+exec !_   !denv !_trackThreads !ustk !bstk !k (Info tx) = do
   info tx ustk
   info tx bstk
   info tx k
   pure (denv, ustk, bstk, k)
-exec !env !denv !ustk !bstk !k (Name r args) = do
+exec !env !denv !_trackThreads !ustk !bstk !k (Name r args) = do
   bstk <- name ustk bstk args =<< resolve env denv bstk r
   pure (denv, ustk, bstk, k)
-exec !_   !denv !ustk !bstk !k (SetDyn p i) = do
+exec !_   !denv !_trackThreads !ustk !bstk !k (SetDyn p i) = do
   clo <- peekOff bstk i
   pure (EC.mapInsert p clo denv, ustk, bstk, k)
-exec !_   !denv !ustk !bstk !k (Capture p) = do
+exec !_   !denv !_trackThreads !ustk !bstk !k (Capture p) = do
   (sk,denv,ustk,bstk,useg,bseg,k) <- splitCont denv ustk bstk k p
   bstk <- bump bstk
   poke bstk $ Captured sk useg bseg
   pure (denv, ustk, bstk, k)
-exec !_   !denv !ustk !bstk !k (UPrim1 op i) = do
+exec !_   !denv !_trackThreads !ustk !bstk !k (UPrim1 op i) = do
   ustk <- uprim1 ustk op i
   pure (denv, ustk, bstk, k)
-exec !_   !denv !ustk !bstk !k (UPrim2 op i j) = do
+exec !_   !denv !_trackThreads !ustk !bstk !k (UPrim2 op i j) = do
   ustk <- uprim2 ustk op i j
   pure (denv, ustk, bstk, k)
-exec !env !denv !ustk !bstk !k (BPrim1 MISS i) = do
+exec !env !denv !_trackThreads !ustk !bstk !k (BPrim1 MISS i) = do
   clink <- peekOff bstk i
   let Ref link = unwrapForeign $ marshalToForeign clink
   m <- readTVarIO (intermed env)
   ustk <- bump ustk
   if (link `M.member` m) then poke ustk 1 else poke ustk 0
   pure (denv, ustk, bstk, k)
-exec !env !denv !ustk !bstk !k (BPrim1 CACH i) = do
+exec !env !denv !_trackThreads !ustk !bstk !k (BPrim1 CACH i) = do
   arg <- peekOffS bstk i
   news <- decodeCacheArgument arg
   unknown <- cacheAdd news env
@@ -252,7 +252,7 @@ exec !env !denv !ustk !bstk !k (BPrim1 CACH i) = do
   pokeS bstk
     (Sq.fromList $ Foreign . Wrap Rf.termLinkRef . Ref <$> unknown)
   pure (denv, ustk, bstk, k)
-exec !env !denv !ustk !bstk !k (BPrim1 CVLD i) = do
+exec !env !denv !_trackThreads !ustk !bstk !k (BPrim1 CVLD i) = do
   arg <- peekOffS bstk i
   news <- decodeCacheArgument arg
   codeValidate news env >>= \case
@@ -269,7 +269,7 @@ exec !env !denv !ustk !bstk !k (BPrim1 CVLD i) = do
       pokeOff bstk 2 clo
       pure (denv, ustk, bstk, k)
 
-exec !env !denv !ustk !bstk !k (BPrim1 LKUP i) = do
+exec !env !denv !_trackThreads !ustk !bstk !k (BPrim1 LKUP i) = do
   clink <- peekOff bstk i
   let Ref link = unwrapForeign $ marshalToForeign clink
   m <- readTVarIO (intermed env)
@@ -281,14 +281,14 @@ exec !env !denv !ustk !bstk !k (BPrim1 LKUP i) = do
       bstk <- bump bstk
       bstk <$ pokeBi bstk sg
   pure (denv, ustk, bstk, k)
-exec !_ !denv !ustk !bstk !k (BPrim1 TLTT i) = do
+exec !_ !denv !_trackThreads !ustk !bstk !k (BPrim1 TLTT i) = do
   clink <- peekOff bstk i
   let Ref link = unwrapForeign $ marshalToForeign clink
   let sh = Util.Text.fromText . SH.toText $ toShortHash link
   bstk <- bump bstk
   pokeBi bstk sh
   pure (denv, ustk, bstk, k)
-exec !env !denv !ustk !bstk !k (BPrim1 LOAD i) = do
+exec !env !denv !_trackThreads !ustk !bstk !k (BPrim1 LOAD i) = do
   v <- peekOffBi bstk i
   ustk <- bump ustk
   bstk <- bump bstk
@@ -301,139 +301,141 @@ exec !env !denv !ustk !bstk !k (BPrim1 LOAD i) = do
       poke ustk 1
       poke bstk x
   pure (denv, ustk, bstk, k)
-exec !env !denv !ustk !bstk !k (BPrim1 VALU i) = do
+exec !env !denv !_trackThreads !ustk !bstk !k (BPrim1 VALU i) = do
   m <- readTVarIO (tagRefs env)
   c <- peekOff bstk i
   bstk <- bump bstk
   pokeBi bstk =<< reflectValue m c
   pure (denv, ustk, bstk, k)
-exec !_   !denv !ustk !bstk !k (BPrim1 op i) = do
+exec !_   !denv !_trackThreads !ustk !bstk !k (BPrim1 op i) = do
   (ustk,bstk) <- bprim1 ustk bstk op i
   pure (denv, ustk, bstk, k)
-exec !_   !denv !ustk !bstk !k (BPrim2 EQLU i j) = do
+exec !_   !denv !_trackThreads !ustk !bstk !k (BPrim2 EQLU i j) = do
   x <- peekOff bstk i
   y <- peekOff bstk j
   ustk <- bump ustk
   poke ustk $ if universalEq (==) x y then 1 else 0
   pure (denv, ustk, bstk, k)
-exec !_   !denv !ustk !bstk !k (BPrim2 CMPU i j) = do
+exec !_   !denv !_trackThreads !ustk !bstk !k (BPrim2 CMPU i j) = do
   x <- peekOff bstk i
   y <- peekOff bstk j
   ustk <- bump ustk
   poke ustk . fromEnum $ universalCompare compare x y
   pure (denv, ustk, bstk, k)
-exec !env !denv !ustk !bstk !k (BPrim2 TRCE i j) = do
+exec !env !denv !_trackThreads !ustk !bstk !k (BPrim2 TRCE i j) = do
   tx <- peekOffBi bstk i
   clo <- peekOff bstk j
   tracer env tx clo
   pure (denv, ustk, bstk, k)
-exec !_   !denv !ustk !bstk !k (BPrim2 op i j) = do
+exec !_   !denv !_trackThreads !ustk !bstk !k (BPrim2 op i j) = do
   (ustk,bstk) <- bprim2 ustk bstk op i j
   pure (denv, ustk, bstk, k)
-exec !_   !denv !ustk !bstk !k (Pack r t args) = do
+exec !_   !denv !_trackThreads !ustk !bstk !k (Pack r t args) = do
   clo <- buildData ustk bstk r t args
   bstk <- bump bstk
   poke bstk clo
   pure (denv, ustk, bstk, k)
-exec !_   !denv !ustk !bstk !k (Unpack r i) = do
+exec !_   !denv !_trackThreads !ustk !bstk !k (Unpack r i) = do
   (ustk, bstk) <- dumpData r ustk bstk =<< peekOff bstk i
   pure (denv, ustk, bstk, k)
-exec !_   !denv !ustk !bstk !k (Print i) = do
+exec !_   !denv !_trackThreads !ustk !bstk !k (Print i) = do
   t <- peekOffBi bstk i
   Tx.putStrLn (Util.Text.toText t)
   pure (denv, ustk, bstk, k)
-exec !_   !denv !ustk !bstk !k (Lit (MI n)) = do
+exec !_   !denv !_trackThreads !ustk !bstk !k (Lit (MI n)) = do
   ustk <- bump ustk
   poke ustk n
   pure (denv, ustk, bstk, k)
-exec !_   !denv !ustk !bstk !k (Lit (MD d)) = do
+exec !_   !denv !_trackThreads !ustk !bstk !k (Lit (MD d)) = do
   ustk <- bump ustk
   pokeD ustk d
   pure (denv, ustk, bstk, k)
-exec !_   !denv !ustk !bstk !k (Lit (MT t)) = do
+exec !_   !denv !_trackThreads !ustk !bstk !k (Lit (MT t)) = do
   bstk <- bump bstk
   poke bstk (Foreign (Wrap Rf.textRef t))
   pure (denv, ustk, bstk, k)
-exec !_   !denv !ustk !bstk !k (Lit (MM r)) = do
+exec !_   !denv !_trackThreads !ustk !bstk !k (Lit (MM r)) = do
   bstk <- bump bstk
   poke bstk (Foreign (Wrap Rf.termLinkRef r))
   pure (denv, ustk, bstk, k)
-exec !_   !denv !ustk !bstk !k (Lit (MY r)) = do
+exec !_   !denv !_trackThreads !ustk !bstk !k (Lit (MY r)) = do
   bstk <- bump bstk
   poke bstk (Foreign (Wrap Rf.typeLinkRef r))
   pure (denv, ustk, bstk, k)
-exec !_   !denv !ustk !bstk !k (Reset ps) = do
+exec !_   !denv !_trackThreads !ustk !bstk !k (Reset ps) = do
   pure (denv, ustk, bstk, Mark ps clos k)
  where clos = EC.restrictKeys denv ps
-exec !_   !denv !ustk !bstk !k (Seq as) = do
+exec !_   !denv !_trackThreads !ustk !bstk !k (Seq as) = do
   l <- closureArgs bstk as
   bstk <- bump bstk
   pokeS bstk $ Sq.fromList l
   pure (denv, ustk, bstk, k)
-exec !env !denv !ustk !bstk !k (ForeignCall _ w args)
+exec !env !denv !_trackThreads !ustk !bstk !k (ForeignCall _ w args)
   | Just (FF arg res ev) <- EC.lookup w (foreignFuncs env)
   = uncurry (denv,,,k)
       <$> (arg ustk bstk args >>= ev >>= res ustk bstk)
   | otherwise
     = die $ "reference to unknown foreign function: " ++ show w
-exec !env !denv !ustk !bstk !k (Fork i) = do
-  tid <- forkEval env =<< peekOff bstk i
+exec !env !denv !trackThreads !ustk !bstk !k (Fork i) = do
+  tid <- forkEval env trackThreads =<< peekOff bstk i
   bstk <- bump bstk
   poke bstk . Foreign . Wrap Rf.threadIdRef $ tid
   pure (denv, ustk, bstk, k)
-exec !env !denv !ustk !bstk !k (Atomically i) = do
+exec !env !denv !trackThreads !ustk !bstk !k (Atomically i) = do
   c <- peekOff bstk i
   bstk <- bump bstk
-  atomicEval env (poke bstk) c
+  atomicEval env trackThreads (poke bstk) c
   pure (denv, ustk, bstk, k)
 {-# inline exec #-}
 
-eval :: CCache -> DEnv
+eval :: CCache -> DEnv -> (ThreadId -> IO ())
      -> Stack 'UN -> Stack 'BX -> K -> Section -> IO ()
-eval !env !denv !ustk !bstk !k (Match i (TestT df cs)) = do
+eval !env !denv !trackThreads !ustk !bstk !k (Match i (TestT df cs)) = do
   t <- peekOffBi bstk i
-  eval env denv ustk bstk k $ selectTextBranch t df cs
-eval !env !denv !ustk !bstk !k (Match i br) = do
+  eval env denv trackThreads ustk bstk k $ selectTextBranch t df cs
+eval !env !denv !trackThreads !ustk !bstk !k (Match i br) = do
   n <- peekOffN ustk i
-  eval env denv ustk bstk k $ selectBranch n br
-eval !env !denv !ustk !bstk !k (Yield args)
+  eval env denv trackThreads ustk bstk k $ selectBranch n br
+eval !env !denv !trackThreads !ustk !bstk !k (Yield args)
   | asize ustk + asize bstk > 0 , BArg1 i <- args = do
-    peekOff bstk i >>= apply env denv ustk bstk k False ZArgs
+    peekOff bstk i >>= apply env denv trackThreads ustk bstk k False ZArgs
   | otherwise = do
     (ustk, bstk) <- moveArgs ustk bstk args
     ustk <- frameArgs ustk
     bstk <- frameArgs bstk
-    yield env denv ustk bstk k
-eval !env !denv !ustk !bstk !k (App ck r args) =
+    yield env denv trackThreads ustk bstk k
+eval !env !denv !trackThreads !ustk !bstk !k (App ck r args) =
   resolve env denv bstk r
-    >>= apply env denv ustk bstk k ck args
-eval !env !denv !ustk !bstk !k (Call ck n args) =
+    >>= apply env denv trackThreads ustk bstk k ck args
+eval !env !denv !trackThreads !ustk !bstk !k (Call ck n args) =
   combSection env (CIx dummyRef n 0)
-    >>= enter env denv ustk bstk k ck args
-eval !env !denv !ustk !bstk !k (Jump i args) =
-  peekOff bstk i >>= jump env denv ustk bstk k args
-eval !env !denv !ustk !bstk !k (Let nw cix) = do
+    >>= enter env denv trackThreads ustk bstk k ck args
+eval !env !denv !trackThreads !ustk !bstk !k (Jump i args) =
+  peekOff bstk i >>= jump env denv trackThreads ustk bstk k args
+eval !env !denv !trackThreads !ustk !bstk !k (Let nw cix) = do
   (ustk, ufsz, uasz) <- saveFrame ustk
   (bstk, bfsz, basz) <- saveFrame bstk
-  eval env denv ustk bstk (Push ufsz bfsz uasz basz cix k) nw
-eval !env !denv !ustk !bstk !k (Ins i nx) = do
-  (denv, ustk, bstk, k) <- exec env denv ustk bstk k i
-  eval env denv ustk bstk k nx
-eval !_   !_    !_    !_    !_ Exit = pure ()
-eval !_   !_    !_    !_    !_ (Die s) = die s
+  eval env denv trackThreads ustk bstk (Push ufsz bfsz uasz basz cix k) nw
+eval !env !denv !trackThreads !ustk !bstk !k (Ins i nx) = do
+  (denv, ustk, bstk, k) <- exec env denv trackThreads ustk bstk k i
+  eval env denv trackThreads ustk bstk k nx
+eval !_   !_    !_    !_trackThreads !_    !_ Exit = pure ()
+eval !_   !_    !_    !_trackThreads !_    !_ (Die s) = die s
 {-# noinline eval #-}
 
-forkEval :: CCache -> Closure -> IO ThreadId
-forkEval env clo
-  = forkIO (apply1 err env clo)
+forkEval :: CCache -> (ThreadId -> IO ()) -> Closure -> IO ThreadId
+forkEval env trackThreads clo
+  = do threadId <- forkIO (apply1 err env trackThreads clo)
+       trackThreads threadId
+       pure threadId
   where
   err :: Stack 'UN -> Stack 'BX -> IO ()
   err _ _ = pure ()
 {-# inline forkEval #-}
 
-atomicEval :: CCache -> (Closure -> IO ()) -> Closure -> IO ()
-atomicEval env write clo
-  = atomically . unsafeIOToSTM $ apply1 readBack env clo
+atomicEval :: CCache -> (ThreadId -> IO ()) -> (Closure -> IO ()) -> Closure -> IO ()
+atomicEval env trackThreads write clo
+  = atomically . unsafeIOToSTM $ apply1 readBack env trackThreads clo
   where
   readBack :: Stack 'UN -> Stack 'BX -> IO ()
   readBack _ bstk = peek bstk >>= write
@@ -441,15 +443,15 @@ atomicEval env write clo
 
 -- fast path application
 enter
-  :: CCache -> DEnv -> Stack 'UN -> Stack 'BX -> K
+  :: CCache -> DEnv -> (ThreadId -> IO ()) -> Stack 'UN -> Stack 'BX -> K
   -> Bool -> Args -> Comb -> IO ()
-enter !env !denv !ustk !bstk !k !ck !args !comb = do
+enter !env !denv !trackThreads !ustk !bstk !k !ck !args !comb = do
   ustk <- if ck then ensure ustk uf else pure ustk
   bstk <- if ck then ensure bstk bf else pure bstk
   (ustk, bstk) <- moveArgs ustk bstk args
   ustk <- acceptArgs ustk ua
   bstk <- acceptArgs bstk ba
-  eval env denv ustk bstk k entry
+  eval env denv trackThreads ustk bstk k entry
   where
   Lam ua ba uf bf entry = comb
 {-# inline enter #-}
@@ -467,9 +469,9 @@ name !ustk !bstk !args clo = case clo of
 
 -- slow path application
 apply
-  :: CCache -> DEnv -> Stack 'UN -> Stack 'BX -> K
+  :: CCache -> DEnv -> (ThreadId -> IO ()) -> Stack 'UN -> Stack 'BX -> K
   -> Bool -> Args -> Closure -> IO ()
-apply !env !denv !ustk !bstk !k !ck !args (PAp comb useg bseg) =
+apply !env !denv !trackThreads !ustk !bstk !k !ck !args (PAp comb useg bseg) =
   combSection env comb >>= \case
     Lam ua ba uf bf entry
       | ck || ua <= uac && ba <= bac -> do
@@ -480,48 +482,48 @@ apply !env !denv !ustk !bstk !k !ck !args (PAp comb useg bseg) =
         bstk <- dumpSeg bstk bseg A
         ustk <- acceptArgs ustk ua
         bstk <- acceptArgs bstk ba
-        eval env denv ustk bstk k entry
+        eval env denv trackThreads ustk bstk k entry
       | otherwise -> do
         (useg, bseg) <- closeArgs C ustk bstk useg bseg args
         ustk <- discardFrame =<< frameArgs ustk
         bstk <- discardFrame =<< frameArgs bstk
         bstk <- bump bstk
         poke bstk $ PAp comb useg bseg
-        yield env denv ustk bstk k
+        yield env denv trackThreads ustk bstk k
   where
   uac = asize ustk + ucount args + uscount useg
   bac = asize bstk + bcount args + bscount bseg
-apply !env !denv !ustk !bstk !k !_  !args clo
+apply !env !denv !trackThreads !ustk !bstk !k !_  !args clo
   | ZArgs <- args, asize ustk == 0, asize bstk == 0 = do
     ustk <- discardFrame ustk
     bstk <- discardFrame bstk
     bstk <- bump bstk
     poke bstk clo
-    yield env denv ustk bstk k
+    yield env denv trackThreads ustk bstk k
   | otherwise = die $ "applying non-function: " ++ show clo
 {-# inline apply #-}
 
 jump
-  :: CCache -> DEnv
+  :: CCache -> DEnv -> (ThreadId -> IO ())
   -> Stack 'UN -> Stack 'BX -> K
   -> Args -> Closure -> IO ()
-jump !env !denv !ustk !bstk !k !args clo = case clo of
+jump !env !denv !trackThreads !ustk !bstk !k !args clo = case clo of
   Captured sk useg bseg -> do
     (useg, bseg) <- closeArgs K ustk bstk useg bseg args
     ustk <- discardFrame ustk
     bstk <- discardFrame bstk
     ustk <- dumpSeg ustk useg . F $ ucount args
     bstk <- dumpSeg bstk bseg . F $ bcount args
-    repush env ustk bstk denv sk k
+    repush env trackThreads ustk bstk denv sk k
   _ -> die "jump: non-cont"
 {-# inline jump #-}
 
 repush
-  :: CCache
+  :: CCache -> (ThreadId -> IO ())
   -> Stack 'UN -> Stack 'BX -> DEnv -> K -> K -> IO ()
-repush !env !ustk !bstk = go
+repush !env !trackThreads !ustk !bstk = go
  where
- go !denv KE !k = yield env denv ustk bstk k
+ go !denv KE !k = yield env denv trackThreads ustk bstk k
  go !denv (Mark ps cs sk) !k = go denv' sk $ Mark ps cs' k
   where
   denv' = cs <> EC.withoutKeys denv ps
@@ -1405,22 +1407,22 @@ bprim2 !ustk !bstk CMPU _ _ = pure (ustk, bstk) -- impossible
 {-# inline bprim2 #-}
 
 yield
-  :: CCache -> DEnv
+  :: CCache -> DEnv -> (ThreadId -> IO ())
   -> Stack 'UN -> Stack 'BX -> K -> IO ()
-yield !env !denv !ustk !bstk !k = leap denv k
+yield !env !denv !trackThreads !ustk !bstk !k = leap denv k
  where
  leap !denv0 (Mark ps cs k) = do
    let denv = cs <> EC.withoutKeys denv0 ps
        clo = denv0 EC.! EC.findMin ps
    poke bstk . DataB1 Rf.effectRef 0 =<< peek bstk
-   apply env denv ustk bstk k False (BArg1 0) clo
+   apply env denv trackThreads ustk bstk k False (BArg1 0) clo
  leap !denv (Push ufsz bfsz uasz basz cix k) = do
    Lam _ _ uf bf nx <- combSection env cix
    ustk <- restoreFrame ustk ufsz uasz
    bstk <- restoreFrame bstk bfsz basz
    ustk <- ensure ustk uf
    bstk <- ensure bstk bf
-   eval env denv ustk bstk k nx
+   eval env denv trackThreads ustk bstk k nx
  leap _ (CB (Hook f)) = f ustk bstk
  leap _ KE = pure ()
 {-# inline yield #-}

--- a/parser-typechecker/src/Unison/Runtime/Machine.hs
+++ b/parser-typechecker/src/Unison/Runtime/Machine.hs
@@ -13,13 +13,10 @@ import GHC.Stack
 import Control.Concurrent.STM as STM
 import GHC.Conc as STM (unsafeIOToSTM)
 
-import Data.Maybe (fromMaybe)
 
 import Data.Bits
-import Data.Foldable (toList, traverse_, fold)
 import Data.Ord (comparing)
 import Data.Traversable
-import Data.Word (Word64)
 
 import qualified Data.Text as DTx
 import qualified Unison.Util.Text as Util.Text
@@ -29,12 +26,10 @@ import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 
 import Control.Exception
-import Control.Lens ((<&>))
-import Control.Concurrent (forkIO, ThreadId)
+import Control.Concurrent (ThreadId)
 
 import qualified Data.Primitive.PrimArray as PA
 
-import Text.Read (readMaybe)
 
 import Unison.Builtin.Decls (exceptionRef, ioFailureRef)
 import Unison.Reference (Reference(Builtin), toShortHash)
@@ -67,7 +62,18 @@ import qualified Unison.Builtin.Decls as Rf
 import qualified Unison.Util.Bytes as By
 import Unison.Util.Pretty (toPlainUnbroken)
 import Unison.Util.EnumContainers as EC
+import UnliftIO (IORef)
+import qualified UnliftIO
+import qualified UnliftIO.Concurrent as UnliftIO
+import Unison.Prelude
+import qualified Data.Set as Set
 
+-- | A ref storing every currently active thread.
+-- This is helpful for cleaning up orphaned threads when the main process
+-- completes. We track threads when running in a host process like UCM,
+-- otherwise we don't bother since forked threads are cleaned up automatically on
+-- termination.
+type ActiveThreads = Maybe (IORef (Set ThreadId))
 type Tag = Word64
 
 -- dynamic environment
@@ -136,11 +142,11 @@ infos :: String -> String -> IO ()
 infos ctx s = putStrLn $ ctx ++ ": " ++ s
 
 -- Entry point for evaluating a section
-eval0 :: CCache -> (ThreadId -> IO ()) -> Section -> IO ()
-eval0 !env !trackThreads !co = do
+eval0 :: CCache -> ActiveThreads -> Section -> IO ()
+eval0 !env !activeThreads !co = do
   ustk <- alloc
   bstk <- alloc
-  eval env mempty trackThreads ustk bstk KE co
+  eval env mempty activeThreads ustk bstk KE co
 
 topDEnv
   :: M.Map Reference Word64
@@ -162,7 +168,7 @@ topDEnv _ _ = (mempty, id)
 -- environment currently.
 apply0
   :: Maybe (Stack 'UN -> Stack 'BX -> IO ())
-  -> CCache -> (ThreadId -> IO ()) -> Word64 -> IO ()
+  -> CCache -> ActiveThreads -> Word64 -> IO ()
 apply0 !callback !env !threadTracker !i = do
     ustk <- alloc
     bstk <- alloc
@@ -181,7 +187,7 @@ apply0 !callback !env !threadTracker !i = do
 -- necessary to evaluate a closure with the provided information.
 apply1
   :: (Stack 'UN -> Stack 'BX -> IO ())
-  -> CCache -> (ThreadId -> IO ()) -> Closure -> IO ()
+  -> CCache -> ActiveThreads -> Closure -> IO ()
 apply1 callback env threadTracker clo = do
   ustk <- alloc
   bstk <- alloc
@@ -211,40 +217,40 @@ lookupDenv :: Word64 -> DEnv -> Closure
 lookupDenv p denv = fromMaybe BlackHole $ EC.lookup p denv
 
 exec
-  :: CCache -> DEnv -> (ThreadId -> IO ())
+  :: CCache -> DEnv -> ActiveThreads
   -> Stack 'UN -> Stack 'BX -> K
   -> Instr
   -> IO (DEnv, Stack 'UN, Stack 'BX, K)
-exec !_   !denv !_trackThreads !ustk !bstk !k (Info tx) = do
+exec !_   !denv !_activeThreads !ustk !bstk !k (Info tx) = do
   info tx ustk
   info tx bstk
   info tx k
   pure (denv, ustk, bstk, k)
-exec !env !denv !_trackThreads !ustk !bstk !k (Name r args) = do
+exec !env !denv !_activeThreads !ustk !bstk !k (Name r args) = do
   bstk <- name ustk bstk args =<< resolve env denv bstk r
   pure (denv, ustk, bstk, k)
-exec !_   !denv !_trackThreads !ustk !bstk !k (SetDyn p i) = do
+exec !_   !denv !_activeThreads !ustk !bstk !k (SetDyn p i) = do
   clo <- peekOff bstk i
   pure (EC.mapInsert p clo denv, ustk, bstk, k)
-exec !_   !denv !_trackThreads !ustk !bstk !k (Capture p) = do
+exec !_   !denv !_activeThreads !ustk !bstk !k (Capture p) = do
   (sk,denv,ustk,bstk,useg,bseg,k) <- splitCont denv ustk bstk k p
   bstk <- bump bstk
   poke bstk $ Captured sk useg bseg
   pure (denv, ustk, bstk, k)
-exec !_   !denv !_trackThreads !ustk !bstk !k (UPrim1 op i) = do
+exec !_   !denv !_activeThreads !ustk !bstk !k (UPrim1 op i) = do
   ustk <- uprim1 ustk op i
   pure (denv, ustk, bstk, k)
-exec !_   !denv !_trackThreads !ustk !bstk !k (UPrim2 op i j) = do
+exec !_   !denv !_activeThreads !ustk !bstk !k (UPrim2 op i j) = do
   ustk <- uprim2 ustk op i j
   pure (denv, ustk, bstk, k)
-exec !env !denv !_trackThreads !ustk !bstk !k (BPrim1 MISS i) = do
+exec !env !denv !_activeThreads !ustk !bstk !k (BPrim1 MISS i) = do
   clink <- peekOff bstk i
   let Ref link = unwrapForeign $ marshalToForeign clink
   m <- readTVarIO (intermed env)
   ustk <- bump ustk
   if (link `M.member` m) then poke ustk 1 else poke ustk 0
   pure (denv, ustk, bstk, k)
-exec !env !denv !_trackThreads !ustk !bstk !k (BPrim1 CACH i) = do
+exec !env !denv !_activeThreads !ustk !bstk !k (BPrim1 CACH i) = do
   arg <- peekOffS bstk i
   news <- decodeCacheArgument arg
   unknown <- cacheAdd news env
@@ -252,7 +258,7 @@ exec !env !denv !_trackThreads !ustk !bstk !k (BPrim1 CACH i) = do
   pokeS bstk
     (Sq.fromList $ Foreign . Wrap Rf.termLinkRef . Ref <$> unknown)
   pure (denv, ustk, bstk, k)
-exec !env !denv !_trackThreads !ustk !bstk !k (BPrim1 CVLD i) = do
+exec !env !denv !_activeThreads !ustk !bstk !k (BPrim1 CVLD i) = do
   arg <- peekOffS bstk i
   news <- decodeCacheArgument arg
   codeValidate news env >>= \case
@@ -269,7 +275,7 @@ exec !env !denv !_trackThreads !ustk !bstk !k (BPrim1 CVLD i) = do
       pokeOff bstk 2 clo
       pure (denv, ustk, bstk, k)
 
-exec !env !denv !_trackThreads !ustk !bstk !k (BPrim1 LKUP i) = do
+exec !env !denv !_activeThreads !ustk !bstk !k (BPrim1 LKUP i) = do
   clink <- peekOff bstk i
   let Ref link = unwrapForeign $ marshalToForeign clink
   m <- readTVarIO (intermed env)
@@ -281,14 +287,14 @@ exec !env !denv !_trackThreads !ustk !bstk !k (BPrim1 LKUP i) = do
       bstk <- bump bstk
       bstk <$ pokeBi bstk sg
   pure (denv, ustk, bstk, k)
-exec !_ !denv !_trackThreads !ustk !bstk !k (BPrim1 TLTT i) = do
+exec !_ !denv !_activeThreads !ustk !bstk !k (BPrim1 TLTT i) = do
   clink <- peekOff bstk i
   let Ref link = unwrapForeign $ marshalToForeign clink
   let sh = Util.Text.fromText . SH.toText $ toShortHash link
   bstk <- bump bstk
   pokeBi bstk sh
   pure (denv, ustk, bstk, k)
-exec !env !denv !_trackThreads !ustk !bstk !k (BPrim1 LOAD i) = do
+exec !env !denv !_activeThreads !ustk !bstk !k (BPrim1 LOAD i) = do
   v <- peekOffBi bstk i
   ustk <- bump ustk
   bstk <- bump bstk
@@ -301,28 +307,28 @@ exec !env !denv !_trackThreads !ustk !bstk !k (BPrim1 LOAD i) = do
       poke ustk 1
       poke bstk x
   pure (denv, ustk, bstk, k)
-exec !env !denv !_trackThreads !ustk !bstk !k (BPrim1 VALU i) = do
+exec !env !denv !_activeThreads !ustk !bstk !k (BPrim1 VALU i) = do
   m <- readTVarIO (tagRefs env)
   c <- peekOff bstk i
   bstk <- bump bstk
   pokeBi bstk =<< reflectValue m c
   pure (denv, ustk, bstk, k)
-exec !_   !denv !_trackThreads !ustk !bstk !k (BPrim1 op i) = do
+exec !_   !denv !_activeThreads !ustk !bstk !k (BPrim1 op i) = do
   (ustk,bstk) <- bprim1 ustk bstk op i
   pure (denv, ustk, bstk, k)
-exec !_   !denv !_trackThreads !ustk !bstk !k (BPrim2 EQLU i j) = do
+exec !_   !denv !_activeThreads !ustk !bstk !k (BPrim2 EQLU i j) = do
   x <- peekOff bstk i
   y <- peekOff bstk j
   ustk <- bump ustk
   poke ustk $ if universalEq (==) x y then 1 else 0
   pure (denv, ustk, bstk, k)
-exec !_   !denv !_trackThreads !ustk !bstk !k (BPrim2 CMPU i j) = do
+exec !_   !denv !_activeThreads !ustk !bstk !k (BPrim2 CMPU i j) = do
   x <- peekOff bstk i
   y <- peekOff bstk j
   ustk <- bump ustk
   poke ustk . fromEnum $ universalCompare compare x y
   pure (denv, ustk, bstk, k)
-exec !env !denv !_trackThreads !ustk !bstk !k (BPrim2 TRCE i j) = do
+exec !env !denv !_activeThreads !ustk !bstk !k (BPrim2 TRCE i j) = do
   tx <- peekOffBi bstk i
   clo <- peekOff bstk j
   tracer env tx clo
@@ -330,112 +336,129 @@ exec !env !denv !_trackThreads !ustk !bstk !k (BPrim2 TRCE i j) = do
 exec !_   !denv !_trackThreads !ustk !bstk !k (BPrim2 op i j) = do
   (ustk,bstk) <- bprim2 ustk bstk op i j
   pure (denv, ustk, bstk, k)
-exec !_   !denv !_trackThreads !ustk !bstk !k (Pack r t args) = do
+exec !_   !denv !_activeThreads !ustk !bstk !k (Pack r t args) = do
   clo <- buildData ustk bstk r t args
   bstk <- bump bstk
   poke bstk clo
   pure (denv, ustk, bstk, k)
-exec !_   !denv !_trackThreads !ustk !bstk !k (Unpack r i) = do
+exec !_   !denv !_activeThreads !ustk !bstk !k (Unpack r i) = do
   (ustk, bstk) <- dumpData r ustk bstk =<< peekOff bstk i
   pure (denv, ustk, bstk, k)
-exec !_   !denv !_trackThreads !ustk !bstk !k (Print i) = do
+exec !_   !denv !_activeThreads !ustk !bstk !k (Print i) = do
   t <- peekOffBi bstk i
   Tx.putStrLn (Util.Text.toText t)
   pure (denv, ustk, bstk, k)
-exec !_   !denv !_trackThreads !ustk !bstk !k (Lit (MI n)) = do
+exec !_   !denv !_activeThreads !ustk !bstk !k (Lit (MI n)) = do
   ustk <- bump ustk
   poke ustk n
   pure (denv, ustk, bstk, k)
-exec !_   !denv !_trackThreads !ustk !bstk !k (Lit (MD d)) = do
+exec !_   !denv !_activeThreads !ustk !bstk !k (Lit (MD d)) = do
   ustk <- bump ustk
   pokeD ustk d
   pure (denv, ustk, bstk, k)
-exec !_   !denv !_trackThreads !ustk !bstk !k (Lit (MT t)) = do
+exec !_   !denv !_activeThreads !ustk !bstk !k (Lit (MT t)) = do
   bstk <- bump bstk
   poke bstk (Foreign (Wrap Rf.textRef t))
   pure (denv, ustk, bstk, k)
-exec !_   !denv !_trackThreads !ustk !bstk !k (Lit (MM r)) = do
+exec !_   !denv !_activeThreads !ustk !bstk !k (Lit (MM r)) = do
   bstk <- bump bstk
   poke bstk (Foreign (Wrap Rf.termLinkRef r))
   pure (denv, ustk, bstk, k)
-exec !_   !denv !_trackThreads !ustk !bstk !k (Lit (MY r)) = do
+exec !_   !denv !_activeThreads !ustk !bstk !k (Lit (MY r)) = do
   bstk <- bump bstk
   poke bstk (Foreign (Wrap Rf.typeLinkRef r))
   pure (denv, ustk, bstk, k)
-exec !_   !denv !_trackThreads !ustk !bstk !k (Reset ps) = do
+exec !_   !denv !_activeThreads !ustk !bstk !k (Reset ps) = do
   pure (denv, ustk, bstk, Mark ps clos k)
  where clos = EC.restrictKeys denv ps
-exec !_   !denv !_trackThreads !ustk !bstk !k (Seq as) = do
+exec !_   !denv !_activeThreads !ustk !bstk !k (Seq as) = do
   l <- closureArgs bstk as
   bstk <- bump bstk
   pokeS bstk $ Sq.fromList l
   pure (denv, ustk, bstk, k)
-exec !env !denv !_trackThreads !ustk !bstk !k (ForeignCall _ w args)
+exec !env !denv !_activeThreads !ustk !bstk !k (ForeignCall _ w args)
   | Just (FF arg res ev) <- EC.lookup w (foreignFuncs env)
   = uncurry (denv,,,k)
       <$> (arg ustk bstk args >>= ev >>= res ustk bstk)
   | otherwise
     = die $ "reference to unknown foreign function: " ++ show w
-exec !env !denv !trackThreads !ustk !bstk !k (Fork i) = do
-  tid <- forkEval env trackThreads =<< peekOff bstk i
+exec !env !denv !activeThreads !ustk !bstk !k (Fork i) = do
+  tid <- forkEval env activeThreads =<< peekOff bstk i
   bstk <- bump bstk
   poke bstk . Foreign . Wrap Rf.threadIdRef $ tid
   pure (denv, ustk, bstk, k)
-exec !env !denv !trackThreads !ustk !bstk !k (Atomically i) = do
+exec !env !denv !activeThreads !ustk !bstk !k (Atomically i) = do
   c <- peekOff bstk i
   bstk <- bump bstk
-  atomicEval env trackThreads (poke bstk) c
+  atomicEval env activeThreads (poke bstk) c
   pure (denv, ustk, bstk, k)
 {-# inline exec #-}
 
-eval :: CCache -> DEnv -> (ThreadId -> IO ())
+eval :: CCache -> DEnv -> ActiveThreads
      -> Stack 'UN -> Stack 'BX -> K -> Section -> IO ()
-eval !env !denv !trackThreads !ustk !bstk !k (Match i (TestT df cs)) = do
+eval !env !denv !activeThreads !ustk !bstk !k (Match i (TestT df cs)) = do
   t <- peekOffBi bstk i
-  eval env denv trackThreads ustk bstk k $ selectTextBranch t df cs
-eval !env !denv !trackThreads !ustk !bstk !k (Match i br) = do
+  eval env denv activeThreads ustk bstk k $ selectTextBranch t df cs
+eval !env !denv !activeThreads !ustk !bstk !k (Match i br) = do
   n <- peekOffN ustk i
-  eval env denv trackThreads ustk bstk k $ selectBranch n br
-eval !env !denv !trackThreads !ustk !bstk !k (Yield args)
+  eval env denv activeThreads ustk bstk k $ selectBranch n br
+eval !env !denv !activeThreads !ustk !bstk !k (Yield args)
   | asize ustk + asize bstk > 0 , BArg1 i <- args = do
-    peekOff bstk i >>= apply env denv trackThreads ustk bstk k False ZArgs
+    peekOff bstk i >>= apply env denv activeThreads ustk bstk k False ZArgs
   | otherwise = do
     (ustk, bstk) <- moveArgs ustk bstk args
     ustk <- frameArgs ustk
     bstk <- frameArgs bstk
-    yield env denv trackThreads ustk bstk k
-eval !env !denv !trackThreads !ustk !bstk !k (App ck r args) =
+    yield env denv activeThreads ustk bstk k
+eval !env !denv !activeThreads !ustk !bstk !k (App ck r args) =
   resolve env denv bstk r
-    >>= apply env denv trackThreads ustk bstk k ck args
-eval !env !denv !trackThreads !ustk !bstk !k (Call ck n args) =
+    >>= apply env denv activeThreads ustk bstk k ck args
+eval !env !denv !activeThreads !ustk !bstk !k (Call ck n args) =
   combSection env (CIx dummyRef n 0)
-    >>= enter env denv trackThreads ustk bstk k ck args
-eval !env !denv !trackThreads !ustk !bstk !k (Jump i args) =
-  peekOff bstk i >>= jump env denv trackThreads ustk bstk k args
-eval !env !denv !trackThreads !ustk !bstk !k (Let nw cix) = do
+    >>= enter env denv activeThreads ustk bstk k ck args
+eval !env !denv !activeThreads !ustk !bstk !k (Jump i args) =
+  peekOff bstk i >>= jump env denv activeThreads ustk bstk k args
+eval !env !denv !activeThreads !ustk !bstk !k (Let nw cix) = do
   (ustk, ufsz, uasz) <- saveFrame ustk
   (bstk, bfsz, basz) <- saveFrame bstk
-  eval env denv trackThreads ustk bstk (Push ufsz bfsz uasz basz cix k) nw
-eval !env !denv !trackThreads !ustk !bstk !k (Ins i nx) = do
-  (denv, ustk, bstk, k) <- exec env denv trackThreads ustk bstk k i
-  eval env denv trackThreads ustk bstk k nx
-eval !_   !_    !_    !_trackThreads !_    !_ Exit = pure ()
-eval !_   !_    !_    !_trackThreads !_    !_ (Die s) = die s
+  eval env denv activeThreads ustk bstk (Push ufsz bfsz uasz basz cix k) nw
+eval !env !denv !activeThreads !ustk !bstk !k (Ins i nx) = do
+  (denv, ustk, bstk, k) <- exec env denv activeThreads ustk bstk k i
+  eval env denv activeThreads ustk bstk k nx
+eval !_   !_    !_    !_activeThreads !_    !_ Exit = pure ()
+eval !_   !_    !_    !_activeThreads !_    !_ (Die s) = die s
 {-# noinline eval #-}
 
-forkEval :: CCache -> (ThreadId -> IO ()) -> Closure -> IO ThreadId
-forkEval env trackThreads clo
-  = do threadId <- forkIO (apply1 err env trackThreads clo)
-       trackThreads threadId
+forkEval :: CCache -> ActiveThreads -> Closure -> IO ThreadId
+forkEval env activeThreads clo
+  = do threadId <- UnliftIO.forkFinally
+                    (apply1 err env activeThreads clo)
+                    (const cleanupThread)
+       trackThread threadId
        pure threadId
   where
   err :: Stack 'UN -> Stack 'BX -> IO ()
   err _ _ = pure ()
+  trackThread :: ThreadId -> IO ()
+  trackThread threadID = do
+    case activeThreads of
+      Nothing -> pure ()
+      Just activeThreads -> UnliftIO.atomicModifyIORef' activeThreads (\ids -> (Set.insert threadID ids, ()))
+  cleanupThread :: IO ()
+  cleanupThread = do
+    case activeThreads of
+      Nothing -> pure ()
+      Just activeThreads -> do
+        myThreadId <- UnliftIO.myThreadId
+        UnliftIO.atomicModifyIORef' activeThreads (\ids -> (Set.delete myThreadId ids, ()))
+
+
+
 {-# inline forkEval #-}
 
-atomicEval :: CCache -> (ThreadId -> IO ()) -> (Closure -> IO ()) -> Closure -> IO ()
-atomicEval env trackThreads write clo
-  = atomically . unsafeIOToSTM $ apply1 readBack env trackThreads clo
+atomicEval :: CCache -> ActiveThreads -> (Closure -> IO ()) -> Closure -> IO ()
+atomicEval env activeThreads write clo
+  = atomically . unsafeIOToSTM $ apply1 readBack env activeThreads clo
   where
   readBack :: Stack 'UN -> Stack 'BX -> IO ()
   readBack _ bstk = peek bstk >>= write
@@ -443,15 +466,15 @@ atomicEval env trackThreads write clo
 
 -- fast path application
 enter
-  :: CCache -> DEnv -> (ThreadId -> IO ()) -> Stack 'UN -> Stack 'BX -> K
+  :: CCache -> DEnv -> ActiveThreads -> Stack 'UN -> Stack 'BX -> K
   -> Bool -> Args -> Comb -> IO ()
-enter !env !denv !trackThreads !ustk !bstk !k !ck !args !comb = do
+enter !env !denv !activeThreads !ustk !bstk !k !ck !args !comb = do
   ustk <- if ck then ensure ustk uf else pure ustk
   bstk <- if ck then ensure bstk bf else pure bstk
   (ustk, bstk) <- moveArgs ustk bstk args
   ustk <- acceptArgs ustk ua
   bstk <- acceptArgs bstk ba
-  eval env denv trackThreads ustk bstk k entry
+  eval env denv activeThreads ustk bstk k entry
   where
   Lam ua ba uf bf entry = comb
 {-# inline enter #-}
@@ -469,9 +492,9 @@ name !ustk !bstk !args clo = case clo of
 
 -- slow path application
 apply
-  :: CCache -> DEnv -> (ThreadId -> IO ()) -> Stack 'UN -> Stack 'BX -> K
+  :: CCache -> DEnv -> ActiveThreads -> Stack 'UN -> Stack 'BX -> K
   -> Bool -> Args -> Closure -> IO ()
-apply !env !denv !trackThreads !ustk !bstk !k !ck !args (PAp comb useg bseg) =
+apply !env !denv !activeThreads !ustk !bstk !k !ck !args (PAp comb useg bseg) =
   combSection env comb >>= \case
     Lam ua ba uf bf entry
       | ck || ua <= uac && ba <= bac -> do
@@ -482,48 +505,48 @@ apply !env !denv !trackThreads !ustk !bstk !k !ck !args (PAp comb useg bseg) =
         bstk <- dumpSeg bstk bseg A
         ustk <- acceptArgs ustk ua
         bstk <- acceptArgs bstk ba
-        eval env denv trackThreads ustk bstk k entry
+        eval env denv activeThreads ustk bstk k entry
       | otherwise -> do
         (useg, bseg) <- closeArgs C ustk bstk useg bseg args
         ustk <- discardFrame =<< frameArgs ustk
         bstk <- discardFrame =<< frameArgs bstk
         bstk <- bump bstk
         poke bstk $ PAp comb useg bseg
-        yield env denv trackThreads ustk bstk k
+        yield env denv activeThreads ustk bstk k
   where
   uac = asize ustk + ucount args + uscount useg
   bac = asize bstk + bcount args + bscount bseg
-apply !env !denv !trackThreads !ustk !bstk !k !_  !args clo
+apply !env !denv !activeThreads !ustk !bstk !k !_  !args clo
   | ZArgs <- args, asize ustk == 0, asize bstk == 0 = do
     ustk <- discardFrame ustk
     bstk <- discardFrame bstk
     bstk <- bump bstk
     poke bstk clo
-    yield env denv trackThreads ustk bstk k
+    yield env denv activeThreads ustk bstk k
   | otherwise = die $ "applying non-function: " ++ show clo
 {-# inline apply #-}
 
 jump
-  :: CCache -> DEnv -> (ThreadId -> IO ())
+  :: CCache -> DEnv -> ActiveThreads
   -> Stack 'UN -> Stack 'BX -> K
   -> Args -> Closure -> IO ()
-jump !env !denv !trackThreads !ustk !bstk !k !args clo = case clo of
+jump !env !denv !activeThreads !ustk !bstk !k !args clo = case clo of
   Captured sk useg bseg -> do
     (useg, bseg) <- closeArgs K ustk bstk useg bseg args
     ustk <- discardFrame ustk
     bstk <- discardFrame bstk
     ustk <- dumpSeg ustk useg . F $ ucount args
     bstk <- dumpSeg bstk bseg . F $ bcount args
-    repush env trackThreads ustk bstk denv sk k
+    repush env activeThreads ustk bstk denv sk k
   _ -> die "jump: non-cont"
 {-# inline jump #-}
 
 repush
-  :: CCache -> (ThreadId -> IO ())
+  :: CCache -> ActiveThreads
   -> Stack 'UN -> Stack 'BX -> DEnv -> K -> K -> IO ()
-repush !env !trackThreads !ustk !bstk = go
+repush !env !activeThreads !ustk !bstk = go
  where
- go !denv KE !k = yield env denv trackThreads ustk bstk k
+ go !denv KE !k = yield env denv activeThreads ustk bstk k
  go !denv (Mark ps cs sk) !k = go denv' sk $ Mark ps cs' k
   where
   denv' = cs <> EC.withoutKeys denv ps
@@ -1407,22 +1430,22 @@ bprim2 !ustk !bstk CMPU _ _ = pure (ustk, bstk) -- impossible
 {-# inline bprim2 #-}
 
 yield
-  :: CCache -> DEnv -> (ThreadId -> IO ())
+  :: CCache -> DEnv -> ActiveThreads
   -> Stack 'UN -> Stack 'BX -> K -> IO ()
-yield !env !denv !trackThreads !ustk !bstk !k = leap denv k
+yield !env !denv !activeThreads !ustk !bstk !k = leap denv k
  where
  leap !denv0 (Mark ps cs k) = do
    let denv = cs <> EC.withoutKeys denv0 ps
        clo = denv0 EC.! EC.findMin ps
    poke bstk . DataB1 Rf.effectRef 0 =<< peek bstk
-   apply env denv trackThreads ustk bstk k False (BArg1 0) clo
+   apply env denv activeThreads ustk bstk k False (BArg1 0) clo
  leap !denv (Push ufsz bfsz uasz basz cix k) = do
    Lam _ _ uf bf nx <- combSection env cix
    ustk <- restoreFrame ustk ufsz uasz
    bstk <- restoreFrame bstk bfsz basz
    ustk <- ensure ustk uf
    bstk <- ensure bstk bf
-   eval env denv trackThreads ustk bstk k nx
+   eval env denv activeThreads ustk bstk k nx
  leap _ (CB (Hook f)) = f ustk bstk
  leap _ KE = pure ()
 {-# inline yield #-}

--- a/parser-typechecker/tests/Unison/Test/MCode.hs
+++ b/parser-typechecker/tests/Unison/Test/MCode.hs
@@ -52,10 +52,8 @@ testEval0 env sect = do
   cc <- io baseCCache
   modifyTVarTest (combs cc) (env <>)
   modifyTVarTest (combRefs cc) ((dummyRef <$ env) <>)
-  io $ eval0 cc dontTrackThreads sect
+  io $ eval0 cc Nothing sect
   ok
-    where
-      dontTrackThreads _ = pure ()
 
 builtins :: Reference -> Word64
 builtins r

--- a/parser-typechecker/tests/Unison/Test/MCode.hs
+++ b/parser-typechecker/tests/Unison/Test/MCode.hs
@@ -52,8 +52,10 @@ testEval0 env sect = do
   cc <- io baseCCache
   modifyTVarTest (combs cc) (env <>)
   modifyTVarTest (combRefs cc) ((dummyRef <$ env) <>)
-  io $ eval0 cc sect
+  io $ eval0 cc dontTrackThreads sect
   ok
+    where
+      dontTrackThreads _ = pure ()
 
 builtins :: Reference -> Word64
 builtins r

--- a/parser-typechecker/tests/Unison/Test/UnisonSources.hs
+++ b/parser-typechecker/tests/Unison/Test/UnisonSources.hs
@@ -61,7 +61,7 @@ bad r = EasyTest.expectLeft r >> done
 
 test :: Test ()
 test = do
-  rt <- io (RTI.startRuntime "")
+  rt <- io (RTI.startRuntime RTI.Standalone "")
   scope "unison-src"
     . tests
     $ [ go rt shouldPassNow   good

--- a/unison-cli/src/Unison/Codebase/TranscriptParser.hs
+++ b/unison-cli/src/Unison/Codebase/TranscriptParser.hs
@@ -146,7 +146,7 @@ run version dir configFile stanzas codebase = do
     (config, cancelConfig)   <-
       catchIOError (watchConfig configFile) $ \_ ->
         die "Your .unisonConfig could not be loaded. Check that it's correct!"
-    runtime                  <- RTI.startRuntime version
+    runtime                  <- RTI.startRuntime RTI.Standalone version
     traverse_ (atomically . Q.enqueue inputQueue) (stanzas `zip` [1..])
     let patternMap =
           Map.fromList

--- a/unison-cli/unison/Main.hs
+++ b/unison-cli/unison/Main.hs
@@ -98,7 +98,7 @@ main = do
 
      Run (RunFromSymbol mainName) args -> do
       getCodebaseOrExit mCodePathOption \(_, _, theCodebase) -> do
-        runtime <- RTI.startRuntime Version.gitDescribeWithDate
+        runtime <- RTI.startRuntime RTI.Standalone Version.gitDescribeWithDate
         withArgs args $ execute theCodebase runtime mainName
      Run (RunFromFile file mainName) args
        | not (isDotU file) -> PT.putPrettyLn $ P.callout "⚠️" "Files must have a .u extension."
@@ -108,7 +108,7 @@ main = do
               Left _ -> PT.putPrettyLn $ P.callout "⚠️" "I couldn't find that file or it is for some reason unreadable."
               Right contents -> do
                 getCodebaseOrExit mCodePathOption \(initRes, _, theCodebase) -> do
-                  rt <- RTI.startRuntime Version.gitDescribeWithDate
+                  rt <- RTI.startRuntime RTI.Standalone Version.gitDescribeWithDate
                   let fileEvent = Input.UnisonFileChanged (Text.pack file) contents
                   launch currentDir config rt theCodebase [Left fileEvent, Right $ Input.ExecuteI mainName args, Right Input.QuitI] Nothing ShouldNotDownloadBase initRes
      Run (RunFromPipe mainName) args -> do
@@ -117,7 +117,7 @@ main = do
         Left _ -> PT.putPrettyLn $ P.callout "⚠️" "I had trouble reading this input."
         Right contents -> do
           getCodebaseOrExit mCodePathOption \(initRes, _, theCodebase) -> do
-            rt <- RTI.startRuntime Version.gitDescribeWithDate
+            rt <- RTI.startRuntime RTI.Standalone Version.gitDescribeWithDate
             let fileEvent = Input.UnisonFileChanged (Text.pack "<standard input>") contents
             launch
               currentDir config rt theCodebase
@@ -184,7 +184,7 @@ main = do
        runTranscripts renderUsageInfo shouldFork shouldSaveCodebase mCodePathOption transcriptFiles
      Launch isHeadless codebaseServerOpts downloadBase -> do
        getCodebaseOrExit mCodePathOption \(initRes, _, theCodebase) -> do
-         runtime <- RTI.startRuntime Version.gitDescribeWithDate
+         runtime <- RTI.startRuntime RTI.UCM Version.gitDescribeWithDate
          Server.startServer codebaseServerOpts runtime theCodebase $ \baseUrl -> do
            case isHeadless of
                Headless -> do


### PR DESCRIPTION
## Overview

Detected when fixing #2734

Currently any threads forked within unison programs run within UCM will run indefinitely and aren't ever cleaned up until the host UCM process itself closes.

This is annoying in many circumstances, but is particularly annoying when testing things like servers since the server will keep running even if you ctrl-c to return to your UCM prompt.

I think the preferred behaviour would be:

* Treat the `run` command as though we've spun up a unison process, killing that program with `ctrl-c` should also terminate any of its forked threads.


## Reproduction

You can easily see the issue by running the following on trunk at the moment:

```unison
main : '{IO, Exception} ()
main _ = let
  fork '(catch loop)
  ()

loop : '{IO, Exception} ()
loop _ = let
  io.delay 1000000
  printLine "WASSUP!"
  !loop
```

```ucm
.> run main
-- At this point the program has finished, and we're returned to the prompt, but the printing thread is orphaned and keeps printing all over our console as we try to do things 😬 
.> WASSUP!
WASSUP!
WASSUP!
.> WASSUP!

```

## Implementation notes

Really not a fan of this implementation TBH, I wrote it like this as a proof of concept to show that it does indeed solve the issue (it does), and to open the conversation about perhaps finding a better way to thread this into the runtime. I needed to touch a lot of spots just for the book-keeping of passing a handler around.

If Unison ever wants to handle its own threads in an exception-safe way it's likely the runtime will need some mechanism like this.

## Interesting/controversial decisions

This implementation seems messy to me, I'm hoping someone can point me to a better spot in the runtime to put this logic.

I was surprised to see that the runtime doesn't use some form of ReaderT for passing the environment around, that would seem to me to be a natural place to put this.