### PR TITLE
Fix a bug in the argument handling of the runtime

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Stack.hs
+++ b/parser-typechecker/src/Unison/Runtime/Stack.hs
@@ -214,7 +214,7 @@ uargOnto stk sp cop cp0 (ArgN v) = do
         | i < 0 = return ()
         | otherwise = do
             (x :: Int) <- readByteArray stk (sp - indexPrimArray v i)
-            writeByteArray buf (sz - 1 - i) x
+            writeByteArray buf (boff - i) x
             loop $ i - 1
   loop $ sz - 1
   when overwrite $
@@ -224,6 +224,7 @@ uargOnto stk sp cop cp0 (ArgN v) = do
     cp = cp0 + sz
     sz = sizeofPrimArray v
     overwrite = sameMutableByteArray stk cop
+    boff | overwrite = sz - 1 | otherwise = cp0 + sz
 uargOnto stk sp cop cp0 (ArgR i l) = do
   moveByteArray cop cbp stk sbp (bytes l)
   pure $ cp0 + l
@@ -255,9 +256,10 @@ bargOnto stk sp cop cp0 (ArgN v) = do
         | i < 0 = return ()
         | otherwise = do
             x <- readArray stk $ sp - indexPrimArray v i
-            writeArray buf (sz - 1 - i) x
+            writeArray buf (boff - i) x
             loop $ i - 1
   loop $ sz - 1
+
   when overwrite $
     copyMutableArray cop (cp0 + 1) buf 0 sz
   pure cp
@@ -265,6 +267,7 @@ bargOnto stk sp cop cp0 (ArgN v) = do
     cp = cp0 + sz
     sz = sizeofPrimArray v
     overwrite = stk == cop
+    boff | overwrite = sz - 1 | otherwise = cp0 + sz
 bargOnto stk sp cop cp0 (ArgR i l) = do
   copyMutableArray cop (cp0 + 1) stk (sp - i - l + 1) l
   pure $ cp0 + l

--- a/unison-src/transcripts/fix2049.md
+++ b/unison-src/transcripts/fix2049.md
@@ -1,0 +1,53 @@
+```ucm:hide
+.> builtins.merge
+```
+
+```unison
+id x = x
+
+structural ability Stream a where
+  emit : a -> ()
+
+Stream.foldl : (x ->{g} a ->{g} x) -> x -> '{g, Stream a} r -> '{g} x
+Stream.foldl f z str _ =
+  h acc = cases
+    { emit x -> k } -> handle !k with h (f acc x)
+    { _ } -> acc
+  handle !str with h z
+
+Stream.range : Nat -> Nat -> '{Stream Nat} ()
+Stream.range m n = do
+  f : Nat ->{Stream Nat} ()
+  f k = if k < n then emit k ; f (k+1) else ()
+  f m
+
+unique type Fold' g a b x = Fold' (x -> {g} a -> {g} x) x (x -> {g} b)
+
+unique type Fold g a b = Fold (∀ g2 r. (∀ x. Fold' g a b x -> {g2} r) -> {g2} r)
+
+Fold.fromFold' : Fold' g a b x -> Fold g a b
+Fold.fromFold' fold = Fold.Fold (f -> f fold)
+
+Fold.mkFold : (t -> {g} a -> {g} t) -> t -> (t -> {g} b) -> Fold g a b
+Fold.mkFold step init extract =
+  Fold.fromFold' (Fold'.Fold' step init extract)
+
+folds.all : (a -> {g} Boolean) -> Fold g a Boolean
+folds.all predicate =
+  Fold.mkFold (b -> a -> b && (predicate a)) true id
+
+Fold.Stream.fold : Fold g a b -> '{g, Stream a} r -> '{g} b
+Fold.Stream.fold =
+  run: Fold' g a b x -> '{g, Stream a} r -> '{g} b
+  run =
+    cases Fold'.Fold' step init extract ->
+      stream -> _ -> extract !(foldl step init stream)
+  cases
+    Fold f -> stream -> f (f' -> run f' stream)
+
+> folds.all.tests.stream =
+    pred = n -> (Nat.gt n 2)
+    res : 'Boolean
+    res = Fold.Stream.fold (folds.all pred) (Stream.range 1 5)
+    !res Universal.== false
+```

--- a/unison-src/transcripts/fix2049.output.md
+++ b/unison-src/transcripts/fix2049.output.md
@@ -1,0 +1,85 @@
+```unison
+id x = x
+
+structural ability Stream a where
+  emit : a -> ()
+
+Stream.foldl : (x ->{g} a ->{g} x) -> x -> '{g, Stream a} r -> '{g} x
+Stream.foldl f z str _ =
+  h acc = cases
+    { emit x -> k } -> handle !k with h (f acc x)
+    { _ } -> acc
+  handle !str with h z
+
+Stream.range : Nat -> Nat -> '{Stream Nat} ()
+Stream.range m n = do
+  f : Nat ->{Stream Nat} ()
+  f k = if k < n then emit k ; f (k+1) else ()
+  f m
+
+unique type Fold' g a b x = Fold' (x -> {g} a -> {g} x) x (x -> {g} b)
+
+unique type Fold g a b = Fold (∀ g2 r. (∀ x. Fold' g a b x -> {g2} r) -> {g2} r)
+
+Fold.fromFold' : Fold' g a b x -> Fold g a b
+Fold.fromFold' fold = Fold.Fold (f -> f fold)
+
+Fold.mkFold : (t -> {g} a -> {g} t) -> t -> (t -> {g} b) -> Fold g a b
+Fold.mkFold step init extract =
+  Fold.fromFold' (Fold'.Fold' step init extract)
+
+folds.all : (a -> {g} Boolean) -> Fold g a Boolean
+folds.all predicate =
+  Fold.mkFold (b -> a -> b && (predicate a)) true id
+
+Fold.Stream.fold : Fold g a b -> '{g, Stream a} r -> '{g} b
+Fold.Stream.fold =
+  run: Fold' g a b x -> '{g, Stream a} r -> '{g} b
+  run =
+    cases Fold'.Fold' step init extract ->
+      stream -> _ -> extract !(foldl step init stream)
+  cases
+    Fold f -> stream -> f (f' -> run f' stream)
+
+> folds.all.tests.stream =
+    pred = n -> (Nat.gt n 2)
+    res : 'Boolean
+    res = Fold.Stream.fold (folds.all pred) (Stream.range 1 5)
+    !res Universal.== false
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique type Fold g a b
+      unique type Fold' g a b x
+      structural ability Stream a
+      Fold.Stream.fold : Fold g a b
+                         -> '{g, Stream a} r
+                         -> '{g} b
+      Fold.fromFold'   : Fold' g a b x -> Fold g a b
+      Fold.mkFold      : (t ->{g} a ->{g} t)
+                         -> t
+                         -> (t ->{g} b)
+                         -> Fold g a b
+      Stream.foldl     : (x ->{g} a ->{g} x)
+                         -> x
+                         -> '{g, Stream a} r
+                         -> '{g} x
+      Stream.range     : Nat -> Nat -> '{Stream Nat} ()
+      folds.all        : (a ->{g} Boolean) -> Fold g a Boolean
+      id               : x -> x
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    44 |     pred = n -> (Nat.gt n 2)
+           ⧩
+           true
+
+```


### PR DESCRIPTION
The argument handling was sometimes failing to correctly offset some of the arguments. This would lead to partial applications with arguments missing and shifted, causing subsequent problems.

Fixes #2409

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3374)
<!-- Reviewable:end -->
