### PR TITLE
Add more flexibility in our ability to specify codeservers

### DIFF
--- a/unison-cli/src/Unison/Auth/CredentialManager.hs
+++ b/unison-cli/src/Unison/Auth/CredentialManager.hs
@@ -11,7 +11,7 @@ where
 import Unison.Auth.CredentialFile
 import Unison.Auth.Types
 import Unison.Prelude
-import Unison.Share.Types (CodeserverHost)
+import Unison.Share.Types (CodeserverId)
 import qualified UnliftIO
 
 -- | A 'CredentialManager' knows how to load, save, and cache credentials.
@@ -22,7 +22,7 @@ import qualified UnliftIO
 newtype CredentialManager = CredentialManager (UnliftIO.MVar Credentials)
 
 -- | Saves credentials to the active profile.
-saveTokens :: UnliftIO.MonadUnliftIO m => CredentialManager -> CodeserverHost -> Tokens -> m ()
+saveTokens :: UnliftIO.MonadUnliftIO m => CredentialManager -> CodeserverId -> Tokens -> m ()
 saveTokens credManager aud tokens = do
   void . modifyCredentials credManager $ setActiveTokens aud tokens
 
@@ -33,7 +33,7 @@ modifyCredentials (CredentialManager credsVar) f = do
     newCreds <- atomicallyModifyCredentialsFile f
     pure (newCreds, newCreds)
 
-getTokens :: MonadIO m => CredentialManager -> CodeserverHost -> m (Either CredentialFailure Tokens)
+getTokens :: MonadIO m => CredentialManager -> CodeserverId -> m (Either CredentialFailure Tokens)
 getTokens (CredentialManager credsVar) aud = do
   creds <- UnliftIO.readMVar credsVar
   pure $ getActiveTokens aud creds

--- a/unison-cli/src/Unison/Auth/CredentialManager.hs
+++ b/unison-cli/src/Unison/Auth/CredentialManager.hs
@@ -11,6 +11,7 @@ where
 import Unison.Auth.CredentialFile
 import Unison.Auth.Types
 import Unison.Prelude
+import Unison.Share.Types (CodeserverHost)
 import qualified UnliftIO
 
 -- | A 'CredentialManager' knows how to load, save, and cache credentials.
@@ -21,7 +22,7 @@ import qualified UnliftIO
 newtype CredentialManager = CredentialManager (UnliftIO.MVar Credentials)
 
 -- | Saves credentials to the active profile.
-saveTokens :: UnliftIO.MonadUnliftIO m => CredentialManager -> Host -> Tokens -> m ()
+saveTokens :: UnliftIO.MonadUnliftIO m => CredentialManager -> CodeserverHost -> Tokens -> m ()
 saveTokens credManager aud tokens = do
   void . modifyCredentials credManager $ setActiveTokens aud tokens
 
@@ -32,7 +33,7 @@ modifyCredentials (CredentialManager credsVar) f = do
     newCreds <- atomicallyModifyCredentialsFile f
     pure (newCreds, newCreds)
 
-getTokens :: MonadIO m => CredentialManager -> Host -> m (Either CredentialFailure Tokens)
+getTokens :: MonadIO m => CredentialManager -> CodeserverHost -> m (Either CredentialFailure Tokens)
 getTokens (CredentialManager credsVar) aud = do
   creds <- UnliftIO.readMVar credsVar
   pure $ getActiveTokens aud creds

--- a/unison-cli/src/Unison/Auth/Discovery.hs
+++ b/unison-cli/src/Unison/Auth/Discovery.hs
@@ -6,12 +6,13 @@ import qualified Network.HTTP.Client as HTTP
 import Network.URI
 import Unison.Auth.Types
 import Unison.Prelude
-import Unison.Share.Types (CodeserverURI (..))
+import Unison.Share.Types (CodeserverURI (..), codeserverToURI)
 import qualified UnliftIO
 
 discoveryURI :: CodeserverURI -> URI
-discoveryURI (CodeserverURI uri) =
-  uri {uriPath = uriPath uri <> "/.well-known/openid-configuration"}
+discoveryURI cs =
+  let uri = codeserverToURI cs
+   in uri {uriPath = uriPath uri <> "/.well-known/openid-configuration"}
 
 discoveryForCodeserver :: MonadIO m => HTTP.Manager -> CodeserverURI -> m (Either CredentialFailure DiscoveryDoc)
 discoveryForCodeserver httpClient host = liftIO . UnliftIO.try @_ @CredentialFailure $ do

--- a/unison-cli/src/Unison/Auth/Discovery.hs
+++ b/unison-cli/src/Unison/Auth/Discovery.hs
@@ -4,19 +4,18 @@ import qualified Data.Aeson as Aeson
 import qualified Data.Text as Text
 import qualified Network.HTTP.Client as HTTP
 import Network.URI
-import qualified Network.URI as URI
 import Unison.Auth.Types
 import Unison.Prelude
+import Unison.Share.Types (CodeserverURI (..))
 import qualified UnliftIO
 
