### PR TITLE
vim-completion: don't include bang

### DIFF
--- a/editor-support/vim/autoload/unison.vim
+++ b/editor-support/vim/autoload/unison.vim
@@ -62,7 +62,7 @@ function! unison#Complete(findstart, base) abort
     "
     " (List.fol<cursor>
     "  ^
-    while start > 0 && line[start - 1] !~ '\v\s|[(){}\[\]]'
+    while start > 0 && line[start - 1] !~ '\v\s|[!(){}\[\]]'
       let start -= 1
     endwhile
     return start


### PR DESCRIPTION
Similar to #2842.

When triggering auto-completion on something like `!currentTime`, we
don't want to include the `!` in the term that we search for.