### PR TITLE
Ignore things with lib in their name in docs.to-html

### DIFF
--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -985,7 +985,9 @@ docsInBranchToHtmlFiles ::
 docsInBranchToHtmlFiles runtime codebase root currentPath directory = do
   let currentBranch = Branch.getAt' currentPath root
   let allTerms = (R.toList . Branch.deepTerms . Branch.head) currentBranch
-  docTermsWithNames <- filterM (isDoc codebase . fst) allTerms
+  -- ignores docs inside lib namespace, recursively
+  let notLib (_, name) = all (/= "lib") (Name.segments name)
+  docTermsWithNames <- filterM (isDoc codebase . fst) (filter notLib allTerms)
   let docNamesByRef = Map.fromList docTermsWithNames
   hqLength <- Codebase.hashLength codebase
   let printNames = prettyNamesForBranch root (AllNames currentPath)


### PR DESCRIPTION
`docs.to-html` now ignores stuff in `lib`. With this change I was able to run it successfully on the whole website codebase.

<img width="272" alt="image" src="https://user-images.githubusercontent.com/11074/178867825-742359c8-aa0f-40d6-8c4f-5c06da4d8a01.png">

<img width="244" alt="image" src="https://user-images.githubusercontent.com/11074/178867802-edf31bc9-415e-4022-8d58-05eeb6e0a2a0.png">

We might want to do something fancier with this command for later, but since it's mostly for our internal use I think this is fine as a quick thing.