### PR TITLE
Update `find` behavior to align with self-contained namespaces

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1757,7 +1757,9 @@ handleFindI isVerbose fscope ws input = do
           respond $ ListOfDefinitions ppe isVerbose results'
     results <- getResults (getNames fscope)
     case (results, fscope) of
-      ([],Local) -> respondResults =<< getResults (getNames LocalAndDeps)
+      ([],Local) -> do
+        respond FindNoLocalMatches
+        respondResults =<< getResults (getNames LocalAndDeps)
       _ -> respondResults results
 
 handleDependents :: Monad m => HQ.HashQualified Name -> Action' m v ()

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -514,7 +514,6 @@ loop = do
           updateAtM = Unison.Codebase.Editor.HandleInput.updateAtM inputDescription
           importRemoteGitBranch ns mode preprocess =
             ExceptT . eval $ ImportRemoteGitBranch ns mode preprocess
-          loadSearchResults = eval . LoadSearchResults
           saveAndApplyPatch patchPath'' patchName patch' = do
             stepAtM
               Branch.CompressHistory
@@ -1116,52 +1115,8 @@ loop = do
                       p | last p == '.' -> p ++ s
                       p -> p ++ "." ++ s
                     pathArgStr = show pathArg
-            FindI isVerbose global ws -> do
-              let prettyPrintNames = basicPrettyPrintNames
-              unlessError do
-                results <- case ws of
-                  -- no query, list everything
-                  [] -> pure . listBranch $ Branch.head currentBranch'
-                  -- type query
-                  ":" : ws ->
-                    ExceptT (parseSearchType (show input) (unwords ws)) >>= \typ ->
-                      ExceptT $ do
-                        let named = Branch.deepReferents root0
-                        matches <-
-                          fmap (filter (`Set.member` named) . toList) $
-                            eval $ GetTermsOfType typ
-                        matches <-
-                          if null matches
-                            then do
-                              respond NoExactTypeMatches
-                              fmap (filter (`Set.member` named) . toList) $
-                                eval $ GetTermsMentioningType typ
-                            else pure matches
-                        let results =
-                              -- in verbose mode, aliases are shown, so we collapse all
-                              -- aliases to a single search result; in non-verbose mode,
-                              -- a separate result may be shown for each alias
-                              (if isVerbose then uniqueBy SR.toReferent else id) $
-                                searchResultsFor prettyPrintNames matches []
-                        pure . pure $ results
-
-                  -- name query
-                  (map HQ.unsafeFromString -> qs) -> do
-                    ns <-
-                      lift $
-                        if not global
-                          then basicParseNames
-                          else fst <$> basicNames' Backend.AllNames
-                    let srs = searchBranchScored ns fuzzyNameDistance qs
-                    pure $ uniqueBy SR.toReferent srs
-                lift do
-                  LoopState.numberedArgs .= fmap searchResultToHQString results
-                  results' <- loadSearchResults results
-                  ppe <-
-                    suffixifiedPPE
-                      =<< makePrintNamesFromLabeled'
-                        (foldMap SR'.labeledDependencies results')
-                  respond $ ListOfDefinitions ppe isVerbose results'
+            FindI isVerbose fscope ws ->
+              handleFindI isVerbose fscope ws input
             ResolveTypeNameI hq ->
               zeroOneOrMore (getHQ'Types hq) (typeNotFound hq) go (typeConflicted hq)
               where
@@ -1725,6 +1680,85 @@ handleCreatePullRequest baseRepo0 headRepo0 = do
             Right baseBranch -> do
               diff <- mergeAndDiff baseBranch headBranch
               respondNumbered diff
+
+handleFindI
+  :: (Monad m, Var v)
+  => Bool
+  -> FindScope
+  -> [String]
+  -> Input
+  -> Action' m v ()
+handleFindI isVerbose fscope ws input = do
+  root' <- use LoopState.root
+  currentPath' <- use LoopState.currentPath
+  currentBranch' <- getAt currentPath'
+  let currentBranch0 = Branch.head currentBranch'
+      getNames :: FindScope -> Names
+      getNames findScope =
+        let namesWithinCurrentPath = Backend.prettyNamesForBranch root' nameScope
+            cp = Path.unabsolute currentPath'
+            nameScope = case findScope of
+              Local -> Backend.Within cp
+              LocalAndDeps -> Backend.Within cp
+              Global -> Backend.AllNames cp
+            scopeFilter = case findScope of
+              Local ->
+                let f n =
+                      case Name.segments n of
+                        "lib" Nel.:| _ : _ -> False
+                        _ -> True
+                in Names.filter f
+              Global -> id
+              LocalAndDeps ->
+                let f n =
+                      case Name.segments n of
+                        "lib" Nel.:| (_ : "lib" : _) -> False
+                        _ -> True
+                in Names.filter f
+        in scopeFilter namesWithinCurrentPath
+  unlessError do
+    let getResults names = do
+          case ws of
+            [] -> pure (List.sortOn (\s -> (SR.name s, s)) (SR.fromNames names))
+            -- type query
+            ":" : ws ->
+              ExceptT (parseSearchType (show input) (unwords ws)) >>= \typ ->
+                ExceptT $ do
+                  let named = Branch.deepReferents currentBranch0
+                  matches <-
+                    fmap (filter (`Set.member` named) . toList) $
+                      eval $ GetTermsOfType typ
+                  matches <-
+                    if null matches
+                      then do
+                        respond NoExactTypeMatches
+                        fmap (filter (`Set.member` named) . toList) $
+                          eval $ GetTermsMentioningType typ
+                      else pure matches
+                  let results =
+                        -- in verbose mode, aliases are shown, so we collapse all
+                        -- aliases to a single search result; in non-verbose mode,
+                        -- a separate result may be shown for each alias
+                        (if isVerbose then uniqueBy SR.toReferent else id) $
+                          searchResultsFor names matches []
+                  pure . pure $ results
+
+            -- name query
+            (map HQ.unsafeFromString -> qs) -> do
+              let srs = searchBranchScored names fuzzyNameDistance qs
+              pure $ uniqueBy SR.toReferent srs
+    let respondResults results = lift do
+          LoopState.numberedArgs .= fmap searchResultToHQString results
+          results' <- eval $ LoadSearchResults results
+          ppe <-
+            suffixifiedPPE
+              =<< makePrintNamesFromLabeled'
+                (foldMap SR'.labeledDependencies results')
+          respond $ ListOfDefinitions ppe isVerbose results'
+    results <- getResults (getNames fscope)
+    case (results, fscope) of
+      ([],Local) -> respondResults =<< getResults (getNames LocalAndDeps)
+      _ -> respondResults results
 
 handleDependents :: Monad m => HQ.HashQualified Name -> Action' m v ()
 handleDependents hq = do
@@ -2587,10 +2621,6 @@ confirmedCommand :: Input -> Action m i v Bool
 confirmedCommand i = do
   i0 <- use LoopState.lastInput
   pure $ Just i == i0
-
-listBranch :: Branch0 m -> [SearchResult]
-listBranch (Branch.toNames -> b) =
-  List.sortOn (\s -> (SR.name s, s)) (SR.fromNames b)
 
 -- | restores the full hash to these search results, for _numberedArgs purposes
 searchResultToHQString :: SearchResult -> String

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -11,6 +11,7 @@ module Unison.Codebase.Editor.Input
     Insistence (..),
     PullMode (..),
     OptionalPatch (..),
+    FindScope (..),
     IsGlobal,
   )
 where
