### PR TITLE
Remove duplicate release key

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,23 +7,6 @@ on:
 
 jobs:
   release:
-    name: "release"
-    runs-on: "ubuntu-latest"
-
-    strategy:
-      # Run each build to completion, regardless of if any have failed
-      fail-fast: false
-    steps:
-      - name: create-release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        with:
-          if-no-files-found: error
-          name: build-linux
-          path: ucm-linux.tar.gz
-  
-  release:
     name: "create_release"
     runs-on: "ubuntu-latest"
     needs:


### PR DESCRIPTION
Not sure what this old step was doing TBH, it appears to just create an empty release, but seems like the new one is more complete (it actually uploads artifacts). The [new action](https://github.com/softprops/action-gh-release) seems to create releases too.

The current version is failing on every push due to duplicate `release` keys anyways, so might as well update it to this and we can fix it if it does anything wrong when we next release 👍🏼 
