### PR TITLE
Use locally installed stack in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,23 +89,6 @@ jobs:
           key: stack-work-3_${{matrix.os}}-${{github.sha}}
           restore-keys: stack-work-3_${{matrix.os}}
 
-      # Install stack by downloading the binary from GitHub. The installation process is different for Linux and macOS,
-      # so this is split into two steps, only one of which will run on any particular build.
-      - name: install stack (Linux)
-        if: runner.os == 'Linux'
-        working-directory: ${{ github.workspace }}
-        run: |
-          mkdir stack && cd stack
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.7.5-linux-x86_64.tar.gz | tar -xz
-          echo "$PWD/stack-2.5.1-linux-x86_64/" >> $GITHUB_PATH
-      - name: install stack (macOS)
-        working-directory: ${{ github.workspace }}
-        if: runner.os == 'macOS'
-        run: |
-          mkdir stack && cd stack
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.7.5-osx-x86_64.tar.gz | tar -xz
-          echo "$PWD/stack-2.5.1-osx-x86_64/" >> $GITHUB_PATH
-
       # One of the transcripts fails if the user's git name hasn't been set.
       - name: set git user info
         run: |

--- a/.github/workflows/haddocks.yaml
+++ b/.github/workflows/haddocks.yaml
@@ -57,14 +57,6 @@ jobs:
             stack-work-2_Linux-haddocks
             stack-work-2_Linux
 
-      # Install stack by downloading the binary from GitHub. The installation process is different for Linux and macOS,
-      # so this is split into two steps, only one of which will run on any particular build.
-      - name: install stack
-        working-directory: unison
-        run: |
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.5.1/stack-2.5.1-linux-x86_64.tar.gz | tar -xz
-          echo "$HOME/stack-2.5.1-linux-x86_64/" >> $GITHUB_PATH
-
       # One of the transcripts fails if the user's git name hasn't been set.
       - name: set git user info
         working-directory: unison

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -14,10 +14,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: install stack
-        run: |
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.5.1/stack-2.5.1-linux-x86_64.tar.gz | tar -xz
-          echo "$HOME/stack-2.5.1-linux-x86_64/" >> $GITHUB_PATH
 
       # One of the transcripts fails if the user's git name hasn't been set.
       - name: set git user info
@@ -50,10 +46,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: install stack
-        run: |
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.5.1/stack-2.5.1-osx-x86_64.tar.gz | tar -xz
-          echo "$HOME/stack-2.5.1-osx-x86_64/" >> $GITHUB_PATH
 
       # One of the transcripts fails if the user's git name hasn't been set.
       - name: set git user info

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,10 +46,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: install stack
-        run: |
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.5.1/stack-2.5.1-linux-x86_64.tar.gz | tar -xz
-          echo "$HOME/stack-2.5.1-linux-x86_64/" >> $GITHUB_PATH
 
       - name: build
         run: stack --no-terminal build --flag unison-parser-typechecker:optimized
@@ -76,11 +72,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: install stack
-        run: |
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.5.1/stack-2.5.1-osx-x86_64.tar.gz | tar -xz
-          echo "$HOME/stack-2.5.1-osx-x86_64/" >> $GITHUB_PATH
-
       - name: remove ~/.stack/setup-exe-cache on macOS
         run: rm -rf ~/.stack/setup-exe-cache
 


### PR DESCRIPTION
## Overview

CI on trunk just recently started failing because of a mismatched hpack version; as I was looking into it I realized we were manually installing stack on all of our CI runs despite the most recent `stack` version being pre-installed on all of our runners (including Windows 🎉 ).
While I can understand that being able to pin the stack version is beneficial, in this case using the local stack fixes our issues, and it turns out that our different jobs were actually running with _different_ stack versions anyways, so I figure this doesn't hurt for now; if we need to in the future we can revive a custom install, but unless we end up having trouble it seems superfluous. Github seems to be pretty good about keeping dependencies up to date here 👍🏼 

## Implementation notes

* Delete custom installs of stack in all CI jobs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3444)
<!-- Reviewable:end -->
