### PR TITLE
Pin stack version in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ jobs:
     defaults: 
       run:
         working-directory: unison
+        shell: bash
     strategy:
       # Run each build to completion, regardless of if any have failed
       fail-fast: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,9 @@
 name: CI
 
+defaults:
+  run:
+    shell: bash
+
 on:
   # Build on every pull request (and new PR commit)
   pull_request:
@@ -110,7 +114,6 @@ jobs:
       - name: install stack (windows)
         working-directory: ${{ github.workspace }}
         if: runner.os == 'Windows'
-        shell: bash
         run: |
           mkdir stack && cd stack
           curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.7.5-windows-x86_64.tar.gz | tar -xz
@@ -129,7 +132,6 @@ jobs:
       # Build deps, then build local code. Splitting it into two steps just allows us to see how much time each step
       # takes.
       - name: build dependencies
-        shell: bash
         # Run up to 5 times in a row before giving up.
         # It's very unlikely that our build-dependencies step will fail on most builds,
         # so if it fails its almost certainly due to a race condition on the Windows

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,6 +89,33 @@ jobs:
           key: stack-work-3_${{matrix.os}}-${{github.sha}}
           restore-keys: stack-work-3_${{matrix.os}}
 
+      # Install stack by downloading the binary from GitHub. 
+      # The installation process differs by OS.
+      - name: install stack (Linux)
+        if: runner.os == 'Linux'
+        working-directory: ${{ github.workspace }}
+        run: |
+          mkdir stack && cd stack
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.7.5-linux-x86_64.tar.gz | tar -xz
+          echo "$PWD/stack-"* >> $GITHUB_PATH
+
+      - name: install stack (macOS)
+        working-directory: ${{ github.workspace }}
+        if: runner.os == 'macOS'
+        run: |
+          mkdir stack && cd stack
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.7.5-osx-x86_64.tar.gz | tar -xz
+          echo "$PWD/stack-"* >> $GITHUB_PATH
+
+      - name: install stack (windows)
+        working-directory: ${{ github.workspace }}
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          mkdir stack && cd stack
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.7.5-windows-x86_64.tar.gz | tar -xz
+          echo "$PWD/stack-"* >> $GITHUB_PATH
+
       # One of the transcripts fails if the user's git name hasn't been set.
       - name: set git user info
         run: |
@@ -110,6 +137,7 @@ jobs:
         # cached within a single build, it should get further along on each re-start
         # and should hopefully finish!
         run: |
+          stack --version
           tries=1
           if [[ ${{matrix.os}} = "windows-"* ]]; then
             tries=5

--- a/.github/workflows/haddocks.yaml
+++ b/.github/workflows/haddocks.yaml
@@ -3,6 +3,7 @@ name: Haddocks
 defaults:
   run:
     working-directory: unison
+    shell: bash
 
 on:
   push:

--- a/.github/workflows/haddocks.yaml
+++ b/.github/workflows/haddocks.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: Haddocks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/haddocks.yaml
+++ b/.github/workflows/haddocks.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: Haddocks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
@@ -56,6 +56,13 @@ jobs:
           restore-keys: |
             stack-work-2_Linux-haddocks
             stack-work-2_Linux
+
+      - name: install stack (Linux)
+        working-directory: ${{ github.workspace }}
+        run: |
+          mkdir stack && cd stack
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.7.5-linux-x86_64.tar.gz | tar -xz
+          echo "$PWD/stack-"* >> $GITHUB_PATH
 
       # One of the transcripts fails if the user's git name hasn't been set.
       - name: set git user info

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -15,6 +15,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: install stack (Linux)
+        working-directory: ${{ github.workspace }}
+        run: |
+          mkdir stack && cd stack
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.7.5-linux-x86_64.tar.gz | tar -xz
+          echo "$PWD/stack-"* >> $GITHUB_PATH
+
       # One of the transcripts fails if the user's git name hasn't been set.
       - name: set git user info
         run: |
@@ -46,6 +53,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: install stack (macOS)
+        working-directory: ${{ github.workspace }}
+        run: |
+          mkdir stack && cd stack
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.7.5-osx-x86_64.tar.gz | tar -xz
+          echo "$PWD/stack-"* >> $GITHUB_PATH
 
       # One of the transcripts fails if the user's git name hasn't been set.
       - name: set git user info
