### PR TITLE
Enforce branch sharing and cache already loaded branches

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -58,6 +58,7 @@ import Unison.Codebase.Patch (Patch)
 import Unison.Codebase.Path (Path)
 import qualified Unison.Codebase.Reflog as Reflog
 import Unison.Codebase.ShortBranchHash (ShortBranchHash)
+import Unison.Codebase.SqliteCodebase.Branch.Cache (newTransactionBranchCache)
 import qualified Unison.Codebase.SqliteCodebase.Branch.Dependencies as BD
 import qualified Unison.Codebase.SqliteCodebase.Conversions as Cv
 import qualified Unison.Codebase.SqliteCodebase.GitError as GitError
@@ -196,6 +197,7 @@ sqliteCodebase debugName root localOrRemote action = do
   typeOfTermCache <- Cache.semispaceCache 8192
   declCache <- Cache.semispaceCache 1024
   rootBranchCache <- newTVarIO Nothing
+  branchCache <- newTransactionBranchCache
   getDeclType <- CodebaseOps.mkGetDeclType
   -- The v1 codebase interface has operations to read and write individual definitions
   -- whereas the v2 codebase writes them as complete components.  These two fields buffer
@@ -275,7 +277,7 @@ sqliteCodebase debugName root localOrRemote action = do
 
             getRootBranch :: TVar (Maybe (Sqlite.DataVersion, Branch Sqlite.Transaction)) -> m (Branch m)
             getRootBranch rootBranchCache =
-              Branch.transform runTransaction <$> runTransaction (CodebaseOps.getRootBranch getDeclType rootBranchCache)
+              Branch.transform runTransaction <$> runTransaction (CodebaseOps.getRootBranch branchCache getDeclType rootBranchCache)
 
             getRootBranchExists :: m Bool
             getRootBranchExists =
@@ -292,7 +294,7 @@ sqliteCodebase debugName root localOrRemote action = do
             -- to one that returns Maybe.
             getBranchForHash :: Branch.CausalHash -> m (Maybe (Branch m))
             getBranchForHash h =
-              fmap (Branch.transform runTransaction) <$> runTransaction (CodebaseOps.getBranchForHash getDeclType h)
+              fmap (Branch.transform runTransaction) <$> runTransaction (CodebaseOps.getBranchForHash branchCache getDeclType h)
 
             putBranch :: Branch m -> m ()
             putBranch branch =

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -58,7 +58,7 @@ import Unison.Codebase.Patch (Patch)
 import Unison.Codebase.Path (Path)
 import qualified Unison.Codebase.Reflog as Reflog
 import Unison.Codebase.ShortBranchHash (ShortBranchHash)
-import Unison.Codebase.SqliteCodebase.Branch.Cache (newTransactionBranchCache)
+import Unison.Codebase.SqliteCodebase.Branch.Cache (newBranchCache)
 import qualified Unison.Codebase.SqliteCodebase.Branch.Dependencies as BD
 import qualified Unison.Codebase.SqliteCodebase.Conversions as Cv
 import qualified Unison.Codebase.SqliteCodebase.GitError as GitError
@@ -197,7 +197,7 @@ sqliteCodebase debugName root localOrRemote action = do
   typeOfTermCache <- Cache.semispaceCache 8192
   declCache <- Cache.semispaceCache 1024
   rootBranchCache <- newTVarIO Nothing
