### PR TITLE
Add "namespace" to name lookup index

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/NamedRef.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/NamedRef.hs
@@ -1,6 +1,7 @@
 module U.Codebase.Sqlite.NamedRef where
 
 import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NEL
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Text as Text
 import Unison.Prelude
@@ -32,7 +33,7 @@ instance ToRow ref => ToRow (NamedRef ref) where
     [toField reversedName, toField namespace] <> toRow ref
     where
       reversedName = Text.intercalate "." . toList $ segments
-      namespace = Text.intercalate "." . init . reverse . toList $ segments
+      namespace = Text.intercalate "." . reverse . NEL.tail $ segments
 
 instance FromRow ref => FromRow (NamedRef ref) where
   fromRow = do

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/NamedRef.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/NamedRef.hs
@@ -29,10 +29,14 @@ data NamedRef ref = NamedRef {reversedSegments :: ReversedSegments, ref :: ref}
 
 instance ToRow ref => ToRow (NamedRef ref) where
   toRow (NamedRef {reversedSegments = segments, ref}) =
-    [toField (Text.intercalate "." . toList $ segments)] <> toRow ref
+    [toField reversedName, toField namespace] <> toRow ref
+    where
+      reversedName = Text.intercalate "." . toList $ segments
+      namespace = Text.intercalate "." . init . reverse . toList $ segments
 
 instance FromRow ref => FromRow (NamedRef ref) where
   fromRow = do
     reversedSegments <- NonEmpty.fromList . Text.splitOn "." <$> field
