### PR TITLE
Add a chez transcript to test `Bytes.toHex` to prepare for crypto tess

### DIFF
--- a/chez-libs/tests/basic.md
+++ b/chez-libs/tests/basic.md
@@ -1,0 +1,63 @@
+
+```ucm:hide
+.> builtins.merge
+.> pull unison.public.base.latest.Bytes
+.> pull unison.public.base.latest.IO
+.> pull dolio.public.internal.trunk.compiler
+```
+
+```unison
+printHello = '(printLine "Hello")
+
+generateBaseFiles _ =
+	h = open (FilePath "unison/builtin-generated.ss") Write
+	putText h (generateBaseFile builtinSpec)
+	close h
+
+schemeToFile dest link = 
+	h = open (FilePath dest) Write
+	text = generateScheme true link
+	putText h text
+	close h
+```
+
+```ucm:hide
+.> add
+.> run generateBaseFiles
+```
+
+```unison
+test1 = '(schemeToFile "test-1.ss" (termLink printHello))
+```
+
+```ucm
+.> run test1
+```
+
+Now run the following:
+```bash
+$ scheme --libdirs ../:./ --script test-1.ss
+```
+
+```unison
+printBytes _ = printLine (toHex (Bytes.fromList [100, 200, 16]))
+```
+
+```ucm:hide
+.> add
+```
+
+```unison
+test2 = '(schemeToFile "test-2.ss" (termLink printBytes))
+```
+
+```ucm
+.> run test2
+```
+
+Now run the following:
+```bash
+$ scheme --libdirs ../:./ --script test-2.ss
+```
+
+

--- a/scheme-libs/common/unison/primops.ss
+++ b/scheme-libs/common/unison/primops.ss
@@ -101,6 +101,7 @@
     unison-POp-VALU
     unison-POp-VWLS
 
+    unison-POp-PAKB
     unison-POp-UPKB
     unison-POp-ADDI
     unison-POp-DIVI
@@ -121,6 +122,7 @@
           (unison bytevector)
           (unison vector))
 
+  ; (define unison-POp-PAKB u8-list->bytevector)
   (define unison-POp-UPKB bytevector->u8-list)
   (define unison-POp-ADDI +)
   (define unison-POp-DIVI /)

--- a/scheme-libs/common/unison/primops.ss
+++ b/scheme-libs/common/unison/primops.ss
@@ -122,7 +122,6 @@
           (unison bytevector)
           (unison vector))
 
-  ; (define unison-POp-PAKB u8-list->bytevector)
   (define unison-POp-UPKB bytevector->u8-list)
   (define unison-POp-ADDI +)
   (define unison-POp-DIVI /)

--- a/scheme-libs/tests/base.md
+++ b/scheme-libs/tests/base.md
@@ -3,6 +3,8 @@
 .> builtins.merge
 .> pull unison.public.base.latest base
 .> pull dolio.public.internal.trunk.compiler
+.> pull dolio.public.internal.trunk.impls impls
+.> pull dolio.public.internal.trunk.Reference Reference
 ```
 
 ```unison

--- a/scheme-libs/tests/base.md
+++ b/scheme-libs/tests/base.md
@@ -1,8 +1,7 @@
 
 ```ucm
 .> builtins.merge
-.> pull unison.public.base.latest.IO base.IO
-.> pull unison.public.base.main.IO.Process base.IO.Process
+.> pull unison.public.base.latest base
 .> pull dolio.public.internal.trunk.compiler
 ```
 
@@ -37,7 +36,7 @@ runChez fileName =
 	(stdin, stdout, stderr, pid) = IO.Process.start "scheme" ["--libdirs", "../chez:../common", "--script", fileName]
 	exitCode = match wait pid with
 		0 -> ""
-		code -> "Non-zero exit code! " ++ (toText code) ++ "\n"
+		code -> "Non-zero exit code! " ++ (Nat.toText code) ++ "\n"
 	exitCode ++ readAll stdout ++ readAll stderr
 
 runInScheme id term =

