### PR TITLE
less verbose migration progress

### DIFF
--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -29,6 +29,7 @@ dependencies:
   - bytestring-to-vector
   - cereal
   - clock
+  - concurrent-output
   - configurator
   - containers >= 0.6.3
   - cryptonite

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -199,6 +199,7 @@ library
     , bytestring-to-vector
     , cereal
     , clock
+    , concurrent-output
     , configurator
     , containers >=0.6.3
     , cryptonite
@@ -380,6 +381,7 @@ test-suite parser-typechecker-tests
     , cereal
     , clock
     , code-page
+    , concurrent-output
     , configurator
     , containers >=0.6.3
     , cryptonite


### PR DESCRIPTION
## Overview

Fixes #3447

This PR makes these four messages, after all migrations run, appear in a "console region" that only occupies a single line of output:

```
🕵️  Checking codebase integrity (step 1 of 3) ...
🕵️  Checking codebase integrity (step 2 of 3) ...
✅  All good, cleaning up... 
🏁 Migration complete 🏁
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3452)
<!-- Reviewable:end -->
