### PR TITLE
Pull base from the most recent major milestone

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
@@ -28,13 +28,16 @@ import qualified Unison.Codebase.Path as Path
 defaultBaseLib :: Parsec Void Text ReadShareRemoteNamespace
 defaultBaseLib = fmap makeNS $ release <|> unknown
   where
-    unknown, release, version :: Parsec Void Text Text
+    unknown, release, milestoneVersion :: Parsec Void Text Text
     unknown = pure "main" <* takeWhileP Nothing (const True) <* eof
-    release = fmap ("releases." <>) $ "release/" *> version <* eof
-    version = do
-      v <- Text.pack <$> some (alphaNumChar <|> ('_' <$ oneOf ['.', '_', '-']))
+    release = fmap ("releases." <>) $ "release/" *> milestoneVersion <* eof
+    -- Parses the milestone of the current version; e.g. M4a -> M4
+    milestoneVersion = do
+      m <- char 'M'
+      milestoneVersion <- some digit
+      _minor <- many (alphaNumChar <|> ('_' <$ oneOf ['.', '_', '-']))
       _dirty <- optional (char '\'')
-      pure v
+      pure . Text.pack $ m : milestoneVersion
     makeNS :: Text -> ReadShareRemoteNamespace
     makeNS t =
       ReadShareRemoteNamespace

--- a/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/VersionParser.hs
@@ -34,7 +34,7 @@ defaultBaseLib = fmap makeNS $ release <|> unknown
     -- Parses the milestone of the current version; e.g. M4a -> M4
     milestoneVersion = do
       m <- char 'M'
-      milestoneVersion <- some digit
+      milestoneVersion <- some digitChar
       _minor <- many (alphaNumChar <|> ('_' <$ oneOf ['.', '_', '-']))
       _dirty <- optional (char '\'')
       pure . Text.pack $ m : milestoneVersion

--- a/unison-cli/tests/Unison/Test/VersionParser.hs
+++ b/unison-cli/tests/Unison/Test/VersionParser.hs
@@ -16,9 +16,10 @@ test =
     [ ("latest-abc", "main"),
       ("dev/M4", "main"), -- or should this be "releases.M4"?
       ("dev/M4-1-g22ccb0b3b", "main"), -- and should this also be "releases.m4"?
+      -- All non-dev releases should pull from the most recent major milestone
       ("release/M4", "releases.M4"),
-      ("release/M2i_3", "releases.M2i_3"),
-      ("release/M2i-HOTFIX", "releases.M2i_HOTFIX")
+      ("release/M2i_3", "releases.M2"),
+      ("release/M2i-HOTFIX", "releases.M2")
     ]
 
 makeTest :: (Text, Text) -> Test ()


### PR DESCRIPTION
## Overview

We want to make a point of having more consistent minor releases, part of doing that is automating the process.
Right now one of the biggest friction points is cutting a new version of base with all the new builtins, it's a bit of a pain to do, and isn't easily automatable.

This PR changes things so that UCM doesn't expect a version of base for every minor release, just for the most recent Major Milestone, which means we only need to worry about cutting a corresponding base release for each Major milestone (though more often than that is fine).

This means we can automate the minor releases.

## Implementation notes

* Change the git-version parser to return only the major milestone and discard the minor components.
* Update tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3438)
<!-- Reviewable:end -->
