### PR TITLE
Allow fetching namespace details (and readme) without loading root branch

### DIFF
--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -338,7 +338,8 @@ findShallowReadmeInBranchAndRender width runtime codebase printNames namespaceBr
         (_, _, doc) <- renderDoc ppe width runtime codebase docReference
         pure doc
 
-      -- allow any of these capitalizations
+      -- choose the first term (among conflicted terms) matching any of these names, in this order.
+      -- we might later want to return all of them to let the front end decide
       toCheck = V2Branch.NameSegment <$> ["README", "Readme", "ReadMe", "readme"]
       readme :: Maybe V2.Referent
       readme = List.firstJust lookup toCheck

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -18,6 +18,7 @@ import Data.Bifunctor (first)
 import Data.Containers.ListUtils (nubOrdOn)
 import qualified Data.List as List
 import Data.List.Extra (nubOrd)
+import qualified Data.List.Extra as List
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Text as Text
@@ -32,6 +33,7 @@ import qualified Text.FuzzyFind as FZF
 import qualified U.Codebase.Branch as V2Branch
 import qualified U.Codebase.Causal as V2Causal
 import qualified U.Codebase.HashTags as V2.Hash
+import qualified U.Codebase.Referent as V2
 import qualified Unison.ABT as ABT
 import qualified Unison.Builtin as B
 import qualified Unison.Builtin.Decls as Decls
@@ -322,25 +324,34 @@ findShallowReadmeInBranchAndRender ::
   Rt.Runtime Symbol ->
   Codebase IO Symbol Ann ->
   NamesWithHistory ->
-  Branch IO ->
+  V2Branch.Branch m ->
   Backend IO (Maybe Doc.Doc)
 findShallowReadmeInBranchAndRender width runtime codebase printNames namespaceBranch =
   let ppe hqLen = PPE.fromNamesDecl hqLen printNames
 
+      renderReadme :: PPE.PrettyPrintEnvDecl -> V2.Referent -> IO Doc.Doc
       renderReadme ppe r = do
-        (_, _, doc) <- renderDoc ppe width runtime codebase (Referent.toReference r)
+        let docReference = case r of
+              -- This shouldn't ever happen unless someone puts a non-doc as their readme.
+              V2.Con ref _conId -> Cv.reference2to1 ref
+              V2.Ref ref -> Cv.reference2to1 ref
+        (_, _, doc) <- renderDoc ppe width runtime codebase docReference
         pure doc
 
       -- allow any of these capitalizations
-      toCheck = NameSegment <$> ["README", "Readme", "ReadMe", "readme"]
-      readmes :: Set Referent
-      readmes = foldMap lookup toCheck
+      toCheck = V2Branch.NameSegment <$> ["README", "Readme", "ReadMe", "readme"]
+      readme :: Maybe V2.Referent
+      readme = List.firstJust lookup toCheck
         where
-          lookup seg = R.lookupRan seg rel
-          rel = Star3.d1 (Branch._terms (Branch.head namespaceBranch))
+          lookup :: (V2Branch.NameSegment -> Maybe V2.Referent)
+          lookup seg = do
+            term <- Map.lookup seg termsMap
+            (k, _v) <- Map.lookupMin term
+            pure k
+          termsMap = V2Branch.terms namespaceBranch
    in liftIO $ do
         hqLen <- Codebase.hashLength codebase
-        traverse (renderReadme (ppe hqLen)) (Set.lookupMin readmes)
+        traverse (renderReadme (ppe hqLen)) readme
 
 isDoc :: Monad m => Codebase m Symbol Ann -> Referent -> m Bool
 isDoc codebase ref = do
@@ -765,6 +776,19 @@ expandShortBranchHash codebase hash = do
     [h] -> pure h
     _ ->
       throwError . AmbiguousBranchHash hash $ Set.map (SBH.fromHash len) hashSet
+
+-- | Efficiently resolve a root hash and path to a shallow branch's causal.
+getShallowCausalAtPathFromRootHash :: Monad m => Codebase m v a -> Maybe Branch.Hash -> Path -> Backend m (V2Branch.CausalBranch m)
+getShallowCausalAtPathFromRootHash codebase mayRootHash path = do
+  shallowRoot <- case mayRootHash of
+    Nothing -> lift (Codebase.getShallowRootBranch codebase)
+    Just h -> do
+      lift $ Codebase.getShallowBranchForHash codebase (Cv.branchHash1to2 h)
+  causal <-
+    (lift $ Codebase.shallowBranchAtPath path shallowRoot) >>= \case
+      Nothing -> pure $ Cv.causalbranch1to2 (Branch.empty)
+      Just lc -> pure lc
+  pure causal
 
 formatType' :: Var v => PPE.PrettyPrintEnv -> Width -> Type v a -> SyntaxText
 formatType' ppe w =

