### PR TITLE
Prepare local-ui endpoints for use in share-server

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Init.hs
+++ b/parser-typechecker/src/Unison/Codebase/Init.hs
@@ -63,6 +63,7 @@ data InitError
   = FoundV1Codebase
   | InitErrorOpen OpenCodebaseError
   | CouldntCreateCodebase Pretty
+  deriving (Show, Eq)
 
 data InitResult
   = OpenedCodebase

--- a/parser-typechecker/src/Unison/Codebase/Init/OpenCodebaseError.hs
+++ b/parser-typechecker/src/Unison/Codebase/Init/OpenCodebaseError.hs
@@ -14,5 +14,5 @@ data OpenCodebaseError
     OpenCodebaseDoesntExist
   | -- | The codebase exists, but its schema version is unknown to this application.
     OpenCodebaseUnknownSchemaVersion Word64
-  deriving stock (Show)
+  deriving stock (Show, Eq)
   deriving anyclass (Exception)

--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -490,10 +490,11 @@ decodeStandalone b = bimap thd thd $ runGetOrFail g b
         <*> getNat
         <*> getStoredCache
 
--- | Whether the runtime is hosted within a UCM session or as a standalone process.
+-- | Whether the runtime is hosted within a persistent session or as a one-off process.
+-- This affects the amount of clean-up and book-keeping the runtime does.
 data RuntimeHost
-  = Standalone
-  | UCM
+  = OneOff
+  | Persistent
 
 startRuntime :: RuntimeHost -> Text -> IO (Runtime Symbol)
 startRuntime runtimeHost version = do
@@ -501,10 +502,10 @@ startRuntime runtimeHost version = do
   (activeThreads, cleanupThreads) <- case runtimeHost of
     -- Don't bother tracking open threads when running standalone, they'll all be cleaned up
     -- when the process itself exits.
-    Standalone -> pure (Nothing, pure ())
+    OneOff -> pure (Nothing, pure ())
     -- Track all forked threads so that they can be killed when the main process returns,
     -- otherwise they'll be orphaned and left running.
-    UCM -> do
+    Persistent -> do
       activeThreads <- newIORef Set.empty
       let cleanupThreads = do
             threads <- readIORef activeThreads

--- a/parser-typechecker/tests/Unison/Test/UnisonSources.hs
+++ b/parser-typechecker/tests/Unison/Test/UnisonSources.hs
@@ -59,7 +59,7 @@ bad r = EasyTest.expectLeft r >> done
 
 test :: Test ()
 test = do
-  rt <- io (RTI.startRuntime RTI.Standalone "")
+  rt <- io (RTI.startRuntime RTI.OneOff "")
   scope "unison-src"
     . tests
     $ [ go rt shouldPassNow good,

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -2448,6 +2448,8 @@ handleBackendError :: Backend.BackendError -> Action m i v ()
 handleBackendError = \case
   Backend.NoSuchNamespace path ->
     respond . BranchNotFound $ Path.absoluteToPath' path
+  Backend.BadNamespace msg namespace ->
+    respond $ BadNamespace msg namespace
   Backend.BadRootBranch e -> respond $ BadRootBranch e
   Backend.NoBranchForHash h -> do
     sbhLength <- eval BranchHashLength

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -143,6 +143,7 @@ data Output v
   | TermAmbiguous (HQ.HashQualified Name) (Set Referent)
   | HashAmbiguous ShortHash (Set Referent)
   | BranchHashAmbiguous ShortBranchHash (Set ShortBranchHash)
+  | BadNamespace String String
   | BranchNotFound Path'
   | NameNotFound Path.HQSplit'
   | PatchNotFound Path.Split'
@@ -310,6 +311,7 @@ isFailure o = case o of
   TermAmbiguous {} -> True
   BranchHashAmbiguous {} -> True
   BadName {} -> True
+  BadNamespace {} -> True
   BranchNotFound {} -> True
   NameNotFound {} -> True
   PatchNotFound {} -> True

--- a/unison-cli/src/Unison/Codebase/TranscriptParser.hs
+++ b/unison-cli/src/Unison/Codebase/TranscriptParser.hs
@@ -159,7 +159,7 @@ withTranscriptRunner ucmVersion configFile action = do
     withRuntime :: ((Runtime.Runtime Symbol -> m a) -> m a)
     withRuntime action =
       UnliftIO.bracket
-        (liftIO $ RTI.startRuntime RTI.UCM ucmVersion)
+        (liftIO $ RTI.startRuntime RTI.Persistent ucmVersion)
         (liftIO . Runtime.terminate)
         action
     withConfig :: forall a. ((Maybe Config -> m a) -> m a)

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -798,6 +798,8 @@ notifyUser dir o = case o of
         "The file "
           <> P.blue (P.shown name)
           <> " could not be loaded."
+  BadNamespace msg path ->
+    pure . P.warnCallout $ "Invalid namespace " <> P.blue (P.string path) <> ", " <> P.string msg
   BranchNotFound b ->
     pure . P.warnCallout $ "The namespace " <> P.blue (P.shown b) <> " doesn't exist."
   CreatedNewBranch path ->

--- a/unison-cli/unison/Main.hs
+++ b/unison-cli/unison/Main.hs
@@ -107,7 +107,7 @@ main = withCP65001 do
             )
       Run (RunFromSymbol mainName) args -> do
         getCodebaseOrExit mCodePathOption \(_, _, theCodebase) -> do
