### PR TITLE
Refactor: remove a couple functions from the Codebase record

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
@@ -40,7 +40,7 @@ module U.Codebase.Sqlite.Operations
     saveWatch,
     loadWatch,
     listWatches,
-    clearWatches,
+    Q.clearWatches,
 
     -- * indexes
 

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
@@ -974,6 +974,7 @@ componentReferencesByPrefix ot b32prefix pos = do
   let filterComponent l = [x | x@(C.Reference.Id _ pos) <- l, test pos]
   join <$> traverse (fmap filterComponent . componentByObjectId) oIds
 
+-- | Get the set of user-defined terms whose hash matches the given prefix.
 termReferencesByPrefix :: Text -> Maybe Word64 -> Transaction [C.Reference.Id]
 termReferencesByPrefix t w =
   componentReferencesByPrefix ObjectType.TermComponent t w

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
@@ -1140,6 +1140,7 @@ namespaceStatsForDbBranch S.Branch {terms, types, patches, children} = do
            in childPatchCount + patchCount
       }
 
+-- | Gets the specified number of reflog entries in chronological order, most recent first.
 getReflog :: Int -> Transaction [Reflog.Entry CausalHash Text]
 getReflog numEntries = do
   entries <- Q.getReflog numEntries

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
@@ -456,9 +456,6 @@ saveWatch w r t = do
   let bytes = S.putBytes S.putWatchResultFormat (uncurry S.Term.WatchResult wterm)
   Q.saveWatch w rs bytes
 
-clearWatches :: Transaction ()
-clearWatches = Q.clearWatches
-
 c2wTerm :: C.Term Symbol -> Transaction (WatchLocalIds, S.Term.Term)
 c2wTerm tm = Q.c2xTerm Q.saveText Q.saveHashHash tm Nothing <&> \(w, tm, _) -> (w, tm)
 

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -1146,6 +1146,7 @@ loadWatchesByWatchKind k = queryListRow sql (Only k) where sql = [here|
   SELECT hash_id, component_index FROM watch WHERE watch_kind_id = ?
 |]
 
+-- | Delete all watches that were put by 'putWatch'.
 clearWatches :: Transaction ()
 clearWatches = do
   execute_ "DELETE FROM watch_result"

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -52,7 +52,6 @@ module Unison.Codebase
 
     -- * Patches
     patchExists,
-    getPatch,
     putPatch,
 
     -- * Watches

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -29,7 +29,7 @@ module Unison.Codebase
     Operations.getDeclComponent,
     putTypeDeclaration,
     putTypeDeclarationComponent,
-    typeReferencesByPrefix,
+    Operations.typeReferencesByPrefix,
     isType,
 
     -- * Branches

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -63,7 +63,7 @@ module Unison.Codebase
     lookupWatchCache,
     Operations.watches,
     Operations.putWatch,
-    clearWatches,
+    Queries.clearWatches,
 
     -- * Reflog
     getReflog,

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -20,7 +20,7 @@ module Unison.Codebase
     -- ** Search
     termsOfType,
     termsMentioningType,
-    termReferencesByPrefix,
+    Operations.termReferencesByPrefix,
     termReferentsByPrefix,
 
     -- * Type declarations

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -54,7 +54,7 @@ module Unison.Codebase
     namesAtPath,
 
     -- * Patches
-    patchExists,
+    Operations.patchExists,
     Operations.getPatch,
     Operations.putPatch,
 

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -70,7 +70,7 @@ module Unison.Codebase
 
     -- * Unambiguous hash length
     Operations.hashLength,
-    branchHashLength,
+    Operations.branchHashLength,
 
     -- * Dependents
     dependents,

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -51,7 +51,7 @@ module Unison.Codebase
     SqliteCodebase.Operations.getRootBranchExists,
     Operations.expectRootCausalHash,
     putRootBranch,
-    namesAtPath,
+    SqliteCodebase.Operations.namesAtPath,
 
     -- * Patches
     SqliteCodebase.Operations.patchExists,

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -62,7 +62,7 @@ module Unison.Codebase
     getWatch,
     lookupWatchCache,
     Operations.watches,
-    putWatch,
+    Operations.putWatch,
     clearWatches,
 
     -- * Reflog

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -20,23 +20,23 @@ module Unison.Codebase
     -- ** Search
     termsOfType,
     termsMentioningType,
-    Operations.termReferencesByPrefix,
+    SqliteCodebase.Operations.termReferencesByPrefix,
     termReferentsByPrefix,
 
     -- * Type declarations
     getTypeDeclaration,
     unsafeGetTypeDeclaration,
-    Operations.getDeclComponent,
+    SqliteCodebase.Operations.getDeclComponent,
     putTypeDeclaration,
     putTypeDeclarationComponent,
-    Operations.typeReferencesByPrefix,
+    SqliteCodebase.Operations.typeReferencesByPrefix,
     isType,
 
     -- * Branches
-    Operations.branchExists,
+    SqliteCodebase.Operations.branchExists,
     getBranchForHash,
     putBranch,
-    causalHashesByPrefix,
+    SqliteCodebase.Operations.causalHashesByPrefix,
     lca,
     beforeImpl,
     getShallowBranchAtPath,
@@ -48,29 +48,29 @@ module Unison.Codebase
 
     -- * Root branch
     getRootBranch,
-    Operations.getRootBranchExists,
+    SqliteCodebase.Operations.getRootBranchExists,
     Operations.expectRootCausalHash,
     putRootBranch,
     namesAtPath,
 
     -- * Patches
-    Operations.patchExists,
-    Operations.getPatch,
-    Operations.putPatch,
+    SqliteCodebase.Operations.patchExists,
+    SqliteCodebase.Operations.getPatch,
+    SqliteCodebase.Operations.putPatch,
 
     -- * Watches
     getWatch,
     lookupWatchCache,
-    Operations.watches,
-    Operations.putWatch,
+    SqliteCodebase.Operations.watches,
+    SqliteCodebase.Operations.putWatch,
     Queries.clearWatches,
 
     -- * Reflog
     Operations.getReflog,
 
     -- * Unambiguous hash length
-    Operations.hashLength,
-    Operations.branchHashLength,
+    SqliteCodebase.Operations.hashLength,
+    SqliteCodebase.Operations.branchHashLength,
 
     -- * Dependents
     dependents,
@@ -134,7 +134,7 @@ import qualified Unison.Codebase.GitError as GitError
 import Unison.Codebase.Path
 import qualified Unison.Codebase.Path as Path
 import qualified Unison.Codebase.SqliteCodebase.Conversions as Cv