@@ -81,6 +94,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: install stack (windows)
+        working-directory: ${{ github.workspace }}
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          mkdir stack && cd stack
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.7.5-windows-x86_64.tar.gz | tar -xz
+          echo "$PWD/stack-"* >> $GITHUB_PATH
+
       - name: build
         run: stack --no-terminal build --flag unison-parser-typechecker:optimized
 

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -10,7 +10,7 @@ jobs:
   build_linux:
 
     name: "build_linux"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -127,7 +127,7 @@ jobs:
 
   release:
     name: "create_release"
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-20.04
     needs:
       - build_linux
       - build_macos

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -1,5 +1,9 @@
 name: "pre-release"
 
+defaults:
+  run:
+    shell: bash
+
 on:
   workflow_run:
     workflows: ["CI"]
@@ -98,7 +102,6 @@ jobs:
       - name: install stack (windows)
         working-directory: ${{ github.workspace }}
         if: runner.os == 'Windows'
-        shell: bash
         run: |
           mkdir stack && cd stack
           curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.7.5-windows-x86_64.tar.gz | tar -xz
@@ -108,15 +111,13 @@ jobs:
         run: stack --no-terminal build --flag unison-parser-typechecker:optimized
 
       - name: fetch latest codebase-ui and package with ucm
-        # Powershell
         run: |
-          mkdir -p tmp\ui
-          mkdir -p release\ui
-          $UCM = stack exec -- where unison
-          cp $UCM .\release\ucm.exe
-          Invoke-WebRequest -Uri https://github.com/unisonweb/codebase-ui/releases/download/latest/unisonLocal.zip -OutFile tmp\unisonLocal.zip
-          Expand-Archive -Path tmp\unisonLocal.zip -DestinationPath release\ui
-          Compress-Archive -Path .\release\* -DestinationPath ucm-windows.zip
+          mkdir -p /tmp/ucm/ui
+          UCM="$(stack path | awk '/local-install-root/{print $2}')/bin/unison"
+          cp "$UCM" /tmp/ucm/ucm
+          wget -O /tmp/unisonLocal.zip https://github.com/unisonweb/unison-local-ui/releases/download/latest/unisonLocal.zip
+          tar.exe -xf /tmp/unisonLocal.zip --directory /tmp/ucm/ui
+          tar.exe -a -c -f ucm-windows.zip /tmp/ucm
 
       - name: Upload windows artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   release:
     name: "create_release"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     needs:
       - build_linux
       - build_macos
@@ -52,7 +52,7 @@ jobs:
   build_linux:
 
     name: "build_linux"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -69,11 +69,11 @@ jobs:
           # recent branch cache.
           # Then it will save a new cache at this commit sha, which should be used by
           # the next build on this branch.
-          key: stack-0_ubuntu-22.04-${{hashFiles('stack.yaml')}}-${{github.sha}}
+          key: stack-0_ubuntu-20.04-${{hashFiles('stack.yaml')}}-${{github.sha}}
           # Fall-back to use the most recent cache for the stack.yaml, or failing that the OS
           restore-keys: |
-            stack-0_ubuntu-22.04-${{hashFiles('stack.yaml')}}
-            stack-0_ubuntu-22.04
+            stack-0_ubuntu-20.04-${{hashFiles('stack.yaml')}}
+            stack-0_ubuntu-20.04
 
       # Cache each local package's ~/.stack-work for fast incremental builds in CI.
       - uses: actions/cache@v3
@@ -87,8 +87,8 @@ jobs:
           # recent branch cache.
           # Then it will save a new cache at this commit sha, which should be used by
           # the next build on this branch.
-          key: stack-work-3_ubuntu-22.04-${{github.sha}}
-          restore-keys: stack-work-3_ubuntu-22.04
+          key: stack-work-3_ubuntu-20.04-${{github.sha}}
+          restore-keys: stack-work-3_ubuntu-20.04
 
       - name: install stack (Linux)
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,9 @@
 name: "release"
 
+defaults:
+  run:
+    shell: bash
+
 on:
   workflow_dispatch:
     inputs:
@@ -228,14 +232,12 @@ jobs:
 
       - name: install stack (windows)
         working-directory: ${{ github.workspace }}
-        shell: bash
         run: |
           mkdir stack && cd stack
           curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.7.5-windows-x86_64.tar.gz | tar -xz
           echo "$PWD/stack-"* >> $GITHUB_PATH
 
       - name: build
-        shell: bash
         run: |
           # Windows will crash on build intermittently because the filesystem
           # sucks at managing concurrent file access;
@@ -246,15 +248,13 @@ jobs:
           done
 
       - name: fetch latest Unison Local UI and package with ucm
