### PR TITLE
Vacuum once after all migrations have been completed.

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
@@ -52,6 +52,9 @@ ensureCodebaseIsUpToDate localOrRemote root conn codebase = UnliftIO.try do
     liftIO . putStrLn $ "🔨 Migrating codebase to version " <> show v <> "..."
     migration conn codebase
   when ((not . null) migrationsToRun) $ do
+    -- Vacuum once now that any migrations have taken place.
+    liftIO $ putStrLn $ "Cleaning up..."
+    liftIO . flip runReaderT conn $ Q.vacuum
     liftIO . putStrLn $ "🏁 Migration complete. 🏁"
 
 -- | Copy the sqlite database to a new file with a unique name based on current time.

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema1To2.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema1To2.hs
@@ -149,8 +149,6 @@ migrateSchema1To2 conn codebase = do
     runDB conn (liftQ Q.garbageCollectWatchesWithoutObjects)
     liftIO $ putStrLn $ "Updating Schema Version..."
     runDB conn . liftQ $ Q.setSchemaVersion 2
-  liftIO $ putStrLn $ "Cleaning up..."
-  runDB conn (liftQ Q.vacuum)
   pure $ Right ()
   where
     withinSavepoint :: (String -> m c -> m c)


### PR DESCRIPTION
## Overview

Migrations often affect the database's contents, and both of our current migrations would benefit from a VACUUM afterwards, however vacuuming after every migration is just a waste of time when we could vacuum a single time after all migrations, so I just moved a single vacuum up to the top level.

## Implementation notes

Run a single VACUUM after all migrations take place (but only if at least one migration was run)

## Testing

- [x] test to ensure this works on codebases which require migrations.