### PR TITLE
Fix a runtime segfault, plus debugging infrastructure

### DIFF
--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -8,10 +8,15 @@ flags:
   optimized:
     manual: true
     default: true
+  arraychecks:
+    manual: true
+    default: false
 
 when:
   - condition: flag(optimized)
     ghc-options: -funbox-strict-fields -O2
+  - condition: flag(arraychecks)
+    cpp-options: -DARRAY_CHECK
 
 dependencies:
   - ListLike

--- a/parser-typechecker/src/Unison/Runtime/ANF.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF.hs
@@ -58,6 +58,8 @@ module Unison.Runtime.ANF
     ANFM,
     Branched (.., MatchDataCover),
     Func (..),
+    SGEqv(..),
+    equivocate,
     superNormalize,
     anfTerm,
     valueTermLinks,
@@ -66,6 +68,8 @@ module Unison.Runtime.ANF
     groupLinks,
     normalLinks,
     prettyGroup,
+    prettySuperNormal,
+    prettyANF,
   )
 where
 
@@ -600,8 +604,9 @@ data ANormalF v e
   | AApp (Func v) [v]
   | AFrc v
   | AVar v
-  deriving (Show)
+  deriving (Show, Eq)
 
+  
 -- Types representing components that will go into the runtime tag of
 -- a data type value. RTags correspond to references, while CTags
 -- correspond to constructors.
@@ -700,6 +705,109 @@ instance Bifoldable ANormalF where
   bifoldMap _ g (AShift _ e) = g e
   bifoldMap f _ (AFrc v) = f v
   bifoldMap f _ (AApp func args) = foldMap f func <> foldMap f args
