### PR TITLE
Allow pushing to v2 codebases

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Init.hs
+++ b/parser-typechecker/src/Unison/Codebase/Init.hs
@@ -112,7 +112,6 @@ withOpenOrCreateCodebase cbInit debugName initOptions action = do
               CreateWhenMissing dir ->
                 createCodebaseWithResult cbInit debugName dir (\codebase -> action (CreatedCodebase, dir, codebase))
     Left err@OpenCodebaseUnknownSchemaVersion{} -> pure (Left (resolvedPath, InitErrorOpen err))
-    Left err@OpenCodebaseOther{} -> pure (Left (resolvedPath, InitErrorOpen err))
 
 createCodebase :: MonadIO m => Init m v a -> DebugName -> CodebasePath -> (Codebase m v a -> m r) -> m (Either Pretty r)
 createCodebase cbInit debugName path action = do
@@ -122,13 +121,6 @@ createCodebase cbInit debugName path action = do
       P.wrap $
         "It looks like there's already a codebase in: "
           <> prettyDir
-    CreateCodebaseOther message ->
-      P.wrap ("I ran into an error when creating the codebase in: " <> prettyDir)
-        <> P.newline
-        <> P.newline
-        <> "The error was:"
-        <> P.newline
-        <> P.indentN 2 message
 
 -- * compatibility stuff
 

--- a/parser-typechecker/src/Unison/Codebase/Init/CreateCodebaseError.hs
+++ b/parser-typechecker/src/Unison/Codebase/Init/CreateCodebaseError.hs
@@ -10,4 +10,3 @@ type Pretty = P.Pretty P.ColorText
 
 data CreateCodebaseError
   = CreateCodebaseAlreadyExists
-  | CreateCodebaseOther Pretty

--- a/parser-typechecker/src/Unison/Codebase/Init/OpenCodebaseError.hs
+++ b/parser-typechecker/src/Unison/Codebase/Init/OpenCodebaseError.hs
@@ -5,13 +5,11 @@ module Unison.Codebase.Init.OpenCodebaseError
 where
 
 import Unison.Prelude
-import Unison.Util.Pretty (ColorText, Pretty)
 
 -- | An error that can occur when attempting to open a codebase.
 data OpenCodebaseError
   = -- | The codebase doesn't exist.
     OpenCodebaseDoesntExist
-    -- | The codebase exists, but its schema version is unknown to this application.
-  | OpenCodebaseUnknownSchemaVersion Word64
-  | OpenCodebaseOther (Pretty ColorText)
+  | -- | The codebase exists, but its schema version is unknown to this application.
+    OpenCodebaseUnknownSchemaVersion Word64
   deriving stock (Show)

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -133,6 +133,7 @@ init = Codebase.Init
     withCreatedCodebase' debugName path action =
       createCodebaseOrError debugName path (action . fst)
 
+-- | Open the codebase at the given location, or create it if one doesn't already exist.
 withOpenOrCreateCodebase ::
   MonadUnliftIO m =>
   Codebase.DebugName ->
@@ -146,6 +147,7 @@ withOpenOrCreateCodebase debugName codebasePath localOrRemote action = do
       sqliteCodebase debugName codebasePath localOrRemote action
     Right r -> pure (Right r)
 
+-- | Create a codebase at the given location.
 createCodebaseOrError ::
   (MonadUnliftIO m) =>
   Codebase.DebugName ->
@@ -1161,7 +1163,6 @@ pushGitBranch srcConn branch repo (PushGitBranchOpts setRoot _syncMode) = Unlift
   -- set up the cache dir
  throwEitherMWith C.GitProtocolError . withRepo readRepo Git.CreateBranchIfMissing $ \pushStaging -> do
    throwEitherMWith (C.GitSqliteCodebaseError . C.gitErrorFromOpenCodebaseError (Git.gitDirToPath pushStaging) readRepo)
