### PR TITLE
Refactor: make getDeclComponent in Transaction, not IO

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -256,9 +256,9 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
             getTypeDeclaration id =
               runTransaction (CodebaseOps.getTypeDeclaration id)
 
-            getDeclComponent :: Hash -> m (Maybe [Decl Symbol Ann])
-            getDeclComponent h =
-              runTransaction (CodebaseOps.getDeclComponent h)
+            getDeclComponent :: Hash -> Sqlite.Transaction (Maybe [Decl Symbol Ann])
+            getDeclComponent =
+              CodebaseOps.getDeclComponent
 
             getCycleLength :: Hash -> m (Maybe Reference.CycleSize)
             getCycleLength h =

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -80,7 +80,7 @@ data Codebase m v a = Codebase
     putTypeDeclarationComponent :: Hash -> [Decl v a] -> Sqlite.Transaction (),
     -- getTermComponent :: Hash -> m (Maybe [Term v a]),
     getTermComponentWithTypes :: Hash -> Sqlite.Transaction (Maybe [(Term v a, Type v a)]),
-    getDeclComponent :: Hash -> m (Maybe [Decl v a]),
+    getDeclComponent :: Hash -> Sqlite.Transaction (Maybe [Decl v a]),
     getComponentLength :: Hash -> m (Maybe Reference.CycleSize),
     -- | Get the root causal Hash.
     getRootCausalHash :: m V2.CausalHash,

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -143,6 +143,7 @@ data BackendError
   | CouldntLoadBranch Branch.CausalHash
   | MissingSignatureForTerm Reference
   | NoSuchDefinition (HQ.HashQualified Name)
+  deriving stock (Show)
 
 newtype BackendEnv = BackendEnv
   { -- | Whether to use the sqlite name-lookup table to generate Names objects rather than building Names from the root branch.


### PR DESCRIPTION
## Overview

This PR makes `Codebase.getDeclComponent` in `Transaction` rather than `IO`.