### PR TITLE
Add `diff.namespace.to-patch` command

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/BranchDiff.hs
+++ b/parser-typechecker/src/Unison/Codebase/BranchDiff.hs
@@ -46,7 +46,7 @@ data BranchDiff = BranchDiff
   deriving (Show)
 
 diff0 :: forall m. Monad m => Branch0 m -> Branch0 m -> m BranchDiff
-diff0 old new = BranchDiff terms types <$> patchDiff old new
+diff0 old new = BranchDiff (traceShowId terms) types <$> patchDiff old new
   where
     (terms, types) =
       computeSlices

--- a/parser-typechecker/src/Unison/Codebase/BranchDiff.hs
+++ b/parser-typechecker/src/Unison/Codebase/BranchDiff.hs
@@ -98,22 +98,24 @@ computeSlices oldTerms newTerms oldTypes newTypes = (termsOut, typesOut)
       let nc = allNames oldTerms newTerms
           nu = allNamespaceUpdates oldTerms newTerms
        in DiffSlice
-            nu
-            (allAdds nc nu)
-            (allRemoves nc nu)
-            (remainingNameChanges nc)
-            (addedMetadata oldTerms newTerms)
-            (removedMetadata oldTerms newTerms)
+            { tallnamespaceUpdates = nu,
+              talladds = allAdds nc nu,
+              tallremoves = allRemoves nc nu,
+              trenames = remainingNameChanges nc,
+              taddedMetadata = addedMetadata oldTerms newTerms,
+              tremovedMetadata = removedMetadata oldTerms newTerms
+            }
     typesOut =
       let nc = allNames oldTypes newTypes
           nu = allNamespaceUpdates oldTypes newTypes
        in DiffSlice
-            nu
-            (allAdds nc nu)
-            (allRemoves nc nu)
-            (remainingNameChanges nc)
-            (addedMetadata oldTypes newTypes)
-            (removedMetadata oldTypes newTypes)
+            { tallnamespaceUpdates = nu,
+              talladds = allAdds nc nu,
+              tallremoves = allRemoves nc nu,
+              trenames = remainingNameChanges nc,
+              taddedMetadata = addedMetadata oldTypes newTypes,
+              tremovedMetadata = removedMetadata oldTypes newTypes
+            }
 
     allNames :: Ord r => NamespaceSlice r -> NamespaceSlice r -> Map r (Set Name, Set Name)
     allNames old new = R.outerJoinDomMultimaps (names old) (names new)

--- a/parser-typechecker/src/Unison/Codebase/BranchDiff.hs
+++ b/parser-typechecker/src/Unison/Codebase/BranchDiff.hs
@@ -36,17 +36,17 @@ data DiffSlice r = DiffSlice
     taddedMetadata :: Relation3 r Name Metadata.Value,
     tremovedMetadata :: Relation3 r Name Metadata.Value
   }
-  deriving (Show)
+  deriving stock (Generic, Show)
 
 data BranchDiff = BranchDiff
   { termsDiff :: DiffSlice Referent,
     typesDiff :: DiffSlice Reference,
     patchesDiff :: Map Name (DiffType PatchDiff)
   }
-  deriving (Show)
+  deriving stock (Generic, Show)
 
 diff0 :: forall m. Monad m => Branch0 m -> Branch0 m -> m BranchDiff
-diff0 old new = BranchDiff (traceShowId terms) types <$> patchDiff old new
+diff0 old new = BranchDiff terms types <$> patchDiff old new
   where
     (terms, types) =
       computeSlices

--- a/unison-cli/src/Unison/Cli/MonadUtils.hs
+++ b/unison-cli/src/Unison/Cli/MonadUtils.hs
@@ -13,6 +13,7 @@ module Unison.Cli.MonadUtils
 
     -- ** Resolving branch identifiers
     resolveAbsBranchId,
+    resolveBranchId,
     resolveShortCausalHash,
 
     -- ** Getting/setting branches
