### PR TITLE
Fix up annotation tracking for patterns and tuples

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/TermParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermParser.hs
@@ -1218,7 +1218,7 @@ tupleOrParenthesizedTerm = label "tuple" $ tupleOrParenthesized term DD.unitTerm
         (ann t1 <> ann t2)
         ( Term.app
             (ann t1)
-            (Term.constructor (ann t1) (ConstructorReference DD.pairRef 0))
+            (Term.constructor (ann t1 <> ann t2) (ConstructorReference DD.pairRef 0))
             t1
         )
         t2

--- a/parser-typechecker/src/Unison/Syntax/TermParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermParser.hs
@@ -1218,7 +1218,7 @@ tupleOrParenthesizedTerm = label "tuple" $ tupleOrParenthesized term DD.unitTerm
         (ann t1 <> ann t2)
         ( Term.app
             (ann t1)
-            (Term.constructor (ann t1 <> ann t2) (ConstructorReference DD.pairRef 0))
+            (Term.constructor (ann t1) (ConstructorReference DD.pairRef 0))
             t1
         )
         t2

--- a/unison-cli/tests/Unison/Test/LSP.hs
+++ b/unison-cli/tests/Unison/Test/LSP.hs
@@ -127,6 +127,14 @@ term = let
         True,
         trm (Term.Boolean True)
       ),
