### PR TITLE
Resolve path remappings to a partial prefix if one exists

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/RemoteRepo.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/RemoteRepo.hs
@@ -1,8 +1,12 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Unison.Codebase.Editor.RemoteRepo where
 
+import Control.Lens (Lens')
+import qualified Control.Lens as Lens
 import qualified Data.Text as Text
 import qualified U.Util.Monoid as Monoid
 import Unison.Codebase.Path (Path)
@@ -129,6 +133,17 @@ data WriteRemotePath
   = WriteRemotePathGit WriteGitRemotePath
   | WriteRemotePathShare WriteShareRemotePath
   deriving stock (Eq, Show)
+
+-- | A lens which focuses the path of a remote path.
+remotePath_ :: Lens' WriteRemotePath Path
+remotePath_ = Lens.lens getter setter
+  where
+    getter = \case
+      WriteRemotePathGit (WriteGitRemotePath _ path) -> path
+      WriteRemotePathShare (WriteShareRemotePath _ _ path) -> path
+    setter remote path = case remote of
+      WriteRemotePathGit (WriteGitRemotePath repo _) -> WriteRemotePathGit $ WriteGitRemotePath repo path
+      WriteRemotePathShare (WriteShareRemotePath server repo _) -> WriteRemotePathShare $ WriteShareRemotePath server repo path
 
 data WriteGitRemotePath = WriteGitRemotePath
   { repo :: WriteGitRepo,

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -15,11 +15,13 @@ import Control.Monad.Writer (WriterT (..))
 import Data.Bifunctor (first, second)
 import Data.Configurator ()
 import qualified Data.Foldable as Foldable
+import qualified Data.Foldable.Extra as Foldable
 import qualified Data.List as List
 import Data.List.Extra (nubOrd)
 import qualified Data.List.NonEmpty as Nel
 import qualified Data.Map as Map
 import Data.Sequence (Seq (..))
+import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 import Data.Set.NonEmpty (NESet)
 import qualified Data.Set.NonEmpty as NESet
@@ -2388,24 +2390,17 @@ resolveMetadata name = do
 resolveConfiguredUrl :: PushPull -> Path' -> Cli r WriteRemotePath
 resolveConfiguredUrl pushPull destPath' = do
   destPath <- Cli.resolvePath' destPath'
-  let remoteMappingConfigKey = remoteMappingKey destPath
-  Cli.getConfig remoteMappingConfigKey >>= \case
-    Nothing -> do
-      let gitUrlConfigKey = gitUrlKey destPath
-      -- Fall back to deprecated GitUrl key
-      Cli.getConfig gitUrlConfigKey >>= \case
-        Just url ->
-          (WriteRemotePathGit <$> P.parse UriParser.deprecatedWriteGitRemotePath (Text.unpack gitUrlConfigKey) url) & onLeft \err ->
-            Cli.returnEarly (ConfiguredRemoteMappingParseError pushPull destPath url (show err))
-        Nothing -> Cli.returnEarly (NoConfiguredRemoteMapping pushPull destPath)
-    Just url -> do
-      P.parse UriParser.writeRemotePath (Text.unpack remoteMappingConfigKey) url & onLeft \err ->
-        Cli.returnEarly (ConfiguredRemoteMappingParseError pushPull destPath url (show err))
+  whenNothingM (remoteMappingForPath pushPull destPath) do
+    let gitUrlConfigKey = gitUrlKey destPath
+    -- Fall back to deprecated GitUrl key
+    Cli.getConfig gitUrlConfigKey >>= \case
+      Just url ->
+        (WriteRemotePathGit <$> P.parse UriParser.deprecatedWriteGitRemotePath (Text.unpack gitUrlConfigKey) url) & onLeft \err ->
+          Cli.returnEarly (ConfiguredRemoteMappingParseError pushPull destPath url (show err))
+      Nothing -> Cli.returnEarly (NoConfiguredRemoteMapping pushPull destPath)
   where
     gitUrlKey :: Path.Absolute -> Text
     gitUrlKey = configKey "GitUrl"
-    remoteMappingKey :: Path.Absolute -> Text
-    remoteMappingKey = configKey "RemoteMapping"
 
 configKey :: Text -> Path.Absolute -> Text
 configKey k p =
@@ -2414,6 +2409,53 @@ configKey k p =
       :<| fmap
         NameSegment.toText
         (Path.toSeq $ Path.unabsolute p)
+
+-- | Tries to look up a remote mapping for a given path.
+-- Will also resolve paths relative to any mapping which is configured for a parent of that
+-- path.
+--
+-- E.g.
+--
+-- A config which maps:
+--
+-- .myshare.foo -> .me.public.foo
+--
+-- Will resolve the following local paths into share paths like so:
+--
+-- .myshare.foo -> .me.public.foo
+-- .myshare.foo.bar -> .me.public.foo.bar
+-- .myshare.foo.bar.baz -> .me.public.foo.bar.baz
+-- .myshare -> <Nothing>
+remoteMappingForPath :: PushPull -> Path.Absolute -> Cli r (Maybe WriteRemotePath)
+remoteMappingForPath pushPull dest = do
+  pathPrefixes dest & Foldable.firstJustM \(prefix, suffix) -> do
+    let remoteMappingConfigKey = remoteMappingKey prefix
+    Cli.getConfig remoteMappingConfigKey >>= \case
+      Just url -> do
+        let parseResult = P.parse UriParser.writeRemotePath (Text.unpack remoteMappingConfigKey) url
+         in case parseResult of
+              Left err -> Cli.returnEarly (ConfiguredRemoteMappingParseError pushPull dest url (show err))
+              Right wrp -> do
+                let remote = wrp & RemoteRepo.remotePath_ %~ \p -> Path.resolve p suffix
+                 in pure $ Just remote
+      Nothing -> pure Nothing
+  where
+    -- Produces a list of path prefixes and suffixes, from longest prefix to shortest
+    --
+    -- E.g.
+    --
+    -- >>> pathPrefixes ("a" :< "b" :< Path.absoluteEmpty)
+    -- fromList [(.a.b,),(.a,b),(.,a.b)]
+    pathPrefixes :: Path.Absolute -> Seq (Path.Absolute, Path.Path)
+    pathPrefixes p =
+      Path.unabsolute p
+        & Path.toSeq
+        & \seq ->
+          Seq.zip (Seq.inits seq) (Seq.tails seq)
+            & Seq.reverse
+            <&> bimap (Path.Absolute . Path.Path) (Path.Path)
+    remoteMappingKey :: Path.Absolute -> Text
+    remoteMappingKey = configKey "RemoteMapping"
 
 importRemoteShareBranch :: ReadShareRemoteNamespace -> Cli r (Branch IO)
 importRemoteShareBranch rrn@(ReadShareRemoteNamespace {server, repo, path}) = do


### PR DESCRIPTION
## Overview

[Slack thread](https://unisonlanguage.slack.com/archives/C03MY5TMKT6/p1660767583540499)
<img width="775" alt="image" src="https://user-images.githubusercontent.com/6439644/186507464-90a3420f-10d5-4023-aa83-18aefc1886bd.png">


This does that, which allows for mapping an entire section of your tree, but still respecting over-rides if they exist. i.e. if there is some prefix of your current path in your remapping, it will resolve the unmatched path relative to the mapping for the parent.

## Implementation notes

* Configurator is silly in that there doesn't appear to be an easy way to "query" keys (I think it's so you can subscribe to updates easily), so that's annoying, but since paths are generally short I just query for each possible path prefix, then add the remainder of the path on the end.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3358)
<!-- Reviewable:end -->
