### PR TITLE
Add a Debug.toText builtin

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -548,6 +548,8 @@ builtinsSrc =
     B "ThreadId.toText" $ threadId --> text,
     B "Debug.watch" $ forall1 "a" (\a -> text --> a --> a),
     B "Debug.trace" $ forall1 "a" (\a -> text --> a --> unit),
+    B "Debug.toText" $
+      forall1 "a" (\a -> a --> optionalt (eithert text text)),
     B "unsafe.coerceAbilities" $
       forall4 "a" "b" "e1" "e2" $ \a b e1 e2 ->
         (a --> Type.effect1 () e1 b) --> (a --> Type.effect1 () e2 b),

--- a/parser-typechecker/src/Unison/Runtime/ANF.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF.hs
@@ -1301,6 +1301,7 @@ data POp
   | PRNT
   | INFO
   | TRCE
+  | DBTX
   | -- STM
     ATOM
   | TFRC -- try force

--- a/parser-typechecker/src/Unison/Runtime/ANF/Serialize.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF/Serialize.hs
@@ -549,6 +549,7 @@ pOpCode op = case op of
   TRCE -> 116
   ATOM -> 117
   TFRC -> 118
+  DBTX -> 119
 
 pOpAssoc :: [(POp, Word16)]
 pOpAssoc = map (\op -> (op, pOpCode op)) [minBound .. maxBound]

--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -880,6 +880,17 @@ gen'trace =
     TLets Direct [] [] (TPrm TRCE [t, v]) $
       TCon Ty.unitRef 0 []
 
+debug'text :: SuperNormal Symbol
+debug'text =
+  unop0 3 $ \[c,r,t,e] ->
+    TLetD r UN (TPrm DBTX [c]) .
+      TMatch r . MatchSum $
+        mapFromList [
+            (0, ([], none)),
+            (1, ([BX], TAbs t . TLetD e BX (left t) $ some e)),
+            (2, ([BX], TAbs t . TLetD e BX (right t) $ some e))
+          ]
+
 code'missing :: SuperNormal Symbol
 code'missing =
   unop0 1 $ \[link, b] ->
