### PR TITLE
Correctly handle errors which occur during transcripts

### DIFF
--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -53,6 +53,7 @@ dependencies:
   - time
   - lock-file
   - jwt
+  - either
 
 
 library:

--- a/unison-cli/transcripts/Transcripts.hs
+++ b/unison-cli/transcripts/Transcripts.hs
@@ -32,8 +32,8 @@ data TestConfig = TestConfig
 type TestBuilder = FilePath -> [String] -> String -> Test ()
 
 testBuilder ::
-  FilePath -> [String] -> String -> Test ()
-testBuilder dir prelude transcript = scope transcript $ do
+  Bool -> FilePath -> [String] -> String -> Test ()
+testBuilder expectFailure dir prelude transcript = scope transcript $ do
   outputs <- io . withTemporaryUcmCodebase SC.init "transcript" $ \(codebasePath, codebase) -> do
     withTranscriptRunner "TODO: pass version here" Nothing $ \runTranscript -> do
       for files $ \filePath -> do
@@ -45,14 +45,15 @@ testBuilder dir prelude transcript = scope transcript $ do
       let outputFile = outputFileForTranscript filePath
       case err of
         TranscriptParseError msg -> do
-          crash $ "Error parsing " <> filePath <> ": " <> Text.unpack msg
+          when (not expectFailure) . crash $ "Error parsing " <> filePath <> ": " <> Text.unpack msg
         TranscriptRunFailure errOutput -> do
           io $ writeUtf8 outputFile errOutput
           io $ Text.putStrLn errOutput
-          crash $ "Failure in " <> filePath
+          when (not expectFailure) . crash $ "Failure in " <> filePath
     (filePath, Right out) -> do
       let outputFile = outputFileForTranscript filePath
       io $ writeUtf8 outputFile out
+      when expectFailure $ crash "Expected a failure, but transcript was successful."
   ok
   where
     files = fmap (dir </>) (prelude ++ [transcript])
@@ -109,11 +110,11 @@ cleanup = do
 
 test :: TestConfig -> Test ()
 test config = do
-  buildTests config testBuilder $
+  buildTests config (testBuilder False) $
     "unison-src" </> "transcripts"
-  buildTests config testBuilder $
+  buildTests config (testBuilder False) $
     "unison-src" </> "transcripts-using-base"
-  buildTests config testBuilder $
+  buildTests config (testBuilder True) $
     "unison-src" </> "transcripts" </> "errors"
   cleanup
 

--- a/unison-cli/transcripts/Transcripts.hs
+++ b/unison-cli/transcripts/Transcripts.hs
@@ -8,6 +8,7 @@ module Main (main) where
 import Data.Bifunctor (second)
 import Data.List
 import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
 import EasyTest
 import System.Directory
 import System.Environment (getArgs)
@@ -47,6 +48,8 @@ testBuilder dir prelude transcript = scope transcript $ do
           crash $ "Error parsing " <> filePath <> ": " <> Text.unpack msg
         TranscriptRunFailure errOutput -> do
           io $ writeUtf8 outputFile errOutput
+          io $ Text.putStrLn errOutput
+          crash $ "Failure in " <> filePath
     (filePath, Right out) -> do
       let outputFile = outputFileForTranscript filePath
       io $ writeUtf8 outputFile out

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -98,6 +98,7 @@ library
     , containers >=0.6.3
     , cryptonite
     , directory
+    , either
     , errors
     , extra
     , filepath
@@ -184,6 +185,7 @@ executable integration-tests
     , cryptonite
     , directory
     , easytest
+    , either
     , errors
     , extra
     , filepath
@@ -266,6 +268,7 @@ executable transcripts
     , cryptonite
     , directory
     , easytest
+    , either
     , errors
     , extra
     , filepath
@@ -351,6 +354,7 @@ executable unison
     , containers >=0.6.3
     , cryptonite
     , directory
+    , either
     , errors
     , extra
     , filepath
@@ -443,6 +447,7 @@ test-suite tests
     , cryptonite
     , directory
     , easytest
+    , either
     , errors
     , extra
     , filepath

--- a/unison-cli/unison/Main.hs
+++ b/unison-cli/unison/Main.hs
@@ -26,8 +26,8 @@ import Control.Error.Safe (rightMay)
 import Control.Exception (evaluate)
 import qualified Data.ByteString.Lazy as BL
 import Data.Configurator.Types (Config)
+import Data.Either.Validation (Validation (..))
 import Data.List.NonEmpty (NonEmpty)
-import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.IO as Text
@@ -70,6 +70,7 @@ import Unison.Symbol (Symbol)
 import qualified Unison.Util.Pretty as P
 import UnliftIO.Directory (getHomeDirectory)
 import qualified Version
+import Data.Bifunctor
 
 main :: IO ()
 main = withCP65001 do
@@ -262,20 +263,19 @@ runTranscripts' ::
   String ->
   Maybe FilePath ->
   FilePath ->
-  NonEmpty String ->
+  NonEmpty MarkdownFile ->
   IO Bool
-runTranscripts' progName mcodepath transcriptDir args = do
+runTranscripts' progName mcodepath transcriptDir markdownFiles = do
   currentDir <- getCurrentDirectory
-  let (markdownFiles, invalidArgs) = NonEmpty.partition isMarkdown args
   configFilePath <- getConfigFilePath mcodepath
   -- We don't need to create a codebase through `getCodebaseOrExit` as we've already done so previously.
-  getCodebaseOrExit (Just (DontCreateCodebaseWhenMissing transcriptDir)) \(_, codebasePath, theCodebase) -> do
+  and <$> getCodebaseOrExit (Just (DontCreateCodebaseWhenMissing transcriptDir)) \(_, codebasePath, theCodebase) -> do
     TR.withTranscriptRunner Version.gitDescribeWithDate (Just configFilePath) $ \runTranscript -> do
