### PR TITLE
Add HLint configuration, excluding infinite filesystem loop.

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,99 @@
+# Avoid infinite loop and other symlinks.
+#   $ find -L . -type l
+#   find: File system loop detected;
+#     ‘./codebase2/codebase-sqlite/unison’ is part of the same file system loop as
+#     ‘./codebase2/codebase-sqlite’.
+#   find: File system loop detected;
+#     ‘./unison’ is part of the same file system loop as
+#     ‘.’.
+- arguments:
+  - --ignore-glob=codebase2/codebase-sqlite/unison
+  - --ignore-glob=unison
+# Warnings currently triggered by your code
+- ignore: {name: "Avoid lambda"} # 44 hints
+- ignore: {name: "Avoid lambda using `infix`"} # 19 hints
+- ignore: {name: "Avoid reverse"} # 1 hint
+- ignore: {name: "Eta reduce"} # 93 hints
+- ignore: {name: "Evaluate"} # 7 hints
+- ignore: {name: "Functor law"} # 6 hints
+- ignore: {name: "Fuse foldMap/fmap"} # 1 hint
+- ignore: {name: "Hoist not"} # 10 hints
+- ignore: {name: "Monoid law, left identity"} # 2 hints
+- ignore: {name: "Move brackets to avoid $"} # 27 hints
+- ignore: {name: "Parse error: on input `|]'"} # 1 hint
+- ignore: {name: "Redundant $"} # 126 hints
+- ignore: {name: "Redundant <$>"} # 17 hints
+- ignore: {name: "Redundant as"} # 1 hint
+- ignore: {name: "Redundant as-pattern"} # 1 hint
+- ignore: {name: "Redundant bang pattern"} # 2 hints
+- ignore: {name: "Redundant bracket"} # 242 hints
+- ignore: {name: "Redundant compare"} # 2 hints
+- ignore: {name: "Redundant first"} # 1 hint
+- ignore: {name: "Redundant flip"} # 7 hints
+- ignore: {name: "Redundant guard"} # 1 hint
+- ignore: {name: "Redundant id"} # 2 hints
+- ignore: {name: "Redundant if"} # 1 hint
+- ignore: {name: "Redundant lambda"} # 1 hint
+- ignore: {name: "Redundant pure"} # 14 hints
+- ignore: {name: "Redundant variable capture"} # 1 hint
+- ignore: {name: "Redundant where"} # 1 hint
+- ignore: {name: "Replace case with maybe"} # 13 hints
+- ignore: {name: "Unused LANGUAGE pragma"} # 127 hints
+- ignore: {name: "Use $>"} # 7 hints
+- ignore: {name: "Use /="} # 2 hints
+- ignore: {name: "Use :"} # 9 hints
+- ignore: {name: "Use <$"} # 12 hints
+- ignore: {name: "Use <$>"} # 32 hints
+- ignore: {name: "Use <&>"} # 1 hint
+- ignore: {name: "Use =<<"} # 3 hints
+- ignore: {name: "Use ?~"} # 2 hints
+- ignore: {name: "Use Just"} # 1 hint
+- ignore: {name: "Use and"} # 1 hint
+- ignore: {name: "Use asks"} # 1 hint
+- ignore: {name: "Use bimap"} # 6 hints
+- ignore: {name: "Use catMaybes"} # 2 hints
+- ignore: {name: "Use const"} # 9 hints
+- ignore: {name: "Use elem"} # 3 hints
+- ignore: {name: "Use first"} # 4 hints
+- ignore: {name: "Use fmap"} # 5 hints
+- ignore: {name: "Use fold"} # 6 hints
+- ignore: {name: "Use forM_"} # 1 hint
+- ignore: {name: "Use for_"} # 1 hint
+- ignore: {name: "Use fromMaybe"} # 1 hint
+- ignore: {name: "Use gets"} # 1 hint
+- ignore: {name: "Use guards"} # 3 hints
+- ignore: {name: "Use id"} # 1 hint
+- ignore: {name: "Use if"} # 4 hints
+- ignore: {name: "Use infix"} # 8 hints
+- ignore: {name: "Use isNothing"} # 7 hints
+- ignore: {name: "Use isSuffixOf"} # 1 hint
+- ignore: {name: "Use join"} # 1 hint
+- ignore: {name: "Use lambda-case"} # 2 hints
+- ignore: {name: "Use let"} # 7 hints
+- ignore: {name: "Use list comprehension"} # 5 hints
+- ignore: {name: "Use list literal pattern"} # 1 hint
+- ignore: {name: "Use map"} # 3 hints
+- ignore: {name: "Use map once"} # 2 hints
+- ignore: {name: "Use mapMaybe"} # 7 hints
+- ignore: {name: "Use max"} # 1 hint
+- ignore: {name: "Use maybe"} # 1 hint
+- ignore: {name: "Use newTMVarIO"} # 1 hint
+- ignore: {name: "Use newTVarIO"} # 1 hint
+- ignore: {name: "Use newtype instead of data"} # 20 hints
+- ignore: {name: "Use notElem"} # 1 hint
+- ignore: {name: "Use null"} # 1 hint
+- ignore: {name: "Use record patterns"} # 17 hints
+- ignore: {name: "Use replicate"} # 1 hint
+- ignore: {name: "Use second"} # 11 hints
+- ignore: {name: "Use sequenceA"} # 3 hints
+- ignore: {name: "Use snd"} # 1 hint
+- ignore: {name: "Use splitAt"} # 1 hint
+- ignore: {name: "Use traverse"} # 2 hints
+- ignore: {name: "Use traverse_"} # 1 hint
+- ignore: {name: "Use tuple-section"} # 3 hints
+- ignore: {name: "Use uncurry"} # 8 hints
+- ignore: {name: "Use unless"} # 40 hints
+- ignore: {name: "Use unwords"} # 3 hints
+- ignore: {name: "Use void"} # 5 hints
+- ignore: {name: "Use when"} # 3 hints
+- ignore: {name: "Use zipWith"} # 2 hints


### PR DESCRIPTION
## Overview

I tried running HLint over the codebase but it ran forever and was killed, see #3746.

## Implementation notes

Excludes the the symlinks that make the filesystem loop so that HLint can run.

## Interesting/controversial decisions

I opted to also ignore all current hints with the `--default` option. This is a clean starting point from which we could remove the hint ignores one-by-one as we fix them, if that is what we want to do with #3747.
