### PR TITLE
Fix erroneous 'compiled' runtime state

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/MCode.hs
+++ b/parser-typechecker/src/Unison/Runtime/MCode.hs
@@ -37,7 +37,7 @@ where
 
 import Control.Applicative (liftA2)
 import Data.Bifunctor (bimap, first)
-import Data.Bits (shiftL, (.|.))
+import Data.Bits (shiftL, shiftR, (.|.))
 import Data.Coerce
 import Data.List (partition)
 import qualified Data.Map.Strict as M
@@ -1407,7 +1407,7 @@ sectionTypes (Match _ br) = branchTypes br
 sectionTypes _ = []
 
 instrTypes :: Instr -> [Word64]
-instrTypes (Pack _ w _) = [w]
+instrTypes (Pack _ w _) = [w `shiftR` 16]
 instrTypes _ = []
 
 branchDeps :: Branch -> [Word64]


### PR DESCRIPTION
When generating a saved runtime state, we would try to serialize all the
type information needed. However, we were actually filtering by the
packed tags instead of the type number. The packed tags have 48 bits of
type information followed by 16 bits of constructor tag, so the type
numbering would never actually match.

Fixes #3280