-          runtime <- RTI.startRuntime RTI.Standalone Version.gitDescribeWithDate
+          runtime <- RTI.startRuntime RTI.OneOff Version.gitDescribeWithDate
           withArgs args $ execute theCodebase runtime mainName
       Run (RunFromFile file mainName) args
         | not (isDotU file) -> PT.putPrettyLn $ P.callout "⚠️" "Files must have a .u extension."
@@ -117,7 +117,7 @@ main = withCP65001 do
             Left _ -> PT.putPrettyLn $ P.callout "⚠️" "I couldn't find that file or it is for some reason unreadable."
             Right contents -> do
               getCodebaseOrExit mCodePathOption \(initRes, _, theCodebase) -> do
-                rt <- RTI.startRuntime RTI.Standalone Version.gitDescribeWithDate
+                rt <- RTI.startRuntime RTI.OneOff Version.gitDescribeWithDate
                 let fileEvent = Input.UnisonFileChanged (Text.pack file) contents
                 launch currentDir config rt theCodebase [Left fileEvent, Right $ Input.ExecuteI mainName args, Right Input.QuitI] Nothing ShouldNotDownloadBase initRes
       Run (RunFromPipe mainName) args -> do
@@ -126,7 +126,7 @@ main = withCP65001 do
           Left _ -> PT.putPrettyLn $ P.callout "⚠️" "I had trouble reading this input."
           Right contents -> do
             getCodebaseOrExit mCodePathOption \(initRes, _, theCodebase) -> do
-              rt <- RTI.startRuntime RTI.Standalone Version.gitDescribeWithDate
+              rt <- RTI.startRuntime RTI.OneOff Version.gitDescribeWithDate
               let fileEvent = Input.UnisonFileChanged (Text.pack "<standard input>") contents
               launch
                 currentDir
@@ -202,7 +202,7 @@ main = withCP65001 do
         runTranscripts renderUsageInfo shouldFork shouldSaveCodebase mCodePathOption transcriptFiles
       Launch isHeadless codebaseServerOpts downloadBase -> do
         getCodebaseOrExit mCodePathOption \(initRes, _, theCodebase) -> do
-          runtime <- RTI.startRuntime RTI.UCM Version.gitDescribeWithDate
+          runtime <- RTI.startRuntime RTI.Persistent Version.gitDescribeWithDate
           Server.startServer codebaseServerOpts runtime theCodebase $ \baseUrl -> do
             case isHeadless of
               Headless -> do

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE ApplicativeDo #-}
 
 module Unison.Server.Backend where
 
@@ -127,6 +127,11 @@ listEntryName = \case
 
 data BackendError
   = NoSuchNamespace Path.Absolute
+  | BadNamespace
+      String
+      -- ^ error message
+      String
+      -- ^ namespace
   | BadRootBranch Codebase.GetRootBranchError
   | CouldntExpandBranchHash ShortBranchHash
   | AmbiguousBranchHash ShortBranchHash (Set ShortBranchHash)
@@ -289,7 +294,7 @@ findShallowReadmeInBranchAndRender width runtime codebase printNames namespaceBr
   let ppe hqLen = PPE.fromNamesDecl hqLen printNames
 
       renderReadme ppe r = do
-        (_, _, doc) <- liftIO $ renderDoc ppe width runtime codebase (Referent.toReference r)
+        (_, _, doc) <- renderDoc ppe width runtime codebase (Referent.toReference r)
         pure doc
 
       -- allow any of these capitalizations
@@ -299,8 +304,8 @@ findShallowReadmeInBranchAndRender width runtime codebase printNames namespaceBr
         where
           lookup seg = R.lookupRan seg rel
           rel = Star3.d1 (Branch._terms (Branch.head namespaceBranch))
