### PR TITLE
2-3x speed improvement for text matching

### DIFF
--- a/parser-typechecker/src/Unison/Util/Text.hs
+++ b/parser-typechecker/src/Unison/Util/Text.hs
@@ -29,6 +29,9 @@ one, singleton :: Char -> Text
 one ch = Text (R.one (chunk (T.singleton ch)))
 singleton = one
 
+appendUnbalanced :: Text -> Text -> Text
+appendUnbalanced (Text t1) (Text t2) = Text (R.two t1 t2)
+
 threshold :: Int
 threshold = 512
 

--- a/parser-typechecker/src/Unison/Util/Text/Pattern.hs
+++ b/parser-typechecker/src/Unison/Util/Text/Pattern.hs
@@ -130,7 +130,12 @@ compile (Many p) !_ !success = case p of
           Just (Text.chunkToText -> txt, t) -> case DT.dropWhile ok txt of
             rem
               | DT.null rem -> go acc t
-              | otherwise -> success acc (Text.fromText rem <> t)
+              | otherwise ->
+                  -- moving the remainder to the root of the tree is much more efficient
+                  -- since the next uncons will be O(1) rather than O(log n)
+                  -- this can't unbalance the tree too badly since these promoted chunks
+                  -- are being consumed and will get removed by a subsequent uncons
+                  success acc (Text.appendUnbalanced (Text.fromText rem) t)
     {-# INLINE walker #-}
 compile (Replicate m n p) !err !success = case p of
   AnyChar -> \acc t ->


### PR DESCRIPTION
I have some bigger ideas for how we could further improve performance of the regex engine, but this is a simple win that took parsing of a million line csv file from 50s to under 20s.