### PR TITLE
Support for pushing/pulling branches/tags

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
@@ -1,4 +1,3 @@
-{- ORMOLU_DISABLE -} -- Remove this when the file is ready to be auto-formatted
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns #-}
 
@@ -11,36 +10,36 @@ module Unison.Codebase.Editor.Git
     withStatus,
     withIsolatedRepo,
     debugGit,
+    gitDirToPath,
+    GitBranchBehavior (..),
+    GitRepo (..),
 
     -- * Exported for testing
     gitCacheDir,
-
-    GitBranchBehavior(..)
   )
 where
 
-
-import Unison.Prelude
-
 import qualified Control.Exception
 import Control.Monad.Except (MonadError, throwError)
-import qualified Data.Text as Text
-import Shellmet (($?), ($^), ($|))
-import System.FilePath ((</>))
-import Unison.Codebase.Editor.RemoteRepo (ReadRepo (..))
-import qualified Unison.Codebase.GitError as GitError
-import Unison.CodebasePath (CodebasePath)
-import UnliftIO.Directory (XdgDirectory (XdgCache), doesDirectoryExist, findExecutable, getXdgDirectory)
-import UnliftIO.IO (hFlush, stdout)
 import qualified Data.ByteString.Base16 as ByteString
 import qualified Data.Char as Char
+import qualified Data.Text as Text
+import Shellmet (($?), ($^), ($|))
+import System.Exit (ExitCode (ExitSuccess))
+import System.FilePath ((</>))
+import System.IO.Unsafe (unsafePerformIO)
+import Unison.Codebase.Editor.RemoteRepo (ReadRepo (..))
 import Unison.Codebase.GitError (GitProtocolError)
+import qualified Unison.Codebase.GitError as GitError
+import Unison.Prelude
 import UnliftIO (MonadUnliftIO)
 import qualified UnliftIO
-import qualified UnliftIO.Process as UnliftIO
+import UnliftIO.Directory (XdgDirectory (XdgCache), doesDirectoryExist, findExecutable, getXdgDirectory)
 import UnliftIO.Environment (lookupEnv)
-import System.IO.Unsafe (unsafePerformIO)
-import System.Exit (ExitCode(ExitSuccess))
+import UnliftIO.IO (hFlush, stdout)
+import qualified UnliftIO.Process as UnliftIO
+
+{- ORMOLU_DISABLE -}
 
 debugGit :: Bool
 debugGit =
@@ -53,10 +52,9 @@ gitVerbosity =
      then []
      else ["--quiet"]
 
-
 -- https://superuser.com/questions/358855/what-characters-are-safe-in-cross-platform-file-names-for-linux-windows-and-os
 encodeFileName :: String -> FilePath
-encodeFileName = let
+encodeFileName s = let
   go ('.' : rem) = "$dot$" <> go rem
   go ('$' : rem) = "$$" <> go rem
   go (c : rem) | elem @[] c "/\\:*?\"<>|" || not (Char.isPrint c && Char.isAscii c)
@@ -66,7 +64,9 @@ encodeFileName = let
   encodeHex :: String -> String
   encodeHex = Text.unpack . Text.toUpper . ByteString.encodeBase16 .
               encodeUtf8 . Text.pack
-  in go
+  -- 'bare' suffix is to avoid clashes with non-bare repos initialized by earlier versions
+  -- of ucm.
+  in go s <> "-bare"
 
 gitCacheDir :: MonadIO m => Text -> m FilePath
 gitCacheDir url =
@@ -92,23 +92,24 @@ withStatus str ma = do
 withIsolatedRepo ::
   forall m r.
   (MonadUnliftIO m) =>
-  FilePath ->
+  GitRepo ->
   Text ->
   Maybe Text ->
-  (FilePath -> m r) ->
+  (GitRepo -> m r) ->
   m (Either GitProtocolError r)
 withIsolatedRepo srcPath origin mayGitRef action = do
   UnliftIO.withSystemTempDirectory "ucm-isolated-repo" $ \tempDir -> do
-    copyCommand tempDir >>= \case
-      Left gitErr -> pure $ Left (GitError.CopyException srcPath tempDir (show gitErr))
-      Right () -> Right <$> action tempDir
+    let tempRepo = Worktree tempDir
+    copyCommand tempRepo >>= \case
+      Left gitErr -> pure $ Left (GitError.CopyException (gitDirToPath srcPath) tempDir (show gitErr))
+      Right () -> Right <$> action tempRepo
   where
-    copyCommand :: FilePath -> m (Either IOException ())
+    copyCommand :: GitRepo -> m (Either IOException ())
     copyCommand dest = UnliftIO.tryIO . liftIO $ do
       gitGlobal (["clone", "--origin", "git-cache"]
                 -- tags work okay here too.
                 ++ maybe [] (\t -> ["--branch", t]) mayGitRef
-                ++ [Text.pack srcPath, Text.pack dest]
+                ++ [Text.pack . gitDirToPath $ srcPath, Text.pack . gitDirToPath $ dest]
                 )
       -- If a specific ref wasn't requested, ensure we have all branches and tags from the source.
       -- This is fast since it's a local fetch.
@@ -116,7 +117,7 @@ withIsolatedRepo srcPath origin mayGitRef action = do
         -- If the source repo is empty, we can't fetch, but there won't be anything to
         -- fetch anyways.
         unlessM (isEmptyGitRepo srcPath) $ do
-          gitIn dest $ ["fetch", "--tags", Text.pack srcPath] ++ gitVerbosity
+          gitIn dest $ ["fetch", "--tags", Text.pack . gitDirToPath $ srcPath] ++ gitVerbosity
       gitIn dest $ ["remote", "add", "origin", origin]
 
 -- | Define what to do if the repo we're pulling/pushing doesn't have the specified branch.
@@ -136,62 +137,60 @@ withRepo ::
   (MonadUnliftIO m) =>
   ReadRepo ->
   GitBranchBehavior ->
-  (CodebasePath -> m a) ->
+  (GitRepo -> m a) ->
   m (Either GitProtocolError a)
 withRepo repo@(ReadGitRepo {url = uri, ref = mayGitRef}) branchBehavior action = UnliftIO.try $ do
   throwExceptT $ checkForGit
   gitCachePath <- gitCacheDir uri
   -- Ensure we have the main branch in the cache dir no matter what
   throwExceptT $ cloneIfMissing repo {ref = Nothing} gitCachePath
+  let gitCacheRepo = Bare gitCachePath
   gitRef <- case mayGitRef of
-    Nothing -> fromMaybe "main" <$> getDefaultBranch gitCachePath
+    Nothing -> fromMaybe "main" <$> getDefaultBranch gitCacheRepo
     Just gitRef -> pure gitRef
-  doesRemoteRefExist <- fetchAndUpdateRef gitCachePath gitRef
+  doesRemoteRefExist <- fetchAndUpdateRef gitCacheRepo gitRef
   if doesRemoteRefExist
      then do
        -- A ref by the requested name exists on the remote.
        withStatus ("Checking out " ++ Text.unpack gitRef ++ " ...") $ do
          -- Check out the ref in a new isolated repo
-         throwEitherM . withIsolatedRepo gitCachePath uri (Just gitRef) $ action
+         throwEitherM . withIsolatedRepo gitCacheRepo uri (Just gitRef) $ action
      else do
        -- No ref by the given name exists on the remote
        case branchBehavior of
          RequireExistingBranch -> UnliftIO.throwIO (GitError.RemoteRefNotFound uri gitRef)
          CreateBranchIfMissing ->
            withStatus ("Creating new branch " ++ Text.unpack gitRef ++ " ...") .
-             throwEitherM . withIsolatedRepo gitCachePath uri Nothing $ \workDir -> do
+             throwEitherM . withIsolatedRepo gitCacheRepo uri Nothing $ \(workTree) -> do
                -- It's possible for the branch to exist in the cache even if it's not in the
                -- remote, if for instance the branch was deleted from the remote.
                -- In that case we delete the branch from the cache and create a new one.
-               localRefExists <- doesLocalRefExist gitCachePath gitRef
+               localRefExists <- doesLocalRefExist gitCacheRepo gitRef
                when localRefExists $ do
-                 currentBranch <- gitTextIn workDir ["branch", "--show-current"]
+                 currentBranch <- gitTextIn workTree ["branch", "--show-current"]
                  -- In the rare case where we've got the branch already checked out,
                  -- we need to temporarily switch to a different branch so we can delete and
                  -- reset the branch to an orphan.
-                 when (currentBranch == gitRef) $ gitIn workDir $ ["branch", "-B", "_unison_temp_branch"] ++ gitVerbosity
-                 gitIn workDir $ ["branch", "-D", gitRef] ++ gitVerbosity
-               gitIn workDir $ ["checkout", "--orphan", gitRef] ++ gitVerbosity
+                 when (currentBranch == gitRef) $ gitIn workTree $ ["branch", "-B", "_unison_temp_branch"] ++ gitVerbosity
+                 gitIn workTree $ ["branch", "-D", gitRef] ++ gitVerbosity
+               gitIn workTree $ ["checkout", "--orphan", gitRef] ++ gitVerbosity
                -- Checking out an orphan branch doesn't actually clear the worktree, do that manually.