-   in do
-        hqLen <- liftIO $ Codebase.hashLength codebase
+   in liftIO $ do
+        hqLen <- Codebase.hashLength codebase
         traverse (renderReadme (ppe hqLen)) (Set.lookupMin readmes)
 
 isDoc :: Monad m => Codebase m Symbol Ann -> Referent -> m Bool

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -127,7 +127,8 @@ listEntryName = \case
 
 data BackendError
   = NoSuchNamespace Path.Absolute
-  | BadNamespace
+  | -- Failed to parse path
+    BadNamespace
       String
       -- ^ error message
       String

--- a/unison-share-api/src/Unison/Server/CodebaseServer.hs
+++ b/unison-share-api/src/Unison/Server/CodebaseServer.hs
@@ -39,7 +39,9 @@ import Network.Wai.Handler.Warp
     withApplicationSettings,
   )
 import Servant
-  ( MimeRender (..),
+  ( HasServer,
+    MimeRender (..),
+    ServerT,
     serve,
     throwError,
   )
@@ -69,6 +71,7 @@ import Servant.Server
     Tagged (Tagged),
     err401,
     err404,
+    hoistServer,
   )
 import Servant.Server.StaticFiles (serveDirectoryWebApp)
 import System.Directory (canonicalizePath, doesFileExist)
@@ -104,7 +107,7 @@ instance MimeRender HTML RawHtml where
 
 type OpenApiJSON = "openapi.json" :> Get '[JSON] OpenApi
 
-type DocAPI = UnisonAPI :<|> OpenApiJSON :<|> Raw
+type UnisonAndDocsAPI = UnisonAPI :<|> OpenApiJSON :<|> Raw
 
 type UnisonAPI =
   NamespaceListing.NamespaceListingAPI
@@ -115,9 +118,13 @@ type UnisonAPI =
 
 type WebUI = CaptureAll "route" Text :> Get '[HTML] RawHtml
 
-type ServerAPI = ("ui" :> WebUI) :<|> ("api" :> DocAPI)
+type ServerAPI = ("ui" :> WebUI) :<|> ("api" :> UnisonAndDocsAPI)
 
-type AuthedServerAPI = ("static" :> Raw) :<|> (Capture "token" Text :> ServerAPI)
+type StaticAPI = "static" :> Raw
+
+type Authed api = (Capture "token" Text :> api)
+
+type AppAPI = StaticAPI :<|> Authed ServerAPI
 
 instance ToSample Char where
   toSamples _ = singleSample 'x'
@@ -173,14 +180,17 @@ docsBS = mungeString . markdown $ docsWithIntros [intro] api
         (Text.unpack $ _infoTitle infoObject)
         (toList $ Text.unpack <$> _infoDescription infoObject)
 
-docAPI :: Proxy DocAPI
-docAPI = Proxy
+unisonAndDocsAPI :: Proxy UnisonAndDocsAPI
+unisonAndDocsAPI = Proxy
 
 api :: Proxy UnisonAPI
 api = Proxy
 
-serverAPI :: Proxy AuthedServerAPI
+serverAPI :: Proxy ServerAPI
 serverAPI = Proxy
+
+appAPI :: Proxy AppAPI
+appAPI = Proxy
 
 app ::
   Rt.Runtime Symbol ->
@@ -189,7 +199,7 @@ app ::
   Strict.ByteString ->
   Application
 app rt codebase uiPath expectedToken =
-  serve serverAPI $ server rt codebase uiPath expectedToken
+  serve appAPI $ server rt codebase uiPath expectedToken
 
 -- The Token is used to help prevent multiple users on a machine gain access to
 -- each others codebases.
@@ -285,31 +295,41 @@ serveIndex path = do
                   <> " environment variable to the directory where the UI is installed."
           }
 
-serveUI :: Handler () -> FilePath -> Server WebUI
-serveUI tryAuth path _ = tryAuth *> serveIndex path
+serveUI :: FilePath -> Server WebUI
+serveUI path _ = serveIndex path
 
 server ::
   Rt.Runtime Symbol ->
   Codebase IO Symbol Ann ->
   FilePath ->
   Strict.ByteString ->
-  Server AuthedServerAPI
-server rt codebase uiPath token =
+  Server AppAPI
+server rt codebase uiPath expectedToken =
   serveDirectoryWebApp (uiPath </> "static")
-    :<|> ( \token ->
-             serveUI (tryAuth token) uiPath
-               :<|> unisonApi token
-               :<|> serveOpenAPI
-               :<|> Tagged serveDocs
-         )
+    :<|> hoistWithAuth serverAPI expectedToken serveServer
   where
+    serveServer :: Server ServerAPI
+    serveServer =
+      ( serveUI uiPath
+          :<|> serveUnisonAndDocs
+      )
+
+    serveUnisonAndDocs :: Server UnisonAndDocsAPI
+    serveUnisonAndDocs = serveUnison codebase rt :<|> serveOpenAPI :<|> Tagged serveDocs
     serveDocs _ respond = respond $ responseLBS ok200 [plain] docsBS
     serveOpenAPI = pure openAPI
     plain = ("Content-Type", "text/plain")