-        # Powershell
         run: |
-          mkdir -p tmp\ui
-          mkdir -p release\ui
-          $UCM = stack exec -- where unison
-          cp $UCM .\release\ucm.exe
-          Invoke-WebRequest -Uri https://github.com/unisonweb/unison-local-ui/releases/download/latest/unisonLocal.zip -OutFile tmp\unisonLocal.zip
-          Expand-Archive -Path tmp\unisonLocal.zip -DestinationPath release\ui
-          Compress-Archive -Path .\release\* -DestinationPath ucm-windows.zip
+          mkdir -p /tmp/ucm/ui
+          UCM="$(stack path | awk '/local-install-root/{print $2}')/bin/unison"
+          cp "$UCM" /tmp/ucm/ucm
+          wget -O /tmp/unisonLocal.zip https://github.com/unisonweb/unison-local-ui/releases/download/latest/unisonLocal.zip
+          tar.exe -xf /tmp/unisonLocal.zip --directory /tmp/ucm/ui
+          tar.exe -a -c -f ucm-windows.zip /tmp/ucm
 
       - name: Upload windows artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,6 +90,13 @@ jobs:
           key: stack-work-3_ubuntu-22.04-${{github.sha}}
           restore-keys: stack-work-3_ubuntu-22.04
 
+      - name: install stack (Linux)
+        working-directory: ${{ github.workspace }}
+        run: |
+          mkdir stack && cd stack
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.7.5-linux-x86_64.tar.gz | tar -xz
+          echo "$PWD/stack-"* >> $GITHUB_PATH
+
       - name: build
         run: stack --no-terminal build --flag unison-parser-typechecker:optimized
 
@@ -148,6 +155,13 @@ jobs:
           # the next build on this branch.
           key: stack-work-3_macOS-11.0-${{github.sha}}
           restore-keys: stack-work-3_macOS-11.0
+
+      - name: install stack (macOS)
+        working-directory: ${{ github.workspace }}
+        run: |
+          mkdir stack && cd stack
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.7.5-osx-x86_64.tar.gz | tar -xz
+          echo "$PWD/stack-"* >> $GITHUB_PATH
 
       - name: remove ~/.stack/setup-exe-cache on macOS
         run: rm -rf ~/.stack/setup-exe-cache
@@ -211,6 +225,14 @@ jobs:
           # the next build on this branch.
           key: stack-work-3_windows-2019-${{github.sha}}
           restore-keys: stack-work-3_windows-2019
+
+      - name: install stack (windows)
+        working-directory: ${{ github.workspace }}
+        shell: bash
+        run: |
+          mkdir stack && cd stack
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.7.5-windows-x86_64.tar.gz | tar -xz
+          echo "$PWD/stack-"* >> $GITHUB_PATH
 
       - name: build
         shell: bash

--- a/codebase2/codebase-sqlite-hashing-v2/unison-codebase-sqlite-hashing-v2.cabal
+++ b/codebase2/codebase-sqlite-hashing-v2/unison-codebase-sqlite-hashing-v2.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 

--- a/codebase2/codebase-sqlite/unison-codebase-sqlite.cabal
+++ b/codebase2/codebase-sqlite/unison-codebase-sqlite.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 

--- a/codebase2/codebase-sync/unison-codebase-sync.cabal
+++ b/codebase2/codebase-sync/unison-codebase-sync.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 

--- a/codebase2/codebase/unison-codebase.cabal
+++ b/codebase2/codebase/unison-codebase.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 

--- a/codebase2/core/unison-core.cabal
+++ b/codebase2/core/unison-core.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 

--- a/codebase2/util-serialization/unison-util-serialization.cabal
+++ b/codebase2/util-serialization/unison-util-serialization.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 

--- a/codebase2/util-term/unison-util-term.cabal
+++ b/codebase2/util-term/unison-util-term.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 

--- a/codebase2/util/unison-util.cabal
+++ b/codebase2/util/unison-util.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 

--- a/lib/unison-prelude/unison-prelude.cabal
+++ b/lib/unison-prelude/unison-prelude.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 

--- a/lib/unison-pretty-printer/unison-pretty-printer.cabal
+++ b/lib/unison-pretty-printer/unison-pretty-printer.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 
@@ -68,9 +68,9 @@ library
     , unison-core1
     , unison-prelude
     , unliftio
-  default-language: Haskell2010
   if flag(optimized)
     ghc-options: -funbox-strict-fields -O2
