### PR TITLE
Clean up applyPropagate

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/Propagate.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Propagate.hs
@@ -650,9 +650,9 @@ applyPropagate patch Edits {..} = do
             typeOf r t = fromMaybe t $ Map.lookup r termTypes
 
         replaceTerm :: Referent -> Referent -> Metadata.Star Referent NameSegment -> Metadata.Star Referent NameSegment
-        replaceTerm r r' s =
+        replaceTerm _r r' s =
           ( if isPropagatedReferent r'
-              then Metadata.insert (propagatedMd r') . Metadata.delete (propagatedMd r)
+              then Metadata.insert (propagatedMd r')
               else Metadata.delete (propagatedMd r')
           )
             $ s

--- a/unison-cli/src/Unison/Codebase/Editor/Propagate.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Propagate.hs
@@ -601,7 +601,7 @@ applyDeprecations patch =
 -- definition that is created by the `Edits` which is passed in is marked as
 -- a propagated change.
 applyPropagate :: Applicative m => Patch -> Edits Symbol -> Branch0 m -> Branch0 m
-applyPropagate patch Edits {..} = do
+applyPropagate patch Edits {newTerms, termReplacements, typeReplacements, constructorReplacements} = do
   let termTypes = Map.map (Hashing.typeToReference . snd) newTerms
   -- recursively update names and delete deprecated definitions
   Branch.stepEverywhere (updateLevel termReplacements typeReplacements termTypes)

--- a/unison-cli/src/Unison/Codebase/Editor/Propagate.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Propagate.hs
@@ -627,23 +627,19 @@ applyPropagate patch Edits {..} = do
         terms0 = Star3.replaceFacts replaceConstructor constructorReplacements _terms
         terms :: Branch.Star Referent NameSegment
         terms =
-          updateMetadatas Referent.Ref $
+          updateMetadatas $
             Star3.replaceFacts replaceTerm termEdits terms0
         types :: Branch.Star Reference NameSegment
         types =
-          updateMetadatas id $
+          updateMetadatas $
             Star3.replaceFacts replaceType typeEdits _types
 
         updateMetadatas ::
           Ord r =>
-          (Reference -> r) ->
           Star3.Star3 r NameSegment Metadata.Type (Metadata.Type, Metadata.Value) ->
           Star3.Star3 r NameSegment Metadata.Type (Metadata.Type, Metadata.Value)
-        updateMetadatas ref s = clearPropagated $ Star3.mapD3 go s
+        updateMetadatas s = Star3.mapD3 go s
           where
-            clearPropagated s = foldl' go s allPatchTargets
-              where
-                go s r = Metadata.delete (propagatedMd $ ref r) s
             go (tp, v) = case Map.lookup (Referent.Ref v) termEdits of
               Just (Referent.Ref r) -> (typeOf r tp, r)
               _ -> (tp, v)


### PR DESCRIPTION
## Overview

Codebase updates are very slow for Stew's codebase. I observe ~76 seconds to execute Stew's update transcript on trunk (6bacb88e614a9883a107bcf50365f8a9025647b3). Profiling revealed that the bulk of the time was spent in `applyPropagate`'s `clearPropagated` call.  `clearPropagated` deletes the propagated metadata tags for all patch targets by looping over the patch targets and deleting them from the metadata Star3.

The call to `clearPropagated` appears to be unnecessary: `replaceFacts` traverses the intersection of the domain of (term/type)Edits and the corresponding metadata Star3 and properly assigns the propagated metadata values (see  `replaceTerms`/`replaceTypes`). So, `clearPropagated` would only be useful if it corrected metadata for references not in this intersection. If a reference is not in the Star3 then there is nothing to correct. If a reference is in the Star3 but not in the domain of `termEdits` then it would be erroneous to label it as not propagated.

I observe ~21 seconds to execute Stew's update transcript with this change.