-    tryAuth = handleAuth token
-    unisonApi t =
-      NamespaceListing.serve (tryAuth t) codebase
-        :<|> NamespaceDetails.serve (tryAuth t) rt codebase
-        :<|> Projects.serve (tryAuth t) codebase
-        :<|> serveDefinitions (tryAuth t) rt codebase
-        :<|> serveFuzzyFind (tryAuth t) codebase
+
+hoistWithAuth :: forall api. HasServer api '[] => Proxy api -> ByteString -> ServerT api Handler -> ServerT (Authed api) Handler
+hoistWithAuth api expectedToken server token = hoistServer @api @Handler @Handler api (\h -> handleAuth expectedToken token *> h) server
+
+serveUnison ::
+  Codebase IO Symbol Ann ->
+  Rt.Runtime Symbol ->
+  Server UnisonAPI
+serveUnison codebase rt =
+  NamespaceListing.serve codebase
+    :<|> NamespaceDetails.serve rt codebase
+    :<|> Projects.serve codebase
+    :<|> serveDefinitions rt codebase
+    :<|> serveFuzzyFind codebase

--- a/unison-share-api/src/Unison/Server/Endpoints/FuzzyFind.hs
+++ b/unison-share-api/src/Unison/Server/Endpoints/FuzzyFind.hs
@@ -10,13 +10,12 @@
 
 module Unison.Server.Endpoints.FuzzyFind where
 
-import Control.Error (runExceptT)
+import Control.Monad.Except
 import Data.Aeson (ToJSON (toEncoding), defaultOptions, genericToEncoding)
 import Data.OpenApi (ToSchema)
 import qualified Data.Text as Text
 import Servant
   ( QueryParam,
-    throwError,
     (:>),
   )
 import Servant.Docs
@@ -27,7 +26,6 @@ import Servant.Docs
     noSamples,
   )
 import Servant.OpenApi ()
-import Servant.Server (Handler)
 import qualified Text.FuzzyFind as FZF
 import Unison.Codebase (Codebase)
 import qualified Unison.Codebase as Codebase
@@ -41,18 +39,12 @@ import Unison.NameSegment
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import qualified Unison.Server.Backend as Backend
-import Unison.Server.Errors
-  ( backendError,
-    badNamespace,
-  )
 import Unison.Server.Syntax (SyntaxText)
 import Unison.Server.Types
   ( APIGet,
-    APIHeaders,
     HashQualifiedName,
     NamedTerm,
     NamedType,
-    addHeaders,
     mayDefaultWidth,
   )
 import Unison.Symbol (Symbol)
@@ -134,20 +126,22 @@ instance ToSample FoundResult where
   toSamples _ = noSamples
 
 serveFuzzyFind ::
-  Codebase IO Symbol Ann ->
+  forall m.
+  MonadIO m =>
+  Codebase m Symbol Ann ->
   Maybe SBH.ShortBranchHash ->
   Maybe HashQualifiedName ->
   Maybe Int ->
   Maybe Width ->
   Maybe String ->
-  Handler (APIHeaders [(FZF.Alignment, FoundResult)])
+  Backend.Backend m [(FZF.Alignment, FoundResult)]
 serveFuzzyFind codebase mayRoot relativePath limit typeWidth query =
-  addHeaders <$> do
+  do
     rel <-
       maybe mempty Path.fromPath'
         <$> traverse (parsePath . Text.unpack) relativePath
-    hashLength <- liftIO $ Codebase.hashLength codebase
-    ea <- liftIO . runExceptT $ do
+    hashLength <- lift $ Codebase.hashLength codebase
+    ea <- lift . runExceptT $ do
       root <- traverse (Backend.expandShortBranchHash codebase) mayRoot
       branch <- Backend.resolveBranchHash root codebase
       let b0 = Branch.head branch
@@ -156,7 +150,7 @@ serveFuzzyFind codebase mayRoot relativePath limit typeWidth query =
           -- Use AllNames to render source
           ppe = Backend.basicSuffixifiedNames hashLength branch (Backend.AllNames rel)
       join <$> traverse (loadEntry root (Just rel) ppe b0) alignments