-
      . withOpenOrCreateCodebase "push.dest" (Git.gitDirToPath pushStaging) Remote $ \(_destCodebase, destConn) -> do
          flip runReaderT destConn $ Q.withSavepoint_ @(ReaderT _ m) "push" $ do
            throwExceptT $ doSync (Git.gitDirToPath pushStaging) srcConn destConn

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -126,15 +126,31 @@ makeCodebaseDirPath root = root </> ".unison" </> "v2"
 init :: HasCallStack => (MonadUnliftIO m) => Codebase.Init m Symbol Ann
 init = Codebase.Init
   { withOpenCodebase=withCodebaseOrError
-  , withCreatedCodebase=createCodebaseOrError
+  , withCreatedCodebase=withCreatedCodebase'
   , codebasePath=makeCodebaseDirPath
   }
+  where
+    withCreatedCodebase' debugName path action =
+      createCodebaseOrError debugName path (action . fst)
+
+withOpenOrCreateCodebase ::
+  MonadUnliftIO m =>
+  Codebase.DebugName ->
+  CodebasePath ->
+  LocalOrRemote ->
+  ((Codebase m Symbol Ann, Connection) -> m r) ->
+  m (Either Codebase1.OpenCodebaseError r)
+withOpenOrCreateCodebase debugName codebasePath localOrRemote action = do
+  createCodebaseOrError debugName codebasePath action >>= \case
+    Left (Codebase1.CreateCodebaseAlreadyExists) -> do
+      sqliteCodebase debugName codebasePath localOrRemote action
+    Right r -> pure (Right r)
 
 createCodebaseOrError ::
   (MonadUnliftIO m) =>
   Codebase.DebugName ->
   CodebasePath ->
-  (Codebase m Symbol Ann -> m r) ->
+  ((Codebase m Symbol Ann, Connection) -> m r) ->
   m (Either Codebase1.CreateCodebaseError r)
 createCodebaseOrError debugName path action = do
   ifM
@@ -153,18 +169,6 @@ createCodebaseOrError debugName path action = do
         Left schemaVersion -> error ("Failed to open codebase with schema version: " ++ show schemaVersion ++ ", which is unexpected because I just created this codebase.")
         Right result -> pure (Right result)
 
-withOpenOrCreateCodebaseConnection ::
-  (MonadUnliftIO m) =>
-  Codebase.DebugName ->
-  FilePath ->
-  (Connection -> m r) ->
-  m r
-withOpenOrCreateCodebaseConnection debugName path action = do
-  unlessM
-    (doesFileExist $ makeCodebasePath path)
-    (initSchemaIfNotExist path)
-  withConnection debugName path action
-
 -- | Use the codebase in the provided path.
 -- The codebase is automatically closed when the action completes or throws an exception.
 withCodebaseOrError ::
@@ -178,7 +182,7 @@ withCodebaseOrError debugName dir action = do
   doesFileExist (makeCodebasePath dir) >>= \case
     False -> pure (Left Codebase1.OpenCodebaseDoesntExist)
     True ->
-      sqliteCodebase debugName dir Local action <&> mapLeft \(SchemaVersion n) -> Codebase1.OpenCodebaseUnknownSchemaVersion n
+      sqliteCodebase debugName dir Local (action . fst)
 
 initSchemaIfNotExist :: MonadIO m => FilePath -> m ()
 initSchemaIfNotExist path = liftIO do
@@ -285,8 +289,8 @@ sqliteCodebase ::
   CodebasePath ->
   -- | When local, back up the existing codebase before migrating, in case there's a catastrophic bug in the migration.
   LocalOrRemote ->
-  (Codebase m Symbol Ann -> m r) ->
-  m (Either SchemaVersion r)
+  ((Codebase m Symbol Ann, Connection) -> m r) ->
+  m (Either Codebase1.OpenCodebaseError r)
 sqliteCodebase debugName root localOrRemote action = do
  Monad.when debug $ traceM $ "sqliteCodebase " ++ debugName ++ " " ++ root
  withConnection debugName root $ \conn -> do
@@ -835,7 +839,7 @@ sqliteCodebase debugName root localOrRemote action = do
 
   -- Migrate if necessary.
   (`finally` finalizer) $ runReaderT Q.schemaVersion conn >>= \case
-    SchemaVersion 2 -> Right <$> action codebase
+    SchemaVersion 2 -> Right <$> action (codebase, conn)
     SchemaVersion 1 -> do
       liftIO $ putStrLn ("Migrating from schema version 1 -> 2.")
       case localOrRemote of