+      ( "Test annotations for destructuring tuples (they have a special parser)",
+        [here|
+term = let
+  (true, fal^se)
+        |],
+        True,
+        trm (Term.Boolean False)
+      ),
       ( "Test annotations within pattern binds",
         [here|
 term = let

--- a/unison-cli/tests/Unison/Test/LSP.hs
+++ b/unison-cli/tests/Unison/Test/LSP.hs
@@ -4,7 +4,6 @@
 module Unison.Test.LSP (test) where
 
 import qualified Crypto.Random as Random
-import Data.Bifunctor (bimap)
 import Data.List.Extra (firstJust)
 import Data.String.Here.Uninterpolated (here)
 import Data.Text
@@ -20,15 +19,14 @@ import qualified Unison.LSP.Queries as LSPQ
 import qualified Unison.Lexer.Pos as Lexer
 import Unison.Parser.Ann (Ann (..))
 import qualified Unison.Parser.Ann as Ann
+import qualified Unison.Pattern as Pattern
 import Unison.Prelude
 import qualified Unison.Reference as Reference
 import qualified Unison.Result as Result
 import Unison.Symbol (Symbol)
 import qualified Unison.Syntax.Lexer as L
 import qualified Unison.Syntax.Parser as Parser
-import Unison.Term (Term)
 import qualified Unison.Term as Term
-import Unison.Type (Type)
 import qualified Unison.Type as Type
 import qualified Unison.UnisonFile as UF
 import Unison.Util.Monoid (foldMapM)
@@ -41,6 +39,15 @@ test = do
         annotationNesting
       ]
 
+trm :: Term.F Symbol () () (ABT.Term (Term.F Symbol () ()) Symbol ()) -> LSPQ.SourceNode ()
+trm = LSPQ.TermNode . ABT.tm
+
+typ :: Type.F (ABT.Term Type.F Symbol ()) -> LSPQ.SourceNode ()
+typ = LSPQ.TypeNode . ABT.tm
+
+pat :: Pattern.Pattern () -> LSPQ.SourceNode ()
+pat = LSPQ.PatternNode
+
 -- | Test that we can find the correct reference for a given cursor position.
 refFinding :: Test ()
 refFinding =
@@ -48,12 +55,12 @@ refFinding =
     [ ( "Binary Op lhs",
         [here|term = tr^ue && false|],
         True,
-        Left (Term.Boolean True)
+        trm (Term.Boolean True)
       ),
       ( "Binary Op rhs",
         [here|term = true && fa^lse|],
         True,
-        Left (Term.Boolean False)
+        trm (Term.Boolean False)
       ),
       ( "Custom Op lhs",
         [here|
@@ -61,7 +68,7 @@ a &&& b = a && b
 term = tr^ue &&& false
 |],
         True,
-        Left (Term.Boolean True)
+        trm (Term.Boolean True)
       ),
       ( "Simple type annotation on non-typechecking file",
         [here|
@@ -70,7 +77,7 @@ term : Thi^ng
 term = "this won't typecheck"
 |],
         False,
-        Right (Type.Ref (Reference.unsafeFromText "#6kbe32g06nqg93cqub6ohqc4ql4o49ntgnunifds0t75qre6lacnbsr3evn8bkivj68ecbvmhkbak4dbg4fqertcpgb396rmo34tnh0"))
+        typ (Type.Ref (Reference.unsafeFromText "#6kbe32g06nqg93cqub6ohqc4ql4o49ntgnunifds0t75qre6lacnbsr3evn8bkivj68ecbvmhkbak4dbg4fqertcpgb396rmo34tnh0"))
       ),
       ( "Simple type annotation on typechecking file",
         [here|
@@ -79,7 +86,7 @@ term : Thi^ng
 term = This
 |],
         True,
-        Right (Type.Ref (Reference.unsafeFromText "#6kbe32g06nqg93cqub6ohqc4ql4o49ntgnunifds0t75qre6lacnbsr3evn8bkivj68ecbvmhkbak4dbg4fqertcpgb396rmo34tnh0"))
+        typ (Type.Ref (Reference.unsafeFromText "#6kbe32g06nqg93cqub6ohqc4ql4o49ntgnunifds0t75qre6lacnbsr3evn8bkivj68ecbvmhkbak4dbg4fqertcpgb396rmo34tnh0"))
       ),
       ( "Test annotations within bindings for do-block elements",
         [here|
@@ -89,7 +96,7 @@ term = do
   first && second
         |],
         True,
-        Left (Term.Boolean True)
+        trm (Term.Boolean True)
       ),
       ( "Test annotations within bindings for let-block elements",
         [here|
@@ -99,7 +106,7 @@ term = let
   first && second
         |],
         True,
-        Left (Term.Boolean True)
+        trm (Term.Boolean True)
       ),
       ( "Test annotations within actions for let-block elements",
         [here|
@@ -108,18 +115,27 @@ term = let
   first && tr^ue
         |],
         True,
-        Left (Term.Boolean True)
+        trm (Term.Boolean True)
       ),
-      -- ( "Test annotations for blocks with destructuring binds",
-      --   [here|
-      -- term = let
-      -- (first, second) = (false, true)
-      -- (third, fourth) = (false, tr^ue)
-      -- first && second && third && fourth
-      --   |],
-      --   True,
-      --   Left (Term.Boolean True)
-      -- ),
+      ( "Test annotations for blocks with destructuring binds",
+        [here|
+structural type Identity a = Identity a
+term = let
+  (Identity a) = Identity tr^ue
+  a
+        |],
+        True,
+        trm (Term.Boolean True)
+      ),
+      ( "Test annotations within pattern binds",
+        [here|
+term = let
+  (third, tr^ue) = (false, true)
+  true
+  |],
+        True,
+        pat (Pattern.Boolean () True)
+      ),
       ( "Test annotations for blocks recursive binds",
         [here|
 term = let
@@ -128,7 +144,7 @@ term = let
   f true
         |],
         True,
-        Left (Term.Boolean False)
+        trm (Term.Boolean False)
       )
     ]
 
@@ -142,7 +158,7 @@ extractCursor txt =
        in pure $ (Lexer.Pos line col, before <> after)
     _ -> crash "expected exactly one cursor"
 
-makeNodeSelectionTest :: (String, Text, Bool, Either ((Term.F Symbol Ann Ann (Term Symbol Ann))) (Type.F (Type Symbol Ann))) -> Test ()
+makeNodeSelectionTest :: (String, Text, Bool, LSPQ.SourceNode ()) -> Test ()
 makeNodeSelectionTest (name, testSrc, testTypechecked, expected) = scope name $ do
   (pos, src) <- extractCursor testSrc
   (notes, mayParsedFile, mayTypecheckedFile) <- typecheckSrc name src
@@ -152,7 +168,7 @@ makeNodeSelectionTest (name, testSrc, testTypechecked, expected) = scope name $ 
           UF.terms pf
             & firstJust \(_v, trm) ->
               LSPQ.findSmallestEnclosingNode pos trm
-    expectEqual (Just $ bimap ABT.Tm ABT.Tm expected) (bimap ABT.out ABT.out <$> pfResult)
+    expectEqual (Just expected) (void <$> pfResult)
 
   when testTypechecked $
     scope "typechecked file" $ do
@@ -162,7 +178,7 @@ makeNodeSelectionTest (name, testSrc, testTypechecked, expected) = scope name $ 
               & toList
               & firstJust \(_refId, _wk, trm, _typ) ->
                 LSPQ.findSmallestEnclosingNode pos trm
-      expectEqual (Just $ bimap ABT.Tm ABT.Tm expected) (bimap ABT.out ABT.out <$> tfResult)
+      expectEqual (Just expected) (void <$> tfResult)
 
 -- | Tests which assert that the annotation for each ABT node spans at least the span of
 -- its children, i.e. all child annotations are contained within the annotation of their parent.

--- a/unison-core/src/Unison/Pattern.hs
+++ b/unison-core/src/Unison/Pattern.hs
@@ -37,6 +37,23 @@ data Pattern loc
   | SequenceOp loc (Pattern loc) !SeqOp (Pattern loc)
   deriving (Ord, Generic, Functor, Foldable, Traversable)
 
+annotation :: Pattern loc -> loc
+annotation = \case
+  Unbound loc -> loc
+  Var loc -> loc
+  Boolean loc _ -> loc
+  Int loc _ -> loc
+  Nat loc _ -> loc
+  Float loc _ -> loc
+  Text loc _ -> loc
+  Char loc _ -> loc
+  Constructor loc _ _ -> loc
+  As loc _ -> loc
+  EffectPure loc _ -> loc
+  EffectBind loc _ _ _ -> loc
+  SequenceLiteral loc _ -> loc
+  SequenceOp loc _ _ _ -> loc
+
 data SeqOp
   = Cons
   | Snoc

--- a/unison-syntax/src/Unison/Syntax/Parser.hs
+++ b/unison-syntax/src/Unison/Syntax/Parser.hs
@@ -370,7 +370,11 @@ string = queryToken getString
 tupleOrParenthesized :: Ord v => P v a -> (Ann -> a) -> (a -> a -> a) -> P v a
 tupleOrParenthesized p unit pair = seq' "(" go p
   where
+    -- Parens without any contents are parsed as a 'unit'
+    go a [] = unit a
+    -- Parens with a single element are parsed as just that element
     go _ [t] = t
+    -- Parens with multiple elements are parsed as a tuple, ending in an implicit unit
     go _ xs = foldr pair (unit External) xs
 
 seq :: Ord v => (Ann -> [a] -> a) -> P v a -> P v a

--- a/unison-syntax/src/Unison/Syntax/Parser.hs
+++ b/unison-syntax/src/Unison/Syntax/Parser.hs
@@ -371,7 +371,7 @@ tupleOrParenthesized :: Ord v => P v a -> (Ann -> a) -> (a -> a -> a) -> P v a
 tupleOrParenthesized p unit pair = seq' "(" go p
   where
     go _ [t] = t
-    go a xs = foldr pair (unit a) xs
+    go _ xs = foldr pair (unit External) xs
 
 seq :: Ord v => (Ann -> [a] -> a) -> P v a -> P v a
 seq = seq' "["


### PR DESCRIPTION
## Overview

Annotations for patterns weren't being searched in the LSP, and annotation mappings for tuples (and tuple patterns) wasn't working because the tuple constructor is special constructor syntax and spans its arguments.

This adds workarounds or fixes for both of those.

## Implementation notes

* Fixes `findSmallestEnclosingNode` so it searches within patterns using the new `findSmallestEnclosingPattern`
* Re-arrange a couple of the searches to handle special cases for tuples and destructuring binds to work around some quirks in how their annotations work.
* Alter the parenthesized term parser to explicitly handle unit terms, but set the annotation for "implicit units" to `External`, since they don't exist in the file.
* Adds a `Pattern.annotation` combinator to `Unison.Pattern`, serves the same purpose as `ABT.annotation`

## Test coverage

Added new regression tests for both of these fixes.
