### PR TITLE
Add transactions to all relevant sqlitecodebase ops

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -116,6 +116,7 @@ module U.Codebase.Sqlite.Queries (
   rollbackRelease,
   withSavepoint,
   withSavepoint_,
+  withTransaction,
 
   vacuumInto,
   setJournalMode,
@@ -887,6 +888,10 @@ withImmediateTransaction action = do
   c <- Reader.reader Connection.underlying
   withRunInIO \run -> SQLite.withImmediateTransaction c (run action)
 
+withTransaction :: (DB m, MonadUnliftIO m) => m a -> m a
+withTransaction action = do
+  c <- Reader.reader Connection.underlying
+  withRunInIO \run -> SQLite.withTransaction c (run action)
 
 -- | low-level transaction stuff
 savepoint, release, rollbackTo, rollbackRelease :: DB m => String -> m ()

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -116,7 +116,6 @@ module U.Codebase.Sqlite.Queries (
   rollbackRelease,
   withSavepoint,
   withSavepoint_,
-  withTransaction,
 
   vacuumInto,
   setJournalMode,
@@ -888,10 +887,6 @@ withImmediateTransaction action = do
   c <- Reader.reader Connection.underlying
   withRunInIO \run -> SQLite.withImmediateTransaction c (run action)
 
-withTransaction :: (DB m, MonadUnliftIO m) => m a -> m a
-withTransaction action = do
-  c <- Reader.reader Connection.underlying
-  withRunInIO \run -> SQLite.withTransaction c (run action)
 
 -- | low-level transaction stuff
 savepoint, release, rollbackTo, rollbackRelease :: DB m => String -> m ()

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -926,7 +926,6 @@ runDB conn = (runExceptT >=> err) . flip runReaderT conn
 
 -- | Like 'runDB', but executes the action within a transaction on the provided
 -- connection.
--- Don't nest 'runDBInTx' calls, use 'withSavepoint' if you need nested transactions.
 runDBInTx ::
   MonadUnliftIO m =>
   Connection ->

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -924,6 +924,9 @@ runDB conn = (runExceptT >=> err) . flip runReaderT conn
   where
     err = \case Left err -> error $ show err; Right a -> pure a
 
+-- | Like 'runDB', but executes the action within a transaction on the provided
+-- connection.
+-- Don't nest 'runDBInTx' calls, use 'withSavepoint' if you need nested transactions.
 runDBInTx ::
   MonadUnliftIO m =>
   Connection ->


### PR DESCRIPTION
## Overview
During migration work we discovered that some operations aren't being performed transactionally and it can possibly lead to database integrity errors, for example, interrupting a 'saveBranch' operation might lead to a future 'saveBranch' call incorrectly thinking it succeeded and saved everything, but in actuality it missed saving some branch objects due to some partially saved work from a previous interrupted call.

It would likely be best to perform transactions safely at the ucm command level, but this gets pretty tricky with cross-codebase transactions and also would likely cause the codebase implementation to leak, so this is at least one step closer to safety without needing to refactor everything.

## Implementation notes

Added transactions to all codebase operations which write/update the codebase.

## Test coverage

Existing tests should show that we at least don't run into any silly errors from nested transactions or something like that.

I ran some benchmarking to detect any performance drop-off.

I started with a transcript which syncs share to ensure that syncing isn't affected negatively. The benchmarks came out almost identical:

```
time unison-transactions transcript ./sync-share.md
142.77s user 12.70s system 97% cpu 2:39.06 total

time unison-trunk transcript ./sync-share.md  
142.41s user 12.06s system 98% cpu 2:37.51 total
```

But that's expected, since the `sync` code shouldn't be affected by any of these new transactions.

The next most-likely issue would be that `putTerm` would be slower, and that it might be called often on large scratch files or in propagations.

I ran a transcript which adds a scratch file with 2000 unique terms in it, twice with each (optimized) build.

```
unison-trunk transcript putTerms.md  3.70s user 0.41s system 93% cpu 4.396 total
unison-trunk transcript putTerms.md  3.69s user 0.42s system 93% cpu 4.391 total

unison-transactions transcript putTerms.md  3.65s user 0.25s system 94% cpu 4.120 total
unison-transactions transcript putTerms.md  3.59s user 0.25s system 95% cpu 4.003 total
```

So no perceptible changes here, if there is any difference it's likely to be dwarfed by the cost of type-checking anyways.