### PR TITLE
Fix roundtrip error with block lambdas

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -86,12 +86,12 @@ data AmbientContext = AmbientContext
   { -- The operator precedence of the enclosing context (a number from 0 to 11,
     -- or -1 to render without outer parentheses unconditionally).
     -- Function application has precedence 10.
-    precedence :: Int,
-    blockContext :: BlockContext,
-    infixContext :: InfixContext,
-    imports :: Imports,
-    docContext :: DocLiteralContext,
-    elideUnit :: Bool -- `True` if a `()` at the end of a block should be elided
+    precedence :: !Int,
+    blockContext :: !BlockContext,
+    infixContext :: !InfixContext,
+    imports :: !Imports,
+    docContext :: !DocLiteralContext,
+    elideUnit :: !Bool -- `True` if a `()` at the end of a block should be elided
   }
 
 -- Description of the position of this ABT node, when viewed in the
@@ -470,7 +470,7 @@ pretty0
                 paren (p >= 10) <$> do
                   lastArg' <- pretty0 (ac 10 Normal im doc) lastArg
                   booleanOps (fmt S.ControlKeyword "||") xs lastArg'
-              _ -> case (term, nonForcePred) of
+              _other -> case (term, nonForcePred) of
                 OverappliedBinaryAppPred' f a b r
                   | binaryOpsPred f ->
                       -- Special case for overapplied binary op
@@ -484,16 +484,20 @@ pretty0
                     f' <- pretty0 (ac 10 Normal im doc) f
                     args' <- PP.spacedTraverse (pretty0 (ac 10 Normal im doc)) args
                     pure $ f' `PP.hang` args'
-                _ -> case (term, \v -> nonUnitArgPred v && not (isDelay term)) of
+                _other -> case (term, \v -> nonUnitArgPred v && not (isDelay term)) of
                   (LamsNamedMatch' [] branches, _) -> do
                     pbs <- printCase im doc branches
                     pure . paren (p >= 3) $
                       PP.group (fmt S.ControlKeyword "cases") `PP.hang` pbs
                   LamsNamedPred' vs body -> do
-                    prettyBody <- pretty0 (ac 2 Block im doc) body
+                    prettyBody <- pretty0 (ac 2 Normal im doc) body
+                    let hang = case body of
+                          Delay' (Lets' _ _) -> PP.softHang
+                          Lets' _ _ -> PP.softHang
+                          _ -> PP.hang
                     pure . paren (p >= 3) $
