### PR TITLE
Obliterate branches in delete.namespace rather than consing an empty branch onto existing history.

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
+++ b/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
@@ -13,8 +13,6 @@ module Unison.Codebase.BranchUtil
 
     -- * Branch modifications
     makeSetBranch,
-    makeDeleteBranch,
-    makeObliterateBranch,
     makeAddTypeName,
     makeDeleteTypeName,
     makeAddTermName,
@@ -24,7 +22,6 @@ module Unison.Codebase.BranchUtil
   )
 where
 
-import Control.Lens
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import Unison.Codebase.Branch (Branch, Branch0)
@@ -137,18 +134,3 @@ makeDeleteTypeName (p, name) r = (p, Branch.deleteTypeName r name)
 makeSetBranch ::
   Path.Split -> Branch m -> (Path, Branch0 m -> Branch0 m)
 makeSetBranch (p, name) b = (p, Branch.setChildBranch name b)
-
--- | "delete"s a branch by cons'ing an empty Branch0 onto the history at that location.
--- See also 'makeObliterateBranch'.
-makeDeleteBranch ::
-  Applicative m =>
-  Path.Split ->
-  (Path, Branch0 m -> Branch0 m)
-makeDeleteBranch (p, name) = (p, Branch.children . ix name %~ Branch.cons Branch.empty0)
-
--- | Erase a branch and its history
--- See also 'makeDeleteBranch'.
--- Note that this requires a AllowRewritingHistory update strategy to behave correctly.
-makeObliterateBranch ::
-  Path.Split -> (Path, Branch0 m -> Branch0 m)
-makeObliterateBranch p = makeSetBranch p Branch.empty

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -884,9 +884,7 @@ loop e = do
                 if hasConfirmed || insistence == Force
                   then do
                     description <- inputDescription input
-                    Cli.stepAt
-                      description
-                      (Path.empty, const Branch.empty0)
+                    Cli.updateRoot Branch.empty description
                     Cli.respond DeletedEverything
                   else Cli.respond DeleteEverythingConfirmation
               DeleteTarget'Branch insistence (Just p@(parentPath, childName)) -> do

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -889,7 +889,7 @@ loop e = do
                       (Path.empty, const Branch.empty0)
                     Cli.respond DeletedEverything
                   else Cli.respond DeleteEverythingConfirmation
-              DeleteTarget'Branch insistence (Just p) -> do
+              DeleteTarget'Branch insistence (Just p@(parentPath, childName)) -> do
                 branch <- Cli.expectBranchAtPath' (Path.unsplit' p)
                 description <- inputDescription input
                 absPath <- Cli.resolveSplit' p
@@ -911,8 +911,12 @@ loop e = do
                       ppeDecl <- currentPrettyPrintEnvDecl Backend.Within
                       Cli.respondNumbered $ CantDeleteNamespace ppeDecl endangerments
                       Cli.returnEarlyWithoutOutput
-                Cli.stepAt description $
-                  BranchUtil.makeDeleteBranch (Path.convert absPath)
+                parentPathAbs <- Cli.resolvePath' parentPath
+                -- We have to modify the parent in order to also wipe out the history at the
+                -- child.
+                Cli.updateAt description parentPathAbs \parentBranch ->
+                  parentBranch
+                    & Branch.modifyAt (Path.singleton childName) \_ -> Branch.empty
                 afterDelete
             DisplayI outputLoc names' -> do
               currentBranch0 <- Cli.getCurrentBranch0
@@ -2796,7 +2800,7 @@ buildScheme main file = do
           ++ lns gd gen
           ++ [surround file]
 
-doRunAsScheme :: HQ.HashQualified Name -> [String] ->  Cli ()
+doRunAsScheme :: HQ.HashQualified Name -> [String] -> Cli ()
 doRunAsScheme main args = do
   fullpath <- generateSchemeFile True (HQ.toString main) main
   runScheme fullpath args

