### PR TITLE
Pull out unison-util-bytes into its own package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -157,6 +157,8 @@ jobs:
         run: stack --no-terminal build --fast --test unison-cli
       - name: unison-parser-typechecker tests
         run: stack --no-terminal build --fast --test unison-parser-typechecker
+      - name: unison-util-bytes tests
+        run: stack --no-terminal build --fast --test unison-util-bytes
       - name: unison-util-relation tests
         run: stack --no-terminal build --fast --test unison-util-relation
       - name: transcripts

--- a/hie.yaml
+++ b/hie.yaml
@@ -51,6 +51,12 @@ cradle:
     - path: "lib/unison-util-base32hex-orphans-sqlite/src"
       component: "unison-util-base32hex-orphans-sqlite:lib"
 
+    - path: "lib/unison-util-bytes/src"
+      component: "unison-util-bytes:lib"
+
+    - path: "lib/unison-util-bytes/test"
+      component: "unison-util-bytes:test:util-bytes-tests"
+
     - path: "lib/unison-util-relation/src"
       component: "unison-util-relation:lib"
 

--- a/lib/unison-util-bytes/package.yaml
+++ b/lib/unison-util-bytes/package.yaml
@@ -1,0 +1,67 @@
+name: unison-util-bytes
+github: unisonweb/unison
+copyright: Copyright (C) 2013-2022 Unison Computing, PBC and contributors
+
+ghc-options: -Wall
+
+dependencies:
+  - base
+  - basement
+  - bytestring
+  - bytestring-to-vector
+  - deepseq
+  - memory
+  - primitive
+  - text
+  - vector
+  - unison-prelude
+  - unison-util-rope
+  - zlib
+
+library:
+  source-dirs: src
+  when:
+    - condition: false
+      other-modules: Paths_unison_util_bytes
+
+tests:
+  util-bytes-tests:
+    when:
+      - condition: false
+        other-modules: Paths_unison_util_bytes
+    dependencies:
+      - code-page
+      - easytest
+      - unison-util-bytes
+    main: Main.hs
+    source-dirs: test
+
+default-extensions:
+  - ApplicativeDo
+  - BangPatterns
+  - BlockArguments
+  - DeriveAnyClass
+  - DeriveFoldable
+  - DeriveFunctor
+  - DeriveGeneric
+  - DeriveTraversable
+  - DerivingStrategies
+  - DerivingVia
+  - DoAndIfThenElse
+  - DuplicateRecordFields
+  - FlexibleContexts
+  - FlexibleInstances
+  - FunctionalDependencies
+  - GeneralizedNewtypeDeriving
+  - LambdaCase
+  - MultiParamTypeClasses
+  - NamedFieldPuns
+  - OverloadedStrings
+  - PatternSynonyms
+  - RankNTypes
+  - ScopedTypeVariables
+  - StandaloneDeriving
+  - TupleSections
+  - TypeApplications
+  - TypeFamilies
+  - ViewPatterns

--- a/lib/unison-util-bytes/src/Unison/Util/Bytes.hs
+++ b/lib/unison-util-bytes/src/Unison/Util/Bytes.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
 

--- a/lib/unison-util-bytes/test/Main.hs
+++ b/lib/unison-util-bytes/test/Main.hs
@@ -1,14 +1,18 @@
-module Unison.Test.Util.Bytes where
+module Main (main) where
 
-import Control.Monad
 import qualified Data.ByteString as BS
