### PR TITLE
Build names index for testing timing

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
@@ -5,6 +5,7 @@ module U.Codebase.Sqlite.Operations
     expectRootCausalHash,
     expectRootCausal,
     expectRootBranchHash,
+    loadRootBranchHash,
     loadCausalHashAtPath,
     expectCausalHashAtPath,
     saveBranch,
@@ -202,6 +203,11 @@ expectRootBranchHash :: Transaction BranchHash
 expectRootBranchHash = do
   rootCausalHashId <- Q.expectNamespaceRoot
   expectValueHashByCausalHashId rootCausalHashId
+
+loadRootBranchHash :: Transaction (Maybe BranchHash)
+loadRootBranchHash = runMaybeT do
+  rootCausalHashId <- MaybeT Q.loadNamespaceRoot
+  lift $ expectValueHashByCausalHashId rootCausalHashId
 
 loadRootCausalHash :: Transaction (Maybe CausalHash)
 loadRootCausalHash =

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -301,7 +301,7 @@ sqliteCodebase debugName root localOrRemote lockOption migrationStrategy action 
                       let toRootCausalHash = Cv.causalHash1to2 (Branch.headHash branch1)
                       let toRootBranchHash = Cv.namespaceHashToBranchHash (Branch.namespaceHash branch1)
                       CodebaseOps.putRootBranch branch1Trans
-                      Timing.unsafeTime "Updating Name Lookup Index" $ updateNameLookup Path.empty mayFromRootBranchHash toRootBranchHash
+                      Timing.timeM Sqlite.unsafeIO "Updating Name Lookup Index" $ updateNameLookup Path.empty mayFromRootBranchHash toRootBranchHash
                       Ops.appendReflog (Reflog.Entry {time = now, fromRootCausalHash, toRootCausalHash, reason})
 
                 -- We need to update the database and the cached

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Conversions.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Conversions.hs
@@ -340,6 +340,9 @@ causalHash2to1 = V1.Causal.CausalHash . V2.unCausalHash
 causalHash1to2 :: V1.Branch.CausalHash -> V2.CausalHash
 causalHash1to2 = V2.CausalHash . V1.Causal.unCausalHash
 
+namespaceHashToBranchHash :: V1.Branch.NamespaceHash m -> V2.BranchHash
+namespaceHashToBranchHash = V2.BranchHash . V1.genericHash
+
 ttype2to1 :: V2.Term.Type V2.Symbol -> V1.Type.Type V1.Symbol Ann
 ttype2to1 = type2to1' reference2to1
 


### PR DESCRIPTION
## Overview

Note: don't merge this.

Keep a name lookup index within UCM. This PR only starts tracking it from change to change, notably it doesn't actually use the index for anything, nor does it build the initial index if one is missing, so it's not useful for anything except determining how long certain actions take to update the index.

Use by pulling this branch, building and running locally with:

```
UNISON_DEBUG=TIMING stack exec unison
```

E.g.

```
.> pull unison.public.base.latest
...
Finished Updating Name Lookup Index in 0.691455s (cpu), 0.614272s (system)

```