### PR TITLE
Missed Name instructions as a source of combinator deps

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/MCode.hs
+++ b/parser-typechecker/src/Unison/Runtime/MCode.hs
@@ -1396,7 +1396,9 @@ sectionDeps :: Section -> [Word64]
 sectionDeps (App _ (Env w _) _) = [w]
 sectionDeps (Call _ w _) = [w]
 sectionDeps (Match _ br) = branchDeps br
-sectionDeps (Ins _ s) = sectionDeps s
+sectionDeps (Ins i s)
+  | Name (Env w _) _ <- i = w : sectionDeps s
+  | otherwise = sectionDeps s
 sectionDeps (Let s (CIx _ w _)) = w : sectionDeps s
 sectionDeps _ = []
 


### PR DESCRIPTION
When making a standalone file, we trace through the combinators to only serialize only the ones that are necessary to run the program. However, the code was missing `Name` as a source of such references.

Previously this never mattered (I think). `Name` is used in compiling abilities. Essentially `handle e with h` turns into something similar to `name x = e in h x`, but `e` was very likely to just be referencing a separate section of the same definition as the `handle`. However, the new lambda lifting can now float this to a completely separate combinator that gets missed when making a standalone file.

Probably fixes a bug that @ceedubs was encountering.