### PR TITLE
stop using Shellmet in Git.hs

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
@@ -24,7 +24,6 @@ import Control.Monad.Except (MonadError, throwError)
 import qualified Data.ByteString.Base16 as ByteString
 import qualified Data.Char as Char
 import qualified Data.Text as Text
-import Shellmet (($?), ($^), ($|))
 import System.Exit (ExitCode (ExitSuccess))
 import System.FilePath ((</>))
 import System.IO.Unsafe (unsafePerformIO)
@@ -307,3 +306,38 @@ gitTextIn :: MonadIO m => GitRepo -> [Text] -> m Text
 gitTextIn localPath args = do
   when debugGit $ traceM (Text.unpack . Text.unwords $ ["$ git"] <> setupGitDir localPath <> args)
   liftIO $ "git" $| setupGitDir localPath <> args
+
+-- copying the Shellmet API for now; we can rename or change it up later
+
+{- | This operator runs shell command with given options but doesn't print the
+command itself.
+>>> "echo" $^ ["Foo", "Bar"]
+Foo Bar
+-}
+infix 5 $^
+($^) :: MonadIO m => FilePath -> [Text] -> m ()
+cmd $^ args = UnliftIO.callProcess cmd (map Text.unpack args)
+
+{- | Run shell command with given options and return stripped stdout of the
+executed command.
+>>> "echo" $| ["Foo", "Bar"]
+"Foo Bar"
+-}
+infix 5 $|
+($|) :: MonadIO m => FilePath -> [Text] -> m Text
+cmd $| args = post <$> UnliftIO.readProcess cmd (map Text.unpack args) stdin
+  where
+    stdin = ""
+    post = Text.strip . Text.pack
+
+{- | Do some IO actions when process failed with 'IOError'.
+>>> "exit" ["0"] $? putStrLn "Command failed"
+⚙  exit 0
+>>> "exit" ["1"] $? putStrLn "Command failed"
+⚙  exit 1
+Command failed
+-}
+infixl 4 $?
+($?) :: IO a -> IO a -> IO a
+action $? handler = action `UnliftIO.catch` \(_ :: IOError) -> handler
+{-# INLINE ($?) #-}


### PR DESCRIPTION
## Overview

Shellmet uses an api (`System.Process.showCommandForUser`) that takes a command and a list of individual arguments and builds a single string that is supposed to be suitable for passing to `sh` or `cmd.exe` for running that command. Then it passes this string to `System.Process.callCommand`. However, this wasn't working for us to launch `git` in Windows, for unknown reasons.

<img width="977" alt="image" src="https://user-images.githubusercontent.com/538571/153774402-d460bce6-b6fd-480c-a50f-481eb17c0402.png">

This PR replaces `callCommand` + `showCommandForUser` with `callProcess`, which does work to launch `git` in Windows.

<img width="597" alt="image" src="https://user-images.githubusercontent.com/538571/153773546-868b93cc-268f-4923-9c00-df541202b95d.png">

Closes #1870 

I think `showCommandForUser` was just being used for Shellmet stdout / debug purposes.

## Implementation notes

I removed the Shellmet import from Git.hs, and rewrote the three operators we were using (`($^), ($|), ($?)`) at the bottom of the file.

<!--
## Interesting/controversial decisions

Include anything that you thought twice about, debated, chose arbitrarily, etc. 
What could have been done differently, but wasn't? And why?
-->

## Test coverage

Have you included tests (which could be a transcript) for this change, or is it somehow covered by existing tests? 

Would you recommend improving the test coverage (either as part of this PR or as a separate issue) or do you think it’s adequate?

## Loose ends

We still use Shellmet in a few places, and we probably shouldn't. unison-cli tests will probably fail in CI, and then I'll have to give them the same treatment. 

- [ ] `unison-cli` tests use Shellmet for `git`
- [ ] `transcripts` tests use Shellmet for `stack exec -- unison transcript`
- [ ] `integration-tests` probably uses Shellmet for `stack exec -- unison`
- [ ] `Version.hs`?

Just kidding, the CI tests won't fail because we don't use any Windows CI image; but we should. This is tracked in #598.

Really we should make our own shell package, and remove the dependency on Shellmet.