--- a/scheme-libs/tests/base.output.md
+++ b/scheme-libs/tests/base.output.md
@@ -4,13 +4,11 @@
 
   Done.
 
-.> pull unison.public.base.latest.IO base.IO
+.> pull unison.public.base.latest base
 
   ✅
   
-  ✅ Successfully pulled into newly created namespace base.IO.
-
-.> pull unison.public.base.main.IO.Process base.IO.Process
+  ✅ Successfully pulled into newly created namespace base.
 
 .> pull dolio.public.internal.trunk.compiler
 
@@ -46,7 +44,7 @@ runChez fileName =
 	(stdin, stdout, stderr, pid) = IO.Process.start "scheme" ["--libdirs", "../chez:../common", "--script", fileName]
 	exitCode = match wait pid with
 		0 -> ""
-		code -> "Non-zero exit code! " ++ (toText code) ++ "\n"
+		code -> "Non-zero exit code! " ++ (Nat.toText code) ++ "\n"
 	exitCode ++ readAll stdout ++ readAll stderr
 
 runInScheme id term =
@@ -70,10 +68,10 @@ runInScheme id term =
       right                        : Either a b -> Optional b
       runChez                      : Text ->{IO, Exception} Text
       runInScheme                  : Nat
-                                     -> Term
+                                     -> Link.Term
                                      ->{IO, Exception} Text
       schemeToFile                 : Text
-                                     -> Term
+                                     -> Link.Term
                                      ->{IO, Exception} ()
       |>                           : a -> (a ->{g} t) ->{g} t
 
@@ -89,10 +87,10 @@ runInScheme id term =
     right                        : Either a b -> Optional b
     runChez                      : Text ->{IO, Exception} Text
     runInScheme                  : Nat
-                                   -> Term
+                                   -> Link.Term
                                    ->{IO, Exception} Text
     schemeToFile                 : Text
-                                   -> Term
+                                   -> Link.Term
                                    ->{IO, Exception} ()
     |>                           : a -> (a ->{g} t) ->{g} t
 

--- a/scheme-libs/tests/bytes.md
+++ b/scheme-libs/tests/bytes.md
@@ -1,0 +1,38 @@
+
+Note: This should be forked off of the codebase created by base.md
+
+```ucm
+.> pull dolio.public.internal.trunk.impls impls
+```
+
+```unison
+printBytes _ = printLine (base.Bytes.toHex (base.Bytes.fromList [100, 200, 16]))
+
+-- removing Bytes.toList and Bytes.fromList
+scheme.builtinLinks : Map Text Link.Term
+scheme.builtinLinks =
+  Map.fromList
+    [ ("builtin-Bytes.empty", termLink #n21jacdb5b),
+      ("builtin-Bytes.++", termLink #5o0nvn3t6l),
+      ("builtin-Bytes.take", termLink #4kv8niiu94),
+      ("builtin-Bytes.drop", termLink #80l7nu1u90),
+      ("builtin-Bytes.at", termLink #7qjq1usqej),
+      ("builtin-Bytes.size", termLink #t320fkv2d5),
+      ("builtin-Bytes.flatten", termLink #cl56gpk7am) ]
+
+```
+
+```ucm:hide
+.> update
+.> add
+.> run generateSchemeBuiltinLibrary
+```
+
+```unison
+bytes = '(runInScheme 2 (termLink printBytes))
+```
+
+```ucm
+.> run bytes
+```
+

--- a/scheme-libs/tests/bytes.md
+++ b/scheme-libs/tests/bytes.md
@@ -1,10 +1,6 @@
 
 Note: This should be forked off of the codebase created by base.md
 
