### PR TITLE
Fix windows release... again

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -111,13 +111,18 @@ jobs:
         run: stack --no-terminal build --flag unison-parser-typechecker:optimized
 
       - name: fetch latest codebase-ui and package with ucm
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Powershell
+        shell: pwsh
         run: |
-          mkdir -p /tmp/ucm/ui
-          UCM="$(stack path | awk '/local-install-root/{print $2}')/bin/unison"
-          cp "$UCM" /tmp/ucm/ucm
-          wget -O /tmp/unisonLocal.zip https://github.com/unisonweb/unison-local-ui/releases/download/latest/unisonLocal.zip
-          tar.exe -xf /tmp/unisonLocal.zip --directory /tmp/ucm/ui
-          tar.exe -a -c -f ucm-windows.zip /tmp/ucm
+          mkdir -p tmp\ui
+          mkdir -p release\ui
+          $UCM = .\stack\stack-2.7.5-windows-x86_64\stack.exe exec -- where unison
+          cp $UCM .\release\ucm.exe
+          Invoke-WebRequest -Uri https://github.com/unisonweb/unison-local-ui/releases/download/latest/unisonLocal.zip -OutFile tmp\unisonLocal.zip
+          Expand-Archive -Path tmp\unisonLocal.zip -DestinationPath release\ui
+          Compress-Archive -Path .\release\* -DestinationPath ucm-windows.zip
 
       - name: Upload windows artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -250,7 +250,7 @@ jobs:
       - name: fetch latest Unison Local UI and package with ucm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # Powershell, because it's the only way to do certain things.
+        # Powershell
         shell: pwsh
         run: |
           mkdir -p tmp\ui

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -250,13 +250,16 @@ jobs:
       - name: fetch latest Unison Local UI and package with ucm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Powershell, because it's the only way to do certain things.
+        shell: pwsh
         run: |
-          mkdir -p /tmp/ucm/ui
-          UCM="$(stack path | awk '/local-install-root/{print $2}')/bin/unison"
-          cp "$UCM" /tmp/ucm/ucm
-          gh release download latest --repo unisonweb/unison-local-ui --pattern '*.zip' --dir /tmp/
-          tar.exe -xf /tmp/unisonLocal.zip --directory /tmp/ucm/ui
-          tar.exe -a -c -f ucm-windows.zip /tmp/ucm
+          mkdir -p tmp\ui
+          mkdir -p release\ui
+          $UCM = .\stack\stack-2.7.5-windows-x86_64\stack.exe exec -- where unison
+          cp $UCM .\release\ucm.exe
+          Invoke-WebRequest -Uri https://github.com/unisonweb/unison-local-ui/releases/download/latest/unisonLocal.zip -OutFile tmp\unisonLocal.zip
+          Expand-Archive -Path tmp\unisonLocal.zip -DestinationPath release\ui
+          Compress-Archive -Path .\release\* -DestinationPath ucm-windows.zip
 
       - name: Upload windows artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -252,7 +252,7 @@ jobs:
           mkdir -p /tmp/ucm/ui
           UCM="$(stack path | awk '/local-install-root/{print $2}')/bin/unison"
           cp "$UCM" /tmp/ucm/ucm
-          wget -O /tmp/unisonLocal.zip https://github.com/unisonweb/unison-local-ui/releases/download/latest/unisonLocal.zip
+          gh release download latest --repo unisonweb/unison-local-ui --pattern '*.zip' --dir /tmp/
           tar.exe -xf /tmp/unisonLocal.zip --directory /tmp/ucm/ui
           tar.exe -a -c -f ucm-windows.zip /tmp/ucm
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -248,6 +248,8 @@ jobs:
           done
 
       - name: fetch latest Unison Local UI and package with ucm
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir -p /tmp/ucm/ui
           UCM="$(stack path | awk '/local-install-root/{print $2}')/bin/unison"


### PR DESCRIPTION
## Overview

Windows builds broke after pinning stack version, we tried to fix it by switching to using bash as our shell, this broke the powershell section, I tried to re-write it in bash, but that was very difficult both to debug and to actually get working, since there aren't many tools for working with Zip files in `bash`, so I swapped that section back to powershell and just call the desired stack executable manually, which is a bit janky but works fine so I'm happy to leave it like that and just not touch this code anymore haha.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3470)
<!-- Reviewable:end -->
