### PR TITLE
Fix incorrect keyword lexing in links in docs

### DIFF
--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -397,7 +397,7 @@ lexemes' eof = P.optional space >> do
           pure s
 
     typeLink = wrap "syntax.docEmbedTypeLink" $ do
-      _ <- typeOrAbilityAlt lit <* CP.space
+      _ <- typeOrAbilityAlt wordyKw <* CP.space
       tok (symbolyId <|> wordyId) <* CP.space
 
     termLink = wrap "syntax.docEmbedTermLink" $

--- a/unison-src/transcripts/doc-type-link-keywords.md
+++ b/unison-src/transcripts/doc-type-link-keywords.md
@@ -1,0 +1,41 @@
+Regression test to ensure that `type` and `ability` in embedded doc links are
+lexed properly when they occur at the start of identifiers.
+
+That is, `{abilityPatterns}` should be a link to the **term** `abilityPatterns`,
+not the ability `Patterns`; the lexer should see this as a single identifier.
+
+See https://github.com/unisonweb/unison/issues/2642 for an example.
+
+```ucm:hide
+.> builtins.mergeio
+```
+
+```unison:hide
+abilityPatterns : ()
+abilityPatterns = ()
+
+structural ability Patterns where p : ()
+
+typeLabels : Nat
+typeLabels = 5
+
+structural type Labels = Labels
+
+docs.example1 = {{A doc that links to the {abilityPatterns} term}}
+docs.example2 = {{A doc that links to the {ability Patterns} ability}}
+docs.example3 = {{A doc that links to the {typeLabels} term}}
+docs.example4 = {{A doc that links to the {type Labels} type}}
+```
+
+```ucm:hide
+.> add
+```
+
+Now we check that each doc links to the object of the correct name:
+
+```ucm
+.> display docs.example1
+.> display docs.example2
+.> display docs.example3
+.> display docs.example4
+```

--- a/unison-src/transcripts/doc-type-link-keywords.output.md
+++ b/unison-src/transcripts/doc-type-link-keywords.output.md
@@ -1,0 +1,45 @@
+Regression test to ensure that `type` and `ability` in embedded doc links are
+lexed properly when they occur at the start of identifiers.
+
+That is, `{abilityPatterns}` should be a link to the **term** `abilityPatterns`,
+not the ability `Patterns`; the lexer should see this as a single identifier.
+
+See https://github.com/unisonweb/unison/issues/2642 for an example.
+
+```unison
+abilityPatterns : ()
+abilityPatterns = ()
+
+structural ability Patterns where p : ()
+
+typeLabels : Nat
+typeLabels = 5
+
+structural type Labels = Labels
+
+docs.example1 = {{A doc that links to the {abilityPatterns} term}}
+docs.example2 = {{A doc that links to the {ability Patterns} ability}}
+docs.example3 = {{A doc that links to the {typeLabels} term}}
+docs.example4 = {{A doc that links to the {type Labels} type}}
+```
+
+Now we check that each doc links to the object of the correct name:
+
+```ucm
+.> display docs.example1
+
+  A doc that links to the abilityPatterns term
+
+.> display docs.example2
+
+  A doc that links to the Patterns ability
+
+.> display docs.example3
+
+  A doc that links to the typeLabels term
+
+.> display docs.example4
+
+  A doc that links to the Labels type
+
+```


### PR DESCRIPTION
## Overview

Resolves #2642

A doc containing a term link in like this:
```
{{A doc linking to {abilityFoo}}}
```
would previously eagerly lex the `ability` or `type` at the start of an identifier as a keyword, tricking the parser into thinking we're in a type link instead. The above would complain about not finding the ability `Foo`, rather than about not finding the term `abilityFoo`.

This fixes the lexer to handle such cases properly.

## Implementation notes

This was just a tiny lexer fix in exactly the same vein as #2727/#2847; the lexer was looking for a literal keyword string, and didn't check to see if it was followed by something that could delimit a keyword.

I've looked over all of the other places where the lexer reads a literal string (using `lit` and its variants), and they all now look correct; I'm hoping this is the last such bug.

## Test coverage

Adds a regression test transcript to test that `type` and `ability` are lexed properly in type and term links in docs. The current lexer tests don't include any tests on docs, so I didn't add any, but I could if it would be preferred.