### PR TITLE
Move histories during `move.namespace`

### DIFF
--- a/unison-cli/src/Unison/Cli/MonadUtils.hs
+++ b/unison-cli/src/Unison/Cli/MonadUtils.hs
@@ -30,6 +30,7 @@ module Unison.Cli.MonadUtils
     -- ** Updating branches
     updateRoot,
     updateAtM,
+    updateAt,
 
     -- * Terms
     getTermsAt,
@@ -291,6 +292,16 @@ updateAtM reason (Path.Absolute p) f = do
   b' <- Branch.modifyAtM p f b
   updateRoot b' reason
   pure $ b /= b'
+
+-- | Update a branch at the given path, returning `True` if
+-- an update occurred and false otherwise
+updateAt ::
+  Text ->
+  Path.Absolute ->
+  (Branch IO -> Branch IO) ->
+  Cli r Bool
+updateAt reason p f = do
+  updateAtM reason p (pure . f)
 
 updateRoot :: Branch IO -> Text -> Cli r ()
 updateRoot new reason =

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -506,19 +506,9 @@ loop e = do
                 (Just merged)
                 (snoc desta "merged")
             MoveBranchI src' dest' -> do
-              destBranchExists <- Cli.branchExistsAtPath' dest'
-              srcAbs <- Cli.resolvePath' src'
-              destAbs <- Cli.resolvePath' dest'
-              let isRootMove = (Path.isRoot srcAbs || Path.isRoot destAbs)
-              when isRootMove do
-                hasConfirmed <- confirmedCommand input
-                when (not hasConfirmed) $ do
-                  Cli.returnEarly MoveRootBranchConfirmation
+              hasConfirmed <- confirmedCommand input
               description <- inputDescription input
