### PR TITLE
Refactor: delete hash1 <-> hash2 conversions

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -262,7 +262,7 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
 
             getCycleLength :: Hash -> m (Maybe Reference.CycleSize)
             getCycleLength h =
-              runTransaction (CodebaseOps.getCycleLength h)
+              runTransaction (Ops.getCycleLen h)
 
             -- putTermComponent :: MonadIO m => Hash -> [(Term Symbol Ann, Type Symbol Ann)] -> m ()
             -- putTerms :: MonadIO m => Map Reference.Id (Term Symbol Ann, Type Symbol Ann) -> m () -- dies horribly if missing dependencies?
@@ -528,7 +528,7 @@ syncInternal progress runSrc runDest b = time "syncInternal" do
               processBranches rest
             do
               when debugProcessBranches $ traceM $ "  " ++ show b0 ++ " doesn't exist in dest db"
-              let h2 = CausalHash . Cv.hash1to2 $ Causal.unCausalHash h
+              let h2 = CausalHash $ Causal.unCausalHash h
               runSrc (Q.loadCausalHashIdByCausalHash h2) >>= \case
                 Just chId -> do
                   when debugProcessBranches $ traceM $ "  " ++ show b0 ++ " exists in source db, so delegating to direct sync"
@@ -559,7 +559,7 @@ syncInternal progress runSrc runDest b = time "syncInternal" do
                         processBranches (os ++ bs ++ b0 : rest)
         O h : rest -> do
           when debugProcessBranches $ traceM $ "processBranches O " ++ take 10 (show h)
-          oId <- runSrc (Q.expectHashIdByHash (Cv.hash1to2 h) >>= Q.expectObjectIdForAnyHashId)
+          oId <- runSrc (Q.expectHashIdByHash h >>= Q.expectObjectIdForAnyHashId)
           doSync [Sync22.O oId]
           processBranches rest
   let bHash = Branch.headHash b

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Conversions.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Conversions.hs
@@ -24,8 +24,6 @@ import qualified U.Codebase.TypeEdit as V2.TypeEdit
 import qualified U.Codebase.WatchKind as V2
 import qualified U.Codebase.WatchKind as V2.WatchKind
 import qualified U.Core.ABT as ABT
-import qualified U.Util.Hash as V2
-import qualified U.Util.Hash as V2.Hash
 import qualified Unison.Codebase.Branch as V1.Branch
 import qualified Unison.Codebase.Causal.Type as V1.Causal
 import qualified Unison.Codebase.Metadata as V1.Metadata
@@ -248,37 +246,34 @@ shortHashSuffix1to2 =
   -- todo: move suffix parsing to frontend
   either error id . V1.Reference.readSuffix
 
-rreference2to1 :: Hash -> V2.Reference' Text (Maybe V2.Hash) -> V1.Reference
+rreference2to1 :: Hash -> V2.Reference' Text (Maybe Hash) -> V1.Reference
 rreference2to1 h = \case
   V2.ReferenceBuiltin t -> V1.Reference.Builtin t
   V2.ReferenceDerived i -> V1.Reference.DerivedId $ rreferenceid2to1 h i
 
-rreference1to2 :: Hash -> V1.Reference -> V2.Reference' Text (Maybe V2.Hash)
+rreference1to2 :: Hash -> V1.Reference -> V2.Reference' Text (Maybe Hash)
 rreference1to2 h = \case
   V1.Reference.Builtin t -> V2.ReferenceBuiltin t
   V1.Reference.DerivedId i -> V2.ReferenceDerived (rreferenceid1to2 h i)
 
-rreferenceid2to1 :: Hash -> V2.Reference.Id' (Maybe V2.Hash) -> V1.Reference.Id
+rreferenceid2to1 :: Hash -> V2.Reference.Id' (Maybe Hash) -> V1.Reference.Id
 rreferenceid2to1 h (V2.Reference.Id oh i) = V1.Reference.Id h' i
   where
-    h' = maybe h hash2to1 oh
+    h' = fromMaybe h oh
 
-rreferenceid1to2 :: Hash -> V1.Reference.Id -> V2.Reference.Id' (Maybe V2.Hash)
+rreferenceid1to2 :: Hash -> V1.Reference.Id -> V2.Reference.Id' (Maybe Hash)
 rreferenceid1to2 h (V1.Reference.Id h' i) = V2.Reference.Id oh i
   where
-    oh = if h == h' then Nothing else Just (hash1to2 h')
-
-hash1to2 :: Hash -> V2.Hash
-hash1to2 (V1.Hash bs) = V2.Hash.Hash bs
+    oh = if h == h' then Nothing else Just h'
 
 branchHash1to2 :: V1.Branch.NamespaceHash m -> V2.BranchHash
