### PR TITLE
prepend "test>" to edited tests

### DIFF
--- a/lib/unison-util-relation/src/Unison/Util/Relation3.hs
+++ b/lib/unison-util-relation/src/Unison/Util/Relation3.hs
@@ -94,6 +94,10 @@ mapD2Monotonic f Relation3 {d1, d2, d3} =
 member :: (Ord a, Ord b, Ord c) => a -> b -> c -> Relation3 a b c -> Bool
 member a b c = R.member b c . lookupD1 a
 
+memberD2 :: Ord b => b -> Relation3 a b c -> Bool
+memberD2 b =
+  Map.member b . d2
+
 lookupD1 :: (Ord a, Ord b, Ord c) => a -> Relation3 a b c -> Relation b c
 lookupD1 a = fromMaybe mempty . Map.lookup a . d1
 

--- a/lib/unison-util-relation/src/Unison/Util/Relation4.hs
+++ b/lib/unison-util-relation/src/Unison/Util/Relation4.hs
@@ -55,6 +55,12 @@ fromList xs = insertAll xs empty
 filter :: (Ord a, Ord b, Ord c, Ord d) => ((a, b, c, d) -> Bool) -> Relation4 a b c d -> Relation4 a b c d
 filter f = fromList . Prelude.filter f . toList
 
+memberD13 :: (Ord a, Ord c) => a -> c -> Relation4 a b c d -> Bool
+memberD13 a c r4 =
+  case Map.lookup a (d1 r4) of
+    Nothing -> False
+    Just r3 -> R3.memberD2 c r3
+
 selectD3 ::
   (Ord a, Ord b, Ord c, Ord d) =>
   c ->

--- a/parser-typechecker/src/Unison/Codebase/Metadata.hs
+++ b/parser-typechecker/src/Unison/Codebase/Metadata.hs
@@ -7,7 +7,6 @@ import Unison.Reference (Reference)
 import qualified Unison.Util.List as List
 import Unison.Util.Relation (Relation)
 import qualified Unison.Util.Relation as R
-import qualified Unison.Util.Relation3 as R3
 import Unison.Util.Relation4 (Relation4)
 import qualified Unison.Util.Relation4 as R4
 import Unison.Util.Star3 (Star3)
@@ -44,8 +43,8 @@ hasMetadata :: Ord a => a -> Type -> Value -> Star a n -> Bool
 hasMetadata a t v = Set.member (t, v) . R.lookupDom a . Star3.d3
 
 hasMetadataWithType' :: Ord a => a -> Type -> R4 a n -> Bool
-hasMetadataWithType' a t r =
-  fromMaybe False $ Set.member t . R3.d2s <$> (Map.lookup a $ R4.d1 r)
+hasMetadataWithType' =
+  R4.memberD13
 
 hasMetadataWithType :: Ord a => a -> Type -> Star a n -> Bool
 hasMetadataWithType a t = Set.member t . R.lookupDom a . Star3.d2

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update.hs
@@ -53,7 +53,7 @@ import qualified Unison.Reference as Reference
 import Unison.Referent (Referent)
 import qualified Unison.Referent as Referent
 import qualified Unison.Result as Result
-import Unison.Runtime.IOSource (isTest)
+import qualified Unison.Runtime.IOSource as IOSource
 import qualified Unison.Sqlite as Sqlite
 import Unison.Symbol (Symbol)
 import qualified Unison.Syntax.Name as Name (toVar, unsafeFromVar)
@@ -589,7 +589,7 @@ doSlurpAdds slurp uf = Branch.batchUpdates (typeActions <> termActions)
         SC.terms slurp <> UF.constructorsForDecls (SC.types slurp) uf
     names = UF.typecheckedToNames uf
     tests = Set.fromList $ fst <$> UF.watchesOfKind WK.TestWatch (UF.discardTypes uf)
-    (isTestType, isTestValue) = isTest
+    (isTestType, isTestValue) = IOSource.isTest
     md v =
       if Set.member v tests
         then Metadata.singleton isTestType isTestValue

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1537,19 +1537,20 @@ viewReflog =
 edit :: InputPattern
 edit =
   InputPattern
