### PR TITLE
Remove external names from names-index lookups

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
@@ -1081,9 +1081,7 @@ updateNameIndex (newTermNames, removedTermNames) (newTypeNames, removedTypeNames
 
 data NamesByPath = NamesByPath
   { termNamesInPath :: [S.NamedRef (C.Referent, Maybe C.ConstructorType)],
-    termNamesExternalToPath :: [S.NamedRef (C.Referent, Maybe C.ConstructorType)],
-    typeNamesInPath :: [S.NamedRef C.Reference],
-    typeNamesExternalToPath :: [S.NamedRef C.Reference]
+    typeNamesInPath :: [S.NamedRef C.Reference]
   }
 
 -- | Get all the term and type names for the root namespace from the lookup table.
@@ -1092,14 +1090,12 @@ rootNamesByPath ::
   Maybe Text ->
   Transaction NamesByPath
 rootNamesByPath path = do
-  (termNamesInPath, termNamesExternalToPath) <- Q.rootTermNamesByPath path
-  (typeNamesInPath, typeNamesExternalToPath) <- Q.rootTypeNamesByPath path
+  termNamesInPath <- Q.rootTermNamesByPath path
+  typeNamesInPath <- Q.rootTypeNamesByPath path
   pure $
     NamesByPath
       { termNamesInPath = convertTerms <$> termNamesInPath,
-        termNamesExternalToPath = convertTerms <$> termNamesExternalToPath,
-        typeNamesInPath = convertTypes <$> typeNamesInPath,
-        typeNamesExternalToPath = convertTypes <$> typeNamesExternalToPath
+        typeNamesInPath = convertTypes <$> typeNamesInPath
       }
   where
     convertTerms = fmap (bimap s2cTextReferent (fmap s2cConstructorType))

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -1750,37 +1750,35 @@ insertTypeNames names =
         |]
 
 -- | Get the list of a term names in the root namespace according to the name lookup index
-rootTermNamesByPath :: Maybe Text -> Transaction ([NamedRef (Referent.TextReferent, Maybe NamedRef.ConstructorType)], [NamedRef (Referent.TextReferent, Maybe NamedRef.ConstructorType)])
+rootTermNamesByPath :: Maybe Text -> Transaction [NamedRef (Referent.TextReferent, Maybe NamedRef.ConstructorType)]
 rootTermNamesByPath mayNamespace = do
   let (namespace, subnamespace) = case mayNamespace of
         Nothing -> ("", "*")
         Just namespace -> (namespace, globEscape namespace <> ".*")
-  results :: [Only Bool :. NamedRef (Referent.TextReferent :. Only (Maybe NamedRef.ConstructorType))] <- queryListRow sql (subnamespace, namespace, subnamespace, namespace)
-  let (namesInNamespace, namesOutsideNamespace) = span (\(Only inNamespace :. _) -> inNamespace) results
-  pure (fmap unRow . dropTag <$> namesInNamespace, fmap unRow . dropTag <$> namesOutsideNamespace)
+  results :: [NamedRef (Referent.TextReferent :. Only (Maybe NamedRef.ConstructorType))] <- queryListRow sql (subnamespace, namespace, subnamespace, namespace)
+  pure (fmap unRow <$> results)
   where
-    dropTag (_ :. name) = name
     unRow (a :. Only b) = (a, b)
     sql =
       [here|
-        SELECT namespace GLOB ? OR namespace = ?, reversed_name, referent_builtin, referent_component_hash, referent_component_index, referent_constructor_index, referent_constructor_type FROM term_name_lookup
+        SELECT reversed_name, referent_builtin, referent_component_hash, referent_component_index, referent_constructor_index, referent_constructor_type FROM term_name_lookup
+        WHERE (namespace GLOB ? OR namespace = ?)
         ORDER BY (namespace GLOB ? OR namespace = ?) DESC
         |]
 
 -- | Get the list of a type names in the root namespace according to the name lookup index
-rootTypeNamesByPath :: Maybe Text -> Transaction ([NamedRef Reference.TextReference], [NamedRef Reference.TextReference])
+rootTypeNamesByPath :: Maybe Text -> Transaction [NamedRef Reference.TextReference]
 rootTypeNamesByPath mayNamespace = do
   let (namespace, subnamespace) = case mayNamespace of
         Nothing -> ("", "*")
         Just namespace -> (namespace, globEscape namespace <> ".*")
