### PR TITLE
pr.create help text: use proper share names

### DIFF
--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1313,8 +1313,8 @@ createPullRequest =
             "example: "
               <> makeExampleNoBackticks
                 createPullRequest
-                [ "unison.base.main",
-                  "myself.prs.base._myFeature"
+                [ "unison.public.base.main",
+                  "myself.public.prs.base.myFeature"
                 ]
           ]
     )


### PR DESCRIPTION
This changes the help text for the `pr.create` command to use names that
line up with what's in Share. Hopefully this prevents some confusion.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3414)
<!-- Reviewable:end -->
