### PR TITLE
Add numbered output to `view.patch`

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1474,7 +1474,7 @@ loop = do
               ppe <-
                 suffixifiedPPE
                   =<< makePrintNamesFromLabeled' (Patch.labeledDependencies patch)
-              respond $ ListEdits patch ppe
+              respondNumbered $ ListEdits patch ppe
             PullRemoteBranchI mayRepo path syncMode pullMode verbosity -> unlessError do
               let preprocess = case pullMode of
                     Input.PullWithHistory -> Unmodified

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -97,6 +97,7 @@ data NumberedOutput v
     CantDeleteNamespace PPE.PrettyPrintEnvDecl (Map LabeledDependency (NESet LabeledDependency))
   | -- | DeletedDespiteDependents ppe deletedThings thingsWhichNowHaveUnnamedReferences
     DeletedDespiteDependents PPE.PrettyPrintEnvDecl (Map LabeledDependency (NESet LabeledDependency))
+  | ListEdits Patch PPE.PrettyPrintEnv
 
 --  | ShowDiff
 
@@ -190,7 +191,6 @@ data Output v
       [(Reference, Text)] -- oks
       [(Reference, Text)] -- fails
   | CantUndo UndoFailureReason
-  | ListEdits Patch PPE.PrettyPrintEnv
   | -- new/unrepresented references followed by old/removed
     -- todo: eventually replace these sets with [SearchResult' v Ann]
     -- and a nicer render.
@@ -328,7 +328,6 @@ isFailure o = case o of
   TestIncrementalOutputEnd {} -> False
   TestResults _ _ _ _ _ fails -> not (null fails)
   CantUndo {} -> True
-  ListEdits {} -> False
   GitError {} -> True
   BustedBuiltins {} -> True
   ConfiguredMetadataParseError {} -> True
@@ -384,3 +383,4 @@ isNumberedFailure = \case
   CantDeleteDefinitions {} -> True
   CantDeleteNamespace {} -> True
   DeletedDespiteDependents {} -> False
+  ListEdits {} -> False

--- a/unison-src/transcripts/command-replace.output.md
+++ b/unison-src/transcripts/command-replace.output.md
@@ -67,9 +67,9 @@ Test that replace works with types
 
 .scratch> view.patch patch
 
-  Edited Types: X#d97e0jhkmd -> X
+  Edited Types: 1. X#d97e0jhkmd -> 3. X
   
-  Edited Terms: #jk19sm5bf8 -> x
+  Edited Terms: 2. #jk19sm5bf8 -> 4. x
   
   Tip: To remove entries from a patch, use
        delete.term-replacement or delete.type-replacement, as

--- a/unison-src/transcripts/copy-patch.output.md
+++ b/unison-src/transcripts/copy-patch.output.md
@@ -39,7 +39,7 @@ Copy the patch and make sure it's still there.
 
 .> view.patch foo.patch
 
-  Edited Terms: #jk19sm5bf8 -> x
+  Edited Terms: 1. #jk19sm5bf8 -> 2. x
   
   Tip: To remove entries from a patch, use
        delete.term-replacement or delete.type-replacement, as
@@ -51,7 +51,7 @@ Copy the patch and make sure it's still there.
 
 .> view.patch bar.patch
 
-  Edited Terms: #jk19sm5bf8 -> x
+  Edited Terms: 1. #jk19sm5bf8 -> 2. x
   
   Tip: To remove entries from a patch, use
        delete.term-replacement or delete.type-replacement, as

--- a/unison-src/transcripts/deleteReplacements.md
+++ b/unison-src/transcripts/deleteReplacements.md
@@ -18,7 +18,7 @@ x = 2
 ```
 
 ```ucm
-.> delete.term-replacement #jk19
+.> delete.term-replacement 1
 .> view.patch
 ```
 
@@ -40,7 +40,7 @@ unique[b] type Foo = Foo | Bar
 ```
 
 ```ucm
-.> delete.type-replacement #hsk1l8232e
+.> delete.type-replacement 1
 .> view.patch
 ```
 
@@ -60,6 +60,6 @@ unique[bb] type bar = Foo | Bar
 ```ucm
 .> update
 .> view.patch
-.> delete.type-replacement #b1ct5ub6du
+.> delete.type-replacement 1
 .> view.patch
 ```

--- a/unison-src/transcripts/deleteReplacements.output.md
+++ b/unison-src/transcripts/deleteReplacements.output.md
@@ -48,7 +48,7 @@ x = 2
 
 .> view.patch
 
-  Edited Terms: x#jk19sm5bf8 -> x
+  Edited Terms: 1. x#jk19sm5bf8 -> 2. x
   
   Tip: To remove entries from a patch, use
        delete.term-replacement or delete.type-replacement, as
@@ -56,7 +56,7 @@ x = 2
 
 ```
 ```ucm
-.> delete.term-replacement #jk19
+.> delete.term-replacement 1
 
   Done.
 
@@ -113,7 +113,7 @@ unique[b] type Foo = Foo | Bar
 
 .> view.patch
 
-  Edited Types: Foo#hsk1l8232e -> Foo
+  Edited Types: 1. Foo#hsk1l8232e -> 2. Foo
   
   Tip: To remove entries from a patch, use
        delete.term-replacement or delete.type-replacement, as
@@ -121,7 +121,7 @@ unique[b] type Foo = Foo | Bar
 
 ```
 ```ucm
-.> delete.type-replacement #hsk1l8232e
+.> delete.type-replacement 1
 
   Done.
 
@@ -181,13 +181,13 @@ unique[bb] type bar = Foo | Bar
 
 .> view.patch
 
-  Edited Types: bar#b1ct5ub6du -> bar
+  Edited Types: 1. bar#b1ct5ub6du -> 2. bar
   
   Tip: To remove entries from a patch, use
        delete.term-replacement or delete.type-replacement, as
        appropriate.
 
-.> delete.type-replacement #b1ct5ub6du
+.> delete.type-replacement 1
 
   Done.
 

--- a/unison-src/transcripts/diff-namespace.output.md
+++ b/unison-src/transcripts/diff-namespace.output.md
@@ -439,8 +439,8 @@ unique type Y a b = Y a b
 .> view.patch ns2.patch
 
   Edited Terms:
-    ns1.b         -> ns2.b
-    ns1.fromJust' -> ns2.fromJust
+    1. ns1.b         -> 3. ns2.b
+    2. ns1.fromJust' -> 4. ns2.fromJust
   
   Tip: To remove entries from a patch, use
        delete.term-replacement or delete.type-replacement, as

--- a/unison-src/transcripts/find-patch.md
+++ b/unison-src/transcripts/find-patch.md
@@ -23,6 +23,5 @@ Update
 ```ucm
 .> update
 .> find.patch
-.> view.patch patch
 .> view.patch 1
 ```

--- a/unison-src/transcripts/find-patch.output.md
+++ b/unison-src/transcripts/find-patch.output.md
@@ -62,17 +62,9 @@ Update
 
   1. patch
 
-.> view.patch patch
-
-  Edited Terms: hey#8e79ctircj -> hey
-  
-  Tip: To remove entries from a patch, use
-       delete.term-replacement or delete.type-replacement, as
-       appropriate.
-
 .> view.patch 1
 
-  Edited Terms: hey#8e79ctircj -> hey
+  Edited Terms: 1. hey#8e79ctircj -> 2. hey
   
   Tip: To remove entries from a patch, use
        delete.term-replacement or delete.type-replacement, as

--- a/unison-src/transcripts/fix1334.output.md
+++ b/unison-src/transcripts/fix1334.output.md
@@ -75,7 +75,7 @@ We used to have to know the full hash for a definition to be able to use the `re
 
 .> view.patch
 
-  Edited Terms: f#msp7bv40rv -> f
+  Edited Terms: 1. f#msp7bv40rv -> 2. f
   
   Tip: To remove entries from a patch, use
        delete.term-replacement or delete.type-replacement, as

--- a/unison-src/transcripts/resolve.output.md
+++ b/unison-src/transcripts/resolve.output.md
@@ -118,7 +118,7 @@ The `a` and `b` namespaces now each contain a patch named `patch`. We can view t
 
 .example.resolve> view.patch a.patch
 
-  Edited Terms: c.foo -> a.foo
+  Edited Terms: 1. c.foo -> 2. a.foo
   
   Tip: To remove entries from a patch, use
        delete.term-replacement or delete.type-replacement, as
@@ -126,7 +126,7 @@ The `a` and `b` namespaces now each contain a patch named `patch`. We can view t
 
 .example.resolve> view.patch b.patch
 
-  Edited Terms: c.foo -> b.foo
+  Edited Terms: 1. c.foo -> 2. b.foo
   
   Tip: To remove entries from a patch, use
        delete.term-replacement or delete.type-replacement, as
@@ -213,7 +213,7 @@ This changes the merged `c.patch` so that only the edit from #44954ulpdf to  #8e
 ```ucm
 .example.resolve.c> view.patch
 
-  Edited Terms: #44954ulpdf -> foo#8e68dvpr0a
+  Edited Terms: 1. #44954ulpdf -> 2. foo#8e68dvpr0a
   
   Tip: To remove entries from a patch, use
        delete.term-replacement or delete.type-replacement, as


### PR DESCRIPTION
## Overview

closes #2872

Adds numbered output to `view.patch`, in addition to just being handy it also allows us to remove some hashes from transcripts which has been a headache for us when we change the hashing algorithm.

Note: I chose the numbering scheme (count the LHS, then count the RHS) because it seems most useful for using with ranges, since it lets you select any "quadrant" of the output. e.g. if you want all the terms from the LHS of a patch you can do `1-3` or w/e, 

<img width="985" alt="image" src="https://user-images.githubusercontent.com/6439644/153062682-1d12e455-502e-42d5-8d98-545dd9e3f926.png">


## Loose ends

Currently we include historical names in the output, which is nice since the LHS would typically be all hashes otherwise.
However, it means that copy-pasting things from the LHS with historical names doesn't actually work to `view`, etc.

<img width="1004" alt="image" src="https://user-images.githubusercontent.com/6439644/153062221-cd82a621-4104-44d3-9eb2-540a5880c510.png">

To address this, I just display Z#d97e0jhkmd, but actually store just the hash  #d97e0jhkmd  in the numbered arg; so it would still fail if you explicitly `view Z#d97e0jhkmd`, but succeeds if you `view 2`


E.g.
<img width="1114" alt="image" src="https://user-images.githubusercontent.com/6439644/153297818-da4fb39c-21d7-4d9d-89f2-14a72f689636.png">