-    "edit"
-    []
-    I.Visible
-    [(OnePlus, definitionQueryArg)]
-    ( P.lines
-        [ "`edit foo` prepends the definition of `foo` to the top of the most "
-            <> "recently saved file.",
-          "`edit` without arguments invokes a search to select a definition for editing, which requires that `fzf` can be found within your PATH."
-        ]
-    )
-    ( fmap (Input.ShowDefinitionI Input.LatestFileLocation Input.ShowDefinitionLocal)
-        . traverse parseHashQualifiedName
-    )
+    { patternName = "edit",
+      aliases = [],
+      visibility = I.Visible,
+      argTypes = [(OnePlus, definitionQueryArg)],
+      help =
+        P.lines
+          [ "`edit foo` prepends the definition of `foo` to the top of the most "
+              <> "recently saved file.",
+            "`edit` without arguments invokes a search to select a definition for editing, which requires that `fzf` can be found within your PATH."
+          ],
+      parse =
+        fmap (Input.ShowDefinitionI Input.LatestFileLocation Input.ShowDefinitionLocal)
+          . traverse parseHashQualifiedName
+    }
 
 topicNameArg :: ArgumentType
 topicNameArg =

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -112,7 +112,7 @@ import Unison.PrintError
     printNoteWithSource,
     renderCompilerBug,
   )
-import Unison.Reference (Reference)
+import Unison.Reference (Reference, TermReference)
 import qualified Unison.Reference as Reference
 import Unison.Referent (Referent)
 import qualified Unison.Referent as Referent
@@ -125,12 +125,14 @@ import qualified Unison.Share.Sync as Share
 import Unison.Share.Sync.Types (CodeserverTransportError (..))
 import qualified Unison.ShortHash as SH
 import qualified Unison.ShortHash as ShortHash
+import Unison.Symbol (Symbol)
 import qualified Unison.Sync.Types as Share
 import qualified Unison.Syntax.DeclPrinter as DeclPrinter
 import qualified Unison.Syntax.HashQualified as HQ (toString, toText, unsafeFromVar)
 import qualified Unison.Syntax.Name as Name (toString, toText)
 import Unison.Syntax.NamePrinter
