### PR TITLE
Include file symbols in PPE used for rendering diagnostics (LSP)

### DIFF
--- a/parser-typechecker/src/Unison/PrettyPrintEnvDecl.hs
+++ b/parser-typechecker/src/Unison/PrettyPrintEnvDecl.hs
@@ -4,6 +4,7 @@ module Unison.PrettyPrintEnvDecl
   ( PrettyPrintEnvDecl (..),
     biasTo,
     empty,
+    addFallback,
   )
 where
 
@@ -35,3 +36,7 @@ biasTo targets PrettyPrintEnvDecl {unsuffixifiedPPE, suffixifiedPPE} =
 
 empty :: PrettyPrintEnvDecl
 empty = PrettyPrintEnvDecl PPE.empty PPE.empty
+
+addFallback :: PrettyPrintEnvDecl -> PrettyPrintEnvDecl -> PrettyPrintEnvDecl
+addFallback (PrettyPrintEnvDecl unsuff1 suff1) (PrettyPrintEnvDecl unsuff2 suff2) =
+  PrettyPrintEnvDecl (unsuff1 `PPE.addFallback` unsuff2) (suff1 `PPE.addFallback` suff2)

--- a/unison-cli/src/Unison/LSP.hs
+++ b/unison-cli/src/Unison/LSP.hs
@@ -110,15 +110,15 @@ lspDoInitialize vfsVar codebase runtime scope latestBranch latestPath lspContext
   -- things to be generated before serving requests.
   checkedFilesVar <- newTVarIO mempty
   dirtyFilesVar <- newTVarIO mempty
-  ppeCacheVar <- newTVarIO PPED.empty
+  ppedCacheVar <- newTVarIO PPED.empty
   parseNamesCacheVar <- newTVarIO mempty
   currentPathCacheVar <- newTVarIO Path.absoluteEmpty
   cancellationMapVar <- newTVarIO mempty
   completionsVar <- newTVarIO mempty
-  let env = Env {ppeCache = readTVarIO ppeCacheVar, parseNamesCache = readTVarIO parseNamesCacheVar, currentPathCache = readTVarIO currentPathCacheVar, ..}
+  let env = Env {ppedCache = readTVarIO ppedCacheVar, parseNamesCache = readTVarIO parseNamesCacheVar, currentPathCache = readTVarIO currentPathCacheVar, ..}
   let lspToIO = flip runReaderT lspContext . unLspT . flip runReaderT env . runLspM
   Ki.fork scope (lspToIO Analysis.fileAnalysisWorker)
-  Ki.fork scope (lspToIO $ ucmWorker ppeCacheVar parseNamesCacheVar latestBranch latestPath)
+  Ki.fork scope (lspToIO $ ucmWorker ppedCacheVar parseNamesCacheVar latestBranch latestPath)
   pure $ Right $ env
 
 -- | LSP request handlers that don't register/unregister dynamically

--- a/unison-cli/src/Unison/LSP/Completion.hs
+++ b/unison-cli/src/Unison/LSP/Completion.hs
@@ -38,7 +38,7 @@ completionHandler :: RequestMessage 'TextDocumentCompletion -> (Either ResponseE
 completionHandler m respond =
   respond . maybe (Right $ InL mempty) (Right . InR) =<< runMaybeT do
     (range, prefix) <- MaybeT $ VFS.completionPrefix (m ^. params)
-    ppe <- PPED.suffixifiedPPE <$> lift globalPPE
+    ppe <- PPED.suffixifiedPPE <$> lift globalPPED
     completions <- lift getCompletions
     Config {maxCompletions} <- lift getConfig
     let defMatches = matchCompletions completions prefix

--- a/unison-cli/src/Unison/LSP/Types.hs
+++ b/unison-cli/src/Unison/LSP/Types.hs
@@ -67,7 +67,7 @@ data Env = Env
     lspContext :: LanguageContextEnv Config,
     codebase :: Codebase IO Symbol Ann,
     parseNamesCache :: IO NamesWithHistory,
-    ppeCache :: IO PrettyPrintEnvDecl,
+    ppedCache :: IO PrettyPrintEnvDecl,
     currentPathCache :: IO Path.Absolute,
     vfsVar :: MVar VFS,
     runtime :: Runtime Symbol,
@@ -119,8 +119,8 @@ getCurrentPath = asks currentPathCache >>= liftIO
 getCompletions :: Lsp CompletionTree
 getCompletions = asks completionsVar >>= readTVarIO
 
-globalPPE :: Lsp PrettyPrintEnvDecl
-globalPPE = asks ppeCache >>= liftIO
+globalPPED :: Lsp PrettyPrintEnvDecl
+globalPPED = asks ppedCache >>= liftIO
 
 getParseNames :: Lsp NamesWithHistory
 getParseNames = asks parseNamesCache >>= liftIO


### PR DESCRIPTION
## Overview

fixes #3651 

The LSP isn't currently including symbols from within the file when rendering diagnostic errors:

![image](https://user-images.githubusercontent.com/6439644/205133034-c5fe6fc0-3c53-4b1c-9a13-d1ed1030d3bb.png)

This fixes that.

## Implementation notes

* Include names from the typechecked file in the ppe for diagnostics, or if we didn't typecheck, names from the parsed file. In all cases, fall back to names from the codebase if not found within the file, or if the file didn't even parse.

Tested it out by loading this scratch file:

```
structural ability X where
  useX : Nat -> ()

x : ()
x = useX 1
```

The error message used to reference X by its hash, now it uses the name `X`
