### PR TITLE
Explicit branch history management

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -547,8 +547,7 @@ uncons (Branch b) = go <$> Causal.uncons b where
   go = over (_Just . _2) Branch
 
 -- | Run a series of updates at specific locations, aggregating all changes into a single causal step.
--- Note: This does not allow you to manipulate history yourself. All changes are compressed
--- into a single causal cons.
+-- History is managed according to 'UpdateStrategy'.
 stepManyAt ::
   forall m f.
   (Monad m, Foldable f) =>
@@ -584,7 +583,7 @@ data UpdateStrategy
   | AllowRewritingHistory
 
 -- | Run a series of updates at specific locations.
--- History is managed according to the 'BranchUpdateStrategy'
+-- History is managed according to the 'UpdateStrategy'
 stepManyAtM :: (Monad m, Monad n, Foldable f)
             => UpdateStrategy -> f (Path, Branch0 m -> n (Branch0 m)) -> Branch m -> n (Branch m)
 stepManyAtM strat actions startBranch =

--- a/parser-typechecker/src/Unison/Codebase/Branch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Branch.hs
@@ -570,17 +570,18 @@ data UpdateStrategy
   -- E.g. if the root.editme branch has history: A -> B -> C
   -- and you use 'makeSetBranch' to update it to a new branch with history X -> Y -> Z,
   -- CompressHistory will result in a history for root.editme of: A -> B -> C -> Z.
-  -- I.e., the 'snapshot' of the updated branch is appended to the existing history.
+  -- A 'snapshot' of the most recent state of the updated branch is appended to the existing history,
+  -- if the new state is equal to the existing state, no new history nodes are appended.
   = CompressHistory
 
   -- | Preserves any history changes made within the update.
   --
-  -- Note that this allows you to clobber history over children.
+  -- Note that this allows you to clobber the history child branches if you want.
   -- E.g. if the root.editme branch has history: A -> B -> C
   -- and you use 'makeSetBranch' to update it to a new branch with history X -> Y -> Z,
-  -- PreserveHistory will result in a history for root.editme of: X -> Y -> Z.
-  -- I.e., the history of the updated branch is replaced entirely.
-  | PreserveHistory
+  -- AllowRewritingHistory will result in a history for root.editme of: X -> Y -> Z.
+  -- The history of the updated branch is replaced entirely.
+  | AllowRewritingHistory
 
 -- | Run a series of updates at specific locations.
 -- History is managed according to the 'BranchUpdateStrategy'
@@ -588,7 +589,7 @@ stepManyAtM :: (Monad m, Monad n, Foldable f)
             => UpdateStrategy -> f (Path, Branch0 m -> n (Branch0 m)) -> Branch m -> n (Branch m)
 stepManyAtM strat actions startBranch =
   case strat of
-    PreserveHistory -> steppedUpdates
+    AllowRewritingHistory -> steppedUpdates
     CompressHistory -> squashedUpdates
   where
     steppedUpdates = do

