### PR TITLE
Fix JSON Representations

### DIFF
--- a/unison-share-api/src/Unison/Server/Types.hs
+++ b/unison-share-api/src/Unison/Server/Types.hs
@@ -243,17 +243,19 @@ deriving instance ToSchema NamedType
 
 instance ToJSON TermTag where
   toJSON = \case
-    Doc -> "doc"
-    Test -> "test"
-    Plain -> "plain"
+    Doc -> "Doc"
+    Test -> "Test"
+    Plain -> "Plain"
     Constructor tt -> case tt of
-      Ability -> "ability-constructor"
-      Data -> "data-constructor"
+      Ability -> "AbilityConstructor"
+      Data -> "DataConstructor"
 
 deriving instance ToSchema TermTag
 
 instance ToJSON TypeTag where
-  toEncoding = genericToEncoding defaultOptions
+  toJSON = \case
+    Ability -> "Ability"
+    Data -> "Data"
 
 deriving instance ToSchema TypeTag
 

--- a/unison-src/transcripts/api-find.output.md
+++ b/unison-src/transcripts/api-find.output.md
@@ -62,7 +62,7 @@ GET /api/find?query=http
                 "namedTerm": {
                     "termHash": "#emomp74i93h6ps0b5sukke0tci0ooba3f9jk21qm919a7act9u7asani84c0mqbdk4lcjrdvr9olpedp23p6df78r4trqlg0cciadc8",
                     "termName": "ross.httpClient.y",
-                    "termTag": "plain",
+                    "termTag": "Plain",
                     "termType": [
                         {
                             "annotation": {
@@ -103,7 +103,7 @@ GET /api/find?query=http
                 "namedTerm": {
                     "termHash": "#a84tg4er4kfl9k2p250vp2o1dsp5kmn9a7q8g2bo723qbtbf9sagrl28fa4q0j5f2cv4alsjik6rf487ss646qt95gbm3dd13k7e1fo",
                     "termName": "joey.httpServer.z",
-                    "termTag": "plain",
+                    "termTag": "Plain",
                     "termType": [
                         {
                             "annotation": {
@@ -148,7 +148,7 @@ GET /api/find?query=Server
                 "namedTerm": {
                     "termHash": "#a84tg4er4kfl9k2p250vp2o1dsp5kmn9a7q8g2bo723qbtbf9sagrl28fa4q0j5f2cv4alsjik6rf487ss646qt95gbm3dd13k7e1fo",
                     "termName": "joey.httpServer.z",
-                    "termTag": "plain",
+                    "termTag": "Plain",
                     "termType": [
                         {
                             "annotation": {
@@ -193,7 +193,7 @@ GET /api/find?query=lesys
                 "namedTerm": {
                     "termHash": "#qkhkl0n238s1eqibd1ecb8605sqj1m4hpoaag177cu572otqlaf1u28c8suuuqgljdtthsjtr07rv04np05o6oa27ml9105k7uas0t8",
                     "termName": "rachel.filesystem.x",
-                    "termTag": "plain",
+                    "termTag": "Plain",
                     "termType": [
                         {
                             "annotation": {
@@ -234,7 +234,7 @@ GET /api/find?query=joey.http
                 "namedTerm": {
                     "termHash": "#a84tg4er4kfl9k2p250vp2o1dsp5kmn9a7q8g2bo723qbtbf9sagrl28fa4q0j5f2cv4alsjik6rf487ss646qt95gbm3dd13k7e1fo",
                     "termName": "joey.httpServer.z",
-                    "termTag": "plain",
+                    "termTag": "Plain",
                     "termType": [
                         {
                             "annotation": {

--- a/unison-src/transcripts/api-getDefinition.output.md
+++ b/unison-src/transcripts/api-getDefinition.output.md
@@ -13,7 +13,7 @@ GET /api/getDefinition?names=x
     "termDefinitions": {
         "#qkhkl0n238s1eqibd1ecb8605sqj1m4hpoaag177cu572otqlaf1u28c8suuuqgljdtthsjtr07rv04np05o6oa27ml9105k7uas0t8": {
             "bestTermName": "x",
-            "defnTermTag": "plain",
+            "defnTermTag": "Plain",
             "signature": [
                 {
                     "annotation": {
@@ -108,7 +108,7 @@ GET /api/getDefinition?names=x&relativeTo=nested
     "termDefinitions": {
         "#qkhkl0n238s1eqibd1ecb8605sqj1m4hpoaag177cu572otqlaf1u28c8suuuqgljdtthsjtr07rv04np05o6oa27ml9105k7uas0t8": {
             "bestTermName": "x",
-            "defnTermTag": "plain",
+            "defnTermTag": "Plain",
             "signature": [
                 {
                     "annotation": {
@@ -203,7 +203,7 @@ GET /api/getDefinition?names=%23qkhkl0n238&relativeTo=nested
     "termDefinitions": {
         "#qkhkl0n238s1eqibd1ecb8605sqj1m4hpoaag177cu572otqlaf1u28c8suuuqgljdtthsjtr07rv04np05o6oa27ml9105k7uas0t8": {
             "bestTermName": "x",
-            "defnTermTag": "plain",
+            "defnTermTag": "Plain",
             "signature": [
                 {
                     "annotation": {
@@ -298,7 +298,7 @@ GET /api/getDefinition?names=%23qkhkl0n238&relativeTo=emptypath
     "termDefinitions": {
         "#qkhkl0n238s1eqibd1ecb8605sqj1m4hpoaag177cu572otqlaf1u28c8suuuqgljdtthsjtr07rv04np05o6oa27ml9105k7uas0t8": {
             "bestTermName": "x",
-            "defnTermTag": "plain",
+            "defnTermTag": "Plain",
             "signature": [
                 {
                     "annotation": {
@@ -390,7 +390,7 @@ GET /api/getDefinition?names=thing&relativeTo=doctest
     "termDefinitions": {
         "#jksc1s5kud95ro5ivngossullt2oavsd41s3u48bch67jf3gknru5j6hmjslonkd5sdqs8mr8k4rrnef8fodngbg4sm7u6au564ekjg": {
             "bestTermName": "thing",
-            "defnTermTag": "plain",
+            "defnTermTag": "Plain",
             "signature": [
                 {
                     "annotation": {
@@ -508,7 +508,7 @@ GET /api/getDefinition?names=thing.doc&relativeTo=doctest
     "termDefinitions": {
         "#t9qfdoiuskj4n9go8cftj1r83s43s3o7sppafm5vr0bq5feieb7ap0cie5ed2qsf9g3ig448vffhnajinq81pnnkila1jp2epa7f26o": {
             "bestTermName": "thing.doc",
-            "defnTermTag": "doc",
+            "defnTermTag": "Doc",
             "signature": [
                 {
                     "annotation": {

--- a/unison-src/transcripts/api-namespace-list.output.md
+++ b/unison-src/transcripts/api-namespace-list.output.md
@@ -38,7 +38,7 @@ GET /api/list?namespace=nested.names
             "contents": {
                 "termHash": "#ddmmatmmiqsts2ku0i02kntd0s7rvcui4nn1cusio8thp9oqhbtilvcnhen52ibv43kr5q83f5er5q9h56s807k17tnelnrac7cch8o",
                 "termName": "readme",
-                "termTag": "doc",
+                "termTag": "Doc",
                 "termType": [
                     {
                         "annotation": {
@@ -55,7 +55,7 @@ GET /api/list?namespace=nested.names
             "contents": {
                 "termHash": "#qkhkl0n238s1eqibd1ecb8605sqj1m4hpoaag177cu572otqlaf1u28c8suuuqgljdtthsjtr07rv04np05o6oa27ml9105k7uas0t8",
                 "termName": "x",
-                "termTag": "plain",
+                "termTag": "Plain",
                 "termType": [
                     {
                         "annotation": {
@@ -87,7 +87,7 @@ GET /api/list?namespace=names&relativeTo=nested
             "contents": {
                 "termHash": "#ddmmatmmiqsts2ku0i02kntd0s7rvcui4nn1cusio8thp9oqhbtilvcnhen52ibv43kr5q83f5er5q9h56s807k17tnelnrac7cch8o",
                 "termName": "readme",
-                "termTag": "doc",
+                "termTag": "Doc",
                 "termType": [
                     {
                         "annotation": {
@@ -104,7 +104,7 @@ GET /api/list?namespace=names&relativeTo=nested
             "contents": {
                 "termHash": "#qkhkl0n238s1eqibd1ecb8605sqj1m4hpoaag177cu572otqlaf1u28c8suuuqgljdtthsjtr07rv04np05o6oa27ml9105k7uas0t8",
                 "termName": "x",
-                "termTag": "plain",
+                "termTag": "Plain",
                 "termType": [
                     {
                         "annotation": {

--- a/unison-src/transcripts/api-summaries.output.md
+++ b/unison-src/transcripts/api-summaries.output.md
@@ -39,7 +39,7 @@ GET /api/definitions/terms/qualified/nat@qkhkl0n238/summary
         ],
         "tag": "UserObject"
     },
-    "tag": "plain"
+    "tag": "Plain"
 }
 --  doc
 GET /api/definitions/terms/qualified/doc@icfnhas71n/summary
@@ -58,7 +58,7 @@ GET /api/definitions/terms/qualified/doc@icfnhas71n/summary
         ],
         "tag": "UserObject"
     },
-    "tag": "doc"
+    "tag": "Doc"
 }
 --  test
 GET /api/definitions/terms/qualified/mytest@u17p9803hd/summary
@@ -89,7 +89,7 @@ GET /api/definitions/terms/qualified/mytest@u17p9803hd/summary
         ],
         "tag": "UserObject"
     },
-    "tag": "test"
+    "tag": "Test"
 }
 --  function
 GET /api/definitions/terms/qualified/func@6ee6j48hk3/summary
@@ -129,7 +129,7 @@ GET /api/definitions/terms/qualified/func@6ee6j48hk3/summary
         ],
         "tag": "UserObject"
     },
-    "tag": "plain"
+    "tag": "Plain"
 }
 --  constructor
 GET /api/definitions/terms/qualified/Thing.This@altimqs66j@0/summary
@@ -169,7 +169,7 @@ GET /api/definitions/terms/qualified/Thing.This@altimqs66j@0/summary
         ],
         "tag": "UserObject"
     },
-    "tag": "data-constructor"
+    "tag": "DataConstructor"
 }
 --  Long type signature
 GET /api/definitions/terms/qualified/funcWithLongType@ieskgcjjvu/summary
@@ -356,7 +356,7 @@ GET /api/definitions/terms/qualified/funcWithLongType@ieskgcjjvu/summary
         ],
         "tag": "UserObject"
     },
-    "tag": "plain"
+    "tag": "Plain"
 }
 --  Long type signature with render width
 GET /api/definitions/terms/qualified/funcWithLongType@ieskgcjjvu/summary?renderWidth=20
@@ -543,7 +543,7 @@ GET /api/definitions/terms/qualified/funcWithLongType@ieskgcjjvu/summary?renderW
         ],
         "tag": "UserObject"
     },
-    "tag": "plain"
+    "tag": "Plain"
 }
 --  Builtin Term
 GET /api/definitions/terms/qualified/putBytesImpl@@IO.putBytes.impl.v3/summary
@@ -646,7 +646,7 @@ GET /api/definitions/terms/qualified/putBytesImpl@@IO.putBytes.impl.v3/summary
         ],
         "tag": "BuiltinObject"
     },
-    "tag": "plain"
+    "tag": "Plain"
 }
 ```## Type Summary APIs
 


### PR DESCRIPTION
This was accidentally changed in https://github.com/unisonweb/unison/pull/3404/files#diff-50211e1ad45637a17a1f142f0243e8b3fb45e4b06c7bae7b69f15cfb8ef454cf ; but hasn't been deployed yet; the transcripts did catch it, but I think they got skimmed over because the addition of the new Term Tag type resulted in a lot of valid transcript changes too. This changes it back, with the exception of changing `null -> Plain`, but @hojberg  added that himself in his original PR so I imagine he has plans to support that 😄 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3427)
<!-- Reviewable:end -->
