### PR TITLE
Better messaging for Transport Errors when speaking to a code server

### DIFF
--- a/lib/unison-prelude/src/Unison/Debug.hs
+++ b/lib/unison-prelude/src/Unison/Debug.hs
@@ -27,6 +27,7 @@ data DebugFlag
   | Auth
   | Migration
   | Integrity
+  | Sync
   deriving (Eq, Ord, Show, Bounded, Enum)
 
 debugFlags :: Set DebugFlag
@@ -44,6 +45,7 @@ debugFlags = case (unsafePerformIO (lookupEnv "UNISON_DEBUG")) of
       "AUTH" -> pure Auth
       "MIGRATION" -> pure Migration
       "INTEGRITY" -> pure Integrity
+      "SYNC" -> pure Sync
       _ -> empty
 {-# NOINLINE debugFlags #-}
 
@@ -70,6 +72,10 @@ debugMigration = Migration `Set.member` debugFlags
 debugIntegrity :: Bool
 debugIntegrity = Integrity `Set.member` debugFlags
 {-# NOINLINE debugIntegrity #-}
+
+debugSync :: Bool
+debugSync = Sync `Set.member` debugFlags
+{-# NOINLINE debugSync #-}
 
 -- | Use for trace-style selective debugging.
 -- E.g. 1 + (debug Git "The second number" 2)
@@ -117,3 +123,4 @@ shouldDebug = \case
   Auth -> debugAuth
   Migration -> debugMigration
   Integrity -> debugIntegrity
+  Sync -> debugSync

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -266,6 +266,7 @@ data ShareError
   | ShareErrorFastForwardPush Sync.FastForwardPushError
   | ShareErrorPull Sync.PullError
   | ShareErrorGetCausalHashByPath Sync.GetCausalHashByPathError
+  | ShareErrorTransport Sync.CodeserverTransportError
 
 data ReflogEntry = ReflogEntry {hash :: ShortBranchHash, reason :: Text}
   deriving (Show)

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1640,6 +1640,7 @@ notifyUser dir o = case o of
       UnreachableCodeserver codeServerURL ->
         P.lines $
           [ P.wrap $ "Unable to reach the code server hosted at:" <> P.string (Servant.showBaseUrl codeServerURL),
+          , ""
             P.wrap "Please check your network, ensure you've provided the correct location, or try again later."
           ]
       InvalidResponse resp -> P.fatalCallout $ P.hang "Invalid response received from codeserver:" (P.shown resp)

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1638,9 +1638,9 @@ notifyUser dir o = case o of
             ]
       PermissionDenied msg -> P.fatalCallout $ P.hang "Permission denied:" (P.text msg)
       UnreachableCodeserver codeServerURL ->
-        P.wrap . P.lines $
-          [ "Unable to reach the code server hosted at:" <> P.string (Servant.showBaseUrl codeServerURL),
-            "Please check your network, ensure you've provided the correct location, or try again later."
+        P.lines $
+          [ P.wrap $ "Unable to reach the code server hosted at:" <> P.string (Servant.showBaseUrl codeServerURL),
+            P.wrap "Please check your network, ensure you've provided the correct location, or try again later."
           ]
       InvalidResponse resp -> P.fatalCallout $ P.hang "Invalid response received from codeserver:" (P.shown resp)
       RateLimitExceeded -> P.warnCallout "Rate limit exceeded, please try again later."

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1640,7 +1640,7 @@ notifyUser dir o = case o of
       UnreachableCodeserver codeServerURL ->
         P.lines $
           [ P.wrap $ "Unable to reach the code server hosted at:" <> P.string (Servant.showBaseUrl codeServerURL),
-          , ""
+            "",
             P.wrap "Please check your network, ensure you've provided the correct location, or try again later."
           ]
       InvalidResponse resp -> P.fatalCallout $ P.hang "Invalid response received from codeserver:" (P.shown resp)

--- a/unison-cli/src/Unison/Share/Sync/Types.hs
+++ b/unison-cli/src/Unison/Share/Sync/Types.hs
@@ -1,8 +1,12 @@
+{-# LANGUAGE DeriveAnyClass #-}
+
 -- | Types used by the UCM client during sync.
 module Unison.Share.Sync.Types where
 
 import Data.Set.NonEmpty (NESet)
+import qualified Servant.Client as Servant
 import U.Util.Hash32 (Hash32)
+import Unison.Prelude
 import qualified Unison.Sync.Types as Share
 
 -- | Error used by the client when pushing code to Unison Share.
@@ -10,6 +14,7 @@ data CheckAndSetPushError
   = CheckAndSetPushErrorHashMismatch Share.HashMismatch
   | CheckAndSetPushErrorNoWritePermission Share.Path
   | CheckAndSetPushErrorServerMissingDependencies (NESet Hash32)
+  deriving (Show)
 
 -- | An error occurred while fast-forward pushing code to Unison Share.
 data FastForwardPushError
@@ -20,14 +25,35 @@ data FastForwardPushError
   | FastForwardPushErrorServerMissingDependencies (NESet Hash32)
   | --                              Parent Child
     FastForwardPushInvalidParentage Hash32 Hash32
+  deriving (Show)
 
 -- | An error occurred while pulling code from Unison Share.
 data PullError
   = -- | An error occurred while resolving a repo+path to a causal hash.
     PullErrorGetCausalHashByPath GetCausalHashByPathError
   | PullErrorNoHistoryAtPath Share.Path
+  deriving (Show)
 
 -- | An error occurred when getting causal hash by path.
 data GetCausalHashByPathError
   = -- | The user does not have permission to read this path.
     GetCausalHashByPathErrorNoReadPermission Share.Path
+  deriving (Show)
+
+-- | Generic Codeserver transport errors
+data CodeserverTransportError
+  = Unauthenticated
+  | -- We try to catch permission failures in the endpoint's response type, but if any slip
+    -- through they'll be translated as a PermissionDenied.
+    PermissionDenied Text
+  | UnreachableCodeserver
+  | InvalidResponse Servant.Response
+  | RateLimitExceeded
+  | InternalServerError
+  | Timeout
+  deriving stock (Show)
+  deriving anyclass (Exception)
+
+data SyncError e
+  = TransportError CodeserverTransportError
+  | SyncError e

--- a/unison-cli/src/Unison/Share/Sync/Types.hs
+++ b/unison-cli/src/Unison/Share/Sync/Types.hs
@@ -42,11 +42,11 @@ data GetCausalHashByPathError
 
 -- | Generic Codeserver transport errors
 data CodeserverTransportError
-  = Unauthenticated
+  = Unauthenticated Servant.BaseUrl
   | -- We try to catch permission failures in the endpoint's response type, but if any slip
     -- through they'll be translated as a PermissionDenied.
     PermissionDenied Text
-  | UnreachableCodeserver
+  | UnreachableCodeserver Servant.BaseUrl
   | InvalidResponse Servant.Response
   | RateLimitExceeded
   | InternalServerError


### PR DESCRIPTION
fixes https://github.com/unisonweb/unison/issues/3108

## Overview

Adds better error messages for a myriad of bad responses from the server; previously we just threw the ClientError as an exception and it blew up the whole operation. 
Now we use proper formatted messages.

e.g.

Old:
![image](https://user-images.githubusercontent.com/6439644/173705922-85a9b6fb-a4ab-4181-ab0c-9d30b79ae8cf.png)

New:
<img width="879" alt="image" src="https://user-images.githubusercontent.com/6439644/173707047-bf30879b-132b-4d71-a5ef-a39c582c9365.png">


Catches and translates common responses from the codeserver into reasonable errors.

## Implementation notes

* If the http client gets a bad response we now throw a Transport Error exception, which is caught into an `Either` by each top-level sync method and converted into an Output Message.
* In the future we may want to be smart and auto-retry on something like a 500 or a timeout; but we don't do that now

## Interesting/controversial decisions

* Potentially people have feelings about throwing exceptions; but I think this is a relatively good use for them, it definitely cuts down on superfluous control flow.