### PR TITLE
Remove diff from delete{.term,.type} output

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -340,11 +340,12 @@ loop e = do
             Cli.respond $ Typechecked (Text.pack sourceName) ppe sr uf
 
           delete ::
+            DeleteOutput ->
             ((Path.Absolute, HQ'.HQSegment) -> Cli (Set Referent)) -> -- compute matching terms
             ((Path.Absolute, HQ'.HQSegment) -> Cli (Set Reference)) -> -- compute matching types
             Path.HQSplit' ->
             Cli ()
-          delete getTerms getTypes hq' = do
+          delete doutput getTerms getTypes hq' = do
             hq <- Cli.resolveSplit' hq'
             terms <- getTerms hq
             types <- getTypes hq
@@ -365,9 +366,13 @@ loop e = do
                 before <- Cli.getRootBranch0
                 description <- inputDescription input
                 Cli.stepManyAt description (makeDeleteTermNames ++ makeDeleteTypeNames)
-                after <- Cli.getRootBranch0
-                (ppe, diff) <- diffHelper before after
-                Cli.respondNumbered (ShowDiffAfterDeleteDefinitions ppe diff)
+                case doutput of
+                  DeleteOutput'Diff -> do
+                    after <- Cli.getRootBranch0
+                    (ppe, diff) <- diffHelper before after
+                    Cli.respondNumbered (ShowDiffAfterDeleteDefinitions ppe diff)
+                  DeleteOutput'NoDiff -> do
+                    Cli.respond Success
               else do
                 ppeDecl <- currentPrettyPrintEnvDecl Backend.Within
                 Cli.respondNumbered (CantDeleteDefinitions ppeDecl endangerments)
@@ -522,49 +527,6 @@ loop e = do
                 description
                 (BranchUtil.makeReplacePatch (Path.convert dest) p)
               Cli.respond Success
-            DeletePatchI src' -> do
-              _ <- Cli.expectPatchAt src'
-              description <- inputDescription input
-              src <- Cli.resolveSplit' src'
-              Cli.stepAt
-                description
-                (BranchUtil.makeDeletePatch (Path.convert src))
-              Cli.respond Success
-            DeleteBranchI insistence Nothing -> do
-              hasConfirmed <- confirmedCommand input
-              if hasConfirmed || insistence == Force
-                then do
-                  description <- inputDescription input
-                  Cli.stepAt
-                    description
-                    (Path.empty, const Branch.empty0)
-                  Cli.respond DeletedEverything
-                else Cli.respond DeleteEverythingConfirmation
-            DeleteBranchI insistence (Just p) -> do
-              branch <- Cli.expectBranchAtPath' (Path.unsplit' p)
-              description <- inputDescription input
-              absPath <- Cli.resolveSplit' p
-              let toDelete =
-                    Names.prefix0
-                      (Path.unsafeToName (Path.unsplit (Path.convert absPath)))
-                      (Branch.toNames (Branch.head branch))
-              afterDelete <- do
-                rootNames <- Branch.toNames <$> Cli.getRootBranch0
-                endangerments <- Cli.runTransaction (getEndangeredDependents toDelete rootNames)
-                case (null endangerments, insistence) of
-                  (True, _) -> pure (Cli.respond Success)
-                  (False, Force) -> do
-                    ppeDecl <- currentPrettyPrintEnvDecl Backend.Within
-                    pure do
-                      Cli.respond Success
-                      Cli.respondNumbered $ DeletedDespiteDependents ppeDecl endangerments
-                  (False, Try) -> do
-                    ppeDecl <- currentPrettyPrintEnvDecl Backend.Within
-                    Cli.respondNumbered $ CantDeleteNamespace ppeDecl endangerments
-                    Cli.returnEarlyWithoutOutput
-              Cli.stepAt description $
-                BranchUtil.makeDeleteBranch (Path.convert absPath)
-              afterDelete
             SwitchBranchI maybePath' -> do
               path' <-
                 maybePath' & onNothing do
@@ -904,9 +866,53 @@ loop e = do
                   BranchUtil.makeAddTypeName (Path.convert dest) srcType srcMetadata
                 ]
               Cli.respond Success
-            DeleteI hq -> delete Cli.getTermsAt Cli.getTypesAt hq
-            DeleteTypeI hq -> delete (const (pure Set.empty)) Cli.getTypesAt hq
-            DeleteTermI hq -> delete Cli.getTermsAt (const (pure Set.empty)) hq
+            DeleteI dtarget -> case dtarget of
+              DeleteTarget'TermOrType doutput hq -> delete doutput Cli.getTermsAt Cli.getTypesAt hq
+              DeleteTarget'Type doutput hq -> delete doutput (const (pure Set.empty)) Cli.getTypesAt hq
+              DeleteTarget'Term doutput hq -> delete doutput Cli.getTermsAt (const (pure Set.empty)) hq
+              DeleteTarget'Patch src' -> do
+                _ <- Cli.expectPatchAt src'
+                description <- inputDescription input
+                src <- Cli.resolveSplit' src'
+                Cli.stepAt
+                  description
+                  (BranchUtil.makeDeletePatch (Path.convert src))
+                Cli.respond Success
+              DeleteTarget'Branch insistence Nothing -> do
+                hasConfirmed <- confirmedCommand input
+                if hasConfirmed || insistence == Force
+                  then do
+                    description <- inputDescription input
+                    Cli.stepAt
+                      description
+                      (Path.empty, const Branch.empty0)
+                    Cli.respond DeletedEverything
+                  else Cli.respond DeleteEverythingConfirmation
+              DeleteTarget'Branch insistence (Just p) -> do
+                branch <- Cli.expectBranchAtPath' (Path.unsplit' p)
+                description <- inputDescription input
+                absPath <- Cli.resolveSplit' p
+                let toDelete =
+                      Names.prefix0
+                        (Path.unsafeToName (Path.unsplit (Path.convert absPath)))
+                        (Branch.toNames (Branch.head branch))
+                afterDelete <- do
+                  rootNames <- Branch.toNames <$> Cli.getRootBranch0
+                  endangerments <- Cli.runTransaction (getEndangeredDependents toDelete rootNames)
+                  case (null endangerments, insistence) of
+                    (True, _) -> pure (Cli.respond Success)
+                    (False, Force) -> do
+                      ppeDecl <- currentPrettyPrintEnvDecl Backend.Within
+                      pure do
+                        Cli.respond Success
+                        Cli.respondNumbered $ DeletedDespiteDependents ppeDecl endangerments
+                    (False, Try) -> do
+                      ppeDecl <- currentPrettyPrintEnvDecl Backend.Within
+                      Cli.respondNumbered $ CantDeleteNamespace ppeDecl endangerments
+                      Cli.returnEarlyWithoutOutput
+                Cli.stepAt description $
+                  BranchUtil.makeDeleteBranch (Path.convert absPath)
+                afterDelete
             DisplayI outputLoc names' -> do
               currentBranch0 <- Cli.getCurrentBranch0
               basicPrettyPrintNames <- getBasicPrettyPrintNames
@@ -1474,24 +1480,35 @@ inputDescription input =
       src <- ps' src0
       dest <- ps' dest0
       pure ("copy.patch " <> src <> " " <> dest)
-    DeleteI thing0 -> do
-      thing <- hqs' thing0
-      pure ("delete " <> thing)
-    DeleteTermI def0 -> do
-      def <- hqs' def0
-      pure ("delete.term " <> def)
-    DeleteTypeI def0 -> do
-      def <- hqs' def0
-      pure ("delete.type " <> def)
-    DeleteBranchI Try opath0 -> do
-      opath <- ops' opath0
-      pure ("delete.namespace " <> opath)
-    DeleteBranchI Force opath0 -> do
-      opath <- ops' opath0
-      pure ("delete.namespace.force " <> opath)
-    DeletePatchI path0 -> do
-      path <- ps' path0
-      pure ("delete.patch " <> path)
+    DeleteI dtarget -> do
+      case dtarget of
+        DeleteTarget'TermOrType DeleteOutput'NoDiff thing0 -> do
+          thing <- hqs' thing0
+          pure ("delete " <> thing)
+        DeleteTarget'TermOrType DeleteOutput'Diff thing0 -> do
+          thing <- hqs' thing0
+          pure ("delete.verbose " <> thing)
+        DeleteTarget'Term DeleteOutput'NoDiff thing0 -> do
+          thing <- hqs' thing0
+          pure ("delete.term " <> thing)
+        DeleteTarget'Term DeleteOutput'Diff thing0 -> do
+          thing <- hqs' thing0
+          pure ("delete.term.verbose " <> thing)
+        DeleteTarget'Type DeleteOutput'NoDiff thing0 -> do
+          thing <- hqs' thing0
+          pure ("delete.type " <> thing)
+        DeleteTarget'Type DeleteOutput'Diff thing0 -> do
+          thing <- hqs' thing0
+          pure ("delete.type.verbose " <> thing)
+        DeleteTarget'Branch Try opath0 -> do
+          opath <- ops' opath0
+          pure ("delete.namespace " <> opath)
+        DeleteTarget'Branch Force opath0 -> do
+          opath <- ops' opath0
+          pure ("delete.namespace.force " <> opath)
+        DeleteTarget'Patch path0 -> do
+          path <- ps' path0
+          pure ("delete.patch " <> path)
     ReplaceI src target p0 -> do
       p <- opatch p0
       pure $

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -17,6 +17,8 @@ module Unison.Codebase.Editor.Input
     FindScope (..),
     ShowDefinitionScope (..),
     IsGlobal,
+    DeleteOutput (..),
+    DeleteTarget (..),
   )
 where
 
