### PR TITLE
Add MonadUnliftIO to unison-prelude

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -144,28 +144,18 @@ module U.Codebase.Sqlite.Queries
 where
 
 import qualified Control.Exception as Exception
-import Control.Monad (when)
 import Control.Monad.Except (MonadError)
 import qualified Control.Monad.Except as Except
-import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Reader (MonadReader (ask))
 import qualified Control.Monad.Reader as Reader
-import Control.Monad.Trans (MonadIO (liftIO))
-import Control.Monad.Trans.Maybe (MaybeT (MaybeT), runMaybeT)
 import qualified Control.Monad.Writer as Writer
-import Data.ByteString (ByteString)
 import qualified Data.Char as Char
-import Data.Foldable (traverse_)
-import Data.Functor ((<&>))
-import Data.Int (Int8)
 import qualified Data.List.Extra as List
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as Nel
 import Data.Maybe (fromJust)
 import qualified Data.Set as Set
-import Data.String (fromString)
 import Data.String.Here.Uninterpolated (here, hereFile)
-import Data.Text (Text)
 import Database.SQLite.Simple
   ( FromRow,
     Only (..),
@@ -175,9 +165,6 @@ import Database.SQLite.Simple
 import qualified Database.SQLite.Simple as SQLite
 import Database.SQLite.Simple.FromField (FromField (..))
 import Database.SQLite.Simple.ToField (ToField (..))
-import Debug.Trace (trace, traceM)
-import GHC.Stack (HasCallStack)
-import Safe (headMay)
 import U.Codebase.HashTags (BranchHash (..), CausalHash (..))
 import U.Codebase.Reference (Reference' (..))
 import qualified U.Codebase.Reference as C.Reference
@@ -204,7 +191,8 @@ import qualified U.Util.Alternative as Alternative
 import U.Util.Base32Hex (Base32Hex (..))
 import U.Util.Hash (Hash)
 import qualified U.Util.Hash as Hash
-import UnliftIO (MonadUnliftIO, throwIO, try, tryAny, withRunInIO)
+import Unison.Prelude
+import UnliftIO (throwIO, tryAny)
 import qualified UnliftIO
 import UnliftIO.Concurrent (myThreadId)
 

--- a/lib/unison-prelude/src/Unison/Prelude.hs
+++ b/lib/unison-prelude/src/Unison/Prelude.hs
@@ -25,7 +25,7 @@ where
 
 import Control.Applicative as X
 import Control.Category as X ((>>>))
-import Control.Exception as X (Exception, IOException, SomeException, try)
+import Control.Exception as X (Exception, IOException, SomeException)
 import Control.Monad as X
 import Control.Monad.Extra as X (ifM, mapMaybeM, unlessM, whenM)
 import Control.Monad.IO.Class as X (MonadIO (liftIO))
@@ -61,6 +61,7 @@ import GHC.Stack as X (HasCallStack)
 import Safe as X (atMay, headMay, lastMay, readMay)
 import qualified System.IO as IO
 import Text.Read as X (readMaybe)
+import UnliftIO as X (MonadUnliftIO (..), askRunInIO, askUnliftIO, toIO, try, withUnliftIO)
 import qualified UnliftIO
 
 -- | E.g.

--- a/lib/unison-prelude/src/Unison/Prelude.hs
+++ b/lib/unison-prelude/src/Unison/Prelude.hs
@@ -61,7 +61,7 @@ import GHC.Stack as X (HasCallStack)
 import Safe as X (atMay, headMay, lastMay, readMay)
 import qualified System.IO as IO
 import Text.Read as X (readMaybe)
-import UnliftIO as X (MonadUnliftIO (..), askRunInIO, askUnliftIO, toIO, try, withUnliftIO)
+import UnliftIO as X (MonadUnliftIO (..), askRunInIO, askUnliftIO, try, withUnliftIO)
 import qualified UnliftIO
 
 -- | E.g.

--- a/lib/unison-sqlite/src/Unison/Sqlite/Connection.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Connection.hs
@@ -67,7 +67,6 @@ import qualified Unison.Debug as Debug
 import Unison.Prelude
 import Unison.Sqlite.Exception
 import Unison.Sqlite.Sql
-import UnliftIO (MonadUnliftIO)
 import UnliftIO.Exception
 
 -- | A /non-thread safe/ connection to a SQLite database.

--- a/lib/unison-sqlite/src/Unison/Sqlite/DB.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/DB.hs
@@ -56,7 +56,6 @@ module Unison.Sqlite.DB
   )
 where
 
-import Control.Monad.IO.Unlift (MonadUnliftIO, withRunInIO)
 import Control.Monad.Reader (MonadReader, ReaderT, ask, runReaderT)
 import qualified Database.SQLite.Simple as Sqlite
 import qualified Database.SQLite.Simple.FromField as Sqlite

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -142,7 +142,6 @@ import qualified Unison.UnisonFile as UF
 import qualified Unison.Util.Relation as Rel
 import Unison.Var (Var)
 import qualified Unison.WatchKind as WK
-import UnliftIO (MonadUnliftIO)
 
 -- | Get a branch from the codebase.
 getBranchForHash :: Monad m => Codebase m v a -> Branch.Hash -> m (Maybe (Branch m))

--- a/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
@@ -32,7 +32,6 @@ import Unison.Codebase.Editor.RemoteRepo (ReadRepo (..))
 import Unison.Codebase.GitError (GitProtocolError)
 import qualified Unison.Codebase.GitError as GitError
 import Unison.Prelude
-import UnliftIO (MonadUnliftIO)
 import qualified UnliftIO
 import UnliftIO.Directory (XdgDirectory (XdgCache), doesDirectoryExist, findExecutable, getXdgDirectory)
 import UnliftIO.Environment (lookupEnv)

--- a/parser-typechecker/src/Unison/Codebase/Init.hs
+++ b/parser-typechecker/src/Unison/Codebase/Init.hs
@@ -28,7 +28,6 @@ import Unison.Prelude
 import qualified Unison.PrettyTerminal as PT
 import Unison.Symbol (Symbol)
 import qualified Unison.Util.Pretty as P
-import UnliftIO (MonadUnliftIO)
 import qualified UnliftIO
 import UnliftIO.Directory (canonicalizePath)
 

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -97,7 +97,7 @@ import Unison.Type (Type)
 import qualified Unison.Type as Type
 import qualified Unison.Util.Set as Set
 import qualified Unison.WatchKind as UF
-import UnliftIO (MonadUnliftIO, catchIO, finally, throwIO, try)
+import UnliftIO (catchIO, finally, throwIO, try)
 import UnliftIO.Directory (createDirectoryIfMissing, doesDirectoryExist, doesFileExist)
 import UnliftIO.Exception (bracket, catch)
 import UnliftIO.STM

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
@@ -19,7 +19,6 @@ import Unison.Codebase.Type (Codebase, LocalOrRemote (..))
 import Unison.Prelude
 import Unison.Symbol (Symbol)
 import Unison.Var (Var)
-import UnliftIO (MonadUnliftIO)
 import qualified UnliftIO
 
 type Migration m a v = Connection -> Codebase m v a -> m (Either MigrationError ())

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema1To2.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema1To2.hs
@@ -79,7 +79,6 @@ import Unison.Type (Type)
 import qualified Unison.Type as Type
 import qualified Unison.Util.Set as Set
 import Unison.Var (Var)
-import UnliftIO (MonadUnliftIO)
 import UnliftIO.Exception (bracket_, onException)
 
 -- todo:

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema2To3.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema2To3.hs
@@ -7,7 +7,7 @@ import qualified U.Codebase.Sqlite.Queries as Q
 import Unison.Codebase (Codebase)
 import Unison.Codebase.SqliteCodebase.Migrations.Errors (MigrationError (IncorrectStartingSchemaVersion))
 import Unison.Var (Var)
-import UnliftIO (MonadUnliftIO)
+import Unison.Prelude
 import qualified UnliftIO
 
 -- | The 1 to 2 migration kept around hash objects of hash version 1, unfortunately this

--- a/unison-cli/src/Unison/Codebase/Editor/Command.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Command.hs
@@ -74,7 +74,7 @@ import qualified Unison.UnisonFile as UF
 import Unison.Util.Free (Free)
 import qualified Unison.Util.Free as Free
 import qualified Unison.WatchKind as WK
-import UnliftIO (MonadUnliftIO (..), UnliftIO)
+import UnliftIO (UnliftIO)
 import qualified UnliftIO
 
 type AmbientAbilities v = [Type v Ann]

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -151,7 +151,6 @@ import Unison.Util.TransitiveClosure (transitiveClosure)
 import Unison.Var (Var)
 import qualified Unison.Var as Var
 import qualified Unison.WatchKind as WK
-import UnliftIO (MonadUnliftIO)
 
 defaultPatchNameSegment :: NameSegment
 defaultPatchNameSegment = "patch"


### PR DESCRIPTION
## Overview

Found myself getting annoyed by needing to import this every time, so I added this real quick.
Just adds MonadUnliftIO to prelude, and swaps `Exception.try` to `MonadUnliftIO.try` so we get Unlifting on it and can maybe avoid some `lift . lift . lift`'s haha, I double-checked any usages with type applications to ensure they line up properly 👍🏼 , we'd get Kind-checker errors if they didn't anyways.
