### PR TITLE
Fix record trailing comma parsing

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/FileParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/FileParser.hs
@@ -347,7 +347,7 @@ dataDeclaration mod = do
               optional (reserved ",")
                 >>= ( \case
                         Nothing -> pure [f]
-                        Just _ -> maybe [] (f :) <$> (optional semi *> optional field)
+                        Just _ -> maybe [f] (f :) <$> (optional semi *> optional field)
                     )
         fields <- field
         _ <- closeBlock

--- a/unison-src/transcripts/records.output.md
+++ b/unison-src/transcripts/records.output.md
@@ -88,5 +88,10 @@ unique type Record5 =
                          -> Record5
                          ->{g} Record5
       Record5.a.set    : Text -> Record5 -> Record5
+      Record5.b        : Record5 -> Int
+      Record5.b.modify : (Int ->{g} Int)
+                         -> Record5
+                         ->{g} Record5
+      Record5.b.set    : Int -> Record5 -> Record5
 
 ```


### PR DESCRIPTION
PR #3453 added support for trailing commas in record types but the last
field of the record was ignored. This fixes the bug. See transcript
update.
