### PR TITLE
Fix pattern matching in docs

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -280,15 +280,17 @@ intermediateTerm
   -> Term Symbol
   -> (SuperGroup Symbol, Map.Map Word64 (Term Symbol))
 intermediateTerm ppe ref ctx tm
-  = final
+  = first ( superNormalize
+          . splitPatterns (dspec ctx)
+          . addDefaultCases tmName
+          )
+  . memorize
   . lamLift
-  . splitPatterns (dspec ctx)
-  . addDefaultCases tmName
   . saturate (uncurryDspec $ dspec ctx)
   . inlineAlias
   $ tm
   where
-  final (ll, dcmp) = (superNormalize ll, backrefLifted ll dcmp)
+  memorize (ll, dcmp) = (ll, backrefLifted ll dcmp)
   tmName = HQ.toString . termName ppe $ RF.Ref ref
 
 prepareEvaluation

--- a/unison-src/transcripts-using-base/doc.md.files/syntax.u
+++ b/unison-src/transcripts-using-base/doc.md.files/syntax.u
@@ -73,6 +73,14 @@ id x = x
 id (sqr 10)
 ``` 
 
+also:
+
+```
+match 1 with
+  1 -> "hi"
+  _ -> "goodbye"
+```
+
 To include a typechecked snippet of code without evaluating it, you can do:
 
 @typecheck ```

--- a/unison-src/transcripts-using-base/doc.output.md
+++ b/unison-src/transcripts-using-base/doc.output.md
@@ -257,6 +257,14 @@ and the rendered output using `display`:
       id (sqr 10)
       ```
       
+      also:
+      
+      ```
+      match 1 with
+        1 -> "hi"
+        _ -> "goodbye"
+      ```
+      
       To include a typechecked snippet of code without
       evaluating it, you can do:
       
@@ -280,6 +288,14 @@ and the rendered output using `display`:
         id (sqr 10)
         ⧨
         100
+  
+    also:
+  
+        match 1 with
+          1 -> "hi"
+          _ -> "goodbye"
+        ⧨
+        "hi"
   
     To include a typechecked snippet of code without evaluating
     it, you can do:
@@ -625,6 +641,14 @@ Lastly, it's common to build longer documents including subdocuments via `{{ sub
           id (sqr 10)
           ⧨
           100
+    
+      also:
+    
+          match 1 with
+            1 -> "hi"
+            _ -> "goodbye"
+          ⧨
+          "hi"
     
       To include a typechecked snippet of code without
       evaluating it, you can do:

--- a/unison-src/transcripts/bug-strange-closure.output.md
+++ b/unison-src/transcripts/bug-strange-closure.output.md
@@ -77,6 +77,14 @@ We can display the guide before and after adding it to the codebase:
           ⧨
           100
     
+      also:
+    
+          match 1 with
+            1 -> "hi"
+            _ -> "goodbye"
+          ⧨
+          "hi"
+    
       To include a typechecked snippet of code without
       evaluating it, you can do:
     
@@ -277,6 +285,14 @@ We can display the guide before and after adding it to the codebase:
           id (sqr 10)
           ⧨
           100
+    
+      also:
+    
+          match 1 with
+            1 -> "hi"
+            _ -> "goodbye"
+          ⧨
+          "hi"
     
       To include a typechecked snippet of code without
       evaluating it, you can do:
@@ -485,6 +501,14 @@ rendered = Pretty.get (docFormatConsole doc.guide)
           ⧨
           100
     
+      also:
+    
+          match 1 with
+            1 -> "hi"
+            _ -> "goodbye"
+          ⧨
+          "hi"
+    
       To include a typechecked snippet of code without
       evaluating it, you can do:
     
@@ -678,6 +702,14 @@ rendered = Pretty.get (docFormatConsole doc.guide)
           id (sqr 10)
           ⧨
           100
+    
+      also:
+    
+          match 1 with
+            1 -> "hi"
+            _ -> "goodbye"
+          ⧨
+          "hi"
     
       To include a typechecked snippet of code without
       evaluating it, you can do:
@@ -1790,6 +1822,29 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                                       (_ ->
                                         id x = x
                                         id (sqr 10)))))))),
+                          !Lit (Right (Plain "\n")),
+                          !Lit (Right (Plain "\n")),
+                          !Indent
+                          (!Lit (Right (Plain "  ")))
+                          (!Lit (Right (Plain "  ")))
+                          (!Annotated.Group
+                            (!Wrap
+                              (!Lit (Right (Plain "also:"))))),
+                          !Lit (Right (Plain "\n")),
+                          !Lit (Right (Plain "\n")),
+                          !Indent
+                          (!Lit (Right (Plain "  ")))
+                          (!Lit (Right (Plain "  ")))
+                          (!Annotated.Group
+                            (!Lit
+                              (Left
+                                (Eval
+                                  (Term.Term
+                                    (Any
+                                      (_ ->
+                                        (match 1 with
+                                          1 -> "hi"
+                                          _ -> "goodbye")))))))),
                           !Lit (Right (Plain "\n")),
                           !Lit (Right (Plain "\n")),
                           !Indent

--- a/unison-src/transcripts/fix2053.output.md
+++ b/unison-src/transcripts/fix2053.output.md
@@ -2,12 +2,11 @@
 .> display List.map
 
   go f i as acc =
-    _pattern = List.at i as
-    match _pattern with
-      None           -> acc
-      Some _pattern1 ->
+    match List.at i as with
+      None   -> acc
+      Some a ->
         use Nat +
-        go f (i + 1) as (acc :+ f _pattern)
+        go f (i + 1) as (acc :+ f a)
   f a -> go f 0 a []
 
 ```


### PR DESCRIPTION
It seems that docs can make multiple trips through the runtime with the decompiler in the middle. The decompiler was producing bad output for matching blocks, reordering cases in an invalid way and such, resulting in subsequent evaluation giving the wrong answer. This tweaks the way that decompilation information is collected to produce something valid in this case.

Fixes #2778 