### PR TITLE
Move to shallow lsBranch implementation everywhere

### DIFF
--- a/codebase2/codebase/U/Codebase/Branch/Type.hs
+++ b/codebase2/codebase/U/Codebase/Branch/Type.hs
@@ -15,6 +15,7 @@ module U.Codebase.Branch.Type
     childAt,
     hoist,
     hoistCausalBranch,
+    U.Codebase.Branch.Type.empty,
   )
 where
 
@@ -53,6 +54,9 @@ instance AsEmpty (Branch m) where
     nearly
       (Branch mempty mempty mempty mempty)
       (\(Branch terms types patches children) -> null terms && null types && null patches && null children)
+
+empty :: Branch m
+empty = Empty
 
 data Patch = Patch
   { termEdits :: Map Referent (Set TermEdit),

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -46,7 +46,7 @@ module Unison.Codebase
     -- * Root branch
     getRootBranch,
     getRootBranchExists,
-    getRootBranchHash,
+    getRootCausalHash,
     putRootBranch,
     namesAtPath,
 
@@ -181,7 +181,7 @@ getShallowCausalFromRoot codebase mayRootHash p = do
 -- history.
 getShallowRootCausal :: Monad m => Codebase m v a -> m (V2.CausalBranch m)
 getShallowRootCausal codebase = do
-  hash <- getRootBranchHash codebase
+  hash <- getRootCausalHash codebase
   getShallowCausalForHash codebase hash
 
 -- | Get the shallow representation of the root branches without loading the children or

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -36,10 +36,12 @@ module Unison.Codebase
     branchHashesByPrefix,
     lca,
     beforeImpl,
-    shallowBranchAtPath,
-    getShallowBranchForHash,
-    getShallowBranchFromRoot,
+    getShallowBranchAtPath,
+    getShallowCausalAtPath,
+    getShallowCausalForHash,
+    getShallowCausalFromRoot,
     getShallowRootBranch,
+    getShallowRootCausal,
 
     -- * Root branch
     getRootBranch,
@@ -162,27 +164,58 @@ runTransaction :: MonadIO m => Codebase m v a -> Sqlite.Transaction b -> m b
 runTransaction Codebase {withConnection} action =
   withConnection \conn -> Sqlite.runTransaction conn action
 
-getShallowBranchFromRoot :: Monad m => Codebase m v a -> Path.Absolute -> m (Maybe (V2Branch.CausalBranch m))
-getShallowBranchFromRoot codebase p = do
-  getShallowRootBranch codebase >>= shallowBranchAtPath (Path.unabsolute p)
+getShallowCausalFromRoot ::
+  Monad m =>
+  Codebase m v a ->
+  -- Optional root branch, if Nothing use the codebase's root branch.
+  Maybe V2.CausalHash ->
+  Path.Path ->
+  m (V2Branch.CausalBranch m)
+getShallowCausalFromRoot codebase mayRootHash p = do
+  rootCausal <- case mayRootHash of
+    Nothing -> getShallowRootCausal codebase
+    Just ch -> getShallowCausalForHash codebase ch
+  getShallowCausalAtPath codebase p (Just rootCausal)
 
 -- | Get the shallow representation of the root branches without loading the children or
 -- history.
-getShallowRootBranch :: Monad m => Codebase m v a -> m (V2.CausalBranch m)
-getShallowRootBranch codebase = do
+getShallowRootCausal :: Monad m => Codebase m v a -> m (V2.CausalBranch m)
+getShallowRootCausal codebase = do
   hash <- getRootBranchHash codebase
-  getShallowBranchForHash codebase hash
+  getShallowCausalForHash codebase hash
 
--- | Recursively descend into shallow branches following the given path.
-shallowBranchAtPath :: Monad m => Path -> V2Branch.CausalBranch m -> m (Maybe (V2Branch.CausalBranch m))
-shallowBranchAtPath path causal = do
+-- | Get the shallow representation of the root branches without loading the children or
+-- history.
+getShallowRootBranch :: Monad m => Codebase m v a -> m (V2.Branch m)
+getShallowRootBranch codebase = do
+  getShallowRootCausal codebase >>= V2Causal.value
+
+-- | Recursively descend into causals following the given path,
+-- Use the root causal if none is provided.
+getShallowCausalAtPath :: Monad m => Codebase m v a -> Path -> Maybe (V2Branch.CausalBranch m) -> m (V2Branch.CausalBranch m)
+getShallowCausalAtPath codebase path mayCausal = do
+  causal <- whenNothing mayCausal (getShallowRootCausal codebase)
   case path of
-    Path.Empty -> pure (Just causal)
+    Path.Empty -> pure causal
     (ns Path.:< p) -> do
       b <- V2Causal.value causal
       case (V2Branch.childAt (Cv.namesegment1to2 ns) b) of
-        Nothing -> pure Nothing
-        Just childCausal -> shallowBranchAtPath p childCausal
+        Nothing -> pure (Cv.causalbranch1to2 Branch.empty)
+        Just childCausal -> getShallowCausalAtPath codebase p (Just childCausal)
+
+-- | Recursively descend into causals following the given path,
+-- Use the root causal if none is provided.
+getShallowBranchAtPath :: Monad m => Codebase m v a -> Path -> Maybe (V2Branch.Branch m) -> m (V2Branch.Branch m)
+getShallowBranchAtPath codebase path mayBranch = do
+  branch <- whenNothing mayBranch (getShallowRootCausal codebase >>= V2Causal.value)
+  case path of
+    Path.Empty -> pure branch
+    (ns Path.:< p) -> do
+      case (V2Branch.childAt (Cv.namesegment1to2 ns) branch) of
+        Nothing -> pure V2Branch.empty
+        Just childCausal -> do
+          childBranch <- V2Causal.value childCausal
+          getShallowBranchAtPath codebase p (Just childBranch)
 
 -- | Get a branch from the codebase.
 getBranchForHash :: Monad m => Codebase m v a -> Branch.CausalHash -> m (Maybe (Branch m))

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -269,8 +269,8 @@ sqliteCodebase debugName root localOrRemote action = do
             getRootBranchHash =
               runTransaction Ops.expectRootCausalHash
 
-            getShallowBranchForHash :: MonadIO m => V2Branch.CausalHash -> m (V2Branch.CausalBranch m)
-            getShallowBranchForHash bh =
+            getShallowCausalForHash :: MonadIO m => V2Branch.CausalHash -> m (V2Branch.CausalBranch m)
+            getShallowCausalForHash bh =
               V2Branch.hoistCausalBranch runTransaction <$> runTransaction (Ops.expectCausalBranchByCausalHash bh)
 
             getRootBranch :: TVar (Maybe (Sqlite.DataVersion, Branch Sqlite.Transaction)) -> m (Branch m)
@@ -433,7 +433,7 @@ sqliteCodebase debugName root localOrRemote action = do
                   getRootBranchHash,
                   getRootBranchExists,
                   putRootBranch = putRootBranch rootBranchCache,
-                  getShallowBranchForHash,
+                  getShallowCausalForHash,
                   getBranchForHashImpl = getBranchForHash,
                   putBranch,
                   branchExists = isCausalHash,

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -265,8 +265,8 @@ sqliteCodebase debugName root localOrRemote action = do
             putTypeDeclaration id decl =
               runTransaction (CodebaseOps.putTypeDeclaration termBuffer declBuffer id decl)
 
-            getRootBranchHash :: MonadIO m => m V2Branch.CausalHash
-            getRootBranchHash =
+            getRootCausalHash :: MonadIO m => m V2Branch.CausalHash
+            getRootCausalHash =
               runTransaction Ops.expectRootCausalHash
 
             getShallowCausalForHash :: MonadIO m => V2Branch.CausalHash -> m (V2Branch.CausalBranch m)
@@ -430,7 +430,7 @@ sqliteCodebase debugName root localOrRemote action = do
                   getDeclComponent,
                   getComponentLength = getCycleLength,
                   getRootBranch = getRootBranch rootBranchCache,
-                  getRootBranchHash,
+                  getRootCausalHash,
                   getRootBranchExists,
                   putRootBranch = putRootBranch rootBranchCache,
                   getShallowCausalForHash,

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -89,7 +89,7 @@ data Codebase m v a = Codebase
       Text -> -- Reason for the change, will be recorded in the reflog
       Branch m ->
       m (),
-    getShallowBranchForHash :: V2.CausalHash -> m (V2.CausalBranch m),
+    getShallowCausalForHash :: V2.CausalHash -> m (V2.CausalBranch m),
     getBranchForHashImpl :: Branch.CausalHash -> m (Maybe (Branch m)),
     -- | Put a branch into the codebase, which includes its children, its patches, and the branch itself, if they don't
     -- already exist.

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -79,7 +79,7 @@ data Codebase m v a = Codebase
     getDeclComponent :: Hash -> m (Maybe [Decl v a]),
     getComponentLength :: Hash -> m (Maybe Reference.CycleSize),
     -- | Get the root branch Hash.
-    getRootBranchHash :: m V2.CausalHash,
+    getRootCausalHash :: m V2.CausalHash,
     -- | Get the root branch.
     getRootBranch :: m (Branch m),
     -- | Get whether the root branch exists.

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -936,7 +936,7 @@ loop e = do
               rootBranch <- Cli.getRootBranch
 
               pathArgAbs <- Cli.resolvePath' pathArg
-              entries <- liftIO (Backend.findShallow codebase pathArgAbs)
+              entries <- liftIO (Backend.lsAtPath codebase Nothing pathArgAbs)
               -- caching the result as an absolute path, for easier jumping around
               #numberedArgs .= fmap entryToHQString entries
               let ppe =

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -107,7 +107,6 @@ import Unison.Util.Pretty (Width)
 import qualified Unison.Util.Pretty as Pretty
 import qualified Unison.Util.Relation as R
 import qualified Unison.Util.Set as Set
-import qualified Unison.Util.Star3 as Star3
 import qualified Unison.Util.SyntaxText as UST
 import Unison.Var (Var)
 import qualified Unison.WatchKind as WK
@@ -304,18 +303,17 @@ fuzzyFind printNames query =
    in refine $ toFoundRef . over _2 Name.toText <$> fzfNames
 
 -- List the immediate children of a namespace
-findShallow ::
-  Monad m =>
+lsAtPath ::
+  MonadIO m =>
   Codebase m Symbol Ann ->
+  -- The root to follow the path from.
+  Maybe (V2Branch.Branch m) ->
+  -- Path from the root to the branch to 'ls'
   Path.Absolute ->
   m [ShallowListEntry Symbol Ann]
-findShallow codebase path' = do
-  let path = Path.unabsolute path'
-  root <- Codebase.getRootBranch codebase
-  let mayb = Branch.getAt path root
-  case mayb of
-    Nothing -> pure []
-    Just b -> lsBranch codebase b
+lsAtPath codebase mayRootBranch absPath = do
+  b <- Codebase.getShallowBranchAtPath codebase (Path.unabsolute absPath) mayRootBranch
+  lsBranch codebase b
 
 findShallowReadmeInBranchAndRender ::
   Width ->
@@ -458,56 +456,13 @@ typeEntryToNamedType (TypeEntry r name tag) =
       typeTag = tag
     }
 
