### PR TITLE
Disable windows release until we can fix it properly.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     needs:
       - build_linux
       - build_macos
-      - build_windows
+      # - build_windows
 
     steps:
       - uses: actions/checkout@v2
@@ -101,32 +101,29 @@ jobs:
           name: build-macos
           path: ucm-macos.tar.gz
 
-  build_windows:
-    name: "build_windows"
-    runs-on: windows-2019
+  # build_windows:
+  #   name: "build_windows"
+  #   runs-on: windows-2019
 
-    steps:
-      - uses: actions/checkout@v2
-      - name: install stack
-        run: |
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.5.1/stack-2.5.1-osx-x86_64.tar.gz | tar -xz
-          echo "$HOME/stack-2.5.1-osx-x86_64/" >> $GITHUB_PATH
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: build
+  #       run: stack --no-terminal build --flag unison-parser-typechecker:optimized
 
-      - name: build
-        run: stack --no-terminal build --flag unison-parser-typechecker:optimized
+  #     - name: fetch latest codebase-ui and package with ucm
+  #       # Powershell
+  #       run: |
+  #         mkdir -p tmp\ui
+  #         mkdir -p release\ui
+  #         $UCM = stack exec -- where unison
+  #         cp $UCM .\release\ucm.exe
+  #         Invoke-WebRequest -Uri https://github.com/unisonweb/codebase-ui/releases/download/latest/unisonLocal.zip -OutFile tmp\unisonLocal.zip
+  #         Expand-Archive -Path tmp\unisonLocal.zip -DestinationPath release\ui
+  #         Compress-Archive -Path .\release\* -DestinationPath ucm-windows.zip
 
-      - name: fetch latest codebase-ui and package with ucm
-        run: |
-          mkdir -p /tmp/ucm/ui
-          UCM=$(stack path | awk '/local-install-root/{print $2}')/bin/unison
-          cp $UCM /tmp/ucm/ucm
-          wget -O/tmp/unisonLocal.zip https://github.com/unisonweb/codebase-ui/releases/download/latest/unisonLocal.zip
-          unzip -d /tmp/ucm/ui /tmp/unisonLocal.zip
-          tar -c -z -f ucm-windows.tar.gz -C /tmp/ucm .
-
-      - name: Upload windows artifact
-        uses: actions/upload-artifact@v2
-        with:
-          if-no-files-found: error
-          name: build-windows
-          path: ucm-windows.tar.gz
+  #     - name: Upload windows artifact
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         if-no-files-found: error
+  #         name: build-windows
+  #         path: ucm-windows.zip


### PR DESCRIPTION
Fixing the release build may or may not take a while; even testing a build usually takes an hour and I'd rather not delay the release artificially just for that; I have a windows build I can upload manually for now and we'll get the proper release automation fixed ASAP so we can use it next time 👍🏼 