### PR TITLE
Don't use `!` syntax for ctor application (`Any ()` and `Some ()`, not `!Any` or `!Some`)

### DIFF
--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -327,12 +327,17 @@ pretty0
 
     t -> l "error: " <> l (show t)
  where
+  goNormal prec tm = pretty0 n (ac prec Normal im doc) tm     
   specialCases term _go | Just p <- prettyDoc2 n a term = p
   specialCases term go = case (term, binaryOpsPred) of
     (DD.Doc, _) | doc == MaybeDoc ->
       if isDocLiteral term
       then prettyDoc n im term
       else pretty0 n (a {docContext = NoDoc}) term
+    (App' f@(Builtin' "Any.Any") arg, _) ->   
+      paren (p >= 10) $ goNormal 9 f `PP.hang` goNormal 10 arg
+    (Apps' f@(Constructor' _) args, _) ->   
+      paren (p >= 10) $ goNormal 9 f `PP.hang` PP.spacedMap (goNormal 10) args
     (TupleTerm' [x], _) ->
       let
           conRef = DD.pairCtorRef

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -334,10 +334,6 @@ pretty0
       if isDocLiteral term
       then prettyDoc n im term
       else pretty0 n (a {docContext = NoDoc}) term
-    (App' f@(Builtin' "Any.Any") arg, _) ->   
-      paren (p >= 10) $ goNormal 9 f `PP.hang` goNormal 10 arg
-    (Apps' f@(Constructor' _) args, _) ->   
-      paren (p >= 10) $ goNormal 9 f `PP.hang` PP.spacedMap (goNormal 10) args
     (TupleTerm' [x], _) ->
       let
           conRef = DD.pairCtorRef
@@ -350,7 +346,10 @@ pretty0
     (TupleTerm' xs, _) ->
       let tupleLink p = fmt (S.TypeReference DD.unitRef) p
       in PP.group (tupleLink "(" <> commaList xs <> tupleLink ")")
-
+    (App' f@(Builtin' "Any.Any") arg, _) ->   
+      paren (p >= 10) $ goNormal 9 f `PP.hang` goNormal 10 arg
+    (Apps' f@(Constructor' _) args, _) ->   
+      paren (p >= 10) $ goNormal 9 f `PP.hang` PP.spacedMap (goNormal 10) args
     (Bytes' bs, _) ->
       fmt S.BytesLiteral "0xs" <> (PP.shown $ Bytes.fromWord8s (map fromIntegral bs))
     BinaryAppsPred' apps lastArg -> paren (p >= 3) $

--- a/parser-typechecker/src/Unison/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/TermPrinter.hs
@@ -258,7 +258,7 @@ pretty0
     List' xs -> PP.group $
       (fmt S.DelimiterChar $ l "[") <> optSpace
           <> intercalateMap ((fmt S.DelimiterChar $ l ",") <> PP.softbreak <> optSpace <> optSpace)
-                            (pretty0 n (ac 0 Normal im doc))
+                            (PP.indentNAfterNewline 2 . pretty0 n (ac 0 Normal im doc))
                             xs
           <> optSpace <> (fmt S.DelimiterChar $ l "]")
       where optSpace = PP.orElse "" " "

--- a/unison-src/transcripts-round-trip/main.md
+++ b/unison-src/transcripts-round-trip/main.md
@@ -354,3 +354,22 @@ foo = let
 .> load unison-src/transcripts-round-trip/nested.u
 ```
 
+## Multiline expressions in multiliine lists
+
+```unison:hide
+foo a b c d e f g h i j = 42 
+
+use Nat +
+x = [ 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
+    , foo 12939233 2102020 329292 429292 522020 62929292 72020202 820202 920202 1020202 ] 
+```
+
+```ucm
+.> add
+.> edit foo x
+.> undo
+```
+
+```ucm
+.> load scratch.u
+```

--- a/unison-src/transcripts-using-base/doc.output.md
+++ b/unison-src/transcripts-using-base/doc.output.md
@@ -494,16 +494,16 @@ and the rendered output using `display`:
     {{
     docTable
       [ [ {{
-      a
-      }},
-        {{
-      b
-      }},
-        {{
-      A longer paragraph that will split onto multiple lines,
-      such that this row occupies multiple lines in the rendered
-      table.
-      }} ],
+          a
+          }},
+          {{
+          b
+          }},
+          {{
+          A longer paragraph that will split onto multiple
+          lines, such that this row occupies multiple lines in
+          the rendered table.
+          }} ],
         [{{ Some text }}, {{ More text }}, {{ Zounds! }}] ] }}
     }}
 

--- a/unison-src/transcripts-using-base/fix2027.output.md
+++ b/unison-src/transcripts-using-base/fix2027.output.md
@@ -90,7 +90,7 @@ myServer = unsafeRun! '(hello "127.0.0.1" "0")
   I've encountered a call to builtin.bug with the following
   value:
   
-    Failure (typeLink IOFailure) "problem" !Any
+    Failure (typeLink IOFailure) "problem" (Any ())
   
   I'm sorry this message doesn't have more detail about the
   location of the failure. My makers plan to fix this in a

--- a/unison-src/transcripts/bug-strange-closure.output.md
+++ b/unison-src/transcripts/bug-strange-closure.output.md
@@ -2827,15 +2827,13 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                                     ()
                                     (Left
                                       (SpecialForm.Source
-                                        [ Cons
-                                            (Left
-                                              (typeLink Optional))
-                                            (Cons [] ()),
-                                          Cons
-                                            (Right
-                                              (Term.Term
-                                                (Any (_ -> sqr))))
-                                            (Cons [] ()) ]))))),
+                                        [ (Left
+                                            (typeLink Optional),
+                                          []),
+                                          (Right
+                                            (Term.Term
+                                              (Any (_ -> sqr))),
+                                          []) ]))))),
                             Lit () (Right (Plain "\n")),
                             Lit () (Right (Plain "\n")),
                             Indent
@@ -2884,15 +2882,13 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                                     ()
                                     (Left
                                       (FoldedSource
-                                        [ Cons
-                                            (Left
-                                              (typeLink Optional))
-                                            (Cons [] ()),
-                                          Cons
-                                            (Right
-                                              (Term.Term
-                                                (Any (_ -> sqr))))
-                                            (Cons [] ()) ]))))),
+                                        [ (Left
+                                            (typeLink Optional),
+                                          []),
+                                          (Right
+                                            (Term.Term
+                                              (Any (_ -> sqr))),
+                                          []) ]))))),
                             Lit () (Right (Plain "\n")),
                             Lit () (Right (Plain "\n")),
                             Indent

--- a/unison-src/transcripts/bug-strange-closure.output.md
+++ b/unison-src/transcripts/bug-strange-closure.output.md
@@ -860,1954 +860,3499 @@ rendered = Pretty.get (docFormatConsole doc.guide)
 
     3 | > rendered
           ⧩
-          !Annotated.Group
-            (!Annotated.Append
-              [ !Indent
-                (!Lit (Right (Plain "# ")))
-                (!Lit (Right (Plain "  ")))
-                (!Annotated.Group
-                  (!Wrap
-                    (!Annotated.Append
-                      [ !Lit
-                        (Right
-                          (ConsoleText.Bold (Plain "Unison"))),
-                        !Lit
-                        (Right
-                          (ConsoleText.Bold (Plain "computable"))),
-                        !Lit
-                        (Right
-                          (ConsoleText.Bold
-                            (Plain "documentation"))) ]))),
-                !Lit (Right (Plain "\n")),
-                !Lit (Right (Plain "\n")),
-                !Indent
-                (!Lit (Right (Plain "  ")))
-                (!Lit (Right (Plain "  ")))
-                (!Annotated.Group
-                  (!Wrap
-                    (!Annotated.Group
-                      (!Annotated.Append
-                        [ !Indent
-                          (!Lit (Right (Plain "# ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Wrap
-                              (!Annotated.Append
-                                [ !Lit
-                                  (Right
-                                    (ConsoleText.Bold
-                                      (Plain "Basic"))),
-                                  !Lit
-                                  (Right
-                                    (ConsoleText.Bold
-                                      (Plain "formatting"))) ]))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Wrap
-                              (!Annotated.Append
-                                [ !Lit
-                                  (Right (Plain "Paragraphs")),
-                                  !Lit (Right (Plain "are")),
-                                  !Lit
-                                  (Right (Plain "separated")),
-                                  !Lit (Right (Plain "by")),
-                                  !Lit (Right (Plain "one")),
-                                  !Lit (Right (Plain "or")),
-                                  !Lit (Right (Plain "more")),
-                                  !Lit
-                                  (Right (Plain "blanklines.")),
-                                  !Lit
-                                  (Right (Plain "Sections")),
-                                  !Lit (Right (Plain "have")),
-                                  !Lit (Right (Plain "a")),
-                                  !Lit (Right (Plain "title")),
-                                  !Lit (Right (Plain "and")),
-                                  !Lit (Right (Plain "0")),
-                                  !Lit (Right (Plain "or")),
-                                  !Lit (Right (Plain "more")),
-                                  !Lit
-                                  (Right (Plain "paragraphs")),
-                                  !Lit (Right (Plain "or")),
-                                  !Lit (Right (Plain "other")),
-                                  !Lit (Right (Plain "section")),
-                                  !Lit
-                                  (Right (Plain "elements.")) ]))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Wrap
-                              (!Annotated.Append
-                                [ !Lit (Right (Plain "Text")),
-                                  !Lit (Right (Plain "can")),
-                                  !Lit (Right (Plain "be")),
-                                  !Annotated.Group
-                                  (!Annotated.Append
-                                    [ !Wrap
-                                      (!Lit
+          Annotated.Group
+            ()
+            (Annotated.Append
+              ()
+              [ Indent
+                  ()
+                  (Lit () (Right (Plain "# ")))
+                  (Lit () (Right (Plain "  ")))
+                  (Annotated.Group
+                    ()
+                    (Wrap
+                      ()
+                      (Annotated.Append
+                        ()
+                        [ Lit
+                            ()
+                            (Right
+                              (ConsoleText.Bold (Plain "Unison"))),
+                          Lit
+                            ()
+                            (Right
+                              (ConsoleText.Bold
+                                (Plain "computable"))),
+                          Lit
+                            ()
+                            (Right
+                              (ConsoleText.Bold
+                                (Plain "documentation"))) ]))),
+                Lit () (Right (Plain "\n")),
+                Lit () (Right (Plain "\n")),
+                Indent
+                  ()
+                  (Lit () (Right (Plain "  ")))
+                  (Lit () (Right (Plain "  ")))
+                  (Annotated.Group
+                    ()
+                    (Wrap
+                      ()
+                      (Annotated.Group
+                        ()
+                        (Annotated.Append
+                          ()
+                          [ Indent
+                              ()
+                              (Lit () (Right (Plain "# ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Wrap
+                                  ()
+                                  (Annotated.Append
+                                    ()
+                                    [ Lit
+                                        ()
                                         (Right
                                           (ConsoleText.Bold
-                                            (Plain "bold")))),
-                                      !Lit (Right (Plain ",")) ]),
-                                  !Annotated.Group
-                                  (!Annotated.Append
-                                    [ !Annotated.Group
-                                      (!Annotated.Append
-                                        [ !Lit
-                                          (Right (Plain "*")),
-                                          !Wrap
-                                          (!Lit
-                                            (Right
-                                              (Plain
-                                                "italicized"))),
-                                          !Lit
-                                          (Right (Plain "*")) ]),
-                                      !Lit (Right (Plain ",")) ]),
-                                  !Annotated.Group
-                                  (!Annotated.Append
-                                    [ !Annotated.Group
-                                      (!Annotated.Append
-                                        [ !Lit
-                                          (Right (Plain "~~")),
-                                          !Wrap
-                                          (!Lit
-                                            (Right
-                                              (Plain
-                                                "strikethrough"))),
-                                          !Lit
-                                          (Right (Plain "~~")) ]),
-                                      !Lit (Right (Plain ",")) ]),
-                                  !Lit (Right (Plain "or")),
-                                  !Annotated.Group
-                                  (!Annotated.Append
-                                    [ !Annotated.Group
-                                      (!Annotated.Append
-                                        [ !Lit
-                                          (Right (Plain "`")),
-                                          !Lit
-                                          (Right
-                                            (Plain "monospaced")),
-                                          !Lit
-                                          (Right (Plain "`")) ]),
-                                      !Lit (Right (Plain ".")) ]) ]))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Wrap
-                              (!Annotated.Append
-                                [ !Lit (Right (Plain "You")),
-                                  !Lit (Right (Plain "can")),
-                                  !Lit (Right (Plain "link")),
-                                  !Lit (Right (Plain "to")),
-                                  !Lit (Right (Plain "Unison")),
-                                  !Lit (Right (Plain "terms,")),
-                                  !Lit (Right (Plain "types,")),
-                                  !Lit (Right (Plain "and")),
-                                  !Lit
-                                  (Right (Plain "external")),
-                                  !Lit (Right (Plain "URLs:")) ]))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Annotated.Group
-                              (!Annotated.Append
-                                [ !Indent
-                                  (!Lit (Right (Plain "* ")))
-                                  (!Lit (Right (Plain "  ")))
-                                  (!Wrap
-                                    (!Wrap
-                                      (!Annotated.Append
-                                        [ !Lit
-                                          (Right
-                                            (Underline
-                                              (Plain "An"))),
-                                          !Lit
-                                          (Right
-                                            (Underline
-                                              (Plain "external"))),
-                                          !Lit
-                                          (Right
-                                            (Underline
-                                              (Plain "url"))) ]))),
-                                  !Lit (Right (Plain "\n")),
-                                  !Indent
-                                  (!Lit (Right (Plain "* ")))
-                                  (!Lit (Right (Plain "  ")))
-                                  (!Wrap
-                                    (!Annotated.Append
-                                      [ !Lit
+                                            (Plain "Basic"))),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (ConsoleText.Bold
+                                            (Plain "formatting"))) ]))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Wrap
+                                  ()
+                                  (Annotated.Append
+                                    ()
+                                    [ Lit
+                                        ()
+                                        (Right
+                                          (Plain "Paragraphs")),
+                                      Lit
+                                        () (Right (Plain "are")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "separated")),
+                                      Lit
+                                        () (Right (Plain "by")),
+                                      Lit
+                                        () (Right (Plain "one")),
+                                      Lit
+                                        () (Right (Plain "or")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "more")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "blanklines.")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "Sections")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "have")),
+                                      Lit () (Right (Plain "a")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "title")),
+                                      Lit
+                                        () (Right (Plain "and")),
+                                      Lit () (Right (Plain "0")),
+                                      Lit
+                                        () (Right (Plain "or")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "more")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "paragraphs")),
+                                      Lit
+                                        () (Right (Plain "or")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "other")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "section")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "elements.")) ]))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Wrap
+                                  ()
+                                  (Annotated.Append
+                                    ()
+                                    [ Lit
+                                        ()
+                                        (Right (Plain "Text")),
+                                      Lit
+                                        () (Right (Plain "can")),
+                                      Lit
+                                        () (Right (Plain "be")),
+                                      Annotated.Group
+                                        ()
+                                        (Annotated.Append
+                                          ()
+                                          [ Wrap
+                                              ()
+                                              (Lit
+                                                ()
+                                                (Right
+                                                  (ConsoleText.Bold
+                                                    (Plain
+                                                      "bold")))),
+                                            Lit
+                                              ()
+                                              (Right (Plain ",")) ]),
+                                      Annotated.Group
+                                        ()
+                                        (Annotated.Append
+                                          ()
+                                          [ Annotated.Group
+                                              ()
+                                              (Annotated.Append
+                                                ()
+                                                [ Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain "*")),
+                                                  Wrap
+                                                    ()
+                                                    (Lit
+                                                      ()
+                                                      (Right
+                                                        (Plain
+                                                          "italicized"))),
+                                                  Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain "*")) ]),
+                                            Lit
+                                              ()
+                                              (Right (Plain ",")) ]),
+                                      Annotated.Group
+                                        ()
+                                        (Annotated.Append
+                                          ()
+                                          [ Annotated.Group
+                                              ()
+                                              (Annotated.Append
+                                                ()
+                                                [ Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "~~")),
+                                                  Wrap
+                                                    ()
+                                                    (Lit
+                                                      ()
+                                                      (Right
+                                                        (Plain
+                                                          "strikethrough"))),
+                                                  Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "~~")) ]),
+                                            Lit
+                                              ()
+                                              (Right (Plain ",")) ]),
+                                      Lit
+                                        () (Right (Plain "or")),
+                                      Annotated.Group
+                                        ()
+                                        (Annotated.Append
+                                          ()
+                                          [ Annotated.Group
+                                              ()
+                                              (Annotated.Append
+                                                ()
+                                                [ Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain "`")),
+                                                  Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "monospaced")),
+                                                  Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain "`")) ]),
+                                            Lit
+                                              ()
+                                              (Right (Plain ".")) ]) ]))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Wrap
+                                  ()
+                                  (Annotated.Append
+                                    ()
+                                    [ Lit
+                                        () (Right (Plain "You")),
+                                      Lit
+                                        () (Right (Plain "can")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "link")),
+                                      Lit
+                                        () (Right (Plain "to")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "Unison")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "terms,")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "types,")),
+                                      Lit
+                                        () (Right (Plain "and")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "external")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "URLs:")) ]))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Annotated.Group
+                                  ()
+                                  (Annotated.Append
+                                    ()
+                                    [ Indent
+                                        ()
+                                        (Lit
+                                          ()
+                                          (Right (Plain "* ")))
+                                        (Lit
+                                          ()
+                                          (Right (Plain "  ")))
+                                        (Wrap
+                                          ()
+                                          (Wrap
+                                            ()
+                                            (Annotated.Append
+                                              ()
+                                              [ Lit
+                                                  ()
+                                                  (Right
+                                                    (Underline
+                                                      (Plain
+                                                        "An"))),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Underline
+                                                      (Plain
+                                                        "external"))),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Underline
+                                                      (Plain
+                                                        "url"))) ]))),
+                                      Lit
+                                        () (Right (Plain "\n")),
+                                      Indent
+                                        ()
+                                        (Lit
+                                          ()
+                                          (Right (Plain "* ")))
+                                        (Lit
+                                          ()
+                                          (Right (Plain "  ")))
+                                        (Wrap
+                                          ()
+                                          (Annotated.Append
+                                            ()
+                                            [ Lit
+                                                ()
+                                                (Left
+                                                  (SpecialForm.Link
+                                                    (Right
+                                                      (Term.Term
+                                                        (Any
+                                                          (_ ->
+                                                            Some)))))),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain "is")),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain "a")),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain "term")),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain "link;")),
+                                              Lit
+                                                ()
+                                                (Left
+                                                  (SpecialForm.Link
+                                                    (Left
+                                                      (typeLink Optional)))),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain "is")),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain "a")),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain "type")),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain "link")) ])),
+                                      Lit
+                                        () (Right (Plain "\n")),
+                                      Indent
+                                        ()
+                                        (Lit
+                                          ()
+                                          (Right (Plain "* ")))
+                                        (Lit
+                                          ()
+                                          (Right (Plain "  ")))
+                                        (Wrap
+                                          ()
+                                          (Annotated.Append
+                                            ()
+                                            [ Wrap
+                                                ()
+                                                (Annotated.Append
+                                                  ()
+                                                  [ Lit
+                                                      ()
+                                                      (Right
+                                                        (Underline
+                                                          (Plain
+                                                            "A"))),
+                                                    Lit
+                                                      ()
+                                                      (Right
+                                                        (Underline
+                                                          (Plain
+                                                            "named"))),
+                                                    Lit
+                                                      ()
+                                                      (Right
+                                                        (Underline
+                                                          (Plain
+                                                            "type"))),
+                                                    Lit
+                                                      ()
+                                                      (Right
+                                                        (Underline
+                                                          (Plain
+                                                            "link"))) ]),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain "and")),
+                                              Annotated.Group
+                                                ()
+                                                (Annotated.Append
+                                                  ()
+                                                  [ Wrap
+                                                      ()
+                                                      (Annotated.Append
+                                                        ()
+                                                        [ Lit
+                                                            ()
+                                                            (Right
+                                                              (Underline
+                                                                (Plain
+                                                                  "a"))),
+                                                          Lit
+                                                            ()
+                                                            (Right
+                                                              (Underline
+                                                                (Plain
+                                                                  "named"))),
+                                                          Lit
+                                                            ()
+                                                            (Right
+                                                              (Underline
+                                                                (Plain
+                                                                  "term"))),
+                                                          Lit
+                                                            ()
+                                                            (Right
+                                                              (Underline
+                                                                (Plain
+                                                                  "link"))) ]),
+                                                    Lit
+                                                      ()
+                                                      (Right
+                                                        (Plain
+                                                          ".")) ]),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain "Term")),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain "links")),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain "are")),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain "handy")),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain "for")),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain
+                                                    "linking")),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain "to")),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain "other")),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain
+                                                    "documents!")) ])) ]))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Wrap
+                                  ()
+                                  (Annotated.Append
+                                    ()
+                                    [ Lit
+                                        () (Right (Plain "You")),
+                                      Lit
+                                        () (Right (Plain "can")),
+                                      Lit
+                                        () (Right (Plain "use")),
+                                      Annotated.Group
+                                        ()
+                                        (Annotated.Append
+                                          ()
+                                          [ Lit
+                                              ()
+                                              (Right (Plain "`")),
+                                            Lit
+                                              ()
+                                              (Right
+                                                (Plain
+                                                  "{{ .. }}")),
+                                            Lit
+                                              ()
+                                              (Right (Plain "`")) ]),
+                                      Lit
+                                        () (Right (Plain "to")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "escape")),
+                                      Lit
+                                        () (Right (Plain "out")),
+                                      Lit
+                                        () (Right (Plain "to")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "regular")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "Unison")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "syntax,")),
+                                      Lit
+                                        () (Right (Plain "for")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "instance")),
+                                      Annotated.Group
+                                        ()
+                                        (Annotated.Append
+                                          ()
+                                          [ Lit
+                                              ()
+                                              (Right
+                                                (Plain
+                                                  "__not bold__")),
+                                            Lit
+                                              ()
+                                              (Right (Plain ".")) ]),
+                                      Lit
+                                        ()
+                                        (Right (Plain "This")),
+                                      Lit
+                                        () (Right (Plain "is")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "useful")),
+                                      Lit
+                                        () (Right (Plain "for")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "creating")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "documents")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain
+                                            "programmatically")),
+                                      Lit
+                                        () (Right (Plain "or")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "just")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "including")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "other")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "documents.")) ]))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Wrap
+                                  ()
+                                  (Annotated.Append
+                                    ()
+                                    [ Annotated.Group
+                                        ()
+                                        (Annotated.Append
+                                          ()
+                                          [ Lit
+                                              ()
+                                              (Right (Plain "*")),
+                                            Lit
+                                              ()
+                                              (Right
+                                                (Plain "Next")) ]),
+                                      Annotated.Group
+                                        ()
+                                        (Annotated.Append
+                                          ()
+                                          [ Lit
+                                              ()
+                                              (Right
+                                                (Plain "up:")),
+                                            Lit
+                                              ()
+                                              (Right (Plain "*")) ]),
+                                      Lit
+                                        ()
                                         (Left
                                           (SpecialForm.Link
                                             (Right
                                               (Term.Term
-                                                (Any (_ -> Some)))))),
-                                        !Lit
-                                        (Right (Plain "is")),
-                                        !Lit (Right (Plain "a")),
-                                        !Lit
-                                        (Right (Plain "term")),
-                                        !Lit
-                                        (Right (Plain "link;")),
-                                        !Lit
-                                        (Left
-                                          (SpecialForm.Link
-                                            (Left
-                                              (typeLink Optional)))),
-                                        !Lit
-                                        (Right (Plain "is")),
-                                        !Lit (Right (Plain "a")),
-                                        !Lit
-                                        (Right (Plain "type")),
-                                        !Lit
-                                        (Right (Plain "link")) ])),
-                                  !Lit (Right (Plain "\n")),
-                                  !Indent
-                                  (!Lit (Right (Plain "* ")))
-                                  (!Lit (Right (Plain "  ")))
-                                  (!Wrap
-                                    (!Annotated.Append
-                                      [ !Wrap
-                                        (!Annotated.Append
-                                          [ !Lit
-                                            (Right
-                                              (Underline
-                                                (Plain "A"))),
-                                            !Lit
-                                            (Right
-                                              (Underline
-                                                (Plain "named"))),
-                                            !Lit
-                                            (Right
-                                              (Underline
-                                                (Plain "type"))),
-                                            !Lit
-                                            (Right
-                                              (Underline
-                                                (Plain "link"))) ]),
-                                        !Lit
-                                        (Right (Plain "and")),
-                                        !Annotated.Group
-                                        (!Annotated.Append
-                                          [ !Wrap
-                                            (!Annotated.Append
-                                              [ !Lit
-                                                (Right
-                                                  (Underline
-                                                    (Plain "a"))),
-                                                !Lit
-                                                (Right
-                                                  (Underline
+                                                (Any
+                                                  (_ -> lists)))))) ]))) ])))),
+                Lit () (Right (Plain "\n")),
+                Lit () (Right (Plain "\n")),
+                Indent
+                  ()
+                  (Lit () (Right (Plain "  ")))
+                  (Lit () (Right (Plain "  ")))
+                  (Annotated.Group
+                    ()
+                    (Wrap
+                      ()
+                      (Annotated.Group
+                        ()
+                        (Annotated.Append
+                          ()
+                          [ Indent
+                              ()
+                              (Lit () (Right (Plain "# ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Wrap
+                                  ()
+                                  (Lit
+                                    ()
+                                    (Right
+                                      (ConsoleText.Bold
+                                        (Plain "Lists")))))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Annotated.Group
+                                  ()
+                                  (Annotated.Append
+                                    ()
+                                    [ Indent
+                                        ()
+                                        (Lit
+                                          ()
+                                          (Right (Plain "# ")))
+                                        (Lit
+                                          ()
+                                          (Right (Plain "  ")))
+                                        (Annotated.Group
+                                          ()
+                                          (Wrap
+                                            ()
+                                            (Annotated.Append
+                                              ()
+                                              [ Lit
+                                                  ()
+                                                  (Right
+                                                    (ConsoleText.Bold
+                                                      (Plain
+                                                        "Bulleted"))),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (ConsoleText.Bold
+                                                      (Plain
+                                                        "lists"))) ]))),
+                                      Lit
+                                        () (Right (Plain "\n")),
+                                      Lit
+                                        () (Right (Plain "\n")),
+                                      Indent
+                                        ()
+                                        (Lit
+                                          ()
+                                          (Right (Plain "  ")))
+                                        (Lit
+                                          ()
+                                          (Right (Plain "  ")))
+                                        (Annotated.Group
+                                          ()
+                                          (Wrap
+                                            ()
+                                            (Annotated.Append
+                                              ()
+                                              [ Lit
+                                                  ()
+                                                  (Right
                                                     (Plain
-                                                      "named"))),
-                                                !Lit
-                                                (Right
-                                                  (Underline
+                                                      "Bulleted")),
+                                                Lit
+                                                  ()
+                                                  (Right
                                                     (Plain
-                                                      "term"))),
-                                                !Lit
-                                                (Right
-                                                  (Underline
+                                                      "lists")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "can")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "use")),
+                                                Annotated.Group
+                                                  ()
+                                                  (Annotated.Append
+                                                    ()
+                                                    [ Annotated.Group
+                                                        ()
+                                                        (Annotated.Append
+                                                          ()
+                                                          [ Lit
+                                                              ()
+                                                              (Right
+                                                                (Plain
+                                                                  "`")),
+                                                            Lit
+                                                              ()
+                                                              (Right
+                                                                (Plain
+                                                                  "+")),
+                                                            Lit
+                                                              ()
+                                                              (Right
+                                                                (Plain
+                                                                  "`")) ]),
+                                                      Lit
+                                                        ()
+                                                        (Right
+                                                          (Plain
+                                                            ",")) ]),
+                                                Annotated.Group
+                                                  ()
+                                                  (Annotated.Append
+                                                    ()
+                                                    [ Annotated.Group
+                                                        ()
+                                                        (Annotated.Append
+                                                          ()
+                                                          [ Lit
+                                                              ()
+                                                              (Right
+                                                                (Plain
+                                                                  "`")),
+                                                            Lit
+                                                              ()
+                                                              (Right
+                                                                (Plain
+                                                                  "-")),
+                                                            Lit
+                                                              ()
+                                                              (Right
+                                                                (Plain
+                                                                  "`")) ]),
+                                                      Lit
+                                                        ()
+                                                        (Right
+                                                          (Plain
+                                                            ",")) ]),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "or")),
+                                                Annotated.Group
+                                                  ()
+                                                  (Annotated.Append
+                                                    ()
+                                                    [ Lit
+                                                        ()
+                                                        (Right
+                                                          (Plain
+                                                            "`")),
+                                                      Lit
+                                                        ()
+                                                        (Right
+                                                          (Plain
+                                                            "*")),
+                                                      Lit
+                                                        ()
+                                                        (Right
+                                                          (Plain
+                                                            "`")) ]),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "for")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "the")),
+                                                Lit
+                                                  ()
+                                                  (Right
                                                     (Plain
-                                                      "link"))) ]),
-                                            !Lit
-                                            (Right (Plain ".")) ]),
-                                        !Lit
-                                        (Right (Plain "Term")),
-                                        !Lit
-                                        (Right (Plain "links")),
-                                        !Lit
-                                        (Right (Plain "are")),
-                                        !Lit
-                                        (Right (Plain "handy")),
-                                        !Lit
-                                        (Right (Plain "for")),
-                                        !Lit
-                                        (Right (Plain "linking")),
-                                        !Lit
-                                        (Right (Plain "to")),
-                                        !Lit
-                                        (Right (Plain "other")),
-                                        !Lit
+                                                      "bullets")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "(though")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "the")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "choice")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "will")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "be")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "normalized")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "away")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "by")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "the")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "pretty-printer).")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "They")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "can")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "be")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "nested,")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "to")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "any")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "depth:")) ]))),
+                                      Lit
+                                        () (Right (Plain "\n")),
+                                      Lit
+                                        () (Right (Plain "\n")),
+                                      Indent
+                                        ()
+                                        (Lit
+                                          ()
+                                          (Right (Plain "  ")))
+                                        (Lit
+                                          ()
+                                          (Right (Plain "  ")))
+                                        (Annotated.Group
+                                          ()
+                                          (Annotated.Group
+                                            ()
+                                            (Annotated.Append
+                                              ()
+                                              [ Indent
+                                                  ()
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "* ")))
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "  ")))
+                                                  (Wrap
+                                                    ()
+                                                    (Lit
+                                                      ()
+                                                      (Right
+                                                        (Plain
+                                                          "A")))),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "\n")),
+                                                Indent
+                                                  ()
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "* ")))
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "  ")))
+                                                  (Wrap
+                                                    ()
+                                                    (Lit
+                                                      ()
+                                                      (Right
+                                                        (Plain
+                                                          "B")))),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "\n")),
+                                                Indent
+                                                  ()
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "* ")))
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "  ")))
+                                                  (Annotated.Append
+                                                    ()
+                                                    [ Wrap
+                                                        ()
+                                                        (Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "C"))),
+                                                      Lit
+                                                        ()
+                                                        (Right
+                                                          (Plain
+                                                            "\n")),
+                                                      Annotated.Group
+                                                        ()
+                                                        (Annotated.Append
+                                                          ()
+                                                          [ Indent
+                                                              ()
+                                                              (Lit
+                                                                ()
+                                                                (Right
+                                                                  (Plain
+                                                                    "* ")))
+                                                              (Lit
+                                                                ()
+                                                                (Right
+                                                                  (Plain
+                                                                    "  ")))
+                                                              (Wrap
+                                                                ()
+                                                                (Lit
+                                                                  ()
+                                                                  (Right
+                                                                    (Plain
+                                                                      "C1")))),
+                                                            Lit
+                                                              ()
+                                                              (Right
+                                                                (Plain
+                                                                  "\n")),
+                                                            Indent
+                                                              ()
+                                                              (Lit
+                                                                ()
+                                                                (Right
+                                                                  (Plain
+                                                                    "* ")))
+                                                              (Lit
+                                                                ()
+                                                                (Right
+                                                                  (Plain
+                                                                    "  ")))
+                                                              (Wrap
+                                                                ()
+                                                                (Lit
+                                                                  ()
+                                                                  (Right
+                                                                    (Plain
+                                                                      "C2")))) ]) ]) ]))) ]))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Annotated.Group
+                                  ()
+                                  (Annotated.Append
+                                    ()
+                                    [ Indent
+                                        ()
+                                        (Lit
+                                          ()
+                                          (Right (Plain "# ")))
+                                        (Lit
+                                          ()
+                                          (Right (Plain "  ")))
+                                        (Annotated.Group
+                                          ()
+                                          (Wrap
+                                            ()
+                                            (Annotated.Append
+                                              ()
+                                              [ Lit
+                                                  ()
+                                                  (Right
+                                                    (ConsoleText.Bold
+                                                      (Plain
+                                                        "Numbered"))),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (ConsoleText.Bold
+                                                      (Plain
+                                                        "lists"))) ]))),
+                                      Lit
+                                        () (Right (Plain "\n")),
+                                      Lit
+                                        () (Right (Plain "\n")),
+                                      Indent
+                                        ()
+                                        (Lit
+                                          ()
+                                          (Right (Plain "  ")))
+                                        (Lit
+                                          ()
+                                          (Right (Plain "  ")))
+                                        (Annotated.Group
+                                          ()
+                                          (Annotated.Group
+                                            ()
+                                            (Annotated.Append
+                                              ()
+                                              [ Indent
+                                                  ()
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "1. ")))
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "   ")))
+                                                  (Wrap
+                                                    ()
+                                                    (Lit
+                                                      ()
+                                                      (Right
+                                                        (Plain
+                                                          "A")))),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "\n")),
+                                                Indent
+                                                  ()
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "2. ")))
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "   ")))
+                                                  (Wrap
+                                                    ()
+                                                    (Lit
+                                                      ()
+                                                      (Right
+                                                        (Plain
+                                                          "B")))),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "\n")),
+                                                Indent
+                                                  ()
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "3. ")))
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "   ")))
+                                                  (Wrap
+                                                    ()
+                                                    (Lit
+                                                      ()
+                                                      (Right
+                                                        (Plain
+                                                          "C")))) ]))),
+                                      Lit
+                                        () (Right (Plain "\n")),
+                                      Lit
+                                        () (Right (Plain "\n")),
+                                      Indent
+                                        ()
+                                        (Lit
+                                          ()
+                                          (Right (Plain "  ")))
+                                        (Lit
+                                          ()
+                                          (Right (Plain "  ")))
+                                        (Annotated.Group
+                                          ()
+                                          (Wrap
+                                            ()
+                                            (Annotated.Append
+                                              ()
+                                              [ Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "The")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "first")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "number")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "of")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "the")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "list")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "determines")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "the")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "starting")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "number")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "in")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "the")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "rendered")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "output.")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "The")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "other")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "numbers")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "are")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "ignored:")) ]))),
+                                      Lit
+                                        () (Right (Plain "\n")),
+                                      Lit
+                                        () (Right (Plain "\n")),
+                                      Indent
+                                        ()
+                                        (Lit
+                                          ()
+                                          (Right (Plain "  ")))
+                                        (Lit
+                                          ()
+                                          (Right (Plain "  ")))
+                                        (Annotated.Group
+                                          ()
+                                          (Annotated.Group
+                                            ()
+                                            (Annotated.Append
+                                              ()
+                                              [ Indent
+                                                  ()
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "10. ")))
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "    ")))
+                                                  (Wrap
+                                                    ()
+                                                    (Lit
+                                                      ()
+                                                      (Right
+                                                        (Plain
+                                                          "A")))),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "\n")),
+                                                Indent
+                                                  ()
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "11. ")))
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "    ")))
+                                                  (Wrap
+                                                    ()
+                                                    (Lit
+                                                      ()
+                                                      (Right
+                                                        (Plain
+                                                          "B")))),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "\n")),
+                                                Indent
+                                                  ()
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "12. ")))
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "    ")))
+                                                  (Wrap
+                                                    ()
+                                                    (Lit
+                                                      ()
+                                                      (Right
+                                                        (Plain
+                                                          "C")))) ]))),
+                                      Lit
+                                        () (Right (Plain "\n")),
+                                      Lit
+                                        () (Right (Plain "\n")),
+                                      Indent
+                                        ()
+                                        (Lit
+                                          ()
+                                          (Right (Plain "  ")))
+                                        (Lit
+                                          ()
+                                          (Right (Plain "  ")))
+                                        (Annotated.Group
+                                          ()
+                                          (Wrap
+                                            ()
+                                            (Annotated.Append
+                                              ()
+                                              [ Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "Numbered")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "lists")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "can")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "be")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "nested")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "as")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "well,")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "and")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "combined")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "with")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "bulleted")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "lists:")) ]))),
+                                      Lit
+                                        () (Right (Plain "\n")),
+                                      Lit
+                                        () (Right (Plain "\n")),
+                                      Indent
+                                        ()
+                                        (Lit
+                                          ()
+                                          (Right (Plain "  ")))
+                                        (Lit
+                                          ()
+                                          (Right (Plain "  ")))
+                                        (Annotated.Group
+                                          ()
+                                          (Annotated.Group
+                                            ()
+                                            (Annotated.Append
+                                              ()
+                                              [ Indent
+                                                  ()
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "1. ")))
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "   ")))
+                                                  (Annotated.Append
+                                                    ()
+                                                    [ Wrap
+                                                        ()
+                                                        (Annotated.Append
+                                                          ()
+                                                          [ Lit
+                                                              ()
+                                                              (Right
+                                                                (Plain
+                                                                  "Wake")),
+                                                            Lit
+                                                              ()
+                                                              (Right
+                                                                (Plain
+                                                                  "up.")) ]),
+                                                      Lit
+                                                        ()
+                                                        (Right
+                                                          (Plain
+                                                            "\n")),
+                                                      Annotated.Group
+                                                        ()
+                                                        (Annotated.Append
+                                                          ()
+                                                          [ Indent
+                                                              ()
+                                                              (Lit
+                                                                ()
+                                                                (Right
+                                                                  (Plain
+                                                                    "* ")))
+                                                              (Lit
+                                                                ()
+                                                                (Right
+                                                                  (Plain
+                                                                    "  ")))
+                                                              (Wrap
+                                                                ()
+                                                                (Annotated.Append
+                                                                  ()
+                                                                  [ Lit
+                                                                      ()
+                                                                      (Right
+                                                                        (Plain
+                                                                          "What")),
+                                                                    Lit
+                                                                      ()
+                                                                      (Right
+                                                                        (Plain
+                                                                          "am")),
+                                                                    Lit
+                                                                      ()
+                                                                      (Right
+                                                                        (Plain
+                                                                          "I")),
+                                                                    Lit
+                                                                      ()
+                                                                      (Right
+                                                                        (Plain
+                                                                          "doing")),
+                                                                    Lit
+                                                                      ()
+                                                                      (Right
+                                                                        (Plain
+                                                                          "here?")) ])),
+                                                            Lit
+                                                              ()
+                                                              (Right
+                                                                (Plain
+                                                                  "\n")),
+                                                            Indent
+                                                              ()
+                                                              (Lit
+                                                                ()
+                                                                (Right
+                                                                  (Plain
+                                                                    "* ")))
+                                                              (Lit
+                                                                ()
+                                                                (Right
+                                                                  (Plain
+                                                                    "  ")))
+                                                              (Wrap
+                                                                ()
+                                                                (Annotated.Append
+                                                                  ()
+                                                                  [ Lit
+                                                                      ()
+                                                                      (Right
+                                                                        (Plain
+                                                                          "In")),
+                                                                    Lit
+                                                                      ()
+                                                                      (Right
+                                                                        (Plain
+                                                                          "this")),
+                                                                    Lit
+                                                                      ()
+                                                                      (Right
+                                                                        (Plain
+                                                                          "nested")),
+                                                                    Lit
+                                                                      ()
+                                                                      (Right
+                                                                        (Plain
+                                                                          "list.")) ])) ]) ]),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "\n")),
+                                                Indent
+                                                  ()
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "2. ")))
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "   ")))
+                                                  (Wrap
+                                                    ()
+                                                    (Annotated.Append
+                                                      ()
+                                                      [ Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "Take")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "shower.")) ])),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "\n")),
+                                                Indent
+                                                  ()
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "3. ")))
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "   ")))
+                                                  (Wrap
+                                                    ()
+                                                    (Annotated.Append
+                                                      ()
+                                                      [ Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "Get")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "dressed.")) ])) ]))) ]))) ])))),
+                Lit () (Right (Plain "\n")),
+                Lit () (Right (Plain "\n")),
+                Indent
+                  ()
+                  (Lit () (Right (Plain "  ")))
+                  (Lit () (Right (Plain "  ")))
+                  (Annotated.Group
+                    ()
+                    (Wrap
+                      ()
+                      (Annotated.Group
+                        ()
+                        (Annotated.Append
+                          ()
+                          [ Indent
+                              ()
+                              (Lit () (Right (Plain "# ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Wrap
+                                  ()
+                                  (Lit
+                                    ()
+                                    (Right
+                                      (ConsoleText.Bold
+                                        (Plain "Evaluation")))))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Wrap
+                                  ()
+                                  (Annotated.Append
+                                    ()
+                                    [ Lit
+                                        ()
                                         (Right
-                                          (Plain "documents!")) ])) ]))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Wrap
-                              (!Annotated.Append
-                                [ !Lit (Right (Plain "You")),
-                                  !Lit (Right (Plain "can")),
-                                  !Lit (Right (Plain "use")),
-                                  !Annotated.Group
-                                  (!Annotated.Append
-                                    [ !Lit (Right (Plain "`")),
-                                      !Lit
-                                      (Right (Plain "{{ .. }}")),
-                                      !Lit (Right (Plain "`")) ]),
-                                  !Lit (Right (Plain "to")),
-                                  !Lit (Right (Plain "escape")),
-                                  !Lit (Right (Plain "out")),
-                                  !Lit (Right (Plain "to")),
-                                  !Lit (Right (Plain "regular")),
-                                  !Lit (Right (Plain "Unison")),
-                                  !Lit (Right (Plain "syntax,")),
-                                  !Lit (Right (Plain "for")),
-                                  !Lit
-                                  (Right (Plain "instance")),
-                                  !Annotated.Group
-                                  (!Annotated.Append
-                                    [ !Lit
-                                      (Right
-                                        (Plain "__not bold__")),
-                                      !Lit (Right (Plain ".")) ]),
-                                  !Lit (Right (Plain "This")),
-                                  !Lit (Right (Plain "is")),
-                                  !Lit (Right (Plain "useful")),
-                                  !Lit (Right (Plain "for")),
-                                  !Lit
-                                  (Right (Plain "creating")),
-                                  !Lit
-                                  (Right (Plain "documents")),
-                                  !Lit
-                                  (Right
-                                    (Plain "programmatically")),
-                                  !Lit (Right (Plain "or")),
-                                  !Lit (Right (Plain "just")),
-                                  !Lit
-                                  (Right (Plain "including")),
-                                  !Lit (Right (Plain "other")),
-                                  !Lit
-                                  (Right (Plain "documents.")) ]))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Wrap
-                              (!Annotated.Append
-                                [ !Annotated.Group
-                                  (!Annotated.Append
-                                    [ !Lit (Right (Plain "*")),
-                                      !Lit
-                                      (Right (Plain "Next")) ]),
-                                  !Annotated.Group
-                                  (!Annotated.Append
-                                    [ !Lit (Right (Plain "up:")),
-                                      !Lit (Right (Plain "*")) ]),
-                                  !Lit
+                                          (Plain "Expressions")),
+                                      Lit
+                                        () (Right (Plain "can")),
+                                      Lit
+                                        () (Right (Plain "be")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "evaluated")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "inline,")),
+                                      Lit
+                                        () (Right (Plain "for")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "instance")),
+                                      Annotated.Group
+                                        ()
+                                        (Annotated.Append
+                                          ()
+                                          [ Lit
+                                              ()
+                                              (Left
+                                                (EvalInline
+                                                  (Term.Term
+                                                    (Any
+                                                      (_ ->
+                                                        1
+                                                          Nat.+ 1))))),
+                                            Lit
+                                              ()
+                                              (Right (Plain ".")) ]) ]))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Wrap
+                                  ()
+                                  (Annotated.Append
+                                    ()
+                                    [ Lit
+                                        ()
+                                        (Right (Plain "Blocks")),
+                                      Lit
+                                        () (Right (Plain "of")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "code")),
+                                      Lit
+                                        () (Right (Plain "can")),
+                                      Lit
+                                        () (Right (Plain "be")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "evaluated")),
+                                      Lit
+                                        () (Right (Plain "as")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "well,")),
+                                      Lit
+                                        () (Right (Plain "for")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "instance:")) ]))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                () (Lit
+                                  () (Left
+                                    (Eval
+                                      (Term.Term
+                                        (Any
+                                          (_ ->
+                                            id x = x
+                                            id (sqr 10)))))))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Wrap
+                                  ()
+                                  (Lit
+                                    () (Right (Plain "also:"))))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Lit
+                                  ()
                                   (Left
-                                    (SpecialForm.Link
-                                      (Right
-                                        (Term.Term
-                                          (Any (_ -> lists)))))) ]))) ])))),
-                !Lit (Right (Plain "\n")),
-                !Lit (Right (Plain "\n")),
-                !Indent
-                (!Lit (Right (Plain "  ")))
-                (!Lit (Right (Plain "  ")))
-                (!Annotated.Group
-                  (!Wrap
-                    (!Annotated.Group
-                      (!Annotated.Append
-                        [ !Indent
-                          (!Lit (Right (Plain "# ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Wrap
-                              (!Lit
-                                (Right
-                                  (ConsoleText.Bold
-                                    (Plain "Lists")))))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Annotated.Group
-                              (!Annotated.Append
-                                [ !Indent
-                                  (!Lit (Right (Plain "# ")))
-                                  (!Lit (Right (Plain "  ")))
-                                  (!Annotated.Group
-                                    (!Wrap
-                                      (!Annotated.Append
-                                        [ !Lit
-                                          (Right
-                                            (ConsoleText.Bold
-                                              (Plain "Bulleted"))),
-                                          !Lit
-                                          (Right
-                                            (ConsoleText.Bold
-                                              (Plain "lists"))) ]))),
-                                  !Lit (Right (Plain "\n")),
-                                  !Lit (Right (Plain "\n")),
-                                  !Indent
-                                  (!Lit (Right (Plain "  ")))
-                                  (!Lit (Right (Plain "  ")))
-                                  (!Annotated.Group
-                                    (!Wrap
-                                      (!Annotated.Append
-                                        [ !Lit
-                                          (Right
-                                            (Plain "Bulleted")),
-                                          !Lit
-                                          (Right (Plain "lists")),
-                                          !Lit
-                                          (Right (Plain "can")),
-                                          !Lit
-                                          (Right (Plain "use")),
-                                          !Annotated.Group
-                                          (!Annotated.Append
-                                            [ !Annotated.Group
-                                              (!Annotated.Append
-                                                [ !Lit
-                                                  (Right
-                                                    (Plain "`")),
-                                                  !Lit
-                                                  (Right
-                                                    (Plain "+")),
-                                                  !Lit
-                                                  (Right
-                                                    (Plain "`")) ]),
-                                              !Lit
+                                    (Eval
+                                      (Term.Term
+                                        (Any
+                                          (_ ->
+                                            (match 1 with
+                                              1 -> "hi"
+                                              _ -> "goodbye")))))))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Wrap
+                                  ()
+                                  (Annotated.Append
+                                    ()
+                                    [ Lit
+                                        () (Right (Plain "To")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "include")),
+                                      Lit () (Right (Plain "a")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "typechecked")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "snippet")),
+                                      Lit
+                                        () (Right (Plain "of")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "code")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "without")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "evaluating")),
+                                      Lit
+                                        () (Right (Plain "it,")),
+                                      Lit
+                                        () (Right (Plain "you")),
+                                      Lit
+                                        () (Right (Plain "can")),
+                                      Lit
+                                        () (Right (Plain "do:")) ]))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                () (Lit
+                                  () (Left
+                                    (ExampleBlock
+                                      0 (Term.Term
+                                        (Any
+                                          (_ ->
+                                            cube : Nat -> Nat
+                                            cube x =
+                                              use Nat *
+                                              x * x * x
+                                            ()))))))) ])))),
+                Lit () (Right (Plain "\n")),
+                Lit () (Right (Plain "\n")),
+                Indent
+                  ()
+                  (Lit () (Right (Plain "  ")))
+                  (Lit () (Right (Plain "  ")))
+                  (Annotated.Group
+                    ()
+                    (Wrap
+                      ()
+                      (Annotated.Group
+                        ()
+                        (Annotated.Append
+                          ()
+                          [ Indent
+                              ()
+                              (Lit () (Right (Plain "# ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Wrap
+                                  ()
+                                  (Annotated.Append
+                                    ()
+                                    [ Lit
+                                        ()
+                                        (Right
+                                          (ConsoleText.Bold
+                                            (Plain "Including"))),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (ConsoleText.Bold
+                                            (Plain "Unison"))),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (ConsoleText.Bold
+                                            (Plain "source"))),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (ConsoleText.Bold
+                                            (Plain "code"))) ]))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Wrap
+                                  ()
+                                  (Annotated.Append
+                                    ()
+                                    [ Lit
+                                        ()
+                                        (Right (Plain "Unison")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "definitions")),
+                                      Lit
+                                        () (Right (Plain "can")),
+                                      Lit
+                                        () (Right (Plain "be")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "included")),
+                                      Lit
+                                        () (Right (Plain "in")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "docs.")),
+                                      Lit
+                                        () (Right (Plain "For")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "instance:")) ]))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Wrap
+                                  ()
+                                  (Lit
+                                    ()
+                                    (Left
+                                      (SpecialForm.Source
+                                        [ Cons
+                                            (Left
+                                              (typeLink Optional))
+                                            (Cons [] ()),
+                                          Cons
+                                            (Right
+                                              (Term.Term
+                                                (Any (_ -> sqr))))
+                                            (Cons [] ()) ]))))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Wrap
+                                  ()
+                                  (Annotated.Append
+                                    ()
+                                    [ Lit
+                                        ()
+                                        (Right (Plain "Some")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "rendering")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "targets")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "also")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "support")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "folded")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "source:")) ]))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Wrap
+                                  ()
+                                  (Lit
+                                    ()
+                                    (Left
+                                      (FoldedSource
+                                        [ Cons
+                                            (Left
+                                              (typeLink Optional))
+                                            (Cons [] ()),
+                                          Cons
+                                            (Right
+                                              (Term.Term
+                                                (Any (_ -> sqr))))
+                                            (Cons [] ()) ]))))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Wrap
+                                  ()
+                                  (Annotated.Append
+                                    ()
+                                    [ Lit
+                                        () (Right (Plain "You")),
+                                      Lit
+                                        () (Right (Plain "can")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "also")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "include")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "just")),
+                                      Lit () (Right (Plain "a")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "signature,")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "inline,")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "with")),
+                                      Annotated.Group
+                                        ()
+                                        (Annotated.Append
+                                          ()
+                                          [ Lit
+                                              ()
+                                              (Left
+                                                (SignatureInline
+                                                  (Term.Term
+                                                    (Any
+                                                      (_ -> sqr))))),
+                                            Lit
+                                              ()
                                               (Right (Plain ",")) ]),
