### PR TITLE
Fix error in dependency closure calculation.

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/SlurpComponent.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/SlurpComponent.hs
@@ -1,88 +1,102 @@
-{- ORMOLU_DISABLE -} -- Remove this when the file is ready to be auto-formatted
 {-# LANGUAGE PatternSynonyms #-}
 
 module Unison.Codebase.Editor.SlurpComponent where
 
-import Unison.Prelude
-
-import Data.Tuple (swap)
-import Unison.Reference ( Reference )
-import Unison.UnisonFile (TypecheckedUnisonFile)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
+import Data.Tuple (swap)
 import qualified Unison.DataDeclaration as DD
+import Unison.Prelude
+import Unison.Reference (Reference)
 import qualified Unison.Term as Term
+import Unison.UnisonFile (TypecheckedUnisonFile)
 import qualified Unison.UnisonFile as UF
 
-data SlurpComponent v =
-  SlurpComponent { types :: Set v, terms :: Set v }
-  deriving (Eq,Ord,Show)
+data SlurpComponent v = SlurpComponent {types :: Set v, terms :: Set v}
+  deriving (Eq, Ord, Show)
 
 isEmpty :: SlurpComponent v -> Bool
 isEmpty sc = Set.null (types sc) && Set.null (terms sc)
 
 empty :: Ord v => SlurpComponent v
-empty = SlurpComponent mempty mempty
+empty = SlurpComponent {types = mempty, terms = mempty}
 
 difference :: Ord v => SlurpComponent v -> SlurpComponent v -> SlurpComponent v
-difference c1 c2 = SlurpComponent types' terms' where
-  types' = types c1 `Set.difference` types c2
-  terms' = terms c1 `Set.difference` terms c2
+difference c1 c2 = SlurpComponent {types = types', terms = terms'}
+  where
+    types' = types c1 `Set.difference` types c2
+    terms' = terms c1 `Set.difference` terms c2
 
 intersection :: Ord v => SlurpComponent v -> SlurpComponent v -> SlurpComponent v
-intersection c1 c2 = SlurpComponent types' terms' where
-  types' = types c1 `Set.intersection` types c2
-  terms' = terms c1 `Set.intersection` terms c2
+intersection c1 c2 = SlurpComponent {types = types', terms = terms'}
+  where
+    types' = types c1 `Set.intersection` types c2
+    terms' = terms c1 `Set.intersection` terms c2
 
 instance Ord v => Semigroup (SlurpComponent v) where (<>) = mappend
-instance Ord v => Monoid (SlurpComponent v) where
-  mempty = SlurpComponent mempty mempty
-  c1 `mappend` c2 = SlurpComponent (types c1 <> types c2)
-                                   (terms c1 <> terms c2)
 
+instance Ord v => Monoid (SlurpComponent v) where
+  mempty = SlurpComponent {types = mempty, terms = mempty}
+  c1 `mappend` c2 =
+    SlurpComponent
+      { types = types c1 <> types c2,
+        terms = terms c1 <> terms c2
+      }
 
 -- I'm calling this `closeWithDependencies` because it doesn't just compute
 -- the dependencies of the inputs, it mixes them together.  Make sure this
 -- is what you want.
-closeWithDependencies :: forall v a. Ord v
-  => TypecheckedUnisonFile v a -> SlurpComponent v -> SlurpComponent v
-closeWithDependencies uf inputs = seenDefns where
-  seenDefns = foldl' termDeps (SlurpComponent {types=seenTypes, terms=mempty}) (terms inputs)
-  seenTypes = foldl' typeDeps mempty (types inputs)
+closeWithDependencies ::
+  forall v a.
+  Ord v =>
+  TypecheckedUnisonFile v a ->
+  SlurpComponent v ->
+  SlurpComponent v
+closeWithDependencies uf inputs = seenDefns
+  where
+    seenDefns = foldl' termDeps (SlurpComponent {types = seenTypes, terms = mempty}) (terms inputs)
+    seenTypes = foldl' typeDeps mempty (types inputs)
 
-  termDeps :: SlurpComponent v -> v -> SlurpComponent v
-  termDeps seen v | Set.member v (terms seen) = seen
-  termDeps seen v = fromMaybe seen $ do
-    term <- findTerm v
-    let -- get the `v`s for the transitive dependency types
-        -- (the ones for terms are just the `freeVars below`)
-        -- although this isn't how you'd do it for a term that's already in codebase
-        tdeps :: [v]
-        tdeps = resolveTypes $ Term.dependencies term
-        seenTypes :: Set v
-        seenTypes = foldl' typeDeps (types seen) tdeps
-        seenTerms = Set.insert v (terms seen)
-    pure $ foldl' termDeps (seen { types = seenTypes
-                                 , terms = seenTerms})
-                           (Term.freeVars term)
+    termDeps :: SlurpComponent v -> v -> SlurpComponent v
+    termDeps seen v | Set.member v (terms seen) = seen
+    termDeps seen v = fromMaybe seen $ do
+      term <- findTerm v
+      let -- get the `v`s for the transitive dependency types
+          -- (the ones for terms are just the `freeVars below`)
+          -- although this isn't how you'd do it for a term that's already in codebase
+          tdeps :: [v]
+          tdeps = resolveTypes $ Term.dependencies term
+          seenTypes :: Set v
+          seenTypes = foldl' typeDeps (types seen) tdeps
+          seenTerms = Set.insert v (terms seen)
+      pure $
+        foldl'
+          termDeps
+          ( seen
+              { types = seenTypes,
+                terms = seenTerms
+              }
+          )
+          (Term.freeVars term)
 