--- a/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
+++ b/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
@@ -153,7 +153,7 @@ makeDeleteBranch (p, name) = (p, Branch.children . ix name %~ Branch.cons Branch
 
 -- | Erase a branch and its history
 -- See also 'makeDeleteBranch'.
--- Note that this requires a PreserveHistory update strategy to behave correctly.
+-- Note that this requires a AllowRewritingHistory update strategy to behave correctly.
 makeObliterateBranch ::
   Path.Split -> (Path, Branch0 m -> Branch0 m)
 makeObliterateBranch p = makeSetBranch p Branch.empty

--- a/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
+++ b/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
@@ -50,8 +50,9 @@ import qualified Unison.Util.List as List
 import Unison.Codebase.Patch (Patch)
 import Unison.NameSegment (NameSegment)
 
+-- | Creates a branch containing all of the given names, with a single history node.
 fromNames :: Monad m => Names -> Branch m
-fromNames names0 = Branch.stepManyAt (typeActions <> termActions) Branch.empty
+fromNames names0 = Branch.stepManyAt Branch.CompressHistory (typeActions <> termActions) Branch.empty
   where
   typeActions = map doType . R.toList $ Names.types names0
   termActions = map doTerm . R.toList $ Names.terms names0

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -724,7 +724,7 @@ loop = do
               hasConfirmed <- confirmedCommand input
               if (hasConfirmed || insistence == Force)
                 then do stepAt
-                          Branch.PreserveHistory  -- Wipe out all definitions, but keep root branch history.
+                          Branch.CompressHistory  -- Wipe out all definitions, but keep root branch history.
                           (Path.empty, const Branch.empty0)
                         respond DeletedEverything
                 else respond DeleteEverythingConfirmation
@@ -745,7 +745,7 @@ loop = do
                          respondNumbered $ CantDeleteNamespace ppeDecl endangerments
               where
                 doDelete b0 = do
-                      stepAt Branch.PreserveHistory $ BranchUtil.makeDeleteBranch (resolveSplit' p)
+                      stepAt Branch.CompressHistory $ BranchUtil.makeDeleteBranch (resolveSplit' p)
                       -- Looks similar to the 'toDelete' above... investigate me! ;)
                       diffHelper b0 Branch.empty0
                         >>= respondNumbered

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -651,7 +651,7 @@ loop = do
                   lift $ do
                     mergedb <- eval $ Merge Branch.RegularMerge baseb headb
                     squashedb <- eval $ Merge Branch.SquashMerge headb baseb
-                    stepManyAt Branch.PreserveHistory
+                    stepManyAt Branch.AllowRewritingHistory
                       [ BranchUtil.makeSetBranch (dest, "base") baseb,
                         BranchUtil.makeSetBranch (dest, "head") headb,
                         BranchUtil.makeSetBranch (dest, "merged") mergedb,
@@ -672,7 +672,7 @@ loop = do
             MoveBranchI Nothing dest -> do
               b <- use LoopState.root
               -- Overwrite history at destination.
-              stepManyAt Branch.PreserveHistory
+              stepManyAt Branch.AllowRewritingHistory
                 [ (Path.empty, const Branch.empty0),
                   BranchUtil.makeSetBranch (resolveSplit' dest) b
                 ]
@@ -682,7 +682,7 @@ loop = do
               where
                 srcOk b = maybe (destOk b) (branchExistsSplit dest) (getAtSplit' dest)
                 destOk b = do
-                  stepManyAt Branch.PreserveHistory
+                  stepManyAt Branch.AllowRewritingHistory
                     [ BranchUtil.makeDeleteBranch (resolveSplit' src),
                       BranchUtil.makeSetBranch (resolveSplit' dest) b
                     ]

--- a/unison-src/transcripts/empty-namespaces.md
+++ b/unison-src/transcripts/empty-namespaces.md
@@ -48,6 +48,8 @@ stuff.thing = 2
 .> delete.namespace .deleted
 ```
 
+## fork
+
 I should be allowed to fork over a deleted namespace
 
 ```ucm
@@ -59,4 +61,25 @@ The history from the `deleted` namespace should have been overwritten by the his
 ```ucm
 .> history stuff
 .> history deleted
+```
+
+## move.namespace
+
+```unison:hide
+moveoverme.x = 1
+moveme.y = 2
+```
+
+```ucm:hide
+.> add
+```
+
+I should be able to move a namespace over-top of a deleted namespace.
+The history should be that of the moved namespace.
+
+```ucm
+.> delete.namespace moveoverme
+.> history moveme
+.> move.namespace moveme moveoverme
+.> history moveoverme
 ```

--- a/unison-src/transcripts/empty-namespaces.md
+++ b/unison-src/transcripts/empty-namespaces.md
@@ -48,8 +48,6 @@ stuff.thing = 2
 .> delete.namespace .deleted
 ```
 
-## fork
-
 I should be allowed to fork over a deleted namespace
 
 ```ucm
@@ -61,25 +59,4 @@ The history from the `deleted` namespace should have been overwritten by the his
 ```ucm
 .> history stuff
 .> history deleted
-```
-
-## move.namespace
-
-```unison:hide
-moveoverme.x = 1
-moveme.y = 2
-```
-
-```ucm:hide
-.> add
-```
-
-I should be able to move a namespace over-top of a deleted namespace.
-The history should be that of the moved namespace.
-
-```ucm
-.> delete.namespace moveoverme
-.> history moveme
-.> move.namespace moveme moveoverme
-.> history moveoverme
 ```


### PR DESCRIPTION
Used in #2761 to preserve history when moving branches.

## Overview
Heads up, this is confusing stuff, if you want some clarification on this feel free to ask in slack or voice chat.

Recursive history management easy, there are a lot of edge cases, there are always multiple 'histories' to talk about, etc.
E.g. what does it mean to "delete" a namespace? Do we still want a history at that node? What about at the parent node?

I'm not sure how to make this problem easier, so instead I've aimed to make our handling of these issues more _explicit_.

Originally our `stepManyAt` combinator allowed operations to completely manage their own history, but this resulted in a lot of redundant history nodes at children in large updates, where we'd ideally compress that update into one cons.

So #2611 aimed to address this by compressing all updates into a single cons by appending a "snapshot" of the updated state onto the old state.

However, there ARE updates we want to perform which SHOULD adjust history, and/or should allow performing multiple cons's when we want to, e.g. the edits done in the `pull-request.load` command should include the histories of the `base`, `head`, `merged`, branches it creates.

This means we have two different history management strategies, 
but even when we manipulate histories on sub-branches, we still want the entire update to appear as a single cons onto the root branch, and we want to apply these changes efficiently by batching them up.

The solution is to tell `stepManyAt` whether you intend to manage histories yourself, or whether you want it to compress all changes into a single cons for you.

Including this as an explicit parameter means that we'll need to consciously think about the desired behaviour every time we do bulk updates, which should help prevent us from being flippant about how history is managed in the future 👍🏼 

## Implementation notes

* Adds an `UpdateStrategy` to the bulk update commands. See the haddocks on that type for info on how it behaves.
* Makes a distinction between **deleting** a branch and **obliterating** a branch, the former keeps history, the latter doesn't.

## Test coverage

We have multiple transcripts which test the affected behaviors.