### PR TITLE
Use explicit deriving strategies where it's ambiguous

### DIFF
--- a/lib/unison-pretty-printer/src/Unison/Util/Pretty.hs
+++ b/lib/unison-pretty-printer/src/Unison/Util/Pretty.hs
@@ -158,7 +158,8 @@ import qualified Unison.Util.SyntaxText as ST
 import Prelude hiding (lines, map)
 
 newtype Width = Width {widthToInt :: Int}
-  deriving (Eq, Ord, Show, Generic, Num, Bounded)
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving newtype (Num, Bounded)
 
 type ColorText = CT.ColorText
 

--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -2,28 +2,6 @@ name: unison-parser-typechecker
 github: unisonweb/unison
 copyright: Copyright (C) 2013-2021 Unison Computing, PBC and contributors
 
-default-extensions:
-  - ApplicativeDo
-  - BangPatterns
-  - BlockArguments
-  - DeriveFunctor
-  - DeriveGeneric
-  - DerivingStrategies
-  - DoAndIfThenElse
-  - FlexibleContexts
-  - FlexibleInstances
-  - GeneralizedNewtypeDeriving
-  - LambdaCase
-  - MultiParamTypeClasses
-  - NamedFieldPuns
-  - OverloadedStrings
-  - PatternSynonyms
-  - RankNTypes
-  - ScopedTypeVariables
-  - TupleSections
-  - TypeApplications
-  - ViewPatterns
-
 ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
 
 flags:
@@ -180,3 +158,27 @@ executables:
       - unison-util
       - unison-util-relation
       - unison-pretty-printer
+
+default-extensions:
+  - ApplicativeDo
+  - BangPatterns
+  - BlockArguments
+  - DeriveFunctor
+  - DeriveGeneric
+  - DeriveTraversable
+  - DerivingStrategies
+  - DerivingVia
+  - DoAndIfThenElse
+  - FlexibleContexts
+  - FlexibleInstances
+  - GeneralizedNewtypeDeriving
+  - LambdaCase
+  - MultiParamTypeClasses
+  - NamedFieldPuns
+  - OverloadedStrings
+  - PatternSynonyms
+  - RankNTypes
+  - ScopedTypeVariables
+  - TupleSections
+  - TypeApplications
+  - ViewPatterns

--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -84,7 +84,9 @@ import Unison.Prelude hiding (empty, toList)
 import Unison.Util.Monoid (intercalateMap)
 
 -- `Foo.Bar.baz` becomes ["Foo", "Bar", "baz"]
-newtype Path = Path {toSeq :: Seq NameSegment} deriving (Eq, Ord, Semigroup, Monoid)
+newtype Path = Path {toSeq :: Seq NameSegment}
+  deriving stock (Eq, Ord)
+  deriving newtype (Semigroup, Monoid)
 
 newtype Absolute = Absolute {unabsolute :: Path} deriving (Eq, Ord)
 

--- a/parser-typechecker/src/Unison/Runtime/ANF.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF.hs
@@ -477,9 +477,13 @@ data ANormalF v e
 -- Types representing components that will go into the runtime tag of
 -- a data type value. RTags correspond to references, while CTags
 -- correspond to constructors.
-newtype RTag = RTag Word64 deriving (Eq, Ord, Show, Read, EC.EnumKey)
+newtype RTag = RTag Word64
+  deriving stock (Eq, Ord, Show, Read)
+  deriving newtype (EC.EnumKey)
 
-newtype CTag = CTag Word16 deriving (Eq, Ord, Show, Read, EC.EnumKey)
+newtype CTag = CTag Word16
+  deriving stock (Eq, Ord, Show, Read)
+  deriving newtype (EC.EnumKey)
 
 class Tag t where rawTag :: t -> Word64
 

--- a/parser-typechecker/src/Unison/Util/Bytes.hs
+++ b/parser-typechecker/src/Unison/Util/Bytes.hs
@@ -83,7 +83,9 @@ import Prelude hiding (drop, take)
 type Chunk = V.Vector Word8
 
 -- Bytes type represented as a rope of ByteStrings
-newtype Bytes = Bytes {underlying :: R.Rope Chunk} deriving (Semigroup, Monoid, Eq, Ord)
+newtype Bytes = Bytes {underlying :: R.Rope Chunk}
+  deriving stock (Eq, Ord)
+  deriving newtype (Semigroup, Monoid)
 
 instance R.Sized Chunk where size = V.length
 

--- a/parser-typechecker/src/Unison/Util/EnumContainers.hs
+++ b/parser-typechecker/src/Unison/Util/EnumContainers.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE DeriveTraversable #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-
 module Unison.Util.EnumContainers
   ( EnumMap,
     EnumSet,
@@ -49,24 +46,28 @@ instance EnumKey Word16 where
   intToKey i = fromIntegral i
 
 newtype EnumMap k a = EM (IM.IntMap a)
-  deriving
-    ( Monoid,
-      Semigroup,
-      Functor,
+  deriving stock
+    ( Functor,
       Foldable,
       Traversable,
       Show,
       Eq,
       Ord
     )
+  deriving newtype
+    ( Monoid,
+      Semigroup
+    )
 
 newtype EnumSet k = ES IS.IntSet
-  deriving
-    ( Monoid,
-      Semigroup,
-      Show,
+  deriving stock
+    ( Show,
       Eq,
       Ord
+    )
+  deriving newtype
+    ( Monoid,
+      Semigroup
     )
 
 mapFromList :: EnumKey k => [(k, a)] -> EnumMap k a

--- a/parser-typechecker/src/Unison/Util/Text.hs
+++ b/parser-typechecker/src/Unison/Util/Text.hs
@@ -14,7 +14,9 @@ import qualified Unison.Util.Rope as R
 import Prelude hiding (drop, replicate, take)
 
 -- Text type represented as a `Rope` of chunks
-newtype Text = Text (R.Rope Chunk) deriving (Eq, Ord, Semigroup, Monoid)
+newtype Text = Text (R.Rope Chunk)
+  deriving stock (Eq, Ord)
+  deriving newtype (Semigroup, Monoid)
 
 data Chunk = Chunk {-# UNPACK #-} !Int {-# UNPACK #-} !T.Text
 

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -188,7 +188,9 @@ library
       BlockArguments
       DeriveFunctor
       DeriveGeneric
+      DeriveTraversable
       DerivingStrategies
+      DerivingVia
       DoAndIfThenElse
       FlexibleContexts
       FlexibleInstances
@@ -352,7 +354,9 @@ executable tests
       BlockArguments
       DeriveFunctor
       DeriveGeneric
+      DeriveTraversable
       DerivingStrategies
+      DerivingVia
       DoAndIfThenElse
       FlexibleContexts
       FlexibleInstances


### PR DESCRIPTION
## Overview

This PR adds a few explicit `stock` / `newtype` deriving strategies where they were ambiguous before.

These clauses were previously causing warnings when loading more than one component into ghci (i.e. `stack ghci`), because:

- With both `DeriveAnyClass` and `GeneralizedNewtypeDeriving` enabled, GHC emits a warning for some deriving clauses indicating that it's defaulting to `DeriveAnyClass` for some type classes, but you should be explicit about which strategy to use.
- `unison-parser-typechecker` only has `GeneralizedNewtypeDeriving` enabled, but some other package(s) have `DeriveAnyClass`
- When multiple components are loaded into ghci by `stack ghci`, it just combines all of the flags/extensions together.

With this PR, you should be able to `stack ghci` without warning. (Better would be to have the same set of extensions enabled in every package :smile:)