### PR TITLE
Type signatures for completion options

### DIFF
--- a/unison-cli/src/Unison/LSP.hs
+++ b/unison-cli/src/Unison/LSP.hs
@@ -26,7 +26,7 @@ import Unison.Codebase.Runtime (Runtime)
 import qualified Unison.Debug as Debug
 import Unison.LSP.CancelRequest (cancelRequestHandler)
 import Unison.LSP.CodeAction (codeActionHandler)
-import Unison.LSP.Completion (completionHandler)
+import Unison.LSP.Completion (completionHandler, completionItemResolveHandler)
 import qualified Unison.LSP.Configuration as Config
 import qualified Unison.LSP.FileAnalysis as Analysis
 import Unison.LSP.FoldingRange (foldingRangeRequest)
@@ -137,6 +137,7 @@ lspRequestHandlers =
     & SMM.insert STextDocumentCodeAction (mkHandler codeActionHandler)
     & SMM.insert STextDocumentFoldingRange (mkHandler foldingRangeRequest)
     & SMM.insert STextDocumentCompletion (mkHandler completionHandler)
+    & SMM.insert SCompletionItemResolve (mkHandler completionItemResolveHandler)
   where
     defaultTimeout = 10_000 -- 10s
     mkHandler ::

--- a/unison-cli/src/Unison/LSP/Completion.hs
+++ b/unison-cli/src/Unison/LSP/Completion.hs
@@ -304,7 +304,10 @@ completionItemResolveHandler message respond = do
             pure $ completion {_detail = Just renderedType, _documentation = Just doc}
           LD.TypeReference ref ->
             case ref of
-              Reference.Builtin {} -> empty
+              Reference.Builtin {} -> do
+                let renderedBuiltin = "<builtin>"
+                let doc = CompletionDocMarkup (toUnisonMarkup renderedBuiltin)
+                pure $ completion {_detail = Just renderedBuiltin, _documentation = Just doc}
               Reference.DerivedId refId -> do
                 decl <- LSPQ.getTypeDeclaration fileUri refId
                 let renderedDecl = Text.pack . Pretty.toPlain typeWidth . Pretty.syntaxToColor $ DeclPrinter.prettyDecl pped ref (HQ.NameOnly name) decl

--- a/unison-cli/src/Unison/LSP/FileAnalysis.hs
+++ b/unison-cli/src/Unison/LSP/FileAnalysis.hs
@@ -10,6 +10,7 @@ import Data.Foldable
 import Data.IntervalMap.Lazy (IntervalMap)
 import qualified Data.IntervalMap.Lazy as IM
 import qualified Data.Map as Map
+import qualified Data.Set as Set
 import qualified Data.Text as Text
 import Debug.RecoverRTTI (anythingToString)
 import Language.LSP.Types
@@ -34,6 +35,7 @@ import Unison.LSP.Diagnostics
   )
 import Unison.LSP.Orphans ()
 import Unison.LSP.Types
+import qualified Unison.LSP.Types as LSP
 import qualified Unison.LSP.VFS as VFS
 import qualified Unison.NamesWithHistory as NamesWithHistory
 import Unison.Parser.Ann (Ann)
@@ -47,10 +49,13 @@ import qualified Unison.PrintError as PrintError
 import Unison.Result (Note)
 import qualified Unison.Result as Result
 import Unison.Symbol (Symbol)
+import qualified Unison.Symbol as Symbol
 import qualified Unison.Syntax.HashQualified' as HQ' (toText)
 import qualified Unison.Syntax.Lexer as L
 import qualified Unison.Syntax.Parser as Parser
 import qualified Unison.Syntax.TypePrinter as TypePrinter
+import qualified Unison.Term as Term
+import Unison.Type (Type)
 import qualified Unison.Typechecker.Context as Context
 import qualified Unison.Typechecker.TypeError as TypeError
 import qualified Unison.UnisonFile as UF
