### PR TITLE
Allow caller to specify migration strategy when loading codebase.

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -290,7 +290,7 @@ createSchema = do
   where
     insertSchemaVersionSql =
       [here|
-        INSERT INTO schema_version (version) VALUES (?);
+        INSERT INTO schema_version (version) VALUES (?)
       |]
 
 addTempEntityTables :: Transaction ()

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -105,6 +105,7 @@ module U.Codebase.Sqlite.Queries
     getDependencyIdsForDependent,
 
     -- ** migrations
+    currentSchemaVersion,
     countObjects,
     countCausals,
     countWatches,
@@ -276,12 +277,21 @@ import Unison.Sqlite
 
 -- * main squeeze
 
+currentSchemaVersion :: SchemaVersion
+currentSchemaVersion = 7
+
 createSchema :: Transaction ()
 createSchema = do
   executeFile [hereFile|unison/sql/create.sql|]
+  execute insertSchemaVersionSql (Only currentSchemaVersion)
   addTempEntityTables
   addNamespaceStatsTables
   addReflogTable
+  where
+    insertSchemaVersionSql =
+      [here|
+        INSERT INTO schema_version (version) VALUES (?);
+      |]
 
 addTempEntityTables :: Transaction ()
 addTempEntityTables =

--- a/codebase2/codebase-sqlite/sql/create.sql
+++ b/codebase2/codebase-sqlite/sql/create.sql
@@ -3,7 +3,6 @@
 CREATE TABLE schema_version (
   version INTEGER NOT NULL
 );
-INSERT INTO schema_version (version) VALUES (7);
 
 -- actually stores the 512-byte hashes
 CREATE TABLE hash (

--- a/parser-typechecker/src/Unison/Codebase/Init/OpenCodebaseError.hs
+++ b/parser-typechecker/src/Unison/Codebase/Init/OpenCodebaseError.hs
@@ -6,6 +6,7 @@ module Unison.Codebase.Init.OpenCodebaseError
   )
 where
 
+import U.Codebase.Sqlite.DbId (SchemaVersion)
 import Unison.Prelude
 
 -- | An error that can occur when attempting to open a codebase.
@@ -13,6 +14,12 @@ data OpenCodebaseError
   = -- | The codebase doesn't exist.
     OpenCodebaseDoesntExist
   | -- | The codebase exists, but its schema version is unknown to this application.
-    OpenCodebaseUnknownSchemaVersion Word64
+    OpenCodebaseUnknownSchemaVersion SchemaVersion
+  | -- | The codebase exists, but requires a migration before it can be used.
+    OpenCodebaseRequiresMigration
+      -- current version
+      SchemaVersion
+      -- required version
+      SchemaVersion
   deriving stock (Show, Eq)
   deriving anyclass (Exception)

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -210,7 +210,7 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
   declBuffer :: TVar (Map Hash CodebaseOps.DeclBufferEntry) <- newTVarIO Map.empty
 
   result <- withConn \conn -> do
-    Migrations.checkCodebaseIsUpToDate conn >>= \case
+    Sqlite.runTransaction conn Migrations.checkCodebaseIsUpToDate >>= \case
       Migrations.CodebaseUpToDate -> pure $ Right ()
       Migrations.CodebaseUnknownSchemaVersion sv -> pure $ Left (OpenCodebaseUnknownSchemaVersion sv)
       Migrations.CodebaseRequiresMigration fromSv toSv ->

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/GitError.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/GitError.hs
@@ -8,4 +8,5 @@ data GitSqliteCodebaseError
   = GitCouldntParseRootBranchHash ReadGitRepo String
   | NoDatabaseFile ReadGitRepo CodebasePath
   | UnrecognizedSchemaVersion ReadGitRepo CodebasePath SchemaVersion
+  | CodebaseRequiresMigration SchemaVersion SchemaVersion
   deriving (Show)

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
@@ -74,8 +74,8 @@ checkCodebaseIsUpToDate conn = do
     pure $
       if
           | schemaVersion == Q.currentSchemaVersion -> CodebaseUpToDate
-          | schemaVersion < Q.currentSchemaVersion -> CodebaseRequiresMigration
-          | otherwise -> CodebaseUnknownSchemaVersion
+          | schemaVersion < Q.currentSchemaVersion -> CodebaseRequiresMigration schemaVersion Q.currentSchemaVersion
+          | otherwise -> CodebaseUnknownSchemaVersion schemaVersion
 
 -- | Migrates a codebase up to the most recent version known to ucm.
 -- This is a No-op if it's up to date

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE MultiWayIf #-}
+
 module Unison.Codebase.SqliteCodebase.Migrations where
 
 import Control.Concurrent.STM (TVar)
