### PR TITLE
Don't clobber latest file on view

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -2013,11 +2013,11 @@ handleShowDefinition outputLoc showDefinitionScope inputQuery = do
     let ppe = PPED.biasTo (mapMaybe HQ.toName inputQuery) unbiasedPPE
     Cli.respond (DisplayDefinitions outputPath ppe types terms)
   when (not (null misses)) (Cli.respond (SearchTermsNotFound misses))
-  for outputPath \p -> do
+  for_ outputPath \p -> do
     -- We set latestFile to be programmatically generated, if we
     -- are viewing these definitions to a file - this will skip the
     -- next update for that file (which will happen immediately)
-    #latestFile .= (p, True)
+    #latestFile ?= (p, True)
   where
     -- `view`: don't include cycles; `edit`: include cycles
     includeCycles =

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -2013,10 +2013,11 @@ handleShowDefinition outputLoc showDefinitionScope inputQuery = do
     let ppe = PPED.biasTo (mapMaybe HQ.toName inputQuery) unbiasedPPE
     Cli.respond (DisplayDefinitions outputPath ppe types terms)
   when (not (null misses)) (Cli.respond (SearchTermsNotFound misses))
-  -- We set latestFile to be programmatically generated, if we
-  -- are viewing these definitions to a file - this will skip the
-  -- next update for that file (which will happen immediately)
-  #latestFile .= ((,True) <$> outputPath)
+  for outputPath \p -> do
+    -- We set latestFile to be programmatically generated, if we
+    -- are viewing these definitions to a file - this will skip the
+    -- next update for that file (which will happen immediately)
+    #latestFile .= (p, True)
   where
     -- `view`: don't include cycles; `edit`: include cycles
     includeCycles =
@@ -3595,26 +3596,26 @@ typecheck ambient names sourceName source =
 
 typecheckHelper ::
   MonadIO m =>
-  Codebase IO Symbol Ann -> IO Parser.UniqueName ->
+  Codebase IO Symbol Ann ->
+  IO Parser.UniqueName ->
   [Type Symbol Ann] ->
   NamesWithHistory ->
   Text ->
   (Text, [L.Token L.Lexeme]) ->
-    m
+  m
     ( Result.Result
         (Seq (Result.Note Symbol Ann))
         (Either (UF.UnisonFile Symbol Ann) (UF.TypecheckedUnisonFile Symbol Ann))
     )
 typecheckHelper codebase generateUniqueName ambient names sourceName source = do
-    uniqueName <- liftIO generateUniqueName
-    (liftIO . Result.getResult) $
-      parseAndSynthesizeFile
-        ambient
-        (((<> Builtin.typeLookup) <$>) . Codebase.typeLookupForDependencies codebase)
-        (Parser.ParsingEnv uniqueName names)
-        (Text.unpack sourceName)
-        (fst source)
-
+  uniqueName <- liftIO generateUniqueName
+  (liftIO . Result.getResult) $
+    parseAndSynthesizeFile
+      ambient
+      (((<> Builtin.typeLookup) <$>) . Codebase.typeLookupForDependencies codebase)
+      (Parser.ParsingEnv uniqueName names)
+      (Text.unpack sourceName)
+      (fst source)
 
 -- | Evaluate all watched expressions in a UnisonFile and return
 -- their results, keyed by the name of the watch variable. The tuple returned


### PR DESCRIPTION
## Overview

fixes #3428

Probably just a typo in the source; but currently it always resets the latest file to `scratch.u` whenever you `view`, when it should only be setting the "programmatic change" bool.

## Implementation notes

* Rather than always wiping out the latest file, instead only set the programmatic change bit if we write to a file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3429)
<!-- Reviewable:end -->
