### PR TITLE
Fix behaviour of names.global

### DIFF
--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -900,7 +900,7 @@ notifyUser dir o = case o of
           then mempty
           else (tip $ "Use " <> IP.makeExample (IP.names True) [] <> " to see more results.")
       formatTerms tms =
-        P.lines . P.nonEmpty $ P.plural tms (P.blue "Term") : (go <$> tms)
+        P.lines . P.nonEmpty $ P.plural tms (P.blue "Term") : List.intersperse "" (go <$> tms)
         where
           go (ref, hqs) =
             P.column2
@@ -908,7 +908,7 @@ notifyUser dir o = case o of
                 ("Names: ", P.group (P.spaced (P.bold . P.syntaxToColor . prettyHashQualified' <$> toList hqs)))
               ]
       formatTypes types =
-        P.lines . P.nonEmpty $ P.plural types (P.blue "Type") : (go <$> types)
+        P.lines . P.nonEmpty $ P.plural types (P.blue "Type") : List.intersperse "" (go <$> types)
         where
           go (ref, hqs) =
             P.column2

--- a/unison-src/transcripts/names.md
+++ b/unison-src/transcripts/names.md
@@ -1,20 +1,46 @@
- Example uses of the `names` command and output
-```ucm:hide
-.> alias.type ##Int .builtins.Int
-```
-
-```unison:hide
-structural type IntTriple = IntTriple (Int, Int, Int)
-intTriple = IntTriple(+1, +1, +1)
-```
+# `names` command
 
 ```ucm:hide
-.> add
+.> builtins.mergeio
+```
+
+Example uses of the `names` command and output
+
+```unison
+-- Some names with the same value
+some.place.x = 1
+some.otherplace.y = 1
+some.otherplace.x = 10
+somewhere.z = 1
+-- Some similar name with a different value
+somewhere.y = 2
 ```
 
 ```ucm
-.> alias.type IntTriple namespc.another.TripleInt
-.> alias.term intTriple namespc.another.tripleInt
-.> names IntTriple
-.> names intTriple
+.> add
+```
+
+
+`names` searches relative to the current path.
+
+```ucm
+-- We can search by suffix and find all definitions named 'x', and each of their aliases respectively.
+-- But we don't see somewhere.z which is has the same value but is out of our namespace
+.some> names x
+-- We can search by hash, and see all aliases of that hash
+.some> names #gjmq673r1v
+-- If the query is absolute, treat it as a `names.global`
+.some> names .some.place.x
+```
+
+`names.global` searches from the root, and absolutely qualifies results
+
+
+```ucm
+-- We can search by suffix and find all definitions in the codebase named 'x', and each of their aliases respectively.
+.some> names.global x
+-- We can search by hash, and see all aliases of that hash in the codebase
+.some> names.global #gjmq673r1v
+-- We can search using an absolute name
+.some> names.global .some.place.x
 ```

--- a/unison-src/transcripts/names.md
+++ b/unison-src/transcripts/names.md
@@ -1,9 +1,5 @@
 # `names` command
 
-```ucm:hide
-.> builtins.mergeio
-```
-
 Example uses of the `names` command and output
 
 ```unison

--- a/unison-src/transcripts/names.output.md
+++ b/unison-src/transcripts/names.output.md
@@ -20,11 +20,11 @@ somewhere.y = 2
   
     ⍟ These new definitions are ok to `add`:
     
-      some.otherplace.x : Nat
-      some.otherplace.y : Nat
-      some.place.x      : Nat
-      somewhere.y       : Nat
-      somewhere.z       : Nat
+      some.otherplace.x : ##Nat
+      some.otherplace.y : ##Nat
+      some.place.x      : ##Nat
+      somewhere.y       : ##Nat
+      somewhere.z       : ##Nat
 
 ```
 ```ucm
@@ -32,11 +32,11 @@ somewhere.y = 2
 
   ⍟ I've added these definitions:
   
-    some.otherplace.x : Nat
-    some.otherplace.y : Nat
-    some.place.x      : Nat
-    somewhere.y       : Nat
-    somewhere.z       : Nat
+    some.otherplace.x : ##Nat
+    some.otherplace.y : ##Nat
+    some.place.x      : ##Nat
+    somewhere.y       : ##Nat
+    somewhere.z       : ##Nat
 
 ```
 `names` searches relative to the current path.

--- a/unison-src/transcripts/names.output.md
+++ b/unison-src/transcripts/names.output.md
@@ -1,36 +1,105 @@
- Example uses of the `names` command and output
+# `names` command
+
+Example uses of the `names` command and output
+
 ```unison
-structural type IntTriple = IntTriple (Int, Int, Int)
-intTriple = IntTriple(+1, +1, +1)
+-- Some names with the same value
+some.place.x = 1
+some.otherplace.y = 1
+some.otherplace.x = 10
+somewhere.z = 1
+-- Some similar name with a different value
+somewhere.y = 2
 ```
 
 ```ucm
-.> alias.type IntTriple namespc.another.TripleInt
 
-  Done.
-
-.> alias.term intTriple namespc.another.tripleInt
-
-  Done.
-
-.> names IntTriple
-
-  Type
-  Hash:  #cp7a2qo5du
-  Names: IntTriple namespc.another.TripleInt
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
   
-  Term
-  Hash:   #cp7a2qo5du#0
-  Names:  IntTriple.IntTriple
+    ⍟ These new definitions are ok to `add`:
+    
+      some.otherplace.x : Nat
+      some.otherplace.y : Nat
+      some.place.x      : Nat
+      somewhere.y       : Nat
+      somewhere.z       : Nat
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    some.otherplace.x : Nat
+    some.otherplace.y : Nat
+    some.place.x      : Nat
+    somewhere.y       : Nat
+    somewhere.z       : Nat
+
+```
+`names` searches relative to the current path.
+
+```ucm
+-- We can search by suffix and find all definitions named 'x', and each of their aliases respectively.
+-- But we don't see somewhere.z which is has the same value but is out of our namespace
+.some> names x
+
+  Terms
+  Hash:   #gjmq673r1v
+  Names:  otherplace.y place.x
+  
+  Hash:   #pi25gcdv0o
+  Names:  otherplace.x
   
   Tip: Use `names.global` to see more results.
 
-.> names intTriple
+-- We can search by hash, and see all aliases of that hash
+.some> names #gjmq673r1v
 
   Term
-  Hash:   #6nuu8h1ib1
-  Names:  intTriple namespc.another.tripleInt
+  Hash:   #gjmq673r1v
+  Names:  otherplace.y place.x
   
   Tip: Use `names.global` to see more results.
+
+-- If the query is absolute, treat it as a `names.global`
+.some> names .some.place.x
+
+  Term
+  Hash:   #gjmq673r1v
+  Names:  .some.otherplace.y .some.place.x .somewhere.z
+  
+  Tip: Use `names.global` to see more results.
+
+```
+`names.global` searches from the root, and absolutely qualifies results
+
+
+```ucm
+-- We can search by suffix and find all definitions in the codebase named 'x', and each of their aliases respectively.
+.some> names.global x
+
+  Terms
+  Hash:   #gjmq673r1v
+  Names:  .some.otherplace.y .some.place.x .somewhere.z
+  
+  Hash:   #pi25gcdv0o
+  Names:  .some.otherplace.x
+
+-- We can search by hash, and see all aliases of that hash in the codebase
+.some> names.global #gjmq673r1v
+
+  Term
+  Hash:   #gjmq673r1v
+  Names:  .some.otherplace.y .some.place.x .somewhere.z
+
+-- We can search using an absolute name
+.some> names.global .some.place.x
+
+  Term
+  Hash:   #gjmq673r1v
+  Names:  .some.otherplace.y .some.place.x .somewhere.z
 
 ```


### PR DESCRIPTION
## Overview

Fixes https://github.com/unisonweb/unison/issues/3294

## Implementation notes

I think the issue was that we were finding all names with `names.global`, but then we use the local names when pretty-printing them. Now I use the correct PPE.

* manually build the correct set of names for each case
* Use a PPE for printing the names rather than using the `names` object

## Interesting/controversial decisions

* If you search with an absolute name using `names` it does a global search and absolutely qualifies results, this was just a quirk in the implementation but I decided to keep it because I think it's a better user experience TBH.

## Test coverage

I rewrote the transcripts to show a few cases.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3367)
<!-- Reviewable:end -->
