### PR TITLE
Enable completion for compile.output

### DIFF
--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1798,7 +1798,7 @@ makeStandalone =
   InputPattern
     "compile.output"
     []
-    []
+    [(Required, exactDefinitionTermQueryArg), (Required, noCompletions)]
     ( P.wrapColumn2
         [ ( "`compile.output main file`",
             "Outputs a stand alone file that can be directly loaded and"


### PR DESCRIPTION
This allows auto-completion for the first argument to `compile.output` (the main method).

Full disclosure: I don't know what I'm doing with `InputPattern` and copy/pasted from other examples. But it seems to work.