### PR TITLE
Ignore conflicts on namespace stats

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -2259,6 +2259,7 @@ saveNamespaceStats bhId stats = do
       [here|
         INSERT INTO namespace_statistics (namespace_hash_id, num_contained_terms, num_contained_types, num_contained_patches)
           VALUES (?, ?, ?, ?)
+          ON CONFLICT DO NOTHING
       |]
 
 -- | Looks up statistics for a given branch, there's no guarantee that we have


### PR DESCRIPTION
## Overview

I'm a bit surprised that it took this long for it to show up, but I ran into an issue with this on share recently, 

```
  |   | 2022-10-19 16:32:08 | 19/Oct/2022:22:32:08 +0000 Error  SqliteQueryException {sql = "INSERT INTO namespace_statistics (namespace_hash_id, num_contained_terms, num_contained_types, num_contained_patches)\n          VALUES (?, ?, ?, ?)", params = ":. 91 (NamespaceStats 1 0 0)", exception = SQLite3 returned ErrorConstraint while attempting to perform step: UNIQUE constraint failed: namespace_statistics.namespace_hash_id, callStack = [], connection = Connection { name = "U-1f13c72e-b554-4622-9d8e-fc5a603700a2", file = "codebases/U-1f13c72e-b554-4622-9d8e-fc5a603700a2/.unison/v2/unison.sqlite3" }, threadId = ThreadId 1265} CallStack (from HasCallStack):   logError, called at src/Enlil/Utils/Errors.hs:40:3 in enlil-0.1.0.0-1eEPyViaNduJtcRpxp7HPS:Enlil.Utils.Errors   respondError, called at src/Enlil.hs:70:26 in enlil-0.1.0.0-1eEPyViaNduJtcRpxp7HPS:Enlil
```

Looks like I just forgot to handle conflicts on the namespace stats table, but since we actually check whether the stats already exist before trying to insert them in most cases I think this only comes up in super rare cases where a new namespace is inserted for the first time more than once in the same transaction or something, and since namespace stats are guaranteed to always be computed the same we can just ignore subsequent writes if that happens.

I plan to look deeper into how this is actually happening when I'm back from holidays, but just wanted to provide a patch in case it comes up while I'm away.

## Implementation

* Use `ON CONFLICT DO NOTHING` to avoid duplicate writes to namespace_statistics 