### PR TITLE
Allow conflicted updates

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/Slurp.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Slurp.hs
@@ -5,10 +5,9 @@ module Unison.Codebase.Editor.Slurp
 where
 
 import Control.Lens
+import qualified Data.Foldable as Foldable
 import qualified Data.Map as Map
-import qualified Data.Semialign as Align
 import qualified Data.Set as Set
-import Data.These
 import Unison.Codebase.Editor.SlurpComponent (SlurpComponent (..))
 import qualified Unison.Codebase.Editor.SlurpComponent as SC
 import qualified Unison.Codebase.Editor.SlurpResult as SR
@@ -52,61 +51,44 @@ untagged (TypeVar v) = v
 untagged (ConstructorVar v) = v
 
 -- | A definition's status with relation to the codebase.
-data SlurpOk
-  = New
-  | Updated
-  | Duplicated
-  deriving (Eq, Ord, Show)
-
--- | Possible error conditions for a definition.
-data SlurpErr
-  = -- | A term in the scratch file conflicts with a Ctor in the codebase
-    TermCtorCollision
-  | -- | A constructor in the scratch file conflicts with a term in the codebase
-    CtorTermCollision
-  | -- | The name of this term is conflicted in the codebase.
-    Conflict
-  deriving (Eq, Ord, Show)
-
--- | Possible statuses for a given definition
 data DefnStatus
-  = DefOk SlurpOk
-  | DefErr SlurpErr
+  = -- | A constructor in the scratch file conflicts with a term in the codebase
+    CtorTermCollision
+  | Duplicated
+  | New
+  | -- | A term in the scratch file conflicts with a Ctor in the codebase
+    TermCtorCollision
+  | -- | The name of the term is already in the codebase (maybe more than once, i.e. conflicted)
+    Updated
   deriving (Eq, Ord, Show)
 
--- | A definition's final status, incorporating the statuses of all of its dependencies.
-data SummarizedStatus v
-  = SelfStatus DefnStatus
-  | -- Dependency Status
-    DepStatus (TaggedVar v) DefnStatus
-  deriving (Eq, Ord, Show)
+-- | A coarser, totally-ordered variant of a defnintion's status, which summarizes its own status and the statuses of
+-- all of its transitive dependencies.
+--
+-- For example, if any transitive dependency of a defnition requires an `update`, then so does the definition itself,
+-- even if it's new (and thus ok to `add`).
+data DepStatus
+  = -- | Part of a term/ctor or ctor/term collision: neither `add` nor `update` ok
+    DepCollision
+  | -- | Requires an update: `add` not ok, `update` ok
+    DepNeedsUpdate
+  | -- | `add` or `update` both ok
+    DepOk
+  deriving stock (Eq, Ord, Show)
 
--- | Ideally we would display all available information about each var to the end-user,
--- but for now we simply pick the "most important" issue to maintain backwards compatibility
--- with current behaviour.
-pickPriorityStatus :: SummarizedStatus v -> SummarizedStatus v -> SummarizedStatus v
-pickPriorityStatus a b =
-  case (a, b) of
-    -- If the definition has its own error, that takes highest priority.
-    (SelfStatus (DefErr err), _) -> SelfStatus (DefErr err)
-    (_, SelfStatus (DefErr err)) -> SelfStatus (DefErr err)
-    -- Next we care if a dependency has an error
-    (DepStatus v (DefErr err), _) -> DepStatus v (DefErr err)
-    (_, DepStatus v (DefErr err)) -> DepStatus v (DefErr err)
-    -- If our definition needs its own update then we don't care if dependencies need updates.
-    (SelfStatus (DefOk Updated), _) -> SelfStatus (DefOk Updated)
-    (_, SelfStatus (DefOk Updated)) -> SelfStatus (DefOk Updated)
-    (DepStatus v (DefOk Updated), _) -> DepStatus v (DefOk Updated)
-    (_, DepStatus v (DefOk Updated)) -> DepStatus v (DefOk Updated)
-    -- Any other 'ok' dependency status doesn't meaningfully affect anything the summary.
-    (DepStatus _ (DefOk _), x) -> x
-    (x, DepStatus _ (DefOk _)) -> x
-    -- 'New' definitions take precedence over duplicated dependencies when reporting status.
-    -- E.g. if a definition has dependencies which are duplicated, but it is itself a new
-    -- definition, we report it as New.
-    (SelfStatus (DefOk New), _) -> SelfStatus (DefOk New)
-    (_, SelfStatus (DefOk New)) -> SelfStatus (DefOk New)
-    (SelfStatus (DefOk Duplicated), _) -> SelfStatus (DefOk Duplicated)
+-- | Classify a definition status into a coarser dependency status.
+defnStatusToDepStatus :: DefnStatus -> DepStatus
+defnStatusToDepStatus = \case
+  CtorTermCollision -> DepCollision
+  Duplicated -> DepOk
+  New -> DepOk
+  TermCtorCollision -> DepCollision
+  Updated -> DepNeedsUpdate
+
+-- | DepCollision more severe than DepNeedsUpdate more severe than DepOk
+mostSevereDepStatus :: DepStatus -> DepStatus -> DepStatus
+mostSevereDepStatus =
+  min
 
 -- | Analyze a file and determine the status of all of its definitions with respect to a set
 -- of vars to analyze and an operation you wish to perform.
