### PR TITLE
Fix issues with continuations and pending arguments

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/ANF.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF.hs
@@ -1016,7 +1016,7 @@ data Value
 
 data Cont
   = KE
-  | Mark [Reference] (Map Reference Value) Cont
+  | Mark Word64 Word64 [Reference] (Map Reference Value) Cont
   | Push Word64 Word64 Word64 Word64 GroupRef Cont
   deriving (Show)
 
@@ -1457,7 +1457,7 @@ valueLinks f (BLit l) = litLinks f l
 contLinks :: Monoid a => (Bool -> Reference -> a) -> Cont -> a
 contLinks f (Push _ _ _ _ (GR cr _) k) =
   f False cr <> contLinks f k
-contLinks f (Mark ps de k) =
+contLinks f (Mark _ _ ps de k) =
   foldMap (f True) ps
     <> Map.foldMapWithKey (\k c -> f True k <> valueLinks f c) de
     <> contLinks f k

--- a/parser-typechecker/src/Unison/Runtime/ANF/Serialize.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF/Serialize.hs
@@ -738,9 +738,10 @@ getCont v =
         <*> getMap getReference (getValue v)
         <*> getCont v
       where
-        maker | v == 1 = pure (Mark 0 0)
-              | v == 2 = Mark <$> getWord64be <*> getWord64be
-              | otherwise = fail $ "getCont: unknown version"
+        maker
+          | v == 1 = pure (Mark 0 0)
+          | v == 2 = Mark <$> getWord64be <*> getWord64be
+          | otherwise = fail $ "getCont: unknown version"
     PushT ->
       Push <$> getWord64be <*> getWord64be
         <*> getWord64be
@@ -765,10 +766,12 @@ serializeGroup fops sg = runPutS (putVersion *> putGroup fops sg)
 deserializeValue :: ByteString -> Either String Value
 deserializeValue bs = runGetS (getVersion >>= getValue) bs
   where
-    getVersion = getWord32be >>= \case
-      n | n < 1 -> fail $ "deserializeValue: unknown version: " ++ show n
-        | n <= 2 -> pure n
-        | otherwise -> fail $ "deserializeValue: unknown version: " ++ show n
+    getVersion =
+      getWord32be >>= \case
+        n
+          | n < 1 -> fail $ "deserializeValue: unknown version: " ++ show n
+          | n <= 2 -> pure n
+          | otherwise -> fail $ "deserializeValue: unknown version: " ++ show n
 
 serializeValue :: Value -> ByteString
 serializeValue v = runPutS (putVersion *> putValue v)

--- a/parser-typechecker/src/Unison/Runtime/Machine.hs
+++ b/parser-typechecker/src/Unison/Runtime/Machine.hs
@@ -138,8 +138,9 @@ infos ctx s = putStrLn $ ctx ++ ": " ++ s
 
 stk'info :: Stack 'BX -> IO ()
 stk'info s@(BS _ _ sp _) = do
-  let prn i | i < 0 = return ()
-            | otherwise = peekOff s i >>= print >> prn (i-1)
+  let prn i
+        | i < 0 = return ()
+        | otherwise = peekOff s i >>= print >> prn (i - 1)
   prn sp
 
 -- Entry point for evaluating a section

--- a/parser-typechecker/src/Unison/Runtime/Machine.hs
+++ b/parser-typechecker/src/Unison/Runtime/Machine.hs
@@ -136,6 +136,12 @@ info ctx x = infos ctx (show x)
 infos :: String -> String -> IO ()
 infos ctx s = putStrLn $ ctx ++ ": " ++ s
 
+stk'info :: Stack 'BX -> IO ()
+stk'info s@(BS _ _ sp _) = do
+  let prn i | i < 0 = return ()
+            | otherwise = peekOff s i >>= print >> prn (i-1)
+  prn sp
+
 -- Entry point for evaluating a section
 eval0 :: CCache -> ActiveThreads -> Section -> IO ()
 eval0 !env !activeThreads !co = do
@@ -154,7 +160,7 @@ topDEnv rfTy rfTm
     rcrf <- Builtin (DTx.pack "raise"),
     Just j <- M.lookup rcrf rfTm =
       ( EC.mapSingleton n (PAp (CIx rcrf j 0) unull bnull),
-        Mark (EC.setSingleton n) mempty
+        Mark 0 0 (EC.setSingleton n) mempty
       )
 topDEnv _ _ = (mempty, id)
 
