### PR TITLE
Refactor: make getWatch in Transaction, not IO

### DIFF
--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -328,7 +328,7 @@ getTypeOfConstructor codebase (ConstructorReference r0 cid) =
 --     MaybeT (getWatch codebase RegularWatch ref)
 --       <|> MaybeT (getWatch codebase TestWatch ref))
 -- @
-lookupWatchCache :: (Monad m) => Codebase m v a -> Reference.Id -> m (Maybe (Term v a))
+lookupWatchCache :: Codebase m v a -> Reference.Id -> Sqlite.Transaction (Maybe (Term v a))
 lookupWatchCache codebase h = do
   m1 <- getWatch codebase WK.RegularWatch h
   maybe (getWatch codebase WK.TestWatch h) (pure . Just) m1

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -314,9 +314,9 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
                     Sqlite.runWriteTransaction destConn \runDest -> do
                       syncInternal (syncProgress progressStateRef) runSrc runDest b
 
-            getWatch :: UF.WatchKind -> Reference.Id -> m (Maybe (Term Symbol Ann))
-            getWatch k r =
-              runTransaction (CodebaseOps.getWatch getDeclType k r)
+            getWatch :: UF.WatchKind -> Reference.Id -> Sqlite.Transaction (Maybe (Term Symbol Ann))
+            getWatch =
+              CodebaseOps.getWatch getDeclType
 
             termsOfTypeImpl :: Reference -> m (Set Referent.Id)
             termsOfTypeImpl r =

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -97,7 +97,7 @@ data Codebase m v a = Codebase
     -- | Push the given branch to the given repo, and optionally set it as the root branch.
     pushGitBranch :: forall e. WriteGitRepo -> PushGitBranchOpts -> (Branch m -> m (Either e (Branch m))) -> m (Either GitError (Either e (Branch m))),
     -- | @getWatch k r@ returns watch result @t@ that was previously put by @putWatch k r t@.
-    getWatch :: WK.WatchKind -> Reference.Id -> m (Maybe (Term v a)),
+    getWatch :: WK.WatchKind -> Reference.Id -> Sqlite.Transaction (Maybe (Term v a)),
     -- | Get the set of user-defined terms-or-constructors that have the given type.
     termsOfTypeImpl :: Reference -> m (Set Referent.Id),
     -- | Get the set of user-defined terms-or-constructors mention the given type anywhere in their signature.

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -2068,7 +2068,7 @@ handleTest TestInput {includeLibNamespace, showFailures, showSuccesses} = do
     fmap Map.fromList do
       Set.toList testRefs & wither \case
         Reference.Builtin _ -> pure Nothing
-        r@(Reference.DerivedId rid) -> liftIO (fmap (r,) <$> Codebase.getWatch codebase WK.TestWatch rid)
+        r@(Reference.DerivedId rid) -> fmap (r,) <$> Cli.runTransaction (Codebase.getWatch codebase WK.TestWatch rid)
   let stats = Output.CachedTests (Set.size testRefs) (Map.size cachedTests)
   names <-
     makePrintNamesFromLabeled' $
@@ -2974,7 +2974,7 @@ evalUnisonFile sandbox ppe unisonFile args = do
 
   let watchCache :: Reference.Id -> IO (Maybe (Term Symbol ()))
       watchCache ref = do
-        maybeTerm <- Codebase.lookupWatchCache codebase ref
+        maybeTerm <- Codebase.runTransaction codebase (Codebase.lookupWatchCache codebase ref)
         pure (Term.amap (\(_ :: Ann) -> ()) <$> maybeTerm)
 
   Cli.with_ (withArgs args) do
@@ -3000,7 +3000,7 @@ evalUnisonTermE sandbox ppe useCache tm = do
 
   let watchCache :: Reference.Id -> IO (Maybe (Term Symbol ()))
       watchCache ref = do
-        maybeTerm <- Codebase.lookupWatchCache codebase ref
+        maybeTerm <- Codebase.runTransaction codebase (Codebase.lookupWatchCache codebase ref)
         pure (Term.amap (\(_ :: Ann) -> ()) <$> maybeTerm)
 
   let cache = if useCache then watchCache else Runtime.noCache

--- a/unison-cli/tests/Unison/Test/GitSync.hs
+++ b/unison-cli/tests/Unison/Test/GitSync.hs
@@ -513,9 +513,10 @@ test =
                     |]
                 )
                 ( \cb -> do
-                    void . fmap (fromJust . sequence) $
-                      traverse (Codebase.getWatch cb TestWatch)
-                        =<< Codebase.runTransaction cb (Codebase.watches TestWatch)
+                    Codebase.runTransaction cb do
+                      void . fmap (fromJust . sequence) $
+                        traverse (Codebase.getWatch cb TestWatch)
+                          =<< Codebase.watches TestWatch
                 ),
               gistTest fmt,
               pushPullBranchesTests fmt,

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -982,7 +982,7 @@ renderDoc ppe width rt codebase r = do
     eval (Term.amap (const mempty) -> tm) = do
       let ppes = PPED.suffixifiedPPE ppe
       let codeLookup = Codebase.toCodeLookup codebase
-      let cache r = fmap Term.unannotate <$> Codebase.lookupWatchCache codebase r
+      let cache r = fmap Term.unannotate <$> Codebase.runTransaction codebase (Codebase.lookupWatchCache codebase r)
       r <- fmap hush . liftIO $ Rt.evaluateTerm' codeLookup cache ppes rt tm
       case r of
         Just tmr ->


### PR DESCRIPTION
- [x] Depends on #3574 
  - [x] Depends on #3573 
    - [x] Depends on #3572 
      - [x] Depends on #3571 
  - [x] Depends on #3576 

---

## Overview

This PR makes `getWatch` in `Transaction`, not `IO`