### PR TITLE
Add 'Show' for backend errors for usage in Sentry errors

### DIFF
--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -143,6 +143,7 @@ data BackendError
   | CouldntLoadBranch Branch.CausalHash
   | MissingSignatureForTerm Reference
   | NoSuchDefinition (HQ.HashQualified Name)
+  deriving stock (Show)
 
 newtype BackendEnv = BackendEnv
   { -- | Whether to use the sqlite name-lookup table to generate Names objects rather than building Names from the root branch.


### PR DESCRIPTION
## Overview

The upcoming Sentry error reporting uses `Show` to generate more useful error descriptions;
Backend Errors don't implement Show.

## Implementation notes

Derive `Show` for backend errors
