### PR TITLE
Improve errors on bad short-hashes

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -554,9 +554,12 @@ referentsByPrefix doGetDeclType (SH.ShortHash prefix (fmap Cv.shortHashSuffix1to
   termReferents <-
     Ops.termReferentsByPrefix prefix cycle
       >>= traverse (Cv.referentid2to1 doGetDeclType)
-  cid' <- case readMaybe (Text.unpack cid) of
-    Nothing -> error $ reportBug "994787297" "cid of ShortHash must be an integer but got: " <> show cid
-    Just cid' -> pure cid'
+  cid' <- case cid of
+    Nothing -> pure Nothing
+    Just c ->
+      case readMaybe (Text.unpack c) of
+        Nothing -> error $ reportBug "994787297" "cid of ShortHash must be an integer but got: " <> show cid
+        Just cInt -> pure $ Just cInt
   declReferents' <- Ops.declReferentsByPrefix prefix cycle cid'
   let declReferents =
         [ Referent.ConId (ConstructorReference (Reference.Id h pos) (fromIntegral cid)) (Cv.decltype2to1 ct)

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -554,7 +554,10 @@ referentsByPrefix doGetDeclType (SH.ShortHash prefix (fmap Cv.shortHashSuffix1to
   termReferents <-
     Ops.termReferentsByPrefix prefix cycle
       >>= traverse (Cv.referentid2to1 doGetDeclType)
-  declReferents' <- Ops.declReferentsByPrefix prefix cycle (read . Text.unpack <$> cid)
+  cid' <- case readMaybe (Text.unpack cid) of
+    Nothing -> error $ reportBug "994787297" "cid of ShortHash must be an integer but got: " <> show cid
+    Just cid' -> pure cid'
+  declReferents' <- Ops.declReferentsByPrefix prefix cycle cid'
   let declReferents =
         [ Referent.ConId (ConstructorReference (Reference.Id h pos) (fromIntegral cid)) (Cv.decltype2to1 ct)
           | (h, pos, ct, cids) <- declReferents',

--- a/unison-core/src/Unison/ShortHash.hs
+++ b/unison-core/src/Unison/ShortHash.hs
@@ -25,19 +25,42 @@ isConstructor = \case
 
 -- Parse a string like those described in Referent.fromText:
 -- examples:
--- `##Text.take` — builtins don’t have cycles or cids
--- `#2tWjVAuc7` — term ref, no cycle
--- `#y9ycWkiC1.y9` — term ref, part of cycle
--- `#cWkiC1x89#1` — constructor
--- `#DCxrnCAPS.WD#0` — constructor of a type in a cycle
+--
+-- builtins don’t have cycles or cids
+-- >>> fromText "##Text.take"
+-- Just (Builtin "Text.take")
+--
+-- term ref, no cycle
+-- >>> fromText "#2tWjVAuc7"
+-- Just (ShortHash {prefix = "2tWjVAuc7", cycle = Nothing, cid = Nothing})
+--
+-- term ref, part of cycle
+-- >>> fromText "#y9ycWkiC1.y9"
+-- Just (ShortHash {prefix = "y9ycWkiC1", cycle = Just "y9", cid = Nothing})
+--
+-- constructor
+-- >>> fromText "#cWkiC1x89#1"
+-- Just (ShortHash {prefix = "cWkiC1x89", cycle = Nothing, cid = Just "1"})
+--
+-- constructor of a type in a cycle
+-- >>> fromText "#DCxrnCAPS.WD#0"
+-- Just (ShortHash {prefix = "DCxrnCAPS", cycle = Just "WD", cid = Just "0"})
+--
 -- A constructor ID on a builtin is ignored:
---  e.g. ##FileIO#2 is parsed as ##FileIO
+-- >>> fromText "##FileIO#2"
+-- Just (Builtin "FileIO")
+--
 -- Anything to the left of the first # is
---   e.g. foo#abc is parsed as #abc
+-- >>> fromText "foo#abc "
+-- Just (ShortHash {prefix = "abc ", cycle = Nothing, cid = Nothing})
+--
 -- Anything including and following a third # is ignored.
---   e.g. foo#abc#2#hello is parsed as #abc#2
+-- >>> fromText "foo#abc#2#hello"
+-- Just (ShortHash {prefix = "abc", cycle = Nothing, cid = Just "2"})
+--
 -- Anything after a second . before a second # is ignored.
---   e.g. foo#abc.1f.x is parsed as #abc.1f
+-- >>> fromText "foo#abc.1f.x"
+-- Just (ShortHash {prefix = "abc", cycle = Just "1f", cid = Nothing})
 fromText :: Text -> Maybe ShortHash
 fromText t = case Text.split (== '#') t of
   [_, "", b] -> Just $ Builtin b -- builtin starts with ##


### PR DESCRIPTION
## Overview

Had a really annoying time tracking down what was happening here because an API error wasn't triggering a problem until a `read` deep within the sqlite layer, and there were no HasCallStacks along the way.


## Implementation notes

* This removes the usage of `read` since it's problematic for things like this, and replaces it with an explicit `reportBug`.
* Converts the ShortHash.fromText docs to doc-tests