### PR TITLE
Fix type declaration example

### DIFF
--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -1267,7 +1267,7 @@ prettyParseError s = \case
     , "\n  - An `ability` declaration, like "
       <> style Code "ability Foo where ..."
     , "\n  - A `type` declaration, like "
-      <> style Code "type Optional a = None | Some a"
+      <> style Code "structural type Optional a = None | Some a"
     , "\n  - A `namespace` declaration, like "
       <> style Code "namespace Seq where ..."
     , "\n"

--- a/unison-src/transcripts/error-messages.output.md
+++ b/unison-src/transcripts/error-messages.output.md
@@ -243,7 +243,7 @@ a ! b = 1
                       a = 42
     - A watch expression, like > a + 1
     - An `ability` declaration, like ability Foo where ...
-    - A `type` declaration, like type Optional a = None | Some a
+    - A `type` declaration, like structural type Optional a = None | Some a
     - A `namespace` declaration, like namespace Seq where ...
   
 

--- a/unison-src/transcripts/errors/unison-hide-all.output.md
+++ b/unison-src/transcripts/errors/unison-hide-all.output.md
@@ -27,7 +27,7 @@ The transcript failed due to an error in the stanza above. The error is:
                       g = 42
     - A watch expression, like > g + 1
     - An `ability` declaration, like ability Foo where ...
-    - A `type` declaration, like type Optional a = None | Some a
+    - A `type` declaration, like structural type Optional a = None | Some a
     - A `namespace` declaration, like namespace Seq where ...
   
 

--- a/unison-src/transcripts/errors/unison-hide.output.md
+++ b/unison-src/transcripts/errors/unison-hide.output.md
@@ -27,7 +27,7 @@ The transcript failed due to an error in the stanza above. The error is:
                       g = 42
     - A watch expression, like > g + 1
     - An `ability` declaration, like ability Foo where ...
-    - A `type` declaration, like type Optional a = None | Some a
+    - A `type` declaration, like structural type Optional a = None | Some a
     - A `namespace` declaration, like namespace Seq where ...
   
 


### PR DESCRIPTION
These days you need to specify `structural` or `unique` for type
declarations.