-               _ <- gitInCaptured workDir $ ["rm", "--ignore-unmatch", "-rf", "."] ++ gitVerbosity
-               action workDir
+               _ <- gitInCaptured workTree $ ["rm", "--ignore-unmatch", "-rf", "."] ++ gitVerbosity
+               action workTree
   where
     -- | Check if a ref exists in the repository at workDir.
-    doesLocalRefExist :: FilePath -> Text -> m Bool
+    doesLocalRefExist :: GitRepo -> Text -> m Bool
     doesLocalRefExist workDir ref = liftIO $ do
-      (gitIn workDir (["show-ref", "--verify", "refs/heads/" <> ref] ++ gitVerbosity) $> True)
+      (gitIn workDir (["show-ref", "--verify", ref] ++ gitVerbosity) $> True)
         $? pure False
     -- | fetch the given ref and update the local repositories ref to match the remote.
     --   returns whether or not the ref existed on the remote.
-    fetchAndUpdateRef :: FilePath -> Text -> m Bool
+    fetchAndUpdateRef :: GitRepo -> Text -> m Bool
     fetchAndUpdateRef workDir gitRef = do
       (succeeded, _, _) <- gitInCaptured workDir
           ( [ "fetch",
               "--tags", -- if the gitref is a tag, fetch and update that too.
               "--force", -- force updating local refs even if not fast-forward
-              -- Update the local ref even if we have it checked out.
-              -- Ideally we'd just use bare repositories, but this allows for backwards-compatibility.
-              "--update-head-ok",
               -- update local refs with the same name they have on the remote.
               "--refmap", "*:*",
             -- Note: a shallow fetch saves time initially, but prevents
@@ -205,28 +204,30 @@ withRepo repo@(ReadGitRepo {url = uri, ref = mayGitRef}) branchBehavior action =
       pure succeeded
 
 -- | Do a `git clone` (for a not-previously-cached repo).
-cloneIfMissing :: (MonadIO m, MonadError GitProtocolError m) => ReadRepo -> CodebasePath -> m ()
+cloneIfMissing :: (MonadIO m, MonadError GitProtocolError m) => ReadRepo -> FilePath -> m GitRepo
 cloneIfMissing repo@(ReadGitRepo {url=uri}) localPath = do
   doesDirectoryExist localPath >>= \case
     True ->
-      whenM (not <$> isGitRepo localPath) $ do
+      whenM (not <$> isGitRepo (Bare localPath)) $ do
         throwError (GitError.UnrecognizableCacheDir repo localPath)
     False -> do
       -- directory doesn't exist, so clone anew
       cloneRepo
+  pure $ Bare localPath
   where
     cloneRepo = do
       withStatus ("Downloading from " ++ Text.unpack uri ++ " ...") $
         (liftIO $
           gitGlobal
             (["clone"]
+            ++ ["--bare"]
             -- Note: a shallow clone saves time on the initial clone, but prevents all future
             -- 'local' clones from using hard-links, so doing a full clone saves the most time
             -- in the long run.
             -- ++ ["--depth", "1"]
             ++ [uri, Text.pack localPath]))
           `withIOError` (throwError . GitError.CloneException repo . show)
-      isGitDir <- liftIO $ isGitRepo localPath
+      isGitDir <- liftIO $ isGitRepo (Bare localPath)
       unless isGitDir . throwError $ GitError.UnrecognizableCheckoutDir repo localPath
 
 -- | See if `git` is on the system path.
@@ -236,19 +237,19 @@ checkForGit = do
   when (isNothing gitPath) $ throwError GitError.NoGit
 
 -- | Returns the name of the default branch of a repository, if one exists.
-getDefaultBranch :: MonadIO m => FilePath -> m (Maybe Text)
+getDefaultBranch :: MonadIO m => GitRepo -> m (Maybe Text)
 getDefaultBranch dir = liftIO $ do
-  (Text.stripPrefix "refs/remotes/origin/" <$> gitTextIn dir ["symbolic-ref", "refs/remotes/origin/HEAD"])
+  (Text.stripPrefix "refs/heads/" <$> gitTextIn dir ["symbolic-ref", "HEAD"])
     $? pure Nothing
 
 -- | Does `git` recognize this directory as being managed by git?
-isGitRepo :: MonadIO m => FilePath -> m Bool
+isGitRepo :: MonadIO m => GitRepo -> m Bool
 isGitRepo dir = liftIO $
   (True <$ gitIn dir (["rev-parse"] ++ gitVerbosity)) $? pure False
 
 -- | Returns True if the repo is empty, i.e. has no commits at the current branch,
 -- or if the dir isn't a git repo at all.
-isEmptyGitRepo ::  (MonadIO m) => FilePath -> m Bool
+isEmptyGitRepo ::  (MonadIO m) => GitRepo -> m Bool
 isEmptyGitRepo dir = liftIO do
   (gitTextIn dir (["rev-parse", "HEAD"] ++ gitVerbosity) $> False) $? pure True
 
@@ -258,36 +259,51 @@ withIOError action handler =
   liftIO (fmap Right action `Control.Exception.catch` (pure . Left)) >>=
     either handler pure
 
+-- | A path to a git repository.
+data GitRepo
+  = Bare FilePath
+  | Worktree FilePath
+  deriving (Show)
+
+gitDirToPath :: GitRepo -> FilePath
+gitDirToPath = \case
+  Bare fp -> fp
+  Worktree fp -> fp
+
 -- | Generate some `git` flags for operating on some arbitary checked out copy
-setupGitDir :: FilePath -> [Text]
-setupGitDir localPath =
-  ["--git-dir", Text.pack $ localPath </> ".git"
-  ,"--work-tree", Text.pack localPath]
+setupGitDir :: GitRepo -> [Text]
+setupGitDir dir =
+  case dir of
+    Bare localPath ->
+      ["--git-dir", Text.pack localPath]
+    Worktree localPath ->
+      ["--git-dir", Text.pack (localPath </> ".git")
+      ,"--work-tree", Text.pack localPath]
 
 -- | Run a git command in the current work directory.
 -- Note: this should only be used for commands like 'clone' which don't interact with an
 -- existing repository.
 gitGlobal :: MonadIO m => [Text] -> m ()
 gitGlobal args = do
-  when debugGit $ traceShowM args
+  when debugGit $ traceM (Text.unpack . Text.unwords $ ["$ git"] <> args)
   liftIO $ "git" $^ (args ++ gitVerbosity)
 
 -- | Run a git command in the repository at localPath
-gitIn :: MonadIO m => FilePath -> [Text] -> m ()
+gitIn :: MonadIO m => GitRepo -> [Text] -> m ()
 gitIn localPath args = do
-  when debugGit $ traceShowM (localPath, args)
+  when debugGit $ traceM (Text.unpack . Text.unwords $ ["$ git"] <> setupGitDir localPath <> args)
   liftIO $ "git" $^ (setupGitDir localPath <> args)
 
 -- | like 'gitIn', but silences all output from the command and returns whether the command
 -- succeeded.
-gitInCaptured :: MonadIO m => FilePath -> [Text] -> m (Bool, Text, Text)
+gitInCaptured :: MonadIO m => GitRepo -> [Text] -> m (Bool, Text, Text)
 gitInCaptured localPath args = do
-  when debugGit $ traceShowM (localPath, args)
+  when debugGit $ traceM (Text.unpack . Text.unwords $ ["$ git"] <> setupGitDir localPath <> args)
   (exitCode, stdout, stderr) <- UnliftIO.readProcessWithExitCode "git" (Text.unpack <$> setupGitDir localPath <> args) ""
   pure (exitCode == ExitSuccess, Text.pack stdout, Text.pack stderr)
 
 -- | Run a git command in the repository at localPath and capture stdout
-gitTextIn :: MonadIO m => FilePath -> [Text] -> m Text
+gitTextIn :: MonadIO m => GitRepo -> [Text] -> m Text
 gitTextIn localPath args = do
-  when debugGit $ traceShowM (localPath, args)
+  when debugGit $ traceM (Text.unpack . Text.unwords $ ["$ git"] <> setupGitDir localPath <> args)
   liftIO $ "git" $| setupGitDir localPath <> args

--- a/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
@@ -5,15 +5,20 @@
 module Unison.Codebase.Editor.Git
   ( gitIn,
     gitTextIn,
-    pullRepo,
+    gitInCaptured,
+    withRepo,
     withIOError,
     withStatus,
     withIsolatedRepo,
+    debugGit,
 
     -- * Exported for testing
     gitCacheDir,
+
+    GitBranchBehavior(..)
   )
 where
+
 
 import Unison.Prelude
 
@@ -22,17 +27,31 @@ import Control.Monad.Except (MonadError, throwError)
 import qualified Data.Text as Text
 import Shellmet (($?), ($^), ($|))
 import System.FilePath ((</>))
-import Unison.Codebase.Editor.RemoteRepo (ReadRepo (ReadGitRepo))
+import Unison.Codebase.Editor.RemoteRepo (ReadRepo (..))
 import qualified Unison.Codebase.GitError as GitError
 import Unison.CodebasePath (CodebasePath)
-import qualified Unison.Util.Exception as Ex
-import UnliftIO.Directory (XdgDirectory (XdgCache), doesDirectoryExist, findExecutable, getXdgDirectory, removeDirectoryRecursive)
+import UnliftIO.Directory (XdgDirectory (XdgCache), doesDirectoryExist, findExecutable, getXdgDirectory)
 import UnliftIO.IO (hFlush, stdout)
 import qualified Data.ByteString.Base16 as ByteString
 import qualified Data.Char as Char
 import Unison.Codebase.GitError (GitProtocolError)
-import UnliftIO (handleIO, MonadUnliftIO)
+import UnliftIO (MonadUnliftIO)
 import qualified UnliftIO
+import qualified UnliftIO.Process as UnliftIO
+import UnliftIO.Environment (lookupEnv)
+import System.IO.Unsafe (unsafePerformIO)
+import System.Exit (ExitCode(ExitSuccess))
+
+debugGit :: Bool
+debugGit =
+  isJust (unsafePerformIO (lookupEnv "UNISON_DEBUG_GIT"))
+{-# NOINLINE debugGit #-}
+
+gitVerbosity :: [Text]
+gitVerbosity =
+  if debugGit
+     then []
+     else ["--quiet"]
 
 
 -- https://superuser.com/questions/358855/what-characters-are-safe-in-cross-platform-file-names-for-linux-windows-and-os
@@ -67,104 +86,148 @@ withStatus str ma = do
     liftIO . putStr $ "  " ++ str ++ "\r"
     hFlush stdout
 
--- | Run an action on an isolated copy of the provided repo. The repo is deleted when the
--- action exits or fails.
+-- | Run an action on an isolated copy of the provided repo.
+-- The repo is deleted when the action exits or fails.
+-- A branch or tag to check out from the source repo may be specified.
 withIsolatedRepo ::
   forall m r.
   (MonadUnliftIO m) =>
   FilePath ->
+  Text ->
+  Maybe Text ->
   (FilePath -> m r) ->
   m (Either GitProtocolError r)
-withIsolatedRepo srcPath action = do
+withIsolatedRepo srcPath origin mayGitRef action = do
   UnliftIO.withSystemTempDirectory "ucm-isolated-repo" $ \tempDir -> do
     copyCommand tempDir >>= \case
       Left gitErr -> pure $ Left (GitError.CopyException srcPath tempDir (show gitErr))
       Right () -> Right <$> action tempDir
   where
     copyCommand :: FilePath -> m (Either IOException ())
-    copyCommand dest = UnliftIO.tryIO . liftIO $
-      "git" $^ (["clone", "--quiet"] ++ ["file://" <> Text.pack srcPath, Text.pack dest])
+    copyCommand dest = UnliftIO.tryIO . liftIO $ do
+      gitGlobal (["clone", "--origin", "git-cache"]
+                -- tags work okay here too.
+                ++ maybe [] (\t -> ["--branch", t]) mayGitRef
+                ++ [Text.pack srcPath, Text.pack dest]
+                )
+      -- If a specific ref wasn't requested, ensure we have all branches and tags from the source.
+      -- This is fast since it's a local fetch.
+      when (isNothing mayGitRef) $ do
+        -- If the source repo is empty, we can't fetch, but there won't be anything to
+        -- fetch anyways.
+        unlessM (isEmptyGitRepo srcPath) $ do
+          gitIn dest $ ["fetch", "--tags", Text.pack srcPath] ++ gitVerbosity
+      gitIn dest $ ["remote", "add", "origin", origin]
 
--- | Given a remote git repo url, and branch/commit hash (currently
--- not allowed): checks for git, clones or updates a cached copy of the repo
-pullRepo :: (MonadIO m, MonadError GitProtocolError m) => ReadRepo -> m CodebasePath
-pullRepo repo@(ReadGitRepo uri) = do
-  checkForGit
-  localPath <- gitCacheDir uri
-  ifM (doesDirectoryExist localPath)
-    -- try to update existing directory
-    (ifM (isGitRepo localPath)
-      (checkoutExisting localPath Nothing)
-      (throwError (GitError.UnrecognizableCacheDir repo localPath)))
-    -- directory doesn't exist, so clone anew
-    (checkOutNew localPath Nothing)
-  pure localPath
+-- | Define what to do if the repo we're pulling/pushing doesn't have the specified branch.
+data GitBranchBehavior =
+      -- If the desired branch doesn't exist in the repo,
+      -- create a new branch by the provided name with a fresh codebase
+      CreateBranchIfMissing
+      -- Fail with an error if the branch doesn't exist.
+    | RequireExistingBranch
+
+-- | Clone or fetch an updated copy of the provided repository and check out the expected ref,
+-- then provide the action with a path to the codebase in that repository.
+-- Note that the repository provided to the action is temporary, it will be removed when the
+-- action completes or fails.
+withRepo ::
+  forall m a.
+  (MonadUnliftIO m) =>
+  ReadRepo ->
+  GitBranchBehavior ->
+  (CodebasePath -> m a) ->
+  m (Either GitProtocolError a)
+withRepo repo@(ReadGitRepo {url = uri, ref = mayGitRef}) branchBehavior action = UnliftIO.try $ do
+  throwExceptT $ checkForGit
+  gitCachePath <- gitCacheDir uri
+  -- Ensure we have the main branch in the cache dir no matter what
+  throwExceptT $ cloneIfMissing repo {ref = Nothing} gitCachePath
+  gitRef <- case mayGitRef of
+    Nothing -> fromMaybe "main" <$> getDefaultBranch gitCachePath
+    Just gitRef -> pure gitRef
+  doesRemoteRefExist <- fetchAndUpdateRef gitCachePath gitRef
+  if doesRemoteRefExist
+     then do
+       -- A ref by the requested name exists on the remote.
+       withStatus ("Checking out " ++ Text.unpack gitRef ++ " ...") $ do
+         -- Check out the ref in a new isolated repo
+         throwEitherM . withIsolatedRepo gitCachePath uri (Just gitRef) $ action
+     else do
+       -- No ref by the given name exists on the remote
+       case branchBehavior of
+         RequireExistingBranch -> UnliftIO.throwIO (GitError.RemoteRefNotFound uri gitRef)
+         CreateBranchIfMissing ->
+           withStatus ("Creating new branch " ++ Text.unpack gitRef ++ " ...") .
+             throwEitherM . withIsolatedRepo gitCachePath uri Nothing $ \workDir -> do
+               -- It's possible for the branch to exist in the cache even if it's not in the
+               -- remote, if for instance the branch was deleted from the remote.
+               -- In that case we delete the branch from the cache and create a new one.
+               localRefExists <- doesLocalRefExist gitCachePath gitRef
+               when localRefExists $ do
+                 currentBranch <- gitTextIn workDir ["branch", "--show-current"]
+                 -- In the rare case where we've got the branch already checked out,
+                 -- we need to temporarily switch to a different branch so we can delete and
+                 -- reset the branch to an orphan.
+                 when (currentBranch == gitRef) $ gitIn workDir $ ["branch", "-B", "_unison_temp_branch"] ++ gitVerbosity
+                 gitIn workDir $ ["branch", "-D", gitRef] ++ gitVerbosity
+               gitIn workDir $ ["checkout", "--orphan", gitRef] ++ gitVerbosity
+               -- Checking out an orphan branch doesn't actually clear the worktree, do that manually.
+               _ <- gitInCaptured workDir $ ["rm", "--ignore-unmatch", "-rf", "."] ++ gitVerbosity
+               action workDir
   where
-  -- | Do a `git clone` (for a not-previously-cached repo).
-  checkOutNew :: (MonadIO m, MonadError GitProtocolError m) => CodebasePath -> Maybe Text -> m ()
-  checkOutNew localPath branch = do
-    withStatus ("Downloading from " ++ Text.unpack uri ++ " ...") $
-      (liftIO $
-        "git" $^ (["clone", "--quiet"] ++ ["--depth", "1"]
-         ++ maybe [] (\t -> ["--branch", t]) branch
-         ++ [uri, Text.pack localPath]))
-        `withIOError` (throwError . GitError.CloneException repo . show)
-    isGitDir <- liftIO $ isGitRepo localPath
-    unless isGitDir . throwError $ GitError.UnrecognizableCheckoutDir repo localPath
+    -- | Check if a ref exists in the repository at workDir.
+    doesLocalRefExist :: FilePath -> Text -> m Bool
+    doesLocalRefExist workDir ref = liftIO $ do
+      (gitIn workDir (["show-ref", "--verify", "refs/heads/" <> ref] ++ gitVerbosity) $> True)
+        $? pure False
+    -- | fetch the given ref and update the local repositories ref to match the remote.
+    --   returns whether or not the ref existed on the remote.
+    fetchAndUpdateRef :: FilePath -> Text -> m Bool
+    fetchAndUpdateRef workDir gitRef = do
+      (succeeded, _, _) <- gitInCaptured workDir
+          ( [ "fetch",
+              "--tags", -- if the gitref is a tag, fetch and update that too.
+              "--force", -- force updating local refs even if not fast-forward
+              -- Update the local ref even if we have it checked out.
+              -- Ideally we'd just use bare repositories, but this allows for backwards-compatibility.
+              "--update-head-ok",
+              -- update local refs with the same name they have on the remote.
+              "--refmap", "*:*",
+            -- Note: a shallow fetch saves time initially, but prevents
+            -- 'local' clones from using hard-links, so doing a normal fetch saves the most time
+            -- in the long run.
+              -- "--depth", "1",
+              uri, -- The repo to fetch from
+              gitRef -- The specific reference to fetch
+            ] ++ gitVerbosity
+          )
+      pure succeeded
 
-  -- | Do a `git pull` on a cached repo.
-  checkoutExisting :: (MonadIO m, MonadError GitProtocolError m)
-                   => FilePath
-                   -> Maybe Text
-                   -> m ()
-  checkoutExisting localPath maybeRemoteRef =
-    ifM (isEmptyGitRepo localPath)
-      -- I don't know how to properly update from an empty remote repo.
-      -- As a heuristic, if this cached copy is empty, then the remote might
-      -- be too, so this impl. just wipes the cached copy and starts from scratch.
-      goFromScratch
-      -- Otherwise proceed!
-      do
-        succeeded <- liftIO . handleIO (const $ pure False) $ do
-                         withStatus ("Updating cached copy of " ++ Text.unpack uri ++ " ...") $ do
-                          -- Fetch only the latest commit, we don't need history.
-                          gitIn localPath (["fetch", "origin", remoteRef, "--quiet"] ++ ["--depth", "1"])
-                          fetchHeadHash <- gitTextIn localPath ["rev-parse", "FETCH_HEAD"]
-                          headHash <- gitTextIn localPath ["rev-parse", "HEAD"]
-                          -- Only do a hard reset if the remote has actually changed.
-                          -- This allows us to persist any codebase migrations in the dirty work tree,
-                          -- and avoid re-migrating a codebase we've migrated before.
-                          when (fetchHeadHash /= headHash) do
-                            -- Reset our branch to point at the latest code from the remote.
-                            gitIn localPath ["reset", "--hard", "--quiet", "FETCH_HEAD"]
-                            -- Wipe out any unwanted files which might be sitting around, but aren't in the commit.
-                            -- Note that this wipes out any in-progress work which other ucm processes may
-                            -- have in progress, which we may want to handle more nicely in the future.
-                            gitIn localPath ["clean", "-d", "--force", "--quiet"]
-                          pure True
-        when (not succeeded) $ goFromScratch
-
-    where
-      remoteRef :: Text
-      remoteRef = fromMaybe "HEAD" maybeRemoteRef
-      goFromScratch :: (MonadIO m, MonadError GitProtocolError m) => m  ()
-      goFromScratch = do
-        wipeDir localPath
-        checkOutNew localPath Nothing
-
-  isEmptyGitRepo :: MonadIO m => FilePath -> m Bool
-  isEmptyGitRepo localPath = liftIO $
-    -- if rev-parse succeeds, the repo is _not_ empty, so return False; else True
-    (gitTextIn localPath ["rev-parse", "--verify", "--quiet", "HEAD"] $> False)
-      $? pure True
-
-  -- | try removing a cached copy
-  wipeDir localPath = do
-    e <- Ex.tryAny . whenM (doesDirectoryExist localPath) $
-      removeDirectoryRecursive localPath
-    case e of
-      Left e -> throwError (GitError.CleanupError e)
-      Right _ -> pure ()
+-- | Do a `git clone` (for a not-previously-cached repo).
+cloneIfMissing :: (MonadIO m, MonadError GitProtocolError m) => ReadRepo -> CodebasePath -> m ()
+cloneIfMissing repo@(ReadGitRepo {url=uri}) localPath = do
+  doesDirectoryExist localPath >>= \case
+    True ->
+      whenM (not <$> isGitRepo localPath) $ do
+        throwError (GitError.UnrecognizableCacheDir repo localPath)
+    False -> do
+      -- directory doesn't exist, so clone anew
+      cloneRepo
+  where
+    cloneRepo = do
+      withStatus ("Downloading from " ++ Text.unpack uri ++ " ...") $
+        (liftIO $
+          gitGlobal
+            (["clone"]
+            -- Note: a shallow clone saves time on the initial clone, but prevents all future
+            -- 'local' clones from using hard-links, so doing a full clone saves the most time
+            -- in the long run.
+            -- ++ ["--depth", "1"]
+            ++ [uri, Text.pack localPath]))
+          `withIOError` (throwError . GitError.CloneException repo . show)
+      isGitDir <- liftIO $ isGitRepo localPath
+      unless isGitDir . throwError $ GitError.UnrecognizableCheckoutDir repo localPath
 
 -- | See if `git` is on the system path.
 checkForGit :: MonadIO m => MonadError GitProtocolError m => m ()
@@ -172,10 +235,22 @@ checkForGit = do
   gitPath <- liftIO $ findExecutable "git"
   when (isNothing gitPath) $ throwError GitError.NoGit
 
+-- | Returns the name of the default branch of a repository, if one exists.
+getDefaultBranch :: MonadIO m => FilePath -> m (Maybe Text)
+getDefaultBranch dir = liftIO $ do
+  (Text.stripPrefix "refs/remotes/origin/" <$> gitTextIn dir ["symbolic-ref", "refs/remotes/origin/HEAD"])
+    $? pure Nothing
+
 -- | Does `git` recognize this directory as being managed by git?
 isGitRepo :: MonadIO m => FilePath -> m Bool
 isGitRepo dir = liftIO $
-  (True <$ gitIn dir ["rev-parse"]) $? pure False
+  (True <$ gitIn dir (["rev-parse"] ++ gitVerbosity)) $? pure False
+
+-- | Returns True if the repo is empty, i.e. has no commits at the current branch,
+-- or if the dir isn't a git repo at all.
+isEmptyGitRepo ::  (MonadIO m) => FilePath -> m Bool
+isEmptyGitRepo dir = liftIO do
+  (gitTextIn dir (["rev-parse", "HEAD"] ++ gitVerbosity) $> False) $? pure True
 
 -- | Perform an IO action, passing any IO exception to `handler`
 withIOError :: MonadIO m => IO a -> (IOException -> m a) -> m a
@@ -189,8 +264,30 @@ setupGitDir localPath =
   ["--git-dir", Text.pack $ localPath </> ".git"
   ,"--work-tree", Text.pack localPath]
 
-gitIn :: MonadIO m => FilePath -> [Text] -> m ()
-gitIn localPath args = liftIO $ "git" $^ (setupGitDir localPath <> args)
+-- | Run a git command in the current work directory.
+-- Note: this should only be used for commands like 'clone' which don't interact with an
+-- existing repository.
+gitGlobal :: MonadIO m => [Text] -> m ()
+gitGlobal args = do
+  when debugGit $ traceShowM args
+  liftIO $ "git" $^ (args ++ gitVerbosity)
 
+-- | Run a git command in the repository at localPath
+gitIn :: MonadIO m => FilePath -> [Text] -> m ()
+gitIn localPath args = do
+  when debugGit $ traceShowM (localPath, args)
+  liftIO $ "git" $^ (setupGitDir localPath <> args)
+
+-- | like 'gitIn', but silences all output from the command and returns whether the command
+-- succeeded.
+gitInCaptured :: MonadIO m => FilePath -> [Text] -> m (Bool, Text, Text)
+gitInCaptured localPath args = do
+  when debugGit $ traceShowM (localPath, args)
+  (exitCode, stdout, stderr) <- UnliftIO.readProcessWithExitCode "git" (Text.unpack <$> setupGitDir localPath <> args) ""
+  pure (exitCode == ExitSuccess, Text.pack stdout, Text.pack stderr)
+
+-- | Run a git command in the repository at localPath and capture stdout
 gitTextIn :: MonadIO m => FilePath -> [Text] -> m Text
-gitTextIn localPath args = liftIO $ "git" $| setupGitDir localPath <> args
+gitTextIn localPath args = do
+  when debugGit $ traceShowM (localPath, args)
+  liftIO $ "git" $| setupGitDir localPath <> args

--- a/parser-typechecker/src/Unison/Codebase/Editor/RemoteRepo.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/RemoteRepo.hs
@@ -8,20 +8,22 @@ import qualified Unison.Codebase.Path as Path
 import Unison.Codebase.Path (Path)
 import Unison.Codebase.ShortBranchHash (ShortBranchHash)
 import qualified Unison.Codebase.ShortBranchHash as SBH
+import qualified U.Util.Monoid as Monoid
+import qualified Data.Text as Text
 
-data ReadRepo = ReadGitRepo { url :: Text {-, commitish :: Maybe Text -}} deriving (Eq, Ord, Show)
-data WriteRepo = WriteGitRepo { url' :: Text {-, branch :: Maybe Text -}} deriving (Eq, Ord, Show)
+data ReadRepo = ReadGitRepo { url :: Text, ref :: Maybe Text } deriving (Eq, Ord, Show)
+data WriteRepo = WriteGitRepo { url' :: Text, branch :: Maybe Text } deriving (Eq, Ord, Show)
 
 writeToRead :: WriteRepo -> ReadRepo
-writeToRead (WriteGitRepo url) = ReadGitRepo url
+writeToRead (WriteGitRepo {url', branch}) = ReadGitRepo {url=url', ref=branch}
 
 writePathToRead :: WriteRemotePath -> ReadRemoteNamespace
 writePathToRead (w, p) = (writeToRead w, Nothing, p)
 
 printReadRepo :: ReadRepo -> Text
-printReadRepo ReadGitRepo{..} = url -- <> Monoid.fromMaybe (Text.cons ':' <$> commit)
+printReadRepo ReadGitRepo{url, ref} = url <> Monoid.fromMaybe (Text.cons ':' <$> ref)
 printWriteRepo :: WriteRepo -> Text
-printWriteRepo WriteGitRepo{..} = url' -- <> Monoid.fromMaybe (Text.cons ':' <$> branch)
+printWriteRepo WriteGitRepo{url', branch} = url' <> Monoid.fromMaybe (Text.cons ':' <$> branch)
 
 printNamespace :: ReadRepo -> Maybe ShortBranchHash -> Path -> Text
 printNamespace repo sbh path =

--- a/parser-typechecker/src/Unison/Codebase/GitError.hs
+++ b/parser-typechecker/src/Unison/Codebase/GitError.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveAnyClass #-}
+
 module Unison.Codebase.GitError where
 
 import Unison.Codebase.Editor.RemoteRepo (ReadRemoteNamespace, ReadRepo, WriteRepo)
@@ -19,7 +21,11 @@ data GitProtocolError
   | -- url commit Diff of what would change on merge with remote
     PushDestinationHasNewStuff WriteRepo
   | CleanupError SomeException
-  deriving (Show)
+  | -- Thrown when a commit, tag, or branch isn't found in a repo.
+    --                repo ref
+    RemoteRefNotFound Text Text
+  deriving stock (Show)
+  deriving anyclass (Exception)
 
 data GitCodebaseError h
   = NoRemoteNamespaceWithHash ReadRepo ShortBranchHash

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -13,7 +13,7 @@ module Unison.Codebase.SqliteCodebase
 where
 
 import qualified Control.Concurrent
-import Control.Monad.Except (runExceptT, withExceptT, throwError, ExceptT)
+import Control.Monad.Except (runExceptT, throwError, ExceptT)
 import qualified Control.Monad.Except as Except
 import qualified Control.Monad.Extra as Monad
 import Control.Monad.Reader (ReaderT (runReaderT))
@@ -54,8 +54,9 @@ import qualified Unison.Codebase as Codebase1
 import Unison.Codebase.Branch (Branch (..))
 import qualified Unison.Codebase.Branch as Branch
 import qualified Unison.Codebase.Causal as Causal
-import Unison.Codebase.Editor.Git (gitIn, gitTextIn, pullRepo, withIsolatedRepo)
-import Unison.Codebase.Editor.RemoteRepo (ReadRemoteNamespace, WriteRepo (WriteGitRepo), printWriteRepo, writeToRead)
+import Unison.Codebase.Editor.Git (gitIn, gitTextIn, gitInCaptured, withRepo)
+import qualified Unison.Codebase.Editor.Git as Git
+import Unison.Codebase.Editor.RemoteRepo (ReadRemoteNamespace, WriteRepo (..), printWriteRepo, writeToRead, ReadRepo)
 import qualified Unison.Codebase.GitError as GitError
 import qualified Unison.Codebase.Init as Codebase
 import qualified Unison.Codebase.Init.CreateCodebaseError as Codebase1
@@ -91,9 +92,8 @@ import Unison.Type (Type)
 import qualified Unison.Type as Type
 import qualified Unison.Util.Set as Set
 import qualified Unison.WatchKind as UF
-import UnliftIO (catchIO, finally, MonadUnliftIO, throwIO)
-import qualified UnliftIO
-import UnliftIO.Directory (createDirectoryIfMissing, doesDirectoryExist, doesFileExist, removePathForcibly)
+import UnliftIO (catchIO, finally, MonadUnliftIO, throwIO, try)
+import UnliftIO.Directory (createDirectoryIfMissing, doesDirectoryExist, doesFileExist)
 import UnliftIO.Exception (bracket, catch)
 import UnliftIO.STM
 import Data.Either.Extra ()
@@ -1027,12 +1027,12 @@ viewRemoteBranch' ::
   forall m r.
   (MonadUnliftIO m) =>
   ReadRemoteNamespace ->
+  Git.GitBranchBehavior ->
   ((Branch m, CodebasePath) -> m r) ->
   m (Either C.GitError r)
-viewRemoteBranch' (repo, sbh, path) action = UnliftIO.try do
+viewRemoteBranch' (repo, sbh, path) gitBranchBehavior action = UnliftIO.try $ do
   -- set up the cache dir
-  remotePath <- UnliftIO.fromEitherM . runExceptT . withExceptT C.GitProtocolError . time "Git fetch" $ pullRepo repo
-
+ time "Git fetch" $ throwEitherMWith C.GitProtocolError . withRepo repo gitBranchBehavior $ \remotePath -> do
   -- Tickle the database before calling into `sqliteCodebase`; this covers the case that the database file either
   -- doesn't exist at all or isn't a SQLite database file, but does not cover the case that the database file itself is
   -- somehow corrupt, or not even a Unison database.
@@ -1085,7 +1085,7 @@ pushGitBranch ::
   WriteRepo ->
   PushGitBranchOpts ->
   m (Either C.GitError ())
-pushGitBranch srcConn branch repo (PushGitBranchOpts setRoot _syncMode) = UnliftIO.try $ do
+pushGitBranch srcConn branch repo (PushGitBranchOpts setRoot _syncMode) = mapLeft C.GitProtocolError <$> do
   -- Pull the latest remote into our git cache
   -- Use a local git clone to copy this git repo into a temp-dir
   -- Delete the codebase in our temp-dir
@@ -1100,19 +1100,14 @@ pushGitBranch srcConn branch repo (PushGitBranchOpts setRoot _syncMode) = Unlift
   -- Delete the temp-dir.
   --
   -- set up the cache dir
-  pathToCachedRemote <- time "Git fetch" $ throwExceptTWith C.GitProtocolError $ pullRepo (writeToRead repo)
-  throwEitherMWith C.GitProtocolError . withIsolatedRepo pathToCachedRemote $ \isolatedRemotePath -> do
-    -- Connect to codebase in the cached git repo so we can copy it over.
-    withOpenOrCreateCodebaseConnection @m "push.cached" pathToCachedRemote $ \cachedRemoteConn -> do
-      -- Copy our cached remote database cleanly into our isolated directory.
-      copyCodebase cachedRemoteConn isolatedRemotePath
-      -- Connect to the newly copied database which we know has been properly closed and
-      -- nobody else could be using.
-      withConnection @m "push.dest" isolatedRemotePath $ \destConn -> do
-        flip runReaderT destConn $ Q.withSavepoint_ @(ReaderT _ m) "push" $ do
-          throwExceptT $ doSync isolatedRemotePath srcConn destConn
-    void $ push isolatedRemotePath repo
+ withRepo readRepo Git.CreateBranchIfMissing $ \pushStaging -> do
+   withOpenOrCreateCodebaseConnection @m "push.dest" pushStaging $ \destConn -> do
+     flip runReaderT destConn $ Q.withSavepoint_ @(ReaderT _ m) "push" $ do
+       throwExceptT $ doSync pushStaging srcConn destConn
+   void $ push pushStaging repo
   where
+    readRepo :: ReadRepo
+    readRepo = writeToRead repo
     doSync :: FilePath -> Connection -> Connection -> ExceptT C.GitError (ReaderT Connection m) ()
     doSync remotePath srcConn destConn = do
       _ <- flip State.execStateT emptySyncProgressState $
@@ -1190,7 +1185,7 @@ pushGitBranch srcConn branch repo (PushGitBranchOpts setRoot _syncMode) = Unlift
 
     -- Commit our changes
     push :: forall m. MonadIO m => CodebasePath -> WriteRepo -> m Bool -- withIOError needs IO
-    push remotePath (WriteGitRepo url) = time "SqliteCodebase.pushGitRootBranch.push" $ do
+    push remotePath repo@(WriteGitRepo {url'=url, branch=mayGitBranch}) = time "SqliteCodebase.pushGitRootBranch.push" $ do
       -- has anything changed?
       -- note: -uall recursively shows status for all files in untracked directories
       --   we want this so that we see
@@ -1217,14 +1212,9 @@ pushGitBranch srcConn branch repo (PushGitBranchOpts setRoot _syncMode) = Unlift
             gitIn
               remotePath
               ["commit", "-q", "-m", "Sync branch " <> Text.pack (show $ Branch.headHash branch)]
-            -- Push our changes to the repo
-            gitIn remotePath ["push", "--quiet", url]
+            -- Push our changes to the repo, silencing all output.
+            -- Even with quiet, the remote (Github) can still send output through,
+            -- so we capture stdout and stderr.
+            (successful, _stdout, stderr) <- gitInCaptured remotePath $ ["push", "--quiet", url] ++ maybe [] (pure @[]) mayGitBranch
+            when (not successful) . throwIO $ GitError.PushException repo (Text.unpack stderr)
             pure True
-
--- | Make a clean copy of the connected codebase into the provided path. Destroys any existing `v2/` directory
-copyCodebase :: MonadIO m => Connection -> CodebasePath -> m ()
-copyCodebase srcConn destPath = runDB srcConn $ do
-  -- remove any existing codebase at the destination location.
-  removePathForcibly (makeCodebaseDirPath destPath)
-  createDirectoryIfMissing True (makeCodebaseDirPath destPath)
-  Q.vacuumInto (makeCodebasePath destPath)

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -31,6 +31,7 @@ import Unison.ShortHash (ShortHash)
 import Unison.Term (Term)
 import Unison.Type (Type)
 import qualified Unison.WatchKind as WK
+import qualified Unison.Codebase.Editor.Git as Git
 
 type SyncToDir m =
   CodebasePath -> -- dest codebase
@@ -92,7 +93,7 @@ data Codebase m v a = Codebase
     syncFromDirectory :: CodebasePath -> SyncMode -> Branch m -> m (),
     -- | Copy a branch and all of its dependencies from this codebase into the given codebase.
     syncToDirectory :: CodebasePath -> SyncMode -> Branch m -> m (),
-    viewRemoteBranch' :: forall r. ReadRemoteNamespace -> ((Branch m, CodebasePath) -> m r) -> m (Either GitError r),
+    viewRemoteBranch' :: forall r. ReadRemoteNamespace -> Git.GitBranchBehavior -> ((Branch m, CodebasePath) -> m r) -> m (Either GitError r),
     -- | Push the given branch to the given repo, and optionally set it as the root branch.
     pushGitBranch :: Branch m -> WriteRepo -> PushGitBranchOpts -> m (Either GitError ()),
     -- | @watches k@ returns all of the references @r@ that were previously put by a @putWatch k r t@. @t@ can be

--- a/unison-cli/src/Unison/Codebase/Editor/Command.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Command.hs
@@ -71,6 +71,7 @@ import UnliftIO (MonadUnliftIO(..), UnliftIO)
 import qualified UnliftIO
 import Unison.Util.Free (Free)
 import qualified Unison.Util.Free as Free
+import qualified Unison.Codebase.Editor.Git as Git
 
 type AmbientAbilities v = [Type v Ann]
 type SourceName = Text
@@ -204,7 +205,7 @@ data Command
   Merge :: Branch.MergeMode -> Branch m -> Branch m -> Command m i v (Branch m)
 
   ViewRemoteBranch ::
-    ReadRemoteNamespace -> (Branch m -> (Free (Command m i v) r)) -> Command m i v (Either GitError r)
+    ReadRemoteNamespace -> Git.GitBranchBehavior -> (Branch m -> (Free (Command m i v) r)) -> Command m i v (Either GitError r)
 
   -- we want to import as little as possible, so we pass the SBH/path as part
   -- of the `RemoteNamespace`.  The Branch that's returned should be fully

--- a/unison-cli/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -150,11 +150,11 @@ commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSour
     SyncLocalRootBranch branch -> lift $ do
       setBranchRef branch
       Codebase.putRootBranch codebase branch
-    ViewRemoteBranch ns action -> do
+    ViewRemoteBranch ns gitBranchBehavior action -> do
       -- TODO: We probably won'd need to unlift anything once we remove the Command
       -- abstraction.
       toIO <- UnliftIO.askRunInIO
-      lift $ Codebase.viewRemoteBranch codebase ns (toIO . Free.fold go . action)
+      lift $ Codebase.viewRemoteBranch codebase ns gitBranchBehavior (toIO . Free.fold go . action)
     ImportRemoteBranch ns syncMode preprocess ->
       lift $ Codebase.importRemoteBranch codebase ns syncMode preprocess
     SyncRemoteBranch branch repo opts ->

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -151,6 +151,7 @@ import qualified Data.Set.NonEmpty as NESet
 import Data.Set.NonEmpty (NESet)
 import Unison.Symbol (Symbol)
 import qualified Unison.Codebase.Editor.Input as Input
+import qualified Unison.Codebase.Editor.Git as Git
 
 defaultPatchNameSegment :: NameSegment
 defaultPatchNameSegment = "patch"
@@ -635,8 +636,8 @@ loop = do
                       ppe
                       outputDiff
             CreatePullRequestI baseRepo headRepo -> do
-              result <- join @(Either GitError) <$> viewRemoteBranch baseRepo \baseBranch -> do
-                 viewRemoteBranch headRepo \headBranch -> do
+              result <- join @(Either GitError) <$> viewRemoteBranch baseRepo Git.RequireExistingBranch \baseBranch -> do
+                 viewRemoteBranch headRepo Git.RequireExistingBranch \headBranch -> do
                    merged <- eval $ Merge Branch.RegularMerge baseBranch headBranch
                    (ppe, diff) <- diffHelperCmd root' currentPath' (Branch.head baseBranch) (Branch.head merged)
                    pure $ ShowDiffAfterCreatePR baseRepo headRepo ppe diff
@@ -1721,7 +1722,7 @@ doPushRemoteBranch repo localPath syncMode remoteTarget = do
                     runExceptT (syncRemoteBranch newRemoteRoot repo opts) >>= \case
                       Left gitErr -> respond (Output.GitError gitErr)
                       Right () -> respond Success
-          viewRemoteBranch (writeToRead repo, Nothing, Path.empty) withRemoteRoot >>= \case
+          viewRemoteBranch (writeToRead repo, Nothing, Path.empty) Git.CreateBranchIfMissing withRemoteRoot >>= \case
             Left (GitSqliteCodebaseError NoDatabaseFile{}) -> withRemoteRoot Branch.empty
             Left err -> throwError err
             Right () -> pure ()
@@ -2086,9 +2087,14 @@ configKey k p =
         NameSegment.toText
         (Path.toSeq $ Path.unabsolute p)
 
-viewRemoteBranch :: (MonadCommand n m i v, MonadUnliftIO m) => ReadRemoteNamespace -> (Branch m -> Free (Command m i v) r) -> n (Either GitError r)
-viewRemoteBranch ns action = do
-  eval $ ViewRemoteBranch ns action
+viewRemoteBranch ::
+  (MonadCommand n m i v, MonadUnliftIO m) =>
+  ReadRemoteNamespace ->
+  Git.GitBranchBehavior ->
+  (Branch m -> Free (Command m i v) r) ->
+  n (Either GitError r)
+viewRemoteBranch ns gitBranchBehavior action = do
+  eval $ ViewRemoteBranch ns gitBranchBehavior action
 
 syncRemoteBranch :: MonadCommand n m i v => Branch m -> WriteRepo -> PushGitBranchOpts -> ExceptT GitError n ()
 syncRemoteBranch b repo opts =

--- a/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
@@ -25,6 +25,6 @@ defaultBaseLib = fmap makeNS $ latest <|> release
   version = do
     Text.pack <$> some (alphaNumChar <|> ('_' <$ oneOf ['.', '_', '-']))
   makeNS :: Text -> ReadRemoteNamespace
-  makeNS t = ( ReadGitRepo "https://github.com/unisonweb/base"
+  makeNS t = ( ReadGitRepo {url="https://github.com/unisonweb/base",ref=Nothing}
              , Nothing
              , Path.fromText t)

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -947,12 +947,7 @@ pullImpl name verbosity pullMode addendum = do
                   )
                 ],
               "",
-              P.wrap "where `remote` is a git repository, optionally followed by `:`"
-                <> "and an absolute remote path, such as:",
-              P.indentN 2 . P.lines $
-                [ P.backticked "https://github.com/org/repo",
-                  P.backticked "https://github.com/org/repo:.some.remote.path"
-                ]
+              explainRemote
             ]
         )
         ( \case
@@ -1021,12 +1016,7 @@ push =
               )
             ],
           "",
-          P.wrap "where `remote` is a git repository, optionally followed by `:`"
-            <> "and an absolute remote path, such as:",
-          P.indentN 2 . P.lines $
-            [ P.backticked "https://github.com/org/repo",
-              P.backticked "https://github.com/org/repo:.some.remote.path"
-            ]
+          explainRemote
         ]
     )
     ( \case
@@ -1066,12 +1056,7 @@ pushCreate =
               )
             ],
           "",
-          P.wrap "where `remote` is a git repository, optionally followed by `:`"
-            <> "and an absolute remote path, such as:",
-          P.indentN 2 . P.lines $
-            [ P.backticked "https://github.com/org/repo",
-              P.backticked "https://github.com/org/repo:.some.remote.path"
-            ]
+          explainRemote
         ]
     )
     ( \case
@@ -1203,9 +1188,9 @@ prettyPrintParseError input = \case
                  ]
 
     printTrivial :: (Maybe (P.ErrorItem Char)) -> (Set (P.ErrorItem Char)) -> P.Pretty P.ColorText
