### PR TITLE
Split doc evaluation from doc rendering

### DIFF
--- a/unison-core/src/Unison/DataDeclaration.hs
+++ b/unison-core/src/Unison/DataDeclaration.hs
@@ -17,8 +17,10 @@ module Unison.DataDeclaration
     constructorIds,
     declConstructorReferents,
     declDependencies,
+    labeledDeclDependencies,
     declFields,
     dependencies,
+    labeledDependencies,
     generateRecordAccessors,
     unhashComponent,
     mkDataDecl',
@@ -41,6 +43,7 @@ import qualified Unison.ABT as ABT
 import Unison.ConstructorReference (GConstructorReference (..))
 import qualified Unison.ConstructorType as CT
 import Unison.DataDeclaration.ConstructorId (ConstructorId)
+import qualified Unison.LabeledDependency as LD
 import qualified Unison.Name as Name
 import qualified Unison.Names.ResolutionResult as Names
 import qualified Unison.Pattern as Pattern
@@ -69,6 +72,9 @@ asDataDecl = either toDataDecl id
 
 declDependencies :: Ord v => Decl v a -> Set Reference
 declDependencies = either (dependencies . toDataDecl) dependencies
+
+labeledDeclDependencies :: Ord v => Decl v a -> Set LD.LabeledDependency
+labeledDeclDependencies = Set.map LD.TypeReference . declDependencies
 
 constructorType :: Decl v a -> CT.ConstructorType
 constructorType = \case
@@ -253,6 +259,9 @@ bindReferences unsafeVarToName keepFree names (DataDeclaration m a bound constru
 dependencies :: Ord v => DataDeclaration v a -> Set Reference
 dependencies dd =
   Set.unions (Type.dependencies <$> constructorTypes dd)
+
+labeledDependencies :: Ord v => DataDeclaration v a -> Set LD.LabeledDependency
+labeledDependencies = Set.map LD.TypeReference . dependencies
 
 mkEffectDecl' ::
   Modifier -> a -> [v] -> [(a, v, Type v a)] -> EffectDeclaration v a

--- a/unison-core/src/Unison/Type.hs
+++ b/unison-core/src/Unison/Type.hs
@@ -11,6 +11,7 @@ import Data.Monoid (Any (..))
 import qualified Data.Set as Set
 import qualified Unison.ABT as ABT
 import qualified Unison.Kind as K
+import qualified Unison.LabeledDependency as LD
 import qualified Unison.Name as Name
 import qualified Unison.Names.ResolutionResult as Names
 import Unison.Prelude
@@ -521,6 +522,9 @@ dependencies t = Set.fromList . Writer.execWriter $ ABT.visit' f t
   where
     f t@(Ref r) = Writer.tell [r] $> t
     f t = pure t
+
+labeledDependencies :: Ord v => Type v a -> Set LD.LabeledDependency
+labeledDependencies = Set.map LD.TypeReference . dependencies
 
 updateDependencies :: Ord v => Map Reference Reference -> Type v a -> Type v a
 updateDependencies typeUpdates = ABT.rebuildUp go

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -972,7 +972,7 @@ renderDoc ppe width rt codebase r = do
   let hash = Reference.toText r
   (name,hash,)
     <$> let tm = Term.ref () r
-         in Doc.renderDoc
+         in Doc.evalAndRenderDoc
               ppe
               terms
               (Codebase.runTransaction codebase . typeOf)

--- a/unison-share-api/src/Unison/Server/Doc.hs
+++ b/unison-share-api/src/Unison/Server/Doc.hs
@@ -474,35 +474,6 @@ data ExpandedTerm v
 
 dependencies :: Ord v => ExpandedDoc v -> Set LD.LabeledDependency
 dependencies = \case
-  -- Word txt -> pure $ Word txt
-  -- Code d -> Code <$> go d
-  -- CodeBlock lang d -> CodeBlock lang <$> go d
-  -- Bold d -> Bold <$> go d
-  -- Italic d -> Italic <$> go d
-  -- Strikethrough d -> Strikethrough <$> go d
-  -- Style s d -> Style s <$> go d
-  -- Anchor a d -> Anchor a <$> go d
-  -- Blockquote d -> Blockquote <$> go d
-  -- Blankline -> pure Blankline
-  -- Linebreak -> pure Linebreak
-  -- SectionBreak -> pure SectionBreak
-  -- Tooltip d1 d2 -> Tooltip <$> go d1 <*> go d2
-  -- Aside d -> Aside <$> go d
-  -- Callout d1 d2 -> Callout <$> traverse go d1 <*> go d2
-  -- Table rows -> Table <$> traverse (traverse go) rows
-  -- Folded folded d1 d2 -> Folded folded <$> go d1 <*> go d2
-  -- Paragraph ds -> Paragraph <$> traverse go ds
-  -- BulletedList ds -> BulletedList <$> traverse go ds
-  -- NumberedList n ds -> NumberedList n <$> traverse go ds
-  -- Section d ds -> Section <$> go d <*> traverse go ds
-  -- NamedLink d1 d2 -> NamedLink <$> go d1 <*> go d2
-  -- Image d1 d2 d3 -> Image <$> go d1 <*> go d2 <*> traverse go d3
-  -- Special s -> Special <$> goSpecial s
-  -- Join ds -> Join <$> traverse go ds
-  -- UntitledSection ds -> UntitledSection <$> traverse go ds
-  -- Column ds -> Column <$> traverse go ds
-  -- Group d -> Group <$> go d
-  -- RenderError (InvalidTerm trm) -> pure . Word . Text.pack . P.toPlain (P.Width 80) . P.indent "🆘  " . TermPrinter.pretty (PPE.suffixifiedPPE pped) $ trmm
   Word _txt -> mempty
   Code d -> dependencies d
   CodeBlock _lang d -> dependencies d

--- a/unison-share-api/src/Unison/Server/Doc.hs
+++ b/unison-share-api/src/Unison/Server/Doc.hs
@@ -458,7 +458,7 @@ expandDoc terms typeOf eval types tm = go tm
 
 data RenderError trm
   = InvalidTerm trm
-  deriving stock (Generic)
+  deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON)
 
 deriving anyclass instance ToSchema trm => ToSchema (RenderError trm)

--- a/unison-share-api/src/Unison/Server/Doc.hs
+++ b/unison-share-api/src/Unison/Server/Doc.hs
@@ -396,7 +396,7 @@ evalDoc terms typeOf eval types tm = go tm
       -- EvalInline Doc2.Term
       DD.Doc2SpecialFormEvalInline (DD.Doc2Term tm) -> do
         result <- eval tm
-        pure $ EEval tm result
+        pure $ EEvalInline tm result
       -- Embed Video
       DD.Doc2SpecialFormEmbedVideo sources config ->
         pure $ EVideo sources' config'

--- a/unison-share-api/src/Unison/Server/Doc.hs
+++ b/unison-share-api/src/Unison/Server/Doc.hs
@@ -3,25 +3,21 @@
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE ViewPatterns #-}
 
 module Unison.Server.Doc where
 
 import Control.Lens (view, (^.))
 import Control.Monad
-import Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
 import Data.Aeson (ToJSON)
 import Data.Foldable
 import Data.Functor
-import Data.Map (Map)
 import qualified Data.Map as Map
-import Data.Maybe (fromMaybe)
 import Data.OpenApi (ToSchema)
 import qualified Data.Set as Set
-import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Word
-import GHC.Generics (Generic)
 import qualified Unison.ABT as ABT
 import qualified Unison.Builtin.Decls as DD
 import qualified Unison.Builtin.Decls as Decls
@@ -29,6 +25,8 @@ import Unison.Codebase.Editor.DisplayObject (DisplayObject)
 import qualified Unison.Codebase.Editor.DisplayObject as DO
 import qualified Unison.ConstructorReference as ConstructorReference
 import qualified Unison.DataDeclaration as DD
+import qualified Unison.LabeledDependency as LD
+import Unison.Prelude
 import qualified Unison.PrettyPrintEnv as PPE
 import qualified Unison.PrettyPrintEnvDecl as PPE
 import Unison.Reference (Reference)
@@ -49,6 +47,7 @@ import qualified Unison.Term as Term
 import Unison.Type (Type)
 import qualified Unison.Type as Type
 import qualified Unison.Util.List as List
+import Unison.Util.Monoid (foldMapM)
 import qualified Unison.Util.Pretty as P
 import qualified Unison.Util.SyntaxText as S
 import Unison.Var (Var)
@@ -57,37 +56,46 @@ type Nat = Word64
 
 type SSyntaxText = S.SyntaxText' Reference
 
