### PR TITLE
Remove unimplemented ucm commands

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -390,7 +390,6 @@ loop = do
               "link " <> HQ.toText md <> " " <> intercalateMap " " hqs' defs
             UnlinkI md defs ->
               "unlink " <> HQ.toText md <> " " <> intercalateMap " " hqs' defs
-            UpdateBuiltinsI -> "builtins.update"
             MergeBuiltinsI -> "builtins.merge"
             MergeIOBuiltinsI -> "builtins.mergeio"
             MakeStandaloneI out nm ->
@@ -443,7 +442,6 @@ loop = do
             ShowDefinitionI {} -> wat
             DisplayI {} -> wat
             DocsI {} -> wat
-            ShowDefinitionByPrefixI {} -> wat
             ShowReflogI {} -> wat
             DebugNumberedArgsI {} -> wat
             DebugTypecheckedUnisonFileI {} -> wat
@@ -451,8 +449,6 @@ loop = do
             DebugDumpNamespaceSimpleI {} -> wat
             DebugClearWatchI {} -> wat
             QuitI {} -> wat
-            DeprecateTermI {} -> undefined
-            DeprecateTypeI {} -> undefined
             GistI {} -> wat
             RemoveTermReplacementI src p ->
               "delete.term-replacement" <> HQ.toText src <> " " <> opatch p
@@ -1609,18 +1605,13 @@ loop = do
               for_ (Relation.toList . Branch.deepTerms . Branch.head $ root') \(r, name) ->
                 traceM $ show name ++ ",Term," ++ Text.unpack (Referent.toText r)
             DebugClearWatchI {} -> eval ClearWatchCache
-            DeprecateTermI {} -> notImplemented
-            DeprecateTypeI {} -> notImplemented
             RemoveTermReplacementI from patchPath ->
               doRemoveReplacement from patchPath True
             RemoveTypeReplacementI from patchPath ->
               doRemoveReplacement from patchPath False
-            ShowDefinitionByPrefixI {} -> notImplemented
-            UpdateBuiltinsI -> notImplemented
             QuitI -> MaybeT $ pure Nothing
             GistI input -> handleGist input
       where
-        notImplemented = eval $ Notify NotImplemented
         success = respond Success
 
   case e of

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -120,8 +120,6 @@ data Input
     | PropagatePatchI PatchPath Path'
     | ListEditsI (Maybe PatchPath)
     -- -- create and remove update directives
-    | DeprecateTermI PatchPath Path.HQSplit'
-    | DeprecateTypeI PatchPath Path.HQSplit'
     | ReplaceI (HQ.HashQualified Name) (HQ.HashQualified Name) (Maybe PatchPath)
     | RemoveTermReplacementI (HQ.HashQualified Name) (Maybe PatchPath)
     | RemoveTypeReplacementI (HQ.HashQualified Name) (Maybe PatchPath)
@@ -154,9 +152,7 @@ data Input
     | FindPatchI
       -- Show provided definitions. If list is empty, prompt a fuzzy search.
     | ShowDefinitionI OutputLocation [HQ.HashQualified Name]
-    | ShowDefinitionByPrefixI OutputLocation [HQ.HashQualified Name]
     | ShowReflogI
-    | UpdateBuiltinsI
     | MergeBuiltinsI
     | MergeIOBuiltinsI
     | ListDependenciesI (HQ.HashQualified Name)

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -191,10 +191,6 @@ data Output v
       [(Reference, Text)] -- fails
   | CantUndo UndoFailureReason
   | ListEdits Patch PPE.PrettyPrintEnv
-  | -- new/unrepresented references followed by old/removed
-    -- todo: eventually replace these sets with [SearchResult' v Ann]
-    -- and a nicer render.
-    BustedBuiltins (Set Reference) (Set Reference)
   | GitError GitError
   | ConfiguredMetadataParseError Path' String (P.Pretty P.ColorText)
   | NoConfiguredGitUrl PushPull Path'
@@ -218,7 +214,6 @@ data Output v
   | PreviewMergeAlreadyUpToDate Path' Path'
   | -- | No conflicts or edits remain for the current patch.
     NoConflictsOrEdits
-  | NotImplemented
   | NoBranchWithHash ShortBranchHash
   | ListDependencies Int LabeledDependency [(Name, Reference)] (Set Reference)
   | -- | List dependents of a type or term.
@@ -330,7 +325,6 @@ isFailure o = case o of
   CantUndo {} -> True
   ListEdits {} -> False
   GitError {} -> True
-  BustedBuiltins {} -> True
   ConfiguredMetadataParseError {} -> True
   NoConfiguredGitUrl {} -> True
   ConfiguredGitUrlParseError {} -> True
@@ -342,7 +336,6 @@ isFailure o = case o of
   WarnIncomingRootBranch {} -> False
   History {} -> False
   StartOfCurrentPathHistory -> True
-  NotImplemented -> True
   DumpNumberedArgs {} -> False
   DumpBitBooster {} -> False
   NoBranchWithHash {} -> True

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -102,17 +102,6 @@ mergeIOBuiltins =
     "Adds all the builtins to `builtins.` in the current namespace, including `io` and misc."
     (const . pure $ Input.MergeIOBuiltinsI)
 
-updateBuiltins :: InputPattern
-updateBuiltins =
-  InputPattern
-    "builtins.update"
-    []
-    []
-    ( "Adds all the builtins that are missing from this namespace, "
-        <> "and deprecate the ones that don't exist in this version of Unison."
-    )
-    (const . pure $ Input.UpdateBuiltinsI)
-
 todo :: InputPattern
 todo =
   InputPattern
@@ -380,17 +369,6 @@ undo =
     []
     "`undo` reverts the most recent change to the codebase."
     (const $ pure Input.UndoI)
-
-viewByPrefix :: InputPattern
-viewByPrefix =
-  InputPattern
-    "view.recursive"
-    []
-    [(OnePlus, definitionQueryArg)]
-    "`view.recursive Foo` prints the definitions of `Foo` and `Foo.blah`."
-    ( fmap (Input.ShowDefinitionByPrefixI Input.ConsoleLocation)
-        . traverse parseHashQualifiedName
-    )
 
 find :: InputPattern
 find =
@@ -1203,9 +1181,9 @@ prettyPrintParseError input = \case
                  ]
 
     printTrivial :: (Maybe (P.ErrorItem Char)) -> (Set (P.ErrorItem Char)) -> P.Pretty P.ColorText
-    printTrivial ue ee = 
+    printTrivial ue ee =
       let expected = "I expected " <> foldMap (P.singleQuoted . P.string . P.showErrorComponent) ee
-          found =  P.string . mappend "I found " . P.showErrorComponent <$> ue 
+          found =  P.string . mappend "I found " . P.showErrorComponent <$> ue
           message = [expected] <> catMaybes [found]
       in P.oxfordCommasWith "." message
 
@@ -1979,7 +1957,6 @@ validInputs =
     viewReflog,
     resetRoot,
     quit,
-    updateBuiltins,
     makeStandalone,
     mergeBuiltins,
     mergeIOBuiltins,

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -578,7 +578,7 @@ notifyUser dir o = case o of
     pure . P.warnCallout $
       P.lines
         [ "The current namespace '" <> prettyPath' path <> "' is not empty. `pull-request.load` downloads the PR into the current namespace which would clutter it.",
-          "Please switch to an empty namespace and try again." 
+          "Please switch to an empty namespace and try again."
         ]
   CantUndo reason -> case reason of
     CantUndoPastStart -> pure . P.warnCallout $ "Nothing more to undo."
@@ -1034,34 +1034,6 @@ notifyUser dir o = case o of
                   <> IP.deleteTypeReplacementCommand
                   <> ", as appropriate."
         ]
