### PR TITLE
Request 'cloud' scope when authorizing

### DIFF
--- a/unison-cli/src/Unison/Auth/OAuth.hs
+++ b/unison-cli/src/Unison/Auth/OAuth.hs
@@ -101,7 +101,7 @@ authURI authEndpoint redirectURI state challenge =
     & addQueryParam "state" state
     & addQueryParam "redirect_uri" (BSC.pack redirectURI)
     & addQueryParam "response_type" "code"
-    & addQueryParam "scope" "openid"
+    & addQueryParam "scope" "openid cloud"
     & addQueryParam "client_id" ucmOAuthClientID
     & addQueryParam "code_challenge" challenge
     & addQueryParam "code_challenge_method" "S256"
@@ -130,10 +130,10 @@ exchangeCode httpClient tokenEndpoint code verifier redirectURI = liftIO $ do
   case HTTP.responseStatus resp of
     status
       | status < status300 -> do
-          let respBytes = HTTP.responseBody resp
-          pure $ case Aeson.eitherDecode @Tokens respBytes of
-            Left err -> Left (InvalidTokenResponse tokenEndpoint (Text.pack err))
-            Right a -> Right a
+        let respBytes = HTTP.responseBody resp
+        pure $ case Aeson.eitherDecode @Tokens respBytes of
+          Left err -> Left (InvalidTokenResponse tokenEndpoint (Text.pack err))
+          Right a -> Right a
       | otherwise -> pure $ Left (InvalidTokenResponse tokenEndpoint $ "Received " <> tShow status <> " response from token endpoint")
 
 addQueryParam :: ByteString -> ByteString -> URI -> URI

--- a/unison-cli/src/Unison/Auth/OAuth.hs
+++ b/unison-cli/src/Unison/Auth/OAuth.hs
@@ -101,7 +101,7 @@ authURI authEndpoint redirectURI state challenge =
     & addQueryParam "state" state
     & addQueryParam "redirect_uri" (BSC.pack redirectURI)
     & addQueryParam "response_type" "code"
-    & addQueryParam "scope" "openid cloud"
+    & addQueryParam "scope" "openid cloud sync"
     & addQueryParam "client_id" ucmOAuthClientID
     & addQueryParam "code_challenge" challenge
     & addQueryParam "code_challenge_method" "S256"


### PR DESCRIPTION
[Context](https://unisoncomputing.slack.com/archives/C02EB6BBPUH/p1658421280501789)

## Overview

Request the `cloud` and `sync` scopes when UCM authenticates. The backend will soon validate that a token has the correct scopes, see https://github.com/unisoncomputing/enlil/pull/73 .

The `sync` scope won't be validated yet, but we should probably do that soon (maybe after everyone's tokens have expired and been re-authed).

## Implementation notes

Simply requests the scope upon authorization, nothing in the user experience will change.

## Loose ends

We should add checks for the `sync` and `share` scopes in Enlil at some point, but no big rush.