### PR TITLE
Add tryEval to the JIT compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dist-newstyle
 # GHC
 *.hie
 *.prof
+/libb2.dylib

--- a/scheme-libs/chez/unison/concurrent.ss
+++ b/scheme-libs/chez/unison/concurrent.ss
@@ -10,13 +10,13 @@
     promise-try-read
     fork
     kill
-    sleep)
+    sleep
+    try-eval)
 
 
   (define err "This operation is not supported on the pure Chez Scheme
 backend, use the Racket over Chez Scheme backend")
 
-  ;; TODO feels like there is a macro waiting to happen here
   (define (ref-new a) (error err))
   (define (ref-read ref) (error err))
   (define (ref-write ref a) (error err))
@@ -25,5 +25,6 @@ backend, use the Racket over Chez Scheme backend")
   (define (promise-read promise) (error err))
   (define (promise-try-read promise) (error err))
   (define (fork thread-thunk) (error err))
-  (define (kill thread-id) (error err)))
+  (define (kill thread-id) (error err))
+  (define (try-eval thunk) (error err)))
   

--- a/scheme-libs/common/unison/data.ss
+++ b/scheme-libs/common/unison/data.ss
@@ -16,7 +16,8 @@
    either-get
    unit
    false
-   true)
+   true
+   failure)
 
   (import (rnrs))
 
@@ -60,4 +61,11 @@
   (define (left? either) (eq? 0 (car either)))
 
   ; Either a b -> a | b
-  (define (either-get either) (car (cdr either))))
+  (define (either-get either) (car (cdr either)))
+
+  ; a -> Any
+  (define (any a) `(0 ,a))
+
+  ; Type -> Text -> a -> Failure
+  (define (failure typeLink msg a)
+    `(0 ,typeLink ,msg ,(any a))))

--- a/scheme-libs/common/unison/data.ss
+++ b/scheme-libs/common/unison/data.ss
@@ -17,7 +17,9 @@
    unit
    false
    true
-   failure)
+   any
+   failure
+   exception)
 
   (import (rnrs))
 
