### PR TITLE
Avoid redundant clone (and migration) when pushing.

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/GitError.hs
+++ b/parser-typechecker/src/Unison/Codebase/GitError.hs
@@ -31,6 +31,7 @@ data GitCodebaseError h
   = NoRemoteNamespaceWithHash ReadRepo ShortBranchHash
   | RemoteNamespaceHashAmbiguous ReadRepo ShortBranchHash (Set h)
   | CouldntLoadRootBranch ReadRepo h
+  | CouldntParseRemoteBranch ReadRepo String
   | CouldntLoadSyncedBranch ReadRemoteNamespace h
   | CouldntFindRemoteBranch ReadRepo Path
   deriving (Show)

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -816,7 +816,7 @@ sqliteCodebase debugName root localOrRemote action = do
             syncFromDirectory
             syncToDirectory
             viewRemoteBranch'
-            (\b r opts -> pushGitBranch conn b r opts)
+            (\r opts action -> pushGitBranch conn r opts action)
             watches
             getWatch
             putWatch
@@ -1143,7 +1143,7 @@ viewRemoteBranch' (repo, sbh, path) gitBranchBehavior action = UnliftIO.try $ do
     Left err -> throwIO . C.GitSqliteCodebaseError $ C.gitErrorFromOpenCodebaseError remotePath repo err
     Right inner -> pure inner
 
--- Push a branch to a repo. Optionally attempt to set the branch as the new root, which fails if the branch is not after
+-- | Push a branch to a repo. Optionally attempt to set the branch as the new root, which fails if the branch is not after
 -- the existing root.
 pushGitBranch ::
   forall m e.
@@ -1151,6 +1151,7 @@ pushGitBranch ::
   Connection ->
   WriteRepo ->
   PushGitBranchOpts ->
+  -- An action which accepts the current root branch on the remote and computes a new branch.
   (Branch m -> m (Either e (Branch m))) ->
   m (Either C.GitError (Either e (Branch m)))
 pushGitBranch srcConn repo (PushGitBranchOpts setRoot _syncMode) action = UnliftIO.try do

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -103,7 +103,7 @@ data Codebase m v a = Codebase
     syncToDirectory :: CodebasePath -> SyncMode -> Branch m -> m (),
     viewRemoteBranch' :: forall r. ReadRemoteNamespace -> Git.GitBranchBehavior -> ((Branch m, CodebasePath) -> m r) -> m (Either GitError r),
     -- | Push the given branch to the given repo, and optionally set it as the root branch.
-    pushGitBranch :: Branch m -> WriteRepo -> PushGitBranchOpts -> m (Either GitError ()),
+    pushGitBranch :: forall e. WriteRepo -> PushGitBranchOpts -> (Branch m -> m (Either e (Branch m))) -> m (Either GitError (Either e (Branch m))),
     -- | @watches k@ returns all of the references @r@ that were previously put by a @putWatch k r t@. @t@ can be
     -- retrieved by @getWatch k r@.
     watches :: WK.WatchKind -> m [Reference.Id],

--- a/unison-cli/src/Unison/Codebase/Editor/Command.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Command.hs
@@ -225,7 +225,7 @@ data Command
   -- codebase are copied there.
   SyncLocalRootBranch :: Branch m -> Command m i v ()
 
-  SyncRemoteBranch :: Branch m -> WriteRepo -> PushGitBranchOpts -> Command m i v (Either GitError ())
+  SyncRemoteBranch :: WriteRepo -> PushGitBranchOpts -> (Branch m -> m (Either e (Branch m))) -> Command m i v (Either GitError (Either e (Branch m)))
 
   AppendToReflog :: Text -> Branch m -> Branch m -> Command m i v ()
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -157,8 +157,8 @@ commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSour
       lift $ Codebase.viewRemoteBranch codebase ns gitBranchBehavior (toIO . Free.fold go . action)
     ImportRemoteBranch ns syncMode preprocess ->
       lift $ Codebase.importRemoteBranch codebase ns syncMode preprocess
