### PR TITLE
Add ability to hide ucm commands until we're ready to release them.

### DIFF
--- a/unison-cli/src/Unison/CommandLine/InputPattern.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPattern.hs
@@ -23,9 +23,13 @@ data IsOptional
   | OnePlus -- 1 or more, at the end
   deriving (Show, Eq)
 
+data Visibility = Hidden | Visible
+  deriving (Show, Eq, Ord)
+
 data InputPattern = InputPattern
   { patternName :: String,
     aliases :: [String],
+    visibility :: Visibility, -- Allow hiding certain commands when debugging or work-in-progress
     argTypes :: [(IsOptional, ArgumentType)],
     help :: P.Pretty CT.ColorText,
     parse :: [String] -> Either (P.Pretty CT.ColorText) Input

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -87,6 +87,7 @@ mergeBuiltins =
   InputPattern
     "builtins.merge"
     []
+    I.Visible
     []
     "Adds the builtins to `builtins.` in the current namespace (excluding `io` and misc)."
     (const . pure $ Input.MergeBuiltinsI)
@@ -96,6 +97,7 @@ mergeIOBuiltins =
   InputPattern
     "builtins.mergeio"
     []
+    I.Visible
     []
     "Adds all the builtins to `builtins.` in the current namespace, including `io` and misc."
     (const . pure $ Input.MergeIOBuiltinsI)
@@ -105,6 +107,7 @@ updateBuiltins =
   InputPattern
     "builtins.update"
     []
+    I.Visible
     []
     ( "Adds all the builtins that are missing from this namespace, "
         <> "and deprecate the ones that don't exist in this version of Unison."
@@ -116,6 +119,7 @@ todo =
   InputPattern
     "todo"
     []
+    I.Visible
     [(Optional, patchArg), (Optional, namespaceArg)]
     ( P.wrapColumn2
         [ ( makeExample' todo,
@@ -147,6 +151,7 @@ load =
   InputPattern
     "load"
     []
+    I.Visible
     [(Optional, noCompletions)]
     ( P.wrapColumn2
         [ ( makeExample' load,
@@ -168,6 +173,7 @@ add =
   InputPattern
     "add"
     []
+    I.Visible
     [(ZeroPlus, noCompletions)]
     ( "`add` adds to the codebase all the definitions from the most recently "
         <> "typechecked file."
@@ -179,6 +185,7 @@ previewAdd =
   InputPattern
     "add.preview"
     []
+    I.Visible
     [(ZeroPlus, noCompletions)]
     ( "`add.preview` previews additions to the codebase from the most recently "
         <> "typechecked file. This command only displays cached typechecking "
@@ -192,6 +199,7 @@ updateNoPatch =
   InputPattern
     "update.nopatch"
     ["un"]
+    I.Visible
     [(ZeroPlus, noCompletions)]
     ( P.wrap
         ( makeExample' updateNoPatch
@@ -225,6 +233,7 @@ update =
   InputPattern
     "update"
     []
+    I.Visible
     [(Optional, patchArg), (ZeroPlus, noCompletions)]
     ( P.wrap
         ( makeExample' update
@@ -268,6 +277,7 @@ previewUpdate =
   InputPattern
     "update.preview"
     []
+    I.Visible
     [(ZeroPlus, noCompletions)]
     ( "`update.preview` previews updates to the codebase from the most "
         <> "recently typechecked file. This command only displays cached "
@@ -281,6 +291,7 @@ patch =
   InputPattern
     "patch"
     []
+    I.Visible
     [(Required, patchArg), (Optional, namespaceArg)]
     ( P.wrap $
         makeExample' patch
@@ -307,6 +318,7 @@ view =
   InputPattern
     "view"
     []
+    I.Visible
     [(ZeroPlus, definitionQueryArg)]
     ( P.lines
         [ "`view foo` prints the definition of `foo`.",
@@ -322,6 +334,7 @@ display =
   InputPattern
     "display"
     []
+    I.Visible
     [(ZeroPlus, definitionQueryArg)]
     ( P.lines
         [ "`display foo` prints a rendered version of the term `foo`.",
@@ -336,6 +349,7 @@ displayTo =
   InputPattern
     "display.to"
     []
+    I.Visible
     [(Required, noCompletions), (ZeroPlus, definitionQueryArg)]
     ( P.wrap $
         makeExample displayTo ["<filename>", "foo"]
@@ -352,6 +366,7 @@ docs =
   InputPattern
     "docs"
     []
+    I.Visible
     [(ZeroPlus, definitionQueryArg)]
     ( P.lines
         [ "`docs foo` shows documentation for the definition `foo`.",
@@ -365,6 +380,7 @@ api =
   InputPattern
     "api"
     []
+    I.Visible
     []
     "`api` provides details about the API."
     (const $ pure Input.ApiI)
@@ -374,6 +390,7 @@ ui =
   InputPattern
     "ui"
     []
+    I.Visible
     []
     "`ui` opens the Codebase UI in the default browser."
     (const $ pure Input.UiI)
@@ -383,6 +400,7 @@ undo =
   InputPattern
     "undo"
     []
+    I.Visible
     []
     "`undo` reverts the most recent change to the codebase."
     (const $ pure Input.UndoI)
@@ -392,6 +410,7 @@ viewByPrefix =
   InputPattern
     "view.recursive"
     []
+    I.Visible
     [(OnePlus, definitionQueryArg)]
     "`view.recursive Foo` prints the definitions of `Foo` and `Foo.blah`."
     ( fmap (Input.ShowDefinitionByPrefixI Input.ConsoleLocation)
@@ -403,6 +422,7 @@ find =
   InputPattern
     "find"
     []
+    I.Visible
     [(ZeroPlus, fuzzyDefinitionQueryArg)]
     ( P.wrapColumn2
         [ ("`find`", "lists all definitions in the current namespace."),
@@ -423,6 +443,7 @@ findShallow =
   InputPattern
     "list"
     ["ls", "dir"]
+    I.Visible
     [(Optional, namespaceArg)]
     ( P.wrapColumn2
         [ ("`list`", "lists definitions and namespaces at the current level of the current namespace."),
@@ -443,6 +464,7 @@ findVerbose =
   InputPattern
     "find.verbose"
     ["list.verbose", "ls.verbose"]
+    I.Visible
     [(ZeroPlus, fuzzyDefinitionQueryArg)]
     ( "`find.verbose` searches for definitions like `find`, but includes hashes "
         <> "and aliases in the results."
@@ -454,6 +476,7 @@ findPatch =
   InputPattern
     "find.patch"
     ["list.patch", "ls.patch"]
+    I.Visible
     []
     ( P.wrapColumn2
         [("`find.patch`", "lists all patches in the current namespace.")]
@@ -465,6 +488,7 @@ renameTerm =
   InputPattern
     "move.term"
     ["rename.term"]
+    I.Visible
     [ (Required, exactDefinitionTermQueryArg),
       (Required, newNameArg)
     ]
@@ -485,6 +509,7 @@ renameType =
   InputPattern
     "move.type"
     ["rename.type"]
+    I.Visible
     [ (Required, exactDefinitionTypeQueryArg),
       (Required, newNameArg)
     ]
@@ -505,6 +530,7 @@ delete =
   InputPattern
     "delete"
     []
+    I.Visible
     [(OnePlus, definitionQueryArg)]
     "`delete foo` removes the term or type name `foo` from the namespace."
     ( \case
@@ -522,6 +548,7 @@ deleteTerm =
   InputPattern
     "delete.term"
     []
+    I.Visible
     [(OnePlus, exactDefinitionTermQueryArg)]
     "`delete.term foo` removes the term name `foo` from the namespace."
     ( \case
@@ -539,6 +566,7 @@ deleteType =
   InputPattern
     "delete.type"
     []
+    I.Visible
     [(OnePlus, exactDefinitionTypeQueryArg)]
     "`delete.type foo` removes the type name `foo` from the namespace."
     ( \case
@@ -562,6 +590,7 @@ deleteReplacement isTerm =
   InputPattern
     commandName
     []
+    I.Visible
     [(Required, if isTerm then exactDefinitionTermQueryArg else exactDefinitionTypeQueryArg), (Optional, patchArg)]
     ( P.string $
         commandName
@@ -626,6 +655,7 @@ aliasTerm =
   InputPattern
     "alias.term"
     []
+    I.Visible
     [(Required, exactDefinitionTermQueryArg), (Required, newNameArg)]
     "`alias.term foo bar` introduces `bar` with the same definition as `foo`."
     ( \case
@@ -644,6 +674,7 @@ aliasType =
   InputPattern
     "alias.type"
     []
+    I.Visible
     [(Required, exactDefinitionTypeQueryArg), (Required, newNameArg)]
     "`alias.type Foo Bar` introduces `Bar` with the same definition as `Foo`."
     ( \case
@@ -662,6 +693,7 @@ aliasMany =
   InputPattern
     "alias.many"
     ["copy"]
+    I.Visible
     [(Required, definitionQueryArg), (OnePlus, exactDefinitionOrPathArg)]
     ( P.group . P.lines $
         [ P.wrap $
@@ -685,6 +717,7 @@ up =
   InputPattern
     "up"
     []
+    I.Visible
     []
     (P.wrapColumn2 [(makeExample up [], "move current path up one level")])
     ( \case
@@ -697,6 +730,7 @@ cd =
   InputPattern
     "namespace"
     ["cd", "j"]
+    I.Visible
     [(Required, namespaceArg)]
     ( P.lines
         [ "Moves your perspective to a different namespace.",
@@ -732,6 +766,7 @@ back =
   InputPattern
     "back"
     ["popd"]
+    I.Visible
     []
     ( P.wrapColumn2
         [ ( makeExample back [],
@@ -749,6 +784,7 @@ deleteNamespace =
   InputPattern
     "delete.namespace"
     []
+    I.Visible
     [(Required, namespaceArg)]
     "`delete.namespace <foo>` deletes the namespace `foo`"
     (deleteNamespaceParser (I.help deleteNamespace) Input.Try)
@@ -758,6 +794,7 @@ deleteNamespaceForce =
   InputPattern
     "delete.namespace.force"
     []
+    I.Visible
     [(Required, namespaceArg)]
     ( "`delete.namespace.force <foo>` deletes the namespace `foo`,"
         <> "deletion will proceed even if other code depends on definitions in foo."
@@ -782,6 +819,7 @@ deletePatch =
   InputPattern
     "delete.patch"
     []
+    I.Visible
     [(Required, patchArg)]
     "`delete.patch <foo>` deletes the patch `foo`"
     ( \case
@@ -808,6 +846,7 @@ copyPatch =
   InputPattern
     "copy.patch"
     []
+    I.Visible
     [(Required, patchArg), (Required, newNameArg)]
     "`copy.patch foo bar` copies the patch `foo` to `bar`."
     ( \case
@@ -820,6 +859,7 @@ renamePatch =
   InputPattern
     "move.patch"
     ["rename.patch"]
+    I.Visible
     [(Required, patchArg), (Required, newNameArg)]
     "`move.patch foo bar` renames the patch `foo` to `bar`."
     ( \case
@@ -832,6 +872,7 @@ renameBranch =
   InputPattern
     "move.namespace"
     ["rename.namespace"]
+    I.Visible
     [(Required, namespaceArg), (Required, newNameArg)]
     "`move.namespace foo bar` renames the path `bar` to `foo`."
     ( \case
@@ -850,6 +891,7 @@ history =
   InputPattern
     "history"
     []
+    I.Visible
     [(Optional, namespaceArg)]
     ( P.wrapColumn2
         [ (makeExample history [], "Shows the history of the current path."),
@@ -873,6 +915,7 @@ forkLocal =
   InputPattern
     "fork"
     ["copy.namespace"]
+    I.Visible
     [ (Required, namespaceArg),
       (Required, newNameArg)
     ]
@@ -890,6 +933,7 @@ resetRoot =
   InputPattern
     "reset-root"
     []
+    I.Visible
     [(Required, namespaceArg)]
     ( P.wrapColumn2
         [ ( makeExample resetRoot [".foo"],
@@ -930,6 +974,7 @@ pullImpl name verbosity pullMode addendum = do
       InputPattern
         name
         []
+        I.Visible
         [(Optional, gitUrlArg), (Optional, namespaceArg)]
         ( P.lines
             [ P.wrap
@@ -975,6 +1020,7 @@ pullExhaustive =
   InputPattern
     "debug.pull-exhaustive"
     []
+    I.Visible
     [(Required, gitUrlArg), (Optional, namespaceArg)]
     ( P.lines
         [ P.wrap $
@@ -1003,6 +1049,7 @@ push =
   InputPattern
     "push"
     []
+    I.Visible
     [(Required, gitUrlArg), (Optional, namespaceArg)]
     ( P.lines
         [ P.wrap
@@ -1043,6 +1090,7 @@ pushCreate =
   InputPattern
     "push.create"
     []
+    I.Visible
     [(Required, gitUrlArg), (Optional, namespaceArg)]
     ( P.lines
         [ P.wrap
@@ -1083,6 +1131,7 @@ pushExhaustive =
   InputPattern
     "debug.push-exhaustive"
     []
+    I.Visible
     [(Required, gitUrlArg), (Optional, namespaceArg)]
     ( P.lines
         [ P.wrap $
@@ -1110,6 +1159,7 @@ createPullRequest =
   InputPattern
     "pull-request.create"
     ["pr.create"]
+    I.Visible
     [(Required, gitUrlArg), (Required, gitUrlArg), (Optional, namespaceArg)]
     ( P.group $
         P.lines
@@ -1139,6 +1189,7 @@ loadPullRequest =
   InputPattern
     "pull-request.load"
     ["pr.load"]
+    I.Visible
     [(Required, gitUrlArg), (Required, gitUrlArg), (Optional, namespaceArg)]
     ( P.lines
         [ P.wrap $
@@ -1220,6 +1271,7 @@ squashMerge =
   InputPattern
     "merge.squash"
     ["squash"]
+    I.Visible
     [(Required, namespaceArg), (Required, namespaceArg)]
     ( P.wrap $
         makeExample squashMerge ["src", "dest"]
@@ -1241,6 +1293,7 @@ mergeLocal =
   InputPattern
     "merge"
     []
+    I.Visible
     [ (Required, namespaceArg),
       (Optional, namespaceArg)
     ]
@@ -1265,6 +1318,7 @@ diffNamespace =
   InputPattern
     "diff.namespace"
     []
+    I.Visible
     [(Required, namespaceArg), (Optional, namespaceArg)]
     ( P.column2
         [ ( "`diff.namespace before after`",
@@ -1293,6 +1347,7 @@ previewMergeLocal =
   InputPattern
     "merge.preview"
     []
+    I.Visible
     [(Required, namespaceArg), (Optional, namespaceArg)]
     ( P.column2
         [ ( "`merge.preview src`",
@@ -1327,6 +1382,7 @@ replaceEdit f = self
       InputPattern
         "replace"
         []
+        I.Visible
         [ (Required, definitionQueryArg),
           (Required, definitionQueryArg),
           (Optional, patchArg)
@@ -1360,6 +1416,7 @@ viewReflog =
   InputPattern
     "reflog"
     []
+    I.Visible
     []
     "`reflog` lists the changes that have affected the root namespace"
     ( \case
@@ -1374,6 +1431,7 @@ edit =
   InputPattern
     "edit"
     []
+    I.Visible
     [(OnePlus, definitionQueryArg)]
     ( P.lines
         [ "`edit foo` prepends the definition of `foo` to the top of the most "
@@ -1398,6 +1456,7 @@ helpTopics =
   InputPattern
     "help-topics"
     ["help-topic"]
+    I.Visible
     [(Optional, topicNameArg)]
     ("`help-topics` lists all topics and `help-topics <topic>` shows an explanation of that topic.")
     ( \case
@@ -1542,6 +1601,7 @@ help =
   InputPattern
     "help"
     ["?"]
+    I.Visible
     [(Optional, commandNameArg)]
     "`help` shows general help and `help <cmd>` shows help for one command."
     ( \case
@@ -1550,7 +1610,7 @@ help =
             intercalateMap
               "\n\n"
               showPatternHelp
-              (sortOn I.patternName validInputs)
+              visibleInputs
         [isHelp -> Just msg] -> Left msg
         [cmd] -> case Map.lookup cmd commandsByName of
           Nothing -> Left . warn $ "I don't know of that command. Try `help`."
@@ -1559,9 +1619,10 @@ help =
     )
   where
     commandsByName =
-      Map.fromList
-        [ (n, i) | i <- validInputs, n <- I.patternName i : I.aliases i
-        ]
+      Map.fromList $ do
+        input@I.InputPattern {I.patternName, I.aliases} <- validInputs
+        name <- patternName : aliases
+        pure (name, input)
     isHelp s = Map.lookup s helpTopicsMap
 
 quit :: InputPattern
@@ -1569,6 +1630,7 @@ quit =
   InputPattern
     "quit"
     ["exit", ":q"]
+    I.Visible
     []
     "Exits the Unison command line interface."
     ( \case
@@ -1581,6 +1643,7 @@ viewPatch =
   InputPattern
     "view.patch"
     []
+    I.Visible
     [(Required, patchArg)]
     ( P.wrapColumn2
         [ ( makeExample' viewPatch,
@@ -1604,6 +1667,7 @@ link =
   InputPattern
     "link"
     []
+    I.Visible
     [(Required, definitionQueryArg), (OnePlus, definitionQueryArg)]
     ( fromString $
         concat
@@ -1629,6 +1693,7 @@ links =
   InputPattern
     "links"
     []
+    I.Visible
     [(Required, definitionQueryArg), (Optional, definitionQueryArg)]
     ( P.column2
         [ (makeExample links ["defn"], "shows all outgoing links from `defn`."),
@@ -1650,6 +1715,7 @@ unlink =
   InputPattern
     "unlink"
     ["delete.link"]
+    I.Visible
     [(Required, definitionQueryArg), (OnePlus, definitionQueryArg)]
     ( fromString $
         concat
@@ -1674,6 +1740,7 @@ names =
   InputPattern
     "names"
     []
+    I.Visible
     [(Required, definitionQueryArg)]
     "`names foo` shows the hash and all known names for `foo`."
     ( \case
@@ -1691,6 +1758,7 @@ dependents =
   InputPattern
     "dependents"
     []
+    I.Visible
     []
     "List the named dependents of the specified definition."
     ( \case
@@ -1701,6 +1769,7 @@ dependencies =
   InputPattern
     "dependencies"
     []
+    I.Visible
     []
     "List the dependencies of the specified definition."
     ( \case
@@ -1713,6 +1782,7 @@ namespaceDependencies =
   InputPattern
     "namespace.dependencies"
     []
+    I.Visible
     [(Optional, namespaceArg)]
     "List the external dependencies of the specified namespace."
     ( \case
@@ -1728,6 +1798,7 @@ debugNumberedArgs =
   InputPattern
     "debug.numberedArgs"
     []
+    I.Visible
     []
     "Dump the contents of the numbered args state."
     (const $ Right Input.DebugNumberedArgsI)
@@ -1737,6 +1808,7 @@ debugFileHashes =
   InputPattern
     "debug.file"
     []
+    I.Visible
     []
     "View details about the most recent succesfully typechecked file."
     (const $ Right Input.DebugTypecheckedUnisonFileI)
@@ -1746,6 +1818,7 @@ debugDumpNamespace =
   InputPattern
     "debug.dump-namespace"
     []
+    I.Visible
     [(Required, noCompletions)]
     "Dump the namespace to a text file"
     (const $ Right Input.DebugDumpNamespacesI)
@@ -1755,6 +1828,7 @@ debugDumpNamespaceSimple =
   InputPattern
     "debug.dump-namespace-simple"
     []
+    I.Visible
     [(Required, noCompletions)]
     "Dump the namespace to a text file"
     (const $ Right Input.DebugDumpNamespaceSimpleI)
@@ -1764,6 +1838,7 @@ debugClearWatchCache =
   InputPattern
     "debug.clear-cache"
     []
+    I.Visible
     [(Required, noCompletions)]
     "Clear the watch expression cache"
     (const $ Right Input.DebugClearWatchI)
@@ -1773,6 +1848,7 @@ test =
   InputPattern
     "test"
     []
+    I.Visible
     []
     "`test` runs unit tests for the current branch."
     (const $ pure $ Input.TestI True True)
@@ -1782,6 +1858,7 @@ docsToHtml =
   InputPattern
     "docs.to-html"
     []
+    I.Visible
     []
     ( P.wrapColumn2
         [ ( "`docs.to-html .path.to.namespace ~/path/to/file/output`",
@@ -1802,6 +1879,7 @@ execute =
   InputPattern
     "run"
     []
+    I.Visible
     [(Required, exactDefinitionTermQueryArg), (ZeroPlus, noCompletions)]
     ( P.wrapColumn2
         [ ( "`run mymain args...`",
@@ -1823,6 +1901,7 @@ ioTest =
   InputPattern
     "io.test"
     []
+    I.Visible
     []
     ( P.wrapColumn2
         [ ( "`io.test mytest`",
@@ -1841,6 +1920,7 @@ makeStandalone =
   InputPattern
     "compile"
     ["compile.output"]
+    I.Visible
     [(Required, exactDefinitionTermQueryArg), (Required, noCompletions)]
     ( P.wrapColumn2
         [ ( "`compile main file`",
@@ -1861,6 +1941,7 @@ createAuthor =
   InputPattern
     "create.author"
     []
+    I.Visible
     [(Required, noCompletions), (Required, noCompletions)]
     ( makeExample createAuthor ["alicecoder", "\"Alice McGee\""]
         <> "creates"
@@ -1888,6 +1969,7 @@ gist =
   InputPattern
     "push.gist"
     ["gist"]
+    I.Visible
     [(Required, gitUrlArg)]
     ( P.lines
         [ "Publish the current namespace.",
@@ -1908,93 +1990,98 @@ gist =
 
 validInputs :: [InputPattern]
 validInputs =
-  [ help,
-    helpTopics,
-    load,
-    add,
-    previewAdd,
-    update,
-    previewUpdate,
-    updateNoPatch,
-    delete,
-    forkLocal,
-    mergeLocal,
-    squashMerge,
-    previewMergeLocal,
-    diffNamespace,
-    names,
-    push,
-    pushCreate,
-    pull,
-    pullWithoutHistory,
-    pullSilent,
-    pushExhaustive,
-    pullExhaustive,
-    createPullRequest,
-    loadPullRequest,
-    cd,
-    up,
-    back,
-    deleteNamespace,
-    deleteNamespaceForce,
-    renameBranch,
-    deletePatch,
-    renamePatch,
-    copyPatch,
-    find,
-    findShallow,
-    findVerbose,
-    view,
-    display,
-    displayTo,
-    api,
-    ui,
-    docs,
-    docsToHtml,
-    findPatch,
-    viewPatch,
-    undo,
-    history,
-    edit,
-    renameTerm,
-    deleteTerm,
-    aliasTerm,
-    renameType,
-    deleteType,
-    aliasType,
-    aliasMany,
-    todo,
-    patch,
-    link,
-    unlink,
-    links,
-    createAuthor,
-    replace,
-    deleteTermReplacement,
-    deleteTypeReplacement,
-    test,
-    ioTest,
-    execute,
-    viewReflog,
-    resetRoot,
-    quit,
-    updateBuiltins,
-    makeStandalone,
-    mergeBuiltins,
-    mergeIOBuiltins,
-    dependents,
-    dependencies,
-    namespaceDependencies,
-    debugNumberedArgs,
-    debugFileHashes,
-    debugDumpNamespace,
-    debugDumpNamespaceSimple,
-    debugClearWatchCache,
-    gist
-  ]
+  sortOn
+    I.patternName
+    [ help,
+      helpTopics,
+      load,
+      add,
+      previewAdd,
+      update,
+      previewUpdate,
+      updateNoPatch,
+      delete,
+      forkLocal,
+      mergeLocal,
+      squashMerge,
+      previewMergeLocal,
+      diffNamespace,
+      names,
+      push,
+      pushCreate,
+      pull,
+      pullWithoutHistory,
+      pullSilent,
+      pushExhaustive,
+      pullExhaustive,
+      createPullRequest,
+      loadPullRequest,
+      cd,
+      up,
+      back,
+      deleteNamespace,
+      deleteNamespaceForce,
+      renameBranch,
+      deletePatch,
+      renamePatch,
+      copyPatch,
+      find,
+      findShallow,
+      findVerbose,
+      view,
+      display,
+      displayTo,
+      api,
+      ui,
+      docs,
+      docsToHtml,
+      findPatch,
+      viewPatch,
+      undo,
+      history,
+      edit,
+      renameTerm,
+      deleteTerm,
+      aliasTerm,
+      renameType,
+      deleteType,
+      aliasType,
+      aliasMany,
+      todo,
+      patch,
+      link,
+      unlink,
+      links,
+      createAuthor,
+      replace,
+      deleteTermReplacement,
+      deleteTypeReplacement,
+      test,
+      ioTest,
+      execute,
+      viewReflog,
+      resetRoot,
+      quit,
+      updateBuiltins,
+      makeStandalone,
+      mergeBuiltins,
+      mergeIOBuiltins,
+      dependents,
+      dependencies,
+      namespaceDependencies,
+      debugNumberedArgs,
+      debugFileHashes,
+      debugDumpNamespace,
+      debugDumpNamespaceSimple,
+      debugClearWatchCache,
+      gist
+    ]
+
+visibleInputs :: [InputPattern]
+visibleInputs = filter ((== I.Visible) . I.visibility) validInputs
 
 commandNames :: [String]
-commandNames = validInputs >>= \i -> I.patternName i : I.aliases i
+commandNames = visibleInputs >>= \i -> I.patternName i : I.aliases i
 
 commandNameArg :: ArgumentType
 commandNameArg =


### PR DESCRIPTION
## Overview

As the UCM team works on the new Share server we'll want to keep merging into trunk to avoid long-lived branches and encourage continuous integration, but it's likely a lot of these commands won't be 100% ready to ship even though they're merged, since some commands might be complete in UCM, but are waiting for a feature on the server, or perhaps we want to dogfood them for a longer period than usual.

I'll be using this so I can merge the `auth.login` command.

This change allows us to merge new commands into UCM, and for us to test them, etc; but hides them from any help output, command lists, and autocomplete so that users don't stumble into them and get confused.

## Implementation notes

Adds a "visibility" parameter to Inputs, inputs which are marked has hidden won't show up in help or autocomplete.
Hidden commands can still be executed if you know the name, and you can request help for it if you know the name.