### PR TITLE
Improve error messages for ability equality errors

### DIFF
--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -469,8 +469,15 @@ renderTypeError e env src curPath = case e of
       ]
   AbilityEqFailure {..} ->
     mconcat
-      [ "I could not solve an ability equation when checking the expression ",
+      [ "I found an ability mismatch when checking the expression ",
         describeStyle ErrorSite,
+        "\n\n",
+        showSourceMaybes
+          src
+          [ (,Type1) <$> rangeForAnnotated tlhs,
+            (,Type2) <$> rangeForAnnotated trhs,
+            (,ErrorSite) <$> rangeForAnnotated abilityCheckFailureSite
+          ],
         "\n\n",
         Pr.wrap $
           mconcat
@@ -481,12 +488,12 @@ renderTypeError e env src curPath = case e of
               case (lhs, rhs) of
                 ([], _) ->
                   mconcat
-                    [ "The right hand side contained extra abilities: ",
+                    [ "the right hand side contained extra abilities: ",
                       style Type2 $ "{" <> commas (renderType' env) rhs <> "}"
                     ]
                 (_, []) ->
                   mconcat
-                    [ "The left hand side contained extra abilities: ",
+                    [ "the left hand side contained extra abilities: ",
                       style Type1 $ "{" <> commas (renderType' env) lhs <> "}"
                     ]
                 _ ->
@@ -499,45 +506,45 @@ renderTypeError e env src curPath = case e of
                     ]
             ],
         "\n\n",
-        annotatedAsErrorSite src abilityCheckFailureSite,
         debugSummary note
       ]
   AbilityEqFailureFromAp {..} ->
     mconcat
-      [ "I could not solve an ability equation when checking the application below.",
-        "\n\n",
-        Pr.wrap $
-          mconcat
-            [ "When trying to match ",
-              style Type1 $ renderType' env tlhs,
-              " with ",
-              style Type2 $ renderType' env trhs,
-              case (lhs, rhs) of
-                ([], _) ->
-                  mconcat
-                    [ "The right hand side contained extra abilities: ",
-                      style Type2 $ "{" <> commas (renderType' env) rhs <> "}"
-                    ]
-                (_, []) ->
-                  mconcat
-                    [ "The left hand side contained extra abilities: ",
-                      style Type1 $ "{" <> commas (renderType' env) lhs <> "}"
-                    ]
-                _ ->
-                  mconcat
-                    [ " I could not make ",
-                      style Type1 $ "{" <> commas (renderType' env) lhs <> "}",
-                      " on the left compatible with ",
-                      style Type2 $ "{" <> commas (renderType' env) rhs <> "}",
-                      " on the right."
-                    ]
-            ],
+      [ "I found an ability mismatch when checking the application",
         "\n\n",
         showSourceMaybes
           src
           [ (,Type1) <$> rangeForAnnotated expectedSite,
             (,Type2) <$> rangeForAnnotated mismatchSite
           ],
+        "\n\n",
+        Pr.wrap $
+          mconcat
+            [ "When trying to match ",
+              style Type1 $ renderType' env tlhs,
+              " with ",
+              style Type2 $ renderType' env trhs,
+              case (lhs, rhs) of
+                ([], _) ->
+                  mconcat
+                    [ "the right hand side contained extra abilities: ",
+                      style Type2 $ "{" <> commas (renderType' env) rhs <> "}"
+                    ]
+                (_, []) ->
+                  mconcat
+                    [ "the left hand side contained extra abilities: ",
+                      style Type1 $ "{" <> commas (renderType' env) lhs <> "}"
+                    ]
+                _ ->
+                  mconcat
+                    [ " I could not make ",
+                      style Type1 $ "{" <> commas (renderType' env) lhs <> "}",
+                      " on the left compatible with ",
+                      style Type2 $ "{" <> commas (renderType' env) rhs <> "}",
+                      " on the right."
+                    ]
+            ],
+        "\n\n",
         debugSummary note
       ]
   UnguardedLetRecCycle vs locs _ ->

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -353,6 +353,7 @@ data Cause v loc
   | UnknownSymbol loc v
   | UnknownTerm loc v [Suggestion v loc] (Type v loc)
   | AbilityCheckFailure [Type v loc] [Type v loc] (Context v loc) -- ambient, requested
+  | AbilityEqFailure [Type v loc] [Type v loc] (Context v loc)
   | EffectConstructorWrongArgCount ExpectedArgCount ActualArgCount ConstructorReference
   | MalformedEffectBind (Type v loc) (Type v loc) [Type v loc] -- type of ctor, type of ctor result
   -- Type of ctor, number of arguments we got
@@ -2700,7 +2701,7 @@ equateAbilities ls rs =
             | [] <- com, null ls, null crs -> for_ vrs defaultAbility
             | [] <- com, Just pl <- mlSlack, null cls -> refine False [pl] [rs]
             | [] <- com, Just pr <- mrSlack, null crs -> refine False [pr] [ls]
-            | otherwise -> getContext >>= failWith . AbilityCheckFailure ls rs
+            | otherwise -> getContext >>= failWith . AbilityEqFailure ls rs
   where
     refine common lbvs ess = do
       cv <- traverse freshenVar cn

--- a/parser-typechecker/src/Unison/Typechecker/Extractor.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Extractor.hs
@@ -173,6 +173,11 @@ inSubtype = asPathExtractor $ \case
   C.InEquate found expected -> Just (found, expected)
   _ -> Nothing
 
+inEquate :: SubseqExtractor v loc (C.Type v loc, C.Type v loc)
+inEquate = asPathExtractor $ \case
+  C.InEquate lhs rhs -> Just (lhs, rhs)
+  _ -> Nothing
+
 inCheck :: SubseqExtractor v loc (C.Term v loc, C.Type v loc)
 inCheck = asPathExtractor $ \case
   C.InCheck e t -> Just (e, t)
@@ -269,6 +274,13 @@ abilityCheckFailure ::
 abilityCheckFailure =
   cause >>= \case
     C.AbilityCheckFailure ambient requested ctx -> pure (ambient, requested, ctx)
+    _ -> mzero
+
+abilityEqFailure ::
+  ErrorExtractor v loc ([C.Type v loc], [C.Type v loc], C.Context v loc)
+abilityEqFailure =
+  cause >>= \case
+    C.AbilityEqFailure lhs rhs ctx -> pure (lhs, rhs, ctx)
     _ -> mzero
 
 effectConstructorWrongArgCount ::

--- a/unison-src/transcripts/fix3037.md
+++ b/unison-src/transcripts/fix3037.md
@@ -16,3 +16,17 @@ pureRunner = Runner base.force
 runner : Runner {IO}
 runner = pureRunner
 ```
+
+Application version:
+
+```unison:error
+structural type A g = A (forall a. '{g} a ->{} a)
+
+anA : A {}
+anA = A base.force
+
+h : A {IO} -> ()
+h _ = ()
+
+> h anA
+```

--- a/unison-src/transcripts/fix3037.output.md
+++ b/unison-src/transcripts/fix3037.output.md
@@ -15,12 +15,46 @@ runner = pureRunner
 
 ```ucm
 
-  I could not solve an ability equation when checking the expression in red
+  I found an ability mismatch when checking the expression in red
   
-  When trying to match Runner {} with Runner {IO} The right hand
+      3 | pureRunner : Runner {}
+      4 | pureRunner = Runner base.force
+      5 | 
+      6 | -- this compiles, but shouldn't the effect type parameter on Runner be invariant?
+      7 | runner : Runner {IO}
+      8 | runner = pureRunner
+  
+  
+  When trying to match Runner {} with Runner {IO} the right hand
   side contained extra abilities: {IO}
   
-      8 | runner = pureRunner
+  
+
+```
+Application version:
+
+```unison
+structural type A g = A (forall a. '{g} a ->{} a)
+
+anA : A {}
+anA = A base.force
+
+h : A {IO} -> ()
+h _ = ()
+
+> h anA
+```
+
+```ucm
+
+  I found an ability mismatch when checking the application
+  
+      9 | > h anA
+  
+  
+  When trying to match A {} with A {IO} the right hand side
+  contained extra abilities: {IO}
+  
   
 
 ```

--- a/unison-src/transcripts/fix3037.output.md
+++ b/unison-src/transcripts/fix3037.output.md
@@ -15,7 +15,10 @@ runner = pureRunner
 
 ```ucm
 
-  The expression in red needs the {IO} ability, but this location does not have access to any abilities.
+  I could not solve an ability equation when checking the expression in red
+  
+  When trying to match Runner {} with Runner {IO} The right hand
+  side contained extra abilities: {IO}
   
       8 | runner = pureRunner
   


### PR DESCRIPTION
This changes the error generated when failing an ability equality check, and detects it for some better error messages.

The messages try to figure out when an ability equality error arose from applying functions, so it can indicate the function and argument involved, together with some more type context available. In other situations, an error about abilities/types not being equal is generated, rather than the old message which was just reporting as if there was an ambient-vs-needed error, which doesn't make much sense in these scenarios.

This also fixes #3300, which was caused by the old error message not expecting the "needed" abilities in a failure to ever be empty, while an equality failure can be due to an empty row not being equal to a non-empty row, and the choice of what goes in the 'needed' spot being arbitrary for an equality.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3317)
<!-- Reviewable:end -->
