### PR TITLE
Initial bare bones TLS implementation

### DIFF
--- a/scheme-libs/common/unison/boot.ss
+++ b/scheme-libs/common/unison/boot.ss
@@ -153,7 +153,10 @@
   (define-syntax request
     (syntax-rules ()
       [(request r t . args)
-       ((cdr (ref-mark (quote r))) (list (quote r) t . args))]))
+      (let ((ref-mark-result (ref-mark (quote r))))
+        (if (equal? #f ref-mark-result)
+            (raise (list . args))
+            ((cdr ref-mark-result) (list (quote r) t . args))))]))
 
   ; See the explanation of `handle` for a more thorough understanding
   ; of why this is doing two control operations.

--- a/scheme-libs/common/unison/primops.ss
+++ b/scheme-libs/common/unison/primops.ss
@@ -267,7 +267,6 @@
     (list 1 (cdr (command-line))))
 
   (define (unison-FOp-Text.fromUtf8.impl.v3 s)
-  (display "Ok\n")
     (right (bytevector->string s utf-8-transcoder)))
 
   (define (unison-FOp-Text.toUtf8 s)

--- a/scheme-libs/common/unison/primops.ss
+++ b/scheme-libs/common/unison/primops.ss
@@ -142,6 +142,9 @@
     unison-FOp-crypto.HashAlgorithm.Blake2b_512
 
     unison-FOp-IO.clientSocket.impl.v3
+    unison-FOp-IO.closeSocket.impl.v3
+    unison-FOp-IO.socketReceive.impl.v3
+    unison-FOp-IO.socketSend.impl.v3
     unison-FOp-Tls.ClientConfig.default
     unison-FOp-Tls.handshake.impl.v3
     unison-FOp-Tls.newClient.impl.v3
@@ -156,6 +159,7 @@
           (unison crypto)
           (unison data)
           (unison tls)
+          (unison tcp)
           (unison bytevector)
           (unison vector)
           (unison concurrent))

--- a/scheme-libs/common/unison/primops.ss
+++ b/scheme-libs/common/unison/primops.ss
@@ -33,7 +33,7 @@
     unison-FOp-IO.closeFile.impl.v3
     unison-FOp-IO.openFile.impl.v3
     unison-FOp-IO.putBytes.impl.v3
-    ; unison-FOp-Text.fromUtf8.impl.v3
+    unison-FOp-Text.fromUtf8.impl.v3
     unison-FOp-Text.repeat
     unison-FOp-Text.toUtf8
     ; unison-FOp-Value.serialize
@@ -139,12 +139,22 @@
     unison-FOp-crypto.HashAlgorithm.Blake2s_256
     unison-FOp-crypto.HashAlgorithm.Blake2b_256
     unison-FOp-crypto.HashAlgorithm.Blake2b_512
+
+    unison-FOp-IO.clientSocket.impl.v3
+    unison-FOp-Tls.ClientConfig.default
+    unison-FOp-Tls.handshake.impl.v3
+    unison-FOp-Tls.newClient.impl.v3
+    unison-FOp-Tls.receive.impl.v3
+    unison-FOp-Tls.send.impl.v3
+    unison-FOp-Tls.terminate.impl.v3
     )
 
   (import (rnrs)
           (unison core)
           (unison string)
           (unison crypto)
+          (unison data)
+          (unison tls)
           (unison bytevector)
           (unison vector)
           (unison concurrent))
@@ -255,6 +265,10 @@
 
   (define (unison-FOp-IO.getArgs.impl.v1)
     (list 1 (cdr (command-line))))
+
+  (define (unison-FOp-Text.fromUtf8.impl.v3 s)
+  (display "Ok\n")
+    (right (bytevector->string s utf-8-transcoder)))
 
   (define (unison-FOp-Text.toUtf8 s)
     (string->bytevector s utf-8-transcoder))