@@ -66,6 +68,10 @@
   ; a -> Any
   (define (any a) `(0 ,a))
 
-  ; Type -> Text -> a -> Failure
-  (define (failure typeLink msg a)
-    `(0 ,typeLink ,msg ,(any a))))
+  ; Type -> Text -> Any -> Failure
+  (define (failure typeLink msg any)
+    `(0 ,typeLink ,msg ,any))
+
+  ; Type -> Text -> a ->{Exception} b
+  (define (exception typeLink msg a)
+    (failure typeLink msg (any a))))

--- a/scheme-libs/common/unison/primops.ss
+++ b/scheme-libs/common/unison/primops.ss
@@ -328,7 +328,7 @@
   (define (unison-FOp-Scope.array n) (make-vector n))
 
   (define (unison-POp-FORK thunk) (fork thunk))
-  (define (unison-POp-TFRC thunk) (display "stub"))
+  (define (unison-POp-TFRC thunk) (try-eval thunk))
   (define (unison-FOp-IO.delay.impl.v3 micros) (sleep micros))
   (define (unison-FOp-IO.kill.impl.v3 threadId) (kill threadId))
   (define (unison-FOp-Scope.ref a) (ref-new a))

--- a/scheme-libs/common/unison/primops.ss
+++ b/scheme-libs/common/unison/primops.ss
@@ -73,6 +73,7 @@
     unison-FOp-IO.delay.impl.v3
     unison-POp-FORK
     unison-FOp-IO.kill.impl.v3
+    unison-POp-TFRC
 
     unison-POp-ADDN
     unison-POp-ANDN
@@ -327,6 +328,7 @@
   (define (unison-FOp-Scope.array n) (make-vector n))
 
   (define (unison-POp-FORK thunk) (fork thunk))
+  (define (unison-POp-TFRC thunk) (display "stub"))
   (define (unison-FOp-IO.delay.impl.v3 micros) (sleep micros))
   (define (unison-FOp-IO.kill.impl.v3 threadId) (kill threadId))
   (define (unison-FOp-Scope.ref a) (ref-new a))

--- a/scheme-libs/racket/unison/concurrent.ss
+++ b/scheme-libs/racket/unison/concurrent.ss
@@ -35,10 +35,12 @@
                  printf
                  with-handlers
                  exn:break?
+                 exn:fail?
                  exn:fail:read?
                  exn:fail:filesystem?
                  exn:fail:network?
-                 exn:fail?)
+                 exn:fail:contract:divide-by-zero?
+                 exn:fail:contract:non-fixnum-result?)
            (box ref-new)
            (unbox ref-read)
            (set-box! ref-write)
@@ -98,11 +100,16 @@
         (exn:fail:filesystem? e)
         (exn:fail:network? e)))
 
-  ;; TODO Add proper type links to the various exception types once we have them
+  (define (exn:arith? e)
+    (or (exn:fail:contract:divide-by-zero? e)
+        (exn:fail:contract:non-fixnum-result? e)))
+
+  ;; TODO Replace strings with proper type links once we have them
   (define (try-eval thunk)
     (with-handlers
-      ([exn:break? (lambda (e) (exception "ThreadKilled" "thread killed" ()))]
-       [exn:io? (lambda (e) (exception "IOException" (exn->string e) ()))]
-       [exn:fail? (lambda (e) (exception "MiscFailure" (exn->string e) ()))]
+      ([exn:break? (lambda (e) (exception "ThreadKilledFailure" "thread killed" ()))]
+       [exn:io? (lambda (e) (exception "IOFailure" (exn->string e) ()))]
+       [exn:arith? (lambda (e) (exception "ArithmeticFailure" (exn->string e) ()))]
+       [exn:fail? (lambda (e) (exception "RuntimeFailure" (exn->string e) ()))]
        [(lambda (x) #t) (lambda (e) (exception "MiscFailure" "unknown exception" e))])
       (right (thunk)))))

--- a/scheme-libs/racket/unison/concurrent.ss
+++ b/scheme-libs/racket/unison/concurrent.ss
@@ -90,5 +90,6 @@
     (right unit))
 
   (define (try-eval thunk)
-    (with-handlers ([exn:break? (lambda (x) ())])
+    (with-handlers
+      ([exn:break? (lambda (x) (left (failure "reference" "thread killed" ())))])
       (right (thunk)))))

--- a/scheme-libs/racket/unison/concurrent.ss
+++ b/scheme-libs/racket/unison/concurrent.ss
@@ -91,5 +91,4 @@
 
   (define (try-eval thunk)
     (with-handlers ([exn:break? (lambda (x) ())])
-      (display "semi-stub")
-      (thunk))))
+      (right (thunk)))))

--- a/scheme-libs/racket/unison/concurrent.ss
+++ b/scheme-libs/racket/unison/concurrent.ss
@@ -91,5 +91,5 @@
 
   (define (try-eval thunk)
     (with-handlers
-      ([exn:break? (lambda (x) (exception "referenceId" "thread killed" ()))])
+      ([exn:break? (lambda (x) (exception "ThreadKilled" "thread killed" x))])
       (right (thunk)))))

--- a/scheme-libs/racket/unison/concurrent.ss
+++ b/scheme-libs/racket/unison/concurrent.ss
@@ -91,5 +91,5 @@
 
   (define (try-eval thunk)
     (with-handlers
-      ([exn:break? (lambda (x) (left (failure "reference" "thread killed" ())))])
+      ([exn:break? (lambda (x) (exception "referenceId" "thread killed" ()))])
       (right (thunk)))))

--- a/scheme-libs/racket/unison/concurrent.ss
+++ b/scheme-libs/racket/unison/concurrent.ss
@@ -89,6 +89,7 @@
     (break-thread threadId)
     (right unit))
 
+  ;; TODO Add proper type links to the various exception types once we have them
   (define (try-eval thunk)
     (with-handlers
       ([exn:break? (lambda (x) (exception "ThreadKilled" "thread killed" x))])

--- a/scheme-libs/racket/unison/concurrent.ss
+++ b/scheme-libs/racket/unison/concurrent.ss
@@ -12,7 +12,8 @@
     promise-try-read
     fork
     kill
-    sleep)
+    sleep
+    try-eval)
 
   (import (rnrs)
           (rnrs records syntactic)
@@ -86,4 +87,9 @@
 
   (define (kill threadId)
     (break-thread threadId)
-    (right unit)))
+    (right unit))
+
+  (define (try-eval thunk)
+    (with-handlers ([exn:break? (lambda (x) ())])
+      (display "semi-stub")
+      (thunk))))

--- a/scheme-libs/racket/unison/concurrent.ss
+++ b/scheme-libs/racket/unison/concurrent.ss
@@ -103,5 +103,6 @@
     (with-handlers
       ([exn:break? (lambda (e) (exception "ThreadKilled" "thread killed" ()))]
        [exn:io? (lambda (e) (exception "IOException" (exn->string e) ()))]
-       [exn:fail? (lambda (e) (exception "MiscFailure" (exn->string e) ()))])
+       [exn:fail? (lambda (e) (exception "MiscFailure" (exn->string e) ()))]
+       [(lambda (x) #t) (lambda (e) (exception "MiscFailure" "unknown exception" e))])
       (right (thunk)))))

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -2659,7 +2659,7 @@ doFetchCompiler =
         { server = RemoteRepo.DefaultCodeserver,
           repo = ShareUserHandle "unison",
           path =
-            Path.fromList $ NameSegment <$> ["public", "internal", "primops"]
+            Path.fromList $ NameSegment <$> ["public", "internal", "trunk"]
         }
     repo = Just $ ReadRemoteNamespaceShare ns
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -2659,7 +2659,7 @@ doFetchCompiler =
         { server = RemoteRepo.DefaultCodeserver,
           repo = ShareUserHandle "unison",
           path =
-            Path.fromList $ NameSegment <$> ["public", "internal", "trunk"]
+            Path.fromList $ NameSegment <$> ["public", "internal", "primops"]
         }
     repo = Just $ ReadRemoteNamespaceShare ns
 

--- a/unison-src/builtin-tests/base.output.md
+++ b/unison-src/builtin-tests/base.output.md
@@ -4,13 +4,13 @@
 
   ✅
   
-  ✅ Successfully pulled into newly created namespace base.
+  Successfully pulled into newly created namespace base.
 
 .> compile.native.fetch
 
   ✅
   
-  ✅ Successfully updated .unison.internal from
-  dolio.public.internal.trunk.
+  Successfully updated .unison.internal from
+  unison.public.internal.primops.
 
 ```

--- a/unison-src/builtin-tests/base.output.md
+++ b/unison-src/builtin-tests/base.output.md
@@ -11,6 +11,6 @@
   ✅
   
   Successfully updated .unison.internal from
-  unison.public.internal.primops.
+  unison.public.internal.trunk.
 
 ```

--- a/unison-src/builtin-tests/concurrency-tests.u
+++ b/unison-src/builtin-tests/concurrency-tests.u
@@ -86,19 +86,26 @@ forkKillTest = do
   checkEqual "Thread was killed" v "initial"
 
 tryEvalForkTest = do
+  ref = IO.ref "initial"
   t = fork do
-    match catchAll do sleep_ (500 * millis) with
-      Left _ -> unsafeRun! do IO.console.printLine "interrupted"
-      Right _ -> unsafeRun! do IO.console.printLine "finished"
-  sleep_ (600 * millis)
+    match catchAll do sleep_ (400 * millis) with
+      Left _ -> unsafeRun! do Ref.write ref "interrupted"
+      Right _ -> unsafeRun! do Ref.write ref "finished"
+  sleep_ (500 * millis)
+  v = Ref.read ref
+  checkEqual "tryEval is a no-op on success" v "finished"
 
 tryEvalKillTest = do
+  ref = IO.ref "initial"              
   t = fork do
-    match catchAll do sleep_ (500 * millis) with
-      Left _ -> unsafeRun! do IO.console.printLine "interrupted"
-      Right _ -> unsafeRun! do IO.console.printLine "finished"
-  sleep_ (300 * millis)
+    match catchAll do sleep_ (400 * millis) with
+      Left _ -> unsafeRun! do Ref.write ref "interrupted"
+      Right _ -> unsafeRun! do Ref.write ref "finished"
+  sleep_ (200 * millis)
   kill_ t
+  sleep_ (300 * millis)
+  v = Ref.read ref
+  checkEqual "Thread was killed" v "interrupted"
 
 atomicUpdate : Ref {IO} a -> (a -> a) ->{IO} ()
 atomicUpdate ref f =

--- a/unison-src/builtin-tests/concurrency-tests.u
+++ b/unison-src/builtin-tests/concurrency-tests.u
@@ -105,7 +105,7 @@ tryEvalKillTest = do
   kill_ t
   sleep_ (300 * millis)
   v = Ref.read ref
-  checkEqual "Thread was killed" v "interrupted"
+  checkEqual "Thread was killed, with finalisers" v "interrupted"
 
 atomicUpdate : Ref {IO} a -> (a -> a) ->{IO} ()
 atomicUpdate ref f =

--- a/unison-src/builtin-tests/concurrency-tests.u
+++ b/unison-src/builtin-tests/concurrency-tests.u
@@ -1,99 +1,99 @@
 concurrency.tests = do
-  !simpleRefTest
-  !simpleRefTestScope
-  !ticketTest
-  !casTest
-  !promiseSequentialTest
-  !promiseConcurrentTest
-  !forkKillTest
-  !tryEvalForkTest
+  --  !simpleRefTest
+  --  !simpleRefTestScope
+  --  !ticketTest
+  --  !casTest
+  --  !promiseSequentialTest
+  --  !promiseConcurrentTest
+  --  !forkKillTest
+  --  !tryEvalForkTest
   !tryEvalKillTest
-  !fullTest
+  --  !fullTest
 
-simpleRefTest = do
-  r = IO.ref 0
-  Ref.write r 1
-  i = Ref.read r
-  Ref.write r 2
-  j = Ref.read r
-  Ref.write r 5
-  checkEqual "Ref read-write"  (i, j, Ref.read r) (1, 2, 5)
+--  simpleRefTest = do
+--    r = IO.ref 0
+--    Ref.write r 1
+--    i = Ref.read r
+--    Ref.write r 2
+--    j = Ref.read r
+--    Ref.write r 5
+--    checkEqual "Ref read-write"  (i, j, Ref.read r) (1, 2, 5)
 
-simpleRefTestScope = do
-  Scope.run do
-    r = Scope.ref 0
-    Ref.write r 1
-    i = Ref.read r
-    Ref.write r 2
-    j = Ref.read r
-    Ref.write r 5
-    checkEqual "Ref read-write"  (i, j, Ref.read r) (1, 2, 5)
+--  simpleRefTestScope = do
+--    Scope.run do
+--      r = Scope.ref 0
+--      Ref.write r 1
+--      i = Ref.read r
+--      Ref.write r 2
+--      j = Ref.read r
+--      Ref.write r 5
+--      checkEqual "Ref read-write"  (i, j, Ref.read r) (1, 2, 5)
 
-ticketTest = do
- r = IO.ref 3
- t = Ref.readForCas r
- v = Ticket.read t
- checkEqual "Ticket contains the Ref value" v 3
+--  ticketTest = do
+--   r = IO.ref 3
+--   t = Ref.readForCas r
+--   v = Ticket.read t
+--   checkEqual "Ticket contains the Ref value" v 3
 
-casTest = do
-   ref = IO.ref 0
-   ticket = Ref.readForCas ref
-   v1 = Ref.cas ref ticket 5
-   check "CAS is successful is there were no conflicting writes" 'v1
-   Ref.write ref 10
-   v2 = Ref.cas ref ticket 15
-   check "CAS fails when there was an intervening write" '(not v2)
+--  casTest = do
+--     ref = IO.ref 0
+--     ticket = Ref.readForCas ref
+--     v1 = Ref.cas ref ticket 5
+--     check "CAS is successful is there were no conflicting writes" 'v1
+--     Ref.write ref 10
+--     v2 = Ref.cas ref ticket 15
+--     check "CAS fails when there was an intervening write" '(not v2)
 
-promiseSequentialTest = do
-  use Nat eq
-  use Promise read write
-  p = !Promise.new
-  v0 = Promise.tryRead p
-  checkEqual "Promise should be empty when created" v0 None
-  Promise.write_ p 0
-  v1 = read p
-  checkEqual "Promise should read a value that's been written" v1 0
-  Promise.write_ p 1
-  v2 = read p
-  checkEqual "Promise can only be written to once" v2 v1
-  v3 = Promise.tryRead p
-  checkEqual "Once the Promise is full, tryRead is the same as read" v3 (Some v2)
+--  promiseSequentialTest = do
+--    use Nat eq
+--    use Promise read write
+--    p = !Promise.new
+--    v0 = Promise.tryRead p
+--    checkEqual "Promise should be empty when created" v0 None
+--    Promise.write_ p 0
+--    v1 = read p
+--    checkEqual "Promise should read a value that's been written" v1 0
+--    Promise.write_ p 1
+--    v2 = read p
+--    checkEqual "Promise can only be written to once" v2 v1
+--    v3 = Promise.tryRead p
+--    checkEqual "Once the Promise is full, tryRead is the same as read" v3 (Some v2)
 
 millis = 1000
 sleep_ n = unsafeRun! do sleep n
 
-promiseConcurrentTest = do
-  use Nat eq
-  use concurrent fork
-  p = !Promise.new
-  _ = fork do
-     sleep_ (200 * millis)
-     Promise.write p 5
-  v = Promise.read p
-  checkEqual "Reads awaits for completion of the Promise" v 5
+--  promiseConcurrentTest = do
+--    use Nat eq
+--    use concurrent fork
+--    p = !Promise.new
+--    _ = fork do
+--       sleep_ (200 * millis)
+--       Promise.write p 5
+--    v = Promise.read p
+--    checkEqual "Reads awaits for completion of the Promise" v 5
 
 kill_ t = unsafeRun! do concurrent.kill t
 
-forkKillTest = do
-  ref = IO.ref "initial"
-  thread = fork do
-    sleep_ (400 * millis)
-    Ref.write ref "done"
-  sleep_ (200 * millis)
-  kill_ thread
-  sleep_ (300 * millis)
-  v = Ref.read ref
-  checkEqual "Thread was killed" v "initial"
+--  forkKillTest = do
+--    ref = IO.ref "initial"
+--    thread = fork do
+--      sleep_ (400 * millis)
+--      Ref.write ref "done"
+--    sleep_ (200 * millis)
+--    kill_ thread
+--    sleep_ (300 * millis)
+--    v = Ref.read ref
+--    checkEqual "Thread was killed" v "initial"
 
-tryEvalForkTest = do
-  ref = IO.ref "initial"
-  t = fork do
-    match catchAll do sleep_ (400 * millis) with
-      Left _ -> unsafeRun! do Ref.write ref "interrupted"
-      Right _ -> unsafeRun! do Ref.write ref "finished"
-  sleep_ (500 * millis)
-  v = Ref.read ref
-  checkEqual "tryEval is a no-op on success" v "finished"
+--  tryEvalForkTest = do
+--    ref = IO.ref "initial"
+--    t = fork do
+--      match catchAll do sleep_ (400 * millis) with
+--        Left _ -> unsafeRun! do Ref.write ref "interrupted"
+--        Right _ -> unsafeRun! do Ref.write ref "finished"
+--    sleep_ (500 * millis)
+--    v = Ref.read ref
+--    checkEqual "tryEval is a no-op on success" v "finished"
 
 tryEvalKillTest = do
   ref = IO.ref "initial"              
@@ -107,42 +107,42 @@ tryEvalKillTest = do
   v = Ref.read ref
   checkEqual "Thread was killed, with finalisers" v "interrupted"
 
-atomicUpdate : Ref {IO} a -> (a -> a) ->{IO} ()
-atomicUpdate ref f =
-  ticket = Ref.readForCas ref
-  value = f (Ticket.read ticket)
-  if Ref.cas ref ticket value then () else atomicUpdate ref f
+--  atomicUpdate : Ref {IO} a -> (a -> a) ->{IO} ()
+--  atomicUpdate ref f =
+--    ticket = Ref.readForCas ref
+--    value = f (Ticket.read ticket)
+--    if Ref.cas ref ticket value then () else atomicUpdate ref f
 
-spawnN : Nat -> '{IO} a ->{IO} [a]
-spawnN n fa =
-  use Nat eq -
-  use concurrent fork
+--  spawnN : Nat -> '{IO} a ->{IO} [a]
+--  spawnN n fa =
+--    use Nat eq -
+--    use concurrent fork
   
-  go i acc =
-    if eq i 0
-    then acc
-    else
-      value = !Promise.new
-      _ = fork do Promise.write value !fa
-      go (i - 1) (acc :+ value)
+--    go i acc =
+--      if eq i 0
+--      then acc
+--      else
+--        value = !Promise.new
+--        _ = fork do Promise.write value !fa
+--        go (i - 1) (acc :+ value)
 
-  map Promise.read (go n [])
+--    map Promise.read (go n [])
 
-fullTest = do
-  use Nat * + eq -
+--  fullTest = do
+--    use Nat * + eq -
   
-  numThreads = 100
-  iterations = 100
-  expected = numThreads * iterations
+--    numThreads = 100
+--    iterations = 100
+--    expected = numThreads * iterations
 
-  state = IO.ref 0
-  thread n =
-    if eq n 0
-    then ()
-    else 
-      atomicUpdate state (v -> v + 1)
-      thread (n - 1)
-  ignore (spawnN numThreads '(thread iterations))
-  result = Ref.read state
-  checkEqual "The state of the counter is consistent " result expected
+--    state = IO.ref 0
+--    thread n =
+--      if eq n 0
+--      then ()
+--      else 
+--        atomicUpdate state (v -> v + 1)
+--        thread (n - 1)
+--    ignore (spawnN numThreads '(thread iterations))
+--    result = Ref.read state
+--    checkEqual "The state of the counter is consistent " result expected
 

--- a/unison-src/builtin-tests/concurrency-tests.u
+++ b/unison-src/builtin-tests/concurrency-tests.u
@@ -7,6 +7,7 @@ concurrency.tests = do
   !promiseConcurrentTest
   !forkKillTest
   !tryEvalForkTest
+  !tryEvalKillTest
   !fullTest
 
 simpleRefTest = do
@@ -85,6 +86,13 @@ forkKillTest = do
   checkEqual "Thread was killed" v "initial"
 
 tryEvalForkTest = do
+  t = fork do
+    match catchAll do sleep_ (500 * millis) with
+      Left _ -> unsafeRun! do IO.console.printLine "interrupted"
+      Right _ -> unsafeRun! do IO.console.printLine "finished"
+  sleep_ (600 * millis)
+
+tryEvalKillTest = do
   t = fork do
     match catchAll do sleep_ (500 * millis) with
       Left _ -> unsafeRun! do IO.console.printLine "interrupted"

--- a/unison-src/builtin-tests/concurrency-tests.u
+++ b/unison-src/builtin-tests/concurrency-tests.u
@@ -89,7 +89,7 @@ tryEvalForkTest = do
   ref = IO.ref "initial"
   t = fork do
     match catchAll do sleep_ (400 * millis) with
-      Left _ -> unsafeRun! do Ref.write ref "interrupted"
+      Left _ -> ()
       Right _ -> unsafeRun! do Ref.write ref "finished"
   sleep_ (500 * millis)
   v = Ref.read ref
@@ -99,13 +99,13 @@ tryEvalKillTest = do
   ref = IO.ref "initial"              
   t = fork do
     match catchAll do sleep_ (400 * millis) with
-      Left _ -> unsafeRun! do Ref.write ref "interrupted"
+      Left (Failure typ msg a) -> unsafeRun! do Ref.write ref msg
       Right _ -> unsafeRun! do Ref.write ref "finished"
   sleep_ (200 * millis)
   kill_ t
   sleep_ (300 * millis)
   v = Ref.read ref
-  checkEqual "Thread was killed, with finalisers" v "interrupted"
+  checkEqual "Thread was killed, with finalisers" v "thread killed"
 
 atomicUpdate : Ref {IO} a -> (a -> a) ->{IO} ()
 atomicUpdate ref f =

--- a/unison-src/builtin-tests/concurrency-tests.u
+++ b/unison-src/builtin-tests/concurrency-tests.u
@@ -6,7 +6,7 @@ concurrency.tests = do
   !promiseSequentialTest
   !promiseConcurrentTest
   !forkKillTest
-  --  !tryEvalForkTest
+  !tryEvalForkTest
   !fullTest
 
 simpleRefTest = do
@@ -84,7 +84,13 @@ forkKillTest = do
   v = Ref.read ref
   checkEqual "Thread was killed" v "initial"
 
-tryEvalForkTest = bug "Depends on the Exception ability being implemented"
+tryEvalForkTest = do
+  t = fork do
+    match catchAll do sleep_ (500 * millis) with
+      Left _ -> unsafeRun! do IO.console.printLine "interrupted"
+      Right _ -> unsafeRun! do IO.console.printLine "finished"
+  sleep_ (300 * millis)
+  kill_ t
 
 atomicUpdate : Ref {IO} a -> (a -> a) ->{IO} ()
 atomicUpdate ref f =

--- a/unison-src/builtin-tests/concurrency-tests.u
+++ b/unison-src/builtin-tests/concurrency-tests.u
@@ -1,99 +1,99 @@
 concurrency.tests = do
-  --  !simpleRefTest
-  --  !simpleRefTestScope
-  --  !ticketTest
-  --  !casTest
-  --  !promiseSequentialTest
-  --  !promiseConcurrentTest
-  --  !forkKillTest
-  --  !tryEvalForkTest
+  !simpleRefTest
+  !simpleRefTestScope
+  !ticketTest
+  !casTest
+  !promiseSequentialTest
+  !promiseConcurrentTest
+  !forkKillTest
+  !tryEvalForkTest
   !tryEvalKillTest
-  --  !fullTest
+  !fullTest
 
---  simpleRefTest = do
---    r = IO.ref 0
---    Ref.write r 1
---    i = Ref.read r
---    Ref.write r 2
---    j = Ref.read r
---    Ref.write r 5
---    checkEqual "Ref read-write"  (i, j, Ref.read r) (1, 2, 5)
+simpleRefTest = do
+  r = IO.ref 0
+  Ref.write r 1
+  i = Ref.read r
+  Ref.write r 2
+  j = Ref.read r
+  Ref.write r 5
+  checkEqual "Ref read-write"  (i, j, Ref.read r) (1, 2, 5)
 
---  simpleRefTestScope = do
---    Scope.run do
---      r = Scope.ref 0
---      Ref.write r 1
---      i = Ref.read r
---      Ref.write r 2
---      j = Ref.read r
---      Ref.write r 5
---      checkEqual "Ref read-write"  (i, j, Ref.read r) (1, 2, 5)
+simpleRefTestScope = do
+  Scope.run do
+    r = Scope.ref 0
+    Ref.write r 1
+    i = Ref.read r
+    Ref.write r 2
+    j = Ref.read r
+    Ref.write r 5
+    checkEqual "Ref read-write"  (i, j, Ref.read r) (1, 2, 5)
 
---  ticketTest = do
---   r = IO.ref 3
---   t = Ref.readForCas r
---   v = Ticket.read t
---   checkEqual "Ticket contains the Ref value" v 3
+ticketTest = do
+ r = IO.ref 3
+ t = Ref.readForCas r
+ v = Ticket.read t
+ checkEqual "Ticket contains the Ref value" v 3
 
---  casTest = do
---     ref = IO.ref 0
---     ticket = Ref.readForCas ref
---     v1 = Ref.cas ref ticket 5
---     check "CAS is successful is there were no conflicting writes" 'v1
---     Ref.write ref 10
---     v2 = Ref.cas ref ticket 15
---     check "CAS fails when there was an intervening write" '(not v2)
+casTest = do
+   ref = IO.ref 0
+   ticket = Ref.readForCas ref
+   v1 = Ref.cas ref ticket 5
+   check "CAS is successful is there were no conflicting writes" 'v1
+   Ref.write ref 10
+   v2 = Ref.cas ref ticket 15
+   check "CAS fails when there was an intervening write" '(not v2)
 
---  promiseSequentialTest = do
---    use Nat eq
---    use Promise read write
---    p = !Promise.new
---    v0 = Promise.tryRead p
---    checkEqual "Promise should be empty when created" v0 None
---    Promise.write_ p 0
---    v1 = read p
---    checkEqual "Promise should read a value that's been written" v1 0
---    Promise.write_ p 1
---    v2 = read p
---    checkEqual "Promise can only be written to once" v2 v1
---    v3 = Promise.tryRead p
---    checkEqual "Once the Promise is full, tryRead is the same as read" v3 (Some v2)
+promiseSequentialTest = do
+  use Nat eq
+  use Promise read write
+  p = !Promise.new
+  v0 = Promise.tryRead p
+  checkEqual "Promise should be empty when created" v0 None
+  Promise.write_ p 0
+  v1 = read p
+  checkEqual "Promise should read a value that's been written" v1 0
+  Promise.write_ p 1
+  v2 = read p
+  checkEqual "Promise can only be written to once" v2 v1
+  v3 = Promise.tryRead p
+  checkEqual "Once the Promise is full, tryRead is the same as read" v3 (Some v2)
 
 millis = 1000
 sleep_ n = unsafeRun! do sleep n
 
---  promiseConcurrentTest = do
---    use Nat eq
---    use concurrent fork
---    p = !Promise.new
---    _ = fork do
---       sleep_ (200 * millis)
---       Promise.write p 5
---    v = Promise.read p
---    checkEqual "Reads awaits for completion of the Promise" v 5
+promiseConcurrentTest = do
+  use Nat eq
+  use concurrent fork
+  p = !Promise.new
+  _ = fork do
+     sleep_ (200 * millis)
+     Promise.write p 5
+  v = Promise.read p
+  checkEqual "Reads awaits for completion of the Promise" v 5
 
 kill_ t = unsafeRun! do concurrent.kill t
 
---  forkKillTest = do
---    ref = IO.ref "initial"
---    thread = fork do
---      sleep_ (400 * millis)
---      Ref.write ref "done"
---    sleep_ (200 * millis)
---    kill_ thread
---    sleep_ (300 * millis)
---    v = Ref.read ref
---    checkEqual "Thread was killed" v "initial"
+forkKillTest = do
+  ref = IO.ref "initial"
+  thread = fork do
+    sleep_ (400 * millis)
+    Ref.write ref "done"
+  sleep_ (200 * millis)
+  kill_ thread
+  sleep_ (300 * millis)
+  v = Ref.read ref
+  checkEqual "Thread was killed" v "initial"
 
---  tryEvalForkTest = do
---    ref = IO.ref "initial"
---    t = fork do
---      match catchAll do sleep_ (400 * millis) with
---        Left _ -> unsafeRun! do Ref.write ref "interrupted"
---        Right _ -> unsafeRun! do Ref.write ref "finished"
---    sleep_ (500 * millis)
---    v = Ref.read ref
---    checkEqual "tryEval is a no-op on success" v "finished"
+tryEvalForkTest = do
+  ref = IO.ref "initial"
+  t = fork do
+    match catchAll do sleep_ (400 * millis) with
+      Left _ -> unsafeRun! do Ref.write ref "interrupted"
+      Right _ -> unsafeRun! do Ref.write ref "finished"
+  sleep_ (500 * millis)
+  v = Ref.read ref
+  checkEqual "tryEval is a no-op on success" v "finished"
 
 tryEvalKillTest = do
   ref = IO.ref "initial"              
@@ -107,42 +107,42 @@ tryEvalKillTest = do
   v = Ref.read ref
   checkEqual "Thread was killed, with finalisers" v "interrupted"
 
---  atomicUpdate : Ref {IO} a -> (a -> a) ->{IO} ()
---  atomicUpdate ref f =
---    ticket = Ref.readForCas ref
---    value = f (Ticket.read ticket)
---    if Ref.cas ref ticket value then () else atomicUpdate ref f
+atomicUpdate : Ref {IO} a -> (a -> a) ->{IO} ()
+atomicUpdate ref f =
+  ticket = Ref.readForCas ref
+  value = f (Ticket.read ticket)
+  if Ref.cas ref ticket value then () else atomicUpdate ref f
 
---  spawnN : Nat -> '{IO} a ->{IO} [a]
---  spawnN n fa =
---    use Nat eq -
---    use concurrent fork
+spawnN : Nat -> '{IO} a ->{IO} [a]
+spawnN n fa =
+  use Nat eq -
+  use concurrent fork
   
---    go i acc =
---      if eq i 0
---      then acc
---      else
---        value = !Promise.new
---        _ = fork do Promise.write value !fa
---        go (i - 1) (acc :+ value)
+  go i acc =
+    if eq i 0
+    then acc
+    else
+      value = !Promise.new
+      _ = fork do Promise.write value !fa
+      go (i - 1) (acc :+ value)
 
---    map Promise.read (go n [])
+  map Promise.read (go n [])
 
---  fullTest = do
---    use Nat * + eq -
+fullTest = do
+  use Nat * + eq -
   
---    numThreads = 100
---    iterations = 100
---    expected = numThreads * iterations
+  numThreads = 100
+  iterations = 100
+  expected = numThreads * iterations
 
---    state = IO.ref 0
---    thread n =
---      if eq n 0
---      then ()
---      else 
---        atomicUpdate state (v -> v + 1)
---        thread (n - 1)
---    ignore (spawnN numThreads '(thread iterations))
---    result = Ref.read state
---    checkEqual "The state of the counter is consistent " result expected
+  state = IO.ref 0
+  thread n =
+    if eq n 0
+    then ()
+    else 
+      atomicUpdate state (v -> v + 1)
+      thread (n - 1)
+  ignore (spawnN numThreads '(thread iterations))
+  result = Ref.read state
+  checkEqual "The state of the counter is consistent " result expected
 

--- a/unison-src/builtin-tests/concurrency-tests.u
+++ b/unison-src/builtin-tests/concurrency-tests.u
@@ -1,4 +1,4 @@
-concurrency.tests = Tests.main do
+concurrency.tests = do
   !simpleRefTest
   !simpleRefTestScope
   !ticketTest

--- a/unison-src/builtin-tests/interpreter-tests.md
+++ b/unison-src/builtin-tests/interpreter-tests.md
@@ -11,6 +11,11 @@ then reference those tests (which should be of type `'{IO,Exception,Tests} ()`, 
 to `Tests.check` and `Tests.checkEqual`).
 
 ```ucm:hide
+.> load unison-src/builtin-tests/concurrency-tests.u
+.> add
+```
+
+```ucm:hide
 .> load unison-src/builtin-tests/tests.u
 .> add
 ```
