### PR TITLE
Small cleanup follow-up to #3527

### DIFF
--- a/unison-core/src/Unison/Name.hs
+++ b/unison-core/src/Unison/Name.hs
@@ -57,7 +57,7 @@ import qualified Data.List.NonEmpty as List.NonEmpty
 import qualified Data.Map as Map
 import qualified Data.RFC5051 as RFC5051
 import qualified Data.Set as Set
-import Unison.Name.Internal (Name (..))
+import Unison.Name.Internal
 import Unison.NameSegment (NameSegment (NameSegment))
 import qualified Unison.NameSegment as NameSegment
 import Unison.Position (Position (..))
@@ -169,14 +169,6 @@ stripReversedPrefix (Name p segs) suffix = do
   stripped <- List.stripSuffix suffix (toList segs)
   nonEmptyStripped <- List.NonEmpty.nonEmpty stripped
   pure $ Name p nonEmptyStripped
-
--- | Is this name absolute?
---
--- /O(1)/.
-isAbsolute :: Name -> Bool
-isAbsolute = \case
-  Name Absolute _ -> True
-  Name Relative _ -> False
 
 -- | @isPrefixOf x y@ returns whether @x@ is a prefix of (or equivalent to) @y@, which is false if one name is relative
 -- and the other is absolute.
@@ -320,16 +312,6 @@ searchByRankedSuffix suffix rel = case searchBySuffix suffix rel of
       minLibs [] = 0
       minLibs ns = minimum (map libCount ns)
       ok name = compareSuffix suffix name == EQ
-
--- | Return the name segments of a name.
---
--- >>> segments "a.b.c"
--- "a" :| ["b", "c"]
---
--- /O(n)/, where /n/ is the number of name segments.
-segments :: Name -> NonEmpty NameSegment
-segments (Name _ ss) =
-  List.NonEmpty.reverse ss
 
 sortByText :: (a -> Text) -> [a] -> [a]
 sortByText by as =

--- a/unison-core/src/Unison/Util/Alphabetical.hs
+++ b/unison-core/src/Unison/Util/Alphabetical.hs
@@ -4,6 +4,7 @@
 
 module Unison.Util.Alphabetical where
 
+import qualified Data.List.NonEmpty as List (NonEmpty)
 import qualified Data.RFC5051 as RFC5051
 import Data.Text (Text)
 
@@ -26,6 +27,9 @@ instance (Eq a, Alphabetical a) => Ord (OrderAlphabetically a) where
   compare (OrderAlphabetically a) (OrderAlphabetically b) = compareAlphabetical a b
 
 instance Alphabetical a => Alphabetical [a] where
+  compareAlphabetical a1s a2s = compare (OrderAlphabetically <$> a1s) (OrderAlphabetically <$> a2s)
+
+instance Alphabetical a => Alphabetical (List.NonEmpty a) where
   compareAlphabetical a1s a2s = compare (OrderAlphabetically <$> a1s) (OrderAlphabetically <$> a2s)
 
 instance Alphabetical a => Alphabetical (Maybe a) where

--- a/unison-syntax/src/Unison/Syntax/Name.hs
+++ b/unison-syntax/src/Unison/Syntax/Name.hs
@@ -24,13 +24,8 @@ import Unison.NameSegment (NameSegment (NameSegment))
 import qualified Unison.NameSegment as NameSegment
 import Unison.Position (Position (..))
 import Unison.Prelude
-import Unison.Util.Alphabetical (Alphabetical, compareAlphabetical)
 import Unison.Var (Var)
 import qualified Unison.Var as Var
-
-instance Alphabetical Name where
-  compareAlphabetical n1 n2 =
-    compareAlphabetical (toText n1) (toText n2)
 
 instance IsString Name where
   fromString =


### PR DESCRIPTION
## Overview

This is a small follow-up to #3527 that addresses some review comments.

- Moved `instance Alphabetical Name` out of `Unison.Syntax.Name`, back into `Unison.Name`. Now it compares segments alphabetically instead of comparing the `toText`-ed string.
- Replaced some top-level comparison functions with proper `Ord` instances, which required turning some type aliases into proper data types.  
