### PR TITLE
Auto-login to codeserver if we don't have pre-existing authentication.

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/AuthLogin.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/AuthLogin.hs
@@ -1,11 +1,21 @@
-module Unison.Codebase.Editor.HandleInput.AuthLogin (authLogin) where
+module Unison.Codebase.Editor.HandleInput.AuthLogin (authLogin, ensureAuthenticatedWithCodeserver) where
 
 import Control.Monad.Reader
+import Unison.Auth.CredentialManager (getCredentials)
 import Unison.Auth.OAuth (authenticateCodeserver)
 import Unison.Codebase.Editor.HandleInput.LoopState
 import Unison.Codebase.Editor.Output (Output (CredentialFailureMsg, Success))
 import Unison.Share.Types
 import qualified UnliftIO
+
+-- | Checks if the user has valid auth for the given codeserver,
+-- and runs through an authentication flow if not.
+ensureAuthenticatedWithCodeserver :: UnliftIO.MonadUnliftIO m => CodeserverURI -> Action m i v ()
+ensureAuthenticatedWithCodeserver codeserverURI = do
+  credsMan <- asks credentialManager
+  getCredentials credsMan (codeserverIdFromCodeserverURI codeserverURI) >>= \case
+    Right _ -> pure ()
+    Left _ -> authLogin codeserverURI
 
 authLogin :: UnliftIO.MonadUnliftIO m => CodeserverURI -> Action m i v ()
 authLogin host = do


### PR DESCRIPTION
## Overview

Currently the flow for a first push is:

1. Try to push,
2. Get an Auth error that just tells you to run `auth.login`,
3. Run `auth.login` and complete authentication
4. Re-run the original push

Since we know the user has to log-in using this flow anyways, we might as well just 'run' `auth.login` for them when we don't have the appropriate credentials.

New flow:

1. Try to push,
2. If we don't have pre-existing credentials, kick off the login flow with the codeserver
3. Complete the login flow and resume the push from where we were.

## Implementation notes

* Adds an `ensureAuthenticatedWithCodeserver` helper
* Calls `ensureAuthenticatedWithCodeserver` before each pull or push, once we've determined it's a push or pull from a codeserver.


```
.> pull blarg

  Please navigate to
  http://localhost:5424/oauth/authorize?state=uma1pFc0i6yrJI6K&redirect_uri=http%3A%2F%2Flocalhost%3A65461%2Fredirect&response_type=code&scope=openid&client_id=ucm&code_challenge=k6gb-u8efQPo38W1oet6fRAEhaXbY38_j_wP4n05UQ8&code_challenge_method=S256
  to authorize UCM with the codebase server.


  Done.

  Downloaded 0 entities.
```