--- a/unison-share-api/src/Unison/Server/CodebaseServer.hs
+++ b/unison-share-api/src/Unison/Server/CodebaseServer.hs
@@ -355,7 +355,7 @@ serveUnison ::
 serveUnison env codebase rt =
   hoistServer (Proxy @UnisonAPI) (backendHandler env) $
     (\root rel name -> setCacheControl <$> NamespaceListing.serve codebase root rel name)
-      :<|> (\namespaceName mayRoot mayWidth -> setCacheControl <$> NamespaceDetails.serve rt codebase namespaceName mayRoot mayWidth)
+      :<|> (\namespaceName mayRoot mayWidth -> setCacheControl <$> NamespaceDetails.namespaceDetails rt codebase namespaceName mayRoot mayWidth)
       :<|> (\mayRoot mayOwner -> setCacheControl <$> Projects.serve codebase mayRoot mayOwner)
       :<|> (\mayRoot relativePath rawHqns width suff -> setCacheControl <$> serveDefinitions rt codebase mayRoot relativePath rawHqns width suff)
       :<|> (\mayRoot relativePath limit typeWidth query -> setCacheControl <$> serveFuzzyFind codebase mayRoot relativePath limit typeWidth query)

--- a/unison-share-api/src/Unison/Server/Doc.hs
+++ b/unison-share-api/src/Unison/Server/Doc.hs
@@ -12,11 +12,13 @@ module Unison.Server.Doc where
 import Control.Lens (view, (^.))
 import Control.Monad
 import Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
+import Data.Aeson (ToJSON)
 import Data.Foldable
 import Data.Functor
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Maybe (fromMaybe)
+import Data.OpenApi (ToSchema)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -38,6 +40,7 @@ import qualified Unison.Reference as Reference
 import Unison.Referent (Referent)
 import qualified Unison.Referent as Referent
 import qualified Unison.Runtime.IOSource as DD
+import Unison.Server.Orphans ()
 import Unison.Server.Syntax (SyntaxText)
 import qualified Unison.Server.Syntax as Syntax
 import qualified Unison.ShortHash as SH
@@ -86,12 +89,19 @@ data Doc
   | Column [Doc]
   | Group Doc
   deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, ToSchema)
 
 type UnisonHash = Text
 
-data Ref a = Term a | Type a deriving (Eq, Show, Generic, Functor, Foldable, Traversable)
+data Ref a = Term a | Type a
+  deriving stock (Eq, Show, Generic, Functor, Foldable, Traversable)
+  deriving anyclass (ToJSON)
 
-data MediaSource = MediaSource {mediaSourceUrl :: Text, mediaSourceMimeType :: Maybe Text} deriving (Eq, Show, Generic)
+instance ToSchema a => ToSchema (Ref a)
+
+data MediaSource = MediaSource {mediaSourceUrl :: Text, mediaSourceMimeType :: Maybe Text}
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, ToSchema)
 
 data SpecialForm
   = Source [Ref (UnisonHash, DisplayObject SyntaxText Src)]
@@ -107,10 +117,13 @@ data SpecialForm
   | EmbedInline SyntaxText
   | Video [MediaSource] (Map Text Text)
   | FrontMatter (Map Text [Text])
-  deriving (Eq, Show, Generic)
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, ToSchema)
 
 -- `Src folded unfolded`
-data Src = Src SyntaxText SyntaxText deriving (Eq, Show, Generic)
+data Src = Src SyntaxText SyntaxText
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, ToSchema)
 
 renderDoc ::
   forall v m.

--- a/unison-share-api/src/Unison/Server/Doc.hs
+++ b/unison-share-api/src/Unison/Server/Doc.hs
@@ -85,7 +85,7 @@ data Doc
   | UntitledSection [Doc]
   | Column [Doc]
   | Group Doc
-  deriving (Eq, Show, Generic)
+  deriving stock (Eq, Show, Generic)
 
 type UnisonHash = Text
 
@@ -289,29 +289,29 @@ renderDoc pped terms typeOf eval types tm =
                 acc' = case tm of
                   Term.Ref' r
                     | Set.notMember r seen ->
