### PR TITLE
Don't re-save branches that already exist

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
@@ -638,7 +638,8 @@ saveBranch ::
 saveBranch hh (C.Causal hc he parents me) = do
   when debug $ traceM $ "\nOperations.saveBranch \n  hc = " ++ show hc ++ ",\n  he = " ++ show he ++ ",\n  parents = " ++ show (Map.keys parents)
 
-  (chId, bhId) <- flip Monad.fromMaybeM (Q.loadCausalByCausalHash hc) do
+  -- Save the causal
+  (chId, bhId) <- whenNothingM (Q.loadCausalByCausalHash hc) do
     -- if not exist, create these
     chId <- Q.saveCausalHash hc
     bhId <- Q.saveBranchHash he
@@ -655,7 +656,9 @@ saveBranch hh (C.Causal hc he parents me) = do
     -- Save these CausalHashIds to the causal_parents table,
     Q.saveCausal hh chId bhId parentCausalHashIds
     pure (chId, bhId)
-  boId <- flip Monad.fromMaybeM (Q.loadBranchObjectIdByCausalHashId chId) do
+
+  -- Save the namespace
+  boId <- flip Monad.fromMaybeM (Q.loadBranchObjectIdByBranchHashId bhId) do
     branch <- me
     dbBranch <- c2sBranch branch
     stats <- namespaceStatsForDbBranch dbBranch

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -79,6 +79,7 @@ module U.Codebase.Sqlite.Queries
     loadCausalByCausalHash,
     expectCausalByCausalHash,
     loadBranchObjectIdByCausalHashId,
+    loadBranchObjectIdByBranchHashId,
     expectBranchObjectIdByCausalHashId,
     expectBranchObjectIdByBranchHashId,
 
@@ -1044,6 +1045,9 @@ loadBranchObjectIdByCausalHashIdSql =
 
 expectBranchObjectIdByBranchHashId :: BranchHashId -> Transaction BranchObjectId
 expectBranchObjectIdByBranchHashId id = queryOneCol loadBranchObjectIdByBranchHashIdSql (Only id)
+
+loadBranchObjectIdByBranchHashId :: BranchHashId -> Transaction (Maybe BranchObjectId)
+loadBranchObjectIdByBranchHashId id = queryMaybeCol loadBranchObjectIdByBranchHashIdSql (Only id)
 
 loadBranchObjectIdByBranchHashIdSql :: Sql
 loadBranchObjectIdByBranchHashIdSql =


### PR DESCRIPTION
## Overview

Supercedes #3526;

```
  |   | 2022-10-19 16:32:08 | 19/Oct/2022:22:32:08 +0000 Error  SqliteQueryException {sql = "INSERT INTO namespace_statistics (namespace_hash_id, num_contained_terms, num_contained_types, num_contained_patches)\n          VALUES (?, ?, ?, ?)", params = ":. 91 (NamespaceStats 1 0 0)", exception = SQLite3 returned ErrorConstraint while attempting to perform step: UNIQUE constraint failed: namespace_statistics.namespace_hash_id, callStack = [], connection = Connection { name = "U-1f13c72e-b554-4622-9d8e-fc5a603700a2", file = "codebases/U-1f13c72e-b554-4622-9d8e-fc5a603700a2/.unison/v2/unison.sqlite3" }, threadId = ThreadId 1265} CallStack (from HasCallStack):   logError, called at src/Enlil/Utils/Errors.hs:40:3 in enlil-0.1.0.0-1eEPyViaNduJtcRpxp7HPS:Enlil.Utils.Errors   respondError, called at src/Enlil.hs:70:26 in enlil-0.1.0.0-1eEPyViaNduJtcRpxp7HPS:Enlil
```

We hit a sqlite error in the case where we save a causal where the same namespace hash exists more than once in the history of that causal, AND those multiple steps of the causal have never been saved in the codebase. I don't think it's possible to encounter this issue in UCM alone, I think it has to happen during a sync.

I've only encountered this error once, when pushing to a fresh branch on Share, which makes sense given this explanation.

## Implementation notes

Rather than check if the causal already exists in order to skip work, we can check if the branch object exists directly.
This fixes the issue because we'll skip re-saving the branch if it was already saved in a previous causal step.

## Testing

I don't believe it's possible to replicate this in a transcript, since it's not generally possible to save multiple new causal steps all at once, so I think it needs to happen in a sync.

I've tried reproducing it against a local enlil and haven't been able to do that either, which is disappointing, but regardless, I think that this change improves the semantics, behaviour, and performance of the code, and should prevent this from happening again even if I can't reproduce it.