### PR TITLE
Fix serialization issue with code that uses abilities

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/MCode.hs
+++ b/parser-typechecker/src/Unison/Runtime/MCode.hs
@@ -918,12 +918,16 @@ emitFunction rns _ _ _ (FCon r t) as =
     rt = toEnum . fromIntegral $ dnum rns r
 emitFunction rns _ _ _ (FReq r e) as =
   -- Currently implementing packed calling convention for abilities
+  -- TODO ct is 16 bits, but a is 48 bits. This will be a problem if we have
+  -- more than 2^16 types.
   Ins (Lit (MI . fromIntegral $ rawTag e))
-    . Ins (Pack r a (reqArgs as))
+    . Ins (Pack r (packTags rt ct) (reqArgs as))
     . App True (Dyn a)
     $ BArg1 0
   where
     a = dnum rns r
+    rt = toEnum . fromIntegral $ a
+    ct = toEnum . fromIntegral $ a
 emitFunction _ _ _ ctx (FCont k) as
   | Just (i, BX) <- ctxResolve ctx k = Jump i as
   | Nothing <- ctxResolve ctx k = emitFunctionVErr k


### PR DESCRIPTION
We were using session-specific constructor tags to identify abilities,
but after 4918b2ef272884f96c76c9f408f3e77595de0ad8 that information was
no longer being populated. This should change it so we properly pack the
tags.