### PR TITLE
Handle more inconsistencies with newline conversion on Windows

### DIFF
--- a/lib/unison-prelude/src/Unison/Prelude.hs
+++ b/lib/unison-prelude/src/Unison/Prelude.hs
@@ -103,7 +103,7 @@ safeReadUtf8 p = try (readUtf8 p)
 -- to convert \r\n -> \n on windows.
 readUtf8Handle :: IO.Handle -> IO Text
 readUtf8Handle handle = do
-  IO.hSetNewlineMode handle IO.universalNewlineMode
+  IO.hSetNewlineMode handle IO.nativeNewlineMode
   decodeUtf8 <$> BS.hGetContents handle
 
 -- | Strictly read from stdin, decoding UTF8.

--- a/lib/unison-prelude/src/Unison/Prelude.hs
+++ b/lib/unison-prelude/src/Unison/Prelude.hs
@@ -30,7 +30,6 @@ import Control.Monad.IO.Class as X (MonadIO (liftIO))
 import Control.Monad.Trans as X (MonadTrans (lift))
 import Control.Monad.Trans.Maybe as X (MaybeT (MaybeT, runMaybeT))
 import Data.ByteString as X (ByteString)
-import qualified Data.ByteString as BS
 import Data.Coerce as X (Coercible, coerce)
 import Data.Either as X
 import Data.Either.Combinators as X (mapLeft, maybeToRight)