-```ucm
-.> pull dolio.public.internal.trunk.impls impls
-```
-
 ```unison
 printBytes _ = printLine (base.Bytes.toHex (base.Bytes.fromList [100, 200, 16]))
 
@@ -20,12 +16,70 @@ scheme.builtinLinks =
       ("builtin-Bytes.size", termLink #t320fkv2d5),
       ("builtin-Bytes.flatten", termLink #cl56gpk7am) ]
 
+scheme.SchemeDefn.toIndentedText : Nat -> SchemeDefn -> Text
+scheme.SchemeDefn.toIndentedText n = cases
+  Define name args body ->
+    use List +:
+    use Nat +
+    bods = match name with
+            "builtin-Char.toNat" -> "(char->integer x0)"
+            "builtin-Char.fromNat" -> "(integer->char x0)"
+            _ -> SchemeTerm.toIndentedText (n + 2) body
+    pexpr
+      (n + 2)
+      [ "define-unison",
+        parens (Text.join " " (name +: args)),
+        bods ]
+
+generateScheme : Boolean -> Link.Term ->{IO, Exception} Text
+generateScheme exec base =
+  found = intermediateCode base
+  bref = #b64k0j6eu8 <| #i3vare757c base
+  header =
+    use Text ++
+    "(top-level-program\n" ++ generateImports 2 mainImports ++ "\n; end toplevel\n"
+  footer = if exec then executeFooter bref else compileFooter bref
+  Text.join "\n\n; divider\n\n" [header, generateDefns false 2 found, footer]
+
+schemeOutput : Boolean -> Nat -> (Link.Term, SuperGroup) ->{Exception} Text
+schemeOutput genIntermediate n = cases
+  (link, anf) ->
+    use Text ++
+    ref = fromTermLink link
+    int =
+      if genIntermediate then
+        SchemeIntermed.toIndentedText n (toSchemeObject ref anf) ++ pad! n
+      else ""
+    exe =
+      Text.join
+        (pad! n)
+        (List.map (SchemeDefn.toIndentedText n) (SuperGroup.toScheme ref anf))
+    int ++ exe
+
+
+scheme.generateDefns :
+  Boolean -> Nat -> Map Link.Term SuperGroup ->{Exception} Text
+scheme.generateDefns genIntermediate n found =
+  use List map
+  use Reference toScheme
+  use Text ++ join
+  hrefs =
+    Map.foldLeft (rs -> Set.union rs << SuperGroup.handled) Set.empty found
+  link tl = toScheme (fromTermLink tl)
+  hdef r =
+    err = "unhandled ability: " ++ toSchemeSym r
+    errk =
+      SExpr [Sym "lambda", SExpr [Sym "_"], SExpr [Sym "raise", String err]]
+    SExpr [Sym "define", toScheme r, errk]
+  hdefs = map (SchemeTerm.toIndentedText n << hdef) (Set.toList hrefs)
+  defs =
+    join (pad! n) (map (schemeOutput genIntermediate n) (Map.toList found))
+  join (pad! n) hdefs ++ "\n; hdefs -> defs \n" ++ pad! n ++ defs
+
 ```
 
 ```ucm:hide
 .> update
-.> add
-.> run generateSchemeBuiltinLibrary
 ```
 
 ```unison

--- a/scheme-libs/tests/bytes.md
+++ b/scheme-libs/tests/bytes.md
@@ -21,7 +21,7 @@ scheme.SchemeDefn.toIndentedText n = cases
   Define name args body ->
     use List +:
     use Nat +
-    bods = match name with
+    formattedBody = match name with
             "builtin-Char.toNat" -> "(char->integer x0)"
             "builtin-Char.fromNat" -> "(integer->char x0)"
             _ -> SchemeTerm.toIndentedText (n + 2) body
@@ -29,17 +29,7 @@ scheme.SchemeDefn.toIndentedText n = cases
       (n + 2)
       [ "define-unison",
         parens (Text.join " " (name +: args)),
-        bods ]
-
-generateScheme : Boolean -> Link.Term ->{IO, Exception} Text
-generateScheme exec base =
-  found = intermediateCode base
-  bref = #b64k0j6eu8 <| #i3vare757c base
-  header =
-    use Text ++
-    "(top-level-program\n" ++ generateImports 2 mainImports ++ "\n; end toplevel\n"
-  footer = if exec then executeFooter bref else compileFooter bref
-  Text.join "\n\n; divider\n\n" [header, generateDefns false 2 found, footer]
+        formattedBody ]
 
 schemeOutput : Boolean -> Nat -> (Link.Term, SuperGroup) ->{Exception} Text
 schemeOutput genIntermediate n = cases
@@ -55,26 +45,6 @@ schemeOutput genIntermediate n = cases
         (pad! n)
         (List.map (SchemeDefn.toIndentedText n) (SuperGroup.toScheme ref anf))
     int ++ exe
-
-
-scheme.generateDefns :
-  Boolean -> Nat -> Map Link.Term SuperGroup ->{Exception} Text
-scheme.generateDefns genIntermediate n found =
-  use List map
-  use Reference toScheme
-  use Text ++ join
-  hrefs =
-    Map.foldLeft (rs -> Set.union rs << SuperGroup.handled) Set.empty found
-  link tl = toScheme (fromTermLink tl)
-  hdef r =
-    err = "unhandled ability: " ++ toSchemeSym r
-    errk =
-      SExpr [Sym "lambda", SExpr [Sym "_"], SExpr [Sym "raise", String err]]
-    SExpr [Sym "define", toScheme r, errk]
-  hdefs = map (SchemeTerm.toIndentedText n << hdef) (Set.toList hrefs)
-  defs =
-    join (pad! n) (map (schemeOutput genIntermediate n) (Map.toList found))
-  join (pad! n) hdefs ++ "\n; hdefs -> defs \n" ++ pad! n ++ defs
 
 ```
 