-                        (: acc) . Term . (Reference.toText r,) <$> case r of
-                          Reference.Builtin _ ->
-                            typeOf (Referent.Ref r) <&> \case
-                              Nothing -> DO.BuiltinObject "🆘 missing type signature"
-                              Just ty -> DO.BuiltinObject (formatPrettyType ppe ty)
-                          ref ->
-                            terms ref >>= \case
-                              Nothing -> pure $ DO.MissingObject (SH.unsafeFromText $ Reference.toText ref)
-                              Just tm -> do
-                                typ <- fromMaybe (Type.builtin () "unknown") <$> typeOf (Referent.Ref ref)
-                                let name = PPE.termName ppe (Referent.Ref ref)
-                                let folded =
-                                      formatPretty . P.lines $
-                                        TypePrinter.prettySignaturesST ppe [(Referent.Ref ref, name, typ)]
-                                let full tm@(Term.Ann' _ _) _ =
-                                      formatPretty (TermPrinter.prettyBinding ppe name tm)
-                                    full tm typ =
-                                      formatPretty (TermPrinter.prettyBinding ppe name (Term.ann () tm typ))
-                                pure (DO.UserObject (Src folded (full tm typ)))
+                      (: acc) . Term . (Reference.toText r,) <$> case r of
+                        Reference.Builtin _ ->
+                          typeOf (Referent.Ref r) <&> \case
+                            Nothing -> DO.BuiltinObject "🆘 missing type signature"
+                            Just ty -> DO.BuiltinObject (formatPrettyType ppe ty)
+                        ref ->
+                          terms ref >>= \case
+                            Nothing -> pure $ DO.MissingObject (SH.unsafeFromText $ Reference.toText ref)
+                            Just tm -> do
+                              typ <- fromMaybe (Type.builtin () "unknown") <$> typeOf (Referent.Ref ref)
+                              let name = PPE.termName ppe (Referent.Ref ref)
+                              let folded =
+                                    formatPretty . P.lines $
+                                      TypePrinter.prettySignaturesST ppe [(Referent.Ref ref, name, typ)]
+                              let full tm@(Term.Ann' _ _) _ =
+                                    formatPretty (TermPrinter.prettyBinding ppe name tm)
+                                  full tm typ =
+                                    formatPretty (TermPrinter.prettyBinding ppe name (Term.ann () tm typ))
+                              pure (DO.UserObject (Src folded (full tm typ)))
                   Term.RequestOrCtor' (view ConstructorReference.reference_ -> r) | Set.notMember r seen -> (: acc) <$> goType r
                   _ -> pure acc
             DD.TupleTerm' [DD.EitherLeft' (Term.TypeLink' ref), _anns]
               | Set.notMember ref seen ->
-                  (Set.insert ref seen,) . (: acc) <$> goType ref
+                (Set.insert ref seen,) . (: acc) <$> goType ref
             _ -> pure s1
       reverse . snd <$> foldM go mempty es

--- a/unison-share-api/src/Unison/Server/Orphans.hs
+++ b/unison-share-api/src/Unison/Server/Orphans.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE StandaloneDeriving #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Unison.Server.Orphans where
+
+import Data.Aeson
+import Data.OpenApi
+import Data.Proxy
+import Servant
+import Unison.Codebase.Editor.DisplayObject
+import Unison.Codebase.ShortBranchHash
+  ( ShortBranchHash (..),
+  )
+import qualified Unison.Codebase.ShortBranchHash as SBH
+import Unison.ConstructorType (ConstructorType)
+import qualified Unison.HashQualified as HQ
+import Unison.Name (Name)
+import qualified Unison.Name as Name
+import Unison.Prelude
+import Unison.ShortHash (ShortHash)
+import Unison.Util.Pretty (Width (..))
+
+instance ToJSON ShortHash where
+  toEncoding = genericToEncoding defaultOptions
+
+instance ToJSONKey ShortHash
+
+deriving instance ToSchema ShortHash
+
+instance FromHttpApiData ShortBranchHash where
+  parseUrlPiece = maybe (Left "Invalid ShortBranchHash") Right . SBH.fromText
+
+instance (ToJSON b, ToJSON a) => ToJSON (DisplayObject b a) where
+  toEncoding = genericToEncoding defaultOptions
+
+deriving instance (ToSchema b, ToSchema a) => ToSchema (DisplayObject b a)
+
+-- [21/10/07] Hello, this is Mitchell. Name refactor in progress. Changing internal representation from a flat text to a
+-- list of segments (in reverse order) plus an "is absolute?" bit.
+--
+-- To preserve backwards compatibility (for now, anyway -- is this even important long term?), the ToJSON and ToSchema
+-- instances below treat Name as before.
+
+instance ToJSON Name where
+  toEncoding = toEncoding . Name.toText
+  toJSON = toJSON . Name.toText
+
+instance ToSchema Name where
+  declareNamedSchema _ = declareNamedSchema (Proxy @Text)
+
+deriving anyclass instance ToParamSchema ShortBranchHash
+
+deriving via Int instance FromHttpApiData Width
+
+deriving anyclass instance ToParamSchema Width
+
+instance ToJSON n => ToJSON (HQ.HashQualified n) where
+  toEncoding = genericToEncoding defaultOptions
+
+deriving instance ToSchema n => ToSchema (HQ.HashQualified n)
+
+instance ToJSON ConstructorType where
+  toEncoding = genericToEncoding defaultOptions
+
+deriving instance ToSchema ConstructorType

--- a/unison-share-api/src/Unison/Server/Types.hs
+++ b/unison-share-api/src/Unison/Server/Types.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Unison.Server.Types where
 
@@ -16,7 +15,6 @@ import Data.OpenApi
   ( ToParamSchema (..),
     ToSchema (..),
   )
-import Data.Proxy (Proxy (..))
 import qualified Data.Text.Lazy as Text
 import qualified Data.Text.Lazy.Encoding as Text
 import Servant.API
@@ -35,20 +33,11 @@ import qualified Unison.Codebase.Causal as Causal
 import Unison.Codebase.Editor.DisplayObject
   ( DisplayObject,
   )
-import Unison.Codebase.ShortBranchHash
-  ( ShortBranchHash (..),
-  )
-import qualified Unison.Codebase.ShortBranchHash as SBH
-import Unison.ConstructorType (ConstructorType)
 import qualified Unison.Hash as Hash
-import qualified Unison.HashQualified as HQ
-import Unison.Name (Name)
-import qualified Unison.Name as Name
 import Unison.Prelude
 import Unison.Server.Doc (Doc)
-import qualified Unison.Server.Doc as Doc
+import Unison.Server.Orphans ()
 import Unison.Server.Syntax (SyntaxText)
-import Unison.ShortHash (ShortHash)
 import Unison.Util.Pretty (Width (..))
 
 type APIHeaders x =
@@ -69,53 +58,9 @@ type UnisonName = Text
 
 type UnisonHash = Text
 
--- [21/10/07] Hello, this is Mitchell. Name refactor in progress. Changing internal representation from a flat text to a
--- list of segments (in reverse order) plus an "is absolute?" bit.
---
--- To preserve backwards compatibility (for now, anyway -- is this even important long term?), the ToJSON and ToSchema
--- instances below treat Name as before.
-
-instance ToJSON Name where
-  toEncoding = toEncoding . Name.toText
-  toJSON = toJSON . Name.toText
-
-instance ToSchema Name where
-  declareNamedSchema _ = declareNamedSchema (Proxy @Text)
-
 deriving via Bool instance FromHttpApiData Suffixify
 
 deriving anyclass instance ToParamSchema Suffixify
-
-instance FromHttpApiData ShortBranchHash where
-  parseUrlPiece = maybe (Left "Invalid ShortBranchHash") Right . SBH.fromText
-
-deriving anyclass instance ToParamSchema ShortBranchHash
-
-deriving via Int instance FromHttpApiData Width
-
-deriving anyclass instance ToParamSchema Width
-
-instance (ToJSON b, ToJSON a) => ToJSON (DisplayObject b a) where
-  toEncoding = genericToEncoding defaultOptions
-
-deriving instance (ToSchema b, ToSchema a) => ToSchema (DisplayObject b a)
-
-instance ToJSON ShortHash where
-  toEncoding = genericToEncoding defaultOptions
-
-instance ToJSONKey ShortHash
-
-deriving instance ToSchema ShortHash
-
-instance ToJSON n => ToJSON (HQ.HashQualified n) where
-  toEncoding = genericToEncoding defaultOptions
-
-deriving instance ToSchema n => ToSchema (HQ.HashQualified n)
-
-instance ToJSON ConstructorType where
-  toEncoding = genericToEncoding defaultOptions
-
-deriving instance ToSchema ConstructorType
 
 instance ToJSON TypeDefinition where
   toEncoding = genericToEncoding defaultOptions
@@ -221,26 +166,6 @@ instance ToJSON TypeTag where
   toEncoding = genericToEncoding defaultOptions
 
 deriving instance ToSchema TypeTag
-
-instance ToJSON Doc
-
-instance ToJSON Doc.MediaSource
-
-instance ToJSON Doc.SpecialForm
-
-instance ToJSON Doc.Src
-
-instance ToJSON a => ToJSON (Doc.Ref a)
-
-instance ToSchema Doc
-
-instance ToSchema Doc.MediaSource
-
-instance ToSchema Doc.SpecialForm
-
-instance ToSchema Doc.Src
-
-instance ToSchema a => ToSchema (Doc.Ref a)
 
 -- Helpers
 

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -27,6 +27,7 @@ library
       Unison.Server.Endpoints.NamespaceListing
       Unison.Server.Endpoints.Projects
       Unison.Server.Errors
+      Unison.Server.Orphans
       Unison.Server.QueryResult
       Unison.Server.SearchResult
       Unison.Server.SearchResult'

--- a/unison-src/transcripts/api-namespace-details.md
+++ b/unison-src/transcripts/api-namespace-details.md
@@ -1,4 +1,4 @@
-# Get Definitions Test
+# Namespace Details Test
 
 ```ucm:hide
 .> builtins.mergeio

--- a/unison-src/transcripts/api-namespace-details.md
+++ b/unison-src/transcripts/api-namespace-details.md
@@ -1,4 +1,4 @@
-# Namespace details api
+# Get Definitions Test
 
 ```ucm:hide
 .> builtins.mergeio
@@ -8,7 +8,9 @@
 {{ Documentation }}
 nested.names.x = 42
 
-nested.names.readme = {{ I'm a readme! }}
+nested.names.readme = {{
+Here's a *README*!
+}}
 ```
 
 ```ucm
@@ -16,5 +18,6 @@ nested.names.readme = {{ I'm a readme! }}
 ```
 
 ```api
+-- Should find names by suffix
 GET /api/namespaces/nested.names
 ```

--- a/unison-src/transcripts/api-namespace-details.output.md
+++ b/unison-src/transcripts/api-namespace-details.output.md
@@ -1,10 +1,12 @@
-# Namespace details api
+# Get Definitions Test
 
 ```unison
 {{ Documentation }}
 nested.names.x = 42
 
-nested.names.readme = {{ I'm a readme! }}
+nested.names.readme = {{
+Here's a *README*!
+}}
 ```
 
 ```ucm
@@ -31,14 +33,15 @@ nested.names.readme = {{ I'm a readme! }}
 
 ```
 ```api
+--  Should find names by suffix
 GET /api/namespaces/nested.names
 {
     "fqn": "nested.names",
-    "hash": "#oms19b4f9s3c8tb5skeb8jii95ij35n3hdg038pu6rv5b0fikqe4gd7lnu6a1i6aq5tdh2opdo4s0sfrupvk6vfkr9lf0n752gbl8o0",
+    "hash": "#6tnmlu9knsce0u2991u6fvcmf4v44fdf0aiqtmnq7mjj0gi5sephg3lf12iv3odr5rc7vlgq75ciborrd3625c701bdmdomia2gcm3o",
     "readme": {
         "contents": [
             {
-                "contents": "I'm",
+                "contents": "Here's",
                 "tag": "Word"
             },
             {
@@ -46,8 +49,28 @@ GET /api/namespaces/nested.names
                 "tag": "Word"
             },
             {
-                "contents": "readme!",
-                "tag": "Word"
+                "contents": {
+                    "contents": [
+                        {
+                            "contents": {
+                                "contents": [
+                                    {
+                                        "contents": "README",
+                                        "tag": "Word"
+                                    }
+                                ],
+                                "tag": "Paragraph"
+                            },
+                            "tag": "Bold"
+                        },
+                        {
+                            "contents": "!",
+                            "tag": "Word"
+                        }
+                    ],
+                    "tag": "Join"
+                },
+                "tag": "Group"
             }
         ],
         "tag": "Paragraph"

--- a/unison-src/transcripts/api-namespace-details.output.md
+++ b/unison-src/transcripts/api-namespace-details.output.md
@@ -1,4 +1,4 @@
-# Get Definitions Test
+# Namespace Details Test
 
 ```unison
 {{ Documentation }}


### PR DESCRIPTION
## Overview

When looking up a user's codebase in share we display their readme. Currently the only way to load the readme is to load the root namespace. This PR allows us to do it piecemeal by crawling using shallow branches and looking up names from the names index.

## Implementation notes

* Switch namespace-details Backend implementation to use the name lookup table and shallow branches rather than a root branch so we can use it in Enlil.
* De-orphan instances for types which are defined in this package, and split off legitimate orphans to their own orphans module. I found myself digging around trying to figure out how this was working before realizing that the instances were orphaned when they didn't need to be.


## Test coverage

- [x] Added an api transcript for this method, and verified it matches against output from trunk (even though trunk didn't have it yet)