### PR TITLE
Add annotations to reserved keyword, reserved word, and empty matches

### DIFF
--- a/parser-typechecker/src/Unison/Parser.hs
+++ b/parser-typechecker/src/Unison/Parser.hs
@@ -115,7 +115,7 @@ data Error v
   | UnknownId (L.Token (HQ.HashQualified Name)) (Set Referent) (Set Reference)
   | ExpectedBlockOpen String (L.Token L.Lexeme)
   | EmptyMatch (L.Token ())
-  | EmptyWatch
+  | EmptyWatch Ann
   | UseInvalidPrefixSuffix (Either (L.Token Name) (L.Token Name)) (Maybe [L.Token Name])
   | UseEmpty (L.Token String) -- an empty `use` statement
   | DidntExpectExpression (L.Token L.Lexeme) (Maybe (L.Token L.Lexeme))

--- a/parser-typechecker/src/Unison/Parser.hs
+++ b/parser-typechecker/src/Unison/Parser.hs
@@ -114,7 +114,7 @@ data Error v
   | UnknownType (L.Token (HQ.HashQualified Name)) (Set Reference)
   | UnknownId (L.Token (HQ.HashQualified Name)) (Set Referent) (Set Reference)
   | ExpectedBlockOpen String (L.Token L.Lexeme)
-  | EmptyMatch
+  | EmptyMatch (L.Token ())
   | EmptyWatch
   | UseInvalidPrefixSuffix (Either (L.Token Name) (L.Token Name)) (Maybe [L.Token Name])
   | UseEmpty (L.Token String) -- an empty `use` statement

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -1062,7 +1062,7 @@ prettyParseError s = \case
         "Here's a few examples of valid syntax: " <>
         style Code "abba1', snake_case, Foo.zoink!, 🌻" ]
       L.ReservedWordyId _id -> Pr.lines [
-        "The identifier used here can't be a reserved keyword: ", "",
+        "The identifier used here isn't allowed to be a reserved keyword: ", "",
         excerpt ]
       L.InvalidSymbolyId _id -> Pr.lines [
         "This infix identifier isn't valid syntax: ", "",

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -692,7 +692,7 @@ renderTypeError e env src = case e of
       , ", actual="
       , (fromString . show) a
       , ", reference="
-      , showConstructor env r 
+      , showConstructor env r
       ]
     C.MalformedEffectBind ctorType ctorResult es -> mconcat
       [ "MalformedEffectBind: "
@@ -1061,11 +1061,17 @@ prettyParseError s = \case
         excerpt,
         "Here's a few examples of valid syntax: " <>
         style Code "abba1', snake_case, Foo.zoink!, 🌻" ]
+      L.ReservedWordyId _id -> Pr.lines [
+        "The identifier used here can't be a reserved keyword: ", "",
+        excerpt ]
       L.InvalidSymbolyId _id -> Pr.lines [
         "This infix identifier isn't valid syntax: ", "",
         excerpt,
         "Here's a few valid examples: " <>
         style Code "++, Float./, `List.map`" ]
+      L.ReservedSymbolyId _id -> Pr.lines [
+        "This identifier is reserved by Unison and can't be used as an operator: ", "",
+        excerpt ]
       L.InvalidBytesLiteral bs -> Pr.lines [
         "This bytes literal isn't valid syntax: " <> style ErrorSite (fromString bs), "",
         excerpt,
@@ -1289,13 +1295,17 @@ prettyParseError s = \case
     , "but there wasn't one.  Maybe check your indentation:\n"
     , tokenAsErrorSite s tok
     ]
-  go Parser.EmptyMatch = mconcat
-    ["I expected some patterns after a "
-    , style ErrorSite "match"
-    , "/"
-    , style ErrorSite "with"
-    , " but I didn't find any."
+  go (Parser.EmptyMatch tok) =
+    Pr.indentN 2 . Pr.callout "😶" $ Pr.lines
+    [ Pr.wrap ( "I expected some patterns after a "
+              <> style ErrorSite "match"
+              <> "/"
+              <> style ErrorSite "with"
+              <> " but I didn't find any."
+              )
+    , tokenAsErrorSite s tok
     ]
+
   go Parser.EmptyWatch =
     "I expected a non-empty watch expression and not just \">\""
   go (Parser.UnknownAbilityConstructor tok _referents) = unknownConstructor "ability" tok

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -1303,11 +1303,15 @@ prettyParseError s = \case
               <> style ErrorSite "with"
               <> " but I didn't find any."
               )
+    , ""
     , tokenAsErrorSite s tok
     ]
 
-  go Parser.EmptyWatch =
-    "I expected a non-empty watch expression and not just \">\""
+  go (Parser.EmptyWatch tok) =
+    Pr.lines [ "I expected a non-empty watch expression and not just \">\""
+             , ""
+             , annotatedAsErrorSite s tok
+             ]
   go (Parser.UnknownAbilityConstructor tok _referents) = unknownConstructor "ability" tok
   go (Parser.UnknownDataConstructor    tok _referents) = unknownConstructor "data" tok
   go (Parser.UnknownId               tok referents references) = Pr.lines

