### PR TITLE
ANSI on Windows fix

### DIFF
--- a/lib/unison-pretty-printer/src/Unison/Util/ColorText.hs
+++ b/lib/unison-pretty-printer/src/Unison/Util/ColorText.hs
@@ -136,13 +136,10 @@ toANSI (AnnotatedText chunks) =
               Nothing -> r <> resetANSI <> pure text
               Just style -> r <> resetANSI <> toANSI style <> pure text
           )
-    -- End every ANSI escape code in the prompt with '\STX' so that haskeline renders it properly on Windows.
-    -- This may also help haskeline make prompt width computations.
-    -- See https://github.com/judah/haskeline/wiki/ControlSequencesInPrompt for details.
-    startOfText = "\STX"
-    resetANSI = pure $ ANSI.setSGRCode [ANSI.Reset] <> startOfText
+    resetANSI :: Seq String
+    resetANSI = pure $ ANSI.setSGRCode [ANSI.Reset]
     toANSI :: Color -> Seq String
-    toANSI c = pure $ ANSI.setSGRCode (toANSI' c) <> startOfText
+    toANSI c = pure $ ANSI.setSGRCode (toANSI' c)
 
     toANSI' :: Color -> [ANSI.SGR]
     toANSI' c = case c of

--- a/stack.yaml
+++ b/stack.yaml
@@ -44,6 +44,12 @@ extra-deps:
   commit: 563e96238dfe392dccf68d93953c8f30fd53bec8
   subdirs:
     - ki
+# This custom Haskeline alters ANSI rendering on Windows.
+# If changing the haskeline dependency, please ensure color renders properly in a
+# Windows terminal.
+# https://github.com/judah/haskeline/pull/126
+- github: judah/haskeline
+  commit: d6c2643b0d5c19be7e440615c6f84d603d4bc648
 - guid-0.1.0@sha256:a7c975be473f6f142d5cc1b39bc807a99043d20b1bb0873fdfe7a3ce84d2faf1,1078
 - prelude-extras-0.4.0.3@sha256:1c10b0123ea13a6423d74a8fcbaeb2d5249b472588abde418a36b47b7c4f48c8,1163
 - sandi-0.5@sha256:b278d072ca717706ea38f9bd646e023f7f2576a778fb43565b434f93638849aa,3010
@@ -63,7 +69,6 @@ extra-deps:
 - co-log-core-0.3.1.0
 # lts 18.28 provides 0.3.2.1 but we need at least 0.3.3
 - terminal-size-0.3.3
-- haskeline-0.8.1.3
 
 ghc-options:
  # All packages

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -40,6 +40,17 @@ packages:
     subdir: ki
     url: https://github.com/awkward-squad/ki/archive/563e96238dfe392dccf68d93953c8f30fd53bec8.tar.gz
 - completed:
+    size: 74363
+    url: https://github.com/judah/haskeline/archive/d6c2643b0d5c19be7e440615c6f84d603d4bc648.tar.gz
+    name: haskeline
+    version: 0.8.0.0
+    sha256: ef827ea5e8581cd68da9600660b2e584877d4fcdcf1cd2eb4652e0e51d817465
+    pantry-tree:
+      size: 3769
+      sha256: e30301b5389893948e25d39978d09948b11479b5b2a3517b978466fde548fc48
+  original:
+    url: https://github.com/judah/haskeline/archive/d6c2643b0d5c19be7e440615c6f84d603d4bc648.tar.gz
+- completed:
     hackage: guid-0.1.0@sha256:a7c975be473f6f142d5cc1b39bc807a99043d20b1bb0873fdfe7a3ce84d2faf1,1078
     pantry-tree:
       size: 364
@@ -151,13 +162,6 @@ packages:
       sha256: 2a9669ed392657d34ec2e180ddac68c9ef657e54bf4b5fbc9b9efaa7b1d341be
   original:
     hackage: terminal-size-0.3.3
-- completed:
-    pantry-tree:
-      sha256: 90969690d0f9b49bdd6f02e5dd6ab005851f70c5778eff40043ce00cba655eaa
-      size: 2955
-    hackage: haskeline-0.8.1.3@sha256:a1ecc7bcaa959ecd751b2eec1c5466aa2db6697471d7e35ea8f1803faad8e985,6011
-  original:
-    hackage: haskeline-0.8.1.3
 snapshots:
 - completed:
     size: 590100


### PR DESCRIPTION
## Overview

M4 unfortunately resulted in strange console rendering on Windows:

![image](https://user-images.githubusercontent.com/6439644/189942535-54f7c4bd-5ef7-44d5-8edd-3c0c2f3aa008.png)

I've reverted this change and instead tried altering the Haskeline dep to commit `d6c2643b0d5c19be7e440615c6f84d603d4bc648` which is mentioned in [this pr](https://github.com/judah/haskeline/pull/126). It seems to resolve this issue;

Tested in both Powershell and CMD prompt on my Windows 11 VM:

![image](https://user-images.githubusercontent.com/6439644/189943207-727dfa74-7b9e-46bf-8f67-ce0a8eaf4388.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3410)
<!-- Reviewable:end -->
