### PR TITLE
Work-around for Effect annotations bug.

### DIFF
--- a/unison-cli/src/Unison/LSP/Queries.hs
+++ b/unison-cli/src/Unison/LSP/Queries.hs
@@ -174,7 +174,11 @@ findSmallestEnclosingType pos typ
             ABT.Tm f -> case f of
               Type.Ref {} -> Just typ
               Type.Arrow a b -> findSmallestEnclosingType pos a <|> findSmallestEnclosingType pos b
-              Type.Effect a b -> findSmallestEnclosingType pos a <|> findSmallestEnclosingType pos b
+              Type.Effect effs rhs ->
+                -- There's currently a bug in the annotations for effects which cause them to
+                -- span larger than they should. As  a workaround for now we just make sure to
+                -- search the RHS before the effects.
+                findSmallestEnclosingType pos rhs <|> findSmallestEnclosingType pos effs
               Type.App a b -> findSmallestEnclosingType pos a <|> findSmallestEnclosingType pos b
               Type.Forall r -> findSmallestEnclosingType pos r
               Type.Ann a _kind -> findSmallestEnclosingType pos a

--- a/unison-cli/tests/Unison/Test/LSP.hs
+++ b/unison-cli/tests/Unison/Test/LSP.hs
@@ -136,6 +136,19 @@ term f = f This
         True,
         Right (Type.Ref (Reference.unsafeFromText "#6kbe32g06nqg93cqub6ohqc4ql4o49ntgnunifds0t75qre6lacnbsr3evn8bkivj68ecbvmhkbak4dbg4fqertcpgb396rmo34tnh0"))
       ),
+      ( "Test annotations for effects themselves",
+        [here|
+structural ability Foo a where
+    foo : a
+
+structural type Thing = This | That
+
+term : () -> {F^oo a} Thing
+term _ = This
+        |],
+        True,
+        Right (Type.Ref (Reference.unsafeFromText "#h4uhcub76va4tckj1iccnsb07rh0fhgpigqapb4jh5n07s0tugec4nm2vikuv973mab7oh4ne07o6armcnnl7mbfjtb4imphgrjgimg"))
+      ),
       -- ( "Test annotations for blocks with destructuring binds",
       --   [here|
       -- term = let

--- a/unison-cli/tests/Unison/Test/LSP.hs
+++ b/unison-cli/tests/Unison/Test/LSP.hs
@@ -110,6 +110,32 @@ term = let
         True,
         Left (Term.Boolean True)
       ),
+      ( "Test annotations for types with arrows",
+        [here|
+structural type Thing = This | That
+
+term : Thing -> Thing -> Thi^ng
+term a b = This
+        |],
+        True,
+        Right (Type.Ref (Reference.unsafeFromText "#6kbe32g06nqg93cqub6ohqc4ql4o49ntgnunifds0t75qre6lacnbsr3evn8bkivj68ecbvmhkbak4dbg4fqertcpgb396rmo34tnh0"))
+      ),
+      ( "Test annotations for types with effects",
+        [here|
+unique ability Foo a where
+    foo : a
+
+unique ability Bar b where
+    bar : b
+
+structural type Thing = This | That
+
+term : (Thing -> {Foo a, Bar b} Th^ing) -> {Foo a, Bar b} Thing
+term f = f This
+        |],
+        True,
+        Right (Type.Ref (Reference.unsafeFromText "#6kbe32g06nqg93cqub6ohqc4ql4o49ntgnunifds0t75qre6lacnbsr3evn8bkivj68ecbvmhkbak4dbg4fqertcpgb396rmo34tnh0"))
+      ),
       -- ( "Test annotations for blocks with destructuring binds",
       --   [here|
       -- term = let

--- a/unison-core/src/Unison/Type.hs
+++ b/unison-core/src/Unison/Type.hs
@@ -279,7 +279,7 @@ mvarRef = Reference.Builtin "MVar"
 tvarRef = Reference.Builtin "TVar"
 
 ticketRef :: Reference
-ticketRef  = Reference.Builtin "Ref.Ticket"
+ticketRef = Reference.Builtin "Ref.Ticket"
 
 promiseRef :: Reference
 promiseRef = Reference.Builtin "Promise"


### PR DESCRIPTION
## Overview

I've got some parser annotation problems with effects lists;

1. Effect lists are currently just assigned the Ann of the RHS of their arrow, rather than the Ann of the effect list itself, causing the LSP to think the cursor is over the effect list when it's actually somewhere later in the type.
2. This applies to inferred effects as well, which are also given the Ann of the RHS of their arrow, causing the LSP to think the cursor is on an effect that doesn't even exist in the file.

All the possible fixes have some of their own problems:

1. Compute the correct effect annotations by folding the annotations of all the types in the effect list.
   Problem: This requires propagating a (Monoid a) constraint throughout the entirety of UCM; I don't think this is semantically incorrect, having at least a semigroup on Annotations makes sense since we often need to get the span of multiple Anns.
2. Add an additional argument for the effects Ann to the all the 'effect' building combinators
   Problem: In some cases we're combining/flattening many effects together, and can't get the correct span without mappend'ing multiple effect Anns together, leading back to solution 1. Also, we still need to provide some Ann for inferred effects. Even if we solve those problems, most of the effect combinators like Type.effect and Type.effect1 fold/flatten effects together from what they're passed, meaning that even if we try to pass a reasonable Ann from the caller, it'll still be incorrect after the flattening takes place. This aspect may be sufficiently rare that we can ignore it in LSP
3. Use 2, but add a new "DerivedFrom Ann" constructor to the `Ann` type, this allows us to track which things were inferred from something in the file, but don't exist in the file itself.
   Problem: Most of the type constructor and parsing combinators are polymorphic over `a`, meaning even if we have an `a` in scope, we can't wrap it in `DerivedFrom` without specializing to `Ann` instead. The flattening problem from 2 would still exist.


Because of those complexities, for now I've found a pretty simple change to the LSP which works around them. Ideally we'd still fix the problem in the future, but this change gives us the correct behaviour in the mean-time.


## Implementation notes

Since we know that the type annotation on the RHS of the Effect nodes is still correct, we simply search for a hover target there before searching within the possibly inferred, non-existent or incorrectly annotated effects.

## Test coverage

I added new "hover-style" LSP tests for each of the cases affected by effect lists
