### PR TITLE
make io.test look in scratch file first

### DIFF
--- a/unison-cli/src/Unison/Cli/Monad.hs
+++ b/unison-cli/src/Unison/Cli/Monad.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DefaultSignatures #-}
 
 -- | The main CLI monad.
 module Unison.Cli.Monad

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -269,7 +269,7 @@ loop e = do
             go (ann, kind, _hash, _uneval, eval, isHit) = (ann, kind, eval, isHit)
         when (not (null e')) do
           Cli.respond $ Evaluated text ppe bindings e'
-        #latestTypecheckedFile .= (Just unisonFile)
+        #latestTypecheckedFile .= Just unisonFile
 
   case e of
     Left (IncomingRootBranch hashes) -> Cli.time "IncomingRootBranch" do
@@ -1186,41 +1186,7 @@ loop e = do
             ExecuteSchemeI main -> doRunAsScheme main
             GenSchemeLibsI -> doGenerateSchemeBoot True Nothing
             FetchSchemeCompilerI -> doFetchCompiler
-            IOTestI main -> do
-              Cli.Env {codebase, runtime} <- ask
-              -- todo - allow this to run tests from scratch file, using addRunMain
-              let testType = Runtime.ioTestType runtime
-              parseNames <- (`NamesWithHistory.NamesWithHistory` mempty) <$> basicParseNames
-              ppe <- suffixifiedPPE parseNames
-              -- use suffixed names for resolving the argument to display
-              let oks results =
-                    [ (r, msg)
-                      | (r, Term.List' ts) <- results,
-                        Term.App' (Term.Constructor' (ConstructorReference ref cid)) (Term.Text' msg) <- toList ts,
-                        cid == DD.okConstructorId && ref == DD.testResultRef
-                    ]
-                  fails results =
-                    [ (r, msg)
-                      | (r, Term.List' ts) <- results,
-                        Term.App' (Term.Constructor' (ConstructorReference ref cid)) (Term.Text' msg) <- toList ts,
-                        cid == DD.failConstructorId && ref == DD.testResultRef
-                    ]
-
-                  results = NamesWithHistory.lookupHQTerm main parseNames
-              ref <- do
-                let noMain = Cli.returnEarly $ NoMainFunction (HQ.toString main) ppe [testType]
-                case toList results of
-                  [Referent.Ref ref] -> do
-                    Cli.runTransaction (loadTypeOfTerm codebase (Referent.Ref ref)) >>= \case
-                      Just typ | Typechecker.isSubtype typ testType -> pure ref
-                      _ -> noMain
-                  _ -> noMain
-              let a = ABT.annotation tm
-                  tm = DD.forceTerm a a (Term.ref a ref)
-              -- Don't cache IO tests
-              tm' <- evalUnisonTerm False ppe False tm
-              Cli.respond $ TestResults Output.NewlyComputed ppe True True (oks [(ref, tm')]) (fails [(ref, tm')])
-
+            IOTestI main -> handleIOTest main
             -- UpdateBuiltinsI -> do
             --   stepAt updateBuiltins
             --   checkTodo
@@ -1868,6 +1834,83 @@ handleDiffNamespaceToPatch description input = do
   Cli.stepAtM
     description
     (Path.unabsolute patchPath, Branch.modifyPatches patchName (const patch))
+
+handleIOTest :: HQ.HashQualified Name -> Cli ()
+handleIOTest main = do
+  Cli.Env {codebase, runtime} <- ask
+
+  let testType = Runtime.ioTestType runtime
+  parseNames <- (`NamesWithHistory.NamesWithHistory` mempty) <$> basicParseNames
+  -- use suffixed names for resolving the argument to display
+  ppe <- suffixifiedPPE parseNames
+  let oks results =
+        [ (r, msg)
+          | (r, Term.List' ts) <- results,
+            Term.App' (Term.Constructor' (ConstructorReference ref cid)) (Term.Text' msg) <- toList ts,
+            cid == DD.okConstructorId && ref == DD.testResultRef
+        ]
+      fails results =
+        [ (r, msg)
+          | (r, Term.List' ts) <- results,
+            Term.App' (Term.Constructor' (ConstructorReference ref cid)) (Term.Text' msg) <- toList ts,
+            cid == DD.failConstructorId && ref == DD.testResultRef
+        ]
+
+  matches <-
+    Cli.label \returnMatches -> do
+      -- First, look at the terms in the latest typechecked file for a name-match.
+      whenJustM Cli.getLatestTypecheckedFile \typecheckedFile -> do
+        let refToType :: Reference -> Type Symbol Ann
+            refToType ref =
+              typecheckedFile
+                & UF.indexByReference
+                & fst
+                -- These two unsafe functions are actually safe:
+                --   1. We can assert ref is actually a Reference.Id because it came from the latest typechecked file.
+                --   2. The reference has to be in this map because we got it from the file itself.
+                & (Map.! (Reference.unsafeId ref))
+                & snd
+        let matches :: [(TermReference, Type Symbol Ann)]
+            matches =
+              typecheckedFile
+                & UF.typecheckedToNames
+                & (\names -> Names.refTermsHQNamed names main)
+                & Set.toList
+                & map (\r -> (r, refToType r))
+
+        -- If 1+ matches (which we know will be exactly 1, since you can't have two definitions in a scratch file with
+        -- the same name), then return them. Otherwise, fall through to looking up in the codebase.
+        when (not (null matches)) (returnMatches matches)
+
+      -- Then, if we get here (because nothing in the scratch file matched), look at the terms in the codebase.
+      fmap catMaybes do
+        Cli.runTransaction do
+          for (Set.toList (NamesWithHistory.lookupHQTerm main parseNames)) \ref0 ->
+            runMaybeT do
+              ref <- MaybeT (pure (Referent.toTermReference ref0))
+              typ <- MaybeT (loadTypeOfTerm codebase (Referent.Ref ref))
+              pure (ref, typ)
+
+  ref <-
+    case matches of
+      [] -> Cli.returnEarly (NoMainFunction (HQ.toString main) ppe [testType])
+      [(ref, typ)] ->
+        if Typechecker.isSubtype typ testType
+          then pure ref
+          else Cli.returnEarly (BadMainFunction "io.test" (HQ.toString main) typ ppe [testType])
+      _ -> do
+        hashLength <- Cli.runTransaction Codebase.hashLength
+        let labeledDependencies =
+              matches
+                & map (\(ref, _typ) -> LD.termRef ref)
+                & Set.fromList
+        Cli.returnEarly (LabeledReferenceAmbiguous hashLength main labeledDependencies)
+
+  let a = ABT.annotation tm
+      tm = DD.forceTerm a a (Term.ref a ref)
+  -- Don't cache IO tests
+  tm' <- evalUnisonTerm False ppe False tm
+  Cli.respond $ TestResults Output.NewlyComputed ppe True True (oks [(ref, tm')]) (fails [(ref, tm')])
 
 -- | Handle a @push@ command.
 handlePushRemoteBranch :: PushRemoteBranchInput -> Cli ()
@@ -2687,7 +2730,7 @@ typecheckAndEval ppe tm = do
       | Typechecker.fitsScheme ty mty ->
           () <$ evalUnisonTerm False ppe False tm
       | otherwise ->
-          Cli.returnEarly $ BadMainFunction rendered ty ppe [mty]
+          Cli.returnEarly $ BadMainFunction "run" rendered ty ppe [mty]
     Result.Result notes Nothing -> do
       currentPath <- Cli.getCurrentPath
       let tes = [err | Result.TypeError err <- toList notes]
@@ -3122,7 +3165,7 @@ getTerm main =
       mainType <- Runtime.mainType <$> view #runtime
       basicPrettyPrintNames <- getBasicPrettyPrintNames
       ppe <- suffixifiedPPE (NamesWithHistory.NamesWithHistory basicPrettyPrintNames mempty)
-      Cli.returnEarly $ BadMainFunction main ty ppe [mainType]
+      Cli.returnEarly $ BadMainFunction "run" main ty ppe [mainType]
     GetTermSuccess x -> pure x
 
 getTerm' :: String -> Cli GetTermResult

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/TermResolution.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/TermResolution.hs
@@ -120,5 +120,5 @@ resolveMainRef main = do
   lookupTermRefWithType codebase main >>= \case
     [(rf, ty)]
       | Typechecker.fitsScheme ty mainType -> pure (rf, ppe)
-      | otherwise -> Cli.returnEarly (BadMainFunction smain ty ppe [mainType])
+      | otherwise -> Cli.returnEarly (BadMainFunction "main" smain ty ppe [mainType])
     _ -> Cli.returnEarly (NoMainFunction smain ppe [mainType])

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -121,8 +121,18 @@ data Output
   | SourceLoadFailed String
   | -- No main function, the [Type v Ann] are the allowed types
     NoMainFunction String PPE.PrettyPrintEnv [Type Symbol Ann]
-  | -- Main function found, but has improper type
-    BadMainFunction String (Type Symbol Ann) PPE.PrettyPrintEnv [Type Symbol Ann]
+  | -- | Function found, but has improper type
+    -- Note: the constructor name is misleading here; we weren't necessarily looking for a "main".
+    BadMainFunction
+      String
+      -- ^ what we were trying to do (e.g. "run", "io.test")
+      String
+      -- ^ name of function
+      (Type Symbol Ann)
+      -- ^ bad type of function
+      PPE.PrettyPrintEnv
+      [Type Symbol Ann]
+      -- ^ acceptable type(s) of function
   | BranchEmpty (Either ShortCausalHash Path')
   | BranchNotEmpty Path'
   | LoadPullRequest ReadRemoteNamespace ReadRemoteNamespace Path' Path' Path' Path'

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2084,20 +2084,20 @@ saveExecuteResult =
 ioTest :: InputPattern
 ioTest =
   InputPattern
-    "io.test"
-    ["test.io"]
-    I.Visible
-    [(Required, exactDefinitionTermQueryArg)]
-    ( P.wrapColumn2
-        [ ( "`io.test mytest`",
-            "Runs `!mytest`, where `mytest` is a delayed test that can use the `IO` and `Exception` abilities. Note: `mytest` must already be added to the codebase."
-          )
-        ]
-    )
-    ( \case
+    { patternName = "io.test",
+      aliases = ["test.io"],
+      visibility = I.Visible,
+      argTypes = [(Required, exactDefinitionTermQueryArg)],
+      help =
+        P.wrapColumn2
+          [ ( "`io.test mytest`",
+              "Runs `!mytest`, where `mytest` is a delayed test that can use the `IO` and `Exception` abilities."
+            )
+          ],
+      parse = \case
         [thing] -> fmap Input.IOTestI $ parseHashQualifiedName thing
         _ -> Left $ showPatternHelp ioTest
-    )
+    }
 
 makeStandalone :: InputPattern
 makeStandalone =

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -799,14 +799,14 @@ notifyUser dir o = case o of
           "",
           P.indentN 2 $ P.lines [P.string main <> " : " <> TypePrinter.pretty ppe t | t <- ts]
         ]
-  BadMainFunction main ty ppe ts ->
+  BadMainFunction what main ty ppe ts ->
     pure . P.callout "😶" $
       P.lines
         [ P.string "I found this function:",
           "",
           P.indentN 2 $ P.string main <> " : " <> TypePrinter.pretty ppe ty,
           "",
-          P.wrap $ P.string "but in order for me to" <> P.backticked (P.string "run") <> "it needs be a subtype of:",
+          P.wrap $ P.string "but in order for me to" <> P.backticked (P.string what) <> "it needs be a subtype of:",
           "",
           P.indentN 2 $ P.lines [P.string main <> " : " <> TypePrinter.pretty ppe t | t <- ts]
         ]

--- a/unison-core/src/Unison/Names.hs
+++ b/unison-core/src/Unison/Names.hs
@@ -29,6 +29,7 @@ module Unison.Names
     prefix0,
     restrictReferences,
     refTermsNamed,
+    refTermsHQNamed,
     termReferences,
     termReferents,
     typeReferences,
@@ -71,6 +72,7 @@ import qualified Unison.ShortHash as SH
 import Unison.Util.Relation (Relation)
 import qualified Unison.Util.Relation as R
 import qualified Unison.Util.Relation as Relation
+import qualified Unison.Util.Set as Set (mapMaybe)
 import Prelude hiding (filter, map)
 import qualified Prelude
 
@@ -249,9 +251,23 @@ numHashChars = 3
 termsNamed :: Names -> Name -> Set Referent
 termsNamed = flip R.lookupDom . terms
 
+-- | Get all terms with a specific name.
 refTermsNamed :: Names -> Name -> Set TermReference
 refTermsNamed names n =
-  Set.fromList [r | Referent.Ref r <- toList $ termsNamed names n]
+  Set.mapMaybe Referent.toTermReference (termsNamed names n)
+
+-- | Get all terms with a specific hash-qualified name.
+refTermsHQNamed :: Names -> HQ.HashQualified Name -> Set TermReference
+refTermsHQNamed names = \case
+  HQ.NameOnly name -> refTermsNamed names name
+  HQ.HashOnly _hash -> Set.empty
+  HQ.HashQualified name hash ->
+    let f :: Referent -> Maybe TermReference
+        f ref0 = do
+          ref <- Referent.toTermReference ref0
+          guard (Reference.isPrefixOf hash ref)
+          Just ref
+     in Set.mapMaybe f (termsNamed names name)
 
 typesNamed :: Names -> Name -> Set TypeReference
 typesNamed = flip R.lookupDom . types


### PR DESCRIPTION
## Overview

Fixes #3654 

This PR makes `io.test <name>` look in the scratch file for `<name>` (as it claimed it did).

Along the way, I also improved the error message for when `io.test <name>` resolves to multiple terms with name `<name>`. Previously, it just output the same "no main" error message you'd get when `<name>` doesn't refer to anything. Now, you'll get a "`<name>` is ambiguous" error.