### PR TITLE
Fix base-pull location

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
@@ -21,6 +21,10 @@ import qualified Unison.Codebase.Path as Path
 --
 -- >>> parseMaybe defaultBaseLib "latest-1234"
 -- Just (ReadShareRemoteNamespace {server = DefaultCodeserver, repo = "unison", path = public.base.main})
+--
+-- A version with the 'dirty' flag
+-- >>> parseMaybe defaultBaseLib "release/M3-409-gbcdf68db3'"
+-- Nothing
 defaultBaseLib :: Parsec Void Text ReadShareRemoteNamespace
 defaultBaseLib = fmap makeNS $ latest <|> release
   where
@@ -28,7 +32,9 @@ defaultBaseLib = fmap makeNS $ latest <|> release
     latest = "latest-" *> many anySingle *> eof $> "main"
     release = fmap ("releases._" <>) $ "release/" *> version <* eof
     version = do
-      Text.pack <$> some (alphaNumChar <|> ('_' <$ oneOf ['.', '_', '-']))
+      v <- Text.pack <$> some (alphaNumChar <|> ('_' <$ oneOf ['.', '_', '-']))
+      _dirty <- optional (char '\'')
+      pure v
     makeNS :: Text -> ReadShareRemoteNamespace
     makeNS t =
       ReadShareRemoteNamespace

--- a/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
@@ -20,12 +20,12 @@ import qualified Unison.Codebase.Path as Path
 -- Just (ReadShareRemoteNamespace {server = DefaultCodeserver, repo = "unison", path = public.base.releases._M1j_2})
 --
 -- >>> parseMaybe defaultBaseLib "latest-1234"
--- Just (ReadShareRemoteNamespace {server = DefaultCodeserver, repo = "unison", path = public.base.latest})
+-- Just (ReadShareRemoteNamespace {server = DefaultCodeserver, repo = "unison", path = public.base.main})
 defaultBaseLib :: Parsec Void Text ReadShareRemoteNamespace
 defaultBaseLib = fmap makeNS $ latest <|> release
   where
     latest, release, version :: Parsec Void Text Text
-    latest = "latest-" *> many anySingle *> eof $> "latest"
+    latest = "latest-" *> many anySingle *> eof $> "main"
     release = fmap ("releases._" <>) $ "release/" *> version <* eof
     version = do
       Text.pack <$> some (alphaNumChar <|> ('_' <$ oneOf ['.', '_', '-']))

--- a/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
@@ -14,18 +14,18 @@ import qualified Unison.Codebase.Path as Path
 -- | Parse git version strings into valid unison namespaces.
 --
 -- >>> parseMaybe defaultBaseLib "release/M1j"
--- Just (ReadShareRemoteNamespace {server = DefaultCodeserver, repo = "unison", path = public.dev.base.releases._M1j})
+-- Just (ReadShareRemoteNamespace {server = DefaultCodeserver, repo = "unison", path = public.base.releases._M1j})
 --
 -- >>> parseMaybe defaultBaseLib "release/M1j.2"
--- Just (ReadShareRemoteNamespace {server = DefaultCodeserver, repo = "unison", path = public.dev.base.releases._M1j_2})
+-- Just (ReadShareRemoteNamespace {server = DefaultCodeserver, repo = "unison", path = public.base.releases._M1j_2})
 --
 -- >>> parseMaybe defaultBaseLib "latest-1234"
--- Just (ReadShareRemoteNamespace {server = DefaultCodeserver, repo = "unison", path = public.dev.base.trunk})
+-- Just (ReadShareRemoteNamespace {server = DefaultCodeserver, repo = "unison", path = public.base.latest})
 defaultBaseLib :: Parsec Void Text ReadShareRemoteNamespace
 defaultBaseLib = fmap makeNS $ latest <|> release
   where
     latest, release, version :: Parsec Void Text Text
-    latest = "latest-" *> many anySingle *> eof $> "trunk"
+    latest = "latest-" *> many anySingle *> eof $> "latest"
     release = fmap ("releases._" <>) $ "release/" *> version <* eof
     version = do
       Text.pack <$> some (alphaNumChar <|> ('_' <$ oneOf ['.', '_', '-']))