-import qualified Unison.Codebase.SqliteCodebase.Operations as Operations
+import qualified Unison.Codebase.SqliteCodebase.Operations as SqliteCodebase.Operations
 import Unison.Codebase.SyncMode (SyncMode)
 import Unison.Codebase.Type
   ( Codebase (..),
@@ -265,8 +265,8 @@ lca code b1@(Branch.headHash -> h1) b2@(Branch.headHash -> h2) = case lcaImpl co
   Just lca -> do
     (eb1, eb2) <-
       runTransaction code do
-        eb1 <- Operations.branchExists h1
-        eb2 <- Operations.branchExists h2
+        eb1 <- SqliteCodebase.Operations.branchExists h1
+        eb2 <- SqliteCodebase.Operations.branchExists h2
         pure (eb1, eb2)
     if eb1 && eb2
       then do
@@ -402,13 +402,13 @@ dependents :: Queries.DependentsSelector -> Reference -> Sqlite.Transaction (Set
 dependents selector r =
   Set.union (Builtin.builtinTypeDependents r)
     . Set.map Reference.DerivedId
-    <$> Operations.dependentsImpl selector r
+    <$> SqliteCodebase.Operations.dependentsImpl selector r
 
 dependentsOfComponent :: Hash -> Sqlite.Transaction (Set Reference)
 dependentsOfComponent h =
   Set.union (Builtin.builtinTypeDependentsOfComponent h)
     . Set.map Reference.DerivedId
-    <$> Operations.dependentsOfComponentImpl h
+    <$> SqliteCodebase.Operations.dependentsOfComponentImpl h
 
 -- | Get the set of terms-or-constructors that have the given type.
 termsOfType :: (Var v, Functor m) => Codebase m v a -> Type v a -> m (Set Referent.Referent)

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -48,7 +48,6 @@ module Unison.Codebase
 
     -- * Root branch
     getRootBranch,
-    getRootBranchExists,
     putRootBranch,
     namesAtPath,
 

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -61,7 +61,7 @@ module Unison.Codebase
     -- * Watches
     getWatch,
     lookupWatchCache,
-    watches,
+    Operations.watches,
     putWatch,
     clearWatches,
 

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -26,7 +26,7 @@ module Unison.Codebase
     -- * Type declarations
     getTypeDeclaration,
     unsafeGetTypeDeclaration,
-    getDeclComponent,
+    Operations.getDeclComponent,
     putTypeDeclaration,
     putTypeDeclarationComponent,
     typeReferencesByPrefix,
@@ -133,7 +133,7 @@ import qualified Unison.Codebase.GitError as GitError
 import Unison.Codebase.Path
 import qualified Unison.Codebase.Path as Path
 import qualified Unison.Codebase.SqliteCodebase.Conversions as Cv
-import Unison.Codebase.SqliteCodebase.Operations (dependentsImpl, getDeclComponent)
+import qualified Unison.Codebase.SqliteCodebase.Operations as Operations
 import Unison.Codebase.SyncMode (SyncMode)
 import Unison.Codebase.Type
   ( Codebase (..),
@@ -398,13 +398,13 @@ dependents :: Queries.DependentsSelector -> Reference -> Sqlite.Transaction (Set
 dependents selector r =
   Set.union (Builtin.builtinTypeDependents r)
     . Set.map Reference.DerivedId
-    <$> dependentsImpl selector r
+    <$> Operations.dependentsImpl selector r
 
-dependentsOfComponent :: Codebase m v a -> Hash -> Sqlite.Transaction (Set Reference)
-dependentsOfComponent c h =
+dependentsOfComponent :: Hash -> Sqlite.Transaction (Set Reference)
+dependentsOfComponent h =
   Set.union (Builtin.builtinTypeDependentsOfComponent h)
     . Set.map Reference.DerivedId
-    <$> dependentsOfComponentImpl c h
+    <$> Operations.dependentsOfComponentImpl h
 
 -- | Get the set of terms-or-constructors that have the given type.
 termsOfType :: (Var v, Functor m) => Codebase m v a -> Type v a -> m (Set Referent.Referent)

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -33,6 +33,7 @@ module Unison.Codebase
     isType,
 
     -- * Branches
+    Operations.branchExists,
     getBranchForHash,
     putBranch,
     causalHashesByPrefix,
@@ -47,12 +48,15 @@ module Unison.Codebase
 
     -- * Root branch
     getRootBranch,
+    Operations.getRootBranchExists,
+    Operations.expectRootCausalHash,
     putRootBranch,
     namesAtPath,
 
     -- * Patches
     patchExists,
-    putPatch,
+    Operations.getPatch,
+    Operations.putPatch,
 
     -- * Watches
     getWatch,

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -69,7 +69,7 @@ module Unison.Codebase
     Operations.getReflog,
 
     -- * Unambiguous hash length
-    hashLength,
+    Operations.hashLength,
     branchHashLength,
 
     -- * Dependents

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -133,7 +133,7 @@ import qualified Unison.Codebase.GitError as GitError
 import Unison.Codebase.Path
 import qualified Unison.Codebase.Path as Path
 import qualified Unison.Codebase.SqliteCodebase.Conversions as Cv
-import Unison.Codebase.SqliteCodebase.Operations (getDeclComponent)
+import Unison.Codebase.SqliteCodebase.Operations (dependentsImpl, getDeclComponent)
 import Unison.Codebase.SyncMode (SyncMode)
 import Unison.Codebase.Type
   ( Codebase (..),
@@ -394,11 +394,11 @@ componentReferencesForReference c = \case
 
 -- | Get the set of terms, type declarations, and builtin types that depend on the given term, type declaration, or
 -- builtin type.
-dependents :: Codebase m v a -> Queries.DependentsSelector -> Reference -> Sqlite.Transaction (Set Reference)
-dependents c selector r =
+dependents :: Queries.DependentsSelector -> Reference -> Sqlite.Transaction (Set Reference)
+dependents selector r =
   Set.union (Builtin.builtinTypeDependents r)
     . Set.map Reference.DerivedId
-    <$> dependentsImpl c selector r
+    <$> dependentsImpl selector r
 
 dependentsOfComponent :: Codebase m v a -> Hash -> Sqlite.Transaction (Set Reference)
 dependentsOfComponent c h =

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -38,7 +38,7 @@ module Unison.Codebase
     putBranch,
     SqliteCodebase.Operations.causalHashesByPrefix,
     lca,
-    beforeImpl,
+    SqliteCodebase.Operations.before,
     getShallowBranchAtPath,
     getShallowCausalAtPath,
     getShallowCausalForHash,

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -133,6 +133,7 @@ import qualified Unison.Codebase.GitError as GitError
 import Unison.Codebase.Path
 import qualified Unison.Codebase.Path as Path
 import qualified Unison.Codebase.SqliteCodebase.Conversions as Cv
+import Unison.Codebase.SqliteCodebase.Operations (getDeclComponent)
 import Unison.Codebase.SyncMode (SyncMode)
 import Unison.Codebase.Type
   ( Codebase (..),

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -66,7 +66,7 @@ module Unison.Codebase
     Queries.clearWatches,
 
     -- * Reflog
-    getReflog,
+    Operations.getReflog,
 
     -- * Unambiguous hash length
     hashLength,

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -257,10 +257,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
             getTypeDeclaration =
               CodebaseOps.getTypeDeclaration
 
-            getDeclComponent :: Hash -> Sqlite.Transaction (Maybe [Decl Symbol Ann])
-            getDeclComponent =
-              CodebaseOps.getDeclComponent
-
             getCycleLength :: Hash -> m (Maybe Reference.CycleSize)
             getCycleLength h =
               runTransaction (Ops.getCycleLen h)
@@ -453,7 +449,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
                   putTypeDeclaration,
                   putTypeDeclarationComponent,
                   getTermComponentWithTypes,
-                  getDeclComponent,
                   getComponentLength = getCycleLength,
                   getRootBranch = getRootBranch rootBranchCache,
                   getRootCausalHash,

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -340,10 +340,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
             patchExists h =
               runTransaction (CodebaseOps.patchExists h)
 
-            dependentsImpl :: Q.DependentsSelector -> Reference -> Sqlite.Transaction (Set Reference.Id)
-            dependentsImpl =
-              CodebaseOps.dependentsImpl
-
             dependentsOfComponentImpl :: Hash -> Sqlite.Transaction (Set Reference.Id)
             dependentsOfComponentImpl =
               CodebaseOps.dependentsOfComponentImpl
@@ -461,7 +457,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
                   getPatch,
                   putPatch,
                   patchExists,
-                  dependentsImpl,
                   dependentsOfComponentImpl,
                   syncFromDirectory,
                   syncToDirectory,

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -285,10 +285,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
             putTypeDeclarationComponent =
               CodebaseOps.putTypeDeclarationComponent termBuffer declBuffer
 
-            getRootCausalHash :: MonadIO m => m V2Branch.CausalHash
-            getRootCausalHash =
-              runTransaction Ops.expectRootCausalHash
-
             getShallowCausalForHash :: MonadIO m => V2Branch.CausalHash -> m (V2Branch.CausalBranch m)
             getShallowCausalForHash bh =
               V2Branch.hoistCausalBranch runTransaction <$> runTransaction (Ops.expectCausalBranchByCausalHash bh)
@@ -443,7 +439,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
                   getTermComponentWithTypes,
                   getComponentLength = getCycleLength,
                   getRootBranch = getRootBranch rootBranchCache,
-                  getRootCausalHash,
                   getRootBranchExists,
                   putRootBranch = putRootBranch rootBranchCache,
                   getShallowCausalForHash,

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -312,10 +312,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
               withRunInIO \runInIO ->
                 runInIO (runTransaction (CodebaseOps.putBranch (Branch.transform (Sqlite.unsafeIO . runInIO) branch)))
 
-            getPatch :: Branch.EditHash -> m (Maybe Patch)
-            getPatch h =
-              runTransaction (CodebaseOps.getPatch h)
-
             putPatch :: Branch.EditHash -> Patch -> m ()
             putPatch h p =
               runTransaction (CodebaseOps.putPatch h p)
@@ -430,7 +426,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
                   getShallowCausalForHash,
                   getBranchForHashImpl = getBranchForHash,
                   putBranch,
-                  getPatch,
                   putPatch,
                   patchExists,
                   syncFromDirectory,

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -342,10 +342,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
             termsMentioningTypeImpl r =
               runTransaction (CodebaseOps.termsMentioningTypeImpl getDeclType r)
 
-            hashLength :: m Int
-            hashLength =
-              runTransaction CodebaseOps.hashLength
-
             branchHashLength :: m Int
             branchHashLength =
               runTransaction CodebaseOps.branchHashLength
@@ -409,7 +405,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
                   getWatch,
                   termsOfTypeImpl,
                   termsMentioningTypeImpl,
-                  hashLength,
                   termReferencesByPrefix,
                   typeReferencesByPrefix = declReferencesByPrefix,
                   termReferentsByPrefix = referentsByPrefix,

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -333,10 +333,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
             referentsByPrefix sh =
               runTransaction (CodebaseOps.referentsByPrefix getDeclType sh)
 
-            sqlLca :: Branch.CausalHash -> Branch.CausalHash -> m (Maybe (Branch.CausalHash))
-            sqlLca h1 h2 =
-              runTransaction (CodebaseOps.sqlLca h1 h2)
-
             beforeImpl :: Maybe (Branch.CausalHash -> Branch.CausalHash -> m Bool)
             beforeImpl =
               Just \l r ->
@@ -377,7 +373,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
                   termsOfTypeImpl,
                   termsMentioningTypeImpl,
                   termReferentsByPrefix = referentsByPrefix,
-                  lcaImpl = Just sqlLca,
                   beforeImpl,
                   namesAtPath,
                   updateNameLookup,

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -334,10 +334,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
             getWatch k r =
               runTransaction (CodebaseOps.getWatch getDeclType k r)
 
-            putWatch :: UF.WatchKind -> Reference.Id -> Term Symbol Ann -> m ()
-            putWatch k r tm =
-              runTransaction (CodebaseOps.putWatch k r tm)
-
             clearWatches :: m ()
             clearWatches =
               runTransaction CodebaseOps.clearWatches
@@ -418,7 +414,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
                   viewRemoteBranch',
                   pushGitBranch = \repo opts action -> withConn \conn -> pushGitBranch conn repo opts action,
                   getWatch,
-                  putWatch,
                   clearWatches,
                   getReflog,
                   termsOfTypeImpl,

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -330,10 +330,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
             termsMentioningTypeImpl r =
               runTransaction (CodebaseOps.termsMentioningTypeImpl getDeclType r)
 
-            declReferencesByPrefix :: ShortHash -> m (Set Reference.Id)
-            declReferencesByPrefix sh =
-              runTransaction (CodebaseOps.declReferencesByPrefix sh)
-
             referentsByPrefix :: ShortHash -> m (Set Referent.Id)
             referentsByPrefix sh =
               runTransaction (CodebaseOps.referentsByPrefix getDeclType sh)
@@ -385,7 +381,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
                   getWatch,
                   termsOfTypeImpl,
                   termsMentioningTypeImpl,
-                  typeReferencesByPrefix = declReferencesByPrefix,
                   termReferentsByPrefix = referentsByPrefix,
                   causalHashesByPrefix,
                   lcaImpl = Just sqlLca,

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -56,7 +56,6 @@ import qualified Unison.Codebase.Init as Codebase
 import qualified Unison.Codebase.Init.CreateCodebaseError as Codebase1
 import Unison.Codebase.Init.OpenCodebaseError (OpenCodebaseError (..))
 import qualified Unison.Codebase.Init.OpenCodebaseError as Codebase1
-import Unison.Codebase.Patch (Patch)
 import Unison.Codebase.Path (Path)
 import Unison.Codebase.ShortCausalHash (ShortCausalHash)
 import Unison.Codebase.SqliteCodebase.Branch.Cache (newBranchCache)
@@ -312,10 +311,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
               withRunInIO \runInIO ->
                 runInIO (runTransaction (CodebaseOps.putBranch (Branch.transform (Sqlite.unsafeIO . runInIO) branch)))
 
-            putPatch :: Branch.EditHash -> Patch -> m ()
-            putPatch h p =
-              runTransaction (CodebaseOps.putPatch h p)
-
             patchExists :: Branch.EditHash -> m Bool
             patchExists h =
               runTransaction (CodebaseOps.patchExists h)
@@ -426,7 +421,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
                   getShallowCausalForHash,
                   getBranchForHashImpl = getBranchForHash,
                   putBranch,
-                  putPatch,
                   patchExists,
                   syncFromDirectory,
                   syncToDirectory,

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -257,10 +257,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
             getTypeDeclaration =
               CodebaseOps.getTypeDeclaration
 
-            getCycleLength :: Hash -> m (Maybe Reference.CycleSize)
-            getCycleLength h =
-              runTransaction (Ops.getCycleLen h)
-
             -- putTermComponent :: MonadIO m => Hash -> [(Term Symbol Ann, Type Symbol Ann)] -> m ()
             -- putTerms :: MonadIO m => Map Reference.Id (Term Symbol Ann, Type Symbol Ann) -> m () -- dies horribly if missing dependencies?
 
@@ -433,7 +429,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
                   putTypeDeclaration,
                   putTypeDeclarationComponent,
                   getTermComponentWithTypes,
-                  getComponentLength = getCycleLength,
                   getRootBranch = getRootBranch rootBranchCache,
                   putRootBranch = putRootBranch rootBranchCache,
                   getShallowCausalForHash,

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -334,10 +334,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
             getWatch k r =
               runTransaction (CodebaseOps.getWatch getDeclType k r)
 
-            clearWatches :: m ()
-            clearWatches =
-              runTransaction CodebaseOps.clearWatches
-
             getReflog :: Int -> m [Reflog.Entry CausalHash Text]
             getReflog numEntries = runTransaction $ Ops.getReflog numEntries
 
@@ -414,7 +410,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
                   viewRemoteBranch',
                   pushGitBranch = \repo opts action -> withConn \conn -> pushGitBranch conn repo opts action,
                   getWatch,
-                  clearWatches,
                   getReflog,
                   termsOfTypeImpl,
                   termsMentioningTypeImpl,

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -311,10 +311,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
               withRunInIO \runInIO ->
                 runInIO (runTransaction (CodebaseOps.putBranch (Branch.transform (Sqlite.unsafeIO . runInIO) branch)))
 
-            patchExists :: Branch.EditHash -> m Bool
-            patchExists h =
-              runTransaction (CodebaseOps.patchExists h)
-
             syncFromDirectory :: Codebase1.CodebasePath -> SyncMode -> Branch m -> m ()
             syncFromDirectory srcRoot _syncMode b =
               withConnection (debugName ++ ".sync.src") srcRoot \srcConn ->
@@ -421,7 +417,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
                   getShallowCausalForHash,
                   getBranchForHashImpl = getBranchForHash,
                   putBranch,
-                  patchExists,
                   syncFromDirectory,
                   syncToDirectory,
                   viewRemoteBranch',

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -330,10 +330,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
             termsMentioningTypeImpl r =
               runTransaction (CodebaseOps.termsMentioningTypeImpl getDeclType r)
 
-            termReferencesByPrefix :: ShortHash -> m (Set Reference.Id)
-            termReferencesByPrefix sh =
-              runTransaction (CodebaseOps.termReferencesByPrefix sh)
-
             declReferencesByPrefix :: ShortHash -> m (Set Reference.Id)
             declReferencesByPrefix sh =
               runTransaction (CodebaseOps.declReferencesByPrefix sh)
@@ -389,7 +385,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
                   getWatch,
                   termsOfTypeImpl,
                   termsMentioningTypeImpl,
-                  termReferencesByPrefix,
                   typeReferencesByPrefix = declReferencesByPrefix,
                   termReferentsByPrefix = referentsByPrefix,
                   causalHashesByPrefix,

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -340,10 +340,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
             patchExists h =
               runTransaction (CodebaseOps.patchExists h)
 
-            dependentsOfComponentImpl :: Hash -> Sqlite.Transaction (Set Reference.Id)
-            dependentsOfComponentImpl =
-              CodebaseOps.dependentsOfComponentImpl
-
             syncFromDirectory :: Codebase1.CodebasePath -> SyncMode -> Branch m -> m ()
             syncFromDirectory srcRoot _syncMode b =
               withConnection (debugName ++ ".sync.src") srcRoot \srcConn ->
@@ -457,7 +453,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
                   getPatch,
                   putPatch,
                   patchExists,
-                  dependentsOfComponentImpl,
                   syncFromDirectory,
                   syncToDirectory,
                   viewRemoteBranch',

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -330,10 +330,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
             termsMentioningTypeImpl r =
               runTransaction (CodebaseOps.termsMentioningTypeImpl getDeclType r)
 
-            branchHashLength :: m Int
-            branchHashLength =
-              runTransaction CodebaseOps.branchHashLength
-
             termReferencesByPrefix :: ShortHash -> m (Set Reference.Id)
             termReferencesByPrefix sh =
               runTransaction (CodebaseOps.termReferencesByPrefix sh)
@@ -396,7 +392,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
                   termReferencesByPrefix,
                   typeReferencesByPrefix = declReferencesByPrefix,
                   termReferentsByPrefix = referentsByPrefix,
-                  branchHashLength,
                   causalHashesByPrefix,
                   lcaImpl = Just sqlLca,
                   beforeImpl,

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -334,9 +334,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
             getWatch k r =
               runTransaction (CodebaseOps.getWatch getDeclType k r)
 
-            getReflog :: Int -> m [Reflog.Entry CausalHash Text]
-            getReflog numEntries = runTransaction $ Ops.getReflog numEntries
-
             termsOfTypeImpl :: Reference -> m (Set Referent.Id)
             termsOfTypeImpl r =
               runTransaction (CodebaseOps.termsOfTypeImpl getDeclType r)
@@ -410,7 +407,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
                   viewRemoteBranch',
                   pushGitBranch = \repo opts action -> withConn \conn -> pushGitBranch conn repo opts action,
                   getWatch,
-                  getReflog,
                   termsOfTypeImpl,
                   termsMentioningTypeImpl,
                   hashLength,

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -330,10 +330,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
                     Sqlite.runWriteTransaction destConn \runDest -> do
                       syncInternal (syncProgress progressStateRef) runSrc runDest b
 
-            watches :: UF.WatchKind -> m [Reference.Id]
-            watches w =
-              runTransaction (CodebaseOps.watches w)
-
             getWatch :: UF.WatchKind -> Reference.Id -> m (Maybe (Term Symbol Ann))
             getWatch k r =
               runTransaction (CodebaseOps.getWatch getDeclType k r)
@@ -421,7 +417,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
                   syncToDirectory,
                   viewRemoteBranch',
                   pushGitBranch = \repo opts action -> withConn \conn -> pushGitBranch conn repo opts action,
-                  watches,
                   getWatch,
                   putWatch,
                   clearWatches,

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -67,7 +67,6 @@ import Unison.Codebase.Type (LocalOrRemote (..), PushGitBranchOpts (..))
 import qualified Unison.Codebase.Type as C
 import Unison.DataDeclaration (Decl)
 import Unison.Hash (Hash)
-import Unison.Names.Scoped (ScopedNames)
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.Reference (Reference)
@@ -331,10 +330,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
             referentsByPrefix sh =
               runTransaction (CodebaseOps.referentsByPrefix getDeclType sh)
 
-            namesAtPath :: Path -> m ScopedNames
-            namesAtPath path =
-              runTransaction (CodebaseOps.namesAtPath path)
-
             updateNameLookup :: Path -> Maybe BranchHash -> BranchHash -> m ()
             updateNameLookup pathPrefix fromBH toBH =
               runTransaction (CodebaseOps.updateNameLookupIndex getDeclType pathPrefix fromBH toBH)
@@ -366,7 +361,6 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
                   termsOfTypeImpl,
                   termsMentioningTypeImpl,
                   termReferentsByPrefix = referentsByPrefix,
-                  namesAtPath,
                   updateNameLookup,
                   withConnection = withConn,
                   withConnectionIO = withConnection debugName root

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -459,6 +459,9 @@ getPatch h =
     patch <- lift (Ops.expectPatch patchId)
     pure (Cv.patch2to1 patch)
 
+-- | Put a patch into the codebase.
+--
+-- Note that 'putBranch' may also put patches.
 putPatch :: Branch.EditHash -> Patch -> Transaction ()
 putPatch h p =
   void $ Ops.savePatch v2HashHandle (Cv.patchHash1to2 h) (Cv.patch1to2 p)

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -616,6 +616,9 @@ before h1 h2 =
 
 -- | Construct a 'ScopedNames' which can produce names which are relative to the provided
 -- Path.
+--
+-- NOTE: this method requires an up-to-date name lookup index, which is
+-- currently not kept up-to-date automatically (because it's slow to do so).
 namesAtPath ::
   Path ->
   Transaction ScopedNames

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -594,6 +594,10 @@ causalHashesByPrefix sh = do
   cs <- Ops.causalHashesByPrefix (Cv.sch1to2 sh)
   pure $ Set.map (Causal.CausalHash . unCausalHash) cs
 
+-- returns `Nothing` to not implemented, fallback to in-memory
+--    also `Nothing` if no LCA
+-- The result is undefined if the two hashes are not in the codebase.
+-- Use `Codebase.lca` which wraps this in a nice API.
 sqlLca :: Branch.CausalHash -> Branch.CausalHash -> Transaction (Maybe Branch.CausalHash)
 sqlLca h1 h2 = do
   h3 <- Ops.lca (Cv.causalHash1to2 h1) (Cv.causalHash1to2 h2)

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -519,9 +519,6 @@ putWatch k r@(Reference.Id h _i) tm =
 standardWatchKinds :: [UF.WatchKind]
 standardWatchKinds = [UF.RegularWatch, UF.TestWatch]
 
-clearWatches :: Transaction ()
-clearWatches = Ops.clearWatches
-
 termsOfTypeImpl ::
   -- | A 'getDeclType'-like lookup, possibly backed by a cache.
   (C.Reference.Reference -> Transaction CT.ConstructorType) ->

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -479,10 +479,11 @@ dependentsOfComponentImpl :: Hash -> Transaction (Set Reference.Id)
 dependentsOfComponentImpl h =
   Set.map Cv.referenceid2to1 <$> Ops.dependentsOfComponent h
 
+-- | @watches k@ returns all of the references @r@ that were previously put by a @putWatch k r t@. @t@ can be
+-- retrieved by @getWatch k r@.
 watches :: UF.WatchKind -> Transaction [Reference.Id]
 watches w =
-  Ops.listWatches (Cv.watchKind1to2 w)
-    <&> fmap Cv.referenceid2to1
+  Ops.listWatches (Cv.watchKind1to2 w) <&> fmap Cv.referenceid2to1
 
 getWatch ::
   -- | A 'getDeclType'-like lookup, possibly backed by a cache.

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -9,6 +9,7 @@ module Unison.Codebase.SqliteCodebase.Operations where
 
 import Control.Lens (ifor)
 import Data.Bifunctor (second)
+import Data.Maybe (fromJust)
 import Data.Bitraversable (bitraverse)
 import Data.Either.Extra ()
 import qualified Data.List as List
@@ -608,9 +609,10 @@ termExists, declExists :: Hash -> Transaction Bool
 termExists = fmap isJust . Q.loadObjectIdForPrimaryHash
 declExists = termExists
 
-before :: Branch.CausalHash -> Branch.CausalHash -> Transaction (Maybe Bool)
+-- `before b1 b2` is undefined if `b2` not in the codebase
+before :: Branch.CausalHash -> Branch.CausalHash -> Transaction Bool
 before h1 h2 =
-  Ops.before (Cv.causalHash1to2 h1) (Cv.causalHash1to2 h2)
+  fromJust <$> Ops.before (Cv.causalHash1to2 h1) (Cv.causalHash1to2 h2)
 
 -- | Construct a 'ScopedNames' which can produce names which are relative to the provided
 -- Path.

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -537,6 +537,7 @@ termsMentioningTypeImpl doGetDeclType r =
   Ops.termsMentioningType (Cv.reference1to2 r)
     >>= Set.traverse (Cv.referentid2to1 doGetDeclType)
 
+-- | The number of base32 characters needed to distinguish any two references in the codebase.
 hashLength :: Transaction Int
 hashLength = pure 10
 

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -541,6 +541,7 @@ termsMentioningTypeImpl doGetDeclType r =
 hashLength :: Transaction Int
 hashLength = pure 10
 
+-- | The number of base32 characters needed to distinguish any two branch in the codebase.
 branchHashLength :: Transaction Int
 branchHashLength = pure 10
 

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -466,6 +466,7 @@ putPatch :: Branch.EditHash -> Patch -> Transaction ()
 putPatch h p =
   void $ Ops.savePatch v2HashHandle (Cv.patchHash1to2 h) (Cv.patch1to2 p)
 
+-- | Check whether the given patch exists in the codebase.
 patchExists :: Branch.EditHash -> Transaction Bool
 patchExists h = fmap isJust $ Q.loadPatchObjectIdForPrimaryHash (Cv.patchHash1to2 h)
 

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -445,8 +445,9 @@ putBranch :: Branch Transaction -> Transaction ()
 putBranch =
   void . Ops.saveBranch v2HashHandle . Cv.causalbranch1to2
 
-isCausalHash :: Branch.CausalHash -> Transaction Bool
-isCausalHash (Causal.CausalHash h) =
+-- | Check whether the given branch exists in the codebase.
+branchExists :: Branch.CausalHash -> Transaction Bool
+branchExists (Causal.CausalHash h) =
   Q.loadHashIdByHash h >>= \case
     Nothing -> pure False
     Just hId -> Q.isCausalHash hId

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -498,6 +498,16 @@ getWatch doGetDeclType k r@(Reference.Id h _i) =
       lift (Cv.term2to1 h doGetDeclType watch)
     else pure Nothing
 
+-- | @putWatch k r t@ puts a watch of kind @k@, with hash-of-expression @r@ and decompiled result @t@ into the
+-- codebase.
+--
+-- For example, in the watch expression below, @k@ is 'WK.Regular', @r@ is the hash of @x@, and @t@ is @7@.
+--
+-- @
+-- > x = 3 + 4
+--   ⧩
+--   7
+-- @
 putWatch :: UF.WatchKind -> Reference.Id -> Term Symbol Ann -> Transaction ()
 putWatch k r@(Reference.Id h _i) tm =
   when (elem k standardWatchKinds) do

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -557,8 +557,9 @@ defnReferencesByPrefix ot (ShortHash.ShortHash prefix (fmap Cv.shortHashSuffix1t
 termReferencesByPrefix :: ShortHash -> Transaction (Set Reference.Id)
 termReferencesByPrefix = defnReferencesByPrefix OT.TermComponent
 
-declReferencesByPrefix :: ShortHash -> Transaction (Set Reference.Id)
-declReferencesByPrefix = defnReferencesByPrefix OT.DeclComponent
+-- | Get the set of type declarations whose hash matches the given prefix.
+typeReferencesByPrefix :: ShortHash -> Transaction (Set Reference.Id)
+typeReferencesByPrefix = defnReferencesByPrefix OT.DeclComponent
 
 referentsByPrefix ::
   -- | A 'getDeclType'-like lookup, possibly backed by a cache.

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -414,6 +414,7 @@ uncachedLoadRootBranch branchCache getDeclType = do
   causal2 <- Ops.expectRootCausal
   Cv.causalbranch2to1 branchCache getDeclType causal2
 
+-- | Get whether the root branch exists.
 getRootBranchExists :: Transaction Bool
 getRootBranchExists =
   isJust <$> Ops.loadRootCausalHash

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -585,6 +585,7 @@ referentsByPrefix doGetDeclType (SH.ShortHash prefix (fmap Cv.shortHashSuffix1to
         ]
   pure . Set.fromList $ termReferents <> declReferents
 
+-- | Get the set of branches whose hash matches the given prefix.
 causalHashesByPrefix :: ShortCausalHash -> Transaction (Set Branch.CausalHash)
 causalHashesByPrefix sh = do
   -- given that a Branch is shallow, it's really `CausalHash` that you'd

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -16,7 +16,6 @@ where
 import qualified U.Codebase.Branch as V2
 import U.Codebase.HashTags (BranchHash)
 import qualified U.Codebase.Reference as V2
-import qualified U.Codebase.Reflog as Reflog
 import Unison.Codebase.Branch (Branch)
 import qualified Unison.Codebase.Branch as Branch
 import qualified Unison.Codebase.Editor.Git as Git
@@ -101,8 +100,6 @@ data Codebase m v a = Codebase
     pushGitBranch :: forall e. WriteGitRepo -> PushGitBranchOpts -> (Branch m -> m (Either e (Branch m))) -> m (Either GitError (Either e (Branch m))),
     -- | @getWatch k r@ returns watch result @t@ that was previously put by @putWatch k r t@.
     getWatch :: WK.WatchKind -> Reference.Id -> m (Maybe (Term v a)),
-    -- | Gets the specified number of reflog entries in chronological order, most recent first.
-    getReflog :: Int -> m [Reflog.Entry V2.CausalHash Text],
     -- | Get the set of user-defined terms-or-constructors that have the given type.
     termsOfTypeImpl :: Reference -> m (Set Referent.Id),
     -- | Get the set of user-defined terms-or-constructors mention the given type anywhere in their signature.

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -101,8 +101,6 @@ data Codebase m v a = Codebase
     pushGitBranch :: forall e. WriteGitRepo -> PushGitBranchOpts -> (Branch m -> m (Either e (Branch m))) -> m (Either GitError (Either e (Branch m))),
     -- | @getWatch k r@ returns watch result @t@ that was previously put by @putWatch k r t@.
     getWatch :: WK.WatchKind -> Reference.Id -> m (Maybe (Term v a)),
-    -- | Delete all watches that were put by 'putWatch'.
-    clearWatches :: m (),
     -- | Gets the specified number of reflog entries in chronological order, most recent first.
     getReflog :: Int -> m [Reflog.Entry V2.CausalHash Text],
     -- | Get the set of user-defined terms-or-constructors that have the given type.

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -29,7 +29,6 @@ import Unison.CodebasePath (CodebasePath)
 import qualified Unison.ConstructorType as CT
 import Unison.DataDeclaration (Decl)
 import Unison.Hash (Hash)
-import Unison.Names.Scoped (ScopedNames)
 import Unison.Prelude
 import Unison.Reference (Reference)
 import qualified Unison.Reference as Reference
@@ -105,11 +104,6 @@ data Codebase m v a = Codebase
     termsMentioningTypeImpl :: Reference -> m (Set Referent.Id),
     -- | Get the set of user-defined terms-or-constructors whose hash matches the given prefix.
     termReferentsByPrefix :: ShortHash -> m (Set Referent.Id),
-    -- Use the name lookup index to build a 'Names' for all names found within 'Path' of the current root namespace.
-    --
-    -- NOTE: this method requires an up-to-date name lookup index, which is
-    -- currently not kept up-to-date automatically (because it's slow to do so).
-    namesAtPath :: Path -> m ScopedNames,
     -- Updates the root namespace names index from an old BranchHash to a new one.
     -- This isn't run automatically because it can be a bit slow.
     updateNameLookup ::

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -93,8 +93,6 @@ data Codebase m v a = Codebase
     --
     -- The terms and type declarations that a branch references must already exist in the codebase.
     putBranch :: Branch m -> m (),
-    -- | Check whether the given branch exists in the codebase.
-    branchExists :: Branch.CausalHash -> m Bool,
     -- | Get a patch from the codebase.
     getPatch :: Branch.EditHash -> m (Maybe Patch),
     -- | Put a patch into the codebase.

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -23,7 +23,6 @@ import qualified Unison.Codebase.Editor.Git as Git
 import Unison.Codebase.Editor.RemoteRepo (ReadGitRemoteNamespace, ReadGitRepo, WriteGitRepo)
 import Unison.Codebase.GitError (GitCodebaseError, GitProtocolError)
 import Unison.Codebase.Init.OpenCodebaseError (OpenCodebaseError (..))
-import Unison.Codebase.Patch (Patch)
 import Unison.Codebase.Path (Path)
 import Unison.Codebase.ShortCausalHash (ShortCausalHash)
 import Unison.Codebase.SqliteCodebase.GitError (GitSqliteCodebaseError (..))
@@ -93,10 +92,6 @@ data Codebase m v a = Codebase
     --
     -- The terms and type declarations that a branch references must already exist in the codebase.
     putBranch :: Branch m -> m (),
-    -- | Put a patch into the codebase.
-    --
-    -- Note that 'putBranch' may also put patches.
-    putPatch :: Branch.EditHash -> Patch -> m (),
     -- | Check whether the given patch exists in the codebase.
     patchExists :: Branch.EditHash -> m Bool,
     -- | Copy a branch and all of its dependencies from the given codebase into this one.

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -23,7 +23,6 @@ import Unison.Codebase.Editor.RemoteRepo (ReadGitRemoteNamespace, ReadGitRepo, W
 import Unison.Codebase.GitError (GitCodebaseError, GitProtocolError)
 import Unison.Codebase.Init.OpenCodebaseError (OpenCodebaseError (..))
 import Unison.Codebase.Path (Path)
-import Unison.Codebase.ShortCausalHash (ShortCausalHash)
 import Unison.Codebase.SqliteCodebase.GitError (GitSqliteCodebaseError (..))
 import Unison.Codebase.SyncMode (SyncMode)
 import Unison.CodebasePath (CodebasePath)
@@ -106,8 +105,6 @@ data Codebase m v a = Codebase
     termsMentioningTypeImpl :: Reference -> m (Set Referent.Id),
     -- | Get the set of user-defined terms-or-constructors whose hash matches the given prefix.
     termReferentsByPrefix :: ShortHash -> m (Set Referent.Id),
-    -- | Get the set of branches whose hash matches the given prefix.
-    causalHashesByPrefix :: ShortCausalHash -> m (Set Branch.CausalHash),
     -- returns `Nothing` to not implemented, fallback to in-memory
     --    also `Nothing` if no LCA
     -- The result is undefined if the two hashes are not in the codebase.

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -110,8 +110,6 @@ data Codebase m v a = Codebase
     typeReferencesByPrefix :: ShortHash -> m (Set Reference.Id),
     -- | Get the set of user-defined terms-or-constructors whose hash matches the given prefix.
     termReferentsByPrefix :: ShortHash -> m (Set Referent.Id),
-    -- | The number of base32 characters needed to distinguish any two branch in the codebase.
-    branchHashLength :: m Int,
     -- | Get the set of branches whose hash matches the given prefix.
     causalHashesByPrefix :: ShortCausalHash -> m (Set Branch.CausalHash),
     -- returns `Nothing` to not implemented, fallback to in-memory

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -105,11 +105,6 @@ data Codebase m v a = Codebase
     termsMentioningTypeImpl :: Reference -> m (Set Referent.Id),
     -- | Get the set of user-defined terms-or-constructors whose hash matches the given prefix.
     termReferentsByPrefix :: ShortHash -> m (Set Referent.Id),
-    -- returns `Nothing` to not implemented, fallback to in-memory
-    --    also `Nothing` if no LCA
-    -- The result is undefined if the two hashes are not in the codebase.
-    -- Use `Codebase.lca` which wraps this in a nice API.
-    lcaImpl :: Maybe (Branch.CausalHash -> Branch.CausalHash -> m (Maybe Branch.CausalHash)),
     -- `beforeImpl` returns `Nothing` if not implemented by the codebase
     -- `beforeImpl b1 b2` is undefined if `b2` not in the codebase
     --

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -79,7 +79,6 @@ data Codebase m v a = Codebase
     putTypeDeclarationComponent :: Hash -> [Decl v a] -> Sqlite.Transaction (),
     -- getTermComponent :: Hash -> m (Maybe [Term v a]),
     getTermComponentWithTypes :: Hash -> Sqlite.Transaction (Maybe [(Term v a, Type v a)]),
-    getComponentLength :: Hash -> m (Maybe Reference.CycleSize),
     -- | Get the root branch.
     getRootBranch :: m (Branch m),
     -- | Like 'putBranch', but also adjusts the root branch pointer afterwards.

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -93,8 +93,6 @@ data Codebase m v a = Codebase
     --
     -- The terms and type declarations that a branch references must already exist in the codebase.
     putBranch :: Branch m -> m (),
-    -- | Get a patch from the codebase.
-    getPatch :: Branch.EditHash -> m (Maybe Patch),
     -- | Put a patch into the codebase.
     --
     -- Note that 'putBranch' may also put patches.

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -104,8 +104,6 @@ data Codebase m v a = Codebase
     termsOfTypeImpl :: Reference -> m (Set Referent.Id),
     -- | Get the set of user-defined terms-or-constructors mention the given type anywhere in their signature.
     termsMentioningTypeImpl :: Reference -> m (Set Referent.Id),
-    -- | Get the set of type declarations whose hash matches the given prefix.
-    typeReferencesByPrefix :: ShortHash -> m (Set Reference.Id),
     -- | Get the set of user-defined terms-or-constructors whose hash matches the given prefix.
     termReferentsByPrefix :: ShortHash -> m (Set Referent.Id),
     -- | Get the set of branches whose hash matches the given prefix.

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -92,8 +92,6 @@ data Codebase m v a = Codebase
     --
     -- The terms and type declarations that a branch references must already exist in the codebase.
     putBranch :: Branch m -> m (),
-    -- | Check whether the given patch exists in the codebase.
-    patchExists :: Branch.EditHash -> m Bool,
     -- | Copy a branch and all of its dependencies from the given codebase into this one.
     syncFromDirectory :: CodebasePath -> SyncMode -> Branch m -> m (),
     -- | Copy a branch and all of its dependencies from this codebase into the given codebase.

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -104,8 +104,6 @@ data Codebase m v a = Codebase
     termsOfTypeImpl :: Reference -> m (Set Referent.Id),
     -- | Get the set of user-defined terms-or-constructors mention the given type anywhere in their signature.
     termsMentioningTypeImpl :: Reference -> m (Set Referent.Id),
-    -- | The number of base32 characters needed to distinguish any two references in the codebase.
-    hashLength :: m Int,
     -- | Get the set of user-defined terms whose hash matches the given prefix.
     termReferencesByPrefix :: ShortHash -> m (Set Reference.Id),
     -- | Get the set of type declarations whose hash matches the given prefix.

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -99,9 +99,6 @@ data Codebase m v a = Codebase
     viewRemoteBranch' :: forall r. ReadGitRemoteNamespace -> Git.GitBranchBehavior -> ((Branch m, CodebasePath) -> m r) -> m (Either GitError r),
     -- | Push the given branch to the given repo, and optionally set it as the root branch.
     pushGitBranch :: forall e. WriteGitRepo -> PushGitBranchOpts -> (Branch m -> m (Either e (Branch m))) -> m (Either GitError (Either e (Branch m))),
-    -- | @watches k@ returns all of the references @r@ that were previously put by a @putWatch k r t@. @t@ can be
-    -- retrieved by @getWatch k r@.
-    watches :: WK.WatchKind -> m [Reference.Id],
     -- | @getWatch k r@ returns watch result @t@ that was previously put by @putWatch k r t@.
     getWatch :: WK.WatchKind -> Reference.Id -> m (Maybe (Term v a)),
     -- | @putWatch k r t@ puts a watch of kind @k@, with hash-of-expression @r@ and decompiled result @t@ into the

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -17,7 +17,6 @@ import qualified U.Codebase.Branch as V2
 import U.Codebase.HashTags (BranchHash)
 import qualified U.Codebase.Reference as V2
 import qualified U.Codebase.Reflog as Reflog
-import qualified U.Codebase.Sqlite.Queries as Queries
 import Unison.Codebase.Branch (Branch)
 import qualified Unison.Codebase.Branch as Branch
 import qualified Unison.Codebase.Editor.Git as Git
@@ -109,9 +108,6 @@ data Codebase m v a = Codebase
     putPatch :: Branch.EditHash -> Patch -> m (),
     -- | Check whether the given patch exists in the codebase.
     patchExists :: Branch.EditHash -> m Bool,
-    -- | Get the set of user-defined terms and type declarations that depend on the given term, type declaration, or
-    -- builtin type.
-    dependentsImpl :: Queries.DependentsSelector -> Reference -> Sqlite.Transaction (Set Reference.Id),
     dependentsOfComponentImpl :: Hash -> Sqlite.Transaction (Set Reference.Id),
     -- | Copy a branch and all of its dependencies from the given codebase into this one.
     syncFromDirectory :: CodebasePath -> SyncMode -> Branch m -> m (),

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -104,8 +104,6 @@ data Codebase m v a = Codebase
     termsOfTypeImpl :: Reference -> m (Set Referent.Id),
     -- | Get the set of user-defined terms-or-constructors mention the given type anywhere in their signature.
     termsMentioningTypeImpl :: Reference -> m (Set Referent.Id),
-    -- | Get the set of user-defined terms whose hash matches the given prefix.
-    termReferencesByPrefix :: ShortHash -> m (Set Reference.Id),
     -- | Get the set of type declarations whose hash matches the given prefix.
     typeReferencesByPrefix :: ShortHash -> m (Set Reference.Id),
     -- | Get the set of user-defined terms-or-constructors whose hash matches the given prefix.

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -101,17 +101,6 @@ data Codebase m v a = Codebase
     pushGitBranch :: forall e. WriteGitRepo -> PushGitBranchOpts -> (Branch m -> m (Either e (Branch m))) -> m (Either GitError (Either e (Branch m))),
     -- | @getWatch k r@ returns watch result @t@ that was previously put by @putWatch k r t@.
     getWatch :: WK.WatchKind -> Reference.Id -> m (Maybe (Term v a)),
-    -- | @putWatch k r t@ puts a watch of kind @k@, with hash-of-expression @r@ and decompiled result @t@ into the
-    -- codebase.
-    --
-    -- For example, in the watch expression below, @k@ is 'WK.Regular', @r@ is the hash of @x@, and @t@ is @7@.
-    --
-    -- @
-    -- > x = 3 + 4
-    --   ⧩
-    --   7
-    -- @
-    putWatch :: WK.WatchKind -> Reference.Id -> Term v a -> m (),
     -- | Delete all watches that were put by 'putWatch'.
     clearWatches :: m (),
     -- | Gets the specified number of reflog entries in chronological order, most recent first.

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -80,8 +80,6 @@ data Codebase m v a = Codebase
     -- getTermComponent :: Hash -> m (Maybe [Term v a]),
     getTermComponentWithTypes :: Hash -> Sqlite.Transaction (Maybe [(Term v a, Type v a)]),
     getComponentLength :: Hash -> m (Maybe Reference.CycleSize),
-    -- | Get the root causal Hash.
-    getRootCausalHash :: m V2.CausalHash,
     -- | Get the root branch.
     getRootBranch :: m (Branch m),
     -- | Get whether the root branch exists.

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -82,8 +82,6 @@ data Codebase m v a = Codebase
     getComponentLength :: Hash -> m (Maybe Reference.CycleSize),
     -- | Get the root branch.
     getRootBranch :: m (Branch m),
-    -- | Get whether the root branch exists.
-    getRootBranchExists :: m Bool,
     -- | Like 'putBranch', but also adjusts the root branch pointer afterwards.
     putRootBranch ::
       Text -> -- Reason for the change, will be recorded in the reflog

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -108,7 +108,6 @@ data Codebase m v a = Codebase
     putPatch :: Branch.EditHash -> Patch -> m (),
     -- | Check whether the given patch exists in the codebase.
     patchExists :: Branch.EditHash -> m Bool,
-    dependentsOfComponentImpl :: Hash -> Sqlite.Transaction (Set Reference.Id),
     -- | Copy a branch and all of its dependencies from the given codebase into this one.
     syncFromDirectory :: CodebasePath -> SyncMode -> Branch m -> m (),
     -- | Copy a branch and all of its dependencies from this codebase into the given codebase.

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -105,11 +105,6 @@ data Codebase m v a = Codebase
     termsMentioningTypeImpl :: Reference -> m (Set Referent.Id),
     -- | Get the set of user-defined terms-or-constructors whose hash matches the given prefix.
     termReferentsByPrefix :: ShortHash -> m (Set Referent.Id),
-    -- `beforeImpl` returns `Nothing` if not implemented by the codebase
-    -- `beforeImpl b1 b2` is undefined if `b2` not in the codebase
-    --
-    --  Use `Codebase.before` which wraps this in a nice API.
-    beforeImpl :: Maybe (Branch.CausalHash -> Branch.CausalHash -> m Bool),
     -- Use the name lookup index to build a 'Names' for all names found within 'Path' of the current root namespace.
     --
     -- NOTE: this method requires an up-to-date name lookup index, which is

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -80,7 +80,6 @@ data Codebase m v a = Codebase
     putTypeDeclarationComponent :: Hash -> [Decl v a] -> Sqlite.Transaction (),
     -- getTermComponent :: Hash -> m (Maybe [Term v a]),
     getTermComponentWithTypes :: Hash -> Sqlite.Transaction (Maybe [(Term v a, Type v a)]),
-    getDeclComponent :: Hash -> Sqlite.Transaction (Maybe [Decl v a]),
     getComponentLength :: Hash -> m (Maybe Reference.CycleSize),
     -- | Get the root causal Hash.
     getRootCausalHash :: m V2.CausalHash,

--- a/unison-cli/src/Unison/Cli/MonadUtils.hs
+++ b/unison-cli/src/Unison/Cli/MonadUtils.hs
@@ -149,8 +149,11 @@ resolveShortCausalHash :: ShortCausalHash -> Cli (Branch IO)
 resolveShortCausalHash hash = do
   Cli.time "resolveShortCausalHash" do
     Cli.Env {codebase} <- ask
-    hashSet <- liftIO (Codebase.causalHashesByPrefix codebase hash)
-    len <- Cli.runTransaction Codebase.branchHashLength
+    (hashSet, len) <-
+      Cli.runTransaction do
+        hashSet <- Codebase.causalHashesByPrefix hash
+        len <- Codebase.branchHashLength
+        pure (hashSet, len)
     h <-
       Set.asSingleton hashSet & onNothing do
         Cli.returnEarly

--- a/unison-cli/src/Unison/Cli/MonadUtils.hs
+++ b/unison-cli/src/Unison/Cli/MonadUtils.hs
@@ -150,7 +150,7 @@ resolveShortCausalHash hash = do
   Cli.time "resolveShortCausalHash" do
     Cli.Env {codebase} <- ask
     hashSet <- liftIO (Codebase.causalHashesByPrefix codebase hash)
-    len <- liftIO (Codebase.branchHashLength codebase)
+    len <- Cli.runTransaction Codebase.branchHashLength
     h <-
       Set.asSingleton hashSet & onNothing do
         Cli.returnEarly

--- a/unison-cli/src/Unison/Cli/PrettyPrintUtils.hs
+++ b/unison-cli/src/Unison/Cli/PrettyPrintUtils.hs
@@ -6,8 +6,6 @@ module Unison.Cli.PrettyPrintUtils
   )
 where
 
-import Control.Lens
-import Control.Monad.Reader (ask)
 import Unison.Cli.Monad (Cli)
 import qualified Unison.Cli.Monad as Cli
 import qualified Unison.Cli.MonadUtils as Cli
@@ -21,15 +19,13 @@ import qualified Unison.PrettyPrintEnvDecl.Names as PPE
 import qualified Unison.Server.Backend as Backend
 
 prettyPrintEnvDecl :: NamesWithHistory -> Cli PPE.PrettyPrintEnvDecl
-prettyPrintEnvDecl ns = do
-  Cli.Env {codebase} <- ask
-  liftIO (Codebase.hashLength codebase) <&> (`PPE.fromNamesDecl` ns)
+prettyPrintEnvDecl ns =
+  Cli.runTransaction Codebase.hashLength <&> (`PPE.fromNamesDecl` ns)
 
 -- | Get a pretty print env decl for the current names at the current path.
 currentPrettyPrintEnvDecl :: (Path -> Backend.NameScoping) -> Cli PPE.PrettyPrintEnvDecl
 currentPrettyPrintEnvDecl scoping = do
-  Cli.Env {codebase} <- ask
   root' <- Cli.getRootBranch
   currentPath <- Cli.getCurrentPath
-  hqLen <- liftIO (Codebase.hashLength codebase)
+  hqLen <- Cli.runTransaction Codebase.hashLength
   pure $ Backend.getCurrentPrettyNames hqLen (scoping (Path.unabsolute currentPath)) root'

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -650,11 +650,10 @@ loop e = do
                 (BranchUtil.makeAddTermName (Path.convert dest) srcTerm srcMetadata)
               Cli.respond Success
             AliasTypeI src' dest' -> do
-              Cli.Env {codebase} <- ask
               src <- traverseOf _Right Cli.resolveSplit' src'
               srcTypes <-
                 either
-                  (liftIO . Backend.typeReferencesByShortHash codebase)
+                  (Cli.runTransaction . Backend.typeReferencesByShortHash)
                   Cli.getTypesAt
                   src
               srcType <-
@@ -2235,7 +2234,7 @@ resolveHQToLabeledDependencies = \case
     resolveHashOnly sh = do
       Cli.Env {codebase} <- ask
       terms <- liftIO (Backend.termReferentsByShortHash codebase sh)
-      types <- liftIO (Backend.typeReferencesByShortHash codebase sh)
+      types <- Cli.runTransaction (Backend.typeReferencesByShortHash sh)
       pure $ Set.map LD.referent terms <> Set.map LD.typeRef types
 
 doDisplay :: OutputLocation -> NamesWithHistory -> Term Symbol () -> Cli ()

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -2126,7 +2126,7 @@ handleTest TestInput {includeLibNamespace, showFailures, showSuccesses} = do
                   pure []
                 Right tm' -> do
                   -- After evaluation, cache the result of the test
-                  liftIO (Codebase.putWatch codebase WK.TestWatch rid tm')
+                  Cli.runTransaction (Codebase.putWatch WK.TestWatch rid tm')
                   Cli.respond $ TestIncrementalOutputEnd ppe (n, total) r tm'
                   pure [(r, tm')]
         r -> error $ "unpossible, tests can't be builtins: " <> show r
@@ -3009,7 +3009,7 @@ evalUnisonFile sandbox ppe unisonFile args = do
     for_ (Map.elems map) \(_loc, kind, hash, _src, value, isHit) ->
       when (not isHit) do
         let value' = Term.amap (\() -> Ann.External) value
-        liftIO (Codebase.putWatch codebase kind hash value')
+        Cli.runTransaction (Codebase.putWatch kind hash value')
     pure rs
 
 -- | Evaluate a single closed definition.
@@ -3033,9 +3033,8 @@ evalUnisonTermE sandbox ppe useCache tm = do
   when useCache do
     case r of
       Right tmr ->
-        liftIO $
+        Cli.runTransaction do
           Codebase.putWatch
-            codebase
             WK.RegularWatch
             (Hashing.hashClosedTerm tm)
             (Term.amap (const Ann.External) tmr)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1420,9 +1420,12 @@ loop e = do
               Cli.respond (IntegrityCheck r)
             DebugNameDiffI fromSCH toSCH -> do
               Cli.Env {codebase} <- ask
-              schLen <- Cli.runTransaction Codebase.branchHashLength
-              fromCHs <- liftIO $ Codebase.causalHashesByPrefix codebase fromSCH
-              toCHs <- liftIO $ Codebase.causalHashesByPrefix codebase toSCH
+              (schLen, fromCHs, toCHs) <- 
+                Cli.runTransaction do
+                  schLen <- Codebase.branchHashLength
+                  fromCHs <- Codebase.causalHashesByPrefix fromSCH
+                  toCHs <- Codebase.causalHashesByPrefix toSCH
+                  pure (schLen, fromCHs, toCHs)
               (fromCH, toCH) <- case (Set.toList fromCHs, Set.toList toCHs) of
                 ((_ : _ : _), _) -> Cli.returnEarly $ Output.BranchHashAmbiguous fromSCH (Set.map (SCH.fromHash schLen) fromCHs)
                 ([], _) -> Cli.returnEarly $ Output.NoBranchWithHash fromSCH

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -389,7 +389,7 @@ loop e = do
               Cli.Env {codebase} <- ask
               schLength <- liftIO (Codebase.branchHashLength codebase)
               let numEntriesToShow = 500
-              entries <- liftIO (Codebase.getReflog codebase numEntriesToShow) <&> fmap (first $ SCH.fromHash schLength)
+              entries <- Cli.runTransaction (Codebase.getReflog numEntriesToShow) <&> fmap (first $ SCH.fromHash schLength)
               let moreEntriesToLoad = length entries == numEntriesToShow
               let expandedEntries = List.unfoldr expandEntries (entries, Nothing, moreEntriesToLoad)
               let numberedEntries = expandedEntries <&> \(_time, hash, _reason) -> "#" <> SCH.toString hash

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1436,9 +1436,8 @@ loop e = do
                 traceM $ show name ++ ",Type," ++ Text.unpack (Reference.toText r)
               for_ (Relation.toList . Branch.deepTerms $ rootBranch0) \(r, name) ->
                 traceM $ show name ++ ",Term," ++ Text.unpack (Referent.toText r)
-            DebugClearWatchI {} -> do
-              Cli.Env {codebase} <- ask
-              liftIO (Codebase.clearWatches codebase)
+            DebugClearWatchI {} -> 
+              Cli.runTransaction Codebase.clearWatches
             DebugDoctorI {} -> do
               r <- Cli.runTransaction IntegrityCheck.integrityCheckFullCodebase
               Cli.respond (IntegrityCheck r)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/MetadataUtils.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/MetadataUtils.hs
@@ -124,7 +124,7 @@ resolveMetadata name = do
   Cli.Env {codebase} <- ask
   root' <- Cli.getRootBranch
   currentPath' <- Cli.getCurrentPath
-  schLength <- liftIO (Codebase.branchHashLength codebase)
+  schLength <- Cli.runTransaction Codebase.branchHashLength
 
   let ppe :: PPE.PrettyPrintEnv
       ppe =

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/NamespaceDiffUtils.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/NamespaceDiffUtils.hs
@@ -39,7 +39,7 @@ diffHelper before after =
     Cli.Env {codebase} <- ask
     rootBranch <- Cli.getRootBranch
     currentPath <- Cli.getCurrentPath
-    hqLength <- liftIO (Codebase.hashLength codebase)
+    hqLength <- Cli.runTransaction Codebase.hashLength
     diff <- liftIO (BranchDiff.diff0 before after)
     let (_parseNames, prettyNames0, _local) = Backend.namesForBranch rootBranch (Backend.AllNames $ Path.unabsolute currentPath)
     ppe <- PPE.suffixifiedPPE <$> prettyPrintEnvDecl (NamesWithHistory prettyNames0 mempty)

--- a/unison-cli/src/Unison/Codebase/Editor/Propagate.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Propagate.hs
@@ -144,12 +144,12 @@ propagateCtorMapping oldComponent newComponent =
 -- If the cycle is size 1 for old and new, then the type names need not be the same,
 -- and if the number of constructors is 1, then the constructor names need not
 -- be the same.
-genInitialCtorMapping :: Codebase IO Symbol Ann -> Names -> Map Reference Reference -> Sqlite.Transaction (Map Referent Referent)
-genInitialCtorMapping codebase rootNames initialTypeReplacements = do
+genInitialCtorMapping :: Names -> Map Reference Reference -> Sqlite.Transaction (Map Referent Referent)
+genInitialCtorMapping rootNames initialTypeReplacements = do
   let mappings :: (Reference, Reference) -> Sqlite.Transaction (Map Referent Referent)
       mappings (old, new) = do
-        old <- unhashTypeComponent codebase old
-        new <- fmap (over _2 (either Decl.toDataDecl id)) <$> unhashTypeComponent codebase new
+        old <- unhashTypeComponent old
+        new <- fmap (over _2 (either Decl.toDataDecl id)) <$> unhashTypeComponent new
         pure $ ctorMapping old new
   Map.unions <$> traverse mappings (Map.toList initialTypeReplacements)
   where
@@ -276,7 +276,7 @@ propagate patch b = case validatePatch patch of
       -- TODO: once patches can directly contain constructor replacements, this
       -- line can turn into a pure function that takes the subset of the term replacements
       -- in the patch which have a `Referent.Con` as their LHS.
-      initialCtorMappings <- genInitialCtorMapping codebase rootNames initialTypeReplacements
+      initialCtorMappings <- genInitialCtorMapping rootNames initialTypeReplacements
 
       order <- sortDependentsGraph codebase initialDirty entireBranch
 
@@ -327,7 +327,7 @@ propagate patch b = case validatePatch patch of
               doType :: Reference -> Sqlite.Transaction (Maybe (Edits Symbol), Set Reference)
               doType r = do
                 when debugMode $ traceM ("Rewriting type: " <> refName r)
-                componentMap <- unhashTypeComponent codebase r
+                componentMap <- unhashTypeComponent r
                 let componentMap' =
                       over _2 (Decl.updateDependencies typeReplacements)
                         <$> componentMap
@@ -560,16 +560,16 @@ typecheckFile codebase ambient file = do
   pure . fmap Right $ synthesizeFile' ambient (typeLookup <> Builtin.typeLookup) file
 
 -- TypecheckFile file ambient -> liftIO $ typecheck' ambient codebase file
-unhashTypeComponent :: Codebase IO Symbol Ann -> Reference -> Sqlite.Transaction (Map Symbol (Reference, Decl Symbol Ann))
-unhashTypeComponent codebase r = case Reference.toId r of
+unhashTypeComponent :: Reference -> Sqlite.Transaction (Map Symbol (Reference, Decl Symbol Ann))
+unhashTypeComponent r = case Reference.toId r of
   Nothing -> pure mempty
   Just id -> do
-    unhashed <- unhashTypeComponent' codebase (Reference.idToHash id)
+    unhashed <- unhashTypeComponent' (Reference.idToHash id)
     pure $ over _1 Reference.DerivedId <$> unhashed
 
-unhashTypeComponent' :: Codebase IO Symbol Ann -> Hash -> Sqlite.Transaction (Map Symbol (Reference.Id, Decl Symbol Ann))
-unhashTypeComponent' codebase h =
-  Codebase.getDeclComponent codebase h <&> foldMap \decls ->
+unhashTypeComponent' :: Hash -> Sqlite.Transaction (Map Symbol (Reference.Id, Decl Symbol Ann))
+unhashTypeComponent' h =
+  Codebase.getDeclComponent h <&> foldMap \decls ->
     unhash $ Map.fromList (Reference.componentFor h decls)
   where
     unhash =

--- a/unison-cli/src/Unison/Codebase/Editor/Propagate.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Propagate.hs
@@ -320,7 +320,7 @@ propagate patch b = case validatePatch patch of
                         -- plan to update the dependents of this component too
                         dependents <- case r of
                           Reference.Builtin {} -> Codebase.dependents Queries.ExcludeOwnComponent r
-                          Reference.Derived h _i -> Codebase.dependentsOfComponent codebase h
+                          Reference.Derived h _i -> Codebase.dependentsOfComponent h
                         let todo' = todo <> getOrdered dependents
                         collectEdits edits' seen' todo'
 

--- a/unison-cli/src/Unison/Codebase/TranscriptParser.hs
+++ b/unison-cli/src/Unison/Codebase/TranscriptParser.hs
@@ -38,6 +38,7 @@ import System.Exit (die)
 import qualified System.IO as IO
 import System.IO.Error (catchIOError)
 import qualified Text.Megaparsec as P
+import qualified U.Codebase.Sqlite.Operations as Operations
 import qualified Unison.Auth.CredentialManager as AuthN
 import qualified Unison.Auth.HTTPClient as AuthN
 import qualified Unison.Auth.Tokens as AuthN
@@ -233,7 +234,7 @@ run dir stanzas codebase runtime sbRuntime config ucmVersion baseURL = UnliftIO.
         "Running the provided transcript file...",
         ""
       ]
-  initialRootCausalHash <- Codebase.getRootCausalHash codebase
+  initialRootCausalHash <- Codebase.runTransaction codebase Operations.expectRootCausalHash
   rootVar <- newEmptyTMVarIO
   void $ Ki.fork scope do
     root <- Codebase.getRootBranch codebase

--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -141,7 +141,7 @@ completeWithinNamespace ::
   Path.Absolute ->
   m [System.Console.Haskeline.Completion.Completion]
 completeWithinNamespace compTypes query codebase currentPath = do
-  shortHashLen <- Codebase.hashLength codebase
+  shortHashLen <- Codebase.runTransaction codebase Codebase.hashLength
   b <- Codebase.getShallowBranchAtPath codebase (Path.unabsolute absQueryPath) Nothing
   currentBranchSuggestions <- do
     nib <- namesInBranch shortHashLen b

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -18,6 +18,7 @@ import qualified System.Console.Haskeline as Line
 import System.IO (hPutStrLn, stderr)
 import System.IO.Error (isDoesNotExistError)
 import Text.Pretty.Simple (pShow)
+import qualified U.Codebase.Sqlite.Operations as Operations
 import Unison.Auth.CredentialManager (newCredentialManager)
 import Unison.Auth.HTTPClient (AuthenticatedHttpClient)
 import qualified Unison.Auth.HTTPClient as AuthN
@@ -106,7 +107,7 @@ main ::
   IO ()
 main dir welcome initialPath (config, cancelConfig) initialInputs runtime sbRuntime codebase serverBaseUrl ucmVersion notifyBranchChange notifyPathChange = Ki.scoped \scope -> do
   rootVar <- newEmptyTMVarIO
-  initialRootCausalHash <- Codebase.getRootCausalHash codebase
+  initialRootCausalHash <- Codebase.runTransaction codebase Operations.expectRootCausalHash
   _ <- Ki.fork scope $ do
     root <- Codebase.getRootBranch codebase
     atomically $ do

--- a/unison-cli/src/Unison/CommandLine/Welcome.hs
+++ b/unison-cli/src/Unison/CommandLine/Welcome.hs
@@ -10,7 +10,6 @@ import Unison.Codebase.Editor.Input
 import Unison.Codebase.Editor.RemoteRepo (ReadRemoteNamespace (..), ReadShareRemoteNamespace (..))
 import Unison.Codebase.Path (Path)
 import qualified Unison.Codebase.Path as Path
-import qualified Unison.Codebase.SqliteCodebase.Operations as Codebase
 import qualified Unison.Codebase.SyncMode as SyncMode
 import qualified Unison.Codebase.Verbosity as Verbosity
 import Unison.NameSegment (NameSegment (NameSegment))

--- a/unison-cli/src/Unison/CommandLine/Welcome.hs
+++ b/unison-cli/src/Unison/CommandLine/Welcome.hs
@@ -10,6 +10,7 @@ import Unison.Codebase.Editor.Input
 import Unison.Codebase.Editor.RemoteRepo (ReadRemoteNamespace (..), ReadShareRemoteNamespace (..))
 import Unison.Codebase.Path (Path)
 import qualified Unison.Codebase.Path as Path
+import qualified Unison.Codebase.SqliteCodebase.Operations as Codebase
 import qualified Unison.Codebase.SyncMode as SyncMode
 import qualified Unison.Codebase.Verbosity as Verbosity
 import Unison.NameSegment (NameSegment (NameSegment))
@@ -103,7 +104,7 @@ toInput pretty =
 
 determineFirstStep :: DownloadBase -> Codebase IO v a -> IO Onboarding
 determineFirstStep downloadBase codebase = do
-  isEmptyCodebase <- Codebase.getRootBranchExists codebase
+  isEmptyCodebase <- Codebase.runTransaction codebase Codebase.getRootBranchExists
   case downloadBase of
     DownloadBase ns
       | isEmptyCodebase ->

--- a/unison-cli/src/Unison/LSP/FileAnalysis.hs
+++ b/unison-cli/src/Unison/LSP/FileAnalysis.hs
@@ -277,7 +277,7 @@ ppeForFile fileUri = do
   ppe <- PPE.suffixifiedPPE <$> globalPPE
   getFileAnalysis fileUri >>= \case
     Just (FileAnalysis {typecheckedFile = Just tf}) -> do
-      hl <- asks codebase >>= liftIO . Codebase.hashLength
+      hl <- asks codebase >>= \codebase -> liftIO (Codebase.runTransaction codebase Codebase.hashLength)
       let fileNames = UF.typecheckedToNames tf
       let filePPE = PPE.fromSuffixNames hl (NamesWithHistory.fromCurrentNames fileNames)
       pure (filePPE `PPE.addFallback` ppe)

--- a/unison-cli/src/Unison/LSP/UCMWorker.hs
+++ b/unison-cli/src/Unison/LSP/UCMWorker.hs
@@ -28,7 +28,7 @@ ucmWorker ppeVar parseNamesVar getLatestRoot getLatestPath = do
       loop (currentRoot, currentPath) = do
         Debug.debugM Debug.LSP "LSP path: " currentPath
         let parseNames = Backend.getCurrentParseNames (Backend.Within (Path.unabsolute currentPath)) currentRoot
-        hl <- liftIO $ Codebase.hashLength codebase
+        hl <- liftIO $ Codebase.runTransaction codebase Codebase.hashLength
         let ppe = PPE.fromNamesDecl hl parseNames
         atomically $ do
           writeTVar parseNamesVar parseNames

--- a/unison-cli/tests/Unison/Test/ClearCache.hs
+++ b/unison-cli/tests/Unison/Test/ClearCache.hs
@@ -16,7 +16,7 @@ test = scope "clearWatchCache" $
   for_ enumerate \codebaseFormat -> scope (show codebaseFormat) do
     c <- io $ Ucm.initCodebase codebaseFormat
     let listWatches = io $ Ucm.lowLevel c \c ->
-          Codebase.watches c WatchKind.RegularWatch
+          Codebase.runTransaction c (Codebase.watches WatchKind.RegularWatch)
 
     io $
       Ucm.runTranscript

--- a/unison-cli/tests/Unison/Test/GitSync.hs
+++ b/unison-cli/tests/Unison/Test/GitSync.hs
@@ -515,7 +515,7 @@ test =
                 ( \cb -> do
                     void . fmap (fromJust . sequence) $
                       traverse (Codebase.getWatch cb TestWatch)
-                        =<< Codebase.watches cb TestWatch
+                        =<< Codebase.runTransaction cb (Codebase.watches TestWatch)
                 ),
               gistTest fmt,
               pushPullBranchesTests fmt,

--- a/unison-share-api/package.yaml
+++ b/unison-share-api/package.yaml
@@ -84,6 +84,7 @@ default-extensions:
   - NumericUnderscores
   - OverloadedStrings
   - PatternSynonyms
+  - RankNTypes
   - ScopedTypeVariables
   - TupleSections
   - TypeApplications

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -781,10 +781,10 @@ data DefinitionResults v = DefinitionResults
   }
 
 expandShortCausalHash ::
-  Monad m => Codebase m v a -> ShortCausalHash -> Backend m Branch.CausalHash
+  MonadIO m => Codebase m v a -> ShortCausalHash -> Backend m Branch.CausalHash
 expandShortCausalHash codebase hash = do
   hashSet <- lift $ Codebase.causalHashesByPrefix codebase hash
-  len <- lift $ Codebase.branchHashLength codebase
+  len <- lift $ Codebase.runTransaction codebase Codebase.branchHashLength
   case Set.toList hashSet of
     [] -> throwError $ CouldntExpandBranchHash hash
     [h] -> pure h
@@ -1151,7 +1151,7 @@ resolveCausalHashV2 codebase h = case h of
   Just ch -> lift $ Codebase.getShallowCausalForHash codebase ch
 
 resolveRootBranchHash ::
-  Monad m => Maybe ShortCausalHash -> Codebase m v a -> Backend m (Branch m)
+  MonadIO m => Maybe ShortCausalHash -> Codebase m v a -> Backend m (Branch m)
 resolveRootBranchHash mayRoot codebase = case mayRoot of
   Nothing ->
     lift (Codebase.getRootBranch codebase)

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -586,9 +586,9 @@ typeReferencesByShortHash codebase sh = do
           B.intrinsicTypeReferences
   pure (fromBuiltins <> Set.map Reference.DerivedId fromCodebase)
 
-termReferencesByShortHash :: Monad m => Codebase m v a -> ShortHash -> m (Set Reference)
-termReferencesByShortHash codebase sh = do
-  fromCodebase <- Codebase.termReferencesByPrefix codebase sh
+termReferencesByShortHash :: ShortHash -> Sqlite.Transaction (Set Reference)
+termReferencesByShortHash sh = do
+  fromCodebase <- Codebase.termReferencesByPrefix sh
   let fromBuiltins =
         Set.filter
           (\r -> sh == Reference.toShortHash r)

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -1184,18 +1184,20 @@ definitionsBySuffixes codebase nameSearch includeCycles query = do
     let termRefsWithoutCycles = searchResultsToTermRefs results
     termRefs <- case includeCycles of
       IncludeCycles ->
-        Monoid.foldMapM
-          (Codebase.componentReferencesForReference codebase)
-          termRefsWithoutCycles
+        Codebase.runTransaction codebase do
+          Monoid.foldMapM
+            Codebase.componentReferencesForReference
+            termRefsWithoutCycles
       DontIncludeCycles -> pure termRefsWithoutCycles
     Map.foldMapM (\ref -> (ref,) <$> displayTerm codebase ref) termRefs
   types <- do
     let typeRefsWithoutCycles = searchResultsToTypeRefs results
     typeRefs <- case includeCycles of
       IncludeCycles ->
-        Monoid.foldMapM
-          (Codebase.componentReferencesForReference codebase)
-          typeRefsWithoutCycles
+        Codebase.runTransaction codebase do
+          Monoid.foldMapM
+            Codebase.componentReferencesForReference
+            typeRefsWithoutCycles
       DontIncludeCycles -> pure typeRefsWithoutCycles
     Codebase.runTransaction codebase (Map.foldMapM (\ref -> (ref,) <$> displayType codebase ref) typeRefs)
   pure (DefinitionResults terms types misses)

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -981,11 +981,11 @@ renderDoc ppe width rt codebase r = do
       r <- fmap hush . liftIO $ Rt.evaluateTerm' codeLookup cache ppes rt tm
       case r of
         Just tmr ->
-          Codebase.putWatch
-            codebase
-            WK.RegularWatch
-            (Hashing.hashClosedTerm tm)
-            (Term.amap (const mempty) tmr)
+          Codebase.runTransaction codebase do
+            Codebase.putWatch
+              WK.RegularWatch
+              (Hashing.hashClosedTerm tm)
+              (Term.amap (const mempty) tmr)
         Nothing -> pure ()
       pure $ r <&> Term.amap (const mempty)
 

--- a/unison-share-api/src/Unison/Server/Endpoints/FuzzyFind.hs
+++ b/unison-share-api/src/Unison/Server/Endpoints/FuzzyFind.hs
@@ -138,7 +138,7 @@ serveFuzzyFind ::
   Backend.Backend m [(FZF.Alignment, FoundResult)]
 serveFuzzyFind codebase mayRoot relativeTo limit typeWidth query = do
   let path = fromMaybe Path.empty relativeTo
-  rootHash <- traverse (Backend.expandShortCausalHash codebase) mayRoot
+  rootHash <- traverse (Backend.hoistBackend (Codebase.runTransaction codebase) . Backend.expandShortCausalHash) mayRoot
   rootCausal <- Backend.resolveCausalHashV2 codebase (Cv.causalHash1to2 <$> rootHash)
   (localNamesOnly, ppe) <- Backend.scopedNamesForBranchHash codebase (Just rootCausal) path
   relativeToCausal <- lift $ Codebase.getShallowCausalAtPath codebase path (Just rootCausal)

--- a/unison-share-api/src/Unison/Server/Endpoints/FuzzyFind.hs
+++ b/unison-share-api/src/Unison/Server/Endpoints/FuzzyFind.hs
@@ -167,10 +167,11 @@ serveFuzzyFind codebase mayRoot relativeTo limit typeWidth query = do
                 )
             )
               <$> Backend.termListEntry codebase relativeToBranch (ExactName (NameSegment n) (Cv.referent1to2 r))
-          Backend.FoundTypeRef r -> do
-            te <- Backend.typeListEntry codebase relativeToBranch (ExactName (NameSegment n) r)
-            let namedType = Backend.typeEntryToNamedType te
-            let typeName = Backend.bestNameForType @Symbol ppe (mayDefaultWidth typeWidth) r
-            typeHeader <- Codebase.runTransaction codebase (Backend.typeDeclHeader codebase ppe r)
-            let ft = FoundType typeName typeHeader namedType
-            pure (a, FoundTypeResult ft)
+          Backend.FoundTypeRef r ->
+            Codebase.runTransaction codebase do
+              te <- Backend.typeListEntry codebase relativeToBranch (ExactName (NameSegment n) r)
+              let namedType = Backend.typeEntryToNamedType te
+              let typeName = Backend.bestNameForType @Symbol ppe (mayDefaultWidth typeWidth) r
+              typeHeader <- Backend.typeDeclHeader codebase ppe r
+              let ft = FoundType typeName typeHeader namedType
+              pure (a, FoundTypeResult ft)

--- a/unison-share-api/src/Unison/Server/Endpoints/GetDefinitions.hs
+++ b/unison-share-api/src/Unison/Server/Endpoints/GetDefinitions.hs
@@ -19,6 +19,7 @@ import Servant.Docs
     noSamples,
   )
 import Unison.Codebase (Codebase)
+import qualified Unison.Codebase as Codebase
 import qualified Unison.Codebase.Path as Path
 import qualified Unison.Codebase.Runtime as Rt
 import Unison.Codebase.ShortCausalHash
@@ -124,7 +125,7 @@ serveDefinitions ::
   Backend.Backend IO DefinitionDisplayResults
 serveDefinitions rt codebase mayRoot relativePath hqns width suff =
   do
-    root <- traverse (Backend.expandShortCausalHash codebase) mayRoot
+    root <- traverse (Backend.hoistBackend (Codebase.runTransaction codebase) . Backend.expandShortCausalHash) mayRoot
     hqns
       & foldMapM
         ( Backend.prettyDefinitionsForHQName

--- a/unison-share-api/src/Unison/Server/Endpoints/NamespaceListing.hs
+++ b/unison-share-api/src/Unison/Server/Endpoints/NamespaceListing.hs
@@ -171,8 +171,11 @@ serve ::
   Backend.Backend IO NamespaceListing
 serve codebase maySCH mayRelativeTo mayNamespaceName = do
   useIndex <- asks Backend.useNamesIndex
-  mayRootHash <- traverse (Backend.expandShortCausalHash codebase) maySCH
-  codebaseRootHash <- liftIO $ Codebase.runTransaction codebase Operations.expectRootCausalHash
+  (mayRootHash, codebaseRootHash) <- 
+    Backend.hoistBackend (Codebase.runTransaction codebase) do
+      mayRootHash <- traverse Backend.expandShortCausalHash maySCH
+      codebaseRootHash <- lift Operations.expectRootCausalHash
+      pure (mayRootHash, codebaseRootHash)
 
   -- Relative and Listing Path resolution
   --

--- a/unison-share-api/src/Unison/Server/Endpoints/NamespaceListing.hs
+++ b/unison-share-api/src/Unison/Server/Endpoints/NamespaceListing.hs
@@ -27,6 +27,7 @@ import Servant.OpenApi ()
 import U.Codebase.Branch (NamespaceStats (..))
 import qualified U.Codebase.Branch as V2Causal
 import qualified U.Codebase.Causal as V2Causal
+import qualified U.Codebase.Sqlite.Operations as Operations
 import qualified U.Util.Hash as Hash
 import Unison.Codebase (Codebase)
 import qualified Unison.Codebase as Codebase
@@ -171,7 +172,7 @@ serve ::
 serve codebase maySCH mayRelativeTo mayNamespaceName = do
   useIndex <- asks Backend.useNamesIndex
   mayRootHash <- traverse (Backend.expandShortCausalHash codebase) maySCH
-  codebaseRootHash <- liftIO $ Codebase.getRootCausalHash codebase
+  codebaseRootHash <- liftIO $ Codebase.runTransaction codebase Operations.expectRootCausalHash
 
   -- Relative and Listing Path resolution
   --
@@ -202,7 +203,7 @@ serve codebase maySCH mayRelativeTo mayNamespaceName = do
     (False, Just rh) -> do
       serveFromBranch codebase path' (Cv.causalHash1to2 rh)
     (False, Nothing) -> do
-      ch <- liftIO $ Codebase.getRootCausalHash codebase
+      ch <- liftIO $ Codebase.runTransaction codebase Operations.expectRootCausalHash
       serveFromBranch codebase path' ch
 
 serveFromBranch ::

--- a/unison-share-api/src/Unison/Server/Endpoints/Projects.hs
+++ b/unison-share-api/src/Unison/Server/Endpoints/Projects.hs
@@ -136,7 +136,7 @@ serve codebase mayRoot mayOwner = projects
       shallowRootBranch <- case mayRoot of
         Nothing -> lift (Codebase.getShallowRootBranch codebase)
         Just sch -> do
-          h <- Backend.expandShortCausalHash codebase sch
+          h <- Backend.hoistBackend (Codebase.runTransaction codebase) (Backend.expandShortCausalHash sch)
           -- TODO: can this ever be missing?
           causal <- lift $ Codebase.getShallowCausalForHash codebase (Cv.causalHash1to2 h)
           lift $ V2Causal.value causal

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -60,6 +60,7 @@ library
       NumericUnderscores
       OverloadedStrings
       PatternSynonyms
+      RankNTypes
       ScopedTypeVariables
       TupleSections
       TypeApplications


### PR DESCRIPTION
- [x] Depends on #3573 
  - [x] Depends on #3572 
    - [x] Depends on #3571 
- [x] Depends on #3576 

---

## Overview

This PR removes a bunch of functions from the `Codebase` record, which simplifies their call sites. There's no need to go through the `Codebase` record indirection, when simply running a transaction with a connection in scope (usually/always? provided by a `Codebase` record) will do.