### PR TITLE
Add Universal.murmurHash

### DIFF
--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -70,6 +70,7 @@ dependencies:
   - monad-validate
   - mtl
   - mutable-containers
+  - murmur-hash
   - mwc-random
   - natural-transformation
   - network

--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -453,6 +453,7 @@ builtinsSrc =
     B "Universal.<" $ forall1 "a" (\a -> a --> a --> boolean),
     B "Universal.>=" $ forall1 "a" (\a -> a --> a --> boolean),
     B "Universal.<=" $ forall1 "a" (\a -> a --> a --> boolean),
+    B "Universal.murmurHash" $ forall1 "a" (\a -> a --> nat),
     B "bug" $ forall1 "a" (\a -> forall1 "b" (\b -> a --> b)),
     B "todo" $ forall1 "a" (\a -> forall1 "b" (\b -> a --> b)),
     B "Any.Any" $ forall1 "a" (\a -> a --> anyt),

--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -1087,6 +1087,17 @@ crypto'hash instr =
   where
     (alg, x, vl) = fresh
 
+murmur'hash :: ForeignOp
+murmur'hash instr =
+  ([BX],)
+    . TAbss [x]
+    . TLetD vl BX (TPrm VALU [x])
+    . TLetD result UN (TFOp instr [vl])
+    $ TCon Ty.natRef 0 [result]
+  where
+    (x, vl, result) = fresh
+
+
 crypto'hmac :: ForeignOp
 crypto'hmac instr =
   ([BX, BX, BX],)
@@ -2559,7 +2570,7 @@ declareForeigns = do
           Left se -> Left (Util.Text.pack (show se))
           Right a -> Right a
 
-  declareForeign Untracked "Universal.murmurHash" boxToNat . mkForeign $
+  declareForeign Untracked "Universal.murmurHash" murmur'hash . mkForeign $
     pure . asWord64 . hash64 . serializeValueLazy
 
   declareForeign Untracked "Bytes.zlib.compress" boxDirect . mkForeign $ pure . Bytes.zlibCompress

--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -36,6 +36,7 @@ import Control.Monad.Catch (MonadCatch)
 import qualified Control.Monad.Primitive as PA
 import Control.Monad.Reader (ReaderT (..), ask, runReaderT)
 import Control.Monad.State.Strict (State, execState, modify)
+import Data.Digest.Murmur64 (hash64, asWord64)
 import qualified Crypto.Hash as Hash
 import qualified Crypto.MAC.HMAC as HMAC
 import Data.Bits (shiftL, shiftR, (.|.))

--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -2559,6 +2559,9 @@ declareForeigns = do
           Left se -> Left (Util.Text.pack (show se))
           Right a -> Right a
 
+  declareForeign Untracked "Universal.murmurHash" boxToNat . mkForeign $
+    pure . asWord64 . hash64 . serializeValueLazy
+
   declareForeign Untracked "Bytes.zlib.compress" boxDirect . mkForeign $ pure . Bytes.zlibCompress
   declareForeign Untracked "Bytes.gzip.compress" boxDirect . mkForeign $ pure . Bytes.gzipCompress
   declareForeign Untracked "Bytes.zlib.decompress" boxToEBoxBox . mkForeign $ \bs ->

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -239,6 +239,7 @@ library
     , mmorph
     , monad-validate
     , mtl
+    , murmur-hash
     , mutable-containers
     , mwc-random
     , natural-transformation
@@ -428,6 +429,7 @@ test-suite parser-typechecker-tests
     , mmorph
     , monad-validate
     , mtl
+    , murmur-hash
     , mutable-containers
     , mwc-random
     , natural-transformation

--- a/unison-src/transcripts-using-base/all-base-hashes.output.md
+++ b/unison-src/transcripts-using-base/all-base-hashes.output.md
@@ -2337,62 +2337,65 @@ This transcript is intended to make visible accidental changes to the hashing al
   666. -- ##Universal.compare
        builtin.Universal.compare : a -> a -> Int
        
-  667. -- ##unsafe.coerceAbilities
+  667. -- ##Universal.murmurHash
+       builtin.Universal.murmurHash : a -> Nat
+       
+  668. -- ##unsafe.coerceAbilities
        builtin.unsafe.coerceAbilities : (a ->{e1} b)
        -> a
        ->{e2} b
        
-  668. -- ##Value
+  669. -- ##Value
        builtin type builtin.Value
        
-  669. -- ##Value.dependencies
+  670. -- ##Value.dependencies
        builtin.Value.dependencies : Value -> [Link.Term]
        
-  670. -- ##Value.deserialize
+  671. -- ##Value.deserialize
        builtin.Value.deserialize : Bytes -> Either Text Value
        
-  671. -- ##Value.load
+  672. -- ##Value.load
        builtin.Value.load : Value ->{IO} Either [Link.Term] a
        
-  672. -- ##Value.serialize
+  673. -- ##Value.serialize
        builtin.Value.serialize : Value -> Bytes
        
-  673. -- ##Value.value
+  674. -- ##Value.value
        builtin.Value.value : a -> Value
        
-  674. -- #dem6aglnj8cppfrnq9qipl7geo5pim3auo9cmv1rhh5la9edalj19sspbpm1pd4vh0plokdh6qfo48gs034dqlg0s7j9fhr9p9ndtpo
+  675. -- #dem6aglnj8cppfrnq9qipl7geo5pim3auo9cmv1rhh5la9edalj19sspbpm1pd4vh0plokdh6qfo48gs034dqlg0s7j9fhr9p9ndtpo
        unique type builtin.Year
        
-  675. -- #dem6aglnj8cppfrnq9qipl7geo5pim3auo9cmv1rhh5la9edalj19sspbpm1pd4vh0plokdh6qfo48gs034dqlg0s7j9fhr9p9ndtpo#0
+  676. -- #dem6aglnj8cppfrnq9qipl7geo5pim3auo9cmv1rhh5la9edalj19sspbpm1pd4vh0plokdh6qfo48gs034dqlg0s7j9fhr9p9ndtpo#0
        builtin.Year.Year : Nat -> Year
        
-  676. -- #k0rcrut9836hr3sevkivq4n2o3t540hllesila69b16gr5fcqe0i6aepqhv2qmso6h22lbipbp3fto0oc8o73l1lvf6vpifi01gmhg8
+  677. -- #k0rcrut9836hr3sevkivq4n2o3t540hllesila69b16gr5fcqe0i6aepqhv2qmso6h22lbipbp3fto0oc8o73l1lvf6vpifi01gmhg8
        cache : [(Link.Term, Code)] ->{IO, Exception} ()
        
-  677. -- #okolgrio28p1mbl1bfjfs9qtsr1m9upblcm3ul872gcir6epkcbq619vk5bdq1fnr371nelsof6jsp8469g4j6f0gg3007p79o4kf18
+  678. -- #okolgrio28p1mbl1bfjfs9qtsr1m9upblcm3ul872gcir6epkcbq619vk5bdq1fnr371nelsof6jsp8469g4j6f0gg3007p79o4kf18
        check : Text -> Boolean ->{Stream Result} ()
        
-  678. -- #je42vk6rsefjlup01e1fmmdssf5i3ba9l6aka3bipggetfm8o4i8d1q5d7hddggu5jure1bu5ot8aq5in31to4788ctrtpb44ri83r8
+  679. -- #je42vk6rsefjlup01e1fmmdssf5i3ba9l6aka3bipggetfm8o4i8d1q5d7hddggu5jure1bu5ot8aq5in31to4788ctrtpb44ri83r8
        checks : [Boolean] -> [Result]
        
-  679. -- #barg6v1n15ea1qhp80i77gjjq3vu1noc67q2jkv9n6n5v0c9djup70ltauujgpfe0kuo8ckd20gc9kutngdpb8d22rubtb5rjldrb3o
+  680. -- #barg6v1n15ea1qhp80i77gjjq3vu1noc67q2jkv9n6n5v0c9djup70ltauujgpfe0kuo8ckd20gc9kutngdpb8d22rubtb5rjldrb3o
        clientSocket : Text -> Text ->{IO, Exception} Socket
        
-  680. -- #lg7i12ido0jr43ovdbhhv2enpk5ar869leouri5qhrivinde93nl86s2rgshubtfhlogbe310k3rluotscmus9moo1tvpn0nmp1efv8
+  681. -- #lg7i12ido0jr43ovdbhhv2enpk5ar869leouri5qhrivinde93nl86s2rgshubtfhlogbe310k3rluotscmus9moo1tvpn0nmp1efv8
        closeFile : Handle ->{IO, Exception} ()
        
-  681. -- #4e6qn65v05l32n380lpf536u4llnp6f6tvvt13hvo0bhqeh3f3i8bquekc120c8h59gld1mf02ok0sje7037ipg1fsu97fqrm01oi00
+  682. -- #4e6qn65v05l32n380lpf536u4llnp6f6tvvt13hvo0bhqeh3f3i8bquekc120c8h59gld1mf02ok0sje7037ipg1fsu97fqrm01oi00
        closeSocket : Socket ->{IO, Exception} ()
        
-  682. -- #7o1e77u808vpg8i6k1mvutg8h6tdr14hegfad23e9sjou1ft10kvfr95goo0kv2ldqlsaa4pmvdl8d7jd6h252i3jija05b4vpqbg5g
+  683. -- #7o1e77u808vpg8i6k1mvutg8h6tdr14hegfad23e9sjou1ft10kvfr95goo0kv2ldqlsaa4pmvdl8d7jd6h252i3jija05b4vpqbg5g
        Code.transitiveDeps : Link.Term
        ->{IO} [(Link.Term, Code)]
        
-  683. -- #sfud7h76up0cofgk61b7tf8rhdlugfmg44lksnpglfes1b8po26si7betka39r9j8dpgueorjdrb1i7v4g62m5bci1e971eqi8dblmo
+  684. -- #sfud7h76up0cofgk61b7tf8rhdlugfmg44lksnpglfes1b8po26si7betka39r9j8dpgueorjdrb1i7v4g62m5bci1e971eqi8dblmo
        compose : ∀ o g1 i1 g i.
          (i1 ->{g1} o) -> (i ->{g} i1) -> i ->{g1, g} o
        
-  684. -- #b0tsob9a3fegn5dkb57jh15smd7ho2qo78st6qngpa7a8hc88mccl7vhido41o4otokv5l8hjdj3nabtkmpni5ikeatd44agmqbhano
+  685. -- #b0tsob9a3fegn5dkb57jh15smd7ho2qo78st6qngpa7a8hc88mccl7vhido41o4otokv5l8hjdj3nabtkmpni5ikeatd44agmqbhano
        compose2 : ∀ o g2 i2 g1 g i i1.
          (i2 ->{g2} o)
          -> (i1 ->{g1} i ->{g} i2)
@@ -2400,7 +2403,7 @@ This transcript is intended to make visible accidental changes to the hashing al
          -> i
          ->{g2, g1, g} o
        
-  685. -- #m632ocgh2rougfejkddsso3vfpf4dmg1f8bhf0k6sha4g4aqfmbeuct3eo0je6dv9utterfvotjdu32p0kojuo9fj4qkp2g1bt464eg
+  686. -- #m632ocgh2rougfejkddsso3vfpf4dmg1f8bhf0k6sha4g4aqfmbeuct3eo0je6dv9utterfvotjdu32p0kojuo9fj4qkp2g1bt464eg
        compose3 : ∀ o g3 i3 g2 g1 g i i1 i2.
          (i3 ->{g3} o)
          -> (i2 ->{g2} i1 ->{g1} i ->{g} i3)
@@ -2409,318 +2412,318 @@ This transcript is intended to make visible accidental changes to the hashing al
          -> i
          ->{g3, g2, g1, g} o
        
-  686. -- #ilkeid6l866bmq90d2v1ilqp9dsjo6ucmf8udgrokq3nr3mo9skl2vao2mo7ish136as52rsf19u9v3jkmd85bl08gnmamo4e5v2fqo
+  687. -- #ilkeid6l866bmq90d2v1ilqp9dsjo6ucmf8udgrokq3nr3mo9skl2vao2mo7ish136as52rsf19u9v3jkmd85bl08gnmamo4e5v2fqo
        contains : Text -> Text -> Boolean
        
-  687. -- #tgvna0i8ea98jvnd2oka85cdtas1prcbq3snvc4qfns6082mlckps2cspk8jln11mklg19bna025tog5m9sb671o27ujsa90lfrbnkg
+  688. -- #tgvna0i8ea98jvnd2oka85cdtas1prcbq3snvc4qfns6082mlckps2cspk8jln11mklg19bna025tog5m9sb671o27ujsa90lfrbnkg
        crawl : [(Link.Term, Code)]
        -> [Link.Term]
        ->{IO} [(Link.Term, Code)]
        
