### PR TITLE
delete unused root branch watching code

### DIFF
--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -45,7 +45,6 @@ module Unison.Codebase
     getRootBranchExists,
     getRootBranchHash,
     putRootBranch,
-    rootBranchUpdates,
     namesAtPath,
 
     -- * Patches

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -86,7 +86,6 @@ data Codebase m v a = Codebase
     getRootBranchExists :: m Bool,
     -- | Like 'putBranch', but also adjusts the root branch pointer afterwards.
     putRootBranch :: Branch m -> m (),
-    rootBranchUpdates :: m (IO (), IO (Set Branch.CausalHash)),
     getShallowBranchForHash :: V2.CausalHash -> m (V2.CausalBranch m),
     getBranchForHashImpl :: Branch.CausalHash -> m (Maybe (Branch m)),
     -- | Put a branch into the codebase, which includes its children, its patches, and the branch itself, if they don't

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -130,11 +130,6 @@ main dir welcome initialPath (config, cancelConfig) initialInputs runtime sbRunt
     numberedArgsRef <- newIORef []
     pageOutput <- newIORef True
     cancelFileSystemWatch <- watchFileSystem eventQueue dir
-    cancelWatchBranchUpdates <-
-      watchBranchUpdates
-        (readIORef rootRef)
-        eventQueue
-        codebase
     let patternMap :: Map String InputPattern
         patternMap =
           Map.fromList $
@@ -175,7 +170,6 @@ main dir welcome initialPath (config, cancelConfig) initialInputs runtime sbRunt
           Runtime.terminate sbRuntime
           cancelConfig
           cancelFileSystemWatch
-          cancelWatchBranchUpdates
         awaitInput :: IO (Either Event Input)
         awaitInput = do
           -- use up buffered input before consulting external events


### PR DESCRIPTION
## Overview

This PR deletes some unused root branch watching code. We may want to implement this feature some day, if we still have in-memory state when we decide that running multiple simultaneous UCMs should work, but it's not clear that any of the existing stubs are really worth keeping around for when/if that happens. Signed off by @aryairani 