-  branchCache <- newTransactionBranchCache
+  branchCache <- newBranchCache
   getDeclType <- CodebaseOps.mkGetDeclType
   -- The v1 codebase interface has operations to read and write individual definitions
   -- whereas the v2 codebase writes them as complete components.  These two fields buffer

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Branch/Cache.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Branch/Cache.hs
@@ -1,0 +1,47 @@
+module Unison.Codebase.SqliteCodebase.Branch.Cache where
+
+import qualified Data.Map as Map
+import qualified U.Codebase.HashTags as V2
+import qualified Unison.Codebase.Branch as V1.Branch
+import Unison.Prelude
+import qualified Unison.Sqlite as Sqlite
+import UnliftIO.STM
+
+-- type BranchCache m = V2.Branch.CausalBranch m -> m (V1.Branch.UnwrappedBranch m)
+data BranchCache' m n = BranchCache
+  { lookupCachedBranch :: V2.CausalHash -> m (Maybe (V1.Branch.Branch n)),
+    insertCachedBranch :: V2.CausalHash -> (V1.Branch.Branch n) -> m ()
+  }
+
+type BranchCache m = BranchCache' m m
+
+type TransactionBranchCache = BranchCache' Sqlite.Transaction Sqlite.Transaction
+
+newTransactionBranchCache :: Sqlite.Transaction TransactionBranchCache
+newTransactionBranchCache = Sqlite.unsafeIO do
+  BranchCache {lookupCachedBranch, insertCachedBranch} <- newBranchCache
+  pure $
+    BranchCache
+      { lookupCachedBranch = Sqlite.unsafeIO . lookupCachedBranch,
+        insertCachedBranch = \ch b -> Sqlite.unsafeIO $ insertCachedBranch ch b
+      }
+
+newBranchCache :: forall m n. MonadIO m => m (BranchCache' m n)
+newBranchCache = do
+  var <- newTVarIO mempty
+  pure $
+    BranchCache
+      { lookupCachedBranch = lookupCachedBranch' var,
+        insertCachedBranch = insertCachedBranch' var
+      }
+  where
+    lookupCachedBranch' :: TVar (Map V2.CausalHash (V1.Branch.Branch n)) -> V2.CausalHash -> m (Maybe (V1.Branch.Branch n))
+    lookupCachedBranch' var ch = do
+      cache <- readTVarIO var
+      let result = Map.lookup ch cache
+      when (isJust result) $ traceM "Branch Cache Hit"
+      pure result
+
+    insertCachedBranch' :: TVar (Map V2.CausalHash (V1.Branch.Branch n)) -> V2.CausalHash -> (V1.Branch.Branch n) -> m ()
+    insertCachedBranch' var ch b = do
+      atomically $ modifyTVar' var (Map.insert ch b)

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Branch/Cache.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Branch/Cache.hs
@@ -1,24 +1,24 @@
 module Unison.Codebase.SqliteCodebase.Branch.Cache where
 
 import qualified Data.Map as Map
+import System.Mem.Weak
 import qualified U.Codebase.HashTags as V2
 import qualified Unison.Codebase.Branch as V1.Branch
 import Unison.Prelude
 import qualified Unison.Sqlite as Sqlite
 import UnliftIO.STM
 
--- type BranchCache m = V2.Branch.CausalBranch m -> m (V1.Branch.UnwrappedBranch m)
 data BranchCache' m n = BranchCache
   { lookupCachedBranch :: V2.CausalHash -> m (Maybe (V1.Branch.Branch n)),
-    insertCachedBranch :: V2.CausalHash -> (V1.Branch.Branch n) -> m ()
+    insertCachedBranch :: V2.CausalHash -> V1.Branch.Branch n -> m ()
   }
 
 type BranchCache m = BranchCache' m m
 
 type TransactionBranchCache = BranchCache' Sqlite.Transaction Sqlite.Transaction
 
-newTransactionBranchCache :: Sqlite.Transaction TransactionBranchCache
-newTransactionBranchCache = Sqlite.unsafeIO do
+newTransactionBranchCache :: MonadIO m => m TransactionBranchCache
+newTransactionBranchCache = liftIO do
   BranchCache {lookupCachedBranch, insertCachedBranch} <- newBranchCache
   pure $
     BranchCache
@@ -35,13 +35,22 @@ newBranchCache = do
         insertCachedBranch = insertCachedBranch' var
       }
   where
