### PR TITLE
Ignore cabal files in change checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,6 +134,8 @@ jobs:
           # Add all changes to the index for when we diff.
           git add --all
           # Ignore changes in generated cabal files. Oftentimes this is just due to mismatched hpack versions
+          shopt -s nullglob
+          shopt -s globstar
           git reset **/*.cabal
           # Fail if any transcripts cause git diffs.
           git diff --cached --ignore-cr-at-eol --exit-code

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -133,6 +133,8 @@ jobs:
           stack --no-terminal exec transcripts
           # Add all changes to the index for when we diff.
           git add --all
+          # Ignore changes in generated cabal files. Oftentimes this is just due to mismatched hpack versions
+          git reset **/*.cabal
           # Fail if any transcripts cause git diffs.
           git diff --cached --ignore-cr-at-eol --exit-code
       - name: prettyprint-round-trip


### PR DESCRIPTION
## Overview

Differences in hpack versions between our developer setups and CI (and also across different CI runners) is causing failures in our transcript diff check.

We have a few options to fix it:

* Try to pin stack version (I think we already were doing this by manually installing stack, but for some reason it didn't seem to work. Maybe we weren't actually using the manually installed version?)
* Try to pin  hpack version (can do this by manually installing the hpack from our current LTS or something, then using stack with --with-hpack)
* Ignore cabal files  in the 'transcript diff check', this is easiest,  but maybe we actually want to know if the cabal file differs from its generated form? Seems pretty unlikely that something would be committed without regenerating the cabal file though, so I think that's not a huge concern.

This implements the latter,  since it's quick, easy, doesn't add any extra time to the build, and doesn't mean that all of us and our contributors  need to use the exact same stack and hpack setup.

## Implementation notes

Ignore cabal files in the git diff check by removing from the index before running `git diff --cached`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3461)
<!-- Reviewable:end -->
