### PR TITLE
Add numbered output to `todo`

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -2264,7 +2264,7 @@ showTodoOutput getPpe patch names0 = do
                <$> fst (TO.todoFrontierDependents todo)
            )
       ppe <- getPpe
-      respond $ TodoOutput ppe todo
+      respondNumbered $ TodoOutput ppe todo
 
 checkTodo :: Patch -> Names -> Action m i v (TO.TodoOutput v Ann)
 checkTodo patch names0 = do

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -91,6 +91,8 @@ data NumberedOutput v
   | ShowDiffAfterCreatePR ReadRemoteNamespace ReadRemoteNamespace PPE.PrettyPrintEnv (BranchDiffOutput v Ann)
   | -- <authorIdentifier> <authorPath> <relativeBase>
     ShowDiffAfterCreateAuthor NameSegment Path.Path' Path.Absolute PPE.PrettyPrintEnv (BranchDiffOutput v Ann)
+  | -- | Invariant: there's at least one conflict or edit in the TodoOutput.
+    TodoOutput PPE.PrettyPrintEnvDecl (TO.TodoOutput v Ann)
   | -- | CantDeleteDefinitions ppe couldntDelete becauseTheseStillReferenceThem
     CantDeleteDefinitions PPE.PrettyPrintEnvDecl (Map LabeledDependency (NESet LabeledDependency))
   | -- | CantDeleteNamespace ppe couldntDelete becauseTheseStillReferenceThem
@@ -178,8 +180,6 @@ data Output v
       PPE.PrettyPrintEnvDecl
       (Map Reference (DisplayObject () (Decl v Ann)))
       (Map Reference (DisplayObject (Type v Ann) (Term v Ann)))
-  | -- | Invariant: there's at least one conflict or edit in the TodoOutput.
-    TodoOutput PPE.PrettyPrintEnvDecl (TO.TodoOutput v Ann)
   | TestIncrementalOutputStart PPE.PrettyPrintEnv (Int, Int) Reference (Term v Ann)
   | TestIncrementalOutputEnd PPE.PrettyPrintEnv (Int, Int) Reference (Term v Ann)
   | TestResults
@@ -323,7 +323,6 @@ isFailure o = case o of
   Typechecked {} -> False
   DisplayDefinitions _ _ m1 m2 -> null m1 && null m2
   DisplayRendered {} -> False
-  TodoOutput _ todo -> TO.todoScore todo > 0 || not (TO.noConflicts todo)
   TestIncrementalOutputStart {} -> False
   TestIncrementalOutputEnd {} -> False
   TestResults _ _ _ _ _ fails -> not (null fails)
@@ -381,6 +380,7 @@ isNumberedFailure = \case
   ShowDiffAfterPull {} -> False
   ShowDiffAfterCreatePR {} -> False
   ShowDiffAfterCreateAuthor {} -> False
+  TodoOutput _ todo -> TO.todoScore todo > 0 || not (TO.noConflicts todo)
   CantDeleteDefinitions {} -> True
   CantDeleteNamespace {} -> True
   DeletedDespiteDependents {} -> False

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1875,7 +1875,7 @@ addNumberedArg s = do
   pure $ (n + 1)
 
 formatNum :: Int -> Pretty
-formatNum n = P.shown n <> ". "
+formatNum n = P.string (show n <> ". ")
 
 runNumbered :: Numbered a -> (a, NumberedArgs)
 runNumbered m =

--- a/unison-src/transcripts/resolve.md
+++ b/unison-src/transcripts/resolve.md
@@ -86,15 +86,15 @@ The namespace `c` now has an edit conflict, since the term `foo` was edited in t
 .example.resolve.c> todo
 ```
 
-We see that `#44954ulpdf` (the original hash of `a.foo`) got replaced with _both_ the `#8e68dvpr0a` and `#jdqoenu794`.
+We see that the original hash of `a.foo` got replaced with _two different_ hashes.
 
 We can resolve this conflict by picking one of the terms as the "winner":
 
 ```ucm
-.example.resolve.c> replace #44954ulpdf #8e68dvpr0a
+.example.resolve.c> replace 1 2
 ```
 
-This changes the merged `c.patch` so that only the edit from #44954ulpdf to  #8e68dvpr0a remains:
+This changes the merged `c.patch` so that only a single edit remains and resolves the conflict.
 
 ```ucm
 .example.resolve.c> view.patch

--- a/unison-src/transcripts/resolve.md
+++ b/unison-src/transcripts/resolve.md
@@ -109,7 +109,7 @@ We still have a remaining _name conflict_ since it just so happened that both of
 We can resolve the name conflict by deleting one of the names.
 
 ```ucm
