### PR TITLE
Improve performance of various relation operations

### DIFF
--- a/lib/unison-util-relation/src/Unison/Util/Relation.hs
+++ b/lib/unison-util-relation/src/Unison/Util/Relation.hs
@@ -230,9 +230,11 @@ union r s =
     }
 
 intersection :: (Ord a, Ord b) => Relation a b -> Relation a b -> Relation a b
-intersection r s
-  | size r > size s = intersection s r
-  | otherwise = filter (\(a, b) -> member a b s) r
+intersection r s =
+  Relation
+    { domain = M.intersectionWith Set.intersection (domain r) (domain s),
+      range = M.intersectionWith Set.intersection (range r) (range s)
+    }
 
 outerJoinDomMultimaps ::
   (Ord a, Ord b, Ord c) =>
@@ -500,32 +502,40 @@ compactSet = S.fold (S.union . fromMaybe S.empty) S.empty
 -- | Domain restriction for a relation. Modeled on z.
 (<|), restrictDom :: (Ord a, Ord b) => Set a -> Relation a b -> Relation a b
 restrictDom = (<|)
-s <| r =
-  fromList $
-    concatMap (\(x, y) -> zip (repeat x) (S.toList y)) (M.toList domain')
+s <| r = go s (domain r)
   where
-    domain' = M.unions . List.map filtrar . S.toList $ s
-    filtrar x = M.filterWithKey (\k _ -> k == x) dr
-    dr = domain r -- just to memoize the value
+    go _ Map.Tip = mempty
+    go s _ | Set.null s = mempty
+    go s (Map.Bin _ amid bs l r) = here <> go sl l <> go sr r
+      where
+        (sl, sr) = Set.split amid s
+        mids = Set.singleton amid
+        here =
+          if Set.member amid s
+            then Relation (Map.singleton amid bs) (Map.fromList $ (,mids) <$> (Set.toList bs))
+            else mempty
 
 -- | Range restriction for a relation. Modeled on z.
 (|>), restrictRan :: (Ord a, Ord b) => Relation a b -> Set b -> Relation a b
 restrictRan = (|>)
-r |> t =
-  fromList $
-    concatMap (\(x, y) -> zip (S.toList y) (repeat x)) (M.toList range')
-  where
-    range' = M.unions . List.map filtrar . S.toList $ t
-    filtrar x = M.filterWithKey (\k _ -> k == x) rr
-    rr = range r -- just to memoize the value
+r |> t = swap (t <| swap r)
 
 -- | Restrict the range to not include these `b`s.
 (||>) :: (Ord a, Ord b) => Relation a b -> Set b -> Relation a b
-Relation {domain, range} ||> t =
-  Relation
-    { domain = Map.mapMaybe (`Set.difference1` t) domain,
-      range = range `Map.withoutKeys` t
-    }
+r@(Relation {domain, range}) ||> t =
+  Relation domain' range'
+  where
+    go m a = Map.alter g a m
+      where
+        g Nothing = Nothing
+        g (Just s) =
+          if Set.null s'
+            then Nothing
+            else Just s'
+          where
+            s' = Set.difference s t
+    domain' = foldl' go domain (foldMap (`lookupRan` r) t)
+    range' = range `Map.withoutKeys` t
 
 -- | Named version of ('||>').
 subtractRan :: (Ord a, Ord b) => Set b -> Relation a b -> Relation a b
@@ -533,11 +543,7 @@ subtractRan = flip (||>)
 
 -- | Restrict the domain to not include these `a`s.
 (<||) :: (Ord a, Ord b) => Set a -> Relation a b -> Relation a b
-s <|| Relation {domain, range} =
-  Relation
-    { domain = domain `Map.withoutKeys` s,
-      range = Map.mapMaybe (`Set.difference1` s) range
-    }
+s <|| r = swap (swap r ||> s)
 
 -- | Named version of ('<||').
 subtractDom :: (Ord a, Ord b) => Set a -> Relation a b -> Relation a b

--- a/lib/unison-util-relation/src/Unison/Util/Relation.hs
+++ b/lib/unison-util-relation/src/Unison/Util/Relation.hs
@@ -508,10 +508,10 @@ s <| r = go s (domain r)
     go s _ | Set.null s = mempty
     go s (Map.Bin _ amid bs l r) = here <> go sl l <> go sr r
       where
-        (sl, sr) = Set.split amid s
+        (sl, hasMid, sr) = Set.splitMember amid s
         mids = Set.singleton amid
         here =
-          if Set.member amid s
+          if hasMid
             then Relation (Map.singleton amid bs) (Map.fromList $ (,mids) <$> (Set.toList bs))
             else mempty
 

--- a/parser-typechecker/tests/Unison/Test/Util/Relation.hs
+++ b/parser-typechecker/tests/Unison/Test/Util/Relation.hs
@@ -1,6 +1,7 @@
 module Unison.Test.Util.Relation where
 
 import Control.Monad
+import qualified Data.Map as Map
 import qualified Data.Set as Set
 import EasyTest
 import qualified Unison.Util.Relation as R
@@ -20,5 +21,16 @@ test =
           expect' $
             R.searchDom (\(x, _) -> compare x q) r
               == Set.fromList [z | ((x, _), z) <- pairs, x == q]
+        ok,
+      scope "(restrict/subtract)Dom" $ do
+        replicateM_ 100 $ do
+          n <- int' 0 100
+          pairs <- listOf n (liftM2 (,) (int' 0 10) (int' 0 1000))
+          let r = R.fromList pairs
+          forM_ (R.dom r) $ \i -> do
+            expect' $
+              R.restrictDom (Set.singleton i) r
+                == R.fromMultimap (Map.singleton i (R.lookupDom i r))
+            expect' $ R.subtractDom (Set.singleton i) r == R.deleteDom i r
         ok
     ]


### PR DESCRIPTION
- Use logarithmic lookups rather than O(n^2) algorithm for restrictDom/Ran
- Remove some duplication by defining some functions in terms of each other, using `Relation.swap`
- `subtractDom/Ran` avoids traversing the whole relation, `O(k log k)` where `k` is number of elements being removed
- Use `Map.intersectWith` for `Relation.intersection`, rather than scanning either relation