### PR TITLE
Fix build with cabal

### DIFF
--- a/contrib/cabal.project
+++ b/contrib/cabal.project
@@ -3,20 +3,27 @@ packages:
   parser-typechecker
   unison-core
   unison-cli
+  unison-hashing-v2
   unison-share-api
+  unison-syntax
 
   codebase2/codebase
   codebase2/codebase-sqlite
+  codebase2/codebase-sqlite-hashing-v2
   codebase2/codebase-sync
   codebase2/core
-  codebase2/util
   codebase2/util-serialization
   codebase2/util-term
 
   lib/unison-prelude
   lib/unison-sqlite
   lib/unison-util-base32hex
+  lib/unison-util-base32hex-orphans-aeson
+  lib/unison-util-base32hex-orphans-sqlite
+  lib/unison-util-bytes
+  lib/unison-util-cache
   lib/unison-util-relation
+  lib/unison-util-rope
   lib/unison-pretty-printer
 
 source-repository-package
@@ -26,21 +33,21 @@ source-repository-package
 
 source-repository-package
   type: git
-  location: https://github.com/unisonweb/haskeline.git
-  tag: 2944b11d19ee034c48276edc991736105c9d6143
-
-source-repository-package
-  type: git
-  location: https://github.com/unisonweb/megaparsec.git
-  tag: c4463124c578e8d1074c04518779b5ce5957af6b
-
-source-repository-package
-  type: git
   location: https://github.com/unisonweb/shellmet.git
   tag: 2fd348592c8f51bb4c0ca6ba4bc8e38668913746
 
-allow-newer: 
-  haskeline:base
+source-repository-package
+  type: git
+  location: https://github.com/awkward-squad/ki.git
+  tag: 563e96238dfe392dccf68d93953c8f30fd53bec8
+  subdir: ki
+
+source-repository-package
+  type: git
+  location: https://github.com/jneira/haskeline.git
+  tag: b7c8b3298426188210fd23555a49bcb8105b264d
+
+constraints: aeson < 2.0, fsnotify < 0.4
 
 -- For now there is no way to apply ghc-options for all local packages
 -- See https://cabal.readthedocs.io/en/latest/cabal-project.html#package-configuration-options
@@ -56,7 +63,13 @@ package unison-core
 package unison-cli
   ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
+package unison-hashing-v2
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+
 package unison-share-api
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+
+package unison-syntax
   ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
 package codebase
@@ -65,13 +78,13 @@ package codebase
 package codebase-sqlite
   ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
+package codebase-sqlite-hashing-v2
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+
 package codebase-sync
   ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
 package core
-  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
-
-package util
   ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
 package util-serialization
@@ -86,7 +99,25 @@ package unison-prelude
 package unison-sqlite
   ghc-options: -Wall         -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
+package unison-util-base32hex
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+
+package unison-util-base32hex-orphans-aeson
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+
+package unison-util-base32hex-orphans-sqlite
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+
+package unison-util-bytes
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+
+package unison-util-cache
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+
 package unison-util-relation
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+
+package unison-util-rope
   ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
 package unison-pretty-printer

--- a/contrib/cabal.project
+++ b/contrib/cabal.project
@@ -16,10 +16,13 @@ packages:
   codebase2/util-term
 
   lib/unison-prelude
+  lib/unison-hash
+  lib/unison-hash-orphans-aeson
+  lib/unison-hash-orphans-sqlite
+  lib/unison-hashing
+  lib/unison-prelude
   lib/unison-sqlite
   lib/unison-util-base32hex
-  lib/unison-util-base32hex-orphans-aeson
-  lib/unison-util-base32hex-orphans-sqlite
   lib/unison-util-bytes
   lib/unison-util-cache
   lib/unison-util-relation
@@ -93,6 +96,9 @@ package util-serialization
 package util-term
   ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
+package unison-hashing
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+
 package unison-prelude
   ghc-options: -Wall         -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
@@ -100,12 +106,6 @@ package unison-sqlite
   ghc-options: -Wall         -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
 package unison-util-base32hex
-  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
-
-package unison-util-base32hex-orphans-aeson
-  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
-
-package unison-util-base32hex-orphans-sqlite
   ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
 package unison-util-bytes

--- a/contrib/cabal.project
+++ b/contrib/cabal.project
@@ -1,12 +1,4 @@
 packages:
-  yaks/easytest
-  parser-typechecker
-  unison-core
-  unison-cli
-  unison-hashing-v2
-  unison-share-api
-  unison-syntax
-
   codebase2/codebase
   codebase2/codebase-sqlite
   codebase2/codebase-sqlite-hashing-v2
@@ -15,19 +7,31 @@ packages:
   codebase2/util-serialization
   codebase2/util-term
 
