### PR TITLE
Don't sync ALL test watches.

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Sync22.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Sync22.hs
@@ -361,22 +361,27 @@ trySync tCache hCache oCache cCache = \case
       srcParents <- runSrc $ Q.loadCausalParents chId
       traverse syncCausal srcParents
 
+    -- Sync any watches of the given kinds to the dest if and only if watches of those kinds
+    -- exist in the src.
     syncWatch :: WK.WatchKind -> Sqlite.Reference.IdH -> m (TrySyncResult Entity)
     syncWatch wk r | debug && trace ("Sync22.syncWatch " ++ show wk ++ " " ++ show r) False = undefined
     syncWatch wk r = do
-      r' <- traverse syncHashLiteral r
-      doneKinds <- runDest (Q.loadWatchKindsByReference r')
-      if (notElem wk doneKinds) then do
-        runSrc (Q.loadWatch wk r) >>= traverse \blob -> do
-          TL.SyncWatchResult li body <-
-            either (throwError . DecodeError ErrWatchResult blob) pure $ runGetS S.decomposeWatchFormat blob
-          li' <- bitraverse syncTextLiteral syncHashLiteral li
-          when debug $ traceM $ "LocalIds for Source watch result " ++ show r ++ ": " ++ show li
-          when debug $ traceM $ "LocalIds for Dest watch result " ++ show r' ++ ": " ++ show li'
-          let blob' = runPutS $ S.recomposeWatchFormat (TL.SyncWatchResult li' body)
-          runDest (Q.saveWatch wk r' blob')
-        pure Sync.Done
-      else pure Sync.PreviouslyDone
+      runSrc (Q.loadWatch wk r) >>= \case
+        Nothing -> pure Sync.Done
+        Just blob -> do
+          r' <- traverse syncHashLiteral r
+          doneKinds <- runDest (Q.loadWatchKindsByReference r')
+          if (elem wk doneKinds)
+            then pure Sync.PreviouslyDone
+            else do
+              TL.SyncWatchResult li body <-
+                either (throwError . DecodeError ErrWatchResult blob) pure $ runGetS S.decomposeWatchFormat blob
+              li' <- bitraverse syncTextLiteral syncHashLiteral li
+              when debug $ traceM $ "LocalIds for Source watch result " ++ show r ++ ": " ++ show li
+              when debug $ traceM $ "LocalIds for Dest watch result " ++ show r' ++ ": " ++ show li'
+              let blob' = runPutS $ S.recomposeWatchFormat (TL.SyncWatchResult li' body)
+              runDest (Q.saveWatch wk r' blob')
+              pure Sync.Done
 
     syncSecondaryHashes oId oId' =
       runSrc (Q.hashIdWithVersionForObject oId) >>= traverse_ (go oId')

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -43,7 +43,6 @@ import qualified U.Codebase.Sqlite.Operations as Ops
 import qualified U.Codebase.Sqlite.Queries as Q
 import qualified U.Codebase.Sqlite.Sync22 as Sync22
 import qualified U.Codebase.Sync as Sync
-import qualified U.Codebase.WatchKind as WK
 import qualified U.Util.Cache as Cache
 import qualified U.Util.Hash as H2
 import qualified U.Util.Monoid as Monoid
@@ -903,10 +902,6 @@ syncInternal progress srcConn destConn b = time "syncInternal" do
     let progress' = Sync.transformProgress (lift . lift) progress
         bHash = Branch.headHash b
     se $ time "SyncInternal.processBranches" $ processBranches sync progress' [B bHash (pure b)]
-    testWatchRefs <- time "SyncInternal enumerate testWatches" $
-      lift . fmap concat $ for [WK.TestWatch] \wk ->
-        fmap (Sync22.W wk) <$> flip runReaderT srcConn (Q.loadWatchesByWatchKind wk)
-    se . r $ Sync.sync sync progress' testWatchRefs
   let onSuccess a = runDB destConn (Q.release "sync") *> pure a
       onFailure e = do
         if debugCommitFailedTransaction


### PR DESCRIPTION
## Overview

closes #2861 

The behaviour on trunk is to ALWAYS sync all test watches in the entire codebase, even if those watches are unreachable from the current namespace root (e.g. have been deleted)

This means that not only are we probably keeping around a bunch of old tests and test results (which can take up a decent amount of space, especially since tests are often iterated on during development), but we also sync them on every push/pull, meaning we also collect ALL historical test watches and results from every codebase we touch, which could inflate sizes a bit in the long run.

Naturally, syncing fewer things also results in a small speedup on all syncs.

This is also a nice fix for when we push to a fresh codebase or new git branch (e.g. named gists), I discovered the issue when I pushed a small branch with only 2 definitions to a fresh branch and it ended up being a 2 MB codebase (from all the watch expressions). Without them it's only 208kb.

Saves about 1 MB on both of base and share as well.

## Implementation notes

This change simply doesn't manually sync test watches. Any test watches which are accessible from the branch being synced are still propagated through the other object syncing logic. (as well as the watch results)

## Test coverage

I tested it out manually and it is correctly excluding watches except ones included in the branch which is being synced.