-                                          !Annotated.Group
-                                          (!Annotated.Append
-                                            [ !Annotated.Group
-                                              (!Annotated.Append
-                                                [ !Lit
+                                      Lit
+                                        () (Right (Plain "or")),
+                                      Lit
+                                        () (Right (Plain "you")),
+                                      Lit
+                                        () (Right (Plain "can")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "include")),
+                                      Lit
+                                        () (Right (Plain "one")),
+                                      Lit
+                                        () (Right (Plain "or")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "more")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "signatures")),
+                                      Lit
+                                        () (Right (Plain "as")),
+                                      Lit () (Right (Plain "a")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "block:")) ]))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Wrap
+                                  ()
+                                  (Lit
+                                    ()
+                                    (Left
+                                      (SpecialForm.Signature
+                                        [ Term.Term
+                                            (Any (_ -> sqr)),
+                                          Term.Term
+                                            (Any (_ -> (Nat.+))) ]))))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Wrap
+                                  ()
+                                  (Annotated.Append
+                                    ()
+                                    [ Lit
+                                        () (Right (Plain "Or")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "alternately:")) ]))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Wrap
+                                  ()
+                                  (Lit
+                                    ()
+                                    (Left
+                                      (SpecialForm.Signature
+                                        [ Term.Term
+                                            (Any (_ -> List.map)) ]))))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Annotated.Group
+                                  ()
+                                  (Annotated.Append
+                                    ()
+                                    [ Indent
+                                        ()
+                                        (Lit
+                                          ()
+                                          (Right (Plain "# ")))
+                                        (Lit
+                                          ()
+                                          (Right (Plain "  ")))
+                                        (Annotated.Group
+                                          ()
+                                          (Wrap
+                                            ()
+                                            (Annotated.Append
+                                              ()
+                                              [ Lit
+                                                  ()
                                                   (Right
-                                                    (Plain "`")),
-                                                  !Lit
+                                                    (ConsoleText.Bold
+                                                      (Plain
+                                                        "Inline"))),
+                                                Lit
+                                                  ()
                                                   (Right
-                                                    (Plain "-")),
-                                                  !Lit
+                                                    (ConsoleText.Bold
+                                                      (Plain
+                                                        "snippets"))) ]))),
+                                      Lit
+                                        () (Right (Plain "\n")),
+                                      Lit
+                                        () (Right (Plain "\n")),
+                                      Indent
+                                        ()
+                                        (Lit
+                                          ()
+                                          (Right (Plain "  ")))
+                                        (Lit
+                                          ()
+                                          (Right (Plain "  ")))
+                                        (Annotated.Group
+                                          ()
+                                          (Wrap
+                                            ()
+                                            (Annotated.Append
+                                              ()
+                                              [ Lit
+                                                  ()
                                                   (Right
-                                                    (Plain "`")) ]),
-                                              !Lit
-                                              (Right (Plain ",")) ]),
-                                          !Lit
-                                          (Right (Plain "or")),
-                                          !Annotated.Group
-                                          (!Annotated.Append
-                                            [ !Lit
-                                              (Right (Plain "`")),
-                                              !Lit
-                                              (Right (Plain "*")),
-                                              !Lit
-                                              (Right (Plain "`")) ]),
-                                          !Lit
-                                          (Right (Plain "for")),
-                                          !Lit
-                                          (Right (Plain "the")),
-                                          !Lit
-                                          (Right
-                                            (Plain "bullets")),
-                                          !Lit
-                                          (Right
-                                            (Plain "(though")),
-                                          !Lit
-                                          (Right (Plain "the")),
-                                          !Lit
-                                          (Right
-                                            (Plain "choice")),
-                                          !Lit
-                                          (Right (Plain "will")),
-                                          !Lit
-                                          (Right (Plain "be")),
-                                          !Lit
-                                          (Right
-                                            (Plain "normalized")),
-                                          !Lit
-                                          (Right (Plain "away")),
-                                          !Lit
-                                          (Right (Plain "by")),
-                                          !Lit
-                                          (Right (Plain "the")),
-                                          !Lit
+                                                    (Plain "You")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "can")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "include")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "typechecked")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "code")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "snippets")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "inline,")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "for")),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain
+                                                      "instance:")) ]))),
+                                      Lit
+                                        () (Right (Plain "\n")),
+                                      Lit
+                                        () (Right (Plain "\n")),
+                                      Indent
+                                        ()
+                                        (Lit
+                                          ()
+                                          (Right (Plain "  ")))
+                                        (Lit
+                                          ()
+                                          (Right (Plain "  ")))
+                                        (Annotated.Group
+                                          ()
+                                          (Annotated.Group
+                                            ()
+                                            (Annotated.Append
+                                              ()
+                                              [ Indent
+                                                  ()
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "* ")))
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "  ")))
+                                                  (Wrap
+                                                    ()
+                                                    (Annotated.Append
+                                                      ()
+                                                      [ Lit
+                                                          ()
+                                                          (Left
+                                                            (Example
+                                                              2
+                                                              (Term.Term
+                                                                (Any
+                                                                  '(f
+                                                                    x ->
+                                                                      f
+                                                                        x
+                                                                        Nat.+ sqr
+                                                                                1))))),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "-")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "the")),
+                                                        Annotated.Group
+                                                          ()
+                                                          (Annotated.Append
+                                                            ()
+                                                            [ Lit
+                                                                ()
+                                                                (Right
+                                                                  (Plain
+                                                                    "`")),
+                                                              Lit
+                                                                ()
+                                                                (Right
+                                                                  (Plain
+                                                                    "2")),
+                                                              Lit
+                                                                ()
+                                                                (Right
+                                                                  (Plain
+                                                                    "`")) ]),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "says")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "to")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "ignore")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "the")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "first")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "two")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "arguments")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "when")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "rendering.")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "In")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "richer")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "renderers,")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "the")),
+                                                        Annotated.Group
+                                                          ()
+                                                          (Annotated.Append
+                                                            ()
+                                                            [ Lit
+                                                                ()
+                                                                (Right
+                                                                  (Plain
+                                                                    "`")),
+                                                              Lit
+                                                                ()
+                                                                (Right
+                                                                  (Plain
+                                                                    "sqr")),
+                                                              Lit
+                                                                ()
+                                                                (Right
+                                                                  (Plain
+                                                                    "`")) ]),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "link")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "will")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "be")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "clickable.")) ])),
+                                                Lit
+                                                  ()
+                                                  (Right
+                                                    (Plain "\n")),
+                                                Indent
+                                                  ()
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "* ")))
+                                                  (Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "  ")))
+                                                  (Wrap
+                                                    ()
+                                                    (Annotated.Append
+                                                      ()
+                                                      [ Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "If")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "your")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "snippet")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "expression")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "is")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "just")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "a")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "single")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "function")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "application,")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "you")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "can")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "put")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "it")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "in")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "double")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "backticks,")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "like")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "so:")),
+                                                        Annotated.Group
+                                                          ()
+                                                          (Annotated.Append
+                                                            ()
+                                                            [ Lit
+                                                                ()
+                                                                (Left
+                                                                  (Example
+                                                                    1
+                                                                    (Term.Term
+                                                                      (Any
+                                                                        (_
+                                                                        x ->
+                                                                          sqr
+                                                                            x))))),
+                                                              Lit
+                                                                ()
+                                                                (Right
+                                                                  (Plain
+                                                                    ".")) ]),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "This")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "is")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "equivalent")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "to")),
+                                                        Annotated.Group
+                                                          ()
+                                                          (Annotated.Append
+                                                            ()
+                                                            [ Lit
+                                                                ()
+                                                                (Left
+                                                                  (Example
+                                                                    1
+                                                                    (Term.Term
+                                                                      (Any
+                                                                        '(x ->
+                                                                            sqr
+                                                                              x))))),
+                                                              Lit
+                                                                ()
+                                                                (Right
+                                                                  (Plain
+                                                                    ".")) ]) ])) ]))) ]))) ])))),
+                Lit () (Right (Plain "\n")),
+                Lit () (Right (Plain "\n")),
+                Indent
+                  ()
+                  (Lit () (Right (Plain "  ")))
+                  (Lit () (Right (Plain "  ")))
+                  (Annotated.Group
+                    ()
+                    (Wrap
+                      ()
+                      (Annotated.Group
+                        ()
+                        (Annotated.Append
+                          ()
+                          [ Indent
+                              ()
+                              (Lit () (Right (Plain "# ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Wrap
+                                  ()
+                                  (Annotated.Append
+                                    ()
+                                    [ Lit
+                                        ()
+                                        (Right
+                                          (ConsoleText.Bold
+                                            (Plain "Non-Unison"))),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (ConsoleText.Bold
+                                            (Plain "code"))),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (ConsoleText.Bold
+                                            (Plain "blocks"))) ]))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Wrap
+                                  ()
+                                  (Annotated.Append
+                                    ()
+                                    [ Lit
+                                        () (Right (Plain "Use")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "three")),
+                                      Lit
+                                        () (Right (Plain "or")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "more")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "single")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "quotes")),
+                                      Lit
+                                        () (Right (Plain "to")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "start")),
+                                      Lit () (Right (Plain "a")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "block")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "with")),
+                                      Lit
+                                        () (Right (Plain "no")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "syntax")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "highlighting:")) ]))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Wrap
+                                  ()
+                                  (Annotated.Group
+                                    ()
+                                    (Annotated.Append
+                                      ()
+                                      [ Lit
+                                          ()
+                                          (Right (Plain "``` ")),
+                                        Annotated.Group
+                                          ()
+                                          (Lit
+                                            ()
+                                            (Right (Plain "raw"))),
+                                        Lit
+                                          ()
+                                          (Right (Plain "\n")),
+                                        Lit
+                                          ()
                                           (Right
                                             (Plain
-                                              "pretty-printer).")),
-                                          !Lit
-                                          (Right (Plain "They")),
-                                          !Lit
-                                          (Right (Plain "can")),
-                                          !Lit
-                                          (Right (Plain "be")),
-                                          !Lit
-                                          (Right
-                                            (Plain "nested,")),
-                                          !Lit
-                                          (Right (Plain "to")),
-                                          !Lit
-                                          (Right (Plain "any")),
-                                          !Lit
-                                          (Right
-                                            (Plain "depth:")) ]))),
-                                  !Lit (Right (Plain "\n")),
-                                  !Lit (Right (Plain "\n")),
-                                  !Indent
-                                  (!Lit (Right (Plain "  ")))
-                                  (!Lit (Right (Plain "  ")))
-                                  (!Annotated.Group
-                                    (!Annotated.Group
-                                      (!Annotated.Append
-                                        [ !Indent
-                                          (!Lit
-                                            (Right (Plain "* ")))
-                                          (!Lit
-                                            (Right (Plain "  ")))
-                                          (!Wrap
-                                            (!Lit
-                                              (Right (Plain "A")))),
-                                          !Lit
+                                              "   _____     _             \n  |  |  |___|_|___ ___ ___ \n  |  |  |   | |_ -| . |   |\n  |_____|_|_|_|___|___|_|_|\n  ")),
+                                        Lit
+                                          ()
                                           (Right (Plain "\n")),
-                                          !Indent
-                                          (!Lit
-                                            (Right (Plain "* ")))
-                                          (!Lit
-                                            (Right (Plain "  ")))
-                                          (!Wrap
-                                            (!Lit
-                                              (Right (Plain "B")))),
-                                          !Lit
-                                          (Right (Plain "\n")),
-                                          !Indent
-                                          (!Lit
-                                            (Right (Plain "* ")))
-                                          (!Lit
-                                            (Right (Plain "  ")))
-                                          (!Annotated.Append
-                                            [ !Wrap
-                                              (!Lit
-                                                (Right
-                                                  (Plain "C"))),
-                                              !Lit
-                                              (Right
-                                                (Plain "\n")),
-                                              !Annotated.Group
-                                              (!Annotated.Append
-                                                [ !Indent
-                                                  (!Lit
-                                                    (Right
-                                                      (Plain
-                                                        "* ")))
-                                                  (!Lit
-                                                    (Right
-                                                      (Plain
-                                                        "  ")))
-                                                  (!Wrap
-                                                    (!Lit
-                                                      (Right
-                                                        (Plain
-                                                          "C1")))),
-                                                  !Lit
-                                                  (Right
-                                                    (Plain "\n")),
-                                                  !Indent
-                                                  (!Lit
-                                                    (Right
-                                                      (Plain
-                                                        "* ")))
-                                                  (!Lit
-                                                    (Right
-                                                      (Plain
-                                                        "  ")))
-                                                  (!Wrap
-                                                    (!Lit
-                                                      (Right
-                                                        (Plain
-                                                          "C2")))) ]) ]) ]))) ]))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Annotated.Group
-                              (!Annotated.Append
-                                [ !Indent
-                                  (!Lit (Right (Plain "# ")))
-                                  (!Lit (Right (Plain "  ")))
-                                  (!Annotated.Group
-                                    (!Wrap
-                                      (!Annotated.Append
-                                        [ !Lit
+                                        Lit
+                                          ()
+                                          (Right (Plain "```")) ])))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Wrap
+                                  ()
+                                  (Annotated.Append
+                                    ()
+                                    [ Lit
+                                        () (Right (Plain "You")),
+                                      Lit
+                                        () (Right (Plain "can")),
+                                      Lit
+                                        () (Right (Plain "use")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "three")),
+                                      Lit
+                                        () (Right (Plain "or")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "more")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "backticks")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "plus")),
+                                      Lit () (Right (Plain "a")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "language")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "name")),
+                                      Lit
+                                        () (Right (Plain "for")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "blocks")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "with")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "syntax")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain "highlighting:")) ]))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Annotated.Group
+                                  ()
+                                  (Annotated.Append
+                                    ()
+                                    [ Lit
+                                        ()
+                                        (Right (Plain "``` ")),
+                                      Annotated.Group
+                                        ()
+                                        (Lit
+                                          ()
                                           (Right
-                                            (ConsoleText.Bold
-                                              (Plain "Numbered"))),
-                                          !Lit
-                                          (Right
-                                            (ConsoleText.Bold
-                                              (Plain "lists"))) ]))),
-                                  !Lit (Right (Plain "\n")),
-                                  !Lit (Right (Plain "\n")),
-                                  !Indent
-                                  (!Lit (Right (Plain "  ")))
-                                  (!Lit (Right (Plain "  ")))
-                                  (!Annotated.Group
-                                    (!Annotated.Group
-                                      (!Annotated.Append
-                                        [ !Indent
-                                          (!Lit
-                                            (Right (Plain "1. ")))
-                                          (!Lit
-                                            (Right (Plain "   ")))
-                                          (!Wrap
-                                            (!Lit
-                                              (Right (Plain "A")))),
-                                          !Lit
-                                          (Right (Plain "\n")),
-                                          !Indent
-                                          (!Lit
-                                            (Right (Plain "2. ")))
-                                          (!Lit
-                                            (Right (Plain "   ")))
-                                          (!Wrap
-                                            (!Lit
-                                              (Right (Plain "B")))),
-                                          !Lit
-                                          (Right (Plain "\n")),
-                                          !Indent
-                                          (!Lit
-                                            (Right (Plain "3. ")))
-                                          (!Lit
-                                            (Right (Plain "   ")))
-                                          (!Wrap
-                                            (!Lit
-                                              (Right (Plain "C")))) ]))),
-                                  !Lit (Right (Plain "\n")),
-                                  !Lit (Right (Plain "\n")),
-                                  !Indent
-                                  (!Lit (Right (Plain "  ")))
-                                  (!Lit (Right (Plain "  ")))
-                                  (!Annotated.Group
-                                    (!Wrap
-                                      (!Annotated.Append
-                                        [ !Lit
-                                          (Right (Plain "The")),
-                                          !Lit
-                                          (Right (Plain "first")),
-                                          !Lit
-                                          (Right
-                                            (Plain "number")),
-                                          !Lit
-                                          (Right (Plain "of")),
-                                          !Lit
-                                          (Right (Plain "the")),
-                                          !Lit
-                                          (Right (Plain "list")),
-                                          !Lit
-                                          (Right
-                                            (Plain "determines")),
-                                          !Lit
-                                          (Right (Plain "the")),
-                                          !Lit
-                                          (Right
-                                            (Plain "starting")),
-                                          !Lit
-                                          (Right
-                                            (Plain "number")),
-                                          !Lit
-                                          (Right (Plain "in")),
-                                          !Lit
-                                          (Right (Plain "the")),
-                                          !Lit
-                                          (Right
-                                            (Plain "rendered")),
-                                          !Lit
-                                          (Right
-                                            (Plain "output.")),
-                                          !Lit
-                                          (Right (Plain "The")),
-                                          !Lit
-                                          (Right (Plain "other")),
-                                          !Lit
-                                          (Right
-                                            (Plain "numbers")),
-                                          !Lit
-                                          (Right (Plain "are")),
-                                          !Lit
-                                          (Right
-                                            (Plain "ignored:")) ]))),
-                                  !Lit (Right (Plain "\n")),
-                                  !Lit (Right (Plain "\n")),
-                                  !Indent
-                                  (!Lit (Right (Plain "  ")))
-                                  (!Lit (Right (Plain "  ")))
-                                  (!Annotated.Group
-                                    (!Annotated.Group
-                                      (!Annotated.Append
-                                        [ !Indent
-                                          (!Lit
+                                            (Plain "Haskell"))),
+                                      Lit
+                                        () (Right (Plain "\n")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain
+                                            "-- A fenced code block which isn't parsed by Unison\nreverse = foldl (flip (:)) []")),
+                                      Lit
+                                        () (Right (Plain "\n")),
+                                      Lit
+                                        () (Right (Plain "```")) ]))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Indent
+                              ()
+                              (Lit () (Right (Plain "  ")))
+                              (Lit () (Right (Plain "  ")))
+                              (Annotated.Group
+                                ()
+                                (Annotated.Group
+                                  ()
+                                  (Annotated.Append
+                                    ()
+                                    [ Lit
+                                        ()
+                                        (Right (Plain "``` ")),
+                                      Annotated.Group
+                                        ()
+                                        (Lit
+                                          ()
+                                          (Right (Plain "Scala"))),
+                                      Lit
+                                        () (Right (Plain "\n")),
+                                      Lit
+                                        ()
+                                        (Right
+                                          (Plain
+                                            "// A fenced code block which isn't parsed by Unison\ndef reverse[A](xs: List[A]) = \n  xs.foldLeft(Nil : List[A])((acc,a) => a +: acc)")),
+                                      Lit
+                                        () (Right (Plain "\n")),
+                                      Lit
+                                        () (Right (Plain "```")) ]))) ])))),
+                Lit () (Right (Plain "\n")),
+                Lit () (Right (Plain "\n")),
+                Indent
+                  ()
+                  (Lit () (Right (Plain "  ")))
+                  (Lit () (Right (Plain "  ")))
+                  (Annotated.Group
+                    ()
+                    (Wrap
+                      ()
+                      (Annotated.Group
+                        ()
+                        (Annotated.Append
+                          ()
+                          [ Annotated.Group
+                              ()
+                              (Wrap
+                                ()
+                                (Annotated.Append
+                                  ()
+                                  [ Lit
+                                      () (Right (Plain "There")),
+                                    Lit () (Right (Plain "are")),
+                                    Lit
+                                      () (Right (Plain "also")),
+                                    Lit
+                                      ()
+                                      (Right (Plain "asides,")),
+                                    Lit
+                                      ()
+                                      (Right (Plain "callouts,")),
+                                    Lit
+                                      ()
+                                      (Right (Plain "tables,")),
+                                    Lit
+                                      ()
+                                      (Right (Plain "tooltips,")),
+                                    Lit () (Right (Plain "and")),
+                                    Lit
+                                      () (Right (Plain "more.")),
+                                    Lit
+                                      () (Right (Plain "These")),
+                                    Lit
+                                      () (Right (Plain "don't")),
+                                    Lit
+                                      ()
+                                      (Right (Plain "currently")),
+                                    Lit
+                                      () (Right (Plain "have")),
+                                    Lit
+                                      ()
+                                      (Right (Plain "special")),
+                                    Lit
+                                      ()
+                                      (Right (Plain "syntax;")),
+                                    Lit
+                                      () (Right (Plain "just")),
+                                    Lit () (Right (Plain "use")),
+                                    Lit () (Right (Plain "the")),
+                                    Annotated.Group
+                                      ()
+                                      (Annotated.Append
+                                        ()
+                                        [ Lit
+                                            ()
+                                            (Right (Plain "`")),
+                                          Lit
+                                            ()
                                             (Right
-                                              (Plain "10. ")))
-                                          (!Lit
-                                            (Right
-                                              (Plain "    ")))
-                                          (!Wrap
-                                            (!Lit
-                                              (Right (Plain "A")))),
-                                          !Lit
-                                          (Right (Plain "\n")),
-                                          !Indent
-                                          (!Lit
-                                            (Right
-                                              (Plain "11. ")))
-                                          (!Lit
-                                            (Right
-                                              (Plain "    ")))
-                                          (!Wrap
-                                            (!Lit
-                                              (Right (Plain "B")))),
-                                          !Lit
-                                          (Right (Plain "\n")),
-                                          !Indent
-                                          (!Lit
-                                            (Right
-                                              (Plain "12. ")))
-                                          (!Lit
-                                            (Right
-                                              (Plain "    ")))
-                                          (!Wrap
-                                            (!Lit
-                                              (Right (Plain "C")))) ]))),
-                                  !Lit (Right (Plain "\n")),
-                                  !Lit (Right (Plain "\n")),
-                                  !Indent
-                                  (!Lit (Right (Plain "  ")))
-                                  (!Lit (Right (Plain "  ")))
-                                  (!Annotated.Group
-                                    (!Wrap
-                                      (!Annotated.Append
-                                        [ !Lit
-                                          (Right
-                                            (Plain "Numbered")),
-                                          !Lit
-                                          (Right (Plain "lists")),
-                                          !Lit
-                                          (Right (Plain "can")),
-                                          !Lit
-                                          (Right (Plain "be")),
-                                          !Lit
-                                          (Right
-                                            (Plain "nested")),
-                                          !Lit
-                                          (Right (Plain "as")),
-                                          !Lit
-                                          (Right (Plain "well,")),
-                                          !Lit
-                                          (Right (Plain "and")),
-                                          !Lit
-                                          (Right
-                                            (Plain "combined")),
-                                          !Lit
-                                          (Right (Plain "with")),
-                                          !Lit
-                                          (Right
-                                            (Plain "bulleted")),
-                                          !Lit
-                                          (Right
-                                            (Plain "lists:")) ]))),
-                                  !Lit (Right (Plain "\n")),
-                                  !Lit (Right (Plain "\n")),
-                                  !Indent
-                                  (!Lit (Right (Plain "  ")))
-                                  (!Lit (Right (Plain "  ")))
-                                  (!Annotated.Group
-                                    (!Annotated.Group
-                                      (!Annotated.Append
-                                        [ !Indent
-                                          (!Lit
-                                            (Right (Plain "1. ")))
-                                          (!Lit
-                                            (Right (Plain "   ")))
-                                          (!Annotated.Append
-                                            [ !Wrap
-                                              (!Annotated.Append
-                                                [ !Lit
-                                                  (Right
-                                                    (Plain
-                                                      "Wake")),
-                                                  !Lit
-                                                  (Right
-                                                    (Plain "up.")) ]),
-                                              !Lit
-                                              (Right
-                                                (Plain "\n")),
-                                              !Annotated.Group
-                                              (!Annotated.Append
-                                                [ !Indent
-                                                  (!Lit
-                                                    (Right
-                                                      (Plain
-                                                        "* ")))
-                                                  (!Lit
-                                                    (Right
-                                                      (Plain
-                                                        "  ")))
-                                                  (!Wrap
-                                                    (!Annotated.Append
-                                                      [ !Lit
-                                                        (Right
-                                                          (Plain
-                                                            "What")),
-                                                        !Lit
-                                                        (Right
-                                                          (Plain
-                                                            "am")),
-                                                        !Lit
-                                                        (Right
-                                                          (Plain
-                                                            "I")),
-                                                        !Lit
-                                                        (Right
-                                                          (Plain
-                                                            "doing")),
-                                                        !Lit
-                                                        (Right
-                                                          (Plain
-                                                            "here?")) ])),
-                                                  !Lit
-                                                  (Right
-                                                    (Plain "\n")),
-                                                  !Indent
-                                                  (!Lit
-                                                    (Right
-                                                      (Plain
-                                                        "* ")))
-                                                  (!Lit
-                                                    (Right
-                                                      (Plain
-                                                        "  ")))
-                                                  (!Wrap
-                                                    (!Annotated.Append
-                                                      [ !Lit
-                                                        (Right
-                                                          (Plain
-                                                            "In")),
-                                                        !Lit
-                                                        (Right
-                                                          (Plain
-                                                            "this")),
-                                                        !Lit
-                                                        (Right
-                                                          (Plain
-                                                            "nested")),
-                                                        !Lit
-                                                        (Right
-                                                          (Plain
-                                                            "list.")) ])) ]) ]),
-                                          !Lit
-                                          (Right (Plain "\n")),
-                                          !Indent
-                                          (!Lit
-                                            (Right (Plain "2. ")))
-                                          (!Lit
-                                            (Right (Plain "   ")))
-                                          (!Wrap
-                                            (!Annotated.Append
-                                              [ !Lit
-                                                (Right
-                                                  (Plain "Take")),
-                                                !Lit
-                                                (Right
-                                                  (Plain
-                                                    "shower.")) ])),
-                                          !Lit
-                                          (Right (Plain "\n")),
-                                          !Indent
-                                          (!Lit
-                                            (Right (Plain "3. ")))
-                                          (!Lit
-                                            (Right (Plain "   ")))
-                                          (!Wrap
-                                            (!Annotated.Append
-                                              [ !Lit
-                                                (Right
-                                                  (Plain "Get")),
-                                                !Lit
-                                                (Right
-                                                  (Plain
-                                                    "dressed.")) ])) ]))) ]))) ])))),
-                !Lit (Right (Plain "\n")),
-                !Lit (Right (Plain "\n")),
-                !Indent
-                (!Lit (Right (Plain "  ")))
-                (!Lit (Right (Plain "  ")))
-                (!Annotated.Group
-                  (!Wrap
-                    (!Annotated.Group
-                      (!Annotated.Append
-                        [ !Indent
-                          (!Lit (Right (Plain "# ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Wrap
-                              (!Lit
-                                (Right
-                                  (ConsoleText.Bold
-                                    (Plain "Evaluation")))))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Wrap
-                              (!Annotated.Append
-                                [ !Lit
-                                  (Right (Plain "Expressions")),
-                                  !Lit (Right (Plain "can")),
-                                  !Lit (Right (Plain "be")),
-                                  !Lit
-                                  (Right (Plain "evaluated")),
-                                  !Lit (Right (Plain "inline,")),
-                                  !Lit (Right (Plain "for")),
-                                  !Lit
-                                  (Right (Plain "instance")),
-                                  !Annotated.Group
-                                  (!Annotated.Append
-                                    [ !Lit
-                                      (Left
-                                        (EvalInline
-                                          (Term.Term
-                                            (Any
-                                              (_ -> 1 Nat.+ 1))))),
-                                      !Lit (Right (Plain ".")) ]) ]))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Wrap
-                              (!Annotated.Append
-                                [ !Lit (Right (Plain "Blocks")),
-                                  !Lit (Right (Plain "of")),
-                                  !Lit (Right (Plain "code")),
-                                  !Lit (Right (Plain "can")),
-                                  !Lit (Right (Plain "be")),
-                                  !Lit
-                                  (Right (Plain "evaluated")),
-                                  !Lit (Right (Plain "as")),
-                                  !Lit (Right (Plain "well,")),
-                                  !Lit (Right (Plain "for")),
-                                  !Lit
-                                  (Right (Plain "instance:")) ]))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Lit
-                              (Left
-                                (Eval
-                                  (Term.Term
-                                    (Any
-                                      (_ ->
-                                        id x = x
-                                        id (sqr 10)))))))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Wrap
-                              (!Lit (Right (Plain "also:"))))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Lit
-                              (Left
-                                (Eval
-                                  (Term.Term
-                                    (Any
-                                      (_ ->
-                                        (match 1 with
-                                          1 -> "hi"
-                                          _ -> "goodbye")))))))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Wrap
-                              (!Annotated.Append
-                                [ !Lit (Right (Plain "To")),
-                                  !Lit (Right (Plain "include")),
-                                  !Lit (Right (Plain "a")),
-                                  !Lit
-                                  (Right (Plain "typechecked")),
-                                  !Lit (Right (Plain "snippet")),
-                                  !Lit (Right (Plain "of")),
-                                  !Lit (Right (Plain "code")),
-                                  !Lit (Right (Plain "without")),
-                                  !Lit
-                                  (Right (Plain "evaluating")),
-                                  !Lit (Right (Plain "it,")),
-                                  !Lit (Right (Plain "you")),
-                                  !Lit (Right (Plain "can")),
-                                  !Lit (Right (Plain "do:")) ]))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Lit
-                              (Left
-                                (ExampleBlock
-                                  0 (Term.Term
-                                    (Any
-                                      (_ ->
-                                        cube : Nat -> Nat
-                                        cube x =
-                                          use Nat *
-                                          x * x * x
-                                        ()))))))) ])))),
-                !Lit (Right (Plain "\n")),
-                !Lit (Right (Plain "\n")),
-                !Indent
-                (!Lit (Right (Plain "  ")))
-                (!Lit (Right (Plain "  ")))
-                (!Annotated.Group
-                  (!Wrap
-                    (!Annotated.Group
-                      (!Annotated.Append
-                        [ !Indent
-                          (!Lit (Right (Plain "# ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Wrap
-                              (!Annotated.Append
-                                [ !Lit
-                                  (Right
-                                    (ConsoleText.Bold
-                                      (Plain "Including"))),
-                                  !Lit
-                                  (Right
-                                    (ConsoleText.Bold
-                                      (Plain "Unison"))),
-                                  !Lit
-                                  (Right
-                                    (ConsoleText.Bold
-                                      (Plain "source"))),
-                                  !Lit
-                                  (Right
-                                    (ConsoleText.Bold
-                                      (Plain "code"))) ]))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Wrap
-                              (!Annotated.Append
-                                [ !Lit (Right (Plain "Unison")),
-                                  !Lit
-                                  (Right (Plain "definitions")),
-                                  !Lit (Right (Plain "can")),
-                                  !Lit (Right (Plain "be")),
-                                  !Lit
-                                  (Right (Plain "included")),
-                                  !Lit (Right (Plain "in")),
-                                  !Lit (Right (Plain "docs.")),
-                                  !Lit (Right (Plain "For")),
-                                  !Lit
-                                  (Right (Plain "instance:")) ]))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Wrap
-                              (!Lit
-                                (Left
-                                  (SpecialForm.Source
-                                    [ (Left (typeLink Optional),
-                                    []),
+                                              (Plain "{{ }}")),
+                                          Lit
+                                            ()
+                                            (Right (Plain "`")) ]),
+                                    Lit
+                                      ()
+                                      (Right (Plain "syntax")),
+                                    Lit () (Right (Plain "to")),
+                                    Lit
+                                      () (Right (Plain "call")),
+                                    Lit
+                                      () (Right (Plain "these")),
+                                    Lit
+                                      ()
+                                      (Right (Plain "functions")),
+                                    Lit
+                                      ()
+                                      (Right (Plain "directly.")) ])),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Annotated.Group
+                              ()
+                              (Wrap
+                                ()
+                                (Lit
+                                  ()
+                                  (Left
+                                    (SpecialForm.Signature
+                                      [ Term.Term
+                                          (Any (_ -> docAside)),
+                                        Term.Term
+                                          (Any (_ -> docCallout)),
+                                        Term.Term
+                                          (Any
+                                            (_ -> docBlockquote)),
+                                        Term.Term
+                                          (Any (_ -> docTooltip)),
+                                        Term.Term
+                                          (Any (_ -> docTable)) ])))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Annotated.Group
+                              ()
+                              (Wrap
+                                ()
+                                (Annotated.Append
+                                  ()
+                                  [ Lit
+                                      () (Right (Plain "This")),
+                                    Lit () (Right (Plain "is")),
+                                    Lit () (Right (Plain "an")),
+                                    Lit
+                                      ()
+                                      (Right (Plain "aside.")),
+                                    Lit
+                                      ()
                                       (Right
-                                      (Term.Term
-                                        (Any (_ -> sqr))),
-                                    []) ]))))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Wrap
-                              (!Annotated.Append
-                                [ !Lit (Right (Plain "Some")),
-                                  !Lit
-                                  (Right (Plain "rendering")),
-                                  !Lit (Right (Plain "targets")),
-                                  !Lit (Right (Plain "also")),
-                                  !Lit (Right (Plain "support")),
-                                  !Lit (Right (Plain "folded")),
-                                  !Lit (Right (Plain "source:")) ]))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Wrap
-                              (!Lit
-                                (Left
-                                  (FoldedSource
-                                    [ (Left (typeLink Optional),
-                                    []),
+                                        (Foreground
+                                          BrightBlack
+                                          (Plain "("))),
+                                    Wrap
+                                      ()
+                                      (Annotated.Append
+                                        ()
+                                        [ Lit
+                                            ()
+                                            (Right
+                                              (Foreground
+                                                BrightBlack
+                                                (Plain "Some"))),
+                                          Lit
+                                            ()
+                                            (Right
+                                              (Foreground
+                                                BrightBlack
+                                                (Plain "extra"))),
+                                          Lit
+                                            ()
+                                            (Right
+                                              (Foreground
+                                                BrightBlack
+                                                (Plain "detail"))),
+                                          Lit
+                                            ()
+                                            (Right
+                                              (Foreground
+                                                BrightBlack
+                                                (Plain "that"))),
+                                          Lit
+                                            ()
+                                            (Right
+                                              (Foreground
+                                                BrightBlack
+                                                (Plain "doesn't"))),
+                                          Lit
+                                            ()
+                                            (Right
+                                              (Foreground
+                                                BrightBlack
+                                                (Plain "belong"))),
+                                          Lit
+                                            ()
+                                            (Right
+                                              (Foreground
+                                                BrightBlack
+                                                (Plain "in"))),
+                                          Lit
+                                            ()
+                                            (Right
+                                              (Foreground
+                                                BrightBlack
+                                                (Plain "main"))),
+                                          Lit
+                                            ()
+                                            (Right
+                                              (Foreground
+                                                BrightBlack
+                                                (Plain "text."))) ]),
+                                    Lit
+                                      ()
                                       (Right
-                                      (Term.Term
-                                        (Any (_ -> sqr))),
-                                    []) ]))))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Wrap
-                              (!Annotated.Append
-                                [ !Lit (Right (Plain "You")),
-                                  !Lit (Right (Plain "can")),
-                                  !Lit (Right (Plain "also")),
-                                  !Lit (Right (Plain "include")),
-                                  !Lit (Right (Plain "just")),
-                                  !Lit (Right (Plain "a")),
-                                  !Lit
-                                  (Right (Plain "signature,")),
-                                  !Lit (Right (Plain "inline,")),
-                                  !Lit (Right (Plain "with")),
-                                  !Annotated.Group
-                                  (!Annotated.Append
-                                    [ !Lit
-                                      (Left
-                                        (SignatureInline
-                                          (Term.Term
-                                            (Any (_ -> sqr))))),
-                                      !Lit (Right (Plain ",")) ]),
-                                  !Lit (Right (Plain "or")),
-                                  !Lit (Right (Plain "you")),
-                                  !Lit (Right (Plain "can")),
-                                  !Lit (Right (Plain "include")),
-                                  !Lit (Right (Plain "one")),
-                                  !Lit (Right (Plain "or")),
-                                  !Lit (Right (Plain "more")),
-                                  !Lit
-                                  (Right (Plain "signatures")),
-                                  !Lit (Right (Plain "as")),
-                                  !Lit (Right (Plain "a")),
-                                  !Lit (Right (Plain "block:")) ]))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Wrap
-                              (!Lit
-                                (Left
-                                  (SpecialForm.Signature
-                                    [ Term.Term (Any (_ -> sqr)),
-                                      Term.Term
-                                      (Any (_ -> (Nat.+))) ]))))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Wrap
-                              (!Annotated.Append
-                                [ !Lit (Right (Plain "Or")),
-                                  !Lit
-                                  (Right (Plain "alternately:")) ]))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Wrap
-                              (!Lit
-                                (Left
-                                  (SpecialForm.Signature
-                                    [ Term.Term
-                                      (Any (_ -> List.map)) ]))))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Annotated.Group
-                              (!Annotated.Append
-                                [ !Indent
-                                  (!Lit (Right (Plain "# ")))
-                                  (!Lit (Right (Plain "  ")))
-                                  (!Annotated.Group
-                                    (!Wrap
-                                      (!Annotated.Append
-                                        [ !Lit
-                                          (Right
-                                            (ConsoleText.Bold
-                                              (Plain "Inline"))),
-                                          !Lit
-                                          (Right
-                                            (ConsoleText.Bold
-                                              (Plain "snippets"))) ]))),
-                                  !Lit (Right (Plain "\n")),
-                                  !Lit (Right (Plain "\n")),
-                                  !Indent
-                                  (!Lit (Right (Plain "  ")))
-                                  (!Lit (Right (Plain "  ")))
-                                  (!Annotated.Group
-                                    (!Wrap
-                                      (!Annotated.Append
-                                        [ !Lit
-                                          (Right (Plain "You")),
-                                          !Lit
-                                          (Right (Plain "can")),
-                                          !Lit
-                                          (Right
-                                            (Plain "include")),
-                                          !Lit
-                                          (Right
-                                            (Plain "typechecked")),
-                                          !Lit
-                                          (Right (Plain "code")),
-                                          !Lit
-                                          (Right
-                                            (Plain "snippets")),
-                                          !Lit
-                                          (Right
-                                            (Plain "inline,")),
-                                          !Lit
-                                          (Right (Plain "for")),
-                                          !Lit
-                                          (Right
-                                            (Plain "instance:")) ]))),
-                                  !Lit (Right (Plain "\n")),
-                                  !Lit (Right (Plain "\n")),
-                                  !Indent
-                                  (!Lit (Right (Plain "  ")))
-                                  (!Lit (Right (Plain "  ")))
-                                  (!Annotated.Group
-                                    (!Annotated.Group
-                                      (!Annotated.Append
-                                        [ !Indent
-                                          (!Lit
-                                            (Right (Plain "* ")))
-                                          (!Lit
-                                            (Right (Plain "  ")))
-                                          (!Wrap
-                                            (!Annotated.Append
-                                              [ !Lit
-                                                (Left
-                                                  (Example
-                                                    2
-                                                    (Term.Term
-                                                      (Any
-                                                        '(f x ->
-                                                            f x
-                                                              Nat.+ sqr
-                                                                      1))))),
-                                                !Lit
-                                                (Right
-                                                  (Plain "-")),
-                                                !Lit
-                                                (Right
-                                                  (Plain "the")),
-                                                !Annotated.Group
-                                                (!Annotated.Append
-                                                  [ !Lit
-                                                    (Right
-                                                      (Plain "`")),
-                                                    !Lit
-                                                    (Right
-                                                      (Plain "2")),
-                                                    !Lit
-                                                    (Right
-                                                      (Plain "`")) ]),
-                                                !Lit
-                                                (Right
-                                                  (Plain "says")),
-                                                !Lit
-                                                (Right
-                                                  (Plain "to")),
-                                                !Lit
-                                                (Right
-                                                  (Plain
-                                                    "ignore")),
-                                                !Lit
-                                                (Right
-                                                  (Plain "the")),
-                                                !Lit
-                                                (Right
-                                                  (Plain "first")),
-                                                !Lit
-                                                (Right
-                                                  (Plain "two")),
-                                                !Lit
-                                                (Right
-                                                  (Plain
-                                                    "arguments")),
-                                                !Lit
-                                                (Right
-                                                  (Plain "when")),
-                                                !Lit
-                                                (Right
-                                                  (Plain
-                                                    "rendering.")),
-                                                !Lit
-                                                (Right
-                                                  (Plain "In")),
-                                                !Lit
-                                                (Right
-                                                  (Plain
-                                                    "richer")),
-                                                !Lit
-                                                (Right
-                                                  (Plain
-                                                    "renderers,")),
-                                                !Lit
-                                                (Right
-                                                  (Plain "the")),
-                                                !Annotated.Group
-                                                (!Annotated.Append
-                                                  [ !Lit
-                                                    (Right
-                                                      (Plain "`")),
-                                                    !Lit
-                                                    (Right
-                                                      (Plain
-                                                        "sqr")),
-                                                    !Lit
-                                                    (Right
-                                                      (Plain "`")) ]),
-                                                !Lit
-                                                (Right
-                                                  (Plain "link")),
-                                                !Lit
-                                                (Right
-                                                  (Plain "will")),
-                                                !Lit
-                                                (Right
-                                                  (Plain "be")),
-                                                !Lit
-                                                (Right
-                                                  (Plain
-                                                    "clickable.")) ])),
-                                          !Lit
+                                        (Foreground
+                                          BrightBlack
+                                          (Plain ")"))) ])),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Annotated.Group
+                              ()
+                              (Wrap
+                                ()
+                                (Annotated.Group
+                                  ()
+                                  (Indent
+                                    ()
+                                    (Lit
+                                      () (Right (Plain "  | ")))
+                                    (Lit
+                                      () (Right (Plain "  | ")))
+                                    (Wrap
+                                      ()
+                                      (Annotated.Append
+                                        ()
+                                        [ Lit
+                                            ()
+                                            (Right
+                                              (Plain "This")),
+                                          Lit
+                                            ()
+                                            (Right (Plain "is")),
+                                          Lit
+                                            ()
+                                            (Right (Plain "an")),
+                                          Lit
+                                            ()
+                                            (Right
+                                              (Plain "important")),
+                                          Lit
+                                            ()
+                                            (Right
+                                              (Plain "callout,")),
+                                          Lit
+                                            ()
+                                            (Right
+                                              (Plain "with")),
+                                          Lit
+                                            ()
+                                            (Right (Plain "no")),
+                                          Lit
+                                            ()
+                                            (Right
+                                              (Plain "icon.")) ]))))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Annotated.Group
+                              ()
+                              (Wrap
+                                ()
+                                (Annotated.Group
+                                  ()
+                                  (Indent
+                                    ()
+                                    (Lit
+                                      () (Right (Plain "  | ")))
+                                    (Lit
+                                      () (Right (Plain "  | ")))
+                                    (Annotated.Append
+                                      ()
+                                      [ Wrap
+                                          ()
+                                          (Lit
+                                            ()
+                                            (Right
+                                              (ConsoleText.Bold
+                                                (Plain "🌻")))),
+                                        Lit
+                                          ()
                                           (Right (Plain "\n")),
-                                          !Indent
-                                          (!Lit
-                                            (Right (Plain "* ")))
-                                          (!Lit
-                                            (Right (Plain "  ")))
-                                          (!Wrap
-                                            (!Annotated.Append
-                                              [ !Lit
-                                                (Right
-                                                  (Plain "If")),
-                                                !Lit
-                                                (Right
-                                                  (Plain "your")),
-                                                !Lit
-                                                (Right
-                                                  (Plain
-                                                    "snippet")),
-                                                !Lit
-                                                (Right
-                                                  (Plain
-                                                    "expression")),
-                                                !Lit
-                                                (Right
-                                                  (Plain "is")),
-                                                !Lit
-                                                (Right
-                                                  (Plain "just")),
-                                                !Lit
-                                                (Right
-                                                  (Plain "a")),
-                                                !Lit
-                                                (Right
-                                                  (Plain
-                                                    "single")),
-                                                !Lit
-                                                (Right
-                                                  (Plain
-                                                    "function")),
-                                                !Lit
-                                                (Right
-                                                  (Plain
-                                                    "application,")),
-                                                !Lit
-                                                (Right
-                                                  (Plain "you")),
-                                                !Lit
-                                                (Right
-                                                  (Plain "can")),
-                                                !Lit
-                                                (Right
-                                                  (Plain "put")),
-                                                !Lit
-                                                (Right
-                                                  (Plain "it")),
-                                                !Lit
-                                                (Right
-                                                  (Plain "in")),
-                                                !Lit
-                                                (Right
-                                                  (Plain
-                                                    "double")),
-                                                !Lit
-                                                (Right
-                                                  (Plain
-                                                    "backticks,")),
-                                                !Lit
-                                                (Right
-                                                  (Plain "like")),
-                                                !Lit
-                                                (Right
-                                                  (Plain "so:")),
-                                                !Annotated.Group
-                                                (!Annotated.Append
-                                                  [ !Lit
-                                                    (Left
-                                                      (Example
-                                                        1
-                                                        (Term.Term
-                                                          (Any
-                                                            (_
-                                                            x ->
-                                                              sqr
-                                                                x))))),
-                                                    !Lit
-                                                    (Right
-                                                      (Plain ".")) ]),
-                                                !Lit
+                                        Lit
+                                          () (Right (Plain "")),
+                                        Lit
+                                          ()
+                                          (Right (Plain "\n")),
+                                        Wrap
+                                          ()
+                                          (Annotated.Append
+                                            ()
+                                            [ Lit
+                                                ()
                                                 (Right
                                                   (Plain "This")),
-                                                !Lit
+                                              Lit
+                                                ()
                                                 (Right
                                                   (Plain "is")),
-                                                !Lit
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain "an")),
+                                              Lit
+                                                ()
                                                 (Right
                                                   (Plain
-                                                    "equivalent")),
-                                                !Lit
+                                                    "important")),
+                                              Lit
+                                                ()
                                                 (Right
-                                                  (Plain "to")),
-                                                !Annotated.Group
-                                                (!Annotated.Append
-                                                  [ !Lit
-                                                    (Left
-                                                      (Example
-                                                        1
-                                                        (Term.Term
-                                                          (Any
-                                                            '(x ->
-                                                                sqr
-                                                                  x))))),
-                                                    !Lit
+                                                  (Plain
+                                                    "callout,")),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain "with")),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain "an")),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain "icon.")),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain "The")),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain "text")),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain "wraps")),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain "onto")),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain
+                                                    "multiple")),
+                                              Lit
+                                                ()
+                                                (Right
+                                                  (Plain
+                                                    "lines.")) ]) ])))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Annotated.Group
+                              ()
+                              (Wrap
+                                ()
+                                (Annotated.Group
+                                  ()
+                                  (Indent
+                                    ()
+                                    (Lit () (Right (Plain "> ")))
+                                    (Lit () (Right (Plain "> ")))
+                                    (Annotated.Group
+                                      ()
+                                      (Annotated.Append
+                                        ()
+                                        [ Annotated.Group
+                                            ()
+                                            (Wrap
+                                              ()
+                                              (Annotated.Append
+                                                ()
+                                                [ Lit
+                                                    ()
                                                     (Right
-                                                      (Plain ".")) ]) ])) ]))) ]))) ])))),
-                !Lit (Right (Plain "\n")),
-                !Lit (Right (Plain "\n")),
-                !Indent
-                (!Lit (Right (Plain "  ")))
-                (!Lit (Right (Plain "  ")))
-                (!Annotated.Group
-                  (!Wrap
-                    (!Annotated.Group
-                      (!Annotated.Append
-                        [ !Indent
-                          (!Lit (Right (Plain "# ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Wrap
-                              (!Annotated.Append
-                                [ !Lit
-                                  (Right
-                                    (ConsoleText.Bold
-                                      (Plain "Non-Unison"))),
-                                  !Lit
-                                  (Right
-                                    (ConsoleText.Bold
-                                      (Plain "code"))),
-                                  !Lit
-                                  (Right
-                                    (ConsoleText.Bold
-                                      (Plain "blocks"))) ]))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Wrap
-                              (!Annotated.Append
-                                [ !Lit (Right (Plain "Use")),
-                                  !Lit (Right (Plain "three")),
-                                  !Lit (Right (Plain "or")),
-                                  !Lit (Right (Plain "more")),
-                                  !Lit (Right (Plain "single")),
-                                  !Lit (Right (Plain "quotes")),
-                                  !Lit (Right (Plain "to")),
-                                  !Lit (Right (Plain "start")),
-                                  !Lit (Right (Plain "a")),
-                                  !Lit (Right (Plain "block")),
-                                  !Lit (Right (Plain "with")),
-                                  !Lit (Right (Plain "no")),
-                                  !Lit (Right (Plain "syntax")),
-                                  !Lit
-                                  (Right (Plain "highlighting:")) ]))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Wrap
-                              (!Annotated.Group
-                                (!Annotated.Append
-                                  [ !Lit (Right (Plain "``` ")),
-                                    !Annotated.Group
-                                    (!Lit (Right (Plain "raw"))),
-                                    !Lit (Right (Plain "\n")),
-                                    !Lit
-                                    (Right
-                                      (Plain
-                                        "   _____     _             \n  |  |  |___|_|___ ___ ___ \n  |  |  |   | |_ -| . |   |\n  |_____|_|_|_|___|___|_|_|\n  ")),
-                                    !Lit (Right (Plain "\n")),
-                                    !Lit (Right (Plain "```")) ])))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Wrap
-                              (!Annotated.Append
-                                [ !Lit (Right (Plain "You")),
-                                  !Lit (Right (Plain "can")),
-                                  !Lit (Right (Plain "use")),
-                                  !Lit (Right (Plain "three")),
-                                  !Lit (Right (Plain "or")),
-                                  !Lit (Right (Plain "more")),
-                                  !Lit
-                                  (Right (Plain "backticks")),
-                                  !Lit (Right (Plain "plus")),
-                                  !Lit (Right (Plain "a")),
-                                  !Lit
-                                  (Right (Plain "language")),
-                                  !Lit (Right (Plain "name")),
-                                  !Lit (Right (Plain "for")),
-                                  !Lit (Right (Plain "blocks")),
-                                  !Lit (Right (Plain "with")),
-                                  !Lit (Right (Plain "syntax")),
-                                  !Lit
-                                  (Right (Plain "highlighting:")) ]))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Annotated.Group
-                              (!Annotated.Append
-                                [ !Lit (Right (Plain "``` ")),
-                                  !Annotated.Group
-                                  (!Lit
-                                    (Right (Plain "Haskell"))),
-                                  !Lit (Right (Plain "\n")),
-                                  !Lit
-                                  (Right
-                                    (Plain
-                                      "-- A fenced code block which isn't parsed by Unison\nreverse = foldl (flip (:)) []")),
-                                  !Lit (Right (Plain "\n")),
-                                  !Lit (Right (Plain "```")) ]))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Indent
-                          (!Lit (Right (Plain "  ")))
-                          (!Lit (Right (Plain "  ")))
-                          (!Annotated.Group
-                            (!Annotated.Group
-                              (!Annotated.Append
-                                [ !Lit (Right (Plain "``` ")),
-                                  !Annotated.Group
-                                  (!Lit (Right (Plain "Scala"))),
-                                  !Lit (Right (Plain "\n")),
-                                  !Lit
-                                  (Right
-                                    (Plain
-                                      "// A fenced code block which isn't parsed by Unison\ndef reverse[A](xs: List[A]) = \n  xs.foldLeft(Nil : List[A])((acc,a) => a +: acc)")),
-                                  !Lit (Right (Plain "\n")),
-                                  !Lit (Right (Plain "```")) ]))) ])))),
-                !Lit (Right (Plain "\n")),
-                !Lit (Right (Plain "\n")),
-                !Indent
-                (!Lit (Right (Plain "  ")))
-                (!Lit (Right (Plain "  ")))
-                (!Annotated.Group
-                  (!Wrap
-                    (!Annotated.Group
-                      (!Annotated.Append
-                        [ !Annotated.Group
-                          (!Wrap
-                            (!Annotated.Append
-                              [ !Lit (Right (Plain "There")),
-                                !Lit (Right (Plain "are")),
-                                !Lit (Right (Plain "also")),
-                                !Lit (Right (Plain "asides,")),
-                                !Lit (Right (Plain "callouts,")),
-                                !Lit (Right (Plain "tables,")),
-                                !Lit (Right (Plain "tooltips,")),
-                                !Lit (Right (Plain "and")),
-                                !Lit (Right (Plain "more.")),
-                                !Lit (Right (Plain "These")),
-                                !Lit (Right (Plain "don't")),
-                                !Lit (Right (Plain "currently")),
-                                !Lit (Right (Plain "have")),
-                                !Lit (Right (Plain "special")),
-                                !Lit (Right (Plain "syntax;")),
-                                !Lit (Right (Plain "just")),
-                                !Lit (Right (Plain "use")),
-                                !Lit (Right (Plain "the")),
-                                !Annotated.Group
-                                (!Annotated.Append
-                                  [ !Lit (Right (Plain "`")),
-                                    !Lit (Right (Plain "{{ }}")),
-                                    !Lit (Right (Plain "`")) ]),
-                                !Lit (Right (Plain "syntax")),
-                                !Lit (Right (Plain "to")),
-                                !Lit (Right (Plain "call")),
-                                !Lit (Right (Plain "these")),
-                                !Lit (Right (Plain "functions")),
-                                !Lit (Right (Plain "directly.")) ])),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Annotated.Group
-                          (!Wrap
-                            (!Lit
-                              (Left
-                                (SpecialForm.Signature
-                                  [ Term.Term
-                                    (Any (_ -> docAside)),
-                                    Term.Term
-                                    (Any (_ -> docCallout)),
-                                    Term.Term
-                                    (Any (_ -> docBlockquote)),
-                                    Term.Term
-                                    (Any (_ -> docTooltip)),
-                                    Term.Term
-                                    (Any (_ -> docTable)) ])))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Annotated.Group
-                          (!Wrap
-                            (!Annotated.Append
-                              [ !Lit (Right (Plain "This")),
-                                !Lit (Right (Plain "is")),
-                                !Lit (Right (Plain "an")),
-                                !Lit (Right (Plain "aside.")),
-                                !Lit
-                                (Right
-                                  (Foreground
-                                    BrightBlack (Plain "("))),
-                                !Wrap
-                                (!Annotated.Append
-                                  [ !Lit
-                                    (Right
-                                      (Foreground
-                                        BrightBlack
-                                        (Plain "Some"))),
-                                    !Lit
-                                    (Right
-                                      (Foreground
-                                        BrightBlack
-                                        (Plain "extra"))),
-                                    !Lit
-                                    (Right
-                                      (Foreground
-                                        BrightBlack
-                                        (Plain "detail"))),
-                                    !Lit
-                                    (Right
-                                      (Foreground
-                                        BrightBlack
-                                        (Plain "that"))),
-                                    !Lit
-                                    (Right
-                                      (Foreground
-                                        BrightBlack
-                                        (Plain "doesn't"))),
-                                    !Lit
-                                    (Right
-                                      (Foreground
-                                        BrightBlack
-                                        (Plain "belong"))),
-                                    !Lit
-                                    (Right
-                                      (Foreground
-                                        BrightBlack (Plain "in"))),
-                                    !Lit
-                                    (Right
-                                      (Foreground
-                                        BrightBlack
-                                        (Plain "main"))),
-                                    !Lit
-                                    (Right
-                                      (Foreground
-                                        BrightBlack
-                                        (Plain "text."))) ]),
-                                !Lit
-                                (Right
-                                  (Foreground
-                                    BrightBlack (Plain ")"))) ])),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Annotated.Group
-                          (!Wrap
-                            (!Annotated.Group
-                              (!Indent
-                                (!Lit (Right (Plain "  | ")))
-                                (!Lit (Right (Plain "  | ")))
-                                (!Wrap
-                                  (!Annotated.Append
-                                    [ !Lit
-                                      (Right (Plain "This")),
-                                      !Lit (Right (Plain "is")),
-                                      !Lit (Right (Plain "an")),
-                                      !Lit
-                                      (Right (Plain "important")),
-                                      !Lit
-                                      (Right (Plain "callout,")),
-                                      !Lit
-                                      (Right (Plain "with")),
-                                      !Lit (Right (Plain "no")),
-                                      !Lit
-                                      (Right (Plain "icon.")) ]))))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Annotated.Group
-                          (!Wrap
-                            (!Annotated.Group
-                              (!Indent
-                                (!Lit (Right (Plain "  | ")))
-                                (!Lit (Right (Plain "  | ")))
-                                (!Annotated.Append
-                                  [ !Wrap
-                                    (!Lit
-                                      (Right
-                                        (ConsoleText.Bold
-                                          (Plain "🌻")))),
-                                    !Lit (Right (Plain "\n")),
-                                    !Lit (Right (Plain "")),
-                                    !Lit (Right (Plain "\n")),
-                                    !Wrap
-                                    (!Annotated.Append
-                                      [ !Lit
-                                        (Right (Plain "This")),
-                                        !Lit
-                                        (Right (Plain "is")),
-                                        !Lit
-                                        (Right (Plain "an")),
-                                        !Lit
-                                        (Right
-                                          (Plain "important")),
-                                        !Lit
-                                        (Right
-                                          (Plain "callout,")),
-                                        !Lit
-                                        (Right (Plain "with")),
-                                        !Lit
-                                        (Right (Plain "an")),
-                                        !Lit
-                                        (Right (Plain "icon.")),
-                                        !Lit
-                                        (Right (Plain "The")),
-                                        !Lit
-                                        (Right (Plain "text")),
-                                        !Lit
-                                        (Right (Plain "wraps")),
-                                        !Lit
-                                        (Right (Plain "onto")),
-                                        !Lit
-                                        (Right
-                                          (Plain "multiple")),
-                                        !Lit
-                                        (Right (Plain "lines.")) ]) ])))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Annotated.Group
-                          (!Wrap
-                            (!Annotated.Group
-                              (!Indent
-                                (!Lit (Right (Plain "> ")))
-                                (!Lit (Right (Plain "> ")))
-                                (!Annotated.Group
-                                  (!Annotated.Append
-                                    [ !Annotated.Group
-                                      (!Wrap
-                                        (!Annotated.Append
-                                          [ !Lit
-                                            (Right
-                                              (Plain "\"And")),
-                                            !Lit
-                                            (Right
-                                              (Plain "what")),
-                                            !Lit
-                                            (Right (Plain "is")),
-                                            !Lit
-                                            (Right (Plain "the")),
-                                            !Lit
-                                            (Right (Plain "use")),
-                                            !Lit
-                                            (Right (Plain "of")),
-                                            !Lit
-                                            (Right (Plain "a")),
-                                            !Lit
-                                            (Right
-                                              (Plain "book,\"")),
-                                            !Lit
-                                            (Right
-                                              (Plain "thought")),
-                                            !Lit
-                                            (Right
-                                              (Plain "Alice,")),
-                                            !Lit
-                                            (Right
-                                              (Plain "\"without")),
-                                            !Lit
-                                            (Right
-                                              (Plain "pictures")),
-                                            !Lit
-                                            (Right (Plain "or")),
-                                            !Lit
-                                            (Right
-                                              (Plain
-                                                "conversation?\"")) ])),
-                                      !Lit (Right (Plain "\n")),
-                                      !Lit (Right (Plain "\n")),
-                                      !Annotated.Group
-                                      (!Wrap
-                                        (!Annotated.Append
-                                          [ !Annotated.Group
-                                            (!Annotated.Append
-                                              [ !Lit
-                                                (Right
-                                                  (Plain "*")),
-                                                !Lit
-                                                (Right
-                                                  (Plain "Lewis")) ]),
-                                            !Lit
-                                            (Right
-                                              (Plain "Carroll,")),
-                                            !Lit
-                                            (Right
-                                              (Plain "Alice's")),
-                                            !Lit
-                                            (Right
-                                              (Plain
-                                                "Adventures")),
-                                            !Lit
-                                            (Right (Plain "in")),
-                                            !Annotated.Group
-                                            (!Annotated.Append
-                                              [ !Lit
-                                                (Right
-                                                  (Plain
-                                                    "Wonderland")),
-                                                !Lit
-                                                (Right
-                                                  (Plain "*")) ]) ])) ]))))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Annotated.Group
-                          (!Wrap
-                            (!Wrap
-                              (!Annotated.Append
-                                [ !Lit (Right (Plain "Hover")),
-                                  !Lit (Right (Plain "over")),
-                                  !Lit (Right (Plain "me")) ]))),
-                          !Lit (Right (Plain "\n")),
-                          !Lit (Right (Plain "\n")),
-                          !Annotated.Group
-                          (!Wrap
-                            (!Annotated.Table
-                              [ [ !Wrap
-                                (!Lit (Right (Plain "a"))),
-                                !Wrap (!Lit (Right (Plain "b"))),
-                                !Wrap
-                                (!Annotated.Append
-                                  [ !Lit (Right (Plain "A")),
-                                    !Lit
-                                    (Right (Plain "longer")),
-                                    !Lit
-                                    (Right (Plain "paragraph")),
-                                    !Lit (Right (Plain "that")),
-                                    !Lit (Right (Plain "will")),
-                                    !Lit (Right (Plain "split")),
-                                    !Lit (Right (Plain "onto")),
-                                    !Lit
-                                    (Right (Plain "multiple")),
-                                    !Lit
-                                    (Right (Plain "lines,")),
-                                    !Lit (Right (Plain "such")),
-                                    !Lit (Right (Plain "that")),
-                                    !Lit (Right (Plain "this")),
-                                    !Lit (Right (Plain "row")),
-                                    !Lit
-                                    (Right (Plain "occupies")),
-                                    !Lit
-                                    (Right (Plain "multiple")),
-                                    !Lit (Right (Plain "lines")),
-                                    !Lit (Right (Plain "in")),
-                                    !Lit (Right (Plain "the")),
-                                    !Lit
-                                    (Right (Plain "rendered")),
-                                    !Lit
-                                    (Right (Plain "table.")) ]) ],
-                                [ !Wrap
-                                (!Annotated.Append
-                                  [ !Lit (Right (Plain "Some")),
-                                    !Lit (Right (Plain "text")) ]),
-                                !Wrap
-                                (!Annotated.Append
-                                  [ !Lit (Right (Plain "More")),
-                                    !Lit (Right (Plain "text")) ]),
-                                !Wrap
-                                (!Lit (Right (Plain "Zounds!"))) ] ])) ])))) ])
+                                                      (Plain
+                                                        "\"And")),
+                                                  Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "what")),
+                                                  Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "is")),
+                                                  Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "the")),
+                                                  Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "use")),
+                                                  Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "of")),
+                                                  Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain "a")),
+                                                  Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "book,\"")),
+                                                  Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "thought")),
+                                                  Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "Alice,")),
+                                                  Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "\"without")),
+                                                  Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "pictures")),
+                                                  Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "or")),
+                                                  Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "conversation?\"")) ])),
+                                          Lit
+                                            ()
+                                            (Right (Plain "\n")),
+                                          Lit
+                                            ()
+                                            (Right (Plain "\n")),
+                                          Annotated.Group
+                                            ()
+                                            (Wrap
+                                              ()
+                                              (Annotated.Append
+                                                ()
+                                                [ Annotated.Group
+                                                    ()
+                                                    (Annotated.Append
+                                                      ()
+                                                      [ Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "*")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "Lewis")) ]),
+                                                  Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "Carroll,")),
+                                                  Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "Alice's")),
+                                                  Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "Adventures")),
+                                                  Lit
+                                                    ()
+                                                    (Right
+                                                      (Plain
+                                                        "in")),
+                                                  Annotated.Group
+                                                    ()
+                                                    (Annotated.Append
+                                                      ()
+                                                      [ Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "Wonderland")),
+                                                        Lit
+                                                          ()
+                                                          (Right
+                                                            (Plain
+                                                              "*")) ]) ])) ]))))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Annotated.Group
+                              ()
+                              (Wrap
+                                ()
+                                (Wrap
+                                  ()
+                                  (Annotated.Append
+                                    ()
+                                    [ Lit
+                                        ()
+                                        (Right (Plain "Hover")),
+                                      Lit
+                                        ()
+                                        (Right (Plain "over")),
+                                      Lit
+                                        () (Right (Plain "me")) ]))),
+                            Lit () (Right (Plain "\n")),
+                            Lit () (Right (Plain "\n")),
+                            Annotated.Group
+                              ()
+                              (Wrap
+                                ()
+                                (Annotated.Table
+                                  ()
+                                  [ [ Wrap
+                                        ()
+                                        (Lit
+                                          () (Right (Plain "a"))),
+                                      Wrap
+                                        ()
+                                        (Lit
+                                          () (Right (Plain "b"))),
+                                      Wrap
+                                        ()
+                                        (Annotated.Append
+                                          ()
+                                          [ Lit
+                                              ()
+                                              (Right (Plain "A")),
+                                            Lit
+                                              ()
+                                              (Right
+                                                (Plain "longer")),
+                                            Lit
+                                              ()
+                                              (Right
+                                                (Plain
+                                                  "paragraph")),
+                                            Lit
+                                              ()
+                                              (Right
+                                                (Plain "that")),
+                                            Lit
+                                              ()
+                                              (Right
+                                                (Plain "will")),
+                                            Lit
+                                              ()
+                                              (Right
+                                                (Plain "split")),
+                                            Lit
+                                              ()
+                                              (Right
+                                                (Plain "onto")),
+                                            Lit
+                                              ()
+                                              (Right
+                                                (Plain
+                                                  "multiple")),
+                                            Lit
+                                              ()
+                                              (Right
+                                                (Plain "lines,")),
+                                            Lit
+                                              ()
+                                              (Right
+                                                (Plain "such")),
+                                            Lit
+                                              ()
+                                              (Right
+                                                (Plain "that")),
+                                            Lit
+                                              ()
+                                              (Right
+                                                (Plain "this")),
+                                            Lit
+                                              ()
+                                              (Right
+                                                (Plain "row")),
+                                            Lit
+                                              ()
+                                              (Right
+                                                (Plain
+                                                  "occupies")),
+                                            Lit
+                                              ()
+                                              (Right
+                                                (Plain
+                                                  "multiple")),
+                                            Lit
+                                              ()
+                                              (Right
+                                                (Plain "lines")),
+                                            Lit
+                                              ()
+                                              (Right
+                                                (Plain "in")),
+                                            Lit
+                                              ()
+                                              (Right
+                                                (Plain "the")),
+                                            Lit
+                                              ()
+                                              (Right
+                                                (Plain
+                                                  "rendered")),
+                                            Lit
+                                              ()
+                                              (Right
+                                                (Plain "table.")) ]) ],
+                                    [ Wrap
+                                        ()
+                                        (Annotated.Append
+                                          ()
+                                          [ Lit
+                                              ()
+                                              (Right
+                                                (Plain "Some")),
+                                            Lit
+                                              ()
+                                              (Right
+                                                (Plain "text")) ]),
+                                      Wrap
+                                        ()
+                                        (Annotated.Append
+                                          ()
+                                          [ Lit
+                                              ()
+                                              (Right
+                                                (Plain "More")),
+                                            Lit
+                                              ()
+                                              (Right
+                                                (Plain "text")) ]),
+                                      Wrap
+                                        ()
+                                        (Lit
+                                          ()
+                                          (Right
+                                            (Plain "Zounds!"))) ] ])) ])))) ])
 
 ```

--- a/unison-src/transcripts/constructor-applied-to-unit.md
+++ b/unison-src/transcripts/constructor-applied-to-unit.md
@@ -1,0 +1,11 @@
+```ucm:hide
+.> alias.type ##Nat Nat
+.> alias.term ##Any.Any Any
+```
+
+```unison
+structural type Zoink a b c = Zoink a b c
+
+> Any ()
+> [ Zoink [0,1,2,3,4,5] [6,3,3,3,3,3,3,3,3,3,3,4,4,4,4,4,4,4,4,4,3] () ]
+```

--- a/unison-src/transcripts/constructor-applied-to-unit.output.md
+++ b/unison-src/transcripts/constructor-applied-to-unit.output.md
@@ -1,0 +1,52 @@
+```unison
+structural type Zoink a b c = Zoink a b c
+
+> Any ()
+> [ Zoink [0,1,2,3,4,5] [6,3,3,3,3,3,3,3,3,3,3,4,4,4,4,4,4,4,4,4,3] () ]
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      structural type Zoink a b c
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    3 | > Any ()
+          ⧩
+          Any ()
+  
+    4 | > [ Zoink [0,1,2,3,4,5] [6,3,3,3,3,3,3,3,3,3,3,4,4,4,4,4,4,4,4,4,3] () ]
+          ⧩
+          [ Zoink
+              [0, 1, 2, 3, 4, 5]
+              [ 6,
+                3,
+                3,
+                3,
+                3,
+                3,
+                3,
+                3,
+                3,
+                3,
+                3,
+                4,
+                4,
+                4,
+                4,
+                4,
+                4,
+                4,
+                4,
+                4,
+                3 ]
+              () ]
+
+```

--- a/unison-src/transcripts/io.output.md
+++ b/unison-src/transcripts/io.output.md
@@ -507,7 +507,7 @@ Calling our examples with the wrong number of args will error.
   
   The program halted with an unhandled exception:
   
-    Failure (typeLink IOFailure) "called with args" !Any
+    Failure (typeLink IOFailure) "called with args" (Any ())
 
 ```
 ```ucm
@@ -517,7 +517,7 @@ Calling our examples with the wrong number of args will error.
   
   The program halted with an unhandled exception:
   
-    Failure (typeLink IOFailure) "called with no args" !Any
+    Failure (typeLink IOFailure) "called with no args" (Any ())
 
 ```
 ```ucm
@@ -528,7 +528,7 @@ Calling our examples with the wrong number of args will error.
   The program halted with an unhandled exception:
   
     Failure
-      (typeLink IOFailure) "called with too many args" !Any
+      (typeLink IOFailure) "called with too many args" (Any ())
 
 ```
 ```ucm
@@ -538,6 +538,6 @@ Calling our examples with the wrong number of args will error.
   
   The program halted with an unhandled exception:
   
-    Failure (typeLink IOFailure) "called with no args" !Any
+    Failure (typeLink IOFailure) "called with no args" (Any ())
 
 ```

--- a/unison-src/transcripts/top-level-exceptions.output.md
+++ b/unison-src/transcripts/top-level-exceptions.output.md
@@ -90,6 +90,6 @@ unique type RuntimeError =
   
   The program halted with an unhandled exception:
   
-    Failure (typeLink RuntimeError) "oh noes!" !Any
+    Failure (typeLink RuntimeError) "oh noes!" (Any ())
 
 ```


### PR DESCRIPTION
Fixes #2402 

This fixes some peculiar use of `!` syntax in pretty-printing application of data constructors, in favor of just passing `()` directly. Like you won't see `!Some` or `!Left`, instead you'll now see `Some ()` and `Left ()`. Have a look at the diff in the transcripts to see more examples.

As I fixed this, I noticed indentation is wrong for multiline lists containing multiline expressions, and fixed that as well. Sorry didn't bother with a separate PR. Specifically, if we have:

```haskell
x = [ foo -- this doesn't parse, yet this is how it is current printed 
      x -- this line should be indented by 2 more
      y -- same here
    , blah ]
```

And the `foo x y` can't fit on one line, it's subsequent lines past the first need to be indented by 2 more than they are, because the list elements start at relative column 2 (after `[ `).

Added a regression test for this to the round trip harness.