-    lookupCachedBranch' :: TVar (Map V2.CausalHash (V1.Branch.Branch n)) -> V2.CausalHash -> m (Maybe (V1.Branch.Branch n))
-    lookupCachedBranch' var ch = do
+    lookupCachedBranch' :: TVar (Map V2.CausalHash (Weak (V1.Branch.Branch n))) -> V2.CausalHash -> m (Maybe (V1.Branch.Branch n))
+    lookupCachedBranch' var ch = liftIO do
       cache <- readTVarIO var
-      let result = Map.lookup ch cache
-      when (isJust result) $ traceM "Branch Cache Hit"
-      pure result
+      case Map.lookup ch cache of
+        Nothing -> pure Nothing
+        Just weakRef -> deRefWeak weakRef
 
-    insertCachedBranch' :: TVar (Map V2.CausalHash (V1.Branch.Branch n)) -> V2.CausalHash -> (V1.Branch.Branch n) -> m ()
-    insertCachedBranch' var ch b = do
-      atomically $ modifyTVar' var (Map.insert ch b)
+    insertCachedBranch' :: TVar (Map V2.CausalHash (Weak (V1.Branch.Branch n))) -> V2.CausalHash -> (V1.Branch.Branch n) -> m ()
+    insertCachedBranch' var ch b = liftIO do
+      -- It's worth reading the semantics of these operations.
+      -- We may in the future wish to instead keep the branch object alive for as long as the
+      -- CausalHash is alive, this is easy to do with 'mkWeak', but we'll start with only
+      -- keeping the branch alive as long as it's directly referenced.
+      wk <- mkWeakPtr b (Just $ removeDeadVal var ch)
+      atomically $ modifyTVar' var (Map.insert ch wk)
+
+    removeDeadVal :: TVar (Map V2.CausalHash (Weak (V1.Branch.Branch n))) -> V2.CausalHash -> IO ()
+    removeDeadVal var ch = liftIO do
+      atomically $ modifyTVar' var (Map.delete ch)

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -42,7 +42,7 @@ import Unison.Codebase.Patch (Patch)
 import Unison.Codebase.Path (Path)
 import qualified Unison.Codebase.Path as Path
 import Unison.Codebase.ShortBranchHash (ShortBranchHash)
-import Unison.Codebase.SqliteCodebase.Branch.Cache (TransactionBranchCache)
+import Unison.Codebase.SqliteCodebase.Branch.Cache (BranchCache)
 import qualified Unison.Codebase.SqliteCodebase.Conversions as Cv
 import Unison.ConstructorReference (GConstructorReference (..))
 import qualified Unison.ConstructorType as CT
@@ -344,7 +344,7 @@ tryFlushDeclBuffer termBuffer declBuffer =
 
 getRootBranch ::
   -- | A 'getDeclType'-like lookup, possibly backed by a cache.
-  TransactionBranchCache ->
+  BranchCache Sqlite.Transaction ->
   (C.Reference.Reference -> Transaction CT.ConstructorType) ->
   TVar (Maybe (Sqlite.DataVersion, Branch Transaction)) ->
   Transaction (Branch Transaction)
@@ -373,7 +373,7 @@ getRootBranch branchCache doGetDeclType rootBranchCache =
       pure branch1
 
 uncachedLoadRootBranch ::
-  TransactionBranchCache ->
+  BranchCache Sqlite.Transaction ->
   (C.Reference.Reference -> Sqlite.Transaction CT.ConstructorType) ->
   Transaction (Branch Transaction)
 uncachedLoadRootBranch branchCache getDeclType = do
@@ -395,7 +395,7 @@ putRootBranch rootBranchCache branch1 = do
 -- to one that returns Maybe.
 getBranchForHash ::
   -- | A 'getDeclType'-like lookup, possibly backed by a cache.
