### PR TITLE
Adjust effect variable 'tweaking' strategy

### DIFF
--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -1688,6 +1688,9 @@ isEffectVar u (Type.Arrow'' i es o) =
     p _ = False
 isEffectVar _ _ = False
 
+-- Checks that a variable only occurs in variant positions. This may mean that
+-- it occurs in both covariant and contravariant positions, so long as it
+-- doesn't occur in a single position that is invariant, like the `x` in `F x`.
 isVariant :: Var v => TypeVar v loc -> Type v loc -> Bool
 isVariant u = walk True
   where


### PR DESCRIPTION
This is a part of the type checker that mediates between some old inferred types and ones that work better in the new type checker. The idea was to turn, e.g. the type of `foldRight`:
    
    (a ->{g} b ->{g} b) -> b -> [a] ->{g} b
    
into:
    
    (a ->{g1} b ->{g2} b) -> b ->[a] ->{g1,g2} b
    
Which makes up distinct variables for each negative occurrence, which in turn means that solving those negative occurrences doesn't interfere in an order-dependent way. This is always sound, because you can instantiate `g` to the whole row, and use subtyping on the negative occurrences.
    
However, having multi-variable rows in invariant positions doesn't work out very well, and this tweak prevents you from declaring such situations to only involve a single variable. So, this patch modifies the tweak to only occur if `g` only occurs in positions that are either covariant or contravariant. It may be "invariant" in that it occurs both covariantly _and_ contravariantly, but it may not occur in a single position that is considered invariant.

Fixes #3159 

