### PR TITLE
add builtins/iosource to Codebase.toCodeLookup

### DIFF
--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -123,6 +123,7 @@ import Unison.Prelude
 import Unison.Reference (Reference)
 import qualified Unison.Reference as Reference
 import qualified Unison.Referent as Referent
+import qualified Unison.Runtime.IOSource as IOSource
 import Unison.Symbol (Symbol)
 import Unison.Term (Term)
 import qualified Unison.Term as Term
@@ -253,8 +254,10 @@ typeLookupForDependencies codebase s = do
               Nothing -> pure mempty
     go tl Reference.Builtin {} = pure tl -- codebase isn't consulted for builtins
 
-toCodeLookup :: Codebase m v a -> CL.CodeLookup v m a
+toCodeLookup :: Monad m => Codebase m Symbol Parser.Ann -> CL.CodeLookup Symbol m Parser.Ann
 toCodeLookup c = CL.CodeLookup (getTerm c) (getTypeDeclaration c)
+  <> Builtin.codeLookup
+  <> IOSource.codeLookupM
 
 -- | Get the type of a term.
 --

--- a/parser-typechecker/src/Unison/Runtime/IOSource.hs
+++ b/parser-typechecker/src/Unison/Runtime/IOSource.hs
@@ -11,6 +11,7 @@ import Unison.Prelude
 
 import Control.Lens (view, _1)
 import Control.Monad.Identity (runIdentity, Identity)
+import Control.Monad.Morph (hoist)
 import Data.List (elemIndex, genericIndex)
 import Text.RawString.QQ (r)
 import Unison.Codebase.CodeLookup (CodeLookup(..))
@@ -59,6 +60,9 @@ termNamed s = fromMaybe (error $ "No builtin term called: " <> s)
 
 codeLookup :: CodeLookup Symbol Identity Ann
 codeLookup = CL.fromTypecheckedUnisonFile typecheckedFile
+
+codeLookupM :: Applicative m => CodeLookup Symbol m Ann
+codeLookupM = hoist (pure . runIdentity) codeLookup
 
 typeNamedId :: String -> R.Id
 typeNamedId s =

--- a/unison-src/transcripts/fix2840.md
+++ b/unison-src/transcripts/fix2840.md
@@ -1,0 +1,87 @@
+This bugfix addresses an issue where embedded Unison code in UCM was expected to be present in the active codebase when the `display` command was used render `Doc` values.
+
+```ucm:hide
+.> builtins.merge
+```
+
+First, a few \[hidden] definitions necessary for typechecking a simple Doc2.
+
+```unison:hide:all
+structural type Optional a = None | Some a
+
+unique[b7a4fb87e34569319591130bf3ec6e24c9955b6a] type Doc2
+  = Word Text
+  | Code Doc2
+  | CodeBlock Text Doc2
+  | Bold Doc2
+  | Italic Doc2
+  | Strikethrough Doc2
+  | Style Text Doc2
+  | Anchor Text Doc2
+  | Blockquote Doc2
+  | Blankline
+  | Linebreak
+  | SectionBreak
+  | Tooltip Doc2 Doc2
+  | Aside Doc2
+  | Callout (Optional Doc2) Doc2
+  | Table [[Doc2]]
+  | Folded Boolean Doc2 Doc2
+  | Paragraph [Doc2]
+  | BulletedList [Doc2]
+  | NumberedList Nat [Doc2]
+  | Section Doc2 [Doc2]
+  | NamedLink Doc2 Doc2
+  | Image Doc2 Doc2 (Optional Doc2)
+  | Special Doc2.SpecialForm
+  | Join [Doc2]
+  | UntitledSection [Doc2]
+  | Column [Doc2]
+  | Group Doc2
+
+unique[da70bff6431da17fa515f3d18ded11852b6a745f] type Doc2.SpecialForm
+  = Source [(Either Link.Type Doc2.Term, [Doc2.Term])]
+  | FoldedSource [(Either Link.Type Doc2.Term, [Doc2.Term])]
+  | Example Nat Doc2.Term
+  | ExampleBlock Nat Doc2.Term
+  | Link (Either Link.Type Doc2.Term)
+  | Signature [Doc2.Term]
+  | SignatureInline Doc2.Term
+  | Eval Doc2.Term
+  | EvalInline Doc2.Term
+  | Embed Any
+  | EmbedInline Any
+
+-- A newtype used when embedding term references in a Doc2
+unique[fb488e55e66e2492c2946388e4e846450701db04] type Doc2.Term = Term Any
+
+syntax.docUntitledSection = cases
+  [d] -> d
+  ds -> UntitledSection ds
+syntax.docParagraph = Paragraph
+syntax.docWord = Word
+```
+
+```ucm
+.> add
+```
+
+Next, define and display a simple Doc:
+```unison:hide
+README = {{
+Hi
+}}
+```
+
+```ucm
+.> display README
+```
+
+Previously, the error was:
+
+```
+⚙️   Processing stanza 5 of 7.ucm: PE [("die",SrcLoc {srcLocPackage = "unison-parser-typechecker-0.0.0-He2Hp1llokT2nN4MnUfUXz", srcLocModule = "Unison.Runtime.Interface", srcLocFile = "src/Unison/Runtime/Interface.hs", srcLocStartLine = 118, srcLocStartCol = 18, srcLocEndLine = 118, srcLocEndCol = 60})] Lit
+  AnnotatedText (fromList [Segment {segment = "Unknown term reference: #4522d", annotation = Nothing}])
+```
+
+but as of this PR, it's okay.

