### PR TITLE
Swap name priority so shorter fqn come first

### DIFF
--- a/parser-typechecker/src/Unison/PrettyPrintEnv/Names.hs
+++ b/parser-typechecker/src/Unison/PrettyPrintEnv/Names.hs
@@ -32,13 +32,13 @@ fromNames len names = PrettyPrintEnv terms' types'
 --
 -- 1. Prefer Relative Names to Absolute Names
 -- 2. Prefer names that aren't hash qualified to those that are
--- 3. Prefer names which have fewer segments in their suffixified form (if applicable)
--- 4. Prefer names which have fewer segments in their fully-qualified form
+-- 3. Prefer names which have fewer segments in their fully-qualified form
+-- 4. Prefer names which have fewer segments in their suffixified form (if applicable)
 prioritize :: [(HQ'.HashQualified Name, HQ'.HashQualified Name)] -> [(HQ'.HashQualified Name, HQ'.HashQualified Name)]
 prioritize =
   sortOn \case
-    (fqn, HQ'.NameOnly name) -> (Name.isAbsolute name, Nothing, Name.countSegments name, Name.countSegments (HQ'.toName fqn))
-    (fqn, HQ'.HashQualified name hash) -> (Name.isAbsolute name, Just hash, Name.countSegments name, Name.countSegments (HQ'.toName fqn))
+    (fqn, HQ'.NameOnly name) -> (Name.isAbsolute name, Nothing, Name.countSegments (HQ'.toName fqn), Name.countSegments name)
+    (fqn, HQ'.HashQualified name hash) -> (Name.isAbsolute name, Just hash, Name.countSegments (HQ'.toName fqn), Name.countSegments name)
 
 fromSuffixNames :: Int -> NamesWithHistory -> PrettyPrintEnv
 fromSuffixNames len names = PrettyPrintEnv terms' types'

--- a/unison-src/transcripts/name-selection.md
+++ b/unison-src/transcripts/name-selection.md
@@ -55,7 +55,7 @@ d = c + 10
 
 At this point, `a3` is conflicted for symbols `c` and `d`, so those are deprioritized. 
 The original `a2` namespace has an unconflicted definition for `c` and `d`, but since there are multiple 'c's in scope, 
-`long.name.but.shortest.suffixification` is chosen because its suffixified version has the fewest segments.
+`a2.c` is chosen because although the suffixified version has fewer segments, its fully-qualified name has the fewest segments.
 
 ```ucm
 .> view a b c d
@@ -88,7 +88,8 @@ other.value = 20
 
 ```ucm
 .biasing> add
--- nested.value should still be preferred even if the suffixification requires more segments than `a`
+-- nested.value should be preferred over the shorter name `a` due to biasing
+-- because `deeply.nested.value` is nearby to the term being viewed.
 .biasing> view deeply.nested.term
 ```
 

--- a/unison-src/transcripts/name-selection.output.md
+++ b/unison-src/transcripts/name-selection.output.md
@@ -1373,7 +1373,7 @@ d = c + 10
 ```
 At this point, `a3` is conflicted for symbols `c` and `d`, so those are deprioritized. 
 The original `a2` namespace has an unconflicted definition for `c` and `d`, but since there are multiple 'c's in scope, 
-`long.name.but.shortest.suffixification` is chosen because its suffixified version has the fewest segments.
+`a2.c` is chosen because although the suffixified version has fewer segments, its fully-qualified name has the fewest segments.
 
 ```ucm
 .> view a b c d
@@ -1394,7 +1394,7 @@ The original `a2` namespace has an unconflicted definition for `c` and `d`, but 
   a2.d : Nat
   a2.d =
     use Nat +
-    suffixification + 10
+    a2.c + 10
   
   a3.c#dcgdua2lj6 : Nat
   a3.c#dcgdua2lj6 = 2
@@ -1475,7 +1475,8 @@ other.value = 20
   
     other.value : Nat
 
--- nested.value should still be preferred even if the suffixification requires more segments than `a`
+-- nested.value should be preferred over the shorter name `a` due to biasing
+-- because `deeply.nested.value` is nearby to the term being viewed.
 .biasing> view deeply.nested.term
 
   deeply.nested.term : Nat


### PR DESCRIPTION
fixes https://github.com/unisonweb/unison/issues/3536

## Overview

Prioritize names by shorter number of segments in their fully qualified name rather than the suffixified name.

## Implementation notes

Swap the priority between the fqn segments and suffixified segments so the fqn segment count is more important.
