### PR TITLE
Add newline conversion to utf8 file helpers for windows support

### DIFF
--- a/parser-typechecker/src/Unison/Parsers.hs
+++ b/parser-typechecker/src/Unison/Parsers.hs
@@ -4,8 +4,6 @@ module Unison.Parsers where
 import Unison.Prelude
 
 import qualified Data.Text                     as Text
-import           Data.Text.IO                   ( readFile )
-import           Prelude                 hiding ( readFile )
 import qualified Unison.NamesWithHistory                 as Names
 import qualified Unison.Builtin                as Builtin
 import qualified Unison.FileParser             as FileParser
@@ -62,7 +60,7 @@ readAndParseFile
   -> FilePath
   -> IO (Either (Parser.Err v) (UnisonFile v Ann))
 readAndParseFile penv fileName = do
-  txt <- readFile fileName
+  txt <- readUtf8 fileName
   let src = Text.unpack txt
   pure $ parseFile fileName src penv
 
@@ -72,7 +70,7 @@ unsafeParseTerm s = fmap (unsafeGetRightFrom s) . parseTerm $ s
 unsafeReadAndParseFile
   :: Parser.ParsingEnv -> FilePath -> IO (UnisonFile Symbol Ann)
 unsafeReadAndParseFile penv fileName = do
-  txt <- readFile fileName
+  txt <- readUtf8 fileName
   let str = Text.unpack txt
   pure . unsafeGetRightFrom str $ parseFile fileName str penv
 

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -14,7 +14,6 @@ import Control.Exception (finally, catch)
 import Control.Monad.State (runStateT)
 import Data.Configurator.Types (Config)
 import Data.IORef
-import Prelude hiding (readFile, writeFile)
 import System.IO.Error (isDoesNotExistError)
 import Unison.Codebase.Branch (Branch)
 import qualified Unison.Codebase.Branch as Branch
@@ -33,7 +32,6 @@ import Unison.Symbol (Symbol)
 import qualified Control.Concurrent.Async as Async
 import qualified Data.Map as Map
 import qualified Data.Text as Text
-import qualified Data.Text.IO
 import qualified System.Console.Haskeline as Line
 import qualified Crypto.Random        as Random
 import qualified Unison.Codebase.Path as Path
@@ -148,7 +146,7 @@ main dir welcome initialPath (config, cancelConfig) initialInputs runtime codeba
                       _ | isDoesNotExistError e -> return InvalidSourceNameError
                       _ -> return LoadError
                   go = do
-                    contents <- Data.Text.IO.readFile $ Text.unpack fname
+                    contents <- readUtf8 $ Text.unpack fname
                     return $ LoadSuccess contents
                   in catch go handle
             else return InvalidSourceNameError

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -19,7 +19,6 @@ import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 import Data.Set.NonEmpty (NESet)
 import qualified Data.Text as Text
-import Data.Text.IO (readFile, writeFile)
 import Data.Tuple (swap)
 import Data.Tuple.Extra (dupe, uncurry3)
 import System.Directory
@@ -125,7 +124,6 @@ import qualified Unison.Util.Relation as R
 import Unison.Var (Var)
 import qualified Unison.Var as Var
 import qualified Unison.WatchKind as WK
-import Prelude hiding (readFile, writeFile)
 import qualified Data.List.NonEmpty as NEList
 import qualified U.Util.Monoid as Monoid
 import qualified Data.Foldable as Foldable
@@ -1645,9 +1643,9 @@ displayRendered outputLoc pp =
           existingContents <- do
             exists <- doesFileExist path
             if exists
-              then readFile path
+              then readUtf8 path
               else pure ""
-          writeFile path . Text.pack . P.toPlain 80 $
+          writeUtf8 path . Text.pack . P.toPlain 80 $
             P.lines [pp, "", P.text existingContents]
         message pp path =
           P.callout "☝️" $
@@ -1681,9 +1679,9 @@ displayDefinitions outputLoc ppe types terms =
           existingContents <- do
             exists <- doesFileExist path
             if exists
-              then readFile path
+              then readUtf8 path
               else pure ""
-          writeFile path . Text.pack . P.toPlain 80 $
+          writeUtf8 path . Text.pack . P.toPlain 80 $
             P.lines
               [ code,
                 "",


### PR DESCRIPTION
## Overview

fixes #2940

The problem:

Code-blocks in docs would be parsed as-is from the file during round-tripping, which would introduce carriage returns on windows, resulting in a "new doc" and a changed term.

## Implementation notes

* Use the [universalNewlineMode](https://hackage.haskell.org/package/base-4.16.0.0/docs/System-IO.html#v:universalNewlineMode) in the `readUtf8` and `writeUtf8` helpers.

This converts `\r\n` into `\n` when reading files, and `\n` -> `\r\n` when writing files, meaning `ucm` only ever sees unix-style newlines, but windows users still see the `\r\n` that they expect.

I added it into these central helpers so we're less likely to encounter Windows bugs like this in the future.

* Use `readUtf8` and `writeUtf8` for parsing and round-tripping in a few spots we weren't already.