--- | Find all definitions and children reachable from the given branch.
--- Note: this differs from 'lsShallowBranch' in that it takes a fully loaded 'Branch' object,
--- and thus can include definition counts for child namespaces.
-lsBranch ::
-  Monad m =>
-  Codebase m Symbol Ann ->
-  Branch m ->
-  m [ShallowListEntry Symbol Ann]
-lsBranch codebase b = do
-  hashLength <- Codebase.hashLength codebase
-  let hqTerm b0 ns r =
-        let refs = Star3.lookupD1 ns . Branch._terms $ b0
-         in case length refs of
-              1 -> HQ'.fromName ns
-              _ -> HQ'.take hashLength $ HQ'.fromNamedReferent ns r
-      hqType b0 ns r =
-        let refs = Star3.lookupD1 ns . Branch._types $ b0
-         in case length refs of
-              1 -> HQ'.fromName ns
-              _ -> HQ'.take hashLength $ HQ'.fromNamedReference ns r
-      b0 = Branch.head b
-  termEntries <- for (R.toList . Star3.d1 $ Branch._terms b0) $ \(r, ns) ->
-    ShallowTermEntry <$> termListEntry codebase r (hqTerm b0 ns r)
-  typeEntries <- for (R.toList . Star3.d1 $ Branch._types b0) $
-    \(r, ns) -> ShallowTypeEntry <$> typeListEntry codebase r (hqType b0 ns r)
-  let branchEntries :: [ShallowListEntry Symbol Ann] = do
-        (ns, childB) <- Map.toList $ Branch.nonEmptyChildren b0
-        let stats = Branch.namespaceStats $ Branch.head childB
-        guard $ V2Branch.hasDefinitions stats
-        pure $ ShallowBranchEntry ns (Branch.headHash childB) stats
-      patchEntries :: [ShallowListEntry Symbol Ann] = do
-        (ns, (_h, _mp)) <- Map.toList $ Branch._edits b0
-        pure $ ShallowPatchEntry ns
-  pure
-    . List.sortOn listEntryName
-    $ termEntries
-      ++ typeEntries
-      ++ branchEntries
-      ++ patchEntries
-
 -- | Find all definitions and children reachable from the given 'V2Branch.Branch',
