### PR TITLE
Fix implementation of getbuffering builtin to actually return Either

### DIFF
--- a/unison-src/transcripts/io.md
+++ b/unison-src/transcripts/io.md
@@ -76,6 +76,7 @@ testOpenClose _ =
     handle1 = openFile fooFile FileMode.Write
     check "file should be open" (isFileOpen handle1)
     setBuffering handle1 (SizedBlockBuffering 1024)
+    check "file handle buffering should match what we just set." (getBuffering handle1 == SizedBlockBuffering 1024)
     setBuffering handle1 (getBuffering handle1)
     putBytes handle1 0xs01
     setBuffering handle1 NoBuffering

--- a/unison-src/transcripts/io.output.md
+++ b/unison-src/transcripts/io.output.md
@@ -94,6 +94,7 @@ testOpenClose _ =
     handle1 = openFile fooFile FileMode.Write
     check "file should be open" (isFileOpen handle1)
     setBuffering handle1 (SizedBlockBuffering 1024)
+    check "file handle buffering should match what we just set." (getBuffering handle1 == SizedBlockBuffering 1024)
     setBuffering handle1 (getBuffering handle1)
     putBytes handle1 0xs01
     setBuffering handle1 NoBuffering
@@ -146,12 +147,13 @@ testOpenClose _ =
     New test results:
   
   ◉ testOpenClose   file should be open
+  ◉ testOpenClose   file handle buffering should match what we just set.
   ◉ testOpenClose   file should be closed
   ◉ testOpenClose   bytes have been written
   ◉ testOpenClose   bytes have been written
   ◉ testOpenClose   file should be closed
   
-  ✅ 5 test(s) passing
+  ✅ 6 test(s) passing
   
   Tip: Use view testOpenClose to view the source of a test.
 


### PR DESCRIPTION
## Overview

Fixes builtin implementation for `getBuffering.impl`, previously it ran without crashing on trunk by fluke; but didn't behave correctly (it would treat the either's tag as the buffering type, so everything appeared to have `NoBuffering`)

closes #2767;

This should fix the failing `io` transcript on the `topic/rehash-codebase` branch.

## Implementation notes

Wrap the result in the appropriate either correctly inside the runtime.

## Test coverage

Added a line to the io transcript which actually checks the result of getBuffering.