### PR TITLE
Fix pattern coverage checking bugs

### DIFF
--- a/parser-typechecker/src/Unison/PatternMatchCoverage.hs
+++ b/parser-typechecker/src/Unison/PatternMatchCoverage.hs
@@ -64,7 +64,7 @@ checkMatch ::
 checkMatch matchLocation scrutineeType cases = do
   v0 <- fresh
   grdtree0 <- desugarMatch matchLocation scrutineeType v0 cases
-  (uncovered, grdtree1) <- uncoverAnnotate (Set.singleton (NC.declVar v0 scrutineeType id NC.emptyNormalizedConstraints)) grdtree0
+  (uncovered, grdtree1) <- uncoverAnnotate (Set.singleton (NC.markDirty v0 $ NC.declVar v0 scrutineeType id NC.emptyNormalizedConstraints)) grdtree0
   uncoveredExpanded <- concat . fmap Set.toList <$> traverse (expandSolution v0) (Set.toList uncovered)
   let sols = map (generateInhabitants v0) uncoveredExpanded
   let (_accessible, inaccessible, redundant) = classify grdtree1

--- a/unison-src/transcripts/pattern-match-coverage.md
+++ b/unison-src/transcripts/pattern-match-coverage.md
@@ -280,3 +280,47 @@ test = cases
   _ ++ [true, false, true, false] -> ()
   _ -> ()
 ```
+
+# bugfix: Sufficient data decl map
+
+```unison
+unique type T = A
+
+unit2t : Unit -> T
+unit2t = cases
+  () -> A
+```
+
+```ucm
+.> add
+```
+
+Pattern coverage checking needs the data decl map to contain all 
+transitive type dependencies of the scrutinee type. We do this 
+before typechecking begins in a roundabout way: fetching all
+transitive type dependencies of references that appear in the expression.
+
+This test ensures that we have fetched the `T` type although there is
+no data decl reference to `T` in `witht`.
+```unison
+witht : Unit
+witht = match unit2t () with
+  x -> ()
+```
+
+```unison
+unique type V =
+
+evil : Unit -> V
+evil = bug ""
+```
+
+```ucm
+.> add
+```
+
+```unison:error
+withV : Unit
+withV = match evil () with
+  x -> ()
+```

--- a/unison-src/transcripts/pattern-match-coverage.md
+++ b/unison-src/transcripts/pattern-match-coverage.md
@@ -63,6 +63,14 @@ uninhabited patterns are reported as redundant
 ```unison:error
 unique type V =
 
+test0 : V -> ()
+test0 = cases
+  _ -> ()
+```
+
+```unison:error
+unique type V =
+
 test : Optional (Optional V) -> ()
 test = cases
   None -> ()

--- a/unison-src/transcripts/pattern-match-coverage.output.md
+++ b/unison-src/transcripts/pattern-match-coverage.output.md
@@ -112,6 +112,26 @@ uninhabited patterns are reported as redundant
 ```unison
 unique type V =
 
+test0 : V -> ()
+test0 = cases
+  _ -> ()
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique type V
+      test0 : V -> ()
+
+```
+```unison
+unique type V =
+
 test : Optional (Optional V) -> ()
 test = cases
   None -> ()

--- a/unison-src/transcripts/pattern-match-coverage.output.md
+++ b/unison-src/transcripts/pattern-match-coverage.output.md
@@ -569,3 +569,66 @@ test = cases
     
 
 ```
+# bugfix: Sufficient data decl map
+
+```unison
+unique type T = A
+
+unit2t : Unit -> T
+unit2t = cases
+  () -> A
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique type T
+      unit2t : 'T
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    unique type T
+    unit2t : 'T
+
+```
+Pattern coverage checking needs the data decl map to contain all 
+transitive type dependencies of the scrutinee type. We do this 
+before typechecking begins in a roundabout way: fetching all
+transitive type dependencies of references that appear in the expression.
+
+This test ensures that we have fetched the `T` type although there is
+no data decl reference to `T` in `witht`.
+```unison
+witht : Unit
+witht = match unit2t () with
+  x -> ()
+```
+
+```ucm
+
+  UnknownDecl:
+    data type
+    reference = T
+
+```
+
+
+
+🛑
+
+The transcript failed due to an error in the stanza above. The error is:
+
+
+  UnknownDecl:
+    data type
+    reference = T
+

--- a/unison-src/transcripts/pattern-match-coverage.output.md
+++ b/unison-src/transcripts/pattern-match-coverage.output.md
@@ -119,14 +119,9 @@ test0 = cases
 
 ```ucm
 
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-  
-    ⍟ These new definitions are ok to `add`:
+  This case would be ignored because it's already covered by the preceding case(s):
+        5 |   _ -> ()
     
-      unique type V
-      test0 : V -> ()
 
 ```
 ```unison

--- a/unison-src/transcripts/pattern-match-coverage.output.md
+++ b/unison-src/transcripts/pattern-match-coverage.output.md
@@ -615,20 +615,53 @@ witht = match unit2t () with
 
 ```ucm
 
-  UnknownDecl:
-    data type
-    reference = T
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      witht : ()
 
 ```
+```unison
+unique type V =
 
+evil : Unit -> V
+evil = bug ""
+```
 
+```ucm
 
-🛑
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique type V
+      evil : 'V
 
-The transcript failed due to an error in the stanza above. The error is:
+```
+```ucm
+.> add
 
+  ⍟ I've added these definitions:
+  
+    unique type V
+    evil : 'V
 
-  UnknownDecl:
-    data type
-    reference = T
+```
+```unison
+withV : Unit
+withV = match evil () with
+  x -> ()
+```
 
+```ucm
+
+  This case would be ignored because it's already covered by the preceding case(s):
+        3 |   x -> ()
+    
+
+```


### PR DESCRIPTION
## Overview

Fixes two bugs:

1. Not ensuring patterns that don't impose any constraints are inhabited (test: 2bc28073d3eeb6ed8fc9acdcddba39a49ebe4714, fix: 491366ece0ba8bad3196c73c21bee254af8bc40d)
2. Not populating the data decl map with all type dependencies (test: cc8eeff414becb4b99f7b620cf428d67e55954ae fix: 0c9949b525250d825b1bb5e4477759278cb13cbe)