### PR TITLE
Add `push.force` command

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/PushBehavior.hs
+++ b/parser-typechecker/src/Unison/Codebase/PushBehavior.hs
@@ -6,7 +6,9 @@ where
 
 -- | How a `push` behaves.
 data PushBehavior
-  = -- | The namespace being pushed to is required to be empty.
+  = -- Force-push over what's there.
+    ForcePush
+  | -- | The namespace being pushed to is required to be empty.
     RequireEmpty
   | -- | The namespace being pushed to is required to be non-empty
     RequireNonEmpty

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -761,7 +761,7 @@ pushGitBranch ::
   -- An action which accepts the current root branch on the remote and computes a new branch.
   (Branch m -> m (Either e (Branch m))) ->
   m (Either C.GitError (Either e (Branch m)))
-pushGitBranch srcConn repo (PushGitBranchOpts forcePush setRoot _syncMode) action = UnliftIO.try do
+pushGitBranch srcConn repo (PushGitBranchOpts behavior _syncMode) action = UnliftIO.try do
   -- Pull the latest remote into our git cache
   -- Use a local git clone to copy this git repo into a temp-dir
   -- Delete the codebase in our temp-dir
@@ -801,35 +801,32 @@ pushGitBranch srcConn repo (PushGitBranchOpts forcePush setRoot _syncMode) actio
       Sqlite.runReadOnlyTransaction srcConn \runSrc -> do
         Sqlite.runWriteTransaction destConn \runDest -> do
           _ <- syncInternal (syncProgress progressStateRef) runSrc runDest newBranch