-import Data.List (foldl')
 import EasyTest
+import System.IO.CodePage (withCP65001)
+import Unison.Prelude
 import qualified Unison.Util.Bytes as Bytes
+
+main :: IO ()
+main =
+  withCP65001 (run (scope "util.bytes" test))
 
 test :: Test ()
 test =
-  scope "util.bytes" . tests $
+  tests $
     [ scope "empty ==" . expect $ Bytes.empty == Bytes.empty,
       scope "empty `compare`" . expect $ Bytes.empty `compare` Bytes.empty == EQ,
       scope "==" . expect $

--- a/lib/unison-util-bytes/unison-util-bytes.cabal
+++ b/lib/unison-util-bytes/unison-util-bytes.cabal
@@ -1,0 +1,119 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.4.
+--
+-- see: https://github.com/sol/hpack
+
+name:           unison-util-bytes
+version:        0.0.0
+homepage:       https://github.com/unisonweb/unison#readme
+bug-reports:    https://github.com/unisonweb/unison/issues
+copyright:      Copyright (C) 2013-2022 Unison Computing, PBC and contributors
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/unisonweb/unison
+
+library
+  exposed-modules:
+      Unison.Util.Bytes
+  hs-source-dirs:
+      src
+  default-extensions:
+      ApplicativeDo
+      BangPatterns
+      BlockArguments
+      DeriveAnyClass
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveTraversable
+      DerivingStrategies
+      DerivingVia
+      DoAndIfThenElse
+      DuplicateRecordFields
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MultiParamTypeClasses
+      NamedFieldPuns
+      OverloadedStrings
+      PatternSynonyms
+      RankNTypes
+      ScopedTypeVariables
+      StandaloneDeriving
+      TupleSections
+      TypeApplications
+      TypeFamilies
+      ViewPatterns
+  ghc-options: -Wall
+  build-depends:
+      base
+    , basement
+    , bytestring
+    , bytestring-to-vector
+    , deepseq
+    , memory
+    , primitive
+    , text
+    , unison-prelude
+    , unison-util-rope
+    , vector
+    , zlib
+  default-language: Haskell2010
+
+test-suite util-bytes-tests
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  hs-source-dirs:
+      test
+  default-extensions:
+      ApplicativeDo
+      BangPatterns
+      BlockArguments
+      DeriveAnyClass
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveTraversable
+      DerivingStrategies
+      DerivingVia
+      DoAndIfThenElse
+      DuplicateRecordFields
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MultiParamTypeClasses
+      NamedFieldPuns
+      OverloadedStrings
+      PatternSynonyms
+      RankNTypes
+      ScopedTypeVariables
+      StandaloneDeriving
+      TupleSections
+      TypeApplications
+      TypeFamilies
+      ViewPatterns
+  ghc-options: -Wall
+  build-depends:
+      base
+    , basement
+    , bytestring
+    , bytestring-to-vector
+    , code-page
+    , deepseq
+    , easytest
+    , memory
+    , primitive
+    , text
+    , unison-prelude
+    , unison-util-bytes
+    , unison-util-rope
+    , vector
+    , zlib
+  default-language: Haskell2010

--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -113,6 +113,7 @@ dependencies:
   - unison-sqlite
   - unison-util
   - unison-util-base32hex
+  - unison-util-bytes
   - unison-util-relation
   - unison-util-rope
   - unison-util-serialization

--- a/parser-typechecker/tests/Suite.hs
+++ b/parser-typechecker/tests/Suite.hs
@@ -29,7 +29,6 @@ import qualified Unison.Test.Typechecker as Typechecker
 import qualified Unison.Test.Typechecker.Context as Context
 import qualified Unison.Test.Typechecker.TypeError as TypeError
 import qualified Unison.Test.UnisonSources as UnisonSources
-import qualified Unison.Test.Util.Bytes as Bytes
 import qualified Unison.Test.Util.PinBoard as PinBoard
 import qualified Unison.Test.Util.Relation as Relation
 import qualified Unison.Test.Util.Text as Text
@@ -49,7 +48,6 @@ test =
       UnisonSources.test,
       FileParser.test,
       DataDeclaration.test,
-      Bytes.test,
       Text.test,
       Relation.test,
       Path.test,

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -138,7 +138,6 @@ library
       Unison.UnisonFile.Error
       Unison.UnisonFile.Names
       Unison.UnisonFile.Type
-      Unison.Util.Bytes
       Unison.Util.Convert
       Unison.Util.CycleTable
       Unison.Util.CyclicEq
@@ -282,6 +281,7 @@ library
     , unison-sqlite
     , unison-util
     , unison-util-base32hex
+    , unison-util-bytes
     , unison-util-relation
     , unison-util-rope
     , unison-util-serialization
@@ -328,7 +328,6 @@ test-suite parser-typechecker-tests
       Unison.Test.Typechecker.Context
       Unison.Test.Typechecker.TypeError
       Unison.Test.UnisonSources
-      Unison.Test.Util.Bytes
       Unison.Test.Util.PinBoard
       Unison.Test.Util.Pretty
       Unison.Test.Util.Relation
@@ -469,6 +468,7 @@ test-suite parser-typechecker-tests
     , unison-sqlite
     , unison-util
     , unison-util-base32hex
+    , unison-util-bytes
     , unison-util-relation
     , unison-util-rope
     , unison-util-serialization

--- a/stack.yaml
+++ b/stack.yaml
@@ -29,6 +29,7 @@ packages:
 - lib/unison-util-base32hex
 - lib/unison-util-base32hex-orphans-aeson
 - lib/unison-util-base32hex-orphans-sqlite
+- lib/unison-util-bytes
 - lib/unison-util-relation
 - lib/unison-util-rope
 - lib/unison-pretty-printer


### PR DESCRIPTION
## Overview

This PR extracts `Unison.Util.Bytes` into its own package, `unison-util-bytes`. The purpose is to continue extracting all of the surface-syntax related parsing/printing modules out of `unison-parser-typechecker`. This type is a dependency of the lexer (`Bytes` is a lexeme), so this package will be depended on by both `unison-parser-typechecker` and `unison-syntax` (see the next PR: #3521)