### PR TITLE
Hide builtins.merge, builtins.mergeio

### DIFF
--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -87,7 +87,7 @@ mergeBuiltins =
   InputPattern
     "builtins.merge"
     []
-    I.Visible
+    I.Hidden
     []
     "Adds the builtins to `builtins.` in the current namespace (excluding `io` and misc)."
     (const . pure $ Input.MergeBuiltinsI)
@@ -97,7 +97,7 @@ mergeIOBuiltins =
   InputPattern
     "builtins.mergeio"
     []
-    I.Visible
+    I.Hidden
     []
     "Adds all the builtins to `builtins.` in the current namespace, including `io` and misc."
     (const . pure $ Input.MergeIOBuiltinsI)


### PR DESCRIPTION
## Overview

Per https://unisonlanguage.slack.com/archives/CLUNF0J5S/p1648677703263049 , 

These commands are confusing to end users, and are also strangely named, since `builtins.mergeio` does more than just IO builtins now.

Hiding them prevents users from stumbling into issues like this which are hard to resolve, while still allowing us to use them in transcripts, etc.

## Implementation notes

Hide `builtins.merge` and `builtins.mergeio` from `help`.