### PR TITLE
Make Codebase object thread-safe

### DIFF
--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -90,8 +90,10 @@ module Unison.Codebase
     CodebasePath,
     SyncToDir,
 
-    -- * Sqlite escape hatch
-    connection,
+    -- * Direct codebase access
+    runTransaction,
+    withConnection,
+    withConnectionIO,
 
     -- * Misc (organize these better)
     addDefsToCodebase,
@@ -154,6 +156,12 @@ import qualified Unison.UnisonFile as UF
 import qualified Unison.Util.Relation as Rel
 import Unison.Var (Var)
 import qualified Unison.WatchKind as WK
+import qualified Unison.Sqlite as Sqlite
+
+-- | Run a transaction on a codebase.
+runTransaction :: MonadIO m => Codebase m v a -> Sqlite.Transaction b -> m b
+runTransaction Codebase{withConnection} action =
+  withConnection \conn -> Sqlite.runTransaction conn action
 
 -- | Get the shallow representation of the root branches without loading the children or
 -- history.

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -176,15 +176,10 @@ data Codebase m v a = Codebase
     -- Updates the root namespace names index.
     -- This isn't run automatically because it can be a bit slow.
     updateNameLookup :: m (),
-    -- | The SQLite connection this codebase closes over.
-    --
-    -- At one time the codebase was meant to abstract over the storage layer, but it has been cumbersome. Now we prefer
-    -- to interact with SQLite directly, and so provide this temporary escape hatch, until we can eliminate this
-    -- interface entirely.
-    connection :: Sqlite.Connection,
-    -- | Another escape hatch like the above connection, but this one makes a new connection to the same underlying
-    -- database file. This allows code (like pull-from-share) to use more than one connection concurrently.
-    withConnection :: forall x. (Sqlite.Connection -> IO x) -> IO x
+    -- | Acquire a new connection to the same underlying database file this codebase object connects to.
+    withConnection :: forall x. (Sqlite.Connection -> m x) -> m x,
+    -- | Acquire a new connection to the same underlying database file this codebase object connects to.
+    withConnectionIO :: forall x. (Sqlite.Connection -> IO x) -> IO x
   }
 
 -- | Whether a codebase is local or remote.

--- a/unison-cli/src/Unison/Codebase/Editor/HandleCommand.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleCommand.hs
@@ -43,7 +43,6 @@ import qualified Unison.Reference as Reference
 import qualified Unison.Result as Result
 import qualified Unison.Server.Backend as Backend
 import qualified Unison.Server.CodebaseServer as Server
-import qualified Unison.Sqlite as Sqlite
 import Unison.Symbol (Symbol)
 import Unison.Term (Term)
 import qualified Unison.Term as Term
@@ -243,8 +242,7 @@ commandLine config awaitInput setBranchRef rt notifyUser notifyNumbered loadSour
               UnliftIO.UnliftIO toIO -> toIO . Free.fold go
         pure runF
       UCMVersion -> pure ucmVersion
-      AnalyzeCodebaseIntegrity -> do
-        Sqlite.runTransaction (Codebase.connection codebase) integrityCheckFullCodebase
+      AnalyzeCodebaseIntegrity -> lift (Codebase.runTransaction codebase integrityCheckFullCodebase)
 
     watchCache :: Reference.Id -> IO (Maybe (Term Symbol ()))
     watchCache h = do

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -99,7 +99,7 @@ import qualified Unison.Codebase.SyncMode as SyncMode
 import Unison.Codebase.TermEdit (TermEdit (..))
 import qualified Unison.Codebase.TermEdit as TermEdit
 import qualified Unison.Codebase.TermEdit.Typing as TermEdit
-import Unison.Codebase.Type (Codebase (..), GitError)
+import Unison.Codebase.Type (GitError)
 import qualified Unison.Codebase.TypeEdit as TypeEdit
 import qualified Unison.Codebase.Verbosity as Verbosity
 import qualified Unison.CommandLine.DisplayValues as DisplayValues
@@ -149,7 +149,6 @@ import qualified Unison.Share.Sync as Share
 import qualified Unison.Share.Sync.Types as Sync
 import Unison.Share.Types (codeserverBaseURL)
 import qualified Unison.ShortHash as SH
-import qualified Unison.Sqlite as Sqlite
 import Unison.Symbol (Symbol)
 import qualified Unison.Sync.Types as Share (Path (..))
 import Unison.Term (Term)
@@ -1865,45 +1864,44 @@ handlePushToUnisonShare WriteShareRemotePath {server, repo, path = remotePath} l
   let sharePath = Share.Path (repo Nel.:| pathToSegments remotePath)
   ensureAuthenticatedWithCodeserver codeserver
 
-  LoopState.Env {authHTTPClient, codebase = Codebase {connection, withConnection}} <- ask
+  LoopState.Env {authHTTPClient, codebase} <- ask
 
   -- doesn't handle the case where a non-existent path is supplied
