### PR TITLE
make a couple Name -> Split functions not return Maybes

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
+++ b/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
@@ -59,14 +59,9 @@ fromNames names0 = Branch.stepManyAt Branch.CompressHistory (typeActions <> term
   typeActions = map doType . R.toList $ Names.types names0
   termActions = map doTerm . R.toList $ Names.terms names0
 --  doTerm :: (Name, Referent) -> (Path, Branch0 m -> Branch0 m)
-  doTerm (n, r) = case Path.splitFromName n of
-    Nothing -> errorEmptyName
-    Just split -> makeAddTermName split r mempty -- no metadata
+  doTerm (n, r) = makeAddTermName (Path.splitFromName n) r mempty -- no metadata
 --  doType :: (Name, Reference) -> (Path, Branch0 m -> Branch0 m)
-  doType (n, r) = case Path.splitFromName n of
-             Nothing -> errorEmptyName
-             Just split -> makeAddTypeName split r mempty -- no metadata
-  errorEmptyName = error "encountered an empty name"
+  doType (n, r) = makeAddTypeName (Path.splitFromName n) r mempty -- no metadata
 
 getTerm :: Path.HQSplit -> Branch0 m -> Set Referent
 getTerm (p, hq) b = case hq of

--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -80,7 +80,7 @@ import Data.Sequence (Seq ((:<|), (:|>)))
 import qualified Data.Sequence as Seq
 import qualified Data.Text as Text
 import qualified Unison.HashQualified' as HQ'
-import Unison.Name (Convert(..), Name, Parse)
+import Unison.Name (Convert(..), Name)
 import qualified Unison.Name as Name
 import Unison.NameSegment (NameSegment (NameSegment))
 import qualified Unison.NameSegment as NameSegment


### PR DESCRIPTION
## Overview

A `Name` is non-empty, so it can always be split into a possibly-empty list of initial segments, and a final segment, which is what a path `Split` is.

This PR changes the types of

```haskell
hqSplitFromName' :: Name -> Maybe HQSplit'
splitFromName :: Name -> Maybe Split
```

to

```haskell
hqSplitFromName' :: Name -> HQSplit'
splitFromName :: Name -> Split
```

and adjusts all the call sites, which no longer have to handle the impossible `Nothing` case.