### PR TITLE
Add `io.getSomeBytes.impl` built-in

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -579,6 +579,7 @@ ioBuiltins =
   , ("IO.getBuffering.impl.v3", handle --> iof bmode)
   , ("IO.setBuffering.impl.v3", handle --> bmode --> iof unit)
   , ("IO.getBytes.impl.v3", handle --> nat --> iof bytes)
+  , ("IO.getSomeBytes.impl.v1", handle --> nat --> iof bytes)
   , ("IO.putBytes.impl.v3", handle --> bytes --> iof unit)
   , ("IO.getLine.impl.v1", handle --> iof text)
   , ("IO.systemTime.impl.v3", unit --> iof nat)

--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -34,7 +34,7 @@ import Control.Monad.State.Strict (State, execState, modify)
 import qualified Crypto.Hash as Hash
 import qualified Crypto.MAC.HMAC as HMAC
 import qualified Data.ByteArray as BA
-import Data.ByteString (hGet, hPut)
+import Data.ByteString (hGet, hGetSome, hPut)
 import qualified Data.ByteString.Lazy as L
 import Data.Default (def)
 import Data.IORef as SYS
@@ -1789,6 +1789,9 @@ declareForeigns = do
 
   declareForeign Tracked "IO.getBytes.impl.v3" boxNatToEFBox . mkForeignIOF $
     \(h, n) -> Bytes.fromArray <$> hGet h n
+
+  declareForeign Tracked "IO.getSomeBytes.impl.v1" boxNatToEFBox . mkForeignIOF $
+    \(h, n) -> Bytes.fromArray <$> hGetSome h n
 
   declareForeign Tracked "IO.putBytes.impl.v3" boxBoxToEF0 . mkForeignIOF $ \(h, bs) -> hPut h (Bytes.toArray bs)
 

--- a/unison-src/transcripts-using-base/base.u
+++ b/unison-src/transcripts-using-base/base.u
@@ -198,6 +198,7 @@ isSeekable = compose reraise isSeekable.impl
 isFileEOF = compose reraise isFileEOF.impl
 Text.fromUtf8 = compose reraise fromUtf8.impl
 getBytes = compose2 reraise getBytes.impl
+getSomeBytes = compose2 reraise getSomeBytes.impl
 handlePosition = compose reraise handlePosition.impl
 getBuffering = compose reraise getBuffering.impl
 setBuffering mode = compose reraise (setBuffering.impl mode)

--- a/unison-src/transcripts/alias-many.output.md
+++ b/unison-src/transcripts/alias-many.output.md
@@ -217,260 +217,263 @@ Let's try it!
   181. io2.IO.getFileTimestamp.impl : Text
                                       ->{IO} Either Failure Nat
   182. io2.IO.getLine.impl : Handle ->{IO} Either Failure Text
-  183. io2.IO.getTempDirectory.impl : '{IO} Either Failure Text
-  184. io2.IO.handlePosition.impl : Handle
+  183. io2.IO.getSomeBytes.impl : Handle
+                                  -> Nat
+                                  ->{IO} Either Failure Bytes
+  184. io2.IO.getTempDirectory.impl : '{IO} Either Failure Text
+  185. io2.IO.handlePosition.impl : Handle
                                     ->{IO} Either Failure Nat
-  185. io2.IO.isDirectory.impl : Text
+  186. io2.IO.isDirectory.impl : Text
                                  ->{IO} Either Failure Boolean
-  186. io2.IO.isFileEOF.impl : Handle
+  187. io2.IO.isFileEOF.impl : Handle
                                ->{IO} Either Failure Boolean
-  187. io2.IO.isFileOpen.impl : Handle
+  188. io2.IO.isFileOpen.impl : Handle
                                 ->{IO} Either Failure Boolean
-  188. io2.IO.isSeekable.impl : Handle
+  189. io2.IO.isSeekable.impl : Handle
                                 ->{IO} Either Failure Boolean
-  189. io2.IO.kill.impl : ThreadId ->{IO} Either Failure ()
-  190. io2.IO.listen.impl : Socket ->{IO} Either Failure ()
-  191. io2.IO.openFile.impl : Text
+  190. io2.IO.kill.impl : ThreadId ->{IO} Either Failure ()
+  191. io2.IO.listen.impl : Socket ->{IO} Either Failure ()
+  192. io2.IO.openFile.impl : Text
                               -> FileMode
                               ->{IO} Either Failure Handle
-  192. io2.IO.putBytes.impl : Handle
+  193. io2.IO.putBytes.impl : Handle
                               -> Bytes
                               ->{IO} Either Failure ()
-  193. io2.IO.ref : a ->{IO} Ref {IO} a
-  194. io2.IO.removeDirectory.impl : Text
+  194. io2.IO.ref : a ->{IO} Ref {IO} a
+  195. io2.IO.removeDirectory.impl : Text
                                      ->{IO} Either Failure ()
