### PR TITLE
Bugfix: make hashing effects order-independent

### DIFF
--- a/parser-typechecker/src/Unison/Hashing/V2/DataDeclaration.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/DataDeclaration.hs
@@ -24,7 +24,6 @@ where
 
 import Control.Lens (over, _3)
 import Data.Bifunctor (first, second)
-import qualified Data.List as List
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import Unison.Var (Var)
@@ -152,7 +151,9 @@ instance Hashable1 F where
             LetRec bindings body ->
               let (hashes, hash') = hashCycle bindings
                in [tag 1] ++ map hashed hashes ++ [hashed $ hash' body]
-            Constructors cs -> tag 2 : map hashed (List.sort (map hash cs))
+            Constructors cs ->
+              let (hashes, _) = hashCycle cs
+               in tag 2 : map hashed hashes
             Modified m t ->
               [tag 3, Hashable.accumulateToken m, hashed $ hash t]
 

--- a/parser-typechecker/src/Unison/Hashing/V2/Type.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Type.hs
@@ -31,7 +31,6 @@ module Unison.Hashing.V2.Type
 import Unison.Prelude
 
 import qualified Control.Monad.Writer.Strict as Writer
-import qualified Data.List as List
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Unison.ABT as ABT
@@ -139,7 +138,7 @@ toReferenceMentions ty =
   in Set.fromList $ toReference . gen <$> ABT.subterms ty
 
 instance Hashable1 F where
-  hash1 _ hash e =
+  hash1 hashCycle hash e =
     let
       (tag, hashed) = (Hashable.Tag, Hashable.Hashed)
       -- Note: start each layer with leading `0` byte, to avoid collisions with
@@ -153,7 +152,9 @@ instance Hashable1 F where
       --   a) {Remote, Abort} (() -> {Remote} ()) should hash the same as
       --   b) {Abort, Remote} (() -> {Remote} ()) but should hash differently from
       --   c) {Remote, Abort} (() -> {Abort} ())
-      Effects es -> tag 4 : map hashed (List.sort (map hash es))
+      Effects es -> let
+        (hs, _) = hashCycle es
+        in tag 4 : map hashed hs
       Effect e t -> [tag 5, hashed (hash e), hashed (hash t)]
       Forall a -> [tag 6, hashed (hash a)]
       IntroOuter a -> [tag 7, hashed (hash a)]

--- a/unison-core/src/Unison/ABT.hs
+++ b/unison-core/src/Unison/ABT.hs
@@ -93,6 +93,7 @@ import Data.Vector ((!))
 import Prelude hiding (abs,cycle)
 import Prelude.Extras (Eq1(..), Show1(..), Ord1(..))
 import Unison.Hashable (Accumulate,Hashable1,hash1)
+import qualified Data.List as List
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Vector as Vector
@@ -719,7 +720,7 @@ hash = hash' [] where
                         ++ " environment = " ++ show env
     Cycle' vs t -> Hashable.hash1 (hashCycle vs env) undefined t
     Abs'' v t -> hash' (Right v : env) t
-    Tm' t -> Hashable.hash1 undefined (hash' env) t
+    Tm' t -> Hashable.hash1 (\ts -> (List.sort (map (hash' env) ts), hash' env)) (hash' env) t
 
   hashCycle :: [v] -> [Either [v] v] -> [Term f v a] -> ([h], Term f v a -> h)
   hashCycle cycle env ts =

--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -737,7 +737,7 @@ unLetRecNamed
        , [(v, Term2 vt at ap v a)]
        , Term2 vt at ap v a
        )
-unLetRecNamed (ABT.Cycle' vs (ABT.Tm' (LetRec isTop bs e)))
+unLetRecNamed (ABT.Cycle' vs (LetRec isTop bs e))
   | length vs == length bs = Just (isTop, zip vs bs, e)
 unLetRecNamed _ = Nothing
 


### PR DESCRIPTION
## Overview

- [x] Run this implementation by Paul
- [x] Close this and make the PR to `topic/rehash-codebase` instead

Previously, terms that are identical other than the order a set of effects is listed hashed differently. The following two terms should have the same hash, and now they do.

```
foo : Nat ->{Exception, IO} Nat
bar : Nat ->{IO, Exception} Nat
```