### PR TITLE
Add/revise some builtins related to open issues.

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -759,6 +759,7 @@ ioBuiltins =
       forall1 "a" $ \a ->
         a --> io (reft iot a)
     ),
+    ( "IO.callProcess", text --> list text --> io nat),
     ( "validateSandboxed",
       forall1 "a" $ \a -> list termLink --> a --> boolean
     ),

--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -204,6 +204,8 @@ builtinTypesSrc =
     Rename' "IO" "io2.IO",
     B' "Handle" CT.Data,
     Rename' "Handle" "io2.Handle",
+    B' "ProcessHandle" CT.Data,
+    Rename' "ProcessHandle" "io2.ProcessHandle",
     B' "Socket" CT.Data,
     Rename' "Socket" "io2.Socket",
     B' "ThreadId" CT.Data,
@@ -759,7 +761,13 @@ ioBuiltins =
       forall1 "a" $ \a ->
         a --> io (reft iot a)
     ),
-    ( "IO.callProcess", text --> list text --> io nat),
+    ( "IO.process.call", text --> list text --> io nat),
+    ( "IO.process.start",
+      text --> list text -->
+        io (tuple [handle, handle, handle, phandle])),
+    ( "IO.process.kill", phandle --> io unit),
+    ( "IO.process.wait", phandle --> io nat),
+    ( "IO.process.exitCode", phandle --> io (optionalt nat)),
     ( "validateSandboxed",
       forall1 "a" $ \a -> list termLink --> a --> boolean
     ),
@@ -955,10 +963,11 @@ iarrayt a = Type.iarrayType () `app` a
 marrayt :: Type -> Type -> Type
 marrayt g a = Type.marrayType () `app` g `app` a
 
-socket, threadId, handle, unit :: Type
+socket, threadId, handle, phandle, unit :: Type
 socket = Type.socket ()
 threadId = Type.threadId ()
 handle = Type.fileHandle ()
+phandle = Type.processHandle ()
 unit = DD.unitType ()
 
 tls, tlsClientConfig, tlsServerConfig, tlsSignedCert, tlsPrivateKey, tlsVersion, tlsCipher :: Type

--- a/parser-typechecker/src/Unison/Runtime/Foreign.hs
+++ b/parser-typechecker/src/Unison/Runtime/Foreign.hs
@@ -27,6 +27,7 @@ import qualified Data.X509 as X509
 import Network.Socket (Socket)
 import qualified Network.TLS as TLS (ClientParams, Context, ServerParams)
 import System.Clock (TimeSpec)
+import System.Process (ProcessHandle)
 import System.IO (Handle)
 import Unison.Reference (Reference)
 import Unison.Referent (Referent)
@@ -190,6 +191,8 @@ instance BuiltinForeign Text where foreignRef = Tagged Ty.textRef
 instance BuiltinForeign Bytes where foreignRef = Tagged Ty.bytesRef
 
 instance BuiltinForeign Handle where foreignRef = Tagged Ty.fileHandleRef
+
+instance BuiltinForeign ProcessHandle where foreignRef = Tagged Ty.processHandleRef
 
 instance BuiltinForeign Socket where foreignRef = Tagged Ty.socketRef
 

--- a/parser-typechecker/src/Unison/Runtime/Foreign/Function.hs
+++ b/parser-typechecker/src/Unison/Runtime/Foreign/Function.hs
@@ -358,6 +358,27 @@ instance
   ( ForeignConvention a,
     ForeignConvention b,
     ForeignConvention c,
+    ForeignConvention d
+  ) =>
+  ForeignConvention (a, b, c, d)
+  where
+  readForeign us bs ustk bstk = do
+    (us, bs, a) <- readForeign us bs ustk bstk
+    (us, bs, b) <- readForeign us bs ustk bstk
+    (us, bs, c) <- readForeign us bs ustk bstk
+    (us, bs, d) <- readForeign us bs ustk bstk
+    pure (us, bs, (a, b, c, d))
+
+  writeForeign ustk bstk (a, b, c, d) = do
+    (ustk, bstk) <- writeForeign ustk bstk d
+    (ustk, bstk) <- writeForeign ustk bstk c
+    (ustk, bstk) <- writeForeign ustk bstk b
+    writeForeign ustk bstk a
+
+instance
+  ( ForeignConvention a,
+    ForeignConvention b,
+    ForeignConvention c,
     ForeignConvention d,
     ForeignConvention e
   ) =>

--- a/parser-typechecker/src/Unison/Runtime/Machine.hs
+++ b/parser-typechecker/src/Unison/Runtime/Machine.hs
@@ -1366,28 +1366,32 @@ bprim1 !ustk !bstk UCNS i =
       pure (ustk, bstk)
 bprim1 !ustk !bstk TTOI i =
   peekOffBi bstk i >>= \t -> case readm $ Util.Text.unpack t of
-    Nothing -> do
+    Just n
+      | fromIntegral (minBound :: Int) <= n,
+        n <= fromIntegral (maxBound :: Int) -> do
+          ustk <- bumpn ustk 2
+          poke ustk 1
+          pokeOff ustk 1 (fromInteger n)
+          pure (ustk, bstk)
+    _ -> do
       ustk <- bump ustk
       poke ustk 0
-      pure (ustk, bstk)
-    Just n -> do
-      ustk <- bumpn ustk 2
-      poke ustk 1
-      pokeOff ustk 1 n
       pure (ustk, bstk)
   where
     readm ('+' : s) = readMaybe s
     readm s = readMaybe s
 bprim1 !ustk !bstk TTON i =
   peekOffBi bstk i >>= \t -> case readMaybe $ Util.Text.unpack t of
-    Nothing -> do
+    Just n
+      | 0 <= n,
+        n <= fromIntegral (maxBound :: Word) -> do
+          ustk <- bumpn ustk 2
+          poke ustk 1
+          pokeOffN ustk 1 (fromInteger n)
+          pure (ustk, bstk)
+    _ -> do
       ustk <- bump ustk
       poke ustk 0
-      pure (ustk, bstk)
-    Just n -> do
-      ustk <- bumpn ustk 2
-      poke ustk 1
-      pokeOffN ustk 1 n
       pure (ustk, bstk)
 bprim1 !ustk !bstk TTOF i =
   peekOffBi bstk i >>= \t -> case readMaybe $ Util.Text.unpack t of

--- a/unison-core/src/Unison/Type.hs
+++ b/unison-core/src/Unison/Type.hs
@@ -259,6 +259,9 @@ filePathRef = Reference.Builtin "FilePath"
 threadIdRef = Reference.Builtin "ThreadId"
 socketRef = Reference.Builtin "Socket"
 
+processHandleRef :: Reference
+processHandleRef = Reference.Builtin "ProcessHandle"
+
 scopeRef, refRef :: Reference
 scopeRef = Reference.Builtin "Scope"
 refRef = Reference.Builtin "Ref"
@@ -347,6 +350,9 @@ char a = ref a charRef
 
 fileHandle :: Ord v => a -> Type v a
 fileHandle a = ref a fileHandleRef
+
+processHandle :: Ord v => a -> Type v a
+processHandle a = ref a processHandleRef
 
 threadId :: Ord v => a -> Type v a
 threadId a = ref a threadIdRef

--- a/unison-src/transcripts-using-base/all-base-hashes.output.md
+++ b/unison-src/transcripts-using-base/all-base-hashes.output.md
@@ -1179,502 +1179,523 @@ This transcript is intended to make visible accidental changes to the hashing al
        -> FileMode
        ->{IO} Either Failure Handle
        
-  341. -- ##IO.putBytes.impl.v3
+  341. -- ##IO.process.call
+       builtin.io2.IO.process.call : Text -> [Text] ->{IO} Nat
+       
+  342. -- ##IO.process.exitCode
+       builtin.io2.IO.process.exitCode : ProcessHandle
+       ->{IO} Optional Nat
+       
+  343. -- ##IO.process.kill
+       builtin.io2.IO.process.kill : ProcessHandle ->{IO} ()
+       
+  344. -- ##IO.process.start
+       builtin.io2.IO.process.start : Text
+       -> [Text]
+       ->{IO} (Handle, Handle, Handle, ProcessHandle)
+       
+  345. -- ##IO.process.wait
+       builtin.io2.IO.process.wait : ProcessHandle ->{IO} Nat
+       
+  346. -- ##IO.putBytes.impl.v3
        builtin.io2.IO.putBytes.impl : Handle
        -> Bytes
        ->{IO} Either Failure ()
        
-  342. -- ##IO.ready.impl.v1
+  347. -- ##IO.ready.impl.v1
        builtin.io2.IO.ready.impl : Handle
        ->{IO} Either Failure Boolean
        
-  343. -- ##IO.ref
+  348. -- ##IO.ref
        builtin.io2.IO.ref : a ->{IO} Ref {IO} a
        
-  344. -- ##IO.removeDirectory.impl.v3
+  349. -- ##IO.removeDirectory.impl.v3
        builtin.io2.IO.removeDirectory.impl : Text
        ->{IO} Either Failure ()
        
-  345. -- ##IO.removeFile.impl.v3
+  350. -- ##IO.removeFile.impl.v3
        builtin.io2.IO.removeFile.impl : Text
        ->{IO} Either Failure ()
        
-  346. -- ##IO.renameDirectory.impl.v3
+  351. -- ##IO.renameDirectory.impl.v3
        builtin.io2.IO.renameDirectory.impl : Text
        -> Text
        ->{IO} Either Failure ()
        
-  347. -- ##IO.renameFile.impl.v3
+  352. -- ##IO.renameFile.impl.v3
        builtin.io2.IO.renameFile.impl : Text
        -> Text
        ->{IO} Either Failure ()
        
-  348. -- ##IO.seekHandle.impl.v3
+  353. -- ##IO.seekHandle.impl.v3
        builtin.io2.IO.seekHandle.impl : Handle
        -> SeekMode
        -> Int
        ->{IO} Either Failure ()
        
-  349. -- ##IO.serverSocket.impl.v3
+  354. -- ##IO.serverSocket.impl.v3
        builtin.io2.IO.serverSocket.impl : Optional Text
        -> Text
        ->{IO} Either Failure Socket
        
-  350. -- ##IO.setBuffering.impl.v3
+  355. -- ##IO.setBuffering.impl.v3
        builtin.io2.IO.setBuffering.impl : Handle
        -> BufferMode
        ->{IO} Either Failure ()
        
-  351. -- ##IO.setCurrentDirectory.impl.v3
+  356. -- ##IO.setCurrentDirectory.impl.v3
        builtin.io2.IO.setCurrentDirectory.impl : Text
        ->{IO} Either Failure ()
        
-  352. -- ##IO.setEcho.impl.v1
+  357. -- ##IO.setEcho.impl.v1
        builtin.io2.IO.setEcho.impl : Handle
        -> Boolean
        ->{IO} Either Failure ()
        
-  353. -- ##IO.socketAccept.impl.v3
+  358. -- ##IO.socketAccept.impl.v3
        builtin.io2.IO.socketAccept.impl : Socket
        ->{IO} Either Failure Socket
        
-  354. -- ##IO.socketPort.impl.v3
+  359. -- ##IO.socketPort.impl.v3
        builtin.io2.IO.socketPort.impl : Socket
        ->{IO} Either Failure Nat
        
-  355. -- ##IO.socketReceive.impl.v3
+  360. -- ##IO.socketReceive.impl.v3
        builtin.io2.IO.socketReceive.impl : Socket
        -> Nat
        ->{IO} Either Failure Bytes
        
-  356. -- ##IO.socketSend.impl.v3
+  361. -- ##IO.socketSend.impl.v3
        builtin.io2.IO.socketSend.impl : Socket
        -> Bytes
        ->{IO} Either Failure ()
        
-  357. -- ##IO.stdHandle
+  362. -- ##IO.stdHandle
        builtin.io2.IO.stdHandle : StdHandle -> Handle
        
-  358. -- ##IO.systemTime.impl.v3
+  363. -- ##IO.systemTime.impl.v3
        builtin.io2.IO.systemTime.impl : '{IO} Either Failure Nat
        
-  359. -- ##IO.systemTimeMicroseconds.v1
+  364. -- ##IO.systemTimeMicroseconds.v1
        builtin.io2.IO.systemTimeMicroseconds : '{IO} Int
        
-  360. -- ##IO.tryEval
+  365. -- ##IO.tryEval
        builtin.io2.IO.tryEval : '{IO} a ->{IO, Exception} a
        
-  361. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0
+  366. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0
        unique type builtin.io2.IOError
        
-  362. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#0
+  367. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#0
        builtin.io2.IOError.AlreadyExists : IOError
        
-  363. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#4
+  368. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#4
        builtin.io2.IOError.EOF : IOError
        
-  364. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#5
+  369. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#5
        builtin.io2.IOError.IllegalOperation : IOError
        
-  365. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#1
+  370. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#1
        builtin.io2.IOError.NoSuchThing : IOError
        
-  366. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#6
+  371. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#6
        builtin.io2.IOError.PermissionDenied : IOError
        
-  367. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#2
+  372. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#2
        builtin.io2.IOError.ResourceBusy : IOError
        
-  368. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#3
+  373. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#3
        builtin.io2.IOError.ResourceExhausted : IOError
        
-  369. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#7
+  374. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#7
        builtin.io2.IOError.UserError : IOError
        
-  370. -- #6ivk1e38hh0l9gcl8fn4mhf8bmak3qaji36vevg5e1n16ju5i4cl9u5gmqi7u16b907rd98gd60pouma892efbqt2ri58tmu99hp77g
+  375. -- #6ivk1e38hh0l9gcl8fn4mhf8bmak3qaji36vevg5e1n16ju5i4cl9u5gmqi7u16b907rd98gd60pouma892efbqt2ri58tmu99hp77g
        unique type builtin.io2.IOFailure
        
-  371. -- #574pvphqahl981k517dtrqtq812m05h3hj6t2bt9sn3pknenfik1krscfdb6r66nf1sm7g3r1r56k0c6ob7vg4opfq4gihi8njbnhsg
+  376. -- #574pvphqahl981k517dtrqtq812m05h3hj6t2bt9sn3pknenfik1krscfdb6r66nf1sm7g3r1r56k0c6ob7vg4opfq4gihi8njbnhsg
        unique type builtin.io2.MiscFailure
        
-  372. -- ##MVar
+  377. -- ##MVar
        builtin type builtin.io2.MVar
        
-  373. -- ##MVar.isEmpty
+  378. -- ##MVar.isEmpty
        builtin.io2.MVar.isEmpty : MVar a ->{IO} Boolean
        
-  374. -- ##MVar.new
+  379. -- ##MVar.new
        builtin.io2.MVar.new : a ->{IO} MVar a
        
-  375. -- ##MVar.newEmpty.v2
+  380. -- ##MVar.newEmpty.v2
        builtin.io2.MVar.newEmpty : '{IO} MVar a
        
-  376. -- ##MVar.put.impl.v3
+  381. -- ##MVar.put.impl.v3
        builtin.io2.MVar.put.impl : MVar a
        -> a
        ->{IO} Either Failure ()
        
-  377. -- ##MVar.read.impl.v3
+  382. -- ##MVar.read.impl.v3
        builtin.io2.MVar.read.impl : MVar a
        ->{IO} Either Failure a
        
-  378. -- ##MVar.swap.impl.v3
+  383. -- ##MVar.swap.impl.v3
        builtin.io2.MVar.swap.impl : MVar a
        -> a
        ->{IO} Either Failure a
        
-  379. -- ##MVar.take.impl.v3
+  384. -- ##MVar.take.impl.v3
        builtin.io2.MVar.take.impl : MVar a
        ->{IO} Either Failure a
        
-  380. -- ##MVar.tryPut.impl.v3
+  385. -- ##MVar.tryPut.impl.v3
        builtin.io2.MVar.tryPut.impl : MVar a
        -> a
        ->{IO} Either Failure Boolean
        
-  381. -- ##MVar.tryRead.impl.v3
+  386. -- ##MVar.tryRead.impl.v3
        builtin.io2.MVar.tryRead.impl : MVar a
        ->{IO} Either Failure (Optional a)
        
-  382. -- ##MVar.tryTake
+  387. -- ##MVar.tryTake
        builtin.io2.MVar.tryTake : MVar a ->{IO} Optional a
        
-  383. -- ##Promise
+  388. -- ##ProcessHandle
+       builtin type builtin.io2.ProcessHandle
+       
+  389. -- ##Promise
        builtin type builtin.io2.Promise
        
-  384. -- ##Promise.new
+  390. -- ##Promise.new
        builtin.io2.Promise.new : '{IO} Promise a
        
-  385. -- ##Promise.read
+  391. -- ##Promise.read
        builtin.io2.Promise.read : Promise a ->{IO} a
        
-  386. -- ##Promise.tryRead
+  392. -- ##Promise.tryRead
        builtin.io2.Promise.tryRead : Promise a ->{IO} Optional a
        
-  387. -- ##Promise.write
+  393. -- ##Promise.write
        builtin.io2.Promise.write : Promise a -> a ->{IO} Boolean
        
-  388. -- ##Ref.cas
+  394. -- ##Ref.cas
        builtin.io2.Ref.cas : Ref {IO} a
        -> Ticket a
        -> a
        ->{IO} Boolean
        
-  389. -- ##Ref.readForCas
+  395. -- ##Ref.readForCas
        builtin.io2.Ref.readForCas : Ref {IO} a ->{IO} Ticket a
        
-  390. -- ##Ref.Ticket
+  396. -- ##Ref.Ticket
        builtin type builtin.io2.Ref.Ticket
        
-  391. -- ##Ref.Ticket.read
+  397. -- ##Ref.Ticket.read
        builtin.io2.Ref.Ticket.read : Ticket a -> a
        
-  392. -- #vph2eas3lf2gi259f3khlrspml3id2l8u0ru07kb5fd833h238jk4iauju0b6decth9i3nao5jkf5eej1e1kovgmu5tghhh8jq3i7p8
+  398. -- #vph2eas3lf2gi259f3khlrspml3id2l8u0ru07kb5fd833h238jk4iauju0b6decth9i3nao5jkf5eej1e1kovgmu5tghhh8jq3i7p8
        unique type builtin.io2.RuntimeFailure
        
-  393. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40
+  399. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40
        unique type builtin.io2.SeekMode
        
-  394. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40#0
+  400. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40#0
        builtin.io2.SeekMode.AbsoluteSeek : SeekMode
        
-  395. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40#1
+  401. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40#1
        builtin.io2.SeekMode.RelativeSeek : SeekMode
        
-  396. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40#2
+  402. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40#2
        builtin.io2.SeekMode.SeekFromEnd : SeekMode
        
-  397. -- ##Socket
+  403. -- ##Socket
        builtin type builtin.io2.Socket
        
-  398. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8
+  404. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8
        unique type builtin.io2.StdHandle
        
-  399. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8#2
+  405. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8#2
        builtin.io2.StdHandle.StdErr : StdHandle
        
-  400. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8#0
+  406. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8#0
        builtin.io2.StdHandle.StdIn : StdHandle
        
-  401. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8#1
+  407. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8#1
        builtin.io2.StdHandle.StdOut : StdHandle
        
-  402. -- ##STM
+  408. -- ##STM
        builtin type builtin.io2.STM
        
-  403. -- ##STM.atomically
+  409. -- ##STM.atomically
        builtin.io2.STM.atomically : '{STM} a ->{IO} a
        
-  404. -- ##STM.retry
+  410. -- ##STM.retry
        builtin.io2.STM.retry : '{STM} a
        
-  405. -- #cggbdfff21ac5uedf4qvn4to83clinvhsovrila35u7f7e73g4l6hoj8pjmjnk713a8luhnn4bi1j9ai1nl0can1un66hvg230eog9g
+  411. -- #cggbdfff21ac5uedf4qvn4to83clinvhsovrila35u7f7e73g4l6hoj8pjmjnk713a8luhnn4bi1j9ai1nl0can1un66hvg230eog9g
        unique type builtin.io2.STMFailure
        
-  406. -- ##ThreadId
+  412. -- ##ThreadId
        builtin type builtin.io2.ThreadId
        
-  407. -- ##Tls
+  413. -- ##Tls
        builtin type builtin.io2.Tls
        
-  408. -- ##Tls.Cipher
+  414. -- ##Tls.Cipher
        builtin type builtin.io2.Tls.Cipher
        
-  409. -- ##Tls.ClientConfig
+  415. -- ##Tls.ClientConfig
        builtin type builtin.io2.Tls.ClientConfig
        
-  410. -- ##Tls.ClientConfig.certificates.set
+  416. -- ##Tls.ClientConfig.certificates.set
        builtin.io2.Tls.ClientConfig.certificates.set : [SignedCert]
        -> ClientConfig
        -> ClientConfig
        
-  411. -- ##TLS.ClientConfig.ciphers.set
+  417. -- ##TLS.ClientConfig.ciphers.set
        builtin.io2.TLS.ClientConfig.ciphers.set : [Cipher]
        -> ClientConfig
        -> ClientConfig
        
-  412. -- ##Tls.ClientConfig.default
+  418. -- ##Tls.ClientConfig.default
        builtin.io2.Tls.ClientConfig.default : Text
        -> Bytes
        -> ClientConfig
        
-  413. -- ##Tls.ClientConfig.versions.set
+  419. -- ##Tls.ClientConfig.versions.set
        builtin.io2.Tls.ClientConfig.versions.set : [Version]
        -> ClientConfig
        -> ClientConfig
        
-  414. -- ##Tls.decodeCert.impl.v3
+  420. -- ##Tls.decodeCert.impl.v3
        builtin.io2.Tls.decodeCert.impl : Bytes
        -> Either Failure SignedCert
        
-  415. -- ##Tls.decodePrivateKey
+  421. -- ##Tls.decodePrivateKey
        builtin.io2.Tls.decodePrivateKey : Bytes -> [PrivateKey]
        
-  416. -- ##Tls.encodeCert
+  422. -- ##Tls.encodeCert
        builtin.io2.Tls.encodeCert : SignedCert -> Bytes
        
-  417. -- ##Tls.encodePrivateKey
+  423. -- ##Tls.encodePrivateKey
        builtin.io2.Tls.encodePrivateKey : PrivateKey -> Bytes
        
-  418. -- ##Tls.handshake.impl.v3
+  424. -- ##Tls.handshake.impl.v3
        builtin.io2.Tls.handshake.impl : Tls
        ->{IO} Either Failure ()
        
-  419. -- ##Tls.newClient.impl.v3
+  425. -- ##Tls.newClient.impl.v3
        builtin.io2.Tls.newClient.impl : ClientConfig
        -> Socket
        ->{IO} Either Failure Tls
        
-  420. -- ##Tls.newServer.impl.v3
+  426. -- ##Tls.newServer.impl.v3
        builtin.io2.Tls.newServer.impl : ServerConfig
        -> Socket
        ->{IO} Either Failure Tls
        
-  421. -- ##Tls.PrivateKey
+  427. -- ##Tls.PrivateKey
        builtin type builtin.io2.Tls.PrivateKey
        
-  422. -- ##Tls.receive.impl.v3
+  428. -- ##Tls.receive.impl.v3
        builtin.io2.Tls.receive.impl : Tls
        ->{IO} Either Failure Bytes
        
-  423. -- ##Tls.send.impl.v3
+  429. -- ##Tls.send.impl.v3
        builtin.io2.Tls.send.impl : Tls
        -> Bytes
        ->{IO} Either Failure ()
        
-  424. -- ##Tls.ServerConfig
+  430. -- ##Tls.ServerConfig
        builtin type builtin.io2.Tls.ServerConfig
        
-  425. -- ##Tls.ServerConfig.certificates.set
+  431. -- ##Tls.ServerConfig.certificates.set
        builtin.io2.Tls.ServerConfig.certificates.set : [SignedCert]
        -> ServerConfig
        -> ServerConfig
        
-  426. -- ##Tls.ServerConfig.ciphers.set
+  432. -- ##Tls.ServerConfig.ciphers.set
        builtin.io2.Tls.ServerConfig.ciphers.set : [Cipher]
        -> ServerConfig
        -> ServerConfig
        
-  427. -- ##Tls.ServerConfig.default
+  433. -- ##Tls.ServerConfig.default
        builtin.io2.Tls.ServerConfig.default : [SignedCert]
        -> PrivateKey
        -> ServerConfig
        
-  428. -- ##Tls.ServerConfig.versions.set
+  434. -- ##Tls.ServerConfig.versions.set
        builtin.io2.Tls.ServerConfig.versions.set : [Version]
        -> ServerConfig
        -> ServerConfig
        
-  429. -- ##Tls.SignedCert
+  435. -- ##Tls.SignedCert
        builtin type builtin.io2.Tls.SignedCert
        
-  430. -- ##Tls.terminate.impl.v3
+  436. -- ##Tls.terminate.impl.v3
        builtin.io2.Tls.terminate.impl : Tls
        ->{IO} Either Failure ()
        
-  431. -- ##Tls.Version
+  437. -- ##Tls.Version
        builtin type builtin.io2.Tls.Version
        
-  432. -- #r3gag1btclr8iclbdt68irgt8n1d1vf7agv5umke3dgdbl11acj6easav6gtihanrjnct18om07638rne9ej06u2bkv2v4l36knm2l0
+  438. -- #r3gag1btclr8iclbdt68irgt8n1d1vf7agv5umke3dgdbl11acj6easav6gtihanrjnct18om07638rne9ej06u2bkv2v4l36knm2l0
        unique type builtin.io2.TlsFailure
        
-  433. -- ##TVar
+  439. -- ##TVar
        builtin type builtin.io2.TVar
        
-  434. -- ##TVar.new
+  440. -- ##TVar.new
        builtin.io2.TVar.new : a ->{STM} TVar a
        
-  435. -- ##TVar.newIO
+  441. -- ##TVar.newIO
        builtin.io2.TVar.newIO : a ->{IO} TVar a
        
-  436. -- ##TVar.read
+  442. -- ##TVar.read
        builtin.io2.TVar.read : TVar a ->{STM} a
        
-  437. -- ##TVar.readIO
+  443. -- ##TVar.readIO
        builtin.io2.TVar.readIO : TVar a ->{IO} a
        
-  438. -- ##TVar.swap
+  444. -- ##TVar.swap
        builtin.io2.TVar.swap : TVar a -> a ->{STM} a
        
-  439. -- ##TVar.write
+  445. -- ##TVar.write
        builtin.io2.TVar.write : TVar a -> a ->{STM} ()
        
-  440. -- ##validateSandboxed
+  446. -- ##validateSandboxed
        builtin.io2.validateSandboxed : [Link.Term]
        -> a
        -> Boolean
        
-  441. -- #c23jofurcegj93796o0karmkcm6baifupiuu1rtkniu74avn6a4r1n66ga5rml5di7easkgn4iak800u3tnb6kfisbrv6tcfgkb13a8
+  447. -- #c23jofurcegj93796o0karmkcm6baifupiuu1rtkniu74avn6a4r1n66ga5rml5di7easkgn4iak800u3tnb6kfisbrv6tcfgkb13a8
        unique type builtin.IsPropagated
        
-  442. -- #c23jofurcegj93796o0karmkcm6baifupiuu1rtkniu74avn6a4r1n66ga5rml5di7easkgn4iak800u3tnb6kfisbrv6tcfgkb13a8#0
+  448. -- #c23jofurcegj93796o0karmkcm6baifupiuu1rtkniu74avn6a4r1n66ga5rml5di7easkgn4iak800u3tnb6kfisbrv6tcfgkb13a8#0
        builtin.IsPropagated.IsPropagated : IsPropagated
        
-  443. -- #q6snodsh7i7u6k7gtqj73tt7nv6htjofs5f37vg2v3dsfk6hau71fs5mcv0hq3lqg111fsvoi92mngm08850aftfgh65uka9mhqvft0
+  449. -- #q6snodsh7i7u6k7gtqj73tt7nv6htjofs5f37vg2v3dsfk6hau71fs5mcv0hq3lqg111fsvoi92mngm08850aftfgh65uka9mhqvft0
        unique type builtin.IsTest
        
-  444. -- #q6snodsh7i7u6k7gtqj73tt7nv6htjofs5f37vg2v3dsfk6hau71fs5mcv0hq3lqg111fsvoi92mngm08850aftfgh65uka9mhqvft0#0
+  450. -- #q6snodsh7i7u6k7gtqj73tt7nv6htjofs5f37vg2v3dsfk6hau71fs5mcv0hq3lqg111fsvoi92mngm08850aftfgh65uka9mhqvft0#0
        builtin.IsTest.IsTest : IsTest
        
-  445. -- #68haromionghg6cvojngjrgc7t0ob658nkk8b20fpho6k6ltjtf6rfmr4ia1omige97hk34lu21qsj933vl1dkpbna7evbjfkh71r9g
+  451. -- #68haromionghg6cvojngjrgc7t0ob658nkk8b20fpho6k6ltjtf6rfmr4ia1omige97hk34lu21qsj933vl1dkpbna7evbjfkh71r9g
        unique type builtin.License
        
-  446. -- #knhl4mlkqf0mt877flahlbas2ufb7bub8f11vi9ihh9uf7r6jqaglk7rm6912q1vml50866ddl0qfa4o6d7o0gomchaoae24m0u2nk8
+  452. -- #knhl4mlkqf0mt877flahlbas2ufb7bub8f11vi9ihh9uf7r6jqaglk7rm6912q1vml50866ddl0qfa4o6d7o0gomchaoae24m0u2nk8
        builtin.License.copyrightHolders : License
        -> [CopyrightHolder]
        
-  447. -- #ucpi54l843bf1osaejl1cnn0jt3o89fak5c0120k8256in3m80ik836hnite0osl12m91utnpnt5n7pgm3oe1rv4r1hk8ai4033agvo
+  453. -- #ucpi54l843bf1osaejl1cnn0jt3o89fak5c0120k8256in3m80ik836hnite0osl12m91utnpnt5n7pgm3oe1rv4r1hk8ai4033agvo
        builtin.License.copyrightHolders.modify : ([CopyrightHolder]
        ->{g} [CopyrightHolder])
        -> License
        ->{g} License
        
-  448. -- #9hbbfn61d2odn8jvtj5da9n1e9decsrheg6chg73uf94oituv3750b9hd6vp3ljhi54dkp5uqfg57j66i39bstfd8ivgav4p3si39ro
+  454. -- #9hbbfn61d2odn8jvtj5da9n1e9decsrheg6chg73uf94oituv3750b9hd6vp3ljhi54dkp5uqfg57j66i39bstfd8ivgav4p3si39ro
        builtin.License.copyrightHolders.set : [CopyrightHolder]
        -> License
        -> License
        
-  449. -- #68haromionghg6cvojngjrgc7t0ob658nkk8b20fpho6k6ltjtf6rfmr4ia1omige97hk34lu21qsj933vl1dkpbna7evbjfkh71r9g#0
+  455. -- #68haromionghg6cvojngjrgc7t0ob658nkk8b20fpho6k6ltjtf6rfmr4ia1omige97hk34lu21qsj933vl1dkpbna7evbjfkh71r9g#0
        builtin.License.License : [CopyrightHolder]
        -> [Year]
        -> LicenseType
        -> License
        
-  450. -- #aqi4h1bfq2rjnrrfanf4nut8jd1elkkc00u1tn0rmt9ocsrds8i8pha7q9cihvbiq7edpg21iqnfornimae2gad0ab8ih0bksjnoi4g
+  456. -- #aqi4h1bfq2rjnrrfanf4nut8jd1elkkc00u1tn0rmt9ocsrds8i8pha7q9cihvbiq7edpg21iqnfornimae2gad0ab8ih0bksjnoi4g
        builtin.License.licenseType : License -> LicenseType
        
-  451. -- #1rm8kpbv278t9tqj4jfssl8q3cn4hgu1mti7bp8lhcr5h7qmojujmt9de4c31p42to8mtav61u98oad3oen8q9im20sacs69psjpugo
+  457. -- #1rm8kpbv278t9tqj4jfssl8q3cn4hgu1mti7bp8lhcr5h7qmojujmt9de4c31p42to8mtav61u98oad3oen8q9im20sacs69psjpugo
        builtin.License.licenseType.modify : (LicenseType
        ->{g} LicenseType)
        -> License
        ->{g} License
        
-  452. -- #dv9jsg0ksrlp3g0uftvkutpa8matt039o7dhat9airnkto2b703mgoi5t412hdi95pdhp9g01luga13ihmp52nk6bgh788gts6elv2o
+  458. -- #dv9jsg0ksrlp3g0uftvkutpa8matt039o7dhat9airnkto2b703mgoi5t412hdi95pdhp9g01luga13ihmp52nk6bgh788gts6elv2o
        builtin.License.licenseType.set : LicenseType
        -> License
        -> License
        
