### PR TITLE
don't call `stack exec` and don't use `/`

### DIFF
--- a/unison-cli/integration-tests/IntegrationTests/ArgumentParsing.hs
+++ b/unison-cli/integration-tests/IntegrationTests/ArgumentParsing.hs
@@ -10,14 +10,21 @@ import Data.Time (getCurrentTime, diffUTCTime)
 import EasyTest
 import Shellmet (($|))
 import System.Exit (ExitCode (ExitSuccess))
+import System.FilePath ((</>))
 import System.Process (readProcessWithExitCode)
 import Text.Printf
 
-uFile :: String
-uFile = "unison-cli/integration-tests/IntegrationTests/print.u"
+integrationTestsDir :: FilePath
+integrationTestsDir = "unison-cli" </> "integration-tests" </> "IntegrationTests"
 
-transcriptFile :: String
-transcriptFile = "unison-cli/integration-tests/IntegrationTests/transcript.md"
+uFile :: FilePath
+uFile = integrationTestsDir </> "print.u"
+
+ucFile :: FilePath
+ucFile = integrationTestsDir </> "main.uc"
+
+transcriptFile :: FilePath
+transcriptFile = integrationTestsDir </> "transcript.md"
 
 unisonCmdString :: String
 unisonCmdString = unlines
@@ -25,39 +32,40 @@ unisonCmdString = unlines
   , "print _ = base.io.printLine \"ok\""
   ]
 
-tempCodebase :: String
+tempCodebase :: FilePath
 tempCodebase = "tempcodebase"
 
 test :: Test ()
-test =
+test = do
+  let ucm = "unison"
   EasyTest.using (pure ()) clearTempCodebase \_ ->
      scope "argument-parsing" . tests $
-      [ expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "--help"] ""
-      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "-h"] ""
-      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "version", "--help"] ""
-      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "init", "--help"] ""
-      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "run", "--help"] ""
-      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "run.file", "--help"] ""
-      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "run.pipe", "--help"] ""
-      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "transcript", "--help"] ""
-      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "transcript.fork", "--help"] ""
-      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "headless", "--help"] ""
-      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "version"] ""
-      -- , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "run"] "" -- how?
-      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "run.file", uFile, "print", "--codebase-create", tempCodebase] ""
-      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "run.pipe", "print", "--codebase-create", tempCodebase] unisonCmdString
-      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "transcript", transcriptFile, "--codebase-create", tempCodebase] ""
-      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "transcript.fork", transcriptFile, "--codebase-create", tempCodebase] ""
-      -- , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "headless"] "" -- ?
+      [ expectExitCode ExitSuccess ucm ["--help"] ""
+      , expectExitCode ExitSuccess ucm ["-h"] ""
+      , expectExitCode ExitSuccess ucm ["version", "--help"] ""
+      , expectExitCode ExitSuccess ucm ["init", "--help"] ""
+      , expectExitCode ExitSuccess ucm ["run", "--help"] ""
+      , expectExitCode ExitSuccess ucm ["run.file", "--help"] ""
+      , expectExitCode ExitSuccess ucm ["run.pipe", "--help"] ""
+      , expectExitCode ExitSuccess ucm ["transcript", "--help"] ""
+      , expectExitCode ExitSuccess ucm ["transcript.fork", "--help"] ""
+      , expectExitCode ExitSuccess ucm ["headless", "--help"] ""
+      , expectExitCode ExitSuccess ucm ["version"] ""
+      -- , expectExitCode ExitSuccess ucm ["run"] "" -- how?
+      , expectExitCode ExitSuccess ucm ["run.file", uFile, "print", "--codebase-create", tempCodebase] ""
+      , expectExitCode ExitSuccess ucm ["run.pipe", "print", "--codebase-create", tempCodebase] unisonCmdString
+      , expectExitCode ExitSuccess ucm ["transcript", transcriptFile, "--codebase-create", tempCodebase] ""
+      , expectExitCode ExitSuccess ucm ["transcript.fork", transcriptFile, "--codebase-create", tempCodebase] ""
+      -- , expectExitCode ExitSuccess ucm ["headless"] "" -- ?
       -- options
-      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "--port", "8000", "--codebase-create", tempCodebase, "--no-base"] ""
-      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "--host", "localhost", "--codebase-create", tempCodebase, "--no-base"] ""
-      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "--token", "MY_TOKEN", "--codebase-create", tempCodebase, "--no-base"] "" -- ?
-      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "--codebase-create", tempCodebase, "--no-base"] ""
-      , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "--ui", tempCodebase, "--codebase-create", tempCodebase, "--no-base"] ""
+      , expectExitCode ExitSuccess ucm ["--port", "8000", "--codebase-create", tempCodebase, "--no-base"] ""
+      , expectExitCode ExitSuccess ucm ["--host", "localhost", "--codebase-create", tempCodebase, "--no-base"] ""
+      , expectExitCode ExitSuccess ucm ["--token", "MY_TOKEN", "--codebase-create", tempCodebase, "--no-base"] "" -- ?
+      , expectExitCode ExitSuccess ucm ["--codebase-create", tempCodebase, "--no-base"] ""
+      , expectExitCode ExitSuccess ucm ["--ui", tempCodebase, "--codebase-create", tempCodebase, "--no-base"] ""
       , scope "can compile, then run compiled artifact" $ tests
