### PR TITLE
Faster ls

### DIFF
--- a/codebase2/codebase/U/Codebase/Branch.hs
+++ b/codebase2/codebase/U/Codebase/Branch.hs
@@ -13,10 +13,11 @@ module U.Codebase.Branch
     childAt,
     hoist,
     hoistCausalBranch,
+    pattern Empty,
   )
 where
 
-import Control.Lens (AsEmpty (..), nearly)
+import Control.Lens (AsEmpty (..), nearly, pattern Empty)
 import qualified Data.Map as Map
 import U.Codebase.Causal (Causal)
 import qualified U.Codebase.Causal as Causal

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -271,8 +271,8 @@ sqliteCodebase debugName root localOrRemote action = do
             getRootBranchHash =
               runTransaction Ops.expectRootCausalHash
 
-            getShallowBranchForHash :: MonadIO m => V2Branch.CausalHash -> m (V2Branch.CausalBranch m)
-            getShallowBranchForHash bh =
+            getShallowCausalForHash :: MonadIO m => V2Branch.CausalHash -> m (V2Branch.CausalBranch m)
+            getShallowCausalForHash bh =
               V2Branch.hoistCausalBranch runTransaction <$> runTransaction (Ops.expectCausalBranchByCausalHash bh)
 
             getRootBranch :: TVar (Maybe (Sqlite.DataVersion, Branch Sqlite.Transaction)) -> m (Branch m)
@@ -453,7 +453,7 @@ sqliteCodebase debugName root localOrRemote action = do
                   getRootBranchHash,
                   getRootBranchExists,
                   putRootBranch = putRootBranch rootBranchCache,
-                  getShallowBranchForHash,
+                  getShallowCausalForHash,
                   getBranchForHashImpl = getBranchForHash,
                   putBranch,
                   branchExists = isCausalHash,

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -86,7 +86,7 @@ data Codebase m v a = Codebase
     getRootBranchExists :: m Bool,
     -- | Like 'putBranch', but also adjusts the root branch pointer afterwards.
     putRootBranch :: Branch m -> m (),
-    getShallowBranchForHash :: V2.CausalHash -> m (V2.CausalBranch m),
+    getShallowCausalForHash :: V2.CausalHash -> m (V2.CausalBranch m),
     getBranchForHashImpl :: Branch.CausalHash -> m (Maybe (Branch m)),
     -- | Put a branch into the codebase, which includes its children, its patches, and the branch itself, if they don't
     -- already exist.

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -966,7 +966,7 @@ loop e = do
               rootBranch <- Cli.getRootBranch
 
               pathArgAbs <- Cli.resolvePath' pathArg
-              entries <- liftIO (Backend.findShallow codebase pathArgAbs)
+              entries <- liftIO (Backend.lsAtPath codebase Nothing pathArgAbs)
               -- caching the result as an absolute path, for easier jumping around
               #numberedArgs .= fmap entryToHQString entries
               let ppe =

--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -129,7 +129,7 @@ completeWithinNamespace ::
   m [System.Console.Haskeline.Completion.Completion]
 completeWithinNamespace compTypes query codebase currentPath = do
   shortHashLen <- Codebase.hashLength codebase
-  Codebase.getShallowBranchFromRoot codebase absQueryPath >>= \case
+  Codebase.getShallowCausalFromRoot codebase Nothing absQueryPath >>= \case
     Nothing -> do
       pure []
     Just cb -> do

--- a/unison-share-api/src/Unison/Server/Endpoints/NamespaceListing.hs
+++ b/unison-share-api/src/Unison/Server/Endpoints/NamespaceListing.hs
@@ -25,17 +25,18 @@ import Servant.Docs
     ToSample (..),
   )
 import Servant.OpenApi ()
+import qualified U.Codebase.Branch as V2Causal
 import qualified U.Codebase.Causal as V2Causal
 import qualified U.Util.Hash as Hash
 import Unison.Codebase (Codebase)
 import qualified Unison.Codebase as Codebase
-import Unison.Codebase.Branch (Branch)
 import qualified Unison.Codebase.Branch as Branch
 import qualified Unison.Codebase.Causal as Causal
 import qualified Unison.Codebase.Path as Path
 import qualified Unison.Codebase.Path.Parse as Path
 import Unison.Codebase.ShortBranchHash (ShortBranchHash)
 import Unison.Codebase.SqliteCodebase.Conversions (causalHash2to1)
+import qualified Unison.Codebase.SqliteCodebase.Conversions as Cv
 import qualified Unison.NameSegment as NameSegment
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
@@ -164,7 +165,7 @@ serve codebase maySBH mayRelativeTo mayNamespaceName = do
   mayRootHash <- traverse (Backend.expandShortBranchHash codebase) maySBH
   codebaseRootHash <- liftIO $ Codebase.getRootBranchHash codebase
 
-  --Relative and Listing Path resolution
+  -- Relative and Listing Path resolution
   --
   -- The full listing path is a combination of the relativeToPath (prefix) and the namespace path
   --
@@ -188,18 +189,14 @@ serve codebase maySBH mayRelativeTo mayNamespaceName = do
       serveFromIndex codebase mayRootHash path'
     (True, Just rh)
       | rh == causalHash2to1 codebaseRootHash ->
-        serveFromIndex codebase mayRootHash path'
+          serveFromIndex codebase mayRootHash path'
       | otherwise -> do
