### PR TITLE
Don't parse guards on destructuring binds

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/TermParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermParser.hs
@@ -984,13 +984,13 @@ destructuringBind = do
   --   Some 42
   --   vs
   --   Some 42 = List.head elems
-  (p, boundVars, guard) <- P.try $ do
+  (p, boundVars) <- P.try $ do
     (p, boundVars) <- parsePattern
     let boundVars' = snd <$> boundVars
-    guard <- optional $ reserved "|" *> infixAppOrBooleanOp
     P.lookAhead (openBlockWith "=")
-    pure (p, boundVars', guard)
+    pure (p, boundVars')
   scrute <- block "=" -- Dwight K. Scrute ("The People's Scrutinee")
+  let guard = Nothing
   let absChain vs t = foldr (\v t -> ABT.abs' (ann t) v t) t vs
       thecase t = Term.MatchCase p (fmap (absChain boundVars) guard) $ absChain boundVars t
   pure $

--- a/unison-src/transcripts/destructuring-binds.md
+++ b/unison-src/transcripts/destructuring-binds.md
@@ -33,14 +33,6 @@ ex2 tup = match tup with
   (a, b, (c,d)) -> c + d
 ```
 
-Syntactically, the left-hand side of the bind can be any pattern and can even include guards, for instance, see below. Because a destructuring bind desugars to a regular pattern match, pattern match coverage will eventually cause this to not typecheck:
-
-```unison:hide
-ex3 =
-  Some x | x > 10 = Some 19
-  x + 1
-```
-
 ## Corner cases
 
 Destructuring binds can't be recursive: the left-hand side bound variables aren't available on the right hand side. For instance, this doesn't typecheck:

--- a/unison-src/transcripts/destructuring-binds.output.md
+++ b/unison-src/transcripts/destructuring-binds.output.md
@@ -71,14 +71,6 @@ ex2 tup = match tup with
         (also named ex1)
 
 ```
-Syntactically, the left-hand side of the bind can be any pattern and can even include guards, for instance, see below. Because a destructuring bind desugars to a regular pattern match, pattern match coverage will eventually cause this to not typecheck:
-
-```unison
-ex3 =
-  Some x | x > 10 = Some 19
-  x + 1
-```
-
 ## Corner cases
 
 Destructuring binds can't be recursive: the left-hand side bound variables aren't available on the right hand side. For instance, this doesn't typecheck:


### PR DESCRIPTION
## Overview

fixes #3769 

I'm not sure why guards were added  here in the fist place; unless it was meant to be some sort of assert shorthand?
Since it'll eventually just always throw a pattern match exhaustiveness error it doesn't seem worthwhile to keep it 🤷🏼‍♂️ ; doesn't seem like there are any valid use-cases for this.

## Implementation notes

Remove the guard parser from destructuring binds, always return a `Nothing` guard.

## Test coverage

Transcripts will test destructuring bind parsing, doesn't seem worth adding a regression test for something like this 🤷🏼‍♂️ 
