### PR TITLE
Don't expect patch LHS when git-syncing

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Sync22.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Sync22.hs
@@ -280,12 +280,6 @@ trySync hh runSrc runDest tCache hCache oCache cCache = \case
       oIds' <- traverse syncLocalObjectId oIds
       tIds' <- lift $ traverse syncTextLiteral tIds
       hIds' <- lift $ traverse syncHashLiteral hIds
-
-      -- workaround for requiring components to compute component lengths for references.
-      -- this line requires objects in the destination for any hashes referenced in the source,
-      -- (making those objects dependencies of this patch).  See Sync21.filter{Term,Type}Edit
-      traverse_ syncLocalObjectId =<< traverse (lift . runSrc . Q.expectObjectIdForAnyHashId) hIds
-
       pure $ PL.LocalIds tIds' hIds' oIds'
 
     syncBranchLocalIds :: BL.BranchLocalIds -> ValidateT (Set Entity) m BL.BranchLocalIds

--- a/unison-core/src/Unison/Reference.hs
+++ b/unison-core/src/Unison/Reference.hs
@@ -76,7 +76,7 @@ pattern Derived h i = DerivedId (Id h i)
 _DerivedId :: Prism' Reference Id
 _DerivedId = _Ctor @"DerivedId"
 
--- | @Pos@ is a position into a cycle of size @Size@, as cycles are hashed together.
+-- | @Pos@ is a position into a cycle, as cycles are hashed together.
 data Id = Id H.Hash Pos deriving (Eq, Ord)
 
 -- | A term reference.


### PR DESCRIPTION
## Overview

Paired with @aryairani and @tstat

This PR removes a bogus line from the git sync code that required the source codebase to contain objects for the LHS of a patch. It was necessary up until we removed the cycle size from `Reference`, but we only noticed the bug recently due to it being possible to acquire patches that refer to objects that one doesn't have locally (e.g. pull M4 from Share).

Fixes #3251 