### PR TITLE
Refactor: make putTerm in Transaction, not IO

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -272,10 +272,10 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
             -- option 2: switch codebase interface from putTerm to putTerms -- buffering can be local to the function
             -- option 3: switch from putTerm to putTermComponent -- needs to buffer dependencies non-locally (or require application to manage + die horribly)
 
-            putTerm :: Reference.Id -> Term Symbol Ann -> Type Symbol Ann -> m ()
+            putTerm :: Reference.Id -> Term Symbol Ann -> Type Symbol Ann -> Sqlite.Transaction ()
             putTerm id tm tp | debug && trace ("SqliteCodebase.putTerm " ++ show id ++ " " ++ show tm ++ " " ++ show tp) False = undefined
             putTerm id tm tp =
-              runTransaction (CodebaseOps.putTerm termBuffer declBuffer id tm tp)
+              CodebaseOps.putTerm termBuffer declBuffer id tm tp
 
             putTermComponent :: Hash -> [(Term Symbol Ann, Type Symbol Ann)] -> Sqlite.Transaction ()
             putTermComponent =

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -72,7 +72,7 @@ data Codebase m v a = Codebase
     -- | Enqueue the put of a user-defined term (with its type) into the codebase, if it doesn't already exist. The
     -- implementation may choose to delay the put until all of the term's (and its type's) references are stored as
     -- well.
-    putTerm :: Reference.Id -> Term v a -> Type v a -> m (),
+    putTerm :: Reference.Id -> Term v a -> Type v a -> Sqlite.Transaction (),
     putTermComponent :: Hash -> [(Term v a, Type v a)] -> Sqlite.Transaction (),
     -- | Enqueue the put of a type declaration into the codebase, if it doesn't already exist. The implementation may
     -- choose to delay the put until all of the type declaration's references are stored as well.

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -832,7 +832,7 @@ loop e = do
                 AuthorInfo.createAuthorInfo Ann.External authorFullName
               description <- inputDescription input
               -- add the new definitions to the codebase and to the namespace
-              traverse_ (liftIO . uncurry3 (Codebase.putTerm codebase)) [guid, author, copyrightHolder]
+              Cli.runTransaction (traverse_ (uncurry3 (Codebase.putTerm codebase)) [guid, author, copyrightHolder])
               authorPath <- Cli.resolveSplit' authorPath'
               copyrightHolderPath <- Cli.resolveSplit' (base |> "copyrightHolders" |> authorNameSegment)
               guidPath <- Cli.resolveSplit' (authorPath' |> "guid")

--- a/unison-cli/src/Unison/Codebase/Editor/Propagate.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Propagate.hs
@@ -397,13 +397,14 @@ propagate patch b = case validatePatch patch of
             doTerm r = do
               when debugMode (traceM $ "Rewriting term: " <> show r)
               componentMap <- unhashTermComponent codebase r
-              let componentMap' =
-                    over
-                      _2
-                      (Term.updateDependencies termReplacements typeReplacements)
-                      <$> componentMap
-                  seen' = seen <> Set.fromList (view _1 <$> Map.elems componentMap)
-              mayComponent <- verifyTermComponent codebase componentMap' es
+              let seen' = seen <> Set.fromList (view _1 <$> Map.elems componentMap)
+              mayComponent <- do
+                let componentMap' =
+                      over
+                        _2
+                        (Term.updateDependencies termReplacements typeReplacements)
+                        <$> componentMap
+                verifyTermComponent codebase componentMap' es
               case mayComponent of
                 Nothing -> do
                   when debugMode (traceM $ refName r <> " did not typecheck after substitutions")

--- a/unison-cli/src/Unison/Codebase/Editor/Propagate.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Propagate.hs
@@ -315,7 +315,7 @@ propagate patch b = case validatePatch patch of
                   let message =
                         "This reference is not a term nor a type " <> show r
                       mmayEdits
-                        | haveTerm = doTerm r
+                        | haveTerm = Cli.runTransaction (doTerm r)
                         | haveType = doType r
                         | otherwise = error message
                   mayEdits <- mmayEdits
@@ -393,20 +393,17 @@ propagate patch b = case validatePatch patch of
                       constructorReplacements',
                   seen'
                 )
-            doTerm :: Reference -> Cli (Maybe (Edits Symbol), Set Reference)
+            doTerm :: Reference -> Sqlite.Transaction (Maybe (Edits Symbol), Set Reference)
             doTerm r = do
               when debugMode (traceM $ "Rewriting term: " <> show r)
-              (componentMap, seen', mayComponent) <-
-                Cli.runTransaction do
-                  componentMap <- unhashTermComponent codebase r
-                  let componentMap' =
-                        over
-                          _2
-                          (Term.updateDependencies termReplacements typeReplacements)
-                          <$> componentMap
-                      seen' = seen <> Set.fromList (view _1 <$> Map.elems componentMap)
-                  mayComponent <- verifyTermComponent codebase componentMap' es
-                  pure (componentMap, seen', mayComponent)
+              componentMap <- unhashTermComponent codebase r
+              let componentMap' =
+                    over
+                      _2
+                      (Term.updateDependencies termReplacements typeReplacements)
+                      <$> componentMap
+                  seen' = seen <> Set.fromList (view _1 <$> Map.elems componentMap)
+              mayComponent <- verifyTermComponent codebase componentMap' es
               case mayComponent of
                 Nothing -> do
                   when debugMode (traceM $ refName r <> " did not typecheck after substitutions")
@@ -436,7 +433,7 @@ propagate patch b = case validatePatch patch of
                       toNewTerm (_, r', tm, _, tp) = (r', (tm, tp))
                       writeTerms =
                         traverse_ \case
-                          (Reference.DerivedId id, (tm, tp)) -> liftIO (Codebase.putTerm codebase id tm tp)
+                          (Reference.DerivedId id, (tm, tp)) -> Codebase.putTerm codebase id tm tp
                           _ -> error "propagate: Expected DerivedId"
                   writeTerms
                     [(r, (tm, ty)) | (_old, r, tm, _oldTy, ty) <- joinedStuff]


### PR DESCRIPTION
- [x] Depends on #3569 

---

## Overview

This PR makes `Codebase.putTerm` in `Transaction`, not `IO`