-    SyncRemoteBranch branch repo opts ->
-      lift $ Codebase.pushGitBranch codebase branch repo opts
+    SyncRemoteBranch repo opts action ->
+      lift $ Codebase.pushGitBranch codebase repo opts action
     LoadTerm r -> lift $ Codebase.getTerm codebase r
     LoadTypeOfTerm r -> lift $ Codebase.getTypeOfTerm codebase r
     LoadTermComponentWithTypes h -> lift $ Codebase.getTermComponentWithTypes codebase h

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -52,7 +52,7 @@ import qualified Unison.Codebase.Editor.Output as Output
 import qualified Unison.Codebase.Editor.Output.BranchDiff as OBranchDiff
 import qualified Unison.Codebase.Editor.Output.DumpNamespace as Output.DN
 import qualified Unison.Codebase.Editor.Propagate as Propagate
-import Unison.Codebase.Editor.RemoteRepo (ReadRemoteNamespace, WriteRemotePath, WriteRepo, printNamespace, writePathToRead, writeToRead)
+import Unison.Codebase.Editor.RemoteRepo (ReadRemoteNamespace, WriteRemotePath, WriteRepo, printNamespace, writePathToRead)
 import Unison.Codebase.Editor.SlurpComponent (SlurpComponent (..))
 import qualified Unison.Codebase.Editor.SlurpComponent as SC
 import Unison.Codebase.Editor.SlurpResult (SlurpResult (..))
@@ -71,12 +71,11 @@ import qualified Unison.Codebase.PushBehavior as PushBehavior
 import qualified Unison.Codebase.Reflog as Reflog
 import Unison.Codebase.ShortBranchHash (ShortBranchHash)
 import qualified Unison.Codebase.ShortBranchHash as SBH
-import Unison.Codebase.SqliteCodebase.GitError (GitSqliteCodebaseError(NoDatabaseFile))
 import qualified Unison.Codebase.SyncMode as SyncMode
 import Unison.Codebase.TermEdit (TermEdit (..))
 import qualified Unison.Codebase.TermEdit as TermEdit
 import qualified Unison.Codebase.TermEdit.Typing as TermEdit
-import Unison.Codebase.Type (GitError(GitSqliteCodebaseError))
+import Unison.Codebase.Type (GitError)
 import qualified Unison.Codebase.TypeEdit as TypeEdit
 import qualified Unison.Codebase.Verbosity as Verbosity
 import qualified Unison.CommandLine.DisplayValues as DisplayValues
@@ -1706,25 +1705,23 @@ doPushRemoteBranch repo localPath syncMode remoteTarget = do
       case remoteTarget of
         Nothing -> do
           let opts = PushGitBranchOpts {setRoot = False, syncMode}
-          syncRemoteBranch sourceBranch repo opts
+          syncRemoteBranch repo opts (\_remoteRoot -> pure (Right sourceBranch))
           sbhLength <- (eval BranchHashLength)
           respond (GistCreated sbhLength repo (Branch.headHash sourceBranch))
         Just (remotePath, pushBehavior) -> do
-          let withRemoteRoot remoteRoot = do
+          let withRemoteRoot :: Branch m -> m (Either (Output v) (Branch m))
+              withRemoteRoot remoteRoot = do
                 let -- We don't merge `sourceBranch` with `remoteBranch`, we just replace it. This push will be rejected if this
                     -- rewinds time or misses any new updates in the remote branch that aren't in `sourceBranch` already.
                     f remoteBranch = if shouldPushTo pushBehavior remoteBranch then Just sourceBranch else Nothing
                 Branch.modifyAtM remotePath f remoteRoot & \case
