### PR TITLE
Fix some bugs in racket/unison/core.ss

### DIFF
--- a/scheme-libs/racket/unison/Readme.md
+++ b/scheme-libs/racket/unison/Readme.md
@@ -1,0 +1,9 @@
+# Racket unison!
+
+To load these libraries into a racket runtime, racket should be invoked like this:
+```bash
+$ racket -S scheme-libs/racket
+Welcome to Racket v8.7 [cs].
+> (require unison/core)
+> ; now you can try out the definitions in core.ss!
+```

--- a/scheme-libs/racket/unison/core.ss
+++ b/scheme-libs/racket/unison/core.ss
@@ -28,7 +28,7 @@
     freeze-bytevector!
     freeze-vector!)
 
-  (import (rnrs) (racket exn))
+  (import (rnrs) (racket exn) (racket unsafe ops) (unison isolated-string-copy))
 
   (define (fx1- n) (fx- n 1))
 

--- a/scheme-libs/racket/unison/isolated-string-copy.rkt
+++ b/scheme-libs/racket/unison/isolated-string-copy.rkt
@@ -5,7 +5,7 @@
 ; as racket/base has name clashes with rnrs
 ; and the #r6rs language can't handle name
 ; clashes (the normal racket language can)
-(module nother racket
+(module isolated-string-copy racket
     (provide string-copy!)
 
     (require racket/base))

--- a/scheme-libs/racket/unison/isolated-string-copy.rkt
+++ b/scheme-libs/racket/unison/isolated-string-copy.rkt
@@ -1,3 +1,4 @@
+#lang racket/base
 ; This library exists solely to
 ; export "string-copy!" for use by "core.ss"
 ;
@@ -5,7 +6,7 @@
 ; as racket/base has name clashes with rnrs
 ; and the #r6rs language can't handle name
 ; clashes (the normal racket language can)
-(module isolated-string-copy racket
-    (provide string-copy!)
 
-    (require racket/base))
+(provide string-copy!)
+
+(require racket/base)

--- a/scheme-libs/racket/unison/isolated-string-copy.rkt
+++ b/scheme-libs/racket/unison/isolated-string-copy.rkt
@@ -1,0 +1,11 @@
+; This library exists solely to
+; export "string-copy!" for use by "core.ss"
+;
+; "core.ss" can't require (racket/base) itself,
+; as racket/base has name clashes with rnrs
+; and the #r6rs language can't handle name
+; clashes (the normal racket language can)
+(module nother racket
+    (provide string-copy!)
+
+    (require racket/base))


### PR DESCRIPTION
It's possible I'm just not running it right, but when I tried to evaluate `core.ss` with racket there were some undefined terms, which I solved by adding some requires, and creating the isolated-string-copy.rkt file.

Now `unison/core` is requirable in the racket runtime!