-  195. io2.IO.removeFile.impl : Text ->{IO} Either Failure ()
-  196. io2.IO.renameDirectory.impl : Text
+  196. io2.IO.removeFile.impl : Text ->{IO} Either Failure ()
+  197. io2.IO.renameDirectory.impl : Text
                                      -> Text
                                      ->{IO} Either Failure ()
-  197. io2.IO.renameFile.impl : Text
+  198. io2.IO.renameFile.impl : Text
                                 -> Text
                                 ->{IO} Either Failure ()
-  198. io2.IO.seekHandle.impl : Handle
+  199. io2.IO.seekHandle.impl : Handle
                                 -> SeekMode
                                 -> Int
                                 ->{IO} Either Failure ()
-  199. io2.IO.serverSocket.impl : Optional Text
+  200. io2.IO.serverSocket.impl : Optional Text
                                   -> Text
                                   ->{IO} Either Failure Socket
-  200. io2.IO.setBuffering.impl : Handle
+  201. io2.IO.setBuffering.impl : Handle
                                   -> BufferMode
                                   ->{IO} Either Failure ()
-  201. io2.IO.setCurrentDirectory.impl : Text
+  202. io2.IO.setCurrentDirectory.impl : Text
                                          ->{IO} Either
                                            Failure ()
-  202. io2.IO.socketAccept.impl : Socket
+  203. io2.IO.socketAccept.impl : Socket
                                   ->{IO} Either Failure Socket
-  203. io2.IO.socketPort.impl : Socket ->{IO} Either Failure Nat
-  204. io2.IO.socketReceive.impl : Socket
+  204. io2.IO.socketPort.impl : Socket ->{IO} Either Failure Nat
+  205. io2.IO.socketReceive.impl : Socket
                                    -> Nat
                                    ->{IO} Either Failure Bytes
-  205. io2.IO.socketSend.impl : Socket
+  206. io2.IO.socketSend.impl : Socket
                                 -> Bytes
                                 ->{IO} Either Failure ()
-  206. io2.IO.stdHandle : StdHandle -> Handle
-  207. io2.IO.systemTime.impl : '{IO} Either Failure Nat
-  208. io2.IO.systemTimeMicroseconds : '{IO} Int
-  209. unique type io2.IOError
-  210. io2.IOError.AlreadyExists : IOError
-  211. io2.IOError.EOF : IOError
-  212. io2.IOError.IllegalOperation : IOError
-  213. io2.IOError.NoSuchThing : IOError
-  214. io2.IOError.PermissionDenied : IOError
-  215. io2.IOError.ResourceBusy : IOError
-  216. io2.IOError.ResourceExhausted : IOError
-  217. io2.IOError.UserError : IOError
-  218. unique type io2.IOFailure
-  219. builtin type io2.MVar
-  220. io2.MVar.isEmpty : MVar a ->{IO} Boolean
-  221. io2.MVar.new : a ->{IO} MVar a
-  222. io2.MVar.newEmpty : '{IO} MVar a
-  223. io2.MVar.put.impl : MVar a -> a ->{IO} Either Failure ()
-  224. io2.MVar.read.impl : MVar a ->{IO} Either Failure a
-  225. io2.MVar.swap.impl : MVar a -> a ->{IO} Either Failure a
-  226. io2.MVar.take.impl : MVar a ->{IO} Either Failure a
-  227. io2.MVar.tryPut.impl : MVar a
+  207. io2.IO.stdHandle : StdHandle -> Handle
+  208. io2.IO.systemTime.impl : '{IO} Either Failure Nat
+  209. io2.IO.systemTimeMicroseconds : '{IO} Int
+  210. unique type io2.IOError
+  211. io2.IOError.AlreadyExists : IOError
+  212. io2.IOError.EOF : IOError
+  213. io2.IOError.IllegalOperation : IOError
+  214. io2.IOError.NoSuchThing : IOError
+  215. io2.IOError.PermissionDenied : IOError
+  216. io2.IOError.ResourceBusy : IOError
+  217. io2.IOError.ResourceExhausted : IOError
+  218. io2.IOError.UserError : IOError
+  219. unique type io2.IOFailure
+  220. builtin type io2.MVar
+  221. io2.MVar.isEmpty : MVar a ->{IO} Boolean
+  222. io2.MVar.new : a ->{IO} MVar a
+  223. io2.MVar.newEmpty : '{IO} MVar a
+  224. io2.MVar.put.impl : MVar a -> a ->{IO} Either Failure ()
+  225. io2.MVar.read.impl : MVar a ->{IO} Either Failure a
+  226. io2.MVar.swap.impl : MVar a -> a ->{IO} Either Failure a
+  227. io2.MVar.take.impl : MVar a ->{IO} Either Failure a
+  228. io2.MVar.tryPut.impl : MVar a
                               -> a
                               ->{IO} Either Failure Boolean
