### PR TITLE
Cli monad simplification: implement scoped short-circuit with exceptions

### DIFF
--- a/unison-cli/src/Unison/Cli/Monad.hs
+++ b/unison-cli/src/Unison/Cli/Monad.hs
@@ -131,6 +131,7 @@ data ReturnType a
   = Success a
   | Continue
   | HaltRepl
+  deriving stock (Eq, Show)
 
 -- | The command-line app monad environment.
 --

--- a/unison-cli/src/Unison/Cli/Monad.hs
+++ b/unison-cli/src/Unison/Cli/Monad.hs
@@ -38,15 +38,14 @@ module Unison.Cli.Monad
 
     -- * Misc types
     LoadSourceResult (..),
-    Label,
-    R,
   )
 where
 
+import Control.Exception (throwIO)
 import Control.Lens (lens, (.=))
-import Control.Monad.Reader (MonadReader (..), ReaderT (ReaderT))
-import Control.Monad.State.Strict (MonadState, StateT (StateT))
-import Control.Monad.Trans.Cont
+import Control.Monad.Reader (MonadReader (..))
+import Control.Monad.State.Strict (MonadState)
+import qualified Control.Monad.State.Strict as State
 import qualified Data.Configurator.Types as Configurator
 import Data.Generics.Labels ()
 import qualified Data.List.NonEmpty as List (NonEmpty)
@@ -54,6 +53,7 @@ import qualified Data.List.NonEmpty as List.NonEmpty
 import Data.Time.Clock (DiffTime, diffTimeToPicoseconds)
 import Data.Time.Clock.System (getSystemTime, systemToTAITime)
 import Data.Time.Clock.TAI (diffAbsoluteTime)
+import Data.Unique (Unique, newUnique)
 import GHC.OverloadedLabels (IsLabel (..))
 import System.CPUTime (getCPUTime)
 import Text.Printf (printf)
@@ -77,6 +77,7 @@ import Unison.Term (Term)
 import Unison.Type (Type)
 import qualified Unison.UnisonFile as UF
 import UnliftIO.STM
+import Unsafe.Coerce (unsafeCoerce)
 
 -- | The main command-line app monad.
 --
@@ -84,34 +85,45 @@ import UnliftIO.STM
 --
 -- * It is a state monad of 'LoopState'.
 --
--- * It is a short-circuiting monad: a @Cli@ computation can short-circuit with success or failure.
+-- * It is a short-circuiting monad: a @Cli@ computation can short-circuit with success or failure in a delimited scope.
 --
--- * It is a resource monad: resources can be acquired with straight-line syntax, and will be released at the end of
--- do-block.
+-- * It is a resource monad: resources can be acquired in callback-style.
 --
 -- * It is an IO monad: you can do IO things, but throwing synchronous exceptions is discouraged. Use the built-in
 -- short-circuiting mechanism instead.
---
--- The @r@ type variable is boilerplate. It starts out as @r@, and grows an new 'R' layer for each scoped action (e.g.
--- 'with' / 'label'). For this reason, whenever you find yourself writing down an explicit type that has to carefully
--- mention how many 'R' layers are inferred, you may prefer to use an @_@ (with @PartialTypeSignatures@) instead, as the
--- precise type is not very meaningful useful to a reader.
-newtype Cli r a = Cli
+newtype Cli a = Cli
   { unCli ::
+      forall r.
       Env ->
       (a -> LoopState -> IO (ReturnType r, LoopState)) ->
       LoopState ->
       IO (ReturnType r, LoopState)
   }
-  deriving
-    ( Functor,
-      Applicative,
-      Monad,
-      MonadIO,
-      MonadReader Env,
-      MonadState LoopState
-    )
-    via ReaderT Env (ContT (ReturnType r) (StateT LoopState IO))
+  deriving stock (Functor)
+
+instance Applicative Cli where
+  pure x = Cli \_ k -> k x
+  (<*>) = ap
+
+instance Monad Cli where
+  return = pure
+  Cli mx >>= f =
+    Cli \env k ->
+      mx env \a -> unCli (f a) env k
+
+instance MonadIO Cli where
+  liftIO mx =
+    Cli \_ k s -> do
+      x <- mx
+      k x s
+
+instance MonadReader Env Cli where
+  ask = Cli \env k -> k env
+  local f m = Cli \env -> unCli m (f env)
+
+instance MonadState LoopState Cli where
+  get = Cli \_ k s -> k s s
+  put s = Cli \_ k _ -> k () s
 
 -- | What a Cli action returns: a value, an instruction to continue processing input, or an instruction to stop
 -- processing input.
@@ -200,23 +212,15 @@ loopState0 lastSavedRootHash b p = do
     }
 
 -- | Run a @Cli@ action down to @IO@.
-runCli :: Env -> LoopState -> Cli a a -> IO (ReturnType a, LoopState)
-runCli = runCli' id
-
-runCli' :: (a -> b) -> Env -> LoopState -> Cli b a -> IO (ReturnType b, LoopState)
-runCli' f env s0 (Cli action) =
-  action env (\x s1 -> pure (Success (f x), s1)) s0
+runCli :: Env -> LoopState -> Cli a -> IO (ReturnType a, LoopState)
+runCli env s0 (Cli action) =
+  action env (\x s1 -> pure (Success x, s1)) s0
 
 feed :: (a -> LoopState -> IO (ReturnType b, LoopState)) -> (ReturnType a, LoopState) -> IO (ReturnType b, LoopState)
 feed k = \case
   (Success x, s) -> k x s
   (Continue, s) -> pure (Continue, s)
   (HaltRepl, s) -> pure (HaltRepl, s)