-discoveryURI :: Host -> Either CredentialFailure URI
-discoveryURI (Host host) =
-  maybeToEither (InvalidHost (Host host)) (URI.parseURI ("https://" <> Text.unpack host)) <&> \host ->
-    host {uriPath = "/.well-known/openid-configuration"}
+discoveryURI :: CodeserverURI -> URI
+discoveryURI (CodeserverURI uri) =
+  uri {uriPath = uriPath uri <> "/.well-known/openid-configuration"}
 
-discoveryForHost :: MonadIO m => HTTP.Manager -> Host -> m (Either CredentialFailure DiscoveryDoc)
-discoveryForHost httpClient host = liftIO . UnliftIO.try @_ @CredentialFailure $ do
-  uri <- UnliftIO.fromEither $ discoveryURI host
+discoveryForCodeserver :: MonadIO m => HTTP.Manager -> CodeserverURI -> m (Either CredentialFailure DiscoveryDoc)
+discoveryForCodeserver httpClient host = liftIO . UnliftIO.try @_ @CredentialFailure $ do
+  let uri = discoveryURI host
   req <- HTTP.requestFromURI uri
   resp <- HTTP.httpLbs req httpClient
   case Aeson.eitherDecode (HTTP.responseBody $ resp) of

--- a/unison-cli/src/Unison/Auth/HTTPClient.hs
+++ b/unison-cli/src/Unison/Auth/HTTPClient.hs
@@ -8,7 +8,7 @@ import Unison.Auth.CredentialManager (CredentialManager)
 import Unison.Auth.Tokens (TokenProvider, newTokenProvider)
 import Unison.Codebase.Editor.Command (UCMVersion)
 import Unison.Prelude
-import Unison.Share.Types (CodeserverURI (..), codeserverHostFromURI)
+import Unison.Share.Types (CodeserverURI (..), codeserverIdFromURI)
 import qualified Unison.Util.HTTP as HTTP
 
 -- | Newtype to delineate HTTP Managers with access-token logic.
@@ -32,7 +32,7 @@ newAuthorizedHTTPClient credsMan ucmVersion = liftIO $ do
 -- If a host isn't associated with any credentials auth is omitted.
 authMiddleware :: TokenProvider -> (Request -> IO Request)
 authMiddleware tokenProvider req = do
-  case (codeserverHostFromURI $ CodeserverURI (HTTP.getUri req)) of
+  case (codeserverIdFromURI $ CodeserverURI (HTTP.getUri req)) of
     Left _ -> pure req
     Right codeserverHost -> do
       result <- tokenProvider codeserverHost

--- a/unison-cli/src/Unison/Auth/HTTPClient.hs
+++ b/unison-cli/src/Unison/Auth/HTTPClient.hs
@@ -8,7 +8,7 @@ import Unison.Auth.CredentialManager (CredentialManager)
 import Unison.Auth.Tokens (TokenProvider, newTokenProvider)
 import Unison.Codebase.Editor.Command (UCMVersion)
 import Unison.Prelude
-import Unison.Share.Types (CodeserverURI (..), codeserverIdFromURI)
+import Unison.Share.Types (codeserverIdFromURI)
 import qualified Unison.Util.HTTP as HTTP
 
 -- | Newtype to delineate HTTP Managers with access-token logic.
@@ -32,7 +32,7 @@ newAuthorizedHTTPClient credsMan ucmVersion = liftIO $ do
 -- If a host isn't associated with any credentials auth is omitted.
 authMiddleware :: TokenProvider -> (Request -> IO Request)
 authMiddleware tokenProvider req = do
-  case (codeserverIdFromURI $ CodeserverURI (HTTP.getUri req)) of
+  case (codeserverIdFromURI $ (HTTP.getUri req)) of
     Left _ -> pure req
     Right codeserverHost -> do
       result <- tokenProvider codeserverHost

--- a/unison-cli/src/Unison/Auth/OAuth.hs
+++ b/unison-cli/src/Unison/Auth/OAuth.hs
@@ -24,7 +24,7 @@ import Unison.Codebase.Editor.HandleInput.LoopState (MonadCommand, respond)
 import qualified Unison.Codebase.Editor.Output as Output
 import Unison.Debug
 import Unison.Prelude
-import Unison.Share.Types (CodeserverURI, codeserverIdFromURI)
+import Unison.Share.Types (CodeserverURI, codeserverIdFromCodeserverURI)
 import qualified UnliftIO
 import qualified Web.Browser as Web
 
@@ -77,8 +77,8 @@ authenticateCodeserver credsManager codeserverURI = UnliftIO.try @_ @CredentialF
     void . liftIO $ Web.openBrowser (show authorizationKickoff)
     respond . Output.InitiateAuthFlow $ authorizationKickoff
     tokens <- throwCredFailure $ UnliftIO.readMVar authResultVar
-    codeserverHost <- throwCredFailure . pure . mapLeft (const $ InvalidHost codeserverURI) $ codeserverIdFromURI codeserverURI
-    saveTokens credsManager codeserverHost tokens
+    let codeserverId = codeserverIdFromCodeserverURI codeserverURI
+    saveTokens credsManager codeserverId tokens
   where
     throwCredFailure :: m (Either CredentialFailure a) -> m a
     throwCredFailure = throwEitherM

