### PR TITLE
Clarify naming & docs for hashing classes.

### DIFF
--- a/parser-typechecker/src/Unison/Hashing/V2/ABT.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/ABT.hs
@@ -14,8 +14,8 @@ import Unison.ABT
 import Data.List hiding (cycle, find)
 import Data.Vector ((!))
 import Prelude hiding (abs, cycle)
-import Unison.Hashing.V2.BuildHashable (Accumulate, Hashable1, hash1)
-import qualified Unison.Hashing.V2.BuildHashable as Hashable
+import Unison.Hashing.V2.Tokenizable (Accumulate, Hashable1, hash1)
+import qualified Unison.Hashing.V2.Tokenizable as Hashable
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Vector as Vector

--- a/parser-typechecker/src/Unison/Hashing/V2/Branch.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Branch.hs
@@ -5,10 +5,10 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ViewPatterns #-}
 
-module Unison.Hashing.V2.Branch (NameSegment(..), Raw (..), MdValues (..), hashBranch) where
+module Unison.Hashing.V2.Branch (NameSegment (..), Raw (..), MdValues (..), hashBranch) where
 
 import Unison.Hash (Hash)
-import Unison.Hashing.V2.BuildHashable (Hashable)
+import Unison.Hashing.V2.BuildHashable (Tokenizable)
 import qualified Unison.Hashing.V2.BuildHashable as H
 import Unison.Hashing.V2.Reference (Reference)
 import Unison.Hashing.V2.Referent (Referent)
@@ -18,12 +18,12 @@ type MetadataValue = Reference
 
 newtype MdValues = MdValues (Set MetadataValue)
   deriving (Eq, Ord, Show)
-  deriving (Hashable) via Set MetadataValue
+  deriving (Tokenizable) via Set MetadataValue
 
 newtype NameSegment = NameSegment Text deriving (Eq, Ord, Show)
 
 hashBranch :: Raw -> Hash
-hashBranch = H.accumulate'
+hashBranch = H.hashTokenizable
 
 data Raw = Raw
   { terms :: Map NameSegment (Map Referent MdValues),
@@ -32,7 +32,7 @@ data Raw = Raw
     children :: Map NameSegment Hash -- the Causal Hash
   }
 
-instance Hashable Raw where
+instance Tokenizable Raw where
   tokens b =
     [ H.accumulateToken (terms b),
       H.accumulateToken (types b),
@@ -40,5 +40,5 @@ instance Hashable Raw where
       H.accumulateToken (patches b)
     ]
 
-instance H.Hashable NameSegment where
+instance H.Tokenizable NameSegment where
   tokens (NameSegment t) = [H.Text t]

--- a/parser-typechecker/src/Unison/Hashing/V2/Branch.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Branch.hs
@@ -8,8 +8,8 @@
 module Unison.Hashing.V2.Branch (NameSegment (..), Raw (..), MdValues (..), hashBranch) where
 
 import Unison.Hash (Hash)
-import Unison.Hashing.V2.BuildHashable (Tokenizable)
-import qualified Unison.Hashing.V2.BuildHashable as H
+import Unison.Hashing.V2.Tokenizable (Tokenizable)
+import qualified Unison.Hashing.V2.Tokenizable as H
 import Unison.Hashing.V2.Reference (Reference)
 import Unison.Hashing.V2.Referent (Referent)
 import Unison.Prelude

--- a/parser-typechecker/src/Unison/Hashing/V2/Causal.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Causal.hs
@@ -11,11 +11,11 @@ where
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Unison.Hash (Hash)
-import qualified Unison.Hashing.V2.BuildHashable as BuildHashable
-import qualified Unison.Hashing.V2.BuildHashable as H
+import qualified Unison.Hashing.V2.Tokenizable as Tokenizable
+import qualified Unison.Hashing.V2.Tokenizable as H
 
 hashCausal :: Causal -> Hash
-hashCausal = BuildHashable.hashTokenizable
+hashCausal = Tokenizable.hashTokenizable
 
 data Causal = Causal {branchHash :: Hash, parents :: Set Hash}
 

--- a/parser-typechecker/src/Unison/Hashing/V2/Causal.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Causal.hs
@@ -11,12 +11,13 @@ where
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Unison.Hash (Hash)
+import qualified Unison.Hashing.V2.BuildHashable as BuildHashable
 import qualified Unison.Hashing.V2.BuildHashable as H
 
 hashCausal :: Causal -> Hash