-  results :: [Only Bool :. NamedRef Reference.TextReference] <- queryListRow sql (subnamespace, namespace, subnamespace, namespace)
-  let (namesInNamespace, namesOutsideNamespace) = span (\(Only inNamespace :. _) -> inNamespace) results
-  pure (dropTag <$> namesInNamespace, dropTag <$> namesOutsideNamespace)
+  results :: [NamedRef Reference.TextReference] <- queryListRow sql (subnamespace, namespace, subnamespace, namespace)
+  pure results
   where
-    dropTag (_ :. name) = name
     sql =
       [here|
-        SELECT namespace GLOB ? OR namespace = ?, reversed_name, reference_builtin, reference_component_hash, reference_component_index FROM type_name_lookup
+        SELECT reversed_name, reference_builtin, reference_component_hash, reference_component_index FROM type_name_lookup
+        WHERE namespace GLOB ? OR namespace = ?
         ORDER BY (namespace GLOB ? OR namespace = ?) DESC
         |]
 

--- a/parser-typechecker/src/U/Codebase/Projects.hs
+++ b/parser-typechecker/src/U/Codebase/Projects.hs
@@ -17,15 +17,15 @@ import qualified Unison.Sqlite as Sqlite
 libSegment :: Branch.NameSegment
 libSegment = (Branch.NameSegment "lib")
 
--- | Infers the project root containing a given path.
+-- | Infers path to use for loading names.
 -- Currently this means finding the closest parent with a "lib" child.
-inferProjectRoot :: Path -> Branch Sqlite.Transaction -> Sqlite.Transaction (Maybe Path)
-inferProjectRoot p _b | Just match <- specialCases p = pure $ Just match
+inferNamesRoot :: Path -> Branch Sqlite.Transaction -> Sqlite.Transaction (Maybe Path)
+inferNamesRoot p _b | Just match <- specialCases p = pure $ Just match
   where
     specialCases :: Path -> Maybe Path
     specialCases ("public" Cons.:< "base" Cons.:< release Cons.:< _rest) = Just (Path.fromList ["public", "base", release])
     specialCases _ = Nothing
-inferProjectRoot p b = getLast <$> execWriterT (runReaderT (go p b) Path.empty)
+inferNamesRoot p b = getLast <$> execWriterT (runReaderT (go p b) Path.empty)
   where
     go :: Path -> Branch Sqlite.Transaction -> ReaderT Path (WriterT (Last Path) Sqlite.Transaction) ()
     go p b = do

--- a/parser-typechecker/src/U/Codebase/Projects.hs
+++ b/parser-typechecker/src/U/Codebase/Projects.hs
@@ -1,0 +1,36 @@
+module U.Codebase.Projects where
+
+import qualified Control.Lens.Cons as Cons
+import Control.Monad.Reader
+import Control.Monad.Writer.Strict (WriterT, execWriterT, tell)
+import qualified Data.Map as Map
+import Data.Monoid (Last (..))
+import U.Codebase.Branch
+import qualified U.Codebase.Branch.Type as Branch
+import qualified U.Codebase.Causal as Causal
+import Unison.Codebase.Path
+import qualified Unison.Codebase.Path as Path
+import Unison.NameSegment (NameSegment (..))
+import Unison.Prelude
+import qualified Unison.Sqlite as Sqlite
+
+libSegment :: Branch.NameSegment
+libSegment = (Branch.NameSegment "lib")
+
+-- | Infers the project root containing a given path.
+-- Currently this means finding the closest parent with a "lib" child.
+inferProjectRoot :: Path -> Branch Sqlite.Transaction -> Sqlite.Transaction (Maybe Path)
+inferProjectRoot p b = getLast <$> execWriterT (runReaderT (go p b) Path.empty)
+  where
+    go :: Path -> Branch Sqlite.Transaction -> ReaderT Path (WriterT (Last Path) Sqlite.Transaction) ()
+    go p b = do
+      childMap <- lift . lift $ nonEmptyChildren b
+      when (isJust $ Map.lookup libSegment childMap) $ ask >>= tell . Last . Just
+      case p of
+        Empty -> pure ()
+        (nextChild Cons.:< pathRemainder) ->
+          case Map.lookup (coerce nextChild) childMap of
+            Nothing -> pure ()
+            Just childCausal -> do
+              childBranch <- lift . lift $ Causal.value childCausal
+              local (Cons.|> nextChild) (go pathRemainder childBranch)