--- a/unison-src/transcripts/fix2840.output.md
+++ b/unison-src/transcripts/fix2840.output.md
@@ -1,0 +1,41 @@
+This bugfix addresses an issue where embedded Unison code in UCM was expected to be present in the active codebase when the `display` command was used render `Doc` values.
+
+First, a few \[hidden] definitions necessary for typechecking a simple Doc2.
+
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    unique type Doc2
+    unique type Doc2.SpecialForm
+    unique type Doc2.Term
+    structural type Optional a
+      (also named builtin.Optional)
+    syntax.docParagraph       : [Doc2] -> Doc2
+    syntax.docUntitledSection : [Doc2] -> Doc2
+    syntax.docWord            : Text -> Doc2
+
+```
+Next, define and display a simple Doc:
+```unison
+README = {{
+Hi
+}}
+```
+
+```ucm
+.> display README
+
+  Hi
+
+```
+Previously, the error was:
+
+```
+⚙️   Processing stanza 5 of 7.ucm: PE [("die",SrcLoc {srcLocPackage = "unison-parser-typechecker-0.0.0-He2Hp1llokT2nN4MnUfUXz", srcLocModule = "Unison.Runtime.Interface", srcLocFile = "src/Unison/Runtime/Interface.hs", srcLocStartLine = 118, srcLocStartCol = 18, srcLocEndLine = 118, srcLocEndCol = 60})] Lit
+  AnnotatedText (fromList [Segment {segment = "Unknown term reference: #4522d", annotation = Nothing}])
+
+```
+
+but as of this PR, it's okay.


### PR DESCRIPTION
## Overview

Certain definitions used by UCM to `display` docs will not necessarily be available in a codebase. This PR makes them available via lazy access to `IOSource.hs`, where the required definitions are defined.

* Fixes #1970
* Fixes #2840

## Implementation notes

This is a simpler version of what we discussed in #2840, 

> 2. Augment the code lookup which is passed to the runtime (for `display` only) to include definitions from IOSource.hs

The augmentation doesn't have to be limited to `display`, so I've included it right into `Codebase.toCodeLookup`.

This has the side effect of forcing `IOSource.typecheckedFile` the first time the runtime requests a definition that's not in the codebase and not in `Builtin.Decls`. This shouldn't be possible except for those definitions that would require this to be forced anyway, though.

## Test coverage

`fix2840.md` is a regression transcript.

## Loose ends

* I opened https://github.com/unisonweb/unison/issues/2864 to maybe speed up `IOSource.typecheckedFile`.
* This doesn't have anything to do with #2845 except that they are both Doc related errors that occur with an empty codebase.
* The definitions of various built-ins still need to be in the codebase in order for them to appear in a namespace, due to the design constraint of the V2 codebase, but I think it would be cool to be able to add them on-demand.  Currently they're only added on `builtins.merge`, `builtins.mergeio`, or `pull <base>`.