-hashCausal = H.accumulate'
+hashCausal = BuildHashable.hashTokenizable
 
 data Causal = Causal {branchHash :: Hash, parents :: Set Hash}
 
-instance H.Hashable Causal where
+instance H.Tokenizable Causal where
   tokens c = H.tokens $ branchHash c : Set.toList (parents c)

--- a/parser-typechecker/src/Unison/Hashing/V2/DataDeclaration.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/DataDeclaration.hs
@@ -22,8 +22,8 @@ import qualified Data.Map as Map
 import qualified Unison.ABT as ABT
 import Unison.Hash (Hash)
 import qualified Unison.Hashing.V2.ABT as ABT
-import Unison.Hashing.V2.BuildHashable (Hashable1)
-import qualified Unison.Hashing.V2.BuildHashable as Hashable
+import Unison.Hashing.V2.Tokenizable (Hashable1)
+import qualified Unison.Hashing.V2.Tokenizable as Hashable
 import Unison.Hashing.V2.Reference (Reference)
 import qualified Unison.Hashing.V2.Reference as Reference
 import qualified Unison.Hashing.V2.Reference.Util as Reference.Util

--- a/parser-typechecker/src/Unison/Hashing/V2/DataDeclaration.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/DataDeclaration.hs
@@ -138,6 +138,6 @@ instance Hashable1 F where
             Modified m t ->
               [tag 3, Hashable.accumulateToken m, hashed $ hash t]
 
-instance Hashable.Hashable Modifier where
+instance Hashable.Tokenizable Modifier where
   tokens Structural = [Hashable.Tag 0]
   tokens (Unique txt) = [Hashable.Tag 1, Hashable.Text txt]

--- a/parser-typechecker/src/Unison/Hashing/V2/Hashable.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Hashable.hs
@@ -1,22 +1,25 @@
 module Unison.Hashing.V2.Hashable
