### PR TITLE
Allow specifying the location to save the codebase from running a transcript

### DIFF
--- a/unison-cli/unison/ArgParse.hs
+++ b/unison-cli/unison/ArgParse.hs
@@ -468,20 +468,26 @@ fileArgument varName =
 transcriptParser :: Parser Command
 transcriptParser = do
   -- ApplicativeDo
-  shouldSaveCodebase <- saveCodebaseToFlag
-  -- shouldSaveCodebase <- saveCodebaseFlag
+  shouldSaveCodebaseTo <- saveCodebaseToFlag
+  shouldSaveCodebase <- saveCodebaseFlag
   mrtsStatsFp <- rtsStatsOption
   files <- liftA2 (NE.:|) (fileArgument "FILE") (many (fileArgument "FILES..."))
-  pure (Transcript DontFork shouldSaveCodebase mrtsStatsFp files)
+  pure (let saveCodebase = case shouldSaveCodebaseTo of
+                              DontSaveCodebase -> shouldSaveCodebase
+                              _ -> shouldSaveCodebaseTo
+        in Transcript DontFork saveCodebase mrtsStatsFp files)
 
 transcriptForkParser :: Parser Command
 transcriptForkParser = do
   -- ApplicativeDo
-  -- shouldSaveCodebase <- saveCodebaseFlag
-  shouldSaveCodebase <- saveCodebaseToFlag
+  shouldSaveCodebaseTo <- saveCodebaseToFlag
+  shouldSaveCodebase <- saveCodebaseFlag
   mrtsStatsFp <- rtsStatsOption
   files <- liftA2 (NE.:|) (fileArgument "FILE") (many (fileArgument "FILES..."))
-  pure (Transcript UseFork shouldSaveCodebase mrtsStatsFp files)
+  pure (let saveCodebase = case shouldSaveCodebaseTo of
+                              DontSaveCodebase -> shouldSaveCodebase
+                              _ -> shouldSaveCodebaseTo
+        in Transcript UseFork saveCodebase mrtsStatsFp files)
 
 unisonHelp :: String -> String -> P.Doc
 unisonHelp (P.text -> executable) (P.text -> version) =

--- a/unison-cli/unison/ArgParse.hs
+++ b/unison-cli/unison/ArgParse.hs
@@ -86,7 +86,7 @@ data ShouldDownloadBase
   deriving (Show, Eq)
 
 data ShouldSaveCodebase
-  = SaveCodebase
+  = SaveCodebase (Maybe FilePath)
   | DontSaveCodebase
   deriving (Show, Eq)
 
@@ -392,9 +392,20 @@ rtsStatsOption =
    in optional (option OptParse.str meta)
 
 saveCodebaseFlag :: Parser ShouldSaveCodebase
-saveCodebaseFlag = flag DontSaveCodebase SaveCodebase (long "save-codebase" <> help saveHelp)
+saveCodebaseFlag = flag DontSaveCodebase (SaveCodebase Nothing) (long "save-codebase" <> help saveHelp)
   where
     saveHelp = "if set the resulting codebase will be saved to a new directory, otherwise it will be deleted"
+
+saveCodebaseToFlag :: Parser ShouldSaveCodebase
+saveCodebaseToFlag = do
+  path <-
+    optional . strOption $
+      long "save-codebase-to"
+        <> short 'S'
+        <> help "Where the codebase should be created. Implies --save-codebase"
+  pure (case path of
+    Just _ -> SaveCodebase path
+    _ -> DontSaveCodebase)
 
 downloadBaseFlag :: Parser ShouldDownloadBase
 downloadBaseFlag =
@@ -457,7 +468,8 @@ fileArgument varName =
 transcriptParser :: Parser Command
 transcriptParser = do
   -- ApplicativeDo
-  shouldSaveCodebase <- saveCodebaseFlag
+  shouldSaveCodebase <- saveCodebaseToFlag
+  -- shouldSaveCodebase <- saveCodebaseFlag
   mrtsStatsFp <- rtsStatsOption
   files <- liftA2 (NE.:|) (fileArgument "FILE") (many (fileArgument "FILES..."))
   pure (Transcript DontFork shouldSaveCodebase mrtsStatsFp files)