-  688. -- #o0qn048fk7tjb8e7d54vq5mg9egr5kophb9pcm0to4aj0kf39mv76c6olsm27vj309d7nhjh4nps7098fpvqe8j5cfg01ghf3bnju90
+  689. -- #o0qn048fk7tjb8e7d54vq5mg9egr5kophb9pcm0to4aj0kf39mv76c6olsm27vj309d7nhjh4nps7098fpvqe8j5cfg01ghf3bnju90
        createTempDirectory : Text ->{IO, Exception} Text
        
-  689. -- #4858f4krb9l4ot1hml21j48lp3bcvbo8b9unlk33b9a3ovu1jrbr1k56pnfhffkiu1bht2ovh0i82nn5jnoc5s5ru85qvua0m2ol43g
+  690. -- #4858f4krb9l4ot1hml21j48lp3bcvbo8b9unlk33b9a3ovu1jrbr1k56pnfhffkiu1bht2ovh0i82nn5jnoc5s5ru85qvua0m2ol43g
        decodeCert : Bytes ->{Exception} SignedCert
        
-  690. -- #ihbmfc4r7o3391jocjm6v4mojpp3hvt84ivqigrmp34vb5l3d7mmdlvh3hkrtebi812npso7rqo203a59pbs7r2g78ig6jvsv0nva38
+  691. -- #ihbmfc4r7o3391jocjm6v4mojpp3hvt84ivqigrmp34vb5l3d7mmdlvh3hkrtebi812npso7rqo203a59pbs7r2g78ig6jvsv0nva38
        delay : Nat ->{IO, Exception} ()
        
-  691. -- #dsen29k7605pkfquesnaphhmlm3pjkfgm7m2oc90m53gqvob4l39p4g3id3pirl8emg5tcdmr81ctl3lk1enm52mldlfmlh1i85rjbg
+  692. -- #dsen29k7605pkfquesnaphhmlm3pjkfgm7m2oc90m53gqvob4l39p4g3id3pirl8emg5tcdmr81ctl3lk1enm52mldlfmlh1i85rjbg
        directoryContents : Text ->{IO, Exception} [Text]
        
-  692. -- #b22tpqhkq6kvt27dcsddnbfci2bcqutvhmumdven9c5psiilboq2mb8v9ekihtkl6mkartd5ml5u75u84v850n29l91de63lkg3ud38
+  693. -- #b22tpqhkq6kvt27dcsddnbfci2bcqutvhmumdven9c5psiilboq2mb8v9ekihtkl6mkartd5ml5u75u84v850n29l91de63lkg3ud38
        Either.isLeft : Either a b -> Boolean
        
-  693. -- #i1ec3csomb1pegm9r7ppabunabb7cq1t6bb6cvqtt72nd01jot7gde2mak288cbml910abbtho0smsbq17b2r33j599b0vuv7je04j8
+  694. -- #i1ec3csomb1pegm9r7ppabunabb7cq1t6bb6cvqtt72nd01jot7gde2mak288cbml910abbtho0smsbq17b2r33j599b0vuv7je04j8
        Either.mapLeft : (i ->{g} o)
        -> Either i b
        ->{g} Either o b
        
-  694. -- #f765l0pa2tb9ieciivum76s7bp8rdjr8j7i635jjenj9tacgba9eeomur4vv3uuh4kem1pggpmrn61a1e3im9g90okcm13r192f7alg
+  695. -- #f765l0pa2tb9ieciivum76s7bp8rdjr8j7i635jjenj9tacgba9eeomur4vv3uuh4kem1pggpmrn61a1e3im9g90okcm13r192f7alg
        Either.raiseMessage : v -> Either Text b ->{Exception} b
        
-  695. -- #9hifem8o2e1g7tdh4om9kfo98ifr60gfmdp8ci58djn17epm1b4m6idli8b373bsrg487n87n4l50ksq76avlrbh9q2jpobkk18ucvg
+  696. -- #9hifem8o2e1g7tdh4om9kfo98ifr60gfmdp8ci58djn17epm1b4m6idli8b373bsrg487n87n4l50ksq76avlrbh9q2jpobkk18ucvg
        evalTest : '{IO, TempDirs, Exception, Stream Result} a
        ->{IO, Exception} ([Result], a)
        
-  696. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng
+  697. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng
        structural ability Exception
        structural ability builtin.Exception
        
-  697. -- #t20uuuiil07o22les8gv4sji7ju5esevloamnja3bjkrh2f250lgitv6595l6hlc2q64c1om0hhjqgter28dtnibb0dkr2j7e3ss530
+  698. -- #t20uuuiil07o22les8gv4sji7ju5esevloamnja3bjkrh2f250lgitv6595l6hlc2q64c1om0hhjqgter28dtnibb0dkr2j7e3ss530
        Exception.catch : '{g, Exception} a
        ->{g} Either Failure a
        
-  698. -- #hbhvk2e00l6o7qhn8e7p6dc36bjl7ljm0gn2df5clidlrdoufsig1gt5pjhg72kl67folgg2b892kh9jc1oh0l79h4p8dqhcf1tkde0
+  699. -- #hbhvk2e00l6o7qhn8e7p6dc36bjl7ljm0gn2df5clidlrdoufsig1gt5pjhg72kl67folgg2b892kh9jc1oh0l79h4p8dqhcf1tkde0
        Exception.failure : Text -> a -> Failure
        
-  699. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng#0
+  700. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng#0
        Exception.raise,
        builtin.Exception.raise : Failure
        ->{Exception} x
        
-  700. -- #5mqjoauctm02dlqdc10cc66relu40997d6o1u8fj7vv7g0i2mtacjc83afqhuekll1gkqr9vv4lq7aenanq4kf53kcce4l1srr6ip08
+  701. -- #5mqjoauctm02dlqdc10cc66relu40997d6o1u8fj7vv7g0i2mtacjc83afqhuekll1gkqr9vv4lq7aenanq4kf53kcce4l1srr6ip08
        Exception.reraise : Either Failure a ->{Exception} a
        
-  701. -- #1f774ia7im9i0cfp7l5a1g9tkvnd4m2940ga3buaf4ekd43dr1289vknghjjvi4qtevh7s61p5s573gpli51qh7e0i5pj9ggmeb69d0
+  702. -- #1f774ia7im9i0cfp7l5a1g9tkvnd4m2940ga3buaf4ekd43dr1289vknghjjvi4qtevh7s61p5s573gpli51qh7e0i5pj9ggmeb69d0
        Exception.toEither : '{ε, Exception} a
        ->{ε} Either Failure a
        
-  702. -- #li2h4hncbgmfi5scuah06rtdt8rjcipiv2t95hos15ol63usv78ti3vng7o9862a70906rum7nrrs9qd9q8iqu1rdcfe292r0al7n38
+  703. -- #li2h4hncbgmfi5scuah06rtdt8rjcipiv2t95hos15ol63usv78ti3vng7o9862a70906rum7nrrs9qd9q8iqu1rdcfe292r0al7n38
        Exception.toEither.handler : Request {Exception} a
        -> Either Failure a
        
-  703. -- #5fi0ep8mufag822f18ukaffakrmm3ddg8a83dkj4gh2ks4e2c60sk9s8pmk92p69bvkcflql3rgoalp8ruth7fapqrks3kbmdl61b00
+  704. -- #5fi0ep8mufag822f18ukaffakrmm3ddg8a83dkj4gh2ks4e2c60sk9s8pmk92p69bvkcflql3rgoalp8ruth7fapqrks3kbmdl61b00
        Exception.unsafeRun! : '{g, Exception} a ->{g} a
        
-  704. -- #qdcih6h4dmf9a2tn2ndvn0br9ef41ubhcniadou1m6ro641gm2tn79m6boh5sr4q271oiui6ehbdqe53r0gobdeagotkjr67kieq3ro
+  705. -- #qdcih6h4dmf9a2tn2ndvn0br9ef41ubhcniadou1m6ro641gm2tn79m6boh5sr4q271oiui6ehbdqe53r0gobdeagotkjr67kieq3ro
        expect : Text
        -> (a -> a -> Boolean)
        -> a
        -> a
        ->{Stream Result} ()
        
-  705. -- #ngmnbge6f7nkehkkhj6rkit60rp3qlt0vij33itch1el3ta2ukrit4gvpn2n0j0s43sj9af53kphgs0h2n65bnqcr9pmasud2r7klsg
+  706. -- #ngmnbge6f7nkehkkhj6rkit60rp3qlt0vij33itch1el3ta2ukrit4gvpn2n0j0s43sj9af53kphgs0h2n65bnqcr9pmasud2r7klsg
        expectU : Text -> a -> a ->{Stream Result} ()
        
-  706. -- #f54plhut9f6mg77r1f033vubik89irq1eri79d5pd6mqi03rq9em99mc90plurvjnmvho73ssof5fvndgmcg4fgrpvuuil7hb5qmebo
+  707. -- #f54plhut9f6mg77r1f033vubik89irq1eri79d5pd6mqi03rq9em99mc90plurvjnmvho73ssof5fvndgmcg4fgrpvuuil7hb5qmebo
        fail : Text -> b ->{Exception} c
        
-  707. -- #mpe805fs330vqp5l5mg73deahken20dub4hrfvmuutfo97dikgagvimncfr6mfp1l24bjqes1m1dp11a3hop92u49b1fb45j8qs9hoo
+  708. -- #mpe805fs330vqp5l5mg73deahken20dub4hrfvmuutfo97dikgagvimncfr6mfp1l24bjqes1m1dp11a3hop92u49b1fb45j8qs9hoo
        fileExists : Text ->{IO, Exception} Boolean
        
-  708. -- #cft2pjc05jljtlefm4osg96k5t2look2ujq1tgg5hoc5i3fkkatt9pf79g2ka461kq8nbmsggrvo2675ocl599to9e8nre5oef4scdo
+  709. -- #cft2pjc05jljtlefm4osg96k5t2look2ujq1tgg5hoc5i3fkkatt9pf79g2ka461kq8nbmsggrvo2675ocl599to9e8nre5oef4scdo
        fromB32 : Bytes ->{Exception} Bytes
        
-  709. -- #13fpchr37ua0pr38ssr7j22pudmseuedf490aok18upagh0f00kg40guj9pgl916v9qurqrvu53f3lpsvi0s82hg3dtjacanrpjvs38
+  710. -- #13fpchr37ua0pr38ssr7j22pudmseuedf490aok18upagh0f00kg40guj9pgl916v9qurqrvu53f3lpsvi0s82hg3dtjacanrpjvs38
        fromHex : Text -> Bytes
        
-  710. -- #b36oslvh534s82lda0ghc5ql7p7nir0tknsluigulmpso22tjh62uiiq4lq9s3m97a2grkso0qofpb423p06olkkikrt4mfn15vpkug
+  711. -- #b36oslvh534s82lda0ghc5ql7p7nir0tknsluigulmpso22tjh62uiiq4lq9s3m97a2grkso0qofpb423p06olkkikrt4mfn15vpkug
        getBuffering : Handle ->{IO, Exception} BufferMode
        
-  711. -- #9vijttgmba0ui9cshmhmmvgn6ve2e95t168766h2n6pkviddebiimgipic5dbg5lmiht12g6np8a7e06jpk03rnue3ln5mbo4prde0g
+  712. -- #9vijttgmba0ui9cshmhmmvgn6ve2e95t168766h2n6pkviddebiimgipic5dbg5lmiht12g6np8a7e06jpk03rnue3ln5mbo4prde0g
        getBytes : Handle -> Nat ->{IO, Exception} Bytes
        
-  712. -- #c5oeqqglf28ungtq1im4fjdh317eeoba4537l1ntq3ob22v07rpgj9307udscbghlrior398hqm1ci099qmriim8cs975kocacsd9r0
+  713. -- #c5oeqqglf28ungtq1im4fjdh317eeoba4537l1ntq3ob22v07rpgj9307udscbghlrior398hqm1ci099qmriim8cs975kocacsd9r0
        getChar : Handle ->{IO, Exception} Char
        
-  713. -- #j9jdo2pqvi4aktcfsb0n4ns1tk2be7dtckqdeedqp7n52oghsq82cgc1tv562rj1sf1abq2h0vta4uo6873cdbgrtrvd5cvollu3ovo
+  714. -- #j9jdo2pqvi4aktcfsb0n4ns1tk2be7dtckqdeedqp7n52oghsq82cgc1tv562rj1sf1abq2h0vta4uo6873cdbgrtrvd5cvollu3ovo
        getEcho : Handle ->{IO, Exception} Boolean
        