@@ -51,6 +53,30 @@ migrations getDeclType termBuffer declBuffer rootCodebasePath =
       (7, migrateSchema6To7)
     ]
 
+data CodebaseVersionStatus
+  = CodebaseUpToDate
+  | CodebaseUnknownSchemaVersion SchemaVersion
+  | CodebaseRequiresMigration
+      -- Current version
+      SchemaVersion
+      -- Required version
+      SchemaVersion
+  deriving stock (Eq, Ord, Show)
+
+checkCodebaseIsUpToDate ::
+  MonadUnliftIO m =>
+  Sqlite.Connection ->
+  m CodebaseVersionStatus
+checkCodebaseIsUpToDate conn = do
+  Sqlite.runWriteTransaction conn \run -> do
+    schemaVersion <- run Q.schemaVersion
+    -- The highest schema that this ucm knows how to migrate to.
+    pure $
+      if
+          | schemaVersion == Q.currentSchemaVersion -> CodebaseUpToDate
+          | schemaVersion < Q.currentSchemaVersion -> CodebaseRequiresMigration
+          | otherwise -> CodebaseUnknownSchemaVersion
+
 -- | Migrates a codebase up to the most recent version known to ucm.
 -- This is a No-op if it's up to date
 -- Returns an error if the schema version is newer than this ucm knows about.
@@ -62,9 +88,10 @@ ensureCodebaseIsUpToDate ::
   (C.Reference.Reference -> Sqlite.Transaction CT.ConstructorType) ->
   TVar (Map Hash Ops2.TermBufferEntry) ->
   TVar (Map Hash Ops2.DeclBufferEntry) ->
+  Bool ->
   Sqlite.Connection ->
   m (Either Codebase.OpenCodebaseError ())
-ensureCodebaseIsUpToDate localOrRemote root getDeclType termBuffer declBuffer conn =
+ensureCodebaseIsUpToDate localOrRemote root getDeclType termBuffer declBuffer shouldPrompt conn =
   UnliftIO.try do
     liftIO do
       ranMigrations <-
@@ -76,7 +103,7 @@ ensureCodebaseIsUpToDate localOrRemote root getDeclType termBuffer declBuffer co
           when (schemaVersion > currentSchemaVersion) $ UnliftIO.throwIO $ OpenCodebaseUnknownSchemaVersion (fromIntegral schemaVersion)
           let migrationsToRun =
                 Map.filterWithKey (\v _ -> v > schemaVersion) migs
-          when (localOrRemote == Local && (not . null) migrationsToRun) $ backupCodebase root
+          when (localOrRemote == Local && (not . null) migrationsToRun) $ backupCodebase root shouldPrompt
           -- This is a bit of a hack, hopefully we can remove this when we have a more
           -- reliable way to freeze old migration code in time.
           -- The problem is that 'saveObject' has been changed to flush temp entity tables,
@@ -118,11 +145,12 @@ ensureCodebaseIsUpToDate localOrRemote root getDeclType termBuffer declBuffer co
         putStrLn $ "🏁 Migration complete 🏁"
 
 -- | Copy the sqlite database to a new file with a unique name based on current time.
-backupCodebase :: CodebasePath -> IO ()
-backupCodebase root = do
+backupCodebase :: CodebasePath -> Bool -> IO ()
+backupCodebase root shouldPrompt = do
   backupPath <- backupCodebasePath <$> getPOSIXTime
   copyFile (root </> codebasePath) (root </> backupPath)
   putStrLn ("📋 I backed up your codebase to " ++ (root </> backupPath))
   putStrLn "⚠️  Please close all other ucm processes and wait for the migration to complete before interacting with your codebase."
-  putStrLn "Press <enter> to start the migration once all other ucm processes are shutdown..."
-  void $ liftIO getLine
+  when shouldPrompt $ do
+    putStrLn "Press <enter> to start the migration once all other ucm processes are shutdown..."
+    void $ liftIO getLine

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -209,3 +209,5 @@ gitErrorFromOpenCodebaseError path repo = \case
   OpenCodebaseDoesntExist -> NoDatabaseFile repo path
   OpenCodebaseUnknownSchemaVersion v ->
     UnrecognizedSchemaVersion repo path (fromIntegral v)