@@ -142,15 +124,11 @@ slurpFile uf defsToConsider slurpOp unalteredCodebaseNames =
       -- Compute the status of each definition on its own.
       -- This doesn't consider the vars dependencies.
       selfStatuses :: Map (TaggedVar v) DefnStatus
-      selfStatuses = computeVarStatuses varDeps varReferences codebaseNames
-      -- Determine the _actual_ status of each var by summarizing all of the statuses of its
-      -- dependencies.
-      summaries :: Map (TaggedVar v) (SummarizedStatus v)
-      summaries = summarizeTransitiveStatus selfStatuses varDeps
-      slurpResult :: SR.SlurpResult v
-      slurpResult =
-        toSlurpResult uf slurpOp defsToConsider involvedVars fileNames codebaseNames summaries
-   in slurpResult
+      selfStatuses = computeSelfStatuses involvedVars varReferences codebaseNames
+      -- A mapping from each definition's name to the most severe status of it plus its transitive dependencies.
+      depStatuses :: Map (TaggedVar v) DepStatus
+      depStatuses = computeDepStatuses varDeps selfStatuses
+   in toSlurpResult uf slurpOp defsToConsider involvedVars fileNames codebaseNames selfStatuses depStatuses
   where
     fileNames :: Names
     fileNames = UF.typecheckedToNames uf
@@ -164,12 +142,11 @@ computeNamesWithDeprecations ::
   Set (TaggedVar v) ->
   SlurpOp ->
   Names
-computeNamesWithDeprecations uf unalteredCodebaseNames involvedVars op =
-  case op of
-    AddOp ->
-      -- If we're 'adding', there won't be any deprecations to worry about.
-      unalteredCodebaseNames
-    _ -> codebaseNames
+computeNamesWithDeprecations uf unalteredCodebaseNames involvedVars = \case
+  -- If we're 'adding', there won't be any deprecations to worry about.
+  AddOp -> unalteredCodebaseNames
+  CheckOp -> codebaseNames
+  UpdateOp -> codebaseNames
   where
     -- Get the set of all DIRECT definitions in the file which a definition depends on.
     codebaseNames :: Names
@@ -202,19 +179,16 @@ computeNamesWithDeprecations uf unalteredCodebaseNames involvedVars op =
        in -- Compute any constructors which were deleted
           existingConstructorsFromEditedTypes `Set.difference` constructorsUnderConsideration
 
--- | Compute a mapping of each definition to its status, and its dependencies' statuses.
-computeVarStatuses ::
+-- | Compute a mapping of each definition to its status.
+computeSelfStatuses ::
   forall v.
   (Ord v, Var v) =>
-  Map (TaggedVar v) (Set (TaggedVar v)) ->
+  Set (TaggedVar v) ->
   Map (TaggedVar v) LD.LabeledDependency ->
   Names ->
   Map (TaggedVar v) DefnStatus
