### PR TITLE
Saving current echo state before running anything and then falling back to it if needed

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -72,3 +72,4 @@ The format for this list: name, GitHub handle
 * Emil Hotkowski (@emilhotkowski)
 * Jesse Looney (@jesselooney)
 * Vlad Posmangiu Luchian (@cstml)
+* Andrii Uvarov (@unorsk)

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -15,7 +15,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.Lazy.IO as Text.Lazy
 import qualified Ki
 import qualified System.Console.Haskeline as Line
-import System.IO (hPutStrLn, stderr)
+import System.IO (hPutStrLn, stderr, hGetEcho, hSetEcho, stdin)
 import System.IO.Error (isDoesNotExistError)
 import Text.Pretty.Simple (pShow)
 import qualified U.Codebase.Sqlite.Operations as Operations
@@ -143,8 +143,12 @@ main dir welcome initialPath config initialInputs runtime sbRuntime codebase ser
   credentialManager <- newCredentialManager
   let tokenProvider = AuthN.newTokenProvider credentialManager
   authHTTPClient <- AuthN.newAuthenticatedHTTPClient tokenProvider ucmVersion
+  initialEcho <- hGetEcho stdin
+  let restoreEcho = (\currentEcho -> when (currentEcho /= initialEcho) $ hSetEcho stdin initialEcho)
   let getInput :: Cli.LoopState -> IO Input
       getInput loopState = do
+        currentEcho <- hGetEcho stdin
+        liftIO $ restoreEcho currentEcho
         getUserInput
           codebase
           authHTTPClient


### PR DESCRIPTION
## Overview

If you run the code below in the REPL, the echo state doesn't get reverted to where it was.

```
main : '{IO, Exception} ()
main = do
  setEcho stdIn false
```

It will result in a behaviour where you'd by typing commands and not see them printed out in the terminal.

<img width="681" alt="Screenshot 2023-01-12 at 17 43 49" src="https://user-images.githubusercontent.com/25188/212128108-de9c36dd-ab52-48ef-bb91-8b44a960ff68.png">

## Implementation notes

The desired behaviour would be to save the initial echo state (but I am guessing it could always be set to `false` which will make the implementation even shorter)
I made a very straightforward and somehow naïve implementation. So I am very open for any comments and feedback :)

## Interesting/controversial decisions

No

## Test coverage

No
