### PR TITLE
Fix a corner case in new 'beta-reduced' decompilation

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/ANF.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF.hs
@@ -249,10 +249,11 @@ prefix :: Ord v => Term v a -> Prefix v (Term v a)
 prefix = ABT.visit \case
   Apps' (Var' u) as -> case splitPfx u as of
     (pf, rest) -> Just $ traverse prefix rest *> pf
+  Var' u -> Just . Pfx $ Map.singleton u []
   _ -> Nothing
 
 appPfx :: Ord v => Prefix v a -> v -> [v] -> [v]
-appPfx (Pfx m) v = maybe id common $ Map.lookup v m
+appPfx (Pfx m) v = maybe (const []) common $ Map.lookup v m
 
 -- Rewrites a term by dropping the first n arguments to every
 -- application of `v`. This just assumes such a thing makes sense, as

--- a/unison-src/transcripts/fix3265.output.md
+++ b/unison-src/transcripts/fix3265.output.md
@@ -43,7 +43,7 @@ are three cases that need to be 'fixed up.'
                   0 -> x
                   n -> 1 + f1 (drop y 1)
               f2 x = f2 x
-              f3 y = 1 + y + f2 x
+              f3 x y = 1 + y + f2 x
               g h = h 1 + x
               g (z -> x + f0 z))
 


### PR DESCRIPTION
The check was looking for occurrences of `f x y z ...` to make sure it was safe to eliminate variables that had been added by enclosure. However, it wasn't finding occurrences of `f` by itself, because that is not considered an application by the predicate that was being used.

I also made the 'fix-up' code default to not eliminating any variables when there are *no* subsequent occurrences of `f`. Previously this would allow eliminating as many variables as possible. However, this can produce ill-scoped definitions. Avoiding this would require knowing which variables are in scope when reducing an unused definition, but that would require a more complicated rewriting process than is currently used.
