### PR TITLE
use posix paths when matching `git status` output

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -1259,7 +1259,9 @@ pushGitBranch srcConn branch repo (PushGitBranchOpts setRoot _syncMode) = mapLef
           Nothing ->
             error $
               "An error occurred during push.\n"
-                <> "I was expecting only to see .unison/v2/unison.sqlite3 modified, but saw:\n\n"
+                <> "I was expecting only to see "
+                <> codebasePath
+                <> " modified, but saw:\n\n"
                 <> Text.unpack status
                 <> "\n\n"
                 <> "Please visit https://github.com/unisonweb/unison/issues/2063\n"
@@ -1267,9 +1269,9 @@ pushGitBranch srcConn branch repo (PushGitBranchOpts setRoot _syncMode) = mapLef
           Just (hasDeleteWal, hasDeleteShm) -> do
             -- Only stage files we're expecting; don't `git add --all .`
             -- which could accidentally commit some garbage
-            gitIn remotePath ["add", ".unison/v2/unison.sqlite3"]
-            when hasDeleteWal $ gitIn remotePath ["rm", ".unison/v2/unison.sqlite3-wal"]
-            when hasDeleteShm $ gitIn remotePath ["rm", ".unison/v2/unison.sqlite3-shm"]
+            gitIn remotePath ["add", Text.pack codebasePath]
+            when hasDeleteWal $ gitIn remotePath ["rm", Text.pack $ codebasePath <> "-wal"]
+            when hasDeleteShm $ gitIn remotePath ["rm", Text.pack $ codebasePath <> "-shm"]
             gitIn
               remotePath
               ["commit", "-q", "-m", "Sync branch " <> Text.pack (show $ Branch.headHash branch)]


### PR DESCRIPTION
## Overview

`push` was failing on non-posix systems due to mismatched expectations about the output of `git status`.

```
EXCEPTION!!!: An error occurred during push.
I was expecting only to see .unison/v2/unison.sqlite3 modified, but saw:

?? .unison/v2/unison.sqlite3
```

Isn't that what you were expecting?  It's not clear from the message, but the problem is this:

```
parseStatus "?? .unison/v2/unison.sqlite3"
codebasePath = ".unison\\v2\\unison.sqlite3"
```

## Implementation notes

When comparing against the parse status, we use the system-dependent `splitDirectories` followed by the Posix `joinPath` to produce a Posix path to compare against.

## Test coverage

This change allows the `unison-cli` test suite to get a little farther on Windows; it was masked by #1870. /cc #598 