### PR TITLE
Add note about installing the vim plugin for neovim LSP

### DIFF
--- a/docs/language-server.markdown
+++ b/docs/language-server.markdown
@@ -23,6 +23,24 @@ By default the LSP is hosted at `127.0.0.1:5757`, but you can change the port us
 
 ### NeoVim
 
+Before configuring the LSP, install the Vim plugin for filetype detection and syntax highlighting.
+For [Packer](https://github.com/wbthomason/packer.nvim) you can install the package as follow:
+
+```lua
+-- You may need to increase the git clone timeout setting in Packer!
+use {
+  "unisonweb/unison",
+  branch = "trunk",
+  rtp = "/editor-support/vim"
+}
+```
+
+or [Plug](https://github.com/junegunn/vim-plug):
+
+```vim
+Plug 'unisonweb/unison', { 'branch': 'trunk', 'rtp': 'editor-support/vim' }
+```
+
 Configuration for [coc-nvim](https://github.com/neoclide/coc.nvim), enter the following in the relevant place of your CocConfig
 
 ```
@@ -34,6 +52,12 @@ Configuration for [coc-nvim](https://github.com/neoclide/coc.nvim), enter the fo
       "settings": {}
     }
   }
+```
+
+For [lspconfig](https://github.com/neovim/nvim-lspconfig), you can use the following setup function:
+
+```lua
+require('lspconfig').unison.setup({})
 ```
 
 Note that you'll need to start UCM _before_ you try connecting to it in your editor or your editor might give up.


### PR DESCRIPTION
## Overview

To get all the goodies for neovim, you'll need to install the vim plugin, residing in `unisonweb/unison/editor-support/vim`, but these isn't obvious for noobs like me :P. I've added a small doc and package manager example to clarify.

## Implementation notes

It's a doc edit, let me know if it could be improved!
As a follow-up:
For Packer you'll need to increase the `git clone` timeout setting, because 60 seconds might not be enough to clone the unison repo. 
I actually use https://github.com/folke/lazy.nvim as package manager and `rtp` support is a bit worse because it involves more involved code:
```lua
-- See https://github.com/folke/lazy.nvim/issues/183#issuecomment-1376449037
  {
    "unisonweb/unison",
    branch = "trunk",
    ft = "u",
    config = function(plugin)
        vim.opt.rtp:append(plugin.dir .. "/editor-support/vim")
        require("lazy.core.loader").packadd(plugin.dir .. "/editor-support/vim")
    end,
    init = function(plugin)
         require("lazy.core.loader").ftdetect(plugin.dir .. "/editor-support/vim")
    end,
  },
```
I don't know how open Unison is to make it it's own repo?
