### PR TITLE
Show self-references in `todo` output

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
@@ -1009,7 +1009,7 @@ causalHashesByPrefix (ShortBranchHash b32prefix) = do
 dependents :: C.Reference -> Transaction (Set C.Reference.Id)
 dependents r = do
   r' <- c2sReference r
-  sIds :: [S.Reference.Id] <- Q.getDependentsForDependency r'
+  sIds :: [S.Reference.Id] <- Q.getDependentsForDependency Q.ExcludeOwnComponent r'
   cIds <- traverse s2cReferenceId sIds
   pure $ Set.fromList cIds
 

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
@@ -1006,10 +1006,10 @@ causalHashesByPrefix (ShortBranchHash b32prefix) = do
   pure $ Set.fromList . map CausalHash $ hashes
 
 -- | returns a list of known definitions referencing `r`
-dependents :: C.Reference -> Transaction (Set C.Reference.Id)
-dependents r = do
+dependents :: Q.DependentsSelector -> C.Reference -> Transaction (Set C.Reference.Id)
+dependents selector r = do
   r' <- c2sReference r
-  sIds <- Q.getDependentsForDependency Q.ExcludeOwnComponent r'
+  sIds <- Q.getDependentsForDependency selector r'
   Set.traverse s2cReferenceId sIds
 
 -- | returns a list of known definitions referencing `h`

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
@@ -1009,9 +1009,8 @@ causalHashesByPrefix (ShortBranchHash b32prefix) = do
 dependents :: C.Reference -> Transaction (Set C.Reference.Id)
 dependents r = do
   r' <- c2sReference r
-  sIds :: [S.Reference.Id] <- Q.getDependentsForDependency Q.ExcludeOwnComponent r'
-  cIds <- traverse s2cReferenceId sIds
-  pure $ Set.fromList cIds
+  sIds <- Q.getDependentsForDependency Q.ExcludeOwnComponent r'
+  Set.traverse s2cReferenceId sIds
 
 -- | returns a list of known definitions referencing `h`
 dependentsOfComponent :: H.Hash -> Transaction (Set C.Reference.Id)

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -1291,13 +1291,14 @@ data DependentsSelector
   | ExcludeOwnComponent
 
 -- | Get dependents of a dependency.
-getDependentsForDependency :: DependentsSelector -> Reference.Reference -> Transaction [Reference.Id]
+getDependentsForDependency :: DependentsSelector -> Reference.Reference -> Transaction (Set Reference.Id)
 getDependentsForDependency selector dependency = do
   dependents <- queryListRow sql dependency
