### PR TITLE
Implement Access Token Refresh

### DIFF
--- a/unison-cli/src/Unison/Auth/CredentialManager.hs
+++ b/unison-cli/src/Unison/Auth/CredentialManager.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE DeriveAnyClass #-}
 
 module Unison.Auth.CredentialManager
-  ( saveTokens,
+  ( saveCredentials,
     CredentialManager,
     newCredentialManager,
-    getTokens,
+    getCredentials,
   )
 where
 
@@ -22,9 +22,9 @@ import qualified UnliftIO
 newtype CredentialManager = CredentialManager (UnliftIO.MVar Credentials)
 
 -- | Saves credentials to the active profile.
-saveTokens :: UnliftIO.MonadUnliftIO m => CredentialManager -> CodeserverId -> Tokens -> m ()
-saveTokens credManager aud tokens = do
-  void . modifyCredentials credManager $ setActiveTokens aud tokens
+saveCredentials :: UnliftIO.MonadUnliftIO m => CredentialManager -> CodeserverId -> CodeserverCredentials -> m ()
+saveCredentials credManager aud creds = do
+  void . modifyCredentials credManager $ setCodeserverCredentials aud creds
 
 -- | Atomically update the credential storage file, and update the in-memory cache.
 modifyCredentials :: UnliftIO.MonadUnliftIO m => CredentialManager -> (Credentials -> Credentials) -> m Credentials
@@ -33,10 +33,10 @@ modifyCredentials (CredentialManager credsVar) f = do
     newCreds <- atomicallyModifyCredentialsFile f
     pure (newCreds, newCreds)
 
-getTokens :: MonadIO m => CredentialManager -> CodeserverId -> m (Either CredentialFailure Tokens)
-getTokens (CredentialManager credsVar) aud = do
+getCredentials :: MonadIO m => CredentialManager -> CodeserverId -> m (Either CredentialFailure CodeserverCredentials)
+getCredentials (CredentialManager credsVar) aud = do
   creds <- UnliftIO.readMVar credsVar
-  pure $ getActiveTokens aud creds
+  pure $ getCodeserverCredentials aud creds
 
 newCredentialManager :: MonadIO m => m CredentialManager
 newCredentialManager = do

--- a/unison-cli/src/Unison/Auth/Discovery.hs
+++ b/unison-cli/src/Unison/Auth/Discovery.hs
@@ -3,22 +3,23 @@ module Unison.Auth.Discovery where
 import qualified Data.Aeson as Aeson
 import qualified Data.Text as Text
 import qualified Network.HTTP.Client as HTTP
+import qualified Network.HTTP.Client.TLS as HTTP
 import Network.URI
 import Unison.Auth.Types
 import Unison.Prelude
 import Unison.Share.Types (CodeserverURI (..), codeserverToURI)
 import qualified UnliftIO
 
-discoveryURI :: CodeserverURI -> URI
-discoveryURI cs =
+discoveryURIForCodeserver :: CodeserverURI -> URI
+discoveryURIForCodeserver cs =
   let uri = codeserverToURI cs
    in uri {uriPath = uriPath uri <> "/.well-known/openid-configuration"}
 
-discoveryForCodeserver :: MonadIO m => HTTP.Manager -> CodeserverURI -> m (Either CredentialFailure DiscoveryDoc)
-discoveryForCodeserver httpClient host = liftIO . UnliftIO.try @_ @CredentialFailure $ do
-  let uri = discoveryURI host
-  req <- HTTP.requestFromURI uri
-  resp <- HTTP.httpLbs req httpClient
+fetchDiscoveryDoc :: MonadIO m => URI -> m (Either CredentialFailure DiscoveryDoc)
+fetchDiscoveryDoc discoveryURI = liftIO . UnliftIO.try @_ @CredentialFailure $ do
+  unauthenticatedHttpClient <- HTTP.getGlobalManager
+  req <- HTTP.requestFromURI discoveryURI
+  resp <- HTTP.httpLbs req unauthenticatedHttpClient
   case Aeson.eitherDecode (HTTP.responseBody $ resp) of
-    Left err -> UnliftIO.throwIO $ InvalidDiscoveryDocument uri (Text.pack err)
+    Left err -> UnliftIO.throwIO $ InvalidDiscoveryDocument discoveryURI (Text.pack err)
     Right doc -> pure doc

--- a/unison-cli/src/Unison/Auth/Types.hs
+++ b/unison-cli/src/Unison/Auth/Types.hs
@@ -14,8 +14,10 @@ module Unison.Auth.Types
     PKCEChallenge,
     ProfileName,
     CredentialFailure (..),
-    getActiveTokens,
-    setActiveTokens,
+    CodeserverCredentials (..),
+    getCodeserverCredentials,
+    setCodeserverCredentials,
+    codeserverCredentials,
     emptyCredentials,
   )
 where
