### PR TITLE
Don't crash on empty namespace prefix for constructors.

### DIFF
--- a/unison-core/src/Unison/HashQualified.hs
+++ b/unison-core/src/Unison/HashQualified.hs
@@ -28,6 +28,7 @@ data HashQualified n
   deriving (Eq, Foldable, Traversable, Functor, Show, Generic)
 
 stripNamespace :: Text -> HashQualified Name -> HashQualified Name
+stripNamespace "" hq = hq
 stripNamespace namespace hq = case hq of
   NameOnly name         -> NameOnly $ strip name
   HashQualified name sh -> HashQualified (strip name) sh


### PR DESCRIPTION
## Overview

`stripNamespace` crashes on an empty namespace (due to `Name.unsafeFromText`); 

This is holding up Rebecca in #2808 
fixes #2808

## Implementation notes

I just made `stripNamespace` with an empty namespace a no-op.

## Loose ends

There remains the question of why this function is being called with an empty namespace, it appears to be primarily called when Constructors aren't nested under their type-name, which is uncommon, but I think is still totally valid, so I'll keep looking into that just to make sure we expect this to happen sometimes. Regardless, this should be enough of a fix to unblock @rlmark 😄 

It appears that upon loading the file dumped out by `edit` in Rebecca's transcript we end up hitting this parsing error so I'll look into that as well.

https://github.com/unisonweb/unison/blob/8b6dba2b5faef7a00bc0bb70585ee6e11e39b165/parser-typechecker/src/Unison/Lexer.hs#L707