### PR TITLE
Add package.yaml workaround to stack rebuild issue

### DIFF
--- a/codebase2/codebase-sqlite/package.yaml
+++ b/codebase2/codebase-sqlite/package.yaml
@@ -2,6 +2,9 @@ name: unison-codebase-sqlite
 github: unisonweb/unison
 
 library:
+  when:
+    - condition: false
+      other-modules: Paths_unison_codebase_sqlite
   source-dirs: .
 
 extra-source-files:

--- a/codebase2/codebase-sqlite/unison-codebase-sqlite.cabal
+++ b/codebase2/codebase-sqlite/unison-codebase-sqlite.cabal
@@ -42,8 +42,6 @@ library
       U.Codebase.Sqlite.Symbol
       U.Codebase.Sqlite.Sync22
       U.Codebase.Sqlite.Term.Format
-  other-modules:
-      Paths_unison_codebase_sqlite
   hs-source-dirs:
       ./
   default-extensions:

--- a/codebase2/codebase-sync/package.yaml
+++ b/codebase2/codebase-sync/package.yaml
@@ -3,6 +3,9 @@ github: unisonweb/unison
 
 library:
   source-dirs: .
+  when:
+    - condition: false
+      other-modules: Paths_unison_codebase_sync
 
 dependencies:
   - base

--- a/codebase2/codebase-sync/unison-codebase-sync.cabal
+++ b/codebase2/codebase-sync/unison-codebase-sync.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a62b0e8dbabe51c01ebc0871290e2427a734c0fbf9e78aee138b2bdad34d2704
+-- hash: e3307c66c00f5bf45548b61cb0aa78f2006c2df8b9ad9172c645f944688d6263
 
 name:           unison-codebase-sync
 version:        0.0.0
@@ -19,8 +19,6 @@ source-repository head
 library
   exposed-modules:
       U.Codebase.Sync
-  other-modules:
-      Paths_unison_codebase_sync
   hs-source-dirs:
       ./
   build-depends:

--- a/codebase2/codebase/package.yaml
+++ b/codebase2/codebase/package.yaml
@@ -20,6 +20,9 @@ default-extensions:
 
 library:
   source-dirs: .
+  when:
+    - condition: false
+      other-modules: Paths_unison_codebase
 
 dependencies:
   - base

--- a/codebase2/codebase/unison-codebase.cabal
+++ b/codebase2/codebase/unison-codebase.cabal
@@ -32,8 +32,6 @@ library
       U.Codebase.Type
       U.Codebase.TypeEdit
       U.Codebase.WatchKind
-  other-modules:
-      Paths_unison_codebase
   hs-source-dirs:
       ./
   default-extensions:

--- a/codebase2/core/package.yaml
+++ b/codebase2/core/package.yaml
@@ -3,6 +3,9 @@ github: unisonweb/unison
 
 library:
   source-dirs: .
+  when:
+    - condition: false
+      other-modules: Paths_unison_core
 
 dependencies:
   - base

--- a/codebase2/core/unison-core.cabal
+++ b/codebase2/core/unison-core.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f696d0f997ab3afba6494f5932ac232d27e77073a331ab64d3c8b7929d1deb3a
+-- hash: 7b810bbd4d380ccd76c363eac447c7233c7b0e9d968960547c00d20ac3edeb08
 
 name:           unison-core
 version:        0.0.0
@@ -20,8 +20,6 @@ library
   exposed-modules:
       U.Core.ABT
       U.Core.ABT.Var
-  other-modules:
-      Paths_unison_core
   hs-source-dirs:
       ./
   build-depends:

--- a/codebase2/util-serialization/package.yaml
+++ b/codebase2/util-serialization/package.yaml
@@ -2,6 +2,9 @@ name: unison-util-serialization
 
 library:
   source-dirs: .
+  when:
+    - condition: false
+      other-modules: Paths_unison_util_serialization
 
 dependencies:
   - base

--- a/codebase2/util-serialization/unison-util-serialization.cabal
+++ b/codebase2/util-serialization/unison-util-serialization.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0dd31d457a6c3bc41017d163374947c1c31752279ce7ce77bc5772150101afe1
+-- hash: 065e98437c72cce9c4cc6102d3eb0b3c8be444a95c3c71ab65a9d17f29e95eae
 
 name:           unison-util-serialization
 version:        0.0.0
