### PR TITLE
Avoid justifying case arrows if the pattern doesn't fit

### DIFF
--- a/unison-src/transcripts/lambdacase.output.md
+++ b/unison-src/transcripts/lambdacase.output.md
@@ -105,8 +105,8 @@ Notice that Unison detects this as an alias of `merge`, and if we view `merge`
 
   merge : [a] -> [a] -> [a]
   merge = cases
-    [], ys           -> ys
-    xs, []           -> xs
+    [], ys -> ys
+    xs, [] -> xs
     h +: t, h2 +: t2 ->
       if h <= h2 then h +: merge t (h2 +: t2)
       else h2 +: merge (h +: t) t2


### PR DESCRIPTION
This is a small change to the pretty-printer to make code with large patterns more readable.

Before:

```
NatMap.Nonempty.Tip k1 v1, NatMap.Nonempty.Tip k2 v2                                     ->
  Ordering.andThen (ordering k1 k2) (f v1 v2)
t1@(NatMap.Nonempty.Bin p1 mask1 sz1 l1 r1), t2@(NatMap.Nonempty.Bin p2 mask2 sz2 l2 r2) ->
  ...
t1@(NatMap.Nonempty.Tip _ _), NatMap.Nonempty.Bin _ _ _ l2 _                             ->
  go t1 l2
NatMap.Nonempty.Bin _ _ _ l1 _, t2@(NatMap.Nonempty.Tip _ _)                             ->
  go l1 t2   
t1, t2                                                                                   ->
   Equal
```

This would cause weird wrapping with `->` confusingly on its own line if the display is too narrow.

After: 

```
NatMap.Nonempty.Tip k1 v1, NatMap.Nonempty.Tip k2 v2 ->
  Ordering.andThen (ordering k1 k2) (f v1 v2)
t1@(NatMap.Nonempty.Bin p1 mask1 sz1 l1 r1), t2@(NatMap.Nonempty.Bin p2 mask2 sz2 l2 r2) ->
  ...
t1@(NatMap.Nonempty.Tip _ _), NatMap.Nonempty.Bin _ _ _ l2 _ ->
  go t1 l2
NatMap.Nonempty.Bin _ _ _ l1 _, t2@(NatMap.Nonempty.Tip _ _) ->
  go l1 t2
t1, t2 ->
  Equal
```

A better fix would be to break the long patterns into lines, but that's a more involved change.