-  typeDeps :: Set v -> v -> Set v
-  typeDeps seen v | Set.member v seen = seen
-  typeDeps seen v = fromMaybe seen $ do
-    dd <- fmap snd (Map.lookup v (UF.dataDeclarations' uf)) <|>
-          fmap (DD.toDataDecl . snd) (Map.lookup v (UF.effectDeclarations' uf))
-    pure $ foldl' typeDeps (Set.insert v seen) (resolveTypes $ DD.dependencies dd)
+    typeDeps :: Set v -> v -> Set v
+    typeDeps seen v | Set.member v seen = seen
+    typeDeps seen v = fromMaybe seen $ do
+      dd <-
+        fmap snd (Map.lookup v (UF.dataDeclarations' uf))
+          <|> fmap (DD.toDataDecl . snd) (Map.lookup v (UF.effectDeclarations' uf))
+      pure $ foldl' typeDeps (Set.insert v seen) (resolveTypes $ DD.dependencies dd)
 
-  resolveTypes :: Set Reference -> [v]
-  resolveTypes rs = [ v | r <- Set.toList rs, Just v <- [Map.lookup r typeNames]]
+    resolveTypes :: Set Reference -> [v]
+    resolveTypes rs = [v | r <- Set.toList rs, Just v <- [Map.lookup r typeNames]]
 
-  findTerm :: v -> Maybe (Term.Term v a)
-  findTerm v = Map.lookup v allTerms
+    findTerm :: v -> Maybe (Term.Term v a)
+    findTerm v = Map.lookup v allTerms
 
-  allTerms = UF.allTerms uf
+    allTerms = UF.allTerms uf
 
-  typeNames :: Map Reference v
-  typeNames = invert (fst <$> UF.dataDeclarations' uf) <> invert (fst <$> UF.effectDeclarations' uf)
+    typeNames :: Map Reference v
+    typeNames = invert (fst <$> UF.dataDeclarations' uf) <> invert (fst <$> UF.effectDeclarations' uf)
 
-  invert :: forall k v . Ord k => Ord v => Map k v -> Map v k
-  invert m = Map.fromList (swap <$> Map.toList m)
+    invert :: forall k v. Ord k => Ord v => Map k v -> Map v k
+    invert m = Map.fromList (swap <$> Map.toList m)

--- a/unison-cli/src/Unison/Codebase/Editor/SlurpComponent.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/SlurpComponent.hs
@@ -47,7 +47,7 @@ instance Ord v => Monoid (SlurpComponent v) where
 closeWithDependencies :: forall v a. Ord v
   => TypecheckedUnisonFile v a -> SlurpComponent v -> SlurpComponent v
 closeWithDependencies uf inputs = seenDefns where
-  seenDefns = foldl' termDeps (SlurpComponent mempty seenTypes) (terms inputs)
+  seenDefns = foldl' termDeps (SlurpComponent {types=seenTypes, terms=mempty}) (terms inputs)
   seenTypes = foldl' typeDeps mempty (types inputs)
 
   termDeps :: SlurpComponent v -> v -> SlurpComponent v

--- a/unison-src/transcripts/type-deps.md
+++ b/unison-src/transcripts/type-deps.md
@@ -1,0 +1,32 @@
+# Ensure type dependencies are properly considered in slurping
+
+https://github.com/unisonweb/unison/pull/2821
+
+```ucm:hide
+.> builtins.merge
+```
+
+
+Define a type.
+
+```unison:hide
+structural type Y = Y
+```
+
+```ucm:hide
+.> add
+```
+
+Now, we update `Y`, and add a new type `Z` which depends on it.
+
+```unison
+structural type Z = Z Y
+structural type Y = Y Nat
+```
+
+Adding should fail for BOTH definitions, `Y` needs an update and `Z` is blocked by `Y`.
+```ucm:error
+.> add 
+-- This shouldn't exist, because it should've been blocked.
+.> view Z
+```

--- a/unison-src/transcripts/type-deps.output.md
+++ b/unison-src/transcripts/type-deps.output.md
@@ -1,0 +1,56 @@
+# Ensure type dependencies are properly considered in slurping
+
+https://github.com/unisonweb/unison/pull/2821
+
+Define a type.
+
+```unison
+structural type Y = Y
+```
+
+Now, we update `Y`, and add a new type `Z` which depends on it.
+
+```unison
+structural type Z = Z Y
+structural type Y = Y Nat
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      structural type Z
+    
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      structural type Y
+        (The old definition is also named builtin.Unit. I'll
+        update this name too.)
+
+```
+Adding should fail for BOTH definitions, `Y` needs an update and `Z` is blocked by `Y`.
+```ucm
+.> add 
+
+  x These definitions failed:
+  
+    Reason
+    needs update structural type Y
+    blocked      structural type Z
+  
+    Tip: Use `help filestatus` to learn more.
+
+-- This shouldn't exist, because it should've been blocked.
+.> view Z
+
+  ⚠️
+  
+  The following names were not found in the codebase. Check your spelling.
+    Z
+
+```


### PR DESCRIPTION
## Overview

`seenTypes` was erroneously put into the `term` slot, leading to incorrect dependency calculations.

Likely this didn't come up often, since it would cause problems if you add dependencies between multiple types in your scratch file and only added one of them.

See changes without the ormolu here: https://github.com/unisonweb/unison/pull/2821/commits/c332e466339dc39157478fc62e56a62733b15286

Since this is a small change I threw an ormolu in with this PR as well, hope that's okay, but they're in separate commits for readability.

## Loose Ends

In writing up this PR I noticed that you can't currently `add` types by name, e.g. `add X` just does nothing if X is a type instead of a term. That should be fixed by my slurping rewrite so I'll leave that alone here for now.