### PR TITLE
Upgrade to stack 2.9.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,7 +101,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           mkdir stack && cd stack
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.7.5-linux-x86_64.tar.gz | tar -xz
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.9.1/stack-2.9.1-linux-x86_64.tar.gz | tar -xz
           echo "$PWD/stack-"* >> $GITHUB_PATH
 
       - name: install stack (macOS)
@@ -109,7 +109,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           mkdir stack && cd stack
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.7.5-osx-x86_64.tar.gz | tar -xz
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.9.1/stack-2.9.1-osx-x86_64.tar.gz | tar -xz
           echo "$PWD/stack-"* >> $GITHUB_PATH
 
       - name: install stack (windows)
@@ -117,7 +117,7 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           mkdir stack && cd stack
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.7.5-windows-x86_64.tar.gz | tar -xz
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.9.1/stack-2.9.1-windows-x86_64.tar.gz | tar -xz
           echo "$PWD/stack-"* >> $GITHUB_PATH
 
       # One of the transcripts fails if the user's git name hasn't been set.

--- a/.github/workflows/haddocks.yaml
+++ b/.github/workflows/haddocks.yaml
@@ -62,7 +62,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           mkdir stack && cd stack
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.7.5-linux-x86_64.tar.gz | tar -xz
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.9.1/stack-2.9.1-linux-x86_64.tar.gz | tar -xz
           echo "$PWD/stack-"* >> $GITHUB_PATH
 
       # One of the transcripts fails if the user's git name hasn't been set.

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -23,7 +23,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           mkdir stack && cd stack
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.7.5-linux-x86_64.tar.gz | tar -xz
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.9.1/stack-2.9.1-linux-x86_64.tar.gz | tar -xz
           echo "$PWD/stack-"* >> $GITHUB_PATH
 
       # One of the transcripts fails if the user's git name hasn't been set.
@@ -61,7 +61,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           mkdir stack && cd stack
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.7.5-osx-x86_64.tar.gz | tar -xz
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.9.1/stack-2.9.1-osx-x86_64.tar.gz | tar -xz
           echo "$PWD/stack-"* >> $GITHUB_PATH
 
       # One of the transcripts fails if the user's git name hasn't been set.
@@ -104,7 +104,7 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           mkdir stack && cd stack
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.7.5-windows-x86_64.tar.gz | tar -xz
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.9.1/stack-2.9.1-windows-x86_64.tar.gz | tar -xz
           echo "$PWD/stack-"* >> $GITHUB_PATH
 
       - name: build
@@ -118,7 +118,7 @@ jobs:
         run: |
           mkdir -p tmp\ui
           mkdir -p release\ui
-          $UCM = .\stack\stack-2.7.5-windows-x86_64\stack.exe exec -- where unison
+          $UCM = .\stack\stack-2.9.1-windows-x86_64\stack.exe exec -- where unison
           cp $UCM .\release\ucm.exe
           Invoke-WebRequest -Uri https://github.com/unisonweb/unison-local-ui/releases/download/latest/unisonLocal.zip -OutFile tmp\unisonLocal.zip
           Expand-Archive -Path tmp\unisonLocal.zip -DestinationPath release\ui

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -104,7 +104,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           mkdir stack && cd stack
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.7.5-linux-x86_64.tar.gz | tar -xz
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.9.1-linux-x86_64.tar.gz | tar -xz
           echo "$PWD/stack-"* >> $GITHUB_PATH
 
       - name: build
@@ -176,7 +176,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           mkdir stack && cd stack
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.7.5-osx-x86_64.tar.gz | tar -xz
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.9.1-osx-x86_64.tar.gz | tar -xz
           echo "$PWD/stack-"* >> $GITHUB_PATH
 
       - name: remove ~/.stack/setup-exe-cache on macOS
@@ -252,7 +252,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           mkdir stack && cd stack
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.7.5-windows-x86_64.tar.gz | tar -xz
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.7.5/stack-2.9.1-windows-x86_64.tar.gz | tar -xz
           echo "$PWD/stack-"* >> $GITHUB_PATH
 
       - name: build
@@ -277,7 +277,7 @@ jobs:
         run: |
           mkdir -p tmp\ui
           mkdir -p release\ui
-          $UCM = .\stack\stack-2.7.5-windows-x86_64\stack.exe exec -- where unison
+          $UCM = .\stack\stack-2.9.1-windows-x86_64\stack.exe exec -- where unison
           cp $UCM .\release\ucm.exe
           Invoke-WebRequest -Uri https://github.com/unisonweb/unison-local-ui/releases/download/latest/unisonLocal.zip -OutFile tmp\unisonLocal.zip
           Expand-Archive -Path tmp\unisonLocal.zip -DestinationPath release\ui

--- a/docs/m1-mac-setup-tips.markdown
+++ b/docs/m1-mac-setup-tips.markdown
@@ -6,7 +6,7 @@ If you are a newcomer to the Haskell ecosystem trying to set up your dev environ
 Here is a working set of versions you can use to build the Unison executable:
 
 GHC version: 8.10.7
-Stack version: 2.7.5
+Stack version: 2.9.1
 Cabal version 3.6.2.0
 Haskell language server version: 1.7.0.0
 
