### PR TITLE
Fix "Text.patterns.charRange" builtin

### DIFF
--- a/parser-typechecker/src/Unison/Util/Text/Pattern.hs
+++ b/parser-typechecker/src/Unison/Util/Text/Pattern.hs
@@ -148,7 +148,7 @@ compile (Many p) !_ !success = case p of
   AnyChar -> (\acc _ -> success acc Text.empty)
   CharIn cs -> walker (charInPred cs)
   NotCharIn cs -> walker (charNotInPred cs)
-  CharRange c1 c2 -> walker (\ch -> ch >= c1 && c1 <= c2)
+  CharRange c1 c2 -> walker (\ch -> ch >= c1 && ch <= c2)
   NotCharRange c1 c2 -> walker (\ch -> ch < c1 || ch > c2)
   Digit -> walker isDigit
   Letter -> walker isLetter


### PR DESCRIPTION
The `charRange` pattern was matching any character above the lower bound of the range.

This was just a typo. Very simple fix.