@@ -143,6 +144,13 @@ resolveAbsBranchId :: Input.AbsBranchId -> Cli (Branch IO)
 resolveAbsBranchId = \case
   Left hash -> resolveShortCausalHash hash
   Right path -> getBranchAt path
+
+-- | Resolve a @BranchId@ to the corresponding @Branch IO@, or fail if no such branch hash is found. (Non-existent
+-- branches by path are OK - the empty branch will be returned).
+resolveBranchId  :: Input.BranchId -> Cli (Branch IO)
+resolveBranchId branchId = do
+  absBranchId <- traverseOf _Right resolvePath' branchId
+  resolveAbsBranchId absBranchId
 
 -- | Resolve a @ShortCausalHash@ to the corresponding @Branch IO@, or fail if no such branch hash is found.
 resolveShortCausalHash :: ShortCausalHash -> Cli (Branch IO)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -64,6 +64,7 @@ import Unison.Codebase.Branch (Branch (..), Branch0 (..))
 import qualified Unison.Codebase.Branch as Branch
 import qualified Unison.Codebase.Branch.Merge as Branch
 import qualified Unison.Codebase.Branch.Names as Branch
+import qualified Unison.Codebase.BranchDiff as BranchDiff (diff0)
 import qualified Unison.Codebase.BranchUtil as BranchUtil
 import qualified Unison.Codebase.Causal as Causal
 import Unison.Codebase.Editor.AuthorInfo (AuthorInfo (..))
@@ -120,8 +121,10 @@ import qualified Unison.Codebase.ShortCausalHash as SCH
 import qualified Unison.Codebase.SqliteCodebase.Conversions as Cv
 import qualified Unison.Codebase.SyncMode as SyncMode
 import Unison.Codebase.TermEdit (TermEdit (..))
+import qualified Unison.Codebase.TermEdit as TermEdit
 import qualified Unison.Codebase.TermEdit.Typing as TermEdit
 import Unison.Codebase.Type (GitPushBehavior (..))
+import Unison.Codebase.TypeEdit (TypeEdit)
 import qualified Unison.Codebase.TypeEdit as TypeEdit
 import qualified Unison.Codebase.Verbosity as Verbosity
 import qualified Unison.CommandLine.Completion as Completion
@@ -1779,7 +1782,64 @@ handleGist (GistInput repo) =
 
 handleOinkletI :: Cli ()
 handleOinkletI = do
