### PR TITLE
Fixed the code of fromBase64UrlEncoded builtin

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -528,7 +528,7 @@ builtinsSrc =
     B "Bytes.fromBase16" $ bytes --> eithert text bytes,
     B "Bytes.fromBase32" $ bytes --> eithert text bytes,
     B "Bytes.fromBase64" $ bytes --> eithert text bytes,
-    B "Bytes.fromBase64UrlUnpadded" $ bytes --> eithert text bytes,
+    B "Bytes.fromBase64UrlUnpadded.v2" $ bytes --> eithert text bytes,
     D "List.empty" $ forall1 "a" list,
     B "List.cons" $ forall1 "a" (\a -> a --> list a --> list a),
     Alias "List.cons" "List.+:",

--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -528,7 +528,7 @@ builtinsSrc =
     B "Bytes.fromBase16" $ bytes --> eithert text bytes,
     B "Bytes.fromBase32" $ bytes --> eithert text bytes,
     B "Bytes.fromBase64" $ bytes --> eithert text bytes,
-    B "Bytes.fromBase64UrlUnpadded.v2" $ bytes --> eithert text bytes,
+    B "Bytes.fromBase64UrlUnpadded" $ bytes --> eithert text bytes,
     D "List.empty" $ forall1 "a" list,
     B "List.cons" $ forall1 "a" (\a -> a --> list a --> list a),
     Alias "List.cons" "List.+:",

--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -1259,8 +1259,8 @@ outIoFailChar stack1 stack2 stack3 fail extra result =
         )
       ]
 
-failureCase
-  :: Var v => v -> v -> v -> v -> v -> (Word64, ([Mem], ANormal v))
+failureCase ::
+  Var v => v -> v -> v -> v -> v -> (Word64, ([Mem], ANormal v))
 failureCase stack1 stack2 stack3 any fail =
   (0,) . ([BX, BX, BX],)
     . TAbss [stack1, stack2, stack3]
@@ -1268,8 +1268,8 @@ failureCase stack1 stack2 stack3 any fail =
     . TLetD fail BX (TCon Ty.failureRef 0 [stack1, stack2, any])
     $ left fail
 
-exnCase
-  :: Var v => v -> v -> v -> v -> v -> (Word64, ([Mem], ANormal v))
+exnCase ::
+  Var v => v -> v -> v -> v -> v -> (Word64, ([Mem], ANormal v))
 exnCase stack1 stack2 stack3 any fail =
   (0,) . ([BX, BX, BX],)
     . TAbss [stack1, stack2, stack3]
@@ -1277,8 +1277,8 @@ exnCase stack1 stack2 stack3 any fail =
     . TLetD fail BX (TCon Ty.failureRef 0 [stack1, stack2, any])
     $ TReq Ty.exceptionRef 0 [fail]
 
-outIoExnNat
-  :: forall v. Var v => v -> v -> v -> v -> v -> v -> ANormal v
+outIoExnNat ::
+  forall v. Var v => v -> v -> v -> v -> v -> v -> ANormal v
 outIoExnNat stack1 stack2 stack3 any fail result =
   TMatch result . MatchSum $
     mapFromList
@@ -1290,8 +1290,8 @@ outIoExnNat stack1 stack2 stack3 any fail result =
         )
       ]
 
-outIoExnUnit
-  :: forall v. Var v => v -> v -> v -> v -> v -> v -> ANormal v
+outIoExnUnit ::
+  forall v. Var v => v -> v -> v -> v -> v -> v -> ANormal v
 outIoExnUnit stack1 stack2 stack3 any fail result =
   TMatch result . MatchSum $
     mapFromList
@@ -1299,8 +1299,8 @@ outIoExnUnit stack1 stack2 stack3 any fail result =
         (1, ([], TCon Ty.unitRef 0 []))
       ]
 
-outIoExnBox
-  :: Var v => v -> v -> v -> v -> v -> v -> ANormal v
+outIoExnBox ::
+  Var v => v -> v -> v -> v -> v -> v -> ANormal v
 outIoExnBox stack1 stack2 stack3 any fail result =
   TMatch result . MatchSum $
     mapFromList
@@ -1970,7 +1970,7 @@ declareForeign sand name op func0 = do
           | sanitize,
             Tracked <- sand,
             FF r w _ <- func0 =
