### PR TITLE
Eta-reduce Doc term links to undo compiler expansion

### DIFF
--- a/unison-share-api/src/Unison/Server/Doc.hs
+++ b/unison-share-api/src/Unison/Server/Doc.hs
@@ -220,7 +220,10 @@ renderDoc pped terms typeOf eval types tm =
             ty r = (NP.styleHashQualified'' (NP.fmt (S.TypeReference r)) . PPE.typeName ppe) r
          in Link <$> case e of
               DD.EitherLeft' (Term.TypeLink' r) -> (pure . formatPretty . ty) r
-              DD.EitherRight' (DD.Doc2Term (Term.Referent' r)) -> (pure . formatPretty . tm) r
+              DD.EitherRight' (DD.Doc2Term t) ->
+                case Term.etaNormalForm t of
+                  Term.Referent' r -> (pure . formatPretty . tm) r
+                  x -> source x
               _ -> source e
       DD.Doc2SpecialFormSignature (Term.List' tms) ->
         let rs = [r | DD.Doc2Term (Term.Referent' r) <- toList tms]

--- a/unison-src/transcripts/fix3634.md
+++ b/unison-src/transcripts/fix3634.md
@@ -1,5 +1,4 @@
 ```ucm:hide
-.> builtins.merge
 .> builtins.mergeio
 ```
 

--- a/unison-src/transcripts/fix3634.md
+++ b/unison-src/transcripts/fix3634.md
@@ -1,0 +1,22 @@
+```ucm:hide
+.> builtins.merge
+.> builtins.mergeio
+```
+
+
+```unison
+structural type M a = N | J a
+
+d = {{
+
+{{ docExample 0 '(x -> J x) }}
+
+{J}
+
+}}
+```
+
+```ucm
+.> add
+.> display d
+```

--- a/unison-src/transcripts/fix3634.output.md
+++ b/unison-src/transcripts/fix3634.output.md
@@ -1,0 +1,41 @@
+```unison
+structural type M a = N | J a
+
+d = {{
+
+{{ docExample 0 '(x -> J x) }}
+
+{J}
+
+}}
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      structural type M a
+        (also named builtin.Optional)
+      d : Doc2
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    structural type M a
+      (also named builtin.Optional)
+    d : Doc2
+
+.> display d
+
+  `x -> J x`
+  
+  J
+
+```


### PR DESCRIPTION
Fixes #3582

For a doc like this:

````
medoc = {{ 

```
x -> Some x
```

{Some}

}}
````

Rendering before: 

```
      x -> Some x
      ⧨
      Some

  Right (Term.Term (Any '(x -> Some x)))
```

Rendering after: 

```
      x -> Some x
      ⧨
      Some

  Some
```

That last `Some` is properly rendered as a link to the `Optional` type.
