### PR TITLE
Make POp serialization more reliable

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/ANF.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF.hs
@@ -822,6 +822,10 @@ litRef (C _) = Ty.charRef
 litRef (LM _) = Ty.termLinkRef
 litRef (LY _) = Ty.typeLinkRef
 
+-- Note: Enum/Bounded instances should only be used for things like
+-- getting a list of all ops. Using auto-generated numberings for
+-- serialization, for instance, could cause observable changes to
+-- formats that we want to control and version.
 data POp
   = -- Int
     ADDI
@@ -954,7 +958,7 @@ data POp
   | TRCE
   | -- STM
     ATOM
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Enum, Bounded)
 
 type ANormal = ABTN.Term ANormalF
 

--- a/parser-typechecker/src/Unison/Runtime/ANF/Serialize.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF/Serialize.hs
@@ -403,7 +403,7 @@ getFunc ctx =
 putPOp :: MonadPut m => POp -> m ()
 putPOp op
   | Just w <- Map.lookup op pop2word = putWord16be w
-  | otherwise = exn "putPOp: unknown POp"
+  | otherwise = exn $ "putPOp: unknown POp: " ++ show op
 
 getPOp :: MonadGet m => m POp
 getPOp =
@@ -411,116 +411,129 @@ getPOp =
     Just op -> pure op
     Nothing -> exn "getPOp: unknown enum code"
 
+pOpCode :: POp -> Word16
+pOpCode op = case op of
+  ADDI -> 0
+  SUBI -> 1
+  MULI -> 2
+  DIVI -> 3
+  SGNI -> 4
+  NEGI -> 5
+  MODI -> 6
+  POWI -> 7
+  SHLI -> 8
+  SHRI -> 9
+  INCI -> 10
+  DECI -> 11
+  LEQI -> 12
+  EQLI -> 13
+  ADDN -> 14
+  SUBN -> 15
+  MULN -> 16
+  DIVN -> 17
+  MODN -> 18
+  TZRO -> 19
+  LZRO -> 20
+  POWN -> 21
+  SHLN -> 22
+  SHRN -> 23
+  ANDN -> 24
+  IORN -> 25
+  XORN -> 26
+  COMN -> 27
+  INCN -> 28
+  DECN -> 29
+  LEQN -> 30
+  EQLN -> 31
+  ADDF -> 32
+  SUBF -> 33
+  MULF -> 34
+  DIVF -> 35
+  MINF -> 36
+  MAXF -> 37
+  LEQF -> 38
+  EQLF -> 39
+  POWF -> 40
+  EXPF -> 41
+  SQRT -> 42
+  LOGF -> 43
+  LOGB -> 44
+  ABSF -> 45
+  CEIL -> 46
+  FLOR -> 47
+  TRNF -> 48
+  RNDF -> 49
+  COSF -> 50
+  ACOS -> 51
+  COSH -> 52
+  ACSH -> 53
+  SINF -> 54
+  ASIN -> 55
+  SINH -> 56
+  ASNH -> 57
+  TANF -> 58
+  ATAN -> 59
+  TANH -> 60
+  ATNH -> 61
+  ATN2 -> 62
+  CATT -> 63
+  TAKT -> 64
+  DRPT -> 65
+  SIZT -> 66
+  UCNS -> 67
+  USNC -> 68
+  EQLT -> 69
+  LEQT -> 70
+  PAKT -> 71
+  UPKT -> 72
+  CATS -> 73
+  TAKS -> 74
+  DRPS -> 75
+  SIZS -> 76
+  CONS -> 77
+  SNOC -> 78
+  IDXS -> 79
+  BLDS -> 80
+  VWLS -> 81
+  VWRS -> 82
+  SPLL -> 83
+  SPLR -> 84
+  PAKB -> 85
+  UPKB -> 86
+  TAKB -> 87
+  DRPB -> 88
+  IDXB -> 89
+  SIZB -> 90
+  FLTB -> 91
+  CATB -> 92
+  ITOF -> 93
+  NTOF -> 94
+  ITOT -> 95
+  NTOT -> 96
+  TTOI -> 97
+  TTON -> 98
+  TTOF -> 99
+  FTOT -> 100
+  FORK -> 101
+  EQLU -> 102
+  CMPU -> 103
+  EROR -> 104
+  PRNT -> 105
+  INFO -> 106
+  POPC -> 107
+  MISS -> 108
+  CACH -> 109
+  LKUP -> 110
+  LOAD -> 111
+  CVLD -> 112
+  SDBX -> 113
+  VALU -> 114
+  TLTT -> 115
+  TRCE -> 116
+  ATOM -> 117
+
 pOpAssoc :: [(POp, Word16)]
