### PR TITLE
Allow explicitly enabling the LSP server on Windows

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,6 +62,12 @@ Note that this doesn't pose any risk of codebase corruption or cause any known i
 
 If you accept this annoyance, you can enable the LSP server on Windows by exporting the `UNISON_LSP_ENABLED=true` environment variable. 
 
+You can set this persistently in powershell using:
+
+```powershell
+[System.Environment]::SetEnvironmentVariable('UNISON_LSP_ENABLED','true')
+```
+
 See [this issue](https://github.com/unisonweb/unison/issues/3487) for more details.
 
 E.g.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,6 +5,7 @@
     * [`UNISON_DEBUG`](#unison_debug)
     * [`UNISON_PAGER`](#unison_pager)
     * [`UNISON_LSP_PORT`](#unison_lsp_port)
+    * [`UNISON_LSP_ENABLED`](#unison_lsp_enabled)
     * [`UNISON_SHARE_HOST`](#unison_share_host)
     * [`UNISON_SHARE_ACCESS_TOKEN`](#unison_share_access_token)
     * [Local Codebase Server](#local-codebase-server)
@@ -48,6 +49,25 @@ E.g.
 
 ```sh
 $ UNISON_LSP_PORT=8080 ucm
+```
+
+### `UNISON_LSP_ENABLED`
+
+Allows explicitly enabling or disabling the LSP server.
+Acceptable values are 'true' or 'false'
+
+Note for Windows users: Due to an outstanding issue with GHC's IO manager on Windows, the LSP is **disabled by default** on Windows machines.
+Enabling the LSP on windows can cause UCM to hang on exit and may require the process to be killed by the operating system or via Ctrl-C.
+Note that this doesn't pose any risk of codebase corruption or cause any known issues, it's simply an annoyance.
+
+If you accept this annoyance, you can enable the LSP server on Windows by exporting the `UNISON_LSP_ENABLED=true` environment variable. 
+
+See [this issue](https://github.com/unisonweb/unison/issues/3487) for more details.
+
+E.g.
+
+```sh
+$ UNISON_LSP_ENABLED=true ucm
 ```
 
 ### `UNISON_SHARE_HOST`

--- a/docs/language-server.markdown
+++ b/docs/language-server.markdown
@@ -20,6 +20,13 @@ Currently the only supported configuration is to connect to the LSP via a specif
 
 By default the LSP is hosted at `127.0.0.1:5757`, but you can change the port using `UNISON_LSP_PORT=1234`.
 
+Note for Windows users: Due to an outstanding issue with GHC's IO manager on Windows, the LSP is **disabled by default** on Windows machines.
+Enabling the LSP on windows can cause UCM to hang on exit and may require the process to be killed by the operating system or via Ctrl-C.
+Note that this doesn't pose any risk of codebase corruption or cause any known issues, it's simply an annoyance.
+
+If you accept this annoyance, you can enable the LSP server on Windows by exporting the `UNISON_LSP_ENABLED=true` environment variable. 
+
+See [this issue](https://github.com/unisonweb/unison/issues/3487) for more details.
 
 ### NeoVim
 

--- a/docs/language-server.markdown
+++ b/docs/language-server.markdown
@@ -26,6 +26,12 @@ Note that this doesn't pose any risk of codebase corruption or cause any known i
 
 If you accept this annoyance, you can enable the LSP server on Windows by exporting the `UNISON_LSP_ENABLED=true` environment variable. 
 
+You can set this persistently in powershell using:
+
+```powershell
+[System.Environment]::SetEnvironmentVariable('UNISON_LSP_ENABLED','true')
+```
+
 See [this issue](https://github.com/unisonweb/unison/issues/3487) for more details.
 
 ### NeoVim

--- a/unison-cli/unison/Main.hs
+++ b/unison-cli/unison/Main.hs
@@ -22,7 +22,7 @@ import ArgParse
     UsageRenderer,
     parseCLIArgs,
   )
-import Compat (defaultInterruptHandler, onWindows, withInterruptHandler)
+import Compat (defaultInterruptHandler, withInterruptHandler)
 import Control.Concurrent (newEmptyMVar, runInUnboundThread, takeMVar)
 import Control.Concurrent.STM
 import Control.Error.Safe (rightMay)

--- a/unison-cli/unison/Main.hs
+++ b/unison-cli/unison/Main.hs
@@ -264,7 +264,7 @@ main = withCP65001 . runInUnboundThread . Ki.scoped $ \scope -> do
               -- prevent UCM from shutting down properly. Hopefully we can re-enable LSP on
               -- Windows when we move to GHC 9.*
               -- https://gitlab.haskell.org/ghc/ghc/-/merge_requests/1224
-              when (not onWindows) . void . Ki.fork scope $ LSP.spawnLsp theCodebase runtime (readTMVar rootVar) (readTVar pathVar)
+              void . Ki.fork scope $ LSP.spawnLsp theCodebase runtime (readTMVar rootVar) (readTVar pathVar)
               Server.startServer (Backend.BackendEnv {Backend.useNamesIndex = False}) codebaseServerOpts sbRuntime theCodebase $ \baseUrl -> do
                 case exitOption of
                   DoNotExit -> do


### PR DESCRIPTION
Workaround for https://github.com/unisonweb/unison/issues/3487

## Overview

Due to an outstanding issue with GHC's IO manager on Windows, the LSP is **disabled by default** on Windows machines.
Enabling the LSP on windows can cause UCM to hang on exit and may require the process to be killed by the operating system or via Ctrl-C.
Note that this doesn't pose any risk of codebase corruption or cause any known issues, it's simply an annoyance.

This change allows windows users to opt-in to the LSP if they don't mind the annoyance by exporting the `UNISON_LSP_ENABLED=true` environment variable. 

## Implementation notes

* In the LSP server, check the OS, if on Windows, don't boot up the LSP unless `UNISON_LSP_ENABLED=true` is set.

## Test coverage

I tested it on Parallels,  the env var works, UCM hangs on exit but mashing ctrl-c a couple times works.

## Loose ends

We should probably revisit this again once we're on GHC 9.x.y and see if we can find another solution.
