### PR TITLE
Tweak some builtin implementations

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -100,6 +100,7 @@ import System.Environment as SYS
   ( getArgs,
     getEnv,
   )
+import System.FilePath (isPathSeparator)
 import System.IO (Handle)
 import System.IO as SYS
   ( IOMode (..),
@@ -2102,13 +2103,15 @@ declareForeigns = do
   declareForeign Tracked "Clock.internals.nsec.v1" boxToNat $
     mkForeign (\n -> pure (fromIntegral $ nsec n :: Word64))
 
+  let chop = reverse . dropWhile isPathSeparator . reverse
+
   declareForeign Tracked "IO.getTempDirectory.impl.v3" unitToEFBox $
-    mkForeignIOF $ \() -> getTemporaryDirectory
+    mkForeignIOF $ \() -> chop <$> getTemporaryDirectory
 
   declareForeign Tracked "IO.createTempDirectory.impl.v3" boxToEFBox $
     mkForeignIOF $ \prefix -> do
       temp <- getTemporaryDirectory
-      createTempDirectory temp prefix
+      chop <$> createTempDirectory temp prefix
 
   declareForeign Tracked "IO.getCurrentDirectory.impl.v3" unitToEFBox
     . mkForeignIOF

--- a/unison-src/transcripts/builtins.md
+++ b/unison-src/transcripts/builtins.md
@@ -14,6 +14,9 @@ This transcript defines unit tests for builtin functions. There's a single `.> t
 ```unison:hide
 use Int
 
+-- used for some take/drop tests later
+bigN = Nat.shiftLeft 1 63
+
 -- Note: you can make the tests more fine-grained if you
 -- want to be able to tell which one is failing
 test> Int.tests.arithmetic =
@@ -198,7 +201,9 @@ test> Text.tests.takeDropAppend =
         Text.take 99 "yabba" == "yabba",
         Text.drop 0 "yabba" == "yabba",
         Text.drop 2 "yabba" == "bba",
-        Text.drop 99 "yabba" == ""
+        Text.drop 99 "yabba" == "",
+        Text.take bigN "yabba" == "yabba",
+        Text.drop bigN "yabba" == ""
         ]
 
 test> Text.tests.repeat =
@@ -255,7 +260,9 @@ test> Bytes.tests.at =
         checks [
           Bytes.at 1 bs == Some 13,
           Bytes.at 0 bs == Some 77,
-          Bytes.at 99 bs == None
+          Bytes.at 99 bs == None,
+          Bytes.take bigN bs == bs,
+          Bytes.drop bigN bs == empty
         ]
 
 test> Bytes.tests.compression =
@@ -304,6 +311,14 @@ test> checks [
 
 ```ucm:hide
 .> add
+```
+
+Other list functions
+```unison:hide
+test> checks [
+        List.take bigN [1,2,3] == [1,2,3],
+        List.drop bigN [1,2,3] == []
+      ]
 ```
 
 ## `Any` functions

--- a/unison-src/transcripts/builtins.output.md
+++ b/unison-src/transcripts/builtins.output.md
@@ -7,6 +7,9 @@ This transcript defines unit tests for builtin functions. There's a single `.> t
 ```unison
 use Int
 
+-- used for some take/drop tests later
+bigN = Nat.shiftLeft 1 63
+
 -- Note: you can make the tests more fine-grained if you
 -- want to be able to tell which one is failing
 test> Int.tests.arithmetic =
@@ -179,7 +182,9 @@ test> Text.tests.takeDropAppend =
         Text.take 99 "yabba" == "yabba",
         Text.drop 0 "yabba" == "yabba",
         Text.drop 2 "yabba" == "bba",
-        Text.drop 99 "yabba" == ""
+        Text.drop 99 "yabba" == "",
+        Text.take bigN "yabba" == "yabba",
+        Text.drop bigN "yabba" == ""
         ]
 
 test> Text.tests.repeat =
@@ -232,7 +237,9 @@ test> Bytes.tests.at =
         checks [
           Bytes.at 1 bs == Some 13,
           Bytes.at 0 bs == Some 77,
-          Bytes.at 99 bs == None
+          Bytes.at 99 bs == None,
+          Bytes.take bigN bs == bs,
+          Bytes.drop bigN bs == empty
         ]
 
 test> Bytes.tests.compression =
@@ -272,6 +279,14 @@ test> checks [
         compare [1,2,3] [1,2,4] == -1,
         compare [1,2,2] [1,2,1,2] == +1,
         compare [1,2,3,4] [3,2,1] == -1
+      ]
+```
+
+Other list functions
+```unison
+test> checks [
+        List.take bigN [1,2,3] == [1,2,3],
+        List.drop bigN [1,2,3] == []
       ]
 ```
 


### PR DESCRIPTION
This changes `take`/`drop` for bytes/list/text to look for negative numbers. Since the inputs are `Nat`, negative numbers mean the argument was actually extremely large, so `take` is treated as the identity, and `drop` as yielding the empty value.

Also changes get/createTempDirectory to avoid returning paths ending with a separator. 

Fixes #3660 
Fixes #3622