-branchHash1to2 = V2.BranchHash . hash1to2 . V1.genericHash
+branchHash1to2 = V2.BranchHash . V1.genericHash
 
 branchHash2to1 :: forall m. V2.BranchHash -> V1.Branch.NamespaceHash m
-branchHash2to1 = V1.HashFor . hash2to1 . V2.unBranchHash
+branchHash2to1 = V1.HashFor . V2.unBranchHash
 
 patchHash1to2 :: V1.Branch.EditHash -> V2.PatchHash
-patchHash1to2 = V2.PatchHash . hash1to2
+patchHash1to2 = V2.PatchHash
 
 reference2to1 :: V2.Reference -> V1.Reference
 reference2to1 = \case
@@ -291,12 +286,10 @@ reference1to2 = \case
   V1.Reference.DerivedId i -> V2.ReferenceDerived (referenceid1to2 i)
 
 referenceid1to2 :: V1.Reference.Id -> V2.Reference.Id
-referenceid1to2 (V1.Reference.Id h i) = V2.Reference.Id (hash1to2 h) i
+referenceid1to2 (V1.Reference.Id h i) = V2.Reference.Id h i
 
 referenceid2to1 :: V2.Reference.Id -> V1.Reference.Id
-referenceid2to1 (V2.Reference.Id h i) = V1.Reference.Id sh i
-  where
-    sh = hash2to1 h
+referenceid2to1 (V2.Reference.Id h i) = V1.Reference.Id h i
 
 rreferent2to1 :: Applicative m => Hash -> (V2.Reference -> m CT.ConstructorType) -> V2.ReferentH -> m V1.Referent
 rreferent2to1 h lookupCT = \case
@@ -334,14 +327,11 @@ constructorType2to1 = \case
   V2.DataConstructor -> CT.Data
   V2.EffectConstructor -> CT.Effect
 
-hash2to1 :: V2.Hash.Hash -> Hash
-hash2to1 (V2.Hash.Hash sbs) = V1.Hash sbs
-
 causalHash2to1 :: V2.CausalHash -> V1.Branch.CausalHash
-causalHash2to1 = V1.Causal.CausalHash . hash2to1 . V2.unCausalHash
+causalHash2to1 = V1.Causal.CausalHash . V2.unCausalHash
 
 causalHash1to2 :: V1.Branch.CausalHash -> V2.CausalHash
-causalHash1to2 = V2.CausalHash . hash1to2 . V1.Causal.unCausalHash
+causalHash1to2 = V2.CausalHash . V1.Causal.unCausalHash
 
 ttype2to1 :: V2.Term.Type V2.Symbol -> V1.Type.Type V1.Symbol Ann
 ttype2to1 = type2to1' reference2to1
@@ -523,10 +513,10 @@ patch1to2 (V1.Patch v1termedits v1typeedits) = V2.Branch.Patch v2termedits v2typ
       V1.TermEdit.Different -> V2.TermEdit.Different
 
 edithash2to1 :: V2.PatchHash -> V1.Branch.EditHash
-edithash2to1 = hash2to1 . V2.unPatchHash
+edithash2to1 = V2.unPatchHash
 
 edithash1to2 :: V1.Branch.EditHash -> V2.PatchHash
-edithash1to2 = V2.PatchHash . hash1to2
+edithash1to2 = V2.PatchHash
 
 namesegment2to1 :: V2.Branch.NameSegment -> V1.NameSegment
 namesegment2to1 (V2.Branch.NameSegment t) = V1.NameSegment t

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -157,16 +157,16 @@ tryFlushBuffer ::
   (Hash -> Transaction ()) ->
   Hash ->
   Transaction ()
-tryFlushBuffer buf saveComponent tryWaiting h@(Cv.hash1to2 -> h2) =
+tryFlushBuffer buf saveComponent tryWaiting h =
   -- skip if it has already been flushed
-  unlessM (Ops.objectExistsForHash h2) do
+  unlessM (Ops.objectExistsForHash h) do
     BufferEntry size comp (Set.delete h -> missing) waiting <- Sqlite.unsafeIO (getBuffer buf h)
     case size of
       Just size -> do
-        missing' <- filterM (fmap not . Ops.objectExistsForHash . Cv.hash1to2) (toList missing)
+        missing' <- filterM (fmap not . Ops.objectExistsForHash) (toList missing)
         if null missing' && size == fromIntegral (length comp)
           then do
-            saveComponent h2 (toList comp)
+            saveComponent h (toList comp)
             Sqlite.unsafeIO (removeBuffer buf h)
             traverse_ tryWaiting waiting
           else Sqlite.unsafeIO do
@@ -184,10 +184,10 @@ getTerm ::
   (C.Reference.Reference -> Transaction CT.ConstructorType) ->
   Reference.Id ->
   Transaction (Maybe (Term Symbol Ann))
