### PR TITLE
Comment out builtins from the edit command

### DIFF
--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2077,9 +2077,10 @@ displayDefinitions outputLoc ppe types terms =
           case dt of
             MissingObject r -> missing n r
             BuiltinObject typ ->
-              P.hang
-                ("builtin " <> prettyHashQualified n <> " :")
-                (TypePrinter.prettySyntax (ppeBody n r) typ)
+              (if isJust outputLoc then P.indent "-- " else id) $
+                P.hang
+                  ("builtin " <> prettyHashQualified n <> " :")
+                  (TypePrinter.prettySyntax (ppeBody n r) typ)
             UserObject tm -> TermPrinter.prettyBinding (ppeBody n r) n tm
         go2 ((n, r), dt) =
           case dt of

--- a/unison-src/transcripts-round-trip/main.md
+++ b/unison-src/transcripts-round-trip/main.md
@@ -470,3 +470,17 @@ roundtripLastLam =
 ```ucm
 .> load scratch.u
 ```
+
+# Comment out builtins in the edit command
+
+Regression test for https://github.com/unisonweb/unison/pull/3548
+
+```ucm
+.> alias.term ##Nat.+ plus
+.> edit plus
+.> undo
+```
+
+```ucm
+.> load scratch.u
+```

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -1432,3 +1432,40 @@ roundtripLastLam =
       roundtripLastLam : Nat
 
 ```
+# Comment out builtins in the edit command
+
+Regression test for https://github.com/unisonweb/unison/pull/3548
+
+```ucm
+.> alias.term ##Nat.+ plus
+
+  Done.
+
+.> edit plus
+
+  ☝️
+  
+  I added these definitions to the top of
+  /Users/runar/work/unison/scratch.u
+  
+    -- builtin plus : builtin.Nat -> builtin.Nat -> builtin.Nat
+  
+  You can edit them there, then do `update` to replace the
+  definitions currently in this namespace.
+
+.> undo
+
+  Here are the changes I undid
+  
+  Name changes:
+  
+    Original            Changes
+    1. builtin.Nat.+    2. plus (added)
+
+```
+```ucm
+.> load scratch.u
+
+  I loaded scratch.u and didn't find anything.
+
+```


### PR DESCRIPTION
Fixes https://github.com/unisonweb/unison/issues/3361

Simply comments out the output when the destination is a file.