### PR TITLE
update version parser for new base release naming

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
@@ -12,24 +12,25 @@ import qualified Unison.Codebase.Path as Path
 
 -- | Parse git version strings into valid unison namespaces.
 --
--- >>> parseMaybe defaultBaseLib "release/M1j"
--- Just (ReadShareRemoteNamespace {server = DefaultCodeserver, repo = "unison", path = public.base.releases._M1j})
---
--- >>> parseMaybe defaultBaseLib "release/M1j.2"
--- Just (ReadShareRemoteNamespace {server = DefaultCodeserver, repo = "unison", path = public.base.releases._M1j_2})
---
--- >>> parseMaybe defaultBaseLib "latest-1234"
+-- >>> parseMaybe defaultBaseLib "release/M4"
+-- >>> parseMaybe defaultBaseLib "release/M4b"
+-- >>> parseMaybe defaultBaseLib "release/M4c.2"
+-- Just (ReadShareRemoteNamespace {server = DefaultCodeserver, repo = "unison", path = public.base.releases.M4})
+-- Just (ReadShareRemoteNamespace {server = DefaultCodeserver, repo = "unison", path = public.base.releases.M4b})
+-- Just (ReadShareRemoteNamespace {server = DefaultCodeserver, repo = "unison", path = public.base.releases.M4c_2})
+
+-- >>> parseMaybe defaultBaseLib "dev/M3-409-gbcdf68db3"
 -- Just (ReadShareRemoteNamespace {server = DefaultCodeserver, repo = "unison", path = public.base.main})
---
+
 -- A version with the 'dirty' flag
--- >>> parseMaybe defaultBaseLib "release/M3-409-gbcdf68db3'"
--- Nothing
+-- >>> parseMaybe defaultBaseLib "dev/M3-409-gbcdf68db3'"
+-- Just (ReadShareRemoteNamespace {server = DefaultCodeserver, repo = "unison", path = public.base.main})
 defaultBaseLib :: Parsec Void Text ReadShareRemoteNamespace
 defaultBaseLib = fmap makeNS $ release <|> unknown
   where
     unknown, release, version :: Parsec Void Text Text
-    unknown = pure "main"
-    release = fmap ("releases._" <>) $ "release/" *> version <* eof
+    unknown = pure "main" <* takeWhileP Nothing (const True) <* eof
+    release = fmap ("releases." <>) $ "release/" *> version <* eof
     version = do
       v <- Text.pack <$> some (alphaNumChar <|> ('_' <$ oneOf ['.', '_', '-']))
       _dirty <- optional (char '\'')

--- a/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
@@ -19,7 +19,7 @@ import qualified Unison.Codebase.Path as Path
 -- Just (ReadShareRemoteNamespace {server = DefaultCodeserver, repo = "unison", path = public.base.releases.M4b})
 -- Just (ReadShareRemoteNamespace {server = DefaultCodeserver, repo = "unison", path = public.base.releases.M4c_2})
 
--- >>> parseMaybe defaultBaseLib "dev/M3-409-gbcdf68db3"
+-- >>> parseMaybe defaultBaseLib "dev/M4-1-g22ccb0b3b"
 -- Just (ReadShareRemoteNamespace {server = DefaultCodeserver, repo = "unison", path = public.base.main})
 
 -- A version with the 'dirty' flag

--- a/unison-cli/tests/Unison/Test/VersionParser.hs
+++ b/unison-cli/tests/Unison/Test/VersionParser.hs
@@ -13,11 +13,12 @@ import qualified Unison.Codebase.Path as Path
 test :: Test ()
 test =
   scope "versionparser" . tests . fmap makeTest $
-    [ ("release/M1j", "releases._M1j"),
-      ("release/M1j.2", "releases._M1j_2"),
-      ("latest-abc", "main"),
-      ("release/M2i_3", "releases._M2i_3"),
-      ("release/M2i-HOTFIX", "releases._M2i_HOTFIX")
+    [ ("latest-abc", "main"),
+      ("dev/M4", "main"), -- or should this be "releases.M4"?
+      ("dev/M4-1-g22ccb0b3b", "main"), -- and should this also be "releases.m4"?
+      ("release/M4", "releases.M4"),
+      ("release/M2i_3", "releases.M2i_3"),
+      ("release/M2i-HOTFIX", "releases.M2i_HOTFIX")
     ]
 
 makeTest :: (Text, Text) -> Test ()


### PR DESCRIPTION
also fixed a bug in #3234 that caused doctests to fail