-.example.resolve.c> delete.term foo#jdqoenu794
+.example.resolve.c> delete.term 2
 .example.resolve.c> todo
 ```
 

--- a/unison-src/transcripts/resolve.output.md
+++ b/unison-src/transcripts/resolve.output.md
@@ -194,8 +194,9 @@ The namespace `c` now has an edit conflict, since the term `foo` was edited in t
   have been merged into this one. You'll have to tell me what to
   use as the new definition:
   
-    The term #44954ulpdf was replaced with foo#8e68dvpr0a and
-    foo#jdqoenu794
+    The term 1. #44954ulpdf was replaced with
+      2. foo#8e68dvpr0a
+      3. foo#jdqoenu794
 
 ```
 We see that `#44954ulpdf` (the original hash of `a.foo`) got replaced with _both_ the `#8e68dvpr0a` and `#jdqoenu794`.
@@ -227,7 +228,7 @@ We still have a remaining _name conflict_ since it just so happened that both of
 
   ❓
   
-  These terms have conflicting definitions: foo
+  These terms have conflicting definitions: 1. foo
   
   Tip: This occurs when merging branches that both independently
        introduce the same name. Use `view foo` to see the

--- a/unison-src/transcripts/resolve.output.md
+++ b/unison-src/transcripts/resolve.output.md
@@ -209,7 +209,6 @@ We can resolve this conflict by picking one of the terms as the "winner":
   Done.
 
 ```
-
 This changes the merged `c.patch` so that only a single edit remains and resolves the conflict.
 
 ```ucm
@@ -229,18 +228,19 @@ We still have a remaining _name conflict_ since it just so happened that both of
 
   ❓
   
-  These terms have conflicting definitions: 1. foo
+  The term foo has conflicting definitions:
+    1. foo#8e68dvpr0a
+    2. foo#jdqoenu794
   
   Tip: This occurs when merging branches that both independently
-       introduce the same name. Use `view foo` to see the
-       conflicting definitions, then use `move.term` to resolve
-       the conflicts.
+       introduce the same name. Use `move.term` or `delete.term`
+       to resolve the conflicts.
 
 ```
 We can resolve the name conflict by deleting one of the names.
 
 ```ucm
-.example.resolve.c> delete.term foo#jdqoenu794
+.example.resolve.c> delete.term 2
 
   Resolved name conflicts:
   

--- a/unison-src/transcripts/resolve.output.md
+++ b/unison-src/transcripts/resolve.output.md
@@ -199,17 +199,18 @@ The namespace `c` now has an edit conflict, since the term `foo` was edited in t
       3. foo#jdqoenu794
 
 ```
-We see that `#44954ulpdf` (the original hash of `a.foo`) got replaced with _both_ the `#8e68dvpr0a` and `#jdqoenu794`.
+We see that the original hash of `a.foo` got replaced with _two different_ hashes.
 
 We can resolve this conflict by picking one of the terms as the "winner":
 
 ```ucm
-.example.resolve.c> replace #44954ulpdf #8e68dvpr0a
+.example.resolve.c> replace 1 2
 
   Done.
 
 ```
