### PR TITLE
add all-base-hashes.md transcript

### DIFF
--- a/unison-src/transcripts-using-base/all-base-hashes.md
+++ b/unison-src/transcripts-using-base/all-base-hashes.md
@@ -1,0 +1,5 @@
+This transcript is intended to make visible accidental changes to the hashing algorithm.
+
+```ucm
+.> find.verbose
+```

--- a/unison-src/transcripts-using-base/all-base-hashes.output.md
+++ b/unison-src/transcripts-using-base/all-base-hashes.output.md
@@ -1,0 +1,2682 @@
+This transcript is intended to make visible accidental changes to the hashing algorithm.
+
+```ucm
+.> find.verbose
+
+  1.   -- #0moj6a30dak6suns8qefi93ljsl8j59ha9bpcu8qbmh49rbobik4bn9m4rre8sm7pprsistr9o5m4a667i82gs089eur75ua8geldj8
+       ascii : Text -> Bytes
+       
+  2.   -- #8gr403lgh2aq58nj3tfgc6bek1hqlv3he0hge0nlperojc99tdjg2cfdbu0vko5a4mp7jqt08npk4fa8grbbdu9fn47s0qmp1oa0aqo
+       autoCleaned : '{IO, TempDirs} r ->{IO, Exception} r
+       
+  3.   -- #lf7arjlkufc078rdqh1653j7ft4tt59b1deugc513p21kep0kj1cp7q7v43o6u8csoi172pt27i2mtu2unsv1au7g0ue52s5pmamjk0
+       autoCleaned.handler : '{IO} (Request {TempDirs} r
+       ->{IO, Exception} r)
+       
+  4.   -- #fajcv3ki8h80htov5pu2beu6f9d5dqsr0he47jssjvivgcpo2n1mqmbh7e0plv5cuqte3kjg18ken8gv1kmtpppkjjein4rr7a50ep8
+       bContains : [(a, b)] -> a -> Boolean
+       
+  5.   -- #js3u40odrqs74lpcqjoemr1b08cbu7co41sf0ubp7gq3eaohl72db3khi0p1neqtmk2ede9f00n07no0kju13i7tliopsgsm69nh38o
+       bInsert : [(a, b)] -> a -> b -> [(a, b)]
+       
+  6.   -- #avou19csadtmkejvdovufstrhtsbvnauqan05o9na0kqo7jon7ql05f7ooccbv777k68jj56ufufthp1cjd0jvium7j2ghrlpghnh58
+       bSearch : [(a, b)] -> a -> Optional b
+       
+  7.   -- #ps5jpme6lr6fgv1a3cjmd4tpqr62pg3flmunkhcu9creojv2hsmei86nb6nndiam5p4q79nlerddrgto5um4ugm0p9evb8isoqu9ur0
+       bSort : [(a, b)] -> [(a, b)]
+       
+  8.   -- #vb7eo70iavak378net6hohjkosud6ooabo1j0dev8l7254ls2j48f4e8gmk46d4016l41tpe7k8gqjqtb84g0gdc93vrh8bh4d62nf8
+       bSplit : [(a, b)] -> a -> ([(a, b)], [(a, b)])
+       
+  9.   -- #1j3e8vsn97qrprjr69ls6llab601sdh577uuvtu8pafmngf59suakbjr7asheadidcj3red140fnmdagsv9ihhdar1mc05ig28jtfr0
+       unique type builtin.ANSI.Color
+       
+  10.  -- #1j3e8vsn97qrprjr69ls6llab601sdh577uuvtu8pafmngf59suakbjr7asheadidcj3red140fnmdagsv9ihhdar1mc05ig28jtfr0#0
+       builtin.ANSI.Color.Black : Color
+       
+  11.  -- #1j3e8vsn97qrprjr69ls6llab601sdh577uuvtu8pafmngf59suakbjr7asheadidcj3red140fnmdagsv9ihhdar1mc05ig28jtfr0#4
+       builtin.ANSI.Color.Blue : Color
+       
+  12.  -- #1j3e8vsn97qrprjr69ls6llab601sdh577uuvtu8pafmngf59suakbjr7asheadidcj3red140fnmdagsv9ihhdar1mc05ig28jtfr0#8
+       builtin.ANSI.Color.BrightBlack : Color
+       
+  13.  -- #1j3e8vsn97qrprjr69ls6llab601sdh577uuvtu8pafmngf59suakbjr7asheadidcj3red140fnmdagsv9ihhdar1mc05ig28jtfr0#12
+       builtin.ANSI.Color.BrightBlue : Color
+       
+  14.  -- #1j3e8vsn97qrprjr69ls6llab601sdh577uuvtu8pafmngf59suakbjr7asheadidcj3red140fnmdagsv9ihhdar1mc05ig28jtfr0#14
+       builtin.ANSI.Color.BrightCyan : Color
+       
+  15.  -- #1j3e8vsn97qrprjr69ls6llab601sdh577uuvtu8pafmngf59suakbjr7asheadidcj3red140fnmdagsv9ihhdar1mc05ig28jtfr0#10
+       builtin.ANSI.Color.BrightGreen : Color
+       
+  16.  -- #1j3e8vsn97qrprjr69ls6llab601sdh577uuvtu8pafmngf59suakbjr7asheadidcj3red140fnmdagsv9ihhdar1mc05ig28jtfr0#13
+       builtin.ANSI.Color.BrightMagenta : Color
+       
+  17.  -- #1j3e8vsn97qrprjr69ls6llab601sdh577uuvtu8pafmngf59suakbjr7asheadidcj3red140fnmdagsv9ihhdar1mc05ig28jtfr0#9
+       builtin.ANSI.Color.BrightRed : Color
+       
+  18.  -- #1j3e8vsn97qrprjr69ls6llab601sdh577uuvtu8pafmngf59suakbjr7asheadidcj3red140fnmdagsv9ihhdar1mc05ig28jtfr0#15
+       builtin.ANSI.Color.BrightWhite : Color
+       
+  19.  -- #1j3e8vsn97qrprjr69ls6llab601sdh577uuvtu8pafmngf59suakbjr7asheadidcj3red140fnmdagsv9ihhdar1mc05ig28jtfr0#11
+       builtin.ANSI.Color.BrightYellow : Color
+       
+  20.  -- #1j3e8vsn97qrprjr69ls6llab601sdh577uuvtu8pafmngf59suakbjr7asheadidcj3red140fnmdagsv9ihhdar1mc05ig28jtfr0#6
+       builtin.ANSI.Color.Cyan : Color
+       
+  21.  -- #1j3e8vsn97qrprjr69ls6llab601sdh577uuvtu8pafmngf59suakbjr7asheadidcj3red140fnmdagsv9ihhdar1mc05ig28jtfr0#2
+       builtin.ANSI.Color.Green : Color
+       
+  22.  -- #1j3e8vsn97qrprjr69ls6llab601sdh577uuvtu8pafmngf59suakbjr7asheadidcj3red140fnmdagsv9ihhdar1mc05ig28jtfr0#5
+       builtin.ANSI.Color.Magenta : Color
+       
+  23.  -- #1j3e8vsn97qrprjr69ls6llab601sdh577uuvtu8pafmngf59suakbjr7asheadidcj3red140fnmdagsv9ihhdar1mc05ig28jtfr0#1
+       builtin.ANSI.Color.Red : Color
+       
+  24.  -- #1j3e8vsn97qrprjr69ls6llab601sdh577uuvtu8pafmngf59suakbjr7asheadidcj3red140fnmdagsv9ihhdar1mc05ig28jtfr0#7
+       builtin.ANSI.Color.White : Color
+       
+  25.  -- #1j3e8vsn97qrprjr69ls6llab601sdh577uuvtu8pafmngf59suakbjr7asheadidcj3red140fnmdagsv9ihhdar1mc05ig28jtfr0#3
+       builtin.ANSI.Color.Yellow : Color
+       
+  26.  -- ##Any
+       builtin type builtin.Any
+       
+  27.  -- ##Any.Any
+       builtin.Any.Any : a -> Any
+       
+  28.  -- ##Any.unsafeExtract
+       builtin.Any.unsafeExtract : Any -> a
+       
+  29.  -- #345f3nptqq1c1ped6gq8578kb2bhp1jejnqborsn6fq59rpe1rren3ogia9o9u8oc339vll953inma8pocc686ooknaitud8i5m27vg
+       unique type builtin.Author
+       
+  30.  -- #345f3nptqq1c1ped6gq8578kb2bhp1jejnqborsn6fq59rpe1rren3ogia9o9u8oc339vll953inma8pocc686ooknaitud8i5m27vg#0
+       builtin.Author.Author : GUID -> Text -> Author
+       
+  31.  -- #09po4pftofof2dl6r5ddr5ucjmbiktvg139pjueica5ncrmbq6irin52tm83mu02r59dbktv7d550ik53bbgvue1qvdbvses746s0f0
+       builtin.Author.guid : Author -> GUID
+       
+  32.  -- #adci09ncqjm7nle4v7irv1skla5q05glhsf2ld2b6cbre33ej7hbvf64deng8o5edv16vm0cat18ehj384gk4u9il7g6v4e7spgisuo
+       builtin.Author.guid.modify : (GUID ->{g} GUID)
+       -> Author
+       ->{g} Author
+       
+  33.  -- #5grcsob7l7dh440he3dibln7m628t4lregtv718vsb33mehvs72muugusuuajc8m804659h0e989dnks2adqr1vb8fnd912854t6nv0
+       builtin.Author.guid.set : GUID -> Author -> Author
+       
+  34.  -- #vm19g9c23c3g186nkmreodqckso1belvfeb3bhbnfe4kfpjnq4bbo91le6bndfq5761eovt7rind30sp74fs1eqo44ukqmr96ggk1jg
+       builtin.Author.name : Author -> Text
+       
+  35.  -- #9udtng9ee5kq8bkq0fte4a4oknjl5h7tg8i6olebmgvat864n9q5k8cf7kpmtbhpdi9js0egpihprgt22v949bff4523h39noopeepo
+       builtin.Author.name.modify : (Text ->{g} Text)
+       -> Author
+       ->{g} Author
+       
+  36.  -- #v7l3vi93crov1681dom6fv17825dpf8rd1q4lpjdr6bn9ltsfliiertoju3rftvdubhn3n8lpf7vtfrmo3p9v47n5in98dq1aosnmq0
+       builtin.Author.name.set : Text -> Author -> Author
+       
+  37.  -- ##Boolean
+       builtin type builtin.Boolean
+       
+  38.  -- ##Boolean.not
+       builtin.Boolean.not : Boolean -> Boolean
+       
+  39.  -- ##bug
+       builtin.bug : a -> b
+       
+  40.  -- ##Bytes
+       builtin type builtin.Bytes
+       
+  41.  -- ##Bytes.++
+       builtin.Bytes.++ : Bytes -> Bytes -> Bytes
+       
+  42.  -- ##Bytes.at
+       builtin.Bytes.at : Nat -> Bytes -> Optional Nat
+       
+  43.  -- ##Bytes.decodeNat16be
+       builtin.Bytes.decodeNat16be : Bytes
+       -> Optional (Nat, Bytes)
+       
+  44.  -- ##Bytes.decodeNat16le
+       builtin.Bytes.decodeNat16le : Bytes
+       -> Optional (Nat, Bytes)
+       
+  45.  -- ##Bytes.decodeNat32be
+       builtin.Bytes.decodeNat32be : Bytes
+       -> Optional (Nat, Bytes)
+       
+  46.  -- ##Bytes.decodeNat32le
+       builtin.Bytes.decodeNat32le : Bytes
+       -> Optional (Nat, Bytes)
+       
+  47.  -- ##Bytes.decodeNat64be
+       builtin.Bytes.decodeNat64be : Bytes
+       -> Optional (Nat, Bytes)
+       
+  48.  -- ##Bytes.decodeNat64le
+       builtin.Bytes.decodeNat64le : Bytes
+       -> Optional (Nat, Bytes)
+       
+  49.  -- ##Bytes.drop
+       builtin.Bytes.drop : Nat -> Bytes -> Bytes
+       
+  50.  -- ##Bytes.empty
+       builtin.Bytes.empty : Bytes
+       
+  51.  -- ##Bytes.encodeNat16be
+       builtin.Bytes.encodeNat16be : Nat -> Bytes
+       
+  52.  -- ##Bytes.encodeNat16le
+       builtin.Bytes.encodeNat16le : Nat -> Bytes
+       
+  53.  -- ##Bytes.encodeNat32be
+       builtin.Bytes.encodeNat32be : Nat -> Bytes
+       
+  54.  -- ##Bytes.encodeNat32le
+       builtin.Bytes.encodeNat32le : Nat -> Bytes
+       
+  55.  -- ##Bytes.encodeNat64be
+       builtin.Bytes.encodeNat64be : Nat -> Bytes
+       
+  56.  -- ##Bytes.encodeNat64le
+       builtin.Bytes.encodeNat64le : Nat -> Bytes
+       
+  57.  -- ##Bytes.flatten
+       builtin.Bytes.flatten : Bytes -> Bytes
+       
+  58.  -- ##Bytes.fromBase16
+       builtin.Bytes.fromBase16 : Bytes -> Either Text Bytes
+       
+  59.  -- ##Bytes.fromBase32
+       builtin.Bytes.fromBase32 : Bytes -> Either Text Bytes
+       
+  60.  -- ##Bytes.fromBase64
+       builtin.Bytes.fromBase64 : Bytes -> Either Text Bytes
+       
+  61.  -- ##Bytes.fromBase64UrlUnpadded
+       builtin.Bytes.fromBase64UrlUnpadded : Bytes
+       -> Either Text Bytes
+       
+  62.  -- ##Bytes.fromList
+       builtin.Bytes.fromList : [Nat] -> Bytes
+       
+  63.  -- ##Bytes.gzip.compress
+       builtin.Bytes.gzip.compress : Bytes -> Bytes
+       
+  64.  -- ##Bytes.gzip.decompress
+       builtin.Bytes.gzip.decompress : Bytes
+       -> Either Text Bytes
+       
+  65.  -- ##Bytes.size
+       builtin.Bytes.size : Bytes -> Nat
+       
+  66.  -- ##Bytes.take
+       builtin.Bytes.take : Nat -> Bytes -> Bytes
+       
+  67.  -- ##Bytes.toBase16
+       builtin.Bytes.toBase16 : Bytes -> Bytes
+       
+  68.  -- ##Bytes.toBase32
+       builtin.Bytes.toBase32 : Bytes -> Bytes
+       
+  69.  -- ##Bytes.toBase64
+       builtin.Bytes.toBase64 : Bytes -> Bytes
+       
+  70.  -- ##Bytes.toBase64UrlUnpadded
+       builtin.Bytes.toBase64UrlUnpadded : Bytes -> Bytes
+       
+  71.  -- ##Bytes.toList
+       builtin.Bytes.toList : Bytes -> [Nat]
+       
+  72.  -- ##Bytes.zlib.compress
+       builtin.Bytes.zlib.compress : Bytes -> Bytes
+       
+  73.  -- ##Bytes.zlib.decompress
+       builtin.Bytes.zlib.decompress : Bytes
+       -> Either Text Bytes
+       
+  74.  -- ##Char
+       builtin type builtin.Char
+       
+  75.  -- ##Char.fromNat
+       builtin.Char.fromNat : Nat -> Char
+       
+  76.  -- ##Char.toNat
+       builtin.Char.toNat : Char -> Nat
+       
+  77.  -- ##Char.toText
+       builtin.Char.toText : Char -> Text
+       
+  78.  -- ##Code
+       builtin type builtin.Code
+       
+  79.  -- ##Code.cache_
+       builtin.Code.cache_ : [(Link.Term, Code)]
+       ->{IO} [Link.Term]
+       
+  80.  -- ##Code.dependencies
+       builtin.Code.dependencies : Code -> [Link.Term]
+       
+  81.  -- ##Code.deserialize
+       builtin.Code.deserialize : Bytes -> Either Text Code
+       
+  82.  -- ##Code.display
+       builtin.Code.display : Text -> Code -> Text
+       
+  83.  -- ##Code.isMissing
+       builtin.Code.isMissing : Link.Term ->{IO} Boolean
+       
+  84.  -- ##Code.lookup
+       builtin.Code.lookup : Link.Term ->{IO} Optional Code
+       
+  85.  -- ##Code.serialize
+       builtin.Code.serialize : Code -> Bytes
+       
+  86.  -- ##Code.validate
+       builtin.Code.validate : [(Link.Term, Code)]
+       ->{IO} Optional Failure
+       
+  87.  -- #ldqsht5qvddaabskcad3idka4nqkv6lfncrp0s0o4rqbbnk1qvq269bueu7qobhvaf7gpluqtpn9bgp9u69jsntv0u6o4qtbktnfrs0
+       unique type builtin.ConsoleText
+       
+  88.  -- #ldqsht5qvddaabskcad3idka4nqkv6lfncrp0s0o4rqbbnk1qvq269bueu7qobhvaf7gpluqtpn9bgp9u69jsntv0u6o4qtbktnfrs0#5
+       builtin.ConsoleText.Background : Color
+       -> ConsoleText
+       -> ConsoleText
+       
+  89.  -- #ldqsht5qvddaabskcad3idka4nqkv6lfncrp0s0o4rqbbnk1qvq269bueu7qobhvaf7gpluqtpn9bgp9u69jsntv0u6o4qtbktnfrs0#0
+       builtin.ConsoleText.Bold : ConsoleText -> ConsoleText
+       
+  90.  -- #ldqsht5qvddaabskcad3idka4nqkv6lfncrp0s0o4rqbbnk1qvq269bueu7qobhvaf7gpluqtpn9bgp9u69jsntv0u6o4qtbktnfrs0#4
+       builtin.ConsoleText.Foreground : Color
+       -> ConsoleText
+       -> ConsoleText
+       
+  91.  -- #ldqsht5qvddaabskcad3idka4nqkv6lfncrp0s0o4rqbbnk1qvq269bueu7qobhvaf7gpluqtpn9bgp9u69jsntv0u6o4qtbktnfrs0#2
+       builtin.ConsoleText.Invert : ConsoleText -> ConsoleText
+       
+  92.  -- #ldqsht5qvddaabskcad3idka4nqkv6lfncrp0s0o4rqbbnk1qvq269bueu7qobhvaf7gpluqtpn9bgp9u69jsntv0u6o4qtbktnfrs0#3
+       builtin.ConsoleText.Plain : Text -> ConsoleText
+       
+  93.  -- #ldqsht5qvddaabskcad3idka4nqkv6lfncrp0s0o4rqbbnk1qvq269bueu7qobhvaf7gpluqtpn9bgp9u69jsntv0u6o4qtbktnfrs0#1
+       builtin.ConsoleText.Underline : ConsoleText
+       -> ConsoleText
+       
+  94.  -- #pgornst1pqaea8qmf8ckbtvrm7f6hn49djhffgebajmo12faf4jku63ftc9fp0r4k58e0qcdi77g08f34b2ihvsu97s48du6mfn7vko
+       unique type builtin.CopyrightHolder
+       
+  95.  -- #pgornst1pqaea8qmf8ckbtvrm7f6hn49djhffgebajmo12faf4jku63ftc9fp0r4k58e0qcdi77g08f34b2ihvsu97s48du6mfn7vko#0
+       builtin.CopyrightHolder.CopyrightHolder : GUID
+       -> Text
+       -> CopyrightHolder
+       
+  96.  -- #9jpkv5bb0d680ffs4f2j4lntj54m1iq9kaei8foqv5973i04jq9fugbn9msmpeiorjh4umhdeak625u53hejkvkm3buruj33msd1p6g
+       builtin.CopyrightHolder.guid : CopyrightHolder -> GUID
+       
+  97.  -- #6fhjsi02lnhvotndl6ufqnnsv20f3b9b4eg45n0rgo96m8f21dpqe5erb2dtn9nhdlp028vkock07r0foqune3jojhcrnmti9srsmdg
+       builtin.CopyrightHolder.guid.modify : (GUID ->{g} GUID)
+       -> CopyrightHolder
+       ->{g} CopyrightHolder
+       
+  98.  -- #1lk04okan4prc9kkh7julshv5l2q331pa5tf5f0ghm7ob5vkep3t6dnqejc8aju4i2vob6b5seliccer3a1kmtq4481i36alivhgdr0
+       builtin.CopyrightHolder.guid.set : GUID
+       -> CopyrightHolder
+       -> CopyrightHolder
+       
+  99.  -- #u1k741o71gg743tr5o7fc3joeqdm14qkd58cf2h2tmkpejr2uj3qhclvugqsgoighd7o4ijlrp17i6iadgsuhhhb56vi4j22i6c2lbo
+       builtin.CopyrightHolder.name : CopyrightHolder -> Text
+       
+  100. -- #3845ei99ci6p7dh3bcsctodd0otjtsntik5n0q7fpafo3s7v45a8nl7mk6ae7qot87jr9p4q3857tm4jtvmkb4s3rtn77t7goaphmf8
+       builtin.CopyrightHolder.name.modify : (Text ->{g} Text)
+       -> CopyrightHolder
+       ->{g} CopyrightHolder
+       
+  101. -- #2ehufgpsgnd2jq0i1topsir6dvv2m132dp2phs2bncnm6n9qrf7oaod6pbmvs9muihlq9dckpnughb3pajrmit7chdr67qco6tsd8j0
+       builtin.CopyrightHolder.name.set : Text
+       -> CopyrightHolder
+       -> CopyrightHolder
+       
+  102. -- ##crypto.hash
+       builtin.crypto.hash : HashAlgorithm -> a -> Bytes
+       
+  103. -- ##crypto.HashAlgorithm
+       builtin type builtin.crypto.HashAlgorithm
+       
+  104. -- ##crypto.HashAlgorithm.Blake2b_256
+       builtin.crypto.HashAlgorithm.Blake2b_256 : HashAlgorithm
+       
+  105. -- ##crypto.HashAlgorithm.Blake2b_512
+       builtin.crypto.HashAlgorithm.Blake2b_512 : HashAlgorithm
+       
+  106. -- ##crypto.HashAlgorithm.Blake2s_256
+       builtin.crypto.HashAlgorithm.Blake2s_256 : HashAlgorithm
+       
+  107. -- ##crypto.HashAlgorithm.Sha1
+       builtin.crypto.HashAlgorithm.Sha1 : HashAlgorithm
+       
+  108. -- ##crypto.HashAlgorithm.Sha2_256
+       builtin.crypto.HashAlgorithm.Sha2_256 : HashAlgorithm
+       
+  109. -- ##crypto.HashAlgorithm.Sha2_512
+       builtin.crypto.HashAlgorithm.Sha2_512 : HashAlgorithm
+       
+  110. -- ##crypto.HashAlgorithm.Sha3_256
+       builtin.crypto.HashAlgorithm.Sha3_256 : HashAlgorithm
+       
+  111. -- ##crypto.HashAlgorithm.Sha3_512
+       builtin.crypto.HashAlgorithm.Sha3_512 : HashAlgorithm
+       
+  112. -- ##crypto.hashBytes
+       builtin.crypto.hashBytes : HashAlgorithm
+       -> Bytes
+       -> Bytes
+       
+  113. -- ##crypto.hmac
+       builtin.crypto.hmac : HashAlgorithm
+       -> Bytes
+       -> a
+       -> Bytes
+       
+  114. -- ##crypto.hmacBytes
+       builtin.crypto.hmacBytes : HashAlgorithm
+       -> Bytes
+       -> Bytes
+       -> Bytes
+       
+  115. -- ##Debug.trace
+       builtin.Debug.trace : Text -> a -> ()
+       
+  116. -- ##Debug.watch
+       builtin.Debug.watch : Text -> a -> a
+       
+  117. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8
+       unique type builtin.Doc
+       
+  118. -- #baiqeiovdrs4ju0grn5q5akq64k4kuhgifqno52smkkttqg31jkgm3qa9o3ohe54fgpiigd1tj0an7rfveopfg622sjj9v9g44n27go
+       builtin.Doc.++ : Doc2 -> Doc2 -> Doc2
+       
+  119. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#0
+       builtin.Doc.Blob : Text -> Doc
+       
+  120. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#4
+       builtin.Doc.Evaluate : Link.Term -> Doc
+       
+  121. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#5
+       builtin.Doc.Join : [Doc] -> Doc
+       
+  122. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#1
+       builtin.Doc.Link : Link -> Doc
+       
+  123. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#3
+       builtin.Doc.Signature : Link.Term -> Doc
+       
+  124. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#2
+       builtin.Doc.Source : Link -> Doc
+       
+  125. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0
+       unique type builtin.Doc2
+       
+  126. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#27
+       builtin.Doc2.Anchor : Text -> Doc2 -> Doc2
+       
+  127. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#11
+       builtin.Doc2.Aside : Doc2 -> Doc2
+       
+  128. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#15
+       builtin.Doc2.Blankline : Doc2
+       
+  129. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#10
+       builtin.Doc2.Blockquote : Doc2 -> Doc2
+       
+  130. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#7
+       builtin.Doc2.Bold : Doc2 -> Doc2
+       
+  131. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#21
+       builtin.Doc2.BulletedList : [Doc2] -> Doc2
+       
+  132. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#3
+       builtin.Doc2.Callout : Optional Doc2 -> Doc2 -> Doc2
+       
+  133. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#6
+       builtin.Doc2.Code : Doc2 -> Doc2
+       
+  134. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#25
+       builtin.Doc2.CodeBlock : Text -> Doc2 -> Doc2
+       
+  135. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#24
+       builtin.Doc2.Column : [Doc2] -> Doc2
+       
+  136. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#0
+       builtin.Doc2.Folded : Boolean -> Doc2 -> Doc2 -> Doc2
+       
+  137. -- #h3gajooii4tsdseghcbcsq4qq7c33mtb71u5npg35b06mgv7v654g0n55gpq212umfmq7nvi11o28m1v13r5fto5g8ium3ee4qk1i68
+       unique type builtin.Doc2.FrontMatter
+       
+  138. -- #h3gajooii4tsdseghcbcsq4qq7c33mtb71u5npg35b06mgv7v654g0n55gpq212umfmq7nvi11o28m1v13r5fto5g8ium3ee4qk1i68#0
+       builtin.Doc2.FrontMatter.FrontMatter : [(Text, Text)]
+       -> FrontMatter
+       
+  139. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#12
+       builtin.Doc2.Group : Doc2 -> Doc2
+       
+  140. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#14
+       builtin.Doc2.Image : Doc2
+       -> Doc2
+       -> Optional Doc2
+       -> Doc2
+       
+  141. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#8
+       builtin.Doc2.Italic : Doc2 -> Doc2
+       
+  142. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#22
+       builtin.Doc2.Join : [Doc2] -> Doc2
+       
+  143. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#16
+       builtin.Doc2.Linebreak : Doc2
+       
+  144. -- #ut0tds116gr0soc9p6nroaalqlq423u1mao3p4jjultjmok3vbck69la7rs26duptji5v5hscijpek4hotu4krbfah8np3sntr87gb0
+       unique type builtin.Doc2.MediaSource
+       
+  145. -- #ut0tds116gr0soc9p6nroaalqlq423u1mao3p4jjultjmok3vbck69la7rs26duptji5v5hscijpek4hotu4krbfah8np3sntr87gb0#0
+       builtin.Doc2.MediaSource.MediaSource : Text
+       -> Optional Text
+       -> MediaSource
+       
+  146. -- #f7s1m2rs7ldj4idrcirtdqohsmc6n719e6cdqtgrhdkcrbm7971uvug6mvkrcc32qhdpo1og4oqin4rbmb2346m47ni24k5m3bpp3so
+       builtin.Doc2.MediaSource.mimeType : MediaSource
+       -> Optional Text
+       
+  147. -- #rncdj545f93f7nfrneabp6jlrjag766vr2n18al8u2a78ju5v746agg62r4ob8u6ue8eeac6nbg8apeii6qfasgfv2q2ap3h4sk1tdg
+       builtin.Doc2.MediaSource.mimeType.modify : (Optional Text
+       ->{g} Optional Text)
+       -> MediaSource
+       ->{g} MediaSource
+       
+  148. -- #54dl203thl9540r2jec546pishtg1b1ecb8vl6rqlbgf4h2rk04mrkdkqo4be82m8d3t2d0ef3gidjsn2r9u8ko7c9kvtavbqflim88
+       builtin.Doc2.MediaSource.mimeType.set : Optional Text
+       -> MediaSource
+       -> MediaSource
+       
+  149. -- #77l9vc6k6miu7pobamoasrpdm455ddgprgvfpg2di6liigijg70f4t3ppmpbs3j12kp93eep7u0e5r1bdq0niou0v85lo4aa5kek8mg
+       builtin.Doc2.MediaSource.sourceUrl : MediaSource -> Text
+       
+  150. -- #laoh1nhllsb9vf0reilmbmjutdei2b0vs0vse1s8j148imfi1m9uu4l17iqdt9r5575dap8jnlq6r48kdn6ob70iroso75erqfc74e0
+       builtin.Doc2.MediaSource.sourceUrl.modify : (Text
+       ->{g} Text)
+       -> MediaSource
+       ->{g} MediaSource
+       
+  151. -- #eb0dl30fc5k80vb0fna187vmag5ta1rgik40s1shlkng8stvvkt2gglecit8ajjd8vmfrtg8ki8ft3ife8rrqlcoit5161ekg6vhcfo
+       builtin.Doc2.MediaSource.sourceUrl.set : Text
+       -> MediaSource
+       -> MediaSource
+       
+  152. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#2
+       builtin.Doc2.NamedLink : Doc2 -> Doc2 -> Doc2
+       
+  153. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#4
+       builtin.Doc2.NumberedList : Nat -> [Doc2] -> Doc2
+       
+  154. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#20
+       builtin.Doc2.Paragraph : [Doc2] -> Doc2
+       
+  155. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#13
+       builtin.Doc2.Section : Doc2 -> [Doc2] -> Doc2
+       
+  156. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#17
+       builtin.Doc2.SectionBreak : Doc2
+       
+  157. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#5
+       builtin.Doc2.Special : SpecialForm -> Doc2
+       
+  158. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0
+       unique type builtin.Doc2.SpecialForm
+       
+  159. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#4
+       builtin.Doc2.SpecialForm.Embed : Any -> SpecialForm
+       
+  160. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#5
+       builtin.Doc2.SpecialForm.EmbedInline : Any -> SpecialForm
+       
+  161. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#9
+       builtin.Doc2.SpecialForm.Eval : Doc2.Term -> SpecialForm
+       
+  162. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#10
+       builtin.Doc2.SpecialForm.EvalInline : Doc2.Term
+       -> SpecialForm
+       
+  163. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#0
+       builtin.Doc2.SpecialForm.Example : Nat
+       -> Doc2.Term
+       -> SpecialForm
+       
+  164. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#1
+       builtin.Doc2.SpecialForm.ExampleBlock : Nat
+       -> Doc2.Term
+       -> SpecialForm
+       
+  165. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#7
+       builtin.Doc2.SpecialForm.FoldedSource : [( Either
+         Type Doc2.Term,
+         [Doc2.Term])]
+       -> SpecialForm
+       
+  166. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#3
+       builtin.Doc2.SpecialForm.Link : Either Type Doc2.Term
+       -> SpecialForm
+       
+  167. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#2
+       builtin.Doc2.SpecialForm.Signature : [Doc2.Term]
+       -> SpecialForm
+       
+  168. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#8
+       builtin.Doc2.SpecialForm.SignatureInline : Doc2.Term
+       -> SpecialForm
+       
+  169. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#6
+       builtin.Doc2.SpecialForm.Source : [( Either
+         Type Doc2.Term,
+         [Doc2.Term])]
+       -> SpecialForm
+       
+  170. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#9
+       builtin.Doc2.Strikethrough : Doc2 -> Doc2
+       
+  171. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#26
+       builtin.Doc2.Style : Text -> Doc2 -> Doc2
+       
+  172. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#18
+       builtin.Doc2.Table : [[Doc2]] -> Doc2
+       
+  173. -- #s0an21vospbdlsbddiskuvt3ngbf00n78sip2o1mnp4jgp16i7sursbm14bf8ap7osphqbis2lduep3i29b7diu8sf03f8tlqd7rgcg
+       unique type builtin.Doc2.Term
+       
+  174. -- #tu2du1k0lrp6iddor1aotdhdgn1j2b86r22tes3o3hka0bv4b4otlbimj88ttrdnbuacokk768k4e54795of8gnosopjirl4jm42g28
+       builtin.Doc2.term : '{g} a -> Doc2.Term
+       
+  175. -- #s0an21vospbdlsbddiskuvt3ngbf00n78sip2o1mnp4jgp16i7sursbm14bf8ap7osphqbis2lduep3i29b7diu8sf03f8tlqd7rgcg#0
+       builtin.Doc2.Term.Term : Any -> Doc2.Term
+       
+  176. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#1
+       builtin.Doc2.Tooltip : Doc2 -> Doc2 -> Doc2
+       
+  177. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#23
+       builtin.Doc2.UntitledSection : [Doc2] -> Doc2
+       
+  178. -- #794fndq1941e2khqv5uh7fmk9es2g4fkp8pr48objgs6blc1pqsdt2ab4o79noril2l7s70iu2eimn1smpd8t40j4g18btian8a2pt0
+       unique type builtin.Doc2.Video
+       
+  179. -- #46er7fsgre91rer0mpk6vhaa2vie19i0piubvtnfmt3vq7odcjfr6tlf0mc57q4jnij9rkolpekjd6dpqdotn41guk9lp9qioa88m58
+       builtin.Doc2.Video.config : Video -> [(Text, Text)]
+       
+  180. -- #vld47vp37855gceko81jj00j5t0mf5p137ub57094585aq3jfevq0ob03fot9d73p97r2pj0alel9e6a7lqcc7mue0ogefshg991e6g
+       builtin.Doc2.Video.config.modify : ([(Text, Text)]
+       ->{g} [(Text, Text)])
+       -> Video
+       ->{g} Video
+       
+  181. -- #ll9hiqi1s63ragrv9ul3ouu2rvpjkok4gdmgqs6cl8j4fgdmqlgikc5lseoe94e9fvrughjfetlcsn7gc5ed8prtnljfo5j6r1vveq8
+       builtin.Doc2.Video.config.set : [(Text, Text)]
+       -> Video
+       -> Video
+       
+  182. -- #a454aldsi00l8kh10bhi6d4phtdr9ht0es6apr05jert6oo4vstm5cdr4ee2k0srted1urqgvkrcoihjvmus6tph92v628f3lr9b92o
+       builtin.Doc2.Video.sources : Video -> [MediaSource]
+       
+  183. -- #nm77894uq9g3kv5mo7ubuptpimt53jml7jt825lr83gu41tqcfpg2krcesn7p5aaea107su7brg2gm8vn1l0mabpfnpbcdi4onlatvo
+       builtin.Doc2.Video.sources.modify : ([MediaSource]
+       ->{g} [MediaSource])
+       -> Video
+       ->{g} Video
+       
+  184. -- #5r0bgv3t666s4lh274mvtk13jqu1doc26ki2k8t2rpophrq2hjran1qodeobf3trlnniarjehr1rgl6scn6mhqpmcokdafja3b54jt0
+       builtin.Doc2.Video.sources.set : [MediaSource]
+       -> Video
+       -> Video
+       
+  185. -- #794fndq1941e2khqv5uh7fmk9es2g4fkp8pr48objgs6blc1pqsdt2ab4o79noril2l7s70iu2eimn1smpd8t40j4g18btian8a2pt0#0
+       builtin.Doc2.Video.Video : [MediaSource]
+       -> [(Text, Text)]
+       -> Video
+       
+  186. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#19
+       builtin.Doc2.Word : Text -> Doc2
+       
+  187. -- #0o7mf021foma9acqdaibmlh1jidlijq08uf7f5se9tssttqs546pfunjpk6s31mqoq8s2o1natede8hkk6he45l95fibglidikt44v8
+       structural type builtin.Either a b
+       
+  188. -- #0o7mf021foma9acqdaibmlh1jidlijq08uf7f5se9tssttqs546pfunjpk6s31mqoq8s2o1natede8hkk6he45l95fibglidikt44v8#1
+       builtin.Either.Left : a -> Either a b
+       
+  189. -- #u3cen22u7p8dfj0nc45j0pg4lskqjjisflm3jq0957756d23lq53tf27vg37g6jnddh8o70grvotcvrfc1fnpog0rlfsvfvjrk1s94g
+       builtin.Either.mapRight : (a ->{g} b)
+       -> Either e a
+       ->{g} Either e b
+       
+  190. -- #0o7mf021foma9acqdaibmlh1jidlijq08uf7f5se9tssttqs546pfunjpk6s31mqoq8s2o1natede8hkk6he45l95fibglidikt44v8#0
+       builtin.Either.Right : b -> Either a b
+       
+  191. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng
+       structural ability builtin.Exception
+       structural ability Exception
+       
+  192. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng#0
+       builtin.Exception.raise,
+       Exception.raise : Failure
+       ->{Exception} x
+       
+  193. -- ##Float
+       builtin type builtin.Float
+       
+  194. -- ##Float.*
+       builtin.Float.* : Float -> Float -> Float
+       
+  195. -- ##Float.+
+       builtin.Float.+ : Float -> Float -> Float
+       
+  196. -- ##Float.-
+       builtin.Float.- : Float -> Float -> Float
+       
+  197. -- ##Float./
+       builtin.Float./ : Float -> Float -> Float
+       
+  198. -- ##Float.abs
+       builtin.Float.abs : Float -> Float
+       
+  199. -- ##Float.acos
+       builtin.Float.acos : Float -> Float
+       
+  200. -- ##Float.acosh
+       builtin.Float.acosh : Float -> Float
+       
+  201. -- ##Float.asin
+       builtin.Float.asin : Float -> Float
+       
+  202. -- ##Float.asinh
+       builtin.Float.asinh : Float -> Float
+       
+  203. -- ##Float.atan
+       builtin.Float.atan : Float -> Float
+       
+  204. -- ##Float.atan2
+       builtin.Float.atan2 : Float -> Float -> Float
+       
+  205. -- ##Float.atanh
+       builtin.Float.atanh : Float -> Float
+       
+  206. -- ##Float.ceiling
+       builtin.Float.ceiling : Float -> Int
+       
+  207. -- ##Float.cos
+       builtin.Float.cos : Float -> Float
+       
+  208. -- ##Float.cosh
+       builtin.Float.cosh : Float -> Float
+       
+  209. -- ##Float.==
+       builtin.Float.eq : Float -> Float -> Boolean
+       
+  210. -- ##Float.exp
+       builtin.Float.exp : Float -> Float
+       
+  211. -- ##Float.floor
+       builtin.Float.floor : Float -> Int
+       
+  212. -- ##Float.fromRepresentation
+       builtin.Float.fromRepresentation : Nat -> Float
+       
+  213. -- ##Float.fromText
+       builtin.Float.fromText : Text -> Optional Float
+       
+  214. -- ##Float.>
+       builtin.Float.gt : Float -> Float -> Boolean
+       
+  215. -- ##Float.>=
+       builtin.Float.gteq : Float -> Float -> Boolean
+       
+  216. -- ##Float.log
+       builtin.Float.log : Float -> Float
+       
+  217. -- ##Float.logBase
+       builtin.Float.logBase : Float -> Float -> Float
+       
+  218. -- ##Float.<
+       builtin.Float.lt : Float -> Float -> Boolean
+       
+  219. -- ##Float.<=
+       builtin.Float.lteq : Float -> Float -> Boolean
+       
+  220. -- ##Float.max
+       builtin.Float.max : Float -> Float -> Float
+       
+  221. -- ##Float.min
+       builtin.Float.min : Float -> Float -> Float
+       
+  222. -- ##Float.pow
+       builtin.Float.pow : Float -> Float -> Float
+       
+  223. -- ##Float.round
+       builtin.Float.round : Float -> Int
+       
+  224. -- ##Float.sin
+       builtin.Float.sin : Float -> Float
+       
+  225. -- ##Float.sinh
+       builtin.Float.sinh : Float -> Float
+       
+  226. -- ##Float.sqrt
+       builtin.Float.sqrt : Float -> Float
+       
+  227. -- ##Float.tan
+       builtin.Float.tan : Float -> Float
+       
+  228. -- ##Float.tanh
+       builtin.Float.tanh : Float -> Float
+       
+  229. -- ##Float.toRepresentation
+       builtin.Float.toRepresentation : Float -> Nat
+       
+  230. -- ##Float.toText
+       builtin.Float.toText : Float -> Text
+       
+  231. -- ##Float.truncate
+       builtin.Float.truncate : Float -> Int
+       
+  232. -- #hqectlr3gt02r6r984b3627eg5bq3d82lab5q18e3ql09u1ka8dblf5k50ae0q0d8gk87udqd7b6767q86gogdt8ghpdiq77gk6blr8
+       unique type builtin.GUID
+       
+  233. -- #hqectlr3gt02r6r984b3627eg5bq3d82lab5q18e3ql09u1ka8dblf5k50ae0q0d8gk87udqd7b6767q86gogdt8ghpdiq77gk6blr8#0
+       builtin.GUID.GUID : Bytes -> GUID
+       
+  234. -- ##Handle.toText
+       builtin.Handle.toText : Handle -> Text
+       
+  235. -- ##ImmutableArray
+       builtin type builtin.ImmutableArray
+       
+  236. -- ##ImmutableArray.copyTo!
+       builtin.ImmutableArray.copyTo! : MutableArray g a
+       -> Nat
+       -> ImmutableArray a
+       -> Nat
+       -> Nat
+       ->{g, Exception} ()
+       
+  237. -- ##ImmutableArray.read
+       builtin.ImmutableArray.read : ImmutableArray a
+       -> Nat
+       ->{Exception} a
+       
+  238. -- ##ImmutableArray.size
+       builtin.ImmutableArray.size : ImmutableArray a -> Nat
+       
+  239. -- ##ImmutableByteArray
+       builtin type builtin.ImmutableByteArray
+       
+  240. -- ##ImmutableByteArray.copyTo!
+       builtin.ImmutableByteArray.copyTo! : MutableByteArray g
+       -> Nat
+       -> ImmutableByteArray
+       -> Nat
+       -> Nat
+       ->{g, Exception} ()
+       
+  241. -- ##ImmutableByteArray.read16be
+       builtin.ImmutableByteArray.read16be : ImmutableByteArray
+       -> Nat
+       ->{Exception} Nat
+       
+  242. -- ##ImmutableByteArray.read24be
+       builtin.ImmutableByteArray.read24be : ImmutableByteArray
+       -> Nat
+       ->{Exception} Nat
+       
+  243. -- ##ImmutableByteArray.read32be
+       builtin.ImmutableByteArray.read32be : ImmutableByteArray
+       -> Nat
+       ->{Exception} Nat
+       
+  244. -- ##ImmutableByteArray.read40be
+       builtin.ImmutableByteArray.read40be : ImmutableByteArray
+       -> Nat
+       ->{Exception} Nat
+       
+  245. -- ##ImmutableByteArray.read64be
+       builtin.ImmutableByteArray.read64be : ImmutableByteArray
+       -> Nat
+       ->{Exception} Nat
+       
+  246. -- ##ImmutableByteArray.read8
+       builtin.ImmutableByteArray.read8 : ImmutableByteArray
+       -> Nat
+       ->{Exception} Nat
+       
+  247. -- ##ImmutableByteArray.size
+       builtin.ImmutableByteArray.size : ImmutableByteArray
+       -> Nat
+       
+  248. -- ##Int
+       builtin type builtin.Int
+       
+  249. -- ##Int.*
+       builtin.Int.* : Int -> Int -> Int
+       
+  250. -- ##Int.+
+       builtin.Int.+ : Int -> Int -> Int
+       
+  251. -- ##Int.-
+       builtin.Int.- : Int -> Int -> Int
+       
+  252. -- ##Int./
+       builtin.Int./ : Int -> Int -> Int
+       
+  253. -- ##Int.and
+       builtin.Int.and : Int -> Int -> Int
+       
+  254. -- ##Int.complement
+       builtin.Int.complement : Int -> Int
+       
+  255. -- ##Int.==
+       builtin.Int.eq : Int -> Int -> Boolean
+       
+  256. -- ##Int.fromRepresentation
+       builtin.Int.fromRepresentation : Nat -> Int
+       
+  257. -- ##Int.fromText
+       builtin.Int.fromText : Text -> Optional Int
+       
+  258. -- ##Int.>
+       builtin.Int.gt : Int -> Int -> Boolean
+       
+  259. -- ##Int.>=
+       builtin.Int.gteq : Int -> Int -> Boolean
+       
+  260. -- ##Int.increment
+       builtin.Int.increment : Int -> Int
+       
+  261. -- ##Int.isEven
+       builtin.Int.isEven : Int -> Boolean
+       
+  262. -- ##Int.isOdd
+       builtin.Int.isOdd : Int -> Boolean
+       
+  263. -- ##Int.leadingZeros
+       builtin.Int.leadingZeros : Int -> Nat
+       
+  264. -- ##Int.<
+       builtin.Int.lt : Int -> Int -> Boolean
+       
+  265. -- ##Int.<=
+       builtin.Int.lteq : Int -> Int -> Boolean
+       
+  266. -- ##Int.mod
+       builtin.Int.mod : Int -> Int -> Int
+       
+  267. -- ##Int.negate
+       builtin.Int.negate : Int -> Int
+       
+  268. -- ##Int.or
+       builtin.Int.or : Int -> Int -> Int
+       
+  269. -- ##Int.popCount
+       builtin.Int.popCount : Int -> Nat
+       
+  270. -- ##Int.pow
+       builtin.Int.pow : Int -> Nat -> Int
+       
+  271. -- ##Int.shiftLeft
+       builtin.Int.shiftLeft : Int -> Nat -> Int
+       
+  272. -- ##Int.shiftRight
+       builtin.Int.shiftRight : Int -> Nat -> Int
+       
+  273. -- ##Int.signum
+       builtin.Int.signum : Int -> Int
+       
+  274. -- ##Int.toFloat
+       builtin.Int.toFloat : Int -> Float
+       
+  275. -- ##Int.toRepresentation
+       builtin.Int.toRepresentation : Int -> Nat
+       
+  276. -- ##Int.toText
+       builtin.Int.toText : Int -> Text
+       
+  277. -- ##Int.trailingZeros
+       builtin.Int.trailingZeros : Int -> Nat
+       
+  278. -- ##Int.truncate0
+       builtin.Int.truncate0 : Int -> Nat
+       
+  279. -- ##Int.xor
+       builtin.Int.xor : Int -> Int -> Int
+       
+  280. -- #s6ijmhqkkaus51chjgahogc7sdrqj9t66i599le2k7ts6fkl216f997hbses3mqk6a21vaj3cm1mertbldn0g503jt522vfo4rfv720
+       unique type builtin.io2.ArithmeticFailure
+       
+  281. -- #6dtvam7msqc64dimm8p0d8ehdf0330o4qbd2fdafb11jj1c2rg4ke3jdcmbgo6s4pf2jgm0vb76jeavv4ba6ht71t74p963a1miekag
+       unique type builtin.io2.ArrayFailure
+       
+  282. -- #dc6n5ebu839ik3b6ohmnqm6p0cifn7o94em1g41mjp4ae0gmv3b4rupba499lbasfrp4bqce9u4hd6518unlbg8vk993c0q6rigos98
+       unique type builtin.io2.BufferMode
+       
+  283. -- #dc6n5ebu839ik3b6ohmnqm6p0cifn7o94em1g41mjp4ae0gmv3b4rupba499lbasfrp4bqce9u4hd6518unlbg8vk993c0q6rigos98#2
+       builtin.io2.BufferMode.BlockBuffering : BufferMode
+       
+  284. -- #dc6n5ebu839ik3b6ohmnqm6p0cifn7o94em1g41mjp4ae0gmv3b4rupba499lbasfrp4bqce9u4hd6518unlbg8vk993c0q6rigos98#1
+       builtin.io2.BufferMode.LineBuffering : BufferMode
+       
+  285. -- #dc6n5ebu839ik3b6ohmnqm6p0cifn7o94em1g41mjp4ae0gmv3b4rupba499lbasfrp4bqce9u4hd6518unlbg8vk993c0q6rigos98#0
+       builtin.io2.BufferMode.NoBuffering : BufferMode
+       
+  286. -- #dc6n5ebu839ik3b6ohmnqm6p0cifn7o94em1g41mjp4ae0gmv3b4rupba499lbasfrp4bqce9u4hd6518unlbg8vk993c0q6rigos98#3
+       builtin.io2.BufferMode.SizedBlockBuffering : Nat
+       -> BufferMode
+       
+  287. -- ##Clock.internals.monotonic.v1
+       builtin.io2.Clock.internals.monotonic : '{IO} Either
+         Failure TimeSpec
+       
+  288. -- ##Clock.internals.nsec.v1
+       builtin.io2.Clock.internals.nsec : TimeSpec -> Nat
+       
+  289. -- ##Clock.internals.processCPUTime.v1
+       builtin.io2.Clock.internals.processCPUTime : '{IO} Either
+         Failure TimeSpec
+       
+  290. -- ##Clock.internals.realtime.v1
+       builtin.io2.Clock.internals.realtime : '{IO} Either
+         Failure TimeSpec
+       
+  291. -- ##Clock.internals.sec.v1
+       builtin.io2.Clock.internals.sec : TimeSpec -> Int
+       
+  292. -- ##Clock.internals.threadCPUTime.v1
+       builtin.io2.Clock.internals.threadCPUTime : '{IO} Either
+         Failure TimeSpec
+       
+  293. -- ##TimeSpec
+       builtin type builtin.io2.Clock.internals.TimeSpec
+       
+  294. -- #r29dja8j9dmjjp45trccchaata8eo1h6d6haar1eai74pq1jt4m7u3ldhlq79f7phfo57eq4bau39vqotl2h63k7ff1m5sj5o9ajuf8
+       unique type builtin.io2.Failure
+       
+  295. -- #r29dja8j9dmjjp45trccchaata8eo1h6d6haar1eai74pq1jt4m7u3ldhlq79f7phfo57eq4bau39vqotl2h63k7ff1m5sj5o9ajuf8#0
+       builtin.io2.Failure.Failure : Type
+       -> Text
+       -> Any
+       -> Failure
+       
+  296. -- #jhnlob35huv3rr7jg6aa4gtd8okhprla7gvlq8io429qita8vj7k696n9jvp4b8ct9i2pc1jodb8ap2bipqtgp138epdgfcth7vqvt8
+       unique type builtin.io2.FileMode
+       
+  297. -- #jhnlob35huv3rr7jg6aa4gtd8okhprla7gvlq8io429qita8vj7k696n9jvp4b8ct9i2pc1jodb8ap2bipqtgp138epdgfcth7vqvt8#2
+       builtin.io2.FileMode.Append : FileMode
+       
+  298. -- #jhnlob35huv3rr7jg6aa4gtd8okhprla7gvlq8io429qita8vj7k696n9jvp4b8ct9i2pc1jodb8ap2bipqtgp138epdgfcth7vqvt8#0
+       builtin.io2.FileMode.Read : FileMode
+       
+  299. -- #jhnlob35huv3rr7jg6aa4gtd8okhprla7gvlq8io429qita8vj7k696n9jvp4b8ct9i2pc1jodb8ap2bipqtgp138epdgfcth7vqvt8#3
+       builtin.io2.FileMode.ReadWrite : FileMode
+       
+  300. -- #jhnlob35huv3rr7jg6aa4gtd8okhprla7gvlq8io429qita8vj7k696n9jvp4b8ct9i2pc1jodb8ap2bipqtgp138epdgfcth7vqvt8#1
+       builtin.io2.FileMode.Write : FileMode
+       
+  301. -- ##Handle
+       builtin type builtin.io2.Handle
+       
+  302. -- ##IO
+       builtin type builtin.io2.IO
+       
+  303. -- ##IO.array
+       builtin.io2.IO.array : Nat ->{IO} MutableArray {IO} a
+       
+  304. -- ##IO.arrayOf
+       builtin.io2.IO.arrayOf : a
+       -> Nat
+       ->{IO} MutableArray {IO} a
+       
+  305. -- ##IO.bytearray
+       builtin.io2.IO.bytearray : Nat
+       ->{IO} MutableByteArray {IO}
+       
+  306. -- ##IO.bytearrayOf
+       builtin.io2.IO.bytearrayOf : Nat
+       -> Nat
+       ->{IO} MutableByteArray {IO}
+       
+  307. -- ##IO.clientSocket.impl.v3
+       builtin.io2.IO.clientSocket.impl : Text
+       -> Text
+       ->{IO} Either Failure Socket
+       
+  308. -- ##IO.closeFile.impl.v3
+       builtin.io2.IO.closeFile.impl : Handle
+       ->{IO} Either Failure ()
+       
+  309. -- ##IO.closeSocket.impl.v3
+       builtin.io2.IO.closeSocket.impl : Socket
+       ->{IO} Either Failure ()
+       
+  310. -- ##IO.createDirectory.impl.v3
+       builtin.io2.IO.createDirectory.impl : Text
+       ->{IO} Either Failure ()
+       
+  311. -- ##IO.createTempDirectory.impl.v3
+       builtin.io2.IO.createTempDirectory.impl : Text
+       ->{IO} Either Failure Text
+       
+  312. -- ##IO.delay.impl.v3
+       builtin.io2.IO.delay.impl : Nat ->{IO} Either Failure ()
+       
+  313. -- ##IO.directoryContents.impl.v3
+       builtin.io2.IO.directoryContents.impl : Text
+       ->{IO} Either Failure [Text]
+       
+  314. -- ##IO.fileExists.impl.v3
+       builtin.io2.IO.fileExists.impl : Text
+       ->{IO} Either Failure Boolean
+       
+  315. -- ##IO.forkComp.v2
+       builtin.io2.IO.forkComp : '{IO} a ->{IO} ThreadId
+       
+  316. -- ##IO.getArgs.impl.v1
+       builtin.io2.IO.getArgs.impl : '{IO} Either Failure [Text]
+       
+  317. -- ##IO.getBuffering.impl.v3
+       builtin.io2.IO.getBuffering.impl : Handle
+       ->{IO} Either Failure BufferMode
+       
+  318. -- ##IO.getBytes.impl.v3
+       builtin.io2.IO.getBytes.impl : Handle
+       -> Nat
+       ->{IO} Either Failure Bytes
+       
+  319. -- ##IO.getChar.impl.v1
+       builtin.io2.IO.getChar.impl : Handle
+       ->{IO} Either Failure Char
+       
+  320. -- ##IO.getCurrentDirectory.impl.v3
+       builtin.io2.IO.getCurrentDirectory.impl : '{IO} Either
+         Failure Text
+       
+  321. -- ##IO.getEcho.impl.v1
+       builtin.io2.IO.getEcho.impl : Handle
+       ->{IO} Either Failure Boolean
+       
+  322. -- ##IO.getEnv.impl.v1
+       builtin.io2.IO.getEnv.impl : Text
+       ->{IO} Either Failure Text
+       
+  323. -- ##IO.getFileSize.impl.v3
+       builtin.io2.IO.getFileSize.impl : Text
+       ->{IO} Either Failure Nat
+       
+  324. -- ##IO.getFileTimestamp.impl.v3
+       builtin.io2.IO.getFileTimestamp.impl : Text
+       ->{IO} Either Failure Nat
+       
+  325. -- ##IO.getLine.impl.v1
+       builtin.io2.IO.getLine.impl : Handle
+       ->{IO} Either Failure Text
+       
+  326. -- ##IO.getSomeBytes.impl.v1
+       builtin.io2.IO.getSomeBytes.impl : Handle
+       -> Nat
+       ->{IO} Either Failure Bytes
+       
+  327. -- ##IO.getTempDirectory.impl.v3
+       builtin.io2.IO.getTempDirectory.impl : '{IO} Either
+         Failure Text
+       
+  328. -- ##IO.handlePosition.impl.v3
+       builtin.io2.IO.handlePosition.impl : Handle
+       ->{IO} Either Failure Nat
+       
+  329. -- ##IO.isDirectory.impl.v3
+       builtin.io2.IO.isDirectory.impl : Text
+       ->{IO} Either Failure Boolean
+       
+  330. -- ##IO.isFileEOF.impl.v3
+       builtin.io2.IO.isFileEOF.impl : Handle
+       ->{IO} Either Failure Boolean
+       
+  331. -- ##IO.isFileOpen.impl.v3
+       builtin.io2.IO.isFileOpen.impl : Handle
+       ->{IO} Either Failure Boolean
+       
+  332. -- ##IO.isSeekable.impl.v3
+       builtin.io2.IO.isSeekable.impl : Handle
+       ->{IO} Either Failure Boolean
+       
+  333. -- ##IO.kill.impl.v3
+       builtin.io2.IO.kill.impl : ThreadId
+       ->{IO} Either Failure ()
+       
+  334. -- ##IO.listen.impl.v3
+       builtin.io2.IO.listen.impl : Socket
+       ->{IO} Either Failure ()
+       
+  335. -- ##IO.openFile.impl.v3
+       builtin.io2.IO.openFile.impl : Text
+       -> FileMode
+       ->{IO} Either Failure Handle
+       
+  336. -- ##IO.putBytes.impl.v3
+       builtin.io2.IO.putBytes.impl : Handle
+       -> Bytes
+       ->{IO} Either Failure ()
+       
+  337. -- ##IO.ready.impl.v1
+       builtin.io2.IO.ready.impl : Handle
+       ->{IO} Either Failure Boolean
+       
+  338. -- ##IO.ref
+       builtin.io2.IO.ref : a ->{IO} Ref {IO} a
+       
+  339. -- ##IO.removeDirectory.impl.v3
+       builtin.io2.IO.removeDirectory.impl : Text
+       ->{IO} Either Failure ()
+       
+  340. -- ##IO.removeFile.impl.v3
+       builtin.io2.IO.removeFile.impl : Text
+       ->{IO} Either Failure ()
+       
+  341. -- ##IO.renameDirectory.impl.v3
+       builtin.io2.IO.renameDirectory.impl : Text
+       -> Text
+       ->{IO} Either Failure ()
+       
+  342. -- ##IO.renameFile.impl.v3
+       builtin.io2.IO.renameFile.impl : Text
+       -> Text
+       ->{IO} Either Failure ()
+       
+  343. -- ##IO.seekHandle.impl.v3
+       builtin.io2.IO.seekHandle.impl : Handle
+       -> SeekMode
+       -> Int
+       ->{IO} Either Failure ()
+       
+  344. -- ##IO.serverSocket.impl.v3
+       builtin.io2.IO.serverSocket.impl : Optional Text
+       -> Text
+       ->{IO} Either Failure Socket
+       
+  345. -- ##IO.setBuffering.impl.v3
+       builtin.io2.IO.setBuffering.impl : Handle
+       -> BufferMode
+       ->{IO} Either Failure ()
+       
+  346. -- ##IO.setCurrentDirectory.impl.v3
+       builtin.io2.IO.setCurrentDirectory.impl : Text
+       ->{IO} Either Failure ()
+       
+  347. -- ##IO.setEcho.impl.v1
+       builtin.io2.IO.setEcho.impl : Handle
+       -> Boolean
+       ->{IO} Either Failure ()
+       
+  348. -- ##IO.socketAccept.impl.v3
+       builtin.io2.IO.socketAccept.impl : Socket
+       ->{IO} Either Failure Socket
+       
+  349. -- ##IO.socketPort.impl.v3
+       builtin.io2.IO.socketPort.impl : Socket
+       ->{IO} Either Failure Nat
+       
+  350. -- ##IO.socketReceive.impl.v3
+       builtin.io2.IO.socketReceive.impl : Socket
+       -> Nat
+       ->{IO} Either Failure Bytes
+       
+  351. -- ##IO.socketSend.impl.v3
+       builtin.io2.IO.socketSend.impl : Socket
+       -> Bytes
+       ->{IO} Either Failure ()
+       
+  352. -- ##IO.stdHandle
+       builtin.io2.IO.stdHandle : StdHandle -> Handle
+       
+  353. -- ##IO.systemTime.impl.v3
+       builtin.io2.IO.systemTime.impl : '{IO} Either Failure Nat
+       
+  354. -- ##IO.systemTimeMicroseconds.v1
+       builtin.io2.IO.systemTimeMicroseconds : '{IO} Int
+       
+  355. -- ##IO.tryEval
+       builtin.io2.IO.tryEval : '{IO} a ->{IO, Exception} a
+       
+  356. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0
+       unique type builtin.io2.IOError
+       
+  357. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#0
+       builtin.io2.IOError.AlreadyExists : IOError
+       
+  358. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#4
+       builtin.io2.IOError.EOF : IOError
+       
+  359. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#5
+       builtin.io2.IOError.IllegalOperation : IOError
+       
+  360. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#1
+       builtin.io2.IOError.NoSuchThing : IOError
+       
+  361. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#6
+       builtin.io2.IOError.PermissionDenied : IOError
+       
+  362. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#2
+       builtin.io2.IOError.ResourceBusy : IOError
+       
+  363. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#3
+       builtin.io2.IOError.ResourceExhausted : IOError
+       
+  364. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#7
+       builtin.io2.IOError.UserError : IOError
+       
+  365. -- #6ivk1e38hh0l9gcl8fn4mhf8bmak3qaji36vevg5e1n16ju5i4cl9u5gmqi7u16b907rd98gd60pouma892efbqt2ri58tmu99hp77g
+       unique type builtin.io2.IOFailure
+       
+  366. -- #574pvphqahl981k517dtrqtq812m05h3hj6t2bt9sn3pknenfik1krscfdb6r66nf1sm7g3r1r56k0c6ob7vg4opfq4gihi8njbnhsg
+       unique type builtin.io2.MiscFailure
+       
+  367. -- ##MVar
+       builtin type builtin.io2.MVar
+       
+  368. -- ##MVar.isEmpty
+       builtin.io2.MVar.isEmpty : MVar a ->{IO} Boolean
+       
+  369. -- ##MVar.new
+       builtin.io2.MVar.new : a ->{IO} MVar a
+       
+  370. -- ##MVar.newEmpty.v2
+       builtin.io2.MVar.newEmpty : '{IO} MVar a
+       
+  371. -- ##MVar.put.impl.v3
+       builtin.io2.MVar.put.impl : MVar a
+       -> a
+       ->{IO} Either Failure ()
+       
+  372. -- ##MVar.read.impl.v3
+       builtin.io2.MVar.read.impl : MVar a
+       ->{IO} Either Failure a
+       
+  373. -- ##MVar.swap.impl.v3
+       builtin.io2.MVar.swap.impl : MVar a
+       -> a
+       ->{IO} Either Failure a
+       
+  374. -- ##MVar.take.impl.v3
+       builtin.io2.MVar.take.impl : MVar a
+       ->{IO} Either Failure a
+       
+  375. -- ##MVar.tryPut.impl.v3
+       builtin.io2.MVar.tryPut.impl : MVar a
+       -> a
+       ->{IO} Either Failure Boolean
+       
+  376. -- ##MVar.tryRead.impl.v3
+       builtin.io2.MVar.tryRead.impl : MVar a
+       ->{IO} Either Failure (Optional a)
+       
+  377. -- ##MVar.tryTake
+       builtin.io2.MVar.tryTake : MVar a ->{IO} Optional a
+       
+  378. -- #vph2eas3lf2gi259f3khlrspml3id2l8u0ru07kb5fd833h238jk4iauju0b6decth9i3nao5jkf5eej1e1kovgmu5tghhh8jq3i7p8
+       unique type builtin.io2.RuntimeFailure
+       
+  379. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40
+       unique type builtin.io2.SeekMode
+       
+  380. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40#0
+       builtin.io2.SeekMode.AbsoluteSeek : SeekMode
+       
+  381. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40#1
+       builtin.io2.SeekMode.RelativeSeek : SeekMode
+       
+  382. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40#2
+       builtin.io2.SeekMode.SeekFromEnd : SeekMode
+       
+  383. -- ##Socket
+       builtin type builtin.io2.Socket
+       
+  384. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8
+       unique type builtin.io2.StdHandle
+       
+  385. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8#2
+       builtin.io2.StdHandle.StdErr : StdHandle
+       
+  386. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8#0
+       builtin.io2.StdHandle.StdIn : StdHandle
+       
+  387. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8#1
+       builtin.io2.StdHandle.StdOut : StdHandle
+       
+  388. -- ##STM
+       builtin type builtin.io2.STM
+       
+  389. -- ##STM.atomically
+       builtin.io2.STM.atomically : '{STM} a ->{IO} a
+       
+  390. -- ##STM.retry
+       builtin.io2.STM.retry : '{STM} a
+       
+  391. -- #cggbdfff21ac5uedf4qvn4to83clinvhsovrila35u7f7e73g4l6hoj8pjmjnk713a8luhnn4bi1j9ai1nl0can1un66hvg230eog9g
+       unique type builtin.io2.STMFailure
+       
+  392. -- ##ThreadId
+       builtin type builtin.io2.ThreadId
+       
+  393. -- ##Tls
+       builtin type builtin.io2.Tls
+       
+  394. -- ##Tls.Cipher
+       builtin type builtin.io2.Tls.Cipher
+       
+  395. -- ##Tls.ClientConfig
+       builtin type builtin.io2.Tls.ClientConfig
+       
+  396. -- ##Tls.ClientConfig.certificates.set
+       builtin.io2.Tls.ClientConfig.certificates.set : [SignedCert]
+       -> ClientConfig
+       -> ClientConfig
+       
+  397. -- ##TLS.ClientConfig.ciphers.set
+       builtin.io2.TLS.ClientConfig.ciphers.set : [Cipher]
+       -> ClientConfig
+       -> ClientConfig
+       
+  398. -- ##Tls.ClientConfig.default
+       builtin.io2.Tls.ClientConfig.default : Text
+       -> Bytes
+       -> ClientConfig
+       
+  399. -- ##Tls.ClientConfig.versions.set
+       builtin.io2.Tls.ClientConfig.versions.set : [Version]
+       -> ClientConfig
+       -> ClientConfig
+       
+  400. -- ##Tls.decodeCert.impl.v3
+       builtin.io2.Tls.decodeCert.impl : Bytes
+       -> Either Failure SignedCert
+       
+  401. -- ##Tls.decodePrivateKey
+       builtin.io2.Tls.decodePrivateKey : Bytes -> [PrivateKey]
+       
+  402. -- ##Tls.encodeCert
+       builtin.io2.Tls.encodeCert : SignedCert -> Bytes
+       
+  403. -- ##Tls.encodePrivateKey
+       builtin.io2.Tls.encodePrivateKey : PrivateKey -> Bytes
+       
+  404. -- ##Tls.handshake.impl.v3
+       builtin.io2.Tls.handshake.impl : Tls
+       ->{IO} Either Failure ()
+       
+  405. -- ##Tls.newClient.impl.v3
+       builtin.io2.Tls.newClient.impl : ClientConfig
+       -> Socket
+       ->{IO} Either Failure Tls
+       
+  406. -- ##Tls.newServer.impl.v3
+       builtin.io2.Tls.newServer.impl : ServerConfig
+       -> Socket
+       ->{IO} Either Failure Tls
+       
+  407. -- ##Tls.PrivateKey
+       builtin type builtin.io2.Tls.PrivateKey
+       
+  408. -- ##Tls.receive.impl.v3
+       builtin.io2.Tls.receive.impl : Tls
+       ->{IO} Either Failure Bytes
+       
+  409. -- ##Tls.send.impl.v3
+       builtin.io2.Tls.send.impl : Tls
+       -> Bytes
+       ->{IO} Either Failure ()
+       
+  410. -- ##Tls.ServerConfig
+       builtin type builtin.io2.Tls.ServerConfig
+       
+  411. -- ##Tls.ServerConfig.certificates.set
+       builtin.io2.Tls.ServerConfig.certificates.set : [SignedCert]
+       -> ServerConfig
+       -> ServerConfig
+       
+  412. -- ##Tls.ServerConfig.ciphers.set
+       builtin.io2.Tls.ServerConfig.ciphers.set : [Cipher]
+       -> ServerConfig
+       -> ServerConfig
+       
+  413. -- ##Tls.ServerConfig.default
+       builtin.io2.Tls.ServerConfig.default : [SignedCert]
+       -> PrivateKey
+       -> ServerConfig
+       
+  414. -- ##Tls.ServerConfig.versions.set
+       builtin.io2.Tls.ServerConfig.versions.set : [Version]
+       -> ServerConfig
+       -> ServerConfig
+       
+  415. -- ##Tls.SignedCert
+       builtin type builtin.io2.Tls.SignedCert
+       
+  416. -- ##Tls.terminate.impl.v3
+       builtin.io2.Tls.terminate.impl : Tls
+       ->{IO} Either Failure ()
+       
+  417. -- ##Tls.Version
+       builtin type builtin.io2.Tls.Version
+       
+  418. -- #r3gag1btclr8iclbdt68irgt8n1d1vf7agv5umke3dgdbl11acj6easav6gtihanrjnct18om07638rne9ej06u2bkv2v4l36knm2l0
+       unique type builtin.io2.TlsFailure
+       
+  419. -- ##TVar
+       builtin type builtin.io2.TVar
+       
+  420. -- ##TVar.new
+       builtin.io2.TVar.new : a ->{STM} TVar a
+       
+  421. -- ##TVar.newIO
+       builtin.io2.TVar.newIO : a ->{IO} TVar a
+       
+  422. -- ##TVar.read
+       builtin.io2.TVar.read : TVar a ->{STM} a
+       
+  423. -- ##TVar.readIO
+       builtin.io2.TVar.readIO : TVar a ->{IO} a
+       
+  424. -- ##TVar.swap
+       builtin.io2.TVar.swap : TVar a -> a ->{STM} a
+       
+  425. -- ##TVar.write
+       builtin.io2.TVar.write : TVar a -> a ->{STM} ()
+       
+  426. -- ##validateSandboxed
+       builtin.io2.validateSandboxed : [Link.Term]
+       -> a
+       -> Boolean
+       
+  427. -- #c23jofurcegj93796o0karmkcm6baifupiuu1rtkniu74avn6a4r1n66ga5rml5di7easkgn4iak800u3tnb6kfisbrv6tcfgkb13a8
+       unique type builtin.IsPropagated
+       
+  428. -- #c23jofurcegj93796o0karmkcm6baifupiuu1rtkniu74avn6a4r1n66ga5rml5di7easkgn4iak800u3tnb6kfisbrv6tcfgkb13a8#0
+       builtin.IsPropagated.IsPropagated : IsPropagated
+       
+  429. -- #q6snodsh7i7u6k7gtqj73tt7nv6htjofs5f37vg2v3dsfk6hau71fs5mcv0hq3lqg111fsvoi92mngm08850aftfgh65uka9mhqvft0
+       unique type builtin.IsTest
+       
+  430. -- #q6snodsh7i7u6k7gtqj73tt7nv6htjofs5f37vg2v3dsfk6hau71fs5mcv0hq3lqg111fsvoi92mngm08850aftfgh65uka9mhqvft0#0
+       builtin.IsTest.IsTest : IsTest
+       
+  431. -- #68haromionghg6cvojngjrgc7t0ob658nkk8b20fpho6k6ltjtf6rfmr4ia1omige97hk34lu21qsj933vl1dkpbna7evbjfkh71r9g
+       unique type builtin.License
+       
+  432. -- #knhl4mlkqf0mt877flahlbas2ufb7bub8f11vi9ihh9uf7r6jqaglk7rm6912q1vml50866ddl0qfa4o6d7o0gomchaoae24m0u2nk8
+       builtin.License.copyrightHolders : License
+       -> [CopyrightHolder]
+       
+  433. -- #ucpi54l843bf1osaejl1cnn0jt3o89fak5c0120k8256in3m80ik836hnite0osl12m91utnpnt5n7pgm3oe1rv4r1hk8ai4033agvo
+       builtin.License.copyrightHolders.modify : ([CopyrightHolder]
+       ->{g} [CopyrightHolder])
+       -> License
+       ->{g} License
+       
+  434. -- #9hbbfn61d2odn8jvtj5da9n1e9decsrheg6chg73uf94oituv3750b9hd6vp3ljhi54dkp5uqfg57j66i39bstfd8ivgav4p3si39ro
+       builtin.License.copyrightHolders.set : [CopyrightHolder]
+       -> License
+       -> License
+       
+  435. -- #68haromionghg6cvojngjrgc7t0ob658nkk8b20fpho6k6ltjtf6rfmr4ia1omige97hk34lu21qsj933vl1dkpbna7evbjfkh71r9g#0
+       builtin.License.License : [CopyrightHolder]
+       -> [Year]
+       -> LicenseType
+       -> License
+       
+  436. -- #aqi4h1bfq2rjnrrfanf4nut8jd1elkkc00u1tn0rmt9ocsrds8i8pha7q9cihvbiq7edpg21iqnfornimae2gad0ab8ih0bksjnoi4g
+       builtin.License.licenseType : License -> LicenseType
+       
+  437. -- #1rm8kpbv278t9tqj4jfssl8q3cn4hgu1mti7bp8lhcr5h7qmojujmt9de4c31p42to8mtav61u98oad3oen8q9im20sacs69psjpugo
+       builtin.License.licenseType.modify : (LicenseType
+       ->{g} LicenseType)
+       -> License
+       ->{g} License
+       
+  438. -- #dv9jsg0ksrlp3g0uftvkutpa8matt039o7dhat9airnkto2b703mgoi5t412hdi95pdhp9g01luga13ihmp52nk6bgh788gts6elv2o
+       builtin.License.licenseType.set : LicenseType
+       -> License
+       -> License
+       
+  439. -- #fh5qbeba2hg5c5k9uppi71rfghj8df37p4cg3hk23b9pv0hpm67ok807f05t368rn6v99v7kvf7cp984v8ipkjr1j1h095g6nd9jtig
+       builtin.License.years : License -> [Year]
+       
+  440. -- #2samr066hti71pf0fkvb4niemm7j3amvaap3sk1dqpihqp9g8f8lknhhmjq9atai6j5kcs4huvfokvpm15ebefmfggr4hd2cetf7co0
+       builtin.License.years.modify : ([Year] ->{g} [Year])
+       -> License
+       ->{g} License
+       
+  441. -- #g3ap8lg6974au4meb2hl49k1k6f048det9uckmics3bkt9s571921ksqfdsch63k2pk3fij8pn697svniakkrueddh8nkflnmjk9ffo
+       builtin.License.years.set : [Year] -> License -> License
+       
+  442. -- #uj652rrb45urfnojgt1ssqoji7iiibu27uhrc1sfl68lm54hbr7r1dpgppsv0pvf0oile2uk2h2gn1h4vgng30fga66idihhen14qc0
+       unique type builtin.LicenseType
+       
+  443. -- #uj652rrb45urfnojgt1ssqoji7iiibu27uhrc1sfl68lm54hbr7r1dpgppsv0pvf0oile2uk2h2gn1h4vgng30fga66idihhen14qc0#0
+       builtin.LicenseType.LicenseType : Doc -> LicenseType
+       
+  444. -- #f4b37niu61dc517c32h3os36ig34fgnt7inaaoqdbecmscchthi14gdo0vj3eee1ru746ibvl9vnmm1pglrv3125qnhsbc0i1tqtic0
+       unique type builtin.Link
+       
+  445. -- ##Link.Term
+       builtin type builtin.Link.Term
+       
+  446. -- #f4b37niu61dc517c32h3os36ig34fgnt7inaaoqdbecmscchthi14gdo0vj3eee1ru746ibvl9vnmm1pglrv3125qnhsbc0i1tqtic0#0
+       builtin.Link.Term : Link.Term -> Link
+       
+  447. -- ##Link.Term.toText
+       builtin.Link.Term.toText : Link.Term -> Text
+       
+  448. -- ##Link.Type
+       builtin type builtin.Link.Type
+       
+  449. -- #f4b37niu61dc517c32h3os36ig34fgnt7inaaoqdbecmscchthi14gdo0vj3eee1ru746ibvl9vnmm1pglrv3125qnhsbc0i1tqtic0#1
+       builtin.Link.Type : Type -> Link
+       
+  450. -- ##Sequence
+       builtin type builtin.List
+       
+  451. -- ##List.++
+       builtin.List.++ : [a] -> [a] -> [a]
+       
+  452. -- ##List.cons
+       builtin.List.+:, builtin.List.cons : a -> [a] -> [a]
+       
+  453. -- ##List.snoc
+       builtin.List.:+, builtin.List.snoc : [a] -> a -> [a]
+       
+  454. -- ##List.at
+       builtin.List.at : Nat -> [a] -> Optional a
+       
+  455. -- ##List.cons
+       builtin.List.cons, builtin.List.+: : a -> [a] -> [a]
+       
+  456. -- ##List.drop
+       builtin.List.drop : Nat -> [a] -> [a]
+       
+  457. -- ##List.empty
+       builtin.List.empty : [a]
+       
+  458. -- #a8ia0nqfghkpj4dt0t5gsk96tsfv6kg1k2cf7d7sb83tkqosebfiib2bkhjq48tc2v8ld94gf9o3hvc42pf6j49q75k0br395qavli0
+       builtin.List.map : (a ->{e} b) -> [a] ->{e} [b]
+       
+  459. -- ##List.size
+       builtin.List.size : [a] -> Nat
+       
+  460. -- ##List.snoc
+       builtin.List.snoc, builtin.List.:+ : [a] -> a -> [a]
+       
+  461. -- ##List.take
+       builtin.List.take : Nat -> [a] -> [a]
+       
+  462. -- #cb9e3iosob3e4q0v96ifmserg27samv1lvi4dh0l0l19phvct4vbbvv19abngneb77b02h8cefr1o3ad8gnm3cn6mjgsub97gjlte8g
+       builtin.metadata.isPropagated : IsPropagated
+       
+  463. -- #lkpne3jg56pmqegv4jba6b5nnjg86qtfllnlmtvijql5lsf89rfu6tgb1s9ic0gsqs5si0v9agmj90lk0bhihbovd5o5ve023g4ocko
+       builtin.metadata.isTest : IsTest
+       
+  464. -- ##MutableArray
+       builtin type builtin.MutableArray
+       
+  465. -- ##MutableArray.copyTo!
+       builtin.MutableArray.copyTo! : MutableArray g a
+       -> Nat
+       -> MutableArray g a
+       -> Nat
+       -> Nat
+       ->{g, Exception} ()
+       
+  466. -- ##MutableArray.freeze
+       builtin.MutableArray.freeze : MutableArray g a
+       -> Nat
+       -> Nat
+       ->{g} ImmutableArray a
+       
+  467. -- ##MutableArray.freeze!
+       builtin.MutableArray.freeze! : MutableArray g a
+       ->{g} ImmutableArray a
+       
+  468. -- ##MutableArray.read
+       builtin.MutableArray.read : MutableArray g a
+       -> Nat
+       ->{g, Exception} a
+       
+  469. -- ##MutableArray.size
+       builtin.MutableArray.size : MutableArray g a -> Nat
+       
+  470. -- ##MutableArray.write
+       builtin.MutableArray.write : MutableArray g a
+       -> Nat
+       -> a
+       ->{g, Exception} ()
+       
+  471. -- ##MutableByteArray
+       builtin type builtin.MutableByteArray
+       
+  472. -- ##MutableByteArray.copyTo!
+       builtin.MutableByteArray.copyTo! : MutableByteArray g
+       -> Nat
+       -> MutableByteArray g
+       -> Nat
+       -> Nat
+       ->{g, Exception} ()
+       
+  473. -- ##MutableByteArray.freeze
+       builtin.MutableByteArray.freeze : MutableByteArray g
+       -> Nat
+       -> Nat
+       ->{g} ImmutableByteArray
+       
+  474. -- ##MutableByteArray.freeze!
+       builtin.MutableByteArray.freeze! : MutableByteArray g
+       ->{g} ImmutableByteArray
+       
+  475. -- ##MutableByteArray.read16be
+       builtin.MutableByteArray.read16be : MutableByteArray g
+       -> Nat
+       ->{g, Exception} Nat
+       
+  476. -- ##MutableByteArray.read24be
+       builtin.MutableByteArray.read24be : MutableByteArray g
+       -> Nat
+       ->{g, Exception} Nat
+       
+  477. -- ##MutableByteArray.read32be
+       builtin.MutableByteArray.read32be : MutableByteArray g
+       -> Nat
+       ->{g, Exception} Nat
+       
+  478. -- ##MutableByteArray.read40be
+       builtin.MutableByteArray.read40be : MutableByteArray g
+       -> Nat
+       ->{g, Exception} Nat
+       
+  479. -- ##MutableByteArray.read64be
+       builtin.MutableByteArray.read64be : MutableByteArray g
+       -> Nat
+       ->{g, Exception} Nat
+       
+  480. -- ##MutableByteArray.read8
+       builtin.MutableByteArray.read8 : MutableByteArray g
+       -> Nat
+       ->{g, Exception} Nat
+       
+  481. -- ##MutableByteArray.size
+       builtin.MutableByteArray.size : MutableByteArray g -> Nat
+       
+  482. -- ##MutableByteArray.write16be
+       builtin.MutableByteArray.write16be : MutableByteArray g
+       -> Nat
+       -> Nat
+       ->{g, Exception} ()
+       
+  483. -- ##MutableByteArray.write32be
+       builtin.MutableByteArray.write32be : MutableByteArray g
+       -> Nat
+       -> Nat
+       ->{g, Exception} ()
+       
+  484. -- ##MutableByteArray.write64be
+       builtin.MutableByteArray.write64be : MutableByteArray g
+       -> Nat
+       -> Nat
+       ->{g, Exception} ()
+       
+  485. -- ##MutableByteArray.write8
+       builtin.MutableByteArray.write8 : MutableByteArray g
+       -> Nat
+       -> Nat
+       ->{g, Exception} ()
+       
+  486. -- ##Nat
+       builtin type builtin.Nat
+       
+  487. -- ##Nat.*
+       builtin.Nat.* : Nat -> Nat -> Nat
+       
+  488. -- ##Nat.+
+       builtin.Nat.+ : Nat -> Nat -> Nat
+       
+  489. -- ##Nat./
+       builtin.Nat./ : Nat -> Nat -> Nat
+       
+  490. -- ##Nat.and
+       builtin.Nat.and : Nat -> Nat -> Nat
+       
+  491. -- ##Nat.complement
+       builtin.Nat.complement : Nat -> Nat
+       
+  492. -- ##Nat.drop
+       builtin.Nat.drop : Nat -> Nat -> Nat
+       
+  493. -- ##Nat.==
+       builtin.Nat.eq : Nat -> Nat -> Boolean
+       
+  494. -- ##Nat.fromText
+       builtin.Nat.fromText : Text -> Optional Nat
+       
+  495. -- ##Nat.>
+       builtin.Nat.gt : Nat -> Nat -> Boolean
+       
+  496. -- ##Nat.>=
+       builtin.Nat.gteq : Nat -> Nat -> Boolean
+       
+  497. -- ##Nat.increment
+       builtin.Nat.increment : Nat -> Nat
+       
+  498. -- ##Nat.isEven
+       builtin.Nat.isEven : Nat -> Boolean
+       
+  499. -- ##Nat.isOdd
+       builtin.Nat.isOdd : Nat -> Boolean
+       
+  500. -- ##Nat.leadingZeros
+       builtin.Nat.leadingZeros : Nat -> Nat
+       
+  501. -- ##Nat.<
+       builtin.Nat.lt : Nat -> Nat -> Boolean
+       
+  502. -- ##Nat.<=
+       builtin.Nat.lteq : Nat -> Nat -> Boolean
+       
+  503. -- ##Nat.mod
+       builtin.Nat.mod : Nat -> Nat -> Nat
+       
+  504. -- ##Nat.or
+       builtin.Nat.or : Nat -> Nat -> Nat
+       
+  505. -- ##Nat.popCount
+       builtin.Nat.popCount : Nat -> Nat
+       
+  506. -- ##Nat.pow
+       builtin.Nat.pow : Nat -> Nat -> Nat
+       
+  507. -- ##Nat.shiftLeft
+       builtin.Nat.shiftLeft : Nat -> Nat -> Nat
+       
+  508. -- ##Nat.shiftRight
+       builtin.Nat.shiftRight : Nat -> Nat -> Nat
+       
+  509. -- ##Nat.sub
+       builtin.Nat.sub : Nat -> Nat -> Int
+       
+  510. -- ##Nat.toFloat
+       builtin.Nat.toFloat : Nat -> Float
+       
+  511. -- ##Nat.toInt
+       builtin.Nat.toInt : Nat -> Int
+       
+  512. -- ##Nat.toText
+       builtin.Nat.toText : Nat -> Text
+       
+  513. -- ##Nat.trailingZeros
+       builtin.Nat.trailingZeros : Nat -> Nat
+       
+  514. -- ##Nat.xor
+       builtin.Nat.xor : Nat -> Nat -> Nat
+       
+  515. -- #nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg
+       structural type builtin.Optional a
+       
+  516. -- #nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#1
+       builtin.Optional.None : Optional a
+       
+  517. -- #nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#0
+       builtin.Optional.Some : a -> Optional a
+       
+  518. -- ##Pattern
+       builtin type builtin.Pattern
+       
+  519. -- ##Pattern.capture
+       builtin.Pattern.capture : Pattern a -> Pattern a
+       
+  520. -- ##Pattern.isMatch
+       builtin.Pattern.isMatch : Pattern a -> a -> Boolean
+       
+  521. -- ##Pattern.join
+       builtin.Pattern.join : [Pattern a] -> Pattern a
+       
+  522. -- ##Pattern.many
+       builtin.Pattern.many : Pattern a -> Pattern a
+       
+  523. -- ##Pattern.or
+       builtin.Pattern.or : Pattern a -> Pattern a -> Pattern a
+       
+  524. -- ##Pattern.replicate
+       builtin.Pattern.replicate : Nat
+       -> Nat
+       -> Pattern a
+       -> Pattern a
+       
+  525. -- ##Pattern.run
+       builtin.Pattern.run : Pattern a -> a -> Optional ([a], a)
+       
+  526. -- #cbo8de57n17pgc5iic1741jeiunhvhfcfd7gt79vd6516u64aplasdodqoouejbgovhge2le5jb6rje923fcrllhtu01t29cdrssgbg
+       structural type builtin.Pretty txt
+       
+  527. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8
+       unique type builtin.Pretty.Annotated w txt
+       
+  528. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#1
+       builtin.Pretty.Annotated.Append : w
+       -> [Annotated w txt]
+       -> Annotated w txt
+       
+  529. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#6
+       builtin.Pretty.Annotated.Empty : Annotated w txt
+       
+  530. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#4
+       builtin.Pretty.Annotated.Group : w
+       -> Annotated w txt
+       -> Annotated w txt
+       
+  531. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#3
+       builtin.Pretty.Annotated.Indent : w
+       -> Annotated w txt
+       -> Annotated w txt
+       -> Annotated w txt
+       -> Annotated w txt
+       
+  532. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#7
+       builtin.Pretty.Annotated.Lit : w
+       -> txt
+       -> Annotated w txt
+       
+  533. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#2
+       builtin.Pretty.Annotated.OrElse : w
+       -> Annotated w txt
+       -> Annotated w txt
+       -> Annotated w txt
+       
+  534. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#0
+       builtin.Pretty.Annotated.Table : w
+       -> [[Annotated w txt]]
+       -> Annotated w txt
+       
+  535. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#5
+       builtin.Pretty.Annotated.Wrap : w
+       -> Annotated w txt
+       -> Annotated w txt
+       
+  536. -- #svdhl4ogs0m1pe7ihtq5q9td72mg41tmndqif4kktbtv4p8e1ciapaj8kvflfbm876llbh60tlkefpi0v0bra8hl7mfgnpscimeqtdg
+       builtin.Pretty.append : Pretty txt
+       -> Pretty txt
+       -> Pretty txt
+       
+  537. -- #sonptakf85a3uklev4rq0pub00k56jdpaop4tcd9bmk0gmjjij5t16sf1knspku2hbp0uikiflbo0dtjv1i6r3t2rpjh86vo1rlaer8
+       builtin.Pretty.empty : Pretty txt
+       
+  538. -- #mlpplm1bhqkcif5j09204uuvfll7qte95msb0skjfd30nmei005kiich1ao39gm2j8687s14qvf5llu6i1a6fvt4vdmbp99jlfundfo
+       builtin.Pretty.get : Pretty txt -> Annotated () txt
+       
+  539. -- #d9m2k9igi4b50cp7v5tlp3o7dot6r41rbbbsc2a4iqae3hc2a7fceh83l1n3nuotfnn7nrgt40s1kfbcnl89qcqieih125gsafk2d00
+       builtin.Pretty.group : Pretty txt -> Pretty txt
+       
+  540. -- #p6rkh0u8gfko2fpqdje6h8cain3qakom06a28rh4ccsjsnbagmmv6gadccg4t380c4nnetq9si7bkkvbh44it4lrfvfvcn4usps1uno
+       builtin.Pretty.indent : Pretty txt
+       -> Pretty txt
+       -> Pretty txt
+       
+  541. -- #f59sgojafl5so8ei4vgdpqflqcpsgovpcea73509k5qm1jb8vkeojsfsavhn64gmfpd52uo631ejqu0oj2a6t6k8jcu282lbqjou7ug
+       builtin.Pretty.indent' : Pretty txt
+       -> Pretty txt
+       -> Pretty txt
+       -> Pretty txt
+       
+  542. -- #hpntja4i04u36vijdesobh75pubru68jf1fhgi49jl3nf6kall1so8hfc0bq0pm8r9kopgskiigdl04hqelklsdrdjndq5on9hsjgmo
+       builtin.Pretty.join : [Pretty txt] -> Pretty txt
+       
+  543. -- #jtn2i6bg3gargdp2rbk08jfd327htap62brih8phdfm2m4d6ib9cu0o2k5vrh7f4jik99eufu4hi0114akgd1oiivi8p1pa9m2fvjv0
+       builtin.Pretty.lit : txt -> Pretty txt
+       
+  544. -- #pn811nf59d63s8711bpktjqub65sb748pmajg7r8n7h7cnap5ecb4n1072ccult24q6gcfac66scrm77cjsa779mcckqrs8si4716sg
+       builtin.Pretty.map : (txt ->{g} txt2)
+       -> Pretty txt
+       ->{g} Pretty txt2
+       
+  545. -- #5rfcm6mlv2njfa8l9slkjp1q2q5r6m1vkp084run6pd632cf02mcpoh2bo3kuqf3uqbb5nh2drf37u51lpf16m5u415tcuk18djnr60
+       builtin.Pretty.orElse : Pretty txt
+       -> Pretty txt
+       -> Pretty txt
+       
+  546. -- #cbo8de57n17pgc5iic1741jeiunhvhfcfd7gt79vd6516u64aplasdodqoouejbgovhge2le5jb6rje923fcrllhtu01t29cdrssgbg#0
+       builtin.Pretty.Pretty : Annotated () txt -> Pretty txt
+       
+  547. -- #qg050nfl4eeeiarp5mvun3j15h3qpgo31a01o03mql8rrrpht3o6h6htov9ghm7cikkbjejgu4vd9v3h1idp0hanol93pqpqiq8rg3g
+       builtin.Pretty.sepBy : Pretty txt
+       -> [Pretty txt]
+       -> Pretty txt
+       
+  548. -- #ev99k0kpivu29vfl7k8pf5n55fnnelq78ul7jqjrk946i1ckvrs5lmrji3l2avhd02mljspdbfspcn26phaqkug6p7rocbbf94uhcro
+       builtin.Pretty.table : [[Pretty txt]] -> Pretty txt
+       
+  549. -- #7c4jq9udglq9n7pfemqmc7qrks18r80t9dgjefpi78aerb1vo8cakc3fv843dg3h60ihbo75u0jrmbhqk0och8be2am98v3mu5f6v10
+       builtin.Pretty.wrap : Pretty txt -> Pretty txt
+       
+  550. -- ##Ref
+       builtin type builtin.Ref
+       
+  551. -- ##Ref.read
+       builtin.Ref.read : Ref g a ->{g} a
+       
+  552. -- ##Ref.write
+       builtin.Ref.write : Ref g a -> a ->{g} ()
+       
+  553. -- ##Effect
+       builtin type builtin.Request
+       
+  554. -- ##Scope
+       builtin type builtin.Scope
+       
+  555. -- ##Scope.array
+       builtin.Scope.array : Nat
+       ->{Scope s} MutableArray (Scope s) a
+       
+  556. -- ##Scope.arrayOf
+       builtin.Scope.arrayOf : a
+       -> Nat
+       ->{Scope s} MutableArray (Scope s) a
+       
+  557. -- ##Scope.bytearray
+       builtin.Scope.bytearray : Nat
+       ->{Scope s} MutableByteArray (Scope s)
+       
+  558. -- ##Scope.bytearrayOf
+       builtin.Scope.bytearrayOf : Nat
+       -> Nat
+       ->{Scope s} MutableByteArray (Scope s)
+       
+  559. -- ##Scope.ref
+       builtin.Scope.ref : a ->{Scope s} Ref {Scope s} a
+       
+  560. -- ##Scope.run
+       builtin.Scope.run : (∀ s. '{g, Scope s} r) ->{g} r
+       
+  561. -- #6uigas14aqgd889s036hq9ssrlo22pju41009m0rktetcrbm97qniljjc1rv1u661r4f63oq6pupoevghs8a2hupvlbi6qi4ntn9320
+       structural type builtin.SeqView a b
+       
+  562. -- #6uigas14aqgd889s036hq9ssrlo22pju41009m0rktetcrbm97qniljjc1rv1u661r4f63oq6pupoevghs8a2hupvlbi6qi4ntn9320#0
+       builtin.SeqView.VElem : a -> b -> SeqView a b
+       
+  563. -- #6uigas14aqgd889s036hq9ssrlo22pju41009m0rktetcrbm97qniljjc1rv1u661r4f63oq6pupoevghs8a2hupvlbi6qi4ntn9320#1
+       builtin.SeqView.VEmpty : SeqView a b
+       
+  564. -- ##Socket.toText
+       builtin.Socket.toText : Socket -> Text
+       
+  565. -- #pfp0ajb4v2mb9tspp29v53dkacb76aa1t5kbk1dl0q354cjcg4egdpmvtr5d6t818ucon9eubf6r1vdvh926fgk8otvbkvbpn90levo
+       builtin.syntax.docAside : Doc2 -> Doc2
+       
+  566. -- #mvov9qf78ctohefjbmrgs8ussspo5juhf75pee4ikkg8asuos72unn4pjn3fdel8471soj2vaskd5ls103pb6nb8qf75sjn4igs7v48
+       builtin.syntax.docBlockquote : Doc2 -> Doc2
+       
+  567. -- #cg64hg7dag89u80104kit2p40rhmo1k6h1j8obfhjolpogs705bt6hc92ct6rfj8h74m3ioug14u9pm1s7qqpmjda2srjojhi01nvf0
+       builtin.syntax.docBold : Doc2 -> Doc2
+       
+  568. -- #3qd5kt9gjiggrb871al82n11jccedl3kb5p8ffemr703frn38tqajkett30fg7hef5orh7vl0obp3lap9qq2po3ufcnu4k3bik81rlg
+       builtin.syntax.docBulletedList : [Doc2] -> Doc2
+       
+  569. -- #el0rph43k5qg25qg20o5jdjukuful041r87v92tcb2339om0hp9u6vqtrcrfkvgj78hrpo2o1l39bbg1oier87pvgkli0lkgalgpo90
+       builtin.syntax.docCallout : Optional Doc2 -> Doc2 -> Doc2
+       
+  570. -- #7jij106qpusbsbpqhmtgrk59qo8ss9e77rtrc1h9hbpnbab8sq717fe6hppmhhds9smqbv3k2q0irjgoe4mogatlp9e4k25kopt6rgo
+       builtin.syntax.docCode : Doc2 -> Doc2
+       
+  571. -- #3paq4qqrk028tati33723c4aqi7ebgnjln12avbnf7eu8h8sflg0frlehb4lni4ru0pcfg9ftsurq3pb2q11cfebeki51vom697l7h0
+       builtin.syntax.docCodeBlock : Text -> Text -> Doc2
+       
+  572. -- #1of955s8tqa74vu0ve863p8dn2mncc2anmms54aj084pkbdcpml6ckvs0qb4defi0df3b1e8inp29p60ac93hf2u7to0je4op9fum40
+       builtin.syntax.docColumn : [Doc2] -> Doc2
+       
+  573. -- #ukv56cjchfao07qb08l7iimd2mmv09s5glmtljo5b71leaijtja04obd0u1hsr38itjnv85f7jvd37nr654bl4lfn4msr1one0hi4s0
+       builtin.syntax.docEmbedAnnotation : tm -> Doc2.Term
+       
+  574. -- #uccvv8mn62ne8iqppsnpgbquqmhk4hk3n4tg7p6kttr20gov4698tu18jmmvdcs7ab455q7kklhb4uv1mtei4vbvq4qmbtbu1dbagmg
+       builtin.syntax.docEmbedAnnotations : tms -> tms
+       
+  575. -- #h53vvsbp1eflh5n41fepa5dana1ucfjbk8qc95kf4ht12svn304hc4fv431hiejspdr84oul4gmd3s65neil759q0hmjjrr8ottc6v0
+       builtin.syntax.docEmbedSignatureLink : '{g} t
+       -> Doc2.Term
+       
+  576. -- #dvjs6ebt2ej6funsr6rv351aqe5eqt8pcbte5hpqossikbnqrblhhnve55pdg896s4e6dvd6m3us0151ejegfg1fi8kbfd7soa31dao
+       builtin.syntax.docEmbedTermLink : '{g} t
+       -> Either a Doc2.Term
+       
+  577. -- #7t98ois54isfkh31uefvdg4bg302s5q3sun4hfh0mqnosk4ded353jp0p2ij6b22vnvlcbipcv2jb91suh6qc33i7uqlfuto9f0r4n8
+       builtin.syntax.docEmbedTypeLink : typ -> Either typ b
+       
+  578. -- #r26nnrb8inld7nstp0rj4sbh7ldbibo3s6ld4hmii114i8fglrvij0a1jgj70u51it80s5vgj5dvu9oi5gqmr2n7j341tg8285mpesg
+       builtin.syntax.docEval : 'a -> Doc2
+       
+  579. -- #ojecdd8rnla7dqqop5a43u8kl12149l24452thb0ljkb99ivh6n2evg3g43dj6unlbsmbuvj5g9js5hvsi9f13lt22uqkueioe1vi9g
+       builtin.syntax.docEvalInline : 'a -> Doc2
+       
+  580. -- #lecedgertb8tj69o0f2bqeso83hl454am6cjp708epen78s5gtr0ljcc6agopns65lnm3du36dr4m4qu9rp8rtjvtcpg359bpbnfcm0
+       builtin.syntax.docExample : Nat -> '{g} t -> Doc2
+       
+  581. -- #m4ini2v12rc468iflsee87m1qrm52b257e3blah4pcblqo2np3k6ad50bt5gkjob3qrct3jbihjd6i02t7la9oh3cft1d0483lf1pq0
+       builtin.syntax.docExampleBlock : Nat -> '{g} t -> Doc2
+       
+  582. -- #pomj7lft70jnnuk5job0pstih2mosva1oee4tediqbkhnm54tjqnfe6qs1mqt8os1ehg9ksgenb6veub2ngdpb1qat400vn0bj3fju0
+       builtin.syntax.docFoldedSource : [( Either Type Doc2.Term,
+         [Doc2.Term])]
+       -> Doc2
+       
+  583. -- #4rv8dvuvf5br3vhhuturaejt1l2u8j5eidjid01f5mo7o0fgjatttmph34ma0b9s1i2badcqj3ale005jb1hnisabnh93i4is1d8kng
+       builtin.syntax.docFormatConsole : Doc2
+       -> Pretty (Either SpecialForm ConsoleText)
+       
+  584. -- #99qvifgs3u7nof50jbp5lhrf8cab0qiujr1tque2b7hfj56r39o8ot2fafhafuphoraddl1j142k994e22g5v2rhq98flc0954t5918
+       builtin.syntax.docGroup : Doc2 -> Doc2
+       
+  585. -- #gsratvk7mo273bqhivdv06f9rog2cj48u7ci0jp6ubt5oidf8cq0rjilimkas5801inbbsjcedh61jl40i3en1qu6r9vfe684ad6r08
+       builtin.syntax.docItalic : Doc2 -> Doc2
+       
+  586. -- #piohhscvm6lgpk6vfg91u2ndmlfv81nnkspihom77ucr4dev6s22rk2n9hp38nifh5p8vt7jfvep85vudpvlg2tt99e9s2qfjv5oau8
+       builtin.syntax.docJoin : [Doc2] -> Doc2
+       
+  587. -- #hjdqcolihf4obmnfoakl2t5hs1e39hpmpo9ijvc37fqgejog1ii7fpd4q2fe2rkm62tf81unmqlbud8uh63vaa9feaekg5a7uo3nq00
+       builtin.syntax.docLink : Either Type Doc2.Term -> Doc2
+       
+  588. -- #iv6urr76b0ohvr22qa6d05e7e01cd0re77g8c98cm0bqo0im345fotsevqnhk1igtutkrrqm562gtltofvku5mh0i87ru8tdf0i53bo
+       builtin.syntax.docNamedLink : Doc2 -> Doc2 -> Doc2
+       
+  589. -- #b5dvn0bqj3rc1rkmlep5f6cd6n3vp247hqku8lqndena5ocgcoae18iuq3985finagr919re4fvji011ved0g21i6o0je2jn8f7k1p0
+       builtin.syntax.docNumberedList : Nat -> [Doc2] -> Doc2
+       
+  590. -- #fs8mho20fqj31ch5kpn8flm4geomotov7fb5ct8mtnh52ladorgp22vder3jgt1mr0u710e6s9gn4u36c9sp19vitvq1r0adtm3t1c0
+       builtin.syntax.docParagraph : [Doc2] -> Doc2
+       
+  591. -- #6dvkai3hc122e2h2h8c3jnijink5m20e27i640qvnt6smefpp2vna1rq4gbmulhb46tdabmkb5hsjeiuo4adtsutg4iu1vfmqhlueso
+       builtin.syntax.docSection : Doc2 -> [Doc2] -> Doc2
+       
+  592. -- #n0idf1bdrq5vgpk4pj9db5demk1es4jsnpodfoajftehvqjelsi0h5j2domdllq2peltdek4ptaqfpl4o8l6jpmqhcom9vq107ivdu0
+       builtin.syntax.docSignature : [Doc2.Term] -> Doc2
+       
+  593. -- #git1povkck9jrptdmmpqrv1g17ptbq9hr17l52l8477ijk4cia24tr7cj36v1o22mvtk00qoo5jt4bs4e79sl3eh6is8ubh8aoc1pu0
+       builtin.syntax.docSignatureInline : Doc2.Term -> Doc2
+       
+  594. -- #47agivvofl1jegbqpdg0eeed72mdj29d623e4kdei0l10mhgckif7q2pd968ggribregcknra9u43mhehr1q86n0t4vbe4eestnu9l8
+       builtin.syntax.docSource : [( Either Type Doc2.Term,
+         [Doc2.Term])]
+       -> Doc2
+       
+  595. -- #n6uk5tc4d8ipbga8boelh51ro24paveca9fijm1nkn3tlfddqludmlppb2ps8807v2kuou1a262sa59764mdhug2va69q4sls5jli10
+       builtin.syntax.docSourceElement : link
+       -> annotations
+       -> (link, annotations)
+       
+  596. -- #nurq288b5rfp1f5keccleh51ojgcpd2rp7cane6ftquf7gidtamffb8tr1r5h6luk1nsrqomn1k4as4kcpaskjjv35rnvoous457sag
+       builtin.syntax.docStrikethrough : Doc2 -> Doc2
+       
+  597. -- #4ns2amu2njhvb5mtdvh3v7oljjb5ammnb41us4ekpbhb337b6mo2a4q0790cmrusko7omphtfdsaust2fn49hr5acl40ef8fkb9556g
+       builtin.syntax.docTable : [[Doc2]] -> Doc2
+       
+  598. -- #i77kddfr68gbjt3767a091dtnqff9beltojh93md8peo28t59c6modeccsfd2tnrtmd75fa7dn0ie21kcv4me098q91h4ftg9eau5fo
+       builtin.syntax.docTooltip : Doc2 -> Doc2 -> Doc2
+       
+  599. -- #r0hdacbk2orcb2ate3uhd7ht05hmfa8643slm3u63nb3jaaim533up04lgt0pq97is43v2spkqble7mtu8f63hgcc0k2tb2jhpr2b68
+       builtin.syntax.docTransclude : d -> d
+       
+  600. -- #0nptdh40ngakd2rh92bl573a7vbdjcj2kc8rai39v8bb9dfpbj90i7nob381usjsott41c3cpo2m2q095fm0k0r68e8mrda135qa1k0
+       builtin.syntax.docUntitledSection : [Doc2] -> Doc2
+       
+  601. -- #krjm78blt08v52c52l4ubsnfidcrs0h6010j2v2h9ud38mgm6jj4vuqn4okp4g75039o7u78sbg6ghforucbfdf94f8am9kvt6875jo
+       builtin.syntax.docVerbatim : Doc2 -> Doc2
+       
+  602. -- #c14vgd4g1tkumf4jjd9vcoos1olb3f4gbc3hketf5l8h3i0efk8igbinh6gn018tr5075uo5nv1elva6tki6ofo3pdafidrkv9m0ot0
+       builtin.syntax.docWord : Text -> Doc2
+       
+  603. -- #aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0
+       unique type builtin.Test.Result
+       
+  604. -- #aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0#0
+       builtin.Test.Result.Fail : Text -> Result
+       
+  605. -- #aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0#1
+       builtin.Test.Result.Ok : Text -> Result
+       
+  606. -- ##Text
+       builtin type builtin.Text
+       
+  607. -- ##Text.!=
+       builtin.Text.!= : Text -> Text -> Boolean
+       
+  608. -- ##Text.++
+       builtin.Text.++ : Text -> Text -> Text
+       
+  609. -- #nv11qo7s2lqirk3qb44jkm3q3fb6i3mn72ji2c52eubh3kufrdumanblh2bnql1o24efdhmue0v21gd7d1p5ec9j6iqrmekas0183do
+       builtin.Text.alignLeftWith : Nat -> Char -> Text -> Text
+       
+  610. -- #ebeq250fdoigvu89fneb4c24f8f18eotc8kocdmosn4ri9shoeeg7ofkejts6clm5c6bifce66qtr0vpfkrhuup2en3khous41hp8rg
+       builtin.Text.alignRightWith : Nat -> Char -> Text -> Text
+       
+  611. -- ##Text.drop
+       builtin.Text.drop : Nat -> Text -> Text
+       
+  612. -- ##Text.empty
+       builtin.Text.empty : Text
+       
+  613. -- ##Text.==
+       builtin.Text.eq : Text -> Text -> Boolean
+       
+  614. -- ##Text.fromCharList
+       builtin.Text.fromCharList : [Char] -> Text
+       
+  615. -- ##Text.fromUtf8.impl.v3
+       builtin.Text.fromUtf8.impl : Bytes -> Either Failure Text
+       
+  616. -- ##Text.>
+       builtin.Text.gt : Text -> Text -> Boolean
+       
+  617. -- ##Text.>=
+       builtin.Text.gteq : Text -> Text -> Boolean
+       
+  618. -- ##Text.<
+       builtin.Text.lt : Text -> Text -> Boolean
+       
+  619. -- ##Text.<=
+       builtin.Text.lteq : Text -> Text -> Boolean
+       
+  620. -- ##Text.patterns.anyChar
+       builtin.Text.patterns.anyChar : Pattern Text
+       
+  621. -- ##Text.patterns.charIn
+       builtin.Text.patterns.charIn : [Char] -> Pattern Text
+       
+  622. -- ##Text.patterns.charRange
+       builtin.Text.patterns.charRange : Char
+       -> Char
+       -> Pattern Text
+       
+  623. -- ##Text.patterns.digit
+       builtin.Text.patterns.digit : Pattern Text
+       
+  624. -- ##Text.patterns.eof
+       builtin.Text.patterns.eof : Pattern Text
+       
+  625. -- ##Text.patterns.letter
+       builtin.Text.patterns.letter : Pattern Text
+       
+  626. -- ##Text.patterns.literal
+       builtin.Text.patterns.literal : Text -> Pattern Text
+       
+  627. -- ##Text.patterns.notCharIn
+       builtin.Text.patterns.notCharIn : [Char] -> Pattern Text
+       
+  628. -- ##Text.patterns.notCharRange
+       builtin.Text.patterns.notCharRange : Char
+       -> Char
+       -> Pattern Text
+       
+  629. -- ##Text.patterns.punctuation
+       builtin.Text.patterns.punctuation : Pattern Text
+       
+  630. -- ##Text.patterns.space
+       builtin.Text.patterns.space : Pattern Text
+       
+  631. -- ##Text.repeat
+       builtin.Text.repeat : Nat -> Text -> Text
+       
+  632. -- ##Text.reverse
+       builtin.Text.reverse : Text -> Text
+       
+  633. -- ##Text.size
+       builtin.Text.size : Text -> Nat
+       
+  634. -- ##Text.take
+       builtin.Text.take : Nat -> Text -> Text
+       
+  635. -- ##Text.toCharList
+       builtin.Text.toCharList : Text -> [Char]
+       
+  636. -- ##Text.toLowercase
+       builtin.Text.toLowercase : Text -> Text
+       
+  637. -- ##Text.toUppercase
+       builtin.Text.toUppercase : Text -> Text
+       
+  638. -- ##Text.toUtf8
+       builtin.Text.toUtf8 : Text -> Bytes
+       
+  639. -- ##Text.uncons
+       builtin.Text.uncons : Text -> Optional (Char, Text)
+       
+  640. -- ##Text.unsnoc
+       builtin.Text.unsnoc : Text -> Optional (Text, Char)
+       
+  641. -- ##ThreadId.toText
+       builtin.ThreadId.toText : ThreadId -> Text
+       
+  642. -- ##todo
+       builtin.todo : a -> b
+       
+  643. -- #2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8
+       structural type builtin.Tuple a b
+       
+  644. -- #2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8#0
+       builtin.Tuple.Cons : a -> b -> Tuple a b
+       
+  645. -- #00nv2kob8fp11qdkr750rlppf81cda95m3q0niohj1pvljnjl4r3hqrhvp1un2p40ptgkhhsne7hocod90r3qdlus9guivh7j3qcq0g
+       structural type builtin.Unit
+       
+  646. -- #00nv2kob8fp11qdkr750rlppf81cda95m3q0niohj1pvljnjl4r3hqrhvp1un2p40ptgkhhsne7hocod90r3qdlus9guivh7j3qcq0g#0
+       builtin.Unit.Unit : ()
+       
+  647. -- ##Universal.<
+       builtin.Universal.< : a -> a -> Boolean
+       
+  648. -- ##Universal.<=
+       builtin.Universal.<= : a -> a -> Boolean
+       
+  649. -- ##Universal.==
+       builtin.Universal.== : a -> a -> Boolean
+       
+  650. -- ##Universal.>
+       builtin.Universal.> : a -> a -> Boolean
+       
+  651. -- ##Universal.>=
+       builtin.Universal.>= : a -> a -> Boolean
+       
+  652. -- ##Universal.compare
+       builtin.Universal.compare : a -> a -> Int
+       
+  653. -- ##unsafe.coerceAbilities
+       builtin.unsafe.coerceAbilities : (a ->{e1} b)
+       -> a
+       ->{e2} b
+       
+  654. -- ##Value
+       builtin type builtin.Value
+       
+  655. -- ##Value.dependencies
+       builtin.Value.dependencies : Value -> [Link.Term]
+       
+  656. -- ##Value.deserialize
+       builtin.Value.deserialize : Bytes -> Either Text Value
+       
+  657. -- ##Value.load
+       builtin.Value.load : Value ->{IO} Either [Link.Term] a
+       
+  658. -- ##Value.serialize
+       builtin.Value.serialize : Value -> Bytes
+       
+  659. -- ##Value.value
+       builtin.Value.value : a -> Value
+       
+  660. -- #dem6aglnj8cppfrnq9qipl7geo5pim3auo9cmv1rhh5la9edalj19sspbpm1pd4vh0plokdh6qfo48gs034dqlg0s7j9fhr9p9ndtpo
+       unique type builtin.Year
+       
+  661. -- #dem6aglnj8cppfrnq9qipl7geo5pim3auo9cmv1rhh5la9edalj19sspbpm1pd4vh0plokdh6qfo48gs034dqlg0s7j9fhr9p9ndtpo#0
+       builtin.Year.Year : Nat -> Year
+       
+  662. -- #k0rcrut9836hr3sevkivq4n2o3t540hllesila69b16gr5fcqe0i6aepqhv2qmso6h22lbipbp3fto0oc8o73l1lvf6vpifi01gmhg8
+       cache : [(Link.Term, Code)] ->{IO, Exception} ()
+       
+  663. -- #okolgrio28p1mbl1bfjfs9qtsr1m9upblcm3ul872gcir6epkcbq619vk5bdq1fnr371nelsof6jsp8469g4j6f0gg3007p79o4kf18
+       check : Text -> Boolean ->{Stream Result} ()
+       
+  664. -- #je42vk6rsefjlup01e1fmmdssf5i3ba9l6aka3bipggetfm8o4i8d1q5d7hddggu5jure1bu5ot8aq5in31to4788ctrtpb44ri83r8
+       checks : [Boolean] -> [Result]
+       
+  665. -- #barg6v1n15ea1qhp80i77gjjq3vu1noc67q2jkv9n6n5v0c9djup70ltauujgpfe0kuo8ckd20gc9kutngdpb8d22rubtb5rjldrb3o
+       clientSocket : Text -> Text ->{IO, Exception} Socket
+       
+  666. -- #lg7i12ido0jr43ovdbhhv2enpk5ar869leouri5qhrivinde93nl86s2rgshubtfhlogbe310k3rluotscmus9moo1tvpn0nmp1efv8
+       closeFile : Handle ->{IO, Exception} ()
+       
+  667. -- #4e6qn65v05l32n380lpf536u4llnp6f6tvvt13hvo0bhqeh3f3i8bquekc120c8h59gld1mf02ok0sje7037ipg1fsu97fqrm01oi00
+       closeSocket : Socket ->{IO, Exception} ()
+       
+  668. -- #7o1e77u808vpg8i6k1mvutg8h6tdr14hegfad23e9sjou1ft10kvfr95goo0kv2ldqlsaa4pmvdl8d7jd6h252i3jija05b4vpqbg5g
+       Code.transitiveDeps : Link.Term
+       ->{IO} [(Link.Term, Code)]
+       
+  669. -- #sfud7h76up0cofgk61b7tf8rhdlugfmg44lksnpglfes1b8po26si7betka39r9j8dpgueorjdrb1i7v4g62m5bci1e971eqi8dblmo
+       compose : ∀ o g1 i1 g i.
+         (i1 ->{g1} o) -> (i ->{g} i1) -> i ->{g1, g} o
+       
+  670. -- #b0tsob9a3fegn5dkb57jh15smd7ho2qo78st6qngpa7a8hc88mccl7vhido41o4otokv5l8hjdj3nabtkmpni5ikeatd44agmqbhano
+       compose2 : ∀ o g2 i2 g1 g i i1.
+         (i2 ->{g2} o)
+         -> (i1 ->{g1} i ->{g} i2)
+         -> i1
+         -> i
+         ->{g2, g1, g} o
+       
+  671. -- #m632ocgh2rougfejkddsso3vfpf4dmg1f8bhf0k6sha4g4aqfmbeuct3eo0je6dv9utterfvotjdu32p0kojuo9fj4qkp2g1bt464eg
+       compose3 : ∀ o g3 i3 g2 g1 g i i1 i2.
+         (i3 ->{g3} o)
+         -> (i2 ->{g2} i1 ->{g1} i ->{g} i3)
+         -> i2
+         -> i1
+         -> i
+         ->{g3, g2, g1, g} o
+       
+  672. -- #ilkeid6l866bmq90d2v1ilqp9dsjo6ucmf8udgrokq3nr3mo9skl2vao2mo7ish136as52rsf19u9v3jkmd85bl08gnmamo4e5v2fqo
+       contains : Text -> Text -> Boolean
+       
+  673. -- #tgvna0i8ea98jvnd2oka85cdtas1prcbq3snvc4qfns6082mlckps2cspk8jln11mklg19bna025tog5m9sb671o27ujsa90lfrbnkg
+       crawl : [(Link.Term, Code)]
+       -> [Link.Term]
+       ->{IO} [(Link.Term, Code)]
+       
+  674. -- #o0qn048fk7tjb8e7d54vq5mg9egr5kophb9pcm0to4aj0kf39mv76c6olsm27vj309d7nhjh4nps7098fpvqe8j5cfg01ghf3bnju90
+       createTempDirectory : Text ->{IO, Exception} Text
+       
+  675. -- #4858f4krb9l4ot1hml21j48lp3bcvbo8b9unlk33b9a3ovu1jrbr1k56pnfhffkiu1bht2ovh0i82nn5jnoc5s5ru85qvua0m2ol43g
+       decodeCert : Bytes ->{Exception} SignedCert
+       
+  676. -- #ihbmfc4r7o3391jocjm6v4mojpp3hvt84ivqigrmp34vb5l3d7mmdlvh3hkrtebi812npso7rqo203a59pbs7r2g78ig6jvsv0nva38
+       delay : Nat ->{IO, Exception} ()
+       
+  677. -- #dsen29k7605pkfquesnaphhmlm3pjkfgm7m2oc90m53gqvob4l39p4g3id3pirl8emg5tcdmr81ctl3lk1enm52mldlfmlh1i85rjbg
+       directoryContents : Text ->{IO, Exception} [Text]
+       
+  678. -- #b22tpqhkq6kvt27dcsddnbfci2bcqutvhmumdven9c5psiilboq2mb8v9ekihtkl6mkartd5ml5u75u84v850n29l91de63lkg3ud38
+       Either.isLeft : Either a b -> Boolean
+       
+  679. -- #i1ec3csomb1pegm9r7ppabunabb7cq1t6bb6cvqtt72nd01jot7gde2mak288cbml910abbtho0smsbq17b2r33j599b0vuv7je04j8
+       Either.mapLeft : (i ->{g} o)
+       -> Either i b
+       ->{g} Either o b
+       
+  680. -- #f765l0pa2tb9ieciivum76s7bp8rdjr8j7i635jjenj9tacgba9eeomur4vv3uuh4kem1pggpmrn61a1e3im9g90okcm13r192f7alg
+       Either.raiseMessage : v -> Either Text b ->{Exception} b
+       
+  681. -- #9hifem8o2e1g7tdh4om9kfo98ifr60gfmdp8ci58djn17epm1b4m6idli8b373bsrg487n87n4l50ksq76avlrbh9q2jpobkk18ucvg
+       evalTest : '{IO, TempDirs, Exception, Stream Result} a
+       ->{IO, Exception} ([Result], a)
+       
+  682. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng
+       structural ability Exception
+       structural ability builtin.Exception
+       
+  683. -- #t20uuuiil07o22les8gv4sji7ju5esevloamnja3bjkrh2f250lgitv6595l6hlc2q64c1om0hhjqgter28dtnibb0dkr2j7e3ss530
+       Exception.catch : '{g, Exception} a
+       ->{g} Either Failure a
+       
+  684. -- #hbhvk2e00l6o7qhn8e7p6dc36bjl7ljm0gn2df5clidlrdoufsig1gt5pjhg72kl67folgg2b892kh9jc1oh0l79h4p8dqhcf1tkde0
+       Exception.failure : Text -> a -> Failure
+       
+  685. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng#0
+       Exception.raise,
+       builtin.Exception.raise : Failure
+       ->{Exception} x
+       
+  686. -- #5mqjoauctm02dlqdc10cc66relu40997d6o1u8fj7vv7g0i2mtacjc83afqhuekll1gkqr9vv4lq7aenanq4kf53kcce4l1srr6ip08
+       Exception.reraise : Either Failure a ->{Exception} a
+       
+  687. -- #1f774ia7im9i0cfp7l5a1g9tkvnd4m2940ga3buaf4ekd43dr1289vknghjjvi4qtevh7s61p5s573gpli51qh7e0i5pj9ggmeb69d0
+       Exception.toEither : '{ε, Exception} a
+       ->{ε} Either Failure a
+       
+  688. -- #li2h4hncbgmfi5scuah06rtdt8rjcipiv2t95hos15ol63usv78ti3vng7o9862a70906rum7nrrs9qd9q8iqu1rdcfe292r0al7n38
+       Exception.toEither.handler : Request {Exception} a
+       -> Either Failure a
+       
+  689. -- #5fi0ep8mufag822f18ukaffakrmm3ddg8a83dkj4gh2ks4e2c60sk9s8pmk92p69bvkcflql3rgoalp8ruth7fapqrks3kbmdl61b00
+       Exception.unsafeRun! : '{g, Exception} a ->{g} a
+       
+  690. -- #qdcih6h4dmf9a2tn2ndvn0br9ef41ubhcniadou1m6ro641gm2tn79m6boh5sr4q271oiui6ehbdqe53r0gobdeagotkjr67kieq3ro
+       expect : Text
+       -> (a -> a -> Boolean)
+       -> a
+       -> a
+       ->{Stream Result} ()
+       
+  691. -- #ngmnbge6f7nkehkkhj6rkit60rp3qlt0vij33itch1el3ta2ukrit4gvpn2n0j0s43sj9af53kphgs0h2n65bnqcr9pmasud2r7klsg
+       expectU : Text -> a -> a ->{Stream Result} ()
+       
+  692. -- #f54plhut9f6mg77r1f033vubik89irq1eri79d5pd6mqi03rq9em99mc90plurvjnmvho73ssof5fvndgmcg4fgrpvuuil7hb5qmebo
+       fail : Text -> b ->{Exception} c
+       
+  693. -- #mpe805fs330vqp5l5mg73deahken20dub4hrfvmuutfo97dikgagvimncfr6mfp1l24bjqes1m1dp11a3hop92u49b1fb45j8qs9hoo
+       fileExists : Text ->{IO, Exception} Boolean
+       
+  694. -- #cft2pjc05jljtlefm4osg96k5t2look2ujq1tgg5hoc5i3fkkatt9pf79g2ka461kq8nbmsggrvo2675ocl599to9e8nre5oef4scdo
+       fromB32 : Bytes ->{Exception} Bytes
+       
+  695. -- #13fpchr37ua0pr38ssr7j22pudmseuedf490aok18upagh0f00kg40guj9pgl916v9qurqrvu53f3lpsvi0s82hg3dtjacanrpjvs38
+       fromHex : Text -> Bytes
+       
+  696. -- #b36oslvh534s82lda0ghc5ql7p7nir0tknsluigulmpso22tjh62uiiq4lq9s3m97a2grkso0qofpb423p06olkkikrt4mfn15vpkug
+       getBuffering : Handle ->{IO, Exception} BufferMode
+       
+  697. -- #9vijttgmba0ui9cshmhmmvgn6ve2e95t168766h2n6pkviddebiimgipic5dbg5lmiht12g6np8a7e06jpk03rnue3ln5mbo4prde0g
+       getBytes : Handle -> Nat ->{IO, Exception} Bytes
+       
+  698. -- #c5oeqqglf28ungtq1im4fjdh317eeoba4537l1ntq3ob22v07rpgj9307udscbghlrior398hqm1ci099qmriim8cs975kocacsd9r0
+       getChar : Handle ->{IO, Exception} Char
+       
+  699. -- #j9jdo2pqvi4aktcfsb0n4ns1tk2be7dtckqdeedqp7n52oghsq82cgc1tv562rj1sf1abq2h0vta4uo6873cdbgrtrvd5cvollu3ovo
+       getEcho : Handle ->{IO, Exception} Boolean
+       
+  700. -- #0hj09gufk8fs2hvr6qij6pie8bp0h6hmm6hpsi8d5fvl1fp1dbk6u8c9p6h4eu2hle6ctgpdbepo9vit5atllkodogn6r0csar9fn1g
+       getLine : Handle ->{IO, Exception} Text
+       
+  701. -- #ck1nfg5fainelng0694jkdf9e06pmn60h7kvble1ff7hkc6jdgqtf7g5o3qevr7ic1bdhfn5n2rc3gde5bh6o9fpbit3ocs0av0scdg
+       getSomeBytes : Handle -> Nat ->{IO, Exception} Bytes
+       
+  702. -- #bk29bjnrcuh55usf3vocm4j1aml161p6ila7t82cpr3ub9vu0g9lsg2mspmfuefc4ig0qtdqk7nds4t3f68jp6o77e0h4ltbitqjpno
+       getTempDirectory : '{IO, Exception} Text
+       
+  703. -- #j8i534slc2rvakvmqcb6j28iatrh3d7btajai9qndutr0edi5aaoi2p5noditaococ4l104hdhhvjc5vr0rbcjoqrbng46fdeqtnf98
+       handlePosition : Handle ->{IO, Exception} Nat
+       
+  704. -- #bgf7sqs0h0p8bhm3t2ei8006oj1gjonvtkdejv2g9kar0kmvob9e88ceevdfh99jom9rs0hbalf1gut5juanudfcb8tpb1e9ta0vrm8
+       handshake : Tls ->{IO, Exception} ()
+       
+  705. -- #128490j1tmitiu3vesv97sqspmefobg1am38vos9p0vt4s1bhki87l7kj4cctquffkp40eanmr9ummfglj9i7s25jrpb32ob5sf2tio
+       hex : Bytes -> Text
+       
+  706. -- #ttjui80dbufvf3vgaddmcr065dpgl0rtp68i5cdht6tq4t2vk3i2vg60hi77rug368qijgijf8oui27te7o5oq0t0osm6dg65c080i0
+       id : a -> a
+       
+  707. -- #9qnapjbbdhcc2mjf1b0slm7mefu0idnj1bs4c5bckq42ruodftolnd193uehr31lc01air6d6b3j4ihurnks13n85h3r8rs16nqvj2g
+       isDirectory : Text ->{IO, Exception} Boolean
+       
+  708. -- #vb1e252fqt0q63hpmtkq2bkg5is2n6thejofnev96040thle5o1ia8dtq7dc6v359gtoqugbqg5tb340aqovrfticb63jgei4ncq3j8
+       isFileEOF : Handle ->{IO, Exception} Boolean
+       
+  709. -- #ahkhlm9sd7arpevos99sqc90g7k5nn9bj5n0lhh82c1uva52ltv0295ugc123l17vd1orkng061e11knqjnmk087qjg3vug3rs6mv60
+       isFileOpen : Handle ->{IO, Exception} Boolean
+       
+  710. -- #2a11371klrv2i8726knma0l3g14on4m2ucihpg65cjj9k930aefg65ovvg0ak4uv3i9evtnu0a5249q3i8ugheqd65cnmgquc1a88n0
+       isNone : Optional a -> Boolean
+       
+  711. -- #ln4avnqpdk7813vsrrr414hg0smcmufrl1c7b87nb7nb0h9cogp6arqa7fbgd7rgolffmgue698ovvefo18j1k8g30t4hbp23onm3l8
+       isSeekable : Handle ->{IO, Exception} Boolean
+       
+  712. -- #gop2v9s6l24ii1v6bf1nks2h0h18pato0vbsf4u3el18s7mp1jfnp4c7fesdf9sunnlv5f5a9fjr1s952pte87mf63l1iqki9bp0mio
+       List.all : (a ->{ε} Boolean) -> [a] ->{ε} Boolean
+       
+  713. -- #m2g5korqq5etr0qk1qrgjbaqktj4ks4bu9m3c4v3j9g8ktsd2e218nml6q8vo45bi3meb53csack40mle6clfrfep073e313b3jagt0
+       List.filter : (a ->{g} Boolean) -> [a] ->{g} [a]
+       
+  714. -- #8s836vq5jggucs6bj3bear30uhe6h9cskudjrdc772ghiec6ce2jqft09l1n05kd1n6chekrbgt0h8mkc9drgscjvgghacojm9e8c5o
+       List.foldLeft : (b ->{g} a ->{g} b) -> b -> [a] ->{g} b
+       
+  715. -- #m5tlb5a0m4kp5b4m9oq9vhda9d7nhu2obn2lpmosal0ebij9gon4gkd1aq0b3b61jtsc1go0hi7b2sm2memtil55ijq32b2n0k39vko
+       List.forEach : [a] -> (a ->{e} ()) ->{e} ()
+       
+  716. -- #j9ve4ionu2sn7f814t0t4gc75objke2drgnfvvvb50v2f57ss0hlsa3ai5g5jsk2t4b8s37ocrtmte7nktfb2vjf8508ksvrc6llu30
+       listen : Socket ->{IO, Exception} ()
+       
+  717. -- #s0f4et1o1ns8cmmvp3i0cm6cmmv5qaf99qm2q4jmgpciof6ntmuh3mpr4epns3ocskn8raacbvm30ovvj2b6arv0ff7iks31rannbf0
+       loadCodeBytes : Bytes ->{Exception} Code
+       
+  718. -- #gvaed1m07qihc9c216125sur1q9a7i5ita44qnevongg4jrbd8k2plsqhdur45nn6h3drn6lc3iidp1b208ht8s73fg2711l76c7j4g
+       loadSelfContained : Text ->{IO, Exception} a
+       
+  719. -- #g1hqlq27e3stamnnfp6q178pleeml9sbo2d6scj2ikubocane5cvf8ctausoqrgj9co9h56ttgt179sgktc0bei2r37dmtj51jg0ou8
+       loadValueBytes : Bytes
+       ->{IO, Exception} ([(Link.Term, Code)], Value)
+       
+  720. -- #tlllu51stumo77vi2e5m0e8m05qletfbr3nea3d84dcgh66dq4s3bt7kdbf8mpdqh16mmnoh11kr3n43m8b5g4pf95l9gfbhhok1h20
+       MVar.put : MVar i -> i ->{IO, Exception} ()
+       
+  721. -- #3b7lp7s9m31mcvh73nh4gfj1kal6onrmppf35esvmma4jsg7bbm7a8tsrfcb4te88f03r97dkf7n1f2kcc6o7ng4vurp95svfj2fg7o
+       MVar.read : MVar o ->{IO, Exception} o
+       
+  722. -- #be8m7lsjnf31u87pt5rvn04c9ellhbm3p56jgapbp8k7qp0v3mm7beh81luoifp17681l0ldjj46gthmmu32lkn0jnejr3tedjotntg
+       MVar.swap : MVar o -> o ->{IO, Exception} o
+       
+  723. -- #c2qb0ca2dj3rronbp4slj3ph56p0iopaos7ib37hjunpkl1rcl1gp820dpg8qflhvt9cm2l1bfm40rkdslce2sr6f0oru5lr5cl5nu0
+       MVar.take : MVar o ->{IO, Exception} o
+       
+  724. -- #ht0k9hb3k1cnjsgmtu9klivo074a2uro4csh63m1sqr2483rkojlj7abcf0jfmssbfig98i6is1osr2djoqubg3bp6articvq9o8090
+       newClient : ClientConfig -> Socket ->{IO, Exception} Tls
+       
+  725. -- #coeloqmjin6lais8u6j0plh5f1601lpcue4ejfcute46opams4vsbkplqj6jg6af0uecjie3mbclv40b3jumghsf09aavvucrc0d148
+       newServer : ServerConfig -> Socket ->{IO, Exception} Tls
+       
+  726. -- #ocvo5mvs8fghsf715tt4mhpj1pu8e8r7pq9nue63ut0ol2vnv70k7t6tavtsljlmdib9lo3bt669qac94dk53ldcgtukvotvrlfkan0
+       openFile : Text -> FileMode ->{IO, Exception} Handle
+       
+  727. -- #c58qbcgd90d965dokk7bu82uehegkbe8jttm7lv4j0ohgi2qm3e3p4v1qfr8vc2dlsmsl9tv0v71kco8c18mneule0ntrhte4ks1090
+       printLine : Text ->{IO, Exception} ()
+       
+  728. -- #dck7pb7qv05ol3b0o76l88a22bc7enl781ton5qbs2umvgsua3p16n22il02m29592oohsnbt3cr7hnlumpdhv2ibjp6iji9te4iot0
+       printText : Text ->{IO} Either Failure ()
+       
+  729. -- #i9lm1g1j0p4qtakg164jdlgac409sgj1cb91k86k0c44ssajbluovuu7ptm5uc20sjgedjbak3iji8o859ek871ul51b8l30s4uf978
+       putBytes : Handle -> Bytes ->{IO, Exception} ()
+       
+  730. -- #84j6ua3924v85vh2a581de7sd8pee1lqbp1ibvatvjtui9hvk36sv2riabu0v2r0s25p62ipnvv4aeadpg0u8m5ffqrc202i71caopg
+       readFile : Text ->{IO, Exception} Bytes
+       
+  731. -- #pk003cv7lvidkbmsnne4mpt20254gh4hd7vvretnbk8na8bhr9fg9776rp8pt9srhiucrd1c7sjl006vmil9e78p40gdcir81ujil2o
+       ready : Handle ->{IO, Exception} Boolean
+       
+  732. -- #unn7qak4qe0nbbpf62uesu0fe8i68o83l4o7f6jcblefbla53fef7a63ts28fh6ql81o5c04j44g7m5rq9aouo73dpeprbl5lka8170
+       receive : Tls ->{IO, Exception} Bytes
+       
+  733. -- #ugs4208vpm97jr2ecmr7l9h4e22r1ije6v379m4v6229c8o7hk669ba63bor4pe6n1bm24il87iq2d99sj78lt6n5eqa1fre0grn93g
+       removeDirectory : Text ->{IO, Exception} ()
+       
+  734. -- #6pia69u5u5rja1jk04v3i9ke24gf4b1t7vnaj0noogord6ekiqhf72qfkc1n08rd11f2cbkofni5rd5u7t1qkgslbi40hut35pfi1v0
+       renameDirectory : Text -> Text ->{IO, Exception} ()
+       
+  735. -- #amtsq2jq1k75r309esfp800a8slelm4d3q9i1pq1qqs3pil13at916958sf9ucb4607kpktbnup7nc58ecoq8mcs01e2a03d08agn18
+       runTest : '{IO, TempDirs, Exception, Stream Result} a
+       ->{IO} [Result]
+       
+  736. -- #va4fcp72qog4dvo8dn4gipr2i1big1lqgpcqfuv9kc98ut8le1bj23s68df7svam7b5sg01s4uf95o458f4rs90mtp71nj84t90ra1o
+       saveSelfContained : a -> Text ->{IO, Exception} ()
+       
+  737. -- #5hbn4gflbo8l4jq0s9l1r0fpee6ie44fbbl6j6km67l25inaaq5avg18g7j6mig2m6eaod04smif7el34tcclvvf8oll39rfonupt2o
+       saveTestCase : Text
+       -> (a -> Text)
+       -> a
+       ->{IO, Exception} ()
+       
+  738. -- #v2otbk1e0e81d6ea9i3j1kivnfam6rk6earsjbjljv4mmrk1mgfals6jhfd74evor6al9mkb5gv8hf15f02807f0aa0hnsg9fas1qco
+       seekHandle : Handle
+       -> SeekMode
+       -> Int
+       ->{IO, Exception} ()
+       
+  739. -- #a98jlos4rj2um55iksdin9p5djo6j70qmuitoe2ff3uvkefb8pqensorln5flr3pm8hkc0lqkchbd63cf9tl0kqnqu3i17kvqnm35g0
+       send : Tls -> Bytes ->{IO, Exception} ()
+       
+  740. -- #qrdia2sc9vuoi7u3a4ukjk8lv0rlhn2i2bbin1adbhcuj79jn366dv3a8t52hpil0jtgkhhuiavibmdev63j5ndriod33rkktjekqv8
+       serverSocket : Optional Text
+       -> Text
+       ->{IO, Exception} Socket
+       
+  741. -- #3vft70875p42eao55rhb61siobuei4h0e9vlu4bbgucjo296c2vfjpucacovnu9538tvup5c7lo9123se8v4fe7m8q9aiqbkjpumkao
+       setBuffering : Handle -> BufferMode ->{IO, Exception} ()
+       
+  742. -- #erqshamlurgahpd4rroild36cc5e4rk56r38r53vcbg8cblr82c6gfji3um8f09ffgjlg58g7r32mtsbvjlcq4c65v0jn3va9888mao
+       setEcho : Handle -> Boolean ->{IO, Exception} ()
+       
+  743. -- #ugar51qqij4ur24frdi84eqdkvqa0fbsi4v6e2586hi3tai52ovtpm3f2dc9crnfv8pk0ppq6b5tv3utl4sl49n5aecorgkqddr7i38
+       snd : ∀ a a1. (a1, a) -> a
+       
+  744. -- #leoq6smeq8to5ej3314uuujmh6rfbcsdb9q8ah8h3ohg9jq5kftc93mq671o0qh2he9vqgd288k0ecea3h7eerpbgjt6a8p843tmon8
+       socketAccept : Socket ->{IO, Exception} Socket
+       
+  745. -- #s43jbp19k91qq704tidpue2vs2re1lh4mtv46rdmdnurkdndst7u0k712entcvip160vh9cilmpamikmflbprg5up0k6cl15b8tr5l0
+       socketPort : Socket ->{IO, Exception} Nat
+       
+  746. -- #3rp8h0dt7g60nrjdehuhqga9dmomti5rdqho7r1rm5rg5moet7kt3ieempo7c9urur752njachq6k48ggbic4ugbbv75jl2mfbk57a0
+       startsWith : Text -> Text -> Boolean
+       
+  747. -- #elsab3sc7p4c6bj73pgvklv0j7qu268rn5isv6micfp7ib8grjoustpqdq0pkd4a379mr5ijb8duu2q0n040osfurppp8pt8vaue2fo
+       stdout : Handle
+       
+  748. -- #rfi1v9429f9qluv533l2iba77aadttilrpmnhljfapfnfa6sru2nr8ibpqvib9nc4s4nb9s1as45upsfqfqe6ivqi2p82b2vd866it8
+       structural ability Stream a
+       
+  749. -- #2jl99er43tnksj8r8oveap5ger9uqlvj0u0ghfs0uqa7i6m45jk976n7a726jb7rtusjdu2p8hbbcgmoacvke7k5o3kdgoj57c3v2v8
+       Stream.collect : '{e, Stream a} r ->{e} ([a], r)
+       
+  750. -- #rnuje46fvuqa4a8sdgl9e250a2gcmhtsscr8bdonj2bduhrst38ur7dorv3ahr2ghf9cufkfit7ndh9qb9gspbfapcnn3sol0l2moqg
+       Stream.collect.handler : Request {Stream a} r -> ([a], r)
+       
+  751. -- #rfi1v9429f9qluv533l2iba77aadttilrpmnhljfapfnfa6sru2nr8ibpqvib9nc4s4nb9s1as45upsfqfqe6ivqi2p82b2vd866it8#0
+       Stream.emit : a ->{Stream a} ()
+       
+  752. -- #c70gf5m1blvh8tg4kvt1taee036fr7r22bbtqcupac5r5igs102nj077vdl0nimef94u951kfcl9a5hcevo01j04v9o6v3cpndq41bo
+       Stream.toList : '{Stream a} r -> [a]
+       
+  753. -- #ul69cgsrsspjni8b0hqnt4kt4bk7sjtp6jvlhhofom7bemu9nb2kimm6tt1raigr7j86afgmnjnrfabn6a5l5v1t219uidiu22ueiv0
+       Stream.toList.handler : Request {Stream a} r -> [a]
+       
+  754. -- #58d8kfuq8sqbipa1aaijjhm28pa6a844h19mgg5s4a1h160etbulig21cm0pcnfla8fisqvrp80840g9luid5u8amvcc8sf46pd25h8
+       systemTime : '{IO, Exception} Nat
+       
+  755. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18
+       structural ability TempDirs
+       
+  756. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18#0
+       TempDirs.newTempDir : Text ->{TempDirs} Text
+       
+  757. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18#1
+       TempDirs.removeDir : Text ->{TempDirs} ()
+       
+  758. -- #natgur73q6b4c3tp5jcor0v1cdnplh0n3fhm4qvhg4v74u3e3ff1352shs1lveot83lj82qqbl78n40qi9a132fhkmaa6g5s1ja91go
+       terminate : Tls ->{IO, Exception} ()
+       
+  759. -- #i3pbnc98rbfug5dnnvpd4uahm2e5fld2fu0re9r305isffr1r43048h7ql6ojdbjcsvjr6h91s6i026na046ltg5ff59klla6e7vq98
+       testAutoClean : '{IO} [Result]
+       
+  760. -- #spepthutvs3p6je794h520665rh8abl36qg43i7ipvj0mtg5sb0sbemjp2vpu9j3feithk2ae0sdtcmb8afoglo9rnvl350380t21h0
+       Text.fromUtf8 : Bytes ->{Exception} Text
+       
+  761. -- #32q9jqhmi8f08pec3hj0je4u7k52f9f1hdfsmn9ncg2kpki5da9dabigplvdcot3a00k7s5npc4n78psd6ojaumqjla259e9pqd4ov8
+       structural ability Throw e
+       
+  762. -- #32q9jqhmi8f08pec3hj0je4u7k52f9f1hdfsmn9ncg2kpki5da9dabigplvdcot3a00k7s5npc4n78psd6ojaumqjla259e9pqd4ov8#0
+       Throw.throw : e ->{Throw e} a
+       
+  763. -- #vri6fsnl704n6aqs346p6ijcbkcsv9875edr6b74enumrhbjiuon94ir4ufmrrn84k9b2jka4f05o16mcvsjrjav6gpskpiu4sknd1g
+       uncurry : ∀ o g1 i g i1.
+         (i1 ->{g} i ->{g1} o) -> (i1, i) ->{g1, g} o
+       
+  764. -- #u2j1bektndcqdo1m13fvu6apt9td96s4tqonelg23tauklak2pqnbisf41v632fmlrcc6f9orqo3iu9757q36ue5ol1khe0hh8pktro
+       Value.transitiveDeps : Value ->{IO} [(Link.Term, Code)]
+       
+  765. -- #o5bg5el7ckak28ib98j5b6rt26bqbprpddd1brrg3s18qahhbbe3uohufjjnt5eenvtjg0hrvnvpra95jmdppqrovvmcfm1ih2k7guo
+       void : x -> ()
+       
+  766. -- #8ugamqlp7a4g0dmbcvipqfi8gnuuj23pjbdfbof11naiun1qf8otjcap80epaom2kl9fv5rhjaudt4558n38dovrc0lhipubqjgm8mg
+       writeFile : Text -> Bytes ->{IO, Exception} ()
+       
+  767. -- #lcmj2envm11lrflvvcl290lplhvbccv82utoej0lg0eomhmsf2vrv8af17k6if7ff98fp1b13rkseng3fng4stlr495c8dn3gn4k400
+       |> : a -> (a ->{g} t) ->{g} t
+       
+  
+
+```


### PR DESCRIPTION
## Overview

This PR just adds a transcript that includes all of the hashes in (whatever old version of) base that is available in `unison-src/transcripts-using-base`.

The purpose is give us more confidence to land refactorings in and around our hashing code like #3686.