@@ -13,8 +13,6 @@ build-type:     Simple
 library
   exposed-modules:
       U.Util.Serialization
-  other-modules:
-      Paths_unison_util_serialization
   hs-source-dirs:
       ./
   build-depends:

--- a/codebase2/util-term/package.yaml
+++ b/codebase2/util-term/package.yaml
@@ -3,6 +3,9 @@ github: unisonweb/unison
 
 library:
   source-dirs: .
+  when:
+    - condition: false
+      other-modules: Paths_unison_util_term
 
 dependencies:
   - base

--- a/codebase2/util-term/unison-util-term.cabal
+++ b/codebase2/util-term/unison-util-term.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 655ca1a695b9a272d6b440b74fe2b6717f710a543d7ddb7639366d4233961bf8
+-- hash: 6b08707c87592d47677b3f2db15c17c94a23c13544f339227e43ac19f7ee7947
 
 name:           unison-util-term
 version:        0.0.0
@@ -20,8 +20,6 @@ library
   exposed-modules:
       U.Util.Term
       U.Util.Type
-  other-modules:
-      Paths_unison_util_term
   hs-source-dirs:
       ./
   build-depends:

--- a/codebase2/util/package.yaml
+++ b/codebase2/util/package.yaml
@@ -3,13 +3,20 @@ github: unisonweb/unison
 
 library:
   source-dirs: src
+  when:
+    - condition: false
+      other-modules: Paths_unison_util
 
 benchmarks:
   bench:
+    when:
+      - condition: false
+        other-modules: Paths_unison_util
     dependencies:
       - criterion
       - sandi
       - unison-util
+      - unison-util-base32hex
     main: Main.hs
     source-dirs: bench
 

--- a/codebase2/util/package.yaml
+++ b/codebase2/util/package.yaml
@@ -16,7 +16,6 @@ benchmarks:
       - criterion
       - sandi
       - unison-util
-      - unison-util-base32hex
     main: Main.hs
     source-dirs: bench
 

--- a/codebase2/util/unison-util.cabal
+++ b/codebase2/util/unison-util.cabal
@@ -97,7 +97,6 @@ benchmark bench
     , text
     , time
     , unison-util
-    , unison-util-base32hex
     , unison-util-relation
     , unliftio
     , vector

--- a/codebase2/util/unison-util.cabal
+++ b/codebase2/util/unison-util.cabal
@@ -26,8 +26,6 @@ library
       U.Util.String
       U.Util.Text
       U.Util.Timing
-  other-modules:
-      Paths_unison_util
   hs-source-dirs:
       src
   default-extensions:
@@ -66,8 +64,6 @@ library
 benchmark bench
   type: exitcode-stdio-1.0
   main-is: Main.hs
-  other-modules:
-      Paths_unison_util
   hs-source-dirs:
       bench
   default-extensions:
@@ -101,6 +97,7 @@ benchmark bench
     , text
     , time
     , unison-util
+    , unison-util-base32hex
     , unison-util-relation
     , unliftio
     , vector

--- a/lib/unison-prelude/package.yaml
+++ b/lib/unison-prelude/package.yaml
@@ -4,6 +4,9 @@ copyright: Copyright (C) 2013-2021 Unison Computing, PBC and contributors
 
 library:
   source-dirs: src
+  when:
+    - condition: false
+      other-modules: Paths_unison_prelude
 
 dependencies:
   - base

--- a/lib/unison-prelude/unison-prelude.cabal
+++ b/lib/unison-prelude/unison-prelude.cabal
@@ -21,8 +21,6 @@ library
       Unison.Prelude
       Unison.Util.Map
       Unison.Util.Set
-  other-modules:
-      Paths_unison_prelude
   hs-source-dirs:
       src
   default-extensions:

--- a/lib/unison-pretty-printer/package.yaml
+++ b/lib/unison-pretty-printer/package.yaml
@@ -36,6 +36,10 @@ when:
     ghc-options: -funbox-strict-fields -O2
 
 library:
+  when:
+    - condition: false
+      other-modules: Paths_unison_pretty_printer
+
   source-dirs: src
   dependencies:
     - base
@@ -53,6 +57,9 @@ library:
 
 executables:
   prettyprintdemo:
+    when:
+      - condition: false
+        other-modules: Paths_unison_pretty_printer
     source-dirs: prettyprintdemo
     main: Main.hs
     dependencies:
