### PR TITLE
Updates `pull-request.load` error message

### DIFF
--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -576,8 +576,10 @@ notifyUser dir o = case o of
       P.group (either P.shown prettyPath' b) <> "is an empty namespace."
   BranchNotEmpty path ->
     pure . P.warnCallout $
-      "I was expecting the namespace " <> prettyPath' path
-        <> " to be empty for this operation, but it isn't."
+      P.lines
+        [ "The current namespace '" <> prettyPath' path <> "' is not empty. `pull-request.load` downloads the PR into the current namespace which would clutter it.",
+          "Please switch to an empty namespace and try again." 
+        ]
   CantUndo reason -> case reason of
     CantUndoPastStart -> pure . P.warnCallout $ "Nothing more to undo."
     CantUndoPastMerge -> pure . P.warnCallout $ "Sorry, I can't undo a merge (not implemented yet)."


### PR DESCRIPTION
## Overview

Resolves issue #2646.

Adds clarity to the `pull-request.load` error message.

```
.> pull-request.load base head

  ⚠️

  The current namespace '.' is not empty. `pull-request.load` downloads the PR into the current namespace which would clutter it.
  Please switch to an empty namespace and try again.
```

## Implementation notes

This is a pretty minor change, not a lot to report on implementation details.

## Interesting/controversial decisions

I hope this isn't controversial. 

## Test coverage

No tests needed.

## Loose ends

Out of scope for this PR, but it would be nice to add documentation to the pretty printer module.
