### PR TITLE
fix Cli.time logic

### DIFF
--- a/unison-cli/src/Unison/Cli/Monad.hs
+++ b/unison-cli/src/Unison/Cli/Monad.hs
@@ -322,7 +322,7 @@ time label action =
     then Cli \env k s -> do
       systemStart <- getSystemTime
       cpuPicoStart <- getCPUTime
-      r <- unCli action env k s
+      a <- unCli action env (\a loopState -> pure (Success a, loopState)) s
       cpuPicoEnd <- getCPUTime
       systemEnd <- getSystemTime
       let systemDiff =
@@ -330,7 +330,7 @@ time label action =
               (diffAbsoluteTime (systemToTAITime systemEnd) (systemToTAITime systemStart))
       let cpuDiff = picosToNanos (cpuPicoEnd - cpuPicoStart)
       printf "%s: %s (cpu), %s (system)\n" label (renderNanos cpuDiff) (renderNanos systemDiff)
-      pure r
+      feed k a
     else action
   where
     diffTimeToNanos :: DiffTime -> Double


### PR DESCRIPTION
We think the previous implementation timed the continuation, and didn't allow fine-grained measurements.

@tstat identified and dictated the fix.

Before:
```
.> diff.namespace #h9fco4 #5s4bin   

  <program output>

toOutput: 60.7 s (cpu), 72.4 s (system)
prettyPrintEnvDecl: 60.7 s (cpu), 72.4 s (system)
suffixifiedPPE: 60.7 s (cpu), 72.4 s (system)
diff0: 69.0 s (cpu), 81.1 s (system)
hashLength codebase: 69.0 s (cpu), 81.1 s (system)
getRootBranch: 69.0 s (cpu), 81.1 s (system)
diffHelper: 69.0 s (cpu), 81.1 s (system)
resolveShortBranchHash: 70.2 s (cpu), 82.3 s (system)
resolveShortBranchHash: 70.2 s (cpu), 82.3 s (system)
```

After:
```
.> diff.namespace #h9fco4 #5s4bin
resolveShortBranchHash: 689 ms (cpu), 511 ms (system)
resolveShortBranchHash: 1.24 ms (cpu), 1.43 ms (system)
getRootBranch: 7.00 µs (cpu), 8.00 µs (system)
hashLength codebase: 403 µs (cpu), 264 µs (system)
diff0: 8.60 s (cpu), 9.03 s (system)
prettyPrintEnvDecl: 367 µs (cpu), 369 µs (system)
suffixifiedPPE: 404 µs (cpu), 407 µs (system)
toOutput: 61.7 s (cpu), 71.1 s (system)
diffHelper: 70.3 s (cpu), 80.1 s (system)

  <program output>
```