### PR TITLE
Refactor: make updateNameLookup in Transaction, not IO

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -435,9 +435,9 @@ sqliteCodebase debugName root localOrRemote migrationStrategy action = do
             namesAtPath path =
               runTransaction (CodebaseOps.namesAtPath path)
 
-            updateNameLookup :: Path -> Maybe BranchHash -> BranchHash -> m ()
-            updateNameLookup pathPrefix fromBH toBH =
-              runTransaction (CodebaseOps.updateNameLookupIndex getDeclType pathPrefix fromBH toBH)
+            updateNameLookup :: Path -> Maybe BranchHash -> BranchHash -> Sqlite.Transaction ()
+            updateNameLookup =
+              CodebaseOps.updateNameLookupIndex getDeclType
 
         let codebase =
               C.Codebase

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -186,7 +186,7 @@ data Codebase m v a = Codebase
       Maybe BranchHash ->
       -- The new branch
       BranchHash ->
-      m (),
+      Sqlite.Transaction (),
     -- | Acquire a new connection to the same underlying database file this codebase object connects to.
     withConnection :: forall x. (Sqlite.Connection -> m x) -> m x,
     -- | Acquire a new connection to the same underlying database file this codebase object connects to.


### PR DESCRIPTION
## Overview

This PR makes `updateNameLookup` in `Transaction`, not `IO`