-computeVarStatuses depMap varReferences codebaseNames =
-  depMap
-    & Map.mapWithKey
-      ( \tv _ -> definitionStatus tv
-      )
+computeSelfStatuses vars varReferences codebaseNames =
+  Map.fromSet definitionStatus vars
   where
     definitionStatus :: TaggedVar v -> DefnStatus
     definitionStatus tv =
@@ -227,64 +201,36 @@ computeVarStatuses depMap varReferences codebaseNames =
        in case ld of
             LD.TypeReference _typeRef ->
               case Set.toList existingTypesAtName of
-                [] -> DefOk New
+                [] -> New
                 [r]
-                  | LD.typeRef r == ld -> DefOk Duplicated
-                  | otherwise -> DefOk Updated
-                -- If there are many existing types, they must be in conflict.
-                -- Currently we treat conflicts as errors rather than resolving them.
-                _ -> DefErr Conflict
+                  | LD.typeRef r == ld -> Duplicated
+                  | otherwise -> Updated
+                _ -> Updated
             LD.TermReference {} ->
               case Set.toList existingTermsOrCtorsAtName of
-                [] -> DefOk New
-                rs | any Referent.isConstructor rs -> DefErr TermCtorCollision
+                [] -> New
+                rs | any Referent.isConstructor rs -> TermCtorCollision
                 [r]
-                  | LD.referent r == ld -> DefOk Duplicated
-                  | otherwise -> DefOk Updated
-                -- If there are many existing terms, they must be in conflict.
-                -- Currently we treat conflicts as errors rather than resolving them.
-                _ -> DefErr Conflict
+                  | LD.referent r == ld -> Duplicated
+                  | otherwise -> Updated
+                _ -> Updated
             LD.ConReference {} ->
               case Set.toList existingTermsOrCtorsAtName of
-                [] -> DefOk New
-                rs | any (not . Referent.isConstructor) rs -> DefErr CtorTermCollision
+                [] -> New
+                rs | any (not . Referent.isConstructor) rs -> CtorTermCollision
                 [r]
-                  | LD.referent r == ld -> DefOk Duplicated
-                  | otherwise -> DefOk Updated
-                -- If there are many existing terms, they must be in conflict.
-                -- Currently we treat conflicts as errors rather than resolving them.
-                _ -> DefErr Conflict
+                  | LD.referent r == ld -> Duplicated
+                  | otherwise -> Updated
+                _ -> Updated
 
--- | Compute all definitions which can be added, or the reasons why a def can't be added.
-summarizeTransitiveStatus ::
-  forall v.
-  (Ord v, Show v) =>
-  Map (TaggedVar v) DefnStatus ->
-  Map (TaggedVar v) (Set (TaggedVar v)) ->
-  Map (TaggedVar v) (SummarizedStatus v)
-summarizeTransitiveStatus statuses deps =
-  flip imap (Align.align statuses deps) $ \tv -> \case
-    -- No dependencies
-    This selfStatus -> toSummary False selfStatus tv
-    That _set -> error $ "Encountered var without a status during slurping: " <> show tv
-    These selfStatus deps ->
-      let selfSummary = toSummary False selfStatus tv
-          summaryOfDeps = do
-            v <- Set.toList deps
-            depStatus <- maybeToList $ Map.lookup v statuses
-            pure $ toSummary True depStatus v
-       in foldl' pickPriorityStatus selfSummary summaryOfDeps
-  where
-    toSummary :: (Ord v, Show v) => Bool -> DefnStatus -> TaggedVar v -> SummarizedStatus v
-    toSummary isDep defNotes tv =
-      case defNotes of
-        DefOk Updated -> if isDep then DepStatus tv (DefOk Updated) else SelfStatus (DefOk Updated)
-        DefErr err ->
-          if isDep
-            then DepStatus tv (DefErr err)
-            else SelfStatus (DefErr err)
-        DefOk New -> SelfStatus (DefOk New)
-        DefOk Duplicated -> SelfStatus (DefOk Duplicated)
+computeDepStatuses :: Ord k => Map k (Set k) -> Map k DefnStatus -> Map k DepStatus
+computeDepStatuses varDeps selfStatuses =
+  selfStatuses & Map.mapWithKey \name status -> do
+    varDeps
+      & Map.findWithDefault Set.empty name
+      & Set.toList
+      & mapMaybe (\depName -> defnStatusToDepStatus <$> Map.lookup depName selfStatuses)
+      & Foldable.foldr mostSevereDepStatus (defnStatusToDepStatus status)
 
 -- | Determine all variables which should be considered in analysis.
 -- I.e. any variable requested by the user and all of their dependencies,
