### PR TITLE
Set journal mode on create rather than open.

### DIFF
--- a/lib/unison-sqlite/src/Unison/Sqlite/JournalMode.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/JournalMode.hs
@@ -46,7 +46,7 @@ journalModeToText = \case
   JournalMode'OFF -> "off"
 
 trySetJournalMode :: MonadIO m => Connection -> JournalMode -> m ()
-trySetJournalMode conn mode0 = liftIO $ do
+trySetJournalMode conn mode0 = liftIO do
   queryOneRowCheck_
     conn
     (Sql ("PRAGMA journal_mode = " <> journalModeToText mode0))

--- a/lib/unison-sqlite/src/Unison/Sqlite/JournalMode.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/JournalMode.hs
@@ -8,9 +8,9 @@ where
 import qualified Data.Text as Text
 import qualified Database.SQLite.Simple as Sqlite
 import Unison.Prelude
+import Unison.Sqlite.Connection
 import Unison.Sqlite.Exception (SqliteExceptionReason)
 import Unison.Sqlite.Sql
-import Unison.Sqlite.Connection
 
 -- | https://www.sqlite.org/pragma.html#pragma_journal_mode
 data JournalMode
@@ -45,8 +45,8 @@ journalModeToText = \case
   JournalMode'WAL -> "wal"
   JournalMode'OFF -> "off"
 
-trySetJournalMode :: Connection -> JournalMode -> IO ()
-trySetJournalMode conn mode0 = do
+trySetJournalMode :: MonadIO m => Connection -> JournalMode -> m ()
+trySetJournalMode conn mode0 = liftIO $ do
   queryOneRowCheck_
     conn
     (Sql ("PRAGMA journal_mode = " <> journalModeToText mode0))

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -132,7 +132,7 @@ createCodebaseOrError debugName path action = do
     do
       createDirectoryIfMissing True (makeCodebaseDirPath path)
       withConnection (debugName ++ ".createSchema") path \conn -> do
-        liftIO $ Sqlite.trySetJournalMode conn Sqlite.JournalMode'WAL
+        Sqlite.trySetJournalMode conn Sqlite.JournalMode'WAL
         Sqlite.runTransaction conn do
           Q.createSchema
           void . Ops.saveRootBranch $ Cv.causalbranch1to2 Branch.empty
@@ -687,6 +687,10 @@ viewRemoteBranch' (repo, sbh, path) gitBranchBehavior action = UnliftIO.try $ do
   time "Git fetch" $
     throwEitherMWith C.GitProtocolError . withRepo repo gitBranchBehavior $ \remoteRepo -> do
       let remotePath = Git.gitDirToPath remoteRepo
+          -- In modern UCM all new codebases are created in WAL mode, but it's possible old
+          -- codebases were pushed to git in DELETE mode, so when pulling remote branches we
+          -- ensure we're in WAL mode just to be safe.
+          ensureWALMode conn = Sqlite.trySetJournalMode conn Sqlite.JournalMode'WAL
       -- Tickle the database before calling into `sqliteCodebase`; this covers the case that the database file either
       -- doesn't exist at all or isn't a SQLite database file, but does not cover the case that the database file itself
       -- is somehow corrupt, or not even a Unison database.
@@ -694,7 +698,7 @@ viewRemoteBranch' (repo, sbh, path) gitBranchBehavior action = UnliftIO.try $ do
       -- FIXME it would probably make more sense to define some proper preconditions on `sqliteCodebase`, and perhaps
       -- update its output type, which currently indicates the only way it can fail is with an `UnknownSchemaVersion`
       -- error.
-      (withConnection "codebase exists check" remotePath \_ -> pure ()) `catch` \exception ->
+      (withConnection "codebase exists check" remotePath ensureWALMode) `catch` \exception ->
         if Sqlite.isCantOpenException exception
           then throwIO (C.GitSqliteCodebaseError (GitError.NoDatabaseFile repo remotePath))
           else throwIO exception


### PR DESCRIPTION
## Overview

We previously set the journal mode to `WAL` every time we opened a connection, this likely because we would switch the journal mode to `DELETE` when pushing to ensure the database was fully synced from the `.wal` file.

Since then, we've done a lot of work to ensure our codebase connections are better managed, and no longer need to set `DELETE` mode on push because we close connections correctly before pushing.

Now, since we never switch away from WAL mode there's no reason to explicitly set WAL mode on every connection, and it's causing some issues in the Share server since we open the codebase for every request and setting the journal mode is requires locking the whole DB.

So, now we can just set WAL on every new codebase and assume all existing codebases are already in WAL mode.

## Implementation notes

* Set WAL mode when creating a new sqlite DB rather than on every new connection.
* Also set WAL mode when pulling from git repos, since it's possible some old codebases still exist which were pushed in DELETE mode.