-data Doc
+type SrcRefs = Ref (UnisonHash, DisplayObject SyntaxText Src)
+
+type Doc = DocG (RenderError SyntaxText) SrcRefs SyntaxText SyntaxText SyntaxText SyntaxText SyntaxText UnisonHash
+
+type ExpandedDoc v = DocG (RenderError (Term v ())) (ExpandedSrc v) (Term v ()) (Referent, Type v ()) (DD.Decl v ()) (Either (Term v ()) LD.LabeledDependency) Builtin ()
+
+data DocG err src trm typ decl ref builtin hash
   = Word Text
-  | Code Doc
-  | CodeBlock Text Doc
-  | Bold Doc
-  | Italic Doc
-  | Strikethrough Doc
-  | Style Text Doc
-  | Anchor Text Doc
-  | Blockquote Doc
+  | Code (DocG err src trm typ decl ref builtin hash)
+  | CodeBlock Text (DocG err src trm typ decl ref builtin hash)
+  | Bold (DocG err src trm typ decl ref builtin hash)
+  | Italic (DocG err src trm typ decl ref builtin hash)
+  | Strikethrough (DocG err src trm typ decl ref builtin hash)
+  | Style Text (DocG err src trm typ decl ref builtin hash)
+  | Anchor Text (DocG err src trm typ decl ref builtin hash)
+  | Blockquote (DocG err src trm typ decl ref builtin hash)
   | Blankline
   | Linebreak
   | SectionBreak
-  | Tooltip Doc Doc
-  | Aside Doc
-  | Callout (Maybe Doc) Doc
-  | Table [[Doc]]
-  | Folded Bool Doc Doc
-  | Paragraph [Doc]
-  | BulletedList [Doc]
-  | NumberedList Nat [Doc]
-  | Section Doc [Doc]
-  | NamedLink Doc Doc
-  | Image Doc Doc (Maybe Doc)
-  | Special SpecialForm
-  | Join [Doc]
-  | UntitledSection [Doc]
-  | Column [Doc]
-  | Group Doc
+  | Tooltip (DocG err src trm typ decl ref builtin hash) (DocG err src trm typ decl ref builtin hash)
+  | Aside (DocG err src trm typ decl ref builtin hash)
+  | Callout (Maybe (DocG err src trm typ decl ref builtin hash)) (DocG err src trm typ decl ref builtin hash)
+  | Table [[(DocG err src trm typ decl ref builtin hash)]]
+  | Folded Bool (DocG err src trm typ decl ref builtin hash) (DocG err src trm typ decl ref builtin hash)
+  | Paragraph [(DocG err src trm typ decl ref builtin hash)]
+  | BulletedList [(DocG err src trm typ decl ref builtin hash)]
+  | NumberedList Nat [(DocG err src trm typ decl ref builtin hash)]
+  | Section (DocG err src trm typ decl ref builtin hash) [(DocG err src trm typ decl ref builtin hash)]
+  | NamedLink (DocG err src trm typ decl ref builtin hash) (DocG err src trm typ decl ref builtin hash)
+  | Image (DocG err src trm typ decl ref builtin hash) (DocG err src trm typ decl ref builtin hash) (Maybe (DocG err src trm typ decl ref builtin hash))
+  | Special (SpecialFormG err src trm typ decl ref builtin hash)
+  | Join [(DocG err src trm typ decl ref builtin hash)]
+  | UntitledSection [(DocG err src trm typ decl ref builtin hash)]
+  | Column [(DocG err src trm typ decl ref builtin hash)]
+  | Group (DocG err src trm typ decl ref builtin hash)
+  | RenderError err
   deriving stock (Eq, Show, Generic)
-  deriving anyclass (ToJSON, ToSchema)
+  deriving anyclass (ToJSON)
+
+deriving anyclass instance ToSchema Doc
 
 type UnisonHash = Text
 
@@ -101,29 +109,40 @@ data MediaSource = MediaSource {mediaSourceUrl :: Text, mediaSourceMimeType :: M
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, ToSchema)
 
-data SpecialForm
-  = Source [Ref (UnisonHash, DisplayObject SyntaxText Src)]
-  | FoldedSource [Ref (UnisonHash, DisplayObject SyntaxText Src)]
-  | Example SyntaxText
-  | ExampleBlock SyntaxText
-  | Link SyntaxText
-  | Signature [SyntaxText]
-  | SignatureInline SyntaxText
-  | Eval SyntaxText SyntaxText
-  | EvalInline SyntaxText SyntaxText
-  | Embed SyntaxText
-  | EmbedInline SyntaxText
+type Builtin = Text
+
+type SpecialForm = SpecialFormG (RenderError SyntaxText) SrcRefs SyntaxText SyntaxText SyntaxText SyntaxText SyntaxText UnisonHash
+
+type ExpandedSpecialForm v = SpecialFormG (RenderError (Term v ())) (ExpandedSrc v) (Term v ()) (Referent, Type v ()) (DD.Decl v ()) (Either (Term v ()) LD.LabeledDependency) Text ()
+
+data SpecialFormG err src trm sigtyp decl ref builtin hash
+  = Source [src]
+  | FoldedSource [src]
+  | Example trm
+  | ExampleBlock trm
+  | Link ref
+  | Signature [sigtyp]
+  | SignatureInline sigtyp
+  | -- Result is Nothing if there was an Eval failure
+    Eval trm (Maybe trm)
+  | -- Result is Nothing if there was an Eval failure
+    EvalInline trm (Maybe trm)
+  | Embed trm
+  | EmbedInline trm
   | Video [MediaSource] (Map Text Text)
   | FrontMatter (Map Text [Text])
+  | SpecialRenderError err
   deriving stock (Eq, Show, Generic)
-  deriving anyclass (ToJSON, ToSchema)
+  deriving anyclass (ToJSON)
+
+deriving anyclass instance ToSchema SpecialForm
 
 -- `Src folded unfolded`
 data Src = Src SyntaxText SyntaxText
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, ToSchema)
 
-renderDoc ::
+evalAndRenderDoc ::
   forall v m.
   (Var v, Monad m) =>
   PPE.PrettyPrintEnvDecl ->
@@ -133,11 +152,148 @@ renderDoc ::
   (Reference -> m (Maybe (DD.Decl v ()))) ->
   Term v () ->
   m Doc
-renderDoc pped terms typeOf eval types tm =
+evalAndRenderDoc pped terms typeOf eval types tm =
   eval tm >>= \case
     Nothing -> pure $ Word "🆘 doc rendering failed during evaluation"
-    Just tm -> go tm
+    Just tm -> expandDoc terms typeOf eval types tm >>= renderDoc pped
+
+renderDoc ::
+  forall v m.
+  (Var v, Monad m) =>
+  PPE.PrettyPrintEnvDecl ->
+  ExpandedDoc v ->
+  m Doc
+renderDoc pped doc = go doc
   where
