### PR TITLE
'Linearize' quantified ability variables for better inference

### DIFF
--- a/unison-src/transcripts/fix2423.md
+++ b/unison-src/transcripts/fix2423.md
@@ -1,0 +1,31 @@
+```ucm:hide
+.> builtins.merge
+```
+
+```unison
+structural ability Split where
+  skip! : x
+  both : a -> a -> a
+
+Split.append : '{Split, g} a -> '{Split, g} a -> '{Split, g} a 
+Split.append s1 s2 _ = force (both s1 s2)
+
+force a = !a
+
+Split.zipSame : '{Split, g} a -> '{Split, g} b -> '{Split, g} (a, b)
+Split.zipSame sa sb _ = 
+  go : '{Split,g2} y -> Request {Split} x ->{Split,g2} (x,y)
+  go sb = cases
+    { a } -> (a, !sb)
+    { skip! -> _ } -> skip!
+    { both la ra -> k } -> 
+      handle !sb with cases
+        { _ } -> skip!
+        { skip! -> k } -> skip!
+        { both lb rb -> k2 } -> 
+          force (Split.append
+            (zipSame '(k la) '(k2 lb))
+             (zipSame '(k ra) '(k2 rb)))
+
+  handle !sa with go sb
+```

--- a/unison-src/transcripts/fix2423.output.md
+++ b/unison-src/transcripts/fix2423.output.md
@@ -1,0 +1,46 @@
+```unison
+structural ability Split where
+  skip! : x
+  both : a -> a -> a
+
+Split.append : '{Split, g} a -> '{Split, g} a -> '{Split, g} a 
+Split.append s1 s2 _ = force (both s1 s2)
+
+force a = !a
+
+Split.zipSame : '{Split, g} a -> '{Split, g} b -> '{Split, g} (a, b)
+Split.zipSame sa sb _ = 
+  go : '{Split,g2} y -> Request {Split} x ->{Split,g2} (x,y)
+  go sb = cases
+    { a } -> (a, !sb)
+    { skip! -> _ } -> skip!
+    { both la ra -> k } -> 
+      handle !sb with cases
+        { _ } -> skip!
+        { skip! -> k } -> skip!
+        { both lb rb -> k2 } -> 
+          force (Split.append
+            (zipSame '(k la) '(k2 lb))
+             (zipSame '(k ra) '(k2 rb)))
+
+  handle !sa with go sb
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      structural ability Split
+      Split.append  : '{g, Split} a
+                      -> '{g, Split} a
+                      -> '{g, Split} a
+      Split.zipSame : '{g, Split} a
+                      -> '{g, Split} b
+                      -> '{g, Split} (a, b)
+      force         : '{g} o ->{g} o
+
+```

--- a/unison-src/transcripts/fix2712.md
+++ b/unison-src/transcripts/fix2712.md
@@ -16,7 +16,7 @@ mapWithKey f m = Tip
 ```unison
 
 naiomi = 
-  susan: Nat ->{} Nat -> ()
+  susan: Nat -> Nat -> ()
   susan a b = ()
   
   pam: Map Nat Nat
@@ -24,15 +24,4 @@ naiomi =
   
   mapWithKey susan pam
   
-```
-
-```ucm
-.> add
-.> edit naiomi
-.> undo
-```
-
-```ucm
-.> load scratch.u
-.> add
 ```

--- a/unison-src/transcripts/fix2712.md
+++ b/unison-src/transcripts/fix2712.md
@@ -1,0 +1,38 @@
+```ucm:hide
+.> builtins.merge
+```
+
+```unison
+unique type Map k v = Tip | Bin Nat k v (Map k v) (Map k v)
+
+mapWithKey : (k ->{e} a ->{e} b) -> Map k a ->{e} Map k b
+mapWithKey f m = Tip
+```
+
+```ucm
+.> add
+```
+
+```unison
+
+naiomi = 
+  susan: Nat ->{} Nat -> ()
+  susan a b = ()
+  
+  pam: Map Nat Nat
+  pam = Tip
+  
+  mapWithKey susan pam
+  
+```
+
+```ucm
+.> add
+.> edit naiomi
+.> undo
+```
+
+```ucm
+.> load scratch.u
+.> add
+```

--- a/unison-src/transcripts/fix2712.output.md
+++ b/unison-src/transcripts/fix2712.output.md
@@ -28,7 +28,7 @@ mapWithKey f m = Tip
 ```
 ```unison
 naiomi = 
-  susan: Nat ->{} Nat -> ()
+  susan: Nat -> Nat -> ()
   susan a b = ()
   
   pam: Map Nat Nat
