### PR TITLE
Don't crash when printing types with higher-rank fields.

### DIFF
--- a/parser-typechecker/src/Unison/DeclPrinter.hs
+++ b/parser-typechecker/src/Unison/DeclPrinter.hs
@@ -133,55 +133,60 @@ prettyDataDecl (PrettyPrintEnvDecl unsuffixifiedPPE suffixifiedPPE) r name dd =
 --
 -- This function bails with `Nothing` if the names aren't an exact match for
 -- the expected record naming convention.
-fieldNames
-  :: forall v a . Var v
-  => PrettyPrintEnv
-  -> Reference
-  -> HashQualified Name
-  -> DataDeclaration v a
-  -> Maybe [HashQualified Name]
-fieldNames env r name dd = case DD.constructors dd of
-  [(_, typ)] -> let
-    vars :: [v]
-    vars = [ Var.freshenId (fromIntegral n) (Var.named "_") | n <- [0..Type.arity typ - 1]]
-    accessors :: [(v, Term.Term v ())]
-    accessors = DD.generateRecordAccessors (map (,()) vars) (HQ.toVar name) r
-    accessorsWithTypes :: [(v, Term.Term v (), Type.Type v ())]
-    accessorsWithTypes = accessors <&> \(v, trm) ->
-                      case Result.result (Typechecker.synthesize typecheckingEnv trm) of
-                        Nothing -> error $ "Failed to typecheck record field: " <> show v
-                        Just typ -> (v, trm, typ)
-    typeLookup :: TypeLookup v ()
-    typeLookup =
-      TypeLookup
-        { TypeLookup.typeOfTerms = mempty,
-          TypeLookup.dataDecls = Map.singleton r (void dd),
-          TypeLookup.effectDecls = mempty
-        }
-    typecheckingEnv :: Typechecker.Env v ()
-    typecheckingEnv =
-      Typechecker.Env
-        { Typechecker._ambientAbilities = mempty,
-          Typechecker._typeLookup = typeLookup,
-          Typechecker._termsByShortname = mempty
-        }
-    hashes = Hashing.hashTermComponents (Map.fromList . fmap (\(v, trm, typ) -> (v, (trm, typ))) $ accessorsWithTypes)
-    names = [ (r, HQ.toString . PPE.termName env . Referent.Ref $ DerivedId r)
-            | r <- (\(refId, _trm, _typ) -> refId) <$> Map.elems hashes ]
-    fieldNames = Map.fromList
-      [ (r, f) | (r, n) <- names
-               , typename <- pure (HQ.toString name)
-               , typename `isPrefixOf` n
-               , rest <- pure $ drop (length typename + 1) n
-               , (f, rest) <- pure $ span (/= '.') rest
-               , rest `elem` ["",".set",".modify"] ]
-    in if Map.size fieldNames == length names then
-         Just [ HQ.unsafeFromString name
-              | v <- vars
-              , Just (ref, _, _) <- [Map.lookup (Var.namespaced [HQ.toVar name, v]) hashes]
-              , Just name <- [Map.lookup ref fieldNames] ]
-       else Nothing
-  _ -> Nothing
+fieldNames ::
+  forall v a.
+  Var v =>
+  PrettyPrintEnv ->
+  Reference ->
+  HashQualified Name ->
+  DataDeclaration v a ->
+  Maybe [HashQualified Name]
+fieldNames env r name dd = do
+  typ <- case DD.constructors dd of
+    [(_, typ)] -> Just typ
+    _ -> Nothing
+  let vars :: [v]
+      vars = [Var.freshenId (fromIntegral n) (Var.named "_") | n <- [0 .. Type.arity typ - 1]]
+  let accessors :: [(v, Term.Term v ())]
+      accessors = DD.generateRecordAccessors (map (,()) vars) (HQ.toVar name) r
+  let typeLookup :: TypeLookup v ()
+      typeLookup =
+        TypeLookup
+          { TypeLookup.typeOfTerms = mempty,
+            TypeLookup.dataDecls = Map.singleton r (void dd),
+            TypeLookup.effectDecls = mempty
+          }
+  let typecheckingEnv :: Typechecker.Env v ()
+      typecheckingEnv =
+        Typechecker.Env
+          { Typechecker._ambientAbilities = mempty,
+            Typechecker._typeLookup = typeLookup,
+            Typechecker._termsByShortname = mempty
+          }
+  accessorsWithTypes :: [(v, Term.Term v (), Type.Type v ())] 
+    <- for accessors \(v, trm) ->
+         case Result.result (Typechecker.synthesize typecheckingEnv trm) of
+           Nothing -> Nothing
+           Just typ -> Just (v, trm, typ)
+  let hashes = Hashing.hashTermComponents (Map.fromList . fmap (\(v, trm, typ) -> (v, (trm, typ))) $ accessorsWithTypes)
+  let names =
+        [ (r, HQ.toString . PPE.termName env . Referent.Ref $ DerivedId r)
+          | r <- (\(refId, _trm, _typ) -> refId) <$> Map.elems hashes
+        ]
+  let fieldNames =
+        Map.fromList
+          [ (r, f) | (r, n) <- names, typename <- pure (HQ.toString name), typename `isPrefixOf` n, rest <- pure $ drop (length typename + 1) n, (f, rest) <- pure $ span (/= '.') rest, rest `elem` ["", ".set", ".modify"]
+          ]
+
+  if Map.size fieldNames == length names
+    then
+      Just
+        [ HQ.unsafeFromString name
+          | v <- vars,
+            Just (ref, _, _) <- [Map.lookup (Var.namespaced [HQ.toVar name, v]) hashes],
+            Just name <- [Map.lookup ref fieldNames]
+        ]
+    else Nothing
 
 prettyModifier :: DD.Modifier -> Pretty SyntaxText
 prettyModifier DD.Structural = fmt S.DataTypeModifier "structural"