-  TransactionBranchCache ->
+  BranchCache Sqlite.Transaction ->
   (C.Reference.Reference -> Transaction CT.ConstructorType) ->
   Branch.CausalHash ->
   Transaction (Maybe (Branch Transaction))

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -42,6 +42,7 @@ import Unison.Codebase.Patch (Patch)
 import Unison.Codebase.Path (Path)
 import qualified Unison.Codebase.Path as Path
 import Unison.Codebase.ShortBranchHash (ShortBranchHash)
+import Unison.Codebase.SqliteCodebase.Branch.Cache (newTransactionBranchCache)
 import qualified Unison.Codebase.SqliteCodebase.Conversions as Cv
 import Unison.ConstructorReference (GConstructorReference (..))
 import qualified Unison.ConstructorType as CT
@@ -375,7 +376,8 @@ uncachedLoadRootBranch ::
   Transaction (Branch Transaction)
 uncachedLoadRootBranch getDeclType = do
   causal2 <- Ops.expectRootCausal
-  Cv.causalbranch2to1 getDeclType causal2
+  branchCache <- newTransactionBranchCache
+  Cv.causalbranch2to1 branchCache getDeclType causal2
 
 getRootBranchExists :: Transaction Bool
 getRootBranchExists =
@@ -396,10 +398,11 @@ getBranchForHash ::
   Branch.CausalHash ->
   Transaction (Maybe (Branch Transaction))
 getBranchForHash doGetDeclType h = do
+  branchCache <- newTransactionBranchCache
   Ops.loadCausalBranchByCausalHash (Cv.causalHash1to2 h) >>= \case
     Nothing -> pure Nothing
     Just causal2 -> do
-      branch1 <- Cv.causalbranch2to1 doGetDeclType causal2
+      branch1 <- Cv.causalbranch2to1 branchCache doGetDeclType causal2
       pure (Just branch1)
 
 putBranch :: Branch Transaction -> Transaction ()

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -63,6 +63,7 @@ library
       Unison.Codebase.Serialization
       Unison.Codebase.ShortBranchHash
       Unison.Codebase.SqliteCodebase
+      Unison.Codebase.SqliteCodebase.Branch.Cache
       Unison.Codebase.SqliteCodebase.Branch.Dependencies
       Unison.Codebase.SqliteCodebase.Conversions
       Unison.Codebase.SqliteCodebase.GitError

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -186,6 +186,7 @@ import qualified Unison.Var as Var
 import qualified Unison.WatchKind as WK
 import Web.Browser (openBrowser)
 import Witherable (wither)
+import System.Mem (performGC)
 
 defaultPatchNameSegment :: NameSegment
 defaultPatchNameSegment = "patch"
@@ -206,6 +207,8 @@ currentPrettyPrintEnvDecl scoping = do
 
 loop :: Either Event Input -> Action ()
 loop e = do
+  liftIO $ putStrLn "Running GC"
+  liftIO $ performGC
   uf <- use Command.latestTypecheckedFile
   root' <- use Command.root
   currentPath' <- use Command.currentPath

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -186,7 +186,6 @@ import qualified Unison.Var as Var
 import qualified Unison.WatchKind as WK
 import Web.Browser (openBrowser)
 import Witherable (wither)
-import System.Mem (performGC)
 
 defaultPatchNameSegment :: NameSegment
 defaultPatchNameSegment = "patch"
@@ -207,8 +206,6 @@ currentPrettyPrintEnvDecl scoping = do
 
 loop :: Either Event Input -> Action ()
 loop e = do
-  liftIO $ putStrLn "Running GC"
-  liftIO $ performGC
   uf <- use Command.latestTypecheckedFile
   root' <- use Command.root
   currentPath' <- use Command.currentPath


### PR DESCRIPTION
## Context

Relevant slack conversations:

* https://unisoncomputing.slack.com/archives/C03HW54CYP4/p1659566372087829
* https://unisoncomputing.slack.com/archives/C03HW54CYP4/p1659566647488839
* https://unisoncomputing.slack.com/archives/C03HW54CYP4/p1659566703635109