@@ -58,16 +63,17 @@ import qualified Unison.UnisonFile.Names as UF
 import Unison.Util.Monoid (foldMapM)
 import qualified Unison.Util.Pretty as Pretty
 import qualified Unison.Var as Var
+import Unison.WatchKind (pattern TestWatch)
 import UnliftIO (atomically, modifyTVar', readTVar, readTVarIO, writeTVar)
 
 -- | Lex, parse, and typecheck a file.
 checkFile :: HasUri d Uri => d -> Lsp (Maybe FileAnalysis)
 checkFile doc = runMaybeT $ do
   let fileUri = doc ^. uri
-  (fileVersion, contents) <- MaybeT (VFS.getFileContents doc)
+  (fileVersion, contents) <- VFS.getFileContents fileUri
   parseNames <- lift getParseNames
   let sourceName = getUri $ doc ^. uri
-  let lexedSource@(srcText, _) = (contents, L.lexer (Text.unpack sourceName) (Text.unpack contents))
+  let lexedSource@(srcText, _tokens) = (contents, L.lexer (Text.unpack sourceName) (Text.unpack contents))
   let ambientAbilities = []
   cb <- asks codebase
   let generateUniqueName = Parser.uniqueBase32Namegen <$> Random.getSystemDRG
@@ -77,8 +83,7 @@ checkFile doc = runMaybeT $ do
         Nothing -> (Nothing, Nothing)
         Just (Left uf) -> (Just uf, Nothing)
         Just (Right tf) -> (Just $ UF.discardTypes tf, Just tf)
-  pped <- lift $ ppedForFileHelper parsedFile typecheckedFile
-  (diagnostics, codeActions) <- lift $ analyseFile pped fileUri srcText notes
+  (diagnostics, codeActions) <- lift $ analyseFile fileUri srcText notes
   let diagnosticRanges =
         diagnostics
           & fmap (\d -> (d ^. range, d))
@@ -87,8 +92,101 @@ checkFile doc = runMaybeT $ do
         codeActions
           & foldMap (\(RangedCodeAction {_codeActionRanges, _codeAction}) -> (,_codeAction) <$> _codeActionRanges)
           & toRangeMap
-  let fileAnalysis = FileAnalysis {diagnostics = diagnosticRanges, codeActions = codeActionRanges, ..}
+  let fileSummary = mkFileSummary parsedFile typecheckedFile
+  let fileAnalysis = FileAnalysis {diagnostics = diagnosticRanges, codeActions = codeActionRanges, fileSummary, ..}
   pure $ fileAnalysis
+
+-- | If a symbol is a 'User' symbol, return (Just sym), otherwise return Nothing.
+assertUserSym :: Symbol -> Maybe Symbol
+assertUserSym sym = case sym of
+  Symbol.Symbol _ (Var.User {}) -> Just sym
+  _ -> Nothing
+
+-- | Summarize the information available to us from the current state of the file.
+-- See 'FileSummary' for more information.
+mkFileSummary :: Maybe (UF.UnisonFile Symbol Ann) -> Maybe (UF.TypecheckedUnisonFile Symbol Ann) -> Maybe FileSummary
+mkFileSummary parsed typechecked = case (parsed, typechecked) of
+  (Nothing, Nothing) -> Nothing
+  (_, Just tf@(UF.TypecheckedUnisonFileId {dataDeclarationsId', effectDeclarationsId', hashTermsId})) ->
+    let (trms, testWatches, exprWatches) =
+          hashTermsId & ifoldMap \sym (ref, wk, trm, typ) ->
+            case wk of
+              Nothing -> (Map.singleton sym (Just ref, trm, getUserTypeAnnotation sym <|> Just typ), mempty, mempty)
+              Just TestWatch -> (mempty, [(assertUserSym sym, Just ref, trm, getUserTypeAnnotation sym <|> Just typ)], mempty)
+              Just _ -> (mempty, mempty, [(assertUserSym sym, Just ref, trm, getUserTypeAnnotation sym <|> Just typ)])
+     in Just $
+          FileSummary
+            { dataDeclsBySymbol = dataDeclarationsId',
+              dataDeclsByReference = declsRefMap dataDeclarationsId',
+              effectDeclsBySymbol = effectDeclarationsId',
+              effectDeclsByReference = declsRefMap effectDeclarationsId',
+              termsBySymbol = trms,
+              termsByReference = termsRefMap trms,
+              testWatchSummary = testWatches,
+              exprWatchSummary = exprWatches,
+              fileNames = UF.typecheckedToNames tf
+            }
+  (Just uf@(UF.UnisonFileId {dataDeclarationsId, effectDeclarationsId, terms, watches}), _) ->
+    let trms =
+          terms & foldMap \(sym, trm) ->
+            (Map.singleton sym (Nothing, trm, Nothing))
+        (testWatches, exprWatches) =
+          watches & ifoldMap \wk tms ->
+            tms & foldMap \(v, trm) ->
+              case wk of
+                TestWatch -> ([(assertUserSym v, Nothing, trm, Nothing)], mempty)
+                _ -> (mempty, [(assertUserSym v, Nothing, trm, Nothing)])
+     in Just $
+          FileSummary
+            { dataDeclsBySymbol = dataDeclarationsId,
+              dataDeclsByReference = declsRefMap dataDeclarationsId,
+              effectDeclsBySymbol = effectDeclarationsId,
+              effectDeclsByReference = declsRefMap effectDeclarationsId,
+              termsBySymbol = trms,
+              termsByReference = termsRefMap trms,
+              testWatchSummary = testWatches,
+              exprWatchSummary = exprWatches,
+              fileNames = UF.toNames uf
+            }
+  where
+    declsRefMap :: (Ord v, Ord r) => Map v (r, a) -> Map r (Map v a)
+    declsRefMap m =
+      m & Map.toList
+        & fmap (\(v, (r, a)) -> (r, Map.singleton v a))
+        & Map.fromListWith (<>)
+    termsRefMap :: (Ord v, Ord r) => Map v (r, a, b) -> Map r (Map v (a, b))
+    termsRefMap m =
+      m & Map.toList
+        & fmap (\(v, (r, a, b)) -> (r, Map.singleton v (a, b)))
+        & Map.fromListWith (<>)
+    -- Gets the user provided type annotation for a term if there is one.
+    -- This type sig will have Ann's within the file if it exists.
+    getUserTypeAnnotation :: Symbol -> Maybe (Type Symbol Ann)
+    getUserTypeAnnotation v = do
+      UF.UnisonFileId {terms, watches} <- parsed
+      trm <- Prelude.lookup v (terms <> fold watches)
+      typ <- Term.getTypeAnnotation trm
+      pure typ
+
+-- | Get the location of user defined definitions within the file
+getFileDefLocations :: Uri -> MaybeT Lsp (Map Symbol (Set Ann))
+getFileDefLocations uri = do
+  fileDefLocations <$> getFileSummary uri
+
+-- | Compute the location of user defined definitions within the file
+fileDefLocations :: FileSummary -> Map Symbol (Set Ann)
+fileDefLocations FileSummary {dataDeclsBySymbol, effectDeclsBySymbol, testWatchSummary, exprWatchSummary, termsBySymbol} =
+  Map.unionsWith
+    (<>)
+    [ fmap (Set.singleton . DD.annotation) . fmap snd $ dataDeclsBySymbol,
+      fmap (Set.singleton . DD.annotation . DD.toDataDecl) . fmap snd $ effectDeclsBySymbol,
+      (testWatchSummary <> exprWatchSummary)
+        & foldMap \(maySym, _id, trm, _typ) ->
+          case maySym of
+            Nothing -> mempty
+            Just sym -> Map.singleton sym (Set.singleton $ ABT.annotation trm),
+      fmap (Set.singleton . ABT.annotation) . fmap (view _2) $ termsBySymbol
+    ]
 
 fileAnalysisWorker :: Lsp ()
 fileAnalysisWorker = forever do
@@ -111,9 +209,10 @@ fileAnalysisWorker = forever do
   for freshlyCheckedFiles \(FileAnalysis {fileUri, fileVersion, diagnostics}) -> do
     reportDiagnostics fileUri (Just fileVersion) $ fold diagnostics
 
-analyseFile :: Foldable f => PPED.PrettyPrintEnvDecl -> Uri -> Text -> f (Note Symbol Ann) -> Lsp ([Diagnostic], [RangedCodeAction])
-analyseFile ppe fileUri srcText notes = do
-  analyseNotes fileUri (PPED.suffixifiedPPE ppe) (Text.unpack srcText) notes
+analyseFile :: Foldable f => Uri -> Text -> f (Note Symbol Ann) -> Lsp ([Diagnostic], [RangedCodeAction])
+analyseFile fileUri srcText notes = do
+  pped <- PPED.suffixifiedPPE <$> LSP.globalPPED
+  analyseNotes fileUri pped (Text.unpack srcText) notes
 
 analyseNotes :: Foldable f => Uri -> PrettyPrintEnv -> String -> f (Note Symbol Ann) -> Lsp ([Diagnostic], [RangedCodeAction])
 analyseNotes fileUri ppe src notes = do
@@ -270,6 +369,11 @@ getFileAnalysis uri = do
   checkedFilesV <- asks checkedFilesVar
   checkedFiles <- readTVarIO checkedFilesV
   pure $ Map.lookup uri checkedFiles
+
+getFileSummary :: Uri -> MaybeT Lsp FileSummary
+getFileSummary uri = do
+  FileAnalysis {fileSummary} <- MaybeT $ getFileAnalysis uri
+  MaybeT . pure $ fileSummary
 
 -- TODO memoize per file
 ppedForFile :: Uri -> Lsp PPED.PrettyPrintEnvDecl

--- a/unison-cli/src/Unison/LSP/Hover.hs
+++ b/unison-cli/src/Unison/LSP/Hover.hs
@@ -24,7 +24,7 @@ hoverHandler :: RequestMessage 'TextDocumentHover -> (Either ResponseError (Resp
 hoverHandler m respond =
   respond . Right =<< runMaybeT do
     let p = (m ^. params)
-    txtIdentifier <- MaybeT $ identifierAtPosition p
+    txtIdentifier <- identifierAtPosition p
     hqIdentifier <- MaybeT . pure $ HQ.fromText txtIdentifier
     cb <- asks codebase
     rt <- asks runtime

--- a/unison-cli/src/Unison/LSP/Types.hs
+++ b/unison-cli/src/Unison/LSP/Types.hs
@@ -29,18 +29,23 @@ import Language.LSP.VFS
 import Unison.Codebase
 import qualified Unison.Codebase.Path as Path
 import Unison.Codebase.Runtime (Runtime)
+import qualified Unison.DataDeclaration as DD
 import Unison.LSP.Orphans ()
 import Unison.LabeledDependency (LabeledDependency)
 import Unison.Name (Name)
 import Unison.NameSegment (NameSegment)
+import Unison.Names (Names)
 import Unison.NamesWithHistory (NamesWithHistory)
 import Unison.Parser.Ann
 import Unison.Prelude
 import Unison.PrettyPrintEnvDecl (PrettyPrintEnvDecl)
+import qualified Unison.Reference as Reference
 import Unison.Result (Note)
 import qualified Unison.Server.Backend as Backend
 import Unison.Symbol
 import qualified Unison.Syntax.Lexer as Lexer
+import Unison.Term (Term)
+import Unison.Type (Type)
 import qualified Unison.UnisonFile as UF
 import UnliftIO
 
@@ -109,14 +114,34 @@ data FileAnalysis = FileAnalysis
     typecheckedFile :: Maybe (UF.TypecheckedUnisonFile Symbol Ann),
     notes :: Seq (Note Symbol Ann),
     diagnostics :: IntervalMap Position [Diagnostic],
-    codeActions :: IntervalMap Position [CodeAction]
+    codeActions :: IntervalMap Position [CodeAction],
+    fileSummary :: Maybe FileSummary
   }