-pOpAssoc =
-  [ (ADDI, 0),
-    (SUBI, 1),
-    (MULI, 2),
-    (DIVI, 3),
-    (SGNI, 4),
-    (NEGI, 5),
-    (MODI, 6),
-    (POWI, 7),
-    (SHLI, 8),
-    (SHRI, 9),
-    (INCI, 10),
-    (DECI, 11),
-    (LEQI, 12),
-    (EQLI, 13),
-    (ADDN, 14),
-    (SUBN, 15),
-    (MULN, 16),
-    (DIVN, 17),
-    (MODN, 18),
-    (TZRO, 19),
-    (LZRO, 20),
-    (POWN, 21),
-    (SHLN, 22),
-    (SHRN, 23),
-    (ANDN, 24),
-    (IORN, 25),
-    (XORN, 26),
-    (COMN, 27),
-    (INCN, 28),
-    (DECN, 29),
-    (LEQN, 30),
-    (EQLN, 31),
-    (ADDF, 32),
-    (SUBF, 33),
-    (MULF, 34),
-    (DIVF, 35),
-    (MINF, 36),
-    (MAXF, 37),
-    (LEQF, 38),
-    (EQLF, 39),
-    (POWF, 40),
-    (EXPF, 41),
-    (SQRT, 42),
-    (LOGF, 43),
-    (LOGB, 44),
-    (ABSF, 45),
-    (CEIL, 46),
-    (FLOR, 47),
-    (TRNF, 48),
-    (RNDF, 49),
-    (COSF, 50),
-    (ACOS, 51),
-    (COSH, 52),
-    (ACSH, 53),
-    (SINF, 54),
-    (ASIN, 55),
-    (SINH, 56),
-    (ASNH, 57),
-    (TANF, 58),
-    (ATAN, 59),
-    (TANH, 60),
-    (ATNH, 61),
-    (ATN2, 62),
-    (CATT, 63),
-    (TAKT, 64),
-    (DRPT, 65),
-    (SIZT, 66),
-    (UCNS, 67),
-    (USNC, 68),
-    (EQLT, 69),
-    (LEQT, 70),
-    (PAKT, 71),
-    (UPKT, 72),
-    (CATS, 73),
-    (TAKS, 74),
-    (DRPS, 75),
-    (SIZS, 76),
-    (CONS, 77),
-    (SNOC, 78),
-    (IDXS, 79),
-    (BLDS, 80),
-    (VWLS, 81),
-    (VWRS, 82),
-    (SPLL, 83),
-    (SPLR, 84),
-    (PAKB, 85),
-    (UPKB, 86),
-    (TAKB, 87),
-    (DRPB, 88),
-    (IDXB, 89),
-    (SIZB, 90),
-    (FLTB, 91),
-    (CATB, 92),
-    (ITOF, 93),
-    (NTOF, 94),
-    (ITOT, 95),
-    (NTOT, 96),
-    (TTOI, 97),
-    (TTON, 98),
-    (TTOF, 99),
-    (FTOT, 100),
-    (FORK, 101),
-    (EQLU, 102),
-    (CMPU, 103),
-    (EROR, 104),
-    (PRNT, 105),
-    (INFO, 106)
-  ]
+pOpAssoc = map (\op -> (op, pOpCode op)) [minBound .. maxBound]
 
 pop2word :: Map POp Word16
 pop2word = fromList pOpAssoc


### PR DESCRIPTION
There was a huge list of all the ops associated with numbers used to serialize them, but there was no way to check that every `POp` was in the list (and some were actually missing). Instead, use a function from `POp` to number so that the coverage checker can complain if a new op is added. Then the list is generated from the `Enum`/`Bounded` instances.