--- a/scheme-libs/tests/bytes.output.md
+++ b/scheme-libs/tests/bytes.output.md
@@ -1,14 +1,6 @@
 
 Note: This should be forked off of the codebase created by base.md
 
-```ucm
-.> pull dolio.public.internal.trunk.impls impls
-
-  ✅
-  
-  ✅ Successfully pulled into newly created namespace impls.
-
-```
 ```unison
 printBytes _ = printLine (base.Bytes.toHex (base.Bytes.fromList [100, 200, 16]))
 
@@ -23,6 +15,66 @@ scheme.builtinLinks =
       ("builtin-Bytes.at", termLink #7qjq1usqej),
       ("builtin-Bytes.size", termLink #t320fkv2d5),
       ("builtin-Bytes.flatten", termLink #cl56gpk7am) ]
+
+scheme.SchemeDefn.toIndentedText : Nat -> SchemeDefn -> Text
+scheme.SchemeDefn.toIndentedText n = cases
+  Define name args body ->
+    use List +:
+    use Nat +
+    bods = match name with
+            "builtin-Char.toNat" -> "(char->integer x0)"
+            "builtin-Char.fromNat" -> "(integer->char x0)"
+            _ -> SchemeTerm.toIndentedText (n + 2) body
+    pexpr
+      (n + 2)
+      [ "define-unison",
+        parens (Text.join " " (name +: args)),
+        bods ]
+
+generateScheme : Boolean -> Link.Term ->{IO, Exception} Text
+generateScheme exec base =
+  found = intermediateCode base
+  bref = #b64k0j6eu8 <| #i3vare757c base
+  header =
+    use Text ++
+    "(top-level-program\n" ++ generateImports 2 mainImports ++ "\n; end toplevel\n"
+  footer = if exec then executeFooter bref else compileFooter bref
+  Text.join "\n\n; divider\n\n" [header, generateDefns false 2 found, footer]
+
+schemeOutput : Boolean -> Nat -> (Link.Term, SuperGroup) ->{Exception} Text
+schemeOutput genIntermediate n = cases
+  (link, anf) ->
+    use Text ++
+    ref = fromTermLink link
+    int =
+      if genIntermediate then
+        SchemeIntermed.toIndentedText n (toSchemeObject ref anf) ++ pad! n
+      else ""
+    exe =
+      Text.join
+        (pad! n)
+        (List.map (SchemeDefn.toIndentedText n) (SuperGroup.toScheme ref anf))
+    int ++ exe
+
+
+scheme.generateDefns :
+  Boolean -> Nat -> Map Link.Term SuperGroup ->{Exception} Text
+scheme.generateDefns genIntermediate n found =
+  use List map
+  use Reference toScheme
+  use Text ++ join
+  hrefs =
+    Map.foldLeft (rs -> Set.union rs << SuperGroup.handled) Set.empty found
+  link tl = toScheme (fromTermLink tl)
+  hdef r =
+    err = "unhandled ability: " ++ toSchemeSym r
+    errk =
+      SExpr [Sym "lambda", SExpr [Sym "_"], SExpr [Sym "raise", String err]]
+    SExpr [Sym "define", toScheme r, errk]
+  hdefs = map (SchemeTerm.toIndentedText n << hdef) (Set.toList hrefs)
+  defs =
+    join (pad! n) (map (schemeOutput genIntermediate n) (Map.toList found))
+  join (pad! n) hdefs ++ "\n; hdefs -> defs \n" ++ pad! n ++ defs
 
 ```
 