@@ -419,9 +365,10 @@ toSlurpResult ::
   Set (TaggedVar v) ->
   Names ->
   Names ->
-  Map (TaggedVar v) (SummarizedStatus v) ->
+  Map (TaggedVar v) DefnStatus ->
+  Map (TaggedVar v) DepStatus ->
   SR.SlurpResult v
-toSlurpResult uf op requestedVars involvedVars fileNames codebaseNames summarizedStatuses =
+toSlurpResult uf op requestedVars involvedVars fileNames codebaseNames selfStatuses depStatuses =
   SR.SlurpResult
     { SR.originalFile = uf,
       SR.extraDefinitions =
@@ -449,35 +396,37 @@ toSlurpResult uf op requestedVars involvedVars fileNames codebaseNames summarize
     }
   where
     SlurpingSummary {adds, duplicates, updates, termCtorColl, ctorTermColl, blocked, conflicts} =
-      summarizedStatuses
-        & ifoldMap
-          ( \tv status ->
-              let sc = scFromTaggedVar tv
-               in case status of
-                    SelfStatus (DefOk New) -> mempty {adds = sc}
-                    SelfStatus (DefOk Duplicated) -> mempty {duplicates = sc}
-                    SelfStatus (DefOk Updated) -> mempty {updates = sc}
-                    DepStatus _ (DefOk Updated) ->
-                      case op of
-                        AddOp ->
-                          mempty {blocked = sc}
-                        UpdateOp ->
-                          mempty {adds = sc}
-                        CheckOp ->
-                          mempty {adds = sc}
-                    -- It shouldn't be possible for the two following cases to occur,
-                    -- since a 'SelfStatus' would take priority when summarizing.
-                    DepStatus _ (DefOk New) ->
-                      error $ "Unexpected summary status for " <> show tv <> ": " <> show status
-                    DepStatus _ (DefOk Duplicated) ->
-                      error $ "Unexpected summary status for " <> show tv <> ": " <> show status
-                    DepStatus _ (DefErr TermCtorCollision) -> mempty {blocked = sc}
-                    DepStatus _ (DefErr CtorTermCollision) -> mempty {blocked = sc}
-                    DepStatus _ (DefErr Conflict) -> mempty {blocked = sc}
-                    SelfStatus (DefErr TermCtorCollision) -> mempty {termCtorColl = sc}
-                    SelfStatus (DefErr CtorTermCollision) -> mempty {ctorTermColl = sc}
-                    SelfStatus (DefErr Conflict) -> mempty {conflicts = sc}
-          )
+      ifoldMap summarize1 selfStatuses
+
+    -- Compute a singleton summary for a single definition, per its own status and the most severe status of its
+    -- transitive dependencies.
+    summarize1 :: TaggedVar v -> DefnStatus -> SlurpingSummary v
+    summarize1 name = \case
+      CtorTermCollision -> mempty {ctorTermColl = sc}
+      Duplicated -> mempty {duplicates = sc}
+      TermCtorCollision -> mempty {termCtorColl = sc}
+      New ->
+        case depStatus of
+          DepOk -> mempty {adds = sc}
+          DepNeedsUpdate ->
+            case op of
+              AddOp -> mempty {blocked = sc}
+              CheckOp -> mempty {adds = sc}
+              UpdateOp -> mempty {adds = sc}
+          DepCollision -> mempty {blocked = sc}
+      Updated ->
+        case depStatus of
+          DepOk -> mempty {updates = sc}
+          DepNeedsUpdate -> mempty {updates = sc}
+          DepCollision -> mempty {blocked = sc}
+      where
+        sc :: SlurpComponent v
+        sc =
+          scFromTaggedVar name
+
+        depStatus :: DepStatus
+        depStatus =
+          Map.findWithDefault DepOk name depStatuses
 
     scFromTaggedVar :: TaggedVar v -> SlurpComponent v
     scFromTaggedVar = \case

