### PR TITLE
Add `Sha1` builtin

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -68,3 +68,4 @@ The format for this list: name, GitHub handle
 * Harald Gliebe (@hagl)
 * Phil de Joux (@philderbeast)
 * Travis Staton (@tstat)
+* Dan Freeman (@dfreeman)

--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -593,7 +593,7 @@ hashBuiltins =
     B "crypto.hmac" $ forall1 "a" (\a -> hashAlgo --> bytes --> a --> bytes),
     B "crypto.hmacBytes" $ hashAlgo --> bytes --> bytes --> bytes
   ]
-    ++ map h ["Sha3_512", "Sha3_256", "Sha2_512", "Sha2_256", "Blake2b_512", "Blake2b_256", "Blake2s_256"]
+    ++ map h ["Sha3_512", "Sha3_256", "Sha2_512", "Sha2_256", "Sha1", "Blake2b_512", "Blake2b_256", "Blake2s_256"]
   where
     hashAlgo = Type.ref () Type.hashAlgorithmRef
     h name = B ("crypto.HashAlgorithm." <> name) hashAlgo

--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -2148,6 +2148,7 @@ declareForeigns = do
   declareHashAlgorithm "Sha3_256" Hash.SHA3_256
   declareHashAlgorithm "Sha2_512" Hash.SHA512
   declareHashAlgorithm "Sha2_256" Hash.SHA256
+  declareHashAlgorithm "Sha1" Hash.SHA1
   declareHashAlgorithm "Blake2b_512" Hash.Blake2b_512
   declareHashAlgorithm "Blake2b_256" Hash.Blake2b_256
   declareHashAlgorithm "Blake2s_256" Hash.Blake2s_256

--- a/unison-src/transcripts-using-base/hashing.md
+++ b/unison-src/transcripts-using-base/hashing.md
@@ -145,6 +145,26 @@ test> sha2_256.tests.ex4 =
     "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu"
     "cf5b16a778af8380036ce59e7b0492370b249b11e8f07a51afac45037afee9d1"
 
+test> sha1.tests.ex1 =
+  ex Sha1
+    "abc"
+    "a9993e364706816aba3e25717850c26c9cd0d89d"
+
+test> sha1.tests.ex2 =
+  ex Sha1
+    ""
+    "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+
+test> sha1.tests.ex3 =
+  ex Sha1
+    "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
+    "84983e441c3bd26ebaae4aa1f95129e5e54670f1"
+
+test> sha1.tests.ex4 =
+  ex Sha1
+    "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu"
+    "a49b2446a02c645bf419f995b67091253a04a259"
+
 test> blake2s_256.tests.ex1 =
   ex Blake2s_256
     ""

--- a/unison-src/transcripts-using-base/hashing.output.md
+++ b/unison-src/transcripts-using-base/hashing.output.md
@@ -124,13 +124,14 @@ And here's the full API:
   3.  HashAlgorithm.Blake2b_256 : HashAlgorithm
   4.  HashAlgorithm.Blake2b_512 : HashAlgorithm
   5.  HashAlgorithm.Blake2s_256 : HashAlgorithm
-  6.  HashAlgorithm.Sha2_256 : HashAlgorithm
-  7.  HashAlgorithm.Sha2_512 : HashAlgorithm
-  8.  HashAlgorithm.Sha3_256 : HashAlgorithm
-  9.  HashAlgorithm.Sha3_512 : HashAlgorithm
-  10. hashBytes : HashAlgorithm -> Bytes -> Bytes
-  11. hmac : HashAlgorithm -> Bytes -> a -> Bytes
-  12. hmacBytes : HashAlgorithm -> Bytes -> Bytes -> Bytes
+  6.  HashAlgorithm.Sha1 : HashAlgorithm
+  7.  HashAlgorithm.Sha2_256 : HashAlgorithm
+  8.  HashAlgorithm.Sha2_512 : HashAlgorithm
+  9.  HashAlgorithm.Sha3_256 : HashAlgorithm
+  10. HashAlgorithm.Sha3_512 : HashAlgorithm
+  11. hashBytes : HashAlgorithm -> Bytes -> Bytes
+  12. hmac : HashAlgorithm -> Bytes -> a -> Bytes
+  13. hmacBytes : HashAlgorithm -> Bytes -> Bytes -> Bytes
   
 
 .> cd .
@@ -243,6 +244,26 @@ test> sha2_256.tests.ex4 =
     "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu"
     "cf5b16a778af8380036ce59e7b0492370b249b11e8f07a51afac45037afee9d1"
 
+test> sha1.tests.ex1 =
+  ex Sha1
+    "abc"
+    "a9993e364706816aba3e25717850c26c9cd0d89d"
+
+test> sha1.tests.ex2 =
+  ex Sha1
+    ""
+    "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+
+test> sha1.tests.ex3 =
+  ex Sha1
+    "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
+    "84983e441c3bd26ebaae4aa1f95129e5e54670f1"
+
+test> sha1.tests.ex4 =
+  ex Sha1
+    "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu"
+    "a49b2446a02c645bf419f995b67091253a04a259"
+
 test> blake2s_256.tests.ex1 =
   ex Blake2s_256
     ""
@@ -273,6 +294,10 @@ test> blake2b_512.tests.ex3 =
   ◉ blake2b_512.tests.ex2   Passed
   ◉ blake2b_512.tests.ex3   Passed
   ◉ blake2s_256.tests.ex1   Passed
+  ◉ sha1.tests.ex1          Passed
+  ◉ sha1.tests.ex2          Passed
+  ◉ sha1.tests.ex3          Passed
+  ◉ sha1.tests.ex4          Passed
   ◉ sha2_256.tests.ex1      Passed
   ◉ sha2_256.tests.ex2      Passed
   ◉ sha2_256.tests.ex3      Passed
@@ -290,7 +315,7 @@ test> blake2b_512.tests.ex3 =
   ◉ sha3_512.tests.ex3      Passed
   ◉ sha3_512.tests.ex4      Passed
   
-  ✅ 20 test(s) passing
+  ✅ 24 test(s) passing
   
   Tip: Use view blake2b_512.tests.ex1 to view the source of a
        test.
@@ -378,6 +403,10 @@ test> hmac_sha2_512.tests.ex2 =
   ◉ hmac_sha2_256.tests.ex2   Passed
   ◉ hmac_sha2_512.tests.ex1   Passed
   ◉ hmac_sha2_512.tests.ex2   Passed
+  ◉ sha1.tests.ex1            Passed
+  ◉ sha1.tests.ex2            Passed
+  ◉ sha1.tests.ex3            Passed
+  ◉ sha1.tests.ex4            Passed
   ◉ sha2_256.tests.ex1        Passed
   ◉ sha2_256.tests.ex2        Passed
   ◉ sha2_256.tests.ex3        Passed
@@ -395,7 +424,7 @@ test> hmac_sha2_512.tests.ex2 =
   ◉ sha3_512.tests.ex3        Passed
   ◉ sha3_512.tests.ex4        Passed
   
-  ✅ 24 test(s) passing
+  ✅ 28 test(s) passing
   
   Tip: Use view blake2b_512.tests.ex1 to view the source of a
        test.

--- a/unison-src/transcripts/alias-many.output.md
+++ b/unison-src/transcripts/alias-many.output.md
@@ -76,415 +76,416 @@ Let's try it!
   56.  crypto.HashAlgorithm.Blake2b_256 : HashAlgorithm
   57.  crypto.HashAlgorithm.Blake2b_512 : HashAlgorithm
   58.  crypto.HashAlgorithm.Blake2s_256 : HashAlgorithm
-  59.  crypto.HashAlgorithm.Sha2_256 : HashAlgorithm
-  60.  crypto.HashAlgorithm.Sha2_512 : HashAlgorithm
-  61.  crypto.HashAlgorithm.Sha3_256 : HashAlgorithm
-  62.  crypto.HashAlgorithm.Sha3_512 : HashAlgorithm
-  63.  crypto.hashBytes : HashAlgorithm -> Bytes -> Bytes
-  64.  crypto.hmac : HashAlgorithm -> Bytes -> a -> Bytes
-  65.  crypto.hmacBytes : HashAlgorithm
+  59.  crypto.HashAlgorithm.Sha1 : HashAlgorithm
+  60.  crypto.HashAlgorithm.Sha2_256 : HashAlgorithm
+  61.  crypto.HashAlgorithm.Sha2_512 : HashAlgorithm
+  62.  crypto.HashAlgorithm.Sha3_256 : HashAlgorithm
+  63.  crypto.HashAlgorithm.Sha3_512 : HashAlgorithm
+  64.  crypto.hashBytes : HashAlgorithm -> Bytes -> Bytes
+  65.  crypto.hmac : HashAlgorithm -> Bytes -> a -> Bytes
+  66.  crypto.hmacBytes : HashAlgorithm
                           -> Bytes
                           -> Bytes
                           -> Bytes