-                      PP.group (varList vs <> fmt S.ControlKeyword " ->") `PP.hang` prettyBody
-                  _ -> go term
+                      PP.group (varList vs <> fmt S.ControlKeyword " ->") `hang` prettyBody
+                  _other -> go term
 
       isDelay (Delay' _) = True
       isDelay _ = False

--- a/unison-src/transcripts-round-trip/main.md
+++ b/unison-src/transcripts-round-trip/main.md
@@ -507,3 +507,38 @@ foo = cases
 ```ucm
 .> load scratch.u
 ```
+
+# Multi-line lambda let
+
+Regression test for #3110 and #3801
+
+```unison:hide
+foreach x f = 
+  _ = List.map f x
+  ()
+
+ignore x = ()
+
+test1 : ()
+test1 =
+  foreach [1, 2, 3] let x -> let
+      y = Nat.increment x
+      ()
+
+test2 = foreach [1, 2, 3] let x -> ignore (Nat.increment x) 
+
+test3 = foreach [1, 2, 3] do x -> do
+  y = Nat.increment x
+  ()
+```
+
+```ucm
+.> add
+.> edit test1 test2 test3 foreach ignore
+.> undo
+```
+
+```ucm
+.> load scratch.u
+```
+

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -34,16 +34,16 @@ x = 1 + 1
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #l7cnk7raag .old`   to make an old namespace
+    `fork #7s9j9tscke .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #l7cnk7raag`  to reset the root namespace and
+    `reset-root #7s9j9tscke`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
        When         Root Hash     Action
-  1.   now          #pdrl1ktsa0   add
-  2.   1 secs ago   #l7cnk7raag   builtins.mergeio
+  1.   now          #42cab6b47j   add
+  2.   1 secs ago   #7s9j9tscke   builtins.mergeio
   3.                #sg60bvjo91   history starts here
   
   Tip: Use `diff.namespace 1 7` to compare namespaces between
@@ -120,18 +120,18 @@ Without the above stanza, the `edit` will send the definition to the most recent
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #l7cnk7raag .old`   to make an old namespace
+    `fork #7s9j9tscke .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #l7cnk7raag`  to reset the root namespace and
+    `reset-root #7s9j9tscke`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
        When         Root Hash     Action
-  1.   now          #7a6vnmv5c9   add
-  2.   now          #l7cnk7raag   reset-root #l7cnk7raag
-  3.   now          #pdrl1ktsa0   add
-  4.   1 secs ago   #l7cnk7raag   builtins.mergeio
+  1.   now          #jsuccp4qsq   add
+  2.   now          #7s9j9tscke   reset-root #7s9j9tscke
+  3.   now          #42cab6b47j   add
+  4.   1 secs ago   #7s9j9tscke   builtins.mergeio
   5.                #sg60bvjo91   history starts here
   
   Tip: Use `diff.namespace 1 7` to compare namespaces between
@@ -199,20 +199,20 @@ f x = let
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #l7cnk7raag .old`   to make an old namespace
+    `fork #7s9j9tscke .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #l7cnk7raag`  to reset the root namespace and
+    `reset-root #7s9j9tscke`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
        When         Root Hash     Action
-  1.   now          #obak7jnhcv   add
-  2.   now          #l7cnk7raag   reset-root #l7cnk7raag
-  3.   now          #7a6vnmv5c9   add
-  4.   now          #l7cnk7raag   reset-root #l7cnk7raag
-  5.   now          #pdrl1ktsa0   add
-  6.   1 secs ago   #l7cnk7raag   builtins.mergeio
+  1.   now          #5nq1cqgki0   add
+  2.   now          #7s9j9tscke   reset-root #7s9j9tscke
+  3.   now          #jsuccp4qsq   add
+  4.   now          #7s9j9tscke   reset-root #7s9j9tscke
+  5.   now          #42cab6b47j   add
+  6.   1 secs ago   #7s9j9tscke   builtins.mergeio
   7.                #sg60bvjo91   history starts here
   
   Tip: Use `diff.namespace 1 7` to compare namespaces between
@@ -285,22 +285,22 @@ h xs = match xs with
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #l7cnk7raag .old`   to make an old namespace
+    `fork #7s9j9tscke .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #l7cnk7raag`  to reset the root namespace and
+    `reset-root #7s9j9tscke`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
        When         Root Hash     Action
-  1.   now          #4skv4f38cf   add
-  2.   now          #l7cnk7raag   reset-root #l7cnk7raag
-  3.   now          #obak7jnhcv   add
-  4.   now          #l7cnk7raag   reset-root #l7cnk7raag
-  5.   now          #7a6vnmv5c9   add
-  6.   now          #l7cnk7raag   reset-root #l7cnk7raag
-  7.   now          #pdrl1ktsa0   add
-  8.   1 secs ago   #l7cnk7raag   builtins.mergeio
+  1.   now          #70m5luveeu   add
+  2.   now          #7s9j9tscke   reset-root #7s9j9tscke
+  3.   now          #5nq1cqgki0   add
+  4.   now          #7s9j9tscke   reset-root #7s9j9tscke
+  5.   now          #jsuccp4qsq   add
+  6.   now          #7s9j9tscke   reset-root #7s9j9tscke
+  7.   now          #42cab6b47j   add
+  8.   1 secs ago   #7s9j9tscke   builtins.mergeio
   9.                #sg60bvjo91   history starts here
   
   Tip: Use `diff.namespace 1 7` to compare namespaces between
@@ -369,24 +369,24 @@ foo n _ = n
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #l7cnk7raag .old`   to make an old namespace
+    `fork #7s9j9tscke .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #l7cnk7raag`  to reset the root namespace and
+    `reset-root #7s9j9tscke`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
         When         Root Hash     Action
-  1.    now          #fdnrhfkoot   add
-  2.    now          #l7cnk7raag   reset-root #l7cnk7raag
-  3.    now          #4skv4f38cf   add
-  4.    now          #l7cnk7raag   reset-root #l7cnk7raag
-  5.    now          #obak7jnhcv   add
-  6.    now          #l7cnk7raag   reset-root #l7cnk7raag
-  7.    now          #7a6vnmv5c9   add
-  8.    now          #l7cnk7raag   reset-root #l7cnk7raag
-  9.    now          #pdrl1ktsa0   add
-  10.   1 secs ago   #l7cnk7raag   builtins.mergeio
+  1.    now          #vniupjo3hs   add
+  2.    now          #7s9j9tscke   reset-root #7s9j9tscke
+  3.    now          #70m5luveeu   add
+  4.    now          #7s9j9tscke   reset-root #7s9j9tscke
+  5.    now          #5nq1cqgki0   add
+  6.    now          #7s9j9tscke   reset-root #7s9j9tscke
+  7.    now          #jsuccp4qsq   add
+  8.    now          #7s9j9tscke   reset-root #7s9j9tscke
+  9.    now          #42cab6b47j   add
+  10.   1 secs ago   #7s9j9tscke   builtins.mergeio
   11.                #sg60bvjo91   history starts here
   
   Tip: Use `diff.namespace 1 7` to compare namespaces between
@@ -452,26 +452,26 @@ foo =
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #l7cnk7raag .old`   to make an old namespace
+    `fork #7s9j9tscke .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #l7cnk7raag`  to reset the root namespace and
+    `reset-root #7s9j9tscke`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
         When         Root Hash     Action
-  1.    now          #dblf9f7ggq   add
-  2.    now          #l7cnk7raag   reset-root #l7cnk7raag
-  3.    now          #fdnrhfkoot   add
-  4.    now          #l7cnk7raag   reset-root #l7cnk7raag
-  5.    now          #4skv4f38cf   add
-  6.    now          #l7cnk7raag   reset-root #l7cnk7raag
-  7.    now          #obak7jnhcv   add
-  8.    now          #l7cnk7raag   reset-root #l7cnk7raag
-  9.    now          #7a6vnmv5c9   add
-  10.   now          #l7cnk7raag   reset-root #l7cnk7raag
-  11.   now          #pdrl1ktsa0   add
-  12.   1 secs ago   #l7cnk7raag   builtins.mergeio
+  1.    now          #u6beqn7af5   add
+  2.    now          #7s9j9tscke   reset-root #7s9j9tscke
+  3.    now          #vniupjo3hs   add
+  4.    now          #7s9j9tscke   reset-root #7s9j9tscke
+  5.    now          #70m5luveeu   add
+  6.    now          #7s9j9tscke   reset-root #7s9j9tscke
+  7.    now          #5nq1cqgki0   add
+  8.    now          #7s9j9tscke   reset-root #7s9j9tscke
+  9.    now          #jsuccp4qsq   add
+  10.   now          #7s9j9tscke   reset-root #7s9j9tscke
+  11.   now          #42cab6b47j   add
+  12.   1 secs ago   #7s9j9tscke   builtins.mergeio
   13.                #sg60bvjo91   history starts here
   
   Tip: Use `diff.namespace 1 7` to compare namespaces between
@@ -875,7 +875,7 @@ broken tvar =
           (cases
             Some _ ->
               "oh boy isn't this a very very very very very very very long string?"
-            None   -> ""))
+            None -> ""))
     
     tvarmodify : tvar -> fun -> ()
     tvarmodify tvar fun = ()
