### PR TITLE
Allow overriding share host via UNISON_SHARE_HOST env var.

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/AuthLogin.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/AuthLogin.hs
@@ -1,17 +1,22 @@
-{-# LANGUAGE RecordWildCards #-}
-
 module Unison.Codebase.Editor.HandleInput.AuthLogin (authLogin) where
 
 import Control.Monad.Reader
+import qualified Data.Text as Text
+import System.IO.Unsafe (unsafePerformIO)
 import Unison.Auth.OAuth
 import Unison.Auth.Types (Host (..))
 import Unison.Codebase.Editor.HandleInput.LoopState
 import Unison.Codebase.Editor.Output (Output (CredentialFailureMsg, Success))
 import Unison.Prelude
 import qualified UnliftIO
+import UnliftIO.Environment (lookupEnv)
 
 defaultShareHost :: Host
-defaultShareHost = Host "enlil.unison-lang.org"
+defaultShareHost = unsafePerformIO $ do
+  lookupEnv "UNISON_SHARE_HOST" <&> \case
+    Nothing -> Host "share.unison-lang.org"
+    Just shareHost -> Host (Text.pack shareHost)
+{-# NOINLINE defaultShareHost #-}
 
 authLogin :: UnliftIO.MonadUnliftIO m => Maybe Host -> Action m i v ()
 authLogin mayHost = do

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/AuthLogin.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/AuthLogin.hs
@@ -14,7 +14,8 @@ import UnliftIO.Environment (lookupEnv)
 defaultShareHost :: Host
 defaultShareHost = unsafePerformIO $ do
   lookupEnv "UNISON_SHARE_HOST" <&> \case
-    Nothing -> Host "share.unison-lang.org"
+    -- TODO: swap to production share before release.
+    Nothing -> Host "share-next.us-west-2.unison-lang.org"
     Just shareHost -> Host (Text.pack shareHost)
 {-# NOINLINE defaultShareHost #-}
 


### PR DESCRIPTION
## Overview

Users will just use the production instance of share, but we'll want to override that during development.

You can now specify your share host like so:

```
UNISON_SHARE_HOST=my-share-host.unison-lang.org ucm
```

## Implementation notes

I'm just using `unsafePerformIO` to check the env var for now, should be fine; and this is only for development anyways.
