### PR TITLE
Fix to `Pattern.or` and `Pattern.replicate` to properly do backtracking when given composite patterns

### DIFF
--- a/parser-typechecker/src/Unison/Util/Text/Pattern.hs
+++ b/parser-typechecker/src/Unison/Util/Text/Pattern.hs
@@ -51,8 +51,14 @@ run p =
       s = reverse . capturesToList . stackCaptures
    in \t -> cp (Empty emptyCaptures) t
 
+-- Stack used to track captures and to support backtracking.
+-- A `try` will push a `Mark` that allows the old state
+-- (both the list of captures and the current remainder)
+-- to be restored on failure.
 data Stack = Empty !Captures | Mark !Captures !Text !Stack
 
+-- A difference list for representing the captures of a pattern.
+-- So that capture lists can be appended in O(1).
 type Captures = [Text] -> [Text]
 
 stackCaptures :: Stack -> Captures
@@ -78,15 +84,6 @@ emptyCaptures = id
 
 capturesToList :: Captures -> [Text]
 capturesToList c = c []
-
--- data Stack = Empty [Text] | Mark [Text] !Text !Stack
--- in `Or`: push a mark, then try left branch, if it succeeds,
---          merge top captures into the thing below, and pop from stack
---          if it fails, just pop the top mark from the stack
--- can just pop from the stack until hitting the correct mark
--- but then that leaves marks on the stack, even when the left branch succeeded
---
--- Pattern a -> ([a] -> a -> r) -> ... -- might need a takeable and droppable interface if go this route
 
 type Compiled r = (Stack -> Text -> r) -> (Stack -> Text -> r) -> Stack -> Text -> r
 

--- a/parser-typechecker/src/Unison/Util/Text/Pattern.hs
+++ b/parser-typechecker/src/Unison/Util/Text/Pattern.hs
@@ -112,14 +112,15 @@ compile (Capture c) !err !success = go
     go acc t = compiled acc t acc t
 compile (Or p1 p2) err success = cp1'
   where
-    err' stk _ = case stk of
-      Mark _ rem stk -> err stk rem
+    cp2 = compile p2 err success
+    cp2' stk _ = case stk of
+      Mark _ rem stk -> cp2 stk rem
       _ -> error "pattern compiler bug"
-    success' stk rem = case stk of
-      Mark caps _ stk -> success (pushCaptures caps stk) rem
-      _ -> error "pattern compiler bug"
-    cp2 = compile p2 err' success'
-    cp1 = compile p1 cp2 success'
+    cp1 = compile p1 cp2' success'
+      where
+        success' stk rem = case stk of
+          Mark caps _ stk -> success (pushCaptures caps stk) rem
+          _ -> error "pattern compiler bug"
     cp1' stk rem = cp1 (Mark (stackCaptures stk) rem stk) rem
 compile (Join ps) !err !success = go ps
   where

--- a/parser-typechecker/src/Unison/Util/Text/Pattern.hs
+++ b/parser-typechecker/src/Unison/Util/Text/Pattern.hs
@@ -74,7 +74,7 @@ appendCaptures c1 c2 = c1 . c2
 {-# INLINE appendCaptures #-}
 
 emptyCaptures :: Captures
-emptyCaptures = const []
+emptyCaptures = id
 
 capturesToList :: Captures -> [Text]
 capturesToList c = c []

--- a/parser-typechecker/tests/Unison/Test/Util/Text.hs
+++ b/parser-typechecker/tests/Unison/Test/Util/Text.hs
@@ -142,6 +142,11 @@ test =
                   )
                   (P.Join [P.Literal "aa", P.Literal "cd"])
            in P.run p "aacd"
+        -- this is just making sure we don't duplicate captures to our left
+        -- when entering an `Or` node
+        expectEqual (Just (["a"], "")) $
+          let p = P.Join [P.Capture P.AnyChar, P.Or (P.Literal "c") (P.Join []), P.Literal "d"]
+           in P.run p "acd"
         expectEqual (Just ([""], "ac")) $
           let p = P.Capture (P.Or (P.Join [P.Literal "a", P.Literal "b"]) (P.Join []))
            in P.run p "ac"

--- a/parser-typechecker/tests/Unison/Test/Util/Text.hs
+++ b/parser-typechecker/tests/Unison/Test/Util/Text.hs
@@ -165,6 +165,16 @@ test =
         expectEqual (Just ([""], "ac")) $
           let p = P.Capture (P.Replicate 0 1 (P.Join [P.Literal "a", P.Literal "b"]))
            in P.run p "ac"
+        -- nested or tests
+        expectEqual (Just (["zzzaaa", "!"], "!!")) $
+          let p =
+                P.Or
+                  ( P.Or
+                      (P.Literal "a")
+                      (P.Join [P.Literal "z", P.Replicate 3 5 (P.Literal "z")])
+                  )
+                  (P.Join [P.Capture (P.Literal "zzzaaa"), P.Capture (P.Literal "!")])
+           in P.run p "zzzaaa!!!"
         ok
     ]
   where

--- a/parser-typechecker/tests/Unison/Test/Util/Text.hs
+++ b/parser-typechecker/tests/Unison/Test/Util/Text.hs
@@ -124,6 +124,19 @@ test =
               dpart = P.Join [P.Literal ".", part]
               ip = P.Join [part, P.Replicate 3 3 dpart, P.Eof]
            in P.run ip "127.0.0.1" == Just (["127", "0", "0", "1"], "")
