### PR TITLE
Fix pretty-printing of empty docs

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/IOSource.hs
+++ b/parser-typechecker/src/Unison/Runtime/IOSource.hs
@@ -331,7 +331,7 @@ prettyAppendId = constructorNamed prettyAnnotatedRef "Pretty.Annotated.Append"
 
 prettyTableId = constructorNamed prettyAnnotatedRef "Pretty.Annotated.Table"
 
-pattern PrettyEmpty ann <- Term.App' (Term.Constructor' (ConstructorReference PrettyAnnotatedRef ((==) prettyEmptyId -> True))) ann
+pattern PrettyEmpty <- Term.Constructor' (ConstructorReference PrettyAnnotatedRef ((==) prettyEmptyId -> True))
 
 pattern PrettyGroup ann tm <- Term.Apps' (Term.Constructor' (ConstructorReference PrettyAnnotatedRef ((==) prettyGroupId -> True))) [ann, tm]
 

--- a/unison-cli/src/Unison/CommandLine/DisplayValues.hs
+++ b/unison-cli/src/Unison/CommandLine/DisplayValues.hs
@@ -76,16 +76,18 @@ displayTerm' elideUnit pped terms typeOf eval types = \case
   tm@(Term.Apps' (Term.Constructor' (ConstructorReference typ _)) _)
     | typ == DD.docRef -> displayDoc pped terms typeOf eval types tm
     | typ == DD.doc2Ref -> do
-        -- Pretty.get (doc.formatConsole tm)
-        let tm' =
-              Term.app
-                ()
-                (Term.ref () DD.prettyGetRef)
-                (Term.app () (Term.ref () DD.doc2FormatConsoleRef) tm)
-        tm <- eval tm'
-        case tm of
-          Nothing -> pure $ errMsg tm'
-          Just tm -> displayTerm pped terms typeOf eval types tm
+      -- Pretty.get (doc.formatConsole tm)
+      let tm' =
+            Term.app
+              ()
+              (Term.ref () DD.prettyGetRef)
+              (Term.app () (Term.ref () DD.doc2FormatConsoleRef) tm)
+      tm <- eval tm'
+      case tm of
+        Nothing -> pure $ errMsg tm'
+        Just tm -> displayTerm pped terms typeOf eval types tm
+    | typ == DD.prettyAnnotatedRef -> displayPretty pped terms typeOf eval types tm
+  tm@(Term.Constructor' (ConstructorReference typ _))
     | typ == DD.prettyAnnotatedRef -> displayPretty pped terms typeOf eval types tm
   tm -> pure $ src tm
   where
@@ -120,7 +122,7 @@ displayPretty ::
 displayPretty pped terms typeOf eval types tm = go tm
   where
     go = \case
-      DD.PrettyEmpty _ -> pure mempty
+      DD.PrettyEmpty -> pure mempty
       DD.PrettyGroup _ p -> P.group <$> go p
       DD.PrettyLit _ (DD.EitherLeft' special) -> goSpecial special
       DD.PrettyLit _ (DD.EitherRight' consoleTxt) -> goConsole consoleTxt


### PR DESCRIPTION
Fixes #3506.

The case for the `Annotated.Empty` constructor was simply missing from `displayTerm'`, as it's not an `Apps'` but just a `Constructor'`. Consequently it was falling through to the regular term pretty-printer.

Further, the `displayPretty` function was using an `App` pattern as well, which is incorrect, as the `Empty` constructor takes no arguments. So if it had been making it into `displayPretty`, this would cause an infinite loop.