@@ -465,7 +477,8 @@ transcriptParser = do
 transcriptForkParser :: Parser Command
 transcriptForkParser = do
   -- ApplicativeDo
-  shouldSaveCodebase <- saveCodebaseFlag
+  -- shouldSaveCodebase <- saveCodebaseFlag
+  shouldSaveCodebase <- saveCodebaseToFlag
   mrtsStatsFp <- rtsStatsOption
   files <- liftA2 (NE.:|) (fileArgument "FILE") (many (fileArgument "FILES..."))
   pure (Transcript UseFork shouldSaveCodebase mrtsStatsFp files)

--- a/unison-cli/unison/Main.hs
+++ b/unison-cli/unison/Main.hs
@@ -334,25 +334,35 @@ initHTTPClient = do
   HTTP.setGlobalManager manager
 
 prepareTranscriptDir :: ShouldForkCodebase -> Maybe CodebasePathOption -> IO FilePath
-prepareTranscriptDir shouldFork mCodePathOption = do
-  tmp <- Temp.getCanonicalTemporaryDirectory >>= (`Temp.createTempDirectory` "transcript")
-  let cbInit = SC.init
-  case shouldFork of
-    UseFork -> do
-      -- A forked codebase does not need to Create a codebase, because it already exists
-      getCodebaseOrExit mCodePathOption SC.MigrateAutomatically $ const (pure ())
-      path <- Codebase.getCodebaseDir (fmap codebasePathOptionToPath mCodePathOption)
+prepareTranscriptDir shouldFork mCodePathOption = case (shouldFork, mCodePathOption) of
+    (DontFork, Just (CreateCodebaseWhenMissing path)) -> do
       PT.putPrettyLn $
         P.lines
-          [ P.wrap "Transcript will be run on a copy of the codebase at: ",
+          [ P.wrap "Transcript will be run on a new codebase at: ",
             "",
             P.indentN 2 (P.string path)
           ]
-      Path.copyDir (CodebaseInit.codebasePath cbInit path) (CodebaseInit.codebasePath cbInit tmp)
-    DontFork -> do
-      PT.putPrettyLn . P.wrap $ "Transcript will be run on a new, empty codebase."
-      CodebaseInit.withNewUcmCodebaseOrExit cbInit "main.transcript" tmp SC.DoLock (const $ pure ())
-  pure tmp
+      CodebaseInit.withNewUcmCodebaseOrExit SC.init "main.transcript" path SC.DoLock (const $ pure ())
+      pure path
+    _ -> do
+      tmp <- Temp.getCanonicalTemporaryDirectory >>= (`Temp.createTempDirectory` "transcript")
+      let cbInit = SC.init
+      case shouldFork of
+        UseFork -> do
+          -- A forked codebase does not need to Create a codebase, because it already exists
+          getCodebaseOrExit mCodePathOption SC.MigrateAutomatically $ const (pure ())
+          path <- Codebase.getCodebaseDir (fmap codebasePathOptionToPath mCodePathOption)
+          PT.putPrettyLn $
+            P.lines
+              [ P.wrap "Transcript will be run on a copy of the codebase at: ",
+                "",
+                P.indentN 2 (P.string path)
+              ]
+          Path.copyDir (CodebaseInit.codebasePath cbInit path) (CodebaseInit.codebasePath cbInit tmp)
+        DontFork -> do
+          PT.putPrettyLn . P.wrap $ "Transcript will be run on a new, empty codebase."
+          CodebaseInit.withNewUcmCodebaseOrExit cbInit "main.transcript" tmp SC.DoLock (const $ pure ())
+      pure tmp
 
 runTranscripts' ::
   String ->


### PR DESCRIPTION
## Summary:
Note that if you want the codebase to be retained, you also have to specify `--save-codebase` ... should `--save-codebase` be implied if you specify `--codebase-create`?

## Test plan:
```
$ ucm transcript -C my.base some.md --save-codebase
```
See that it creates the codebase `my.base`! If that directory already exists, it exits with an error.