### PR TITLE
feat(respect-ucm-host): makes codebase server use the correct host

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -73,3 +73,4 @@ The format for this list: name, GitHub handle
 * Jesse Looney (@jesselooney)
 * Vlad Posmangiu Luchian (@cstml)
 * Andrii Uvarov (@unorsk)
+* Mario Bašić (@mabasic)

--- a/unison-share-api/src/Unison/Server/CodebaseServer.hs
+++ b/unison-share-api/src/Unison/Server/CodebaseServer.hs
@@ -277,7 +277,7 @@ startServer env opts rt codebase onStart = do
   token <- case token opts of
     Just t -> return $ C8.pack t
     _ -> genToken
-  let baseUrl = BaseUrl "http://127.0.0.1" token
+  let baseUrl = BaseUrl (fromMaybe "http://127.0.0.1" (host opts)) token
   let settings =
         defaultSettings
           & maybe id setPort (port opts)


### PR DESCRIPTION
Fixes #2689

## Overview

The environment variable `UCM_HOST` was already parsed, so I have just made it so that it tries to use the value of it or default to "http://127.0.0.1", instead of just defaulting to "http://127.0.0.1".

I've tested it and it works.