### PR TITLE
fix bug in elaborateHashes

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -1589,11 +1589,6 @@ deleteTempEntity hash =
     |]
     (Only hash)
 
-data EmptyTempEntityMissingDependencies
-  = EmptyTempEntityMissingDependencies
-  deriving stock (Show)
-  deriving anyclass (SqliteExceptionReason)
-
 -- | "Elaborate" a set of `temp_entity` hashes.
 --
 -- Given a set of `temp_entity` hashes, returns the (known) set of transitive dependencies that haven't already been
@@ -1610,7 +1605,7 @@ data EmptyTempEntityMissingDependencies
 --
 -- ... then `elaborateHashes {A}` would return the singleton set {C} (because we take the set of transitive
 -- dependencies {A,B,C} and subtract the set we already have, {A,B}).
-elaborateHashes :: Nel.NonEmpty Hash32 -> Transaction (Nel.NonEmpty Text)
+elaborateHashes :: Nel.NonEmpty Hash32 -> Transaction [Text]
 elaborateHashes hashes = do
   execute_
     [here|
@@ -1624,7 +1619,7 @@ elaborateHashes hashes = do
     |]
     (map Only (Nel.toList hashes))
   result <-
-    queryListColCheck_
+    queryListCol_
       [here|
         WITH RECURSIVE elaborated_dependency (hash, hashJwt) AS (
           SELECT temd.dependency, temd.dependencyJwt
@@ -1644,10 +1639,6 @@ elaborateHashes hashes = do
           WHERE temp_entity.hash = elaborated_dependency.hash
         )
       |]
-      ( \case
-          [] -> Left EmptyTempEntityMissingDependencies
-          x : xs -> Right (x Nel.:| xs)
-      )
   execute_ [here|DROP TABLE new_temp_entity_dependents|]
   pure result
 


### PR DESCRIPTION
Fixes #3143 

Previously, the `elaborateHashes` query asserted that given a non-empty input, it would always
produce a non-empty output, but that was a bad assumption. The output may be empty.

I'm haven't puzzled through how the existing single-threaded `pull` algorithm triggered this case, but the same bug is much easier to trigger on the WIP concurrent pull branch, where it became clear that just because the caller of `elaborateHashes` believes it has some temp entity hashes in hand, it's not the case that those temp entities haven't been flushed to main storage by the time `elaborateHashes` is called.