@@ -851,8 +855,8 @@ sqliteCodebase debugName root localOrRemote action = do
         Remote -> pure ()
       migrateSchema12 conn codebase
       -- it's ok to pass codebase along; whatever it cached during the migration won't break anything
-      Right <$> action codebase
-    v -> pure $ Left v
+      Right <$> action (codebase, conn)
+    v -> pure . Left $ Codebase1.OpenCodebaseUnknownSchemaVersion (fromIntegral v)
 
 -- well one or the other. :zany_face: the thinking being that they wouldn't hash-collide
 termExists', declExists' :: MonadIO m => Hash -> ReaderT Connection (ExceptT Ops.Error m) Bool
@@ -1100,7 +1104,7 @@ viewRemoteBranch' (repo, sbh, path) gitBranchBehavior action = UnliftIO.try $ do
       -- Unexpected error from sqlite
       _ -> throwIO sqlError
 
-  result <- sqliteCodebase "viewRemoteBranch.gitCache" remotePath Remote \codebase -> do
+  result <- sqliteCodebase "viewRemoteBranch.gitCache" remotePath Remote \(codebase, _conn) -> do
     -- try to load the requested branch from it
     branch <- time "Git fetch (sbh)" $ case sbh of
       -- no sub-branch was specified, so use the root.
@@ -1127,7 +1131,7 @@ viewRemoteBranch' (repo, sbh, path) gitBranchBehavior action = UnliftIO.try $ do
       Just b -> action (b, remotePath)
       Nothing -> throwIO . C.GitCodebaseError $ GitError.CouldntFindRemoteBranch repo path
   case result of
-    Left schemaVersion -> throwIO . C.GitSqliteCodebaseError $ GitError.UnrecognizedSchemaVersion repo remotePath schemaVersion
+    Left err -> throwIO . C.GitSqliteCodebaseError $ C.gitErrorFromOpenCodebaseError remotePath repo err
     Right inner -> pure inner
 
 -- Push a branch to a repo. Optionally attempt to set the branch as the new root, which fails if the branch is not after
@@ -1140,7 +1144,7 @@ pushGitBranch ::
   WriteRepo ->
   PushGitBranchOpts ->
   m (Either C.GitError ())
-pushGitBranch srcConn branch repo (PushGitBranchOpts setRoot _syncMode) = mapLeft C.GitProtocolError <$> do
+pushGitBranch srcConn branch repo (PushGitBranchOpts setRoot _syncMode) = UnliftIO.try do
   -- Pull the latest remote into our git cache
   -- Use a local git clone to copy this git repo into a temp-dir
   -- Delete the codebase in our temp-dir
@@ -1155,10 +1159,12 @@ pushGitBranch srcConn branch repo (PushGitBranchOpts setRoot _syncMode) = mapLef
   -- Delete the temp-dir.
   --
   -- set up the cache dir
- withRepo readRepo Git.CreateBranchIfMissing $ \pushStaging -> do
-   withOpenOrCreateCodebaseConnection @m "push.dest" (Git.gitDirToPath pushStaging) $ \destConn -> do
-     flip runReaderT destConn $ Q.withSavepoint_ @(ReaderT _ m) "push" $ do
-       throwExceptT $ doSync (Git.gitDirToPath pushStaging) srcConn destConn
+ throwEitherMWith C.GitProtocolError . withRepo readRepo Git.CreateBranchIfMissing $ \pushStaging -> do
+   throwEitherMWith (C.GitSqliteCodebaseError . C.gitErrorFromOpenCodebaseError (Git.gitDirToPath pushStaging) readRepo)
+
+     . withOpenOrCreateCodebase "push.dest" (Git.gitDirToPath pushStaging) Remote $ \(_destCodebase, destConn) -> do
+         flip runReaderT destConn $ Q.withSavepoint_ @(ReaderT _ m) "push" $ do
+           throwExceptT $ doSync (Git.gitDirToPath pushStaging) srcConn destConn
    void $ push pushStaging repo
   where
     readRepo :: ReadRepo

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -9,17 +9,18 @@ module Unison.Codebase.Type
     GitError (..),
     GetRootBranchError (..),
     SyncToDir,
