### PR TITLE
Fix transcripts/io.md to work on windows builds.

### DIFF
--- a/unison-src/transcripts/io.md
+++ b/unison-src/transcripts/io.md
@@ -258,11 +258,11 @@ testDirContents _ =
 ### Read environment variables
 
 ```unison:hide
-testHomeEnvVar : '{io2.IO} [Result]
-testHomeEnvVar _ =
+testGetEnv : '{io2.IO} [Result]
+testGetEnv _ =
   test = 'let
-    home = reraise (getEnv.impl "HOME")
-    check "HOME environent variable should be set"  (size home > 0)
+    path = reraise (getEnv.impl "PATH") -- PATH exists on windows, mac and linux.
+    check "PATH environent variable should be set"  (size path > 0)
     match getEnv.impl "DOESNTEXIST" with 
       Right _ -> emit (Fail "env var shouldn't exist")
       Left _ -> emit (Ok "DOESNTEXIST didn't exist")
@@ -270,7 +270,7 @@ testHomeEnvVar _ =
 ```
 ```ucm
 .> add
-.> io.test testHomeEnvVar
+.> io.test testGetEnv
 ```
 
 ### Read command line args

--- a/unison-src/transcripts/io.output.md
+++ b/unison-src/transcripts/io.output.md
@@ -414,11 +414,11 @@ testDirContents _ =
 ### Read environment variables
 
 ```unison
-testHomeEnvVar : '{io2.IO} [Result]
-testHomeEnvVar _ =
+testGetEnv : '{io2.IO} [Result]
+testGetEnv _ =
   test = 'let
-    home = reraise (getEnv.impl "HOME")
-    check "HOME environent variable should be set"  (size home > 0)
+    path = reraise (getEnv.impl "PATH") -- PATH exists on windows, mac and linux.
+    check "PATH environent variable should be set"  (size path > 0)
     match getEnv.impl "DOESNTEXIST" with 
       Right _ -> emit (Fail "env var shouldn't exist")
       Left _ -> emit (Ok "DOESNTEXIST didn't exist")
@@ -430,18 +430,18 @@ testHomeEnvVar _ =
 
   ⍟ I've added these definitions:
   
-    testHomeEnvVar : '{IO} [Result]
+    testGetEnv : '{IO} [Result]
 
-.> io.test testHomeEnvVar
+.> io.test testGetEnv
 
     New test results:
   
-  ◉ testHomeEnvVar   HOME environent variable should be set
-  ◉ testHomeEnvVar   DOESNTEXIST didn't exist
+  ◉ testGetEnv   PATH environent variable should be set
+  ◉ testGetEnv   DOESNTEXIST didn't exist
   
   ✅ 2 test(s) passing
   
-  Tip: Use view testHomeEnvVar to view the source of a test.
+  Tip: Use view testGetEnv to view the source of a test.
 
 ```
 ### Read command line args


### PR DESCRIPTION
fixes #2941 

## Overview

`HOME` doesn't exist on windows machines, so this test fails on windows.
This swaps it to use `PATH` will always be set on windows (either by the OS, or by stack itself)