+  OpenCodebaseRequiresMigration fromSv toSv ->
+    CodebaseRequiresMigration fromSv toSv

--- a/parser-typechecker/tests/Unison/Test/CodebaseInit.hs
+++ b/parser-typechecker/tests/Unison/Test/CodebaseInit.hs
@@ -29,7 +29,7 @@ test =
             [ scope "a v2 codebase should be opened" do
                 tmp <- io (Temp.getCanonicalTemporaryDirectory >>= flip Temp.createTempDirectory "ucm-test")
                 cbInit <- io initMockWithCodebase
-                r <- io $ CI.withOpenOrCreateCodebase cbInit "ucm-test" (Home tmp) \case
+                r <- io $ CI.withOpenOrCreateCodebase cbInit "ucm-test" (Home tmp) CI.DontMigrate \case
                   (CI.OpenedCodebase, _, _) -> pure True
                   _ -> pure False
                 case r of
@@ -38,7 +38,7 @@ test =
               scope "a v2 codebase should be created when one does not exist" do
                 tmp <- io (Temp.getCanonicalTemporaryDirectory >>= flip Temp.createTempDirectory "ucm-test")
                 cbInit <- io initMockWithoutCodebase
-                r <- io $ CI.withOpenOrCreateCodebase cbInit "ucm-test" (Home tmp) \case
+                r <- io $ CI.withOpenOrCreateCodebase cbInit "ucm-test" (Home tmp) CI.DontMigrate \case
                   (CI.CreatedCodebase, _, _) -> pure True
                   _ -> pure False
                 case r of
@@ -51,7 +51,7 @@ test =
                 tmp <- io (Temp.getCanonicalTemporaryDirectory >>= flip Temp.createTempDirectory "ucm-test")
                 cbInit <- io initMockWithCodebase
                 res <- io $
-                  CI.withOpenOrCreateCodebase cbInit "ucm-test" (Specified (DontCreateWhenMissing tmp)) $ \case
+                  CI.withOpenOrCreateCodebase cbInit "ucm-test" (Specified (DontCreateWhenMissing tmp)) CI.DontMigrate $ \case
                     (CI.OpenedCodebase, _, _) -> pure True
                     _ -> pure False
                 case res of
@@ -61,7 +61,7 @@ test =
                 tmp <- io (Temp.getCanonicalTemporaryDirectory >>= flip Temp.createTempDirectory "ucm-test")
                 cbInit <- io initMockWithoutCodebase
                 res <- io $
-                  CI.withOpenOrCreateCodebase cbInit "ucm-test" (Specified (DontCreateWhenMissing tmp)) $ \case
+                  CI.withOpenOrCreateCodebase cbInit "ucm-test" (Specified (DontCreateWhenMissing tmp)) CI.DontMigrate $ \case
                     _ -> pure False
                 case res of
                   Left (_, CI.InitErrorOpen OpenCodebaseDoesntExist) -> expect True
@@ -72,7 +72,7 @@ test =
             [ scope "a v2 codebase should be created when one does not exist at the Specified dir" do
                 tmp <- io (Temp.getCanonicalTemporaryDirectory >>= flip Temp.createTempDirectory "ucm-test")
                 cbInit <- io initMockWithoutCodebase
-                res <- io $ CI.withOpenOrCreateCodebase cbInit "ucm-test" (Specified (CreateWhenMissing tmp)) \case
+                res <- io $ CI.withOpenOrCreateCodebase cbInit "ucm-test" (Specified (CreateWhenMissing tmp)) CI.DontMigrate \case
                   (CI.CreatedCodebase, _, _) -> pure True
                   _ -> pure False
                 case res of
@@ -81,7 +81,7 @@ test =
               scope "a v2 codebase should be opened when one exists" do
                 tmp <- io (Temp.getCanonicalTemporaryDirectory >>= flip Temp.createTempDirectory "ucm-test")
                 cbInit <- io initMockWithCodebase
-                res <- io $ CI.withOpenOrCreateCodebase cbInit "ucm-test" (Specified (CreateWhenMissing tmp)) \case
+                res <- io $ CI.withOpenOrCreateCodebase cbInit "ucm-test" (Specified (CreateWhenMissing tmp)) CI.DontMigrate \case
                   (CI.OpenedCodebase, _, _) -> pure True
                   _ -> pure False
                 case res of
@@ -98,7 +98,7 @@ initMockWithCodebase = do
   pure $
     Init
       { -- withOpenCodebase :: forall r. DebugName -> CodebasePath -> (Codebase m v a -> m r) -> m (Either Pretty r),
-        withOpenCodebase = \_ _ action -> Right <$> action codebase,
+        withOpenCodebase = \_ _ _ action -> Right <$> action codebase,
         -- withCreatedCodebase :: forall r. DebugName -> CodebasePath -> (Codebase m v a -> m r) -> m (Either CreateCodebaseError r),
         withCreatedCodebase = \_ _ action -> Right <$> action codebase,
         -- CodebasePath -> CodebasePath
@@ -110,7 +110,7 @@ initMockWithoutCodebase = do
   let codebase = error "did we /actually/ need a Codebase?"
   pure $
     Init
-      { withOpenCodebase = \_ _ _ -> pure (Left OpenCodebaseDoesntExist),
+      { withOpenCodebase = \_ _ _ _ -> pure (Left OpenCodebaseDoesntExist),
         -- withCreatedCodebase :: forall r. DebugName -> CodebasePath -> (Codebase m v a -> m r) -> m (Either CreateCodebaseError r),
         withCreatedCodebase = \_ _ action -> Right <$> action codebase,
         -- CodebasePath -> CodebasePath

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -75,11 +75,7 @@ import qualified Unison.Codebase.Runtime as Runtime
 import Unison.Codebase.ShortBranchHash (ShortBranchHash)
 import qualified Unison.Codebase.ShortBranchHash as SBH
 import Unison.Codebase.SqliteCodebase.GitError
-  ( GitSqliteCodebaseError
-      ( GitCouldntParseRootBranchHash,
-        NoDatabaseFile,
-        UnrecognizedSchemaVersion
-      ),
+  ( GitSqliteCodebaseError (..),
   )
 import qualified Unison.Codebase.TermEdit as TermEdit
 import Unison.Codebase.Type (GitError (GitCodebaseError, GitProtocolError, GitSqliteCodebaseError))
@@ -1130,6 +1126,11 @@ notifyUser dir o = case o of
             <> prettyReadGitRepo repo
             <> "in the cache directory at"
             <> P.backticked' (P.string localPath) "."
+      CodebaseRequiresMigration (SchemaVersion fromSv) (SchemaVersion toSv) -> do
+        P.wrap $
+          "The specified codebase codebase is on version " <> P.shown fromSv
+            <> " but needs to be on version "
+            <> P.shown toSv
       UnrecognizedSchemaVersion repo localPath (SchemaVersion v) ->
         P.wrap $
           "I don't know how to interpret schema version " <> P.shown v

--- a/unison-cli/tests/Unison/Test/Ucm.hs
+++ b/unison-cli/tests/Unison/Test/Ucm.hs
@@ -66,7 +66,7 @@ runTranscript (Codebase codebasePath fmt) transcript = do
   let err e = fail $ "Parse error: \n" <> show e
       cbInit = case fmt of CodebaseFormat2 -> SC.init
   TR.withTranscriptRunner "Unison.Test.Ucm.runTranscript Invalid Version String" configFile $ \runner -> do
-    result <- Codebase.Init.withOpenCodebase cbInit "transcript" codebasePath \codebase -> do
+    result <- Codebase.Init.withOpenCodebase cbInit "transcript" codebasePath SC.DontMigrate \codebase -> do
       Codebase.installUcmDependencies codebase
       let transcriptSrc = Text.pack . stripMargin $ unTranscript transcript
       output <- either err Text.unpack <$> runner "transcript" transcriptSrc (codebasePath, codebase)
@@ -81,7 +81,7 @@ runTranscript (Codebase codebasePath fmt) transcript = do
 lowLevel :: Codebase -> (Codebase.Codebase IO Symbol Ann -> IO a) -> IO a
 lowLevel (Codebase root fmt) action = do
   let cbInit = case fmt of CodebaseFormat2 -> SC.init
-  result <- Codebase.Init.withOpenCodebase cbInit "lowLevel" root action
+  result <- Codebase.Init.withOpenCodebase cbInit "lowLevel" root SC.DontMigrate action
   case result of
     Left e -> PT.putPrettyLn (P.shown e) *> pure (error "This really should have loaded")
     Right a -> pure a

--- a/unison-cli/unison/Main.hs
+++ b/unison-cli/unison/Main.hs
@@ -118,28 +118,28 @@ main = withCP65001 . Ki.scoped $ \scope -> do
                 ]
             )
       Run (RunFromSymbol mainName) args -> do
-        getCodebaseOrExit mCodePathOption \(_, _, theCodebase) -> do
+        getCodebaseOrExit mCodePathOption SC.MigrateAutomatically \(_, _, theCodebase) -> do
           runtime <- RTI.startRuntime False RTI.OneOff Version.gitDescribeWithDate
           withArgs args $ execute theCodebase runtime mainName
       Run (RunFromFile file mainName) args
         | not (isDotU file) -> PT.putPrettyLn $ P.callout "⚠️" "Files must have a .u extension."
         | otherwise -> do
-          e <- safeReadUtf8 file
-          case e of
-            Left _ -> PT.putPrettyLn $ P.callout "⚠️" "I couldn't find that file or it is for some reason unreadable."
-            Right contents -> do
-              getCodebaseOrExit mCodePathOption \(initRes, _, theCodebase) -> do
-                rt <- RTI.startRuntime False RTI.OneOff Version.gitDescribeWithDate
-                sbrt <- RTI.startRuntime True RTI.OneOff Version.gitDescribeWithDate
-                let fileEvent = Input.UnisonFileChanged (Text.pack file) contents
-                let notifyOnUcmChanges _ = pure ()
-                launch currentDir config rt sbrt theCodebase [Left fileEvent, Right $ Input.ExecuteI mainName args, Right Input.QuitI] Nothing ShouldNotDownloadBase initRes notifyOnUcmChanges
+            e <- safeReadUtf8 file
+            case e of
+              Left _ -> PT.putPrettyLn $ P.callout "⚠️" "I couldn't find that file or it is for some reason unreadable."
+              Right contents -> do
+                getCodebaseOrExit mCodePathOption SC.MigrateAutomatically \(initRes, _, theCodebase) -> do
+                  rt <- RTI.startRuntime False RTI.OneOff Version.gitDescribeWithDate
+                  sbrt <- RTI.startRuntime True RTI.OneOff Version.gitDescribeWithDate
+                  let fileEvent = Input.UnisonFileChanged (Text.pack file) contents
+                  let notifyOnUcmChanges _ = pure ()
+                  launch currentDir config rt sbrt theCodebase [Left fileEvent, Right $ Input.ExecuteI mainName args, Right Input.QuitI] Nothing ShouldNotDownloadBase initRes notifyOnUcmChanges
       Run (RunFromPipe mainName) args -> do
         e <- safeReadUtf8StdIn
         case e of
           Left _ -> PT.putPrettyLn $ P.callout "⚠️" "I had trouble reading this input."
           Right contents -> do
-            getCodebaseOrExit mCodePathOption \(initRes, _, theCodebase) -> do
+            getCodebaseOrExit mCodePathOption SC.MigrateAutomatically \(initRes, _, theCodebase) -> do
               rt <- RTI.startRuntime False RTI.OneOff Version.gitDescribeWithDate
               sbrt <- RTI.startRuntime True RTI.OneOff Version.gitDescribeWithDate
               let fileEvent = Input.UnisonFileChanged (Text.pack "<standard input>") contents
@@ -219,7 +219,7 @@ main = withCP65001 . Ki.scoped $ \scope -> do
       Transcript shouldFork shouldSaveCodebase transcriptFiles ->
         runTranscripts renderUsageInfo shouldFork shouldSaveCodebase mCodePathOption transcriptFiles
       Launch isHeadless codebaseServerOpts downloadBase -> do
-        getCodebaseOrExit mCodePathOption \(initRes, _, theCodebase) -> do
+        getCodebaseOrExit mCodePathOption SC.MigrateAfterPrompt \(initRes, _, theCodebase) -> do
           runtime <- RTI.startRuntime False RTI.Persistent Version.gitDescribeWithDate
           ucmStateVar <- newTVarIO Nothing
           let notifyOnUcmChanges :: (Branch IO, Path.Absolute) -> IO ()
@@ -277,7 +277,7 @@ prepareTranscriptDir shouldFork mCodePathOption = do
   case shouldFork of
     UseFork -> do
       -- A forked codebase does not need to Create a codebase, because it already exists
-      getCodebaseOrExit mCodePathOption $ const (pure ())
+      getCodebaseOrExit mCodePathOption SC.MigrateAutomatically $ const (pure ())
       path <- Codebase.getCodebaseDir (fmap codebasePathOptionToPath mCodePathOption)
       PT.putPrettyLn $
         P.lines
@@ -301,7 +301,7 @@ runTranscripts' progName mcodepath transcriptDir markdownFiles = do
   currentDir <- getCurrentDirectory
   configFilePath <- getConfigFilePath mcodepath
   -- We don't need to create a codebase through `getCodebaseOrExit` as we've already done so previously.
-  and <$> getCodebaseOrExit (Just (DontCreateCodebaseWhenMissing transcriptDir)) \(_, codebasePath, theCodebase) -> do
+  and <$> getCodebaseOrExit (Just (DontCreateCodebaseWhenMissing transcriptDir)) SC.MigrateAutomatically \(_, codebasePath, theCodebase) -> do
     TR.withTranscriptRunner Version.gitDescribeWithDate (Just configFilePath) $ \runTranscript -> do
       for markdownFiles $ \(MarkdownFile fileName) -> do
         transcriptSrc <- readUtf8 fileName
@@ -454,11 +454,10 @@ defaultBaseLib =
   where
     (gitRef, _date) = Version.gitDescribe
 
--- (Unison.Codebase.Init.FinalizerAndCodebase IO Symbol Ann, InitResult IO Symbol Ann)
-getCodebaseOrExit :: Maybe CodebasePathOption -> ((InitResult, CodebasePath, Codebase IO Symbol Ann) -> IO r) -> IO r
-getCodebaseOrExit codebasePathOption action = do
+getCodebaseOrExit :: Maybe CodebasePathOption -> SC.MigrationStrategy -> ((InitResult, CodebasePath, Codebase IO Symbol Ann) -> IO r) -> IO r
+getCodebaseOrExit codebasePathOption migrationStrategy action = do
   initOptions <- argsToCodebaseInitOptions codebasePathOption
-  result <- CodebaseInit.withOpenOrCreateCodebase SC.init "main" initOptions \case
+  result <- CodebaseInit.withOpenOrCreateCodebase SC.init "main" initOptions migrationStrategy \case
     cbInit@(CreatedCodebase, dir, _) -> do
       pDir <- prettyDir dir
       PT.putPrettyLn' ""
@@ -475,20 +474,29 @@ getCodebaseOrExit codebasePathOption action = do
             executableName <- P.text . Text.pack <$> getProgName
 
             case err of
-              InitErrorOpen OpenCodebaseDoesntExist ->
-                pure
-                  ( P.lines
-                      [ "No codebase exists in " <> pDir <> ".",
-                        "Run `" <> executableName <> " --codebase-create " <> P.string dir <> " to create one, then try again!"
-                      ]
-                  )
-              InitErrorOpen (OpenCodebaseUnknownSchemaVersion _) ->
-                pure
-                  ( P.lines
-                      [ "I can't read the codebase in " <> pDir <> " because it was constructed using a newer version of unison.",
-                        "Please upgrade your version of UCM."
-                      ]
-                  )
+              InitErrorOpen err ->
+                case err of
+                  OpenCodebaseDoesntExist ->
+                    pure
+                      ( P.lines
+                          [ "No codebase exists in " <> pDir <> ".",
+                            "Run `" <> executableName <> " --codebase-create " <> P.string dir <> " to create one, then try again!"
+                          ]
+                      )
+                  (OpenCodebaseUnknownSchemaVersion _) ->
+                    pure
+                      ( P.lines
+                          [ "I can't read the codebase in " <> pDir <> " because it was constructed using a newer version of unison.",
+                            "Please upgrade your version of UCM."
+                          ]
+                      )
+                  (OpenCodebaseRequiresMigration _ _) ->
+                    pure
+                      ( P.lines
+                          [ "The codebase is from an older version of UCM, it needs to be migrated before it can be used.",
+                            "You can migrate it by opening it in UCM, e.g. ucm -c mycodebase"
+                          ]
+                      )
               FoundV1Codebase ->
                 pure
                   ( P.lines


### PR DESCRIPTION
## Overview

Currently codebases are always automatically migrated, and always require an interactive prompt to migrate, which is no-bueno on Share, where it might mean starting an ad-hoc migration during an api request (which will inevitably timeout).

Instead, we allow the caller to specify the migration strategy, one of:

* Migrate without a prompt
* Migrate with a prompt
* Don't migrate, throw an error instead.

This allows Share to run migration jobs without triggering prompts, and also allows codebases opened within api calls to throw a more appropriate error which we can expose to the user to let them know a migration is in progress.

## Implementation notes

* Adds a `MigrationStrategy` to the code which opens a codebase, then propagate that all the way outwards.
* Changes transcripts and any non-interactive UCM commands to migrate without a prompt, (I'm open to feedback on this one)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3408)
<!-- Reviewable:end -->