-  ( Hashable,
-    hash,
+  ( Hashable (..),
   )
 where
 
 import Data.Int (Int64)
-import Unison.Hash (Hash)
-import qualified Unison.Hashing.V2.BuildHashable as BuildHashable
 import Data.Set (Set)
+import Unison.Hash (Hash (..))
+import qualified Unison.Hashing.V2.BuildHashable as BuildHashable
 
+-- | This typeclass provides a mechanism for obtaining a content-based hash for Unison types &
+-- terms.
+-- Be wary that Unison requires that these hashes be deterministic, any change to a Hashable
+-- instance requires a full codebase migration and should not be taken lightly.
 class Hashable t where
   hash :: t -> Hash
 
-instance BuildHashable.Hashable a => Hashable [a] where
-  hash = BuildHashable.hash
+instance BuildHashable.Tokenizable a => Hashable [a] where
+  hash = BuildHashable.hashTokenizable
 
-instance BuildHashable.Hashable a => Hashable (Set a) where
-  hash = BuildHashable.hash
+instance BuildHashable.Tokenizable a => Hashable (Set a) where
+  hash = BuildHashable.hashTokenizable
 
 instance Hashable Int64 where
-  hash = BuildHashable.hash
+  hash = BuildHashable.hashTokenizable

--- a/parser-typechecker/src/Unison/Hashing/V2/Hashable.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Hashable.hs
@@ -6,7 +6,7 @@ where
 import Data.Int (Int64)
 import Data.Set (Set)
 import Unison.Hash (Hash (..))
-import qualified Unison.Hashing.V2.BuildHashable as BuildHashable
+import qualified Unison.Hashing.V2.Tokenizable as Tokenizable
 
 -- | This typeclass provides a mechanism for obtaining a content-based hash for Unison types &
 -- terms.
@@ -15,11 +15,11 @@ import qualified Unison.Hashing.V2.BuildHashable as BuildHashable
 class Hashable t where
   hash :: t -> Hash
 
-instance BuildHashable.Tokenizable a => Hashable [a] where
-  hash = BuildHashable.hashTokenizable
+instance Tokenizable.Tokenizable a => Hashable [a] where
+  hash = Tokenizable.hashTokenizable
 
-instance BuildHashable.Tokenizable a => Hashable (Set a) where
-  hash = BuildHashable.hashTokenizable
+instance Tokenizable.Tokenizable a => Hashable (Set a) where
+  hash = Tokenizable.hashTokenizable
 
 instance Hashable Int64 where
-  hash = BuildHashable.hashTokenizable
+  hash = Tokenizable.hashTokenizable

--- a/parser-typechecker/src/Unison/Hashing/V2/Kind.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Kind.hs
@@ -2,14 +2,13 @@
 
 module Unison.Hashing.V2.Kind where
 
+import Unison.Hashing.V2.BuildHashable (Tokenizable)
+import qualified Unison.Hashing.V2.BuildHashable as Hashable
 import Unison.Prelude
 
-import Unison.Hashing.V2.BuildHashable (Hashable)
-import qualified Unison.Hashing.V2.BuildHashable as Hashable
+data Kind = Star | Arrow Kind Kind deriving (Eq, Ord, Read, Show, Generic)
 
-data Kind = Star | Arrow Kind Kind deriving (Eq,Ord,Read,Show,Generic)
-
-instance Hashable Kind where
+instance Tokenizable Kind where
   tokens k = case k of
     Star -> [Hashable.Tag 0]
     Arrow k1 k2 -> (Hashable.Tag 1 : Hashable.tokens k1) ++ Hashable.tokens k2

--- a/parser-typechecker/src/Unison/Hashing/V2/Kind.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Kind.hs
@@ -2,8 +2,8 @@
 
 module Unison.Hashing.V2.Kind where
 
-import Unison.Hashing.V2.BuildHashable (Tokenizable)
-import qualified Unison.Hashing.V2.BuildHashable as Hashable
+import Unison.Hashing.V2.Tokenizable (Tokenizable)
+import qualified Unison.Hashing.V2.Tokenizable as Hashable
 import Unison.Prelude
 
 data Kind = Star | Arrow Kind Kind deriving (Eq, Ord, Read, Show, Generic)

--- a/parser-typechecker/src/Unison/Hashing/V2/Patch.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Patch.hs
@@ -7,7 +7,7 @@ module Unison.Hashing.V2.Patch (Patch (..), hashPatch) where
 import Data.Map (Map)
 import Data.Set (Set)
 import Unison.Hash (Hash)
-import Unison.Hashing.V2.BuildHashable (Hashable)
+import Unison.Hashing.V2.BuildHashable (Tokenizable)
 import qualified Unison.Hashing.V2.BuildHashable as H
 import Unison.Hashing.V2.Reference (Reference)
 import Unison.Hashing.V2.Referent (Referent)
@@ -15,14 +15,14 @@ import Unison.Hashing.V2.TermEdit (TermEdit)
 import Unison.Hashing.V2.TypeEdit (TypeEdit)
 
 hashPatch :: Patch -> Hash
-hashPatch = H.accumulate'
+hashPatch = H.hashTokenizable
 
 data Patch = Patch
   { termEdits :: Map Referent (Set TermEdit),
     typeEdits :: Map Reference (Set TypeEdit)
   }
 
-instance Hashable Patch where
+instance Tokenizable Patch where
   tokens p =
     [ H.accumulateToken (termEdits p),
       H.accumulateToken (typeEdits p)

--- a/parser-typechecker/src/Unison/Hashing/V2/Patch.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Patch.hs
@@ -7,8 +7,8 @@ module Unison.Hashing.V2.Patch (Patch (..), hashPatch) where
 import Data.Map (Map)
 import Data.Set (Set)
 import Unison.Hash (Hash)
-import Unison.Hashing.V2.BuildHashable (Tokenizable)
-import qualified Unison.Hashing.V2.BuildHashable as H
+import Unison.Hashing.V2.Tokenizable (Tokenizable)
+import qualified Unison.Hashing.V2.Tokenizable as H
 import Unison.Hashing.V2.Reference (Reference)
 import Unison.Hashing.V2.Referent (Referent)
 import Unison.Hashing.V2.TermEdit (TermEdit)

--- a/parser-typechecker/src/Unison/Hashing/V2/Pattern.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Pattern.hs
@@ -10,7 +10,7 @@ import Data.Foldable as Foldable hiding (foldMap')
 import Data.List (intercalate)
 import qualified Data.Set as Set
 import Unison.DataDeclaration.ConstructorId (ConstructorId)
-import qualified Unison.Hashing.V2.BuildHashable as H
+import qualified Unison.Hashing.V2.Tokenizable as H
 import Unison.Hashing.V2.Reference (Reference)
 import qualified Unison.Hashing.V2.Type as Type
 import Unison.Prelude

--- a/parser-typechecker/src/Unison/Hashing/V2/Pattern.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Pattern.hs
@@ -38,7 +38,7 @@ data SeqOp
   | Concat
   deriving (Eq, Show, Ord, Generic)
 
-instance H.Hashable SeqOp where
+instance H.Tokenizable SeqOp where
   tokens Cons = [H.Tag 0]
   tokens Snoc = [H.Tag 1]
   tokens Concat = [H.Tag 2]
@@ -78,7 +78,7 @@ setLoc p loc = case p of
   SequenceOp _ ph op pt -> SequenceOp loc ph op pt
   x -> fmap (const loc) x
 
-instance H.Hashable (Pattern p) where
+instance H.Tokenizable (Pattern p) where
   tokens (Unbound _) = [H.Tag 0]
   tokens (Var _) = [H.Tag 1]
   tokens (Boolean _ b) = H.Tag 2 : [H.Tag $ if b then 1 else 0]

--- a/parser-typechecker/src/Unison/Hashing/V2/Reference.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Reference.hs
@@ -18,7 +18,7 @@ import Unison.Prelude
 
 import qualified Data.Text as Text
 import qualified Unison.Hash as H
-import Unison.Hashing.V2.BuildHashable (Hashable)
+import Unison.Hashing.V2.BuildHashable (Tokenizable)
 import qualified Unison.Hashing.V2.BuildHashable as Hashable
 import Unison.ShortHash (ShortHash)
 import qualified Unison.ShortHash as SH
@@ -65,6 +65,6 @@ components sccs = uncurry component =<< sccs
 instance Show Id where show = SH.toString . SH.take 5 . toShortHash . DerivedId
 instance Show Reference where show = SH.toString . SH.take 5 . toShortHash
 
-instance Hashable Reference where
+instance Tokenizable Reference where
   tokens (Builtin txt) = [Hashable.Tag 0, Hashable.Text txt]
   tokens (DerivedId (Id h i)) = [Hashable.Tag 1, Hashable.Bytes (H.toByteString h), Hashable.Nat i]

--- a/parser-typechecker/src/Unison/Hashing/V2/Reference.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Reference.hs
@@ -18,8 +18,8 @@ import Unison.Prelude
 
 import qualified Data.Text as Text
 import qualified Unison.Hash as H
-import Unison.Hashing.V2.BuildHashable (Tokenizable)
-import qualified Unison.Hashing.V2.BuildHashable as Hashable
+import Unison.Hashing.V2.Tokenizable (Tokenizable)
+import qualified Unison.Hashing.V2.Tokenizable as Hashable
 import Unison.ShortHash (ShortHash)
 import qualified Unison.ShortHash as SH
 

--- a/parser-typechecker/src/Unison/Hashing/V2/Reference/Util.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Reference/Util.hs
@@ -4,7 +4,7 @@ module Unison.Hashing.V2.Reference.Util where
 import Unison.Prelude
 
 import qualified Unison.Hashing.V2.Reference as Reference
-import Unison.Hashing.V2.BuildHashable (Hashable1)
+import Unison.Hashing.V2.Tokenizable (Hashable1)
 import Unison.ABT (Var)
 import qualified Unison.Hashing.V2.ABT as ABT
 import qualified Data.Map as Map

--- a/parser-typechecker/src/Unison/Hashing/V2/Referent.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Referent.hs
@@ -11,8 +11,8 @@ module Unison.Hashing.V2.Referent
 where
 
 import Unison.DataDeclaration.ConstructorId (ConstructorId)
-import Unison.Hashing.V2.BuildHashable (Tokenizable)
-import qualified Unison.Hashing.V2.BuildHashable as H
+import Unison.Hashing.V2.Tokenizable (Tokenizable)
+import qualified Unison.Hashing.V2.Tokenizable as H
 import Unison.Hashing.V2.Reference (Reference)
 
 data Referent = Ref Reference | Con Reference ConstructorId

--- a/parser-typechecker/src/Unison/Hashing/V2/Referent.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Referent.hs
@@ -11,13 +11,13 @@ module Unison.Hashing.V2.Referent
 where
 
 import Unison.DataDeclaration.ConstructorId (ConstructorId)
-import Unison.Hashing.V2.BuildHashable (Hashable)
+import Unison.Hashing.V2.BuildHashable (Tokenizable)
 import qualified Unison.Hashing.V2.BuildHashable as H
 import Unison.Hashing.V2.Reference (Reference)
 
 data Referent = Ref Reference | Con Reference ConstructorId
   deriving (Show, Ord, Eq)
 
-instance Hashable Referent where
+instance Tokenizable Referent where
   tokens (Ref r) = [H.Tag 0] ++ H.tokens r
   tokens (Con r i) = [H.Tag 2] ++ H.tokens r ++ H.tokens i

--- a/parser-typechecker/src/Unison/Hashing/V2/Term.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Term.hs
@@ -26,8 +26,8 @@ import qualified Unison.ABT as ABT
 import qualified Unison.Blank as B
 import Unison.DataDeclaration.ConstructorId (ConstructorId)
 import qualified Unison.Hash as Hash
-import Unison.Hashing.V2.BuildHashable (Hashable1, accumulateToken)
-import qualified Unison.Hashing.V2.BuildHashable as Hashable
+import Unison.Hashing.V2.Tokenizable (Hashable1, accumulateToken)
+import qualified Unison.Hashing.V2.Tokenizable as Hashable
 import qualified Unison.Hashing.V2.ABT as ABT
 import Unison.Hashing.V2.Pattern (Pattern)
 import Unison.Hashing.V2.Reference (Reference)

--- a/parser-typechecker/src/Unison/Hashing/V2/TermEdit.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/TermEdit.hs
@@ -1,12 +1,12 @@
 module Unison.Hashing.V2.TermEdit (TermEdit (..)) where
 
-import Unison.Hashing.V2.BuildHashable (Hashable)
+import Unison.Hashing.V2.BuildHashable (Tokenizable)
 import qualified Unison.Hashing.V2.BuildHashable as H
 import Unison.Hashing.V2.Referent (Referent)
 
 data TermEdit = Replace Referent | Deprecate
   deriving (Eq, Ord, Show)
 
-instance Hashable TermEdit where
+instance Tokenizable TermEdit where
   tokens (Replace r) = [H.Tag 0] ++ H.tokens r
   tokens Deprecate = [H.Tag 1]

--- a/parser-typechecker/src/Unison/Hashing/V2/TermEdit.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/TermEdit.hs
@@ -1,7 +1,7 @@
 module Unison.Hashing.V2.TermEdit (TermEdit (..)) where
 
-import Unison.Hashing.V2.BuildHashable (Tokenizable)
-import qualified Unison.Hashing.V2.BuildHashable as H
+import Unison.Hashing.V2.Tokenizable (Tokenizable)
+import qualified Unison.Hashing.V2.Tokenizable as H
 import Unison.Hashing.V2.Referent (Referent)
 
 data TermEdit = Replace Referent | Deprecate

--- a/parser-typechecker/src/Unison/Hashing/V2/Tokenizable.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Tokenizable.hs
@@ -1,4 +1,4 @@
-module Unison.Hashing.V2.BuildHashable
+module Unison.Hashing.V2.Tokenizable
   ( Tokenizable (..),
     Accumulate (..),
     Hashable1 (..),

--- a/parser-typechecker/src/Unison/Hashing/V2/Tokenizable.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Tokenizable.hs
@@ -58,6 +58,21 @@ accumulateToken = Hashed . hashTokenizable
 hashTokenizable :: (Tokenizable t, Accumulate h) => t -> h
 hashTokenizable = accumulate . tokens
 
+-- | Tokenizable converts a value into a set of hashing tokens which will later be accumulated
+-- into a Hash. Be very careful when adding or altering instances of this typeclass, changing
+-- the hash of a value is a major breaking change and requires a complete codebase migration.
+--
+-- If you simply want to provide a convenience instance for a type which wraps some Hashable
+-- type, write an instance of 'Hashable' which calls through to the inner instance instead.
+--
+-- E.g. If I want to be able to hash a @TaggedBranch@ using its Branch0 hashable instance:
+--
+-- @@
+-- data TaggedBranch = TaggedBranch String Branch
+--
+-- instance Hashable TaggedBranch where
+--   hash (TaggedBranch _ b) = hash b
+-- @@
 class Tokenizable t where
   tokens :: Accumulate h => t -> [Token h]
 
@@ -109,6 +124,9 @@ instance Tokenizable Bool where
 instance Tokenizable Hash where
   tokens h = [Bytes (Hash.toByteString h)]
 
+-- | A class for all types which can accumulate tokens into a hash.
+-- If you want to provide an instance for hashing a Unison value, see 'Tokenizable'
+-- and 'Hashable' instead.
 instance Accumulate Hash where
   accumulate = fromBytes . BA.convert . CH.hashFinalize . go CH.hashInit
     where

--- a/parser-typechecker/src/Unison/Hashing/V2/Type.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Type.hs
@@ -28,8 +28,8 @@ module Unison.Hashing.V2.Type (
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Unison.ABT as ABT
-import Unison.Hashing.V2.BuildHashable (Hashable1)
-import qualified Unison.Hashing.V2.BuildHashable as Hashable
+import Unison.Hashing.V2.Tokenizable (Hashable1)
+import qualified Unison.Hashing.V2.Tokenizable as Hashable
 import qualified Unison.Hashing.V2.ABT as ABT
 import Unison.Hashing.V2.Reference (Reference)
 import qualified Unison.Hashing.V2.Reference as Reference

--- a/parser-typechecker/src/Unison/Hashing/V2/TypeEdit.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/TypeEdit.hs
@@ -1,7 +1,7 @@
 module Unison.Hashing.V2.TypeEdit (TypeEdit (..)) where
 
-import Unison.Hashing.V2.BuildHashable (Tokenizable)
-import qualified Unison.Hashing.V2.BuildHashable as H
+import Unison.Hashing.V2.Tokenizable (Tokenizable)
+import qualified Unison.Hashing.V2.Tokenizable as H
 import Unison.Hashing.V2.Reference (Reference)
 
 data TypeEdit = Replace Reference | Deprecate

--- a/parser-typechecker/src/Unison/Hashing/V2/TypeEdit.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/TypeEdit.hs
@@ -1,12 +1,12 @@
 module Unison.Hashing.V2.TypeEdit (TypeEdit (..)) where
 
-import Unison.Hashing.V2.BuildHashable (Hashable)
+import Unison.Hashing.V2.BuildHashable (Tokenizable)
 import qualified Unison.Hashing.V2.BuildHashable as H
 import Unison.Hashing.V2.Reference (Reference)
 
 data TypeEdit = Replace Reference | Deprecate
   deriving (Eq, Ord, Show)
 
-instance Hashable TypeEdit where
+instance Tokenizable TypeEdit where
   tokens (Replace r) = H.Tag 0 : H.tokens r
   tokens Deprecate = [H.Tag 1]

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -81,7 +81,6 @@ library
       Unison.FileParsers
       Unison.Hashing.V2.ABT
       Unison.Hashing.V2.Branch
-      Unison.Hashing.V2.BuildHashable
       Unison.Hashing.V2.Causal
       Unison.Hashing.V2.Convert
       Unison.Hashing.V2.DataDeclaration
@@ -94,6 +93,7 @@ library
       Unison.Hashing.V2.Referent
       Unison.Hashing.V2.Term
       Unison.Hashing.V2.TermEdit
+      Unison.Hashing.V2.Tokenizable
       Unison.Hashing.V2.Type
       Unison.Hashing.V2.TypeEdit
       Unison.Lexer

--- a/unison-cli/tests/Unison/Test/GitSync.hs
+++ b/unison-cli/tests/Unison/Test/GitSync.hs
@@ -303,29 +303,6 @@ test = scope "gitsync22" . tests $
       ```
       ```ucm
       .> debug.file
-      .> add
-      .> push.create ${repo}
-      ```
-    |])
--- simplest-user
-    (\repo -> [i|
-      ```ucm
-      .> pull ${repo}
-      .> alias.term ##Nat.+ +
-      ```
-      ```unison
-      > #fs7la111vn + 1
-      ```
-    |])
-  ,
-  pushPullTest "one-term2" fmt
--- simplest-author
-    (\repo -> [i|
-      ```unison
-      c = 3
-      ```
-      ```ucm
-      .> debug.file
       .myLib> add
       .myLib> push.create ${repo}
       ```

--- a/unison-core/src/Unison/Hashable.hs
+++ b/unison-core/src/Unison/Hashable.hs
@@ -41,6 +41,12 @@ hash, accumulate' :: (Accumulate h, Hashable t) => t -> h
 accumulate' = accumulate . tokens
 hash = accumulate'
 
+-- | NOTE: This typeclass is distinct from 'Unison.Hashing.V2.Hashable', which is the
+-- content-based hashish class used for Unison types & terms.
+--
+-- This class however, is meant only to be used as a utility when hash-based identities are
+-- useful in algorithms, the runtime, etc.
+-- Consider carefully which class you want in each use-case.
 class Hashable t where
   tokens :: Accumulate h => t -> [Token h]
 


### PR DESCRIPTION
Currently we have THREE (3) different and non-interchangable classes named `Hashable`, which is confusing for us as developers and also for new contributors.

This PR:
* Renames one of these classes to `Tokenizable`
* Adds haddocks to help explain when and how to use each
* Moves the hashing version salt into instance of accumulate for `Hash` so that it can't be accidentally missed.

