### PR TITLE
Accept trailing commas in records

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/FileParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/FileParser.hs
@@ -342,9 +342,14 @@ dataDeclaration mod = do
       dataConstructor = go <$> prefixVar <*> many TypeParser.valueTypeLeaf
       record = do
         _ <- openBlockWith "{"
-        fields <-
-          sepBy1 (reserved "," <* optional semi) $
-            liftA2 (,) (prefixVar <* reserved ":") TypeParser.valueType
+        let field = do
+              f <- liftA2 (,) (prefixVar <* reserved ":") TypeParser.valueType
+              optional (reserved ",")
+                >>= ( \case
+                        Nothing -> pure [f]
+                        Just _ -> maybe [] (f :) <$> (optional semi *> optional field)
+                    )
+        fields <- field
         _ <- closeBlock
         let lastSegment = name <&> (\v -> Var.named (Name.toText $ Name.unqualified (Name.unsafeFromVar v)))
         pure ([go lastSegment (snd <$> fields)], [(name, fields)])

--- a/unison-src/transcripts/records.md
+++ b/unison-src/transcripts/records.md
@@ -68,3 +68,14 @@ unique type Record4 =
 ```ucm
 .> view Record4
 ```
+
+## Syntax
+
+Trailing commas are allowed.
+
+```unison
+unique type Record5 = 
+  { a : Text, 
+    b : Int,
+  }
+```

--- a/unison-src/transcripts/records.output.md
+++ b/unison-src/transcripts/records.output.md
@@ -63,3 +63,30 @@ unique type Record4 =
         g : [Nat] }
 
 ```
+## Syntax
+
+Trailing commas are allowed.
+
+```unison
+unique type Record5 = 
+  { a : Text, 
+    b : Int,
+  }
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique type Record5
+      Record5.a        : Record5 -> Text
+      Record5.a.modify : (Text ->{g} Text)
+                         -> Record5
+                         ->{g} Record5
+      Record5.a.set    : Text -> Record5 -> Record5
+
+```


### PR DESCRIPTION
## Overview

Allows trailing commas on records, e.g.

```unison
unique type Record = 
  { a : Text, 
    b : Int,
  }
```

Maybe closes #2558 ; that's up to @ceedubs .

This currently doesn't accept _leading_ commas like Lists do, is that something we want or nah? I could add that pretty easily here if desired.

## Implementation notes

Alters the parser to allow optional trailing comma

## Test coverage

Transcript

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3453)
<!-- Reviewable:end -->
