### PR TITLE
Fix integration tests

### DIFF
--- a/unison-cli/integration-tests/IntegrationTests/ArgumentParsing.hs
+++ b/unison-cli/integration-tests/IntegrationTests/ArgumentParsing.hs
@@ -20,7 +20,7 @@ transcriptFile :: String
 transcriptFile = "unison-cli/integration-tests/IntegrationTests/transcript.md"
 
 unisonCmdString :: String
-unisonCmdString = unlines 
+unisonCmdString = unlines
   [ "print : '{IO, Exception} ()"
   , "print _ = base.io.printLine \"ok\""
   ]
@@ -32,42 +32,42 @@ test :: Test ()
 test =
   EasyTest.using (pure ()) clearTempCodebase \_ ->
      scope "argument-parsing" . tests $
-      [ expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison", "--help"] ""
-      , expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison", "-h"] ""
-      , expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison", "version", "--help"] ""
-      , expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison", "init", "--help"] ""
-      , expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison", "run", "--help"] ""
-      , expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison", "run.file", "--help"] ""
-      , expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison", "run.pipe", "--help"] ""
-      , expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison", "transcript", "--help"] ""
-      , expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison", "transcript.fork", "--help"] ""
-      , expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison", "headless", "--help"] ""
-      , expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison", "version"] ""
-      -- , expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison", "run"] "" -- how?
-      , expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison", "run.file", uFile, "print"] ""
-      , expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison", "run.pipe", "print"] unisonCmdString
-      , expectExitCode ExitSuccess "stack" [] ["exec", "--", "unison", "transcript", transcriptFile, "--codebase-create", tempCodebase] ""
-      , expectExitCode ExitSuccess "stack" [] ["exec", "--", "unison", "transcript.fork", transcriptFile, "--codebase-create", tempCodebase] ""
-      -- , expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison", "headless"] "" -- ?
+      [ expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "--help"] ""
+      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "-h"] ""
+      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "version", "--help"] ""
+      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "init", "--help"] ""
+      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "run", "--help"] ""
+      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "run.file", "--help"] ""
+      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "run.pipe", "--help"] ""
+      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "transcript", "--help"] ""
+      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "transcript.fork", "--help"] ""
+      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "headless", "--help"] ""
+      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "version"] ""
+      -- , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "run"] "" -- how?
+      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "run.file", uFile, "print", "--codebase-create", tempCodebase] ""
+      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "run.pipe", "print", "--codebase-create", tempCodebase] unisonCmdString
+      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "transcript", transcriptFile, "--codebase-create", tempCodebase] ""
+      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "transcript.fork", transcriptFile, "--codebase-create", tempCodebase] ""
+      -- , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "headless"] "" -- ?
       -- options
-      , expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison", "--port", "8000"] ""
-      , expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison", "--host", "localhost"] ""
-      , expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison", "--token", "MY_TOKEN"] "" -- ?
-      , expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison"] ""
-      , expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison", "--ui", tempCodebase] ""
+      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "--port", "8000", "--codebase-create", tempCodebase, "--no-base"] ""
+      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "--host", "localhost", "--codebase-create", tempCodebase, "--no-base"] ""
+      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "--token", "MY_TOKEN", "--codebase-create", tempCodebase, "--no-base"] "" -- ?
+      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "--codebase-create", tempCodebase, "--no-base"] ""
+      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "--ui", tempCodebase, "--codebase-create", tempCodebase, "--no-base"] ""
       , scope "can compile, then run compiled artifact" $ tests
-        [ expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison", "transcript", transcriptFile] ""
-        , expectExitCode ExitSuccess "stack" defaultArgs ["exec", "--", "unison", "run.compiled", "./unison-cli/integration-tests/IntegrationTests/main.uc"] ""
+        [ expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "transcript", transcriptFile] ""
+        , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "run.compiled", "./unison-cli/integration-tests/IntegrationTests/main.uc"] ""
         ]
       ]
 
-expectExitCode :: ExitCode -> FilePath -> [String] -> [String] -> String -> Test ()
-expectExitCode expected cmd defArgs args stdin = scope (intercalate " " (cmd : args <> defArgs)) do
+expectExitCode :: ExitCode -> FilePath -> [String] -> String -> Test ()
+expectExitCode expected cmd args stdin = scope (intercalate " " (cmd : args)) do
   start <- io $ getCurrentTime
   (code, _, _) <- io $ readProcessWithExitCode cmd args stdin
   end <- io $ getCurrentTime
   let diff = diffUTCTime end start
-  note $ printf "\n[Time: %s sec]" $ show diff 
+  note $ printf "\n[Time: %s sec]" $ show diff
   expectEqual code expected
 
 defaultArgs :: [String]

--- a/unison-cli/integration-tests/IntegrationTests/print.u
+++ b/unison-cli/integration-tests/IntegrationTests/print.u
@@ -1,2 +1,1 @@
-print : '{IO, Exception} ()
-print _ = base.io.printLine "ok"
+print _ = ()


### PR DESCRIPTION
Fixes an issue on #2471 
closes #2756 

## Overview

Not sure how this ended up in trunk in this state, but many of the integration test commands are just incorrect.

I personally don't love having tests that don't run in CI, they get out of date without anyone noticing, and then when you want them to test something you have to fix them first before you can see if they've been broken, which kind of defeats the purpose.

## Implementation notes

Don't pass invalid CLI flags.