@@ -47,57 +47,5 @@ naiomi =
     ⍟ These new definitions are ok to `add`:
     
       naiomi : Map Nat ()
-
-```
-```ucm
-.> add
-
-  ⍟ I've added these definitions:
-  
-    naiomi : Map Nat ()
-
-.> edit naiomi
-
-  ☝️
-  
-  I added these definitions to the top of
-  /home/dolio/Programming/unison/bugfixing/scratch.u
-  
-    naiomi : Map Nat ()
-    naiomi =
-      susan : Nat -> Nat -> ()
-      susan a b = ()
-      pam : Map Nat Nat
-      pam = Tip
-      mapWithKey susan pam
-  
-  You can edit them there, then do `update` to replace the
-  definitions currently in this namespace.
-
-.> undo
-
-  Here are the changes I undid
-  
-  Added definitions:
-  
-    1. naiomi : Map Nat ()
-
-```
-```ucm
-.> load scratch.u
-
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-  
-    ⍟ These new definitions are ok to `add`:
-    
-      naiomi : Map Nat ()
-
-.> add
-
-  ⍟ I've added these definitions:
-  
-    naiomi : Map Nat ()
 
 ```

--- a/unison-src/transcripts/fix2712.output.md
+++ b/unison-src/transcripts/fix2712.output.md
@@ -1,0 +1,103 @@
+```unison
+unique type Map k v = Tip | Bin Nat k v (Map k v) (Map k v)
+
+mapWithKey : (k ->{e} a ->{e} b) -> Map k a ->{e} Map k b
+mapWithKey f m = Tip
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique type Map k v
+      mapWithKey : (k ->{e} a ->{e} b) -> Map k a ->{e} Map k b
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    unique type Map k v
+    mapWithKey : (k ->{e} a ->{e} b) -> Map k a ->{e} Map k b
+
+```
+```unison
+naiomi = 
+  susan: Nat ->{} Nat -> ()
+  susan a b = ()
+  
+  pam: Map Nat Nat
+  pam = Tip
+  
+  mapWithKey susan pam
+  
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      naiomi : Map Nat ()
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    naiomi : Map Nat ()
+
+.> edit naiomi
+
+  ☝️
+  
+  I added these definitions to the top of
+  /home/dolio/Programming/unison/bugfixing/scratch.u
+  
+    naiomi : Map Nat ()
+    naiomi =
+      susan : Nat -> Nat -> ()
+      susan a b = ()
+      pam : Map Nat Nat
+      pam = Tip
+      mapWithKey susan pam
+  
+  You can edit them there, then do `update` to replace the
+  definitions currently in this namespace.
+
+.> undo
+
+  Here are the changes I undid
+  
+  Added definitions:
+  
+    1. naiomi : Map Nat ()
+
+```
+```ucm
+.> load scratch.u
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      naiomi : Map Nat ()
+
+.> add
+
+  ⍟ I've added these definitions:
+  
+    naiomi : Map Nat ()
+
+```

--- a/unison-src/transcripts/old-fold-right.md
+++ b/unison-src/transcripts/old-fold-right.md
@@ -1,0 +1,17 @@
+```ucm:hide
+.> builtins.merge
+```
+
+```unison
+oldRight: (b ->{e} a ->{e} b) -> [a] ->{e} [b]
+oldRight f la = bug "out"
+
+pecan: '{} [Text]
+pecan = 'let
+  la = [1, 2, 3]
+  f: Text -> Nat -> Text
+  f = bug "out"
+
+  oldRight f la
+```
+

--- a/unison-src/transcripts/old-fold-right.output.md
+++ b/unison-src/transcripts/old-fold-right.output.md
@@ -1,0 +1,25 @@
+```unison
+oldRight: (b ->{e} a ->{e} b) -> [a] ->{e} [b]
+oldRight f la = bug "out"
+
+pecan: '{} [Text]
+pecan = 'let
+  la = [1, 2, 3]
+  f: Text -> Nat -> Text
+  f = bug "out"
+
+  oldRight f la
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      oldRight : (b ->{e} a ->{e} b) -> [a] ->{e} [b]
+      pecan    : '[Text]
+
+```


### PR DESCRIPTION
This inserts some processing when ungeneralizing types that should lead to better inference with the newer ability algorithm. It rewrites types like:

    (a ->{e} b ->{e} c) ->{e} d

to:

    (a ->{e1} b ->{e2} c) ->{e1,e2} d

which behave a bit better. These types are inter-convertible (set all variables to `e` for one direction, and instantiate `e` to the whole row and use subtyping for the other), but the latter avoids some issues when inferring types involving higher-order functions.