### PR TITLE
Multiline raw text literals

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -227,8 +227,9 @@ pretty0
       --      metaprograms), then it needs to be able to print them (and then the
       --      parser ought to be able to parse them, to maintain symmetry.)
       Boolean' b -> pure . fmt S.BooleanLiteral $ if b then l "true" else l "false"
-      Text' s | Just quotes <- useRaw s -> 
-        pure . fmt S.TextLiteral $ PP.text quotes <> "\n" <> PP.text s <> PP.text quotes
+      Text' s
+        | Just quotes <- useRaw s ->
+            pure . fmt S.TextLiteral $ PP.text quotes <> "\n" <> PP.text s <> PP.text quotes
         where
           -- we only use this syntax if we're not wrapped in something else,
           -- to avoid possible round trip issues if the text ends at an odd column
@@ -238,10 +239,12 @@ pretty0
           ok ch = isPrint ch || ch == '\n' || ch == '\r'
           -- Picks smallest number of surrounding """ to be unique
           n 10 = Nothing -- bail at 10, avoiding quadratic behavior in weird cases
-          n cur = 
-            if null (Text.breakOnAll quotes s) then Just quotes
-            else n (cur + 1)
-            where quotes = Text.pack (replicate cur '"')
+          n cur =
+            if null (Text.breakOnAll quotes s)
+              then Just quotes
+              else n (cur + 1)
+            where
+              quotes = Text.pack (replicate cur '"')
       Text' s -> pure . fmt S.TextLiteral $ l $ U.ushow s
       Char' c -> pure
         . fmt S.CharLiteral

--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -230,9 +230,12 @@ pretty0
       Text' s | Just quotes <- useRaw s -> 
         pure . fmt S.TextLiteral $ PP.text quotes <> "\n" <> PP.text s <> PP.text quotes
         where
-          useRaw _ | p > 0 = Nothing -- only do this 
-          useRaw s | Text.find (== '\n') s == Just '\n' && Text.all isPrint s = n 3
+          -- we only use this syntax if we're not wrapped in something else,
+          -- to avoid possible round trip issues if the text ends at an odd column
+          useRaw _ | p > 0 = Nothing
+          useRaw s | Text.find (== '\n') s == Just '\n' && Text.all ok s = n 3
           useRaw _ = Nothing
+          ok ch = isPrint ch || ch == '\n' || ch == '\r'
           -- Picks smallest number of surrounding """ to be unique
           n 10 = Nothing -- bail at 10, avoiding quadratic behavior in weird cases
           n cur = 

--- a/unison-src/transcripts/text-literals.md
+++ b/unison-src/transcripts/text-literals.md
@@ -16,15 +16,16 @@ The initial newline, if it exists, is ignored.
 """
 
 > lit1
+> Some lit1
 
 lit2 = """"
-This is a raw text literal.
-It can start with 3 or more ",
-and is terminated by the same number of quotes.
-Nothing is escaped. \n
+    This is a raw text literal, indented.
+    It can start with 3 or more ",
+    and is terminated by the same number of quotes.
+    Nothing is escaped. \n
 
-This doesn't terminate the literal - """
-""""
+    This doesn't terminate the literal - """
+    """"
 
 > lit2
 > Some lit2

--- a/unison-src/transcripts/text-literals.md
+++ b/unison-src/transcripts/text-literals.md
@@ -3,7 +3,7 @@
 .> builtins.merge
 ```
 
-This transcript shows some syntax for text literals.
+This transcript shows some syntax for raw text literals.
 
 ```unison
 lit1 = """
@@ -27,4 +27,10 @@ This doesn't terminate the literal - """
 """"
 
 > lit2
+> Some lit2
+```
+
+```ucm
+.> add
+.> view lit1 lit2
 ```

--- a/unison-src/transcripts/text-literals.md
+++ b/unison-src/transcripts/text-literals.md
@@ -1,0 +1,30 @@
+
+```ucm:hide
+.> builtins.merge
+```
+
+This transcript shows some syntax for text literals.
+
+```unison
+lit1 = """
+This is a raw text literal.
+It can start with 3 or more ",
+and is terminated by the same number of quotes.
+Nothing is escaped. \n
+
+The initial newline, if it exists, is ignored.
+"""
+
+> lit1
+
+lit2 = """"
+This is a raw text literal.
+It can start with 3 or more ",
+and is terminated by the same number of quotes.
+Nothing is escaped. \n
+
+This doesn't terminate the literal - """
+""""
+
+> lit2
+```

--- a/unison-src/transcripts/text-literals.output.md
+++ b/unison-src/transcripts/text-literals.output.md
@@ -1,5 +1,5 @@
 
-This transcript shows some syntax for text literals.
+This transcript shows some syntax for raw text literals.
 
 ```unison
 lit1 = """
