### PR TITLE
Add debugging combinators

### DIFF
--- a/lib/unison-prelude/package.yaml
+++ b/lib/unison-prelude/package.yaml
@@ -16,6 +16,7 @@ dependencies:
   - text
   - transformers
   - unliftio
+  - pretty-simple
 
 ghc-options:
   -Wall

--- a/lib/unison-prelude/src/Unison/Debug.hs
+++ b/lib/unison-prelude/src/Unison/Debug.hs
@@ -1,0 +1,67 @@
+module Unison.Debug (debug, debugM, whenDebug, DebugFlag (..)) where
+
+import Control.Monad (when)
+import Data.Maybe (isJust)
+import Debug.Pretty.Simple (pTrace, pTraceM, pTraceShowId, pTraceShowM)
+import System.IO.Unsafe (unsafePerformIO)
+import UnliftIO.Environment (lookupEnv)
+
+data DebugFlag
+  = Git
+  | Sqlite
+  | Codebase
+
+debugAll :: Bool
+debugAll =
+  isJust (unsafePerformIO (lookupEnv "UNISON_DEBUG"))
+{-# NOINLINE debugAll #-}
+
+debugGit :: Bool
+debugGit =
+  isJust (unsafePerformIO (lookupEnv "UNISON_DEBUG_GIT"))
+{-# NOINLINE debugGit #-}
+
+debugSqlite :: Bool
+debugSqlite =
+  isJust (unsafePerformIO (lookupEnv "UNISON_DEBUG_SQLITE"))
+{-# NOINLINE debugSqlite #-}
+
+debugCodebase :: Bool
+debugCodebase =
+  isJust (unsafePerformIO (lookupEnv "UNISON_DEBUG_CODEBASE"))
+{-# NOINLINE debugCodebase #-}
+
+-- | Use for trace-style selective debugging.
+-- E.g. 1 + (debug Git "The second number" 2)
+--
+-- Or, use in pattern matching to view arguments.
+-- E.g.
+-- myFunc (debug Git "argA" -> argA) = ...
+debug :: Show a => DebugFlag -> String -> a -> a
+debug flag msg a =
+  if shouldDebug flag
+    then pTrace (msg <> ":\n") $ pTraceShowId a
+    else a
+
+-- | Use for selective debug logging in monadic contexts.
+-- E.g.
+-- do
+--   debugM Git "source repo" srcRepo
+--   ...
+debugM :: (Show a, Monad m) => DebugFlag -> String -> a -> m ()
+debugM flag msg a =
+  when (shouldDebug flag) $ do
+    pTraceM (msg <> ":\n")
+    pTraceShowM a
+
+-- | A 'when' block which is triggered if the given flag is being debugged.
+whenDebug :: Monad m => DebugFlag -> m () -> m ()
+whenDebug flag action = do
+  when (shouldDebug flag) action
+
+shouldDebug :: DebugFlag -> Bool
+shouldDebug flag =
+  debugAll || case flag of
+    Git -> debugGit
+    Sqlite -> debugSqlite
+    Codebase -> debugCodebase

--- a/lib/unison-prelude/src/Unison/Debug.hs
+++ b/lib/unison-prelude/src/Unison/Debug.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Unison.Debug (debug, debugM, whenDebug, DebugFlag (..)) where
+module Unison.Debug (debug, debugM, whenDebug, debugLogM, DebugFlag (..)) where
 
 import Control.Applicative (empty)
 import Control.Monad (when)
@@ -63,6 +63,10 @@ debugM flag msg a =
   when (shouldDebug flag) $ do
     pTraceM (msg <> ":\n")
     pTraceShowM a
+
+debugLogM :: (Monad m) => DebugFlag -> String -> m ()
+debugLogM flag msg =
+  when (shouldDebug flag) $ pTraceM msg
 
 -- | A 'when' block which is triggered if the given flag is being debugged.
 whenDebug :: Monad m => DebugFlag -> m () -> m ()

--- a/lib/unison-prelude/unison-prelude.cabal
+++ b/lib/unison-prelude/unison-prelude.cabal
@@ -17,6 +17,7 @@ source-repository head
 
 library
   exposed-modules:
+      Unison.Debug
       Unison.Prelude
       Unison.Util.Map
       Unison.Util.Set
@@ -45,6 +46,7 @@ library
     , either
     , extra
     , mtl
+    , pretty-simple
     , safe
     , text
     , transformers


### PR DESCRIPTION
Define some shared debugging patterns so it's easier to know how to debug a given piece of UCM.

E.g.

```sh
$ UNISON_DEBUG=git,sqlite ucm
```

This should provide enough combinators for most cases, but as with most utilities people can add more if they need it.