### PR TITLE
switch less args from -r to -R to fix reflog weirdness

### DIFF
--- a/lib/unison-pretty-printer/src/Unison/Util/Less.hs
+++ b/lib/unison-pretty-printer/src/Unison/Util/Less.hs
@@ -48,7 +48,7 @@ less str = do
     lessArgs :: [String]
     lessArgs =
       [ "--no-init", -- don't clear the screen on exit
-        "--raw-control-chars", -- pass through colors and stuff
+        "--RAW-CONTROL-CHARS", -- pass through colors and stuff
         "--prompt=[less] Use space/arrow keys to navigate, or 'q' to return to ucm:",
         "--quit-if-one-screen" -- self-explanatory
       ]


### PR DESCRIPTION
## Overview

Switched `less` arg from the not-recommended: 

       -r or --raw-control-chars
              Causes "raw" control characters to be displayed.  The default is
              to display control characters using the caret notation; for
              example, a control-A (octal 001) is displayed as "^A".  Warning:
              when the -r option is used, less cannot keep track of the actual
              appearance of the screen (since this depends on how the screen
              responds to each type of control character).  Thus, various
              display problems may result, such as long lines being split in
              the wrong place.

              USE OF THE -r OPTION IS NOT RECOMMENDED.

to the not-not-recommended:

       -R or --RAW-CONTROL-CHARS
              Like -r, but only ANSI "color" escape sequences and OSC 8
              hyperlink sequences are output in "raw" form.  Unlike -r, the
              screen appearance is maintained correctly, provided that there
              are no escape sequences in the file other than these types of
              escape sequences.  Color escape sequences are only supported
              when the color is changed within one line, not across lines.  In
              other words, the beginning of each line is assumed to be normal
              (non-colored), regardless of any escape sequences in previous
              lines.  For the purpose of keeping track of screen appearance,
              these escape sequences are assumed to not move the cursor.

No screenshots, but I can reproduce the problem without this PR and can't reproduce with the PR.

Fixes #3551

## Loose ends

Only tested on macOS. @stew or @mitchellwrosen or @tstat could you try it on Linux?