### PR TITLE
Re-arrange Migrations module to support multiple migrations.

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Init/OpenCodebaseError.hs
+++ b/parser-typechecker/src/Unison/Codebase/Init/OpenCodebaseError.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveAnyClass #-}
+
 -- | Open codebase error type.
 module Unison.Codebase.Init.OpenCodebaseError
   ( OpenCodebaseError (..),
@@ -13,3 +15,4 @@ data OpenCodebaseError
   | -- | The codebase exists, but its schema version is unknown to this application.
     OpenCodebaseUnknownSchemaVersion Word64
   deriving stock (Show)
+  deriving anyclass (Exception)

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
@@ -45,10 +45,9 @@ ensureCodebaseIsUpToDate localOrRemote root conn codebase = UnliftIO.try do
   let migrationsToRun =
         Map.filterWithKey (\v _ -> v > schemaVersion) migrations
   when (localOrRemote == Local && (not . null) migrationsToRun) $ backupCodebase root
-  for_ (Map.toAscList migrationsToRun) $ \(SchemaVersion v, migration) ->
-    flip runReaderT conn . Q.withSavepoint ("MIGRATE_TO_VERSION_" <> show v) $ \_rollback -> do
-      liftIO . putStrLn $ "Migrating codebase to version " <> show v <> "..."
-      lift $ migration conn codebase
+  for_ (Map.toAscList migrationsToRun) $ \(SchemaVersion v, migration) -> do
+    liftIO . putStrLn $ "Migrating codebase to version " <> show v <> "..."
+    migration conn codebase
 
 -- | Copy the sqlite database to a new file with a unique name based on current time.
 backupCodebase :: CodebasePath -> MonadIO m => m ()

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
@@ -1,0 +1,61 @@
+module Unison.Codebase.SqliteCodebase.Migrations where
+
+import Control.Monad.Reader
+import qualified Data.Map as Map
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import System.Directory (copyFile)
+import System.FilePath ((</>))
+import U.Codebase.Sqlite.Connection (Connection)
+import U.Codebase.Sqlite.DbId (SchemaVersion (..))
+import qualified U.Codebase.Sqlite.Queries as Q
+import Unison.Codebase (CodebasePath)
+import Unison.Codebase.Init.OpenCodebaseError (OpenCodebaseError (OpenCodebaseUnknownSchemaVersion))
+import qualified Unison.Codebase.Init.OpenCodebaseError as Codebase
+import Unison.Codebase.SqliteCodebase.Migrations.MigrateSchema1To2 (migrateSchema1To2)
+import Unison.Codebase.SqliteCodebase.Paths
+import Unison.Codebase.Type (Codebase, LocalOrRemote (..))
+import Unison.Prelude
+import Unison.Symbol (Symbol)
+import Unison.Var (Var)
+import UnliftIO (MonadUnliftIO)
+import qualified UnliftIO
+
+type Migration m a v = Connection -> Codebase m v a -> m ()
+
+-- | The highest schema that this ucm knows how to migrate to.
+currentSchemaVersion :: SchemaVersion
+currentSchemaVersion = fst . head $ Map.toDescList (migrations @IO @Symbol @())
+
+-- | Mapping from schema version to the migration required to get there.
+-- Each migration may only be run on a schema of its immediate predecessor,
+-- E.g. The migration at index 2 must be run on a codebase at version 1.
+migrations :: forall m v a. (MonadUnliftIO m, Var v) => Map SchemaVersion (Migration m a v)
+migrations =
+  Map.fromList
+    [ (2, migrateSchema1To2)
+    ]
+
+-- | Migrates a codebase up to the most recent version known to ucm.
+-- This is a No-op if it's up to date
+-- Returns an error if the schema version is newer than this ucm knows about.
+ensureCodebaseIsUpToDate :: (MonadUnliftIO m, Var v) => LocalOrRemote -> CodebasePath -> Connection -> Codebase m v a -> m (Either Codebase.OpenCodebaseError ())
+ensureCodebaseIsUpToDate localOrRemote root conn codebase = UnliftIO.try do
+  schemaVersion <- runReaderT Q.schemaVersion conn
+  when (schemaVersion > currentSchemaVersion) $ UnliftIO.throwIO $ OpenCodebaseUnknownSchemaVersion (fromIntegral schemaVersion)
+  let migrationsToRun =
+        Map.filterWithKey (\v _ -> v > schemaVersion) migrations
+  when (localOrRemote == Local && (not . null) migrationsToRun) $ backupCodebase root
+  for_ (Map.toAscList migrationsToRun) $ \(SchemaVersion v, migration) -> do
+    liftIO . putStrLn $ "Migrating codebase to version " <> show v <> "..."
+    migration conn codebase
+
+-- | Copy the sqlite database to a new file with a unique name based on current time.
+backupCodebase :: CodebasePath -> MonadIO m => m ()
+backupCodebase root =
+  liftIO do
+    backupPath <- backupCodebasePath <$> getPOSIXTime
+    copyFile (root </> codebasePath) (root </> backupPath)
+    putStrLn ("📋 I backed up your codebase to " ++ (root </> backupPath))
+    putStrLn "⚠️  Please close all other ucm processes and wait for the migration to complete before interacting with your codebase."
+    putStrLn "Press <enter> to start the migration once all other ucm processes are shutdown..."
+    void $ liftIO getLine

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
@@ -45,9 +45,10 @@ ensureCodebaseIsUpToDate localOrRemote root conn codebase = UnliftIO.try do
   let migrationsToRun =
         Map.filterWithKey (\v _ -> v > schemaVersion) migrations
   when (localOrRemote == Local && (not . null) migrationsToRun) $ backupCodebase root
-  for_ (Map.toAscList migrationsToRun) $ \(SchemaVersion v, migration) -> do
-    liftIO . putStrLn $ "Migrating codebase to version " <> show v <> "..."
-    migration conn codebase
+  for_ (Map.toAscList migrationsToRun) $ \(SchemaVersion v, migration) ->
+    flip runReaderT conn . Q.withSavepoint ("MIGRATE_TO_VERSION_" <> show v) $ \_rollback -> do
+      liftIO . putStrLn $ "Migrating codebase to version " <> show v <> "..."
+      lift $ migration conn codebase
 
 -- | Copy the sqlite database to a new file with a unique name based on current time.
 backupCodebase :: CodebasePath -> MonadIO m => m ()

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema1To2.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema1To2.hs
@@ -5,8 +5,8 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ViewPatterns #-}
 
-module Unison.Codebase.SqliteCodebase.MigrateSchema12
-  ( migrateSchema12,
+module Unison.Codebase.SqliteCodebase.Migrations.MigrateSchema1To2
+  ( migrateSchema1To2,
   )
 where
 
@@ -58,7 +58,7 @@ import U.Util.Monoid (foldMapM)
 import qualified Unison.ABT as ABT
 import qualified Unison.Codebase as Codebase
 import qualified Unison.Codebase.SqliteCodebase.Conversions as Cv
-import qualified Unison.Codebase.SqliteCodebase.MigrateSchema12.DbHelpers as Hashing
+import qualified Unison.Codebase.SqliteCodebase.Migrations.MigrateSchema1To2.DbHelpers as Hashing
 import Unison.Codebase.Type (Codebase (Codebase))
 import qualified Unison.ConstructorReference as ConstructorReference
 import qualified Unison.DataDeclaration as DD
@@ -99,10 +99,10 @@ import UnliftIO.Exception (bracket_, onException)
 --          * [x] I guess move Hashable to V2.Hashing pseudo-package
 --          * [x] Delete V1 Hashing to ensure it's unused
 --          * [x] Salt V2 hashes with version number
---    * [ ] confirm that pulls are handled ok
+--    * [x] confirm that pulls are handled ok
 --    * [x] Make a backup of the v1 codebase before migrating, in a temp directory.
 --          Include a message explaining where we put it.
---    * [ ] Improved error message (don't crash) if loading a codebase newer than your ucm
+--    * [x] Improved error message (don't crash) if loading a codebase newer than your ucm
 --    * [x] Update the schema version in the database after migrating so we only migrate
 --    once.
 
@@ -111,8 +111,8 @@ verboseOutput =
   isJust (unsafePerformIO (lookupEnv "UNISON_MIGRATION_DEBUG"))
 {-# NOINLINE verboseOutput #-}
 
-migrateSchema12 :: forall a m v. (MonadUnliftIO m, Var v) => Connection -> Codebase m v a -> m ()
-migrateSchema12 conn codebase = do
+migrateSchema1To2 :: forall a m v. (MonadUnliftIO m, Var v) => Connection -> Codebase m v a -> m ()
+migrateSchema1To2 conn codebase = do
   withinSavepoint "MIGRATESCHEMA12" $ do
     liftIO $ putStrLn $ "Starting codebase migration. This may take a while, it's a good time to make some tea ☕️"
     corruptedCausals <- runDB conn (liftQ Q.getCausalsWithoutBranchObjects)

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema1To2/DbHelpers.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema1To2/DbHelpers.hs
@@ -1,4 +1,4 @@
-module Unison.Codebase.SqliteCodebase.MigrateSchema12.DbHelpers
+module Unison.Codebase.SqliteCodebase.Migrations.MigrateSchema1To2.DbHelpers
   ( dbBranchHash,
     dbPatchHash,
   )

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Paths.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Paths.hs
@@ -1,0 +1,28 @@
+module Unison.Codebase.SqliteCodebase.Paths
+  ( codebasePath,
+    makeCodebasePath,
+    makeCodebaseDirPath,
+    backupCodebasePath,
+  )
+where
+
+import Data.Time (NominalDiffTime)
+import System.FilePath ((</>))
+import Unison.Codebase (CodebasePath)
+
+-- | Prefer makeCodebasePath or makeCodebaseDirPath when possible.
+codebasePath :: FilePath
+codebasePath = ".unison" </> "v2" </> "unison.sqlite3"
+
+-- | Makes a path to a sqlite database from a codebase path.
+makeCodebasePath :: CodebasePath -> FilePath
+makeCodebasePath root = makeCodebaseDirPath root </> "unison.sqlite3"
+
+-- | Makes a path to the location where sqlite files are stored within a codebase path.
+makeCodebaseDirPath :: CodebasePath -> FilePath
+makeCodebaseDirPath root = root </> ".unison" </> "v2"
+
+-- | Makes a path to store a backup of a sqlite database given the current time.
+backupCodebasePath :: NominalDiffTime -> FilePath
+backupCodebasePath now =
+  codebasePath ++ "." ++ show @Int (floor now)

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -9,6 +9,7 @@ module Unison.Codebase.Type
     GitError (..),
     GetRootBranchError (..),
     SyncToDir,
+    LocalOrRemote(..),
     gitErrorFromOpenCodebaseError,
   )
 where
@@ -159,6 +160,13 @@ data Codebase m v a = Codebase
     --  Use `Codebase.before` which wraps this in a nice API.
     beforeImpl :: Maybe (Branch.Hash -> Branch.Hash -> m Bool)
   }
+
+-- | Whether a codebase is local or remote.
+data LocalOrRemote
+  = Local
+  | Remote
+  deriving (Show, Eq, Ord)
+
 
 data PushGitBranchOpts = PushGitBranchOpts
   { -- | Set the branch as root?

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -65,8 +65,10 @@ library
       Unison.Codebase.SqliteCodebase.Branch.Dependencies
       Unison.Codebase.SqliteCodebase.Conversions
       Unison.Codebase.SqliteCodebase.GitError
-      Unison.Codebase.SqliteCodebase.MigrateSchema12
-      Unison.Codebase.SqliteCodebase.MigrateSchema12.DbHelpers
+      Unison.Codebase.SqliteCodebase.Migrations
+      Unison.Codebase.SqliteCodebase.Migrations.MigrateSchema1To2
+      Unison.Codebase.SqliteCodebase.Migrations.MigrateSchema1To2.DbHelpers
+      Unison.Codebase.SqliteCodebase.Paths
       Unison.Codebase.SqliteCodebase.SyncEphemeral
       Unison.Codebase.SyncMode
       Unison.Codebase.TermEdit


### PR DESCRIPTION
## Overview

On trunk we've hard-coded the migration from 1 -> 2, but this doesn't scale well to multiple migrations.
As part of #2962  I'll need to add another migration and I think it makes sense to have a module which makes it easy to add new migrations and ensure that all necessary migrations will be run in the correct order regardless which codebase you open.

## Implementation notes

* Moves backup and migration code from `SqliteCodebase.hs` into `Migrations.hs`
* Adds a `migrations` map where we can add new migrations and they'll be handled properly for us.
* Moves `MigrateSchema12.hs` into `Migrations.MigrateSchema1To2`