### PR TITLE
Optimize Names.contains

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/Propagate.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Propagate.hs
@@ -652,5 +652,8 @@ computeFrontier getDependents patch names = do
     -> m (R.Relation Reference Reference)
   addDependents dependents ref =
     (\ds -> R.insertManyDom ds ref dependents)
-      .   Set.filter (Names.contains names)
+      .   Set.filter isNamed
       <$> getDependents ref
+  isNamed :: Reference -> Bool
+  isNamed =
+    Names.contains names

--- a/unison-core/src/Unison/Names.hs
+++ b/unison-core/src/Unison/Names.hs
@@ -381,10 +381,13 @@ difference a b = Names (R.difference (terms a) (terms b))
                        (R.difference (types a) (types b))
 
 contains :: Names -> Reference -> Bool
-contains names r =
-  -- this check makes `contains` O(n) instead of O(log n)
-  (Set.member r . Set.map Referent.toReference . R.ran) (terms names)
-  || R.memberRan r (types names)
+contains names =
+  \r -> Set.member r termsReferences || R.memberRan r (types names)
+  where
+    -- this check makes `contains` O(n) instead of O(log n)
+    termsReferences :: Set Reference
+    termsReferences =
+      Set.map Referent.toReference (R.ran (terms names))
 
 -- | filters out everything from the domain except what's conflicted
 conflicts :: Names -> Names

--- a/unison-core/src/Unison/Names.hs
+++ b/unison-core/src/Unison/Names.hs
@@ -382,6 +382,9 @@ difference a b = Names (R.difference (terms a) (terms b))
 
 contains :: Names -> Reference -> Bool
 contains names =
+  -- We want to compute `termsReferences` only once, if `contains` is partially applied to a `Names`, and called over
+  -- and over for different references. GHC would probably float `termsReferences` out without the explicit lambda, but
+  -- it's written like this just to be sure.
   \r -> Set.member r termsReferences || R.memberRan r (types names)
   where
     -- this check makes `contains` O(n) instead of O(log n)


### PR DESCRIPTION
This PR reorganizes `Names.contains` a bit so the set of references in a `Names` does not have to be recomputed each time we enter `contains names r`. I think it's possible GHC could have figured this out on its own, but I'm not sure.

On one transcript I'm testing against (loading `.distributed` and updating a type with 17 dependents 8 times), this dropped the both the runtime and allocation attributed to `Unison.Codebase.Editor.Propagate.computeFrontier.addDependents` from 11% to 0%.

Or, maybe some more relevant numbers: previously, `Names.contains` was responsible for around 80% of the time and allocations of `propagateAndApply` on this transcript. On this branch, it's only responsible for 7% of the time, and 0% of the allocations.