### PR TITLE
Save information for decompiling non-closed definitions

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/ANF.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF.hs
@@ -332,7 +332,7 @@ floater _ rec (Let1Named' v b e)
   | Just (vs0, _, vs1, bd) <- unLamsAnnot b =
       Just $
         rec bd
-          >>= lamFloater (null $ ABT.freeVars b) b (Just v) a (vs0 ++ vs1)
+          >>= lamFloater True b (Just v) a (vs0 ++ vs1)
           >>= \lv -> rec $ ABT.renames (Map.singleton v lv) e
   where
     a = ABT.annotation b
@@ -340,7 +340,7 @@ floater top rec tm@(LamsNamed' vs bd)
   | top = Just $ lam' a vs <$> rec bd
   | otherwise = Just $ do
       bd <- rec bd
-      lv <- lamFloater (null $ ABT.freeVars tm) tm Nothing a vs bd
+      lv <- lamFloater True tm Nothing a vs bd
       pure $ var a lv
   where
     a = ABT.annotation tm


### PR DESCRIPTION
Previously in cases like:

    let
      f x = ...
      g y = ... f ...
      ...

we would not save decompilation information for `g`, because it wouldn't
be possible to guarantee that the output of decompilation actually made
sense (for instance, if `g` is decompiled, it will not mention `f`.

However, this seems to block some useful documentation, even in cases
where it doesn't seem like such intermediate definitions would need to
be decompiled. So, it seems like a better trade-off to just allow
decompilation, and accept that some output might be difficult to
understand. Such output can be avoided when writing documentation.

Fixes #2061.