-                  Nothing -> respond (RefusedToPush pushBehavior)
-                  Just newRemoteRoot -> do
-                    let opts = PushGitBranchOpts {setRoot = True, syncMode}
-                    runExceptT (syncRemoteBranch newRemoteRoot repo opts) >>= \case
-                      Left gitErr -> respond (Output.GitError gitErr)
-                      Right () -> respond Success
-          viewRemoteBranch (writeToRead repo, Nothing, Path.empty) Git.CreateBranchIfMissing withRemoteRoot >>= \case
-            Left (GitSqliteCodebaseError NoDatabaseFile{}) -> withRemoteRoot Branch.empty
-            Left err -> throwError err
-            Right () -> pure ()
+                  Nothing -> pure (Left $ RefusedToPush pushBehavior)
+                  Just newRemoteRoot -> pure (Right newRemoteRoot)
+          let opts = PushGitBranchOpts {setRoot = True, syncMode}
+          runExceptT (syncRemoteBranch repo opts withRemoteRoot) >>= \case
+            Left gitErr -> respond (Output.GitError gitErr)
+            Right (Left output) -> respond output
+            Right (Right _branch) -> respond Success
   where
     -- Per `pushBehavior`, we are either:
     --
@@ -2095,9 +2092,9 @@ viewRemoteBranch ::
 viewRemoteBranch ns gitBranchBehavior action = do
   eval $ ViewRemoteBranch ns gitBranchBehavior action
 
-syncRemoteBranch :: MonadCommand n m i v => Branch m -> WriteRepo -> PushGitBranchOpts -> ExceptT GitError n ()
-syncRemoteBranch b repo opts =
-  ExceptT . eval $ SyncRemoteBranch b repo opts
+syncRemoteBranch :: MonadCommand n m i v => WriteRepo -> PushGitBranchOpts -> (Branch m -> m (Either e (Branch m))) -> ExceptT GitError n (Either e (Branch m))
+syncRemoteBranch repo opts action =
+  ExceptT . eval $ SyncRemoteBranch repo opts action
 
 -- todo: compare to `getHQTerms` / `getHQTypes`.  Is one universally better?
 resolveHQToLabeledDependencies :: Functor m => HQ.HashQualified Name -> Action' m v (Set LabeledDependency)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -2092,7 +2092,15 @@ viewRemoteBranch ::
 viewRemoteBranch ns gitBranchBehavior action = do
   eval $ ViewRemoteBranch ns gitBranchBehavior action
 
-syncRemoteBranch :: MonadCommand n m i v => WriteRepo -> PushGitBranchOpts -> (Branch m -> m (Either e (Branch m))) -> ExceptT GitError n (Either e (Branch m))
+-- | Given the current root branch of a remote
+-- (or an empty branch if no root branch exists)
+-- compute a new branch, which will then be synced and pushed.
+syncRemoteBranch ::
+  MonadCommand n m i v =>
+  WriteRepo ->
+  PushGitBranchOpts ->
+  (Branch m -> m (Either e (Branch m))) ->
+  ExceptT GitError n (Either e (Branch m))
 syncRemoteBranch repo opts action =
   ExceptT . eval $ SyncRemoteBranch repo opts action
 

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1114,6 +1114,12 @@ notifyUser dir o = case o of
           push = P.group . P.backticked . IP.patternName $ IP.push
           pull = P.group . P.backticked . IP.patternName $ IP.pull
     GitCodebaseError e -> case e of
+      CouldntParseRemoteBranch repo s ->
+        P.wrap $
+          "I couldn't decode the root branch "
+            <> P.string s
+            <> "from the repository at"
+            <> prettyReadRepo repo
       CouldntLoadRootBranch repo hash ->
         P.wrap $
           "I couldn't load the designated root hash"


### PR DESCRIPTION
## Overview

Builds on #2910

If we want to push on trunk, currently uses 'viewRemoteBranch' to pull the repo, and load the root branch, then it makes changes to that root branch, then it calls `syncRemoteBranch`, which clones the repo _again_ and makes the changes there, then pushes the result.

This results in a few extra git ops, but more importantly, when pushing over a `v1` codebase with a new `v2` codebase, it requires us to run the migration twice!

## Implementation notes

`syncRemoteBranch` now accepts an action to transform the existing root. This allows us to avoid any redundant clones by viewing the branch and pushing within the same repo.

It still respects the options, so for adding gists we just provide `(const $ pure newBranch)` and set the option to not update the root branch