-  Sqlite.runTransaction connection (Ops.loadCausalHashAtPath (pathToSegments (Path.unabsolute localPath)))
-    >>= \case
-      Nothing -> respond (BranchNotFound . Path.absoluteToPath' $ localPath)
-      Just localCausalHash ->
-        case behavior of
-          PushBehavior.RequireEmpty -> do
-            let push :: IO (Either (Sync.SyncError Share.CheckAndSetPushError) ())
-                push =
-                  withEntitiesUploadedProgressCallbacks \callbacks ->
-                    Share.checkAndSetPush
-                      authHTTPClient
-                      baseURL
-                      withConnection
-                      sharePath
-                      Nothing
-                      localCausalHash
-                      callbacks
-            liftIO push >>= \case
-              Left (Sync.SyncError err) -> respond (Output.ShareError (ShareErrorCheckAndSetPush err))
-              Left (Sync.TransportError err) -> respond (Output.ShareError (ShareErrorTransport err))
-              Right () -> pure ()
-          PushBehavior.RequireNonEmpty -> do
-            let push :: IO (Either (Sync.SyncError Share.FastForwardPushError) ())
-                push = do
-                  withEntitiesUploadedProgressCallbacks \callbacks ->
-                    Share.fastForwardPush
-                      authHTTPClient
-                      baseURL
-                      withConnection
-                      sharePath
-                      localCausalHash
-                      callbacks
-            liftIO push >>= \case
-              Left (Sync.SyncError err) -> respond (Output.ShareError (ShareErrorFastForwardPush err))
-              Left (Sync.TransportError err) -> respond (Output.ShareError (ShareErrorTransport err))
-              Right () -> pure ()
+  eval (Eval (Codebase.runTransaction codebase (Ops.loadCausalHashAtPath (pathToSegments (Path.unabsolute localPath))))) >>= \case
+    Nothing -> respond (BranchNotFound . Path.absoluteToPath' $ localPath)
+    Just localCausalHash ->
+      case behavior of
+        PushBehavior.RequireEmpty -> do
+          let push :: IO (Either (Sync.SyncError Share.CheckAndSetPushError) ())
+              push =
+                withEntitiesUploadedProgressCallbacks \callbacks ->
+                  Share.checkAndSetPush
+                    authHTTPClient
+                    baseURL
+                    (Codebase.withConnectionIO codebase)
+                    sharePath
+                    Nothing
+                    localCausalHash
+                    callbacks
+          liftIO push >>= \case
+            Left (Sync.SyncError err) -> respond (Output.ShareError (ShareErrorCheckAndSetPush err))
+            Left (Sync.TransportError err) -> respond (Output.ShareError (ShareErrorTransport err))
+            Right () -> pure ()
+        PushBehavior.RequireNonEmpty -> do
+          let push :: IO (Either (Sync.SyncError Share.FastForwardPushError) ())
+              push = do
+                withEntitiesUploadedProgressCallbacks \callbacks ->
+                  Share.fastForwardPush
+                    authHTTPClient
+                    baseURL
+                    (Codebase.withConnectionIO codebase)
+                    sharePath
+                    localCausalHash
+                    callbacks
+          liftIO push >>= \case
+            Left (Sync.SyncError err) -> respond (Output.ShareError (ShareErrorFastForwardPush err))
+            Left (Sync.TransportError err) -> respond (Output.ShareError (ShareErrorTransport err))
+            Right () -> pure ()
   where
     pathToSegments :: Path -> [Text]
     pathToSegments =
@@ -2322,14 +2320,14 @@ importRemoteShareBranch rrn@(ReadShareRemoteNamespace {server, repo, path}) = do
   when (not $ RemoteRepo.isPublic rrn) $ ensureAuthenticatedWithCodeserver codeserver
   mapLeft Output.ShareError <$> do
     let shareFlavoredPath = Share.Path (repo Nel.:| coerce @[NameSegment] @[Text] (Path.toList path))
-    LoopState.Env {authHTTPClient, codebase = codebase@Codebase {withConnection}} <- ask
+    LoopState.Env {authHTTPClient, codebase} <- ask
     let pull :: IO (Either (Sync.SyncError Share.PullError) CausalHash)
         pull =
           withEntitiesDownloadedProgressCallbacks \callbacks ->
             Share.pull
               authHTTPClient
               baseURL
-              withConnection
+              (Codebase.withConnectionIO codebase)
               shareFlavoredPath
               callbacks
     liftIO pull >>= \case


### PR DESCRIPTION
## Overview

This PR makes the Codebase object thread-safe by making each operation use a new underlying connection to SQLite, rather than a shared connection that the Codebase closes over.

Fixes #3190, which was caused by the local UI and ucm simultaneously using the same SQLite connection. 