-  714. -- #0hj09gufk8fs2hvr6qij6pie8bp0h6hmm6hpsi8d5fvl1fp1dbk6u8c9p6h4eu2hle6ctgpdbepo9vit5atllkodogn6r0csar9fn1g
+  715. -- #0hj09gufk8fs2hvr6qij6pie8bp0h6hmm6hpsi8d5fvl1fp1dbk6u8c9p6h4eu2hle6ctgpdbepo9vit5atllkodogn6r0csar9fn1g
        getLine : Handle ->{IO, Exception} Text
        
-  715. -- #ck1nfg5fainelng0694jkdf9e06pmn60h7kvble1ff7hkc6jdgqtf7g5o3qevr7ic1bdhfn5n2rc3gde5bh6o9fpbit3ocs0av0scdg
+  716. -- #ck1nfg5fainelng0694jkdf9e06pmn60h7kvble1ff7hkc6jdgqtf7g5o3qevr7ic1bdhfn5n2rc3gde5bh6o9fpbit3ocs0av0scdg
        getSomeBytes : Handle -> Nat ->{IO, Exception} Bytes
        
-  716. -- #bk29bjnrcuh55usf3vocm4j1aml161p6ila7t82cpr3ub9vu0g9lsg2mspmfuefc4ig0qtdqk7nds4t3f68jp6o77e0h4ltbitqjpno
+  717. -- #bk29bjnrcuh55usf3vocm4j1aml161p6ila7t82cpr3ub9vu0g9lsg2mspmfuefc4ig0qtdqk7nds4t3f68jp6o77e0h4ltbitqjpno
        getTempDirectory : '{IO, Exception} Text
        
-  717. -- #j8i534slc2rvakvmqcb6j28iatrh3d7btajai9qndutr0edi5aaoi2p5noditaococ4l104hdhhvjc5vr0rbcjoqrbng46fdeqtnf98
+  718. -- #j8i534slc2rvakvmqcb6j28iatrh3d7btajai9qndutr0edi5aaoi2p5noditaococ4l104hdhhvjc5vr0rbcjoqrbng46fdeqtnf98
        handlePosition : Handle ->{IO, Exception} Nat
        
-  718. -- #bgf7sqs0h0p8bhm3t2ei8006oj1gjonvtkdejv2g9kar0kmvob9e88ceevdfh99jom9rs0hbalf1gut5juanudfcb8tpb1e9ta0vrm8
+  719. -- #bgf7sqs0h0p8bhm3t2ei8006oj1gjonvtkdejv2g9kar0kmvob9e88ceevdfh99jom9rs0hbalf1gut5juanudfcb8tpb1e9ta0vrm8
        handshake : Tls ->{IO, Exception} ()
        
-  719. -- #128490j1tmitiu3vesv97sqspmefobg1am38vos9p0vt4s1bhki87l7kj4cctquffkp40eanmr9ummfglj9i7s25jrpb32ob5sf2tio
+  720. -- #128490j1tmitiu3vesv97sqspmefobg1am38vos9p0vt4s1bhki87l7kj4cctquffkp40eanmr9ummfglj9i7s25jrpb32ob5sf2tio
        hex : Bytes -> Text
        
-  720. -- #ttjui80dbufvf3vgaddmcr065dpgl0rtp68i5cdht6tq4t2vk3i2vg60hi77rug368qijgijf8oui27te7o5oq0t0osm6dg65c080i0
+  721. -- #ttjui80dbufvf3vgaddmcr065dpgl0rtp68i5cdht6tq4t2vk3i2vg60hi77rug368qijgijf8oui27te7o5oq0t0osm6dg65c080i0
        id : a -> a
        
-  721. -- #9qnapjbbdhcc2mjf1b0slm7mefu0idnj1bs4c5bckq42ruodftolnd193uehr31lc01air6d6b3j4ihurnks13n85h3r8rs16nqvj2g
+  722. -- #9qnapjbbdhcc2mjf1b0slm7mefu0idnj1bs4c5bckq42ruodftolnd193uehr31lc01air6d6b3j4ihurnks13n85h3r8rs16nqvj2g
        isDirectory : Text ->{IO, Exception} Boolean
        
-  722. -- #vb1e252fqt0q63hpmtkq2bkg5is2n6thejofnev96040thle5o1ia8dtq7dc6v359gtoqugbqg5tb340aqovrfticb63jgei4ncq3j8
+  723. -- #vb1e252fqt0q63hpmtkq2bkg5is2n6thejofnev96040thle5o1ia8dtq7dc6v359gtoqugbqg5tb340aqovrfticb63jgei4ncq3j8
        isFileEOF : Handle ->{IO, Exception} Boolean
        
-  723. -- #ahkhlm9sd7arpevos99sqc90g7k5nn9bj5n0lhh82c1uva52ltv0295ugc123l17vd1orkng061e11knqjnmk087qjg3vug3rs6mv60
+  724. -- #ahkhlm9sd7arpevos99sqc90g7k5nn9bj5n0lhh82c1uva52ltv0295ugc123l17vd1orkng061e11knqjnmk087qjg3vug3rs6mv60
        isFileOpen : Handle ->{IO, Exception} Boolean
        
-  724. -- #2a11371klrv2i8726knma0l3g14on4m2ucihpg65cjj9k930aefg65ovvg0ak4uv3i9evtnu0a5249q3i8ugheqd65cnmgquc1a88n0
+  725. -- #2a11371klrv2i8726knma0l3g14on4m2ucihpg65cjj9k930aefg65ovvg0ak4uv3i9evtnu0a5249q3i8ugheqd65cnmgquc1a88n0
        isNone : Optional a -> Boolean
        
-  725. -- #ln4avnqpdk7813vsrrr414hg0smcmufrl1c7b87nb7nb0h9cogp6arqa7fbgd7rgolffmgue698ovvefo18j1k8g30t4hbp23onm3l8
+  726. -- #ln4avnqpdk7813vsrrr414hg0smcmufrl1c7b87nb7nb0h9cogp6arqa7fbgd7rgolffmgue698ovvefo18j1k8g30t4hbp23onm3l8
        isSeekable : Handle ->{IO, Exception} Boolean
        
-  726. -- #gop2v9s6l24ii1v6bf1nks2h0h18pato0vbsf4u3el18s7mp1jfnp4c7fesdf9sunnlv5f5a9fjr1s952pte87mf63l1iqki9bp0mio
+  727. -- #gop2v9s6l24ii1v6bf1nks2h0h18pato0vbsf4u3el18s7mp1jfnp4c7fesdf9sunnlv5f5a9fjr1s952pte87mf63l1iqki9bp0mio
        List.all : (a ->{ε} Boolean) -> [a] ->{ε} Boolean
        
-  727. -- #m2g5korqq5etr0qk1qrgjbaqktj4ks4bu9m3c4v3j9g8ktsd2e218nml6q8vo45bi3meb53csack40mle6clfrfep073e313b3jagt0
+  728. -- #m2g5korqq5etr0qk1qrgjbaqktj4ks4bu9m3c4v3j9g8ktsd2e218nml6q8vo45bi3meb53csack40mle6clfrfep073e313b3jagt0
        List.filter : (a ->{g} Boolean) -> [a] ->{g} [a]
        
-  728. -- #8s836vq5jggucs6bj3bear30uhe6h9cskudjrdc772ghiec6ce2jqft09l1n05kd1n6chekrbgt0h8mkc9drgscjvgghacojm9e8c5o
+  729. -- #8s836vq5jggucs6bj3bear30uhe6h9cskudjrdc772ghiec6ce2jqft09l1n05kd1n6chekrbgt0h8mkc9drgscjvgghacojm9e8c5o
        List.foldLeft : (b ->{g} a ->{g} b) -> b -> [a] ->{g} b
        
-  729. -- #m5tlb5a0m4kp5b4m9oq9vhda9d7nhu2obn2lpmosal0ebij9gon4gkd1aq0b3b61jtsc1go0hi7b2sm2memtil55ijq32b2n0k39vko
+  730. -- #m5tlb5a0m4kp5b4m9oq9vhda9d7nhu2obn2lpmosal0ebij9gon4gkd1aq0b3b61jtsc1go0hi7b2sm2memtil55ijq32b2n0k39vko
        List.forEach : [a] -> (a ->{e} ()) ->{e} ()
        
-  730. -- #j9ve4ionu2sn7f814t0t4gc75objke2drgnfvvvb50v2f57ss0hlsa3ai5g5jsk2t4b8s37ocrtmte7nktfb2vjf8508ksvrc6llu30
+  731. -- #j9ve4ionu2sn7f814t0t4gc75objke2drgnfvvvb50v2f57ss0hlsa3ai5g5jsk2t4b8s37ocrtmte7nktfb2vjf8508ksvrc6llu30
        listen : Socket ->{IO, Exception} ()
        
-  731. -- #s0f4et1o1ns8cmmvp3i0cm6cmmv5qaf99qm2q4jmgpciof6ntmuh3mpr4epns3ocskn8raacbvm30ovvj2b6arv0ff7iks31rannbf0
+  732. -- #s0f4et1o1ns8cmmvp3i0cm6cmmv5qaf99qm2q4jmgpciof6ntmuh3mpr4epns3ocskn8raacbvm30ovvj2b6arv0ff7iks31rannbf0
        loadCodeBytes : Bytes ->{Exception} Code
        
-  732. -- #gvaed1m07qihc9c216125sur1q9a7i5ita44qnevongg4jrbd8k2plsqhdur45nn6h3drn6lc3iidp1b208ht8s73fg2711l76c7j4g
+  733. -- #gvaed1m07qihc9c216125sur1q9a7i5ita44qnevongg4jrbd8k2plsqhdur45nn6h3drn6lc3iidp1b208ht8s73fg2711l76c7j4g
        loadSelfContained : Text ->{IO, Exception} a
        
-  733. -- #g1hqlq27e3stamnnfp6q178pleeml9sbo2d6scj2ikubocane5cvf8ctausoqrgj9co9h56ttgt179sgktc0bei2r37dmtj51jg0ou8
+  734. -- #g1hqlq27e3stamnnfp6q178pleeml9sbo2d6scj2ikubocane5cvf8ctausoqrgj9co9h56ttgt179sgktc0bei2r37dmtj51jg0ou8
        loadValueBytes : Bytes
        ->{IO, Exception} ([(Link.Term, Code)], Value)
        
-  734. -- #tlllu51stumo77vi2e5m0e8m05qletfbr3nea3d84dcgh66dq4s3bt7kdbf8mpdqh16mmnoh11kr3n43m8b5g4pf95l9gfbhhok1h20
+  735. -- #tlllu51stumo77vi2e5m0e8m05qletfbr3nea3d84dcgh66dq4s3bt7kdbf8mpdqh16mmnoh11kr3n43m8b5g4pf95l9gfbhhok1h20
        MVar.put : MVar i -> i ->{IO, Exception} ()
        
-  735. -- #3b7lp7s9m31mcvh73nh4gfj1kal6onrmppf35esvmma4jsg7bbm7a8tsrfcb4te88f03r97dkf7n1f2kcc6o7ng4vurp95svfj2fg7o
+  736. -- #3b7lp7s9m31mcvh73nh4gfj1kal6onrmppf35esvmma4jsg7bbm7a8tsrfcb4te88f03r97dkf7n1f2kcc6o7ng4vurp95svfj2fg7o
        MVar.read : MVar o ->{IO, Exception} o
        
-  736. -- #be8m7lsjnf31u87pt5rvn04c9ellhbm3p56jgapbp8k7qp0v3mm7beh81luoifp17681l0ldjj46gthmmu32lkn0jnejr3tedjotntg
+  737. -- #be8m7lsjnf31u87pt5rvn04c9ellhbm3p56jgapbp8k7qp0v3mm7beh81luoifp17681l0ldjj46gthmmu32lkn0jnejr3tedjotntg
        MVar.swap : MVar o -> o ->{IO, Exception} o
        
-  737. -- #c2qb0ca2dj3rronbp4slj3ph56p0iopaos7ib37hjunpkl1rcl1gp820dpg8qflhvt9cm2l1bfm40rkdslce2sr6f0oru5lr5cl5nu0
+  738. -- #c2qb0ca2dj3rronbp4slj3ph56p0iopaos7ib37hjunpkl1rcl1gp820dpg8qflhvt9cm2l1bfm40rkdslce2sr6f0oru5lr5cl5nu0
        MVar.take : MVar o ->{IO, Exception} o
        