-        [ expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "transcript", transcriptFile] ""
-        , expectExitCode ExitSuccess "stack" ["exec", "--", "unison", "run.compiled", "./unison-cli/integration-tests/IntegrationTests/main.uc"] ""
+        [ expectExitCode ExitSuccess ucm ["transcript", transcriptFile] ""
+        , expectExitCode ExitSuccess ucm ["run.compiled", ucFile] ""
         ]
       ]
 

--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -93,6 +93,8 @@ executables:
       - process
       - shellmet
       - time
+    build-tools:
+      - unison-cli:unison
 
 when:
   - condition: flag(optimized)

--- a/unison-cli/transcripts/Transcripts.hs
+++ b/unison-cli/transcripts/Transcripts.hs
@@ -12,7 +12,7 @@ import Data.Text
     unpack,
   )
 import EasyTest
-import Shellmet (($|))
+import Shellmet () -- import instance for IsString ([Text] -> IO())
 import System.Directory
 import System.Environment (getArgs)
 import System.FilePath
@@ -79,7 +79,7 @@ buildTests config testBuilder dir = do
           -- if there is a matchPrefix set, filter non-prelude files by that prefix - or return True
           & second (filter (\f -> maybe True (`isPrefixOf` f) (matchPrefix config)))
 
-  ucm <- io $ unpack <$> "stack" $| ["exec", "--", "which", "unison"] -- todo: what is it in windows?
+  let ucm = "unison"
   case length transcripts of
     0 -> pure ()
     -- EasyTest exits early with "no test results recorded"

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -149,6 +149,8 @@ executable integration-tests
       TypeApplications
       ViewPatterns
   ghc-options: -Wall -W -threaded -rtsopts "-with-rtsopts=-N -T" -v0
+  build-tools:
+      unison
   build-depends:
       ListLike
     , async


### PR DESCRIPTION
## Overview

Fixes #2928, in which calling `stack exec -- which` gave problematic results on Windows.

Also fixes several spots in `integration-tests` where `"/"` was being used instead of `</>`, which is generally problematic on Windows.

Not calling `stack exec` speeds up `transcripts` by a negligible amount (2s out of ~4min) and `integration-tests` by 40% (8s out of 20s).

## Implementation notes

I previously thought we needed `stack` or something to help us find the `unison` executable in various places, but we don't.  

Since we only programmatically call `unison` within a dev environment, we're already inheriting a $PATH set by `stack`, and can just call `"unison"`. /cc @stew 

## Future work

We should #2935 because it's still so slow. (4 minutes)