### PR TITLE
Fix a bug in the `tryEval` wrapper code

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -816,7 +816,7 @@ try'eval =
     . MatchSum
     $ mapFromList
       [ exnCase lnk msg xtra fail,
-        (1, ([BX], TAbs r $ some r))
+        (1, ([BX], TAbs r (TVar r)))
       ]
   where
     (act, unit, lz, ta, lnk, msg, xtra, fail, r) = fresh9

--- a/unison-src/transcripts-using-base/fix2049.md
+++ b/unison-src/transcripts-using-base/fix2049.md
@@ -18,6 +18,10 @@ tests _ =
       1/0
       ()
   , catcher '(bug "testing")
+  , handle tryEval (do 1+1) with cases
+      { raise _ -> _ } -> Fail "1+1 failed"
+      { 2 } -> Ok "got the right answer"
+      { _ } -> Fail "got the wrong answer"
   ]
 ```
 

--- a/unison-src/transcripts-using-base/fix2049.output.md
+++ b/unison-src/transcripts-using-base/fix2049.output.md
@@ -14,6 +14,10 @@ tests _ =
       1/0
       ()
   , catcher '(bug "testing")
+  , handle tryEval (do 1+1) with cases
+      { raise _ -> _ } -> Fail "1+1 failed"
+      { 2 } -> Ok "got the right answer"
+      { _ } -> Fail "got the wrong answer"
   ]
 ```
 
@@ -44,8 +48,9 @@ tests _ =
   ◉ tests   caught
   ◉ tests   caught
   ◉ tests   caught
+  ◉ tests   got the right answer
   
-  ✅ 3 test(s) passing
+  ✅ 4 test(s) passing
   
   Tip: Use view tests to view the source of a test.
 


### PR DESCRIPTION
It was wrapping the successful result in a `Some` by mistake

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3372)
<!-- Reviewable:end -->
