### PR TITLE
update push and pull `help` with new share / git() syntax

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -60,6 +60,7 @@ import Unison.Codebase.Editor.Output
 import qualified Unison.Codebase.Editor.Output as Output
 import qualified Unison.Codebase.Editor.Output.BranchDiff as OBranchDiff
 import qualified Unison.Codebase.Editor.Output.DumpNamespace as Output.DN
+import Unison.Codebase.Editor.Output.PushPull (PushPull (Pull, Push))
 import qualified Unison.Codebase.Editor.Propagate as Propagate
 import Unison.Codebase.Editor.RemoteRepo
   ( ReadGitRemoteNamespace (..),
@@ -721,8 +722,8 @@ loop = do
               case getAtSplit' dest of
                 Just existingDest
                   | not (Branch.isEmpty0 (Branch.head existingDest)) -> do
-                      -- Branch exists and isn't empty, print an error
-                      throwError (BranchAlreadyExists (Path.unsplit' dest))
+                    -- Branch exists and isn't empty, print an error
+                    throwError (BranchAlreadyExists (Path.unsplit' dest))
                 _ -> pure ()
               -- allow rewriting history to ensure we move the branch's history too.
               lift $
@@ -1410,11 +1411,11 @@ loop = do
               case filtered of
                 [(Referent.Ref ref, ty)]
                   | Typechecker.isSubtype ty mainType ->
-                      eval (MakeStandalone ppe ref output) >>= \case
-                        Just err -> respond $ EvaluationFailure err
-                        Nothing -> pure ()
+                    eval (MakeStandalone ppe ref output) >>= \case
+                      Just err -> respond $ EvaluationFailure err
+                      Nothing -> pure ()
                   | otherwise ->
-                      respond $ BadMainFunction smain ty ppe [mainType]
+                    respond $ BadMainFunction smain ty ppe [mainType]
                 _ -> respond $ NoMainFunction smain ppe [mainType]
             IOTestI main -> do
               -- todo - allow this to run tests from scratch file, using addRunMain
@@ -2652,10 +2653,10 @@ searchBranchScored names0 score queries =
             pair qn
           HQ.HashQualified qn h
             | h `SH.isPrefixOf` Referent.toShortHash ref ->
-                pair qn
+              pair qn
           HQ.HashOnly h
             | h `SH.isPrefixOf` Referent.toShortHash ref ->
-                Set.singleton (Nothing, result)
+              Set.singleton (Nothing, result)
           _ -> mempty
           where
             result = SR.termSearchResult names0 name ref
@@ -2672,10 +2673,10 @@ searchBranchScored names0 score queries =
             pair qn
           HQ.HashQualified qn h
             | h `SH.isPrefixOf` Reference.toShortHash ref ->
-                pair qn
+              pair qn
           HQ.HashOnly h
             | h `SH.isPrefixOf` Reference.toShortHash ref ->
-                Set.singleton (Nothing, result)
+              Set.singleton (Nothing, result)
           _ -> mempty
           where
             result = SR.typeSearchResult names0 name ref
@@ -3068,7 +3069,7 @@ docsI srcLoc prettyPrintNames src = do
           | Set.size s == 1 -> displayI prettyPrintNames ConsoleLocation dotDoc
           | Set.size s == 0 -> respond $ ListOfLinks mempty []
           | otherwise -> -- todo: return a list of links here too
-              respond $ ListOfLinks mempty []
+            respond $ ListOfLinks mempty []
 
 filterBySlurpResult ::
   Ord v =>

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -8,10 +8,8 @@ module Unison.Codebase.Editor.Output
     HistoryTail (..),
     TestReportStats (..),
     UndoFailureReason (..),
-    PushPull (..),
     ReflogEntry (..),
     ShareError (..),
-    pushPull,
     isFailure,
     isNumberedFailure,
   )
@@ -26,6 +24,7 @@ import qualified Unison.Codebase.Branch as Branch
 import Unison.Codebase.Editor.DisplayObject (DisplayObject)
 import Unison.Codebase.Editor.Input
 import Unison.Codebase.Editor.Output.BranchDiff (BranchDiffOutput)
+import Unison.Codebase.Editor.Output.PushPull (PushPull)
 import Unison.Codebase.Editor.RemoteRepo
 import Unison.Codebase.Editor.SlurpResult (SlurpResult (..))
 import qualified Unison.Codebase.Editor.SlurpResult as SR
@@ -75,13 +74,6 @@ type SourceName = Text
 type NumberedArgs = [String]
 
 type HashLength = Int
-
-data PushPull = Push | Pull deriving (Eq, Ord, Show)
-
-pushPull :: a -> a -> PushPull -> a
-pushPull push pull p = case p of
-  Push -> push
-  Pull -> pull
 
 data NumberedOutput v
   = ShowDiffNamespace AbsBranchId AbsBranchId PPE.PrettyPrintEnv (BranchDiffOutput v Ann)

--- a/unison-cli/src/Unison/Codebase/Editor/Output/PushPull.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output/PushPull.hs
@@ -1,0 +1,8 @@
+module Unison.Codebase.Editor.Output.PushPull where
+
+data PushPull = Push | Pull deriving (Eq, Ord, Show)
+
+fold :: a -> a -> PushPull -> a
+fold push pull p = case p of
+  Push -> push
+  Pull -> pull

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -22,6 +22,8 @@ import qualified Unison.Codebase.Branch.Merge as Branch
 import qualified Unison.Codebase.Branch.Names as Branch
 import Unison.Codebase.Editor.Input (Input)
 import qualified Unison.Codebase.Editor.Input as Input
+import Unison.Codebase.Editor.Output.PushPull (PushPull (Pull, Push))
+import qualified Unison.Codebase.Editor.Output.PushPull as PushPull
 import Unison.Codebase.Editor.RemoteRepo (ReadRemoteNamespace, WriteGitRepo, WriteRemotePath)
 import qualified Unison.Codebase.Editor.SlurpResult as SR
 import qualified Unison.Codebase.Editor.UriParser as UriParser
@@ -1021,7 +1023,7 @@ pullImpl name verbosity pullMode addendum = do
                   )
                 ],
               "",
-              explainRemote
+              explainRemote Pull
             ]
         )
         ( \case
@@ -1042,7 +1044,7 @@ pullExhaustive =
   InputPattern
     "debug.pull-exhaustive"
     []
-    I.Visible
+    I.Hidden
     [(Required, remoteNamespaceArg), (Optional, namespaceArg)]
     ( P.lines
         [ P.wrap $
@@ -1091,7 +1093,7 @@ push =
               )
             ],
           "",
-          explainRemote
+          explainRemote Push
         ]
     )
     ( \case
@@ -1132,7 +1134,7 @@ pushCreate =
               )
             ],
           "",