@@ -243,9 +249,9 @@ exec !_ !denv !_activeThreads !ustk !bstk !k (SetDyn p i) = do
   clo <- peekOff bstk i
   pure (EC.mapInsert p clo denv, ustk, bstk, k)
 exec !_ !denv !_activeThreads !ustk !bstk !k (Capture p) = do
-  (sk, denv, ustk, bstk, useg, bseg, k) <- splitCont denv ustk bstk k p
+  (cap, denv, ustk, bstk, k) <- splitCont denv ustk bstk k p
   bstk <- bump bstk
-  poke bstk $ Captured sk useg bseg
+  poke bstk cap
   pure (denv, ustk, bstk, k)
 exec !_ !denv !_activeThreads !ustk !bstk !k (UPrim1 op i) = do
   ustk <- uprim1 ustk op i
@@ -405,7 +411,9 @@ exec !_ !denv !_activeThreads !ustk !bstk !k (Lit (MY r)) = do
   poke bstk (Foreign (Wrap Rf.typeLinkRef r))
   pure (denv, ustk, bstk, k)
 exec !_ !denv !_activeThreads !ustk !bstk !k (Reset ps) = do
-  pure (denv, ustk, bstk, Mark ps clos k)
+  (ustk, ua) <- saveArgs ustk
+  (bstk, ba) <- saveArgs bstk
+  pure (denv, ustk, bstk, Mark ua ba ps clos k)
   where
     clos = EC.restrictKeys denv ps
 exec !_ !denv !_activeThreads !ustk !bstk !k (Seq as) = do
@@ -452,7 +460,7 @@ eval !env !denv !activeThreads !ustk !bstk !k (Match i br) = do
   eval env denv activeThreads ustk bstk k $ selectBranch n br
 eval !env !denv !activeThreads !ustk !bstk !k (Yield args)
   | asize ustk + asize bstk > 0,
-    BArg1 i <- args = do
+    BArg1 i <- args =
       peekOff bstk i >>= apply env denv activeThreads ustk bstk k False ZArgs
   | otherwise = do
       (ustk, bstk) <- moveArgs ustk bstk args
@@ -603,14 +611,23 @@ jump ::
   Closure ->
   IO ()
 jump !env !denv !activeThreads !ustk !bstk !k !args clo = case clo of
-  Captured sk useg bseg -> do
+  Captured sk0 ua ba useg bseg -> do
+    let (up, bp, sk) = adjust sk0
     (useg, bseg) <- closeArgs K ustk bstk useg bseg args
     ustk <- discardFrame ustk
     bstk <- discardFrame bstk
-    ustk <- dumpSeg ustk useg . F $ ucount args
-    bstk <- dumpSeg bstk bseg . F $ bcount args
+    ustk <- dumpSeg ustk useg $ F (ucount args) ua
+    bstk <- dumpSeg bstk bseg $ F (bcount args) ba
+    ustk <- adjustArgs ustk up
+    bstk <- adjustArgs bstk bp
     repush env activeThreads ustk bstk denv sk k
   _ -> die "jump: non-cont"
