### PR TITLE
Fix #3861

### DIFF
--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -96,7 +96,6 @@ resolveNames ::
     (Term v, TDNRMap v, TL.TypeLookup v Ann)
 resolveNames typeLookupf preexistingNames uf = do
   let tm = UF.typecheckingTerm uf
-      deps = Term.dependencies tm
       possibleDeps =
         [ (Name.toText name, Var.name v, r)
           | (name, r) <- Rel.toList (Names.terms preexistingNames),
@@ -104,9 +103,7 @@ resolveNames typeLookupf preexistingNames uf = do
             name `Name.endsWithReverseSegments` List.NonEmpty.toList (Name.reverseSegments (Name.unsafeFromVar v))
         ]
       possibleRefs = Referent.toReference . view _3 <$> possibleDeps
-  tl <-
-    lift . lift . fmap (UF.declsToTypeLookup uf <>) $
-      typeLookupf (deps <> Set.fromList possibleRefs)
+  tl <- lift . lift $ fmap (UF.declsToTypeLookup uf <>) (typeLookupf (UF.dependencies uf <> Set.fromList possibleRefs))
   -- For populating the TDNR environment, we pick definitions
   -- from the namespace and from the local file whose full name
   -- has a suffix that equals one of the free variables in the file.

--- a/unison-src/transcripts/pattern-match-coverage.md
+++ b/unison-src/transcripts/pattern-match-coverage.md
@@ -324,3 +324,22 @@ withV : Unit
 withV = match evil () with
   x -> ()
 ```
+
+```unison
+unique type SomeType = A
+```
+
+```ucm
+.> add
+```
+
+```unison
+unique type R = R SomeType
+
+get x = match x with
+  R y -> y
+```
+
+```unison
+unique type R = { someType : SomeType }
+```

--- a/unison-src/transcripts/pattern-match-coverage.output.md
+++ b/unison-src/transcripts/pattern-match-coverage.output.md
@@ -697,20 +697,31 @@ get x = match x with
 
 ```ucm
 
-  UnknownDecl:
-    data type
-    reference = SomeType
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique type R
+      get : R -> SomeType
 
 ```
+```unison
+unique type R = { someType : SomeType }
+```
 
+```ucm
 
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique type R
+      R.someType        : R -> SomeType
+      R.someType.modify : (SomeType ->{g} SomeType) -> R ->{g} R
+      R.someType.set    : SomeType -> R -> R
 
-🛑
-
-The transcript failed due to an error in the stanza above. The error is:
-
-
-  UnknownDecl:
-    data type
-    reference = SomeType
-
+```

--- a/unison-src/transcripts/pattern-match-coverage.output.md
+++ b/unison-src/transcripts/pattern-match-coverage.output.md
@@ -665,3 +665,52 @@ withV = match evil () with
     
 
 ```
+```unison
+unique type SomeType = A
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique type SomeType
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    unique type SomeType
+
+```
+```unison
+unique type R = R SomeType
+
+get x = match x with
+  R y -> y
+```
+
+```ucm
+
+  UnknownDecl:
+    data type
+    reference = SomeType
+
+```
+
+
+
+🛑
+
+The transcript failed due to an error in the stanza above. The error is:
+
+
+  UnknownDecl:
+    data type
+    reference = SomeType
+


### PR DESCRIPTION

## Overview

There is another typechecking codepath that seeded the `TypeLookup` building function with `Term.dependencies` instead of `UnisonFile.dependencies`, so it didn't fetch data decl dependencies.