### PR TITLE
Persist local changes in Git Cache on pull/push

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
@@ -126,10 +126,18 @@ pullRepo repo@(ReadGitRepo uri) = do
                          withStatus ("Updating cached copy of " ++ Text.unpack uri ++ " ...") $ do
                           -- Fetch only the latest commit, we don't need history.
                           gitIn localPath (["fetch", "origin", remoteRef, "--quiet"] ++ ["--depth", "1"])
-                          -- Reset our branch to point at the latest code from the remote.
-                          gitIn localPath ["reset", "--hard", "--quiet", "FETCH_HEAD"]
-                          -- Wipe out any unwanted files which might be sitting around, but aren't in the commit.
-                          gitIn localPath ["clean", "-d", "--force", "--quiet"]
+                          fetchHeadHash <- gitTextIn localPath ["rev-parse", "FETCH_HEAD"]
+                          headHash <- gitTextIn localPath ["rev-parse", "HEAD"]
+                          -- Only do a hard reset if the remote has actually changed.
+                          -- This allows us to persist any codebase migrations in the dirty work tree,
+                          -- and avoid re-migrating a codebase we've migrated before.
+                          when (fetchHeadHash /= headHash) do
+                            -- Reset our branch to point at the latest code from the remote.
+                            gitIn localPath ["reset", "--hard", "--quiet", "FETCH_HEAD"]
+                            -- Wipe out any unwanted files which might be sitting around, but aren't in the commit.
+                            -- Note that this wipes out any in-progress work which other ucm processes may
+                            -- have in progress, which we may want to handle more nicely in the future.
+                            gitIn localPath ["clean", "-d", "--force", "--quiet"]
                           pure True
         when (not succeeded) $ goFromScratch
 

--- a/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
@@ -9,6 +9,9 @@ module Unison.Codebase.Editor.Git
     withIOError,
     withStatus,
     withIsolatedRepo,
+
+    -- * Exported for testing
+    gitCacheDir,
   )
 where
 
@@ -145,7 +148,10 @@ pullRepo repo@(ReadGitRepo uri) = do
       remoteRef :: Text
       remoteRef = fromMaybe "HEAD" maybeRemoteRef
       goFromScratch :: (MonadIO m, MonadError GitProtocolError m) => m  ()
-      goFromScratch = do wipeDir localPath; checkOutNew localPath Nothing
+      goFromScratch = do
+        liftIO . putStrLn $ "FROM SCRATCH"
+        wipeDir localPath
+        checkOutNew localPath Nothing
 
   isEmptyGitRepo :: MonadIO m => FilePath -> m Bool
   isEmptyGitRepo localPath = liftIO $

--- a/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
@@ -149,7 +149,6 @@ pullRepo repo@(ReadGitRepo uri) = do
       remoteRef = fromMaybe "HEAD" maybeRemoteRef
       goFromScratch :: (MonadIO m, MonadError GitProtocolError m) => m  ()
       goFromScratch = do
-        liftIO . putStrLn $ "FROM SCRATCH"
         wipeDir localPath
         checkOutNew localPath Nothing
 

--- a/unison-cli/tests/Unison/Test/GitSync.hs
+++ b/unison-cli/tests/Unison/Test/GitSync.hs
@@ -11,7 +11,7 @@ import Data.String.Here.Interpolated (i)
 import qualified Data.Text as Text
 import EasyTest
 import Shellmet ()
-import System.Directory (removeDirectoryRecursive)
+import System.Directory (removeDirectoryRecursive, doesFileExist)
 import System.FilePath ((</>))
 import qualified System.IO.Temp as Temp
 import qualified Unison.Codebase as Codebase
@@ -40,6 +40,7 @@ test = scope "gitsync22" . tests $
   fastForwardPush :
   nonFastForwardPush :
   localStatePersistence :