@@ -34,5 +34,5 @@ defaultBaseLib = fmap makeNS $ latest <|> release
       ReadShareRemoteNamespace
         { server = DefaultCodeserver,
           repo = "unison",
-          path = "public" Path.:< "dev" Path.:< "base" Path.:< Path.fromText t
+          path = "public" Path.:< "base" Path.:< Path.fromText t
         }

--- a/unison-cli/src/Unison/CommandLine/Welcome.hs
+++ b/unison-cli/src/Unison/CommandLine/Welcome.hs
@@ -27,6 +27,7 @@ data Welcome = Welcome
 data DownloadBase
   = DownloadBase ReadShareRemoteNamespace
   | DontDownloadBase
+  deriving (Show, Eq)
 
 -- Previously Created is different from Previously Onboarded because a user can
 -- 1.) create a new codebase
@@ -35,6 +36,7 @@ data DownloadBase
 data CodebaseInitStatus
   = NewlyCreatedCodebase -- Can transition to [Base, Author, Finished]
   | PreviouslyCreatedCodebase -- Can transition to [Base, Author, Finished, PreviouslyOnboarded].
+  deriving (Show, Eq)
 
 data Onboarding
   = Init CodebaseInitStatus -- Can transition to [DownloadingBase, Author, Finished, PreviouslyOnboarded]
@@ -43,6 +45,7 @@ data Onboarding
   -- End States
   | Finished
   | PreviouslyOnboarded
+  deriving (Show, Eq)
 
 welcome :: CodebaseInitStatus -> DownloadBase -> FilePath -> Text -> Welcome
 welcome initStatus downloadBase filePath unisonVersion =

--- a/unison-cli/tests/Unison/Test/VersionParser.hs
+++ b/unison-cli/tests/Unison/Test/VersionParser.hs
@@ -15,7 +15,7 @@ test =
   scope "versionparser" . tests . fmap makeTest $
     [ ("release/M1j", "releases._M1j"),
       ("release/M1j.2", "releases._M1j_2"),
-      ("latest-abc", "latest"),
+      ("latest-abc", "main"),
       ("release/M2i_3", "releases._M2i_3"),
       ("release/M2i-HOTFIX", "releases._M2i_HOTFIX")
     ]

--- a/unison-cli/tests/Unison/Test/VersionParser.hs
+++ b/unison-cli/tests/Unison/Test/VersionParser.hs
@@ -15,7 +15,7 @@ test =
   scope "versionparser" . tests . fmap makeTest $
     [ ("release/M1j", "releases._M1j"),
       ("release/M1j.2", "releases._M1j_2"),
-      ("latest-abc", "trunk"),
+      ("latest-abc", "latest"),
       ("release/M2i_3", "releases._M2i_3"),
       ("release/M2i-HOTFIX", "releases._M2i_HOTFIX")
     ]
@@ -29,7 +29,7 @@ makeTest (version, path) =
           ( ReadShareRemoteNamespace
               { server = DefaultCodeserver,
                 repo = "unison",
-                path = Path.fromList ["public", "dev", "base"] <> Path.fromText path
+                path = Path.fromList ["public", "base"] <> Path.fromText path
               }
           )
       )

--- a/unison-cli/unison/Main.hs
+++ b/unison-cli/unison/Main.hs
@@ -13,9 +13,9 @@ import ArgParse
     Command (Init, Launch, PrintVersion, Run, Transcript),
     GlobalOptions (GlobalOptions, codebasePathOption, exitOption),
     IsHeadless (Headless, WithCLI),
-    ShouldExit(Exit, DoNotExit),
     RunSource (..),
     ShouldDownloadBase (..),
+    ShouldExit (DoNotExit, Exit),
     ShouldForkCodebase (..),
     ShouldSaveCodebase (..),
     UsageRenderer,
@@ -212,7 +212,7 @@ main = withCP65001 do
         getCodebaseOrExit mCodePathOption \(initRes, _, theCodebase) -> do
           runtime <- RTI.startRuntime RTI.Persistent Version.gitDescribeWithDate
           Server.startServer (Backend.BackendEnv {Backend.useNamesIndex = False}) codebaseServerOpts runtime theCodebase $ \baseUrl -> do
-            case exitOption of 
+            case exitOption of
               DoNotExit -> do
                 case isHeadless of
                   Headless -> do


### PR DESCRIPTION
Default location of base moved to `unison.public.base.(releases | latest)`