--- a/unison-cli/src/Unison/Auth/OAuth.hs
+++ b/unison-cli/src/Unison/Auth/OAuth.hs
@@ -24,7 +24,7 @@ import Unison.Codebase.Editor.HandleInput.LoopState (MonadCommand, respond)
 import qualified Unison.Codebase.Editor.Output as Output
 import Unison.Debug
 import Unison.Prelude
-import Unison.Share.Types (CodeserverURI, codeserverHostFromURI)
+import Unison.Share.Types (CodeserverURI, codeserverIdFromURI)
 import qualified UnliftIO
 import qualified Web.Browser as Web
 
@@ -77,7 +77,7 @@ authenticateCodeserver credsManager codeserverURI = UnliftIO.try @_ @CredentialF
     void . liftIO $ Web.openBrowser (show authorizationKickoff)
     respond . Output.InitiateAuthFlow $ authorizationKickoff
     tokens <- throwCredFailure $ UnliftIO.readMVar authResultVar
-    codeserverHost <- throwCredFailure . pure . mapLeft (const $ InvalidHost codeserverURI) $ codeserverHostFromURI codeserverURI
+    codeserverHost <- throwCredFailure . pure . mapLeft (const $ InvalidHost codeserverURI) $ codeserverIdFromURI codeserverURI
     saveTokens credsManager codeserverHost tokens
   where
     throwCredFailure :: m (Either CredentialFailure a) -> m a

--- a/unison-cli/src/Unison/Auth/Tokens.hs
+++ b/unison-cli/src/Unison/Auth/Tokens.hs
@@ -7,6 +7,7 @@ import Unison.Auth.Types
 import Unison.CommandLine.InputPattern (patternName)
 import qualified Unison.CommandLine.InputPatterns as IP
 import Unison.Prelude
+import Unison.Share.Types (CodeserverHost)
 import qualified UnliftIO
 import UnliftIO.Exception
 import Web.JWT
@@ -23,7 +24,7 @@ isExpired accessToken = liftIO do
 
 -- | Given a 'Host', provide a valid 'AccessToken' for the associated host.
 -- The TokenProvider may automatically refresh access tokens if we have a refresh token.
-type TokenProvider = Host -> IO (Either CredentialFailure AccessToken)
+type TokenProvider = CodeserverHost -> IO (Either CredentialFailure AccessToken)
 
 -- | Creates a 'TokenProvider' using the given 'CredentialManager'
 newTokenProvider :: CredentialManager -> TokenProvider
@@ -38,7 +39,7 @@ newTokenProvider manager host = UnliftIO.try @_ @CredentialFailure $ do
     else pure accessToken
 
 -- | Don't yet support automatically refreshing tokens.
-refreshTokens :: MonadIO m => CredentialManager -> Host -> Tokens -> m (Either CredentialFailure Tokens)
+refreshTokens :: MonadIO m => CredentialManager -> CodeserverHost -> Tokens -> m (Either CredentialFailure Tokens)
 refreshTokens _manager _host _tokens =
   -- Refreshing tokens is currently unsupported.
   pure (Left (RefreshFailure . Text.pack $ "Unable to refresh authentication, please run " <> patternName IP.authLogin <> " and try again."))

--- a/unison-cli/src/Unison/Auth/Tokens.hs
+++ b/unison-cli/src/Unison/Auth/Tokens.hs
@@ -22,7 +22,7 @@ isExpired accessToken = liftIO do
   let expiry = JWT.secondsSinceEpoch expDate
   pure (now >= expiry)
 
--- | Given a 'Host', provide a valid 'AccessToken' for the associated host.
+-- | Given a 'CodeserverId', provide a valid 'AccessToken' for the associated host.
 -- The TokenProvider may automatically refresh access tokens if we have a refresh token.
 type TokenProvider = CodeserverId -> IO (Either CredentialFailure AccessToken)
 

--- a/unison-cli/src/Unison/Auth/Tokens.hs
+++ b/unison-cli/src/Unison/Auth/Tokens.hs
@@ -7,7 +7,7 @@ import Unison.Auth.Types
 import Unison.CommandLine.InputPattern (patternName)
 import qualified Unison.CommandLine.InputPatterns as IP
 import Unison.Prelude
-import Unison.Share.Types (CodeserverHost)
+import Unison.Share.Types (CodeserverId)
 import qualified UnliftIO
 import UnliftIO.Exception
 import Web.JWT
@@ -24,7 +24,7 @@ isExpired accessToken = liftIO do
 
 -- | Given a 'Host', provide a valid 'AccessToken' for the associated host.
 -- The TokenProvider may automatically refresh access tokens if we have a refresh token.
-type TokenProvider = CodeserverHost -> IO (Either CredentialFailure AccessToken)
+type TokenProvider = CodeserverId -> IO (Either CredentialFailure AccessToken)
 
 -- | Creates a 'TokenProvider' using the given 'CredentialManager'
 newTokenProvider :: CredentialManager -> TokenProvider