--- a/scheme-libs/racket/unison/tcp.rkt
+++ b/scheme-libs/racket/unison/tcp.rkt
@@ -1,0 +1,39 @@
+; TLS primitives! Supplied by openssl (libssl)
+#lang racket/base
+(require racket/exn
+         racket/tcp
+         racket/port
+         unison/data
+         openssl)
+
+
+(provide (prefix-out unison-FOp-IO.   (combine-out
+        clientSocket.impl.v3
+        closeSocket.impl.v3
+        socketReceive.impl.v3
+        socketSend.impl.v3))
+)
+
+(define (input socket) (car socket))
+(define (output socket) (car (cdr socket)))
+
+(define (closeSocket.impl.v3 socket)
+    (close-input-port (input socket))
+    (close-output-port (output socket))
+    (right none))
+
+(define (clientSocket.impl.v3 host port)
+    (with-handlers
+        [[exn:fail:network? (lambda (e) (exception "IOFailure" (exn->string e) '()))]
+         [(lambda _ #t) (lambda (e) (exception "MiscFailure" "Unknown exception" e))] ]
+
+        (let-values ([(input output) (tcp-connect host (string->number port))])
+            (right (list input output)))))
+
+(define (socketSend.impl.v3 socket data)
+    (write-bytes data (output socket))
+    (flush-output (output socket))
+    (right none))
+
+(define (socketReceive.impl.v3 socket amt)
+    (right (read-bytes amt (input socket))))

--- a/scheme-libs/racket/unison/tls.rkt
+++ b/scheme-libs/racket/unison/tls.rkt
@@ -24,9 +24,9 @@
 
 (define (clientSocket.impl.v3 host port)
     (with-handlers
-        [[exn:fail:network? (lambda (e) (exception "IOFailure" (exn->string e) ()))]
+        [[exn:fail:network? (lambda (e) (exception "IOFailure" (exn->string e) '()))]
          [(lambda _ #t) (lambda (e) (exception "MiscFailure" "Unknown exception" e))] ]
-    
+
         (let-values ([(input output) (tcp-connect host (string->number port))])
             (right (list input output)))))
 

--- a/scheme-libs/racket/unison/tls.rkt
+++ b/scheme-libs/racket/unison/tls.rkt
@@ -23,8 +23,12 @@
 ; unison-src/transcripts-using-base/net.md
 
 (define (clientSocket.impl.v3 host port)
-    (let-values ([(input output) (tcp-connect host (string->number port))])
-        (right (list input output))))
+    (with-handlers
+        [[exn:fail:network? (lambda (e) (exception "IOFailure" (exn->string e) ()))]
+         [(lambda _ #t) (lambda (e) (exception "MiscFailure" "Unknown exception" e))] ]
+    
+        (let-values ([(input output) (tcp-connect host (string->number port))])
+            (right (list input output)))))
 
 (define (ClientConfig.default host certificateSuffix)
     (list host certificateSuffix))

--- a/scheme-libs/racket/unison/tls.rkt
+++ b/scheme-libs/racket/unison/tls.rkt
@@ -1,0 +1,68 @@
+; TLS primitives! Supplied by openssl (libssl)
+#lang racket/base
+(require ffi/unsafe
+         ffi/unsafe/define
+         racket/exn
+         racket/tcp
+         racket/port
+         unison/data
+         openssl
+         )
+
+(provide
+    (prefix-out unison-FOp-IO.   (combine-out
+        clientSocket.impl.v3))
+    (prefix-out unison-FOp-Tls.  (combine-out
+        ClientConfig.default
+        handshake.impl.v3
+        newClient.impl.v3
+        receive.impl.v3
+        send.impl.v3
+        terminate.impl.v3)))
+
+; tests in here
+; unison-src/transcripts-using-base/net.md
+
+(define (clientSocket.impl.v3 host port)
+    (let-values ([(input output) (tcp-connect host (string->number port))])
+        (right (list input output))))
+
+(define (ClientConfig.default host certificateSuffix)
+    (list host certificateSuffix))
+
+(define (newClient.impl.v3 config socket)
+    (let ([i (car socket)]
+          [o (car (cdr socket))]
+          [hostname (car config)]
+          [cert-suffix (car (cdr config))]
+    )
+    (let-values ([(in out) (ports->ssl-ports
+                                i o
+                                #:hostname hostname
+                                #:close-original? #t
+                                )])
+        (right (cons (cons in out) config)))))
+
+(define (handshake.impl.v3 tls)
+    (let ([ports (car tls)]
+          [config (cdr tls)])
+        (ssl-set-verify! (car ports) #t)
+        (right none)))
+
+(define (send.impl.v3 tls data)
+    (let* ([ports (car tls)]
+           [output (cdr ports)]
+           [config (cdr tls)])
+        (write-bytes data output)
+    (right none)))
+
+(define (receive.impl.v3 tls)
+    (right (port->bytes (car (car tls)) #:close? #f)))
+
+(define (terminate.impl.v3 tls)
+    (let ([ports (car tls)])
+        (ssl-abandon-port (car ports))
+        (ssl-abandon-port (cdr ports))
+        (right none)))
+
+

--- a/scheme-libs/racket/unison/tls.rkt
+++ b/scheme-libs/racket/unison/tls.rkt
@@ -1,34 +1,21 @@
 ; TLS primitives! Supplied by openssl (libssl)
 #lang racket/base
-(require ffi/unsafe
-         ffi/unsafe/define
-         racket/exn
+(require racket/exn
          racket/tcp
          racket/port
          unison/data
          openssl)
 
-(provide
-    (prefix-out unison-FOp-IO.   (combine-out
-        clientSocket.impl.v3))
-    (prefix-out unison-FOp-Tls.  (combine-out
-        ClientConfig.default
-        handshake.impl.v3
-        newClient.impl.v3
-        receive.impl.v3
-        send.impl.v3
-        terminate.impl.v3)))
+(provide (prefix-out unison-FOp-Tls. (combine-out
+    ClientConfig.default
+    handshake.impl.v3
+    newClient.impl.v3
+    receive.impl.v3
+    send.impl.v3
+    terminate.impl.v3)))
 
 ; TODO check out the tests in here
 ; unison-src/transcripts-using-base/net.md
-
-(define (clientSocket.impl.v3 host port)
-    (with-handlers
-        [[exn:fail:network? (lambda (e) (exception "IOFailure" (exn->string e) '()))]
-         [(lambda _ #t) (lambda (e) (exception "MiscFailure" "Unknown exception" e))] ]
-
-        (let-values ([(input output) (tcp-connect host (string->number port))])
-            (right (list input output)))))
 
 (define (ClientConfig.default host certificateSuffix)
     (list host certificateSuffix))


### PR DESCRIPTION
Turns out racket's `openssl` lib did expose the things I needed 🎉

Just enough to make this example work:
```hs
getExample _ =
    socket = Socket.client (HostName "example.com") (Port "443")
    config = ClientConfig.default (HostName "example.com") ""
    tls = base.IO.net.Tls.newClient config socket
    conn = base.IO.net.Tls.handshake tls
    TlsSocket.send conn (toUtf8 "GET /index.html HTTP/1.0\r\n\r\n")
    response = receive tls
    TlsSocket.close conn
    builtin.printLine (base.Text.fromUtf8 response)
```

Open issues:
- [ ] I haven't handled any errors, need to add that
- [ ] I'm ignoring certificateSuffix for now, haven't figured out what that correlates to in racket's lib
- [ ] Text.fromUtf8 will be different, as we're now doing an impl of Text in scheme