-getTerm doGetDeclType (Reference.Id h1@(Cv.hash1to2 -> h2) i) =
+getTerm doGetDeclType (Reference.Id h i) =
   runMaybeT do
-    term2 <- Ops.loadTermByReference (C.Reference.Id h2 i)
-    lift (Cv.term2to1 h1 doGetDeclType term2)
+    term2 <- Ops.loadTermByReference (C.Reference.Id h i)
+    lift (Cv.term2to1 h doGetDeclType term2)
 
 getDeclType :: C.Reference.Reference -> Transaction CT.ConstructorType
 getDeclType = \case
@@ -205,9 +205,9 @@ expectDeclTypeById :: C.Reference.Id -> Transaction CT.ConstructorType
 expectDeclTypeById = fmap Cv.decltype2to1 . Ops.expectDeclTypeById
 
 getTypeOfTermImpl :: Reference.Id -> Transaction (Maybe (Type Symbol Ann))
-getTypeOfTermImpl (Reference.Id (Cv.hash1to2 -> h2) i) =
+getTypeOfTermImpl (Reference.Id h i) =
   runMaybeT do
-    type2 <- Ops.loadTypeOfTermByTermReference (C.Reference.Id h2 i)
+    type2 <- Ops.loadTypeOfTermByTermReference (C.Reference.Id h i)
     pure (Cv.ttype2to1 type2)
 
 getTermComponentWithTypes ::
@@ -215,26 +215,22 @@ getTermComponentWithTypes ::
   (C.Reference.Reference -> Transaction CT.ConstructorType) ->
   Hash ->
   Transaction (Maybe [(Term Symbol Ann, Type Symbol Ann)])
-getTermComponentWithTypes doGetDeclType h1@(Cv.hash1to2 -> h2) =
+getTermComponentWithTypes doGetDeclType h =
   runMaybeT do
-    tms <- Ops.loadTermComponent h2
-    for tms (bitraverse (lift . Cv.term2to1 h1 doGetDeclType) (pure . Cv.ttype2to1))
+    tms <- Ops.loadTermComponent h
+    for tms (bitraverse (lift . Cv.term2to1 h doGetDeclType) (pure . Cv.ttype2to1))
 
 getTypeDeclaration :: Reference.Id -> Transaction (Maybe (Decl Symbol Ann))
-getTypeDeclaration (Reference.Id h1@(Cv.hash1to2 -> h2) i) =
+getTypeDeclaration (Reference.Id h i) =
   runMaybeT do
-    decl2 <- Ops.loadDeclByReference (C.Reference.Id h2 i)
-    pure (Cv.decl2to1 h1 decl2)
+    decl2 <- Ops.loadDeclByReference (C.Reference.Id h i)
+    pure (Cv.decl2to1 h decl2)
 
 getDeclComponent :: Hash -> Transaction (Maybe [Decl Symbol Ann])
-getDeclComponent h1@(Cv.hash1to2 -> h2) =
+getDeclComponent h =
   runMaybeT do
-    decl2 <- Ops.loadDeclComponent h2
-    pure (map (Cv.decl2to1 h1) decl2)
-
-getCycleLength :: Hash -> Transaction (Maybe Reference.CycleSize)
-getCycleLength (Cv.hash1to2 -> h2) =
-  Ops.getCycleLen h2
+    decl2 <- Ops.loadDeclComponent h
+    pure (map (Cv.decl2to1 h) decl2)
 
 putTerm ::
   TVar (Map Hash TermBufferEntry) ->
@@ -243,8 +239,8 @@ putTerm ::
   Term Symbol Ann ->
   Type Symbol Ann ->
   Transaction ()
-putTerm termBuffer declBuffer (Reference.Id h@(Cv.hash1to2 -> h2) i) tm tp =
-  unlessM (Ops.objectExistsForHash h2) do
+putTerm termBuffer declBuffer (Reference.Id h i) tm tp =
+  unlessM (Ops.objectExistsForHash h) do
     BufferEntry size comp missing waiting <- Sqlite.unsafeIO (getBuffer termBuffer h)
     let termDependencies = Set.toList $ Term.termDependencies tm
     -- update the component target size if we encounter any higher self-references
@@ -257,10 +253,10 @@ putTerm termBuffer declBuffer (Reference.Id h@(Cv.hash1to2 -> h2) i) tm tp =
     -- for the component element that's been passed in, add its dependencies to missing'
     missingTerms' <-
       filterM
-        (fmap not . Ops.objectExistsForHash . Cv.hash1to2)
+        (fmap not . Ops.objectExistsForHash)
         [h | Reference.Derived h _i <- termDependencies]
     missingTypes' <-
