### PR TITLE
codepage 65001 for parser-typechecker tests too

### DIFF
--- a/lib/unison-util-relation/benchmarks/relation/Main.hs
+++ b/lib/unison-util-relation/benchmarks/relation/Main.hs
@@ -2,6 +2,7 @@ module Main where
 
 import Control.Monad
 import qualified Data.Set as Set
+import System.IO.CodePage (withCP65001)
 import System.Random
 import Test.Tasty.Bench
 import Unison.Prelude
@@ -9,7 +10,7 @@ import Unison.Util.Relation (Relation)
 import qualified Unison.Util.Relation as R
 
 main :: IO ()
-main =
+main = withCP65001 $
   defaultMain
     [ env (genRelations @Char @Char 10000 20) \rs ->
         bgroup

--- a/lib/unison-util-relation/package.yaml
+++ b/lib/unison-util-relation/package.yaml
@@ -21,6 +21,7 @@ benchmarks:
     main: Main.hs
     dependencies:
       - base
+      - code-page
       - containers
       - random
       - tasty-bench

--- a/lib/unison-util-relation/package.yaml
+++ b/lib/unison-util-relation/package.yaml
@@ -8,6 +8,7 @@ library:
 tests:
   tests:
     dependencies:
+      - code-page
       - easytest
       - random
       - unison-util-relation

--- a/lib/unison-util-relation/test/Main.hs
+++ b/lib/unison-util-relation/test/Main.hs
@@ -2,6 +2,7 @@
 module Main where
 
 import EasyTest
+import System.IO.CodePage (withCP65001)
 import System.Random (Random)
 import qualified Unison.Util.Relation as Relation
 import Unison.Util.Relation3 (Relation3)
@@ -10,7 +11,7 @@ import Unison.Util.Relation4 (Relation4)
 import qualified Unison.Util.Relation4 as Relation4
 
 main :: IO ()
-main =
+main = withCP65001 $
   (run . tests)
     [ (scope "Relation" . tests)
         [ scope "mapDom works" do

--- a/lib/unison-util-relation/unison-util-relation.cabal
+++ b/lib/unison-util-relation/unison-util-relation.cabal
@@ -73,6 +73,7 @@ test-suite tests
   ghc-options: -Wall
   build-depends:
       base
+    , code-page
     , containers
     , deepseq
     , easytest

--- a/lib/unison-util-relation/unison-util-relation.cabal
+++ b/lib/unison-util-relation/unison-util-relation.cabal
@@ -108,6 +108,7 @@ benchmark relation
   ghc-options: -Wall
   build-depends:
       base
+    , code-page
     , containers
     , deepseq
     , extra

--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -159,6 +159,7 @@ executables:
       - async
       - base
       - bytestring
+      - code-page
       - containers
       - directory
       - easytest

--- a/parser-typechecker/tests/Suite.hs
+++ b/parser-typechecker/tests/Suite.hs
@@ -7,6 +7,7 @@ module Main where
 import           EasyTest
 import           System.Environment (getArgs)
 import           System.IO
+import System.IO.CodePage (withCP65001)
 import qualified Unison.Core.Test.Name as Name
 import qualified Unison.Test.ABT as ABT
 import qualified Unison.Test.Cache as Cache
@@ -73,7 +74,7 @@ test = tests
  ]
 
 main :: IO ()
-main = do
+main = withCP65001 do
   args <- getArgs
   mapM_ (`hSetEncoding` utf8) [stdout, stdin, stderr]
   case args of

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -413,6 +413,7 @@ executable tests
       async
     , base
     , bytestring
+    , code-page
     , containers
     , directory
     , easytest

--- a/unison-cli/integration-tests/Suite.hs
+++ b/unison-cli/integration-tests/Suite.hs
@@ -8,6 +8,7 @@ import EasyTest
 import qualified IntegrationTests.ArgumentParsing as ArgumentParsing
 import System.Environment (getArgs)
 import System.IO
+import System.IO.CodePage (withCP65001)
 
 test :: Test ()
 test =
@@ -16,7 +17,7 @@ test =
     ]
 
 main :: IO ()
-main = do
+main = withCP65001 do
   args <- getArgs
   mapM_ (`hSetEncoding` utf8) [stdout, stdin, stderr]
   case args of

--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -78,6 +78,7 @@ executables:
     main: Transcripts.hs
     ghc-options: -threaded -rtsopts -with-rtsopts=-N -v0
     dependencies:
+      - code-page
       - easytest
       - process
       - shellmet
@@ -89,6 +90,7 @@ executables:
     main: Suite.hs
     ghc-options: -W -threaded -rtsopts "-with-rtsopts=-N -T" -v0
     dependencies:
+      - code-page
       - easytest
       - process
       - shellmet

--- a/unison-cli/transcripts/Transcripts.hs
+++ b/unison-cli/transcripts/Transcripts.hs
@@ -21,6 +21,7 @@ import System.FilePath
     takeExtensions,
     (</>),
   )
+import System.IO.CodePage (withCP65001)
 import System.Process (readProcessWithExitCode)
 import Unison.Prelude
 
@@ -126,6 +127,6 @@ handleArgs args =
    in TestConfig matchPrefix
 
 main :: IO ()
-main = do
+main = withCP65001 do
   testConfig <- handleArgs <$> getArgs
   run (test testConfig)

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -154,6 +154,7 @@ executable integration-tests
     , async
     , base
     , bytestring
+    , code-page
     , configurator
     , containers >=0.6.3
     , cryptonite
@@ -226,6 +227,7 @@ executable transcripts
     , async
     , base
     , bytestring
+    , code-page
     , configurator
     , containers >=0.6.3
     , cryptonite


### PR DESCRIPTION
`parser-typechecker:tests` also requires codepage 65001 on Windows. Should have been part of #2917. Closes #2901 .