--- Note: this differs from 'lsBranch' in that it takes a shallow v2 branch,
--- As a result, it omits definition counts from child-namespaces in its results,
--- but doesn't require loading the entire sub-tree to do so.
-lsShallowBranch ::
+lsBranch ::
   (MonadIO m) =>
   Codebase m Symbol Ann ->
   V2Branch.Branch m ->
   m [ShallowListEntry Symbol Ann]
-lsShallowBranch codebase b0 = do
+lsBranch codebase b0 = do
   hashLength <- Codebase.hashLength codebase
   let hqTerm ::
         ( V2Branch.Branch m ->
@@ -774,13 +729,10 @@ expandShortBranchHash codebase hash = do
 getShallowCausalAtPathFromRootHash :: Monad m => Codebase m v a -> Maybe (Branch.CausalHash) -> Path -> Backend m (V2Branch.CausalBranch m)
 getShallowCausalAtPathFromRootHash codebase mayRootHash path = do
   shallowRoot <- case mayRootHash of
-    Nothing -> lift (Codebase.getShallowRootBranch codebase)
+    Nothing -> lift (Codebase.getShallowRootCausal codebase)
     Just h -> do
-      lift $ Codebase.getShallowBranchForHash codebase (Cv.causalHash1to2 h)
-  causal <-
-    (lift $ Codebase.shallowBranchAtPath path shallowRoot) >>= \case
-      Nothing -> pure $ Cv.causalbranch1to2 (Branch.empty)
-      Just lc -> pure lc
+      lift $ Codebase.getShallowCausalForHash codebase (Cv.causalHash1to2 h)
+  causal <- lift $ Codebase.getShallowCausalAtPath codebase path (Just shallowRoot)
   pure causal
 
 formatType' :: Var v => PPE.PrettyPrintEnv -> Width -> Type v a -> SyntaxText

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -1042,7 +1042,7 @@ scopedNamesForBranchHash codebase mbh path = do
           let (parseNames, _prettyNames, localNames) = namesForBranch rootBranch (AllNames path)
           pure (parseNames, localNames)
     Just bh -> do
-      rootHash <- lift $ Codebase.getRootBranchHash codebase
+      rootHash <- lift $ Codebase.getRootCausalHash codebase
       if (Causal.unCausalHash bh == V2.Hash.unCausalHash rootHash) && shouldUseNamesIndex
         then indexNames
         else do

--- a/unison-share-api/src/Unison/Server/Endpoints/NamespaceListing.hs
+++ b/unison-share-api/src/Unison/Server/Endpoints/NamespaceListing.hs
@@ -162,7 +162,7 @@ serve ::
 serve codebase maySBH mayRelativeTo mayNamespaceName = do
   useIndex <- asks Backend.useNamesIndex
   mayRootHash <- traverse (Backend.expandShortBranchHash codebase) maySBH
-  codebaseRootHash <- liftIO $ Codebase.getRootBranchHash codebase
+  codebaseRootHash <- liftIO $ Codebase.getRootCausalHash codebase
 
   -- Relative and Listing Path resolution
   --
@@ -194,7 +194,7 @@ serve codebase maySBH mayRelativeTo mayNamespaceName = do
     (False, Just rh) -> do
       serveFromBranch codebase path' (Cv.causalHash1to2 rh)
     (False, Nothing) -> do
-      rh <- liftIO $ Codebase.getRootBranchHash codebase
+      rh <- liftIO $ Codebase.getRootCausalHash codebase
       serveFromBranch codebase path' rh
   where
     parsePath :: String -> Backend IO Path.Path'

--- a/unison-share-api/src/Unison/Server/Endpoints/Projects.hs
+++ b/unison-share-api/src/Unison/Server/Endpoints/Projects.hs
@@ -24,14 +24,16 @@ import Servant.Docs
     ToParam (..),
     ToSample (..),
   )
