### PR TITLE
Fix incorrect hanging of boolean operators, and elide extra parentheses

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -64,3 +64,4 @@ The format for this list: name, GitHub handle, and then optional blurb about wha
 * Shawn Bachlet (@shawn-bachlet)
 * Solomon Bothwell (@solomon-b)
 * Sameer Kolhar (@kolharsam)
+* Nicole Prindle (@nprindle)

--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -428,6 +428,8 @@ pattern Or' x y <- (ABT.out -> ABT.Tm (Or x y))
 pattern Handle' h body <- (ABT.out -> ABT.Tm (Handle h body))
 pattern Apps' f args <- (unApps -> Just (f, args))
 -- begin pretty-printer helper patterns
+pattern Ands' ands lastArg <- (unAnds -> Just (ands, lastArg))
+pattern Ors' ors lastArg <- (unOrs -> Just (ors, lastArg))
 pattern AppsPred' f args <- (unAppsPred -> Just (f, args))
 pattern BinaryApp' f arg1 arg2 <- (unBinaryApp -> Just (f, arg1, arg2))
 pattern BinaryApps' apps lastArg <- (unBinaryApps -> Just (apps, lastArg))
@@ -760,6 +762,30 @@ unLetRec (unLetRecNamed -> Just (isTop, bs, e)) = Just
     pure (vs `zip` [ sub b | (_, b) <- bs ], sub e)
   )
 unLetRec _ = Nothing
+
+unAnds
+  :: Term2 vt at ap v a
+  -> Maybe
+       ( [Term2 vt at ap v a]
+       , Term2 vt at ap v a
+       )
+unAnds t = case t of
+  And' i o -> case unAnds i of
+    Just (as, xLast) -> Just (xLast:as, o)
+    Nothing -> Just ([i], o)
+  _ -> Nothing
+
+unOrs
+  :: Term2 vt at ap v a
+  -> Maybe
+       ( [Term2 vt at ap v a]
+       , Term2 vt at ap v a
+       )
+unOrs t = case t of
+  Or' i o -> case unOrs i of
+    Just (as, xLast) -> Just (xLast:as, o)
+    Nothing -> Just ([i], o)
+  _ -> Nothing
 
 unApps
   :: Term2 vt at ap v a

--- a/unison-src/transcripts/boolean-op-pretty-print-2819.md
+++ b/unison-src/transcripts/boolean-op-pretty-print-2819.md
@@ -1,5 +1,9 @@
 Regression test for https://github.com/unisonweb/unison/pull/2819
 
+```ucm:hide
+.> builtins.merge
+```
+
 ```unison
 hangExample : Boolean
 hangExample =

--- a/unison-src/transcripts/boolean-op-pretty-print-2819.md
+++ b/unison-src/transcripts/boolean-op-pretty-print-2819.md
@@ -1,0 +1,14 @@
+Regression test for https://github.com/unisonweb/unison/pull/2819
+
+```unison
+hangExample : Boolean
+hangExample =
+  ("a long piece of text to hang the line" == "")
+    && ("a long piece of text to hang the line" == "")
+```
+
+```ucm
+.> add
+.> view hangExample
+```
+

--- a/unison-src/transcripts/boolean-op-pretty-print-2819.output.md
+++ b/unison-src/transcripts/boolean-op-pretty-print-2819.output.md
@@ -29,7 +29,6 @@ hangExample =
 
   hangExample : Boolean
   hangExample =
-    use Text ==
     ("a long piece of text to hang the line" == "")
       && ("a long piece of text to hang the line" == "")
 

--- a/unison-src/transcripts/boolean-op-pretty-print-2819.output.md
+++ b/unison-src/transcripts/boolean-op-pretty-print-2819.output.md
@@ -1,0 +1,36 @@
+Regression test for https://github.com/unisonweb/unison/pull/2819
+
+```unison
+hangExample : Boolean
+hangExample =
+  ("a long piece of text to hang the line" == "")
+    && ("a long piece of text to hang the line" == "")
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      hangExample : Boolean
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    hangExample : Boolean
+
+.> view hangExample
+
+  hangExample : Boolean
+  hangExample =
+    use Text ==
+    ("a long piece of text to hang the line" == "")
+      && ("a long piece of text to hang the line" == "")
+
+```


### PR DESCRIPTION
## Overview

Per #2818, the pretty-printer does not handle `&&` and `||` the same as other infix operators, and naively incorrectly hangs them when the line breaks, causing a roundtrip error. Previously, breaking a long line with an `&&` or `||` would incorrectly print without indentation, like this:

```
("a long piece of text to hang the line" == "")
&&
("a long piece of text to hang the line" == "")
```

This fails to parse, and primarily happens becaues `&&` and `||` are special-cased and not handled the same as other infix operators. This modifies the pretty-printer to now correctly hang the line as:

```
("a long piece of text to hang the line" == "")
  && ("a long piece of text to hang the line" == "")
```

An additional side effect of the change removes redundant parentheses in adjacent boolean operators; see below.

Resolves #2818

## Implementation notes

This is implemented very similarly to how infix operators are handled, having a special case for a chain of like boolean operators and pretty-printing them all at once.

Another consequence of the old approach was that subsequent `&&`s and `||`s do not elide parentheses like infix operators do. For example, `a && b && c && d` would be rendered as `(((a && b) && c) && d)`. A side effect of the above change is that the pretty-printer will now search for a chain of `&&`s or `||`s and render it without the extra parentheses.

## Controversial decisions

Since infix operators are always left-assocative and at the same fixity, chains of infix operators usually drop all parentheses. For the sake of clarity, this handles chains of `&&` and `||` separately, so that parentheses are kept when `&&` and `||` are mixed. However, this is easy to change if it would be better to elide all parentheses, if this were more in line with unison's current decisions.

For example, take `a && b && c || d && e && f`:

- Previously, this would be printed as `((((a && b) && c) || d) && e) && f`
- Now, this would be printed as `((a && b && c) || d) && e && f`
- If the two cases were optionally merged, it would be printed as `a && b && c || d && e && f`

## Test coverage

A regression test can be added after the PR is created to ensure that splitting a line with a boolean operator will roundtrip. Let me know if more regression tests are necessary, or if changes need to be made elsewhere!

## Loose ends

While testing, I ran into a special case of #2492, which I do not address here. Consider this code:

```hs
hangExample1 =
  ((or
      ("a long piece of text to hang the line" == "")
      ("a long piece of text to hang the line" == ""))
    && true)
    || true
```

Before, this would be pretty-printed as:
```hs
hangExample1 : Boolean
hangExample1 =
  use Text ==
  ((Boolean.or
    ("a long piece of text to hang the line" == "")
    ("a long piece of text to hang the line" == ""))
  &&
  true)
  ||
  true
```
which is clearly a roundtrip error.

Now, it will be printed as the following:
```hs
hangExample1 : Boolean
hangExample1 =
  use Text ==
  ((or
    ("a long piece of text to hang the line" == "")
    ("a long piece of text to hang the line" == ""))
    && true)
    || true
```
This is more correct, but because this happens to put two parentheses before the `or`, it runs into the same error observed in #2492.


This would be my first contribution to unison; I'm open to any feedback/suggestions/alternatives!