@@ -18,13 +23,3 @@ to `Tests.check` and `Tests.checkEqual`).
 ```ucm
 .> run tests
 ```
-
-```ucm:hide
-.> load unison-src/builtin-tests/concurrency-tests.u
-.> add
-```
-
-```ucm
-.> run concurrency.tests
-```
-

--- a/unison-src/builtin-tests/interpreter-tests.output.md
+++ b/unison-src/builtin-tests/interpreter-tests.output.md
@@ -11,9 +11,3 @@ to `Tests.check` and `Tests.checkEqual`).
   ()
 
 ```
-```ucm
-.> run concurrency.tests
-
-  ()
-
-```

--- a/unison-src/builtin-tests/jit-tests.md
+++ b/unison-src/builtin-tests/jit-tests.md
@@ -13,19 +13,15 @@ then reference those tests (which should be of type `'{IO,Exception,Tests} ()`, 
 to `Tests.check` and `Tests.checkEqual`).
 
 ```ucm:hide
+.> load unison-src/builtin-tests/concurrency-tests.u
+.> add
+```
+
+```ucm:hide
 .> load unison-src/builtin-tests/tests.u
 .> add
 ```
 
 ```ucm
 .> run.native tests
-```
-
-```ucm:hide
-.> load unison-src/builtin-tests/concurrency-tests.u
-.> add
-```
-
-```ucm
-.> run.native concurrency.tests
 ```

