### PR TITLE
Pull: update the success message when pulling

### DIFF
--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1477,12 +1477,12 @@ notifyUser dir o = case o of
   PullSuccessful ns dest ->
     pure . P.okCallout $
       P.wrap $
-        "Successfully updated" <> prettyPath' dest <> "from"
+        "✅ Successfully updated" <> prettyPath' dest <> "from"
           <> P.group (prettyReadRemoteNamespace ns <> ".")
   MergeOverEmpty dest ->
     pure . P.okCallout $
       P.wrap $
-        "The destination" <> prettyPath' dest <> "was empty, and was replaced instead of merging."
+        "✅ Successfully pulled into newly created namespace " <> prettyPath' dest <> "."
   MergeAlreadyUpToDate src dest ->
     pure . P.callout "😶" $
       P.wrap $

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1482,7 +1482,7 @@ notifyUser dir o = case o of
   MergeOverEmpty dest ->
     pure . P.okCallout $
       P.wrap $
-        "✅ Successfully pulled into newly created namespace " <> prettyPath' dest <> "."
+        "✅ Successfully pulled into newly created namespace " <> P.group (prettyPath' dest <> ".")
   MergeAlreadyUpToDate src dest ->
     pure . P.callout "😶" $
       P.wrap $


### PR DESCRIPTION
## Overview

Update the success message when pulling into a new namespace that didn't exist. It now looks like so:

```ucm
Successfully pulled into newly created namespace myLocalNamespace
```

Fixes https://github.com/unisonweb/unison/issues/3313

## Loose ends

I really the name of the rename namespace that was pulled (like the original issue suggested), but `MergeOverEmpty` didn't currently include it. Might need some help on that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3416)
<!-- Reviewable:end -->
