### PR TITLE
Add "debug.doctor" command for assessing codebase integrity

### DIFF
--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -90,6 +90,9 @@ module Unison.Codebase
     CodebasePath,
     SyncToDir,
 
+    -- * Sqlite escape hatch
+    connection,
+
     -- * Misc (organize these better)
     addDefsToCodebase,
     componentReferencesForReference,

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -492,7 +492,8 @@ sqliteCodebase debugName root localOrRemote action = do
                 runTx (CodebaseOps.namesAtPath path),
               updateNameLookup = Sqlite.runTransaction conn $ do
                 root <- (CodebaseOps.getRootBranch getDeclType rootBranchCache)
-                CodebaseOps.saveRootNamesIndex (Branch.toNames . Branch.head $ root)
+                CodebaseOps.saveRootNamesIndex (Branch.toNames . Branch.head $ root),
+              connection = conn
             }
     let finalizer :: MonadIO m => m ()
         finalizer = do

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -36,6 +36,7 @@ import Unison.Reference (Reference)
 import qualified Unison.Reference as Reference
 import qualified Unison.Referent as Referent
 import Unison.ShortHash (ShortHash)
+import qualified Unison.Sqlite as Sqlite
 import Unison.Term (Term)
 import Unison.Type (Type)
 import qualified Unison.WatchKind as WK
@@ -174,7 +175,13 @@ data Codebase m v a = Codebase
     namesAtPath :: Path -> m ScopedNames,
     -- Updates the root namespace names index.
     -- This isn't run automatically because it can be a bit slow.
-    updateNameLookup :: m ()
+    updateNameLookup :: m (),
+    -- | The SQLite connection this codebase closes over.
+    --
+    -- At one time the codebase was meant to abstract over the storage layer, but it has been cumbersome. Now we prefer
+    -- to interact with SQLite directly, and so provide this temporary escape hatch, until we can eliminate this
+    -- interface entirely.
+    connection :: Sqlite.Connection
   }
 
 -- | Whether a codebase is local or remote.

--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -36,6 +36,7 @@ dependencies:
   - stm
   - text
   - unison-codebase-sqlite
+  - unison-sqlite
   - unison-core1
   - unison-parser-typechecker
   - unison-prelude

--- a/unison-cli/src/Unison/Codebase/Editor/Command.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Command.hs
@@ -30,6 +30,7 @@ import Unison.Codebase.Editor.AuthorInfo (AuthorInfo)
 import qualified Unison.Codebase.Editor.Git as Git
 import Unison.Codebase.Editor.Output
 import Unison.Codebase.Editor.RemoteRepo
+import Unison.Codebase.IntegrityCheck (IntegrityResult)
 import Unison.Codebase.Path (Path)
 import qualified Unison.Codebase.Path as Path
 import qualified Unison.Codebase.Reflog as Reflog
@@ -252,7 +253,7 @@ data
   RuntimeMain :: Command m i v (Type v Ann)
   RuntimeTest :: Command m i v (Type v Ann)
   ClearWatchCache :: Command m i v ()
-  AnalyzeCodebaseIntegrity :: Command m i v ()
+  AnalyzeCodebaseIntegrity :: Command m i v IntegrityResult
   MakeStandalone :: PPE.PrettyPrintEnv -> Reference -> String -> Command m i v (Maybe Runtime.Error)
   -- | Trigger an interactive fuzzy search over the provided options and return all
   -- selected results.

--- a/unison-cli/src/Unison/Codebase/Editor/Command.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Command.hs
@@ -252,6 +252,7 @@ data
   RuntimeMain :: Command m i v (Type v Ann)
   RuntimeTest :: Command m i v (Type v Ann)
   ClearWatchCache :: Command m i v ()
+  AnalyzeCodebaseIntegrity :: Command m i v ()
   MakeStandalone :: PPE.PrettyPrintEnv -> Reference -> String -> Command m i v (Maybe Runtime.Error)
   -- | Trigger an interactive fuzzy search over the provided options and return all
   -- selected results.
@@ -348,3 +349,4 @@ commandName = \case
   FuzzySelect {} -> "FuzzySelect"
   CmdUnliftIO {} -> "UnliftIO"
   UCMVersion {} -> "UCMVersion"
+  AnalyzeCodebaseIntegrity -> "AnalyzeCodebaseIntegrity"

