### PR TITLE
Use `bug` for emitting pattern match failures.

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/ANF.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF.hs
@@ -372,9 +372,11 @@ defaultCaseVisitor func m@(Match' scrut cases)
   a = ABT.annotation m
   v = Var.freshIn mempty $ typed Var.Blank
   txt = "pattern match failure in function `" <> func <> "`"
+  msg = text a $ Data.Text.pack txt
+  bu = ref a (Builtin "bug")
   dflt = MatchCase (P.Var a) Nothing
        . ABT.abs' a v
-       $ apps' (placeholder a txt) [var a v]
+       $ apps bu [(a, Ty.tupleTerm [msg,  var a v])]
 defaultCaseVisitor _ _ = Nothing
 
 inlineAlias :: Var v => Monoid a => Term v a -> Term v a

--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -393,6 +393,19 @@ bugMsg ppe name tm
   , ""
   , P.indentN 2 $ pretty ppe tm
   ]
+  | name == "builtin.bug"
+  , RF.TupleTerm' [Tm.Text' msg, x] <- tm
+  , "pattern match failure" `isPrefixOf` msg
+  = P.callout icon . P.lines $
+  [ P.wrap ("I've encountered a" <> P.red (P.text msg)
+      <> "while scrutinizing:")
+  , ""
+  , P.indentN 2 $ pretty ppe x
+  , ""
+  , "This happens when calling a function that doesn't handle all \
+    \possible inputs"
+  , sorryMsg
+  ]
 bugMsg ppe name tm = P.callout icon . P.lines $
   [ P.wrap ("I've encountered a call to" <> P.red (P.text name)
       <> "with the following value:")

--- a/parser-typechecker/src/Unison/Runtime/Pattern.hs
+++ b/parser-typechecker/src/Unison/Runtime/Pattern.hs
@@ -584,7 +584,9 @@ lookupAbil rf (Map.lookup rf -> Just econs)
 lookupAbil rf _ = Left $ "unknown ability reference: " ++ show rf
 
 compile :: Var v => DataSpec -> Ctx v -> PatternMatrix v -> Term v
-compile _ _ (PM []) = placeholder () "pattern match failure"
+compile _ _ (PM []) = apps' bu [text () "pattern match failure"]
+  where
+  bu = ref () (Builtin "bug")
 compile spec ctx m@(PM (r:rs))
   | rowIrrefutable r
   = case guard r of


### PR DESCRIPTION
The previous approach was using Blank, which are expected not to occur in certain places; they are only for handling unbound variables and the like in scratch files.
