### PR TITLE
Change error message, constructor, functions from `vector` to `list` (closes  #3360)

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -71,3 +71,4 @@ The format for this list: name, GitHub handle
 * Dan Freeman (@dfreeman)
 * Emil Hotkowski (@emilhotkowski)
 * Jesse Looney (@jesselooney)
+* Vlad Posmangiu Luchian (@cstml)

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -261,7 +261,7 @@ renderTypeError e env src curPath = case e of
               style ErrorSite "then",
               " clause."
             ]
-        VectorBody -> "The elements of a vector all need to have the same type."
+        ListBody -> "All the elements of a list need to have the same type."
         CaseBody ->
           mconcat
             [ "Each case of a ",

--- a/parser-typechecker/src/Unison/Typechecker/TypeError.hs
+++ b/parser-typechecker/src/Unison/Typechecker/TypeError.hs
@@ -17,7 +17,7 @@ import Prelude hiding (all, and, or)
 data BooleanMismatch = CondMismatch | AndMismatch | OrMismatch | GuardMismatch
   deriving (Show)
 
-data ExistentialMismatch = IfBody | VectorBody | CaseBody
+data ExistentialMismatch = IfBody | ListBody | CaseBody
   deriving (Show)
 
 data TypeError v loc
@@ -135,7 +135,7 @@ allErrors =
       cond,
       matchGuard,
       ifBody,
-      vectorBody,
+      listBody,
       matchBody,
       applyingFunction,
       applyingNonFunction,
@@ -288,11 +288,11 @@ existentialMismatch0 em getExpectedLoc = do
       n
 
 ifBody,
-  vectorBody,
+  listBody,
   matchBody ::
     (Var v, Ord loc) => Ex.ErrorExtractor v loc (TypeError v loc)
 ifBody = existentialMismatch0 IfBody (Ex.inSynthesizeApp >> Ex.inIfBody)
-vectorBody = existentialMismatch0 VectorBody (Ex.inSynthesizeApp >> Ex.inVector)
+listBody = existentialMismatch0 ListBody (Ex.inSynthesizeApp >> Ex.inVector)
 matchBody = existentialMismatch0 CaseBody (Ex.inMatchBody >> Ex.inMatch)
 
 applyingNonFunction :: Var v => Ex.ErrorExtractor v loc (TypeError v loc)

--- a/parser-typechecker/tests/Unison/Test/Typechecker/TypeError.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker/TypeError.hs
@@ -25,7 +25,7 @@ test =
       y "> match 3 with 3 | 3 -> 3" Err.matchGuard,
       y "> match 3 with\n 3 -> 3\n 4 -> \"surprise\"" Err.matchBody,
       -- , y "> match 3 with true -> true" Err.
-      y "> [1, +1]" Err.vectorBody,
+      y "> [1, +1]" Err.listBody,
       n "> true && ((x -> x + 1) true)" Err.and,
       n "> true || ((x -> x + 1) true)" Err.or,
       n "> if ((x -> x + 1) true) then 1 else 2" Err.cond,


### PR DESCRIPTION
## Overview

Changes the error pretty print error message from `vector` to `list` #3360 and rephrases it in a more naturally reading way. 

## Implementation notes

The PR also reflects the change at the type level - changing the name of the Constructor and the functions.

## Interesting/controversial decisions

None

## Test coverage

Tests have been refactored to include the function binder change.

## Loose ends

None

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3380)
<!-- Reviewable:end -->