-  66.  Debug.trace : Text -> a -> ()
-  67.  Debug.watch : Text -> a -> a
-  68.  unique type Doc
-  69.  Doc.Blob : Text -> Doc
-  70.  Doc.Evaluate : Term -> Doc
-  71.  Doc.Join : [Doc] -> Doc
-  72.  Doc.Link : Link -> Doc
-  73.  Doc.Signature : Term -> Doc
-  74.  Doc.Source : Link -> Doc
-  75.  structural type Either a b
-  76.  Either.Left : a -> Either a b
-  77.  Either.Right : b -> Either a b
-  78.  structural ability Exception
-  79.  Exception.raise : Failure ->{Exception} x
-  80.  builtin type Float
-  81.  Float.* : Float -> Float -> Float
-  82.  Float.+ : Float -> Float -> Float
-  83.  Float.- : Float -> Float -> Float
-  84.  Float./ : Float -> Float -> Float
-  85.  Float.abs : Float -> Float
-  86.  Float.acos : Float -> Float
-  87.  Float.acosh : Float -> Float
-  88.  Float.asin : Float -> Float
-  89.  Float.asinh : Float -> Float
-  90.  Float.atan : Float -> Float
-  91.  Float.atan2 : Float -> Float -> Float
-  92.  Float.atanh : Float -> Float
-  93.  Float.ceiling : Float -> Int
-  94.  Float.cos : Float -> Float
-  95.  Float.cosh : Float -> Float
-  96.  Float.eq : Float -> Float -> Boolean
-  97.  Float.exp : Float -> Float
-  98.  Float.floor : Float -> Int
-  99.  Float.fromRepresentation : Nat -> Float
-  100. Float.fromText : Text -> Optional Float
-  101. Float.gt : Float -> Float -> Boolean
-  102. Float.gteq : Float -> Float -> Boolean
-  103. Float.log : Float -> Float
-  104. Float.logBase : Float -> Float -> Float
-  105. Float.lt : Float -> Float -> Boolean
-  106. Float.lteq : Float -> Float -> Boolean
-  107. Float.max : Float -> Float -> Float
-  108. Float.min : Float -> Float -> Float
-  109. Float.pow : Float -> Float -> Float
-  110. Float.round : Float -> Int
-  111. Float.sin : Float -> Float
-  112. Float.sinh : Float -> Float
-  113. Float.sqrt : Float -> Float
-  114. Float.tan : Float -> Float
-  115. Float.tanh : Float -> Float
-  116. Float.toRepresentation : Float -> Nat
-  117. Float.toText : Float -> Text
-  118. Float.truncate : Float -> Int
-  119. Handle.toText : Handle -> Text
-  120. builtin type Int
-  121. Int.* : Int -> Int -> Int
-  122. Int.+ : Int -> Int -> Int
-  123. Int.- : Int -> Int -> Int
-  124. Int./ : Int -> Int -> Int
-  125. Int.and : Int -> Int -> Int
-  126. Int.complement : Int -> Int
-  127. Int.eq : Int -> Int -> Boolean
-  128. Int.fromRepresentation : Nat -> Int
-  129. Int.fromText : Text -> Optional Int
-  130. Int.gt : Int -> Int -> Boolean
-  131. Int.gteq : Int -> Int -> Boolean
-  132. Int.increment : Int -> Int
-  133. Int.isEven : Int -> Boolean
-  134. Int.isOdd : Int -> Boolean
-  135. Int.leadingZeros : Int -> Nat
-  136. Int.lt : Int -> Int -> Boolean
-  137. Int.lteq : Int -> Int -> Boolean
-  138. Int.mod : Int -> Int -> Int
-  139. Int.negate : Int -> Int
-  140. Int.or : Int -> Int -> Int
-  141. Int.popCount : Int -> Nat
-  142. Int.pow : Int -> Nat -> Int
-  143. Int.shiftLeft : Int -> Nat -> Int
-  144. Int.shiftRight : Int -> Nat -> Int
-  145. Int.signum : Int -> Int
-  146. Int.toFloat : Int -> Float
-  147. Int.toRepresentation : Int -> Nat
-  148. Int.toText : Int -> Text
-  149. Int.trailingZeros : Int -> Nat
-  150. Int.truncate0 : Int -> Nat
-  151. Int.xor : Int -> Int -> Int
-  152. unique type io2.BufferMode
-  153. io2.BufferMode.BlockBuffering : BufferMode
-  154. io2.BufferMode.LineBuffering : BufferMode
-  155. io2.BufferMode.NoBuffering : BufferMode
-  156. io2.BufferMode.SizedBlockBuffering : Nat -> BufferMode
-  157. io2.Clock.internals.monotonic : '{IO} Either
+  67.  Debug.trace : Text -> a -> ()
+  68.  Debug.watch : Text -> a -> a
+  69.  unique type Doc
+  70.  Doc.Blob : Text -> Doc
+  71.  Doc.Evaluate : Term -> Doc
+  72.  Doc.Join : [Doc] -> Doc
+  73.  Doc.Link : Link -> Doc
+  74.  Doc.Signature : Term -> Doc
+  75.  Doc.Source : Link -> Doc
+  76.  structural type Either a b
+  77.  Either.Left : a -> Either a b
+  78.  Either.Right : b -> Either a b
+  79.  structural ability Exception
+  80.  Exception.raise : Failure ->{Exception} x
+  81.  builtin type Float
+  82.  Float.* : Float -> Float -> Float
+  83.  Float.+ : Float -> Float -> Float
+  84.  Float.- : Float -> Float -> Float
+  85.  Float./ : Float -> Float -> Float
+  86.  Float.abs : Float -> Float
+  87.  Float.acos : Float -> Float
+  88.  Float.acosh : Float -> Float
+  89.  Float.asin : Float -> Float
+  90.  Float.asinh : Float -> Float
+  91.  Float.atan : Float -> Float
+  92.  Float.atan2 : Float -> Float -> Float
+  93.  Float.atanh : Float -> Float
+  94.  Float.ceiling : Float -> Int
+  95.  Float.cos : Float -> Float
+  96.  Float.cosh : Float -> Float
+  97.  Float.eq : Float -> Float -> Boolean
+  98.  Float.exp : Float -> Float
+  99.  Float.floor : Float -> Int
+  100. Float.fromRepresentation : Nat -> Float
+  101. Float.fromText : Text -> Optional Float
+  102. Float.gt : Float -> Float -> Boolean
+  103. Float.gteq : Float -> Float -> Boolean
+  104. Float.log : Float -> Float
+  105. Float.logBase : Float -> Float -> Float
+  106. Float.lt : Float -> Float -> Boolean
+  107. Float.lteq : Float -> Float -> Boolean
+  108. Float.max : Float -> Float -> Float
+  109. Float.min : Float -> Float -> Float
+  110. Float.pow : Float -> Float -> Float
+  111. Float.round : Float -> Int
+  112. Float.sin : Float -> Float
+  113. Float.sinh : Float -> Float
+  114. Float.sqrt : Float -> Float
+  115. Float.tan : Float -> Float
+  116. Float.tanh : Float -> Float
+  117. Float.toRepresentation : Float -> Nat
+  118. Float.toText : Float -> Text
+  119. Float.truncate : Float -> Int
+  120. Handle.toText : Handle -> Text
+  121. builtin type Int
+  122. Int.* : Int -> Int -> Int
+  123. Int.+ : Int -> Int -> Int
+  124. Int.- : Int -> Int -> Int
+  125. Int./ : Int -> Int -> Int
+  126. Int.and : Int -> Int -> Int
+  127. Int.complement : Int -> Int
+  128. Int.eq : Int -> Int -> Boolean
+  129. Int.fromRepresentation : Nat -> Int
+  130. Int.fromText : Text -> Optional Int
+  131. Int.gt : Int -> Int -> Boolean
+  132. Int.gteq : Int -> Int -> Boolean
+  133. Int.increment : Int -> Int
+  134. Int.isEven : Int -> Boolean
+  135. Int.isOdd : Int -> Boolean
+  136. Int.leadingZeros : Int -> Nat
+  137. Int.lt : Int -> Int -> Boolean
+  138. Int.lteq : Int -> Int -> Boolean
+  139. Int.mod : Int -> Int -> Int
+  140. Int.negate : Int -> Int
+  141. Int.or : Int -> Int -> Int
+  142. Int.popCount : Int -> Nat
+  143. Int.pow : Int -> Nat -> Int
+  144. Int.shiftLeft : Int -> Nat -> Int
+  145. Int.shiftRight : Int -> Nat -> Int
+  146. Int.signum : Int -> Int
+  147. Int.toFloat : Int -> Float
+  148. Int.toRepresentation : Int -> Nat
+  149. Int.toText : Int -> Text
+  150. Int.trailingZeros : Int -> Nat
+  151. Int.truncate0 : Int -> Nat
+  152. Int.xor : Int -> Int -> Int
+  153. unique type io2.BufferMode
+  154. io2.BufferMode.BlockBuffering : BufferMode
+  155. io2.BufferMode.LineBuffering : BufferMode
+  156. io2.BufferMode.NoBuffering : BufferMode
+  157. io2.BufferMode.SizedBlockBuffering : Nat -> BufferMode
+  158. io2.Clock.internals.monotonic : '{IO} Either
                                          Failure TimeSpec
-  158. io2.Clock.internals.nsec : TimeSpec -> Nat
-  159. io2.Clock.internals.processCPUTime : '{IO} Either
+  159. io2.Clock.internals.nsec : TimeSpec -> Nat
+  160. io2.Clock.internals.processCPUTime : '{IO} Either
                                               Failure TimeSpec
-  160. io2.Clock.internals.realtime : '{IO} Either
+  161. io2.Clock.internals.realtime : '{IO} Either
                                         Failure TimeSpec
-  161. io2.Clock.internals.sec : TimeSpec -> Int
-  162. io2.Clock.internals.threadCPUTime : '{IO} Either
+  162. io2.Clock.internals.sec : TimeSpec -> Int
+  163. io2.Clock.internals.threadCPUTime : '{IO} Either
                                              Failure TimeSpec
-  163. builtin type io2.Clock.internals.TimeSpec
-  164. unique type io2.Failure
-  165. io2.Failure.Failure : Type -> Text -> Any -> Failure
-  166. unique type io2.FileMode
-  167. io2.FileMode.Append : FileMode
-  168. io2.FileMode.Read : FileMode
-  169. io2.FileMode.ReadWrite : FileMode
-  170. io2.FileMode.Write : FileMode
-  171. builtin type io2.Handle
-  172. builtin type io2.IO
-  173. io2.IO.clientSocket.impl : Text
+  164. builtin type io2.Clock.internals.TimeSpec
+  165. unique type io2.Failure
+  166. io2.Failure.Failure : Type -> Text -> Any -> Failure
+  167. unique type io2.FileMode
+  168. io2.FileMode.Append : FileMode
+  169. io2.FileMode.Read : FileMode
+  170. io2.FileMode.ReadWrite : FileMode
+  171. io2.FileMode.Write : FileMode
+  172. builtin type io2.Handle
+  173. builtin type io2.IO
+  174. io2.IO.clientSocket.impl : Text
                                   -> Text
                                   ->{IO} Either Failure Socket
-  174. io2.IO.closeFile.impl : Handle ->{IO} Either Failure ()
-  175. io2.IO.closeSocket.impl : Socket ->{IO} Either Failure ()
-  176. io2.IO.createDirectory.impl : Text
+  175. io2.IO.closeFile.impl : Handle ->{IO} Either Failure ()
+  176. io2.IO.closeSocket.impl : Socket ->{IO} Either Failure ()
+  177. io2.IO.createDirectory.impl : Text
                                      ->{IO} Either Failure ()
-  177. io2.IO.createTempDirectory.impl : Text
+  178. io2.IO.createTempDirectory.impl : Text
                                          ->{IO} Either
                                            Failure Text
-  178. io2.IO.delay.impl : Nat ->{IO} Either Failure ()
-  179. io2.IO.directoryContents.impl : Text
+  179. io2.IO.delay.impl : Nat ->{IO} Either Failure ()
+  180. io2.IO.directoryContents.impl : Text
                                        ->{IO} Either
                                          Failure [Text]
-  180. io2.IO.fileExists.impl : Text
+  181. io2.IO.fileExists.impl : Text
                                 ->{IO} Either Failure Boolean
-  181. io2.IO.forkComp : '{IO} a ->{IO} ThreadId
-  182. io2.IO.getArgs.impl : '{IO} Either Failure [Text]
-  183. io2.IO.getBuffering.impl : Handle
+  182. io2.IO.forkComp : '{IO} a ->{IO} ThreadId
+  183. io2.IO.getArgs.impl : '{IO} Either Failure [Text]
+  184. io2.IO.getBuffering.impl : Handle
                                   ->{IO} Either
                                     Failure BufferMode
-  184. io2.IO.getBytes.impl : Handle
+  185. io2.IO.getBytes.impl : Handle
                               -> Nat
                               ->{IO} Either Failure Bytes
-  185. io2.IO.getCurrentDirectory.impl : '{IO} Either
+  186. io2.IO.getCurrentDirectory.impl : '{IO} Either
                                            Failure Text
-  186. io2.IO.getEnv.impl : Text ->{IO} Either Failure Text
-  187. io2.IO.getFileSize.impl : Text ->{IO} Either Failure Nat
-  188. io2.IO.getFileTimestamp.impl : Text
+  187. io2.IO.getEnv.impl : Text ->{IO} Either Failure Text
+  188. io2.IO.getFileSize.impl : Text ->{IO} Either Failure Nat
+  189. io2.IO.getFileTimestamp.impl : Text
                                       ->{IO} Either Failure Nat
-  189. io2.IO.getLine.impl : Handle ->{IO} Either Failure Text
-  190. io2.IO.getSomeBytes.impl : Handle
+  190. io2.IO.getLine.impl : Handle ->{IO} Either Failure Text
+  191. io2.IO.getSomeBytes.impl : Handle
                                   -> Nat
                                   ->{IO} Either Failure Bytes
-  191. io2.IO.getTempDirectory.impl : '{IO} Either Failure Text
-  192. io2.IO.handlePosition.impl : Handle
+  192. io2.IO.getTempDirectory.impl : '{IO} Either Failure Text
+  193. io2.IO.handlePosition.impl : Handle
                                     ->{IO} Either Failure Nat
-  193. io2.IO.isDirectory.impl : Text
+  194. io2.IO.isDirectory.impl : Text
                                  ->{IO} Either Failure Boolean
-  194. io2.IO.isFileEOF.impl : Handle
+  195. io2.IO.isFileEOF.impl : Handle
                                ->{IO} Either Failure Boolean
-  195. io2.IO.isFileOpen.impl : Handle
+  196. io2.IO.isFileOpen.impl : Handle
                                 ->{IO} Either Failure Boolean
-  196. io2.IO.isSeekable.impl : Handle
+  197. io2.IO.isSeekable.impl : Handle
                                 ->{IO} Either Failure Boolean
-  197. io2.IO.kill.impl : ThreadId ->{IO} Either Failure ()
-  198. io2.IO.listen.impl : Socket ->{IO} Either Failure ()
-  199. io2.IO.openFile.impl : Text
+  198. io2.IO.kill.impl : ThreadId ->{IO} Either Failure ()
+  199. io2.IO.listen.impl : Socket ->{IO} Either Failure ()
+  200. io2.IO.openFile.impl : Text
                               -> FileMode
                               ->{IO} Either Failure Handle
-  200. io2.IO.putBytes.impl : Handle
+  201. io2.IO.putBytes.impl : Handle
                               -> Bytes
                               ->{IO} Either Failure ()
-  201. io2.IO.ref : a ->{IO} Ref {IO} a
-  202. io2.IO.removeDirectory.impl : Text
+  202. io2.IO.ref : a ->{IO} Ref {IO} a
+  203. io2.IO.removeDirectory.impl : Text
                                      ->{IO} Either Failure ()
