### PR TITLE
Some type references were being ignored when compiling code

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/MCode.hs
+++ b/parser-typechecker/src/Unison/Runtime/MCode.hs
@@ -1436,6 +1436,9 @@ sectionTypes _ = []
 
 instrTypes :: Instr -> [Word64]
 instrTypes (Pack _ w _) = [w `shiftR` 16]
+instrTypes (Reset ws) = setToList ws
+instrTypes (Capture w) = [w]
+instrTypes (SetDyn w _) = [w]
 instrTypes _ = []
 
 branchDeps :: Branch -> [Word64]


### PR DESCRIPTION
The existing code was assuming that only references involved in `Pack` instructions were relevant, but this only preserves data type and request information. We need to remember types used in handlers, or else we will think that remote requests are coming from distinct abilities than the ones we are handling.

I don't know of a way to test this, because the error only occurs when using `compile`. I wrote transcripts to try to test it, but since they run in ucm, and it doesn't try to throw things away like the compiling code does. So the transcript ends up having all the types used in handlers, just because they were necessary to define the loading test case.

I have verified locally that a case that used to fail is now working correctly with the new code.