### PR TITLE
Fix wrong hash being returned from squash pull

### DIFF
--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -353,10 +353,10 @@ importRemoteBranch ::
 importRemoteBranch codebase ns mode preprocess = runExceptT $ do
   branchHash <- ExceptT . viewRemoteBranch' codebase ns $ \(branch, cacheDir) -> do
          withStatus "Importing downloaded files into local codebase..." $ do
-           branch <- preprocessOp branch
-           time "SyncFromDirectory" $
-             syncFromDirectory codebase cacheDir mode branch
-         pure $ Branch.headHash branch
+           processedBranch <- preprocessOp branch
+           time "SyncFromDirectory" $ do
+             syncFromDirectory codebase cacheDir mode processedBranch
+             pure $ Branch.headHash processedBranch
   time "load fresh local branch after sync" $ do
     lift (getBranchForHash codebase branchHash) >>= \case
       Nothing -> throwE . GitCodebaseError $ GitError.CouldntLoadSyncedBranch ns branchHash

--- a/unison-cli/tests/Unison/Test/GitSync.hs
+++ b/unison-cli/tests/Unison/Test/GitSync.hs
@@ -63,6 +63,43 @@ test = scope "gitsync22" . tests $
       ```
     |])
   ,
+  pushPullTest  "pull.without-history" fmt
+    (\repo -> [i|
+      ```unison:hide
+      child.x = 1
+      ```
+
+      ```ucm:hide
+      .> add
+      ```
+
+      ```unison:hide
+      child.y = 2
+      ```
+
+      ```ucm:hide
+      .> add
+      ```
+
+      ```unison:hide
+      child.x = 3
+      ```
+
+      ```ucm:hide
+      .> update
+      .> push.create ${repo}
+      ```
+    |])
+    (\repo -> [i|
+      Should be able to pull the branch from the remote without its history.
+      Note that this only tests that the pull succeeds, since (at time of writing) we don't
+      track/test transcript output for these tests in the unison repo.
+      ```ucm
+      .> pull.without-history ${repo}:.child .child
+      .> history .child
+      ```
+    |])
+  ,
   pushPullTest  "push-over-deleted-namespace" fmt
     (\repo -> [i|
       ```unison:hide


### PR DESCRIPTION
Just a bad indentation 😓 

I'll add some gitsync tests for this.