### PR TITLE
Fix a variable handling bug in the pattern compiler

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Pattern.hs
+++ b/parser-typechecker/src/Unison/Runtime/Pattern.hs
@@ -698,6 +698,8 @@ mkRow sv (MatchCase (normalizeSeqP -> p0) g0 (AbsN' vs b)) =
     g = case g0 of
       Just (AbsN' us g)
         | us == vs -> Just g
+        | length us == length vs ->
+            Just $ renames (Map.fromList (zip us vs)) g
         | otherwise ->
             internalBug "mkRow: guard variables do not match body"
       Nothing -> Nothing

--- a/unison-src/transcripts/fix3244.md
+++ b/unison-src/transcripts/fix3244.md
@@ -1,0 +1,21 @@
+```ucm:hide
+.> builtins.merge
+```
+
+This tests an previously erroneous case in the pattern compiler. It was assuming
+that the variables bound in a guard matched the variables bound in the rest of
+the branch exactly, but apparently this needn't be the case.
+
+```unison
+
+foo t =
+  (x, _) = t
+  f w = w + x
+
+  match t with
+    (x, y)
+      | y < 5 -> f x
+      | otherwise -> x + y
+
+> foo (10,20)
+```

--- a/unison-src/transcripts/fix3244.output.md
+++ b/unison-src/transcripts/fix3244.output.md
@@ -1,0 +1,35 @@
+This tests an previously erroneous case in the pattern compiler. It was assuming
+that the variables bound in a guard matched the variables bound in the rest of
+the branch exactly, but apparently this needn't be the case.
+
+```unison
+foo t =
+  (x, _) = t
+  f w = w + x
+
+  match t with
+    (x, y)
+      | y < 5 -> f x
+      | otherwise -> x + y
+
+> foo (10,20)
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      foo : (Nat, Nat) -> Nat
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    10 | > foo (10,20)
+           ⧩
+           30
+
+```


### PR DESCRIPTION
The pattern compiler was assuming that the variables bound in a guard always match those bound in the rest of the branch, but apparently that isn't the case. This fixes the case where they at least have the same length. I'm not sure what it would mean for them to _not_ have the same length, so an error is still reported in those cases.

Fixes #3244 