### PR TITLE
Fix skipped sync in add.run

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1131,9 +1131,9 @@ loop e = do
               Cli.stepAtNoSync (Path.unabsolute currentPath, doSlurpAdds adds uf)
               Cli.runTransaction . Codebase.addDefsToCodebase codebase . SlurpResult.filterUnisonFile sr $ uf
               ppe <- prettyPrintEnvDecl =<< displayNames uf
-              Cli.returnEarly $ SlurpOutput input (PPE.suffixifiedPPE ppe) sr
               addDefaultMetadata adds
               Cli.syncRoot description
+              Cli.respond $ SlurpOutput input (PPE.suffixifiedPPE ppe) sr
             PreviewAddI requestedNames -> do
               (sourceName, _) <- Cli.expectLatestFile
               uf <- Cli.expectLatestTypecheckedFile


### PR DESCRIPTION
## Overview

While digging around  on the client-server stuff I noticed `returnEarly` was skipping a sync in `add.run`; the changes were still applied to the in-memory branch so this doesn't show up in transcripts 🙈 

## Implementation notes

Change `returnEarly` to a respond.

## Test coverage

Hrmm, one option would be to add a check to the transcript runner that the in-memory branch always matches the synced root. If we'd like to do that let me know and I can add it in a separate PR.
