### PR TITLE
edit command: don't bring all members of a component into scratch file

### DIFF
--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -1164,6 +1164,8 @@ resolveRootBranchHashV2 codebase mayRoot = case mayRoot of
     resolveCausalHashV2 codebase (Just h)
 
 -- | Determines whether we include full cycles in the results, (e.g. if I search for `isEven`, will I find `isOdd` too?)
+-- This was once used for term components, but is no longer, because now 'update' Does The Right Thing when editing a
+-- member of a term component. Decl components, on the other hand... :grimace:
 data IncludeCycles
   = IncludeCycles
   | DontIncludeCycles
@@ -1180,15 +1182,7 @@ definitionsBySuffixes codebase nameSearch includeCycles query = do
   QueryResult misses results <- hqNameQuery codebase nameSearch query
   -- todo: remember to replace this with getting components directly,
   -- and maybe even remove getComponentLength from Codebase interface altogether
-  terms <- do
-    let termRefsWithoutCycles = searchResultsToTermRefs results
-    termRefs <- case includeCycles of
-      IncludeCycles ->
-        Monoid.foldMapM
-          (Codebase.componentReferencesForReference codebase)
-          termRefsWithoutCycles
-      DontIncludeCycles -> pure termRefsWithoutCycles
-    Map.foldMapM (\ref -> (ref,) <$> displayTerm codebase ref) termRefs
+  terms <- Map.foldMapM (\ref -> (ref,) <$> displayTerm codebase ref) (searchResultsToTermRefs results)
   types <- do
     let typeRefsWithoutCycles = searchResultsToTypeRefs results
     typeRefs <- case includeCycles of

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -1164,8 +1164,12 @@ resolveRootBranchHashV2 codebase mayRoot = case mayRoot of
     resolveCausalHashV2 codebase (Just h)
 
 -- | Determines whether we include full cycles in the results, (e.g. if I search for `isEven`, will I find `isOdd` too?)
--- This was once used for term components, but is no longer, because now 'update' Does The Right Thing when editing a
--- member of a term component. Decl components, on the other hand... :grimace:
+--
+-- This was once used for both term and decl components, but now is only used for decl components, because 'update' does
+-- The Right Thing for terms (i.e. propagates changes to all dependents, including component-mates, which are de facto
+-- dependents).
+--
+-- Ticket of interest: https://github.com/unisonweb/unison/issues/3445
 data IncludeCycles
   = IncludeCycles
   | DontIncludeCycles


### PR DESCRIPTION
## Overview

As of #3466 updating a member of a term component does the right thing, so we no longer need to bring an entire component into a scratch file when editing a member.

No new tests, but I did test this manually, and it worked.