@@ -118,11 +120,7 @@ data Input
   | MovePatchI Path.Split' Path.Split'
   | CopyPatchI Path.Split' Path.Split'
   | -- delete = unname
-    DeleteI Path.HQSplit'
-  | DeleteTermI Path.HQSplit'
-  | DeleteTypeI Path.HQSplit'
-  | DeleteBranchI Insistence (Maybe Path.Split')
-  | DeletePatchI Path.Split'
+    DeleteI DeleteTarget
   | -- resolving naming conflicts within `branchpath`
     -- Add the specified name after deleting all others for a given reference
     -- within a given branch.
@@ -251,4 +249,17 @@ data FindScope
 data ShowDefinitionScope
   = ShowDefinitionLocal
   | ShowDefinitionGlobal
+  deriving stock (Eq, Show)
+
+data DeleteOutput
+  = DeleteOutput'Diff
+  | DeleteOutput'NoDiff
+  deriving stock (Eq, Show)
+
+data DeleteTarget
+  = DeleteTarget'TermOrType DeleteOutput Path.HQSplit'
+  | DeleteTarget'Term DeleteOutput Path.HQSplit'
+  | DeleteTarget'Type DeleteOutput Path.HQSplit'
+  | DeleteTarget'Branch Insistence (Maybe Path.Split')
+  | DeleteTarget'Patch Path.Split'
   deriving stock (Eq, Show)

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -16,7 +16,7 @@ import qualified Text.Megaparsec as P
 import qualified Unison.Codebase as Codebase
 import qualified Unison.Codebase.Branch as Branch
 import qualified Unison.Codebase.Branch.Merge as Branch