@@ -64,6 +71,9 @@ executables:
 
 tests:
   pretty-printer-tests:
+    when:
+      - condition: false
+        other-modules: Paths_unison_pretty_printer
     source-dirs: tests
     main: Suite.hs
     ghc-options: -W -threaded -rtsopts "-with-rtsopts=-N -T" -v0

--- a/lib/unison-pretty-printer/unison-pretty-printer.cabal
+++ b/lib/unison-pretty-printer/unison-pretty-printer.cabal
@@ -31,8 +31,6 @@ library
       Unison.Util.Pretty
       Unison.Util.Range
       Unison.Util.SyntaxText
-  other-modules:
-      Paths_unison_pretty_printer
   hs-source-dirs:
       src
   default-extensions:
@@ -76,8 +74,6 @@ library
 
 executable prettyprintdemo
   main-is: Main.hs
-  other-modules:
-      Paths_unison_pretty_printer
   hs-source-dirs:
       prettyprintdemo
   default-extensions:
@@ -118,7 +114,6 @@ test-suite pretty-printer-tests
       Unison.Test.ColorText
       Unison.Test.Range
       Unison.Test.Util.Pretty
-      Paths_unison_pretty_printer
   hs-source-dirs:
       tests
   default-extensions:

--- a/lib/unison-sqlite/package.yaml
+++ b/lib/unison-sqlite/package.yaml
@@ -3,6 +3,10 @@ github: unisonweb/unison
 copyright: Copyright (C) 2013-2021 Unison Computing, PBC and contributors
 
 library:
+  when:
+    - condition: false
+      other-modules: Paths_unison_sqlite
+
   source-dirs: src
   other-modules:
     - Unison.Sqlite.DataVersion

--- a/lib/unison-util-relation/package.yaml
+++ b/lib/unison-util-relation/package.yaml
@@ -4,9 +4,15 @@ copyright: Copyright (C) 2013-2021 Unison Computing, PBC and contributors
 
 library:
   source-dirs: src
+  when:
+    - condition: false
+      other-modules: Paths_unison_util_relation
 
 tests:
   util-relation-tests:
+    when:
+      - condition: false
+        other-modules: Paths_unison_util_relation
     dependencies:
       - code-page
       - easytest
@@ -17,6 +23,9 @@ tests:
 
 benchmarks:
   relation:
+    when:
+      - condition: false
+        other-modules: Paths_unison_util_relation
     source-dirs: benchmarks/relation
     main: Main.hs
     dependencies:

--- a/lib/unison-util-relation/unison-util-relation.cabal
+++ b/lib/unison-util-relation/unison-util-relation.cabal
@@ -20,8 +20,6 @@ library
       Unison.Util.Relation
       Unison.Util.Relation3
       Unison.Util.Relation4
-  other-modules:
-      Paths_unison_util_relation
   hs-source-dirs:
       src
   default-extensions:
@@ -51,8 +49,6 @@ library
 test-suite util-relation-tests
   type: exitcode-stdio-1.0
   main-is: Main.hs
-  other-modules:
-      Paths_unison_util_relation
   hs-source-dirs:
       test
   default-extensions:
@@ -86,8 +82,6 @@ test-suite util-relation-tests
 benchmark relation
   type: exitcode-stdio-1.0
   main-is: Main.hs
-  other-modules:
-      Paths_unison_util_relation
   hs-source-dirs:
       benchmarks/relation
   default-extensions:

--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -125,6 +125,9 @@ library:
     - open-browser
     - uri-encode
     - generic-lens
+  when:
+    - condition: false
+      other-modules: Paths_unison_parser_typechecker
 
 tests:
   parser-typechecker-tests:
@@ -163,6 +166,9 @@ tests:
       - unison-util
       - unison-util-relation
       - unison-pretty-printer
+    when:
+      - condition: false
+        other-modules: Paths_unison_parser_typechecker
 
 default-extensions:
   - ApplicativeDo

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -165,8 +165,6 @@ library
       Unison.Util.Text
       Unison.Util.TQueue
       Unison.Util.TransitiveClosure
-  other-modules:
-      Paths_unison_parser_typechecker
   hs-source-dirs:
       src
   default-extensions:
@@ -339,7 +337,6 @@ test-suite parser-typechecker-tests
       Unison.Test.Util.Relation
       Unison.Test.Util.Text
       Unison.Test.Var