--- a/unison-cli/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -240,6 +240,7 @@ commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSour
               UnliftIO.UnliftIO toIO -> toIO . Free.fold go
         pure runF
       UCMVersion -> pure ucmVersion
+      AnalyzeCodebaseIntegrity -> pure ucmVersion
 
     watchCache :: Reference.Id -> IO (Maybe (Term Symbol ()))
     watchCache h = do

--- a/unison-cli/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -24,6 +24,7 @@ import qualified Unison.Codebase.Branch.Merge as Branch
 import qualified Unison.Codebase.Editor.AuthorInfo as AuthorInfo
 import Unison.Codebase.Editor.Command (Command (..), LexedSource, LoadSourceResult, SourceName, TypecheckingResult, UCMVersion, UseCache)
 import Unison.Codebase.Editor.Output (NumberedArgs, NumberedOutput, Output (PrintMessage))
+import Unison.Codebase.IntegrityCheck (integrityCheckFullCodebase)
 import qualified Unison.Codebase.Path as Path
 import Unison.Codebase.Runtime (Runtime)
 import qualified Unison.Codebase.Runtime as Runtime
@@ -41,6 +42,7 @@ import qualified Unison.Reference as Reference
 import qualified Unison.Result as Result
 import qualified Unison.Server.Backend as Backend
 import qualified Unison.Server.CodebaseServer as Server
+import qualified Unison.Sqlite as Sqlite
 import Unison.Symbol (Symbol)
 import Unison.Term (Term)
 import qualified Unison.Term as Term
@@ -240,7 +242,8 @@ commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSour
               UnliftIO.UnliftIO toIO -> toIO . Free.fold go
         pure runF
       UCMVersion -> pure ucmVersion
-      AnalyzeCodebaseIntegrity -> pure ucmVersion
+      AnalyzeCodebaseIntegrity -> do
+        Sqlite.runTransaction (Codebase.connection codebase) integrityCheckFullCodebase
 
     watchCache :: Reference.Id -> IO (Maybe (Term Symbol ()))
     watchCache h = do

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -455,6 +455,7 @@ loop = do
             DebugDumpNamespacesI {} -> wat
             DebugDumpNamespaceSimpleI {} -> wat
             DebugClearWatchI {} -> wat
+            DebugDoctorI {} -> wat
             QuitI {} -> wat
             DeprecateTermI {} -> undefined
             DeprecateTypeI {} -> undefined
