### PR TITLE
Hash filtering fix

### DIFF
--- a/unison-core/src/Unison/Names.hs
+++ b/unison-core/src/Unison/Names.hs
@@ -40,6 +40,7 @@ module Unison.Names
     typesNamed,
     unionLeft,
     unionLeftName,
+    unionLeftRef,
     namesForReference,
     namesForReferent,
     shadowTerms,
@@ -221,8 +222,13 @@ unionLeftName = unionLeft' $ const . R.memberDom
 -- e.g. unionLeftRef [foo -> #a, bar -> #a, cat -> #c]
 --                   [foo -> #b, baz -> #c]
 --                 = [foo -> #a, bar -> #a, foo -> #b, cat -> #c]
-_unionLeftRef :: Names -> Names -> Names
-_unionLeftRef = unionLeft' $ const R.memberRan
+unionLeftRef :: Names -> Names -> Names
+unionLeftRef (Names priorityTerms priorityTypes) (Names fallbackTerms fallbackTypes) =
+  Names (restricter priorityTerms fallbackTerms) (restricter priorityTypes fallbackTypes)
+  where
+    restricter priorityRel fallbackRel =
+      let refsExclusiveToFallback = (Relation.ran fallbackRel) `Set.difference` (Relation.ran priorityRel)
+       in priorityRel <> Relation.restrictRan fallbackRel refsExclusiveToFallback
 
 -- unionLeft two Names, but don't create new aliases or new name conflicts.
 -- e.g. unionLeft [foo -> #a, bar -> #a, cat -> #c]
@@ -239,12 +245,12 @@ unionLeft' ::
   Names ->
   Names ->
   Names
-unionLeft' p a b = Names terms' types'
+unionLeft' shouldOmit a b = Names terms' types'
   where
     terms' = foldl' go (terms a) (R.toList $ terms b)
     types' = foldl' go (types a) (R.toList $ types b)
     go :: (Ord a, Ord b) => Relation a b -> (a, b) -> Relation a b
-    go acc (n, r) = if p n r acc then acc else R.insert n r acc
+    go acc (n, r) = if shouldOmit n r acc then acc else R.insert n r acc
 
 -- | TODO: get this from database. For now it's a constant.
 numHashChars :: Int

--- a/unison-share-api/src/Unison/Server/Endpoints/FuzzyFind.hs
+++ b/unison-share-api/src/Unison/Server/Endpoints/FuzzyFind.hs
@@ -141,7 +141,7 @@ serveFuzzyFind codebase mayRoot relativePath limit typeWidth query =
       maybe mempty Path.fromPath'
         <$> traverse (parsePath . Text.unpack) relativePath
     rootHash <- traverse (Backend.expandShortBranchHash codebase) mayRoot
-    (localNamesOnly, ppe) <- Backend.scopedNamesForBranchHash codebase rootHash rel
+    (_parseNames, localNamesOnly, ppe) <- Backend.scopedNamesForBranchHash codebase rootHash rel
     let alignments ::
           ( [ ( FZF.Alignment,
                 UnisonName,

--- a/unison-share-api/src/Unison/Server/Endpoints/NamespaceDetails.hs
+++ b/unison-share-api/src/Unison/Server/Endpoints/NamespaceDetails.hs
@@ -95,7 +95,7 @@ namespaceDetails runtime codebase namespaceName maySBH mayWidth =
         namespaceCausal <- Backend.getShallowCausalAtPathFromRootHash codebase mayRootHash namespacePath
         shallowBranch <- lift $ V2Causal.value namespaceCausal
         namespaceDetails <- do
-          (_localNamesOnly, ppe) <- Backend.scopedNamesForBranchHash codebase mayRootHash namespacePath
+          (_parseNames, _localNamesOnly, ppe) <- Backend.scopedNamesForBranchHash codebase mayRootHash namespacePath
           readme <-
             Backend.findShallowReadmeInBranchAndRender
               width

--- a/unison-src/transcripts/api-getDefinition.output.md
+++ b/unison-src/transcripts/api-getDefinition.output.md
@@ -316,7 +316,81 @@ GET /api/getDefinition?names=%23qkhkl0n238&relativeTo=nested
 GET /api/getDefinition?names=%23qkhkl0n238&relativeTo=emptypath
 {
     "missingDefinitions": [],
-    "termDefinitions": {},
+    "termDefinitions": {
+        "#qkhkl0n238s1eqibd1ecb8605sqj1m4hpoaag177cu572otqlaf1u28c8suuuqgljdtthsjtr07rv04np05o6oa27ml9105k7uas0t8": {
+            "bestTermName": "x",
+            "defnTermTag": null,
+            "signature": [
+                {
+                    "annotation": {
+                        "contents": "##Nat",
+                        "tag": "TypeReference"
+                    },
+                    "segment": "Nat"
+                }
+            ],
+            "termDefinition": {
+                "contents": [
+                    {
+                        "annotation": {
+                            "contents": "x",
+                            "tag": "HashQualifier"
+                        },
+                        "segment": "x"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "TypeAscriptionColon"
+                        },
+                        "segment": " :"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "contents": "##Nat",
+                            "tag": "TypeReference"
+                        },
+                        "segment": "Nat"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "\n"
+                    },
+                    {
+                        "annotation": {
+                            "contents": "x",
+                            "tag": "HashQualifier"
+                        },
+                        "segment": "x"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "BindingEquals"
+                        },
+                        "segment": " ="
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "NumericLiteral"
+                        },
+                        "segment": "42"
+                    }
+                ],
+                "tag": "UserObject"
+            },
+            "termDocs": [],
+            "termNames": [
+                ".nested.names.x"
+            ]
+        }
+    },
     "typeDefinitions": {}
 }
 ```


### PR DESCRIPTION
## Overview

Currently trunk is filtering out hashes outside the current perspective, but it also means you can't click on terms which are outside of your perspective or you get this:

<img width="1066" alt="image" src="https://user-images.githubusercontent.com/6439644/178601362-9eaea10d-0832-46a2-9a6c-df6e6aaa115e.png">

This fixes that, while still preferring to load hashes within the current namespace if one is found.

After:

<img width="789" alt="image" src="https://user-images.githubusercontent.com/6439644/178777169-292c546d-a346-4ca6-ab59-d75730f84e66.png">


## Implementation notes

* Adds a new implementation for `unionLeftRef` which will only look into the fallback set of names if a name is missing from the primary
* Use this in the definition handler to get all the names of a hash within the current scope.
