### PR TITLE
Fix paging on windows - Less Is More!

### DIFF
--- a/parser-typechecker/src/Unison/Util/Less.hs
+++ b/parser-typechecker/src/Unison/Util/Less.hs
@@ -5,27 +5,50 @@ import System.Environment (lookupEnv)
 import System.Process
 import System.IO (hPutStr, hClose)
 import Control.Exception.Extra (ignore)
-import Unison.Prelude (void)
+import Unison.Prelude
+import UnliftIO.Directory (findExecutable)
+import qualified UnliftIO
 
 less :: String -> IO ()
 less str = do
-  inEmacs <- lookupEnv "INSIDE_EMACS"
-  case inEmacs of
-    Just _ -> putStr str
-    Nothing -> do
-      let args = ["--no-init"            -- don't clear the screen on exit
-                 ,"--raw-control-chars"  -- pass through colors and stuff
-                 ,"--prompt=[less] Use space/arrow keys to navigate, or 'q' to return to ucm:"
-                 ,"--quit-if-one-screen" -- self-explanatory
-                 ]
-      (Just stdin, _stdout, _stderr, pid)
-        <- createProcess (proc "less" args) { std_in = CreatePipe }
+  isInteractive <- lookupEnv "INSIDE_EMACS" >>= \case
+                     Just _ -> pure False
+                     Nothing -> UnliftIO.hIsTerminalDevice UnliftIO.stdin
+  if isInteractive
+     then usePager
+     else noPager
+  where
+    noPager :: IO ()
+    noPager = putStr str
+    usePager :: IO ()
+    usePager = do
+      pager <- runMaybeT $ msum
+                [ shell <$> MaybeT (lookupEnv "PAGER")
+                , MaybeT (findExecutable "less") <&> \less -> proc less lessArgs
+                -- most windows machines have 'more'.
+                , MaybeT (findExecutable "more") <&> \more -> proc more moreArgs
+                ]
+      case pager of
+        Nothing -> noPager
+        Just process -> do
+          (Just stdin, _stdout, _stderr, pid)
+            <- createProcess process { std_in = CreatePipe }
 
-      -- If `less` exits before consuming all of stdin, `hPutStr` will crash.
-      ignore $ hPutStr stdin str
+          -- If pager exits before consuming all of stdin, `hPutStr` will crash.
+          ignore $ hPutStr stdin str
 
-      -- If `less` has already exited, hClose throws an exception.
-      ignore $ hClose stdin
+          -- If pager has already exited, hClose throws an exception.
+          ignore $ hClose stdin
 
-      -- Wait for `less` to exit.
-      void $ waitForProcess pid
+          -- Wait for pager to exit.
+          void $ waitForProcess pid
+
+    lessArgs :: [String]
+    lessArgs = ["--no-init"            -- don't clear the screen on exit
+               ,"--raw-control-chars"  -- pass through colors and stuff
+               ,"--prompt=[less] Use space/arrow keys to navigate, or 'q' to return to ucm:"
+               ,"--quit-if-one-screen" -- self-explanatory
+                           ]
+
+    moreArgs :: [String]
+    moreArgs = []

--- a/parser-typechecker/src/Unison/Util/Less.hs
+++ b/parser-typechecker/src/Unison/Util/Less.hs
@@ -25,7 +25,7 @@ less str = do
       pager <-
         runMaybeT $
           msum