@@ -23,6 +23,7 @@ This doesn't terminate the literal - """
 """"
 
 > lit2
+> Some lit2
 ```
 
 ```ucm
@@ -46,5 +47,29 @@ This doesn't terminate the literal - """
     21 | > lit2
            ⧩
            "This is a raw text literal.\nIt can start with 3 or more \",\nand is terminated by the same number of quotes.\nNothing is escaped. \\n\n\nThis doesn't terminate the literal - \"\"\"\n"
+  
+    22 | > Some lit2
+           ⧩
+           Some
+             "This is a raw text literal.\nIt can start with 3 or more \",\nand is terminated by the same number of quotes.\nNothing is escaped. \\n\n\nThis doesn't terminate the literal - \"\"\"\n"
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    lit1 : Text
+    lit2 : Text
+
+.> view lit1 lit2
+
+  lit1 : Text
+  lit1 =
+    "This is a raw text literal.\nIt can start with 3 or more \",\nand is terminated by the same number of quotes.\nNothing is escaped. \\n\n\nThe initial newline, if it exists, is ignored.\n"
+  
+  lit2 : Text
+  lit2 =
+    "This is a raw text literal.\nIt can start with 3 or more \",\nand is terminated by the same number of quotes.\nNothing is escaped. \\n\n\nThis doesn't terminate the literal - \"\"\"\n"
 
 ```

--- a/unison-src/transcripts/text-literals.output.md
+++ b/unison-src/transcripts/text-literals.output.md
@@ -1,0 +1,50 @@
+
+This transcript shows some syntax for text literals.
+
+```unison
+lit1 = """
+This is a raw text literal.
+It can start with 3 or more ",
+and is terminated by the same number of quotes.
+Nothing is escaped. \n
+
+The initial newline, if it exists, is ignored.
+"""
+
+> lit1
+
+lit2 = """"
+This is a raw text literal.
+It can start with 3 or more ",
+and is terminated by the same number of quotes.
+Nothing is escaped. \n
+
+This doesn't terminate the literal - """
+""""
+
+> lit2
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      lit1 : Text
+      lit2 : Text
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    10 | > lit1
+           ⧩
+           "This is a raw text literal.\nIt can start with 3 or more \",\nand is terminated by the same number of quotes.\nNothing is escaped. \\n\n\nThe initial newline, if it exists, is ignored.\n"
+  
+    21 | > lit2
+           ⧩
+           "This is a raw text literal.\nIt can start with 3 or more \",\nand is terminated by the same number of quotes.\nNothing is escaped. \\n\n\nThis doesn't terminate the literal - \"\"\"\n"
+
+```

--- a/unison-src/transcripts/text-literals.output.md
+++ b/unison-src/transcripts/text-literals.output.md
@@ -12,15 +12,16 @@ The initial newline, if it exists, is ignored.
 """
 
 > lit1
+> Some lit1
 
 lit2 = """"
-This is a raw text literal.
-It can start with 3 or more ",
-and is terminated by the same number of quotes.
-Nothing is escaped. \n
+    This is a raw text literal, indented.
+    It can start with 3 or more ",
+    and is terminated by the same number of quotes.
+    Nothing is escaped. \n
 
-This doesn't terminate the literal - """
-""""
+    This doesn't terminate the literal - """
+    """"
 
 > lit2
 > Some lit2
@@ -42,16 +43,35 @@ This doesn't terminate the literal - """
 
     10 | > lit1
            ⧩
-           "This is a raw text literal.\nIt can start with 3 or more \",\nand is terminated by the same number of quotes.\nNothing is escaped. \\n\n\nThe initial newline, if it exists, is ignored.\n"
+           """
+           This is a raw text literal.
+           It can start with 3 or more ",
+           and is terminated by the same number of quotes.
+           Nothing is escaped. \n
+           
+           The initial newline, if it exists, is ignored.
+           """
   
-    21 | > lit2
-           ⧩
-           "This is a raw text literal.\nIt can start with 3 or more \",\nand is terminated by the same number of quotes.\nNothing is escaped. \\n\n\nThis doesn't terminate the literal - \"\"\"\n"
-  
-    22 | > Some lit2
+    11 | > Some lit1
            ⧩
            Some
