### PR TITLE
Sync HTTP client

### DIFF
--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -50,6 +50,7 @@ library:
     - haskeline
     - http-types
     - http-media
+    - http-client
     - lens
     - ListLike
     - megaparsec >= 5.0.0 && < 7.0.0

--- a/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Git.hs
@@ -56,7 +56,7 @@ encodeFileName s =
       go ('$' : rem) = "$$" <> go rem
       go (c : rem)
         | elem @[] c "/\\:*?\"<>|" || not (Char.isPrint c && Char.isAscii c) =
-            "$x" <> encodeHex [c] <> "$" <> go rem
+          "$x" <> encodeHex [c] <> "$" <> go rem
         | otherwise = c : go rem
       go [] = []
       encodeHex :: String -> String

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -241,6 +241,7 @@ library
     , hashable
     , hashtables
     , haskeline
+    , http-client
     , http-media
     , http-types
     , lens

--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -54,7 +54,9 @@ dependencies:
   - lock-file
   - jwt
   - either
-
+  - unison-share-api
+  - servant-client
+  - servant
 
 library:
   source-dirs: src

--- a/unison-cli/src/Unison/Auth/HTTPClient.hs
+++ b/unison-cli/src/Unison/Auth/HTTPClient.hs
@@ -1,4 +1,4 @@
-module Unison.Auth.HTTPClient where
+module Unison.Auth.HTTPClient (newAuthorizedHTTPClient, AuthorizedHttpClient(..)) where
 
 import qualified Data.Text.Encoding as Text
 import Network.HTTP.Client (Request)
@@ -10,6 +10,9 @@ import Unison.Auth.Types
 import Unison.Codebase.Editor.Command (UCMVersion)
 import Unison.Prelude
 import qualified Unison.Util.HTTP as HTTP
+
+-- | Newtype to delineate HTTP Managers with access-token logic.
+newtype AuthorizedHttpClient = AuthorizedHttpClient HTTP.Manager
 
 -- | Returns a new http manager which applies the appropriate Authorization header to
 -- any hosts our UCM is authenticated with.

--- a/unison-cli/src/Unison/Sync/HTTP.hs
+++ b/unison-cli/src/Unison/Sync/HTTP.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Unison.Sync.HTTP
+  ( getPathHandler,
+    updatePathHandler,
+    downloadEntitiesHandler,
+    uploadEntitiesHandler,
+  )
+where
+
+import Control.Monad.Reader
+import Servant.API
+import Servant.Client
+import qualified Unison.Auth.HTTPClient as Auth
+import Unison.Prelude
+import qualified Unison.Sync.API as Sync
+import Unison.Sync.Types
+
+data SyncError
+  = ClientErr ClientError
+  deriving stock (Show)
+  deriving anyclass (Exception)
+
+getPathHandler :: Auth.AuthorizedHttpClient -> BaseUrl -> GetCausalHashByPathRequest -> IO GetCausalHashByPathResponse
+updatePathHandler :: Auth.AuthorizedHttpClient -> BaseUrl -> UpdatePathRequest -> IO UpdatePathResponse
+downloadEntitiesHandler :: Auth.AuthorizedHttpClient -> BaseUrl -> DownloadEntitiesRequest -> IO DownloadEntitiesResponse
+uploadEntitiesHandler :: Auth.AuthorizedHttpClient -> BaseUrl -> UploadEntitiesRequest -> IO UploadEntitiesResponse
+( getPathHandler,
+  updatePathHandler,
+  downloadEntitiesHandler,
+  uploadEntitiesHandler
+  ) =
+    let ( getPathHandler
+            :<|> updatePathHandler
+            :<|> downloadEntitiesHandler
+            :<|> uploadEntitiesHandler
+          ) = hoistClient Sync.api hoist (client Sync.api)
+     in (uncurryReaderT getPathHandler, uncurryReaderT updatePathHandler, uncurryReaderT downloadEntitiesHandler, uncurryReaderT uploadEntitiesHandler)
+    where
+      hoist :: forall a. ClientM a -> ReaderT (Auth.AuthorizedHttpClient, BaseUrl) IO a
+      hoist m = do
+        (Auth.AuthorizedHttpClient manager, baseUrl) <- ask
+        let clientEnv = mkClientEnv manager baseUrl
+        resp <- liftIO . throwEitherMWith ClientErr $ (runClientM m clientEnv)
+        pure resp
+
+      uncurryReaderT :: forall req resp. (req -> ReaderT (Auth.AuthorizedHttpClient, BaseUrl) IO resp) -> Auth.AuthorizedHttpClient -> BaseUrl -> req -> IO resp
+      uncurryReaderT f httpClient baseURL req =
+        runReaderT (f req) (httpClient, baseURL)

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -59,6 +59,7 @@ library
       Unison.CommandLine.Main
       Unison.CommandLine.OutputMessages
       Unison.CommandLine.Welcome