-        mayBranch <- liftIO $ Codebase.getBranchForHash codebase rh
-        branch <- maybe (throwError $ Backend.NoBranchForHash rh) pure mayBranch
-        serveFromBranch codebase path' branch
+          serveFromBranch codebase path' (Cv.causalHash1to2 rh)
     (False, Just rh) -> do
-      mayBranch <- liftIO $ Codebase.getBranchForHash codebase rh
-      branch <- maybe (throwError $ Backend.NoBranchForHash rh) pure mayBranch
-      serveFromBranch codebase path' branch
+      serveFromBranch codebase path' (Cv.causalHash1to2 rh)
     (False, Nothing) -> do
-      branch <- liftIO $ Codebase.getRootBranch codebase
-      serveFromBranch codebase path' branch
+      rh <- liftIO $ Codebase.getRootBranchHash codebase
+      serveFromBranch codebase path' rh
   where
     parsePath :: String -> Backend IO Path.Path'
     parsePath p = errFromEither (`Backend.BadNamespace` p) $ Path.parsePath' p
@@ -208,17 +205,20 @@ serve codebase maySBH mayRelativeTo mayNamespaceName = do
 serveFromBranch ::
   Codebase IO Symbol Ann ->
   Path.Path' ->
-  Branch IO ->
+  V2Causal.CausalHash ->
   Backend.Backend IO NamespaceListing
-serveFromBranch codebase path' branch = do
-  let branchAtPath = Branch.getAt' (Path.fromPath' path') branch
+serveFromBranch codebase path' rootHash = do
+  let absPath = Path.Absolute . Path.fromPath' $ path'
   -- TODO: Currently the ppe is just used to render the types returned from the namespace
   -- listing, which are currently unused because we don't show types in the side-bar.
   -- If we ever show types on hover we need to build and use a proper PPE here, but it's not
   -- worth slowing down the request for this right now.
   let ppe = PPE.empty
   let listingFQN = Path.toText . Path.unabsolute . either id (Path.Absolute . Path.unrelative) $ Path.unPath' path'
-  let listingHash = branchToUnisonHash branchAtPath
+  mayCausalAtPath <- liftIO $ Codebase.getShallowBranchFromRoot codebase (Just rootHash) absPath
+  mayBranchAtPath <- liftIO $ traverse V2Causal.value mayCausalAtPath
+  let branchAtPath = fromMaybe V2Causal.Empty mayBranchAtPath
+  let listingHash = maybe (branchToUnisonHash Branch.empty) v2CausalBranchToUnisonHash mayCausalAtPath
   listingEntries <- liftIO $ Backend.lsBranch codebase branchAtPath
   makeNamespaceListing ppe listingFQN listingHash listingEntries
 
@@ -237,7 +237,7 @@ serveFromIndex codebase mayRootHash path' = do
   let shallowPPE = PPE.empty
   let listingFQN = Path.toText . Path.unabsolute . either id (Path.Absolute . Path.unrelative) $ Path.unPath' path'
   let listingHash = v2CausalBranchToUnisonHash listingCausal
-  listingEntries <- lift (Backend.lsShallowBranch codebase listingBranch)
+  listingEntries <- lift (Backend.lsBranch codebase listingBranch)
   makeNamespaceListing shallowPPE listingFQN listingHash listingEntries
 
 makeNamespaceListing ::

--- a/unison-share-api/src/Unison/Server/Endpoints/NamespaceListing.hs
+++ b/unison-share-api/src/Unison/Server/Endpoints/NamespaceListing.hs
@@ -215,7 +215,7 @@ serveFromBranch codebase path' rootHash = do
   -- worth slowing down the request for this right now.
   let ppe = PPE.empty
   let listingFQN = Path.toText . Path.unabsolute . either id (Path.Absolute . Path.unrelative) $ Path.unPath' path'
-  mayCausalAtPath <- liftIO $ Codebase.getShallowBranchFromRoot codebase (Just rootHash) absPath
+  mayCausalAtPath <- liftIO $ Codebase.getShallowCausalFromRoot codebase (Just rootHash) absPath
   mayBranchAtPath <- liftIO $ traverse V2Causal.value mayCausalAtPath
   let branchAtPath = fromMaybe V2Causal.Empty mayBranchAtPath
   let listingHash = maybe (branchToUnisonHash Branch.empty) v2CausalBranchToUnisonHash mayCausalAtPath

--- a/unison-share-api/src/Unison/Server/Endpoints/Projects.hs
+++ b/unison-share-api/src/Unison/Server/Endpoints/Projects.hs
@@ -131,7 +131,7 @@ serve codebase mayRoot mayOwner = projects
   where
     projects :: Backend m [ProjectListing]
     projects = do
-      root <- case mayRoot of
+      (root, shallowRoot) <- case mayRoot of
         Nothing -> lift (Codebase.getRootBranch codebase)
         Just sbh -> do
           h <- Backend.expandShortBranchHash codebase sbh


### PR DESCRIPTION
This speeds up ls and doesn't use the root branch or deepTerms/deepTypes;

HOWEVER, it's currently blocked by the fact that we can't tell whether a given child namespace is "empty" or not without crawling the whole thing, so this should wait until we have term/type counts in namespace metadata, or have relational namespaces.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3331)
<!-- Reviewable:end -->