+
+instance ABTN.Align ANormalF where
+  align f _ (AVar u) (AVar v) = Just $ AVar <$> f u v
+  align _ _ (ALit l) (ALit r)
+    | l == r = Just $ pure (ALit l)
+  align _ g (ALet dl ccl bl el) (ALet dr ccr br er)
+    | dl == dr, ccl == ccr =
+      Just $ ALet dl ccl <$> g bl br <*> g el er
+  align f g (AName hl asl el) (AName hr asr er)
+    | length asl == length asr
+    , Just hs <- alignEither f hl hr =
+    Just $
+      AName <$> hs
+            <*> traverse (uncurry f) (zip asl asr)
+            <*> g el er
+  align f g (AMatch vl bsl) (AMatch vr bsr)
+    | Just bss <- alignBranch g bsl bsr =
+    Just $ AMatch <$> f vl vr <*> bss
+  align f g (AHnd rl hl bl) (AHnd rr hr br)
+    | rl == rr = Just $ AHnd rl <$> f hl hr <*> g bl br
+  align _ g (AShift rl bl) (AShift rr br)
+    | rl == rr = Just $ AShift rl <$> g bl br
+  align f _ (AFrc u) (AFrc v) = Just $ AFrc <$> f u v
+  align f _ (AApp hl asl) (AApp hr asr)
+    | Just hs <- alignFunc f hl hr
+    , length asl == length asr
+    = Just $ AApp <$> hs <*> traverse (uncurry f) (zip asl asr)
+  align _ _ _ _ = Nothing
+
+alignEither ::
+  Applicative f =>
+  (l -> r -> f s) ->
+  Either Reference l -> Either Reference r -> Maybe (f (Either Reference s))
+alignEither _ (Left rl) (Left rr) | rl == rr = Just . pure $ Left rl
+alignEither f (Right u) (Right v) = Just $ Right <$> f u v
+alignEither _ _ _ = Nothing
+
+alignMaybe ::
+  Applicative f =>
+  (l -> r -> f s) ->
+  Maybe l -> Maybe r -> Maybe (f (Maybe s))
+alignMaybe f (Just l) (Just r) = Just $ Just <$> f l r
+alignMaybe _ Nothing Nothing = Just (pure Nothing)
+alignMaybe _ _ _ = Nothing
+
+alignFunc ::
+  Applicative f =>
+  (vl -> vr -> f vs) ->
+  Func vl -> Func vr -> Maybe (f (Func vs))
+alignFunc f (FVar u) (FVar v) = Just $ FVar <$> f u v
+alignFunc _ (FComb rl) (FComb rr) | rl == rr = Just . pure $ FComb rl
+alignFunc f (FCont u) (FCont v) = Just $ FCont <$> f u v
+alignFunc _ (FCon rl tl) (FCon rr tr)
+  | rl == rr, tl == tr = Just . pure $ FCon rl tl
+alignFunc _ (FReq rl tl) (FReq rr tr)
+  | rl == rr, tl == tr = Just . pure $ FReq rl tl
+alignFunc _ (FPrim ol) (FPrim or)
+  | ol == or = Just . pure $ FPrim ol
+alignFunc _ _ _ = Nothing
+
+alignBranch ::
+  Applicative f =>
+  (el -> er -> f es) ->
+  Branched el -> Branched er -> Maybe (f (Branched es))
+alignBranch _ MatchEmpty MatchEmpty = Just $ pure MatchEmpty
+alignBranch f (MatchIntegral bl dl) (MatchIntegral br dr)
+  | keysSet bl == keysSet br
+  , Just ds <- alignMaybe f dl dr
+  = Just $ MatchIntegral
+             <$> interverse f bl br
+             <*> ds
+alignBranch f (MatchText bl dl) (MatchText br dr)
+  | Map.keysSet bl == Map.keysSet br
+  , Just ds <- alignMaybe f dl dr
+  = Just $ MatchText
+             <$> traverse id (Map.intersectionWith f bl br)
+             <*> ds
+alignBranch f (MatchRequest bl pl) (MatchRequest br pr)
+  | Map.keysSet bl == Map.keysSet br
+  , all p (Map.keysSet bl)
+  = Just $ MatchRequest
+      <$> traverse id (Map.intersectionWith (interverse (alignCCs f)) bl br)
+      <*> f pl pr
+  where
+    p r = keysSet hsl == keysSet hsr && all q (keys hsl)
+      where
+        hsl = bl Map.! r
+        hsr = br Map.! r
+        q t = fst (hsl ! t) == fst (hsr ! t)
+alignBranch f (MatchData rfl bl dl) (MatchData rfr br dr)
+  | rfl == rfr
+  , keysSet bl == keysSet br
+  , all (\t -> fst (bl ! t) == fst (br ! t)) (keys bl)
+  , Just ds <- alignMaybe f dl dr
+  = Just $ MatchData rfl <$> interverse (alignCCs f) bl br <*> ds
+alignBranch f (MatchSum bl) (MatchSum br)
+  | keysSet bl == keysSet br
+  , all (\w -> fst (bl ! w) == fst (br ! w)) (keys bl)
+  = Just $ MatchSum <$> interverse (alignCCs f) bl br
+alignBranch _ _ _ = Nothing
+
+alignCCs :: Functor f => (l -> r -> f s) -> (a, l) -> (a, r) -> f (a, s)
+alignCCs f (ccs, l) (_, r) = (,) ccs <$> f l r
 
 matchLit :: Term v a -> Maybe Lit
 matchLit (Int' i) = Just $ I i
@@ -927,7 +1035,7 @@ data Branched e
   | MatchEmpty
   | MatchData Reference (EnumMap CTag ([Mem], e)) (Maybe e)
   | MatchSum (EnumMap Word64 ([Mem], e))
-  deriving (Show, Functor, Foldable, Traversable)
+  deriving (Show, Eq, Functor, Foldable, Traversable)
 
 -- Data cases expected to cover all constructors
 pattern MatchDataCover :: Reference -> EnumMap CTag ([Mem], e) -> Branched e
@@ -1038,7 +1146,7 @@ data Func v
     FReq !Reference !CTag
   | -- prim op
     FPrim (Either POp FOp)
-  deriving (Show, Functor, Foldable, Traversable)
+  deriving (Show, Eq, Functor, Foldable, Traversable)
 
 data Lit
   = I Int64
@@ -1048,7 +1156,7 @@ data Lit
   | C Char
   | LM Referent
   | LY Reference
-  deriving (Show)
+  deriving (Show, Eq)
 
 litRef :: Lit -> Reference
 litRef (I _) = Ty.intRef
@@ -1227,13 +1335,47 @@ type DNormal v = Directed () (ANormal v)
 
 -- Should be a completely closed term
 data SuperNormal v = Lambda {conventions :: [Mem], bound :: ANormal v}
-  deriving (Show)
+  deriving (Show, Eq)
 
 data SuperGroup v = Rec
   { group :: [(v, SuperNormal v)],
     entry :: SuperNormal v
   }
   deriving (Show)
+
+instance Var v => Eq (SuperGroup v) where
+  g0 == g1 | Left _ <- equivocate g0 g1 = False | otherwise = True
+
+-- Failure modes for SuperGroup alpha equivalence test
+data SGEqv v
+  -- mismatch number of definitions in group
+  = NumDefns (SuperGroup v) (SuperGroup v)
+  -- mismatched SuperNormal calling conventions
+  | DefnConventions (SuperNormal v) (SuperNormal v)
+  -- mismatched subterms in corresponding definition
+  | Subterms (ANormal v) (ANormal v)
+
+-- Checks if two SuperGroups are equivalent up to renaming. The rest
+-- of the structure must match on the nose. If the two groups are not
+-- equivalent, an example of conflicting structure is returned.
+equivocate ::
+  Var v =>
+  SuperGroup v -> SuperGroup v -> Either (SGEqv v) ()
+equivocate g0@(Rec bs0 e0) g1@(Rec bs1 e1)
+  | length bs0 == length bs1 =
+    traverse_ eqvSN (zip ns0 ns1) *> eqvSN (e0, e1)
+  | otherwise = Left $ NumDefns g0 g1
+  where
+  (vs0, ns0) = unzip bs0
+  (vs1, ns1) = unzip bs1
+  vm = Map.fromList (zip vs1 vs0)
+
+  promote (Left (l, r)) = Left $ Subterms l r
+  promote (Right v) = Right v
+
+  eqvSN (Lambda ccs0 e0, Lambda ccs1 e1)
+    | ccs0 == ccs1 = promote $ ABTN.alpha vm e0 e1
+  eqvSN (n0, n1) = Left $ DefnConventions n0 n1
 
 type ANFM v =
   ReaderT

--- a/parser-typechecker/src/Unison/Runtime/Array.hs
+++ b/parser-typechecker/src/Unison/Runtime/Array.hs
@@ -1,0 +1,378 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+
+-- This module wraps the operations in the primitive package so that
+-- bounds checks can be toggled on during the build for debugging
+-- purposes. It exports the entire API for the three array types
+-- needed, and adds wrappers for the operations that are unchecked in
+-- the base library.
+--
+-- Checking is toggled using the `arraychecks` flag.
+module Unison.Runtime.Array
+  ( module EPA,
+    readArray,
+    writeArray,
+    copyArray,
+    copyMutableArray,
+    cloneMutableArray,
+    readByteArray,
+    writeByteArray,
+    indexByteArray,
+    copyByteArray,
+    copyMutableByteArray,
+    moveByteArray,
+    readPrimArray,
+    writePrimArray,
+    indexPrimArray,
+  )
+where
+
+import Control.Monad.Primitive
+import Data.Kind (Constraint)
+import Data.Primitive.Array as EPA hiding
+  ( cloneMutableArray,
+    copyArray,
+    copyMutableArray,
+    readArray,
+    writeArray,
+  )
+import qualified Data.Primitive.Array as PA
+import Data.Primitive.ByteArray as EPA hiding
+  ( copyByteArray,
+    copyMutableByteArray,
+    indexByteArray,
+    moveByteArray,
+    readByteArray,
+    writeByteArray,
+  )
+import qualified Data.Primitive.ByteArray as PA
+import Data.Primitive.PrimArray as EPA hiding
+  ( indexPrimArray,
+    readPrimArray,
+    writePrimArray,
+  )
+import qualified Data.Primitive.PrimArray as PA
+import Data.Primitive.Types
+
+#ifdef ARRAY_CHECK
+import GHC.Stack
+
+type CheckCtx :: Constraint
+type CheckCtx = HasCallStack
+
+type MA = MutableArray
+type MBA = MutableByteArray
+type A = Array
+type BA = ByteArray
+
+-- check index mutable array
+checkIMArray
+  :: CheckCtx
+  => String
+  -> (MA s a -> Int -> r)
+  -> MA s a -> Int -> r
+checkIMArray name f arr i
+  | i < 0 || sizeofMutableArray arr <= i
+  = error $ name ++ " unsafe check out of bounds: " ++ show i
+  | otherwise = f arr i
+{-# inline checkIMArray #-}
+
+-- check copy array
+checkCArray
+  :: CheckCtx
+  => String
+  -> (MA s a -> Int -> A a -> Int -> Int -> r)
+  -> MA s a -> Int -> A a -> Int -> Int -> r
+checkCArray name f dst d src s l
+  | d < 0
+  || s < 0
+  || sizeofMutableArray dst < d + l
+  || sizeofArray src < s + l
+  = error $ name ++ " unsafe check out of bounds: " ++ show (d, s, l)
+  | otherwise = f dst d src s l
+{-# inline checkCArray #-}
+
+-- check copy mutable array
+checkCMArray
+  :: CheckCtx
+  => String
+  -> (MA s a -> Int -> MA s a -> Int -> Int -> r)
+  -> MA s a -> Int -> MA s a -> Int -> Int -> r
+checkCMArray name f dst d src s l
+  | d < 0
+  || s < 0
+  || sizeofMutableArray dst < d + l
+  || sizeofMutableArray src < s + l
+  = error $ name ++ " unsafe check out of bounds: " ++ show (d, s, l)
+  | otherwise = f dst d src s l
+{-# inline checkCMArray #-}
+
+-- check range mutable array
+checkRMArray
+  :: CheckCtx
+  => String
+  -> (MA s a -> Int -> Int -> r)
+  -> MA s a -> Int -> Int -> r
+checkRMArray name f arr o l
+  | o < 0 || sizeofMutableArray arr < o+l
+  = error $ name ++ "unsafe check out of bounds: " ++ show (o, l)
+  | otherwise = f arr o l
+{-# inline checkRMArray #-}
+
+-- check index byte array
+checkIBArray
+  :: CheckCtx
+  => Prim a
+  => String
+  -> a
+  -> (ByteArray -> Int -> r)
+  -> ByteArray -> Int -> r
+checkIBArray name a f arr i
+  | i < 0 || sizeofByteArray arr `quot` sizeOf a <= i
+  = error $ name ++ " unsafe check out of bounds: " ++ show i
+  | otherwise = f arr i
+{-# inline checkIBArray #-}
+
+-- check index mutable byte array
+checkIMBArray
+  :: CheckCtx
+  => Prim a
+  => String
+  -> a
+  -> (MutableByteArray s -> Int -> r)
+  -> MutableByteArray s -> Int -> r
+checkIMBArray name a f arr i
+  | i < 0 || sizeofMutableByteArray arr `quot` sizeOf a <= i
+  = error $ name ++ " unsafe check out of bounds: " ++ show i
+  | otherwise = f arr i
+{-# inline checkIMBArray #-}
+
+-- check copy byte array
+checkCBArray
+  :: CheckCtx
+  => String
+  -> (MBA s -> Int -> BA -> Int -> Int -> r)
+  -> MBA s -> Int -> BA -> Int -> Int -> r
+checkCBArray name f dst d src s l
+  | d < 0
+  || s < 0
+  || sizeofMutableByteArray dst < d + l
+  || sizeofByteArray src < s + l
+  = error $ name ++ " unsafe check out of bounds: " ++ show (d, s, l)
+  | otherwise = f dst d src s l
+{-# inline checkCBArray #-}
+
+-- check copy mutable byte array
+checkCMBArray
+  :: CheckCtx
+  => String
+  -> (MBA s -> Int -> MBA s -> Int -> Int -> r)
+  -> MBA s -> Int -> MBA s -> Int -> Int -> r
+checkCMBArray name f dst d src s l
+  | d < 0
+  || s < 0
+  || sizeofMutableByteArray dst < d + l
+  || sizeofMutableByteArray src < s + l
+  = error $ name ++ " unsafe check out of bounds: " ++ show (d, s, l)
+  | otherwise = f dst d src s l
+{-# inline checkCMBArray #-}
+
+-- check index prim array
+checkIPArray
+  :: CheckCtx
+  => Prim a
+  => String
+  -> (PrimArray a -> Int -> r)
+  -> PrimArray a -> Int -> r
+checkIPArray name f arr i
+  | i < 0 || sizeofPrimArray arr <= i
+  = error $ name ++ " unsafe check out of bounds: " ++ show i
+  | otherwise = f arr i
+{-# inline checkIPArray #-}
+
+-- check index mutable prim array
+checkIMPArray
+  :: CheckCtx
+  => Prim a
+  => String
+  -> (MutablePrimArray s a -> Int -> r)
+  -> MutablePrimArray s a -> Int -> r
+checkIMPArray name f arr i
+  | i < 0 || sizeofMutablePrimArray arr <= i
+  = error $ name ++ " unsafe check out of bounds: " ++ show i
+  | otherwise = f arr i
+{-# inline checkIMPArray #-}
+
+#else
+type CheckCtx :: Constraint
+type CheckCtx = ()
+
+checkIMArray, checkIMPArray, checkIPArray :: String -> r -> r
+checkCArray, checkCMArray, checkRMArray :: String -> r -> r
+checkIMArray _ = id
+checkIMPArray _ = id
+checkCArray _ = id
+checkCMArray _ = id
+checkRMArray _ = id
+checkIPArray _ = id
+
+checkIBArray, checkIMBArray :: String -> a -> r -> r
+checkCBArray, checkCMBArray :: String -> r -> r
+checkIBArray _ _ = id
+checkIMBArray _ _ = id
+checkCBArray _ = id
+checkCMBArray _ = id
+#endif
+
+readArray ::
+  CheckCtx =>
+  PrimMonad m =>
+  MutableArray (PrimState m) a ->
+  Int ->
+  m a
+readArray = checkIMArray "readArray" PA.readArray
+{-# INLINE readArray #-}
+
+writeArray ::
+  CheckCtx =>
+  PrimMonad m =>
+  MutableArray (PrimState m) a ->
+  Int ->
+  a ->
+  m ()
+writeArray = checkIMArray "writeArray" PA.writeArray
+{-# INLINE writeArray #-}
+
+copyArray ::
+  CheckCtx =>
+  PrimMonad m =>
+  MutableArray (PrimState m) a ->
+  Int ->
+  Array a ->
+  Int ->
+  Int ->
+  m ()
+copyArray = checkCArray "copyArray" PA.copyArray
+{-# INLINE copyArray #-}
+
+cloneMutableArray ::
+  CheckCtx =>
+  PrimMonad m =>
+  MutableArray (PrimState m) a ->
+  Int ->
+  Int ->
+  m (MutableArray (PrimState m) a)
+cloneMutableArray = checkRMArray "cloneMutableArray" PA.cloneMutableArray
+{-# INLINE cloneMutableArray #-}
+
+copyMutableArray ::
+  CheckCtx =>
+  PrimMonad m =>
+  MutableArray (PrimState m) a ->
+  Int ->
+  MutableArray (PrimState m) a ->
+  Int ->
+  Int ->
+  m ()
+copyMutableArray = checkCMArray "copyMutableArray" PA.copyMutableArray
+{-# INLINE copyMutableArray #-}
+
+readByteArray ::
+  forall a m.
+  CheckCtx =>
+  PrimMonad m =>
+  Prim a =>
+  MutableByteArray (PrimState m) ->
+  Int ->
+  m a
+readByteArray = checkIMBArray @a "readByteArray" undefined PA.readByteArray
+{-# INLINE readByteArray #-}
+
+writeByteArray ::
+  forall a m.
+  CheckCtx =>
+  PrimMonad m =>
+  Prim a =>
+  MutableByteArray (PrimState m) ->
+  Int ->
+  a ->
+  m ()
+writeByteArray = checkIMBArray @a "writeByteArray" undefined PA.writeByteArray
+{-# INLINE writeByteArray #-}
+
+indexByteArray ::
+  forall a.
+  CheckCtx =>
+  Prim a =>
+  ByteArray ->
+  Int ->
+  a
+indexByteArray = checkIBArray @a "indexByteArray" undefined PA.indexByteArray
+{-# INLINE indexByteArray #-}
+
+copyByteArray ::
+  CheckCtx =>
+  PrimMonad m =>
+  MutableByteArray (PrimState m) ->
+  Int ->
+  ByteArray ->
+  Int ->
+  Int ->
+  m ()
+copyByteArray = checkCBArray "copyByteArray" PA.copyByteArray
+{-# INLINE copyByteArray #-}
+
+copyMutableByteArray ::
+  CheckCtx =>
+  PrimMonad m =>
+  MutableByteArray (PrimState m) ->
+  Int ->
+  MutableByteArray (PrimState m) ->
+  Int ->
+  Int ->
+  m ()
+copyMutableByteArray = checkCMBArray "copyMutableByteArray" PA.copyMutableByteArray
+{-# INLINE copyMutableByteArray #-}
+
+moveByteArray ::
+  CheckCtx =>
+  PrimMonad m =>
+  MutableByteArray (PrimState m) ->
+  Int ->
+  MutableByteArray (PrimState m) ->
+  Int ->
+  Int ->
+  m ()
+moveByteArray = checkCMBArray "moveByteArray" PA.moveByteArray
+{-# INLINE moveByteArray #-}
+
+readPrimArray ::
+  CheckCtx =>
+  PrimMonad m =>
+  Prim a =>
+  MutablePrimArray (PrimState m) a ->
+  Int ->
+  m a
+readPrimArray = checkIMPArray "readPrimArray" PA.readPrimArray
+{-# INLINE readPrimArray #-}
+
+writePrimArray ::
+  CheckCtx =>
+  PrimMonad m =>
+  Prim a =>
+  MutablePrimArray (PrimState m) a ->
+  Int ->
+  a ->
+  m ()
+writePrimArray = checkIMPArray "writePrimArray" PA.writePrimArray
+{-# INLINE writePrimArray #-}
+
+indexPrimArray ::
+  CheckCtx =>
+  Prim a =>
+  PrimArray a ->
+  Int ->
+  a
+indexPrimArray = checkIPArray "indexPrimArray" PA.indexPrimArray
+{-# INLINE indexPrimArray #-}

--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -51,7 +51,7 @@ import Data.IORef as SYS
   )
 import qualified Data.Map as Map
 import Data.PEM (PEM, pemContent, pemParseLBS)
-import qualified Data.Primitive as PA
+import qualified Unison.Runtime.Array as PA
 import Data.Set (insert)
 import qualified Data.Set as Set
 import qualified Data.Text

--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -51,7 +51,6 @@ import Data.IORef as SYS
   )
 import qualified Data.Map as Map
 import Data.PEM (PEM, pemContent, pemParseLBS)
-import qualified Unison.Runtime.Array as PA
 import Data.Set (insert)
 import qualified Data.Set as Set
 import qualified Data.Text
@@ -131,6 +130,7 @@ import Unison.Reference
 import Unison.Referent (pattern Ref)
 import Unison.Runtime.ANF as ANF
 import Unison.Runtime.ANF.Serialize as ANF
+import qualified Unison.Runtime.Array as PA
 import Unison.Runtime.Exception (die)
 import Unison.Runtime.Foreign
   ( Foreign (Wrap),
@@ -1970,7 +1970,7 @@ declareForeign sand name op func0 = do
           | sanitize,
             Tracked <- sand,
             FF r w _ <- func0 =
-            FF r w (bomb name)
+              FF r w (bomb name)
           | otherwise = func0
         code = (name, (sand, uncurry Lambda (op w)))
      in (w + 1, code : codes, mapInsert w (name, func) funcs)

--- a/parser-typechecker/src/Unison/Runtime/Foreign.hs
+++ b/parser-typechecker/src/Unison/Runtime/Foreign.hs
@@ -52,59 +52,59 @@ promote (~~) x y = unsafeCoerce x ~~ unsafeCoerce y
 -- alias seems to prevent the faults.
 txtEq :: Text -> Text -> Bool
 txtEq l r = l == r
-{-# noinline txtEq #-}
+{-# NOINLINE txtEq #-}
 
 txtCmp :: Text -> Text -> Ordering
 txtCmp l r = compare l r
-{-# noinline txtCmp #-}
+{-# NOINLINE txtCmp #-}
 
 bytesEq :: Bytes -> Bytes -> Bool
 bytesEq l r = l == r
-{-# noinline bytesEq #-}
+{-# NOINLINE bytesEq #-}
 
 bytesCmp :: Bytes -> Bytes -> Ordering
 bytesCmp l r = compare l r
-{-# noinline bytesCmp #-}
+{-# NOINLINE bytesCmp #-}
 
 mvarEq :: MVar () -> MVar () -> Bool
 mvarEq l r = l == r
-{-# noinline mvarEq #-}
+{-# NOINLINE mvarEq #-}
 
 refEq :: IORef () -> IORef () -> Bool
 refEq l r = l == r
-{-# noinline refEq #-}
+{-# NOINLINE refEq #-}
 
 tidEq :: ThreadId -> ThreadId -> Bool
 tidEq l r = l == r
-{-# noinline tidEq #-}
+{-# NOINLINE tidEq #-}
 
 tidCmp :: ThreadId -> ThreadId -> Ordering
 tidCmp l r = compare l r
-{-# noinline tidCmp #-}
+{-# NOINLINE tidCmp #-}
 
 marrEq :: MutableArray () () -> MutableArray () () -> Bool
 marrEq l r = l == r
-{-# noinline marrEq #-}
+{-# NOINLINE marrEq #-}
 
 mbarrEq :: MutableByteArray () -> MutableByteArray () -> Bool
 mbarrEq l r = l == r
-{-# noinline mbarrEq #-}
+{-# NOINLINE mbarrEq #-}
 
 barrEq :: ByteArray -> ByteArray -> Bool
 barrEq l r = l == r
-{-# noinline barrEq #-}
+{-# NOINLINE barrEq #-}
 
 barrCmp :: ByteArray -> ByteArray -> Ordering
 barrCmp l r = compare l r
-{-# noinline barrCmp #-}
+{-# NOINLINE barrCmp #-}
 
 cpatEq :: CPattern -> CPattern -> Bool
 cpatEq l r = l == r
-{-# noinline cpatEq #-}
+{-# NOINLINE cpatEq #-}
 
 cpatCmp :: CPattern -> CPattern -> Ordering
 cpatCmp l r = compare l r
-{-# noinline cpatCmp #-}
+{-# NOINLINE cpatCmp #-}
 
 tylEq :: Reference -> Reference -> Bool
 tylEq r l = r == l

--- a/parser-typechecker/src/Unison/Runtime/Machine.hs
+++ b/parser-typechecker/src/Unison/Runtime/Machine.hs
@@ -15,8 +15,6 @@ import Control.Exception
 import Data.Bits
 import qualified Data.Map.Strict as M
 import Data.Ord (comparing)
-import qualified Data.Primitive.Array as PA
-import qualified Data.Primitive.PrimArray as PA
 import qualified Data.Sequence as Sq
 import qualified Data.Set as S
 import qualified Data.Set as Set
@@ -40,6 +38,7 @@ import Unison.Runtime.ANF as ANF
     valueLinks,
   )
 import qualified Unison.Runtime.ANF as ANF
+import Unison.Runtime.Array as PA
 import Unison.Runtime.Builtin
 import Unison.Runtime.Exception
 import Unison.Runtime.Foreign

--- a/parser-typechecker/src/Unison/Runtime/Stack.hs
+++ b/parser-typechecker/src/Unison/Runtime/Stack.hs
@@ -48,15 +48,13 @@ import Control.Monad (when)
 import Control.Monad.Primitive
 import Data.Foldable as F (for_)
 import qualified Data.Kind as Kind
-import Data.Primitive.Array
-import Data.Primitive.ByteArray
-import Data.Primitive.PrimArray
 import Data.Sequence (Seq)
 import Data.Word
 import GHC.Exts as L (IsList (..))
 import GHC.Stack (HasCallStack)
 import Unison.Reference (Reference)
 import Unison.Runtime.ANF as ANF (Mem (..))
+import Unison.Runtime.Array
 import Unison.Runtime.Foreign
 import Unison.Runtime.MCode
 import qualified Unison.Type as Ty

--- a/parser-typechecker/src/Unison/Runtime/Stack.hs
+++ b/parser-typechecker/src/Unison/Runtime/Stack.hs
@@ -109,12 +109,13 @@ data Closure
   deriving (Show, Eq, Ord)
 
 traceK :: Reference -> K -> [(Reference, Int)]
-traceK begin = dedup (begin, 1) where
-  dedup p (Mark _ _ _ _ k) = dedup p k
-  dedup p@(cur,n) (Push _ _ _ _ (CIx r _ _) k)
-    | cur == r = dedup (cur,1+n) k
-    | otherwise = p : dedup (r,1) k
-  dedup p _ = [p]
+traceK begin = dedup (begin, 1)
+  where
+    dedup p (Mark _ _ _ _ k) = dedup p k
+    dedup p@(cur, n) (Push _ _ _ _ (CIx r _ _) k)
+      | cur == r = dedup (cur, 1 + n) k
+      | otherwise = p : dedup (r, 1) k
+    dedup p _ = [p]
 
 splitData :: Closure -> Maybe (Reference, Word64, [Int], [Closure])
 splitData (Enum r t) = Just (r, t, [], [])

--- a/parser-typechecker/src/Unison/Util/EnumContainers.hs
+++ b/parser-typechecker/src/Unison/Util/EnumContainers.hs
@@ -101,7 +101,9 @@ unionWith f (EM l) (EM r) = EM $ IM.unionWith f l r
 
 intersectionWith ::
   (a -> b -> c) ->
-  EnumMap k a -> EnumMap k b -> EnumMap k c
+  EnumMap k a ->
+  EnumMap k b ->
+  EnumMap k c
 intersectionWith f (EM l) (EM r) = EM $ IM.intersectionWith f l r
 
 keys :: EnumKey k => EnumMap k a -> [k]
@@ -148,10 +150,12 @@ traverseSet_ ::
 traverseSet_ f (ES s) =
   IS.foldr (\i r -> f (intToKey i) *> r) (pure ()) s
 
-interverse
-  :: Applicative f
-  => (a -> b -> f c)
-  -> EnumMap k a -> EnumMap k b -> f (EnumMap k c)
+interverse ::
+  Applicative f =>
+  (a -> b -> f c) ->
+  EnumMap k a ->
+  EnumMap k b ->
+  f (EnumMap k c)
 interverse f (EM l) (EM r) =
   fmap EM . traverse id $ IM.intersectionWith f l r
 

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -17,6 +17,10 @@ source-repository head
   type: git
   location: https://github.com/unisonweb/unison
 
+flag arraychecks
+  manual: True
+  default: False
+
 flag optimized
   manual: True
   default: True
@@ -103,6 +107,7 @@ library
       Unison.Result
       Unison.Runtime.ANF
       Unison.Runtime.ANF.Serialize
+      Unison.Runtime.Array
       Unison.Runtime.Builtin
       Unison.Runtime.Debug
       Unison.Runtime.Decompile
@@ -301,6 +306,8 @@ library
     , zlib
   if flag(optimized)
     ghc-options: -funbox-strict-fields -O2
+  if flag(arraychecks)
+    cpp-options: -DARRAY_CHECK
   default-language: Haskell2010
 
 test-suite parser-typechecker-tests
@@ -489,4 +496,6 @@ test-suite parser-typechecker-tests
     , zlib
   if flag(optimized)
     ghc-options: -funbox-strict-fields -O2
+  if flag(arraychecks)
+    cpp-options: -DARRAY_CHECK
   default-language: Haskell2010

--- a/unison-core/src/Unison/ABT/Normalized.hs
+++ b/unison-core/src/Unison/ABT/Normalized.hs
@@ -96,25 +96,28 @@ class (Bifoldable f, Bifunctor f) => Align f where
     Applicative g =>
     (vl -> vr -> g vs) ->
     (el -> er -> g es) ->
-    f vl el -> f vr er -> Maybe (g (f vs es))
+    f vl el ->
+    f vr er ->
+    Maybe (g (f vs es))
 
 alphaErr ::
   Align f => Var v => Map v v -> Term f v -> Term f v -> Either (Term f v, Term f v) a
 alphaErr un tml tmr = Left (tml, renames count un tmr)
   where
-    count = Map.fromListWith (+) . flip zip [1,1..] $ toList un
+    count = Map.fromListWith (+) . flip zip [1, 1 ..] $ toList un
 
 -- Checks if two terms are equal up to a given variable renaming. The
 -- renaming should map variables in the right hand term to the
 -- equivalent variable in the left hand term.
 alpha :: Align f => Var v => Map v v -> Term f v -> Term f v -> Either (Term f v, Term f v) ()
-alpha un (TAbs u tml) (TAbs v tmr)
-  = alpha (Map.insert v u (Map.filter (/= u) un)) tml tmr
+alpha un (TAbs u tml) (TAbs v tmr) =
+  alpha (Map.insert v u (Map.filter (/= u) un)) tml tmr
 alpha un tml@(TTm bdl) tmr@(TTm bdr)
   | Just sub <- align av (alpha un) bdl bdr = () <$ sub
   where
-    av u v | maybe False (== u) (Map.lookup v un) = pure ()
-           | otherwise = alphaErr un tml tmr
+    av u v
+      | maybe False (== u) (Map.lookup v un) = pure ()
+      | otherwise = alphaErr un tml tmr
 alpha un tml tmr = alphaErr un tml tmr
 
 unabss :: Var v => Term f v -> ([v], Term f v)

--- a/unison-core/src/Unison/ABT/Normalized.hs
+++ b/unison-core/src/Unison/ABT/Normalized.hs
@@ -12,6 +12,8 @@
 module Unison.ABT.Normalized
   ( ABT (..),
     Term (.., TAbs, TTm, TAbss),
+    Align (..),
+    alpha,
     renames,
     rename,
     transform,
@@ -20,6 +22,7 @@ where
 
 import Data.Bifoldable
 import Data.Bifunctor
+import Data.Foldable (toList)
 -- import Data.Bitraversable
 
 import Data.Map.Strict (Map)
@@ -58,6 +61,22 @@ instance
   showsPrec p (Term _ e) =
     showParen (p >= 9) $ showString "Term " . showsPrec 10 e
 
+instance
+  (forall a b. Eq a => Eq b => Eq (f a b), Bifunctor f, Bifoldable f, Var v) =>
+  Eq (ABT f v)
+  where
+  Abs v1 e1 == Abs v2 e2
+    | v1 == v2 = e1 == e2
+    | otherwise = e1 == rename v2 v1 e2
+  Tm e1 == Tm e2 = e1 == e2
+  _ == _ = False
+
+instance
+  (forall a b. Eq a => Eq b => Eq (f a b), Bifunctor f, Bifoldable f, Var v) =>
+  Eq (Term f v)
+  where
+  Term _ abt1 == Term _ abt2 = abt1 == abt2
+
 pattern TAbs :: Var v => v -> Term f v -> Term f v
 pattern TAbs u bd <-
   Term _ (Abs u bd)
@@ -71,6 +90,32 @@ pattern TTm bd <-
     TTm bd = Term (bifoldMap Set.singleton freeVars bd) (Tm bd)
 
 {-# COMPLETE TAbs, TTm #-}
+
+class (Bifoldable f, Bifunctor f) => Align f where
+  align ::
+    Applicative g =>
+    (vl -> vr -> g vs) ->
+    (el -> er -> g es) ->
+    f vl el -> f vr er -> Maybe (g (f vs es))
+
+alphaErr ::
+  Align f => Var v => Map v v -> Term f v -> Term f v -> Either (Term f v, Term f v) a
+alphaErr un tml tmr = Left (tml, renames count un tmr)
+  where
+    count = Map.fromListWith (+) . flip zip [1,1..] $ toList un
+
+-- Checks if two terms are equal up to a given variable renaming. The
+-- renaming should map variables in the right hand term to the
+-- equivalent variable in the left hand term.
+alpha :: Align f => Var v => Map v v -> Term f v -> Term f v -> Either (Term f v, Term f v) ()
+alpha un (TAbs u tml) (TAbs v tmr)
+  = alpha (Map.insert v u (Map.filter (/= u) un)) tml tmr
+alpha un tml@(TTm bdl) tmr@(TTm bdr)
+  | Just sub <- align av (alpha un) bdl bdr = () <$ sub
+  where
+    av u v | maybe False (== u) (Map.lookup v un) = pure ()
+           | otherwise = alphaErr un tml tmr
+alpha un tml tmr = alphaErr un tml tmr
 
 unabss :: Var v => Term f v -> ([v], Term f v)
 unabss (TAbs v (unabss -> (vs, bd))) = (v : vs, bd)


### PR DESCRIPTION
This PR is the result of investigating a segfault that was occurring on some cloud jobs. The apparent culprit was the implementation of universal equality/compare for wrapped, boxed Haskell types. Somehow `unsafeCoerce` was causing bad behavior even though it didn't appear that the coercions were ill typed upon investigation.

The implementation of the comparisons has been modified to a form that doesn't seem to crash.

In addition, some debugging infrastructure that was written has been included in case it will be useful in the future.

Primitive array functions used in the runtime have been broken out into their own module, and bounds checking wrappers have been written for them. The checks are off by default, but can be turned on at build-time.

Functions for comparing intermediate code for alpha equality are now available. This was used to check that what we get back from a serialized standalone file is equivalent to the original code, and at least in this case, it appears to be so.

I'm not sure what percentage of the runtime this test case exercised, but all these checks (and more) turned up nothing actually wrong with the runtime, other than (most likely) an bad interaction of `unsafeCoerce` with the optimizer. So that's good news. I didn't include it in this PR, but at one point I had all uses of `unsafeCoerce` replaced with GHC Typeable, and got 0 runtime type errors. So everything was actually type correct in that respect.