-          when setRoot (overwriteRoot runDest codebaseStatus remotePath newBranch)
-    overwriteRoot ::
-      (forall a. Sqlite.Transaction a -> m a) ->
-      CodebaseStatus ->
-      FilePath ->
-      Branch m ->
-      m ()
-    overwriteRoot run codebaseStatus remotePath newBranch = do
-      let newBranchHash = Branch.headHash newBranch
-      case codebaseStatus of
-        ExistingCodebase -> do
-          when (not forcePush) do
-            -- the call to runDB "handles" the possible DB error by bombing
-            run Ops.loadRootCausalHash >>= \case
-              Nothing -> pure ()
-              Just oldRootHash -> do
-                run (CodebaseOps.before (Cv.causalHash2to1 oldRootHash) newBranchHash) >>= \case
-                  Nothing ->
-                    error $
-                      "I couldn't find the hash " ++ show newBranchHash
-                        ++ " that I just synced to the cached copy of "
-                        ++ repoString
-                        ++ " in "
-                        ++ show remotePath
-                        ++ "."
-                  Just False -> throwIO . C.GitProtocolError $ GitError.PushDestinationHasNewStuff repo
-                  Just True -> pure ()
-        CreatedCodebase -> pure ()
-      run (setRepoRoot newBranchHash)
+          let overwriteRoot forcePush = do
+                let newBranchHash = Branch.headHash newBranch
+                case codebaseStatus of
+                  ExistingCodebase -> do
+                    when (not forcePush) do
+                      -- the call to runDB "handles" the possible DB error by bombing
+                      runDest Ops.loadRootCausalHash >>= \case
+                        Nothing -> pure ()
+                        Just oldRootHash -> do
+                          runDest (CodebaseOps.before (Cv.causalHash2to1 oldRootHash) newBranchHash) >>= \case
+                            Nothing ->
+                              error $
+                                "I couldn't find the hash " ++ show newBranchHash
+                                  ++ " that I just synced to the cached copy of "
+                                  ++ repoString
+                                  ++ " in "
+                                  ++ show remotePath
+                                  ++ "."
+                            Just False -> throwIO . C.GitProtocolError $ GitError.PushDestinationHasNewStuff repo
+                            Just True -> pure ()
+                  CreatedCodebase -> pure ()
+                runDest (setRepoRoot newBranchHash)
+          case behavior of
+            C.GitPushBehaviorGist -> pure ()
+            C.GitPushBehaviorFf -> overwriteRoot False
+            C.GitPushBehaviorForce -> overwriteRoot True
     repoString = Text.unpack $ printWriteGitRepo repo
     setRepoRoot :: Branch.CausalHash -> Sqlite.Transaction ()
     setRepoRoot h = do

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -5,6 +5,7 @@ module Unison.Codebase.Type
   ( Codebase (..),
     CodebasePath,
     PushGitBranchOpts (..),
+    GitPushBehavior (..),
     GitError (..),
     SyncToDir,
     LocalOrRemote (..),
@@ -189,10 +190,24 @@ data LocalOrRemote
   deriving (Show, Eq, Ord)
 
 data PushGitBranchOpts = PushGitBranchOpts
-  { -- | Set the branch as root?
+  { -- | Should we perform a local `before` check, or just force-push?
+    forcePush :: Bool,
+    -- | Set the branch as root?
     setRoot :: Bool,
     syncMode :: SyncMode
   }
+
+data GitPushBehavior
+  = -- | Don't set root, just sync entities.
+    GitPushBehaviorGist
+  | -- | After syncing entities, do a fast-forward check, then set the root.
+    GitPushBehaviorFf
+  | -- | After syncing entities, just set the root (force-pushy).
+    GitPushBehaviorForce
+
+-- valid: dont set root,
+--        set root, fast-forward
+--        set root, force push
 
 data GitError
   = GitProtocolError GitProtocolError

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -190,10 +190,7 @@ data LocalOrRemote
   deriving (Show, Eq, Ord)
 
 data PushGitBranchOpts = PushGitBranchOpts
-  { -- | Should we perform a local `before` check, or just force-push?
-    forcePush :: Bool,
-    -- | Set the branch as root?
-    setRoot :: Bool,
+  { behavior :: GitPushBehavior,
     syncMode :: SyncMode
   }
 
@@ -204,10 +201,6 @@ data GitPushBehavior
     GitPushBehaviorFf
   | -- | After syncing entities, just set the root (force-pushy).
     GitPushBehaviorForce
-
--- valid: dont set root,
---        set root, fast-forward
---        set root, force push
 
 data GitError
   = GitProtocolError GitProtocolError

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -1,6 +1,7 @@
 module Unison.Codebase.Editor.Input
   ( Input (..),
     GistInput (..),
+    PushRemoteBranchInput (..),
     Event (..),
     OutputLocation (..),
     PatchPath,
@@ -81,7 +82,7 @@ data Input
   | PreviewMergeLocalBranchI Path' Path'
   | DiffNamespaceI BranchId BranchId -- old new
   | PullRemoteBranchI (Maybe ReadRemoteNamespace) Path' SyncMode PullMode Verbosity
-  | PushRemoteBranchI (Maybe WriteRemotePath) Path' PushBehavior SyncMode
+  | PushRemoteBranchI PushRemoteBranchInput
   | CreatePullRequestI ReadRemoteNamespace ReadRemoteNamespace
   | LoadPullRequestI ReadRemoteNamespace ReadRemoteNamespace Path'
   | ResetRootI (Either ShortBranchHash Path')
@@ -191,6 +192,17 @@ data Input
 -- | @"push.gist repo"@ pushes the contents of the current namespace to @repo@.
 data GistInput = GistInput
   { repo :: WriteGitRepo
+  }
+  deriving stock (Eq, Show)
+
+data PushRemoteBranchInput = PushRemoteBranchInput
+  { -- | The local path to push. If relative, it's resolved relative to the current path (`cd`).
+    localPath :: Path',
+    -- | The repo to push to. If missing, it is looked up in `.unisonConfig`.
+    maybeRemoteRepo :: Maybe WriteRemotePath,
+    -- | The push behavior (whether the remote branch is required to be empty or non-empty).
+    pushBehavior :: PushBehavior,
+    syncMode :: SyncMode
   }
   deriving stock (Eq, Show)
 

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1178,7 +1178,7 @@ pushCreate =
 pushForce :: InputPattern
 pushForce =
   InputPattern
-    "push.force"
+    "unsafe.force-push"
     []
     I.Visible
     [(Required, remoteNamespaceArg), (Optional, namespaceArg)]

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1096,14 +1096,28 @@ push =
     )
     ( \case
         [] ->
-          Right $ Input.PushRemoteBranchI Nothing Path.relativeEmpty' PushBehavior.RequireNonEmpty SyncMode.ShortCircuit
+          Right $
+            Input.PushRemoteBranchI
+              Input.PushRemoteBranchInput
+                { localPath = Path.relativeEmpty',
+                  maybeRemoteRepo = Nothing,
+                  pushBehavior = PushBehavior.RequireNonEmpty,
+                  syncMode = SyncMode.ShortCircuit
+                }
         url : rest -> do
           pushPath <- parseWriteRemotePath "remote-path" url
           p <- case rest of
             [] -> Right Path.relativeEmpty'
             [path] -> first fromString $ Path.parsePath' path
             _ -> Left (I.help push)
-          Right $ Input.PushRemoteBranchI (Just pushPath) p PushBehavior.RequireNonEmpty SyncMode.ShortCircuit
+          Right $
+            Input.PushRemoteBranchI
+              Input.PushRemoteBranchInput
+                { localPath = p,
+                  maybeRemoteRepo = Just pushPath,
+                  pushBehavior = PushBehavior.RequireNonEmpty,
+                  syncMode = SyncMode.ShortCircuit
+                }
     )
 
 pushCreate :: InputPattern
@@ -1137,14 +1151,28 @@ pushCreate =
     )
     ( \case
         [] ->
-          Right $ Input.PushRemoteBranchI Nothing Path.relativeEmpty' PushBehavior.RequireEmpty SyncMode.ShortCircuit
+          Right $
+            Input.PushRemoteBranchI
+              Input.PushRemoteBranchInput
+                { localPath = Path.relativeEmpty',
+                  maybeRemoteRepo = Nothing,
+                  pushBehavior = PushBehavior.RequireEmpty,
+                  syncMode = SyncMode.ShortCircuit
+                }
         url : rest -> do
           pushPath <- parseWriteRemotePath "remote-path" url
           p <- case rest of
             [] -> Right Path.relativeEmpty'
             [path] -> first fromString $ Path.parsePath' path
             _ -> Left (I.help push)
-          Right $ Input.PushRemoteBranchI (Just pushPath) p PushBehavior.RequireEmpty SyncMode.ShortCircuit
+          Right $
+            Input.PushRemoteBranchI
+              Input.PushRemoteBranchInput
+                { localPath = p,
+                  maybeRemoteRepo = Just pushPath,
+                  pushBehavior = PushBehavior.RequireEmpty,
+                  syncMode = SyncMode.ShortCircuit
+                }
     )
 
 pushExhaustive :: InputPattern
@@ -1165,14 +1193,28 @@ pushExhaustive =
     )
     ( \case
         [] ->
-          Right $ Input.PushRemoteBranchI Nothing Path.relativeEmpty' PushBehavior.RequireNonEmpty SyncMode.Complete
+          Right $
+            Input.PushRemoteBranchI
+              Input.PushRemoteBranchInput
+                { localPath = Path.relativeEmpty',
+                  maybeRemoteRepo = Nothing,
+                  pushBehavior = PushBehavior.RequireNonEmpty,
+                  syncMode = SyncMode.Complete
+                }
         url : rest -> do
           pushPath <- parseWriteRemotePath "remote-path" url
           p <- case rest of
             [] -> Right Path.relativeEmpty'
             [path] -> first fromString $ Path.parsePath' path
             _ -> Left (I.help push)
-          Right $ Input.PushRemoteBranchI (Just pushPath) p PushBehavior.RequireNonEmpty SyncMode.Complete
+          Right $
+            Input.PushRemoteBranchI
+              Input.PushRemoteBranchInput
+                { localPath = p,
+                  maybeRemoteRepo = Just pushPath,
+                  pushBehavior = PushBehavior.RequireNonEmpty,
+                  syncMode = SyncMode.Complete
+                }
     )
 
 createPullRequest :: InputPattern

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1175,6 +1175,40 @@ pushCreate =
                 }
     )
 
