### PR TITLE
don't assume ucm trunk versions start with `latest-`

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
@@ -2,7 +2,6 @@
 
 module Unison.Codebase.Editor.VersionParser where
 
-import Data.Functor (($>))
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Void (Void)
@@ -26,10 +25,10 @@ import qualified Unison.Codebase.Path as Path
 -- >>> parseMaybe defaultBaseLib "release/M3-409-gbcdf68db3'"
 -- Nothing
 defaultBaseLib :: Parsec Void Text ReadShareRemoteNamespace
-defaultBaseLib = fmap makeNS $ latest <|> release
+defaultBaseLib = fmap makeNS $ release <|> unknown
   where
-    latest, release, version :: Parsec Void Text Text
-    latest = "latest-" *> many anySingle *> eof $> "main"
+    unknown, release, version :: Parsec Void Text Text
+    unknown = pure "main"
     release = fmap ("releases._" <>) $ "release/" *> version <* eof
     version = do
       v <- Text.pack <$> some (alphaNumChar <|> ('_' <$ oneOf ['.', '_', '-']))


### PR DESCRIPTION
closes #3233

UCM versions are (intentionally) based on `git describe` and hence sensitive to the git repo state.  When the welcome flow was written, `trunk` UCM builds tended to have a version number that began with `latest-`, but that won't necessarily be the case, and isn't the case today.

The result was that `Main.launch` was hitting this `DontDownloadBase` case instead of complaining about the unknown library:

https://github.com/unisonweb/unison/blob/265157b1697dbe96a9dd4aab7fff7e5e4a1372dc/unison-cli/unison/Main.hs#L391-L393

### Controversial decisions
Maybe line 393 should be an `error`?