+    suffixifiedPPE = PPE.suffixifiedPPE pped
+    go :: ExpandedDoc v -> m Doc
+    go = \case
+      Word txt -> pure $ Word txt
+      Code d -> Code <$> go d
+      CodeBlock lang d -> CodeBlock lang <$> go d
+      Bold d -> Bold <$> go d
+      Italic d -> Italic <$> go d
+      Strikethrough d -> Strikethrough <$> go d
+      Style s d -> Style s <$> go d
+      Anchor a d -> Anchor a <$> go d
+      Blockquote d -> Blockquote <$> go d
+      Blankline -> pure Blankline
+      Linebreak -> pure Linebreak
+      SectionBreak -> pure SectionBreak
+      Tooltip d1 d2 -> Tooltip <$> go d1 <*> go d2
+      Aside d -> Aside <$> go d
+      Callout d1 d2 -> Callout <$> traverse go d1 <*> go d2
+      Table rows -> Table <$> traverse (traverse go) rows
+      Folded folded d1 d2 -> Folded folded <$> go d1 <*> go d2
+      Paragraph ds -> Paragraph <$> traverse go ds
+      BulletedList ds -> BulletedList <$> traverse go ds
+      NumberedList n ds -> NumberedList n <$> traverse go ds
+      Section d ds -> Section <$> go d <*> traverse go ds
+      NamedLink d1 d2 -> NamedLink <$> go d1 <*> go d2
+      Image d1 d2 d3 -> Image <$> go d1 <*> go d2 <*> traverse go d3
+      Special s -> Special <$> goSpecial s
+      Join ds -> Join <$> traverse go ds
+      UntitledSection ds -> UntitledSection <$> traverse go ds
+      Column ds -> Column <$> traverse go ds
+      Group d -> Group <$> go d
+      RenderError (InvalidTerm trm) -> pure . Word . Text.pack . P.toPlain (P.Width 80) . P.indent "🆘  " . TermPrinter.pretty (PPE.suffixifiedPPE pped) $ trm
+
+    formatPretty = fmap Syntax.convertElement . P.render (P.Width 70)
+
+    formatPrettyType :: PPE.PrettyPrintEnv -> Type v a -> SyntaxText
+    formatPrettyType ppe typ = formatPretty (TypePrinter.prettySyntax ppe typ)
+
+    source :: Term v () -> m SyntaxText
+    source tm = pure . formatPretty $ TermPrinter.prettyBlock' True (PPE.suffixifiedPPE pped) tm
+
+    goSignatures :: [(Referent, Type v ())] -> m [P.Pretty SSyntaxText]
+    goSignatures types =
+      pure . fmap P.group $
+        TypePrinter.prettySignaturesST
+          (PPE.suffixifiedPPE pped)
+          [(r, PPE.termName (PPE.suffixifiedPPE pped) r, ty) | (r, ty) <- types]
+
+    goSpecial :: ExpandedSpecialForm v -> m SpecialForm
+    goSpecial = \case
+      Source srcs -> Source <$> goSrc srcs
+      FoldedSource srcs -> FoldedSource <$> goSrc srcs
+      Example trm -> Example <$> source trm
+      ExampleBlock trm -> ExampleBlock <$> source trm
+      Link ref ->
+        let ppe = PPE.suffixifiedPPE pped
+            tm :: Referent -> P.Pretty SSyntaxText
+            tm r = (NP.styleHashQualified'' (NP.fmt (S.TermReference r)) . PPE.termName ppe) r
+            ty :: Reference -> P.Pretty SSyntaxText
+            ty r = (NP.styleHashQualified'' (NP.fmt (S.TypeReference r)) . PPE.typeName ppe) r
+         in Link <$> case ref of
+              Left trm -> source trm
+              Right ld -> case ld of
+                LD.TermReferent r -> (pure . formatPretty . tm) r
+                LD.TypeReference r -> (pure . formatPretty . ty) r
+      Signature rs -> goSignatures rs <&> \s -> Signature (map formatPretty s)
+      SignatureInline r -> goSignatures [r] <&> \s -> SignatureInline (formatPretty (P.lines s))
+      Eval trm result -> do
+        renderedTrm <- source trm
+        case result of
+          Nothing -> pure $ Eval renderedTrm Nothing
+          Just renderedResult -> Eval renderedTrm <$> (Just <$> source renderedResult)
+      EvalInline trm result -> do
+        renderedTrm <- source trm
+        case result of
+          Nothing -> pure $ EvalInline renderedTrm Nothing
+          Just renderedResult -> EvalInline renderedTrm <$> (Just <$> source renderedResult)
+      Embed any -> source any <&> \p -> Embed ("{{ embed {{" <> p <> "}} }}")
+      EmbedInline any -> source any <&> \p -> EmbedInline ("{{ embed {{" <> p <> "}} }}")
+      Video sources config -> pure $ Video sources config
+      FrontMatter frontMatter -> pure $ FrontMatter frontMatter
+      SpecialRenderError (InvalidTerm tm) -> source tm <&> \p -> Embed ("🆘  unable to render " <> p)
+
+    goSrc :: [ExpandedSrc v] -> m [Ref (UnisonHash, DisplayObject SyntaxText Src)]
+    goSrc srcs =
+      srcs & foldMapM \case
+        ExpandedSrcDecl srcDecl -> case srcDecl of
+          MissingDecl r -> pure [(Type (Reference.toText r, DO.MissingObject (SH.unsafeFromText $ Reference.toText r)))]
+          BuiltinDecl r _builtin -> do
+            let name =
+                  formatPretty . NP.styleHashQualified (NP.fmt (S.TypeReference r))
+                    . PPE.typeName suffixifiedPPE
+                    $ r
+            pure [Type (Reference.toText r, DO.BuiltinObject name)]
+            where
+
+          FoundDecl r decl -> do
+            pure $ [Type (Reference.toText r, DO.UserObject (Src folded full))]
+            where
+              full = formatPretty (DeclPrinter.prettyDecl pped r (PPE.typeName suffixifiedPPE r) decl)
+              folded = formatPretty (DeclPrinter.prettyDeclHeader (PPE.typeName suffixifiedPPE r) decl)
+        ExpandedSrcTerm srcTerm -> case srcTerm of
+          MissingBuiltinTypeSig r -> pure [(Type (Reference.toText r, DO.BuiltinObject "🆘 missing type signature"))]
+          BuiltinTypeSig r typ -> do
+            pure $ [Type (Reference.toText r, DO.BuiltinObject (formatPrettyType suffixifiedPPE typ))]
+          MissingTerm r -> pure [Term (Reference.toText r, DO.MissingObject (SH.unsafeFromText $ Reference.toText r))]
+          FoundTerm ref typ tm -> do
+            let name = PPE.termName suffixifiedPPE (Referent.Ref ref)
+            let folded =
+                  formatPretty . P.lines $
+                    TypePrinter.prettySignaturesST suffixifiedPPE [(Referent.Ref ref, name, typ)]
+            let full tm@(Term.Ann' _ _) _ =
+                  formatPretty (TermPrinter.prettyBinding suffixifiedPPE name tm)
+                full tm typ =
+                  formatPretty (TermPrinter.prettyBinding suffixifiedPPE name (Term.ann () tm typ))
+            pure [Term (Reference.toText ref, DO.UserObject (Src folded (full tm typ)))]
+
+expandDoc ::
+  forall v m.
+  (Var v, Monad m) =>
+  (Reference -> m (Maybe (Term v ()))) ->
+  (Referent -> m (Maybe (Type v ()))) ->
+  (Term v () -> m (Maybe (Term v ()))) ->
+  (Reference -> m (Maybe (DD.Decl v ()))) ->
+  Term v () ->
+  m (ExpandedDoc v)
+expandDoc terms typeOf eval types tm = go tm
+  where
+    go :: Term v () -> m (ExpandedDoc v)
     go = \case
       DD.Doc2Word txt -> pure $ Word txt
       DD.Doc2Code d -> Code <$> go d
@@ -172,28 +328,21 @@ renderDoc pped terms typeOf eval types tm =
       DD.Doc2UntitledSection ds -> UntitledSection <$> traverse go ds
       DD.Doc2Column ds -> Column <$> traverse go ds
       DD.Doc2Group d -> Group <$> go d
-      wat ->
-        pure . Word . Text.pack . P.toPlain (P.Width 80) . P.indent "🆘  "
-          . TermPrinter.pretty (PPE.suffixifiedPPE pped)
-          $ wat
+      wat -> pure $ RenderError (InvalidTerm wat)
+    -- pure . Word . Text.pack . P.toPlain (P.Width 80) . P.indent "🆘  "
+    --   . TermPrinter.pretty (PPE.suffixifiedPPE pped)
+    --   $ wat
 
-    formatPretty = fmap Syntax.convertElement . P.render (P.Width 70)
-    formatPrettyType ppe typ = formatPretty (TypePrinter.prettySyntax ppe typ)
+    source :: Term v () -> m (Term v ())
+    source = pure
 
-    source :: Term v () -> m SyntaxText
-    source tm = pure . formatPretty $ TermPrinter.prettyBlock' True (PPE.suffixifiedPPE pped) tm
-
-    goSignatures :: [Referent] -> m [P.Pretty SSyntaxText]
+    goSignatures :: [Referent] -> m [(Referent, Type v ())]
     goSignatures rs =
       runMaybeT (traverse (MaybeT . typeOf) rs) >>= \case
-        Nothing -> pure ["🆘  codebase is missing type signature for these definitions"]
-        Just types ->
-          pure . fmap P.group $
-            TypePrinter.prettySignaturesST
-              (PPE.suffixifiedPPE pped)
-              [(r, PPE.termName (PPE.suffixifiedPPE pped) r, ty) | (r, ty) <- zip rs types]
+        Nothing -> error "🆘  codebase is missing type signature for these definitions"
+        Just types -> pure (zip rs types)
 
-    goSpecial :: Term v () -> m SpecialForm
+    goSpecial :: Term v () -> m (ExpandedSpecialForm v)
     goSpecial = \case
       DD.Doc2SpecialFormFoldedSource (Term.List' es) -> FoldedSource <$> goSrc (toList es)
       -- Source [Either Link.Type Doc2.Term]
@@ -213,34 +362,31 @@ renderDoc pped terms typeOf eval types tm =
 
       -- Link (Either Link.Type Doc2.Term)
       DD.Doc2SpecialFormLink e ->
-        let ppe = PPE.suffixifiedPPE pped
-            tm :: Referent -> P.Pretty SSyntaxText
-            tm r = (NP.styleHashQualified'' (NP.fmt (S.TermReference r)) . PPE.termName ppe) r
-            ty :: Reference -> P.Pretty SSyntaxText
-            ty r = (NP.styleHashQualified'' (NP.fmt (S.TypeReference r)) . PPE.typeName ppe) r
+        let tm :: Referent -> (Either a LD.LabeledDependency)
+            tm r = Right $ LD.TermReferent r
+            ty :: Reference -> (Either a LD.LabeledDependency)
+            ty r = Right $ LD.TypeReference r
          in Link <$> case e of
-              DD.EitherLeft' (Term.TypeLink' r) -> (pure . formatPretty . ty) r
+              DD.EitherLeft' (Term.TypeLink' r) -> pure $ ty r
               DD.EitherRight' (DD.Doc2Term t) ->
                 case Term.etaNormalForm t of
