### PR TITLE
Add getRootBranchExists to the Codebase API

### DIFF
--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -37,8 +37,8 @@ module Unison.Codebase
 
     -- * Root branch
     getRootBranch,
+    getRootBranchExists,
     GetRootBranchError (..),
-    isBlank,
     putRootBranch,
     rootBranchUpdates,
 
@@ -91,7 +91,6 @@ module Unison.Codebase
   )
 where
 
-import Control.Error (rightMay)
 import Control.Error.Util (hush)
 import Data.List as List
 import qualified Data.Map as Map
@@ -324,12 +323,6 @@ isType :: Applicative m => Codebase m v a -> Reference -> m Bool
 isType c r = case r of
   Reference.Builtin {} -> pure $ Builtin.isBuiltinType r
   Reference.DerivedId r -> isJust <$> getTypeDeclaration c r
-
--- | Return whether the root branch is empty.
-isBlank :: Applicative m => Codebase m v a -> m Bool
-isBlank codebase = do
-  root <- fromMaybe Branch.empty . rightMay <$> getRootBranch codebase
-  pure (root == Branch.empty)
 
 -- * Git stuff
 

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -518,6 +518,10 @@ sqliteCodebase debugName root action = do
                   Codebase1.CouldntLoadRootBranch $ Cv.causalHash2to1 ch
                 e -> error $ show e
 
+          getRootBranchExists :: MonadIO m => m Bool
+          getRootBranchExists =
+            isJust <$> runDB conn (Ops.loadMaybeRootCausalHash)
+
           putRootBranch :: MonadIO m => TVar (Maybe (Q.DataVersion, Branch m)) -> Branch m -> m ()
           putRootBranch rootBranchCache branch1 = do
             -- todo: check to see if root namespace hash has been externally modified
@@ -745,6 +749,7 @@ sqliteCodebase debugName root action = do
         putTerm
         putTypeDeclaration
         (getRootBranch rootBranchCache)
+        getRootBranchExists
         (putRootBranch rootBranchCache)
         (rootBranchUpdates rootBranchCache)
         getBranchForHash

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -64,6 +64,8 @@ data Codebase m v a = Codebase
     putTypeDeclaration :: Reference.Id -> Decl v a -> m (),
     -- | Get the root branch.
     getRootBranch :: m (Either GetRootBranchError (Branch m)),
+    -- | Get whether the root branch exists.
+    getRootBranchExists :: m Bool,
     -- | Like 'putBranch', but also adjusts the root branch pointer afterwards.
     putRootBranch :: Branch m -> m (),
     rootBranchUpdates :: m (IO (), IO (Set Branch.Hash)),

--- a/unison-cli/src/Unison/CommandLine/Welcome.hs
+++ b/unison-cli/src/Unison/CommandLine/Welcome.hs
@@ -29,13 +29,13 @@ data Welcome = Welcome
 data DownloadBase
   = DownloadBase ReadRemoteNamespace | DontDownloadBase
 
--- Previously Created is different from Previously Onboarded because a user can 
--- 1.) create a new codebase 
+-- Previously Created is different from Previously Onboarded because a user can
+-- 1.) create a new codebase
 -- 2.) decide not to go through the onboarding flow until later and exit
--- 3.) then reopen their blank codebase 
+-- 3.) then reopen their blank codebase
 data CodebaseInitStatus
   = NewlyCreatedCodebase -- Can transition to [Base, Author, Finished]
-  | PreviouslyCreatedCodebase -- Can transition to [Base, Author, Finished, PreviouslyOnboarded]. 
+  | PreviouslyCreatedCodebase -- Can transition to [Base, Author, Finished, PreviouslyOnboarded].
 
 data Onboarding
   = Init CodebaseInitStatus -- Can transition to [DownloadingBase, Author, Finished, PreviouslyOnboarded]
@@ -46,7 +46,7 @@ data Onboarding
   | PreviouslyOnboarded
 
 welcome :: CodebaseInitStatus -> DownloadBase -> FilePath -> String -> Welcome
-welcome initStatus downloadBase filePath unisonVersion = 
+welcome initStatus downloadBase filePath unisonVersion =
   Welcome (Init initStatus) downloadBase filePath unisonVersion
 
 pullBase :: ReadRemoteNamespace -> Either Event Input
@@ -95,9 +95,9 @@ toInput pretty =
 
 determineFirstStep :: DownloadBase -> Codebase IO v a -> IO Onboarding
 determineFirstStep downloadBase codebase = do
-  isBlankCodebase <- Codebase.isBlank codebase
+  isEmptyCodebase <- Codebase.getRootBranchExists codebase
   case downloadBase of
-    DownloadBase ns | isBlankCodebase ->
+    DownloadBase ns | isEmptyCodebase ->
       pure $ DownloadingBase ns
     _ ->
       pure PreviouslyOnboarded
@@ -131,7 +131,7 @@ asciiartUnison =
 downloading :: Path -> P.Pretty P.ColorText
 downloading path =
   P.lines
-    [ P.group (P.wrap "🐣 Since this is a fresh codebase, let me download the base library for you." <> P.newline ), 
+    [ P.group (P.wrap "🐣 Since this is a fresh codebase, let me download the base library for you." <> P.newline ),
       P.wrap
         ("🕐 Downloading"
             <> P.blue (P.string (show path))


### PR DESCRIPTION
## Overview

(Context: this came up while working on a PR that moves `unison-codebase-sqlite` over to use `unison-sqlite`).

This PR adds a `getRootBranchExists` function to the codebase API. I noticed we had an inefficient `isBlank` function in its API, which pulled the whole root branch into memory, only to check whether it's empty.

I don't think it's possible with the current onboarding flow to end up asking whether a non-blank codebase is blank, but it looks like from a comment that this flow is intended eventually:

```
-- Previously Created is different from Previously Onboarded because a user can 
-- 1.) create a new codebase 
-- 2.) decide not to go through the onboarding flow until later and exit
-- 3.) then reopen their blank codebase 
```