### PR TITLE
"View it on Share" message

### DIFF
--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -40,6 +40,7 @@ dependencies:
   - memory
   - mtl
   - network-uri
+  - uri-encode
   - nonempty-containers
   - open-browser
   - pretty-simple

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1841,7 +1841,7 @@ doPushRemoteBranch pushFlavor localPath0 syncMode = do
         PushBehavior.RequireNonEmpty -> not (Branch.isEmpty0 (Branch.head remoteBranch))
 
 handlePushToUnisonShare :: (MonadUnliftIO m) => WriteShareRemotePath -> Path.Absolute -> PushBehavior -> Action' m v ()
-handlePushToUnisonShare WriteShareRemotePath {server, repo, path = remotePath} localPath behavior = do
+handlePushToUnisonShare remote@WriteShareRemotePath {server, repo, path = remotePath} localPath behavior = do
   let codeserver = Codeserver.resolveCodeserver server
   let baseURL = codeserverBaseURL codeserver
   let sharePath = Share.Path (repo Nel.:| pathToSegments remotePath)
@@ -1869,7 +1869,7 @@ handlePushToUnisonShare WriteShareRemotePath {server, repo, path = remotePath} l
           liftIO push >>= \case
             Left (Sync.SyncError err) -> respond (Output.ShareError (ShareErrorCheckAndSetPush err))
             Left (Sync.TransportError err) -> respond (Output.ShareError (ShareErrorTransport err))
-            Right () -> pure ()
+            Right () -> respond (ViewOnShare remote)
         PushBehavior.RequireNonEmpty -> do
           let push :: IO (Either (Sync.SyncError Share.FastForwardPushError) ())
               push = do
@@ -1884,7 +1884,7 @@ handlePushToUnisonShare WriteShareRemotePath {server, repo, path = remotePath} l
           liftIO push >>= \case
             Left (Sync.SyncError err) -> respond (Output.ShareError (ShareErrorFastForwardPush err))
             Left (Sync.TransportError err) -> respond (Output.ShareError (ShareErrorTransport err))
-            Right () -> pure ()
+            Right () -> respond (ViewOnShare remote)
   where
     pathToSegments :: Path -> [Text]
     pathToSegments =

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -203,6 +203,7 @@ data Output v
     BustedBuiltins (Set Reference) (Set Reference)
   | GitError GitError
   | ShareError ShareError
+  | ViewOnShare WriteShareRemotePath
   | ConfiguredMetadataParseError Path' String (P.Pretty P.ColorText)
   | NoConfiguredRemoteMapping PushPull Path.Absolute
   | ConfiguredRemoteMappingParseError PushPull Path.Absolute Text String
@@ -392,6 +393,7 @@ isFailure o = case o of
       NoIntegrityErrors -> False
       IntegrityErrorDetected {} -> True
   ShareError {} -> True
+  ViewOnShare {} -> False
 
 isNumberedFailure :: NumberedOutput v -> Bool
 isNumberedFailure = \case

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1751,13 +1751,16 @@ notifyUser dir o = case o of
 --      ns targets = P.oxfordCommas $
 --        map (fromString . Names.renderNameTarget) (toList targets)
 
+shareOrigin :: Text
+shareOrigin = "https://share.unison-lang.org"
+
 prettyShareLink :: WriteShareRemotePath -> Pretty
 prettyShareLink WriteShareRemotePath {repo, path} =
   let encodedPath =
         Path.toList path
           & fmap (URI.encodeText . NameSegment.toText)
           & Text.intercalate "/"
-   in P.green . P.text $ "https://share-next.unison-lang.org/users/" <> repo <> "/code/latest/namespaces/" <> encodedPath
+   in P.green . P.text $ shareOrigin <> "/users/" <> repo <> "/code/latest/namespaces/" <> encodedPath
 
 prettyFilePath :: FilePath -> Pretty
 prettyFilePath fp =

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -26,6 +26,7 @@ import Data.Tuple (swap)
 import Data.Tuple.Extra (dupe)
 import qualified Network.HTTP.Types as Http
 import Network.URI (URI)
+import qualified Network.URI.Encode as URI
 import qualified Servant.Client as Servant
 import System.Directory
   ( canonicalizePath,
@@ -106,6 +107,7 @@ import Unison.NamePrinter
     styleHashQualified',
   )
 import Unison.NameSegment (NameSegment (..))
+import qualified Unison.NameSegment as NameSegment
 import Unison.Names (Names (..))
 import qualified Unison.Names as Names
 import qualified Unison.NamesWithHistory as Names