+    gitErrorFromOpenCodebaseError,
   )
 where
 
 import Unison.Codebase.Branch (Branch)
 import qualified Unison.Codebase.Branch as Branch
-import Unison.Codebase.Editor.RemoteRepo (ReadRemoteNamespace, WriteRepo)
+import Unison.Codebase.Editor.RemoteRepo (ReadRemoteNamespace, WriteRepo, ReadRepo)
 import Unison.Codebase.GitError (GitCodebaseError, GitProtocolError)
 import Unison.Codebase.Patch (Patch)
 import qualified Unison.Codebase.Reflog as Reflog
 import Unison.Codebase.ShortBranchHash (ShortBranchHash)
-import Unison.Codebase.SqliteCodebase.GitError (GitSqliteCodebaseError)
+import Unison.Codebase.SqliteCodebase.GitError (GitSqliteCodebaseError (..))
 import Unison.Codebase.SyncMode (SyncMode)
 import Unison.CodebasePath (CodebasePath)
 import Unison.DataDeclaration (Decl)
@@ -33,6 +34,7 @@ import Unison.Term (Term)
 import Unison.Type (Type)
 import qualified Unison.WatchKind as WK
 import qualified Unison.Codebase.Editor.Git as Git
+import Unison.Codebase.Init.OpenCodebaseError (OpenCodebaseError(..))
 
 type SyncToDir m =
   CodebasePath -> -- dest codebase
@@ -177,3 +179,9 @@ data GitError
   deriving (Show)
 
 instance Exception GitError
+
+gitErrorFromOpenCodebaseError :: CodebasePath -> ReadRepo -> OpenCodebaseError -> GitSqliteCodebaseError
+gitErrorFromOpenCodebaseError path repo = \case
+  OpenCodebaseDoesntExist -> NoDatabaseFile repo path
+  OpenCodebaseUnknownSchemaVersion v ->
+    UnrecognizedSchemaVersion repo path (fromIntegral v)

--- a/unison-cli/tests/Unison/Test/Ucm.hs
+++ b/unison-cli/tests/Unison/Test/Ucm.hs
@@ -57,7 +57,6 @@ initCodebase fmt = do
   result <- Codebase.Init.withCreatedCodebase cbInit "ucm-test" tmp (const $ pure ())
   case result of
     Left CreateCodebaseAlreadyExists -> fail $ P.toANSI 80 "Codebase already exists"
-    Left (CreateCodebaseOther p) -> fail $ P.toANSI 80 p
     Right _ -> pure $ Codebase tmp fmt
 
 deleteCodebase :: Codebase -> IO ()

--- a/unison-cli/unison/Main.hs
+++ b/unison-cli/unison/Main.hs
@@ -386,9 +386,6 @@ getCodebaseOrExit codebasePathOption action = do
                 , "Please upgrade your version of UCM."
                 ])
 
-            InitErrorOpen (OpenCodebaseOther errMessage) ->
-              pure errMessage
-
             FoundV1Codebase ->
               pure (P.lines
                 [ "Found a v1 codebase at " <> pDir <> ".",


### PR DESCRIPTION
## Overview

On trunk, pushing a v2 codebase over a v1 codebase refuses to push citing that the remote has changes the local copy doesn't know about, making it impossible to upload a v2 codebase over a v1 version.

## Implementation notes

The issue stems from the fact that not all codebases were being opened in the same way. Some codebases were being opened directly using Sqlite connections, which was circumventing the migration path!
This meant that the remote codebase would be opened without migrating, and so the remote root was never an ancestor of the local root since the DBs were on different hashing versions.

This fixes the issue by opening codebases with `sqliteCodebase` rather than circumventing the process and opening with sqlite directly

## Test coverage

It's difficult to add tests since it requires multiple versions of UCM, but I did test it manually.

## Loose ends

This PR fixes the ability to push a v2 codebase over a v1 version, but due to how pushing works on trunk at the moment it will migrate the remote codebase **TWICE** as part of that process.

I'll fix that as a separate PR 👍🏼  (#2912 )

fixes #2906