### PR TITLE
Doc Embed: Add Video and FrontMatter

### DIFF
--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -100,6 +100,7 @@ library:
     - mwc-random
     - NanoID
     - lucid
+    - yaml
     - semialign
     - servant
     - servant-docs

--- a/parser-typechecker/src/Unison/Server/Types.hs
+++ b/parser-typechecker/src/Unison/Server/Types.hs
@@ -214,10 +214,12 @@ instance ToJSON TypeTag where
 deriving instance ToSchema TypeTag
 
 instance ToJSON Doc where
+instance ToJSON Doc.MediaSource where
 instance ToJSON Doc.SpecialForm where
 instance ToJSON Doc.Src where
 instance ToJSON a => ToJSON (Doc.Ref a) where
 instance ToSchema Doc where
+instance ToSchema Doc.MediaSource where
 instance ToSchema Doc.SpecialForm where
 instance ToSchema Doc.Src where
 instance ToSchema a => ToSchema (Doc.Ref a) where

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -307,6 +307,7 @@ library
     , x509
     , x509-store
     , x509-system
+    , yaml
     , zlib
   if flag(optimized)
     ghc-options: -funbox-strict-fields -O2

--- a/unison-core/src/Unison/Util/List.hs
+++ b/unison-core/src/Unison/Util/List.hs
@@ -62,16 +62,16 @@ intercalateMapWith :: (a -> a -> b) -> (a -> b) -> [a] -> [b]
 intercalateMapWith sep f xs  = result where
   xs'   = map f xs
   pairs = filter (\p -> length p == 2) $ map (take 2) $ List.tails xs
-  seps  = (flip map) pairs $ \case
+  seps  = flip map pairs $ \case
     x1 : x2 : _ -> sep x1 x2
     _           -> error "bad list length"
   paired = zipWith (\sep x -> [sep, x]) seps (drop 1 xs')
-  result = (take 1 xs') ++ mconcat paired
+  result = take 1 xs' ++ mconcat paired
 
 -- Take runs of consecutive occurrences of r within a list,
 -- and in each run, overwrite all but the first occurrence of r with w.
 quenchRuns :: Eq a => a -> a -> [a] -> [a]
-quenchRuns r w = reverse . (go False r w []) where
+quenchRuns r w = reverse . go False r w [] where
   go inRun r w acc = \case
     [] -> acc
     h : tl ->

--- a/unison-src/transcripts/emptyCodebase.output.md
+++ b/unison-src/transcripts/emptyCodebase.output.md
@@ -35,7 +35,7 @@ And for a limited time, you can get even more builtin goodies:
 
 .foo> ls
 
-  1. builtin/ (551 definitions)
+  1. builtin/ (569 definitions)
 
 ```
 More typically, you'd start out by pulling `base.


### PR DESCRIPTION
## Overview
Expand the Doc Embed variant to support embedding videos and
front-matter. The latter will be rendered at the top of the output of the
html file rendered via the `docs.to-html` command.

This is needed as part of the effort to move the blog to Unison Doc.

Paired with @pchiusano 

## Implementation notes
Add a few new types that `Doc2.Embed` wraps and add patterns for them and add support for them
when rendering docs to html.

## Caveat

Haven't tested this yet. Not actually sure the doc syntax to embed. @pchiusano any pointers?