### PR TITLE
Consolidate messages into single outputs

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -312,7 +312,6 @@ loop e = do
                         patchName
                         (const (if isTerm then termPatch else typePatch))
                     )
-                  -- Say something
                   Cli.respond Success
             when (Set.null hits) do
               Cli.respond (SearchTermsNotFoundDetailed isTerm misses (Set.toList opHits))

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -200,10 +200,13 @@ data Output
       PPE.PrettyPrintEnv
       SlurpResult
       (UF.TypecheckedUnisonFile Symbol Ann)
-      -- evaluated watch expressions:
-      SourceFileContents
-      [(Symbol, Term Symbol ())]
-      (Map Symbol (Ann, WK.WatchKind, Term Symbol (), Runtime.IsCacheHit))
+      -- Optionally print evaluated watch expressions:
+      ( Maybe
+          ( SourceFileContents,
+            [(Symbol, Term Symbol ())],
+            (Map Symbol (Ann, WK.WatchKind, Term Symbol (), Runtime.IsCacheHit))
+          )
+      )
   | DisplayRendered (Maybe FilePath) (P.Pretty P.ColorText)
   | -- "display" definitions, possibly to a FilePath on disk (e.g. editing)
     DisplayDefinitions

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -194,13 +194,16 @@ data Output
   | CompilerBugs Text PPE.PrettyPrintEnv [Context.CompilerBug Symbol Ann]
   | DisplayConflicts (Relation Name Referent) (Relation Name Reference)
   | EvaluationFailure Runtime.Error
-  | Evaluated
-      SourceFileContents
+  | RunResult PPE.PrettyPrintEnv (Term Symbol ())
+  | CheckedUnisonFile
+      SourceName
       PPE.PrettyPrintEnv
+      SlurpResult
+      (UF.TypecheckedUnisonFile Symbol Ann)
+      -- evaluated watch expressions:
+      SourceFileContents
       [(Symbol, Term Symbol ())]
       (Map Symbol (Ann, WK.WatchKind, Term Symbol (), Runtime.IsCacheHit))
-  | RunResult PPE.PrettyPrintEnv (Term Symbol ())
-  | Typechecked SourceName PPE.PrettyPrintEnv SlurpResult (UF.TypecheckedUnisonFile Symbol Ann)
   | DisplayRendered (Maybe FilePath) (P.Pretty P.ColorText)
   | -- "display" definitions, possibly to a FilePath on disk (e.g. editing)
     DisplayDefinitions
@@ -367,8 +370,7 @@ isFailure o = case o of
   CompilerBugs {} -> True
   DisplayConflicts {} -> False
   EvaluationFailure {} -> True
-  Evaluated {} -> False
-  Typechecked {} -> False
+  CheckedUnisonFile {} -> False
   DisplayDefinitions _ _ m1 m2 -> null m1 && null m2
   DisplayRendered {} -> False
   TestIncrementalOutputStart {} -> False

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1051,8 +1051,7 @@ notifyUser dir o = case o of
               ]
   -- TODO: Present conflicting TermEdits and TypeEdits
   -- if we ever allow users to edit hashes directly.
-  CheckedUnisonFile sourceName ppe slurpResult uf fileContents bindings watches -> do
-    evaluationResult <- prettyEvaluate ppe fileContents bindings watches
+  CheckedUnisonFile sourceName ppe slurpResult uf evalutationResults -> do
     slurpMsg <-
       if UF.nonEmpty uf
         then prettySlurpResult ppe slurpResult uf sourceName
@@ -1062,7 +1061,11 @@ notifyUser dir o = case o of
               pure . P.wrap $
                 "I loaded " <> P.text sourceName <> " and didn't find anything."
             else pure mempty
-    pure (P.lines [slurpMsg, "", evaluationResult])
+    case evalutationResults of
+      Just (fileContents, bindings, watches) -> do
+        evaluations <- prettyEvaluate ppe fileContents bindings watches
+        pure (P.lines [slurpMsg, "", evaluations])
+      Nothing -> pure slurpMsg
   GitError e -> pure $ case e of
     GitSqliteCodebaseError e -> case e of
       NoDatabaseFile repo localPath ->


### PR DESCRIPTION
## Overview

I'm working towards adding a client/server JSON interface for UCM commands for scripting purposes.
In order to use commands in a request/response style server it's very helpful if each command has a single output (which I can then convert into a JSON payload).

Currently any given command can output any number of Outputs, and can even do IO in the output layer, so I'm going to start consolidating where I can.

There may be a few cases where we  print things in pieces as we go along, I'll evaluate what to do if I find any important uses of that behaviour, but I'm not aware of any that require that behaviour. I may also add the distinction between output which is provided for flavour or context vs the actual payload of the response so that commands can still print nice things to the CLI, but we know what's important to go into the response.

## Implementation notes

* Start consolidating output messages into at most one output per command.