### PR TITLE
Fix codebase root branch cache bugs

### DIFF
--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -41,6 +41,7 @@ dependencies:
   - errors
   - exceptions
   - extra
+  - filelock
   - filepath
   - fingertree
   - fsnotify

--- a/parser-typechecker/src/Unison/Codebase/Init.hs
+++ b/parser-typechecker/src/Unison/Codebase/Init.hs
@@ -6,6 +6,7 @@ module Unison.Codebase.Init
     DebugName,
     InitError (..),
     CodebaseInitOptions (..),
+    CodebaseLockOption (..),
     InitResult (..),
     SpecifiedCodebase (..),
     MigrationStrategy (..),
@@ -42,6 +43,10 @@ data SpecifiedCodebase
   = CreateWhenMissing CodebasePath
   | DontCreateWhenMissing CodebasePath
 
+data CodebaseLockOption
+  = DoLock
+  | DontLock
+
 data MigrationStrategy
   = -- | Perform a migration immediately if one is required.
     MigrateAutomatically
@@ -60,9 +65,9 @@ type DebugName = String
 
 data Init m v a = Init
   { -- | open an existing codebase
-    withOpenCodebase :: forall r. DebugName -> CodebasePath -> MigrationStrategy -> (Codebase m v a -> m r) -> m (Either OpenCodebaseError r),
+    withOpenCodebase :: forall r. DebugName -> CodebasePath -> CodebaseLockOption -> MigrationStrategy -> (Codebase m v a -> m r) -> m (Either OpenCodebaseError r),
     -- | create a new codebase
-    withCreatedCodebase :: forall r. DebugName -> CodebasePath -> (Codebase m v a -> m r) -> m (Either CreateCodebaseError r),
+    withCreatedCodebase :: forall r. DebugName -> CodebasePath -> CodebaseLockOption -> (Codebase m v a -> m r) -> m (Either CreateCodebaseError r),
     -- | given a codebase root, and given that the codebase root may have other junk in it,
     -- give the path to the "actual" files; e.g. what a forked transcript should clone.
     codebasePath :: CodebasePath -> CodebasePath
@@ -85,10 +90,11 @@ createCodebaseWithResult ::
   Init m v a ->
   DebugName ->
   CodebasePath ->
+  CodebaseLockOption ->
   (Codebase m v a -> m r) ->
   m (Either (CodebasePath, InitError) r)
-createCodebaseWithResult cbInit debugName dir action =
-  createCodebase cbInit debugName dir action <&> mapLeft \case
+createCodebaseWithResult cbInit debugName dir lockOption action =
+  createCodebase cbInit debugName dir lockOption action <&> mapLeft \case
     errorMessage -> (dir, (CouldntCreateCodebase errorMessage))
 
 withOpenOrCreateCodebase ::
@@ -96,12 +102,13 @@ withOpenOrCreateCodebase ::
   Init m v a ->
   DebugName ->
   CodebaseInitOptions ->
+  CodebaseLockOption ->
   MigrationStrategy ->
   ((InitResult, CodebasePath, Codebase m v a) -> m r) ->
   m (Either (CodebasePath, InitError) r)
-withOpenOrCreateCodebase cbInit debugName initOptions migrationStrategy action = do
+withOpenOrCreateCodebase cbInit debugName initOptions lockOption migrationStrategy action = do
   let resolvedPath = initOptionsToDir initOptions
-  result <- withOpenCodebase cbInit debugName resolvedPath migrationStrategy \codebase -> do
+  result <- withOpenCodebase cbInit debugName resolvedPath lockOption migrationStrategy \codebase -> do
     action (OpenedCodebase, resolvedPath, codebase)
   case result of
     Right r -> pure $ Right r
@@ -114,7 +121,7 @@ withOpenOrCreateCodebase cbInit debugName initOptions migrationStrategy action =
               (do pure (Left (homeDir, FoundV1Codebase)))
               ( do
                   -- Create V2 codebase if neither a V1 or V2 exists
-                  createCodebaseWithResult cbInit debugName homeDir (\codebase -> action (CreatedCodebase, homeDir, codebase))
+                  createCodebaseWithResult cbInit debugName homeDir lockOption (\codebase -> action (CreatedCodebase, homeDir, codebase))
               )
           Specified specified ->
             ifM
@@ -124,14 +131,15 @@ withOpenOrCreateCodebase cbInit debugName initOptions migrationStrategy action =
                 DontCreateWhenMissing dir ->
                   pure (Left (dir, (InitErrorOpen OpenCodebaseDoesntExist)))
                 CreateWhenMissing dir ->
-                  createCodebaseWithResult cbInit debugName dir (\codebase -> action (CreatedCodebase, dir, codebase))
+                  createCodebaseWithResult cbInit debugName dir lockOption (\codebase -> action (CreatedCodebase, dir, codebase))
       OpenCodebaseUnknownSchemaVersion {} -> pure (Left (resolvedPath, InitErrorOpen err))
       OpenCodebaseRequiresMigration {} -> pure (Left (resolvedPath, InitErrorOpen err))
+      OpenCodebaseFileLockFailed {} -> pure (Left (resolvedPath, InitErrorOpen err))
 
-createCodebase :: MonadIO m => Init m v a -> DebugName -> CodebasePath -> (Codebase m v a -> m r) -> m (Either Pretty r)
-createCodebase cbInit debugName path action = do
+createCodebase :: MonadIO m => Init m v a -> DebugName -> CodebasePath -> CodebaseLockOption -> (Codebase m v a -> m r) -> m (Either Pretty r)
+createCodebase cbInit debugName path lockOption action = do
   prettyDir <- P.string <$> canonicalizePath path
-  withCreatedCodebase cbInit debugName path action <&> mapLeft \case
+  withCreatedCodebase cbInit debugName path lockOption action <&> mapLeft \case
     CreateCodebaseAlreadyExists ->
       P.wrap $
         "It looks like there's already a codebase in: "
@@ -141,30 +149,31 @@ createCodebase cbInit debugName path action = do
 
 -- previously: initCodebaseOrExit :: CodebasePath -> m (m (), Codebase m v a)
 -- previously: FileCodebase.initCodebase :: CodebasePath -> m (m (), Codebase m v a)
-withNewUcmCodebaseOrExit :: MonadIO m => Init m Symbol Ann -> DebugName -> CodebasePath -> (Codebase m Symbol Ann -> m r) -> m r
-withNewUcmCodebaseOrExit cbInit debugName path action = do
+withNewUcmCodebaseOrExit :: MonadIO m => Init m Symbol Ann -> DebugName -> CodebasePath -> CodebaseLockOption -> (Codebase m Symbol Ann -> m r) -> m r
+withNewUcmCodebaseOrExit cbInit debugName path lockOption action = do
   prettyDir <- P.string <$> canonicalizePath path
   let codebaseSetup codebase = do
         liftIO $ PT.putPrettyLn' . P.wrap $ "Initializing a new codebase in: " <> prettyDir
         Codebase.runTransaction codebase (Codebase.installUcmDependencies codebase)
-  createCodebase cbInit debugName path (\cb -> codebaseSetup cb *> action cb)
+  createCodebase cbInit debugName path lockOption (\cb -> codebaseSetup cb *> action cb)
     >>= \case
       Left error -> liftIO $ PT.putPrettyLn' error >> exitFailure
       Right result -> pure result
 
 -- | try to init a codebase where none exists and then exit regardless (i.e. `ucm --codebase dir init`)
-initCodebaseAndExit :: MonadIO m => Init m Symbol Ann -> DebugName -> Maybe CodebasePath -> m ()
-initCodebaseAndExit i debugName mdir = do
+initCodebaseAndExit :: MonadIO m => Init m Symbol Ann -> DebugName -> Maybe CodebasePath -> CodebaseLockOption -> m ()
+initCodebaseAndExit i debugName mdir lockOption = do
   codebaseDir <- Codebase.getCodebaseDir mdir
-  withNewUcmCodebaseOrExit i debugName codebaseDir (const $ pure ())
+  withNewUcmCodebaseOrExit i debugName codebaseDir lockOption (const $ pure ())
 
 withTemporaryUcmCodebase ::
   MonadUnliftIO m =>
   Init m Symbol Ann ->
   DebugName ->
+  CodebaseLockOption ->
   ((CodebasePath, Codebase m Symbol Ann) -> m r) ->
   m r
-withTemporaryUcmCodebase cbInit debugName action = do
+withTemporaryUcmCodebase cbInit debugName lockOption action = do
   UnliftIO.withSystemTempDirectory debugName $ \tempDir -> do
-    withNewUcmCodebaseOrExit cbInit debugName tempDir $ \codebase -> do
+    withNewUcmCodebaseOrExit cbInit debugName tempDir lockOption $ \codebase -> do
       action (tempDir, codebase)

--- a/parser-typechecker/src/Unison/Codebase/Init/OpenCodebaseError.hs
+++ b/parser-typechecker/src/Unison/Codebase/Init/OpenCodebaseError.hs
@@ -15,6 +15,7 @@ data OpenCodebaseError
     OpenCodebaseDoesntExist
   | -- | The codebase exists, but its schema version is unknown to this application.
     OpenCodebaseUnknownSchemaVersion SchemaVersion
+  | OpenCodebaseFileLockFailed
   | -- | The codebase exists, but requires a migration before it can be used.
     OpenCodebaseRequiresMigration
       -- current version

--- a/parser-typechecker/src/Unison/Codebase/RootBranchCache.hs
+++ b/parser-typechecker/src/Unison/Codebase/RootBranchCache.hs
@@ -1,0 +1,110 @@
+module Unison.Codebase.RootBranchCache
+  ( RootBranchCache,
+    newEmptyRootBranchCache,
+    newEmptyRootBranchCacheIO,
+    fetchRootBranch,
+    withLock,
+  )
+where
+
+import Control.Concurrent.STM (newTVarIO)
+import Control.Monad (join)
+import Control.Monad.IO.Class
+import Data.Coerce (coerce)
+import Unison.Codebase.Branch.Type (Branch)
+import qualified Unison.Sqlite as Sqlite
+import UnliftIO (MonadUnliftIO, mask, onException)
+import UnliftIO.STM
+  ( STM,
+    TVar,
+    atomically,
+    newTVar,
+    readTVar,
+    retrySTM,
+    writeTVar,
+  )
+
+data RootBranchCacheVal
+  = Empty
+  | -- | Another thread is updating the cache. If this value is observed
+    -- then the reader should wait until the value is Empty or Full. The
+    -- api exposed from this module guarantees that a thread cannot exit
+    -- and leave the cache in this state.
+    ConcurrentModification
+  | Full (Branch Sqlite.Transaction)
+
+-- This is isomorphic to @TMVar (Maybe (Branch Sqlite.Transaction))@
+newtype RootBranchCache = RootBranchCache (TVar RootBranchCacheVal)
+
+newEmptyRootBranchCacheIO :: MonadIO m => m RootBranchCache
+newEmptyRootBranchCacheIO = liftIO (coerce $ newTVarIO Empty)
+
+newEmptyRootBranchCache :: STM RootBranchCache
+newEmptyRootBranchCache = coerce (newTVar Empty)
+
+readRbc :: RootBranchCache -> STM RootBranchCacheVal
+readRbc (RootBranchCache v) = readTVar v
+
+writeRbc :: RootBranchCache -> RootBranchCacheVal -> STM ()
+writeRbc (RootBranchCache v) x = writeTVar v x
+
+-- | Read the root branch cache, wait if the cache is currently being
+-- updated
+readRootBranchCache :: RootBranchCache -> STM (Maybe (Branch Sqlite.Transaction))
+readRootBranchCache v =
+  readRbc v >>= \case
+    Empty -> pure Nothing
+    ConcurrentModification -> retrySTM
+    Full x -> pure (Just x)
+
+fetchRootBranch :: forall m. MonadUnliftIO m => RootBranchCache -> m (Branch Sqlite.Transaction) -> m (Branch Sqlite.Transaction)
+fetchRootBranch rbc getFromDb = mask \restore -> do
+  join (atomically (fetch restore))
+  where
+    fetch :: (forall x. m x -> m x) -> STM (m (Branch Sqlite.Transaction))
+    fetch restore = do
+      readRbc rbc >>= \case
+        Empty -> do
+          writeRbc rbc ConcurrentModification
+          pure do
+            rootBranch <- restore getFromDb `onException` atomically (writeRbc rbc Empty)
+            atomically (writeRbc rbc (Full rootBranch))
+            pure rootBranch
+        ConcurrentModification -> retrySTM
+        Full x -> pure (pure x)
+
+-- | Take a cache lock so that no other thread can read or write to
+-- the cache, perform an action with the cached value, then restore
+-- the cache to Empty or Full
+withLock ::
+  forall m r.
+  MonadUnliftIO m =>
+  RootBranchCache ->
+  -- | Perform an action with the cached value
+  ( -- restore masking state
+    (forall x. m x -> m x) ->
+    -- value retrieved from cache
+    Maybe (Branch Sqlite.Transaction) ->
+    m r
+  ) ->
+  -- | compute value to restore to the cache
+  (r -> Maybe (Branch Sqlite.Transaction)) ->
+  m r
+withLock v f g = mask \restore -> do
+  mbranch <- atomically (takeLock v)
+  r <- f restore mbranch `onException` releaseLock mbranch
+  releaseLock (g r)
+  pure r
+  where
+    releaseLock :: Maybe (Branch Sqlite.Transaction) -> m ()
+    releaseLock mbranch =
+      let !val = case mbranch of
+            Nothing -> Empty
+            Just x -> Full x
+       in atomically (writeRbc v val)
+
+takeLock :: RootBranchCache -> STM (Maybe (Branch Sqlite.Transaction))
+takeLock v = do
+  res <- readRootBranchCache v
+  writeRbc v ConcurrentModification
+  pure res

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/GitError.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/GitError.hs
@@ -6,6 +6,7 @@ import Unison.CodebasePath (CodebasePath)
 
 data GitSqliteCodebaseError
   = GitCouldntParseRootBranchHash ReadGitRepo String
+  | CodebaseFileLockFailed
   | NoDatabaseFile ReadGitRepo CodebasePath
   | UnrecognizedSchemaVersion ReadGitRepo CodebasePath SchemaVersion
   | CodebaseRequiresMigration SchemaVersion SchemaVersion

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Paths.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Paths.hs
@@ -3,6 +3,7 @@ module Unison.Codebase.SqliteCodebase.Paths
     makeCodebasePath,
     makeCodebaseDirPath,
     backupCodebasePath,
+    lockfilePath,
   )
 where
 
