### PR TITLE
Fix a problem with equating ability rows where one is concrete

### DIFF
--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -2696,15 +2696,10 @@ equateAbilities ls rs =
                 refine True [(loc t, bc, cv)] [cls ++ crs]
             | [] <- com, null rs, null cls -> for_ vls defaultAbility
             | [] <- com, null ls, null crs -> for_ vrs defaultAbility
-            | otherwise -> do
-                mrefine mlSlack ls rs
-                mrefine mrSlack rs ls
+            | [] <- com, Just pl <- mlSlack, null cls -> refine False [pl] [rs]
+            | [] <- com, Just pr <- mrSlack, null crs -> refine False [pr] [ls]
+            | otherwise -> getContext >>= failWith . AbilityCheckFailure ls rs
   where
-    mrefine (Just p) _ es = refine False [p] [es]
-    mrefine Nothing _ [] = pure ()
-    mrefine Nothing hs es =
-      getContext >>= failWith . AbilityCheckFailure hs es
-
     refine common lbvs ess = do
       cv <- traverse freshenVar cn
       ctx <- getContext

--- a/unison-src/transcripts/fix3196.md
+++ b/unison-src/transcripts/fix3196.md
@@ -1,0 +1,32 @@
+
+```ucm:hide
+.> builtins.merge
+```
+
+Tests ability checking in scenarios where one side is concrete and the other is
+a variable. This was supposed to be covered, but the method wasn't actually
+symmetric, so doing `equate l r` might work, but not `equate r l`.
+
+Below were cases that caused the failing order.
+
+```unison
+structural type W es = W
+
+unique ability Zoot where
+  zoot : ()
+
+woot : W {g} -> '{g, Zoot} a ->{Zoot} a
+woot w a = todo ()
+
+ex = do
+  w = (W : W {Zoot})
+  woot w do bug "why don't you typecheck?"
+
+w1 : W {Zoot}
+w1 = W
+
+w2 : W {g} -> W {g}
+w2 = cases W -> W
+
+> w2 w1
+```

--- a/unison-src/transcripts/fix3196.output.md
+++ b/unison-src/transcripts/fix3196.output.md
@@ -1,0 +1,52 @@
+
+Tests ability checking in scenarios where one side is concrete and the other is
+a variable. This was supposed to be covered, but the method wasn't actually
+symmetric, so doing `equate l r` might work, but not `equate r l`.
+
+Below were cases that caused the failing order.
+
+```unison
+structural type W es = W
+
+unique ability Zoot where
+  zoot : ()
+
+woot : W {g} -> '{g, Zoot} a ->{Zoot} a
+woot w a = todo ()
+
+ex = do
+  w = (W : W {Zoot})
+  woot w do bug "why don't you typecheck?"
+
+w1 : W {Zoot}
+w1 = W
+
+w2 : W {g} -> W {g}
+w2 = cases W -> W
+
+> w2 w1
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      structural type W es
+      unique ability Zoot
+      ex   : '{Zoot} r
+      w1   : W {Zoot}
+      w2   : W {g} -> W {g}
+      woot : W {g} -> '{g, Zoot} a ->{Zoot} a
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    19 | > w2 w1
+           ⧩
+           W
+
+```


### PR DESCRIPTION
There was logic to equate rows like `{g,Foo}` with `{Bar,Foo}`. However, it was only actually working if the rows were passed into the equating function in the right order. Fixed the logic so that it behaves symmetrically.

Fixes #3196 