### PR TITLE
docs.as-html: move tooltips to hidden spot in dom

### DIFF
--- a/parser-typechecker/src/Unison/Server/Doc/AsHtml.hs
+++ b/parser-typechecker/src/Unison/Server/Doc/AsHtml.hs
@@ -1,13 +1,20 @@
-{- ORMOLU_DISABLE -} -- Remove this when the file is ready to be auto-formatted
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 -- | Render Unison.Server.Doc and embedded source to Html
 module Unison.Server.Doc.AsHtml where
 
+import Control.Monad.State.Class (MonadState)
+import qualified Control.Monad.State.Class as State
+import Control.Monad.Trans.State (evalStateT)
+import Control.Monad.Writer.Class (MonadWriter)
+import qualified Control.Monad.Writer.Class as Writer
+import Control.Monad.Writer.Lazy (runWriterT)
 import Data.Foldable
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Maybe
+import Data.Sequence (Seq)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Lucid
@@ -118,11 +125,13 @@ foldedToHtmlSource isFolded source =
             )
         )
     EmbeddedSource summary details ->
-      foldedToHtml [class_ "folded rich source"] $
-        IsFolded
-          isFolded
-          [codeBlock [] $ Syntax.toHtml summary]
-          [codeBlock [] $ Syntax.toHtml details]
+      foldedToHtml
+        [class_ "folded rich source"]
+        ( IsFolded
+            isFolded
+            [codeBlock [] $ Syntax.toHtml summary]
+            [codeBlock [] $ Syntax.toHtml details]
+        )
 
 -- | Merge adjacent Word elements in a list to 1 element with a string of words
 -- separated by space— useful for rendering to the dom without creating dom
@@ -179,181 +188,231 @@ toText sep doc =
 
 toHtml :: Map Referent Name -> Doc -> Html ()
 toHtml docNamesByRef document =
-  let toHtml_ sectionLevel doc =
-        let -- Make it simple to retain the sectionLevel when recurring.
-            -- the Section variant increments it locally
-            currentSectionLevelToHtml =
-              toHtml_ sectionLevel
+  article_ [class_ "unison-doc"] $ do
+    content
+    div_ [class_ "tooltips", style_ "display: none;"] $ sequence_ tooltips
+  where
+    (content, (_, tooltips)) =
+      runWriterT (evalStateT (toHtml_ 1 document) 0)
 
-            sectionContentToHtml renderer doc_ =
-              -- Block elements can't be children for <p> elements
-              case doc_ of
-                Paragraph [CodeBlock {}] -> renderer doc_
-                Paragraph [Blockquote _] -> renderer doc_
-                Paragraph [Blankline] -> renderer doc_
-                Paragraph [SectionBreak] -> renderer doc_
-                Paragraph [Callout {} ] -> renderer doc_
-                Paragraph [Table _] -> renderer doc_
-                Paragraph [Folded {} ] -> renderer doc_
-                Paragraph [BulletedList _] -> renderer doc_
-                Paragraph [NumberedList {}] -> renderer doc_
-                -- Paragraph [Section _ _] -> renderer doc_
-                Paragraph [Image {} ] -> renderer doc_
-                Paragraph [Special (Source _)] -> renderer doc_
-                Paragraph [Special (FoldedSource _)] -> renderer doc_
-                Paragraph [Special (ExampleBlock _)] -> renderer doc_
-                Paragraph [Special (Signature _)] -> renderer doc_
-                Paragraph [Special Eval {}] ->renderer doc_
-                Paragraph [Special (Embed _)] -> renderer doc_
-                Paragraph [UntitledSection ds] -> mapM_ (sectionContentToHtml renderer) ds
-                Paragraph [Column _] -> renderer doc_
+    toHtml_ ::
+      forall m.
+      (MonadState Int m, MonadWriter (Seq (Html ())) m) =>
+      Nat ->
+      Doc ->
+      m (Html ())
+    toHtml_ sectionLevel doc =
+      let -- Make it simple to retain the sectionLevel when recurring.
+          -- the Section variant increments it locally
+          currentSectionLevelToHtml ::
+            (MonadState Int m, MonadWriter (Seq (Html ())) m) =>
+            Doc ->
+            m (Html ())
+          currentSectionLevelToHtml =
+            toHtml_ sectionLevel
 
-                Paragraph _ -> p_ [] $ renderer doc_
+          renderSequence :: (a -> m (Html ())) -> [a] -> m (Html ())
+          renderSequence f xs =
+            sequence_ <$> traverse f xs
 