+import qualified U.Codebase.Branch as V2Branch
+import qualified U.Codebase.Causal as V2Causal
 import qualified U.Util.Hash as Hash
 import Unison.Codebase (Codebase)
 import qualified Unison.Codebase as Codebase
-import qualified Unison.Codebase.Branch as Branch
 import qualified Unison.Codebase.Causal.Type as Causal
 import qualified Unison.Codebase.Path as Path
 import qualified Unison.Codebase.Path.Parse as Path
 import Unison.Codebase.ShortBranchHash (ShortBranchHash)
+import qualified Unison.Codebase.SqliteCodebase.Conversions as Cv
 import qualified Unison.NameSegment as NameSegment
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
@@ -131,35 +133,31 @@ serve codebase mayRoot mayOwner = projects
   where
     projects :: Backend m [ProjectListing]
     projects = do
-      root <- case mayRoot of
-        Nothing -> lift (Codebase.getRootBranch codebase)
+      shallowRootBranch <- case mayRoot of
+        Nothing -> lift (Codebase.getShallowRootBranch codebase)
         Just sbh -> do
           h <- Backend.expandShortBranchHash codebase sbh
-          mayBranch <- lift $ Codebase.getBranchForHash codebase h
-          whenNothing mayBranch (throwError $ Backend.CouldntLoadBranch h)
+          -- TODO: can this ever be missing?
+          causal <- lift $ Codebase.getShallowCausalForHash codebase (Cv.causalHash1to2 h)
+          lift $ V2Causal.value causal
 