+pushForce :: InputPattern
+pushForce =
+  InputPattern
+    "push.force"
+    []
+    I.Visible
+    [(Required, remoteNamespaceArg), (Optional, namespaceArg)]
+    (P.wrap "Like `push`, but overwrites any remote namespace.")
+    ( \case
+        [] ->
+          Right $
+            Input.PushRemoteBranchI
+              Input.PushRemoteBranchInput
+                { localPath = Path.relativeEmpty',
+                  maybeRemoteRepo = Nothing,
+                  pushBehavior = PushBehavior.ForcePush,
+                  syncMode = SyncMode.ShortCircuit
+                }
+        url : rest -> do
+          pushPath <- parseWriteRemotePath "remote-path" url
+          p <- case rest of
+            [] -> Right Path.relativeEmpty'
+            [path] -> first fromString $ Path.parsePath' path
+            _ -> Left (I.help push)
+          Right $
+            Input.PushRemoteBranchI
+              Input.PushRemoteBranchInput
+                { localPath = p,
+                  maybeRemoteRepo = Just pushPath,
+                  pushBehavior = PushBehavior.ForcePush,
+                  syncMode = SyncMode.ShortCircuit
+                }
+    )
+
 pushExhaustive :: InputPattern
 pushExhaustive =
   InputPattern
@@ -2131,6 +2165,7 @@ validInputs =
       names False, -- names
       push,
       pushCreate,
+      pushForce,
       pull,
       pullWithoutHistory,
       pullSilent,

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1201,7 +1201,7 @@ pushForce =
   InputPattern
     "unsafe.force-push"
     []
-    I.Visible
+    I.Hidden
     [(Required, remoteNamespaceArg), (Optional, namespaceArg)]
     (P.wrap "Like `push`, but overwrites any remote namespace.")
     ( \case

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1531,6 +1531,7 @@ notifyUser dir o = case o of
            )
   RefusedToPush pushBehavior path ->
     (pure . P.warnCallout) case pushBehavior of
+      PushBehavior.ForcePush -> error "impossible: refused to push due to ForcePush?"
       PushBehavior.RequireEmpty -> expectedEmptyPushDest path
       PushBehavior.RequireNonEmpty -> expectedNonEmptyPushDest path
   GistCreated remoteNamespace ->


### PR DESCRIPTION
Paired with @tstat 

## Overview

This PR adds a `push.force` command, which gets the remote causal hash, and uses it in a follow-up check-and-set-push call.

TODO: bikeshed the naming/visibility of the command.