-                _ ->
-                  renderer doc_
-         in case doc of
-              Word word ->
-                span_ [class_ "word"] (L.toHtml word)
-              Code code ->
-                span_ [class_ "rich source inline-code"] $ inlineCode [] (currentSectionLevelToHtml code)
-              CodeBlock lang code ->
-                div_ [class_ $ "rich source code " <> textToClass lang] $ codeBlock [] (currentSectionLevelToHtml code)
-              Bold d ->
-                strong_ [] $ currentSectionLevelToHtml d
-              Italic d ->
-                span_ [class_ "italic"] $ currentSectionLevelToHtml d
-              Strikethrough d ->
-                span_ [class_ "strikethrough"] $ currentSectionLevelToHtml d
-              Style cssclass_ d ->
-                span_ [class_ $ textToClass cssclass_] $ currentSectionLevelToHtml d
-              Anchor id' d ->
-                a_ [id_ id', href_ $ "#" <> id'] $ currentSectionLevelToHtml d
-              Blockquote d ->
-                blockquote_ [] $ currentSectionLevelToHtml d
-              Blankline ->
-                div_ [] $ do
-                  br_ []
-                  br_ []
-              Linebreak ->
-                br_ []
-              SectionBreak ->
-                hr_ []
-              Tooltip triggerContent tooltipContent ->
-                span_
-                  [class_ "tooltip below arrow-start"]
-                  $ do
-                    span_ [class_ "tooltip-trigger"] $ currentSectionLevelToHtml triggerContent
-                    div_ [class_ "tooltip-bubble", style_ "display: none"] $ currentSectionLevelToHtml tooltipContent
-              Aside d ->
-                span_
-                  [class_ "aside-anchor"]
-                  $ aside_ [] $ currentSectionLevelToHtml d
-              Callout icon content ->
-                let (cls, ico) =
-                      case icon of
-                        Just emoji ->
-                          (class_ "callout callout-with-icon", div_ [class_ "callout-icon"] $ L.toHtml . toText "" $ emoji)
-                        Nothing ->
-                          (class_ "callout", "")
-                 in div_ [cls] $ do
-                      ico
-                      div_ [class_ "callout-content"] $ currentSectionLevelToHtml content
-              Table rows ->
-                let cellToHtml =
-                      td_ [] . currentSectionLevelToHtml
+          sectionContentToHtml ::
+            (MonadState Int m, MonadWriter (Seq (Html ())) m) =>
+            (Doc -> m (Html ())) ->
+            Doc ->
+            m (Html ())
+          sectionContentToHtml renderer doc_ =
+            -- Block elements can't be children for <p> elements
+            case doc_ of
+              Paragraph [CodeBlock {}] -> renderer doc_
+              Paragraph [Blockquote _] -> renderer doc_
+              Paragraph [Blankline] -> renderer doc_
+              Paragraph [SectionBreak] -> renderer doc_
+              Paragraph [Callout {}] -> renderer doc_
+              Paragraph [Table _] -> renderer doc_
+              Paragraph [Folded {}] -> renderer doc_
+              Paragraph [BulletedList _] -> renderer doc_
+              Paragraph [NumberedList {}] -> renderer doc_
+              -- Paragraph [Section _ _] -> renderer doc_
+              Paragraph [Image {}] -> renderer doc_
+              Paragraph [Special (Source _)] -> renderer doc_
+              Paragraph [Special (FoldedSource _)] -> renderer doc_
+              Paragraph [Special (ExampleBlock _)] -> renderer doc_
+              Paragraph [Special (Signature _)] -> renderer doc_
+              Paragraph [Special Eval {}] -> renderer doc_
+              Paragraph [Special (Embed _)] -> renderer doc_
+              Paragraph [UntitledSection ds] ->
+                renderSequence (sectionContentToHtml renderer) ds
+              Paragraph [Column _] -> renderer doc_
+              Paragraph _ -> p_ [] <$> renderer doc_
+              _ ->
+                renderer doc_
+       in case doc of
+            Tooltip triggerContent tooltipContent -> do
+              tooltipNo <- State.get
+              let tooltipId = Text.pack . show $ tooltipId
+              State.put (tooltipNo + 1)
+              tooltip <-
+                div_ [class_ "tooltip-content", id_ ("tooltip-" <> tooltipId)]
+                  <$> currentSectionLevelToHtml tooltipContent
+              Writer.tell (pure tooltip)
 