-  BustedBuiltins (Set.toList -> new) (Set.toList -> old) ->
-    -- todo: this could be prettier!  Have a nice list like `find` gives, but
-    -- that requires querying the codebase to determine term types.  Probably
-    -- the only built-in types will be primitive types like `Int`, so no need
-    -- to look up decl types.
-    -- When we add builtin terms, they may depend on new derived types, so
-    -- these derived types should be added to the branch too; but not
-    -- necessarily ever be automatically deprecated.  (A library curator might
-    -- deprecate them; more work needs to go into the idea of sharing deprecations and stuff.
-    pure . P.warnCallout . P.lines $
-      case (new, old) of
-        ([], []) -> error "BustedBuiltins busted, as there were no busted builtins."
-        ([], old) ->
-          P.wrap ("This codebase includes some builtins that are considered deprecated. Use the " <> makeExample' IP.updateBuiltins <> " command when you're ready to work on eliminating them from your codebase:") :
-          "" :
-          fmap (P.text . Reference.toText) old
-        (new, []) ->
-          P.wrap ("This version of Unison provides builtins that are not part of your codebase. Use " <> makeExample' IP.updateBuiltins <> " to add them:") :
-          "" : fmap (P.text . Reference.toText) new
-        (new@(_ : _), old@(_ : _)) ->
-          [ P.wrap
-              ( "Sorry and/or good news!  This version of Unison supports a different set of builtins than this codebase uses.  You can use "
-                  <> makeExample' IP.updateBuiltins
-                  <> " to add the ones you're missing and deprecate the ones I'm missing. 😉"
-              ),
-            "You're missing:" `P.hang` P.lines (fmap (P.text . Reference.toText) new),
-            "I'm missing:" `P.hang` P.lines (fmap (P.text . Reference.toText) old)
-          ]
   ListOfPatches patches ->
     pure $
       if null patches
@@ -1119,7 +1091,6 @@ notifyUser dir o = case o of
   NoBranchWithHash _h ->
     pure . P.callout "😶" $
       P.wrap $ "I don't know of a namespace with that hash."
-  NotImplemented -> pure $ P.wrap "That's not implemented yet. Sorry! 😬"
   BranchAlreadyExists p ->
     pure . P.wrap $
       "The namespace" <> prettyPath' p <> "already exists."


### PR DESCRIPTION
## Overview

Found these when I was digging around for a different issue,
looks like most of these have been sitting around since 2019;

Should we remove these? What do you think @aryairani ?