-  pure case selector of
-    IncludeAllDependents -> dependents
-    ExcludeOwnReference -> filter isNotSelfReference dependents
-    ExcludeOwnComponent -> filter isNotReferenceFromOwnComponent dependents
+  pure . Set.fromList $
+    case selector of
+      IncludeAllDependents -> dependents
+      ExcludeOwnReference -> filter isNotSelfReference dependents
+      ExcludeOwnComponent -> filter isNotReferenceFromOwnComponent dependents
   where
     sql =
       [here|

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -95,6 +95,7 @@ module U.Codebase.Sqlite.Queries
 
     -- ** dependents index
     addToDependentsIndex,
+    DependentsSelector (..),
     getDependentsForDependency,
     getDependentsForDependencyComponent,
     getDependenciesForDependent,
@@ -1277,10 +1278,26 @@ addToDependentsIndex dependency dependent = execute sql (dependency :. dependent
     ON CONFLICT DO NOTHING
   |]
 
--- | Get non-self, user-defined dependents of a dependency.
-getDependentsForDependency :: Reference.Reference -> Transaction [Reference.Id]
-getDependentsForDependency dependency =
-  filter isNotSelfReference <$> queryListRow sql dependency
+-- | Which dependents should be returned?
+--
+-- * /IncludeAllDependents/. Include all dependents, including references from one's own component-mates, and references
+-- from oneself (e.g. those in recursive functions)
+-- * /ExcludeOwnReference/. Include all dependents, including references from one's own component-mates, but excluding
+-- actual self references (e.g. those in recursive functions).
+-- * /ExcludeOwnComponent/. Include all dependents outside of one's own component.
+data DependentsSelector
+  = IncludeAllDependents
+  | ExcludeOwnReference
+  | ExcludeOwnComponent
+
+-- | Get dependents of a dependency.
+getDependentsForDependency :: DependentsSelector -> Reference.Reference -> Transaction [Reference.Id]
+getDependentsForDependency selector dependency = do
+  dependents <- queryListRow sql dependency
+  pure case selector of
+    IncludeAllDependents -> dependents
+    ExcludeOwnReference -> filter isNotSelfReference dependents
+    ExcludeOwnComponent -> filter isNotReferenceFromOwnComponent dependents
   where
     sql =
       [here|
@@ -1291,11 +1308,17 @@ getDependentsForDependency dependency =
           AND dependency_component_index IS ?
       |]
 
+    isNotReferenceFromOwnComponent :: Reference.Id -> Bool
+    isNotReferenceFromOwnComponent =
+      case dependency of
+        ReferenceBuiltin _ -> const True
+        ReferenceDerived (C.Reference.Id oid0 _pos0) -> \(C.Reference.Id oid1 _pos1) -> oid0 /= oid1
+
     isNotSelfReference :: Reference.Id -> Bool
     isNotSelfReference =
       case dependency of
         ReferenceBuiltin _ -> const True
-        ReferenceDerived (C.Reference.Id oid0 _pos0) -> \(C.Reference.Id oid1 _pos1) -> oid0 /= oid1
+        ReferenceDerived ref -> (ref /=)
 
 getDependentsForDependencyComponent :: ObjectId -> Transaction [Reference.Id]
 getDependentsForDependencyComponent dependency =

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -1282,12 +1282,12 @@ addToDependentsIndex dependency dependent = execute sql (dependency :. dependent
 --
 -- * /IncludeAllDependents/. Include all dependents, including references from one's own component-mates, and references
 -- from oneself (e.g. those in recursive functions)
--- * /ExcludeOwnReference/. Include all dependents, including references from one's own component-mates, but excluding
+-- * /ExcludeSelf/. Include all dependents, including references from one's own component-mates, but excluding
 -- actual self references (e.g. those in recursive functions).
 -- * /ExcludeOwnComponent/. Include all dependents outside of one's own component.
 data DependentsSelector
   = IncludeAllDependents
-  | ExcludeOwnReference
+  | ExcludeSelf
   | ExcludeOwnComponent
 
 -- | Get dependents of a dependency.
@@ -1297,7 +1297,7 @@ getDependentsForDependency selector dependency = do
   pure . Set.fromList $
     case selector of
       IncludeAllDependents -> dependents
-      ExcludeOwnReference -> filter isNotSelfReference dependents
+      ExcludeSelf -> filter isNotSelfReference dependents
       ExcludeOwnComponent -> filter isNotReferenceFromOwnComponent dependents
   where
     sql =

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -112,6 +112,7 @@ import qualified Data.Set as Set
 import qualified U.Codebase.Branch as V2
 import qualified U.Codebase.Branch as V2Branch
 import qualified U.Codebase.Causal as V2Causal
+import qualified U.Codebase.Sqlite.Queries as Queries
 import U.Util.Timing (time)
 import qualified Unison.Builtin as Builtin
 import qualified Unison.Builtin.Terms as Builtin
@@ -339,11 +340,11 @@ componentReferencesForReference c = \case
 
 -- | Get the set of terms, type declarations, and builtin types that depend on the given term, type declaration, or
 -- builtin type.
-dependents :: Functor m => Codebase m v a -> Reference -> m (Set Reference)
-dependents c r =
+dependents :: Functor m => Codebase m v a -> Queries.DependentsSelector -> Reference -> m (Set Reference)
+dependents c selector r =
   Set.union (Builtin.builtinTypeDependents r)
     . Set.map Reference.DerivedId
-    <$> dependentsImpl c r
+    <$> dependentsImpl c selector r
 
 dependentsOfComponent :: Functor f => Codebase f v a -> Hash -> f (Set Reference)
 dependentsOfComponent c h =

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -320,9 +320,9 @@ sqliteCodebase debugName root localOrRemote action = do
             patchExists h =
               runTransaction (CodebaseOps.patchExists h)
 
-            dependentsImpl :: Reference -> m (Set Reference.Id)
-            dependentsImpl r =
-              runTransaction (CodebaseOps.dependentsImpl r)
+            dependentsImpl :: Q.DependentsSelector -> Reference -> m (Set Reference.Id)
+            dependentsImpl selector r =
+              runTransaction (CodebaseOps.dependentsImpl selector r)
 
             dependentsOfComponentImpl :: Hash -> m (Set Reference.Id)
             dependentsOfComponentImpl h =

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -430,10 +430,10 @@ putPatch h p =
 patchExists :: Branch.EditHash -> Transaction Bool
 patchExists h = fmap isJust $ Q.loadPatchObjectIdForPrimaryHash (Cv.patchHash1to2 h)
 
-dependentsImpl :: Reference -> Transaction (Set Reference.Id)
-dependentsImpl r =
+dependentsImpl :: Q.DependentsSelector -> Reference -> Transaction (Set Reference.Id)
+dependentsImpl selector r =
   Set.map Cv.referenceid2to1
-    <$> Ops.dependents (Cv.reference1to2 r)
+    <$> Ops.dependents selector (Cv.reference1to2 r)
 
 dependentsOfComponentImpl :: Hash -> Transaction (Set Reference.Id)
 dependentsOfComponentImpl h =

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -16,6 +16,7 @@ where
 import qualified U.Codebase.Branch as V2
 import qualified U.Codebase.Reference as V2
 import qualified U.Codebase.Reflog as Reflog
+import qualified U.Codebase.Sqlite.Queries as Queries
 import Unison.Codebase.Branch (Branch)
 import qualified Unison.Codebase.Branch as Branch
 import qualified Unison.Codebase.Editor.Git as Git
@@ -108,7 +109,7 @@ data Codebase m v a = Codebase
     patchExists :: Branch.EditHash -> m Bool,
     -- | Get the set of user-defined terms and type declarations that depend on the given term, type declaration, or
     -- builtin type.
-    dependentsImpl :: Reference -> m (Set Reference.Id),
+    dependentsImpl :: Queries.DependentsSelector -> Reference -> m (Set Reference.Id),
     dependentsOfComponentImpl :: Hash -> m (Set Reference.Id),
     -- | Copy a branch and all of its dependencies from the given codebase into this one.
     syncFromDirectory :: CodebasePath -> SyncMode -> Branch m -> m (),

--- a/unison-cli/src/Unison/Codebase/Editor/Propagate.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Propagate.hs
@@ -707,7 +707,7 @@ computeDirty getDependents patch shouldUpdate =
 computeFrontier :: Patch -> (Reference -> Bool) -> Cli r (R.Relation Reference Reference)
 computeFrontier patch shouldUpdate = do
   Cli.Env {codebase} <- ask
-  -- (r,r2) ∈ dependsOn if r depends on r2
+  -- (r,r2) ∈ dependsOn if r depends on r2, excluding self-references (i.e. (r,r))
   dependsOn <- liftIO (foldMapM (dependentsOf codebase) edited)
   -- Dirty is everything that `dependsOn` Frontier, minus already edited defns
   pure $ R.filterDom (flip Set.notMember edited) dependsOn
@@ -719,5 +719,5 @@ computeFrontier patch shouldUpdate = do
       Reference ->
       IO (R.Relation Reference Reference)
     dependentsOf codebase ref = do
-      dependents <- Codebase.dependents codebase Queries.ExcludeOwnComponent ref
+      dependents <- Codebase.dependents codebase Queries.ExcludeSelf ref
       pure (R.fromManyDom (Set.filter shouldUpdate dependents) ref)

--- a/unison-src/transcripts/todo.md
+++ b/unison-src/transcripts/todo.md
@@ -73,3 +73,34 @@ structural type MyType = MyType Int
 .mergeA> merge .mergeB
 .mergeA> todo
 ```
+
+## An update to one element of a cycle, but not the other
+
+```ucm
+.cycle> builtins.mergeio
+```
+
+```unison
+even = cases
+  0 -> true
+  n -> odd (drop 1 n)
+
+odd = cases
+  0 -> false
+  n -> even (drop 1 n)
+```
+
+```ucm
+.cycle> add
+```
+
+```unison
+even = 17
+```
+
+```ucm
+.cycle> update
+.cycle> view odd
+.cycle> view.patch patch
+.cycle> todo
+```

--- a/unison-src/transcripts/todo.md
+++ b/unison-src/transcripts/todo.md
@@ -102,5 +102,8 @@ even = 17
 .cycle> update
 .cycle> view odd
 .cycle> view.patch patch
+```
+
+```ucm:error
 .cycle> todo
 ```

--- a/unison-src/transcripts/todo.md
+++ b/unison-src/transcripts/todo.md
@@ -74,10 +74,42 @@ structural type MyType = MyType Int
 .mergeA> todo
 ```
 
-## An update to one element of a cycle, but not the other
+## A named value that appears on the LHS of a patch isn't shown
+
+```ucm:hide
+.lhs> cd .lhs
+```
+
+```unison
+foo = 801
+```
 
 ```ucm
-.cycle> builtins.mergeio
+.lhs> add
+```
+
+```unison
+foo = 802
+```
+
+```ucm
+.lhs> update
+```
+
+```unison
+oldfoo = 801
+```
+
+```ucm
+.lhs> add
+.lhs> view.patch patch
+.lhs> todo
+```
+
+## A type-preserving update to one element of a cycle, which doesn't (yet) propagate to the other
+
+```ucm:hide
+.cycle1> builtins.mergeio
 ```
 
 ```unison
@@ -91,7 +123,42 @@ odd = cases
 ```
 
 ```ucm
-.cycle> add
+.cycle1> add
+```
+
+```unison
+even = cases
+  0 -> true
+  2 -> true
+  n -> odd (drop 1 n)
+```
+
+```ucm
+.cycle1> update
+```
+
+```ucm:error
+.cycle1> todo
+```
+
+## A type-changing update to one element of a cycle, which doesn't propagate to the other
+
+```ucm:hide
+.cycle2> builtins.mergeio
+```
+
+```unison
+even = cases
+  0 -> true
+  n -> odd (drop 1 n)
+
+odd = cases
+  0 -> false
+  n -> even (drop 1 n)
+```
+
+```ucm
+.cycle2> add
 ```
 
 ```unison
@@ -99,11 +166,9 @@ even = 17
 ```
 
 ```ucm
-.cycle> update
-.cycle> view odd
-.cycle> view.patch patch
+.cycle2> update
 ```
 
 ```ucm:error
-.cycle> todo
+.cycle2> todo
 ```

--- a/unison-src/transcripts/todo.output.md
+++ b/unison-src/transcripts/todo.output.md
@@ -131,16 +131,94 @@ structural type MyType = MyType Int
        to resolve the conflicts.
 
 ```
-## An update to one element of a cycle, but not the other
+## A named value that appears on the LHS of a patch isn't shown
+
+```unison
+foo = 801
+```
 
 ```ucm
-  ☝️  The namespace .cycle is empty.
 
-.cycle> builtins.mergeio
-
-  Done.
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      foo : Nat
 
 ```
+```ucm
+.lhs> add
+
+  ⍟ I've added these definitions:
+  
+    foo : Nat
+
+```
+```unison
+foo = 802
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      foo : Nat
+
+```
+```ucm
+.lhs> update
+
+  ⍟ I've updated these names to your new definition:
+  
+    foo : Nat
+
+```
+```unison
+oldfoo = 801
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      oldfoo : Nat
+
+```
+```ucm
+.lhs> add
+
+  ⍟ I've added these definitions:
+  
+    oldfoo : Nat
+
+.lhs> view.patch patch
+
+  Edited Terms: 1. oldfoo -> 2. foo
+  
+  Tip: To remove entries from a patch, use
+       delete.term-replacement or delete.type-replacement, as
+       appropriate.
+
+.lhs> todo
+
+  ✅
+  
+  No conflicts or edits in progress.
+
+```
+## A type-preserving update to one element of a cycle, which doesn't (yet) propagate to the other
+
 ```unison
 even = cases
   0 -> true
@@ -164,7 +242,84 @@ odd = cases
 
 ```
 ```ucm
-.cycle> add
+.cycle1> add
+
+  ⍟ I've added these definitions:
+  
+    even : Nat -> Boolean
+    odd  : Nat -> Boolean
+
+```
+```unison
+even = cases
+  0 -> true
+  2 -> true
+  n -> odd (drop 1 n)
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      even : Nat -> Boolean
+
+```
+```ucm
+.cycle1> update
+
+  ⍟ I've updated these names to your new definition:
+  
+    even : Nat -> Boolean
+
+```
+```ucm
+.cycle1> todo
+
+  🚧
+  
+  The namespace has 2 transitive dependent(s) left to upgrade.
+  Your edit frontier is the dependents of these definitions:
+  
+    even#kkohl7ba1e : Nat -> Boolean
+  
+  I recommend working on them in the following order:
+  
+  1. odd : Nat -> Boolean
+  
+  
+
+```
+## A type-changing update to one element of a cycle, which doesn't propagate to the other
+
+```unison
+even = cases
+  0 -> true
+  n -> odd (drop 1 n)
+
+odd = cases
+  0 -> false
+  n -> even (drop 1 n)
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      even : Nat -> Boolean
+      odd  : Nat -> Boolean
+
+```
+```ucm
+.cycle2> add
 
   ⍟ I've added these definitions:
   
@@ -189,30 +344,15 @@ even = 17
 
 ```
 ```ucm
-.cycle> update
+.cycle2> update
 
   ⍟ I've updated these names to your new definition:
   
     even : Nat
 
-.cycle> view odd
-
-  odd : Nat -> Boolean
-  odd = cases
-    0 -> false
-    n -> #kkohl7ba1e (Nat.drop 1 n)
-
-.cycle> view.patch patch
-
-  Edited Terms: 1. even#kkohl7ba1e -> 2. even
-  
-  Tip: To remove entries from a patch, use
-       delete.term-replacement or delete.type-replacement, as
-       appropriate.
-
 ```
 ```ucm
-.cycle> todo
+.cycle2> todo
 
   🚧
   

--- a/unison-src/transcripts/todo.output.md
+++ b/unison-src/transcripts/todo.output.md
@@ -131,3 +131,89 @@ structural type MyType = MyType Int
        to resolve the conflicts.
 
 ```
+## An update to one element of a cycle, but not the other
+
+```ucm
+  ☝️  The namespace .cycle is empty.
+
+.cycle> builtins.mergeio
+
+  Done.
+
+```
+```unison
+even = cases
+  0 -> true
+  n -> odd (drop 1 n)
+
+odd = cases
+  0 -> false
+  n -> even (drop 1 n)
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      even : Nat -> Boolean
+      odd  : Nat -> Boolean
+
+```
+```ucm
+.cycle> add
+
+  ⍟ I've added these definitions:
+  
+    even : Nat -> Boolean
+    odd  : Nat -> Boolean
+
+```
+```unison
+even = 17
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      even : Nat
+
+```
+```ucm
+.cycle> update
+
+  ⍟ I've updated these names to your new definition:
+  
+    even : Nat
+
+.cycle> view odd
+
+  odd : Nat -> Boolean
+  odd = cases
+    0 -> false
+    n -> #kkohl7ba1e (Nat.drop 1 n)
+
+.cycle> view.patch patch
+
+  Edited Terms: 1. even#kkohl7ba1e -> 2. even
+  
+  Tip: To remove entries from a patch, use
+       delete.term-replacement or delete.type-replacement, as
+       appropriate.
+
+.cycle> todo
+
+  ✅
+  
+  No conflicts or edits in progress.
+
+```

--- a/unison-src/transcripts/todo.output.md
+++ b/unison-src/transcripts/todo.output.md
@@ -210,10 +210,21 @@ even = 17
        delete.term-replacement or delete.type-replacement, as
        appropriate.
 
+```
+```ucm
 .cycle> todo
 
-  ✅
+  🚧
   
-  No conflicts or edits in progress.
+  The namespace has 1 transitive dependent(s) left to upgrade.
+  Your edit frontier is the dependents of these definitions:
+  
+    even#kkohl7ba1e : Nat -> Boolean
+  
+  I recommend working on them in the following order:
+  
+  1. odd : Nat -> Boolean
+  
+  
 
 ```


### PR DESCRIPTION
## Overview

Currently, updating a member of a cycle is somewhat fraught: the update algorithm simply doesn't yet know to include cycle-mates during an update (if possible). See #2794 

One workaround we implemented a while ago was pulling an entire component into a scratch file, even if you only ask to `edit` some subset:

```
.> edit ping
-- ping and pong appear in scratch.u
```

If you're changing the definition of `ping`, so long as you don't explicitly delete `pong` from the scratch file, `update` will do what you want.

Part of what contributed to the confusion prior to to this workaround was the fact that `todo` would not report any edits in-progress, if you managed to only update some members of a component, but not all. This patch fixes that.

This will be useful today if one manages to update a partial cycle (e.g. they delete some stuff that `edit` put in their scratch file), and it will also be useful when #2794 is fixed, because an update to a member of a component may not even successfully propagate to its component-mates (i.e. type-changing updates), and we would want those component-mates to appear in `todo` output (of course).

## Implementation notes

Previously, when computing the "todo set" (originating from the definitions that were updated previously, and propagating outward to their named dependents), we would only find dependents that were members of other components.

Now, we also include reference's dependents that are in its own component. 

## Test coverage

`todo.md` has been updated with a few new cases that capture the new behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3400)
<!-- Reviewable:end -->
