### PR TITLE
Builtins test suite no longer uses IO refs

### DIFF
--- a/scheme-libs/racket/unison/crypto.ss
+++ b/scheme-libs/racket/unison/crypto.ss
@@ -1,0 +1,11 @@
+#!r6rs
+;; stubbed out just to avoid import error, replace with real thing
+(library (unison crypto)
+  (export
+    unison-FOp-crypto.HashAlgorithm.Sha1
+    unison-FOp-crypto.hashBytes)
+
+  (import (rnrs))
+
+  (define (unison-FOp-crypto.HashAlgorithm.Sha1) (lambda (x) x))
+  (define (unison-FOp-crypto.hashBytes algo text) (algo text)))

--- a/unison-src/builtin-tests/interpreter-tests.output.md
+++ b/unison-src/builtin-tests/interpreter-tests.output.md
@@ -17,6 +17,8 @@ Note: This should be forked off of the codebase created by base.md
       Tests.checkEqual : Text -> a1 -> a1 ->{Tests} ()
       Tests.main       : '{IO, Exception, Tests} ()
                          -> '{IO, Exception} ()
+      Tests.run        : '{IO, Exception, Tests} ()
+                         ->{IO, Exception} Boolean
 
 .> add
 
@@ -29,6 +31,8 @@ Note: This should be forked off of the codebase created by base.md
     Tests.checkEqual : Text -> a1 -> a1 ->{Tests} ()
     Tests.main       : '{IO, Exception, Tests} ()
                        -> '{IO, Exception} ()
+    Tests.run        : '{IO, Exception, Tests} ()
+                       ->{IO, Exception} Boolean
 
 .> load unison-src/builtin-tests/tests.u
 

--- a/unison-src/builtin-tests/interpreter-tests.sh
+++ b/unison-src/builtin-tests/interpreter-tests.sh
@@ -5,7 +5,7 @@ ucm=$(stack exec -- which unison)
 
 base_codebase=${XDG_CACHE_HOME:-"$HOME/.cache"}/unisonlanguage/base.unison
 
-if [ ! -d $base_dir ]; then
+if [ ! -d $base_codebase ]; then
     $ucm transcript -S $base_codebase unison-src/builtin-tests/base.md
 fi
 

--- a/unison-src/builtin-tests/jit-tests.md
+++ b/unison-src/builtin-tests/jit-tests.md
@@ -2,6 +2,7 @@
 Note: This should be forked off of the codebase created by base.md
 
 ```ucm:hide
+.> compile.native.fetch
 .> compile.native.genlibs
 .> load unison-src/builtin-tests/testlib.u
 .> add

--- a/unison-src/builtin-tests/jit-tests.sh
+++ b/unison-src/builtin-tests/jit-tests.sh
@@ -5,7 +5,7 @@ ucm=$(stack exec -- which unison)
 
 base_codebase=${XDG_CACHE_HOME:-"$HOME/.cache"}/unisonlanguage/base.unison
 
-if [ ! -d $base_dir ]; then
+if [ ! -d $base_codebase ]; then
     $ucm transcript -S $base_codebase unison-src/builtin-tests/base.md
 fi
 

--- a/unison-src/builtin-tests/testlib.u
+++ b/unison-src/builtin-tests/testlib.u
@@ -18,37 +18,37 @@ Tests.checkEqual msg a1 a2 =
 
 Tests.main : '{IO,Exception,Tests} () -> '{IO,Exception} ()
 Tests.main suite = do
-  passed = IO.ref 0
-  failed = IO.ref 0
-  h = cases
-    { _ } -> () 
+  if Tests.run suite then ()
+  else bug "test suite failed" 
+
+Tests.run : '{IO,Exception,Tests} () ->{IO,Exception} Boolean
+Tests.run suite =
+  h passed failed = cases
+    { _ } -> (passed, failed) 
     { pass msg -> k } -> 
       printLine (" ✅  " ++ msg)
-      Ref.write passed (Ref.read passed + 1)
-      handle !k with h
+      handle !k with h (passed + 1) failed
     { fail msg reason -> k } -> 
       printLine (" 🆘  " ++ msg ++ "   " ++ reason)
-      Ref.write failed (Ref.read failed + 1)
-      handle !k with h
+      handle !k with h passed (failed + 1)
     { exception msg failure@(Failure _ cause payload) -> k} -> 
       printLine (" 💥  " ++ msg ++ " " ++ cause)
-      Ref.write failed (Ref.read failed + 1)
-      handle !k with h
+      handle !k with h passed (failed + 1)
 
   printLine ""
   printLine "*** Test suite ***"
   printLine ""
 
-  handle !suite with h
+  (passed, failed) = handle !suite with h 0 0 
 
   printLine ""
   printLine ""
   printLine "Summary of results:"
   printLine ""
 
-  if Ref.read failed == 0 then
-    printLine ("  ✅✅✅  " ++ Nat.toText (Ref.read passed) ++ " PASSED")
+  if failed == 0 then
+    printLine ("  ✅✅✅  " ++ Nat.toText passed ++ " PASSED")
   else
-    printLine ("  🆘🆘🆘  " ++ Nat.toText (Ref.read failed) ++ " FAILED, " 
-                           ++ Nat.toText (Ref.read passed) ++ " passed")
-    bug "test suite failed"
+    printLine ("  🆘🆘🆘  " ++ Nat.toText failed ++ " FAILED, " 
+                           ++ Nat.toText passed ++ " passed")
+  failed == 0


### PR DESCRIPTION
Also changed jit-tests.sh to fetch latest scheme generating library and fix a typo in the shell scripts.

With this, when I do `unison-src/builtin-tests/jit-tests.sh`, I now get as far as:

```
*** Test suite ***

result arity mismatch;
 expected number of values not received
  expected: 1
  received: 0
  context...:
   /Users/pchiusano/.local/share/unisonlanguage/scheme-libs/common/unison/boot.ss:86:27: fast-path
   [repeats 3 more times]
   body of "/Users/pchiusano/.cache/unisonlanguage/scheme-tmp/tests.scm"
```

The `*** Test suite ***` is actual Unison code being executed so that's a good sign - that's a message from the test library (`testlib.u`).