-  453. -- #fh5qbeba2hg5c5k9uppi71rfghj8df37p4cg3hk23b9pv0hpm67ok807f05t368rn6v99v7kvf7cp984v8ipkjr1j1h095g6nd9jtig
+  459. -- #fh5qbeba2hg5c5k9uppi71rfghj8df37p4cg3hk23b9pv0hpm67ok807f05t368rn6v99v7kvf7cp984v8ipkjr1j1h095g6nd9jtig
        builtin.License.years : License -> [Year]
        
-  454. -- #2samr066hti71pf0fkvb4niemm7j3amvaap3sk1dqpihqp9g8f8lknhhmjq9atai6j5kcs4huvfokvpm15ebefmfggr4hd2cetf7co0
+  460. -- #2samr066hti71pf0fkvb4niemm7j3amvaap3sk1dqpihqp9g8f8lknhhmjq9atai6j5kcs4huvfokvpm15ebefmfggr4hd2cetf7co0
        builtin.License.years.modify : ([Year] ->{g} [Year])
        -> License
        ->{g} License
        
-  455. -- #g3ap8lg6974au4meb2hl49k1k6f048det9uckmics3bkt9s571921ksqfdsch63k2pk3fij8pn697svniakkrueddh8nkflnmjk9ffo
+  461. -- #g3ap8lg6974au4meb2hl49k1k6f048det9uckmics3bkt9s571921ksqfdsch63k2pk3fij8pn697svniakkrueddh8nkflnmjk9ffo
        builtin.License.years.set : [Year] -> License -> License
        
-  456. -- #uj652rrb45urfnojgt1ssqoji7iiibu27uhrc1sfl68lm54hbr7r1dpgppsv0pvf0oile2uk2h2gn1h4vgng30fga66idihhen14qc0
+  462. -- #uj652rrb45urfnojgt1ssqoji7iiibu27uhrc1sfl68lm54hbr7r1dpgppsv0pvf0oile2uk2h2gn1h4vgng30fga66idihhen14qc0
        unique type builtin.LicenseType
        
-  457. -- #uj652rrb45urfnojgt1ssqoji7iiibu27uhrc1sfl68lm54hbr7r1dpgppsv0pvf0oile2uk2h2gn1h4vgng30fga66idihhen14qc0#0
+  463. -- #uj652rrb45urfnojgt1ssqoji7iiibu27uhrc1sfl68lm54hbr7r1dpgppsv0pvf0oile2uk2h2gn1h4vgng30fga66idihhen14qc0#0
        builtin.LicenseType.LicenseType : Doc -> LicenseType
        
-  458. -- #f4b37niu61dc517c32h3os36ig34fgnt7inaaoqdbecmscchthi14gdo0vj3eee1ru746ibvl9vnmm1pglrv3125qnhsbc0i1tqtic0
+  464. -- #f4b37niu61dc517c32h3os36ig34fgnt7inaaoqdbecmscchthi14gdo0vj3eee1ru746ibvl9vnmm1pglrv3125qnhsbc0i1tqtic0
        unique type builtin.Link
        
-  459. -- ##Link.Term
+  465. -- ##Link.Term
        builtin type builtin.Link.Term
        
-  460. -- #f4b37niu61dc517c32h3os36ig34fgnt7inaaoqdbecmscchthi14gdo0vj3eee1ru746ibvl9vnmm1pglrv3125qnhsbc0i1tqtic0#0
+  466. -- #f4b37niu61dc517c32h3os36ig34fgnt7inaaoqdbecmscchthi14gdo0vj3eee1ru746ibvl9vnmm1pglrv3125qnhsbc0i1tqtic0#0
        builtin.Link.Term : Link.Term -> Link
        
-  461. -- ##Link.Term.toText
+  467. -- ##Link.Term.toText
        builtin.Link.Term.toText : Link.Term -> Text
        
-  462. -- ##Link.Type
+  468. -- ##Link.Type
        builtin type builtin.Link.Type
        
-  463. -- #f4b37niu61dc517c32h3os36ig34fgnt7inaaoqdbecmscchthi14gdo0vj3eee1ru746ibvl9vnmm1pglrv3125qnhsbc0i1tqtic0#1
+  469. -- #f4b37niu61dc517c32h3os36ig34fgnt7inaaoqdbecmscchthi14gdo0vj3eee1ru746ibvl9vnmm1pglrv3125qnhsbc0i1tqtic0#1
        builtin.Link.Type : Type -> Link
        
-  464. -- ##Sequence
+  470. -- ##Sequence
        builtin type builtin.List
        
-  465. -- ##List.++
+  471. -- ##List.++
        builtin.List.++ : [a] -> [a] -> [a]
        
-  466. -- ##List.cons
+  472. -- ##List.cons
        builtin.List.+:, builtin.List.cons : a -> [a] -> [a]
        
-  467. -- ##List.snoc
+  473. -- ##List.snoc
        builtin.List.:+, builtin.List.snoc : [a] -> a -> [a]
        
-  468. -- ##List.at
+  474. -- ##List.at
        builtin.List.at : Nat -> [a] -> Optional a
        
-  469. -- ##List.cons
+  475. -- ##List.cons
        builtin.List.cons, builtin.List.+: : a -> [a] -> [a]
        
-  470. -- ##List.drop
+  476. -- ##List.drop
        builtin.List.drop : Nat -> [a] -> [a]
        
-  471. -- ##List.empty
+  477. -- ##List.empty
        builtin.List.empty : [a]
        
-  472. -- #a8ia0nqfghkpj4dt0t5gsk96tsfv6kg1k2cf7d7sb83tkqosebfiib2bkhjq48tc2v8ld94gf9o3hvc42pf6j49q75k0br395qavli0
+  478. -- #a8ia0nqfghkpj4dt0t5gsk96tsfv6kg1k2cf7d7sb83tkqosebfiib2bkhjq48tc2v8ld94gf9o3hvc42pf6j49q75k0br395qavli0
        builtin.List.map : (a ->{e} b) -> [a] ->{e} [b]
        
-  473. -- ##List.size
+  479. -- ##List.size
        builtin.List.size : [a] -> Nat
        
-  474. -- ##List.snoc
+  480. -- ##List.snoc
        builtin.List.snoc, builtin.List.:+ : [a] -> a -> [a]
        
-  475. -- ##List.take
+  481. -- ##List.take
        builtin.List.take : Nat -> [a] -> [a]
        
-  476. -- #cb9e3iosob3e4q0v96ifmserg27samv1lvi4dh0l0l19phvct4vbbvv19abngneb77b02h8cefr1o3ad8gnm3cn6mjgsub97gjlte8g
+  482. -- #cb9e3iosob3e4q0v96ifmserg27samv1lvi4dh0l0l19phvct4vbbvv19abngneb77b02h8cefr1o3ad8gnm3cn6mjgsub97gjlte8g
        builtin.metadata.isPropagated : IsPropagated
        
-  477. -- #lkpne3jg56pmqegv4jba6b5nnjg86qtfllnlmtvijql5lsf89rfu6tgb1s9ic0gsqs5si0v9agmj90lk0bhihbovd5o5ve023g4ocko
+  483. -- #lkpne3jg56pmqegv4jba6b5nnjg86qtfllnlmtvijql5lsf89rfu6tgb1s9ic0gsqs5si0v9agmj90lk0bhihbovd5o5ve023g4ocko
        builtin.metadata.isTest : IsTest
        
-  478. -- ##MutableArray
+  484. -- ##MutableArray
        builtin type builtin.MutableArray
        
-  479. -- ##MutableArray.copyTo!
+  485. -- ##MutableArray.copyTo!
        builtin.MutableArray.copyTo! : MutableArray g a
        -> Nat
        -> MutableArray g a
@@ -1682,34 +1703,34 @@ This transcript is intended to make visible accidental changes to the hashing al
        -> Nat
        ->{g, Exception} ()
        
-  480. -- ##MutableArray.freeze
+  486. -- ##MutableArray.freeze
        builtin.MutableArray.freeze : MutableArray g a
        -> Nat
        -> Nat
        ->{g} ImmutableArray a
        
-  481. -- ##MutableArray.freeze!
+  487. -- ##MutableArray.freeze!
        builtin.MutableArray.freeze! : MutableArray g a
        ->{g} ImmutableArray a
        
-  482. -- ##MutableArray.read
+  488. -- ##MutableArray.read
        builtin.MutableArray.read : MutableArray g a
        -> Nat
        ->{g, Exception} a
        
-  483. -- ##MutableArray.size
+  489. -- ##MutableArray.size
        builtin.MutableArray.size : MutableArray g a -> Nat
        
-  484. -- ##MutableArray.write
+  490. -- ##MutableArray.write
        builtin.MutableArray.write : MutableArray g a
        -> Nat
        -> a
        ->{g, Exception} ()
        
-  485. -- ##MutableByteArray
+  491. -- ##MutableByteArray
        builtin type builtin.MutableByteArray
        
-  486. -- ##MutableByteArray.copyTo!
+  492. -- ##MutableByteArray.copyTo!
        builtin.MutableByteArray.copyTo! : MutableByteArray g
        -> Nat
        -> MutableByteArray g
@@ -1717,682 +1738,682 @@ This transcript is intended to make visible accidental changes to the hashing al
        -> Nat
        ->{g, Exception} ()
        
-  487. -- ##MutableByteArray.freeze
+  493. -- ##MutableByteArray.freeze
        builtin.MutableByteArray.freeze : MutableByteArray g
        -> Nat
        -> Nat
        ->{g} ImmutableByteArray
        
-  488. -- ##MutableByteArray.freeze!
+  494. -- ##MutableByteArray.freeze!
        builtin.MutableByteArray.freeze! : MutableByteArray g
        ->{g} ImmutableByteArray
        
-  489. -- ##MutableByteArray.read16be
+  495. -- ##MutableByteArray.read16be
        builtin.MutableByteArray.read16be : MutableByteArray g
        -> Nat
        ->{g, Exception} Nat
        
-  490. -- ##MutableByteArray.read24be
+  496. -- ##MutableByteArray.read24be
        builtin.MutableByteArray.read24be : MutableByteArray g
        -> Nat
        ->{g, Exception} Nat
        
-  491. -- ##MutableByteArray.read32be
+  497. -- ##MutableByteArray.read32be
        builtin.MutableByteArray.read32be : MutableByteArray g
        -> Nat
        ->{g, Exception} Nat
        
-  492. -- ##MutableByteArray.read40be
+  498. -- ##MutableByteArray.read40be
        builtin.MutableByteArray.read40be : MutableByteArray g
        -> Nat
        ->{g, Exception} Nat
        
-  493. -- ##MutableByteArray.read64be
+  499. -- ##MutableByteArray.read64be
        builtin.MutableByteArray.read64be : MutableByteArray g
        -> Nat
        ->{g, Exception} Nat
        
-  494. -- ##MutableByteArray.read8
+  500. -- ##MutableByteArray.read8
        builtin.MutableByteArray.read8 : MutableByteArray g
        -> Nat
        ->{g, Exception} Nat
        
-  495. -- ##MutableByteArray.size
+  501. -- ##MutableByteArray.size
        builtin.MutableByteArray.size : MutableByteArray g -> Nat
        
-  496. -- ##MutableByteArray.write16be
+  502. -- ##MutableByteArray.write16be
        builtin.MutableByteArray.write16be : MutableByteArray g
        -> Nat
        -> Nat
        ->{g, Exception} ()
        
-  497. -- ##MutableByteArray.write32be
+  503. -- ##MutableByteArray.write32be
        builtin.MutableByteArray.write32be : MutableByteArray g
        -> Nat
        -> Nat
        ->{g, Exception} ()
        
-  498. -- ##MutableByteArray.write64be
+  504. -- ##MutableByteArray.write64be
        builtin.MutableByteArray.write64be : MutableByteArray g
        -> Nat
        -> Nat
        ->{g, Exception} ()
        
-  499. -- ##MutableByteArray.write8
+  505. -- ##MutableByteArray.write8
        builtin.MutableByteArray.write8 : MutableByteArray g
        -> Nat
        -> Nat
        ->{g, Exception} ()
        
-  500. -- ##Nat
+  506. -- ##Nat
        builtin type builtin.Nat
        
-  501. -- ##Nat.*
+  507. -- ##Nat.*
        builtin.Nat.* : Nat -> Nat -> Nat
        
-  502. -- ##Nat.+
+  508. -- ##Nat.+
        builtin.Nat.+ : Nat -> Nat -> Nat
        
-  503. -- ##Nat./
+  509. -- ##Nat./
        builtin.Nat./ : Nat -> Nat -> Nat
        
-  504. -- ##Nat.and
+  510. -- ##Nat.and
        builtin.Nat.and : Nat -> Nat -> Nat
        
-  505. -- ##Nat.complement
+  511. -- ##Nat.complement
        builtin.Nat.complement : Nat -> Nat
        
-  506. -- ##Nat.drop
+  512. -- ##Nat.drop
        builtin.Nat.drop : Nat -> Nat -> Nat
        
-  507. -- ##Nat.==
+  513. -- ##Nat.==
        builtin.Nat.eq : Nat -> Nat -> Boolean
        
-  508. -- ##Nat.fromText
+  514. -- ##Nat.fromText
        builtin.Nat.fromText : Text -> Optional Nat
        
-  509. -- ##Nat.>
+  515. -- ##Nat.>
        builtin.Nat.gt : Nat -> Nat -> Boolean
        
-  510. -- ##Nat.>=
+  516. -- ##Nat.>=
        builtin.Nat.gteq : Nat -> Nat -> Boolean
        
-  511. -- ##Nat.increment
+  517. -- ##Nat.increment
        builtin.Nat.increment : Nat -> Nat
        
-  512. -- ##Nat.isEven
+  518. -- ##Nat.isEven
        builtin.Nat.isEven : Nat -> Boolean
        
-  513. -- ##Nat.isOdd
+  519. -- ##Nat.isOdd
        builtin.Nat.isOdd : Nat -> Boolean
        
-  514. -- ##Nat.leadingZeros
+  520. -- ##Nat.leadingZeros
        builtin.Nat.leadingZeros : Nat -> Nat
        
-  515. -- ##Nat.<
+  521. -- ##Nat.<
        builtin.Nat.lt : Nat -> Nat -> Boolean
        
-  516. -- ##Nat.<=
+  522. -- ##Nat.<=
        builtin.Nat.lteq : Nat -> Nat -> Boolean
        
-  517. -- ##Nat.mod
+  523. -- ##Nat.mod
        builtin.Nat.mod : Nat -> Nat -> Nat
        
-  518. -- ##Nat.or
+  524. -- ##Nat.or
        builtin.Nat.or : Nat -> Nat -> Nat
        
-  519. -- ##Nat.popCount
+  525. -- ##Nat.popCount
        builtin.Nat.popCount : Nat -> Nat
        
-  520. -- ##Nat.pow
+  526. -- ##Nat.pow
        builtin.Nat.pow : Nat -> Nat -> Nat
        
-  521. -- ##Nat.shiftLeft
+  527. -- ##Nat.shiftLeft
        builtin.Nat.shiftLeft : Nat -> Nat -> Nat
        
-  522. -- ##Nat.shiftRight
+  528. -- ##Nat.shiftRight
        builtin.Nat.shiftRight : Nat -> Nat -> Nat
        
-  523. -- ##Nat.sub
+  529. -- ##Nat.sub
        builtin.Nat.sub : Nat -> Nat -> Int
        
-  524. -- ##Nat.toFloat
+  530. -- ##Nat.toFloat
        builtin.Nat.toFloat : Nat -> Float
        
-  525. -- ##Nat.toInt
+  531. -- ##Nat.toInt
        builtin.Nat.toInt : Nat -> Int
        
-  526. -- ##Nat.toText
+  532. -- ##Nat.toText
        builtin.Nat.toText : Nat -> Text
        
-  527. -- ##Nat.trailingZeros
+  533. -- ##Nat.trailingZeros
        builtin.Nat.trailingZeros : Nat -> Nat
        
-  528. -- ##Nat.xor
+  534. -- ##Nat.xor
        builtin.Nat.xor : Nat -> Nat -> Nat
        
-  529. -- #nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg
+  535. -- #nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg
        structural type builtin.Optional a
        
-  530. -- #nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#1
+  536. -- #nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#1
        builtin.Optional.None : Optional a
        
-  531. -- #nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#0
+  537. -- #nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#0
        builtin.Optional.Some : a -> Optional a
        
-  532. -- ##Pattern
+  538. -- ##Pattern
        builtin type builtin.Pattern
        
-  533. -- ##Pattern.capture
+  539. -- ##Pattern.capture
        builtin.Pattern.capture : Pattern a -> Pattern a
        
-  534. -- ##Pattern.isMatch
+  540. -- ##Pattern.isMatch
        builtin.Pattern.isMatch : Pattern a -> a -> Boolean
        
-  535. -- ##Pattern.join
+  541. -- ##Pattern.join
        builtin.Pattern.join : [Pattern a] -> Pattern a
        
-  536. -- ##Pattern.many
+  542. -- ##Pattern.many
        builtin.Pattern.many : Pattern a -> Pattern a
        
-  537. -- ##Pattern.or
+  543. -- ##Pattern.or
        builtin.Pattern.or : Pattern a -> Pattern a -> Pattern a
        
-  538. -- ##Pattern.replicate
+  544. -- ##Pattern.replicate
        builtin.Pattern.replicate : Nat
        -> Nat
        -> Pattern a
        -> Pattern a
        
-  539. -- ##Pattern.run
+  545. -- ##Pattern.run
        builtin.Pattern.run : Pattern a -> a -> Optional ([a], a)
        
-  540. -- #cbo8de57n17pgc5iic1741jeiunhvhfcfd7gt79vd6516u64aplasdodqoouejbgovhge2le5jb6rje923fcrllhtu01t29cdrssgbg
+  546. -- #cbo8de57n17pgc5iic1741jeiunhvhfcfd7gt79vd6516u64aplasdodqoouejbgovhge2le5jb6rje923fcrllhtu01t29cdrssgbg
        structural type builtin.Pretty txt
        
-  541. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8
+  547. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8
        unique type builtin.Pretty.Annotated w txt
        
-  542. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#1
+  548. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#1
        builtin.Pretty.Annotated.Append : w
        -> [Annotated w txt]
        -> Annotated w txt
        
-  543. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#6
+  549. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#6
        builtin.Pretty.Annotated.Empty : Annotated w txt
        
-  544. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#4
+  550. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#4
        builtin.Pretty.Annotated.Group : w
        -> Annotated w txt
        -> Annotated w txt
        
-  545. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#3
+  551. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#3
        builtin.Pretty.Annotated.Indent : w
        -> Annotated w txt
        -> Annotated w txt
        -> Annotated w txt
        -> Annotated w txt
        
-  546. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#7
+  552. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#7
        builtin.Pretty.Annotated.Lit : w
        -> txt
        -> Annotated w txt
        
-  547. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#2
+  553. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#2
        builtin.Pretty.Annotated.OrElse : w
        -> Annotated w txt
        -> Annotated w txt
        -> Annotated w txt
        
-  548. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#0
+  554. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#0
        builtin.Pretty.Annotated.Table : w
        -> [[Annotated w txt]]
        -> Annotated w txt
        
-  549. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#5
+  555. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#5
        builtin.Pretty.Annotated.Wrap : w
        -> Annotated w txt
        -> Annotated w txt
        
-  550. -- #svdhl4ogs0m1pe7ihtq5q9td72mg41tmndqif4kktbtv4p8e1ciapaj8kvflfbm876llbh60tlkefpi0v0bra8hl7mfgnpscimeqtdg
+  556. -- #svdhl4ogs0m1pe7ihtq5q9td72mg41tmndqif4kktbtv4p8e1ciapaj8kvflfbm876llbh60tlkefpi0v0bra8hl7mfgnpscimeqtdg
        builtin.Pretty.append : Pretty txt
        -> Pretty txt
        -> Pretty txt
        
-  551. -- #sonptakf85a3uklev4rq0pub00k56jdpaop4tcd9bmk0gmjjij5t16sf1knspku2hbp0uikiflbo0dtjv1i6r3t2rpjh86vo1rlaer8
+  557. -- #sonptakf85a3uklev4rq0pub00k56jdpaop4tcd9bmk0gmjjij5t16sf1knspku2hbp0uikiflbo0dtjv1i6r3t2rpjh86vo1rlaer8
        builtin.Pretty.empty : Pretty txt
        
-  552. -- #mlpplm1bhqkcif5j09204uuvfll7qte95msb0skjfd30nmei005kiich1ao39gm2j8687s14qvf5llu6i1a6fvt4vdmbp99jlfundfo
+  558. -- #mlpplm1bhqkcif5j09204uuvfll7qte95msb0skjfd30nmei005kiich1ao39gm2j8687s14qvf5llu6i1a6fvt4vdmbp99jlfundfo
        builtin.Pretty.get : Pretty txt -> Annotated () txt
        
-  553. -- #d9m2k9igi4b50cp7v5tlp3o7dot6r41rbbbsc2a4iqae3hc2a7fceh83l1n3nuotfnn7nrgt40s1kfbcnl89qcqieih125gsafk2d00
+  559. -- #d9m2k9igi4b50cp7v5tlp3o7dot6r41rbbbsc2a4iqae3hc2a7fceh83l1n3nuotfnn7nrgt40s1kfbcnl89qcqieih125gsafk2d00
        builtin.Pretty.group : Pretty txt -> Pretty txt
        
-  554. -- #p6rkh0u8gfko2fpqdje6h8cain3qakom06a28rh4ccsjsnbagmmv6gadccg4t380c4nnetq9si7bkkvbh44it4lrfvfvcn4usps1uno
+  560. -- #p6rkh0u8gfko2fpqdje6h8cain3qakom06a28rh4ccsjsnbagmmv6gadccg4t380c4nnetq9si7bkkvbh44it4lrfvfvcn4usps1uno
        builtin.Pretty.indent : Pretty txt
        -> Pretty txt
        -> Pretty txt
        
-  555. -- #f59sgojafl5so8ei4vgdpqflqcpsgovpcea73509k5qm1jb8vkeojsfsavhn64gmfpd52uo631ejqu0oj2a6t6k8jcu282lbqjou7ug
+  561. -- #f59sgojafl5so8ei4vgdpqflqcpsgovpcea73509k5qm1jb8vkeojsfsavhn64gmfpd52uo631ejqu0oj2a6t6k8jcu282lbqjou7ug
        builtin.Pretty.indent' : Pretty txt
        -> Pretty txt
        -> Pretty txt
        -> Pretty txt
        
-  556. -- #hpntja4i04u36vijdesobh75pubru68jf1fhgi49jl3nf6kall1so8hfc0bq0pm8r9kopgskiigdl04hqelklsdrdjndq5on9hsjgmo
+  562. -- #hpntja4i04u36vijdesobh75pubru68jf1fhgi49jl3nf6kall1so8hfc0bq0pm8r9kopgskiigdl04hqelklsdrdjndq5on9hsjgmo
        builtin.Pretty.join : [Pretty txt] -> Pretty txt
        
-  557. -- #jtn2i6bg3gargdp2rbk08jfd327htap62brih8phdfm2m4d6ib9cu0o2k5vrh7f4jik99eufu4hi0114akgd1oiivi8p1pa9m2fvjv0
+  563. -- #jtn2i6bg3gargdp2rbk08jfd327htap62brih8phdfm2m4d6ib9cu0o2k5vrh7f4jik99eufu4hi0114akgd1oiivi8p1pa9m2fvjv0
        builtin.Pretty.lit : txt -> Pretty txt
        
-  558. -- #pn811nf59d63s8711bpktjqub65sb748pmajg7r8n7h7cnap5ecb4n1072ccult24q6gcfac66scrm77cjsa779mcckqrs8si4716sg
+  564. -- #pn811nf59d63s8711bpktjqub65sb748pmajg7r8n7h7cnap5ecb4n1072ccult24q6gcfac66scrm77cjsa779mcckqrs8si4716sg
        builtin.Pretty.map : (txt ->{g} txt2)
        -> Pretty txt
        ->{g} Pretty txt2
        
-  559. -- #5rfcm6mlv2njfa8l9slkjp1q2q5r6m1vkp084run6pd632cf02mcpoh2bo3kuqf3uqbb5nh2drf37u51lpf16m5u415tcuk18djnr60
+  565. -- #5rfcm6mlv2njfa8l9slkjp1q2q5r6m1vkp084run6pd632cf02mcpoh2bo3kuqf3uqbb5nh2drf37u51lpf16m5u415tcuk18djnr60
        builtin.Pretty.orElse : Pretty txt
        -> Pretty txt
        -> Pretty txt
        
-  560. -- #cbo8de57n17pgc5iic1741jeiunhvhfcfd7gt79vd6516u64aplasdodqoouejbgovhge2le5jb6rje923fcrllhtu01t29cdrssgbg#0
+  566. -- #cbo8de57n17pgc5iic1741jeiunhvhfcfd7gt79vd6516u64aplasdodqoouejbgovhge2le5jb6rje923fcrllhtu01t29cdrssgbg#0
        builtin.Pretty.Pretty : Annotated () txt -> Pretty txt
        
-  561. -- #qg050nfl4eeeiarp5mvun3j15h3qpgo31a01o03mql8rrrpht3o6h6htov9ghm7cikkbjejgu4vd9v3h1idp0hanol93pqpqiq8rg3g
+  567. -- #qg050nfl4eeeiarp5mvun3j15h3qpgo31a01o03mql8rrrpht3o6h6htov9ghm7cikkbjejgu4vd9v3h1idp0hanol93pqpqiq8rg3g
        builtin.Pretty.sepBy : Pretty txt
        -> [Pretty txt]
        -> Pretty txt
        
-  562. -- #ev99k0kpivu29vfl7k8pf5n55fnnelq78ul7jqjrk946i1ckvrs5lmrji3l2avhd02mljspdbfspcn26phaqkug6p7rocbbf94uhcro
+  568. -- #ev99k0kpivu29vfl7k8pf5n55fnnelq78ul7jqjrk946i1ckvrs5lmrji3l2avhd02mljspdbfspcn26phaqkug6p7rocbbf94uhcro
        builtin.Pretty.table : [[Pretty txt]] -> Pretty txt
        
-  563. -- #7c4jq9udglq9n7pfemqmc7qrks18r80t9dgjefpi78aerb1vo8cakc3fv843dg3h60ihbo75u0jrmbhqk0och8be2am98v3mu5f6v10
+  569. -- #7c4jq9udglq9n7pfemqmc7qrks18r80t9dgjefpi78aerb1vo8cakc3fv843dg3h60ihbo75u0jrmbhqk0och8be2am98v3mu5f6v10
        builtin.Pretty.wrap : Pretty txt -> Pretty txt
        
-  564. -- ##Ref
+  570. -- ##Ref
        builtin type builtin.Ref
        
-  565. -- ##Ref.read
+  571. -- ##Ref.read
        builtin.Ref.read : Ref g a ->{g} a
        
-  566. -- ##Ref.write
+  572. -- ##Ref.write
        builtin.Ref.write : Ref g a -> a ->{g} ()
        
-  567. -- ##Effect
+  573. -- ##Effect
        builtin type builtin.Request
        
-  568. -- ##Scope
+  574. -- ##Scope
        builtin type builtin.Scope
        
-  569. -- ##Scope.array
+  575. -- ##Scope.array
        builtin.Scope.array : Nat
        ->{Scope s} MutableArray (Scope s) a
        
-  570. -- ##Scope.arrayOf
+  576. -- ##Scope.arrayOf
        builtin.Scope.arrayOf : a
        -> Nat
        ->{Scope s} MutableArray (Scope s) a
        
-  571. -- ##Scope.bytearray
+  577. -- ##Scope.bytearray
        builtin.Scope.bytearray : Nat
        ->{Scope s} MutableByteArray (Scope s)
        
-  572. -- ##Scope.bytearrayOf
+  578. -- ##Scope.bytearrayOf
        builtin.Scope.bytearrayOf : Nat
        -> Nat
        ->{Scope s} MutableByteArray (Scope s)
        
-  573. -- ##Scope.ref
+  579. -- ##Scope.ref
        builtin.Scope.ref : a ->{Scope s} Ref {Scope s} a
        
