### PR TITLE
Insert temp tables before other migrations take place.

### DIFF
--- a/codebase2/codebase-sqlite/sql/001-temp-entity-tables.sql
+++ b/codebase2/codebase-sqlite/sql/001-temp-entity-tables.sql
@@ -1,4 +1,4 @@
-create table temp_entity_type_description (
+create table if not exists temp_entity_type_description (
   id integer primary key not null,
   description text unique not null
 );
@@ -7,7 +7,9 @@ insert into temp_entity_type_description values
   (1, 'Decl Component'),
   (2, 'Namespace'),
   (3, 'Patch'),
-  (4, 'Causal');
+  (4, 'Causal')
+  ON CONFLICT DO NOTHING
+;
 
 -- A "temp entity" is a term/decl/namespace/patch/causal that we cannot store in the database proper due to missing
 -- dependencies.
@@ -19,7 +21,7 @@ insert into temp_entity_type_description values
 -- Similarly, each `temp_entity` row implies we do not have the entity in the database proper. When and if we *do* store
 -- an entity proper (after storing all of its dependencies), we should always atomically delete the corresponding
 -- `temp_entity` row, if any.
-create table temp_entity (
+create table if not exists temp_entity (
   hash text primary key not null,
   blob bytes not null,
   type_id integer not null references temp_entity_type_description(id)
@@ -51,11 +53,11 @@ create table temp_entity (
 -- |========================================|
 -- | #foo      | #bar       | aT.Eb.cx      |
 -- +----------------------------------------+
-create table temp_entity_missing_dependency (
+create table if not exists temp_entity_missing_dependency (
   dependent text not null references temp_entity(hash),
   dependency text not null,
   dependencyJwt text not null,
   unique (dependent, dependency)
 );
-create index temp_entity_missing_dependency_ix_dependent on temp_entity_missing_dependency (dependent);
-create index temp_entity_missing_dependency_ix_dependency on temp_entity_missing_dependency (dependency)
+create index if not exists temp_entity_missing_dependency_ix_dependent on temp_entity_missing_dependency (dependent);
+create index if not exists temp_entity_missing_dependency_ix_dependency on temp_entity_missing_dependency (dependency)


### PR DESCRIPTION
Old Context:


- Arya is looking into how to 'freeze code' which is used in migrations because a recent change to `saveObject`; Currently looking into copy-pasting all existing code and 'Weeder'ing out any code not used by the migration
    - Chris suggests that maybe we should look into simpler options to save time while we're in crunch mode.
    - Option 1: Use an old version of UCM to do some of the updates 
        - Arya: kind of janky
    - Option 1b: separate migration tool 
    - Option 2: Copy monorepo to migration-specific package + weed out unnecessary dependencies -**A**
        - getting weeder working might be a big job / low priority?
    - Option 3: Copy monorepo to migration-specific package + __don't__ weed out unnecessary dependencies
        - high compilation times
            - no, this should be okay if pulled out of the monorepo
        - high binary sizes
    - Option 4: Copy monorepo to migration-specific package + weed out __some__ unnecessary dependencies -**M**/**T**
        - Just try the insert and check for a 'missing table exception' or w/e
    - Option 5: Check for Temp Table existence (or schema version) in saveObject
        - global variables -**A** -**C (temporarily, just until we have more time for a better solution)**
    - Option 6: Check/save schema version in runTransaction or something
    - Note: We want a principled way to handle this in future migrations, regardless.
    - Note: Majority of codebases don't need to be migrated
    - Note: Migrations don't need to be run in the same transaction
    - Note: In some cases, pushing a codebase to Share w/ old `ucm` and pulling it back with a new one might be faster / more convenient.


New:

This PR take an alternative approach, the only requirement for old migrations to work is that these tables EXIST, they don't need to be populated with anything at all, so we can just add those tables as a 'pre-migration' step whenever we run a migration.

It's still a hack that should be removed later, but it's safer, simpler, adds less junk code, and is more performant than our other approaches.

- [x] Tested on commit 5cf1da4 from `base` which is a v1 codebase.