+    _namespace <- void $ field @Text
     ref <- fromRow
     pure (NamedRef {reversedSegments, ref})

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -1389,7 +1389,10 @@ resetNameLookupTables = do
   execute_
     [here|
       CREATE TABLE term_name_lookup (
-        reversed_name TEXT NOT NULL, -- e.g. map.List.base
+        -- The name of the term: E.g. map.List.base
+        reversed_name TEXT NOT NULL,
+        -- The namespace containing this term, not reversed: E.g. base.List
+        namespace TEXT NOT NULL,
         referent_builtin TEXT NULL,
         referent_component_hash TEXT NULL,
         referent_component_index INTEGER NULL,
@@ -1406,7 +1409,10 @@ resetNameLookupTables = do
   execute_
     [here|
       CREATE TABLE type_name_lookup (
-        reversed_name TEXT NOT NULL, -- e.g. map.List.base
+        -- The name of the term: E.g. List.base
+        reversed_name TEXT NOT NULL,
+        -- The namespace containing this term, not reversed: E.g. base.List
+        namespace TEXT NOT NULL,
         reference_builtin TEXT NULL,
         reference_component_hash INTEGER NULL,
         reference_component_index INTEGER NULL,
@@ -1428,7 +1434,7 @@ insertTermNames names = do
     asRow (a, b) = a :. Only b
     sql =
       [here|
-      INSERT INTO term_name_lookup (reversed_name, referent_builtin, referent_component_hash, referent_component_index, referent_constructor_index, referent_constructor_type)
+      INSERT INTO term_name_lookup (reversed_name, namespace, referent_builtin, referent_component_hash, referent_component_index, referent_constructor_index, referent_constructor_type)
         VALUES (?, ?, ?, ?, ?, ?)
         ON CONFLICT DO NOTHING
         |]
@@ -1440,7 +1446,7 @@ insertTypeNames names =
   where
     sql =
       [here|
-      INSERT INTO type_name_lookup (reversed_name, reference_builtin, reference_component_hash, reference_component_index)
+      INSERT INTO type_name_lookup (reversed_name, namespace, reference_builtin, reference_component_hash, reference_component_index)
         VALUES (?, ?, ?, ?)
         ON CONFLICT DO NOTHING
         |]

--- a/lib/unison-sqlite/src/Unison/Sqlite.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite.hs
@@ -51,6 +51,7 @@ module Unison.Sqlite
     queryMaybeCol,
     queryOneRow,
     queryOneCol,
+    queryManyListRow,
 
     -- **** With checks
     queryListRowCheck,

--- a/lib/unison-sqlite/src/Unison/Sqlite/Transaction.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Transaction.hs
@@ -31,6 +31,7 @@ module Unison.Sqlite.Transaction
     queryMaybeCol,
     queryOneRow,
     queryOneCol,
+    queryManyListRow,
 
     -- **** With checks
     queryListRowCheck,
@@ -210,6 +211,11 @@ executeMany s params =
 execute_ :: Sql -> Transaction ()
 execute_ s =
   Transaction \conn -> Connection.execute_ conn s
+
+-- | Run a query many times using a prepared statement.
+queryManyListRow :: (Sqlite.FromRow r, Sqlite.ToRow q) => Sql -> [q] -> Transaction [[r]]
+queryManyListRow s params =
+  Transaction \conn -> Connection.queryManyListRow conn s params
 
 -- With results, with parameters, without checks
 

--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -11,7 +11,9 @@ module Unison.Codebase.Path
   ( Path (..),
     Path' (..),
     Absolute (..),
+    pattern AbsolutePath',
     Relative (..),
+    pattern RelativePath',
     Resolve (..),
     pattern Empty,
     pattern (Lens.:<),
@@ -262,6 +264,14 @@ toName' :: Path' -> Name
 toName' = Name.unsafeFromText . toText'
 
 pattern Empty = Path Seq.Empty
+
+pattern AbsolutePath' :: Absolute -> Path'
+pattern AbsolutePath' p = Path' (Left p)
+
+pattern RelativePath' :: Relative -> Path'
+pattern RelativePath' p = Path' (Right p)
+
+{-# COMPLETE AbsolutePath', RelativePath' #-}
 
 empty :: Path
 empty = Path mempty

--- a/unison-share-api/src/Unison/Server/Endpoints/NamespaceListing.hs
+++ b/unison-share-api/src/Unison/Server/Endpoints/NamespaceListing.hs
@@ -105,7 +105,7 @@ data NamedNamespace = NamedNamespace
   { namespaceName :: UnisonName,
     namespaceHash :: UnisonHash,
     -- May not be provided on all server implementations.
-    numContainedDefinitions :: Maybe Int
+    namespaceSize :: Maybe Int
   }
   deriving (Generic, Show)
 
@@ -143,7 +143,7 @@ backendListEntryToNamespaceObject ppe typeWidth = \case
       NamedNamespace
         { namespaceName = NameSegment.toText name,
           namespaceHash = "#" <> Hash.toBase32HexText (Causal.unCausalHash hash),
-          numContainedDefinitions = Nothing
+          namespaceSize = Nothing
         }
   Backend.ShallowPatchEntry name ->
     PatchObject . NamedPatch $ NameSegment.toText name

--- a/unison-share-api/src/Unison/Server/Endpoints/NamespaceListing.hs
+++ b/unison-share-api/src/Unison/Server/Endpoints/NamespaceListing.hs
@@ -73,7 +73,7 @@ instance ToSample NamespaceListing where
         NamespaceListing
           "."
           "#gjlk0dna8dongct6lsd19d1o9hi5n642t8jttga5e81e91fviqjdffem0tlddj7ahodjo5"
-          [Subnamespace $ NamedNamespace "base" "#19d1o9hi5n642t8jttg"]
+          [Subnamespace $ NamedNamespace "base" "#19d1o9hi5n642t8jttg" (Just 237)]
       )
     ]
 
@@ -103,7 +103,9 @@ deriving instance ToSchema NamespaceObject
 
 data NamedNamespace = NamedNamespace
   { namespaceName :: UnisonName,
-    namespaceHash :: UnisonHash
+    namespaceHash :: UnisonHash,
+    -- May not be provided on all server implementations.
+    numContainedDefinitions :: Maybe Int
   }
   deriving (Generic, Show)
 
@@ -140,7 +142,8 @@ backendListEntryToNamespaceObject ppe typeWidth = \case
     Subnamespace $
       NamedNamespace
         { namespaceName = NameSegment.toText name,
-          namespaceHash = "#" <> Hash.toBase32HexText (Causal.unCausalHash hash)
+          namespaceHash = "#" <> Hash.toBase32HexText (Causal.unCausalHash hash),
+          numContainedDefinitions = Nothing
         }
   Backend.ShallowPatchEntry name ->
     PatchObject . NamedPatch $ NameSegment.toText name

--- a/unison-share-api/src/Unison/Server/Orphans.hs
+++ b/unison-share-api/src/Unison/Server/Orphans.hs
@@ -15,7 +15,6 @@ import U.Codebase.HashTags
 import U.Util.Hash (Hash (..))
 import qualified U.Util.Hash as Hash
 import Unison.Codebase.Editor.DisplayObject
-import Unison.Codebase.Path (Path)
 import qualified Unison.Codebase.Path as Path
 import qualified Unison.Codebase.Path.Parse as Path
 import Unison.Codebase.ShortBranchHash

--- a/unison-src/transcripts/api-namespace-list.output.md
+++ b/unison-src/transcripts/api-namespace-list.output.md
@@ -71,7 +71,8 @@ GET /api/list?namespace=nested.names
         {
             "contents": {
                 "namespaceHash": "#n1egracfeljprftoktbjcase2hs4f4p8idbhs5ujipl42agld1810hrq9t7p7ped16aagni2cm1fjcjhho770jh80ipthhmg0cnsur0",
-                "namespaceName": "x"
+                "namespaceName": "x",
+                "numContainedDefinitions": null
             },
             "tag": "Subnamespace"
         }
@@ -119,7 +120,8 @@ GET /api/list?namespace=names&relativeTo=nested
         {
             "contents": {
                 "namespaceHash": "#n1egracfeljprftoktbjcase2hs4f4p8idbhs5ujipl42agld1810hrq9t7p7ped16aagni2cm1fjcjhho770jh80ipthhmg0cnsur0",
-                "namespaceName": "x"
+                "namespaceName": "x",
+                "numContainedDefinitions": null
             },
             "tag": "Subnamespace"
         }

--- a/unison-src/transcripts/api-namespace-list.output.md
+++ b/unison-src/transcripts/api-namespace-list.output.md
@@ -72,7 +72,7 @@ GET /api/list?namespace=nested.names
             "contents": {
                 "namespaceHash": "#n1egracfeljprftoktbjcase2hs4f4p8idbhs5ujipl42agld1810hrq9t7p7ped16aagni2cm1fjcjhho770jh80ipthhmg0cnsur0",
                 "namespaceName": "x",
-                "numContainedDefinitions": null
+                "namespaceSize": null
             },
             "tag": "Subnamespace"
         }
@@ -121,7 +121,7 @@ GET /api/list?namespace=names&relativeTo=nested
             "contents": {
                 "namespaceHash": "#n1egracfeljprftoktbjcase2hs4f4p8idbhs5ujipl42agld1810hrq9t7p7ped16aagni2cm1fjcjhho770jh80ipthhmg0cnsur0",
                 "namespaceName": "x",
-                "numContainedDefinitions": null
+                "namespaceSize": null
             },
             "tag": "Subnamespace"
         }


### PR DESCRIPTION
## Overview

When querying namespaces for the share api we have no way to know whether a given child namespace contains any definitions, it might just contain a history with an empty "current namespace". 

We really don't want to show a drop-down in share for namespace trees which might end up being empty once you dig all the way down; that's a bad experience.

The goal of this work is to allow us to filter out child namespaces which contain no definitions, in an efficient way, on share.

## Implementation notes

* Adds a `namespace` column to the name-lookup-index. This is computed by dropping the final segment from the provided name.
* Adds an index for the new namespace column.
* Adds a query which counts all definitions nested under a provided namespace prefix.
* Adds a few instances which are useful on the server.

## Interesting/controversial decisions

* If a namespace contains only patches, but is otherwise empty, it's still filtered out.
* Over time these "ghost" children may build up and cause performance issues, but it doesn't seem correct to completely delete the history at those locations either. Is there an alternative?