-              FF r w (bomb name)
+            FF r w (bomb name)
           | otherwise = func0
         code = (name, (sand, uncurry Lambda (op w)))
      in (w + 1, code : codes, mapInsert w (name, func) funcs)
@@ -2489,7 +2489,7 @@ declareForeigns = do
     pure . mapLeft Util.Text.fromText . Bytes.fromBase32
   declareForeign Untracked "Bytes.fromBase64" boxToEBoxBox . mkForeign $
     pure . mapLeft Util.Text.fromText . Bytes.fromBase64
-  declareForeign Untracked "Bytes.fromBase64UrlUnpadded" boxDirect . mkForeign $
+  declareForeign Untracked "Bytes.fromBase64UrlUnpadded.v2" boxToEBoxBox . mkForeign $
     pure . mapLeft Util.Text.fromText . Bytes.fromBase64UrlUnpadded
 
   declareForeign Untracked "Bytes.decodeNat64be" boxToMaybeNTup . mkForeign $ pure . Bytes.decodeNat64be

--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -2489,7 +2489,7 @@ declareForeigns = do
     pure . mapLeft Util.Text.fromText . Bytes.fromBase32
   declareForeign Untracked "Bytes.fromBase64" boxToEBoxBox . mkForeign $
     pure . mapLeft Util.Text.fromText . Bytes.fromBase64
-  declareForeign Untracked "Bytes.fromBase64UrlUnpadded.v2" boxToEBoxBox . mkForeign $
+  declareForeign Untracked "Bytes.fromBase64UrlUnpadded" boxToEBoxBox . mkForeign $
     pure . mapLeft Util.Text.fromText . Bytes.fromBase64UrlUnpadded
 
   declareForeign Untracked "Bytes.decodeNat64be" boxToMaybeNTup . mkForeign $ pure . Bytes.decodeNat64be

--- a/unison-src/transcripts-using-base/base.u
+++ b/unison-src/transcripts-using-base/base.u
@@ -18,6 +18,26 @@ Exception.reraise = cases
   Left e  -> Exception.raise e
   Right a -> a
 
+Either.isLeft = cases
+  Left _ -> true
+  Right _ -> false
+
+Exception.catch : '{g, Exception} a ->{g} Either Failure a
+Exception.catch ex =
+    handle !ex
+    with
+      cases
+        { a }                    -> Right a
+        {Exception.raise f -> _} -> Left f
+
+Either.raiseMessage v e = reraise (Either.mapLeft (msg -> failure msg v) e)
+
+Either.mapLeft f = cases
+  Left l  -> Left (f l)
+  Right r -> Right r
+
+Exception.failure msg a = Failure (typeLink Unit) msg (Any a)
+
 Exception.toEither.handler : Request {Exception} a -> Either Failure a
 Exception.toEither.handler = cases
   { a }                         -> Right a
@@ -390,3 +410,4 @@ saveTestCase name f i =
   saveSelfContained (f, i) sfile
   writeFile ofile (toUtf8 output)
   writeFile hfile (Bytes.toBase32 (crypto.hash Sha3_512 (f, i)))
+

--- a/unison-src/transcripts/builtins.md
+++ b/unison-src/transcripts/builtins.md
@@ -261,10 +261,6 @@ test> Bytes.tests.compression =
           (Bytes.zlib.decompress (Bytes.zlib.compress b) == Right b)
             && (Bytes.gzip.decompress (Bytes.gzip.compress b) == Right b)
 
-        isLeft = cases
-          Left _ -> true
-          Right _ -> false
-
         checks [
           roundTrip 0xs2093487509823745709827345789023457892345,
           roundTrip 0xs00000000000000000000000000000000000000000000,
@@ -276,6 +272,13 @@ test> Bytes.tests.compression =
           isLeft (zlib.decompress 0xs2093487509823745709827345789023457892345),
           isLeft (gzip.decompress 0xs201209348750982374593939393939709827345789023457892345)
         ]
+
+test> Bytes.tests.fromBase64UrlUnpadded = 
+  checks [Exception.catch
+           '(fromUtf8
+              (raiseMessage () (Bytes.fromBase64UrlUnpadded (toUtf8 "aGVsbG8gd29ybGQ")))) == Right "hello world"
+         , isLeft (Bytes.fromBase64UrlUnpadded (toUtf8 "aGVsbG8gd29ybGQ="))]
+  
 ```
 
 ```ucm:hide

