### PR TITLE
Fix universal equality for Socket

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Foreign.hs
+++ b/parser-typechecker/src/Unison/Runtime/Foreign.hs
@@ -71,6 +71,10 @@ mvarEq :: MVar () -> MVar () -> Bool
 mvarEq l r = l == r
 {-# NOINLINE mvarEq #-}
 
+socketEq :: Socket -> Socket -> Bool
+socketEq l r = l == r
+{-# NOINLINE socketEq #-}
+
 refEq :: IORef () -> IORef () -> Bool
 refEq l r = l == r
 {-# NOINLINE refEq #-}
@@ -133,6 +137,7 @@ ref2eq r
   -- matter what type the MVar holds.
   | r == Ty.mvarRef = Just $ promote mvarEq
   -- Ditto
+  | r == Ty.socketRef = Just $ promote socketEq
   | r == Ty.refRef = Just $ promote refEq
   | r == Ty.threadIdRef = Just $ promote tidEq
   | r == Ty.marrayRef = Just $ promote marrEq


### PR DESCRIPTION
Resolves #3791

Delegate to the runtime's Socket equality, which I believe uses pointer
equality.

I tested this by running the following code, which no longer gives an
error after this change:

```
main = do
  socket = Socket.client (HostName "www.google.com") (Port "http")
  socket === socket
```
