### PR TITLE
Add putTermComponent to codebase interface

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Conversions.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Conversions.hs
@@ -204,6 +204,13 @@ term2to1 h lookupCT =
           V2.Term.PConcat -> V1.Pattern.Concat
         a = Ann.External
 
+termComponent1to2 ::
+  Hash ->
+  [(V1.Term.Term V1.Symbol Ann, V1.Type.Type V1.Symbol a)] ->
+  [(V2.Term.Term V2.Symbol, V2.Type.TypeT V2.Symbol)]
+termComponent1to2 h =
+  map (bimap (term1to2 h) ttype1to2)
+
 decl2to1 :: Hash -> V2.Decl.Decl V2.Symbol -> V1.Decl.Decl V1.Symbol Ann
 decl2to1 h (V2.Decl.DataDeclaration dt m bound cts) =
   goCT dt $


### PR DESCRIPTION
## Overview

This PR adds a `putTermComponent` helper to the codebase interface.

Previously, we only had `putTerm`, which:

- Buffers the term in-memory, because it might be part of a component, and we need the whole component buffered before we can write a row to SQLite.
- Tries flushing the buffer (which flushes complete components, and then other components that depend on the flushed ones)

`putTermComponent` is similar, it just takes the whole component as input, and only tries flushing the buffer once, after buffering each term individually.

So, not a huge change, just a step towards eliminating `putTerm` and replacing it with some ideal `putTermComponent` that doesn't do any buffering.