-  228. io2.MVar.tryRead.impl : MVar a
+  229. io2.MVar.tryRead.impl : MVar a
                                ->{IO} Either
                                  Failure (Optional a)
-  229. io2.MVar.tryTake : MVar a ->{IO} Optional a
-  230. unique type io2.SeekMode
-  231. io2.SeekMode.AbsoluteSeek : SeekMode
-  232. io2.SeekMode.RelativeSeek : SeekMode
-  233. io2.SeekMode.SeekFromEnd : SeekMode
-  234. builtin type io2.Socket
-  235. unique type io2.StdHandle
-  236. io2.StdHandle.StdErr : StdHandle
-  237. io2.StdHandle.StdIn : StdHandle
-  238. io2.StdHandle.StdOut : StdHandle
-  239. builtin type io2.STM
-  240. io2.STM.atomically : '{STM} a ->{IO} a
-  241. io2.STM.retry : '{STM} a
-  242. builtin type io2.ThreadId
-  243. builtin type io2.Tls
-  244. builtin type io2.Tls.Cipher
-  245. builtin type io2.Tls.ClientConfig
-  246. io2.Tls.ClientConfig.certificates.set : [SignedCert]
+  230. io2.MVar.tryTake : MVar a ->{IO} Optional a
+  231. unique type io2.SeekMode
+  232. io2.SeekMode.AbsoluteSeek : SeekMode
+  233. io2.SeekMode.RelativeSeek : SeekMode
+  234. io2.SeekMode.SeekFromEnd : SeekMode
+  235. builtin type io2.Socket
+  236. unique type io2.StdHandle
+  237. io2.StdHandle.StdErr : StdHandle
+  238. io2.StdHandle.StdIn : StdHandle
+  239. io2.StdHandle.StdOut : StdHandle
+  240. builtin type io2.STM
+  241. io2.STM.atomically : '{STM} a ->{IO} a
+  242. io2.STM.retry : '{STM} a
+  243. builtin type io2.ThreadId
+  244. builtin type io2.Tls
+  245. builtin type io2.Tls.Cipher
+  246. builtin type io2.Tls.ClientConfig
+  247. io2.Tls.ClientConfig.certificates.set : [SignedCert]
                                                -> ClientConfig
                                                -> ClientConfig
-  247. io2.TLS.ClientConfig.ciphers.set : [Cipher]
+  248. io2.TLS.ClientConfig.ciphers.set : [Cipher]
                                           -> ClientConfig
                                           -> ClientConfig
-  248. io2.Tls.ClientConfig.default : Text
+  249. io2.Tls.ClientConfig.default : Text
                                       -> Bytes
                                       -> ClientConfig
-  249. io2.Tls.ClientConfig.versions.set : [Version]
+  250. io2.Tls.ClientConfig.versions.set : [Version]
                                            -> ClientConfig
                                            -> ClientConfig
-  250. io2.Tls.decodeCert.impl : Bytes
+  251. io2.Tls.decodeCert.impl : Bytes
                                  -> Either Failure SignedCert
-  251. io2.Tls.decodePrivateKey : Bytes -> [PrivateKey]
-  252. io2.Tls.encodeCert : SignedCert -> Bytes
-  253. io2.Tls.encodePrivateKey : PrivateKey -> Bytes
-  254. io2.Tls.handshake.impl : Tls ->{IO} Either Failure ()
-  255. io2.Tls.newClient.impl : ClientConfig
+  252. io2.Tls.decodePrivateKey : Bytes -> [PrivateKey]
+  253. io2.Tls.encodeCert : SignedCert -> Bytes
+  254. io2.Tls.encodePrivateKey : PrivateKey -> Bytes
+  255. io2.Tls.handshake.impl : Tls ->{IO} Either Failure ()
+  256. io2.Tls.newClient.impl : ClientConfig
                                 -> Socket
                                 ->{IO} Either Failure Tls
-  256. io2.Tls.newServer.impl : ServerConfig
+  257. io2.Tls.newServer.impl : ServerConfig
                                 -> Socket
                                 ->{IO} Either Failure Tls
-  257. builtin type io2.Tls.PrivateKey
-  258. io2.Tls.receive.impl : Tls ->{IO} Either Failure Bytes
-  259. io2.Tls.send.impl : Tls -> Bytes ->{IO} Either Failure ()
-  260. builtin type io2.Tls.ServerConfig
-  261. io2.Tls.ServerConfig.certificates.set : [SignedCert]
+  258. builtin type io2.Tls.PrivateKey
+  259. io2.Tls.receive.impl : Tls ->{IO} Either Failure Bytes
+  260. io2.Tls.send.impl : Tls -> Bytes ->{IO} Either Failure ()
+  261. builtin type io2.Tls.ServerConfig
+  262. io2.Tls.ServerConfig.certificates.set : [SignedCert]
                                                -> ServerConfig
                                                -> ServerConfig