@@ -644,8 +646,8 @@ notifyUser dir o = case o of
     CachedTests 0 _ -> pure . P.callout "😶" $ "No tests to run."
     CachedTests n n'
       | n == n' ->
-          pure $
-            P.lines [cache, "", displayTestResults True ppe oks fails]
+        pure $
+          P.lines [cache, "", displayTestResults True ppe oks fails]
     CachedTests _n m ->
       pure $
         if m == 0
@@ -654,7 +656,6 @@ notifyUser dir o = case o of
             P.indentN 2 $
               P.lines ["", cache, "", displayTestResults False ppe oks fails, "", "✅  "]
       where
-
     NewlyComputed -> do
       clearCurrentLine
       pure $
@@ -1692,6 +1693,9 @@ notifyUser dir o = case o of
         P.wrap $ P.text "The server said you don't have permission to read" <> P.group (prettySharePath sharePath <> ".")
       noWritePermission sharePath =
         P.wrap $ P.text "The server said you don't have permission to write" <> P.group (prettySharePath sharePath <> ".")
+  ViewOnShare repoPath ->
+    pure $
+      "View it on share: " <> prettyShareLink repoPath
   IntegrityCheck result -> pure $ case result of
     NoIntegrityErrors -> "🎉 No issues detected 🎉"
     IntegrityErrorDetected ns -> prettyPrintIntegrityErrors ns
@@ -1746,6 +1750,14 @@ notifyUser dir o = case o of
 --    where
 --      ns targets = P.oxfordCommas $
 --        map (fromString . Names.renderNameTarget) (toList targets)
+
+prettyShareLink :: WriteShareRemotePath -> Pretty
+prettyShareLink WriteShareRemotePath {repo, path} =
+  let encodedPath =
+        Path.toList path
+          & fmap (URI.encodeText . NameSegment.toText)
+          & Text.intercalate "/"
+   in P.green . P.text $ "https://share-next.unison-lang.org/users/" <> repo <> "/code/latest/namespaces/" <> encodedPath
 
 prettyFilePath :: FilePath -> Pretty
 prettyFilePath fp =
@@ -2316,7 +2328,7 @@ showDiffNamespace ::
   (Pretty, NumberedArgs)
 showDiffNamespace _ _ _ _ diffOutput
   | OBD.isEmpty diffOutput =
-      ("The namespaces are identical.", mempty)
+    ("The namespaces are identical.", mempty)
 showDiffNamespace sn ppe oldPath newPath OBD.BranchDiffOutput {..} =
   (P.sepNonEmpty "\n\n" p, toList args)
   where

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1695,7 +1695,7 @@ notifyUser dir o = case o of
         P.wrap $ P.text "The server said you don't have permission to write" <> P.group (prettySharePath sharePath <> ".")
   ViewOnShare repoPath ->
     pure $
-      "View it on share: " <> prettyShareLink repoPath
+      "View it on Unison Share: " <> prettyShareLink repoPath
   IntegrityCheck result -> pure $ case result of
     NoIntegrityErrors -> "🎉 No issues detected 🎉"
     IntegrityErrorDetected ns -> prettyPrintIntegrityErrors ns

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -150,6 +150,7 @@ library
     , unison-util-base32hex
     , unison-util-relation
     , unliftio
+    , uri-encode
     , vector
     , wai
     , warp
@@ -255,6 +256,7 @@ executable cli-integration-tests
     , unison-util-base32hex
     , unison-util-relation
     , unliftio
+    , uri-encode
     , vector
     , wai
     , warp
@@ -354,6 +356,7 @@ executable transcripts
     , unison-util-base32hex
     , unison-util-relation
     , unliftio
+    , uri-encode
     , vector
     , wai
     , warp
@@ -458,6 +461,7 @@ executable unison
     , unison-util-base32hex
     , unison-util-relation
     , unliftio
+    , uri-encode
     , vector
     , wai
     , warp
@@ -566,6 +570,7 @@ test-suite cli-tests
     , unison-util-base32hex
     , unison-util-relation
     , unliftio
+    , uri-encode
     , vector
     , wai
     , warp


### PR DESCRIPTION
## Overview

<img width="879" alt="image" src="https://user-images.githubusercontent.com/6439644/178768589-87117e53-a5e2-4af1-97c2-c7ae409831d2.png">

## Interesting/controversial decisions

Without a [discovery protocol implementation](https://github.com/unisonweb/unison/pull/3103) or something like it, we don't have an easy way to get the current share host for a given code-server, so I just hard-coded it for now.

We need to remember to change this when we move `share-next` -> `share`