-  203. io2.IO.removeFile.impl : Text ->{IO} Either Failure ()
-  204. io2.IO.renameDirectory.impl : Text
+  204. io2.IO.removeFile.impl : Text ->{IO} Either Failure ()
+  205. io2.IO.renameDirectory.impl : Text
                                      -> Text
                                      ->{IO} Either Failure ()
-  205. io2.IO.renameFile.impl : Text
+  206. io2.IO.renameFile.impl : Text
                                 -> Text
                                 ->{IO} Either Failure ()
-  206. io2.IO.seekHandle.impl : Handle
+  207. io2.IO.seekHandle.impl : Handle
                                 -> SeekMode
                                 -> Int
                                 ->{IO} Either Failure ()
-  207. io2.IO.serverSocket.impl : Optional Text
+  208. io2.IO.serverSocket.impl : Optional Text
                                   -> Text
                                   ->{IO} Either Failure Socket
-  208. io2.IO.setBuffering.impl : Handle
+  209. io2.IO.setBuffering.impl : Handle
                                   -> BufferMode
                                   ->{IO} Either Failure ()
-  209. io2.IO.setCurrentDirectory.impl : Text
+  210. io2.IO.setCurrentDirectory.impl : Text
                                          ->{IO} Either
                                            Failure ()
-  210. io2.IO.socketAccept.impl : Socket
+  211. io2.IO.socketAccept.impl : Socket
                                   ->{IO} Either Failure Socket
-  211. io2.IO.socketPort.impl : Socket ->{IO} Either Failure Nat
-  212. io2.IO.socketReceive.impl : Socket
+  212. io2.IO.socketPort.impl : Socket ->{IO} Either Failure Nat
+  213. io2.IO.socketReceive.impl : Socket
                                    -> Nat
                                    ->{IO} Either Failure Bytes
-  213. io2.IO.socketSend.impl : Socket
+  214. io2.IO.socketSend.impl : Socket
                                 -> Bytes
                                 ->{IO} Either Failure ()
-  214. io2.IO.stdHandle : StdHandle -> Handle
-  215. io2.IO.systemTime.impl : '{IO} Either Failure Nat
-  216. io2.IO.systemTimeMicroseconds : '{IO} Int
-  217. unique type io2.IOError
-  218. io2.IOError.AlreadyExists : IOError
-  219. io2.IOError.EOF : IOError
-  220. io2.IOError.IllegalOperation : IOError
-  221. io2.IOError.NoSuchThing : IOError
-  222. io2.IOError.PermissionDenied : IOError
-  223. io2.IOError.ResourceBusy : IOError
-  224. io2.IOError.ResourceExhausted : IOError
-  225. io2.IOError.UserError : IOError
-  226. unique type io2.IOFailure
-  227. builtin type io2.MVar
-  228. io2.MVar.isEmpty : MVar a ->{IO} Boolean
-  229. io2.MVar.new : a ->{IO} MVar a
-  230. io2.MVar.newEmpty : '{IO} MVar a
-  231. io2.MVar.put.impl : MVar a -> a ->{IO} Either Failure ()
-  232. io2.MVar.read.impl : MVar a ->{IO} Either Failure a
-  233. io2.MVar.swap.impl : MVar a -> a ->{IO} Either Failure a
-  234. io2.MVar.take.impl : MVar a ->{IO} Either Failure a
-  235. io2.MVar.tryPut.impl : MVar a
+  215. io2.IO.stdHandle : StdHandle -> Handle
+  216. io2.IO.systemTime.impl : '{IO} Either Failure Nat
+  217. io2.IO.systemTimeMicroseconds : '{IO} Int
+  218. unique type io2.IOError
+  219. io2.IOError.AlreadyExists : IOError
+  220. io2.IOError.EOF : IOError
+  221. io2.IOError.IllegalOperation : IOError
+  222. io2.IOError.NoSuchThing : IOError
+  223. io2.IOError.PermissionDenied : IOError
+  224. io2.IOError.ResourceBusy : IOError
+  225. io2.IOError.ResourceExhausted : IOError
+  226. io2.IOError.UserError : IOError
+  227. unique type io2.IOFailure
+  228. builtin type io2.MVar
+  229. io2.MVar.isEmpty : MVar a ->{IO} Boolean
+  230. io2.MVar.new : a ->{IO} MVar a
+  231. io2.MVar.newEmpty : '{IO} MVar a
+  232. io2.MVar.put.impl : MVar a -> a ->{IO} Either Failure ()
+  233. io2.MVar.read.impl : MVar a ->{IO} Either Failure a
+  234. io2.MVar.swap.impl : MVar a -> a ->{IO} Either Failure a
+  235. io2.MVar.take.impl : MVar a ->{IO} Either Failure a
+  236. io2.MVar.tryPut.impl : MVar a
                               -> a
                               ->{IO} Either Failure Boolean
-  236. io2.MVar.tryRead.impl : MVar a
+  237. io2.MVar.tryRead.impl : MVar a
                                ->{IO} Either
                                  Failure (Optional a)
-  237. io2.MVar.tryTake : MVar a ->{IO} Optional a
-  238. unique type io2.SeekMode
-  239. io2.SeekMode.AbsoluteSeek : SeekMode
-  240. io2.SeekMode.RelativeSeek : SeekMode
-  241. io2.SeekMode.SeekFromEnd : SeekMode
-  242. builtin type io2.Socket
-  243. unique type io2.StdHandle
-  244. io2.StdHandle.StdErr : StdHandle
-  245. io2.StdHandle.StdIn : StdHandle
-  246. io2.StdHandle.StdOut : StdHandle
-  247. builtin type io2.STM
-  248. io2.STM.atomically : '{STM} a ->{IO} a
-  249. io2.STM.retry : '{STM} a
-  250. builtin type io2.ThreadId
-  251. builtin type io2.Tls
-  252. builtin type io2.Tls.Cipher
-  253. builtin type io2.Tls.ClientConfig
-  254. io2.Tls.ClientConfig.certificates.set : [SignedCert]
+  238. io2.MVar.tryTake : MVar a ->{IO} Optional a
+  239. unique type io2.SeekMode
+  240. io2.SeekMode.AbsoluteSeek : SeekMode
+  241. io2.SeekMode.RelativeSeek : SeekMode
+  242. io2.SeekMode.SeekFromEnd : SeekMode
+  243. builtin type io2.Socket
+  244. unique type io2.StdHandle
+  245. io2.StdHandle.StdErr : StdHandle
+  246. io2.StdHandle.StdIn : StdHandle
+  247. io2.StdHandle.StdOut : StdHandle
+  248. builtin type io2.STM
+  249. io2.STM.atomically : '{STM} a ->{IO} a
+  250. io2.STM.retry : '{STM} a
+  251. builtin type io2.ThreadId
+  252. builtin type io2.Tls
+  253. builtin type io2.Tls.Cipher
+  254. builtin type io2.Tls.ClientConfig
+  255. io2.Tls.ClientConfig.certificates.set : [SignedCert]
                                                -> ClientConfig
                                                -> ClientConfig
-  255. io2.TLS.ClientConfig.ciphers.set : [Cipher]
+  256. io2.TLS.ClientConfig.ciphers.set : [Cipher]
                                           -> ClientConfig
                                           -> ClientConfig
-  256. io2.Tls.ClientConfig.default : Text
+  257. io2.Tls.ClientConfig.default : Text
                                       -> Bytes
                                       -> ClientConfig
-  257. io2.Tls.ClientConfig.versions.set : [Version]
+  258. io2.Tls.ClientConfig.versions.set : [Version]
                                            -> ClientConfig
                                            -> ClientConfig
-  258. io2.Tls.decodeCert.impl : Bytes
+  259. io2.Tls.decodeCert.impl : Bytes
                                  -> Either Failure SignedCert
-  259. io2.Tls.decodePrivateKey : Bytes -> [PrivateKey]
-  260. io2.Tls.encodeCert : SignedCert -> Bytes
-  261. io2.Tls.encodePrivateKey : PrivateKey -> Bytes
-  262. io2.Tls.handshake.impl : Tls ->{IO} Either Failure ()
-  263. io2.Tls.newClient.impl : ClientConfig
+  260. io2.Tls.decodePrivateKey : Bytes -> [PrivateKey]
+  261. io2.Tls.encodeCert : SignedCert -> Bytes
+  262. io2.Tls.encodePrivateKey : PrivateKey -> Bytes
+  263. io2.Tls.handshake.impl : Tls ->{IO} Either Failure ()
+  264. io2.Tls.newClient.impl : ClientConfig
                                 -> Socket
                                 ->{IO} Either Failure Tls
-  264. io2.Tls.newServer.impl : ServerConfig
+  265. io2.Tls.newServer.impl : ServerConfig
                                 -> Socket
                                 ->{IO} Either Failure Tls
-  265. builtin type io2.Tls.PrivateKey
-  266. io2.Tls.receive.impl : Tls ->{IO} Either Failure Bytes
-  267. io2.Tls.send.impl : Tls -> Bytes ->{IO} Either Failure ()
-  268. builtin type io2.Tls.ServerConfig
-  269. io2.Tls.ServerConfig.certificates.set : [SignedCert]
+  266. builtin type io2.Tls.PrivateKey
+  267. io2.Tls.receive.impl : Tls ->{IO} Either Failure Bytes
+  268. io2.Tls.send.impl : Tls -> Bytes ->{IO} Either Failure ()
+  269. builtin type io2.Tls.ServerConfig
+  270. io2.Tls.ServerConfig.certificates.set : [SignedCert]
                                                -> ServerConfig
                                                -> ServerConfig
-  270. io2.Tls.ServerConfig.ciphers.set : [Cipher]
+  271. io2.Tls.ServerConfig.ciphers.set : [Cipher]
                                           -> ServerConfig
                                           -> ServerConfig
-  271. io2.Tls.ServerConfig.default : [SignedCert]
+  272. io2.Tls.ServerConfig.default : [SignedCert]
                                       -> PrivateKey
                                       -> ServerConfig
-  272. io2.Tls.ServerConfig.versions.set : [Version]
+  273. io2.Tls.ServerConfig.versions.set : [Version]
                                            -> ServerConfig
                                            -> ServerConfig
