### PR TITLE
Don't auto-login on pulling public routes; pull base from share

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/RemoteRepo.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/RemoteRepo.hs
@@ -119,6 +119,12 @@ data ReadShareRemoteNamespace = ReadShareRemoteNamespace
   }
   deriving stock (Eq, Show)
 
+isPublic :: ReadShareRemoteNamespace -> Bool
+isPublic ReadShareRemoteNamespace {path} =
+  case path of
+    ("public" Path.:< _) -> True
+    _ -> False
+
 data WriteRemotePath
   = WriteRemotePathGit WriteGitRemotePath
   | WriteRemotePathShare WriteShareRemotePath

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -2315,7 +2315,7 @@ viewRemoteGitBranch ns gitBranchBehavior action = do
   eval $ ViewRemoteGitBranch ns gitBranchBehavior action
 
 importRemoteShareBranch :: MonadUnliftIO m => ReadShareRemoteNamespace -> Action' m v (Either (Output v) (Branch m))
-importRemoteShareBranch (rrn@(ReadShareRemoteNamespace {server, repo, path})) = do
+importRemoteShareBranch rrn@(ReadShareRemoteNamespace {server, repo, path}) = do
   let codeserver = Codeserver.resolveCodeserver server
   let baseURL = codeserverBaseURL codeserver
   -- Auto-login to share if pulling from a non-public path

--- a/unison-cli/src/Unison/Codebase/TranscriptParser.hs
+++ b/unison-cli/src/Unison/Codebase/TranscriptParser.hs
@@ -442,7 +442,7 @@ run dir stanzas codebase runtime config ucmVersion baseURL = UnliftIO.try $ do
                   "The transcript was expecting an error in the stanza above, but did not encounter one."
                 ]
 
-    authenticatedHTTPClient <- AuthN.newAuthenticatedHTTPClient print tokenProvider ucmVersion
+    authenticatedHTTPClient <- AuthN.newAuthenticatedHTTPClient tokenProvider ucmVersion
     let loop state = do
           writeIORef pathRef (view LoopState.currentPath state)
           let env =

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -196,7 +196,7 @@ main dir welcome initialPath (config, cancelConfig) initialInputs runtime codeba
             writeIORef pathRef (view LoopState.currentPath state)
             credMan <- newCredentialManager
             let tokenProvider = AuthN.newTokenProvider credMan
-            authorizedHTTPClient <- AuthN.newAuthenticatedHTTPClient notify tokenProvider ucmVersion
+            authorizedHTTPClient <- AuthN.newAuthenticatedHTTPClient tokenProvider ucmVersion
             let env =
                   LoopState.Env
                     { LoopState.authHTTPClient = authorizedHTTPClient,

--- a/unison-cli/tests/Unison/Test/VersionParser.hs
+++ b/unison-cli/tests/Unison/Test/VersionParser.hs
@@ -27,9 +27,10 @@ makeTest (version, path) =
       (rightMay $ runParser defaultBaseLib "versionparser" version)
       ( Just
           -- We've hard-coded the v4 branch for base for now. See 'defaultBaseLib'
-          ( ReadGitRemoteNamespace
-              (ReadGitRepo "https://github.com/unisonweb/base" (Just "v4"))
-              Nothing
-              (Path.fromText path)
+          ( ReadShareRemoteNamespace
+              { server = DefaultCodeserver,
+                repo = "unison",
+                path = Path.fromList ["public", "dev", "base"] <> Path.fromText path
+              }
           )
       )

--- a/unison-cli/tests/Unison/Test/VersionParser.hs
+++ b/unison-cli/tests/Unison/Test/VersionParser.hs
@@ -26,7 +26,6 @@ makeTest (version, path) =
     expectEqual
       (rightMay $ runParser defaultBaseLib "versionparser" version)
       ( Just
-          -- We've hard-coded the v4 branch for base for now. See 'defaultBaseLib'
           ( ReadShareRemoteNamespace
               { server = DefaultCodeserver,
                 repo = "unison",

--- a/unison-cli/unison/Main.hs
+++ b/unison-cli/unison/Main.hs
@@ -50,7 +50,7 @@ import Text.Pretty.Simple (pHPrint)
 import Unison.Codebase (Codebase, CodebasePath)
 import qualified Unison.Codebase as Codebase
 import qualified Unison.Codebase.Editor.Input as Input
-import Unison.Codebase.Editor.RemoteRepo (ReadGitRemoteNamespace)
+import Unison.Codebase.Editor.RemoteRepo (ReadShareRemoteNamespace)
 import qualified Unison.Codebase.Editor.VersionParser as VP
 import Unison.Codebase.Execute (execute)
 import Unison.Codebase.Init (CodebaseInitOptions (..), InitError (..), InitResult (..), SpecifiedCodebase (..))
@@ -418,7 +418,7 @@ isFlag f arg = arg == f || arg == "-" ++ f || arg == "--" ++ f
 getConfigFilePath :: Maybe FilePath -> IO FilePath
 getConfigFilePath mcodepath = (FP.</> ".unisonConfig") <$> Codebase.getCodebaseDir mcodepath
 
-defaultBaseLib :: Maybe ReadGitRemoteNamespace
+defaultBaseLib :: Maybe ReadShareRemoteNamespace
 defaultBaseLib =
   rightMay $
     runParser VP.defaultBaseLib "version" gitRef


### PR DESCRIPTION
## Overview

We don't want to force folks to be logged in on public pulls. We also need to this to allow the initial "Welcome" pull of base.

## Implementation notes

Currently I'm just checking if the first path segment is the literal string "public".
Keep in mind that the server still does any auth checks it needs to.