+  default-language: Haskell2010
 
 executable prettyprintdemo
   main-is: Main.hs
@@ -103,9 +103,9 @@ executable prettyprintdemo
     , safe
     , text
     , unison-pretty-printer
-  default-language: Haskell2010
   if flag(optimized)
     ghc-options: -funbox-strict-fields -O2
+  default-language: Haskell2010
 
 test-suite pretty-printer-tests
   type: exitcode-stdio-1.0
@@ -145,6 +145,6 @@ test-suite pretty-printer-tests
     , easytest
     , raw-strings-qq
     , unison-pretty-printer
-  default-language: Haskell2010
   if flag(optimized)
     ghc-options: -funbox-strict-fields -O2
+  default-language: Haskell2010

--- a/lib/unison-sqlite/unison-sqlite.cabal
+++ b/lib/unison-sqlite/unison-sqlite.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 

--- a/lib/unison-util-base32hex-orphans-aeson/unison-util-base32hex-orphans-aeson.cabal
+++ b/lib/unison-util-base32hex-orphans-aeson/unison-util-base32hex-orphans-aeson.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 

--- a/lib/unison-util-base32hex-orphans-sqlite/unison-util-base32hex-orphans-sqlite.cabal
+++ b/lib/unison-util-base32hex-orphans-sqlite/unison-util-base32hex-orphans-sqlite.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 

--- a/lib/unison-util-base32hex/unison-util-base32hex.cabal
+++ b/lib/unison-util-base32hex/unison-util-base32hex.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 

--- a/lib/unison-util-relation/unison-util-relation.cabal
+++ b/lib/unison-util-relation/unison-util-relation.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 
@@ -296,9 +296,9 @@ library
     , x509-system
     , yaml
     , zlib
-  default-language: Haskell2010
   if flag(optimized)
     ghc-options: -funbox-strict-fields -O2
+  default-language: Haskell2010
 
 test-suite parser-typechecker-tests
   type: exitcode-stdio-1.0
@@ -482,6 +482,6 @@ test-suite parser-typechecker-tests
     , x509-system
     , yaml
     , zlib
-  default-language: Haskell2010
   if flag(optimized)
     ghc-options: -funbox-strict-fields -O2
+  default-language: Haskell2010

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 
@@ -192,12 +192,12 @@ library
     , wai
     , warp
     , witherable
-  default-language: Haskell2010
   if flag(optimized)
     ghc-options: -O2 -funbox-strict-fields
   if !os(windows)
     build-depends:
         unix
+  default-language: Haskell2010
 
 executable cli-integration-tests
   main-is: Suite.hs
@@ -315,9 +315,9 @@ executable cli-integration-tests
     , wai
     , warp
     , witherable
-  default-language: Haskell2010
   if flag(optimized)
     ghc-options: -O2 -funbox-strict-fields
+  default-language: Haskell2010
 
 executable transcripts
   main-is: Transcripts.hs
@@ -432,9 +432,9 @@ executable transcripts
     , wai
     , warp
     , witherable
-  default-language: Haskell2010
   if flag(optimized)
     ghc-options: -O2 -funbox-strict-fields
+  default-language: Haskell2010
 
 executable unison
   main-is: Main.hs
@@ -554,9 +554,9 @@ executable unison
     , wai
     , warp
     , witherable
-  default-language: Haskell2010
   if flag(optimized)
     ghc-options: -O2 -funbox-strict-fields
+  default-language: Haskell2010
 
 test-suite cli-tests
   type: exitcode-stdio-1.0
@@ -678,6 +678,6 @@ test-suite cli-tests
     , wai
     , warp
     , witherable
-  default-language: Haskell2010
   if flag(optimized)
     ghc-options: -O2 -funbox-strict-fields
+  default-language: Haskell2010

--- a/unison-core/unison-core1.cabal
+++ b/unison-core/unison-core1.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 
@@ -105,6 +105,6 @@ library
     , unison-util-base32hex
     , unison-util-relation
     , vector
-  default-language: Haskell2010
   if flag(optimized)
     ghc-options: -O2 -funbox-strict-fields
+  default-language: Haskell2010

--- a/unison-hashing-v2/unison-hashing-v2.cabal
+++ b/unison-hashing-v2/unison-hashing-v2.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 


### PR DESCRIPTION
## Overview

Pin the stack version we use in CI to avoid mismatched hpack versions.

The previously pinned stack wasn't working due to a simple typo in the PATH we were adding.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3465)
<!-- Reviewable:end -->
