### PR TITLE
add Values literal to unison-sqlite

### DIFF
--- a/lib/unison-sqlite/package.yaml
+++ b/lib/unison-sqlite/package.yaml
@@ -19,10 +19,12 @@ dependencies:
   - direct-sqlite
   - exceptions
   - mtl
+  - neat-interpolation
   - pretty-simple
   - random
   - recover-rtti
   - sqlite-simple
+  - template-haskell
   - text
   - transformers
   - unison-prelude

--- a/lib/unison-sqlite/src/Unison/Sqlite.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite.hs
@@ -26,6 +26,9 @@ module Unison.Sqlite
 
     -- * Executing queries
     Sql (..),
+    sql,
+    Values (..),
+    valuesSql,
 
     -- ** Without results
 
@@ -91,8 +94,8 @@ module Unison.Sqlite
     -- * Exceptions
     SomeSqliteException (..),
     isCantOpenException,
-    SqliteConnectException (..),
-    SqliteQueryException (..),
+    SqliteConnectException,
+    SqliteQueryException,
     SqliteExceptionReason,
     SomeSqliteExceptionReason (..),
     ExpectedAtMostOneRowException (..),
@@ -128,14 +131,15 @@ import Unison.Sqlite.DataVersion (DataVersion (..), getDataVersion)
 import Unison.Sqlite.Exception
   ( SomeSqliteException (..),
     SomeSqliteExceptionReason (..),
-    SqliteConnectException (..),
+    SqliteConnectException,
     SqliteExceptionReason,
-    SqliteQueryException (..),
+    SqliteQueryException,
     isCantOpenException,
   )
 import Unison.Sqlite.JournalMode (JournalMode (..), SetJournalModeException (..), trySetJournalMode)
-import Unison.Sqlite.Sql (Sql (..))
+import Unison.Sqlite.Sql (Sql (..), sql)
 import Unison.Sqlite.Transaction
+import Unison.Sqlite.Values (Values (..), valuesSql)
 
 -- $query-naming-convention
 --

--- a/lib/unison-sqlite/src/Unison/Sqlite/Sql.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Sql.hs
@@ -1,11 +1,27 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 module Unison.Sqlite.Sql
   ( Sql (..),
+    sql,
   )
 where
 
+import Language.Haskell.TH.Quote (QuasiQuoter (quoteExp))
+import qualified Language.Haskell.TH.Syntax as TH
+import qualified NeatInterpolation
 import Unison.Prelude
 
 -- | A SQL snippet.
 newtype Sql
   = Sql Text
-  deriving newtype (IsString, Show)
+  deriving newtype (IsString, Monoid, Semigroup, Show)
+
+-- | A quasi-quoter that produces expressions of type 'Sql'.
+sql :: QuasiQuoter
+sql =
+  NeatInterpolation.trimming
+    { quoteExp =
+        \string -> do
+          text <- quoteExp NeatInterpolation.trimming string
+          pure (TH.AppE (TH.ConE 'Sql) text)
+    }

--- a/lib/unison-sqlite/src/Unison/Sqlite/Values.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Values.hs
@@ -1,0 +1,35 @@
+module Unison.Sqlite.Values
+  ( Values (..),
+    valuesSql,
+  )
+where
+
+import qualified Data.List.NonEmpty as List (NonEmpty)
+import qualified Data.List.NonEmpty as List.NonEmpty
+import qualified Data.Text as Text
+import qualified Database.SQLite.Simple as Sqlite.Simple
+import Unison.Prelude
+import Unison.Sqlite.Sql (Sql (..))
+
+-- | A @VALUES@ literal.
+newtype Values a
+  = Values (List.NonEmpty a)
+  deriving stock (Show)
+
+instance Sqlite.Simple.ToRow a => Sqlite.Simple.ToRow (Values a) where
+  toRow (Values values) =
+    foldMap Sqlite.Simple.toRow values
+
+-- | Example: given a 'Values' of length 3, where each element has a @toRow@ that produces 2 elements, produce the SQL
+-- string:
+--
+-- @
+-- VALUES (?, ?), (?, ?), (?, ?)
+-- @
+valuesSql :: Sqlite.Simple.ToRow a => Values a -> Sql
+valuesSql (Values values) =
+  Sql ("VALUES " <> Text.intercalate "," (map valueSql (List.NonEmpty.toList values)))
+
+valueSql :: Sqlite.Simple.ToRow a => a -> Text
+valueSql value =
+  "(" <> Text.intercalate "," (map (\_ -> "?") (Sqlite.Simple.toRow value)) <> ")"

--- a/lib/unison-sqlite/src/Unison/Sqlite/Values.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Values.hs
@@ -28,8 +28,12 @@ instance Sqlite.Simple.ToRow a => Sqlite.Simple.ToRow (Values a) where
 -- @
 valuesSql :: Sqlite.Simple.ToRow a => Values a -> Sql
 valuesSql (Values values) =
-  Sql ("VALUES " <> Text.intercalate "," (map valueSql (List.NonEmpty.toList values)))
+  Sql ("VALUES " <> Text.intercalate "," (replicate (length values) (valueSql columns)))
+  where
+    columns :: Int
+    columns =
+      length (Sqlite.Simple.toRow (List.NonEmpty.head values))
 
-valueSql :: Sqlite.Simple.ToRow a => a -> Text
-valueSql value =
-  "(" <> Text.intercalate "," (map (\_ -> "?") (Sqlite.Simple.toRow value)) <> ")"
+valueSql :: Int -> Text
+valueSql columns =
+  "(" <> Text.intercalate "," (replicate columns "?") <> ")"

--- a/lib/unison-sqlite/unison-sqlite.cabal
+++ b/lib/unison-sqlite/unison-sqlite.cabal
@@ -21,6 +21,7 @@ library
       Unison.Sqlite.Connection
       Unison.Sqlite.Connection.Internal
       Unison.Sqlite.Transaction
+      Unison.Sqlite.Values
   other-modules:
       Unison.Sqlite.DataVersion
       Unison.Sqlite.Exception
@@ -61,10 +62,12 @@ library
     , direct-sqlite
     , exceptions
     , mtl
+    , neat-interpolation
     , pretty-simple
     , random
     , recover-rtti
     , sqlite-simple
+    , template-haskell
     , text
     , transformers
     , unison-prelude


### PR DESCRIPTION
## Overview

This PR adds a `Values` newtype to our `unison-sqlite` package, so we can (more) easily write queries with a variable-length values literal.

This will be used in at least one upcoming PR to make `elaborateHashes` a lot more efficient, and maybe other places, too.

h/t @tstat for looking at our current implementation of `elaborateHashes` and saying "let's make that better"