### PR TITLE
Fix an issue with the effect variable linearizing patch

### DIFF
--- a/unison-src/transcripts/abilities.md
+++ b/unison-src/transcripts/abilities.md
@@ -1,0 +1,27 @@
+
+```ucm:hide
+.> builtins.merge
+```
+
+Some random ability stuff to ensure things work.
+
+```unison
+
+unique ability A where
+  one : Nat ->{A} Nat
+  two : Nat -> Nat ->{A} Nat
+  three : Nat -> Nat -> Nat ->{A} Nat
+  four : Nat ->{A} (Nat -> Nat -> Nat -> Nat)
+
+ha : Request {A} r -> r
+ha = cases
+  { x } -> x
+  { one i -> c } -> handle c (i+1) with ha
+  { two i j -> c } -> handle c (i+j) with ha
+  { three i j k -> c } -> handle c (i+j+k) with ha
+  { four i -> c } -> handle c (j k l -> i+j+k+l) with ha
+```
+
+```ucm
+.> add
+```

--- a/unison-src/transcripts/abilities.output.md
+++ b/unison-src/transcripts/abilities.output.md
@@ -1,0 +1,40 @@
+
+Some random ability stuff to ensure things work.
+
+```unison
+unique ability A where
+  one : Nat ->{A} Nat
+  two : Nat -> Nat ->{A} Nat
+  three : Nat -> Nat -> Nat ->{A} Nat
+  four : Nat ->{A} (Nat -> Nat -> Nat -> Nat)
+
+ha : Request {A} r -> r
+ha = cases
+  { x } -> x
+  { one i -> c } -> handle c (i+1) with ha
+  { two i j -> c } -> handle c (i+j) with ha
+  { three i j k -> c } -> handle c (i+j+k) with ha
+  { four i -> c } -> handle c (j k l -> i+j+k+l) with ha
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique ability A
+      ha : Request {A} r -> r
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    unique ability A
+    ha : Request {A} r -> r
+
+```


### PR DESCRIPTION
The rewriting was accidentally inserting empty row in every spot without an ability variable. Since this is how the type system tells the arity of an effect in an ability in some spots, it was breaking that. It's possible it caused other issues, too.