@@ -158,7 +159,7 @@ data Input
   | -- Display docs for provided terms. If list is empty, prompt a fuzzy search.
     DocsI [Path.HQSplit']
   | -- other
-    FindI Bool IsGlobal [String] -- FindI isVerbose global query
+    FindI Bool FindScope [String] -- FindI isVerbose findScope query
   | FindShallowI Path'
   | FindPatchI
   | -- Show provided definitions. If list is empty, prompt a fuzzy search.
@@ -201,3 +202,9 @@ data OutputLocation
   | FileLocation FilePath
   -- ClipboardLocation
   deriving (Eq, Show)
+
+data FindScope
+  = Local
+  | LocalAndDeps
+  | Global
+  deriving stock (Eq, Show)

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -132,6 +132,7 @@ data Output v
   | LoadPullRequest ReadRemoteNamespace ReadRemoteNamespace Path' Path' Path' Path'
   | CreatedNewBranch Path.Absolute
   | BranchAlreadyExists Path'
+  | FindNoLocalMatches
   | PatchAlreadyExists Path.Split'
   | NoExactTypeMatches
   | TypeAlreadyExists Path.Split' (Set Reference)
@@ -306,6 +307,7 @@ isFailure o = case o of
   BadMainFunction {} -> True
   CreatedNewBranch {} -> False
   BranchAlreadyExists {} -> True
+  FindNoLocalMatches {} -> True
   PatchAlreadyExists {} -> True
   NoExactTypeMatches -> True
   BranchEmpty {} -> True

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -432,13 +432,16 @@ viewByPrefix =
     )
 
 find :: InputPattern
-find = find' "find" False
+find = find' "find" Input.Local
+
+findAll :: InputPattern
+findAll = find' "find.all" Input.LocalAndDeps
 
 findGlobal :: InputPattern
-findGlobal = find' "find.global" True
+findGlobal = find' "find.global" Input.Global
 
-find' :: String -> Bool -> InputPattern
-find' cmd global =
+find' :: String -> Input.FindScope -> InputPattern
+find' cmd fscope =
   InputPattern
     cmd
     []
