### PR TITLE
replace `removeDirectoryRecursive` with `removePathForcibly`

### DIFF
--- a/unison-cli/integration-tests/IntegrationTests/ArgumentParsing.hs
+++ b/unison-cli/integration-tests/IntegrationTests/ArgumentParsing.hs
@@ -5,10 +5,9 @@ module IntegrationTests.ArgumentParsing where
 
 import Data.List (intercalate)
 
-import Data.Text (pack)
 import Data.Time (getCurrentTime, diffUTCTime)
 import EasyTest
-import Shellmet (($|))
+import qualified System.Directory
 import System.Exit (ExitCode (ExitSuccess))
 import System.Process (readProcessWithExitCode)
 import Text.Printf
@@ -73,7 +72,6 @@ expectExitCode expected cmd args stdin = scope (intercalate " " (cmd : args)) do
 defaultArgs :: [String]
 defaultArgs = ["--codebase-create", tempCodebase, "--no-base"]
 
-clearTempCodebase :: () -> IO()
-clearTempCodebase _ = do
-    "rm" $| (map pack ["-rf", tempCodebase])
-    pure ()
+clearTempCodebase :: () -> IO ()
+clearTempCodebase _ =
+  System.Directory.removePathForcibly tempCodebase

--- a/unison-cli/tests/Unison/Test/GitSync.hs
+++ b/unison-cli/tests/Unison/Test/GitSync.hs
@@ -11,7 +11,7 @@ import Data.String.Here.Interpolated (i)
 import qualified Data.Text as Text
 import EasyTest
 import Shellmet ()
-import System.Directory (removeDirectoryRecursive)
+import System.Directory (removePathForcibly)
 import System.FilePath ((</>))
 import qualified System.IO.Temp as Temp
 import qualified Unison.Codebase as Codebase
@@ -554,7 +554,7 @@ pushPullTest name fmt authorScript userScript = scope name do
       (authorOutput <> "\n-------\n" <> userOutput)
 
     -- if we haven't crashed, clean up!
-    removeDirectoryRecursive repo
+    removePathForcibly repo
     Ucm.deleteCodebase author
     Ucm.deleteCodebase user
   ok
@@ -574,7 +574,7 @@ watchPushPullTest name fmt authorScript userScript codebaseCheck = scope name do
       (authorOutput <> "\n-------\n" <> userOutput)
 
     -- if we haven't crashed, clean up!
-    removeDirectoryRecursive repo
+    removePathForcibly repo
     Ucm.deleteCodebase author
     Ucm.deleteCodebase user
   ok
@@ -720,8 +720,8 @@ destroyedRemote = scope "destroyed-remote" do
     |]
   ok
   where
-    reinitRepo (Text.pack -> repo) = do
-      "rm" ["-rf", repo]
+    reinitRepo repoStr@(Text.pack -> repo) = do
+      removePathForcibly repoStr
       "git" ["init", "--bare", repo]
 
 


### PR DESCRIPTION
`removeDirectoryRecursive` doesn't remove read-only files (e.g. git repo objects) on Windows.

The PR also replaces calls to `"rm -rf"` with `removePathForcibly` as the former won't work on Windows outside of a dev environment.

Fixes #2924.
