### PR TITLE
Run transcripts using Haskell API rather than shelling out

### DIFF
--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -82,8 +82,7 @@ executables:
       - easytest
       - process
       - shellmet
-    build-tools:
-      - unison-cli:unison
+      - unison-cli
 
   integration-tests:
     source-dirs: integration-tests

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -222,8 +222,6 @@ executable transcripts
       TypeApplications
       ViewPatterns
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N -v0
-  build-tools:
-      unison
   build-depends:
       ListLike
     , async
@@ -253,6 +251,7 @@ executable transcripts
     , text
     , these
     , transformers
+    , unison-cli
     , unison-codebase-sqlite
     , unison-core1
     , unison-parser-typechecker


### PR DESCRIPTION
fixes #2935 ;
It still spins up a new runtime instance for each transcript, but since the IOSource typechecked unison file is a top-level-definition, laziness means we'll only parse it once.

## Overview

trunk currently runs all of the transcripts by shelling out to the unison cli, this causes two problems:

* It's slow to boot up a fresh ucm for every transcript
* On Windows, we're likely to encounter [this bug](https://github.com/commercialhaskell/stack/issues/5038) which comes up when using `readProcess`, I'm noticing when I run transcripts on windows it inserts a ton of `++stty: 'standard input': Inappropriate ioctl for device` into output files.


As far as speedup goes, a quick benchmark on non-optimized builds shaves off ~90 seconds!

```
# New version
/usr/bin/time stack exec transcripts
      103.79 real       153.25 user        89.79 sys


# trunk
/usr/bin/time stack exec transcripts
      193.79 real       183.08 user         6.97 sys
```

## Implementation notes

* Define `withTranscriptRunner`, which does a single initialization and then provides a transcript runner to the provided action. The caller can run any number of transcripts without re-initializing the runtime.
* Rather than crash the with an `exit 1` on failure and then detect that exit code, we return an Either which can be handled as a test failure.