-             "This is a raw text literal.\nIt can start with 3 or more \",\nand is terminated by the same number of quotes.\nNothing is escaped. \\n\n\nThis doesn't terminate the literal - \"\"\"\n"
+             "This is a raw text literal.\nIt can start with 3 or more \",\nand is terminated by the same number of quotes.\nNothing is escaped. \\n\n\nThe initial newline, if it exists, is ignored.\n"
+  
+    22 | > lit2
+           ⧩
+           """"
+           This is a raw text literal, indented.
+           It can start with 3 or more ",
+           and is terminated by the same number of quotes.
+           Nothing is escaped. \n
+           
+           This doesn't terminate the literal - """
+           """"
+  
+    23 | > Some lit2
+           ⧩
+           Some
+             "This is a raw text literal, indented.\nIt can start with 3 or more \",\nand is terminated by the same number of quotes.\nNothing is escaped. \\n\n\nThis doesn't terminate the literal - \"\"\"\n"
 
 ```
 ```ucm
@@ -66,10 +86,24 @@ This doesn't terminate the literal - """
 
   lit1 : Text
   lit1 =
-    "This is a raw text literal.\nIt can start with 3 or more \",\nand is terminated by the same number of quotes.\nNothing is escaped. \\n\n\nThe initial newline, if it exists, is ignored.\n"
+    """
+    This is a raw text literal.
+    It can start with 3 or more ",
+    and is terminated by the same number of quotes.
+    Nothing is escaped. \n
+    
+    The initial newline, if it exists, is ignored.
+    """
   
   lit2 : Text
   lit2 =
-    "This is a raw text literal.\nIt can start with 3 or more \",\nand is terminated by the same number of quotes.\nNothing is escaped. \\n\n\nThis doesn't terminate the literal - \"\"\"\n"
+    """"
+    This is a raw text literal, indented.
+    It can start with 3 or more ",
+    and is terminated by the same number of quotes.
+    Nothing is escaped. \n
+    
+    This doesn't terminate the literal - """
+    """"
 
 ```

--- a/unison-syntax/src/Unison/Syntax/Lexer.hs
+++ b/unison-syntax/src/Unison/Syntax/Lexer.hs
@@ -783,7 +783,13 @@ lexemes' eof =
 
     semi = char ';' $> Semi False
     textual = Textual <$> quoted
-    quoted = char '"' *> P.manyTill (LP.charLiteral <|> sp) (char '"')
+    quoted = quotedRaw <|> quotedSingleLine
+    quotedRaw = do
+      _ <- lit "\"\"\""
+      n <- many (char '"')
+      _ <- optional (char '\n') -- initial newline is skipped
+      P.manyTill P.anySingle (lit (replicate (length n + 3) '"'))
+    quotedSingleLine = char '"' *> P.manyTill (LP.charLiteral <|> sp) (char '"')
       where
         sp = lit "\\s" $> ' '
     character = Character <$> (char '?' *> (spEsc <|> LP.charLiteral))

--- a/unison-syntax/src/Unison/Syntax/Lexer.hs
+++ b/unison-syntax/src/Unison/Syntax/Lexer.hs
@@ -787,9 +787,10 @@ lexemes' eof =
     quotedRaw = do
       _ <- lit "\"\"\""
       n <- many (char '"')
-      col <- column <$> P.lookAhead (P.takeWhileP (Just "spaces") isSpace *> pos)
       _ <- optional (char '\n') -- initial newline is skipped
       s <- P.manyTill P.anySingle (lit (replicate (length n + 3) '"'))
+      col0 <- column <$> pos
+      let col = col0 - (length n) - 3
       let leading = replicate (max 0 (col - 1)) ' '
       -- lines "foo\n" will produce ["foo"]     (ignoring last newline),
       -- lines' "foo\n" will produce ["foo",""] (preserving trailing newline)


### PR DESCRIPTION
Pretty simple. Three or more `"` starts out a text literal, terminated by the same number of consecutive closing quotes. For instance:

```unison
lit1 = """
This is a raw text literal.
It can start with 3 or more ",
and is terminated by the same number of quotes.
Nothing is escaped. \n

The initial newline, if it exists, is ignored.
"""

> lit1
```

This is especially handy when testing out parsing libraries.

The column of the closing quote determines the starting column, and if all lines start with that many spaces, it's stripped from all the lines. This means you can do things like this:

```
foo = 
  """
  uno
  dos
  tres
  """
```

And it works as expected. Thanks to @ceedubs for the suggestion.

## Implementation notes

A small change to the lexer and pretty-printer

## Interesting/controversial decisions

The pretty-printer opportunistically uses this syntax whenever the string contains `\n` and consists solely of printable characters, as long as it's at the top level. If the string is nested inside a function call, say, it won't use the syntax, since that could (I believe) potentially cause round-trip issues if the string ends on a weird column.

## Test coverage

Added a simple transcript to exercise.