-  262. io2.Tls.ServerConfig.ciphers.set : [Cipher]
+  263. io2.Tls.ServerConfig.ciphers.set : [Cipher]
                                           -> ServerConfig
                                           -> ServerConfig
-  263. io2.Tls.ServerConfig.default : [SignedCert]
+  264. io2.Tls.ServerConfig.default : [SignedCert]
                                       -> PrivateKey
                                       -> ServerConfig
-  264. io2.Tls.ServerConfig.versions.set : [Version]
+  265. io2.Tls.ServerConfig.versions.set : [Version]
                                            -> ServerConfig
                                            -> ServerConfig
-  265. builtin type io2.Tls.SignedCert
-  266. io2.Tls.terminate.impl : Tls ->{IO} Either Failure ()
-  267. builtin type io2.Tls.Version
-  268. unique type io2.TlsFailure
-  269. builtin type io2.TVar
-  270. io2.TVar.new : a ->{STM} TVar a
-  271. io2.TVar.newIO : a ->{IO} TVar a
-  272. io2.TVar.read : TVar a ->{STM} a
-  273. io2.TVar.readIO : TVar a ->{IO} a
-  274. io2.TVar.swap : TVar a -> a ->{STM} a
-  275. io2.TVar.write : TVar a -> a ->{STM} ()
-  276. io2.validateSandboxed : [Term] -> a -> Boolean
-  277. unique type IsPropagated
-  278. IsPropagated.IsPropagated : IsPropagated
-  279. unique type IsTest
-  280. IsTest.IsTest : IsTest
-  281. unique type Link
-  282. builtin type Link.Term
-  283. Link.Term : Term -> Link
-  284. Link.Term.toText : Term -> Text
-  285. builtin type Link.Type
-  286. Link.Type : Type -> Link
-  287. builtin type List
-  288. List.++ : [a] -> [a] -> [a]
-  289. List.+: : a -> [a] -> [a]
-  290. List.:+ : [a] -> a -> [a]
-  291. List.at : Nat -> [a] -> Optional a
-  292. List.cons : a -> [a] -> [a]
-  293. List.drop : Nat -> [a] -> [a]
-  294. List.empty : [a]
-  295. List.size : [a] -> Nat
-  296. List.snoc : [a] -> a -> [a]
-  297. List.take : Nat -> [a] -> [a]
-  298. metadata.isPropagated : IsPropagated
-  299. metadata.isTest : IsTest
-  300. builtin type Nat
-  301. Nat.* : Nat -> Nat -> Nat
-  302. Nat.+ : Nat -> Nat -> Nat
-  303. Nat./ : Nat -> Nat -> Nat
-  304. Nat.and : Nat -> Nat -> Nat
-  305. Nat.complement : Nat -> Nat
-  306. Nat.drop : Nat -> Nat -> Nat
-  307. Nat.eq : Nat -> Nat -> Boolean
-  308. Nat.fromText : Text -> Optional Nat
-  309. Nat.gt : Nat -> Nat -> Boolean
-  310. Nat.gteq : Nat -> Nat -> Boolean
-  311. Nat.increment : Nat -> Nat
-  312. Nat.isEven : Nat -> Boolean
-  313. Nat.isOdd : Nat -> Boolean
-  314. Nat.leadingZeros : Nat -> Nat
-  315. Nat.lt : Nat -> Nat -> Boolean
-  316. Nat.lteq : Nat -> Nat -> Boolean
-  317. Nat.mod : Nat -> Nat -> Nat
-  318. Nat.or : Nat -> Nat -> Nat
-  319. Nat.popCount : Nat -> Nat
-  320. Nat.pow : Nat -> Nat -> Nat
-  321. Nat.shiftLeft : Nat -> Nat -> Nat
-  322. Nat.shiftRight : Nat -> Nat -> Nat
-  323. Nat.sub : Nat -> Nat -> Int
-  324. Nat.toFloat : Nat -> Float
-  325. Nat.toInt : Nat -> Int
-  326. Nat.toText : Nat -> Text
-  327. Nat.trailingZeros : Nat -> Nat
-  328. Nat.xor : Nat -> Nat -> Nat
-  329. structural type Optional a
-  330. Optional.None : Optional a
-  331. Optional.Some : a -> Optional a
-  332. builtin type Ref
-  333. Ref.read : Ref g a ->{g} a
-  334. Ref.write : Ref g a -> a ->{g} ()
-  335. builtin type Request
-  336. builtin type Scope
-  337. Scope.ref : a ->{Scope s} Ref {Scope s} a
-  338. Scope.run : (∀ s. '{g, Scope s} r) ->{g} r
-  339. structural type SeqView a b
-  340. SeqView.VElem : a -> b -> SeqView a b
-  341. SeqView.VEmpty : SeqView a b
-  342. Socket.toText : Socket -> Text
-  343. unique type Test.Result
-  344. Test.Result.Fail : Text -> Result
-  345. Test.Result.Ok : Text -> Result
-  346. builtin type Text
-  347. Text.!= : Text -> Text -> Boolean
-  348. Text.++ : Text -> Text -> Text
-  349. Text.drop : Nat -> Text -> Text
-  350. Text.empty : Text
-  351. Text.eq : Text -> Text -> Boolean
-  352. Text.fromCharList : [Char] -> Text
-  353. Text.fromUtf8.impl : Bytes -> Either Failure Text
-  354. Text.gt : Text -> Text -> Boolean
-  355. Text.gteq : Text -> Text -> Boolean
-  356. Text.lt : Text -> Text -> Boolean
-  357. Text.lteq : Text -> Text -> Boolean
-  358. Text.repeat : Nat -> Text -> Text
-  359. Text.size : Text -> Nat
-  360. Text.take : Nat -> Text -> Text
-  361. Text.toCharList : Text -> [Char]
-  362. Text.toUtf8 : Text -> Bytes
-  363. Text.uncons : Text -> Optional (Char, Text)
-  364. Text.unsnoc : Text -> Optional (Text, Char)
-  365. ThreadId.toText : ThreadId -> Text
-  366. todo : a -> b
-  367. structural type Tuple a b
-  368. Tuple.Cons : a -> b -> Tuple a b
-  369. structural type Unit
-  370. Unit.Unit : ()
-  371. Universal.< : a -> a -> Boolean
-  372. Universal.<= : a -> a -> Boolean
-  373. Universal.== : a -> a -> Boolean
-  374. Universal.> : a -> a -> Boolean
-  375. Universal.>= : a -> a -> Boolean
-  376. Universal.compare : a -> a -> Int
-  377. unsafe.coerceAbilities : (a ->{e1} b) -> a ->{e2} b
-  378. builtin type Value
-  379. Value.dependencies : Value -> [Term]
-  380. Value.deserialize : Bytes -> Either Text Value
-  381. Value.load : Value ->{IO} Either [Term] a
-  382. Value.serialize : Value -> Bytes
-  383. Value.value : a -> Value
+  266. builtin type io2.Tls.SignedCert
+  267. io2.Tls.terminate.impl : Tls ->{IO} Either Failure ()
+  268. builtin type io2.Tls.Version
+  269. unique type io2.TlsFailure
+  270. builtin type io2.TVar
+  271. io2.TVar.new : a ->{STM} TVar a
+  272. io2.TVar.newIO : a ->{IO} TVar a
+  273. io2.TVar.read : TVar a ->{STM} a
+  274. io2.TVar.readIO : TVar a ->{IO} a
+  275. io2.TVar.swap : TVar a -> a ->{STM} a
+  276. io2.TVar.write : TVar a -> a ->{STM} ()
+  277. io2.validateSandboxed : [Term] -> a -> Boolean
+  278. unique type IsPropagated
+  279. IsPropagated.IsPropagated : IsPropagated
+  280. unique type IsTest
+  281. IsTest.IsTest : IsTest
+  282. unique type Link
+  283. builtin type Link.Term
+  284. Link.Term : Term -> Link
+  285. Link.Term.toText : Term -> Text
+  286. builtin type Link.Type
+  287. Link.Type : Type -> Link
+  288. builtin type List
+  289. List.++ : [a] -> [a] -> [a]
+  290. List.+: : a -> [a] -> [a]
+  291. List.:+ : [a] -> a -> [a]
+  292. List.at : Nat -> [a] -> Optional a
+  293. List.cons : a -> [a] -> [a]
+  294. List.drop : Nat -> [a] -> [a]
+  295. List.empty : [a]
+  296. List.size : [a] -> Nat
+  297. List.snoc : [a] -> a -> [a]
+  298. List.take : Nat -> [a] -> [a]
+  299. metadata.isPropagated : IsPropagated
+  300. metadata.isTest : IsTest
+  301. builtin type Nat
+  302. Nat.* : Nat -> Nat -> Nat
+  303. Nat.+ : Nat -> Nat -> Nat
+  304. Nat./ : Nat -> Nat -> Nat
+  305. Nat.and : Nat -> Nat -> Nat
+  306. Nat.complement : Nat -> Nat
+  307. Nat.drop : Nat -> Nat -> Nat
+  308. Nat.eq : Nat -> Nat -> Boolean
+  309. Nat.fromText : Text -> Optional Nat
+  310. Nat.gt : Nat -> Nat -> Boolean
+  311. Nat.gteq : Nat -> Nat -> Boolean
+  312. Nat.increment : Nat -> Nat
+  313. Nat.isEven : Nat -> Boolean
+  314. Nat.isOdd : Nat -> Boolean
+  315. Nat.leadingZeros : Nat -> Nat
+  316. Nat.lt : Nat -> Nat -> Boolean
+  317. Nat.lteq : Nat -> Nat -> Boolean
+  318. Nat.mod : Nat -> Nat -> Nat
+  319. Nat.or : Nat -> Nat -> Nat
+  320. Nat.popCount : Nat -> Nat
+  321. Nat.pow : Nat -> Nat -> Nat
+  322. Nat.shiftLeft : Nat -> Nat -> Nat
+  323. Nat.shiftRight : Nat -> Nat -> Nat
+  324. Nat.sub : Nat -> Nat -> Int
+  325. Nat.toFloat : Nat -> Float
+  326. Nat.toInt : Nat -> Int
+  327. Nat.toText : Nat -> Text
+  328. Nat.trailingZeros : Nat -> Nat
+  329. Nat.xor : Nat -> Nat -> Nat
+  330. structural type Optional a
+  331. Optional.None : Optional a
+  332. Optional.Some : a -> Optional a
+  333. builtin type Ref
+  334. Ref.read : Ref g a ->{g} a
+  335. Ref.write : Ref g a -> a ->{g} ()
+  336. builtin type Request
+  337. builtin type Scope
+  338. Scope.ref : a ->{Scope s} Ref {Scope s} a
+  339. Scope.run : (∀ s. '{g, Scope s} r) ->{g} r
+  340. structural type SeqView a b
+  341. SeqView.VElem : a -> b -> SeqView a b
+  342. SeqView.VEmpty : SeqView a b
+  343. Socket.toText : Socket -> Text
+  344. unique type Test.Result
+  345. Test.Result.Fail : Text -> Result
+  346. Test.Result.Ok : Text -> Result
+  347. builtin type Text
+  348. Text.!= : Text -> Text -> Boolean
+  349. Text.++ : Text -> Text -> Text
+  350. Text.drop : Nat -> Text -> Text
+  351. Text.empty : Text
+  352. Text.eq : Text -> Text -> Boolean
+  353. Text.fromCharList : [Char] -> Text
+  354. Text.fromUtf8.impl : Bytes -> Either Failure Text
+  355. Text.gt : Text -> Text -> Boolean
+  356. Text.gteq : Text -> Text -> Boolean
+  357. Text.lt : Text -> Text -> Boolean
+  358. Text.lteq : Text -> Text -> Boolean
+  359. Text.repeat : Nat -> Text -> Text
+  360. Text.size : Text -> Nat
+  361. Text.take : Nat -> Text -> Text
+  362. Text.toCharList : Text -> [Char]
+  363. Text.toUtf8 : Text -> Bytes
+  364. Text.uncons : Text -> Optional (Char, Text)
+  365. Text.unsnoc : Text -> Optional (Text, Char)
+  366. ThreadId.toText : ThreadId -> Text
+  367. todo : a -> b
+  368. structural type Tuple a b
+  369. Tuple.Cons : a -> b -> Tuple a b
+  370. structural type Unit
+  371. Unit.Unit : ()
+  372. Universal.< : a -> a -> Boolean
+  373. Universal.<= : a -> a -> Boolean
+  374. Universal.== : a -> a -> Boolean
+  375. Universal.> : a -> a -> Boolean
+  376. Universal.>= : a -> a -> Boolean
+  377. Universal.compare : a -> a -> Int
+  378. unsafe.coerceAbilities : (a ->{e1} b) -> a ->{e2} b
+  379. builtin type Value
+  380. Value.dependencies : Value -> [Term]
+  381. Value.deserialize : Bytes -> Either Text Value
+  382. Value.load : Value ->{IO} Either [Term] a
+  383. Value.serialize : Value -> Bytes
+  384. Value.value : a -> Value
   
 
 .builtin> alias.many 94-104 .mylib

--- a/unison-src/transcripts/builtins-merge.output.md
+++ b/unison-src/transcripts/builtins-merge.output.md
@@ -64,7 +64,7 @@ The `builtins.merge` command adds the known builtins to a `builtin` subnamespace
   53. Value/        (5 definitions)
   54. bug           (a -> b)
   55. crypto/       (12 definitions)
-  56. io2/          (125 definitions)
+  56. io2/          (126 definitions)
   57. metadata/     (2 definitions)
   58. todo          (a -> b)
   59. unsafe/       (1 definition)

--- a/unison-src/transcripts/emptyCodebase.output.md
+++ b/unison-src/transcripts/emptyCodebase.output.md
@@ -23,7 +23,7 @@ Technically, the definitions all exist, but they have no names. `builtins.merge`
 
 .foo> ls
 
-  1. builtin/ (383 definitions)
+  1. builtin/ (384 definitions)
 
 ```
 And for a limited time, you can get even more builtin goodies:
@@ -35,7 +35,7 @@ And for a limited time, you can get even more builtin goodies:
 
 .foo> ls
 
-  1. builtin/ (569 definitions)
+  1. builtin/ (570 definitions)
 
 ```
 More typically, you'd start out by pulling `base.

--- a/unison-src/transcripts/io.output.md
+++ b/unison-src/transcripts/io.output.md
@@ -158,6 +158,96 @@ testOpenClose _ =
   Tip: Use view testOpenClose to view the source of a test.
 
 ```
+### Reading files with getSomeBytes
+
+Tests: getSomeBytes
+       putBytes
+       isFileOpen
+       seekHandle
+
+```unison
+testGetSomeBytes : '{io2.IO} [Result]
+testGetSomeBytes _ =
+  test = 'let
+    tempDir = (newTempDir "getSomeBytes")
+    fooFile = tempDir ++ "/foo"
+
+    testData = "0123456789"
+    testSize = size testData
+
+    chunkSize = 7
+    check "chunk size splits data into 2 uneven sides" ((chunkSize > (testSize / 2)) && (chunkSize < testSize))
+
+
+    -- write testData to a temporary file
+    fooWrite = openFile fooFile Write
+    putBytes fooWrite (toUtf8 testData)
+    closeFile fooWrite
+    check "file should be closed" (not (isFileOpen fooWrite))
+
+    -- reopen for reading back the data in chunks
+    fooRead = openFile fooFile Read
+
+    -- read first part of file
+    chunk1 = getSomeBytes fooRead chunkSize |> fromUtf8
+    check "first chunk matches first part of testData" (chunk1 == take chunkSize testData)
+
+    -- read rest of file
+    chunk2 = getSomeBytes fooRead chunkSize |> fromUtf8
+    check "second chunk matches rest of testData" (chunk2 == drop chunkSize testData)
+
+    check "should be at end of file" (isFileEOF fooRead)
+
+    readAtEOF = getSomeBytes fooRead chunkSize
+    check "reading at end of file results in Bytes.empty" (readAtEOF == Bytes.empty)
+
+    -- request many bytes from the start of the file
+    seekHandle fooRead AbsoluteSeek +0
+    bigRead = getSomeBytes fooRead (testSize * 999) |> fromUtf8
+    check "requesting many bytes results in what's available" (bigRead == testData)
+
+    closeFile fooRead
+    check "file should be closed" (not (isFileOpen fooRead))
+
+  runTest test
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      testGetSomeBytes : '{IO} [Result]
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    testGetSomeBytes : '{IO} [Result]
+
+.> io.test testGetSomeBytes
+
+    New test results:
+  
+  ◉ testGetSomeBytes   chunk size splits data into 2 uneven sides
+  ◉ testGetSomeBytes   file should be closed
+  ◉ testGetSomeBytes   first chunk matches first part of testData
+  ◉ testGetSomeBytes   second chunk matches rest of testData
+  ◉ testGetSomeBytes   should be at end of file
+  ◉ testGetSomeBytes   reading at end of file results in Bytes.empty
+  ◉ testGetSomeBytes   requesting many bytes results in what's available
+  ◉ testGetSomeBytes   file should be closed
+  
+  ✅ 8 test(s) passing
+  
+  Tip: Use view testGetSomeBytes to view the source of a test.
+
+```
 ### Seeking in open files
 
 Tests: openFile

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -125,13 +125,13 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #6meejv5nn9
+  ⊙ 1. #j1lsljjhdd
   
     - Deletes:
     
       feature1.y
   
-  ⊙ 2. #jiaec3stf0
+  ⊙ 2. #r969k3jgve
   
     + Adds / updates:
     
@@ -142,26 +142,26 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
       Original name New name(s)
       feature1.y    master.y
   
-  ⊙ 3. #oi6qeaaasg
+  ⊙ 3. #0gi7v0d7tu
   
     + Adds / updates:
     
       feature1.y
   
-  ⊙ 4. #s0e9mj6462
+  ⊙ 4. #2nqtlij18m
   
     > Moves:
     
       Original name New name
       x             master.x
   
-  ⊙ 5. #uiim9cuh1n
+  ⊙ 5. #heict59ifr
   
     + Adds / updates:
     
       x
   
-  □ 6. #8oo4auc4cv (start of history)
+  □ 6. #pnv2a0gkq2 (start of history)
 
 ```
 To resurrect an old version of a namespace, you can learn its hash via the `history` command, then use `fork #namespacehash .newname`.

--- a/unison-src/transcripts/reflog.output.md
+++ b/unison-src/transcripts/reflog.output.md
@@ -59,16 +59,16 @@ y = 2
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #n5s5u3ncj8 .old`   to make an old namespace
+    `fork #252vcd822j .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #n5s5u3ncj8`  to reset the root namespace and
+    `reset-root #252vcd822j`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
-  1. #tv14d51d4l : add
-  2. #n5s5u3ncj8 : add
-  3. #8oo4auc4cv : builtins.merge
+  1. #1svuebjsh1 : add
+  2. #252vcd822j : add
+  3. #pnv2a0gkq2 : builtins.merge
   4. #sg60bvjo91 : (initial reflogged namespace)
 
 ```

--- a/unison-src/transcripts/squash.output.md
+++ b/unison-src/transcripts/squash.output.md
@@ -13,7 +13,7 @@ Let's look at some examples. We'll start with a namespace with just the builtins
   
   
   
-  □ 1. #soipbkdq9m (start of history)
+  □ 1. #aktpkdqc1d (start of history)
 
 .> fork builtin builtin2
 
@@ -42,21 +42,21 @@ Now suppose we `fork` a copy of builtin, then rename `Nat.+` to `frobnicate`, th
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #u2acmt4ut5
+  ⊙ 1. #su54dhbbgp
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ 2. #tq3np8qtmn
+  ⊙ 2. #nhe50pjji2
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ 3. #soipbkdq9m (start of history)
+  □ 3. #aktpkdqc1d (start of history)
 
 ```
 If we merge that back into `builtin`, we get that same chain of history:
@@ -71,21 +71,21 @@ If we merge that back into `builtin`, we get that same chain of history:
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #u2acmt4ut5
+  ⊙ 1. #su54dhbbgp
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ 2. #tq3np8qtmn
+  ⊙ 2. #nhe50pjji2
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ 3. #soipbkdq9m (start of history)
+  □ 3. #aktpkdqc1d (start of history)
 
 ```
 Let's try again, but using a `merge.squash` (or just `squash`) instead. The history will be unchanged:
@@ -106,7 +106,7 @@ Let's try again, but using a `merge.squash` (or just `squash`) instead. The hist
   
   
   
-  □ 1. #soipbkdq9m (start of history)
+  □ 1. #aktpkdqc1d (start of history)
 
 ```
 The churn that happened in `mybuiltin` namespace ended up back in the same spot, so the squash merge of that namespace with our original namespace had no effect.
@@ -485,13 +485,13 @@ This checks to see that squashing correctly preserves deletions:
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #n48gujdtqf
+  ⊙ 1. #bl7pg3asuu
   
     - Deletes:
     
       Nat.* Nat.+
   
-  □ 2. #soipbkdq9m (start of history)
+  □ 2. #aktpkdqc1d (start of history)
 
 ```
 Notice that `Nat.+` and `Nat.*` are deleted by the squash, and we see them deleted in one atomic step in the history.


### PR DESCRIPTION
## Overview

This change adds a new built-in `io.getSomeBytes.impl` to read bytes from handle with less blocking than `io.getBytes`.

The existing builtin `io.getBytes` reads up to `n` bytes from a handle, blocking until it gets either that many bytes or `EOF`. `io.getSomeBytes` is similar but only blocks if there's nothing to read and it's not at `EOF`.

This allows you to read from a buffer like stdin without knowing ahead of time how much data there is to read. stdin won't give you an `EOF` unless it's closed so `getBytes` would always block if you asked for too many bytes. You can't parse ANSI control codes from stdin without some lookahead. (for example: the escape key is `\ESC` and the up arrow is `\ESC[A`. if you see the first `\ESC` byte you can't tell if there's more you should read without trying and potentially blocking)

## Demo

The `main` term in the root of this namespace reads input from stdin and prints the individual characters that make up any control codes:

`pull git@github.com:iamevn/unison-code:gists:#srgs6d0pp2`

![image](https://user-images.githubusercontent.com/5936748/161653689-7a4bf420-2fb7-4ea5-aa1f-367cdd00d4ac.png)

(Sorry it's a bit messy, hacked it together while playing with ANSI stuff.)

## Implementation notes

This is implemented using [`hGetSome`](https://hackage.haskell.org/package/bytestring-0.11.3.0/docs/Data-ByteString.html#v:hGetSome) where `getBytes` used [`hGet`](https://hackage.haskell.org/package/bytestring-0.11.3.0/docs/Data-ByteString.html#v:hGet).

## Interesting/controversial decisions

The name sort of collides with `Optional.Some` in a way I don't like. I just matched the name of the analguous function in the Haskell Data.ByteString package. Open to any suggestions.

Could also add `io.getBytesNonBlocking` (using [`hGetNonBlocking`](https://hackage.haskell.org/package/bytestring-0.11.3.0/docs/Data-ByteString.html#v:hGetNonBlocking)) which would return `Bytes.empty` if there's nothing to read (`io.getSomeBytes` would block until there's something to read or `EOF`). If it seems like a good addition it'd be trivial to add.

## Test coverage

I added a section to the io transcript for this that reads various chunk sizes from a test file.

Not sure how to wire up a test that uses a non-seekable buffer like stdin and I'm not familiar enough with how to use `fork` to have a test with reading and writing happening at the same time. Neither seem like they are worth the effort to add imo.

Not sure if tests should do anything with the handle's buffering mode.


## Loose ends

PR against base v3 here: unisonweb/base#91