--- a/unison-src/transcripts/delete-namespace.md
+++ b/unison-src/transcripts/delete-namespace.md
@@ -47,11 +47,15 @@ Deleting the root namespace should require confirmation if not forced.
 ```ucm
 .> delete.namespace .
 .> delete.namespace .
+-- Should have an empty history
+.> history .
 ```
 
 Deleting the root namespace shouldn't require confirmation if forced.
 
 ```ucm
 .> delete.namespace.force .
+-- Should have an empty history
+.> history .
 ```
 

--- a/unison-src/transcripts/delete-namespace.output.md
+++ b/unison-src/transcripts/delete-namespace.output.md
@@ -86,6 +86,11 @@ Deleting the root namespace should require confirmation if not forced.
   undo, or `builtins.merge` to restore the absolute basics to
   the current path.
 
+-- Should have an empty history
+.> history .
+
+  ☝️  The namespace . is empty.
+
 ```
 Deleting the root namespace shouldn't require confirmation if forced.
 
@@ -95,5 +100,10 @@ Deleting the root namespace shouldn't require confirmation if forced.
   Okay, I deleted everything except the history. Use `undo` to
   undo, or `builtins.merge` to restore the absolute basics to
   the current path.
+
+-- Should have an empty history
+.> history .
+
+  ☝️  The namespace . is empty.
 
 ```

--- a/unison-src/transcripts/empty-namespaces.md
+++ b/unison-src/transcripts/empty-namespaces.md
@@ -22,15 +22,15 @@ The deleted namespace shouldn't appear in `ls` output.
 
 ## history
 
-The history of the namespace should still exist if requested explicitly.
+The history of the namespace should be empty.
 
 ```ucm
 .> history mynamespace
 ```
 
-Merging an empty namespace should still copy its history if it has some.
+Merging an empty namespace should be a no-op
 
-```ucm
+```ucm:error
 .empty> history
 .empty> merge .mynamespace
 .empty> history

--- a/unison-src/transcripts/empty-namespaces.output.md
+++ b/unison-src/transcripts/empty-namespaces.output.md
@@ -47,24 +47,15 @@ The deleted namespace shouldn't appear in `ls` output.
 ```
 ## history
 
-The history of the namespace should still exist if requested explicitly.
+The history of the namespace should be empty.
 
 ```ucm
 .> history mynamespace
 
-  Note: The most recent namespace hash is immediately below this
-        message.
-  
-  ⊙ 1. #nvh8d4j0fm
-  
-    - Deletes:
-    
-      x
-  
-  □ 2. #i52j9fd57b (start of history)
+  ☝️  The namespace .mynamespace is empty.
 
 ```
-Merging an empty namespace should still copy its history if it has some.
+Merging an empty namespace should be a no-op
 
 ```ucm
   ☝️  The namespace .empty is empty.
@@ -75,20 +66,13 @@ Merging an empty namespace should still copy its history if it has some.
 
 .empty> merge .mynamespace
 
-  Nothing changed as a result of the merge.
+  ⚠️
+  
+  The namespace .mynamespace doesn't exist.
 
 .empty> history
 
-  Note: The most recent namespace hash is immediately below this
-        message.
-  
-  ⊙ 1. #nvh8d4j0fm
-  
-    - Deletes:
-    
-      x
-  
-  □ 2. #i52j9fd57b (start of history)
+  ☝️  The namespace .empty is empty.
 
 ```
 Add and then delete a term to add some history to a deleted namespace.

--- a/unison-src/transcripts/merges.md
+++ b/unison-src/transcripts/merges.md
@@ -49,7 +49,8 @@ y = "hello"
 
 Notice that `master` now has the definition of `y` we wrote.
 
-We can also delete the fork if we're done with it. (Don't worry, it's still in the `history` and can be resurrected at any time.)
+We can also delete the fork if we're done with it. (Don't worry, even though the history at that path is now empty, 
+it's still in the `history` of the parent namespace and can be resurrected at any time.)
 
 ```ucm
 .> delete.namespace .feature1

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -96,7 +96,8 @@ y = "hello"
 
 Notice that `master` now has the definition of `y` we wrote.
 
