### PR TITLE
Fix a shadowing bug in `instantiateL`

### DIFF
--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -2408,8 +2408,8 @@ instantiateL blank v (Type.stripIntroOuters -> t) =
         -- InstLIIL
         v0 <- ABT.freshen body freshenTypeVar
         markThenRetract0 v0 $ do
-          v <- extendUniversal v0
-          instantiateL B.Blank v (ABT.bindInheritAnnotation body (universal' () v))
+          v1 <- extendUniversal v0
+          instantiateL B.Blank v (ABT.bindInheritAnnotation body (universal' () v1))
       _ -> failWith $ TypeMismatch ctx
 
 nameFrom :: Var v => v -> Type v loc -> v

--- a/unison-src/transcripts/fix2354.md
+++ b/unison-src/transcripts/fix2354.md
@@ -1,0 +1,14 @@
+
+```ucm:hide
+.> builtins.merge
+```
+
+Tests that delaying an un-annotated higher-rank type gives a normal
+type error, rather than an internal compiler error.
+
+```unison:error
+f : (forall a . a -> a) -> Nat
+f id = id 0
+
+x = 'f
+```

--- a/unison-src/transcripts/fix2354.output.md
+++ b/unison-src/transcripts/fix2354.output.md
@@ -1,0 +1,27 @@
+
+Tests that delaying an un-annotated higher-rank type gives a normal
+type error, rather than an internal compiler error.
+
+```unison
+f : (forall a . a -> a) -> Nat
+f id = id 0
+
+x = 'f
+```
+
+```ucm
+
+  I found a value of type:  (a1 ->{𝕖} a1) ->{𝕖} Nat
+  where I expected to find:  (a -> 𝕣1) -> 𝕣
+  
+      1 | f : (forall a . a -> a) -> Nat
+      2 | f id = id 0
+      3 | 
+      4 | x = 'f
+  
+    from right here:
+  
+      1 | f : (forall a . a -> a) -> Nat
+  
+
+```


### PR DESCRIPTION
This fixes an apparent bug in `instantiateL`, where the case for:

    v <= forall a. T

was proceeding to:

    let x = fresh in
    x <= T[a := x]

rather than the correct:

    v <= T[a := fresh]

The recursive call was using a shadowing variable rather than the original.

Includes a test case. The code in question is still an error, but gives a proper type error message, rather than a bad, internal compiler error.

Addresses #2354.