### PR TITLE
[chez] Add a failing test for Bytes.toHexString

### DIFF
--- a/chez-libs/tests/basic.md
+++ b/chez-libs/tests/basic.md
@@ -10,12 +10,12 @@ printHello = '(printLine "Hello")
 
 schemeToFile dest link = 
 	fop = open (FilePath dest) Write
-	text = generateScheme false link
+	text = generateScheme true link
 	putText fop text
 	close fop
 ```
 
-```ucm
+```ucm:hide
 .> add
 ```
 
@@ -31,3 +31,26 @@ Now run the following:
 ```bash
 $ scheme --libdirs ../:~/.cache/unisonlanguage/scheme-libs/ --script test-1.ss
 ```
+
+```unison
+printBytes = printLine (toHexString (base.Bytes.fromList [100, 200, 16]))
+```
+
+```ucm:hide
+.> add
+```
+
+```unison
+test2 = '(schemeToFile "test-2.ss" (termLink test2))
+```
+
+```ucm
+.> run test2
+```
+
+Now run the following:
+```bash
+$ scheme --libdirs ../:~/.cache/unisonlanguage/scheme-libs/ --script test-2.ss
+```
+
+

--- a/chez-libs/tests/basic.md
+++ b/chez-libs/tests/basic.md
@@ -1,6 +1,7 @@
 
 ```ucm:hide
 .> builtins.merge
+.> pull unison.public.base.latest.Bytes
 .> pull unison.public.base.latest.IO
 .> pull dolio.public.internal.trunk.compiler
 ```
@@ -8,15 +9,24 @@
 ```unison
 printHello = '(printLine "Hello")
 
+generateBaseFiles _ =
+	h = open (FilePath "bootSpec.ss") Write
+	putText h (generateBaseFile bootSpec)
+	close h
+	h2 = open (FilePath "builtinSpec.ss") Write
+	putText h2 (generateBaseFile builtinSpec)
+	close h2
+
 schemeToFile dest link = 
-	fop = open (FilePath dest) Write
+	h = open (FilePath dest) Write
 	text = generateScheme true link
-	putText fop text
-	close fop
+	putText h text
+	close h
 ```
 
 ```ucm:hide
 .> add
+.> run generateBaseFiles
 ```
 
 ```unison
@@ -33,7 +43,7 @@ $ scheme --libdirs ../:~/.cache/unisonlanguage/scheme-libs/ --script test-1.ss
 ```
 
 ```unison
-printBytes = printLine (toHexString (base.Bytes.fromList [100, 200, 16]))
+printBytes _ = printLine (toHex (Bytes.fromList [100, 200, 16]))
 ```
 
 ```ucm:hide
@@ -41,7 +51,7 @@ printBytes = printLine (toHexString (base.Bytes.fromList [100, 200, 16]))
 ```
 
 ```unison
-test2 = '(schemeToFile "test-2.ss" (termLink test2))
+test2 = '(schemeToFile "test-2.ss" (termLink printBytes))
 ```
 
 ```ucm

--- a/chez-libs/tests/basic.md
+++ b/chez-libs/tests/basic.md
@@ -10,12 +10,9 @@
 printHello = '(printLine "Hello")
 
 generateBaseFiles _ =
-	h = open (FilePath "bootSpec.ss") Write
-	putText h (generateBaseFile bootSpec)
+	h = open (FilePath "unison/builtin-generated.ss") Write
+	putText h (generateBaseFile builtinSpec)
 	close h
-	h2 = open (FilePath "builtinSpec.ss") Write
-	putText h2 (generateBaseFile builtinSpec)
-	close h2
 
 schemeToFile dest link = 
 	h = open (FilePath dest) Write
@@ -39,7 +36,7 @@ test1 = '(schemeToFile "test-1.ss" (termLink printHello))
 
 Now run the following:
 ```bash
-$ scheme --libdirs ../:~/.cache/unisonlanguage/scheme-libs/ --script test-1.ss
+$ scheme --libdirs ../:./ --script test-1.ss
 ```
 
 ```unison
@@ -60,7 +57,7 @@ test2 = '(schemeToFile "test-2.ss" (termLink printBytes))
 
 Now run the following:
 ```bash
-$ scheme --libdirs ../:~/.cache/unisonlanguage/scheme-libs/ --script test-2.ss
+$ scheme --libdirs ../:./ --script test-2.ss
 ```
 
 

--- a/chez-libs/tests/basic.output.md
+++ b/chez-libs/tests/basic.output.md
@@ -3,12 +3,9 @@
 printHello = '(printLine "Hello")
 
 generateBaseFiles _ =
-	h = open (FilePath "bootSpec.ss") Write
-	putText h (generateBaseFile bootSpec)
+	h = open (FilePath "unison/builtin-generated.ss") Write
+	putText h (generateBaseFile builtinSpec)
 	close h
-	h2 = open (FilePath "builtinSpec.ss") Write
-	putText h2 (generateBaseFile builtinSpec)
-	close h2
 
 schemeToFile dest link = 
 	h = open (FilePath dest) Write