-  ( prettyHashQualified,
+  ( SyntaxText,
+    prettyHashQualified,
     prettyHashQualified',
     prettyLabeledDependency,
     prettyName,
@@ -658,8 +660,7 @@ notifyUser dir o = case o of
                 [prettyReadRemoteNamespace baseNS, prettyPath' squashedPath]
               <> "to push the changes."
         ]
-  DisplayDefinitions outputLoc ppe types terms ->
-    displayDefinitions outputLoc ppe types terms
+  DisplayDefinitions output -> displayDefinitions output
   DisplayRendered outputLoc pp ->
     displayRendered outputLoc pp
   TestResults stats ppe _showSuccess _showFailures oks fails -> case stats of
@@ -2034,24 +2035,18 @@ displayRendered outputLoc pp =
                 P.indentN 2 pp
               ]
 
-displayDefinitions ::
-  Var v =>
-  Ord a1 =>
-  Maybe FilePath ->
-  PPED.PrettyPrintEnvDecl ->
-  Map Reference.Reference (DisplayObject () (DD.Decl v a1)) ->
-  Map Reference.Reference (DisplayObject (Type v a1) (Term v a1)) ->
-  IO Pretty
-displayDefinitions _outputLoc _ppe types terms
-  | Map.null types && Map.null terms = pure $ P.callout "😶" "No results to display."
-displayDefinitions outputLoc ppe types terms =
-  maybe displayOnly scratchAndDisplay outputLoc
+displayDefinitions :: DisplayDefinitionsOutput -> IO Pretty
+displayDefinitions DisplayDefinitionsOutput {isTest, outputFile, prettyPrintEnv = ppe, terms, types} =
+  if Map.null types && Map.null terms
+    then pure $ P.callout "😶" "No results to display."
+    else maybe displayOnly scratchAndDisplay outputFile
   where
-    displayOnly = pure code
+    ppeDecl = PPED.unsuffixifiedPPE ppe
+    displayOnly = pure (code (const False))
     scratchAndDisplay path = do
       path' <- canonicalizePath path
-      prependToFile code path'
-      pure (message code path')
+      prependToFile (code isTest) path'
+      pure (message (code (const False)) path')
       where
         prependToFile code path = do
           existingContents <- do
@@ -2078,47 +2073,63 @@ displayDefinitions outputLoc ppe types terms =
                   "You can edit them there, then do" <> makeExample' IP.update
                     <> "to replace the definitions currently in this namespace."
               ]
-    code =
-      P.syntaxToColor $ P.sep "\n\n" (prettyTypes <> prettyTerms)
+
+    code :: (TermReference -> Bool) -> Pretty
+    code isTest =
+      P.syntaxToColor $ P.sep "\n\n" (prettyTypes <> prettyTerms isTest)
+
+    prettyTypes :: [P.Pretty SyntaxText]
+    prettyTypes =
+      types
+        & Map.toList
+        & map (\(ref, dt) -> (PPE.typeName ppeDecl ref, ref, dt))
+        & List.sortBy (\(n0, _, _) (n1, _, _) -> Name.compareAlphabetical n0 n1)
+        & map prettyType
+
+    prettyTerms :: (TermReference -> Bool) -> [P.Pretty SyntaxText]
+    prettyTerms isTest =
+      terms
+        & Map.toList
+        & map (\(ref, dt) -> (PPE.termName ppeDecl (Referent.Ref ref), ref, dt))
+        & List.sortBy (\(n0, _, _) (n1, _, _) -> Name.compareAlphabetical n0 n1)
+        & map (\t -> prettyTerm (isTest (t ^. _2)) t)
+
+    prettyTerm ::
+      Bool ->
+      (HQ.HashQualified Name, Reference, DisplayObject (Type Symbol Ann) (Term Symbol Ann)) ->
+      P.Pretty SyntaxText
+    prettyTerm isTest (n, r, dt) =
+      case dt of
+        MissingObject r -> missing n r
+        BuiltinObject typ ->
+          (if isJust outputFile then P.indent "-- " else id) $
+            P.hang
+              ("builtin " <> prettyHashQualified n <> " :")
+              (TypePrinter.prettySyntax (ppeBody n r) typ)
+        UserObject tm ->
+          if isTest
+            then WK.TestWatch <> "> " <> TermPrinter.prettyBindingWithoutTypeSignature (ppeBody n r) n tm
+            else TermPrinter.prettyBinding (ppeBody n r) n tm
       where
         ppeBody n r = PPE.biasTo (maybeToList $ HQ.toName n) $ PPE.declarationPPE ppe r
-        ppeDecl = PPED.unsuffixifiedPPE ppe
-        prettyTerms =
-          terms
-            & Map.toList
-            & map (\(ref, dt) -> (PPE.termName ppeDecl (Referent.Ref ref), ref, dt))
-            & List.sortBy (\(n0, _, _) (n1, _, _) -> Name.compareAlphabetical n0 n1)
-            & map go
-        prettyTypes =
-          types
-            & Map.toList
-            & map (\(ref, dt) -> (PPE.typeName ppeDecl ref, ref, dt))
-            & List.sortBy (\(n0, _, _) (n1, _, _) -> Name.compareAlphabetical n0 n1)
-            & map go2
-        go (n, r, dt) =
-          case dt of
-            MissingObject r -> missing n r
-            BuiltinObject typ ->
-              (if isJust outputLoc then P.indent "-- " else id) $
-                P.hang
-                  ("builtin " <> prettyHashQualified n <> " :")
-                  (TypePrinter.prettySyntax (ppeBody n r) typ)
-            UserObject tm -> TermPrinter.prettyBinding (ppeBody n r) n tm
-        go2 (n, r, dt) =
-          case dt of
-            MissingObject r -> missing n r
-            BuiltinObject _ -> builtin n
-            UserObject decl -> DeclPrinter.prettyDecl (PPED.biasTo (maybeToList $ HQ.toName n) $ PPE.declarationPPEDecl ppe r) r n decl
-        builtin n = P.wrap $ "--" <> prettyHashQualified n <> " is built-in."
-        missing n r =
-          P.wrap
-            ( "-- The name " <> prettyHashQualified n <> " is assigned to the "
-                <> "reference "
-                <> fromString (show r ++ ",")
-                <> "which is missing from the codebase."
-            )
-            <> P.newline
-            <> tip "You might need to repair the codebase manually."
+
+    prettyType :: (HQ.HashQualified Name, Reference, DisplayObject () (DD.Decl Symbol Ann)) -> P.Pretty SyntaxText
+    prettyType (n, r, dt) =
+      case dt of
+        MissingObject r -> missing n r
+        BuiltinObject _ -> builtin n
+        UserObject decl -> DeclPrinter.prettyDecl (PPED.biasTo (maybeToList $ HQ.toName n) $ PPE.declarationPPEDecl ppe r) r n decl
+
+    builtin n = P.wrap $ "--" <> prettyHashQualified n <> " is built-in."
+    missing n r =
+      P.wrap
+        ( "-- The name " <> prettyHashQualified n <> " is assigned to the "
+            <> "reference "
+            <> fromString (show r ++ ",")
+            <> "which is missing from the codebase."
+        )
+        <> P.newline
+        <> tip "You might need to repair the codebase manually."
 
 displayTestResults ::
   Bool -> -- whether to show the tip

--- a/unison-core/src/Unison/WatchKind.hs
+++ b/unison-core/src/Unison/WatchKind.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ViewPatterns #-}
 
 module Unison.WatchKind where
 

--- a/unison-share-api/package.yaml
+++ b/unison-share-api/package.yaml
@@ -69,6 +69,7 @@ default-extensions:
   - ConstraintKinds
   - DeriveAnyClass
   - DeriveFunctor
+  - DeriveGeneric
   - DerivingStrategies
   - DerivingVia
   - DoAndIfThenElse
@@ -86,6 +87,7 @@ default-extensions:
   - PatternSynonyms
   - RankNTypes
   - ScopedTypeVariables
+  - StandaloneDeriving
   - TupleSections
   - TypeApplications
   - TypeOperators

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -701,7 +701,7 @@ makeNameSearch hashLength names =
     }
 
 -- | Interpret a 'Search' as a function from name to search results.
-applySearch :: (Show r) => Search r -> HQ'.HashQualified Name -> [SR.SearchResult]
+applySearch :: Show r => Search r -> HQ'.HashQualified Name -> [SR.SearchResult]
 applySearch Search {lookupNames, lookupRelativeHQRefs', makeResult, matchesNamedRef} query = do
   -- a bunch of references will match a HQ ref.
   toList (lookupRelativeHQRefs' query) <&> \ref ->
@@ -778,9 +778,9 @@ hqNameQuery codebase NameSearch {typeSearch, termSearch} hqs = do
       }
 
 -- TODO: Move this to its own module
-data DefinitionResults v = DefinitionResults
-  { termResults :: Map Reference (DisplayObject (Type v Ann) (Term v Ann)),
-    typeResults :: Map Reference (DisplayObject () (DD.Decl v Ann)),
+data DefinitionResults = DefinitionResults
+  { termResults :: Map Reference (DisplayObject (Type Symbol Ann) (Term Symbol Ann)),
+    typeResults :: Map Reference (DisplayObject () (DD.Decl Symbol Ann)),
     noResults :: [HQ.HashQualified Name]
   }
 
@@ -1204,7 +1204,7 @@ definitionsBySuffixes ::
   NameSearch ->
   IncludeCycles ->
   [HQ.HashQualified Name] ->
-  Sqlite.Transaction (DefinitionResults Symbol)
+  Sqlite.Transaction DefinitionResults
 definitionsBySuffixes codebase nameSearch includeCycles query = do
   QueryResult misses results <- hqNameQuery codebase nameSearch query
   -- todo: remember to replace this with getting components directly,

--- a/unison-share-api/src/Unison/Server/Types.hs
+++ b/unison-share-api/src/Unison/Server/Types.hs
@@ -1,10 +1,5 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Unison.Server.Types where
 

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -45,6 +45,7 @@ library
       ConstraintKinds
       DeriveAnyClass
       DeriveFunctor
+      DeriveGeneric
       DerivingStrategies
       DerivingVia
       DoAndIfThenElse
@@ -62,6 +63,7 @@ library
       PatternSynonyms
       RankNTypes
       ScopedTypeVariables
+      StandaloneDeriving
       TupleSections
       TypeApplications
       TypeOperators


### PR DESCRIPTION
## Overview

Fixes #3373 

This PR puts `"test> "` before tests that are `edit`ed.

Notable implementation detail: we had a term binding printer that always put a type signature (if the term was annotated), e.g.:

```unison
mytest : [Test.Result]
mytest = []
```

However, I couldn't figure out a syntax for test watches that includes type signatures. This is a parse error, for example.

```unison
test>
  mytest : [Test.Result]
  mytest = []
```

I also figured type signatures were not very important to print for tests, since they're always type `[Test.Result]`. So, this PR puts tests in the scratch file without type signatures, e.g.:

```unison
test> mytest = []
```

### Testing

I tested this manually.