### PR TITLE
Refactor: Derive instance Show NameSegment

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1421,15 +1421,15 @@ loop e = do
                                [ Monoid.unlessM (null causalParents) $ P.lit "Causal Parents:" <> P.newline <> P.indentN 2 (P.lines (map P.shown $ Set.toList causalParents)),
                                  Monoid.unlessM (null terms) $ P.lit "Terms:" <> P.newline <> P.indentN 2 (P.lines (map (prettyDefn Referent.toText) $ Map.toList terms)),
                                  Monoid.unlessM (null types) $ P.lit "Types:" <> P.newline <> P.indentN 2 (P.lines (map (prettyDefn Reference.toText) $ Map.toList types)),
-                                 Monoid.unlessM (null patches) $ P.lit "Patches:" <> P.newline <> P.indentN 2 (P.column2 (map (bimap P.shown P.shown) $ Map.toList patches)),
-                                 Monoid.unlessM (null children) $ P.lit "Children:" <> P.newline <> P.indentN 2 (P.column2 (map (bimap P.shown P.shown) $ Map.toList children))
+                                 Monoid.unlessM (null patches) $ P.lit "Patches:" <> P.newline <> P.indentN 2 (P.column2 (map (bimap (P.text . NameSegment.toText) P.shown) $ Map.toList patches)),
+                                 Monoid.unlessM (null children) $ P.lit "Children:" <> P.newline <> P.indentN 2 (P.column2 (map (bimap (P.text . NameSegment.toText) P.shown) $ Map.toList children))
                                ]
                          )
                     where
                       prettyLinks renderR r [] = P.indentN 2 $ P.text (renderR r)
                       prettyLinks renderR r links = P.indentN 2 (P.lines (P.text (renderR r) : (links <&> \r -> "+ " <> P.text (Reference.toText r))))
                       prettyDefn renderR (r, (Foldable.toList -> names, Foldable.toList -> links)) =
-                        P.lines (P.shown <$> if null names then [NameSegment "<unnamed>"] else names) <> P.newline <> prettyLinks renderR r links
+                        P.lines (P.text . NameSegment.toText <$> if null names then [NameSegment "<unnamed>"] else names) <> P.newline <> prettyLinks renderR r links
               rootBranch <- Cli.getRootBranch
               void . liftIO . flip State.execStateT mempty $ goCausal [getCausal rootBranch]
             DebugDumpNamespaceSimpleI -> do
@@ -1683,7 +1683,7 @@ inputDescription input =
     hqs' :: Path.HQSplit' -> Cli Text
     hqs' (p0, hq) = do
       p <- if Path.isRoot' p0 then pure mempty else p' p0
-      pure (p <> "." <> tShow hq)
+      pure (p <> "." <> HQ'.toTextWith NameSegment.toText hq)
     hqs (p, hq) = hqs' (Path' . Right . Path.Relative $ p, hq)
     ps' = p' . Path.unsplit'
 

--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -390,10 +390,10 @@ shareCompletion completionTypes authHTTPClient str =
                   let name = Server.namespaceName nn
                    in (NamespaceCompletion, name)
                 Server.TermObject nt ->
-                  let name = HQ'.toText $ Server.termName nt
+                  let name = HQ'.toTextWith NameSegment.toText $ Server.termName nt
                    in (NamespaceCompletion, name)
                 Server.TypeObject nt ->
-                  let name = HQ'.toText $ Server.typeName nt
+                  let name = HQ'.toTextWith NameSegment.toText $ Server.typeName nt
                    in (TermCompletion, name)
                 Server.PatchObject np ->
                   let name = Server.patchName np

--- a/unison-core/src/Unison/NameSegment.hs
+++ b/unison-core/src/Unison/NameSegment.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module Unison.NameSegment where
 
 import qualified Data.Text as Text
@@ -10,7 +8,7 @@ import Unison.Util.Alphabetical (Alphabetical, compareAlphabetical)
 
 -- Represents the parts of a name between the `.`s
 newtype NameSegment = NameSegment {toText :: Text}
-  deriving stock (Eq, Ord, Generic)
+  deriving stock (Eq, Ord, Generic, Show)
 
 instance Alphabetical NameSegment where
   compareAlphabetical n1 n2 = compareAlphabetical (toText n1) (toText n2)