--- a/unison-src/transcripts/higher-rank.md
+++ b/unison-src/transcripts/higher-rank.md
@@ -67,3 +67,16 @@ Loc.transform2 nt = cases Loc f ->
   f' a = f (nt a)
   Loc f' 
 ```
+
+## Types with polymorphic fields
+
+```unison:hide
+structural type HigherRanked = HigherRanked (forall a. a -> a)
+```
+
+We should be able to add and view records with higher-rank fields.
+
+```ucm
+.higher_ranked> add
+.higher_ranked> view HigherRanked
+```

--- a/unison-src/transcripts/higher-rank.output.md
+++ b/unison-src/transcripts/higher-rank.output.md
@@ -124,3 +124,25 @@ Loc.transform2 nt = cases Loc f ->
                        -> Loc
 
 ```
+## Types with polymorphic fields
+
+```unison
+structural type HigherRanked = HigherRanked (forall a. a -> a)
+```
+
+We should be able to add and view records with higher-rank fields.
+
+```ucm
+  ☝️  The namespace .higher_ranked is empty.
+
+.higher_ranked> add
+
+  ⍟ I've added these definitions:
+  
+    structural type HigherRanked
+
+.higher_ranked> view HigherRanked
+
+  structural type HigherRanked = HigherRanked (∀ a. a -> a)
+
+```


### PR DESCRIPTION
## Overview

fixes #2849 

Now that we typecheck record fields to get their hashes, we added a failure case when we can't properly typecheck the fields. It turns out that higher-rank fields trigger that error case, but it's acceptable to simply skip fetching field-names in that case since records aren't supported for higher-rank fields at the moment anyways.

Transcript:

    ```unison:hide
    structural type HigherRanked = HigherRanked (forall a. a -> a)
    ```

    We should be able to add and view records with higher-rank fields.

    ```ucm
    .higher_ranked> add
    .higher_ranked> view HigherRanked
    ```

### Old behaviour:

```
unison: Failed to typecheck record field: User "HigherRanked._.set"
CallStack (from HasCallStack):
  error, called at src/Unison/DeclPrinter.hs:152:36 in unison-parser-typechecker-0.0.0-3BUf37b1GA08ZzhhUKJgym:Unison.DeclPrinter
higher-rank.md EXCEPTION!!!: callCommand: /Users/cpenner/dev/unison-trunk/.stack-work/install/x86_64-osx/927e170d2a97df40cec5690e18a9496b9598d494d02c3ae16f7d0d2bc6c9948c/8.10.7/bin/unison transcript unison-src/transcripts/higher-rank.md (exit 1): failed
```

### New behaviour:

    ```ucm
    .higher_ranked> add

      ⍟ I've added these definitions:
      
        structural type HigherRanked

    .higher_ranked> view HigherRanked

      structural type HigherRanked = HigherRanked (∀ a. a -> a)

    ```


## Implementation notes

Rather than `error`, we simply return `Nothing` indicating that field names could not be found.

## Test coverage

Added a regression transcript.