-  738. -- #ht0k9hb3k1cnjsgmtu9klivo074a2uro4csh63m1sqr2483rkojlj7abcf0jfmssbfig98i6is1osr2djoqubg3bp6articvq9o8090
+  739. -- #ht0k9hb3k1cnjsgmtu9klivo074a2uro4csh63m1sqr2483rkojlj7abcf0jfmssbfig98i6is1osr2djoqubg3bp6articvq9o8090
        newClient : ClientConfig -> Socket ->{IO, Exception} Tls
        
-  739. -- #coeloqmjin6lais8u6j0plh5f1601lpcue4ejfcute46opams4vsbkplqj6jg6af0uecjie3mbclv40b3jumghsf09aavvucrc0d148
+  740. -- #coeloqmjin6lais8u6j0plh5f1601lpcue4ejfcute46opams4vsbkplqj6jg6af0uecjie3mbclv40b3jumghsf09aavvucrc0d148
        newServer : ServerConfig -> Socket ->{IO, Exception} Tls
        
-  740. -- #ocvo5mvs8fghsf715tt4mhpj1pu8e8r7pq9nue63ut0ol2vnv70k7t6tavtsljlmdib9lo3bt669qac94dk53ldcgtukvotvrlfkan0
+  741. -- #ocvo5mvs8fghsf715tt4mhpj1pu8e8r7pq9nue63ut0ol2vnv70k7t6tavtsljlmdib9lo3bt669qac94dk53ldcgtukvotvrlfkan0
        openFile : Text -> FileMode ->{IO, Exception} Handle
        
-  741. -- #c58qbcgd90d965dokk7bu82uehegkbe8jttm7lv4j0ohgi2qm3e3p4v1qfr8vc2dlsmsl9tv0v71kco8c18mneule0ntrhte4ks1090
+  742. -- #c58qbcgd90d965dokk7bu82uehegkbe8jttm7lv4j0ohgi2qm3e3p4v1qfr8vc2dlsmsl9tv0v71kco8c18mneule0ntrhte4ks1090
        printLine : Text ->{IO, Exception} ()
        
-  742. -- #dck7pb7qv05ol3b0o76l88a22bc7enl781ton5qbs2umvgsua3p16n22il02m29592oohsnbt3cr7hnlumpdhv2ibjp6iji9te4iot0
+  743. -- #dck7pb7qv05ol3b0o76l88a22bc7enl781ton5qbs2umvgsua3p16n22il02m29592oohsnbt3cr7hnlumpdhv2ibjp6iji9te4iot0
        printText : Text ->{IO} Either Failure ()
        
-  743. -- #i9lm1g1j0p4qtakg164jdlgac409sgj1cb91k86k0c44ssajbluovuu7ptm5uc20sjgedjbak3iji8o859ek871ul51b8l30s4uf978
+  744. -- #i9lm1g1j0p4qtakg164jdlgac409sgj1cb91k86k0c44ssajbluovuu7ptm5uc20sjgedjbak3iji8o859ek871ul51b8l30s4uf978
        putBytes : Handle -> Bytes ->{IO, Exception} ()
        
-  744. -- #84j6ua3924v85vh2a581de7sd8pee1lqbp1ibvatvjtui9hvk36sv2riabu0v2r0s25p62ipnvv4aeadpg0u8m5ffqrc202i71caopg
+  745. -- #84j6ua3924v85vh2a581de7sd8pee1lqbp1ibvatvjtui9hvk36sv2riabu0v2r0s25p62ipnvv4aeadpg0u8m5ffqrc202i71caopg
        readFile : Text ->{IO, Exception} Bytes
        
-  745. -- #pk003cv7lvidkbmsnne4mpt20254gh4hd7vvretnbk8na8bhr9fg9776rp8pt9srhiucrd1c7sjl006vmil9e78p40gdcir81ujil2o
+  746. -- #pk003cv7lvidkbmsnne4mpt20254gh4hd7vvretnbk8na8bhr9fg9776rp8pt9srhiucrd1c7sjl006vmil9e78p40gdcir81ujil2o
        ready : Handle ->{IO, Exception} Boolean
        
-  746. -- #unn7qak4qe0nbbpf62uesu0fe8i68o83l4o7f6jcblefbla53fef7a63ts28fh6ql81o5c04j44g7m5rq9aouo73dpeprbl5lka8170
+  747. -- #unn7qak4qe0nbbpf62uesu0fe8i68o83l4o7f6jcblefbla53fef7a63ts28fh6ql81o5c04j44g7m5rq9aouo73dpeprbl5lka8170
        receive : Tls ->{IO, Exception} Bytes
        
-  747. -- #ugs4208vpm97jr2ecmr7l9h4e22r1ije6v379m4v6229c8o7hk669ba63bor4pe6n1bm24il87iq2d99sj78lt6n5eqa1fre0grn93g
+  748. -- #ugs4208vpm97jr2ecmr7l9h4e22r1ije6v379m4v6229c8o7hk669ba63bor4pe6n1bm24il87iq2d99sj78lt6n5eqa1fre0grn93g
        removeDirectory : Text ->{IO, Exception} ()
        
-  748. -- #6pia69u5u5rja1jk04v3i9ke24gf4b1t7vnaj0noogord6ekiqhf72qfkc1n08rd11f2cbkofni5rd5u7t1qkgslbi40hut35pfi1v0
+  749. -- #6pia69u5u5rja1jk04v3i9ke24gf4b1t7vnaj0noogord6ekiqhf72qfkc1n08rd11f2cbkofni5rd5u7t1qkgslbi40hut35pfi1v0
        renameDirectory : Text -> Text ->{IO, Exception} ()
        
-  749. -- #amtsq2jq1k75r309esfp800a8slelm4d3q9i1pq1qqs3pil13at916958sf9ucb4607kpktbnup7nc58ecoq8mcs01e2a03d08agn18
+  750. -- #amtsq2jq1k75r309esfp800a8slelm4d3q9i1pq1qqs3pil13at916958sf9ucb4607kpktbnup7nc58ecoq8mcs01e2a03d08agn18
        runTest : '{IO, TempDirs, Exception, Stream Result} a
        ->{IO} [Result]
        
-  750. -- #va4fcp72qog4dvo8dn4gipr2i1big1lqgpcqfuv9kc98ut8le1bj23s68df7svam7b5sg01s4uf95o458f4rs90mtp71nj84t90ra1o
+  751. -- #va4fcp72qog4dvo8dn4gipr2i1big1lqgpcqfuv9kc98ut8le1bj23s68df7svam7b5sg01s4uf95o458f4rs90mtp71nj84t90ra1o
        saveSelfContained : a -> Text ->{IO, Exception} ()
        
-  751. -- #5hbn4gflbo8l4jq0s9l1r0fpee6ie44fbbl6j6km67l25inaaq5avg18g7j6mig2m6eaod04smif7el34tcclvvf8oll39rfonupt2o
+  752. -- #5hbn4gflbo8l4jq0s9l1r0fpee6ie44fbbl6j6km67l25inaaq5avg18g7j6mig2m6eaod04smif7el34tcclvvf8oll39rfonupt2o
        saveTestCase : Text
        -> (a -> Text)
        -> a
        ->{IO, Exception} ()
        
-  752. -- #v2otbk1e0e81d6ea9i3j1kivnfam6rk6earsjbjljv4mmrk1mgfals6jhfd74evor6al9mkb5gv8hf15f02807f0aa0hnsg9fas1qco
+  753. -- #v2otbk1e0e81d6ea9i3j1kivnfam6rk6earsjbjljv4mmrk1mgfals6jhfd74evor6al9mkb5gv8hf15f02807f0aa0hnsg9fas1qco
        seekHandle : Handle
        -> SeekMode
        -> Int
        ->{IO, Exception} ()
        
-  753. -- #a98jlos4rj2um55iksdin9p5djo6j70qmuitoe2ff3uvkefb8pqensorln5flr3pm8hkc0lqkchbd63cf9tl0kqnqu3i17kvqnm35g0
+  754. -- #a98jlos4rj2um55iksdin9p5djo6j70qmuitoe2ff3uvkefb8pqensorln5flr3pm8hkc0lqkchbd63cf9tl0kqnqu3i17kvqnm35g0
        send : Tls -> Bytes ->{IO, Exception} ()
        
-  754. -- #qrdia2sc9vuoi7u3a4ukjk8lv0rlhn2i2bbin1adbhcuj79jn366dv3a8t52hpil0jtgkhhuiavibmdev63j5ndriod33rkktjekqv8
+  755. -- #qrdia2sc9vuoi7u3a4ukjk8lv0rlhn2i2bbin1adbhcuj79jn366dv3a8t52hpil0jtgkhhuiavibmdev63j5ndriod33rkktjekqv8
        serverSocket : Optional Text
        -> Text
        ->{IO, Exception} Socket
        
-  755. -- #3vft70875p42eao55rhb61siobuei4h0e9vlu4bbgucjo296c2vfjpucacovnu9538tvup5c7lo9123se8v4fe7m8q9aiqbkjpumkao
+  756. -- #3vft70875p42eao55rhb61siobuei4h0e9vlu4bbgucjo296c2vfjpucacovnu9538tvup5c7lo9123se8v4fe7m8q9aiqbkjpumkao
        setBuffering : Handle -> BufferMode ->{IO, Exception} ()
        
-  756. -- #erqshamlurgahpd4rroild36cc5e4rk56r38r53vcbg8cblr82c6gfji3um8f09ffgjlg58g7r32mtsbvjlcq4c65v0jn3va9888mao
+  757. -- #erqshamlurgahpd4rroild36cc5e4rk56r38r53vcbg8cblr82c6gfji3um8f09ffgjlg58g7r32mtsbvjlcq4c65v0jn3va9888mao
        setEcho : Handle -> Boolean ->{IO, Exception} ()
        
-  757. -- #ugar51qqij4ur24frdi84eqdkvqa0fbsi4v6e2586hi3tai52ovtpm3f2dc9crnfv8pk0ppq6b5tv3utl4sl49n5aecorgkqddr7i38
+  758. -- #ugar51qqij4ur24frdi84eqdkvqa0fbsi4v6e2586hi3tai52ovtpm3f2dc9crnfv8pk0ppq6b5tv3utl4sl49n5aecorgkqddr7i38
        snd : ∀ a a1. (a1, a) -> a
        
-  758. -- #leoq6smeq8to5ej3314uuujmh6rfbcsdb9q8ah8h3ohg9jq5kftc93mq671o0qh2he9vqgd288k0ecea3h7eerpbgjt6a8p843tmon8
+  759. -- #leoq6smeq8to5ej3314uuujmh6rfbcsdb9q8ah8h3ohg9jq5kftc93mq671o0qh2he9vqgd288k0ecea3h7eerpbgjt6a8p843tmon8
        socketAccept : Socket ->{IO, Exception} Socket
        
-  759. -- #s43jbp19k91qq704tidpue2vs2re1lh4mtv46rdmdnurkdndst7u0k712entcvip160vh9cilmpamikmflbprg5up0k6cl15b8tr5l0
+  760. -- #s43jbp19k91qq704tidpue2vs2re1lh4mtv46rdmdnurkdndst7u0k712entcvip160vh9cilmpamikmflbprg5up0k6cl15b8tr5l0
        socketPort : Socket ->{IO, Exception} Nat
        
-  760. -- #3rp8h0dt7g60nrjdehuhqga9dmomti5rdqho7r1rm5rg5moet7kt3ieempo7c9urur752njachq6k48ggbic4ugbbv75jl2mfbk57a0
+  761. -- #3rp8h0dt7g60nrjdehuhqga9dmomti5rdqho7r1rm5rg5moet7kt3ieempo7c9urur752njachq6k48ggbic4ugbbv75jl2mfbk57a0
        startsWith : Text -> Text -> Boolean
        
-  761. -- #elsab3sc7p4c6bj73pgvklv0j7qu268rn5isv6micfp7ib8grjoustpqdq0pkd4a379mr5ijb8duu2q0n040osfurppp8pt8vaue2fo
+  762. -- #elsab3sc7p4c6bj73pgvklv0j7qu268rn5isv6micfp7ib8grjoustpqdq0pkd4a379mr5ijb8duu2q0n040osfurppp8pt8vaue2fo
        stdout : Handle
        