--- a/unison-cli/src/Unison/Codebase/Editor/Slurp.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Slurp.hs
@@ -67,6 +67,8 @@ data DefnStatus
 --
 -- For example, if any transitive dependency of a defnition requires an `update`, then so does the definition itself,
 -- even if it's new (and thus ok to `add`).
+--
+-- Note: these must be defined in descending severity order, per @mostSevereDepStatus@!
 data DepStatus
   = -- | Part of a term/ctor or ctor/term collision: neither `add` nor `update` ok
     DepCollision
@@ -202,25 +204,19 @@ computeSelfStatuses vars varReferences codebaseNames =
             LD.TypeReference _typeRef ->
               case Set.toList existingTypesAtName of
                 [] -> New
-                [r]
-                  | LD.typeRef r == ld -> Duplicated
-                  | otherwise -> Updated
+                [r] | LD.typeRef r == ld -> Duplicated
                 _ -> Updated
             LD.TermReference {} ->
               case Set.toList existingTermsOrCtorsAtName of
                 [] -> New
                 rs | any Referent.isConstructor rs -> TermCtorCollision
-                [r]
-                  | LD.referent r == ld -> Duplicated
-                  | otherwise -> Updated
+                [r] | LD.referent r == ld -> Duplicated
                 _ -> Updated
             LD.ConReference {} ->
               case Set.toList existingTermsOrCtorsAtName of
                 [] -> New
                 rs | any (not . Referent.isConstructor) rs -> CtorTermCollision
-                [r]
-                  | LD.referent r == ld -> Duplicated
-                  | otherwise -> Updated
+                [r] | LD.referent r == ld -> Duplicated
                 _ -> Updated
 
 computeDepStatuses :: Ord k => Map k (Set k) -> Map k DefnStatus -> Map k DepStatus

--- a/unison-cli/src/Unison/Codebase/Editor/Slurp.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Slurp.hs
@@ -336,13 +336,12 @@ data SlurpingSummary v = SlurpingSummary
     updates :: !(SlurpComponent v),
     termCtorColl :: !(SlurpComponent v),
     ctorTermColl :: !(SlurpComponent v),
-    blocked :: !(SlurpComponent v),
-    conflicts :: !(SlurpComponent v)
+    blocked :: !(SlurpComponent v)
   }
 
