### PR TITLE
Add -- comments to the transcript parser

### DIFF
--- a/unison-cli/src/Unison/Codebase/TranscriptParser.hs
+++ b/unison-cli/src/Unison/Codebase/TranscriptParser.hs
@@ -11,7 +11,7 @@ module Unison.Codebase.TranscriptParser
     ExpectingError,
     Hidden,
     Err,
-    UcmCommand (..),
+    UcmLine (..),
     run,
     parse,
     parseFile,
@@ -72,16 +72,19 @@ type FenceType = Text
 
 data Hidden = Shown | HideOutput | HideAll
             deriving (Eq, Show)
-data UcmCommand = UcmCommand Path.Absolute Text
+data UcmLine =
+  UcmCommand Path.Absolute Text
+  | UcmComment Text -- Text does not include the '--' prefix.
 
 data Stanza
-  = Ucm Hidden ExpectingError [UcmCommand]
+  = Ucm Hidden ExpectingError [UcmLine]
   | Unison Hidden ExpectingError (Maybe ScratchFileName) Text
   | UnprocessedFence FenceType Text
   | Unfenced Text
 
-instance Show UcmCommand where
+instance Show UcmLine where
   show (UcmCommand path txt) = show path <> ">" <> Text.unpack txt
+  show (UcmComment txt) = "--" ++ Text.unpack txt
 
 instance Show Stanza where
   show s = case s of
@@ -182,21 +185,26 @@ run version dir configFile stanzas codebase = do
             dieUnexpectedSuccess
             awaitInput
           -- ucm command to run
-          Just (Just p@(UcmCommand path lineTxt)) -> do
-            curPath <- readIORef pathRef
-            if curPath /= path then do
-              atomically $ Q.undequeue cmdQueue (Just p)
-              pure $ Right (SwitchBranchI $ Just (Path.absoluteToPath' path))
-            else case words . Text.unpack $ lineTxt of
-              [] -> awaitInput
-              args -> do
-                output ("\n" <> show p <> "\n")
-                numberedArgs <- readIORef numberedArgsRef
-                currentRoot <- Branch.head <$> readIORef rootBranchRef
-                case parseInput currentRoot curPath numberedArgs patternMap args of
-                  -- invalid command is treated as a failure
-                  Left msg -> dieWithMsg $ P.toPlain terminalWidth msg
-                  Right input -> pure $ Right input
+          Just (Just ucmLine) -> do
+            case ucmLine of
+              p@(UcmComment {}) -> do
+                output ("\n" <> show p)
+                awaitInput
+              p@(UcmCommand path lineTxt) -> do
+                curPath <- readIORef pathRef
+                if curPath /= path then do
+                  atomically $ Q.undequeue cmdQueue (Just p)
+                  pure $ Right (SwitchBranchI $ Just (Path.absoluteToPath' path))
+                else case words . Text.unpack $ lineTxt of
+                  [] -> awaitInput
+                  args -> do
+                    output ("\n" <> show p <> "\n")
+                    numberedArgs <- readIORef numberedArgsRef
+                    currentRoot <- Branch.head <$> readIORef rootBranchRef
+                    case parseInput currentRoot curPath numberedArgs patternMap args of
+                      -- invalid command is treated as a failure
+                      Left msg -> dieWithMsg $ P.toPlain terminalWidth msg
+                      Right input -> pure $ Right input
 
           Nothing -> do
             dieUnexpectedSuccess
@@ -345,17 +353,26 @@ type P = P.Parsec () Text
 stanzas :: P [Stanza]
 stanzas = P.many (fenced <|> unfenced)
 
-ucmCommand :: P UcmCommand
-ucmCommand = do
-  P.lookAhead (word ".")
-  path <- P.takeWhile1P Nothing (/= '>')
-  void $ word ">"
-  line <- P.takeWhileP Nothing (/= '\n') <* spaces
-  path <- case Path.parsePath' (Text.unpack path) of
-    Right (Path.unPath' -> Left abs) -> pure abs
-    Right _ -> fail "expected absolute path"
-    Left e -> fail e
-  pure $ UcmCommand path line
+ucmLine :: P UcmLine
+ucmLine = ucmCommand <|> ucmComment
+  where
+    ucmCommand :: P UcmLine
+    ucmCommand = do
+      P.lookAhead (word ".")
+      path <- P.takeWhile1P Nothing (/= '>')
+      void $ word ">"
+      line <- P.takeWhileP Nothing (/= '\n') <* spaces
+      path <- case Path.parsePath' (Text.unpack path) of
+        Right (Path.unPath' -> Left abs) -> pure abs
+        Right _ -> fail "expected absolute path"
+        Left e -> fail e
+      pure $ UcmCommand path line
+
+    ucmComment :: P UcmLine
+    ucmComment = do
+      word "--"
+      line <- P.takeWhileP Nothing (/= '\n') <* spaces
+      pure $ UcmComment line
 
 fenced :: P Stanza
 fenced = do
@@ -366,7 +383,7 @@ fenced = do
       hide <- hidden
       err <- expectingError
       _ <- spaces
-      cmds <- many ucmCommand
+      cmds <- many ucmLine
       pure $ Ucm hide err cmds
     else if fenceType == "unison" then do
       -- todo: this has to be more interesting


### PR DESCRIPTION
https://unisonlanguage.slack.com/archives/CLUNF0J5S/p1641994376014200

## Overview

I've found myself wanting to comment individual UCM commands in transcripts, and it's a bit of a headache to split up into multiple fenced blocks for each command.

This is just a super quick fix to parse `--` prefixed lines in UCM blocks in transcripts as comments.

## Implementation notes

Adds a new UCMComment parser to the transcript parser and just propagates them to the output as-is.


## Test coverage

Running it on this transcript:

    # Test

    ```unison
    x = 1
    ```

    ```ucm
    -- Here's a comment
    .> add
    -- Here are some comments
    -- ...on multiple lines
    .> cd blah
    ```

Produces this output:

    # Test

    ```unison
    x = 1
    ```

    ```ucm

      I found and typechecked these definitions in scratch.u. If you
      do an `add` or `update`, here's how your codebase would
      change:
      
        ⍟ These new definitions are ok to `add`:
        
          x : ##Nat

    ```
    ```ucm
    -- Here's a comment
    .> add

      ⍟ I've added these definitions:
      
        x : ##Nat

    -- Here are some comments
    -- ...on multiple lines
    .> cd blah

      ☝️  The namespace .blah is empty.

    ```


I don't think it's worth adding an actual test-transcript for this, once people start using comments in transcripts it'll be tested that way.