### PR TITLE
Fix universal equality

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Machine.hs
+++ b/parser-typechecker/src/Unison/Runtime/Machine.hs
@@ -1292,7 +1292,7 @@ bprim2 !ustk !bstk EQLU i j = do
   x <- peekOff bstk i
   y <- peekOff bstk j
   ustk <- bump ustk
-  poke ustk $ if x == y then 1 else 0
+  poke ustk $ if universalEq (==) x y then 1 else 0
   pure (ustk, bstk)
 bprim2 !ustk !bstk DRPT i j = do
   n <- peekOff ustk i

--- a/unison-src/transcripts/builtins.md
+++ b/unison-src/transcripts/builtins.md
@@ -213,6 +213,8 @@ test> Text.tests.alignment =
         Text.alignRightWith 5 ?_ "ababa" == "ababa",
         Text.alignRightWith 5 ?_ "ab" == "___ab"
       ]
+
+test> Text.tests.literalsEq = checks [":)" == ":)"]
 ```
 
 ```ucm:hide

--- a/unison-src/transcripts/builtins.output.md
+++ b/unison-src/transcripts/builtins.output.md
@@ -194,6 +194,8 @@ test> Text.tests.alignment =
         Text.alignRightWith 5 ?_ "ababa" == "ababa",
         Text.alignRightWith 5 ?_ "ab" == "___ab"
       ]
+
+test> Text.tests.literalsEq = checks [":)" == ":)"]
 ```
 
 ## `Bytes` functions
@@ -328,10 +330,11 @@ Now that all the tests have been added to the codebase, let's view the test repo
   ◉ Sandbox.test2               Passed
   ◉ Sandbox.test3               Passed
   ◉ Text.tests.alignment        Passed
+  ◉ Text.tests.literalsEq       Passed
   ◉ Text.tests.repeat           Passed
   ◉ Text.tests.takeDropAppend   Passed
   
-  ✅ 19 test(s) passing
+  ✅ 20 test(s) passing
   
   Tip: Use view Any.test1 to view the source of a test.
 


### PR DESCRIPTION
This duplicates some code from another place where `EQLU` is implemented. I'm guessing it was an oversight.