### PR TITLE
Make universal compare do lexicographic comparison on lists

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Machine.hs
+++ b/parser-typechecker/src/Unison/Runtime/Machine.hs
@@ -2159,7 +2159,7 @@ universalCompare frn = cmpc False
     cmpc tyEq (Foreign fl) (Foreign fr)
       | Just sl <- maybeUnwrapForeign Rf.listRef fl,
         Just sr <- maybeUnwrapForeign Rf.listRef fr =
-          comparing Sq.length sl sr <> fold (Sq.zipWith (cmpc tyEq) sl sr)
+          fold (Sq.zipWith (cmpc tyEq) sl sr)
       | Just al <- maybeUnwrapForeign Rf.iarrayRef fl,
         Just ar <- maybeUnwrapForeign Rf.iarrayRef fr =
           arrayCmp (cmpc tyEq) al ar

--- a/parser-typechecker/src/Unison/Runtime/Machine.hs
+++ b/parser-typechecker/src/Unison/Runtime/Machine.hs
@@ -2160,6 +2160,7 @@ universalCompare frn = cmpc False
       | Just sl <- maybeUnwrapForeign Rf.listRef fl,
         Just sr <- maybeUnwrapForeign Rf.listRef fr =
           fold (Sq.zipWith (cmpc tyEq) sl sr)
+            <> compare (length sl) (length sr)
       | Just al <- maybeUnwrapForeign Rf.iarrayRef fl,
         Just ar <- maybeUnwrapForeign Rf.iarrayRef fr =
           arrayCmp (cmpc tyEq) al ar

--- a/unison-src/transcripts/builtins.md
+++ b/unison-src/transcripts/builtins.md
@@ -287,6 +287,25 @@ test> Bytes.tests.fromBase64UrlUnpadded =
 .> add
 ```
 
+## `List` comparison
+
+```unison:hide
+test> checks [
+        compare [] [1,2,3] == -1,
+        compare [1,2,3] [1,2,3,4] == -1,
+        compare [1,2,3,4] [1,2,3] == +1,
+        compare [1,2,3] [1,2,3] == +0,
+        compare [3] [1,2,3] == +1,
+        compare [1,2,3] [1,2,4] == -1,
+        compare [1,2,2] [1,2,1,2] == +1,
+        compare [1,2,3,4] [3,2,1] == -1
+      ]
+```
+
+```ucm:hide
+.> add
+```
+
 ## `Any` functions
 
 ```unison

--- a/unison-src/transcripts/builtins.output.md
+++ b/unison-src/transcripts/builtins.output.md
@@ -260,6 +260,21 @@ test> Bytes.tests.fromBase64UrlUnpadded =
 
 ```
 
+## `List` comparison
+
+```unison
+test> checks [
+        compare [] [1,2,3] == -1,
+        compare [1,2,3] [1,2,3,4] == -1,
+        compare [1,2,3,4] [1,2,3] == +1,
+        compare [1,2,3] [1,2,3] == +0,
+        compare [3] [1,2,3] == +1,
+        compare [1,2,3] [1,2,4] == -1,
+        compare [1,2,2] [1,2,1,2] == +1,
+        compare [1,2,3,4] [3,2,1] == -1
+      ]
+```
+
 ## `Any` functions
 
 ```unison
@@ -371,13 +386,14 @@ Now that all the tests have been added to the codebase, let's view the test repo
   ◉ Sandbox.test1                       Passed
   ◉ Sandbox.test2                       Passed
   ◉ Sandbox.test3                       Passed
+  ◉ test.rtjqan7bcs                     Passed
   ◉ Text.tests.alignment                Passed
   ◉ Text.tests.literalsEq               Passed
   ◉ Text.tests.patterns                 Passed
   ◉ Text.tests.repeat                   Passed
   ◉ Text.tests.takeDropAppend           Passed
   
-  ✅ 22 test(s) passing
+  ✅ 23 test(s) passing
   
   Tip: Use view Any.test1 to view the source of a test.
 


### PR DESCRIPTION
Equality still checks length first, because that should be able to short circuit a bit faster.

Addresses #3603 