### PR TITLE
Create UI url with namespace and definition reference

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -12,6 +12,7 @@ import Control.Concurrent.STM (atomically)
 import qualified Control.Error.Util as ErrorUtil
 import Control.Exception (catch)
 import Control.Lens
+import qualified Control.Lens as Lens
 import Control.Monad.Reader (ask)
 import Control.Monad.State (StateT)
 import qualified Control.Monad.State as State
@@ -45,10 +46,13 @@ import System.Process
     readCreateProcessWithExitCode,
     shell,
   )
-import qualified U.Codebase.Branch.Diff as V2Branch
+import qualified U.Codebase.Branch.Diff as V2Branch.Diff
+import qualified U.Codebase.Branch.Type as V2Branch
 import qualified U.Codebase.Causal as V2Causal
 import U.Codebase.HashTags (CausalHash (..))
 import qualified U.Codebase.Reference as V2 (Reference)
+import qualified U.Codebase.Referent as V2 (Referent)
+import qualified U.Codebase.Referent as V2.Referent
 import qualified U.Codebase.Reflog as Reflog
 import qualified U.Codebase.Sqlite.Project as Sqlite
 import qualified U.Codebase.Sqlite.ProjectBranch as Sqlite
@@ -137,6 +141,7 @@ import qualified Unison.CommandLine.InputPattern as InputPattern
 import qualified Unison.CommandLine.InputPatterns as IP
 import qualified Unison.CommandLine.InputPatterns as InputPatterns
 import Unison.ConstructorReference (GConstructorReference (..))
+import qualified Unison.ConstructorType as ConstructorType
 import Unison.Core.Project (ProjectAndBranch (..), ProjectBranchName, ProjectName)
 import qualified Unison.DataDeclaration as DD
 import qualified Unison.Hash as Hash
@@ -356,7 +361,7 @@ loop e = do
                     P.lines
                       [ "The API information is as follows:",
                         P.newline,
-                        P.indentN 2 (P.hiBlue ("UI: " <> fromString (Server.urlFor Server.UI baseUrl))),
+                        P.indentN 2 (P.hiBlue ("UI: " <> fromString (Server.urlFor (Server.UI Path.absoluteEmpty Nothing) baseUrl))),
                         P.newline,
                         P.indentN 2 (P.hiBlue ("API: " <> fromString (Server.urlFor Server.Api baseUrl)))
                       ]
@@ -535,11 +540,73 @@ loop e = do
               Cli.updateRoot prev description
               (ppe, diff) <- diffHelper (Branch.head prev) (Branch.head rootBranch)
               Cli.respondNumbered (Output.ShowDiffAfterUndo ppe diff)
-            UiI -> do
-              Cli.Env {serverBaseUrl} <- ask
+            UiI path' -> do
+              Cli.Env {serverBaseUrl, codebase} <- ask
               whenJust serverBaseUrl \url -> do
-                _success <- liftIO (openBrowser (Server.urlFor Server.UI url))
+                (perspective, definitionRef) <-
+                  getUIUrlParts codebase
+
+                _success <- liftIO (openBrowser (Server.urlFor (Server.UI perspective definitionRef) url))
                 pure ()
+              where
+                getUIUrlParts :: Codebase m Symbol Ann -> Cli (Path.Absolute, Maybe (Server.DefinitionReference))
+                getUIUrlParts codebase = do
+                  currentPath <- Cli.getCurrentPath
+                  let absPath = Path.resolve currentPath path'
+
+                  case Lens.unsnoc absPath of
+                    Just (abs, nameSeg) -> do
+                      namespaceBranch <-
+                        Cli.runTransaction
+                          (Codebase.getShallowBranchAtPath (Path.unabsolute abs) Nothing)
+
+                      let terms = maybe Set.empty Map.keysSet (Map.lookup nameSeg (V2Branch.terms namespaceBranch))
+                      let types = maybe Set.empty Map.keysSet (Map.lookup nameSeg (V2Branch.types namespaceBranch))
+
+                      -- Only safe to force in toTypeReference and toTermReference
+                      case (Set.lookupMin terms, Set.lookupMin types) of
+                        (Just te, _) -> do
+                          let name = Path.unsafeToName $ Path.fromPath' path'
+                          defRef <- Cli.runTransaction (toTermReference codebase name te)
+
+                          if Path.isAbsolute path'
+                            then pure (Path.absoluteEmpty, Just defRef)
+                            else pure (currentPath, Just defRef)
+                        (Nothing, Just ty) ->
+                          let name = Path.unsafeToName $ Path.fromPath' path'
+                              defRef = toTypeReference name ty
+                           in if Path.isAbsolute path'
+                                then pure (Path.absoluteEmpty, Just defRef)
+                                else pure (currentPath, Just defRef)
+                        -- Catch all that uses the absPath to build the perspective.
+                        -- Also catches the case where a namespace arg was given.
+                        (Nothing, Nothing) ->
+                          pure (absPath, Nothing)
+                    Nothing ->
+                      pure (absPath, Nothing)
+
+                toTypeReference :: Name -> V2.Reference -> Server.DefinitionReference
+                toTypeReference name reference =
+                  Server.TypeReference $
+                    HQ.fromNamedReference name (Conversions.reference2to1 reference)
+
+                toTermReference :: Codebase m Symbol Ann -> Name -> V2.Referent -> Sqlite.Transaction Server.DefinitionReference
+                toTermReference codebase name referent = do
+                  case referent of
+                    V2.Referent.Ref reference ->
+                      pure $
+                        Server.TermReference $
+                          HQ.fromNamedReference name (Conversions.reference2to1 reference)
+                    V2.Referent.Con _ _ -> do
+                      v1Referent <- Conversions.referent2to1 (Codebase.getDeclType codebase) referent
+                      let hq = HQ.fromNamedReferent name v1Referent
+
+                      pure case v1Referent of
+                        Referent.Con _ ConstructorType.Data ->
+                          Server.DataConstructorReference hq
+                        Referent.Con _ ConstructorType.Effect ->
+                          Server.AbilityConstructorReference hq
+                        Referent.Ref _ -> error "Impossible! *twirls mustache*"
             DocToMarkdownI docName -> do
               basicPrettyPrintNames <- getBasicPrettyPrintNames
               hqLength <- Cli.runTransaction Codebase.hashLength