-    printTrivial ue ee = 
+    printTrivial ue ee =
       let expected = "I expected " <> foldMap (P.singleQuoted . P.string . P.showErrorComponent) ee
-          found =  P.string . mappend "I found " . P.showErrorComponent <$> ue 
+          found =  P.string . mappend "I found " . P.showErrorComponent <$> ue
           message = [expected] <> catMaybes [found]
       in P.oxfordCommasWith "." message
 
@@ -2185,3 +2170,16 @@ gitUrlArg =
 
 collectNothings :: (a -> Maybe b) -> [a] -> [a]
 collectNothings f as = [a | (Nothing, a) <- map f as `zip` as]
+
+explainRemote :: P.Pretty CT.ColorText
+explainRemote =
+  P.lines
+    [ P.wrap "where `remote` is a git repository, optionally followed by `:`"
+          <> "and an absolute remote path, a branch, or both, such as:",
+      P.indentN 2 . P.lines $
+        [ P.backticked "https://github.com/org/repo",
+          P.backticked "https://github.com/org/repo:.some.remote.path",
+          P.backticked "https://github.com/org/repo:some-branch:.some.remote.path",
+          P.backticked "https://github.com/org/repo:some-branch"
+        ]
+    ]

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -578,7 +578,7 @@ notifyUser dir o = case o of
     pure . P.warnCallout $
       P.lines
         [ "The current namespace '" <> prettyPath' path <> "' is not empty. `pull-request.load` downloads the PR into the current namespace which would clutter it.",
-          "Please switch to an empty namespace and try again." 
+          "Please switch to an empty namespace and try again."
         ]
   CantUndo reason -> case reason of
     CantUndoPastStart -> pure . P.warnCallout $ "Nothing more to undo."