-          explainRemote
+          explainRemote Push
         ]
     )
     ( \case
@@ -1152,7 +1154,7 @@ pushExhaustive =
   InputPattern
     "debug.push-exhaustive"
     []
-    I.Visible
+    I.Hidden
     [(Required, remoteNamespaceArg), (Optional, namespaceArg)]
     ( P.lines
         [ P.wrap $
@@ -1192,8 +1194,8 @@ createPullRequest =
             "example: "
               <> makeExampleNoBackticks
                 createPullRequest
-                [ "https://github.com/unisonweb/base:.trunk",
-                  "https://github.com/me/unison:.prs.base._myFeature"
+                [ "unison.base.main",
+                  "myself.prs.base._myFeature"
                 ]
           ]
     )
@@ -2022,15 +2024,19 @@ gist =
         [ "Publish the current namespace.",
           "",
           P.wrapColumn2
-            [ ( "`gist remote`",
-                "publishes the contents of the current namespace into the repo `remote`."
+            [ ( "`gist git(git@github.com:user/repo)`",
+                "publishes the contents of the current namespace into the specified git repo."
               )
-            ]
+            ],
+          "",
+          P.indentN 2 . P.wrap $
+            "Note: Gists are not yet supported on Unison Share, though you can just do a normal"
+              <> "`push.create` of the current namespace to your Unison Share codebase wherever you like!"
         ]
     )
     ( \case
         [repoString] -> do
-          repo <- parseWriteGitRepo "repo" repoString
+          repo <- parseWriteGitRepo "gist git repo" repoString
           pure (Input.GistI (Input.GistInput repo))
         _ -> Left (showPatternHelp gist)
     )
@@ -2335,7 +2341,7 @@ noCompletions =
       globTargets = mempty
     }
 
--- Arya: I could imagine completions coming from previous git pulls
+-- Arya: I could imagine completions coming from previous pulls
 gitUrlArg :: ArgumentType
 gitUrlArg =
   ArgumentType
@@ -2374,18 +2380,21 @@ remoteNamespaceArg =
 collectNothings :: (a -> Maybe b) -> [a] -> [a]
 collectNothings f as = [a | (Nothing, a) <- map f as `zip` as]
 
-explainRemote :: P.Pretty CT.ColorText
-explainRemote =
-  P.lines
-    [ P.wrap "where `remote` is a git repository, optionally followed by `:`"
-        <> "and an absolute remote path, a branch, or both, such as:",
-      P.indentN 2 . P.lines $
-        [ P.backticked "https://github.com/org/repo",
-          P.backticked "https://github.com/org/repo:.some.remote.path",
-          P.backticked "https://github.com/org/repo:some-branch:.some.remote.path",
-          P.backticked "https://github.com/org/repo:some-branch"
-        ]
-    ]
+explainRemote :: PushPull -> P.Pretty CT.ColorText
+explainRemote pushPull =
+  P.group $
+    P.lines
+      [ P.wrap $ "where `remote` is a hosted codebase, such as:",
+        P.indentN 2 . P.column2 $
+          [ ("Unison Share", P.backticked "user.public.some.remote.path"),
+            ("Git + root", P.backticked $ "git(" <> gitRepo <> "user/repo)"),
+            ("Git + path", P.backticked $ "git(" <> gitRepo <> "user/repo).some.remote.path"),
+            ("Git + branch", P.backticked $ "git(" <> gitRepo <> "user/repo:some-branch)"),
+            ("Git + branch + path", P.backticked $ "git(" <> gitRepo <> "user/repo:some-branch).some.remote.path")
+          ]
+      ]
+  where
+    gitRepo = PushPull.fold @(P.Pretty P.ColorText) "git@github.com:" "https://github.com/" pushPull
 
 showErrorFancy :: P.ShowErrorComponent e => P.ErrorFancy e -> String
 showErrorFancy (P.ErrorFail msg) = msg

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -47,6 +47,7 @@ import Unison.Codebase.Editor.Output
 import qualified Unison.Codebase.Editor.Output as E
 import qualified Unison.Codebase.Editor.Output as Output
 import qualified Unison.Codebase.Editor.Output.BranchDiff as OBD
+import qualified Unison.Codebase.Editor.Output.PushPull as PushPull
 import Unison.Codebase.Editor.RemoteRepo
   ( ReadGitRepo,
     ReadRemoteNamespace,
@@ -1235,7 +1236,7 @@ notifyUser dir o = case o of
   NoConfiguredRemoteMapping pp p ->
     pure . P.fatalCallout . P.wrap $
       "I don't know where to "
-        <> pushPull "push to!" "pull from!" pp
+        <> PushPull.fold "push to!" "pull from!" pp
         <> ( if Path.isRoot p
                then ""
                else
@@ -1243,7 +1244,7 @@ notifyUser dir o = case o of
                    <> " = namespace.path' to .unisonConfig. "
            )
         <> "Type `help "
-        <> pushPull "push" "pull" pp
+        <> PushPull.fold "push" "pull" pp
         <> "` for more information."
   --  | ConfiguredGitUrlParseError PushPull Path' Text String
   ConfiguredRemoteMappingParseError pp p url err ->
@@ -1259,7 +1260,7 @@ notifyUser dir o = case o of
         P.string err,
         "",
         P.wrap $
-          "Type" <> P.backticked ("help " <> pushPull "push" "pull" pp)
+          "Type" <> P.backticked ("help " <> PushPull.fold "push" "pull" pp)
             <> "for more information."
       ]
   NoBranchWithHash _h ->
@@ -1675,11 +1676,11 @@ notifyUser dir o = case o of
   where
     _nameChange _cmd _pastTenseCmd _oldName _newName _r = error "todo"
     expectedEmptyPushDest writeRemotePath =
-        P.lines
-          [ "The remote namespace " <> prettyWriteRemotePath writeRemotePath <> " is not empty.",
-            "",
-            "Did you mean to use " <> IP.makeExample' IP.push <> " instead?"
-          ]
+      P.lines
+        [ "The remote namespace " <> prettyWriteRemotePath writeRemotePath <> " is not empty.",
+          "",
+          "Did you mean to use " <> IP.makeExample' IP.push <> " instead?"
+        ]
     expectedNonEmptyPushDest writeRemotePath =
       P.lines
         [ P.wrap ("The remote namespace " <> prettyWriteRemotePath writeRemotePath <> " is empty."),

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -42,6 +42,7 @@ library
       Unison.Codebase.Editor.Output
       Unison.Codebase.Editor.Output.BranchDiff
       Unison.Codebase.Editor.Output.DumpNamespace
+      Unison.Codebase.Editor.Output.PushPull
       Unison.Codebase.Editor.Propagate
       Unison.Codebase.Editor.Slurp
       Unison.Codebase.Editor.SlurpComponent


### PR DESCRIPTION
## Overview

Before:
<img width="705" alt="image" src="https://user-images.githubusercontent.com/538571/178544381-2f11544a-bed5-4ee5-a1f0-649c7c6c1481.png">

After:
<img width="713" alt="image" src="https://user-images.githubusercontent.com/538571/178544491-d840235c-c914-4bde-b4dd-a5a5092b7cde.png">

Before:
<img width="625" alt="image" src="https://user-images.githubusercontent.com/538571/178544643-6da23cd9-cb10-4816-9a78-7885ae145869.png">

After:
<img width="691" alt="image" src="https://user-images.githubusercontent.com/538571/178544838-5f2ea71b-06a3-44c9-ae4c-f4412953220c.png">

Closes #3177 

## Implementation notes

The PR contains 4 basic changes:

1. Rewrite the `explainRemote` helper with updated examples, and also change it to take a `PushPull` parameter, to show Github SSH examples in `push` help.
2. Move the `PushPull` type to its own module to support this.
3. Rename the `pushPull` function to `PushPull.fold`
4. Hide some M1 push/pull repair commands.

## Interesting/controversial decisions

On (4), they could probably just as well be deleted.

## Test coverage

Just the screenshots above.