-    errFromEither backendError ea
+    liftEither ea
   where
     loadEntry _root _rel ppe b0 (a, HQ'.NameOnly . NameSegment -> n, refs) =
       for refs $
@@ -179,5 +173,5 @@ serveFuzzyFind codebase mayRoot relativePath limit typeWidth query =
             let ft = FoundType typeName typeHeader namedType
             pure (a, FoundTypeResult ft)
 
-    parsePath p = errFromEither (`badNamespace` p) $ Path.parsePath' p
+    parsePath p = errFromEither (`Backend.BadNamespace` p) $ Path.parsePath' p
     errFromEither f = either (throwError . f) pure

--- a/unison-share-api/src/Unison/Server/Endpoints/FuzzyFind.hs
+++ b/unison-share-api/src/Unison/Server/Endpoints/FuzzyFind.hs
@@ -134,7 +134,6 @@ instance ToSample FoundResult where
   toSamples _ = noSamples
 
 serveFuzzyFind ::
-  Handler () ->
   Codebase IO Symbol Ann ->
   Maybe SBH.ShortBranchHash ->
   Maybe HashQualifiedName ->
@@ -142,9 +141,8 @@ serveFuzzyFind ::
   Maybe Width ->
   Maybe String ->
   Handler (APIHeaders [(FZF.Alignment, FoundResult)])
-serveFuzzyFind h codebase mayRoot relativePath limit typeWidth query =
+serveFuzzyFind codebase mayRoot relativePath limit typeWidth query =
   addHeaders <$> do
-    h
     rel <-
       maybe mempty Path.fromPath'
         <$> traverse (parsePath . Text.unpack) relativePath

--- a/unison-share-api/src/Unison/Server/Endpoints/GetDefinitions.hs
+++ b/unison-share-api/src/Unison/Server/Endpoints/GetDefinitions.hs
@@ -113,7 +113,6 @@ instance ToSample DefinitionDisplayResults where
   toSamples _ = noSamples
 
 serveDefinitions ::
-  Handler () ->
   Rt.Runtime Symbol ->
   Codebase IO Symbol Ann ->
   Maybe ShortBranchHash ->
@@ -122,9 +121,8 @@ serveDefinitions ::
   Maybe Width ->
   Maybe Suffixify ->
   Handler (APIHeaders DefinitionDisplayResults)
-serveDefinitions h rt codebase mayRoot relativePath rawHqns width suff =
+serveDefinitions rt codebase mayRoot relativePath rawHqns width suff =
   addHeaders <$> do
-    h
     rel <-
       fmap Path.fromPath' <$> traverse (parsePath . Text.unpack) relativePath
     ea <- liftIO . runExceptT $ do

--- a/unison-share-api/src/Unison/Server/Endpoints/NamespaceDetails.hs
+++ b/unison-share-api/src/Unison/Server/Endpoints/NamespaceDetails.hs
@@ -9,14 +9,13 @@
 
 module Unison.Server.Endpoints.NamespaceDetails where
 
-import Control.Error (runExceptT)
+import Control.Monad.Except
 import Data.Aeson
 import Data.OpenApi (ToSchema)
 import qualified Data.Text as Text
-import Servant (Capture, QueryParam, throwError, (:>))
+import Servant (Capture, QueryParam, (:>))
 import Servant.Docs (DocCapture (..), ToCapture (..), ToSample (..))
 import Servant.OpenApi ()
-import Servant.Server (Handler)
 import Unison.Codebase (Codebase)
 import qualified Unison.Codebase.Branch as Branch
 import qualified Unison.Codebase.Path as Path
@@ -25,16 +24,14 @@ import qualified Unison.Codebase.Runtime as Rt
 import Unison.Codebase.ShortBranchHash (ShortBranchHash)
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
+import Unison.Server.Backend
 import qualified Unison.Server.Backend as Backend
 import Unison.Server.Doc (Doc)
-import Unison.Server.Errors (backendError, badNamespace)
 import Unison.Server.Types
   ( APIGet,
-    APIHeaders,
     NamespaceFQN,
     UnisonHash,
     UnisonName,
-    addHeaders,
     branchToUnisonHash,
     mayDefaultWidth,
   )
@@ -82,24 +79,20 @@ serve ::
   NamespaceFQN ->
   Maybe ShortBranchHash ->
   Maybe Width ->
-  Handler (APIHeaders NamespaceDetails)
+  Backend IO NamespaceDetails
 serve runtime codebase namespaceName mayRoot mayWidth =
-  let doBackend a = do
-        ea <- liftIO $ runExceptT a
-        errFromEither backendError ea
-
-      errFromEither f = either (throwError . f) pure
+  let errFromEither f = either (throwError . f) pure
 
       fqnToPath fqn = do
         let fqnS = Text.unpack fqn
-        path' <- errFromEither (`badNamespace` fqnS) $ parsePath' fqnS
+        path' <- errFromEither (`Backend.BadNamespace` fqnS) $ parsePath' fqnS
         pure (Path.fromPath' path')
 
       width = mayDefaultWidth mayWidth
    in do
         namespacePath <- fqnToPath namespaceName
 
-        namespaceDetails <- doBackend $ do
+        namespaceDetails <- do
           root <- Backend.resolveRootBranchHash mayRoot codebase
 
           let namespaceBranch = Branch.getAt' namespacePath root
@@ -119,4 +112,4 @@ serve runtime codebase namespaceName mayRoot mayWidth =
 
           pure $ NamespaceDetails namespaceName (branchToUnisonHash namespaceBranch) readme
 
-        pure $ addHeaders namespaceDetails
+        pure $ namespaceDetails

--- a/unison-share-api/src/Unison/Server/Endpoints/NamespaceDetails.hs
+++ b/unison-share-api/src/Unison/Server/Endpoints/NamespaceDetails.hs
@@ -77,14 +77,13 @@ instance ToJSON NamespaceDetails where
 deriving instance ToSchema NamespaceDetails
 
 serve ::
-  Handler () ->
   Rt.Runtime Symbol ->
   Codebase IO Symbol Ann ->
   NamespaceFQN ->
   Maybe ShortBranchHash ->
   Maybe Width ->
   Handler (APIHeaders NamespaceDetails)
-serve tryAuth runtime codebase namespaceName mayRoot mayWidth =
+serve runtime codebase namespaceName mayRoot mayWidth =
   let doBackend a = do
         ea <- liftIO $ runExceptT a
         errFromEither backendError ea
@@ -120,4 +119,4 @@ serve tryAuth runtime codebase namespaceName mayRoot mayWidth =
 
           pure $ NamespaceDetails namespaceName (branchToUnisonHash namespaceBranch) readme
 
-        addHeaders <$> (tryAuth $> namespaceDetails)
+        pure $ addHeaders namespaceDetails

--- a/unison-share-api/src/Unison/Server/Endpoints/NamespaceListing.hs
+++ b/unison-share-api/src/Unison/Server/Endpoints/NamespaceListing.hs
@@ -157,13 +157,12 @@ backendListEntryToNamespaceObject ppe typeWidth = \case
     PatchObject . NamedPatch $ NameSegment.toText name
 
 serve ::
-  Handler () ->
   Codebase IO Symbol Ann ->
   Maybe ShortBranchHash ->
   Maybe NamespaceFQN ->
   Maybe NamespaceFQN ->
   Handler (APIHeaders NamespaceListing)
-serve tryAuth codebase mayRoot mayRelativeTo mayNamespaceName =
+serve codebase mayRoot mayRelativeTo mayNamespaceName =
   let -- Various helpers
       errFromEither f = either (throwError . f) pure
 
@@ -224,4 +223,4 @@ serve tryAuth codebase mayRoot mayRelativeTo mayNamespaceName =
         listingEntries <- findShallow listingBranch
 
         makeNamespaceListing shallowPPE listingFQN listingHash listingEntries
-   in addHeaders <$> (tryAuth *> namespaceListing)
+   in addHeaders <$> namespaceListing

--- a/unison-share-api/src/Unison/Server/Endpoints/NamespaceListing.hs
+++ b/unison-share-api/src/Unison/Server/Endpoints/NamespaceListing.hs
@@ -9,14 +9,13 @@
 
 module Unison.Server.Endpoints.NamespaceListing where
 
-import Control.Error (runExceptT)
 import Control.Error.Util ((??))
+import Control.Monad.Except
 import Data.Aeson
 import Data.OpenApi (ToSchema)
 import qualified Data.Text as Text
 import Servant
   ( QueryParam,
-    throwError,
     (:>),
   )
 import Servant.Docs
@@ -26,7 +25,6 @@ import Servant.Docs
     ToSample (..),
   )
 import Servant.OpenApi ()
