### PR TITLE
Blocks enforce that actions return `()`

### DIFF
--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -19,7 +19,7 @@ import qualified Data.Set.NonEmpty as NES
 import qualified Data.Text as Text
 import qualified Text.Megaparsec as P
 import qualified Unison.ABT as ABT
-import Unison.Builtin.Decls (pattern TupleType')
+import Unison.Builtin.Decls (pattern TupleType', unitRef)
 import qualified Unison.Codebase.Path as Path
 import Unison.ConstructorReference (ConstructorReference, GConstructorReference (..))
 import Unison.HashQualified (HashQualified)
@@ -364,7 +364,7 @@ renderTypeError e env src curPath = case e of
   Mismatch {..} ->
     mconcat
       [ Pr.lines
-          [ "I found a value of type:  " <> style Type1 (renderType' env foundLeaf),
+          [ "I found a value  of type:  " <> style Type1 (renderType' env foundLeaf),
             "where I expected to find:  " <> style Type2 (renderType' env expectedLeaf)
           ],
         "\n\n",
@@ -375,13 +375,17 @@ renderTypeError e env src curPath = case e of
             -- , (,Color.ForceShow) <$> rangeForType foundType
             -- , (,Color.ForceShow) <$> rangeForType expectedType
             -- ,
-            (,Type1) <$> rangeForAnnotated mismatchSite,
+            (,Type1) <$> rangeForAnnotated foundLeaf,
             (,Type2) <$> rangeForAnnotated expectedLeaf
           ],
         fromOverHere'
           src
           [styleAnnotated Type1 foundLeaf]
           [styleAnnotated Type1 mismatchSite],
+        if giveUnitHint then 
+          "\nNote: actions within a block must have type " <> 
+             style Type2 (renderType' env expectedLeaf)    <> ".\n" 
+        else "",
         intLiteralSyntaxTip mismatchSite expectedType,
         debugNoteLoc
           . mconcat
@@ -400,6 +404,12 @@ renderTypeError e env src curPath = case e of
             ],
         debugSummary note
       ]
+      where
+        giveUnitHint = case expectedType of  
+          Type.Ref' u | u == unitRef -> case mismatchSite of 
+            Term.Let1Named' v _ _ -> Var.isAction v
+            _ -> False
+          _ -> False
   AbilityCheckFailure {..}
     | [tv@(Type.Var' ev)] <- ambient,
       ev `Set.member` foldMap Type.freeVars requested ->

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -375,17 +375,14 @@ renderTypeError e env src curPath = case e of
             -- , (,Color.ForceShow) <$> rangeForType foundType
             -- , (,Color.ForceShow) <$> rangeForType expectedType
             -- ,
-            (,Type1) <$> rangeForAnnotated foundLeaf,
+            (,Type1) <$> rangeForAnnotated foundType,
             (,Type2) <$> rangeForAnnotated expectedLeaf
           ],
         fromOverHere'
           src
           [styleAnnotated Type1 foundLeaf]
-          [styleAnnotated Type1 mismatchSite],
-        if giveUnitHint then 
-          "\nNote: actions within a block must have type " <> 
-             style Type2 (renderType' env expectedLeaf)    <> ".\n" 
-        else "",
+          [styleAnnotated Type1 expectedLeaf],
+        unitHint,
         intLiteralSyntaxTip mismatchSite expectedType,
         debugNoteLoc
           . mconcat
@@ -405,6 +402,10 @@ renderTypeError e env src curPath = case e of
         debugSummary note
       ]
       where
+        unitHintMsg = 
+          "\nNote: actions within a block must have type " <> 
+             style Type2 (renderType' env expectedLeaf)    <> ".\n" 
+        unitHint = if giveUnitHint then unitHintMsg else "" 
         giveUnitHint = case expectedType of  
           Type.Ref' u | u == unitRef -> case mismatchSite of 
             Term.Let1Named' v _ _ -> Var.isAction v

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -403,8 +403,9 @@ renderTypeError e env src curPath = case e of
       ]
       where
         unitHintMsg = 
-          "\nNote: actions within a block must have type " <> 
-             style Type2 (renderType' env expectedLeaf)    <> ".\n" 
+          "\nHint: Actions within a block must have type " <> 
+             style Type2 (renderType' env expectedLeaf)    <> ".\n" <> 
+             "      Use " <> style Type1 "_ = <expr>" <> " to ignore a result."  
         unitHint = if giveUnitHint then unitHintMsg else "" 
         giveUnitHint = case expectedType of  
           Type.Ref' u | u == unitRef -> case mismatchSite of 

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -375,13 +375,13 @@ renderTypeError e env src curPath = case e of
             -- , (,Color.ForceShow) <$> rangeForType foundType
             -- , (,Color.ForceShow) <$> rangeForType expectedType
             -- ,
-            (,Type1) <$> rangeForAnnotated foundType,
+            (,Type1) . startingLine <$> (rangeForAnnotated mismatchSite),
             (,Type2) <$> rangeForAnnotated expectedLeaf
           ],
         fromOverHere'
           src
           [styleAnnotated Type1 foundLeaf]
-          [styleAnnotated Type1 expectedLeaf],
+          [styleAnnotated Type2 expectedLeaf],
         unitHint,
         intLiteralSyntaxTip mismatchSite expectedType,
         debugNoteLoc

--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -509,7 +509,7 @@ pretty0
           body (Constructor' (ConstructorReference DD.UnitRef 0)) | elideUnit = pure []
           body e = (: []) <$> pretty0 (ac 0 Normal im doc) e
           printBinding (v, binding) =
-            if isBlank $ Var.nameStr v
+            if Var.isAction v
               then pretty0 (ac (-1) Normal im doc) binding
               else prettyBinding0 (ac (-1) Normal im doc) (HQ.unsafeFromVar v) binding
           letIntro = case sc of
@@ -966,10 +966,6 @@ isSymbolic' name = case symbolyId . Name.toString $ name of
   Right _ -> True
   _ -> False
 
-isBlank :: String -> Bool
-isBlank ('_' : rest) | isJust (readMaybe rest :: Maybe Int) = True
-isBlank _ = False
-
 emptyAc :: AmbientContext
 emptyAc = ac (-1) Normal Map.empty MaybeDoc
 
@@ -1410,7 +1406,7 @@ immediateChildBlockTerms = \case
     handleDelay (Delay' b@(Lets' _ _)) = [b]
     handleDelay _ = []
     doLet (v, Ann' tm _) = doLet (v, tm)
-    doLet (v, LamsNamedOpt' _ body) = [body | not (isBlank $ Var.nameStr v)]
+    doLet (v, LamsNamedOpt' _ body) = [body | not (Var.isAction v)]
     doLet t = error (show t) []
 
 -- Matches with a single case, no variable shadowing, and where the pattern

--- a/unison-core/src/Unison/Var.hs
+++ b/unison-core/src/Unison/Var.hs
@@ -14,6 +14,7 @@ module Unison.Var
     inferPatternPureV,
     inferTypeConstructor,
     inferTypeConstructorArg,
+    isAction,
     joinDot,
     missingResult,
     name,
@@ -86,6 +87,19 @@ name v = rawName (typeOf v) <> showid v
   where
     showid (freshId -> 0) = ""
     showid (freshId -> n) = pack (show n)
+
+-- | Currently, actions in blocks are encoded as bindings
+-- with names of the form _123 (an underscore, followed by 
+-- 1 or more digits). This function returns `True` if the
+-- input variable has this form.
+-- 
+-- Various places check for this (the pretty-printer, to
+-- determine how to print the binding), and the typechecker
+-- (to decide if it should ensure the binding has type `()`).
+isAction :: Var v => v -> Bool
+isAction v = case Text.unpack (name v) of
+  ('_' : rest) | Just _ <- (readMaybe rest :: Maybe Int) -> True
+  _ -> False
 
 uncapitalize :: Var v => v -> v
 uncapitalize v = nameds $ go (nameStr v)

--- a/unison-src/transcripts-round-trip/main.md
+++ b/unison-src/transcripts-round-trip/main.md
@@ -456,7 +456,7 @@ afun x f = f x
 
 roundtripLastLam =
   afun "foo" (n -> let
-    1 + 1
+    _ = 1 + 1
     3
   )
 ```

--- a/unison-src/transcripts-using-base/base.u
+++ b/unison-src/transcripts-using-base/base.u
@@ -9,6 +9,7 @@ compose2 f g = a -> b -> f (g a b)
 compose3 f g = a -> b -> c -> f (g a b c)
 
 id a = a
+void x = ()
 
 structural ability Exception where
   raise: io2.Failure -> anything

--- a/unison-src/transcripts-using-base/failure-tests.md
+++ b/unison-src/transcripts-using-base/failure-tests.md
@@ -13,12 +13,12 @@ tested here.
 ```unison
 test1 : '{IO, Exception} [Result]
 test1 = do
-  fromUtf8 0xsee
+  _ = fromUtf8 0xsee
   [Ok "test1"]
 
 test2 : '{IO, Exception} [Result]
 test2 = do
-  tryEval '(bug "whoa")
+  _ = tryEval '(bug "whoa")
   [Ok "test2"]
 ```
 

--- a/unison-src/transcripts-using-base/failure-tests.output.md
+++ b/unison-src/transcripts-using-base/failure-tests.output.md
@@ -9,12 +9,12 @@ tested here.
 ```unison
 test1 : '{IO, Exception} [Result]
 test1 = do
-  fromUtf8 0xsee
+  _ = fromUtf8 0xsee
   [Ok "test1"]
 
 test2 : '{IO, Exception} [Result]
 test2 = do
-  tryEval '(bug "whoa")
+  _ = tryEval '(bug "whoa")
   [Ok "test2"]
 ```
 

--- a/unison-src/transcripts-using-base/fix2049.md
+++ b/unison-src/transcripts-using-base/fix2049.md
@@ -15,7 +15,7 @@ tests _ =
   [ catcher do
       match None with Some x -> x
   , catcher do
-      1/0
+      _ = 1/0
       ()
   , catcher '(bug "testing")
   , handle tryEval (do 1+1) with cases

--- a/unison-src/transcripts-using-base/fix2049.output.md
+++ b/unison-src/transcripts-using-base/fix2049.output.md
@@ -11,7 +11,7 @@ tests _ =
   [ catcher do
       match None with Some x -> x
   , catcher do
-      1/0
+      _ = 1/0
       ()
   , catcher '(bug "testing")
   , handle tryEval (do 1+1) with cases

--- a/unison-src/transcripts-using-base/fix3166.md
+++ b/unison-src/transcripts-using-base/fix3166.md
@@ -8,7 +8,7 @@ functions.
 ```unison
 Stream.fromList : [a] -> '{Stream a} ()
 Stream.fromList l _ =
-  List.map (x -> emit x) l
+  _ = List.map (x -> emit x) l
   ()
 
 Stream.map : (a -> b) -> '{Stream a} r -> '{Stream b} r

--- a/unison-src/transcripts-using-base/fix3166.output.md
+++ b/unison-src/transcripts-using-base/fix3166.output.md
@@ -4,7 +4,7 @@ functions.
 ```unison
 Stream.fromList : [a] -> '{Stream a} ()
 Stream.fromList l _ =
-  List.map (x -> emit x) l
+  _ = List.map (x -> emit x) l
   ()
 
 Stream.map : (a -> b) -> '{Stream a} r -> '{Stream b} r

--- a/unison-src/transcripts-using-base/net.md
+++ b/unison-src/transcripts-using-base/net.md
@@ -137,8 +137,8 @@ testTcpConnect = 'let
     
     toSend = "12345"
 
-    forkComp (serverThread portVar toSend)
-    forkComp (clientThread portVar resultVar)
+    void (forkComp (serverThread portVar toSend))
+    void (forkComp (clientThread portVar resultVar))
     
     received = take resultVar
 

--- a/unison-src/transcripts-using-base/net.output.md
+++ b/unison-src/transcripts-using-base/net.output.md
@@ -165,8 +165,8 @@ testTcpConnect = 'let
     
     toSend = "12345"
 
-    forkComp (serverThread portVar toSend)
-    forkComp (clientThread portVar resultVar)
+    void (forkComp (serverThread portVar toSend))
+    void (forkComp (clientThread portVar resultVar))
     
     received = take resultVar
 

--- a/unison-src/transcripts-using-base/stm.md
+++ b/unison-src/transcripts-using-base/stm.md
@@ -39,8 +39,8 @@ spawn k = let
   out1 = TVar.newIO None
   out2 = TVar.newIO None
   counter = atomically '(TVar.new 0)
-  forkComp '(Right (body k out1 counter))
-  forkComp '(Right (body k out2 counter))
+  void (forkComp '(Right (body k out1 counter)))
+  void (forkComp '(Right (body k out2 counter)))
   p = atomically 'let
     r1 = TVar.read out1
     r2 = TVar.swap out2 None

--- a/unison-src/transcripts-using-base/stm.output.md
+++ b/unison-src/transcripts-using-base/stm.output.md
@@ -60,8 +60,8 @@ spawn k = let
   out1 = TVar.newIO None
   out2 = TVar.newIO None
   counter = atomically '(TVar.new 0)
-  forkComp '(Right (body k out1 counter))
-  forkComp '(Right (body k out2 counter))
+  void (forkComp '(Right (body k out1 counter)))
+  void (forkComp '(Right (body k out2 counter)))
   p = atomically 'let
     r1 = TVar.read out1
     r2 = TVar.swap out2 None

--- a/unison-src/transcripts-using-base/thread.md
+++ b/unison-src/transcripts-using-base/thread.md
@@ -38,7 +38,7 @@ testBasicMultiThreadMVar : '{io2.IO} [Result]
 testBasicMultiThreadMVar = 'let
   test = 'let
     mv = !newEmpty
-    .builtin.io2.IO.forkComp (thread1 10 mv)
+    void (forkComp (thread1 10 mv))
     next = take mv
     expectU "other thread should have incremented" 11 next
 
@@ -79,8 +79,8 @@ testTwoThreads = 'let
     send = !MVar.newEmpty
     recv = !MVar.newEmpty
 
-    .builtin.io2.IO.forkComp (sendingThread 6 send)
-    .builtin.io2.IO.forkComp (receivingThread send recv)
+    void (forkComp (sendingThread 6 send))
+    void (forkComp (receivingThread send recv))
 
     recvd = take recv
 

--- a/unison-src/transcripts-using-base/thread.output.md
+++ b/unison-src/transcripts-using-base/thread.output.md
@@ -45,7 +45,7 @@ testBasicMultiThreadMVar : '{io2.IO} [Result]
 testBasicMultiThreadMVar = 'let
   test = 'let
     mv = !newEmpty
-    .builtin.io2.IO.forkComp (thread1 10 mv)
+    void (forkComp (thread1 10 mv))
     next = take mv
     expectU "other thread should have incremented" 11 next
 
@@ -113,8 +113,8 @@ testTwoThreads = 'let
     send = !MVar.newEmpty
     recv = !MVar.newEmpty
 
-    .builtin.io2.IO.forkComp (sendingThread 6 send)
-    .builtin.io2.IO.forkComp (receivingThread send recv)
+    void (forkComp (sendingThread 6 send))
+    void (forkComp (receivingThread send recv))
 
     recvd = take recv
 

--- a/unison-src/transcripts-using-base/tls.md
+++ b/unison-src/transcripts-using-base/tls.md
@@ -137,7 +137,7 @@ testConnectSelfSigned _ =
     cert = decodeCert (toUtf8 self_signed_cert_pem2)
     received = !(testClient (Some cert) "test.unison.cloud" portVar)
 
-    kill.impl tid
+    _ = kill.impl tid
 
     expectU "should have reaped what we've sown" toSend received
 

--- a/unison-src/transcripts-using-base/tls.output.md
+++ b/unison-src/transcripts-using-base/tls.output.md
@@ -154,7 +154,7 @@ testConnectSelfSigned _ =
     cert = decodeCert (toUtf8 self_signed_cert_pem2)
     received = !(testClient (Some cert) "test.unison.cloud" portVar)
 
-    kill.impl tid
+    _ = kill.impl tid
 
     expectU "should have reaped what we've sown" toSend received
 

--- a/unison-src/transcripts/anf-tests.md
+++ b/unison-src/transcripts/anf-tests.md
@@ -16,10 +16,11 @@ remain in the definition of `baz`.
 ```unison
 foo _ =
   id x = x
+  void x = ()
   bar = let
-    Debug.watch "hello" "hello"
+    void (Debug.watch "hello" "hello")
     result = 5
-    Debug.watch "goodbye" "goodbye"
+    void (Debug.watch "goodbye" "goodbye")
     result
   baz = id bar
   baz

--- a/unison-src/transcripts/anf-tests.output.md
+++ b/unison-src/transcripts/anf-tests.output.md
@@ -12,10 +12,11 @@ remain in the definition of `baz`.
 ```unison
 foo _ =
   id x = x
+  void x = ()
   bar = let
-    Debug.watch "hello" "hello"
+    void (Debug.watch "hello" "hello")
     result = 5
-    Debug.watch "goodbye" "goodbye"
+    void (Debug.watch "goodbye" "goodbye")
     result
   baz = id bar
   baz
@@ -36,7 +37,7 @@ foo _ =
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.
 
-    11 | > !foo
+    12 | > !foo
            ⧩
            5
 

--- a/unison-src/transcripts/doc-formatting.md
+++ b/unison-src/transcripts/doc-formatting.md
@@ -9,7 +9,7 @@ Docs can be used as inline code comments.
 ```unison
 foo : Nat -> Nat
 foo n =
-  [: do the thing :]
+  _ = [: do the thing :]
   n + 1
 ```
 

--- a/unison-src/transcripts/doc-formatting.output.md
+++ b/unison-src/transcripts/doc-formatting.output.md
@@ -5,7 +5,7 @@ Docs can be used as inline code comments.
 ```unison
 foo : Nat -> Nat
 foo n =
-  [: do the thing :]
+  _ = [: do the thing :]
   n + 1
 ```
 
@@ -26,7 +26,7 @@ foo n =
   foo : Nat -> Nat
   foo n =
     use Nat +
-    [: do the thing :]
+    _ = [: do the thing :]
     n + 1
 
 ```
@@ -500,7 +500,7 @@ But note it's not obvious how display should best be handling this.  At the mome
   foo : Nat -> Nat
   foo n =
     use Nat +
-    [: do the thing :]
+    _ = [: do the thing :]
     n + 1    ▶    bar
   
 

--- a/unison-src/transcripts/fix1800.md
+++ b/unison-src/transcripts/fix1800.md
@@ -6,7 +6,7 @@
 ```unison:hide
 printLine : Text ->{IO} ()
 printLine msg =
-  putBytes.impl (stdHandle StdOut) (Text.toUtf8 (msg ++ "\n"))
+  _ = putBytes.impl (stdHandle StdOut) (Text.toUtf8 (msg ++ "\n"))
   ()
 
 -- An unannotated main function

--- a/unison-src/transcripts/fix1800.output.md
+++ b/unison-src/transcripts/fix1800.output.md
@@ -2,7 +2,7 @@
 ```unison
 printLine : Text ->{IO} ()
 printLine msg =
-  putBytes.impl (stdHandle StdOut) (Text.toUtf8 (msg ++ "\n"))
+  _ = putBytes.impl (stdHandle StdOut) (Text.toUtf8 (msg ++ "\n"))
   ()
 
 -- An unannotated main function

--- a/unison-src/transcripts/fix2354.output.md
+++ b/unison-src/transcripts/fix2354.output.md
@@ -15,6 +15,13 @@ x = 'f
   where I expected to find:  (a -> 𝕣1) -> 𝕣
   
       1 | f : (forall a . a -> a) -> Nat
+      2 | f id = id 0
+      3 | 
+      4 | x = 'f
+  
+    from right here:
+  
+      1 | f : (forall a . a -> a) -> Nat
   
 
 ```

--- a/unison-src/transcripts/fix2354.output.md
+++ b/unison-src/transcripts/fix2354.output.md
@@ -11,13 +11,10 @@ x = 'f
 
 ```ucm
 
-  I found a value of type:  (a1 ->{𝕖} a1) ->{𝕖} Nat
+  I found a value  of type:  (a1 ->{𝕖} a1) ->{𝕖} Nat
   where I expected to find:  (a -> 𝕣1) -> 𝕣
   
       1 | f : (forall a . a -> a) -> Nat
-      2 | f id = id 0
-      3 | 
-      4 | x = 'f
   
     from right here:
   

--- a/unison-src/transcripts/fix2354.output.md
+++ b/unison-src/transcripts/fix2354.output.md
@@ -16,9 +16,5 @@ x = 'f
   
       1 | f : (forall a . a -> a) -> Nat
   
-    from right here:
-  
-      1 | f : (forall a . a -> a) -> Nat
-  
 
 ```

--- a/unison-src/transcripts/fix614.md
+++ b/unison-src/transcripts/fix614.md
@@ -1,0 +1,54 @@
+```ucm:hide
+.> builtins.merge
+```
+
+This transcript demonstrates that Unison forces actions in blocks to have a return type of `()`.
+
+This works, as expected:
+
+```unison
+structural ability Stream a where emit : a -> ()
+
+ex1 = do
+  Stream.emit 1 
+  Stream.emit 2
+  42
+```
+
+```ucm:hide
+.> add
+```
+
+This does not typecheck, we've accidentally underapplied `Stream.emit`:
+
+```unison:error
+ex2 = do
+  Stream.emit
+  42
+```
+
+We can explicitly ignore an unused result like so:
+
+```unison
+ex3 = do
+  _ = Stream.emit
+  ()
+```
+
+Using a helper function like `void` also works fine:
+
+```unison
+void x = ()
+
+ex4 =
+  void [1,2,3]
+  ()
+```
+
+One more example:
+
+```unison:error
+ex4 =
+  [1,2,3] -- no good
+  ()
+```

--- a/unison-src/transcripts/fix614.output.md
+++ b/unison-src/transcripts/fix614.output.md
@@ -38,8 +38,8 @@ ex2 = do
   
       2 |   Stream.emit
   
-  Note: actions within a block must have type Unit.
-  
+  Hint: Actions within a block must have type Unit.
+        Use _ = <expr> to ignore a result.
 
 ```
 We can explicitly ignore an unused result like so:
@@ -98,7 +98,7 @@ ex4 =
   
       2 |   [1,2,3] -- no good
   
-  Note: actions within a block must have type Unit.
-  
+  Hint: Actions within a block must have type Unit.
+        Use _ = <expr> to ignore a result.
 
 ```

--- a/unison-src/transcripts/fix614.output.md
+++ b/unison-src/transcripts/fix614.output.md
@@ -37,6 +37,7 @@ ex2 = do
   where I expected to find:  Unit
   
       2 |   Stream.emit
+      3 |   42
   
   Hint: Actions within a block must have type Unit.
         Use _ = <expr> to ignore a result.
@@ -95,6 +96,11 @@ ex4 =
 
   I found a value  of type:  [Nat]
   where I expected to find:  Unit
+  
+      2 |   [1,2,3] -- no good
+      3 |   ()
+  
+    from right here:
   
       2 |   [1,2,3] -- no good
   

--- a/unison-src/transcripts/fix614.output.md
+++ b/unison-src/transcripts/fix614.output.md
@@ -33,11 +33,12 @@ ex2 = do
 
 ```ucm
 
-  I found a value of type:  a ->{Stream a} Unit
+  I found a value  of type:  a ->{Stream a} Unit
   where I expected to find:  Unit
   
       2 |   Stream.emit
-      3 |   42
+  
+  Note: actions within a block must have type Unit.
   
 
 ```
@@ -92,15 +93,16 @@ ex4 =
 
 ```ucm
 
-  I found a value of type:  [Nat]
+  I found a value  of type:  [Nat]
   where I expected to find:  Unit
   
       2 |   [1,2,3] -- no good
-      3 |   ()
   
     from right here:
   
       2 |   [1,2,3] -- no good
+  
+  Note: actions within a block must have type Unit.
   
 
 ```

--- a/unison-src/transcripts/fix614.output.md
+++ b/unison-src/transcripts/fix614.output.md
@@ -98,10 +98,6 @@ ex4 =
   
       2 |   [1,2,3] -- no good
   
-    from right here:
-  
-      2 |   [1,2,3] -- no good
-  
   Note: actions within a block must have type Unit.
   
 

--- a/unison-src/transcripts/fix614.output.md
+++ b/unison-src/transcripts/fix614.output.md
@@ -1,0 +1,106 @@
+This transcript demonstrates that Unison forces actions in blocks to have a return type of `()`.
+
+This works, as expected:
+
+```unison
+structural ability Stream a where emit : a -> ()
+
+ex1 = do
+  Stream.emit 1 
+  Stream.emit 2
+  42
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      structural ability Stream a
+      ex1 : '{Stream Nat} Nat
+
+```
+This does not typecheck, we've accidentally underapplied `Stream.emit`:
+
+```unison
+ex2 = do
+  Stream.emit
+  42
+```
+
+```ucm
+
+  I found a value of type:  a ->{Stream a} Unit
+  where I expected to find:  Unit
+  
+      2 |   Stream.emit
+      3 |   42
+  
+
+```
+We can explicitly ignore an unused result like so:
+
+```unison
+ex3 = do
+  _ = Stream.emit
+  ()
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      ex3 : '()
+
+```
+Using a helper function like `void` also works fine:
+
+```unison
+void x = ()
+
+ex4 =
+  void [1,2,3]
+  ()
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      ex4  : ()
+      void : x -> ()
+
+```
+One more example:
+
+```unison
+ex4 =
+  [1,2,3] -- no good
+  ()
+```
+
+```ucm
+
+  I found a value of type:  [Nat]
+  where I expected to find:  Unit
+  
+      2 |   [1,2,3] -- no good
+      3 |   ()
+  
+    from right here:
+  
+      2 |   [1,2,3] -- no good
+  
+
+```

--- a/unison-src/transcripts/fix693.output.md
+++ b/unison-src/transcripts/fix693.output.md
@@ -47,10 +47,6 @@ h0 req = match req with
   
       1 | h0 : Request {X t} b -> Optional b
   
-    from right here:
-  
-      1 | h0 : Request {X t} b -> Optional b
-  
 
 ```
 This code should not check because `t` does not match `b`.

--- a/unison-src/transcripts/fix693.output.md
+++ b/unison-src/transcripts/fix693.output.md
@@ -42,12 +42,10 @@ h0 req = match req with
 
 ```ucm
 
-  I found a value of type:  Optional a1
+  I found a value  of type:  Optional a1
   where I expected to find:  Optional a
   
       1 | h0 : Request {X t} b -> Optional b
-      2 | h0 req = match req with
-      3 |   { X.x _ c -> _ } -> handle c with h0
   
     from right here:
   

--- a/unison-src/transcripts/fix693.output.md
+++ b/unison-src/transcripts/fix693.output.md
@@ -46,6 +46,12 @@ h0 req = match req with
   where I expected to find:  Optional a
   
       1 | h0 : Request {X t} b -> Optional b
+      2 | h0 req = match req with
+      3 |   { X.x _ c -> _ } -> handle c with h0
+  
+    from right here:
+  
+      1 | h0 : Request {X t} b -> Optional b
   
 
 ```

--- a/unison-src/transcripts/hello.output.md
+++ b/unison-src/transcripts/hello.output.md
@@ -83,7 +83,7 @@ hmm = "Not, in fact, a number"
 
 ```ucm
 
-  I found a value of type:  Text
+  I found a value  of type:  Text
   where I expected to find:  Nat
   
       1 | hmm : .builtin.Nat

--- a/unison-src/transcripts/hello.output.md
+++ b/unison-src/transcripts/hello.output.md
@@ -89,5 +89,9 @@ hmm = "Not, in fact, a number"
       1 | hmm : .builtin.Nat
       2 | hmm = "Not, in fact, a number"
   
+    from right here:
+  
+      2 | hmm = "Not, in fact, a number"
+  
 
 ```

--- a/unison-src/transcripts/higher-rank.md
+++ b/unison-src/transcripts/higher-rank.md
@@ -21,7 +21,7 @@ Another example, involving abilities. Here the ability-polymorphic function is i
 ```unison
 f : (forall a g . '{g} a -> '{g} a) -> () -> () 
 f id _ = 
-  (id ('1 : '{} Nat), id ('("hi") : '{IO} Text))
+  _ = (id ('1 : '{} Nat), id ('("hi") : '{IO} Text))
   ()
 ```
 

--- a/unison-src/transcripts/higher-rank.output.md
+++ b/unison-src/transcripts/higher-rank.output.md
@@ -33,7 +33,7 @@ Another example, involving abilities. Here the ability-polymorphic function is i
 ```unison
 f : (forall a g . '{g} a -> '{g} a) -> () -> () 
 f id _ = 
-  (id ('1 : '{} Nat), id ('("hi") : '{IO} Text))
+  _ = (id ('1 : '{} Nat), id ('("hi") : '{IO} Text))
   ()
 ```
 

--- a/unison-src/transcripts/io.md
+++ b/unison-src/transcripts/io.md
@@ -38,7 +38,8 @@ testCreateRename _ =
     tempDir = newTempDir "fileio"
     fooDir = tempDir ++ "/foo"
     barDir = tempDir ++ "/bar"
-    createDirectory.impl fooDir
+    void x = ()
+    void (createDirectory.impl fooDir)
     check "create a foo directory" (isDirectory fooDir)
     check "directory should exist" (fileExists fooDir)
     renameDirectory fooDir barDir
@@ -47,8 +48,8 @@ testCreateRename _ =
     check "bar should now exist" (fileExists barDir)
 
     bazDir = barDir ++ "/baz"
-    createDirectory.impl bazDir
-    removeDirectory.impl barDir
+    void (createDirectory.impl bazDir)
+    void (removeDirectory.impl barDir)
 
     check "removeDirectory works recursively" (not (isDirectory barDir))
     check "removeDirectory works recursively" (not (isDirectory bazDir))

--- a/unison-src/transcripts/io.output.md
+++ b/unison-src/transcripts/io.output.md
@@ -26,7 +26,8 @@ testCreateRename _ =
     tempDir = newTempDir "fileio"
     fooDir = tempDir ++ "/foo"
     barDir = tempDir ++ "/bar"
-    createDirectory.impl fooDir
+    void x = ()
+    void (createDirectory.impl fooDir)
     check "create a foo directory" (isDirectory fooDir)
     check "directory should exist" (fileExists fooDir)
     renameDirectory fooDir barDir
@@ -35,8 +36,8 @@ testCreateRename _ =
     check "bar should now exist" (fileExists barDir)
 
     bazDir = barDir ++ "/baz"
-    createDirectory.impl bazDir
-    removeDirectory.impl barDir
+    void (createDirectory.impl bazDir)
+    void (removeDirectory.impl barDir)
 
     check "removeDirectory works recursively" (not (isDirectory barDir))
     check "removeDirectory works recursively" (not (isDirectory bazDir))

--- a/unison-src/transcripts/universal-cmp.md
+++ b/unison-src/transcripts/universal-cmp.md
@@ -12,9 +12,7 @@ unique type A = A
 threadEyeDeez _ =
   t1 = forkComp '()
   t2 = forkComp '()
-  t1 == t2 
-  t1 < t2
-  ()
+  (t1 == t2, t1 < t2)
 ```
 
 ```ucm

--- a/unison-src/transcripts/universal-cmp.output.md
+++ b/unison-src/transcripts/universal-cmp.output.md
@@ -8,9 +8,7 @@ unique type A = A
 threadEyeDeez _ =
   t1 = forkComp '()
   t2 = forkComp '()
-  t1 == t2 
-  t1 < t2
-  ()
+  (t1 == t2, t1 < t2)
 ```
 
 ```ucm
@@ -22,7 +20,7 @@ threadEyeDeez _ =
     ⍟ These new definitions are ok to `add`:
     
       unique type A
-      threadEyeDeez : ∀ _. _ ->{IO} ()
+      threadEyeDeez : ∀ _. _ ->{IO} (Boolean, Boolean)
 
 ```
 ```ucm
@@ -31,11 +29,11 @@ threadEyeDeez _ =
   ⍟ I've added these definitions:
   
     unique type A
-    threadEyeDeez : ∀ _. _ ->{IO} ()
+    threadEyeDeez : ∀ _. _ ->{IO} (Boolean, Boolean)
 
 .> run threadEyeDeez
 
-  ()
+  (false, true)
 
 ```
 ```unison


### PR DESCRIPTION
@stew and I recently wasted another 30 minutes being bit by Unison gleefully allowing non-`()` actions in blocks, so I decided to take a crack at fixing this and it was quite easy. 

There is a minor change to 3 lines of the typechecker, a very minor update to the prettyprinter, and I updated the error message printer to detect this case and give a nice message. 

A number of transcripts were changed as they were reliant on the old behavior.

Closes #614

This modifies the typechecker so that code like this no longer typechecks: 

```haskell
main = do
  Stream.emit -- oops, underapplied!
  ()
```

<img width="658" alt="image" src="https://user-images.githubusercontent.com/11074/205376859-5ea6f426-cd6a-4cce-8112-111362e04c36.png">

Instead, you'll have to explicitly ignore, using something like:

```haskell
main = do
  _ = Stream.emit
  ()

-- alternately
main2 = do
  void Stream.emit
  ()
```

See [the transcript](https://github.com/unisonweb/unison/pull/3655/files#diff-ce00beb0766862294065f9c16ae5f8b2efd9f33da5fea875502d088072af97b9) for more examples.

Also updated a number of existing transcripts which were taking advantage of this loophole and now have to be explicit about where they're discarding values.

# Interesting stuff and scope of this PR

In working on this, I discovered that the way actions are represented in a block is just as bindings with a name of the form `_123` (a single underscore followed by 1 or more digits). A bit janky. I didn't have the stamina to seriously consider a more comprehensive fix for that, but I think the way you'd do it is with a new type of variable which makes this explicit ("this is an ignored variable"). But then that would have to become a codebase schema change, since you want that to survive a round trip to the codebase? Alternately, you could change the AST to make this explicit, but that seems more complex to me (and it's also a schema change). 

Anyway, I'm not touching that for this PR but it would be good future cleanup work.

I did factor out the logic into a new `Var.isAction` function which is used in both the pretty-printer and the typechecker to detect this situation.