-      Paths_unison_parser_typechecker
   hs-source-dirs:
       tests
   default-extensions:

--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -66,9 +66,14 @@ library:
   when:
     - condition: '!os(windows)'
       dependencies: unix
+    - condition: false
+      other-modules: Paths_unison_cli
 
 tests:
   cli-tests:
+    when:
+      - condition: false
+        other-modules: Paths_unison_cli
     dependencies:
       - code-page
       - easytest
@@ -81,6 +86,9 @@ tests:
 
 executables:
   unison:
+    when:
+      - condition: false
+        other-modules: Paths_unison_cli
     source-dirs: unison
     main: Main.hs
     ghc-options: -threaded -rtsopts -with-rtsopts=-I0 -optP-Wno-nonportable-include-path
@@ -93,6 +101,9 @@ executables:
       - unison-cli
 
   transcripts:
+    when:
+      - condition: false
+        other-modules: Paths_unison_cli
     source-dirs: transcripts
     main: Transcripts.hs
     ghc-options: -threaded -rtsopts -with-rtsopts=-N -v0
@@ -104,6 +115,9 @@ executables:
       - unison-cli
 
   cli-integration-tests:
+    when:
+      - condition: false
+        other-modules: Paths_unison_cli
     source-dirs: integration-tests
     main: Suite.hs
     ghc-options: -W -threaded -rtsopts "-with-rtsopts=-N -T" -v0

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -62,8 +62,6 @@ library
       Unison.Share.Types
       Unison.Sync.HTTP
       Unison.Util.HTTP
-  other-modules:
-      Paths_unison_cli
   hs-source-dirs:
       src
   default-extensions:
@@ -152,7 +150,6 @@ executable cli-integration-tests
   main-is: Suite.hs
   other-modules:
       IntegrationTests.ArgumentParsing
-      Paths_unison_cli
   hs-source-dirs:
       integration-tests
   default-extensions:
@@ -242,8 +239,6 @@ executable cli-integration-tests
 
 executable transcripts
   main-is: Transcripts.hs
-  other-modules:
-      Paths_unison_cli
   hs-source-dirs:
       transcripts
   default-extensions:
@@ -336,7 +331,6 @@ executable unison
       ArgParse
       System.Path
       Version
-      Paths_unison_cli
   hs-source-dirs:
       unison
   default-extensions:
@@ -434,7 +428,6 @@ test-suite cli-tests
       Unison.Test.Ucm
       Unison.Test.UriParser
       Unison.Test.VersionParser
-      Paths_unison_cli
   hs-source-dirs:
       tests
   default-extensions:

--- a/unison-core/package.yaml
+++ b/unison-core/package.yaml
@@ -3,6 +3,9 @@ github: unisonweb/unison
 copyright: Copyright (C) 2013-2018 Unison Computing, PBC and contributors
 
 library:
+  when:
+    - condition: false
+      other-modules: Paths_unison_core1
   source-dirs: src
   ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -funbox-strict-fields
   dependencies:

--- a/unison-core/unison-core1.cabal
+++ b/unison-core/unison-core1.cabal
@@ -61,8 +61,6 @@ library
       Unison.Var
       Unison.Var.RefNamed
       Unison.WatchKind
-  other-modules:
-      Paths_unison_core1
   hs-source-dirs:
       src
   default-extensions:

--- a/unison-share-api/package.yaml
+++ b/unison-share-api/package.yaml
@@ -4,6 +4,9 @@ copyright: Copyright (C) 2013-2021 Unison Computing, PBC and contributors
 
 library:
   source-dirs: src
+  when:
+    - condition: false
+      other-modules: Paths_unison_share_api
 
 dependencies:
   - base

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -36,8 +36,6 @@ library
       Unison.Sync.API
       Unison.Sync.Types
       Unison.Util.Find
-  other-modules:
-      Paths_unison_share_api
   hs-source-dirs:
       src
   default-extensions:


### PR DESCRIPTION
Upstream issue: https://github.com/commercialhaskell/stack/issues/5503

In short, `stack` later than 2.3.1 rebuilds too often:

```
stack build
stack build
```

usually unregisters a few packages and rebuilds, due to detected changes to auto-generated `Paths_*` modules. So, @aryairani found this workaround, which I cherry-picked from another branch onto trunk.