### PR TITLE
#3137 - Added exit flag on launch

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -69,3 +69,4 @@ The format for this list: name, GitHub handle
 * Phil de Joux (@philderbeast)
 * Travis Staton (@tstat)
 * Dan Freeman (@dfreeman)
+* Emil Hotkowski (@emilhotkowski)


### PR DESCRIPTION
## Overview

We want to have an option, by adding a new flag `--exit`, to close REPL when running `ucm --codebasecreate path` command.

https://github.com/unisonweb/unison/issues/3137

## Implementation notes

I added a global flag so we can later use it in potentially another commands.