@@ -448,18 +451,22 @@ find' cmd global =
         [ ("`find`", "lists all definitions in the current namespace."),
           ( "`find foo`",
             "lists all definitions with a name similar to 'foo' in the current "
-              <> "namespace."
+              <> "namespace. Falls back to `find.all` if no matches are found."
           ),
           ( "`find foo bar`",
             "lists all definitions with a name similar to 'foo' or 'bar' in the "
               <> "current namespace."
+          ),
+          ( "find.all foo",
+            "lists all definitions with a name similar to 'foo' in the current "
+              <> "namespace or direct dependencies."
           ),
           ( "find.global foo",
             "lists all definitions with a name similar to 'foo' in any namespace"
           )
         ]
     )
-    (pure . Input.FindI False global)
+    (pure . Input.FindI False fscope)
 
 findShallow :: InputPattern
 findShallow =
@@ -492,7 +499,7 @@ findVerbose =
     ( "`find.verbose` searches for definitions like `find`, but includes hashes "
         <> "and aliases in the results."
     )
-    (pure . Input.FindI True False)
+    (pure . Input.FindI True Input.Local)
 
 findPatch :: InputPattern
 findPatch =
@@ -2107,6 +2114,7 @@ validInputs =
       copyPatch,
       find,
       findGlobal,
+      findAll,
       findShallow,
       findVerbose,
       view,

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -493,13 +493,25 @@ findVerbose :: InputPattern
 findVerbose =
   InputPattern
     "find.verbose"
-    ["list.verbose", "ls.verbose"]
+    []
     I.Visible
     [(ZeroPlus, fuzzyDefinitionQueryArg)]
     ( "`find.verbose` searches for definitions like `find`, but includes hashes "
         <> "and aliases in the results."
     )
     (pure . Input.FindI True Input.Local)
+
+findVerboseAll :: InputPattern
+findVerboseAll =
+  InputPattern
+    "find.all.verbose"
+    []
+    I.Visible
+    [(ZeroPlus, fuzzyDefinitionQueryArg)]
+    ( "`find.all.verbose` searches for definitions like `find.all`, but includes hashes "
+        <> "and aliases in the results."
+    )
+    (pure . Input.FindI True Input.LocalAndDeps)
 
 findPatch :: InputPattern
 findPatch =
@@ -2117,6 +2129,7 @@ validInputs =
       findAll,
       findShallow,
       findVerbose,