-                    rowToHtml cells =
-                      tr_ [] $ mapM_ cellToHtml $ mergeWords " " cells
-                 in table_ [] $ tbody_ [] $ mapM_ rowToHtml rows
-              Folded isFolded summary details ->
+              span_
+                [ class_ "tooltip-trigger",
+                  data_ "tooltip-content-id" tooltipId
+                ]
+                <$> currentSectionLevelToHtml triggerContent
+            Word word ->
+              pure $ span_ [class_ "word"] (L.toHtml word)
+            Code code ->
+              span_ [class_ "rich source inline-code"] . inlineCode [] <$> currentSectionLevelToHtml code
+            CodeBlock lang code ->
+              div_ [class_ $ "rich source code " <> textToClass lang] . codeBlock [] <$> currentSectionLevelToHtml code
+            Bold d ->
+              strong_ [] <$> currentSectionLevelToHtml d
+            Italic d ->
+              span_ [class_ "italic"] <$> currentSectionLevelToHtml d
+            Strikethrough d ->
+              span_ [class_ "strikethrough"] <$> currentSectionLevelToHtml d
+            Style cssclass_ d ->
+              span_ [class_ $ textToClass cssclass_] <$> currentSectionLevelToHtml d
+            Anchor id' d ->
+              a_ [id_ id', href_ $ "#" <> id'] <$> currentSectionLevelToHtml d
+            Blockquote d ->
+              blockquote_ [] <$> currentSectionLevelToHtml d
+            Blankline ->
+              pure
+                ( div_ [] $ do
+                    br_ []
+                    br_ []
+                )
+            Linebreak ->
+              pure $ br_ []
+            SectionBreak ->
+              pure $ hr_ []
+            Aside d ->
+              span_
+                [class_ "aside-anchor"]
+                . aside_ []
+                <$> currentSectionLevelToHtml d
+            Callout icon content ->
+              let (cls :: Attribute, ico :: Html ()) =
+                    case icon of
+                      Just emoji ->
+                        ( class_ "callout callout-with-icon",
+                          div_ [class_ "callout-icon"] $ L.toHtml . toText "" $ emoji
+                        )
+                      Nothing ->
+                        (class_ "callout", "")
+               in div_ [cls] <$> do
+                    _ <- pure ico
+                    div_ [class_ "callout-content"] <$> currentSectionLevelToHtml content
+            Table rows ->
+              let cellToHtml c =
+                    td_ [] <$> currentSectionLevelToHtml c
+
+                  rowToHtml cells =
+                    tr_ [] <$> renderSequence cellToHtml (mergeWords " " cells)
+
+                  rows_ =
+                    renderSequence rowToHtml rows
+               in table_ [] . tbody_ [] <$> rows_
+            Folded isFolded summary details -> do
+              summary' <- currentSectionLevelToHtml summary
+              details' <- currentSectionLevelToHtml details
+
+              pure $
                 foldedToHtml [class_ "folded"] $
                   IsFolded
                     isFolded