--- a/unison-src/builtin-tests/jit-tests.output.md
+++ b/unison-src/builtin-tests/jit-tests.output.md
@@ -1,26 +1,9 @@
 
 Note: This should be forked off of the codebase created by base.md
 
-If you want to define more complex tests somewhere other than `tests.u`, just `load my-tests.u` then `add`,
-then reference those tests (which should be of type `'{IO,Exception,Tests} ()`, written using calls
-to `Tests.check` and `Tests.checkEqual`).
-
 ```ucm
-.> run.native tests
-
-  💔💥
-  
-  The program halted with an unhandled exception:
-  
-    Failure
-      (typeLink ANFDecodeError) "unrecognized POp tag" (Any 118)
-  
-  
-  Stack trace:
-    ##raise
-
+.> compile.native.fetch.> compile.native.genlibs.> load unison-src/builtin-tests/testlib.u.> add
 ```
-
 
 
 🛑
@@ -28,14 +11,8 @@ to `Tests.check` and `Tests.checkEqual`).
 The transcript failed due to an error in the stanza above. The error is:
 
 
-  💔💥
+  ❗️
   
-  The program halted with an unhandled exception:
-  
-    Failure
-      (typeLink ANFDecodeError) "unrecognized POp tag" (Any 118)
-  
-  
-  Stack trace:
-    ##raise
+  The server didn't find anything at
+  unison.public.internal.primop-tags
 