-import Servant.Server (Handler)
 import Unison.Codebase (Codebase)
 import qualified Unison.Codebase as Codebase
 import qualified Unison.Codebase.Branch as Branch
@@ -39,14 +37,8 @@ import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import qualified Unison.PrettyPrintEnv as PPE
 import qualified Unison.Server.Backend as Backend
-import Unison.Server.Errors
-  ( backendError,
-    badNamespace,
-    rootBranchError,
-  )
 import Unison.Server.Types
   ( APIGet,
-    APIHeaders,
     HashQualifiedName,
     NamedTerm (..),
     NamedType (..),
@@ -54,7 +46,6 @@ import Unison.Server.Types
     Size,
     UnisonHash,
     UnisonName,
-    addHeaders,
     branchToUnisonHash,
   )
 import Unison.Symbol (Symbol)
@@ -161,18 +152,14 @@ serve ::
   Maybe ShortBranchHash ->
   Maybe NamespaceFQN ->
   Maybe NamespaceFQN ->
-  Handler (APIHeaders NamespaceListing)
+  Backend.Backend IO NamespaceListing
 serve codebase mayRoot mayRelativeTo mayNamespaceName =
   let -- Various helpers
       errFromEither f = either (throwError . f) pure
 
-      parsePath p = errFromEither (`badNamespace` p) $ Path.parsePath' p
+      parsePath p = errFromEither (`Backend.BadNamespace` p) $ Path.parsePath' p
 
