### PR TITLE
docs(m1-mac): fixes link to M1 Mac tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If these instructions don't work for you or are incomplete, please file an issue
 
 The build uses [Stack](http://docs.haskellstack.org/). If you don't already have it installed, [follow the install instructions](http://docs.haskellstack.org/en/stable/README.html#how-to-install) for your platform.  (Hint: `brew update && brew install stack`)
 
-If you have not set up the Haskell toolchain before and are trying to contribute to Unison on an M1 Mac, we have [some tips specifically for you](docs/m1-mac-setup-tips.markdown/new).
+If you have not set up the Haskell toolchain before and are trying to contribute to Unison on an M1 Mac, we have [some tips specifically for you](docs/m1-mac-setup-tips.markdown).
 
 ```sh
 $ git clone https://github.com/unisonweb/unison.git


### PR DESCRIPTION
## Overview

Fixes the link to M1 Mac tips for getting started.

Before:
<img width="788" alt="Screenshot 2023-02-24 at 4 18 36 PM" src="https://user-images.githubusercontent.com/3999862/221304200-c1d32826-46d8-447a-9d6c-6889f800b7e0.png">

## Implementation notes

Just a doc update.
