### PR TITLE
Use production share server

### DIFF
--- a/parser-typechecker/src/Unison/Share/Types.hs
+++ b/parser-typechecker/src/Unison/Share/Types.hs
@@ -116,9 +116,9 @@ newtype CodeserverId = CodeserverId {codeserverId :: Text}
 --
 -- >>> import Data.Maybe (fromJust)
 -- >>> import Network.URI (parseURI)
--- >>> codeserverIdFromURI (CodeserverURI . fromJust $ parseURI "http://localhost:5424/api")
--- >>> codeserverIdFromURI (CodeserverURI . fromJust $ parseURI "https://share.unison-lang.org/api")
--- Right "localhost"
+-- >>> codeserverIdFromURI (fromJust $ parseURI "http://localhost:5424/api")
+-- >>> codeserverIdFromURI (fromJust $ parseURI "https://share.unison-lang.org/api")
+-- Right "localhost:5424"
 -- Right "share.unison-lang.org"
 codeserverIdFromURI :: URI -> Either Text CodeserverId
 codeserverIdFromURI uri =
@@ -129,7 +129,7 @@ codeserverIdFromURI uri =
 -- | Builds a CodeserverId from a URIAuth
 codeserverIdFromURIAuth :: URIAuth -> CodeserverId
 codeserverIdFromURIAuth ua =
-  (CodeserverId (Text.pack $ uriUserInfo ua <> uriRegName ua <> uriPort ua))
+  (CodeserverId (Text.pack $ uriRegName ua <> uriPort ua))
 
 -- | Gets the CodeserverId for a given CodeserverURI
 codeserverIdFromCodeserverURI :: CodeserverURI -> CodeserverId

--- a/unison-cli/src/Unison/Share/Codeserver.hs
+++ b/unison-cli/src/Unison/Share/Codeserver.hs
@@ -17,7 +17,7 @@ defaultCodeserver = unsafePerformIO $ do
         { codeserverScheme = Share.Https,
           codeserverUserInfo = "",
           codeserverRegName = "api.unison-lang.org",
-          codeserverPort = Just 443,
+          codeserverPort = Nothing,
           codeserverPath = []
         }
     Just shareHost ->

--- a/unison-cli/src/Unison/Share/Codeserver.hs
+++ b/unison-cli/src/Unison/Share/Codeserver.hs
@@ -12,14 +12,13 @@ import UnliftIO.Environment (lookupEnv)
 defaultCodeserver :: CodeserverURI
 defaultCodeserver = unsafePerformIO $ do
   lookupEnv "UNISON_SHARE_HOST" <&> \case
-    -- TODO: swap to production share before release.
     Nothing ->
       CodeserverURI
         { codeserverScheme = Share.Https,
           codeserverUserInfo = "",
-          codeserverRegName = "share-next.us-west-2.unison-lang.org",
+          codeserverRegName = "api.unison-lang.org",
           codeserverPort = Just 443,
-          codeserverPath = ["api"]
+          codeserverPath = []
         }
     Just shareHost ->
       fromMaybe (error $ "Share Host is not a valid URI: " <> shareHost) $ do


### PR DESCRIPTION
Swaps the hard-coded share to the new location so folks don't need to `UNISON_SHARE_HOST=...`