### PR TITLE
Avoid inferring duplicate concrete abilities

### DIFF
--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -38,7 +38,7 @@ module Unison.Typechecker.Context
   )
 where
 
-import Control.Lens (over, _2)
+import Control.Lens (over, _2, view)
 import qualified Control.Monad.Fail as MonadFail
 import Control.Monad.State
   ( MonadState,
@@ -54,7 +54,7 @@ import Data.Bifunctor
     second,
   )
 import qualified Data.Foldable as Foldable
-import Data.Functor.Compose (Compose (..))
+import Data.Function (on)
 import Data.List
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map as Map
@@ -65,7 +65,8 @@ import qualified Data.Set as Set
 import qualified Data.Text as Text
 import qualified Unison.ABT as ABT
 import qualified Unison.Blank as B
-import Unison.ConstructorReference (ConstructorReference, GConstructorReference (..))
+import Unison.ConstructorReference
+  (ConstructorReference, GConstructorReference (..), reference_)
 import Unison.DataDeclaration
   ( DataDeclaration,
     EffectDeclaration,
@@ -1258,13 +1259,14 @@ getEffect ref = do
 
 requestType ::
   Var v => Ord loc => [Pattern loc] -> M v loc (Maybe [Type v loc])
-requestType ps = getCompose . fmap fold $ traverse single ps
+requestType ps =
+  traverse (traverse getEffect . nubBy ((==) `on` view reference_)) $
+    Foldable.foldlM (\acc p -> (++ acc) <$> single p) [] ps
   where
     single (Pattern.As _ p) = single p
-    single Pattern.EffectPure {} = Compose . pure . Just $ []
-    single (Pattern.EffectBind _ ref _ _) =
-      Compose $ Just . pure <$> getEffect ref
-    single _ = Compose $ pure Nothing
+    single Pattern.EffectPure {} = Just []
+    single (Pattern.EffectBind _ ref _ _) = Just [ref]
+    single _ = Nothing
 
 checkCase ::
   forall v loc.

--- a/unison-src/transcripts/fix3215.md
+++ b/unison-src/transcripts/fix3215.md
@@ -1,0 +1,21 @@
+```ucm:hide
+.> builtins.merge
+```
+
+Tests a case where concrete abilities were appearing multiple times in an
+inferred type. This was due to the pre-pass that figures out which abilities
+are being matched on. It was just concatenating the ability for each pattern
+into a list, and not checking whether there were duplicates.
+
+```unison
+structural ability T where
+  nat : Nat
+  int : Int
+  flo : Float
+
+f = cases
+  {nat -> k} -> 5
+  {int -> k} -> 5
+  {flo -> k} -> 5
+  {x} -> 5
+```

--- a/unison-src/transcripts/fix3215.output.md
+++ b/unison-src/transcripts/fix3215.output.md
@@ -1,0 +1,30 @@
+Tests a case where concrete abilities were appearing multiple times in an
+inferred type. This was due to the pre-pass that figures out which abilities
+are being matched on. It was just concatenating the ability for each pattern
+into a list, and not checking whether there were duplicates.
+
+```unison
+structural ability T where
+  nat : Nat
+  int : Int
+  flo : Float
+
+f = cases
+  {nat -> k} -> 5
+  {int -> k} -> 5
+  {flo -> k} -> 5
+  {x} -> 5
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      structural ability T
+      f : Request {g, T} x -> Nat
+
+```


### PR DESCRIPTION
The pre-pass that figured out the abilities covered in a match was just putting them all in a list and not checking for redundancy.

Fixes #3215