### PR TITLE
Add branch fallback for caching

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,9 +50,10 @@ jobs:
           # recent branch cache.
           # Then it will save a new cache at this commit sha, which should be used by
           # the next build on this branch.
-          key: stack-0_${{matrix.os}}-${{hashFiles('stack.yaml')}}-${{github.sha}}
-          # Fall-back to use the most recent cache for the stack.yaml, or failing that the OS
+          key: stack-0_${{matrix.os}}-${{hashFiles('stack.yaml')}}-${{github.ref}}-${{github.sha}}
+          # Fall-back to use the most recent cache for the branch, stack.yaml, or the OS
           restore-keys: |
+            stack-0_${{matrix.os}}-${{hashFiles('stack.yaml')}}-${{github.ref}}
             stack-0_${{matrix.os}}-${{hashFiles('stack.yaml')}}
             stack-0_${{matrix.os}}
 
@@ -68,9 +69,10 @@ jobs:
           # recent branch cache.
           # Then it will save a new cache at this commit sha, which should be used by
           # the next build on this branch.
-          key: stack-0_${{matrix.os}}-${{hashFiles('stack.yaml')}}-${{github.sha}}
-          # Fall-back to use the most recent cache for the stack.yaml, or failing that the OS
+          key: stack-0_${{matrix.os}}-${{hashFiles('stack.yaml')}}-${{github.ref}}-${{github.sha}}
+          # Fall-back to use the most recent cache for the branch, stack.yaml, or the OS
           restore-keys: |
+            stack-0_${{matrix.os}}-${{hashFiles('stack.yaml')}}-${{github.ref}}
             stack-0_${{matrix.os}}-${{hashFiles('stack.yaml')}}
             stack-0_${{matrix.os}}
 
@@ -86,8 +88,10 @@ jobs:
           # recent branch cache.
           # Then it will save a new cache at this commit sha, which should be used by
           # the next build on this branch.
-          key: stack-work-3_${{matrix.os}}-${{github.sha}}
-          restore-keys: stack-work-3_${{matrix.os}}
+          key: stack-work-3_${{matrix.os}}-${{github.ref}}-${{github.sha}}
+          restore-keys: |
+            stack-work-3_${{matrix.os}}-${{github.ref}}
+            stack-work-3_${{matrix.os}}
 
       # Install stack by downloading the binary from GitHub. The installation process is different for Linux and macOS,
       # so this is split into two steps, only one of which will run on any particular build.


### PR DESCRIPTION
## Overview

The current cache will fall back to using a general cache based only on the stack.yaml, which means CI runs across different branches are stepping on each other.
This adds an additional layer of caching for the 'ref name' which is either the tag, or the branch being merged.

This means that `trunk` builds will always use the latest trunk cache, and each commit on a PR builds from the previous build on that branch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3458)
<!-- Reviewable:end -->