-
-feedE :: (a -> LoopState -> IO (ReturnType r, LoopState)) -> (ReturnType (R r a), LoopState) -> IO (ReturnType r, LoopState)
-feedE k = feed \era s -> case era of
-  GoL r -> pure (Success r, s)
-  GoR a -> k a s
 
 -- | The result of calling 'loadSource'.
 data LoadSourceResult
@@ -225,28 +229,28 @@ data LoadSourceResult
   | LoadSuccess Text
 
 -- | Lift an action of type @IO (Either e a)@, given a continuation for @e@.
-ioE :: IO (Either e a) -> (e -> Cli r a) -> Cli r a
+ioE :: IO (Either e a) -> (e -> Cli a) -> Cli a
 ioE action errK =
   liftIO action >>= \case
     Left err -> errK err
     Right value -> pure value
 
-short :: ReturnType r -> Cli r a
+short :: (forall r. ReturnType r) -> Cli a
 short r = Cli \_env _k s -> pure (r, s)
 
 -- | Short-circuit the processing of the current input.
-returnEarly :: Output -> Cli r a
+returnEarly :: Output -> Cli a
 returnEarly x = do
   respond x
   returnEarlyWithoutOutput
 
 -- | Variant of 'returnEarly' that doesn't take a final output message.
-returnEarlyWithoutOutput :: Cli r a
+returnEarlyWithoutOutput :: Cli a
 returnEarlyWithoutOutput =
   short Continue
 
 -- | Stop processing inputs from the user.
-haltRepl :: Cli r a
+haltRepl :: Cli a
 haltRepl = short HaltRepl
 
 -- | Wrap a continuation with 'Cli'.
@@ -257,25 +261,32 @@ haltRepl = short HaltRepl
 -- with (bracket create destroy) \\resource ->
 --   ...
 -- @
-with :: (forall x. (a -> IO x) -> IO x) -> (a -> Cli (R r b) b) -> Cli r b
+with :: (forall x. (a -> IO x) -> IO x) -> (a -> Cli b) -> Cli b
 with resourceK action =
   Cli \env k s ->
