### PR TITLE
Bump megaparsec dependency

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -67,3 +67,4 @@ The format for this list: name, GitHub handle
 * Nicole Prindle (@nprindle)
 * Harald Gliebe (@hagl)
 * Phil de Joux (@philderbeast)
+* Travis Staton (@tstat)

--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -55,7 +55,7 @@ library:
     - http-client
     - lens
     - ListLike
-    - megaparsec >= 5.0.0 && < 7.0.0
+    - megaparsec
     - memory
     - mmorph
     - monad-validate

--- a/parser-typechecker/src/Unison/Lexer.hs
+++ b/parser-typechecker/src/Unison/Lexer.hs
@@ -49,7 +49,6 @@ import qualified Text.Megaparsec as P
 import Text.Megaparsec.Char (char)
 import qualified Text.Megaparsec.Char as CP
 import qualified Text.Megaparsec.Char.Lexer as LP
-import Text.Megaparsec.Error (ShowToken (..))
 import qualified Text.Megaparsec.Error as EP
 import qualified Text.Megaparsec.Internal as PI
 import Unison.Lexer.Pos (Column, Line, Pos (Pos), column, line)
@@ -68,7 +67,7 @@ data Token a = Token
     start :: !Pos,
     end :: !Pos
   }
-  deriving (Eq, Ord, Show, Functor)
+  deriving stock (Eq, Ord, Show, Functor, Foldable, Traversable)
 
 data ParsingEnv = ParsingEnv
   { layout :: !Layout, -- layout stack
@@ -92,7 +91,7 @@ local f p = do
     Left e -> parseFailure e
     Right a -> pure a
 
-parseFailure :: EP.ParseError Char (Token Err) -> P a
+parseFailure :: EP.ParseError [Char] (Token Err) -> P a
 parseFailure e = PI.ParsecT $ \s _ _ _ eerr -> eerr e s
 
 data Err
@@ -160,7 +159,7 @@ token = token' (\a start end -> [Token a start end])
 
 pos :: P Pos
 pos = do
-  p <- P.getPosition
+  p <- P.getSourcePos
   pure $ Pos (P.unPos (P.sourceLine p)) (P.unPos (P.sourceColumn p))
 
 -- Token parser: strips trailing whitespace and comments after a
@@ -175,7 +174,7 @@ err start t = do
   stop <- pos
   -- This consumes a character and therefore produces committed failure,
   -- so `err s t <|> p2` won't try `p2`
-  _ <- void CP.anyChar <|> P.eof
+  _ <- void P.anySingle <|> P.eof
   P.customFailure (Token t start stop)
 
 {-
@@ -249,17 +248,40 @@ token'' tok p = do
     topHasClosePair ((name, _) : _) =
       name `elem` ["{", "(", "[", "handle", "match", "if", "then"]
 
+showErrorFancy :: P.ShowErrorComponent e => P.ErrorFancy e -> String
+showErrorFancy (P.ErrorFail msg) = msg
+showErrorFancy (P.ErrorIndentation ord ref actual) =
+  "incorrect indentation (got " <> show (P.unPos actual)
+    <> ", should be "
+    <> p
+    <> show (P.unPos ref)
+    <> ")"
+  where
+    p = case ord of
+      LT -> "less than "
+      EQ -> "equal to "
+      GT -> "greater than "
+showErrorFancy (P.ErrorCustom a) = P.showErrorComponent a
+
 lexer0' :: String -> String -> [Token Lexeme]
 lexer0' scope rem =
   case flip S.evalState env0 $ P.runParserT lexemes scope rem of
-    Left e -> case e of
-      P.FancyError _ (customErrs -> es) | not (null es) -> es
-      P.FancyError (top Nel.:| _) es ->
-        let msg = intercalateMap "\n" P.showErrorComponent es
-         in [Token (Err (Opaque msg)) (toPos top) (toPos top)]
-      P.TrivialError (top Nel.:| _) _ _ ->
-        let msg = Opaque $ EP.parseErrorPretty e
-         in [Token (Err msg) (toPos top) (toPos top)]
+    Left e ->
+      let errsWithSourcePos =
+            fst $
+              P.attachSourcePos
+                P.errorOffset
+                (toList (P.bundleErrors e))
+                (P.bundlePosState e)
+          errorToTokens (err, top) = case err of
+            P.FancyError _ (customErrs -> es) | not (null es) -> es
+            P.FancyError _errOffset es ->
+              let msg = intercalateMap "\n" showErrorFancy es
+               in [Token (Err (Opaque msg)) (toPos top) (toPos top)]
+            P.TrivialError _errOffset _ _ ->
+              let msg = Opaque $ EP.parseErrorPretty err
+               in [Token (Err msg) (toPos top) (toPos top)]
+       in errsWithSourcePos >>= errorToTokens
     Right ts -> Token (Open scope) topLeftCorner topLeftCorner : tweak ts
   where
     customErrs es = [Err <$> e | P.ErrorCustom e <- toList es]
@@ -387,9 +409,9 @@ lexemes' eof =
                 P.lookAhead $
                   void docClose
                     <|> void docOpen
-                    <|> void (CP.satisfy isSpace)
+                    <|> void (P.satisfy isSpace)
                     <|> void closing
-          word <- P.manyTill (CP.satisfy (\ch -> not (isSpace ch))) end
+          word <- P.manyTill (P.satisfy (\ch -> not (isSpace ch))) end
           guard (not $ reserved word || null word)
           pure word
 
@@ -471,8 +493,8 @@ lexemes' eof =
         verbatim =
           P.label "code (examples: ''**unformatted**'', '''_words_''')" $ do
             (start, txt, stop) <- positioned $ do
-              quotes <- lit "''" <+> many (CP.satisfy (== '\''))
-              P.someTill CP.anyChar (lit quotes)
+              quotes <- lit "''" <+> many (P.satisfy (== '\''))
+              P.someTill P.anySingle (lit quotes)
             if all isSpace $ takeWhile (/= '\n') txt
               then
                 wrap "syntax.docVerbatim" $
@@ -523,7 +545,7 @@ lexemes' eof =
             evalUnison = wrap "syntax.docEval" $ do
               -- commit after seeing that ``` is on its own line
               fence <- P.try $ do
-                fence <- lit "```" <+> P.many (CP.satisfy (== '`'))
+                fence <- lit "```" <+> P.many (P.satisfy (== '`'))
                 b <- all isSpace <$> P.lookAhead (P.takeWhileP Nothing (/= '\n'))
                 fence <$ guard b
               CP.space
@@ -533,7 +555,7 @@ lexemes' eof =
 
             exampleBlock = wrap "syntax.docExampleBlock" $ do
               void $ lit "@typecheck" <* CP.space
-              fence <- lit "```" <+> P.many (CP.satisfy (== '`'))
+              fence <- lit "```" <+> P.many (P.satisfy (== '`'))
               local
                 (\env -> env {inLayout = True, opening = Just "docExampleBlock"})
                 (restoreStack "docExampleBlock" $ lexemes' ([] <$ lit fence))
@@ -550,31 +572,31 @@ lexemes' eof =
 
             other = wrap "syntax.docCodeBlock" $ do
               column <- (\x -> x - 1) . toInteger . P.unPos <$> LP.indentLevel
-              tabWidth <- toInteger . P.unPos <$> P.getTabWidth
-              fence <- lit "```" <+> P.many (CP.satisfy (== '`'))
+              let tabWidth = toInteger . P.unPos $ P.defaultTabWidth
+              fence <- lit "```" <+> P.many (P.satisfy (== '`'))
               name <-
-                P.many (CP.satisfy nonNewlineSpace)
+                P.many (P.satisfy nonNewlineSpace)
                   *> tok (Textual <$> P.takeWhile1P Nothing (not . isSpace))
-                  <* P.many (CP.satisfy nonNewlineSpace)
+                  <* P.many (P.satisfy nonNewlineSpace)
               _ <- void CP.eol
               verbatim <-
                 tok $
                   Textual . uncolumn column tabWidth . trim
-                    <$> P.someTill CP.anyChar ([] <$ lit fence)
+                    <$> P.someTill P.anySingle ([] <$ lit fence)
               pure (name <> verbatim)
 
         boldOrItalicOrStrikethrough closing = do
           let start =
-                some (CP.satisfy (== '*')) <|> some (CP.satisfy (== '_'))
+                some (P.satisfy (== '*')) <|> some (P.satisfy (== '_'))
                   <|> some
-                    (CP.satisfy (== '~'))
+                    (P.satisfy (== '~'))
               name s =
                 if take 1 s == "~"
                   then "syntax.docStrikethrough"
                   else if take 1 s == "*" then "syntax.docBold" else "syntax.docItalic"
           end <- P.try $ do
             end <- start
-            P.lookAhead (CP.satisfy (not . isSpace))
+            P.lookAhead (P.satisfy (not . isSpace))
             pure end
           wrap (name end) . wrap "syntax.docParagraph" $
             join
@@ -618,8 +640,8 @@ lexemes' eof =
         listSep = P.try $ newline *> nonNewlineSpaces *> P.lookAhead (bulletedStart <|> numberedStart)
 
         bulletedStart = P.try $ do
-          r <- listItemStart' $ [] <$ CP.satisfy bulletChar
-          P.lookAhead (CP.satisfy isSpace)
+          r <- listItemStart' $ [] <$ P.satisfy bulletChar
+          P.lookAhead (P.satisfy isSpace)
           pure r
           where
             bulletChar ch = ch == '*' || ch == '-' || ch == '+'
@@ -733,14 +755,14 @@ lexemes' eof =
         body :: P [Token Lexeme]
         body = txt <+> (atk <|> pure [])
           where
-            ch = (":]" <$ lit "\\:]") <|> ("@" <$ lit "\\@") <|> (pure <$> CP.anyChar)
+            ch = (":]" <$ lit "\\:]") <|> ("@" <$ lit "\\@") <|> (pure <$> P.anySingle)
             txt = tok (Textual . join <$> P.manyTill ch (P.lookAhead sep))
             sep = void at <|> void close
             ref = at *> (tok wordyId <|> tok symbolyId <|> docTyp)
             atk = (ref <|> docTyp) <+> body
             docTyp = do
               _ <- lit "["
-              typ <- tok (P.manyTill CP.anyChar (P.lookAhead (lit "]")))
+              typ <- tok (P.manyTill P.anySingle (P.lookAhead (lit "]")))
               _ <- lit "]" *> CP.space
               t <- tok wordyId <|> tok symbolyId
               pure $ (fmap Reserved <$> typ) <> t
@@ -760,7 +782,7 @@ lexemes' eof =
     wordyId :: P Lexeme
     wordyId = P.label wordyMsg . P.try $ do
       dot <- P.optional (lit ".")
-      segs <- P.sepBy1 wordyIdSeg (P.try (char '.' <* P.lookAhead (CP.satisfy wordyIdChar)))
+      segs <- P.sepBy1 wordyIdSeg (P.try (char '.' <* P.lookAhead (P.satisfy wordyIdChar)))
       shorthash <- P.optional shorthash
       pure $ WordyId (fromMaybe "" dot <> intercalate "." segs) shorthash
       where
@@ -794,8 +816,8 @@ lexemes' eof =
     -- wordyIdSeg = litSeg <|> (P.try do -- todo
     wordyIdSeg = P.try $ do
       start <- pos
-      ch <- CP.satisfy wordyIdStartChar
-      rest <- P.many (CP.satisfy wordyIdChar)
+      ch <- P.satisfy wordyIdStartChar
+      rest <- P.many (P.satisfy wordyIdChar)
       let word = ch : rest
       when (Set.member word keywords) $ do
         stop <- pos
@@ -824,7 +846,7 @@ lexemes' eof =
         Just sh -> pure sh
 
     separated :: (Char -> Bool) -> P a -> P a
-    separated ok p = P.try $ p <* P.lookAhead (void (CP.satisfy ok) <|> P.eof)
+    separated ok p = P.try $ p <* P.lookAhead (void (P.satisfy ok) <|> P.eof)
 
     numeric = bytes <|> otherbase <|> float <|> intOrNat
       where
@@ -973,7 +995,7 @@ lexemes' eof =
               -- if we're within an existing {{ }} block, inLayout will be false
               -- so we can actually allow }} to appear in normal code
               inLayout <- S.gets inLayout
-              when (not inLayout) $ void $ P.lookAhead (CP.satisfy (/= '}'))
+              when (not inLayout) $ void $ P.lookAhead (P.satisfy (/= '}'))
               pure l
         matchWithBlocks = ["match-with", "cases"]
         parens = open "(" <|> close ["("] (lit ")")
@@ -992,12 +1014,12 @@ lexemes' eof =
             _ -> fail "this comma is a pattern separator"
 
         delim = P.try $ do
-          ch <- CP.satisfy (\ch -> ch /= ';' && Set.member ch delimiters)
+          ch <- P.satisfy (\ch -> ch /= ';' && Set.member ch delimiters)
           pos <- pos
           pure [Token (Reserved [ch]) pos (inc pos)]
 
         delayOrForce = separated ok $ do
-          (start, op, end) <- positioned $ CP.satisfy isDelayOrForce
+          (start, op, end) <- positioned $ P.satisfy isDelayOrForce
           pure [Token (Reserved [op]) start end]
           where
             ok c = isDelayOrForce c || isSpace c || isAlphaNum c || Set.member c delimiters || c == '\"'
@@ -1333,8 +1355,8 @@ instance EP.ShowErrorComponent (Token Err) where
         e -> show e
       excerpt s = if length s < 15 then s else take 15 s <> "..."
 
-instance ShowToken (Token Lexeme) where
-  showTokens xs =
+instance P.VisualStream [Token Lexeme] where
+  showTokens _ xs =
     join . Nel.toList . S.evalState (traverse go xs) . end $ Nel.head xs
     where
       go :: Token Lexeme -> S.State Pos String

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -11,12 +11,12 @@ import Data.List (find, intersperse)
 import Data.List.Extra (nubOrd)
 import qualified Data.List.NonEmpty as Nel
 import qualified Data.Map as Map
+import Data.Proxy
 import Data.Sequence (Seq (..))
 import qualified Data.Set as Set
 import Data.Set.NonEmpty (NESet)
 import qualified Data.Set.NonEmpty as NES
 import qualified Data.Text as Text
-import Data.Void (Void)
 import qualified Text.Megaparsec as P
 import qualified Unison.ABT as ABT
 import Unison.Builtin.Decls (pattern TupleType')
@@ -1230,9 +1230,9 @@ prettyParseError s = \case
               excerpt
             ]
         L.Opaque msg -> style ErrorSite msg
-  P.TrivialError sp unexpected expected ->
+  te@(P.TrivialError _errOffset unexpected _expected) ->
     fromString
-      (P.parseErrorPretty @_ @Void (P.TrivialError sp unexpected expected))
+      (P.parseErrorPretty te)
       <> ( case unexpected of
              Just (P.Tokens (toList -> ts)) -> case ts of
                [] -> mempty
@@ -1418,7 +1418,7 @@ prettyParseError s = \case
           "\n"
         ]
       where
-        t = style Code (fromString (P.showTokens (pure tok)))
+        t = style Code (fromString (P.showTokens (Proxy @[L.Token L.Lexeme]) (pure tok)))
     go (Parser.ExpectedBlockOpen blockName tok@(L.payload -> L.Close)) =
       mconcat
         [ "I was expecting an indented block following the "

--- a/parser-typechecker/tests/Unison/Test/Common.hs
+++ b/parser-typechecker/tests/Unison/Test/Common.hs
@@ -15,7 +15,6 @@ import qualified Text.Megaparsec.Error as MPE
 import qualified Unison.ABT as ABT
 import qualified Unison.Builtin as B
 import qualified Unison.FileParsers as FP
-import qualified Unison.Lexer as L
 import Unison.Names (Names)
 import qualified Unison.Parser as Parser
 import Unison.Parser.Ann (Ann (..))
@@ -58,7 +57,7 @@ tm s =
 showParseError ::
   Var v =>
   String ->
-  MPE.ParseError (L.Token L.Lexeme) (Parser.Error v) ->
+  MPE.ParseError Parser.Input (Parser.Error v) ->
   String
 showParseError s = Pr.toANSI 60 . prettyParseError s
 

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -236,7 +236,7 @@ library
     , http-types
     , lens
     , lucid
-    , megaparsec >=5.0.0 && <7.0.0
+    , megaparsec
     , memory
     , mmorph
     , monad-validate

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.34.7.
 --
 -- see: https://github.com/sol/hpack
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -35,8 +35,6 @@ extra-deps:
   commit: e47e9e9fe1f576f8c835183b9def52d73c01327a
 - github: unisonweb/haskeline
   commit: 2944b11d19ee034c48276edc991736105c9d6143
-- github: unisonweb/megaparsec
-  commit: c4463124c578e8d1074c04518779b5ce5957af6b
 - github: unisonweb/shellmet
   commit: 2fd348592c8f51bb4c0ca6ba4bc8e38668913746
 - guid-0.1.0@sha256:a7c975be473f6f142d5cc1b39bc807a99043d20b1bb0873fdfe7a3ce84d2faf1,1078

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,122 +5,111 @@
 
 packages:
 - completed:
-    sha256: d4fd87fb7bfc5d8e9fbc3e4ee7302c6b1500cdc00fdb9b659d0f4849b6ebe2d5
-    name: configurator
     size: 15989
     url: https://github.com/unisonweb/configurator/archive/e47e9e9fe1f576f8c835183b9def52d73c01327a.tar.gz
-    pantry-tree:
-      sha256: 90547cd983fd15ebdc803e057d3ef8735fe93a75e29a00f8a74eadc13ee0f6e9
-      size: 955
+    name: configurator
     version: 0.3.0.0
+    sha256: d4fd87fb7bfc5d8e9fbc3e4ee7302c6b1500cdc00fdb9b659d0f4849b6ebe2d5
+    pantry-tree:
+      size: 955
+      sha256: 90547cd983fd15ebdc803e057d3ef8735fe93a75e29a00f8a74eadc13ee0f6e9
   original:
     url: https://github.com/unisonweb/configurator/archive/e47e9e9fe1f576f8c835183b9def52d73c01327a.tar.gz
 - completed:
-    sha256: 6d44207a4e94a16bc99d13dccbbb79bf676190c0476436b03235eeeaf6c72f9d
-    name: haskeline
     size: 75098
     url: https://github.com/unisonweb/haskeline/archive/2944b11d19ee034c48276edc991736105c9d6143.tar.gz
-    pantry-tree:
-      sha256: 878c7fb5801ec7418761a49b529ca3fdab274f22707c7d2759f2b3a2df06c3ea
-      size: 3717
+    name: haskeline
     version: 0.7.5.0
+    sha256: 6d44207a4e94a16bc99d13dccbbb79bf676190c0476436b03235eeeaf6c72f9d
+    pantry-tree:
+      size: 3717
+      sha256: 878c7fb5801ec7418761a49b529ca3fdab274f22707c7d2759f2b3a2df06c3ea
   original:
     url: https://github.com/unisonweb/haskeline/archive/2944b11d19ee034c48276edc991736105c9d6143.tar.gz
 - completed:
-    sha256: 94f9573735fefda868371ff735a6b1f52bea22b9e52289abeb8114c99bbf8832
-    name: megaparsec
-    size: 92490
-    url: https://github.com/unisonweb/megaparsec/archive/c4463124c578e8d1074c04518779b5ce5957af6b.tar.gz
-    pantry-tree:
-      sha256: 7d3f8b23c862d878b4adce628caaf7bc337f0ac10b2556e1cdf0913c28a45929
-      size: 2635
-    version: 6.5.0
-  original:
-    url: https://github.com/unisonweb/megaparsec/archive/c4463124c578e8d1074c04518779b5ce5957af6b.tar.gz
-- completed:
-    sha256: 6e642163070a217cc3363bdbefde571ff6c1878f4fc3d92e9c910db7fa88eaf2
-    name: shellmet
     size: 10460
     url: https://github.com/unisonweb/shellmet/archive/2fd348592c8f51bb4c0ca6ba4bc8e38668913746.tar.gz
-    pantry-tree:
-      sha256: 05a169a7a6b68100630e885054dc1821d31cd06571b0317ec90c75ac2c41aeb7
-      size: 654
+    name: shellmet
     version: 0.0.4.0
+    sha256: 6e642163070a217cc3363bdbefde571ff6c1878f4fc3d92e9c910db7fa88eaf2
+    pantry-tree:
+      size: 654
+      sha256: 05a169a7a6b68100630e885054dc1821d31cd06571b0317ec90c75ac2c41aeb7
   original:
     url: https://github.com/unisonweb/shellmet/archive/2fd348592c8f51bb4c0ca6ba4bc8e38668913746.tar.gz
 - completed:
+    hackage: guid-0.1.0@sha256:a7c975be473f6f142d5cc1b39bc807a99043d20b1bb0873fdfe7a3ce84d2faf1,1078
     pantry-tree:
-      sha256: a33838b7b1c54f6ac3e1b436b25674948713a4189658e4d82e639b9a689bc90d
       size: 364
-    hackage: guid-0.1.0@sha256:a7c975be473f6f142d5cc1b39bc807a99043d20b1bb0873fdfe7a3ce84d2faf1,1078
+      sha256: a33838b7b1c54f6ac3e1b436b25674948713a4189658e4d82e639b9a689bc90d
   original:
     hackage: guid-0.1.0@sha256:a7c975be473f6f142d5cc1b39bc807a99043d20b1bb0873fdfe7a3ce84d2faf1,1078
 - completed:
+    hackage: prelude-extras-0.4.0.3@sha256:1c10b0123ea13a6423d74a8fcbaeb2d5249b472588abde418a36b47b7c4f48c8,1163
     pantry-tree:
-      sha256: a03f60a1250c9d0daaf208ba58ccf24e05e0807f2e3dc7892fad3f2f3a196f7f
       size: 476
-    hackage: prelude-extras-0.4.0.3@sha256:1c10b0123ea13a6423d74a8fcbaeb2d5249b472588abde418a36b47b7c4f48c8,1163
+      sha256: a03f60a1250c9d0daaf208ba58ccf24e05e0807f2e3dc7892fad3f2f3a196f7f
   original:
     hackage: prelude-extras-0.4.0.3@sha256:1c10b0123ea13a6423d74a8fcbaeb2d5249b472588abde418a36b47b7c4f48c8,1163
 - completed:
+    hackage: sandi-0.5@sha256:b278d072ca717706ea38f9bd646e023f7f2576a778fb43565b434f93638849aa,3010
     pantry-tree:
-      sha256: 5ca7ce4bc22ab9d4427bb149b5e283ab9db43375df14f7131fdfd48775f36350
       size: 3455
-    hackage: sandi-0.5@sha256:b278d072ca717706ea38f9bd646e023f7f2576a778fb43565b434f93638849aa,3010
+      sha256: 5ca7ce4bc22ab9d4427bb149b5e283ab9db43375df14f7131fdfd48775f36350
   original:
     hackage: sandi-0.5@sha256:b278d072ca717706ea38f9bd646e023f7f2576a778fb43565b434f93638849aa,3010
 - completed:
+    hackage: strings-1.1@sha256:0285dec4c8ab262359342b3e5ef1eb567074669461b9b38404f1cb870c881c5c,1617
     pantry-tree:
-      sha256: 876e5a679244143e2a7e74357427c7522a8d61f68a4cc3ae265fe4960b75a2e2
       size: 212
-    hackage: strings-1.1@sha256:0285dec4c8ab262359342b3e5ef1eb567074669461b9b38404f1cb870c881c5c,1617
+      sha256: 876e5a679244143e2a7e74357427c7522a8d61f68a4cc3ae265fe4960b75a2e2
   original:
     hackage: strings-1.1@sha256:0285dec4c8ab262359342b3e5ef1eb567074669461b9b38404f1cb870c881c5c,1617
 - completed:
+    hackage: fuzzyfind-3.0.0@sha256:d79a5d3ed194dd436c6b839bf187211d880cf773b2febaca456e5ccf93f5ac65,1814
     pantry-tree:
-      sha256: 0e6c6d4f89083c8385de5adc4f36ad01b2b0ff45261b47f7d90d919969c8b5ed
       size: 542
-    hackage: fuzzyfind-3.0.0@sha256:d79a5d3ed194dd436c6b839bf187211d880cf773b2febaca456e5ccf93f5ac65,1814
+      sha256: 0e6c6d4f89083c8385de5adc4f36ad01b2b0ff45261b47f7d90d919969c8b5ed
   original:
     hackage: fuzzyfind-3.0.0@sha256:d79a5d3ed194dd436c6b839bf187211d880cf773b2febaca456e5ccf93f5ac65,1814
 - completed:
+    hackage: monad-validate-1.2.0.0@sha256:9850f408431098b28806dd464b6825a88a0b56c84f380d7fe0454c1df9d6f881,3505
     pantry-tree:
-      sha256: 8e049bd12ce2bd470909578f2ee8eb80b89d5ff88860afa30e29dd4eafecfa3e
       size: 713
-    hackage: monad-validate-1.2.0.0@sha256:9850f408431098b28806dd464b6825a88a0b56c84f380d7fe0454c1df9d6f881,3505
+      sha256: 8e049bd12ce2bd470909578f2ee8eb80b89d5ff88860afa30e29dd4eafecfa3e
   original:
     hackage: monad-validate-1.2.0.0@sha256:9850f408431098b28806dd464b6825a88a0b56c84f380d7fe0454c1df9d6f881,3505
 - completed:
+    hackage: NanoID-3.1.0@sha256:9118ab00e8650b5a56a10c90295d357eb77a8057a598b7e56dfedc9c6d53c77d,1524
     pantry-tree:
-      sha256: d33d603a2f0d1a220ff0d5e7edb6273def89120e6bb958c2d836cae89e788334
       size: 363
-    hackage: NanoID-3.1.0@sha256:9118ab00e8650b5a56a10c90295d357eb77a8057a598b7e56dfedc9c6d53c77d,1524
+      sha256: d33d603a2f0d1a220ff0d5e7edb6273def89120e6bb958c2d836cae89e788334
   original:
     hackage: NanoID-3.1.0@sha256:9118ab00e8650b5a56a10c90295d357eb77a8057a598b7e56dfedc9c6d53c77d,1524
 - completed:
+    hackage: recover-rtti-0.4.0.0@sha256:2ce1e031ec0e34d736fa45f0149bbd55026f614939dc90ffd14a9c5d24093ff4,4423
     pantry-tree:
-      sha256: d87d84c3f760c1b2540f74e4a301cd4e8294df891e8e4262e8bdd313bc8e0bfd
       size: 2410
-    hackage: recover-rtti-0.4.0.0@sha256:2ce1e031ec0e34d736fa45f0149bbd55026f614939dc90ffd14a9c5d24093ff4,4423
+      sha256: d87d84c3f760c1b2540f74e4a301cd4e8294df891e8e4262e8bdd313bc8e0bfd
   original:
     hackage: recover-rtti-0.4.0.0@sha256:2ce1e031ec0e34d736fa45f0149bbd55026f614939dc90ffd14a9c5d24093ff4,4423
 - completed:
+    hackage: lock-file-0.7.0.0@sha256:3ad84b5e454145e1d928063b56abb96db24a99a21b493989520e58fa0ab37b00,4484
     pantry-tree:
-      sha256: 3634593ce191e82793ea0e060598ab3cf67f2ef2fe1d65345dc9335ad529d25f
       size: 718
-    hackage: lock-file-0.7.0.0@sha256:3ad84b5e454145e1d928063b56abb96db24a99a21b493989520e58fa0ab37b00,4484
+      sha256: 3634593ce191e82793ea0e060598ab3cf67f2ef2fe1d65345dc9335ad529d25f
   original:
     hackage: lock-file-0.7.0.0@sha256:3ad84b5e454145e1d928063b56abb96db24a99a21b493989520e58fa0ab37b00,4484
 - completed:
-    pantry-tree:
-      sha256: 8372e84e9c710097f4f80f2016ca15a5a0cd7884b8ac5ce70f26b3110f4401bd
-      size: 2547
     hackage: http-client-0.7.11@sha256:3f59ac8ffe2a3768846cdda040a0d1df2a413960529ba61c839861c948871967,5756
+    pantry-tree:
+      size: 2547
+      sha256: 8372e84e9c710097f4f80f2016ca15a5a0cd7884b8ac5ce70f26b3110f4401bd
   original:
     hackage: http-client-0.7.11
 snapshots:
 - completed:
-    sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68
     size: 590100
     url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/28.yaml
+    sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68
   original: lts-18.28

--- a/unison-cli/src/Unison/Codebase/Editor/UriParser.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/UriParser.hs
@@ -176,15 +176,15 @@ absolutePath = do
   void $ C.char '.'
   Path . Seq.fromList . fmap (NameSegment . Text.pack)
     <$> P.sepBy1
-      ( (:) <$> C.satisfy Unison.Lexer.wordyIdStartChar
-          <*> P.many (C.satisfy Unison.Lexer.wordyIdChar)
+      ( (:) <$> P.satisfy Unison.Lexer.wordyIdStartChar
+          <*> P.many (P.satisfy Unison.Lexer.wordyIdChar)
       )
       (C.char '.')
 
 treeishSuffix :: P Text
 treeishSuffix = P.label "git treeish" . P.try $ do
   void $ C.char ':'
-  notdothash <- C.noneOf @[] ".#:"
+  notdothash <- P.noneOf @[] ".#:"
   rest <- P.takeWhileP (Just "not colon") (/= ':')
   pure $ Text.cons notdothash rest
 

--- a/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
@@ -19,7 +19,7 @@ defaultBaseLib :: Parsec Void Text ReadRemoteNamespace
 defaultBaseLib = fmap makeNS $ latest <|> release
   where
     latest, release, version :: Parsec Void Text Text
-    latest = "latest-" *> many anyChar *> eof $> "trunk"
+    latest = "latest-" *> many anySingle *> eof $> "trunk"
     release = fmap ("releases._" <>) $ "release/" *> version <* eof
     version = do
       Text.pack <$> some (alphaNumChar <|> ('_' <$ oneOf ['.', '_', '-']))

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.34.7.
 --
 -- see: https://github.com/sol/hpack
 


### PR DESCRIPTION
## Overview

The unison codebase is pinned to megaparsec 6.5.0. This PR makes it compatible with megaparsec 9.0.1, which is the version in the stackage snapshot.

## Interesting/controversial decisions

`ErrorItem` and `ErrorFancy` were instances of `ShowErrorComponent` in 6.5.0, but were removed in 7.0.0. So, this PR adds `showErrorItem` and `showErrorFancy` functions where they were previously calls to `showErrorComponent`:

`showErrorFancy` is defined in both [unison-parser-typechecker](https://github.com/unisonweb/unison/compare/travis/bump-megaparsec?expand=1#diff-d6765d3cc5b214121e17f32cf9ef50a335a9630933e5ce2bfa6569fef12926cfR251-R265) and [unison-cli](https://github.com/unisonweb/unison/compare/travis/bump-megaparsec?expand=1#diff-4927adadae99f150f6af96ec90f31693b28333ddd5bd3f6c83d701bee193e826R2374-R2387). I'm not sure if we want to define it somewhere else that would be imported by `unison-cli` and `unison-parser-typechecker`, or let them evolve independently.

`showErrorItem` is only defined in [unison-cli](https://github.com/unisonweb/unison/compare/travis/bump-megaparsec?expand=1#diff-4927adadae99f150f6af96ec90f31693b28333ddd5bd3f6c83d701bee193e826R2389-R2392).

## Test coverage

I am relying upon the existing parser tests.

## Other notes

In Megaparsec 7.0.0 and higher `runParser` and friends return a [ParseErrorBundle](https://hackage.haskell.org/package/megaparsec-9.2.1/docs/Text-Megaparsec-Error.html#t:ParseErrorBundle) rather than a `ParseError`. This PR takes the first error from the bundle in a number of places, which should maintain the existing behavior. But, we do have the option of throwing and displaying multiple errors with the `ParseErrorBundle` if we want to in the future.
