### PR TITLE
Fix universal eq/compare for links

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Foreign.hs
+++ b/parser-typechecker/src/Unison/Runtime/Foreign.hs
@@ -40,11 +40,27 @@ data Foreign where
 promote :: (a -> a -> r) -> b -> c -> r
 promote (~~) x y = unsafeCoerce x ~~ unsafeCoerce y
 
+tylEq :: Reference -> Reference -> Bool
+tylEq r l = r == l
+{-# noinline tylEq #-}
+
+tmlEq :: Referent -> Referent -> Bool
+tmlEq r l = r == l
+{-# noinline tmlEq #-}
+
+tylCmp :: Reference -> Reference -> Ordering
+tylCmp r l = compare r l
+{-# noinline tylCmp #-}
+
+tmlCmp :: Referent -> Referent -> Ordering
+tmlCmp r l = compare r l
+{-# noinline tmlCmp #-}
+
 ref2eq :: Reference -> Maybe (a -> b -> Bool)
 ref2eq r
   | r == Ty.textRef = Just $ promote ((==) @Text)
-  | r == Ty.termLinkRef = Just $ promote ((==) @Referent)
-  | r == Ty.typeLinkRef = Just $ promote ((==) @Reference)
+  | r == Ty.termLinkRef = Just $ promote tmlEq
+  | r == Ty.typeLinkRef = Just $ promote tylEq
   | r == Ty.bytesRef = Just $ promote ((==) @Bytes)
   -- Note: MVar equality is just reference equality, so it shouldn't
   -- matter what type the MVar holds.
@@ -57,8 +73,8 @@ ref2eq r
 ref2cmp :: Reference -> Maybe (a -> b -> Ordering)
 ref2cmp r
   | r == Ty.textRef = Just $ promote (compare @Text)
-  | r == Ty.termLinkRef = Just $ promote (compare @Referent)
-  | r == Ty.typeLinkRef = Just $ promote (compare @Reference)
+  | r == Ty.termLinkRef = Just $ promote tmlCmp
+  | r == Ty.typeLinkRef = Just $ promote tylCmp
   | r == Ty.bytesRef = Just $ promote (compare @Bytes)
   | r == Ty.threadIdRef = Just $ promote (compare @ThreadId)
   | otherwise = Nothing

--- a/unison-src/transcripts/universal-cmp.md
+++ b/unison-src/transcripts/universal-cmp.md
@@ -7,6 +7,8 @@ cases exist for built-in types. Just making sure they don't crash.
 ```
 
 ```unison
+unique type A = A
+
 threadEyeDeez _ =
   t1 = forkComp '()
   t2 = forkComp '()
@@ -16,5 +18,13 @@ threadEyeDeez _ =
 ```
 
 ```ucm
+.> add
 .> run threadEyeDeez
+```
+
+```unison
+> typeLink A == typeLink A
+> typeLink Text == typeLink Text
+> typeLink Text == typeLink A
+> termLink threadEyeDeez == termLink threadEyeDeez
 ```

--- a/unison-src/transcripts/universal-cmp.output.md
+++ b/unison-src/transcripts/universal-cmp.output.md
@@ -3,6 +3,8 @@ File for test cases making sure that universal equality/comparison
 cases exist for built-in types. Just making sure they don't crash.
 
 ```unison
+unique type A = A
+
 threadEyeDeez _ =
   t1 = forkComp '()
   t2 = forkComp '()
@@ -19,10 +21,51 @@ threadEyeDeez _ =
   
     ⍟ These new definitions are ok to `add`:
     
+      unique type A
       threadEyeDeez : ∀ _. _ ->{IO} ()
 
 ```
 ```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    unique type A
+    threadEyeDeez : ∀ _. _ ->{IO} ()
+
 .> run threadEyeDeez
+
+```
+```unison
+> typeLink A == typeLink A
+> typeLink Text == typeLink Text
+> typeLink Text == typeLink A
+> termLink threadEyeDeez == termLink threadEyeDeez
+```
+
+```ucm
+
+  ✅
+  
+  scratch.u changed.
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    1 | > typeLink A == typeLink A
+          ⧩
+          true
+  
+    2 | > typeLink Text == typeLink Text
+          ⧩
+          true
+  
+    3 | > typeLink Text == typeLink A
+          ⧩
+          false
+  
+    4 | > termLink threadEyeDeez == termLink threadEyeDeez
+          ⧩
+          true
 
 ```


### PR DESCRIPTION
It seems that optimizations cause problems together with the combination
of coercing and unsafe IO involved in reference equality. I'm not
exactly sure what goes wrong, but it causes segfaults. Defining a
noinline function for the equalities (instead of just `(==)@Reference`)
seems to fix the problem.

I got the same problem to happen for term links, so both of those use a
noinline function now. Other foreign values don't seem to be affected,
which I assume is due to them having pure primitive functions for
equality.

Fixes #2431