Closes https://github.com/unisonweb/unison/issues/3295
Fixes https://github.com/unisonweb/unison/issues/3290

## Overview

We have a rootbranch cache, but we don't currently cache or share any other branches; this means that the same branch will be duplicated in memory for every space it appears in the namespace tree. E.g. base is likely to be included in every project, so if you have 30 projects that means:

* 29x redundant copies of base in memory
* 29x unnecessary loads from sqlite
* 29x identical thunks for deeptypes/deepterms which need to be evaluated separately

## Outcome

Here are some numbers I observed on unoptimized builds against Stew's rather large codebase:

```
# unison-trunk
Time-to-interactive: 84s
Memory residency on load (without performing any actions): 2.73GB
Memory residency after `ls`: 7.39GB 

# unison-branch-sharing-weak-refs
Time-to-interactive: 4s
Memory residency on load (without performing any actions): 148MB
Memory residency after `ls`: 148MB
```

Easy to see that it's a worthwhile improvement.
Memory residency _does_ still climb a bit after cd'ing around and doing some work, but for me it capped out around 2.8GB, which is still too high, but is less than half of 7.39GB.
I can likely improve memory residency further with improvements on deepTerms/deepTypes in future PRs.

## Design

* Each codebase keeps a branch cache, which is effectively: `TVar (Map V2.CausalHash (Weak (V1.Branch.Branch n)))`
* Whenever we load branches using `getBranchForHash` or `getRootBranch` we consult the cache
  * on a cache hit, we return the result
  * on a cache miss, we build the branch (making sure to use the same caching strategy on child branches), then store it in the cache, and return it.

### About weakness

Originally the plan was to use the cache on the initial root branch load, then discard it after that to ensure that the existence of the cache wouldn't keep branches alive in memory past their natural lifespan. This worked fine, but means that branches are only shared within the initial load. Things like querying history would still unnecessarily create copies of everything.

Instead, we can use [`Weak`](https://hackage.haskell.org/package/base-4.16.3.0/docs/System-Mem-Weak.html#t:Weak) references in the cache. This allows us to keep results in the cache, but they will gracefully remove themselves if they get garbage collected due to otherwise being out of scope.

This means we can keep every live branch in the cache without paying any additional memory cost other than the spine of the `Map` used by the cache; I believe the savings provided by sharing outweigh this cost.

Note: I tested out the finalizers by adding a manual `performGC` and then adding/deleting branches. The finalizers definitely do fire when the branch goes out of scope, but I observed that branches don't always go out of scope immediately after being deleted. This is likely an existing issue rather than being caused by this PR, I suspect they're being referenced in un-forced thunks, perhaps in a `Names` object somewhere. This is likely worth looking into in the future.

## Implementation notes

* Adds a `branchCache` which keys `V2.CausalHash`'s to `V1.Branch`'s, it's used by `getRootBranch` and `getBranchForHash`. This cache **both** speeds up loads (since they're cached, no deserialization or sqlite queries needed), but also enforces sharing, which provides huge memory residency benefits.
* Note, this cache runs `IO` within a transaction using `unsafeIO`, but it's not an issue since it's fine if the IO for fetching/inserting branches into the cache runs multiple times, it's effectively idempotent. Also, it's currently only used in read transactions which I don't believe are ever retried anyways.

## Interesting/controversial decisions

* Is using `Weak` worth the additional complexity? I think so, the whole PR is less than 100 lines, and only a dozen of those are from `Weak` logic. Longer-lived caching without suffering any long-lived memory buildup sounds like a win to me.

## Loose ends

* We should ask ourselves whether there are other types which could benefit from sharing like this
* We have caches for types and terms and such, but are they properly sharing everything? 
* Would those caches benefit from being "weak" caches like this one rather than a semispace cache?