--- a/unison-src/builtin-tests/jit-tests.output.md
+++ b/unison-src/builtin-tests/jit-tests.output.md
@@ -9,7 +9,3 @@ to `Tests.check` and `Tests.checkEqual`).
 .> run.native tests
 
 ```
-```ucm
-.> run.native concurrency.tests
-
-```

--- a/unison-src/builtin-tests/jit-tests.output.md
+++ b/unison-src/builtin-tests/jit-tests.output.md
@@ -8,4 +8,34 @@ to `Tests.check` and `Tests.checkEqual`).
 ```ucm
 .> run.native tests
 
+  💔💥
+  
+  The program halted with an unhandled exception:
+  
+    Failure
+      (typeLink ANFDecodeError) "unrecognized POp tag" (Any 118)
+  
+  
+  Stack trace:
+    ##raise
+
 ```
+
+
+
+🛑
+
+The transcript failed due to an error in the stanza above. The error is:
+
+
+  💔💥
+  
+  The program halted with an unhandled exception:
+  
+    Failure
+      (typeLink ANFDecodeError) "unrecognized POp tag" (Any 118)
+  
+  
+  Stack trace:
+    ##raise
+

--- a/unison-src/builtin-tests/jit-tests.output.md
+++ b/unison-src/builtin-tests/jit-tests.output.md
@@ -8,4 +8,6 @@ to `Tests.check` and `Tests.checkEqual`).
 ```ucm
 .> run.native tests
 
+  Scheme evaluation failed.
+
 ```

--- a/unison-src/builtin-tests/jit-tests.output.md
+++ b/unison-src/builtin-tests/jit-tests.output.md
@@ -8,6 +8,4 @@ to `Tests.check` and `Tests.checkEqual`).
 ```ucm
 .> run.native tests
 
-  Scheme evaluation failed.
-
 ```

--- a/unison-src/builtin-tests/jit-tests.output.md
+++ b/unison-src/builtin-tests/jit-tests.output.md
@@ -1,18 +1,11 @@
 
 Note: This should be forked off of the codebase created by base.md
 
+If you want to define more complex tests somewhere other than `tests.u`, just `load my-tests.u` then `add`,
+then reference those tests (which should be of type `'{IO,Exception,Tests} ()`, written using calls
+to `Tests.check` and `Tests.checkEqual`).
+
 ```ucm
-.> compile.native.fetch.> compile.native.genlibs.> load unison-src/builtin-tests/testlib.u.> add
+.> run.native tests
+
 ```
-
-
-🛑
-
-The transcript failed due to an error in the stanza above. The error is:
-
-
-  ❗️
-  
-  The server didn't find anything at
-  unison.public.internal.primop-tags
-

--- a/unison-src/builtin-tests/tests.u
+++ b/unison-src/builtin-tests/tests.u
@@ -24,3 +24,5 @@ tests = Tests.main do
   check "Blake2s_256 hmacBytes" do hmacBytes Blake2s_256 (toUtf8 "key") (toUtf8 "") === 0xs67148074efc0f6741b474ef81c4d98d266e880d372fe723d2569b1d414d234be
   check "Blake2b_256 hmacBytes" do hmacBytes Blake2b_256 (toUtf8 "key") (toUtf8 "") === 0xs4224e1297e51239a642e21f756bde2785716f872298178180d7f3d1d36a5e4e4
   check "Blake2b_512 hmacBytes" do hmacBytes Blake2b_512 (toUtf8 "key") (toUtf8 "") === 0xs019fe04bf010b8d72772e6b46897ecf74b4878c394ff2c4d5cfa0b7cc9bbefcb28c36de23cef03089db9c3d900468c89804f135e9fdef7ec9b3c7abe50ed33d3
