### PR TITLE
add a script to perform checks tests similar to CI

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -2,7 +2,7 @@
 
 # eventually: ormolu -c `find . -name '*.hs'`
 true \
-  && stack build --fast \
+  && stack build --fast --no-run-tests --test \
   && stack test unison-cli \
   && stack exec tests \
   && stack test unison-util-relation \

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# eventually: ormolu -c `find . -name '*.hs'`
+true \
+  && stack build --fast \
+  && stack test unison-cli \
+  && stack exec tests \
+  && stack test unison-util-relation \
+  && stack exec transcripts \
+  && stack exec unison transcript unison-src/transcripts-round-trip/main.md \
+  && stack exec integration-tests


### PR DESCRIPTION
## Overview

Run `./scripts/check.sh` to run our 6 test suites, for fewer surprises in PRs.

## Interesting/controversial decisions

The script short circuits after the first failing test suite, which is a bummer, because I'd like to know about all failing tests, but it is tough to find the exit status of earlier test suites if we run them all too.