-We can also delete the fork if we're done with it. (Don't worry, it's still in the `history` and can be resurrected at any time.)
+We can also delete the fork if we're done with it. (Don't worry, even though the history at that path is now empty, 
+it's still in the `history` of the parent namespace and can be resurrected at any time.)
 
 ```ucm
 .> delete.namespace .feature1
@@ -105,23 +106,14 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
 
 .> history .feature1
 
-  Note: The most recent namespace hash is immediately below this
-        message.
-  
-  ⊙ 1. #hsbtlt2og6
-  
-    - Deletes:
-    
-      y
-  
-  □ 2. #q95r47tc4l (start of history)
+  ☝️  The namespace .feature1 is empty.
 
 .> history
 
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #1487pemruj
+  ⊙ 1. #492bge1qkb
   
     - Deletes:
     

--- a/unison-src/transcripts/move-namespace.md
+++ b/unison-src/transcripts/move-namespace.md
@@ -58,7 +58,9 @@ b.termInB = 11
 .history> update
 ```
 
-Now, if we soft-delete a namespace, but move another over it we expect the history to be replaced, and we expect the history from the source to be wiped out.
+Deleting a namespace should not leave behind any history,
+if we move another to that location we expect the history to simply be the history
+of the moved namespace. 
 
 ```ucm
 .history> delete.namespace b

--- a/unison-src/transcripts/move-namespace.output.md
+++ b/unison-src/transcripts/move-namespace.output.md
@@ -150,7 +150,9 @@ b.termInB = 11
     b.termInB : Nat
 
 ```
-Now, if we soft-delete a namespace, but move another over it we expect the history to be replaced, and we expect the history from the source to be wiped out.
+Deleting a namespace should not leave behind any history,
+if we move another to that location we expect the history to simply be the history
+of the moved namespace. 
 
 ```ucm
 .history> delete.namespace b
@@ -276,7 +278,7 @@ I should be able to move the root into a sub-namespace
   
   
   
-  □ 1. #eur72kuror (start of history)
+  □ 1. #bn675bbtpm (start of history)
 
 ```
 ```ucm
@@ -292,7 +294,7 @@ I should be able to move the root into a sub-namespace
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #uu7qrred6m
+  ⊙ 1. #vor04lbt72
   
     - Deletes:
     
@@ -303,7 +305,7 @@ I should be able to move the root into a sub-namespace
       Original name      New name
       existing.a.termInA existing.b.termInA
   
-  ⊙ 2. #91mc5pd4t0
+  ⊙ 2. #tk3qtdeoov
   
     + Adds / updates:
     
@@ -315,20 +317,20 @@ I should be able to move the root into a sub-namespace
       happy.b.termInA   existing.a.termInA
       history.b.termInA existing.a.termInA
   
-  ⊙ 3. #ndr3vmlmv7
+  ⊙ 3. #r971i7m95i
   
     + Adds / updates:
     
       existing.a.termInA existing.b.termInB
   
-  ⊙ 4. #2jqg9n2e8u
+  ⊙ 4. #6qh988adub
   
     > Moves:
     
       Original name     New name
       history.a.termInA history.b.termInA
   
-  ⊙ 5. #dsj92ppiqi
+  ⊙ 5. #g19mlrid0i
   
     - Deletes:
     


### PR DESCRIPTION


~EDIT: seems like this change doesn't actually work and needs a bit more looking into iff we decide to go forward with this plan~

Update: Okay took the time to do it correctly, updated the transcripts as well.

## Overview

Currently, deleting a namespace doesn't actually delete the history, it just conses an empty branch onto the history at that location. The distinction is important, and might be relevant in certain cases, but I think @stew and @ceedubs  have proven through experience that the current behaviour is rarely what's desired.

This PR changes the behaviour so that the history at the delete path is empty after deletion. If users want to revive the old branch it will still exist in the history of the parent namespace.

## Implementation

* Change the delete operation to replace the branch at the specified path with an empty branch (with an empty history) within the parent branch. 
* Change the delete root operation to just replace the namespace root with an empty causal instead of stepping forward in history with an empty branch.

## Testing

Updated the altered transcripts and confirmed they're behaving as expected.