### PR TITLE
Use unison-local-ui over codebase-ui

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -28,12 +28,12 @@ jobs:
       - name: build
         run: stack --no-terminal build --flag unison-parser-typechecker:optimized
 
-      - name: fetch latest codebase-ui and package with ucm
+      - name: fetch latest Unison Local UI and package with ucm
         run: |
           mkdir -p /tmp/ucm/ui
           UCM=$(stack path | awk '/local-install-root/{print $2}')/bin/unison
           cp $UCM /tmp/ucm/ucm
-          wget -O/tmp/unisonLocal.zip https://github.com/unisonweb/codebase-ui/releases/download/latest/unisonLocal.zip
+          wget -O/tmp/unisonLocal.zip https://github.com/unisonweb/unison-local-ui/releases/download/latest/unisonLocal.zip
           unzip -d /tmp/ucm/ui /tmp/unisonLocal.zip
           tar -c -z -f ucm-linux.tar.gz -C /tmp/ucm .
 
@@ -67,12 +67,12 @@ jobs:
       - name: build
         run: stack --no-terminal build --flag unison-parser-typechecker:optimized
 
-      - name: fetch latest codebase-ui and package with ucm
+      - name: fetch latest Unison Local UI and package with ucm
         run: |
           mkdir -p /tmp/ucm/ui
           UCM=$(stack path | awk '/local-install-root/{print $2}')/bin/unison
           cp $UCM /tmp/ucm/ucm
-          wget -O/tmp/unisonLocal.zip https://github.com/unisonweb/codebase-ui/releases/download/latest/unisonLocal.zip
+          wget -O/tmp/unisonLocal.zip https://github.com/unisonweb/unison-local-ui/releases/download/latest/unisonLocal.zip
           unzip -d /tmp/ucm/ui /tmp/unisonLocal.zip
           tar -c -z -f ucm-macos.tar.gz -C /tmp/ucm .
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,12 +54,12 @@ jobs:
       - name: build
         run: stack --no-terminal build --flag unison-parser-typechecker:optimized
 
-      - name: fetch latest codebase-ui and package with ucm
+      - name: fetch latest Unison Local UI and package with ucm
         run: |
           mkdir -p /tmp/ucm/ui
           UCM=$(stack path | awk '/local-install-root/{print $2}')/bin/unison
           cp $UCM /tmp/ucm/ucm
-          wget -O/tmp/unisonLocal.zip https://github.com/unisonweb/codebase-ui/releases/download/latest/unisonLocal.zip
+          wget -O/tmp/unisonLocal.zip https://github.com/unisonweb/unison-local-ui/releases/download/latest/unisonLocal.zip
           unzip -d /tmp/ucm/ui /tmp/unisonLocal.zip
           tar -c -z -f ucm-linux.tar.gz -C /tmp/ucm .
 
@@ -87,12 +87,12 @@ jobs:
       - name: build
         run: stack --no-terminal build --flag unison-parser-typechecker:optimized
 
-      - name: fetch latest codebase-ui and package with ucm
+      - name: fetch latest Unison Local UI and package with ucm
         run: |
           mkdir -p /tmp/ucm/ui
           UCM=$(stack path | awk '/local-install-root/{print $2}')/bin/unison
           cp $UCM /tmp/ucm/ucm
-          wget -O/tmp/unisonLocal.zip https://github.com/unisonweb/codebase-ui/releases/download/latest/unisonLocal.zip
+          wget -O/tmp/unisonLocal.zip https://github.com/unisonweb/unison-local-ui/releases/download/latest/unisonLocal.zip
           unzip -d /tmp/ucm/ui /tmp/unisonLocal.zip
           tar -c -z -f ucm-macos.tar.gz -C /tmp/ucm .
 
@@ -112,14 +112,14 @@ jobs:
       - name: build
         run: stack --no-terminal build --flag unison-parser-typechecker:optimized
 
-      - name: fetch latest codebase-ui and package with ucm
+      - name: fetch latest Unison Local UI and package with ucm
         # Powershell
         run: |
           mkdir -p tmp\ui
           mkdir -p release\ui
           $UCM = stack exec -- where unison
           cp $UCM .\release\ucm.exe
-          Invoke-WebRequest -Uri https://github.com/unisonweb/codebase-ui/releases/download/latest/unisonLocal.zip -OutFile tmp\unisonLocal.zip
+          Invoke-WebRequest -Uri https://github.com/unisonweb/unison-local-ui/releases/download/latest/unisonLocal.zip -OutFile tmp\unisonLocal.zip
           Expand-Archive -Path tmp\unisonLocal.zip -DestinationPath release\ui
           Compress-Archive -Path .\release\* -DestinationPath ucm-windows.zip
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ stack --version # we'll want to know this version if you run into trouble
 $ stack build --fast --test && stack exec unison
 ```
 
-To run a local codebase-ui while building from source, you can use the `/dev-ui-install.sh` script. It will download the latest release of the codebase-ui and put it in the expected location for the unison executable created by `stack build`. When you start unison, you'll see a url where the codebase-ui is running. 
+To run the Unison Local UI while building from source, you can use the `/dev-ui-install.sh` script. It will download the latest release of [unison-local-ui](https://github.com/unisonweb/unison-local-ui) and put it in the expected location for the unison executable created by `stack build`. When you start unison, you'll see a url where Unison Local UI is running. 
 
 See [`development.markdown`](development.markdown) for a list of build commands you'll likely use during development.
 
@@ -48,7 +48,7 @@ Codebase Server
 ---------------
 
 When `ucm` starts it starts a Codebase web server that is used by the 
-[Codebase UI](https://github.com/unisonweb/codebase-ui). It selects a random
+[Unison Local UI](https://github.com/unisonweb/unison-local-ui). It selects a random
 port and a unique token that must be used when starting the UI to correctly
 connect to the server.
 

--- a/dev-ui-install.sh
+++ b/dev-ui-install.sh
@@ -4,7 +4,7 @@ echo "executable built by stack."
 echo ""
 
 stack build
-curl -L https://github.com/unisonweb/codebase-ui/releases/download/latest/unisonLocal.zip --output unisonLocal.zip
+curl -L https://github.com/unisonweb/unison-local-ui/releases/download/latest/unisonLocal.zip --output unisonLocal.zip
 parent_dir="$(dirname -- $(stack exec which unison))"
 mkdir -p "$parent_dir/ui"
 unzip -o unisonLocal.zip -d "$parent_dir/ui"


### PR DESCRIPTION
## Overview

Migrate to use the new Unison Local UI repository from [unison-local-ui](https://github.com/unisonweb/unison-local-ui) instead of [codebase-ui](https://github.com/unisonweb/codebase-ui).