### PR TITLE
add transcript demonstrating an update bug

### DIFF
--- a/unison-src/transcripts-using-base/update-test-to-non-test.md
+++ b/unison-src/transcripts-using-base/update-test-to-non-test.md
@@ -1,4 +1,4 @@
-When updating a term from a test to a non-test, we don't delete its metadata that indicates it's a test.
+When updating a term from a test to a non-test, we don't delete its metadata that indicates it's a test. This is a bug.
 
 ```unison
 test> foo = []

--- a/unison-src/transcripts-using-base/update-test-to-non-test.md
+++ b/unison-src/transcripts-using-base/update-test-to-non-test.md
@@ -1,0 +1,18 @@
+When updating a term from a test to a non-test, we don't delete its metadata that indicates it's a test.
+
+```unison
+test> foo = []
+```
+
+```ucm
+.> add
+```
+
+```unison
+foo = 1
+```
+
+```ucm
+.> update
+.> links foo
+```

--- a/unison-src/transcripts-using-base/update-test-to-non-test.output.md
+++ b/unison-src/transcripts-using-base/update-test-to-non-test.output.md
@@ -1,0 +1,62 @@
+When updating a term from a test to a non-test, we don't delete its metadata that indicates it's a test.
+
+```unison
+test> foo = []
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      foo : [Result]
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    1 | test> foo = []
+    
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    foo : [Result]
+
+```
+```unison
+foo = 1
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      foo : Nat
+
+```
+```ucm
+.> update
+
+  ⍟ I've updated these names to your new definition:
+  
+    foo : Nat
+
+.> links foo
+
+  1. builtin.metadata.isTest : IsTest
+  
+  Tip: Try using `display 1` to display the first result or
+       `view 1` to view its source.
+
+```

--- a/unison-src/transcripts-using-base/update-test-to-non-test.output.md
+++ b/unison-src/transcripts-using-base/update-test-to-non-test.output.md
@@ -1,4 +1,4 @@
-When updating a term from a test to a non-test, we don't delete its metadata that indicates it's a test.
+When updating a term from a test to a non-test, we don't delete its metadata that indicates it's a test. This is a bug.
 
 ```unison
 test> foo = []


### PR DESCRIPTION
## Overview

This PR adds a transcript that demonstrates when we update a term from a test to a non-test, we retain its `isTest` metadata.

This will be fixed by the work in #2649 / #2794 
