### PR TITLE
Allow destructuring bind at beginning of do/lambda

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -293,6 +293,10 @@ pretty0
             px <- pretty0 (ac 0 Block im doc) x
             pure . paren (p >= 3) $
               fmt S.ControlKeyword "do" `PP.hang` px
+        | Match' _ _ <- x -> do
+            px <- pretty0 (ac 0 Block im doc) x
+            pure . paren (p >= 3) $
+              fmt S.ControlKeyword "do" `PP.hang` px
         | otherwise -> do
             px <- pretty0 (ac 10 Normal im doc) x
             pure . paren (p >= 11 || isBlock x && p >= 3) $
@@ -354,7 +358,7 @@ pretty0
       --   blah
       -- See `isDestructuringBind` definition.
       Match' scrutinee cs@[MatchCase pat guard (AbsN' vs body)]
-        | p < 1 && isDestructuringBind scrutinee cs -> do
+        | p <= 2 && isDestructuringBind scrutinee cs -> do
             n <- getPPE
             let letIntro = case bc of
                   Block -> id
@@ -514,6 +518,7 @@ pretty0
                     let hang = case body of
                           Delay' (Lets' _ _) -> PP.softHang
                           Lets' _ _ -> PP.softHang
+                          Match' _ _ -> PP.softHang
                           _ -> PP.hang
                     pure . paren (p >= 3) $
                       PP.group (varList vs <> fmt S.ControlKeyword " ->") `hang` prettyBody
@@ -937,6 +942,7 @@ prettyBinding0 a@AmbientContext {imports = im, docContext = doc} v term =
           -- Special case for 'let being on the same line
           let hang = case body' of
                 Delay' (Lets' _ _) -> PP.softHang
+                Delay' (Match' _ _) -> PP.softHang
                 _ -> PP.hang
           pure
             PrettyBinding