-  574. -- ##Scope.run
+  580. -- ##Scope.run
        builtin.Scope.run : (∀ s. '{g, Scope s} r) ->{g} r
        
-  575. -- #6uigas14aqgd889s036hq9ssrlo22pju41009m0rktetcrbm97qniljjc1rv1u661r4f63oq6pupoevghs8a2hupvlbi6qi4ntn9320
+  581. -- #6uigas14aqgd889s036hq9ssrlo22pju41009m0rktetcrbm97qniljjc1rv1u661r4f63oq6pupoevghs8a2hupvlbi6qi4ntn9320
        structural type builtin.SeqView a b
        
-  576. -- #6uigas14aqgd889s036hq9ssrlo22pju41009m0rktetcrbm97qniljjc1rv1u661r4f63oq6pupoevghs8a2hupvlbi6qi4ntn9320#0
+  582. -- #6uigas14aqgd889s036hq9ssrlo22pju41009m0rktetcrbm97qniljjc1rv1u661r4f63oq6pupoevghs8a2hupvlbi6qi4ntn9320#0
        builtin.SeqView.VElem : a -> b -> SeqView a b
        
-  577. -- #6uigas14aqgd889s036hq9ssrlo22pju41009m0rktetcrbm97qniljjc1rv1u661r4f63oq6pupoevghs8a2hupvlbi6qi4ntn9320#1
+  583. -- #6uigas14aqgd889s036hq9ssrlo22pju41009m0rktetcrbm97qniljjc1rv1u661r4f63oq6pupoevghs8a2hupvlbi6qi4ntn9320#1
        builtin.SeqView.VEmpty : SeqView a b
        
-  578. -- ##Socket.toText
+  584. -- ##Socket.toText
        builtin.Socket.toText : Socket -> Text
        
-  579. -- #pfp0ajb4v2mb9tspp29v53dkacb76aa1t5kbk1dl0q354cjcg4egdpmvtr5d6t818ucon9eubf6r1vdvh926fgk8otvbkvbpn90levo
+  585. -- #pfp0ajb4v2mb9tspp29v53dkacb76aa1t5kbk1dl0q354cjcg4egdpmvtr5d6t818ucon9eubf6r1vdvh926fgk8otvbkvbpn90levo
        builtin.syntax.docAside : Doc2 -> Doc2
        
-  580. -- #mvov9qf78ctohefjbmrgs8ussspo5juhf75pee4ikkg8asuos72unn4pjn3fdel8471soj2vaskd5ls103pb6nb8qf75sjn4igs7v48
+  586. -- #mvov9qf78ctohefjbmrgs8ussspo5juhf75pee4ikkg8asuos72unn4pjn3fdel8471soj2vaskd5ls103pb6nb8qf75sjn4igs7v48
        builtin.syntax.docBlockquote : Doc2 -> Doc2
        
-  581. -- #cg64hg7dag89u80104kit2p40rhmo1k6h1j8obfhjolpogs705bt6hc92ct6rfj8h74m3ioug14u9pm1s7qqpmjda2srjojhi01nvf0
+  587. -- #cg64hg7dag89u80104kit2p40rhmo1k6h1j8obfhjolpogs705bt6hc92ct6rfj8h74m3ioug14u9pm1s7qqpmjda2srjojhi01nvf0
        builtin.syntax.docBold : Doc2 -> Doc2
        
-  582. -- #3qd5kt9gjiggrb871al82n11jccedl3kb5p8ffemr703frn38tqajkett30fg7hef5orh7vl0obp3lap9qq2po3ufcnu4k3bik81rlg
+  588. -- #3qd5kt9gjiggrb871al82n11jccedl3kb5p8ffemr703frn38tqajkett30fg7hef5orh7vl0obp3lap9qq2po3ufcnu4k3bik81rlg
        builtin.syntax.docBulletedList : [Doc2] -> Doc2
        
-  583. -- #el0rph43k5qg25qg20o5jdjukuful041r87v92tcb2339om0hp9u6vqtrcrfkvgj78hrpo2o1l39bbg1oier87pvgkli0lkgalgpo90
+  589. -- #el0rph43k5qg25qg20o5jdjukuful041r87v92tcb2339om0hp9u6vqtrcrfkvgj78hrpo2o1l39bbg1oier87pvgkli0lkgalgpo90
        builtin.syntax.docCallout : Optional Doc2 -> Doc2 -> Doc2
        
-  584. -- #7jij106qpusbsbpqhmtgrk59qo8ss9e77rtrc1h9hbpnbab8sq717fe6hppmhhds9smqbv3k2q0irjgoe4mogatlp9e4k25kopt6rgo
+  590. -- #7jij106qpusbsbpqhmtgrk59qo8ss9e77rtrc1h9hbpnbab8sq717fe6hppmhhds9smqbv3k2q0irjgoe4mogatlp9e4k25kopt6rgo
        builtin.syntax.docCode : Doc2 -> Doc2
        
-  585. -- #3paq4qqrk028tati33723c4aqi7ebgnjln12avbnf7eu8h8sflg0frlehb4lni4ru0pcfg9ftsurq3pb2q11cfebeki51vom697l7h0
+  591. -- #3paq4qqrk028tati33723c4aqi7ebgnjln12avbnf7eu8h8sflg0frlehb4lni4ru0pcfg9ftsurq3pb2q11cfebeki51vom697l7h0
        builtin.syntax.docCodeBlock : Text -> Text -> Doc2
        
-  586. -- #1of955s8tqa74vu0ve863p8dn2mncc2anmms54aj084pkbdcpml6ckvs0qb4defi0df3b1e8inp29p60ac93hf2u7to0je4op9fum40
+  592. -- #1of955s8tqa74vu0ve863p8dn2mncc2anmms54aj084pkbdcpml6ckvs0qb4defi0df3b1e8inp29p60ac93hf2u7to0je4op9fum40
        builtin.syntax.docColumn : [Doc2] -> Doc2
        
-  587. -- #ukv56cjchfao07qb08l7iimd2mmv09s5glmtljo5b71leaijtja04obd0u1hsr38itjnv85f7jvd37nr654bl4lfn4msr1one0hi4s0
+  593. -- #ukv56cjchfao07qb08l7iimd2mmv09s5glmtljo5b71leaijtja04obd0u1hsr38itjnv85f7jvd37nr654bl4lfn4msr1one0hi4s0
        builtin.syntax.docEmbedAnnotation : tm -> Doc2.Term
        
-  588. -- #uccvv8mn62ne8iqppsnpgbquqmhk4hk3n4tg7p6kttr20gov4698tu18jmmvdcs7ab455q7kklhb4uv1mtei4vbvq4qmbtbu1dbagmg
+  594. -- #uccvv8mn62ne8iqppsnpgbquqmhk4hk3n4tg7p6kttr20gov4698tu18jmmvdcs7ab455q7kklhb4uv1mtei4vbvq4qmbtbu1dbagmg
        builtin.syntax.docEmbedAnnotations : tms -> tms
        
-  589. -- #h53vvsbp1eflh5n41fepa5dana1ucfjbk8qc95kf4ht12svn304hc4fv431hiejspdr84oul4gmd3s65neil759q0hmjjrr8ottc6v0
+  595. -- #h53vvsbp1eflh5n41fepa5dana1ucfjbk8qc95kf4ht12svn304hc4fv431hiejspdr84oul4gmd3s65neil759q0hmjjrr8ottc6v0
        builtin.syntax.docEmbedSignatureLink : '{g} t
        -> Doc2.Term
        
-  590. -- #dvjs6ebt2ej6funsr6rv351aqe5eqt8pcbte5hpqossikbnqrblhhnve55pdg896s4e6dvd6m3us0151ejegfg1fi8kbfd7soa31dao
+  596. -- #dvjs6ebt2ej6funsr6rv351aqe5eqt8pcbte5hpqossikbnqrblhhnve55pdg896s4e6dvd6m3us0151ejegfg1fi8kbfd7soa31dao
        builtin.syntax.docEmbedTermLink : '{g} t
        -> Either a Doc2.Term
        
-  591. -- #7t98ois54isfkh31uefvdg4bg302s5q3sun4hfh0mqnosk4ded353jp0p2ij6b22vnvlcbipcv2jb91suh6qc33i7uqlfuto9f0r4n8
+  597. -- #7t98ois54isfkh31uefvdg4bg302s5q3sun4hfh0mqnosk4ded353jp0p2ij6b22vnvlcbipcv2jb91suh6qc33i7uqlfuto9f0r4n8
        builtin.syntax.docEmbedTypeLink : typ -> Either typ b
        
-  592. -- #r26nnrb8inld7nstp0rj4sbh7ldbibo3s6ld4hmii114i8fglrvij0a1jgj70u51it80s5vgj5dvu9oi5gqmr2n7j341tg8285mpesg
+  598. -- #r26nnrb8inld7nstp0rj4sbh7ldbibo3s6ld4hmii114i8fglrvij0a1jgj70u51it80s5vgj5dvu9oi5gqmr2n7j341tg8285mpesg
        builtin.syntax.docEval : 'a -> Doc2
        
-  593. -- #ojecdd8rnla7dqqop5a43u8kl12149l24452thb0ljkb99ivh6n2evg3g43dj6unlbsmbuvj5g9js5hvsi9f13lt22uqkueioe1vi9g
+  599. -- #ojecdd8rnla7dqqop5a43u8kl12149l24452thb0ljkb99ivh6n2evg3g43dj6unlbsmbuvj5g9js5hvsi9f13lt22uqkueioe1vi9g
        builtin.syntax.docEvalInline : 'a -> Doc2
        
-  594. -- #lecedgertb8tj69o0f2bqeso83hl454am6cjp708epen78s5gtr0ljcc6agopns65lnm3du36dr4m4qu9rp8rtjvtcpg359bpbnfcm0
+  600. -- #lecedgertb8tj69o0f2bqeso83hl454am6cjp708epen78s5gtr0ljcc6agopns65lnm3du36dr4m4qu9rp8rtjvtcpg359bpbnfcm0
        builtin.syntax.docExample : Nat -> '{g} t -> Doc2
        
-  595. -- #m4ini2v12rc468iflsee87m1qrm52b257e3blah4pcblqo2np3k6ad50bt5gkjob3qrct3jbihjd6i02t7la9oh3cft1d0483lf1pq0
+  601. -- #m4ini2v12rc468iflsee87m1qrm52b257e3blah4pcblqo2np3k6ad50bt5gkjob3qrct3jbihjd6i02t7la9oh3cft1d0483lf1pq0
        builtin.syntax.docExampleBlock : Nat -> '{g} t -> Doc2
        
-  596. -- #pomj7lft70jnnuk5job0pstih2mosva1oee4tediqbkhnm54tjqnfe6qs1mqt8os1ehg9ksgenb6veub2ngdpb1qat400vn0bj3fju0
+  602. -- #pomj7lft70jnnuk5job0pstih2mosva1oee4tediqbkhnm54tjqnfe6qs1mqt8os1ehg9ksgenb6veub2ngdpb1qat400vn0bj3fju0
        builtin.syntax.docFoldedSource : [( Either Type Doc2.Term,
          [Doc2.Term])]
        -> Doc2
        
-  597. -- #4rv8dvuvf5br3vhhuturaejt1l2u8j5eidjid01f5mo7o0fgjatttmph34ma0b9s1i2badcqj3ale005jb1hnisabnh93i4is1d8kng
+  603. -- #4rv8dvuvf5br3vhhuturaejt1l2u8j5eidjid01f5mo7o0fgjatttmph34ma0b9s1i2badcqj3ale005jb1hnisabnh93i4is1d8kng
        builtin.syntax.docFormatConsole : Doc2
        -> Pretty (Either SpecialForm ConsoleText)
        
-  598. -- #99qvifgs3u7nof50jbp5lhrf8cab0qiujr1tque2b7hfj56r39o8ot2fafhafuphoraddl1j142k994e22g5v2rhq98flc0954t5918
+  604. -- #99qvifgs3u7nof50jbp5lhrf8cab0qiujr1tque2b7hfj56r39o8ot2fafhafuphoraddl1j142k994e22g5v2rhq98flc0954t5918
        builtin.syntax.docGroup : Doc2 -> Doc2
        
-  599. -- #gsratvk7mo273bqhivdv06f9rog2cj48u7ci0jp6ubt5oidf8cq0rjilimkas5801inbbsjcedh61jl40i3en1qu6r9vfe684ad6r08
+  605. -- #gsratvk7mo273bqhivdv06f9rog2cj48u7ci0jp6ubt5oidf8cq0rjilimkas5801inbbsjcedh61jl40i3en1qu6r9vfe684ad6r08
        builtin.syntax.docItalic : Doc2 -> Doc2
        
-  600. -- #piohhscvm6lgpk6vfg91u2ndmlfv81nnkspihom77ucr4dev6s22rk2n9hp38nifh5p8vt7jfvep85vudpvlg2tt99e9s2qfjv5oau8
+  606. -- #piohhscvm6lgpk6vfg91u2ndmlfv81nnkspihom77ucr4dev6s22rk2n9hp38nifh5p8vt7jfvep85vudpvlg2tt99e9s2qfjv5oau8
        builtin.syntax.docJoin : [Doc2] -> Doc2
        
-  601. -- #hjdqcolihf4obmnfoakl2t5hs1e39hpmpo9ijvc37fqgejog1ii7fpd4q2fe2rkm62tf81unmqlbud8uh63vaa9feaekg5a7uo3nq00
+  607. -- #hjdqcolihf4obmnfoakl2t5hs1e39hpmpo9ijvc37fqgejog1ii7fpd4q2fe2rkm62tf81unmqlbud8uh63vaa9feaekg5a7uo3nq00
        builtin.syntax.docLink : Either Type Doc2.Term -> Doc2
        
-  602. -- #iv6urr76b0ohvr22qa6d05e7e01cd0re77g8c98cm0bqo0im345fotsevqnhk1igtutkrrqm562gtltofvku5mh0i87ru8tdf0i53bo
+  608. -- #iv6urr76b0ohvr22qa6d05e7e01cd0re77g8c98cm0bqo0im345fotsevqnhk1igtutkrrqm562gtltofvku5mh0i87ru8tdf0i53bo
        builtin.syntax.docNamedLink : Doc2 -> Doc2 -> Doc2
        
-  603. -- #b5dvn0bqj3rc1rkmlep5f6cd6n3vp247hqku8lqndena5ocgcoae18iuq3985finagr919re4fvji011ved0g21i6o0je2jn8f7k1p0
+  609. -- #b5dvn0bqj3rc1rkmlep5f6cd6n3vp247hqku8lqndena5ocgcoae18iuq3985finagr919re4fvji011ved0g21i6o0je2jn8f7k1p0
        builtin.syntax.docNumberedList : Nat -> [Doc2] -> Doc2
        
-  604. -- #fs8mho20fqj31ch5kpn8flm4geomotov7fb5ct8mtnh52ladorgp22vder3jgt1mr0u710e6s9gn4u36c9sp19vitvq1r0adtm3t1c0
+  610. -- #fs8mho20fqj31ch5kpn8flm4geomotov7fb5ct8mtnh52ladorgp22vder3jgt1mr0u710e6s9gn4u36c9sp19vitvq1r0adtm3t1c0
        builtin.syntax.docParagraph : [Doc2] -> Doc2
        
-  605. -- #6dvkai3hc122e2h2h8c3jnijink5m20e27i640qvnt6smefpp2vna1rq4gbmulhb46tdabmkb5hsjeiuo4adtsutg4iu1vfmqhlueso
+  611. -- #6dvkai3hc122e2h2h8c3jnijink5m20e27i640qvnt6smefpp2vna1rq4gbmulhb46tdabmkb5hsjeiuo4adtsutg4iu1vfmqhlueso
        builtin.syntax.docSection : Doc2 -> [Doc2] -> Doc2
        
-  606. -- #n0idf1bdrq5vgpk4pj9db5demk1es4jsnpodfoajftehvqjelsi0h5j2domdllq2peltdek4ptaqfpl4o8l6jpmqhcom9vq107ivdu0
+  612. -- #n0idf1bdrq5vgpk4pj9db5demk1es4jsnpodfoajftehvqjelsi0h5j2domdllq2peltdek4ptaqfpl4o8l6jpmqhcom9vq107ivdu0
        builtin.syntax.docSignature : [Doc2.Term] -> Doc2
        
-  607. -- #git1povkck9jrptdmmpqrv1g17ptbq9hr17l52l8477ijk4cia24tr7cj36v1o22mvtk00qoo5jt4bs4e79sl3eh6is8ubh8aoc1pu0
+  613. -- #git1povkck9jrptdmmpqrv1g17ptbq9hr17l52l8477ijk4cia24tr7cj36v1o22mvtk00qoo5jt4bs4e79sl3eh6is8ubh8aoc1pu0
        builtin.syntax.docSignatureInline : Doc2.Term -> Doc2
        
-  608. -- #47agivvofl1jegbqpdg0eeed72mdj29d623e4kdei0l10mhgckif7q2pd968ggribregcknra9u43mhehr1q86n0t4vbe4eestnu9l8
+  614. -- #47agivvofl1jegbqpdg0eeed72mdj29d623e4kdei0l10mhgckif7q2pd968ggribregcknra9u43mhehr1q86n0t4vbe4eestnu9l8
        builtin.syntax.docSource : [( Either Type Doc2.Term,
          [Doc2.Term])]
        -> Doc2
        
-  609. -- #n6uk5tc4d8ipbga8boelh51ro24paveca9fijm1nkn3tlfddqludmlppb2ps8807v2kuou1a262sa59764mdhug2va69q4sls5jli10
+  615. -- #n6uk5tc4d8ipbga8boelh51ro24paveca9fijm1nkn3tlfddqludmlppb2ps8807v2kuou1a262sa59764mdhug2va69q4sls5jli10
        builtin.syntax.docSourceElement : link
        -> annotations
        -> (link, annotations)
        
-  610. -- #nurq288b5rfp1f5keccleh51ojgcpd2rp7cane6ftquf7gidtamffb8tr1r5h6luk1nsrqomn1k4as4kcpaskjjv35rnvoous457sag
+  616. -- #nurq288b5rfp1f5keccleh51ojgcpd2rp7cane6ftquf7gidtamffb8tr1r5h6luk1nsrqomn1k4as4kcpaskjjv35rnvoous457sag
        builtin.syntax.docStrikethrough : Doc2 -> Doc2
        
-  611. -- #4ns2amu2njhvb5mtdvh3v7oljjb5ammnb41us4ekpbhb337b6mo2a4q0790cmrusko7omphtfdsaust2fn49hr5acl40ef8fkb9556g
+  617. -- #4ns2amu2njhvb5mtdvh3v7oljjb5ammnb41us4ekpbhb337b6mo2a4q0790cmrusko7omphtfdsaust2fn49hr5acl40ef8fkb9556g
        builtin.syntax.docTable : [[Doc2]] -> Doc2
        
-  612. -- #i77kddfr68gbjt3767a091dtnqff9beltojh93md8peo28t59c6modeccsfd2tnrtmd75fa7dn0ie21kcv4me098q91h4ftg9eau5fo
+  618. -- #i77kddfr68gbjt3767a091dtnqff9beltojh93md8peo28t59c6modeccsfd2tnrtmd75fa7dn0ie21kcv4me098q91h4ftg9eau5fo
        builtin.syntax.docTooltip : Doc2 -> Doc2 -> Doc2
        
-  613. -- #r0hdacbk2orcb2ate3uhd7ht05hmfa8643slm3u63nb3jaaim533up04lgt0pq97is43v2spkqble7mtu8f63hgcc0k2tb2jhpr2b68
+  619. -- #r0hdacbk2orcb2ate3uhd7ht05hmfa8643slm3u63nb3jaaim533up04lgt0pq97is43v2spkqble7mtu8f63hgcc0k2tb2jhpr2b68
        builtin.syntax.docTransclude : d -> d
        
-  614. -- #0nptdh40ngakd2rh92bl573a7vbdjcj2kc8rai39v8bb9dfpbj90i7nob381usjsott41c3cpo2m2q095fm0k0r68e8mrda135qa1k0
+  620. -- #0nptdh40ngakd2rh92bl573a7vbdjcj2kc8rai39v8bb9dfpbj90i7nob381usjsott41c3cpo2m2q095fm0k0r68e8mrda135qa1k0
        builtin.syntax.docUntitledSection : [Doc2] -> Doc2
        
-  615. -- #krjm78blt08v52c52l4ubsnfidcrs0h6010j2v2h9ud38mgm6jj4vuqn4okp4g75039o7u78sbg6ghforucbfdf94f8am9kvt6875jo
+  621. -- #krjm78blt08v52c52l4ubsnfidcrs0h6010j2v2h9ud38mgm6jj4vuqn4okp4g75039o7u78sbg6ghforucbfdf94f8am9kvt6875jo
        builtin.syntax.docVerbatim : Doc2 -> Doc2
        
-  616. -- #c14vgd4g1tkumf4jjd9vcoos1olb3f4gbc3hketf5l8h3i0efk8igbinh6gn018tr5075uo5nv1elva6tki6ofo3pdafidrkv9m0ot0
+  622. -- #c14vgd4g1tkumf4jjd9vcoos1olb3f4gbc3hketf5l8h3i0efk8igbinh6gn018tr5075uo5nv1elva6tki6ofo3pdafidrkv9m0ot0
        builtin.syntax.docWord : Text -> Doc2
        
-  617. -- #aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0
+  623. -- #aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0
        unique type builtin.Test.Result
        
-  618. -- #aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0#0
+  624. -- #aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0#0
        builtin.Test.Result.Fail : Text -> Result
        
-  619. -- #aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0#1
+  625. -- #aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0#1
        builtin.Test.Result.Ok : Text -> Result
        
-  620. -- ##Text
+  626. -- ##Text
        builtin type builtin.Text
        
-  621. -- ##Text.!=
+  627. -- ##Text.!=
        builtin.Text.!= : Text -> Text -> Boolean
        
-  622. -- ##Text.++
+  628. -- ##Text.++
        builtin.Text.++ : Text -> Text -> Text
        
-  623. -- #nv11qo7s2lqirk3qb44jkm3q3fb6i3mn72ji2c52eubh3kufrdumanblh2bnql1o24efdhmue0v21gd7d1p5ec9j6iqrmekas0183do
+  629. -- #nv11qo7s2lqirk3qb44jkm3q3fb6i3mn72ji2c52eubh3kufrdumanblh2bnql1o24efdhmue0v21gd7d1p5ec9j6iqrmekas0183do
        builtin.Text.alignLeftWith : Nat -> Char -> Text -> Text
        
-  624. -- #ebeq250fdoigvu89fneb4c24f8f18eotc8kocdmosn4ri9shoeeg7ofkejts6clm5c6bifce66qtr0vpfkrhuup2en3khous41hp8rg
+  630. -- #ebeq250fdoigvu89fneb4c24f8f18eotc8kocdmosn4ri9shoeeg7ofkejts6clm5c6bifce66qtr0vpfkrhuup2en3khous41hp8rg
        builtin.Text.alignRightWith : Nat -> Char -> Text -> Text
        
-  625. -- ##Text.drop
+  631. -- ##Text.drop
        builtin.Text.drop : Nat -> Text -> Text
        
-  626. -- ##Text.empty
+  632. -- ##Text.empty
        builtin.Text.empty : Text
        
-  627. -- ##Text.==
+  633. -- ##Text.==
        builtin.Text.eq : Text -> Text -> Boolean
        
-  628. -- ##Text.fromCharList
+  634. -- ##Text.fromCharList
        builtin.Text.fromCharList : [Char] -> Text
        
-  629. -- ##Text.fromUtf8.impl.v3
+  635. -- ##Text.fromUtf8.impl.v3
        builtin.Text.fromUtf8.impl : Bytes -> Either Failure Text
        
-  630. -- ##Text.>
+  636. -- ##Text.>
        builtin.Text.gt : Text -> Text -> Boolean
        
-  631. -- ##Text.>=
+  637. -- ##Text.>=
        builtin.Text.gteq : Text -> Text -> Boolean
        
-  632. -- ##Text.<
+  638. -- ##Text.<
        builtin.Text.lt : Text -> Text -> Boolean
        
-  633. -- ##Text.<=
+  639. -- ##Text.<=
        builtin.Text.lteq : Text -> Text -> Boolean
        
-  634. -- ##Text.patterns.anyChar
+  640. -- ##Text.patterns.anyChar
        builtin.Text.patterns.anyChar : Pattern Text
        
-  635. -- ##Text.patterns.charIn
+  641. -- ##Text.patterns.charIn
        builtin.Text.patterns.charIn : [Char] -> Pattern Text
        
-  636. -- ##Text.patterns.charRange
+  642. -- ##Text.patterns.charRange
        builtin.Text.patterns.charRange : Char
        -> Char
        -> Pattern Text
        
-  637. -- ##Text.patterns.digit
+  643. -- ##Text.patterns.digit
        builtin.Text.patterns.digit : Pattern Text
        
-  638. -- ##Text.patterns.eof
+  644. -- ##Text.patterns.eof
        builtin.Text.patterns.eof : Pattern Text
        
-  639. -- ##Text.patterns.letter
+  645. -- ##Text.patterns.letter
        builtin.Text.patterns.letter : Pattern Text
        
-  640. -- ##Text.patterns.literal
+  646. -- ##Text.patterns.literal
        builtin.Text.patterns.literal : Text -> Pattern Text
        
-  641. -- ##Text.patterns.notCharIn
+  647. -- ##Text.patterns.notCharIn
        builtin.Text.patterns.notCharIn : [Char] -> Pattern Text
        
-  642. -- ##Text.patterns.notCharRange
+  648. -- ##Text.patterns.notCharRange
        builtin.Text.patterns.notCharRange : Char
        -> Char
        -> Pattern Text
        
-  643. -- ##Text.patterns.punctuation
+  649. -- ##Text.patterns.punctuation
        builtin.Text.patterns.punctuation : Pattern Text
        
-  644. -- ##Text.patterns.space
+  650. -- ##Text.patterns.space
        builtin.Text.patterns.space : Pattern Text
        
-  645. -- ##Text.repeat
+  651. -- ##Text.repeat
        builtin.Text.repeat : Nat -> Text -> Text
        
-  646. -- ##Text.reverse
+  652. -- ##Text.reverse
        builtin.Text.reverse : Text -> Text
        
-  647. -- ##Text.size
+  653. -- ##Text.size
        builtin.Text.size : Text -> Nat
        
-  648. -- ##Text.take
+  654. -- ##Text.take
        builtin.Text.take : Nat -> Text -> Text
        
-  649. -- ##Text.toCharList
+  655. -- ##Text.toCharList
        builtin.Text.toCharList : Text -> [Char]
        
-  650. -- ##Text.toLowercase
+  656. -- ##Text.toLowercase
        builtin.Text.toLowercase : Text -> Text
        
-  651. -- ##Text.toUppercase
+  657. -- ##Text.toUppercase
        builtin.Text.toUppercase : Text -> Text
        
-  652. -- ##Text.toUtf8
+  658. -- ##Text.toUtf8
        builtin.Text.toUtf8 : Text -> Bytes
        
-  653. -- ##Text.uncons
+  659. -- ##Text.uncons
        builtin.Text.uncons : Text -> Optional (Char, Text)
        
-  654. -- ##Text.unsnoc
+  660. -- ##Text.unsnoc
        builtin.Text.unsnoc : Text -> Optional (Text, Char)
        
-  655. -- ##ThreadId.toText
+  661. -- ##ThreadId.toText
        builtin.ThreadId.toText : ThreadId -> Text
        
-  656. -- ##todo
+  662. -- ##todo
        builtin.todo : a -> b
        
-  657. -- #2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8
+  663. -- #2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8
        structural type builtin.Tuple a b
        
-  658. -- #2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8#0
+  664. -- #2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8#0
        builtin.Tuple.Cons : a -> b -> Tuple a b
        
-  659. -- #00nv2kob8fp11qdkr750rlppf81cda95m3q0niohj1pvljnjl4r3hqrhvp1un2p40ptgkhhsne7hocod90r3qdlus9guivh7j3qcq0g
+  665. -- #00nv2kob8fp11qdkr750rlppf81cda95m3q0niohj1pvljnjl4r3hqrhvp1un2p40ptgkhhsne7hocod90r3qdlus9guivh7j3qcq0g
        structural type builtin.Unit
        
-  660. -- #00nv2kob8fp11qdkr750rlppf81cda95m3q0niohj1pvljnjl4r3hqrhvp1un2p40ptgkhhsne7hocod90r3qdlus9guivh7j3qcq0g#0
+  666. -- #00nv2kob8fp11qdkr750rlppf81cda95m3q0niohj1pvljnjl4r3hqrhvp1un2p40ptgkhhsne7hocod90r3qdlus9guivh7j3qcq0g#0
        builtin.Unit.Unit : ()
        
-  661. -- ##Universal.<
+  667. -- ##Universal.<
        builtin.Universal.< : a -> a -> Boolean
        
-  662. -- ##Universal.<=
+  668. -- ##Universal.<=
        builtin.Universal.<= : a -> a -> Boolean
        
-  663. -- ##Universal.==
+  669. -- ##Universal.==
        builtin.Universal.== : a -> a -> Boolean
        
-  664. -- ##Universal.>
+  670. -- ##Universal.>
        builtin.Universal.> : a -> a -> Boolean
        
-  665. -- ##Universal.>=
+  671. -- ##Universal.>=
        builtin.Universal.>= : a -> a -> Boolean
        
-  666. -- ##Universal.compare
+  672. -- ##Universal.compare
        builtin.Universal.compare : a -> a -> Int
        
-  667. -- ##unsafe.coerceAbilities
+  673. -- ##unsafe.coerceAbilities
        builtin.unsafe.coerceAbilities : (a ->{e1} b)
        -> a
        ->{e2} b
        
-  668. -- ##Value
+  674. -- ##Value
        builtin type builtin.Value
        
-  669. -- ##Value.dependencies
+  675. -- ##Value.dependencies
        builtin.Value.dependencies : Value -> [Link.Term]
        
-  670. -- ##Value.deserialize
+  676. -- ##Value.deserialize
        builtin.Value.deserialize : Bytes -> Either Text Value
        
-  671. -- ##Value.load
+  677. -- ##Value.load
        builtin.Value.load : Value ->{IO} Either [Link.Term] a
        
-  672. -- ##Value.serialize
+  678. -- ##Value.serialize
        builtin.Value.serialize : Value -> Bytes
        
-  673. -- ##Value.value
+  679. -- ##Value.value
        builtin.Value.value : a -> Value
        
-  674. -- #dem6aglnj8cppfrnq9qipl7geo5pim3auo9cmv1rhh5la9edalj19sspbpm1pd4vh0plokdh6qfo48gs034dqlg0s7j9fhr9p9ndtpo
+  680. -- #dem6aglnj8cppfrnq9qipl7geo5pim3auo9cmv1rhh5la9edalj19sspbpm1pd4vh0plokdh6qfo48gs034dqlg0s7j9fhr9p9ndtpo
        unique type builtin.Year
        
-  675. -- #dem6aglnj8cppfrnq9qipl7geo5pim3auo9cmv1rhh5la9edalj19sspbpm1pd4vh0plokdh6qfo48gs034dqlg0s7j9fhr9p9ndtpo#0
+  681. -- #dem6aglnj8cppfrnq9qipl7geo5pim3auo9cmv1rhh5la9edalj19sspbpm1pd4vh0plokdh6qfo48gs034dqlg0s7j9fhr9p9ndtpo#0
        builtin.Year.Year : Nat -> Year
        
-  676. -- #k0rcrut9836hr3sevkivq4n2o3t540hllesila69b16gr5fcqe0i6aepqhv2qmso6h22lbipbp3fto0oc8o73l1lvf6vpifi01gmhg8
+  682. -- #k0rcrut9836hr3sevkivq4n2o3t540hllesila69b16gr5fcqe0i6aepqhv2qmso6h22lbipbp3fto0oc8o73l1lvf6vpifi01gmhg8
        cache : [(Link.Term, Code)] ->{IO, Exception} ()
        
-  677. -- #okolgrio28p1mbl1bfjfs9qtsr1m9upblcm3ul872gcir6epkcbq619vk5bdq1fnr371nelsof6jsp8469g4j6f0gg3007p79o4kf18
+  683. -- #okolgrio28p1mbl1bfjfs9qtsr1m9upblcm3ul872gcir6epkcbq619vk5bdq1fnr371nelsof6jsp8469g4j6f0gg3007p79o4kf18
        check : Text -> Boolean ->{Stream Result} ()
        
-  678. -- #je42vk6rsefjlup01e1fmmdssf5i3ba9l6aka3bipggetfm8o4i8d1q5d7hddggu5jure1bu5ot8aq5in31to4788ctrtpb44ri83r8
+  684. -- #je42vk6rsefjlup01e1fmmdssf5i3ba9l6aka3bipggetfm8o4i8d1q5d7hddggu5jure1bu5ot8aq5in31to4788ctrtpb44ri83r8
        checks : [Boolean] -> [Result]
        
-  679. -- #barg6v1n15ea1qhp80i77gjjq3vu1noc67q2jkv9n6n5v0c9djup70ltauujgpfe0kuo8ckd20gc9kutngdpb8d22rubtb5rjldrb3o
+  685. -- #barg6v1n15ea1qhp80i77gjjq3vu1noc67q2jkv9n6n5v0c9djup70ltauujgpfe0kuo8ckd20gc9kutngdpb8d22rubtb5rjldrb3o
        clientSocket : Text -> Text ->{IO, Exception} Socket
        
-  680. -- #lg7i12ido0jr43ovdbhhv2enpk5ar869leouri5qhrivinde93nl86s2rgshubtfhlogbe310k3rluotscmus9moo1tvpn0nmp1efv8
+  686. -- #lg7i12ido0jr43ovdbhhv2enpk5ar869leouri5qhrivinde93nl86s2rgshubtfhlogbe310k3rluotscmus9moo1tvpn0nmp1efv8
        closeFile : Handle ->{IO, Exception} ()
        
-  681. -- #4e6qn65v05l32n380lpf536u4llnp6f6tvvt13hvo0bhqeh3f3i8bquekc120c8h59gld1mf02ok0sje7037ipg1fsu97fqrm01oi00
+  687. -- #4e6qn65v05l32n380lpf536u4llnp6f6tvvt13hvo0bhqeh3f3i8bquekc120c8h59gld1mf02ok0sje7037ipg1fsu97fqrm01oi00
        closeSocket : Socket ->{IO, Exception} ()
        
-  682. -- #7o1e77u808vpg8i6k1mvutg8h6tdr14hegfad23e9sjou1ft10kvfr95goo0kv2ldqlsaa4pmvdl8d7jd6h252i3jija05b4vpqbg5g
+  688. -- #7o1e77u808vpg8i6k1mvutg8h6tdr14hegfad23e9sjou1ft10kvfr95goo0kv2ldqlsaa4pmvdl8d7jd6h252i3jija05b4vpqbg5g
        Code.transitiveDeps : Link.Term
        ->{IO} [(Link.Term, Code)]
        
-  683. -- #sfud7h76up0cofgk61b7tf8rhdlugfmg44lksnpglfes1b8po26si7betka39r9j8dpgueorjdrb1i7v4g62m5bci1e971eqi8dblmo
+  689. -- #sfud7h76up0cofgk61b7tf8rhdlugfmg44lksnpglfes1b8po26si7betka39r9j8dpgueorjdrb1i7v4g62m5bci1e971eqi8dblmo
        compose : ∀ o g1 i1 g i.
          (i1 ->{g1} o) -> (i ->{g} i1) -> i ->{g1, g} o
        
-  684. -- #b0tsob9a3fegn5dkb57jh15smd7ho2qo78st6qngpa7a8hc88mccl7vhido41o4otokv5l8hjdj3nabtkmpni5ikeatd44agmqbhano
+  690. -- #b0tsob9a3fegn5dkb57jh15smd7ho2qo78st6qngpa7a8hc88mccl7vhido41o4otokv5l8hjdj3nabtkmpni5ikeatd44agmqbhano
        compose2 : ∀ o g2 i2 g1 g i i1.
          (i2 ->{g2} o)
          -> (i1 ->{g1} i ->{g} i2)
@@ -2400,7 +2421,7 @@ This transcript is intended to make visible accidental changes to the hashing al
          -> i
          ->{g2, g1, g} o
        
-  685. -- #m632ocgh2rougfejkddsso3vfpf4dmg1f8bhf0k6sha4g4aqfmbeuct3eo0je6dv9utterfvotjdu32p0kojuo9fj4qkp2g1bt464eg
+  691. -- #m632ocgh2rougfejkddsso3vfpf4dmg1f8bhf0k6sha4g4aqfmbeuct3eo0je6dv9utterfvotjdu32p0kojuo9fj4qkp2g1bt464eg
        compose3 : ∀ o g3 i3 g2 g1 g i i1 i2.
          (i3 ->{g3} o)
          -> (i2 ->{g2} i1 ->{g1} i ->{g} i3)
@@ -2409,318 +2430,318 @@ This transcript is intended to make visible accidental changes to the hashing al
          -> i
          ->{g3, g2, g1, g} o
        
-  686. -- #ilkeid6l866bmq90d2v1ilqp9dsjo6ucmf8udgrokq3nr3mo9skl2vao2mo7ish136as52rsf19u9v3jkmd85bl08gnmamo4e5v2fqo
+  692. -- #ilkeid6l866bmq90d2v1ilqp9dsjo6ucmf8udgrokq3nr3mo9skl2vao2mo7ish136as52rsf19u9v3jkmd85bl08gnmamo4e5v2fqo
        contains : Text -> Text -> Boolean
        
-  687. -- #tgvna0i8ea98jvnd2oka85cdtas1prcbq3snvc4qfns6082mlckps2cspk8jln11mklg19bna025tog5m9sb671o27ujsa90lfrbnkg
+  693. -- #tgvna0i8ea98jvnd2oka85cdtas1prcbq3snvc4qfns6082mlckps2cspk8jln11mklg19bna025tog5m9sb671o27ujsa90lfrbnkg
        crawl : [(Link.Term, Code)]
        -> [Link.Term]
        ->{IO} [(Link.Term, Code)]
        
-  688. -- #o0qn048fk7tjb8e7d54vq5mg9egr5kophb9pcm0to4aj0kf39mv76c6olsm27vj309d7nhjh4nps7098fpvqe8j5cfg01ghf3bnju90
+  694. -- #o0qn048fk7tjb8e7d54vq5mg9egr5kophb9pcm0to4aj0kf39mv76c6olsm27vj309d7nhjh4nps7098fpvqe8j5cfg01ghf3bnju90
        createTempDirectory : Text ->{IO, Exception} Text
        
-  689. -- #4858f4krb9l4ot1hml21j48lp3bcvbo8b9unlk33b9a3ovu1jrbr1k56pnfhffkiu1bht2ovh0i82nn5jnoc5s5ru85qvua0m2ol43g
+  695. -- #4858f4krb9l4ot1hml21j48lp3bcvbo8b9unlk33b9a3ovu1jrbr1k56pnfhffkiu1bht2ovh0i82nn5jnoc5s5ru85qvua0m2ol43g
        decodeCert : Bytes ->{Exception} SignedCert
        
-  690. -- #ihbmfc4r7o3391jocjm6v4mojpp3hvt84ivqigrmp34vb5l3d7mmdlvh3hkrtebi812npso7rqo203a59pbs7r2g78ig6jvsv0nva38
+  696. -- #ihbmfc4r7o3391jocjm6v4mojpp3hvt84ivqigrmp34vb5l3d7mmdlvh3hkrtebi812npso7rqo203a59pbs7r2g78ig6jvsv0nva38
        delay : Nat ->{IO, Exception} ()
        
-  691. -- #dsen29k7605pkfquesnaphhmlm3pjkfgm7m2oc90m53gqvob4l39p4g3id3pirl8emg5tcdmr81ctl3lk1enm52mldlfmlh1i85rjbg
+  697. -- #dsen29k7605pkfquesnaphhmlm3pjkfgm7m2oc90m53gqvob4l39p4g3id3pirl8emg5tcdmr81ctl3lk1enm52mldlfmlh1i85rjbg
        directoryContents : Text ->{IO, Exception} [Text]
        
-  692. -- #b22tpqhkq6kvt27dcsddnbfci2bcqutvhmumdven9c5psiilboq2mb8v9ekihtkl6mkartd5ml5u75u84v850n29l91de63lkg3ud38
+  698. -- #b22tpqhkq6kvt27dcsddnbfci2bcqutvhmumdven9c5psiilboq2mb8v9ekihtkl6mkartd5ml5u75u84v850n29l91de63lkg3ud38
        Either.isLeft : Either a b -> Boolean
        
-  693. -- #i1ec3csomb1pegm9r7ppabunabb7cq1t6bb6cvqtt72nd01jot7gde2mak288cbml910abbtho0smsbq17b2r33j599b0vuv7je04j8
+  699. -- #i1ec3csomb1pegm9r7ppabunabb7cq1t6bb6cvqtt72nd01jot7gde2mak288cbml910abbtho0smsbq17b2r33j599b0vuv7je04j8
        Either.mapLeft : (i ->{g} o)
        -> Either i b
        ->{g} Either o b
        
-  694. -- #f765l0pa2tb9ieciivum76s7bp8rdjr8j7i635jjenj9tacgba9eeomur4vv3uuh4kem1pggpmrn61a1e3im9g90okcm13r192f7alg
+  700. -- #f765l0pa2tb9ieciivum76s7bp8rdjr8j7i635jjenj9tacgba9eeomur4vv3uuh4kem1pggpmrn61a1e3im9g90okcm13r192f7alg
        Either.raiseMessage : v -> Either Text b ->{Exception} b
        
-  695. -- #9hifem8o2e1g7tdh4om9kfo98ifr60gfmdp8ci58djn17epm1b4m6idli8b373bsrg487n87n4l50ksq76avlrbh9q2jpobkk18ucvg
+  701. -- #9hifem8o2e1g7tdh4om9kfo98ifr60gfmdp8ci58djn17epm1b4m6idli8b373bsrg487n87n4l50ksq76avlrbh9q2jpobkk18ucvg
        evalTest : '{IO, TempDirs, Exception, Stream Result} a
        ->{IO, Exception} ([Result], a)
        
-  696. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng
+  702. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng
        structural ability Exception
        structural ability builtin.Exception
        
-  697. -- #t20uuuiil07o22les8gv4sji7ju5esevloamnja3bjkrh2f250lgitv6595l6hlc2q64c1om0hhjqgter28dtnibb0dkr2j7e3ss530
+  703. -- #t20uuuiil07o22les8gv4sji7ju5esevloamnja3bjkrh2f250lgitv6595l6hlc2q64c1om0hhjqgter28dtnibb0dkr2j7e3ss530
        Exception.catch : '{g, Exception} a
        ->{g} Either Failure a
        
-  698. -- #hbhvk2e00l6o7qhn8e7p6dc36bjl7ljm0gn2df5clidlrdoufsig1gt5pjhg72kl67folgg2b892kh9jc1oh0l79h4p8dqhcf1tkde0
+  704. -- #hbhvk2e00l6o7qhn8e7p6dc36bjl7ljm0gn2df5clidlrdoufsig1gt5pjhg72kl67folgg2b892kh9jc1oh0l79h4p8dqhcf1tkde0
        Exception.failure : Text -> a -> Failure
        
-  699. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng#0
+  705. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng#0
        Exception.raise,
        builtin.Exception.raise : Failure
        ->{Exception} x
        
-  700. -- #5mqjoauctm02dlqdc10cc66relu40997d6o1u8fj7vv7g0i2mtacjc83afqhuekll1gkqr9vv4lq7aenanq4kf53kcce4l1srr6ip08
+  706. -- #5mqjoauctm02dlqdc10cc66relu40997d6o1u8fj7vv7g0i2mtacjc83afqhuekll1gkqr9vv4lq7aenanq4kf53kcce4l1srr6ip08
        Exception.reraise : Either Failure a ->{Exception} a
        
-  701. -- #1f774ia7im9i0cfp7l5a1g9tkvnd4m2940ga3buaf4ekd43dr1289vknghjjvi4qtevh7s61p5s573gpli51qh7e0i5pj9ggmeb69d0
+  707. -- #1f774ia7im9i0cfp7l5a1g9tkvnd4m2940ga3buaf4ekd43dr1289vknghjjvi4qtevh7s61p5s573gpli51qh7e0i5pj9ggmeb69d0
        Exception.toEither : '{ε, Exception} a
        ->{ε} Either Failure a
        
-  702. -- #li2h4hncbgmfi5scuah06rtdt8rjcipiv2t95hos15ol63usv78ti3vng7o9862a70906rum7nrrs9qd9q8iqu1rdcfe292r0al7n38
+  708. -- #li2h4hncbgmfi5scuah06rtdt8rjcipiv2t95hos15ol63usv78ti3vng7o9862a70906rum7nrrs9qd9q8iqu1rdcfe292r0al7n38
        Exception.toEither.handler : Request {Exception} a
        -> Either Failure a
        
-  703. -- #5fi0ep8mufag822f18ukaffakrmm3ddg8a83dkj4gh2ks4e2c60sk9s8pmk92p69bvkcflql3rgoalp8ruth7fapqrks3kbmdl61b00
+  709. -- #5fi0ep8mufag822f18ukaffakrmm3ddg8a83dkj4gh2ks4e2c60sk9s8pmk92p69bvkcflql3rgoalp8ruth7fapqrks3kbmdl61b00
        Exception.unsafeRun! : '{g, Exception} a ->{g} a
        
-  704. -- #qdcih6h4dmf9a2tn2ndvn0br9ef41ubhcniadou1m6ro641gm2tn79m6boh5sr4q271oiui6ehbdqe53r0gobdeagotkjr67kieq3ro
+  710. -- #qdcih6h4dmf9a2tn2ndvn0br9ef41ubhcniadou1m6ro641gm2tn79m6boh5sr4q271oiui6ehbdqe53r0gobdeagotkjr67kieq3ro
        expect : Text
        -> (a -> a -> Boolean)
        -> a
        -> a
        ->{Stream Result} ()
        
-  705. -- #ngmnbge6f7nkehkkhj6rkit60rp3qlt0vij33itch1el3ta2ukrit4gvpn2n0j0s43sj9af53kphgs0h2n65bnqcr9pmasud2r7klsg
+  711. -- #ngmnbge6f7nkehkkhj6rkit60rp3qlt0vij33itch1el3ta2ukrit4gvpn2n0j0s43sj9af53kphgs0h2n65bnqcr9pmasud2r7klsg
        expectU : Text -> a -> a ->{Stream Result} ()
        
-  706. -- #f54plhut9f6mg77r1f033vubik89irq1eri79d5pd6mqi03rq9em99mc90plurvjnmvho73ssof5fvndgmcg4fgrpvuuil7hb5qmebo
+  712. -- #f54plhut9f6mg77r1f033vubik89irq1eri79d5pd6mqi03rq9em99mc90plurvjnmvho73ssof5fvndgmcg4fgrpvuuil7hb5qmebo
        fail : Text -> b ->{Exception} c
        
-  707. -- #mpe805fs330vqp5l5mg73deahken20dub4hrfvmuutfo97dikgagvimncfr6mfp1l24bjqes1m1dp11a3hop92u49b1fb45j8qs9hoo
+  713. -- #mpe805fs330vqp5l5mg73deahken20dub4hrfvmuutfo97dikgagvimncfr6mfp1l24bjqes1m1dp11a3hop92u49b1fb45j8qs9hoo
        fileExists : Text ->{IO, Exception} Boolean
        
-  708. -- #cft2pjc05jljtlefm4osg96k5t2look2ujq1tgg5hoc5i3fkkatt9pf79g2ka461kq8nbmsggrvo2675ocl599to9e8nre5oef4scdo
+  714. -- #cft2pjc05jljtlefm4osg96k5t2look2ujq1tgg5hoc5i3fkkatt9pf79g2ka461kq8nbmsggrvo2675ocl599to9e8nre5oef4scdo
        fromB32 : Bytes ->{Exception} Bytes
        
-  709. -- #13fpchr37ua0pr38ssr7j22pudmseuedf490aok18upagh0f00kg40guj9pgl916v9qurqrvu53f3lpsvi0s82hg3dtjacanrpjvs38
+  715. -- #13fpchr37ua0pr38ssr7j22pudmseuedf490aok18upagh0f00kg40guj9pgl916v9qurqrvu53f3lpsvi0s82hg3dtjacanrpjvs38
        fromHex : Text -> Bytes
        
-  710. -- #b36oslvh534s82lda0ghc5ql7p7nir0tknsluigulmpso22tjh62uiiq4lq9s3m97a2grkso0qofpb423p06olkkikrt4mfn15vpkug
+  716. -- #b36oslvh534s82lda0ghc5ql7p7nir0tknsluigulmpso22tjh62uiiq4lq9s3m97a2grkso0qofpb423p06olkkikrt4mfn15vpkug
        getBuffering : Handle ->{IO, Exception} BufferMode
        
-  711. -- #9vijttgmba0ui9cshmhmmvgn6ve2e95t168766h2n6pkviddebiimgipic5dbg5lmiht12g6np8a7e06jpk03rnue3ln5mbo4prde0g
+  717. -- #9vijttgmba0ui9cshmhmmvgn6ve2e95t168766h2n6pkviddebiimgipic5dbg5lmiht12g6np8a7e06jpk03rnue3ln5mbo4prde0g
        getBytes : Handle -> Nat ->{IO, Exception} Bytes
        
-  712. -- #c5oeqqglf28ungtq1im4fjdh317eeoba4537l1ntq3ob22v07rpgj9307udscbghlrior398hqm1ci099qmriim8cs975kocacsd9r0
+  718. -- #c5oeqqglf28ungtq1im4fjdh317eeoba4537l1ntq3ob22v07rpgj9307udscbghlrior398hqm1ci099qmriim8cs975kocacsd9r0
        getChar : Handle ->{IO, Exception} Char
        
-  713. -- #j9jdo2pqvi4aktcfsb0n4ns1tk2be7dtckqdeedqp7n52oghsq82cgc1tv562rj1sf1abq2h0vta4uo6873cdbgrtrvd5cvollu3ovo
+  719. -- #j9jdo2pqvi4aktcfsb0n4ns1tk2be7dtckqdeedqp7n52oghsq82cgc1tv562rj1sf1abq2h0vta4uo6873cdbgrtrvd5cvollu3ovo
        getEcho : Handle ->{IO, Exception} Boolean
        
-  714. -- #0hj09gufk8fs2hvr6qij6pie8bp0h6hmm6hpsi8d5fvl1fp1dbk6u8c9p6h4eu2hle6ctgpdbepo9vit5atllkodogn6r0csar9fn1g
+  720. -- #0hj09gufk8fs2hvr6qij6pie8bp0h6hmm6hpsi8d5fvl1fp1dbk6u8c9p6h4eu2hle6ctgpdbepo9vit5atllkodogn6r0csar9fn1g
        getLine : Handle ->{IO, Exception} Text
        
-  715. -- #ck1nfg5fainelng0694jkdf9e06pmn60h7kvble1ff7hkc6jdgqtf7g5o3qevr7ic1bdhfn5n2rc3gde5bh6o9fpbit3ocs0av0scdg
+  721. -- #ck1nfg5fainelng0694jkdf9e06pmn60h7kvble1ff7hkc6jdgqtf7g5o3qevr7ic1bdhfn5n2rc3gde5bh6o9fpbit3ocs0av0scdg
        getSomeBytes : Handle -> Nat ->{IO, Exception} Bytes
        
-  716. -- #bk29bjnrcuh55usf3vocm4j1aml161p6ila7t82cpr3ub9vu0g9lsg2mspmfuefc4ig0qtdqk7nds4t3f68jp6o77e0h4ltbitqjpno
+  722. -- #bk29bjnrcuh55usf3vocm4j1aml161p6ila7t82cpr3ub9vu0g9lsg2mspmfuefc4ig0qtdqk7nds4t3f68jp6o77e0h4ltbitqjpno
        getTempDirectory : '{IO, Exception} Text
        
-  717. -- #j8i534slc2rvakvmqcb6j28iatrh3d7btajai9qndutr0edi5aaoi2p5noditaococ4l104hdhhvjc5vr0rbcjoqrbng46fdeqtnf98
+  723. -- #j8i534slc2rvakvmqcb6j28iatrh3d7btajai9qndutr0edi5aaoi2p5noditaococ4l104hdhhvjc5vr0rbcjoqrbng46fdeqtnf98
        handlePosition : Handle ->{IO, Exception} Nat
        
-  718. -- #bgf7sqs0h0p8bhm3t2ei8006oj1gjonvtkdejv2g9kar0kmvob9e88ceevdfh99jom9rs0hbalf1gut5juanudfcb8tpb1e9ta0vrm8
+  724. -- #bgf7sqs0h0p8bhm3t2ei8006oj1gjonvtkdejv2g9kar0kmvob9e88ceevdfh99jom9rs0hbalf1gut5juanudfcb8tpb1e9ta0vrm8
        handshake : Tls ->{IO, Exception} ()
        
-  719. -- #128490j1tmitiu3vesv97sqspmefobg1am38vos9p0vt4s1bhki87l7kj4cctquffkp40eanmr9ummfglj9i7s25jrpb32ob5sf2tio
+  725. -- #128490j1tmitiu3vesv97sqspmefobg1am38vos9p0vt4s1bhki87l7kj4cctquffkp40eanmr9ummfglj9i7s25jrpb32ob5sf2tio
        hex : Bytes -> Text
        
-  720. -- #ttjui80dbufvf3vgaddmcr065dpgl0rtp68i5cdht6tq4t2vk3i2vg60hi77rug368qijgijf8oui27te7o5oq0t0osm6dg65c080i0
+  726. -- #ttjui80dbufvf3vgaddmcr065dpgl0rtp68i5cdht6tq4t2vk3i2vg60hi77rug368qijgijf8oui27te7o5oq0t0osm6dg65c080i0
        id : a -> a
        
-  721. -- #9qnapjbbdhcc2mjf1b0slm7mefu0idnj1bs4c5bckq42ruodftolnd193uehr31lc01air6d6b3j4ihurnks13n85h3r8rs16nqvj2g
+  727. -- #9qnapjbbdhcc2mjf1b0slm7mefu0idnj1bs4c5bckq42ruodftolnd193uehr31lc01air6d6b3j4ihurnks13n85h3r8rs16nqvj2g
        isDirectory : Text ->{IO, Exception} Boolean
        
-  722. -- #vb1e252fqt0q63hpmtkq2bkg5is2n6thejofnev96040thle5o1ia8dtq7dc6v359gtoqugbqg5tb340aqovrfticb63jgei4ncq3j8
+  728. -- #vb1e252fqt0q63hpmtkq2bkg5is2n6thejofnev96040thle5o1ia8dtq7dc6v359gtoqugbqg5tb340aqovrfticb63jgei4ncq3j8
        isFileEOF : Handle ->{IO, Exception} Boolean
        
-  723. -- #ahkhlm9sd7arpevos99sqc90g7k5nn9bj5n0lhh82c1uva52ltv0295ugc123l17vd1orkng061e11knqjnmk087qjg3vug3rs6mv60
+  729. -- #ahkhlm9sd7arpevos99sqc90g7k5nn9bj5n0lhh82c1uva52ltv0295ugc123l17vd1orkng061e11knqjnmk087qjg3vug3rs6mv60
        isFileOpen : Handle ->{IO, Exception} Boolean
        
-  724. -- #2a11371klrv2i8726knma0l3g14on4m2ucihpg65cjj9k930aefg65ovvg0ak4uv3i9evtnu0a5249q3i8ugheqd65cnmgquc1a88n0
+  730. -- #2a11371klrv2i8726knma0l3g14on4m2ucihpg65cjj9k930aefg65ovvg0ak4uv3i9evtnu0a5249q3i8ugheqd65cnmgquc1a88n0
        isNone : Optional a -> Boolean
        
-  725. -- #ln4avnqpdk7813vsrrr414hg0smcmufrl1c7b87nb7nb0h9cogp6arqa7fbgd7rgolffmgue698ovvefo18j1k8g30t4hbp23onm3l8
+  731. -- #ln4avnqpdk7813vsrrr414hg0smcmufrl1c7b87nb7nb0h9cogp6arqa7fbgd7rgolffmgue698ovvefo18j1k8g30t4hbp23onm3l8
        isSeekable : Handle ->{IO, Exception} Boolean
        
-  726. -- #gop2v9s6l24ii1v6bf1nks2h0h18pato0vbsf4u3el18s7mp1jfnp4c7fesdf9sunnlv5f5a9fjr1s952pte87mf63l1iqki9bp0mio
+  732. -- #gop2v9s6l24ii1v6bf1nks2h0h18pato0vbsf4u3el18s7mp1jfnp4c7fesdf9sunnlv5f5a9fjr1s952pte87mf63l1iqki9bp0mio
        List.all : (a ->{ε} Boolean) -> [a] ->{ε} Boolean
        
-  727. -- #m2g5korqq5etr0qk1qrgjbaqktj4ks4bu9m3c4v3j9g8ktsd2e218nml6q8vo45bi3meb53csack40mle6clfrfep073e313b3jagt0
+  733. -- #m2g5korqq5etr0qk1qrgjbaqktj4ks4bu9m3c4v3j9g8ktsd2e218nml6q8vo45bi3meb53csack40mle6clfrfep073e313b3jagt0
        List.filter : (a ->{g} Boolean) -> [a] ->{g} [a]
        
-  728. -- #8s836vq5jggucs6bj3bear30uhe6h9cskudjrdc772ghiec6ce2jqft09l1n05kd1n6chekrbgt0h8mkc9drgscjvgghacojm9e8c5o
+  734. -- #8s836vq5jggucs6bj3bear30uhe6h9cskudjrdc772ghiec6ce2jqft09l1n05kd1n6chekrbgt0h8mkc9drgscjvgghacojm9e8c5o
        List.foldLeft : (b ->{g} a ->{g} b) -> b -> [a] ->{g} b
        
-  729. -- #m5tlb5a0m4kp5b4m9oq9vhda9d7nhu2obn2lpmosal0ebij9gon4gkd1aq0b3b61jtsc1go0hi7b2sm2memtil55ijq32b2n0k39vko
+  735. -- #m5tlb5a0m4kp5b4m9oq9vhda9d7nhu2obn2lpmosal0ebij9gon4gkd1aq0b3b61jtsc1go0hi7b2sm2memtil55ijq32b2n0k39vko
        List.forEach : [a] -> (a ->{e} ()) ->{e} ()
        
-  730. -- #j9ve4ionu2sn7f814t0t4gc75objke2drgnfvvvb50v2f57ss0hlsa3ai5g5jsk2t4b8s37ocrtmte7nktfb2vjf8508ksvrc6llu30
+  736. -- #j9ve4ionu2sn7f814t0t4gc75objke2drgnfvvvb50v2f57ss0hlsa3ai5g5jsk2t4b8s37ocrtmte7nktfb2vjf8508ksvrc6llu30
        listen : Socket ->{IO, Exception} ()
        
-  731. -- #s0f4et1o1ns8cmmvp3i0cm6cmmv5qaf99qm2q4jmgpciof6ntmuh3mpr4epns3ocskn8raacbvm30ovvj2b6arv0ff7iks31rannbf0
+  737. -- #s0f4et1o1ns8cmmvp3i0cm6cmmv5qaf99qm2q4jmgpciof6ntmuh3mpr4epns3ocskn8raacbvm30ovvj2b6arv0ff7iks31rannbf0
        loadCodeBytes : Bytes ->{Exception} Code
        
-  732. -- #gvaed1m07qihc9c216125sur1q9a7i5ita44qnevongg4jrbd8k2plsqhdur45nn6h3drn6lc3iidp1b208ht8s73fg2711l76c7j4g
+  738. -- #gvaed1m07qihc9c216125sur1q9a7i5ita44qnevongg4jrbd8k2plsqhdur45nn6h3drn6lc3iidp1b208ht8s73fg2711l76c7j4g
        loadSelfContained : Text ->{IO, Exception} a
        
-  733. -- #g1hqlq27e3stamnnfp6q178pleeml9sbo2d6scj2ikubocane5cvf8ctausoqrgj9co9h56ttgt179sgktc0bei2r37dmtj51jg0ou8
+  739. -- #g1hqlq27e3stamnnfp6q178pleeml9sbo2d6scj2ikubocane5cvf8ctausoqrgj9co9h56ttgt179sgktc0bei2r37dmtj51jg0ou8
        loadValueBytes : Bytes
        ->{IO, Exception} ([(Link.Term, Code)], Value)
        
-  734. -- #tlllu51stumo77vi2e5m0e8m05qletfbr3nea3d84dcgh66dq4s3bt7kdbf8mpdqh16mmnoh11kr3n43m8b5g4pf95l9gfbhhok1h20
+  740. -- #tlllu51stumo77vi2e5m0e8m05qletfbr3nea3d84dcgh66dq4s3bt7kdbf8mpdqh16mmnoh11kr3n43m8b5g4pf95l9gfbhhok1h20
        MVar.put : MVar i -> i ->{IO, Exception} ()
        
-  735. -- #3b7lp7s9m31mcvh73nh4gfj1kal6onrmppf35esvmma4jsg7bbm7a8tsrfcb4te88f03r97dkf7n1f2kcc6o7ng4vurp95svfj2fg7o
+  741. -- #3b7lp7s9m31mcvh73nh4gfj1kal6onrmppf35esvmma4jsg7bbm7a8tsrfcb4te88f03r97dkf7n1f2kcc6o7ng4vurp95svfj2fg7o
        MVar.read : MVar o ->{IO, Exception} o
        
-  736. -- #be8m7lsjnf31u87pt5rvn04c9ellhbm3p56jgapbp8k7qp0v3mm7beh81luoifp17681l0ldjj46gthmmu32lkn0jnejr3tedjotntg
+  742. -- #be8m7lsjnf31u87pt5rvn04c9ellhbm3p56jgapbp8k7qp0v3mm7beh81luoifp17681l0ldjj46gthmmu32lkn0jnejr3tedjotntg
        MVar.swap : MVar o -> o ->{IO, Exception} o
        
-  737. -- #c2qb0ca2dj3rronbp4slj3ph56p0iopaos7ib37hjunpkl1rcl1gp820dpg8qflhvt9cm2l1bfm40rkdslce2sr6f0oru5lr5cl5nu0
+  743. -- #c2qb0ca2dj3rronbp4slj3ph56p0iopaos7ib37hjunpkl1rcl1gp820dpg8qflhvt9cm2l1bfm40rkdslce2sr6f0oru5lr5cl5nu0
        MVar.take : MVar o ->{IO, Exception} o
        
-  738. -- #ht0k9hb3k1cnjsgmtu9klivo074a2uro4csh63m1sqr2483rkojlj7abcf0jfmssbfig98i6is1osr2djoqubg3bp6articvq9o8090
+  744. -- #ht0k9hb3k1cnjsgmtu9klivo074a2uro4csh63m1sqr2483rkojlj7abcf0jfmssbfig98i6is1osr2djoqubg3bp6articvq9o8090
        newClient : ClientConfig -> Socket ->{IO, Exception} Tls
        
-  739. -- #coeloqmjin6lais8u6j0plh5f1601lpcue4ejfcute46opams4vsbkplqj6jg6af0uecjie3mbclv40b3jumghsf09aavvucrc0d148
+  745. -- #coeloqmjin6lais8u6j0plh5f1601lpcue4ejfcute46opams4vsbkplqj6jg6af0uecjie3mbclv40b3jumghsf09aavvucrc0d148
        newServer : ServerConfig -> Socket ->{IO, Exception} Tls
        
-  740. -- #ocvo5mvs8fghsf715tt4mhpj1pu8e8r7pq9nue63ut0ol2vnv70k7t6tavtsljlmdib9lo3bt669qac94dk53ldcgtukvotvrlfkan0
+  746. -- #ocvo5mvs8fghsf715tt4mhpj1pu8e8r7pq9nue63ut0ol2vnv70k7t6tavtsljlmdib9lo3bt669qac94dk53ldcgtukvotvrlfkan0
        openFile : Text -> FileMode ->{IO, Exception} Handle
        
-  741. -- #c58qbcgd90d965dokk7bu82uehegkbe8jttm7lv4j0ohgi2qm3e3p4v1qfr8vc2dlsmsl9tv0v71kco8c18mneule0ntrhte4ks1090
+  747. -- #c58qbcgd90d965dokk7bu82uehegkbe8jttm7lv4j0ohgi2qm3e3p4v1qfr8vc2dlsmsl9tv0v71kco8c18mneule0ntrhte4ks1090
        printLine : Text ->{IO, Exception} ()
        
-  742. -- #dck7pb7qv05ol3b0o76l88a22bc7enl781ton5qbs2umvgsua3p16n22il02m29592oohsnbt3cr7hnlumpdhv2ibjp6iji9te4iot0
+  748. -- #dck7pb7qv05ol3b0o76l88a22bc7enl781ton5qbs2umvgsua3p16n22il02m29592oohsnbt3cr7hnlumpdhv2ibjp6iji9te4iot0
        printText : Text ->{IO} Either Failure ()
        
-  743. -- #i9lm1g1j0p4qtakg164jdlgac409sgj1cb91k86k0c44ssajbluovuu7ptm5uc20sjgedjbak3iji8o859ek871ul51b8l30s4uf978
+  749. -- #i9lm1g1j0p4qtakg164jdlgac409sgj1cb91k86k0c44ssajbluovuu7ptm5uc20sjgedjbak3iji8o859ek871ul51b8l30s4uf978
        putBytes : Handle -> Bytes ->{IO, Exception} ()
        
-  744. -- #84j6ua3924v85vh2a581de7sd8pee1lqbp1ibvatvjtui9hvk36sv2riabu0v2r0s25p62ipnvv4aeadpg0u8m5ffqrc202i71caopg
+  750. -- #84j6ua3924v85vh2a581de7sd8pee1lqbp1ibvatvjtui9hvk36sv2riabu0v2r0s25p62ipnvv4aeadpg0u8m5ffqrc202i71caopg
        readFile : Text ->{IO, Exception} Bytes
        
-  745. -- #pk003cv7lvidkbmsnne4mpt20254gh4hd7vvretnbk8na8bhr9fg9776rp8pt9srhiucrd1c7sjl006vmil9e78p40gdcir81ujil2o
+  751. -- #pk003cv7lvidkbmsnne4mpt20254gh4hd7vvretnbk8na8bhr9fg9776rp8pt9srhiucrd1c7sjl006vmil9e78p40gdcir81ujil2o
        ready : Handle ->{IO, Exception} Boolean
        
-  746. -- #unn7qak4qe0nbbpf62uesu0fe8i68o83l4o7f6jcblefbla53fef7a63ts28fh6ql81o5c04j44g7m5rq9aouo73dpeprbl5lka8170
+  752. -- #unn7qak4qe0nbbpf62uesu0fe8i68o83l4o7f6jcblefbla53fef7a63ts28fh6ql81o5c04j44g7m5rq9aouo73dpeprbl5lka8170
        receive : Tls ->{IO, Exception} Bytes
        
-  747. -- #ugs4208vpm97jr2ecmr7l9h4e22r1ije6v379m4v6229c8o7hk669ba63bor4pe6n1bm24il87iq2d99sj78lt6n5eqa1fre0grn93g
+  753. -- #ugs4208vpm97jr2ecmr7l9h4e22r1ije6v379m4v6229c8o7hk669ba63bor4pe6n1bm24il87iq2d99sj78lt6n5eqa1fre0grn93g
        removeDirectory : Text ->{IO, Exception} ()
        
-  748. -- #6pia69u5u5rja1jk04v3i9ke24gf4b1t7vnaj0noogord6ekiqhf72qfkc1n08rd11f2cbkofni5rd5u7t1qkgslbi40hut35pfi1v0
+  754. -- #6pia69u5u5rja1jk04v3i9ke24gf4b1t7vnaj0noogord6ekiqhf72qfkc1n08rd11f2cbkofni5rd5u7t1qkgslbi40hut35pfi1v0
        renameDirectory : Text -> Text ->{IO, Exception} ()
        
-  749. -- #amtsq2jq1k75r309esfp800a8slelm4d3q9i1pq1qqs3pil13at916958sf9ucb4607kpktbnup7nc58ecoq8mcs01e2a03d08agn18
+  755. -- #amtsq2jq1k75r309esfp800a8slelm4d3q9i1pq1qqs3pil13at916958sf9ucb4607kpktbnup7nc58ecoq8mcs01e2a03d08agn18
        runTest : '{IO, TempDirs, Exception, Stream Result} a
        ->{IO} [Result]
        
-  750. -- #va4fcp72qog4dvo8dn4gipr2i1big1lqgpcqfuv9kc98ut8le1bj23s68df7svam7b5sg01s4uf95o458f4rs90mtp71nj84t90ra1o
+  756. -- #va4fcp72qog4dvo8dn4gipr2i1big1lqgpcqfuv9kc98ut8le1bj23s68df7svam7b5sg01s4uf95o458f4rs90mtp71nj84t90ra1o
        saveSelfContained : a -> Text ->{IO, Exception} ()
        
-  751. -- #5hbn4gflbo8l4jq0s9l1r0fpee6ie44fbbl6j6km67l25inaaq5avg18g7j6mig2m6eaod04smif7el34tcclvvf8oll39rfonupt2o
+  757. -- #5hbn4gflbo8l4jq0s9l1r0fpee6ie44fbbl6j6km67l25inaaq5avg18g7j6mig2m6eaod04smif7el34tcclvvf8oll39rfonupt2o
        saveTestCase : Text
        -> (a -> Text)
        -> a
        ->{IO, Exception} ()
        
-  752. -- #v2otbk1e0e81d6ea9i3j1kivnfam6rk6earsjbjljv4mmrk1mgfals6jhfd74evor6al9mkb5gv8hf15f02807f0aa0hnsg9fas1qco
+  758. -- #v2otbk1e0e81d6ea9i3j1kivnfam6rk6earsjbjljv4mmrk1mgfals6jhfd74evor6al9mkb5gv8hf15f02807f0aa0hnsg9fas1qco
        seekHandle : Handle
        -> SeekMode
        -> Int
        ->{IO, Exception} ()
        
-  753. -- #a98jlos4rj2um55iksdin9p5djo6j70qmuitoe2ff3uvkefb8pqensorln5flr3pm8hkc0lqkchbd63cf9tl0kqnqu3i17kvqnm35g0
+  759. -- #a98jlos4rj2um55iksdin9p5djo6j70qmuitoe2ff3uvkefb8pqensorln5flr3pm8hkc0lqkchbd63cf9tl0kqnqu3i17kvqnm35g0
        send : Tls -> Bytes ->{IO, Exception} ()
        
-  754. -- #qrdia2sc9vuoi7u3a4ukjk8lv0rlhn2i2bbin1adbhcuj79jn366dv3a8t52hpil0jtgkhhuiavibmdev63j5ndriod33rkktjekqv8
+  760. -- #qrdia2sc9vuoi7u3a4ukjk8lv0rlhn2i2bbin1adbhcuj79jn366dv3a8t52hpil0jtgkhhuiavibmdev63j5ndriod33rkktjekqv8
        serverSocket : Optional Text
        -> Text
        ->{IO, Exception} Socket
        
-  755. -- #3vft70875p42eao55rhb61siobuei4h0e9vlu4bbgucjo296c2vfjpucacovnu9538tvup5c7lo9123se8v4fe7m8q9aiqbkjpumkao
+  761. -- #3vft70875p42eao55rhb61siobuei4h0e9vlu4bbgucjo296c2vfjpucacovnu9538tvup5c7lo9123se8v4fe7m8q9aiqbkjpumkao
        setBuffering : Handle -> BufferMode ->{IO, Exception} ()
        
-  756. -- #erqshamlurgahpd4rroild36cc5e4rk56r38r53vcbg8cblr82c6gfji3um8f09ffgjlg58g7r32mtsbvjlcq4c65v0jn3va9888mao
+  762. -- #erqshamlurgahpd4rroild36cc5e4rk56r38r53vcbg8cblr82c6gfji3um8f09ffgjlg58g7r32mtsbvjlcq4c65v0jn3va9888mao
        setEcho : Handle -> Boolean ->{IO, Exception} ()
        
-  757. -- #ugar51qqij4ur24frdi84eqdkvqa0fbsi4v6e2586hi3tai52ovtpm3f2dc9crnfv8pk0ppq6b5tv3utl4sl49n5aecorgkqddr7i38
+  763. -- #ugar51qqij4ur24frdi84eqdkvqa0fbsi4v6e2586hi3tai52ovtpm3f2dc9crnfv8pk0ppq6b5tv3utl4sl49n5aecorgkqddr7i38
        snd : ∀ a a1. (a1, a) -> a
        
-  758. -- #leoq6smeq8to5ej3314uuujmh6rfbcsdb9q8ah8h3ohg9jq5kftc93mq671o0qh2he9vqgd288k0ecea3h7eerpbgjt6a8p843tmon8
+  764. -- #leoq6smeq8to5ej3314uuujmh6rfbcsdb9q8ah8h3ohg9jq5kftc93mq671o0qh2he9vqgd288k0ecea3h7eerpbgjt6a8p843tmon8
        socketAccept : Socket ->{IO, Exception} Socket
        
-  759. -- #s43jbp19k91qq704tidpue2vs2re1lh4mtv46rdmdnurkdndst7u0k712entcvip160vh9cilmpamikmflbprg5up0k6cl15b8tr5l0
+  765. -- #s43jbp19k91qq704tidpue2vs2re1lh4mtv46rdmdnurkdndst7u0k712entcvip160vh9cilmpamikmflbprg5up0k6cl15b8tr5l0
        socketPort : Socket ->{IO, Exception} Nat
        
-  760. -- #3rp8h0dt7g60nrjdehuhqga9dmomti5rdqho7r1rm5rg5moet7kt3ieempo7c9urur752njachq6k48ggbic4ugbbv75jl2mfbk57a0
+  766. -- #3rp8h0dt7g60nrjdehuhqga9dmomti5rdqho7r1rm5rg5moet7kt3ieempo7c9urur752njachq6k48ggbic4ugbbv75jl2mfbk57a0
        startsWith : Text -> Text -> Boolean
        
-  761. -- #elsab3sc7p4c6bj73pgvklv0j7qu268rn5isv6micfp7ib8grjoustpqdq0pkd4a379mr5ijb8duu2q0n040osfurppp8pt8vaue2fo
+  767. -- #elsab3sc7p4c6bj73pgvklv0j7qu268rn5isv6micfp7ib8grjoustpqdq0pkd4a379mr5ijb8duu2q0n040osfurppp8pt8vaue2fo
        stdout : Handle
        
-  762. -- #rfi1v9429f9qluv533l2iba77aadttilrpmnhljfapfnfa6sru2nr8ibpqvib9nc4s4nb9s1as45upsfqfqe6ivqi2p82b2vd866it8
+  768. -- #rfi1v9429f9qluv533l2iba77aadttilrpmnhljfapfnfa6sru2nr8ibpqvib9nc4s4nb9s1as45upsfqfqe6ivqi2p82b2vd866it8
        structural ability Stream a
        
-  763. -- #2jl99er43tnksj8r8oveap5ger9uqlvj0u0ghfs0uqa7i6m45jk976n7a726jb7rtusjdu2p8hbbcgmoacvke7k5o3kdgoj57c3v2v8
+  769. -- #2jl99er43tnksj8r8oveap5ger9uqlvj0u0ghfs0uqa7i6m45jk976n7a726jb7rtusjdu2p8hbbcgmoacvke7k5o3kdgoj57c3v2v8
        Stream.collect : '{e, Stream a} r ->{e} ([a], r)
        
-  764. -- #rnuje46fvuqa4a8sdgl9e250a2gcmhtsscr8bdonj2bduhrst38ur7dorv3ahr2ghf9cufkfit7ndh9qb9gspbfapcnn3sol0l2moqg
+  770. -- #rnuje46fvuqa4a8sdgl9e250a2gcmhtsscr8bdonj2bduhrst38ur7dorv3ahr2ghf9cufkfit7ndh9qb9gspbfapcnn3sol0l2moqg
        Stream.collect.handler : Request {Stream a} r -> ([a], r)
        
-  765. -- #rfi1v9429f9qluv533l2iba77aadttilrpmnhljfapfnfa6sru2nr8ibpqvib9nc4s4nb9s1as45upsfqfqe6ivqi2p82b2vd866it8#0
+  771. -- #rfi1v9429f9qluv533l2iba77aadttilrpmnhljfapfnfa6sru2nr8ibpqvib9nc4s4nb9s1as45upsfqfqe6ivqi2p82b2vd866it8#0
        Stream.emit : a ->{Stream a} ()
        
-  766. -- #c70gf5m1blvh8tg4kvt1taee036fr7r22bbtqcupac5r5igs102nj077vdl0nimef94u951kfcl9a5hcevo01j04v9o6v3cpndq41bo
+  772. -- #c70gf5m1blvh8tg4kvt1taee036fr7r22bbtqcupac5r5igs102nj077vdl0nimef94u951kfcl9a5hcevo01j04v9o6v3cpndq41bo
        Stream.toList : '{Stream a} r -> [a]
        
-  767. -- #ul69cgsrsspjni8b0hqnt4kt4bk7sjtp6jvlhhofom7bemu9nb2kimm6tt1raigr7j86afgmnjnrfabn6a5l5v1t219uidiu22ueiv0
+  773. -- #ul69cgsrsspjni8b0hqnt4kt4bk7sjtp6jvlhhofom7bemu9nb2kimm6tt1raigr7j86afgmnjnrfabn6a5l5v1t219uidiu22ueiv0
        Stream.toList.handler : Request {Stream a} r -> [a]
        
-  768. -- #58d8kfuq8sqbipa1aaijjhm28pa6a844h19mgg5s4a1h160etbulig21cm0pcnfla8fisqvrp80840g9luid5u8amvcc8sf46pd25h8
+  774. -- #58d8kfuq8sqbipa1aaijjhm28pa6a844h19mgg5s4a1h160etbulig21cm0pcnfla8fisqvrp80840g9luid5u8amvcc8sf46pd25h8
        systemTime : '{IO, Exception} Nat
        
-  769. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18
+  775. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18
        structural ability TempDirs
        
-  770. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18#0
+  776. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18#0
        TempDirs.newTempDir : Text ->{TempDirs} Text
        
-  771. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18#1
+  777. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18#1
        TempDirs.removeDir : Text ->{TempDirs} ()
        
-  772. -- #natgur73q6b4c3tp5jcor0v1cdnplh0n3fhm4qvhg4v74u3e3ff1352shs1lveot83lj82qqbl78n40qi9a132fhkmaa6g5s1ja91go
+  778. -- #natgur73q6b4c3tp5jcor0v1cdnplh0n3fhm4qvhg4v74u3e3ff1352shs1lveot83lj82qqbl78n40qi9a132fhkmaa6g5s1ja91go
        terminate : Tls ->{IO, Exception} ()
        
-  773. -- #i3pbnc98rbfug5dnnvpd4uahm2e5fld2fu0re9r305isffr1r43048h7ql6ojdbjcsvjr6h91s6i026na046ltg5ff59klla6e7vq98
+  779. -- #i3pbnc98rbfug5dnnvpd4uahm2e5fld2fu0re9r305isffr1r43048h7ql6ojdbjcsvjr6h91s6i026na046ltg5ff59klla6e7vq98
        testAutoClean : '{IO} [Result]
        
-  774. -- #spepthutvs3p6je794h520665rh8abl36qg43i7ipvj0mtg5sb0sbemjp2vpu9j3feithk2ae0sdtcmb8afoglo9rnvl350380t21h0
+  780. -- #spepthutvs3p6je794h520665rh8abl36qg43i7ipvj0mtg5sb0sbemjp2vpu9j3feithk2ae0sdtcmb8afoglo9rnvl350380t21h0
        Text.fromUtf8 : Bytes ->{Exception} Text
        
-  775. -- #32q9jqhmi8f08pec3hj0je4u7k52f9f1hdfsmn9ncg2kpki5da9dabigplvdcot3a00k7s5npc4n78psd6ojaumqjla259e9pqd4ov8
+  781. -- #32q9jqhmi8f08pec3hj0je4u7k52f9f1hdfsmn9ncg2kpki5da9dabigplvdcot3a00k7s5npc4n78psd6ojaumqjla259e9pqd4ov8
        structural ability Throw e
        
-  776. -- #32q9jqhmi8f08pec3hj0je4u7k52f9f1hdfsmn9ncg2kpki5da9dabigplvdcot3a00k7s5npc4n78psd6ojaumqjla259e9pqd4ov8#0
+  782. -- #32q9jqhmi8f08pec3hj0je4u7k52f9f1hdfsmn9ncg2kpki5da9dabigplvdcot3a00k7s5npc4n78psd6ojaumqjla259e9pqd4ov8#0
        Throw.throw : e ->{Throw e} a
        
-  777. -- #vri6fsnl704n6aqs346p6ijcbkcsv9875edr6b74enumrhbjiuon94ir4ufmrrn84k9b2jka4f05o16mcvsjrjav6gpskpiu4sknd1g
+  783. -- #vri6fsnl704n6aqs346p6ijcbkcsv9875edr6b74enumrhbjiuon94ir4ufmrrn84k9b2jka4f05o16mcvsjrjav6gpskpiu4sknd1g
        uncurry : ∀ o g1 i g i1.
          (i1 ->{g} i ->{g1} o) -> (i1, i) ->{g1, g} o
        
-  778. -- #u2j1bektndcqdo1m13fvu6apt9td96s4tqonelg23tauklak2pqnbisf41v632fmlrcc6f9orqo3iu9757q36ue5ol1khe0hh8pktro
+  784. -- #u2j1bektndcqdo1m13fvu6apt9td96s4tqonelg23tauklak2pqnbisf41v632fmlrcc6f9orqo3iu9757q36ue5ol1khe0hh8pktro
        Value.transitiveDeps : Value ->{IO} [(Link.Term, Code)]
        
-  779. -- #o5bg5el7ckak28ib98j5b6rt26bqbprpddd1brrg3s18qahhbbe3uohufjjnt5eenvtjg0hrvnvpra95jmdppqrovvmcfm1ih2k7guo
+  785. -- #o5bg5el7ckak28ib98j5b6rt26bqbprpddd1brrg3s18qahhbbe3uohufjjnt5eenvtjg0hrvnvpra95jmdppqrovvmcfm1ih2k7guo
        void : x -> ()
        
-  780. -- #8ugamqlp7a4g0dmbcvipqfi8gnuuj23pjbdfbof11naiun1qf8otjcap80epaom2kl9fv5rhjaudt4558n38dovrc0lhipubqjgm8mg
+  786. -- #8ugamqlp7a4g0dmbcvipqfi8gnuuj23pjbdfbof11naiun1qf8otjcap80epaom2kl9fv5rhjaudt4558n38dovrc0lhipubqjgm8mg
        writeFile : Text -> Bytes ->{IO, Exception} ()
        
-  781. -- #lcmj2envm11lrflvvcl290lplhvbccv82utoej0lg0eomhmsf2vrv8af17k6if7ff98fp1b13rkseng3fng4stlr495c8dn3gn4k400
+  787. -- #lcmj2envm11lrflvvcl290lplhvbccv82utoej0lg0eomhmsf2vrv8af17k6if7ff98fp1b13rkseng3fng4stlr495c8dn3gn4k400
        |> : a -> (a ->{g} t) ->{g} t
        
   

--- a/unison-src/transcripts/alias-many.output.md
+++ b/unison-src/transcripts/alias-many.output.md
@@ -297,362 +297,374 @@ Let's try it!
   222. io2.IO.openFile.impl : Text
                               -> FileMode
                               ->{IO} Either Failure Handle
-  223. io2.IO.putBytes.impl : Handle
+  223. io2.IO.process.call : Text -> [Text] ->{IO} Nat
+  224. io2.IO.process.exitCode : ProcessHandle
+                                 ->{IO} Optional Nat
+  225. io2.IO.process.kill : ProcessHandle ->{IO} ()
+  226. io2.IO.process.start : Text
+                              -> [Text]
+                              ->{IO} ( Handle,
+                                Handle,
+                                Handle,
+                                ProcessHandle)
+  227. io2.IO.process.wait : ProcessHandle ->{IO} Nat
+  228. io2.IO.putBytes.impl : Handle
                               -> Bytes
                               ->{IO} Either Failure ()
-  224. io2.IO.ready.impl : Handle ->{IO} Either Failure Boolean
-  225. io2.IO.ref : a ->{IO} Ref {IO} a
-  226. io2.IO.removeDirectory.impl : Text
+  229. io2.IO.ready.impl : Handle ->{IO} Either Failure Boolean
+  230. io2.IO.ref : a ->{IO} Ref {IO} a
+  231. io2.IO.removeDirectory.impl : Text
                                      ->{IO} Either Failure ()
-  227. io2.IO.removeFile.impl : Text ->{IO} Either Failure ()
-  228. io2.IO.renameDirectory.impl : Text
+  232. io2.IO.removeFile.impl : Text ->{IO} Either Failure ()
+  233. io2.IO.renameDirectory.impl : Text
                                      -> Text
                                      ->{IO} Either Failure ()
-  229. io2.IO.renameFile.impl : Text
+  234. io2.IO.renameFile.impl : Text
                                 -> Text
                                 ->{IO} Either Failure ()
-  230. io2.IO.seekHandle.impl : Handle
+  235. io2.IO.seekHandle.impl : Handle
                                 -> SeekMode
                                 -> Int
                                 ->{IO} Either Failure ()
-  231. io2.IO.serverSocket.impl : Optional Text
+  236. io2.IO.serverSocket.impl : Optional Text
                                   -> Text
                                   ->{IO} Either Failure Socket
-  232. io2.IO.setBuffering.impl : Handle
+  237. io2.IO.setBuffering.impl : Handle
                                   -> BufferMode
                                   ->{IO} Either Failure ()
-  233. io2.IO.setCurrentDirectory.impl : Text
+  238. io2.IO.setCurrentDirectory.impl : Text
                                          ->{IO} Either
                                            Failure ()
-  234. io2.IO.setEcho.impl : Handle
+  239. io2.IO.setEcho.impl : Handle
                              -> Boolean
                              ->{IO} Either Failure ()
-  235. io2.IO.socketAccept.impl : Socket
+  240. io2.IO.socketAccept.impl : Socket
                                   ->{IO} Either Failure Socket
-  236. io2.IO.socketPort.impl : Socket ->{IO} Either Failure Nat
-  237. io2.IO.socketReceive.impl : Socket
+  241. io2.IO.socketPort.impl : Socket ->{IO} Either Failure Nat
+  242. io2.IO.socketReceive.impl : Socket
                                    -> Nat
                                    ->{IO} Either Failure Bytes
-  238. io2.IO.socketSend.impl : Socket
+  243. io2.IO.socketSend.impl : Socket
                                 -> Bytes
                                 ->{IO} Either Failure ()
-  239. io2.IO.stdHandle : StdHandle -> Handle
-  240. io2.IO.systemTime.impl : '{IO} Either Failure Nat
-  241. io2.IO.systemTimeMicroseconds : '{IO} Int
-  242. io2.IO.tryEval : '{IO} a ->{IO, Exception} a
-  243. unique type io2.IOError
-  244. io2.IOError.AlreadyExists : IOError
-  245. io2.IOError.EOF : IOError
-  246. io2.IOError.IllegalOperation : IOError
-  247. io2.IOError.NoSuchThing : IOError
-  248. io2.IOError.PermissionDenied : IOError
-  249. io2.IOError.ResourceBusy : IOError
-  250. io2.IOError.ResourceExhausted : IOError
-  251. io2.IOError.UserError : IOError
-  252. unique type io2.IOFailure
-  253. unique type io2.MiscFailure
-  254. builtin type io2.MVar
-  255. io2.MVar.isEmpty : MVar a ->{IO} Boolean
-  256. io2.MVar.new : a ->{IO} MVar a
-  257. io2.MVar.newEmpty : '{IO} MVar a
-  258. io2.MVar.put.impl : MVar a -> a ->{IO} Either Failure ()
-  259. io2.MVar.read.impl : MVar a ->{IO} Either Failure a
-  260. io2.MVar.swap.impl : MVar a -> a ->{IO} Either Failure a
-  261. io2.MVar.take.impl : MVar a ->{IO} Either Failure a
-  262. io2.MVar.tryPut.impl : MVar a
+  244. io2.IO.stdHandle : StdHandle -> Handle
+  245. io2.IO.systemTime.impl : '{IO} Either Failure Nat
+  246. io2.IO.systemTimeMicroseconds : '{IO} Int
+  247. io2.IO.tryEval : '{IO} a ->{IO, Exception} a
+  248. unique type io2.IOError
+  249. io2.IOError.AlreadyExists : IOError
+  250. io2.IOError.EOF : IOError
+  251. io2.IOError.IllegalOperation : IOError
+  252. io2.IOError.NoSuchThing : IOError
+  253. io2.IOError.PermissionDenied : IOError
+  254. io2.IOError.ResourceBusy : IOError
+  255. io2.IOError.ResourceExhausted : IOError
+  256. io2.IOError.UserError : IOError
+  257. unique type io2.IOFailure
+  258. unique type io2.MiscFailure
+  259. builtin type io2.MVar
+  260. io2.MVar.isEmpty : MVar a ->{IO} Boolean
+  261. io2.MVar.new : a ->{IO} MVar a
+  262. io2.MVar.newEmpty : '{IO} MVar a
+  263. io2.MVar.put.impl : MVar a -> a ->{IO} Either Failure ()
+  264. io2.MVar.read.impl : MVar a ->{IO} Either Failure a
+  265. io2.MVar.swap.impl : MVar a -> a ->{IO} Either Failure a
+  266. io2.MVar.take.impl : MVar a ->{IO} Either Failure a
+  267. io2.MVar.tryPut.impl : MVar a
                               -> a
                               ->{IO} Either Failure Boolean
-  263. io2.MVar.tryRead.impl : MVar a
+  268. io2.MVar.tryRead.impl : MVar a
                                ->{IO} Either
                                  Failure (Optional a)
-  264. io2.MVar.tryTake : MVar a ->{IO} Optional a
-  265. builtin type io2.Promise
-  266. io2.Promise.new : '{IO} Promise a
-  267. io2.Promise.read : Promise a ->{IO} a
-  268. io2.Promise.tryRead : Promise a ->{IO} Optional a
-  269. io2.Promise.write : Promise a -> a ->{IO} Boolean
-  270. io2.Ref.cas : Ref {IO} a -> Ticket a -> a ->{IO} Boolean
-  271. io2.Ref.readForCas : Ref {IO} a ->{IO} Ticket a
-  272. builtin type io2.Ref.Ticket
-  273. io2.Ref.Ticket.read : Ticket a -> a
-  274. unique type io2.RuntimeFailure
-  275. unique type io2.SeekMode
-  276. io2.SeekMode.AbsoluteSeek : SeekMode
-  277. io2.SeekMode.RelativeSeek : SeekMode
-  278. io2.SeekMode.SeekFromEnd : SeekMode
-  279. builtin type io2.Socket
-  280. unique type io2.StdHandle
-  281. io2.StdHandle.StdErr : StdHandle
-  282. io2.StdHandle.StdIn : StdHandle
-  283. io2.StdHandle.StdOut : StdHandle
-  284. builtin type io2.STM
-  285. io2.STM.atomically : '{STM} a ->{IO} a
-  286. io2.STM.retry : '{STM} a
-  287. unique type io2.STMFailure
-  288. builtin type io2.ThreadId
-  289. builtin type io2.Tls
-  290. builtin type io2.Tls.Cipher
-  291. builtin type io2.Tls.ClientConfig
-  292. io2.Tls.ClientConfig.certificates.set : [SignedCert]
+  269. io2.MVar.tryTake : MVar a ->{IO} Optional a
+  270. builtin type io2.ProcessHandle
+  271. builtin type io2.Promise
+  272. io2.Promise.new : '{IO} Promise a
+  273. io2.Promise.read : Promise a ->{IO} a
+  274. io2.Promise.tryRead : Promise a ->{IO} Optional a
+  275. io2.Promise.write : Promise a -> a ->{IO} Boolean
+  276. io2.Ref.cas : Ref {IO} a -> Ticket a -> a ->{IO} Boolean
+  277. io2.Ref.readForCas : Ref {IO} a ->{IO} Ticket a
+  278. builtin type io2.Ref.Ticket
+  279. io2.Ref.Ticket.read : Ticket a -> a
+  280. unique type io2.RuntimeFailure
+  281. unique type io2.SeekMode
+  282. io2.SeekMode.AbsoluteSeek : SeekMode
+  283. io2.SeekMode.RelativeSeek : SeekMode
+  284. io2.SeekMode.SeekFromEnd : SeekMode
+  285. builtin type io2.Socket
+  286. unique type io2.StdHandle
+  287. io2.StdHandle.StdErr : StdHandle
+  288. io2.StdHandle.StdIn : StdHandle
+  289. io2.StdHandle.StdOut : StdHandle
+  290. builtin type io2.STM
+  291. io2.STM.atomically : '{STM} a ->{IO} a
+  292. io2.STM.retry : '{STM} a
+  293. unique type io2.STMFailure
+  294. builtin type io2.ThreadId
+  295. builtin type io2.Tls
+  296. builtin type io2.Tls.Cipher
+  297. builtin type io2.Tls.ClientConfig
+  298. io2.Tls.ClientConfig.certificates.set : [SignedCert]
                                                -> ClientConfig
                                                -> ClientConfig
-  293. io2.TLS.ClientConfig.ciphers.set : [Cipher]
+  299. io2.TLS.ClientConfig.ciphers.set : [Cipher]
                                           -> ClientConfig
                                           -> ClientConfig
-  294. io2.Tls.ClientConfig.default : Text
+  300. io2.Tls.ClientConfig.default : Text
                                       -> Bytes
                                       -> ClientConfig
-  295. io2.Tls.ClientConfig.versions.set : [Version]
+  301. io2.Tls.ClientConfig.versions.set : [Version]
                                            -> ClientConfig
                                            -> ClientConfig
-  296. io2.Tls.decodeCert.impl : Bytes
+  302. io2.Tls.decodeCert.impl : Bytes
                                  -> Either Failure SignedCert
-  297. io2.Tls.decodePrivateKey : Bytes -> [PrivateKey]
-  298. io2.Tls.encodeCert : SignedCert -> Bytes
-  299. io2.Tls.encodePrivateKey : PrivateKey -> Bytes
-  300. io2.Tls.handshake.impl : Tls ->{IO} Either Failure ()
-  301. io2.Tls.newClient.impl : ClientConfig
+  303. io2.Tls.decodePrivateKey : Bytes -> [PrivateKey]
+  304. io2.Tls.encodeCert : SignedCert -> Bytes
+  305. io2.Tls.encodePrivateKey : PrivateKey -> Bytes
+  306. io2.Tls.handshake.impl : Tls ->{IO} Either Failure ()
+  307. io2.Tls.newClient.impl : ClientConfig
                                 -> Socket
                                 ->{IO} Either Failure Tls
-  302. io2.Tls.newServer.impl : ServerConfig
+  308. io2.Tls.newServer.impl : ServerConfig
                                 -> Socket
                                 ->{IO} Either Failure Tls
-  303. builtin type io2.Tls.PrivateKey
-  304. io2.Tls.receive.impl : Tls ->{IO} Either Failure Bytes
-  305. io2.Tls.send.impl : Tls -> Bytes ->{IO} Either Failure ()
-  306. builtin type io2.Tls.ServerConfig
-  307. io2.Tls.ServerConfig.certificates.set : [SignedCert]
+  309. builtin type io2.Tls.PrivateKey
+  310. io2.Tls.receive.impl : Tls ->{IO} Either Failure Bytes
+  311. io2.Tls.send.impl : Tls -> Bytes ->{IO} Either Failure ()
+  312. builtin type io2.Tls.ServerConfig
+  313. io2.Tls.ServerConfig.certificates.set : [SignedCert]
                                                -> ServerConfig
                                                -> ServerConfig
-  308. io2.Tls.ServerConfig.ciphers.set : [Cipher]
+  314. io2.Tls.ServerConfig.ciphers.set : [Cipher]
                                           -> ServerConfig
                                           -> ServerConfig
-  309. io2.Tls.ServerConfig.default : [SignedCert]
+  315. io2.Tls.ServerConfig.default : [SignedCert]
                                       -> PrivateKey
                                       -> ServerConfig
-  310. io2.Tls.ServerConfig.versions.set : [Version]
+  316. io2.Tls.ServerConfig.versions.set : [Version]
                                            -> ServerConfig
                                            -> ServerConfig
-  311. builtin type io2.Tls.SignedCert
-  312. io2.Tls.terminate.impl : Tls ->{IO} Either Failure ()
-  313. builtin type io2.Tls.Version
-  314. unique type io2.TlsFailure
-  315. builtin type io2.TVar
-  316. io2.TVar.new : a ->{STM} TVar a
-  317. io2.TVar.newIO : a ->{IO} TVar a
-  318. io2.TVar.read : TVar a ->{STM} a
-  319. io2.TVar.readIO : TVar a ->{IO} a
-  320. io2.TVar.swap : TVar a -> a ->{STM} a
-  321. io2.TVar.write : TVar a -> a ->{STM} ()
-  322. io2.validateSandboxed : [Term] -> a -> Boolean
-  323. unique type IsPropagated
-  324. IsPropagated.IsPropagated : IsPropagated
-  325. unique type IsTest
-  326. IsTest.IsTest : IsTest
-  327. unique type Link
-  328. builtin type Link.Term
-  329. Link.Term : Term -> Link
-  330. Link.Term.toText : Term -> Text
-  331. builtin type Link.Type
-  332. Link.Type : Type -> Link
-  333. builtin type List
-  334. List.++ : [a] -> [a] -> [a]
-  335. List.+: : a -> [a] -> [a]
-  336. List.:+ : [a] -> a -> [a]
-  337. List.at : Nat -> [a] -> Optional a
-  338. List.cons : a -> [a] -> [a]
-  339. List.drop : Nat -> [a] -> [a]
-  340. List.empty : [a]
-  341. List.size : [a] -> Nat
-  342. List.snoc : [a] -> a -> [a]
-  343. List.take : Nat -> [a] -> [a]
-  344. metadata.isPropagated : IsPropagated
-  345. metadata.isTest : IsTest
-  346. builtin type MutableArray
-  347. MutableArray.copyTo! : MutableArray g a
+  317. builtin type io2.Tls.SignedCert
+  318. io2.Tls.terminate.impl : Tls ->{IO} Either Failure ()
+  319. builtin type io2.Tls.Version
+  320. unique type io2.TlsFailure
+  321. builtin type io2.TVar
+  322. io2.TVar.new : a ->{STM} TVar a
+  323. io2.TVar.newIO : a ->{IO} TVar a
+  324. io2.TVar.read : TVar a ->{STM} a
+  325. io2.TVar.readIO : TVar a ->{IO} a
+  326. io2.TVar.swap : TVar a -> a ->{STM} a
+  327. io2.TVar.write : TVar a -> a ->{STM} ()
+  328. io2.validateSandboxed : [Term] -> a -> Boolean
+  329. unique type IsPropagated
+  330. IsPropagated.IsPropagated : IsPropagated
+  331. unique type IsTest
+  332. IsTest.IsTest : IsTest
+  333. unique type Link
+  334. builtin type Link.Term
+  335. Link.Term : Term -> Link
+  336. Link.Term.toText : Term -> Text
+  337. builtin type Link.Type
+  338. Link.Type : Type -> Link
+  339. builtin type List
+  340. List.++ : [a] -> [a] -> [a]
+  341. List.+: : a -> [a] -> [a]
+  342. List.:+ : [a] -> a -> [a]
+  343. List.at : Nat -> [a] -> Optional a
+  344. List.cons : a -> [a] -> [a]
+  345. List.drop : Nat -> [a] -> [a]
+  346. List.empty : [a]
+  347. List.size : [a] -> Nat
+  348. List.snoc : [a] -> a -> [a]
+  349. List.take : Nat -> [a] -> [a]
+  350. metadata.isPropagated : IsPropagated
+  351. metadata.isTest : IsTest
+  352. builtin type MutableArray
+  353. MutableArray.copyTo! : MutableArray g a
                               -> Nat
                               -> MutableArray g a
                               -> Nat
                               -> Nat
                               ->{g, Exception} ()
-  348. MutableArray.freeze : MutableArray g a
+  354. MutableArray.freeze : MutableArray g a
                              -> Nat
                              -> Nat
                              ->{g} ImmutableArray a
-  349. MutableArray.freeze! : MutableArray g a
+  355. MutableArray.freeze! : MutableArray g a
                               ->{g} ImmutableArray a
-  350. MutableArray.read : MutableArray g a
+  356. MutableArray.read : MutableArray g a
                            -> Nat
                            ->{g, Exception} a
-  351. MutableArray.size : MutableArray g a -> Nat
-  352. MutableArray.write : MutableArray g a
+  357. MutableArray.size : MutableArray g a -> Nat
+  358. MutableArray.write : MutableArray g a
                             -> Nat
                             -> a
                             ->{g, Exception} ()
-  353. builtin type MutableByteArray
-  354. MutableByteArray.copyTo! : MutableByteArray g
+  359. builtin type MutableByteArray
+  360. MutableByteArray.copyTo! : MutableByteArray g
                                   -> Nat
                                   -> MutableByteArray g
                                   -> Nat
                                   -> Nat
                                   ->{g, Exception} ()
-  355. MutableByteArray.freeze : MutableByteArray g
+  361. MutableByteArray.freeze : MutableByteArray g
                                  -> Nat
                                  -> Nat
                                  ->{g} ImmutableByteArray
-  356. MutableByteArray.freeze! : MutableByteArray g
+  362. MutableByteArray.freeze! : MutableByteArray g
                                   ->{g} ImmutableByteArray
-  357. MutableByteArray.read16be : MutableByteArray g
+  363. MutableByteArray.read16be : MutableByteArray g
                                    -> Nat
                                    ->{g, Exception} Nat
-  358. MutableByteArray.read24be : MutableByteArray g
+  364. MutableByteArray.read24be : MutableByteArray g
                                    -> Nat
                                    ->{g, Exception} Nat
-  359. MutableByteArray.read32be : MutableByteArray g
+  365. MutableByteArray.read32be : MutableByteArray g
                                    -> Nat
                                    ->{g, Exception} Nat
-  360. MutableByteArray.read40be : MutableByteArray g
+  366. MutableByteArray.read40be : MutableByteArray g
                                    -> Nat
                                    ->{g, Exception} Nat
-  361. MutableByteArray.read64be : MutableByteArray g
+  367. MutableByteArray.read64be : MutableByteArray g
                                    -> Nat
                                    ->{g, Exception} Nat
-  362. MutableByteArray.read8 : MutableByteArray g
+  368. MutableByteArray.read8 : MutableByteArray g
                                 -> Nat
                                 ->{g, Exception} Nat
-  363. MutableByteArray.size : MutableByteArray g -> Nat
-  364. MutableByteArray.write16be : MutableByteArray g
+  369. MutableByteArray.size : MutableByteArray g -> Nat
+  370. MutableByteArray.write16be : MutableByteArray g
                                     -> Nat
                                     -> Nat
                                     ->{g, Exception} ()
-  365. MutableByteArray.write32be : MutableByteArray g
+  371. MutableByteArray.write32be : MutableByteArray g
                                     -> Nat
                                     -> Nat
                                     ->{g, Exception} ()
-  366. MutableByteArray.write64be : MutableByteArray g
+  372. MutableByteArray.write64be : MutableByteArray g
                                     -> Nat
                                     -> Nat
                                     ->{g, Exception} ()
-  367. MutableByteArray.write8 : MutableByteArray g
+  373. MutableByteArray.write8 : MutableByteArray g
                                  -> Nat
                                  -> Nat
                                  ->{g, Exception} ()
-  368. builtin type Nat
-  369. Nat.* : Nat -> Nat -> Nat
-  370. Nat.+ : Nat -> Nat -> Nat
-  371. Nat./ : Nat -> Nat -> Nat
-  372. Nat.and : Nat -> Nat -> Nat
-  373. Nat.complement : Nat -> Nat
-  374. Nat.drop : Nat -> Nat -> Nat
-  375. Nat.eq : Nat -> Nat -> Boolean
-  376. Nat.fromText : Text -> Optional Nat
-  377. Nat.gt : Nat -> Nat -> Boolean
-  378. Nat.gteq : Nat -> Nat -> Boolean
-  379. Nat.increment : Nat -> Nat
-  380. Nat.isEven : Nat -> Boolean
-  381. Nat.isOdd : Nat -> Boolean
-  382. Nat.leadingZeros : Nat -> Nat
-  383. Nat.lt : Nat -> Nat -> Boolean
-  384. Nat.lteq : Nat -> Nat -> Boolean
-  385. Nat.mod : Nat -> Nat -> Nat
-  386. Nat.or : Nat -> Nat -> Nat
-  387. Nat.popCount : Nat -> Nat
-  388. Nat.pow : Nat -> Nat -> Nat
-  389. Nat.shiftLeft : Nat -> Nat -> Nat
-  390. Nat.shiftRight : Nat -> Nat -> Nat
-  391. Nat.sub : Nat -> Nat -> Int
-  392. Nat.toFloat : Nat -> Float
-  393. Nat.toInt : Nat -> Int
-  394. Nat.toText : Nat -> Text
-  395. Nat.trailingZeros : Nat -> Nat
-  396. Nat.xor : Nat -> Nat -> Nat
-  397. structural type Optional a
-  398. Optional.None : Optional a
-  399. Optional.Some : a -> Optional a
-  400. builtin type Pattern
-  401. Pattern.capture : Pattern a -> Pattern a
-  402. Pattern.isMatch : Pattern a -> a -> Boolean
-  403. Pattern.join : [Pattern a] -> Pattern a
-  404. Pattern.many : Pattern a -> Pattern a
-  405. Pattern.or : Pattern a -> Pattern a -> Pattern a
-  406. Pattern.replicate : Nat -> Nat -> Pattern a -> Pattern a
-  407. Pattern.run : Pattern a -> a -> Optional ([a], a)
-  408. builtin type Ref
-  409. Ref.read : Ref g a ->{g} a
-  410. Ref.write : Ref g a -> a ->{g} ()
-  411. builtin type Request
-  412. builtin type Scope
-  413. Scope.array : Nat ->{Scope s} MutableArray (Scope s) a
-  414. Scope.arrayOf : a
+  374. builtin type Nat
+  375. Nat.* : Nat -> Nat -> Nat
+  376. Nat.+ : Nat -> Nat -> Nat
+  377. Nat./ : Nat -> Nat -> Nat
+  378. Nat.and : Nat -> Nat -> Nat
+  379. Nat.complement : Nat -> Nat
+  380. Nat.drop : Nat -> Nat -> Nat
+  381. Nat.eq : Nat -> Nat -> Boolean
+  382. Nat.fromText : Text -> Optional Nat
+  383. Nat.gt : Nat -> Nat -> Boolean
+  384. Nat.gteq : Nat -> Nat -> Boolean
+  385. Nat.increment : Nat -> Nat
+  386. Nat.isEven : Nat -> Boolean
+  387. Nat.isOdd : Nat -> Boolean
+  388. Nat.leadingZeros : Nat -> Nat
+  389. Nat.lt : Nat -> Nat -> Boolean
+  390. Nat.lteq : Nat -> Nat -> Boolean
+  391. Nat.mod : Nat -> Nat -> Nat
+  392. Nat.or : Nat -> Nat -> Nat
+  393. Nat.popCount : Nat -> Nat
+  394. Nat.pow : Nat -> Nat -> Nat
+  395. Nat.shiftLeft : Nat -> Nat -> Nat
+  396. Nat.shiftRight : Nat -> Nat -> Nat
+  397. Nat.sub : Nat -> Nat -> Int
+  398. Nat.toFloat : Nat -> Float
+  399. Nat.toInt : Nat -> Int
+  400. Nat.toText : Nat -> Text
+  401. Nat.trailingZeros : Nat -> Nat
+  402. Nat.xor : Nat -> Nat -> Nat
+  403. structural type Optional a
+  404. Optional.None : Optional a
+  405. Optional.Some : a -> Optional a
+  406. builtin type Pattern
+  407. Pattern.capture : Pattern a -> Pattern a
+  408. Pattern.isMatch : Pattern a -> a -> Boolean
+  409. Pattern.join : [Pattern a] -> Pattern a
+  410. Pattern.many : Pattern a -> Pattern a
+  411. Pattern.or : Pattern a -> Pattern a -> Pattern a
+  412. Pattern.replicate : Nat -> Nat -> Pattern a -> Pattern a
+  413. Pattern.run : Pattern a -> a -> Optional ([a], a)
+  414. builtin type Ref
+  415. Ref.read : Ref g a ->{g} a
+  416. Ref.write : Ref g a -> a ->{g} ()
+  417. builtin type Request
+  418. builtin type Scope
+  419. Scope.array : Nat ->{Scope s} MutableArray (Scope s) a
+  420. Scope.arrayOf : a
                        -> Nat
                        ->{Scope s} MutableArray (Scope s) a
-  415. Scope.bytearray : Nat
+  421. Scope.bytearray : Nat
                          ->{Scope s} MutableByteArray (Scope s)
-  416. Scope.bytearrayOf : Nat
+  422. Scope.bytearrayOf : Nat
                            -> Nat
                            ->{Scope s} MutableByteArray
                              (Scope s)
-  417. Scope.ref : a ->{Scope s} Ref {Scope s} a
-  418. Scope.run : (∀ s. '{g, Scope s} r) ->{g} r
-  419. structural type SeqView a b
-  420. SeqView.VElem : a -> b -> SeqView a b
-  421. SeqView.VEmpty : SeqView a b
-  422. Socket.toText : Socket -> Text
-  423. unique type Test.Result
-  424. Test.Result.Fail : Text -> Result
-  425. Test.Result.Ok : Text -> Result
-  426. builtin type Text
-  427. Text.!= : Text -> Text -> Boolean
-  428. Text.++ : Text -> Text -> Text
-  429. Text.drop : Nat -> Text -> Text
-  430. Text.empty : Text
-  431. Text.eq : Text -> Text -> Boolean
-  432. Text.fromCharList : [Char] -> Text
-  433. Text.fromUtf8.impl : Bytes -> Either Failure Text
-  434. Text.gt : Text -> Text -> Boolean
-  435. Text.gteq : Text -> Text -> Boolean
-  436. Text.lt : Text -> Text -> Boolean
-  437. Text.lteq : Text -> Text -> Boolean
-  438. Text.patterns.anyChar : Pattern Text
-  439. Text.patterns.charIn : [Char] -> Pattern Text
-  440. Text.patterns.charRange : Char -> Char -> Pattern Text
-  441. Text.patterns.digit : Pattern Text
-  442. Text.patterns.eof : Pattern Text
-  443. Text.patterns.letter : Pattern Text
-  444. Text.patterns.literal : Text -> Pattern Text
-  445. Text.patterns.notCharIn : [Char] -> Pattern Text
-  446. Text.patterns.notCharRange : Char -> Char -> Pattern Text
-  447. Text.patterns.punctuation : Pattern Text
-  448. Text.patterns.space : Pattern Text
-  449. Text.repeat : Nat -> Text -> Text
-  450. Text.reverse : Text -> Text
-  451. Text.size : Text -> Nat
-  452. Text.take : Nat -> Text -> Text
-  453. Text.toCharList : Text -> [Char]
-  454. Text.toLowercase : Text -> Text
-  455. Text.toUppercase : Text -> Text
-  456. Text.toUtf8 : Text -> Bytes
-  457. Text.uncons : Text -> Optional (Char, Text)
-  458. Text.unsnoc : Text -> Optional (Text, Char)
-  459. ThreadId.toText : ThreadId -> Text
-  460. todo : a -> b
-  461. structural type Tuple a b
-  462. Tuple.Cons : a -> b -> Tuple a b
-  463. structural type Unit
-  464. Unit.Unit : ()
-  465. Universal.< : a -> a -> Boolean
-  466. Universal.<= : a -> a -> Boolean
-  467. Universal.== : a -> a -> Boolean
-  468. Universal.> : a -> a -> Boolean
-  469. Universal.>= : a -> a -> Boolean
-  470. Universal.compare : a -> a -> Int
-  471. unsafe.coerceAbilities : (a ->{e1} b) -> a ->{e2} b
-  472. builtin type Value
-  473. Value.dependencies : Value -> [Term]
-  474. Value.deserialize : Bytes -> Either Text Value
-  475. Value.load : Value ->{IO} Either [Term] a
-  476. Value.serialize : Value -> Bytes
-  477. Value.value : a -> Value
+  423. Scope.ref : a ->{Scope s} Ref {Scope s} a
+  424. Scope.run : (∀ s. '{g, Scope s} r) ->{g} r
+  425. structural type SeqView a b
+  426. SeqView.VElem : a -> b -> SeqView a b
+  427. SeqView.VEmpty : SeqView a b
+  428. Socket.toText : Socket -> Text
+  429. unique type Test.Result
+  430. Test.Result.Fail : Text -> Result
+  431. Test.Result.Ok : Text -> Result
+  432. builtin type Text
+  433. Text.!= : Text -> Text -> Boolean
+  434. Text.++ : Text -> Text -> Text
+  435. Text.drop : Nat -> Text -> Text
+  436. Text.empty : Text
+  437. Text.eq : Text -> Text -> Boolean
+  438. Text.fromCharList : [Char] -> Text
+  439. Text.fromUtf8.impl : Bytes -> Either Failure Text
+  440. Text.gt : Text -> Text -> Boolean
+  441. Text.gteq : Text -> Text -> Boolean
+  442. Text.lt : Text -> Text -> Boolean
+  443. Text.lteq : Text -> Text -> Boolean
+  444. Text.patterns.anyChar : Pattern Text
+  445. Text.patterns.charIn : [Char] -> Pattern Text
+  446. Text.patterns.charRange : Char -> Char -> Pattern Text
+  447. Text.patterns.digit : Pattern Text
+  448. Text.patterns.eof : Pattern Text
+  449. Text.patterns.letter : Pattern Text
+  450. Text.patterns.literal : Text -> Pattern Text
+  451. Text.patterns.notCharIn : [Char] -> Pattern Text
+  452. Text.patterns.notCharRange : Char -> Char -> Pattern Text
+  453. Text.patterns.punctuation : Pattern Text
+  454. Text.patterns.space : Pattern Text
+  455. Text.repeat : Nat -> Text -> Text
+  456. Text.reverse : Text -> Text
+  457. Text.size : Text -> Nat
+  458. Text.take : Nat -> Text -> Text
+  459. Text.toCharList : Text -> [Char]
+  460. Text.toLowercase : Text -> Text
+  461. Text.toUppercase : Text -> Text
+  462. Text.toUtf8 : Text -> Bytes
+  463. Text.uncons : Text -> Optional (Char, Text)
+  464. Text.unsnoc : Text -> Optional (Text, Char)
+  465. ThreadId.toText : ThreadId -> Text
+  466. todo : a -> b
+  467. structural type Tuple a b
+  468. Tuple.Cons : a -> b -> Tuple a b
+  469. structural type Unit
+  470. Unit.Unit : ()
+  471. Universal.< : a -> a -> Boolean
+  472. Universal.<= : a -> a -> Boolean
+  473. Universal.== : a -> a -> Boolean
+  474. Universal.> : a -> a -> Boolean
+  475. Universal.>= : a -> a -> Boolean
+  476. Universal.compare : a -> a -> Int
+  477. unsafe.coerceAbilities : (a ->{e1} b) -> a ->{e2} b
+  478. builtin type Value
+  479. Value.dependencies : Value -> [Term]
+  480. Value.deserialize : Bytes -> Either Text Value
+  481. Value.load : Value ->{IO} Either [Term] a
+  482. Value.serialize : Value -> Bytes
+  483. Value.value : a -> Value
   
 
 .builtin> alias.many 94-104 .mylib

--- a/unison-src/transcripts/builtins-merge.output.md
+++ b/unison-src/transcripts/builtins-merge.output.md
@@ -74,7 +74,7 @@ The `builtins.merge` command adds the known builtins to a `builtin` subnamespace
   63. Value/              (5 terms)
   64. bug                 (a -> b)
   65. crypto/             (12 terms, 1 type)
-  66. io2/                (126 terms, 30 types)
+  66. io2/                (131 terms, 31 types)
   67. metadata/           (2 terms)
   68. todo                (a -> b)
   69. unsafe/             (1 term)

--- a/unison-src/transcripts/builtins.md
+++ b/unison-src/transcripts/builtins.md
@@ -81,6 +81,8 @@ test> Int.tests.conversions =
         fromText "+0" == Some +0,
         fromText "a8f9djasdlfkj" == None,
         fromText "3940" == Some +3940,
+        fromText "1000000000000000000000000000" == None,
+        fromText "-1000000000000000000000000000" == None,
         toFloat +9394 == 9394.0,
         toFloat -20349 == -20349.0
         ]
@@ -150,6 +152,8 @@ test> Nat.tests.conversions =
         toText 10 == "10",
         fromText "ooga" == None,
         fromText "90" == Some 90,
+        fromText "-1" == None,
+        fromText "100000000000000000000000000" == None,
         unsnoc "abc" == Some ("ab", ?c),
         uncons "abc" == Some (?a, "bc"),
         unsnoc "" == None,

--- a/unison-src/transcripts/builtins.output.md
+++ b/unison-src/transcripts/builtins.output.md
@@ -74,6 +74,8 @@ test> Int.tests.conversions =
         fromText "+0" == Some +0,
         fromText "a8f9djasdlfkj" == None,
         fromText "3940" == Some +3940,
+        fromText "1000000000000000000000000000" == None,
+        fromText "-1000000000000000000000000000" == None,
         toFloat +9394 == 9394.0,
         toFloat -20349 == -20349.0
         ]
@@ -139,6 +141,8 @@ test> Nat.tests.conversions =
         toText 10 == "10",
         fromText "ooga" == None,
         fromText "90" == Some 90,
+        fromText "-1" == None,
+        fromText "100000000000000000000000000" == None,
         unsnoc "abc" == Some ("ab", ?c),
         uncons "abc" == Some (?a, "bc"),
         unsnoc "" == None,

--- a/unison-src/transcripts/emptyCodebase.output.md
+++ b/unison-src/transcripts/emptyCodebase.output.md
@@ -23,7 +23,7 @@ Technically, the definitions all exist, but they have no names. `builtins.merge`
 
 .foo> ls
 
-  1. builtin/ (414 terms, 63 types)
+  1. builtin/ (419 terms, 64 types)
 
 ```
 And for a limited time, you can get even more builtin goodies:
@@ -35,7 +35,7 @@ And for a limited time, you can get even more builtin goodies:
 
 .foo> ls
 
-  1. builtin/ (586 terms, 81 types)
+  1. builtin/ (591 terms, 82 types)
 
 ```
 More typically, you'd start out by pulling `base.

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -121,13 +121,13 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #khhiq1sc3o
+  ⊙ 1. #ss5rfipsc9
   
     - Deletes:
     
       feature1.y
   
-  ⊙ 2. #0t16m7j03m
+  ⊙ 2. #pbsfditts0
   
     + Adds / updates:
     
@@ -138,26 +138,26 @@ We can also delete the fork if we're done with it. (Don't worry, it's still in t
       Original name New name(s)
       feature1.y    master.y
   
-  ⊙ 3. #l4cc5snm7c
+  ⊙ 3. #6vsh9eatk2
   
     + Adds / updates:
     
       feature1.y
   
-  ⊙ 4. #0ujfvnropc
+  ⊙ 4. #8q0ijp9unj
   
     > Moves:
     
       Original name New name
       x             master.x
   
-  ⊙ 5. #jd5q4ga1jk
+  ⊙ 5. #5ultfinuna
   
     + Adds / updates:
     
       x
   
-  □ 6. #67ki96tn2j (start of history)
+  □ 6. #hsdh3pm9ua (start of history)
 
 ```
 To resurrect an old version of a namespace, you can learn its hash via the `history` command, then use `fork #namespacehash .newname`.

--- a/unison-src/transcripts/move-namespace.output.md
+++ b/unison-src/transcripts/move-namespace.output.md
@@ -267,7 +267,7 @@ I should be able to move the root into a sub-namespace
 
 .> ls
 
-  1. root/ (591 terms, 82 types)
+  1. root/ (596 terms, 83 types)
 
 .> history
 
@@ -276,13 +276,13 @@ I should be able to move the root into a sub-namespace
   
   
   
-  □ 1. #2kibet66dd (start of history)
+  □ 1. #trup0d2160 (start of history)
 
 ```
 ```ucm
 .> ls .root.at.path
 
-  1. builtin/  (586 terms, 81 types)
+  1. builtin/  (591 terms, 82 types)
   2. existing/ (1 term)
   3. happy/    (3 terms, 1 type)
   4. history/  (1 term)
@@ -292,7 +292,7 @@ I should be able to move the root into a sub-namespace
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #e7uij3oft2
+  ⊙ 1. #dd8n885fue
   
     - Deletes:
     
@@ -303,7 +303,7 @@ I should be able to move the root into a sub-namespace
       Original name      New name
       existing.a.termInA existing.b.termInA
   
-  ⊙ 2. #v32ubv0p3r
+  ⊙ 2. #k5g4ehotlf
   
     + Adds / updates:
     
@@ -315,26 +315,26 @@ I should be able to move the root into a sub-namespace
       happy.b.termInA   existing.a.termInA
       history.b.termInA existing.a.termInA
   
-  ⊙ 3. #8brjmr30ls
+  ⊙ 3. #aqijafrrrj
   
     + Adds / updates:
     
       existing.a.termInA existing.b.termInB
   
-  ⊙ 4. #aie72ekk7e
+  ⊙ 4. #el3jo3o2n3
   
     > Moves:
     
       Original name     New name
       history.a.termInA history.b.termInA
   
-  ⊙ 5. #t05a2u5s1a
+  ⊙ 5. #io04ududm1
   
     - Deletes:
     
       history.b.termInB
   
-  ⊙ 6. #7e116chrdg
+  ⊙ 6. #7u417uihfu
   
     + Adds / updates:
     
@@ -345,13 +345,13 @@ I should be able to move the root into a sub-namespace
       Original name   New name(s)
       happy.b.termInA history.a.termInA
   
-  ⊙ 7. #aq0rd3db7l
+  ⊙ 7. #09p85hi2gq
   
     + Adds / updates:
     
       history.a.termInA history.b.termInB
   
-  ⊙ 8. #rk1p4aamml
+  ⊙ 8. #rqjb9hgqfn
   
     > Moves:
     
@@ -361,7 +361,7 @@ I should be able to move the root into a sub-namespace
       happy.a.T.T2    happy.b.T.T2
       happy.a.termInA happy.b.termInA
   
-  ⊙ 9. #dhr3sctdec
+  ⊙ 9. #11fgfgp2m2
   
     + Adds / updates:
     
@@ -371,7 +371,7 @@ I should be able to move the root into a sub-namespace
     
       happy.a.T.T
   
-  ⊙ 10. #bu35nl3qi6
+  ⊙ 10. #627cdfv199
   
     + Adds / updates:
     
@@ -383,7 +383,7 @@ I should be able to move the root into a sub-namespace
   
   ⠇
   
-  ⊙ 11. #bjgbu0j8dd
+  ⊙ 11. #5o3ve5br4l
   
 
 ```

--- a/unison-src/transcripts/name-selection.output.md
+++ b/unison-src/transcripts/name-selection.output.md
@@ -128,302 +128,306 @@ d = c + 10
     40.  structural type builtin.Optional a
     41.  builtin type builtin.Pattern
     42.  builtin type builtin.io2.Tls.PrivateKey
-    43.  builtin type builtin.io2.Promise
-    44.  builtin type builtin.Ref
-    45.  builtin type builtin.Request
-    46.  unique type builtin.Test.Result
-    47.  unique type builtin.io2.RuntimeFailure
-    48.  builtin ability builtin.io2.STM
-    49.  unique type builtin.io2.STMFailure
-    50.  builtin ability builtin.Scope
-    51.  unique type builtin.io2.SeekMode
-    52.  structural type builtin.SeqView a b
-    53.  builtin type builtin.io2.Tls.ServerConfig
-    54.  builtin type builtin.io2.Tls.SignedCert
-    55.  builtin type builtin.io2.Socket
-    56.  unique type builtin.io2.StdHandle
-    57.  builtin type builtin.io2.TVar
-    58.  builtin type builtin.Link.Term
-    59.  builtin type builtin.Text
-    60.  builtin type builtin.io2.ThreadId
-    61.  builtin type builtin.io2.Ref.Ticket
-    62.  builtin type builtin.io2.Clock.internals.TimeSpec
-    63.  builtin type builtin.io2.Tls
-    64.  unique type builtin.io2.TlsFailure
-    65.  structural type builtin.Tuple a b
-    66.  builtin type builtin.Link.Type
-    67.  structural type builtin.Unit
-    68.  builtin type builtin.Value
-    69.  builtin type builtin.io2.Tls.Version
-    70.  builtin.io2.SeekMode.AbsoluteSeek             : SeekMode
-    71.  builtin.io2.IOError.AlreadyExists             : IOError
-    72.  builtin.io2.FileMode.Append                   : FileMode
-    73.  builtin.Doc.Blob                              : Text
+    43.  builtin type builtin.io2.ProcessHandle
+    44.  builtin type builtin.io2.Promise
+    45.  builtin type builtin.Ref
+    46.  builtin type builtin.Request
+    47.  unique type builtin.Test.Result
+    48.  unique type builtin.io2.RuntimeFailure
+    49.  builtin ability builtin.io2.STM
+    50.  unique type builtin.io2.STMFailure
+    51.  builtin ability builtin.Scope
+    52.  unique type builtin.io2.SeekMode
+    53.  structural type builtin.SeqView a b
+    54.  builtin type builtin.io2.Tls.ServerConfig
+    55.  builtin type builtin.io2.Tls.SignedCert
+    56.  builtin type builtin.io2.Socket
+    57.  unique type builtin.io2.StdHandle
+    58.  builtin type builtin.io2.TVar
+    59.  builtin type builtin.Link.Term
+    60.  builtin type builtin.Text
+    61.  builtin type builtin.io2.ThreadId
+    62.  builtin type builtin.io2.Ref.Ticket
+    63.  builtin type builtin.io2.Clock.internals.TimeSpec
+    64.  builtin type builtin.io2.Tls
+    65.  unique type builtin.io2.TlsFailure
+    66.  structural type builtin.Tuple a b
+    67.  builtin type builtin.Link.Type
+    68.  structural type builtin.Unit
+    69.  builtin type builtin.Value
+    70.  builtin type builtin.io2.Tls.Version
+    71.  builtin.io2.SeekMode.AbsoluteSeek             : SeekMode
+    72.  builtin.io2.IOError.AlreadyExists             : IOError
+    73.  builtin.io2.FileMode.Append                   : FileMode
+    74.  builtin.Doc.Blob                              : Text
                                                        -> Doc
-    74.  builtin.io2.BufferMode.BlockBuffering         : BufferMode
-    75.  builtin.Tuple.Cons                            : a
+    75.  builtin.io2.BufferMode.BlockBuffering         : BufferMode
+    76.  builtin.Tuple.Cons                            : a
                                                        -> b
                                                        -> Tuple
                                                          a b
-    76.  builtin.io2.IOError.EOF                       : IOError
-    77.  builtin.Doc.Evaluate                          : Term
+    77.  builtin.io2.IOError.EOF                       : IOError
+    78.  builtin.Doc.Evaluate                          : Term
                                                        -> Doc
-    78.  builtin.Test.Result.Fail                      : Text
+    79.  builtin.Test.Result.Fail                      : Text
                                                        -> Result
-    79.  builtin.io2.Failure.Failure                   : Type
+    80.  builtin.io2.Failure.Failure                   : Type
                                                        -> Text
                                                        -> Any
                                                        -> Failure
-    80.  builtin.io2.IOError.IllegalOperation          : IOError
-    81.  builtin.IsPropagated.IsPropagated             : IsPropagated
-    82.  builtin.IsTest.IsTest                         : IsTest
-    83.  builtin.Doc.Join                              : [Doc]
+    81.  builtin.io2.IOError.IllegalOperation          : IOError
+    82.  builtin.IsPropagated.IsPropagated             : IsPropagated
+    83.  builtin.IsTest.IsTest                         : IsTest
+    84.  builtin.Doc.Join                              : [Doc]
                                                        -> Doc
-    84.  builtin.Either.Left                           : a
+    85.  builtin.Either.Left                           : a
                                                        -> Either
                                                          a b
-    85.  builtin.io2.BufferMode.LineBuffering          : BufferMode
-    86.  builtin.Doc.Link                              : Link
+    86.  builtin.io2.BufferMode.LineBuffering          : BufferMode
+    87.  builtin.Doc.Link                              : Link
                                                        -> Doc
-    87.  builtin.io2.BufferMode.NoBuffering            : BufferMode
-    88.  builtin.io2.IOError.NoSuchThing               : IOError
-    89.  builtin.Optional.None                         : Optional
+    88.  builtin.io2.BufferMode.NoBuffering            : BufferMode
+    89.  builtin.io2.IOError.NoSuchThing               : IOError
+    90.  builtin.Optional.None                         : Optional
                                                          a
-    90.  builtin.Test.Result.Ok                        : Text
+    91.  builtin.Test.Result.Ok                        : Text
                                                        -> Result
-    91.  builtin.io2.IOError.PermissionDenied          : IOError
-    92.  builtin.io2.FileMode.Read                     : FileMode
-    93.  builtin.io2.FileMode.ReadWrite                : FileMode
-    94.  builtin.io2.SeekMode.RelativeSeek             : SeekMode
-    95.  builtin.io2.IOError.ResourceBusy              : IOError
-    96.  builtin.io2.IOError.ResourceExhausted         : IOError
-    97.  builtin.Either.Right                          : b
+    92.  builtin.io2.IOError.PermissionDenied          : IOError
+    93.  builtin.io2.FileMode.Read                     : FileMode
+    94.  builtin.io2.FileMode.ReadWrite                : FileMode
+    95.  builtin.io2.SeekMode.RelativeSeek             : SeekMode
+    96.  builtin.io2.IOError.ResourceBusy              : IOError
+    97.  builtin.io2.IOError.ResourceExhausted         : IOError
+    98.  builtin.Either.Right                          : b
                                                        -> Either
                                                          a b
-    98.  builtin.io2.SeekMode.SeekFromEnd              : SeekMode
-    99.  builtin.Doc.Signature                         : Term
+    99.  builtin.io2.SeekMode.SeekFromEnd              : SeekMode
+    100. builtin.Doc.Signature                         : Term
                                                        -> Doc
-    100. builtin.io2.BufferMode.SizedBlockBuffering    : Nat
+    101. builtin.io2.BufferMode.SizedBlockBuffering    : Nat
                                                        -> BufferMode
-    101. builtin.Optional.Some                         : a
+    102. builtin.Optional.Some                         : a
                                                        -> Optional
                                                          a
-    102. builtin.Doc.Source                            : Link
+    103. builtin.Doc.Source                            : Link
                                                        -> Doc
-    103. builtin.io2.StdHandle.StdErr                  : StdHandle
-    104. builtin.io2.StdHandle.StdIn                   : StdHandle
-    105. builtin.io2.StdHandle.StdOut                  : StdHandle
-    106. builtin.Link.Term                             : Term
+    104. builtin.io2.StdHandle.StdErr                  : StdHandle
+    105. builtin.io2.StdHandle.StdIn                   : StdHandle
+    106. builtin.io2.StdHandle.StdOut                  : StdHandle
+    107. builtin.Link.Term                             : Term
                                                        -> Link
-    107. builtin.Link.Type                             : Type
+    108. builtin.Link.Type                             : Type
                                                        -> Link
-    108. builtin.Unit.Unit                             : ()
-    109. builtin.io2.IOError.UserError                 : IOError
-    110. builtin.SeqView.VElem                         : a
+    109. builtin.Unit.Unit                             : ()
+    110. builtin.io2.IOError.UserError                 : IOError
+    111. builtin.SeqView.VElem                         : a
                                                        -> b
                                                        -> SeqView
                                                          a b
-    111. builtin.SeqView.VEmpty                        : SeqView
+    112. builtin.SeqView.VEmpty                        : SeqView
                                                          a b
-    112. builtin.io2.FileMode.Write                    : FileMode
-    113. builtin.Exception.raise                       : Failure
+    113. builtin.io2.FileMode.Write                    : FileMode
+    114. builtin.Exception.raise                       : Failure
                                                        ->{Exception} x
-    114. builtin.Text.!=                               : Text
+    115. builtin.Text.!=                               : Text
                                                        -> Text
                                                        -> Boolean
-    115. builtin.Float.*                               : Float
+    116. builtin.Float.*                               : Float
                                                        -> Float
                                                        -> Float
-    116. builtin.Int.*                                 : Int
+    117. builtin.Int.*                                 : Int
                                                        -> Int
                                                        -> Int
-    117. builtin.Nat.*                                 : Nat
+    118. builtin.Nat.*                                 : Nat
                                                        -> Nat
                                                        -> Nat
-    118. builtin.Float.+                               : Float
+    119. builtin.Float.+                               : Float
                                                        -> Float
                                                        -> Float
-    119. builtin.Int.+                                 : Int
+    120. builtin.Int.+                                 : Int
                                                        -> Int
                                                        -> Int
-    120. builtin.Nat.+                                 : Nat
+    121. builtin.Nat.+                                 : Nat
                                                        -> Nat
                                                        -> Nat
-    121. builtin.Bytes.++                              : Bytes
+    122. builtin.Bytes.++                              : Bytes
                                                        -> Bytes
                                                        -> Bytes
-    122. builtin.List.++                               : [a]
+    123. builtin.List.++                               : [a]
                                                        -> [a]
                                                        -> [a]
-    123. builtin.Text.++                               : Text
+    124. builtin.Text.++                               : Text
                                                        -> Text
                                                        -> Text
-    124. ┌ builtin.List.+:                             : a
+    125. ┌ builtin.List.+:                             : a
                                                        -> [a]
                                                        -> [a]
-    125. └ builtin.List.cons                           : a
+    126. └ builtin.List.cons                           : a
                                                        -> [a]
                                                        -> [a]
-    126. builtin.Float.-                               : Float
+    127. builtin.Float.-                               : Float
                                                        -> Float
                                                        -> Float
-    127. builtin.Int.-                                 : Int
+    128. builtin.Int.-                                 : Int
                                                        -> Int
                                                        -> Int
-    128. builtin.Float./                               : Float
+    129. builtin.Float./                               : Float
                                                        -> Float
                                                        -> Float
-    129. builtin.Int./                                 : Int
+    130. builtin.Int./                                 : Int
                                                        -> Int
                                                        -> Int
-    130. builtin.Nat./                                 : Nat
+    131. builtin.Nat./                                 : Nat
                                                        -> Nat
                                                        -> Nat
-    131. ┌ builtin.List.:+                             : [a]
+    132. ┌ builtin.List.:+                             : [a]
                                                        -> a
                                                        -> [a]
-    132. └ builtin.List.snoc                           : [a]
+    133. └ builtin.List.snoc                           : [a]
                                                        -> a
                                                        -> [a]
-    133. builtin.Universal.<                           : a
+    134. builtin.Universal.<                           : a
                                                        -> a
                                                        -> Boolean
-    134. builtin.Universal.<=                          : a
+    135. builtin.Universal.<=                          : a
                                                        -> a
                                                        -> Boolean
-    135. builtin.Universal.==                          : a
+    136. builtin.Universal.==                          : a
                                                        -> a
                                                        -> Boolean
-    136. builtin.Universal.>                           : a
+    137. builtin.Universal.>                           : a
                                                        -> a
                                                        -> Boolean
-    137. builtin.Universal.>=                          : a
+    138. builtin.Universal.>=                          : a
                                                        -> a
                                                        -> Boolean
-    138. builtin.Any.Any                               : a
+    139. builtin.Any.Any                               : a
                                                        -> Any
-    139. builtin.crypto.HashAlgorithm.Blake2b_256      : HashAlgorithm
-    140. builtin.crypto.HashAlgorithm.Blake2b_512      : HashAlgorithm
-    141. builtin.crypto.HashAlgorithm.Blake2s_256      : HashAlgorithm
-    142. builtin.crypto.HashAlgorithm.Sha1             : HashAlgorithm
-    143. builtin.crypto.HashAlgorithm.Sha2_256         : HashAlgorithm
-    144. builtin.crypto.HashAlgorithm.Sha2_512         : HashAlgorithm
-    145. builtin.crypto.HashAlgorithm.Sha3_256         : HashAlgorithm
-    146. builtin.crypto.HashAlgorithm.Sha3_512         : HashAlgorithm
-    147. builtin.Float.abs                             : Float
+    140. builtin.crypto.HashAlgorithm.Blake2b_256      : HashAlgorithm
+    141. builtin.crypto.HashAlgorithm.Blake2b_512      : HashAlgorithm
+    142. builtin.crypto.HashAlgorithm.Blake2s_256      : HashAlgorithm
+    143. builtin.crypto.HashAlgorithm.Sha1             : HashAlgorithm
+    144. builtin.crypto.HashAlgorithm.Sha2_256         : HashAlgorithm
+    145. builtin.crypto.HashAlgorithm.Sha2_512         : HashAlgorithm
+    146. builtin.crypto.HashAlgorithm.Sha3_256         : HashAlgorithm
+    147. builtin.crypto.HashAlgorithm.Sha3_512         : HashAlgorithm
+    148. builtin.Float.abs                             : Float
                                                        -> Float
-    148. builtin.Float.acos                            : Float
+    149. builtin.Float.acos                            : Float
                                                        -> Float
-    149. builtin.Float.acosh                           : Float
+    150. builtin.Float.acosh                           : Float
                                                        -> Float
-    150. builtin.Int.and                               : Int
+    151. builtin.Int.and                               : Int
                                                        -> Int
                                                        -> Int
-    151. builtin.Nat.and                               : Nat
+    152. builtin.Nat.and                               : Nat
                                                        -> Nat
                                                        -> Nat
-    152. builtin.Text.patterns.anyChar                 : Pattern
+    153. builtin.Text.patterns.anyChar                 : Pattern
                                                          Text
-    153. builtin.io2.IO.array                          : Nat
+    154. builtin.io2.IO.array                          : Nat
                                                        ->{IO} MutableArray
                                                          {IO} a
-    154. builtin.Scope.array                           : Nat
+    155. builtin.Scope.array                           : Nat
                                                        ->{Scope
                                                          s} MutableArray
                                                          (Scope
                                                            s)
                                                          a
-    155. builtin.io2.IO.arrayOf                        : a
+    156. builtin.io2.IO.arrayOf                        : a
                                                        -> Nat
                                                        ->{IO} MutableArray
                                                          {IO} a
-    156. builtin.Scope.arrayOf                         : a
+    157. builtin.Scope.arrayOf                         : a
                                                        -> Nat
                                                        ->{Scope
                                                          s} MutableArray
                                                          (Scope
                                                            s)
                                                          a
-    157. builtin.Float.asin                            : Float
+    158. builtin.Float.asin                            : Float
                                                        -> Float
-    158. builtin.Float.asinh                           : Float
+    159. builtin.Float.asinh                           : Float
                                                        -> Float
-    159. builtin.Bytes.at                              : Nat
+    160. builtin.Bytes.at                              : Nat
                                                        -> Bytes
                                                        -> Optional
                                                          Nat
-    160. builtin.List.at                               : Nat
+    161. builtin.List.at                               : Nat
                                                        -> [a]
                                                        -> Optional
                                                          a
-    161. builtin.Float.atan                            : Float
+    162. builtin.Float.atan                            : Float
                                                        -> Float
-    162. builtin.Float.atan2                           : Float
+    163. builtin.Float.atan2                           : Float
                                                        -> Float
                                                        -> Float
-    163. builtin.Float.atanh                           : Float
+    164. builtin.Float.atanh                           : Float
                                                        -> Float
-    164. builtin.io2.STM.atomically                    : '{STM} a
+    165. builtin.io2.STM.atomically                    : '{STM} a
                                                        ->{IO} a
-    165. builtin.bug                                   : a -> b
-    166. builtin.io2.IO.bytearray                      : Nat
+    166. builtin.bug                                   : a -> b
+    167. builtin.io2.IO.bytearray                      : Nat
                                                        ->{IO} MutableByteArray
                                                          {IO}
-    167. builtin.Scope.bytearray                       : Nat
+    168. builtin.Scope.bytearray                       : Nat
                                                        ->{Scope
                                                          s} MutableByteArray
                                                          (Scope
                                                            s)
-    168. builtin.io2.IO.bytearrayOf                    : Nat
+    169. builtin.io2.IO.bytearrayOf                    : Nat
                                                        -> Nat
                                                        ->{IO} MutableByteArray
                                                          {IO}
-    169. builtin.Scope.bytearrayOf                     : Nat
+    170. builtin.Scope.bytearrayOf                     : Nat
                                                        -> Nat
                                                        ->{Scope
                                                          s} MutableByteArray
                                                          (Scope
                                                            s)
-    170. ┌ c#gjmq673r1v                                : Nat
-    171. └ long.name.but.shortest.suffixification      : Nat
-    172. builtin.Code.cache_                           : [( Term,
+    171. ┌ c#gjmq673r1v                                : Nat
+    172. └ long.name.but.shortest.suffixification      : Nat
+    173. builtin.Code.cache_                           : [( Term,
                                                          Code)]
                                                        ->{IO} [Term]
-    173. builtin.Pattern.capture                       : Pattern
+    174. builtin.io2.IO.process.call                   : Text
+                                                       -> [Text]
+                                                       ->{IO} Nat
+    175. builtin.Pattern.capture                       : Pattern
                                                          a
                                                        -> Pattern
                                                          a
-    174. builtin.io2.Ref.cas                           : Ref
+    176. builtin.io2.Ref.cas                           : Ref
                                                          {IO} a
                                                        -> Ticket
                                                          a
                                                        -> a
                                                        ->{IO} Boolean
-    175. builtin.Float.ceiling                         : Float
+    177. builtin.Float.ceiling                         : Float
                                                        -> Int
-    176. builtin.Text.patterns.charIn                  : [Char]
+    178. builtin.Text.patterns.charIn                  : [Char]
                                                        -> Pattern
                                                          Text
-    177. builtin.Text.patterns.charRange               : Char
+    179. builtin.Text.patterns.charRange               : Char
                                                        -> Char
                                                        -> Pattern
                                                          Text
-    178. builtin.unsafe.coerceAbilities                : (a
+    180. builtin.unsafe.coerceAbilities                : (a
                                                        ->{e1} b)
                                                        -> a
                                                        ->{e2} b
-    179. builtin.Universal.compare                     : a
+    181. builtin.Universal.compare                     : a
                                                        -> a
                                                        -> Int
-    180. builtin.Int.complement                        : Int
+    182. builtin.Int.complement                        : Int
                                                        -> Int
-    181. builtin.Nat.complement                        : Nat
+    183. builtin.Nat.complement                        : Nat
                                                        -> Nat
-    182. builtin.Bytes.gzip.compress                   : Bytes
+    184. builtin.Bytes.gzip.compress                   : Bytes
                                                        -> Bytes
-    183. builtin.Bytes.zlib.compress                   : Bytes
+    185. builtin.Bytes.zlib.compress                   : Bytes
                                                        -> Bytes
-    184. builtin.ImmutableArray.copyTo!                : MutableArray
+    186. builtin.ImmutableArray.copyTo!                : MutableArray
                                                          g a
                                                        -> Nat
                                                        -> ImmutableArray
@@ -432,7 +436,7 @@ d = c + 10
                                                        -> Nat
                                                        ->{g,
                                                        Exception} ()
-    185. builtin.ImmutableByteArray.copyTo!            : MutableByteArray
+    187. builtin.ImmutableByteArray.copyTo!            : MutableByteArray
                                                          g
                                                        -> Nat
                                                        -> ImmutableByteArray
@@ -440,7 +444,7 @@ d = c + 10
                                                        -> Nat
                                                        ->{g,
                                                        Exception} ()
-    186. builtin.MutableArray.copyTo!                  : MutableArray
+    188. builtin.MutableArray.copyTo!                  : MutableArray
                                                          g a
                                                        -> Nat
                                                        -> MutableArray
@@ -449,7 +453,7 @@ d = c + 10
                                                        -> Nat
                                                        ->{g,
                                                        Exception} ()
-    187. builtin.MutableByteArray.copyTo!              : MutableByteArray
+    189. builtin.MutableByteArray.copyTo!              : MutableByteArray
                                                          g
                                                        -> Nat
                                                        -> MutableByteArray
@@ -458,943 +462,956 @@ d = c + 10
                                                        -> Nat
                                                        ->{g,
                                                        Exception} ()
-    188. builtin.Float.cos                             : Float
+    190. builtin.Float.cos                             : Float
                                                        -> Float
-    189. builtin.Float.cosh                            : Float
+    191. builtin.Float.cosh                            : Float
                                                        -> Float
-    190. builtin.Bytes.decodeNat16be                   : Bytes
+    192. builtin.Bytes.decodeNat16be                   : Bytes
                                                        -> Optional
                                                          ( Nat,
                                                            Bytes)
-    191. builtin.Bytes.decodeNat16le                   : Bytes
+    193. builtin.Bytes.decodeNat16le                   : Bytes
                                                        -> Optional
                                                          ( Nat,
                                                            Bytes)
-    192. builtin.Bytes.decodeNat32be                   : Bytes
+    194. builtin.Bytes.decodeNat32be                   : Bytes
                                                        -> Optional
                                                          ( Nat,
                                                            Bytes)
-    193. builtin.Bytes.decodeNat32le                   : Bytes
+    195. builtin.Bytes.decodeNat32le                   : Bytes
                                                        -> Optional
                                                          ( Nat,
                                                            Bytes)
-    194. builtin.Bytes.decodeNat64be                   : Bytes
+    196. builtin.Bytes.decodeNat64be                   : Bytes
                                                        -> Optional
                                                          ( Nat,
                                                            Bytes)
-    195. builtin.Bytes.decodeNat64le                   : Bytes
+    197. builtin.Bytes.decodeNat64le                   : Bytes
                                                        -> Optional
                                                          ( Nat,
                                                            Bytes)
-    196. builtin.io2.Tls.decodePrivateKey              : Bytes
+    198. builtin.io2.Tls.decodePrivateKey              : Bytes
                                                        -> [PrivateKey]
-    197. builtin.Bytes.gzip.decompress                 : Bytes
+    199. builtin.Bytes.gzip.decompress                 : Bytes
                                                        -> Either
                                                          Text
                                                          Bytes
-    198. builtin.Bytes.zlib.decompress                 : Bytes
+    200. builtin.Bytes.zlib.decompress                 : Bytes
                                                        -> Either
                                                          Text
                                                          Bytes
-    199. builtin.io2.Tls.ClientConfig.default          : Text
+    201. builtin.io2.Tls.ClientConfig.default          : Text
                                                        -> Bytes
                                                        -> ClientConfig
-    200. builtin.io2.Tls.ServerConfig.default          : [SignedCert]
+    202. builtin.io2.Tls.ServerConfig.default          : [SignedCert]
                                                        -> PrivateKey
                                                        -> ServerConfig
-    201. builtin.Code.dependencies                     : Code
+    203. builtin.Code.dependencies                     : Code
                                                        -> [Term]
-    202. builtin.Value.dependencies                    : Value
+    204. builtin.Value.dependencies                    : Value
                                                        -> [Term]
-    203. builtin.Code.deserialize                      : Bytes
+    205. builtin.Code.deserialize                      : Bytes
                                                        -> Either
                                                          Text
                                                          Code
-    204. builtin.Value.deserialize                     : Bytes
+    206. builtin.Value.deserialize                     : Bytes
                                                        -> Either
                                                          Text
                                                          Value
-    205. builtin.Text.patterns.digit                   : Pattern
+    207. builtin.Text.patterns.digit                   : Pattern
                                                          Text
-    206. builtin.Code.display                          : Text
+    208. builtin.Code.display                          : Text
                                                        -> Code
                                                        -> Text
-    207. builtin.Bytes.drop                            : Nat
+    209. builtin.Bytes.drop                            : Nat
                                                        -> Bytes
                                                        -> Bytes
-    208. builtin.List.drop                             : Nat
+    210. builtin.List.drop                             : Nat
                                                        -> [a]
                                                        -> [a]
-    209. builtin.Nat.drop                              : Nat
+    211. builtin.Nat.drop                              : Nat
                                                        -> Nat
                                                        -> Nat
-    210. builtin.Text.drop                             : Nat
+    212. builtin.Text.drop                             : Nat
                                                        -> Text
                                                        -> Text
-    211. builtin.Bytes.empty                           : Bytes
-    212. builtin.List.empty                            : [a]
-    213. builtin.Text.empty                            : Text
-    214. builtin.io2.Tls.encodeCert                    : SignedCert
+    213. builtin.Bytes.empty                           : Bytes
+    214. builtin.List.empty                            : [a]
+    215. builtin.Text.empty                            : Text
+    216. builtin.io2.Tls.encodeCert                    : SignedCert
                                                        -> Bytes
-    215. builtin.Bytes.encodeNat16be                   : Nat
+    217. builtin.Bytes.encodeNat16be                   : Nat
                                                        -> Bytes
-    216. builtin.Bytes.encodeNat16le                   : Nat
+    218. builtin.Bytes.encodeNat16le                   : Nat
                                                        -> Bytes
-    217. builtin.Bytes.encodeNat32be                   : Nat
+    219. builtin.Bytes.encodeNat32be                   : Nat
                                                        -> Bytes
-    218. builtin.Bytes.encodeNat32le                   : Nat
+    220. builtin.Bytes.encodeNat32le                   : Nat
                                                        -> Bytes
-    219. builtin.Bytes.encodeNat64be                   : Nat
+    221. builtin.Bytes.encodeNat64be                   : Nat
                                                        -> Bytes
-    220. builtin.Bytes.encodeNat64le                   : Nat
+    222. builtin.Bytes.encodeNat64le                   : Nat
                                                        -> Bytes
-    221. builtin.io2.Tls.encodePrivateKey              : PrivateKey
+    223. builtin.io2.Tls.encodePrivateKey              : PrivateKey
                                                        -> Bytes
-    222. builtin.Text.patterns.eof                     : Pattern
+    224. builtin.Text.patterns.eof                     : Pattern
                                                          Text
-    223. builtin.Float.eq                              : Float
+    225. builtin.Float.eq                              : Float
                                                        -> Float
                                                        -> Boolean
-    224. builtin.Int.eq                                : Int
+    226. builtin.Int.eq                                : Int
                                                        -> Int
                                                        -> Boolean
-    225. builtin.Nat.eq                                : Nat
+    227. builtin.Nat.eq                                : Nat
                                                        -> Nat
                                                        -> Boolean
-    226. builtin.Text.eq                               : Text
+    228. builtin.Text.eq                               : Text
                                                        -> Text
                                                        -> Boolean
-    227. builtin.Float.exp                             : Float
+    229. builtin.io2.IO.process.exitCode               : ProcessHandle
+                                                       ->{IO} Optional
+                                                         Nat
+    230. builtin.Float.exp                             : Float
                                                        -> Float
-    228. builtin.Bytes.flatten                         : Bytes
+    231. builtin.Bytes.flatten                         : Bytes
                                                        -> Bytes
-    229. builtin.Float.floor                           : Float
+    232. builtin.Float.floor                           : Float
                                                        -> Int
-    230. builtin.io2.IO.forkComp                       : '{IO} a
+    233. builtin.io2.IO.forkComp                       : '{IO} a
                                                        ->{IO} ThreadId
-    231. builtin.MutableArray.freeze                   : MutableArray
+    234. builtin.MutableArray.freeze                   : MutableArray
                                                          g a
                                                        -> Nat
                                                        -> Nat
                                                        ->{g} ImmutableArray
                                                          a
-    232. builtin.MutableByteArray.freeze               : MutableByteArray
+    235. builtin.MutableByteArray.freeze               : MutableByteArray
                                                          g
                                                        -> Nat
                                                        -> Nat
                                                        ->{g} ImmutableByteArray
-    233. builtin.MutableArray.freeze!                  : MutableArray
+    236. builtin.MutableArray.freeze!                  : MutableArray
                                                          g a
                                                        ->{g} ImmutableArray
                                                          a
-    234. builtin.MutableByteArray.freeze!              : MutableByteArray
+    237. builtin.MutableByteArray.freeze!              : MutableByteArray
                                                          g
                                                        ->{g} ImmutableByteArray
-    235. builtin.Bytes.fromBase16                      : Bytes
+    238. builtin.Bytes.fromBase16                      : Bytes
                                                        -> Either
                                                          Text
                                                          Bytes
-    236. builtin.Bytes.fromBase32                      : Bytes
+    239. builtin.Bytes.fromBase32                      : Bytes
                                                        -> Either
                                                          Text
                                                          Bytes
-    237. builtin.Bytes.fromBase64                      : Bytes
+    240. builtin.Bytes.fromBase64                      : Bytes
                                                        -> Either
                                                          Text
                                                          Bytes
-    238. builtin.Bytes.fromBase64UrlUnpadded           : Bytes
+    241. builtin.Bytes.fromBase64UrlUnpadded           : Bytes
                                                        -> Either
                                                          Text
                                                          Bytes
-    239. builtin.Text.fromCharList                     : [Char]
+    242. builtin.Text.fromCharList                     : [Char]
                                                        -> Text
-    240. builtin.Bytes.fromList                        : [Nat]
+    243. builtin.Bytes.fromList                        : [Nat]
                                                        -> Bytes
-    241. builtin.Char.fromNat                          : Nat
+    244. builtin.Char.fromNat                          : Nat
                                                        -> Char
-    242. builtin.Float.fromRepresentation              : Nat
+    245. builtin.Float.fromRepresentation              : Nat
                                                        -> Float
-    243. builtin.Int.fromRepresentation                : Nat
+    246. builtin.Int.fromRepresentation                : Nat
                                                        -> Int
-    244. builtin.Float.fromText                        : Text
+    247. builtin.Float.fromText                        : Text
                                                        -> Optional
                                                          Float
-    245. builtin.Int.fromText                          : Text
+    248. builtin.Int.fromText                          : Text
                                                        -> Optional
                                                          Int
-    246. builtin.Nat.fromText                          : Text
+    249. builtin.Nat.fromText                          : Text
                                                        -> Optional
                                                          Nat
-    247. builtin.Float.gt                              : Float
+    250. builtin.Float.gt                              : Float
                                                        -> Float
                                                        -> Boolean
-    248. builtin.Int.gt                                : Int
+    251. builtin.Int.gt                                : Int
                                                        -> Int
                                                        -> Boolean
-    249. builtin.Nat.gt                                : Nat
+    252. builtin.Nat.gt                                : Nat
                                                        -> Nat
                                                        -> Boolean
-    250. builtin.Text.gt                               : Text
+    253. builtin.Text.gt                               : Text
                                                        -> Text
                                                        -> Boolean
-    251. builtin.Float.gteq                            : Float
+    254. builtin.Float.gteq                            : Float
                                                        -> Float
                                                        -> Boolean
-    252. builtin.Int.gteq                              : Int
+    255. builtin.Int.gteq                              : Int
                                                        -> Int
                                                        -> Boolean
-    253. builtin.Nat.gteq                              : Nat
+    256. builtin.Nat.gteq                              : Nat
                                                        -> Nat
                                                        -> Boolean
-    254. builtin.Text.gteq                             : Text
+    257. builtin.Text.gteq                             : Text
                                                        -> Text
                                                        -> Boolean
-    255. builtin.crypto.hash                           : HashAlgorithm
+    258. builtin.crypto.hash                           : HashAlgorithm
                                                        -> a
                                                        -> Bytes
-    256. builtin.crypto.hashBytes                      : HashAlgorithm
+    259. builtin.crypto.hashBytes                      : HashAlgorithm
                                                        -> Bytes
                                                        -> Bytes
-    257. builtin.crypto.hmac                           : HashAlgorithm
+    260. builtin.crypto.hmac                           : HashAlgorithm
                                                        -> Bytes
                                                        -> a
                                                        -> Bytes
-    258. builtin.crypto.hmacBytes                      : HashAlgorithm
+    261. builtin.crypto.hmacBytes                      : HashAlgorithm
                                                        -> Bytes
                                                        -> Bytes
                                                        -> Bytes
-    259. builtin.io2.IO.clientSocket.impl              : Text
+    262. builtin.io2.IO.clientSocket.impl              : Text
                                                        -> Text
                                                        ->{IO} Either
                                                          Failure
                                                          Socket
-    260. builtin.io2.IO.closeFile.impl                 : Handle
+    263. builtin.io2.IO.closeFile.impl                 : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    261. builtin.io2.IO.closeSocket.impl               : Socket
+    264. builtin.io2.IO.closeSocket.impl               : Socket
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    262. builtin.io2.IO.createDirectory.impl           : Text
+    265. builtin.io2.IO.createDirectory.impl           : Text
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    263. builtin.io2.IO.createTempDirectory.impl       : Text
+    266. builtin.io2.IO.createTempDirectory.impl       : Text
                                                        ->{IO} Either
                                                          Failure
                                                          Text
-    264. builtin.io2.Tls.decodeCert.impl               : Bytes
+    267. builtin.io2.Tls.decodeCert.impl               : Bytes
                                                        -> Either
                                                          Failure
                                                          SignedCert
-    265. builtin.io2.IO.delay.impl                     : Nat
+    268. builtin.io2.IO.delay.impl                     : Nat
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    266. builtin.io2.IO.directoryContents.impl         : Text
+    269. builtin.io2.IO.directoryContents.impl         : Text
                                                        ->{IO} Either
                                                          Failure
                                                          [Text]
-    267. builtin.io2.IO.fileExists.impl                : Text
+    270. builtin.io2.IO.fileExists.impl                : Text
                                                        ->{IO} Either
                                                          Failure
                                                          Boolean
-    268. builtin.Text.fromUtf8.impl                    : Bytes
+    271. builtin.Text.fromUtf8.impl                    : Bytes
                                                        -> Either
                                                          Failure
                                                          Text
-    269. builtin.io2.IO.getArgs.impl                   : '{IO} Either
+    272. builtin.io2.IO.getArgs.impl                   : '{IO} Either
                                                          Failure
                                                          [Text]
-    270. builtin.io2.IO.getBuffering.impl              : Handle
+    273. builtin.io2.IO.getBuffering.impl              : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          BufferMode
-    271. builtin.io2.IO.getBytes.impl                  : Handle
+    274. builtin.io2.IO.getBytes.impl                  : Handle
                                                        -> Nat
                                                        ->{IO} Either
                                                          Failure
                                                          Bytes
-    272. builtin.io2.IO.getChar.impl                   : Handle
+    275. builtin.io2.IO.getChar.impl                   : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          Char
-    273. builtin.io2.IO.getCurrentDirectory.impl       : '{IO} Either
+    276. builtin.io2.IO.getCurrentDirectory.impl       : '{IO} Either
                                                          Failure
                                                          Text
-    274. builtin.io2.IO.getEcho.impl                   : Handle
+    277. builtin.io2.IO.getEcho.impl                   : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          Boolean
-    275. builtin.io2.IO.getEnv.impl                    : Text
+    278. builtin.io2.IO.getEnv.impl                    : Text
                                                        ->{IO} Either
                                                          Failure
                                                          Text
-    276. builtin.io2.IO.getFileSize.impl               : Text
+    279. builtin.io2.IO.getFileSize.impl               : Text
                                                        ->{IO} Either
                                                          Failure
                                                          Nat
-    277. builtin.io2.IO.getFileTimestamp.impl          : Text
+    280. builtin.io2.IO.getFileTimestamp.impl          : Text
                                                        ->{IO} Either
                                                          Failure
                                                          Nat
-    278. builtin.io2.IO.getLine.impl                   : Handle
+    281. builtin.io2.IO.getLine.impl                   : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          Text
-    279. builtin.io2.IO.getSomeBytes.impl              : Handle
+    282. builtin.io2.IO.getSomeBytes.impl              : Handle
                                                        -> Nat
                                                        ->{IO} Either
                                                          Failure
                                                          Bytes
-    280. builtin.io2.IO.getTempDirectory.impl          : '{IO} Either
+    283. builtin.io2.IO.getTempDirectory.impl          : '{IO} Either
                                                          Failure
                                                          Text
-    281. builtin.io2.IO.handlePosition.impl            : Handle
+    284. builtin.io2.IO.handlePosition.impl            : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          Nat
-    282. builtin.io2.Tls.handshake.impl                : Tls
+    285. builtin.io2.Tls.handshake.impl                : Tls
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    283. builtin.io2.IO.isDirectory.impl               : Text
+    286. builtin.io2.IO.isDirectory.impl               : Text
                                                        ->{IO} Either
                                                          Failure
                                                          Boolean
-    284. builtin.io2.IO.isFileEOF.impl                 : Handle
+    287. builtin.io2.IO.isFileEOF.impl                 : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          Boolean
-    285. builtin.io2.IO.isFileOpen.impl                : Handle
+    288. builtin.io2.IO.isFileOpen.impl                : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          Boolean
-    286. builtin.io2.IO.isSeekable.impl                : Handle
+    289. builtin.io2.IO.isSeekable.impl                : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          Boolean
-    287. builtin.io2.IO.kill.impl                      : ThreadId
+    290. builtin.io2.IO.kill.impl                      : ThreadId
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    288. builtin.io2.IO.listen.impl                    : Socket
+    291. builtin.io2.IO.listen.impl                    : Socket
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    289. builtin.io2.Tls.newClient.impl                : ClientConfig
+    292. builtin.io2.Tls.newClient.impl                : ClientConfig
                                                        -> Socket
                                                        ->{IO} Either
                                                          Failure
                                                          Tls
-    290. builtin.io2.Tls.newServer.impl                : ServerConfig
+    293. builtin.io2.Tls.newServer.impl                : ServerConfig
                                                        -> Socket
                                                        ->{IO} Either
                                                          Failure
                                                          Tls
-    291. builtin.io2.IO.openFile.impl                  : Text
+    294. builtin.io2.IO.openFile.impl                  : Text
                                                        -> FileMode
                                                        ->{IO} Either
                                                          Failure
                                                          Handle
-    292. builtin.io2.MVar.put.impl                     : MVar a
+    295. builtin.io2.MVar.put.impl                     : MVar a
                                                        -> a
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    293. builtin.io2.IO.putBytes.impl                  : Handle
+    296. builtin.io2.IO.putBytes.impl                  : Handle
                                                        -> Bytes
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    294. builtin.io2.MVar.read.impl                    : MVar a
+    297. builtin.io2.MVar.read.impl                    : MVar a
                                                        ->{IO} Either
                                                          Failure
                                                          a
-    295. builtin.io2.IO.ready.impl                     : Handle
+    298. builtin.io2.IO.ready.impl                     : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          Boolean
-    296. builtin.io2.Tls.receive.impl                  : Tls
+    299. builtin.io2.Tls.receive.impl                  : Tls
                                                        ->{IO} Either
                                                          Failure
                                                          Bytes
-    297. builtin.io2.IO.removeDirectory.impl           : Text
+    300. builtin.io2.IO.removeDirectory.impl           : Text
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    298. builtin.io2.IO.removeFile.impl                : Text
+    301. builtin.io2.IO.removeFile.impl                : Text
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    299. builtin.io2.IO.renameDirectory.impl           : Text
+    302. builtin.io2.IO.renameDirectory.impl           : Text
                                                        -> Text
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    300. builtin.io2.IO.renameFile.impl                : Text
+    303. builtin.io2.IO.renameFile.impl                : Text
                                                        -> Text
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    301. builtin.io2.IO.seekHandle.impl                : Handle
+    304. builtin.io2.IO.seekHandle.impl                : Handle
                                                        -> SeekMode
                                                        -> Int
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    302. builtin.io2.Tls.send.impl                     : Tls
+    305. builtin.io2.Tls.send.impl                     : Tls
                                                        -> Bytes
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    303. builtin.io2.IO.serverSocket.impl              : Optional
+    306. builtin.io2.IO.serverSocket.impl              : Optional
                                                          Text
                                                        -> Text
                                                        ->{IO} Either
                                                          Failure
                                                          Socket
-    304. builtin.io2.IO.setBuffering.impl              : Handle
+    307. builtin.io2.IO.setBuffering.impl              : Handle
                                                        -> BufferMode
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    305. builtin.io2.IO.setCurrentDirectory.impl       : Text
+    308. builtin.io2.IO.setCurrentDirectory.impl       : Text
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    306. builtin.io2.IO.setEcho.impl                   : Handle
+    309. builtin.io2.IO.setEcho.impl                   : Handle
                                                        -> Boolean
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    307. builtin.io2.IO.socketAccept.impl              : Socket
+    310. builtin.io2.IO.socketAccept.impl              : Socket
                                                        ->{IO} Either
                                                          Failure
                                                          Socket
-    308. builtin.io2.IO.socketPort.impl                : Socket
+    311. builtin.io2.IO.socketPort.impl                : Socket
                                                        ->{IO} Either
                                                          Failure
                                                          Nat
-    309. builtin.io2.IO.socketReceive.impl             : Socket
+    312. builtin.io2.IO.socketReceive.impl             : Socket
                                                        -> Nat
                                                        ->{IO} Either
                                                          Failure
                                                          Bytes
-    310. builtin.io2.IO.socketSend.impl                : Socket
+    313. builtin.io2.IO.socketSend.impl                : Socket
                                                        -> Bytes
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    311. builtin.io2.MVar.swap.impl                    : MVar a
+    314. builtin.io2.MVar.swap.impl                    : MVar a
                                                        -> a
                                                        ->{IO} Either
                                                          Failure
                                                          a
-    312. builtin.io2.IO.systemTime.impl                : '{IO} Either
+    315. builtin.io2.IO.systemTime.impl                : '{IO} Either
                                                          Failure
                                                          Nat
-    313. builtin.io2.MVar.take.impl                    : MVar a
+    316. builtin.io2.MVar.take.impl                    : MVar a
                                                        ->{IO} Either
                                                          Failure
                                                          a
-    314. builtin.io2.Tls.terminate.impl                : Tls
+    317. builtin.io2.Tls.terminate.impl                : Tls
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    315. builtin.io2.MVar.tryPut.impl                  : MVar a
+    318. builtin.io2.MVar.tryPut.impl                  : MVar a
                                                        -> a
                                                        ->{IO} Either
                                                          Failure
                                                          Boolean
-    316. builtin.io2.MVar.tryRead.impl                 : MVar a
+    319. builtin.io2.MVar.tryRead.impl                 : MVar a
                                                        ->{IO} Either
                                                          Failure
                                                          (Optional
                                                            a)
-    317. builtin.Int.increment                         : Int
+    320. builtin.Int.increment                         : Int
                                                        -> Int
-    318. builtin.Nat.increment                         : Nat
+    321. builtin.Nat.increment                         : Nat
                                                        -> Nat
-    319. builtin.io2.MVar.isEmpty                      : MVar a
+    322. builtin.io2.MVar.isEmpty                      : MVar a
                                                        ->{IO} Boolean
-    320. builtin.Int.isEven                            : Int
+    323. builtin.Int.isEven                            : Int
                                                        -> Boolean
-    321. builtin.Nat.isEven                            : Nat
+    324. builtin.Nat.isEven                            : Nat
                                                        -> Boolean
-    322. builtin.Pattern.isMatch                       : Pattern
+    325. builtin.Pattern.isMatch                       : Pattern
                                                          a
                                                        -> a
                                                        -> Boolean
-    323. builtin.Code.isMissing                        : Term
+    326. builtin.Code.isMissing                        : Term
                                                        ->{IO} Boolean
-    324. builtin.Int.isOdd                             : Int
+    327. builtin.Int.isOdd                             : Int
                                                        -> Boolean
-    325. builtin.Nat.isOdd                             : Nat
+    328. builtin.Nat.isOdd                             : Nat
                                                        -> Boolean
-    326. builtin.metadata.isPropagated                 : IsPropagated
-    327. builtin.metadata.isTest                       : IsTest
-    328. builtin.Pattern.join                          : [Pattern
+    329. builtin.metadata.isPropagated                 : IsPropagated
+    330. builtin.metadata.isTest                       : IsTest
+    331. builtin.Pattern.join                          : [Pattern
                                                          a]
                                                        -> Pattern
                                                          a
-    329. builtin.Int.leadingZeros                      : Int
+    332. builtin.io2.IO.process.kill                   : ProcessHandle
+                                                       ->{IO} ()
+    333. builtin.Int.leadingZeros                      : Int
                                                        -> Nat
-    330. builtin.Nat.leadingZeros                      : Nat
+    334. builtin.Nat.leadingZeros                      : Nat
                                                        -> Nat
-    331. builtin.Text.patterns.letter                  : Pattern
+    335. builtin.Text.patterns.letter                  : Pattern
                                                          Text
-    332. builtin.Text.patterns.literal                 : Text
+    336. builtin.Text.patterns.literal                 : Text
                                                        -> Pattern
                                                          Text
-    333. builtin.Value.load                            : Value
+    337. builtin.Value.load                            : Value
                                                        ->{IO} Either
                                                          [Term]
                                                          a
-    334. builtin.Float.log                             : Float
+    338. builtin.Float.log                             : Float
                                                        -> Float
-    335. builtin.Float.logBase                         : Float
+    339. builtin.Float.logBase                         : Float
                                                        -> Float
                                                        -> Float
-    336. builtin.Code.lookup                           : Term
+    340. builtin.Code.lookup                           : Term
                                                        ->{IO} Optional
                                                          Code
-    337. builtin.Float.lt                              : Float
+    341. builtin.Float.lt                              : Float
                                                        -> Float
                                                        -> Boolean
-    338. builtin.Int.lt                                : Int
+    342. builtin.Int.lt                                : Int
                                                        -> Int
                                                        -> Boolean
-    339. builtin.Nat.lt                                : Nat
+    343. builtin.Nat.lt                                : Nat
                                                        -> Nat
                                                        -> Boolean
-    340. builtin.Text.lt                               : Text
+    344. builtin.Text.lt                               : Text
                                                        -> Text
                                                        -> Boolean
-    341. builtin.Float.lteq                            : Float
+    345. builtin.Float.lteq                            : Float
                                                        -> Float
                                                        -> Boolean
-    342. builtin.Int.lteq                              : Int
+    346. builtin.Int.lteq                              : Int
                                                        -> Int
                                                        -> Boolean
-    343. builtin.Nat.lteq                              : Nat
+    347. builtin.Nat.lteq                              : Nat
                                                        -> Nat
                                                        -> Boolean
-    344. builtin.Text.lteq                             : Text
+    348. builtin.Text.lteq                             : Text
                                                        -> Text
                                                        -> Boolean
-    345. builtin.Pattern.many                          : Pattern
+    349. builtin.Pattern.many                          : Pattern
                                                          a
                                                        -> Pattern
                                                          a
-    346. builtin.Float.max                             : Float
+    350. builtin.Float.max                             : Float
                                                        -> Float
                                                        -> Float
-    347. builtin.Float.min                             : Float
+    351. builtin.Float.min                             : Float
                                                        -> Float
                                                        -> Float
-    348. builtin.Int.mod                               : Int
+    352. builtin.Int.mod                               : Int
                                                        -> Int
                                                        -> Int
-    349. builtin.Nat.mod                               : Nat
+    353. builtin.Nat.mod                               : Nat
                                                        -> Nat
                                                        -> Nat
-    350. builtin.io2.Clock.internals.monotonic         : '{IO} Either
+    354. builtin.io2.Clock.internals.monotonic         : '{IO} Either
                                                          Failure
                                                          TimeSpec
-    351. builtin.Int.negate                            : Int
+    355. builtin.Int.negate                            : Int
                                                        -> Int
-    352. builtin.io2.MVar.new                          : a
+    356. builtin.io2.MVar.new                          : a
                                                        ->{IO} MVar
                                                          a
-    353. builtin.io2.Promise.new                       : '{IO} Promise
+    357. builtin.io2.Promise.new                       : '{IO} Promise
                                                          a
-    354. builtin.io2.TVar.new                          : a
+    358. builtin.io2.TVar.new                          : a
                                                        ->{STM} TVar
                                                          a
-    355. builtin.io2.MVar.newEmpty                     : '{IO} MVar
+    359. builtin.io2.MVar.newEmpty                     : '{IO} MVar
                                                          a
-    356. builtin.io2.TVar.newIO                        : a
+    360. builtin.io2.TVar.newIO                        : a
                                                        ->{IO} TVar
                                                          a
-    357. builtin.Boolean.not                           : Boolean
+    361. builtin.Boolean.not                           : Boolean
                                                        -> Boolean
-    358. builtin.Text.patterns.notCharIn               : [Char]
+    362. builtin.Text.patterns.notCharIn               : [Char]
                                                        -> Pattern
                                                          Text
-    359. builtin.Text.patterns.notCharRange            : Char
+    363. builtin.Text.patterns.notCharRange            : Char
                                                        -> Char
                                                        -> Pattern
                                                          Text
-    360. builtin.io2.Clock.internals.nsec              : TimeSpec
+    364. builtin.io2.Clock.internals.nsec              : TimeSpec
                                                        -> Nat
-    361. builtin.Int.or                                : Int
+    365. builtin.Int.or                                : Int
                                                        -> Int
                                                        -> Int
-    362. builtin.Nat.or                                : Nat
+    366. builtin.Nat.or                                : Nat
                                                        -> Nat
                                                        -> Nat
-    363. builtin.Pattern.or                            : Pattern
+    367. builtin.Pattern.or                            : Pattern
                                                          a
                                                        -> Pattern
                                                          a
                                                        -> Pattern
                                                          a
-    364. builtin.Int.popCount                          : Int
+    368. builtin.Int.popCount                          : Int
                                                        -> Nat
-    365. builtin.Nat.popCount                          : Nat
+    369. builtin.Nat.popCount                          : Nat
                                                        -> Nat
-    366. builtin.Float.pow                             : Float
+    370. builtin.Float.pow                             : Float
                                                        -> Float
                                                        -> Float
-    367. builtin.Int.pow                               : Int
+    371. builtin.Int.pow                               : Int
                                                        -> Nat
                                                        -> Int
-    368. builtin.Nat.pow                               : Nat
+    372. builtin.Nat.pow                               : Nat
                                                        -> Nat
                                                        -> Nat
-    369. builtin.io2.Clock.internals.processCPUTime    : '{IO} Either
+    373. builtin.io2.Clock.internals.processCPUTime    : '{IO} Either
                                                          Failure
                                                          TimeSpec
-    370. builtin.Text.patterns.punctuation             : Pattern
+    374. builtin.Text.patterns.punctuation             : Pattern
                                                          Text
-    371. builtin.ImmutableArray.read                   : ImmutableArray
+    375. builtin.ImmutableArray.read                   : ImmutableArray
                                                          a
                                                        -> Nat
                                                        ->{Exception} a
-    372. builtin.MutableArray.read                     : MutableArray
+    376. builtin.MutableArray.read                     : MutableArray
                                                          g a
                                                        -> Nat
                                                        ->{g,
                                                        Exception} a
-    373. builtin.io2.Promise.read                      : Promise
+    377. builtin.io2.Promise.read                      : Promise
                                                          a
                                                        ->{IO} a
-    374. builtin.Ref.read                              : Ref g a
+    378. builtin.Ref.read                              : Ref g a
                                                        ->{g} a
-    375. builtin.io2.TVar.read                         : TVar a
+    379. builtin.io2.TVar.read                         : TVar a
                                                        ->{STM} a
-    376. builtin.io2.Ref.Ticket.read                   : Ticket
+    380. builtin.io2.Ref.Ticket.read                   : Ticket
                                                          a
                                                        -> a
-    377. builtin.ImmutableByteArray.read16be           : ImmutableByteArray
+    381. builtin.ImmutableByteArray.read16be           : ImmutableByteArray
                                                        -> Nat
                                                        ->{Exception} Nat
-    378. builtin.MutableByteArray.read16be             : MutableByteArray
+    382. builtin.MutableByteArray.read16be             : MutableByteArray
                                                          g
                                                        -> Nat
                                                        ->{g,
                                                        Exception} Nat
-    379. builtin.ImmutableByteArray.read24be           : ImmutableByteArray
+    383. builtin.ImmutableByteArray.read24be           : ImmutableByteArray
                                                        -> Nat
                                                        ->{Exception} Nat
-    380. builtin.MutableByteArray.read24be             : MutableByteArray
+    384. builtin.MutableByteArray.read24be             : MutableByteArray
                                                          g
                                                        -> Nat
                                                        ->{g,
                                                        Exception} Nat
-    381. builtin.ImmutableByteArray.read32be           : ImmutableByteArray
+    385. builtin.ImmutableByteArray.read32be           : ImmutableByteArray
                                                        -> Nat
                                                        ->{Exception} Nat
-    382. builtin.MutableByteArray.read32be             : MutableByteArray
+    386. builtin.MutableByteArray.read32be             : MutableByteArray
                                                          g
                                                        -> Nat
                                                        ->{g,
                                                        Exception} Nat
-    383. builtin.ImmutableByteArray.read40be           : ImmutableByteArray
+    387. builtin.ImmutableByteArray.read40be           : ImmutableByteArray
                                                        -> Nat
                                                        ->{Exception} Nat
-    384. builtin.MutableByteArray.read40be             : MutableByteArray
+    388. builtin.MutableByteArray.read40be             : MutableByteArray
                                                          g
                                                        -> Nat
                                                        ->{g,
                                                        Exception} Nat
-    385. builtin.ImmutableByteArray.read64be           : ImmutableByteArray
+    389. builtin.ImmutableByteArray.read64be           : ImmutableByteArray
                                                        -> Nat
                                                        ->{Exception} Nat
-    386. builtin.MutableByteArray.read64be             : MutableByteArray
+    390. builtin.MutableByteArray.read64be             : MutableByteArray
                                                          g
                                                        -> Nat
                                                        ->{g,
                                                        Exception} Nat
-    387. builtin.ImmutableByteArray.read8              : ImmutableByteArray
+    391. builtin.ImmutableByteArray.read8              : ImmutableByteArray
                                                        -> Nat
                                                        ->{Exception} Nat
-    388. builtin.MutableByteArray.read8                : MutableByteArray
+    392. builtin.MutableByteArray.read8                : MutableByteArray
                                                          g
                                                        -> Nat
                                                        ->{g,
                                                        Exception} Nat
-    389. builtin.io2.Ref.readForCas                    : Ref
+    393. builtin.io2.Ref.readForCas                    : Ref
                                                          {IO} a
                                                        ->{IO} Ticket
                                                          a
-    390. builtin.io2.TVar.readIO                       : TVar a
+    394. builtin.io2.TVar.readIO                       : TVar a
                                                        ->{IO} a
-    391. builtin.io2.Clock.internals.realtime          : '{IO} Either
+    395. builtin.io2.Clock.internals.realtime          : '{IO} Either
                                                          Failure
                                                          TimeSpec
-    392. builtin.io2.IO.ref                            : a
+    396. builtin.io2.IO.ref                            : a
                                                        ->{IO} Ref
                                                          {IO} a
-    393. builtin.Scope.ref                             : a
+    397. builtin.Scope.ref                             : a
                                                        ->{Scope
                                                          s} Ref
                                                          {Scope
                                                            s}
                                                          a
-    394. builtin.Text.repeat                           : Nat
+    398. builtin.Text.repeat                           : Nat
                                                        -> Text
                                                        -> Text
-    395. builtin.Pattern.replicate                     : Nat
+    399. builtin.Pattern.replicate                     : Nat
                                                        -> Nat
                                                        -> Pattern
                                                          a
                                                        -> Pattern
                                                          a
-    396. builtin.io2.STM.retry                         : '{STM} a
-    397. builtin.Text.reverse                          : Text
+    400. builtin.io2.STM.retry                         : '{STM} a
+    401. builtin.Text.reverse                          : Text
                                                        -> Text
-    398. builtin.Float.round                           : Float
+    402. builtin.Float.round                           : Float
                                                        -> Int
-    399. builtin.Pattern.run                           : Pattern
+    403. builtin.Pattern.run                           : Pattern
                                                          a
                                                        -> a
                                                        -> Optional
                                                          ( [a],
                                                            a)
-    400. builtin.Scope.run                             : (∀ s.
+    404. builtin.Scope.run                             : (∀ s.
                                                          '{g,
                                                          Scope s} r)
                                                        ->{g} r
-    401. builtin.io2.Clock.internals.sec               : TimeSpec
+    405. builtin.io2.Clock.internals.sec               : TimeSpec
                                                        -> Int
-    402. builtin.Code.serialize                        : Code
+    406. builtin.Code.serialize                        : Code
                                                        -> Bytes
-    403. builtin.Value.serialize                       : Value
+    407. builtin.Value.serialize                       : Value
                                                        -> Bytes
-    404. builtin.io2.Tls.ClientConfig.certificates.set : [SignedCert]
+    408. builtin.io2.Tls.ClientConfig.certificates.set : [SignedCert]
                                                        -> ClientConfig
                                                        -> ClientConfig
-    405. builtin.io2.Tls.ServerConfig.certificates.set : [SignedCert]
+    409. builtin.io2.Tls.ServerConfig.certificates.set : [SignedCert]
                                                        -> ServerConfig
                                                        -> ServerConfig
-    406. builtin.io2.TLS.ClientConfig.ciphers.set      : [Cipher]
+    410. builtin.io2.TLS.ClientConfig.ciphers.set      : [Cipher]
                                                        -> ClientConfig
                                                        -> ClientConfig
-    407. builtin.io2.Tls.ServerConfig.ciphers.set      : [Cipher]
+    411. builtin.io2.Tls.ServerConfig.ciphers.set      : [Cipher]
                                                        -> ServerConfig
                                                        -> ServerConfig
-    408. builtin.io2.Tls.ClientConfig.versions.set     : [Version]
+    412. builtin.io2.Tls.ClientConfig.versions.set     : [Version]
                                                        -> ClientConfig
                                                        -> ClientConfig
-    409. builtin.io2.Tls.ServerConfig.versions.set     : [Version]
+    413. builtin.io2.Tls.ServerConfig.versions.set     : [Version]
                                                        -> ServerConfig
                                                        -> ServerConfig
-    410. builtin.Int.shiftLeft                         : Int
+    414. builtin.Int.shiftLeft                         : Int
                                                        -> Nat
                                                        -> Int
-    411. builtin.Nat.shiftLeft                         : Nat
+    415. builtin.Nat.shiftLeft                         : Nat
                                                        -> Nat
                                                        -> Nat
-    412. builtin.Int.shiftRight                        : Int
+    416. builtin.Int.shiftRight                        : Int
                                                        -> Nat
                                                        -> Int
-    413. builtin.Nat.shiftRight                        : Nat
+    417. builtin.Nat.shiftRight                        : Nat
                                                        -> Nat
                                                        -> Nat
-    414. builtin.Int.signum                            : Int
+    418. builtin.Int.signum                            : Int
                                                        -> Int
-    415. builtin.Float.sin                             : Float
+    419. builtin.Float.sin                             : Float
                                                        -> Float
-    416. builtin.Float.sinh                            : Float
+    420. builtin.Float.sinh                            : Float
                                                        -> Float
-    417. builtin.Bytes.size                            : Bytes
+    421. builtin.Bytes.size                            : Bytes
                                                        -> Nat
-    418. builtin.ImmutableArray.size                   : ImmutableArray
+    422. builtin.ImmutableArray.size                   : ImmutableArray
                                                          a
                                                        -> Nat
-    419. builtin.ImmutableByteArray.size               : ImmutableByteArray
+    423. builtin.ImmutableByteArray.size               : ImmutableByteArray
                                                        -> Nat
-    420. builtin.List.size                             : [a]
+    424. builtin.List.size                             : [a]
                                                        -> Nat
-    421. builtin.MutableArray.size                     : MutableArray
+    425. builtin.MutableArray.size                     : MutableArray
                                                          g a
                                                        -> Nat
-    422. builtin.MutableByteArray.size                 : MutableByteArray
+    426. builtin.MutableByteArray.size                 : MutableByteArray
                                                          g
                                                        -> Nat
-    423. builtin.Text.size                             : Text
+    427. builtin.Text.size                             : Text
                                                        -> Nat
-    424. builtin.Text.patterns.space                   : Pattern
+    428. builtin.Text.patterns.space                   : Pattern
                                                          Text
-    425. builtin.Float.sqrt                            : Float
+    429. builtin.Float.sqrt                            : Float
                                                        -> Float
-    426. builtin.io2.IO.stdHandle                      : StdHandle
+    430. builtin.io2.IO.process.start                  : Text
+                                                       -> [Text]
+                                                       ->{IO} ( Handle,
+                                                         Handle,
+                                                         Handle,
+                                                         ProcessHandle)
+    431. builtin.io2.IO.stdHandle                      : StdHandle
                                                        -> Handle
-    427. builtin.Nat.sub                               : Nat
+    432. builtin.Nat.sub                               : Nat
                                                        -> Nat
                                                        -> Int
-    428. builtin.io2.TVar.swap                         : TVar a
+    433. builtin.io2.TVar.swap                         : TVar a
                                                        -> a
                                                        ->{STM} a
-    429. builtin.io2.IO.systemTimeMicroseconds         : '{IO} Int
-    430. builtin.Bytes.take                            : Nat
+    434. builtin.io2.IO.systemTimeMicroseconds         : '{IO} Int
+    435. builtin.Bytes.take                            : Nat
                                                        -> Bytes
                                                        -> Bytes
-    431. builtin.List.take                             : Nat
+    436. builtin.List.take                             : Nat
                                                        -> [a]
                                                        -> [a]
-    432. builtin.Text.take                             : Nat
+    437. builtin.Text.take                             : Nat
                                                        -> Text
                                                        -> Text
-    433. builtin.Float.tan                             : Float
+    438. builtin.Float.tan                             : Float
                                                        -> Float
-    434. builtin.Float.tanh                            : Float
+    439. builtin.Float.tanh                            : Float
                                                        -> Float
-    435. builtin.io2.Clock.internals.threadCPUTime     : '{IO} Either
+    440. builtin.io2.Clock.internals.threadCPUTime     : '{IO} Either
                                                          Failure
                                                          TimeSpec
-    436. builtin.Bytes.toBase16                        : Bytes
+    441. builtin.Bytes.toBase16                        : Bytes
                                                        -> Bytes
-    437. builtin.Bytes.toBase32                        : Bytes
+    442. builtin.Bytes.toBase32                        : Bytes
                                                        -> Bytes
-    438. builtin.Bytes.toBase64                        : Bytes
+    443. builtin.Bytes.toBase64                        : Bytes
                                                        -> Bytes
-    439. builtin.Bytes.toBase64UrlUnpadded             : Bytes
+    444. builtin.Bytes.toBase64UrlUnpadded             : Bytes
                                                        -> Bytes
-    440. builtin.Text.toCharList                       : Text
+    445. builtin.Text.toCharList                       : Text
                                                        -> [Char]
-    441. builtin.Int.toFloat                           : Int
+    446. builtin.Int.toFloat                           : Int
                                                        -> Float
-    442. builtin.Nat.toFloat                           : Nat
+    447. builtin.Nat.toFloat                           : Nat
                                                        -> Float
-    443. builtin.Nat.toInt                             : Nat
+    448. builtin.Nat.toInt                             : Nat
                                                        -> Int
-    444. builtin.Bytes.toList                          : Bytes
+    449. builtin.Bytes.toList                          : Bytes
                                                        -> [Nat]
-    445. builtin.Text.toLowercase                      : Text
+    450. builtin.Text.toLowercase                      : Text
                                                        -> Text
-    446. builtin.Char.toNat                            : Char
+    451. builtin.Char.toNat                            : Char
                                                        -> Nat
-    447. builtin.Float.toRepresentation                : Float
+    452. builtin.Float.toRepresentation                : Float
                                                        -> Nat
-    448. builtin.Int.toRepresentation                  : Int
+    453. builtin.Int.toRepresentation                  : Int
                                                        -> Nat
-    449. builtin.Char.toText                           : Char
+    454. builtin.Char.toText                           : Char
                                                        -> Text
-    450. builtin.Debug.toText                          : a
+    455. builtin.Debug.toText                          : a
                                                        -> Optional
                                                          (Either
                                                            Text
                                                            Text)
-    451. builtin.Float.toText                          : Float
+    456. builtin.Float.toText                          : Float
                                                        -> Text
-    452. builtin.Handle.toText                         : Handle
+    457. builtin.Handle.toText                         : Handle
                                                        -> Text
-    453. builtin.Int.toText                            : Int
+    458. builtin.Int.toText                            : Int
                                                        -> Text
-    454. builtin.Nat.toText                            : Nat
+    459. builtin.Nat.toText                            : Nat
                                                        -> Text
-    455. builtin.Socket.toText                         : Socket
+    460. builtin.Socket.toText                         : Socket
                                                        -> Text
-    456. builtin.Link.Term.toText                      : Term
+    461. builtin.Link.Term.toText                      : Term
                                                        -> Text
-    457. builtin.ThreadId.toText                       : ThreadId
+    462. builtin.ThreadId.toText                       : ThreadId
                                                        -> Text
-    458. builtin.Text.toUppercase                      : Text
+    463. builtin.Text.toUppercase                      : Text
                                                        -> Text
-    459. builtin.Text.toUtf8                           : Text
+    464. builtin.Text.toUtf8                           : Text
                                                        -> Bytes
-    460. builtin.todo                                  : a -> b
-    461. builtin.Debug.trace                           : Text
+    465. builtin.todo                                  : a -> b
+    466. builtin.Debug.trace                           : Text
                                                        -> a
                                                        -> ()
-    462. builtin.Int.trailingZeros                     : Int
+    467. builtin.Int.trailingZeros                     : Int
                                                        -> Nat
-    463. builtin.Nat.trailingZeros                     : Nat
+    468. builtin.Nat.trailingZeros                     : Nat
                                                        -> Nat
-    464. builtin.Float.truncate                        : Float
+    469. builtin.Float.truncate                        : Float
                                                        -> Int
-    465. builtin.Int.truncate0                         : Int
+    470. builtin.Int.truncate0                         : Int
                                                        -> Nat
-    466. builtin.io2.IO.tryEval                        : '{IO} a
+    471. builtin.io2.IO.tryEval                        : '{IO} a
                                                        ->{IO,
                                                        Exception} a
-    467. builtin.io2.Promise.tryRead                   : Promise
+    472. builtin.io2.Promise.tryRead                   : Promise
                                                          a
                                                        ->{IO} Optional
                                                          a
-    468. builtin.io2.MVar.tryTake                      : MVar a
+    473. builtin.io2.MVar.tryTake                      : MVar a
                                                        ->{IO} Optional
                                                          a
-    469. builtin.Text.uncons                           : Text
+    474. builtin.Text.uncons                           : Text
                                                        -> Optional
                                                          ( Char,
                                                            Text)
-    470. builtin.Any.unsafeExtract                     : Any
+    475. builtin.Any.unsafeExtract                     : Any
                                                        -> a
-    471. builtin.Text.unsnoc                           : Text
+    476. builtin.Text.unsnoc                           : Text
                                                        -> Optional
                                                          ( Text,
                                                            Char)
-    472. builtin.Code.validate                         : [( Term,
+    477. builtin.Code.validate                         : [( Term,
                                                          Code)]
                                                        ->{IO} Optional
                                                          Failure
-    473. builtin.io2.validateSandboxed                 : [Term]
+    478. builtin.io2.validateSandboxed                 : [Term]
                                                        -> a
                                                        -> Boolean
-    474. builtin.Value.value                           : a
+    479. builtin.Value.value                           : a
                                                        -> Value
-    475. builtin.Debug.watch                           : Text
+    480. builtin.io2.IO.process.wait                   : ProcessHandle
+                                                       ->{IO} Nat
+    481. builtin.Debug.watch                           : Text
                                                        -> a
                                                        -> a
-    476. builtin.MutableArray.write                    : MutableArray
+    482. builtin.MutableArray.write                    : MutableArray
                                                          g a
                                                        -> Nat
                                                        -> a
                                                        ->{g,
                                                        Exception} ()
-    477. builtin.io2.Promise.write                     : Promise
+    483. builtin.io2.Promise.write                     : Promise
                                                          a
                                                        -> a
                                                        ->{IO} Boolean
-    478. builtin.Ref.write                             : Ref g a
+    484. builtin.Ref.write                             : Ref g a
                                                        -> a
                                                        ->{g} ()
-    479. builtin.io2.TVar.write                        : TVar a
+    485. builtin.io2.TVar.write                        : TVar a
                                                        -> a
                                                        ->{STM} ()
-    480. builtin.MutableByteArray.write16be            : MutableByteArray
+    486. builtin.MutableByteArray.write16be            : MutableByteArray
                                                          g
                                                        -> Nat
                                                        -> Nat
                                                        ->{g,
                                                        Exception} ()
-    481. builtin.MutableByteArray.write32be            : MutableByteArray
+    487. builtin.MutableByteArray.write32be            : MutableByteArray
                                                          g
                                                        -> Nat
                                                        -> Nat
                                                        ->{g,
                                                        Exception} ()
-    482. builtin.MutableByteArray.write64be            : MutableByteArray
+    488. builtin.MutableByteArray.write64be            : MutableByteArray
                                                          g
                                                        -> Nat
                                                        -> Nat
                                                        ->{g,
                                                        Exception} ()
-    483. builtin.MutableByteArray.write8               : MutableByteArray
+    489. builtin.MutableByteArray.write8               : MutableByteArray
                                                          g
                                                        -> Nat
                                                        -> Nat
                                                        ->{g,
                                                        Exception} ()
-    484. builtin.Int.xor                               : Int
+    490. builtin.Int.xor                               : Int
                                                        -> Int
                                                        -> Int
-    485. builtin.Nat.xor                               : Nat
+    491. builtin.Nat.xor                               : Nat
                                                        -> Nat
                                                        -> Nat
   

--- a/unison-src/transcripts/reflog.output.md
+++ b/unison-src/transcripts/reflog.output.md
@@ -59,17 +59,17 @@ y = 2
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #9014t8bemk .old`   to make an old namespace
+    `fork #bu6c7lmbfc .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #9014t8bemk`  to reset the root namespace and
+    `reset-root #bu6c7lmbfc`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
        When   Root Hash     Action
-  1.   now    #q24i9rm0u0   add
-  2.   now    #9014t8bemk   add
-  3.   now    #2p31h4lsei   builtins.merge
+  1.   now    #cl7pneoh0i   add
+  2.   now    #bu6c7lmbfc   add
+  3.   now    #s0g21i3u0g   builtins.merge
   4.          #sg60bvjo91   history starts here
   
   Tip: Use `diff.namespace 1 7` to compare namespaces between

--- a/unison-src/transcripts/squash.output.md
+++ b/unison-src/transcripts/squash.output.md
@@ -13,7 +13,7 @@ Let's look at some examples. We'll start with a namespace with just the builtins
   
   
   
-  □ 1. #5r75rvflum (start of history)
+  □ 1. #d8s9u1138r (start of history)
 
 .> fork builtin builtin2
 
@@ -42,21 +42,21 @@ Now suppose we `fork` a copy of builtin, then rename `Nat.+` to `frobnicate`, th
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #ih7oa9qmee
+  ⊙ 1. #lb60fofgfp
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ 2. #2nsvr26oeu
+  ⊙ 2. #vn8dtrgv6r
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ 3. #5r75rvflum (start of history)
+  □ 3. #d8s9u1138r (start of history)
 
 ```
 If we merge that back into `builtin`, we get that same chain of history:
@@ -71,21 +71,21 @@ If we merge that back into `builtin`, we get that same chain of history:
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #ih7oa9qmee
+  ⊙ 1. #lb60fofgfp
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ 2. #2nsvr26oeu
+  ⊙ 2. #vn8dtrgv6r
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ 3. #5r75rvflum (start of history)
+  □ 3. #d8s9u1138r (start of history)
 
 ```
 Let's try again, but using a `merge.squash` (or just `squash`) instead. The history will be unchanged:
@@ -106,7 +106,7 @@ Let's try again, but using a `merge.squash` (or just `squash`) instead. The hist
   
   
   
-  □ 1. #5r75rvflum (start of history)
+  □ 1. #d8s9u1138r (start of history)
 
 ```
 The churn that happened in `mybuiltin` namespace ended up back in the same spot, so the squash merge of that namespace with our original namespace had no effect.
@@ -485,13 +485,13 @@ This checks to see that squashing correctly preserves deletions:
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #65gt0djmn2
+  ⊙ 1. #8i72q7ac2u
   
     - Deletes:
     
       Nat.* Nat.+
   
-  □ 2. #5r75rvflum (start of history)
+  □ 2. #d8s9u1138r (start of history)
 
 ```
 Notice that `Nat.+` and `Nat.*` are deleted by the squash, and we see them deleted in one atomic step in the history.


### PR DESCRIPTION
This PR includes some work on builtin functions related to some open bugs.

1. It makes `Nat.fromText` and `Int.fromText` return `None` when the textual number would over or underflow. The prior behavior was just to wrap around like arithmetic. This fixes #3674
2. New builtins for calling system processes are added
  - `IO.process.call` does a synchronous call to an external process
  - `IO.process.start` does spawns an asynchronous process, yielding handles for interacting with it
  - `IO.process.kill` `IO.process.wait` and `IO.process.exitCode` allow some additional operations with regard to the process (besides just sending/receiving data via the normal handles)
  - This addresses #2931 

The latter API is a little more complicated than what Chez provides (which is _only_ shell string based system calls, unfortunately), so we might have to use the FFI when we get to compiling to it. Haskell and Racket both support this sort of API.

I have tests for the `fromText` changes, but I'm not sure I can write a test for the process stuff that will actually work across different platforms. I tested it some locally, though.