@@ -928,6 +928,9 @@ notifyUser dir o = case o of
           "I couldn't push to the repository at" <> prettyWriteRepo repo <> ";"
             <> "the error was:"
             <> (P.indentNAfterNewline 2 . P.group . P.string) msg
+      RemoteRefNotFound repo ref ->
+        P.wrap $
+          "I couldn't find the ref " <> P.green (P.text ref) <> " in the repository at " <> P.blue (P.text repo) <> ";"
       UnrecognizableCacheDir uri localPath ->
         P.wrap $
           "A cache directory for"
@@ -2603,10 +2606,10 @@ prettyTypeName ppe r =
     prettyHashQualified (PPE.typeName ppe r)
 
 prettyReadRepo :: ReadRepo -> Pretty
-prettyReadRepo (RemoteRepo.ReadGitRepo url) = P.blue (P.text url)
+prettyReadRepo (RemoteRepo.ReadGitRepo{url}) = P.blue (P.text url)
 
 prettyWriteRepo :: WriteRepo -> Pretty
-prettyWriteRepo (RemoteRepo.WriteGitRepo url) = P.blue (P.text url)
+prettyWriteRepo (RemoteRepo.WriteGitRepo{url'}) = P.blue (P.text url')
 
 isTestOk :: Term v Ann -> Bool
 isTestOk tm = case tm of

--- a/unison-cli/tests/Unison/Test/GitSync.hs
+++ b/unison-cli/tests/Unison/Test/GitSync.hs
@@ -11,7 +11,7 @@ import Data.String.Here.Interpolated (i)
 import qualified Data.Text as Text
 import EasyTest
 import Shellmet ()
-import System.Directory (removeDirectoryRecursive, doesFileExist)
+import System.Directory (removeDirectoryRecursive)
 import System.FilePath ((</>))
 import qualified System.IO.Temp as Temp
 import qualified Unison.Codebase as Codebase
@@ -22,8 +22,6 @@ import Unison.Symbol (Symbol)
 import Unison.Test.Ucm (CodebaseFormat, Transcript)
 import qualified Unison.Test.Ucm as Ucm
 import Unison.WatchKind (pattern TestWatch)
-import qualified Data.Text.IO as Text
-import Unison.Codebase.Editor.Git (gitCacheDir)
 
 transcriptOutputFile :: String -> FilePath
 transcriptOutputFile name =
@@ -39,8 +37,6 @@ test :: Test ()
 test = scope "gitsync22" . tests $
   fastForwardPush :
   nonFastForwardPush :
-  localStatePersistence :
-  localStateUpdate :
   destroyedRemote :
   flip map [(Ucm.CodebaseFormat2, "sc")]
   \(fmt, name) -> scope name $ tests [
@@ -460,6 +456,7 @@ test = scope "gitsync22" . tests $
           Codebase.watches cb TestWatch)
   ,
   gistTest fmt,
+  pushPullBranchesTests fmt,
   pushPullTest "fix2068_a_" fmt
     -- this triggers
     {-
@@ -624,6 +621,73 @@ gistTest fmt =
         ```
       |]
 
+pushPullBranchesTests :: CodebaseFormat -> Test ()
+pushPullBranchesTests fmt = scope "branches" $ do
+  simplePushPull
+  multiplePushPull
+  emptyBranchFailure
+  where
+    simplePushPull =
+      let authorScript repo =
+            [i|
+              ```unison:hide
+              y = 3
+              ```
+              ```ucm
+              .> add
+              .> push.create ${repo}:mybranch:.path
+              ```
+            |]
+          userScript repo =
+            [i|
+              ```ucm
+              .> pull ${repo}:mybranch .dest
+              .> view .dest.path.y
+              ```
+            |]
+       in pushPullTest "simple" fmt authorScript userScript
+    emptyBranchFailure =
+      let authorScript _repo = ""
+          userScript repo =
+            [i|
+              ```ucm:error
+              .> pull ${repo}:mybranch .dest
+              ```
+            |]
+       in pushPullTest "empty" fmt authorScript userScript
+    multiplePushPull =
+      let authorScript repo =
+            [i|
+              ```unison:hide
+              ns1.x = 10
+              ns2.y = 20
+              ```
+              ```ucm
+              .> add
+              .> push.create ${repo}:mybranch:.ns1 .ns1
+              .> push.create ${repo}:mybranch:.ns2 .ns2
+              ```
+              ```unison
+              ns1.x = 11
+              ns1.new = 12
+              ```
+              ```ucm
+              .> update
+              .> push ${repo}:mybranch:.ns1 .ns1
+              ```
+            |]
+          userScript repo =
+            [i|
+              ```ucm
+              .> pull ${repo}:mybranch:.ns1 .ns1
+              .> pull ${repo}:mybranch:.ns2 .ns2
+              .> view .ns1.x
+              .> view .ns1.new
+              .> view .ns2.y
+              ```
+            |]
+       in pushPullTest "multiple" fmt authorScript userScript
+
 fastForwardPush :: Test ()
 fastForwardPush = scope "fastforward-push" do
   io do
@@ -638,75 +702,6 @@ fastForwardPush = scope "fastforward-push" do
       ```
     |]
   ok
-
-localStatePersistence :: Test ()
-localStatePersistence = scope "local-state-persistence" do
-  repo <- io initGitRepo
-  cachedRepoDir <- io $ gitCacheDir (Text.pack repo)
-  -- Create some local state in the cached git repo.
-  let someFilePath = cachedRepoDir </> "myfile.txt"
-  let someText = "SOME TEXT"
-  io $ do
-    codebase <- Ucm.initCodebase Ucm.CodebaseFormat2
-    -- Push some state the remote codebase
-    -- Then pull to ensure we have a non-empty local git repo.
-    void $ Ucm.runTranscript codebase [i|
-      ```ucm
-      .lib> alias.type ##Nat Nat
-      .lib> push.create ${repo}
-      .lib> pull ${repo}
-      ```
-    |]
-    -- Write a file to our local git cache to represent some changes we may have made to our
-    -- codebase, e.g. a migration.
-    Text.writeFile someFilePath someText
-    void $ Ucm.runTranscript codebase [i|
-      ```ucm
-      .lib> pull ${repo}
-      .lib> push ${repo}
-      ```
-    |]
-  -- We expect the state in the cached git repo to remain untouched iff the remote
-  -- hasn't changed. This is helpful for when we need to migrate a remote codebase,
-  -- we don't want to re-migrate if nothing has changed.
-  txt <- io $ Text.readFile someFilePath
-  expectEqual someText txt
-
--- | Any untracked files in the cache directory should be wiped out if there's a change
--- on the remote.
-localStateUpdate :: Test ()
-localStateUpdate = scope "local-state-update" do
-  repo <- io initGitRepo
-  cachedRepoDir <- io $ gitCacheDir (Text.pack repo)
-  -- Create some local state in the cached git repo.
-  let someFilePath = cachedRepoDir </> "myfile.txt"
-  let someText = "SOME TEXT"
-  io $ do
-    codebase <- Ucm.initCodebase Ucm.CodebaseFormat2
-    -- Push some state the remote codebase
-    -- Then pull to ensure we have a non-empty local git repo.
-    void $ Ucm.runTranscript codebase [i|
-      ```ucm
-      .lib> alias.type ##Nat Nat
-      .lib> push.create ${repo}
-      .lib> pull ${repo}
-      ```
-    |]
-    -- Write a file to our local git cache to represent some changes we may have made to our
-    -- codebase, e.g. a migration.
-    Text.writeFile someFilePath someText
-    -- Push the new change, then pull the new remote.
-    void $ Ucm.runTranscript codebase [i|
-      ```ucm
-      .lib> alias.type ##Nat Nat2
-      .lib> push ${repo}
-      .lib> pull ${repo}
-      ```
-    |]
-  -- We expect the state in the cached git repo to be wiped out, since there's a new commit on
-  -- the remote.
-  fileExists <- io $ doesFileExist someFilePath
-  expect (not fileExists)
 
 nonFastForwardPush :: Test ()
 nonFastForwardPush = scope "non-fastforward-push" do

--- a/unison-cli/tests/Unison/Test/UriParser.hs
+++ b/unison-cli/tests/Unison/Test/UriParser.hs
@@ -25,50 +25,50 @@ testAugmented = scope "augmented" . tests $
 --  $ git clone /srv/git/project.git[:treeish][:[#hash][.path]]
   [ scope "local-protocol" . tests . map parseAugmented $
     [ ("/srv/git/project.git",
-      (ReadGitRepo "/srv/git/project.git", Nothing, Path.empty))
-    -- , ("/srv/git/project.git:abc:#def.hij.klm",
-    --   (ReadGitRepo "/srv/git/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
+      (ReadGitRepo "/srv/git/project.git" Nothing, Nothing, Path.empty))
+    , ("/srv/git/project.git:abc:#def.hij.klm",
+      (ReadGitRepo "/srv/git/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
     , ("srv/git/project.git",
-      (ReadGitRepo "srv/git/project.git", Nothing, Path.empty))
-    -- , ("srv/git/project.git:abc:#def.hij.klm",
-    --   (ReadGitRepo "srv/git/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
+      (ReadGitRepo "srv/git/project.git" Nothing, Nothing, Path.empty))
+    , ("srv/git/project.git:abc:#def.hij.klm",
+      (ReadGitRepo "srv/git/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
     ],
 -- File Protocol
 --  $ git clone file:///srv/git/project.git[:treeish][:[#hash][.path]] <- imagined
     scope "file-protocol" . tests . map parseAugmented $
     [ ("file:///srv/git/project.git",
-      (ReadGitRepo "file:///srv/git/project.git", Nothing, Path.empty))
-    -- , ("file:///srv/git/project.git:abc:#def.hij.klm",
-    --   (ReadGitRepo "file:///srv/git/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
+      (ReadGitRepo "file:///srv/git/project.git" Nothing, Nothing, Path.empty))
+    , ("file:///srv/git/project.git:abc:#def.hij.klm",
+      (ReadGitRepo "file:///srv/git/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
     , ("file://srv/git/project.git",
-      (ReadGitRepo "file://srv/git/project.git", Nothing, Path.empty))
-    -- , ("file://srv/git/project.git:abc:#def.hij.klm",
-    --   (ReadGitRepo "file://srv/git/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
+      (ReadGitRepo "file://srv/git/project.git" Nothing, Nothing, Path.empty))
+    , ("file://srv/git/project.git:abc:#def.hij.klm",
+      (ReadGitRepo "file://srv/git/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
     ],
 -- Smart / Dumb HTTP protocol
 --  $ git clone https://example.com/gitproject.git[:treeish][:[#hash][.path]] <- imagined
     scope "http-protocol" . tests . map parseAugmented $
     [ ("https://example.com/git/project.git",
-      (ReadGitRepo "https://example.com/git/project.git", Nothing, Path.empty))
-    -- , ("https://user@example.com/git/project.git:abc:#def.hij.klm]",
-    --   (ReadGitRepo "https://user@example.com/git/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
+      (ReadGitRepo "https://example.com/git/project.git" Nothing, Nothing, Path.empty))
+    , ("https://user@example.com/git/project.git:abc:#def.hij.klm]",
+      (ReadGitRepo "https://user@example.com/git/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
     ],
 -- SSH Protocol
 --  $ git clone ssh://[user@]server/project.git[:treeish][:[#hash][.path]]
     scope "ssh-protocol" . tests . map parseAugmented $
     [ ("ssh://git@8.8.8.8:222/user/project.git",
-      (ReadGitRepo "ssh://git@8.8.8.8:222/user/project.git", Nothing, Path.empty))
-    -- , ("ssh://git@github.com/user/project.git:abc:#def.hij.klm",
-    --   (ReadGitRepo "ssh://git@github.com/user/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
+      (ReadGitRepo "ssh://git@8.8.8.8:222/user/project.git" Nothing, Nothing, Path.empty))
+    , ("ssh://git@github.com/user/project.git:abc:#def.hij.klm",
+      (ReadGitRepo "ssh://git@github.com/user/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
     ],
 --  $ git clone [user@]server:project.git[:treeish][:[#hash][.path]]
     scope "scp-protocol" . tests . map parseAugmented $
     [ ("git@github.com:user/project.git",
-      (ReadGitRepo "git@github.com:user/project.git", Nothing, Path.empty))
+      (ReadGitRepo "git@github.com:user/project.git" Nothing, Nothing, Path.empty))
     , ("github.com:user/project.git",
-      (ReadGitRepo "github.com:user/project.git", Nothing, Path.empty))
-    -- , ("git@github.com:user/project.git:abc:#def.hij.klm",
-    --   (ReadGitRepo "git@github.com:user/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
+      (ReadGitRepo "github.com:user/project.git" Nothing, Nothing, Path.empty))
+    , ("git@github.com:user/project.git:abc:#def.hij.klm",
+      (ReadGitRepo "git@github.com:user/project.git" (Just "abc"), sbh "def", path ["hij", "klm"]))
     ]
   ]
 

--- a/unison-cli/tests/Unison/Test/VersionParser.hs
+++ b/unison-cli/tests/Unison/Test/VersionParser.hs
@@ -24,6 +24,6 @@ makeTest (version, path) =
   scope (unpack version) $ expectEqual
     (rightMay $ runParser defaultBaseLib "versionparser" version)
     (Just
-      ( ReadGitRepo "https://github.com/unisonweb/base"
+      ( ReadGitRepo "https://github.com/unisonweb/base" Nothing
       , Nothing
       , Path.fromText path ))


### PR DESCRIPTION
closes #2858
## Overview

Allows users to push to branches, or pull from branches or tags.
Commit hashes are not yet supported.

E.g.

```
.> push.create git@github.com:ChrisPenner/unison-testing:mybranch:.mynamespace .mynamespace
```

Will add the namespace `.mynamespace` to the codebase on the `mybranch` branch, or will create a new branch and fresh codebase if none exists there.

Note, pushing to a branch which doesn't exist creates a brand new codebase there, it doesn't copy the version from the main branch or anything like that.

We can also use this behaviour to create named gists on branches, and is a bit quicker than using the gist command since it creates an isolated codebase with ONLY the code you want, rather than adding a new orphaned root namespace to an existing (and potentially very large) codebase.

## Implementation notes

Git repos are big balls of state that are pretty tough to manage, and our current git caches are shared by all ucm's on the host, so we have to be careful about any assumptions regarding the state of the global git cache.

To mitigate these issues, this PR now treats the global git cache like a bare repo and never makes commits there or performs any operations in the worktree.
Instead, we perform a cheap local clone of the cache into a temp-dir, then do all of our work there in a pristine environment.

As a bonus, this gives each ucm better isolation from one-another if multiple ucms are performing pulls/pushes at the same time.

~~Ideally the caches would just be `bare` repos to remove the state entirely, but for backwards compatibility with the old version of git caches I won't change that behaviour here.~~
I changed it to use bare repos and just use a `-bare` suffix to avoid conflicts with existing repos.

## Test coverage

I added GitSync tests for pulling/pushing branches.