+
+-- | A file that parses might not always type-check, but often we just want to get as much
+-- information as we have available. This provides a type where we can summarize the
+-- information available in a Unison file.
+--
+-- If the file typechecked then all the Ref Ids and types will be filled in, otherwise
+-- they will be Nothing.
+data FileSummary = FileSummary
+  { dataDeclsBySymbol :: Map Symbol (Reference.Id, DD.DataDeclaration Symbol Ann),
+    dataDeclsByReference :: Map Reference.Id (Map Symbol (DD.DataDeclaration Symbol Ann)),
+    effectDeclsBySymbol :: Map Symbol (Reference.Id, DD.EffectDeclaration Symbol Ann),
+    effectDeclsByReference :: Map Reference.Id (Map Symbol (DD.EffectDeclaration Symbol Ann)),
+    termsBySymbol :: Map Symbol (Maybe Reference.Id, Term Symbol Ann, Maybe (Type Symbol Ann)),
+    termsByReference :: Map (Maybe Reference.Id) (Map Symbol (Term Symbol Ann, Maybe (Type Symbol Ann))),
+    testWatchSummary :: [(Maybe Symbol, Maybe Reference.Id, Term Symbol Ann, Maybe (Type Symbol Ann))],
+    exprWatchSummary :: [(Maybe Symbol, Maybe Reference.Id, Term Symbol Ann, Maybe (Type Symbol Ann))],
+    fileNames :: Names
+  }
+  deriving stock (Show)
 
 getCurrentPath :: Lsp Path.Absolute
 getCurrentPath = asks currentPathCache >>= liftIO
 
