### PR TITLE
Install a top level exception handler during compiled execution

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -362,9 +362,16 @@ executeMainComb
   -> CCache
   -> IO ()
 executeMainComb init cc
-  = eval0 cc Nothing
+  = flip catch (putStrLn . toANSI 50 <=< handler)
+  . eval0 cc Nothing
   . Ins (Pack RF.unitRef 0 ZArgs)
   $ Call True init (BArg1 0)
+  where
+  handler (PE _ msg) = pure msg
+  handler (BU nm c) = do
+    crs <- readTVarIO (combRefs cc)
+    let decom = decompile (backReferenceTm crs (decompTm $ cacheContext cc))
+    pure . either id (bugMsg mempty nm) $ decom c
 
 bugMsg :: PrettyPrintEnv -> Text -> Term Symbol -> Pretty ColorText
 

--- a/parser-typechecker/src/Unison/Runtime/Machine.hs
+++ b/parser-typechecker/src/Unison/Runtime/Machine.hs
@@ -146,7 +146,9 @@ eval0 :: CCache -> ActiveThreads -> Section -> IO ()
 eval0 !env !activeThreads !co = do
   ustk <- alloc
   bstk <- alloc
-  eval env mempty activeThreads ustk bstk KE co
+  (denv, k) <-
+    topDEnv <$> readTVarIO (refTy env) <*> readTVarIO (refTm env)
+  eval env denv activeThreads ustk bstk (k KE) co
 
 topDEnv
   :: M.Map Reference Word64

--- a/parser-typechecker/tests/Unison/Test/MCode.hs
+++ b/parser-typechecker/tests/Unison/Test/MCode.hs
@@ -72,7 +72,7 @@ env m = mapInsert (bit 24) m
 asrt :: Section
 asrt = Ins (Unpack Nothing 0)
      $ Match 0
-     $ Test1 1 (Yield ZArgs)
+     $ Test1 1 (Yield (BArg1 0))
                (Die "assertion failed")
 
 multRec :: String


### PR DESCRIPTION
Some stuff @stew and @ceedubs were working on was getting weird errors during execution because compiled evaluation didn't have a top level exception handler. This should make it have a somewhat more normal message.