-      ownerEntries <- lift $ findShallow root
+      ownerEntries <- lift $ Backend.lsBranch codebase shallowRootBranch
       -- If an owner is provided, we only want projects belonging to them
       let owners =
             case mayOwner of
               Just o -> [o]
               Nothing -> mapMaybe entryToOwner ownerEntries
-      foldMapM (ownerToProjectListings root) owners
+      foldMapM (ownerToProjectListings shallowRootBranch) owners
 
-    ownerToProjectListings :: Branch.Branch m -> ProjectOwner -> Backend m [ProjectListing]
+    ownerToProjectListings :: V2Branch.Branch m -> ProjectOwner -> Backend m [ProjectListing]
     ownerToProjectListings root owner = do
       let (ProjectOwner ownerName) = owner
       ownerPath' <- (parsePath . Text.unpack) ownerName
       let path = Path.fromPath' ownerPath'
-      let ownerBranch = Branch.getAt' path root
-      entries <- lift $ findShallow ownerBranch
+      entries <- lift $ Backend.lsAtPath codebase (Just root) (Path.Absolute path)
       pure $ mapMaybe (backendListEntryToProjectListing owner) entries
 
     -- Minor helpers
-
-    findShallow :: Branch.Branch m -> m [Backend.ShallowListEntry Symbol Ann]
-    findShallow branch =
-      Backend.lsBranch codebase branch
 
     parsePath :: String -> Backend m Path.Path'
     parsePath p =


### PR DESCRIPTION
## Overview

When working on Term Summaries for Simon I realized that some of the underlying changes I was making required a bunch of work to port into the old lsBranch implementation, but we don't need that anymore now that namespace stats is merged, so this pulls out that refactor and deletes some code so we don't need to maintain it any more.

It also means that UCM and Share can now both share the same implementation :tada: 

When working on Term Summaries I also noticed some inconsistencies had crept into the Codebase API for V2 stuff, so I tried to settle on a consistent interface here that makes that PR much easier 👍🏼 

## Implementation notes

* delete the old `lsBranch` which relied on loading the whole branch into memory recursively, use the v2 "shallow" version instead.
* Be consistent in the v2 Codebase.hs functions between "causal" and "branch"
* Most of these functions now take an optional "root" to start at, if not provided, they use the root of the current codebase. This makes using them much simpler and reduces duplication and boilerplate

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3405)
<!-- Reviewable:end -->