+  localStateUpdate :
   destroyedRemote :
   flip map [(Ucm.CodebaseFormat2, "sc")]
   \(fmt, name) -> scope name $ tests [
@@ -670,6 +671,42 @@ localStatePersistence = scope "local-state-persistence" do
   -- we don't want to re-migrate if nothing has changed.
   txt <- io $ Text.readFile someFilePath
   expectEqual someText txt
+
+-- | Any untracked files in the cache directory should be wiped out if there's a change
+-- on the remote.
+localStateUpdate :: Test ()
+localStateUpdate = scope "local-state-update" do
+  repo <- io initGitRepo
+  cachedRepoDir <- io $ gitCacheDir (Text.pack repo)
+  -- Create some local state in the cached git repo.
+  let someFilePath = cachedRepoDir </> "myfile.txt"
+  let someText = "SOME TEXT"
+  io $ do
+    codebase <- Ucm.initCodebase Ucm.CodebaseFormat2
+    -- Push some state the remote codebase
+    -- Then pull to ensure we have a non-empty local git repo.
+    void $ Ucm.runTranscript codebase [i|
+      ```ucm
+      .lib> alias.type ##Nat Nat
+      .lib> push.create ${repo}
+      .lib> pull ${repo}
+      ```
+    |]
+    -- Write a file to our local git cache to represent some changes we may have made to our
+    -- codebase, e.g. a migration.
+    Text.writeFile someFilePath someText
+    -- Push the new change, then pull the new remote.
+    void $ Ucm.runTranscript codebase [i|
+      ```ucm
+      .lib> alias.type ##Nat Nat2
+      .lib> push ${repo}
+      .lib> pull ${repo}
+      ```
+    |]
+  -- We expect the state in the cached git repo to be wiped out, since there's a new commit on
+  -- the remote.
+  fileExists <- io $ doesFileExist someFilePath
+  expect (not fileExists)
 
 nonFastForwardPush :: Test ()
 nonFastForwardPush = scope "non-fastforward-push" do

--- a/unison-cli/tests/Unison/Test/GitSync.hs
+++ b/unison-cli/tests/Unison/Test/GitSync.hs
@@ -22,6 +22,8 @@ import Unison.Symbol (Symbol)
 import Unison.Test.Ucm (CodebaseFormat, Transcript)
 import qualified Unison.Test.Ucm as Ucm
 import Unison.WatchKind (pattern TestWatch)
+import qualified Data.Text.IO as Text
+import Unison.Codebase.Editor.Git (gitCacheDir)
 
 transcriptOutputFile :: String -> FilePath
 transcriptOutputFile name =
@@ -37,6 +39,7 @@ test :: Test ()
 test = scope "gitsync22" . tests $
   fastForwardPush :
   nonFastForwardPush :
+  localStatePersistence :
   destroyedRemote :
   flip map [(Ucm.CodebaseFormat2, "sc")]
   \(fmt, name) -> scope name $ tests [
@@ -634,6 +637,39 @@ fastForwardPush = scope "fastforward-push" do
       ```
     |]
   ok
+
+localStatePersistence :: Test ()
+localStatePersistence = scope "local-state-persistence" do
+  repo <- io initGitRepo
+  cachedRepoDir <- io $ gitCacheDir (Text.pack repo)
+  -- Create some local state in the cached git repo.
+  let someFilePath = cachedRepoDir </> "myfile.txt"
+  let someText = "SOME TEXT"
+  io $ do
+    codebase <- Ucm.initCodebase Ucm.CodebaseFormat2
+    -- Push some state the remote codebase
+    -- Then pull to ensure we have a non-empty local git repo.
+    void $ Ucm.runTranscript codebase [i|
+      ```ucm
+      .lib> alias.type ##Nat Nat
+      .lib> push.create ${repo}
+      .lib> pull ${repo}
+      ```
+    |]
+    -- Write a file to our local git cache to represent some changes we may have made to our
+    -- codebase, e.g. a migration.
+    Text.writeFile someFilePath someText
+    void $ Ucm.runTranscript codebase [i|
+      ```ucm
+      .lib> pull ${repo}
+      .lib> push ${repo}
+      ```
+    |]
+  -- We expect the state in the cached git repo to remain untouched iff the remote
+  -- hasn't changed. This is helpful for when we need to migrate a remote codebase,
+  -- we don't want to re-migrate if nothing has changed.
+  txt <- io $ Text.readFile someFilePath
+  expectEqual someText txt
 
 nonFastForwardPush :: Test ()
 nonFastForwardPush = scope "non-fastforward-push" do


### PR DESCRIPTION
- [x] Merge #2772  first

---

## Overview

The goal of this PR is to prevent superfluous migrations when pulling/pushing to a remote which **hasn't changed** since the last pull/push.

## Implementation notes

Relies on #2772 so that staged changes don't dirty the git cache.

This works by:
* When a pull is initiated, just fetch the latest remote HEAD
* If the remote HEAD is the same as our cached repo, do nothing, leaving the dirty local state alone
* If the remote HEAD has changed, we have no choice but to hard reset and wipe out local changes.

## Interesting/controversial decisions

Are there any cases where we have bad or unexpected local dirty state?
AFAIK no, there aren't any cases where this would happen.

## Test coverage

Added a GitSync test.

## Loose ends

We probably still need either a form of directory locking at some point in the future, or perhaps pull isolation to ensure that a pull doesn't hard-reset the DB when a different UCM process is connected. 
I think we can kick this can down the road for now, but this is a step in the right direction.