-      doBackend a = do
-        ea <- liftIO $ runExceptT a
-        errFromEither backendError ea
-
-      findShallow branch = doBackend $ Backend.findShallowInBranch codebase branch
+      findShallow branch = Backend.findShallowInBranch codebase branch
 
       makeNamespaceListing ppe fqn hash entries =
         pure . NamespaceListing fqn hash $
@@ -185,13 +172,13 @@ serve codebase mayRoot mayRelativeTo mayNamespaceName =
         root <- case mayRoot of
           Nothing -> do
             gotRoot <- liftIO $ Codebase.getRootBranch codebase
-            errFromEither rootBranchError gotRoot
+            errFromEither Backend.BadRootBranch gotRoot
           Just sbh -> do
             ea <- liftIO . runExceptT $ do
               h <- Backend.expandShortBranchHash codebase sbh
               mayBranch <- lift $ Codebase.getBranchForHash codebase h
               mayBranch ?? Backend.CouldntLoadBranch h
-            errFromEither backendError ea
+            liftEither ea
 
         -- Relative and Listing Path resolution
         --
@@ -223,4 +210,4 @@ serve codebase mayRoot mayRelativeTo mayNamespaceName =
         listingEntries <- findShallow listingBranch
 
         makeNamespaceListing shallowPPE listingFQN listingHash listingEntries
-   in addHeaders <$> namespaceListing
+   in namespaceListing

--- a/unison-share-api/src/Unison/Server/Endpoints/Projects.hs
+++ b/unison-share-api/src/Unison/Server/Endpoints/Projects.hs
@@ -122,12 +122,11 @@ entryToOwner = \case
   _ -> Nothing
 
 serve ::
-  Handler () ->
   Codebase IO Symbol Ann ->
   Maybe ShortBranchHash ->
   Maybe ProjectOwner ->
   Handler (APIHeaders [ProjectListing])
-serve tryAuth codebase mayRoot mayOwner = addHeaders <$> (tryAuth *> projects)
+serve codebase mayRoot mayOwner = addHeaders <$> projects
   where
     projects :: Handler [ProjectListing]
     projects = do

--- a/unison-share-api/src/Unison/Server/Endpoints/Projects.hs
+++ b/unison-share-api/src/Unison/Server/Endpoints/Projects.hs
@@ -8,8 +8,8 @@
 
 module Unison.Server.Endpoints.Projects where
 
-import Control.Error (ExceptT, runExceptT)
 import Control.Error.Util ((??))
+import Control.Monad.Except
 import Data.Aeson
 import Data.Char
 import Data.OpenApi
@@ -17,7 +17,7 @@ import Data.OpenApi
     ToSchema (..),
   )
 import qualified Data.Text as Text
-import Servant (QueryParam, ServerError, throwError, (:>))
+import Servant (QueryParam, (:>))
 import Servant.API (FromHttpApiData (..))
 import Servant.Docs
   ( DocQueryParam (..),
@@ -25,7 +25,6 @@ import Servant.Docs
     ToParam (..),
     ToSample (..),
   )
-import Servant.Server (Handler)
 import Unison.Codebase (Codebase)
 import qualified Unison.Codebase as Codebase
 import qualified Unison.Codebase.Branch as Branch
@@ -36,9 +35,9 @@ import qualified Unison.Codebase.ShortBranchHash as SBH
 import qualified Unison.NameSegment as NameSegment
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
+import Unison.Server.Backend
 import qualified Unison.Server.Backend as Backend
-import Unison.Server.Errors (backendError, badNamespace, rootBranchError)
-import Unison.Server.Types (APIGet, APIHeaders, UnisonHash, addHeaders)
+import Unison.Server.Types (APIGet, UnisonHash)
 import Unison.Symbol (Symbol)
 import Unison.Util.Monoid (foldMapM)
 
@@ -122,24 +121,26 @@ entryToOwner = \case
   _ -> Nothing
 
 serve ::
-  Codebase IO Symbol Ann ->
+  forall m.
+  MonadIO m =>
+  Codebase m Symbol Ann ->
   Maybe ShortBranchHash ->
   Maybe ProjectOwner ->
