### PR TITLE
`Scope.bytearrayOf` builtin had reversed arguments

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -2696,7 +2696,7 @@ declareForeigns = do
   declareForeign Untracked "Scope.bytearray" natToBox . mkForeign $ PA.newByteArray
   declareForeign Untracked "Scope.bytearrayOf" natNatToBox
     . mkForeign
-    $ \(sz, init) -> do
+    $ \(init, sz) -> do
       arr <- PA.newByteArray sz
       PA.fillByteArray arr 0 sz init
       pure arr

--- a/unison-src/transcripts-using-base/fix3542.md
+++ b/unison-src/transcripts-using-base/fix3542.md
@@ -1,0 +1,19 @@
+
+```ucm:hide
+.> builtins.mergeio
+```
+
+```unison
+arrayList v n = do
+  use ImmutableByteArray read8
+  ma = Scope.bytearrayOf v n
+  a = freeze! ma
+  go acc i =
+    acc' = [read8 a i] ++ acc
+    if i == 0
+    then acc'
+    else go acc' (drop i 1)
+  go [] (drop n 1)
+
+> Scope.run '(catch (arrayList 7 8))
+```

--- a/unison-src/transcripts-using-base/fix3542.output.md
+++ b/unison-src/transcripts-using-base/fix3542.output.md
@@ -1,0 +1,34 @@
+
+```unison
+arrayList v n = do
+  use ImmutableByteArray read8
+  ma = Scope.bytearrayOf v n
+  a = freeze! ma
+  go acc i =
+    acc' = [read8 a i] ++ acc
+    if i == 0
+    then acc'
+    else go acc' (drop i 1)
+  go [] (drop n 1)
+
+> Scope.run '(catch (arrayList 7 8))
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      arrayList : Nat -> Nat -> () ->{Exception, Scope s} [Nat]
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    12 | > Scope.run '(catch (arrayList 7 8))
+           ⧩
+           Right [7, 7, 7, 7, 7, 7, 7, 7]
+
+```


### PR DESCRIPTION
The `(byte)arrayOf` builtins were intended to take the value to fill the array with first, but one of the `Scope` functions was using the wrong order. This PR fixes it.

Fixes #3542