### PR TITLE
Return 'null' instead of an empty hover result

### DIFF
--- a/unison-cli/src/Unison/LSP/Hover.hs
+++ b/unison-cli/src/Unison/LSP/Hover.hs
@@ -31,6 +31,7 @@ hoverHandler m respond =
     results <- MaybeT . fmap eitherToMaybe $ (lspBackend $ Backend.prettyDefinitionsForHQName Path.empty Nothing Nothing (Backend.Suffixify True) rt cb hqIdentifier)
     let termResults = formatTermDefinition <$> toList (Backend.termDefinitions results)
     let typeResults = formatTypeDefinition <$> toList (Backend.typeDefinitions results)
+    guard (not . null $ termResults <> typeResults)
     let markup = Text.intercalate "\n\n---\n\n" $ termResults <> typeResults
     pure $
       Hover


### PR DESCRIPTION
## Overview

Some LSP clients choke if you return an empty string as your hover response; this makes us return `null` instead.

fixes #3739 

## Implementation notes

return `Nothing` if we have no results, rather than building an empty string as the response.

## Test coverage

None

## Loose ends

None (although I do have a complete re-implementation of Hover that's just waiting on some annotation fixes #3637 )