-getCompletions :: Lsp CompletionTree
-getCompletions = asks completionsVar >>= readTVarIO
+getCodebaseCompletions :: Lsp CompletionTree
+getCodebaseCompletions = asks completionsVar >>= readTVarIO
 
 globalPPED :: Lsp PrettyPrintEnvDecl
 globalPPED = asks ppedCache >>= liftIO

--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -116,6 +116,11 @@ _TermLink = _Ctor @"TermLink"
 _TypeLink :: Prism' (F tv ta pa a) Reference
 _TypeLink = _Ctor @"TypeLink"
 
+-- | Returns the top-level type annotation for a term if it has one.
+getTypeAnnotation :: Term v a -> Maybe (Type v a)
+getTypeAnnotation (ABT.Tm' (Ann _ t)) = Just t
+getTypeAnnotation _ = Nothing
+
 type IsTop = Bool
 
 -- | Like `Term v`, but with an annotation of type `a` at every level in the tree


### PR DESCRIPTION
## Overview

Adds type signatures to completion options.

In vs code you can press ctrl-space to toggle the expanded panel, which for now includes the type and fully qualified name, it's where the docs will go soon too.

![completion-signatures](https://user-images.githubusercontent.com/6439644/207750312-a1b786fb-79b0-4538-bb5f-41dc236895f7.gif)


## Implementation notes

The LSP allows us to resolve the additional details "on-demand" when the user considers a specific option, we take advantage of that to avoid loading and rendering types for potentially hundreds of completion options up-front.

* Implements the `completionResolve` handler which adds the type signature as additional details when the user considers a completion option.
* Adds `FileSummary` to file analysis. This represents all the information we currently know about a file, which saves us a lot of fiddling about in LSP where we don't necessarily know whether the file typechecks or even parses. I also use this in other PRs (that are stalled right now).

## Interesting/controversial decisions

I'm not in love with the formatting ATM, it'll look better once I add docs as well 🤷🏼‍♂️ 

## Loose ends

I plan to add docs, and in-file completions soon too.