--- a/parser-typechecker/tests/Unison/Test/FileParser.hs
+++ b/parser-typechecker/tests/Unison/Test/FileParser.hs
@@ -81,7 +81,7 @@ module Unison.Test.FileParser where
       where
         expectation :: Var e => P.Error e -> Test ()
         expectation e = case e of
-          P.EmptyWatch -> ok
+          P.EmptyWatch _ann -> ok
           _ -> crash "Error wasn't EmptyWatch"
 
   signatureNeedsAccompanyingBodyTest :: Test ()

--- a/unison-src/transcripts/error-messages.md
+++ b/unison-src/transcripts/error-messages.md
@@ -58,3 +58,20 @@ foo = then -- unclosed
 ```unison:error
 foo = with -- unclosed
 ```
+
+```unison:error
+foo = match 1 with
+  2 -- no right-hand-side
+```
+
+### Keywords
+
+```unison:error
+use.keyword.in.namespace = 1
+```
+
+
+```unison:error
+-- reserved operator
+a ! b = 1
+```

--- a/unison-src/transcripts/error-messages.md
+++ b/unison-src/transcripts/error-messages.md
@@ -59,9 +59,26 @@ foo = then -- unclosed
 foo = with -- unclosed
 ```
 
+### Matching
+
 ```unison:error
 foo = match 1 with
   2 -- no right-hand-side
+```
+
+```unison:error
+-- Mismatched arities
+foo = cases
+  1, 2 -> ()
+  3 -> ()
+```
+
+
+### Watches
+
+```unison:error
+-- Empty watch
+>
 ```
 
 ### Keywords
@@ -69,7 +86,6 @@ foo = match 1 with
 ```unison:error
 use.keyword.in.namespace = 1
 ```
-
 
 ```unison:error
 -- reserved operator

--- a/unison-src/transcripts/error-messages.output.md
+++ b/unison-src/transcripts/error-messages.output.md
@@ -159,6 +159,8 @@ foo = with -- unclosed
   
 
 ```
+### Matching
+
 ```unison
 foo = match 1 with
   2 -- no right-hand-side
@@ -170,8 +172,43 @@ foo = match 1 with
     
     I expected some patterns after a match / with but I didn't
     find any.
+    
         1 | foo = match 1 with
     
+
+```
+```unison
+-- Mismatched arities
+foo = cases
+  1, 2 -> ()
+  3 -> ()
+```
+
+```ucm
+
+    😶
+    
+    Not all the branches of this pattern matching have the same
+    number of arguments. I was assuming they'd all have 2
+    arguments (based on the previous patterns) but this one has
+    1 arguments:
+        4 |   3 -> ()
+    
+
+```
+### Watches
+
+```unison
+-- Empty watch
+>
+```
+
+```ucm
+
+  I expected a non-empty watch expression and not just ">"
+  
+      2 | >
+  
 
 ```
 ### Keywords

--- a/unison-src/transcripts/error-messages.output.md
+++ b/unison-src/transcripts/error-messages.output.md
@@ -159,3 +159,55 @@ foo = with -- unclosed
   
 
 ```
+```unison
+foo = match 1 with
+  2 -- no right-hand-side
+```
+
+```ucm
+
+    😶
+    
+    I expected some patterns after a match / with but I didn't
+    find any.
+        1 | foo = match 1 with
+    
+
+```
+### Keywords
+
+```unison
+use.keyword.in.namespace = 1
+```
+
+```ucm
+
+  The identifier used here isn't allowed to be a reserved keyword: 
+  
+      1 | use.keyword.in.namespace = 1
+  
+
+```
+```unison
+-- reserved operator
+a ! b = 1
+```
+
+```ucm
+
+  This looks like the start of an expression here 
+  
+      2 | a ! b = 1
+  
+  but at the file top-level, I expect one of the following:
+  
+    - A binding, like a = 42 OR
+                      a : Nat
+                      a = 42
+    - A watch expression, like > a + 1
+    - An `ability` declaration, like ability Foo where ...
+    - A `type` declaration, like type Optional a = None | Some a
+    - A `namespace` declaration, like namespace Seq where ...
+  
+
+```


### PR DESCRIPTION
## Overview

I noticed a few errors didn't have any annotations, which makes them pretty tricky to track down in large scratch files (I'm trying to get nimbus compiling from a scratch file, so I need to look through 3000 lines to find the "reserved operator" haha).

The following scratch file includes triggers for each of the errors:

```
-- Add this first to get the hash in scope.
x _ = 1

test = !#fm33gb5nhn

matcher : X -> Text
matcher x = match x with
  1

ns.if.blah = 20

>
```

### Before:

<img width="744" alt="image" src="https://user-images.githubusercontent.com/6439644/154548658-37563210-e799-4bd7-88be-521df15f01be.png">



### After:

<img width="749" alt="image" src="https://user-images.githubusercontent.com/6439644/154548547-76fc2cc6-d385-4d05-b949-71b3c6f6e7ce.png">

## Implementation notes

* I added custom errors for reserved keywords in words and operators
* I added an annotation for the empty match case, and added a little additional type-safety to ensure cases can't be empty. (@runarorama , are there plans to allow empty matches in the future again for things like `Void`?)
* I added an annotation to empty watch expressions.

## Test coverage

Added to `error-messages` transcript

## Loose ends

`!#abcdef` Probably shouldn't report a "reserved keyword in operator" error, but that's out of scope for this PR.