### PR TITLE
Change `delete.namespace` to not print a diff

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -760,25 +760,20 @@ loop = do
                 Just (Branch.head -> b0) -> do
                   endangerments <- computeEndangerments b0
                   if null endangerments
-                    then doDelete b0
+                    then doDelete
                     else case insistence of
                       Force -> do
                         ppeDecl <- currentPrettyPrintEnvDecl Backend.Within
-                        doDelete b0
+                        doDelete
                         respondNumbered $ DeletedDespiteDependents ppeDecl endangerments
                       Try -> do
                         ppeDecl <- currentPrettyPrintEnvDecl Backend.Within
                         respondNumbered $ CantDeleteNamespace ppeDecl endangerments
               where
-                doDelete b0 = do
+                doDelete = do
                   stepAt Branch.CompressHistory $ BranchUtil.makeDeleteBranch (resolveSplit' p)
+                  respond Success
                   -- Looks similar to the 'toDelete' above... investigate me! ;)
-                  diffHelper b0 Branch.empty0
-                    >>= respondNumbered
-                      . uncurry
-                        ( ShowDiffAfterDeleteBranch $
-                            resolveToAbsolute (Path.unsplit' p)
-                        )
                 computeEndangerments :: Branch0 m1 -> Action' m v (Map LabeledDependency (NESet LabeledDependency))
                 computeEndangerments b0 = do
                   let rootNames = Branch.toNames root0

--- a/unison-src/transcripts/delete-namespace.output.md
+++ b/unison-src/transcripts/delete-namespace.output.md
@@ -15,11 +15,7 @@ Deleting a namespace with no external dependencies should succeed.
 ```ucm
 .> delete.namespace no_dependencies
 
-  Removed definitions:
-  
-    1. thing : Text
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
 ```
 Deleting a namespace with external dependencies should fail and list all dependents.
@@ -48,12 +44,7 @@ Deleting a namespace with external dependencies should succeed when using `delet
 ```ucm
 .> delete.namespace.force dependencies
 
-  Removed definitions:
-  
-    1. term1 : Nat
-    2. term2 : Nat
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
   ⚠️
   

--- a/unison-src/transcripts/empty-namespaces.output.md
+++ b/unison-src/transcripts/empty-namespaces.output.md
@@ -133,11 +133,7 @@ The history should be that of the moved namespace.
 ```ucm
 .> delete.namespace moveoverme
 
-  Removed definitions:
-  
-    1. x : ##Nat
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
 .> history moveme
 

--- a/unison-src/transcripts/merge.output.md
+++ b/unison-src/transcripts/merge.output.md
@@ -99,19 +99,11 @@ foo.z = +28348
 
 .P2> delete.namespace baz
 
-  Removed definitions:
-  
-    1. x : Nat
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
 .P2> delete.namespace quux
 
-  Removed definitions:
-  
-    1. x : Nat
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
 .P2> find
 

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -101,11 +101,7 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
 ```ucm
 .> delete.namespace .feature1
 
-  Removed definitions:
-  
-    1. y : Text
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
 .> history .feature1
 

--- a/unison-src/transcripts/propagate.output.md
+++ b/unison-src/transcripts/propagate.output.md
@@ -189,18 +189,7 @@ Cleaning up a bit...
 ```ucm
 .> delete.namespace subpath
 
-  Removed definitions:
-  
-    1. unique type Foo
-    2. Foo.Bar            : #isd1untaal
-    3. Foo.Foo            : #isd1untaal
-    4. fooToInt           : #isd1untaal -> Int
-    5. preserve.otherTerm : Optional baz -> Optional baz
-    6. preserve.someTerm  : Optional x -> Optional x
-    7. patch patch
-    8. patch preserve.patch
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
 ```
 Now, we make two terms, where one depends on the other.

--- a/unison-src/transcripts/unitnamespace.output.md
+++ b/unison-src/transcripts/unitnamespace.output.md
@@ -26,10 +26,6 @@ foo = "bar"
 
 .> delete.namespace ()
 
-  Removed definitions:
-  
-    1. foo : ##Text
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
 ```


### PR DESCRIPTION
It's not really useful information and takes a while to compute (like tens of seconds sometimes). You can always `ls` or `find` within the namespace before deleting if you're not sure what you're deleting.

Here's the new behavior.

<img width="287" alt="image" src="https://user-images.githubusercontent.com/11074/172219653-86dda523-e90f-4298-8f12-a93f1e8bea0c.png">

A super common use of `delete.namespace` is deleting a feature branch after it's been merged to trunk. Seeing a massive "diff" of all the definitions in your library (and also your library's dependencies) is not helpful.