@@ -1344,8 +1411,8 @@ loop e = do
                 Cli.runTransaction do
                   fromBranch <- Codebase.expectCausalBranchByCausalHash fromCH >>= V2Causal.value
                   toBranch <- Codebase.expectCausalBranchByCausalHash toCH >>= V2Causal.value
-                  let treeDiff = V2Branch.diffBranches fromBranch toBranch
-                  nameChanges <- V2Branch.allNameChanges Nothing treeDiff
+                  let treeDiff = V2Branch.Diff.diffBranches fromBranch toBranch
+                  nameChanges <- V2Branch.Diff.allNameChanges Nothing treeDiff
                   pure (DisplayDebugNameDiff nameChanges)
               Cli.respond output
             DeprecateTermI {} -> Cli.respond NotImplemented
@@ -1587,7 +1654,7 @@ inputDescription input =
     SwitchBranchI {} -> wat
     TestI {} -> wat
     TodoI {} -> wat
-    UiI -> wat
+    UiI {} -> wat
     UpI {} -> wat
     VersionI -> wat
   where
@@ -1744,7 +1811,7 @@ handleDiffNamespaceToPatch description input = do
         branch1 <- ExceptT (Cli.resolveAbsBranchIdV2 absBranchId1)
         branch2 <- ExceptT (Cli.resolveAbsBranchIdV2 absBranchId2)
         lift do