-instance (Ord v) => Semigroup (SlurpingSummary v) where
-  SlurpingSummary a b c d e f g
-    <> SlurpingSummary a' b' c' d' e' f' g' =
+instance Ord v => Semigroup (SlurpingSummary v) where
+  SlurpingSummary a b c d e f
+    <> SlurpingSummary a' b' c' d' e' f' =
       SlurpingSummary
         (a <> a')
         (b <> b')
@@ -350,10 +349,9 @@ instance (Ord v) => Semigroup (SlurpingSummary v) where
         (d <> d')
         (e <> e')
         (f <> f')
-        (g <> g')
 
-instance (Ord v) => Monoid (SlurpingSummary v) where
-  mempty = SlurpingSummary mempty mempty mempty mempty mempty mempty mempty
+instance Ord v => Monoid (SlurpingSummary v) where
+  mempty = SlurpingSummary mempty mempty mempty mempty mempty mempty
 
 -- | Convert a 'VarsByStatus' mapping into a 'SR.SlurpResult'
 toSlurpResult ::
@@ -382,7 +380,6 @@ toSlurpResult uf op requestedVars involvedVars fileNames codebaseNames selfStatu
       SR.adds = adds,
       SR.duplicates = duplicates,
       SR.collisions = if op == AddOp then updates else mempty,
-      SR.conflicts = conflicts,
       SR.updates = if op /= AddOp then updates else mempty,
       SR.termExistingConstructorCollisions =
         let SlurpComponent {types, terms, ctors} = termCtorColl
@@ -395,7 +392,7 @@ toSlurpResult uf op requestedVars involvedVars fileNames codebaseNames selfStatu
       SR.defsWithBlockedDependencies = blocked
     }
   where
-    SlurpingSummary {adds, duplicates, updates, termCtorColl, ctorTermColl, blocked, conflicts} =
+    SlurpingSummary {adds, duplicates, updates, termCtorColl, ctorTermColl, blocked} =
       ifoldMap summarize1 selfStatuses
 
     -- Compute a singleton summary for a single definition, per its own status and the most severe status of its

--- a/unison-cli/src/Unison/Codebase/Editor/SlurpResult.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/SlurpResult.hs
@@ -1,9 +1,23 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ViewPatterns #-}
 
-module Unison.Codebase.Editor.SlurpResult where
+module Unison.Codebase.Editor.SlurpResult
+  ( -- * Slurp result
+    SlurpResult (..),
+    Aliases (..),
+
+    -- ** Predicates
+    isOk,
+    isAllDuplicates,
+    hasAddsOrUpdates,
+
+    -- ** Pretty-printing
+    pretty,
+
+    -- * Definion status
+    Status (..),
+    prettyStatus,
+  )
+where
 
 import qualified Data.Map as Map
 import qualified Data.Set as Set
@@ -84,15 +98,6 @@ data Status
   | ExtraDefinition
   | BlockedDependency
   deriving (Ord, Eq, Show)
-
-isFailure :: Status -> Bool
-isFailure s = case s of
-  TermExistingConstructorCollision -> True
-  ConstructorExistingTermCollision -> True
-  BlockedDependency -> True
-  Collision -> True
-  Conflicted -> True
-  _ -> False
 
 prettyStatus :: Status -> P.Pretty P.ColorText
 prettyStatus s = case s of
@@ -326,46 +331,3 @@ isAllDuplicates SlurpResult {..} =
     emptyIgnoringConstructors :: SlurpComponent v -> Bool
     emptyIgnoringConstructors SlurpComponent {types, terms} =
       null types && null terms
-
--- stack repl
---
--- λ> import Unison.Util.Pretty
--- λ> import Unison.Codebase.Editor.SlurpResult
--- λ> putStrLn $ toANSI 80 ex
-ex :: P.Pretty P.ColorText
-ex =
-  P.indentN 2 $
-    P.lines
-      [ "",
-        P.green "▣ I've added these definitions: ",
-        "",
-        P.indentN 2 . P.column2 $ [("a", "Nat"), ("map", "(a -> b) -> [a] -> [b]")],
-        "",
-        P.green "▣ I've updated these definitions: ",
-        "",
-        P.indentN 2 . P.column2 $ [("c", "Nat"), ("flatMap", "(a -> [b]) -> [a] -> [b]")],
-        "",
-        P.wrap $ P.red "x" <> P.bold "These definitions couldn't be added:",
-        "",
-        P.indentN 2 $
-          P.lines
-            [ P.column2
-                [ ( P.hiBlack
-                      "Reason for failure    Symbol ",
-                    P.hiBlack "Type"
-                  ),
-                  ("ctor/term collision   foo ", "Nat"),
-                  ("failed dependency     zoot ", "[a] -> [a] -> [a]"),
-                  ("term/ctor collision   unique type Foo ", "f x")
-                ],
-              "",
-              "Tip: use `help filestatus` to learn more."
-            ],
-        "",
-        "⊡ Ignoring previously added definitions: "
-          <> P.indentNAfterNewline
-            2
-            ( P.hiBlack (P.wrap $ P.sep " " ["zonk", "anotherOne", "List.wrangle", "oatbag", "blarg", "mcgee", P.group "ability Woot"])
-            ),
-        ""
-      ]

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1652,12 +1652,6 @@ helpTopicsMap =
                   <> "update."
               ),
               blankline,
-              ( P.bold $ SR.prettyStatus SR.Conflicted,
-                "A definition with the same name as an existing definition."
-                  <> "Resolving the conflict and then trying an `update` again will"
-                  <> "turn this into a successful update."
-              ),
-              blankline,
               ( P.bold $ SR.prettyStatus SR.TermExistingConstructorCollision,
                 "A definition with the same name as an existing constructor for "
                   <> "some data type. Rename your definition or the data type before"

--- a/unison-src/transcripts/diff-namespace.md
+++ b/unison-src/transcripts/diff-namespace.md
@@ -143,14 +143,6 @@ a = 555
 .> diff.namespace nsx nsw
 .nsw> view a b
 ```
-```unison
-a = 777
-```
-
-```ucm:error
-.nsw> update
-.nsw> view a b
-```
 
 ## Should be able to diff a namespace hash from history.
 

--- a/unison-src/transcripts/diff-namespace.output.md
+++ b/unison-src/transcripts/diff-namespace.output.md
@@ -629,56 +629,6 @@ a = 555
     a#mdl4vqtu00 + 1
 
 ```
-```unison
-a = 777
-```
-
-```ucm
-
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-  
-    x These definitions would fail on `add` or `update`:
-    
-      Reason
-      conflicted   a   : Nat
-    
-      Tip: Use `help filestatus` to learn more.
-
-```
-```ucm
-.nsw> update
-
-  x These definitions failed:
-  
-    Reason
-    conflicted   a   : Nat
-  
-    Tip: Use `help filestatus` to learn more.
-
-  I tried to auto-apply the patch, but couldn't because it
-  contained contradictory entries.
-
-.nsw> view a b
-
-  a#mdl4vqtu00 : Nat
-  a#mdl4vqtu00 = 444
-  
-  a#vrs8gtkl2t : Nat
-  a#vrs8gtkl2t = 555
-  
-  b#aapqletas7 : Nat
-  b#aapqletas7 =
-    use Nat +
-    a#vrs8gtkl2t + 1
-  
-  b#unkqhuu66p : Nat
-  b#unkqhuu66p =
-    use Nat +
-    a#mdl4vqtu00 + 1
-
-```
 ## Should be able to diff a namespace hash from history.
 
 ```unison

--- a/unison-src/transcripts/update-on-conflict.md
+++ b/unison-src/transcripts/update-on-conflict.md
@@ -14,18 +14,15 @@ Cause a conflict:
 .> add
 .merged> merge .a
 .merged> merge .b
-.> cd .
 ```
 
-Ideally we could just define the canonical `x` that we want, and update
-to accept it, but we can't:
+Updating conflicted definitions works fine, and the associated patch contains two entries.
 
 ```unison
-x = 1 + 2
+x = 3
 ```
 
-Update fails on conflicted `x`:
-
-```ucm:error
+```ucm
 .merged> update
+.merged> view.patch
 ```

--- a/unison-src/transcripts/update-on-conflict.output.md
+++ b/unison-src/transcripts/update-on-conflict.output.md
@@ -59,14 +59,11 @@ Cause a conflict:
        can use `undo` or `reflog` to undo the results of this
        merge.
 
-.> cd .
-
 ```
-Ideally we could just define the canonical `x` that we want, and update
-to accept it, but we can't:
+Updating conflicted definitions works fine, and the associated patch contains two entries.
 
 ```unison
-x = 1 + 2
+x = 3
 ```
 
 ```ucm
@@ -75,21 +72,27 @@ x = 1 + 2
   do an `add` or `update`, here's how your codebase would
   change:
   
-    ⍟ These new definitions are ok to `add`:
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
     
       x : Nat
 
 ```
-Update fails on conflicted `x`:
-
 ```ucm
 .merged> update
 
-  x These definitions failed:
+  ⍟ I've updated these names to your new definition:
   
-    Reason
-    conflicted   x   : Nat
+    x : Nat
+
+.merged> view.patch
+
+  Edited Terms:
+    1. b.x -> 3. x
+    2. a.x -> 4. x
   
-    Tip: Use `help filestatus` to learn more.
+  Tip: To remove entries from a patch, use
+       delete.term-replacement or delete.type-replacement, as
+       appropriate.
 
 ```


### PR DESCRIPTION
## Overview

Fixes #3308 

This PR relaxes the requirement that a conflicted term or type be renamed prior to applying an `update`.

Before, two conflicted terms `foo#123` and `foo#456` could not be resolved by defining `foo` in a `scratch.u` file and running `update`. Now, they can.

## Implementation notes

During "slurp", when we classify each definition as a new, a duplicate, a term/ctor conflict, et cetera, we no longer have a classification for definitions that are already conflicted in the codebase. Now, whether or not there already exists exactly one or more than one definition in the codebase with the same name as a new term, it's classified as an update.

## Test coverage

The `update-on-conflict` transcript has been updated to account for the new behavior of accepting updates to conflicted definitions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3375)
<!-- Reviewable:end -->