+
+  !concurrency.tests

--- a/unison-src/builtin-tests/tests.u
+++ b/unison-src/builtin-tests/tests.u
@@ -1,29 +1,35 @@
 
 tests : '{IO,Exception} ()
 tests = Tests.main do
-  check "Nat.+" do 1 + 1 == 2
-  check "Nat.*" do 10 * 100 == 1000
-  check "Nat./" do 100 / 10 == 10
-
-  -- cryptographic hashing
-  check "Sha1 hashBytes" do hashBytes Sha1 (toUtf8 "") === 0xsda39a3ee5e6b4b0d3255bfef95601890afd80709
-  check "Sha2_256 hashBytes" do hashBytes Sha2_256 (toUtf8 "") === 0xse3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-  check "Sha2_512 hashBytes" do hashBytes Sha2_512 (toUtf8 "") === 0xscf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e
-  check "Sha3_256 hashBytes" do hashBytes Sha3_256 (toUtf8 "") === 0xsa7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a
-  check "Sha3_512 hashBytes" do hashBytes Sha3_512 (toUtf8 "") === 0xsa69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26
-  check "Blake2s_256 hashBytes" do hashBytes Blake2s_256 (toUtf8 "") === 0xs69217a3079908094e11121d042354a7c1f55b6482ca1a51e1b250dfd1ed0eef9
-  check "Blake2b_256 hashBytes" do hashBytes Blake2b_256 (toUtf8 "") === 0xs0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8
-  check "Blake2b_512 hashBytes" do hashBytes Blake2b_512 (toUtf8 "") === 0xs786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce
-
-  -- hmacs
-  check "Sha1 hmacBytes" do hmacBytes Sha1 (toUtf8 "key") (toUtf8 "") === 0xsf42bb0eeb018ebbd4597ae7213711ec60760843f
-  check "Sha2_256 hmacBytes" do hmacBytes Sha2_256 (toUtf8 "key") (toUtf8 "") === 0xs5d5d139563c95b5967b9bd9a8c9b233a9dedb45072794cd232dc1b74832607d0
-  check "Sha2_512 hmacBytes" do hmacBytes Sha2_512 (toUtf8 "key") (toUtf8 "") === 0xs84fa5aa0279bbc473267d05a53ea03310a987cecc4c1535ff29b6d76b8f1444a728df3aadb89d4a9a6709e1998f373566e8f824a8ca93b1821f0b69bc2a2f65e
-  check "Sha3_256 hmacBytes" do hmacBytes Sha3_256 (toUtf8 "key") (toUtf8 "") === 0xs74f3c030ecc36a1835d04a333ebb7fce2688c0c78fb0bcf9592213331c884c75
-  check "Sha3_512 hmacBytes" do hmacBytes Sha3_512 (toUtf8 "key") (toUtf8 "") === 0xs7539119b6367aa902bdc6f558d20c906d6acbd4aba3fd344eb08b0200144a1fa453ff6e7919962358be53f6db2a320d1852c52a3dea3e907070775f7a91f1282
-  check "Blake2s_256 hmacBytes" do hmacBytes Blake2s_256 (toUtf8 "key") (toUtf8 "") === 0xs67148074efc0f6741b474ef81c4d98d266e880d372fe723d2569b1d414d234be
-  check "Blake2b_256 hmacBytes" do hmacBytes Blake2b_256 (toUtf8 "key") (toUtf8 "") === 0xs4224e1297e51239a642e21f756bde2785716f872298178180d7f3d1d36a5e4e4
-  check "Blake2b_512 hmacBytes" do hmacBytes Blake2b_512 (toUtf8 "key") (toUtf8 "") === 0xs019fe04bf010b8d72772e6b46897ecf74b4878c394ff2c4d5cfa0b7cc9bbefcb28c36de23cef03089db9c3d900468c89804f135e9fdef7ec9b3c7abe50ed33d3
-
-  check "bug is caught" do isLeft (catchAll do bug ())
+  !crypto.hash.tests
+  !hmac.tests
   !concurrency.tests
+  check "bug is caught" do isLeft (catchAll do bug ())
+
+crypto.hash.tests = do
+  hash alg = hashBytes alg (toUtf8 "")
+  tag name = name ++ " hashBytes"
+  [
+   ("Sha1", Sha1, 0xsda39a3ee5e6b4b0d3255bfef95601890afd80709),
+   ("Sha2_256", Sha2_256, 0xse3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855),
+   ("Sha2_512", Sha2_512, 0xscf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e),
+   ("Sha3_256", Sha3_256, 0xsa7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a),
+   ("Sha3_512", Sha3_512, 0xsa69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26),
+   ("Blake2s_256", Blake2s_256, 0xs69217a3079908094e11121d042354a7c1f55b6482ca1a51e1b250dfd1ed0eef9),
+   ("Blake2b_256", Blake2b_256, 0xs0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8),
+   ("Blake2b_512", Blake2b_512, 0xs786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce)
+  ] |> List.foreach_ cases (name, alg, res) -> checkEqual (tag name) (hash alg) res
+
+hmac.tests = do
+  hmac alg = hmacBytes alg (toUtf8 "key") (toUtf8 "")
+  tag name = name ++ " hmacBytes"
+  [
+   ("Sha1", Sha1, 0xsf42bb0eeb018ebbd4597ae7213711ec60760843f),
+   ("Sha2_256", Sha2_256, 0xs5d5d139563c95b5967b9bd9a8c9b233a9dedb45072794cd232dc1b74832607d0),
+   ("Sha2_512", Sha2_512, 0xs84fa5aa0279bbc473267d05a53ea03310a987cecc4c1535ff29b6d76b8f1444a728df3aadb89d4a9a6709e1998f373566e8f824a8ca93b1821f0b69bc2a2f65e),
+   ("Sha3_256", Sha3_256, 0xs74f3c030ecc36a1835d04a333ebb7fce2688c0c78fb0bcf9592213331c884c75),
+   ("Sha3_512", Sha3_512, 0xs7539119b6367aa902bdc6f558d20c906d6acbd4aba3fd344eb08b0200144a1fa453ff6e7919962358be53f6db2a320d1852c52a3dea3e907070775f7a91f1282),
+   ("Blake2s_256", Blake2s_256, 0xs67148074efc0f6741b474ef81c4d98d266e880d372fe723d2569b1d414d234be),
+   ("Blake2b_256", Blake2b_256, 0xs4224e1297e51239a642e21f756bde2785716f872298178180d7f3d1d36a5e4e4),
+   ("Blake2b_512", Blake2b_512, 0xs019fe04bf010b8d72772e6b46897ecf74b4878c394ff2c4d5cfa0b7cc9bbefcb28c36de23cef03089db9c3d900468c89804f135e9fdef7ec9b3c7abe50ed33d3)
+  ] |> List.foreach_ cases (name, alg, res) -> checkEqual (tag name) (hmac alg) res

--- a/unison-src/builtin-tests/tests.u
+++ b/unison-src/builtin-tests/tests.u
@@ -25,13 +25,5 @@ tests = Tests.main do
   check "Blake2b_256 hmacBytes" do hmacBytes Blake2b_256 (toUtf8 "key") (toUtf8 "") === 0xs4224e1297e51239a642e21f756bde2785716f872298178180d7f3d1d36a5e4e4
   check "Blake2b_512 hmacBytes" do hmacBytes Blake2b_512 (toUtf8 "key") (toUtf8 "") === 0xs019fe04bf010b8d72772e6b46897ecf74b4878c394ff2c4d5cfa0b7cc9bbefcb28c36de23cef03089db9c3d900468c89804f135e9fdef7ec9b3c7abe50ed33d3
 
+  check "bug is caught" do isLeft (catchAll do bug ())
   !concurrency.tests
-  !foo
-
-
-foo = do
-  match catchAll do bug "nooo!"  with
-    Left (Failure typ msg a) ->
-      IO.console.printLine msg
-      IO.console.printLine "caught there"
-    Right _ -> ()