-  pure ()
+  Cli.Env {codebase} <- ask
+
+  let branchId1 = Right (Name.convert @Path.Absolute @Path' (Path.Absolute (Path.fromList ["oink1"])))
+  let branchId2 = Right (Name.convert @Path.Absolute @Path' (Path.Absolute (Path.fromList ["oink2"])))
+  branch1 <- Branch.head <$> Cli.resolveBranchId branchId1
+  branch2 <- Branch.head <$> Cli.resolveBranchId branchId2
+  branchDiff <- liftIO (BranchDiff.diff0 branch1 branch2)
+
+  -- Given {old referents} and {new referents}, create term edit patch entries as follows:
+  --
+  --   * If the {new referents} is a singleton set {new referent}, proceed. (Otherwise, the patch we might create would
+  --     not be a function, which is a bogus/conflicted patch).
+  --   * If the new referent is a term reference, not a data constructor, proceed. (Patches currently can't track
+  --     updates to data constructors).
+  --   * For each old term reference (again, throwing constructors away) in {old referents}, create a patch entry that
+  --     maps the old reference to the new. The patch entry includes the typing relationship between the terms, so we
+  --     look the references' types up in the codebase, too.
+  let termNamespaceUpdateToTermEdits :: (Set Referent, Set Referent) -> Sqlite.Transaction (Set (Reference, TermEdit))
+      termNamespaceUpdateToTermEdits (refs0, refs1) =
+        case Set.asSingleton refs1 of
+          Just (Referent.Ref ref1) ->
+            Codebase.getTypeOfTerm codebase ref1 >>= \case
+              Nothing -> pure Set.empty
+              Just ty1 ->
+                Monoid.foldMapM
+                  ( \ref0 ->
+                      Codebase.getTypeOfTerm codebase ref0 <&> \case
+                        Nothing -> Set.empty
+                        Just ty0 -> Set.singleton (ref0, TermEdit.Replace ref1 (TermEdit.typing ty0 ty1))
+                  )
+                  (mapMaybe Referent.toTermReference (Set.toList refs0))
+          _ -> pure Set.empty
+
+  -- The same idea as above, but for types: if there's one new reference in {new references}, then map each of the old
+  -- references to it.
+  let typeNamespaceUpdateToTypeEdits :: (Set Reference, Set Reference) -> Set (Reference, TypeEdit)
+      typeNamespaceUpdateToTypeEdits (refs0, refs1) =
+        case Set.asSingleton refs1 of
+          Just ref1 -> Set.map (\ref0 -> (ref0, TypeEdit.Replace ref1)) refs0
+          _ -> Set.empty
+
+  termUpdates <-
+    Cli.runTransaction do
+      (branchDiff ^. #termsDiff . #tallnamespaceUpdates)
+        & Map.elems
+        & Monoid.foldMapM termNamespaceUpdateToTermEdits
+  let typeUpdates =
+        (branchDiff ^. #typesDiff . #tallnamespaceUpdates)
+          & Map.elems
+          & foldMap typeNamespaceUpdateToTypeEdits
+
+  let patch =
+        Patch
+          { _termEdits = Relation.fromSet termUpdates,
+            _typeEdits = Relation.fromSet typeUpdates
+          }
+
+  liftIO (print patch)
 
 -- | Handle a @push@ command.
 handlePushRemoteBranch :: PushRemoteBranchInput -> Cli ()

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1575,7 +1575,11 @@ inputDescription input =
     RemoveTypeReplacementI src p0 -> do
       p <- opatch p0
       pure ("delete.type-replacement" <> HQ.toText src <> " " <> p)
-    DiffNamespaceToPatchI _ -> if False then wundefined else pure "diff.namespace.toPatch"
+    DiffNamespaceToPatchI input -> do
+      branchId1 <- hp' (input ^. #branchId1)
+      branchId2 <- hp' (input ^. #branchId2)
+      patch <- ps' (input ^. #patch)
+      pure (Text.unwords ["diff.namespace.to-patch", branchId1, branchId2, patch])
     --
     ApiI -> wat
     AuthLoginI {} -> wat

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -207,6 +207,7 @@ data Input
   | GistI GistInput
   | AuthLoginI
   | VersionI
+  | OinkletI
   deriving (Eq, Show)
 
 -- | @"push.gist repo"@ pushes the contents of the current namespace to @repo@.

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -1,5 +1,6 @@
 module Unison.Codebase.Editor.Input
   ( Input (..),
+    DiffNamespaceToPatchInput (..),
     GistInput (..),
     PushRemoteBranchInput (..),
     TestInput (..),
@@ -207,8 +208,18 @@ data Input
   | GistI GistInput
   | AuthLoginI
   | VersionI
-  | OinkletI
+  | DiffNamespaceToPatchI DiffNamespaceToPatchInput
   deriving (Eq, Show)
+
+data DiffNamespaceToPatchInput = DiffNamespaceToPatchInput
+  { -- The first/earlier namespace.
+    branchId1 :: BranchId,
+    -- The second/later namespace.
+    branchId2 :: BranchId,
+    -- Where to store the patch that corresponds to the diff between the namespaces.
+    patch :: Path.Split'
+  }
+  deriving stock (Eq, Generic, Show)
 
 -- | @"push.gist repo"@ pushes the contents of the current namespace to @repo@.
 data GistInput = GistInput

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2286,6 +2286,17 @@ authLogin =
         _ -> Left (showPatternHelp authLogin)
     )
 
+oinklet :: InputPattern
+oinklet =
+  InputPattern
+    { patternName = if False then wundefined else "oinklet",
+      aliases = [],
+      visibility = I.Hidden,
+      argTypes = [],
+      help = "oinklet",
+      parse = \_ -> Right Input.OinkletI
+    }
+
 printVersion :: InputPattern
 printVersion =
   InputPattern
@@ -2403,7 +2414,8 @@ validInputs =
       debugNameDiff,
       gist,
       authLogin,
-      printVersion
+      printVersion,
+      oinklet
     ]
 
 -- | A map of all command patterns by pattern name or alias.

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2286,17 +2286,6 @@ authLogin =
         _ -> Left (showPatternHelp authLogin)
     )
 
-oinklet :: InputPattern
-oinklet =
-  InputPattern
-    { patternName = if False then wundefined else "oinklet",
-      aliases = [],
-      visibility = I.Hidden,
-      argTypes = [],
-      help = "oinklet",
-      parse = \_ -> Right Input.OinkletI
-    }
-
 printVersion :: InputPattern
 printVersion =
   InputPattern
@@ -2310,6 +2299,24 @@ printVersion =
         [] -> Right $ Input.VersionI
         _ -> Left (showPatternHelp printVersion)
     )
+
+diffNamespaceToPatch :: InputPattern
+diffNamespaceToPatch =
+  InputPattern
+    { patternName = "diff.namespace.toPatch",
+      aliases = [],
+      visibility = I.Visible,
+      argTypes = [],
+      help = if False then wundefined else "diff.namespace.toPatch",
+      parse = \case
+        [branchId1, branchId2, patch] ->
+          mapLeft fromString do
+            branchId1 <- Input.parseBranchId branchId1
+            branchId2 <- Input.parseBranchId branchId2
+            patch <- Path.parseSplit' Path.definitionNameSegment patch
+            pure (Input.DiffNamespaceToPatchI Input.DiffNamespaceToPatchInput {branchId1, branchId2, patch})
+        _ -> Left (showPatternHelp diffNamespaceToPatch)
+    }
 
 validInputs :: [InputPattern]
 validInputs =
@@ -2415,7 +2422,7 @@ validInputs =
       gist,
       authLogin,
       printVersion,
-      oinklet
+      diffNamespaceToPatch
     ]
 
 -- | A map of all command patterns by pattern name or alias.

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2303,11 +2303,11 @@ printVersion =
 diffNamespaceToPatch :: InputPattern
 diffNamespaceToPatch =
   InputPattern