+  where
+    adjust (Mark ua ba rs denv k) =
+      (0, 0, Mark (ua + asize ustk) (ba + asize bstk) rs denv k)
+    adjust (Push un bn ua ba cix k) =
+      (0, 0, Push un bn (ua + asize ustk) (ba + asize bstk) cix k)
+    adjust k = (asize ustk, asize bstk, k)
 {-# INLINE jump #-}
 
 repush ::
@@ -625,7 +642,7 @@ repush ::
 repush !env !activeThreads !ustk !bstk = go
   where
     go !denv KE !k = yield env denv activeThreads ustk bstk k
-    go !denv (Mark ps cs sk) !k = go denv' sk $ Mark ps cs' k
+    go !denv (Mark ua ba ps cs sk) !k = go denv' sk $ Mark ua ba ps cs' k
       where
         denv' = cs <> EC.withoutKeys denv ps
         cs' = EC.restrictKeys denv ps
@@ -1541,10 +1558,12 @@ yield ::
   IO ()
 yield !env !denv !activeThreads !ustk !bstk !k = leap denv k
   where
-    leap !denv0 (Mark ps cs k) = do
+    leap !denv0 (Mark ua ba ps cs k) = do
       let denv = cs <> EC.withoutKeys denv0 ps
           clo = denv0 EC.! EC.findMin ps
       poke bstk . DataB1 Rf.effectRef 0 =<< peek bstk
+      ustk <- adjustArgs ustk ua
+      bstk <- adjustArgs bstk ba
       apply env denv activeThreads ustk bstk k False (BArg1 0) clo
     leap !denv (Push ufsz bfsz uasz basz cix k) = do
       Lam _ _ uf bf nx <- combSection env cix
@@ -1580,27 +1599,31 @@ splitCont ::
   Stack 'BX ->
   K ->
   Word64 ->
-  IO (K, DEnv, Stack 'UN, Stack 'BX, Seg 'UN, Seg 'BX, K)
+  IO (Closure, DEnv, Stack 'UN, Stack 'BX, K)
 splitCont !denv !ustk !bstk !k !p =
-  walk denv (asize ustk) (asize bstk) KE k
+  walk denv uasz basz KE k
   where
+    uasz = asize ustk
+    basz = asize bstk
     walk !denv !usz !bsz !ck KE =
-      die "fell off stack" >> finish denv usz bsz ck KE
+      die "fell off stack" >> finish denv usz bsz 0 0 ck KE
     walk !denv !usz !bsz !ck (CB _) =
-      die "fell off stack" >> finish denv usz bsz ck KE
-    walk !denv !usz !bsz !ck (Mark ps cs k)
-      | EC.member p ps = finish denv' usz bsz ck k
-      | otherwise = walk denv' usz bsz (Mark ps cs' ck) k
+      die "fell off stack" >> finish denv usz bsz 0 0 ck KE
+    walk !denv !usz !bsz !ck (Mark ua ba ps cs k)
+      | EC.member p ps = finish denv' usz bsz ua ba ck k
+      | otherwise = walk denv' (usz + ua) (bsz + ba) (Mark ua ba ps cs' ck) k
       where
         denv' = cs <> EC.withoutKeys denv ps
         cs' = EC.restrictKeys denv ps
     walk !denv !usz !bsz !ck (Push un bn ua ba br k) =
       walk denv (usz + un + ua) (bsz + bn + ba) (Push un bn ua ba br ck) k
 
-    finish !denv !usz !bsz !ck !k = do
+    finish !denv !usz !bsz !ua !ba !ck !k = do
       (useg, ustk) <- grab ustk usz
       (bseg, bstk) <- grab bstk bsz