@@ -928,8 +928,8 @@ broken = cases
     broken : Optional Nat -> ()
     broken = cases
       Some
-        loooooooooooooooooooooooooooooooooooooooooooooooooooooooong | loooooooooooooooooooooooooooooooooooooooooooooooooooooooong
-        == 1 ->
+        loooooooooooooooooooooooooooooooooooooooooooooooooooooooong| loooooooooooooooooooooooooooooooooooooooooooooooooooooooong
+        == 1  ->
         ()
   
   You can edit them there, then do `update` to replace the
@@ -994,9 +994,9 @@ foo = let
       go x =
         '(match (a -> a) x with
             SomethingUnusuallyLong
-              lijaefliejalfijelfj aefilaeifhlei liaehjffeafijij 
-              | lijaefliejalfijelfj == aefilaeifhlei   -> 0
-              | lijaefliejalfijelfj == liaehjffeafijij -> 1)
+              lijaefliejalfijelfj aefilaeifhlei liaehjffeafijij
+              | lijaefliejalfijelfj == aefilaeifhlei    -> 0
+              | lijaefliejalfijelfj == liaehjffeafijij  -> 1)
       go (SomethingUnusuallyLong "one" "two" "three")
   
   You can edit them there, then do `update` to replace the
@@ -1375,7 +1375,7 @@ afun x f = f x
 
 roundtripLastLam =
   afun "foo" (n -> let
-    1 + 1
+    _ = 1 + 1
     3
   )
 ```
@@ -1402,7 +1402,7 @@ roundtripLastLam =
     roundtripLastLam : Nat
     roundtripLastLam =
       afun "foo" do
-        1 + 1
+        _ = 1 + 1
         3
   
   You can edit them there, then do `update` to replace the
@@ -1527,5 +1527,104 @@ foo = cases
     ⍟ These new definitions are ok to `add`:
     
       foo : Nat -> Nat -> Nat
+
+```
+# Multi-line lambda let
+
+Regression test for #3110 and #3801
+
+```unison
+foreach x f = 
+  _ = List.map f x
+  ()
+
+ignore x = ()
+
+test1 : ()
+test1 =
+  foreach [1, 2, 3] let x -> let
+      y = Nat.increment x
+      ()
+
+test2 = foreach [1, 2, 3] let x -> ignore (Nat.increment x) 
+
+test3 = foreach [1, 2, 3] do x -> do
+  y = Nat.increment x
+  ()
+```
+
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    foreach : [a] -> (a ->{e} t) ->{e} ()
+    ignore  : x -> ()
+    test1   : ()
+    test2   : ()
+    test3   : ()
+
+.> edit test1 test2 test3 foreach ignore
+
+  ☝️
+  
+  I added these definitions to the top of
+  /Users/runar/work/unison/scratch.u
+  
+    foreach : [a] -> (a ->{e} t) ->{e} ()
+    foreach x f =
+      _ = List.map f x
+      ()
+    
+    ignore : x -> ()
+    ignore x = ()
+    
+    test1 : ()
+    test1 =
+      foreach
+        [1, 2, 3] (x -> let
+          y = Nat.increment x
+          ())
+    
+    test2 : ()
+    test2 = foreach [1, 2, 3] (x -> ignore (Nat.increment x))
+    
+    test3 : ()
+    test3 =
+      foreach
+        [1, 2, 3] '(x -> do
+            y = Nat.increment x
+            ())
+  
+  You can edit them there, then do `update` to replace the
+  definitions currently in this namespace.
+
+.> undo
+
+  Here are the changes I undid
+  
+  Added definitions:
+  
+    1. foreach : [a] -> (a ->{e} t) ->{e} ()
+    2. ignore  : x -> ()
+    3. test1   : ()
+    4. test2   : ()
+    5. test3   : ()
+
+```
+```ucm
+.> load scratch.u
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      foreach : [a] -> (a ->{e} t) ->{e} ()
+      ignore  : x -> ()
+      test1   : ()
+      test2   : ()
+      test3   : ()
 
 ```

--- a/unison-src/transcripts/fix2053.output.md
+++ b/unison-src/transcripts/fix2053.output.md
@@ -2,12 +2,13 @@
 .> display List.map
 
   f a ->
-    go i as acc =
-      match List.at i as with
-        None   -> acc
-        Some a ->
-          use Nat +
-          go (i + 1) as (acc :+ f a)
-    go 0 a []
+    let
+      go i as acc =
+        match List.at i as with
+          None   -> acc
+          Some a ->
+            use Nat +
+            go (i + 1) as (acc :+ f a)
+      go 0 a []
 
 ```