@@ -39,7 +91,23 @@ scheme.builtinLinks =
     ⍟ These names already exist. You can `update` them to your
       new definition:
     
-      scheme.builtinLinks : Map Text Link.Term
+      generateScheme                   : Boolean
+                                         -> Link.Term
+                                         ->{IO, Exception} Text
+      scheme.SchemeDefn.toIndentedText : Nat
+                                         -> SchemeDefn
+                                         -> Text
+      scheme.builtinLinks              : Map Text Link.Term
+      scheme.generateDefns             : Boolean
+                                         -> Nat
+                                         -> Map
+                                           Link.Term SuperGroup
+                                         ->{Exception} Text
+      schemeOutput                     : Boolean
+                                         -> Nat
+                                         -> ( Link.Term,
+                                           SuperGroup)
+                                         ->{Exception} Text
 
 ```
 ```unison
@@ -60,6 +128,6 @@ bytes = '(runInScheme 2 (termLink printBytes))
 ```ucm
 .> run bytes
 
-  "Non-zero exit code! 255\nException in fx+: #\\0 is not a fixnum\n"
+  "480\n"
 
 ```

--- a/scheme-libs/tests/bytes.output.md
+++ b/scheme-libs/tests/bytes.output.md
@@ -21,7 +21,7 @@ scheme.SchemeDefn.toIndentedText n = cases
   Define name args body ->
     use List +:
     use Nat +
-    bods = match name with
+    formattedBody = match name with
             "builtin-Char.toNat" -> "(char->integer x0)"
             "builtin-Char.fromNat" -> "(integer->char x0)"
             _ -> SchemeTerm.toIndentedText (n + 2) body
@@ -29,17 +29,7 @@ scheme.SchemeDefn.toIndentedText n = cases
       (n + 2)
       [ "define-unison",
         parens (Text.join " " (name +: args)),
-        bods ]
-
-generateScheme : Boolean -> Link.Term ->{IO, Exception} Text
-generateScheme exec base =
-  found = intermediateCode base
-  bref = #b64k0j6eu8 <| #i3vare757c base
-  header =
-    use Text ++
-    "(top-level-program\n" ++ generateImports 2 mainImports ++ "\n; end toplevel\n"
-  footer = if exec then executeFooter bref else compileFooter bref
-  Text.join "\n\n; divider\n\n" [header, generateDefns false 2 found, footer]
+        formattedBody ]
 
 schemeOutput : Boolean -> Nat -> (Link.Term, SuperGroup) ->{Exception} Text
 schemeOutput genIntermediate n = cases
@@ -56,26 +46,6 @@ schemeOutput genIntermediate n = cases
         (List.map (SchemeDefn.toIndentedText n) (SuperGroup.toScheme ref anf))
     int ++ exe
 