-      for_ markdownFiles $ \fileName -> do
+      for markdownFiles $ \(MarkdownFile fileName) -> do
         transcriptSrc <- readUtf8 fileName
         result <- runTranscript fileName transcriptSrc (codebasePath, theCodebase)
         let outputFile = FP.replaceExtension (currentDir FP.</> fileName) ".output.md"
-        output <- case result of
+        (output, succeeded) <- case result of
           Left err -> case err of
             TR.TranscriptParseError err -> do
               PT.putPrettyLn $
@@ -287,7 +287,7 @@ runTranscripts' progName mcodepath transcriptDir args = do
                         P.indentN 2 $ P.text err
                       ]
                   )
-              pure err
+              pure (err, False)
             TR.TranscriptRunFailure err -> do
               PT.putPrettyLn $
                 P.callout
@@ -305,24 +305,12 @@ runTranscripts' progName mcodepath transcriptDir args = do
                             <> "to do more work with it."
                       ]
                   )
-              pure err
+              pure (err, False)
           Right mdOut -> do
-            pure mdOut
+            pure (mdOut, True)
         writeUtf8 outputFile output
         putStrLn $ "💾  Wrote " <> outputFile
-
-  when (not . null $ invalidArgs) $ do
-    PT.putPrettyLn $
-      P.callout
-        "❓"
-        ( P.lines
-            [ P.indentN 2 "Transcripts must have an .md or .markdown extension.",
-              P.indentN 2 "Skipping the following invalid files:",
-              "",
-              P.bulleted $ fmap (P.bold . P.string . (<> "\n")) invalidArgs
-            ]
-        )
-  pure True
+        pure succeeded
 
 runTranscripts ::
   UsageRenderer ->
@@ -332,32 +320,43 @@ runTranscripts ::
   NonEmpty String ->
   IO ()
 runTranscripts renderUsageInfo shouldFork shouldSaveTempCodebase mCodePathOption args = do
+  markdownFiles <- case traverse (first (pure @[]) . markdownFile) args of
+    Failure invalidArgs -> do
+      PT.putPrettyLn $
+        P.callout
+          "❓"
+          ( P.lines
+              [ P.indentN 2 "Transcripts must have an .md or .markdown extension.",
+                "",
+                P.bulleted $ fmap (P.bold . P.string . (<> "\n")) invalidArgs
+              ]
+          )
+      putStrLn (renderUsageInfo $ Just "transcript")
+      Exit.exitWith (Exit.ExitFailure 1)
+    Success markdownFiles -> pure markdownFiles
   progName <- getProgName
   transcriptDir <- prepareTranscriptDir shouldFork mCodePathOption
   completed <-
-    runTranscripts' progName (Just transcriptDir) transcriptDir args
+    runTranscripts' progName (Just transcriptDir) transcriptDir markdownFiles
   case shouldSaveTempCodebase of
     DontSaveCodebase -> removeDirectoryRecursive transcriptDir
     SaveCodebase ->
-      if completed
-        then
-          PT.putPrettyLn $
-            P.callout
-              "🌸"
-              ( P.lines
-                  [ "I've finished running the transcript(s) in this codebase:",
-                    "",
-                    P.indentN 2 (P.string transcriptDir),
-                    "",
-                    P.wrap $
-                      "You can run"
-                        <> P.backticked (P.string progName <> " --codebase " <> P.string transcriptDir)
-                        <> "to do more work with it."
-                  ]
-              )
-        else do
-          putStrLn (renderUsageInfo $ Just "transcript")
-          Exit.exitWith (Exit.ExitFailure 1)
+      when completed $ do
+        PT.putPrettyLn $
+          P.callout
+            "🌸"
+            ( P.lines
+                [ "I've finished running the transcript(s) in this codebase:",
+                  "",
+                  P.indentN 2 (P.string transcriptDir),
+                  "",
+                  P.wrap $
+                    "You can run"
+                      <> P.backticked (P.string progName <> " --codebase " <> P.string transcriptDir)
+                      <> "to do more work with it."
+                ]
+            )
+  when (not completed) $ Exit.exitWith (Exit.ExitFailure 1)
 
 initialPath :: Path.Absolute
 initialPath = Path.absoluteEmpty
@@ -393,11 +392,13 @@ launch dir config runtime codebase inputs serverBaseUrl shouldDownloadBase initR
         serverBaseUrl
         ucmVersion
 
-isMarkdown :: String -> Bool
-isMarkdown md = case FP.takeExtension md of
-  ".md" -> True
-  ".markdown" -> True
-  _ -> False
+newtype MarkdownFile = MarkdownFile FilePath
+
+markdownFile :: FilePath -> Validation FilePath MarkdownFile
+markdownFile md = case FP.takeExtension md of
+  ".md" -> Success $ MarkdownFile md
+  ".markdown" -> Success $ MarkdownFile md
+  _ -> Failure md
 
 isDotU :: String -> Bool
 isDotU file = FP.takeExtension file == ".u"


### PR DESCRIPTION
@dolio  noticed that at some point transcripts stopped failing with an exit code or maybe never did?, CI would still catch the changed transcript output if it didn't match.

This fixes that up, and makes the `ucm transcript` command result in correct exit codes too.

## Overview

We needed to collect transcript failures and `exit 1` if any transcript fails.
I also made it so we fail-fast if any args are invalid, since we probably shouldn't waste time setting up a temporary codebase first if we're not going to run anyways.

## Implementation notes

* Collect transcript run results and `and` them together.
* I switched the markdown file validation to earlier on.
