### PR TITLE
Use 'v2' branch for auto-pull of base on topic/rehash-codebase

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
@@ -26,5 +26,9 @@ defaultBaseLib = fmap makeNS $ latest <|> release
     Text.pack <$> some (alphaNumChar <|> ('_' <$ oneOf ['.', '_', '-']))
   makeNS :: Text -> ReadRemoteNamespace
   makeNS t = ( ReadGitRepo {url="https://github.com/unisonweb/base",ref=Nothing}
-             , Nothing
+             -- Use the 'v2' branch of base for now.
+             -- We can revert back to the main branch once enough people have upgraded ucm and
+             -- we're okay with pushing the v2 base codebase to main (perhaps by the next ucm
+             -- release).
+             , Just "v2"
              , Path.fromText t)

--- a/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
@@ -25,10 +25,10 @@ defaultBaseLib = fmap makeNS $ latest <|> release
   version = do
     Text.pack <$> some (alphaNumChar <|> ('_' <$ oneOf ['.', '_', '-']))
   makeNS :: Text -> ReadRemoteNamespace
-  makeNS t = ( ReadGitRepo {url="https://github.com/unisonweb/base",ref=Nothing}
+  makeNS t = ( ReadGitRepo {url="https://github.com/unisonweb/base",ref=Just "v2"}
              -- Use the 'v2' branch of base for now.
              -- We can revert back to the main branch once enough people have upgraded ucm and
              -- we're okay with pushing the v2 base codebase to main (perhaps by the next ucm
              -- release).
-             , Just "v2"
+             , Nothing
              , Path.fromText t)

--- a/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
@@ -25,10 +25,12 @@ defaultBaseLib = fmap makeNS $ latest <|> release
   version = do
     Text.pack <$> some (alphaNumChar <|> ('_' <$ oneOf ['.', '_', '-']))
   makeNS :: Text -> ReadRemoteNamespace
-  makeNS t = ( ReadGitRepo {url="https://github.com/unisonweb/base",ref=Just "v2"}
-             -- Use the 'v2' branch of base for now.
-             -- We can revert back to the main branch once enough people have upgraded ucm and
-             -- we're okay with pushing the v2 base codebase to main (perhaps by the next ucm
-             -- release).
+  makeNS t = ( ReadGitRepo { url="https://github.com/unisonweb/base"
+                           -- Use the 'v2' branch of base for now.
+                           -- We can revert back to the main branch once enough people have upgraded ucm and
+                           -- we're okay with pushing the v2 base codebase to main (perhaps by the next ucm
+                           -- release).
+                           , ref=Just "v2"
+                           }
              , Nothing
              , Path.fromText t)

--- a/unison-cli/tests/Unison/Test/VersionParser.hs
+++ b/unison-cli/tests/Unison/Test/VersionParser.hs
@@ -24,6 +24,7 @@ makeTest (version, path) =
   scope (unpack version) $ expectEqual
     (rightMay $ runParser defaultBaseLib "versionparser" version)
     (Just
-      ( ReadGitRepo "https://github.com/unisonweb/base" Nothing
+      -- We've hard-coded the v2 branch for base for now. See 'defaultBaseLib'
+      ( ReadGitRepo "https://github.com/unisonweb/base" (Just "v2")
       , Nothing
       , Path.fromText path ))


### PR DESCRIPTION
## Overview

Use 'v2' branch of base to avoid needing to migrate base on every pull.

This also allows us to keep v1 and v2 versions of base around during the transition period.

## Implementation notes

I just added a branch into the repo object that ucm uses for pulling base.

I tested it by creating a new codebase and it works fine, we'll just need to remember to push the base version for the next release to the `v2` branch. 👍🏼 