### PR TITLE
Float local function definitions to their own reference during compilation

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/ANF.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF.hs
@@ -87,6 +87,7 @@ import qualified Unison.ABT.Normalized as ABTN
 import Unison.Blank (nameb)
 import qualified Unison.Builtin.Decls as Ty
 import Unison.ConstructorReference (ConstructorReference, GConstructorReference (..))
+import Unison.Hashing.V2.Convert (hashTermComponentsWithoutTypes)
 import Unison.Pattern (SeqOp (..))
 import qualified Unison.Pattern as P
 import Unison.Prelude hiding (Text)
@@ -346,17 +347,25 @@ floater top rec tm@(LamsNamed' vs bd)
     a = ABT.annotation tm
 floater _ _ _ = Nothing
 
-float :: (Var v, Monoid a) => Term v a -> (Term v a, [(v, Term v a)])
+float ::
+  Var v =>
+  Monoid a =>
+  Term v a ->
+  (Term v a, [(Reference, Term v a)], [(Reference, Term v a)])
 float tm = case runState go0 (Set.empty, [], []) of
-  (bd, (_, ctx, dcmp)) -> (deannotate $ letRec' True ctx bd, dcmp)
+  (bd, (_, ctx, dcmp)) -> let
+      m = hashTermComponentsWithoutTypes . Map.fromList $ fmap deannotate <$> ctx
+      trips = Map.toList m
+      f (v, (id, tm)) = ((v, id), (v, idtm), (id, tm))
+        where idtm = ref (ABT.annotation tm) (DerivedId id)
+      (subvs, subs, tops) = unzip3 $ map f trips
+      subm = Map.fromList subvs
+    in ( letRec' True [] . ABT.substs subs . deannotate $ bd
+       , fmap (first DerivedId) tops
+       , dcmp <&> \(v, tm) -> (DerivedId $ subm Map.! v, tm))
   where
     go0 = fromMaybe (go tm) (floater True go tm)
     go = ABT.visit $ floater False go
-
--- tm | LetRecNamedTop' _ vbs e <- tm0
---    , (pre, rec, post) <- reduceCycle vbs
---    = let1' False pre . letRec' False rec . let1' False post $ e
---    | otherwise = tm0
 
 unAnn :: Term v a -> Term v a
 unAnn (Ann' tm _) = tm
@@ -382,7 +391,11 @@ deannotate = ABT.visitPure $ \case
   Ann' c _ -> Just $ deannotate c
   _ -> Nothing
 
-lamLift :: (Var v, Monoid a) => Term v a -> (Term v a, [(v, Term v a)])
+lamLift ::
+  Var v =>
+  Monoid a =>
+  Term v a ->
+  (Term v a, [(Reference, Term v a)], [(Reference, Term v a)])
 lamLift = float . close Set.empty
 
 saturate ::

--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -274,16 +274,6 @@ backrefLifted ::
 backrefLifted ref (Tm.Ann' tm _) dcmp = backrefLifted ref tm dcmp
 backrefLifted ref tm dcmp =
   Map.fromList . (fmap.fmap) (Map.singleton 0) $ (ref,tm):dcmp
--- backrefLifted tm@(Tm.LetRecNamed' bs _) dcmp =
---   Map.fromList . ((0, tm) :) $
---     [ (ix, dc)
---       | ix <- ixs
---       | (v, _) <- reverse bs,
---         dc <- maybeToList $ Prelude.lookup v dcmp
---     ]
---   where
---     ixs = fmap (`shiftL` 16) [1 ..]
--- backrefLifted tm _ = Map.singleton 0 tm
 
 intermediateTerms ::
   HasCallStack =>

--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -273,7 +273,7 @@ backrefLifted ::
   Map.Map Reference (Map.Map Word64 (Term Symbol))
 backrefLifted ref (Tm.Ann' tm _) dcmp = backrefLifted ref tm dcmp
 backrefLifted ref tm dcmp =
-  Map.fromList . (fmap.fmap) (Map.singleton 0) $ (ref,tm):dcmp
+  Map.fromList . (fmap . fmap) (Map.singleton 0) $ (ref, tm) : dcmp
 
 intermediateTerms ::
   HasCallStack =>
@@ -284,7 +284,7 @@ intermediateTerms ::
     Map.Map Reference (Map.Map Word64 (Term Symbol))
   )
 intermediateTerms ppe ctx rtms =
-  foldMap (\(ref,tm) -> intermediateTerm ppe ref ctx tm) rtms
+  foldMap (\(ref, tm) -> intermediateTerm ppe ref ctx tm) rtms
 
 intermediateTerm ::
   HasCallStack =>
@@ -292,11 +292,11 @@ intermediateTerm ::
   Reference ->
   EvalCtx ->
   Term Symbol ->
-  ( Map.Map Reference (SuperGroup Symbol)
-  , Map.Map Reference (Map.Map Word64 (Term Symbol))
+  ( Map.Map Reference (SuperGroup Symbol),
+    Map.Map Reference (Map.Map Word64 (Term Symbol))
   )
 intermediateTerm ppe ref ctx tm =
-  (first.fmap)
+  (first . fmap)
     ( superNormalize
         . splitPatterns (dspec ctx)
         . addDefaultCases tmName
@@ -308,8 +308,9 @@ intermediateTerm ppe ref ctx tm =
     $ tm
   where
     memorize (ll, ctx, dcmp) =
-      ( Map.fromList $ (ref,ll):ctx
-      , backrefLifted ref tm dcmp)
+      ( Map.fromList $ (ref, ll) : ctx,
+        backrefLifted ref tm dcmp
+      )
     tmName = HQ.toString . termName ppe $ RF.Ref ref
 
 prepareEvaluation ::

--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -271,6 +271,7 @@ backrefLifted ::
   Term Symbol ->
   [(Reference, Term Symbol)] ->
   Map.Map Reference (Map.Map Word64 (Term Symbol))
+backrefLifted ref (Tm.Ann' tm _) dcmp = backrefLifted ref tm dcmp
 backrefLifted ref tm dcmp =
   Map.fromList . (fmap.fmap) (Map.singleton 0) $ (ref,tm):dcmp
 -- backrefLifted tm@(Tm.LetRecNamed' bs _) dcmp =
@@ -318,7 +319,7 @@ intermediateTerm ppe ref ctx tm =
   where
     memorize (ll, ctx, dcmp) =
       ( Map.fromList $ (ref,ll):ctx
-      , backrefLifted ref ll dcmp)
+      , backrefLifted ref tm dcmp)
     tmName = HQ.toString . termName ppe $ RF.Ref ref
 
 prepareEvaluation ::

--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -20,9 +20,9 @@ where
 import Control.Concurrent.STM as STM
 import Control.Exception (catch, try)
 import Control.Monad
-import Data.Bifunctor (bimap, first, second)
+import Data.Bifunctor (bimap, first)
 import Data.Binary.Get (runGetOrFail)
-import Data.Bits (shiftL)
+-- import Data.Bits (shiftL)
 import qualified Data.ByteString.Lazy as BL
 import Data.Bytes.Get (MonadGet)
 import Data.Bytes.Put (MonadPut, runPutL)
@@ -58,7 +58,7 @@ import qualified Unison.HashQualified as HQ
 import qualified Unison.Hashing.V2.Convert as Hashing
 import qualified Unison.LabeledDependency as RF
 import Unison.Parser.Ann (Ann (External))
-import Unison.Prelude (maybeToList, reportBug)
+import Unison.Prelude (reportBug)
 import Unison.PrettyPrintEnv
 import Unison.Reference (Reference)
 import qualified Unison.Reference as RF
@@ -260,40 +260,40 @@ loadDeps cl ppe ctx tyrs tmrs = do
   rtms <-
     traverse (\r -> (,) r <$> resolveTermRef cl r) $
       Prelude.filter q tmrs
-  let (rgrp, rbkr) = intermediateTerms ppe ctx rtms
+  let (rgrp0, rbkr) = intermediateTerms ppe ctx rtms
+      rgrp = Map.toList rgrp0
       tyAdd = Set.fromList $ fst <$> tyrs
   backrefAdd rbkr ctx
     <$ cacheAdd0 tyAdd rgrp (expandSandbox sand rgrp) cc
 
 backrefLifted ::
+  Reference ->
   Term Symbol ->
-  [(Symbol, Term Symbol)] ->
-  Map.Map Word64 (Term Symbol)
-backrefLifted tm@(Tm.LetRecNamed' bs _) dcmp =
-  Map.fromList . ((0, tm) :) $
-    [ (ix, dc)
-      | ix <- ixs
-      | (v, _) <- reverse bs,
-        dc <- maybeToList $ Prelude.lookup v dcmp
-    ]
-  where
-    ixs = fmap (`shiftL` 16) [1 ..]
-backrefLifted tm _ = Map.singleton 0 tm
+  [(Reference, Term Symbol)] ->
+  Map.Map Reference (Map.Map Word64 (Term Symbol))
+backrefLifted ref tm dcmp =
+  Map.fromList . (fmap.fmap) (Map.singleton 0) $ (ref,tm):dcmp
+-- backrefLifted tm@(Tm.LetRecNamed' bs _) dcmp =
+--   Map.fromList . ((0, tm) :) $
+--     [ (ix, dc)
+--       | ix <- ixs
+--       | (v, _) <- reverse bs,
+--         dc <- maybeToList $ Prelude.lookup v dcmp
+--     ]
+--   where
+--     ixs = fmap (`shiftL` 16) [1 ..]
+-- backrefLifted tm _ = Map.singleton 0 tm
 
 intermediateTerms ::
   HasCallStack =>
   PrettyPrintEnv ->
   EvalCtx ->
   [(Reference, Term Symbol)] ->
-  ( [(Reference, SuperGroup Symbol)],
+  ( Map.Map Reference (SuperGroup Symbol),
     Map.Map Reference (Map.Map Word64 (Term Symbol))
   )
 intermediateTerms ppe ctx rtms =
-  ((fmap . second) fst rint, Map.fromList $ (fmap . second) snd rint)
-  where
-    rint =
-      rtms <&> \(ref, tm) ->
-        (ref, intermediateTerm ppe ref ctx tm)
+  foldMap (\(ref,tm) -> intermediateTerm ppe ref ctx tm) rtms
 
 intermediateTerm ::
   HasCallStack =>
@@ -301,9 +301,11 @@ intermediateTerm ::
   Reference ->
   EvalCtx ->
   Term Symbol ->
-  (SuperGroup Symbol, Map.Map Word64 (Term Symbol))
+  ( Map.Map Reference (SuperGroup Symbol)
+  , Map.Map Reference (Map.Map Word64 (Term Symbol))
+  )
 intermediateTerm ppe ref ctx tm =
-  first
+  (first.fmap)
     ( superNormalize
         . splitPatterns (dspec ctx)
         . addDefaultCases tmName
@@ -314,7 +316,9 @@ intermediateTerm ppe ref ctx tm =
     . inlineAlias
     $ tm
   where
-    memorize (ll, dcmp) = (ll, backrefLifted ll dcmp)
+    memorize (ll, ctx, dcmp) =
+      ( Map.fromList $ (ref,ll):ctx
+      , backrefLifted ref ll dcmp)
     tmName = HQ.toString . termName ppe $ RF.Ref ref
 
 prepareEvaluation ::
@@ -341,7 +345,8 @@ prepareEvaluation ppe tm ctx = do
       | rmn <- RF.DerivedId $ Hashing.hashClosedTerm tm =
           (rmn, [(rmn, tm)])
 
-    (rgrp, rbkr) = intermediateTerms ppe ctx rtms
+    (rgrp0, rbkr) = intermediateTerms ppe ctx rtms
+    rgrp = Map.toList rgrp0
 
 watchHook :: IORef Closure -> Stack 'UN -> Stack 'BX -> IO ()
 watchHook r _ bstk = peek bstk >>= writeIORef r

--- a/parser-typechecker/tests/Unison/Test/ANF.hs
+++ b/parser-typechecker/tests/Unison/Test/ANF.hs
@@ -55,7 +55,7 @@ testLift s = case cs of !_ -> ok
     cs =
       emitCombs (RN (const 0) (const 0)) 0
         . superNormalize
-        . fst
+        . (\(ll,_,_) -> ll)
         . lamLift
         $ tm s
 

--- a/parser-typechecker/tests/Unison/Test/ANF.hs
+++ b/parser-typechecker/tests/Unison/Test/ANF.hs
@@ -55,7 +55,7 @@ testLift s = case cs of !_ -> ok
     cs =
       emitCombs (RN (const 0) (const 0)) 0
         . superNormalize
-        . (\(ll,_,_) -> ll)
+        . (\(ll, _, _) -> ll)
         . lamLift
         $ tm s
 
@@ -88,7 +88,7 @@ denormalize (TApp f args)
   | FCon r 0 <- f,
     r `elem` [Ty.natRef, Ty.intRef],
     [v] <- args =
-    Term.var () v
+      Term.var () v
 denormalize (TApp f args) = Term.apps' df (Term.var () <$> args)
   where
     df = case f of
@@ -120,16 +120,16 @@ denormalizeMatch ::
 denormalizeMatch b
   | MatchEmpty <- b = []
   | MatchIntegral m df <- b =
-    (dcase (ipat @Word64 @Integer Ty.intRef) <$> mapToList m) ++ dfcase df
+      (dcase (ipat @Word64 @Integer Ty.intRef) <$> mapToList m) ++ dfcase df
   | MatchText m df <- b =
-    (dcase (const @_ @Integer $ P.Text () . Util.Text.toText) <$> Map.toList m) ++ dfcase df
+      (dcase (const @_ @Integer $ P.Text () . Util.Text.toText) <$> Map.toList m) ++ dfcase df
   | MatchData r cs Nothing <- b,
     [(0, ([UN], zb))] <- mapToList cs,
     TAbs i (TMatch j (MatchIntegral m df)) <- zb,
     i == j =
-    (dcase (ipat @Word64 @Integer r) <$> mapToList m) ++ dfcase df
+      (dcase (ipat @Word64 @Integer r) <$> mapToList m) ++ dfcase df
   | MatchData r m df <- b =
-    (dcase (dpat r) . fmap snd <$> mapToList m) ++ dfcase df
+      (dcase (dpat r) . fmap snd <$> mapToList m) ++ dfcase df
   | MatchRequest hs df <- b = denormalizeHandler hs df
   | MatchSum _ <- b = error "MatchSum not a compilation target"
   where

--- a/parser-typechecker/tests/Unison/Test/MCode.hs
+++ b/parser-typechecker/tests/Unison/Test/MCode.hs
@@ -48,28 +48,6 @@ testEval0 env main = ok << io do
   apply0 Nothing cc Nothing (rtm Map.! mainRef)
   where (<<) = flip (>>)
 
-  -- modifyTVarTest (combs cc) (env <>)
-  -- modifyTVarTest (combRefs cc) ((dummyRef <$ env) <>)
-  -- ok
-
--- resolve :: Map Reference Word64 -> Reference -> Word64
--- resolve m r
---   | Builtin "todo" <- r = bit 64
---   | Just i <- Map.lookup r m = i
---   | otherwise = error $ "resolve: " ++ show r
-
--- cenv :: EnumMap Word64 Combs
--- cenv =
---   fmap
---     (emitComb numbering 0 mempty . (0,))
---     numberedTermLookup
-
--- env :: Combs -> EnumMap Word64 Combs
--- env m =
---   mapInsert (bit 24) m
---     . mapInsert (bit 64) (mapSingleton 0 $ Lam 0 1 2 1 asrt)
---     $ cenv
-
 asrt :: Section
 asrt =
   Ins (Unpack Nothing 0) $

--- a/parser-typechecker/tests/Unison/Test/MCode.hs
+++ b/parser-typechecker/tests/Unison/Test/MCode.hs
@@ -1,7 +1,7 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE BlockArguments #-}
 
 module Unison.Test.MCode where
 
@@ -10,9 +10,9 @@ import qualified Data.Map.Strict as Map
 import EasyTest
 import Unison.Reference (Reference (Builtin))
 import Unison.Runtime.ANF
-  ( lamLift,
+  ( SuperGroup (..),
+    lamLift,
     superNormalize,
-    SuperGroup (..),
   )
 import Unison.Runtime.MCode
   ( Args (..),
@@ -22,8 +22,8 @@ import Unison.Runtime.MCode
   )
 import Unison.Runtime.Machine
   ( CCache (..),
-    baseCCache,
     apply0,
+    baseCCache,
     cacheAdd,
   )
 import Unison.Runtime.Pattern
@@ -41,12 +41,14 @@ modifyTVarTest :: TVar a -> (a -> a) -> Test ()
 modifyTVarTest v f = io . atomically $ modifyTVar v f
 
 testEval0 :: [(Reference, SuperGroup Symbol)] -> SuperGroup Symbol -> Test ()
-testEval0 env main = ok << io do
-  cc <- baseCCache False
-  cacheAdd ((mainRef,main):env) cc
-  rtm <- readTVarIO (refTm cc)
-  apply0 Nothing cc Nothing (rtm Map.! mainRef)
-  where (<<) = flip (>>)
+testEval0 env main =
+  ok << io do
+    cc <- baseCCache False
+    cacheAdd ((mainRef, main) : env) cc
+    rtm <- readTVarIO (refTm cc)
+    apply0 Nothing cc Nothing (rtm Map.! mainRef)
+  where
+    (<<) = flip (>>)
 
 asrt :: Section
 asrt =

--- a/parser-typechecker/tests/Unison/Test/MCode.hs
+++ b/parser-typechecker/tests/Unison/Test/MCode.hs
@@ -1,72 +1,74 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE BlockArguments #-}
 
 module Unison.Test.MCode where
 
 import Control.Concurrent.STM
-import Data.Bits (bit)
 import qualified Data.Map.Strict as Map
-import Data.Word (Word64)
 import EasyTest
 import Unison.Reference (Reference (Builtin))
 import Unison.Runtime.ANF
   ( lamLift,
     superNormalize,
+    SuperGroup (..),
   )
-import Unison.Runtime.Builtin
 import Unison.Runtime.MCode
   ( Args (..),
     Branch (..),
-    Comb (..),
-    Combs,
     Instr (..),
-    RefNums (..),
     Section (..),
-    emitComb,
-    emitCombs,
   )
 import Unison.Runtime.Machine
   ( CCache (..),
     baseCCache,
-    eval0,
+    apply0,
+    cacheAdd,
   )
 import Unison.Runtime.Pattern
+import Unison.Symbol (Symbol)
 import Unison.Term (unannotate)
 import Unison.Test.Common (tm)
-import Unison.Util.EnumContainers as EC
 
 dummyRef :: Reference
 dummyRef = Builtin "dummy"
 
+mainRef :: Reference
+mainRef = Builtin "main"
+
 modifyTVarTest :: TVar a -> (a -> a) -> Test ()
 modifyTVarTest v f = io . atomically $ modifyTVar v f
 
-testEval0 :: EnumMap Word64 Combs -> Section -> Test ()
-testEval0 env sect = do
-  cc <- io (baseCCache False)
-  modifyTVarTest (combs cc) (env <>)
-  modifyTVarTest (combRefs cc) ((dummyRef <$ env) <>)
-  io $ eval0 cc Nothing sect
-  ok
+testEval0 :: [(Reference, SuperGroup Symbol)] -> SuperGroup Symbol -> Test ()
+testEval0 env main = ok << io do
+  cc <- baseCCache False
+  cacheAdd ((mainRef,main):env) cc
+  rtm <- readTVarIO (refTm cc)
+  apply0 Nothing cc Nothing (rtm Map.! mainRef)
+  where (<<) = flip (>>)
 
-builtins :: Reference -> Word64
-builtins r
-  | Builtin "todo" <- r = bit 64
-  | Just i <- Map.lookup r builtinTermNumbering = i
-  | otherwise = error $ "builtins: " ++ show r
+  -- modifyTVarTest (combs cc) (env <>)
+  -- modifyTVarTest (combRefs cc) ((dummyRef <$ env) <>)
+  -- ok
 
-cenv :: EnumMap Word64 Combs
-cenv =
-  fmap
-    (emitComb numbering 0 mempty . (0,))
-    numberedTermLookup
+-- resolve :: Map Reference Word64 -> Reference -> Word64
+-- resolve m r
+--   | Builtin "todo" <- r = bit 64
+--   | Just i <- Map.lookup r m = i
+--   | otherwise = error $ "resolve: " ++ show r
 
-env :: Combs -> EnumMap Word64 Combs
-env m =
-  mapInsert (bit 24) m
-    . mapInsert (bit 64) (mapSingleton 0 $ Lam 0 1 2 1 asrt)
-    $ cenv
+-- cenv :: EnumMap Word64 Combs
+-- cenv =
+--   fmap
+--     (emitComb numbering 0 mempty . (0,))
+--     numberedTermLookup
+
+-- env :: Combs -> EnumMap Word64 Combs
+-- env m =
+--   mapInsert (bit 24) m
+--     . mapInsert (bit 64) (mapSingleton 0 $ Lam 0 1 2 1 asrt)
+--     $ cenv
 
 asrt :: Section
 asrt =
@@ -84,20 +86,13 @@ multRec =
   \  f acc i = match i with\n\
   \    0 -> acc\n\
   \    _ -> f (##Nat.+ acc n) (##Nat.sub i 1)\n\
-  \  ##todo (##Nat.== (f 0 1000) 5000)"
-
-numbering :: RefNums
-numbering = RN (builtinTypeNumbering Map.!) builtins
+  \  if (##Nat.== (f 0 1000) 5000) then () else ##bug ()"
 
 testEval :: String -> Test ()
-testEval s = testEval0 (env aux) main
+testEval s = testEval0 (fmap superNormalize <$> ctx) (superNormalize ll)
   where
-    Lam 0 0 _ _ main = aux ! 0
-    aux =
-      emitCombs numbering (bit 24)
-        . superNormalize
-        . fst
-        . lamLift
+    (ll, ctx, _) =
+      lamLift
         . splitPatterns builtinDataSpec
         . unannotate
         $ tm s
@@ -108,7 +103,7 @@ nested =
   \  x = match 2 with\n\
   \        0 -> ##Nat.+ 0 1\n\
   \        m@n -> n\n\
-  \  ##todo (##Nat.== x 2)"
+  \  if (##Nat.== x 2) then () else ##bug ()"
 
 matching'arguments :: String
 matching'arguments =
@@ -122,18 +117,18 @@ matching'arguments =
   \    h = g a b\n\
   \    c = 2\n\
   \    h c\n\
-  \  ##todo (##Nat.== blorf 1)"
+  \  if (##Nat.== blorf 1) then () else ##bug ()"
 
 test :: Test ()
 test =
   scope "mcode" . tests $
-    [ scope "2=2" $ testEval "##todo (##Nat.== 2 2)",
-      scope "2=1+1" $ testEval "##todo (##Nat.== 2 (##Nat.+ 1 1))",
-      scope "2=3-1" $ testEval "##todo (##Nat.== 2 (##Nat.sub 3 1))",
+    [ scope "2=2" $ testEval "if (##Nat.== 2 2) then () else ##bug ()",
+      scope "2=1+1" $ testEval "if (##Nat.== 2 (##Nat.+ 1 1)) then () else ##bug ()",
+      scope "2=3-1" $ testEval "if (##Nat.== 2 (##Nat.sub 3 1)) then () else ##bug ()",
       scope "5*5=25" $
-        testEval "##todo (##Nat.== (##Nat.* 5 5) 25)",
+        testEval "if (##Nat.== (##Nat.* 5 5) 25) then () else ##bug ()",
       scope "5*1000=5000" $
-        testEval "##todo (##Nat.== (##Nat.* 5 1000) 5000)",
+        testEval "if (##Nat.== (##Nat.* 5 1000) 5000) then () else ##bug ()",
       scope "5*1000=5000 rec" $ testEval multRec,
       scope "nested" $
         testEval nested,

--- a/unison-src/transcripts/fix2053.output.md
+++ b/unison-src/transcripts/fix2053.output.md
@@ -1,12 +1,13 @@
 ```ucm
 .> display List.map
 
-  go f i as acc =
-    match List.at i as with
-      None   -> acc
-      Some a ->
-        use Nat +
-        go f (i + 1) as (acc :+ f a)
-  f a -> go f 0 a []
+  f a ->
+    go i as acc =
+      match List.at i as with
+        None   -> acc
+        Some a ->
+          use Nat +
+          go (i + 1) as (acc :+ f a)
+    go 0 a []
 
 ```


### PR DESCRIPTION
This PR implements a simple method of floating local function definitions to proper top-level combinators during compilation. Essentially it runs the old floater, then calls a function for hashing the letrec. This should make serialization and sandboxing more fine grained. Since a local pure function gets turned into its own reference, it shouldn't be flagged as sandboxed just because the enclosing function uses some I/O.

@aryairani Can you (or someone else who would know) check that I used the right hashing function? I used `hashTermComponentsWithoutTypes`, which seems like it's the only analogue of something I was using in the past for this sort of thing. However, it seems like an odd module for that functionality to be (something about converting between versions).