-    resourceK (runCli' GoR env s . action) >>= feedE k
+    resourceK (runCli env s . action) >>= feed k
 
 -- | A variant of 'with' for actions that don't acquire a resource (like 'Control.Exception.bracket_').
-with_ :: (forall x. IO x -> IO x) -> Cli (R r a) a -> Cli r a
+with_ :: (forall x. IO x -> IO x) -> Cli a -> Cli a
 with_ resourceK action =
   Cli \env k s ->
-    resourceK (runCli' GoR env s action) >>= feedE k
+    resourceK (runCli env s action) >>= feed k
 
 -- | A variant of 'with' for the variant of bracketing function that may return a Left rather than call the provided
 -- continuation.
-withE :: (forall x. (a -> IO x) -> IO (Either e x)) -> (Either e a -> Cli (R r b) b) -> Cli r b
+withE :: (forall x. (a -> IO x) -> IO (Either e x)) -> (Either e a -> Cli b) -> Cli b
 withE resourceK action =
   Cli \env k s ->
-    resourceK (\a -> runCli' GoR env s (action (Right a))) >>= \case
-      Left err -> runCli' GoR env s (action (Left err)) >>= feedE k
-      Right result -> feedE k result
+    resourceK (\a -> runCli env s (action (Right a))) >>= \case
+      Left err -> runCli env s (action (Left err)) >>= feed k
+      Right result -> feed k result
+
+data X
+  = forall a. X !Unique !LoopState a
+  deriving anyclass (Exception)
+
+instance Show X where
+  show _ = "<internal exception type>"
 
 -- | Create a label that can be jumped to.
 --
@@ -289,22 +300,22 @@ withE resourceK action =
 --   ... -- We don't get here
 -- -- x is bound to someValue
 -- @
-label :: forall r a. ((forall t b. Label (R r a) t => a -> Cli t b) -> Cli (R r a) a) -> Cli r a
-label f = Cli \env k s0 -> do
-  res <-
-    unCli
-      ( f
-          ( \a -> Cli \_ _ s1 ->
-              pure (Success (wrap @(R r a) (GoR a)), s1)
-          )
-      )
-      env
-      (\a s -> pure (Success (GoR a), s))
-      s0
-  feedE k res
+label :: forall a. ((forall void. a -> Cli void) -> Cli a) -> Cli a
+label f =
+  Cli \env k s0 -> do
+    n <- newUnique
+    let bail :: forall void. a -> Cli void
+        bail a = do
+          s1 <- State.get
+          liftIO (throwIO (X n s1 a))
+    try (runCli env s0 (f bail)) >>= \case
+      Left err@(X m s1 a)
+        | n == m -> k (unsafeCoerce a) s1
+        | otherwise -> throwIO err
+      Right a -> feed k a
 
 -- | Time an action.
-time :: String -> Cli r a -> Cli r a
+time :: String -> Cli a -> Cli a
 time label action =
   if Debug.shouldDebug Debug.Timing
     then Cli \env k s -> do
@@ -348,30 +359,14 @@ time label action =
         ms = ns / 1_000_000
         s = ns / 1_000_000_000
 
-respond :: Output -> Cli r ()
+respond :: Output -> Cli ()
 respond output = do
   Env {notify} <- ask
   liftIO (notify output)
 
-respondNumbered :: NumberedOutput -> Cli r ()
+respondNumbered :: NumberedOutput -> Cli ()
 respondNumbered output = do
   Env {notifyNumbered} <- ask
   args <- liftIO (notifyNumbered output)
   unless (null args) do
     #numberedArgs .= args
-
-class Label s t where
-  wrap :: s -> t
-  -- this default is only provided so that the haddocks don't show
-  -- 'wrap'
-  default wrap :: s ~ t => s -> t
-  wrap = id
-
-instance Label (R t x) (R t x)
-
-instance {-# OVERLAPPABLE #-} Label s t => Label s (R t x) where
-  wrap = GoL . wrap
-
-data R a b
-  = GoL a
-  | GoR b

--- a/unison-cli/src/Unison/Cli/MonadUtils.hs
+++ b/unison-cli/src/Unison/Cli/MonadUtils.hs
@@ -110,7 +110,7 @@ import UnliftIO.STM
 -- .unisonConfig things
 
 -- | Lookup a config value by key.
-getConfig :: Configurator.Configured a => Text -> Cli r (Maybe a)
+getConfig :: Configurator.Configured a => Text -> Cli (Maybe a)
 getConfig key = do
   Cli.Env {config} <- ask
   liftIO (Configurator.lookup config key)
@@ -119,18 +119,18 @@ getConfig key = do
 -- Getting paths, path resolution, etc.
 
 -- | Get the current path.
-getCurrentPath :: Cli r Path.Absolute
+getCurrentPath :: Cli Path.Absolute
 getCurrentPath = do
   use #currentPath
 
 -- | Resolve a @Path'@ to a @Path.Absolute@, per the current path.
-resolvePath' :: Path' -> Cli r Path.Absolute
+resolvePath' :: Path' -> Cli Path.Absolute
 resolvePath' path = do
   currentPath <- getCurrentPath
   pure (Path.resolve currentPath path)
 
 -- | Resolve a path split, per the current path.
-resolveSplit' :: (Path', a) -> Cli r (Path.Absolute, a)
+resolveSplit' :: (Path', a) -> Cli (Path.Absolute, a)
 resolveSplit' =
   traverseOf _1 resolvePath'
 
@@ -139,13 +139,13 @@ resolveSplit' =
 
 -- | Resolve an @AbsBranchId@ to the corresponding @Branch IO@, or fail if no such branch hash is found. (Non-existent
 -- branches by path are OK - the empty branch will be returned).
-resolveAbsBranchId :: Input.AbsBranchId -> Cli r (Branch IO)
+resolveAbsBranchId :: Input.AbsBranchId -> Cli (Branch IO)
 resolveAbsBranchId = \case
   Left hash -> resolveShortBranchHash hash
   Right path -> getBranchAt path
 
 -- | Resolve a @ShortBranchHash@ to the corresponding @Branch IO@, or fail if no such branch hash is found.
-resolveShortBranchHash :: ShortBranchHash -> Cli r (Branch IO)
+resolveShortBranchHash :: ShortBranchHash -> Cli (Branch IO)
 resolveShortBranchHash hash = do
   Cli.time "resolveShortBranchHash" do
     Cli.Env {codebase} <- ask
@@ -164,23 +164,23 @@ resolveShortBranchHash hash = do
 -- Getting/Setting branches
 
 -- | Get the root branch.
-getRootBranch :: Cli r (Branch IO)
+getRootBranch :: Cli (Branch IO)
 getRootBranch = do
   use #root >>= atomically . readTMVar
 
 -- | Get the root branch0.
-getRootBranch0 :: Cli r (Branch0 IO)
+getRootBranch0 :: Cli (Branch0 IO)
 getRootBranch0 =
   Branch.head <$> getRootBranch
 
 -- | Set a new root branch.
 -- Note: This does _not_ update the codebase, the caller is responsible for that.
-setRootBranch :: Branch IO -> Cli r ()
+setRootBranch :: Branch IO -> Cli ()
 setRootBranch b = do
   void $ modifyRootBranch (const b)
 
 -- | Get the root branch.
-modifyRootBranch :: (Branch IO -> Branch IO) -> Cli r (Branch IO)
+modifyRootBranch :: (Branch IO -> Branch IO) -> Cli (Branch IO)
 modifyRootBranch f = do
   rootVar <- use #root
   atomically do
@@ -190,45 +190,45 @@ modifyRootBranch f = do
     pure newRoot
 
 -- | Get the current branch.
-getCurrentBranch :: Cli r (Branch IO)
+getCurrentBranch :: Cli (Branch IO)
 getCurrentBranch = do
   path <- getCurrentPath
   getBranchAt path
 
 -- | Get the current branch0.
-getCurrentBranch0 :: Cli r (Branch0 IO)
+getCurrentBranch0 :: Cli (Branch0 IO)
 getCurrentBranch0 = do
   Branch.head <$> getCurrentBranch
 
 -- | Get the last saved root hash.
-getLastSavedRootHash :: Cli r V2Branch.CausalHash
+getLastSavedRootHash :: Cli V2Branch.CausalHash
 getLastSavedRootHash = do
   use #lastSavedRootHash
 
 -- | Set a new root branch.
 -- Note: This does _not_ update the codebase, the caller is responsible for that.
-setLastSavedRootHash :: V2Branch.CausalHash -> Cli r ()
+setLastSavedRootHash :: V2Branch.CausalHash -> Cli ()
 setLastSavedRootHash ch = do
   #lastSavedRootHash .= ch
 
 -- | Get the branch at an absolute path.
-getBranchAt :: Path.Absolute -> Cli r (Branch IO)
+getBranchAt :: Path.Absolute -> Cli (Branch IO)
 getBranchAt path =
   getMaybeBranchAt path <&> fromMaybe Branch.empty
 
 -- | Get the branch0 at an absolute path.
-getBranch0At :: Path.Absolute -> Cli r (Branch0 IO)
+getBranch0At :: Path.Absolute -> Cli (Branch0 IO)
 getBranch0At path =
   Branch.head <$> getBranchAt path
 
 -- | Get the maybe-branch at an absolute path.
-getMaybeBranchAt :: Path.Absolute -> Cli r (Maybe (Branch IO))
+getMaybeBranchAt :: Path.Absolute -> Cli (Maybe (Branch IO))
 getMaybeBranchAt path = do
   rootBranch <- getRootBranch
   pure (Branch.getAt (Path.unabsolute path) rootBranch)
 
 -- | Get the branch at an absolute or relative path, or return early if there's no such branch.
-expectBranchAtPath' :: Path' -> Cli r (Branch IO)
+expectBranchAtPath' :: Path' -> Cli (Branch IO)
 expectBranchAtPath' path0 = do
   path <- resolvePath' path0
   getMaybeBranchAt path & onNothingM (Cli.returnEarly (Output.BranchNotFound path0))
@@ -236,7 +236,7 @@ expectBranchAtPath' path0 = do
 -- | Assert that there's "no branch" at an absolute or relative path, or return early if there is one, where "no branch"
 -- means either there's actually no branch, or there is a branch whose head is empty (i.e. it may have a history, but no
 -- current terms/types etc).
-assertNoBranchAtPath' :: Path' -> Cli r ()
+assertNoBranchAtPath' :: Path' -> Cli ()
 assertNoBranchAtPath' path' = do
   whenM (branchExistsAtPath' path') do
     Cli.returnEarly (Output.BranchAlreadyExists path')
@@ -245,7 +245,7 @@ assertNoBranchAtPath' path' = do
 --
 -- "no branch" means either there's actually no branch, or there is a branch whose head is empty (i.e. it may have a history, but no
 -- current terms/types etc).
-branchExistsAtPath' :: Path' -> Cli r Bool
+branchExistsAtPath' :: Path' -> Cli Bool
 branchExistsAtPath' path' = do
   absPath <- resolvePath' path'
   Cli.Env {codebase} <- ask
@@ -261,36 +261,36 @@ branchExistsAtPath' path' = do
 stepAt ::
   Text ->
   (Path, Branch0 IO -> Branch0 IO) ->
-  Cli r ()
+  Cli ()
 stepAt cause = stepManyAt @[] cause . pure
 
 stepAt' ::
   Text ->
-  (Path, Branch0 IO -> Cli r (Branch0 IO)) ->
-  Cli r Bool
+  (Path, Branch0 IO -> Cli (Branch0 IO)) ->
+  Cli Bool
 stepAt' cause = stepManyAt' @[] cause . pure
 
 stepAtNoSync' ::
-  (Path, Branch0 IO -> Cli r (Branch0 IO)) ->
-  Cli r Bool
+  (Path, Branch0 IO -> Cli (Branch0 IO)) ->
+  Cli Bool
 stepAtNoSync' = stepManyAtNoSync' @[] . pure
 
 stepAtNoSync ::
   (Path, Branch0 IO -> Branch0 IO) ->
-  Cli r ()
+  Cli ()
 stepAtNoSync = stepManyAtNoSync @[] . pure
 
 stepAtM ::
   Text ->
   (Path, Branch0 IO -> IO (Branch0 IO)) ->
-  Cli r ()
+  Cli ()
 stepAtM cause = stepManyAtM @[] cause . pure
 
 stepManyAt ::
   Foldable f =>
   Text ->
   f (Path, Branch0 IO -> Branch0 IO) ->
-  Cli r ()
+  Cli ()
 stepManyAt reason actions = do
   stepManyAtNoSync actions
   syncRoot reason
@@ -298,8 +298,8 @@ stepManyAt reason actions = do
 stepManyAt' ::
   Foldable f =>
   Text ->
-  f (Path, Branch0 IO -> Cli r (Branch0 IO)) ->
-  Cli r Bool
+  f (Path, Branch0 IO -> Cli (Branch0 IO)) ->
+  Cli Bool
 stepManyAt' reason actions = do
   res <- stepManyAtNoSync' actions
   syncRoot reason
@@ -307,8 +307,8 @@ stepManyAt' reason actions = do
 
 stepManyAtNoSync' ::
   Foldable f =>
-  f (Path, Branch0 IO -> Cli r (Branch0 IO)) ->
-  Cli r Bool
+  f (Path, Branch0 IO -> Cli (Branch0 IO)) ->
+  Cli Bool
 stepManyAtNoSync' actions = do
   origRoot <- getRootBranch
   newRoot <- Branch.stepManyAtM actions origRoot
@@ -319,7 +319,7 @@ stepManyAtNoSync' actions = do
 stepManyAtNoSync ::
   Foldable f =>
   f (Path, Branch0 IO -> Branch0 IO) ->
-  Cli r ()
+  Cli ()
 stepManyAtNoSync actions =
   void . modifyRootBranch $ Branch.stepManyAt actions
 
@@ -327,7 +327,7 @@ stepManyAtM ::
   Foldable f =>
   Text ->
   f (Path, Branch0 IO -> IO (Branch0 IO)) ->
-  Cli r ()
+  Cli ()
 stepManyAtM reason actions = do
   stepManyAtMNoSync actions
   syncRoot reason
@@ -335,14 +335,14 @@ stepManyAtM reason actions = do
 stepManyAtMNoSync ::
   Foldable f =>
   f (Path, Branch0 IO -> IO (Branch0 IO)) ->
-  Cli r ()
+  Cli ()
 stepManyAtMNoSync actions = do
   oldRoot <- getRootBranch
   newRoot <- liftIO (Branch.stepManyAtM actions oldRoot)
   setRootBranch newRoot
 
 -- | Sync the in-memory root branch.
-syncRoot :: Text -> Cli r ()
+syncRoot :: Text -> Cli ()
 syncRoot description = do
   rootBranch <- getRootBranch
   updateRoot rootBranch description
@@ -352,8 +352,8 @@ syncRoot description = do
 updateAtM ::
   Text ->
   Path.Absolute ->
-  (Branch IO -> Cli r (Branch IO)) ->
-  Cli r Bool
+  (Branch IO -> Cli (Branch IO)) ->
+  Cli Bool
 updateAtM reason (Path.Absolute p) f = do
   b <- getRootBranch
   b' <- Branch.modifyAtM p f b
@@ -366,11 +366,11 @@ updateAt ::
   Text ->
   Path.Absolute ->
   (Branch IO -> Branch IO) ->
-  Cli r Bool
+  Cli Bool
 updateAt reason p f = do
   updateAtM reason p (pure . f)
 
-updateRoot :: Branch IO -> Text -> Cli r ()
+updateRoot :: Branch IO -> Text -> Cli ()
 updateRoot new reason =
   Cli.time "updateRoot" do
     Cli.Env {codebase} <- ask
@@ -384,7 +384,7 @@ updateRoot new reason =
 ------------------------------------------------------------------------------------------------------------------------
 -- Getting terms
 
-getTermsAt :: (Path.Absolute, HQ'.HQSegment) -> Cli r (Set Referent)
+getTermsAt :: (Path.Absolute, HQ'.HQSegment) -> Cli (Set Referent)
 getTermsAt path = do
   rootBranch0 <- getRootBranch0
   pure (BranchUtil.getTerm (Path.convert path) rootBranch0)
@@ -392,7 +392,7 @@ getTermsAt path = do
 ------------------------------------------------------------------------------------------------------------------------
 -- Getting types
 
-getTypesAt :: (Path.Absolute, HQ'.HQSegment) -> Cli r (Set TypeReference)
+getTypesAt :: (Path.Absolute, HQ'.HQSegment) -> Cli (Set TypeReference)
 getTypesAt path = do
   rootBranch0 <- getRootBranch0
   pure (BranchUtil.getType (Path.convert path) rootBranch0)
@@ -409,44 +409,44 @@ defaultPatchPath =
   (Path.RelativePath' (Path.Relative Path.empty), defaultPatchNameSegment)
 
 -- | Get the patch at a path, or the empty patch if there's no such patch.
-getPatchAt :: Path.Split' -> Cli r Patch
+getPatchAt :: Path.Split' -> Cli Patch
 getPatchAt path =
   getMaybePatchAt path <&> fromMaybe Patch.empty
 
 -- | Get the patch at a path.
-getMaybePatchAt :: Path.Split' -> Cli r (Maybe Patch)
+getMaybePatchAt :: Path.Split' -> Cli (Maybe Patch)
 getMaybePatchAt path0 = do
   (path, name) <- resolveSplit' path0
   branch <- getBranch0At path
   liftIO (Branch.getMaybePatch name branch)
 
 -- | Get the patch at a path, or return early if there's no such patch.
-expectPatchAt :: Path.Split' -> Cli r Patch
+expectPatchAt :: Path.Split' -> Cli Patch
 expectPatchAt path =
   getMaybePatchAt path & onNothingM (Cli.returnEarly (Output.PatchNotFound path))
 
 -- | Assert that there's no patch at a path, or return early if there is one.
-assertNoPatchAt :: Path.Split' -> Cli r ()
+assertNoPatchAt :: Path.Split' -> Cli ()
 assertNoPatchAt path = do
   whenJustM (getMaybePatchAt path) \_ -> Cli.returnEarly (Output.PatchAlreadyExists path)
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Latest (typechecked) unison file utils
 
-getLatestFile :: Cli r (Maybe (FilePath, Bool))
+getLatestFile :: Cli (Maybe (FilePath, Bool))
 getLatestFile = do
   use #latestFile
 
-expectLatestFile :: Cli r (FilePath, Bool)
+expectLatestFile :: Cli (FilePath, Bool)
 expectLatestFile = do
   getLatestFile & onNothingM (Cli.returnEarly Output.NoUnisonFile)
 
 -- | Get the latest typechecked unison file.
-getLatestTypecheckedFile :: Cli r (Maybe (TypecheckedUnisonFile Symbol Ann))
+getLatestTypecheckedFile :: Cli (Maybe (TypecheckedUnisonFile Symbol Ann))
 getLatestTypecheckedFile = do
   use #latestTypecheckedFile
 
 -- | Get the latest typechecked unison file, or return early if there isn't one.
-expectLatestTypecheckedFile :: Cli r (TypecheckedUnisonFile Symbol Ann)
+expectLatestTypecheckedFile :: Cli (TypecheckedUnisonFile Symbol Ann)
 expectLatestTypecheckedFile =
   getLatestTypecheckedFile & onNothingM (Cli.returnEarly Output.NoUnisonFile)

--- a/unison-cli/src/Unison/Cli/NamesUtils.hs
+++ b/unison-cli/src/Unison/Cli/NamesUtils.hs
@@ -33,15 +33,15 @@ import qualified Unison.UnisonFile as UF
 import qualified Unison.UnisonFile.Names as UF
 import Unison.Var (Var)
 
-basicParseNames :: Cli r Names
+basicParseNames :: Cli Names
 basicParseNames =
   fst <$> basicNames' Backend.Within
 
-basicPrettyPrintNamesA :: Cli r Names
+basicPrettyPrintNamesA :: Cli Names
 basicPrettyPrintNamesA = snd <$> basicNames' Backend.AllNames
 
 -- implementation detail of basicParseNames and basicPrettyPrintNames
-basicNames' :: (Path -> Backend.NameScoping) -> Cli r (Names, Names)
+basicNames' :: (Path -> Backend.NameScoping) -> Cli (Names, Names)
 basicNames' nameScoping = do
   root' <- Cli.getRootBranch
   currentPath' <- Cli.getCurrentPath
@@ -52,7 +52,7 @@ basicNames' nameScoping = do
 displayNames ::
   Var v =>
   TypecheckedUnisonFile v a ->
-  Cli r NamesWithHistory
+  Cli NamesWithHistory
 displayNames unisonFile =
   -- voodoo
   makeShadowedPrintNamesFromLabeled
@@ -61,7 +61,7 @@ displayNames unisonFile =
 
 -- discards inputs that aren't hashqualified;
 -- I'd enforce it with finer-grained types if we had them.
-findHistoricalHQs :: Set (HQ.HashQualified Name) -> Cli r Names
+findHistoricalHQs :: Set (HQ.HashQualified Name) -> Cli Names
 findHistoricalHQs lexedHQs0 = do
   root' <- Cli.getRootBranch
   curPath <- Cli.getCurrentPath
@@ -101,13 +101,13 @@ fixupNamesRelative currentPath' = Names.map fixName
           prefix <- Path.toName (Path.unabsolute currentPath')
           Name.stripNamePrefix prefix n
 
-getBasicPrettyPrintNames :: Cli r Names
+getBasicPrettyPrintNames :: Cli Names
 getBasicPrettyPrintNames = do
   rootBranch <- Cli.getRootBranch
   currentPath <- Cli.getCurrentPath
   pure (Backend.prettyNamesForBranch rootBranch (Backend.AllNames (Path.unabsolute currentPath)))
 
-makeHistoricalParsingNames :: Set (HQ.HashQualified Name) -> Cli r NamesWithHistory
+makeHistoricalParsingNames :: Set (HQ.HashQualified Name) -> Cli NamesWithHistory
 makeHistoricalParsingNames lexedHQs = do
   currentPath <- Cli.getCurrentPath
 
@@ -120,7 +120,7 @@ makeHistoricalParsingNames lexedHQs = do
           <> fixupNamesRelative currentPath rawHistoricalNames
       )
 
-makePrintNamesFromLabeled' :: Set LabeledDependency -> Cli r NamesWithHistory
+makePrintNamesFromLabeled' :: Set LabeledDependency -> Cli NamesWithHistory
 makePrintNamesFromLabeled' deps = do
   root' <- Cli.getRootBranch
   curPath <- Cli.getCurrentPath
@@ -132,7 +132,7 @@ makePrintNamesFromLabeled' deps = do
   basicNames <- basicPrettyPrintNamesA
   pure $ NamesWithHistory basicNames (fixupNamesRelative curPath rawHistoricalNames)
 
-makeShadowedPrintNamesFromHQ :: Set (HQ.HashQualified Name) -> Names -> Cli r NamesWithHistory
+makeShadowedPrintNamesFromHQ :: Set (HQ.HashQualified Name) -> Names -> Cli NamesWithHistory
 makeShadowedPrintNamesFromHQ lexedHQs shadowing = do
   rawHistoricalNames <- findHistoricalHQs lexedHQs
   basicNames <- basicPrettyPrintNamesA
@@ -144,6 +144,6 @@ makeShadowedPrintNamesFromHQ lexedHQs shadowing = do
       shadowing
       (NamesWithHistory basicNames (fixupNamesRelative currentPath rawHistoricalNames))
 
-makeShadowedPrintNamesFromLabeled :: Set LabeledDependency -> Names -> Cli r NamesWithHistory
+makeShadowedPrintNamesFromLabeled :: Set LabeledDependency -> Names -> Cli NamesWithHistory
 makeShadowedPrintNamesFromLabeled deps shadowing =
   NamesWithHistory.shadowing shadowing <$> makePrintNamesFromLabeled' deps

--- a/unison-cli/src/Unison/Cli/PrettyPrintUtils.hs
+++ b/unison-cli/src/Unison/Cli/PrettyPrintUtils.hs
@@ -20,13 +20,13 @@ import qualified Unison.PrettyPrintEnvDecl as PPE hiding (biasTo)
 import qualified Unison.PrettyPrintEnvDecl.Names as PPE
 import qualified Unison.Server.Backend as Backend
 
-prettyPrintEnvDecl :: NamesWithHistory -> Cli r PPE.PrettyPrintEnvDecl
+prettyPrintEnvDecl :: NamesWithHistory -> Cli PPE.PrettyPrintEnvDecl
 prettyPrintEnvDecl ns = do
   Cli.Env {codebase} <- ask
   liftIO (Codebase.hashLength codebase) <&> (`PPE.fromNamesDecl` ns)
 
 -- | Get a pretty print env decl for the current names at the current path.
-currentPrettyPrintEnvDecl :: (Path -> Backend.NameScoping) -> Cli r PPE.PrettyPrintEnvDecl
+currentPrettyPrintEnvDecl :: (Path -> Backend.NameScoping) -> Cli PPE.PrettyPrintEnvDecl
 currentPrettyPrintEnvDecl scoping = do
   Cli.Env {codebase} <- ask
   root' <- Cli.getRootBranch

--- a/unison-cli/src/Unison/Cli/TypeCheck.hs
+++ b/unison-cli/src/Unison/Cli/TypeCheck.hs
@@ -30,7 +30,6 @@ typecheck ::
   Text ->
   (Text, [L.Token L.Lexeme]) ->
   Cli
-    r
     ( Result.Result
         (Seq (Result.Note Symbol Ann))
         (Either (UF.UnisonFile Symbol Ann) (UF.TypecheckedUnisonFile Symbol Ann))
@@ -74,7 +73,6 @@ typecheckFile ::
   [Type Symbol Ann] ->
   UF.UnisonFile Symbol Ann ->
   Cli
-    r
     ( Result.Result
         (Seq (Result.Note Symbol Ann))
         (Either Names (UF.TypecheckedUnisonFile Symbol Ann))

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/AuthLogin.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/AuthLogin.hs
@@ -46,7 +46,7 @@ ucmOAuthClientID = "ucm"
 
 -- | Checks if the user has valid auth for the given codeserver,
 -- and runs through an authentication flow if not.
-ensureAuthenticatedWithCodeserver :: CodeserverURI -> Cli r ()
+ensureAuthenticatedWithCodeserver :: CodeserverURI -> Cli ()
 ensureAuthenticatedWithCodeserver codeserverURI = do
   Cli.Env {credentialManager} <- ask
   getCredentials credentialManager (codeserverIdFromCodeserverURI codeserverURI) >>= \case
@@ -55,7 +55,7 @@ ensureAuthenticatedWithCodeserver codeserverURI = do
 
 -- | Direct the user through an authentication flow with the given server and store the credentials in the provided
 -- credential manager.
-authLogin :: CodeserverURI -> Cli r ()
+authLogin :: CodeserverURI -> Cli ()
 authLogin host = do
   Cli.Env {credentialManager} <- ask
   httpClient <- liftIO HTTP.getGlobalManager

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/MetadataUtils.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/MetadataUtils.hs
@@ -40,7 +40,7 @@ import qualified Unison.Util.Set as Set
 -- Add default metadata to all added types and terms in a slurp component.
 --
 -- No-op if the slurp component is empty.
-addDefaultMetadata :: SlurpComponent Symbol -> Cli r ()
+addDefaultMetadata :: SlurpComponent Symbol -> Cli ()
 addDefaultMetadata adds =
   when (not (SC.isEmpty adds)) do
     Cli.time "add-default-metadata" do
@@ -84,7 +84,7 @@ manageLinks ::
     Branch.Star r NameSegment ->
     Branch.Star r NameSegment
   ) ->
-  Cli r ()
+  Cli ()
 manageLinks silent srcs' metadataNames op = do
   metadatas <- traverse resolveMetadata metadataNames
   before <- Cli.getRootBranch0
@@ -120,7 +120,7 @@ manageLinks silent srcs' metadataNames op = do
               diff
 
 -- | Resolve a metadata name to its type/value, or return early if no such metadata is found.
-resolveMetadata :: HQ.HashQualified Name -> Cli r (Either Output (Metadata.Type, Metadata.Value))
+resolveMetadata :: HQ.HashQualified Name -> Cli (Either Output (Metadata.Type, Metadata.Value))
 resolveMetadata name = do
   Cli.Env {codebase} <- ask
   root' <- Cli.getRootBranch
@@ -142,7 +142,7 @@ resolveMetadata name = do
     Nothing ->
       pure (Left (MetadataMissingType ppe (Referent.Ref ref)))
 
-resolveDefaultMetadata :: Path.Absolute -> Cli r [String]
+resolveDefaultMetadata :: Path.Absolute -> Cli [String]
 resolveDefaultMetadata path = do
   let superpaths = Path.ancestors path
   xs <-
@@ -155,7 +155,7 @@ resolveDefaultMetadata path = do
   pure . join $ toList xs
 
 -- | Get the set of terms related to a hash-qualified name.
-getHQTerms :: HQ.HashQualified Name -> Cli r (Set Referent)
+getHQTerms :: HQ.HashQualified Name -> Cli (Set Referent)
 getHQTerms = \case
   HQ.NameOnly n -> do
     root0 <- Cli.getRootBranch0

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveBranch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveBranch.hs
@@ -10,7 +10,7 @@ import Unison.Prelude
 
 -- | Moves a branch and its history from one location to another, and saves the new root
 -- branch.
-doMoveBranch :: forall r. Text -> Bool -> Path.Path' -> Path.Path' -> Cli r ()
+doMoveBranch :: Text -> Bool -> Path.Path' -> Path.Path' -> Cli ()
 doMoveBranch actionDescription hasConfirmed src' dest' = do
   srcAbs <- Cli.resolvePath' src'
   destAbs <- Cli.resolvePath' dest'

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/NamespaceDependencies.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/NamespaceDependencies.hs
@@ -37,7 +37,7 @@ import qualified Unison.Util.Relation4 as Relation4
 --
 -- Returns a Set of names rather than using the PPE since we already have the correct names in
 -- scope on this branch, and also want to list ALL names of dependents, including aliases.
-namespaceDependencies :: forall m r. Branch0 m -> Cli r (Map LabeledDependency (Set Name))
+namespaceDependencies :: Branch0 m -> Cli (Map LabeledDependency (Set Name))
 namespaceDependencies branch = do
   Env {codebase} <- ask
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/NamespaceDiffUtils.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/NamespaceDiffUtils.hs
@@ -32,7 +32,7 @@ import Unison.Symbol (Symbol)
 diffHelper ::
   Branch0 IO ->
   Branch0 IO ->
-  Cli r (PPE.PrettyPrintEnv, OBranchDiff.BranchDiffOutput Symbol Ann)
+  Cli (PPE.PrettyPrintEnv, OBranchDiff.BranchDiffOutput Symbol Ann)
 diffHelper before after =
   Cli.time "diffHelper" do
     Cli.Env {codebase} <- ask

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update.hs
@@ -75,7 +75,7 @@ import Unison.WatchKind (WatchKind)
 import qualified Unison.WatchKind as WK
 
 -- | Handle an @update@ command.
-handleUpdate :: Input -> OptionalPatch -> Set Name -> Cli r ()
+handleUpdate :: Input -> OptionalPatch -> Set Name -> Cli ()
 handleUpdate input optionalPatch requestedNames = do
   Cli.Env {codebase} <- ask
   currentPath' <- Cli.getCurrentPath
@@ -202,7 +202,7 @@ handleUpdate input optionalPatch requestedNames = do
         & Path.resolve @_ @_ @Path.Absolute currentPath'
         & tShow
 
-getSlurpResultForUpdate :: Set Name -> Names -> Cli r (SlurpResult Symbol)
+getSlurpResultForUpdate :: Set Name -> Names -> Cli (SlurpResult Symbol)
 getSlurpResultForUpdate requestedNames slurpCheckNames = do
   let slurp :: TypecheckedUnisonFile Symbol Ann -> SlurpResult Symbol
       slurp file =
@@ -594,10 +594,7 @@ doSlurpUpdates typeEdits termEdits deprecated b0 =
         oldMd = BranchUtil.getTermMetadataAt split (Referent.Ref old) b0
 
 -- Returns True if the operation changed the namespace, False otherwise.
-propagatePatchNoSync ::
-  Patch ->
-  Path.Absolute ->
-  Cli r Bool
+propagatePatchNoSync :: Patch -> Path.Absolute -> Cli Bool
 propagatePatchNoSync patch scopePath =
   Cli.time "propagatePatchNoSync" do
     Cli.stepAtNoSync' (Path.unabsolute scopePath, Propagate.propagateAndApply patch)

--- a/unison-cli/tests/Main.hs
+++ b/unison-cli/tests/Main.hs
@@ -5,6 +5,7 @@ import System.Environment (getArgs)
 import System.IO
 import System.IO.CodePage (withCP65001)
 import qualified Unison.Test.ClearCache as ClearCache
+import qualified Unison.Test.Cli.Monad as Cli.Monad
 import qualified Unison.Test.GitSync as GitSync
 import qualified Unison.Test.UriParser as UriParser
 import qualified Unison.Test.VersionParser as VersionParser
@@ -13,6 +14,7 @@ test :: Test ()
 test =
   tests
     [ ClearCache.test,
+      Cli.Monad.test,
       GitSync.test,
       UriParser.test,
       VersionParser.test

--- a/unison-cli/tests/Unison/Test/Cli/Monad.hs
+++ b/unison-cli/tests/Unison/Test/Cli/Monad.hs
@@ -1,0 +1,43 @@
+module Unison.Test.Cli.Monad
+  ( test,
+  )
+where
+
+import Control.Lens
+import EasyTest
+import qualified Unison.Cli.Monad as Cli
+
+test :: Test ()
+test =
+  (scope "Unison.Cli.Monad" . tests)
+    [ scope "label" do
+        (r, state) <-
+          io do
+            Cli.runCli dummyEnv dummyLoopState do
+              Cli.label \goto -> do
+                Cli.label \_ -> do
+                  #numberedArgs .= ["foo"]
+                  goto (1 :: Int)
+                  pure 2
+        -- test that 'goto' short-circuits, as expected
+        expectEqual' (Cli.Success 1) r
+        -- test that calling 'goto' doesn't lose state changes made along the way
+        expectEqual' ["foo"] (state ^. #numberedArgs)
+        ok
+    ]
+
+dummyEnv :: Cli.Env
+dummyEnv = undefined
+
+dummyLoopState :: Cli.LoopState
+dummyLoopState =
+  Cli.LoopState
+    { currentPathStack = undefined,
+      lastInput = Nothing,
+      lastRunResult = Nothing,
+      lastSavedRootHash = undefined,
+      latestFile = Nothing,
+      latestTypecheckedFile = Nothing,
+      numberedArgs = [],
+      root = undefined
+    }

--- a/unison-cli/tests/Unison/Test/Cli/Monad.hs
+++ b/unison-cli/tests/Unison/Test/Cli/Monad.hs
@@ -18,7 +18,7 @@ test =
                 Cli.label \_ -> do
                   #numberedArgs .= ["foo"]
                   goto (1 :: Int)
-                  pure 2
+                pure 2
         -- test that 'goto' short-circuits, as expected
         expectEqual' (Cli.Success 1) r
         -- test that calling 'goto' doesn't lose state changes made along the way

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -564,6 +564,7 @@ test-suite cli-tests
   main-is: Main.hs
   other-modules:
       Unison.Test.ClearCache
+      Unison.Test.Cli.Monad
       Unison.Test.GitSync
       Unison.Test.Ucm
       Unison.Test.UriParser


### PR DESCRIPTION
## Overview

This PR reworks the `label` machinery that powers scoped short-circuiting to use exceptions under the hood, rather than a tricky `Label` type class.

The primary motivation was to fix a type inference issue with the current design that made it impossible to call a "goto" function that was passed down into a helper:

```haskell
label \goto ->
  helper goto
```

@tstat and I looked into this and determined that removing the `{-# OVERLAPS #-}` pragma on the base `Label` instance, and adding an `{-# INCOHERENT #-}` pragma instead (to either) would have solved the issue:

```haskell
-- trunk
instance {-# OVERLAPS #-} Label (R a b) (R a b)
instance Label a b => Label a (R b c)

-- one solution
instance Label (R a b) (R a b)
instance {-# INCOHERENT #-} Label a b => Label a (R b c)
```

However, we think there are a couple issues with that design:

First, the types involved aren't great. Look at the type of such a helper:

```haskell
helper :: 
  forall x xx. 
  Label (R x Int) xx => 
  (forall yy void. Label (R x Int) yy => Int -> Cli yy void) -> Cli xx Int
```

Basically, the author of such a helper function has to carefully provide the correct given-dictionary (`Label (R x Int) xx`), and scope the type variables in some order (`forall x xx` or `forall xx x`) for the caller to guide inference.

Second, the call site must also use a type application, as the correct `x` to use in `Label (R x Int) xx` cannot be inferred:

```haskell
label \goto ->
  helper @x goto
```

All in all, it seems like too much trickery and typery. The actual feature that this machinery supports is a scoped short-circuit, which can be implemented with exceptions. So, that's what this PR does.

Whenever `label` is called, we generate a unique thing (using `Data.Unique.newUnique`); the "goto" callback provided to the caller of `label` simply puts this unique thing into an unexported exception type and throws the exception. The implementation of `label` catches such exceptions.

Overall, this design lets us eliminate the `r` type variable from `Cli` (yay), the `R` type, and the `Label` type class. It's simpler to write helpers, since there are no more `Label` dictionaries:

```haskell
helper :: (forall void. Int -> Cli void) -> Cli Int
```

```haskell
label \goto ->
  helper goto -- no more @x necessary
```