### PR TITLE
Update vim support. Comments are now correct, and syntax is closer to…

### DIFF
--- a/editor-support/vim/ftplugin/unison.vim
+++ b/editor-support/vim/ftplugin/unison.vim
@@ -4,4 +4,9 @@ if exists("b:did_ftplugin")
 endif
 let b:did_ftplugin = 1
 
-call unison#SetBufferDefaults()
+setlocal commentstring=--\ %s
+setlocal iskeyword+=!,'
+" setlocal tabstop=2
+" setlocal softtabstop=2
+" setlocal shiftwidth=2
+" setlocal completefunc=syntaxcomplete#Complete


### PR DESCRIPTION
… current Unison

The current Vim language support was somewhat divorced from the current Unison: lots of Haskel stuff, comment and doc string syntax was wrong, etc.

This brings it closer to the current reality.

## Interesting/controversial decisions

I made the choice to highlight watch clauses to make them stand out. 

## Test coverage

n/a

## Loose ends

It's missing UTF in identifiers: I need to research how that can be done in vim.
