### PR TITLE
default pull to silent mode

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Verbosity.hs
+++ b/parser-typechecker/src/Unison/Codebase/Verbosity.hs
@@ -1,8 +1,8 @@
 module Unison.Codebase.Verbosity where
 
-data Verbosity = Default | Silent deriving (Eq, Show)
+data Verbosity = Verbose | Silent deriving (Eq, Show)
 
 isSilent :: Verbosity -> Bool
 isSilent v = case v of
-  Default -> False
+  Verbose -> False
   Silent -> True


### PR DESCRIPTION
## Overview

What was `pull.silent` is now also `pull`.
What was `pull` is now `pull.verbose`.

Resolves #3566.

## Interesting/controversial decisions

Before this change, the `Verbosity` type (which I believe was only used
for variations of pulling code) was either `Silent` or `Default`. This
is awkward because silent became the new default. So I changed it to
`Silent` or `Verbose` and filled in default values as needed.

I retained the verbose functionality for `debug.pull-exhaustive` because
if you are in the state that you need that command, some extra output
about what is happening might be useful.

## Test coverage

I was surprised to see that this didn't affect the output of any transcripts. I probably should have added a transcript, but it was a straightforward change and worked when I manually tested it, so I haven't bothered.

## Loose ends

I think that there are still some other commands that are defaulting to verbose mode that probably shouldn't be. I'll open issues for them as I encounter them.
