### PR TITLE
run ucm main in an unbound thread

### DIFF
--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 
@@ -300,9 +300,9 @@ library
     , x509-system
     , yaml
     , zlib
-  default-language: Haskell2010
   if flag(optimized)
     ghc-options: -funbox-strict-fields -O2
+  default-language: Haskell2010
 
 test-suite parser-typechecker-tests
   type: exitcode-stdio-1.0
@@ -488,6 +488,6 @@ test-suite parser-typechecker-tests
     , x509-system
     , yaml
     , zlib
-  default-language: Haskell2010
   if flag(optimized)
     ghc-options: -funbox-strict-fields -O2
+  default-language: Haskell2010

--- a/unison-cli/unison/Main.hs
+++ b/unison-cli/unison/Main.hs
@@ -23,7 +23,7 @@ import ArgParse
     parseCLIArgs,
   )
 import Compat (defaultInterruptHandler, onWindows, withInterruptHandler)
-import Control.Concurrent (newEmptyMVar, takeMVar)
+import Control.Concurrent (newEmptyMVar, runInUnboundThread, takeMVar)
 import Control.Concurrent.STM
 import Control.Error.Safe (rightMay)
 import Control.Exception (evaluate)
@@ -86,7 +86,7 @@ import UnliftIO.Directory (getHomeDirectory)
 import qualified Version
 
 main :: IO ()
-main = withCP65001 . Ki.scoped $ \scope -> do
+main = withCP65001 . runInUnboundThread . Ki.scoped $ \scope -> do
   -- Replace the default exception handler with one that pretty-prints.
   setUncaughtExceptionHandler (pHPrint stderr)
 


### PR DESCRIPTION
## Overview

This PR changes ucm's main to run in an unbound thread. When main is bound (the default), all of its foreign calls are run on the same OS thread, and its capability can't run any other haskell threads. `ucm` has a little bit of concurrency (background web server, LSP thread, maybe one other), so we often end up paying for an OS thread context switch when scheduling between main and any other thread. This PR fixes that.