-                  Term.Referent' r -> (pure . formatPretty . tm) r
-                  x -> source x
-              _ -> source e
+                  Term.Referent' r -> pure $ tm r
+                  x -> Left <$> source x
+              _ -> Left <$> source e
       DD.Doc2SpecialFormSignature (Term.List' tms) ->
         let rs = [r | DD.Doc2Term (Term.Referent' r) <- toList tms]
-         in goSignatures rs <&> \s -> Signature (map formatPretty s)
+         in goSignatures rs <&> \s -> Signature s
       -- SignatureInline Doc2.Term
       DD.Doc2SpecialFormSignatureInline (DD.Doc2Term (Term.Referent' r)) ->
-        goSignatures [r] <&> \s -> SignatureInline (formatPretty (P.lines s))
+        goSignatures [r] <&> \[s] -> SignatureInline s
       -- Eval Doc2.Term
-      DD.Doc2SpecialFormEval (DD.Doc2Term tm) ->
-        eval tm >>= \case
-          Nothing -> Eval <$> source tm <*> pure evalErrMsg
-          Just result -> Eval <$> source tm <*> source result
+      DD.Doc2SpecialFormEval (DD.Doc2Term tm) -> do
+        result <- eval tm
+        Eval <$> source tm <*> traverse source result
       -- EvalInline Doc2.Term
-      DD.Doc2SpecialFormEvalInline (DD.Doc2Term tm) ->
-        eval tm >>= \case
-          Nothing -> EvalInline <$> source tm <*> pure evalErrMsg
-          Just result -> EvalInline <$> source tm <*> source result
+      DD.Doc2SpecialFormEvalInline (DD.Doc2Term tm) -> do
+        result <- eval tm
+        Eval <$> source tm <*> traverse source result
       -- Embed Video
       DD.Doc2SpecialFormEmbedVideo sources config ->
         pure $ Video sources' config'
@@ -258,43 +404,31 @@ renderDoc pped terms typeOf eval types tm =
 
       -- Embed Any
       DD.Doc2SpecialFormEmbed (Term.App' _ any) ->
-        source any <&> \p -> Embed ("{{ embed {{" <> p <> "}} }}")
+        source any <&> \p -> Embed p
       -- EmbedInline Any
       DD.Doc2SpecialFormEmbedInline any ->
-        source any <&> \p -> EmbedInline ("{{ embed {{" <> p <> "}} }}")
-      tm -> source tm <&> \p -> Embed ("🆘  unable to render " <> p)
+        source any <&> \p -> EmbedInline p
+      tm -> source tm <&> \p -> SpecialRenderError $ InvalidTerm p
 
-    evalErrMsg = "🆘  An error occured during evaluation"
-
-    goSrc :: [Term v ()] -> m [Ref (UnisonHash, DisplayObject SyntaxText Src)]
+    goSrc :: [Term v ()] -> m [ExpandedSrc v]
     goSrc es = do
       let toRef (Term.Ref' r) = Set.singleton r
           toRef (Term.RequestOrCtor' r) = Set.singleton (r ^. ConstructorReference.reference_)
           toRef _ = mempty
-          ppe = PPE.suffixifiedPPE pped
-          goType :: Reference -> m (Ref (UnisonHash, DisplayObject SyntaxText Src))
-          goType r@(Reference.Builtin _) =
-            pure (Type (Reference.toText r, DO.BuiltinObject name))
-            where
-              name =
-                formatPretty . NP.styleHashQualified (NP.fmt (S.TypeReference r))
-                  . PPE.typeName ppe
-                  $ r
-          goType r =
-            Type . (Reference.toText r,) <$> do
-              d <- types r
-              case d of
-                Nothing -> pure (DO.MissingObject (SH.unsafeFromText $ Reference.toText r))
-                Just decl ->
-                  pure $ DO.UserObject (Src folded full)
-                  where
-                    full = formatPretty (DeclPrinter.prettyDecl pped r (PPE.typeName ppe r) decl)
-                    folded = formatPretty (DeclPrinter.prettyDeclHeader (PPE.typeName ppe r) decl)
+          goType :: Reference -> m (ExpandedSrc v)
+          goType r@(Reference.Builtin builtin) =
+            pure (ExpandedSrcDecl (BuiltinDecl r builtin))
+          goType r = do
+            d <- types r
+            case d of
+              Nothing -> pure (ExpandedSrcDecl $ MissingDecl r)
+              Just decl ->
+                pure $ ExpandedSrcDecl (FoundDecl r decl)
 
           go ::
-            (Set.Set Reference, [Ref (UnisonHash, DisplayObject SyntaxText Src)]) ->
+            (Set.Set Reference, [ExpandedSrc v]) ->
             Term v () ->
-            m (Set.Set Reference, [Ref (UnisonHash, DisplayObject SyntaxText Src)])
+            m (Set.Set Reference, [ExpandedSrc v])
           go s1@(!seen, !acc) = \case
             -- we ignore the annotations; but this could be extended later
             DD.TupleTerm' [DD.EitherRight' (DD.Doc2Term tm), _anns] ->
@@ -303,29 +437,139 @@ renderDoc pped terms typeOf eval types tm =
                 acc' = case tm of
                   Term.Ref' r
                     | Set.notMember r seen ->
-                      (: acc) . Term . (Reference.toText r,) <$> case r of
-                        Reference.Builtin _ ->
-                          typeOf (Referent.Ref r) <&> \case
-                            Nothing -> DO.BuiltinObject "🆘 missing type signature"
-                            Just ty -> DO.BuiltinObject (formatPrettyType ppe ty)
-                        ref ->
-                          terms ref >>= \case
-                            Nothing -> pure $ DO.MissingObject (SH.unsafeFromText $ Reference.toText ref)
-                            Just tm -> do
-                              typ <- fromMaybe (Type.builtin () "unknown") <$> typeOf (Referent.Ref ref)
-                              let name = PPE.termName ppe (Referent.Ref ref)
-                              let folded =
-                                    formatPretty . P.lines $
-                                      TypePrinter.prettySignaturesST ppe [(Referent.Ref ref, name, typ)]
-                              let full tm@(Term.Ann' _ _) _ =
-                                    formatPretty (TermPrinter.prettyBinding ppe name tm)
-                                  full tm typ =
-                                    formatPretty (TermPrinter.prettyBinding ppe name (Term.ann () tm typ))
-                              pure (DO.UserObject (Src folded (full tm typ)))
+                        (: acc) <$> case r of
+                          Reference.Builtin _ ->
+                            typeOf (Referent.Ref r) <&> \case
+                              Nothing -> ExpandedSrcTerm (MissingBuiltinTypeSig r)
+                              Just ty -> ExpandedSrcTerm (BuiltinTypeSig r ty)
+                          ref ->
+                            terms ref >>= \case
+                              Nothing -> pure . ExpandedSrcTerm . MissingTerm $ ref
+                              Just tm -> do
+                                typ <- fromMaybe (Type.builtin () "unknown") <$> typeOf (Referent.Ref ref)
+                                pure $ ExpandedSrcTerm (FoundTerm ref typ tm)
                   Term.RequestOrCtor' (view ConstructorReference.reference_ -> r) | Set.notMember r seen -> (: acc) <$> goType r
                   _ -> pure acc
             DD.TupleTerm' [DD.EitherLeft' (Term.TypeLink' ref), _anns]
               | Set.notMember ref seen ->
-                (Set.insert ref seen,) . (: acc) <$> goType ref
+                  (Set.insert ref seen,) . (: acc) <$> goType ref
             _ -> pure s1
       reverse . snd <$> foldM go mempty es
+
+data RenderError trm
+  = InvalidTerm trm
+  deriving stock (Generic)
+  deriving anyclass (ToJSON)
+
+deriving anyclass instance ToSchema trm => ToSchema (RenderError trm)
+
+data ExpandedSrc v
+  = ExpandedSrcDecl (ExpandedDecl v)
+  | ExpandedSrcTerm (ExpandedTerm v)
+
+data ExpandedDecl v
+  = MissingDecl Reference
+  | BuiltinDecl Reference Builtin
+  | FoundDecl Reference (DD.Decl v ())
+
+data ExpandedTerm v
+  = MissingTerm Reference
+  | BuiltinTypeSig Reference (Type v ())
+  | MissingBuiltinTypeSig Reference
+  | FoundTerm Reference (Type v ()) (Term v ())
+
+dependencies :: Ord v => ExpandedDoc v -> Set LD.LabeledDependency
+dependencies = \case
+  -- Word txt -> pure $ Word txt
+  -- Code d -> Code <$> go d
+  -- CodeBlock lang d -> CodeBlock lang <$> go d
+  -- Bold d -> Bold <$> go d
+  -- Italic d -> Italic <$> go d
+  -- Strikethrough d -> Strikethrough <$> go d
+  -- Style s d -> Style s <$> go d
+  -- Anchor a d -> Anchor a <$> go d
+  -- Blockquote d -> Blockquote <$> go d
+  -- Blankline -> pure Blankline
+  -- Linebreak -> pure Linebreak
+  -- SectionBreak -> pure SectionBreak
+  -- Tooltip d1 d2 -> Tooltip <$> go d1 <*> go d2
+  -- Aside d -> Aside <$> go d
+  -- Callout d1 d2 -> Callout <$> traverse go d1 <*> go d2
+  -- Table rows -> Table <$> traverse (traverse go) rows
+  -- Folded folded d1 d2 -> Folded folded <$> go d1 <*> go d2
+  -- Paragraph ds -> Paragraph <$> traverse go ds
+  -- BulletedList ds -> BulletedList <$> traverse go ds
+  -- NumberedList n ds -> NumberedList n <$> traverse go ds
+  -- Section d ds -> Section <$> go d <*> traverse go ds
+  -- NamedLink d1 d2 -> NamedLink <$> go d1 <*> go d2
+  -- Image d1 d2 d3 -> Image <$> go d1 <*> go d2 <*> traverse go d3
+  -- Special s -> Special <$> goSpecial s
+  -- Join ds -> Join <$> traverse go ds
+  -- UntitledSection ds -> UntitledSection <$> traverse go ds
+  -- Column ds -> Column <$> traverse go ds
+  -- Group d -> Group <$> go d
+  -- RenderError (InvalidTerm trm) -> pure . Word . Text.pack . P.toPlain (P.Width 80) . P.indent "🆘  " . TermPrinter.pretty (PPE.suffixifiedPPE pped) $ trmm
+  Word _txt -> mempty
+  Code d -> dependencies d
+  CodeBlock _lang d -> dependencies d
+  Bold d -> dependencies d
+  Italic d -> dependencies d
+  Strikethrough d -> dependencies d
+  Style _s d -> dependencies d
+  Anchor _a d -> dependencies d
+  Blockquote d -> dependencies d
+  Blankline -> mempty
+  Linebreak -> mempty
+  SectionBreak -> mempty
+  Tooltip d1 d2 -> dependencies d1 <> dependencies d2
+  Aside d -> dependencies d
+  Callout d1 d2 -> foldMap dependencies d1 <> dependencies d2
+  Table rows -> foldMap (foldMap dependencies) rows
+  Folded _folded d1 d2 -> dependencies d1 <> dependencies d2
+  Paragraph ds -> foldMap dependencies ds
+  BulletedList ds -> foldMap dependencies ds
+  NumberedList _n ds -> foldMap dependencies ds
+  Section d ds -> dependencies d <> foldMap dependencies ds
+  NamedLink d1 d2 -> dependencies d1 <> dependencies d2
+  Image d1 d2 d3 -> dependencies d1 <> dependencies d2 <> foldMap dependencies d3
+  Special s -> dependenciesSpecial s
+  Join ds -> foldMap dependencies ds
+  UntitledSection ds -> foldMap dependencies ds
+  Column ds -> foldMap dependencies ds
+  Group d -> dependencies d
+  RenderError {} -> mempty
+
+-- | Determines all dependencies of a special form
+dependenciesSpecial :: forall v. Ord v => ExpandedSpecialForm v -> Set LD.LabeledDependency
+dependenciesSpecial = \case
+  Source srcs -> srcDeps srcs
+  FoldedSource srcs -> srcDeps srcs
+  Example trm -> Term.labeledDependencies trm
+  ExampleBlock trm -> Term.labeledDependencies trm
+  Link ref -> either Term.labeledDependencies Set.singleton ref
+  Signature sigtyps -> sigtypDeps sigtyps
+  SignatureInline sig -> sigtypDeps [sig]
+  Eval trm mayTrm -> Term.labeledDependencies trm <> foldMap Term.labeledDependencies mayTrm
+  EvalInline trm mayTrm -> Term.labeledDependencies trm <> foldMap Term.labeledDependencies mayTrm
+  Embed trm -> Term.labeledDependencies trm
+  EmbedInline trm -> Term.labeledDependencies trm
+  Video {} -> mempty
+  FrontMatter {} -> mempty
+  SpecialRenderError (InvalidTerm trm) -> Term.labeledDependencies trm
+  where
+    sigtypDeps :: [(Referent, Type v a)] -> Set LD.LabeledDependency
+    sigtypDeps sigtyps =
+      sigtyps & foldMap \(ref, typ) ->
+        Set.singleton (LD.TermReferent ref) <> Type.labeledDependencies typ
+    srcDeps :: [ExpandedSrc v] -> Set LD.LabeledDependency
+    srcDeps srcs =
+      srcs & foldMap \case
+        ExpandedSrcDecl srcDecl -> case srcDecl of
+          MissingDecl ref -> Set.singleton (LD.TypeReference ref)
+          BuiltinDecl ref _ -> Set.singleton (LD.TypeReference ref)
+          FoundDecl ref decl -> Set.singleton (LD.TypeReference ref) <> DD.labeledDeclDependencies decl
+        ExpandedSrcTerm srcTerm -> case srcTerm of
+          MissingTerm ref -> Set.singleton (LD.TermReference ref)
+          BuiltinTypeSig ref _ -> Set.singleton (LD.TermReference ref)
+          MissingBuiltinTypeSig ref -> Set.singleton (LD.TermReference ref)
+          FoundTerm ref typ trm -> Set.singleton (LD.TermReference ref) <> Type.labeledDependencies typ <> Term.labeledDependencies trm

--- a/unison-share-api/src/Unison/Server/Doc/AsHtml.hs
+++ b/unison-share-api/src/Unison/Server/Doc/AsHtml.hs
@@ -11,7 +11,6 @@ import qualified Data.Char as Char
 import Data.Foldable
 import Data.Map (Map)
 import qualified Data.Map as Map
-import qualified Unison.Syntax.Name as Name (toText)
 import Data.Maybe
 import Data.Sequence (Seq)
 import Data.Text (Text)
@@ -27,6 +26,7 @@ import Unison.Server.Doc
 import qualified Unison.Server.Doc as Doc
 import Unison.Server.Syntax (SyntaxText)
 import qualified Unison.Server.Syntax as Syntax
+import qualified Unison.Syntax.Name as Name (toText)
 
 data NamedLinkHref
   = Href Text
@@ -447,7 +447,7 @@ toHtml docNamesByRef document =
                           Syntax.toHtml source
                           div_ [class_ "result"] $ do
                             "⧨"
-                            div_ [] $ Syntax.toHtml result
+                            div_ [] $ Syntax.toHtml (fromMaybe "🆘 doc rendering failed during evaluation" result)
                 EvalInline source result ->
                   pure $
                     span_ [class_ "source rich eval-inline"] $
@@ -456,7 +456,7 @@ toHtml docNamesByRef document =
                           Syntax.toHtml source
                           span_ [class_ "result"] $ do
                             "⧨"
-                            Syntax.toHtml result
+                            Syntax.toHtml (fromMaybe "🆘 doc rendering failed during evaluation" result)
                 Video sources attrs ->
                   let source (MediaSource s Nothing) =
                         source_ [src_ s]
@@ -478,6 +478,7 @@ toHtml docNamesByRef document =
                   pure $ div_ [class_ "source rich embed"] $ codeBlock [] (Syntax.toHtml syntax)
                 EmbedInline syntax ->
                   pure $ span_ [class_ "source rich embed-inline"] $ inlineCode [] (Syntax.toHtml syntax)
+                SpecialRenderError (InvalidTerm err) -> pure $ Syntax.toHtml err
             Join docs ->
               span_ [class_ "join"] <$> renderSequence currentSectionLevelToHtml (mergeWords " " docs)
             UntitledSection docs ->
@@ -490,6 +491,7 @@ toHtml docNamesByRef document =
                   (mergeWords " " docs)
             Group content ->
               span_ [class_ "group"] <$> currentSectionLevelToHtml content
+            RenderError (InvalidTerm err) -> pure $ Syntax.toHtml err
 
 -- HELPERS --------------------------------------------------------------------
 

--- a/unison-share-api/src/Unison/Server/Doc/AsHtml.hs
+++ b/unison-share-api/src/Unison/Server/Doc/AsHtml.hs
@@ -447,7 +447,7 @@ toHtml docNamesByRef document =
                           Syntax.toHtml source
                           div_ [class_ "result"] $ do
                             "⧨"
-                            div_ [] $ Syntax.toHtml (fromMaybe "🆘 doc rendering failed during evaluation" result)
+                            div_ [] $ Syntax.toHtml result
                 EvalInline source result ->
                   pure $
                     span_ [class_ "source rich eval-inline"] $
@@ -456,7 +456,7 @@ toHtml docNamesByRef document =
                           Syntax.toHtml source
                           span_ [class_ "result"] $ do
                             "⧨"
-                            Syntax.toHtml (fromMaybe "🆘 doc rendering failed during evaluation" result)
+                            Syntax.toHtml result
                 Video sources attrs ->
                   let source (MediaSource s Nothing) =
                         source_ [src_ s]
@@ -478,7 +478,7 @@ toHtml docNamesByRef document =
                   pure $ div_ [class_ "source rich embed"] $ codeBlock [] (Syntax.toHtml syntax)
                 EmbedInline syntax ->
                   pure $ span_ [class_ "source rich embed-inline"] $ inlineCode [] (Syntax.toHtml syntax)
-                SpecialRenderError (InvalidTerm err) -> pure $ Syntax.toHtml err
+                RenderError (InvalidTerm err) -> pure $ Syntax.toHtml err
             Join docs ->
               span_ [class_ "join"] <$> renderSequence currentSectionLevelToHtml (mergeWords " " docs)
             UntitledSection docs ->
@@ -491,7 +491,6 @@ toHtml docNamesByRef document =
                   (mergeWords " " docs)
             Group content ->
               span_ [class_ "group"] <$> currentSectionLevelToHtml content
-            RenderError (InvalidTerm err) -> pure $ Syntax.toHtml err
 
 -- HELPERS --------------------------------------------------------------------
 

--- a/unison-src/transcripts/api-doc-rendering.md
+++ b/unison-src/transcripts/api-doc-rendering.md
@@ -1,0 +1,96 @@
+# Doc rendering
+
+```ucm:hide
+.> builtins.mergeio
+```
+
+```unison:hide
+structural type Maybe a = Nothing | Just a
+otherTerm = "text"
+
+otherDoc : (Text -> Doc2) -> Doc2
+otherDoc mkMsg = {{
+This doc should be embedded.
+
+{{mkMsg "message"}}
+
+}}
+
+{{
+# Heading
+
+## Heading 2
+
+Term Link: {otherTerm}
+
+Type Link: {type Maybe}
+
+Term source:
+
+@source{term}
+
+Term signature:
+
+@signature{term}
+
+* List item
+
+1. Numbered list item
+
+> Block quote
+
+    Code block
+
+Inline code:
+
+`` 1 + 2 ``
+
+`
+"doesn't typecheck" + 1
+`
+
+[Link](https://unison-lang.org)
+
+![Image](https://share-next.unison-lang.org/static/unison-logo-circle.png)
+
+**Bold**
+
+*Italic*
+
+~~Strikethrough~~
+
+Horizontal rule
+
+---
+
+Table
+
+| Header 1 | Header 2 |
+| -------- | -------- |
+| Cell 1   | Cell 2   |
+| Cell 3   | Cell 4   |
+
+
+Video
+
+{{ Special (Embed (Any (Video [(MediaSource "test.mp4" None)] [("poster", "test.png")]))) }}
+
+Transclusion/evaluation:
+
+{{otherDoc (a -> Word a )}}
+
+}}
+term = 42
+```
+
+```ucm:hide
+.> add
+```
+
+```ucm
+.> display term.doc
+```
+
+```api
+GET /api/getDefinition?names=term
+```

--- a/unison-src/transcripts/api-doc-rendering.output.md
+++ b/unison-src/transcripts/api-doc-rendering.output.md
@@ -1,0 +1,962 @@
+# Doc rendering
+
+```unison
+structural type Maybe a = Nothing | Just a
+otherTerm = "text"
+
+otherDoc : (Text -> Doc2) -> Doc2
+otherDoc mkMsg = {{
+This doc should be embedded.
+
+{{mkMsg "message"}}
+
+}}
+
+{{
+# Heading
+
+## Heading 2
+
+Term Link: {otherTerm}
+
+Type Link: {type Maybe}
+
+Term source:
+
+@source{term}
+
+Term signature:
+
+@signature{term}
+
+* List item
+
+1. Numbered list item
+
+> Block quote
+
+    Code block
+
+Inline code:
+
+`` 1 + 2 ``
+
+`
+"doesn't typecheck" + 1
+`
+
+[Link](https://unison-lang.org)
+
+![Image](https://share-next.unison-lang.org/static/unison-logo-circle.png)
+
+**Bold**
+
+*Italic*
+
+~~Strikethrough~~
+
+Horizontal rule
+
+---
+
+Table
+
+| Header 1 | Header 2 |
+| -------- | -------- |
+| Cell 1   | Cell 2   |
+| Cell 3   | Cell 4   |
+
+
+Video
+
+{{ Special (Embed (Any (Video [(MediaSource "test.mp4" None)] [("poster", "test.png")]))) }}
+
+Transclusion/evaluation:
+
+{{otherDoc (a -> Word a )}}
+
+}}
+term = 42
+```
+
+```ucm
+.> display term.doc
+
+  # Heading
+  
+    # Heading 2
+    
+      Term Link: otherTerm
+    
+      Type Link: Maybe
+    
+      Term source:
+    
+          term : Nat
+          term = 42
+    
+      Term signature:
+    
+          term : Nat
+    
+      * List item
+    
+      1. Numbered list item
+    
+      > Block quote
+    
+      Code block
+    
+      Inline code:
+    
+      `1 Nat.+ 2`
+    
+      ` "doesn't typecheck" + 1 `
+    
+      Link
+    
+      ![Image](https://share-next.unison-lang.org/static/unison-logo-circle.png)
+    
+      Bold
+    
+      Italic
+    
+      ~~Strikethrough~~
+    
+      Horizontal rule
+    
+      ---
+    
+      Table
+    
+      | Header 1 | Header 2 | | -------- | -------- | | Cell 1 |
+      Cell 2 | | Cell 3 | Cell 4 |
+    
+      Video
+    
+          
+           {{ embed {{
+      Video
+          [MediaSource "test.mp4" Nothing]
+          [("poster", "test.png")] }} }}  
+          
+    
+      Transclusion/evaluation:
+    
+      This doc should be embedded.
+      
+      message
+
+```
+```api
+GET /api/getDefinition?names=term
+{
+    "missingDefinitions": [],
+    "termDefinitions": {
+        "#qkhkl0n238s1eqibd1ecb8605sqj1m4hpoaag177cu572otqlaf1u28c8suuuqgljdtthsjtr07rv04np05o6oa27ml9105k7uas0t8": {
+            "bestTermName": "term",
+            "defnTermTag": "Plain",
+            "signature": [
+                {
+                    "annotation": {
+                        "contents": "##Nat",
+                        "tag": "TypeReference"
+                    },
+                    "segment": "Nat"
+                }
+            ],
+            "termDefinition": {
+                "contents": [
+                    {
+                        "annotation": {
+                            "contents": "term",
+                            "tag": "HashQualifier"
+                        },
+                        "segment": "term"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "TypeAscriptionColon"
+                        },
+                        "segment": " :"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "contents": "##Nat",
+                            "tag": "TypeReference"
+                        },
+                        "segment": "Nat"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "\n"
+                    },
+                    {
+                        "annotation": {
+                            "contents": "term",
+                            "tag": "HashQualifier"
+                        },
+                        "segment": "term"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "BindingEquals"
+                        },
+                        "segment": " ="
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "NumericLiteral"
+                        },
+                        "segment": "42"
+                    }
+                ],
+                "tag": "UserObject"
+            },
+            "termDocs": [
+                [
+                    "doc",
+                    "#343l8ugvo7vgp7d1fp4rlnf272k3ea8111m2f97ckuovkutulvmac6jej39kk95s0fdpma0vkhtios6ihh9jo968gb9c5cde0spa9co",
+                    {
+                        "contents": [
+                            {
+                                "contents": [
+                                    {
+                                        "contents": "Heading",
+                                        "tag": "Word"
+                                    }
+                                ],
+                                "tag": "Paragraph"
+                            },
+                            [
+                                {
+                                    "contents": [
+                                        {
+                                            "contents": [
+                                                {
+                                                    "contents": "Heading",
+                                                    "tag": "Word"
+                                                },
+                                                {
+                                                    "contents": "2",
+                                                    "tag": "Word"
+                                                }
+                                            ],
+                                            "tag": "Paragraph"
+                                        },
+                                        [
+                                            {
+                                                "contents": [
+                                                    {
+                                                        "contents": "Term",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "Link:",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": {
+                                                            "contents": [
+                                                                {
+                                                                    "annotation": {
+                                                                        "contents": "#k5gpql9cbdfau6lf1aja24joc3sfctvjor8esu8bemn0in3l148otb0t3vebgqrt6qml302h62bbfeftg65gec1v8ouin5m6v2969d8",
+                                                                        "tag": "TermReference"
+                                                                    },
+                                                                    "segment": "otherTerm"
+                                                                }
+                                                            ],
+                                                            "tag": "Link"
+                                                        },
+                                                        "tag": "Special"
+                                                    }
+                                                ],
+                                                "tag": "Paragraph"
+                                            },
+                                            {
+                                                "contents": [
+                                                    {
+                                                        "contents": "Type",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "Link:",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": {
+                                                            "contents": [
+                                                                {
+                                                                    "annotation": {
+                                                                        "contents": "#nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg",
+                                                                        "tag": "TypeReference"
+                                                                    },
+                                                                    "segment": "Maybe"
+                                                                }
+                                                            ],
+                                                            "tag": "Link"
+                                                        },
+                                                        "tag": "Special"
+                                                    }
+                                                ],
+                                                "tag": "Paragraph"
+                                            },
+                                            {
+                                                "contents": [
+                                                    {
+                                                        "contents": "Term",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "source:",
+                                                        "tag": "Word"
+                                                    }
+                                                ],
+                                                "tag": "Paragraph"
+                                            },
+                                            {
+                                                "contents": [
+                                                    {
+                                                        "contents": {
+                                                            "contents": [
+                                                                {
+                                                                    "contents": [
+                                                                        "#qkhkl0n238s1eqibd1ecb8605sqj1m4hpoaag177cu572otqlaf1u28c8suuuqgljdtthsjtr07rv04np05o6oa27ml9105k7uas0t8",
+                                                                        {
+                                                                            "contents": [
+                                                                                [
+                                                                                    {
+                                                                                        "annotation": {
+                                                                                            "contents": "#qkhkl0n238s1eqibd1ecb8605sqj1m4hpoaag177cu572otqlaf1u28c8suuuqgljdtthsjtr07rv04np05o6oa27ml9105k7uas0t8",
+                                                                                            "tag": "TermReference"
+                                                                                        },
+                                                                                        "segment": "term"
+                                                                                    },
+                                                                                    {
+                                                                                        "annotation": null,
+                                                                                        "segment": " "
+                                                                                    },
+                                                                                    {
+                                                                                        "annotation": {
+                                                                                            "tag": "TypeAscriptionColon"
+                                                                                        },
+                                                                                        "segment": ": "
+                                                                                    },
+                                                                                    {
+                                                                                        "annotation": {
+                                                                                            "contents": "##Nat",
+                                                                                            "tag": "TypeReference"
+                                                                                        },
+                                                                                        "segment": "Nat"
+                                                                                    }
+                                                                                ],
+                                                                                [
+                                                                                    {
+                                                                                        "annotation": {
+                                                                                            "contents": "term",
+                                                                                            "tag": "HashQualifier"
+                                                                                        },
+                                                                                        "segment": "term"
+                                                                                    },
+                                                                                    {
+                                                                                        "annotation": {
+                                                                                            "tag": "TypeAscriptionColon"
+                                                                                        },
+                                                                                        "segment": " :"
+                                                                                    },
+                                                                                    {
+                                                                                        "annotation": null,
+                                                                                        "segment": " "
+                                                                                    },
+                                                                                    {
+                                                                                        "annotation": {
+                                                                                            "contents": "##Nat",
+                                                                                            "tag": "TypeReference"
+                                                                                        },
+                                                                                        "segment": "Nat"
+                                                                                    },
+                                                                                    {
+                                                                                        "annotation": null,
+                                                                                        "segment": "\n"
+                                                                                    },
+                                                                                    {
+                                                                                        "annotation": {
+                                                                                            "contents": "term",
+                                                                                            "tag": "HashQualifier"
+                                                                                        },
+                                                                                        "segment": "term"
+                                                                                    },
+                                                                                    {
+                                                                                        "annotation": {
+                                                                                            "tag": "BindingEquals"
+                                                                                        },
+                                                                                        "segment": " ="
+                                                                                    },
+                                                                                    {
+                                                                                        "annotation": null,
+                                                                                        "segment": " "
+                                                                                    },
+                                                                                    {
+                                                                                        "annotation": {
+                                                                                            "tag": "NumericLiteral"
+                                                                                        },
+                                                                                        "segment": "42"
+                                                                                    }
+                                                                                ]
+                                                                            ],
+                                                                            "tag": "UserObject"
+                                                                        }
+                                                                    ],
+                                                                    "tag": "Term"
+                                                                }
+                                                            ],
+                                                            "tag": "Source"
+                                                        },
+                                                        "tag": "Special"
+                                                    }
+                                                ],
+                                                "tag": "Paragraph"
+                                            },
+                                            {
+                                                "contents": [
+                                                    {
+                                                        "contents": "Term",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "signature:",
+                                                        "tag": "Word"
+                                                    }
+                                                ],
+                                                "tag": "Paragraph"
+                                            },
+                                            {
+                                                "contents": [
+                                                    {
+                                                        "contents": {
+                                                            "contents": [
+                                                                [
+                                                                    {
+                                                                        "annotation": {
+                                                                            "contents": "#qkhkl0n238s1eqibd1ecb8605sqj1m4hpoaag177cu572otqlaf1u28c8suuuqgljdtthsjtr07rv04np05o6oa27ml9105k7uas0t8",
+                                                                            "tag": "TermReference"
+                                                                        },
+                                                                        "segment": "term"
+                                                                    },
+                                                                    {
+                                                                        "annotation": null,
+                                                                        "segment": " "
+                                                                    },
+                                                                    {
+                                                                        "annotation": {
+                                                                            "tag": "TypeAscriptionColon"
+                                                                        },
+                                                                        "segment": ": "
+                                                                    },
+                                                                    {
+                                                                        "annotation": {
+                                                                            "contents": "##Nat",
+                                                                            "tag": "TypeReference"
+                                                                        },
+                                                                        "segment": "Nat"
+                                                                    }
+                                                                ]
+                                                            ],
+                                                            "tag": "Signature"
+                                                        },
+                                                        "tag": "Special"
+                                                    }
+                                                ],
+                                                "tag": "Paragraph"
+                                            },
+                                            {
+                                                "contents": [
+                                                    {
+                                                        "contents": [
+                                                            {
+                                                                "contents": "List",
+                                                                "tag": "Word"
+                                                            },
+                                                            {
+                                                                "contents": "item",
+                                                                "tag": "Word"
+                                                            }
+                                                        ],
+                                                        "tag": "Paragraph"
+                                                    }
+                                                ],
+                                                "tag": "BulletedList"
+                                            },
+                                            {
+                                                "contents": [
+                                                    1,
+                                                    [
+                                                        {
+                                                            "contents": [
+                                                                {
+                                                                    "contents": "Numbered",
+                                                                    "tag": "Word"
+                                                                },
+                                                                {
+                                                                    "contents": "list",
+                                                                    "tag": "Word"
+                                                                },
+                                                                {
+                                                                    "contents": "item",
+                                                                    "tag": "Word"
+                                                                }
+                                                            ],
+                                                            "tag": "Paragraph"
+                                                        }
+                                                    ]
+                                                ],
+                                                "tag": "NumberedList"
+                                            },
+                                            {
+                                                "contents": [
+                                                    {
+                                                        "contents": ">",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "Block",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "quote",
+                                                        "tag": "Word"
+                                                    }
+                                                ],
+                                                "tag": "Paragraph"
+                                            },
+                                            {
+                                                "contents": [
+                                                    {
+                                                        "contents": "Code",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "block",
+                                                        "tag": "Word"
+                                                    }
+                                                ],
+                                                "tag": "Paragraph"
+                                            },
+                                            {
+                                                "contents": [
+                                                    {
+                                                        "contents": "Inline",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "code:",
+                                                        "tag": "Word"
+                                                    }
+                                                ],
+                                                "tag": "Paragraph"
+                                            },
+                                            {
+                                                "contents": [
+                                                    {
+                                                        "contents": {
+                                                            "contents": [
+                                                                {
+                                                                    "annotation": {
+                                                                        "tag": "NumericLiteral"
+                                                                    },
+                                                                    "segment": "1"
+                                                                },
+                                                                {
+                                                                    "annotation": null,
+                                                                    "segment": " "
+                                                                },
+                                                                {
+                                                                    "annotation": {
+                                                                        "contents": "##Nat.+",
+                                                                        "tag": "TermReference"
+                                                                    },
+                                                                    "segment": "Nat.+"
+                                                                },
+                                                                {
+                                                                    "annotation": null,
+                                                                    "segment": " "
+                                                                },
+                                                                {
+                                                                    "annotation": {
+                                                                        "tag": "NumericLiteral"
+                                                                    },
+                                                                    "segment": "2"
+                                                                }
+                                                            ],
+                                                            "tag": "Example"
+                                                        },
+                                                        "tag": "Special"
+                                                    }
+                                                ],
+                                                "tag": "Paragraph"
+                                            },
+                                            {
+                                                "contents": [
+                                                    {
+                                                        "contents": "`",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "\"doesn't",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "typecheck\"",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "+",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "1",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "`",
+                                                        "tag": "Word"
+                                                    }
+                                                ],
+                                                "tag": "Paragraph"
+                                            },
+                                            {
+                                                "contents": [
+                                                    {
+                                                        "contents": [
+                                                            {
+                                                                "contents": [
+                                                                    {
+                                                                        "contents": "Link",
+                                                                        "tag": "Word"
+                                                                    }
+                                                                ],
+                                                                "tag": "Paragraph"
+                                                            },
+                                                            {
+                                                                "contents": {
+                                                                    "contents": "https://unison-lang.org",
+                                                                    "tag": "Word"
+                                                                },
+                                                                "tag": "Group"
+                                                            }
+                                                        ],
+                                                        "tag": "NamedLink"
+                                                    }
+                                                ],
+                                                "tag": "Paragraph"
+                                            },
+                                            {
+                                                "contents": [
+                                                    {
+                                                        "contents": "![Image](https://share-next.unison-lang.org/static/unison-logo-circle.png)",
+                                                        "tag": "Word"
+                                                    }
+                                                ],
+                                                "tag": "Paragraph"
+                                            },
+                                            {
+                                                "contents": [
+                                                    {
+                                                        "contents": {
+                                                            "contents": [
+                                                                {
+                                                                    "contents": "Bold",
+                                                                    "tag": "Word"
+                                                                }
+                                                            ],
+                                                            "tag": "Paragraph"
+                                                        },
+                                                        "tag": "Bold"
+                                                    }
+                                                ],
+                                                "tag": "Paragraph"
+                                            },
+                                            {
+                                                "contents": [
+                                                    {
+                                                        "contents": {
+                                                            "contents": [
+                                                                {
+                                                                    "contents": "Italic",
+                                                                    "tag": "Word"
+                                                                }
+                                                            ],
+                                                            "tag": "Paragraph"
+                                                        },
+                                                        "tag": "Bold"
+                                                    }
+                                                ],
+                                                "tag": "Paragraph"
+                                            },
+                                            {
+                                                "contents": [
+                                                    {
+                                                        "contents": {
+                                                            "contents": [
+                                                                {
+                                                                    "contents": "Strikethrough",
+                                                                    "tag": "Word"
+                                                                }
+                                                            ],
+                                                            "tag": "Paragraph"
+                                                        },
+                                                        "tag": "Strikethrough"
+                                                    }
+                                                ],
+                                                "tag": "Paragraph"
+                                            },
+                                            {
+                                                "contents": [
+                                                    {
+                                                        "contents": "Horizontal",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "rule",
+                                                        "tag": "Word"
+                                                    }
+                                                ],
+                                                "tag": "Paragraph"
+                                            },
+                                            {
+                                                "contents": [
+                                                    {
+                                                        "contents": "---",
+                                                        "tag": "Word"
+                                                    }
+                                                ],
+                                                "tag": "Paragraph"
+                                            },
+                                            {
+                                                "contents": [
+                                                    {
+                                                        "contents": "Table",
+                                                        "tag": "Word"
+                                                    }
+                                                ],
+                                                "tag": "Paragraph"
+                                            },
+                                            {
+                                                "contents": [
+                                                    {
+                                                        "contents": "|",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "Header",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "1",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "|",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "Header",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "2",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "|",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "|",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "--------",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "|",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "--------",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "|",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "|",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "Cell",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "1",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "|",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "Cell",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "2",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "|",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "|",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "Cell",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "3",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "|",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "Cell",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "4",
+                                                        "tag": "Word"
+                                                    },
+                                                    {
+                                                        "contents": "|",
+                                                        "tag": "Word"
+                                                    }
+                                                ],
+                                                "tag": "Paragraph"
+                                            },
+                                            {
+                                                "contents": [
+                                                    {
+                                                        "contents": "Video",
+                                                        "tag": "Word"
+                                                    }
+                                                ],
+                                                "tag": "Paragraph"
+                                            },
+                                            {
+                                                "contents": [
+                                                    {
+                                                        "contents": {
+                                                            "contents": [
+                                                                [
+                                                                    {
+                                                                        "mediaSourceMimeType": null,
+                                                                        "mediaSourceUrl": "test.mp4"
+                                                                    }
+                                                                ],
+                                                                {
+                                                                    "poster": "test.png"
+                                                                }
+                                                            ],
+                                                            "tag": "Video"
+                                                        },
+                                                        "tag": "Special"
+                                                    }
+                                                ],
+                                                "tag": "Paragraph"
+                                            },
+                                            {
+                                                "contents": [
+                                                    {
+                                                        "contents": "Transclusion/evaluation:",
+                                                        "tag": "Word"
+                                                    }
+                                                ],
+                                                "tag": "Paragraph"
+                                            },
+                                            {
+                                                "contents": [
+                                                    {
+                                                        "contents": [
+                                                            {
+                                                                "contents": [
+                                                                    {
+                                                                        "contents": "This",
+                                                                        "tag": "Word"
+                                                                    },
+                                                                    {
+                                                                        "contents": "doc",
+                                                                        "tag": "Word"
+                                                                    },
+                                                                    {
+                                                                        "contents": "should",
+                                                                        "tag": "Word"
+                                                                    },
+                                                                    {
+                                                                        "contents": "be",
+                                                                        "tag": "Word"
+                                                                    },
+                                                                    {
+                                                                        "contents": "embedded.",
+                                                                        "tag": "Word"
+                                                                    }
+                                                                ],
+                                                                "tag": "Paragraph"
+                                                            },
+                                                            {
+                                                                "contents": [
+                                                                    {
+                                                                        "contents": "message",
+                                                                        "tag": "Word"
+                                                                    }
+                                                                ],
+                                                                "tag": "Paragraph"
+                                                            }
+                                                        ],
+                                                        "tag": "UntitledSection"
+                                                    }
+                                                ],
+                                                "tag": "Paragraph"
+                                            }
+                                        ]
+                                    ],
+                                    "tag": "Section"
+                                }
+                            ]
+                        ],
+                        "tag": "Section"
+                    }
+                ]
+            ],
+            "termNames": [
+                "term"
+            ]
+        }
+    },
+    "typeDefinitions": {}
+}
+```


### PR DESCRIPTION
## Overview

As part of optimizing our pretty printing we want to load only names for references we know we'll need to render out.
In order to do that, we need to know ALL of the references a pretty print env might need before we construct it and use it for rendering.

Currently, we can't do this because a Doc term is unevaluated, evaluating it may bring into scope new terms/definitions.
The evaluation and rendering are currently interleaved, so we have to have the full ppe in scope before even evaluating it.

This is a refactor to split up doc evaluation from doc rendering so we can fully evaluate a doc to determine all of its dependencies, then collect those dependencies and use them to build a pretty printer before rendering the doc with that PPE.

## Implementation notes

* Adds a type param for specialForms in the Doc type, then specializes it to form a Rendered doc and Evaluated doc.
* Splits `renderDoc` into `evalDoc`, `renderDoc` and `evalAndRenderDoc`.

## Interesting/controversial decisions

Rather than split off into completely different doc types, I just parameterized the top-level doc type by the 'special form' which is where all of the actual rendering of references occurs.

## Test coverage

I added a doc-rendering transcript test test in #3695 to ensure this change doesn't change anything.

## Loose ends

This is just a small piece of the pretty-printing optimizations that I realized I needed when tweaking dependency rendering, stay tuned.