@@ -46,6 +45,7 @@ import Data.Set as X (Set)
 import Data.String as X (IsString, fromString)
 import Data.Text as X (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
 import Data.Text.Encoding as X (decodeUtf8, encodeUtf8)
 import Data.Traversable as X (for)
 import Data.Typeable as X (Typeable)
@@ -103,8 +103,8 @@ safeReadUtf8 p = try (readUtf8 p)
 -- to convert \r\n -> \n on windows.
 readUtf8Handle :: IO.Handle -> IO Text
 readUtf8Handle handle = do
-  IO.hSetNewlineMode handle IO.nativeNewlineMode
-  decodeUtf8 <$> BS.hGetContents handle
+  Handle.hSetEncoding handle IO.utf8
+  Text.hGetContents handle
 
 -- | Strictly read from stdin, decoding UTF8.
 -- Converts \r\n -> \n on windows.
@@ -122,8 +122,8 @@ uncurry4 f (a, b, c, d) =
 writeUtf8 :: FilePath -> Text -> IO ()
 writeUtf8 fileName txt = do
   UnliftIO.withFile fileName UnliftIO.WriteMode $ \handle -> do
-    IO.hSetNewlineMode handle IO.universalNewlineMode
-    BS.hPut handle (encodeUtf8 txt)
+    Handle.hSetEncoding handle IO.utf8
+    Text.hPutStr handle txt
 
 reportBug :: String -> String -> String
 reportBug bugId msg =

--- a/parser-typechecker/src/Unison/Codebase/Watch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Watch.hs
@@ -21,7 +21,6 @@ import           UnliftIO.IORef                 ( newIORef
                                                 , writeIORef
                                                 )
 import qualified Data.Map                      as Map
-import qualified Data.Text.IO
 import           Data.Time.Clock                ( UTCTime
                                                 , diffUTCTime
                                                 )
@@ -92,7 +91,7 @@ watchDirectory dir allow = do
           liftIO $ print (e :: IOException)
         go :: IO (Maybe (FilePath, Text))
         go = liftIO $ do
-          contents <- Data.Text.IO.readFile file
+          contents <- readUtf8 file
           prevs    <- readIORef previousFiles
           case Map.lookup file prevs of
             -- if the file's content's haven't changed and less than .5s

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -42,6 +42,7 @@ import Text.Megaparsec.Char (char)
 import qualified Text.Megaparsec.Char.Lexer as LP
 import Unison.Lexer.Pos (Pos (Pos), Column, Line, column, line)
 import qualified Unison.Util.Bytes as Bytes
+import qualified Data.Text as Text
 
 type BlockName = String
 type Layout = [(BlockName,Column)]
@@ -1188,8 +1189,8 @@ inc (Pos line col) = Pos line (col + 1)
 
 debugFileLex :: String -> IO ()
 debugFileLex file = do
-  contents <- readFile file
-  let s = debugLex'' (lexer file contents)
+  contents <- readUtf8 file
+  let s = debugLex'' (lexer file (Text.unpack contents))
   putStrLn s
 
 debugLex'' :: [Token Lexeme] -> String

--- a/parser-typechecker/tests/Unison/Test/UnisonSources.hs
+++ b/parser-typechecker/tests/Unison/Test/UnisonSources.hs
@@ -11,7 +11,6 @@ import           Control.Monad.IO.Class (liftIO)
 import qualified Data.Map               as Map
 import           Data.Sequence          (Seq)
 import           Data.Text              (unpack)
-import           Data.Text.IO           (readFile)
 import           EasyTest
 import           System.FilePath        (joinPath, splitPath, replaceExtension)
 import           System.FilePath.Find   (always, extension, find, (==?))
@@ -119,7 +118,7 @@ shortName = joinPath . drop 1 . splitPath
 
 typecheckingTest :: (EitherResult -> Test TFile) -> FilePath -> Test TFile
 typecheckingTest how filepath = scope "typecheck" $ do
-  source <- io $ unpack <$> Data.Text.IO.readFile filepath
+  source <- io $ unpack <$> readUtf8 filepath
   how . decodeResult source $ parseAndSynthesizeAsFile [] (shortName filepath) source
 
 resultTest
@@ -129,7 +128,7 @@ resultTest rt uf filepath = do
   rFileExists <- io $ doesFileExist valueFile
   if rFileExists
     then scope "result" $ do
-      values <- io $ unpack <$> Data.Text.IO.readFile valueFile
+      values <- io $ unpack <$> readUtf8 valueFile
       let term        = Parsers.parseTerm values parsingEnv
       let report e = throwIO (userError $ toPlain 10000 e)
       (bindings, watches) <- io $ either report pure =<<

--- a/parser-typechecker/tests/Unison/Test/UnisonSources.hs
+++ b/parser-typechecker/tests/Unison/Test/UnisonSources.hs
@@ -7,9 +7,7 @@ module Unison.Test.UnisonSources where
 import           Control.Exception      (throwIO)
 import           Control.Lens           ( view )
 import           Control.Lens.Tuple     ( _5 )
-import           Control.Monad.IO.Class (liftIO)
 import qualified Data.Map               as Map
-import           Data.Sequence          (Seq)
 import           Data.Text              (unpack)
 import           EasyTest
 import           System.FilePath        (joinPath, splitPath, replaceExtension)
@@ -21,6 +19,7 @@ import Unison.Parser.Ann (Ann)
 import qualified Unison.Parsers         as Parsers
 import qualified Unison.PrettyPrintEnv  as PPE
 import qualified Unison.PrettyPrintEnv.Names as PPE
+import           Unison.Prelude
 import qualified Unison.PrintError      as PrintError
 import           Unison.Result          (pattern Result, Result)
 import qualified Unison.Result          as Result

--- a/unison-cli/tests/Unison/Test/GitSync.hs
+++ b/unison-cli/tests/Unison/Test/GitSync.hs
@@ -549,9 +549,9 @@ pushPullTest name fmt authorScript userScript = scope name do
     user <- Ucm.initCodebase fmt
     userOutput <- Ucm.runTranscript user (userScript repo)
 
-    when writeTranscriptOutput $ writeFile
+    when writeTranscriptOutput $ writeUtf8
       (transcriptOutputFile name)
-      (authorOutput <> "\n-------\n" <> userOutput)
+      (Text.pack $ authorOutput <> "\n-------\n" <> userOutput)
 
     -- if we haven't crashed, clean up!
     removePathForcibly repo
@@ -569,9 +569,9 @@ watchPushPullTest name fmt authorScript userScript codebaseCheck = scope name do
     userOutput <- Ucm.runTranscript user (userScript repo)
     Ucm.lowLevel user codebaseCheck
 
-    when writeTranscriptOutput $ writeFile
+    when writeTranscriptOutput $ writeUtf8
       (transcriptOutputFile name)
-      (authorOutput <> "\n-------\n" <> userOutput)
+      (Text.pack $ authorOutput <> "\n-------\n" <> userOutput)
 
     -- if we haven't crashed, clean up!
     removePathForcibly repo

--- a/unison-src/parser-tests/GenerateErrors.hs
+++ b/unison-src/parser-tests/GenerateErrors.hs
@@ -27,7 +27,7 @@ errorFileName :: String -> String
 errorFileName n = dropExtension n ++ ".message.txt"
 
 emitAsPlainTextTo :: Var v => String -> Err v -> FilePath -> IO ()
-emitAsPlainTextTo src e f = writeFile f plainErr
+emitAsPlainTextTo src e f = writeUtf8 f plainErr
   where plainErr = Color.toPlain $ prettyParseError src e
 
 printError :: Var v => String -> Err v -> IO ()

--- a/unison-src/parser-tests/GenerateErrors.hs
+++ b/unison-src/parser-tests/GenerateErrors.hs
@@ -2,8 +2,7 @@
 {- For every file foo.u in the current directory write the parse error to foo.message.txt -}
 module GenerateErrors where
 import qualified Data.Text                as Text
-import           Data.Text.IO             ( readFile )
-import           Prelude           hiding ( readFile )
+import           Prelude
 import           System.Directory         ( listDirectory, getCurrentDirectory )
 import           System.FilePath          ( takeExtension, dropExtension )
 import           System.IO                ( putStrLn )
@@ -36,7 +35,7 @@ printError src e = putStrLn $ B.showParseError src e
 
 processFile :: FilePath -> IO ()
 processFile f = do
-  content <- Text.unpack <$> readFile f
+  content <- Text.unpack <$> readUtf8 f
   let res = P.parseFile f content B.names
   case res of
     Left err -> do


### PR DESCRIPTION
## Overview

It turns out the problem runs deeper than originally thought in #2943 ,
The default newline mode on Handles is correct, BUT we were circumventing newline handling by reading the files in Bytestring mode.

I took a look at how `rio` does this and ported it over (see their impl [here](https://hackage.haskell.org/package/rio-0.1.21.0/docs/src/RIO.Prelude.IO.html#readFileUtf8), since they're the current authority on `readFile`, and indeed this new version works better 👍🏼 

I also found another few spots to swap to `readUtf8`/`writeUtf8`

## Implementation notes

* Update `readUtf8`/`writeUtf8` to explicitly set `utf8` mode on their file handle, then use the `Text.IO` operations to read and write, which handles newlines properly (e.g. converts `\r\n -> \n` on read, and the reverse on write.)