-  lib/unison-prelude
+  lib/orphans/network-uri-orphans-sqlite
+  lib/orphans/unison-core-orphans-sqlite
+  lib/orphans/unison-hash-orphans-aeson
+  lib/orphans/unison-hash-orphans-sqlite
+  lib/orphans/uuid-orphans-sqlite
+
   lib/unison-hash
-  lib/unison-hash-orphans-aeson
-  lib/unison-hash-orphans-sqlite
   lib/unison-hashing
   lib/unison-prelude
+  lib/unison-pretty-printer
   lib/unison-sqlite
   lib/unison-util-base32hex
   lib/unison-util-bytes
   lib/unison-util-cache
   lib/unison-util-relation
   lib/unison-util-rope
-  lib/unison-pretty-printer
+
+  parser-typechecker
+  unison-core
+  unison-cli
+  unison-hashing-v2
+  unison-share-api
+  unison-share-projects-api
+  unison-syntax
+  yaks/easytest
 
 source-repository-package
   type: git
@@ -36,45 +40,13 @@ source-repository-package
 
 source-repository-package
   type: git
-  location: https://github.com/unisonweb/shellmet.git
-  tag: 2fd348592c8f51bb4c0ca6ba4bc8e38668913746
+  location: https://github.com/unisonweb/haskeline.git
+  tag: 9275eea7982dabbf47be2ba078ced669ae7ef3d5
 
-source-repository-package
-  type: git
-  location: https://github.com/awkward-squad/ki.git
-  tag: 563e96238dfe392dccf68d93953c8f30fd53bec8
-  subdir: ki
-
-source-repository-package
-  type: git
-  location: https://github.com/jneira/haskeline.git
-  tag: b7c8b3298426188210fd23555a49bcb8105b264d
-
-constraints: aeson < 2.0, fsnotify < 0.4
+constraints: fsnotify < 0.4
 
 -- For now there is no way to apply ghc-options for all local packages
 -- See https://cabal.readthedocs.io/en/latest/cabal-project.html#package-configuration-options
-package easytest
-  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
-
-package parser-typechecker
-  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
-
-package unison-core
-  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
-
-package unison-cli
-  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
-
-package unison-hashing-v2
-  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
-
-package unison-share-api
-  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
-
-package unison-syntax
-  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
-
 package codebase
   ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
@@ -87,23 +59,41 @@ package codebase-sqlite-hashing-v2
 package codebase-sync
   ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
-package core
-  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
-
-package util-serialization
+package util-serializatio
   ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
 package util-term
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+
+package network-uri-orphans-sqlite
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+
+package unison-core-orphans-sqlite
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+
+package unison-hash-orphans-aeson
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+
+package unison-hash-orphans-sqlite
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+
+package uuid-orphans-sqlite
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+
+package unison-hash
   ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
 package unison-hashing
   ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
 package unison-prelude
-  ghc-options: -Wall         -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+
+package unison-pretty-printer
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
 package unison-sqlite
-  ghc-options: -Wall         -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
 package unison-util-base32hex
   ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
@@ -120,7 +110,28 @@ package unison-util-relation
 package unison-util-rope
   ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
-package unison-pretty-printer
+package parser-typechecker
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+
+package unison-cli
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+
+package unison-core
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+
+package unison-hashing-v2
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+
+package unison-share-api
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+
+package unison-share-projects-api
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+
+package unison-syntax
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+
+package easytest
   ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
 -- This options are applied to all packages, local ones and also external dependencies.

--- a/development.markdown
+++ b/development.markdown
@@ -111,6 +111,10 @@ its location on the command line.
 
 * The install directory can be modified with the option `--installdir: ...`
 
+* Take in account that if you want to load the project in haskell-language-server using cabal instead stack you will need:
+  * Copy or link `./contrib/cabal.project` to `./cabal.project`
+  * Delete or rename the existing `./hie.yaml`. The default behaviour without `hie.yaml` works with cabal.
+
 ## Building on Windows
 
 ### I get an error about unison/sql/something


### PR DESCRIPTION
The pr updates cabal.project to adjust it to last structural changes.
Unfortunately the codebase now uses th referencing files with relative paths and stack and cabal sets a different cwd 😟 (https://github.com/haskell/haskell-language-server/issues/481)
Not sure how coud we solve that behaviour tbh. I believe atleats stack sets some C defs and we could add CPP conditions but i don't like it at all.

Another caveat: the haskeline commit 2944b11d19ee034c48276edc991736105c9d6143 does not exist anymore.
It is being referenced in stack.yaml but i am not sure how is even working. I've replicated the commit in my repo, but obviously it cant be the definitive solution.

The cabal build should be checked in ci to keep it sync (even with an optional job)
