### PR TITLE
let mergify wait for windows build

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,6 +5,7 @@ pull_request_rules:
       # - status-success=ubuntu-18.04
       - status-success=macOS-11.0
       - status-success=macOS-10.15
+      - status-success=windows-2019
       - label=ready-to-merge
       - "#approved-reviews-by>=1"
     actions:


### PR DESCRIPTION
Closes #2961, hopefully.

We can also have a discussion about when to drop macOS 10.15 builds from CI and Mergify. We currently do CI and Mergify checks with macOS 10.15 and macOS 11, and new machines are shipping with macOS 12, I think. Currently our release build is macOS 10.15, though. I don't think it deserves a ticket of its own yet, though.