### PR TITLE
stack.yaml: update to final lts-18.28 snapshot

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,7 +100,21 @@ jobs:
       # Build deps, then build local code. Splitting it into two steps just allows us to see how much time each step
       # takes.
       - name: build dependencies
-        run: stack --no-terminal build --fast --only-dependencies
+        # Run up to 5 times in a row before giving up.
+        # It's very unlikely that our build-dependencies step will fail on most builds,
+        # so if it fails its almost certainly due to a race condition on the Windows
+        # file-system API that stack runs into. Since any successful packages are
+        # cached within a single build, it should get further along on each re-start
+        # and should hopefully finish!
+        run: |
+          tries=1
+          if [[ ${{matrix.os}} = "windows-"* ]]; then
+            tries=5
+          fi
+
+          for (( i = 0; i < $tries; i++ )); do
+              stack --no-terminal build --fast --only-dependencies && break;
+          done
       - name: build
         run: stack --no-terminal build --fast --no-run-tests --test
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,6 +100,7 @@ jobs:
       # Build deps, then build local code. Splitting it into two steps just allows us to see how much time each step
       # takes.
       - name: build dependencies
+        shell: bash
         # Run up to 5 times in a row before giving up.
         # It's very unlikely that our build-dependencies step will fail on most builds,
         # so if it fails its almost certainly due to a race condition on the Windows

--- a/stack.yaml
+++ b/stack.yaml
@@ -27,7 +27,7 @@ packages:
 - lib/unison-pretty-printer
 
 #compiler-check: match-exact
-resolver: lts-18.13
+resolver: lts-18.28
 
 extra-deps:
 - github: unisonweb/configurator


### PR DESCRIPTION
lts-18.28 is the last minor release of LTS 18

I tested this successfully building M3 and also current HEAD (863d989).
stack exec tests and stack test also pass.