-  762. -- #rfi1v9429f9qluv533l2iba77aadttilrpmnhljfapfnfa6sru2nr8ibpqvib9nc4s4nb9s1as45upsfqfqe6ivqi2p82b2vd866it8
+  763. -- #rfi1v9429f9qluv533l2iba77aadttilrpmnhljfapfnfa6sru2nr8ibpqvib9nc4s4nb9s1as45upsfqfqe6ivqi2p82b2vd866it8
        structural ability Stream a
        
-  763. -- #2jl99er43tnksj8r8oveap5ger9uqlvj0u0ghfs0uqa7i6m45jk976n7a726jb7rtusjdu2p8hbbcgmoacvke7k5o3kdgoj57c3v2v8
+  764. -- #2jl99er43tnksj8r8oveap5ger9uqlvj0u0ghfs0uqa7i6m45jk976n7a726jb7rtusjdu2p8hbbcgmoacvke7k5o3kdgoj57c3v2v8
        Stream.collect : '{e, Stream a} r ->{e} ([a], r)
        
-  764. -- #rnuje46fvuqa4a8sdgl9e250a2gcmhtsscr8bdonj2bduhrst38ur7dorv3ahr2ghf9cufkfit7ndh9qb9gspbfapcnn3sol0l2moqg
+  765. -- #rnuje46fvuqa4a8sdgl9e250a2gcmhtsscr8bdonj2bduhrst38ur7dorv3ahr2ghf9cufkfit7ndh9qb9gspbfapcnn3sol0l2moqg
        Stream.collect.handler : Request {Stream a} r -> ([a], r)
        
-  765. -- #rfi1v9429f9qluv533l2iba77aadttilrpmnhljfapfnfa6sru2nr8ibpqvib9nc4s4nb9s1as45upsfqfqe6ivqi2p82b2vd866it8#0
+  766. -- #rfi1v9429f9qluv533l2iba77aadttilrpmnhljfapfnfa6sru2nr8ibpqvib9nc4s4nb9s1as45upsfqfqe6ivqi2p82b2vd866it8#0
        Stream.emit : a ->{Stream a} ()
        
-  766. -- #c70gf5m1blvh8tg4kvt1taee036fr7r22bbtqcupac5r5igs102nj077vdl0nimef94u951kfcl9a5hcevo01j04v9o6v3cpndq41bo
+  767. -- #c70gf5m1blvh8tg4kvt1taee036fr7r22bbtqcupac5r5igs102nj077vdl0nimef94u951kfcl9a5hcevo01j04v9o6v3cpndq41bo
        Stream.toList : '{Stream a} r -> [a]
        
-  767. -- #ul69cgsrsspjni8b0hqnt4kt4bk7sjtp6jvlhhofom7bemu9nb2kimm6tt1raigr7j86afgmnjnrfabn6a5l5v1t219uidiu22ueiv0
+  768. -- #ul69cgsrsspjni8b0hqnt4kt4bk7sjtp6jvlhhofom7bemu9nb2kimm6tt1raigr7j86afgmnjnrfabn6a5l5v1t219uidiu22ueiv0
        Stream.toList.handler : Request {Stream a} r -> [a]
        
-  768. -- #58d8kfuq8sqbipa1aaijjhm28pa6a844h19mgg5s4a1h160etbulig21cm0pcnfla8fisqvrp80840g9luid5u8amvcc8sf46pd25h8
+  769. -- #58d8kfuq8sqbipa1aaijjhm28pa6a844h19mgg5s4a1h160etbulig21cm0pcnfla8fisqvrp80840g9luid5u8amvcc8sf46pd25h8
        systemTime : '{IO, Exception} Nat
        
-  769. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18
+  770. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18
        structural ability TempDirs
        
-  770. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18#0
+  771. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18#0
        TempDirs.newTempDir : Text ->{TempDirs} Text
        
-  771. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18#1
+  772. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18#1
        TempDirs.removeDir : Text ->{TempDirs} ()
        
-  772. -- #natgur73q6b4c3tp5jcor0v1cdnplh0n3fhm4qvhg4v74u3e3ff1352shs1lveot83lj82qqbl78n40qi9a132fhkmaa6g5s1ja91go
+  773. -- #natgur73q6b4c3tp5jcor0v1cdnplh0n3fhm4qvhg4v74u3e3ff1352shs1lveot83lj82qqbl78n40qi9a132fhkmaa6g5s1ja91go
        terminate : Tls ->{IO, Exception} ()
        
-  773. -- #i3pbnc98rbfug5dnnvpd4uahm2e5fld2fu0re9r305isffr1r43048h7ql6ojdbjcsvjr6h91s6i026na046ltg5ff59klla6e7vq98
+  774. -- #i3pbnc98rbfug5dnnvpd4uahm2e5fld2fu0re9r305isffr1r43048h7ql6ojdbjcsvjr6h91s6i026na046ltg5ff59klla6e7vq98
        testAutoClean : '{IO} [Result]
        
-  774. -- #spepthutvs3p6je794h520665rh8abl36qg43i7ipvj0mtg5sb0sbemjp2vpu9j3feithk2ae0sdtcmb8afoglo9rnvl350380t21h0
+  775. -- #spepthutvs3p6je794h520665rh8abl36qg43i7ipvj0mtg5sb0sbemjp2vpu9j3feithk2ae0sdtcmb8afoglo9rnvl350380t21h0
        Text.fromUtf8 : Bytes ->{Exception} Text
        
-  775. -- #32q9jqhmi8f08pec3hj0je4u7k52f9f1hdfsmn9ncg2kpki5da9dabigplvdcot3a00k7s5npc4n78psd6ojaumqjla259e9pqd4ov8
+  776. -- #32q9jqhmi8f08pec3hj0je4u7k52f9f1hdfsmn9ncg2kpki5da9dabigplvdcot3a00k7s5npc4n78psd6ojaumqjla259e9pqd4ov8
        structural ability Throw e
        
-  776. -- #32q9jqhmi8f08pec3hj0je4u7k52f9f1hdfsmn9ncg2kpki5da9dabigplvdcot3a00k7s5npc4n78psd6ojaumqjla259e9pqd4ov8#0
+  777. -- #32q9jqhmi8f08pec3hj0je4u7k52f9f1hdfsmn9ncg2kpki5da9dabigplvdcot3a00k7s5npc4n78psd6ojaumqjla259e9pqd4ov8#0
        Throw.throw : e ->{Throw e} a
        
-  777. -- #vri6fsnl704n6aqs346p6ijcbkcsv9875edr6b74enumrhbjiuon94ir4ufmrrn84k9b2jka4f05o16mcvsjrjav6gpskpiu4sknd1g
+  778. -- #vri6fsnl704n6aqs346p6ijcbkcsv9875edr6b74enumrhbjiuon94ir4ufmrrn84k9b2jka4f05o16mcvsjrjav6gpskpiu4sknd1g
        uncurry : ∀ o g1 i g i1.
          (i1 ->{g} i ->{g1} o) -> (i1, i) ->{g1, g} o
        
-  778. -- #u2j1bektndcqdo1m13fvu6apt9td96s4tqonelg23tauklak2pqnbisf41v632fmlrcc6f9orqo3iu9757q36ue5ol1khe0hh8pktro
+  779. -- #u2j1bektndcqdo1m13fvu6apt9td96s4tqonelg23tauklak2pqnbisf41v632fmlrcc6f9orqo3iu9757q36ue5ol1khe0hh8pktro
        Value.transitiveDeps : Value ->{IO} [(Link.Term, Code)]
        
-  779. -- #o5bg5el7ckak28ib98j5b6rt26bqbprpddd1brrg3s18qahhbbe3uohufjjnt5eenvtjg0hrvnvpra95jmdppqrovvmcfm1ih2k7guo
+  780. -- #o5bg5el7ckak28ib98j5b6rt26bqbprpddd1brrg3s18qahhbbe3uohufjjnt5eenvtjg0hrvnvpra95jmdppqrovvmcfm1ih2k7guo
        void : x -> ()
        
-  780. -- #8ugamqlp7a4g0dmbcvipqfi8gnuuj23pjbdfbof11naiun1qf8otjcap80epaom2kl9fv5rhjaudt4558n38dovrc0lhipubqjgm8mg
+  781. -- #8ugamqlp7a4g0dmbcvipqfi8gnuuj23pjbdfbof11naiun1qf8otjcap80epaom2kl9fv5rhjaudt4558n38dovrc0lhipubqjgm8mg
        writeFile : Text -> Bytes ->{IO, Exception} ()
        
-  781. -- #lcmj2envm11lrflvvcl290lplhvbccv82utoej0lg0eomhmsf2vrv8af17k6if7ff98fp1b13rkseng3fng4stlr495c8dn3gn4k400
+  782. -- #lcmj2envm11lrflvvcl290lplhvbccv82utoej0lg0eomhmsf2vrv8af17k6if7ff98fp1b13rkseng3fng4stlr495c8dn3gn4k400
        |> : a -> (a ->{g} t) ->{g} t
        
   

--- a/unison-src/transcripts/alias-many.output.md
+++ b/unison-src/transcripts/alias-many.output.md
@@ -646,13 +646,14 @@ Let's try it!
   468. Universal.> : a -> a -> Boolean
   469. Universal.>= : a -> a -> Boolean
   470. Universal.compare : a -> a -> Int
-  471. unsafe.coerceAbilities : (a ->{e1} b) -> a ->{e2} b
-  472. builtin type Value
-  473. Value.dependencies : Value -> [Term]
-  474. Value.deserialize : Bytes -> Either Text Value
-  475. Value.load : Value ->{IO} Either [Term] a
-  476. Value.serialize : Value -> Bytes
-  477. Value.value : a -> Value
+  471. Universal.murmurHash : a -> Nat
+  472. unsafe.coerceAbilities : (a ->{e1} b) -> a ->{e2} b
+  473. builtin type Value
+  474. Value.dependencies : Value -> [Term]
+  475. Value.deserialize : Bytes -> Either Text Value
+  476. Value.load : Value ->{IO} Either [Term] a
+  477. Value.serialize : Value -> Bytes
+  478. Value.value : a -> Value
   
 
 .builtin> alias.many 94-104 .mylib

--- a/unison-src/transcripts/builtins-merge.output.md
+++ b/unison-src/transcripts/builtins-merge.output.md
@@ -69,7 +69,7 @@ The `builtins.merge` command adds the known builtins to a `builtin` subnamespace
   58. Tuple/              (1 term)
   59. Unit                (type)
   60. Unit/               (1 term)
-  61. Universal/          (6 terms)
+  61. Universal/          (7 terms)
   62. Value               (builtin type)
   63. Value/              (5 terms)
   64. bug                 (a -> b)

--- a/unison-src/transcripts/builtins.md
+++ b/unison-src/transcripts/builtins.md
@@ -362,7 +362,7 @@ Just exercises the function
 
 ```unison
 > Universal.murmurHash 1
-test> checks [Universal.murmurHash [1,2,3] == Universal.murmurHash [1,2,3]]
+test> Universal.murmurHash.tests = checks [Universal.murmurHash [1,2,3] == Universal.murmurHash [1,2,3]]
 ```
 
 ```ucm:hide

--- a/unison-src/transcripts/builtins.md
+++ b/unison-src/transcripts/builtins.md
@@ -361,6 +361,7 @@ openFile]
 Just exercises the function
 
 ```unison
+> Universal.murmurHash 1
 test> checks [Universal.murmurHash [1,2,3] == Universal.murmurHash [1,2,3]]
 ```
 

--- a/unison-src/transcripts/builtins.md
+++ b/unison-src/transcripts/builtins.md
@@ -356,6 +356,18 @@ openFile]
 .> add
 ```
 
+## Universal hash functions
+
+Just exercises the function
+
+```unison
+test> checks [Universal.murmurHash [1,2,3] == Universal.murmurHash [1,2,3]]
+```
+
+```ucm:hide
+.> add
+```
+
 ## Run the tests
 
 Now that all the tests have been added to the codebase, let's view the test report. This will fail the transcript (with a nice message) if any of the tests are failing.

--- a/unison-src/transcripts/builtins.output.md
+++ b/unison-src/transcripts/builtins.output.md
@@ -380,7 +380,8 @@ openFile]
 Just exercises the function
 
 ```unison
-test> checks [Universal.murmurHash [1,2,3] == Universal.murmurHash [1,2,3]]
+> Universal.murmurHash 1
+test> Universal.murmurHash.tests = checks [Universal.murmurHash [1,2,3] == Universal.murmurHash [1,2,3]]
 ```
 
 ```ucm
@@ -391,14 +392,18 @@ test> checks [Universal.murmurHash [1,2,3] == Universal.murmurHash [1,2,3]]
   
     ⍟ These new definitions are ok to `add`:
     
-      test.boua3l3u3g : [Result]
+      Universal.murmurHash.tests : [Result]
   
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.
 
-    1 | test> checks [Universal.murmurHash [1,2,3] == Universal.murmurHash [1,2,3]]
+    1 | > Universal.murmurHash 1
+          ⧩
+          919612540558110011
+  
+    2 | test> Universal.murmurHash.tests = checks [Universal.murmurHash [1,2,3] == Universal.murmurHash [1,2,3]]
     
-    🚫 FAILED Failed
+    ✅ Passed Passed
 
 ```
 ## Run the tests
