### PR TITLE
Adds `api` command

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/Command.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Command.hs
@@ -96,6 +96,8 @@ data Command
 
   UI :: Command m i v ()
 
+  API :: Command m i v ()
+
   DocsToHtml
     :: Branch m -- Root branch
     -> Path -- ^ namespace source
@@ -298,6 +300,7 @@ lookupEvalResult v (_, m) = view _5 <$> Map.lookup v m
 commandName :: Command m i v a -> String
 commandName = \case
   Eval {} -> "Eval"
+  API -> "API"
   UI -> "UI"
   DocsToHtml {} -> "DocsToHtml"
   ConfigLookup {} -> "ConfigLookup"

--- a/unison-cli/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -25,7 +25,7 @@ import qualified Unison.Codebase.Branch as Branch
 import qualified Unison.Codebase.Branch.Merge as Branch
 import qualified Unison.Codebase.Editor.AuthorInfo as AuthorInfo
 import Unison.Codebase.Editor.Command (Command (..), LexedSource, LoadSourceResult, SourceName, TypecheckingResult, UseCache)
-import Unison.Codebase.Editor.Output (NumberedArgs, NumberedOutput, Output)
+import Unison.Codebase.Editor.Output (NumberedArgs, NumberedOutput, Output (PrintMessage))
 import Unison.Codebase.Runtime (Runtime)
 import qualified Unison.Codebase.Runtime as Runtime
 import Unison.FileParsers (parseAndSynthesizeFile, synthesizeFile')
@@ -45,6 +45,7 @@ import Unison.Type (Type)
 import qualified Unison.UnisonFile as UF
 import Unison.Util.Free (Free)
 import qualified Unison.Util.Free as Free
+import qualified Unison.Util.Pretty as P
 import Unison.Var (Var)
 import qualified Unison.WatchKind as WK
 import Web.Browser (openBrowser)
@@ -105,6 +106,14 @@ commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSour
   go x = case x of
     -- Wait until we get either user input or a unison file update
     Eval m        -> lift m
+    API           -> lift $ forM_ serverBaseUrl $ \baseUrl ->
+      notifyUser $ PrintMessage $ P.lines
+        ["The API information is as follows:" 
+        , P.newline
+        , P.indentN 2 (P.hiBlue ("UI: " <> fromString (Server.urlFor Server.UI baseUrl)))
+        , P.newline
+        , P.indentN 2 (P.hiBlue ("API: " <> fromString (Server.urlFor Server.Api baseUrl)))
+        ]
     UI            ->
       case serverBaseUrl of
         Just url -> lift . void $ openBrowser (Server.urlFor Server.UI url)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -377,6 +377,7 @@ loop = do
             UpdateI p _selection -> "update " <> opatch p
             PropagatePatchI p scope -> "patch " <> ps' p <> " " <> p' scope
             UndoI {} -> "undo"
+            ApiI -> "api"
             UiI -> "ui"
             DocsToHtmlI path dir -> "docs.to-html " <> Path.toText' path <> " " <> Text.pack dir
             ExecuteI s args -> "execute " <> (Text.unwords . fmap Text.pack $ (s : args))
@@ -524,6 +525,7 @@ loop = do
                     ppeDecl <- currentPrettyPrintEnvDecl
                     respondNumbered $ CantDeleteDefinitions ppeDecl endangerments
        in case input of
+            ApiI -> eval API
             CreateMessage pretty ->
               respond $ PrintMessage pretty
             ShowReflogI -> do

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -170,6 +170,7 @@ data Input
     | DebugDumpNamespaceSimpleI
     | DebugClearWatchI
     | QuitI
+    | ApiI
     | UiI
     | DocsToHtmlI Path' FilePath
     | GistI GistInput

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -352,6 +352,15 @@ docs =
     )
     (bimap fromString Input.DocsI . traverse Path.parseHQSplit')
 
+api :: InputPattern
+api =
+  InputPattern
+    "api"
+    []
+    []
+    "`api` provides details about the API."
+    (const $ pure Input.ApiI)
+
 ui :: InputPattern
 ui =
   InputPattern
@@ -1907,6 +1916,7 @@ validInputs =
     view,
     display,
     displayTo,
+    api,
     ui,
     docs,
     docsToHtml,


### PR DESCRIPTION
## Overview

Resolves #2452 

Adds an `api` command which prints the current API host:

```
.> api

  The API information is as follows:
  
  
    UI: http://127.0.0.1:33919/3oAFbKvKuuSyaLzW/ui
  
  
    API: http://127.0.0.1:33919/3oAFbKvKuuSyaLzW/api

```

## Implementation notes

I added `ApiI` to `Input` and `API` to `Command` and print the message in `commandLine`.

## Interesting/controversial decisions

I couldn't figure out how to access `BaseUrl` in `loop` so I had to so do the pretty printing in  `commandLine`.

## Test coverage

Not yet. I haven't sorted out how to write tests yet.

## Loose ends

Link to related issues that address things you didn't get to. Stuff you encountered on the way and decided not to include in this PR.
