### PR TITLE
Add tip to reflog output showing example diff.namespace usage

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -70,3 +70,4 @@ The format for this list: name, GitHub handle
 * Travis Staton (@tstat)
 * Dan Freeman (@dfreeman)
 * Emil Hotkowski (@emilhotkowski)
+* Jesse Looney (@jesselooney)

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1390,7 +1390,9 @@ notifyUser dir o = case o of
                   )
                 ],
           "",
-          P.numberedList . fmap renderEntry $ entries
+          P.numberedList . fmap renderEntry $ entries,
+          "",
+          tip $ "Use " <> IP.makeExample IP.diffNamespace ["1", "7"] <> " to compare namespaces between two points in history."
         ]
     where
       renderEntry :: Output.ReflogEntry -> Pretty

--- a/unison-src/transcripts/reflog.output.md
+++ b/unison-src/transcripts/reflog.output.md
@@ -70,6 +70,9 @@ y = 2
   2. #tpbeffu5sn : add
   3. #1a0f7cshrd : builtins.merge
   4. #sg60bvjo91 : (initial reflogged namespace)
+  
+  Tip: Use `diff.namespace 1 7` to compare namespaces between
+       two points in history.
 
 ```
 If we `reset-root` to its previous value, `y` disappears.


### PR DESCRIPTION
Closes #3145 

Running `reflog` in `ucm` now displays a tip below the list of history entries:

```
...
4. #sg60bvjo91 : ...

Tip: Use `diff.namespace 1 7` to compare namespaces between two points in history.
```

I copied the example in the issue verbatim, and I hope the wording is fine.

This is my first pull request, so let me know if there is anything I've done wrong.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3302)
<!-- Reviewable:end -->