-          branchDiff <- V2Branch.nameBasedDiff (V2Branch.diffBranches branch1 branch2)
+          branchDiff <- V2Branch.Diff.nameBasedDiff (V2Branch.Diff.diffBranches branch1 branch2)
           termEdits <-
             (branchDiff ^. #terms)
               & Relation.domain

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -214,7 +214,7 @@ data Input
   | DebugNameDiffI ShortCausalHash ShortCausalHash
   | QuitI
   | ApiI
-  | UiI
+  | UiI Path'
   | DocToMarkdownI Name
   | DocsToHtmlI Path' FilePath
   | GistI GistInput

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -451,12 +451,18 @@ api =
 ui :: InputPattern
 ui =
   InputPattern
-    "ui"
-    []
-    I.Visible
-    []
-    "`ui` opens the Codebase UI in the default browser."
-    (const $ pure Input.UiI)
+    { patternName = "ui",
+      aliases = [],
+      visibility = I.Visible,
+      argTypes = [],
+      help = P.wrap "`ui` opens the Local UI in the default browser.",
+      parse = \case
+        [] -> pure $ Input.UiI Path.relativeEmpty'
+        [path] -> first fromString $ do
+          p <- Path.parsePath' path
+          pure $ Input.UiI p
+        _ -> Left (I.help ui)
+    }
 
 undo :: InputPattern
 undo =

--- a/unison-cli/unison/Main.hs
+++ b/unison-cli/unison/Main.hs
@@ -275,7 +275,7 @@ main = withCP65001 . runInUnboundThread . Ki.scoped $ \scope -> do
                             [ "I've started the Codebase API server at",
                               P.string $ Server.urlFor Server.Api baseUrl,
                               "and the Codebase UI at",
-                              P.string $ Server.urlFor Server.UI baseUrl
+                              P.string $ Server.urlFor (Server.UI Path.absoluteEmpty Nothing) baseUrl
                             ]
                         PT.putPrettyLn $
                           P.string "Running the codebase manager headless with "

--- a/unison-core/src/Unison/HashQualified'.hs
+++ b/unison-core/src/Unison/HashQualified'.hs
@@ -14,6 +14,7 @@ import Unison.ShortHash (ShortHash)
 import qualified Unison.ShortHash as SH
 import Prelude hiding (take)
 
+-- | Like Unison.HashQualified, but doesn't support a HashOnly variant
 data HashQualified n = NameOnly n | HashQualified n ShortHash
   deriving stock (Eq, Functor, Generic, Foldable, Ord, Show, Traversable)
 

--- a/unison-share-api/src/Unison/Server/CodebaseServer.hs
+++ b/unison-share-api/src/Unison/Server/CodebaseServer.hs
@@ -87,6 +87,7 @@ import Unison.Codebase (Codebase)
 import qualified Unison.Codebase.Path as Path
 import qualified Unison.Codebase.Runtime as Rt
 import Unison.HashQualified
+import qualified Unison.HashQualified as HQ
 import Unison.Name as Name (Name, segments)
 import qualified Unison.NameSegment as NameSegment
 import Unison.Parser.Ann (Ann)
@@ -164,6 +165,24 @@ data Service
 instance Show BaseUrl where
   show url = urlHost url <> ":" <> show (urlPort url) <> "/" <> (URI.encode . unpack . urlToken $ url)
 
+-- | Create a Service URL, either for the UI or the API
+--
+-- Examples:
+--
+-- >>> urlFor Api { urlHost = "https://localhost", urlToken = "asdf", urlPort = Port 1234 }
+-- "https://localhost:1234/asdf/api"
+--
+-- >>> urlFor
+-- >>>   UI
+-- >>>     (Path.absoluteEmpty)
+-- >>>     (Just (TermReference (NameOnly (Name (NameSegment "base.data.List.map")))))
+-- "https://localhost:1234/asdf/ui/latest/terms/base/data/List/map"
+--
+-- >>> urlFor
+-- >>>   UI
+-- >>>     (Path.Absolute (Path.fromText "base.data"))
+-- >>>     (Just (TermReference (NameOnly (Name (NameSegment "List.map")))))
+-- "https://localhost:1234/asdf/ui/latest/namespaces/;/terms/base/data/List/map"
 urlFor :: Service -> BaseUrl -> String
 urlFor service baseUrl =
   case service of

--- a/unison-share-api/src/Unison/Server/CodebaseServer.hs
+++ b/unison-share-api/src/Unison/Server/CodebaseServer.hs
@@ -87,7 +87,6 @@ import Unison.Codebase (Codebase)
 import qualified Unison.Codebase.Path as Path
 import qualified Unison.Codebase.Runtime as Rt
 import Unison.HashQualified
-import qualified Unison.HashQualified as HQ
 import Unison.Name as Name (Name, segments)
 import qualified Unison.NameSegment as NameSegment
 import Unison.Parser.Ann (Ann)
@@ -169,20 +168,20 @@ instance Show BaseUrl where
 --
 -- Examples:
 --
--- >>> urlFor Api { urlHost = "https://localhost", urlToken = "asdf", urlPort = Port 1234 }
+-- >>> urlFor Api (BaseUrl{ urlHost = "https://localhost", urlToken = "asdf", urlPort = 1234 })
 -- "https://localhost:1234/asdf/api"
 --
--- >>> urlFor
--- >>>   UI
--- >>>     (Path.absoluteEmpty)
--- >>>     (Just (TermReference (NameOnly (Name (NameSegment "base.data.List.map")))))
--- "https://localhost:1234/asdf/ui/latest/terms/base/data/List/map"
+-- >>> import qualified Unison.Syntax.Name as Name
+-- >>> let service = UI (Path.absoluteEmpty) (Just (TermReference (NameOnly (Name.unsafeFromText "base.data.List.map"))))
+-- >>> let baseUrl = (BaseUrl{ urlHost = "https://localhost", urlToken = "asdf", urlPort = 1234 })
+-- >>> urlFor service baseUrl
+-- "https://localhost:1234/asdf/ui/latest/;/terms/base/data/List/map"
 --
--- >>> urlFor
--- >>>   UI
--- >>>     (Path.Absolute (Path.fromText "base.data"))
--- >>>     (Just (TermReference (NameOnly (Name (NameSegment "List.map")))))
--- "https://localhost:1234/asdf/ui/latest/namespaces/;/terms/base/data/List/map"
+-- >>> import qualified Unison.Syntax.Name as Name
+-- >>> let service = UI (Path.Absolute (Path.fromText "base.data")) (Just (TermReference (NameOnly (Name.unsafeFromText "List.map"))))
+-- >>> let baseUrl = (BaseUrl{ urlHost = "https://localhost", urlToken = "asdf", urlPort = 1234 })
+-- >>> urlFor service baseUrl
+-- "https://localhost:1234/asdf/ui/latest/namespaces/base/data/;/terms/List/map"
 urlFor :: Service -> BaseUrl -> String
 urlFor service baseUrl =
   case service of


### PR DESCRIPTION
## Overview

Extend the UI URL function to support a namespace (perspective) and a definition.

Fixes https://github.com/unisonweb/unison/issues/3617

## Loose ends

* I could use some pointers on how to make this more idiomatic.
* I need some help actually hooking this up to the UI command, where I'm not sure how to extract args from.
