### PR TITLE
refactor: leave getTermComponentWithTypes in Transaction

### DIFF
--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -526,11 +526,11 @@ unsafeGetTermWithType codebase rid = do
 
 -- | Like 'getTermComponentWithTypes', for when the term component is known to exist in the codebase.
 unsafeGetTermComponent ::
-  (HasCallStack, Monad m) =>
+  HasCallStack =>
   Codebase m v a ->
   Hash ->
-  m [(Term v a, Type v a)]
+  Sqlite.Transaction [(Term v a, Type v a)]
 unsafeGetTermComponent codebase hash =
-  getTermComponentWithTypes codebase hash >>= \case
+  getTermComponentWithTypes codebase hash <&> \case
     Nothing -> error (reportBug "E769004" ("term component " ++ show hash ++ " not found"))
-    Just terms -> pure terms
+    Just terms -> terms

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -248,9 +248,9 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
             getTypeOfTermImpl id =
               runTransaction (CodebaseOps.getTypeOfTermImpl id)
 
-            getTermComponentWithTypes :: Hash -> m (Maybe [(Term Symbol Ann, Type Symbol Ann)])
-            getTermComponentWithTypes h =
-              runTransaction (CodebaseOps.getTermComponentWithTypes getDeclType h)
+            getTermComponentWithTypes :: Hash -> Sqlite.Transaction (Maybe [(Term Symbol Ann, Type Symbol Ann)])
+            getTermComponentWithTypes =
+              CodebaseOps.getTermComponentWithTypes getDeclType
 
             getTypeDeclaration :: Reference.Id -> m (Maybe (Decl Symbol Ann))
             getTypeDeclaration id =

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -76,7 +76,7 @@ data Codebase m v a = Codebase
     -- choose to delay the put until all of the type declaration's references are stored as well.
     putTypeDeclaration :: Reference.Id -> Decl v a -> m (),
     -- getTermComponent :: Hash -> m (Maybe [Term v a]),
-    getTermComponentWithTypes :: Hash -> m (Maybe [(Term v a, Type v a)]),
+    getTermComponentWithTypes :: Hash -> Sqlite.Transaction (Maybe [(Term v a, Type v a)]),
     getDeclComponent :: Hash -> m (Maybe [Decl v a]),
     getComponentLength :: Hash -> m (Maybe Reference.CycleSize),
     -- | Get the root causal Hash.

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update.hs
@@ -54,6 +54,7 @@ import Unison.Referent (Referent)
 import qualified Unison.Referent as Referent
 import qualified Unison.Result as Result
 import Unison.Runtime.IOSource (isTest)
+import qualified Unison.Sqlite as Sqlite
 import Unison.Symbol (Symbol)
 import Unison.Term (Term)
 import qualified Unison.Term as Term
@@ -322,7 +323,9 @@ getSlurpResultForUpdate requestedNames = do
           --   [ (<#pingpong.pong + 1>, <Nat>),
           --     (<#pingpong.ping + 2>, <Nat>)
           --   ]
-          terms <- Codebase.unsafeGetTermComponent codebase oldHash
+          terms <-
+            Codebase.withConnection codebase \conn ->
+              Sqlite.runTransaction conn (Codebase.unsafeGetTermComponent codebase oldHash)
           pure $
             terms
               -- Running example:


### PR DESCRIPTION
## Overview

This PR changes the type (in the codebase record-of-functions) of `getTermComponentWithTypes` from

```haskell
getTermComponentWithTypes :: Hash -> m (Maybe [(Term v a, Type v a)]),
```

to

```haskell
getTermComponentWithTypes :: Hash -> Transaction (Maybe [(Term v a, Type v a)]),
```

thus allowing the caller to put together a transaction that uses this function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unisonweb/unison/3473)
<!-- Reviewable:end -->