@@ -17,6 +18,9 @@ codebasePath = ".unison" </> "v2" </> "unison.sqlite3"
 -- | Makes a path to a sqlite database from a codebase path.
 makeCodebasePath :: CodebasePath -> FilePath
 makeCodebasePath root = makeCodebaseDirPath root </> "unison.sqlite3"
+
+lockfilePath :: CodebasePath -> FilePath
+lockfilePath root = makeCodebaseDirPath root </> "unison.lockfile"
 
 -- | Makes a path to the location where sqlite files are stored within a codebase path.
 makeCodebaseDirPath :: CodebasePath -> FilePath

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -159,3 +159,4 @@ gitErrorFromOpenCodebaseError path repo = \case
     UnrecognizedSchemaVersion repo path (fromIntegral v)
   OpenCodebaseRequiresMigration fromSv toSv ->
     CodebaseRequiresMigration fromSv toSv
+  OpenCodebaseFileLockFailed -> CodebaseFileLockFailed

--- a/parser-typechecker/tests/Unison/Test/CodebaseInit.hs
+++ b/parser-typechecker/tests/Unison/Test/CodebaseInit.hs
@@ -29,7 +29,7 @@ test =
             [ scope "a v2 codebase should be opened" do
                 tmp <- io (Temp.getCanonicalTemporaryDirectory >>= flip Temp.createTempDirectory "ucm-test")
                 cbInit <- io initMockWithCodebase
-                r <- io $ CI.withOpenOrCreateCodebase cbInit "ucm-test" (Home tmp) CI.DontMigrate \case
+                r <- io $ CI.withOpenOrCreateCodebase cbInit "ucm-test" (Home tmp) CI.DontLock CI.DontMigrate \case
                   (CI.OpenedCodebase, _, _) -> pure True
                   _ -> pure False
                 case r of
@@ -38,7 +38,7 @@ test =
               scope "a v2 codebase should be created when one does not exist" do
                 tmp <- io (Temp.getCanonicalTemporaryDirectory >>= flip Temp.createTempDirectory "ucm-test")
                 cbInit <- io initMockWithoutCodebase
-                r <- io $ CI.withOpenOrCreateCodebase cbInit "ucm-test" (Home tmp) CI.DontMigrate \case
+                r <- io $ CI.withOpenOrCreateCodebase cbInit "ucm-test" (Home tmp) CI.DontLock CI.DontMigrate \case
                   (CI.CreatedCodebase, _, _) -> pure True
                   _ -> pure False
                 case r of
@@ -51,7 +51,7 @@ test =
                 tmp <- io (Temp.getCanonicalTemporaryDirectory >>= flip Temp.createTempDirectory "ucm-test")
                 cbInit <- io initMockWithCodebase
                 res <- io $
-                  CI.withOpenOrCreateCodebase cbInit "ucm-test" (Specified (DontCreateWhenMissing tmp)) CI.DontMigrate $ \case
+                  CI.withOpenOrCreateCodebase cbInit "ucm-test" (Specified (DontCreateWhenMissing tmp)) CI.DontLock CI.DontMigrate $ \case
                     (CI.OpenedCodebase, _, _) -> pure True
                     _ -> pure False
                 case res of
@@ -61,7 +61,7 @@ test =
                 tmp <- io (Temp.getCanonicalTemporaryDirectory >>= flip Temp.createTempDirectory "ucm-test")
                 cbInit <- io initMockWithoutCodebase
                 res <- io $
-                  CI.withOpenOrCreateCodebase cbInit "ucm-test" (Specified (DontCreateWhenMissing tmp)) CI.DontMigrate $ \case
+                  CI.withOpenOrCreateCodebase cbInit "ucm-test" (Specified (DontCreateWhenMissing tmp)) CI.DontLock CI.DontMigrate $ \case
                     _ -> pure False
                 case res of
                   Left (_, CI.InitErrorOpen OpenCodebaseDoesntExist) -> expect True
@@ -72,7 +72,7 @@ test =
             [ scope "a v2 codebase should be created when one does not exist at the Specified dir" do
                 tmp <- io (Temp.getCanonicalTemporaryDirectory >>= flip Temp.createTempDirectory "ucm-test")
                 cbInit <- io initMockWithoutCodebase
-                res <- io $ CI.withOpenOrCreateCodebase cbInit "ucm-test" (Specified (CreateWhenMissing tmp)) CI.DontMigrate \case
+                res <- io $ CI.withOpenOrCreateCodebase cbInit "ucm-test" (Specified (CreateWhenMissing tmp)) CI.DontLock CI.DontMigrate \case
                   (CI.CreatedCodebase, _, _) -> pure True
                   _ -> pure False
                 case res of
@@ -81,7 +81,7 @@ test =
               scope "a v2 codebase should be opened when one exists" do
                 tmp <- io (Temp.getCanonicalTemporaryDirectory >>= flip Temp.createTempDirectory "ucm-test")
                 cbInit <- io initMockWithCodebase
-                res <- io $ CI.withOpenOrCreateCodebase cbInit "ucm-test" (Specified (CreateWhenMissing tmp)) CI.DontMigrate \case
+                res <- io $ CI.withOpenOrCreateCodebase cbInit "ucm-test" (Specified (CreateWhenMissing tmp)) CI.DontLock CI.DontMigrate \case
                   (CI.OpenedCodebase, _, _) -> pure True
                   _ -> pure False
                 case res of
@@ -98,9 +98,9 @@ initMockWithCodebase = do
   pure $
     Init
       { -- withOpenCodebase :: forall r. DebugName -> CodebasePath -> (Codebase m v a -> m r) -> m (Either Pretty r),
-        withOpenCodebase = \_ _ _ action -> Right <$> action codebase,
+        withOpenCodebase = \_ _ _ _ action -> Right <$> action codebase,
         -- withCreatedCodebase :: forall r. DebugName -> CodebasePath -> (Codebase m v a -> m r) -> m (Either CreateCodebaseError r),
-        withCreatedCodebase = \_ _ action -> Right <$> action codebase,
+        withCreatedCodebase = \_ _ _ action -> Right <$> action codebase,
         -- CodebasePath -> CodebasePath
         codebasePath = id
       }
@@ -110,9 +110,9 @@ initMockWithoutCodebase = do
   let codebase = error "did we /actually/ need a Codebase?"
   pure $
     Init
-      { withOpenCodebase = \_ _ _ _ -> pure (Left OpenCodebaseDoesntExist),
+      { withOpenCodebase = \_ _ _ _ _ -> pure (Left OpenCodebaseDoesntExist),
         -- withCreatedCodebase :: forall r. DebugName -> CodebasePath -> (Codebase m v a -> m r) -> m (Either CreateCodebaseError r),
-        withCreatedCodebase = \_ _ action -> Right <$> action codebase,
+        withCreatedCodebase = \_ _ _ action -> Right <$> action codebase,
         -- CodebasePath -> CodebasePath
         codebasePath = id
       }

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -59,6 +59,7 @@ library
       Unison.Codebase.Path
       Unison.Codebase.Path.Parse
       Unison.Codebase.PushBehavior
+      Unison.Codebase.RootBranchCache
       Unison.Codebase.Runtime
       Unison.Codebase.Serialization
       Unison.Codebase.ShortCausalHash

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -209,6 +209,7 @@ library
     , errors
     , exceptions
     , extra
+    , filelock
     , filepath
     , fingertree
     , free
@@ -394,6 +395,7 @@ test-suite parser-typechecker-tests
     , errors
     , exceptions
     , extra
+    , filelock
     , filemanip
     , filepath
     , fingertree

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1134,8 +1134,7 @@ notifyUser dir o = case o of
     GitSqliteCodebaseError e -> case e of
       CodebaseFileLockFailed ->
         P.wrap $
-          "Failed to obtain a file lock on the codebase. "
-            <> "Perhaps you are running multiple ucm processes against the same codebase."
+          "It looks to me like another ucm process is using this codebase. Only one ucm process can use a codebase at a time."
       NoDatabaseFile repo localPath ->
         P.wrap $
           "I didn't find a codebase in the repository at"

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -665,8 +665,8 @@ notifyUser dir o = case o of
     CachedTests 0 _ -> pure . P.callout "😶" $ "No tests to run."
     CachedTests n n'
       | n == n' ->
-        pure $
-          P.lines [cache, "", displayTestResults True ppe oks fails]
+          pure $
+            P.lines [cache, "", displayTestResults True ppe oks fails]
     CachedTests _n m ->
       pure $
         if m == 0
@@ -675,6 +675,7 @@ notifyUser dir o = case o of
             P.indentN 2 $
               P.lines ["", cache, "", displayTestResults False ppe oks fails, "", "✅  "]
       where
+
     NewlyComputed -> do
       clearCurrentLine
       pure $
@@ -1131,6 +1132,10 @@ notifyUser dir o = case o of
           else pure mempty
   GitError e -> pure $ case e of
     GitSqliteCodebaseError e -> case e of
+      CodebaseFileLockFailed ->
+        P.wrap $
+          "Failed to obtain a file lock on the codebase. "
+            <> "Perhaps you are running multiple ucm processes against the same codebase."
       NoDatabaseFile repo localPath ->
         P.wrap $
           "I didn't find a codebase in the repository at"
@@ -2463,7 +2468,7 @@ showDiffNamespace ::
   (Pretty, NumberedArgs)
 showDiffNamespace _ _ _ _ diffOutput
   | OBD.isEmpty diffOutput =
-    ("The namespaces are identical.", mempty)
+      ("The namespaces are identical.", mempty)
 showDiffNamespace sn ppe oldPath newPath OBD.BranchDiffOutput {..} =
   (P.sepNonEmpty "\n\n" p, toList args)
   where

--- a/unison-cli/tests/Unison/Test/Ucm.hs
+++ b/unison-cli/tests/Unison/Test/Ucm.hs
@@ -53,7 +53,7 @@ initCodebase fmt = do
   tmp <-
     Temp.getCanonicalTemporaryDirectory
       >>= flip Temp.createTempDirectory "ucm-test"
-  result <- Codebase.Init.withCreatedCodebase cbInit "ucm-test" tmp (const $ pure ())
+  result <- Codebase.Init.withCreatedCodebase cbInit "ucm-test" tmp SC.DoLock (const $ pure ())
   case result of
     Left CreateCodebaseAlreadyExists -> fail $ P.toANSI 80 "Codebase already exists"
     Right _ -> pure $ Codebase tmp fmt
@@ -66,7 +66,7 @@ runTranscript (Codebase codebasePath fmt) transcript = do
   let err e = fail $ "Parse error: \n" <> show e
       cbInit = case fmt of CodebaseFormat2 -> SC.init
   TR.withTranscriptRunner "Unison.Test.Ucm.runTranscript Invalid Version String" configFile $ \runner -> do
-    result <- Codebase.Init.withOpenCodebase cbInit "transcript" codebasePath SC.DontMigrate \codebase -> do
+    result <- Codebase.Init.withOpenCodebase cbInit "transcript" codebasePath SC.DoLock SC.DontMigrate \codebase -> do
       Codebase.runTransaction codebase (Codebase.installUcmDependencies codebase)
       let transcriptSrc = Text.pack . stripMargin $ unTranscript transcript
       output <- either err Text.unpack <$> runner "transcript" transcriptSrc (codebasePath, codebase)
@@ -81,7 +81,7 @@ runTranscript (Codebase codebasePath fmt) transcript = do
 lowLevel :: Codebase -> (Codebase.Codebase IO Symbol Ann -> IO a) -> IO a
 lowLevel (Codebase root fmt) action = do
   let cbInit = case fmt of CodebaseFormat2 -> SC.init
-  result <- Codebase.Init.withOpenCodebase cbInit "lowLevel" root SC.DontMigrate action
+  result <- Codebase.Init.withOpenCodebase cbInit "lowLevel" root SC.DoLock SC.DontMigrate action
   case result of
     Left e -> PT.putPrettyLn (P.shown e) *> pure (error "This really should have loaded")
     Right a -> pure a

--- a/unison-cli/transcripts/Transcripts.hs
+++ b/unison-cli/transcripts/Transcripts.hs
@@ -34,7 +34,7 @@ type TestBuilder = FilePath -> [String] -> String -> Test ()
 testBuilder ::
   Bool -> FilePath -> [String] -> String -> Test ()
 testBuilder expectFailure dir prelude transcript = scope transcript $ do
-  outputs <- io . withTemporaryUcmCodebase SC.init "transcript" $ \(codebasePath, codebase) -> do
+  outputs <- io . withTemporaryUcmCodebase SC.init "transcript" SC.DoLock $ \(codebasePath, codebase) -> do
     withTranscriptRunner "TODO: pass version here" Nothing $ \runTranscript -> do
       for files $ \filePath -> do
         transcriptSrc <- readUtf8 filePath


### PR DESCRIPTION
I noticed two bugs in the root branch codebase cache on trunk:

1. concurrent calls to `getRootBranch` can force fetching the root branch from sqlite multiple times (I noticed this while profiling). 
2. `putRootBranch` fails to update the cache if it the current cache value is `Nothing` (a misplaced `fmap` I think)

This PR fixes those bugs. Additionally, it removes the sqlite data version check from `getRootBranch`. It is my understanding that the check is to protect against two ucm clients being open and working against the same codebase, invalidating one another's root branch cache (although I don't think the loop state root branch cache is checked, so I'm not sure we are preventing anything). To prevent the multiple ucm issue an exclusive file lock is obtained when opening ucm.

At some point I think we should clean up/document the different root branch caches. We have a codebase-local root branch cache (that this PR modifies), a loop state branch cache, and another root branch var used for LSP. Getting it all straight when reading was confusing, it's not very clear to me that they should to be separate vars, but if they should we could benefit from documenting each one, what they are for, and how they interact.

Reviewing this PR as two separate commits will make more sense than reading all together.