--- a/unison-src/builtin-tests/tests.u
+++ b/unison-src/builtin-tests/tests.u
@@ -1,28 +1,28 @@
 
 tests : '{IO,Exception} ()
 tests = Tests.main do
-  --  check "Nat.+" do 1 + 1 == 2
-  --  check "Nat.*" do 10 * 100 == 1000
-  --  check "Nat./" do 100 / 10 == 10
+  check "Nat.+" do 1 + 1 == 2
+  check "Nat.*" do 10 * 100 == 1000
+  check "Nat./" do 100 / 10 == 10
 
-  --  -- cryptographic hashing
-  --  check "Sha1 hashBytes" do hashBytes Sha1 (toUtf8 "") === 0xsda39a3ee5e6b4b0d3255bfef95601890afd80709
-  --  check "Sha2_256 hashBytes" do hashBytes Sha2_256 (toUtf8 "") === 0xse3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-  --  check "Sha2_512 hashBytes" do hashBytes Sha2_512 (toUtf8 "") === 0xscf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e
-  --  check "Sha3_256 hashBytes" do hashBytes Sha3_256 (toUtf8 "") === 0xsa7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a
-  --  check "Sha3_512 hashBytes" do hashBytes Sha3_512 (toUtf8 "") === 0xsa69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26
-  --  check "Blake2s_256 hashBytes" do hashBytes Blake2s_256 (toUtf8 "") === 0xs69217a3079908094e11121d042354a7c1f55b6482ca1a51e1b250dfd1ed0eef9
-  --  check "Blake2b_256 hashBytes" do hashBytes Blake2b_256 (toUtf8 "") === 0xs0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8
-  --  check "Blake2b_512 hashBytes" do hashBytes Blake2b_512 (toUtf8 "") === 0xs786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce
+  -- cryptographic hashing
+  check "Sha1 hashBytes" do hashBytes Sha1 (toUtf8 "") === 0xsda39a3ee5e6b4b0d3255bfef95601890afd80709
+  check "Sha2_256 hashBytes" do hashBytes Sha2_256 (toUtf8 "") === 0xse3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+  check "Sha2_512 hashBytes" do hashBytes Sha2_512 (toUtf8 "") === 0xscf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e
+  check "Sha3_256 hashBytes" do hashBytes Sha3_256 (toUtf8 "") === 0xsa7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a
+  check "Sha3_512 hashBytes" do hashBytes Sha3_512 (toUtf8 "") === 0xsa69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26
+  check "Blake2s_256 hashBytes" do hashBytes Blake2s_256 (toUtf8 "") === 0xs69217a3079908094e11121d042354a7c1f55b6482ca1a51e1b250dfd1ed0eef9
+  check "Blake2b_256 hashBytes" do hashBytes Blake2b_256 (toUtf8 "") === 0xs0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8
+  check "Blake2b_512 hashBytes" do hashBytes Blake2b_512 (toUtf8 "") === 0xs786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce
 
-  --  -- hmacs
-  --  check "Sha1 hmacBytes" do hmacBytes Sha1 (toUtf8 "key") (toUtf8 "") === 0xsf42bb0eeb018ebbd4597ae7213711ec60760843f
-  --  check "Sha2_256 hmacBytes" do hmacBytes Sha2_256 (toUtf8 "key") (toUtf8 "") === 0xs5d5d139563c95b5967b9bd9a8c9b233a9dedb45072794cd232dc1b74832607d0
-  --  check "Sha2_512 hmacBytes" do hmacBytes Sha2_512 (toUtf8 "key") (toUtf8 "") === 0xs84fa5aa0279bbc473267d05a53ea03310a987cecc4c1535ff29b6d76b8f1444a728df3aadb89d4a9a6709e1998f373566e8f824a8ca93b1821f0b69bc2a2f65e
-  --  check "Sha3_256 hmacBytes" do hmacBytes Sha3_256 (toUtf8 "key") (toUtf8 "") === 0xs74f3c030ecc36a1835d04a333ebb7fce2688c0c78fb0bcf9592213331c884c75
-  --  check "Sha3_512 hmacBytes" do hmacBytes Sha3_512 (toUtf8 "key") (toUtf8 "") === 0xs7539119b6367aa902bdc6f558d20c906d6acbd4aba3fd344eb08b0200144a1fa453ff6e7919962358be53f6db2a320d1852c52a3dea3e907070775f7a91f1282
-  --  check "Blake2s_256 hmacBytes" do hmacBytes Blake2s_256 (toUtf8 "key") (toUtf8 "") === 0xs67148074efc0f6741b474ef81c4d98d266e880d372fe723d2569b1d414d234be
-  --  check "Blake2b_256 hmacBytes" do hmacBytes Blake2b_256 (toUtf8 "key") (toUtf8 "") === 0xs4224e1297e51239a642e21f756bde2785716f872298178180d7f3d1d36a5e4e4
-  --  check "Blake2b_512 hmacBytes" do hmacBytes Blake2b_512 (toUtf8 "key") (toUtf8 "") === 0xs019fe04bf010b8d72772e6b46897ecf74b4878c394ff2c4d5cfa0b7cc9bbefcb28c36de23cef03089db9c3d900468c89804f135e9fdef7ec9b3c7abe50ed33d3
+  -- hmacs
+  check "Sha1 hmacBytes" do hmacBytes Sha1 (toUtf8 "key") (toUtf8 "") === 0xsf42bb0eeb018ebbd4597ae7213711ec60760843f
+  check "Sha2_256 hmacBytes" do hmacBytes Sha2_256 (toUtf8 "key") (toUtf8 "") === 0xs5d5d139563c95b5967b9bd9a8c9b233a9dedb45072794cd232dc1b74832607d0
+  check "Sha2_512 hmacBytes" do hmacBytes Sha2_512 (toUtf8 "key") (toUtf8 "") === 0xs84fa5aa0279bbc473267d05a53ea03310a987cecc4c1535ff29b6d76b8f1444a728df3aadb89d4a9a6709e1998f373566e8f824a8ca93b1821f0b69bc2a2f65e
+  check "Sha3_256 hmacBytes" do hmacBytes Sha3_256 (toUtf8 "key") (toUtf8 "") === 0xs74f3c030ecc36a1835d04a333ebb7fce2688c0c78fb0bcf9592213331c884c75
+  check "Sha3_512 hmacBytes" do hmacBytes Sha3_512 (toUtf8 "key") (toUtf8 "") === 0xs7539119b6367aa902bdc6f558d20c906d6acbd4aba3fd344eb08b0200144a1fa453ff6e7919962358be53f6db2a320d1852c52a3dea3e907070775f7a91f1282
+  check "Blake2s_256 hmacBytes" do hmacBytes Blake2s_256 (toUtf8 "key") (toUtf8 "") === 0xs67148074efc0f6741b474ef81c4d98d266e880d372fe723d2569b1d414d234be
+  check "Blake2b_256 hmacBytes" do hmacBytes Blake2b_256 (toUtf8 "key") (toUtf8 "") === 0xs4224e1297e51239a642e21f756bde2785716f872298178180d7f3d1d36a5e4e4
+  check "Blake2b_512 hmacBytes" do hmacBytes Blake2b_512 (toUtf8 "key") (toUtf8 "") === 0xs019fe04bf010b8d72772e6b46897ecf74b4878c394ff2c4d5cfa0b7cc9bbefcb28c36de23cef03089db9c3d900468c89804f135e9fdef7ec9b3c7abe50ed33d3
 
   !concurrency.tests

--- a/unison-src/builtin-tests/tests.u
+++ b/unison-src/builtin-tests/tests.u
@@ -1,28 +1,28 @@
 
 tests : '{IO,Exception} ()
 tests = Tests.main do
-  check "Nat.+" do 1 + 1 == 2 
-  check "Nat.*" do 10 * 100 == 1000 
-  check "Nat./" do 100 / 10 == 10 
+  --  check "Nat.+" do 1 + 1 == 2
+  --  check "Nat.*" do 10 * 100 == 1000
+  --  check "Nat./" do 100 / 10 == 10
 
