### PR TITLE
Auth failure messaging

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -58,7 +58,7 @@ import qualified Unison.Reference as Reference
 import Unison.Referent (Referent)
 import Unison.Server.Backend (ShallowListEntry (..))
 import Unison.Server.SearchResult' (SearchResult')
-import qualified Unison.Share.Sync as Sync
+import qualified Unison.Share.Sync.Types as Sync
 import Unison.ShortHash (ShortHash)
 import Unison.Term (Term)
 import Unison.Type (Type)

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -195,7 +195,7 @@ main dir welcome initialPath (config, cancelConfig) initialInputs runtime codeba
             writeIORef pathRef (view LoopState.currentPath state)
             credMan <- newCredentialManager
             let tokenProvider = AuthN.newTokenProvider credMan
-            authorizedHTTPClient <- AuthN.newAuthenticatedHTTPClient tokenProvider ucmVersion
+            authorizedHTTPClient <- AuthN.newAuthenticatedHTTPClient notify tokenProvider ucmVersion
             let env =
                   LoopState.Env
                     { LoopState.authHTTPClient = authorizedHTTPClient,

--- a/unison-cli/src/Unison/Share/Sync.hs
+++ b/unison-cli/src/Unison/Share/Sync.hs
@@ -46,6 +46,7 @@ import U.Util.Hash32 (Hash32)
 import Unison.Auth.HTTPClient (AuthenticatedHttpClient)
 import qualified Unison.Auth.HTTPClient as Auth
 import Unison.Prelude
+import Unison.Share.Sync.Types
 import qualified Unison.Sqlite as Sqlite
 import qualified Unison.Sync.API as Share (API)
 import Unison.Sync.Common (causalHashToHash32, entityToTempEntity, expectEntity, hash32ToCausalHash)
@@ -55,12 +56,6 @@ import qualified Unison.Util.Set as Set
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Push
-
--- | An error occurred while pushing code to Unison Share.
-data CheckAndSetPushError
-  = CheckAndSetPushErrorHashMismatch Share.HashMismatch
-  | CheckAndSetPushErrorNoWritePermission Share.Path
-  | CheckAndSetPushErrorServerMissingDependencies (NESet Hash32)
 
 -- | Push a causal to Unison Share.
 -- FIXME reword this
@@ -116,16 +111,6 @@ checkAndSetPush httpClient unisonShareUrl conn path expectedHash causalHash uplo
             expectedHash,
             newHash = causalHashToHash32 causalHash
           }
-
--- | An error occurred while fast-forward pushing code to Unison Share.
-data FastForwardPushError
-  = FastForwardPushErrorNoHistory Share.Path
-  | FastForwardPushErrorNoReadPermission Share.Path
-  | FastForwardPushErrorNotFastForward Share.Path
-  | FastForwardPushErrorNoWritePermission Share.Path
-  | FastForwardPushErrorServerMissingDependencies (NESet Hash32)
-  | --                              Parent Child
-    FastForwardPushInvalidParentage Hash32 Hash32
 
 -- | Push a causal to Unison Share.
 -- FIXME reword this
@@ -313,12 +298,6 @@ dagbfs goal children =
 ------------------------------------------------------------------------------------------------------------------------
 -- Pull
 
--- | An error occurred while pulling code from Unison Share.
-data PullError
-  = -- | An error occurred while resolving a repo+path to a causal hash.
-    PullErrorGetCausalHashByPath GetCausalHashByPathError
-  | PullErrorNoHistoryAtPath Share.Path
-
 pull ::
   -- | The HTTP client to use for Unison Share requests.
   AuthenticatedHttpClient ->
@@ -406,11 +385,6 @@ downloadEntities doDownload conn hashes = do
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Get causal hash by path
-
--- | An error occurred when getting causal hash by path.
-data GetCausalHashByPathError
-  = -- | The user does not have permission to read this path.
-    GetCausalHashByPathErrorNoReadPermission Share.Path
 
 -- | Get the causal hash of a path hosted on Unison Share.
 getCausalHashByPath ::

--- a/unison-cli/src/Unison/Share/Sync/Types.hs
+++ b/unison-cli/src/Unison/Share/Sync/Types.hs
@@ -1,0 +1,33 @@
+-- | Types used by the UCM client during sync.
+module Unison.Share.Sync.Types where
+
+import Data.Set.NonEmpty (NESet)
+import U.Util.Hash32 (Hash32)
+import qualified Unison.Sync.Types as Share
+
+-- | Error used by the client when pushing code to Unison Share.
+data CheckAndSetPushError
+  = CheckAndSetPushErrorHashMismatch Share.HashMismatch
+  | CheckAndSetPushErrorNoWritePermission Share.Path
+  | CheckAndSetPushErrorServerMissingDependencies (NESet Hash32)
+
+-- | An error occurred while fast-forward pushing code to Unison Share.
+data FastForwardPushError
+  = FastForwardPushErrorNoHistory Share.Path
+  | FastForwardPushErrorNoReadPermission Share.Path
+  | FastForwardPushErrorNotFastForward Share.Path
+  | FastForwardPushErrorNoWritePermission Share.Path
+  | FastForwardPushErrorServerMissingDependencies (NESet Hash32)
+  | --                              Parent Child
+    FastForwardPushInvalidParentage Hash32 Hash32
+
+-- | An error occurred while pulling code from Unison Share.
+data PullError
+  = -- | An error occurred while resolving a repo+path to a causal hash.
+    PullErrorGetCausalHashByPath GetCausalHashByPathError
+  | PullErrorNoHistoryAtPath Share.Path
+
+-- | An error occurred when getting causal hash by path.
+data GetCausalHashByPathError
+  = -- | The user does not have permission to read this path.
+    GetCausalHashByPathErrorNoReadPermission Share.Path

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -62,6 +62,7 @@ library
       Unison.CommandLine.Welcome
       Unison.Share.Codeserver
       Unison.Share.Sync
+      Unison.Share.Sync.Types
       Unison.Util.HTTP
   hs-source-dirs:
       src


### PR DESCRIPTION
fixes #3090 #3086

## Overview

Improve user messaging when Auth issues are encountered.

## Implementation notes

* Pass the output-handling-function into the Authenticated Client such that it can provide messaging to the user for Credential Failures.
* We have a bit of an issue where the `Output` module depends on a LOT of modules, which means it can be tricky to add the `Output v -> IO ()` type to some modules. As a result I moved the sync error types which are used in `Output` into their own types module to avoid circular deps.

## Interesting/controversial decisions

Didn't make these changes here, but I also notice we have a ton of control-flow inside Action where we encounter error cases, but need to keep nesting case-statements because we don’t currently have a way to “bail” on an error.

Might be nice to, at some point, make Output an instance of Exception, 
so anywhere in the stack you can throw an Output to bail on the current CLI operation if you encounter an unrecoverable failure, then have a try-catch at the cli level to catch, respond, and re-prompt.