@@ -57,9 +55,6 @@ toString = Text.unpack . toText
 toTextBuilder :: NameSegment -> Text.Builder
 toTextBuilder =
   coerce Text.Builder.fromText
-
-instance Show NameSegment where
-  show = Text.unpack . toText
 
 instance IsString NameSegment where
   fromString = NameSegment . Text.pack

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -263,7 +263,7 @@ data TermEntry v a = TermEntry
   deriving (Eq, Ord, Show, Generic)
 
 termEntryDisplayName :: TermEntry v a -> Text
-termEntryDisplayName = HQ'.toText . termEntryHQName
+termEntryDisplayName = HQ'.toTextWith NameSegment.toText . termEntryHQName
 
 termEntryHQName :: TermEntry v a -> HQ'.HashQualified NameSegment
 termEntryHQName TermEntry {termEntryName, termEntryConflicted, termEntryHash} =
@@ -281,7 +281,7 @@ data TypeEntry = TypeEntry
   deriving (Eq, Ord, Show, Generic)
 
 typeEntryDisplayName :: TypeEntry -> Text
-typeEntryDisplayName = HQ'.toText . typeEntryHQName
+typeEntryDisplayName = HQ'.toTextWith NameSegment.toText . typeEntryHQName
 
 typeEntryHQName :: TypeEntry -> HQ'.HashQualified NameSegment
 typeEntryHQName TypeEntry {typeEntryName, typeEntryConflicted, typeEntryReference} =

--- a/unison-share-api/src/Unison/Server/Orphans.hs
+++ b/unison-share-api/src/Unison/Server/Orphans.hs
@@ -31,6 +31,7 @@ import qualified Unison.HashQualified' as HQ'
 import Unison.Name (Name)
 import qualified Unison.Name as Name
 import Unison.NameSegment (NameSegment (..))
+import qualified Unison.NameSegment as NameSegment
 import Unison.Prelude
 import qualified Unison.Reference as Reference
 import qualified Unison.Referent as Referent
@@ -287,11 +288,11 @@ instance ToJSON Path.Path where
 instance ToSchema Path.Path where
   declareNamedSchema _ = declareNamedSchema (Proxy @Text)
 
-instance Show n => ToJSON (HQ.HashQualified n) where
-  toJSON = Aeson.String . HQ.toText
+instance ToJSON (HQ.HashQualified Name) where
+  toJSON = Aeson.String . HQ.toTextWith Name.toText
 
-instance Show n => ToJSON (HQ'.HashQualified n) where
-  toJSON = Aeson.String . HQ'.toText
+instance ToJSON (HQ'.HashQualified NameSegment) where
+  toJSON = Aeson.String . HQ'.toTextWith NameSegment.toText
 
 instance FromJSON (HQ'.HashQualified Name) where
   parseJSON = Aeson.withText "HashQualified'" \txt ->

--- a/unison-share-api/src/Unison/Server/Types.hs
+++ b/unison-share-api/src/Unison/Server/Types.hs
@@ -25,6 +25,7 @@ import qualified Data.OpenApi.Lens as OpenApi
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as Text.Lazy
 import qualified Data.Text.Lazy.Encoding as Text
+import qualified Unison.NameSegment as NameSegment
 import Servant.API
   ( Capture,
     FromHttpApiData (..),
@@ -222,7 +223,7 @@ data NamedTerm = NamedTerm
 instance ToJSON NamedTerm where
   toJSON (NamedTerm n h typ tag) =
     Aeson.object
-      [ "termName" .= n,
+      [ "termName" .= HQ'.toTextWith NameSegment.toText n,
         "termHash" .= h,
         "termType" .= typ,
         "termTag" .= tag


### PR DESCRIPTION
## Overview

This PR removes the too-convenient

```haskell
instance Show NameSegment where
  show = Text.unpack . toText
```

in favor of

```haskell
deriving stock instance (Show)
```

(really we don't need the `Show` instance for anything, but it's convenient to use when `error`-ing in an impossible case, or debugging in the repl).

All call sites of `instance Show NameSegment` were audited and replaced with a call to `NameSegment.toText` where appropriate.

This change is motivated by #3525, which will benefit from all stringy conversions to/from `Name`, `NameSegment`, and the like to be encapsulated behind an interface (the `unison-syntax` package).