### PR TITLE
Make sure we're actually caching the right stack root

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,14 +38,6 @@ jobs:
       # purge one manually.
 
 
-      - name: Get path info
-        run: |
-          stack path --stack-root
-          stack path --project-root
-          stack path --local-pkg-db
-          stack path --snapshot-pkg-db
-          stack path --snapshot-install-root
-
       # Cache ~/.stack, keyed by the contents of 'stack.yaml'.
       - uses: actions/cache@v3
         name: cache ~/.stack (unix)
@@ -113,6 +105,15 @@ jobs:
           mkdir stack && cd stack
           curl -L https://github.com/commercialhaskell/stack/releases/download/v2.5.1/stack-2.5.1-osx-x86_64.tar.gz | tar -xz
           echo "$PWD/stack-2.5.1-osx-x86_64/" >> $GITHUB_PATH
+
+      - name: Get path info
+        run: |
+          stack path --stack-root
+          stack path --project-root
+          stack path --local-pkg-db
+          stack path --snapshot-pkg-db
+          stack path --snapshot-install-root
+
 
       # One of the transcripts fails if the user's git name hasn't been set.
       - name: set git user info

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
         name: cache ~/.stack (Windows)
         if: runner.os == 'Windows'
         with:
-          path: "C:\\Users\\runneradmin\\AppData\\Local\\Programs\\stack"
+          path: "C:\\Users\\runneradmin\\AppData\\Roaming\\stack"
           # Main cache key: commit hash. This should always result in a cache miss...
           # So when loading a cache we'll always fall back to the restore-keys,
           # which should load the most recent cache via a prefix search on the most
@@ -105,15 +105,6 @@ jobs:
           mkdir stack && cd stack
           curl -L https://github.com/commercialhaskell/stack/releases/download/v2.5.1/stack-2.5.1-osx-x86_64.tar.gz | tar -xz
           echo "$PWD/stack-2.5.1-osx-x86_64/" >> $GITHUB_PATH
-
-      - name: Get path info
-        run: |
-          stack path --stack-root
-          stack path --project-root
-          stack path --local-pkg-db
-          stack path --snapshot-pkg-db
-          stack path --snapshot-install-root
-
 
       # One of the transcripts fails if the user's git name hasn't been set.
       - name: set git user info

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,15 @@ jobs:
       # GitHub will automatically delete caches that haven't been accessed in 7 days, but there is no way to
       # purge one manually.
 
+
+      - name: Get path info
+        run: |
+          stack path --stack-root
+          stack path --project-root
+          stack path --local-pkg-db
+          stack path --snapshot-pkg-db
+          stack path --snapshot-install-root
+
       # Cache ~/.stack, keyed by the contents of 'stack.yaml'.
       - uses: actions/cache@v3
         name: cache ~/.stack (unix)


### PR DESCRIPTION
Cache the correct stack root on windows; just had the wrong path.

takes builds from ~1hr down to ~20mins;

There's still probably room for improvement here somewhere, but chopping down to 33% of previous time is worth merging haha.