-
-scheme.generateDefns :
-  Boolean -> Nat -> Map Link.Term SuperGroup ->{Exception} Text
-scheme.generateDefns genIntermediate n found =
-  use List map
-  use Reference toScheme
-  use Text ++ join
-  hrefs =
-    Map.foldLeft (rs -> Set.union rs << SuperGroup.handled) Set.empty found
-  link tl = toScheme (fromTermLink tl)
-  hdef r =
-    err = "unhandled ability: " ++ toSchemeSym r
-    errk =
-      SExpr [Sym "lambda", SExpr [Sym "_"], SExpr [Sym "raise", String err]]
-    SExpr [Sym "define", toScheme r, errk]
-  hdefs = map (SchemeTerm.toIndentedText n << hdef) (Set.toList hrefs)
-  defs =
-    join (pad! n) (map (schemeOutput genIntermediate n) (Map.toList found))
-  join (pad! n) hdefs ++ "\n; hdefs -> defs \n" ++ pad! n ++ defs
-
 ```
 
 ```ucm
@@ -91,18 +61,10 @@ scheme.generateDefns genIntermediate n found =
     ⍟ These names already exist. You can `update` them to your
       new definition:
     
-      generateScheme                   : Boolean
-                                         -> Link.Term
-                                         ->{IO, Exception} Text
       scheme.SchemeDefn.toIndentedText : Nat
                                          -> SchemeDefn
                                          -> Text
       scheme.builtinLinks              : Map Text Link.Term
-      scheme.generateDefns             : Boolean
-                                         -> Nat
-                                         -> Map
-                                           Link.Term SuperGroup
-                                         ->{Exception} Text
       schemeOutput                     : Boolean
                                          -> Nat
                                          -> ( Link.Term,

--- a/scheme-libs/tests/bytes.output.md
+++ b/scheme-libs/tests/bytes.output.md
@@ -1,0 +1,65 @@
+
+Note: This should be forked off of the codebase created by base.md
+
+```ucm
+.> pull dolio.public.internal.trunk.impls impls
+
+  ✅
+  
+  ✅ Successfully pulled into newly created namespace impls.
+
+```
+```unison
+printBytes _ = printLine (base.Bytes.toHex (base.Bytes.fromList [100, 200, 16]))
+
+-- removing Bytes.toList and Bytes.fromList
+scheme.builtinLinks : Map Text Link.Term
+scheme.builtinLinks =
+  Map.fromList
+    [ ("builtin-Bytes.empty", termLink #n21jacdb5b),
+      ("builtin-Bytes.++", termLink #5o0nvn3t6l),
+      ("builtin-Bytes.take", termLink #4kv8niiu94),
+      ("builtin-Bytes.drop", termLink #80l7nu1u90),
+      ("builtin-Bytes.at", termLink #7qjq1usqej),
+      ("builtin-Bytes.size", termLink #t320fkv2d5),
+      ("builtin-Bytes.flatten", termLink #cl56gpk7am) ]
+
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      printBytes : ∀ _. _ ->{IO, Exception} ()
+    
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      scheme.builtinLinks : Map Text Link.Term
+
+```
+```unison
+bytes = '(runInScheme 2 (termLink printBytes))
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bytes : '{IO, Exception} Text
+
+```
+```ucm
+.> run bytes
+
+  "Non-zero exit code! 255\nException in fx+: #\\0 is not a fixnum\n"
+
+```

--- a/scheme-libs/tests/run-tests.sh
+++ b/scheme-libs/tests/run-tests.sh
@@ -10,4 +10,5 @@ if [ ! -d "base.unison" ]; then
 fi
 
 ./ucm transcript.fork -c base.unison basic.md
+./ucm transcript.fork -c base.unison bytes.md
 


### PR DESCRIPTION
I had to make two changes to the scheme generation (illustrated in bytes.md)
- builtinLinks needed `Bytes.toList` and `Bytes.fromList` removed
- SchemeDefn.toIndentedText needed to be generating a different definition for Char.toNat and Char.fromNat. This probably isn't the right way to do it though 😉 `Char.fromNat` and `Char.toNat` are defined as a `cast` in `Builtin.hs`, which I assume is why they get generated as `identity` in the scheme output. Do we want to indicate there somehow that scheme will need it to be more than just a `cast`?