-This changes the merged `c.patch` so that only the edit from #44954ulpdf to  #8e68dvpr0a remains:
+
+This changes the merged `c.patch` so that only a single edit remains and resolves the conflict.
 
 ```ucm
 .example.resolve.c> view.patch

--- a/unison-src/transcripts/todo.md
+++ b/unison-src/transcripts/todo.md
@@ -1,0 +1,72 @@
+# Test the `todo` command
+
+## Simple type-changing update.
+
+```ucm:hide
+.> builtins.mergeio
+```
+
+```unison:hide
+x = 1
+useX = x + 10
+
+structural type MyType = MyType Nat
+useMyType = match MyType 1 with
+  MyType a -> a + 10
+```
+
+```ucm:hide
+.simple> add
+```
+
+Perform a type-changing update so dependents are added to our update frontier.
+
+```unison:hide
+x = -1
+
+structural type MyType = MyType Text
+```
+
+```ucm:error
+.simple> update
+.simple> todo
+```
+
+## A merge with conflicting updates.
+
+```unison:hide
+x = 1
+structural type MyType = MyType
+```
+
+Set up two branches with the same starting point.
+
+```ucm:hide
+.mergeA> add
+.> fork .mergeA .mergeB
+```
+
+Update `x` to a different term in each branch.
+
+```unison:hide
+x = 2
+structural type MyType = MyType Nat
+```
+
+```ucm:hide
+.mergeA> update
+```
+
+```unison:hide
+x = 3
+structural type MyType = MyType Int
+```
+
+```ucm:hide
+.mergeB> update
+```
+
+```ucm:error
+.mergeA> merge .mergeB
+.mergeA> todo
+```

--- a/unison-src/transcripts/todo.output.md
+++ b/unison-src/transcripts/todo.output.md
@@ -1,0 +1,130 @@
+# Test the `todo` command
+
+## Simple type-changing update.
+
+```unison
+x = 1
+useX = x + 10
+
+structural type MyType = MyType Nat
+useMyType = match MyType 1 with
+  MyType a -> a + 10
+```
+
+Perform a type-changing update so dependents are added to our update frontier.
+
+```unison
+x = -1
+
+structural type MyType = MyType Text
+```
+
+```ucm
+.simple> update
+
+  ⍟ I've updated these names to your new definition:
+  
+    structural type MyType
+    x : Int
+
+.simple> todo
+
+  🚧
+  
+  The namespace has 2 transitive dependent(s) left to upgrade.
+  Your edit frontier is the dependents of these definitions:
+  
+    structural type MyType#d97e0jhkmd
+    x#jk19sm5bf8 : Nat
+  
+  I recommend working on them in the following order:
+  
+  1. useMyType : Nat
+  2. useX      : Nat
+  
+  
+
+```
+## A merge with conflicting updates.
+
+```unison
+x = 1
+structural type MyType = MyType
+```
+
+Set up two branches with the same starting point.
+
+Update `x` to a different term in each branch.
+
+```unison
+x = 2
+structural type MyType = MyType Nat
+```
+
+```unison
+x = 3
+structural type MyType = MyType Int
+```
+
+```ucm
+.mergeA> merge .mergeB
+
+  Here's what's changed in the current namespace after the
+  merge:
+  
+  New name conflicts:
+  
+    1.  structural type MyType#d97e0jhkmd
+           
+        ↓
+    2.  ┌ structural type MyType#d97e0jhkmd
+             
+    3.  └ structural type MyType#muulibntaq
+             
+    
+    4.  MyType.MyType#d97e0jhkmd#0 : Nat -> MyType#d97e0jhkmd
+        ↓
+    5.  ┌ MyType.MyType#d97e0jhkmd#0 : Nat -> MyType#d97e0jhkmd
+    6.  └ MyType.MyType#muulibntaq#0 : Int -> MyType#muulibntaq
+    
+    7.  x#0ja1qfpej6 : Nat
+        ↓
+    8.  ┌ x#0ja1qfpej6 : Nat
+    9.  └ x#msp7bv40rv : Nat
+  
+  Updates:
+  
+    10. patch patch (added 2 updates)
+  
+  Tip: You can use `todo` to see if this generated any work to
+       do in this namespace and `test` to run the tests. Or you
+       can use `undo` or `reflog` to undo the results of this
+       merge.
+
+  I tried to auto-apply the patch, but couldn't because it
+  contained contradictory entries.
+
+.mergeA> todo
+
+  ❓
+  
+  These definitions were edited differently in namespaces that
+  have been merged into this one. You'll have to tell me what to
+  use as the new definition:
+  
+    The type 1. .builtin.Unit was replaced with
+      2. MyType#d97e0jhkmd
+      3. MyType#muulibntaq
+    The term 4. #jk19sm5bf8 was replaced with
+      5. x#0ja1qfpej6
+      6. x#msp7bv40rv
+  ❓
+  
+  These terms have conflicting definitions: 7. MyType.MyType
+  
+  Tip: This occurs when merging branches that both independently
+       introduce the same name. Use `view MyType.MyType` to see
+       the conflicting definitions, then use `move.term` to
+       resolve the conflicts.
+
+```

--- a/unison-src/transcripts/todo.output.md
+++ b/unison-src/transcripts/todo.output.md
@@ -120,11 +120,12 @@ structural type MyType = MyType Int
       6. x#msp7bv40rv
   ❓
   
-  These terms have conflicting definitions: 7. MyType.MyType
+  The term MyType.MyType has conflicting definitions:
+    7. MyType.MyType#d97e0jhkmd#0
+    8. MyType.MyType#muulibntaq#0
   
   Tip: This occurs when merging branches that both independently
-       introduce the same name. Use `view MyType.MyType` to see
-       the conflicting definitions, then use `move.term` to
-       resolve the conflicts.
+       introduce the same name. Use `move.term` or `delete.term`
+       to resolve the conflicts.
 
 ```


### PR DESCRIPTION
fixes #2870

## Overview

* Adds numbered output to the `todo` command
* Adds a transcript for testing the `todo` command
* Changes `resolve.md` to not rely on hashes.
* Adds formatted conflicts to output of `todo`.

It got a bit hairy to thread everything through, I recommend reading the **transcript output** to see what you think of the new output.

## Test coverage

Added a new `todo.md` transcript with a bunch of examples.