@@ -54,7 +51,7 @@ test1 = '(schemeToFile "test-1.ss" (termLink printHello))
 Now run the following:
 ```bash
 
-$ scheme --libdirs ../:~/.cache/unisonlanguage/scheme-libs/ --script test-1.ss
+$ scheme --libdirs ../:./ --script test-1.ss
 
 ```
 
@@ -97,7 +94,7 @@ test2 = '(schemeToFile "test-2.ss" (termLink printBytes))
 Now run the following:
 ```bash
 
-$ scheme --libdirs ../:~/.cache/unisonlanguage/scheme-libs/ --script test-2.ss
+$ scheme --libdirs ../:./ --script test-2.ss
 
 ```
 

--- a/chez-libs/tests/basic.output.md
+++ b/chez-libs/tests/basic.output.md
@@ -4,7 +4,7 @@ printHello = '(printLine "Hello")
 
 schemeToFile dest link = 
 	fop = open (FilePath dest) Write
-	text = generateScheme false link
+	text = generateScheme true link
 	putText fop text
 	close fop
 ```
@@ -51,3 +51,10 @@ test1 = '(schemeToFile "test-1.ss" (termLink printHello))
   ()
 
 ```
+Now run the following:
+```bash
+
+$ scheme --libdirs ../:~/.cache/unisonlanguage/scheme-libs/ --script test-1.ss
+
+```
+

--- a/chez-libs/tests/basic.output.md
+++ b/chez-libs/tests/basic.output.md
@@ -2,11 +2,19 @@
 ```unison
 printHello = '(printLine "Hello")
 
+generateBaseFiles _ =
+	h = open (FilePath "bootSpec.ss") Write
+	putText h (generateBaseFile bootSpec)
+	close h
+	h2 = open (FilePath "builtinSpec.ss") Write
+	putText h2 (generateBaseFile builtinSpec)
+	close h2
+
 schemeToFile dest link = 
-	fop = open (FilePath dest) Write
+	h = open (FilePath dest) Write
 	text = generateScheme true link
-	putText fop text
-	close fop
+	putText h text
+	close h
 ```
 
 ```ucm
@@ -17,17 +25,9 @@ schemeToFile dest link =
   
     ⍟ These new definitions are ok to `add`:
     
-      printHello   : '{IO, Exception} ()
-      schemeToFile : Text -> Term ->{IO, Exception} ()
-
-```
-```ucm
-.> add
-
-  ⍟ I've added these definitions:
-  
-    printHello   : '{IO, Exception} ()
-    schemeToFile : Text -> Term ->{IO, Exception} ()
+      generateBaseFiles : ∀ _. _ ->{IO, Exception} ()
+      printHello        : '{IO, Exception} ()
+      schemeToFile      : Text -> Term ->{IO, Exception} ()
 
 ```
 ```unison
@@ -55,6 +55,49 @@ Now run the following:
 ```bash
 
 $ scheme --libdirs ../:~/.cache/unisonlanguage/scheme-libs/ --script test-1.ss
+
+```
+
+```unison
+printBytes _ = printLine (toHex (Bytes.fromList [100, 200, 16]))
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      printBytes : ∀ _. _ ->{IO, Exception} ()
+
+```
+```unison
+test2 = '(schemeToFile "test-2.ss" (termLink printBytes))
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      test2 : '{IO, Exception} ()
+
+```
+```ucm
+.> run test2
+
+  ()
+
+```
+Now run the following:
+```bash
+
+$ scheme --libdirs ../:~/.cache/unisonlanguage/scheme-libs/ --script test-2.ss
 
 ```
 

--- a/unison-share-api/src/Unison/Server/CodebaseServer.hs
+++ b/unison-share-api/src/Unison/Server/CodebaseServer.hs
@@ -312,7 +312,7 @@ serveIndex path = do
                 "No codebase UI configured."
                   <> " Set the "
                   <> ucmUIVar
-                  <> " environment variable to the directory where the UI is installed."
+                  <> " environment variable to the directory where the UI is installed, or run ./dev-ui-install.sh."
           }
 
 serveUI :: FilePath -> Server WebUI


### PR DESCRIPTION
## Summary:
This demonstrates one of the errors I'm seeing when I try to test out my crypto hashing stuff.
```
Exception: multiple definitions for builtin-Bytes.fromList in body (top-level-program (import (chezscheme) (unison core) (unison cont) (unison boot) (unison primops) ...) (define ref-4n0fgs00 (lambda (...) (...))) (define ref-b589mbg4 (lambda (...) (...))) (define-unison (builtin-Any.Any x0) (list 0 x0)) (define-unison (builtin-Boolean.not x0) (record-case x0 (...) (...))) ...) at line 1, char 1 of test-2.ss
```

`builtin-generated.ss` also exports a Bytes.fromList, which conflicts.


Looks like the fix for this is to remove `Bytes.fromList` from `public.internal.trunk.compiler.scheme.builtinLinks`?