### PR TITLE
Add Clear command

### DIFF
--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -14,6 +14,7 @@ dependencies:
   - ListLike
   - aeson
   - aeson-pretty
+  - ansi-terminal
   - async
   - base
   - bytes

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1101,6 +1101,7 @@ loop e = do
                   Cli.LoadError -> Cli.returnEarly $ SourceLoadFailed path
                   Cli.LoadSuccess contents -> pure contents
               loadUnisonFile (Text.pack path) contents
+            ClearI -> Cli.respond ClearScreen
             AddI requestedNames -> do
               description <- inputDescription input
               let vars = Set.map Name.toVar requestedNames
@@ -1625,6 +1626,7 @@ inputDescription input =
     ListDependentsI {} -> wat
     ListEditsI {} -> wat
     LoadI {} -> wat
+    ClearI {} -> pure "clear"
     NamesI {} -> wat
     NamespaceDependenciesI {} -> wat
     PopBranchI {} -> wat

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -129,6 +129,7 @@ data Input
   | ResolveTypeNameI Path.HQSplit'
   | -- edits stuff:
     LoadI (Maybe FilePath)
+  | ClearI
   | AddI (Set Name)
   | PreviewAddI (Set Name)
   | UpdateI OptionalPatch (Set Name)

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -277,6 +277,7 @@ data Output
   | IntegrityCheck IntegrityResult
   | DisplayDebugNameDiff NameChanges
   | DisplayDebugCompletions [Completion.Completion]
+  | ClearScreen
 
 data ShareError
   = ShareErrorCheckAndSetPush Sync.CheckAndSetPushError
@@ -424,6 +425,7 @@ isFailure o = case o of
   ViewOnShare {} -> False
   DisplayDebugCompletions {} -> False
   DisplayDebugNameDiff {} -> False
+  ClearScreen -> False
 
 isNumberedFailure :: NumberedOutput -> Bool
 isNumberedFailure = \case

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -168,6 +168,24 @@ load =
         _ -> Left (I.help load)
     )
 
+clear :: InputPattern
+clear =
+  InputPattern
+    "clear"
+    []
+    I.Visible
+    []
+    ( P.wrapColumn2
+        [ ( makeExample' clear,
+            "Clears the screen."
+          )
+        ]
+    )
+    ( \case
+        [] -> pure $ Input.ClearI
+        _ -> Left (I.help clear)
+    )
+
 add :: InputPattern
 add =
   InputPattern
@@ -2323,6 +2341,7 @@ validInputs =
     [ help,
       helpTopics,
       load,
+      clear,
       add,
       previewAdd,
       update,

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -30,6 +30,7 @@ import qualified Network.HTTP.Types as Http
 import Network.URI (URI)
 import qualified Network.URI.Encode as URI
 import qualified Servant.Client as Servant
+import qualified System.Console.ANSI as ANSI
 import qualified System.Console.Haskeline.Completion as Completion
 import System.Directory
   ( canonicalizePath,
@@ -1847,6 +1848,10 @@ notifyUser dir o = case o of
                     else ""
              in (isCompleteTxt, P.string (Completion.replacement comp))
         )
+  ClearScreen -> do
+    ANSI.clearScreen
+    ANSI.setCursorPosition 0 0
+    pure mempty
   where
     _nameChange _cmd _pastTenseCmd _oldName _newName _r = error "todo"
     expectedEmptyPushDest writeRemotePath =

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -129,6 +129,7 @@ library
     , ListLike
     , aeson
     , aeson-pretty
+    , ansi-terminal
     , async
     , base
     , bytes
@@ -252,6 +253,7 @@ executable cli-integration-tests
     , ListLike
     , aeson
     , aeson-pretty
+    , ansi-terminal
     , async
     , base
     , bytes
@@ -371,6 +373,7 @@ executable transcripts
     , ListLike
     , aeson
     , aeson-pretty
+    , ansi-terminal
     , async
     , base
     , bytes
@@ -496,6 +499,7 @@ executable unison
     , ListLike
     , aeson
     , aeson-pretty
+    , ansi-terminal
     , async
     , base
     , bytes
@@ -627,6 +631,7 @@ test-suite cli-tests
     , ListLike
     , aeson
     , aeson-pretty
+    , ansi-terminal
     , async
     , base
     , bytes


### PR DESCRIPTION
Closes #3650 

## Overview

Adds the `clear` command uses ANSI codes to clear the terminal and reset the cursor to the top.

* [x] Test on windows terminal (unfortunately I can't test under WSL because it doesn't run under Parallels)

## Implementation notes

* Add a new command
* Use the `ansi-terminal` library to clear the screen and move the cursor. This lib supports windows too 🙌🏼 