### PR TITLE
Various racket related fixes/changes

### DIFF
--- a/scheme-libs/chez/unison/core.ss
+++ b/scheme-libs/chez/unison/core.ss
@@ -28,7 +28,9 @@
     string-copy!
 
     freeze-bytevector!
-    freeze-vector!)
+    freeze-vector!
+
+    bytevector)
 
   (import (chezscheme))
 

--- a/scheme-libs/common/unison/bytevector.ss
+++ b/scheme-libs/common/unison/bytevector.ss
@@ -5,6 +5,7 @@
 ; implements all the functions we'd want. This library exports the
 ; desired functionality on top of an unsafe in-place freeze
 ; re-exported from the (unison core) module.
+#!r6rs
 (library (unison bytevector)
   (export
     freeze-bytevector!

--- a/scheme-libs/common/unison/primops.ss
+++ b/scheme-libs/common/unison/primops.ss
@@ -21,6 +21,7 @@
 ; Unison.Runtime.Builtin, so the POp/FOp implementation must
 ; take/return arguments that match what is expected in those wrappers.
 
+#!r6rs
 (library (unison primops)
   (export
     ; unison-FOp-Bytes.decodeNat16be

--- a/scheme-libs/common/unison/string.ss
+++ b/scheme-libs/common/unison/string.ss
@@ -4,6 +4,7 @@
 ; entirely in terms of immutable strings. This module takes the
 ; freezing function, re-exported by (unison core) and implements the
 ; API needed for unison.
+#!r6rs
 (library (unison string)
   (export
     istring

--- a/scheme-libs/common/unison/vector.ss
+++ b/scheme-libs/common/unison/vector.ss
@@ -1,4 +1,5 @@
 
+#!r6rs
 (library (unison vector)
   (export
     freeze-vector!


### PR DESCRIPTION
- Put `#!r6rs` on common modules. This is apparently a scheme comment, but is used by racket to know which language mode to use to parse things.
- Racket doesn't seem to support `#vu8` syntax for bytevectors, so instead export a common `(bytevector ...)` function from `(unison core)` for creation. This has to be a rename on racket, because apparently the standard scheme bytevector is called "bytes" there.
- Import `(racket unsafe ops)` in `(unison core)` for various freezing operations.
- Reimplement record-case macro for racket, it seems to work now
- Implement some dynamic scoping via continuation marks. This is untested as yet, but at least passes syntax checking for generated libraries. No chez equivalent yet, because that part of the continuation library hasn't been implemented.
- Tweaks in `HandleInput` to do `run.native` via racket. The chez code is still there, so that there can be an option to toggle later, but right now use of racket is hard coded. The `compile.native` command is still using the chez commands, until I can figure out how to call the appropriate `raco` command.

So far, I've run my test case of Runar's array sort via `run.native` using racket, and it works. That doesn't actually use any ability control flow (when run successfully) though, so I'm unsure if that's actually working yet.