+      findVerboseAll,
       view,
       display,
       displayTo,

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -451,15 +451,15 @@ find' cmd fscope =
         [ ("`find`", "lists all definitions in the current namespace."),
           ( "`find foo`",
             "lists all definitions with a name similar to 'foo' in the current "
-              <> "namespace. Falls back to `find.all` if no matches are found."
+              <> "namespace (excluding those under 'lib')."
           ),
           ( "`find foo bar`",
             "lists all definitions with a name similar to 'foo' or 'bar' in the "
-              <> "current namespace."
+              <> "current namespace (excluding those under 'lib')."
           ),
           ( "find.all foo",
             "lists all definitions with a name similar to 'foo' in the current "
-              <> "namespace or direct dependencies."
+              <> "namespace (including one level of 'lib')."
           ),
           ( "find.global foo",
             "lists all definitions with a name similar to 'foo' in any namespace"

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -650,6 +650,7 @@ notifyUser dir o = case o of
             P.indentN 2 $
               P.lines ["", cache, "", displayTestResults False ppe oks fails, "", "✅  "]
       where
+
     NewlyComputed -> do
       clearCurrentLine
       pure $
@@ -926,6 +927,8 @@ notifyUser dir o = case o of
           Input.UpdateI {} -> True
           _ -> False
      in pure $ SlurpResult.pretty isPast ppe s
+  FindNoLocalMatches ->
+    pure . P.callout "☝️" $ P.wrap "I couldn't find matches in this namespace, searching in 'lib'..."
   NoExactTypeMatches ->
     pure . P.callout "☝️" $ P.wrap "I couldn't find exact type matches, resorting to fuzzy matching..."
   TypeParseError src e ->
@@ -1675,11 +1678,11 @@ notifyUser dir o = case o of
   where
     _nameChange _cmd _pastTenseCmd _oldName _newName _r = error "todo"
     expectedEmptyPushDest writeRemotePath =
-        P.lines
-          [ "The remote namespace " <> prettyWriteRemotePath writeRemotePath <> " is not empty.",
-            "",
-            "Did you mean to use " <> IP.makeExample' IP.push <> " instead?"
-          ]
+      P.lines
+        [ "The remote namespace " <> prettyWriteRemotePath writeRemotePath <> " is not empty.",
+          "",
+          "Did you mean to use " <> IP.makeExample' IP.push <> " instead?"
+        ]
     expectedNonEmptyPushDest writeRemotePath =
       P.lines
         [ P.wrap ("The remote namespace " <> prettyWriteRemotePath writeRemotePath <> " is empty."),

--- a/unison-src/transcripts/empty-namespaces.md
+++ b/unison-src/transcripts/empty-namespaces.md
@@ -14,7 +14,7 @@ The deleted namespace shouldn't appear in `ls` output.
 .> ls
 ```
 ```ucm:error
-.> ls.verbose
+.> find.verbose
 ```
 ```ucm:error
 .> find mynamespace

--- a/unison-src/transcripts/empty-namespaces.output.md
+++ b/unison-src/transcripts/empty-namespaces.output.md
@@ -12,7 +12,12 @@ The deleted namespace shouldn't appear in `ls` output.
 
 ```
 ```ucm
-.> ls.verbose
+.> find.verbose
+
+  ☝️
+  
+  I couldn't find matches in this namespace, searching in
+  'lib'...
 
   😶
   
@@ -25,6 +30,11 @@ The deleted namespace shouldn't appear in `ls` output.
 ```
 ```ucm
 .> find mynamespace
+
+  ☝️
+  
+  I couldn't find matches in this namespace, searching in
+  'lib'...
 
   😶
   

--- a/unison-src/transcripts/find-command.md
+++ b/unison-src/transcripts/find-command.md
@@ -2,6 +2,7 @@
 foo = 1
 lib.foo = 2
 lib.bar = 3
+foo.lib.qux = 4
 ```
 
 ```ucm
@@ -18,4 +19,8 @@ lib.bar = 3
 
 ```ucm:error
 .> find baz
+```
+
+```ucm
+.> find qux
 ```

--- a/unison-src/transcripts/find-command.md
+++ b/unison-src/transcripts/find-command.md
@@ -1,0 +1,21 @@
+```unison
+foo = 1
+lib.foo = 2
+lib.bar = 3
+```
+
+```ucm
+.> add
+```
+
+```ucm
+.> find foo
+```
+
+```ucm:error
+.> find bar
+```
+
+```ucm:error
+.> find baz
+```

--- a/unison-src/transcripts/find-command.output.md
+++ b/unison-src/transcripts/find-command.output.md
@@ -2,6 +2,7 @@
 foo = 1
 lib.foo = 2
 lib.bar = 3
+foo.lib.qux = 4
 ```
 
 ```ucm
@@ -12,9 +13,10 @@ lib.bar = 3
   
     ⍟ These new definitions are ok to `add`:
     
-      foo     : ##Nat
-      lib.bar : ##Nat
-      lib.foo : ##Nat
+      foo         : ##Nat
+      foo.lib.qux : ##Nat
+      lib.bar     : ##Nat
+      lib.foo     : ##Nat
 
 ```
 ```ucm
@@ -22,15 +24,17 @@ lib.bar = 3
 
   ⍟ I've added these definitions:
   
-    foo     : ##Nat
-    lib.bar : ##Nat
-    lib.foo : ##Nat
+    foo         : ##Nat
+    foo.lib.qux : ##Nat
+    lib.bar     : ##Nat
+    lib.foo     : ##Nat
 
 ```
 ```ucm
 .> find foo
 
   1. foo : ##Nat
+  2. foo.lib.qux : ##Nat
   
 
 ```
@@ -61,5 +65,12 @@ lib.bar = 3
   
   `find.global` can be used to search outside the current
   namespace.
+
+```
+```ucm
+.> find qux
+
+  1. foo.lib.qux : ##Nat
+  
 
 ```

--- a/unison-src/transcripts/find-command.output.md
+++ b/unison-src/transcripts/find-command.output.md
@@ -1,0 +1,65 @@
+```unison
+foo = 1
+lib.foo = 2
+lib.bar = 3
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      foo     : ##Nat
+      lib.bar : ##Nat
+      lib.foo : ##Nat
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    foo     : ##Nat
+    lib.bar : ##Nat
+    lib.foo : ##Nat
+
+```
+```ucm
+.> find foo
+
+  1. foo : ##Nat
+  
+
+```
+```ucm
+.> find bar
+
+  ☝️
+  
+  I couldn't find matches in this namespace, searching in
+  'lib'...
+
+  1. lib.bar : ##Nat
+  
+
+```
+```ucm
+.> find baz
+
+  ☝️
+  
+  I couldn't find matches in this namespace, searching in
+  'lib'...
+
+  😶
+  
+  No results. Check your spelling, or try using tab completion
+  to supply command arguments.
+  
+  `find.global` can be used to search outside the current
+  namespace.
+
+```


### PR DESCRIPTION
#3144 

find searches the current namespace, but not "lib". Falls back to find.all if no results are found.
find.all searches the current namespace and direct dependencies in lib
find.global searches everything

I'm not sure how best to update the documentation, suggestions welcome.