-            [ shell <$> MaybeT (lookupEnv "PAGER"),
+            [ shell <$> MaybeT (lookupEnv "UNISON_PAGER"),
               MaybeT (findExecutable "less") <&> \less -> proc less lessArgs,
               -- most windows machines have 'more'.
               MaybeT (findExecutable "more") <&> \more -> proc more []

--- a/parser-typechecker/src/Unison/Util/Less.hs
+++ b/parser-typechecker/src/Unison/Util/Less.hs
@@ -1,38 +1,40 @@
-{- ORMOLU_DISABLE -} -- Remove this when the file is ready to be auto-formatted
 module Unison.Util.Less where
 
-import System.Environment (lookupEnv)
-import System.Process
-import System.IO (hPutStr, hClose)
 import Control.Exception.Extra (ignore)
+import System.Environment (lookupEnv)
+import System.IO (hClose, hPutStr)
+import System.Process
 import Unison.Prelude
-import UnliftIO.Directory (findExecutable)
 import qualified UnliftIO
+import UnliftIO.Directory (findExecutable)
 
 less :: String -> IO ()
 less str = do
-  isInteractive <- lookupEnv "INSIDE_EMACS" >>= \case
-                     Just _ -> pure False
-                     Nothing -> UnliftIO.hIsTerminalDevice UnliftIO.stdin
+  isInteractive <-
+    lookupEnv "INSIDE_EMACS" >>= \case
+      Just _ -> pure False
+      Nothing -> UnliftIO.hIsTerminalDevice UnliftIO.stdin
   if isInteractive
-     then usePager
-     else noPager
+    then usePager
+    else noPager
   where
     noPager :: IO ()
     noPager = putStr str
     usePager :: IO ()
     usePager = do
-      pager <- runMaybeT $ msum
-                [ shell <$> MaybeT (lookupEnv "PAGER")
-                , MaybeT (findExecutable "less") <&> \less -> proc less lessArgs
-                -- most windows machines have 'more'.
-                , MaybeT (findExecutable "more") <&> \more -> proc more moreArgs
-                ]
+      pager <-
+        runMaybeT $
+          msum
+            [ shell <$> MaybeT (lookupEnv "PAGER"),
+              MaybeT (findExecutable "less") <&> \less -> proc less lessArgs,
+              -- most windows machines have 'more'.
+              MaybeT (findExecutable "more") <&> \more -> proc more []
+            ]
       case pager of
         Nothing -> noPager
         Just process -> do
-          (Just stdin, _stdout, _stderr, pid)
-            <- createProcess process { std_in = CreatePipe }
+          (Just stdin, _stdout, _stderr, pid) <-
+            createProcess process {std_in = CreatePipe}
 
           -- If pager exits before consuming all of stdin, `hPutStr` will crash.
           ignore $ hPutStr stdin str
@@ -44,11 +46,9 @@ less str = do
           void $ waitForProcess pid
 
     lessArgs :: [String]
-    lessArgs = ["--no-init"            -- don't clear the screen on exit
-               ,"--raw-control-chars"  -- pass through colors and stuff
-               ,"--prompt=[less] Use space/arrow keys to navigate, or 'q' to return to ucm:"
-               ,"--quit-if-one-screen" -- self-explanatory
-                           ]
-
-    moreArgs :: [String]
-    moreArgs = []
+    lessArgs =
+      [ "--no-init", -- don't clear the screen on exit
+        "--raw-control-chars", -- pass through colors and stuff
+        "--prompt=[less] Use space/arrow keys to navigate, or 'q' to return to ucm:",
+        "--quit-if-one-screen" -- self-explanatory
+      ]


### PR DESCRIPTION
fixes #2939 
closes #2518

## Overview

`less` isn't usually in scope, this adds `more` and raw-output as a fallback, and the option to override with the `UNISON_PAGER` env var.

I decided not to use the `PAGER` env var directly, since the default settings of many pagers don’t work well with the way ucm currently uses the pager. 
We currently set a lot of flags for less to make it work in a specific way, without them it doesn’t work right.
E.g. if you set PAGER=less  then every time ucm prints something it spawns a new process, clears the screen, and you need to hit q to get back to what you were doing, also it won’t properly parse ANSI codes.

less should do the trick for most folks I figure. People on Windows can use more or raw output until they get annoyed and install less.
(Or we can figure out how to package less with it once we have a better packaging solution on Windows)

## Implementation notes

Here's a flow chart:

* If we're `INSIDE_EMACS` or the output device isn't a terminal, don't use a pager. This also means the pager won't be triggered inside scripts.
* else, If a `UNISON_PAGER` env var exists, use it as a shell command pipe input to that,
* else, If `less` exists, use that with the appropriate flags
* else, If `more` exists, use that.
* else, don't use a pager.

## Interesting/controversial decisions

I investigated what it would take to use a `Config` value for this, it's possible, but since most of the pretty printer stuff is currently in `IO` we'd probably need to thread through a new `ReaderT` with config values all the way through, or make a new Pretty Printer monad.
I think we should probably do that at some point, since it's helpful to pass information to the pretty-printer layer like desired output width, which pager to use, whether to use ANSI colors etc. There will also probably be cases where we want to capture pretty printed output rather than dumping it directly to stdout. However, doing this right now involves generalizing IO to `MonadUnliftIO` in a big piece of the module stack. We can re-visit this idea later when we have more complex needs.
