### PR TITLE
Improve type-safety of reference suffix parsing

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Conversions.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Conversions.hs
@@ -6,7 +6,6 @@ module Unison.Codebase.SqliteCodebase.Conversions where
 import Control.Monad (foldM)
 import Data.Bifunctor (Bifunctor (bimap))
 import Data.Bitraversable (Bitraversable (bitraverse))
-import Data.Either (fromRight)
 import Data.Foldable (Foldable (toList))
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -249,7 +248,8 @@ symbol1to2 (V1.Symbol i varType) = V2.Symbol i (Var.rawName varType)
 shortHashSuffix1to2 :: Text -> V1.Reference.Pos
 shortHashSuffix1to2 =
   fst
-    . fromRight (error "todo: move suffix parsing to frontend")
+    -- todo: move suffix parsing to frontend
+    . either error id
     . V1.Reference.readSuffix
 
 abt2to1 :: Functor f => V2.ABT.Term f v a -> V1.ABT.Term f v a

--- a/parser-typechecker/src/Unison/Hashing/V2/Reference.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Reference.hs
@@ -106,8 +106,10 @@ showSuffix i n = Text.pack $ show i <> "c" <> show n
 -- todo: don't read or return size; must also update showSuffix and fromText
 readSuffix :: Text -> Either String (Pos, Size)
 readSuffix t = case Text.breakOn "c" t of
-  (pos, Text.drop 1 -> size) | Text.all isDigit pos && Text.all isDigit size ->
-    Right (read (Text.unpack pos), read (Text.unpack size))
+  (pos, Text.drop 1 -> size) 
+    | Text.all isDigit pos && Text.all isDigit size,
+      Just pos' <- readMaybe (Text.unpack pos),
+      Just size' <- readMaybe (Text.unpack size) -> Right (pos', size')
   _ -> Left "suffix decoding error"
 
 isPrefixOf :: ShortHash -> Reference -> Bool

--- a/parser-typechecker/src/Unison/Hashing/V2/Referent.hs
+++ b/parser-typechecker/src/Unison/Hashing/V2/Referent.hs
@@ -101,8 +101,10 @@ fromText t = either (const Nothing) Just $
   else if Text.all Char.isDigit cidPart then do
     r <- R.fromText (Text.dropEnd 1 refPart)
     ctorType <- ctorType
-    let cid = read (Text.unpack cidPart)
-    pure $ Con r cid ctorType
+    let maybeCid = readMaybe (Text.unpack cidPart)
+    case maybeCid of
+      Nothing -> Left ("invalid constructor id: " <> Text.unpack cidPart)
+      Just cid -> Right $ Con r cid ctorType
   else
     Left ("invalid constructor id: " <> Text.unpack cidPart)
   where

--- a/unison-core/src/Unison/Reference.hs
+++ b/unison-core/src/Unison/Reference.hs
@@ -122,9 +122,11 @@ showSuffix i n = Text.pack $ show i <> "c" <> show n
 -- todo: don't read or return size; must also update showSuffix and fromText
 readSuffix :: Text -> Either String (Pos, Size)
 readSuffix t = case Text.breakOn "c" t of
-  (pos, Text.drop 1 -> size) | Text.all isDigit pos && Text.all isDigit size ->
-    Right (read (Text.unpack pos), read (Text.unpack size))
-  _ -> Left "suffix decoding error"
+  (pos, Text.drop 1 -> size)
+    | Text.all isDigit pos && Text.all isDigit size,
+      Just pos' <- readMaybe (Text.unpack pos),
+      Just size' <- readMaybe (Text.unpack size) -> Right (pos', size')
+  _ -> Left $ "Invalid reference suffix: " <> show t
 
 isPrefixOf :: ShortHash -> Reference -> Bool
 isPrefixOf sh r = SH.isPrefixOf sh (toShortHash r)

--- a/unison-core/src/Unison/Referent.hs
+++ b/unison-core/src/Unison/Referent.hs
@@ -116,11 +116,13 @@ fromText t = either (const Nothing) Just $
   -- if the string has just one hash at the start, it's just a reference
   if Text.length refPart == 1 then
     Ref <$> R.fromText t
-  else if Text.all Char.isDigit cidPart then do
+  else if Text.all Char.isDigit cidPart && (not . Text.null) cidPart then do
     r <- R.fromText (Text.dropEnd 1 refPart)
     ctorType <- ctorType
-    let cid = read (Text.unpack cidPart)
-    pure $ Con (ConstructorReference r cid) ctorType
+    let maybeCid = readMaybe (Text.unpack cidPart)
+    case maybeCid of
+      Nothing -> Left ("invalid constructor id: " <> Text.unpack cidPart)
+      Just cid -> Right $ Con (ConstructorReference r cid) ctorType
   else
     Left ("invalid constructor id: " <> Text.unpack cidPart)
   where


### PR DESCRIPTION
Very small patch to improve the error message for #2503 

closes #2503

There's still the larger issue of actually handling these failures rather than just `error`'ing, but this gives a better error message at least, and removes several unchecked `read`s from the codebase.

I had a few free minutes before checking out for holidays, so figured this was a reasonably quick patch to alleviate the issue without diving too deep down the rabbit hole.

```
BEFORE:
.> view #a.
Exception: Prelude.read: no parse
ucm: Prelude.read: no parse

AFTER:
.> view #a.
Encountered Exception: Invalid reference suffix: ""
CallStack (from HasCallStack):
  error, called at src/Unison/Codebase/SqliteCodebase/Conversions.hs:252:14 in unison-parser-typechecker-0.0.0-3ZCXoyD1xK78Xx2xOdGxbl:Unison.Codebase.SqliteCodebase.Conversions
```