### PR TITLE
vim completion: handle leading {

### DIFF
--- a/editor-support/vim/autoload/unison.vim
+++ b/editor-support/vim/autoload/unison.vim
@@ -52,7 +52,17 @@ function! unison#Complete(findstart, base) abort
     " locate the start of the word
     let line = getline('.')
     let start = col('.') - 1
-    while start > 0 && line[start - 1] !~ '\s' && line[start - 1] != '(' && line[start - 1] != ')'
+    " Examples of where we want to count the start of a word:
+    "
+    " foo List.fold<cursor>
+    "     ^
+    "
+    " {Abor<cursor>
+    "  ^
+    "
+    " (List.fol<cursor>
+    "  ^
+    while start > 0 && line[start - 1] !~ '\v\s|[(){}\[\]]'
       let start -= 1
     endwhile
     return start


### PR DESCRIPTION
Before this change if you had `{Abor<cursor>` and triggered completion,
nothing would be found because the `{` was included in the search
string. This change special-cases a few characters (braces, parentheses)
so that they don't accidentally get included in the search term.

I think that a fix that is 100% compatible with the Unison spec would be
more involved. But this seems to handle the vast majority of uses. Also
I don't think that the Unison parser even is 100% compatible with the
Unison spec 🙂.