@@ -39,7 +39,7 @@ newTokenProvider manager host = UnliftIO.try @_ @CredentialFailure $ do
     else pure accessToken
 
 -- | Don't yet support automatically refreshing tokens.
-refreshTokens :: MonadIO m => CredentialManager -> CodeserverHost -> Tokens -> m (Either CredentialFailure Tokens)
+refreshTokens :: MonadIO m => CredentialManager -> CodeserverId -> Tokens -> m (Either CredentialFailure Tokens)
 refreshTokens _manager _host _tokens =
   -- Refreshing tokens is currently unsupported.
   pure (Left (RefreshFailure . Text.pack $ "Unable to refresh authentication, please run " <> patternName IP.authLogin <> " and try again."))

--- a/unison-cli/src/Unison/Auth/Types.hs
+++ b/unison-cli/src/Unison/Auth/Types.hs
@@ -29,13 +29,13 @@ import Data.Time (NominalDiffTime)
 import Network.URI
 import qualified Network.URI as URI
 import Unison.Prelude
-import Unison.Share.Types (CodeserverHost, CodeserverURI)
+import Unison.Share.Types (CodeserverId, CodeserverURI)
 
 defaultProfileName :: ProfileName
 defaultProfileName = "default"
 
 data CredentialFailure
-  = ReauthRequired CodeserverHost
+  = ReauthRequired CodeserverId
   | CredentialParseFailure FilePath Text
   | InvalidDiscoveryDocument URI Text
   | InvalidJWT Text
@@ -128,7 +128,7 @@ instance Aeson.FromJSON DiscoveryDoc where
 type ProfileName = Text
 
 data Credentials = Credentials