@@ -128,25 +130,10 @@ instance Aeson.FromJSON DiscoveryDoc where
 type ProfileName = Text
 
 data Credentials = Credentials
-  { credentials :: Map ProfileName (Map CodeserverId Tokens),
+  { credentials :: Map ProfileName (Map CodeserverId CodeserverCredentials),
     activeProfile :: ProfileName
   }
   deriving (Eq)
-
-emptyCredentials :: Credentials
-emptyCredentials = Credentials mempty defaultProfileName
-
-getActiveTokens :: CodeserverId -> Credentials -> Either CredentialFailure Tokens
-getActiveTokens host (Credentials {credentials, activeProfile}) =
-  maybeToEither (ReauthRequired host) $
-    credentials ^? ix activeProfile . ix host
-
-setActiveTokens :: CodeserverId -> Tokens -> Credentials -> Credentials
-setActiveTokens host tokens creds@(Credentials {credentials, activeProfile}) =
-  let newCredMap =
-        credentials
-          & at activeProfile . non Map.empty . at host .~ Just tokens
-   in creds {credentials = newCredMap}
 
 instance Aeson.ToJSON Credentials where
   toJSON (Credentials credMap activeProfile) =
@@ -160,3 +147,45 @@ instance Aeson.FromJSON Credentials where
     credentials <- obj .: "credentials"
     activeProfile <- obj .: "active_profile"
     pure Credentials {..}
+
+-- | Credentials for a specific codeserver
+data CodeserverCredentials = CodeserverCredentials
+  { -- The most recent set of authentication tokens
+    tokens :: Tokens,
+    -- URI where the discovery document for this codeserver can be fetched.
+    discoveryURI :: URI
+  }
+  deriving (Eq)
+
+instance ToJSON CodeserverCredentials where
+  toJSON (CodeserverCredentials tokens discoveryURI) =
+    Aeson.object ["tokens" .= tokens, "discovery_uri" .= show discoveryURI]
+
+instance FromJSON CodeserverCredentials where
+  parseJSON =
+    Aeson.withObject "CodeserverCredentials" $ \v ->
+      do
+        tokens <- v .: "tokens"
+        discoveryURIString <- v .: "discovery_uri"
+        discoveryURI <- case parseURI discoveryURIString of
+          Nothing -> fail "discovery_uri is not a valid URI"
+          Just uri -> pure uri
+        pure $ CodeserverCredentials {..}
+
+emptyCredentials :: Credentials
+emptyCredentials = Credentials mempty defaultProfileName
+
+codeserverCredentials :: URI -> Tokens -> CodeserverCredentials
+codeserverCredentials discoveryURI tokens = CodeserverCredentials {discoveryURI, tokens}
+
+getCodeserverCredentials :: CodeserverId -> Credentials -> Either CredentialFailure CodeserverCredentials
+getCodeserverCredentials host (Credentials {credentials, activeProfile}) =
+  maybeToEither (ReauthRequired host) $
+    credentials ^? ix activeProfile . ix host
+
+setCodeserverCredentials :: CodeserverId -> CodeserverCredentials -> Credentials -> Credentials
+setCodeserverCredentials host codeserverCreds creds@(Credentials {credentials, activeProfile}) =
+  let newCredMap =
+        credentials
+          & at activeProfile . non Map.empty . at host .~ Just codeserverCreds
+   in creds {credentials = newCredMap}


### PR DESCRIPTION
## Overview

Best-practices for authentication is to use very short-lived Access Tokens for api calls (typically 30-mins) then use refresh tokens as a mechanism to refresh those access tokens when they expire. This provides a relatively safe mechanism to avoid forcing users to re-auth every 30 days or w/e; they can refresh indefinitely or until the revoke the refresh token.

This implements the UCM-side of the refresh token flow, everything will still continue to work as-is, but UCM will gain the benefits as soon as the Enlil side is implemented. 

## Implementation notes

* If the Auth'd http client middleware detects If the token is expired or the server responds with "401 - Unauthenticated":
  *  look up the refresh token for that server
  *. Hit the token endpoint and get new access token/refresh token
  * Store the new tokens in the credentials file
  * Re-perform the request with the new credentials. 