@@ -45,7 +45,7 @@ The GHCup Haskell installer, version 0.1.19.0
 $ which stack
 ~/.ghcup/bin/stack
 $ stack --version
-Version 2.7.5, Git revision 717ec96c15520748f3fcee00f72504ddccaa30b5 (dirty) (163 commits) aarch64
+Version 2.9.1, Git revision 13c9c8772a6dce093dbeacc08bb5877bdb6cfc2e (dirty) (155 commits) aarch64
 ```
 
 ```shell
@@ -79,7 +79,7 @@ Cradle type: Stack
 
 Tool versions found on the $PATH
 cabal:		3.6.2.0
-stack:		2.7.5
+stack:		2.9.1
 ghc:		8.10.7
 ```
 
@@ -88,7 +88,7 @@ If you're a VS Code user, you can download the Haskell extension for IDE support
 ```json
     "haskell.manageHLS": "GHCup",
     "haskell.toolchain": {
-      "stack": "2.7.5",
+      "stack": "2.9.1",
       "ghc": "8.10.7",
       "cabal": "recommended",
       "hls": "1.7.0.0"

--- a/lib/unison-pretty-printer/unison-pretty-printer.cabal
+++ b/lib/unison-pretty-printer/unison-pretty-printer.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -68,9 +68,9 @@ library
     , unison-prelude
     , unison-syntax
     , unliftio
+  default-language: Haskell2010
   if flag(optimized)
     ghc-options: -funbox-strict-fields -O2
-  default-language: Haskell2010
 
 executable prettyprintdemo
   main-is: Main.hs
@@ -103,9 +103,9 @@ executable prettyprintdemo
     , safe
     , text
     , unison-pretty-printer
+  default-language: Haskell2010
   if flag(optimized)
     ghc-options: -funbox-strict-fields -O2
-  default-language: Haskell2010
 
 test-suite pretty-printer-tests
   type: exitcode-stdio-1.0
@@ -146,6 +146,6 @@ test-suite pretty-printer-tests
     , raw-strings-qq
     , unison-pretty-printer
     , unison-syntax
+  default-language: Haskell2010
   if flag(optimized)
     ghc-options: -funbox-strict-fields -O2
-  default-language: Haskell2010

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -308,11 +308,11 @@ library
     , x509-system
     , yaml
     , zlib
+  default-language: Haskell2010
   if flag(optimized)
     ghc-options: -funbox-strict-fields -O2
   if flag(arraychecks)
     cpp-options: -DARRAY_CHECK
-  default-language: Haskell2010
 
 test-suite parser-typechecker-tests
   type: exitcode-stdio-1.0
@@ -500,8 +500,8 @@ test-suite parser-typechecker-tests
     , x509-system
     , yaml
     , zlib
+  default-language: Haskell2010
   if flag(optimized)
     ghc-options: -funbox-strict-fields -O2
   if flag(arraychecks)
     cpp-options: -DARRAY_CHECK
-  default-language: Haskell2010

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -203,12 +203,12 @@ library
     , wai
     , warp
     , witherable
+  default-language: Haskell2010
   if flag(optimized)
     ghc-options: -O2 -funbox-strict-fields
   if !os(windows)
     build-depends:
         unix
-  default-language: Haskell2010
 
 executable cli-integration-tests
   main-is: Suite.hs
@@ -331,9 +331,9 @@ executable cli-integration-tests
     , wai
     , warp
     , witherable
+  default-language: Haskell2010
   if flag(optimized)
     ghc-options: -O2 -funbox-strict-fields
-  default-language: Haskell2010
 
 executable transcripts
   main-is: Transcripts.hs
@@ -453,9 +453,9 @@ executable transcripts
     , wai
     , warp
     , witherable
+  default-language: Haskell2010
   if flag(optimized)
     ghc-options: -O2 -funbox-strict-fields
-  default-language: Haskell2010
 
 executable unison
   main-is: Main.hs
@@ -582,9 +582,9 @@ executable unison
     , wai
     , warp
     , witherable
+  default-language: Haskell2010
   if flag(optimized)
     ghc-options: -O2 -funbox-strict-fields
-  default-language: Haskell2010
 
 test-suite cli-tests
   type: exitcode-stdio-1.0
@@ -714,6 +714,6 @@ test-suite cli-tests
     , wai
     , warp
     , witherable
+  default-language: Haskell2010
   if flag(optimized)
     ghc-options: -O2 -funbox-strict-fields
-  default-language: Haskell2010

--- a/unison-core/unison-core1.cabal
+++ b/unison-core/unison-core1.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -106,6 +106,6 @@ library
     , unison-util-base32hex
     , unison-util-relation
     , vector
+  default-language: Haskell2010
   if flag(optimized)
     ghc-options: -O2 -funbox-strict-fields
-  default-language: Haskell2010


### PR DESCRIPTION
## Overview

team-arya discussed it and now that stack 2.9.1 is more widely supported we've decided to upgrade.

Not only will this help new contributors avoid hpack mismatches, but also there's a weird stack bug on M1 macs where stack segfaults sometimes that seems like it might be fixed in 2.9.1

## Implementation notes

* Update the stack versions we use in CI
* Commit the cabal files generated by hpack 0.35
* Update the mac setup guide.
