### PR TITLE
Allow moving branch (and its history!) over a deleted branch.

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -340,8 +340,6 @@ loop = do
             unless (Set.null misses) $
               respond $ SearchTermsNotFound (Set.toList misses)
             traverse_ go (if isTerm then tmRefs else tpRefs)
-          branchExists dest _x = respond $ BranchAlreadyExists dest
-          branchExistsSplit = branchExists . Path.unsplit'
           typeExists dest = respond . TypeAlreadyExists dest
           termExists dest = respond . TermAlreadyExists dest
           inputDescription :: LoopState.InputDescription
@@ -671,16 +669,22 @@ loop = do
                   BranchUtil.makeSetBranch (resolveSplit' dest) b
                 ]
               success
-            MoveBranchI (Just src) dest ->
-              maybe (branchNotFound' src) srcOk (getAtSplit' src)
-              where
-                srcOk b = maybe (destOk b) (branchExistsSplit dest) (getAtSplit' dest)
-                destOk b = do
-                  stepManyAt
-                    [ BranchUtil.makeDeleteBranch (resolveSplit' src),
-                      BranchUtil.makeSetBranch (resolveSplit' dest) b
-                    ]
-                  success -- could give rando stats about new defns
+            MoveBranchI (Just src) dest -> unlessError $ do
+              srcBranch <- case getAtSplit' src of
+                Just existingSrc | not (Branch.isEmpty0 (Branch.head existingSrc)) -> do
+                  pure existingSrc
+                _ -> throwError $ BranchNotFound (Path.unsplit' src)
+              case getAtSplit' dest of
+                Just existingDest
+                  | not (Branch.isEmpty0 (Branch.head existingDest)) -> do
+                    -- Branch exists and isn't empty, print an error
+                    throwError (BranchAlreadyExists (Path.unsplit' dest))
+                _ -> pure ()
+              lift $ stepManyAt
+                [ BranchUtil.makeDeleteBranch (resolveSplit' src),
+                  BranchUtil.makeSetBranch (resolveSplit' dest) srcBranch
+                ]
+              lift $ success -- could give rando stats about new defns
             MovePatchI src dest -> do
               psrc <- getPatchAtSplit' src
               pdest <- getPatchAtSplit' dest

--- a/unison-src/transcripts/empty-namespaces.md
+++ b/unison-src/transcripts/empty-namespaces.md
@@ -48,6 +48,8 @@ stuff.thing = 2
 .> delete.namespace .deleted
 ```
 
+## fork
+
 I should be allowed to fork over a deleted namespace
 
 ```ucm
@@ -59,4 +61,25 @@ The history from the `deleted` namespace should have been overwritten by the his
 ```ucm
 .> history stuff
 .> history deleted
+```
+
+## move.namespace
+
+```unison:hide
+moveoverme.x = 1
+moveme.y = 2
+```
+
+```ucm:hide
+.> add
+```
+
+I should be able to move a namespace over-top of a deleted namespace.
+The history should be that of the moved namespace.
+
+```ucm
+.> delete.namespace moveoverme
+.> history moveme
+.> move.namespace moveme moveoverme
+.> history moveoverme
 ```

--- a/unison-src/transcripts/empty-namespaces.output.md
+++ b/unison-src/transcripts/empty-namespaces.output.md
@@ -151,18 +151,8 @@ The history should be that of the moved namespace.
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ #3ahcthnkvt
   
-    + Adds / updates:
-    
-      y
   
-  ⊙ #qjc20aua9h
-  
-    - Deletes:
-    
-      x
-  
-  □ #hkrqt3tm05 (start of history)
+  □ #ldl7o5e9i5 (start of history)
 
 ```

--- a/unison-src/transcripts/empty-namespaces.output.md
+++ b/unison-src/transcripts/empty-namespaces.output.md
@@ -82,6 +82,8 @@ deleted.x = 1
 stuff.thing = 2
 ```
 
+## fork
+
 I should be allowed to fork over a deleted namespace
 
 ```ucm
@@ -110,5 +112,57 @@ The history from the `deleted` namespace should have been overwritten by the his
   
   
   □ #3bm1524lb7 (start of history)
+
+```
+## move.namespace
+
+```unison
+moveoverme.x = 1
+moveme.y = 2
+```
+
+I should be able to move a namespace over-top of a deleted namespace.
+The history should be that of the moved namespace.
+
+```ucm
+.> delete.namespace moveoverme
+
+  Removed definitions:
+  
+    1. x : ##Nat
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
+
+.> history moveme
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  
+  
+  □ #ldl7o5e9i5 (start of history)
+
+.> move.namespace moveme moveoverme
+
+  Done.
+
+.> history moveoverme
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ #3ahcthnkvt
+  
+    + Adds / updates:
+    
+      y
+  
+  ⊙ #qjc20aua9h
+  
+    - Deletes:
+    
+      x
+  
+  □ #hkrqt3tm05 (start of history)
 
 ```


### PR DESCRIPTION
Based on #2760  which should be merged first.

## Overview

Recent changes to branch history management made it so that you couldn't move a branch over an empty "deleted" branch. This fixes that and adds a regression test.

## Implementation notes

I added `isEmpty0` checks to the appropriate spots which were previously just checking whether a history exists at the given location.

## Test coverage

Added a regression transcript.