--- a/parser-typechecker/src/U/Codebase/Projects.hs
+++ b/parser-typechecker/src/U/Codebase/Projects.hs
@@ -20,6 +20,11 @@ libSegment = (Branch.NameSegment "lib")
 -- | Infers the project root containing a given path.
 -- Currently this means finding the closest parent with a "lib" child.
 inferProjectRoot :: Path -> Branch Sqlite.Transaction -> Sqlite.Transaction (Maybe Path)
+inferProjectRoot p _b | Just match <- specialCases p = pure $ Just match
+  where
+    specialCases :: Path -> Maybe Path
+    specialCases ("public" Cons.:< "base" Cons.:< release Cons.:< _rest) = Just (Path.fromList ["public", "base", release])
+    specialCases _ = Nothing
 inferProjectRoot p b = getLast <$> execWriterT (runReaderT (go p b) Path.empty)
   where
     go :: Path -> Branch Sqlite.Transaction -> ReaderT Path (WriterT (Last Path) Sqlite.Transaction) ()

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -592,19 +592,12 @@ namesAtPath ::
   Transaction ScopedNames
 namesAtPath path = do
   let namespace = if path == Path.empty then Nothing else Just $ tShow path
-  NamesByPath {termNamesInPath, termNamesExternalToPath, typeNamesInPath, typeNamesExternalToPath} <- Ops.rootNamesByPath namespace
+  NamesByPath {termNamesInPath, typeNamesInPath} <- Ops.rootNamesByPath namespace
   let termsInPath = convertTerms termNamesInPath
   let typesInPath = convertTypes typeNamesInPath
-  let termsOutsidePath = convertTerms termNamesExternalToPath
-  let typesOutsidePath = convertTypes typeNamesExternalToPath
-  let allTerms :: [(Name, Referent.Referent)]
-      allTerms = termsInPath <> termsOutsidePath
-  let allTypes :: [(Name, Reference.Reference)]
-      allTypes = typesInPath <> typesOutsidePath
-  let rootTerms = Rel.fromList allTerms
-  let rootTypes = Rel.fromList allTypes
+  let rootTerms = Rel.fromList termsInPath
+  let rootTypes = Rel.fromList typesInPath
   let absoluteRootNames = Names.makeAbsolute $ Names {terms = rootTerms, types = rootTypes}
-  let absoluteExternalNames = Names.makeAbsolute $ Names {terms = Rel.fromList termsOutsidePath, types = Rel.fromList typesOutsidePath}
   let relativeScopedNames =
         case path of
           Path.Empty -> (Names.makeRelative $ absoluteRootNames)
@@ -615,8 +608,7 @@ namesAtPath path = do
              in (Names {terms = Rel.fromList relativeTerms, types = Rel.fromList relativeTypes})
   pure $
     ScopedNames
