### PR TITLE
Add Unison.Util.Map.upsert

### DIFF
--- a/lib/unison-prelude/src/Unison/Util/Map.hs
+++ b/lib/unison-prelude/src/Unison/Util/Map.hs
@@ -10,6 +10,7 @@ module Unison.Util.Map
     traverseKeys,
     traverseKeysWith,
     swap,
+    upsert,
     valuesVector,
   )
 where
@@ -38,6 +39,11 @@ bitraversed keyT valT f m =
 swap :: Ord b => Map a b -> Map b a
 swap =
   Map.foldlWithKey' (\z a b -> Map.insert b a z) mempty
+
+-- | Upsert an element into a map.
+upsert :: Ord k => (Maybe v -> v) -> k -> Map k v -> Map k v
+upsert f =
+  Map.alter (Just . f)
 
 valuesVector :: Map k v -> Vector v
 valuesVector =


### PR DESCRIPTION
## Overview

This PR adds `upsert`, a missing insert-like combinator to `Unison.Util.Map`:

```haskell
-- Data.Map
adjust :: Ord k => k -> (v       -> v)       -> Map k v -> Map k v
update :: Ord k => k -> (v       -> Maybe v) -> Map k v -> Map k v
alter  :: Ord k => k -> (Maybe v -> Maybe v) -> Map k v -> Map k v

-- Unison.Util.Map
upsert :: Ord k => k -> (Maybe v -> v)       -> Map k v -> Map k v
```

It's `Map.insertWith`, but less awkward to use (imo).