### PR TITLE
Fix an issue computing sandbox info

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Machine.hs
+++ b/parser-typechecker/src/Unison/Runtime/Machine.hs
@@ -1650,14 +1650,22 @@ expandSandbox
   :: Map Reference (Set Reference)
   -> [(Reference, SuperGroup Symbol)]
   -> [(Reference, Set Reference)]
-expandSandbox sand = mapMaybe h
+expandSandbox sand0 groups = fixed mempty
   where
-  f False r = fromMaybe mempty $ M.lookup r sand
-  f True  _ = mempty
+  f sand False r = fromMaybe mempty $ M.lookup r sand
+  f _    True  _ = mempty
 
-  h (r, groupLinks f -> s)
+  h sand (r, groupLinks (f sand) -> s)
     | S.null s = Nothing
     | otherwise = Just (r, s)
+
+  fixed extra
+    | extra == extra' = new
+    | otherwise = fixed extra'
+    where
+    new = mapMaybe (h $ extra <> sand0) groups
+    extra' = M.fromList new
+
 
 cacheAdd
   :: [(Reference, SuperGroup Symbol)]

--- a/unison-src/transcripts/builtins.md
+++ b/unison-src/transcripts/builtins.md
@@ -272,8 +272,17 @@ test> Any.test2 = checks [(not (Any "hi" == Any 42))]
 ## Sandboxing functions
 
 ```unison
+openFile1 t = openFile t
+openFile2 t = openFile1 t
+
+openFiles =
+  [ not (validateSandboxed [] openFile)
+  , not (validateSandboxed [] openFile1)
+  , not (validateSandboxed [] openFile2)
+  ]
+
 test> Sandbox.test1 = checks [validateSandboxed [] "hello"]
-test> Sandbox.test2 = checks [not (validateSandboxed [] openFile)]
+test> Sandbox.test2 = checks openFiles
 test> Sandbox.test3 = checks [validateSandboxed [termLink openFile.impl]
 openFile]
 ```

--- a/unison-src/transcripts/builtins.output.md
+++ b/unison-src/transcripts/builtins.output.md
@@ -268,8 +268,17 @@ test> Any.test2 = checks [(not (Any "hi" == Any 42))]
 ## Sandboxing functions
 
 ```unison
+openFile1 t = openFile t
+openFile2 t = openFile1 t
+
+openFiles =
+  [ not (validateSandboxed [] openFile)
+  , not (validateSandboxed [] openFile1)
+  , not (validateSandboxed [] openFile2)
+  ]
+
 test> Sandbox.test1 = checks [validateSandboxed [] "hello"]
-test> Sandbox.test2 = checks [not (validateSandboxed [] openFile)]
+test> Sandbox.test2 = checks openFiles
 test> Sandbox.test3 = checks [validateSandboxed [termLink openFile.impl]
 openFile]
 ```
@@ -285,19 +294,22 @@ openFile]
       Sandbox.test1 : [Result]
       Sandbox.test2 : [Result]
       Sandbox.test3 : [Result]
+      openFile1     : Text -> FileMode ->{IO, Exception} Handle
+      openFile2     : Text -> FileMode ->{IO, Exception} Handle
+      openFiles     : [Boolean]
   
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.
 
-    1 | test> Sandbox.test1 = checks [validateSandboxed [] "hello"]
+    10 | test> Sandbox.test1 = checks [validateSandboxed [] "hello"]
     
     ✅ Passed Passed
   
-    2 | test> Sandbox.test2 = checks [not (validateSandboxed [] openFile)]
+    11 | test> Sandbox.test2 = checks openFiles
     
     ✅ Passed Passed
   
-    3 | test> Sandbox.test3 = checks [validateSandboxed [termLink openFile.impl]
+    12 | test> Sandbox.test3 = checks [validateSandboxed [termLink openFile.impl]
     
     ✅ Passed Passed
 


### PR DESCRIPTION
The sandboxed dependencies for combinators were being computed just from
the previously known combinators. So, if multiple new, interrelated
combinators were introduced simultaneously, their full transitive
dependencies wouldn't take into account anything in the new set.

To fix this, just iterate the dependency inference until a fixed point
is reached.