@@ -1624,6 +1625,7 @@ loop = do
               for_ (Relation.toList . Branch.deepTerms . Branch.head $ root') \(r, name) ->
                 traceM $ show name ++ ",Term," ++ Text.unpack (Referent.toText r)
             DebugClearWatchI {} -> eval ClearWatchCache
+            DebugDoctorI {} -> eval ClearWatchCache
             DeprecateTermI {} -> notImplemented
             DeprecateTypeI {} -> notImplemented
             RemoveTermReplacementI from patchPath ->

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1625,7 +1625,9 @@ loop = do
               for_ (Relation.toList . Branch.deepTerms . Branch.head $ root') \(r, name) ->
                 traceM $ show name ++ ",Term," ++ Text.unpack (Referent.toText r)
             DebugClearWatchI {} -> eval ClearWatchCache
-            DebugDoctorI {} -> eval ClearWatchCache
+            DebugDoctorI {} -> do
+              r <- eval AnalyzeCodebaseIntegrity
+              respond (IntegrityCheck r)
             DeprecateTermI {} -> notImplemented
             DeprecateTypeI {} -> notImplemented
             RemoveTermReplacementI from patchPath ->

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -180,6 +180,7 @@ data Input
   | DebugDumpNamespacesI
   | DebugDumpNamespaceSimpleI
   | DebugClearWatchI
+  | DebugDoctorI
   | QuitI
   | ApiI
   | UiI

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -29,6 +29,7 @@ import Unison.Codebase.Editor.RemoteRepo
 import Unison.Codebase.Editor.SlurpResult (SlurpResult (..))
 import qualified Unison.Codebase.Editor.SlurpResult as SR
 import qualified Unison.Codebase.Editor.TodoOutput as TO
+import Unison.Codebase.IntegrityCheck (IntegrityResult (..))
 import Unison.Codebase.Patch (Patch)
 import Unison.Codebase.Path (Path')
 import qualified Unison.Codebase.Path as Path
@@ -255,6 +256,7 @@ data Output v
   | UnknownCodeServer Text
   | CredentialFailureMsg CredentialFailure
   | PrintVersion Text
+  | IntegrityCheck IntegrityResult
 
 data ReflogEntry = ReflogEntry {hash :: ShortBranchHash, reason :: Text}
   deriving (Show)
@@ -381,6 +383,10 @@ isFailure o = case o of
   UnknownCodeServer {} -> True
   CredentialFailureMsg {} -> True
   PrintVersion {} -> False
+  IntegrityCheck r ->
+    case r of
+      NoIntegrityErrors -> False
+      IntegrityErrorDetected {} -> True
 
 isNumberedFailure :: NumberedOutput v -> Bool
 isNumberedFailure = \case

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1862,6 +1862,20 @@ debugClearWatchCache =
     "Clear the watch expression cache"
     (const $ Right Input.DebugClearWatchI)
 
+debugDoctor :: InputPattern
+debugDoctor =
+  InputPattern
+    "debug.doctor"
+    []
+    I.Visible
+    []
+    ( P.wrap "Analyze your codebase for errors and inconsistencies."
+    )
+    ( \case
+        [] -> Right $ Input.DebugDoctorI
+        _ -> Left (showPatternHelp debugDoctor)
+    )
+
 test :: InputPattern
 test =
   InputPattern
@@ -2132,6 +2146,7 @@ validInputs =
       debugDumpNamespace,
       debugDumpNamespaceSimple,
       debugClearWatchCache,
+      debugDoctor,
       gist,
       authLogin,
       printVersion

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -49,6 +49,7 @@ import qualified Unison.Codebase.Editor.RemoteRepo as RemoteRepo
 import qualified Unison.Codebase.Editor.SlurpResult as SlurpResult
 import qualified Unison.Codebase.Editor.TodoOutput as TO
 import Unison.Codebase.GitError
+import Unison.Codebase.IntegrityCheck (IntegrityResult (..), prettyPrintIntegrityErrors)
 import Unison.Codebase.Patch (Patch (..))
 import qualified Unison.Codebase.Patch as Patch
 import qualified Unison.Codebase.Path as Path
@@ -1580,6 +1581,9 @@ notifyUser dir o = case o of
           "Host names should NOT include a schema or path."
         ]
   PrintVersion ucmVersion -> pure (P.text ucmVersion)
+  IntegrityCheck result -> pure $ case result of
+    NoIntegrityErrors -> "🎉 No issues detected 🎉"
+    IntegrityErrorDetected ns -> prettyPrintIntegrityErrors ns
   where
     _nameChange _cmd _pastTenseCmd _oldName _newName _r = error "todo"
 

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -134,6 +134,7 @@ library
     , unison-prelude
     , unison-pretty-printer
     , unison-share-api
+    , unison-sqlite
     , unison-util
     , unison-util-relation
     , unliftio
@@ -228,6 +229,7 @@ executable cli-integration-tests
     , unison-prelude
     , unison-pretty-printer
     , unison-share-api
+    , unison-sqlite
     , unison-util
     , unison-util-relation
     , unliftio
@@ -317,6 +319,7 @@ executable transcripts
     , unison-prelude
     , unison-pretty-printer
     , unison-share-api
+    , unison-sqlite
     , unison-util
     , unison-util-relation
     , unliftio
@@ -410,6 +413,7 @@ executable unison
     , unison-prelude
     , unison-pretty-printer
     , unison-share-api
+    , unison-sqlite
     , unison-util
     , unison-util-relation
     , unliftio
@@ -507,6 +511,7 @@ test-suite cli-tests
     , unison-prelude
     , unison-pretty-printer
     , unison-share-api
+    , unison-sqlite
     , unison-util
     , unison-util-relation
     , unliftio


### PR DESCRIPTION
## Overview

Over the last few migrations we've noticed there are actually a lot of invariants we expect on our codebases which aren't (currently) expressed via database constraints. As a result we've gotten ourselves into more than a few messes that have taken a lot of work to clean up.

#3073 adds some manual database integrity checks which will now run after every migration, but I've also added these to be runnable on-demand with the `debug.doctor` command. This may also be helpful when troubleshooting issues with users.

We can continue to add additional checks as we go along.

```
.> debug.doctor
Checking Hash Object Integrity...
Checking Namespace Integrity...
Checking Causal Integrity...

  🎉 No issues detected 🎉
```



## Implementation notes

Runs the integrity checks added in #3073  on demand, then prints output on any failures.