### PR TITLE
Record timings of various operations in HandleInput

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -573,10 +573,10 @@ loop = do
                         (Just new)
                         (Output.ReflogEntry (SBH.fromHash sbhLength new) reason : acc)
                         rest
-            ResetRootI src0 ->
+            ResetRootI src0 -> unsafeTime "reset-root" $
               case src0 of
                 Left hash -> unlessError do
-                  newRoot <- resolveShortBranchHash hash
+                  newRoot <- unsafeTime "resolveShortBranchHash" $ resolveShortBranchHash hash
                   lift do
                     updateRoot newRoot
                     success

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -237,7 +237,7 @@ loop = do
         let parseNames = Backend.getCurrentParseNames (Backend.Within currentPath'') root'
         LoopState.latestFile .= Just (Text.unpack sourceName, False)
         LoopState.latestTypecheckedFile .= Nothing
-        Result notes r <- eval $ Typecheck ambient parseNames sourceName lexed
+        Result notes r <- unsafeTime "typechecking" $ eval $ Typecheck ambient parseNames sourceName lexed
         case r of
           -- Parsing failed
           Nothing ->
@@ -258,19 +258,19 @@ loop = do
       loadUnisonFile sourceName text = do
         let lexed = L.lexer (Text.unpack sourceName) (Text.unpack text)
         withFile [] sourceName (text, lexed) $ \unisonFile -> do
-          currentNames <- currentPathNames
+          currentNames <- unsafeTime "currentPathNames" currentPathNames
           let sr = Slurp.slurpFile unisonFile mempty Slurp.CheckOp currentNames
-          names <- displayNames unisonFile
+          names <- unsafeTime "displayNames" $ displayNames unisonFile
           pped <- prettyPrintEnvDecl names
           let ppe = PPE.suffixifiedPPE pped
-          respond $ Typechecked sourceName ppe sr unisonFile
+          unsafeTime "typechecked.respond" $ respond $ Typechecked sourceName ppe sr unisonFile
           unlessError' EvaluationFailure do