-      return (ck, denv, ustk, bstk, useg, bseg, k)
+      ustk <- adjustArgs ustk ua
+      bstk <- adjustArgs bstk ba
+      return (Captured ck uasz basz useg bseg, denv, ustk, bstk, k)
 {-# INLINE splitCont #-}
 
 discardCont ::
@@ -1612,7 +1635,7 @@ discardCont ::
   IO (DEnv, Stack 'UN, Stack 'BX, K)
 discardCont denv ustk bstk k p =
   splitCont denv ustk bstk k p
-    <&> \(_, denv, ustk, bstk, _, _, k) -> (denv, ustk, bstk, k)
+    <&> \(_, denv, ustk, bstk, k) -> (denv, ustk, bstk, k)
 {-# INLINE discardCont #-}
 
 resolve :: CCache -> DEnv -> Stack 'BX -> Ref -> IO Closure
@@ -1807,17 +1830,17 @@ reflectValue rty = goV
       ANF.Partial (goIx cix) (fromIntegral <$> ua) <$> traverse goV ba
     goV (DataC r t us bs) =
       ANF.Data r (maskTags t) (fromIntegral <$> us) <$> traverse goV bs
-    goV (CapV k us bs) =
+    goV (CapV k _ _ us bs) =
       ANF.Cont (fromIntegral <$> us) <$> traverse goV bs <*> goK k
     goV (Foreign f) = ANF.BLit <$> goF f
     goV BlackHole = die $ err "black hole"
 
     goK (CB _) = die $ err "callback continuation"
     goK KE = pure ANF.KE
-    goK (Mark ps de k) = do
+    goK (Mark ua ba ps de k) = do
       ps <- traverse refTy (EC.setToList ps)
       de <- traverse (\(k, v) -> (,) <$> refTy k <*> goV v) (mapToList de)
-      ANF.Mark ps (M.fromList de) <$> goK k
+      ANF.Mark (fromIntegral ua) (fromIntegral ba) ps (M.fromList de) <$> goK k
     goK (Push uf bf ua ba cix k) =
       ANF.Push
         (fromIntegral uf)
@@ -1880,16 +1903,21 @@ reifyValue0 (rty, rtm) = goV
       DataC r t (fromIntegral <$> us) <$> traverse goV bs
     goV (ANF.Cont us bs k) = cv <$> goK k <*> traverse goV bs
       where
-        cv k bs = CapV k (fromIntegral <$> us) bs
+        cv k bs = CapV k ua ba (fromIntegral <$> us) bs
+          where
+            (uksz, bksz) = frameDataSize k
+            ua = fromIntegral $ length us - uksz
+            ba = fromIntegral $ length bs - bksz
     goV (ANF.BLit l) = goL l
 
     goK ANF.KE = pure KE
-    goK (ANF.Mark ps de k) =
+    goK (ANF.Mark ua ba ps de k) =
       mrk <$> traverse refTy ps
         <*> traverse (\(k, v) -> (,) <$> refTy k <*> goV v) (M.toList de)
         <*> goK k
       where
-        mrk ps de k = Mark (setFromList ps) (mapFromList de) k
+        mrk ps de k =
+          Mark (fromIntegral ua) (fromIntegral ba) (setFromList ps) (mapFromList de) k
     goK (ANF.Push uf bf ua ba gr k) =
       Push
         (fromIntegral uf)
@@ -1929,8 +1957,10 @@ universalEq frn = eqc
       i1 == i2
         && eql (==) us1 us2
         && eql eqc bs1 bs2
-    eqc (CapV k1 us1 bs1) (CapV k2 us2 bs2) =
+    eqc (CapV k1 ua1 ba1 us1 bs1) (CapV k2 ua2 ba2 us2 bs2) =
       k1 == k2
+        && ua1 == ua2
+        && ba1 == ba2
         && eql (==) us1 us2
         && eql eqc bs1 bs2
     eqc (Foreign fl) (Foreign fr)
@@ -2041,8 +2071,10 @@ universalCompare frn = cmpc False
       compare i1 i2
         <> cmpl compare us1 us2
         <> cmpl (cmpc tyEq) bs1 bs2
-    cmpc _ (CapV k1 us1 bs1) (CapV k2 us2 bs2) =
+    cmpc _ (CapV k1 ua1 ba1 us1 bs1) (CapV k2 ua2 ba2 us2 bs2) =
       compare k1 k2
+        <> compare ua1 ua2
+        <> compare ba1 ba2
         <> cmpl compare us1 us2
         <> cmpl (cmpc True) bs1 bs2
     cmpc tyEq (Foreign fl) (Foreign fr)

--- a/parser-typechecker/src/Unison/Runtime/Stack.hs
+++ b/parser-typechecker/src/Unison/Runtime/Stack.hs
@@ -17,6 +17,7 @@ module Unison.Runtime.Stack
     Off,
     SZ,
     FP,
+    frameDataSize,
     marshalToForeign,
     unull,
     bnull,
@@ -73,6 +74,8 @@ data K
     CB Callback
   | -- mark continuation with a prompt
     Mark
+      !Int -- pending unboxed args
+      !Int -- pending boxed args
       !(EnumSet Word64)
       !(EnumMap Word64 Closure)
       !K
@@ -99,7 +102,8 @@ data Closure
   | DataB2 !Reference !Word64 !Closure !Closure
   | DataUB !Reference !Word64 !Int !Closure
   | DataG !Reference !Word64 !(Seg 'UN) !(Seg 'BX)
-  | Captured !K {-# UNPACK #-} !(Seg 'UN) !(Seg 'BX)
+  -- code cont, u/b arg size, u/b data stacks
+  | Captured !K !Int !Int {-# UNPACK #-} !(Seg 'UN) !(Seg 'BX)
   | Foreign !Foreign
   | BlackHole
   deriving (Show, Eq, Ord)
@@ -132,6 +136,13 @@ formData r t [] [x, y] = DataB2 r t x y
 formData r t [i] [x] = DataUB r t i x
 formData r t us bs = DataG r t (useg us) (L.fromList $ reverse bs)
 
+frameDataSize :: K -> (Int, Int)
+frameDataSize = go 0 0 where
+  go usz bsz KE = (usz, bsz)
+  go usz bsz (CB _) = (usz, bsz)
+  go usz bsz (Mark ua ba _ _ k) = go (usz + ua) (bsz + ba) k
+  go usz bsz (Push uf bf ua ba _ k) = go (usz + uf + ua) (bsz + bf + ba) k
+
 pattern DataC :: Reference -> Word64 -> [Int] -> [Closure] -> Closure
 pattern DataC rf ct us bs <-
   (splitData -> Just (rf, ct, us, bs))
@@ -144,11 +155,11 @@ pattern PApV ic us bs <-
   where
     PApV ic us bs = PAp ic (useg us) (L.fromList bs)
 
-pattern CapV :: K -> [Int] -> [Closure] -> Closure
-pattern CapV k us bs <-
-  Captured k (ints -> us) (L.toList -> bs)
+pattern CapV :: K -> Int -> Int -> [Int] -> [Closure] -> Closure
+pattern CapV k ua ba us bs <-
+  Captured k ua ba (ints -> us) (L.toList -> bs)
   where
-    CapV k us bs = Captured k (useg us) (L.fromList bs)
+    CapV k ua ba us bs = Captured k ua ba (useg us) (L.fromList bs)
 
 {-# COMPLETE DataC, PAp, Captured, Foreign, BlackHole #-}
 
@@ -256,16 +267,16 @@ bargOnto stk sp cop cp0 (ArgR i l) = do
   copyMutableArray cop (cp0 + 1) stk (sp - i - l + 1) l
   pure $ cp0 + l
 
-data Dump = A | F Int | S
+data Dump = A | F Int Int | S
 
 dumpAP :: Int -> Int -> Int -> Dump -> Int
-dumpAP _ fp sz d@(F _) = dumpFP fp sz d
+dumpAP _ fp sz d@(F _ a) = dumpFP fp sz d - a
 dumpAP ap _ _ _ = ap
 
 dumpFP :: Int -> Int -> Dump -> Int
 dumpFP fp _ S = fp
 dumpFP fp sz A = fp + sz
-dumpFP fp sz (F n) = fp + sz - n
+dumpFP fp sz (F n _) = fp + sz - n
 
 -- closure augmentation mode
 -- instruction, kontinuation, call
@@ -287,12 +298,14 @@ class MEM (b :: Mem) where
   duplicate :: Stack b -> IO (Stack b)
   discardFrame :: Stack b -> IO (Stack b)
   saveFrame :: Stack b -> IO (Stack b, SZ, SZ)
+  saveArgs :: Stack b -> IO (Stack b, SZ)
   restoreFrame :: Stack b -> SZ -> SZ -> IO (Stack b)
   prepareArgs :: Stack b -> Args' -> IO (Stack b)
   acceptArgs :: Stack b -> Int -> IO (Stack b)
   frameArgs :: Stack b -> IO (Stack b)
   augSeg :: Augment -> Stack b -> Seg b -> Maybe Args' -> IO (Seg b)
   dumpSeg :: Stack b -> Seg b -> Dump -> IO (Stack b)
+  adjustArgs :: Stack b -> SZ -> IO (Stack b)
   fsize :: Stack b -> SZ
   asize :: Stack b -> SZ
 
@@ -364,6 +377,9 @@ instance MEM 'UN where
   saveFrame (US ap fp sp stk) = pure (US sp sp sp stk, sp - fp, fp - ap)
   {-# INLINE saveFrame #-}
 
+  saveArgs (US ap fp sp stk) = pure (US fp fp sp stk, fp - ap)
+  {-# INLINE saveArgs #-}
+
   restoreFrame (US _ fp0 sp stk) fsz asz = pure $ US ap fp sp stk
     where
       fp = fp0 - fsz
@@ -415,6 +431,9 @@ instance MEM 'UN where
       fp' = dumpFP fp sz mode
       ap' = dumpAP ap fp sz mode
   {-# INLINE dumpSeg #-}
+
+  adjustArgs (US ap fp sp stk) sz = pure $ US (ap-sz) fp sp stk
+  {-# INLINE adjustArgs #-}
 
   fsize (US _ fp sp _) = sp - fp
   {-# INLINE fsize #-}
@@ -502,9 +521,10 @@ instance Show K where
     where
       go _ KE = "]"
       go _ (CB _) = "]"
-      go com (Push uf bf ua ba _ k) =
-        com ++ show (uf, bf, ua, ba) ++ go "," k
-      go com (Mark ps _ k) = com ++ "M" ++ show ps ++ go "," k
+      go com (Push uf bf ua ba ci k) =
+        com ++ show (uf, bf, ua, ba, ci) ++ go "," k
+      go com (Mark ua ba ps _ k) =
+        com ++ "M " ++ show ua ++ " " ++ show ba ++ " " ++ show ps ++ go "," k
 
 instance MEM 'BX where
   data Stack 'BX = BS
@@ -569,6 +589,9 @@ instance MEM 'BX where
   saveFrame (BS ap fp sp stk) = pure (BS sp sp sp stk, sp - fp, fp - ap)
   {-# INLINE saveFrame #-}
 
+  saveArgs (BS ap fp sp stk) = pure (BS fp fp sp stk, fp - ap)
+  {-# INLINE saveArgs #-}
+
   restoreFrame (BS _ fp0 sp stk) fsz asz = pure $ BS ap fp sp stk
     where
       fp = fp0 - fsz
@@ -618,6 +641,9 @@ instance MEM 'BX where
       ap' = dumpAP ap fp sz mode
   {-# INLINE dumpSeg #-}
 
+  adjustArgs (BS ap fp sp stk) sz = pure $ BS (ap-sz) fp sp stk
+  {-# INLINE adjustArgs #-}
+
   fsize (BS _ fp sp _) = sp - fp
   {-# INLINE fsize #-}
 
@@ -655,7 +681,7 @@ closureTermRefs f (DataB2 _ _ c1 c2) =
   closureTermRefs f c1 <> closureTermRefs f c2
 closureTermRefs f (DataUB _ _ _ c) =
   closureTermRefs f c
-closureTermRefs f (Captured k _ cs) =
+closureTermRefs f (Captured k _ _ _ cs) =
   contTermRefs f k <> foldMap (closureTermRefs f) cs
 closureTermRefs f (Foreign fo)
   | Just (cs :: Seq Closure) <- maybeUnwrapForeign Ty.listRef fo =
@@ -663,7 +689,7 @@ closureTermRefs f (Foreign fo)
 closureTermRefs _ _ = mempty
 
 contTermRefs :: Monoid m => (Reference -> m) -> K -> m
-contTermRefs f (Mark _ m k) =
+contTermRefs f (Mark _ _ _ m k) =
   foldMap (closureTermRefs f) m <> contTermRefs f k
 contTermRefs f (Push _ _ _ _ (CIx r _ _) k) =
   f r <> contTermRefs f k

--- a/unison-src/transcripts-using-base/fix3166.md
+++ b/unison-src/transcripts-using-base/fix3166.md
@@ -1,0 +1,77 @@
+```ucm:hide
+.> builtins.mergeio
+```
+
+This file tests some obscure issues involved with abilities and over-applied
+functions.
+
+```unison
+Stream.fromList : [a] -> '{Stream a} ()
+Stream.fromList l _ =
+  List.map (x -> emit x) l
+  ()
+
+Stream.map : (a -> b) -> '{Stream a} r -> '{Stream b} r
+Stream.map f stream = handle !stream with Stream.map.handler f
+
+Stream.map.handler : (a -> b) -> Request {Stream a} r -> '{Stream b} r
+Stream.map.handler f = cases 
+  {Stream.emit a -> resume} -> 'let
+    Stream.emit (f a)
+    Stream.map f resume ()
+  {r} -> 'r
+
+increment : Nat -> Nat
+increment n = 1 + n
+
+> Stream.toList (Stream.map increment (Stream.fromList [1,2,3]))
+
+> let
+    s1 = do emit 10 
+            emit 20
+            emit 30
+            emit 40
+    s2 = Stream.map (a -> a * 10) s1
+    Stream.toList s2 
+```
+
+```unison
+structural ability E where
+  eff : () -> ()
+
+hh : Request {E} (Nat ->{} r) -> Nat -> r
+hh = cases
+  {eff _ -> k} -> x -> h k x
+  {x} -> x
+
+h : '{E} (Nat -> r) -> Nat -> r
+h k = handle !k with hh
+
+foo : '{E} (Nat -> Nat)
+foo _ =
+  eff ()
+  x -> 7
+
+> h foo 337
+```
+
+```unison
+structural ability Over where
+  over : Nat ->{Over} (Nat -> Nat)
+
+hd = cases
+  {over m -> k} ->
+    handle k (n -> m + n) with hd
+  {x} -> x
+
+delegated _ =
+  handle over 5 with hd
+
+hmm =
+  x : Nat
+  x = delegated () 16789
+  trace "x" x
+  x
+
+> hmm
+```

--- a/unison-src/transcripts-using-base/fix3166.output.md
+++ b/unison-src/transcripts-using-base/fix3166.output.md
@@ -1,0 +1,145 @@
+This file tests some obscure issues involved with abilities and over-applied
+functions.
+
+```unison
+Stream.fromList : [a] -> '{Stream a} ()
+Stream.fromList l _ =
+  List.map (x -> emit x) l
+  ()
+
+Stream.map : (a -> b) -> '{Stream a} r -> '{Stream b} r
+Stream.map f stream = handle !stream with Stream.map.handler f
+
+Stream.map.handler : (a -> b) -> Request {Stream a} r -> '{Stream b} r
+Stream.map.handler f = cases 
+  {Stream.emit a -> resume} -> 'let
+    Stream.emit (f a)
+    Stream.map f resume ()
+  {r} -> 'r
+
+increment : Nat -> Nat
+increment n = 1 + n
+
+> Stream.toList (Stream.map increment (Stream.fromList [1,2,3]))
+
+> let
+    s1 = do emit 10 
+            emit 20
+            emit 30
+            emit 40
+    s2 = Stream.map (a -> a * 10) s1
+    Stream.toList s2 
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      Stream.fromList    : [a] -> '{Stream a} ()
+      Stream.map         : (a -> b)
+                           -> '{Stream a} r
+                           -> '{Stream b} r
+      Stream.map.handler : (a -> b)
+                           -> Request {Stream a} r
+                           -> '{Stream b} r
+      increment          : Nat -> Nat
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    19 | > Stream.toList (Stream.map increment (Stream.fromList [1,2,3]))
+           ⧩
+           [2, 3, 4]
+  
+    22 |     s1 = do emit 10 
+           ⧩
+           [100, 200, 300, 400]
+
+```
+```unison
+structural ability E where
+  eff : () -> ()
+
+hh : Request {E} (Nat ->{} r) -> Nat -> r
+hh = cases
+  {eff _ -> k} -> x -> h k x
+  {x} -> x
+
+h : '{E} (Nat -> r) -> Nat -> r
+h k = handle !k with hh
+
+foo : '{E} (Nat -> Nat)
+foo _ =
+  eff ()
+  x -> 7
+
+> h foo 337
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      structural ability E
+      foo : '{E} (Nat -> Nat)
+      h   : '{E} (Nat -> r) -> Nat -> r
+      hh  : Request {E} (Nat -> r) -> Nat -> r
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    17 | > h foo 337
+           ⧩
+           7
+
+```
+```unison
+structural ability Over where
+  over : Nat ->{Over} (Nat -> Nat)
+
+hd = cases
+  {over m -> k} ->
+    handle k (n -> m + n) with hd
+  {x} -> x
+
+delegated _ =
+  handle over 5 with hd
+
+hmm =
+  x : Nat
+  x = delegated () 16789
+  trace "x" x
+  x
+
+> hmm
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      structural ability Over
+      delegated : ∀ _. _ -> Nat -> Nat
+      hd        : Request {g, Over} x -> x
+      hmm       : Nat
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    18 | > hmm
+           ⧩
+           16794
+
+```


### PR DESCRIPTION
There were multiple problems with how the continuation operations worked related to over-applied functions. In either case, it would result in said arguments getting effectively removed from the stack, and the functions that were supposed to consume them would be under applied.

- When capturing a continuation, the pending arguments are captured.  However, how many there were was not recorded in the continuation.  When restoring the continuation, the stack should have as many pending  arguments as were originally captured, but we were just setting the  pending arguments to 0.
  * The number of arguments can be calculated from the captured  continuation, but storing the numbers is likely faster. The numbers are only discared and re-computed when moving to the serialized representation, which allows the storage format to remain the same.
- Similarly, it is possible to _restore_ a continuation while arguments are pending, in which case the restored continuation/stack as to account for that. The previous code wasn't.
- Also, since pending arguments are part of the continuation, Reset should block the capture of those arguments. Instead, the previous code was just leaving them in the pending position. The new code for Reset modifies the stack pointers, and records how many arguments  are pending in the continuation mark.
  * This information is not redundant, so the serialization format had to be modified. I've incremented the version and added support for parsing the old version, although those values could actually be erroneous.