-      { absoluteExternalNames,
-        relativeScopedNames,
+      { relativeScopedNames,
         absoluteRootNames
       }
   where

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -24,6 +24,7 @@ flag optimized
 library
   exposed-modules:
       U.Codebase.Branch.Diff
+      U.Codebase.Projects
       Unison.Builtin
       Unison.Builtin.Decls
       Unison.Builtin.Terms

--- a/unison-core/src/Unison/Names/Scoped.hs
+++ b/unison-core/src/Unison/Names/Scoped.hs
@@ -1,12 +1,10 @@
 module Unison.Names.Scoped where
 
 import Unison.Names (Names)
-import qualified Unison.Names as Names
 
 -- | Contains all useful permutations of names scoped to a given branch.
 data ScopedNames = ScopedNames
-  { absoluteExternalNames :: Names,
-    relativeScopedNames :: Names,
+  { relativeScopedNames :: Names,
     absoluteRootNames :: Names
   }
 
@@ -21,4 +19,4 @@ parseNames (ScopedNames {relativeScopedNames, absoluteRootNames}) = relativeScop
 -- | Includes includes relative names for anything in the path, and absolute names for
 -- everything else.
 prettyNames :: ScopedNames -> Names
-prettyNames (ScopedNames {relativeScopedNames, absoluteExternalNames}) = relativeScopedNames `Names.unionLeft` absoluteExternalNames
+prettyNames (ScopedNames {relativeScopedNames}) = relativeScopedNames

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -31,6 +31,7 @@ import qualified Text.FuzzyFind as FZF
 import U.Codebase.Branch (NamespaceStats (..))
 import qualified U.Codebase.Branch as V2Branch
 import qualified U.Codebase.Causal as V2Causal
+import U.Codebase.Projects as Projects
 import qualified U.Codebase.Referent as V2Referent
 import qualified U.Codebase.Sqlite.Operations as Operations
 import qualified Unison.ABT as ABT
@@ -1124,7 +1125,8 @@ scopedNamesForBranchHash codebase mbh path = do
   hashLen <- lift $ Codebase.runTransaction codebase Codebase.hashLength
   (parseNames, localNames) <- case mbh of
     Nothing
-      | shouldUseNamesIndex -> lift $ Codebase.runTransaction codebase indexNames
+      | shouldUseNamesIndex -> do
+          lift $ Codebase.runTransaction codebase indexNames
       | otherwise -> do
           rootBranch <- lift $ Codebase.getRootBranch codebase
           let (parseNames, _prettyNames, localNames) = namesForBranch rootBranch (AllNames path)
@@ -1150,7 +1152,10 @@ scopedNamesForBranchHash codebase mbh path = do
         (PPED.suffixifiedPPE primary `PPE.addFallback` PPED.suffixifiedPPE addFallback)
     indexNames :: Sqlite.Transaction (Names, Names)
     indexNames = do
-      scopedNames <- Codebase.namesAtPath path
+      branch <- Codebase.getShallowRootBranch
+      mayProjectRoot <- Projects.inferProjectRoot path branch
+      let namesRoot = fromMaybe path mayProjectRoot
+      scopedNames <- Codebase.namesAtPath namesRoot path
       pure (ScopedNames.parseNames scopedNames, ScopedNames.namesAtPath scopedNames)
 
 resolveCausalHash ::

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -1153,7 +1153,7 @@ scopedNamesForBranchHash codebase mbh path = do
     indexNames :: Sqlite.Transaction (Names, Names)
     indexNames = do
       branch <- Codebase.getShallowRootBranch
-      mayProjectRoot <- Projects.inferProjectRoot path branch
+      mayProjectRoot <- Projects.inferNamesRoot path branch
       let namesRoot = fromMaybe path mayProjectRoot
       scopedNames <- Codebase.namesAtPath namesRoot path
       pure (ScopedNames.parseNames scopedNames, ScopedNames.namesAtPath scopedNames)


### PR DESCRIPTION
## Overview

This code was written when we still wanted to "fallback" to external names on share (before we expected everything to be properly self-contained).
Looks like it didn't ever get re-visited, so we're still naively loading ALL names regardless of perspective.

Before this PR: O(codebase) names
After this PR: O(perspective) names

I'm still working on the minimal ppe patch which will be: O(references in term) names, but this is a super quick patch to improve things in the meantime, and significantly reduce memory and cpu load in Share.

## Implementation notes

* Exclude names from outside of the perspective at SQLite time rather than in Haskell.
* This means that we lose the "fallback" to external names in the case that there's no local name for a given term, so some users may begin to see hashes if their project-namespace isn't self-contained.
* In order to still support perspectives we need to infer the project-root so we can fetch all the names for the project regardless of the perspective, so I added `inferProjectRoot` as a stop-gap until we have proper projects. given a path, it will infer the project root by finding the closest parent which has a "lib" child
* There's a special case where `public.base.*` is chosen as the "project root" if the path matches that prefix, this is because `base` won't have a `lib` directory at all.
* If a project root isn't inferred (e.g. there's no lib in any of the parents, and it's not 'base') then we simply use the perspective as the root to load names for.

I'm not in love with these "hacks", but they're small, self-contained, and we can remove them once we transition to proper projects so I'm not concerned.