### PR TITLE
docs.as-html: use block elements for Style

### DIFF
--- a/parser-typechecker/src/Unison/Server/Doc/AsHtml.hs
+++ b/parser-typechecker/src/Unison/Server/Doc/AsHtml.hs
@@ -274,7 +274,7 @@ toHtml docNamesByRef document =
             Strikethrough d ->
               span_ [class_ "strikethrough"] <$> currentSectionLevelToHtml d
             Style cssclass_ d ->
-              span_ [class_ $ textToClass cssclass_] <$> currentSectionLevelToHtml d
+              div_ [class_ $ textToClass cssclass_] <$> currentSectionLevelToHtml d
             Anchor id' d ->
               a_ [id_ id', href_ $ "#" <> id'] <$> currentSectionLevelToHtml d
             Blockquote d ->


### PR DESCRIPTION
## Overview

The `Style` variant is meant to wrap things to give them an appropriate
css class, but needs to be a block element so that it can contain other
block elements.

This fixes an issue with the new docs site where the css class weren't being applied.