### PR TITLE
Don't abort 'add' on missing metadata

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -2262,14 +2262,15 @@ addDefaultMetadata adds =
           resolveDefaultMetadata currentPath' >>= \case
             [] -> pure ()
             dm -> do
-              defaultMeta <-
-                traverse InputPatterns.parseHashQualifiedName dm & onLeft \err ->
-                  Cli.returnEarly $
+              traverse InputPatterns.parseHashQualifiedName dm & \case
+                Left err -> do
+                  Cli.respond $
                     ConfiguredMetadataParseError
                       (Path.absoluteToPath' currentPath')
                       (show dm)
                       err
-              manageLinks True addedNames defaultMeta Metadata.insert
+                Right defaultMeta -> do
+                  manageLinks True addedNames defaultMeta Metadata.insert
 
 resolveDefaultMetadata :: Path.Absolute -> Cli r [String]
 resolveDefaultMetadata path = do


### PR DESCRIPTION
fixes #3357 

## Overview

Ran into this when testing something else:

```
.share.scratch> add

  ⍟ I've added these definitions:

    y : Nat


  ⚠️

  I couldn't find any metadata matching .base.metadata.authors.chrispenner

.share.scratch> ls

  nothing to show

.share.scratch> ls

  nothing to show

.share.scratch> add

  ⊡ Ignored previously added definitions: y

.share.scratch> ls

  1. y (Nat)

```

Which is weird 🤔 

It turns out that `addDefaultMetadata` is doing an early return before the root is synced, but after the 'add' and printing the success message.

There are two ways we could resolve this:

1. Defer printing the 'successfully added message' until after the metadata has been added. Note that this will block people with invalid authors from adding anything.
2. Just print the warning message that metadata failed to link, but carry on with the add.

I went with 2 to avoid blocking folks, this logic also applies to manual `link` `unlink` commands.

## Implementation notes

* Don't early return on failure in `addDefaultMetadata`, we print a warning that the metadata wasn't added, but don't prevent the add/update from succeeding.

One could also solve this by checking for default metadata before adding and fail-fast; but I don't personally think we should prevent adding terms due to missing metadata 🤷🏼‍♂️

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3359)
<!-- Reviewable:end -->