@@ -1922,6 +1933,7 @@ builtinLookup =
         ("todo", (Untracked, bug "builtin.todo")),
         ("Debug.watch", (Tracked, watch)),
         ("Debug.trace", (Tracked, gen'trace)),
+        ("Debug.toText", (Tracked, debug'text)),
         ("unsafe.coerceAbilities", (Untracked, poly'coerce)),
         ("Char.toNat", (Untracked, cast Ty.charRef Ty.natRef)),
         ("Char.fromNat", (Untracked, cast Ty.natRef Ty.charRef)),

--- a/parser-typechecker/src/Unison/Runtime/MCode.hs
+++ b/parser-typechecker/src/Unison/Runtime/MCode.hs
@@ -387,6 +387,8 @@ data BPrim1
   | CVLD -- validate
   | VALU
   | TLTT -- value, Term.Link.toText
+  -- debug
+  | DBTX -- debug text
   deriving (Show, Eq, Ord)
 
 data BPrim2
@@ -415,8 +417,8 @@ data BPrim2
   | IDXB
   | CATB -- take,drop,index,append
   -- general
-  | THRO
-  | TRCE -- throw
+  | THRO -- throw
+  | TRCE -- trace
   -- code
   | SDBX -- sandbox
   deriving (Show, Eq, Ord)
@@ -1176,6 +1178,7 @@ emitPOp ANF.SDBX = emitBP2 SDBX
 -- error call
 emitPOp ANF.EROR = emitBP2 THRO
 emitPOp ANF.TRCE = emitBP2 TRCE
+emitPOp ANF.DBTX = emitBP1 DBTX
 -- non-prim translations
 emitPOp ANF.BLDS = Seq
 emitPOp ANF.FORK = \case

--- a/parser-typechecker/src/Unison/Runtime/Machine.hs
+++ b/parser-typechecker/src/Unison/Runtime/Machine.hs
@@ -51,7 +51,6 @@ import qualified Unison.Type as Rf
 import qualified Unison.Util.Bytes as By
 import Unison.Util.EnumContainers as EC
 import Unison.Util.Pretty (toPlainUnbroken)
-import Unison.Util.Text (Text)
 import qualified Unison.Util.Text as Util.Text
 import UnliftIO (IORef)
 import qualified UnliftIO
@@ -69,11 +68,16 @@ type Tag = Word64
 -- dynamic environment
 type DEnv = EnumMap Word64 Closure
 
+data Tracer
+  = NoTrace
+  | MsgTrace String String
+  | SimpleTrace String
+
 -- code caching environment
 data CCache = CCache
   { foreignFuncs :: EnumMap Word64 ForeignFunc,
     sandboxed :: Bool,
-    tracer :: Unison.Util.Text.Text -> Closure -> IO (),
+    tracer :: Bool -> Closure -> Tracer,
     combs :: TVar (EnumMap Word64 Combs),
     combRefs :: TVar (EnumMap Word64 Reference),
     tagRefs :: TVar (EnumMap Word64 Reference),
@@ -120,7 +124,7 @@ baseCCache sandboxed = do
     <*> newTVarIO baseSandboxInfo
   where
     ffuncs | sandboxed = sandboxedForeigns | otherwise = builtinForeigns
-    noTrace _ _ = pure ()
+    noTrace _ _ = NoTrace
     ftm = 1 + maximum builtinTermNumbering
     fty = 1 + maximum builtinTypeNumbering
 
@@ -351,6 +355,23 @@ exec !env !denv !_activeThreads !ustk !bstk !k _ (BPrim1 VALU i) = do
   bstk <- bump bstk
   pokeBi bstk =<< reflectValue m c
   pure (denv, ustk, bstk, k)
+exec !env !denv !_activeThreads !ustk !bstk !k _ (BPrim1 DBTX i)
+  | sandboxed env =
+      die "attempted to use sandboxed operation: Debug.toText"
+  | otherwise = do
+      clo <- peekOff bstk i
+      ustk <- bump ustk
+      bstk <- case tracer env False clo of
+        NoTrace -> bstk <$ poke ustk 0
+        MsgTrace _ tx -> do
+          poke ustk 1
+          bstk <- bump bstk
+          bstk <$ pokeBi bstk (Util.Text.pack tx)
+        SimpleTrace tx -> do
+          poke ustk 2
+          bstk <- bump bstk
+          bstk <$ pokeBi bstk (Util.Text.pack tx)
+      pure (denv, ustk, bstk, k)
 exec !_ !denv !_activeThreads !ustk !bstk !k _ (BPrim1 op i) = do
   (ustk, bstk) <- bprim1 ustk bstk op i
   pure (denv, ustk, bstk, k)
@@ -383,7 +404,15 @@ exec !env !denv !_activeThreads !ustk !bstk !k _ (BPrim2 TRCE i j)
   | otherwise = do
       tx <- peekOffBi bstk i
       clo <- peekOff bstk j
-      tracer env tx clo
+      case tracer env True clo of
+        NoTrace -> pure ()
+        SimpleTrace str -> do
+          putStrLn $ "trace: " ++ Util.Text.unpack tx
+          putStrLn str
+        MsgTrace msg str -> do
+          putStrLn $ "trace: " ++ Util.Text.unpack tx
+          putStrLn msg
+          putStrLn str
       pure (denv, ustk, bstk, k)
 exec !_ !denv !_trackThreads !ustk !bstk !k _ (BPrim2 op i j) = do
   (ustk, bstk) <- bprim2 ustk bstk op i j
@@ -1445,6 +1474,7 @@ bprim1 !ustk !bstk CVLD _ = pure (ustk, bstk)
 bprim1 !ustk !bstk TLTT _ = pure (ustk, bstk)
 bprim1 !ustk !bstk LOAD _ = pure (ustk, bstk)
 bprim1 !ustk !bstk VALU _ = pure (ustk, bstk)
+bprim1 !ustk !bstk DBTX _ = pure (ustk, bstk)
 {-# INLINE bprim1 #-}
 
 bprim2 ::

--- a/parser-typechecker/src/Unison/Runtime/Serialize.hs
+++ b/parser-typechecker/src/Unison/Runtime/Serialize.hs
@@ -401,6 +401,7 @@ instance Tag BPrim1 where
   tag2word CVLD = 22
   tag2word VALU = 23
   tag2word TLTT = 24
+  tag2word DBTX = 25
 
   word2tag 0 = pure SIZT
   word2tag 1 = pure USNC
@@ -427,6 +428,7 @@ instance Tag BPrim1 where
   word2tag 22 = pure CVLD
   word2tag 23 = pure VALU
   word2tag 24 = pure TLTT
+  word2tag 25 = pure DBTX
   word2tag n = unknownTag "BPrim1" n
 
 instance Tag BPrim2 where

--- a/unison-src/transcripts-using-base/all-base-hashes.output.md
+++ b/unison-src/transcripts-using-base/all-base-hashes.output.md
@@ -384,418 +384,421 @@ This transcript is intended to make visible accidental changes to the hashing al
        -> Bytes
        -> Bytes
        
-  115. -- ##Debug.trace
+  115. -- ##Debug.toText
+       builtin.Debug.toText : a -> Optional (Either Text Text)
+       
+  116. -- ##Debug.trace
        builtin.Debug.trace : Text -> a -> ()
        
-  116. -- ##Debug.watch
+  117. -- ##Debug.watch
        builtin.Debug.watch : Text -> a -> a
        
-  117. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8
+  118. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8
        unique type builtin.Doc
        
-  118. -- #baiqeiovdrs4ju0grn5q5akq64k4kuhgifqno52smkkttqg31jkgm3qa9o3ohe54fgpiigd1tj0an7rfveopfg622sjj9v9g44n27go
+  119. -- #baiqeiovdrs4ju0grn5q5akq64k4kuhgifqno52smkkttqg31jkgm3qa9o3ohe54fgpiigd1tj0an7rfveopfg622sjj9v9g44n27go
        builtin.Doc.++ : Doc2 -> Doc2 -> Doc2
        
-  119. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#0
+  120. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#0
        builtin.Doc.Blob : Text -> Doc
        
-  120. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#4
+  121. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#4
        builtin.Doc.Evaluate : Link.Term -> Doc
        
-  121. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#5
+  122. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#5
        builtin.Doc.Join : [Doc] -> Doc
        
-  122. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#1
+  123. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#1
        builtin.Doc.Link : Link -> Doc
        
-  123. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#3
+  124. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#3
        builtin.Doc.Signature : Link.Term -> Doc
        
-  124. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#2
+  125. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#2
        builtin.Doc.Source : Link -> Doc
        
-  125. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0
+  126. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0
        unique type builtin.Doc2
        
-  126. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#27
+  127. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#27
        builtin.Doc2.Anchor : Text -> Doc2 -> Doc2
        
-  127. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#11
+  128. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#11
        builtin.Doc2.Aside : Doc2 -> Doc2
        
-  128. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#15
+  129. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#15
        builtin.Doc2.Blankline : Doc2
        
-  129. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#10
+  130. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#10
        builtin.Doc2.Blockquote : Doc2 -> Doc2
        
-  130. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#7
+  131. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#7
        builtin.Doc2.Bold : Doc2 -> Doc2
        
-  131. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#21
+  132. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#21
        builtin.Doc2.BulletedList : [Doc2] -> Doc2
        
-  132. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#3
+  133. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#3
        builtin.Doc2.Callout : Optional Doc2 -> Doc2 -> Doc2
        
-  133. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#6
+  134. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#6
        builtin.Doc2.Code : Doc2 -> Doc2
        
-  134. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#25
+  135. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#25
        builtin.Doc2.CodeBlock : Text -> Doc2 -> Doc2
        
-  135. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#24
+  136. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#24
        builtin.Doc2.Column : [Doc2] -> Doc2
        
-  136. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#0
+  137. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#0
        builtin.Doc2.Folded : Boolean -> Doc2 -> Doc2 -> Doc2
        
-  137. -- #h3gajooii4tsdseghcbcsq4qq7c33mtb71u5npg35b06mgv7v654g0n55gpq212umfmq7nvi11o28m1v13r5fto5g8ium3ee4qk1i68
+  138. -- #h3gajooii4tsdseghcbcsq4qq7c33mtb71u5npg35b06mgv7v654g0n55gpq212umfmq7nvi11o28m1v13r5fto5g8ium3ee4qk1i68
        unique type builtin.Doc2.FrontMatter
        
-  138. -- #h3gajooii4tsdseghcbcsq4qq7c33mtb71u5npg35b06mgv7v654g0n55gpq212umfmq7nvi11o28m1v13r5fto5g8ium3ee4qk1i68#0
+  139. -- #h3gajooii4tsdseghcbcsq4qq7c33mtb71u5npg35b06mgv7v654g0n55gpq212umfmq7nvi11o28m1v13r5fto5g8ium3ee4qk1i68#0
        builtin.Doc2.FrontMatter.FrontMatter : [(Text, Text)]
        -> FrontMatter
        
-  139. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#12
+  140. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#12
        builtin.Doc2.Group : Doc2 -> Doc2
        
-  140. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#14
+  141. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#14
        builtin.Doc2.Image : Doc2
        -> Doc2
        -> Optional Doc2
        -> Doc2
        
-  141. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#8
+  142. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#8
        builtin.Doc2.Italic : Doc2 -> Doc2
        
-  142. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#22
+  143. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#22
        builtin.Doc2.Join : [Doc2] -> Doc2
        
-  143. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#16
+  144. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#16
        builtin.Doc2.Linebreak : Doc2
        
-  144. -- #ut0tds116gr0soc9p6nroaalqlq423u1mao3p4jjultjmok3vbck69la7rs26duptji5v5hscijpek4hotu4krbfah8np3sntr87gb0
+  145. -- #ut0tds116gr0soc9p6nroaalqlq423u1mao3p4jjultjmok3vbck69la7rs26duptji5v5hscijpek4hotu4krbfah8np3sntr87gb0
        unique type builtin.Doc2.MediaSource
        
-  145. -- #ut0tds116gr0soc9p6nroaalqlq423u1mao3p4jjultjmok3vbck69la7rs26duptji5v5hscijpek4hotu4krbfah8np3sntr87gb0#0
+  146. -- #ut0tds116gr0soc9p6nroaalqlq423u1mao3p4jjultjmok3vbck69la7rs26duptji5v5hscijpek4hotu4krbfah8np3sntr87gb0#0
        builtin.Doc2.MediaSource.MediaSource : Text
        -> Optional Text
        -> MediaSource
        
-  146. -- #f7s1m2rs7ldj4idrcirtdqohsmc6n719e6cdqtgrhdkcrbm7971uvug6mvkrcc32qhdpo1og4oqin4rbmb2346m47ni24k5m3bpp3so
+  147. -- #f7s1m2rs7ldj4idrcirtdqohsmc6n719e6cdqtgrhdkcrbm7971uvug6mvkrcc32qhdpo1og4oqin4rbmb2346m47ni24k5m3bpp3so
        builtin.Doc2.MediaSource.mimeType : MediaSource
        -> Optional Text
        
-  147. -- #rncdj545f93f7nfrneabp6jlrjag766vr2n18al8u2a78ju5v746agg62r4ob8u6ue8eeac6nbg8apeii6qfasgfv2q2ap3h4sk1tdg
+  148. -- #rncdj545f93f7nfrneabp6jlrjag766vr2n18al8u2a78ju5v746agg62r4ob8u6ue8eeac6nbg8apeii6qfasgfv2q2ap3h4sk1tdg
        builtin.Doc2.MediaSource.mimeType.modify : (Optional Text
        ->{g} Optional Text)
        -> MediaSource
        ->{g} MediaSource
        
-  148. -- #54dl203thl9540r2jec546pishtg1b1ecb8vl6rqlbgf4h2rk04mrkdkqo4be82m8d3t2d0ef3gidjsn2r9u8ko7c9kvtavbqflim88
+  149. -- #54dl203thl9540r2jec546pishtg1b1ecb8vl6rqlbgf4h2rk04mrkdkqo4be82m8d3t2d0ef3gidjsn2r9u8ko7c9kvtavbqflim88
        builtin.Doc2.MediaSource.mimeType.set : Optional Text
        -> MediaSource
        -> MediaSource
        
-  149. -- #77l9vc6k6miu7pobamoasrpdm455ddgprgvfpg2di6liigijg70f4t3ppmpbs3j12kp93eep7u0e5r1bdq0niou0v85lo4aa5kek8mg
+  150. -- #77l9vc6k6miu7pobamoasrpdm455ddgprgvfpg2di6liigijg70f4t3ppmpbs3j12kp93eep7u0e5r1bdq0niou0v85lo4aa5kek8mg
        builtin.Doc2.MediaSource.sourceUrl : MediaSource -> Text
        
-  150. -- #laoh1nhllsb9vf0reilmbmjutdei2b0vs0vse1s8j148imfi1m9uu4l17iqdt9r5575dap8jnlq6r48kdn6ob70iroso75erqfc74e0
+  151. -- #laoh1nhllsb9vf0reilmbmjutdei2b0vs0vse1s8j148imfi1m9uu4l17iqdt9r5575dap8jnlq6r48kdn6ob70iroso75erqfc74e0
        builtin.Doc2.MediaSource.sourceUrl.modify : (Text
        ->{g} Text)
        -> MediaSource
        ->{g} MediaSource
        
-  151. -- #eb0dl30fc5k80vb0fna187vmag5ta1rgik40s1shlkng8stvvkt2gglecit8ajjd8vmfrtg8ki8ft3ife8rrqlcoit5161ekg6vhcfo
+  152. -- #eb0dl30fc5k80vb0fna187vmag5ta1rgik40s1shlkng8stvvkt2gglecit8ajjd8vmfrtg8ki8ft3ife8rrqlcoit5161ekg6vhcfo
        builtin.Doc2.MediaSource.sourceUrl.set : Text
        -> MediaSource
        -> MediaSource
        
-  152. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#2
+  153. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#2
        builtin.Doc2.NamedLink : Doc2 -> Doc2 -> Doc2
        
-  153. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#4
+  154. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#4
        builtin.Doc2.NumberedList : Nat -> [Doc2] -> Doc2
        
-  154. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#20
+  155. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#20
        builtin.Doc2.Paragraph : [Doc2] -> Doc2
        
-  155. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#13
+  156. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#13
        builtin.Doc2.Section : Doc2 -> [Doc2] -> Doc2
        
-  156. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#17
+  157. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#17
        builtin.Doc2.SectionBreak : Doc2
        
-  157. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#5
+  158. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#5
        builtin.Doc2.Special : SpecialForm -> Doc2
        
-  158. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0
+  159. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0
        unique type builtin.Doc2.SpecialForm
        
-  159. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#4
+  160. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#4
        builtin.Doc2.SpecialForm.Embed : Any -> SpecialForm
        
-  160. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#5
+  161. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#5
        builtin.Doc2.SpecialForm.EmbedInline : Any -> SpecialForm
        
-  161. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#9
+  162. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#9
        builtin.Doc2.SpecialForm.Eval : Doc2.Term -> SpecialForm
        
-  162. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#10
+  163. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#10
        builtin.Doc2.SpecialForm.EvalInline : Doc2.Term
        -> SpecialForm
        
-  163. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#0
+  164. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#0
        builtin.Doc2.SpecialForm.Example : Nat
        -> Doc2.Term
        -> SpecialForm
        
-  164. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#1
+  165. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#1
        builtin.Doc2.SpecialForm.ExampleBlock : Nat
        -> Doc2.Term
        -> SpecialForm
        
-  165. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#7
+  166. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#7
        builtin.Doc2.SpecialForm.FoldedSource : [( Either
          Type Doc2.Term,
          [Doc2.Term])]
        -> SpecialForm
        
-  166. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#3
+  167. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#3
        builtin.Doc2.SpecialForm.Link : Either Type Doc2.Term
        -> SpecialForm
        
-  167. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#2
+  168. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#2
        builtin.Doc2.SpecialForm.Signature : [Doc2.Term]
        -> SpecialForm
        
-  168. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#8
+  169. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#8
        builtin.Doc2.SpecialForm.SignatureInline : Doc2.Term
        -> SpecialForm
        
-  169. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#6
+  170. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#6
        builtin.Doc2.SpecialForm.Source : [( Either
          Type Doc2.Term,
          [Doc2.Term])]
        -> SpecialForm
        
-  170. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#9
+  171. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#9
        builtin.Doc2.Strikethrough : Doc2 -> Doc2
        
-  171. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#26
+  172. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#26
        builtin.Doc2.Style : Text -> Doc2 -> Doc2
        
-  172. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#18
+  173. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#18
        builtin.Doc2.Table : [[Doc2]] -> Doc2
        
-  173. -- #s0an21vospbdlsbddiskuvt3ngbf00n78sip2o1mnp4jgp16i7sursbm14bf8ap7osphqbis2lduep3i29b7diu8sf03f8tlqd7rgcg
+  174. -- #s0an21vospbdlsbddiskuvt3ngbf00n78sip2o1mnp4jgp16i7sursbm14bf8ap7osphqbis2lduep3i29b7diu8sf03f8tlqd7rgcg
        unique type builtin.Doc2.Term
        
-  174. -- #tu2du1k0lrp6iddor1aotdhdgn1j2b86r22tes3o3hka0bv4b4otlbimj88ttrdnbuacokk768k4e54795of8gnosopjirl4jm42g28
+  175. -- #tu2du1k0lrp6iddor1aotdhdgn1j2b86r22tes3o3hka0bv4b4otlbimj88ttrdnbuacokk768k4e54795of8gnosopjirl4jm42g28
        builtin.Doc2.term : '{g} a -> Doc2.Term
        
-  175. -- #s0an21vospbdlsbddiskuvt3ngbf00n78sip2o1mnp4jgp16i7sursbm14bf8ap7osphqbis2lduep3i29b7diu8sf03f8tlqd7rgcg#0
+  176. -- #s0an21vospbdlsbddiskuvt3ngbf00n78sip2o1mnp4jgp16i7sursbm14bf8ap7osphqbis2lduep3i29b7diu8sf03f8tlqd7rgcg#0
        builtin.Doc2.Term.Term : Any -> Doc2.Term
        
-  176. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#1
+  177. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#1
        builtin.Doc2.Tooltip : Doc2 -> Doc2 -> Doc2
        
-  177. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#23
+  178. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#23
        builtin.Doc2.UntitledSection : [Doc2] -> Doc2
        
-  178. -- #794fndq1941e2khqv5uh7fmk9es2g4fkp8pr48objgs6blc1pqsdt2ab4o79noril2l7s70iu2eimn1smpd8t40j4g18btian8a2pt0
+  179. -- #794fndq1941e2khqv5uh7fmk9es2g4fkp8pr48objgs6blc1pqsdt2ab4o79noril2l7s70iu2eimn1smpd8t40j4g18btian8a2pt0
        unique type builtin.Doc2.Video
        
-  179. -- #46er7fsgre91rer0mpk6vhaa2vie19i0piubvtnfmt3vq7odcjfr6tlf0mc57q4jnij9rkolpekjd6dpqdotn41guk9lp9qioa88m58
+  180. -- #46er7fsgre91rer0mpk6vhaa2vie19i0piubvtnfmt3vq7odcjfr6tlf0mc57q4jnij9rkolpekjd6dpqdotn41guk9lp9qioa88m58
        builtin.Doc2.Video.config : Video -> [(Text, Text)]
        
-  180. -- #vld47vp37855gceko81jj00j5t0mf5p137ub57094585aq3jfevq0ob03fot9d73p97r2pj0alel9e6a7lqcc7mue0ogefshg991e6g
+  181. -- #vld47vp37855gceko81jj00j5t0mf5p137ub57094585aq3jfevq0ob03fot9d73p97r2pj0alel9e6a7lqcc7mue0ogefshg991e6g
        builtin.Doc2.Video.config.modify : ([(Text, Text)]
        ->{g} [(Text, Text)])
        -> Video
        ->{g} Video
        
-  181. -- #ll9hiqi1s63ragrv9ul3ouu2rvpjkok4gdmgqs6cl8j4fgdmqlgikc5lseoe94e9fvrughjfetlcsn7gc5ed8prtnljfo5j6r1vveq8
+  182. -- #ll9hiqi1s63ragrv9ul3ouu2rvpjkok4gdmgqs6cl8j4fgdmqlgikc5lseoe94e9fvrughjfetlcsn7gc5ed8prtnljfo5j6r1vveq8
        builtin.Doc2.Video.config.set : [(Text, Text)]
        -> Video
        -> Video
        
-  182. -- #a454aldsi00l8kh10bhi6d4phtdr9ht0es6apr05jert6oo4vstm5cdr4ee2k0srted1urqgvkrcoihjvmus6tph92v628f3lr9b92o
+  183. -- #a454aldsi00l8kh10bhi6d4phtdr9ht0es6apr05jert6oo4vstm5cdr4ee2k0srted1urqgvkrcoihjvmus6tph92v628f3lr9b92o
        builtin.Doc2.Video.sources : Video -> [MediaSource]
        
-  183. -- #nm77894uq9g3kv5mo7ubuptpimt53jml7jt825lr83gu41tqcfpg2krcesn7p5aaea107su7brg2gm8vn1l0mabpfnpbcdi4onlatvo
+  184. -- #nm77894uq9g3kv5mo7ubuptpimt53jml7jt825lr83gu41tqcfpg2krcesn7p5aaea107su7brg2gm8vn1l0mabpfnpbcdi4onlatvo
        builtin.Doc2.Video.sources.modify : ([MediaSource]
        ->{g} [MediaSource])
        -> Video
        ->{g} Video
        
-  184. -- #5r0bgv3t666s4lh274mvtk13jqu1doc26ki2k8t2rpophrq2hjran1qodeobf3trlnniarjehr1rgl6scn6mhqpmcokdafja3b54jt0
+  185. -- #5r0bgv3t666s4lh274mvtk13jqu1doc26ki2k8t2rpophrq2hjran1qodeobf3trlnniarjehr1rgl6scn6mhqpmcokdafja3b54jt0
        builtin.Doc2.Video.sources.set : [MediaSource]
        -> Video
        -> Video
        
-  185. -- #794fndq1941e2khqv5uh7fmk9es2g4fkp8pr48objgs6blc1pqsdt2ab4o79noril2l7s70iu2eimn1smpd8t40j4g18btian8a2pt0#0
+  186. -- #794fndq1941e2khqv5uh7fmk9es2g4fkp8pr48objgs6blc1pqsdt2ab4o79noril2l7s70iu2eimn1smpd8t40j4g18btian8a2pt0#0
        builtin.Doc2.Video.Video : [MediaSource]
        -> [(Text, Text)]
        -> Video
        
-  186. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#19
+  187. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#19
        builtin.Doc2.Word : Text -> Doc2
        
-  187. -- #0o7mf021foma9acqdaibmlh1jidlijq08uf7f5se9tssttqs546pfunjpk6s31mqoq8s2o1natede8hkk6he45l95fibglidikt44v8
+  188. -- #0o7mf021foma9acqdaibmlh1jidlijq08uf7f5se9tssttqs546pfunjpk6s31mqoq8s2o1natede8hkk6he45l95fibglidikt44v8
        structural type builtin.Either a b
        
-  188. -- #0o7mf021foma9acqdaibmlh1jidlijq08uf7f5se9tssttqs546pfunjpk6s31mqoq8s2o1natede8hkk6he45l95fibglidikt44v8#1
+  189. -- #0o7mf021foma9acqdaibmlh1jidlijq08uf7f5se9tssttqs546pfunjpk6s31mqoq8s2o1natede8hkk6he45l95fibglidikt44v8#1
        builtin.Either.Left : a -> Either a b
        
-  189. -- #u3cen22u7p8dfj0nc45j0pg4lskqjjisflm3jq0957756d23lq53tf27vg37g6jnddh8o70grvotcvrfc1fnpog0rlfsvfvjrk1s94g
+  190. -- #u3cen22u7p8dfj0nc45j0pg4lskqjjisflm3jq0957756d23lq53tf27vg37g6jnddh8o70grvotcvrfc1fnpog0rlfsvfvjrk1s94g
        builtin.Either.mapRight : (a ->{g} b)
        -> Either e a
        ->{g} Either e b
        
-  190. -- #0o7mf021foma9acqdaibmlh1jidlijq08uf7f5se9tssttqs546pfunjpk6s31mqoq8s2o1natede8hkk6he45l95fibglidikt44v8#0
+  191. -- #0o7mf021foma9acqdaibmlh1jidlijq08uf7f5se9tssttqs546pfunjpk6s31mqoq8s2o1natede8hkk6he45l95fibglidikt44v8#0
        builtin.Either.Right : b -> Either a b
        
-  191. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng
+  192. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng
        structural ability builtin.Exception
        structural ability Exception
        
-  192. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng#0
+  193. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng#0
        builtin.Exception.raise,
        Exception.raise : Failure
        ->{Exception} x
        
-  193. -- ##Float
+  194. -- ##Float
        builtin type builtin.Float
        
-  194. -- ##Float.*
+  195. -- ##Float.*
        builtin.Float.* : Float -> Float -> Float
        
-  195. -- ##Float.+
+  196. -- ##Float.+
        builtin.Float.+ : Float -> Float -> Float
        
-  196. -- ##Float.-
+  197. -- ##Float.-
        builtin.Float.- : Float -> Float -> Float
        
-  197. -- ##Float./
+  198. -- ##Float./
        builtin.Float./ : Float -> Float -> Float
        
-  198. -- ##Float.abs
+  199. -- ##Float.abs
        builtin.Float.abs : Float -> Float
        
-  199. -- ##Float.acos
+  200. -- ##Float.acos
        builtin.Float.acos : Float -> Float
        
-  200. -- ##Float.acosh
+  201. -- ##Float.acosh
        builtin.Float.acosh : Float -> Float
        
-  201. -- ##Float.asin
+  202. -- ##Float.asin
        builtin.Float.asin : Float -> Float
        
-  202. -- ##Float.asinh
+  203. -- ##Float.asinh
        builtin.Float.asinh : Float -> Float
        
-  203. -- ##Float.atan
+  204. -- ##Float.atan
        builtin.Float.atan : Float -> Float
        
-  204. -- ##Float.atan2
+  205. -- ##Float.atan2
        builtin.Float.atan2 : Float -> Float -> Float
        
-  205. -- ##Float.atanh
+  206. -- ##Float.atanh
        builtin.Float.atanh : Float -> Float
        
-  206. -- ##Float.ceiling
+  207. -- ##Float.ceiling
        builtin.Float.ceiling : Float -> Int
        
-  207. -- ##Float.cos
+  208. -- ##Float.cos
        builtin.Float.cos : Float -> Float
        
-  208. -- ##Float.cosh
+  209. -- ##Float.cosh
        builtin.Float.cosh : Float -> Float
        
-  209. -- ##Float.==
+  210. -- ##Float.==
        builtin.Float.eq : Float -> Float -> Boolean
        
-  210. -- ##Float.exp
+  211. -- ##Float.exp
        builtin.Float.exp : Float -> Float
        
-  211. -- ##Float.floor
+  212. -- ##Float.floor
        builtin.Float.floor : Float -> Int
        
-  212. -- ##Float.fromRepresentation
+  213. -- ##Float.fromRepresentation
        builtin.Float.fromRepresentation : Nat -> Float
        
-  213. -- ##Float.fromText
+  214. -- ##Float.fromText
        builtin.Float.fromText : Text -> Optional Float
        
-  214. -- ##Float.>
+  215. -- ##Float.>
        builtin.Float.gt : Float -> Float -> Boolean
        
-  215. -- ##Float.>=
+  216. -- ##Float.>=
        builtin.Float.gteq : Float -> Float -> Boolean
        
-  216. -- ##Float.log
+  217. -- ##Float.log
        builtin.Float.log : Float -> Float
        
-  217. -- ##Float.logBase
+  218. -- ##Float.logBase
        builtin.Float.logBase : Float -> Float -> Float
        
-  218. -- ##Float.<
+  219. -- ##Float.<
        builtin.Float.lt : Float -> Float -> Boolean
        
-  219. -- ##Float.<=
+  220. -- ##Float.<=
        builtin.Float.lteq : Float -> Float -> Boolean
        
-  220. -- ##Float.max
+  221. -- ##Float.max
        builtin.Float.max : Float -> Float -> Float
        
-  221. -- ##Float.min
+  222. -- ##Float.min
        builtin.Float.min : Float -> Float -> Float
        
-  222. -- ##Float.pow
+  223. -- ##Float.pow
        builtin.Float.pow : Float -> Float -> Float
        
-  223. -- ##Float.round
+  224. -- ##Float.round
        builtin.Float.round : Float -> Int
        
-  224. -- ##Float.sin
+  225. -- ##Float.sin
        builtin.Float.sin : Float -> Float
        
-  225. -- ##Float.sinh
+  226. -- ##Float.sinh
        builtin.Float.sinh : Float -> Float
        
-  226. -- ##Float.sqrt
+  227. -- ##Float.sqrt
        builtin.Float.sqrt : Float -> Float
        
-  227. -- ##Float.tan
+  228. -- ##Float.tan
        builtin.Float.tan : Float -> Float
        
-  228. -- ##Float.tanh
+  229. -- ##Float.tanh
        builtin.Float.tanh : Float -> Float
        
-  229. -- ##Float.toRepresentation
+  230. -- ##Float.toRepresentation
        builtin.Float.toRepresentation : Float -> Nat
        
-  230. -- ##Float.toText
+  231. -- ##Float.toText
        builtin.Float.toText : Float -> Text
        
-  231. -- ##Float.truncate
+  232. -- ##Float.truncate
        builtin.Float.truncate : Float -> Int
        
-  232. -- #hqectlr3gt02r6r984b3627eg5bq3d82lab5q18e3ql09u1ka8dblf5k50ae0q0d8gk87udqd7b6767q86gogdt8ghpdiq77gk6blr8
+  233. -- #hqectlr3gt02r6r984b3627eg5bq3d82lab5q18e3ql09u1ka8dblf5k50ae0q0d8gk87udqd7b6767q86gogdt8ghpdiq77gk6blr8
        unique type builtin.GUID
        
-  233. -- #hqectlr3gt02r6r984b3627eg5bq3d82lab5q18e3ql09u1ka8dblf5k50ae0q0d8gk87udqd7b6767q86gogdt8ghpdiq77gk6blr8#0
+  234. -- #hqectlr3gt02r6r984b3627eg5bq3d82lab5q18e3ql09u1ka8dblf5k50ae0q0d8gk87udqd7b6767q86gogdt8ghpdiq77gk6blr8#0
        builtin.GUID.GUID : Bytes -> GUID
        
-  234. -- ##Handle.toText
+  235. -- ##Handle.toText
        builtin.Handle.toText : Handle -> Text
        
-  235. -- ##ImmutableArray
+  236. -- ##ImmutableArray
        builtin type builtin.ImmutableArray
        
-  236. -- ##ImmutableArray.copyTo!
+  237. -- ##ImmutableArray.copyTo!
        builtin.ImmutableArray.copyTo! : MutableArray g a
        -> Nat
        -> ImmutableArray a
@@ -803,18 +806,18 @@ This transcript is intended to make visible accidental changes to the hashing al
        -> Nat
        ->{g, Exception} ()
        
-  237. -- ##ImmutableArray.read
+  238. -- ##ImmutableArray.read
        builtin.ImmutableArray.read : ImmutableArray a
        -> Nat
        ->{Exception} a
        
-  238. -- ##ImmutableArray.size
+  239. -- ##ImmutableArray.size
        builtin.ImmutableArray.size : ImmutableArray a -> Nat
        
-  239. -- ##ImmutableByteArray
+  240. -- ##ImmutableByteArray
        builtin type builtin.ImmutableByteArray
        
-  240. -- ##ImmutableByteArray.copyTo!
+  241. -- ##ImmutableByteArray.copyTo!
        builtin.ImmutableByteArray.copyTo! : MutableByteArray g
        -> Nat
        -> ImmutableByteArray
@@ -822,843 +825,843 @@ This transcript is intended to make visible accidental changes to the hashing al
        -> Nat
        ->{g, Exception} ()
        
-  241. -- ##ImmutableByteArray.read16be
+  242. -- ##ImmutableByteArray.read16be
        builtin.ImmutableByteArray.read16be : ImmutableByteArray
        -> Nat
        ->{Exception} Nat
        
-  242. -- ##ImmutableByteArray.read24be
+  243. -- ##ImmutableByteArray.read24be
        builtin.ImmutableByteArray.read24be : ImmutableByteArray
        -> Nat
        ->{Exception} Nat
        
-  243. -- ##ImmutableByteArray.read32be
+  244. -- ##ImmutableByteArray.read32be
        builtin.ImmutableByteArray.read32be : ImmutableByteArray
        -> Nat
        ->{Exception} Nat
        
-  244. -- ##ImmutableByteArray.read40be
+  245. -- ##ImmutableByteArray.read40be
        builtin.ImmutableByteArray.read40be : ImmutableByteArray
        -> Nat
        ->{Exception} Nat
        
-  245. -- ##ImmutableByteArray.read64be
+  246. -- ##ImmutableByteArray.read64be
        builtin.ImmutableByteArray.read64be : ImmutableByteArray
        -> Nat
        ->{Exception} Nat
        
-  246. -- ##ImmutableByteArray.read8
+  247. -- ##ImmutableByteArray.read8
        builtin.ImmutableByteArray.read8 : ImmutableByteArray
        -> Nat
        ->{Exception} Nat
        
-  247. -- ##ImmutableByteArray.size
+  248. -- ##ImmutableByteArray.size
        builtin.ImmutableByteArray.size : ImmutableByteArray
        -> Nat
        
-  248. -- ##Int
+  249. -- ##Int
        builtin type builtin.Int
        
-  249. -- ##Int.*
+  250. -- ##Int.*
        builtin.Int.* : Int -> Int -> Int
        
-  250. -- ##Int.+
+  251. -- ##Int.+
        builtin.Int.+ : Int -> Int -> Int
        
-  251. -- ##Int.-
+  252. -- ##Int.-
        builtin.Int.- : Int -> Int -> Int
        
-  252. -- ##Int./
+  253. -- ##Int./
        builtin.Int./ : Int -> Int -> Int
        
-  253. -- ##Int.and
+  254. -- ##Int.and
        builtin.Int.and : Int -> Int -> Int
        
-  254. -- ##Int.complement
+  255. -- ##Int.complement
        builtin.Int.complement : Int -> Int
        
-  255. -- ##Int.==
+  256. -- ##Int.==
        builtin.Int.eq : Int -> Int -> Boolean
        
-  256. -- ##Int.fromRepresentation
+  257. -- ##Int.fromRepresentation
        builtin.Int.fromRepresentation : Nat -> Int
        
-  257. -- ##Int.fromText
+  258. -- ##Int.fromText
        builtin.Int.fromText : Text -> Optional Int
        
-  258. -- ##Int.>
+  259. -- ##Int.>
        builtin.Int.gt : Int -> Int -> Boolean
        
-  259. -- ##Int.>=
+  260. -- ##Int.>=
        builtin.Int.gteq : Int -> Int -> Boolean
        
-  260. -- ##Int.increment
+  261. -- ##Int.increment
        builtin.Int.increment : Int -> Int
        
-  261. -- ##Int.isEven
+  262. -- ##Int.isEven
        builtin.Int.isEven : Int -> Boolean
        
-  262. -- ##Int.isOdd
+  263. -- ##Int.isOdd
        builtin.Int.isOdd : Int -> Boolean
        
-  263. -- ##Int.leadingZeros
+  264. -- ##Int.leadingZeros
        builtin.Int.leadingZeros : Int -> Nat
        
-  264. -- ##Int.<
+  265. -- ##Int.<
        builtin.Int.lt : Int -> Int -> Boolean
        
-  265. -- ##Int.<=
+  266. -- ##Int.<=
        builtin.Int.lteq : Int -> Int -> Boolean
        
-  266. -- ##Int.mod
+  267. -- ##Int.mod
        builtin.Int.mod : Int -> Int -> Int
        
-  267. -- ##Int.negate
+  268. -- ##Int.negate
        builtin.Int.negate : Int -> Int
        
-  268. -- ##Int.or
+  269. -- ##Int.or
        builtin.Int.or : Int -> Int -> Int
        
-  269. -- ##Int.popCount
+  270. -- ##Int.popCount
        builtin.Int.popCount : Int -> Nat
        
-  270. -- ##Int.pow
+  271. -- ##Int.pow
        builtin.Int.pow : Int -> Nat -> Int
        
-  271. -- ##Int.shiftLeft
+  272. -- ##Int.shiftLeft
        builtin.Int.shiftLeft : Int -> Nat -> Int
        
-  272. -- ##Int.shiftRight
+  273. -- ##Int.shiftRight
        builtin.Int.shiftRight : Int -> Nat -> Int
        
-  273. -- ##Int.signum
+  274. -- ##Int.signum
        builtin.Int.signum : Int -> Int
        
-  274. -- ##Int.toFloat
+  275. -- ##Int.toFloat
        builtin.Int.toFloat : Int -> Float
        
-  275. -- ##Int.toRepresentation
+  276. -- ##Int.toRepresentation
        builtin.Int.toRepresentation : Int -> Nat
        
-  276. -- ##Int.toText
+  277. -- ##Int.toText
        builtin.Int.toText : Int -> Text
        
-  277. -- ##Int.trailingZeros
+  278. -- ##Int.trailingZeros
        builtin.Int.trailingZeros : Int -> Nat
        
-  278. -- ##Int.truncate0
+  279. -- ##Int.truncate0
        builtin.Int.truncate0 : Int -> Nat
        
-  279. -- ##Int.xor
+  280. -- ##Int.xor
        builtin.Int.xor : Int -> Int -> Int
        
-  280. -- #s6ijmhqkkaus51chjgahogc7sdrqj9t66i599le2k7ts6fkl216f997hbses3mqk6a21vaj3cm1mertbldn0g503jt522vfo4rfv720
+  281. -- #s6ijmhqkkaus51chjgahogc7sdrqj9t66i599le2k7ts6fkl216f997hbses3mqk6a21vaj3cm1mertbldn0g503jt522vfo4rfv720
        unique type builtin.io2.ArithmeticFailure
        
-  281. -- #6dtvam7msqc64dimm8p0d8ehdf0330o4qbd2fdafb11jj1c2rg4ke3jdcmbgo6s4pf2jgm0vb76jeavv4ba6ht71t74p963a1miekag
+  282. -- #6dtvam7msqc64dimm8p0d8ehdf0330o4qbd2fdafb11jj1c2rg4ke3jdcmbgo6s4pf2jgm0vb76jeavv4ba6ht71t74p963a1miekag
        unique type builtin.io2.ArrayFailure
        
-  282. -- #dc6n5ebu839ik3b6ohmnqm6p0cifn7o94em1g41mjp4ae0gmv3b4rupba499lbasfrp4bqce9u4hd6518unlbg8vk993c0q6rigos98
+  283. -- #dc6n5ebu839ik3b6ohmnqm6p0cifn7o94em1g41mjp4ae0gmv3b4rupba499lbasfrp4bqce9u4hd6518unlbg8vk993c0q6rigos98
        unique type builtin.io2.BufferMode
        
-  283. -- #dc6n5ebu839ik3b6ohmnqm6p0cifn7o94em1g41mjp4ae0gmv3b4rupba499lbasfrp4bqce9u4hd6518unlbg8vk993c0q6rigos98#2
+  284. -- #dc6n5ebu839ik3b6ohmnqm6p0cifn7o94em1g41mjp4ae0gmv3b4rupba499lbasfrp4bqce9u4hd6518unlbg8vk993c0q6rigos98#2
        builtin.io2.BufferMode.BlockBuffering : BufferMode
        
-  284. -- #dc6n5ebu839ik3b6ohmnqm6p0cifn7o94em1g41mjp4ae0gmv3b4rupba499lbasfrp4bqce9u4hd6518unlbg8vk993c0q6rigos98#1
+  285. -- #dc6n5ebu839ik3b6ohmnqm6p0cifn7o94em1g41mjp4ae0gmv3b4rupba499lbasfrp4bqce9u4hd6518unlbg8vk993c0q6rigos98#1
        builtin.io2.BufferMode.LineBuffering : BufferMode
        
-  285. -- #dc6n5ebu839ik3b6ohmnqm6p0cifn7o94em1g41mjp4ae0gmv3b4rupba499lbasfrp4bqce9u4hd6518unlbg8vk993c0q6rigos98#0
+  286. -- #dc6n5ebu839ik3b6ohmnqm6p0cifn7o94em1g41mjp4ae0gmv3b4rupba499lbasfrp4bqce9u4hd6518unlbg8vk993c0q6rigos98#0
        builtin.io2.BufferMode.NoBuffering : BufferMode
        
-  286. -- #dc6n5ebu839ik3b6ohmnqm6p0cifn7o94em1g41mjp4ae0gmv3b4rupba499lbasfrp4bqce9u4hd6518unlbg8vk993c0q6rigos98#3
+  287. -- #dc6n5ebu839ik3b6ohmnqm6p0cifn7o94em1g41mjp4ae0gmv3b4rupba499lbasfrp4bqce9u4hd6518unlbg8vk993c0q6rigos98#3
        builtin.io2.BufferMode.SizedBlockBuffering : Nat
        -> BufferMode
        
-  287. -- ##Clock.internals.monotonic.v1
+  288. -- ##Clock.internals.monotonic.v1
        builtin.io2.Clock.internals.monotonic : '{IO} Either
          Failure TimeSpec
        
-  288. -- ##Clock.internals.nsec.v1
+  289. -- ##Clock.internals.nsec.v1
        builtin.io2.Clock.internals.nsec : TimeSpec -> Nat
        
-  289. -- ##Clock.internals.processCPUTime.v1
+  290. -- ##Clock.internals.processCPUTime.v1
        builtin.io2.Clock.internals.processCPUTime : '{IO} Either
          Failure TimeSpec
        
-  290. -- ##Clock.internals.realtime.v1
+  291. -- ##Clock.internals.realtime.v1
        builtin.io2.Clock.internals.realtime : '{IO} Either
          Failure TimeSpec
        
-  291. -- ##Clock.internals.sec.v1
+  292. -- ##Clock.internals.sec.v1
        builtin.io2.Clock.internals.sec : TimeSpec -> Int
        
-  292. -- ##Clock.internals.threadCPUTime.v1
+  293. -- ##Clock.internals.threadCPUTime.v1
        builtin.io2.Clock.internals.threadCPUTime : '{IO} Either
          Failure TimeSpec
        
-  293. -- ##TimeSpec
+  294. -- ##TimeSpec
        builtin type builtin.io2.Clock.internals.TimeSpec
        
-  294. -- #r29dja8j9dmjjp45trccchaata8eo1h6d6haar1eai74pq1jt4m7u3ldhlq79f7phfo57eq4bau39vqotl2h63k7ff1m5sj5o9ajuf8
+  295. -- #r29dja8j9dmjjp45trccchaata8eo1h6d6haar1eai74pq1jt4m7u3ldhlq79f7phfo57eq4bau39vqotl2h63k7ff1m5sj5o9ajuf8
        unique type builtin.io2.Failure
        
-  295. -- #r29dja8j9dmjjp45trccchaata8eo1h6d6haar1eai74pq1jt4m7u3ldhlq79f7phfo57eq4bau39vqotl2h63k7ff1m5sj5o9ajuf8#0
+  296. -- #r29dja8j9dmjjp45trccchaata8eo1h6d6haar1eai74pq1jt4m7u3ldhlq79f7phfo57eq4bau39vqotl2h63k7ff1m5sj5o9ajuf8#0
        builtin.io2.Failure.Failure : Type
        -> Text
        -> Any
        -> Failure
        
-  296. -- #jhnlob35huv3rr7jg6aa4gtd8okhprla7gvlq8io429qita8vj7k696n9jvp4b8ct9i2pc1jodb8ap2bipqtgp138epdgfcth7vqvt8
+  297. -- #jhnlob35huv3rr7jg6aa4gtd8okhprla7gvlq8io429qita8vj7k696n9jvp4b8ct9i2pc1jodb8ap2bipqtgp138epdgfcth7vqvt8
        unique type builtin.io2.FileMode
        
-  297. -- #jhnlob35huv3rr7jg6aa4gtd8okhprla7gvlq8io429qita8vj7k696n9jvp4b8ct9i2pc1jodb8ap2bipqtgp138epdgfcth7vqvt8#2
+  298. -- #jhnlob35huv3rr7jg6aa4gtd8okhprla7gvlq8io429qita8vj7k696n9jvp4b8ct9i2pc1jodb8ap2bipqtgp138epdgfcth7vqvt8#2
        builtin.io2.FileMode.Append : FileMode
        
-  298. -- #jhnlob35huv3rr7jg6aa4gtd8okhprla7gvlq8io429qita8vj7k696n9jvp4b8ct9i2pc1jodb8ap2bipqtgp138epdgfcth7vqvt8#0
+  299. -- #jhnlob35huv3rr7jg6aa4gtd8okhprla7gvlq8io429qita8vj7k696n9jvp4b8ct9i2pc1jodb8ap2bipqtgp138epdgfcth7vqvt8#0
        builtin.io2.FileMode.Read : FileMode
        
-  299. -- #jhnlob35huv3rr7jg6aa4gtd8okhprla7gvlq8io429qita8vj7k696n9jvp4b8ct9i2pc1jodb8ap2bipqtgp138epdgfcth7vqvt8#3
+  300. -- #jhnlob35huv3rr7jg6aa4gtd8okhprla7gvlq8io429qita8vj7k696n9jvp4b8ct9i2pc1jodb8ap2bipqtgp138epdgfcth7vqvt8#3
        builtin.io2.FileMode.ReadWrite : FileMode
        
-  300. -- #jhnlob35huv3rr7jg6aa4gtd8okhprla7gvlq8io429qita8vj7k696n9jvp4b8ct9i2pc1jodb8ap2bipqtgp138epdgfcth7vqvt8#1
+  301. -- #jhnlob35huv3rr7jg6aa4gtd8okhprla7gvlq8io429qita8vj7k696n9jvp4b8ct9i2pc1jodb8ap2bipqtgp138epdgfcth7vqvt8#1
        builtin.io2.FileMode.Write : FileMode
        
-  301. -- ##Handle
+  302. -- ##Handle
        builtin type builtin.io2.Handle
        
-  302. -- ##IO
+  303. -- ##IO
        builtin type builtin.io2.IO
        
-  303. -- ##IO.array
+  304. -- ##IO.array
        builtin.io2.IO.array : Nat ->{IO} MutableArray {IO} a
        
-  304. -- ##IO.arrayOf
+  305. -- ##IO.arrayOf
        builtin.io2.IO.arrayOf : a
        -> Nat
        ->{IO} MutableArray {IO} a
        
-  305. -- ##IO.bytearray
+  306. -- ##IO.bytearray
        builtin.io2.IO.bytearray : Nat
        ->{IO} MutableByteArray {IO}
        
-  306. -- ##IO.bytearrayOf
+  307. -- ##IO.bytearrayOf
        builtin.io2.IO.bytearrayOf : Nat
        -> Nat
        ->{IO} MutableByteArray {IO}
        
-  307. -- ##IO.clientSocket.impl.v3
+  308. -- ##IO.clientSocket.impl.v3
        builtin.io2.IO.clientSocket.impl : Text
        -> Text
        ->{IO} Either Failure Socket
        
-  308. -- ##IO.closeFile.impl.v3
+  309. -- ##IO.closeFile.impl.v3
        builtin.io2.IO.closeFile.impl : Handle
        ->{IO} Either Failure ()
        
-  309. -- ##IO.closeSocket.impl.v3
+  310. -- ##IO.closeSocket.impl.v3
        builtin.io2.IO.closeSocket.impl : Socket
        ->{IO} Either Failure ()
        
-  310. -- ##IO.createDirectory.impl.v3
+  311. -- ##IO.createDirectory.impl.v3
        builtin.io2.IO.createDirectory.impl : Text
        ->{IO} Either Failure ()
        
-  311. -- ##IO.createTempDirectory.impl.v3
+  312. -- ##IO.createTempDirectory.impl.v3
        builtin.io2.IO.createTempDirectory.impl : Text
        ->{IO} Either Failure Text
        
-  312. -- ##IO.delay.impl.v3
+  313. -- ##IO.delay.impl.v3
        builtin.io2.IO.delay.impl : Nat ->{IO} Either Failure ()
        
-  313. -- ##IO.directoryContents.impl.v3
+  314. -- ##IO.directoryContents.impl.v3
        builtin.io2.IO.directoryContents.impl : Text
        ->{IO} Either Failure [Text]
        
-  314. -- ##IO.fileExists.impl.v3
+  315. -- ##IO.fileExists.impl.v3
        builtin.io2.IO.fileExists.impl : Text
        ->{IO} Either Failure Boolean
        
-  315. -- ##IO.forkComp.v2
+  316. -- ##IO.forkComp.v2
        builtin.io2.IO.forkComp : '{IO} a ->{IO} ThreadId
        
-  316. -- ##IO.getArgs.impl.v1
+  317. -- ##IO.getArgs.impl.v1
        builtin.io2.IO.getArgs.impl : '{IO} Either Failure [Text]
        
-  317. -- ##IO.getBuffering.impl.v3
+  318. -- ##IO.getBuffering.impl.v3
        builtin.io2.IO.getBuffering.impl : Handle
        ->{IO} Either Failure BufferMode
        
-  318. -- ##IO.getBytes.impl.v3
+  319. -- ##IO.getBytes.impl.v3
        builtin.io2.IO.getBytes.impl : Handle
        -> Nat
        ->{IO} Either Failure Bytes
        
-  319. -- ##IO.getChar.impl.v1
+  320. -- ##IO.getChar.impl.v1
        builtin.io2.IO.getChar.impl : Handle
        ->{IO} Either Failure Char
        
-  320. -- ##IO.getCurrentDirectory.impl.v3
+  321. -- ##IO.getCurrentDirectory.impl.v3
        builtin.io2.IO.getCurrentDirectory.impl : '{IO} Either
          Failure Text
        
-  321. -- ##IO.getEcho.impl.v1
+  322. -- ##IO.getEcho.impl.v1
        builtin.io2.IO.getEcho.impl : Handle
        ->{IO} Either Failure Boolean
        
-  322. -- ##IO.getEnv.impl.v1
+  323. -- ##IO.getEnv.impl.v1
        builtin.io2.IO.getEnv.impl : Text
        ->{IO} Either Failure Text
        
-  323. -- ##IO.getFileSize.impl.v3
+  324. -- ##IO.getFileSize.impl.v3
        builtin.io2.IO.getFileSize.impl : Text
        ->{IO} Either Failure Nat
        
-  324. -- ##IO.getFileTimestamp.impl.v3
+  325. -- ##IO.getFileTimestamp.impl.v3
        builtin.io2.IO.getFileTimestamp.impl : Text
        ->{IO} Either Failure Nat
        
-  325. -- ##IO.getLine.impl.v1
+  326. -- ##IO.getLine.impl.v1
        builtin.io2.IO.getLine.impl : Handle
        ->{IO} Either Failure Text
        
-  326. -- ##IO.getSomeBytes.impl.v1
+  327. -- ##IO.getSomeBytes.impl.v1
        builtin.io2.IO.getSomeBytes.impl : Handle
        -> Nat
        ->{IO} Either Failure Bytes
        
-  327. -- ##IO.getTempDirectory.impl.v3
+  328. -- ##IO.getTempDirectory.impl.v3
        builtin.io2.IO.getTempDirectory.impl : '{IO} Either
          Failure Text
        
-  328. -- ##IO.handlePosition.impl.v3
+  329. -- ##IO.handlePosition.impl.v3
        builtin.io2.IO.handlePosition.impl : Handle
        ->{IO} Either Failure Nat
        
-  329. -- ##IO.isDirectory.impl.v3
+  330. -- ##IO.isDirectory.impl.v3
        builtin.io2.IO.isDirectory.impl : Text
        ->{IO} Either Failure Boolean
        
-  330. -- ##IO.isFileEOF.impl.v3
+  331. -- ##IO.isFileEOF.impl.v3
        builtin.io2.IO.isFileEOF.impl : Handle
        ->{IO} Either Failure Boolean
        
-  331. -- ##IO.isFileOpen.impl.v3
+  332. -- ##IO.isFileOpen.impl.v3
        builtin.io2.IO.isFileOpen.impl : Handle
        ->{IO} Either Failure Boolean
        
-  332. -- ##IO.isSeekable.impl.v3
+  333. -- ##IO.isSeekable.impl.v3
        builtin.io2.IO.isSeekable.impl : Handle
        ->{IO} Either Failure Boolean
        
-  333. -- ##IO.kill.impl.v3
+  334. -- ##IO.kill.impl.v3
        builtin.io2.IO.kill.impl : ThreadId
        ->{IO} Either Failure ()
        
-  334. -- ##IO.listen.impl.v3
+  335. -- ##IO.listen.impl.v3
        builtin.io2.IO.listen.impl : Socket
        ->{IO} Either Failure ()
        
-  335. -- ##IO.openFile.impl.v3
+  336. -- ##IO.openFile.impl.v3
        builtin.io2.IO.openFile.impl : Text
        -> FileMode
        ->{IO} Either Failure Handle
        
-  336. -- ##IO.putBytes.impl.v3
+  337. -- ##IO.putBytes.impl.v3
        builtin.io2.IO.putBytes.impl : Handle
        -> Bytes
        ->{IO} Either Failure ()
        
-  337. -- ##IO.ready.impl.v1
+  338. -- ##IO.ready.impl.v1
        builtin.io2.IO.ready.impl : Handle
        ->{IO} Either Failure Boolean
        
-  338. -- ##IO.ref
+  339. -- ##IO.ref
        builtin.io2.IO.ref : a ->{IO} Ref {IO} a
        
-  339. -- ##IO.removeDirectory.impl.v3
+  340. -- ##IO.removeDirectory.impl.v3
        builtin.io2.IO.removeDirectory.impl : Text
        ->{IO} Either Failure ()
        
-  340. -- ##IO.removeFile.impl.v3
+  341. -- ##IO.removeFile.impl.v3
        builtin.io2.IO.removeFile.impl : Text
        ->{IO} Either Failure ()
        
-  341. -- ##IO.renameDirectory.impl.v3
+  342. -- ##IO.renameDirectory.impl.v3
        builtin.io2.IO.renameDirectory.impl : Text
        -> Text
        ->{IO} Either Failure ()
        
-  342. -- ##IO.renameFile.impl.v3
+  343. -- ##IO.renameFile.impl.v3
        builtin.io2.IO.renameFile.impl : Text
        -> Text
        ->{IO} Either Failure ()
        
-  343. -- ##IO.seekHandle.impl.v3
+  344. -- ##IO.seekHandle.impl.v3
        builtin.io2.IO.seekHandle.impl : Handle
        -> SeekMode
        -> Int
        ->{IO} Either Failure ()
        
-  344. -- ##IO.serverSocket.impl.v3
+  345. -- ##IO.serverSocket.impl.v3
        builtin.io2.IO.serverSocket.impl : Optional Text
        -> Text
        ->{IO} Either Failure Socket
        
-  345. -- ##IO.setBuffering.impl.v3
+  346. -- ##IO.setBuffering.impl.v3
        builtin.io2.IO.setBuffering.impl : Handle
        -> BufferMode
        ->{IO} Either Failure ()
        
-  346. -- ##IO.setCurrentDirectory.impl.v3
+  347. -- ##IO.setCurrentDirectory.impl.v3
        builtin.io2.IO.setCurrentDirectory.impl : Text
        ->{IO} Either Failure ()
        
-  347. -- ##IO.setEcho.impl.v1
+  348. -- ##IO.setEcho.impl.v1
        builtin.io2.IO.setEcho.impl : Handle
        -> Boolean
        ->{IO} Either Failure ()
        
-  348. -- ##IO.socketAccept.impl.v3
+  349. -- ##IO.socketAccept.impl.v3
        builtin.io2.IO.socketAccept.impl : Socket
        ->{IO} Either Failure Socket
        
-  349. -- ##IO.socketPort.impl.v3
+  350. -- ##IO.socketPort.impl.v3
        builtin.io2.IO.socketPort.impl : Socket
        ->{IO} Either Failure Nat
        
-  350. -- ##IO.socketReceive.impl.v3
+  351. -- ##IO.socketReceive.impl.v3
        builtin.io2.IO.socketReceive.impl : Socket
        -> Nat
        ->{IO} Either Failure Bytes
        
-  351. -- ##IO.socketSend.impl.v3
+  352. -- ##IO.socketSend.impl.v3
        builtin.io2.IO.socketSend.impl : Socket
        -> Bytes
        ->{IO} Either Failure ()
        
-  352. -- ##IO.stdHandle
+  353. -- ##IO.stdHandle
        builtin.io2.IO.stdHandle : StdHandle -> Handle
        
-  353. -- ##IO.systemTime.impl.v3
+  354. -- ##IO.systemTime.impl.v3
        builtin.io2.IO.systemTime.impl : '{IO} Either Failure Nat
        
-  354. -- ##IO.systemTimeMicroseconds.v1
+  355. -- ##IO.systemTimeMicroseconds.v1
        builtin.io2.IO.systemTimeMicroseconds : '{IO} Int
        
-  355. -- ##IO.tryEval
+  356. -- ##IO.tryEval
        builtin.io2.IO.tryEval : '{IO} a ->{IO, Exception} a
        
-  356. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0
+  357. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0
        unique type builtin.io2.IOError
        
-  357. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#0
+  358. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#0
        builtin.io2.IOError.AlreadyExists : IOError
        
-  358. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#4
+  359. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#4
        builtin.io2.IOError.EOF : IOError
        
-  359. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#5
+  360. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#5
        builtin.io2.IOError.IllegalOperation : IOError
        
-  360. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#1
+  361. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#1
        builtin.io2.IOError.NoSuchThing : IOError
        
-  361. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#6
+  362. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#6
        builtin.io2.IOError.PermissionDenied : IOError
        
-  362. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#2
+  363. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#2
        builtin.io2.IOError.ResourceBusy : IOError
        
-  363. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#3
+  364. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#3
        builtin.io2.IOError.ResourceExhausted : IOError
        
-  364. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#7
+  365. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#7
        builtin.io2.IOError.UserError : IOError
        
-  365. -- #6ivk1e38hh0l9gcl8fn4mhf8bmak3qaji36vevg5e1n16ju5i4cl9u5gmqi7u16b907rd98gd60pouma892efbqt2ri58tmu99hp77g
+  366. -- #6ivk1e38hh0l9gcl8fn4mhf8bmak3qaji36vevg5e1n16ju5i4cl9u5gmqi7u16b907rd98gd60pouma892efbqt2ri58tmu99hp77g
        unique type builtin.io2.IOFailure
        
-  366. -- #574pvphqahl981k517dtrqtq812m05h3hj6t2bt9sn3pknenfik1krscfdb6r66nf1sm7g3r1r56k0c6ob7vg4opfq4gihi8njbnhsg
+  367. -- #574pvphqahl981k517dtrqtq812m05h3hj6t2bt9sn3pknenfik1krscfdb6r66nf1sm7g3r1r56k0c6ob7vg4opfq4gihi8njbnhsg
        unique type builtin.io2.MiscFailure
        
-  367. -- ##MVar
+  368. -- ##MVar
        builtin type builtin.io2.MVar
        
-  368. -- ##MVar.isEmpty
+  369. -- ##MVar.isEmpty
        builtin.io2.MVar.isEmpty : MVar a ->{IO} Boolean
        
-  369. -- ##MVar.new
+  370. -- ##MVar.new
        builtin.io2.MVar.new : a ->{IO} MVar a
        
-  370. -- ##MVar.newEmpty.v2
+  371. -- ##MVar.newEmpty.v2
        builtin.io2.MVar.newEmpty : '{IO} MVar a
        
-  371. -- ##MVar.put.impl.v3
+  372. -- ##MVar.put.impl.v3
        builtin.io2.MVar.put.impl : MVar a
        -> a
        ->{IO} Either Failure ()
        
-  372. -- ##MVar.read.impl.v3
+  373. -- ##MVar.read.impl.v3
        builtin.io2.MVar.read.impl : MVar a
        ->{IO} Either Failure a
        
-  373. -- ##MVar.swap.impl.v3
+  374. -- ##MVar.swap.impl.v3
        builtin.io2.MVar.swap.impl : MVar a
        -> a
        ->{IO} Either Failure a
        
-  374. -- ##MVar.take.impl.v3
+  375. -- ##MVar.take.impl.v3
        builtin.io2.MVar.take.impl : MVar a
        ->{IO} Either Failure a
        
-  375. -- ##MVar.tryPut.impl.v3
+  376. -- ##MVar.tryPut.impl.v3
        builtin.io2.MVar.tryPut.impl : MVar a
        -> a
        ->{IO} Either Failure Boolean
        
-  376. -- ##MVar.tryRead.impl.v3
+  377. -- ##MVar.tryRead.impl.v3
        builtin.io2.MVar.tryRead.impl : MVar a
        ->{IO} Either Failure (Optional a)
        
-  377. -- ##MVar.tryTake
+  378. -- ##MVar.tryTake
        builtin.io2.MVar.tryTake : MVar a ->{IO} Optional a
        
-  378. -- ##Promise
+  379. -- ##Promise
        builtin type builtin.io2.Promise
        
-  379. -- ##Promise.new
+  380. -- ##Promise.new
        builtin.io2.Promise.new : '{IO} Promise a
        
-  380. -- ##Promise.read
+  381. -- ##Promise.read
        builtin.io2.Promise.read : Promise a ->{IO} a
        
-  381. -- ##Promise.tryRead
+  382. -- ##Promise.tryRead
        builtin.io2.Promise.tryRead : Promise a ->{IO} Optional a
        
-  382. -- ##Promise.write
+  383. -- ##Promise.write
        builtin.io2.Promise.write : Promise a -> a ->{IO} Boolean
        
-  383. -- ##Ref.cas
+  384. -- ##Ref.cas
        builtin.io2.Ref.cas : Ref {IO} a
        -> Ticket a
        -> a
        ->{IO} Boolean
        
-  384. -- ##Ref.readForCas
+  385. -- ##Ref.readForCas
        builtin.io2.Ref.readForCas : Ref {IO} a ->{IO} Ticket a
        
-  385. -- ##Ref.Ticket
+  386. -- ##Ref.Ticket
        builtin type builtin.io2.Ref.Ticket
        
-  386. -- ##Ref.Ticket.read
+  387. -- ##Ref.Ticket.read
        builtin.io2.Ref.Ticket.read : Ticket a -> a
        
-  387. -- #vph2eas3lf2gi259f3khlrspml3id2l8u0ru07kb5fd833h238jk4iauju0b6decth9i3nao5jkf5eej1e1kovgmu5tghhh8jq3i7p8
+  388. -- #vph2eas3lf2gi259f3khlrspml3id2l8u0ru07kb5fd833h238jk4iauju0b6decth9i3nao5jkf5eej1e1kovgmu5tghhh8jq3i7p8
        unique type builtin.io2.RuntimeFailure
        
-  388. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40
+  389. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40
        unique type builtin.io2.SeekMode
        
-  389. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40#0
+  390. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40#0
        builtin.io2.SeekMode.AbsoluteSeek : SeekMode
        
-  390. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40#1
+  391. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40#1
        builtin.io2.SeekMode.RelativeSeek : SeekMode
        
-  391. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40#2
+  392. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40#2
        builtin.io2.SeekMode.SeekFromEnd : SeekMode
        
-  392. -- ##Socket
+  393. -- ##Socket
        builtin type builtin.io2.Socket
        
-  393. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8
+  394. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8
        unique type builtin.io2.StdHandle
        
-  394. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8#2
+  395. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8#2
        builtin.io2.StdHandle.StdErr : StdHandle
        
-  395. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8#0
+  396. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8#0
        builtin.io2.StdHandle.StdIn : StdHandle
        
-  396. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8#1
+  397. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8#1
        builtin.io2.StdHandle.StdOut : StdHandle
        
-  397. -- ##STM
+  398. -- ##STM
        builtin type builtin.io2.STM
        
-  398. -- ##STM.atomically
+  399. -- ##STM.atomically
        builtin.io2.STM.atomically : '{STM} a ->{IO} a
        
-  399. -- ##STM.retry
+  400. -- ##STM.retry
        builtin.io2.STM.retry : '{STM} a
        
-  400. -- #cggbdfff21ac5uedf4qvn4to83clinvhsovrila35u7f7e73g4l6hoj8pjmjnk713a8luhnn4bi1j9ai1nl0can1un66hvg230eog9g
+  401. -- #cggbdfff21ac5uedf4qvn4to83clinvhsovrila35u7f7e73g4l6hoj8pjmjnk713a8luhnn4bi1j9ai1nl0can1un66hvg230eog9g
        unique type builtin.io2.STMFailure
        
-  401. -- ##ThreadId
+  402. -- ##ThreadId
        builtin type builtin.io2.ThreadId
        
-  402. -- ##Tls
+  403. -- ##Tls
        builtin type builtin.io2.Tls
        
-  403. -- ##Tls.Cipher
+  404. -- ##Tls.Cipher
        builtin type builtin.io2.Tls.Cipher
        
-  404. -- ##Tls.ClientConfig
+  405. -- ##Tls.ClientConfig
        builtin type builtin.io2.Tls.ClientConfig
        
-  405. -- ##Tls.ClientConfig.certificates.set
+  406. -- ##Tls.ClientConfig.certificates.set
        builtin.io2.Tls.ClientConfig.certificates.set : [SignedCert]
        -> ClientConfig
        -> ClientConfig
        
-  406. -- ##TLS.ClientConfig.ciphers.set
+  407. -- ##TLS.ClientConfig.ciphers.set
        builtin.io2.TLS.ClientConfig.ciphers.set : [Cipher]
        -> ClientConfig
        -> ClientConfig
        
-  407. -- ##Tls.ClientConfig.default
+  408. -- ##Tls.ClientConfig.default
        builtin.io2.Tls.ClientConfig.default : Text
        -> Bytes
        -> ClientConfig
        
-  408. -- ##Tls.ClientConfig.versions.set
+  409. -- ##Tls.ClientConfig.versions.set
        builtin.io2.Tls.ClientConfig.versions.set : [Version]
        -> ClientConfig
        -> ClientConfig
        
-  409. -- ##Tls.decodeCert.impl.v3
+  410. -- ##Tls.decodeCert.impl.v3
        builtin.io2.Tls.decodeCert.impl : Bytes
        -> Either Failure SignedCert
        
-  410. -- ##Tls.decodePrivateKey
+  411. -- ##Tls.decodePrivateKey
        builtin.io2.Tls.decodePrivateKey : Bytes -> [PrivateKey]
        
-  411. -- ##Tls.encodeCert
+  412. -- ##Tls.encodeCert
        builtin.io2.Tls.encodeCert : SignedCert -> Bytes
        
-  412. -- ##Tls.encodePrivateKey
+  413. -- ##Tls.encodePrivateKey
        builtin.io2.Tls.encodePrivateKey : PrivateKey -> Bytes
        
-  413. -- ##Tls.handshake.impl.v3
+  414. -- ##Tls.handshake.impl.v3
        builtin.io2.Tls.handshake.impl : Tls
        ->{IO} Either Failure ()
        
-  414. -- ##Tls.newClient.impl.v3
+  415. -- ##Tls.newClient.impl.v3
        builtin.io2.Tls.newClient.impl : ClientConfig
        -> Socket
        ->{IO} Either Failure Tls
        
-  415. -- ##Tls.newServer.impl.v3
+  416. -- ##Tls.newServer.impl.v3
        builtin.io2.Tls.newServer.impl : ServerConfig
        -> Socket
        ->{IO} Either Failure Tls
        
-  416. -- ##Tls.PrivateKey
+  417. -- ##Tls.PrivateKey
        builtin type builtin.io2.Tls.PrivateKey
        
-  417. -- ##Tls.receive.impl.v3
+  418. -- ##Tls.receive.impl.v3
        builtin.io2.Tls.receive.impl : Tls
        ->{IO} Either Failure Bytes
        
-  418. -- ##Tls.send.impl.v3
+  419. -- ##Tls.send.impl.v3
        builtin.io2.Tls.send.impl : Tls
        -> Bytes
        ->{IO} Either Failure ()
        
-  419. -- ##Tls.ServerConfig
+  420. -- ##Tls.ServerConfig
        builtin type builtin.io2.Tls.ServerConfig
        
-  420. -- ##Tls.ServerConfig.certificates.set
+  421. -- ##Tls.ServerConfig.certificates.set
        builtin.io2.Tls.ServerConfig.certificates.set : [SignedCert]
        -> ServerConfig
        -> ServerConfig
        
-  421. -- ##Tls.ServerConfig.ciphers.set
+  422. -- ##Tls.ServerConfig.ciphers.set
        builtin.io2.Tls.ServerConfig.ciphers.set : [Cipher]
        -> ServerConfig
        -> ServerConfig
        
-  422. -- ##Tls.ServerConfig.default
+  423. -- ##Tls.ServerConfig.default
        builtin.io2.Tls.ServerConfig.default : [SignedCert]
        -> PrivateKey
        -> ServerConfig
        
-  423. -- ##Tls.ServerConfig.versions.set
+  424. -- ##Tls.ServerConfig.versions.set
        builtin.io2.Tls.ServerConfig.versions.set : [Version]
        -> ServerConfig
        -> ServerConfig
        
-  424. -- ##Tls.SignedCert
+  425. -- ##Tls.SignedCert
        builtin type builtin.io2.Tls.SignedCert
        
-  425. -- ##Tls.terminate.impl.v3
+  426. -- ##Tls.terminate.impl.v3
        builtin.io2.Tls.terminate.impl : Tls
        ->{IO} Either Failure ()
        
-  426. -- ##Tls.Version
+  427. -- ##Tls.Version
        builtin type builtin.io2.Tls.Version
        
-  427. -- #r3gag1btclr8iclbdt68irgt8n1d1vf7agv5umke3dgdbl11acj6easav6gtihanrjnct18om07638rne9ej06u2bkv2v4l36knm2l0
+  428. -- #r3gag1btclr8iclbdt68irgt8n1d1vf7agv5umke3dgdbl11acj6easav6gtihanrjnct18om07638rne9ej06u2bkv2v4l36knm2l0
        unique type builtin.io2.TlsFailure
        
-  428. -- ##TVar
+  429. -- ##TVar
        builtin type builtin.io2.TVar
        
-  429. -- ##TVar.new
+  430. -- ##TVar.new
        builtin.io2.TVar.new : a ->{STM} TVar a
        
-  430. -- ##TVar.newIO
+  431. -- ##TVar.newIO
        builtin.io2.TVar.newIO : a ->{IO} TVar a
        
-  431. -- ##TVar.read
+  432. -- ##TVar.read
        builtin.io2.TVar.read : TVar a ->{STM} a
        
-  432. -- ##TVar.readIO
+  433. -- ##TVar.readIO
        builtin.io2.TVar.readIO : TVar a ->{IO} a
        
-  433. -- ##TVar.swap
+  434. -- ##TVar.swap
        builtin.io2.TVar.swap : TVar a -> a ->{STM} a
        
-  434. -- ##TVar.write
+  435. -- ##TVar.write
        builtin.io2.TVar.write : TVar a -> a ->{STM} ()
        
-  435. -- ##validateSandboxed
+  436. -- ##validateSandboxed
        builtin.io2.validateSandboxed : [Link.Term]
        -> a
        -> Boolean
        
-  436. -- #c23jofurcegj93796o0karmkcm6baifupiuu1rtkniu74avn6a4r1n66ga5rml5di7easkgn4iak800u3tnb6kfisbrv6tcfgkb13a8
+  437. -- #c23jofurcegj93796o0karmkcm6baifupiuu1rtkniu74avn6a4r1n66ga5rml5di7easkgn4iak800u3tnb6kfisbrv6tcfgkb13a8
        unique type builtin.IsPropagated
        
-  437. -- #c23jofurcegj93796o0karmkcm6baifupiuu1rtkniu74avn6a4r1n66ga5rml5di7easkgn4iak800u3tnb6kfisbrv6tcfgkb13a8#0
+  438. -- #c23jofurcegj93796o0karmkcm6baifupiuu1rtkniu74avn6a4r1n66ga5rml5di7easkgn4iak800u3tnb6kfisbrv6tcfgkb13a8#0
        builtin.IsPropagated.IsPropagated : IsPropagated
        
-  438. -- #q6snodsh7i7u6k7gtqj73tt7nv6htjofs5f37vg2v3dsfk6hau71fs5mcv0hq3lqg111fsvoi92mngm08850aftfgh65uka9mhqvft0
+  439. -- #q6snodsh7i7u6k7gtqj73tt7nv6htjofs5f37vg2v3dsfk6hau71fs5mcv0hq3lqg111fsvoi92mngm08850aftfgh65uka9mhqvft0
        unique type builtin.IsTest
        
-  439. -- #q6snodsh7i7u6k7gtqj73tt7nv6htjofs5f37vg2v3dsfk6hau71fs5mcv0hq3lqg111fsvoi92mngm08850aftfgh65uka9mhqvft0#0
+  440. -- #q6snodsh7i7u6k7gtqj73tt7nv6htjofs5f37vg2v3dsfk6hau71fs5mcv0hq3lqg111fsvoi92mngm08850aftfgh65uka9mhqvft0#0
        builtin.IsTest.IsTest : IsTest
        
-  440. -- #68haromionghg6cvojngjrgc7t0ob658nkk8b20fpho6k6ltjtf6rfmr4ia1omige97hk34lu21qsj933vl1dkpbna7evbjfkh71r9g
+  441. -- #68haromionghg6cvojngjrgc7t0ob658nkk8b20fpho6k6ltjtf6rfmr4ia1omige97hk34lu21qsj933vl1dkpbna7evbjfkh71r9g
        unique type builtin.License
        
-  441. -- #knhl4mlkqf0mt877flahlbas2ufb7bub8f11vi9ihh9uf7r6jqaglk7rm6912q1vml50866ddl0qfa4o6d7o0gomchaoae24m0u2nk8
+  442. -- #knhl4mlkqf0mt877flahlbas2ufb7bub8f11vi9ihh9uf7r6jqaglk7rm6912q1vml50866ddl0qfa4o6d7o0gomchaoae24m0u2nk8
        builtin.License.copyrightHolders : License
        -> [CopyrightHolder]
        
-  442. -- #ucpi54l843bf1osaejl1cnn0jt3o89fak5c0120k8256in3m80ik836hnite0osl12m91utnpnt5n7pgm3oe1rv4r1hk8ai4033agvo
+  443. -- #ucpi54l843bf1osaejl1cnn0jt3o89fak5c0120k8256in3m80ik836hnite0osl12m91utnpnt5n7pgm3oe1rv4r1hk8ai4033agvo
        builtin.License.copyrightHolders.modify : ([CopyrightHolder]
        ->{g} [CopyrightHolder])
        -> License
        ->{g} License
        
-  443. -- #9hbbfn61d2odn8jvtj5da9n1e9decsrheg6chg73uf94oituv3750b9hd6vp3ljhi54dkp5uqfg57j66i39bstfd8ivgav4p3si39ro
+  444. -- #9hbbfn61d2odn8jvtj5da9n1e9decsrheg6chg73uf94oituv3750b9hd6vp3ljhi54dkp5uqfg57j66i39bstfd8ivgav4p3si39ro
        builtin.License.copyrightHolders.set : [CopyrightHolder]
        -> License
        -> License
        
-  444. -- #68haromionghg6cvojngjrgc7t0ob658nkk8b20fpho6k6ltjtf6rfmr4ia1omige97hk34lu21qsj933vl1dkpbna7evbjfkh71r9g#0
+  445. -- #68haromionghg6cvojngjrgc7t0ob658nkk8b20fpho6k6ltjtf6rfmr4ia1omige97hk34lu21qsj933vl1dkpbna7evbjfkh71r9g#0
        builtin.License.License : [CopyrightHolder]
        -> [Year]
        -> LicenseType
        -> License
        
-  445. -- #aqi4h1bfq2rjnrrfanf4nut8jd1elkkc00u1tn0rmt9ocsrds8i8pha7q9cihvbiq7edpg21iqnfornimae2gad0ab8ih0bksjnoi4g
+  446. -- #aqi4h1bfq2rjnrrfanf4nut8jd1elkkc00u1tn0rmt9ocsrds8i8pha7q9cihvbiq7edpg21iqnfornimae2gad0ab8ih0bksjnoi4g
        builtin.License.licenseType : License -> LicenseType
        
-  446. -- #1rm8kpbv278t9tqj4jfssl8q3cn4hgu1mti7bp8lhcr5h7qmojujmt9de4c31p42to8mtav61u98oad3oen8q9im20sacs69psjpugo
+  447. -- #1rm8kpbv278t9tqj4jfssl8q3cn4hgu1mti7bp8lhcr5h7qmojujmt9de4c31p42to8mtav61u98oad3oen8q9im20sacs69psjpugo
        builtin.License.licenseType.modify : (LicenseType
        ->{g} LicenseType)
        -> License
        ->{g} License
        
-  447. -- #dv9jsg0ksrlp3g0uftvkutpa8matt039o7dhat9airnkto2b703mgoi5t412hdi95pdhp9g01luga13ihmp52nk6bgh788gts6elv2o
+  448. -- #dv9jsg0ksrlp3g0uftvkutpa8matt039o7dhat9airnkto2b703mgoi5t412hdi95pdhp9g01luga13ihmp52nk6bgh788gts6elv2o
        builtin.License.licenseType.set : LicenseType
        -> License
        -> License
        
-  448. -- #fh5qbeba2hg5c5k9uppi71rfghj8df37p4cg3hk23b9pv0hpm67ok807f05t368rn6v99v7kvf7cp984v8ipkjr1j1h095g6nd9jtig
+  449. -- #fh5qbeba2hg5c5k9uppi71rfghj8df37p4cg3hk23b9pv0hpm67ok807f05t368rn6v99v7kvf7cp984v8ipkjr1j1h095g6nd9jtig
        builtin.License.years : License -> [Year]
        
-  449. -- #2samr066hti71pf0fkvb4niemm7j3amvaap3sk1dqpihqp9g8f8lknhhmjq9atai6j5kcs4huvfokvpm15ebefmfggr4hd2cetf7co0
+  450. -- #2samr066hti71pf0fkvb4niemm7j3amvaap3sk1dqpihqp9g8f8lknhhmjq9atai6j5kcs4huvfokvpm15ebefmfggr4hd2cetf7co0
        builtin.License.years.modify : ([Year] ->{g} [Year])
        -> License
        ->{g} License
        
-  450. -- #g3ap8lg6974au4meb2hl49k1k6f048det9uckmics3bkt9s571921ksqfdsch63k2pk3fij8pn697svniakkrueddh8nkflnmjk9ffo
+  451. -- #g3ap8lg6974au4meb2hl49k1k6f048det9uckmics3bkt9s571921ksqfdsch63k2pk3fij8pn697svniakkrueddh8nkflnmjk9ffo
        builtin.License.years.set : [Year] -> License -> License
        
-  451. -- #uj652rrb45urfnojgt1ssqoji7iiibu27uhrc1sfl68lm54hbr7r1dpgppsv0pvf0oile2uk2h2gn1h4vgng30fga66idihhen14qc0
+  452. -- #uj652rrb45urfnojgt1ssqoji7iiibu27uhrc1sfl68lm54hbr7r1dpgppsv0pvf0oile2uk2h2gn1h4vgng30fga66idihhen14qc0
        unique type builtin.LicenseType
        
-  452. -- #uj652rrb45urfnojgt1ssqoji7iiibu27uhrc1sfl68lm54hbr7r1dpgppsv0pvf0oile2uk2h2gn1h4vgng30fga66idihhen14qc0#0
+  453. -- #uj652rrb45urfnojgt1ssqoji7iiibu27uhrc1sfl68lm54hbr7r1dpgppsv0pvf0oile2uk2h2gn1h4vgng30fga66idihhen14qc0#0
        builtin.LicenseType.LicenseType : Doc -> LicenseType
        
-  453. -- #f4b37niu61dc517c32h3os36ig34fgnt7inaaoqdbecmscchthi14gdo0vj3eee1ru746ibvl9vnmm1pglrv3125qnhsbc0i1tqtic0
+  454. -- #f4b37niu61dc517c32h3os36ig34fgnt7inaaoqdbecmscchthi14gdo0vj3eee1ru746ibvl9vnmm1pglrv3125qnhsbc0i1tqtic0
        unique type builtin.Link
        
-  454. -- ##Link.Term
+  455. -- ##Link.Term
        builtin type builtin.Link.Term
        
-  455. -- #f4b37niu61dc517c32h3os36ig34fgnt7inaaoqdbecmscchthi14gdo0vj3eee1ru746ibvl9vnmm1pglrv3125qnhsbc0i1tqtic0#0
+  456. -- #f4b37niu61dc517c32h3os36ig34fgnt7inaaoqdbecmscchthi14gdo0vj3eee1ru746ibvl9vnmm1pglrv3125qnhsbc0i1tqtic0#0
        builtin.Link.Term : Link.Term -> Link
        
-  456. -- ##Link.Term.toText
+  457. -- ##Link.Term.toText
        builtin.Link.Term.toText : Link.Term -> Text
        
-  457. -- ##Link.Type
+  458. -- ##Link.Type
        builtin type builtin.Link.Type
        
-  458. -- #f4b37niu61dc517c32h3os36ig34fgnt7inaaoqdbecmscchthi14gdo0vj3eee1ru746ibvl9vnmm1pglrv3125qnhsbc0i1tqtic0#1
+  459. -- #f4b37niu61dc517c32h3os36ig34fgnt7inaaoqdbecmscchthi14gdo0vj3eee1ru746ibvl9vnmm1pglrv3125qnhsbc0i1tqtic0#1
        builtin.Link.Type : Type -> Link
        
-  459. -- ##Sequence
+  460. -- ##Sequence
        builtin type builtin.List
        
-  460. -- ##List.++
+  461. -- ##List.++
        builtin.List.++ : [a] -> [a] -> [a]
        
-  461. -- ##List.cons
+  462. -- ##List.cons
        builtin.List.+:, builtin.List.cons : a -> [a] -> [a]
        
-  462. -- ##List.snoc
+  463. -- ##List.snoc
        builtin.List.:+, builtin.List.snoc : [a] -> a -> [a]
        
-  463. -- ##List.at
+  464. -- ##List.at
        builtin.List.at : Nat -> [a] -> Optional a
        
-  464. -- ##List.cons
+  465. -- ##List.cons
        builtin.List.cons, builtin.List.+: : a -> [a] -> [a]
        
-  465. -- ##List.drop
+  466. -- ##List.drop
        builtin.List.drop : Nat -> [a] -> [a]
        
-  466. -- ##List.empty
+  467. -- ##List.empty
        builtin.List.empty : [a]
        
-  467. -- #a8ia0nqfghkpj4dt0t5gsk96tsfv6kg1k2cf7d7sb83tkqosebfiib2bkhjq48tc2v8ld94gf9o3hvc42pf6j49q75k0br395qavli0
+  468. -- #a8ia0nqfghkpj4dt0t5gsk96tsfv6kg1k2cf7d7sb83tkqosebfiib2bkhjq48tc2v8ld94gf9o3hvc42pf6j49q75k0br395qavli0
        builtin.List.map : (a ->{e} b) -> [a] ->{e} [b]
        
-  468. -- ##List.size
+  469. -- ##List.size
        builtin.List.size : [a] -> Nat
        
-  469. -- ##List.snoc
+  470. -- ##List.snoc
        builtin.List.snoc, builtin.List.:+ : [a] -> a -> [a]
        
-  470. -- ##List.take
+  471. -- ##List.take
        builtin.List.take : Nat -> [a] -> [a]
        
-  471. -- #cb9e3iosob3e4q0v96ifmserg27samv1lvi4dh0l0l19phvct4vbbvv19abngneb77b02h8cefr1o3ad8gnm3cn6mjgsub97gjlte8g
+  472. -- #cb9e3iosob3e4q0v96ifmserg27samv1lvi4dh0l0l19phvct4vbbvv19abngneb77b02h8cefr1o3ad8gnm3cn6mjgsub97gjlte8g
        builtin.metadata.isPropagated : IsPropagated
        
-  472. -- #lkpne3jg56pmqegv4jba6b5nnjg86qtfllnlmtvijql5lsf89rfu6tgb1s9ic0gsqs5si0v9agmj90lk0bhihbovd5o5ve023g4ocko
+  473. -- #lkpne3jg56pmqegv4jba6b5nnjg86qtfllnlmtvijql5lsf89rfu6tgb1s9ic0gsqs5si0v9agmj90lk0bhihbovd5o5ve023g4ocko
        builtin.metadata.isTest : IsTest
        
-  473. -- ##MutableArray
+  474. -- ##MutableArray
        builtin type builtin.MutableArray
        
-  474. -- ##MutableArray.copyTo!
+  475. -- ##MutableArray.copyTo!
        builtin.MutableArray.copyTo! : MutableArray g a
        -> Nat
        -> MutableArray g a
@@ -1666,34 +1669,34 @@ This transcript is intended to make visible accidental changes to the hashing al
        -> Nat
        ->{g, Exception} ()
        
-  475. -- ##MutableArray.freeze
+  476. -- ##MutableArray.freeze
        builtin.MutableArray.freeze : MutableArray g a
        -> Nat
        -> Nat
        ->{g} ImmutableArray a
        
-  476. -- ##MutableArray.freeze!
+  477. -- ##MutableArray.freeze!
        builtin.MutableArray.freeze! : MutableArray g a
        ->{g} ImmutableArray a
        
-  477. -- ##MutableArray.read
+  478. -- ##MutableArray.read
        builtin.MutableArray.read : MutableArray g a
        -> Nat
        ->{g, Exception} a
        
-  478. -- ##MutableArray.size
+  479. -- ##MutableArray.size
        builtin.MutableArray.size : MutableArray g a -> Nat
        
-  479. -- ##MutableArray.write
+  480. -- ##MutableArray.write
        builtin.MutableArray.write : MutableArray g a
        -> Nat
        -> a
        ->{g, Exception} ()
        
-  480. -- ##MutableByteArray
+  481. -- ##MutableByteArray
        builtin type builtin.MutableByteArray
        
-  481. -- ##MutableByteArray.copyTo!
+  482. -- ##MutableByteArray.copyTo!
        builtin.MutableByteArray.copyTo! : MutableByteArray g
        -> Nat
        -> MutableByteArray g
@@ -1701,682 +1704,682 @@ This transcript is intended to make visible accidental changes to the hashing al
        -> Nat
        ->{g, Exception} ()
        
-  482. -- ##MutableByteArray.freeze
+  483. -- ##MutableByteArray.freeze
        builtin.MutableByteArray.freeze : MutableByteArray g
        -> Nat
        -> Nat
        ->{g} ImmutableByteArray
        
-  483. -- ##MutableByteArray.freeze!
+  484. -- ##MutableByteArray.freeze!
        builtin.MutableByteArray.freeze! : MutableByteArray g
        ->{g} ImmutableByteArray
        
-  484. -- ##MutableByteArray.read16be
+  485. -- ##MutableByteArray.read16be
        builtin.MutableByteArray.read16be : MutableByteArray g
        -> Nat
        ->{g, Exception} Nat
        
-  485. -- ##MutableByteArray.read24be
+  486. -- ##MutableByteArray.read24be
        builtin.MutableByteArray.read24be : MutableByteArray g
        -> Nat
        ->{g, Exception} Nat
        
-  486. -- ##MutableByteArray.read32be
+  487. -- ##MutableByteArray.read32be
        builtin.MutableByteArray.read32be : MutableByteArray g
        -> Nat
        ->{g, Exception} Nat
        
-  487. -- ##MutableByteArray.read40be
+  488. -- ##MutableByteArray.read40be
        builtin.MutableByteArray.read40be : MutableByteArray g
        -> Nat
        ->{g, Exception} Nat
        
-  488. -- ##MutableByteArray.read64be
+  489. -- ##MutableByteArray.read64be
        builtin.MutableByteArray.read64be : MutableByteArray g
        -> Nat
        ->{g, Exception} Nat
        
-  489. -- ##MutableByteArray.read8
+  490. -- ##MutableByteArray.read8
        builtin.MutableByteArray.read8 : MutableByteArray g
        -> Nat
        ->{g, Exception} Nat
        
-  490. -- ##MutableByteArray.size
+  491. -- ##MutableByteArray.size
        builtin.MutableByteArray.size : MutableByteArray g -> Nat
        
-  491. -- ##MutableByteArray.write16be
+  492. -- ##MutableByteArray.write16be
        builtin.MutableByteArray.write16be : MutableByteArray g
        -> Nat
        -> Nat
        ->{g, Exception} ()
        
-  492. -- ##MutableByteArray.write32be
+  493. -- ##MutableByteArray.write32be
        builtin.MutableByteArray.write32be : MutableByteArray g
        -> Nat
        -> Nat
        ->{g, Exception} ()
        
-  493. -- ##MutableByteArray.write64be
+  494. -- ##MutableByteArray.write64be
        builtin.MutableByteArray.write64be : MutableByteArray g
        -> Nat
        -> Nat
        ->{g, Exception} ()
        
-  494. -- ##MutableByteArray.write8
+  495. -- ##MutableByteArray.write8
        builtin.MutableByteArray.write8 : MutableByteArray g
        -> Nat
        -> Nat
        ->{g, Exception} ()
        
-  495. -- ##Nat
+  496. -- ##Nat
        builtin type builtin.Nat
        
-  496. -- ##Nat.*
+  497. -- ##Nat.*
        builtin.Nat.* : Nat -> Nat -> Nat
        
-  497. -- ##Nat.+
+  498. -- ##Nat.+
        builtin.Nat.+ : Nat -> Nat -> Nat
        
-  498. -- ##Nat./
+  499. -- ##Nat./
        builtin.Nat./ : Nat -> Nat -> Nat
        
-  499. -- ##Nat.and
+  500. -- ##Nat.and
        builtin.Nat.and : Nat -> Nat -> Nat
        
-  500. -- ##Nat.complement
+  501. -- ##Nat.complement
        builtin.Nat.complement : Nat -> Nat
        
-  501. -- ##Nat.drop
+  502. -- ##Nat.drop
        builtin.Nat.drop : Nat -> Nat -> Nat
        
-  502. -- ##Nat.==
+  503. -- ##Nat.==
        builtin.Nat.eq : Nat -> Nat -> Boolean
        
-  503. -- ##Nat.fromText
+  504. -- ##Nat.fromText
        builtin.Nat.fromText : Text -> Optional Nat
        
-  504. -- ##Nat.>
+  505. -- ##Nat.>
        builtin.Nat.gt : Nat -> Nat -> Boolean
        
-  505. -- ##Nat.>=
+  506. -- ##Nat.>=
        builtin.Nat.gteq : Nat -> Nat -> Boolean
        
-  506. -- ##Nat.increment
+  507. -- ##Nat.increment
        builtin.Nat.increment : Nat -> Nat
        
-  507. -- ##Nat.isEven
+  508. -- ##Nat.isEven
        builtin.Nat.isEven : Nat -> Boolean
        
-  508. -- ##Nat.isOdd
+  509. -- ##Nat.isOdd
        builtin.Nat.isOdd : Nat -> Boolean
        
-  509. -- ##Nat.leadingZeros
+  510. -- ##Nat.leadingZeros
        builtin.Nat.leadingZeros : Nat -> Nat
        
-  510. -- ##Nat.<
+  511. -- ##Nat.<
        builtin.Nat.lt : Nat -> Nat -> Boolean
        
-  511. -- ##Nat.<=
+  512. -- ##Nat.<=
        builtin.Nat.lteq : Nat -> Nat -> Boolean
        
-  512. -- ##Nat.mod
+  513. -- ##Nat.mod
        builtin.Nat.mod : Nat -> Nat -> Nat
        
-  513. -- ##Nat.or
+  514. -- ##Nat.or
        builtin.Nat.or : Nat -> Nat -> Nat
        
-  514. -- ##Nat.popCount
+  515. -- ##Nat.popCount
        builtin.Nat.popCount : Nat -> Nat
        
-  515. -- ##Nat.pow
+  516. -- ##Nat.pow
        builtin.Nat.pow : Nat -> Nat -> Nat
        
-  516. -- ##Nat.shiftLeft
+  517. -- ##Nat.shiftLeft
        builtin.Nat.shiftLeft : Nat -> Nat -> Nat
        
-  517. -- ##Nat.shiftRight
+  518. -- ##Nat.shiftRight
        builtin.Nat.shiftRight : Nat -> Nat -> Nat
        
-  518. -- ##Nat.sub
+  519. -- ##Nat.sub
        builtin.Nat.sub : Nat -> Nat -> Int
        
-  519. -- ##Nat.toFloat
+  520. -- ##Nat.toFloat
        builtin.Nat.toFloat : Nat -> Float
        
-  520. -- ##Nat.toInt
+  521. -- ##Nat.toInt
        builtin.Nat.toInt : Nat -> Int
        
-  521. -- ##Nat.toText
+  522. -- ##Nat.toText
        builtin.Nat.toText : Nat -> Text
        
-  522. -- ##Nat.trailingZeros
+  523. -- ##Nat.trailingZeros
        builtin.Nat.trailingZeros : Nat -> Nat
        
-  523. -- ##Nat.xor
+  524. -- ##Nat.xor
        builtin.Nat.xor : Nat -> Nat -> Nat
        
-  524. -- #nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg
+  525. -- #nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg
        structural type builtin.Optional a
        
-  525. -- #nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#1
+  526. -- #nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#1
        builtin.Optional.None : Optional a
        
-  526. -- #nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#0
+  527. -- #nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#0
        builtin.Optional.Some : a -> Optional a
        
-  527. -- ##Pattern
+  528. -- ##Pattern
        builtin type builtin.Pattern
        
-  528. -- ##Pattern.capture
+  529. -- ##Pattern.capture
        builtin.Pattern.capture : Pattern a -> Pattern a
        
-  529. -- ##Pattern.isMatch
+  530. -- ##Pattern.isMatch
        builtin.Pattern.isMatch : Pattern a -> a -> Boolean
        
-  530. -- ##Pattern.join
+  531. -- ##Pattern.join
        builtin.Pattern.join : [Pattern a] -> Pattern a
        
-  531. -- ##Pattern.many
+  532. -- ##Pattern.many
        builtin.Pattern.many : Pattern a -> Pattern a
        
-  532. -- ##Pattern.or
+  533. -- ##Pattern.or
        builtin.Pattern.or : Pattern a -> Pattern a -> Pattern a
        
-  533. -- ##Pattern.replicate
+  534. -- ##Pattern.replicate
        builtin.Pattern.replicate : Nat
        -> Nat
        -> Pattern a
        -> Pattern a
        
-  534. -- ##Pattern.run
+  535. -- ##Pattern.run
        builtin.Pattern.run : Pattern a -> a -> Optional ([a], a)
        
-  535. -- #cbo8de57n17pgc5iic1741jeiunhvhfcfd7gt79vd6516u64aplasdodqoouejbgovhge2le5jb6rje923fcrllhtu01t29cdrssgbg
+  536. -- #cbo8de57n17pgc5iic1741jeiunhvhfcfd7gt79vd6516u64aplasdodqoouejbgovhge2le5jb6rje923fcrllhtu01t29cdrssgbg
        structural type builtin.Pretty txt
        
-  536. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8
+  537. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8
        unique type builtin.Pretty.Annotated w txt
        
-  537. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#1
+  538. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#1
        builtin.Pretty.Annotated.Append : w
        -> [Annotated w txt]
        -> Annotated w txt
        
-  538. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#6
+  539. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#6
        builtin.Pretty.Annotated.Empty : Annotated w txt
        
-  539. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#4
+  540. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#4
        builtin.Pretty.Annotated.Group : w
        -> Annotated w txt
        -> Annotated w txt
        
-  540. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#3
+  541. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#3
        builtin.Pretty.Annotated.Indent : w
        -> Annotated w txt
        -> Annotated w txt
        -> Annotated w txt
        -> Annotated w txt
        
-  541. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#7
+  542. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#7
        builtin.Pretty.Annotated.Lit : w
        -> txt
        -> Annotated w txt
        
-  542. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#2
+  543. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#2
        builtin.Pretty.Annotated.OrElse : w
        -> Annotated w txt
        -> Annotated w txt
        -> Annotated w txt
        
-  543. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#0
+  544. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#0
        builtin.Pretty.Annotated.Table : w
        -> [[Annotated w txt]]
        -> Annotated w txt
        
-  544. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#5
+  545. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#5
        builtin.Pretty.Annotated.Wrap : w
        -> Annotated w txt
        -> Annotated w txt
        
-  545. -- #svdhl4ogs0m1pe7ihtq5q9td72mg41tmndqif4kktbtv4p8e1ciapaj8kvflfbm876llbh60tlkefpi0v0bra8hl7mfgnpscimeqtdg
+  546. -- #svdhl4ogs0m1pe7ihtq5q9td72mg41tmndqif4kktbtv4p8e1ciapaj8kvflfbm876llbh60tlkefpi0v0bra8hl7mfgnpscimeqtdg
        builtin.Pretty.append : Pretty txt
        -> Pretty txt
        -> Pretty txt
        
-  546. -- #sonptakf85a3uklev4rq0pub00k56jdpaop4tcd9bmk0gmjjij5t16sf1knspku2hbp0uikiflbo0dtjv1i6r3t2rpjh86vo1rlaer8
+  547. -- #sonptakf85a3uklev4rq0pub00k56jdpaop4tcd9bmk0gmjjij5t16sf1knspku2hbp0uikiflbo0dtjv1i6r3t2rpjh86vo1rlaer8
        builtin.Pretty.empty : Pretty txt
        
-  547. -- #mlpplm1bhqkcif5j09204uuvfll7qte95msb0skjfd30nmei005kiich1ao39gm2j8687s14qvf5llu6i1a6fvt4vdmbp99jlfundfo
+  548. -- #mlpplm1bhqkcif5j09204uuvfll7qte95msb0skjfd30nmei005kiich1ao39gm2j8687s14qvf5llu6i1a6fvt4vdmbp99jlfundfo
        builtin.Pretty.get : Pretty txt -> Annotated () txt
        
-  548. -- #d9m2k9igi4b50cp7v5tlp3o7dot6r41rbbbsc2a4iqae3hc2a7fceh83l1n3nuotfnn7nrgt40s1kfbcnl89qcqieih125gsafk2d00
+  549. -- #d9m2k9igi4b50cp7v5tlp3o7dot6r41rbbbsc2a4iqae3hc2a7fceh83l1n3nuotfnn7nrgt40s1kfbcnl89qcqieih125gsafk2d00
        builtin.Pretty.group : Pretty txt -> Pretty txt
        
-  549. -- #p6rkh0u8gfko2fpqdje6h8cain3qakom06a28rh4ccsjsnbagmmv6gadccg4t380c4nnetq9si7bkkvbh44it4lrfvfvcn4usps1uno
+  550. -- #p6rkh0u8gfko2fpqdje6h8cain3qakom06a28rh4ccsjsnbagmmv6gadccg4t380c4nnetq9si7bkkvbh44it4lrfvfvcn4usps1uno
        builtin.Pretty.indent : Pretty txt
        -> Pretty txt
        -> Pretty txt
        
-  550. -- #f59sgojafl5so8ei4vgdpqflqcpsgovpcea73509k5qm1jb8vkeojsfsavhn64gmfpd52uo631ejqu0oj2a6t6k8jcu282lbqjou7ug
+  551. -- #f59sgojafl5so8ei4vgdpqflqcpsgovpcea73509k5qm1jb8vkeojsfsavhn64gmfpd52uo631ejqu0oj2a6t6k8jcu282lbqjou7ug
        builtin.Pretty.indent' : Pretty txt
        -> Pretty txt
        -> Pretty txt
        -> Pretty txt
        
-  551. -- #hpntja4i04u36vijdesobh75pubru68jf1fhgi49jl3nf6kall1so8hfc0bq0pm8r9kopgskiigdl04hqelklsdrdjndq5on9hsjgmo
+  552. -- #hpntja4i04u36vijdesobh75pubru68jf1fhgi49jl3nf6kall1so8hfc0bq0pm8r9kopgskiigdl04hqelklsdrdjndq5on9hsjgmo
        builtin.Pretty.join : [Pretty txt] -> Pretty txt
        
-  552. -- #jtn2i6bg3gargdp2rbk08jfd327htap62brih8phdfm2m4d6ib9cu0o2k5vrh7f4jik99eufu4hi0114akgd1oiivi8p1pa9m2fvjv0
+  553. -- #jtn2i6bg3gargdp2rbk08jfd327htap62brih8phdfm2m4d6ib9cu0o2k5vrh7f4jik99eufu4hi0114akgd1oiivi8p1pa9m2fvjv0
        builtin.Pretty.lit : txt -> Pretty txt
        
-  553. -- #pn811nf59d63s8711bpktjqub65sb748pmajg7r8n7h7cnap5ecb4n1072ccult24q6gcfac66scrm77cjsa779mcckqrs8si4716sg
+  554. -- #pn811nf59d63s8711bpktjqub65sb748pmajg7r8n7h7cnap5ecb4n1072ccult24q6gcfac66scrm77cjsa779mcckqrs8si4716sg
        builtin.Pretty.map : (txt ->{g} txt2)
        -> Pretty txt
        ->{g} Pretty txt2
        
-  554. -- #5rfcm6mlv2njfa8l9slkjp1q2q5r6m1vkp084run6pd632cf02mcpoh2bo3kuqf3uqbb5nh2drf37u51lpf16m5u415tcuk18djnr60
+  555. -- #5rfcm6mlv2njfa8l9slkjp1q2q5r6m1vkp084run6pd632cf02mcpoh2bo3kuqf3uqbb5nh2drf37u51lpf16m5u415tcuk18djnr60
        builtin.Pretty.orElse : Pretty txt
        -> Pretty txt
        -> Pretty txt
        
-  555. -- #cbo8de57n17pgc5iic1741jeiunhvhfcfd7gt79vd6516u64aplasdodqoouejbgovhge2le5jb6rje923fcrllhtu01t29cdrssgbg#0
+  556. -- #cbo8de57n17pgc5iic1741jeiunhvhfcfd7gt79vd6516u64aplasdodqoouejbgovhge2le5jb6rje923fcrllhtu01t29cdrssgbg#0
        builtin.Pretty.Pretty : Annotated () txt -> Pretty txt
        
-  556. -- #qg050nfl4eeeiarp5mvun3j15h3qpgo31a01o03mql8rrrpht3o6h6htov9ghm7cikkbjejgu4vd9v3h1idp0hanol93pqpqiq8rg3g
+  557. -- #qg050nfl4eeeiarp5mvun3j15h3qpgo31a01o03mql8rrrpht3o6h6htov9ghm7cikkbjejgu4vd9v3h1idp0hanol93pqpqiq8rg3g
        builtin.Pretty.sepBy : Pretty txt
        -> [Pretty txt]
        -> Pretty txt
        
-  557. -- #ev99k0kpivu29vfl7k8pf5n55fnnelq78ul7jqjrk946i1ckvrs5lmrji3l2avhd02mljspdbfspcn26phaqkug6p7rocbbf94uhcro
+  558. -- #ev99k0kpivu29vfl7k8pf5n55fnnelq78ul7jqjrk946i1ckvrs5lmrji3l2avhd02mljspdbfspcn26phaqkug6p7rocbbf94uhcro
        builtin.Pretty.table : [[Pretty txt]] -> Pretty txt
        
-  558. -- #7c4jq9udglq9n7pfemqmc7qrks18r80t9dgjefpi78aerb1vo8cakc3fv843dg3h60ihbo75u0jrmbhqk0och8be2am98v3mu5f6v10
+  559. -- #7c4jq9udglq9n7pfemqmc7qrks18r80t9dgjefpi78aerb1vo8cakc3fv843dg3h60ihbo75u0jrmbhqk0och8be2am98v3mu5f6v10
        builtin.Pretty.wrap : Pretty txt -> Pretty txt
        
-  559. -- ##Ref
+  560. -- ##Ref
        builtin type builtin.Ref
        
-  560. -- ##Ref.read
+  561. -- ##Ref.read
        builtin.Ref.read : Ref g a ->{g} a
        
-  561. -- ##Ref.write
+  562. -- ##Ref.write
        builtin.Ref.write : Ref g a -> a ->{g} ()
        
-  562. -- ##Effect
+  563. -- ##Effect
        builtin type builtin.Request
        
-  563. -- ##Scope
+  564. -- ##Scope
        builtin type builtin.Scope
        
-  564. -- ##Scope.array
+  565. -- ##Scope.array
        builtin.Scope.array : Nat
        ->{Scope s} MutableArray (Scope s) a
        
-  565. -- ##Scope.arrayOf
+  566. -- ##Scope.arrayOf
        builtin.Scope.arrayOf : a
        -> Nat
        ->{Scope s} MutableArray (Scope s) a
        
-  566. -- ##Scope.bytearray
+  567. -- ##Scope.bytearray
        builtin.Scope.bytearray : Nat
        ->{Scope s} MutableByteArray (Scope s)
        
-  567. -- ##Scope.bytearrayOf
+  568. -- ##Scope.bytearrayOf
        builtin.Scope.bytearrayOf : Nat
        -> Nat
        ->{Scope s} MutableByteArray (Scope s)
        
-  568. -- ##Scope.ref
+  569. -- ##Scope.ref
        builtin.Scope.ref : a ->{Scope s} Ref {Scope s} a
        
-  569. -- ##Scope.run
+  570. -- ##Scope.run
        builtin.Scope.run : (∀ s. '{g, Scope s} r) ->{g} r
        
-  570. -- #6uigas14aqgd889s036hq9ssrlo22pju41009m0rktetcrbm97qniljjc1rv1u661r4f63oq6pupoevghs8a2hupvlbi6qi4ntn9320
+  571. -- #6uigas14aqgd889s036hq9ssrlo22pju41009m0rktetcrbm97qniljjc1rv1u661r4f63oq6pupoevghs8a2hupvlbi6qi4ntn9320
        structural type builtin.SeqView a b
        
-  571. -- #6uigas14aqgd889s036hq9ssrlo22pju41009m0rktetcrbm97qniljjc1rv1u661r4f63oq6pupoevghs8a2hupvlbi6qi4ntn9320#0
+  572. -- #6uigas14aqgd889s036hq9ssrlo22pju41009m0rktetcrbm97qniljjc1rv1u661r4f63oq6pupoevghs8a2hupvlbi6qi4ntn9320#0
        builtin.SeqView.VElem : a -> b -> SeqView a b
        
-  572. -- #6uigas14aqgd889s036hq9ssrlo22pju41009m0rktetcrbm97qniljjc1rv1u661r4f63oq6pupoevghs8a2hupvlbi6qi4ntn9320#1
+  573. -- #6uigas14aqgd889s036hq9ssrlo22pju41009m0rktetcrbm97qniljjc1rv1u661r4f63oq6pupoevghs8a2hupvlbi6qi4ntn9320#1
        builtin.SeqView.VEmpty : SeqView a b
        
-  573. -- ##Socket.toText
+  574. -- ##Socket.toText
        builtin.Socket.toText : Socket -> Text
        
-  574. -- #pfp0ajb4v2mb9tspp29v53dkacb76aa1t5kbk1dl0q354cjcg4egdpmvtr5d6t818ucon9eubf6r1vdvh926fgk8otvbkvbpn90levo
+  575. -- #pfp0ajb4v2mb9tspp29v53dkacb76aa1t5kbk1dl0q354cjcg4egdpmvtr5d6t818ucon9eubf6r1vdvh926fgk8otvbkvbpn90levo
        builtin.syntax.docAside : Doc2 -> Doc2
        
-  575. -- #mvov9qf78ctohefjbmrgs8ussspo5juhf75pee4ikkg8asuos72unn4pjn3fdel8471soj2vaskd5ls103pb6nb8qf75sjn4igs7v48
+  576. -- #mvov9qf78ctohefjbmrgs8ussspo5juhf75pee4ikkg8asuos72unn4pjn3fdel8471soj2vaskd5ls103pb6nb8qf75sjn4igs7v48
        builtin.syntax.docBlockquote : Doc2 -> Doc2
        
-  576. -- #cg64hg7dag89u80104kit2p40rhmo1k6h1j8obfhjolpogs705bt6hc92ct6rfj8h74m3ioug14u9pm1s7qqpmjda2srjojhi01nvf0
+  577. -- #cg64hg7dag89u80104kit2p40rhmo1k6h1j8obfhjolpogs705bt6hc92ct6rfj8h74m3ioug14u9pm1s7qqpmjda2srjojhi01nvf0
        builtin.syntax.docBold : Doc2 -> Doc2
        
-  577. -- #3qd5kt9gjiggrb871al82n11jccedl3kb5p8ffemr703frn38tqajkett30fg7hef5orh7vl0obp3lap9qq2po3ufcnu4k3bik81rlg
+  578. -- #3qd5kt9gjiggrb871al82n11jccedl3kb5p8ffemr703frn38tqajkett30fg7hef5orh7vl0obp3lap9qq2po3ufcnu4k3bik81rlg
        builtin.syntax.docBulletedList : [Doc2] -> Doc2
        
-  578. -- #el0rph43k5qg25qg20o5jdjukuful041r87v92tcb2339om0hp9u6vqtrcrfkvgj78hrpo2o1l39bbg1oier87pvgkli0lkgalgpo90
+  579. -- #el0rph43k5qg25qg20o5jdjukuful041r87v92tcb2339om0hp9u6vqtrcrfkvgj78hrpo2o1l39bbg1oier87pvgkli0lkgalgpo90
        builtin.syntax.docCallout : Optional Doc2 -> Doc2 -> Doc2
        
-  579. -- #7jij106qpusbsbpqhmtgrk59qo8ss9e77rtrc1h9hbpnbab8sq717fe6hppmhhds9smqbv3k2q0irjgoe4mogatlp9e4k25kopt6rgo
+  580. -- #7jij106qpusbsbpqhmtgrk59qo8ss9e77rtrc1h9hbpnbab8sq717fe6hppmhhds9smqbv3k2q0irjgoe4mogatlp9e4k25kopt6rgo
        builtin.syntax.docCode : Doc2 -> Doc2
        
-  580. -- #3paq4qqrk028tati33723c4aqi7ebgnjln12avbnf7eu8h8sflg0frlehb4lni4ru0pcfg9ftsurq3pb2q11cfebeki51vom697l7h0
+  581. -- #3paq4qqrk028tati33723c4aqi7ebgnjln12avbnf7eu8h8sflg0frlehb4lni4ru0pcfg9ftsurq3pb2q11cfebeki51vom697l7h0
        builtin.syntax.docCodeBlock : Text -> Text -> Doc2
        
-  581. -- #1of955s8tqa74vu0ve863p8dn2mncc2anmms54aj084pkbdcpml6ckvs0qb4defi0df3b1e8inp29p60ac93hf2u7to0je4op9fum40
+  582. -- #1of955s8tqa74vu0ve863p8dn2mncc2anmms54aj084pkbdcpml6ckvs0qb4defi0df3b1e8inp29p60ac93hf2u7to0je4op9fum40
        builtin.syntax.docColumn : [Doc2] -> Doc2
        
-  582. -- #ukv56cjchfao07qb08l7iimd2mmv09s5glmtljo5b71leaijtja04obd0u1hsr38itjnv85f7jvd37nr654bl4lfn4msr1one0hi4s0
+  583. -- #ukv56cjchfao07qb08l7iimd2mmv09s5glmtljo5b71leaijtja04obd0u1hsr38itjnv85f7jvd37nr654bl4lfn4msr1one0hi4s0
        builtin.syntax.docEmbedAnnotation : tm -> Doc2.Term
        
-  583. -- #uccvv8mn62ne8iqppsnpgbquqmhk4hk3n4tg7p6kttr20gov4698tu18jmmvdcs7ab455q7kklhb4uv1mtei4vbvq4qmbtbu1dbagmg
+  584. -- #uccvv8mn62ne8iqppsnpgbquqmhk4hk3n4tg7p6kttr20gov4698tu18jmmvdcs7ab455q7kklhb4uv1mtei4vbvq4qmbtbu1dbagmg
        builtin.syntax.docEmbedAnnotations : tms -> tms
        
-  584. -- #h53vvsbp1eflh5n41fepa5dana1ucfjbk8qc95kf4ht12svn304hc4fv431hiejspdr84oul4gmd3s65neil759q0hmjjrr8ottc6v0
+  585. -- #h53vvsbp1eflh5n41fepa5dana1ucfjbk8qc95kf4ht12svn304hc4fv431hiejspdr84oul4gmd3s65neil759q0hmjjrr8ottc6v0
        builtin.syntax.docEmbedSignatureLink : '{g} t
        -> Doc2.Term
        
-  585. -- #dvjs6ebt2ej6funsr6rv351aqe5eqt8pcbte5hpqossikbnqrblhhnve55pdg896s4e6dvd6m3us0151ejegfg1fi8kbfd7soa31dao
+  586. -- #dvjs6ebt2ej6funsr6rv351aqe5eqt8pcbte5hpqossikbnqrblhhnve55pdg896s4e6dvd6m3us0151ejegfg1fi8kbfd7soa31dao
        builtin.syntax.docEmbedTermLink : '{g} t
        -> Either a Doc2.Term
        
-  586. -- #7t98ois54isfkh31uefvdg4bg302s5q3sun4hfh0mqnosk4ded353jp0p2ij6b22vnvlcbipcv2jb91suh6qc33i7uqlfuto9f0r4n8
+  587. -- #7t98ois54isfkh31uefvdg4bg302s5q3sun4hfh0mqnosk4ded353jp0p2ij6b22vnvlcbipcv2jb91suh6qc33i7uqlfuto9f0r4n8
        builtin.syntax.docEmbedTypeLink : typ -> Either typ b
        
-  587. -- #r26nnrb8inld7nstp0rj4sbh7ldbibo3s6ld4hmii114i8fglrvij0a1jgj70u51it80s5vgj5dvu9oi5gqmr2n7j341tg8285mpesg
+  588. -- #r26nnrb8inld7nstp0rj4sbh7ldbibo3s6ld4hmii114i8fglrvij0a1jgj70u51it80s5vgj5dvu9oi5gqmr2n7j341tg8285mpesg
        builtin.syntax.docEval : 'a -> Doc2
        
-  588. -- #ojecdd8rnla7dqqop5a43u8kl12149l24452thb0ljkb99ivh6n2evg3g43dj6unlbsmbuvj5g9js5hvsi9f13lt22uqkueioe1vi9g
+  589. -- #ojecdd8rnla7dqqop5a43u8kl12149l24452thb0ljkb99ivh6n2evg3g43dj6unlbsmbuvj5g9js5hvsi9f13lt22uqkueioe1vi9g
        builtin.syntax.docEvalInline : 'a -> Doc2
        
-  589. -- #lecedgertb8tj69o0f2bqeso83hl454am6cjp708epen78s5gtr0ljcc6agopns65lnm3du36dr4m4qu9rp8rtjvtcpg359bpbnfcm0
+  590. -- #lecedgertb8tj69o0f2bqeso83hl454am6cjp708epen78s5gtr0ljcc6agopns65lnm3du36dr4m4qu9rp8rtjvtcpg359bpbnfcm0
        builtin.syntax.docExample : Nat -> '{g} t -> Doc2
        
-  590. -- #m4ini2v12rc468iflsee87m1qrm52b257e3blah4pcblqo2np3k6ad50bt5gkjob3qrct3jbihjd6i02t7la9oh3cft1d0483lf1pq0
+  591. -- #m4ini2v12rc468iflsee87m1qrm52b257e3blah4pcblqo2np3k6ad50bt5gkjob3qrct3jbihjd6i02t7la9oh3cft1d0483lf1pq0
        builtin.syntax.docExampleBlock : Nat -> '{g} t -> Doc2
        
-  591. -- #pomj7lft70jnnuk5job0pstih2mosva1oee4tediqbkhnm54tjqnfe6qs1mqt8os1ehg9ksgenb6veub2ngdpb1qat400vn0bj3fju0
+  592. -- #pomj7lft70jnnuk5job0pstih2mosva1oee4tediqbkhnm54tjqnfe6qs1mqt8os1ehg9ksgenb6veub2ngdpb1qat400vn0bj3fju0
        builtin.syntax.docFoldedSource : [( Either Type Doc2.Term,
          [Doc2.Term])]
        -> Doc2
        
-  592. -- #4rv8dvuvf5br3vhhuturaejt1l2u8j5eidjid01f5mo7o0fgjatttmph34ma0b9s1i2badcqj3ale005jb1hnisabnh93i4is1d8kng
+  593. -- #4rv8dvuvf5br3vhhuturaejt1l2u8j5eidjid01f5mo7o0fgjatttmph34ma0b9s1i2badcqj3ale005jb1hnisabnh93i4is1d8kng
        builtin.syntax.docFormatConsole : Doc2
        -> Pretty (Either SpecialForm ConsoleText)
        
-  593. -- #99qvifgs3u7nof50jbp5lhrf8cab0qiujr1tque2b7hfj56r39o8ot2fafhafuphoraddl1j142k994e22g5v2rhq98flc0954t5918
+  594. -- #99qvifgs3u7nof50jbp5lhrf8cab0qiujr1tque2b7hfj56r39o8ot2fafhafuphoraddl1j142k994e22g5v2rhq98flc0954t5918
        builtin.syntax.docGroup : Doc2 -> Doc2
        
-  594. -- #gsratvk7mo273bqhivdv06f9rog2cj48u7ci0jp6ubt5oidf8cq0rjilimkas5801inbbsjcedh61jl40i3en1qu6r9vfe684ad6r08
+  595. -- #gsratvk7mo273bqhivdv06f9rog2cj48u7ci0jp6ubt5oidf8cq0rjilimkas5801inbbsjcedh61jl40i3en1qu6r9vfe684ad6r08
        builtin.syntax.docItalic : Doc2 -> Doc2
        
-  595. -- #piohhscvm6lgpk6vfg91u2ndmlfv81nnkspihom77ucr4dev6s22rk2n9hp38nifh5p8vt7jfvep85vudpvlg2tt99e9s2qfjv5oau8
+  596. -- #piohhscvm6lgpk6vfg91u2ndmlfv81nnkspihom77ucr4dev6s22rk2n9hp38nifh5p8vt7jfvep85vudpvlg2tt99e9s2qfjv5oau8
        builtin.syntax.docJoin : [Doc2] -> Doc2
        
-  596. -- #hjdqcolihf4obmnfoakl2t5hs1e39hpmpo9ijvc37fqgejog1ii7fpd4q2fe2rkm62tf81unmqlbud8uh63vaa9feaekg5a7uo3nq00
+  597. -- #hjdqcolihf4obmnfoakl2t5hs1e39hpmpo9ijvc37fqgejog1ii7fpd4q2fe2rkm62tf81unmqlbud8uh63vaa9feaekg5a7uo3nq00
        builtin.syntax.docLink : Either Type Doc2.Term -> Doc2
        
-  597. -- #iv6urr76b0ohvr22qa6d05e7e01cd0re77g8c98cm0bqo0im345fotsevqnhk1igtutkrrqm562gtltofvku5mh0i87ru8tdf0i53bo
+  598. -- #iv6urr76b0ohvr22qa6d05e7e01cd0re77g8c98cm0bqo0im345fotsevqnhk1igtutkrrqm562gtltofvku5mh0i87ru8tdf0i53bo
        builtin.syntax.docNamedLink : Doc2 -> Doc2 -> Doc2
        
-  598. -- #b5dvn0bqj3rc1rkmlep5f6cd6n3vp247hqku8lqndena5ocgcoae18iuq3985finagr919re4fvji011ved0g21i6o0je2jn8f7k1p0
+  599. -- #b5dvn0bqj3rc1rkmlep5f6cd6n3vp247hqku8lqndena5ocgcoae18iuq3985finagr919re4fvji011ved0g21i6o0je2jn8f7k1p0
        builtin.syntax.docNumberedList : Nat -> [Doc2] -> Doc2
        
-  599. -- #fs8mho20fqj31ch5kpn8flm4geomotov7fb5ct8mtnh52ladorgp22vder3jgt1mr0u710e6s9gn4u36c9sp19vitvq1r0adtm3t1c0
+  600. -- #fs8mho20fqj31ch5kpn8flm4geomotov7fb5ct8mtnh52ladorgp22vder3jgt1mr0u710e6s9gn4u36c9sp19vitvq1r0adtm3t1c0
        builtin.syntax.docParagraph : [Doc2] -> Doc2
        
-  600. -- #6dvkai3hc122e2h2h8c3jnijink5m20e27i640qvnt6smefpp2vna1rq4gbmulhb46tdabmkb5hsjeiuo4adtsutg4iu1vfmqhlueso
+  601. -- #6dvkai3hc122e2h2h8c3jnijink5m20e27i640qvnt6smefpp2vna1rq4gbmulhb46tdabmkb5hsjeiuo4adtsutg4iu1vfmqhlueso
        builtin.syntax.docSection : Doc2 -> [Doc2] -> Doc2
        
-  601. -- #n0idf1bdrq5vgpk4pj9db5demk1es4jsnpodfoajftehvqjelsi0h5j2domdllq2peltdek4ptaqfpl4o8l6jpmqhcom9vq107ivdu0
+  602. -- #n0idf1bdrq5vgpk4pj9db5demk1es4jsnpodfoajftehvqjelsi0h5j2domdllq2peltdek4ptaqfpl4o8l6jpmqhcom9vq107ivdu0
        builtin.syntax.docSignature : [Doc2.Term] -> Doc2
        
-  602. -- #git1povkck9jrptdmmpqrv1g17ptbq9hr17l52l8477ijk4cia24tr7cj36v1o22mvtk00qoo5jt4bs4e79sl3eh6is8ubh8aoc1pu0
+  603. -- #git1povkck9jrptdmmpqrv1g17ptbq9hr17l52l8477ijk4cia24tr7cj36v1o22mvtk00qoo5jt4bs4e79sl3eh6is8ubh8aoc1pu0
        builtin.syntax.docSignatureInline : Doc2.Term -> Doc2
        
-  603. -- #47agivvofl1jegbqpdg0eeed72mdj29d623e4kdei0l10mhgckif7q2pd968ggribregcknra9u43mhehr1q86n0t4vbe4eestnu9l8
+  604. -- #47agivvofl1jegbqpdg0eeed72mdj29d623e4kdei0l10mhgckif7q2pd968ggribregcknra9u43mhehr1q86n0t4vbe4eestnu9l8
        builtin.syntax.docSource : [( Either Type Doc2.Term,
          [Doc2.Term])]
        -> Doc2
        
-  604. -- #n6uk5tc4d8ipbga8boelh51ro24paveca9fijm1nkn3tlfddqludmlppb2ps8807v2kuou1a262sa59764mdhug2va69q4sls5jli10
+  605. -- #n6uk5tc4d8ipbga8boelh51ro24paveca9fijm1nkn3tlfddqludmlppb2ps8807v2kuou1a262sa59764mdhug2va69q4sls5jli10
        builtin.syntax.docSourceElement : link
        -> annotations
        -> (link, annotations)
        
-  605. -- #nurq288b5rfp1f5keccleh51ojgcpd2rp7cane6ftquf7gidtamffb8tr1r5h6luk1nsrqomn1k4as4kcpaskjjv35rnvoous457sag
+  606. -- #nurq288b5rfp1f5keccleh51ojgcpd2rp7cane6ftquf7gidtamffb8tr1r5h6luk1nsrqomn1k4as4kcpaskjjv35rnvoous457sag
        builtin.syntax.docStrikethrough : Doc2 -> Doc2
        
-  606. -- #4ns2amu2njhvb5mtdvh3v7oljjb5ammnb41us4ekpbhb337b6mo2a4q0790cmrusko7omphtfdsaust2fn49hr5acl40ef8fkb9556g
+  607. -- #4ns2amu2njhvb5mtdvh3v7oljjb5ammnb41us4ekpbhb337b6mo2a4q0790cmrusko7omphtfdsaust2fn49hr5acl40ef8fkb9556g
        builtin.syntax.docTable : [[Doc2]] -> Doc2
        
-  607. -- #i77kddfr68gbjt3767a091dtnqff9beltojh93md8peo28t59c6modeccsfd2tnrtmd75fa7dn0ie21kcv4me098q91h4ftg9eau5fo
+  608. -- #i77kddfr68gbjt3767a091dtnqff9beltojh93md8peo28t59c6modeccsfd2tnrtmd75fa7dn0ie21kcv4me098q91h4ftg9eau5fo
        builtin.syntax.docTooltip : Doc2 -> Doc2 -> Doc2
        
-  608. -- #r0hdacbk2orcb2ate3uhd7ht05hmfa8643slm3u63nb3jaaim533up04lgt0pq97is43v2spkqble7mtu8f63hgcc0k2tb2jhpr2b68
+  609. -- #r0hdacbk2orcb2ate3uhd7ht05hmfa8643slm3u63nb3jaaim533up04lgt0pq97is43v2spkqble7mtu8f63hgcc0k2tb2jhpr2b68
        builtin.syntax.docTransclude : d -> d
        
-  609. -- #0nptdh40ngakd2rh92bl573a7vbdjcj2kc8rai39v8bb9dfpbj90i7nob381usjsott41c3cpo2m2q095fm0k0r68e8mrda135qa1k0
+  610. -- #0nptdh40ngakd2rh92bl573a7vbdjcj2kc8rai39v8bb9dfpbj90i7nob381usjsott41c3cpo2m2q095fm0k0r68e8mrda135qa1k0
        builtin.syntax.docUntitledSection : [Doc2] -> Doc2
        
-  610. -- #krjm78blt08v52c52l4ubsnfidcrs0h6010j2v2h9ud38mgm6jj4vuqn4okp4g75039o7u78sbg6ghforucbfdf94f8am9kvt6875jo
+  611. -- #krjm78blt08v52c52l4ubsnfidcrs0h6010j2v2h9ud38mgm6jj4vuqn4okp4g75039o7u78sbg6ghforucbfdf94f8am9kvt6875jo
        builtin.syntax.docVerbatim : Doc2 -> Doc2
        
-  611. -- #c14vgd4g1tkumf4jjd9vcoos1olb3f4gbc3hketf5l8h3i0efk8igbinh6gn018tr5075uo5nv1elva6tki6ofo3pdafidrkv9m0ot0
+  612. -- #c14vgd4g1tkumf4jjd9vcoos1olb3f4gbc3hketf5l8h3i0efk8igbinh6gn018tr5075uo5nv1elva6tki6ofo3pdafidrkv9m0ot0
        builtin.syntax.docWord : Text -> Doc2
        
-  612. -- #aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0
+  613. -- #aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0
        unique type builtin.Test.Result
        
-  613. -- #aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0#0
+  614. -- #aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0#0
        builtin.Test.Result.Fail : Text -> Result
        
-  614. -- #aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0#1
+  615. -- #aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0#1
        builtin.Test.Result.Ok : Text -> Result
        
-  615. -- ##Text
+  616. -- ##Text
        builtin type builtin.Text
        
-  616. -- ##Text.!=
+  617. -- ##Text.!=
        builtin.Text.!= : Text -> Text -> Boolean
        
-  617. -- ##Text.++
+  618. -- ##Text.++
        builtin.Text.++ : Text -> Text -> Text
        
-  618. -- #nv11qo7s2lqirk3qb44jkm3q3fb6i3mn72ji2c52eubh3kufrdumanblh2bnql1o24efdhmue0v21gd7d1p5ec9j6iqrmekas0183do
+  619. -- #nv11qo7s2lqirk3qb44jkm3q3fb6i3mn72ji2c52eubh3kufrdumanblh2bnql1o24efdhmue0v21gd7d1p5ec9j6iqrmekas0183do
        builtin.Text.alignLeftWith : Nat -> Char -> Text -> Text
        
-  619. -- #ebeq250fdoigvu89fneb4c24f8f18eotc8kocdmosn4ri9shoeeg7ofkejts6clm5c6bifce66qtr0vpfkrhuup2en3khous41hp8rg
+  620. -- #ebeq250fdoigvu89fneb4c24f8f18eotc8kocdmosn4ri9shoeeg7ofkejts6clm5c6bifce66qtr0vpfkrhuup2en3khous41hp8rg
        builtin.Text.alignRightWith : Nat -> Char -> Text -> Text
        
-  620. -- ##Text.drop
+  621. -- ##Text.drop
        builtin.Text.drop : Nat -> Text -> Text
        
-  621. -- ##Text.empty
+  622. -- ##Text.empty
        builtin.Text.empty : Text
        
-  622. -- ##Text.==
+  623. -- ##Text.==
        builtin.Text.eq : Text -> Text -> Boolean
        
-  623. -- ##Text.fromCharList
+  624. -- ##Text.fromCharList
        builtin.Text.fromCharList : [Char] -> Text
        
-  624. -- ##Text.fromUtf8.impl.v3
+  625. -- ##Text.fromUtf8.impl.v3
        builtin.Text.fromUtf8.impl : Bytes -> Either Failure Text
        
-  625. -- ##Text.>
+  626. -- ##Text.>
        builtin.Text.gt : Text -> Text -> Boolean
        
-  626. -- ##Text.>=
+  627. -- ##Text.>=
        builtin.Text.gteq : Text -> Text -> Boolean
        
-  627. -- ##Text.<
+  628. -- ##Text.<
        builtin.Text.lt : Text -> Text -> Boolean
        
-  628. -- ##Text.<=
+  629. -- ##Text.<=
        builtin.Text.lteq : Text -> Text -> Boolean
        
-  629. -- ##Text.patterns.anyChar
+  630. -- ##Text.patterns.anyChar
        builtin.Text.patterns.anyChar : Pattern Text
        
-  630. -- ##Text.patterns.charIn
+  631. -- ##Text.patterns.charIn
        builtin.Text.patterns.charIn : [Char] -> Pattern Text
        
-  631. -- ##Text.patterns.charRange
+  632. -- ##Text.patterns.charRange
        builtin.Text.patterns.charRange : Char
        -> Char
        -> Pattern Text
        
-  632. -- ##Text.patterns.digit
+  633. -- ##Text.patterns.digit
        builtin.Text.patterns.digit : Pattern Text
        
-  633. -- ##Text.patterns.eof
+  634. -- ##Text.patterns.eof
        builtin.Text.patterns.eof : Pattern Text
        
-  634. -- ##Text.patterns.letter
+  635. -- ##Text.patterns.letter
        builtin.Text.patterns.letter : Pattern Text
        
-  635. -- ##Text.patterns.literal
+  636. -- ##Text.patterns.literal
        builtin.Text.patterns.literal : Text -> Pattern Text
        
-  636. -- ##Text.patterns.notCharIn
+  637. -- ##Text.patterns.notCharIn
        builtin.Text.patterns.notCharIn : [Char] -> Pattern Text
        
-  637. -- ##Text.patterns.notCharRange
+  638. -- ##Text.patterns.notCharRange
        builtin.Text.patterns.notCharRange : Char
        -> Char
        -> Pattern Text
        
-  638. -- ##Text.patterns.punctuation
+  639. -- ##Text.patterns.punctuation
        builtin.Text.patterns.punctuation : Pattern Text
        
-  639. -- ##Text.patterns.space
+  640. -- ##Text.patterns.space
        builtin.Text.patterns.space : Pattern Text
        
-  640. -- ##Text.repeat
+  641. -- ##Text.repeat
        builtin.Text.repeat : Nat -> Text -> Text
        
-  641. -- ##Text.reverse
+  642. -- ##Text.reverse
        builtin.Text.reverse : Text -> Text
        
-  642. -- ##Text.size
+  643. -- ##Text.size
        builtin.Text.size : Text -> Nat
        
-  643. -- ##Text.take
+  644. -- ##Text.take
        builtin.Text.take : Nat -> Text -> Text
        
-  644. -- ##Text.toCharList
+  645. -- ##Text.toCharList
        builtin.Text.toCharList : Text -> [Char]
        
-  645. -- ##Text.toLowercase
+  646. -- ##Text.toLowercase
        builtin.Text.toLowercase : Text -> Text
        
-  646. -- ##Text.toUppercase
+  647. -- ##Text.toUppercase
        builtin.Text.toUppercase : Text -> Text
        
-  647. -- ##Text.toUtf8
+  648. -- ##Text.toUtf8
        builtin.Text.toUtf8 : Text -> Bytes
        
-  648. -- ##Text.uncons
+  649. -- ##Text.uncons
        builtin.Text.uncons : Text -> Optional (Char, Text)
        
-  649. -- ##Text.unsnoc
+  650. -- ##Text.unsnoc
        builtin.Text.unsnoc : Text -> Optional (Text, Char)
        
-  650. -- ##ThreadId.toText
+  651. -- ##ThreadId.toText
        builtin.ThreadId.toText : ThreadId -> Text
        
-  651. -- ##todo
+  652. -- ##todo
        builtin.todo : a -> b
        
-  652. -- #2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8
+  653. -- #2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8
        structural type builtin.Tuple a b
        
-  653. -- #2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8#0
+  654. -- #2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8#0
        builtin.Tuple.Cons : a -> b -> Tuple a b
        
-  654. -- #00nv2kob8fp11qdkr750rlppf81cda95m3q0niohj1pvljnjl4r3hqrhvp1un2p40ptgkhhsne7hocod90r3qdlus9guivh7j3qcq0g
+  655. -- #00nv2kob8fp11qdkr750rlppf81cda95m3q0niohj1pvljnjl4r3hqrhvp1un2p40ptgkhhsne7hocod90r3qdlus9guivh7j3qcq0g
        structural type builtin.Unit
        
-  655. -- #00nv2kob8fp11qdkr750rlppf81cda95m3q0niohj1pvljnjl4r3hqrhvp1un2p40ptgkhhsne7hocod90r3qdlus9guivh7j3qcq0g#0
+  656. -- #00nv2kob8fp11qdkr750rlppf81cda95m3q0niohj1pvljnjl4r3hqrhvp1un2p40ptgkhhsne7hocod90r3qdlus9guivh7j3qcq0g#0
        builtin.Unit.Unit : ()
        
-  656. -- ##Universal.<
+  657. -- ##Universal.<
        builtin.Universal.< : a -> a -> Boolean
        
-  657. -- ##Universal.<=
+  658. -- ##Universal.<=
        builtin.Universal.<= : a -> a -> Boolean
        
-  658. -- ##Universal.==
+  659. -- ##Universal.==
        builtin.Universal.== : a -> a -> Boolean
        
-  659. -- ##Universal.>
+  660. -- ##Universal.>
        builtin.Universal.> : a -> a -> Boolean
        
-  660. -- ##Universal.>=
+  661. -- ##Universal.>=
        builtin.Universal.>= : a -> a -> Boolean
        
-  661. -- ##Universal.compare
+  662. -- ##Universal.compare
        builtin.Universal.compare : a -> a -> Int
        
-  662. -- ##unsafe.coerceAbilities
+  663. -- ##unsafe.coerceAbilities
        builtin.unsafe.coerceAbilities : (a ->{e1} b)
        -> a
        ->{e2} b
        
-  663. -- ##Value
+  664. -- ##Value
        builtin type builtin.Value
        
-  664. -- ##Value.dependencies
+  665. -- ##Value.dependencies
        builtin.Value.dependencies : Value -> [Link.Term]
        
-  665. -- ##Value.deserialize
+  666. -- ##Value.deserialize
        builtin.Value.deserialize : Bytes -> Either Text Value
        
-  666. -- ##Value.load
+  667. -- ##Value.load
        builtin.Value.load : Value ->{IO} Either [Link.Term] a
        
-  667. -- ##Value.serialize
+  668. -- ##Value.serialize
        builtin.Value.serialize : Value -> Bytes
        
-  668. -- ##Value.value
+  669. -- ##Value.value
        builtin.Value.value : a -> Value
        
-  669. -- #dem6aglnj8cppfrnq9qipl7geo5pim3auo9cmv1rhh5la9edalj19sspbpm1pd4vh0plokdh6qfo48gs034dqlg0s7j9fhr9p9ndtpo
+  670. -- #dem6aglnj8cppfrnq9qipl7geo5pim3auo9cmv1rhh5la9edalj19sspbpm1pd4vh0plokdh6qfo48gs034dqlg0s7j9fhr9p9ndtpo
        unique type builtin.Year
        
-  670. -- #dem6aglnj8cppfrnq9qipl7geo5pim3auo9cmv1rhh5la9edalj19sspbpm1pd4vh0plokdh6qfo48gs034dqlg0s7j9fhr9p9ndtpo#0
+  671. -- #dem6aglnj8cppfrnq9qipl7geo5pim3auo9cmv1rhh5la9edalj19sspbpm1pd4vh0plokdh6qfo48gs034dqlg0s7j9fhr9p9ndtpo#0
        builtin.Year.Year : Nat -> Year
        
-  671. -- #k0rcrut9836hr3sevkivq4n2o3t540hllesila69b16gr5fcqe0i6aepqhv2qmso6h22lbipbp3fto0oc8o73l1lvf6vpifi01gmhg8
+  672. -- #k0rcrut9836hr3sevkivq4n2o3t540hllesila69b16gr5fcqe0i6aepqhv2qmso6h22lbipbp3fto0oc8o73l1lvf6vpifi01gmhg8
        cache : [(Link.Term, Code)] ->{IO, Exception} ()
        
-  672. -- #okolgrio28p1mbl1bfjfs9qtsr1m9upblcm3ul872gcir6epkcbq619vk5bdq1fnr371nelsof6jsp8469g4j6f0gg3007p79o4kf18
+  673. -- #okolgrio28p1mbl1bfjfs9qtsr1m9upblcm3ul872gcir6epkcbq619vk5bdq1fnr371nelsof6jsp8469g4j6f0gg3007p79o4kf18
        check : Text -> Boolean ->{Stream Result} ()
        
-  673. -- #je42vk6rsefjlup01e1fmmdssf5i3ba9l6aka3bipggetfm8o4i8d1q5d7hddggu5jure1bu5ot8aq5in31to4788ctrtpb44ri83r8
+  674. -- #je42vk6rsefjlup01e1fmmdssf5i3ba9l6aka3bipggetfm8o4i8d1q5d7hddggu5jure1bu5ot8aq5in31to4788ctrtpb44ri83r8
        checks : [Boolean] -> [Result]
        
-  674. -- #barg6v1n15ea1qhp80i77gjjq3vu1noc67q2jkv9n6n5v0c9djup70ltauujgpfe0kuo8ckd20gc9kutngdpb8d22rubtb5rjldrb3o
+  675. -- #barg6v1n15ea1qhp80i77gjjq3vu1noc67q2jkv9n6n5v0c9djup70ltauujgpfe0kuo8ckd20gc9kutngdpb8d22rubtb5rjldrb3o
        clientSocket : Text -> Text ->{IO, Exception} Socket
        
-  675. -- #lg7i12ido0jr43ovdbhhv2enpk5ar869leouri5qhrivinde93nl86s2rgshubtfhlogbe310k3rluotscmus9moo1tvpn0nmp1efv8
+  676. -- #lg7i12ido0jr43ovdbhhv2enpk5ar869leouri5qhrivinde93nl86s2rgshubtfhlogbe310k3rluotscmus9moo1tvpn0nmp1efv8
        closeFile : Handle ->{IO, Exception} ()
        
-  676. -- #4e6qn65v05l32n380lpf536u4llnp6f6tvvt13hvo0bhqeh3f3i8bquekc120c8h59gld1mf02ok0sje7037ipg1fsu97fqrm01oi00
+  677. -- #4e6qn65v05l32n380lpf536u4llnp6f6tvvt13hvo0bhqeh3f3i8bquekc120c8h59gld1mf02ok0sje7037ipg1fsu97fqrm01oi00
        closeSocket : Socket ->{IO, Exception} ()
        
-  677. -- #7o1e77u808vpg8i6k1mvutg8h6tdr14hegfad23e9sjou1ft10kvfr95goo0kv2ldqlsaa4pmvdl8d7jd6h252i3jija05b4vpqbg5g
+  678. -- #7o1e77u808vpg8i6k1mvutg8h6tdr14hegfad23e9sjou1ft10kvfr95goo0kv2ldqlsaa4pmvdl8d7jd6h252i3jija05b4vpqbg5g
        Code.transitiveDeps : Link.Term
        ->{IO} [(Link.Term, Code)]
        
-  678. -- #sfud7h76up0cofgk61b7tf8rhdlugfmg44lksnpglfes1b8po26si7betka39r9j8dpgueorjdrb1i7v4g62m5bci1e971eqi8dblmo
+  679. -- #sfud7h76up0cofgk61b7tf8rhdlugfmg44lksnpglfes1b8po26si7betka39r9j8dpgueorjdrb1i7v4g62m5bci1e971eqi8dblmo
        compose : ∀ o g1 i1 g i.
          (i1 ->{g1} o) -> (i ->{g} i1) -> i ->{g1, g} o
        
-  679. -- #b0tsob9a3fegn5dkb57jh15smd7ho2qo78st6qngpa7a8hc88mccl7vhido41o4otokv5l8hjdj3nabtkmpni5ikeatd44agmqbhano
+  680. -- #b0tsob9a3fegn5dkb57jh15smd7ho2qo78st6qngpa7a8hc88mccl7vhido41o4otokv5l8hjdj3nabtkmpni5ikeatd44agmqbhano
        compose2 : ∀ o g2 i2 g1 g i i1.
          (i2 ->{g2} o)
          -> (i1 ->{g1} i ->{g} i2)
@@ -2384,7 +2387,7 @@ This transcript is intended to make visible accidental changes to the hashing al
          -> i
          ->{g2, g1, g} o
        
-  680. -- #m632ocgh2rougfejkddsso3vfpf4dmg1f8bhf0k6sha4g4aqfmbeuct3eo0je6dv9utterfvotjdu32p0kojuo9fj4qkp2g1bt464eg
+  681. -- #m632ocgh2rougfejkddsso3vfpf4dmg1f8bhf0k6sha4g4aqfmbeuct3eo0je6dv9utterfvotjdu32p0kojuo9fj4qkp2g1bt464eg
        compose3 : ∀ o g3 i3 g2 g1 g i i1 i2.
          (i3 ->{g3} o)
          -> (i2 ->{g2} i1 ->{g1} i ->{g} i3)
@@ -2393,318 +2396,318 @@ This transcript is intended to make visible accidental changes to the hashing al
          -> i
          ->{g3, g2, g1, g} o
        
-  681. -- #ilkeid6l866bmq90d2v1ilqp9dsjo6ucmf8udgrokq3nr3mo9skl2vao2mo7ish136as52rsf19u9v3jkmd85bl08gnmamo4e5v2fqo
+  682. -- #ilkeid6l866bmq90d2v1ilqp9dsjo6ucmf8udgrokq3nr3mo9skl2vao2mo7ish136as52rsf19u9v3jkmd85bl08gnmamo4e5v2fqo
        contains : Text -> Text -> Boolean
        
-  682. -- #tgvna0i8ea98jvnd2oka85cdtas1prcbq3snvc4qfns6082mlckps2cspk8jln11mklg19bna025tog5m9sb671o27ujsa90lfrbnkg
+  683. -- #tgvna0i8ea98jvnd2oka85cdtas1prcbq3snvc4qfns6082mlckps2cspk8jln11mklg19bna025tog5m9sb671o27ujsa90lfrbnkg
        crawl : [(Link.Term, Code)]
        -> [Link.Term]
        ->{IO} [(Link.Term, Code)]
        
-  683. -- #o0qn048fk7tjb8e7d54vq5mg9egr5kophb9pcm0to4aj0kf39mv76c6olsm27vj309d7nhjh4nps7098fpvqe8j5cfg01ghf3bnju90
+  684. -- #o0qn048fk7tjb8e7d54vq5mg9egr5kophb9pcm0to4aj0kf39mv76c6olsm27vj309d7nhjh4nps7098fpvqe8j5cfg01ghf3bnju90
        createTempDirectory : Text ->{IO, Exception} Text
        
-  684. -- #4858f4krb9l4ot1hml21j48lp3bcvbo8b9unlk33b9a3ovu1jrbr1k56pnfhffkiu1bht2ovh0i82nn5jnoc5s5ru85qvua0m2ol43g
+  685. -- #4858f4krb9l4ot1hml21j48lp3bcvbo8b9unlk33b9a3ovu1jrbr1k56pnfhffkiu1bht2ovh0i82nn5jnoc5s5ru85qvua0m2ol43g
        decodeCert : Bytes ->{Exception} SignedCert
        
-  685. -- #ihbmfc4r7o3391jocjm6v4mojpp3hvt84ivqigrmp34vb5l3d7mmdlvh3hkrtebi812npso7rqo203a59pbs7r2g78ig6jvsv0nva38
+  686. -- #ihbmfc4r7o3391jocjm6v4mojpp3hvt84ivqigrmp34vb5l3d7mmdlvh3hkrtebi812npso7rqo203a59pbs7r2g78ig6jvsv0nva38
        delay : Nat ->{IO, Exception} ()
        
-  686. -- #dsen29k7605pkfquesnaphhmlm3pjkfgm7m2oc90m53gqvob4l39p4g3id3pirl8emg5tcdmr81ctl3lk1enm52mldlfmlh1i85rjbg
+  687. -- #dsen29k7605pkfquesnaphhmlm3pjkfgm7m2oc90m53gqvob4l39p4g3id3pirl8emg5tcdmr81ctl3lk1enm52mldlfmlh1i85rjbg
        directoryContents : Text ->{IO, Exception} [Text]
        
-  687. -- #b22tpqhkq6kvt27dcsddnbfci2bcqutvhmumdven9c5psiilboq2mb8v9ekihtkl6mkartd5ml5u75u84v850n29l91de63lkg3ud38
+  688. -- #b22tpqhkq6kvt27dcsddnbfci2bcqutvhmumdven9c5psiilboq2mb8v9ekihtkl6mkartd5ml5u75u84v850n29l91de63lkg3ud38
        Either.isLeft : Either a b -> Boolean
        
-  688. -- #i1ec3csomb1pegm9r7ppabunabb7cq1t6bb6cvqtt72nd01jot7gde2mak288cbml910abbtho0smsbq17b2r33j599b0vuv7je04j8
+  689. -- #i1ec3csomb1pegm9r7ppabunabb7cq1t6bb6cvqtt72nd01jot7gde2mak288cbml910abbtho0smsbq17b2r33j599b0vuv7je04j8
        Either.mapLeft : (i ->{g} o)
        -> Either i b
        ->{g} Either o b
        
-  689. -- #f765l0pa2tb9ieciivum76s7bp8rdjr8j7i635jjenj9tacgba9eeomur4vv3uuh4kem1pggpmrn61a1e3im9g90okcm13r192f7alg
+  690. -- #f765l0pa2tb9ieciivum76s7bp8rdjr8j7i635jjenj9tacgba9eeomur4vv3uuh4kem1pggpmrn61a1e3im9g90okcm13r192f7alg
        Either.raiseMessage : v -> Either Text b ->{Exception} b
        
-  690. -- #9hifem8o2e1g7tdh4om9kfo98ifr60gfmdp8ci58djn17epm1b4m6idli8b373bsrg487n87n4l50ksq76avlrbh9q2jpobkk18ucvg
+  691. -- #9hifem8o2e1g7tdh4om9kfo98ifr60gfmdp8ci58djn17epm1b4m6idli8b373bsrg487n87n4l50ksq76avlrbh9q2jpobkk18ucvg
        evalTest : '{IO, TempDirs, Exception, Stream Result} a
        ->{IO, Exception} ([Result], a)
        
-  691. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng
+  692. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng
        structural ability Exception
        structural ability builtin.Exception
        
-  692. -- #t20uuuiil07o22les8gv4sji7ju5esevloamnja3bjkrh2f250lgitv6595l6hlc2q64c1om0hhjqgter28dtnibb0dkr2j7e3ss530
+  693. -- #t20uuuiil07o22les8gv4sji7ju5esevloamnja3bjkrh2f250lgitv6595l6hlc2q64c1om0hhjqgter28dtnibb0dkr2j7e3ss530
        Exception.catch : '{g, Exception} a
        ->{g} Either Failure a
        
-  693. -- #hbhvk2e00l6o7qhn8e7p6dc36bjl7ljm0gn2df5clidlrdoufsig1gt5pjhg72kl67folgg2b892kh9jc1oh0l79h4p8dqhcf1tkde0
+  694. -- #hbhvk2e00l6o7qhn8e7p6dc36bjl7ljm0gn2df5clidlrdoufsig1gt5pjhg72kl67folgg2b892kh9jc1oh0l79h4p8dqhcf1tkde0
        Exception.failure : Text -> a -> Failure
        
-  694. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng#0
+  695. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng#0
        Exception.raise,
        builtin.Exception.raise : Failure
        ->{Exception} x
        
-  695. -- #5mqjoauctm02dlqdc10cc66relu40997d6o1u8fj7vv7g0i2mtacjc83afqhuekll1gkqr9vv4lq7aenanq4kf53kcce4l1srr6ip08
+  696. -- #5mqjoauctm02dlqdc10cc66relu40997d6o1u8fj7vv7g0i2mtacjc83afqhuekll1gkqr9vv4lq7aenanq4kf53kcce4l1srr6ip08
        Exception.reraise : Either Failure a ->{Exception} a
        
-  696. -- #1f774ia7im9i0cfp7l5a1g9tkvnd4m2940ga3buaf4ekd43dr1289vknghjjvi4qtevh7s61p5s573gpli51qh7e0i5pj9ggmeb69d0
+  697. -- #1f774ia7im9i0cfp7l5a1g9tkvnd4m2940ga3buaf4ekd43dr1289vknghjjvi4qtevh7s61p5s573gpli51qh7e0i5pj9ggmeb69d0
        Exception.toEither : '{ε, Exception} a
        ->{ε} Either Failure a
        
-  697. -- #li2h4hncbgmfi5scuah06rtdt8rjcipiv2t95hos15ol63usv78ti3vng7o9862a70906rum7nrrs9qd9q8iqu1rdcfe292r0al7n38
+  698. -- #li2h4hncbgmfi5scuah06rtdt8rjcipiv2t95hos15ol63usv78ti3vng7o9862a70906rum7nrrs9qd9q8iqu1rdcfe292r0al7n38
        Exception.toEither.handler : Request {Exception} a
        -> Either Failure a
        
-  698. -- #5fi0ep8mufag822f18ukaffakrmm3ddg8a83dkj4gh2ks4e2c60sk9s8pmk92p69bvkcflql3rgoalp8ruth7fapqrks3kbmdl61b00
+  699. -- #5fi0ep8mufag822f18ukaffakrmm3ddg8a83dkj4gh2ks4e2c60sk9s8pmk92p69bvkcflql3rgoalp8ruth7fapqrks3kbmdl61b00
        Exception.unsafeRun! : '{g, Exception} a ->{g} a
        
-  699. -- #qdcih6h4dmf9a2tn2ndvn0br9ef41ubhcniadou1m6ro641gm2tn79m6boh5sr4q271oiui6ehbdqe53r0gobdeagotkjr67kieq3ro
+  700. -- #qdcih6h4dmf9a2tn2ndvn0br9ef41ubhcniadou1m6ro641gm2tn79m6boh5sr4q271oiui6ehbdqe53r0gobdeagotkjr67kieq3ro
        expect : Text
        -> (a -> a -> Boolean)
        -> a
        -> a
        ->{Stream Result} ()
        
-  700. -- #ngmnbge6f7nkehkkhj6rkit60rp3qlt0vij33itch1el3ta2ukrit4gvpn2n0j0s43sj9af53kphgs0h2n65bnqcr9pmasud2r7klsg
+  701. -- #ngmnbge6f7nkehkkhj6rkit60rp3qlt0vij33itch1el3ta2ukrit4gvpn2n0j0s43sj9af53kphgs0h2n65bnqcr9pmasud2r7klsg
        expectU : Text -> a -> a ->{Stream Result} ()
        
-  701. -- #f54plhut9f6mg77r1f033vubik89irq1eri79d5pd6mqi03rq9em99mc90plurvjnmvho73ssof5fvndgmcg4fgrpvuuil7hb5qmebo
+  702. -- #f54plhut9f6mg77r1f033vubik89irq1eri79d5pd6mqi03rq9em99mc90plurvjnmvho73ssof5fvndgmcg4fgrpvuuil7hb5qmebo
        fail : Text -> b ->{Exception} c
        
-  702. -- #mpe805fs330vqp5l5mg73deahken20dub4hrfvmuutfo97dikgagvimncfr6mfp1l24bjqes1m1dp11a3hop92u49b1fb45j8qs9hoo
+  703. -- #mpe805fs330vqp5l5mg73deahken20dub4hrfvmuutfo97dikgagvimncfr6mfp1l24bjqes1m1dp11a3hop92u49b1fb45j8qs9hoo
        fileExists : Text ->{IO, Exception} Boolean
        
-  703. -- #cft2pjc05jljtlefm4osg96k5t2look2ujq1tgg5hoc5i3fkkatt9pf79g2ka461kq8nbmsggrvo2675ocl599to9e8nre5oef4scdo
+  704. -- #cft2pjc05jljtlefm4osg96k5t2look2ujq1tgg5hoc5i3fkkatt9pf79g2ka461kq8nbmsggrvo2675ocl599to9e8nre5oef4scdo
        fromB32 : Bytes ->{Exception} Bytes
        
-  704. -- #13fpchr37ua0pr38ssr7j22pudmseuedf490aok18upagh0f00kg40guj9pgl916v9qurqrvu53f3lpsvi0s82hg3dtjacanrpjvs38
+  705. -- #13fpchr37ua0pr38ssr7j22pudmseuedf490aok18upagh0f00kg40guj9pgl916v9qurqrvu53f3lpsvi0s82hg3dtjacanrpjvs38
        fromHex : Text -> Bytes
        
-  705. -- #b36oslvh534s82lda0ghc5ql7p7nir0tknsluigulmpso22tjh62uiiq4lq9s3m97a2grkso0qofpb423p06olkkikrt4mfn15vpkug
+  706. -- #b36oslvh534s82lda0ghc5ql7p7nir0tknsluigulmpso22tjh62uiiq4lq9s3m97a2grkso0qofpb423p06olkkikrt4mfn15vpkug
        getBuffering : Handle ->{IO, Exception} BufferMode
        
-  706. -- #9vijttgmba0ui9cshmhmmvgn6ve2e95t168766h2n6pkviddebiimgipic5dbg5lmiht12g6np8a7e06jpk03rnue3ln5mbo4prde0g
+  707. -- #9vijttgmba0ui9cshmhmmvgn6ve2e95t168766h2n6pkviddebiimgipic5dbg5lmiht12g6np8a7e06jpk03rnue3ln5mbo4prde0g
        getBytes : Handle -> Nat ->{IO, Exception} Bytes
        
-  707. -- #c5oeqqglf28ungtq1im4fjdh317eeoba4537l1ntq3ob22v07rpgj9307udscbghlrior398hqm1ci099qmriim8cs975kocacsd9r0
+  708. -- #c5oeqqglf28ungtq1im4fjdh317eeoba4537l1ntq3ob22v07rpgj9307udscbghlrior398hqm1ci099qmriim8cs975kocacsd9r0
        getChar : Handle ->{IO, Exception} Char
        
-  708. -- #j9jdo2pqvi4aktcfsb0n4ns1tk2be7dtckqdeedqp7n52oghsq82cgc1tv562rj1sf1abq2h0vta4uo6873cdbgrtrvd5cvollu3ovo
+  709. -- #j9jdo2pqvi4aktcfsb0n4ns1tk2be7dtckqdeedqp7n52oghsq82cgc1tv562rj1sf1abq2h0vta4uo6873cdbgrtrvd5cvollu3ovo
        getEcho : Handle ->{IO, Exception} Boolean
        
-  709. -- #0hj09gufk8fs2hvr6qij6pie8bp0h6hmm6hpsi8d5fvl1fp1dbk6u8c9p6h4eu2hle6ctgpdbepo9vit5atllkodogn6r0csar9fn1g
+  710. -- #0hj09gufk8fs2hvr6qij6pie8bp0h6hmm6hpsi8d5fvl1fp1dbk6u8c9p6h4eu2hle6ctgpdbepo9vit5atllkodogn6r0csar9fn1g
        getLine : Handle ->{IO, Exception} Text
        
-  710. -- #ck1nfg5fainelng0694jkdf9e06pmn60h7kvble1ff7hkc6jdgqtf7g5o3qevr7ic1bdhfn5n2rc3gde5bh6o9fpbit3ocs0av0scdg
+  711. -- #ck1nfg5fainelng0694jkdf9e06pmn60h7kvble1ff7hkc6jdgqtf7g5o3qevr7ic1bdhfn5n2rc3gde5bh6o9fpbit3ocs0av0scdg
        getSomeBytes : Handle -> Nat ->{IO, Exception} Bytes
        
-  711. -- #bk29bjnrcuh55usf3vocm4j1aml161p6ila7t82cpr3ub9vu0g9lsg2mspmfuefc4ig0qtdqk7nds4t3f68jp6o77e0h4ltbitqjpno
+  712. -- #bk29bjnrcuh55usf3vocm4j1aml161p6ila7t82cpr3ub9vu0g9lsg2mspmfuefc4ig0qtdqk7nds4t3f68jp6o77e0h4ltbitqjpno
        getTempDirectory : '{IO, Exception} Text
        
-  712. -- #j8i534slc2rvakvmqcb6j28iatrh3d7btajai9qndutr0edi5aaoi2p5noditaococ4l104hdhhvjc5vr0rbcjoqrbng46fdeqtnf98
+  713. -- #j8i534slc2rvakvmqcb6j28iatrh3d7btajai9qndutr0edi5aaoi2p5noditaococ4l104hdhhvjc5vr0rbcjoqrbng46fdeqtnf98
        handlePosition : Handle ->{IO, Exception} Nat
        
-  713. -- #bgf7sqs0h0p8bhm3t2ei8006oj1gjonvtkdejv2g9kar0kmvob9e88ceevdfh99jom9rs0hbalf1gut5juanudfcb8tpb1e9ta0vrm8
+  714. -- #bgf7sqs0h0p8bhm3t2ei8006oj1gjonvtkdejv2g9kar0kmvob9e88ceevdfh99jom9rs0hbalf1gut5juanudfcb8tpb1e9ta0vrm8
        handshake : Tls ->{IO, Exception} ()
        
-  714. -- #128490j1tmitiu3vesv97sqspmefobg1am38vos9p0vt4s1bhki87l7kj4cctquffkp40eanmr9ummfglj9i7s25jrpb32ob5sf2tio
+  715. -- #128490j1tmitiu3vesv97sqspmefobg1am38vos9p0vt4s1bhki87l7kj4cctquffkp40eanmr9ummfglj9i7s25jrpb32ob5sf2tio
        hex : Bytes -> Text
        
-  715. -- #ttjui80dbufvf3vgaddmcr065dpgl0rtp68i5cdht6tq4t2vk3i2vg60hi77rug368qijgijf8oui27te7o5oq0t0osm6dg65c080i0
+  716. -- #ttjui80dbufvf3vgaddmcr065dpgl0rtp68i5cdht6tq4t2vk3i2vg60hi77rug368qijgijf8oui27te7o5oq0t0osm6dg65c080i0
        id : a -> a
        
-  716. -- #9qnapjbbdhcc2mjf1b0slm7mefu0idnj1bs4c5bckq42ruodftolnd193uehr31lc01air6d6b3j4ihurnks13n85h3r8rs16nqvj2g
+  717. -- #9qnapjbbdhcc2mjf1b0slm7mefu0idnj1bs4c5bckq42ruodftolnd193uehr31lc01air6d6b3j4ihurnks13n85h3r8rs16nqvj2g
        isDirectory : Text ->{IO, Exception} Boolean
        
-  717. -- #vb1e252fqt0q63hpmtkq2bkg5is2n6thejofnev96040thle5o1ia8dtq7dc6v359gtoqugbqg5tb340aqovrfticb63jgei4ncq3j8
+  718. -- #vb1e252fqt0q63hpmtkq2bkg5is2n6thejofnev96040thle5o1ia8dtq7dc6v359gtoqugbqg5tb340aqovrfticb63jgei4ncq3j8
        isFileEOF : Handle ->{IO, Exception} Boolean
        
-  718. -- #ahkhlm9sd7arpevos99sqc90g7k5nn9bj5n0lhh82c1uva52ltv0295ugc123l17vd1orkng061e11knqjnmk087qjg3vug3rs6mv60
+  719. -- #ahkhlm9sd7arpevos99sqc90g7k5nn9bj5n0lhh82c1uva52ltv0295ugc123l17vd1orkng061e11knqjnmk087qjg3vug3rs6mv60
        isFileOpen : Handle ->{IO, Exception} Boolean
        
-  719. -- #2a11371klrv2i8726knma0l3g14on4m2ucihpg65cjj9k930aefg65ovvg0ak4uv3i9evtnu0a5249q3i8ugheqd65cnmgquc1a88n0
+  720. -- #2a11371klrv2i8726knma0l3g14on4m2ucihpg65cjj9k930aefg65ovvg0ak4uv3i9evtnu0a5249q3i8ugheqd65cnmgquc1a88n0
        isNone : Optional a -> Boolean
        
-  720. -- #ln4avnqpdk7813vsrrr414hg0smcmufrl1c7b87nb7nb0h9cogp6arqa7fbgd7rgolffmgue698ovvefo18j1k8g30t4hbp23onm3l8
+  721. -- #ln4avnqpdk7813vsrrr414hg0smcmufrl1c7b87nb7nb0h9cogp6arqa7fbgd7rgolffmgue698ovvefo18j1k8g30t4hbp23onm3l8
        isSeekable : Handle ->{IO, Exception} Boolean
        
-  721. -- #gop2v9s6l24ii1v6bf1nks2h0h18pato0vbsf4u3el18s7mp1jfnp4c7fesdf9sunnlv5f5a9fjr1s952pte87mf63l1iqki9bp0mio
+  722. -- #gop2v9s6l24ii1v6bf1nks2h0h18pato0vbsf4u3el18s7mp1jfnp4c7fesdf9sunnlv5f5a9fjr1s952pte87mf63l1iqki9bp0mio
        List.all : (a ->{ε} Boolean) -> [a] ->{ε} Boolean
        
-  722. -- #m2g5korqq5etr0qk1qrgjbaqktj4ks4bu9m3c4v3j9g8ktsd2e218nml6q8vo45bi3meb53csack40mle6clfrfep073e313b3jagt0
+  723. -- #m2g5korqq5etr0qk1qrgjbaqktj4ks4bu9m3c4v3j9g8ktsd2e218nml6q8vo45bi3meb53csack40mle6clfrfep073e313b3jagt0
        List.filter : (a ->{g} Boolean) -> [a] ->{g} [a]
        
-  723. -- #8s836vq5jggucs6bj3bear30uhe6h9cskudjrdc772ghiec6ce2jqft09l1n05kd1n6chekrbgt0h8mkc9drgscjvgghacojm9e8c5o
+  724. -- #8s836vq5jggucs6bj3bear30uhe6h9cskudjrdc772ghiec6ce2jqft09l1n05kd1n6chekrbgt0h8mkc9drgscjvgghacojm9e8c5o
        List.foldLeft : (b ->{g} a ->{g} b) -> b -> [a] ->{g} b
        
-  724. -- #m5tlb5a0m4kp5b4m9oq9vhda9d7nhu2obn2lpmosal0ebij9gon4gkd1aq0b3b61jtsc1go0hi7b2sm2memtil55ijq32b2n0k39vko
+  725. -- #m5tlb5a0m4kp5b4m9oq9vhda9d7nhu2obn2lpmosal0ebij9gon4gkd1aq0b3b61jtsc1go0hi7b2sm2memtil55ijq32b2n0k39vko
        List.forEach : [a] -> (a ->{e} ()) ->{e} ()
        
-  725. -- #j9ve4ionu2sn7f814t0t4gc75objke2drgnfvvvb50v2f57ss0hlsa3ai5g5jsk2t4b8s37ocrtmte7nktfb2vjf8508ksvrc6llu30
+  726. -- #j9ve4ionu2sn7f814t0t4gc75objke2drgnfvvvb50v2f57ss0hlsa3ai5g5jsk2t4b8s37ocrtmte7nktfb2vjf8508ksvrc6llu30
        listen : Socket ->{IO, Exception} ()
        
-  726. -- #s0f4et1o1ns8cmmvp3i0cm6cmmv5qaf99qm2q4jmgpciof6ntmuh3mpr4epns3ocskn8raacbvm30ovvj2b6arv0ff7iks31rannbf0
+  727. -- #s0f4et1o1ns8cmmvp3i0cm6cmmv5qaf99qm2q4jmgpciof6ntmuh3mpr4epns3ocskn8raacbvm30ovvj2b6arv0ff7iks31rannbf0
        loadCodeBytes : Bytes ->{Exception} Code
        
-  727. -- #gvaed1m07qihc9c216125sur1q9a7i5ita44qnevongg4jrbd8k2plsqhdur45nn6h3drn6lc3iidp1b208ht8s73fg2711l76c7j4g
+  728. -- #gvaed1m07qihc9c216125sur1q9a7i5ita44qnevongg4jrbd8k2plsqhdur45nn6h3drn6lc3iidp1b208ht8s73fg2711l76c7j4g
        loadSelfContained : Text ->{IO, Exception} a
        
-  728. -- #g1hqlq27e3stamnnfp6q178pleeml9sbo2d6scj2ikubocane5cvf8ctausoqrgj9co9h56ttgt179sgktc0bei2r37dmtj51jg0ou8
+  729. -- #g1hqlq27e3stamnnfp6q178pleeml9sbo2d6scj2ikubocane5cvf8ctausoqrgj9co9h56ttgt179sgktc0bei2r37dmtj51jg0ou8
        loadValueBytes : Bytes
        ->{IO, Exception} ([(Link.Term, Code)], Value)
        
-  729. -- #tlllu51stumo77vi2e5m0e8m05qletfbr3nea3d84dcgh66dq4s3bt7kdbf8mpdqh16mmnoh11kr3n43m8b5g4pf95l9gfbhhok1h20
+  730. -- #tlllu51stumo77vi2e5m0e8m05qletfbr3nea3d84dcgh66dq4s3bt7kdbf8mpdqh16mmnoh11kr3n43m8b5g4pf95l9gfbhhok1h20
        MVar.put : MVar i -> i ->{IO, Exception} ()
        
-  730. -- #3b7lp7s9m31mcvh73nh4gfj1kal6onrmppf35esvmma4jsg7bbm7a8tsrfcb4te88f03r97dkf7n1f2kcc6o7ng4vurp95svfj2fg7o
+  731. -- #3b7lp7s9m31mcvh73nh4gfj1kal6onrmppf35esvmma4jsg7bbm7a8tsrfcb4te88f03r97dkf7n1f2kcc6o7ng4vurp95svfj2fg7o
        MVar.read : MVar o ->{IO, Exception} o
        
-  731. -- #be8m7lsjnf31u87pt5rvn04c9ellhbm3p56jgapbp8k7qp0v3mm7beh81luoifp17681l0ldjj46gthmmu32lkn0jnejr3tedjotntg
+  732. -- #be8m7lsjnf31u87pt5rvn04c9ellhbm3p56jgapbp8k7qp0v3mm7beh81luoifp17681l0ldjj46gthmmu32lkn0jnejr3tedjotntg
        MVar.swap : MVar o -> o ->{IO, Exception} o
        
-  732. -- #c2qb0ca2dj3rronbp4slj3ph56p0iopaos7ib37hjunpkl1rcl1gp820dpg8qflhvt9cm2l1bfm40rkdslce2sr6f0oru5lr5cl5nu0
+  733. -- #c2qb0ca2dj3rronbp4slj3ph56p0iopaos7ib37hjunpkl1rcl1gp820dpg8qflhvt9cm2l1bfm40rkdslce2sr6f0oru5lr5cl5nu0
        MVar.take : MVar o ->{IO, Exception} o
        
-  733. -- #ht0k9hb3k1cnjsgmtu9klivo074a2uro4csh63m1sqr2483rkojlj7abcf0jfmssbfig98i6is1osr2djoqubg3bp6articvq9o8090
+  734. -- #ht0k9hb3k1cnjsgmtu9klivo074a2uro4csh63m1sqr2483rkojlj7abcf0jfmssbfig98i6is1osr2djoqubg3bp6articvq9o8090
        newClient : ClientConfig -> Socket ->{IO, Exception} Tls
        
-  734. -- #coeloqmjin6lais8u6j0plh5f1601lpcue4ejfcute46opams4vsbkplqj6jg6af0uecjie3mbclv40b3jumghsf09aavvucrc0d148
+  735. -- #coeloqmjin6lais8u6j0plh5f1601lpcue4ejfcute46opams4vsbkplqj6jg6af0uecjie3mbclv40b3jumghsf09aavvucrc0d148
        newServer : ServerConfig -> Socket ->{IO, Exception} Tls
        
-  735. -- #ocvo5mvs8fghsf715tt4mhpj1pu8e8r7pq9nue63ut0ol2vnv70k7t6tavtsljlmdib9lo3bt669qac94dk53ldcgtukvotvrlfkan0
+  736. -- #ocvo5mvs8fghsf715tt4mhpj1pu8e8r7pq9nue63ut0ol2vnv70k7t6tavtsljlmdib9lo3bt669qac94dk53ldcgtukvotvrlfkan0
        openFile : Text -> FileMode ->{IO, Exception} Handle
        
-  736. -- #c58qbcgd90d965dokk7bu82uehegkbe8jttm7lv4j0ohgi2qm3e3p4v1qfr8vc2dlsmsl9tv0v71kco8c18mneule0ntrhte4ks1090
+  737. -- #c58qbcgd90d965dokk7bu82uehegkbe8jttm7lv4j0ohgi2qm3e3p4v1qfr8vc2dlsmsl9tv0v71kco8c18mneule0ntrhte4ks1090
        printLine : Text ->{IO, Exception} ()
        
-  737. -- #dck7pb7qv05ol3b0o76l88a22bc7enl781ton5qbs2umvgsua3p16n22il02m29592oohsnbt3cr7hnlumpdhv2ibjp6iji9te4iot0
+  738. -- #dck7pb7qv05ol3b0o76l88a22bc7enl781ton5qbs2umvgsua3p16n22il02m29592oohsnbt3cr7hnlumpdhv2ibjp6iji9te4iot0
        printText : Text ->{IO} Either Failure ()
        
-  738. -- #i9lm1g1j0p4qtakg164jdlgac409sgj1cb91k86k0c44ssajbluovuu7ptm5uc20sjgedjbak3iji8o859ek871ul51b8l30s4uf978
+  739. -- #i9lm1g1j0p4qtakg164jdlgac409sgj1cb91k86k0c44ssajbluovuu7ptm5uc20sjgedjbak3iji8o859ek871ul51b8l30s4uf978
        putBytes : Handle -> Bytes ->{IO, Exception} ()
        
-  739. -- #84j6ua3924v85vh2a581de7sd8pee1lqbp1ibvatvjtui9hvk36sv2riabu0v2r0s25p62ipnvv4aeadpg0u8m5ffqrc202i71caopg
+  740. -- #84j6ua3924v85vh2a581de7sd8pee1lqbp1ibvatvjtui9hvk36sv2riabu0v2r0s25p62ipnvv4aeadpg0u8m5ffqrc202i71caopg
        readFile : Text ->{IO, Exception} Bytes
        
-  740. -- #pk003cv7lvidkbmsnne4mpt20254gh4hd7vvretnbk8na8bhr9fg9776rp8pt9srhiucrd1c7sjl006vmil9e78p40gdcir81ujil2o
+  741. -- #pk003cv7lvidkbmsnne4mpt20254gh4hd7vvretnbk8na8bhr9fg9776rp8pt9srhiucrd1c7sjl006vmil9e78p40gdcir81ujil2o
        ready : Handle ->{IO, Exception} Boolean
        
-  741. -- #unn7qak4qe0nbbpf62uesu0fe8i68o83l4o7f6jcblefbla53fef7a63ts28fh6ql81o5c04j44g7m5rq9aouo73dpeprbl5lka8170
+  742. -- #unn7qak4qe0nbbpf62uesu0fe8i68o83l4o7f6jcblefbla53fef7a63ts28fh6ql81o5c04j44g7m5rq9aouo73dpeprbl5lka8170
        receive : Tls ->{IO, Exception} Bytes
        
-  742. -- #ugs4208vpm97jr2ecmr7l9h4e22r1ije6v379m4v6229c8o7hk669ba63bor4pe6n1bm24il87iq2d99sj78lt6n5eqa1fre0grn93g
+  743. -- #ugs4208vpm97jr2ecmr7l9h4e22r1ije6v379m4v6229c8o7hk669ba63bor4pe6n1bm24il87iq2d99sj78lt6n5eqa1fre0grn93g
        removeDirectory : Text ->{IO, Exception} ()
        
-  743. -- #6pia69u5u5rja1jk04v3i9ke24gf4b1t7vnaj0noogord6ekiqhf72qfkc1n08rd11f2cbkofni5rd5u7t1qkgslbi40hut35pfi1v0
+  744. -- #6pia69u5u5rja1jk04v3i9ke24gf4b1t7vnaj0noogord6ekiqhf72qfkc1n08rd11f2cbkofni5rd5u7t1qkgslbi40hut35pfi1v0
        renameDirectory : Text -> Text ->{IO, Exception} ()
        
-  744. -- #amtsq2jq1k75r309esfp800a8slelm4d3q9i1pq1qqs3pil13at916958sf9ucb4607kpktbnup7nc58ecoq8mcs01e2a03d08agn18
+  745. -- #amtsq2jq1k75r309esfp800a8slelm4d3q9i1pq1qqs3pil13at916958sf9ucb4607kpktbnup7nc58ecoq8mcs01e2a03d08agn18
        runTest : '{IO, TempDirs, Exception, Stream Result} a
        ->{IO} [Result]
        
-  745. -- #va4fcp72qog4dvo8dn4gipr2i1big1lqgpcqfuv9kc98ut8le1bj23s68df7svam7b5sg01s4uf95o458f4rs90mtp71nj84t90ra1o
+  746. -- #va4fcp72qog4dvo8dn4gipr2i1big1lqgpcqfuv9kc98ut8le1bj23s68df7svam7b5sg01s4uf95o458f4rs90mtp71nj84t90ra1o
        saveSelfContained : a -> Text ->{IO, Exception} ()
        
-  746. -- #5hbn4gflbo8l4jq0s9l1r0fpee6ie44fbbl6j6km67l25inaaq5avg18g7j6mig2m6eaod04smif7el34tcclvvf8oll39rfonupt2o
+  747. -- #5hbn4gflbo8l4jq0s9l1r0fpee6ie44fbbl6j6km67l25inaaq5avg18g7j6mig2m6eaod04smif7el34tcclvvf8oll39rfonupt2o
        saveTestCase : Text
        -> (a -> Text)
        -> a
        ->{IO, Exception} ()
        
-  747. -- #v2otbk1e0e81d6ea9i3j1kivnfam6rk6earsjbjljv4mmrk1mgfals6jhfd74evor6al9mkb5gv8hf15f02807f0aa0hnsg9fas1qco
+  748. -- #v2otbk1e0e81d6ea9i3j1kivnfam6rk6earsjbjljv4mmrk1mgfals6jhfd74evor6al9mkb5gv8hf15f02807f0aa0hnsg9fas1qco
        seekHandle : Handle
        -> SeekMode
        -> Int
        ->{IO, Exception} ()
        
-  748. -- #a98jlos4rj2um55iksdin9p5djo6j70qmuitoe2ff3uvkefb8pqensorln5flr3pm8hkc0lqkchbd63cf9tl0kqnqu3i17kvqnm35g0
+  749. -- #a98jlos4rj2um55iksdin9p5djo6j70qmuitoe2ff3uvkefb8pqensorln5flr3pm8hkc0lqkchbd63cf9tl0kqnqu3i17kvqnm35g0
        send : Tls -> Bytes ->{IO, Exception} ()
        
-  749. -- #qrdia2sc9vuoi7u3a4ukjk8lv0rlhn2i2bbin1adbhcuj79jn366dv3a8t52hpil0jtgkhhuiavibmdev63j5ndriod33rkktjekqv8
+  750. -- #qrdia2sc9vuoi7u3a4ukjk8lv0rlhn2i2bbin1adbhcuj79jn366dv3a8t52hpil0jtgkhhuiavibmdev63j5ndriod33rkktjekqv8
        serverSocket : Optional Text
        -> Text
        ->{IO, Exception} Socket
        
-  750. -- #3vft70875p42eao55rhb61siobuei4h0e9vlu4bbgucjo296c2vfjpucacovnu9538tvup5c7lo9123se8v4fe7m8q9aiqbkjpumkao
+  751. -- #3vft70875p42eao55rhb61siobuei4h0e9vlu4bbgucjo296c2vfjpucacovnu9538tvup5c7lo9123se8v4fe7m8q9aiqbkjpumkao
        setBuffering : Handle -> BufferMode ->{IO, Exception} ()
        
-  751. -- #erqshamlurgahpd4rroild36cc5e4rk56r38r53vcbg8cblr82c6gfji3um8f09ffgjlg58g7r32mtsbvjlcq4c65v0jn3va9888mao
+  752. -- #erqshamlurgahpd4rroild36cc5e4rk56r38r53vcbg8cblr82c6gfji3um8f09ffgjlg58g7r32mtsbvjlcq4c65v0jn3va9888mao
        setEcho : Handle -> Boolean ->{IO, Exception} ()
        
-  752. -- #ugar51qqij4ur24frdi84eqdkvqa0fbsi4v6e2586hi3tai52ovtpm3f2dc9crnfv8pk0ppq6b5tv3utl4sl49n5aecorgkqddr7i38
+  753. -- #ugar51qqij4ur24frdi84eqdkvqa0fbsi4v6e2586hi3tai52ovtpm3f2dc9crnfv8pk0ppq6b5tv3utl4sl49n5aecorgkqddr7i38
        snd : ∀ a a1. (a1, a) -> a
        
-  753. -- #leoq6smeq8to5ej3314uuujmh6rfbcsdb9q8ah8h3ohg9jq5kftc93mq671o0qh2he9vqgd288k0ecea3h7eerpbgjt6a8p843tmon8
+  754. -- #leoq6smeq8to5ej3314uuujmh6rfbcsdb9q8ah8h3ohg9jq5kftc93mq671o0qh2he9vqgd288k0ecea3h7eerpbgjt6a8p843tmon8
        socketAccept : Socket ->{IO, Exception} Socket
        
-  754. -- #s43jbp19k91qq704tidpue2vs2re1lh4mtv46rdmdnurkdndst7u0k712entcvip160vh9cilmpamikmflbprg5up0k6cl15b8tr5l0
+  755. -- #s43jbp19k91qq704tidpue2vs2re1lh4mtv46rdmdnurkdndst7u0k712entcvip160vh9cilmpamikmflbprg5up0k6cl15b8tr5l0
        socketPort : Socket ->{IO, Exception} Nat
        
-  755. -- #3rp8h0dt7g60nrjdehuhqga9dmomti5rdqho7r1rm5rg5moet7kt3ieempo7c9urur752njachq6k48ggbic4ugbbv75jl2mfbk57a0
+  756. -- #3rp8h0dt7g60nrjdehuhqga9dmomti5rdqho7r1rm5rg5moet7kt3ieempo7c9urur752njachq6k48ggbic4ugbbv75jl2mfbk57a0
        startsWith : Text -> Text -> Boolean
        
-  756. -- #elsab3sc7p4c6bj73pgvklv0j7qu268rn5isv6micfp7ib8grjoustpqdq0pkd4a379mr5ijb8duu2q0n040osfurppp8pt8vaue2fo
+  757. -- #elsab3sc7p4c6bj73pgvklv0j7qu268rn5isv6micfp7ib8grjoustpqdq0pkd4a379mr5ijb8duu2q0n040osfurppp8pt8vaue2fo
        stdout : Handle
        
-  757. -- #rfi1v9429f9qluv533l2iba77aadttilrpmnhljfapfnfa6sru2nr8ibpqvib9nc4s4nb9s1as45upsfqfqe6ivqi2p82b2vd866it8
+  758. -- #rfi1v9429f9qluv533l2iba77aadttilrpmnhljfapfnfa6sru2nr8ibpqvib9nc4s4nb9s1as45upsfqfqe6ivqi2p82b2vd866it8
        structural ability Stream a
        
-  758. -- #2jl99er43tnksj8r8oveap5ger9uqlvj0u0ghfs0uqa7i6m45jk976n7a726jb7rtusjdu2p8hbbcgmoacvke7k5o3kdgoj57c3v2v8
+  759. -- #2jl99er43tnksj8r8oveap5ger9uqlvj0u0ghfs0uqa7i6m45jk976n7a726jb7rtusjdu2p8hbbcgmoacvke7k5o3kdgoj57c3v2v8
        Stream.collect : '{e, Stream a} r ->{e} ([a], r)
        
-  759. -- #rnuje46fvuqa4a8sdgl9e250a2gcmhtsscr8bdonj2bduhrst38ur7dorv3ahr2ghf9cufkfit7ndh9qb9gspbfapcnn3sol0l2moqg
+  760. -- #rnuje46fvuqa4a8sdgl9e250a2gcmhtsscr8bdonj2bduhrst38ur7dorv3ahr2ghf9cufkfit7ndh9qb9gspbfapcnn3sol0l2moqg
        Stream.collect.handler : Request {Stream a} r -> ([a], r)
        
-  760. -- #rfi1v9429f9qluv533l2iba77aadttilrpmnhljfapfnfa6sru2nr8ibpqvib9nc4s4nb9s1as45upsfqfqe6ivqi2p82b2vd866it8#0
+  761. -- #rfi1v9429f9qluv533l2iba77aadttilrpmnhljfapfnfa6sru2nr8ibpqvib9nc4s4nb9s1as45upsfqfqe6ivqi2p82b2vd866it8#0
        Stream.emit : a ->{Stream a} ()
        
-  761. -- #c70gf5m1blvh8tg4kvt1taee036fr7r22bbtqcupac5r5igs102nj077vdl0nimef94u951kfcl9a5hcevo01j04v9o6v3cpndq41bo
+  762. -- #c70gf5m1blvh8tg4kvt1taee036fr7r22bbtqcupac5r5igs102nj077vdl0nimef94u951kfcl9a5hcevo01j04v9o6v3cpndq41bo
        Stream.toList : '{Stream a} r -> [a]
        
-  762. -- #ul69cgsrsspjni8b0hqnt4kt4bk7sjtp6jvlhhofom7bemu9nb2kimm6tt1raigr7j86afgmnjnrfabn6a5l5v1t219uidiu22ueiv0
+  763. -- #ul69cgsrsspjni8b0hqnt4kt4bk7sjtp6jvlhhofom7bemu9nb2kimm6tt1raigr7j86afgmnjnrfabn6a5l5v1t219uidiu22ueiv0
        Stream.toList.handler : Request {Stream a} r -> [a]
        
-  763. -- #58d8kfuq8sqbipa1aaijjhm28pa6a844h19mgg5s4a1h160etbulig21cm0pcnfla8fisqvrp80840g9luid5u8amvcc8sf46pd25h8
+  764. -- #58d8kfuq8sqbipa1aaijjhm28pa6a844h19mgg5s4a1h160etbulig21cm0pcnfla8fisqvrp80840g9luid5u8amvcc8sf46pd25h8
        systemTime : '{IO, Exception} Nat
        
-  764. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18
+  765. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18
        structural ability TempDirs
        
-  765. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18#0
+  766. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18#0
        TempDirs.newTempDir : Text ->{TempDirs} Text
        
-  766. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18#1
+  767. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18#1
        TempDirs.removeDir : Text ->{TempDirs} ()
        
-  767. -- #natgur73q6b4c3tp5jcor0v1cdnplh0n3fhm4qvhg4v74u3e3ff1352shs1lveot83lj82qqbl78n40qi9a132fhkmaa6g5s1ja91go
+  768. -- #natgur73q6b4c3tp5jcor0v1cdnplh0n3fhm4qvhg4v74u3e3ff1352shs1lveot83lj82qqbl78n40qi9a132fhkmaa6g5s1ja91go
        terminate : Tls ->{IO, Exception} ()
        
-  768. -- #i3pbnc98rbfug5dnnvpd4uahm2e5fld2fu0re9r305isffr1r43048h7ql6ojdbjcsvjr6h91s6i026na046ltg5ff59klla6e7vq98
+  769. -- #i3pbnc98rbfug5dnnvpd4uahm2e5fld2fu0re9r305isffr1r43048h7ql6ojdbjcsvjr6h91s6i026na046ltg5ff59klla6e7vq98
        testAutoClean : '{IO} [Result]
        
-  769. -- #spepthutvs3p6je794h520665rh8abl36qg43i7ipvj0mtg5sb0sbemjp2vpu9j3feithk2ae0sdtcmb8afoglo9rnvl350380t21h0
+  770. -- #spepthutvs3p6je794h520665rh8abl36qg43i7ipvj0mtg5sb0sbemjp2vpu9j3feithk2ae0sdtcmb8afoglo9rnvl350380t21h0
        Text.fromUtf8 : Bytes ->{Exception} Text
        
-  770. -- #32q9jqhmi8f08pec3hj0je4u7k52f9f1hdfsmn9ncg2kpki5da9dabigplvdcot3a00k7s5npc4n78psd6ojaumqjla259e9pqd4ov8
+  771. -- #32q9jqhmi8f08pec3hj0je4u7k52f9f1hdfsmn9ncg2kpki5da9dabigplvdcot3a00k7s5npc4n78psd6ojaumqjla259e9pqd4ov8
        structural ability Throw e
        
-  771. -- #32q9jqhmi8f08pec3hj0je4u7k52f9f1hdfsmn9ncg2kpki5da9dabigplvdcot3a00k7s5npc4n78psd6ojaumqjla259e9pqd4ov8#0
+  772. -- #32q9jqhmi8f08pec3hj0je4u7k52f9f1hdfsmn9ncg2kpki5da9dabigplvdcot3a00k7s5npc4n78psd6ojaumqjla259e9pqd4ov8#0
        Throw.throw : e ->{Throw e} a
        
-  772. -- #vri6fsnl704n6aqs346p6ijcbkcsv9875edr6b74enumrhbjiuon94ir4ufmrrn84k9b2jka4f05o16mcvsjrjav6gpskpiu4sknd1g
+  773. -- #vri6fsnl704n6aqs346p6ijcbkcsv9875edr6b74enumrhbjiuon94ir4ufmrrn84k9b2jka4f05o16mcvsjrjav6gpskpiu4sknd1g
        uncurry : ∀ o g1 i g i1.
          (i1 ->{g} i ->{g1} o) -> (i1, i) ->{g1, g} o
        
-  773. -- #u2j1bektndcqdo1m13fvu6apt9td96s4tqonelg23tauklak2pqnbisf41v632fmlrcc6f9orqo3iu9757q36ue5ol1khe0hh8pktro
+  774. -- #u2j1bektndcqdo1m13fvu6apt9td96s4tqonelg23tauklak2pqnbisf41v632fmlrcc6f9orqo3iu9757q36ue5ol1khe0hh8pktro
        Value.transitiveDeps : Value ->{IO} [(Link.Term, Code)]
        
-  774. -- #o5bg5el7ckak28ib98j5b6rt26bqbprpddd1brrg3s18qahhbbe3uohufjjnt5eenvtjg0hrvnvpra95jmdppqrovvmcfm1ih2k7guo
+  775. -- #o5bg5el7ckak28ib98j5b6rt26bqbprpddd1brrg3s18qahhbbe3uohufjjnt5eenvtjg0hrvnvpra95jmdppqrovvmcfm1ih2k7guo
        void : x -> ()
        
-  775. -- #8ugamqlp7a4g0dmbcvipqfi8gnuuj23pjbdfbof11naiun1qf8otjcap80epaom2kl9fv5rhjaudt4558n38dovrc0lhipubqjgm8mg
+  776. -- #8ugamqlp7a4g0dmbcvipqfi8gnuuj23pjbdfbof11naiun1qf8otjcap80epaom2kl9fv5rhjaudt4558n38dovrc0lhipubqjgm8mg
        writeFile : Text -> Bytes ->{IO, Exception} ()
        
-  776. -- #lcmj2envm11lrflvvcl290lplhvbccv82utoej0lg0eomhmsf2vrv8af17k6if7ff98fp1b13rkseng3fng4stlr495c8dn3gn4k400
+  777. -- #lcmj2envm11lrflvvcl290lplhvbccv82utoej0lg0eomhmsf2vrv8af17k6if7ff98fp1b13rkseng3fng4stlr495c8dn3gn4k400
        |> : a -> (a ->{g} t) ->{g} t
        
   

--- a/unison-src/transcripts/alias-many.output.md
+++ b/unison-src/transcripts/alias-many.output.md
@@ -87,571 +87,572 @@ Let's try it!
                           -> Bytes
                           -> Bytes
                           -> Bytes
-  67.  Debug.trace : Text -> a -> ()
-  68.  Debug.watch : Text -> a -> a
-  69.  unique type Doc
-  70.  Doc.Blob : Text -> Doc
-  71.  Doc.Evaluate : Term -> Doc
-  72.  Doc.Join : [Doc] -> Doc
-  73.  Doc.Link : Link -> Doc
-  74.  Doc.Signature : Term -> Doc
-  75.  Doc.Source : Link -> Doc
-  76.  structural type Either a b
-  77.  Either.Left : a -> Either a b
-  78.  Either.Right : b -> Either a b
-  79.  structural ability Exception
-  80.  Exception.raise : Failure ->{Exception} x
-  81.  builtin type Float
-  82.  Float.* : Float -> Float -> Float
-  83.  Float.+ : Float -> Float -> Float
-  84.  Float.- : Float -> Float -> Float
-  85.  Float./ : Float -> Float -> Float
-  86.  Float.abs : Float -> Float
-  87.  Float.acos : Float -> Float
-  88.  Float.acosh : Float -> Float
-  89.  Float.asin : Float -> Float
-  90.  Float.asinh : Float -> Float
-  91.  Float.atan : Float -> Float
-  92.  Float.atan2 : Float -> Float -> Float
-  93.  Float.atanh : Float -> Float
-  94.  Float.ceiling : Float -> Int
-  95.  Float.cos : Float -> Float
-  96.  Float.cosh : Float -> Float
-  97.  Float.eq : Float -> Float -> Boolean
-  98.  Float.exp : Float -> Float
-  99.  Float.floor : Float -> Int
-  100. Float.fromRepresentation : Nat -> Float
-  101. Float.fromText : Text -> Optional Float
-  102. Float.gt : Float -> Float -> Boolean
-  103. Float.gteq : Float -> Float -> Boolean
-  104. Float.log : Float -> Float
-  105. Float.logBase : Float -> Float -> Float
-  106. Float.lt : Float -> Float -> Boolean
-  107. Float.lteq : Float -> Float -> Boolean
-  108. Float.max : Float -> Float -> Float
-  109. Float.min : Float -> Float -> Float
-  110. Float.pow : Float -> Float -> Float
-  111. Float.round : Float -> Int
-  112. Float.sin : Float -> Float
-  113. Float.sinh : Float -> Float
-  114. Float.sqrt : Float -> Float
-  115. Float.tan : Float -> Float
-  116. Float.tanh : Float -> Float
-  117. Float.toRepresentation : Float -> Nat
-  118. Float.toText : Float -> Text
-  119. Float.truncate : Float -> Int
-  120. Handle.toText : Handle -> Text
-  121. builtin type ImmutableArray
-  122. ImmutableArray.copyTo! : MutableArray g a
+  67.  Debug.toText : a -> Optional (Either Text Text)
+  68.  Debug.trace : Text -> a -> ()
+  69.  Debug.watch : Text -> a -> a
+  70.  unique type Doc
+  71.  Doc.Blob : Text -> Doc
+  72.  Doc.Evaluate : Term -> Doc
+  73.  Doc.Join : [Doc] -> Doc
+  74.  Doc.Link : Link -> Doc
+  75.  Doc.Signature : Term -> Doc
+  76.  Doc.Source : Link -> Doc
+  77.  structural type Either a b
+  78.  Either.Left : a -> Either a b
+  79.  Either.Right : b -> Either a b
+  80.  structural ability Exception
+  81.  Exception.raise : Failure ->{Exception} x
+  82.  builtin type Float
+  83.  Float.* : Float -> Float -> Float
+  84.  Float.+ : Float -> Float -> Float
+  85.  Float.- : Float -> Float -> Float
+  86.  Float./ : Float -> Float -> Float
+  87.  Float.abs : Float -> Float
+  88.  Float.acos : Float -> Float
+  89.  Float.acosh : Float -> Float
+  90.  Float.asin : Float -> Float
+  91.  Float.asinh : Float -> Float
+  92.  Float.atan : Float -> Float
+  93.  Float.atan2 : Float -> Float -> Float
+  94.  Float.atanh : Float -> Float
+  95.  Float.ceiling : Float -> Int
+  96.  Float.cos : Float -> Float
+  97.  Float.cosh : Float -> Float
+  98.  Float.eq : Float -> Float -> Boolean
+  99.  Float.exp : Float -> Float
+  100. Float.floor : Float -> Int
+  101. Float.fromRepresentation : Nat -> Float
+  102. Float.fromText : Text -> Optional Float
+  103. Float.gt : Float -> Float -> Boolean
+  104. Float.gteq : Float -> Float -> Boolean
+  105. Float.log : Float -> Float
+  106. Float.logBase : Float -> Float -> Float
+  107. Float.lt : Float -> Float -> Boolean
+  108. Float.lteq : Float -> Float -> Boolean
+  109. Float.max : Float -> Float -> Float
+  110. Float.min : Float -> Float -> Float
+  111. Float.pow : Float -> Float -> Float
+  112. Float.round : Float -> Int
+  113. Float.sin : Float -> Float
+  114. Float.sinh : Float -> Float
+  115. Float.sqrt : Float -> Float
+  116. Float.tan : Float -> Float
+  117. Float.tanh : Float -> Float
+  118. Float.toRepresentation : Float -> Nat
+  119. Float.toText : Float -> Text
+  120. Float.truncate : Float -> Int
+  121. Handle.toText : Handle -> Text
+  122. builtin type ImmutableArray
+  123. ImmutableArray.copyTo! : MutableArray g a
                                 -> Nat
                                 -> ImmutableArray a
                                 -> Nat
                                 -> Nat
                                 ->{g, Exception} ()
-  123. ImmutableArray.read : ImmutableArray a
+  124. ImmutableArray.read : ImmutableArray a
                              -> Nat
                              ->{Exception} a
-  124. ImmutableArray.size : ImmutableArray a -> Nat
-  125. builtin type ImmutableByteArray
-  126. ImmutableByteArray.copyTo! : MutableByteArray g
+  125. ImmutableArray.size : ImmutableArray a -> Nat
+  126. builtin type ImmutableByteArray
+  127. ImmutableByteArray.copyTo! : MutableByteArray g
                                     -> Nat
                                     -> ImmutableByteArray
                                     -> Nat
                                     -> Nat
                                     ->{g, Exception} ()
-  127. ImmutableByteArray.read16be : ImmutableByteArray
+  128. ImmutableByteArray.read16be : ImmutableByteArray
                                      -> Nat
                                      ->{Exception} Nat
-  128. ImmutableByteArray.read24be : ImmutableByteArray
+  129. ImmutableByteArray.read24be : ImmutableByteArray
                                      -> Nat
                                      ->{Exception} Nat
-  129. ImmutableByteArray.read32be : ImmutableByteArray
+  130. ImmutableByteArray.read32be : ImmutableByteArray
                                      -> Nat
                                      ->{Exception} Nat
-  130. ImmutableByteArray.read40be : ImmutableByteArray
+  131. ImmutableByteArray.read40be : ImmutableByteArray
                                      -> Nat
                                      ->{Exception} Nat
-  131. ImmutableByteArray.read64be : ImmutableByteArray
+  132. ImmutableByteArray.read64be : ImmutableByteArray
                                      -> Nat
                                      ->{Exception} Nat
-  132. ImmutableByteArray.read8 : ImmutableByteArray
+  133. ImmutableByteArray.read8 : ImmutableByteArray
                                   -> Nat
                                   ->{Exception} Nat
-  133. ImmutableByteArray.size : ImmutableByteArray -> Nat
-  134. builtin type Int
-  135. Int.* : Int -> Int -> Int
-  136. Int.+ : Int -> Int -> Int
-  137. Int.- : Int -> Int -> Int
-  138. Int./ : Int -> Int -> Int
-  139. Int.and : Int -> Int -> Int
-  140. Int.complement : Int -> Int
-  141. Int.eq : Int -> Int -> Boolean
-  142. Int.fromRepresentation : Nat -> Int
-  143. Int.fromText : Text -> Optional Int
-  144. Int.gt : Int -> Int -> Boolean
-  145. Int.gteq : Int -> Int -> Boolean
-  146. Int.increment : Int -> Int
-  147. Int.isEven : Int -> Boolean
-  148. Int.isOdd : Int -> Boolean
-  149. Int.leadingZeros : Int -> Nat
-  150. Int.lt : Int -> Int -> Boolean
-  151. Int.lteq : Int -> Int -> Boolean
-  152. Int.mod : Int -> Int -> Int
-  153. Int.negate : Int -> Int
-  154. Int.or : Int -> Int -> Int
-  155. Int.popCount : Int -> Nat
-  156. Int.pow : Int -> Nat -> Int
-  157. Int.shiftLeft : Int -> Nat -> Int
-  158. Int.shiftRight : Int -> Nat -> Int
-  159. Int.signum : Int -> Int
-  160. Int.toFloat : Int -> Float
-  161. Int.toRepresentation : Int -> Nat
-  162. Int.toText : Int -> Text
-  163. Int.trailingZeros : Int -> Nat
-  164. Int.truncate0 : Int -> Nat
-  165. Int.xor : Int -> Int -> Int
-  166. unique type io2.ArithmeticFailure
-  167. unique type io2.ArrayFailure
-  168. unique type io2.BufferMode
-  169. io2.BufferMode.BlockBuffering : BufferMode
-  170. io2.BufferMode.LineBuffering : BufferMode
-  171. io2.BufferMode.NoBuffering : BufferMode
-  172. io2.BufferMode.SizedBlockBuffering : Nat -> BufferMode
-  173. io2.Clock.internals.monotonic : '{IO} Either
+  134. ImmutableByteArray.size : ImmutableByteArray -> Nat
+  135. builtin type Int
+  136. Int.* : Int -> Int -> Int
+  137. Int.+ : Int -> Int -> Int
+  138. Int.- : Int -> Int -> Int
+  139. Int./ : Int -> Int -> Int
+  140. Int.and : Int -> Int -> Int
+  141. Int.complement : Int -> Int
+  142. Int.eq : Int -> Int -> Boolean
+  143. Int.fromRepresentation : Nat -> Int
+  144. Int.fromText : Text -> Optional Int
+  145. Int.gt : Int -> Int -> Boolean
+  146. Int.gteq : Int -> Int -> Boolean
+  147. Int.increment : Int -> Int
+  148. Int.isEven : Int -> Boolean
+  149. Int.isOdd : Int -> Boolean
+  150. Int.leadingZeros : Int -> Nat
+  151. Int.lt : Int -> Int -> Boolean
+  152. Int.lteq : Int -> Int -> Boolean
+  153. Int.mod : Int -> Int -> Int
+  154. Int.negate : Int -> Int
+  155. Int.or : Int -> Int -> Int
+  156. Int.popCount : Int -> Nat
+  157. Int.pow : Int -> Nat -> Int
+  158. Int.shiftLeft : Int -> Nat -> Int
+  159. Int.shiftRight : Int -> Nat -> Int
+  160. Int.signum : Int -> Int
+  161. Int.toFloat : Int -> Float
+  162. Int.toRepresentation : Int -> Nat
+  163. Int.toText : Int -> Text
+  164. Int.trailingZeros : Int -> Nat
+  165. Int.truncate0 : Int -> Nat
+  166. Int.xor : Int -> Int -> Int
+  167. unique type io2.ArithmeticFailure
+  168. unique type io2.ArrayFailure
+  169. unique type io2.BufferMode
+  170. io2.BufferMode.BlockBuffering : BufferMode
+  171. io2.BufferMode.LineBuffering : BufferMode
+  172. io2.BufferMode.NoBuffering : BufferMode
+  173. io2.BufferMode.SizedBlockBuffering : Nat -> BufferMode
+  174. io2.Clock.internals.monotonic : '{IO} Either
                                          Failure TimeSpec
-  174. io2.Clock.internals.nsec : TimeSpec -> Nat
-  175. io2.Clock.internals.processCPUTime : '{IO} Either
+  175. io2.Clock.internals.nsec : TimeSpec -> Nat
+  176. io2.Clock.internals.processCPUTime : '{IO} Either
                                               Failure TimeSpec
-  176. io2.Clock.internals.realtime : '{IO} Either
+  177. io2.Clock.internals.realtime : '{IO} Either
                                         Failure TimeSpec
-  177. io2.Clock.internals.sec : TimeSpec -> Int
-  178. io2.Clock.internals.threadCPUTime : '{IO} Either
+  178. io2.Clock.internals.sec : TimeSpec -> Int
+  179. io2.Clock.internals.threadCPUTime : '{IO} Either
                                              Failure TimeSpec
-  179. builtin type io2.Clock.internals.TimeSpec
-  180. unique type io2.Failure
-  181. io2.Failure.Failure : Type -> Text -> Any -> Failure
-  182. unique type io2.FileMode
-  183. io2.FileMode.Append : FileMode
-  184. io2.FileMode.Read : FileMode
-  185. io2.FileMode.ReadWrite : FileMode
-  186. io2.FileMode.Write : FileMode
-  187. builtin type io2.Handle
-  188. builtin type io2.IO
-  189. io2.IO.array : Nat ->{IO} MutableArray {IO} a
-  190. io2.IO.arrayOf : a -> Nat ->{IO} MutableArray {IO} a
-  191. io2.IO.bytearray : Nat ->{IO} MutableByteArray {IO}
-  192. io2.IO.bytearrayOf : Nat
+  180. builtin type io2.Clock.internals.TimeSpec
+  181. unique type io2.Failure
+  182. io2.Failure.Failure : Type -> Text -> Any -> Failure
+  183. unique type io2.FileMode
+  184. io2.FileMode.Append : FileMode
+  185. io2.FileMode.Read : FileMode
+  186. io2.FileMode.ReadWrite : FileMode
+  187. io2.FileMode.Write : FileMode
+  188. builtin type io2.Handle
+  189. builtin type io2.IO
+  190. io2.IO.array : Nat ->{IO} MutableArray {IO} a
+  191. io2.IO.arrayOf : a -> Nat ->{IO} MutableArray {IO} a
+  192. io2.IO.bytearray : Nat ->{IO} MutableByteArray {IO}
+  193. io2.IO.bytearrayOf : Nat
                             -> Nat
                             ->{IO} MutableByteArray {IO}
-  193. io2.IO.clientSocket.impl : Text
+  194. io2.IO.clientSocket.impl : Text
                                   -> Text
                                   ->{IO} Either Failure Socket
-  194. io2.IO.closeFile.impl : Handle ->{IO} Either Failure ()
-  195. io2.IO.closeSocket.impl : Socket ->{IO} Either Failure ()
-  196. io2.IO.createDirectory.impl : Text
+  195. io2.IO.closeFile.impl : Handle ->{IO} Either Failure ()
+  196. io2.IO.closeSocket.impl : Socket ->{IO} Either Failure ()
+  197. io2.IO.createDirectory.impl : Text
                                      ->{IO} Either Failure ()
-  197. io2.IO.createTempDirectory.impl : Text
+  198. io2.IO.createTempDirectory.impl : Text
                                          ->{IO} Either
                                            Failure Text
-  198. io2.IO.delay.impl : Nat ->{IO} Either Failure ()
-  199. io2.IO.directoryContents.impl : Text
+  199. io2.IO.delay.impl : Nat ->{IO} Either Failure ()
+  200. io2.IO.directoryContents.impl : Text
                                        ->{IO} Either
                                          Failure [Text]
-  200. io2.IO.fileExists.impl : Text
+  201. io2.IO.fileExists.impl : Text
                                 ->{IO} Either Failure Boolean
-  201. io2.IO.forkComp : '{IO} a ->{IO} ThreadId
-  202. io2.IO.getArgs.impl : '{IO} Either Failure [Text]
-  203. io2.IO.getBuffering.impl : Handle
+  202. io2.IO.forkComp : '{IO} a ->{IO} ThreadId
+  203. io2.IO.getArgs.impl : '{IO} Either Failure [Text]
+  204. io2.IO.getBuffering.impl : Handle
                                   ->{IO} Either
                                     Failure BufferMode
-  204. io2.IO.getBytes.impl : Handle
+  205. io2.IO.getBytes.impl : Handle
                               -> Nat
                               ->{IO} Either Failure Bytes
-  205. io2.IO.getChar.impl : Handle ->{IO} Either Failure Char
-  206. io2.IO.getCurrentDirectory.impl : '{IO} Either
+  206. io2.IO.getChar.impl : Handle ->{IO} Either Failure Char
+  207. io2.IO.getCurrentDirectory.impl : '{IO} Either
                                            Failure Text
-  207. io2.IO.getEcho.impl : Handle
+  208. io2.IO.getEcho.impl : Handle
                              ->{IO} Either Failure Boolean
-  208. io2.IO.getEnv.impl : Text ->{IO} Either Failure Text
-  209. io2.IO.getFileSize.impl : Text ->{IO} Either Failure Nat
-  210. io2.IO.getFileTimestamp.impl : Text
+  209. io2.IO.getEnv.impl : Text ->{IO} Either Failure Text
+  210. io2.IO.getFileSize.impl : Text ->{IO} Either Failure Nat
+  211. io2.IO.getFileTimestamp.impl : Text
                                       ->{IO} Either Failure Nat
-  211. io2.IO.getLine.impl : Handle ->{IO} Either Failure Text
-  212. io2.IO.getSomeBytes.impl : Handle
+  212. io2.IO.getLine.impl : Handle ->{IO} Either Failure Text
+  213. io2.IO.getSomeBytes.impl : Handle
                                   -> Nat
                                   ->{IO} Either Failure Bytes
-  213. io2.IO.getTempDirectory.impl : '{IO} Either Failure Text
-  214. io2.IO.handlePosition.impl : Handle
+  214. io2.IO.getTempDirectory.impl : '{IO} Either Failure Text
+  215. io2.IO.handlePosition.impl : Handle
                                     ->{IO} Either Failure Nat
-  215. io2.IO.isDirectory.impl : Text
+  216. io2.IO.isDirectory.impl : Text
                                  ->{IO} Either Failure Boolean
-  216. io2.IO.isFileEOF.impl : Handle
+  217. io2.IO.isFileEOF.impl : Handle
                                ->{IO} Either Failure Boolean
-  217. io2.IO.isFileOpen.impl : Handle
+  218. io2.IO.isFileOpen.impl : Handle
                                 ->{IO} Either Failure Boolean
-  218. io2.IO.isSeekable.impl : Handle
+  219. io2.IO.isSeekable.impl : Handle
                                 ->{IO} Either Failure Boolean
-  219. io2.IO.kill.impl : ThreadId ->{IO} Either Failure ()
-  220. io2.IO.listen.impl : Socket ->{IO} Either Failure ()
-  221. io2.IO.openFile.impl : Text
+  220. io2.IO.kill.impl : ThreadId ->{IO} Either Failure ()
+  221. io2.IO.listen.impl : Socket ->{IO} Either Failure ()
+  222. io2.IO.openFile.impl : Text
                               -> FileMode
                               ->{IO} Either Failure Handle
-  222. io2.IO.putBytes.impl : Handle
+  223. io2.IO.putBytes.impl : Handle
                               -> Bytes
                               ->{IO} Either Failure ()
-  223. io2.IO.ready.impl : Handle ->{IO} Either Failure Boolean
-  224. io2.IO.ref : a ->{IO} Ref {IO} a
-  225. io2.IO.removeDirectory.impl : Text
+  224. io2.IO.ready.impl : Handle ->{IO} Either Failure Boolean
+  225. io2.IO.ref : a ->{IO} Ref {IO} a
+  226. io2.IO.removeDirectory.impl : Text
                                      ->{IO} Either Failure ()
-  226. io2.IO.removeFile.impl : Text ->{IO} Either Failure ()
-  227. io2.IO.renameDirectory.impl : Text
+  227. io2.IO.removeFile.impl : Text ->{IO} Either Failure ()
+  228. io2.IO.renameDirectory.impl : Text
                                      -> Text
                                      ->{IO} Either Failure ()
-  228. io2.IO.renameFile.impl : Text
+  229. io2.IO.renameFile.impl : Text
                                 -> Text
                                 ->{IO} Either Failure ()
-  229. io2.IO.seekHandle.impl : Handle
+  230. io2.IO.seekHandle.impl : Handle
                                 -> SeekMode
                                 -> Int
                                 ->{IO} Either Failure ()
-  230. io2.IO.serverSocket.impl : Optional Text
+  231. io2.IO.serverSocket.impl : Optional Text
                                   -> Text
                                   ->{IO} Either Failure Socket
-  231. io2.IO.setBuffering.impl : Handle
+  232. io2.IO.setBuffering.impl : Handle
                                   -> BufferMode
                                   ->{IO} Either Failure ()
-  232. io2.IO.setCurrentDirectory.impl : Text
+  233. io2.IO.setCurrentDirectory.impl : Text
                                          ->{IO} Either
                                            Failure ()
-  233. io2.IO.setEcho.impl : Handle
+  234. io2.IO.setEcho.impl : Handle
                              -> Boolean
                              ->{IO} Either Failure ()
-  234. io2.IO.socketAccept.impl : Socket
+  235. io2.IO.socketAccept.impl : Socket
                                   ->{IO} Either Failure Socket
-  235. io2.IO.socketPort.impl : Socket ->{IO} Either Failure Nat
-  236. io2.IO.socketReceive.impl : Socket
+  236. io2.IO.socketPort.impl : Socket ->{IO} Either Failure Nat
+  237. io2.IO.socketReceive.impl : Socket
                                    -> Nat
                                    ->{IO} Either Failure Bytes
-  237. io2.IO.socketSend.impl : Socket
+  238. io2.IO.socketSend.impl : Socket
                                 -> Bytes
                                 ->{IO} Either Failure ()
-  238. io2.IO.stdHandle : StdHandle -> Handle
-  239. io2.IO.systemTime.impl : '{IO} Either Failure Nat
-  240. io2.IO.systemTimeMicroseconds : '{IO} Int
-  241. io2.IO.tryEval : '{IO} a ->{IO, Exception} a
-  242. unique type io2.IOError
-  243. io2.IOError.AlreadyExists : IOError
-  244. io2.IOError.EOF : IOError
-  245. io2.IOError.IllegalOperation : IOError
-  246. io2.IOError.NoSuchThing : IOError
-  247. io2.IOError.PermissionDenied : IOError
-  248. io2.IOError.ResourceBusy : IOError
-  249. io2.IOError.ResourceExhausted : IOError
-  250. io2.IOError.UserError : IOError
-  251. unique type io2.IOFailure
-  252. unique type io2.MiscFailure
-  253. builtin type io2.MVar
-  254. io2.MVar.isEmpty : MVar a ->{IO} Boolean
-  255. io2.MVar.new : a ->{IO} MVar a
-  256. io2.MVar.newEmpty : '{IO} MVar a
-  257. io2.MVar.put.impl : MVar a -> a ->{IO} Either Failure ()
-  258. io2.MVar.read.impl : MVar a ->{IO} Either Failure a
-  259. io2.MVar.swap.impl : MVar a -> a ->{IO} Either Failure a
-  260. io2.MVar.take.impl : MVar a ->{IO} Either Failure a
-  261. io2.MVar.tryPut.impl : MVar a
+  239. io2.IO.stdHandle : StdHandle -> Handle
+  240. io2.IO.systemTime.impl : '{IO} Either Failure Nat
+  241. io2.IO.systemTimeMicroseconds : '{IO} Int
+  242. io2.IO.tryEval : '{IO} a ->{IO, Exception} a
+  243. unique type io2.IOError
+  244. io2.IOError.AlreadyExists : IOError
+  245. io2.IOError.EOF : IOError
+  246. io2.IOError.IllegalOperation : IOError
+  247. io2.IOError.NoSuchThing : IOError
+  248. io2.IOError.PermissionDenied : IOError
+  249. io2.IOError.ResourceBusy : IOError
+  250. io2.IOError.ResourceExhausted : IOError
+  251. io2.IOError.UserError : IOError
+  252. unique type io2.IOFailure
+  253. unique type io2.MiscFailure
+  254. builtin type io2.MVar
+  255. io2.MVar.isEmpty : MVar a ->{IO} Boolean
+  256. io2.MVar.new : a ->{IO} MVar a
+  257. io2.MVar.newEmpty : '{IO} MVar a
+  258. io2.MVar.put.impl : MVar a -> a ->{IO} Either Failure ()
+  259. io2.MVar.read.impl : MVar a ->{IO} Either Failure a
+  260. io2.MVar.swap.impl : MVar a -> a ->{IO} Either Failure a
+  261. io2.MVar.take.impl : MVar a ->{IO} Either Failure a
+  262. io2.MVar.tryPut.impl : MVar a
                               -> a
                               ->{IO} Either Failure Boolean
-  262. io2.MVar.tryRead.impl : MVar a
+  263. io2.MVar.tryRead.impl : MVar a
                                ->{IO} Either
                                  Failure (Optional a)
-  263. io2.MVar.tryTake : MVar a ->{IO} Optional a
-  264. builtin type io2.Promise
-  265. io2.Promise.new : '{IO} Promise a
-  266. io2.Promise.read : Promise a ->{IO} a
-  267. io2.Promise.tryRead : Promise a ->{IO} Optional a
-  268. io2.Promise.write : Promise a -> a ->{IO} Boolean
-  269. io2.Ref.cas : Ref {IO} a -> Ticket a -> a ->{IO} Boolean
-  270. io2.Ref.readForCas : Ref {IO} a ->{IO} Ticket a
-  271. builtin type io2.Ref.Ticket
-  272. io2.Ref.Ticket.read : Ticket a -> a
-  273. unique type io2.RuntimeFailure
-  274. unique type io2.SeekMode
-  275. io2.SeekMode.AbsoluteSeek : SeekMode
-  276. io2.SeekMode.RelativeSeek : SeekMode
-  277. io2.SeekMode.SeekFromEnd : SeekMode
-  278. builtin type io2.Socket
-  279. unique type io2.StdHandle
-  280. io2.StdHandle.StdErr : StdHandle
-  281. io2.StdHandle.StdIn : StdHandle
-  282. io2.StdHandle.StdOut : StdHandle
-  283. builtin type io2.STM
-  284. io2.STM.atomically : '{STM} a ->{IO} a
-  285. io2.STM.retry : '{STM} a
-  286. unique type io2.STMFailure
-  287. builtin type io2.ThreadId
-  288. builtin type io2.Tls
-  289. builtin type io2.Tls.Cipher
-  290. builtin type io2.Tls.ClientConfig
-  291. io2.Tls.ClientConfig.certificates.set : [SignedCert]
+  264. io2.MVar.tryTake : MVar a ->{IO} Optional a
+  265. builtin type io2.Promise
+  266. io2.Promise.new : '{IO} Promise a
+  267. io2.Promise.read : Promise a ->{IO} a
+  268. io2.Promise.tryRead : Promise a ->{IO} Optional a
+  269. io2.Promise.write : Promise a -> a ->{IO} Boolean
+  270. io2.Ref.cas : Ref {IO} a -> Ticket a -> a ->{IO} Boolean
+  271. io2.Ref.readForCas : Ref {IO} a ->{IO} Ticket a
+  272. builtin type io2.Ref.Ticket
+  273. io2.Ref.Ticket.read : Ticket a -> a
+  274. unique type io2.RuntimeFailure
+  275. unique type io2.SeekMode
+  276. io2.SeekMode.AbsoluteSeek : SeekMode
+  277. io2.SeekMode.RelativeSeek : SeekMode
+  278. io2.SeekMode.SeekFromEnd : SeekMode
+  279. builtin type io2.Socket
+  280. unique type io2.StdHandle
+  281. io2.StdHandle.StdErr : StdHandle
+  282. io2.StdHandle.StdIn : StdHandle
+  283. io2.StdHandle.StdOut : StdHandle
+  284. builtin type io2.STM
+  285. io2.STM.atomically : '{STM} a ->{IO} a
+  286. io2.STM.retry : '{STM} a
+  287. unique type io2.STMFailure
+  288. builtin type io2.ThreadId
+  289. builtin type io2.Tls
+  290. builtin type io2.Tls.Cipher
+  291. builtin type io2.Tls.ClientConfig
+  292. io2.Tls.ClientConfig.certificates.set : [SignedCert]
                                                -> ClientConfig
                                                -> ClientConfig
-  292. io2.TLS.ClientConfig.ciphers.set : [Cipher]
+  293. io2.TLS.ClientConfig.ciphers.set : [Cipher]
                                           -> ClientConfig
                                           -> ClientConfig
-  293. io2.Tls.ClientConfig.default : Text
+  294. io2.Tls.ClientConfig.default : Text
                                       -> Bytes
                                       -> ClientConfig
-  294. io2.Tls.ClientConfig.versions.set : [Version]
+  295. io2.Tls.ClientConfig.versions.set : [Version]
                                            -> ClientConfig
                                            -> ClientConfig
-  295. io2.Tls.decodeCert.impl : Bytes
+  296. io2.Tls.decodeCert.impl : Bytes
                                  -> Either Failure SignedCert
-  296. io2.Tls.decodePrivateKey : Bytes -> [PrivateKey]
-  297. io2.Tls.encodeCert : SignedCert -> Bytes
-  298. io2.Tls.encodePrivateKey : PrivateKey -> Bytes
-  299. io2.Tls.handshake.impl : Tls ->{IO} Either Failure ()
-  300. io2.Tls.newClient.impl : ClientConfig
+  297. io2.Tls.decodePrivateKey : Bytes -> [PrivateKey]
+  298. io2.Tls.encodeCert : SignedCert -> Bytes
+  299. io2.Tls.encodePrivateKey : PrivateKey -> Bytes
+  300. io2.Tls.handshake.impl : Tls ->{IO} Either Failure ()
+  301. io2.Tls.newClient.impl : ClientConfig
                                 -> Socket
                                 ->{IO} Either Failure Tls
-  301. io2.Tls.newServer.impl : ServerConfig
+  302. io2.Tls.newServer.impl : ServerConfig
                                 -> Socket
                                 ->{IO} Either Failure Tls
-  302. builtin type io2.Tls.PrivateKey
-  303. io2.Tls.receive.impl : Tls ->{IO} Either Failure Bytes
-  304. io2.Tls.send.impl : Tls -> Bytes ->{IO} Either Failure ()
-  305. builtin type io2.Tls.ServerConfig
-  306. io2.Tls.ServerConfig.certificates.set : [SignedCert]
+  303. builtin type io2.Tls.PrivateKey
+  304. io2.Tls.receive.impl : Tls ->{IO} Either Failure Bytes
+  305. io2.Tls.send.impl : Tls -> Bytes ->{IO} Either Failure ()
+  306. builtin type io2.Tls.ServerConfig
+  307. io2.Tls.ServerConfig.certificates.set : [SignedCert]
                                                -> ServerConfig
                                                -> ServerConfig
-  307. io2.Tls.ServerConfig.ciphers.set : [Cipher]
+  308. io2.Tls.ServerConfig.ciphers.set : [Cipher]
                                           -> ServerConfig
                                           -> ServerConfig
-  308. io2.Tls.ServerConfig.default : [SignedCert]
+  309. io2.Tls.ServerConfig.default : [SignedCert]
                                       -> PrivateKey
                                       -> ServerConfig
-  309. io2.Tls.ServerConfig.versions.set : [Version]
+  310. io2.Tls.ServerConfig.versions.set : [Version]
                                            -> ServerConfig
                                            -> ServerConfig
-  310. builtin type io2.Tls.SignedCert
-  311. io2.Tls.terminate.impl : Tls ->{IO} Either Failure ()
-  312. builtin type io2.Tls.Version
-  313. unique type io2.TlsFailure
-  314. builtin type io2.TVar
-  315. io2.TVar.new : a ->{STM} TVar a
-  316. io2.TVar.newIO : a ->{IO} TVar a
-  317. io2.TVar.read : TVar a ->{STM} a
-  318. io2.TVar.readIO : TVar a ->{IO} a
-  319. io2.TVar.swap : TVar a -> a ->{STM} a
-  320. io2.TVar.write : TVar a -> a ->{STM} ()
-  321. io2.validateSandboxed : [Term] -> a -> Boolean
-  322. unique type IsPropagated
-  323. IsPropagated.IsPropagated : IsPropagated
-  324. unique type IsTest
-  325. IsTest.IsTest : IsTest
-  326. unique type Link
-  327. builtin type Link.Term
-  328. Link.Term : Term -> Link
-  329. Link.Term.toText : Term -> Text
-  330. builtin type Link.Type
-  331. Link.Type : Type -> Link
-  332. builtin type List
-  333. List.++ : [a] -> [a] -> [a]
-  334. List.+: : a -> [a] -> [a]
-  335. List.:+ : [a] -> a -> [a]
-  336. List.at : Nat -> [a] -> Optional a
-  337. List.cons : a -> [a] -> [a]
-  338. List.drop : Nat -> [a] -> [a]
-  339. List.empty : [a]
-  340. List.size : [a] -> Nat
-  341. List.snoc : [a] -> a -> [a]
-  342. List.take : Nat -> [a] -> [a]
-  343. metadata.isPropagated : IsPropagated
-  344. metadata.isTest : IsTest
-  345. builtin type MutableArray
-  346. MutableArray.copyTo! : MutableArray g a
+  311. builtin type io2.Tls.SignedCert
+  312. io2.Tls.terminate.impl : Tls ->{IO} Either Failure ()
+  313. builtin type io2.Tls.Version
+  314. unique type io2.TlsFailure
+  315. builtin type io2.TVar
+  316. io2.TVar.new : a ->{STM} TVar a
+  317. io2.TVar.newIO : a ->{IO} TVar a
+  318. io2.TVar.read : TVar a ->{STM} a
+  319. io2.TVar.readIO : TVar a ->{IO} a
+  320. io2.TVar.swap : TVar a -> a ->{STM} a
+  321. io2.TVar.write : TVar a -> a ->{STM} ()
+  322. io2.validateSandboxed : [Term] -> a -> Boolean
+  323. unique type IsPropagated
+  324. IsPropagated.IsPropagated : IsPropagated
+  325. unique type IsTest
+  326. IsTest.IsTest : IsTest
+  327. unique type Link
+  328. builtin type Link.Term
+  329. Link.Term : Term -> Link
+  330. Link.Term.toText : Term -> Text
+  331. builtin type Link.Type
+  332. Link.Type : Type -> Link
+  333. builtin type List
+  334. List.++ : [a] -> [a] -> [a]
+  335. List.+: : a -> [a] -> [a]
+  336. List.:+ : [a] -> a -> [a]
+  337. List.at : Nat -> [a] -> Optional a
+  338. List.cons : a -> [a] -> [a]
+  339. List.drop : Nat -> [a] -> [a]
+  340. List.empty : [a]
+  341. List.size : [a] -> Nat
+  342. List.snoc : [a] -> a -> [a]
+  343. List.take : Nat -> [a] -> [a]
+  344. metadata.isPropagated : IsPropagated
+  345. metadata.isTest : IsTest
+  346. builtin type MutableArray
+  347. MutableArray.copyTo! : MutableArray g a
                               -> Nat
                               -> MutableArray g a
                               -> Nat
                               -> Nat
                               ->{g, Exception} ()
-  347. MutableArray.freeze : MutableArray g a
+  348. MutableArray.freeze : MutableArray g a
                              -> Nat
                              -> Nat
                              ->{g} ImmutableArray a
-  348. MutableArray.freeze! : MutableArray g a
+  349. MutableArray.freeze! : MutableArray g a
                               ->{g} ImmutableArray a
-  349. MutableArray.read : MutableArray g a
+  350. MutableArray.read : MutableArray g a
                            -> Nat
                            ->{g, Exception} a
-  350. MutableArray.size : MutableArray g a -> Nat
-  351. MutableArray.write : MutableArray g a
+  351. MutableArray.size : MutableArray g a -> Nat
+  352. MutableArray.write : MutableArray g a
                             -> Nat
                             -> a
                             ->{g, Exception} ()
-  352. builtin type MutableByteArray
-  353. MutableByteArray.copyTo! : MutableByteArray g
+  353. builtin type MutableByteArray
+  354. MutableByteArray.copyTo! : MutableByteArray g
                                   -> Nat
                                   -> MutableByteArray g
                                   -> Nat
                                   -> Nat
                                   ->{g, Exception} ()
-  354. MutableByteArray.freeze : MutableByteArray g
+  355. MutableByteArray.freeze : MutableByteArray g
                                  -> Nat
                                  -> Nat
                                  ->{g} ImmutableByteArray
-  355. MutableByteArray.freeze! : MutableByteArray g
+  356. MutableByteArray.freeze! : MutableByteArray g
                                   ->{g} ImmutableByteArray
-  356. MutableByteArray.read16be : MutableByteArray g
+  357. MutableByteArray.read16be : MutableByteArray g
                                    -> Nat
                                    ->{g, Exception} Nat
-  357. MutableByteArray.read24be : MutableByteArray g
+  358. MutableByteArray.read24be : MutableByteArray g
                                    -> Nat
                                    ->{g, Exception} Nat
-  358. MutableByteArray.read32be : MutableByteArray g
+  359. MutableByteArray.read32be : MutableByteArray g
                                    -> Nat
                                    ->{g, Exception} Nat
-  359. MutableByteArray.read40be : MutableByteArray g
+  360. MutableByteArray.read40be : MutableByteArray g
                                    -> Nat
                                    ->{g, Exception} Nat
-  360. MutableByteArray.read64be : MutableByteArray g
+  361. MutableByteArray.read64be : MutableByteArray g
                                    -> Nat
                                    ->{g, Exception} Nat
-  361. MutableByteArray.read8 : MutableByteArray g
+  362. MutableByteArray.read8 : MutableByteArray g
                                 -> Nat
                                 ->{g, Exception} Nat
-  362. MutableByteArray.size : MutableByteArray g -> Nat
-  363. MutableByteArray.write16be : MutableByteArray g
+  363. MutableByteArray.size : MutableByteArray g -> Nat
+  364. MutableByteArray.write16be : MutableByteArray g
                                     -> Nat
                                     -> Nat
                                     ->{g, Exception} ()
-  364. MutableByteArray.write32be : MutableByteArray g
+  365. MutableByteArray.write32be : MutableByteArray g
                                     -> Nat
                                     -> Nat
                                     ->{g, Exception} ()
-  365. MutableByteArray.write64be : MutableByteArray g
+  366. MutableByteArray.write64be : MutableByteArray g
                                     -> Nat
                                     -> Nat
                                     ->{g, Exception} ()
-  366. MutableByteArray.write8 : MutableByteArray g
+  367. MutableByteArray.write8 : MutableByteArray g
                                  -> Nat
                                  -> Nat
                                  ->{g, Exception} ()
-  367. builtin type Nat
-  368. Nat.* : Nat -> Nat -> Nat
-  369. Nat.+ : Nat -> Nat -> Nat
-  370. Nat./ : Nat -> Nat -> Nat
-  371. Nat.and : Nat -> Nat -> Nat
-  372. Nat.complement : Nat -> Nat
-  373. Nat.drop : Nat -> Nat -> Nat
-  374. Nat.eq : Nat -> Nat -> Boolean
-  375. Nat.fromText : Text -> Optional Nat
-  376. Nat.gt : Nat -> Nat -> Boolean
-  377. Nat.gteq : Nat -> Nat -> Boolean
-  378. Nat.increment : Nat -> Nat
-  379. Nat.isEven : Nat -> Boolean
-  380. Nat.isOdd : Nat -> Boolean
-  381. Nat.leadingZeros : Nat -> Nat
-  382. Nat.lt : Nat -> Nat -> Boolean
-  383. Nat.lteq : Nat -> Nat -> Boolean
-  384. Nat.mod : Nat -> Nat -> Nat
-  385. Nat.or : Nat -> Nat -> Nat
-  386. Nat.popCount : Nat -> Nat
-  387. Nat.pow : Nat -> Nat -> Nat
-  388. Nat.shiftLeft : Nat -> Nat -> Nat
-  389. Nat.shiftRight : Nat -> Nat -> Nat
-  390. Nat.sub : Nat -> Nat -> Int
-  391. Nat.toFloat : Nat -> Float
-  392. Nat.toInt : Nat -> Int
-  393. Nat.toText : Nat -> Text
-  394. Nat.trailingZeros : Nat -> Nat
-  395. Nat.xor : Nat -> Nat -> Nat
-  396. structural type Optional a
-  397. Optional.None : Optional a
-  398. Optional.Some : a -> Optional a
-  399. builtin type Pattern
-  400. Pattern.capture : Pattern a -> Pattern a
-  401. Pattern.isMatch : Pattern a -> a -> Boolean
-  402. Pattern.join : [Pattern a] -> Pattern a
-  403. Pattern.many : Pattern a -> Pattern a
-  404. Pattern.or : Pattern a -> Pattern a -> Pattern a
-  405. Pattern.replicate : Nat -> Nat -> Pattern a -> Pattern a
-  406. Pattern.run : Pattern a -> a -> Optional ([a], a)
-  407. builtin type Ref
-  408. Ref.read : Ref g a ->{g} a
-  409. Ref.write : Ref g a -> a ->{g} ()
-  410. builtin type Request
-  411. builtin type Scope
-  412. Scope.array : Nat ->{Scope s} MutableArray (Scope s) a
-  413. Scope.arrayOf : a
+  368. builtin type Nat
+  369. Nat.* : Nat -> Nat -> Nat
+  370. Nat.+ : Nat -> Nat -> Nat
+  371. Nat./ : Nat -> Nat -> Nat
+  372. Nat.and : Nat -> Nat -> Nat
+  373. Nat.complement : Nat -> Nat
+  374. Nat.drop : Nat -> Nat -> Nat
+  375. Nat.eq : Nat -> Nat -> Boolean
+  376. Nat.fromText : Text -> Optional Nat
+  377. Nat.gt : Nat -> Nat -> Boolean
+  378. Nat.gteq : Nat -> Nat -> Boolean
+  379. Nat.increment : Nat -> Nat
+  380. Nat.isEven : Nat -> Boolean
+  381. Nat.isOdd : Nat -> Boolean
+  382. Nat.leadingZeros : Nat -> Nat
+  383. Nat.lt : Nat -> Nat -> Boolean
+  384. Nat.lteq : Nat -> Nat -> Boolean
+  385. Nat.mod : Nat -> Nat -> Nat
+  386. Nat.or : Nat -> Nat -> Nat
+  387. Nat.popCount : Nat -> Nat
+  388. Nat.pow : Nat -> Nat -> Nat
+  389. Nat.shiftLeft : Nat -> Nat -> Nat
+  390. Nat.shiftRight : Nat -> Nat -> Nat
+  391. Nat.sub : Nat -> Nat -> Int
+  392. Nat.toFloat : Nat -> Float
+  393. Nat.toInt : Nat -> Int
+  394. Nat.toText : Nat -> Text
+  395. Nat.trailingZeros : Nat -> Nat
+  396. Nat.xor : Nat -> Nat -> Nat
+  397. structural type Optional a
+  398. Optional.None : Optional a
+  399. Optional.Some : a -> Optional a
+  400. builtin type Pattern
+  401. Pattern.capture : Pattern a -> Pattern a
+  402. Pattern.isMatch : Pattern a -> a -> Boolean
+  403. Pattern.join : [Pattern a] -> Pattern a
+  404. Pattern.many : Pattern a -> Pattern a
+  405. Pattern.or : Pattern a -> Pattern a -> Pattern a
+  406. Pattern.replicate : Nat -> Nat -> Pattern a -> Pattern a
+  407. Pattern.run : Pattern a -> a -> Optional ([a], a)
+  408. builtin type Ref
+  409. Ref.read : Ref g a ->{g} a
+  410. Ref.write : Ref g a -> a ->{g} ()
+  411. builtin type Request
+  412. builtin type Scope
+  413. Scope.array : Nat ->{Scope s} MutableArray (Scope s) a
+  414. Scope.arrayOf : a
                        -> Nat
                        ->{Scope s} MutableArray (Scope s) a
-  414. Scope.bytearray : Nat
+  415. Scope.bytearray : Nat
                          ->{Scope s} MutableByteArray (Scope s)
-  415. Scope.bytearrayOf : Nat
+  416. Scope.bytearrayOf : Nat
                            -> Nat
                            ->{Scope s} MutableByteArray
                              (Scope s)
-  416. Scope.ref : a ->{Scope s} Ref {Scope s} a
-  417. Scope.run : (∀ s. '{g, Scope s} r) ->{g} r
-  418. structural type SeqView a b
-  419. SeqView.VElem : a -> b -> SeqView a b
-  420. SeqView.VEmpty : SeqView a b
-  421. Socket.toText : Socket -> Text
-  422. unique type Test.Result
-  423. Test.Result.Fail : Text -> Result
-  424. Test.Result.Ok : Text -> Result
-  425. builtin type Text
-  426. Text.!= : Text -> Text -> Boolean
-  427. Text.++ : Text -> Text -> Text
-  428. Text.drop : Nat -> Text -> Text
-  429. Text.empty : Text
-  430. Text.eq : Text -> Text -> Boolean
-  431. Text.fromCharList : [Char] -> Text
-  432. Text.fromUtf8.impl : Bytes -> Either Failure Text
-  433. Text.gt : Text -> Text -> Boolean
-  434. Text.gteq : Text -> Text -> Boolean
-  435. Text.lt : Text -> Text -> Boolean
-  436. Text.lteq : Text -> Text -> Boolean
-  437. Text.patterns.anyChar : Pattern Text
-  438. Text.patterns.charIn : [Char] -> Pattern Text
-  439. Text.patterns.charRange : Char -> Char -> Pattern Text
-  440. Text.patterns.digit : Pattern Text
-  441. Text.patterns.eof : Pattern Text
-  442. Text.patterns.letter : Pattern Text
-  443. Text.patterns.literal : Text -> Pattern Text
-  444. Text.patterns.notCharIn : [Char] -> Pattern Text
-  445. Text.patterns.notCharRange : Char -> Char -> Pattern Text
-  446. Text.patterns.punctuation : Pattern Text
-  447. Text.patterns.space : Pattern Text
-  448. Text.repeat : Nat -> Text -> Text
-  449. Text.reverse : Text -> Text
-  450. Text.size : Text -> Nat
-  451. Text.take : Nat -> Text -> Text
-  452. Text.toCharList : Text -> [Char]
-  453. Text.toLowercase : Text -> Text
-  454. Text.toUppercase : Text -> Text
-  455. Text.toUtf8 : Text -> Bytes
-  456. Text.uncons : Text -> Optional (Char, Text)
-  457. Text.unsnoc : Text -> Optional (Text, Char)
-  458. ThreadId.toText : ThreadId -> Text
-  459. todo : a -> b
-  460. structural type Tuple a b
-  461. Tuple.Cons : a -> b -> Tuple a b
-  462. structural type Unit
-  463. Unit.Unit : ()
-  464. Universal.< : a -> a -> Boolean
-  465. Universal.<= : a -> a -> Boolean
-  466. Universal.== : a -> a -> Boolean
-  467. Universal.> : a -> a -> Boolean
-  468. Universal.>= : a -> a -> Boolean
-  469. Universal.compare : a -> a -> Int
-  470. unsafe.coerceAbilities : (a ->{e1} b) -> a ->{e2} b
-  471. builtin type Value
-  472. Value.dependencies : Value -> [Term]
-  473. Value.deserialize : Bytes -> Either Text Value
-  474. Value.load : Value ->{IO} Either [Term] a
-  475. Value.serialize : Value -> Bytes
-  476. Value.value : a -> Value
+  417. Scope.ref : a ->{Scope s} Ref {Scope s} a
+  418. Scope.run : (∀ s. '{g, Scope s} r) ->{g} r
+  419. structural type SeqView a b
+  420. SeqView.VElem : a -> b -> SeqView a b
+  421. SeqView.VEmpty : SeqView a b
+  422. Socket.toText : Socket -> Text
+  423. unique type Test.Result
+  424. Test.Result.Fail : Text -> Result
+  425. Test.Result.Ok : Text -> Result
+  426. builtin type Text
+  427. Text.!= : Text -> Text -> Boolean
+  428. Text.++ : Text -> Text -> Text
+  429. Text.drop : Nat -> Text -> Text
+  430. Text.empty : Text
+  431. Text.eq : Text -> Text -> Boolean
+  432. Text.fromCharList : [Char] -> Text
+  433. Text.fromUtf8.impl : Bytes -> Either Failure Text
+  434. Text.gt : Text -> Text -> Boolean
+  435. Text.gteq : Text -> Text -> Boolean
+  436. Text.lt : Text -> Text -> Boolean
+  437. Text.lteq : Text -> Text -> Boolean
+  438. Text.patterns.anyChar : Pattern Text
+  439. Text.patterns.charIn : [Char] -> Pattern Text
+  440. Text.patterns.charRange : Char -> Char -> Pattern Text
+  441. Text.patterns.digit : Pattern Text
+  442. Text.patterns.eof : Pattern Text
+  443. Text.patterns.letter : Pattern Text
+  444. Text.patterns.literal : Text -> Pattern Text
+  445. Text.patterns.notCharIn : [Char] -> Pattern Text
+  446. Text.patterns.notCharRange : Char -> Char -> Pattern Text
+  447. Text.patterns.punctuation : Pattern Text
+  448. Text.patterns.space : Pattern Text
+  449. Text.repeat : Nat -> Text -> Text
+  450. Text.reverse : Text -> Text
+  451. Text.size : Text -> Nat
+  452. Text.take : Nat -> Text -> Text
+  453. Text.toCharList : Text -> [Char]
+  454. Text.toLowercase : Text -> Text
+  455. Text.toUppercase : Text -> Text
+  456. Text.toUtf8 : Text -> Bytes
+  457. Text.uncons : Text -> Optional (Char, Text)
+  458. Text.unsnoc : Text -> Optional (Text, Char)
+  459. ThreadId.toText : ThreadId -> Text
+  460. todo : a -> b
+  461. structural type Tuple a b
+  462. Tuple.Cons : a -> b -> Tuple a b
+  463. structural type Unit
+  464. Unit.Unit : ()
+  465. Universal.< : a -> a -> Boolean
+  466. Universal.<= : a -> a -> Boolean
+  467. Universal.== : a -> a -> Boolean
+  468. Universal.> : a -> a -> Boolean
+  469. Universal.>= : a -> a -> Boolean
+  470. Universal.compare : a -> a -> Int
+  471. unsafe.coerceAbilities : (a ->{e1} b) -> a ->{e2} b
+  472. builtin type Value
+  473. Value.dependencies : Value -> [Term]
+  474. Value.deserialize : Bytes -> Either Text Value
+  475. Value.load : Value ->{IO} Either [Term] a
+  476. Value.serialize : Value -> Bytes
+  477. Value.value : a -> Value
   
 
 .builtin> alias.many 94-104 .mylib
@@ -660,17 +661,17 @@ Let's try it!
   
   Added definitions:
   
-    1.  Float.ceiling            : Float -> Int
-    2.  Float.cos                : Float -> Float
-    3.  Float.cosh               : Float -> Float
-    4.  Float.eq                 : Float -> Float -> Boolean
-    5.  Float.exp                : Float -> Float
-    6.  Float.floor              : Float -> Int
-    7.  Float.fromRepresentation : Nat -> Float
-    8.  Float.fromText           : Text -> Optional Float
-    9.  Float.gt                 : Float -> Float -> Boolean
-    10. Float.gteq               : Float -> Float -> Boolean
-    11. Float.log                : Float -> Float
+    1.  Float.atanh              : Float -> Float
+    2.  Float.ceiling            : Float -> Int
+    3.  Float.cos                : Float -> Float
+    4.  Float.cosh               : Float -> Float
+    5.  Float.eq                 : Float -> Float -> Boolean
+    6.  Float.exp                : Float -> Float
+    7.  Float.floor              : Float -> Int
+    8.  Float.fromRepresentation : Nat -> Float
+    9.  Float.fromText           : Text -> Optional Float
+    10. Float.gt                 : Float -> Float -> Boolean
+    11. Float.gteq               : Float -> Float -> Boolean
   
   Tip: You can use `undo` or `reflog` to undo this change.
 
@@ -730,17 +731,17 @@ I want to incorporate a few more from another namespace:
 
 .mylib> find
 
-  1.  Float.ceiling : Float -> Int
-  2.  Float.cos : Float -> Float
-  3.  Float.cosh : Float -> Float
-  4.  Float.eq : Float -> Float -> Boolean
-  5.  Float.exp : Float -> Float
-  6.  Float.floor : Float -> Int
-  7.  Float.fromRepresentation : Nat -> Float
-  8.  Float.fromText : Text -> Optional Float
-  9.  Float.gt : Float -> Float -> Boolean
-  10. Float.gteq : Float -> Float -> Boolean
-  11. Float.log : Float -> Float
+  1.  Float.atanh : Float -> Float
+  2.  Float.ceiling : Float -> Int
+  3.  Float.cos : Float -> Float
+  4.  Float.cosh : Float -> Float
+  5.  Float.eq : Float -> Float -> Boolean
+  6.  Float.exp : Float -> Float
+  7.  Float.floor : Float -> Int
+  8.  Float.fromRepresentation : Nat -> Float
+  9.  Float.fromText : Text -> Optional Float
+  10. Float.gt : Float -> Float -> Boolean
+  11. Float.gteq : Float -> Float -> Boolean
   12. List.adjacentPairs : [a] -> [(a, a)]
   13. List.all : (a ->{g} Boolean) -> [a] ->{g} Boolean
   14. List.any : (a ->{g} Boolean) -> [a] ->{g} Boolean

--- a/unison-src/transcripts/builtins-merge.output.md
+++ b/unison-src/transcripts/builtins-merge.output.md
@@ -19,7 +19,7 @@ The `builtins.merge` command adds the known builtins to a `builtin` subnamespace
   8.  Char/               (3 terms)
   9.  Code                (builtin type)
   10. Code/               (8 terms)
-  11. Debug/              (2 terms)
+  11. Debug/              (3 terms)
   12. Doc                 (type)
   13. Doc/                (6 terms)
   14. Either              (type)

--- a/unison-src/transcripts/emptyCodebase.output.md
+++ b/unison-src/transcripts/emptyCodebase.output.md
@@ -23,7 +23,7 @@ Technically, the definitions all exist, but they have no names. `builtins.merge`
 
 .foo> ls
 
-  1. builtin/ (413 terms, 63 types)
+  1. builtin/ (414 terms, 63 types)
 
 ```
 And for a limited time, you can get even more builtin goodies:
@@ -35,7 +35,7 @@ And for a limited time, you can get even more builtin goodies:
 
 .foo> ls
 
-  1. builtin/ (583 terms, 79 types)
+  1. builtin/ (584 terms, 79 types)
 
 ```
 More typically, you'd start out by pulling `base.

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -121,13 +121,13 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #q2cb2dqvje
+  ⊙ 1. #khhiq1sc3o
   
     - Deletes:
     
       feature1.y
   
-  ⊙ 2. #lbjaubg5e9
+  ⊙ 2. #0t16m7j03m
   
     + Adds / updates:
     
@@ -138,26 +138,26 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
       Original name New name(s)
       feature1.y    master.y
   
-  ⊙ 3. #71ajvea616
+  ⊙ 3. #l4cc5snm7c
   
     + Adds / updates:
     
       feature1.y
   
-  ⊙ 4. #vr2ttthg2l
+  ⊙ 4. #0ujfvnropc
   
     > Moves:
     
       Original name New name
       x             master.x
   
-  ⊙ 5. #b1o80r34ce
+  ⊙ 5. #jd5q4ga1jk
   
     + Adds / updates:
     
       x
   
-  □ 6. #7un22ntllg (start of history)
+  □ 6. #67ki96tn2j (start of history)
 
 ```
 To resurrect an old version of a namespace, you can learn its hash via the `history` command, then use `fork #namespacehash .newname`.

--- a/unison-src/transcripts/move-namespace.output.md
+++ b/unison-src/transcripts/move-namespace.output.md
@@ -267,7 +267,7 @@ I should be able to move the root into a sub-namespace
 
 .> ls
 
-  1. root/ (588 terms, 80 types)
+  1. root/ (589 terms, 80 types)
 
 .> history
 
@@ -276,13 +276,13 @@ I should be able to move the root into a sub-namespace
   
   
   
-  □ 1. #3rt95kasco (start of history)
+  □ 1. #auu2tl56oq (start of history)
 
 ```
 ```ucm
 .> ls .root.at.path
 
-  1. builtin/  (583 terms, 79 types)
+  1. builtin/  (584 terms, 79 types)
   2. existing/ (1 term)
   3. happy/    (3 terms, 1 type)
   4. history/  (1 term)
@@ -292,7 +292,7 @@ I should be able to move the root into a sub-namespace
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #9h5q2s97j1
+  ⊙ 1. #97qd306bhl
   
     - Deletes:
     
@@ -303,7 +303,7 @@ I should be able to move the root into a sub-namespace
       Original name      New name
       existing.a.termInA existing.b.termInA
   
-  ⊙ 2. #uc76cu49n5
+  ⊙ 2. #m150lr1ui2
   
     + Adds / updates:
     
@@ -315,26 +315,26 @@ I should be able to move the root into a sub-namespace
       happy.b.termInA   existing.a.termInA
       history.b.termInA existing.a.termInA
   
-  ⊙ 3. #p0i5leprku
+  ⊙ 3. #jjjgo7q3n5
   
     + Adds / updates:
     
       existing.a.termInA existing.b.termInB
   
-  ⊙ 4. #6653phkspu
+  ⊙ 4. #c0mb4ochf8
   
     > Moves:
     
       Original name     New name
       history.a.termInA history.b.termInA
   
-  ⊙ 5. #96s54m0o9q
+  ⊙ 5. #usfoef2l86
   
     - Deletes:
     
       history.b.termInB
   
-  ⊙ 6. #kdt1ubsjvc
+  ⊙ 6. #gdreu1e9hl
   
     + Adds / updates:
     
@@ -345,13 +345,13 @@ I should be able to move the root into a sub-namespace
       Original name   New name(s)
       happy.b.termInA history.a.termInA
   
-  ⊙ 7. #ilms0te7e9
+  ⊙ 7. #u0lvtvmjtq
   
     + Adds / updates:
     
       history.a.termInA history.b.termInB
   
-  ⊙ 8. #s4rrj4ar8p
+  ⊙ 8. #6p6s9eutui
   
     > Moves:
     
@@ -361,7 +361,7 @@ I should be able to move the root into a sub-namespace
       happy.a.T.T2    happy.b.T.T2
       happy.a.termInA happy.b.termInA
   
-  ⊙ 9. #neo6d1tqh5
+  ⊙ 9. #iaptpdrgpv
   
     + Adds / updates:
     
@@ -371,7 +371,7 @@ I should be able to move the root into a sub-namespace
     
       happy.a.T.T
   
-  ⊙ 10. #u3uo460daa
+  ⊙ 10. #qt23b1u7cq
   
     + Adds / updates:
     
@@ -383,7 +383,7 @@ I should be able to move the root into a sub-namespace
   
   ⠇
   
-  ⊙ 11. #bqq857tsem
+  ⊙ 11. #h8kqn6r8hl
   
 
 ```

--- a/unison-src/transcripts/name-selection.output.md
+++ b/unison-src/transcripts/name-selection.output.md
@@ -1284,112 +1284,117 @@ d = c + 10
                                                        -> Nat
     449. builtin.Char.toText                           : Char
                                                        -> Text
-    450. builtin.Float.toText                          : Float
+    450. builtin.Debug.toText                          : a
+                                                       -> Optional
+                                                         (Either
+                                                           Text
+                                                           Text)
+    451. builtin.Float.toText                          : Float
                                                        -> Text
-    451. builtin.Handle.toText                         : Handle
+    452. builtin.Handle.toText                         : Handle
                                                        -> Text
-    452. builtin.Int.toText                            : Int
+    453. builtin.Int.toText                            : Int
                                                        -> Text
-    453. builtin.Nat.toText                            : Nat
+    454. builtin.Nat.toText                            : Nat
                                                        -> Text
-    454. builtin.Socket.toText                         : Socket
+    455. builtin.Socket.toText                         : Socket
                                                        -> Text
-    455. builtin.Link.Term.toText                      : Term
+    456. builtin.Link.Term.toText                      : Term
                                                        -> Text
-    456. builtin.ThreadId.toText                       : ThreadId
+    457. builtin.ThreadId.toText                       : ThreadId
                                                        -> Text
-    457. builtin.Text.toUppercase                      : Text
+    458. builtin.Text.toUppercase                      : Text
                                                        -> Text
-    458. builtin.Text.toUtf8                           : Text
+    459. builtin.Text.toUtf8                           : Text
                                                        -> Bytes
-    459. builtin.todo                                  : a -> b
-    460. builtin.Debug.trace                           : Text
+    460. builtin.todo                                  : a -> b
+    461. builtin.Debug.trace                           : Text
                                                        -> a
                                                        -> ()
-    461. builtin.Int.trailingZeros                     : Int
+    462. builtin.Int.trailingZeros                     : Int
                                                        -> Nat
-    462. builtin.Nat.trailingZeros                     : Nat
+    463. builtin.Nat.trailingZeros                     : Nat
                                                        -> Nat
-    463. builtin.Float.truncate                        : Float
+    464. builtin.Float.truncate                        : Float
                                                        -> Int
-    464. builtin.Int.truncate0                         : Int
+    465. builtin.Int.truncate0                         : Int
                                                        -> Nat
-    465. builtin.io2.IO.tryEval                        : '{IO} a
+    466. builtin.io2.IO.tryEval                        : '{IO} a
                                                        ->{IO,
                                                        Exception} a
-    466. builtin.io2.Promise.tryRead                   : Promise
+    467. builtin.io2.Promise.tryRead                   : Promise
                                                          a
                                                        ->{IO} Optional
                                                          a
-    467. builtin.io2.MVar.tryTake                      : MVar a
+    468. builtin.io2.MVar.tryTake                      : MVar a
                                                        ->{IO} Optional
                                                          a
-    468. builtin.Text.uncons                           : Text
+    469. builtin.Text.uncons                           : Text
                                                        -> Optional
                                                          ( Char,
                                                            Text)
-    469. builtin.Any.unsafeExtract                     : Any
+    470. builtin.Any.unsafeExtract                     : Any
                                                        -> a
-    470. builtin.Text.unsnoc                           : Text
+    471. builtin.Text.unsnoc                           : Text
                                                        -> Optional
                                                          ( Text,
                                                            Char)
-    471. builtin.Code.validate                         : [( Term,
+    472. builtin.Code.validate                         : [( Term,
                                                          Code)]
                                                        ->{IO} Optional
                                                          Failure
-    472. builtin.io2.validateSandboxed                 : [Term]
+    473. builtin.io2.validateSandboxed                 : [Term]
                                                        -> a
                                                        -> Boolean
-    473. builtin.Value.value                           : a
+    474. builtin.Value.value                           : a
                                                        -> Value
-    474. builtin.Debug.watch                           : Text
+    475. builtin.Debug.watch                           : Text
                                                        -> a
                                                        -> a
-    475. builtin.MutableArray.write                    : MutableArray
+    476. builtin.MutableArray.write                    : MutableArray
                                                          g a
                                                        -> Nat
                                                        -> a
                                                        ->{g,
                                                        Exception} ()
-    476. builtin.io2.Promise.write                     : Promise
+    477. builtin.io2.Promise.write                     : Promise
                                                          a
                                                        -> a
                                                        ->{IO} Boolean
-    477. builtin.Ref.write                             : Ref g a
+    478. builtin.Ref.write                             : Ref g a
                                                        -> a
                                                        ->{g} ()
-    478. builtin.io2.TVar.write                        : TVar a
+    479. builtin.io2.TVar.write                        : TVar a
                                                        -> a
                                                        ->{STM} ()
-    479. builtin.MutableByteArray.write16be            : MutableByteArray
+    480. builtin.MutableByteArray.write16be            : MutableByteArray
                                                          g
                                                        -> Nat
                                                        -> Nat
                                                        ->{g,
                                                        Exception} ()
-    480. builtin.MutableByteArray.write32be            : MutableByteArray
+    481. builtin.MutableByteArray.write32be            : MutableByteArray
                                                          g
                                                        -> Nat
                                                        -> Nat
                                                        ->{g,
                                                        Exception} ()
-    481. builtin.MutableByteArray.write64be            : MutableByteArray
+    482. builtin.MutableByteArray.write64be            : MutableByteArray
                                                          g
                                                        -> Nat
                                                        -> Nat
                                                        ->{g,
                                                        Exception} ()
-    482. builtin.MutableByteArray.write8               : MutableByteArray
+    483. builtin.MutableByteArray.write8               : MutableByteArray
                                                          g
                                                        -> Nat
                                                        -> Nat
                                                        ->{g,
                                                        Exception} ()
-    483. builtin.Int.xor                               : Int
+    484. builtin.Int.xor                               : Int
                                                        -> Int
                                                        -> Int
-    484. builtin.Nat.xor                               : Nat
+    485. builtin.Nat.xor                               : Nat
                                                        -> Nat
                                                        -> Nat
   

--- a/unison-src/transcripts/reflog.output.md
+++ b/unison-src/transcripts/reflog.output.md
@@ -59,17 +59,17 @@ y = 2
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #momui2psqq .old`   to make an old namespace
+    `fork #9014t8bemk .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #momui2psqq`  to reset the root namespace and
+    `reset-root #9014t8bemk`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
        When   Root Hash     Action
-  1.   now    #gea9reo4v8   add
-  2.   now    #momui2psqq   add
-  3.   now    #5055be919q   builtins.merge
+  1.   now    #q24i9rm0u0   add
+  2.   now    #9014t8bemk   add
+  3.   now    #2p31h4lsei   builtins.merge
   4.          #sg60bvjo91   history starts here
   
   Tip: Use `diff.namespace 1 7` to compare namespaces between

--- a/unison-src/transcripts/squash.output.md
+++ b/unison-src/transcripts/squash.output.md
@@ -13,7 +13,7 @@ Let's look at some examples. We'll start with a namespace with just the builtins
   
   
   
-  □ 1. #jj96fe1hif (start of history)
+  □ 1. #5r75rvflum (start of history)
 
 .> fork builtin builtin2
 
@@ -42,21 +42,21 @@ Now suppose we `fork` a copy of builtin, then rename `Nat.+` to `frobnicate`, th
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #akqqraofi8
+  ⊙ 1. #ih7oa9qmee
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ 2. #jqtt4ku7e6
+  ⊙ 2. #2nsvr26oeu
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ 3. #jj96fe1hif (start of history)
+  □ 3. #5r75rvflum (start of history)
 
 ```
 If we merge that back into `builtin`, we get that same chain of history:
@@ -71,21 +71,21 @@ If we merge that back into `builtin`, we get that same chain of history:
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #akqqraofi8
+  ⊙ 1. #ih7oa9qmee
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ 2. #jqtt4ku7e6
+  ⊙ 2. #2nsvr26oeu
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ 3. #jj96fe1hif (start of history)
+  □ 3. #5r75rvflum (start of history)
 
 ```
 Let's try again, but using a `merge.squash` (or just `squash`) instead. The history will be unchanged:
@@ -106,7 +106,7 @@ Let's try again, but using a `merge.squash` (or just `squash`) instead. The hist
   
   
   
-  □ 1. #jj96fe1hif (start of history)
+  □ 1. #5r75rvflum (start of history)
 
 ```
 The churn that happened in `mybuiltin` namespace ended up back in the same spot, so the squash merge of that namespace with our original namespace had no effect.
@@ -485,13 +485,13 @@ This checks to see that squashing correctly preserves deletions:
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #igp95kiubr
+  ⊙ 1. #65gt0djmn2
   
     - Deletes:
     
       Nat.* Nat.+
   
-  □ 2. #jj96fe1hif (start of history)
+  □ 2. #5r75rvflum (start of history)
 
 ```
 Notice that `Nat.+` and `Nat.*` are deleted by the squash, and we see them deleted in one atomic step in the history.


### PR DESCRIPTION
This reworks the `Debug.trace` machinery to allow getting just the text that would be shown for a value. Instead of carrying a tracing function in the runtime, a function that generates the (annotated) text is used, and the logic for printing it is moved to the runtime itself.

Also, a builtin operation `Debug.toText` is available for getting at the text. It has three possible results:

  * `None` - the tracer is completely off
  * `Some (Left txt)` - an 'ugly' textual representation
  * `Some (Right txt)` - a 'pretty' textual representation

@jaredly This lets you get text like `"termLink Map.insert"` for term links when running inside UCM.