### PR TITLE
Use softhang if a delayed block is the last argument to a function

### DIFF
--- a/unison-src/transcripts-round-trip/main.md
+++ b/unison-src/transcripts-round-trip/main.md
@@ -373,3 +373,71 @@ x = [ 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
 ```ucm
 .> load scratch.u
 ```
+
+## Delayed computations passed to a function as the last argument
+
+When a delayed computation block is passed to a function as the last argument
+in a context where the ambient precedence is low enough, we can elide parentheses 
+around it and use a "soft hang" to put the `'let` on the same line as the function call. 
+This looks nice.
+
+    forkAt usEast 'let
+      x = thing1
+      y = thing2
+      ...
+
+vs the not as pretty but still correct:
+
+    forkAt 
+      usEast 
+      ('let 
+          x = thing1
+          y = thing2
+          ...)
+
+Okay, here's the test, showing that we use the prettier version when possible:
+
+```unison:hide
+(+) a b = ##Nat.+ a b
+
+foo a b = 42 
+
+bar0 x = 'let
+  a = 1
+  b = 2
+  foo a 'let
+    c = 3
+    a + b
+
+bar1 x = 'let
+  a = 1
+  b = 2
+  foo (100 + 200 + 300 + 400 + 500 + 600 + 700 + 800 + 900 + 1000 + 1100 + 1200 + 1300 + 1400 + 1500) 'let
+    c = 3
+    a + b
+
+bar2 x = 'let
+  a = 1
+  b = 2
+  1 + foo a 'let
+    c = 3
+    a + b
+
+bar3 x = 'let
+  a = 1
+  b = 2
+  c = foo 'let
+    c = 3
+    a + b
+  c
+```
+
+```ucm
+.> add
+.> edit foo bar0 bar1 bar2 bar3
+.> undo
+```
+
+```ucm
+.> load scratch.u
+```

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -18,7 +18,7 @@ x = 1 + 1
   ☝️
   
   I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
+  /Users/pchiusano/unison/scratch.u
   
     x : Nat
     x =
@@ -34,16 +34,16 @@ x = 1 + 1
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #3c9e0ekrve .old`   to make an old namespace
+    `fork #7q3vkcpt75 .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #3c9e0ekrve`  to reset the root namespace and
+    `reset-root #7q3vkcpt75`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
-  1. #2l4u38r8o4 : add
-  2. #3c9e0ekrve : builtins.mergeio
-  3. #sjg2v58vn2 : (initial reflogged namespace)
+  1. #9u7u21tka1 : add
+  2. #7q3vkcpt75 : builtins.mergeio
+  3. #sg60bvjo91 : (initial reflogged namespace)
 
 .> reset-root 2
 
@@ -102,7 +102,7 @@ Without the above stanza, the `edit` will send the definition to the most recent
   ☝️
   
   I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
+  /Users/pchiusano/unison/scratch.u
   
     b : Nat
     b = 92384
@@ -116,18 +116,18 @@ Without the above stanza, the `edit` will send the definition to the most recent
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #3c9e0ekrve .old`   to make an old namespace
+    `fork #7q3vkcpt75 .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #3c9e0ekrve`  to reset the root namespace and
+    `reset-root #7q3vkcpt75`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
-  1. #il1nrbvapm : add
-  2. #3c9e0ekrve : reset-root #3c9e0ekrve
-  3. #2l4u38r8o4 : add
-  4. #3c9e0ekrve : builtins.mergeio
-  5. #sjg2v58vn2 : (initial reflogged namespace)
+  1. #braja24u2c : add
+  2. #7q3vkcpt75 : reset-root #7q3vkcpt75
+  3. #9u7u21tka1 : add
+  4. #7q3vkcpt75 : builtins.mergeio
+  5. #sg60bvjo91 : (initial reflogged namespace)
 
 .> reset-root 2
 
@@ -174,7 +174,7 @@ f x = let
   ☝️
   
   I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
+  /Users/pchiusano/unison/scratch.u
   
     unique type Blah
       = Blah Boolean Boolean
@@ -191,20 +191,20 @@ f x = let
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #3c9e0ekrve .old`   to make an old namespace
+    `fork #7q3vkcpt75 .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #3c9e0ekrve`  to reset the root namespace and
+    `reset-root #7q3vkcpt75`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
-  1. #ujscu5crkl : add
-  2. #3c9e0ekrve : reset-root #3c9e0ekrve
-  3. #il1nrbvapm : add
-  4. #3c9e0ekrve : reset-root #3c9e0ekrve
-  5. #2l4u38r8o4 : add
-  6. #3c9e0ekrve : builtins.mergeio
-  7. #sjg2v58vn2 : (initial reflogged namespace)
+  1. #r4cr8bjrq6 : add
+  2. #7q3vkcpt75 : reset-root #7q3vkcpt75
+  3. #braja24u2c : add
+  4. #7q3vkcpt75 : reset-root #7q3vkcpt75
+  5. #9u7u21tka1 : add
+  6. #7q3vkcpt75 : builtins.mergeio
+  7. #sg60bvjo91 : (initial reflogged namespace)
 
 .> reset-root 2
 
@@ -256,7 +256,7 @@ h xs = match xs with
   ☝️
   
   I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
+  /Users/pchiusano/unison/scratch.u
   
     f : [a] -> a
     f = cases x +: (x' +: rest) -> x
@@ -273,22 +273,22 @@ h xs = match xs with
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #3c9e0ekrve .old`   to make an old namespace
+    `fork #7q3vkcpt75 .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #3c9e0ekrve`  to reset the root namespace and
+    `reset-root #7q3vkcpt75`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
-  1. #nidbht5ocv : add
-  2. #3c9e0ekrve : reset-root #3c9e0ekrve
-  3. #ujscu5crkl : add
-  4. #3c9e0ekrve : reset-root #3c9e0ekrve
-  5. #il1nrbvapm : add
-  6. #3c9e0ekrve : reset-root #3c9e0ekrve
-  7. #2l4u38r8o4 : add
-  8. #3c9e0ekrve : builtins.mergeio
-  9. #sjg2v58vn2 : (initial reflogged namespace)
+  1. #uhh1lpve1d : add
+  2. #7q3vkcpt75 : reset-root #7q3vkcpt75
+  3. #r4cr8bjrq6 : add
+  4. #7q3vkcpt75 : reset-root #7q3vkcpt75
+  5. #braja24u2c : add
+  6. #7q3vkcpt75 : reset-root #7q3vkcpt75
+  7. #9u7u21tka1 : add
+  8. #7q3vkcpt75 : builtins.mergeio
+  9. #sg60bvjo91 : (initial reflogged namespace)
 
 .> reset-root 2
 
@@ -334,7 +334,7 @@ foo n _ = n
   ☝️
   
   I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
+  /Users/pchiusano/unison/scratch.u
   
     unique type Foo x y
       = 
@@ -353,24 +353,24 @@ foo n _ = n
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #3c9e0ekrve .old`   to make an old namespace
+    `fork #7q3vkcpt75 .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #3c9e0ekrve`  to reset the root namespace and
+    `reset-root #7q3vkcpt75`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
-  1.  #rrjp642tnp : add
-  2.  #3c9e0ekrve : reset-root #3c9e0ekrve
-  3.  #nidbht5ocv : add
-  4.  #3c9e0ekrve : reset-root #3c9e0ekrve
-  5.  #ujscu5crkl : add
-  6.  #3c9e0ekrve : reset-root #3c9e0ekrve
-  7.  #il1nrbvapm : add
-  8.  #3c9e0ekrve : reset-root #3c9e0ekrve
-  9.  #2l4u38r8o4 : add
-  10. #3c9e0ekrve : builtins.mergeio
-  11. #sjg2v58vn2 : (initial reflogged namespace)
+  1.  #v4mbt4a1fa : add
+  2.  #7q3vkcpt75 : reset-root #7q3vkcpt75
+  3.  #uhh1lpve1d : add
+  4.  #7q3vkcpt75 : reset-root #7q3vkcpt75
+  5.  #r4cr8bjrq6 : add
+  6.  #7q3vkcpt75 : reset-root #7q3vkcpt75
+  7.  #braja24u2c : add
+  8.  #7q3vkcpt75 : reset-root #7q3vkcpt75
+  9.  #9u7u21tka1 : add
+  10. #7q3vkcpt75 : builtins.mergeio
+  11. #sg60bvjo91 : (initial reflogged namespace)
 
 .> reset-root 2
 
@@ -413,7 +413,7 @@ foo =
   ☝️
   
   I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
+  /Users/pchiusano/unison/scratch.u
   
     foo : Text
     foo =
@@ -432,26 +432,26 @@ foo =
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #3c9e0ekrve .old`   to make an old namespace
+    `fork #7q3vkcpt75 .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #3c9e0ekrve`  to reset the root namespace and
+    `reset-root #7q3vkcpt75`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
-  1.  #876bkg1cir : add
-  2.  #3c9e0ekrve : reset-root #3c9e0ekrve
-  3.  #rrjp642tnp : add
-  4.  #3c9e0ekrve : reset-root #3c9e0ekrve
-  5.  #nidbht5ocv : add
-  6.  #3c9e0ekrve : reset-root #3c9e0ekrve
-  7.  #ujscu5crkl : add
-  8.  #3c9e0ekrve : reset-root #3c9e0ekrve
-  9.  #il1nrbvapm : add
-  10. #3c9e0ekrve : reset-root #3c9e0ekrve
-  11. #2l4u38r8o4 : add
-  12. #3c9e0ekrve : builtins.mergeio
-  13. #sjg2v58vn2 : (initial reflogged namespace)
+  1.  #qam2buklki : add
+  2.  #7q3vkcpt75 : reset-root #7q3vkcpt75
+  3.  #v4mbt4a1fa : add
+  4.  #7q3vkcpt75 : reset-root #7q3vkcpt75
+  5.  #uhh1lpve1d : add
+  6.  #7q3vkcpt75 : reset-root #7q3vkcpt75
+  7.  #r4cr8bjrq6 : add
+  8.  #7q3vkcpt75 : reset-root #7q3vkcpt75
+  9.  #braja24u2c : add
+  10. #7q3vkcpt75 : reset-root #7q3vkcpt75
+  11. #9u7u21tka1 : add
+  12. #7q3vkcpt75 : builtins.mergeio
+  13. #sg60bvjo91 : (initial reflogged namespace)
 
 .> reset-root 2
 
@@ -490,7 +490,7 @@ myDoc = {{ **my text** __my text__ **MY_TEXT** ___MY__TEXT___ ~~MY~TEXT~~ **MY*T
   ☝️
   
   I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
+  /Users/pchiusano/unison/scratch.u
   
     myDoc : Doc2
     myDoc =
@@ -573,7 +573,7 @@ x = '(let
   ☝️
   
   I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
+  /Users/pchiusano/unison/scratch.u
   
     structural ability base.Abort where abort : {base.Abort} a
     
@@ -612,12 +612,12 @@ x = '(let
   Added definitions:
   
     1. structural ability base.Abort
-    2. base.Abort.abort  : {#oup50kgmqv} a
-    3. handler           : a -> Request {#oup50kgmqv} a -> a
-    4. Abort.toDefault!  : a -> '{g, #oup50kgmqv} a ->{g} a
-    5. Abort.toOptional  : '{g, #oup50kgmqv} a
+    2. base.Abort.abort  : {#b589mbg492} a
+    3. handler           : a -> Request {#b589mbg492} a -> a
+    4. Abort.toDefault!  : a -> '{g, #b589mbg492} a ->{g} a
+    5. Abort.toOptional  : '{g, #b589mbg492} a
                          -> '{g} Optional a
-    6. Abort.toOptional! : '{g, #oup50kgmqv} a ->{g} Optional a
+    6. Abort.toOptional! : '{g, #b589mbg492} a ->{g} Optional a
     7. x                 : 'Optional Nat
     8. |>                : a -> (a ->{e} b) ->{e} b
 
@@ -662,7 +662,7 @@ r = 'let
   ☝️
   
   I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
+  /Users/pchiusano/unison/scratch.u
   
     r : 'Nat
     r = 'let
@@ -725,7 +725,7 @@ x = 2
   ☝️
   
   I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
+  /Users/pchiusano/unison/scratch.u
   
     docTest2 : Doc2
     docTest2 =
@@ -785,7 +785,7 @@ broken =
   ☝️
   
   I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
+  /Users/pchiusano/unison/scratch.u
   
     broken : Nat
     broken =
@@ -842,7 +842,7 @@ broken tvar =
   ☝️
   
   I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
+  /Users/pchiusano/unison/scratch.u
   
     broken : tvar -> () -> ()
     broken tvar =
@@ -899,7 +899,7 @@ broken = cases
   ☝️
   
   I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
+  /Users/pchiusano/unison/scratch.u
   
     broken : Optional Nat -> ()
     broken = cases
@@ -960,7 +960,7 @@ foo = let
   ☝️
   
   I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
+  /Users/pchiusano/unison/scratch.u
   
     structural type SomethingUnusuallyLong
       = SomethingUnusuallyLong Text Text Text
@@ -988,7 +988,7 @@ foo = let
     2. SomethingUnusuallyLong.SomethingUnusuallyLong : Text
                                                      -> Text
                                                      -> Text
-                                                     -> #l6si6n2hsl
+                                                     -> #p9dp5r8ff6
     3. foo                                           : 'Nat
 
 ```
@@ -1031,7 +1031,7 @@ foo = let
   ☝️
   
   I added these definitions to the top of
-  /Users/runar/work/unison/unison-src/transcripts-round-trip/nested.u
+  /Users/pchiusano/unison/unison-src/transcripts-round-trip/nested.u
   
     nested : Doc2
     nested =
@@ -1063,5 +1063,277 @@ foo = let
     ⍟ These new definitions are ok to `add`:
     
       nested : Doc2
+
+```
+## Multiline expressions in multiliine lists
+
+```unison
+foo a b c d e f g h i j = 42 
+
+use Nat +
+x = [ 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
+    , foo 12939233 2102020 329292 429292 522020 62929292 72020202 820202 920202 1020202 ] 
+```
+
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    foo : a -> b -> c -> d -> e -> f -> g -> h -> i -> j -> Nat
+    x   : [Nat]
+
+.> edit foo x
+
+  ☝️
+  
+  I added these definitions to the top of
+  /Users/pchiusano/unison/scratch.u
+  
+    foo : a -> b -> c -> d -> e -> f -> g -> h -> i -> j -> Nat
+    foo a b c d e f g h i j = 42
+    
+    x : [Nat]
+    x =
+      use Nat +
+      [ 1
+          + 1
+          + 1
+          + 1
+          + 1
+          + 1
+          + 1
+          + 1
+          + 1
+          + 1
+          + 1
+          + 1
+          + 1
+          + 1
+          + 1
+          + 1
+          + 1
+          + 1
+          + 1,
+        foo
+          12939233
+          2102020
+          329292
+          429292
+          522020
+          62929292
+          72020202
+          820202
+          920202
+          1020202 ]
+  
+  You can edit them there, then do `update` to replace the
+  definitions currently in this namespace.
+
+.> undo
+
+  Here are the changes I undid
+  
+  Added definitions:
+  
+    1. foo : a
+           -> b
+           -> c
+           -> d
+           -> e
+           -> f
+           -> g
+           -> h
+           -> i
+           -> j
+           -> Nat
+    2. x   : [Nat]
+
+```
+```ucm
+.> load scratch.u
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      foo : a
+            -> b
+            -> c
+            -> d
+            -> e
+            -> f
+            -> g
+            -> h
+            -> i
+            -> j
+            -> Nat
+      x   : [Nat]
+
+```
+## Delayed computations passed to a function as the last argument
+
+When a delayed computation block is passed to a function as the last argument
+in a context where the ambient precedence is low enough, we can elide parentheses 
+around it and use a "soft hang" to put the `'let` on the same line as the function call. 
+This looks nice.
+
+    forkAt usEast 'let
+      x = thing1
+      y = thing2
+      ...
+
+vs the not as pretty but still correct:
+
+    forkAt 
+      usEast 
+      ('let 
+          x = thing1
+          y = thing2
+          ...)
+
+Okay, here's the test, showing that we use the prettier version when possible:
+
+```unison
+(+) a b = ##Nat.+ a b
+
+foo a b = 42 
+
+bar0 x = 'let
+  a = 1
+  b = 2
+  foo a 'let
+    c = 3
+    a + b
+
+bar1 x = 'let
+  a = 1
+  b = 2
+  foo (100 + 200 + 300 + 400 + 500 + 600 + 700 + 800 + 900 + 1000 + 1100 + 1200 + 1300 + 1400 + 1500) 'let
+    c = 3
+    a + b
+
+bar2 x = 'let
+  a = 1
+  b = 2
+  1 + foo a 'let
+    c = 3
+    a + b
+
+bar3 x = 'let
+  a = 1
+  b = 2
+  c = foo 'let
+    c = 3
+    a + b
+  c
+```
+
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    +    : Nat -> Nat -> Nat
+    bar0 : x -> () -> Nat
+    bar1 : x -> () -> Nat
+    bar2 : x -> () -> Nat
+    bar3 : x -> () -> b -> Nat
+    foo  : a -> b -> Nat
+
+.> edit foo bar0 bar1 bar2 bar3
+
+  ☝️
+  
+  I added these definitions to the top of
+  /Users/pchiusano/unison/scratch.u
+  
+    bar0 : x -> () -> Nat
+    bar0 x = 'let
+      a = 1
+      b = 2
+      foo a 'let
+        c = 3
+        a + b
+    
+    bar1 : x -> () -> Nat
+    bar1 x =
+      'let
+        a = 1
+        b = 2
+        foo
+          (100
+            + 200
+            + 300
+            + 400
+            + 500
+            + 600
+            + 700
+            + 800
+            + 900
+            + 1000
+            + 1100
+            + 1200
+            + 1300
+            + 1400
+            + 1500)
+          'let
+            c = 3
+            a + b
+    
+    bar2 : x -> () -> Nat
+    bar2 x = 'let
+      a = 1
+      b = 2
+      1 + (foo a 'let
+        c = 3
+        a + b)
+    
+    bar3 : x -> () -> b -> Nat
+    bar3 x = 'let
+      a = 1
+      b = 2
+      c =
+        foo 'let
+          c = 3
+          a + b
+      c
+    
+    foo : a -> b -> Nat
+    foo a b = 42
+  
+  You can edit them there, then do `update` to replace the
+  definitions currently in this namespace.
+
+.> undo
+
+  Here are the changes I undid
+  
+  Added definitions:
+  
+    1. +    : Nat -> Nat -> Nat
+    2. bar0 : x -> () -> Nat
+    3. bar1 : x -> () -> Nat
+    4. bar2 : x -> () -> Nat
+    5. bar3 : x -> () -> b -> Nat
+    6. foo  : a -> b -> Nat
+
+```
+```ucm
+.> load scratch.u
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bar0 : x -> 'Nat
+      bar1 : x -> 'Nat
+      bar2 : x -> 'Nat
+      bar3 : x -> '(b -> Nat)
+      foo  : a -> b -> Nat
 
 ```


### PR DESCRIPTION
This has been bugging me for a while. 

When a delayed computation block is passed to a function as the last argument in a context where the ambient precedence is low enough, we can elide parentheses around it and use a "soft hang" to put the `'let` on the same line as the function call. This looks nice and is typically how you'd write the code in your scratch file. **So now the pretty-printer will produce code like:**

```Haskell
forkAt usEast 'let
  x = thing1
  y = thing2
  ...
```

instead of the ugly but effective current rendering. 👎 (😢 🎺 sad trombone)

```Haskell
forkAt 
  usEast 
  ('let
    x = thing1
    y = thing2
    ...)
```

I added this as a round trip test along with a few corner cases. It looks super!

Note: @runarorama you added softhangs when a delayed block is the RHS of a binding (like `x = 'let`) and this is applying the same sort of strategy to a different spot in the pretty-printer.

This will probably need a refresh after #2958 if that gets merged first.