### PR TITLE
Allow pulls to overwrite empty local branches instead of merging, and improve messaging in this situation.

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -470,6 +470,10 @@ loop = do
           stepManyAt = Unison.Codebase.Editor.HandleInput.stepManyAt inputDescription
           updateRoot = flip Unison.Codebase.Editor.HandleInput.updateRoot inputDescription
           syncRoot = use LoopState.root >>= updateRoot
+          updateAtM ::
+            Path.Absolute
+            -> (Branch m -> Action m i v1 (Branch m))
+            -> Action m i v1 Bool
           updateAtM = Unison.Codebase.Editor.HandleInput.updateAtM inputDescription
           unlessGitError = unlessError' Output.GitError
           importRemoteBranch ns mode preprocess =
@@ -1466,13 +1470,16 @@ loop = do
                 let printDiffPath = if Verbosity.isSilent verbosity then Nothing else Just path
                 lift $ case pullMode of
                   Input.PullWithHistory -> do
-                    mergeBranchAndPropagateDefaultPatch
-                      Branch.RegularMerge
-                      inputDescription
-                      (Just unchangedMsg)
-                      remoteBranch
-                      printDiffPath
-                      destAbs
+                    destBranch <- getAt destAbs
+                    if Branch.isEmpty0 (Branch.head destBranch)
+                       then void $ updateAtM destAbs (const $ pure remoteBranch)
+                       else mergeBranchAndPropagateDefaultPatch
+                              Branch.RegularMerge
+                              inputDescription
+                              (Just unchangedMsg)
+                              remoteBranch
+                              printDiffPath
+                              destAbs
                   Input.PullWithoutHistory -> do
                     didUpdate <- updateAtM
                                    destAbs

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1472,7 +1472,9 @@ loop = do
                   Input.PullWithHistory -> do
                     destBranch <- getAt destAbs
                     if Branch.isEmpty0 (Branch.head destBranch)
-                       then void $ updateAtM destAbs (const $ pure remoteBranch)
+                       then do
+                         void $ updateAtM destAbs (const $ pure remoteBranch)
+                         respond $ MergeOverEmpty path
                        else mergeBranchAndPropagateDefaultPatch
                               Branch.RegularMerge
                               inputDescription

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -212,6 +212,8 @@ data Output v
   | ShowReflog [ReflogEntry]
   | PullAlreadyUpToDate ReadRemoteNamespace Path'
   | PullSuccessful ReadRemoteNamespace Path'
+    -- | Indicates a trivial merge where the destination was empty and was just replaced.
+  | MergeOverEmpty Path'
   | MergeAlreadyUpToDate Path' Path'
   | PreviewMergeAlreadyUpToDate Path' Path'
   | -- | No conflicts or edits remain for the current patch.
@@ -346,6 +348,7 @@ isFailure o = case o of
   NoBranchWithHash {} -> True
   PullAlreadyUpToDate {} -> False
   PullSuccessful {} -> False
+  MergeOverEmpty {} -> False
   MergeAlreadyUpToDate {} -> False
   PreviewMergeAlreadyUpToDate {} -> False
   NoConflictsOrEdits {} -> False

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1294,6 +1294,10 @@ notifyUser dir o = case o of
       P.wrap $
         "Successfully updated" <> prettyPath' dest <> "from"
           <> P.group (prettyRemoteNamespace ns <> ".")
+  MergeOverEmpty dest ->
+    pure . P.okCallout $
+      P.wrap $
+        "The destination" <> prettyPath' dest <> "was empty, and was replaced instead of merging."
   MergeAlreadyUpToDate src dest ->
     pure . P.callout "😶" $
       P.wrap $


### PR DESCRIPTION
## Overview

closes #2745

Previously, if you had deleted a namespace in your local ucm, then tried to pull a remote to overwrite that local branch, it would merge instead. 
Although conceptually this might be something you want in certain cases, after a discussion with the team it seems like this is the 'rarer' case, so overwriting is the new default.

Now:
![image](https://user-images.githubusercontent.com/6439644/145892476-30b655d9-3a82-4237-9cfe-9adfea3070b2.png)


## Implementation notes

When merging, check if the destination's head is empty. If it is, replace the entire destination with the branch being merged and print a message indicating that a replacement occurred instead of a merge.

## Interesting/controversial decisions

We want back and forth in the meeting a few times on what the default behaviour should be here.

Ultimately neither approach is perfect, we should likely investigating clearer distinctions between "namespaces" and "causals/history" in the future to make the correct behaviour clearer in these situations.

## Testing

There's already a transcript which observes this behaviour, but we don't track Git transcript outputs in CI, which I think we should find a way to do 😓 