### PR TITLE
io.test alias, completion, and doc fix

### DIFF
--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2103,13 +2103,12 @@ ioTest :: InputPattern
 ioTest =
   InputPattern
     "io.test"
-    []
+    ["test.io"]
     I.Visible
-    []
+    [(Required, exactDefinitionTermQueryArg)]
     ( P.wrapColumn2
         [ ( "`io.test mytest`",
-            "Runs `!mytest`, where `mytest` is searched for in the most recent"
-              <> "typechecked file, or in the codebase."
+            "Runs `!mytest`, where `mytest` is a test that requires the IO ability and has been added to the codebase."
           )
         ]
     )

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2108,7 +2108,7 @@ ioTest =
     [(Required, exactDefinitionTermQueryArg)]
     ( P.wrapColumn2
         [ ( "`io.test mytest`",
-            "Runs `!mytest`, where `mytest` is a test that requires the IO ability and has been added to the codebase."
+            "Runs `!mytest`, where `mytest` is a delayed test that can use the `IO` and `Exception` abilities. Note: `mytest` must already be added to the codebase."
           )
         ]
     )

--- a/unison-src/transcripts/tab-completion.md
+++ b/unison-src/transcripts/tab-completion.md
@@ -49,4 +49,7 @@ unique type subnamespace.AType = A | B
 .> debug.tab-complete cd sub
 .> debug.tab-complete cd subnamespace
 .> debug.tab-complete cd subnamespace.
+.> debug.tab-complete io.test sub
+.> debug.tab-complete io.test subnamespace
+.> debug.tab-complete io.test subnamespace.
 ```

--- a/unison-src/transcripts/tab-completion.output.md
+++ b/unison-src/transcripts/tab-completion.output.md
@@ -113,4 +113,20 @@ unique type subnamespace.AType = A | B
 
    subnamespace.AType
 
+.> debug.tab-complete io.test sub
+
+   subnamespace.
+   subnamespace2.
+
+.> debug.tab-complete io.test subnamespace
+
+   subnamespace.
+   subnamespace2.
+
+.> debug.tab-complete io.test subnamespace.
+
+    subnamespace.AType.
+  * subnamespace.someName
+  * subnamespace.someOtherName
+
 ```


### PR DESCRIPTION
## Overview

This does 3 things for `io.test`:

- Adds a `test.io` alias (resolves #2678)
- Changes the doc to not say that it searches the most recently saved
  scratch file, since it doesn't (resolves #2677)
- Adds term tab completion similar to that of the `run` command.

## Test coverage

Some transcript tests for the tab completion

## Loose ends

At some point we should probably make `io.test` allow you to run it on a term recently saved to the scratch file but not yet added to the codebase. But until then its help shouldn't say that it can do this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3420)
<!-- Reviewable:end -->
