### PR TITLE
Fix: '"" should be parsed as delayed text

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -65,3 +65,4 @@ The format for this list: name, GitHub handle, and then optional blurb about wha
 * Solomon Bothwell (@solomon-b)
 * Sameer Kolhar (@kolharsam)
 * Nicole Prindle (@nprindle)
+* Harald Gliebe (@hagl)

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -912,7 +912,7 @@ lexemes' eof = P.optional space >> do
     delayOrForce = separated ok $ do
       (start, op, end) <- positioned $ CP.satisfy isDelayOrForce
       pure [Token (Reserved [op]) start end]
-      where ok c = isDelayOrForce c || isSpace c || isAlphaNum c || Set.member c delimiters
+      where ok c = isDelayOrForce c || isSpace c || isAlphaNum c || Set.member c delimiters || c == '\"'
 
     open :: String -> P [Token Lexeme]
     open b = do

--- a/parser-typechecker/tests/Unison/Test/Lexer.hs
+++ b/parser-typechecker/tests/Unison/Test/Lexer.hs
@@ -203,6 +203,8 @@ test =
       , t "\"test escaped quotes \\\"in quotes\\\"\""
           [Textual "test escaped quotes \"in quotes\""]
       , t "\"\\n \\t \\b \\a\"" [Textual "\n \t \b \a"]
+  -- Delayed string
+      , t "'\"\"" [Reserved "'", Textual ""]
       ]
 
 t :: String -> [Lexeme] -> Test ()


### PR DESCRIPTION
The code `'""` currently causes a parse error:

```
unexpected '"'
expecting end of input
```

## Overview

I came across this problem in code like 
```
display = Optional.fold '("") Nat.toText
```
which is parsed correctly because the delayed text is in parentheses. But when editing this method the pretty-printer removes the parentheses and causes a compile error.

See this discussion on Slack
https://unisonlanguage.slack.com/archives/CLUNF0J5S/p1643913764607739

## Implementation notes

The lexer will will now treat double-quotes as separator for delay and force tokens. (So `!""` is also be accepted by the lexer, but is then rejected by the type checker)

## Test coverage

I've added a test case 