+        -- https://github.com/unisonweb/unison/issues/3530
+        expectEqual Nothing $
+          let p =
+                P.Or
+                  (P.Join [P.Literal "a", P.Literal "b"])
+                  (P.Join [P.Literal "a", P.Literal "c"])
+           in P.run p "aac"
+        expectEqual (Just ([""], "ac")) $
+          let p = P.Capture (P.Or (P.Join [P.Literal "a", P.Literal "b"]) (P.Join []))
+           in P.run p "ac"
+        expectEqual (Just ([""], "ac")) $
+          let p = P.Capture (P.Replicate 0 1 (P.Join [P.Literal "a", P.Literal "b"]))
+           in P.run p "ac"
         ok
     ]
   where

--- a/parser-typechecker/tests/Unison/Test/Util/Text.hs
+++ b/parser-typechecker/tests/Unison/Test/Util/Text.hs
@@ -131,6 +131,17 @@ test =
                   (P.Join [P.Literal "a", P.Literal "b"])
                   (P.Join [P.Literal "a", P.Literal "c"])
            in P.run p "aac"
+        expectEqual (Just ([], "")) $
+          let p =
+                P.Or
+                  ( P.Capture $
+                      ( P.Or
+                          (P.Join [P.Literal "a", P.Literal "b"])
+                          (P.Join [P.Literal "a", P.Literal "c"])
+                      )
+                  )
+                  (P.Join [P.Literal "aa", P.Literal "cd"])
+           in P.run p "aacd"
         expectEqual (Just ([""], "ac")) $
           let p = P.Capture (P.Or (P.Join [P.Literal "a", P.Literal "b"]) (P.Join []))
            in P.run p "ac"

--- a/unison-src/transcripts/builtins.md
+++ b/unison-src/transcripts/builtins.md
@@ -234,6 +234,8 @@ test> Text.tests.patterns =
     run (capture (many (notCharIn [?,,]))) "abracadabra,123" == Some (["abracadabra"], ",123"),
     run (capture (many (or digit letter))) "11234abc,remainder" == Some (["11234abc"], ",remainder"),
     run (capture (replicate 1 5 (or digit letter))) "1a2ba aaa" == Some (["1a2ba"], " aaa"),
+    -- Regression test for: https://github.com/unisonweb/unison/issues/3530
+    run (capture (replicate 0 1 (join [literal "a", literal "b"]))) "ac" == Some ([""], "ac"),
     isMatch (join [many letter, eof]) "aaaaabbbb" == true,
     isMatch (join [many letter, eof]) "aaaaabbbb1" == false,
     isMatch (join [l "abra", many (l "cadabra")]) "abracadabracadabra" == true,
@@ -273,12 +275,12 @@ test> Bytes.tests.compression =
           isLeft (gzip.decompress 0xs201209348750982374593939393939709827345789023457892345)
         ]
 
-test> Bytes.tests.fromBase64UrlUnpadded = 
+test> Bytes.tests.fromBase64UrlUnpadded =
   checks [Exception.catch
            '(fromUtf8
               (raiseMessage () (Bytes.fromBase64UrlUnpadded (toUtf8 "aGVsbG8gd29ybGQ")))) == Right "hello world"
          , isLeft (Bytes.fromBase64UrlUnpadded (toUtf8 "aGVsbG8gd29ybGQ="))]
-  
+
 ```
 
 ```ucm:hide

--- a/unison-src/transcripts/builtins.output.md
+++ b/unison-src/transcripts/builtins.output.md
@@ -215,6 +215,8 @@ test> Text.tests.patterns =
     run (capture (many (notCharIn [?,,]))) "abracadabra,123" == Some (["abracadabra"], ",123"),
     run (capture (many (or digit letter))) "11234abc,remainder" == Some (["11234abc"], ",remainder"),
     run (capture (replicate 1 5 (or digit letter))) "1a2ba aaa" == Some (["1a2ba"], " aaa"),
+    -- Regression test for: https://github.com/unisonweb/unison/issues/3530
+    run (capture (replicate 0 1 (join [literal "a", literal "b"]))) "ac" == Some ([""], "ac"),
     isMatch (join [many letter, eof]) "aaaaabbbb" == true,
     isMatch (join [many letter, eof]) "aaaaabbbb1" == false,
     isMatch (join [l "abra", many (l "cadabra")]) "abracadabracadabra" == true,
@@ -250,12 +252,12 @@ test> Bytes.tests.compression =
           isLeft (gzip.decompress 0xs201209348750982374593939393939709827345789023457892345)
         ]
 
-test> Bytes.tests.fromBase64UrlUnpadded = 
+test> Bytes.tests.fromBase64UrlUnpadded =
   checks [Exception.catch
            '(fromUtf8
               (raiseMessage () (Bytes.fromBase64UrlUnpadded (toUtf8 "aGVsbG8gd29ybGQ")))) == Right "hello world"
          , isLeft (Bytes.fromBase64UrlUnpadded (toUtf8 "aGVsbG8gd29ybGQ="))]
-  
+
 ```
 
 ## `Any` functions


### PR DESCRIPTION
Fixes #3530 thanks to @dolio for pairing on this!

Previously, patterns like:

```
Pattern.or (Pattern.join [p1, p2]) p3
```

Would not correctly backtrack the state (including both captures and the position) if `p1` succeeded. `Pattern.replicate` had a similar issue.

This PR fixes that and adds a regression (unit) test for the specific case reported by @ceedubs and a number of other related test cases.

I'm shocked this wasn't noticed before, but I'm guessing it's a combination of:

* Many "in the wild" patterns only need "1 token of lookahead" and are written as such. (Including examples in the docs and the prior unit tests 😳)
* API hasn't gotten a ton of usage yet

Note that if you do `capture (optional p)`, that will always capture at least the empty string (if `p` fails, then `optional` succeeds, consuming 0 characters, so the empty string consisting of 0 characters is captured), so the original bug report was slightly off in its expectations.