-              doMoveBranch description srcAbs destAbs
-              if (destBranchExists && not isRootMove)
-                then Cli.respond (MovedOverExistingBranch dest')
-                else Cli.respond Success
+              doMoveBranch description hasConfirmed src' dest'
             MovePatchI src' dest' -> do
               description <- inputDescription input
               p <- Cli.expectPatchAt src'

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -507,13 +507,15 @@ loop e = do
                 (snoc desta "merged")
             MoveBranchI src' dest' -> do
               destBranchExists <- Cli.branchExistsAtPath' dest'
-              let isRootMove = (isNothing src' || dest' == Path.relativeEmpty' || dest' == Path.absoluteEmpty')
+              srcAbs <- Cli.resolvePath' src'
+              destAbs <- Cli.resolvePath' dest'
+              let isRootMove = (Path.isRoot srcAbs || Path.isRoot destAbs)
               when isRootMove do
                 hasConfirmed <- confirmedCommand input
                 when (not hasConfirmed) $ do
                   Cli.returnEarly MoveRootBranchConfirmation
               description <- inputDescription input
-              doMoveBranch description src' dest'
+              doMoveBranch description srcAbs destAbs
               if (destBranchExists && not isRootMove)
                 then Cli.respond (MovedOverExistingBranch dest')
                 else Cli.respond Success
@@ -1490,7 +1492,7 @@ inputDescription input =
       dest <- ps' dest0
       pure ("move.type " <> src <> " " <> dest)
     MoveBranchI src0 dest0 -> do
-      src <- ops' src0
+      src <- p' src0
       dest <- p' dest0
       pure ("move.namespace " <> src <> " " <> dest)
     MovePatchI src0 dest0 -> do

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -53,6 +53,7 @@ import qualified Unison.Codebase.Editor.AuthorInfo as AuthorInfo
 import Unison.Codebase.Editor.DisplayObject
 import qualified Unison.Codebase.Editor.Git as Git
 import Unison.Codebase.Editor.HandleInput.AuthLogin (authLogin, ensureAuthenticatedWithCodeserver)
+import Unison.Codebase.Editor.HandleInput.MoveBranch (doMoveBranch)
 import qualified Unison.Codebase.Editor.HandleInput.NamespaceDependencies as NamespaceDependencies
 import Unison.Codebase.Editor.Input
 import qualified Unison.Codebase.Editor.Input as Input
@@ -430,7 +431,7 @@ loop e = do
                     Left hash -> Cli.resolveShortBranchHash hash
                     Right path' -> Cli.expectBranchAtPath' path'
                 description <- inputDescription input
-                updateRoot newRoot description
+                Cli.updateRoot newRoot description
                 Cli.respond Success
             ForkLocalBranchI src0 dest0 -> do
               srcb <-
@@ -440,7 +441,7 @@ loop e = do
               Cli.assertNoBranchAtPath' dest0
               description <- inputDescription input
               dest <- Cli.resolvePath' dest0
-              ok <- updateAtM description dest (const $ pure srcb)
+              ok <- Cli.updateAtM description dest (const $ pure srcb)
               Cli.respond if ok then Success else BranchEmpty src0
             MergeLocalBranchI src0 dest0 mergeMode -> do
               description <- inputDescription input
@@ -504,34 +505,9 @@ loop e = do
                 description
                 (Just merged)
                 (snoc desta "merged")
-
-            -- move the Command.root to a sub-branch
-            MoveBranchI Nothing dest' -> do
+            MoveBranchI src' dest' -> do
               description <- inputDescription input
-              rootBranch <- Cli.getRootBranch
-              dest <- Cli.resolveSplit' dest'
-              -- Overwrite history at destination.
-              stepManyAt
-                description
-                Branch.AllowRewritingHistory
-                [ (Path.empty, const Branch.empty0),
-                  BranchUtil.makeSetBranch (Path.convert dest) rootBranch
-                ]
-              Cli.respond Success
-            MoveBranchI (Just src') dest' -> do
-              description <- inputDescription input
-              src <- Cli.resolveSplit' src'
-              dest <- Cli.resolveSplit' dest'
-              srcBranch <- Cli.expectBranchAtPath' (Path.unsplit' src')
-              Cli.assertNoBranchAtPath' (Path.unsplit' dest')
-              -- allow rewriting history to ensure we move the branch's history too.
-              stepManyAt
-                description
-                Branch.AllowRewritingHistory
-                [ BranchUtil.makeDeleteBranch (Path.convert src),
-                  BranchUtil.makeSetBranch (Path.convert dest) srcBranch
-                ]
-              Cli.respond Success -- could give rando stats about new defns
+              doMoveBranch description src' dest'
             MovePatchI src' dest' -> do
               description <- inputDescription input
               p <- Cli.expectPatchAt src'
@@ -655,7 +631,7 @@ loop e = do
                       then CantUndoPastStart
                       else CantUndoPastMerge
               description <- inputDescription input
-              updateRoot prev description
+              Cli.updateRoot prev description
               (ppe, diff) <- diffHelper (Branch.head prev) (Branch.head rootBranch)
               Cli.respondNumbered (Output.ShowDiffAfterUndo ppe diff)
             UiI -> do
@@ -1261,7 +1237,7 @@ loop e = do
               -- due to builtin terms; so we don't just reuse `uf` above.
               let srcb = BranchUtil.fromNames Builtin.names0
               currentPath <- Cli.getCurrentPath
-              _ <- updateAtM description (currentPath `snoc` "builtin") \destb ->
+              _ <- Cli.updateAtM description (currentPath `snoc` "builtin") \destb ->
                 liftIO (Branch.merge'' (Codebase.lca codebase) Branch.RegularMerge srcb destb)
               Cli.respond Success
             MergeIOBuiltinsI -> do
@@ -1284,7 +1260,7 @@ loop e = do
               let names0 = Builtin.names0 <> UF.typecheckedToNames IOSource.typecheckedFile'
               let srcb = BranchUtil.fromNames names0
               currentPath <- Cli.getCurrentPath
-              _ <- updateAtM description (currentPath `snoc` "builtin") \destb ->
+              _ <- Cli.updateAtM description (currentPath `snoc` "builtin") \destb ->
                 liftIO (Branch.merge'' (Codebase.lca codebase) Branch.RegularMerge srcb destb)
               Cli.respond Success
             ListEditsI maybePath -> do
@@ -1313,7 +1289,7 @@ loop e = do
                   destBranch <- Cli.getBranch0At destAbs
                   if Branch.isEmpty0 destBranch
                     then do
-                      void $ updateAtM description destAbs (const $ pure remoteBranch)
+                      void $ Cli.updateAtM description destAbs (const $ pure remoteBranch)
                       Cli.respond $ MergeOverEmpty path
                     else
                       mergeBranchAndPropagateDefaultPatch
@@ -1325,7 +1301,7 @@ loop e = do
                         destAbs
                 Input.PullWithoutHistory -> do
                   didUpdate <-
-                    updateAtM
+                    Cli.updateAtM
                       description
                       destAbs
                       (\destBranch -> pure $ remoteBranch `Branch.consBranchSnapshot` destBranch)
@@ -2759,7 +2735,7 @@ mergeBranchAndPropagateDefaultPatch mode inputDescription unchangedMessage srcb 
         Cli.Env {codebase} <- ask
         destb <- Cli.getBranchAt dest
         merged <- liftIO (Branch.merge'' (Codebase.lca codebase) mode srcb destb)
-        b <- updateAtM inputDescription dest (const $ pure merged)
+        b <- Cli.updateAtM inputDescription dest (const $ pure merged)
         for_ maybeDest0 \dest0 -> do
           (ppe, diff) <- diffHelper (Branch.head destb) (Branch.head merged)
           Cli.respondNumbered (ShowDiffAfterMerge dest0 dest ppe diff)
@@ -2802,20 +2778,6 @@ getHQTerms = \case
     hashOnly sh = do
       Cli.Env {codebase} <- ask
       liftIO (Backend.termReferentsByShortHash codebase sh)
-
--- Update a branch at the given path, returning `True` if
--- an update occurred and false otherwise
-updateAtM ::
-  Text ->
-  Path.Absolute ->
-  (Branch IO -> Cli r (Branch IO)) ->
-  Cli r Bool
-updateAtM reason (Path.Absolute p) f = do
-  loopState <- State.get
-  let b = loopState ^. #lastSavedRoot
-  b' <- Branch.modifyAtM p f b
-  updateRoot b' reason
-  pure $ b /= b'
 
 stepAt ::
   Text ->
@@ -2915,19 +2877,7 @@ stepManyAtMNoSync strat actions = do
 syncRoot :: Text -> Cli r ()
 syncRoot description = do
   rootBranch <- Cli.getRootBranch
-  updateRoot rootBranch description
-
-updateRoot :: Branch IO -> Text -> Cli r ()
-updateRoot new reason =
-  Cli.time "updateRoot" do
-    Cli.Env {codebase} <- ask
-    loopState <- State.get
-    let old = loopState ^. #lastSavedRoot
-    when (old /= new) do
-      #root .= new
-      liftIO (Codebase.putRootBranch codebase new)
-      liftIO (Codebase.appendReflog codebase reason old new)
-      #lastSavedRoot .= new
+  Cli.updateRoot rootBranch description
 
 -- | Goal: When deleting, we might be removing the last name of a given definition (i.e. the
 -- definition is going "extinct"). In this case we may wish to take some action or warn the

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -506,6 +506,11 @@ loop e = do
                 (Just merged)
                 (snoc desta "merged")
             MoveBranchI src' dest' -> do
+              when (isNothing src' || dest' == Path.relativeEmpty' || dest' == Path.absoluteEmpty') do
+                hasConfirmed <- confirmedCommand input
+                when (not hasConfirmed) $ do
+                  Cli.returnEarly MoveRootBranchConfirmation
+
               description <- inputDescription input
               doMoveBranch description src' dest'
             MovePatchI src' dest' -> do

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveBranch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveBranch.hs
@@ -22,7 +22,7 @@ doMoveBranch actionDescription hasConfirmed src' dest' = do
   let isRootMove = (Path.isRoot srcAbs || Path.isRoot destAbs)
   when (isRootMove && not hasConfirmed) do
     Cli.returnEarly MoveRootBranchConfirmation
-  srcBranch <- Cli.expectBranchAtPath' (Path.AbsolutePath' src)
+  srcBranch <- Cli.expectBranchAtPath' src'
   rootBranch <- Cli.getRootBranch
   let newRoot =
         rootBranch

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveBranch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveBranch.hs
@@ -2,10 +2,8 @@ module Unison.Codebase.Editor.HandleInput.MoveBranch where
 
 import Data.Configurator ()
 import Unison.Cli.Monad (Cli)
-import qualified Unison.Cli.Monad as Cli
 import qualified Unison.Cli.MonadUtils as Cli
 import qualified Unison.Codebase.Branch as Branch
-import Unison.Codebase.Editor.Output
 import qualified Unison.Codebase.Path as Path
 import Unison.Prelude
 
@@ -21,9 +19,7 @@ doMoveBranch actionDescription maySrc dest' = do
       -- Just add the current root as a child of an empty root
       let newRoot = Branch.modifyAt (Path.unabsolute destAbs) (const rootBranch) Branch.empty
       Cli.updateRoot newRoot actionDescription
-      Cli.respond Success
     moveNamespace src' dest' = do
-      Cli.assertNoBranchAtPath' dest'
       srcAbs <- Cli.resolvePath' src'
       destAbs <- Cli.resolvePath' dest'
       srcBranch <- Cli.expectBranchAtPath' src'
@@ -33,4 +29,3 @@ doMoveBranch actionDescription maySrc dest' = do
               & Branch.modifyAt (Path.unabsolute srcAbs) (const Branch.empty)
               & Branch.modifyAt (Path.unabsolute destAbs) (const srcBranch)
       Cli.updateRoot newRoot actionDescription
-      Cli.respond Success -- could give rando stats about new defns

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveBranch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveBranch.hs
@@ -9,11 +9,11 @@ import Unison.Codebase.Editor.Output
 import qualified Unison.Codebase.Path as Path
 import Unison.Prelude
 
-doMoveBranch :: Text -> Maybe Path.Split' -> Path.Split' -> Cli r ()
-doMoveBranch actionDescription maySrc dest = do
+doMoveBranch :: Text -> Maybe Path.Split' -> Path.Path' -> Cli r ()
+doMoveBranch actionDescription maySrc dest' = do
   case maySrc of
-    Nothing -> moveRoot (Path.unsplit' dest)
-    Just src -> moveNamespace (Path.unsplit' src) (Path.unsplit' dest)
+    Nothing -> moveRoot dest'
+    Just src -> moveNamespace (Path.unsplit' src) dest'
   where
     moveRoot dest' = do
       rootBranch <- Cli.getRootBranch

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveBranch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveBranch.hs
@@ -1,0 +1,36 @@
+module Unison.Codebase.Editor.HandleInput.MoveBranch where
+
+import Data.Configurator ()
+import Unison.Cli.Monad (Cli)
+import qualified Unison.Cli.Monad as Cli
+import qualified Unison.Cli.MonadUtils as Cli
+import qualified Unison.Codebase.Branch as Branch
+import Unison.Codebase.Editor.Output
+import qualified Unison.Codebase.Path as Path
+import Unison.Prelude
+
+doMoveBranch :: Text -> Maybe Path.Split' -> Path.Split' -> Cli r ()
+doMoveBranch actionDescription maySrc dest = do
+  case maySrc of
+    Nothing -> moveRoot (Path.unsplit' dest)
+    Just src -> moveNamespace (Path.unsplit' src) (Path.unsplit' dest)
+  where
+    moveRoot dest' = do
+      rootBranch <- Cli.getRootBranch
+      destAbs <- Cli.resolvePath' dest'
+      -- Just add the current root as a child of an empty root
+      let newRoot = Branch.modifyAt (Path.unabsolute destAbs) (const rootBranch) Branch.empty
+      Cli.updateRoot newRoot actionDescription
+      Cli.respond Success
+    moveNamespace src' dest' = do
+      Cli.assertNoBranchAtPath' dest'
+      srcAbs <- Cli.resolvePath' src'
+      destAbs <- Cli.resolvePath' dest'
+      srcBranch <- Cli.expectBranchAtPath' src'
+      rootBranch <- Cli.getRootBranch
+      let newRoot =
+            rootBranch
+              & Branch.modifyAt (Path.unabsolute srcAbs) (const Branch.empty)
+              & Branch.modifyAt (Path.unabsolute destAbs) (const srcBranch)
+      Cli.updateRoot newRoot actionDescription
+      Cli.respond Success -- could give rando stats about new defns

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveBranch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveBranch.hs
@@ -7,25 +7,14 @@ import qualified Unison.Codebase.Branch as Branch
 import qualified Unison.Codebase.Path as Path
 import Unison.Prelude
 
-doMoveBranch :: Text -> Maybe Path.Split' -> Path.Path' -> Cli r ()
-doMoveBranch actionDescription maySrc dest' = do
-  case maySrc of
-    Nothing -> moveRoot dest'
-    Just src -> moveNamespace (Path.unsplit' src) dest'
-  where
-    moveRoot dest' = do
-      rootBranch <- Cli.getRootBranch
-      destAbs <- Cli.resolvePath' dest'
-      -- Just add the current root as a child of an empty root
-      let newRoot = Branch.modifyAt (Path.unabsolute destAbs) (const rootBranch) Branch.empty
-      Cli.updateRoot newRoot actionDescription
-    moveNamespace src' dest' = do
-      srcAbs <- Cli.resolvePath' src'
-      destAbs <- Cli.resolvePath' dest'
-      srcBranch <- Cli.expectBranchAtPath' src'
-      rootBranch <- Cli.getRootBranch
-      let newRoot =
-            rootBranch
-              & Branch.modifyAt (Path.unabsolute srcAbs) (const Branch.empty)
-              & Branch.modifyAt (Path.unabsolute destAbs) (const srcBranch)
-      Cli.updateRoot newRoot actionDescription
+-- | Moves a branch and its history from one location to another, and saves the new root
+-- branch.
+doMoveBranch :: forall r. Text -> Path.Absolute -> Path.Absolute -> Cli r ()
+doMoveBranch actionDescription src dest = do
+  srcBranch <- Cli.expectBranchAtPath' (Path.AbsolutePath' src)
+  rootBranch <- Cli.getRootBranch
+  let newRoot =
+        rootBranch
+          & Branch.modifyAt (Path.unabsolute src) (const Branch.empty)
+          & Branch.modifyAt (Path.unabsolute dest) (const srcBranch)
+  Cli.updateRoot newRoot actionDescription

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveBranch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveBranch.hs
@@ -2,15 +2,26 @@ module Unison.Codebase.Editor.HandleInput.MoveBranch where
 
 import Data.Configurator ()
 import Unison.Cli.Monad (Cli)
+import qualified Unison.Cli.Monad as Cli
 import qualified Unison.Cli.MonadUtils as Cli
 import qualified Unison.Codebase.Branch as Branch
+import Unison.Codebase.Editor.Output (Output (..))
 import qualified Unison.Codebase.Path as Path
 import Unison.Prelude
 
 -- | Moves a branch and its history from one location to another, and saves the new root
 -- branch.
-doMoveBranch :: forall r. Text -> Path.Absolute -> Path.Absolute -> Cli r ()
-doMoveBranch actionDescription src dest = do
+doMoveBranch :: forall r. Text -> Bool -> Path.Path' -> Path.Path' -> Cli r ()
+doMoveBranch actionDescription hasConfirmed src' dest' = do
+  src <- Cli.resolvePath' src'
+  dest <- Cli.resolvePath' dest'
+
+  destBranchExists <- Cli.branchExistsAtPath' dest'
+  srcAbs <- Cli.resolvePath' src'
+  destAbs <- Cli.resolvePath' dest'
+  let isRootMove = (Path.isRoot srcAbs || Path.isRoot destAbs)
+  when (isRootMove && not hasConfirmed) do
+    Cli.returnEarly MoveRootBranchConfirmation
   srcBranch <- Cli.expectBranchAtPath' (Path.AbsolutePath' src)
   rootBranch <- Cli.getRootBranch
   let newRoot =
@@ -18,3 +29,6 @@ doMoveBranch actionDescription src dest = do
           & Branch.modifyAt (Path.unabsolute src) (const Branch.empty)
           & Branch.modifyAt (Path.unabsolute dest) (const srcBranch)
   Cli.updateRoot newRoot actionDescription
+  if (destBranchExists && not isRootMove)
+    then Cli.respond (MovedOverExistingBranch dest')
+    else Cli.respond Success

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveBranch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveBranch.hs
@@ -13,22 +13,18 @@ import Unison.Prelude
 -- branch.
 doMoveBranch :: forall r. Text -> Bool -> Path.Path' -> Path.Path' -> Cli r ()
 doMoveBranch actionDescription hasConfirmed src' dest' = do
-  src <- Cli.resolvePath' src'
-  dest <- Cli.resolvePath' dest'
-
-  destBranchExists <- Cli.branchExistsAtPath' dest'
   srcAbs <- Cli.resolvePath' src'
   destAbs <- Cli.resolvePath' dest'
+  destBranchExists <- Cli.branchExistsAtPath' dest'
   let isRootMove = (Path.isRoot srcAbs || Path.isRoot destAbs)
   when (isRootMove && not hasConfirmed) do
     Cli.returnEarly MoveRootBranchConfirmation
   srcBranch <- Cli.expectBranchAtPath' src'
-  rootBranch <- Cli.getRootBranch
-  let newRoot =
-        rootBranch
-          & Branch.modifyAt (Path.unabsolute src) (const Branch.empty)
-          & Branch.modifyAt (Path.unabsolute dest) (const srcBranch)
-  Cli.updateRoot newRoot actionDescription
+  let (changeRootPath, srcLoc, destLoc) = Path.longestPathPrefix (Path.unabsolute srcAbs) (Path.unabsolute destAbs)
+  Cli.updateAt actionDescription (Path.Absolute changeRootPath) \changeRoot ->
+    changeRoot
+      & Branch.modifyAt srcLoc (const Branch.empty)
+      & Branch.modifyAt destLoc (const srcBranch)
   if (destBranchExists && not isRootMove)
     then Cli.respond (MovedOverExistingBranch dest')
     else Cli.respond Success

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveBranch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveBranch.hs
@@ -20,6 +20,10 @@ doMoveBranch actionDescription hasConfirmed src' dest' = do
   when (isRootMove && not hasConfirmed) do
     Cli.returnEarly MoveRootBranchConfirmation
   srcBranch <- Cli.expectBranchAtPath' src'
+
+  -- We want the move to appear as a single step in the root namespace, but we need to make
+  -- surgical changes in both the root and the destination, so we make our modifications at the shared parent of
+  -- those changes such that they appear as a single change in the root.
   let (changeRootPath, srcLoc, destLoc) = Path.longestPathPrefix (Path.unabsolute srcAbs) (Path.unabsolute destAbs)
   Cli.updateAt actionDescription (Path.Absolute changeRootPath) \changeRoot ->
     changeRoot

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -109,7 +109,7 @@ data Input
   | -- Move = Rename; It's an HQSplit' not an HQSplit', meaning the arg has to have a name.
     MoveTermI Path.HQSplit' Path.Split'
   | MoveTypeI Path.HQSplit' Path.Split'
-  | MoveBranchI (Maybe Path.Split') Path.Path'
+  | MoveBranchI Path.Path' Path.Path'
   | MovePatchI Path.Split' Path.Split'
   | CopyPatchI Path.Split' Path.Split'
   | -- delete = unname

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -109,7 +109,7 @@ data Input
   | -- Move = Rename; It's an HQSplit' not an HQSplit', meaning the arg has to have a name.
     MoveTermI Path.HQSplit' Path.Split'
   | MoveTypeI Path.HQSplit' Path.Split'
-  | MoveBranchI (Maybe Path.Split') Path.Split'
+  | MoveBranchI (Maybe Path.Split') Path.Path'
   | MovePatchI Path.Split' Path.Split'
   | CopyPatchI Path.Split' Path.Split'
   | -- delete = unname

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -158,6 +158,7 @@ data Output
     DeleteBranchConfirmation
       [(Path', (Names, [SearchResult' Symbol Ann]))]
   | DeleteEverythingConfirmation
+  | MoveRootBranchConfirmation
   | DeletedEverything
   | ListNames
       IsGlobal
@@ -333,6 +334,7 @@ isFailure o = case o of
   SearchTermsNotFound ts -> not (null ts)
   DeleteBranchConfirmation {} -> False
   DeleteEverythingConfirmation -> False
+  MoveRootBranchConfirmation -> False
   DeletedEverything -> False
   ListNames _ _ tys tms -> null tms && null tys
   ListOfLinks _ ds -> null ds

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -159,6 +159,7 @@ data Output
       [(Path', (Names, [SearchResult' Symbol Ann]))]
   | DeleteEverythingConfirmation
   | MoveRootBranchConfirmation
+  | MovedOverExistingBranch Path'
   | DeletedEverything
   | ListNames
       IsGlobal
@@ -335,6 +336,7 @@ isFailure o = case o of
   DeleteBranchConfirmation {} -> False
   DeleteEverythingConfirmation -> False
   MoveRootBranchConfirmation -> False
+  MovedOverExistingBranch {} -> False
   DeletedEverything -> False
   ListNames _ _ tys tms -> null tms && null tys
   ListOfLinks _ ds -> null ds

--- a/unison-cli/src/Unison/Codebase/TranscriptParser.hs
+++ b/unison-cli/src/Unison/Codebase/TranscriptParser.hs
@@ -19,7 +19,7 @@ module Unison.Codebase.TranscriptParser
 where
 
 import Control.Concurrent.STM (atomically)
-import Control.Lens ((^.))
+import Control.Lens ((?~), (^.))
 import qualified Crypto.Random as Random
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Encode.Pretty as Aeson
@@ -466,8 +466,16 @@ run dir stanzas codebase runtime sbRuntime config ucmVersion baseURL = UnliftIO.
       loop s0 = do
         input <- awaitInput s0
         Cli.runCli env s0 (HandleInput.loop input) >>= \case
-          (Cli.Success (), s1) -> loop s1
-          (Cli.Continue, s1) -> loop s1
+          (Cli.Success (), s1) -> do
+            let sNext = case input of
+                  Left _ -> s1
+                  Right inp -> s1 & #lastInput ?~ inp
+            loop sNext
+          (Cli.Continue, s1) -> do
+            let sNext = case input of
+                  Left _ -> s1
+                  Right inp -> s1 & #lastInput ?~ inp
+            loop sNext
           (Cli.HaltRepl, _) -> do
             texts <- readIORef out
             pure $ Text.concat (Text.pack <$> toList (texts :: Seq String))

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -932,11 +932,11 @@ renameBranch =
     "`move.namespace foo bar` renames the path `foo` to `bar`."
     ( \case
         [".", dest] -> first fromString $ do
-          dest <- Path.parseSplit' Path.definitionNameSegment dest
+          dest <- Path.parsePath' dest
           pure $ Input.MoveBranchI Nothing dest
         [src, dest] -> first fromString $ do
           src <- Path.parseSplit' Path.definitionNameSegment src
-          dest <- Path.parseSplit' Path.definitionNameSegment dest
+          dest <- Path.parsePath' dest
           pure $ Input.MoveBranchI (Just src) dest
         _ -> Left (I.help renameBranch)
     )

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -931,13 +931,10 @@ renameBranch =
     [(Required, namespaceArg), (Required, newNameArg)]
     "`move.namespace foo bar` renames the path `foo` to `bar`."
     ( \case
-        [".", dest] -> first fromString $ do
-          dest <- Path.parsePath' dest
-          pure $ Input.MoveBranchI Nothing dest
         [src, dest] -> first fromString $ do
-          src <- Path.parseSplit' Path.definitionNameSegment src
+          src <- Path.parsePath' src
           dest <- Path.parsePath' dest
-          pure $ Input.MoveBranchI (Just src) dest
+          pure $ Input.MoveBranchI src dest
         _ -> Left (I.help renameBranch)
     )
 

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -7,7 +7,7 @@ import Compat (withInterruptHandler)
 import qualified Control.Concurrent.Async as Async
 import Control.Concurrent.STM (atomically)
 import Control.Exception (catch, finally, mask)
-import Control.Lens ((^.))
+import Control.Lens ((?~), (^.))
 import Control.Monad.Catch (MonadMask)
 import qualified Crypto.Random as Random
 import Data.Configurator.Types (Config)
@@ -187,7 +187,11 @@ main dir welcome initialPath (config, cancelConfig) initialInputs runtime sbRunt
         loop0 s0 = do
           let step = do
                 input <- awaitInput s0
-                Cli.runCli env s0 (HandleInput.loop input)
+                (result, resultState) <- Cli.runCli env s0 (HandleInput.loop input)
+                let sNext = case input of
+                      Left _ -> resultState
+                      Right inp -> resultState & #lastInput ?~ inp
+                pure (result, sNext)
           UnliftIO.race waitForInterrupt (UnliftIO.tryAny (restore step)) >>= \case
             -- SIGINT
             Left () -> do

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -848,6 +848,11 @@ notifyUser dir o = case o of
   --   <> P.border 2 (mconcat (fmap pretty uniqueDeletions))
   --   <> P.newline
   --   <> P.wrap "Please repeat the same command to confirm the deletion."
+  MoveRootBranchConfirmation ->
+    pure . P.warnCallout . P.lines $
+      [ "Moves which affect the root branch cannot be undone, are you sure?",
+        "Re-run the same command to proceed."
+      ]
   ListOfDefinitions ppe detailed results ->
     listOfDefinitions ppe detailed results
   ListOfLinks ppe results ->

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -424,12 +424,14 @@ notifyNumbered o = case o of
   ListEdits patch ppe -> showListEdits patch ppe
   where
     absPathToBranchId = Right
-    undoTip =
-      tip $
-        "You can use" <> IP.makeExample' IP.undo
-          <> "or"
-          <> IP.makeExample' IP.viewReflog
-          <> "to undo this change."
+
+undoTip :: P.Pretty P.ColorText
+undoTip =
+  tip $
+    "You can use" <> IP.makeExample' IP.undo
+      <> "or"
+      <> IP.makeExample' IP.viewReflog
+      <> "to undo this change."
 
 showListEdits :: Patch -> PPE.PrettyPrintEnv -> (P.Pretty P.ColorText, NumberedArgs)
 showListEdits patch ppe =
@@ -852,6 +854,12 @@ notifyUser dir o = case o of
     pure . P.warnCallout . P.lines $
       [ "Moves which affect the root branch cannot be undone, are you sure?",
         "Re-run the same command to proceed."
+      ]
+  MovedOverExistingBranch dest' ->
+    pure . P.warnCallout . P.lines $
+      [ P.wrap $ "A branch existed at the destination:" <> prettyPath' dest' <> "so I over-wrote it.",
+        "",
+        undoTip
       ]
   ListOfDefinitions ppe detailed results ->
     listOfDefinitions ppe detailed results

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -35,6 +35,7 @@ library
       Unison.Codebase.Editor.AuthorInfo
       Unison.Codebase.Editor.HandleInput
       Unison.Codebase.Editor.HandleInput.AuthLogin
+      Unison.Codebase.Editor.HandleInput.MoveBranch
       Unison.Codebase.Editor.HandleInput.NamespaceDependencies
       Unison.Codebase.Editor.Input
       Unison.Codebase.Editor.Output

--- a/unison-src/transcripts/move-namespace.md
+++ b/unison-src/transcripts/move-namespace.md
@@ -1,0 +1,128 @@
+# Tests for `move.namespace`
+
+```ucm:hide
+.> builtins.mergeio
+```
+
+## Happy path
+
+Create a namespace and add some history to it
+
+```unison
+a.termInA = 1
+unique type a.T = T
+```
+
+```ucm
+.happy> add
+```
+
+```unison
+a.termInA = 2
+unique type a.T = T1 | T2
+```
+
+```ucm
+.happy> update
+```
+
+Should be able to move the namespace, including its types, terms, and sub-namespaces.
+
+```ucm
+.happy> move.namespace a b
+.happy> ls b
+.happy> history b
+```
+
+
+## Namespace history
+
+
+Create some namespaces and add some history to them
+
+```unison
+a.termInA = 1
+b.termInB = 10
+```
+
+```ucm
+.history> add
+```
+
+```unison
+a.termInA = 2
+b.termInB = 11
+```
+
+```ucm
+.history> update
+```
+
+Now, if we soft-delete a namespace, but move another over it we expect the history to be replaced, and we expect the history from the source to be wiped out.
+
+```ucm
+.history> delete.namespace b
+.history> move.namespace a b
+-- Should be the history from 'a'
+.history> history b
+-- Should be empty
+.history> history a
+```
+
+
+## Moving over an existing branch 
+
+Create some namespace and add some history to them
+
+```unison
+a.termInA = 1
+b.termInB = 10
+```
+
+```ucm
+.existing> add
+```
+
+```unison
+a.termInA = 2
+b.termInB = 11
+```
+
+```ucm
+.existing> update
+.existing> move.namespace a b
+```
+
+## Moving the Root 
+
+I should be able to move the root into a sub-namespace
+
+```ucm
+-- Should request confirmation
+.> move.namespace . .root.at.path
+.> move.namespace . .root.at.path
+.> ls
+.> history
+```
+
+```ucm
+.> ls .root.at.path
+.> history .root.at.path
+```
+
+I should be able to move a sub namespace _over_ the root.
+
+```ucm
+-- Should request confirmation
+.> move.namespace .root.at.path.happy .
+.> move.namespace .root.at.path.happy .
+.> ls
+.> history
+```
+
+
+```ucm:error
+-- should be empty
+.> ls .root.at.path.happy
+.> history .root.at.path.happy
+```

--- a/unison-src/transcripts/move-namespace.output.md
+++ b/unison-src/transcripts/move-namespace.output.md
@@ -276,7 +276,7 @@ I should be able to move the root into a sub-namespace
   
   
   
-  □ 1. #2nas5hrc9s (start of history)
+  □ 1. #ahrsp3ikbo (start of history)
 
 ```
 ```ucm
@@ -292,29 +292,18 @@ I should be able to move the root into a sub-namespace
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #q48335uhmc
+  ⊙ 1. #dlt97rjvvu
   
-    + Adds / updates:
-    
-      existing.b.termInA
-    
     - Deletes:
     
       existing.b.termInB
     
-    = Copies:
+    > Moves:
     
-      Original name     New name(s)
-      happy.b.termInA   existing.b.termInA
-      history.b.termInA existing.b.termInA
+      Original name      New name
+      existing.a.termInA existing.b.termInA
   
-  ⊙ 2. #fefiecr41j
-  
-    - Deletes:
-    
-      existing.a.termInA
-  
-  ⊙ 3. #mn3guc87fn
+  ⊙ 2. #cbqlmluqqe
   
     + Adds / updates:
     
@@ -326,36 +315,26 @@ I should be able to move the root into a sub-namespace
       happy.b.termInA   existing.a.termInA
       history.b.termInA existing.a.termInA
   
-  ⊙ 4. #r4gvd65v1d
+  ⊙ 3. #ui42utbgg6
   
     + Adds / updates:
     
       existing.a.termInA existing.b.termInB
   
-  ⊙ 5. #4qp4d1k6k3
+  ⊙ 4. #99vremteun
   
-    + Adds / updates:
+    > Moves:
     
-      history.b.termInA
-    
-    = Copies:
-    
-      Original name   New name(s)
-      happy.b.termInA history.b.termInA
+      Original name     New name
+      history.a.termInA history.b.termInA
   
-  ⊙ 6. #5r9unf5aat
-  
-    - Deletes:
-    
-      history.a.termInA
-  
-  ⊙ 7. #sa1t93smod
+  ⊙ 5. #j7kntsmsa8
   
     - Deletes:
     
       history.b.termInB
   
-  ⊙ 8. #qu535qeig8
+  ⊙ 6. #369iicce20
   
     + Adds / updates:
     
@@ -366,17 +345,37 @@ I should be able to move the root into a sub-namespace
       Original name   New name(s)
       happy.b.termInA history.a.termInA
   
-  ⊙ 9. #t7u5n8kktl
+  ⊙ 7. #i6gamrc998
   
     + Adds / updates:
     
       history.a.termInA history.b.termInB
   
-  ⊙ 10. #f5qeaed6vu
+  ⊙ 8. #bs4dup0bnq
+  
+    > Moves:
+    
+      Original name   New name
+      happy.a.T       happy.b.T
+      happy.a.T.T1    happy.b.T.T1
+      happy.a.T.T2    happy.b.T.T2
+      happy.a.termInA happy.b.termInA
+  
+  ⊙ 9. #gs8o9jjqv7
   
     + Adds / updates:
     
-      happy.b.T happy.b.T.T1 happy.b.T.T2 happy.b.termInA
+      happy.a.T happy.a.T.T1 happy.a.T.T2 happy.a.termInA
+    
+    - Deletes:
+    
+      happy.a.T.T
+  
+  ⊙ 10. #8afnij51kr
+  
+    + Adds / updates:
+    
+      happy.a.T happy.a.T.T happy.a.termInA
   
   There's more history before the versions shown here. Use
   `history #som3n4m3space` to view history starting from a given
@@ -384,7 +383,7 @@ I should be able to move the root into a sub-namespace
   
   ⠇
   
-  ⊙ 11. #bcgf19c1he
+  ⊙ 11. #ulhuik33de
   
 
 ```

--- a/unison-src/transcripts/move-namespace.output.md
+++ b/unison-src/transcripts/move-namespace.output.md
@@ -1,0 +1,451 @@
+# Tests for `move.namespace`
+
+## Happy path
+
+Create a namespace and add some history to it
+
+```unison
+a.termInA = 1
+unique type a.T = T
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique type a.T
+      a.termInA : Nat
+
+```
+```ucm
+  ☝️  The namespace .happy is empty.
+
+.happy> add
+
+  ⍟ I've added these definitions:
+  
+    unique type a.T
+    a.termInA : Nat
+
+```
+```unison
+a.termInA = 2
+unique type a.T = T1 | T2
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      unique type a.T
+      a.termInA : Nat
+
+```
+```ucm
+.happy> update
+
+  ⍟ I've updated these names to your new definition:
+  
+    unique type a.T
+    a.termInA : Nat
+
+```
+Should be able to move the namespace, including its types, terms, and sub-namespaces.
+
+```ucm
+.happy> move.namespace a b
+
+  Done.
+
+.happy> ls b
+
+  1. T       (type)
+  2. T/      (2 definitions)
+  3. termInA (Nat)
+
+.happy> history b
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ 1. #imgt3sdjum
+  
+    + Adds / updates:
+    
+      T T.T1 T.T2 termInA
+    
+    - Deletes:
+    
+      T.T
+  
+  □ 2. #r71j4144fe (start of history)
+
+```
+## Namespace history
+
+
+Create some namespaces and add some history to them
+
+```unison
+a.termInA = 1
+b.termInB = 10
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      a.termInA : Nat
+      b.termInB : Nat
+
+```
+```ucm
+  ☝️  The namespace .history is empty.
+
+.history> add
+
+  ⍟ I've added these definitions:
+  
+    a.termInA : Nat
+    b.termInB : Nat
+
+```
+```unison
+a.termInA = 2
+b.termInB = 11
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      a.termInA : Nat
+      b.termInB : Nat
+
+```
+```ucm
+.history> update
+
+  ⍟ I've updated these names to your new definition:
+  
+    a.termInA : Nat
+    b.termInB : Nat
+
+```
+Now, if we soft-delete a namespace, but move another over it we expect the history to be replaced, and we expect the history from the source to be wiped out.
+
+```ucm
+.history> delete.namespace b
+
+  Done.
+
+.history> move.namespace a b
+
+  Done.
+
+-- Should be the history from 'a'
+.history> history b
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ 1. #j0cjjqepb3
+  
+    + Adds / updates:
+    
+      termInA
+  
+  □ 2. #m8smmmgjso (start of history)
+
+-- Should be empty
+.history> history a
+
+  ☝️  The namespace .history.a is empty.
+
+```
+## Moving over an existing branch 
+
+Create some namespace and add some history to them
+
+```unison
+a.termInA = 1
+b.termInB = 10
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      a.termInA : Nat
+      b.termInB : Nat
+
+```
+```ucm
+  ☝️  The namespace .existing is empty.
+
+.existing> add
+
+  ⍟ I've added these definitions:
+  
+    a.termInA : Nat
+    b.termInB : Nat
+
+```
+```unison
+a.termInA = 2
+b.termInB = 11
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      a.termInA : Nat
+      b.termInB : Nat
+
+```
+```ucm
+.existing> update
+
+  ⍟ I've updated these names to your new definition:
+  
+    a.termInA : Nat
+    b.termInB : Nat
+
+.existing> move.namespace a b
+
+  ⚠️
+  
+  A branch existed at the destination: b so I over-wrote it.
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
+
+```
+## Moving the Root 
+
+I should be able to move the root into a sub-namespace
+
+```ucm
+-- Should request confirmation
+.> move.namespace . .root.at.path
+
+  ⚠️
+  
+  Moves which affect the root branch cannot be undone, are you sure?
+  Re-run the same command to proceed.
+
+.> move.namespace . .root.at.path
+
+  Done.
+
+.> ls
+
+  1. root/ (650 definitions)
+
+.> history
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  
+  
+  □ 1. #2nas5hrc9s (start of history)
+
+```
+```ucm
+.> ls .root.at.path
+
+  1. builtin/  (644 definitions)
+  2. existing/ (1 definition)
+  3. happy/    (4 definitions)
+  4. history/  (1 definition)
+
+.> history .root.at.path
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ 1. #q48335uhmc
+  
+    + Adds / updates:
+    
+      existing.b.termInA
+    
+    - Deletes:
+    
+      existing.b.termInB
+    
+    = Copies:
+    
+      Original name     New name(s)
+      happy.b.termInA   existing.b.termInA
+      history.b.termInA existing.b.termInA
+  
+  ⊙ 2. #fefiecr41j
+  
+    - Deletes:
+    
+      existing.a.termInA
+  
+  ⊙ 3. #mn3guc87fn
+  
+    + Adds / updates:
+    
+      existing.a.termInA existing.b.termInB
+    
+    = Copies:
+    
+      Original name     New name(s)
+      happy.b.termInA   existing.a.termInA
+      history.b.termInA existing.a.termInA
+  
+  ⊙ 4. #r4gvd65v1d
+  
+    + Adds / updates:
+    
+      existing.a.termInA existing.b.termInB
+  
+  ⊙ 5. #4qp4d1k6k3
+  
+    + Adds / updates:
+    
+      history.b.termInA
+    
+    = Copies:
+    
+      Original name   New name(s)
+      happy.b.termInA history.b.termInA
+  
+  ⊙ 6. #5r9unf5aat
+  
+    - Deletes:
+    
+      history.a.termInA
+  
+  ⊙ 7. #sa1t93smod
+  
+    - Deletes:
+    
+      history.b.termInB
+  
+  ⊙ 8. #qu535qeig8
+  
+    + Adds / updates:
+    
+      history.a.termInA history.b.termInB
+    
+    = Copies:
+    
+      Original name   New name(s)
+      happy.b.termInA history.a.termInA
+  
+  ⊙ 9. #t7u5n8kktl
+  
+    + Adds / updates:
+    
+      history.a.termInA history.b.termInB
+  
+  ⊙ 10. #f5qeaed6vu
+  
+    + Adds / updates:
+    
+      happy.b.T happy.b.T.T1 happy.b.T.T2 happy.b.termInA
+  
+  There's more history before the versions shown here. Use
+  `history #som3n4m3space` to view history starting from a given
+  namespace hash.
+  
+  ⠇
+  
+  ⊙ 11. #bcgf19c1he
+  
+
+```
+I should be able to move a sub namespace _over_ the root.
+
+```ucm
+-- Should request confirmation
+.> move.namespace .root.at.path.happy .
+
+  ⚠️
+  
+  Moves which affect the root branch cannot be undone, are you sure?
+  Re-run the same command to proceed.
+
+.> move.namespace .root.at.path.happy .
+
+  Done.
+
+.> ls
+
+  1. b/    (4 definitions)
+  2. patch (patch)
+
+.> history
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ 1. #ddf955gbso
+  
+    + Adds / updates:
+    
+      b.T b.T.T1 b.T.T2 b.termInA
+  
+  ⊙ 2. #8c8naats2k
+  
+    - Deletes:
+    
+      a.T a.T.T1 a.T.T2 a.termInA
+  
+  ⊙ 3. #qat4i8g3qm
+  
+    + Adds / updates:
+    
+      a.T a.T.T1 a.T.T2 a.termInA
+    
+    - Deletes:
+    
+      a.T.T
+  
+  □ 4. #kfuu64io6v (start of history)
+
+```
+```ucm
+-- should be empty
+.> ls .root.at.path.happy
+
+  nothing to show
+
+.> history .root.at.path.happy
+
+  ☝️  The namespace .root.at.path.happy is empty.
+
+```


### PR DESCRIPTION
## Overview

This PR fixes an issue discovered in https://github.com/unisonweb/unison/issues/3316

Managing nested namespace histories can be a bit confusing, right now "moving" a namespace only moves a snapshot of the current head, which has been causing weird issues for @ceedubs  when trying to manage releases, sometimes resulting in a very unexpected state.

### The problem

The `AllowRewritingHistory` mode was added to `stepManyAt` to allow setting the history of a subnamespace within its parent branches without being "squashed" down by `stepManyAt`. This works, but it has the unintended side-effect that all parents of the intended change are modified _in-place_ rather than being a causal-step. This means that every `move.namespace` actually rewrites history for _all_ parent namespaces except the root (which takes a single step).

This is just a bug in how `AllowRewritingHistory` was written, it turns out nested histories are tricky.

I now think it's much safer to remove `AllowRewritingHistory` entirely and just use something like `updateAtM` to perform the exact updates a given command needs, this PR rewrites `move.namespace` to use this strategy.

For a demo, see the newly added transcript.

## Implementation notes

* Rewrite `move.namespace` so that instead of using `stepManyAt` with the flawed `AllowRewritingHistory` option it now uses `modifyAt` to surgically adjust history exactly as intended.
* Unfortunately the new `returnEarly` feature added recently seems to skip the part where we set `lastInput`, so it was making `confirmed` commands not work as expected. I've moved the setting of `lastInput` up one layer out of the input loop to avoid this. Possibly not an ideal solution, but it was simple and seems to work just fine. I'm open to other suggestions here.
* Adds a confirmation when moving to/from the namespace root, the current implementation of `undo` can't handle undo's for these commands properly so I offer a warning and require confirmation.
* Previously, `move.namespace` would refuse to replace a destination namespace. Now it allows it, but provides a message indicating what happened and how to undo.


## Test coverage

New transcripts 🎉 

## Loose ends

Rewrite all other uses of `AllowRewritingHistory`; there's currently just `pull-request.load` which should be easy enough to fix.


The behaviour of commands with respect to history is pretty arbitrary/inconsistent at this point.
Our guiding metric has been mostly "what feels correct here", but it would be nice to have some unifying rule so that users know what to actually expect. One solution I'd propose (in the distant future) would be to have a single history per-project which exists only at the project root. I.e. each project would have a single `Branch` at the root, and all children would just be `Branch0`'s. We can explore this later on once we're further along with projects

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3348)
<!-- Reviewable:end -->
