### PR TITLE
Ensure test-watch dependencies are properly included in slurping calculations.

### DIFF
--- a/parser-typechecker/src/Unison/UnisonFile.hs
+++ b/parser-typechecker/src/Unison/UnisonFile.hs
@@ -136,9 +136,13 @@ indexByReference uf = (tms, tys)
     tms = Map.fromList [
       (r, (tm,ty)) | (Reference.DerivedId r, _wk, tm, ty) <- toList (hashTerms uf) ]
 
+-- | A mapping of all terms in the file by their var name.
+-- The returned terms refer to other definitions in the file by their
+-- var, not by reference.
+-- Includes test watches.
 allTerms :: Ord v => TypecheckedUnisonFile v a -> Map v (Term v a)
 allTerms uf =
-  Map.fromList [ (v, t) | (v, t, _) <- join $ topLevelComponents' uf ]
+  Map.fromList [ (v, t) | (v, t, _) <- join $ topLevelComponents uf ]
 
 -- |the top level components (no watches) plus test watches.
 topLevelComponents :: TypecheckedUnisonFile v a

--- a/unison-src/transcripts-using-base/test-watch-dependencies.md
+++ b/unison-src/transcripts-using-base/test-watch-dependencies.md
@@ -1,4 +1,4 @@
-# Ensure Test watch dependencies are properly considered.
+# Ensure test watch dependencies are properly considered.
 
 https://github.com/unisonweb/unison/issues/2195
 
@@ -6,19 +6,38 @@ https://github.com/unisonweb/unison/issues/2195
 .> builtins.merge
 ```
 
-```unison
+We add a simple definition.
+
+```unison:hide
 x = 999
 ```
 
-```ucm
+```ucm:hide
 .> add
 ```
+
+Now, we update that definition and define a test-watch which depends on it.
 
 ```unison
 x = 1000
-test> mytest = [let x + 1 == 1001; Ok "ok"]
+test> mytest = checks [x + 1 == 1001]
 ```
 
-```ucm
+We expect this 'add' to fail because the test is blocked by the update to `x`.
+
+```ucm:error
 .> add
+```
+
+---
+
+```unison
+y = 42
+test> useY = checks [y + 1 == 43]
+```
+
+This should correctly identify `y` as a dependency and add that too.
+
+```ucm
+.> add useY
 ```

--- a/unison-src/transcripts-using-base/test-watch-dependencies.md
+++ b/unison-src/transcripts-using-base/test-watch-dependencies.md
@@ -1,0 +1,24 @@
+# Ensure Test watch dependencies are properly considered.
+
+https://github.com/unisonweb/unison/issues/2195
+
+```ucm:hide
+.> builtins.merge
+```
+
+```unison
+x = 999
+```
+
+```ucm
+.> add
+```
+
+```unison
+x = 1000
+test> mytest = [let x + 1 == 1001; Ok "ok"]
+```
+
+```ucm
+.> add
+```

--- a/unison-src/transcripts-using-base/test-watch-dependencies.output.md
+++ b/unison-src/transcripts-using-base/test-watch-dependencies.output.md
@@ -1,0 +1,55 @@
+# Ensure Test watch dependencies are properly considered.
+
+https://github.com/unisonweb/unison/issues/2195
+
+```unison
+x = 999
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      x : Nat
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    x : Nat
+
+```
+```unison
+x = 1000
+test> mytest = [let x + 1 == 1001; Ok "ok"]
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      mytest : [Result]
+    
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      x : Nat
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    2 | test> mytest = [let x + 1 == 1001; Ok "ok"]
+    
+    ✅ Passed ok
+
+```

--- a/unison-src/transcripts-using-base/test-watch-dependencies.output.md
+++ b/unison-src/transcripts-using-base/test-watch-dependencies.output.md
@@ -1,33 +1,18 @@
-# Ensure Test watch dependencies are properly considered.
+# Ensure test watch dependencies are properly considered.
 
 https://github.com/unisonweb/unison/issues/2195
+
+We add a simple definition.
 
 ```unison
 x = 999
 ```
 
-```ucm
+Now, we update that definition and define a test-watch which depends on it.
 
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-  
-    ⍟ These new definitions are ok to `add`:
-    
-      x : Nat
-
-```
-```ucm
-.> add
-
-  ⍟ I've added these definitions:
-  
-    x : Nat
-
-```
 ```unison
 x = 1000
-test> mytest = [let x + 1 == 1001; Ok "ok"]
+test> mytest = checks [x + 1 == 1001]
 ```
 
 ```ucm
@@ -48,8 +33,59 @@ test> mytest = [let x + 1 == 1001; Ok "ok"]
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.
 
-    2 | test> mytest = [let x + 1 == 1001; Ok "ok"]
+    2 | test> mytest = checks [x + 1 == 1001]
     
-    ✅ Passed ok
+    ✅ Passed Passed
+
+```
+We expect this 'add' to fail because the test is blocked by the update to `x`.
+
+```ucm
+.> add
+
+  x These definitions failed:
+  
+    Reason
+    needs update   x        : Nat
+    blocked        mytest   : [Result]
+  
+    Tip: Use `help filestatus` to learn more.
+
+```
+---
+
+```unison
+y = 42
+test> useY = checks [y + 1 == 43]
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      useY : [Result]
+      y    : Nat
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    2 | test> useY = checks [y + 1 == 43]
+    
+    ✅ Passed Passed
+
+```
+This should correctly identify `y` as a dependency and add that too.
+
+```ucm
+.> add useY
+
+  ⍟ I've added these definitions:
+  
+    useY : [Result]
+    y    : Nat
 
 ```


### PR DESCRIPTION
## Overview

fixes #2195

The code which was computing closure over definitions in a typechecked unison file wasn't properly considering test-watch components, leading to dependencies of those watches not being saved in certain situations.

## Implementation notes

Include test-watches when determining var closure.

## Test coverage

Added regression transcript.