### PR TITLE
Make user id optional on hash-jwts to accomodate unauthenticated public downloads.

### DIFF
--- a/unison-share-api/src/Unison/Sync/Types.hs
+++ b/unison-share-api/src/Unison/Sync/Types.hs
@@ -152,7 +152,7 @@ hashJWTHash =
 
 data HashJWTClaims = HashJWTClaims
   { hash :: Hash32,
-    userId :: Text
+    userId :: Maybe Text
   }
   deriving stock (Show, Eq, Ord)
 


### PR DESCRIPTION
Server-side: https://github.com/unisoncomputing/enlil/pull/44

We need to accomodate public downloads (e.g. for downloading base from share on start-up)

Currently hash-jwts require a user-id; this would allow that user id to be `null`, which means that hash-jwt may be used without an authenticated session (or for any authenticated user).

Q: should we add an expiry to these jwt's since they're not tied to any user session?