### PR TITLE
add PRAGMA busy_timeout = 1000 to sqlite connections

### DIFF
--- a/lib/unison-sqlite/src/Unison/Sqlite/Connection.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Connection.hs
@@ -119,6 +119,7 @@ openConnection name file = do
   conn0 <- Sqlite.open file `catch` rethrowAsSqliteConnectException name file
   let conn = Connection {conn = conn0, file, name}
   execute_ conn "PRAGMA foreign_keys = ON"
+  execute_ conn "PRAGMA busy_timeout = 1000"
   pure conn
 
 -- Close a connection opened with 'openConnection'.


### PR DESCRIPTION
We were getting HTTP 500 errors from enlil during concurrent pull, possibly due to SQLITE_BUSY during WAL cleanup conflicting with an assumption of `runReadOnlyTransaction` that it will not encounter SQLITE_BUSY except in cases of programmer error.

Sqlite lets you install a simple timeout for SQLITE_BUSY with https://www.sqlite.org/pragma.html#pragma_busy_timeout, which we install here on every connection.

Travis and I verified (with a small test) that the busy handler is not invoked if SQLITE_BUSY is returned due to concurrent writers. So, it seems that we can set it on connection acquisition without worrying that it introduces an unnecessary delay for concurrent writers.