### PR TITLE
More intuitive tab completion behaviour

### DIFF
--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -143,7 +143,11 @@ completeWithinNamespace compTypes query codebase currentPath = do
           & pure
 
       childSuggestions <- getChildSuggestions shortHashLen b
-      pure . nubOrdOn Haskeline.replacement . List.sortOn Haskeline.replacement $ currentBranchSuggestions <> childSuggestions
+      let allSuggestions =
+            currentBranchSuggestions
+              -- Only show child suggestions when the current branch isn't ambiguous
+              <> Monoid.whenM (length currentBranchSuggestions <= 1) childSuggestions
+      pure . nubOrdOn Haskeline.replacement . List.sortOn Haskeline.replacement $ allSuggestions
   where
     queryPathPrefix :: Path.Path'
     querySuffix :: NameSegment.NameSegment

--- a/unison-src/transcripts/tab-completion.md
+++ b/unison-src/transcripts/tab-completion.md
@@ -16,7 +16,8 @@ Test that tab completion works as expected.
 ```unison
 subnamespace.someName = 1
 subnamespace.someOtherName = 2
-othernamespace.someName = 3
+subnamespace2.thing = 3
+othernamespace.someName = 4
 
 unique type subnamespace.AType = A | B
 ```
@@ -28,9 +29,12 @@ unique type subnamespace.AType = A | B
 ```ucm
 -- Should tab complete namespaces since they may contain terms/types
 .> debug.tab-complete view sub
--- Should complete things from child namespaces of the current query
+-- Should not complete things from child namespaces of the current query if there are other completions at this level
 .> debug.tab-complete view subnamespace
+-- Should complete things from child namespaces of the current query if it's dot-suffixed
 .> debug.tab-complete view subnamespace.
+-- Should complete things from child namespaces of the current query if there are no more completions at this level.
+.> debug.tab-complete view subnamespace2
 -- Should prefix-filter by query suffix
 .> debug.tab-complete view subnamespace.some
 .> debug.tab-complete view subnamespace.someOther

--- a/unison-src/transcripts/tab-completion.output.md
+++ b/unison-src/transcripts/tab-completion.output.md
@@ -30,7 +30,8 @@ Test that tab completion works as expected.
 ```unison
 subnamespace.someName = 1
 subnamespace.someOtherName = 2
-othernamespace.someName = 3
+subnamespace2.thing = 3
+othernamespace.someName = 4
 
 unique type subnamespace.AType = A | B
 ```
@@ -47,6 +48,7 @@ unique type subnamespace.AType = A | B
       othernamespace.someName    : ##Nat
       subnamespace.someName      : ##Nat
       subnamespace.someOtherName : ##Nat
+      subnamespace2.thing        : ##Nat
 
 ```
 ```ucm
@@ -54,22 +56,27 @@ unique type subnamespace.AType = A | B
 .> debug.tab-complete view sub
 
    subnamespace.
+   subnamespace2.
 
--- Should complete things from child namespaces of the current query
+-- Should not complete things from child namespaces of the current query if there are other completions at this level
 .> debug.tab-complete view subnamespace
 
-    subnamespace.
-  * subnamespace.AType
-    subnamespace.AType.
-  * subnamespace.someName
-  * subnamespace.someOtherName
+   subnamespace.
+   subnamespace2.
 
+-- Should complete things from child namespaces of the current query if it's dot-suffixed
 .> debug.tab-complete view subnamespace.
 
   * subnamespace.AType
     subnamespace.AType.
   * subnamespace.someName
   * subnamespace.someOtherName
+
+-- Should complete things from child namespaces of the current query if there are no more completions at this level.
+.> debug.tab-complete view subnamespace2
+
+    subnamespace2.
+  * subnamespace2.thing
 
 -- Should prefix-filter by query suffix
 .> debug.tab-complete view subnamespace.some
@@ -95,11 +102,12 @@ unique type subnamespace.AType = A | B
 .> debug.tab-complete cd sub
 
    subnamespace
+   subnamespace2
 
 .> debug.tab-complete cd subnamespace
 
    subnamespace
-   subnamespace.AType
+   subnamespace2
 
 .> debug.tab-complete cd subnamespace.
 


### PR DESCRIPTION
Just tweaks the tab completion very slightly; here's a slack thread for context:

Slack thread for context: https://unisonlanguage.slack.com/archives/CLUNF0J5S/p1662485890100209?thread_ts=1661200159.112979&cid=CLUNF0J5S

See transcript changes for clarification, but the gist is that we make sure the current "level" of completion is unambiguous before providing completions for the next level down.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3406)
<!-- Reviewable:end -->