-  { credentials :: Map ProfileName (Map CodeserverHost Tokens),
+  { credentials :: Map ProfileName (Map CodeserverId Tokens),
     activeProfile :: ProfileName
   }
   deriving (Eq)
@@ -136,12 +136,12 @@ data Credentials = Credentials
 emptyCredentials :: Credentials
 emptyCredentials = Credentials mempty defaultProfileName
 
-getActiveTokens :: CodeserverHost -> Credentials -> Either CredentialFailure Tokens
+getActiveTokens :: CodeserverId -> Credentials -> Either CredentialFailure Tokens
 getActiveTokens host (Credentials {credentials, activeProfile}) =
   maybeToEither (ReauthRequired host) $
     credentials ^? ix activeProfile . ix host
 
-setActiveTokens :: CodeserverHost -> Tokens -> Credentials -> Credentials
+setActiveTokens :: CodeserverId -> Tokens -> Credentials -> Credentials
 setActiveTokens host tokens creds@(Credentials {credentials, activeProfile}) =
   let newCredMap =
         credentials

--- a/unison-cli/src/Unison/Auth/Types.hs
+++ b/unison-cli/src/Unison/Auth/Types.hs
@@ -14,7 +14,6 @@ module Unison.Auth.Types
     PKCEChallenge,
     ProfileName,
     CredentialFailure (..),
-    Host (..),
     getActiveTokens,
     setActiveTokens,
     emptyCredentials,
@@ -22,7 +21,7 @@ module Unison.Auth.Types
 where
 
 import Control.Lens hiding ((.=))
-import Data.Aeson (FromJSON (..), FromJSONKey, KeyValue ((.=)), ToJSON (..), ToJSONKey, (.:), (.:?))
+import Data.Aeson (FromJSON (..), KeyValue ((.=)), ToJSON (..), (.:), (.:?))
 import qualified Data.Aeson as Aeson
 import qualified Data.Map as Map
 import qualified Data.Text as Text
@@ -30,18 +29,19 @@ import Data.Time (NominalDiffTime)
 import Network.URI
 import qualified Network.URI as URI
 import Unison.Prelude
+import Unison.Share.Types (CodeserverHost, CodeserverURI)
 
 defaultProfileName :: ProfileName
 defaultProfileName = "default"
 
 data CredentialFailure
-  = ReauthRequired Host
+  = ReauthRequired CodeserverHost
   | CredentialParseFailure FilePath Text
   | InvalidDiscoveryDocument URI Text
   | InvalidJWT Text
   | RefreshFailure Text
   | InvalidTokenResponse URI Text
-  | InvalidHost Host
+  | InvalidHost CodeserverURI
   deriving stock (Show, Eq)
   deriving anyclass (Exception)
 
@@ -127,14 +127,8 @@ instance Aeson.FromJSON DiscoveryDoc where
 
 type ProfileName = Text
 
--- | The hostname of a server we may authenticate with,
--- e.g. @Host "enlil.unison-lang.org"@
-newtype Host = Host Text
-  deriving stock (Eq, Ord, Show)
-  deriving newtype (ToJSON, FromJSON, ToJSONKey, FromJSONKey)
-
 data Credentials = Credentials
-  { credentials :: Map ProfileName (Map Host Tokens),
+  { credentials :: Map ProfileName (Map CodeserverHost Tokens),
     activeProfile :: ProfileName
   }
   deriving (Eq)
@@ -142,12 +136,12 @@ data Credentials = Credentials
 emptyCredentials :: Credentials
 emptyCredentials = Credentials mempty defaultProfileName
 
-getActiveTokens :: Host -> Credentials -> Either CredentialFailure Tokens
+getActiveTokens :: CodeserverHost -> Credentials -> Either CredentialFailure Tokens
 getActiveTokens host (Credentials {credentials, activeProfile}) =
   maybeToEither (ReauthRequired host) $
     credentials ^? ix activeProfile . ix host
 
-setActiveTokens :: Host -> Tokens -> Credentials -> Credentials
+setActiveTokens :: CodeserverHost -> Tokens -> Credentials -> Credentials
 setActiveTokens host tokens creds@(Credentials {credentials, activeProfile}) =
   let newCredMap =
         credentials

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -29,7 +29,6 @@ import Data.Tuple.Extra (uncurry3)
 import qualified Text.Megaparsec as P
 import U.Util.Timing (unsafeTime)
 import qualified Unison.ABT as ABT
-import Unison.Auth.Types (Host (Host))
 import qualified Unison.Builtin as Builtin
 import qualified Unison.Builtin.Decls as DD
 import qualified Unison.Builtin.Terms as Builtin
@@ -1645,7 +1644,7 @@ loop = do
                   mayHost <- eval $ ConfigLookup ("CodeServers." <> codeServer)
                   case mayHost of
                     Nothing -> respond (UnknownCodeServer codeServer)
-                    Just host -> authLogin (Just $ Host host)
+                    Just codeserverURI -> authLogin (Just codeserverURI)
             VersionI -> do
               ucmVersion <- eval UCMVersion
               respond $ PrintVersion ucmVersion

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1637,14 +1637,7 @@ loop = do
             UpdateBuiltinsI -> notImplemented
             QuitI -> empty
             GistI input -> handleGist input
-            AuthLoginI mayCodebaseServer -> do
-              case mayCodebaseServer of
-                Nothing -> authLogin Nothing
-                Just codeServer -> do
-                  mayHost <- eval $ ConfigLookup ("CodeServers." <> codeServer)
-                  case mayHost of
-                    Nothing -> respond (UnknownCodeServer codeServer)
-                    Just codeserverURI -> authLogin (Just codeserverURI)
+            AuthLoginI -> authLogin
             VersionI -> do
               ucmVersion <- eval UCMVersion
               respond $ PrintVersion ucmVersion

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/AuthLogin.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/AuthLogin.hs
@@ -1,8 +1,7 @@
 module Unison.Codebase.Editor.HandleInput.AuthLogin (authLogin) where
 
 import Control.Monad.Reader
-import Data.Maybe (fromJust)
-import Network.URI (parseURI)
+import Network.URI (URIAuth (..), parseURI)
 import System.IO.Unsafe (unsafePerformIO)
 import Unison.Auth.OAuth (authenticateCodeserver)
 import Unison.Codebase.Editor.HandleInput.LoopState
@@ -18,11 +17,15 @@ defaultShareURI = unsafePerformIO $ do
   lookupEnv "UNISON_SHARE_HOST" <&> \case
     -- TODO: swap to production share before release.
     Nothing ->
-      CodeserverURI . fromJust . parseURI $ "https://share-next.us-west-2.unison-lang.org/api"
+      CodeserverURI
+        { codeserverScheme = "https:",
+          codeserverAuthority = URIAuth {uriUserInfo = "", uriRegName = "share-next.us-west-2.unison-lang.org", uriPort = ""},
+          codeserverPath = "/api"
+        }
     Just shareHost ->
-      case parseURI shareHost of
-        Nothing -> error $ "Share Host is not a valid URI: " <> shareHost
-        Just uri -> CodeserverURI uri
+      fromMaybe (error $ "Share Host is not a valid URI: " <> shareHost) $ do
+        uri <- parseURI shareHost
+        codeserverFromURI uri
 {-# NOINLINE defaultShareURI #-}
 
 authLogin :: UnliftIO.MonadUnliftIO m => Action m i v ()

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/AuthLogin.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/AuthLogin.hs
@@ -25,9 +25,9 @@ defaultShareURI = unsafePerformIO $ do
         Just uri -> CodeserverURI uri
 {-# NOINLINE defaultShareURI #-}
 
-authLogin :: UnliftIO.MonadUnliftIO m => Maybe CodeserverURI -> Action m i v ()
-authLogin mayURI = do
-  let host = fromMaybe defaultShareURI mayURI
+authLogin :: UnliftIO.MonadUnliftIO m => Action m i v ()
+authLogin = do
+  let host = defaultShareURI
   credsMan <- asks credentialManager
   (Action . lift . lift . lift $ authenticateCodeserver credsMan host) >>= \case
     Left err -> respond (CredentialFailureMsg err)

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -44,8 +44,6 @@ type SourceName = Text -- "foo.u" or "buffer 7"
 
 type PatchPath = Path.Split'
 
-type CodebaseServerName = Text
-
 data OptionalPatch = NoPatch | DefaultPatch | UsePatch PatchPath
   deriving (Eq, Ord, Show)
 
@@ -186,7 +184,7 @@ data Input
   | UiI
   | DocsToHtmlI Path' FilePath
   | GistI GistInput
-  | AuthLoginI (Maybe CodebaseServerName)
+  | AuthLoginI
   | VersionI
   deriving (Eq, Show)
 

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -294,23 +294,23 @@ patch =
     I.Visible
     [(Required, patchArg), (Optional, namespaceArg)]
     ( P.lines
-      [ P.wrap $
-        makeExample' patch
-        <> "rewrites any definitions that depend on "
-        <> "definitions with type-preserving edits to use the updated versions of"
-        <> "these dependencies.",
-        "",
-        P.wrapColumn2
-        [ ( makeExample patch  ["<patch>", "[path]"],
-            "applies the given patch"
-            <> "to the given namespace"
-          ),
-          ( makeExample patch ["<patch>"],
-            "applies the given patch"
-            <> "to the current namespace"
-          )
+        [ P.wrap $
+            makeExample' patch
+              <> "rewrites any definitions that depend on "
+              <> "definitions with type-preserving edits to use the updated versions of"
+              <> "these dependencies.",
+          "",
+          P.wrapColumn2
+            [ ( makeExample patch ["<patch>", "[path]"],
+                "applies the given patch"
+                  <> "to the given namespace"
+              ),
+              ( makeExample patch ["<patch>"],
+                "applies the given patch"
+                  <> "to the current namespace"
+              )
+            ]
         ]
-      ]
     )
     ( \case
         patchStr : ws -> first fromString $ do
@@ -2040,20 +2040,15 @@ authLogin =
     "auth.login"
     []
     I.Hidden
-    [(Optional, noCompletions)]
+    []
     ( P.lines
-        [ P.wrap "Obtain an authentication session with Unison Share or a specified codeserver host.",
+        [ P.wrap "Obtain an authentication session with Unison Share.",
           makeExample authLogin []
-            <> "authenticates ucm with Unison Share.",
-          makeExample authLogin ["mycodeserver"]
-            <> "authenticates ucm with the host configured at"
-            <> P.backticked "CodeServers.mycodeserver"
-            <> "in your .unisonConfig"
+            <> "authenticates ucm with Unison Share."
         ]
     )
     ( \case
-        [] -> Right $ Input.AuthLoginI Nothing
-        [codebaseServerName] -> Right . Input.AuthLoginI $ Just (Text.pack codebaseServerName)
+        [] -> Right $ Input.AuthLoginI
         _ -> Left (showPatternHelp authLogin)
     )
 

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1547,9 +1547,9 @@ notifyUser dir o = case o of
           "You can configure code server hosts in your .unisonConfig file."
         ]
   CredentialFailureMsg err -> pure $ case err of
-    Auth.ReauthRequired (Auth.Host host) ->
+    Auth.ReauthRequired host ->
       P.lines
-        [ "Authentication for host " <> P.red (P.text host) <> " is required.",
+        [ "Authentication for host " <> P.red (P.shown host) <> " is required.",
           "Run " <> IP.makeExample IP.help [IP.patternName IP.authLogin]
             <> " to learn how."
         ]
@@ -1575,9 +1575,9 @@ notifyUser dir o = case o of
         [ "Failed to parse token response from authentication server: " <> prettyURI uri,
           "The error was: " <> P.text txt
         ]
-    Auth.InvalidHost (Auth.Host host) ->
+    Auth.InvalidHost host ->
       P.lines
-        [ "Failed to parse a URI from the hostname: " <> P.text host <> ".",
+        [ "Failed to parse a URI from the hostname: " <> P.shown host <> ".",
           "Host names should NOT include a schema or path."
         ]
   PrintVersion ucmVersion -> pure (P.text ucmVersion)

--- a/unison-cli/src/Unison/Share/Types.hs
+++ b/unison-cli/src/Unison/Share/Types.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE DeriveAnyClass #-}
+
+module Unison.Share.Types where
+
+import Data.Aeson
+import qualified Data.Configurator.Types as Configurator
+import Data.Text
+import qualified Data.Text as Text
+import Network.URI
+import Unison.Prelude
+
+newtype CodeserverURI = CodeserverURI URI
+  deriving newtype (Show, Eq, Ord)
+
+instance Configurator.Configured CodeserverURI where
+  convert = \case
+    Configurator.String txt ->
+      CodeserverURI <$> parseURI (Text.unpack txt)
+    _ -> Nothing
+
+-- foldMap Just . fromJSON
+
+-- | This is distinct from the codeserver URI in that we store credentials by host, since it's
+-- much easier to look up that way than from an arbitrary path.
+-- We may wish to use explicitly named configurations in the future.
+newtype CodeserverHost = CodeserverHost URIAuth
+  deriving newtype (Show, Eq, Ord)
+  deriving anyclass (ToJSONKey, FromJSONKey)
+
+instance ToJSON CodeserverHost where
+  toJSON (CodeserverHost uri) = toJSON $ show uri
+
+instance FromJSON CodeserverHost where
+  parseJSON =
+    withText "CodeserverHost" $ \txt ->
+      either (fail . Text.unpack) pure $ parseCodeserverHost txt
+
+parseCodeserverHost :: Text -> Either Text CodeserverHost
+parseCodeserverHost txt =
+  case parseURI (Text.unpack txt) of
+    Nothing -> Left $ "Invalid URI" <> txt
+    Just uri -> case uriAuthority uri of
+      Nothing -> Left $ "Invalid URI Authority" <> txt
+      Just ua -> pure (CodeserverHost ua)
+
+codeserverHostFromURI :: CodeserverURI -> Either Text CodeserverHost
+codeserverHostFromURI (CodeserverURI uri) =
+  case uriAuthority uri of
+    Nothing -> Left $ "No URI Authority for URI " <> tShow uri
+    Just ua -> pure (CodeserverHost ua)

--- a/unison-cli/src/Unison/Share/Types.hs
+++ b/unison-cli/src/Unison/Share/Types.hs
@@ -1,45 +1,47 @@
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Unison.Share.Types where
 
 import Data.Aeson
-import qualified Data.Aeson.Types as Aeson
-import qualified Data.Configurator.Types as Configurator
-import Data.Functor.Contravariant (contramap)
 import Data.Text
 import qualified Data.Text as Text
 import Network.URI
 import Unison.Prelude
 
-newtype CodeserverURI = CodeserverURI URI
-  deriving newtype (Show, Eq, Ord)
+data CodeserverURI = CodeserverURI
+  { codeserverScheme :: String,
+    codeserverAuthority :: URIAuth,
+    codeserverPath :: String
+  }
+  deriving stock (Show, Eq, Ord)
 
-instance Configurator.Configured CodeserverURI where
-  convert = \case
-    Configurator.String txt ->
-      CodeserverURI <$> parseURI (Text.unpack txt)
-    _ -> Nothing
+codeserverToURI :: CodeserverURI -> URI
+codeserverToURI (CodeserverURI {..}) =
+  URI
+    { uriScheme = codeserverScheme,
+      uriAuthority = Just codeserverAuthority,
+      uriPath = codeserverPath,
+      uriQuery = "",
+      uriFragment = ""
+    }
+
+codeserverFromURI :: URI -> Maybe CodeserverURI
+codeserverFromURI URI {..} = do
+  uriAuth <- uriAuthority
+  pure $
+    CodeserverURI
+      { codeserverScheme = uriScheme,
+        codeserverAuthority = uriAuth,
+        codeserverPath = uriPath
+      }
 
 -- | This is distinct from the codeserver URI in that we store credentials by a normalized ID, since it's
 -- much easier to look up that way than from an arbitrary path.
 -- We may wish to use explicitly named configurations in the future.
 -- This currently uses the 'uriRegName' from a parsed URI as the identifier.
 newtype CodeserverId = CodeserverId {codeserverId :: Text}
-  deriving newtype (Show, Eq, Ord)
-
-instance ToJSON CodeserverId where
-  toJSON (CodeserverId txt) =
-    toJSON txt
-
-instance ToJSONKey CodeserverId where
-  toJSONKey = contramap codeserverId toJSONKey
-
-instance FromJSONKey CodeserverId where
-  fromJSONKey = Aeson.FromJSONKeyText CodeserverId
-
-instance FromJSON CodeserverId where
-  parseJSON =
-    withText "CodeserverId" $ pure . CodeserverId
+  deriving newtype (Show, Eq, Ord, ToJSON, FromJSON, ToJSONKey, FromJSONKey)
 
 -- | Gets the part of the CodeserverURI that we use for identifying that codeserver in
 -- credentials files.
@@ -47,11 +49,14 @@ instance FromJSON CodeserverId where
 -- >>> import Data.Maybe (fromJust)
 -- >>> import Network.URI (parseURI)
 -- >>> codeserverIdFromURI (CodeserverURI . fromJust $ parseURI "http://localhost:5424/api")
--- >>> codeserverIdFromURI (CodeserverURI . fromJust $ parseURI "https://api.share.unison-lang.org")
+-- >>> codeserverIdFromURI (CodeserverURI . fromJust $ parseURI "https://share.unison-lang.org/api")
 -- Right "localhost"
--- Right "api.share.unison-lang.org"
-codeserverIdFromURI :: CodeserverURI -> Either Text CodeserverId
-codeserverIdFromURI (CodeserverURI uri) =
+-- Right "share.unison-lang.org"
+codeserverIdFromURI :: URI -> Either Text CodeserverId
+codeserverIdFromURI uri =
   case uriAuthority uri of
     Nothing -> Left $ "No URI Authority for URI " <> tShow uri
     Just ua -> pure (CodeserverId (Text.pack $ uriRegName ua))
+
+codeserverIdFromCodeserverURI :: CodeserverURI -> CodeserverId
+codeserverIdFromCodeserverURI = CodeserverId . Text.pack . uriRegName . codeserverAuthority

--- a/unison-cli/src/Unison/Share/Types.hs
+++ b/unison-cli/src/Unison/Share/Types.hs
@@ -3,7 +3,9 @@
 module Unison.Share.Types where
 
 import Data.Aeson
+import qualified Data.Aeson.Types as Aeson
 import qualified Data.Configurator.Types as Configurator
+import Data.Functor.Contravariant (contramap)
 import Data.Text
 import qualified Data.Text as Text
 import Network.URI
@@ -18,33 +20,38 @@ instance Configurator.Configured CodeserverURI where
       CodeserverURI <$> parseURI (Text.unpack txt)
     _ -> Nothing
 
--- foldMap Just . fromJSON
-
--- | This is distinct from the codeserver URI in that we store credentials by host, since it's
+-- | This is distinct from the codeserver URI in that we store credentials by a normalized ID, since it's
 -- much easier to look up that way than from an arbitrary path.
 -- We may wish to use explicitly named configurations in the future.
-newtype CodeserverHost = CodeserverHost URIAuth
+-- This currently uses the 'uriRegName' from a parsed URI as the identifier.
+newtype CodeserverId = CodeserverId {codeserverId :: Text}
   deriving newtype (Show, Eq, Ord)
-  deriving anyclass (ToJSONKey, FromJSONKey)
 
-instance ToJSON CodeserverHost where
-  toJSON (CodeserverHost uri) = toJSON $ show uri
+instance ToJSON CodeserverId where
+  toJSON (CodeserverId txt) =
+    toJSON txt
 
-instance FromJSON CodeserverHost where
+instance ToJSONKey CodeserverId where
+  toJSONKey = contramap codeserverId toJSONKey
+
+instance FromJSONKey CodeserverId where
+  fromJSONKey = Aeson.FromJSONKeyText CodeserverId
+
+instance FromJSON CodeserverId where
   parseJSON =
-    withText "CodeserverHost" $ \txt ->
-      either (fail . Text.unpack) pure $ parseCodeserverHost txt
+    withText "CodeserverId" $ pure . CodeserverId
 
-parseCodeserverHost :: Text -> Either Text CodeserverHost
-parseCodeserverHost txt =
-  case parseURI (Text.unpack txt) of
-    Nothing -> Left $ "Invalid URI" <> txt
-    Just uri -> case uriAuthority uri of
-      Nothing -> Left $ "Invalid URI Authority" <> txt
-      Just ua -> pure (CodeserverHost ua)
-
-codeserverHostFromURI :: CodeserverURI -> Either Text CodeserverHost
-codeserverHostFromURI (CodeserverURI uri) =
+-- | Gets the part of the CodeserverURI that we use for identifying that codeserver in
+-- credentials files.
+--
+-- >>> import Data.Maybe (fromJust)
+-- >>> import Network.URI (parseURI)
+-- >>> codeserverIdFromURI (CodeserverURI . fromJust $ parseURI "http://localhost:5424/api")
+-- >>> codeserverIdFromURI (CodeserverURI . fromJust $ parseURI "https://api.share.unison-lang.org")
+-- Right "localhost"
+-- Right "api.share.unison-lang.org"
+codeserverIdFromURI :: CodeserverURI -> Either Text CodeserverId
+codeserverIdFromURI (CodeserverURI uri) =
   case uriAuthority uri of
     Nothing -> Left $ "No URI Authority for URI " <> tShow uri
-    Just ua -> pure (CodeserverHost ua)
+    Just ua -> pure (CodeserverId (Text.pack $ uriRegName ua))

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -59,6 +59,7 @@ library
       Unison.CommandLine.Main
       Unison.CommandLine.OutputMessages
       Unison.CommandLine.Welcome
+      Unison.Share.Types
       Unison.Sync.HTTP
       Unison.Util.HTTP
   other-modules:


### PR DESCRIPTION
# Overview

Currently there are two different ways to specify your codeserver;

* `CodeServers` in `.unisonConfig`, then specify an alias to `auth.login`
* Provide the `UNISON_SHARE_HOST` env var when running unison.

This deletes the `CodeServers` config option and removes the `auth.login` argument.

We also had the issue that it's not straight-forward to provide a port, http scheme, or additional path to the specified share server, this is important because:

* The share api is currently hosted at the `/api/` prefix on share (for now)
* We need to be able to run locally, which means overriding the scheme to http; and specifying a port number.
* We still need a way to canonically identify each host such that we can easily look up the credentials we need for that host from the stored credentials file.

## Implementation

* The rule for finding share server endpoint is now:
  * Take the value of `UNISON_SHARE_HOST`, or `https://share-next.us-west-2.unison-lang.org/api` as a default value, 
  * Append `/.well-known/openid-configuration` and fetch the discovery document
  * Use the routes provided in the discovery document to authenticate with that host.
  * After authenticating, store the credentials under the `uriRegName` from the provided URI in our credentials file; (E.g. `share.unison-lang.org` for `https://share.unison-lang.org/api`.
  * When making an authenticated request, check if we have credentials for the request's `uriRegName`, and if so, attach those credentials.