### PR TITLE
Rename compile.output to compile

### DIFF
--- a/unison-cli/integration-tests/IntegrationTests/transcript.md
+++ b/unison-cli/integration-tests/IntegrationTests/transcript.md
@@ -20,5 +20,5 @@ main = '(printLine "Hello, world!")
 
 ```ucm
 .> add
-.> compile.output main ./unison-cli/integration-tests/IntegrationTests/main
+.> compile main ./unison-cli/integration-tests/IntegrationTests/main
 ```

--- a/unison-cli/integration-tests/IntegrationTests/transcript.output.md
+++ b/unison-cli/integration-tests/IntegrationTests/transcript.output.md
@@ -25,6 +25,6 @@ main = '(printLine "Hello, world!")
   
     main : '{IO, Exception} ()
 
-.> compile.output main ./unison-cli/integration-tests/IntegrationTests/main
+.> compile main ./unison-cli/integration-tests/IntegrationTests/main
 
 ```

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -394,7 +394,7 @@ loop = do
             MergeBuiltinsI -> "builtins.merge"
             MergeIOBuiltinsI -> "builtins.mergeio"
             MakeStandaloneI out nm ->
-              "compile.output " <> Text.pack out <> " " <> HQ.toText nm
+              "compile " <> Text.pack out <> " " <> HQ.toText nm
             PullRemoteBranchI orepo dest _syncMode pullMode _ ->
               (Text.pack . InputPattern.patternName $
                 case pullMode of

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1797,7 +1797,7 @@ makeStandalone :: InputPattern
 makeStandalone =
   InputPattern
     "compile"
-    []
+    ["compile.output"]
     [(Required, exactDefinitionTermQueryArg), (Required, noCompletions)]
     ( P.wrapColumn2
         [ ( "`compile main file`",

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1796,11 +1796,11 @@ ioTest =
 makeStandalone :: InputPattern
 makeStandalone =
   InputPattern
-    "compile.output"
+    "compile"
     []
     [(Required, exactDefinitionTermQueryArg), (Required, noCompletions)]
     ( P.wrapColumn2
-        [ ( "`compile.output main file`",
+        [ ( "`compile main file`",
             "Outputs a stand alone file that can be directly loaded and"
               <> "executed by unison. Said execution will have the effect of"
               <> "running `!main`."

--- a/unison-cli/unison/Main.hs
+++ b/unison-cli/unison/Main.hs
@@ -176,7 +176,7 @@ main = withCP65001 do
                  <> "you can do:"
              , ""
              , P.indentN 4
-               $ ".> compile.output "
+               $ ".> compile "
                  <> P.text rf <> " " <> P.string ifile
              , ""
              , P.wrap "to produce a new compiled program \


### PR DESCRIPTION
As [suggested](https://github.com/unisonweb/unison/pull/2959#issuecomment-1057059547) by @pchiusano.

There was another suggestion to filter to only terms that match subtypes
of `{Exception, IO} ()`. So far I haven't done that, because I'm not
very familiar with these types and am having trouble figuring out how to
get type information out of relations and referents.