@@ -433,51 +438,10 @@ Now that all the tests have been added to the codebase, let's view the test repo
   ◉ Text.tests.patterns                 Passed
   ◉ Text.tests.repeat                   Passed
   ◉ Text.tests.takeDropAppend           Passed
+  ◉ Universal.murmurHash.tests          Passed
   
-  ✗ test.boua3l3u3g   Failed
+  ✅ 24 test(s) passing
   
-  🚫 1 test(s) failing, ✅ 23 test(s) passing
-  
-  Tip: Use view test.boua3l3u3g to view the source of a test.
+  Tip: Use view Any.test1 to view the source of a test.
 
 ```
-
-
-
-🛑
-
-The transcript failed due to an error in the stanza above. The error is:
-
-
-  Cached test results (`help testcache` to learn more)
-  
-  ◉ Any.test1                           Passed
-  ◉ Any.test2                           Passed
-  ◉ Boolean.tests.andTable              Passed
-  ◉ Boolean.tests.notTable              Passed
-  ◉ Boolean.tests.orTable               Passed
-  ◉ Bytes.tests.at                      Passed
-  ◉ Bytes.tests.compression             Passed
-  ◉ Bytes.tests.fromBase64UrlUnpadded   Passed
-  ◉ Int.tests.arithmetic                Passed
-  ◉ Int.tests.bitTwiddling              Passed
-  ◉ Int.tests.conversions               Passed
-  ◉ Nat.tests.arithmetic                Passed
-  ◉ Nat.tests.bitTwiddling              Passed
-  ◉ Nat.tests.conversions               Passed
-  ◉ Sandbox.test1                       Passed
-  ◉ Sandbox.test2                       Passed
-  ◉ Sandbox.test3                       Passed
-  ◉ test.rtjqan7bcs                     Passed
-  ◉ Text.tests.alignment                Passed
-  ◉ Text.tests.literalsEq               Passed
-  ◉ Text.tests.patterns                 Passed
-  ◉ Text.tests.repeat                   Passed
-  ◉ Text.tests.takeDropAppend           Passed
-  
-  ✗ test.boua3l3u3g   Failed
-  
-  🚫 1 test(s) failing, ✅ 23 test(s) passing
-  
-  Tip: Use view test.boua3l3u3g to view the source of a test.
-

--- a/unison-src/transcripts/builtins.output.md
+++ b/unison-src/transcripts/builtins.output.md
@@ -375,6 +375,32 @@ openFile]
     ✅ Passed Passed
 
 ```
+## Universal hash functions
+
+Just exercises the function
+
+```unison
+test> checks [Universal.murmurHash [1,2,3] == Universal.murmurHash [1,2,3]]
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      test.boua3l3u3g : [Result]
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    1 | test> checks [Universal.murmurHash [1,2,3] == Universal.murmurHash [1,2,3]]
+    
+    🚫 FAILED Failed
+
+```
 ## Run the tests
 
 Now that all the tests have been added to the codebase, let's view the test report. This will fail the transcript (with a nice message) if any of the tests are failing.
@@ -408,8 +434,50 @@ Now that all the tests have been added to the codebase, let's view the test repo
   ◉ Text.tests.repeat                   Passed
   ◉ Text.tests.takeDropAppend           Passed
   
-  ✅ 23 test(s) passing
+  ✗ test.boua3l3u3g   Failed
   
-  Tip: Use view Any.test1 to view the source of a test.
+  🚫 1 test(s) failing, ✅ 23 test(s) passing
+  
+  Tip: Use view test.boua3l3u3g to view the source of a test.
 
 ```
+
+
+
+🛑
+
+The transcript failed due to an error in the stanza above. The error is:
+
+
+  Cached test results (`help testcache` to learn more)
+  
+  ◉ Any.test1                           Passed
+  ◉ Any.test2                           Passed
+  ◉ Boolean.tests.andTable              Passed
+  ◉ Boolean.tests.notTable              Passed
+  ◉ Boolean.tests.orTable               Passed
+  ◉ Bytes.tests.at                      Passed
+  ◉ Bytes.tests.compression             Passed
+  ◉ Bytes.tests.fromBase64UrlUnpadded   Passed
+  ◉ Int.tests.arithmetic                Passed
+  ◉ Int.tests.bitTwiddling              Passed
+  ◉ Int.tests.conversions               Passed
+  ◉ Nat.tests.arithmetic                Passed
+  ◉ Nat.tests.bitTwiddling              Passed
+  ◉ Nat.tests.conversions               Passed
+  ◉ Sandbox.test1                       Passed
+  ◉ Sandbox.test2                       Passed
+  ◉ Sandbox.test3                       Passed
+  ◉ test.rtjqan7bcs                     Passed
+  ◉ Text.tests.alignment                Passed
+  ◉ Text.tests.literalsEq               Passed
+  ◉ Text.tests.patterns                 Passed
+  ◉ Text.tests.repeat                   Passed
+  ◉ Text.tests.takeDropAppend           Passed
+  
+  ✗ test.boua3l3u3g   Failed
+  
+  🚫 1 test(s) failing, ✅ 23 test(s) passing
+  
+  Tip: Use view test.boua3l3u3g to view the source of a test.
+

--- a/unison-src/transcripts/builtins.output.md
+++ b/unison-src/transcripts/builtins.output.md
@@ -399,7 +399,7 @@ test> Universal.murmurHash.tests = checks [Universal.murmurHash [1,2,3] == Unive
 
     1 | > Universal.murmurHash 1
           ⧩
-          919612540558110011
+          5006114823290027883
   
     2 | test> Universal.murmurHash.tests = checks [Universal.murmurHash [1,2,3] == Universal.murmurHash [1,2,3]]
     

--- a/unison-src/transcripts/emptyCodebase.output.md
+++ b/unison-src/transcripts/emptyCodebase.output.md
@@ -23,7 +23,7 @@ Technically, the definitions all exist, but they have no names. `builtins.merge`
 
 .foo> ls
 
-  1. builtin/ (414 terms, 63 types)
+  1. builtin/ (415 terms, 63 types)
 
 ```
 And for a limited time, you can get even more builtin goodies:
@@ -35,7 +35,7 @@ And for a limited time, you can get even more builtin goodies:
 
 .foo> ls
 
-  1. builtin/ (586 terms, 81 types)
+  1. builtin/ (587 terms, 81 types)
 
 ```
 More typically, you'd start out by pulling `base.

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -121,13 +121,13 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #khhiq1sc3o
+  ⊙ 1. #ut7mk2guld
   
     - Deletes:
     
       feature1.y
   
-  ⊙ 2. #0t16m7j03m
+  ⊙ 2. #oaneanmrn8
   
     + Adds / updates:
     
@@ -138,26 +138,26 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
       Original name New name(s)
       feature1.y    master.y
   
-  ⊙ 3. #l4cc5snm7c
+  ⊙ 3. #m6o57p1elr
   
     + Adds / updates:
     
       feature1.y
   
-  ⊙ 4. #0ujfvnropc
+  ⊙ 4. #ep8ckbhnqt
   
     > Moves:
     
       Original name New name
       x             master.x
   
-  ⊙ 5. #jd5q4ga1jk
+  ⊙ 5. #t7aklphn43
   
     + Adds / updates:
     
       x
   
-  □ 6. #67ki96tn2j (start of history)
+  □ 6. #l6lcr63iti (start of history)
 
 ```
 To resurrect an old version of a namespace, you can learn its hash via the `history` command, then use `fork #namespacehash .newname`.

--- a/unison-src/transcripts/move-namespace.output.md
+++ b/unison-src/transcripts/move-namespace.output.md
@@ -267,7 +267,7 @@ I should be able to move the root into a sub-namespace
 
 .> ls
 
-  1. root/ (591 terms, 82 types)
+  1. root/ (592 terms, 82 types)
 
 .> history
 
@@ -276,13 +276,13 @@ I should be able to move the root into a sub-namespace
   
   
   
-  □ 1. #2kibet66dd (start of history)
+  □ 1. #o2vkdh7ltv (start of history)
 
 ```
 ```ucm
 .> ls .root.at.path
 
-  1. builtin/  (586 terms, 81 types)
+  1. builtin/  (587 terms, 81 types)
   2. existing/ (1 term)
   3. happy/    (3 terms, 1 type)
   4. history/  (1 term)
@@ -292,7 +292,7 @@ I should be able to move the root into a sub-namespace
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #e7uij3oft2
+  ⊙ 1. #i0lk1c81v7
   
     - Deletes:
     
@@ -303,7 +303,7 @@ I should be able to move the root into a sub-namespace
       Original name      New name
       existing.a.termInA existing.b.termInA
   
-  ⊙ 2. #v32ubv0p3r
+  ⊙ 2. #64lmvl3fbe
   
     + Adds / updates:
     
@@ -315,26 +315,26 @@ I should be able to move the root into a sub-namespace
       happy.b.termInA   existing.a.termInA
       history.b.termInA existing.a.termInA
   
-  ⊙ 3. #8brjmr30ls
+  ⊙ 3. #1upc23ts8h
   
     + Adds / updates:
     
       existing.a.termInA existing.b.termInB
   
-  ⊙ 4. #aie72ekk7e
+  ⊙ 4. #hp3nttbbeu
   
     > Moves:
     
       Original name     New name
       history.a.termInA history.b.termInA
   
-  ⊙ 5. #t05a2u5s1a
+  ⊙ 5. #3vt487avqa
   
     - Deletes:
     
       history.b.termInB
   
-  ⊙ 6. #7e116chrdg
+  ⊙ 6. #cng5456u5h
   
     + Adds / updates:
     
@@ -345,13 +345,13 @@ I should be able to move the root into a sub-namespace
       Original name   New name(s)
       happy.b.termInA history.a.termInA
   
-  ⊙ 7. #aq0rd3db7l
+  ⊙ 7. #6s6rta6dft
   
     + Adds / updates:
     
       history.a.termInA history.b.termInB
   
-  ⊙ 8. #rk1p4aamml
+  ⊙ 8. #ri5k67h719
   
     > Moves:
     
@@ -361,7 +361,7 @@ I should be able to move the root into a sub-namespace
       happy.a.T.T2    happy.b.T.T2
       happy.a.termInA happy.b.termInA
   
-  ⊙ 9. #dhr3sctdec
+  ⊙ 9. #5lhn2nqa5u
   
     + Adds / updates:
     
@@ -371,7 +371,7 @@ I should be able to move the root into a sub-namespace
     
       happy.a.T.T
   
-  ⊙ 10. #bu35nl3qi6
+  ⊙ 10. #2oljit38kd
   
     + Adds / updates:
     
@@ -383,7 +383,7 @@ I should be able to move the root into a sub-namespace
   
   ⠇
   
