### PR TITLE
Silence error message from scratch-file contention

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Watch.hs
+++ b/parser-typechecker/src/Unison/Codebase/Watch.hs
@@ -97,9 +97,11 @@ watchDirectory dir allow = do
         if allow file
           then
             let handle :: IOException -> IO ()
-                handle e = do
-                  liftIO $ putStrLn $ "‼  Got an exception while reading: " <> file
-                  liftIO $ print (e :: IOException)
+                handle _e =
+                  -- Sometimes we notice a change and try to read a file while it's being written.
+                  -- This typically occurs when UCM is writing to the scratch file and can be
+                  -- ignored anyways.
+                  pure ()
                 go :: IO (Maybe (FilePath, Text))
                 go = liftIO $ do
                   contents <- readUtf8 file


### PR DESCRIPTION
Closes https://github.com/unisonweb/unison/issues/3664

Some background:
* The file watcher reads the entire file every time a change is detected to see if the contents have changed since the last save, if it's been a set amount of time since the last event it will emit one even if the file hasn't changed.
* Sometimes editing dozens of definitions will cause the file-watcher to try to read a file  while UCM is writing to it.

E.g.

```
edit ?
‼  Got an exception while reading: /home/username/unison/aoe2022_unison/scratch.u
/home/username/unison/aoe2022_unison/scratch.u: openFile: resource busy (file is locked)
```

The edit still succeeds, and in all reported cases of this error the "edit  event" that occurs would be ignored by unison anyways because of "ignore next edit".

Options for fixing this include:
* Simply silence the error for now, this problem is occurring rarely and isn't breaking  anything for anyone. The worst case is that an extra change in the scratch file _might_ be missed, but in the very rare cases that happens the user can simply save again.
* Rewrite the watcher so that it reports file-changes, but defers actually reading the files to in-between command runs; this would also likely require relaxing/changing the debouncing so that it doesn't make decisions based on file-contents.
* Add a 'scratch file' mutex.


I recommend the first approach for now because it simply doesn't seem worth any more effort at the present time, but if we want a more robust approach I'd go for the second option.