-  -- cryptographic hashing
-  check "Sha1 hashBytes" do hashBytes Sha1 (toUtf8 "") === 0xsda39a3ee5e6b4b0d3255bfef95601890afd80709
-  check "Sha2_256 hashBytes" do hashBytes Sha2_256 (toUtf8 "") === 0xse3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-  check "Sha2_512 hashBytes" do hashBytes Sha2_512 (toUtf8 "") === 0xscf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e
-  check "Sha3_256 hashBytes" do hashBytes Sha3_256 (toUtf8 "") === 0xsa7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a
-  check "Sha3_512 hashBytes" do hashBytes Sha3_512 (toUtf8 "") === 0xsa69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26
-  check "Blake2s_256 hashBytes" do hashBytes Blake2s_256 (toUtf8 "") === 0xs69217a3079908094e11121d042354a7c1f55b6482ca1a51e1b250dfd1ed0eef9
-  check "Blake2b_256 hashBytes" do hashBytes Blake2b_256 (toUtf8 "") === 0xs0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8
-  check "Blake2b_512 hashBytes" do hashBytes Blake2b_512 (toUtf8 "") === 0xs786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce
+  --  -- cryptographic hashing
+  --  check "Sha1 hashBytes" do hashBytes Sha1 (toUtf8 "") === 0xsda39a3ee5e6b4b0d3255bfef95601890afd80709
+  --  check "Sha2_256 hashBytes" do hashBytes Sha2_256 (toUtf8 "") === 0xse3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+  --  check "Sha2_512 hashBytes" do hashBytes Sha2_512 (toUtf8 "") === 0xscf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e
+  --  check "Sha3_256 hashBytes" do hashBytes Sha3_256 (toUtf8 "") === 0xsa7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a
+  --  check "Sha3_512 hashBytes" do hashBytes Sha3_512 (toUtf8 "") === 0xsa69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26
+  --  check "Blake2s_256 hashBytes" do hashBytes Blake2s_256 (toUtf8 "") === 0xs69217a3079908094e11121d042354a7c1f55b6482ca1a51e1b250dfd1ed0eef9
+  --  check "Blake2b_256 hashBytes" do hashBytes Blake2b_256 (toUtf8 "") === 0xs0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8
+  --  check "Blake2b_512 hashBytes" do hashBytes Blake2b_512 (toUtf8 "") === 0xs786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce
 
-  -- hmacs
-  check "Sha1 hmacBytes" do hmacBytes Sha1 (toUtf8 "key") (toUtf8 "") === 0xsf42bb0eeb018ebbd4597ae7213711ec60760843f
-  check "Sha2_256 hmacBytes" do hmacBytes Sha2_256 (toUtf8 "key") (toUtf8 "") === 0xs5d5d139563c95b5967b9bd9a8c9b233a9dedb45072794cd232dc1b74832607d0
-  check "Sha2_512 hmacBytes" do hmacBytes Sha2_512 (toUtf8 "key") (toUtf8 "") === 0xs84fa5aa0279bbc473267d05a53ea03310a987cecc4c1535ff29b6d76b8f1444a728df3aadb89d4a9a6709e1998f373566e8f824a8ca93b1821f0b69bc2a2f65e
-  check "Sha3_256 hmacBytes" do hmacBytes Sha3_256 (toUtf8 "key") (toUtf8 "") === 0xs74f3c030ecc36a1835d04a333ebb7fce2688c0c78fb0bcf9592213331c884c75
-  check "Sha3_512 hmacBytes" do hmacBytes Sha3_512 (toUtf8 "key") (toUtf8 "") === 0xs7539119b6367aa902bdc6f558d20c906d6acbd4aba3fd344eb08b0200144a1fa453ff6e7919962358be53f6db2a320d1852c52a3dea3e907070775f7a91f1282
-  check "Blake2s_256 hmacBytes" do hmacBytes Blake2s_256 (toUtf8 "key") (toUtf8 "") === 0xs67148074efc0f6741b474ef81c4d98d266e880d372fe723d2569b1d414d234be
-  check "Blake2b_256 hmacBytes" do hmacBytes Blake2b_256 (toUtf8 "key") (toUtf8 "") === 0xs4224e1297e51239a642e21f756bde2785716f872298178180d7f3d1d36a5e4e4
-  check "Blake2b_512 hmacBytes" do hmacBytes Blake2b_512 (toUtf8 "key") (toUtf8 "") === 0xs019fe04bf010b8d72772e6b46897ecf74b4878c394ff2c4d5cfa0b7cc9bbefcb28c36de23cef03089db9c3d900468c89804f135e9fdef7ec9b3c7abe50ed33d3
+  --  -- hmacs
+  --  check "Sha1 hmacBytes" do hmacBytes Sha1 (toUtf8 "key") (toUtf8 "") === 0xsf42bb0eeb018ebbd4597ae7213711ec60760843f
+  --  check "Sha2_256 hmacBytes" do hmacBytes Sha2_256 (toUtf8 "key") (toUtf8 "") === 0xs5d5d139563c95b5967b9bd9a8c9b233a9dedb45072794cd232dc1b74832607d0
+  --  check "Sha2_512 hmacBytes" do hmacBytes Sha2_512 (toUtf8 "key") (toUtf8 "") === 0xs84fa5aa0279bbc473267d05a53ea03310a987cecc4c1535ff29b6d76b8f1444a728df3aadb89d4a9a6709e1998f373566e8f824a8ca93b1821f0b69bc2a2f65e
+  --  check "Sha3_256 hmacBytes" do hmacBytes Sha3_256 (toUtf8 "key") (toUtf8 "") === 0xs74f3c030ecc36a1835d04a333ebb7fce2688c0c78fb0bcf9592213331c884c75
+  --  check "Sha3_512 hmacBytes" do hmacBytes Sha3_512 (toUtf8 "key") (toUtf8 "") === 0xs7539119b6367aa902bdc6f558d20c906d6acbd4aba3fd344eb08b0200144a1fa453ff6e7919962358be53f6db2a320d1852c52a3dea3e907070775f7a91f1282
+  --  check "Blake2s_256 hmacBytes" do hmacBytes Blake2s_256 (toUtf8 "key") (toUtf8 "") === 0xs67148074efc0f6741b474ef81c4d98d266e880d372fe723d2569b1d414d234be
+  --  check "Blake2b_256 hmacBytes" do hmacBytes Blake2b_256 (toUtf8 "key") (toUtf8 "") === 0xs4224e1297e51239a642e21f756bde2785716f872298178180d7f3d1d36a5e4e4
+  --  check "Blake2b_512 hmacBytes" do hmacBytes Blake2b_512 (toUtf8 "key") (toUtf8 "") === 0xs019fe04bf010b8d72772e6b46897ecf74b4878c394ff2c4d5cfa0b7cc9bbefcb28c36de23cef03089db9c3d900468c89804f135e9fdef7ec9b3c7abe50ed33d3
 
   !concurrency.tests

--- a/unison-src/builtin-tests/tests.u
+++ b/unison-src/builtin-tests/tests.u
@@ -26,3 +26,12 @@ tests = Tests.main do
   check "Blake2b_512 hmacBytes" do hmacBytes Blake2b_512 (toUtf8 "key") (toUtf8 "") === 0xs019fe04bf010b8d72772e6b46897ecf74b4878c394ff2c4d5cfa0b7cc9bbefcb28c36de23cef03089db9c3d900468c89804f135e9fdef7ec9b3c7abe50ed33d3
 
   !concurrency.tests
+  !foo
+
+
+foo = do
+  match catchAll do bug "nooo!"  with
+    Left (Failure typ msg a) ->
+      IO.console.printLine msg
+      IO.console.printLine "caught there"
+    Right _ -> ()


### PR DESCRIPTION
## Overview

Adds tryEval, which catches native failures. The main practical use case is dealing with async exceptions.

## Implementation notes

Uses the native racket mechanism for exceptions.

## Interesting/controversial decisions

Categorises exceptions when possible, using racket's predicates

## Test coverage

Tested the main use case with async exceptions, and tested `bug` as far as possible right now.

## Loose ends

- The JIT compiler doesn't have type links yet, so I'm making up a String tag. They will be replaced once type links are in.
- I didn't fully model the behaviour of `bug`, because we don't have universal toText yet.
-  I will open another PR to add a type link for ThreadKilled on the Haskell side, but I think it's better to merge this one now because it contains helpers to build exceptions that will be useful to add network/file builtins