-  ⊙ 11. #bjgbu0j8dd
+  ⊙ 11. #95soup1m3q
   
 
 ```

--- a/unison-src/transcripts/name-selection.output.md
+++ b/unison-src/transcripts/name-selection.output.md
@@ -1003,398 +1003,400 @@ d = c + 10
     350. builtin.io2.Clock.internals.monotonic         : '{IO} Either
                                                          Failure
                                                          TimeSpec
-    351. builtin.Int.negate                            : Int
+    351. builtin.Universal.murmurHash                  : a
+                                                       -> Nat
+    352. builtin.Int.negate                            : Int
                                                        -> Int
-    352. builtin.io2.MVar.new                          : a
+    353. builtin.io2.MVar.new                          : a
                                                        ->{IO} MVar
                                                          a
-    353. builtin.io2.Promise.new                       : '{IO} Promise
+    354. builtin.io2.Promise.new                       : '{IO} Promise
                                                          a
-    354. builtin.io2.TVar.new                          : a
+    355. builtin.io2.TVar.new                          : a
                                                        ->{STM} TVar
                                                          a
-    355. builtin.io2.MVar.newEmpty                     : '{IO} MVar
+    356. builtin.io2.MVar.newEmpty                     : '{IO} MVar
                                                          a
-    356. builtin.io2.TVar.newIO                        : a
+    357. builtin.io2.TVar.newIO                        : a
                                                        ->{IO} TVar
                                                          a
-    357. builtin.Boolean.not                           : Boolean
+    358. builtin.Boolean.not                           : Boolean
                                                        -> Boolean
-    358. builtin.Text.patterns.notCharIn               : [Char]
+    359. builtin.Text.patterns.notCharIn               : [Char]
                                                        -> Pattern
                                                          Text
-    359. builtin.Text.patterns.notCharRange            : Char
+    360. builtin.Text.patterns.notCharRange            : Char
                                                        -> Char
                                                        -> Pattern
                                                          Text
-    360. builtin.io2.Clock.internals.nsec              : TimeSpec
+    361. builtin.io2.Clock.internals.nsec              : TimeSpec
                                                        -> Nat
-    361. builtin.Int.or                                : Int
+    362. builtin.Int.or                                : Int
                                                        -> Int
                                                        -> Int
-    362. builtin.Nat.or                                : Nat
+    363. builtin.Nat.or                                : Nat
                                                        -> Nat
                                                        -> Nat
-    363. builtin.Pattern.or                            : Pattern
+    364. builtin.Pattern.or                            : Pattern
                                                          a
                                                        -> Pattern
                                                          a
                                                        -> Pattern
                                                          a
-    364. builtin.Int.popCount                          : Int
+    365. builtin.Int.popCount                          : Int
                                                        -> Nat
-    365. builtin.Nat.popCount                          : Nat
+    366. builtin.Nat.popCount                          : Nat
                                                        -> Nat
-    366. builtin.Float.pow                             : Float
+    367. builtin.Float.pow                             : Float
                                                        -> Float
                                                        -> Float
-    367. builtin.Int.pow                               : Int
+    368. builtin.Int.pow                               : Int
                                                        -> Nat
                                                        -> Int
-    368. builtin.Nat.pow                               : Nat
+    369. builtin.Nat.pow                               : Nat
                                                        -> Nat
                                                        -> Nat
-    369. builtin.io2.Clock.internals.processCPUTime    : '{IO} Either
+    370. builtin.io2.Clock.internals.processCPUTime    : '{IO} Either
                                                          Failure
                                                          TimeSpec
-    370. builtin.Text.patterns.punctuation             : Pattern
+    371. builtin.Text.patterns.punctuation             : Pattern
                                                          Text
-    371. builtin.ImmutableArray.read                   : ImmutableArray
+    372. builtin.ImmutableArray.read                   : ImmutableArray
                                                          a
                                                        -> Nat
                                                        ->{Exception} a
-    372. builtin.MutableArray.read                     : MutableArray
+    373. builtin.MutableArray.read                     : MutableArray
                                                          g a
                                                        -> Nat
                                                        ->{g,
                                                        Exception} a
-    373. builtin.io2.Promise.read                      : Promise
+    374. builtin.io2.Promise.read                      : Promise
                                                          a
                                                        ->{IO} a
-    374. builtin.Ref.read                              : Ref g a
+    375. builtin.Ref.read                              : Ref g a
                                                        ->{g} a
-    375. builtin.io2.TVar.read                         : TVar a
+    376. builtin.io2.TVar.read                         : TVar a
                                                        ->{STM} a
-    376. builtin.io2.Ref.Ticket.read                   : Ticket
+    377. builtin.io2.Ref.Ticket.read                   : Ticket
                                                          a
                                                        -> a
-    377. builtin.ImmutableByteArray.read16be           : ImmutableByteArray
+    378. builtin.ImmutableByteArray.read16be           : ImmutableByteArray
                                                        -> Nat
                                                        ->{Exception} Nat
-    378. builtin.MutableByteArray.read16be             : MutableByteArray
+    379. builtin.MutableByteArray.read16be             : MutableByteArray
                                                          g
                                                        -> Nat
                                                        ->{g,
                                                        Exception} Nat
-    379. builtin.ImmutableByteArray.read24be           : ImmutableByteArray
+    380. builtin.ImmutableByteArray.read24be           : ImmutableByteArray
                                                        -> Nat
                                                        ->{Exception} Nat
-    380. builtin.MutableByteArray.read24be             : MutableByteArray
+    381. builtin.MutableByteArray.read24be             : MutableByteArray
                                                          g
                                                        -> Nat
                                                        ->{g,
                                                        Exception} Nat
-    381. builtin.ImmutableByteArray.read32be           : ImmutableByteArray
+    382. builtin.ImmutableByteArray.read32be           : ImmutableByteArray
                                                        -> Nat
                                                        ->{Exception} Nat
-    382. builtin.MutableByteArray.read32be             : MutableByteArray
+    383. builtin.MutableByteArray.read32be             : MutableByteArray
                                                          g
                                                        -> Nat
                                                        ->{g,
                                                        Exception} Nat
-    383. builtin.ImmutableByteArray.read40be           : ImmutableByteArray
+    384. builtin.ImmutableByteArray.read40be           : ImmutableByteArray
                                                        -> Nat
                                                        ->{Exception} Nat
-    384. builtin.MutableByteArray.read40be             : MutableByteArray
+    385. builtin.MutableByteArray.read40be             : MutableByteArray
                                                          g
                                                        -> Nat
                                                        ->{g,
                                                        Exception} Nat
-    385. builtin.ImmutableByteArray.read64be           : ImmutableByteArray
+    386. builtin.ImmutableByteArray.read64be           : ImmutableByteArray
                                                        -> Nat
                                                        ->{Exception} Nat
-    386. builtin.MutableByteArray.read64be             : MutableByteArray
+    387. builtin.MutableByteArray.read64be             : MutableByteArray
                                                          g
                                                        -> Nat
                                                        ->{g,
                                                        Exception} Nat
-    387. builtin.ImmutableByteArray.read8              : ImmutableByteArray
+    388. builtin.ImmutableByteArray.read8              : ImmutableByteArray
                                                        -> Nat
                                                        ->{Exception} Nat
-    388. builtin.MutableByteArray.read8                : MutableByteArray
+    389. builtin.MutableByteArray.read8                : MutableByteArray
                                                          g
                                                        -> Nat
                                                        ->{g,
                                                        Exception} Nat
-    389. builtin.io2.Ref.readForCas                    : Ref
+    390. builtin.io2.Ref.readForCas                    : Ref
                                                          {IO} a
                                                        ->{IO} Ticket
                                                          a
-    390. builtin.io2.TVar.readIO                       : TVar a
+    391. builtin.io2.TVar.readIO                       : TVar a
                                                        ->{IO} a
-    391. builtin.io2.Clock.internals.realtime          : '{IO} Either
+    392. builtin.io2.Clock.internals.realtime          : '{IO} Either
                                                          Failure
                                                          TimeSpec
-    392. builtin.io2.IO.ref                            : a
+    393. builtin.io2.IO.ref                            : a
                                                        ->{IO} Ref
                                                          {IO} a
-    393. builtin.Scope.ref                             : a
+    394. builtin.Scope.ref                             : a
                                                        ->{Scope
                                                          s} Ref
                                                          {Scope
                                                            s}
                                                          a
-    394. builtin.Text.repeat                           : Nat
+    395. builtin.Text.repeat                           : Nat
                                                        -> Text
                                                        -> Text
-    395. builtin.Pattern.replicate                     : Nat
+    396. builtin.Pattern.replicate                     : Nat
                                                        -> Nat
                                                        -> Pattern
                                                          a
                                                        -> Pattern
                                                          a
-    396. builtin.io2.STM.retry                         : '{STM} a
-    397. builtin.Text.reverse                          : Text
+    397. builtin.io2.STM.retry                         : '{STM} a
+    398. builtin.Text.reverse                          : Text
                                                        -> Text
-    398. builtin.Float.round                           : Float
+    399. builtin.Float.round                           : Float
                                                        -> Int
-    399. builtin.Pattern.run                           : Pattern
+    400. builtin.Pattern.run                           : Pattern
                                                          a
                                                        -> a
                                                        -> Optional
                                                          ( [a],
                                                            a)
-    400. builtin.Scope.run                             : (∀ s.
+    401. builtin.Scope.run                             : (∀ s.
                                                          '{g,
                                                          Scope s} r)
                                                        ->{g} r
-    401. builtin.io2.Clock.internals.sec               : TimeSpec
+    402. builtin.io2.Clock.internals.sec               : TimeSpec
                                                        -> Int
-    402. builtin.Code.serialize                        : Code
+    403. builtin.Code.serialize                        : Code
                                                        -> Bytes
-    403. builtin.Value.serialize                       : Value
+    404. builtin.Value.serialize                       : Value
                                                        -> Bytes
-    404. builtin.io2.Tls.ClientConfig.certificates.set : [SignedCert]
+    405. builtin.io2.Tls.ClientConfig.certificates.set : [SignedCert]
                                                        -> ClientConfig
                                                        -> ClientConfig
-    405. builtin.io2.Tls.ServerConfig.certificates.set : [SignedCert]
+    406. builtin.io2.Tls.ServerConfig.certificates.set : [SignedCert]
                                                        -> ServerConfig
                                                        -> ServerConfig
-    406. builtin.io2.TLS.ClientConfig.ciphers.set      : [Cipher]
+    407. builtin.io2.TLS.ClientConfig.ciphers.set      : [Cipher]
                                                        -> ClientConfig
                                                        -> ClientConfig
-    407. builtin.io2.Tls.ServerConfig.ciphers.set      : [Cipher]
+    408. builtin.io2.Tls.ServerConfig.ciphers.set      : [Cipher]
                                                        -> ServerConfig
                                                        -> ServerConfig
-    408. builtin.io2.Tls.ClientConfig.versions.set     : [Version]
+    409. builtin.io2.Tls.ClientConfig.versions.set     : [Version]
                                                        -> ClientConfig
                                                        -> ClientConfig
-    409. builtin.io2.Tls.ServerConfig.versions.set     : [Version]
+    410. builtin.io2.Tls.ServerConfig.versions.set     : [Version]
                                                        -> ServerConfig
                                                        -> ServerConfig
-    410. builtin.Int.shiftLeft                         : Int
+    411. builtin.Int.shiftLeft                         : Int
                                                        -> Nat
                                                        -> Int
-    411. builtin.Nat.shiftLeft                         : Nat
+    412. builtin.Nat.shiftLeft                         : Nat
                                                        -> Nat
                                                        -> Nat
-    412. builtin.Int.shiftRight                        : Int
+    413. builtin.Int.shiftRight                        : Int
                                                        -> Nat
                                                        -> Int
-    413. builtin.Nat.shiftRight                        : Nat
+    414. builtin.Nat.shiftRight                        : Nat
                                                        -> Nat
                                                        -> Nat
-    414. builtin.Int.signum                            : Int
+    415. builtin.Int.signum                            : Int
                                                        -> Int
-    415. builtin.Float.sin                             : Float
+    416. builtin.Float.sin                             : Float
                                                        -> Float
-    416. builtin.Float.sinh                            : Float
+    417. builtin.Float.sinh                            : Float
                                                        -> Float
-    417. builtin.Bytes.size                            : Bytes
+    418. builtin.Bytes.size                            : Bytes
                                                        -> Nat
-    418. builtin.ImmutableArray.size                   : ImmutableArray
+    419. builtin.ImmutableArray.size                   : ImmutableArray
                                                          a
                                                        -> Nat
-    419. builtin.ImmutableByteArray.size               : ImmutableByteArray
+    420. builtin.ImmutableByteArray.size               : ImmutableByteArray
                                                        -> Nat
-    420. builtin.List.size                             : [a]
+    421. builtin.List.size                             : [a]
                                                        -> Nat
-    421. builtin.MutableArray.size                     : MutableArray
+    422. builtin.MutableArray.size                     : MutableArray
                                                          g a
                                                        -> Nat
-    422. builtin.MutableByteArray.size                 : MutableByteArray
+    423. builtin.MutableByteArray.size                 : MutableByteArray
                                                          g
                                                        -> Nat
-    423. builtin.Text.size                             : Text
+    424. builtin.Text.size                             : Text
                                                        -> Nat
-    424. builtin.Text.patterns.space                   : Pattern
+    425. builtin.Text.patterns.space                   : Pattern
                                                          Text
-    425. builtin.Float.sqrt                            : Float
+    426. builtin.Float.sqrt                            : Float
                                                        -> Float
-    426. builtin.io2.IO.stdHandle                      : StdHandle
+    427. builtin.io2.IO.stdHandle                      : StdHandle
                                                        -> Handle
-    427. builtin.Nat.sub                               : Nat
+    428. builtin.Nat.sub                               : Nat
                                                        -> Nat
                                                        -> Int
-    428. builtin.io2.TVar.swap                         : TVar a
+    429. builtin.io2.TVar.swap                         : TVar a
                                                        -> a
                                                        ->{STM} a
-    429. builtin.io2.IO.systemTimeMicroseconds         : '{IO} Int
-    430. builtin.Bytes.take                            : Nat
+    430. builtin.io2.IO.systemTimeMicroseconds         : '{IO} Int
+    431. builtin.Bytes.take                            : Nat
                                                        -> Bytes
                                                        -> Bytes
-    431. builtin.List.take                             : Nat
+    432. builtin.List.take                             : Nat
                                                        -> [a]
                                                        -> [a]
-    432. builtin.Text.take                             : Nat
+    433. builtin.Text.take                             : Nat
                                                        -> Text
                                                        -> Text
-    433. builtin.Float.tan                             : Float
+    434. builtin.Float.tan                             : Float
                                                        -> Float
-    434. builtin.Float.tanh                            : Float
+    435. builtin.Float.tanh                            : Float
                                                        -> Float
-    435. builtin.io2.Clock.internals.threadCPUTime     : '{IO} Either
+    436. builtin.io2.Clock.internals.threadCPUTime     : '{IO} Either
                                                          Failure
                                                          TimeSpec
-    436. builtin.Bytes.toBase16                        : Bytes
+    437. builtin.Bytes.toBase16                        : Bytes
                                                        -> Bytes
-    437. builtin.Bytes.toBase32                        : Bytes
+    438. builtin.Bytes.toBase32                        : Bytes
                                                        -> Bytes
-    438. builtin.Bytes.toBase64                        : Bytes
+    439. builtin.Bytes.toBase64                        : Bytes
                                                        -> Bytes
-    439. builtin.Bytes.toBase64UrlUnpadded             : Bytes
+    440. builtin.Bytes.toBase64UrlUnpadded             : Bytes
                                                        -> Bytes
-    440. builtin.Text.toCharList                       : Text
+    441. builtin.Text.toCharList                       : Text
                                                        -> [Char]
-    441. builtin.Int.toFloat                           : Int
+    442. builtin.Int.toFloat                           : Int
                                                        -> Float
-    442. builtin.Nat.toFloat                           : Nat
+    443. builtin.Nat.toFloat                           : Nat
                                                        -> Float
-    443. builtin.Nat.toInt                             : Nat
+    444. builtin.Nat.toInt                             : Nat
                                                        -> Int
-    444. builtin.Bytes.toList                          : Bytes
+    445. builtin.Bytes.toList                          : Bytes
                                                        -> [Nat]
-    445. builtin.Text.toLowercase                      : Text
+    446. builtin.Text.toLowercase                      : Text
                                                        -> Text
-    446. builtin.Char.toNat                            : Char
+    447. builtin.Char.toNat                            : Char
                                                        -> Nat
-    447. builtin.Float.toRepresentation                : Float
+    448. builtin.Float.toRepresentation                : Float
                                                        -> Nat
-    448. builtin.Int.toRepresentation                  : Int
+    449. builtin.Int.toRepresentation                  : Int
                                                        -> Nat
-    449. builtin.Char.toText                           : Char
+    450. builtin.Char.toText                           : Char
                                                        -> Text
-    450. builtin.Debug.toText                          : a
+    451. builtin.Debug.toText                          : a
                                                        -> Optional
                                                          (Either
                                                            Text
                                                            Text)
-    451. builtin.Float.toText                          : Float
+    452. builtin.Float.toText                          : Float
                                                        -> Text
-    452. builtin.Handle.toText                         : Handle
+    453. builtin.Handle.toText                         : Handle
                                                        -> Text
-    453. builtin.Int.toText                            : Int
+    454. builtin.Int.toText                            : Int
                                                        -> Text
-    454. builtin.Nat.toText                            : Nat
+    455. builtin.Nat.toText                            : Nat
                                                        -> Text
-    455. builtin.Socket.toText                         : Socket
+    456. builtin.Socket.toText                         : Socket
                                                        -> Text
-    456. builtin.Link.Term.toText                      : Term
+    457. builtin.Link.Term.toText                      : Term
                                                        -> Text
-    457. builtin.ThreadId.toText                       : ThreadId
+    458. builtin.ThreadId.toText                       : ThreadId
                                                        -> Text
-    458. builtin.Text.toUppercase                      : Text
+    459. builtin.Text.toUppercase                      : Text
                                                        -> Text
-    459. builtin.Text.toUtf8                           : Text
+    460. builtin.Text.toUtf8                           : Text
                                                        -> Bytes
-    460. builtin.todo                                  : a -> b
-    461. builtin.Debug.trace                           : Text
+    461. builtin.todo                                  : a -> b
+    462. builtin.Debug.trace                           : Text
                                                        -> a
                                                        -> ()
-    462. builtin.Int.trailingZeros                     : Int
+    463. builtin.Int.trailingZeros                     : Int
                                                        -> Nat
-    463. builtin.Nat.trailingZeros                     : Nat
+    464. builtin.Nat.trailingZeros                     : Nat
                                                        -> Nat
-    464. builtin.Float.truncate                        : Float
+    465. builtin.Float.truncate                        : Float
                                                        -> Int
-    465. builtin.Int.truncate0                         : Int
+    466. builtin.Int.truncate0                         : Int
                                                        -> Nat
-    466. builtin.io2.IO.tryEval                        : '{IO} a
+    467. builtin.io2.IO.tryEval                        : '{IO} a
                                                        ->{IO,
                                                        Exception} a
-    467. builtin.io2.Promise.tryRead                   : Promise
+    468. builtin.io2.Promise.tryRead                   : Promise
                                                          a
                                                        ->{IO} Optional
                                                          a
-    468. builtin.io2.MVar.tryTake                      : MVar a
+    469. builtin.io2.MVar.tryTake                      : MVar a
                                                        ->{IO} Optional
                                                          a
-    469. builtin.Text.uncons                           : Text
+    470. builtin.Text.uncons                           : Text
                                                        -> Optional
                                                          ( Char,
                                                            Text)
-    470. builtin.Any.unsafeExtract                     : Any
+    471. builtin.Any.unsafeExtract                     : Any
                                                        -> a
-    471. builtin.Text.unsnoc                           : Text
+    472. builtin.Text.unsnoc                           : Text
                                                        -> Optional
                                                          ( Text,
                                                            Char)
-    472. builtin.Code.validate                         : [( Term,
+    473. builtin.Code.validate                         : [( Term,
                                                          Code)]
                                                        ->{IO} Optional
                                                          Failure
-    473. builtin.io2.validateSandboxed                 : [Term]
+    474. builtin.io2.validateSandboxed                 : [Term]
                                                        -> a
                                                        -> Boolean
-    474. builtin.Value.value                           : a
+    475. builtin.Value.value                           : a
                                                        -> Value
-    475. builtin.Debug.watch                           : Text
+    476. builtin.Debug.watch                           : Text
                                                        -> a
                                                        -> a
-    476. builtin.MutableArray.write                    : MutableArray
+    477. builtin.MutableArray.write                    : MutableArray
                                                          g a
                                                        -> Nat
                                                        -> a
                                                        ->{g,
                                                        Exception} ()
-    477. builtin.io2.Promise.write                     : Promise
+    478. builtin.io2.Promise.write                     : Promise
                                                          a
                                                        -> a
                                                        ->{IO} Boolean
-    478. builtin.Ref.write                             : Ref g a
+    479. builtin.Ref.write                             : Ref g a
                                                        -> a
                                                        ->{g} ()
-    479. builtin.io2.TVar.write                        : TVar a
+    480. builtin.io2.TVar.write                        : TVar a
                                                        -> a
                                                        ->{STM} ()
-    480. builtin.MutableByteArray.write16be            : MutableByteArray
+    481. builtin.MutableByteArray.write16be            : MutableByteArray
                                                          g
                                                        -> Nat
                                                        -> Nat
                                                        ->{g,
                                                        Exception} ()
-    481. builtin.MutableByteArray.write32be            : MutableByteArray
+    482. builtin.MutableByteArray.write32be            : MutableByteArray
                                                          g
                                                        -> Nat
                                                        -> Nat
                                                        ->{g,
                                                        Exception} ()
-    482. builtin.MutableByteArray.write64be            : MutableByteArray
+    483. builtin.MutableByteArray.write64be            : MutableByteArray
                                                          g
                                                        -> Nat
                                                        -> Nat
                                                        ->{g,
                                                        Exception} ()
-    483. builtin.MutableByteArray.write8               : MutableByteArray
+    484. builtin.MutableByteArray.write8               : MutableByteArray
                                                          g
                                                        -> Nat
                                                        -> Nat
                                                        ->{g,
                                                        Exception} ()
-    484. builtin.Int.xor                               : Int
+    485. builtin.Int.xor                               : Int
                                                        -> Int
                                                        -> Int
-    485. builtin.Nat.xor                               : Nat
+    486. builtin.Nat.xor                               : Nat
                                                        -> Nat
                                                        -> Nat
   

--- a/unison-src/transcripts/reflog.output.md
+++ b/unison-src/transcripts/reflog.output.md
@@ -59,17 +59,17 @@ y = 2
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #9014t8bemk .old`   to make an old namespace
+    `fork #c50ilio6t7 .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #9014t8bemk`  to reset the root namespace and
+    `reset-root #c50ilio6t7`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
        When   Root Hash     Action
