### PR TITLE
hide timing output behind UNISON_DEBUG=timing

### DIFF
--- a/codebase2/util/package.yaml
+++ b/codebase2/util/package.yaml
@@ -32,6 +32,7 @@ dependencies:
   - safe
   - text
   - time
+  - unison-prelude
   - unison-util-relation
   - unliftio
   - vector

--- a/codebase2/util/src/U/Util/Timing.hs
+++ b/codebase2/util/src/U/Util/Timing.hs
@@ -7,35 +7,37 @@ import Data.Time.Clock.System (getSystemTime, systemToTAITime)
 import Data.Time.Clock.TAI (diffAbsoluteTime)
 import System.CPUTime (getCPUTime)
 import System.IO.Unsafe (unsafePerformIO)
+import qualified Unison.Debug as Debug
 import UnliftIO (MonadIO, liftIO)
 
-enabled :: Bool
-enabled = True
-
 time :: MonadIO m => String -> m a -> m a
-time _ ma | not enabled = ma
-time label ma = do
-  systemStart <- liftIO getSystemTime
-  cpuPicoStart <- liftIO getCPUTime
-  liftIO $ putStrLn $ "Timing " ++ label ++ "..."
-  a <- ma
-  cpuPicoEnd <- liftIO getCPUTime
-  systemEnd <- liftIO getSystemTime
-  let systemDiff = diffAbsoluteTime (systemToTAITime systemEnd) (systemToTAITime systemStart)
-  let cpuDiff = picosecondsToDiffTime (cpuPicoEnd - cpuPicoStart)
-  liftIO $ putStrLn $ "Finished " ++ label ++ " in " ++ show cpuDiff ++ " (cpu), " ++ show systemDiff ++ " (system)"
-  pure a
+time label ma =
+  if Debug.shouldDebug Debug.Timing
+    then do
+      systemStart <- liftIO getSystemTime
+      cpuPicoStart <- liftIO getCPUTime
+      liftIO $ putStrLn $ "Timing " ++ label ++ "..."
+      a <- ma
+      cpuPicoEnd <- liftIO getCPUTime
+      systemEnd <- liftIO getSystemTime
+      let systemDiff = diffAbsoluteTime (systemToTAITime systemEnd) (systemToTAITime systemStart)
+      let cpuDiff = picosecondsToDiffTime (cpuPicoEnd - cpuPicoStart)
+      liftIO $ putStrLn $ "Finished " ++ label ++ " in " ++ show cpuDiff ++ " (cpu), " ++ show systemDiff ++ " (system)"
+      pure a
+    else ma
 
 unsafeTime :: Monad m => String -> m a -> m a
-unsafeTime _ ma | not enabled = ma
-unsafeTime label ma = do
-  let !systemStart = unsafePerformIO getSystemTime
-      !cpuPicoStart = unsafePerformIO getCPUTime
-      !_ = unsafePerformIO $ putStrLn $ "Timing " ++ label ++ "..."
-  a <- ma
-  let !cpuPicoEnd = unsafePerformIO getCPUTime
-      !systemEnd = unsafePerformIO getSystemTime
-  let systemDiff = diffAbsoluteTime (systemToTAITime systemEnd) (systemToTAITime systemStart)
-  let cpuDiff = picosecondsToDiffTime (cpuPicoEnd - cpuPicoStart)
-  let !_ = unsafePerformIO $ putStrLn $ "Finished " ++ label ++ " in " ++ show cpuDiff ++ " (cpu), " ++ show systemDiff ++ " (system)"
-  pure a
+unsafeTime label ma =
+  if Debug.shouldDebug Debug.Timing
+    then do
+      let !systemStart = unsafePerformIO getSystemTime
+          !cpuPicoStart = unsafePerformIO getCPUTime
+          !_ = unsafePerformIO $ putStrLn $ "Timing " ++ label ++ "..."
+      a <- ma
+      let !cpuPicoEnd = unsafePerformIO getCPUTime
+          !systemEnd = unsafePerformIO getSystemTime
+      let systemDiff = diffAbsoluteTime (systemToTAITime systemEnd) (systemToTAITime systemStart)
+      let cpuDiff = picosecondsToDiffTime (cpuPicoEnd - cpuPicoStart)
+      let !_ = unsafePerformIO $ putStrLn $ "Finished " ++ label ++ " in " ++ show cpuDiff ++ " (cpu), " ++ show systemDiff ++ " (system)"
+      pure a
+    else ma

--- a/codebase2/util/unison-util.cabal
+++ b/codebase2/util/unison-util.cabal
@@ -54,6 +54,7 @@ library
     , safe
     , text
     , time
+    , unison-prelude
     , unison-util-relation
     , unliftio
     , vector
@@ -94,6 +95,7 @@ benchmark bench
     , sandi
     , text
     , time
+    , unison-prelude
     , unison-util
     , unison-util-base32hex
     , unison-util-relation


### PR DESCRIPTION
## Overview

This PR hides debug timing info behind the `UNISON_DEBUG=timing` env var
