### PR TITLE
Recover from missing branch objects by replacing with empty branches.

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Branch/Full.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Branch/Full.hs
@@ -18,6 +18,7 @@ import U.Codebase.Sqlite.LocalIds (LocalBranchChildId, LocalDefnId, LocalPatchOb
 import qualified Unison.Util.Set as Set
 import Unison.Prelude
 import qualified Unison.Util.Map as Map
+import qualified Data.Map as Map
 
 -- |
 -- @
@@ -50,6 +51,9 @@ data Branch' t h p c = Branch
     children :: Map t c
   }
   deriving (Show, Generic)
+
+emptyBranch :: Branch' t h p c
+emptyBranch = Branch Map.empty Map.empty Map.empty Map.empty
 
 branchHashes_ :: (Ord h', Ord t, Ord h) => Traversal (Branch' t h p c) (Branch' t h' p c) h h'
 branchHashes_ f Branch {..} = do

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/MigrateSchema12.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/MigrateSchema12.hs
@@ -117,9 +117,10 @@ migrateSchema12 conn codebase = do
     liftIO $ putStrLn $ "Starting codebase migration. This may take a while, it's a good time to make some tea ☕️"
     corruptedCausals <- runDB conn (liftQ Q.getCausalsWithoutBranchObjects)
     when (not . null $ corruptedCausals) $ do
-      liftIO $ putStrLn $ "⚠️  I detected " <> show (length corruptedCausals) <> " missing namespace(s) in the codebase."
-      liftIO $ putStrLn $ "I'll go ahead with the migration, but will replace any missing namespaces with empty ones."
-      liftIO $ putStrLn $ "Typically this is no cause for concern."
+      liftIO $ putStrLn $ "⚠️  I detected " <> show (length corruptedCausals) <> " corrupted namespace(s) in the history of the codebase."
+      liftIO $ putStrLn $ "This is due to a bug in a previous version of ucm."
+      liftIO $ putStrLn $ "This only affects the history of your codebase, the most up-to-date iteration will remain intact."
+      liftIO $ putStrLn $ "I'll go ahead with the migration, but will replace any corrupted namespaces with empty ones."
 
     liftIO $ putStrLn $ "Updating Namespace Root..."
     rootCausalHashId <- runDB conn (liftQ Q.loadNamespaceRoot)


### PR DESCRIPTION
## Overview

It seems that due to some race conditions when saving branches in the past, it's possible that some causals refer to branches which don't have an object saved in the DB.
Unfortunately we have no way to recover the missing branch itself, but we probably shouldn't fail the migration entirely.


## Implementation notes

To mitigate the issue as best we can, this replaces missing branches with an empty branch, and rebuilds all future causals on top of that.

I also added a warning message when starting the migration.


![image](https://user-images.githubusercontent.com/6439644/151598717-4db57f9e-f40b-4ed6-8407-30a6e26f2eed.png)

## Test coverage

- [x] Test this on Simon's corrupted codebase.

Here's a tiny corrupted codebase to try it out yourself if you like:

[corrupted.zip](https://github.com/unisonweb/unison/files/7960967/corrupted.zip)

I migrated this codebase, checked the history, confirmed that the branch was replaced with an empty one and that I could fork that point in history and that everything else still worked 👍🏼 