### PR TITLE
Use v3 branch instead of v2 for less confusion

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
@@ -26,11 +26,11 @@ defaultBaseLib = fmap makeNS $ latest <|> release
     Text.pack <$> some (alphaNumChar <|> ('_' <$ oneOf ['.', '_', '-']))
   makeNS :: Text -> ReadRemoteNamespace
   makeNS t = ( ReadGitRepo { url="https://github.com/unisonweb/base"
-                           -- Use the 'v2' branch of base for now.
+                           -- Use the 'v3' branch of base for now.
                            -- We can revert back to the main branch once enough people have upgraded ucm and
-                           -- we're okay with pushing the v2 base codebase to main (perhaps by the next ucm
+                           -- we're okay with pushing the v3 base codebase to main (perhaps by the next ucm
                            -- release).
-                           , ref=Just "v2"
+                           , ref=Just "v3"
                            }
              , Nothing
              , Path.fromText t)

--- a/unison-cli/tests/Unison/Test/VersionParser.hs
+++ b/unison-cli/tests/Unison/Test/VersionParser.hs
@@ -24,7 +24,7 @@ makeTest (version, path) =
   scope (unpack version) $ expectEqual
     (rightMay $ runParser defaultBaseLib "versionparser" version)
     (Just
-      -- We've hard-coded the v2 branch for base for now. See 'defaultBaseLib'
-      ( ReadGitRepo "https://github.com/unisonweb/base" (Just "v2")
+      -- We've hard-coded the v3 branch for base for now. See 'defaultBaseLib'
+      ( ReadGitRepo "https://github.com/unisonweb/base" (Just "v3")
       , Nothing
       , Path.fromText path ))


### PR DESCRIPTION
## Overview
Just swaps the auto-pull of base to use v3 instead of v2 since we decided on slack that it's less confusing 😄 

Looks like @hojberg  already pushed a share version to v3, and I went ahead and pushed `v3` in base as well.