-            (bindings, e) <- ExceptT . eval . Evaluate ppe $ unisonFile
+            (bindings, e) <- unsafeTime "evaluate" $ ExceptT . eval . Evaluate ppe $ unisonFile
             lift do
               let e' = Map.map go e
                   go (ann, kind, _hash, _uneval, eval, isHit) = (ann, kind, eval, isHit)
               unless (null e') $
-                respond $ Evaluated text ppe bindings e'
+                unsafeTime "evaluate.respond" $ respond $ Evaluated text ppe bindings e'
               LoopState.latestTypecheckedFile .= Just unisonFile
 
   case e of
@@ -627,7 +627,7 @@ loop = do
                     else
                       diffHelper (Branch.head destb) (Branch.head merged)
                         >>= respondNumbered . uncurry (ShowDiffAfterMergePreview dest0 dest)
-            DiffNamespaceI before after -> unlessError do
+            DiffNamespaceI before after -> unsafeTime "diff.namespace" $ unlessError do
               let (absBefore, absAfter) = (resolveToAbsolute <$> before, resolveToAbsolute <$> after)
               beforeBranch0 <- Branch.head <$> branchForBranchId absBefore
               afterBranch0 <- Branch.head <$> branchForBranchId absAfter
@@ -1965,7 +1965,7 @@ handleUpdate input optionalPatch requestedNames = do
       -- propagatePatch prints TodoOutput
       for_ patchOps $ \case
         (updatedPatch, _, _) -> void $ propagatePatchNoSync updatedPatch currentPath'
-      addDefaultMetadata addsAndUpdates
+      unsafeTime "addDefaultMetadata" $ addDefaultMetadata addsAndUpdates
       syncRoot $ case patchPath of
         Nothing -> "update.nopatch"
         Just p ->
@@ -2253,7 +2253,7 @@ propagatePatchNoSync ::
   Patch ->
   Path.Absolute ->
   Action' m v Bool
-propagatePatchNoSync patch scopePath = do
+propagatePatchNoSync patch scopePath = unsafeTime "propagate" $ do
   r <- use LoopState.root
   let nroot = Branch.toNames (Branch.head r)
   stepAtMNoSync'
@@ -2696,12 +2696,12 @@ stepManyAtMNoSync' strat actions = do
 
 -- | Sync the in-memory root branch.
 syncRoot :: LoopState.InputDescription -> Action m i v ()
-syncRoot description = do
+syncRoot description = unsafeTime "syncRoot" $ do
   root' <- use LoopState.root
   Unison.Codebase.Editor.HandleInput.updateRoot root' description
 
 updateRoot :: Branch m -> LoopState.InputDescription -> Action m i v ()
-updateRoot new reason = do
+updateRoot new reason = unsafeTime "updateRoot" $ do
   old <- use LoopState.lastSavedRoot
   when (old /= new) $ do
     LoopState.root .= new
@@ -3259,7 +3259,7 @@ diffHelper ::
   Branch0 m ->
   Branch0 m ->
   Action' m v (PPE.PrettyPrintEnv, OBranchDiff.BranchDiffOutput v Ann)
-diffHelper before after = do
+diffHelper before after = unsafeTime "HandleInput.diffHelper" $ do
   currentRoot <- use LoopState.root
   currentPath <- use LoopState.currentPath
   diffHelperCmd currentRoot currentPath before after


### PR DESCRIPTION
I've noticed some slowness when working with larger namespace trees. This PR sprinkles calls to collect timing info for various operations in HandleInput. You can switch it on by setting the flag in `Timing.hs`. 

Here's some example output: 

```
.> cd scratch
.scratch> 
Timing typechecking...
Finished typechecking in 0.213882s (cpu), 0.21361s (system)
Timing currentPathNames...
Finished currentPathNames in 0.000018s (cpu), 0.000009s (system)
Timing displayNames...
Finished displayNames in 0.027699s (cpu), 0.027686s (system)
Timing typechecked.respond...

  I found and typechecked these definitions in ~/unison/scratch.u. If you do an `add` or `update`,
  here's how your codebase would change:
  
    ⍟ These new definitions are ok to `add`:
    
      unique ability Bound b
      Bound.bumped       : b -> a ->{Bound b} a
      Bound.bumped.id    : b ->{Bound b} b
      Bound.minBy        : (b -> b ->{g} b)
                           -> (b -> b ->{g} Boolean)
                           -> b
                           -> b
                           -> '{g, Each, Bound b} a
                           ->{g} Optional (a, b)
      Bound.minimize.nat : '{g, Each, Bound Nat} a ->{g} Optional (a, Nat)
      foo                : Nat -> Nat
  
  Now evaluating any watch expressions (lines starting with `>`)... Ctrl+C cancels.

Finished typechecked.respond in 0.59553s (cpu), 0.595556s (system)
Timing evaluate...
Finished evaluate in 0.350549s (cpu), 0.353964s (system)
Timing evaluate.respond...

    4 | > 1 + 10
          ⧩
          11

Finished evaluate.respond in 0.000292s (cpu), 0.000291s (system)
.scratch> add

  ⍟ I've added these definitions:
  
    unique ability Bound b
    Bound.bumped       : b -> a ->{Bound b} a
    Bound.bumped.id    : b ->{Bound b} b
    Bound.minBy        : (b -> b ->{g} b)
                         -> (b -> b ->{g} Boolean)
                         -> b
                         -> b
                         -> '{g, Each, Bound b} a
                         ->{g} Optional (a, b)
    Bound.minimize.nat : '{g, Each, Bound Nat} a ->{g} Optional (a, Nat)
    foo                : Nat -> Nat


  I added some default metadata.

Timing updateRoot...
Finished updateRoot in 3.955598s (cpu), 3.971577s (system)
.scratch> reflog

  Here is a log of the root namespace hashes, starting with the most recent, along with the command
  that got us there. Try:
  
    `fork 2 .old`             
    `fork #tc5ai1q4bs .old`   to make an old namespace accessible again,
                              
    `reset-root #tc5ai1q4bs`  to reset the root namespace and its history to that of the specified
                              namespace.
  
  1.    #vkn30dgoi7 : add
  2.    #tc5ai1q4bs : reset-root #tc5ai1q4bs
  ... 
.scratch> reset-root 2
Timing reset-root...
Timing resolveShortBranchHash...
Finished resolveShortBranchHash in 12.373796s (cpu), 12.575855s (system)
Timing updateRoot...
Finished updateRoot in 0.026713s (cpu), 0.100789s (system)

  Done.

Finished reset-root in 12.401652s (cpu), 12.68418s (system)
```