### PR TITLE
Fix garbled UCM prompt on Windows

### DIFF
--- a/lib/unison-pretty-printer/src/Unison/Util/ColorText.hs
+++ b/lib/unison-pretty-printer/src/Unison/Util/ColorText.hs
@@ -136,9 +136,13 @@ toANSI (AnnotatedText chunks) =
               Nothing -> r <> resetANSI <> pure text
               Just style -> r <> resetANSI <> toANSI style <> pure text
           )
-    resetANSI = pure . ANSI.setSGRCode $ [ANSI.Reset]
+    -- End every ANSI escape code in the prompt with '\STX' so that haskeline renders it properly on Windows.
+    -- This may also help haskeline make prompt width computations.
+    -- See https://github.com/judah/haskeline/wiki/ControlSequencesInPrompt for details.
+    startText = "\STX"
+    resetANSI = pure $ ANSI.setSGRCode [ANSI.Reset] <> startText
     toANSI :: Color -> Seq String
-    toANSI c = pure $ ANSI.setSGRCode (toANSI' c)
+    toANSI c = pure $ ANSI.setSGRCode (toANSI' c) <> startText
 
     toANSI' :: Color -> [ANSI.SGR]
     toANSI' c = case c of

--- a/lib/unison-pretty-printer/src/Unison/Util/ColorText.hs
+++ b/lib/unison-pretty-printer/src/Unison/Util/ColorText.hs
@@ -139,10 +139,10 @@ toANSI (AnnotatedText chunks) =
     -- End every ANSI escape code in the prompt with '\STX' so that haskeline renders it properly on Windows.
     -- This may also help haskeline make prompt width computations.
     -- See https://github.com/judah/haskeline/wiki/ControlSequencesInPrompt for details.
-    startText = "\STX"
-    resetANSI = pure $ ANSI.setSGRCode [ANSI.Reset] <> startText
+    startOfText = "\STX"
+    resetANSI = pure $ ANSI.setSGRCode [ANSI.Reset] <> startOfText
     toANSI :: Color -> Seq String
-    toANSI c = pure $ ANSI.setSGRCode (toANSI' c) <> startText
+    toANSI c = pure $ ANSI.setSGRCode (toANSI' c) <> startOfText
 
     toANSI' :: Color -> [ANSI.SGR]
     toANSI' c = case c of


### PR DESCRIPTION
## Overview

Fixes #3275

On Windows, the UCM prompt is corrected from this
`[0m[32m.[0m> [0m`
to this
`.> `
but there is still no color.

## Implementation

This change appends the ASCII start-of-text (`\STX`) character within the `toANSI` and `resetANSI` functions inside the `Unison.Util.ColorText.toANSI` function, which should mean that every ANSI escape sequence rendered with that function should be followed immediately by this character. This is the [recommended practice for haskeline](https://github.com/judah/haskeline/wiki/ControlSequencesInPrompt), and most importantly should prevent the remainders of character control codes seen in issue #3275 from being displayed when haskeline removes the leading `\ESC` character on Windows. This does not fix the lack of coloration of the UCM prompt on Windows, but it does stop the prompt from appearing garbled.

While `\STX` is a control character and should not be rendered, I could see not wanting to insert them in every single place `toANSI` is used and instead just limiting this change to affect haskeline prompts. I didn't do that because it would require more work and the PR as it stands might be fine, but it could definitely be done.

## Additional notes

The issue of haskeline removing color codes on Windows is seemingly out of our control. See https://github.com/judah/haskeline/issues/130 for more information on the topic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3307)
<!-- Reviewable:end -->