--- a/unison-src/transcripts/fix3265.output.md
+++ b/unison-src/transcripts/fix3265.output.md
@@ -33,19 +33,20 @@ are three cases that need to be 'fixed up.'
           ⧩
           Any
             (w x ->
-              use Nat + drop
-              f1 y =
-                match y with
-                  0 -> w + x
-                  n -> 1 + f0 (drop y 1)
-              f0 y =
-                match y with
-                  0 -> x
-                  n -> 1 + f1 (drop y 1)
-              f2 x = f2 x
-              f3 x y = 1 + y + f2 x
-              g h = h 1 + x
-              g (z -> x + f0 z))
+              let
+                use Nat + drop
+                f1 y =
+                  match y with
+                    0 -> w + x
+                    n -> 1 + f0 (drop y 1)
+                f0 y =
+                  match y with
+                    0 -> x
+                    n -> 1 + f1 (drop y 1)
+                f2 x = f2 x
+                f3 x y = 1 + y + f2 x
+                g h = h 1 + x
+                g (z -> x + f0 z))
 
 ```
 Also check for some possible corner cases.
@@ -77,10 +78,11 @@ discard its arguments, where `f` also occurs.
           ⧩
           Any
             (x ->
-              f x y =
-                match y with
-                  0 -> 0
-                  _ -> f x (f y (Nat.drop y 1))
-              f x 20)
+              let
+                f x y =
+                  match y with
+                    0 -> 0
+                    _ -> f x (f y (Nat.drop y 1))
+                f x 20)
 
 ```


### PR DESCRIPTION
This is an attempt to fix #3110 and #3801 by always forcing a `let` (or `do`) if the body of a lambda is a multi-line block.

There might be a better way of addressing this, but I suspect there's a parser issue that prevents a block being detected after the opening `->` of the lambda body. If always adding the `let` for a block lambda body is controversial, then I can look into that instead.

See transcript output diff for difference in output.
