### PR TITLE
switch to Windows code page 65001 in exe:unison and exe:tests

### DIFF
--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -51,6 +51,7 @@ library:
 tests:
   tests:
     dependencies:
+      - code-page
       - easytest
       - here
       - shellmet
@@ -65,6 +66,7 @@ executables:
     main: Main.hs
     ghc-options: -threaded -rtsopts -with-rtsopts=-I0 -optP-Wno-nonportable-include-path
     dependencies:
+      - code-page
       - optparse-applicative >= 0.16.1.0
       - shellmet
       - template-haskell

--- a/unison-cli/tests/Main.hs
+++ b/unison-cli/tests/Main.hs
@@ -3,6 +3,7 @@ module Main where
 import EasyTest
 import System.Environment (getArgs)
 import System.IO
+import System.IO.CodePage (withCP65001)
 import qualified Unison.Test.ClearCache as ClearCache
 import qualified Unison.Test.CommandLine as CommandLine
 import qualified Unison.Test.GitSync as GitSync
@@ -20,7 +21,7 @@ test =
     ]
 
 main :: IO ()
-main = do
+main = withCP65001 do
   args <- getArgs
   mapM_ (`hSetEncoding` utf8) [stdout, stdin, stderr]
   case args of

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -298,6 +298,7 @@ executable unison
     , async
     , base
     , bytestring
+    , code-page
     , configurator
     , containers >=0.6.3
     , cryptonite
@@ -376,6 +377,7 @@ test-suite tests
     , async
     , base
     , bytestring
+    , code-page
     , configurator
     , containers >=0.6.3
     , cryptonite

--- a/unison-cli/unison/Main.hs
+++ b/unison-cli/unison/Main.hs
@@ -20,6 +20,7 @@ import System.Directory (canonicalizePath, getCurrentDirectory, removeDirectoryR
 import System.Environment (getProgName, withArgs)
 import qualified System.Exit as Exit
 import qualified System.FilePath as FP
+import System.IO.CodePage (withCP65001)
 import System.IO.Error (catchIOError)
 import qualified System.IO.Temp as Temp
 import qualified System.Path as Path
@@ -67,7 +68,7 @@ import qualified Data.List.NonEmpty as NonEmpty
 import Unison.CommandLine.Welcome (CodebaseInitStatus(..))
 
 main :: IO ()
-main = do
+main = withCP65001 do
  interruptHandler <- defaultInterruptHandler
  withInterruptHandler interruptHandler $ do
   progName <- getProgName


### PR DESCRIPTION
I think it's only needed in these two spots, as the other executables just shell out to `stack exec unison`.
    
I'm not actually clear on how this interacts with (or could be replaced by `hSetEncoding`, which we do have sprinkled around already, but not sufficiently to let Windows builds work. If there's a cleaner solution, I'd like to use it. _i.e._ Am I papering over a more correct multi-platform fix by using the Windows-only `System.IO.Codepage`?

See https://hackage.haskell.org/package/code-page-0.2.1/docs/src/System.IO.CodePage.html#withCodePage