### PR TITLE
Remember more type annotations in decompiled output

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/ANF.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF.hs
@@ -178,7 +178,7 @@ enclose keep rec (LetRecNamedTop' top vbs bd)
   lvbs = (map.fmap) (rec keep' . abstract keep' . ABT.substs xpnd) vbs
   lbd = rec keep' . ABT.substs xpnd $ bd
 -- will be lifted, so keep this variable
-enclose keep rec (Let1NamedTop' top v b@(LamsNamed' vs bd) e)
+enclose keep rec (Let1NamedTop' top v b@(unAnn -> LamsNamed' vs bd) e)
   = Just . let1' top [(v, lamb)] . rec (Set.insert v keep)
   $ ABT.subst v av e
   where
@@ -188,7 +188,10 @@ enclose keep rec (Let1NamedTop' top v b@(LamsNamed' vs bd) e)
   evs = Set.toList $ Set.difference fvs keep
   a = ABT.annotation b
   lbody = rec keep' bd
-  lamb = lam' a (evs ++ vs) lbody
+  annotate tm
+    | Ann' _ ty <- b = ann a tm ty
+    | otherwise = tm
+  lamb = lam' a evs (annotate $ lam' a vs lbody)
 enclose keep rec t@(LamsNamed' vs body)
   = Just $ if null evs then lamb else apps' lamb $ map (var a) evs
   where
@@ -264,6 +267,9 @@ letFloater rec vbs e = do
   modify (\(vs,ctx,dcmp) -> (vs, ctx ++ fvbs, dcmp))
   pure $ ABT.renames shadowMap e
   where
+  rec' b@(Ann' (LamsNamed' vs bd) _ty)
+    = lam' a vs <$> rec bd
+    where a = ABT.annotation b
   rec' b@(LamsNamed' vs bd) = lam' (ABT.annotation b) vs <$> rec bd
   rec' b = rec b
 
@@ -294,9 +300,9 @@ floater top rec (LetRecNamed' vbs e)
         where a = ABT.annotation lm
       tm -> rec tm
 floater _   rec (Let1Named' v b e)
-  | LamsNamed' vs bd <- b
+  | Just (vs0, _, vs1, bd) <- unLamsAnnot b
   = Just $ rec bd
-       >>= lamFloater (null $ ABT.freeVars b) b (Just v) a vs
+       >>= lamFloater (null $ ABT.freeVars b) b (Just v) a (vs0++vs1)
        >>= \lv -> rec $ ABT.renames (Map.singleton v lv) e
   where a = ABT.annotation b
 
@@ -311,7 +317,7 @@ floater _ _ _ = Nothing
 
 float :: (Var v, Monoid a) => Term v a -> (Term v a, [(v, Term v a)])
 float tm = case runState go0 (Set.empty, [], []) of
-  (bd, (_, ctx, dcmp)) -> (letRec' True ctx bd, dcmp)
+  (bd, (_, ctx, dcmp)) -> (deannotate $ letRec' True ctx bd, dcmp)
   where
   go0 = fromMaybe (go tm) (floater True go tm)
   go = ABT.visit $ floater False go
@@ -320,13 +326,32 @@ float tm = case runState go0 (Set.empty, [], []) of
   --    = let1' False pre . letRec' False rec . let1' False post $ e
   --    | otherwise = tm0
 
+unAnn :: Term v a -> Term v a
+unAnn (Ann' tm _) = tm
+unAnn tm = tm
+
+unLamsAnnot :: Term v a -> Maybe ([v], Maybe (Ty.Type v a), [v], Term v a)
+unLamsAnnot tm0
+  | null vs0, null vs1 = Nothing
+  | otherwise = Just (vs0, mty, vs1, bd)
+  where
+  (vs0, bd0)
+    | LamsNamed' vs bd <- tm0 = (vs, bd)
+    | otherwise = ([], tm0)
+  (mty, bd1)
+    | Ann' bd ty <- bd0 = (Just ty, bd)
+    | otherwise = (Nothing, bd0)
+  (vs1, bd)
+    | LamsNamed' vs bd <- bd1 = (vs, bd)
+    | otherwise = ([], bd1)
+
 deannotate :: Var v => Term v a -> Term v a
 deannotate = ABT.visitPure $ \case
   Ann' c _ -> Just $ deannotate c
   _ -> Nothing
 
 lamLift :: (Var v, Monoid a) => Term v a -> (Term v a, [(v, Term v a)])
-lamLift = float . close Set.empty . deannotate
+lamLift = float . close Set.empty
 
 saturate
   :: (Var v, Monoid a)

--- a/parser-typechecker/src/Unison/Runtime/Debug.hs
+++ b/parser-typechecker/src/Unison/Runtime/Debug.hs
@@ -5,6 +5,7 @@ module Unison.Runtime.Debug
   , traceCombs
   , tracePretty
   , tracePrettyGroup
+  , module Debug.Trace
   ) where
 
 import Data.Word

--- a/unison-src/transcripts-using-base/doc.output.md
+++ b/unison-src/transcripts-using-base/doc.output.md
@@ -300,6 +300,7 @@ and the rendered output using `display`:
     To include a typechecked snippet of code without evaluating
     it, you can do:
   
+        cube : Nat -> Nat
         cube x =
           use Nat *
           x * x * x
@@ -653,6 +654,7 @@ Lastly, it's common to build longer documents including subdocuments via `{{ sub
       To include a typechecked snippet of code without
       evaluating it, you can do:
     
+          cube : Nat -> Nat
           cube x =
             use Nat *
             x * x * x

--- a/unison-src/transcripts/bug-strange-closure.output.md
+++ b/unison-src/transcripts/bug-strange-closure.output.md
@@ -88,6 +88,7 @@ We can display the guide before and after adding it to the codebase:
       To include a typechecked snippet of code without
       evaluating it, you can do:
     
+          cube : Nat -> Nat
           cube x =
             use Nat *
             x * x * x
@@ -297,6 +298,7 @@ We can display the guide before and after adding it to the codebase:
       To include a typechecked snippet of code without
       evaluating it, you can do:
     
+          cube : Nat -> Nat
           cube x =
             use Nat *
             x * x * x
@@ -512,6 +514,7 @@ rendered = Pretty.get (docFormatConsole doc.guide)
       To include a typechecked snippet of code without
       evaluating it, you can do:
     
+          cube : Nat -> Nat
           cube x =
             use Nat *
             x * x * x
@@ -714,6 +717,7 @@ rendered = Pretty.get (docFormatConsole doc.guide)
       To include a typechecked snippet of code without
       evaluating it, you can do:
     
+          cube : Nat -> Nat
           cube x =
             use Nat *
             x * x * x
@@ -1880,6 +1884,7 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                                   0 (Term.Term
                                     (Any
                                       (_ ->
+                                        cube : Nat -> Nat
                                         cube x =
                                           use Nat *
                                           x * x * x

--- a/unison-src/transcripts/fix2795.md
+++ b/unison-src/transcripts/fix2795.md
@@ -1,0 +1,5 @@
+```ucm
+.> builtins.mergeio
+.> load unison-src/transcripts/fix2795/docs.u
+.> display test
+```

--- a/unison-src/transcripts/fix2795.output.md
+++ b/unison-src/transcripts/fix2795.output.md
@@ -1,0 +1,27 @@
+```ucm
+.> builtins.mergeio
+
+  Done.
+
+.> load unison-src/transcripts/fix2795/docs.u
+
+  I found and typechecked these definitions in
+  unison-src/transcripts/fix2795/docs.u. If you do an `add` or
+  `update`, here's how your codebase would change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      t1   : Text
+      test : Doc2
+
+.> display test
+
+      t : Text
+      t = "hi"
+      t
+      ⧨
+      "hi"
+  
+      t1 = "hi"
+
+```

--- a/unison-src/transcripts/fix2795/docs.u
+++ b/unison-src/transcripts/fix2795/docs.u
@@ -1,0 +1,12 @@
+test = {{
+  ```
+  t : Text
+  t = "hi"
+
+  t
+  ```
+  @source{t1}
+
+}}
+
+t1 = "hi"


### PR DESCRIPTION
This keeps some type annotations around in the remembered code for decompiled output, so that it can show up in docs, for instance. Should fix #2795 I believe.

I didn't include a test case for #2795 because you can't actually use a triple backtick doc in a transcript.