### PR TITLE
Downgrade haskeline (somehow it fixes ucm navigation issues on arm64)

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -59,6 +59,7 @@ extra-deps:
 - http-client-0.7.11
 # lts 18.28 provides 0.3.2.1 but we need at least 0.3.3
 - terminal-size-0.3.3
+- haskeline-0.8.1.3
 
 ghc-options:
  # All packages

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -123,6 +123,13 @@ packages:
     hackage: terminal-size-0.3.3@sha256:bd5f02333982bc8d6017db257b2a0b91870a295b4a37142a0c0525d8f533a48f,1255
   original:
     hackage: terminal-size-0.3.3
+- completed:
+    pantry-tree:
+      sha256: 90969690d0f9b49bdd6f02e5dd6ab005851f70c5778eff40043ce00cba655eaa
+      size: 2955
+    hackage: haskeline-0.8.1.3@sha256:a1ecc7bcaa959ecd751b2eec1c5466aa2db6697471d7e35ea8f1803faad8e985,6011
+  original:
+    hackage: haskeline-0.8.1.3
 snapshots:
 - completed:
     sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68


### PR DESCRIPTION
## Overview

I don't understand how, but it fixes ucm navigation issues on Apple M1 (arm64): #3183 

## Implementation notes

Downgrades version of haskeline:
- 0.8.2 -> 0.8.1.3

## Interesting/controversial decisions

Version 0.8.2 is supposed to also have the fix, but for some reason the bug manifests itself for me on that version.