+      Unison.Sync.HTTP
       Unison.Util.HTTP
   other-modules:
       Paths_unison_cli
@@ -118,6 +119,8 @@ library
     , random >=1.2.0
     , regex-tdfa
     , semialign
+    , servant
+    , servant-client
     , stm
     , text
     , these
@@ -128,6 +131,7 @@ library
     , unison-parser-typechecker
     , unison-prelude
     , unison-pretty-printer
+    , unison-share-api
     , unison-util
     , unison-util-relation
     , unliftio
@@ -206,6 +210,8 @@ executable integration-tests
     , random >=1.2.0
     , regex-tdfa
     , semialign
+    , servant
+    , servant-client
     , shellmet
     , stm
     , text
@@ -217,6 +223,7 @@ executable integration-tests
     , unison-parser-typechecker
     , unison-prelude
     , unison-pretty-printer
+    , unison-share-api
     , unison-util
     , unison-util-relation
     , unliftio
@@ -289,6 +296,8 @@ executable transcripts
     , random >=1.2.0
     , regex-tdfa
     , semialign
+    , servant
+    , servant-client
     , shellmet
     , stm
     , text
@@ -301,6 +310,7 @@ executable transcripts
     , unison-parser-typechecker
     , unison-prelude
     , unison-pretty-printer
+    , unison-share-api
     , unison-util
     , unison-util-relation
     , unliftio
@@ -375,6 +385,8 @@ executable unison
     , random >=1.2.0
     , regex-tdfa
     , semialign
+    , servant
+    , servant-client
     , shellmet
     , stm
     , template-haskell
@@ -389,6 +401,7 @@ executable unison
     , unison-parser-typechecker
     , unison-prelude
     , unison-pretty-printer
+    , unison-share-api
     , unison-util
     , unison-util-relation
     , unliftio
@@ -468,6 +481,8 @@ test-suite tests
     , random >=1.2.0
     , regex-tdfa
     , semialign
+    , servant
+    , servant-client
     , shellmet
     , stm
     , temporary
@@ -481,6 +496,7 @@ test-suite tests
     , unison-parser-typechecker
     , unison-prelude
     , unison-pretty-printer
+    , unison-share-api
     , unison-util
     , unison-util-relation
     , unliftio

--- a/unison-share-api/src/Unison/Sync/API.hs
+++ b/unison-share-api/src/Unison/Sync/API.hs
@@ -1,9 +1,13 @@
 {-# LANGUAGE DataKinds #-}
 
-module Unison.Sync.API (API) where
+module Unison.Sync.API (API, api) where
 
+import Data.Proxy
 import Servant.API
 import Unison.Sync.Types
+
+api :: Proxy API
+api = Proxy
 
 type API =
   "path" :> "get" :> GetCausalHashByPathEndpoint
@@ -17,7 +21,7 @@ type GetCausalHashByPathEndpoint =
 
 type UpdatePathEndpoint =
   ReqBody '[JSON] UpdatePathRequest
-    :> UVerb 'POST '[JSON] '[WithStatus 204 NoContent, WithStatus 404 (NeedDependencies HashJWT), WithStatus 412 HashMismatch]
+    :> Post '[JSON] UpdatePathResponse
 
 type DownloadEntitiesEndpoint =
   ReqBody '[JSON] DownloadEntitiesRequest
@@ -25,4 +29,4 @@ type DownloadEntitiesEndpoint =
 
 type UploadEntitiesEndpoint =
   ReqBody '[JSON] UploadEntitiesRequest
-    :> UVerb 'POST '[JSON] '[WithStatus 200 NoContent, WithStatus 202 (NeedDependencies Hash)]
+    :> Post '[JSON] UploadEntitiesResponse


### PR DESCRIPTION
## Overview

More concrete (less abstracted) version of #3026 

We chatted and decided that the servant-client abstraction for multiple response types is more work than its worth. 
Our sync protocol will use Haskell-sum-types to indicate different responses, this means all calls with be POST calls, and responses will be 200 OKs, the response itself indicates whether the action was successful or if something went wrong.

## Implementation notes

* Exposes simple functions of type `AuthorizedHTTPClient -> BaseURL -> req -> IO response` for each RPC