-  Handler (APIHeaders [ProjectListing])
-serve codebase mayRoot mayOwner = addHeaders <$> projects
+  Backend m [ProjectListing]
+serve codebase mayRoot mayOwner = projects
   where
-    projects :: Handler [ProjectListing]
+    projects :: Backend m [ProjectListing]
     projects = do
       root <- case mayRoot of
         Nothing -> do
-          gotRoot <- liftIO $ Codebase.getRootBranch codebase
-          errFromEither rootBranchError gotRoot
+          gotRoot <- lift $ Codebase.getRootBranch codebase
+          errFromEither BadRootBranch gotRoot
         Just sbh -> do
-          ea <- liftIO . runExceptT $ do
+          ea <- lift . runExceptT $ do
             h <- Backend.expandShortBranchHash codebase sbh
             mayBranch <- lift $ Codebase.getBranchForHash codebase h
             mayBranch ?? Backend.CouldntLoadBranch h
-          errFromEither backendError ea
+          liftEither ea
 
       ownerEntries <- findShallow root
       -- If an owner is provided, we only want projects belonging to them
@@ -149,7 +150,7 @@ serve codebase mayRoot mayOwner = addHeaders <$> projects
               Nothing -> mapMaybe entryToOwner ownerEntries
       foldMapM (ownerToProjectListings root) owners
 
-    ownerToProjectListings :: Branch.Branch IO -> ProjectOwner -> Handler [ProjectListing]
+    ownerToProjectListings :: Branch.Branch m -> ProjectOwner -> Backend m [ProjectListing]
     ownerToProjectListings root owner = do
       let (ProjectOwner ownerName) = owner
       ownerPath' <- (parsePath . Text.unpack) ownerName
@@ -160,19 +161,14 @@ serve codebase mayRoot mayOwner = addHeaders <$> projects
 
     -- Minor helpers
 
-    findShallow :: Branch.Branch IO -> Handler [Backend.ShallowListEntry Symbol Ann]
+    findShallow :: Branch.Branch m -> Backend m [Backend.ShallowListEntry Symbol Ann]
     findShallow branch =
-      doBackend $ Backend.findShallowInBranch codebase branch
+      Backend.findShallowInBranch codebase branch
 
-    parsePath :: String -> Handler Path.Path'
+    parsePath :: String -> Backend m Path.Path'
     parsePath p =
-      errFromEither (`badNamespace` p) $ Path.parsePath' p
+      errFromEither (`Backend.BadNamespace` p) $ Path.parsePath' p
 
-    errFromEither :: (a -> ServerError) -> Either a a1 -> Handler a1
+    errFromEither :: (e -> BackendError) -> Either e a -> Backend m a
     errFromEither f =
       either (throwError . f) pure
-
-    doBackend :: ExceptT Backend.BackendError IO b -> Handler b
-    doBackend a = do
-      ea <- liftIO $ runExceptT a
-      errFromEither backendError ea

--- a/unison-share-api/src/Unison/Server/Errors.hs
+++ b/unison-share-api/src/Unison/Server/Errors.hs
@@ -36,6 +36,7 @@ backendError :: Backend.BackendError -> ServerError
 backendError = \case
   Backend.NoSuchNamespace n ->
     noSuchNamespace . Path.toText $ Path.unabsolute n
+  Backend.BadNamespace err namespace -> badNamespace err namespace
   Backend.BadRootBranch e -> rootBranchError e
   Backend.NoBranchForHash h ->
     noSuchNamespace . Text.toStrict . Text.pack $ show h

--- a/unison-share-api/src/Unison/Server/Types.hs
+++ b/unison-share-api/src/Unison/Server/Types.hs
@@ -259,8 +259,8 @@ discard = const $ pure ()
 mayDefaultWidth :: Maybe Width -> Width
 mayDefaultWidth = fromMaybe defaultWidth
 
-addHeaders :: v -> APIHeaders v
-addHeaders = addHeader "public"
+setCacheControl :: v -> APIHeaders v
+setCacheControl = addHeader @"Cache-Control" "public"
 
 branchToUnisonHash :: Branch.Branch m -> UnisonHash
 branchToUnisonHash b =


### PR DESCRIPTION
## Overview

The new Share server we're building will need endpoints which share a lot with local-ui ones.

This PR makes a few small tweaks which makes it easier to share the underlying implementation of these endpoints with both codebases.

## Implementation notes

* Moves the auth-token checks up to the top-level of the API, this allows the Share server to choose its own method of auth as-needed.
* Pulls any servant or api-specific stuff out of the actual endpoint implementation so we can run it in the share server despite using a different base monad. This also allows us to know exactly which errors the handlers might trigger, and allow us to handle them as-needed before converting them to actual servant responses