-                    [currentSectionLevelToHtml summary]
+                    [summary']
                     -- We include the summary in the details slot to make it
                     -- symmetric with code folding, which currently always
                     -- includes the type signature in the details portion
-                    [ div_ [] $ currentSectionLevelToHtml summary,
-                    currentSectionLevelToHtml details
-                    ]
-              Paragraph docs ->
-                case docs of
-                  [d] ->
-                    currentSectionLevelToHtml d
-                  ds ->
-                    span_ [class_ "span"] $ mapM_ currentSectionLevelToHtml $ mergeWords " " ds
-              BulletedList items ->
-                let itemToHtml =
-                      li_ [] . currentSectionLevelToHtml
-                 in ul_ [] $ mapM_ itemToHtml $ mergeWords " " items
-              NumberedList startNum items ->
-                let itemToHtml =
-                      li_ [] . currentSectionLevelToHtml
-                 in ol_ [start_ $ Text.pack $ show startNum] $ mapM_ itemToHtml $ mergeWords " " items
-              Section title docs ->
-                let titleEl =
-                      h sectionLevel $ currentSectionLevelToHtml title
-                 in section_ [] $ sequence_ (titleEl : map (sectionContentToHtml (toHtml_ (sectionLevel + 1))) docs)
-              NamedLink label href ->
-                case normalizeHref docNamesByRef href of
-                  Href h ->
-                    -- Fragments (starting with a #) are links internal to the page
-                    if Text.isPrefixOf "#" h then
-                      a_ [class_ "named-link", href_ h ] $ currentSectionLevelToHtml label
-                    else
-                      a_ [class_ "named-link", href_ h, rel_ "noopener", target_ "_blank"] $ currentSectionLevelToHtml label
-                  DocLinkHref name ->
-                    let href = "/" <> Text.replace "." "/" (Name.toText name) <> ".html"
-                     in a_ [class_ "named-link doc-link", href_ href] $ currentSectionLevelToHtml label
-                  ReferenceHref ref ->
-                    span_ [class_ "named-link", data_ "ref" ref, data_ "ref-type" "term"] $ currentSectionLevelToHtml label
-                  InvalidHref ->
-                    span_ [class_ "named-link invalid-href"] $ currentSectionLevelToHtml label
-              Image altText src caption ->
-                let altAttr =
-                      [alt_ $ toText " " altText]
+                    [div_ [] summary', details']
+            Paragraph docs ->
+              case docs of
+                [d] ->
+                  currentSectionLevelToHtml d
+                ds ->
+                  span_ [class_ "span"] <$> renderSequence currentSectionLevelToHtml (mergeWords " " ds)
+            BulletedList items ->
+              let itemToHtml i =
+                    li_ [] <$> currentSectionLevelToHtml i
+               in ul_ [] <$> renderSequence itemToHtml (mergeWords " " items)
+            NumberedList startNum items ->
+              let itemToHtml i =
+                    li_ [] <$> currentSectionLevelToHtml i
+               in ol_ [start_ $ Text.pack $ show startNum]
+                    <$> renderSequence itemToHtml (mergeWords " " items)
+            Section title docs -> do
+              titleEl <-
+                h sectionLevel <$> currentSectionLevelToHtml title
 
-                    image =
-                      img_ (altAttr ++ [src_ $ toText "" src])
+              docs' <- renderSequence (sectionContentToHtml (toHtml_ (sectionLevel + 1))) docs
 
-                    imageWithCaption c =
-                      div_
-                        [class_ "image-with-caption"]
-                        $ do
-                          image
-                          div_ [class_ "caption"] $ currentSectionLevelToHtml c
-                 in maybe image imageWithCaption caption
-              Special specialForm ->
-                case specialForm of
-                  Source sources ->
-                    let sources' =
-                          mapMaybe
-                            (fmap (foldedToHtmlSource False) . embeddedSource)
-                            sources
-                     in div_ [class_ "folded-sources"] $ sequence_ sources'
-                  FoldedSource sources ->
-                    let sources' =
-                          mapMaybe
-                            (fmap (foldedToHtmlSource True) . embeddedSource)
-                            sources
-                     in div_ [class_ "folded-sources"] $ sequence_ sources'
-                  Example syntax ->
-                    span_ [class_ "source rich example-inline"] $ inlineCode [] (Syntax.toHtml syntax)
-                  ExampleBlock syntax ->
-                    div_ [class_ "source rich example"] $ codeBlock [] (Syntax.toHtml syntax)
-                  Link syntax ->
-                    inlineCode ["rich", "source"] $ Syntax.toHtml syntax
-                  Signature signatures ->
-                    codeBlock
-                      [class_ "rich source signatures"]
-                      ( mapM_
-                          (div_ [class_ "signature"] . Syntax.toHtml)
-                          signatures
-                      )
-                  SignatureInline sig ->
-                    inlineCode ["rich", "source", "signature-inline"] $ Syntax.toHtml sig
-                  Eval source result ->
+              pure $ section_ [] $ titleEl *> docs'
+            NamedLink label href ->
+              case normalizeHref docNamesByRef href of
+                Href h ->
+                  -- Fragments (starting with a #) are links internal to the page
+                  if Text.isPrefixOf "#" h
+                    then a_ [class_ "named-link", href_ h] <$> currentSectionLevelToHtml label
+                    else a_ [class_ "named-link", href_ h, rel_ "noopener", target_ "_blank"] <$> currentSectionLevelToHtml label
+                DocLinkHref name ->
+                  let href = "/" <> Text.replace "." "/" (Name.toText name) <> ".html"
+                   in a_ [class_ "named-link doc-link", href_ href] <$> currentSectionLevelToHtml label
+                ReferenceHref ref ->
+                  span_ [class_ "named-link", data_ "ref" ref, data_ "ref-type" "term"] <$> currentSectionLevelToHtml label
+                InvalidHref ->
+                  span_ [class_ "named-link invalid-href"] <$> currentSectionLevelToHtml label
+            Image altText src caption ->
+              let altAttr =
+                    [alt_ $ toText " " altText]
+
+                  image =
+                    img_ (altAttr ++ [src_ $ toText "" src])
+
+                  imageWithCaption c = do
+                    caption' <- currentSectionLevelToHtml c
+
+                    pure $
+                      div_ [class_ "image-with-caption"] $ do
+                        image
+                        div_ [class_ "caption"] caption'
+               in maybe (pure image) imageWithCaption caption
+            Special specialForm ->
+              case specialForm of
+                Source sources ->
+                  let sources' =
+                        mapMaybe
+                          (fmap (foldedToHtmlSource False) . embeddedSource)
+                          sources
+                   in pure $ div_ [class_ "folded-sources"] $ sequence_ sources'
+                FoldedSource sources ->
+                  let sources' =
+                        mapMaybe
+                          (fmap (foldedToHtmlSource True) . embeddedSource)
+                          sources
+                   in pure $ div_ [class_ "folded-sources"] $ sequence_ sources'
+                Example syntax ->
+                  pure $ span_ [class_ "source rich example-inline"] $ inlineCode [] (Syntax.toHtml syntax)
+                ExampleBlock syntax ->
+                  pure $ div_ [class_ "source rich example"] $ codeBlock [] (Syntax.toHtml syntax)
+                Link syntax ->
+                  pure (inlineCode ["rich", "source"] $ Syntax.toHtml syntax)
+                Signature signatures ->
+                  pure
+                    ( codeBlock
+                        [class_ "rich source signatures"]
+                        ( mapM_
+                            (div_ [class_ "signature"] . Syntax.toHtml)
+                            signatures
+                        )
+                    )
+                SignatureInline sig ->
+                  pure (inlineCode ["rich", "source", "signature-inline"] $ Syntax.toHtml sig)
+                Eval source result ->
+                  pure $
                     div_ [class_ "source rich eval"] $
                       codeBlock [] $
                         div_ [] $ do
@@ -361,7 +420,8 @@ toHtml docNamesByRef document =
                           div_ [class_ "result"] $ do
                             "⧨"
                             div_ [] $ Syntax.toHtml result
-                  EvalInline source result ->
+                EvalInline source result ->
+                  pure $
                     span_ [class_ "source rich eval-inline"] $
                       inlineCode [] $
                         span_ [] $ do
@@ -369,24 +429,22 @@ toHtml docNamesByRef document =
                           span_ [class_ "result"] $ do
                             "⧨"
                             Syntax.toHtml result
-                  Embed syntax ->
-                    div_ [class_ "source rich embed"] $ codeBlock [] (Syntax.toHtml syntax)
-                  EmbedInline syntax ->
-                    span_ [class_ "source rich embed-inline"] $ inlineCode [] (Syntax.toHtml syntax)
-              Join docs ->
-                span_ [class_ "join"] (mapM_ currentSectionLevelToHtml (mergeWords " " docs))
-              UntitledSection docs ->
-                section_ [] (mapM_ (sectionContentToHtml currentSectionLevelToHtml) docs)
-              Column docs ->
-                ul_
-                  [class_ "column"]
-                  ( mapM_
-                      (li_ [] . currentSectionLevelToHtml)
-                      (mergeWords " " docs)
-                  )
-              Group content ->
-                span_ [class_ "group"] $ currentSectionLevelToHtml content
-   in article_ [class_ "unison-doc"] $ toHtml_ 1 document
+                Embed syntax ->
+                  pure $ div_ [class_ "source rich embed"] $ codeBlock [] (Syntax.toHtml syntax)
+                EmbedInline syntax ->
+                  pure $ span_ [class_ "source rich embed-inline"] $ inlineCode [] (Syntax.toHtml syntax)
+            Join docs ->
+              span_ [class_ "join"] <$> renderSequence currentSectionLevelToHtml (mergeWords " " docs)
+            UntitledSection docs ->
+              section_ [] <$> renderSequence (sectionContentToHtml currentSectionLevelToHtml) docs
+            Column docs ->
+              ul_
+                [class_ "column"]
+                <$> renderSequence
+                  (fmap (li_ []) . currentSectionLevelToHtml)
+                  (mergeWords " " docs)
+            Group content ->
+              span_ [class_ "group"] <$> currentSectionLevelToHtml content
 
 -- HELPERS --------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem
Rich tooltips use block elements, which, in the html spec, and in how browsers interpret it, are not allowed inside <p> elements. This results in the browser closing the <p> as soon as it encounters a block element, effectively moving that block element outside of the narrative flow.

## Solution
To fix this, when rendering docs as html, collect the contents of tooltips in a separate collection (using `State` and `Writer`) from the rest of the document, and insert them at the end of the DOM in a hidden div. Each tooltip trigger has a `data-tooltip-content-id` attribute that can be used to render the tooltip in-place when hovering with additional JavaScript.

## Notes
Paired with @pchiusano 