-import Unison.Codebase.Editor.Input (Input)
+import Unison.Codebase.Editor.Input (DeleteOutput (..), DeleteTarget (..), Input)
 import qualified Unison.Codebase.Editor.Input as Input
 import Unison.Codebase.Editor.Output.PushPull (PushPull (Pull, Push))
 import qualified Unison.Codebase.Editor.Output.PushPull as PushPull
@@ -587,59 +587,55 @@ renameType =
               "`rename.type` takes two arguments, like `rename.type oldname newname`."
     )
 
+deleteGen :: Maybe String -> String -> (Path.HQSplit' -> DeleteTarget) -> InputPattern
+deleteGen suffix target mkTarget =
+  let cmd = maybe "delete" ("delete." <>) suffix
+      info =
+        P.sep
+          " "
+          [ backtick (P.sep " " [P.string cmd, "foo"]),
+            "removes the",
+            P.string target,
+            "name `foo` from the namespace."
+          ]
+      warn =
+        P.sep
+          " "
+          [ backtick (P.string cmd),
+            "takes an argument, like",
+            backtick (P.sep " " [P.string cmd, "name"]) <> "."
+          ]
+   in InputPattern
+        cmd
+        []
+        I.Visible
+        [(OnePlus, exactDefinitionTermQueryArg)]
+        info
+        ( \case
+            [query] -> first fromString $ do
+              p <- Path.parseHQSplit' query
+              pure $ Input.DeleteI (mkTarget p)
+            _ ->
+              Left . P.warnCallout $ P.wrap warn
+        )
+
 delete :: InputPattern
-delete =
-  InputPattern
-    "delete"
-    []
-    I.Visible
-    [(OnePlus, definitionQueryArg)]
-    "`delete foo` removes the term or type name `foo` from the namespace."
-    ( \case
-        [query] -> first fromString $ do
-          p <- Path.parseHQSplit' query
-          pure $ Input.DeleteI p
-        _ ->
-          Left . P.warnCallout $
-            P.wrap
-              "`delete` takes an argument, like `delete name`."
-    )
+delete = deleteGen Nothing "term or type" (DeleteTarget'TermOrType DeleteOutput'NoDiff)
+
+deleteVerbose :: InputPattern
+deleteVerbose = deleteGen (Just "verbose") "term or type" (DeleteTarget'TermOrType DeleteOutput'Diff)
 
 deleteTerm :: InputPattern
-deleteTerm =
-  InputPattern
-    "delete.term"
-    []
-    I.Visible
-    [(OnePlus, exactDefinitionTermQueryArg)]
-    "`delete.term foo` removes the term name `foo` from the namespace."
-    ( \case
-        [query] -> first fromString $ do
-          p <- Path.parseHQSplit' query
-          pure $ Input.DeleteTermI p
-        _ ->
-          Left . P.warnCallout $
-            P.wrap
-              "`delete.term` takes an argument, like `delete.term name`."
-    )
+deleteTerm = deleteGen (Just "term") "term" (DeleteTarget'Term DeleteOutput'NoDiff)
+
+deleteTermVerbose :: InputPattern
+deleteTermVerbose = deleteGen (Just "term.verbose") "term" (DeleteTarget'Term DeleteOutput'Diff)
 
 deleteType :: InputPattern
-deleteType =
-  InputPattern
-    "delete.type"
-    []
-    I.Visible
-    [(OnePlus, exactDefinitionTypeQueryArg)]
-    "`delete.type foo` removes the type name `foo` from the namespace."
-    ( \case
-        [query] -> first fromString $ do
-          p <- Path.parseHQSplit' query
-          pure $ Input.DeleteTypeI p
-        _ ->
-          Left . P.warnCallout $
-            P.wrap
-              "`delete.type` takes an argument, like `delete.type name`."
-    )
+deleteType = deleteGen (Just "type") "type" (DeleteTarget'Type DeleteOutput'NoDiff)
+
+deleteTypeVerbose :: InputPattern
+deleteTypeVerbose = deleteGen (Just "type.verbose") "type" (DeleteTarget'Type DeleteOutput'Diff)
 
 deleteTermReplacementCommand :: String
 deleteTermReplacementCommand = "delete.term-replacement"
@@ -869,10 +865,10 @@ deleteNamespaceParser helpText insistence =
       ["."] ->
         first fromString
           . pure
-          $ Input.DeleteBranchI insistence Nothing
+          $ Input.DeleteI (DeleteTarget'Branch insistence Nothing)
       [p] -> first fromString $ do
         p <- Path.parseSplit' Path.definitionNameSegment p
-        pure . Input.DeleteBranchI insistence $ Just p
+        pure $ Input.DeleteI (DeleteTarget'Branch insistence (Just p))
       _ -> Left helpText
   )
 
@@ -887,7 +883,7 @@ deletePatch =
     ( \case
         [p] -> first fromString $ do
           p <- Path.parseSplit' Path.definitionNameSegment p
-          pure . Input.DeletePatchI $ p
+          pure . Input.DeleteI $ DeleteTarget'Patch p
         _ -> Left (I.help deletePatch)
     )
 
@@ -2314,6 +2310,7 @@ validInputs =
       previewUpdate,
       updateNoPatch,
       delete,
+      deleteVerbose,
       forkLocal,
       mergeLocal,
       squashMerge,
@@ -2361,9 +2358,11 @@ validInputs =
       edit,
       renameTerm,
       deleteTerm,
+      deleteTermVerbose,
       aliasTerm,
       renameType,
       deleteType,
+      deleteTypeVerbose,
       aliasType,
       aliasMany,
       todo,

--- a/unison-src/transcripts/debug-name-diffs.md
+++ b/unison-src/transcripts/debug-name-diffs.md
@@ -11,7 +11,7 @@ structural type a.b.Baz = Boo
 
 ```ucm
 .> add
-.> delete.term a.b.one
+.> delete.term.verbose a.b.one
 .> alias.term a.two a.newtwo
 .> move.namespace a.x a.y
 .> history

--- a/unison-src/transcripts/debug-name-diffs.output.md
+++ b/unison-src/transcripts/debug-name-diffs.output.md
@@ -37,9 +37,13 @@ structural type a.b.Baz = Boo
     a.x.four  : ##Nat
     a.x.three : ##Nat
 
-.> delete.term a.b.one
+.> delete.term.verbose a.b.one
 
-  Done.
+  Removed definitions:
+  
+    1. a.b.one : ##Nat
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
 
 .> alias.term a.two a.newtwo
 

--- a/unison-src/transcripts/debug-name-diffs.output.md
+++ b/unison-src/transcripts/debug-name-diffs.output.md
@@ -39,11 +39,7 @@ structural type a.b.Baz = Boo
 
 .> delete.term a.b.one
 
-  Removed definitions:
-  
-    1. a.b.one : ##Nat
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
 .> alias.term a.two a.newtwo
 

--- a/unison-src/transcripts/delete-silent.md
+++ b/unison-src/transcripts/delete-silent.md
@@ -1,0 +1,15 @@
+```ucm:error
+.> delete foo
+```
+
+```unison:hide
+foo = 1
+structural type Foo = Foo ()
+```
+
+```ucm
+.> add
+.> delete foo
+.> delete.type Foo
+.> delete.term Foo.Foo
+```

--- a/unison-src/transcripts/delete-silent.output.md
+++ b/unison-src/transcripts/delete-silent.output.md
@@ -1,0 +1,34 @@
+```ucm
+.> delete foo
+
+  ⚠️
+  
+  I don't know about that name.
+
+```
+```unison
+foo = 1
+structural type Foo = Foo ()
+```
+
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    structural type Foo
+    foo : ##Nat
+
+.> delete foo
+
+  Done.
+
+.> delete.type Foo
+
+  Done.
+
+.> delete.term Foo.Foo
+
+  Done.
+
+```

--- a/unison-src/transcripts/delete.md
+++ b/unison-src/transcripts/delete.md
@@ -10,7 +10,7 @@ First, let's make sure it complains when we try to delete a name that doesn't
 exist.
 
 ```ucm:error
-.> delete foo
+.> delete.verbose foo
 ```
 
 Now for some easy cases. Deleting an unambiguous term, then deleting an
@@ -23,9 +23,9 @@ structural type Foo = Foo ()
 
 ```ucm
 .> add
-.> delete foo
-.> delete Foo
-.> delete Foo.Foo
+.> delete.verbose foo
+.> delete.verbose Foo
+.> delete.verbose Foo.Foo
 ```
 
 How about an ambiguous term?
@@ -50,7 +50,7 @@ foo = 2
 A delete should remove both versions of the term.
 
 ```ucm
-.a> delete foo
+.a> delete.verbose foo
 ```
 
 ```ucm:error
@@ -77,11 +77,11 @@ structural type Foo = Foo
 ```
 
 ```ucm
-.a> delete Foo
+.a> delete.verbose Foo
 ```
 
 ```ucm
-.a> delete Foo.Foo
+.a> delete.verbose Foo.Foo
 ```
 
 Finally, let's try to delete a term and a type with the same name.
@@ -96,5 +96,5 @@ structural type foo = Foo ()
 ```
 
 ```ucm
-.> delete foo
+.> delete.verbose foo
 ```

--- a/unison-src/transcripts/delete.output.md
+++ b/unison-src/transcripts/delete.output.md
@@ -31,27 +31,15 @@ structural type Foo = Foo ()
 
 .> delete foo
 
-  Removed definitions:
-  
-    1. foo : Nat
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
 .> delete Foo
 
-  Removed definitions:
-  
-    1. structural type Foo
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
 .> delete Foo.Foo
 
-  Removed definitions:
-  
-    1. Foo.Foo : '#089vmor9c5
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
 ```
 How about an ambiguous term?
@@ -106,17 +94,7 @@ A delete should remove both versions of the term.
 ```ucm
 .a> delete foo
 
-  Removed definitions:
-  
-    1. a.foo#gjmq673r1v : Nat
-  
-  Name changes:
-  
-    Original               Changes
-    2. b.foo            ┐  3. a.foo#dcgdua2lj6 (removed)
-    4. a.foo#dcgdua2lj6 ┘  
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
 ```
 ```ucm
@@ -179,35 +157,13 @@ structural type Foo = Foo
 ```ucm
 .a> delete Foo
 
-  Removed definitions:
-  
-    1. structural type a.Foo#089vmor9c5
-  
-  Name changes:
-  
-    Original               Changes
-    2. b.Foo            ┐  3. a.Foo#00nv2kob8f (removed)
-    4. builtin.Unit     │  
-    5. a.Foo#00nv2kob8f ┘  
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
 ```
 ```ucm
 .a> delete Foo.Foo
 
-  Removed definitions:
-  
-    1. a.Foo.Foo#089vmor9c5#0 : '#089vmor9c5
-  
-  Name changes:
-  
-    Original                     Changes
-    2. b.Foo.Foo              ┐  3. a.Foo.Foo#00nv2kob8f#0 (removed)
-    4. builtin.Unit.Unit      │  
-    5. a.Foo.Foo#00nv2kob8f#0 ┘  
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
 ```
 Finally, let's try to delete a term and a type with the same name.
@@ -229,11 +185,6 @@ structural type foo = Foo ()
 ```ucm
 .> delete foo
 
-  Removed definitions:
-  
-    1. structural type foo
-    2. foo : Nat
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
 ```

--- a/unison-src/transcripts/delete.output.md
+++ b/unison-src/transcripts/delete.output.md
@@ -6,7 +6,7 @@ First, let's make sure it complains when we try to delete a name that doesn't
 exist.
 
 ```ucm
-.> delete foo
+.> delete.verbose foo
 
   ⚠️
   
@@ -29,17 +29,29 @@ structural type Foo = Foo ()
     structural type Foo
     foo : Nat
 
-.> delete foo
+.> delete.verbose foo
 
-  Done.
+  Removed definitions:
+  
+    1. foo : Nat
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
 
-.> delete Foo
+.> delete.verbose Foo
 
-  Done.
+  Removed definitions:
+  
+    1. structural type Foo
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
 
-.> delete Foo.Foo
+.> delete.verbose Foo.Foo
 
-  Done.
+  Removed definitions:
+  
+    1. Foo.Foo : '#089vmor9c5
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
 
 ```
 How about an ambiguous term?
@@ -92,9 +104,19 @@ foo = 2
 A delete should remove both versions of the term.
 
 ```ucm
-.a> delete foo
+.a> delete.verbose foo
 
-  Done.
+  Removed definitions:
+  
+    1. a.foo#gjmq673r1v : Nat
+  
+  Name changes:
+  
+    Original               Changes
+    2. b.foo            ┐  3. a.foo#dcgdua2lj6 (removed)
+    4. a.foo#dcgdua2lj6 ┘  
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
 
 ```
 ```ucm
@@ -155,15 +177,37 @@ structural type Foo = Foo
 
 ```
 ```ucm
-.a> delete Foo
+.a> delete.verbose Foo
 
-  Done.
+  Removed definitions:
+  
+    1. structural type a.Foo#089vmor9c5
+  
+  Name changes:
+  
+    Original               Changes
+    2. b.Foo            ┐  3. a.Foo#00nv2kob8f (removed)
+    4. builtin.Unit     │  
+    5. a.Foo#00nv2kob8f ┘  
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
 
 ```
 ```ucm
-.a> delete Foo.Foo
+.a> delete.verbose Foo.Foo
 
-  Done.
+  Removed definitions:
+  
+    1. a.Foo.Foo#089vmor9c5#0 : '#089vmor9c5
+  
+  Name changes:
+  
+    Original                     Changes
+    2. b.Foo.Foo              ┐  3. a.Foo.Foo#00nv2kob8f#0 (removed)
+    4. builtin.Unit.Unit      │  
+    5. a.Foo.Foo#00nv2kob8f#0 ┘  
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
 
 ```
 Finally, let's try to delete a term and a type with the same name.
@@ -183,8 +227,13 @@ structural type foo = Foo ()
 
 ```
 ```ucm
-.> delete foo
+.> delete.verbose foo
 
-  Done.
+  Removed definitions:
+  
+    1. structural type foo
+    2. foo : Nat
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
 
 ```

--- a/unison-src/transcripts/diff-namespace.md
+++ b/unison-src/transcripts/diff-namespace.md
@@ -99,7 +99,7 @@ unique type Y a b = Y a b
 .> view.patch ns2.patch
 .> fork ns2 ns3
 .> alias.term ns2.fromJust' ns2.yoohoo
-.> delete.term ns2.fromJust'
+.> delete.term.verbose ns2.fromJust'
 .> diff.namespace ns3 ns2
 ```
 ```unison:hide

--- a/unison-src/transcripts/diff-namespace.output.md
+++ b/unison-src/transcripts/diff-namespace.output.md
@@ -448,16 +448,7 @@ unique type Y a b = Y a b
 
 .> delete.term ns2.fromJust'
 
-  Name changes:
-  
-    Original            Changes
-    1. ns2.fromJust  ┐  2. ns2.fromJust' (removed)
-    3. ns2.fromJust' │  
-    4. ns2.yoohoo    │  
-    5. ns3.fromJust  │  
-    6. ns3.fromJust' ┘  
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
 .> diff.namespace ns3 ns2
 

--- a/unison-src/transcripts/diff-namespace.output.md
+++ b/unison-src/transcripts/diff-namespace.output.md
@@ -446,9 +446,18 @@ unique type Y a b = Y a b
 
   Done.
 
-.> delete.term ns2.fromJust'
+.> delete.term.verbose ns2.fromJust'
 
-  Done.
+  Name changes:
+  
+    Original            Changes
+    1. ns2.fromJust  ┐  2. ns2.fromJust' (removed)
+    3. ns2.fromJust' │  
+    4. ns2.yoohoo    │  
+    5. ns3.fromJust  │  
+    6. ns3.fromJust' ┘  
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
 
 .> diff.namespace ns3 ns2
 

--- a/unison-src/transcripts/fix2000.md
+++ b/unison-src/transcripts/fix2000.md
@@ -15,7 +15,7 @@ x.a.q = "ef"
 .> fork x y
 .> fork x s
 .> fork x m
-.> delete y.a.p
+.> delete.verbose y.a.p
 ```
 
 ```unison
@@ -35,7 +35,7 @@ Merge back into the ancestor.
 ```ucm
 .> add
 .> merge y.b y.a
-.> delete.term 1
+.> delete.term.verbose 1
 .> merge y m
 .> squash y s
 .s> todo

--- a/unison-src/transcripts/fix2000.output.md
+++ b/unison-src/transcripts/fix2000.output.md
@@ -40,15 +40,7 @@ x.a.q = "ef"
 
 .> delete y.a.p
 
-  Name changes:
-  
-    Original    Changes
-    1. m.a.p ┐  2. y.a.p (removed)
-    3. s.a.p │  
-    4. x.a.p │  
-    5. y.a.p ┘  
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
 ```
 ```unison
@@ -116,14 +108,7 @@ Merge back into the ancestor.
 
 .> delete.term 1
 
-  Resolved name conflicts:
-  
-    1. ┌ y.a.p#l2mmpgn323 : Text
-    2. └ y.a.p#nm3omrdks9 : Text
-       ↓
-    3. y.a.p#nm3omrdks9 : Text
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
 .> merge y m
 

--- a/unison-src/transcripts/fix2000.output.md
+++ b/unison-src/transcripts/fix2000.output.md
@@ -38,9 +38,17 @@ x.a.q = "ef"
 
   Done.
 
-.> delete y.a.p
+.> delete.verbose y.a.p
 
-  Done.
+  Name changes:
+  
+    Original    Changes
+    1. m.a.p ┐  2. y.a.p (removed)
+    3. s.a.p │  
+    4. x.a.p │  
+    5. y.a.p ┘  
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
 
 ```
 ```unison
@@ -106,9 +114,16 @@ Merge back into the ancestor.
        can use `undo` or `reflog` to undo the results of this
        merge.
 
-.> delete.term 1
+.> delete.term.verbose 1
 
-  Done.
+  Resolved name conflicts:
+  
+    1. ┌ y.a.p#l2mmpgn323 : Text
+    2. └ y.a.p#nm3omrdks9 : Text
+       ↓
+    3. y.a.p#nm3omrdks9 : Text
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
 
 .> merge y m
 

--- a/unison-src/transcripts/fix2004.md
+++ b/unison-src/transcripts/fix2004.md
@@ -33,10 +33,10 @@ Now we fork `a2` off of `a`. `a` continues on, deleting the terms it added previ
 
 ```ucm
 .> fork a a2
-.a> delete.term delete1
-.a> delete.term delete2
-.a> delete.term delete3
-.a> delete.type Delete4
+.a> delete.term.verbose delete1
+.a> delete.term.verbose delete2
+.a> delete.term.verbose delete3
+.a> delete.type.verbose Delete4
 .newbranchA> alias.term .builtin.Float.+ dontDelete
 .> merge newbranchA a
 .a> find

--- a/unison-src/transcripts/fix2004.output.md
+++ b/unison-src/transcripts/fix2004.output.md
@@ -46,21 +46,49 @@ Now we fork `a2` off of `a`. `a` continues on, deleting the terms it added previ
 
   Done.
 
-.a> delete.term delete1
+.a> delete.term.verbose delete1
 
-  Done.
+  Name changes:
+  
+    Original            Changes
+    1. a.delete1     ┐  2. a.delete1 (removed)
+    3. a2.delete1    │  
+    4. builtin.Nat.+ ┘  
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
 
-.a> delete.term delete2
+.a> delete.term.verbose delete2
 
-  Done.
+  Name changes:
+  
+    Original            Changes
+    1. a.delete2     ┐  2. a.delete2 (removed)
+    3. a2.delete2    │  
+    4. builtin.Nat.* ┘  
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
 
-.a> delete.term delete3
+.a> delete.term.verbose delete3
 
-  Done.
+  Name changes:
+  
+    Original               Changes
+    1. a.delete3        ┐  2. a.delete3 (removed)
+    3. a2.delete3       │  
+    4. builtin.Nat.drop ┘  
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
 
-.a> delete.type Delete4
+.a> delete.type.verbose Delete4
 
-  Done.
+  Name changes:
+  
+    Original          Changes
+    1. a.Delete4   ┐  2. a.Delete4 (removed)
+    3. a2.Delete4  │  
+    4. builtin.Nat ┘  
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
 
   ☝️  The namespace .newbranchA is empty.
 

--- a/unison-src/transcripts/fix2004.output.md
+++ b/unison-src/transcripts/fix2004.output.md
@@ -48,47 +48,19 @@ Now we fork `a2` off of `a`. `a` continues on, deleting the terms it added previ
 
 .a> delete.term delete1
 
-  Name changes:
-  
-    Original            Changes
-    1. a.delete1     ┐  2. a.delete1 (removed)
-    3. a2.delete1    │  
-    4. builtin.Nat.+ ┘  
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
 .a> delete.term delete2
 
-  Name changes:
-  
-    Original            Changes
-    1. a.delete2     ┐  2. a.delete2 (removed)
-    3. a2.delete2    │  
-    4. builtin.Nat.* ┘  
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
 .a> delete.term delete3
 
-  Name changes:
-  
-    Original               Changes
-    1. a.delete3        ┐  2. a.delete3 (removed)
-    3. a2.delete3       │  
-    4. builtin.Nat.drop ┘  
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
 .a> delete.type Delete4
 
-  Name changes:
-  
-    Original          Changes
-    1. a.Delete4   ┐  2. a.Delete4 (removed)
-    3. a2.Delete4  │  
-    4. builtin.Nat ┘  
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
   ☝️  The namespace .newbranchA is empty.
 

--- a/unison-src/transcripts/merge.md
+++ b/unison-src/transcripts/merge.md
@@ -55,7 +55,7 @@ quux.y = 333
 
 ```ucm
 .P1> add
-.P1> delete.term foo.w
+.P1> delete.term.verbose foo.w
 ```
 
 We added to `foo`, `bar` and `baz`, and deleted `foo.w`, which should stay deleted in the merge.

--- a/unison-src/transcripts/merge.output.md
+++ b/unison-src/transcripts/merge.output.md
@@ -74,14 +74,7 @@ quux.y = 333
 
 .P1> delete.term foo.w
 
-  Name changes:
-  
-    Original       Changes
-    1. P0.foo.w ┐  2. P1.foo.w (removed)
-    3. P1.foo.w │  
-    4. P2.foo.w ┘  
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
 ```
 We added to `foo`, `bar` and `baz`, and deleted `foo.w`, which should stay deleted in the merge.

--- a/unison-src/transcripts/merge.output.md
+++ b/unison-src/transcripts/merge.output.md
@@ -72,9 +72,16 @@ quux.y = 333
     foo.y  : Nat
     quux.y : Nat
 
-.P1> delete.term foo.w
+.P1> delete.term.verbose foo.w
 
-  Done.
+  Name changes:
+  
+    Original       Changes
+    1. P0.foo.w ┐  2. P1.foo.w (removed)
+    3. P1.foo.w │  
+    4. P2.foo.w ┘  
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
 
 ```
 We added to `foo`, `bar` and `baz`, and deleted `foo.w`, which should stay deleted in the merge.

--- a/unison-src/transcripts/merges.md
+++ b/unison-src/transcripts/merges.md
@@ -79,7 +79,7 @@ z = 99
 
 ```ucm
 .feature2> add
-.feature2> delete.term x
+.feature2> delete.term.verbose x
 ```
 
 And here's the other fork, where we update `y` and add a new definition, `frobnicate`:

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -202,13 +202,7 @@ z = 99
 
 .feature2> delete.term x
 
-  Name changes:
-  
-    Original         Changes
-    1. feature2.x ┐  2. feature2.x (removed)
-    3. master.x   ┘  
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
 ```
 And here's the other fork, where we update `y` and add a new definition, `frobnicate`:

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -200,9 +200,15 @@ z = 99
   
     z : Nat
 
-.feature2> delete.term x
+.feature2> delete.term.verbose x
 
-  Done.
+  Name changes:
+  
+    Original         Changes
+    1. feature2.x ┐  2. feature2.x (removed)
+    3. master.x   ┘  
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
 
 ```
 And here's the other fork, where we update `y` and add a new definition, `frobnicate`:

--- a/unison-src/transcripts/resolve.md
+++ b/unison-src/transcripts/resolve.md
@@ -109,7 +109,7 @@ We still have a remaining _name conflict_ since it just so happened that both of
 We can resolve the name conflict by deleting one of the names.
 
 ```ucm
-.example.resolve.c> delete.term 2
+.example.resolve.c> delete.term.verbose 2
 .example.resolve.c> todo
 ```
 

--- a/unison-src/transcripts/resolve.output.md
+++ b/unison-src/transcripts/resolve.output.md
@@ -240,9 +240,22 @@ We still have a remaining _name conflict_ since it just so happened that both of
 We can resolve the name conflict by deleting one of the names.
 
 ```ucm
-.example.resolve.c> delete.term 2
+.example.resolve.c> delete.term.verbose 2
 
-  Done.
+  Resolved name conflicts:
+  
+    1. ┌ example.resolve.c.foo#a84tg4er4k : Nat
+    2. └ example.resolve.c.foo#emomp74i93 : Nat
+       ↓
+    3. example.resolve.c.foo#a84tg4er4k : Nat
+  
+  Name changes:
+  
+    Original                               Changes
+    4. example.resolve.a.foo            ┐  5. example.resolve.c.foo#emomp74i93 (removed)
+    6. example.resolve.c.foo#emomp74i93 ┘  
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
 
 .example.resolve.c> todo
 

--- a/unison-src/transcripts/resolve.output.md
+++ b/unison-src/transcripts/resolve.output.md
@@ -242,20 +242,7 @@ We can resolve the name conflict by deleting one of the names.
 ```ucm
 .example.resolve.c> delete.term 2
 
-  Resolved name conflicts:
-  
-    1. ┌ example.resolve.c.foo#a84tg4er4k : Nat
-    2. └ example.resolve.c.foo#emomp74i93 : Nat
-       ↓
-    3. example.resolve.c.foo#a84tg4er4k : Nat
-  
-  Name changes:
-  
-    Original                               Changes
-    4. example.resolve.a.foo            ┐  5. example.resolve.c.foo#emomp74i93 (removed)
-    6. example.resolve.c.foo#emomp74i93 ┘  
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
 .example.resolve.c> todo
 

--- a/unison-src/transcripts/squash.md
+++ b/unison-src/transcripts/squash.md
@@ -134,8 +134,8 @@ This checks to see that squashing correctly preserves deletions:
 ```ucm
 .delete> builtins.merge
 .delete> fork builtin builtin2
-.delete> delete.term builtin2.Nat.+
-.delete> delete.term builtin2.Nat.*
+.delete> delete.term.verbose builtin2.Nat.+
+.delete> delete.term.verbose builtin2.Nat.*
 .delete> squash builtin2 builtin
 .delete> history builtin
 ```

--- a/unison-src/transcripts/squash.output.md
+++ b/unison-src/transcripts/squash.output.md
@@ -440,13 +440,31 @@ This checks to see that squashing correctly preserves deletions:
 
   Done.
 
-.delete> delete.term builtin2.Nat.+
+.delete> delete.term.verbose builtin2.Nat.+
 
-  Done.
+  Name changes:
+  
+    Original                    Changes
+    1. builtin.Nat.+         ┐  2. delete.builtin2.Nat.+ (removed)
+    3. builtin2.Nat.+        │  
+    4. delete.builtin.Nat.+  │  
+    5. delete.builtin2.Nat.+ │  
+    6. mybuiltin.Nat.+       ┘  
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
 
-.delete> delete.term builtin2.Nat.*
+.delete> delete.term.verbose builtin2.Nat.*
 
-  Done.
+  Name changes:
+  
+    Original                    Changes
+    1. builtin.Nat.*         ┐  2. delete.builtin2.Nat.* (removed)
+    3. builtin2.Nat.*        │  
+    4. delete.builtin.Nat.*  │  
+    5. delete.builtin2.Nat.* │  
+    6. mybuiltin.Nat.*       ┘  
+  
+  Tip: You can use `undo` or `reflog` to undo this change.
 
 .delete> squash builtin2 builtin
 

--- a/unison-src/transcripts/squash.output.md
+++ b/unison-src/transcripts/squash.output.md
@@ -442,29 +442,11 @@ This checks to see that squashing correctly preserves deletions:
 
 .delete> delete.term builtin2.Nat.+
 
-  Name changes:
-  
-    Original                    Changes
-    1. builtin.Nat.+         ┐  2. delete.builtin2.Nat.+ (removed)
-    3. builtin2.Nat.+        │  
-    4. delete.builtin.Nat.+  │  
-    5. delete.builtin2.Nat.+ │  
-    6. mybuiltin.Nat.+       ┘  
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
 .delete> delete.term builtin2.Nat.*
 
-  Name changes:
-  
-    Original                    Changes
-    1. builtin.Nat.*         ┐  2. delete.builtin2.Nat.* (removed)
-    3. builtin2.Nat.*        │  
-    4. delete.builtin.Nat.*  │  
-    5. delete.builtin2.Nat.* │  
-    6. mybuiltin.Nat.*       ┘  
-  
-  Tip: You can use `undo` or `reflog` to undo this change.
+  Done.
 
 .delete> squash builtin2 builtin
 

--- a/unison-src/transcripts/tab-completion.output.md
+++ b/unison-src/transcripts/tab-completion.output.md
@@ -21,8 +21,11 @@ Test that tab completion works as expected.
    delete.patch
    delete.term
    delete.term-replacement
+   delete.term.verbose
    delete.type
    delete.type-replacement
+   delete.type.verbose
+   delete.verbose
 
 ```
 ## Tab complete terms & types


### PR DESCRIPTION
fixes #3395

add delete{.term,.type}.verbose variants with the old behavior.

When a delete occurs we put a new root branch into the loop state's root branch cache. This new root branch has thunks for the deep* fields that are expensive to force. Diffing the namespaces forces these deep* fields (to come up with names for terms I think), and ends up consuming a lot of time and heap space. 

In an example on Stew's codebase this brought the time to execute a delete transcript down from 68 seconds to 17 seconds, and the max heap size from 2.8G to 280M.

This is, of course, just a band-aid the real fix involves moving away from the deep* fields altogether with the "relational namespaces" effort.