-  273. builtin type io2.Tls.SignedCert
-  274. io2.Tls.terminate.impl : Tls ->{IO} Either Failure ()
-  275. builtin type io2.Tls.Version
-  276. unique type io2.TlsFailure
-  277. builtin type io2.TVar
-  278. io2.TVar.new : a ->{STM} TVar a
-  279. io2.TVar.newIO : a ->{IO} TVar a
-  280. io2.TVar.read : TVar a ->{STM} a
-  281. io2.TVar.readIO : TVar a ->{IO} a
-  282. io2.TVar.swap : TVar a -> a ->{STM} a
-  283. io2.TVar.write : TVar a -> a ->{STM} ()
-  284. io2.validateSandboxed : [Term] -> a -> Boolean
-  285. unique type IsPropagated
-  286. IsPropagated.IsPropagated : IsPropagated
-  287. unique type IsTest
-  288. IsTest.IsTest : IsTest
-  289. unique type Link
-  290. builtin type Link.Term
-  291. Link.Term : Term -> Link
-  292. Link.Term.toText : Term -> Text
-  293. builtin type Link.Type
-  294. Link.Type : Type -> Link
-  295. builtin type List
-  296. List.++ : [a] -> [a] -> [a]
-  297. List.+: : a -> [a] -> [a]
-  298. List.:+ : [a] -> a -> [a]
-  299. List.at : Nat -> [a] -> Optional a
-  300. List.cons : a -> [a] -> [a]
-  301. List.drop : Nat -> [a] -> [a]
-  302. List.empty : [a]
-  303. List.size : [a] -> Nat
-  304. List.snoc : [a] -> a -> [a]
-  305. List.take : Nat -> [a] -> [a]
-  306. metadata.isPropagated : IsPropagated
-  307. metadata.isTest : IsTest
-  308. builtin type Nat
-  309. Nat.* : Nat -> Nat -> Nat
-  310. Nat.+ : Nat -> Nat -> Nat
-  311. Nat./ : Nat -> Nat -> Nat
-  312. Nat.and : Nat -> Nat -> Nat
-  313. Nat.complement : Nat -> Nat
-  314. Nat.drop : Nat -> Nat -> Nat
-  315. Nat.eq : Nat -> Nat -> Boolean
-  316. Nat.fromText : Text -> Optional Nat
-  317. Nat.gt : Nat -> Nat -> Boolean
-  318. Nat.gteq : Nat -> Nat -> Boolean
-  319. Nat.increment : Nat -> Nat
-  320. Nat.isEven : Nat -> Boolean
-  321. Nat.isOdd : Nat -> Boolean
-  322. Nat.leadingZeros : Nat -> Nat
-  323. Nat.lt : Nat -> Nat -> Boolean
-  324. Nat.lteq : Nat -> Nat -> Boolean
-  325. Nat.mod : Nat -> Nat -> Nat
-  326. Nat.or : Nat -> Nat -> Nat
-  327. Nat.popCount : Nat -> Nat
-  328. Nat.pow : Nat -> Nat -> Nat
-  329. Nat.shiftLeft : Nat -> Nat -> Nat
-  330. Nat.shiftRight : Nat -> Nat -> Nat
-  331. Nat.sub : Nat -> Nat -> Int
-  332. Nat.toFloat : Nat -> Float
-  333. Nat.toInt : Nat -> Int
-  334. Nat.toText : Nat -> Text
-  335. Nat.trailingZeros : Nat -> Nat
-  336. Nat.xor : Nat -> Nat -> Nat
-  337. structural type Optional a
-  338. Optional.None : Optional a
-  339. Optional.Some : a -> Optional a
-  340. builtin type Ref
-  341. Ref.read : Ref g a ->{g} a
-  342. Ref.write : Ref g a -> a ->{g} ()
-  343. builtin type Request
-  344. builtin type Scope
-  345. Scope.ref : a ->{Scope s} Ref {Scope s} a
-  346. Scope.run : (∀ s. '{g, Scope s} r) ->{g} r
-  347. structural type SeqView a b
-  348. SeqView.VElem : a -> b -> SeqView a b
-  349. SeqView.VEmpty : SeqView a b
-  350. Socket.toText : Socket -> Text
-  351. unique type Test.Result
-  352. Test.Result.Fail : Text -> Result
-  353. Test.Result.Ok : Text -> Result
-  354. builtin type Text
-  355. Text.!= : Text -> Text -> Boolean
-  356. Text.++ : Text -> Text -> Text
-  357. Text.drop : Nat -> Text -> Text
-  358. Text.empty : Text
-  359. Text.eq : Text -> Text -> Boolean
-  360. Text.fromCharList : [Char] -> Text
-  361. Text.fromUtf8.impl : Bytes -> Either Failure Text
-  362. Text.gt : Text -> Text -> Boolean
-  363. Text.gteq : Text -> Text -> Boolean
-  364. Text.lt : Text -> Text -> Boolean
-  365. Text.lteq : Text -> Text -> Boolean
-  366. Text.repeat : Nat -> Text -> Text
-  367. Text.size : Text -> Nat
-  368. Text.take : Nat -> Text -> Text
-  369. Text.toCharList : Text -> [Char]
-  370. Text.toUtf8 : Text -> Bytes
-  371. Text.uncons : Text -> Optional (Char, Text)
-  372. Text.unsnoc : Text -> Optional (Text, Char)
-  373. ThreadId.toText : ThreadId -> Text
-  374. todo : a -> b
-  375. structural type Tuple a b
-  376. Tuple.Cons : a -> b -> Tuple a b
-  377. structural type Unit
-  378. Unit.Unit : ()
-  379. Universal.< : a -> a -> Boolean
-  380. Universal.<= : a -> a -> Boolean
-  381. Universal.== : a -> a -> Boolean
-  382. Universal.> : a -> a -> Boolean
-  383. Universal.>= : a -> a -> Boolean
-  384. Universal.compare : a -> a -> Int
-  385. unsafe.coerceAbilities : (a ->{e1} b) -> a ->{e2} b
-  386. builtin type Value
-  387. Value.dependencies : Value -> [Term]
-  388. Value.deserialize : Bytes -> Either Text Value
-  389. Value.load : Value ->{IO} Either [Term] a
-  390. Value.serialize : Value -> Bytes
-  391. Value.value : a -> Value
+  274. builtin type io2.Tls.SignedCert
+  275. io2.Tls.terminate.impl : Tls ->{IO} Either Failure ()
+  276. builtin type io2.Tls.Version
+  277. unique type io2.TlsFailure
+  278. builtin type io2.TVar
+  279. io2.TVar.new : a ->{STM} TVar a
+  280. io2.TVar.newIO : a ->{IO} TVar a
+  281. io2.TVar.read : TVar a ->{STM} a
+  282. io2.TVar.readIO : TVar a ->{IO} a
+  283. io2.TVar.swap : TVar a -> a ->{STM} a
+  284. io2.TVar.write : TVar a -> a ->{STM} ()
+  285. io2.validateSandboxed : [Term] -> a -> Boolean
+  286. unique type IsPropagated
+  287. IsPropagated.IsPropagated : IsPropagated
+  288. unique type IsTest
+  289. IsTest.IsTest : IsTest
+  290. unique type Link
+  291. builtin type Link.Term
+  292. Link.Term : Term -> Link
+  293. Link.Term.toText : Term -> Text
+  294. builtin type Link.Type
+  295. Link.Type : Type -> Link
+  296. builtin type List
+  297. List.++ : [a] -> [a] -> [a]
+  298. List.+: : a -> [a] -> [a]
+  299. List.:+ : [a] -> a -> [a]
+  300. List.at : Nat -> [a] -> Optional a
+  301. List.cons : a -> [a] -> [a]
+  302. List.drop : Nat -> [a] -> [a]
+  303. List.empty : [a]
+  304. List.size : [a] -> Nat
+  305. List.snoc : [a] -> a -> [a]
+  306. List.take : Nat -> [a] -> [a]
+  307. metadata.isPropagated : IsPropagated
+  308. metadata.isTest : IsTest
+  309. builtin type Nat
+  310. Nat.* : Nat -> Nat -> Nat
+  311. Nat.+ : Nat -> Nat -> Nat
+  312. Nat./ : Nat -> Nat -> Nat
+  313. Nat.and : Nat -> Nat -> Nat
+  314. Nat.complement : Nat -> Nat
+  315. Nat.drop : Nat -> Nat -> Nat
+  316. Nat.eq : Nat -> Nat -> Boolean
+  317. Nat.fromText : Text -> Optional Nat
+  318. Nat.gt : Nat -> Nat -> Boolean
+  319. Nat.gteq : Nat -> Nat -> Boolean
+  320. Nat.increment : Nat -> Nat
+  321. Nat.isEven : Nat -> Boolean
+  322. Nat.isOdd : Nat -> Boolean
+  323. Nat.leadingZeros : Nat -> Nat
+  324. Nat.lt : Nat -> Nat -> Boolean
+  325. Nat.lteq : Nat -> Nat -> Boolean
+  326. Nat.mod : Nat -> Nat -> Nat
+  327. Nat.or : Nat -> Nat -> Nat
+  328. Nat.popCount : Nat -> Nat
+  329. Nat.pow : Nat -> Nat -> Nat
+  330. Nat.shiftLeft : Nat -> Nat -> Nat
+  331. Nat.shiftRight : Nat -> Nat -> Nat
+  332. Nat.sub : Nat -> Nat -> Int
+  333. Nat.toFloat : Nat -> Float
+  334. Nat.toInt : Nat -> Int
+  335. Nat.toText : Nat -> Text
+  336. Nat.trailingZeros : Nat -> Nat
+  337. Nat.xor : Nat -> Nat -> Nat
+  338. structural type Optional a
+  339. Optional.None : Optional a
+  340. Optional.Some : a -> Optional a
+  341. builtin type Ref
+  342. Ref.read : Ref g a ->{g} a
+  343. Ref.write : Ref g a -> a ->{g} ()
+  344. builtin type Request
+  345. builtin type Scope
+  346. Scope.ref : a ->{Scope s} Ref {Scope s} a
+  347. Scope.run : (∀ s. '{g, Scope s} r) ->{g} r
+  348. structural type SeqView a b
+  349. SeqView.VElem : a -> b -> SeqView a b
+  350. SeqView.VEmpty : SeqView a b
+  351. Socket.toText : Socket -> Text
+  352. unique type Test.Result
+  353. Test.Result.Fail : Text -> Result
+  354. Test.Result.Ok : Text -> Result
+  355. builtin type Text
+  356. Text.!= : Text -> Text -> Boolean
+  357. Text.++ : Text -> Text -> Text
+  358. Text.drop : Nat -> Text -> Text
+  359. Text.empty : Text
+  360. Text.eq : Text -> Text -> Boolean
+  361. Text.fromCharList : [Char] -> Text
+  362. Text.fromUtf8.impl : Bytes -> Either Failure Text
+  363. Text.gt : Text -> Text -> Boolean
+  364. Text.gteq : Text -> Text -> Boolean
+  365. Text.lt : Text -> Text -> Boolean
+  366. Text.lteq : Text -> Text -> Boolean
+  367. Text.repeat : Nat -> Text -> Text
+  368. Text.size : Text -> Nat
+  369. Text.take : Nat -> Text -> Text
+  370. Text.toCharList : Text -> [Char]
+  371. Text.toUtf8 : Text -> Bytes
+  372. Text.uncons : Text -> Optional (Char, Text)
+  373. Text.unsnoc : Text -> Optional (Text, Char)
+  374. ThreadId.toText : ThreadId -> Text
+  375. todo : a -> b
+  376. structural type Tuple a b
+  377. Tuple.Cons : a -> b -> Tuple a b
+  378. structural type Unit
+  379. Unit.Unit : ()
+  380. Universal.< : a -> a -> Boolean
+  381. Universal.<= : a -> a -> Boolean
+  382. Universal.== : a -> a -> Boolean
+  383. Universal.> : a -> a -> Boolean
+  384. Universal.>= : a -> a -> Boolean
+  385. Universal.compare : a -> a -> Int
+  386. unsafe.coerceAbilities : (a ->{e1} b) -> a ->{e2} b
+  387. builtin type Value
+  388. Value.dependencies : Value -> [Term]
+  389. Value.deserialize : Bytes -> Either Text Value
+  390. Value.load : Value ->{IO} Either [Term] a
+  391. Value.serialize : Value -> Bytes
+  392. Value.value : a -> Value
   
 
 .builtin> alias.many 94-104 .mylib
@@ -493,17 +494,17 @@ Let's try it!
   
   Added definitions:
   
-    1.  Float.cos                : Float -> Float
-    2.  Float.cosh               : Float -> Float
-    3.  Float.eq                 : Float -> Float -> Boolean
-    4.  Float.exp                : Float -> Float
-    5.  Float.floor              : Float -> Int
-    6.  Float.fromRepresentation : Nat -> Float
-    7.  Float.fromText           : Text -> Optional Float
-    8.  Float.gt                 : Float -> Float -> Boolean
-    9.  Float.gteq               : Float -> Float -> Boolean
-    10. Float.log                : Float -> Float
-    11. Float.logBase            : Float -> Float -> Float
+    1.  Float.ceiling            : Float -> Int
+    2.  Float.cos                : Float -> Float
+    3.  Float.cosh               : Float -> Float
+    4.  Float.eq                 : Float -> Float -> Boolean
+    5.  Float.exp                : Float -> Float
+    6.  Float.floor              : Float -> Int
+    7.  Float.fromRepresentation : Nat -> Float
+    8.  Float.fromText           : Text -> Optional Float
+    9.  Float.gt                 : Float -> Float -> Boolean
+    10. Float.gteq               : Float -> Float -> Boolean
+    11. Float.log                : Float -> Float
   
   Tip: You can use `undo` or `reflog` to undo this change.
 
@@ -563,17 +564,17 @@ I want to incorporate a few more from another namespace:
 
 .mylib> find
 
-  1.  Float.cos : Float -> Float
-  2.  Float.cosh : Float -> Float
-  3.  Float.eq : Float -> Float -> Boolean
-  4.  Float.exp : Float -> Float
-  5.  Float.floor : Float -> Int
-  6.  Float.fromRepresentation : Nat -> Float
-  7.  Float.fromText : Text -> Optional Float
-  8.  Float.gt : Float -> Float -> Boolean
-  9.  Float.gteq : Float -> Float -> Boolean
-  10. Float.log : Float -> Float
-  11. Float.logBase : Float -> Float -> Float
+  1.  Float.ceiling : Float -> Int
+  2.  Float.cos : Float -> Float
+  3.  Float.cosh : Float -> Float
+  4.  Float.eq : Float -> Float -> Boolean
+  5.  Float.exp : Float -> Float
+  6.  Float.floor : Float -> Int
+  7.  Float.fromRepresentation : Nat -> Float
+  8.  Float.fromText : Text -> Optional Float
+  9.  Float.gt : Float -> Float -> Boolean
+  10. Float.gteq : Float -> Float -> Boolean
+  11. Float.log : Float -> Float
   12. List.adjacentPairs : [a] -> [(a, a)]
   13. List.all : (a ->{g} Boolean) -> [a] ->{g} Boolean
   14. List.any : (a ->{g} Boolean) -> [a] ->{g} Boolean

--- a/unison-src/transcripts/builtins-merge.output.md
+++ b/unison-src/transcripts/builtins-merge.output.md
@@ -63,7 +63,7 @@ The `builtins.merge` command adds the known builtins to a `builtin` subnamespace
   52. Value         (builtin type)
   53. Value/        (5 definitions)
   54. bug           (a -> b)
-  55. crypto/       (12 definitions)
+  55. crypto/       (13 definitions)
   56. io2/          (133 definitions)
   57. metadata/     (2 definitions)
   58. todo          (a -> b)

--- a/unison-src/transcripts/emptyCodebase.output.md
+++ b/unison-src/transcripts/emptyCodebase.output.md
@@ -23,7 +23,7 @@ Technically, the definitions all exist, but they have no names. `builtins.merge`
 
 .foo> ls
 
-  1. builtin/ (391 definitions)
+  1. builtin/ (392 definitions)
 
 ```
 And for a limited time, you can get even more builtin goodies:
@@ -35,7 +35,7 @@ And for a limited time, you can get even more builtin goodies:
 
 .foo> ls
 
-  1. builtin/ (577 definitions)
+  1. builtin/ (578 definitions)
 
 ```
 More typically, you'd start out by pulling `base.

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -121,13 +121,13 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #1q6g6u3m73
+  ⊙ 1. #0mhdtddb80
   
     - Deletes:
     
       feature1.y
   
-  ⊙ 2. #9e4kqo72l2
+  ⊙ 2. #leu63g3bpn
   
     + Adds / updates:
     
@@ -138,26 +138,26 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
       Original name New name(s)
       feature1.y    master.y
   
-  ⊙ 3. #n59irrs1fe
+  ⊙ 3. #qsefehkn4s
   
     + Adds / updates:
     
       feature1.y
   
-  ⊙ 4. #7qstntsn5f
+  ⊙ 4. #5vssi6fg86
   
     > Moves:
     
       Original name New name
       x             master.x
   
-  ⊙ 5. #4360t4806a
+  ⊙ 5. #g3lmsiv8ui
   
     + Adds / updates:
     
       x
   
-  □ 6. #n38tt1aodo (start of history)
+  □ 6. #jnr0fqsfop (start of history)
 
 ```
 To resurrect an old version of a namespace, you can learn its hash via the `history` command, then use `fork #namespacehash .newname`.

--- a/unison-src/transcripts/name-selection.output.md
+++ b/unison-src/transcripts/name-selection.output.md
@@ -293,786 +293,787 @@ d = c + 10
     127. builtin.crypto.HashAlgorithm.Blake2b_256      : HashAlgorithm
     128. builtin.crypto.HashAlgorithm.Blake2b_512      : HashAlgorithm
     129. builtin.crypto.HashAlgorithm.Blake2s_256      : HashAlgorithm
-    130. builtin.crypto.HashAlgorithm.Sha2_256         : HashAlgorithm
-    131. builtin.crypto.HashAlgorithm.Sha2_512         : HashAlgorithm
-    132. builtin.crypto.HashAlgorithm.Sha3_256         : HashAlgorithm
-    133. builtin.crypto.HashAlgorithm.Sha3_512         : HashAlgorithm
-    134. builtin.Float.abs                             : Float
+    130. builtin.crypto.HashAlgorithm.Sha1             : HashAlgorithm
+    131. builtin.crypto.HashAlgorithm.Sha2_256         : HashAlgorithm
+    132. builtin.crypto.HashAlgorithm.Sha2_512         : HashAlgorithm
+    133. builtin.crypto.HashAlgorithm.Sha3_256         : HashAlgorithm
+    134. builtin.crypto.HashAlgorithm.Sha3_512         : HashAlgorithm
+    135. builtin.Float.abs                             : Float
                                                        -> Float
-    135. builtin.Float.acos                            : Float
+    136. builtin.Float.acos                            : Float
                                                        -> Float
-    136. builtin.Float.acosh                           : Float
+    137. builtin.Float.acosh                           : Float
                                                        -> Float
-    137. builtin.Int.and                               : Int
+    138. builtin.Int.and                               : Int
                                                        -> Int
                                                        -> Int
-    138. builtin.Nat.and                               : Nat
+    139. builtin.Nat.and                               : Nat
                                                        -> Nat
                                                        -> Nat
-    139. builtin.Float.asin                            : Float
+    140. builtin.Float.asin                            : Float
                                                        -> Float
-    140. builtin.Float.asinh                           : Float
+    141. builtin.Float.asinh                           : Float
                                                        -> Float
-    141. builtin.Bytes.at                              : Nat
+    142. builtin.Bytes.at                              : Nat
                                                        -> Bytes
                                                        -> Optional
                                                          Nat
-    142. builtin.List.at                               : Nat
+    143. builtin.List.at                               : Nat
                                                        -> [a]
                                                        -> Optional
                                                          a
-    143. builtin.Float.atan                            : Float
+    144. builtin.Float.atan                            : Float
                                                        -> Float
-    144. builtin.Float.atan2                           : Float
+    145. builtin.Float.atan2                           : Float
                                                        -> Float
                                                        -> Float
-    145. builtin.Float.atanh                           : Float
+    146. builtin.Float.atanh                           : Float
                                                        -> Float
-    146. builtin.io2.STM.atomically                    : '{STM} a
+    147. builtin.io2.STM.atomically                    : '{STM} a
                                                        ->{IO} a
-    147. builtin.bug                                   : a -> b
-    148. ┌ c#gjmq673r1v                                : Nat
-    149. └ aaaa.tooManySegments                        : Nat
-    150. builtin.Code.cache_                           : [( Term,
+    148. builtin.bug                                   : a -> b
+    149. ┌ c#gjmq673r1v                                : Nat
+    150. └ aaaa.tooManySegments                        : Nat
+    151. builtin.Code.cache_                           : [( Term,
                                                          Code)]
                                                        ->{IO} [Term]
-    151. builtin.Float.ceiling                         : Float
+    152. builtin.Float.ceiling                         : Float
                                                        -> Int
-    152. builtin.unsafe.coerceAbilities                : (a
+    153. builtin.unsafe.coerceAbilities                : (a
                                                        ->{e1} b)
                                                        -> a
                                                        ->{e2} b
-    153. builtin.Universal.compare                     : a
+    154. builtin.Universal.compare                     : a
                                                        -> a
                                                        -> Int
-    154. builtin.Int.complement                        : Int
+    155. builtin.Int.complement                        : Int
                                                        -> Int
-    155. builtin.Nat.complement                        : Nat
+    156. builtin.Nat.complement                        : Nat
                                                        -> Nat
-    156. builtin.Bytes.gzip.compress                   : Bytes
+    157. builtin.Bytes.gzip.compress                   : Bytes
                                                        -> Bytes
-    157. builtin.Bytes.zlib.compress                   : Bytes
+    158. builtin.Bytes.zlib.compress                   : Bytes
                                                        -> Bytes
-    158. builtin.Float.cos                             : Float
+    159. builtin.Float.cos                             : Float
                                                        -> Float
-    159. builtin.Float.cosh                            : Float
+    160. builtin.Float.cosh                            : Float
                                                        -> Float
-    160. builtin.Bytes.decodeNat16be                   : Bytes
+    161. builtin.Bytes.decodeNat16be                   : Bytes
                                                        -> Optional
                                                          ( Nat,
                                                            Bytes)
-    161. builtin.Bytes.decodeNat16le                   : Bytes
+    162. builtin.Bytes.decodeNat16le                   : Bytes
                                                        -> Optional
                                                          ( Nat,
                                                            Bytes)
-    162. builtin.Bytes.decodeNat32be                   : Bytes
+    163. builtin.Bytes.decodeNat32be                   : Bytes
                                                        -> Optional
                                                          ( Nat,
                                                            Bytes)
-    163. builtin.Bytes.decodeNat32le                   : Bytes
+    164. builtin.Bytes.decodeNat32le                   : Bytes
                                                        -> Optional
                                                          ( Nat,
                                                            Bytes)
-    164. builtin.Bytes.decodeNat64be                   : Bytes
+    165. builtin.Bytes.decodeNat64be                   : Bytes
                                                        -> Optional
                                                          ( Nat,
                                                            Bytes)
-    165. builtin.Bytes.decodeNat64le                   : Bytes
+    166. builtin.Bytes.decodeNat64le                   : Bytes
                                                        -> Optional
                                                          ( Nat,
                                                            Bytes)
-    166. builtin.io2.Tls.decodePrivateKey              : Bytes
+    167. builtin.io2.Tls.decodePrivateKey              : Bytes
                                                        -> [PrivateKey]
-    167. builtin.Bytes.gzip.decompress                 : Bytes
+    168. builtin.Bytes.gzip.decompress                 : Bytes
                                                        -> Either
                                                          Text
                                                          Bytes
-    168. builtin.Bytes.zlib.decompress                 : Bytes
+    169. builtin.Bytes.zlib.decompress                 : Bytes
                                                        -> Either
                                                          Text
                                                          Bytes
-    169. builtin.io2.Tls.ClientConfig.default          : Text
+    170. builtin.io2.Tls.ClientConfig.default          : Text
                                                        -> Bytes
                                                        -> ClientConfig
-    170. builtin.io2.Tls.ServerConfig.default          : [SignedCert]
+    171. builtin.io2.Tls.ServerConfig.default          : [SignedCert]
                                                        -> PrivateKey
                                                        -> ServerConfig
-    171. builtin.Code.dependencies                     : Code
+    172. builtin.Code.dependencies                     : Code
                                                        -> [Term]
-    172. builtin.Value.dependencies                    : Value
+    173. builtin.Value.dependencies                    : Value
                                                        -> [Term]
-    173. builtin.Code.deserialize                      : Bytes
+    174. builtin.Code.deserialize                      : Bytes
                                                        -> Either
                                                          Text
                                                          Code
-    174. builtin.Value.deserialize                     : Bytes
+    175. builtin.Value.deserialize                     : Bytes
                                                        -> Either
                                                          Text
                                                          Value
-    175. builtin.Code.display                          : Text
+    176. builtin.Code.display                          : Text
                                                        -> Code
                                                        -> Text
-    176. builtin.Bytes.drop                            : Nat
+    177. builtin.Bytes.drop                            : Nat
                                                        -> Bytes
                                                        -> Bytes
-    177. builtin.List.drop                             : Nat
+    178. builtin.List.drop                             : Nat
                                                        -> [a]
                                                        -> [a]
-    178. builtin.Nat.drop                              : Nat
+    179. builtin.Nat.drop                              : Nat
                                                        -> Nat
                                                        -> Nat
-    179. builtin.Text.drop                             : Nat
+    180. builtin.Text.drop                             : Nat
                                                        -> Text
                                                        -> Text
-    180. builtin.Bytes.empty                           : Bytes
-    181. builtin.List.empty                            : [a]
-    182. builtin.Text.empty                            : Text
-    183. builtin.io2.Tls.encodeCert                    : SignedCert
+    181. builtin.Bytes.empty                           : Bytes
+    182. builtin.List.empty                            : [a]
+    183. builtin.Text.empty                            : Text
+    184. builtin.io2.Tls.encodeCert                    : SignedCert
                                                        -> Bytes
-    184. builtin.Bytes.encodeNat16be                   : Nat
+    185. builtin.Bytes.encodeNat16be                   : Nat
                                                        -> Bytes
-    185. builtin.Bytes.encodeNat16le                   : Nat
+    186. builtin.Bytes.encodeNat16le                   : Nat
                                                        -> Bytes
-    186. builtin.Bytes.encodeNat32be                   : Nat
+    187. builtin.Bytes.encodeNat32be                   : Nat
                                                        -> Bytes
-    187. builtin.Bytes.encodeNat32le                   : Nat
+    188. builtin.Bytes.encodeNat32le                   : Nat
                                                        -> Bytes
-    188. builtin.Bytes.encodeNat64be                   : Nat
+    189. builtin.Bytes.encodeNat64be                   : Nat
                                                        -> Bytes
-    189. builtin.Bytes.encodeNat64le                   : Nat
+    190. builtin.Bytes.encodeNat64le                   : Nat
                                                        -> Bytes
-    190. builtin.io2.Tls.encodePrivateKey              : PrivateKey
+    191. builtin.io2.Tls.encodePrivateKey              : PrivateKey
                                                        -> Bytes
-    191. builtin.Float.eq                              : Float
+    192. builtin.Float.eq                              : Float
                                                        -> Float
                                                        -> Boolean
-    192. builtin.Int.eq                                : Int
+    193. builtin.Int.eq                                : Int
                                                        -> Int
                                                        -> Boolean
-    193. builtin.Nat.eq                                : Nat
+    194. builtin.Nat.eq                                : Nat
                                                        -> Nat
                                                        -> Boolean
-    194. builtin.Text.eq                               : Text
+    195. builtin.Text.eq                               : Text
                                                        -> Text
                                                        -> Boolean
-    195. builtin.Float.exp                             : Float
+    196. builtin.Float.exp                             : Float
                                                        -> Float
-    196. builtin.Bytes.flatten                         : Bytes
+    197. builtin.Bytes.flatten                         : Bytes
                                                        -> Bytes
-    197. builtin.Float.floor                           : Float
+    198. builtin.Float.floor                           : Float
                                                        -> Int
-    198. builtin.io2.IO.forkComp                       : '{IO} a
+    199. builtin.io2.IO.forkComp                       : '{IO} a
                                                        ->{IO} ThreadId
-    199. builtin.Bytes.fromBase16                      : Bytes
+    200. builtin.Bytes.fromBase16                      : Bytes
                                                        -> Either
                                                          Text
                                                          Bytes
-    200. builtin.Bytes.fromBase32                      : Bytes
+    201. builtin.Bytes.fromBase32                      : Bytes
                                                        -> Either
                                                          Text
                                                          Bytes
-    201. builtin.Bytes.fromBase64                      : Bytes
+    202. builtin.Bytes.fromBase64                      : Bytes
                                                        -> Either
                                                          Text
                                                          Bytes
-    202. builtin.Bytes.fromBase64UrlUnpadded           : Bytes
+    203. builtin.Bytes.fromBase64UrlUnpadded           : Bytes
                                                        -> Either
                                                          Text
                                                          Bytes
-    203. builtin.Text.fromCharList                     : [Char]
+    204. builtin.Text.fromCharList                     : [Char]
                                                        -> Text
-    204. builtin.Bytes.fromList                        : [Nat]
+    205. builtin.Bytes.fromList                        : [Nat]
                                                        -> Bytes
-    205. builtin.Char.fromNat                          : Nat
+    206. builtin.Char.fromNat                          : Nat
                                                        -> Char
-    206. builtin.Float.fromRepresentation              : Nat
+    207. builtin.Float.fromRepresentation              : Nat
                                                        -> Float
-    207. builtin.Int.fromRepresentation                : Nat
+    208. builtin.Int.fromRepresentation                : Nat
                                                        -> Int
-    208. builtin.Float.fromText                        : Text
+    209. builtin.Float.fromText                        : Text
                                                        -> Optional
                                                          Float
-    209. builtin.Int.fromText                          : Text
+    210. builtin.Int.fromText                          : Text
                                                        -> Optional
                                                          Int
-    210. builtin.Nat.fromText                          : Text
+    211. builtin.Nat.fromText                          : Text
                                                        -> Optional
                                                          Nat
-    211. builtin.Float.gt                              : Float
+    212. builtin.Float.gt                              : Float
                                                        -> Float
                                                        -> Boolean
-    212. builtin.Int.gt                                : Int
+    213. builtin.Int.gt                                : Int
                                                        -> Int
                                                        -> Boolean
-    213. builtin.Nat.gt                                : Nat
+    214. builtin.Nat.gt                                : Nat
                                                        -> Nat
                                                        -> Boolean
-    214. builtin.Text.gt                               : Text
+    215. builtin.Text.gt                               : Text
                                                        -> Text
                                                        -> Boolean
-    215. builtin.Float.gteq                            : Float
+    216. builtin.Float.gteq                            : Float
                                                        -> Float
                                                        -> Boolean
-    216. builtin.Int.gteq                              : Int
+    217. builtin.Int.gteq                              : Int
                                                        -> Int
                                                        -> Boolean
-    217. builtin.Nat.gteq                              : Nat
+    218. builtin.Nat.gteq                              : Nat
                                                        -> Nat
                                                        -> Boolean
-    218. builtin.Text.gteq                             : Text
+    219. builtin.Text.gteq                             : Text
                                                        -> Text
                                                        -> Boolean
-    219. builtin.crypto.hash                           : HashAlgorithm
+    220. builtin.crypto.hash                           : HashAlgorithm
                                                        -> a
                                                        -> Bytes
-    220. builtin.crypto.hashBytes                      : HashAlgorithm
+    221. builtin.crypto.hashBytes                      : HashAlgorithm
                                                        -> Bytes
                                                        -> Bytes
-    221. builtin.crypto.hmac                           : HashAlgorithm
+    222. builtin.crypto.hmac                           : HashAlgorithm
                                                        -> Bytes
                                                        -> a
                                                        -> Bytes
-    222. builtin.crypto.hmacBytes                      : HashAlgorithm
+    223. builtin.crypto.hmacBytes                      : HashAlgorithm
                                                        -> Bytes
                                                        -> Bytes
                                                        -> Bytes
-    223. builtin.io2.IO.clientSocket.impl              : Text
+    224. builtin.io2.IO.clientSocket.impl              : Text
                                                        -> Text
                                                        ->{IO} Either
                                                          Failure
                                                          Socket
-    224. builtin.io2.IO.closeFile.impl                 : Handle
+    225. builtin.io2.IO.closeFile.impl                 : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    225. builtin.io2.IO.closeSocket.impl               : Socket
+    226. builtin.io2.IO.closeSocket.impl               : Socket
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    226. builtin.io2.IO.createDirectory.impl           : Text
+    227. builtin.io2.IO.createDirectory.impl           : Text
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    227. builtin.io2.IO.createTempDirectory.impl       : Text
+    228. builtin.io2.IO.createTempDirectory.impl       : Text
                                                        ->{IO} Either
                                                          Failure
                                                          Text
-    228. builtin.io2.Tls.decodeCert.impl               : Bytes
+    229. builtin.io2.Tls.decodeCert.impl               : Bytes
                                                        -> Either
                                                          Failure
                                                          SignedCert
-    229. builtin.io2.IO.delay.impl                     : Nat
+    230. builtin.io2.IO.delay.impl                     : Nat
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    230. builtin.io2.IO.directoryContents.impl         : Text
+    231. builtin.io2.IO.directoryContents.impl         : Text
                                                        ->{IO} Either
                                                          Failure
                                                          [Text]
-    231. builtin.io2.IO.fileExists.impl                : Text
+    232. builtin.io2.IO.fileExists.impl                : Text
                                                        ->{IO} Either
                                                          Failure
                                                          Boolean
-    232. builtin.Text.fromUtf8.impl                    : Bytes
+    233. builtin.Text.fromUtf8.impl                    : Bytes
                                                        -> Either
                                                          Failure
                                                          Text
-    233. builtin.io2.IO.getArgs.impl                   : '{IO} Either
+    234. builtin.io2.IO.getArgs.impl                   : '{IO} Either
                                                          Failure
                                                          [Text]
-    234. builtin.io2.IO.getBuffering.impl              : Handle
+    235. builtin.io2.IO.getBuffering.impl              : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          BufferMode
-    235. builtin.io2.IO.getBytes.impl                  : Handle
+    236. builtin.io2.IO.getBytes.impl                  : Handle
                                                        -> Nat
                                                        ->{IO} Either
                                                          Failure
                                                          Bytes
-    236. builtin.io2.IO.getCurrentDirectory.impl       : '{IO} Either
+    237. builtin.io2.IO.getCurrentDirectory.impl       : '{IO} Either
                                                          Failure
                                                          Text
-    237. builtin.io2.IO.getEnv.impl                    : Text
+    238. builtin.io2.IO.getEnv.impl                    : Text
                                                        ->{IO} Either
                                                          Failure
                                                          Text
-    238. builtin.io2.IO.getFileSize.impl               : Text
+    239. builtin.io2.IO.getFileSize.impl               : Text
                                                        ->{IO} Either
                                                          Failure
                                                          Nat
-    239. builtin.io2.IO.getFileTimestamp.impl          : Text
+    240. builtin.io2.IO.getFileTimestamp.impl          : Text
                                                        ->{IO} Either
                                                          Failure
                                                          Nat
-    240. builtin.io2.IO.getLine.impl                   : Handle
+    241. builtin.io2.IO.getLine.impl                   : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          Text
-    241. builtin.io2.IO.getSomeBytes.impl              : Handle
+    242. builtin.io2.IO.getSomeBytes.impl              : Handle
                                                        -> Nat
                                                        ->{IO} Either
                                                          Failure
                                                          Bytes
-    242. builtin.io2.IO.getTempDirectory.impl          : '{IO} Either
+    243. builtin.io2.IO.getTempDirectory.impl          : '{IO} Either
                                                          Failure
                                                          Text
-    243. builtin.io2.IO.handlePosition.impl            : Handle
+    244. builtin.io2.IO.handlePosition.impl            : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          Nat
-    244. builtin.io2.Tls.handshake.impl                : Tls
+    245. builtin.io2.Tls.handshake.impl                : Tls
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    245. builtin.io2.IO.isDirectory.impl               : Text
+    246. builtin.io2.IO.isDirectory.impl               : Text
                                                        ->{IO} Either
                                                          Failure
                                                          Boolean
-    246. builtin.io2.IO.isFileEOF.impl                 : Handle
+    247. builtin.io2.IO.isFileEOF.impl                 : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          Boolean
-    247. builtin.io2.IO.isFileOpen.impl                : Handle
+    248. builtin.io2.IO.isFileOpen.impl                : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          Boolean
-    248. builtin.io2.IO.isSeekable.impl                : Handle
+    249. builtin.io2.IO.isSeekable.impl                : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          Boolean
-    249. builtin.io2.IO.kill.impl                      : ThreadId
+    250. builtin.io2.IO.kill.impl                      : ThreadId
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    250. builtin.io2.IO.listen.impl                    : Socket
+    251. builtin.io2.IO.listen.impl                    : Socket
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    251. builtin.io2.Tls.newClient.impl                : ClientConfig
+    252. builtin.io2.Tls.newClient.impl                : ClientConfig
                                                        -> Socket
                                                        ->{IO} Either
                                                          Failure
                                                          Tls
-    252. builtin.io2.Tls.newServer.impl                : ServerConfig
+    253. builtin.io2.Tls.newServer.impl                : ServerConfig
                                                        -> Socket
                                                        ->{IO} Either
                                                          Failure
                                                          Tls
-    253. builtin.io2.IO.openFile.impl                  : Text
+    254. builtin.io2.IO.openFile.impl                  : Text
                                                        -> FileMode
                                                        ->{IO} Either
                                                          Failure
                                                          Handle
-    254. builtin.io2.MVar.put.impl                     : MVar a
+    255. builtin.io2.MVar.put.impl                     : MVar a
                                                        -> a
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    255. builtin.io2.IO.putBytes.impl                  : Handle
+    256. builtin.io2.IO.putBytes.impl                  : Handle
                                                        -> Bytes
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    256. builtin.io2.MVar.read.impl                    : MVar a
+    257. builtin.io2.MVar.read.impl                    : MVar a
                                                        ->{IO} Either
                                                          Failure
                                                          a
-    257. builtin.io2.Tls.receive.impl                  : Tls
+    258. builtin.io2.Tls.receive.impl                  : Tls
                                                        ->{IO} Either
                                                          Failure
                                                          Bytes
-    258. builtin.io2.IO.removeDirectory.impl           : Text
+    259. builtin.io2.IO.removeDirectory.impl           : Text
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    259. builtin.io2.IO.removeFile.impl                : Text
+    260. builtin.io2.IO.removeFile.impl                : Text
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    260. builtin.io2.IO.renameDirectory.impl           : Text
+    261. builtin.io2.IO.renameDirectory.impl           : Text
                                                        -> Text
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    261. builtin.io2.IO.renameFile.impl                : Text
+    262. builtin.io2.IO.renameFile.impl                : Text
                                                        -> Text
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    262. builtin.io2.IO.seekHandle.impl                : Handle
+    263. builtin.io2.IO.seekHandle.impl                : Handle
                                                        -> SeekMode
                                                        -> Int
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    263. builtin.io2.Tls.send.impl                     : Tls
+    264. builtin.io2.Tls.send.impl                     : Tls
                                                        -> Bytes
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    264. builtin.io2.IO.serverSocket.impl              : Optional
+    265. builtin.io2.IO.serverSocket.impl              : Optional
                                                          Text
                                                        -> Text
                                                        ->{IO} Either
                                                          Failure
                                                          Socket
-    265. builtin.io2.IO.setBuffering.impl              : Handle
+    266. builtin.io2.IO.setBuffering.impl              : Handle
                                                        -> BufferMode
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    266. builtin.io2.IO.setCurrentDirectory.impl       : Text
+    267. builtin.io2.IO.setCurrentDirectory.impl       : Text
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    267. builtin.io2.IO.socketAccept.impl              : Socket
+    268. builtin.io2.IO.socketAccept.impl              : Socket
                                                        ->{IO} Either
                                                          Failure
                                                          Socket
-    268. builtin.io2.IO.socketPort.impl                : Socket
+    269. builtin.io2.IO.socketPort.impl                : Socket
                                                        ->{IO} Either
                                                          Failure
                                                          Nat
-    269. builtin.io2.IO.socketReceive.impl             : Socket
+    270. builtin.io2.IO.socketReceive.impl             : Socket
                                                        -> Nat
                                                        ->{IO} Either
                                                          Failure
                                                          Bytes
-    270. builtin.io2.IO.socketSend.impl                : Socket
+    271. builtin.io2.IO.socketSend.impl                : Socket
                                                        -> Bytes
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    271. builtin.io2.MVar.swap.impl                    : MVar a
+    272. builtin.io2.MVar.swap.impl                    : MVar a
                                                        -> a
                                                        ->{IO} Either
                                                          Failure
                                                          a
-    272. builtin.io2.IO.systemTime.impl                : '{IO} Either
+    273. builtin.io2.IO.systemTime.impl                : '{IO} Either
                                                          Failure
                                                          Nat
-    273. builtin.io2.MVar.take.impl                    : MVar a
+    274. builtin.io2.MVar.take.impl                    : MVar a
                                                        ->{IO} Either
                                                          Failure
                                                          a
-    274. builtin.io2.Tls.terminate.impl                : Tls
+    275. builtin.io2.Tls.terminate.impl                : Tls
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    275. builtin.io2.MVar.tryPut.impl                  : MVar a
+    276. builtin.io2.MVar.tryPut.impl                  : MVar a
                                                        -> a
                                                        ->{IO} Either
                                                          Failure
                                                          Boolean
-    276. builtin.io2.MVar.tryRead.impl                 : MVar a
+    277. builtin.io2.MVar.tryRead.impl                 : MVar a
                                                        ->{IO} Either
                                                          Failure
                                                          (Optional
                                                            a)
-    277. builtin.Int.increment                         : Int
+    278. builtin.Int.increment                         : Int
                                                        -> Int
-    278. builtin.Nat.increment                         : Nat
+    279. builtin.Nat.increment                         : Nat
                                                        -> Nat
-    279. builtin.io2.MVar.isEmpty                      : MVar a
+    280. builtin.io2.MVar.isEmpty                      : MVar a
                                                        ->{IO} Boolean
-    280. builtin.Int.isEven                            : Int
+    281. builtin.Int.isEven                            : Int
                                                        -> Boolean
-    281. builtin.Nat.isEven                            : Nat
+    282. builtin.Nat.isEven                            : Nat
                                                        -> Boolean
-    282. builtin.Code.isMissing                        : Term
+    283. builtin.Code.isMissing                        : Term
                                                        ->{IO} Boolean
-    283. builtin.Int.isOdd                             : Int
+    284. builtin.Int.isOdd                             : Int
                                                        -> Boolean
-    284. builtin.Nat.isOdd                             : Nat
+    285. builtin.Nat.isOdd                             : Nat
                                                        -> Boolean
-    285. builtin.metadata.isPropagated                 : IsPropagated
-    286. builtin.metadata.isTest                       : IsTest
-    287. builtin.Int.leadingZeros                      : Int
+    286. builtin.metadata.isPropagated                 : IsPropagated
+    287. builtin.metadata.isTest                       : IsTest
+    288. builtin.Int.leadingZeros                      : Int
                                                        -> Nat
-    288. builtin.Nat.leadingZeros                      : Nat
+    289. builtin.Nat.leadingZeros                      : Nat
                                                        -> Nat
-    289. builtin.Value.load                            : Value
+    290. builtin.Value.load                            : Value
                                                        ->{IO} Either
                                                          [Term]
                                                          a
-    290. builtin.Float.log                             : Float
+    291. builtin.Float.log                             : Float
                                                        -> Float
-    291. builtin.Float.logBase                         : Float
+    292. builtin.Float.logBase                         : Float
                                                        -> Float
                                                        -> Float
-    292. builtin.Code.lookup                           : Term
+    293. builtin.Code.lookup                           : Term
                                                        ->{IO} Optional
                                                          Code
-    293. builtin.Float.lt                              : Float
+    294. builtin.Float.lt                              : Float
                                                        -> Float
                                                        -> Boolean
-    294. builtin.Int.lt                                : Int
+    295. builtin.Int.lt                                : Int
                                                        -> Int
                                                        -> Boolean
-    295. builtin.Nat.lt                                : Nat
+    296. builtin.Nat.lt                                : Nat
                                                        -> Nat
                                                        -> Boolean
-    296. builtin.Text.lt                               : Text
+    297. builtin.Text.lt                               : Text
                                                        -> Text
                                                        -> Boolean
-    297. builtin.Float.lteq                            : Float
+    298. builtin.Float.lteq                            : Float
                                                        -> Float
                                                        -> Boolean
-    298. builtin.Int.lteq                              : Int
+    299. builtin.Int.lteq                              : Int
                                                        -> Int
                                                        -> Boolean
-    299. builtin.Nat.lteq                              : Nat
+    300. builtin.Nat.lteq                              : Nat
                                                        -> Nat
                                                        -> Boolean
-    300. builtin.Text.lteq                             : Text
+    301. builtin.Text.lteq                             : Text
                                                        -> Text
                                                        -> Boolean
-    301. builtin.Float.max                             : Float
+    302. builtin.Float.max                             : Float
                                                        -> Float
                                                        -> Float
-    302. builtin.Float.min                             : Float
+    303. builtin.Float.min                             : Float
                                                        -> Float
                                                        -> Float
-    303. builtin.Int.mod                               : Int
+    304. builtin.Int.mod                               : Int
                                                        -> Int
                                                        -> Int
-    304. builtin.Nat.mod                               : Nat
+    305. builtin.Nat.mod                               : Nat
                                                        -> Nat
                                                        -> Nat
-    305. builtin.io2.Clock.internals.monotonic         : '{IO} Either
+    306. builtin.io2.Clock.internals.monotonic         : '{IO} Either
                                                          Failure
                                                          TimeSpec
-    306. builtin.Int.negate                            : Int
+    307. builtin.Int.negate                            : Int
                                                        -> Int
-    307. builtin.io2.MVar.new                          : a
+    308. builtin.io2.MVar.new                          : a
                                                        ->{IO} MVar
                                                          a
-    308. builtin.io2.TVar.new                          : a
+    309. builtin.io2.TVar.new                          : a
                                                        ->{STM} TVar
                                                          a
-    309. builtin.io2.MVar.newEmpty                     : '{IO} MVar
+    310. builtin.io2.MVar.newEmpty                     : '{IO} MVar
                                                          a
-    310. builtin.io2.TVar.newIO                        : a
+    311. builtin.io2.TVar.newIO                        : a
                                                        ->{IO} TVar
                                                          a
-    311. builtin.Boolean.not                           : Boolean
+    312. builtin.Boolean.not                           : Boolean
                                                        -> Boolean
-    312. builtin.io2.Clock.internals.nsec              : TimeSpec
+    313. builtin.io2.Clock.internals.nsec              : TimeSpec
                                                        -> Nat
-    313. builtin.Int.or                                : Int
+    314. builtin.Int.or                                : Int
                                                        -> Int
                                                        -> Int
-    314. builtin.Nat.or                                : Nat
+    315. builtin.Nat.or                                : Nat
                                                        -> Nat
                                                        -> Nat
-    315. builtin.Int.popCount                          : Int
+    316. builtin.Int.popCount                          : Int
                                                        -> Nat
-    316. builtin.Nat.popCount                          : Nat
+    317. builtin.Nat.popCount                          : Nat
                                                        -> Nat
-    317. builtin.Float.pow                             : Float
+    318. builtin.Float.pow                             : Float
                                                        -> Float
                                                        -> Float
-    318. builtin.Int.pow                               : Int
+    319. builtin.Int.pow                               : Int
                                                        -> Nat
                                                        -> Int
-    319. builtin.Nat.pow                               : Nat
+    320. builtin.Nat.pow                               : Nat
                                                        -> Nat
                                                        -> Nat
-    320. builtin.io2.Clock.internals.processCPUTime    : '{IO} Either
+    321. builtin.io2.Clock.internals.processCPUTime    : '{IO} Either
                                                          Failure
                                                          TimeSpec
-    321. builtin.Ref.read                              : Ref g a
+    322. builtin.Ref.read                              : Ref g a
                                                        ->{g} a
-    322. builtin.io2.TVar.read                         : TVar a
+    323. builtin.io2.TVar.read                         : TVar a
                                                        ->{STM} a
-    323. builtin.io2.TVar.readIO                       : TVar a
+    324. builtin.io2.TVar.readIO                       : TVar a
                                                        ->{IO} a
-    324. builtin.io2.Clock.internals.realtime          : '{IO} Either
+    325. builtin.io2.Clock.internals.realtime          : '{IO} Either
                                                          Failure
                                                          TimeSpec
-    325. builtin.io2.IO.ref                            : a
+    326. builtin.io2.IO.ref                            : a
                                                        ->{IO} Ref
                                                          {IO} a
-    326. builtin.Scope.ref                             : a
+    327. builtin.Scope.ref                             : a
                                                        ->{Scope
                                                          s} Ref
                                                          {Scope
                                                            s}
                                                          a
-    327. builtin.Text.repeat                           : Nat
+    328. builtin.Text.repeat                           : Nat
                                                        -> Text
                                                        -> Text
-    328. builtin.io2.STM.retry                         : '{STM} a
-    329. builtin.Float.round                           : Float
+    329. builtin.io2.STM.retry                         : '{STM} a
+    330. builtin.Float.round                           : Float
                                                        -> Int
-    330. builtin.Scope.run                             : (∀ s.
+    331. builtin.Scope.run                             : (∀ s.
                                                          '{g,
                                                          Scope s} r)
                                                        ->{g} r
-    331. builtin.io2.Clock.internals.sec               : TimeSpec
+    332. builtin.io2.Clock.internals.sec               : TimeSpec
                                                        -> Int
-    332. builtin.Code.serialize                        : Code
+    333. builtin.Code.serialize                        : Code
                                                        -> Bytes
-    333. builtin.Value.serialize                       : Value
+    334. builtin.Value.serialize                       : Value
                                                        -> Bytes
-    334. builtin.io2.Tls.ClientConfig.certificates.set : [SignedCert]
+    335. builtin.io2.Tls.ClientConfig.certificates.set : [SignedCert]
                                                        -> ClientConfig
                                                        -> ClientConfig
-    335. builtin.io2.Tls.ServerConfig.certificates.set : [SignedCert]
+    336. builtin.io2.Tls.ServerConfig.certificates.set : [SignedCert]
                                                        -> ServerConfig
                                                        -> ServerConfig
-    336. builtin.io2.TLS.ClientConfig.ciphers.set      : [Cipher]
+    337. builtin.io2.TLS.ClientConfig.ciphers.set      : [Cipher]
                                                        -> ClientConfig
                                                        -> ClientConfig
-    337. builtin.io2.Tls.ServerConfig.ciphers.set      : [Cipher]
+    338. builtin.io2.Tls.ServerConfig.ciphers.set      : [Cipher]
                                                        -> ServerConfig
                                                        -> ServerConfig
-    338. builtin.io2.Tls.ClientConfig.versions.set     : [Version]
+    339. builtin.io2.Tls.ClientConfig.versions.set     : [Version]
                                                        -> ClientConfig
                                                        -> ClientConfig
-    339. builtin.io2.Tls.ServerConfig.versions.set     : [Version]
+    340. builtin.io2.Tls.ServerConfig.versions.set     : [Version]
                                                        -> ServerConfig
                                                        -> ServerConfig
-    340. builtin.Int.shiftLeft                         : Int
+    341. builtin.Int.shiftLeft                         : Int
                                                        -> Nat
                                                        -> Int
-    341. builtin.Nat.shiftLeft                         : Nat
+    342. builtin.Nat.shiftLeft                         : Nat
                                                        -> Nat
                                                        -> Nat
-    342. builtin.Int.shiftRight                        : Int
+    343. builtin.Int.shiftRight                        : Int
                                                        -> Nat
                                                        -> Int
-    343. builtin.Nat.shiftRight                        : Nat
+    344. builtin.Nat.shiftRight                        : Nat
                                                        -> Nat
                                                        -> Nat
-    344. builtin.Int.signum                            : Int
+    345. builtin.Int.signum                            : Int
                                                        -> Int
-    345. builtin.Float.sin                             : Float
+    346. builtin.Float.sin                             : Float
                                                        -> Float
-    346. builtin.Float.sinh                            : Float
+    347. builtin.Float.sinh                            : Float
                                                        -> Float
-    347. builtin.Bytes.size                            : Bytes
+    348. builtin.Bytes.size                            : Bytes
                                                        -> Nat
-    348. builtin.List.size                             : [a]
+    349. builtin.List.size                             : [a]
                                                        -> Nat
-    349. builtin.Text.size                             : Text
+    350. builtin.Text.size                             : Text
                                                        -> Nat
-    350. builtin.Float.sqrt                            : Float
+    351. builtin.Float.sqrt                            : Float
                                                        -> Float
-    351. builtin.io2.IO.stdHandle                      : StdHandle
+    352. builtin.io2.IO.stdHandle                      : StdHandle
                                                        -> Handle
-    352. builtin.Nat.sub                               : Nat
+    353. builtin.Nat.sub                               : Nat
                                                        -> Nat
                                                        -> Int
-    353. builtin.io2.TVar.swap                         : TVar a
+    354. builtin.io2.TVar.swap                         : TVar a
                                                        -> a
                                                        ->{STM} a
-    354. builtin.io2.IO.systemTimeMicroseconds         : '{IO} Int
-    355. builtin.Bytes.take                            : Nat
+    355. builtin.io2.IO.systemTimeMicroseconds         : '{IO} Int
+    356. builtin.Bytes.take                            : Nat
                                                        -> Bytes
                                                        -> Bytes
-    356. builtin.List.take                             : Nat
+    357. builtin.List.take                             : Nat
                                                        -> [a]
                                                        -> [a]
-    357. builtin.Text.take                             : Nat
+    358. builtin.Text.take                             : Nat
                                                        -> Text
                                                        -> Text
-    358. builtin.Float.tan                             : Float
+    359. builtin.Float.tan                             : Float
                                                        -> Float
-    359. builtin.Float.tanh                            : Float
+    360. builtin.Float.tanh                            : Float
                                                        -> Float
-    360. builtin.io2.Clock.internals.threadCPUTime     : '{IO} Either
+    361. builtin.io2.Clock.internals.threadCPUTime     : '{IO} Either
                                                          Failure
                                                          TimeSpec
-    361. builtin.Bytes.toBase16                        : Bytes
+    362. builtin.Bytes.toBase16                        : Bytes
                                                        -> Bytes
-    362. builtin.Bytes.toBase32                        : Bytes
+    363. builtin.Bytes.toBase32                        : Bytes
                                                        -> Bytes
-    363. builtin.Bytes.toBase64                        : Bytes
+    364. builtin.Bytes.toBase64                        : Bytes
                                                        -> Bytes
-    364. builtin.Bytes.toBase64UrlUnpadded             : Bytes
+    365. builtin.Bytes.toBase64UrlUnpadded             : Bytes
                                                        -> Bytes
-    365. builtin.Text.toCharList                       : Text
+    366. builtin.Text.toCharList                       : Text
                                                        -> [Char]
-    366. builtin.Int.toFloat                           : Int
+    367. builtin.Int.toFloat                           : Int
                                                        -> Float
-    367. builtin.Nat.toFloat                           : Nat
+    368. builtin.Nat.toFloat                           : Nat
                                                        -> Float
-    368. builtin.Nat.toInt                             : Nat
+    369. builtin.Nat.toInt                             : Nat
                                                        -> Int
-    369. builtin.Bytes.toList                          : Bytes
+    370. builtin.Bytes.toList                          : Bytes
                                                        -> [Nat]
-    370. builtin.Char.toNat                            : Char
+    371. builtin.Char.toNat                            : Char
                                                        -> Nat
-    371. builtin.Float.toRepresentation                : Float
+    372. builtin.Float.toRepresentation                : Float
                                                        -> Nat
-    372. builtin.Int.toRepresentation                  : Int
+    373. builtin.Int.toRepresentation                  : Int
                                                        -> Nat
-    373. builtin.Char.toText                           : Char
+    374. builtin.Char.toText                           : Char
                                                        -> Text
-    374. builtin.Float.toText                          : Float
+    375. builtin.Float.toText                          : Float
                                                        -> Text
-    375. builtin.Handle.toText                         : Handle
+    376. builtin.Handle.toText                         : Handle
                                                        -> Text
-    376. builtin.Int.toText                            : Int
+    377. builtin.Int.toText                            : Int
                                                        -> Text
-    377. builtin.Nat.toText                            : Nat
+    378. builtin.Nat.toText                            : Nat
                                                        -> Text
-    378. builtin.Socket.toText                         : Socket
+    379. builtin.Socket.toText                         : Socket
                                                        -> Text
-    379. builtin.Link.Term.toText                      : Term
+    380. builtin.Link.Term.toText                      : Term
                                                        -> Text
-    380. builtin.ThreadId.toText                       : ThreadId
+    381. builtin.ThreadId.toText                       : ThreadId
                                                        -> Text
-    381. builtin.Text.toUtf8                           : Text
+    382. builtin.Text.toUtf8                           : Text
                                                        -> Bytes
-    382. builtin.todo                                  : a -> b
-    383. builtin.Debug.trace                           : Text
+    383. builtin.todo                                  : a -> b
+    384. builtin.Debug.trace                           : Text
                                                        -> a
                                                        -> ()
-    384. builtin.Int.trailingZeros                     : Int
+    385. builtin.Int.trailingZeros                     : Int
                                                        -> Nat
-    385. builtin.Nat.trailingZeros                     : Nat
+    386. builtin.Nat.trailingZeros                     : Nat
                                                        -> Nat
-    386. builtin.Float.truncate                        : Float
+    387. builtin.Float.truncate                        : Float
                                                        -> Int
-    387. builtin.Int.truncate0                         : Int
+    388. builtin.Int.truncate0                         : Int
                                                        -> Nat
-    388. builtin.io2.MVar.tryTake                      : MVar a
+    389. builtin.io2.MVar.tryTake                      : MVar a
                                                        ->{IO} Optional
                                                          a
-    389. builtin.Text.uncons                           : Text
+    390. builtin.Text.uncons                           : Text
                                                        -> Optional
                                                          ( Char,
                                                            Text)
-    390. builtin.Any.unsafeExtract                     : Any
+    391. builtin.Any.unsafeExtract                     : Any
                                                        -> a
-    391. builtin.Text.unsnoc                           : Text
+    392. builtin.Text.unsnoc                           : Text
                                                        -> Optional
                                                          ( Text,
                                                            Char)
-    392. builtin.Code.validate                         : [( Term,
+    393. builtin.Code.validate                         : [( Term,
                                                          Code)]
                                                        ->{IO} Optional
                                                          Failure
-    393. builtin.io2.validateSandboxed                 : [Term]
+    394. builtin.io2.validateSandboxed                 : [Term]
                                                        -> a
                                                        -> Boolean
-    394. builtin.Value.value                           : a
+    395. builtin.Value.value                           : a
                                                        -> Value
-    395. builtin.Debug.watch                           : Text
+    396. builtin.Debug.watch                           : Text
                                                        -> a
                                                        -> a
-    396. builtin.Ref.write                             : Ref g a
+    397. builtin.Ref.write                             : Ref g a
                                                        -> a
                                                        ->{g} ()
-    397. builtin.io2.TVar.write                        : TVar a
+    398. builtin.io2.TVar.write                        : TVar a
                                                        -> a
                                                        ->{STM} ()
-    398. builtin.Int.xor                               : Int
+    399. builtin.Int.xor                               : Int
                                                        -> Int
                                                        -> Int
-    399. builtin.Nat.xor                               : Nat
+    400. builtin.Nat.xor                               : Nat
                                                        -> Nat
                                                        -> Nat
   

--- a/unison-src/transcripts/reflog.output.md
+++ b/unison-src/transcripts/reflog.output.md
@@ -59,16 +59,16 @@ y = 2
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #j7ar890fgd .old`   to make an old namespace
+    `fork #6rnlsqcthn .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #j7ar890fgd`  to reset the root namespace and
+    `reset-root #6rnlsqcthn`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
-  1. #396ap2v898 : add
-  2. #j7ar890fgd : add
-  3. #7eacs027uv : builtins.merge
+  1. #8kr5i8gver : add
+  2. #6rnlsqcthn : add
+  3. #odl13ktegj : builtins.merge
   4. #sg60bvjo91 : (initial reflogged namespace)
 
 ```

--- a/unison-src/transcripts/squash.output.md
+++ b/unison-src/transcripts/squash.output.md
@@ -13,7 +13,7 @@ Let's look at some examples. We'll start with a namespace with just the builtins
   
   
   
-  □ 1. #4vt616ak19 (start of history)
+  □ 1. #ia768a41ec (start of history)
 
 .> fork builtin builtin2
 
@@ -42,21 +42,21 @@ Now suppose we `fork` a copy of builtin, then rename `Nat.+` to `frobnicate`, th
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #6k85v9fd02
+  ⊙ 1. #7su28m7gvs
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ 2. #0rpodsf1gq
+  ⊙ 2. #00duj13j0k
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ 3. #4vt616ak19 (start of history)
+  □ 3. #ia768a41ec (start of history)
 
 ```
 If we merge that back into `builtin`, we get that same chain of history:
@@ -71,21 +71,21 @@ If we merge that back into `builtin`, we get that same chain of history:
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #6k85v9fd02
+  ⊙ 1. #7su28m7gvs
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ 2. #0rpodsf1gq
+  ⊙ 2. #00duj13j0k
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ 3. #4vt616ak19 (start of history)
+  □ 3. #ia768a41ec (start of history)
 
 ```
 Let's try again, but using a `merge.squash` (or just `squash`) instead. The history will be unchanged:
@@ -106,7 +106,7 @@ Let's try again, but using a `merge.squash` (or just `squash`) instead. The hist
   
   
   
-  □ 1. #4vt616ak19 (start of history)
+  □ 1. #ia768a41ec (start of history)
 
 ```
 The churn that happened in `mybuiltin` namespace ended up back in the same spot, so the squash merge of that namespace with our original namespace had no effect.
@@ -485,13 +485,13 @@ This checks to see that squashing correctly preserves deletions:
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #h1ecefevst
+  ⊙ 1. #3g9mjnkcpa
   
     - Deletes:
     
       Nat.* Nat.+
   
-  □ 2. #4vt616ak19 (start of history)
+  □ 2. #ia768a41ec (start of history)
 
 ```
 Notice that `Nat.+` and `Nat.*` are deleted by the squash, and we see them deleted in one atomic step in the history.


### PR DESCRIPTION
## Overview

We discussed this briefly in Slack last weekend. While SHA-1 is a broken algorithm from a cryptographic perspective, it's still useful to have available for existing protocols that require its use (e.g. the [WebSocket handshake](https://datatracker.ietf.org/doc/html/rfc6455#section-4.2.2)).

## Implementation notes

This introduces a new builtin `crypto.HashAlgorithm.Sha1` using the existing `declareHashAlgorithm` machinery in `parser-typechecker`.

## Interesting/controversial decisions

In principle there's no reason this couldn't be implemented in pure Unison (and in fact I did just that as an exercise), but that's likely significantly slower, and there's already a fairly established pattern of exposing well-known cryptographic primitives as builtins.

## Test coverage

I've mirrored the transcript coverage that the other hash builtins have using test vectors from [the same source](https://www.di-mgt.com.au/sha_testvectors.html) as the existing ones.

## Loose ends

I'm not 100% clear about the relationship between `.base` and `.builtin`, and whether there are any additional steps necessary to integrate this. If so, I'd welcome guidance 🙂 