-      filterM (fmap not . Ops.objectExistsForHash . Cv.hash1to2) $
+      filterM (fmap not . Ops.objectExistsForHash) $
         [h | Reference.Derived h _i <- Set.toList $ Term.typeDependencies tm]
           ++ [h | Reference.Derived h _i <- Set.toList $ Type.dependencies tp]
     let missing' = missing <> Set.fromList (missingTerms' <> missingTypes')
@@ -303,8 +299,8 @@ putTypeDeclaration ::
   Reference.Id ->
   Decl Symbol Ann ->
   Transaction ()
-putTypeDeclaration termBuffer declBuffer (Reference.Id h@(Cv.hash1to2 -> h2) i) decl =
-  unlessM (Ops.objectExistsForHash h2) do
+putTypeDeclaration termBuffer declBuffer (Reference.Id h i) decl =
+  unlessM (Ops.objectExistsForHash h) do
     BufferEntry size comp missing waiting <- Sqlite.unsafeIO (getBuffer declBuffer h)
     let declDependencies = Set.toList $ Decl.declDependencies decl
     let size' = max size (Just $ biggestSelfReference + 1)
@@ -314,7 +310,7 @@ putTypeDeclaration termBuffer declBuffer (Reference.Id h@(Cv.hash1to2 -> h2) i) 
                 i :| [i' | Reference.Derived h' i' <- declDependencies, h == h']
     let comp' = Map.insert i decl comp
     moreMissing <-
-      filterM (fmap not . Ops.objectExistsForHash . Cv.hash1to2) $
+      filterM (fmap not . Ops.objectExistsForHash) $
         [h | Reference.Derived h _i <- declDependencies]
     let missing' = missing <> Set.fromList moreMissing
     Sqlite.unsafeIO do
@@ -412,7 +408,7 @@ putBranch =
 
 isCausalHash :: Branch.CausalHash -> Transaction Bool
 isCausalHash (Causal.CausalHash h) =
-  Q.loadHashIdByHash (Cv.hash1to2 h) >>= \case
+  Q.loadHashIdByHash h >>= \case
     Nothing -> pure False
     Just hId -> Q.isCausalHash hId
 
@@ -437,8 +433,7 @@ dependentsImpl selector r =
 
 dependentsOfComponentImpl :: Hash -> Transaction (Set Reference.Id)
 dependentsOfComponentImpl h =
-  Set.map Cv.referenceid2to1
-    <$> Ops.dependentsOfComponent (Cv.hash1to2 h)
+  Set.map Cv.referenceid2to1 <$> Ops.dependentsOfComponent h
 
 watches :: UF.WatchKind -> Transaction [Reference.Id]
 watches w =
@@ -523,7 +518,7 @@ referentsByPrefix doGetDeclType (SH.ShortHash prefix (fmap Cv.shortHashSuffix1to
       >>= traverse (Cv.referentid2to1 doGetDeclType)
   declReferents' <- Ops.declReferentsByPrefix prefix cycle (read . Text.unpack <$> cid)
   let declReferents =
-        [ Referent.ConId (ConstructorReference (Reference.Id (Cv.hash2to1 h) pos) (fromIntegral cid)) (Cv.decltype2to1 ct)
+        [ Referent.ConId (ConstructorReference (Reference.Id h pos) (fromIntegral cid)) (Cv.decltype2to1 ct)
           | (h, pos, ct, cids) <- declReferents',
             cid <- cids
         ]
@@ -535,7 +530,7 @@ branchHashesByPrefix sh = do
   -- refer to to specify a full namespace w/ history.
   -- but do we want to be able to refer to a namespace without its history?
   cs <- Ops.causalHashesByPrefix (Cv.sbh1to2 sh)
-  pure $ Set.map (Causal.CausalHash . Cv.hash2to1 . unCausalHash) cs
+  pure $ Set.map (Causal.CausalHash . unCausalHash) cs
 
 sqlLca :: Branch.CausalHash -> Branch.CausalHash -> Transaction (Maybe Branch.CausalHash)
 sqlLca h1 h2 = do
@@ -544,7 +539,7 @@ sqlLca h1 h2 = do
 
 -- well one or the other. :zany_face: the thinking being that they wouldn't hash-collide
 termExists, declExists :: Hash -> Transaction Bool
-termExists = fmap isJust . Q.loadObjectIdForPrimaryHash . Cv.hash1to2
+termExists = fmap isJust . Q.loadObjectIdForPrimaryHash
 declExists = termExists
 
 before :: Branch.CausalHash -> Branch.CausalHash -> Transaction (Maybe Bool)


### PR DESCRIPTION
## Overview

The "v1" / "v2" hash types were somewhat recently unified. This PR removes the associated conversion functions, which were just `id`.