--- a/unison-src/transcripts-round-trip/main.md
+++ b/unison-src/transcripts-round-trip/main.md
@@ -547,3 +547,46 @@ test3 = foreach [1, 2, 3] do x -> do
 .> load scratch.u
 ```
 
+# Destructuring bind in delay or lambda
+
+Regression test for https://github.com/unisonweb/unison/issues/3710
+
+```unison:hide
+d1 = do
+  (a,b) = (1,2)
+  (c,d) = (3,4)
+  (e,f) = (5,6)
+  (a,b,c,d,e,f)
+
+d2 = let
+  (a,b) = (1,2)
+  (c,d) = (3,4)
+  (e,f) = (5,6)
+  (a,b,c,d,e,f)
+
+d3 x = let
+  (a,b) = (1,x)
+  (c,d) = (3,4)
+  (e,f) = (5,6)
+  (a,b,c,d,e,f)
+
+d4 x = do
+  (a,b) = (1,x)
+  (c,d) = (3,4)
+  (e,f) = (5,6)
+  (a,b,c,d,e,f)
+
+d5 x = match x with
+  Some x -> x
+  None -> bug "oops"
+```
+
+```ucm
+.> add
+.> edit d1 d2 d3 d4 d5
+.> undo
+```
+
+```ucm
+.> load scratch.u
+```

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -1002,12 +1002,13 @@ foo = let
     foo : 'Nat
     foo =
       go x =
-        '(match (a -> a) x with
+        do
+          match (a -> a) x with
             SomethingUnusuallyLong
               lijaefliejalfijelfj aefilaeifhlei liaehjffeafijij
               | lijaefliejalfijelfj == aefilaeifhlei    -> 0
               | lijaefliejalfijelfj == liaehjffeafijij  -> 1
-            _ -> 2)
+            _ -> 2
       go (SomethingUnusuallyLong "one" "two" "three")
   
   You can edit them there, then do `update` to replace the
@@ -1637,5 +1638,122 @@ test3 = foreach [1, 2, 3] do x -> do
       test1   : ()
       test2   : ()
       test3   : ()
+
+```
+# Destructuring bind in delay or lambda
+
+Regression test for https://github.com/unisonweb/unison/issues/3710
+
+```unison
+d1 = do
+  (a,b) = (1,2)
+  (c,d) = (3,4)
+  (e,f) = (5,6)
+  (a,b,c,d,e,f)
+
+d2 = let
+  (a,b) = (1,2)
+  (c,d) = (3,4)
+  (e,f) = (5,6)
+  (a,b,c,d,e,f)
+
+d3 x = let
+  (a,b) = (1,x)
+  (c,d) = (3,4)
+  (e,f) = (5,6)
+  (a,b,c,d,e,f)
+
+d4 x = do
+  (a,b) = (1,x)
+  (c,d) = (3,4)
+  (e,f) = (5,6)
+  (a,b,c,d,e,f)
+
+d5 x = match x with
+  Some x -> x
+  None -> bug "oops"
+```
+
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    d1 : '(Nat, Nat, Nat, Nat, Nat, Nat)
+    d2 : (Nat, Nat, Nat, Nat, Nat, Nat)
+    d3 : x -> (Nat, x, Nat, Nat, Nat, Nat)
+    d4 : x -> () -> (Nat, x, Nat, Nat, Nat, Nat)
+    d5 : Optional a -> a
+
+.> edit d1 d2 d3 d4 d5
+
+  ☝️
+  
+  I added these definitions to the top of
+  /Users/runar/work/unison/scratch.u
+  
+    d1 : '(Nat, Nat, Nat, Nat, Nat, Nat)
+    d1 = do
+      (a, b) = (1, 2)
+      (c, d) = (3, 4)
+      (e, f) = (5, 6)
+      (a, b, c, d, e, f)
+    
+    d2 : (Nat, Nat, Nat, Nat, Nat, Nat)
+    d2 =
+      (a, b) = (1, 2)
+      (c, d) = (3, 4)
+      (e, f) = (5, 6)
+      (a, b, c, d, e, f)
+    
+    d3 : x -> (Nat, x, Nat, Nat, Nat, Nat)
+    d3 x =
+      (a, b) = (1, x)
+      (c, d) = (3, 4)
+      (e, f) = (5, 6)
+      (a, b, c, d, e, f)
+    
+    d4 : x -> () -> (Nat, x, Nat, Nat, Nat, Nat)
+    d4 x = do
+      (a, b) = (1, x)
+      (c, d) = (3, 4)
+      (e, f) = (5, 6)
+      (a, b, c, d, e, f)
+    
+    d5 : Optional a -> a
+    d5 = cases
+      Some x -> x
+      None   -> bug "oops"
+  
+  You can edit them there, then do `update` to replace the
+  definitions currently in this namespace.
+
+.> undo
+
+  Here are the changes I undid
+  
+  Added definitions:
+  
+    1. d1 : '(Nat, Nat, Nat, Nat, Nat, Nat)
+    2. d2 : (Nat, Nat, Nat, Nat, Nat, Nat)
+    3. d3 : x -> (Nat, x, Nat, Nat, Nat, Nat)
+    4. d4 : x -> () -> (Nat, x, Nat, Nat, Nat, Nat)
+    5. d5 : Optional a -> a
+
+```
+```ucm
+.> load scratch.u
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      d1 : '(Nat, Nat, Nat, Nat, Nat, Nat)
+      d2 : (Nat, Nat, Nat, Nat, Nat, Nat)
+      d3 : x -> (Nat, x, Nat, Nat, Nat, Nat)
+      d4 : x -> '(Nat, x, Nat, Nat, Nat, Nat)
+      d5 : Optional a -> a
 
 ```

--- a/unison-src/transcripts/bug-strange-closure.output.md
+++ b/unison-src/transcripts/bug-strange-closure.output.md
@@ -2669,9 +2669,10 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                                     (Eval
                                       (Term.Term
                                         (Any
-                                          ('(match 1 with
+                                          (do
+                                            match 1 with
                                               1 -> "hi"
-                                              _ -> "goodbye")))))))),
+                                              _ -> "goodbye"))))))),
                             Lit () (Right (Plain "\n")),
                             Lit () (Right (Plain "\n")),
                             Indent


### PR DESCRIPTION
Fixes #3710 

Main changes:

* Allow destructuring bind at the outermost match of a block
* Allow `do` before `match` (and consequently when introducing a block with destructuring binds).

Minor adjustments:

* Allow `do` and `match` to appear at the end the first line of a binding or lambda introduction in more cases.