-    { patternName = "diff.namespace.toPatch",
+    { patternName = "diff.namespace.to-patch",
       aliases = [],
       visibility = I.Visible,
       argTypes = [],
-      help = if False then wundefined else "diff.namespace.toPatch",
+      help = P.wrap "Create a patch from a namespace diff.",
       parse = \case
         [branchId1, branchId2, patch] ->
           mapLeft fromString do


### PR DESCRIPTION
Fixes #3638 

## Overview

This PR adds a `diff.namespace.to-patch` command, which creates a patch out of a namespace diff.

Usage:

```
diff.namespace.to-patch <namespace-1> <namespace-2> <patch-name>
```

This command creates a namespace diff (a la `diff.namespace`) between `<namespace-1>` and `<namespace-2>`, and creates a patch from its "namespace updates" fields (one for terms, one for types).

The "namespace updates" contains, for each name that appears in both of the given namespaces, the two sets of references that the name is related to in each.

For example, a simple update of a term `foo#abc` to `foo#def` would result in the pair of sets

```
{#abc}, {#def}
```

indicating that the name `foo`  referred to `#abc` in `<namespace-1>`, and `#def` in `<namespace-2>`.

For all such pairs of sets whose second set contains only one element, we construct a patch that maps each element in the left set to the element in the second set.

For example, the pair of sets

```
{#a, #b, #c}, {#d}
```

would result in a patch with entries

```
#a -> #d
#b -> #d
#c -> #d
```

If the second set is not a singleton, we don't include anything in the patch for that name. This is because, for whatever reason, that name is related to multiple references in `<namespace-2>`; such a patch is not a function and would not be able to be applied ("this patch is conflicted").

The `<patch-name>` argument overwrites any existing patch with that name.

The user is shown the patch that's created, as if they typed `view.patch <patch-name>`.