--- a/unison-src/transcripts/builtins.output.md
+++ b/unison-src/transcripts/builtins.output.md
@@ -238,10 +238,6 @@ test> Bytes.tests.compression =
           (Bytes.zlib.decompress (Bytes.zlib.compress b) == Right b)
             && (Bytes.gzip.decompress (Bytes.gzip.compress b) == Right b)
 
-        isLeft = cases
-          Left _ -> true
-          Right _ -> false
-
         checks [
           roundTrip 0xs2093487509823745709827345789023457892345,
           roundTrip 0xs00000000000000000000000000000000000000000000,
@@ -253,6 +249,13 @@ test> Bytes.tests.compression =
           isLeft (zlib.decompress 0xs2093487509823745709827345789023457892345),
           isLeft (gzip.decompress 0xs201209348750982374593939393939709827345789023457892345)
         ]
+
+test> Bytes.tests.fromBase64UrlUnpadded = 
+  checks [Exception.catch
+           '(fromUtf8
+              (raiseMessage () (Bytes.fromBase64UrlUnpadded (toUtf8 "aGVsbG8gd29ybGQ")))) == Right "hello world"
+         , isLeft (Bytes.fromBase64UrlUnpadded (toUtf8 "aGVsbG8gd29ybGQ="))]
+  
 ```
 
 ## `Any` functions
@@ -349,29 +352,30 @@ Now that all the tests have been added to the codebase, let's view the test repo
 
   Cached test results (`help testcache` to learn more)
   
-  ◉ Any.test1                   Passed
-  ◉ Any.test2                   Passed
-  ◉ Boolean.tests.andTable      Passed
-  ◉ Boolean.tests.notTable      Passed
-  ◉ Boolean.tests.orTable       Passed
-  ◉ Bytes.tests.at              Passed
-  ◉ Bytes.tests.compression     Passed
-  ◉ Int.tests.arithmetic        Passed
-  ◉ Int.tests.bitTwiddling      Passed
-  ◉ Int.tests.conversions       Passed
-  ◉ Nat.tests.arithmetic        Passed
-  ◉ Nat.tests.bitTwiddling      Passed
-  ◉ Nat.tests.conversions       Passed
-  ◉ Sandbox.test1               Passed
-  ◉ Sandbox.test2               Passed
-  ◉ Sandbox.test3               Passed
-  ◉ Text.tests.alignment        Passed
-  ◉ Text.tests.literalsEq       Passed
-  ◉ Text.tests.patterns         Passed
-  ◉ Text.tests.repeat           Passed
-  ◉ Text.tests.takeDropAppend   Passed
+  ◉ Any.test1                           Passed
+  ◉ Any.test2                           Passed
+  ◉ Boolean.tests.andTable              Passed
+  ◉ Boolean.tests.notTable              Passed
+  ◉ Boolean.tests.orTable               Passed
+  ◉ Bytes.tests.at                      Passed
+  ◉ Bytes.tests.compression             Passed
+  ◉ Bytes.tests.fromBase64UrlUnpadded   Passed
+  ◉ Int.tests.arithmetic                Passed
+  ◉ Int.tests.bitTwiddling              Passed
+  ◉ Int.tests.conversions               Passed
+  ◉ Nat.tests.arithmetic                Passed
+  ◉ Nat.tests.bitTwiddling              Passed
+  ◉ Nat.tests.conversions               Passed
+  ◉ Sandbox.test1                       Passed
+  ◉ Sandbox.test2                       Passed
+  ◉ Sandbox.test3                       Passed
+  ◉ Text.tests.alignment                Passed
+  ◉ Text.tests.literalsEq               Passed
+  ◉ Text.tests.patterns                 Passed
+  ◉ Text.tests.repeat                   Passed
+  ◉ Text.tests.takeDropAppend           Passed
   
-  ✅ 21 test(s) passing
+  ✅ 22 test(s) passing
   
   Tip: Use view Any.test1 to view the source of a test.
 


### PR DESCRIPTION
This fixes #3494. The type was correct, but the implementation was forgetting to wrap the result in `Left` or `Right`.