-  1.   now    #q24i9rm0u0   add
-  2.   now    #9014t8bemk   add
-  3.   now    #2p31h4lsei   builtins.merge
+  1.   now    #r1ojo66sp7   add
+  2.   now    #c50ilio6t7   add
+  3.   now    #k0vh8qed2b   builtins.merge
   4.          #sg60bvjo91   history starts here
   
   Tip: Use `diff.namespace 1 7` to compare namespaces between

--- a/unison-src/transcripts/squash.output.md
+++ b/unison-src/transcripts/squash.output.md
@@ -13,7 +13,7 @@ Let's look at some examples. We'll start with a namespace with just the builtins
   
   
   
-  □ 1. #5r75rvflum (start of history)
+  □ 1. #61h5m6vr8d (start of history)
 
 .> fork builtin builtin2
 
@@ -42,21 +42,21 @@ Now suppose we `fork` a copy of builtin, then rename `Nat.+` to `frobnicate`, th
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #ih7oa9qmee
+  ⊙ 1. #h3t1td6j70
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ 2. #2nsvr26oeu
+  ⊙ 2. #hof2b14ggf
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ 3. #5r75rvflum (start of history)
+  □ 3. #61h5m6vr8d (start of history)
 
 ```
 If we merge that back into `builtin`, we get that same chain of history:
@@ -71,21 +71,21 @@ If we merge that back into `builtin`, we get that same chain of history:
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #ih7oa9qmee
+  ⊙ 1. #h3t1td6j70
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ 2. #2nsvr26oeu
+  ⊙ 2. #hof2b14ggf
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ 3. #5r75rvflum (start of history)
+  □ 3. #61h5m6vr8d (start of history)
 
 ```
 Let's try again, but using a `merge.squash` (or just `squash`) instead. The history will be unchanged:
@@ -106,7 +106,7 @@ Let's try again, but using a `merge.squash` (or just `squash`) instead. The hist
   
   
   
-  □ 1. #5r75rvflum (start of history)
+  □ 1. #61h5m6vr8d (start of history)
 
 ```
 The churn that happened in `mybuiltin` namespace ended up back in the same spot, so the squash merge of that namespace with our original namespace had no effect.
@@ -485,13 +485,13 @@ This checks to see that squashing correctly preserves deletions:
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #65gt0djmn2
+  ⊙ 1. #v3tbgssvfo
   
     - Deletes:
     
       Nat.* Nat.+
   
-  □ 2. #5r75rvflum (start of history)
+  □ 2. #61h5m6vr8d (start of history)
 
 ```
 Notice that `Nat.+` and `Nat.*` are deleted by the squash, and we see them deleted in one atomic step in the history.


### PR DESCRIPTION
## Overview

Add a universal non crypto hash function, useful for hash map. Fixes #3756 

## Implementation notes

Uses Haskell's `murmur-hash`, which already integrates with ByteString

## Interesting/controversial decisions

None

## Test coverage

I've done some manual testing, and the code is a very thin wrapper over the haskell lib.

## Loose ends

Not sure whether it's worth adding a `murmurBytes: Bytes -> Nat` as well or not, it can currently be written in pure Unison 

