### PR TITLE
Add some comments on defining builtin tests in separate .u files

### DIFF
--- a/unison-src/builtin-tests/interpreter-tests.md
+++ b/unison-src/builtin-tests/interpreter-tests.md
@@ -1,9 +1,16 @@
 
 Note: This should be forked off of the codebase created by base.md
 
-```ucm
+```ucm:hide
 .> load unison-src/builtin-tests/testlib.u
 .> add
+```
+
+If you want to define more complex tests somewhere other than `tests.u`, just `load my-tests.u` then `add`,
+then reference those tests (which should be of type `'{IO,Exception,Tests} ()`, written using calls
+to `Tests.check` and `Tests.checkEqual`).
+
+```ucm:hide
 .> load unison-src/builtin-tests/tests.u
 .> add
 ```

--- a/unison-src/builtin-tests/interpreter-tests.output.md
+++ b/unison-src/builtin-tests/interpreter-tests.output.md
@@ -1,56 +1,10 @@
 
 Note: This should be forked off of the codebase created by base.md
 
-```ucm
-.> load unison-src/builtin-tests/testlib.u
+If you want to define more complex tests somewhere other than `tests.u`, just `load my-tests.u` then `add`,
+then reference those tests (which should be of type `'{IO,Exception,Tests} ()`, written using calls
+to `Tests.check` and `Tests.checkEqual`).
 
-  I found and typechecked these definitions in
-  unison-src/builtin-tests/testlib.u. If you do an `add` or
-  `update`, here's how your codebase would change:
-  
-    ⍟ These new definitions are ok to `add`:
-    
-      unique ability Tests
-      Tests.check      : Text
-                         -> '{g, Exception} Boolean
-                         ->{g, Tests} ()
-      Tests.checkEqual : Text -> a1 -> a1 ->{Tests} ()
-      Tests.main       : '{IO, Exception, Tests} ()
-                         -> '{IO, Exception} ()
-      Tests.run        : '{IO, Exception, Tests} ()
-                         ->{IO, Exception} Boolean
-
-.> add
-
-  ⍟ I've added these definitions:
-  
-    unique ability Tests
-    Tests.check      : Text
-                       -> '{g, Exception} Boolean
-                       ->{g, Tests} ()
-    Tests.checkEqual : Text -> a1 -> a1 ->{Tests} ()
-    Tests.main       : '{IO, Exception, Tests} ()
-                       -> '{IO, Exception} ()
-    Tests.run        : '{IO, Exception, Tests} ()
-                       ->{IO, Exception} Boolean
-
-.> load unison-src/builtin-tests/tests.u
-
-  I found and typechecked these definitions in
-  unison-src/builtin-tests/tests.u. If you do an `add` or
-  `update`, here's how your codebase would change:
-  
-    ⍟ These new definitions are ok to `add`:
-    
-      tests : '{IO, Exception} ()
-
-.> add
-
-  ⍟ I've added these definitions:
-  
-    tests : '{IO, Exception} ()
-
-```
 ```ucm
 .> run tests
 

--- a/unison-src/builtin-tests/jit-tests.md
+++ b/unison-src/builtin-tests/jit-tests.md
@@ -6,6 +6,13 @@ Note: This should be forked off of the codebase created by base.md
 .> compile.native.genlibs
 .> load unison-src/builtin-tests/testlib.u
 .> add
+```
+
+If you want to define more complex tests somewhere other than `tests.u`, just `load my-tests.u` then `add`,
+then reference those tests (which should be of type `'{IO,Exception,Tests} ()`, written using calls
+to `Tests.check` and `Tests.checkEqual`).
+
+```ucm:hide
 .> load unison-src/builtin-tests/tests.u
 .> add
 ```

--- a/unison-src/builtin-tests/jit-tests.output.md
+++ b/unison-src/builtin-tests/jit-tests.output.md
@@ -1,6 +1,10 @@
 
 Note: This should be forked off of the codebase created by base.md
 
+If you want to define more complex tests somewhere other than `tests.u`, just `load my-tests.u` then `add`,
+then reference those tests (which should be of type `'{IO,Exception,Tests} ()`, written using calls
+to `Tests.check` and `Tests.checkEqual`).
+
 ```ucm
 .> run.native tests
 

--- a/unison-src/builtin-tests/testlib.u
+++ b/unison-src/builtin-tests/testlib.u
@@ -4,12 +4,14 @@ unique ability Tests where
   fail : Text -> Text -> ()   
   exception : Text -> Failure -> ()
 
+Tests.check : Text -> '{g, Exception} Boolean ->{g, Tests} ()
 Tests.check msg b = 
   match catch b with 
     Left e -> exception msg e
     Right true -> pass msg
     Right false -> fail msg ""
 
+Tests.checkEqual : Text -> a -> a ->{Tests} ()
 Tests.checkEqual msg a1 a2 = 
   match catch '(a1 === a2) with
     Left e -> exception msg e


### PR DESCRIPTION
@SystemFw and I were discussing how to add builtin tests without just dumping them into `tests.u` (for instance, for exercising the network I/O stuff where you create a client / server and send some bytes). I added some commentary to the `jit-tests.md` and `interpreter-tests.md` transcripts on how to do this.