### PR TITLE
Fix Label instance

### DIFF
--- a/unison-cli/src/Unison/Cli/Monad.hs
+++ b/unison-cli/src/Unison/Cli/Monad.hs
@@ -359,8 +359,7 @@ class Label s t where
   default wrap :: s ~ t => s -> t
   wrap = id
 
-instance Label t (R t x) where
-  wrap = GoL
+instance Label (R t x) (R t x)
 
 instance {-# OVERLAPPABLE #-} Label s t => Label s (R t x) where
   wrap = GoL . wrap


### PR DESCRIPTION
## Overview

The previous base case wasn't allowing jumping to a label directly (i.e. not underneath a second label).

Before:

```haskell
-- type error
label \goto0 ->
  goto0 "yo"

-- ok
label \goto0 ->
  label \goto1 ->
    goto0 "yo"
```

After:

```haskell
-- ok
label \goto0 ->
  goto0 "yo"

-- ok
label \goto0 ->
  label \goto1 ->
    goto0 "yo"
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3321)
<!-- Reviewable:end -->
