### PR TITLE
Add `Md5` builtin to `crypto.HashAlgorithm`

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -74,3 +74,4 @@ The format for this list: name, GitHub handle
 * Vlad Posmangiu Luchian (@cstml)
 * Andrii Uvarov (@unorsk)
 * Mario Bašić (@mabasic)
+* Chris Krycho (@chriskrycho)

--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -762,7 +762,7 @@ hashBuiltins =
     B "crypto.hmac" $ forall1 "a" (\a -> hashAlgo --> bytes --> a --> bytes),
     B "crypto.hmacBytes" $ hashAlgo --> bytes --> bytes --> bytes
   ]
-    ++ map h ["Sha3_512", "Sha3_256", "Sha2_512", "Sha2_256", "Sha1", "Blake2b_512", "Blake2b_256", "Blake2s_256"]
+    ++ map h ["Sha3_512", "Sha3_256", "Sha2_512", "Sha2_256", "Sha1", "Blake2b_512", "Blake2b_256", "Blake2s_256", "Md5"]
   where
     hashAlgo = Type.ref () Type.hashAlgorithmRef
     h name = B ("crypto.HashAlgorithm." <> name) hashAlgo

--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -2633,6 +2633,7 @@ declareForeigns = do
   declareHashAlgorithm "Blake2b_512" Hash.Blake2b_512
   declareHashAlgorithm "Blake2b_256" Hash.Blake2b_256
   declareHashAlgorithm "Blake2s_256" Hash.Blake2s_256
+  declareHashAlgorithm "Md5" Hash.MD5
 
   declareForeign Untracked "crypto.hashBytes" boxBoxDirect . mkForeign $
     \(HashAlgorithm _ alg, b :: Bytes.Bytes) ->

--- a/unison-src/transcripts-using-base/all-base-hashes.output.md
+++ b/unison-src/transcripts-using-base/all-base-hashes.output.md
@@ -412,466 +412,469 @@ This transcript is intended to make visible accidental changes to the hashing al
   126. -- ##crypto.HashAlgorithm.Blake2s_256
        builtin.crypto.HashAlgorithm.Blake2s_256 : HashAlgorithm
        
-  127. -- ##crypto.HashAlgorithm.Sha1
+  127. -- ##crypto.HashAlgorithm.Md5
+       builtin.crypto.HashAlgorithm.Md5 : HashAlgorithm
+       
+  128. -- ##crypto.HashAlgorithm.Sha1
        builtin.crypto.HashAlgorithm.Sha1 : HashAlgorithm
        
-  128. -- ##crypto.HashAlgorithm.Sha2_256
+  129. -- ##crypto.HashAlgorithm.Sha2_256
        builtin.crypto.HashAlgorithm.Sha2_256 : HashAlgorithm
        
-  129. -- ##crypto.HashAlgorithm.Sha2_512
+  130. -- ##crypto.HashAlgorithm.Sha2_512
        builtin.crypto.HashAlgorithm.Sha2_512 : HashAlgorithm
        
-  130. -- ##crypto.HashAlgorithm.Sha3_256
+  131. -- ##crypto.HashAlgorithm.Sha3_256
        builtin.crypto.HashAlgorithm.Sha3_256 : HashAlgorithm
        
-  131. -- ##crypto.HashAlgorithm.Sha3_512
+  132. -- ##crypto.HashAlgorithm.Sha3_512
        builtin.crypto.HashAlgorithm.Sha3_512 : HashAlgorithm
        
-  132. -- ##crypto.hashBytes
+  133. -- ##crypto.hashBytes
        builtin.crypto.hashBytes : HashAlgorithm
        -> Bytes
        -> Bytes
        
-  133. -- ##crypto.hmac
+  134. -- ##crypto.hmac
        builtin.crypto.hmac : HashAlgorithm
        -> Bytes
        -> a
        -> Bytes
        
-  134. -- ##crypto.hmacBytes
+  135. -- ##crypto.hmacBytes
        builtin.crypto.hmacBytes : HashAlgorithm
        -> Bytes
        -> Bytes
        -> Bytes
        
-  135. -- ##Debug.toText
+  136. -- ##Debug.toText
        builtin.Debug.toText : a -> Optional (Either Text Text)
        
-  136. -- ##Debug.trace
+  137. -- ##Debug.trace
        builtin.Debug.trace : Text -> a -> ()
        
-  137. -- ##Debug.watch
+  138. -- ##Debug.watch
        builtin.Debug.watch : Text -> a -> a
        
-  138. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8
+  139. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8
        unique type builtin.Doc
        
-  139. -- #baiqeiovdrs4ju0grn5q5akq64k4kuhgifqno52smkkttqg31jkgm3qa9o3ohe54fgpiigd1tj0an7rfveopfg622sjj9v9g44n27go
+  140. -- #baiqeiovdrs4ju0grn5q5akq64k4kuhgifqno52smkkttqg31jkgm3qa9o3ohe54fgpiigd1tj0an7rfveopfg622sjj9v9g44n27go
        builtin.Doc.++ : Doc2 -> Doc2 -> Doc2
        
-  140. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#0
+  141. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#0
        builtin.Doc.Blob : Text -> Doc
        
-  141. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#4
+  142. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#4
        builtin.Doc.Evaluate : Link.Term -> Doc
        
-  142. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#5
+  143. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#5
        builtin.Doc.Join : [Doc] -> Doc
        
-  143. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#1
+  144. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#1
        builtin.Doc.Link : Link -> Doc
        
-  144. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#3
+  145. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#3
        builtin.Doc.Signature : Link.Term -> Doc
        
-  145. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#2
+  146. -- #p65rcethk26an850aaaceojremfu054hqllhoip1mt9s22584j9r62o08qo9t0pri7ssgu9m7f0rfp4nujhulgbmo41tkgl182quhd8#2
        builtin.Doc.Source : Link -> Doc
        
-  146. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0
+  147. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0
        unique type builtin.Doc2
        
-  147. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#27
+  148. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#27
        builtin.Doc2.Anchor : Text -> Doc2 -> Doc2
        
-  148. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#11
+  149. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#11
        builtin.Doc2.Aside : Doc2 -> Doc2
        
-  149. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#15
+  150. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#15
        builtin.Doc2.Blankline : Doc2
        
-  150. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#10
+  151. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#10
        builtin.Doc2.Blockquote : Doc2 -> Doc2
        
-  151. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#7
+  152. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#7
        builtin.Doc2.Bold : Doc2 -> Doc2
        
-  152. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#21
+  153. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#21
        builtin.Doc2.BulletedList : [Doc2] -> Doc2
        
-  153. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#3
+  154. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#3
        builtin.Doc2.Callout : Optional Doc2 -> Doc2 -> Doc2
        
-  154. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#6
+  155. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#6
        builtin.Doc2.Code : Doc2 -> Doc2
        
-  155. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#25
+  156. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#25
        builtin.Doc2.CodeBlock : Text -> Doc2 -> Doc2
        
-  156. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#24
+  157. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#24
        builtin.Doc2.Column : [Doc2] -> Doc2
        
-  157. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#0
+  158. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#0
        builtin.Doc2.Folded : Boolean -> Doc2 -> Doc2 -> Doc2
        
-  158. -- #h3gajooii4tsdseghcbcsq4qq7c33mtb71u5npg35b06mgv7v654g0n55gpq212umfmq7nvi11o28m1v13r5fto5g8ium3ee4qk1i68
+  159. -- #h3gajooii4tsdseghcbcsq4qq7c33mtb71u5npg35b06mgv7v654g0n55gpq212umfmq7nvi11o28m1v13r5fto5g8ium3ee4qk1i68
        unique type builtin.Doc2.FrontMatter
        
-  159. -- #h3gajooii4tsdseghcbcsq4qq7c33mtb71u5npg35b06mgv7v654g0n55gpq212umfmq7nvi11o28m1v13r5fto5g8ium3ee4qk1i68#0
+  160. -- #h3gajooii4tsdseghcbcsq4qq7c33mtb71u5npg35b06mgv7v654g0n55gpq212umfmq7nvi11o28m1v13r5fto5g8ium3ee4qk1i68#0
        builtin.Doc2.FrontMatter.FrontMatter : [(Text, Text)]
        -> FrontMatter
        
-  160. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#12
+  161. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#12
        builtin.Doc2.Group : Doc2 -> Doc2
        
-  161. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#14
+  162. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#14
        builtin.Doc2.Image : Doc2
        -> Doc2
        -> Optional Doc2
        -> Doc2
        
-  162. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#8
+  163. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#8
        builtin.Doc2.Italic : Doc2 -> Doc2
        
-  163. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#22
+  164. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#22
        builtin.Doc2.Join : [Doc2] -> Doc2
        
-  164. -- #lpf7g5c2ct61mci2okedmug8o0i2j0rhpealc05r2musapmn15cina6dsqdvis234evvb2bo09l2p8v5qhh0me7gi1j37nqqp47qvto
+  165. -- #lpf7g5c2ct61mci2okedmug8o0i2j0rhpealc05r2musapmn15cina6dsqdvis234evvb2bo09l2p8v5qhh0me7gi1j37nqqp47qvto
        unique type builtin.Doc2.LaTeXInline
        
-  165. -- #lpf7g5c2ct61mci2okedmug8o0i2j0rhpealc05r2musapmn15cina6dsqdvis234evvb2bo09l2p8v5qhh0me7gi1j37nqqp47qvto#0
+  166. -- #lpf7g5c2ct61mci2okedmug8o0i2j0rhpealc05r2musapmn15cina6dsqdvis234evvb2bo09l2p8v5qhh0me7gi1j37nqqp47qvto#0
        builtin.Doc2.LaTeXInline.LaTeXInline : Text
        -> LaTeXInline
        
-  166. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#16
+  167. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#16
        builtin.Doc2.Linebreak : Doc2
        
-  167. -- #ut0tds116gr0soc9p6nroaalqlq423u1mao3p4jjultjmok3vbck69la7rs26duptji5v5hscijpek4hotu4krbfah8np3sntr87gb0
+  168. -- #ut0tds116gr0soc9p6nroaalqlq423u1mao3p4jjultjmok3vbck69la7rs26duptji5v5hscijpek4hotu4krbfah8np3sntr87gb0
        unique type builtin.Doc2.MediaSource
        
-  168. -- #ut0tds116gr0soc9p6nroaalqlq423u1mao3p4jjultjmok3vbck69la7rs26duptji5v5hscijpek4hotu4krbfah8np3sntr87gb0#0
+  169. -- #ut0tds116gr0soc9p6nroaalqlq423u1mao3p4jjultjmok3vbck69la7rs26duptji5v5hscijpek4hotu4krbfah8np3sntr87gb0#0
        builtin.Doc2.MediaSource.MediaSource : Text
        -> Optional Text
        -> MediaSource
        
-  169. -- #f7s1m2rs7ldj4idrcirtdqohsmc6n719e6cdqtgrhdkcrbm7971uvug6mvkrcc32qhdpo1og4oqin4rbmb2346m47ni24k5m3bpp3so
+  170. -- #f7s1m2rs7ldj4idrcirtdqohsmc6n719e6cdqtgrhdkcrbm7971uvug6mvkrcc32qhdpo1og4oqin4rbmb2346m47ni24k5m3bpp3so
        builtin.Doc2.MediaSource.mimeType : MediaSource
        -> Optional Text
        
-  170. -- #rncdj545f93f7nfrneabp6jlrjag766vr2n18al8u2a78ju5v746agg62r4ob8u6ue8eeac6nbg8apeii6qfasgfv2q2ap3h4sk1tdg
+  171. -- #rncdj545f93f7nfrneabp6jlrjag766vr2n18al8u2a78ju5v746agg62r4ob8u6ue8eeac6nbg8apeii6qfasgfv2q2ap3h4sk1tdg
        builtin.Doc2.MediaSource.mimeType.modify : (Optional Text
        ->{g} Optional Text)
        -> MediaSource
        ->{g} MediaSource
        
-  171. -- #54dl203thl9540r2jec546pishtg1b1ecb8vl6rqlbgf4h2rk04mrkdkqo4be82m8d3t2d0ef3gidjsn2r9u8ko7c9kvtavbqflim88
+  172. -- #54dl203thl9540r2jec546pishtg1b1ecb8vl6rqlbgf4h2rk04mrkdkqo4be82m8d3t2d0ef3gidjsn2r9u8ko7c9kvtavbqflim88
        builtin.Doc2.MediaSource.mimeType.set : Optional Text
        -> MediaSource
        -> MediaSource
        
-  172. -- #77l9vc6k6miu7pobamoasrpdm455ddgprgvfpg2di6liigijg70f4t3ppmpbs3j12kp93eep7u0e5r1bdq0niou0v85lo4aa5kek8mg
+  173. -- #77l9vc6k6miu7pobamoasrpdm455ddgprgvfpg2di6liigijg70f4t3ppmpbs3j12kp93eep7u0e5r1bdq0niou0v85lo4aa5kek8mg
        builtin.Doc2.MediaSource.sourceUrl : MediaSource -> Text
        
-  173. -- #laoh1nhllsb9vf0reilmbmjutdei2b0vs0vse1s8j148imfi1m9uu4l17iqdt9r5575dap8jnlq6r48kdn6ob70iroso75erqfc74e0
+  174. -- #laoh1nhllsb9vf0reilmbmjutdei2b0vs0vse1s8j148imfi1m9uu4l17iqdt9r5575dap8jnlq6r48kdn6ob70iroso75erqfc74e0
        builtin.Doc2.MediaSource.sourceUrl.modify : (Text
        ->{g} Text)
        -> MediaSource
        ->{g} MediaSource
        
-  174. -- #eb0dl30fc5k80vb0fna187vmag5ta1rgik40s1shlkng8stvvkt2gglecit8ajjd8vmfrtg8ki8ft3ife8rrqlcoit5161ekg6vhcfo
+  175. -- #eb0dl30fc5k80vb0fna187vmag5ta1rgik40s1shlkng8stvvkt2gglecit8ajjd8vmfrtg8ki8ft3ife8rrqlcoit5161ekg6vhcfo
        builtin.Doc2.MediaSource.sourceUrl.set : Text
        -> MediaSource
        -> MediaSource
        
-  175. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#2
+  176. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#2
        builtin.Doc2.NamedLink : Doc2 -> Doc2 -> Doc2
        
-  176. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#4
+  177. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#4
        builtin.Doc2.NumberedList : Nat -> [Doc2] -> Doc2
        
-  177. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#20
+  178. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#20
        builtin.Doc2.Paragraph : [Doc2] -> Doc2
        
-  178. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#13
+  179. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#13
        builtin.Doc2.Section : Doc2 -> [Doc2] -> Doc2
        
-  179. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#17
+  180. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#17
        builtin.Doc2.SectionBreak : Doc2
        
-  180. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#5
+  181. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#5
        builtin.Doc2.Special : SpecialForm -> Doc2
        
-  181. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0
+  182. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0
        unique type builtin.Doc2.SpecialForm
        
-  182. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#4
+  183. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#4
        builtin.Doc2.SpecialForm.Embed : Any -> SpecialForm
        
-  183. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#5
+  184. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#5
        builtin.Doc2.SpecialForm.EmbedInline : Any -> SpecialForm
        
-  184. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#9
+  185. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#9
        builtin.Doc2.SpecialForm.Eval : Doc2.Term -> SpecialForm
        
-  185. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#10
+  186. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#10
        builtin.Doc2.SpecialForm.EvalInline : Doc2.Term
        -> SpecialForm
        
-  186. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#0
+  187. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#0
        builtin.Doc2.SpecialForm.Example : Nat
        -> Doc2.Term
        -> SpecialForm
        
-  187. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#1
+  188. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#1
        builtin.Doc2.SpecialForm.ExampleBlock : Nat
        -> Doc2.Term
        -> SpecialForm
        
-  188. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#7
+  189. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#7
        builtin.Doc2.SpecialForm.FoldedSource : [( Either
          Type Doc2.Term,
          [Doc2.Term])]
        -> SpecialForm
        
-  189. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#3
+  190. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#3
        builtin.Doc2.SpecialForm.Link : Either Type Doc2.Term
        -> SpecialForm
        
-  190. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#2
+  191. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#2
        builtin.Doc2.SpecialForm.Signature : [Doc2.Term]
        -> SpecialForm
        
-  191. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#8
+  192. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#8
        builtin.Doc2.SpecialForm.SignatureInline : Doc2.Term
        -> SpecialForm
        
-  192. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#6
+  193. -- #e46kdnv67raqhc4m3jnitkh3o9seq3q5mtlqnvobjlqnnd2tk7nui54b6grui7eql62fne4fo3ndetmeb23oj5es85habha5f6saoi0#6
        builtin.Doc2.SpecialForm.Source : [( Either
          Type Doc2.Term,
          [Doc2.Term])]
        -> SpecialForm
        
-  193. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#9
+  194. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#9
        builtin.Doc2.Strikethrough : Doc2 -> Doc2
        
-  194. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#26
+  195. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#26
        builtin.Doc2.Style : Text -> Doc2 -> Doc2
        
-  195. -- #sv2cta4p4th10h7tpurvr0t6s3cbahlevvmpadk01v32e39kse8aicdvfsm2dbk6ltc68ht788jvkfhk6ol2mch7eubngtug019e8fg
+  196. -- #sv2cta4p4th10h7tpurvr0t6s3cbahlevvmpadk01v32e39kse8aicdvfsm2dbk6ltc68ht788jvkfhk6ol2mch7eubngtug019e8fg
        unique type builtin.Doc2.Svg
        
-  196. -- #sv2cta4p4th10h7tpurvr0t6s3cbahlevvmpadk01v32e39kse8aicdvfsm2dbk6ltc68ht788jvkfhk6ol2mch7eubngtug019e8fg#0
+  197. -- #sv2cta4p4th10h7tpurvr0t6s3cbahlevvmpadk01v32e39kse8aicdvfsm2dbk6ltc68ht788jvkfhk6ol2mch7eubngtug019e8fg#0
        builtin.Doc2.Svg.Svg : Text -> Svg
        
-  197. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#18
+  198. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#18
        builtin.Doc2.Table : [[Doc2]] -> Doc2
        
-  198. -- #s0an21vospbdlsbddiskuvt3ngbf00n78sip2o1mnp4jgp16i7sursbm14bf8ap7osphqbis2lduep3i29b7diu8sf03f8tlqd7rgcg
+  199. -- #s0an21vospbdlsbddiskuvt3ngbf00n78sip2o1mnp4jgp16i7sursbm14bf8ap7osphqbis2lduep3i29b7diu8sf03f8tlqd7rgcg
        unique type builtin.Doc2.Term
        
-  199. -- #tu2du1k0lrp6iddor1aotdhdgn1j2b86r22tes3o3hka0bv4b4otlbimj88ttrdnbuacokk768k4e54795of8gnosopjirl4jm42g28
+  200. -- #tu2du1k0lrp6iddor1aotdhdgn1j2b86r22tes3o3hka0bv4b4otlbimj88ttrdnbuacokk768k4e54795of8gnosopjirl4jm42g28
        builtin.Doc2.term : '{g} a -> Doc2.Term
        
-  200. -- #s0an21vospbdlsbddiskuvt3ngbf00n78sip2o1mnp4jgp16i7sursbm14bf8ap7osphqbis2lduep3i29b7diu8sf03f8tlqd7rgcg#0
+  201. -- #s0an21vospbdlsbddiskuvt3ngbf00n78sip2o1mnp4jgp16i7sursbm14bf8ap7osphqbis2lduep3i29b7diu8sf03f8tlqd7rgcg#0
        builtin.Doc2.Term.Term : Any -> Doc2.Term
        
-  201. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#1
+  202. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#1
        builtin.Doc2.Tooltip : Doc2 -> Doc2 -> Doc2
        
-  202. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#23
+  203. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#23
        builtin.Doc2.UntitledSection : [Doc2] -> Doc2
        
-  203. -- #794fndq1941e2khqv5uh7fmk9es2g4fkp8pr48objgs6blc1pqsdt2ab4o79noril2l7s70iu2eimn1smpd8t40j4g18btian8a2pt0
+  204. -- #794fndq1941e2khqv5uh7fmk9es2g4fkp8pr48objgs6blc1pqsdt2ab4o79noril2l7s70iu2eimn1smpd8t40j4g18btian8a2pt0
        unique type builtin.Doc2.Video
        
-  204. -- #46er7fsgre91rer0mpk6vhaa2vie19i0piubvtnfmt3vq7odcjfr6tlf0mc57q4jnij9rkolpekjd6dpqdotn41guk9lp9qioa88m58
+  205. -- #46er7fsgre91rer0mpk6vhaa2vie19i0piubvtnfmt3vq7odcjfr6tlf0mc57q4jnij9rkolpekjd6dpqdotn41guk9lp9qioa88m58
        builtin.Doc2.Video.config : Video -> [(Text, Text)]
        
-  205. -- #vld47vp37855gceko81jj00j5t0mf5p137ub57094585aq3jfevq0ob03fot9d73p97r2pj0alel9e6a7lqcc7mue0ogefshg991e6g
+  206. -- #vld47vp37855gceko81jj00j5t0mf5p137ub57094585aq3jfevq0ob03fot9d73p97r2pj0alel9e6a7lqcc7mue0ogefshg991e6g
        builtin.Doc2.Video.config.modify : ([(Text, Text)]
        ->{g} [(Text, Text)])
        -> Video
        ->{g} Video
        
-  206. -- #ll9hiqi1s63ragrv9ul3ouu2rvpjkok4gdmgqs6cl8j4fgdmqlgikc5lseoe94e9fvrughjfetlcsn7gc5ed8prtnljfo5j6r1vveq8
+  207. -- #ll9hiqi1s63ragrv9ul3ouu2rvpjkok4gdmgqs6cl8j4fgdmqlgikc5lseoe94e9fvrughjfetlcsn7gc5ed8prtnljfo5j6r1vveq8
        builtin.Doc2.Video.config.set : [(Text, Text)]
        -> Video
        -> Video
        
-  207. -- #a454aldsi00l8kh10bhi6d4phtdr9ht0es6apr05jert6oo4vstm5cdr4ee2k0srted1urqgvkrcoihjvmus6tph92v628f3lr9b92o
+  208. -- #a454aldsi00l8kh10bhi6d4phtdr9ht0es6apr05jert6oo4vstm5cdr4ee2k0srted1urqgvkrcoihjvmus6tph92v628f3lr9b92o
        builtin.Doc2.Video.sources : Video -> [MediaSource]
        
-  208. -- #nm77894uq9g3kv5mo7ubuptpimt53jml7jt825lr83gu41tqcfpg2krcesn7p5aaea107su7brg2gm8vn1l0mabpfnpbcdi4onlatvo
+  209. -- #nm77894uq9g3kv5mo7ubuptpimt53jml7jt825lr83gu41tqcfpg2krcesn7p5aaea107su7brg2gm8vn1l0mabpfnpbcdi4onlatvo
        builtin.Doc2.Video.sources.modify : ([MediaSource]
        ->{g} [MediaSource])
        -> Video
        ->{g} Video
        
-  209. -- #5r0bgv3t666s4lh274mvtk13jqu1doc26ki2k8t2rpophrq2hjran1qodeobf3trlnniarjehr1rgl6scn6mhqpmcokdafja3b54jt0
+  210. -- #5r0bgv3t666s4lh274mvtk13jqu1doc26ki2k8t2rpophrq2hjran1qodeobf3trlnniarjehr1rgl6scn6mhqpmcokdafja3b54jt0
        builtin.Doc2.Video.sources.set : [MediaSource]
        -> Video
        -> Video
        
-  210. -- #794fndq1941e2khqv5uh7fmk9es2g4fkp8pr48objgs6blc1pqsdt2ab4o79noril2l7s70iu2eimn1smpd8t40j4g18btian8a2pt0#0
+  211. -- #794fndq1941e2khqv5uh7fmk9es2g4fkp8pr48objgs6blc1pqsdt2ab4o79noril2l7s70iu2eimn1smpd8t40j4g18btian8a2pt0#0
        builtin.Doc2.Video.Video : [MediaSource]
        -> [(Text, Text)]
        -> Video
        
-  211. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#19
+  212. -- #ej86si0ur1lsjade71dojr25phk9bbom9rdks6dltolos5tjivakujcriqe02npba53n9gd7tkh8bmv08ttjb9t35lq2ch5heshqcs0#19
        builtin.Doc2.Word : Text -> Doc2
        
-  212. -- #0o7mf021foma9acqdaibmlh1jidlijq08uf7f5se9tssttqs546pfunjpk6s31mqoq8s2o1natede8hkk6he45l95fibglidikt44v8
+  213. -- #0o7mf021foma9acqdaibmlh1jidlijq08uf7f5se9tssttqs546pfunjpk6s31mqoq8s2o1natede8hkk6he45l95fibglidikt44v8
        structural type builtin.Either a b
        
-  213. -- #0o7mf021foma9acqdaibmlh1jidlijq08uf7f5se9tssttqs546pfunjpk6s31mqoq8s2o1natede8hkk6he45l95fibglidikt44v8#1
+  214. -- #0o7mf021foma9acqdaibmlh1jidlijq08uf7f5se9tssttqs546pfunjpk6s31mqoq8s2o1natede8hkk6he45l95fibglidikt44v8#1
        builtin.Either.Left : a -> Either a b
        
-  214. -- #u3cen22u7p8dfj0nc45j0pg4lskqjjisflm3jq0957756d23lq53tf27vg37g6jnddh8o70grvotcvrfc1fnpog0rlfsvfvjrk1s94g
+  215. -- #u3cen22u7p8dfj0nc45j0pg4lskqjjisflm3jq0957756d23lq53tf27vg37g6jnddh8o70grvotcvrfc1fnpog0rlfsvfvjrk1s94g
        builtin.Either.mapRight : (a ->{g} b)
        -> Either e a
        ->{g} Either e b
        
-  215. -- #0o7mf021foma9acqdaibmlh1jidlijq08uf7f5se9tssttqs546pfunjpk6s31mqoq8s2o1natede8hkk6he45l95fibglidikt44v8#0
+  216. -- #0o7mf021foma9acqdaibmlh1jidlijq08uf7f5se9tssttqs546pfunjpk6s31mqoq8s2o1natede8hkk6he45l95fibglidikt44v8#0
        builtin.Either.Right : b -> Either a b
        
-  216. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng
+  217. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng
        structural ability builtin.Exception
        structural ability Exception
        
-  217. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng#0
+  218. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng#0
        builtin.Exception.raise,
        Exception.raise : Failure
        ->{Exception} x
        
-  218. -- ##Float
+  219. -- ##Float
        builtin type builtin.Float
        
-  219. -- ##Float.*
+  220. -- ##Float.*
        builtin.Float.* : Float -> Float -> Float
        
-  220. -- ##Float.+
+  221. -- ##Float.+
        builtin.Float.+ : Float -> Float -> Float
        
-  221. -- ##Float.-
+  222. -- ##Float.-
        builtin.Float.- : Float -> Float -> Float
        
-  222. -- ##Float./
+  223. -- ##Float./
        builtin.Float./ : Float -> Float -> Float
        
-  223. -- ##Float.abs
+  224. -- ##Float.abs
        builtin.Float.abs : Float -> Float
        
-  224. -- ##Float.acos
+  225. -- ##Float.acos
        builtin.Float.acos : Float -> Float
        
-  225. -- ##Float.acosh
+  226. -- ##Float.acosh
        builtin.Float.acosh : Float -> Float
        
-  226. -- ##Float.asin
+  227. -- ##Float.asin
        builtin.Float.asin : Float -> Float
        
-  227. -- ##Float.asinh
+  228. -- ##Float.asinh
        builtin.Float.asinh : Float -> Float
        
-  228. -- ##Float.atan
+  229. -- ##Float.atan
        builtin.Float.atan : Float -> Float
        
-  229. -- ##Float.atan2
+  230. -- ##Float.atan2
        builtin.Float.atan2 : Float -> Float -> Float
        
-  230. -- ##Float.atanh
+  231. -- ##Float.atanh
        builtin.Float.atanh : Float -> Float
        
-  231. -- ##Float.ceiling
+  232. -- ##Float.ceiling
        builtin.Float.ceiling : Float -> Int
        
-  232. -- ##Float.cos
+  233. -- ##Float.cos
        builtin.Float.cos : Float -> Float
        
-  233. -- ##Float.cosh
+  234. -- ##Float.cosh
        builtin.Float.cosh : Float -> Float
        
-  234. -- ##Float.==
+  235. -- ##Float.==
        builtin.Float.eq : Float -> Float -> Boolean
        
-  235. -- ##Float.exp
+  236. -- ##Float.exp
        builtin.Float.exp : Float -> Float
        
-  236. -- ##Float.floor
+  237. -- ##Float.floor
        builtin.Float.floor : Float -> Int
        
-  237. -- ##Float.fromRepresentation
+  238. -- ##Float.fromRepresentation
        builtin.Float.fromRepresentation : Nat -> Float
        
-  238. -- ##Float.fromText
+  239. -- ##Float.fromText
        builtin.Float.fromText : Text -> Optional Float
        
-  239. -- ##Float.>
+  240. -- ##Float.>
        builtin.Float.gt : Float -> Float -> Boolean
        
-  240. -- ##Float.>=
+  241. -- ##Float.>=
        builtin.Float.gteq : Float -> Float -> Boolean
        
-  241. -- ##Float.log
+  242. -- ##Float.log
        builtin.Float.log : Float -> Float
        
-  242. -- ##Float.logBase
+  243. -- ##Float.logBase
        builtin.Float.logBase : Float -> Float -> Float
        
-  243. -- ##Float.<
+  244. -- ##Float.<
        builtin.Float.lt : Float -> Float -> Boolean
        
-  244. -- ##Float.<=
+  245. -- ##Float.<=
        builtin.Float.lteq : Float -> Float -> Boolean
        
-  245. -- ##Float.max
+  246. -- ##Float.max
        builtin.Float.max : Float -> Float -> Float
        
-  246. -- ##Float.min
+  247. -- ##Float.min
        builtin.Float.min : Float -> Float -> Float
        
-  247. -- ##Float.pow
+  248. -- ##Float.pow
        builtin.Float.pow : Float -> Float -> Float
        
-  248. -- ##Float.round
+  249. -- ##Float.round
        builtin.Float.round : Float -> Int
        
-  249. -- ##Float.sin
+  250. -- ##Float.sin
        builtin.Float.sin : Float -> Float
        
-  250. -- ##Float.sinh
+  251. -- ##Float.sinh
        builtin.Float.sinh : Float -> Float
        
-  251. -- ##Float.sqrt
+  252. -- ##Float.sqrt
        builtin.Float.sqrt : Float -> Float
        
-  252. -- ##Float.tan
+  253. -- ##Float.tan
        builtin.Float.tan : Float -> Float
        
-  253. -- ##Float.tanh
+  254. -- ##Float.tanh
        builtin.Float.tanh : Float -> Float
        
-  254. -- ##Float.toRepresentation
+  255. -- ##Float.toRepresentation
        builtin.Float.toRepresentation : Float -> Nat
        
-  255. -- ##Float.toText
+  256. -- ##Float.toText
        builtin.Float.toText : Float -> Text
        
-  256. -- ##Float.truncate
+  257. -- ##Float.truncate
        builtin.Float.truncate : Float -> Int
        
-  257. -- #hqectlr3gt02r6r984b3627eg5bq3d82lab5q18e3ql09u1ka8dblf5k50ae0q0d8gk87udqd7b6767q86gogdt8ghpdiq77gk6blr8
+  258. -- #hqectlr3gt02r6r984b3627eg5bq3d82lab5q18e3ql09u1ka8dblf5k50ae0q0d8gk87udqd7b6767q86gogdt8ghpdiq77gk6blr8
        unique type builtin.GUID
        
-  258. -- #hqectlr3gt02r6r984b3627eg5bq3d82lab5q18e3ql09u1ka8dblf5k50ae0q0d8gk87udqd7b6767q86gogdt8ghpdiq77gk6blr8#0
+  259. -- #hqectlr3gt02r6r984b3627eg5bq3d82lab5q18e3ql09u1ka8dblf5k50ae0q0d8gk87udqd7b6767q86gogdt8ghpdiq77gk6blr8#0
        builtin.GUID.GUID : Bytes -> GUID
        
-  259. -- ##Handle.toText
+  260. -- ##Handle.toText
        builtin.Handle.toText : Handle -> Text
        
-  260. -- ##ImmutableArray
+  261. -- ##ImmutableArray
        builtin type builtin.ImmutableArray
        
-  261. -- ##ImmutableArray.copyTo!
+  262. -- ##ImmutableArray.copyTo!
        builtin.ImmutableArray.copyTo! : MutableArray g a
        -> Nat
        -> ImmutableArray a
@@ -879,18 +882,18 @@ This transcript is intended to make visible accidental changes to the hashing al
        -> Nat
        ->{g, Exception} ()
        
-  262. -- ##ImmutableArray.read
+  263. -- ##ImmutableArray.read
        builtin.ImmutableArray.read : ImmutableArray a
        -> Nat
        ->{Exception} a
        
-  263. -- ##ImmutableArray.size
+  264. -- ##ImmutableArray.size
        builtin.ImmutableArray.size : ImmutableArray a -> Nat
        
-  264. -- ##ImmutableByteArray
+  265. -- ##ImmutableByteArray
        builtin type builtin.ImmutableByteArray
        
-  265. -- ##ImmutableByteArray.copyTo!
+  266. -- ##ImmutableByteArray.copyTo!
        builtin.ImmutableByteArray.copyTo! : MutableByteArray g
        -> Nat
        -> ImmutableByteArray
@@ -898,867 +901,867 @@ This transcript is intended to make visible accidental changes to the hashing al
        -> Nat
        ->{g, Exception} ()
        
-  266. -- ##ImmutableByteArray.read16be
+  267. -- ##ImmutableByteArray.read16be
        builtin.ImmutableByteArray.read16be : ImmutableByteArray
        -> Nat
        ->{Exception} Nat
        
-  267. -- ##ImmutableByteArray.read24be
+  268. -- ##ImmutableByteArray.read24be
        builtin.ImmutableByteArray.read24be : ImmutableByteArray
        -> Nat
        ->{Exception} Nat
        
-  268. -- ##ImmutableByteArray.read32be
+  269. -- ##ImmutableByteArray.read32be
        builtin.ImmutableByteArray.read32be : ImmutableByteArray
        -> Nat
        ->{Exception} Nat
        
-  269. -- ##ImmutableByteArray.read40be
+  270. -- ##ImmutableByteArray.read40be
        builtin.ImmutableByteArray.read40be : ImmutableByteArray
        -> Nat
        ->{Exception} Nat
        
-  270. -- ##ImmutableByteArray.read64be
+  271. -- ##ImmutableByteArray.read64be
        builtin.ImmutableByteArray.read64be : ImmutableByteArray
        -> Nat
        ->{Exception} Nat
        
-  271. -- ##ImmutableByteArray.read8
+  272. -- ##ImmutableByteArray.read8
        builtin.ImmutableByteArray.read8 : ImmutableByteArray
        -> Nat
        ->{Exception} Nat
        
-  272. -- ##ImmutableByteArray.size
+  273. -- ##ImmutableByteArray.size
        builtin.ImmutableByteArray.size : ImmutableByteArray
        -> Nat
        
-  273. -- ##Int
+  274. -- ##Int
        builtin type builtin.Int
        
-  274. -- ##Int.*
+  275. -- ##Int.*
        builtin.Int.* : Int -> Int -> Int
        
-  275. -- ##Int.+
+  276. -- ##Int.+
        builtin.Int.+ : Int -> Int -> Int
        
-  276. -- ##Int.-
+  277. -- ##Int.-
        builtin.Int.- : Int -> Int -> Int
        
-  277. -- ##Int./
+  278. -- ##Int./
        builtin.Int./ : Int -> Int -> Int
        
-  278. -- ##Int.and
+  279. -- ##Int.and
        builtin.Int.and : Int -> Int -> Int
        
-  279. -- ##Int.complement
+  280. -- ##Int.complement
        builtin.Int.complement : Int -> Int
        
-  280. -- ##Int.==
+  281. -- ##Int.==
        builtin.Int.eq : Int -> Int -> Boolean
        
-  281. -- ##Int.fromRepresentation
+  282. -- ##Int.fromRepresentation
        builtin.Int.fromRepresentation : Nat -> Int
        
-  282. -- ##Int.fromText
+  283. -- ##Int.fromText
        builtin.Int.fromText : Text -> Optional Int
        
-  283. -- ##Int.>
+  284. -- ##Int.>
        builtin.Int.gt : Int -> Int -> Boolean
        
-  284. -- ##Int.>=
+  285. -- ##Int.>=
        builtin.Int.gteq : Int -> Int -> Boolean
        
-  285. -- ##Int.increment
+  286. -- ##Int.increment
        builtin.Int.increment : Int -> Int
        
-  286. -- ##Int.isEven
+  287. -- ##Int.isEven
        builtin.Int.isEven : Int -> Boolean
        
-  287. -- ##Int.isOdd
+  288. -- ##Int.isOdd
        builtin.Int.isOdd : Int -> Boolean
        
-  288. -- ##Int.leadingZeros
+  289. -- ##Int.leadingZeros
        builtin.Int.leadingZeros : Int -> Nat
        
-  289. -- ##Int.<
+  290. -- ##Int.<
        builtin.Int.lt : Int -> Int -> Boolean
        
-  290. -- ##Int.<=
+  291. -- ##Int.<=
        builtin.Int.lteq : Int -> Int -> Boolean
        
-  291. -- ##Int.mod
+  292. -- ##Int.mod
        builtin.Int.mod : Int -> Int -> Int
        
-  292. -- ##Int.negate
+  293. -- ##Int.negate
        builtin.Int.negate : Int -> Int
        
-  293. -- ##Int.or
+  294. -- ##Int.or
        builtin.Int.or : Int -> Int -> Int
        
-  294. -- ##Int.popCount
+  295. -- ##Int.popCount
        builtin.Int.popCount : Int -> Nat
        
-  295. -- ##Int.pow
+  296. -- ##Int.pow
        builtin.Int.pow : Int -> Nat -> Int
        
-  296. -- ##Int.shiftLeft
+  297. -- ##Int.shiftLeft
        builtin.Int.shiftLeft : Int -> Nat -> Int
        
-  297. -- ##Int.shiftRight
+  298. -- ##Int.shiftRight
        builtin.Int.shiftRight : Int -> Nat -> Int
        
-  298. -- ##Int.signum
+  299. -- ##Int.signum
        builtin.Int.signum : Int -> Int
        
-  299. -- ##Int.toFloat
+  300. -- ##Int.toFloat
        builtin.Int.toFloat : Int -> Float
        
-  300. -- ##Int.toRepresentation
+  301. -- ##Int.toRepresentation
        builtin.Int.toRepresentation : Int -> Nat
        
-  301. -- ##Int.toText
+  302. -- ##Int.toText
        builtin.Int.toText : Int -> Text
        
-  302. -- ##Int.trailingZeros
+  303. -- ##Int.trailingZeros
        builtin.Int.trailingZeros : Int -> Nat
        
-  303. -- ##Int.truncate0
+  304. -- ##Int.truncate0
        builtin.Int.truncate0 : Int -> Nat
        
-  304. -- ##Int.xor
+  305. -- ##Int.xor
        builtin.Int.xor : Int -> Int -> Int
        
-  305. -- #s6ijmhqkkaus51chjgahogc7sdrqj9t66i599le2k7ts6fkl216f997hbses3mqk6a21vaj3cm1mertbldn0g503jt522vfo4rfv720
+  306. -- #s6ijmhqkkaus51chjgahogc7sdrqj9t66i599le2k7ts6fkl216f997hbses3mqk6a21vaj3cm1mertbldn0g503jt522vfo4rfv720
        unique type builtin.io2.ArithmeticFailure
        
-  306. -- #6dtvam7msqc64dimm8p0d8ehdf0330o4qbd2fdafb11jj1c2rg4ke3jdcmbgo6s4pf2jgm0vb76jeavv4ba6ht71t74p963a1miekag
+  307. -- #6dtvam7msqc64dimm8p0d8ehdf0330o4qbd2fdafb11jj1c2rg4ke3jdcmbgo6s4pf2jgm0vb76jeavv4ba6ht71t74p963a1miekag
        unique type builtin.io2.ArrayFailure
        
-  307. -- #dc6n5ebu839ik3b6ohmnqm6p0cifn7o94em1g41mjp4ae0gmv3b4rupba499lbasfrp4bqce9u4hd6518unlbg8vk993c0q6rigos98
+  308. -- #dc6n5ebu839ik3b6ohmnqm6p0cifn7o94em1g41mjp4ae0gmv3b4rupba499lbasfrp4bqce9u4hd6518unlbg8vk993c0q6rigos98
        unique type builtin.io2.BufferMode
        
-  308. -- #dc6n5ebu839ik3b6ohmnqm6p0cifn7o94em1g41mjp4ae0gmv3b4rupba499lbasfrp4bqce9u4hd6518unlbg8vk993c0q6rigos98#2
+  309. -- #dc6n5ebu839ik3b6ohmnqm6p0cifn7o94em1g41mjp4ae0gmv3b4rupba499lbasfrp4bqce9u4hd6518unlbg8vk993c0q6rigos98#2
        builtin.io2.BufferMode.BlockBuffering : BufferMode
        
-  309. -- #dc6n5ebu839ik3b6ohmnqm6p0cifn7o94em1g41mjp4ae0gmv3b4rupba499lbasfrp4bqce9u4hd6518unlbg8vk993c0q6rigos98#1
+  310. -- #dc6n5ebu839ik3b6ohmnqm6p0cifn7o94em1g41mjp4ae0gmv3b4rupba499lbasfrp4bqce9u4hd6518unlbg8vk993c0q6rigos98#1
        builtin.io2.BufferMode.LineBuffering : BufferMode
        
-  310. -- #dc6n5ebu839ik3b6ohmnqm6p0cifn7o94em1g41mjp4ae0gmv3b4rupba499lbasfrp4bqce9u4hd6518unlbg8vk993c0q6rigos98#0
+  311. -- #dc6n5ebu839ik3b6ohmnqm6p0cifn7o94em1g41mjp4ae0gmv3b4rupba499lbasfrp4bqce9u4hd6518unlbg8vk993c0q6rigos98#0
        builtin.io2.BufferMode.NoBuffering : BufferMode
        
-  311. -- #dc6n5ebu839ik3b6ohmnqm6p0cifn7o94em1g41mjp4ae0gmv3b4rupba499lbasfrp4bqce9u4hd6518unlbg8vk993c0q6rigos98#3
+  312. -- #dc6n5ebu839ik3b6ohmnqm6p0cifn7o94em1g41mjp4ae0gmv3b4rupba499lbasfrp4bqce9u4hd6518unlbg8vk993c0q6rigos98#3
        builtin.io2.BufferMode.SizedBlockBuffering : Nat
        -> BufferMode
        
-  312. -- ##Clock.internals.monotonic.v1
+  313. -- ##Clock.internals.monotonic.v1
        builtin.io2.Clock.internals.monotonic : '{IO} Either
          Failure TimeSpec
        
-  313. -- ##Clock.internals.nsec.v1
+  314. -- ##Clock.internals.nsec.v1
        builtin.io2.Clock.internals.nsec : TimeSpec -> Nat
        
-  314. -- ##Clock.internals.processCPUTime.v1
+  315. -- ##Clock.internals.processCPUTime.v1
        builtin.io2.Clock.internals.processCPUTime : '{IO} Either
          Failure TimeSpec
        
-  315. -- ##Clock.internals.realtime.v1
+  316. -- ##Clock.internals.realtime.v1
        builtin.io2.Clock.internals.realtime : '{IO} Either
          Failure TimeSpec
        
-  316. -- ##Clock.internals.sec.v1
+  317. -- ##Clock.internals.sec.v1
        builtin.io2.Clock.internals.sec : TimeSpec -> Int
        
-  317. -- ##Clock.internals.threadCPUTime.v1
+  318. -- ##Clock.internals.threadCPUTime.v1
        builtin.io2.Clock.internals.threadCPUTime : '{IO} Either
          Failure TimeSpec
        
-  318. -- ##TimeSpec
+  319. -- ##TimeSpec
        builtin type builtin.io2.Clock.internals.TimeSpec
        
-  319. -- #r29dja8j9dmjjp45trccchaata8eo1h6d6haar1eai74pq1jt4m7u3ldhlq79f7phfo57eq4bau39vqotl2h63k7ff1m5sj5o9ajuf8
+  320. -- #r29dja8j9dmjjp45trccchaata8eo1h6d6haar1eai74pq1jt4m7u3ldhlq79f7phfo57eq4bau39vqotl2h63k7ff1m5sj5o9ajuf8
        unique type builtin.io2.Failure
        
-  320. -- #r29dja8j9dmjjp45trccchaata8eo1h6d6haar1eai74pq1jt4m7u3ldhlq79f7phfo57eq4bau39vqotl2h63k7ff1m5sj5o9ajuf8#0
+  321. -- #r29dja8j9dmjjp45trccchaata8eo1h6d6haar1eai74pq1jt4m7u3ldhlq79f7phfo57eq4bau39vqotl2h63k7ff1m5sj5o9ajuf8#0
        builtin.io2.Failure.Failure : Type
        -> Text
        -> Any
        -> Failure
        
-  321. -- #jhnlob35huv3rr7jg6aa4gtd8okhprla7gvlq8io429qita8vj7k696n9jvp4b8ct9i2pc1jodb8ap2bipqtgp138epdgfcth7vqvt8
+  322. -- #jhnlob35huv3rr7jg6aa4gtd8okhprla7gvlq8io429qita8vj7k696n9jvp4b8ct9i2pc1jodb8ap2bipqtgp138epdgfcth7vqvt8
        unique type builtin.io2.FileMode
        
-  322. -- #jhnlob35huv3rr7jg6aa4gtd8okhprla7gvlq8io429qita8vj7k696n9jvp4b8ct9i2pc1jodb8ap2bipqtgp138epdgfcth7vqvt8#2
+  323. -- #jhnlob35huv3rr7jg6aa4gtd8okhprla7gvlq8io429qita8vj7k696n9jvp4b8ct9i2pc1jodb8ap2bipqtgp138epdgfcth7vqvt8#2
        builtin.io2.FileMode.Append : FileMode
        
-  323. -- #jhnlob35huv3rr7jg6aa4gtd8okhprla7gvlq8io429qita8vj7k696n9jvp4b8ct9i2pc1jodb8ap2bipqtgp138epdgfcth7vqvt8#0
+  324. -- #jhnlob35huv3rr7jg6aa4gtd8okhprla7gvlq8io429qita8vj7k696n9jvp4b8ct9i2pc1jodb8ap2bipqtgp138epdgfcth7vqvt8#0
        builtin.io2.FileMode.Read : FileMode
        
-  324. -- #jhnlob35huv3rr7jg6aa4gtd8okhprla7gvlq8io429qita8vj7k696n9jvp4b8ct9i2pc1jodb8ap2bipqtgp138epdgfcth7vqvt8#3
+  325. -- #jhnlob35huv3rr7jg6aa4gtd8okhprla7gvlq8io429qita8vj7k696n9jvp4b8ct9i2pc1jodb8ap2bipqtgp138epdgfcth7vqvt8#3
        builtin.io2.FileMode.ReadWrite : FileMode
        
-  325. -- #jhnlob35huv3rr7jg6aa4gtd8okhprla7gvlq8io429qita8vj7k696n9jvp4b8ct9i2pc1jodb8ap2bipqtgp138epdgfcth7vqvt8#1
+  326. -- #jhnlob35huv3rr7jg6aa4gtd8okhprla7gvlq8io429qita8vj7k696n9jvp4b8ct9i2pc1jodb8ap2bipqtgp138epdgfcth7vqvt8#1
        builtin.io2.FileMode.Write : FileMode
        
-  326. -- ##Handle
+  327. -- ##Handle
        builtin type builtin.io2.Handle
        
-  327. -- ##IO
+  328. -- ##IO
        builtin type builtin.io2.IO
        
-  328. -- ##IO.array
+  329. -- ##IO.array
        builtin.io2.IO.array : Nat ->{IO} MutableArray {IO} a
        
-  329. -- ##IO.arrayOf
+  330. -- ##IO.arrayOf
        builtin.io2.IO.arrayOf : a
        -> Nat
        ->{IO} MutableArray {IO} a
        
-  330. -- ##IO.bytearray
+  331. -- ##IO.bytearray
        builtin.io2.IO.bytearray : Nat
        ->{IO} MutableByteArray {IO}
        
-  331. -- ##IO.bytearrayOf
+  332. -- ##IO.bytearrayOf
        builtin.io2.IO.bytearrayOf : Nat
        -> Nat
        ->{IO} MutableByteArray {IO}
        
-  332. -- ##IO.clientSocket.impl.v3
+  333. -- ##IO.clientSocket.impl.v3
        builtin.io2.IO.clientSocket.impl : Text
        -> Text
        ->{IO} Either Failure Socket
        
-  333. -- ##IO.closeFile.impl.v3
+  334. -- ##IO.closeFile.impl.v3
        builtin.io2.IO.closeFile.impl : Handle
        ->{IO} Either Failure ()
        
-  334. -- ##IO.closeSocket.impl.v3
+  335. -- ##IO.closeSocket.impl.v3
        builtin.io2.IO.closeSocket.impl : Socket
        ->{IO} Either Failure ()
        
-  335. -- ##IO.createDirectory.impl.v3
+  336. -- ##IO.createDirectory.impl.v3
        builtin.io2.IO.createDirectory.impl : Text
        ->{IO} Either Failure ()
        
-  336. -- ##IO.createTempDirectory.impl.v3
+  337. -- ##IO.createTempDirectory.impl.v3
        builtin.io2.IO.createTempDirectory.impl : Text
        ->{IO} Either Failure Text
        
-  337. -- ##IO.delay.impl.v3
+  338. -- ##IO.delay.impl.v3
        builtin.io2.IO.delay.impl : Nat ->{IO} Either Failure ()
        
-  338. -- ##IO.directoryContents.impl.v3
+  339. -- ##IO.directoryContents.impl.v3
        builtin.io2.IO.directoryContents.impl : Text
        ->{IO} Either Failure [Text]
        
-  339. -- ##IO.fileExists.impl.v3
+  340. -- ##IO.fileExists.impl.v3
        builtin.io2.IO.fileExists.impl : Text
        ->{IO} Either Failure Boolean
        
-  340. -- ##IO.forkComp.v2
+  341. -- ##IO.forkComp.v2
        builtin.io2.IO.forkComp : '{IO} a ->{IO} ThreadId
        
-  341. -- ##IO.getArgs.impl.v1
+  342. -- ##IO.getArgs.impl.v1
        builtin.io2.IO.getArgs.impl : '{IO} Either Failure [Text]
        
-  342. -- ##IO.getBuffering.impl.v3
+  343. -- ##IO.getBuffering.impl.v3
        builtin.io2.IO.getBuffering.impl : Handle
        ->{IO} Either Failure BufferMode
        
-  343. -- ##IO.getBytes.impl.v3
+  344. -- ##IO.getBytes.impl.v3
        builtin.io2.IO.getBytes.impl : Handle
        -> Nat
        ->{IO} Either Failure Bytes
        
-  344. -- ##IO.getChar.impl.v1
+  345. -- ##IO.getChar.impl.v1
        builtin.io2.IO.getChar.impl : Handle
        ->{IO} Either Failure Char
        
-  345. -- ##IO.getCurrentDirectory.impl.v3
+  346. -- ##IO.getCurrentDirectory.impl.v3
        builtin.io2.IO.getCurrentDirectory.impl : '{IO} Either
          Failure Text
        
-  346. -- ##IO.getEcho.impl.v1
+  347. -- ##IO.getEcho.impl.v1
        builtin.io2.IO.getEcho.impl : Handle
        ->{IO} Either Failure Boolean
        
-  347. -- ##IO.getEnv.impl.v1
+  348. -- ##IO.getEnv.impl.v1
        builtin.io2.IO.getEnv.impl : Text
        ->{IO} Either Failure Text
        
-  348. -- ##IO.getFileSize.impl.v3
+  349. -- ##IO.getFileSize.impl.v3
        builtin.io2.IO.getFileSize.impl : Text
        ->{IO} Either Failure Nat
        
-  349. -- ##IO.getFileTimestamp.impl.v3
+  350. -- ##IO.getFileTimestamp.impl.v3
        builtin.io2.IO.getFileTimestamp.impl : Text
        ->{IO} Either Failure Nat
        
-  350. -- ##IO.getLine.impl.v1
+  351. -- ##IO.getLine.impl.v1
        builtin.io2.IO.getLine.impl : Handle
        ->{IO} Either Failure Text
        
-  351. -- ##IO.getSomeBytes.impl.v1
+  352. -- ##IO.getSomeBytes.impl.v1
        builtin.io2.IO.getSomeBytes.impl : Handle
        -> Nat
        ->{IO} Either Failure Bytes
        
-  352. -- ##IO.getTempDirectory.impl.v3
+  353. -- ##IO.getTempDirectory.impl.v3
        builtin.io2.IO.getTempDirectory.impl : '{IO} Either
          Failure Text
        
-  353. -- ##IO.handlePosition.impl.v3
+  354. -- ##IO.handlePosition.impl.v3
        builtin.io2.IO.handlePosition.impl : Handle
        ->{IO} Either Failure Nat
        
-  354. -- ##IO.isDirectory.impl.v3
+  355. -- ##IO.isDirectory.impl.v3
        builtin.io2.IO.isDirectory.impl : Text
        ->{IO} Either Failure Boolean
        
-  355. -- ##IO.isFileEOF.impl.v3
+  356. -- ##IO.isFileEOF.impl.v3
        builtin.io2.IO.isFileEOF.impl : Handle
        ->{IO} Either Failure Boolean
        
-  356. -- ##IO.isFileOpen.impl.v3
+  357. -- ##IO.isFileOpen.impl.v3
        builtin.io2.IO.isFileOpen.impl : Handle
        ->{IO} Either Failure Boolean
        
-  357. -- ##IO.isSeekable.impl.v3
+  358. -- ##IO.isSeekable.impl.v3
        builtin.io2.IO.isSeekable.impl : Handle
        ->{IO} Either Failure Boolean
        
-  358. -- ##IO.kill.impl.v3
+  359. -- ##IO.kill.impl.v3
        builtin.io2.IO.kill.impl : ThreadId
        ->{IO} Either Failure ()
        
-  359. -- ##IO.listen.impl.v3
+  360. -- ##IO.listen.impl.v3
        builtin.io2.IO.listen.impl : Socket
        ->{IO} Either Failure ()
        
-  360. -- ##IO.openFile.impl.v3
+  361. -- ##IO.openFile.impl.v3
        builtin.io2.IO.openFile.impl : Text
        -> FileMode
        ->{IO} Either Failure Handle
        
-  361. -- ##IO.process.call
+  362. -- ##IO.process.call
        builtin.io2.IO.process.call : Text -> [Text] ->{IO} Nat
        
-  362. -- ##IO.process.exitCode
+  363. -- ##IO.process.exitCode
        builtin.io2.IO.process.exitCode : ProcessHandle
        ->{IO} Optional Nat
        
-  363. -- ##IO.process.kill
+  364. -- ##IO.process.kill
        builtin.io2.IO.process.kill : ProcessHandle ->{IO} ()
        
-  364. -- ##IO.process.start
+  365. -- ##IO.process.start
        builtin.io2.IO.process.start : Text
        -> [Text]
        ->{IO} (Handle, Handle, Handle, ProcessHandle)
        
-  365. -- ##IO.process.wait
+  366. -- ##IO.process.wait
        builtin.io2.IO.process.wait : ProcessHandle ->{IO} Nat
        
-  366. -- ##IO.putBytes.impl.v3
+  367. -- ##IO.putBytes.impl.v3
        builtin.io2.IO.putBytes.impl : Handle
        -> Bytes
        ->{IO} Either Failure ()
        
-  367. -- ##IO.ready.impl.v1
+  368. -- ##IO.ready.impl.v1
        builtin.io2.IO.ready.impl : Handle
        ->{IO} Either Failure Boolean
        
-  368. -- ##IO.ref
+  369. -- ##IO.ref
        builtin.io2.IO.ref : a ->{IO} Ref {IO} a
        
-  369. -- ##IO.removeDirectory.impl.v3
+  370. -- ##IO.removeDirectory.impl.v3
        builtin.io2.IO.removeDirectory.impl : Text
        ->{IO} Either Failure ()
        
-  370. -- ##IO.removeFile.impl.v3
+  371. -- ##IO.removeFile.impl.v3
        builtin.io2.IO.removeFile.impl : Text
        ->{IO} Either Failure ()
        
-  371. -- ##IO.renameDirectory.impl.v3
+  372. -- ##IO.renameDirectory.impl.v3
        builtin.io2.IO.renameDirectory.impl : Text
        -> Text
        ->{IO} Either Failure ()
        
-  372. -- ##IO.renameFile.impl.v3
+  373. -- ##IO.renameFile.impl.v3
        builtin.io2.IO.renameFile.impl : Text
        -> Text
        ->{IO} Either Failure ()
        
-  373. -- ##IO.seekHandle.impl.v3
+  374. -- ##IO.seekHandle.impl.v3
        builtin.io2.IO.seekHandle.impl : Handle
        -> SeekMode
        -> Int
        ->{IO} Either Failure ()
        
-  374. -- ##IO.serverSocket.impl.v3
+  375. -- ##IO.serverSocket.impl.v3
        builtin.io2.IO.serverSocket.impl : Optional Text
        -> Text
        ->{IO} Either Failure Socket
        
-  375. -- ##IO.setBuffering.impl.v3
+  376. -- ##IO.setBuffering.impl.v3
        builtin.io2.IO.setBuffering.impl : Handle
        -> BufferMode
        ->{IO} Either Failure ()
        
-  376. -- ##IO.setCurrentDirectory.impl.v3
+  377. -- ##IO.setCurrentDirectory.impl.v3
        builtin.io2.IO.setCurrentDirectory.impl : Text
        ->{IO} Either Failure ()
        
-  377. -- ##IO.setEcho.impl.v1
+  378. -- ##IO.setEcho.impl.v1
        builtin.io2.IO.setEcho.impl : Handle
        -> Boolean
        ->{IO} Either Failure ()
        
-  378. -- ##IO.socketAccept.impl.v3
+  379. -- ##IO.socketAccept.impl.v3
        builtin.io2.IO.socketAccept.impl : Socket
        ->{IO} Either Failure Socket
        
-  379. -- ##IO.socketPort.impl.v3
+  380. -- ##IO.socketPort.impl.v3
        builtin.io2.IO.socketPort.impl : Socket
        ->{IO} Either Failure Nat
        
-  380. -- ##IO.socketReceive.impl.v3
+  381. -- ##IO.socketReceive.impl.v3
        builtin.io2.IO.socketReceive.impl : Socket
        -> Nat
        ->{IO} Either Failure Bytes
        
-  381. -- ##IO.socketSend.impl.v3
+  382. -- ##IO.socketSend.impl.v3
        builtin.io2.IO.socketSend.impl : Socket
        -> Bytes
        ->{IO} Either Failure ()
        
-  382. -- ##IO.stdHandle
+  383. -- ##IO.stdHandle
        builtin.io2.IO.stdHandle : StdHandle -> Handle
        
-  383. -- ##IO.systemTime.impl.v3
+  384. -- ##IO.systemTime.impl.v3
        builtin.io2.IO.systemTime.impl : '{IO} Either Failure Nat
        
-  384. -- ##IO.systemTimeMicroseconds.v1
+  385. -- ##IO.systemTimeMicroseconds.v1
        builtin.io2.IO.systemTimeMicroseconds : '{IO} Int
        
-  385. -- ##IO.tryEval
+  386. -- ##IO.tryEval
        builtin.io2.IO.tryEval : '{IO} a ->{IO, Exception} a
        
-  386. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0
+  387. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0
        unique type builtin.io2.IOError
        
-  387. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#0
+  388. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#0
        builtin.io2.IOError.AlreadyExists : IOError
        
-  388. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#4
+  389. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#4
        builtin.io2.IOError.EOF : IOError
        
-  389. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#5
+  390. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#5
        builtin.io2.IOError.IllegalOperation : IOError
        
-  390. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#1
+  391. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#1
        builtin.io2.IOError.NoSuchThing : IOError
        
-  391. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#6
+  392. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#6
        builtin.io2.IOError.PermissionDenied : IOError
        
-  392. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#2
+  393. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#2
        builtin.io2.IOError.ResourceBusy : IOError
        
-  393. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#3
+  394. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#3
        builtin.io2.IOError.ResourceExhausted : IOError
        
-  394. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#7
+  395. -- #h4smnou0l3fg4dn92g2r88j0imfvufjerkgbuscvvmaprv12l22nk6sff3c12edlikb2vfg3vfdj4b23a09q4lvtk75ckbe4lsmtuc0#7
        builtin.io2.IOError.UserError : IOError
        
-  395. -- #6ivk1e38hh0l9gcl8fn4mhf8bmak3qaji36vevg5e1n16ju5i4cl9u5gmqi7u16b907rd98gd60pouma892efbqt2ri58tmu99hp77g
+  396. -- #6ivk1e38hh0l9gcl8fn4mhf8bmak3qaji36vevg5e1n16ju5i4cl9u5gmqi7u16b907rd98gd60pouma892efbqt2ri58tmu99hp77g
        unique type builtin.io2.IOFailure
        
-  396. -- #574pvphqahl981k517dtrqtq812m05h3hj6t2bt9sn3pknenfik1krscfdb6r66nf1sm7g3r1r56k0c6ob7vg4opfq4gihi8njbnhsg
+  397. -- #574pvphqahl981k517dtrqtq812m05h3hj6t2bt9sn3pknenfik1krscfdb6r66nf1sm7g3r1r56k0c6ob7vg4opfq4gihi8njbnhsg
        unique type builtin.io2.MiscFailure
        
-  397. -- ##MVar
+  398. -- ##MVar
        builtin type builtin.io2.MVar
        
-  398. -- ##MVar.isEmpty
+  399. -- ##MVar.isEmpty
        builtin.io2.MVar.isEmpty : MVar a ->{IO} Boolean
        
-  399. -- ##MVar.new
+  400. -- ##MVar.new
        builtin.io2.MVar.new : a ->{IO} MVar a
        
-  400. -- ##MVar.newEmpty.v2
+  401. -- ##MVar.newEmpty.v2
        builtin.io2.MVar.newEmpty : '{IO} MVar a
        
-  401. -- ##MVar.put.impl.v3
+  402. -- ##MVar.put.impl.v3
        builtin.io2.MVar.put.impl : MVar a
        -> a
        ->{IO} Either Failure ()
        
-  402. -- ##MVar.read.impl.v3
+  403. -- ##MVar.read.impl.v3
        builtin.io2.MVar.read.impl : MVar a
        ->{IO} Either Failure a
        
-  403. -- ##MVar.swap.impl.v3
+  404. -- ##MVar.swap.impl.v3
        builtin.io2.MVar.swap.impl : MVar a
        -> a
        ->{IO} Either Failure a
        
-  404. -- ##MVar.take.impl.v3
+  405. -- ##MVar.take.impl.v3
        builtin.io2.MVar.take.impl : MVar a
        ->{IO} Either Failure a
        
-  405. -- ##MVar.tryPut.impl.v3
+  406. -- ##MVar.tryPut.impl.v3
        builtin.io2.MVar.tryPut.impl : MVar a
        -> a
        ->{IO} Either Failure Boolean
        
-  406. -- ##MVar.tryRead.impl.v3
+  407. -- ##MVar.tryRead.impl.v3
        builtin.io2.MVar.tryRead.impl : MVar a
        ->{IO} Either Failure (Optional a)
        
-  407. -- ##MVar.tryTake
+  408. -- ##MVar.tryTake
        builtin.io2.MVar.tryTake : MVar a ->{IO} Optional a
        
-  408. -- ##ProcessHandle
+  409. -- ##ProcessHandle
        builtin type builtin.io2.ProcessHandle
        
-  409. -- ##Promise
+  410. -- ##Promise
        builtin type builtin.io2.Promise
        
-  410. -- ##Promise.new
+  411. -- ##Promise.new
        builtin.io2.Promise.new : '{IO} Promise a
        
-  411. -- ##Promise.read
+  412. -- ##Promise.read
        builtin.io2.Promise.read : Promise a ->{IO} a
        
-  412. -- ##Promise.tryRead
+  413. -- ##Promise.tryRead
        builtin.io2.Promise.tryRead : Promise a ->{IO} Optional a
        
-  413. -- ##Promise.write
+  414. -- ##Promise.write
        builtin.io2.Promise.write : Promise a -> a ->{IO} Boolean
        
-  414. -- ##Ref.cas
+  415. -- ##Ref.cas
        builtin.io2.Ref.cas : Ref {IO} a
        -> Ticket a
        -> a
        ->{IO} Boolean
        
-  415. -- ##Ref.readForCas
+  416. -- ##Ref.readForCas
        builtin.io2.Ref.readForCas : Ref {IO} a ->{IO} Ticket a
        
-  416. -- ##Ref.Ticket
+  417. -- ##Ref.Ticket
        builtin type builtin.io2.Ref.Ticket
        
-  417. -- ##Ref.Ticket.read
+  418. -- ##Ref.Ticket.read
        builtin.io2.Ref.Ticket.read : Ticket a -> a
        
-  418. -- #vph2eas3lf2gi259f3khlrspml3id2l8u0ru07kb5fd833h238jk4iauju0b6decth9i3nao5jkf5eej1e1kovgmu5tghhh8jq3i7p8
+  419. -- #vph2eas3lf2gi259f3khlrspml3id2l8u0ru07kb5fd833h238jk4iauju0b6decth9i3nao5jkf5eej1e1kovgmu5tghhh8jq3i7p8
        unique type builtin.io2.RuntimeFailure
        
-  419. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40
+  420. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40
        unique type builtin.io2.SeekMode
        
-  420. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40#0
+  421. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40#0
        builtin.io2.SeekMode.AbsoluteSeek : SeekMode
        
-  421. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40#1
+  422. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40#1
        builtin.io2.SeekMode.RelativeSeek : SeekMode
        
-  422. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40#2
+  423. -- #1bca3hq98sfgr6a4onuon1tsda69cdjggq8pkmlsfola6492dbrih5up6dv18ptfbqeocm9q6parf64pj773p7p19qe76238o4trc40#2
        builtin.io2.SeekMode.SeekFromEnd : SeekMode
        
-  423. -- ##Socket
+  424. -- ##Socket
        builtin type builtin.io2.Socket
        
-  424. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8
+  425. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8
        unique type builtin.io2.StdHandle
        
-  425. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8#2
+  426. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8#2
        builtin.io2.StdHandle.StdErr : StdHandle
        
-  426. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8#0
+  427. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8#0
        builtin.io2.StdHandle.StdIn : StdHandle
        
-  427. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8#1
+  428. -- #121tku5rfh21t247v1cakhd6ir44fakkqsm799rrfp5qcjdls4nvdu4r3nco80stdd86tdo2hhh0ulcpoaofnrnkjun04kqnfmjqio8#1
        builtin.io2.StdHandle.StdOut : StdHandle
        
-  428. -- ##STM
+  429. -- ##STM
        builtin type builtin.io2.STM
        
-  429. -- ##STM.atomically
+  430. -- ##STM.atomically
        builtin.io2.STM.atomically : '{STM} a ->{IO} a
        
-  430. -- ##STM.retry
+  431. -- ##STM.retry
        builtin.io2.STM.retry : '{STM} a
        
-  431. -- #cggbdfff21ac5uedf4qvn4to83clinvhsovrila35u7f7e73g4l6hoj8pjmjnk713a8luhnn4bi1j9ai1nl0can1un66hvg230eog9g
+  432. -- #cggbdfff21ac5uedf4qvn4to83clinvhsovrila35u7f7e73g4l6hoj8pjmjnk713a8luhnn4bi1j9ai1nl0can1un66hvg230eog9g
        unique type builtin.io2.STMFailure
        
-  432. -- ##ThreadId
+  433. -- ##ThreadId
        builtin type builtin.io2.ThreadId
        
-  433. -- #ggh649864d9bfnk90n7kgtj7dflddc4kn8osu7u7mub8p7l8biid8dgtungj4u005h7karbgupfpum9jp94spks3ma1sgh39bhirv38
+  434. -- #ggh649864d9bfnk90n7kgtj7dflddc4kn8osu7u7mub8p7l8biid8dgtungj4u005h7karbgupfpum9jp94spks3ma1sgh39bhirv38
        unique type builtin.io2.ThreadKilledFailure
        
-  434. -- ##Tls
+  435. -- ##Tls
        builtin type builtin.io2.Tls
        
-  435. -- ##Tls.Cipher
+  436. -- ##Tls.Cipher
        builtin type builtin.io2.Tls.Cipher
        
-  436. -- ##Tls.ClientConfig
+  437. -- ##Tls.ClientConfig
        builtin type builtin.io2.Tls.ClientConfig
        
-  437. -- ##Tls.ClientConfig.certificates.set
+  438. -- ##Tls.ClientConfig.certificates.set
        builtin.io2.Tls.ClientConfig.certificates.set : [SignedCert]
        -> ClientConfig
        -> ClientConfig
        
-  438. -- ##TLS.ClientConfig.ciphers.set
+  439. -- ##TLS.ClientConfig.ciphers.set
        builtin.io2.TLS.ClientConfig.ciphers.set : [Cipher]
        -> ClientConfig
        -> ClientConfig
        
-  439. -- ##Tls.ClientConfig.default
+  440. -- ##Tls.ClientConfig.default
        builtin.io2.Tls.ClientConfig.default : Text
        -> Bytes
        -> ClientConfig
        
-  440. -- ##Tls.ClientConfig.versions.set
+  441. -- ##Tls.ClientConfig.versions.set
        builtin.io2.Tls.ClientConfig.versions.set : [Version]
        -> ClientConfig
        -> ClientConfig
        
-  441. -- ##Tls.decodeCert.impl.v3
+  442. -- ##Tls.decodeCert.impl.v3
        builtin.io2.Tls.decodeCert.impl : Bytes
        -> Either Failure SignedCert
        
-  442. -- ##Tls.decodePrivateKey
+  443. -- ##Tls.decodePrivateKey
        builtin.io2.Tls.decodePrivateKey : Bytes -> [PrivateKey]
        
-  443. -- ##Tls.encodeCert
+  444. -- ##Tls.encodeCert
        builtin.io2.Tls.encodeCert : SignedCert -> Bytes
        
-  444. -- ##Tls.encodePrivateKey
+  445. -- ##Tls.encodePrivateKey
        builtin.io2.Tls.encodePrivateKey : PrivateKey -> Bytes
        
-  445. -- ##Tls.handshake.impl.v3
+  446. -- ##Tls.handshake.impl.v3
        builtin.io2.Tls.handshake.impl : Tls
        ->{IO} Either Failure ()
        
-  446. -- ##Tls.newClient.impl.v3
+  447. -- ##Tls.newClient.impl.v3
        builtin.io2.Tls.newClient.impl : ClientConfig
        -> Socket
        ->{IO} Either Failure Tls
        
-  447. -- ##Tls.newServer.impl.v3
+  448. -- ##Tls.newServer.impl.v3
        builtin.io2.Tls.newServer.impl : ServerConfig
        -> Socket
        ->{IO} Either Failure Tls
        
-  448. -- ##Tls.PrivateKey
+  449. -- ##Tls.PrivateKey
        builtin type builtin.io2.Tls.PrivateKey
        
-  449. -- ##Tls.receive.impl.v3
+  450. -- ##Tls.receive.impl.v3
        builtin.io2.Tls.receive.impl : Tls
        ->{IO} Either Failure Bytes
        
-  450. -- ##Tls.send.impl.v3
+  451. -- ##Tls.send.impl.v3
        builtin.io2.Tls.send.impl : Tls
        -> Bytes
        ->{IO} Either Failure ()
        
-  451. -- ##Tls.ServerConfig
+  452. -- ##Tls.ServerConfig
        builtin type builtin.io2.Tls.ServerConfig
        
-  452. -- ##Tls.ServerConfig.certificates.set
+  453. -- ##Tls.ServerConfig.certificates.set
        builtin.io2.Tls.ServerConfig.certificates.set : [SignedCert]
        -> ServerConfig
        -> ServerConfig
        
-  453. -- ##Tls.ServerConfig.ciphers.set
+  454. -- ##Tls.ServerConfig.ciphers.set
        builtin.io2.Tls.ServerConfig.ciphers.set : [Cipher]
        -> ServerConfig
        -> ServerConfig
        
-  454. -- ##Tls.ServerConfig.default
+  455. -- ##Tls.ServerConfig.default
        builtin.io2.Tls.ServerConfig.default : [SignedCert]
        -> PrivateKey
        -> ServerConfig
        
-  455. -- ##Tls.ServerConfig.versions.set
+  456. -- ##Tls.ServerConfig.versions.set
        builtin.io2.Tls.ServerConfig.versions.set : [Version]
        -> ServerConfig
        -> ServerConfig
        
-  456. -- ##Tls.SignedCert
+  457. -- ##Tls.SignedCert
        builtin type builtin.io2.Tls.SignedCert
        
-  457. -- ##Tls.terminate.impl.v3
+  458. -- ##Tls.terminate.impl.v3
        builtin.io2.Tls.terminate.impl : Tls
        ->{IO} Either Failure ()
        
-  458. -- ##Tls.Version
+  459. -- ##Tls.Version
        builtin type builtin.io2.Tls.Version
        
-  459. -- #r3gag1btclr8iclbdt68irgt8n1d1vf7agv5umke3dgdbl11acj6easav6gtihanrjnct18om07638rne9ej06u2bkv2v4l36knm2l0
+  460. -- #r3gag1btclr8iclbdt68irgt8n1d1vf7agv5umke3dgdbl11acj6easav6gtihanrjnct18om07638rne9ej06u2bkv2v4l36knm2l0
        unique type builtin.io2.TlsFailure
        
-  460. -- ##TVar
+  461. -- ##TVar
        builtin type builtin.io2.TVar
        
-  461. -- ##TVar.new
+  462. -- ##TVar.new
        builtin.io2.TVar.new : a ->{STM} TVar a
        
-  462. -- ##TVar.newIO
+  463. -- ##TVar.newIO
        builtin.io2.TVar.newIO : a ->{IO} TVar a
        
-  463. -- ##TVar.read
+  464. -- ##TVar.read
        builtin.io2.TVar.read : TVar a ->{STM} a
        
-  464. -- ##TVar.readIO
+  465. -- ##TVar.readIO
        builtin.io2.TVar.readIO : TVar a ->{IO} a
        
-  465. -- ##TVar.swap
+  466. -- ##TVar.swap
        builtin.io2.TVar.swap : TVar a -> a ->{STM} a
        
-  466. -- ##TVar.write
+  467. -- ##TVar.write
        builtin.io2.TVar.write : TVar a -> a ->{STM} ()
        
-  467. -- ##validateSandboxed
+  468. -- ##validateSandboxed
        builtin.io2.validateSandboxed : [Link.Term]
        -> a
        -> Boolean
        
-  468. -- #c23jofurcegj93796o0karmkcm6baifupiuu1rtkniu74avn6a4r1n66ga5rml5di7easkgn4iak800u3tnb6kfisbrv6tcfgkb13a8
+  469. -- #c23jofurcegj93796o0karmkcm6baifupiuu1rtkniu74avn6a4r1n66ga5rml5di7easkgn4iak800u3tnb6kfisbrv6tcfgkb13a8
        unique type builtin.IsPropagated
        
-  469. -- #c23jofurcegj93796o0karmkcm6baifupiuu1rtkniu74avn6a4r1n66ga5rml5di7easkgn4iak800u3tnb6kfisbrv6tcfgkb13a8#0
+  470. -- #c23jofurcegj93796o0karmkcm6baifupiuu1rtkniu74avn6a4r1n66ga5rml5di7easkgn4iak800u3tnb6kfisbrv6tcfgkb13a8#0
        builtin.IsPropagated.IsPropagated : IsPropagated
        
-  470. -- #q6snodsh7i7u6k7gtqj73tt7nv6htjofs5f37vg2v3dsfk6hau71fs5mcv0hq3lqg111fsvoi92mngm08850aftfgh65uka9mhqvft0
+  471. -- #q6snodsh7i7u6k7gtqj73tt7nv6htjofs5f37vg2v3dsfk6hau71fs5mcv0hq3lqg111fsvoi92mngm08850aftfgh65uka9mhqvft0
        unique type builtin.IsTest
        
-  471. -- #q6snodsh7i7u6k7gtqj73tt7nv6htjofs5f37vg2v3dsfk6hau71fs5mcv0hq3lqg111fsvoi92mngm08850aftfgh65uka9mhqvft0#0
+  472. -- #q6snodsh7i7u6k7gtqj73tt7nv6htjofs5f37vg2v3dsfk6hau71fs5mcv0hq3lqg111fsvoi92mngm08850aftfgh65uka9mhqvft0#0
        builtin.IsTest.IsTest : IsTest
        
-  472. -- #68haromionghg6cvojngjrgc7t0ob658nkk8b20fpho6k6ltjtf6rfmr4ia1omige97hk34lu21qsj933vl1dkpbna7evbjfkh71r9g
+  473. -- #68haromionghg6cvojngjrgc7t0ob658nkk8b20fpho6k6ltjtf6rfmr4ia1omige97hk34lu21qsj933vl1dkpbna7evbjfkh71r9g
        unique type builtin.License
        
-  473. -- #knhl4mlkqf0mt877flahlbas2ufb7bub8f11vi9ihh9uf7r6jqaglk7rm6912q1vml50866ddl0qfa4o6d7o0gomchaoae24m0u2nk8
+  474. -- #knhl4mlkqf0mt877flahlbas2ufb7bub8f11vi9ihh9uf7r6jqaglk7rm6912q1vml50866ddl0qfa4o6d7o0gomchaoae24m0u2nk8
        builtin.License.copyrightHolders : License
        -> [CopyrightHolder]
        
-  474. -- #ucpi54l843bf1osaejl1cnn0jt3o89fak5c0120k8256in3m80ik836hnite0osl12m91utnpnt5n7pgm3oe1rv4r1hk8ai4033agvo
+  475. -- #ucpi54l843bf1osaejl1cnn0jt3o89fak5c0120k8256in3m80ik836hnite0osl12m91utnpnt5n7pgm3oe1rv4r1hk8ai4033agvo
        builtin.License.copyrightHolders.modify : ([CopyrightHolder]
        ->{g} [CopyrightHolder])
        -> License
        ->{g} License
        
-  475. -- #9hbbfn61d2odn8jvtj5da9n1e9decsrheg6chg73uf94oituv3750b9hd6vp3ljhi54dkp5uqfg57j66i39bstfd8ivgav4p3si39ro
+  476. -- #9hbbfn61d2odn8jvtj5da9n1e9decsrheg6chg73uf94oituv3750b9hd6vp3ljhi54dkp5uqfg57j66i39bstfd8ivgav4p3si39ro
        builtin.License.copyrightHolders.set : [CopyrightHolder]
        -> License
        -> License
        
-  476. -- #68haromionghg6cvojngjrgc7t0ob658nkk8b20fpho6k6ltjtf6rfmr4ia1omige97hk34lu21qsj933vl1dkpbna7evbjfkh71r9g#0
+  477. -- #68haromionghg6cvojngjrgc7t0ob658nkk8b20fpho6k6ltjtf6rfmr4ia1omige97hk34lu21qsj933vl1dkpbna7evbjfkh71r9g#0
        builtin.License.License : [CopyrightHolder]
        -> [Year]
        -> LicenseType
        -> License
        
-  477. -- #aqi4h1bfq2rjnrrfanf4nut8jd1elkkc00u1tn0rmt9ocsrds8i8pha7q9cihvbiq7edpg21iqnfornimae2gad0ab8ih0bksjnoi4g
+  478. -- #aqi4h1bfq2rjnrrfanf4nut8jd1elkkc00u1tn0rmt9ocsrds8i8pha7q9cihvbiq7edpg21iqnfornimae2gad0ab8ih0bksjnoi4g
        builtin.License.licenseType : License -> LicenseType
        
-  478. -- #1rm8kpbv278t9tqj4jfssl8q3cn4hgu1mti7bp8lhcr5h7qmojujmt9de4c31p42to8mtav61u98oad3oen8q9im20sacs69psjpugo
+  479. -- #1rm8kpbv278t9tqj4jfssl8q3cn4hgu1mti7bp8lhcr5h7qmojujmt9de4c31p42to8mtav61u98oad3oen8q9im20sacs69psjpugo
        builtin.License.licenseType.modify : (LicenseType
        ->{g} LicenseType)
        -> License
        ->{g} License
        
-  479. -- #dv9jsg0ksrlp3g0uftvkutpa8matt039o7dhat9airnkto2b703mgoi5t412hdi95pdhp9g01luga13ihmp52nk6bgh788gts6elv2o
+  480. -- #dv9jsg0ksrlp3g0uftvkutpa8matt039o7dhat9airnkto2b703mgoi5t412hdi95pdhp9g01luga13ihmp52nk6bgh788gts6elv2o
        builtin.License.licenseType.set : LicenseType
        -> License
        -> License
        
-  480. -- #fh5qbeba2hg5c5k9uppi71rfghj8df37p4cg3hk23b9pv0hpm67ok807f05t368rn6v99v7kvf7cp984v8ipkjr1j1h095g6nd9jtig
+  481. -- #fh5qbeba2hg5c5k9uppi71rfghj8df37p4cg3hk23b9pv0hpm67ok807f05t368rn6v99v7kvf7cp984v8ipkjr1j1h095g6nd9jtig
        builtin.License.years : License -> [Year]
        
-  481. -- #2samr066hti71pf0fkvb4niemm7j3amvaap3sk1dqpihqp9g8f8lknhhmjq9atai6j5kcs4huvfokvpm15ebefmfggr4hd2cetf7co0
+  482. -- #2samr066hti71pf0fkvb4niemm7j3amvaap3sk1dqpihqp9g8f8lknhhmjq9atai6j5kcs4huvfokvpm15ebefmfggr4hd2cetf7co0
        builtin.License.years.modify : ([Year] ->{g} [Year])
        -> License
        ->{g} License
        
-  482. -- #g3ap8lg6974au4meb2hl49k1k6f048det9uckmics3bkt9s571921ksqfdsch63k2pk3fij8pn697svniakkrueddh8nkflnmjk9ffo
+  483. -- #g3ap8lg6974au4meb2hl49k1k6f048det9uckmics3bkt9s571921ksqfdsch63k2pk3fij8pn697svniakkrueddh8nkflnmjk9ffo
        builtin.License.years.set : [Year] -> License -> License
        
-  483. -- #uj652rrb45urfnojgt1ssqoji7iiibu27uhrc1sfl68lm54hbr7r1dpgppsv0pvf0oile2uk2h2gn1h4vgng30fga66idihhen14qc0
+  484. -- #uj652rrb45urfnojgt1ssqoji7iiibu27uhrc1sfl68lm54hbr7r1dpgppsv0pvf0oile2uk2h2gn1h4vgng30fga66idihhen14qc0
        unique type builtin.LicenseType
        
-  484. -- #uj652rrb45urfnojgt1ssqoji7iiibu27uhrc1sfl68lm54hbr7r1dpgppsv0pvf0oile2uk2h2gn1h4vgng30fga66idihhen14qc0#0
+  485. -- #uj652rrb45urfnojgt1ssqoji7iiibu27uhrc1sfl68lm54hbr7r1dpgppsv0pvf0oile2uk2h2gn1h4vgng30fga66idihhen14qc0#0
        builtin.LicenseType.LicenseType : Doc -> LicenseType
        
-  485. -- #f4b37niu61dc517c32h3os36ig34fgnt7inaaoqdbecmscchthi14gdo0vj3eee1ru746ibvl9vnmm1pglrv3125qnhsbc0i1tqtic0
+  486. -- #f4b37niu61dc517c32h3os36ig34fgnt7inaaoqdbecmscchthi14gdo0vj3eee1ru746ibvl9vnmm1pglrv3125qnhsbc0i1tqtic0
        unique type builtin.Link
        
-  486. -- ##Link.Term
+  487. -- ##Link.Term
        builtin type builtin.Link.Term
        
-  487. -- #f4b37niu61dc517c32h3os36ig34fgnt7inaaoqdbecmscchthi14gdo0vj3eee1ru746ibvl9vnmm1pglrv3125qnhsbc0i1tqtic0#0
+  488. -- #f4b37niu61dc517c32h3os36ig34fgnt7inaaoqdbecmscchthi14gdo0vj3eee1ru746ibvl9vnmm1pglrv3125qnhsbc0i1tqtic0#0
        builtin.Link.Term : Link.Term -> Link
        
-  488. -- ##Link.Term.toText
+  489. -- ##Link.Term.toText
        builtin.Link.Term.toText : Link.Term -> Text
        
-  489. -- ##Link.Type
+  490. -- ##Link.Type
        builtin type builtin.Link.Type
        
-  490. -- #f4b37niu61dc517c32h3os36ig34fgnt7inaaoqdbecmscchthi14gdo0vj3eee1ru746ibvl9vnmm1pglrv3125qnhsbc0i1tqtic0#1
+  491. -- #f4b37niu61dc517c32h3os36ig34fgnt7inaaoqdbecmscchthi14gdo0vj3eee1ru746ibvl9vnmm1pglrv3125qnhsbc0i1tqtic0#1
        builtin.Link.Type : Type -> Link
        
-  491. -- ##Sequence
+  492. -- ##Sequence
        builtin type builtin.List
        
-  492. -- ##List.++
+  493. -- ##List.++
        builtin.List.++ : [a] -> [a] -> [a]
        
-  493. -- ##List.cons
+  494. -- ##List.cons
        builtin.List.+:, builtin.List.cons : a -> [a] -> [a]
        
-  494. -- ##List.snoc
+  495. -- ##List.snoc
        builtin.List.:+, builtin.List.snoc : [a] -> a -> [a]
        
-  495. -- ##List.at
+  496. -- ##List.at
        builtin.List.at : Nat -> [a] -> Optional a
        
-  496. -- ##List.cons
+  497. -- ##List.cons
        builtin.List.cons, builtin.List.+: : a -> [a] -> [a]
        
-  497. -- ##List.drop
+  498. -- ##List.drop
        builtin.List.drop : Nat -> [a] -> [a]
        
-  498. -- ##List.empty
+  499. -- ##List.empty
        builtin.List.empty : [a]
        
-  499. -- #a8ia0nqfghkpj4dt0t5gsk96tsfv6kg1k2cf7d7sb83tkqosebfiib2bkhjq48tc2v8ld94gf9o3hvc42pf6j49q75k0br395qavli0
+  500. -- #a8ia0nqfghkpj4dt0t5gsk96tsfv6kg1k2cf7d7sb83tkqosebfiib2bkhjq48tc2v8ld94gf9o3hvc42pf6j49q75k0br395qavli0
        builtin.List.map : (a ->{e} b) -> [a] ->{e} [b]
        
-  500. -- ##List.size
+  501. -- ##List.size
        builtin.List.size : [a] -> Nat
        
-  501. -- ##List.snoc
+  502. -- ##List.snoc
        builtin.List.snoc, builtin.List.:+ : [a] -> a -> [a]
        
-  502. -- ##List.take
+  503. -- ##List.take
        builtin.List.take : Nat -> [a] -> [a]
        
-  503. -- #cb9e3iosob3e4q0v96ifmserg27samv1lvi4dh0l0l19phvct4vbbvv19abngneb77b02h8cefr1o3ad8gnm3cn6mjgsub97gjlte8g
+  504. -- #cb9e3iosob3e4q0v96ifmserg27samv1lvi4dh0l0l19phvct4vbbvv19abngneb77b02h8cefr1o3ad8gnm3cn6mjgsub97gjlte8g
        builtin.metadata.isPropagated : IsPropagated
        
-  504. -- #lkpne3jg56pmqegv4jba6b5nnjg86qtfllnlmtvijql5lsf89rfu6tgb1s9ic0gsqs5si0v9agmj90lk0bhihbovd5o5ve023g4ocko
+  505. -- #lkpne3jg56pmqegv4jba6b5nnjg86qtfllnlmtvijql5lsf89rfu6tgb1s9ic0gsqs5si0v9agmj90lk0bhihbovd5o5ve023g4ocko
        builtin.metadata.isTest : IsTest
        
-  505. -- ##MutableArray
+  506. -- ##MutableArray
        builtin type builtin.MutableArray
        
-  506. -- ##MutableArray.copyTo!
+  507. -- ##MutableArray.copyTo!
        builtin.MutableArray.copyTo! : MutableArray g a
        -> Nat
        -> MutableArray g a
@@ -1766,34 +1769,34 @@ This transcript is intended to make visible accidental changes to the hashing al
        -> Nat
        ->{g, Exception} ()
        
-  507. -- ##MutableArray.freeze
+  508. -- ##MutableArray.freeze
        builtin.MutableArray.freeze : MutableArray g a
        -> Nat
        -> Nat
        ->{g} ImmutableArray a
        
-  508. -- ##MutableArray.freeze!
+  509. -- ##MutableArray.freeze!
        builtin.MutableArray.freeze! : MutableArray g a
        ->{g} ImmutableArray a
        
-  509. -- ##MutableArray.read
+  510. -- ##MutableArray.read
        builtin.MutableArray.read : MutableArray g a
        -> Nat
        ->{g, Exception} a
        
-  510. -- ##MutableArray.size
+  511. -- ##MutableArray.size
        builtin.MutableArray.size : MutableArray g a -> Nat
        
-  511. -- ##MutableArray.write
+  512. -- ##MutableArray.write
        builtin.MutableArray.write : MutableArray g a
        -> Nat
        -> a
        ->{g, Exception} ()
        
-  512. -- ##MutableByteArray
+  513. -- ##MutableByteArray
        builtin type builtin.MutableByteArray
        
-  513. -- ##MutableByteArray.copyTo!
+  514. -- ##MutableByteArray.copyTo!
        builtin.MutableByteArray.copyTo! : MutableByteArray g
        -> Nat
        -> MutableByteArray g
@@ -1801,688 +1804,688 @@ This transcript is intended to make visible accidental changes to the hashing al
        -> Nat
        ->{g, Exception} ()
        
-  514. -- ##MutableByteArray.freeze
+  515. -- ##MutableByteArray.freeze
        builtin.MutableByteArray.freeze : MutableByteArray g
        -> Nat
        -> Nat
        ->{g} ImmutableByteArray
        
-  515. -- ##MutableByteArray.freeze!
+  516. -- ##MutableByteArray.freeze!
        builtin.MutableByteArray.freeze! : MutableByteArray g
        ->{g} ImmutableByteArray
        
-  516. -- ##MutableByteArray.read16be
+  517. -- ##MutableByteArray.read16be
        builtin.MutableByteArray.read16be : MutableByteArray g
        -> Nat
        ->{g, Exception} Nat
        
-  517. -- ##MutableByteArray.read24be
+  518. -- ##MutableByteArray.read24be
        builtin.MutableByteArray.read24be : MutableByteArray g
        -> Nat
        ->{g, Exception} Nat
        
-  518. -- ##MutableByteArray.read32be
+  519. -- ##MutableByteArray.read32be
        builtin.MutableByteArray.read32be : MutableByteArray g
        -> Nat
        ->{g, Exception} Nat
        
-  519. -- ##MutableByteArray.read40be
+  520. -- ##MutableByteArray.read40be
        builtin.MutableByteArray.read40be : MutableByteArray g
        -> Nat
        ->{g, Exception} Nat
        
-  520. -- ##MutableByteArray.read64be
+  521. -- ##MutableByteArray.read64be
        builtin.MutableByteArray.read64be : MutableByteArray g
        -> Nat
        ->{g, Exception} Nat
        
-  521. -- ##MutableByteArray.read8
+  522. -- ##MutableByteArray.read8
        builtin.MutableByteArray.read8 : MutableByteArray g
        -> Nat
        ->{g, Exception} Nat
        
-  522. -- ##MutableByteArray.size
+  523. -- ##MutableByteArray.size
        builtin.MutableByteArray.size : MutableByteArray g -> Nat
        
-  523. -- ##MutableByteArray.write16be
+  524. -- ##MutableByteArray.write16be
        builtin.MutableByteArray.write16be : MutableByteArray g
        -> Nat
        -> Nat
        ->{g, Exception} ()
        
-  524. -- ##MutableByteArray.write32be
+  525. -- ##MutableByteArray.write32be
        builtin.MutableByteArray.write32be : MutableByteArray g
        -> Nat
        -> Nat
        ->{g, Exception} ()
        
-  525. -- ##MutableByteArray.write64be
+  526. -- ##MutableByteArray.write64be
        builtin.MutableByteArray.write64be : MutableByteArray g
        -> Nat
        -> Nat
        ->{g, Exception} ()
        
-  526. -- ##MutableByteArray.write8
+  527. -- ##MutableByteArray.write8
        builtin.MutableByteArray.write8 : MutableByteArray g
        -> Nat
        -> Nat
        ->{g, Exception} ()
        
-  527. -- ##Nat
+  528. -- ##Nat
        builtin type builtin.Nat
        
-  528. -- ##Nat.*
+  529. -- ##Nat.*
        builtin.Nat.* : Nat -> Nat -> Nat
        
-  529. -- ##Nat.+
+  530. -- ##Nat.+
        builtin.Nat.+ : Nat -> Nat -> Nat
        
-  530. -- ##Nat./
+  531. -- ##Nat./
        builtin.Nat./ : Nat -> Nat -> Nat
        
-  531. -- ##Nat.and
+  532. -- ##Nat.and
        builtin.Nat.and : Nat -> Nat -> Nat
        
-  532. -- ##Nat.complement
+  533. -- ##Nat.complement
        builtin.Nat.complement : Nat -> Nat
        
-  533. -- ##Nat.drop
+  534. -- ##Nat.drop
        builtin.Nat.drop : Nat -> Nat -> Nat
        
-  534. -- ##Nat.==
+  535. -- ##Nat.==
        builtin.Nat.eq : Nat -> Nat -> Boolean
        
-  535. -- ##Nat.fromText
+  536. -- ##Nat.fromText
        builtin.Nat.fromText : Text -> Optional Nat
        
-  536. -- ##Nat.>
+  537. -- ##Nat.>
        builtin.Nat.gt : Nat -> Nat -> Boolean
        
-  537. -- ##Nat.>=
+  538. -- ##Nat.>=
        builtin.Nat.gteq : Nat -> Nat -> Boolean
        
-  538. -- ##Nat.increment
+  539. -- ##Nat.increment
        builtin.Nat.increment : Nat -> Nat
        
-  539. -- ##Nat.isEven
+  540. -- ##Nat.isEven
        builtin.Nat.isEven : Nat -> Boolean
        
-  540. -- ##Nat.isOdd
+  541. -- ##Nat.isOdd
        builtin.Nat.isOdd : Nat -> Boolean
        
-  541. -- ##Nat.leadingZeros
+  542. -- ##Nat.leadingZeros
        builtin.Nat.leadingZeros : Nat -> Nat
        
-  542. -- ##Nat.<
+  543. -- ##Nat.<
        builtin.Nat.lt : Nat -> Nat -> Boolean
        
-  543. -- ##Nat.<=
+  544. -- ##Nat.<=
        builtin.Nat.lteq : Nat -> Nat -> Boolean
        
-  544. -- ##Nat.mod
+  545. -- ##Nat.mod
        builtin.Nat.mod : Nat -> Nat -> Nat
        
-  545. -- ##Nat.or
+  546. -- ##Nat.or
        builtin.Nat.or : Nat -> Nat -> Nat
        
-  546. -- ##Nat.popCount
+  547. -- ##Nat.popCount
        builtin.Nat.popCount : Nat -> Nat
        
-  547. -- ##Nat.pow
+  548. -- ##Nat.pow
        builtin.Nat.pow : Nat -> Nat -> Nat
        
-  548. -- ##Nat.shiftLeft
+  549. -- ##Nat.shiftLeft
        builtin.Nat.shiftLeft : Nat -> Nat -> Nat
        
-  549. -- ##Nat.shiftRight
+  550. -- ##Nat.shiftRight
        builtin.Nat.shiftRight : Nat -> Nat -> Nat
        
-  550. -- ##Nat.sub
+  551. -- ##Nat.sub
        builtin.Nat.sub : Nat -> Nat -> Int
        
-  551. -- ##Nat.toFloat
+  552. -- ##Nat.toFloat
        builtin.Nat.toFloat : Nat -> Float
        
-  552. -- ##Nat.toInt
+  553. -- ##Nat.toInt
        builtin.Nat.toInt : Nat -> Int
        
-  553. -- ##Nat.toText
+  554. -- ##Nat.toText
        builtin.Nat.toText : Nat -> Text
        
-  554. -- ##Nat.trailingZeros
+  555. -- ##Nat.trailingZeros
        builtin.Nat.trailingZeros : Nat -> Nat
        
-  555. -- ##Nat.xor
+  556. -- ##Nat.xor
        builtin.Nat.xor : Nat -> Nat -> Nat
        
-  556. -- #nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg
+  557. -- #nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg
        structural type builtin.Optional a
        
-  557. -- #nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#1
+  558. -- #nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#1
        builtin.Optional.None : Optional a
        
-  558. -- #nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#0
+  559. -- #nirp5os0q69o4e1u9p3t6mmq6l6otluefi3ksm7dhm0diidjvkkgl8o9bvnflbj0sanuvdusf34f1qrins3ktcaglpcqv9oums2slsg#0
        builtin.Optional.Some : a -> Optional a
        
-  559. -- ##Pattern
+  560. -- ##Pattern
        builtin type builtin.Pattern
        
-  560. -- ##Pattern.capture
+  561. -- ##Pattern.capture
        builtin.Pattern.capture : Pattern a -> Pattern a
        
-  561. -- ##Pattern.isMatch
+  562. -- ##Pattern.isMatch
        builtin.Pattern.isMatch : Pattern a -> a -> Boolean
        
-  562. -- ##Pattern.join
+  563. -- ##Pattern.join
        builtin.Pattern.join : [Pattern a] -> Pattern a
        
-  563. -- ##Pattern.many
+  564. -- ##Pattern.many
        builtin.Pattern.many : Pattern a -> Pattern a
        
-  564. -- ##Pattern.or
+  565. -- ##Pattern.or
        builtin.Pattern.or : Pattern a -> Pattern a -> Pattern a
        
-  565. -- ##Pattern.replicate
+  566. -- ##Pattern.replicate
        builtin.Pattern.replicate : Nat
        -> Nat
        -> Pattern a
        -> Pattern a
        
-  566. -- ##Pattern.run
+  567. -- ##Pattern.run
        builtin.Pattern.run : Pattern a -> a -> Optional ([a], a)
        
-  567. -- #cbo8de57n17pgc5iic1741jeiunhvhfcfd7gt79vd6516u64aplasdodqoouejbgovhge2le5jb6rje923fcrllhtu01t29cdrssgbg
+  568. -- #cbo8de57n17pgc5iic1741jeiunhvhfcfd7gt79vd6516u64aplasdodqoouejbgovhge2le5jb6rje923fcrllhtu01t29cdrssgbg
        structural type builtin.Pretty txt
        
-  568. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8
+  569. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8
        unique type builtin.Pretty.Annotated w txt
        
-  569. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#1
+  570. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#1
        builtin.Pretty.Annotated.Append : w
        -> [Annotated w txt]
        -> Annotated w txt
        
-  570. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#6
+  571. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#6
        builtin.Pretty.Annotated.Empty : Annotated w txt
        
-  571. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#4
+  572. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#4
        builtin.Pretty.Annotated.Group : w
        -> Annotated w txt
        -> Annotated w txt
        
-  572. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#3
+  573. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#3
        builtin.Pretty.Annotated.Indent : w
        -> Annotated w txt
        -> Annotated w txt
        -> Annotated w txt
        -> Annotated w txt
        
-  573. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#7
+  574. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#7
        builtin.Pretty.Annotated.Lit : w
        -> txt
        -> Annotated w txt
        
-  574. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#2
+  575. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#2
        builtin.Pretty.Annotated.OrElse : w
        -> Annotated w txt
        -> Annotated w txt
        -> Annotated w txt
        
-  575. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#0
+  576. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#0
        builtin.Pretty.Annotated.Table : w
        -> [[Annotated w txt]]
        -> Annotated w txt
        
-  576. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#5
+  577. -- #fqfaur9v9v4fks5d0c74ouitpjp121c3fbu2l9t05km8otjcj43gk453vu668pg54rte6qmh4v3uao6vbfpntrtaq057jgni1jk8fj8#5
        builtin.Pretty.Annotated.Wrap : w
        -> Annotated w txt
        -> Annotated w txt
        
-  577. -- #svdhl4ogs0m1pe7ihtq5q9td72mg41tmndqif4kktbtv4p8e1ciapaj8kvflfbm876llbh60tlkefpi0v0bra8hl7mfgnpscimeqtdg
+  578. -- #svdhl4ogs0m1pe7ihtq5q9td72mg41tmndqif4kktbtv4p8e1ciapaj8kvflfbm876llbh60tlkefpi0v0bra8hl7mfgnpscimeqtdg
        builtin.Pretty.append : Pretty txt
        -> Pretty txt
        -> Pretty txt
        
-  578. -- #sonptakf85a3uklev4rq0pub00k56jdpaop4tcd9bmk0gmjjij5t16sf1knspku2hbp0uikiflbo0dtjv1i6r3t2rpjh86vo1rlaer8
+  579. -- #sonptakf85a3uklev4rq0pub00k56jdpaop4tcd9bmk0gmjjij5t16sf1knspku2hbp0uikiflbo0dtjv1i6r3t2rpjh86vo1rlaer8
        builtin.Pretty.empty : Pretty txt
        
-  579. -- #mlpplm1bhqkcif5j09204uuvfll7qte95msb0skjfd30nmei005kiich1ao39gm2j8687s14qvf5llu6i1a6fvt4vdmbp99jlfundfo
+  580. -- #mlpplm1bhqkcif5j09204uuvfll7qte95msb0skjfd30nmei005kiich1ao39gm2j8687s14qvf5llu6i1a6fvt4vdmbp99jlfundfo
        builtin.Pretty.get : Pretty txt -> Annotated () txt
        
-  580. -- #d9m2k9igi4b50cp7v5tlp3o7dot6r41rbbbsc2a4iqae3hc2a7fceh83l1n3nuotfnn7nrgt40s1kfbcnl89qcqieih125gsafk2d00
+  581. -- #d9m2k9igi4b50cp7v5tlp3o7dot6r41rbbbsc2a4iqae3hc2a7fceh83l1n3nuotfnn7nrgt40s1kfbcnl89qcqieih125gsafk2d00
        builtin.Pretty.group : Pretty txt -> Pretty txt
        
-  581. -- #p6rkh0u8gfko2fpqdje6h8cain3qakom06a28rh4ccsjsnbagmmv6gadccg4t380c4nnetq9si7bkkvbh44it4lrfvfvcn4usps1uno
+  582. -- #p6rkh0u8gfko2fpqdje6h8cain3qakom06a28rh4ccsjsnbagmmv6gadccg4t380c4nnetq9si7bkkvbh44it4lrfvfvcn4usps1uno
        builtin.Pretty.indent : Pretty txt
        -> Pretty txt
        -> Pretty txt
        
-  582. -- #f59sgojafl5so8ei4vgdpqflqcpsgovpcea73509k5qm1jb8vkeojsfsavhn64gmfpd52uo631ejqu0oj2a6t6k8jcu282lbqjou7ug
+  583. -- #f59sgojafl5so8ei4vgdpqflqcpsgovpcea73509k5qm1jb8vkeojsfsavhn64gmfpd52uo631ejqu0oj2a6t6k8jcu282lbqjou7ug
        builtin.Pretty.indent' : Pretty txt
        -> Pretty txt
        -> Pretty txt
        -> Pretty txt
        
-  583. -- #hpntja4i04u36vijdesobh75pubru68jf1fhgi49jl3nf6kall1so8hfc0bq0pm8r9kopgskiigdl04hqelklsdrdjndq5on9hsjgmo
+  584. -- #hpntja4i04u36vijdesobh75pubru68jf1fhgi49jl3nf6kall1so8hfc0bq0pm8r9kopgskiigdl04hqelklsdrdjndq5on9hsjgmo
        builtin.Pretty.join : [Pretty txt] -> Pretty txt
        
-  584. -- #jtn2i6bg3gargdp2rbk08jfd327htap62brih8phdfm2m4d6ib9cu0o2k5vrh7f4jik99eufu4hi0114akgd1oiivi8p1pa9m2fvjv0
+  585. -- #jtn2i6bg3gargdp2rbk08jfd327htap62brih8phdfm2m4d6ib9cu0o2k5vrh7f4jik99eufu4hi0114akgd1oiivi8p1pa9m2fvjv0
        builtin.Pretty.lit : txt -> Pretty txt
        
-  585. -- #kfgfekabh7tiprb6ljjkf4qa5puqp6bbpe1oiqv9r39taljs8ahtb518mpcmec3plesvpssn3bpgvq3e7d71giot6lb2j7mbk23dtqo
+  586. -- #kfgfekabh7tiprb6ljjkf4qa5puqp6bbpe1oiqv9r39taljs8ahtb518mpcmec3plesvpssn3bpgvq3e7d71giot6lb2j7mbk23dtqo
        builtin.Pretty.map : (txt ->{g} txt2)
        -> Pretty txt
        ->{g} Pretty txt2
        
-  586. -- #5rfcm6mlv2njfa8l9slkjp1q2q5r6m1vkp084run6pd632cf02mcpoh2bo3kuqf3uqbb5nh2drf37u51lpf16m5u415tcuk18djnr60
+  587. -- #5rfcm6mlv2njfa8l9slkjp1q2q5r6m1vkp084run6pd632cf02mcpoh2bo3kuqf3uqbb5nh2drf37u51lpf16m5u415tcuk18djnr60
        builtin.Pretty.orElse : Pretty txt
        -> Pretty txt
        -> Pretty txt
        
-  587. -- #cbo8de57n17pgc5iic1741jeiunhvhfcfd7gt79vd6516u64aplasdodqoouejbgovhge2le5jb6rje923fcrllhtu01t29cdrssgbg#0
+  588. -- #cbo8de57n17pgc5iic1741jeiunhvhfcfd7gt79vd6516u64aplasdodqoouejbgovhge2le5jb6rje923fcrllhtu01t29cdrssgbg#0
        builtin.Pretty.Pretty : Annotated () txt -> Pretty txt
        
-  588. -- #qg050nfl4eeeiarp5mvun3j15h3qpgo31a01o03mql8rrrpht3o6h6htov9ghm7cikkbjejgu4vd9v3h1idp0hanol93pqpqiq8rg3g
+  589. -- #qg050nfl4eeeiarp5mvun3j15h3qpgo31a01o03mql8rrrpht3o6h6htov9ghm7cikkbjejgu4vd9v3h1idp0hanol93pqpqiq8rg3g
        builtin.Pretty.sepBy : Pretty txt
        -> [Pretty txt]
        -> Pretty txt
        
-  589. -- #ev99k0kpivu29vfl7k8pf5n55fnnelq78ul7jqjrk946i1ckvrs5lmrji3l2avhd02mljspdbfspcn26phaqkug6p7rocbbf94uhcro
+  590. -- #ev99k0kpivu29vfl7k8pf5n55fnnelq78ul7jqjrk946i1ckvrs5lmrji3l2avhd02mljspdbfspcn26phaqkug6p7rocbbf94uhcro
        builtin.Pretty.table : [[Pretty txt]] -> Pretty txt
        
-  590. -- #7c4jq9udglq9n7pfemqmc7qrks18r80t9dgjefpi78aerb1vo8cakc3fv843dg3h60ihbo75u0jrmbhqk0och8be2am98v3mu5f6v10
+  591. -- #7c4jq9udglq9n7pfemqmc7qrks18r80t9dgjefpi78aerb1vo8cakc3fv843dg3h60ihbo75u0jrmbhqk0och8be2am98v3mu5f6v10
        builtin.Pretty.wrap : Pretty txt -> Pretty txt
        
-  591. -- ##Ref
+  592. -- ##Ref
        builtin type builtin.Ref
        
-  592. -- ##Ref.read
+  593. -- ##Ref.read
        builtin.Ref.read : Ref g a ->{g} a
        
-  593. -- ##Ref.write
+  594. -- ##Ref.write
        builtin.Ref.write : Ref g a -> a ->{g} ()
        
-  594. -- ##Effect
+  595. -- ##Effect
        builtin type builtin.Request
        
-  595. -- ##Scope
+  596. -- ##Scope
        builtin type builtin.Scope
        
-  596. -- ##Scope.array
+  597. -- ##Scope.array
        builtin.Scope.array : Nat
        ->{Scope s} MutableArray (Scope s) a
        
-  597. -- ##Scope.arrayOf
+  598. -- ##Scope.arrayOf
        builtin.Scope.arrayOf : a
        -> Nat
        ->{Scope s} MutableArray (Scope s) a
        
-  598. -- ##Scope.bytearray
+  599. -- ##Scope.bytearray
        builtin.Scope.bytearray : Nat
        ->{Scope s} MutableByteArray (Scope s)
        
-  599. -- ##Scope.bytearrayOf
+  600. -- ##Scope.bytearrayOf
        builtin.Scope.bytearrayOf : Nat
        -> Nat
        ->{Scope s} MutableByteArray (Scope s)
        
-  600. -- ##Scope.ref
+  601. -- ##Scope.ref
        builtin.Scope.ref : a ->{Scope s} Ref {Scope s} a
        
-  601. -- ##Scope.run
+  602. -- ##Scope.run
        builtin.Scope.run : (∀ s. '{g, Scope s} r) ->{g} r
        
-  602. -- #6uigas14aqgd889s036hq9ssrlo22pju41009m0rktetcrbm97qniljjc1rv1u661r4f63oq6pupoevghs8a2hupvlbi6qi4ntn9320
+  603. -- #6uigas14aqgd889s036hq9ssrlo22pju41009m0rktetcrbm97qniljjc1rv1u661r4f63oq6pupoevghs8a2hupvlbi6qi4ntn9320
        structural type builtin.SeqView a b
        
-  603. -- #6uigas14aqgd889s036hq9ssrlo22pju41009m0rktetcrbm97qniljjc1rv1u661r4f63oq6pupoevghs8a2hupvlbi6qi4ntn9320#0
+  604. -- #6uigas14aqgd889s036hq9ssrlo22pju41009m0rktetcrbm97qniljjc1rv1u661r4f63oq6pupoevghs8a2hupvlbi6qi4ntn9320#0
        builtin.SeqView.VElem : a -> b -> SeqView a b
        
-  604. -- #6uigas14aqgd889s036hq9ssrlo22pju41009m0rktetcrbm97qniljjc1rv1u661r4f63oq6pupoevghs8a2hupvlbi6qi4ntn9320#1
+  605. -- #6uigas14aqgd889s036hq9ssrlo22pju41009m0rktetcrbm97qniljjc1rv1u661r4f63oq6pupoevghs8a2hupvlbi6qi4ntn9320#1
        builtin.SeqView.VEmpty : SeqView a b
        
-  605. -- ##Socket.toText
+  606. -- ##Socket.toText
        builtin.Socket.toText : Socket -> Text
        
-  606. -- #pfp0ajb4v2mb9tspp29v53dkacb76aa1t5kbk1dl0q354cjcg4egdpmvtr5d6t818ucon9eubf6r1vdvh926fgk8otvbkvbpn90levo
+  607. -- #pfp0ajb4v2mb9tspp29v53dkacb76aa1t5kbk1dl0q354cjcg4egdpmvtr5d6t818ucon9eubf6r1vdvh926fgk8otvbkvbpn90levo
        builtin.syntax.docAside : Doc2 -> Doc2
        
-  607. -- #mvov9qf78ctohefjbmrgs8ussspo5juhf75pee4ikkg8asuos72unn4pjn3fdel8471soj2vaskd5ls103pb6nb8qf75sjn4igs7v48
+  608. -- #mvov9qf78ctohefjbmrgs8ussspo5juhf75pee4ikkg8asuos72unn4pjn3fdel8471soj2vaskd5ls103pb6nb8qf75sjn4igs7v48
        builtin.syntax.docBlockquote : Doc2 -> Doc2
        
-  608. -- #cg64hg7dag89u80104kit2p40rhmo1k6h1j8obfhjolpogs705bt6hc92ct6rfj8h74m3ioug14u9pm1s7qqpmjda2srjojhi01nvf0
+  609. -- #cg64hg7dag89u80104kit2p40rhmo1k6h1j8obfhjolpogs705bt6hc92ct6rfj8h74m3ioug14u9pm1s7qqpmjda2srjojhi01nvf0
        builtin.syntax.docBold : Doc2 -> Doc2
        
-  609. -- #3qd5kt9gjiggrb871al82n11jccedl3kb5p8ffemr703frn38tqajkett30fg7hef5orh7vl0obp3lap9qq2po3ufcnu4k3bik81rlg
+  610. -- #3qd5kt9gjiggrb871al82n11jccedl3kb5p8ffemr703frn38tqajkett30fg7hef5orh7vl0obp3lap9qq2po3ufcnu4k3bik81rlg
        builtin.syntax.docBulletedList : [Doc2] -> Doc2
        
-  610. -- #el0rph43k5qg25qg20o5jdjukuful041r87v92tcb2339om0hp9u6vqtrcrfkvgj78hrpo2o1l39bbg1oier87pvgkli0lkgalgpo90
+  611. -- #el0rph43k5qg25qg20o5jdjukuful041r87v92tcb2339om0hp9u6vqtrcrfkvgj78hrpo2o1l39bbg1oier87pvgkli0lkgalgpo90
        builtin.syntax.docCallout : Optional Doc2 -> Doc2 -> Doc2
        
-  611. -- #7jij106qpusbsbpqhmtgrk59qo8ss9e77rtrc1h9hbpnbab8sq717fe6hppmhhds9smqbv3k2q0irjgoe4mogatlp9e4k25kopt6rgo
+  612. -- #7jij106qpusbsbpqhmtgrk59qo8ss9e77rtrc1h9hbpnbab8sq717fe6hppmhhds9smqbv3k2q0irjgoe4mogatlp9e4k25kopt6rgo
        builtin.syntax.docCode : Doc2 -> Doc2
        
-  612. -- #3paq4qqrk028tati33723c4aqi7ebgnjln12avbnf7eu8h8sflg0frlehb4lni4ru0pcfg9ftsurq3pb2q11cfebeki51vom697l7h0
+  613. -- #3paq4qqrk028tati33723c4aqi7ebgnjln12avbnf7eu8h8sflg0frlehb4lni4ru0pcfg9ftsurq3pb2q11cfebeki51vom697l7h0
        builtin.syntax.docCodeBlock : Text -> Text -> Doc2
        
-  613. -- #1of955s8tqa74vu0ve863p8dn2mncc2anmms54aj084pkbdcpml6ckvs0qb4defi0df3b1e8inp29p60ac93hf2u7to0je4op9fum40
+  614. -- #1of955s8tqa74vu0ve863p8dn2mncc2anmms54aj084pkbdcpml6ckvs0qb4defi0df3b1e8inp29p60ac93hf2u7to0je4op9fum40
        builtin.syntax.docColumn : [Doc2] -> Doc2
        
-  614. -- #ukv56cjchfao07qb08l7iimd2mmv09s5glmtljo5b71leaijtja04obd0u1hsr38itjnv85f7jvd37nr654bl4lfn4msr1one0hi4s0
+  615. -- #ukv56cjchfao07qb08l7iimd2mmv09s5glmtljo5b71leaijtja04obd0u1hsr38itjnv85f7jvd37nr654bl4lfn4msr1one0hi4s0
        builtin.syntax.docEmbedAnnotation : tm -> Doc2.Term
        
-  615. -- #uccvv8mn62ne8iqppsnpgbquqmhk4hk3n4tg7p6kttr20gov4698tu18jmmvdcs7ab455q7kklhb4uv1mtei4vbvq4qmbtbu1dbagmg
+  616. -- #uccvv8mn62ne8iqppsnpgbquqmhk4hk3n4tg7p6kttr20gov4698tu18jmmvdcs7ab455q7kklhb4uv1mtei4vbvq4qmbtbu1dbagmg
        builtin.syntax.docEmbedAnnotations : tms -> tms
        
-  616. -- #h53vvsbp1eflh5n41fepa5dana1ucfjbk8qc95kf4ht12svn304hc4fv431hiejspdr84oul4gmd3s65neil759q0hmjjrr8ottc6v0
+  617. -- #h53vvsbp1eflh5n41fepa5dana1ucfjbk8qc95kf4ht12svn304hc4fv431hiejspdr84oul4gmd3s65neil759q0hmjjrr8ottc6v0
        builtin.syntax.docEmbedSignatureLink : '{g} t
        -> Doc2.Term
        
-  617. -- #dvjs6ebt2ej6funsr6rv351aqe5eqt8pcbte5hpqossikbnqrblhhnve55pdg896s4e6dvd6m3us0151ejegfg1fi8kbfd7soa31dao
+  618. -- #dvjs6ebt2ej6funsr6rv351aqe5eqt8pcbte5hpqossikbnqrblhhnve55pdg896s4e6dvd6m3us0151ejegfg1fi8kbfd7soa31dao
        builtin.syntax.docEmbedTermLink : '{g} t
        -> Either a Doc2.Term
        
-  618. -- #7t98ois54isfkh31uefvdg4bg302s5q3sun4hfh0mqnosk4ded353jp0p2ij6b22vnvlcbipcv2jb91suh6qc33i7uqlfuto9f0r4n8
+  619. -- #7t98ois54isfkh31uefvdg4bg302s5q3sun4hfh0mqnosk4ded353jp0p2ij6b22vnvlcbipcv2jb91suh6qc33i7uqlfuto9f0r4n8
        builtin.syntax.docEmbedTypeLink : typ -> Either typ b
        
-  619. -- #r26nnrb8inld7nstp0rj4sbh7ldbibo3s6ld4hmii114i8fglrvij0a1jgj70u51it80s5vgj5dvu9oi5gqmr2n7j341tg8285mpesg
+  620. -- #r26nnrb8inld7nstp0rj4sbh7ldbibo3s6ld4hmii114i8fglrvij0a1jgj70u51it80s5vgj5dvu9oi5gqmr2n7j341tg8285mpesg
        builtin.syntax.docEval : 'a -> Doc2
        
-  620. -- #ojecdd8rnla7dqqop5a43u8kl12149l24452thb0ljkb99ivh6n2evg3g43dj6unlbsmbuvj5g9js5hvsi9f13lt22uqkueioe1vi9g
+  621. -- #ojecdd8rnla7dqqop5a43u8kl12149l24452thb0ljkb99ivh6n2evg3g43dj6unlbsmbuvj5g9js5hvsi9f13lt22uqkueioe1vi9g
        builtin.syntax.docEvalInline : 'a -> Doc2
        
-  621. -- #lecedgertb8tj69o0f2bqeso83hl454am6cjp708epen78s5gtr0ljcc6agopns65lnm3du36dr4m4qu9rp8rtjvtcpg359bpbnfcm0
+  622. -- #lecedgertb8tj69o0f2bqeso83hl454am6cjp708epen78s5gtr0ljcc6agopns65lnm3du36dr4m4qu9rp8rtjvtcpg359bpbnfcm0
        builtin.syntax.docExample : Nat -> '{g} t -> Doc2
        
-  622. -- #m4ini2v12rc468iflsee87m1qrm52b257e3blah4pcblqo2np3k6ad50bt5gkjob3qrct3jbihjd6i02t7la9oh3cft1d0483lf1pq0
+  623. -- #m4ini2v12rc468iflsee87m1qrm52b257e3blah4pcblqo2np3k6ad50bt5gkjob3qrct3jbihjd6i02t7la9oh3cft1d0483lf1pq0
        builtin.syntax.docExampleBlock : Nat -> '{g} t -> Doc2
        
-  623. -- #pomj7lft70jnnuk5job0pstih2mosva1oee4tediqbkhnm54tjqnfe6qs1mqt8os1ehg9ksgenb6veub2ngdpb1qat400vn0bj3fju0
+  624. -- #pomj7lft70jnnuk5job0pstih2mosva1oee4tediqbkhnm54tjqnfe6qs1mqt8os1ehg9ksgenb6veub2ngdpb1qat400vn0bj3fju0
        builtin.syntax.docFoldedSource : [( Either Type Doc2.Term,
          [Doc2.Term])]
        -> Doc2
        
-  624. -- #inrar1e9lnt58n0ru88v05a9d9d0la94m7ok5l6i7pr3pg4lapc9vegr542ffog1kl7pfqhmltr53of3qkci8nnrt8gig93qsnggisg
+  625. -- #inrar1e9lnt58n0ru88v05a9d9d0la94m7ok5l6i7pr3pg4lapc9vegr542ffog1kl7pfqhmltr53of3qkci8nnrt8gig93qsnggisg
        builtin.syntax.docFormatConsole : Doc2
        -> Pretty (Either SpecialForm ConsoleText)
        
-  625. -- #99qvifgs3u7nof50jbp5lhrf8cab0qiujr1tque2b7hfj56r39o8ot2fafhafuphoraddl1j142k994e22g5v2rhq98flc0954t5918
+  626. -- #99qvifgs3u7nof50jbp5lhrf8cab0qiujr1tque2b7hfj56r39o8ot2fafhafuphoraddl1j142k994e22g5v2rhq98flc0954t5918
        builtin.syntax.docGroup : Doc2 -> Doc2
        
-  626. -- #gsratvk7mo273bqhivdv06f9rog2cj48u7ci0jp6ubt5oidf8cq0rjilimkas5801inbbsjcedh61jl40i3en1qu6r9vfe684ad6r08
+  627. -- #gsratvk7mo273bqhivdv06f9rog2cj48u7ci0jp6ubt5oidf8cq0rjilimkas5801inbbsjcedh61jl40i3en1qu6r9vfe684ad6r08
        builtin.syntax.docItalic : Doc2 -> Doc2
        
-  627. -- #piohhscvm6lgpk6vfg91u2ndmlfv81nnkspihom77ucr4dev6s22rk2n9hp38nifh5p8vt7jfvep85vudpvlg2tt99e9s2qfjv5oau8
+  628. -- #piohhscvm6lgpk6vfg91u2ndmlfv81nnkspihom77ucr4dev6s22rk2n9hp38nifh5p8vt7jfvep85vudpvlg2tt99e9s2qfjv5oau8
        builtin.syntax.docJoin : [Doc2] -> Doc2
        
-  628. -- #hjdqcolihf4obmnfoakl2t5hs1e39hpmpo9ijvc37fqgejog1ii7fpd4q2fe2rkm62tf81unmqlbud8uh63vaa9feaekg5a7uo3nq00
+  629. -- #hjdqcolihf4obmnfoakl2t5hs1e39hpmpo9ijvc37fqgejog1ii7fpd4q2fe2rkm62tf81unmqlbud8uh63vaa9feaekg5a7uo3nq00
        builtin.syntax.docLink : Either Type Doc2.Term -> Doc2
        
-  629. -- #iv6urr76b0ohvr22qa6d05e7e01cd0re77g8c98cm0bqo0im345fotsevqnhk1igtutkrrqm562gtltofvku5mh0i87ru8tdf0i53bo
+  630. -- #iv6urr76b0ohvr22qa6d05e7e01cd0re77g8c98cm0bqo0im345fotsevqnhk1igtutkrrqm562gtltofvku5mh0i87ru8tdf0i53bo
        builtin.syntax.docNamedLink : Doc2 -> Doc2 -> Doc2
        
-  630. -- #b5dvn0bqj3rc1rkmlep5f6cd6n3vp247hqku8lqndena5ocgcoae18iuq3985finagr919re4fvji011ved0g21i6o0je2jn8f7k1p0
+  631. -- #b5dvn0bqj3rc1rkmlep5f6cd6n3vp247hqku8lqndena5ocgcoae18iuq3985finagr919re4fvji011ved0g21i6o0je2jn8f7k1p0
        builtin.syntax.docNumberedList : Nat -> [Doc2] -> Doc2
        
-  631. -- #fs8mho20fqj31ch5kpn8flm4geomotov7fb5ct8mtnh52ladorgp22vder3jgt1mr0u710e6s9gn4u36c9sp19vitvq1r0adtm3t1c0
+  632. -- #fs8mho20fqj31ch5kpn8flm4geomotov7fb5ct8mtnh52ladorgp22vder3jgt1mr0u710e6s9gn4u36c9sp19vitvq1r0adtm3t1c0
        builtin.syntax.docParagraph : [Doc2] -> Doc2
        
-  632. -- #6dvkai3hc122e2h2h8c3jnijink5m20e27i640qvnt6smefpp2vna1rq4gbmulhb46tdabmkb5hsjeiuo4adtsutg4iu1vfmqhlueso
+  633. -- #6dvkai3hc122e2h2h8c3jnijink5m20e27i640qvnt6smefpp2vna1rq4gbmulhb46tdabmkb5hsjeiuo4adtsutg4iu1vfmqhlueso
        builtin.syntax.docSection : Doc2 -> [Doc2] -> Doc2
        
-  633. -- #n0idf1bdrq5vgpk4pj9db5demk1es4jsnpodfoajftehvqjelsi0h5j2domdllq2peltdek4ptaqfpl4o8l6jpmqhcom9vq107ivdu0
+  634. -- #n0idf1bdrq5vgpk4pj9db5demk1es4jsnpodfoajftehvqjelsi0h5j2domdllq2peltdek4ptaqfpl4o8l6jpmqhcom9vq107ivdu0
        builtin.syntax.docSignature : [Doc2.Term] -> Doc2
        
-  634. -- #git1povkck9jrptdmmpqrv1g17ptbq9hr17l52l8477ijk4cia24tr7cj36v1o22mvtk00qoo5jt4bs4e79sl3eh6is8ubh8aoc1pu0
+  635. -- #git1povkck9jrptdmmpqrv1g17ptbq9hr17l52l8477ijk4cia24tr7cj36v1o22mvtk00qoo5jt4bs4e79sl3eh6is8ubh8aoc1pu0
        builtin.syntax.docSignatureInline : Doc2.Term -> Doc2
        
-  635. -- #47agivvofl1jegbqpdg0eeed72mdj29d623e4kdei0l10mhgckif7q2pd968ggribregcknra9u43mhehr1q86n0t4vbe4eestnu9l8
+  636. -- #47agivvofl1jegbqpdg0eeed72mdj29d623e4kdei0l10mhgckif7q2pd968ggribregcknra9u43mhehr1q86n0t4vbe4eestnu9l8
        builtin.syntax.docSource : [( Either Type Doc2.Term,
          [Doc2.Term])]
        -> Doc2
        
-  636. -- #n6uk5tc4d8ipbga8boelh51ro24paveca9fijm1nkn3tlfddqludmlppb2ps8807v2kuou1a262sa59764mdhug2va69q4sls5jli10
+  637. -- #n6uk5tc4d8ipbga8boelh51ro24paveca9fijm1nkn3tlfddqludmlppb2ps8807v2kuou1a262sa59764mdhug2va69q4sls5jli10
        builtin.syntax.docSourceElement : link
        -> annotations
        -> (link, annotations)
        
-  637. -- #nurq288b5rfp1f5keccleh51ojgcpd2rp7cane6ftquf7gidtamffb8tr1r5h6luk1nsrqomn1k4as4kcpaskjjv35rnvoous457sag
+  638. -- #nurq288b5rfp1f5keccleh51ojgcpd2rp7cane6ftquf7gidtamffb8tr1r5h6luk1nsrqomn1k4as4kcpaskjjv35rnvoous457sag
        builtin.syntax.docStrikethrough : Doc2 -> Doc2
        
-  638. -- #4ns2amu2njhvb5mtdvh3v7oljjb5ammnb41us4ekpbhb337b6mo2a4q0790cmrusko7omphtfdsaust2fn49hr5acl40ef8fkb9556g
+  639. -- #4ns2amu2njhvb5mtdvh3v7oljjb5ammnb41us4ekpbhb337b6mo2a4q0790cmrusko7omphtfdsaust2fn49hr5acl40ef8fkb9556g
        builtin.syntax.docTable : [[Doc2]] -> Doc2
        
-  639. -- #i77kddfr68gbjt3767a091dtnqff9beltojh93md8peo28t59c6modeccsfd2tnrtmd75fa7dn0ie21kcv4me098q91h4ftg9eau5fo
+  640. -- #i77kddfr68gbjt3767a091dtnqff9beltojh93md8peo28t59c6modeccsfd2tnrtmd75fa7dn0ie21kcv4me098q91h4ftg9eau5fo
        builtin.syntax.docTooltip : Doc2 -> Doc2 -> Doc2
        
-  640. -- #r0hdacbk2orcb2ate3uhd7ht05hmfa8643slm3u63nb3jaaim533up04lgt0pq97is43v2spkqble7mtu8f63hgcc0k2tb2jhpr2b68
+  641. -- #r0hdacbk2orcb2ate3uhd7ht05hmfa8643slm3u63nb3jaaim533up04lgt0pq97is43v2spkqble7mtu8f63hgcc0k2tb2jhpr2b68
        builtin.syntax.docTransclude : d -> d
        
-  641. -- #0nptdh40ngakd2rh92bl573a7vbdjcj2kc8rai39v8bb9dfpbj90i7nob381usjsott41c3cpo2m2q095fm0k0r68e8mrda135qa1k0
+  642. -- #0nptdh40ngakd2rh92bl573a7vbdjcj2kc8rai39v8bb9dfpbj90i7nob381usjsott41c3cpo2m2q095fm0k0r68e8mrda135qa1k0
        builtin.syntax.docUntitledSection : [Doc2] -> Doc2
        
-  642. -- #krjm78blt08v52c52l4ubsnfidcrs0h6010j2v2h9ud38mgm6jj4vuqn4okp4g75039o7u78sbg6ghforucbfdf94f8am9kvt6875jo
+  643. -- #krjm78blt08v52c52l4ubsnfidcrs0h6010j2v2h9ud38mgm6jj4vuqn4okp4g75039o7u78sbg6ghforucbfdf94f8am9kvt6875jo
        builtin.syntax.docVerbatim : Doc2 -> Doc2
        
-  643. -- #c14vgd4g1tkumf4jjd9vcoos1olb3f4gbc3hketf5l8h3i0efk8igbinh6gn018tr5075uo5nv1elva6tki6ofo3pdafidrkv9m0ot0
+  644. -- #c14vgd4g1tkumf4jjd9vcoos1olb3f4gbc3hketf5l8h3i0efk8igbinh6gn018tr5075uo5nv1elva6tki6ofo3pdafidrkv9m0ot0
        builtin.syntax.docWord : Text -> Doc2
        
-  644. -- #aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0
+  645. -- #aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0
        unique type builtin.Test.Result
        
-  645. -- #aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0#0
+  646. -- #aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0#0
        builtin.Test.Result.Fail : Text -> Result
        
-  646. -- #aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0#1
+  647. -- #aql7qk3iud6vs4cvu43aimopoosgk0fnipibdkc3so13adencmibgfn0u5c01r0adei55nkl3ttsjhl8gbj7tr4gnpj63g64ftbq6s0#1
        builtin.Test.Result.Ok : Text -> Result
        
-  647. -- ##Text
+  648. -- ##Text
        builtin type builtin.Text
        
-  648. -- ##Text.!=
+  649. -- ##Text.!=
        builtin.Text.!= : Text -> Text -> Boolean
        
-  649. -- ##Text.++
+  650. -- ##Text.++
        builtin.Text.++ : Text -> Text -> Text
        
-  650. -- #nv11qo7s2lqirk3qb44jkm3q3fb6i3mn72ji2c52eubh3kufrdumanblh2bnql1o24efdhmue0v21gd7d1p5ec9j6iqrmekas0183do
+  651. -- #nv11qo7s2lqirk3qb44jkm3q3fb6i3mn72ji2c52eubh3kufrdumanblh2bnql1o24efdhmue0v21gd7d1p5ec9j6iqrmekas0183do
        builtin.Text.alignLeftWith : Nat -> Char -> Text -> Text
        
-  651. -- #ebeq250fdoigvu89fneb4c24f8f18eotc8kocdmosn4ri9shoeeg7ofkejts6clm5c6bifce66qtr0vpfkrhuup2en3khous41hp8rg
+  652. -- #ebeq250fdoigvu89fneb4c24f8f18eotc8kocdmosn4ri9shoeeg7ofkejts6clm5c6bifce66qtr0vpfkrhuup2en3khous41hp8rg
        builtin.Text.alignRightWith : Nat -> Char -> Text -> Text
        
-  652. -- ##Text.drop
+  653. -- ##Text.drop
        builtin.Text.drop : Nat -> Text -> Text
        
-  653. -- ##Text.empty
+  654. -- ##Text.empty
        builtin.Text.empty : Text
        
-  654. -- ##Text.==
+  655. -- ##Text.==
        builtin.Text.eq : Text -> Text -> Boolean
        
-  655. -- ##Text.fromCharList
+  656. -- ##Text.fromCharList
        builtin.Text.fromCharList : [Char] -> Text
        
-  656. -- ##Text.fromUtf8.impl.v3
+  657. -- ##Text.fromUtf8.impl.v3
        builtin.Text.fromUtf8.impl : Bytes -> Either Failure Text
        
-  657. -- ##Text.>
+  658. -- ##Text.>
        builtin.Text.gt : Text -> Text -> Boolean
        
-  658. -- ##Text.>=
+  659. -- ##Text.>=
        builtin.Text.gteq : Text -> Text -> Boolean
        
-  659. -- ##Text.<
+  660. -- ##Text.<
        builtin.Text.lt : Text -> Text -> Boolean
        
-  660. -- ##Text.<=
+  661. -- ##Text.<=
        builtin.Text.lteq : Text -> Text -> Boolean
        
-  661. -- ##Text.patterns.anyChar
+  662. -- ##Text.patterns.anyChar
        builtin.Text.patterns.anyChar : Pattern Text
        
-  662. -- ##Text.patterns.char
+  663. -- ##Text.patterns.char
        builtin.Text.patterns.char : Class -> Pattern Text
        
-  663. -- ##Text.patterns.charIn
+  664. -- ##Text.patterns.charIn
        builtin.Text.patterns.charIn : [Char] -> Pattern Text
        
-  664. -- ##Text.patterns.charRange
+  665. -- ##Text.patterns.charRange
        builtin.Text.patterns.charRange : Char
        -> Char
        -> Pattern Text
        
-  665. -- ##Text.patterns.digit
+  666. -- ##Text.patterns.digit
        builtin.Text.patterns.digit : Pattern Text
        
-  666. -- ##Text.patterns.eof
+  667. -- ##Text.patterns.eof
        builtin.Text.patterns.eof : Pattern Text
        
-  667. -- ##Text.patterns.letter
+  668. -- ##Text.patterns.letter
        builtin.Text.patterns.letter : Pattern Text
        
-  668. -- ##Text.patterns.literal
+  669. -- ##Text.patterns.literal
        builtin.Text.patterns.literal : Text -> Pattern Text
        
-  669. -- ##Text.patterns.notCharIn
+  670. -- ##Text.patterns.notCharIn
        builtin.Text.patterns.notCharIn : [Char] -> Pattern Text
        
-  670. -- ##Text.patterns.notCharRange
+  671. -- ##Text.patterns.notCharRange
        builtin.Text.patterns.notCharRange : Char
        -> Char
        -> Pattern Text
        
-  671. -- ##Text.patterns.punctuation
+  672. -- ##Text.patterns.punctuation
        builtin.Text.patterns.punctuation : Pattern Text
        
-  672. -- ##Text.patterns.space
+  673. -- ##Text.patterns.space
        builtin.Text.patterns.space : Pattern Text
        
-  673. -- ##Text.repeat
+  674. -- ##Text.repeat
        builtin.Text.repeat : Nat -> Text -> Text
        
-  674. -- ##Text.reverse
+  675. -- ##Text.reverse
        builtin.Text.reverse : Text -> Text
        
-  675. -- ##Text.size
+  676. -- ##Text.size
        builtin.Text.size : Text -> Nat
        
-  676. -- ##Text.take
+  677. -- ##Text.take
        builtin.Text.take : Nat -> Text -> Text
        
-  677. -- ##Text.toCharList
+  678. -- ##Text.toCharList
        builtin.Text.toCharList : Text -> [Char]
        
-  678. -- ##Text.toLowercase
+  679. -- ##Text.toLowercase
        builtin.Text.toLowercase : Text -> Text
        
-  679. -- ##Text.toUppercase
+  680. -- ##Text.toUppercase
        builtin.Text.toUppercase : Text -> Text
        
-  680. -- ##Text.toUtf8
+  681. -- ##Text.toUtf8
        builtin.Text.toUtf8 : Text -> Bytes
        
-  681. -- ##Text.uncons
+  682. -- ##Text.uncons
        builtin.Text.uncons : Text -> Optional (Char, Text)
        
-  682. -- ##Text.unsnoc
+  683. -- ##Text.unsnoc
        builtin.Text.unsnoc : Text -> Optional (Text, Char)
        
-  683. -- ##ThreadId.toText
+  684. -- ##ThreadId.toText
        builtin.ThreadId.toText : ThreadId -> Text
        
-  684. -- ##todo
+  685. -- ##todo
        builtin.todo : a -> b
        
-  685. -- #2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8
+  686. -- #2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8
        structural type builtin.Tuple a b
        
-  686. -- #2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8#0
+  687. -- #2lg4ah6ir6t129m33d7gssnigacral39qdamo20mn6r2vefliubpeqnjhejai9ekjckv0qnu9mlu3k9nbpfhl2schec4dohn7rjhjt8#0
        builtin.Tuple.Cons : a -> b -> Tuple a b
        
-  687. -- #00nv2kob8fp11qdkr750rlppf81cda95m3q0niohj1pvljnjl4r3hqrhvp1un2p40ptgkhhsne7hocod90r3qdlus9guivh7j3qcq0g
+  688. -- #00nv2kob8fp11qdkr750rlppf81cda95m3q0niohj1pvljnjl4r3hqrhvp1un2p40ptgkhhsne7hocod90r3qdlus9guivh7j3qcq0g
        structural type builtin.Unit
        
-  688. -- #00nv2kob8fp11qdkr750rlppf81cda95m3q0niohj1pvljnjl4r3hqrhvp1un2p40ptgkhhsne7hocod90r3qdlus9guivh7j3qcq0g#0
+  689. -- #00nv2kob8fp11qdkr750rlppf81cda95m3q0niohj1pvljnjl4r3hqrhvp1un2p40ptgkhhsne7hocod90r3qdlus9guivh7j3qcq0g#0
        builtin.Unit.Unit : ()
        
-  689. -- ##Universal.<
+  690. -- ##Universal.<
        builtin.Universal.< : a -> a -> Boolean
        
-  690. -- ##Universal.<=
+  691. -- ##Universal.<=
        builtin.Universal.<= : a -> a -> Boolean
        
-  691. -- ##Universal.==
+  692. -- ##Universal.==
        builtin.Universal.== : a -> a -> Boolean
        
-  692. -- ##Universal.>
+  693. -- ##Universal.>
        builtin.Universal.> : a -> a -> Boolean
        
-  693. -- ##Universal.>=
+  694. -- ##Universal.>=
        builtin.Universal.>= : a -> a -> Boolean
        
-  694. -- ##Universal.compare
+  695. -- ##Universal.compare
        builtin.Universal.compare : a -> a -> Int
        
-  695. -- ##Universal.murmurHash
+  696. -- ##Universal.murmurHash
        builtin.Universal.murmurHash : a -> Nat
        
-  696. -- ##unsafe.coerceAbilities
+  697. -- ##unsafe.coerceAbilities
        builtin.unsafe.coerceAbilities : (a ->{e1} b)
        -> a
        ->{e2} b
        
-  697. -- ##Value
+  698. -- ##Value
        builtin type builtin.Value
        
-  698. -- ##Value.dependencies
+  699. -- ##Value.dependencies
        builtin.Value.dependencies : Value -> [Link.Term]
        
-  699. -- ##Value.deserialize
+  700. -- ##Value.deserialize
        builtin.Value.deserialize : Bytes -> Either Text Value
        
-  700. -- ##Value.load
+  701. -- ##Value.load
        builtin.Value.load : Value ->{IO} Either [Link.Term] a
        
-  701. -- ##Value.serialize
+  702. -- ##Value.serialize
        builtin.Value.serialize : Value -> Bytes
        
-  702. -- ##Value.value
+  703. -- ##Value.value
        builtin.Value.value : a -> Value
        
-  703. -- #dem6aglnj8cppfrnq9qipl7geo5pim3auo9cmv1rhh5la9edalj19sspbpm1pd4vh0plokdh6qfo48gs034dqlg0s7j9fhr9p9ndtpo
+  704. -- #dem6aglnj8cppfrnq9qipl7geo5pim3auo9cmv1rhh5la9edalj19sspbpm1pd4vh0plokdh6qfo48gs034dqlg0s7j9fhr9p9ndtpo
        unique type builtin.Year
        
-  704. -- #dem6aglnj8cppfrnq9qipl7geo5pim3auo9cmv1rhh5la9edalj19sspbpm1pd4vh0plokdh6qfo48gs034dqlg0s7j9fhr9p9ndtpo#0
+  705. -- #dem6aglnj8cppfrnq9qipl7geo5pim3auo9cmv1rhh5la9edalj19sspbpm1pd4vh0plokdh6qfo48gs034dqlg0s7j9fhr9p9ndtpo#0
        builtin.Year.Year : Nat -> Year
        
-  705. -- #k0rcrut9836hr3sevkivq4n2o3t540hllesila69b16gr5fcqe0i6aepqhv2qmso6h22lbipbp3fto0oc8o73l1lvf6vpifi01gmhg8
+  706. -- #k0rcrut9836hr3sevkivq4n2o3t540hllesila69b16gr5fcqe0i6aepqhv2qmso6h22lbipbp3fto0oc8o73l1lvf6vpifi01gmhg8
        cache : [(Link.Term, Code)] ->{IO, Exception} ()
        
-  706. -- #okolgrio28p1mbl1bfjfs9qtsr1m9upblcm3ul872gcir6epkcbq619vk5bdq1fnr371nelsof6jsp8469g4j6f0gg3007p79o4kf18
+  707. -- #okolgrio28p1mbl1bfjfs9qtsr1m9upblcm3ul872gcir6epkcbq619vk5bdq1fnr371nelsof6jsp8469g4j6f0gg3007p79o4kf18
        check : Text -> Boolean ->{Stream Result} ()
        
-  707. -- #je42vk6rsefjlup01e1fmmdssf5i3ba9l6aka3bipggetfm8o4i8d1q5d7hddggu5jure1bu5ot8aq5in31to4788ctrtpb44ri83r8
+  708. -- #je42vk6rsefjlup01e1fmmdssf5i3ba9l6aka3bipggetfm8o4i8d1q5d7hddggu5jure1bu5ot8aq5in31to4788ctrtpb44ri83r8
        checks : [Boolean] -> [Result]
        
-  708. -- #barg6v1n15ea1qhp80i77gjjq3vu1noc67q2jkv9n6n5v0c9djup70ltauujgpfe0kuo8ckd20gc9kutngdpb8d22rubtb5rjldrb3o
+  709. -- #barg6v1n15ea1qhp80i77gjjq3vu1noc67q2jkv9n6n5v0c9djup70ltauujgpfe0kuo8ckd20gc9kutngdpb8d22rubtb5rjldrb3o
        clientSocket : Text -> Text ->{IO, Exception} Socket
        
-  709. -- #lg7i12ido0jr43ovdbhhv2enpk5ar869leouri5qhrivinde93nl86s2rgshubtfhlogbe310k3rluotscmus9moo1tvpn0nmp1efv8
+  710. -- #lg7i12ido0jr43ovdbhhv2enpk5ar869leouri5qhrivinde93nl86s2rgshubtfhlogbe310k3rluotscmus9moo1tvpn0nmp1efv8
        closeFile : Handle ->{IO, Exception} ()
        
-  710. -- #4e6qn65v05l32n380lpf536u4llnp6f6tvvt13hvo0bhqeh3f3i8bquekc120c8h59gld1mf02ok0sje7037ipg1fsu97fqrm01oi00
+  711. -- #4e6qn65v05l32n380lpf536u4llnp6f6tvvt13hvo0bhqeh3f3i8bquekc120c8h59gld1mf02ok0sje7037ipg1fsu97fqrm01oi00
        closeSocket : Socket ->{IO, Exception} ()
        
-  711. -- #2cl9ivrimnadurkum2blduls21kcihu89oasj2efmi03s1vfm433pi6c4k1d2a3obpmf2orm3c9lfgffnlhuc6ktaa98a1ccdhfueqo
+  712. -- #2cl9ivrimnadurkum2blduls21kcihu89oasj2efmi03s1vfm433pi6c4k1d2a3obpmf2orm3c9lfgffnlhuc6ktaa98a1ccdhfueqo
        Code.transitiveDeps : Link.Term
        ->{IO} [(Link.Term, Code)]
        
-  712. -- #sfud7h76up0cofgk61b7tf8rhdlugfmg44lksnpglfes1b8po26si7betka39r9j8dpgueorjdrb1i7v4g62m5bci1e971eqi8dblmo
+  713. -- #sfud7h76up0cofgk61b7tf8rhdlugfmg44lksnpglfes1b8po26si7betka39r9j8dpgueorjdrb1i7v4g62m5bci1e971eqi8dblmo
        compose : ∀ o g1 i1 g i.
          (i1 ->{g1} o) -> (i ->{g} i1) -> i ->{g1, g} o
        
-  713. -- #b0tsob9a3fegn5dkb57jh15smd7ho2qo78st6qngpa7a8hc88mccl7vhido41o4otokv5l8hjdj3nabtkmpni5ikeatd44agmqbhano
+  714. -- #b0tsob9a3fegn5dkb57jh15smd7ho2qo78st6qngpa7a8hc88mccl7vhido41o4otokv5l8hjdj3nabtkmpni5ikeatd44agmqbhano
        compose2 : ∀ o g2 i2 g1 g i i1.
          (i2 ->{g2} o)
          -> (i1 ->{g1} i ->{g} i2)
@@ -2490,7 +2493,7 @@ This transcript is intended to make visible accidental changes to the hashing al
          -> i
          ->{g2, g1, g} o
        
-  714. -- #m632ocgh2rougfejkddsso3vfpf4dmg1f8bhf0k6sha4g4aqfmbeuct3eo0je6dv9utterfvotjdu32p0kojuo9fj4qkp2g1bt464eg
+  715. -- #m632ocgh2rougfejkddsso3vfpf4dmg1f8bhf0k6sha4g4aqfmbeuct3eo0je6dv9utterfvotjdu32p0kojuo9fj4qkp2g1bt464eg
        compose3 : ∀ o g3 i3 g2 g1 g i i1 i2.
          (i3 ->{g3} o)
          -> (i2 ->{g2} i1 ->{g1} i ->{g} i3)
@@ -2499,318 +2502,318 @@ This transcript is intended to make visible accidental changes to the hashing al
          -> i
          ->{g3, g2, g1, g} o
        
-  715. -- #ilkeid6l866bmq90d2v1ilqp9dsjo6ucmf8udgrokq3nr3mo9skl2vao2mo7ish136as52rsf19u9v3jkmd85bl08gnmamo4e5v2fqo
+  716. -- #ilkeid6l866bmq90d2v1ilqp9dsjo6ucmf8udgrokq3nr3mo9skl2vao2mo7ish136as52rsf19u9v3jkmd85bl08gnmamo4e5v2fqo
        contains : Text -> Text -> Boolean
        
-  716. -- #pen6v1vcqdsg5ar8ajio0baiujthquamelbqd00p66amfjftk2o3stod4n81snc3hb9sc4fmnitf6ada0n5sfqfroi8sv1nbn7rnq48
+  717. -- #pen6v1vcqdsg5ar8ajio0baiujthquamelbqd00p66amfjftk2o3stod4n81snc3hb9sc4fmnitf6ada0n5sfqfroi8sv1nbn7rnq48
        crawl : [(Link.Term, Code)]
        -> [Link.Term]
        ->{IO} [(Link.Term, Code)]
        
-  717. -- #o0qn048fk7tjb8e7d54vq5mg9egr5kophb9pcm0to4aj0kf39mv76c6olsm27vj309d7nhjh4nps7098fpvqe8j5cfg01ghf3bnju90
+  718. -- #o0qn048fk7tjb8e7d54vq5mg9egr5kophb9pcm0to4aj0kf39mv76c6olsm27vj309d7nhjh4nps7098fpvqe8j5cfg01ghf3bnju90
        createTempDirectory : Text ->{IO, Exception} Text
        
-  718. -- #4858f4krb9l4ot1hml21j48lp3bcvbo8b9unlk33b9a3ovu1jrbr1k56pnfhffkiu1bht2ovh0i82nn5jnoc5s5ru85qvua0m2ol43g
+  719. -- #4858f4krb9l4ot1hml21j48lp3bcvbo8b9unlk33b9a3ovu1jrbr1k56pnfhffkiu1bht2ovh0i82nn5jnoc5s5ru85qvua0m2ol43g
        decodeCert : Bytes ->{Exception} SignedCert
        
-  719. -- #ihbmfc4r7o3391jocjm6v4mojpp3hvt84ivqigrmp34vb5l3d7mmdlvh3hkrtebi812npso7rqo203a59pbs7r2g78ig6jvsv0nva38
+  720. -- #ihbmfc4r7o3391jocjm6v4mojpp3hvt84ivqigrmp34vb5l3d7mmdlvh3hkrtebi812npso7rqo203a59pbs7r2g78ig6jvsv0nva38
        delay : Nat ->{IO, Exception} ()
        
-  720. -- #dsen29k7605pkfquesnaphhmlm3pjkfgm7m2oc90m53gqvob4l39p4g3id3pirl8emg5tcdmr81ctl3lk1enm52mldlfmlh1i85rjbg
+  721. -- #dsen29k7605pkfquesnaphhmlm3pjkfgm7m2oc90m53gqvob4l39p4g3id3pirl8emg5tcdmr81ctl3lk1enm52mldlfmlh1i85rjbg
        directoryContents : Text ->{IO, Exception} [Text]
        
-  721. -- #b22tpqhkq6kvt27dcsddnbfci2bcqutvhmumdven9c5psiilboq2mb8v9ekihtkl6mkartd5ml5u75u84v850n29l91de63lkg3ud38
+  722. -- #b22tpqhkq6kvt27dcsddnbfci2bcqutvhmumdven9c5psiilboq2mb8v9ekihtkl6mkartd5ml5u75u84v850n29l91de63lkg3ud38
        Either.isLeft : Either a b -> Boolean
        
-  722. -- #i1ec3csomb1pegm9r7ppabunabb7cq1t6bb6cvqtt72nd01jot7gde2mak288cbml910abbtho0smsbq17b2r33j599b0vuv7je04j8
+  723. -- #i1ec3csomb1pegm9r7ppabunabb7cq1t6bb6cvqtt72nd01jot7gde2mak288cbml910abbtho0smsbq17b2r33j599b0vuv7je04j8
        Either.mapLeft : (i ->{g} o)
        -> Either i b
        ->{g} Either o b
        
-  723. -- #f765l0pa2tb9ieciivum76s7bp8rdjr8j7i635jjenj9tacgba9eeomur4vv3uuh4kem1pggpmrn61a1e3im9g90okcm13r192f7alg
+  724. -- #f765l0pa2tb9ieciivum76s7bp8rdjr8j7i635jjenj9tacgba9eeomur4vv3uuh4kem1pggpmrn61a1e3im9g90okcm13r192f7alg
        Either.raiseMessage : v -> Either Text b ->{Exception} b
        
-  724. -- #9hifem8o2e1g7tdh4om9kfo98ifr60gfmdp8ci58djn17epm1b4m6idli8b373bsrg487n87n4l50ksq76avlrbh9q2jpobkk18ucvg
+  725. -- #9hifem8o2e1g7tdh4om9kfo98ifr60gfmdp8ci58djn17epm1b4m6idli8b373bsrg487n87n4l50ksq76avlrbh9q2jpobkk18ucvg
        evalTest : '{IO, TempDirs, Exception, Stream Result} a
        ->{IO, Exception} ([Result], a)
        
-  725. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng
+  726. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng
        structural ability Exception
        structural ability builtin.Exception
        
-  726. -- #t20uuuiil07o22les8gv4sji7ju5esevloamnja3bjkrh2f250lgitv6595l6hlc2q64c1om0hhjqgter28dtnibb0dkr2j7e3ss530
+  727. -- #t20uuuiil07o22les8gv4sji7ju5esevloamnja3bjkrh2f250lgitv6595l6hlc2q64c1om0hhjqgter28dtnibb0dkr2j7e3ss530
        Exception.catch : '{g, Exception} a
        ->{g} Either Failure a
        
-  727. -- #hbhvk2e00l6o7qhn8e7p6dc36bjl7ljm0gn2df5clidlrdoufsig1gt5pjhg72kl67folgg2b892kh9jc1oh0l79h4p8dqhcf1tkde0
+  728. -- #hbhvk2e00l6o7qhn8e7p6dc36bjl7ljm0gn2df5clidlrdoufsig1gt5pjhg72kl67folgg2b892kh9jc1oh0l79h4p8dqhcf1tkde0
        Exception.failure : Text -> a -> Failure
        
-  728. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng#0
+  729. -- #4n0fgs00hpsj3paqnm9bfm4nbt9cbrin3hl88i992m9tjiq1ik7eq72asu4hcg885uti36tbnj5rudt56eahhnut1nobofg86pk1bng#0
        Exception.raise,
        builtin.Exception.raise : Failure
        ->{Exception} x
        
-  729. -- #5mqjoauctm02dlqdc10cc66relu40997d6o1u8fj7vv7g0i2mtacjc83afqhuekll1gkqr9vv4lq7aenanq4kf53kcce4l1srr6ip08
+  730. -- #5mqjoauctm02dlqdc10cc66relu40997d6o1u8fj7vv7g0i2mtacjc83afqhuekll1gkqr9vv4lq7aenanq4kf53kcce4l1srr6ip08
        Exception.reraise : Either Failure a ->{Exception} a
        
-  730. -- #1f774ia7im9i0cfp7l5a1g9tkvnd4m2940ga3buaf4ekd43dr1289vknghjjvi4qtevh7s61p5s573gpli51qh7e0i5pj9ggmeb69d0
+  731. -- #1f774ia7im9i0cfp7l5a1g9tkvnd4m2940ga3buaf4ekd43dr1289vknghjjvi4qtevh7s61p5s573gpli51qh7e0i5pj9ggmeb69d0
        Exception.toEither : '{ε, Exception} a
        ->{ε} Either Failure a
        
-  731. -- #li2h4hncbgmfi5scuah06rtdt8rjcipiv2t95hos15ol63usv78ti3vng7o9862a70906rum7nrrs9qd9q8iqu1rdcfe292r0al7n38
+  732. -- #li2h4hncbgmfi5scuah06rtdt8rjcipiv2t95hos15ol63usv78ti3vng7o9862a70906rum7nrrs9qd9q8iqu1rdcfe292r0al7n38
        Exception.toEither.handler : Request {Exception} a
        -> Either Failure a
        
-  732. -- #5fi0ep8mufag822f18ukaffakrmm3ddg8a83dkj4gh2ks4e2c60sk9s8pmk92p69bvkcflql3rgoalp8ruth7fapqrks3kbmdl61b00
+  733. -- #5fi0ep8mufag822f18ukaffakrmm3ddg8a83dkj4gh2ks4e2c60sk9s8pmk92p69bvkcflql3rgoalp8ruth7fapqrks3kbmdl61b00
        Exception.unsafeRun! : '{g, Exception} a ->{g} a
        
-  733. -- #qdcih6h4dmf9a2tn2ndvn0br9ef41ubhcniadou1m6ro641gm2tn79m6boh5sr4q271oiui6ehbdqe53r0gobdeagotkjr67kieq3ro
+  734. -- #qdcih6h4dmf9a2tn2ndvn0br9ef41ubhcniadou1m6ro641gm2tn79m6boh5sr4q271oiui6ehbdqe53r0gobdeagotkjr67kieq3ro
        expect : Text
        -> (a -> a -> Boolean)
        -> a
        -> a
        ->{Stream Result} ()
        
-  734. -- #ngmnbge6f7nkehkkhj6rkit60rp3qlt0vij33itch1el3ta2ukrit4gvpn2n0j0s43sj9af53kphgs0h2n65bnqcr9pmasud2r7klsg
+  735. -- #ngmnbge6f7nkehkkhj6rkit60rp3qlt0vij33itch1el3ta2ukrit4gvpn2n0j0s43sj9af53kphgs0h2n65bnqcr9pmasud2r7klsg
        expectU : Text -> a -> a ->{Stream Result} ()
        
-  735. -- #f54plhut9f6mg77r1f033vubik89irq1eri79d5pd6mqi03rq9em99mc90plurvjnmvho73ssof5fvndgmcg4fgrpvuuil7hb5qmebo
+  736. -- #f54plhut9f6mg77r1f033vubik89irq1eri79d5pd6mqi03rq9em99mc90plurvjnmvho73ssof5fvndgmcg4fgrpvuuil7hb5qmebo
        fail : Text -> b ->{Exception} c
        
-  736. -- #mpe805fs330vqp5l5mg73deahken20dub4hrfvmuutfo97dikgagvimncfr6mfp1l24bjqes1m1dp11a3hop92u49b1fb45j8qs9hoo
+  737. -- #mpe805fs330vqp5l5mg73deahken20dub4hrfvmuutfo97dikgagvimncfr6mfp1l24bjqes1m1dp11a3hop92u49b1fb45j8qs9hoo
        fileExists : Text ->{IO, Exception} Boolean
        
-  737. -- #cft2pjc05jljtlefm4osg96k5t2look2ujq1tgg5hoc5i3fkkatt9pf79g2ka461kq8nbmsggrvo2675ocl599to9e8nre5oef4scdo
+  738. -- #cft2pjc05jljtlefm4osg96k5t2look2ujq1tgg5hoc5i3fkkatt9pf79g2ka461kq8nbmsggrvo2675ocl599to9e8nre5oef4scdo
        fromB32 : Bytes ->{Exception} Bytes
        
-  738. -- #13fpchr37ua0pr38ssr7j22pudmseuedf490aok18upagh0f00kg40guj9pgl916v9qurqrvu53f3lpsvi0s82hg3dtjacanrpjvs38
+  739. -- #13fpchr37ua0pr38ssr7j22pudmseuedf490aok18upagh0f00kg40guj9pgl916v9qurqrvu53f3lpsvi0s82hg3dtjacanrpjvs38
        fromHex : Text -> Bytes
        
-  739. -- #b36oslvh534s82lda0ghc5ql7p7nir0tknsluigulmpso22tjh62uiiq4lq9s3m97a2grkso0qofpb423p06olkkikrt4mfn15vpkug
+  740. -- #b36oslvh534s82lda0ghc5ql7p7nir0tknsluigulmpso22tjh62uiiq4lq9s3m97a2grkso0qofpb423p06olkkikrt4mfn15vpkug
        getBuffering : Handle ->{IO, Exception} BufferMode
        
-  740. -- #9vijttgmba0ui9cshmhmmvgn6ve2e95t168766h2n6pkviddebiimgipic5dbg5lmiht12g6np8a7e06jpk03rnue3ln5mbo4prde0g
+  741. -- #9vijttgmba0ui9cshmhmmvgn6ve2e95t168766h2n6pkviddebiimgipic5dbg5lmiht12g6np8a7e06jpk03rnue3ln5mbo4prde0g
        getBytes : Handle -> Nat ->{IO, Exception} Bytes
        
-  741. -- #c5oeqqglf28ungtq1im4fjdh317eeoba4537l1ntq3ob22v07rpgj9307udscbghlrior398hqm1ci099qmriim8cs975kocacsd9r0
+  742. -- #c5oeqqglf28ungtq1im4fjdh317eeoba4537l1ntq3ob22v07rpgj9307udscbghlrior398hqm1ci099qmriim8cs975kocacsd9r0
        getChar : Handle ->{IO, Exception} Char
        
-  742. -- #j9jdo2pqvi4aktcfsb0n4ns1tk2be7dtckqdeedqp7n52oghsq82cgc1tv562rj1sf1abq2h0vta4uo6873cdbgrtrvd5cvollu3ovo
+  743. -- #j9jdo2pqvi4aktcfsb0n4ns1tk2be7dtckqdeedqp7n52oghsq82cgc1tv562rj1sf1abq2h0vta4uo6873cdbgrtrvd5cvollu3ovo
        getEcho : Handle ->{IO, Exception} Boolean
        
-  743. -- #0hj09gufk8fs2hvr6qij6pie8bp0h6hmm6hpsi8d5fvl1fp1dbk6u8c9p6h4eu2hle6ctgpdbepo9vit5atllkodogn6r0csar9fn1g
+  744. -- #0hj09gufk8fs2hvr6qij6pie8bp0h6hmm6hpsi8d5fvl1fp1dbk6u8c9p6h4eu2hle6ctgpdbepo9vit5atllkodogn6r0csar9fn1g
        getLine : Handle ->{IO, Exception} Text
        
-  744. -- #ck1nfg5fainelng0694jkdf9e06pmn60h7kvble1ff7hkc6jdgqtf7g5o3qevr7ic1bdhfn5n2rc3gde5bh6o9fpbit3ocs0av0scdg
+  745. -- #ck1nfg5fainelng0694jkdf9e06pmn60h7kvble1ff7hkc6jdgqtf7g5o3qevr7ic1bdhfn5n2rc3gde5bh6o9fpbit3ocs0av0scdg
        getSomeBytes : Handle -> Nat ->{IO, Exception} Bytes
        
-  745. -- #bk29bjnrcuh55usf3vocm4j1aml161p6ila7t82cpr3ub9vu0g9lsg2mspmfuefc4ig0qtdqk7nds4t3f68jp6o77e0h4ltbitqjpno
+  746. -- #bk29bjnrcuh55usf3vocm4j1aml161p6ila7t82cpr3ub9vu0g9lsg2mspmfuefc4ig0qtdqk7nds4t3f68jp6o77e0h4ltbitqjpno
        getTempDirectory : '{IO, Exception} Text
        
-  746. -- #j8i534slc2rvakvmqcb6j28iatrh3d7btajai9qndutr0edi5aaoi2p5noditaococ4l104hdhhvjc5vr0rbcjoqrbng46fdeqtnf98
+  747. -- #j8i534slc2rvakvmqcb6j28iatrh3d7btajai9qndutr0edi5aaoi2p5noditaococ4l104hdhhvjc5vr0rbcjoqrbng46fdeqtnf98
        handlePosition : Handle ->{IO, Exception} Nat
        
-  747. -- #bgf7sqs0h0p8bhm3t2ei8006oj1gjonvtkdejv2g9kar0kmvob9e88ceevdfh99jom9rs0hbalf1gut5juanudfcb8tpb1e9ta0vrm8
+  748. -- #bgf7sqs0h0p8bhm3t2ei8006oj1gjonvtkdejv2g9kar0kmvob9e88ceevdfh99jom9rs0hbalf1gut5juanudfcb8tpb1e9ta0vrm8
        handshake : Tls ->{IO, Exception} ()
        
-  748. -- #128490j1tmitiu3vesv97sqspmefobg1am38vos9p0vt4s1bhki87l7kj4cctquffkp40eanmr9ummfglj9i7s25jrpb32ob5sf2tio
+  749. -- #128490j1tmitiu3vesv97sqspmefobg1am38vos9p0vt4s1bhki87l7kj4cctquffkp40eanmr9ummfglj9i7s25jrpb32ob5sf2tio
        hex : Bytes -> Text
        
-  749. -- #ttjui80dbufvf3vgaddmcr065dpgl0rtp68i5cdht6tq4t2vk3i2vg60hi77rug368qijgijf8oui27te7o5oq0t0osm6dg65c080i0
+  750. -- #ttjui80dbufvf3vgaddmcr065dpgl0rtp68i5cdht6tq4t2vk3i2vg60hi77rug368qijgijf8oui27te7o5oq0t0osm6dg65c080i0
        id : a -> a
        
-  750. -- #9qnapjbbdhcc2mjf1b0slm7mefu0idnj1bs4c5bckq42ruodftolnd193uehr31lc01air6d6b3j4ihurnks13n85h3r8rs16nqvj2g
+  751. -- #9qnapjbbdhcc2mjf1b0slm7mefu0idnj1bs4c5bckq42ruodftolnd193uehr31lc01air6d6b3j4ihurnks13n85h3r8rs16nqvj2g
        isDirectory : Text ->{IO, Exception} Boolean
        
-  751. -- #vb1e252fqt0q63hpmtkq2bkg5is2n6thejofnev96040thle5o1ia8dtq7dc6v359gtoqugbqg5tb340aqovrfticb63jgei4ncq3j8
+  752. -- #vb1e252fqt0q63hpmtkq2bkg5is2n6thejofnev96040thle5o1ia8dtq7dc6v359gtoqugbqg5tb340aqovrfticb63jgei4ncq3j8
        isFileEOF : Handle ->{IO, Exception} Boolean
        
-  752. -- #ahkhlm9sd7arpevos99sqc90g7k5nn9bj5n0lhh82c1uva52ltv0295ugc123l17vd1orkng061e11knqjnmk087qjg3vug3rs6mv60
+  753. -- #ahkhlm9sd7arpevos99sqc90g7k5nn9bj5n0lhh82c1uva52ltv0295ugc123l17vd1orkng061e11knqjnmk087qjg3vug3rs6mv60
        isFileOpen : Handle ->{IO, Exception} Boolean
        
-  753. -- #2a11371klrv2i8726knma0l3g14on4m2ucihpg65cjj9k930aefg65ovvg0ak4uv3i9evtnu0a5249q3i8ugheqd65cnmgquc1a88n0
+  754. -- #2a11371klrv2i8726knma0l3g14on4m2ucihpg65cjj9k930aefg65ovvg0ak4uv3i9evtnu0a5249q3i8ugheqd65cnmgquc1a88n0
        isNone : Optional a -> Boolean
        
-  754. -- #ln4avnqpdk7813vsrrr414hg0smcmufrl1c7b87nb7nb0h9cogp6arqa7fbgd7rgolffmgue698ovvefo18j1k8g30t4hbp23onm3l8
+  755. -- #ln4avnqpdk7813vsrrr414hg0smcmufrl1c7b87nb7nb0h9cogp6arqa7fbgd7rgolffmgue698ovvefo18j1k8g30t4hbp23onm3l8
        isSeekable : Handle ->{IO, Exception} Boolean
        
-  755. -- #gop2v9s6l24ii1v6bf1nks2h0h18pato0vbsf4u3el18s7mp1jfnp4c7fesdf9sunnlv5f5a9fjr1s952pte87mf63l1iqki9bp0mio
+  756. -- #gop2v9s6l24ii1v6bf1nks2h0h18pato0vbsf4u3el18s7mp1jfnp4c7fesdf9sunnlv5f5a9fjr1s952pte87mf63l1iqki9bp0mio
        List.all : (a ->{ε} Boolean) -> [a] ->{ε} Boolean
        
-  756. -- #m2g5korqq5etr0qk1qrgjbaqktj4ks4bu9m3c4v3j9g8ktsd2e218nml6q8vo45bi3meb53csack40mle6clfrfep073e313b3jagt0
+  757. -- #m2g5korqq5etr0qk1qrgjbaqktj4ks4bu9m3c4v3j9g8ktsd2e218nml6q8vo45bi3meb53csack40mle6clfrfep073e313b3jagt0
        List.filter : (a ->{g} Boolean) -> [a] ->{g} [a]
        
-  757. -- #8s836vq5jggucs6bj3bear30uhe6h9cskudjrdc772ghiec6ce2jqft09l1n05kd1n6chekrbgt0h8mkc9drgscjvgghacojm9e8c5o
+  758. -- #8s836vq5jggucs6bj3bear30uhe6h9cskudjrdc772ghiec6ce2jqft09l1n05kd1n6chekrbgt0h8mkc9drgscjvgghacojm9e8c5o
        List.foldLeft : (b ->{g} a ->{g} b) -> b -> [a] ->{g} b
        
-  758. -- #m5tlb5a0m4kp5b4m9oq9vhda9d7nhu2obn2lpmosal0ebij9gon4gkd1aq0b3b61jtsc1go0hi7b2sm2memtil55ijq32b2n0k39vko
+  759. -- #m5tlb5a0m4kp5b4m9oq9vhda9d7nhu2obn2lpmosal0ebij9gon4gkd1aq0b3b61jtsc1go0hi7b2sm2memtil55ijq32b2n0k39vko
        List.forEach : [a] -> (a ->{e} ()) ->{e} ()
        
-  759. -- #j9ve4ionu2sn7f814t0t4gc75objke2drgnfvvvb50v2f57ss0hlsa3ai5g5jsk2t4b8s37ocrtmte7nktfb2vjf8508ksvrc6llu30
+  760. -- #j9ve4ionu2sn7f814t0t4gc75objke2drgnfvvvb50v2f57ss0hlsa3ai5g5jsk2t4b8s37ocrtmte7nktfb2vjf8508ksvrc6llu30
        listen : Socket ->{IO, Exception} ()
        
-  760. -- #s0f4et1o1ns8cmmvp3i0cm6cmmv5qaf99qm2q4jmgpciof6ntmuh3mpr4epns3ocskn8raacbvm30ovvj2b6arv0ff7iks31rannbf0
+  761. -- #s0f4et1o1ns8cmmvp3i0cm6cmmv5qaf99qm2q4jmgpciof6ntmuh3mpr4epns3ocskn8raacbvm30ovvj2b6arv0ff7iks31rannbf0
        loadCodeBytes : Bytes ->{Exception} Code
        
-  761. -- #gvaed1m07qihc9c216125sur1q9a7i5ita44qnevongg4jrbd8k2plsqhdur45nn6h3drn6lc3iidp1b208ht8s73fg2711l76c7j4g
+  762. -- #gvaed1m07qihc9c216125sur1q9a7i5ita44qnevongg4jrbd8k2plsqhdur45nn6h3drn6lc3iidp1b208ht8s73fg2711l76c7j4g
        loadSelfContained : Text ->{IO, Exception} a
        
-  762. -- #g1hqlq27e3stamnnfp6q178pleeml9sbo2d6scj2ikubocane5cvf8ctausoqrgj9co9h56ttgt179sgktc0bei2r37dmtj51jg0ou8
+  763. -- #g1hqlq27e3stamnnfp6q178pleeml9sbo2d6scj2ikubocane5cvf8ctausoqrgj9co9h56ttgt179sgktc0bei2r37dmtj51jg0ou8
        loadValueBytes : Bytes
        ->{IO, Exception} ([(Link.Term, Code)], Value)
        
-  763. -- #tlllu51stumo77vi2e5m0e8m05qletfbr3nea3d84dcgh66dq4s3bt7kdbf8mpdqh16mmnoh11kr3n43m8b5g4pf95l9gfbhhok1h20
+  764. -- #tlllu51stumo77vi2e5m0e8m05qletfbr3nea3d84dcgh66dq4s3bt7kdbf8mpdqh16mmnoh11kr3n43m8b5g4pf95l9gfbhhok1h20
        MVar.put : MVar i -> i ->{IO, Exception} ()
        
-  764. -- #3b7lp7s9m31mcvh73nh4gfj1kal6onrmppf35esvmma4jsg7bbm7a8tsrfcb4te88f03r97dkf7n1f2kcc6o7ng4vurp95svfj2fg7o
+  765. -- #3b7lp7s9m31mcvh73nh4gfj1kal6onrmppf35esvmma4jsg7bbm7a8tsrfcb4te88f03r97dkf7n1f2kcc6o7ng4vurp95svfj2fg7o
        MVar.read : MVar o ->{IO, Exception} o
        
-  765. -- #be8m7lsjnf31u87pt5rvn04c9ellhbm3p56jgapbp8k7qp0v3mm7beh81luoifp17681l0ldjj46gthmmu32lkn0jnejr3tedjotntg
+  766. -- #be8m7lsjnf31u87pt5rvn04c9ellhbm3p56jgapbp8k7qp0v3mm7beh81luoifp17681l0ldjj46gthmmu32lkn0jnejr3tedjotntg
        MVar.swap : MVar o -> o ->{IO, Exception} o
        
-  766. -- #c2qb0ca2dj3rronbp4slj3ph56p0iopaos7ib37hjunpkl1rcl1gp820dpg8qflhvt9cm2l1bfm40rkdslce2sr6f0oru5lr5cl5nu0
+  767. -- #c2qb0ca2dj3rronbp4slj3ph56p0iopaos7ib37hjunpkl1rcl1gp820dpg8qflhvt9cm2l1bfm40rkdslce2sr6f0oru5lr5cl5nu0
        MVar.take : MVar o ->{IO, Exception} o
        
-  767. -- #ht0k9hb3k1cnjsgmtu9klivo074a2uro4csh63m1sqr2483rkojlj7abcf0jfmssbfig98i6is1osr2djoqubg3bp6articvq9o8090
+  768. -- #ht0k9hb3k1cnjsgmtu9klivo074a2uro4csh63m1sqr2483rkojlj7abcf0jfmssbfig98i6is1osr2djoqubg3bp6articvq9o8090
        newClient : ClientConfig -> Socket ->{IO, Exception} Tls
        
-  768. -- #coeloqmjin6lais8u6j0plh5f1601lpcue4ejfcute46opams4vsbkplqj6jg6af0uecjie3mbclv40b3jumghsf09aavvucrc0d148
+  769. -- #coeloqmjin6lais8u6j0plh5f1601lpcue4ejfcute46opams4vsbkplqj6jg6af0uecjie3mbclv40b3jumghsf09aavvucrc0d148
        newServer : ServerConfig -> Socket ->{IO, Exception} Tls
        
-  769. -- #ocvo5mvs8fghsf715tt4mhpj1pu8e8r7pq9nue63ut0ol2vnv70k7t6tavtsljlmdib9lo3bt669qac94dk53ldcgtukvotvrlfkan0
+  770. -- #ocvo5mvs8fghsf715tt4mhpj1pu8e8r7pq9nue63ut0ol2vnv70k7t6tavtsljlmdib9lo3bt669qac94dk53ldcgtukvotvrlfkan0
        openFile : Text -> FileMode ->{IO, Exception} Handle
        
-  770. -- #c58qbcgd90d965dokk7bu82uehegkbe8jttm7lv4j0ohgi2qm3e3p4v1qfr8vc2dlsmsl9tv0v71kco8c18mneule0ntrhte4ks1090
+  771. -- #c58qbcgd90d965dokk7bu82uehegkbe8jttm7lv4j0ohgi2qm3e3p4v1qfr8vc2dlsmsl9tv0v71kco8c18mneule0ntrhte4ks1090
        printLine : Text ->{IO, Exception} ()
        
-  771. -- #dck7pb7qv05ol3b0o76l88a22bc7enl781ton5qbs2umvgsua3p16n22il02m29592oohsnbt3cr7hnlumpdhv2ibjp6iji9te4iot0
+  772. -- #dck7pb7qv05ol3b0o76l88a22bc7enl781ton5qbs2umvgsua3p16n22il02m29592oohsnbt3cr7hnlumpdhv2ibjp6iji9te4iot0
        printText : Text ->{IO} Either Failure ()
        
-  772. -- #i9lm1g1j0p4qtakg164jdlgac409sgj1cb91k86k0c44ssajbluovuu7ptm5uc20sjgedjbak3iji8o859ek871ul51b8l30s4uf978
+  773. -- #i9lm1g1j0p4qtakg164jdlgac409sgj1cb91k86k0c44ssajbluovuu7ptm5uc20sjgedjbak3iji8o859ek871ul51b8l30s4uf978
        putBytes : Handle -> Bytes ->{IO, Exception} ()
        
-  773. -- #84j6ua3924v85vh2a581de7sd8pee1lqbp1ibvatvjtui9hvk36sv2riabu0v2r0s25p62ipnvv4aeadpg0u8m5ffqrc202i71caopg
+  774. -- #84j6ua3924v85vh2a581de7sd8pee1lqbp1ibvatvjtui9hvk36sv2riabu0v2r0s25p62ipnvv4aeadpg0u8m5ffqrc202i71caopg
        readFile : Text ->{IO, Exception} Bytes
        
-  774. -- #pk003cv7lvidkbmsnne4mpt20254gh4hd7vvretnbk8na8bhr9fg9776rp8pt9srhiucrd1c7sjl006vmil9e78p40gdcir81ujil2o
+  775. -- #pk003cv7lvidkbmsnne4mpt20254gh4hd7vvretnbk8na8bhr9fg9776rp8pt9srhiucrd1c7sjl006vmil9e78p40gdcir81ujil2o
        ready : Handle ->{IO, Exception} Boolean
        
-  775. -- #unn7qak4qe0nbbpf62uesu0fe8i68o83l4o7f6jcblefbla53fef7a63ts28fh6ql81o5c04j44g7m5rq9aouo73dpeprbl5lka8170
+  776. -- #unn7qak4qe0nbbpf62uesu0fe8i68o83l4o7f6jcblefbla53fef7a63ts28fh6ql81o5c04j44g7m5rq9aouo73dpeprbl5lka8170
        receive : Tls ->{IO, Exception} Bytes
        
-  776. -- #ugs4208vpm97jr2ecmr7l9h4e22r1ije6v379m4v6229c8o7hk669ba63bor4pe6n1bm24il87iq2d99sj78lt6n5eqa1fre0grn93g
+  777. -- #ugs4208vpm97jr2ecmr7l9h4e22r1ije6v379m4v6229c8o7hk669ba63bor4pe6n1bm24il87iq2d99sj78lt6n5eqa1fre0grn93g
        removeDirectory : Text ->{IO, Exception} ()
        
-  777. -- #6pia69u5u5rja1jk04v3i9ke24gf4b1t7vnaj0noogord6ekiqhf72qfkc1n08rd11f2cbkofni5rd5u7t1qkgslbi40hut35pfi1v0
+  778. -- #6pia69u5u5rja1jk04v3i9ke24gf4b1t7vnaj0noogord6ekiqhf72qfkc1n08rd11f2cbkofni5rd5u7t1qkgslbi40hut35pfi1v0
        renameDirectory : Text -> Text ->{IO, Exception} ()
        
-  778. -- #amtsq2jq1k75r309esfp800a8slelm4d3q9i1pq1qqs3pil13at916958sf9ucb4607kpktbnup7nc58ecoq8mcs01e2a03d08agn18
+  779. -- #amtsq2jq1k75r309esfp800a8slelm4d3q9i1pq1qqs3pil13at916958sf9ucb4607kpktbnup7nc58ecoq8mcs01e2a03d08agn18
        runTest : '{IO, TempDirs, Exception, Stream Result} a
        ->{IO} [Result]
        
-  779. -- #b59q94bf9mrvv4gl8gqjd04dc3ahq373ka5esh4grtjupkm8ov7o7h0n56q2dg3ocdsreqvm973rlhs4etua1tbrsuabc398e5pvs0o
+  780. -- #b59q94bf9mrvv4gl8gqjd04dc3ahq373ka5esh4grtjupkm8ov7o7h0n56q2dg3ocdsreqvm973rlhs4etua1tbrsuabc398e5pvs0o
        saveSelfContained : a -> Text ->{IO, Exception} ()
        
-  780. -- #f55p4o2hlhka9olk8a9dnan57o51605g4q26jtpsbkt0g652s322779sej71182ntb6lkh01gom3g26cmngqq7vtl7m7oovdi0koc70
+  781. -- #f55p4o2hlhka9olk8a9dnan57o51605g4q26jtpsbkt0g652s322779sej71182ntb6lkh01gom3g26cmngqq7vtl7m7oovdi0koc70
        saveTestCase : Text
        -> (a -> Text)
        -> a
        ->{IO, Exception} ()
        
-  781. -- #v2otbk1e0e81d6ea9i3j1kivnfam6rk6earsjbjljv4mmrk1mgfals6jhfd74evor6al9mkb5gv8hf15f02807f0aa0hnsg9fas1qco
+  782. -- #v2otbk1e0e81d6ea9i3j1kivnfam6rk6earsjbjljv4mmrk1mgfals6jhfd74evor6al9mkb5gv8hf15f02807f0aa0hnsg9fas1qco
        seekHandle : Handle
        -> SeekMode
        -> Int
        ->{IO, Exception} ()
        
-  782. -- #a98jlos4rj2um55iksdin9p5djo6j70qmuitoe2ff3uvkefb8pqensorln5flr3pm8hkc0lqkchbd63cf9tl0kqnqu3i17kvqnm35g0
+  783. -- #a98jlos4rj2um55iksdin9p5djo6j70qmuitoe2ff3uvkefb8pqensorln5flr3pm8hkc0lqkchbd63cf9tl0kqnqu3i17kvqnm35g0
        send : Tls -> Bytes ->{IO, Exception} ()
        
-  783. -- #qrdia2sc9vuoi7u3a4ukjk8lv0rlhn2i2bbin1adbhcuj79jn366dv3a8t52hpil0jtgkhhuiavibmdev63j5ndriod33rkktjekqv8
+  784. -- #qrdia2sc9vuoi7u3a4ukjk8lv0rlhn2i2bbin1adbhcuj79jn366dv3a8t52hpil0jtgkhhuiavibmdev63j5ndriod33rkktjekqv8
        serverSocket : Optional Text
        -> Text
        ->{IO, Exception} Socket
        
-  784. -- #3vft70875p42eao55rhb61siobuei4h0e9vlu4bbgucjo296c2vfjpucacovnu9538tvup5c7lo9123se8v4fe7m8q9aiqbkjpumkao
+  785. -- #3vft70875p42eao55rhb61siobuei4h0e9vlu4bbgucjo296c2vfjpucacovnu9538tvup5c7lo9123se8v4fe7m8q9aiqbkjpumkao
        setBuffering : Handle -> BufferMode ->{IO, Exception} ()
        
-  785. -- #erqshamlurgahpd4rroild36cc5e4rk56r38r53vcbg8cblr82c6gfji3um8f09ffgjlg58g7r32mtsbvjlcq4c65v0jn3va9888mao
+  786. -- #erqshamlurgahpd4rroild36cc5e4rk56r38r53vcbg8cblr82c6gfji3um8f09ffgjlg58g7r32mtsbvjlcq4c65v0jn3va9888mao
        setEcho : Handle -> Boolean ->{IO, Exception} ()
        
-  786. -- #ugar51qqij4ur24frdi84eqdkvqa0fbsi4v6e2586hi3tai52ovtpm3f2dc9crnfv8pk0ppq6b5tv3utl4sl49n5aecorgkqddr7i38
+  787. -- #ugar51qqij4ur24frdi84eqdkvqa0fbsi4v6e2586hi3tai52ovtpm3f2dc9crnfv8pk0ppq6b5tv3utl4sl49n5aecorgkqddr7i38
        snd : ∀ a a1. (a1, a) -> a
        
-  787. -- #leoq6smeq8to5ej3314uuujmh6rfbcsdb9q8ah8h3ohg9jq5kftc93mq671o0qh2he9vqgd288k0ecea3h7eerpbgjt6a8p843tmon8
+  788. -- #leoq6smeq8to5ej3314uuujmh6rfbcsdb9q8ah8h3ohg9jq5kftc93mq671o0qh2he9vqgd288k0ecea3h7eerpbgjt6a8p843tmon8
        socketAccept : Socket ->{IO, Exception} Socket
        
-  788. -- #s43jbp19k91qq704tidpue2vs2re1lh4mtv46rdmdnurkdndst7u0k712entcvip160vh9cilmpamikmflbprg5up0k6cl15b8tr5l0
+  789. -- #s43jbp19k91qq704tidpue2vs2re1lh4mtv46rdmdnurkdndst7u0k712entcvip160vh9cilmpamikmflbprg5up0k6cl15b8tr5l0
        socketPort : Socket ->{IO, Exception} Nat
        
-  789. -- #3rp8h0dt7g60nrjdehuhqga9dmomti5rdqho7r1rm5rg5moet7kt3ieempo7c9urur752njachq6k48ggbic4ugbbv75jl2mfbk57a0
+  790. -- #3rp8h0dt7g60nrjdehuhqga9dmomti5rdqho7r1rm5rg5moet7kt3ieempo7c9urur752njachq6k48ggbic4ugbbv75jl2mfbk57a0
        startsWith : Text -> Text -> Boolean
        
-  790. -- #elsab3sc7p4c6bj73pgvklv0j7qu268rn5isv6micfp7ib8grjoustpqdq0pkd4a379mr5ijb8duu2q0n040osfurppp8pt8vaue2fo
+  791. -- #elsab3sc7p4c6bj73pgvklv0j7qu268rn5isv6micfp7ib8grjoustpqdq0pkd4a379mr5ijb8duu2q0n040osfurppp8pt8vaue2fo
        stdout : Handle
        
-  791. -- #rfi1v9429f9qluv533l2iba77aadttilrpmnhljfapfnfa6sru2nr8ibpqvib9nc4s4nb9s1as45upsfqfqe6ivqi2p82b2vd866it8
+  792. -- #rfi1v9429f9qluv533l2iba77aadttilrpmnhljfapfnfa6sru2nr8ibpqvib9nc4s4nb9s1as45upsfqfqe6ivqi2p82b2vd866it8
        structural ability Stream a
        
-  792. -- #2jl99er43tnksj8r8oveap5ger9uqlvj0u0ghfs0uqa7i6m45jk976n7a726jb7rtusjdu2p8hbbcgmoacvke7k5o3kdgoj57c3v2v8
+  793. -- #2jl99er43tnksj8r8oveap5ger9uqlvj0u0ghfs0uqa7i6m45jk976n7a726jb7rtusjdu2p8hbbcgmoacvke7k5o3kdgoj57c3v2v8
        Stream.collect : '{e, Stream a} r ->{e} ([a], r)
        
-  793. -- #rnuje46fvuqa4a8sdgl9e250a2gcmhtsscr8bdonj2bduhrst38ur7dorv3ahr2ghf9cufkfit7ndh9qb9gspbfapcnn3sol0l2moqg
+  794. -- #rnuje46fvuqa4a8sdgl9e250a2gcmhtsscr8bdonj2bduhrst38ur7dorv3ahr2ghf9cufkfit7ndh9qb9gspbfapcnn3sol0l2moqg
        Stream.collect.handler : Request {Stream a} r -> ([a], r)
        
-  794. -- #rfi1v9429f9qluv533l2iba77aadttilrpmnhljfapfnfa6sru2nr8ibpqvib9nc4s4nb9s1as45upsfqfqe6ivqi2p82b2vd866it8#0
+  795. -- #rfi1v9429f9qluv533l2iba77aadttilrpmnhljfapfnfa6sru2nr8ibpqvib9nc4s4nb9s1as45upsfqfqe6ivqi2p82b2vd866it8#0
        Stream.emit : a ->{Stream a} ()
        
-  795. -- #c70gf5m1blvh8tg4kvt1taee036fr7r22bbtqcupac5r5igs102nj077vdl0nimef94u951kfcl9a5hcevo01j04v9o6v3cpndq41bo
+  796. -- #c70gf5m1blvh8tg4kvt1taee036fr7r22bbtqcupac5r5igs102nj077vdl0nimef94u951kfcl9a5hcevo01j04v9o6v3cpndq41bo
        Stream.toList : '{Stream a} r -> [a]
        
-  796. -- #ul69cgsrsspjni8b0hqnt4kt4bk7sjtp6jvlhhofom7bemu9nb2kimm6tt1raigr7j86afgmnjnrfabn6a5l5v1t219uidiu22ueiv0
+  797. -- #ul69cgsrsspjni8b0hqnt4kt4bk7sjtp6jvlhhofom7bemu9nb2kimm6tt1raigr7j86afgmnjnrfabn6a5l5v1t219uidiu22ueiv0
        Stream.toList.handler : Request {Stream a} r -> [a]
        
-  797. -- #58d8kfuq8sqbipa1aaijjhm28pa6a844h19mgg5s4a1h160etbulig21cm0pcnfla8fisqvrp80840g9luid5u8amvcc8sf46pd25h8
+  798. -- #58d8kfuq8sqbipa1aaijjhm28pa6a844h19mgg5s4a1h160etbulig21cm0pcnfla8fisqvrp80840g9luid5u8amvcc8sf46pd25h8
        systemTime : '{IO, Exception} Nat
        
-  798. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18
+  799. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18
        structural ability TempDirs
        
-  799. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18#0
+  800. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18#0
        TempDirs.newTempDir : Text ->{TempDirs} Text
        
-  800. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18#1
+  801. -- #11mhfqj6rts8lm3im7saf44tn3km5bboqtu1td0udnaiit4qqg6ar1ecmccosl6gufsnp6sug3vcmgapsc58sgj7dh7rg8msq2qkj18#1
        TempDirs.removeDir : Text ->{TempDirs} ()
        
-  801. -- #natgur73q6b4c3tp5jcor0v1cdnplh0n3fhm4qvhg4v74u3e3ff1352shs1lveot83lj82qqbl78n40qi9a132fhkmaa6g5s1ja91go
+  802. -- #natgur73q6b4c3tp5jcor0v1cdnplh0n3fhm4qvhg4v74u3e3ff1352shs1lveot83lj82qqbl78n40qi9a132fhkmaa6g5s1ja91go
        terminate : Tls ->{IO, Exception} ()
        
-  802. -- #i3pbnc98rbfug5dnnvpd4uahm2e5fld2fu0re9r305isffr1r43048h7ql6ojdbjcsvjr6h91s6i026na046ltg5ff59klla6e7vq98
+  803. -- #i3pbnc98rbfug5dnnvpd4uahm2e5fld2fu0re9r305isffr1r43048h7ql6ojdbjcsvjr6h91s6i026na046ltg5ff59klla6e7vq98
        testAutoClean : '{IO} [Result]
        
-  803. -- #spepthutvs3p6je794h520665rh8abl36qg43i7ipvj0mtg5sb0sbemjp2vpu9j3feithk2ae0sdtcmb8afoglo9rnvl350380t21h0
+  804. -- #spepthutvs3p6je794h520665rh8abl36qg43i7ipvj0mtg5sb0sbemjp2vpu9j3feithk2ae0sdtcmb8afoglo9rnvl350380t21h0
        Text.fromUtf8 : Bytes ->{Exception} Text
        
-  804. -- #32q9jqhmi8f08pec3hj0je4u7k52f9f1hdfsmn9ncg2kpki5da9dabigplvdcot3a00k7s5npc4n78psd6ojaumqjla259e9pqd4ov8
+  805. -- #32q9jqhmi8f08pec3hj0je4u7k52f9f1hdfsmn9ncg2kpki5da9dabigplvdcot3a00k7s5npc4n78psd6ojaumqjla259e9pqd4ov8
        structural ability Throw e
        
-  805. -- #32q9jqhmi8f08pec3hj0je4u7k52f9f1hdfsmn9ncg2kpki5da9dabigplvdcot3a00k7s5npc4n78psd6ojaumqjla259e9pqd4ov8#0
+  806. -- #32q9jqhmi8f08pec3hj0je4u7k52f9f1hdfsmn9ncg2kpki5da9dabigplvdcot3a00k7s5npc4n78psd6ojaumqjla259e9pqd4ov8#0
        Throw.throw : e ->{Throw e} a
        
-  806. -- #vri6fsnl704n6aqs346p6ijcbkcsv9875edr6b74enumrhbjiuon94ir4ufmrrn84k9b2jka4f05o16mcvsjrjav6gpskpiu4sknd1g
+  807. -- #vri6fsnl704n6aqs346p6ijcbkcsv9875edr6b74enumrhbjiuon94ir4ufmrrn84k9b2jka4f05o16mcvsjrjav6gpskpiu4sknd1g
        uncurry : ∀ o g1 i g i1.
          (i1 ->{g} i ->{g1} o) -> (i1, i) ->{g1, g} o
        
-  807. -- #rhak55ntto40n4utgv5o93jvlmv82lceb625slrt8tsmg74vin5bclf10vkl1sgpau3thqsa6guiihog74qoknlsqbuce5th60bu2eg
+  808. -- #rhak55ntto40n4utgv5o93jvlmv82lceb625slrt8tsmg74vin5bclf10vkl1sgpau3thqsa6guiihog74qoknlsqbuce5th60bu2eg
        Value.transitiveDeps : Value ->{IO} [(Link.Term, Code)]
        
-  808. -- #o5bg5el7ckak28ib98j5b6rt26bqbprpddd1brrg3s18qahhbbe3uohufjjnt5eenvtjg0hrvnvpra95jmdppqrovvmcfm1ih2k7guo
+  809. -- #o5bg5el7ckak28ib98j5b6rt26bqbprpddd1brrg3s18qahhbbe3uohufjjnt5eenvtjg0hrvnvpra95jmdppqrovvmcfm1ih2k7guo
        void : x -> ()
        
-  809. -- #8ugamqlp7a4g0dmbcvipqfi8gnuuj23pjbdfbof11naiun1qf8otjcap80epaom2kl9fv5rhjaudt4558n38dovrc0lhipubqjgm8mg
+  810. -- #8ugamqlp7a4g0dmbcvipqfi8gnuuj23pjbdfbof11naiun1qf8otjcap80epaom2kl9fv5rhjaudt4558n38dovrc0lhipubqjgm8mg
        writeFile : Text -> Bytes ->{IO, Exception} ()
        
-  810. -- #lcmj2envm11lrflvvcl290lplhvbccv82utoej0lg0eomhmsf2vrv8af17k6if7ff98fp1b13rkseng3fng4stlr495c8dn3gn4k400
+  811. -- #lcmj2envm11lrflvvcl290lplhvbccv82utoej0lg0eomhmsf2vrv8af17k6if7ff98fp1b13rkseng3fng4stlr495c8dn3gn4k400
        |> : a -> (a ->{g} t) ->{g} t
        
   

--- a/unison-src/transcripts-using-base/hashing.md
+++ b/unison-src/transcripts-using-base/hashing.md
@@ -225,6 +225,29 @@ test> hmac_sha2_512.tests.ex2 =
     "164b7a7bfcf819e2e395fbe73b56e0a387bd64222e831fd610270cd7ea2505549758bf75c05a994a6d034f65f8f0e6fdcaeab1a34d4a6b4b636e070a38bce737"
 ```
 
+## MD5 tests
+
+Test vectors here pulled from [Wikipedia's writeup](https://en.wikipedia.org/wiki/MD5).
+
+```unison
+ex alg input expected = checks [hashBytes alg (ascii input) == fromHex expected]
+
+test> md5.tests.ex1 =
+  ex Md5
+    ""
+    "d41d8cd98f00b204e9800998ecf8427e"
+
+test> md5.tests.ex2 =
+  ex Md5
+    "The quick brown fox jumps over the lazy dog"
+    "9e107d9d372bb6826bd81d3542a419d6"
+
+test> md5.tests.ex3 =
+  ex Md5
+    "The quick brown fox jumps over the lazy dog."
+    "e4d909c290d0fb1ca068ffaddf22cbd0"
+```
+
 ```ucm:hide
 .> add
 ```

--- a/unison-src/transcripts-using-base/hashing.output.md
+++ b/unison-src/transcripts-using-base/hashing.output.md
@@ -124,14 +124,15 @@ And here's the full API:
   3.  HashAlgorithm.Blake2b_256 : HashAlgorithm
   4.  HashAlgorithm.Blake2b_512 : HashAlgorithm
   5.  HashAlgorithm.Blake2s_256 : HashAlgorithm
-  6.  HashAlgorithm.Sha1 : HashAlgorithm
-  7.  HashAlgorithm.Sha2_256 : HashAlgorithm
-  8.  HashAlgorithm.Sha2_512 : HashAlgorithm
-  9.  HashAlgorithm.Sha3_256 : HashAlgorithm
-  10. HashAlgorithm.Sha3_512 : HashAlgorithm
-  11. hashBytes : HashAlgorithm -> Bytes -> Bytes
-  12. hmac : HashAlgorithm -> Bytes -> a -> Bytes
-  13. hmacBytes : HashAlgorithm -> Bytes -> Bytes -> Bytes
+  6.  HashAlgorithm.Md5 : HashAlgorithm
+  7.  HashAlgorithm.Sha1 : HashAlgorithm
+  8.  HashAlgorithm.Sha2_256 : HashAlgorithm
+  9.  HashAlgorithm.Sha2_512 : HashAlgorithm
+  10. HashAlgorithm.Sha3_256 : HashAlgorithm
+  11. HashAlgorithm.Sha3_512 : HashAlgorithm
+  12. hashBytes : HashAlgorithm -> Bytes -> Bytes
+  13. hmac : HashAlgorithm -> Bytes -> a -> Bytes
+  14. hmacBytes : HashAlgorithm -> Bytes -> Bytes -> Bytes
   
 
 .> cd .
@@ -390,41 +391,93 @@ test> hmac_sha2_512.tests.ex2 =
     ✅ Passed Passed
 
 ```
+## MD5 tests
+
+Test vectors here pulled from [Wikipedia's writeup](https://en.wikipedia.org/wiki/MD5).
+
+```unison
+ex alg input expected = checks [hashBytes alg (ascii input) == fromHex expected]
+
+test> md5.tests.ex1 =
+  ex Md5
+    ""
+    "d41d8cd98f00b204e9800998ecf8427e"
+
+test> md5.tests.ex2 =
+  ex Md5
+    "The quick brown fox jumps over the lazy dog"
+    "9e107d9d372bb6826bd81d3542a419d6"
+
+test> md5.tests.ex3 =
+  ex Md5
+    "The quick brown fox jumps over the lazy dog."
+    "e4d909c290d0fb1ca068ffaddf22cbd0"
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⊡ Previously added definitions will be ignored: ex
+    
+    ⍟ These new definitions are ok to `add`:
+    
+      md5.tests.ex1 : [Result]
+      md5.tests.ex2 : [Result]
+      md5.tests.ex3 : [Result]
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    4 |   ex Md5
+    
+    ✅ Passed Passed
+  
+    9 |   ex Md5
+    
+    ✅ Passed Passed
+  
+    14 |   ex Md5
+    
+    ✅ Passed Passed
+
+```
 ```ucm
 .> test
 
   Cached test results (`help testcache` to learn more)
   
-  ◉ blake2b_512.tests.ex1     Passed
-  ◉ blake2b_512.tests.ex2     Passed
-  ◉ blake2b_512.tests.ex3     Passed
-  ◉ blake2s_256.tests.ex1     Passed
-  ◉ hmac_sha2_256.tests.ex1   Passed
-  ◉ hmac_sha2_256.tests.ex2   Passed
-  ◉ hmac_sha2_512.tests.ex1   Passed
-  ◉ hmac_sha2_512.tests.ex2   Passed
-  ◉ sha1.tests.ex1            Passed
-  ◉ sha1.tests.ex2            Passed
-  ◉ sha1.tests.ex3            Passed
-  ◉ sha1.tests.ex4            Passed
-  ◉ sha2_256.tests.ex1        Passed
-  ◉ sha2_256.tests.ex2        Passed
-  ◉ sha2_256.tests.ex3        Passed
-  ◉ sha2_256.tests.ex4        Passed
-  ◉ sha2_512.tests.ex1        Passed
-  ◉ sha2_512.tests.ex2        Passed
-  ◉ sha2_512.tests.ex3        Passed
-  ◉ sha2_512.tests.ex4        Passed
-  ◉ sha3_256.tests.ex1        Passed
-  ◉ sha3_256.tests.ex2        Passed
-  ◉ sha3_256.tests.ex3        Passed
-  ◉ sha3_256.tests.ex4        Passed
-  ◉ sha3_512.tests.ex1        Passed
-  ◉ sha3_512.tests.ex2        Passed
-  ◉ sha3_512.tests.ex3        Passed
-  ◉ sha3_512.tests.ex4        Passed
+  ◉ blake2b_512.tests.ex1   Passed
+  ◉ blake2b_512.tests.ex2   Passed
+  ◉ blake2b_512.tests.ex3   Passed
+  ◉ blake2s_256.tests.ex1   Passed
+  ◉ md5.tests.ex1           Passed
+  ◉ md5.tests.ex2           Passed
+  ◉ md5.tests.ex3           Passed
+  ◉ sha1.tests.ex1          Passed
+  ◉ sha1.tests.ex2          Passed
+  ◉ sha1.tests.ex3          Passed
+  ◉ sha1.tests.ex4          Passed
+  ◉ sha2_256.tests.ex1      Passed
+  ◉ sha2_256.tests.ex2      Passed
+  ◉ sha2_256.tests.ex3      Passed
+  ◉ sha2_256.tests.ex4      Passed
+  ◉ sha2_512.tests.ex1      Passed
+  ◉ sha2_512.tests.ex2      Passed
+  ◉ sha2_512.tests.ex3      Passed
+  ◉ sha2_512.tests.ex4      Passed
+  ◉ sha3_256.tests.ex1      Passed
+  ◉ sha3_256.tests.ex2      Passed
+  ◉ sha3_256.tests.ex3      Passed
+  ◉ sha3_256.tests.ex4      Passed
+  ◉ sha3_512.tests.ex1      Passed
+  ◉ sha3_512.tests.ex2      Passed
+  ◉ sha3_512.tests.ex3      Passed
+  ◉ sha3_512.tests.ex4      Passed
   
-  ✅ 28 test(s) passing
+  ✅ 27 test(s) passing
   
   Tip: Use view blake2b_512.tests.ex1 to view the source of a
        test.

--- a/unison-src/transcripts/alias-many.output.md
+++ b/unison-src/transcripts/alias-many.output.md
@@ -96,598 +96,599 @@ Let's try it!
   76.  crypto.HashAlgorithm.Blake2b_256 : HashAlgorithm
   77.  crypto.HashAlgorithm.Blake2b_512 : HashAlgorithm
   78.  crypto.HashAlgorithm.Blake2s_256 : HashAlgorithm
-  79.  crypto.HashAlgorithm.Sha1 : HashAlgorithm
-  80.  crypto.HashAlgorithm.Sha2_256 : HashAlgorithm
-  81.  crypto.HashAlgorithm.Sha2_512 : HashAlgorithm
-  82.  crypto.HashAlgorithm.Sha3_256 : HashAlgorithm
-  83.  crypto.HashAlgorithm.Sha3_512 : HashAlgorithm
-  84.  crypto.hashBytes : HashAlgorithm -> Bytes -> Bytes
-  85.  crypto.hmac : HashAlgorithm -> Bytes -> a -> Bytes
-  86.  crypto.hmacBytes : HashAlgorithm
+  79.  crypto.HashAlgorithm.Md5 : HashAlgorithm
+  80.  crypto.HashAlgorithm.Sha1 : HashAlgorithm
+  81.  crypto.HashAlgorithm.Sha2_256 : HashAlgorithm
+  82.  crypto.HashAlgorithm.Sha2_512 : HashAlgorithm
+  83.  crypto.HashAlgorithm.Sha3_256 : HashAlgorithm
+  84.  crypto.HashAlgorithm.Sha3_512 : HashAlgorithm
+  85.  crypto.hashBytes : HashAlgorithm -> Bytes -> Bytes
+  86.  crypto.hmac : HashAlgorithm -> Bytes -> a -> Bytes
+  87.  crypto.hmacBytes : HashAlgorithm
                           -> Bytes
                           -> Bytes
                           -> Bytes
-  87.  Debug.toText : a -> Optional (Either Text Text)
-  88.  Debug.trace : Text -> a -> ()
-  89.  Debug.watch : Text -> a -> a
-  90.  unique type Doc
-  91.  Doc.Blob : Text -> Doc
-  92.  Doc.Evaluate : Term -> Doc
-  93.  Doc.Join : [Doc] -> Doc
-  94.  Doc.Link : Link -> Doc
-  95.  Doc.Signature : Term -> Doc
-  96.  Doc.Source : Link -> Doc
-  97.  structural type Either a b
-  98.  Either.Left : a -> Either a b
-  99.  Either.Right : b -> Either a b
-  100. structural ability Exception
-  101. Exception.raise : Failure ->{Exception} x
-  102. builtin type Float
-  103. Float.* : Float -> Float -> Float
-  104. Float.+ : Float -> Float -> Float
-  105. Float.- : Float -> Float -> Float
-  106. Float./ : Float -> Float -> Float
-  107. Float.abs : Float -> Float
-  108. Float.acos : Float -> Float
-  109. Float.acosh : Float -> Float
-  110. Float.asin : Float -> Float
-  111. Float.asinh : Float -> Float
-  112. Float.atan : Float -> Float
-  113. Float.atan2 : Float -> Float -> Float
-  114. Float.atanh : Float -> Float
-  115. Float.ceiling : Float -> Int
-  116. Float.cos : Float -> Float
-  117. Float.cosh : Float -> Float
-  118. Float.eq : Float -> Float -> Boolean
-  119. Float.exp : Float -> Float
-  120. Float.floor : Float -> Int
-  121. Float.fromRepresentation : Nat -> Float
-  122. Float.fromText : Text -> Optional Float
-  123. Float.gt : Float -> Float -> Boolean
-  124. Float.gteq : Float -> Float -> Boolean
-  125. Float.log : Float -> Float
-  126. Float.logBase : Float -> Float -> Float
-  127. Float.lt : Float -> Float -> Boolean
-  128. Float.lteq : Float -> Float -> Boolean
-  129. Float.max : Float -> Float -> Float
-  130. Float.min : Float -> Float -> Float
-  131. Float.pow : Float -> Float -> Float
-  132. Float.round : Float -> Int
-  133. Float.sin : Float -> Float
-  134. Float.sinh : Float -> Float
-  135. Float.sqrt : Float -> Float
-  136. Float.tan : Float -> Float
-  137. Float.tanh : Float -> Float
-  138. Float.toRepresentation : Float -> Nat
-  139. Float.toText : Float -> Text
-  140. Float.truncate : Float -> Int
-  141. Handle.toText : Handle -> Text
-  142. builtin type ImmutableArray
-  143. ImmutableArray.copyTo! : MutableArray g a
+  88.  Debug.toText : a -> Optional (Either Text Text)
+  89.  Debug.trace : Text -> a -> ()
+  90.  Debug.watch : Text -> a -> a
+  91.  unique type Doc
+  92.  Doc.Blob : Text -> Doc
+  93.  Doc.Evaluate : Term -> Doc
+  94.  Doc.Join : [Doc] -> Doc
+  95.  Doc.Link : Link -> Doc
+  96.  Doc.Signature : Term -> Doc
+  97.  Doc.Source : Link -> Doc
+  98.  structural type Either a b
+  99.  Either.Left : a -> Either a b
+  100. Either.Right : b -> Either a b
+  101. structural ability Exception
+  102. Exception.raise : Failure ->{Exception} x
+  103. builtin type Float
+  104. Float.* : Float -> Float -> Float
+  105. Float.+ : Float -> Float -> Float
+  106. Float.- : Float -> Float -> Float
+  107. Float./ : Float -> Float -> Float
+  108. Float.abs : Float -> Float
+  109. Float.acos : Float -> Float
+  110. Float.acosh : Float -> Float
+  111. Float.asin : Float -> Float
+  112. Float.asinh : Float -> Float
+  113. Float.atan : Float -> Float
+  114. Float.atan2 : Float -> Float -> Float
+  115. Float.atanh : Float -> Float
+  116. Float.ceiling : Float -> Int
+  117. Float.cos : Float -> Float
+  118. Float.cosh : Float -> Float
+  119. Float.eq : Float -> Float -> Boolean
+  120. Float.exp : Float -> Float
+  121. Float.floor : Float -> Int
+  122. Float.fromRepresentation : Nat -> Float
+  123. Float.fromText : Text -> Optional Float
+  124. Float.gt : Float -> Float -> Boolean
+  125. Float.gteq : Float -> Float -> Boolean
+  126. Float.log : Float -> Float
+  127. Float.logBase : Float -> Float -> Float
+  128. Float.lt : Float -> Float -> Boolean
+  129. Float.lteq : Float -> Float -> Boolean
+  130. Float.max : Float -> Float -> Float
+  131. Float.min : Float -> Float -> Float
+  132. Float.pow : Float -> Float -> Float
+  133. Float.round : Float -> Int
+  134. Float.sin : Float -> Float
+  135. Float.sinh : Float -> Float
+  136. Float.sqrt : Float -> Float
+  137. Float.tan : Float -> Float
+  138. Float.tanh : Float -> Float
+  139. Float.toRepresentation : Float -> Nat
+  140. Float.toText : Float -> Text
+  141. Float.truncate : Float -> Int
+  142. Handle.toText : Handle -> Text
+  143. builtin type ImmutableArray
+  144. ImmutableArray.copyTo! : MutableArray g a
                                 -> Nat
                                 -> ImmutableArray a
                                 -> Nat
                                 -> Nat
                                 ->{g, Exception} ()
-  144. ImmutableArray.read : ImmutableArray a
+  145. ImmutableArray.read : ImmutableArray a
                              -> Nat
                              ->{Exception} a
-  145. ImmutableArray.size : ImmutableArray a -> Nat
-  146. builtin type ImmutableByteArray
-  147. ImmutableByteArray.copyTo! : MutableByteArray g
+  146. ImmutableArray.size : ImmutableArray a -> Nat
+  147. builtin type ImmutableByteArray
+  148. ImmutableByteArray.copyTo! : MutableByteArray g
                                     -> Nat
                                     -> ImmutableByteArray
                                     -> Nat
                                     -> Nat
                                     ->{g, Exception} ()
-  148. ImmutableByteArray.read16be : ImmutableByteArray
+  149. ImmutableByteArray.read16be : ImmutableByteArray
                                      -> Nat
                                      ->{Exception} Nat
-  149. ImmutableByteArray.read24be : ImmutableByteArray
+  150. ImmutableByteArray.read24be : ImmutableByteArray
                                      -> Nat
                                      ->{Exception} Nat
-  150. ImmutableByteArray.read32be : ImmutableByteArray
+  151. ImmutableByteArray.read32be : ImmutableByteArray
                                      -> Nat
                                      ->{Exception} Nat
-  151. ImmutableByteArray.read40be : ImmutableByteArray
+  152. ImmutableByteArray.read40be : ImmutableByteArray
                                      -> Nat
                                      ->{Exception} Nat
-  152. ImmutableByteArray.read64be : ImmutableByteArray
+  153. ImmutableByteArray.read64be : ImmutableByteArray
                                      -> Nat
                                      ->{Exception} Nat
-  153. ImmutableByteArray.read8 : ImmutableByteArray
+  154. ImmutableByteArray.read8 : ImmutableByteArray
                                   -> Nat
                                   ->{Exception} Nat
-  154. ImmutableByteArray.size : ImmutableByteArray -> Nat
-  155. builtin type Int
-  156. Int.* : Int -> Int -> Int
-  157. Int.+ : Int -> Int -> Int
-  158. Int.- : Int -> Int -> Int
-  159. Int./ : Int -> Int -> Int
-  160. Int.and : Int -> Int -> Int
-  161. Int.complement : Int -> Int
-  162. Int.eq : Int -> Int -> Boolean
-  163. Int.fromRepresentation : Nat -> Int
-  164. Int.fromText : Text -> Optional Int
-  165. Int.gt : Int -> Int -> Boolean
-  166. Int.gteq : Int -> Int -> Boolean
-  167. Int.increment : Int -> Int
-  168. Int.isEven : Int -> Boolean
-  169. Int.isOdd : Int -> Boolean
-  170. Int.leadingZeros : Int -> Nat
-  171. Int.lt : Int -> Int -> Boolean
-  172. Int.lteq : Int -> Int -> Boolean
-  173. Int.mod : Int -> Int -> Int
-  174. Int.negate : Int -> Int
-  175. Int.or : Int -> Int -> Int
-  176. Int.popCount : Int -> Nat
-  177. Int.pow : Int -> Nat -> Int
-  178. Int.shiftLeft : Int -> Nat -> Int
-  179. Int.shiftRight : Int -> Nat -> Int
-  180. Int.signum : Int -> Int
-  181. Int.toFloat : Int -> Float
-  182. Int.toRepresentation : Int -> Nat
-  183. Int.toText : Int -> Text
-  184. Int.trailingZeros : Int -> Nat
-  185. Int.truncate0 : Int -> Nat
-  186. Int.xor : Int -> Int -> Int
-  187. unique type io2.ArithmeticFailure
-  188. unique type io2.ArrayFailure
-  189. unique type io2.BufferMode
-  190. io2.BufferMode.BlockBuffering : BufferMode
-  191. io2.BufferMode.LineBuffering : BufferMode
-  192. io2.BufferMode.NoBuffering : BufferMode
-  193. io2.BufferMode.SizedBlockBuffering : Nat -> BufferMode
-  194. io2.Clock.internals.monotonic : '{IO} Either
+  155. ImmutableByteArray.size : ImmutableByteArray -> Nat
+  156. builtin type Int
+  157. Int.* : Int -> Int -> Int
+  158. Int.+ : Int -> Int -> Int
+  159. Int.- : Int -> Int -> Int
+  160. Int./ : Int -> Int -> Int
+  161. Int.and : Int -> Int -> Int
+  162. Int.complement : Int -> Int
+  163. Int.eq : Int -> Int -> Boolean
+  164. Int.fromRepresentation : Nat -> Int
+  165. Int.fromText : Text -> Optional Int
+  166. Int.gt : Int -> Int -> Boolean
+  167. Int.gteq : Int -> Int -> Boolean
+  168. Int.increment : Int -> Int
+  169. Int.isEven : Int -> Boolean
+  170. Int.isOdd : Int -> Boolean
+  171. Int.leadingZeros : Int -> Nat
+  172. Int.lt : Int -> Int -> Boolean
+  173. Int.lteq : Int -> Int -> Boolean
+  174. Int.mod : Int -> Int -> Int
+  175. Int.negate : Int -> Int
+  176. Int.or : Int -> Int -> Int
+  177. Int.popCount : Int -> Nat
+  178. Int.pow : Int -> Nat -> Int
+  179. Int.shiftLeft : Int -> Nat -> Int
+  180. Int.shiftRight : Int -> Nat -> Int
+  181. Int.signum : Int -> Int
+  182. Int.toFloat : Int -> Float
+  183. Int.toRepresentation : Int -> Nat
+  184. Int.toText : Int -> Text
+  185. Int.trailingZeros : Int -> Nat
+  186. Int.truncate0 : Int -> Nat
+  187. Int.xor : Int -> Int -> Int
+  188. unique type io2.ArithmeticFailure
+  189. unique type io2.ArrayFailure
+  190. unique type io2.BufferMode
+  191. io2.BufferMode.BlockBuffering : BufferMode
+  192. io2.BufferMode.LineBuffering : BufferMode
+  193. io2.BufferMode.NoBuffering : BufferMode
+  194. io2.BufferMode.SizedBlockBuffering : Nat -> BufferMode
+  195. io2.Clock.internals.monotonic : '{IO} Either
                                          Failure TimeSpec
-  195. io2.Clock.internals.nsec : TimeSpec -> Nat
-  196. io2.Clock.internals.processCPUTime : '{IO} Either
+  196. io2.Clock.internals.nsec : TimeSpec -> Nat
+  197. io2.Clock.internals.processCPUTime : '{IO} Either
                                               Failure TimeSpec
-  197. io2.Clock.internals.realtime : '{IO} Either
+  198. io2.Clock.internals.realtime : '{IO} Either
                                         Failure TimeSpec
-  198. io2.Clock.internals.sec : TimeSpec -> Int
-  199. io2.Clock.internals.threadCPUTime : '{IO} Either
+  199. io2.Clock.internals.sec : TimeSpec -> Int
+  200. io2.Clock.internals.threadCPUTime : '{IO} Either
                                              Failure TimeSpec
-  200. builtin type io2.Clock.internals.TimeSpec
-  201. unique type io2.Failure
-  202. io2.Failure.Failure : Type -> Text -> Any -> Failure
-  203. unique type io2.FileMode
-  204. io2.FileMode.Append : FileMode
-  205. io2.FileMode.Read : FileMode
-  206. io2.FileMode.ReadWrite : FileMode
-  207. io2.FileMode.Write : FileMode
-  208. builtin type io2.Handle
-  209. builtin type io2.IO
-  210. io2.IO.array : Nat ->{IO} MutableArray {IO} a
-  211. io2.IO.arrayOf : a -> Nat ->{IO} MutableArray {IO} a
-  212. io2.IO.bytearray : Nat ->{IO} MutableByteArray {IO}
-  213. io2.IO.bytearrayOf : Nat
+  201. builtin type io2.Clock.internals.TimeSpec
+  202. unique type io2.Failure
+  203. io2.Failure.Failure : Type -> Text -> Any -> Failure
+  204. unique type io2.FileMode
+  205. io2.FileMode.Append : FileMode
+  206. io2.FileMode.Read : FileMode
+  207. io2.FileMode.ReadWrite : FileMode
+  208. io2.FileMode.Write : FileMode
+  209. builtin type io2.Handle
+  210. builtin type io2.IO
+  211. io2.IO.array : Nat ->{IO} MutableArray {IO} a
+  212. io2.IO.arrayOf : a -> Nat ->{IO} MutableArray {IO} a
+  213. io2.IO.bytearray : Nat ->{IO} MutableByteArray {IO}
+  214. io2.IO.bytearrayOf : Nat
                             -> Nat
                             ->{IO} MutableByteArray {IO}
-  214. io2.IO.clientSocket.impl : Text
+  215. io2.IO.clientSocket.impl : Text
                                   -> Text
                                   ->{IO} Either Failure Socket
-  215. io2.IO.closeFile.impl : Handle ->{IO} Either Failure ()
-  216. io2.IO.closeSocket.impl : Socket ->{IO} Either Failure ()
-  217. io2.IO.createDirectory.impl : Text
+  216. io2.IO.closeFile.impl : Handle ->{IO} Either Failure ()
+  217. io2.IO.closeSocket.impl : Socket ->{IO} Either Failure ()
+  218. io2.IO.createDirectory.impl : Text
                                      ->{IO} Either Failure ()
-  218. io2.IO.createTempDirectory.impl : Text
+  219. io2.IO.createTempDirectory.impl : Text
                                          ->{IO} Either
                                            Failure Text
-  219. io2.IO.delay.impl : Nat ->{IO} Either Failure ()
-  220. io2.IO.directoryContents.impl : Text
+  220. io2.IO.delay.impl : Nat ->{IO} Either Failure ()
+  221. io2.IO.directoryContents.impl : Text
                                        ->{IO} Either
                                          Failure [Text]
-  221. io2.IO.fileExists.impl : Text
+  222. io2.IO.fileExists.impl : Text
                                 ->{IO} Either Failure Boolean
-  222. io2.IO.forkComp : '{IO} a ->{IO} ThreadId
-  223. io2.IO.getArgs.impl : '{IO} Either Failure [Text]
-  224. io2.IO.getBuffering.impl : Handle
+  223. io2.IO.forkComp : '{IO} a ->{IO} ThreadId
+  224. io2.IO.getArgs.impl : '{IO} Either Failure [Text]
+  225. io2.IO.getBuffering.impl : Handle
                                   ->{IO} Either
                                     Failure BufferMode
-  225. io2.IO.getBytes.impl : Handle
+  226. io2.IO.getBytes.impl : Handle
                               -> Nat
                               ->{IO} Either Failure Bytes
-  226. io2.IO.getChar.impl : Handle ->{IO} Either Failure Char
-  227. io2.IO.getCurrentDirectory.impl : '{IO} Either
+  227. io2.IO.getChar.impl : Handle ->{IO} Either Failure Char
+  228. io2.IO.getCurrentDirectory.impl : '{IO} Either
                                            Failure Text
-  228. io2.IO.getEcho.impl : Handle
+  229. io2.IO.getEcho.impl : Handle
                              ->{IO} Either Failure Boolean
-  229. io2.IO.getEnv.impl : Text ->{IO} Either Failure Text
-  230. io2.IO.getFileSize.impl : Text ->{IO} Either Failure Nat
-  231. io2.IO.getFileTimestamp.impl : Text
+  230. io2.IO.getEnv.impl : Text ->{IO} Either Failure Text
+  231. io2.IO.getFileSize.impl : Text ->{IO} Either Failure Nat
+  232. io2.IO.getFileTimestamp.impl : Text
                                       ->{IO} Either Failure Nat
-  232. io2.IO.getLine.impl : Handle ->{IO} Either Failure Text
-  233. io2.IO.getSomeBytes.impl : Handle
+  233. io2.IO.getLine.impl : Handle ->{IO} Either Failure Text
+  234. io2.IO.getSomeBytes.impl : Handle
                                   -> Nat
                                   ->{IO} Either Failure Bytes
-  234. io2.IO.getTempDirectory.impl : '{IO} Either Failure Text
-  235. io2.IO.handlePosition.impl : Handle
+  235. io2.IO.getTempDirectory.impl : '{IO} Either Failure Text
+  236. io2.IO.handlePosition.impl : Handle
                                     ->{IO} Either Failure Nat
-  236. io2.IO.isDirectory.impl : Text
+  237. io2.IO.isDirectory.impl : Text
                                  ->{IO} Either Failure Boolean
-  237. io2.IO.isFileEOF.impl : Handle
+  238. io2.IO.isFileEOF.impl : Handle
                                ->{IO} Either Failure Boolean
-  238. io2.IO.isFileOpen.impl : Handle
+  239. io2.IO.isFileOpen.impl : Handle
                                 ->{IO} Either Failure Boolean
-  239. io2.IO.isSeekable.impl : Handle
+  240. io2.IO.isSeekable.impl : Handle
                                 ->{IO} Either Failure Boolean
-  240. io2.IO.kill.impl : ThreadId ->{IO} Either Failure ()
-  241. io2.IO.listen.impl : Socket ->{IO} Either Failure ()
-  242. io2.IO.openFile.impl : Text
+  241. io2.IO.kill.impl : ThreadId ->{IO} Either Failure ()
+  242. io2.IO.listen.impl : Socket ->{IO} Either Failure ()
+  243. io2.IO.openFile.impl : Text
                               -> FileMode
                               ->{IO} Either Failure Handle
-  243. io2.IO.process.call : Text -> [Text] ->{IO} Nat
-  244. io2.IO.process.exitCode : ProcessHandle
+  244. io2.IO.process.call : Text -> [Text] ->{IO} Nat
+  245. io2.IO.process.exitCode : ProcessHandle
                                  ->{IO} Optional Nat
-  245. io2.IO.process.kill : ProcessHandle ->{IO} ()
-  246. io2.IO.process.start : Text
+  246. io2.IO.process.kill : ProcessHandle ->{IO} ()
+  247. io2.IO.process.start : Text
                               -> [Text]
                               ->{IO} ( Handle,
                                 Handle,
                                 Handle,
                                 ProcessHandle)
-  247. io2.IO.process.wait : ProcessHandle ->{IO} Nat
-  248. io2.IO.putBytes.impl : Handle
+  248. io2.IO.process.wait : ProcessHandle ->{IO} Nat
+  249. io2.IO.putBytes.impl : Handle
                               -> Bytes
                               ->{IO} Either Failure ()
-  249. io2.IO.ready.impl : Handle ->{IO} Either Failure Boolean
-  250. io2.IO.ref : a ->{IO} Ref {IO} a
-  251. io2.IO.removeDirectory.impl : Text
+  250. io2.IO.ready.impl : Handle ->{IO} Either Failure Boolean
+  251. io2.IO.ref : a ->{IO} Ref {IO} a
+  252. io2.IO.removeDirectory.impl : Text
                                      ->{IO} Either Failure ()
-  252. io2.IO.removeFile.impl : Text ->{IO} Either Failure ()
-  253. io2.IO.renameDirectory.impl : Text
+  253. io2.IO.removeFile.impl : Text ->{IO} Either Failure ()
+  254. io2.IO.renameDirectory.impl : Text
                                      -> Text
                                      ->{IO} Either Failure ()
-  254. io2.IO.renameFile.impl : Text
+  255. io2.IO.renameFile.impl : Text
                                 -> Text
                                 ->{IO} Either Failure ()
-  255. io2.IO.seekHandle.impl : Handle
+  256. io2.IO.seekHandle.impl : Handle
                                 -> SeekMode
                                 -> Int
                                 ->{IO} Either Failure ()
-  256. io2.IO.serverSocket.impl : Optional Text
+  257. io2.IO.serverSocket.impl : Optional Text
                                   -> Text
                                   ->{IO} Either Failure Socket
-  257. io2.IO.setBuffering.impl : Handle
+  258. io2.IO.setBuffering.impl : Handle
                                   -> BufferMode
                                   ->{IO} Either Failure ()
-  258. io2.IO.setCurrentDirectory.impl : Text
+  259. io2.IO.setCurrentDirectory.impl : Text
                                          ->{IO} Either
                                            Failure ()
-  259. io2.IO.setEcho.impl : Handle
+  260. io2.IO.setEcho.impl : Handle
                              -> Boolean
                              ->{IO} Either Failure ()
-  260. io2.IO.socketAccept.impl : Socket
+  261. io2.IO.socketAccept.impl : Socket
                                   ->{IO} Either Failure Socket
-  261. io2.IO.socketPort.impl : Socket ->{IO} Either Failure Nat
-  262. io2.IO.socketReceive.impl : Socket
+  262. io2.IO.socketPort.impl : Socket ->{IO} Either Failure Nat
+  263. io2.IO.socketReceive.impl : Socket
                                    -> Nat
                                    ->{IO} Either Failure Bytes
-  263. io2.IO.socketSend.impl : Socket
+  264. io2.IO.socketSend.impl : Socket
                                 -> Bytes
                                 ->{IO} Either Failure ()
-  264. io2.IO.stdHandle : StdHandle -> Handle
-  265. io2.IO.systemTime.impl : '{IO} Either Failure Nat
-  266. io2.IO.systemTimeMicroseconds : '{IO} Int
-  267. io2.IO.tryEval : '{IO} a ->{IO, Exception} a
-  268. unique type io2.IOError
-  269. io2.IOError.AlreadyExists : IOError
-  270. io2.IOError.EOF : IOError
-  271. io2.IOError.IllegalOperation : IOError
-  272. io2.IOError.NoSuchThing : IOError
-  273. io2.IOError.PermissionDenied : IOError
-  274. io2.IOError.ResourceBusy : IOError
-  275. io2.IOError.ResourceExhausted : IOError
-  276. io2.IOError.UserError : IOError
-  277. unique type io2.IOFailure
-  278. unique type io2.MiscFailure
-  279. builtin type io2.MVar
-  280. io2.MVar.isEmpty : MVar a ->{IO} Boolean
-  281. io2.MVar.new : a ->{IO} MVar a
-  282. io2.MVar.newEmpty : '{IO} MVar a
-  283. io2.MVar.put.impl : MVar a -> a ->{IO} Either Failure ()
-  284. io2.MVar.read.impl : MVar a ->{IO} Either Failure a
-  285. io2.MVar.swap.impl : MVar a -> a ->{IO} Either Failure a
-  286. io2.MVar.take.impl : MVar a ->{IO} Either Failure a
-  287. io2.MVar.tryPut.impl : MVar a
+  265. io2.IO.stdHandle : StdHandle -> Handle
+  266. io2.IO.systemTime.impl : '{IO} Either Failure Nat
+  267. io2.IO.systemTimeMicroseconds : '{IO} Int
+  268. io2.IO.tryEval : '{IO} a ->{IO, Exception} a
+  269. unique type io2.IOError
+  270. io2.IOError.AlreadyExists : IOError
+  271. io2.IOError.EOF : IOError
+  272. io2.IOError.IllegalOperation : IOError
+  273. io2.IOError.NoSuchThing : IOError
+  274. io2.IOError.PermissionDenied : IOError
+  275. io2.IOError.ResourceBusy : IOError
+  276. io2.IOError.ResourceExhausted : IOError
+  277. io2.IOError.UserError : IOError
+  278. unique type io2.IOFailure
+  279. unique type io2.MiscFailure
+  280. builtin type io2.MVar
+  281. io2.MVar.isEmpty : MVar a ->{IO} Boolean
+  282. io2.MVar.new : a ->{IO} MVar a
+  283. io2.MVar.newEmpty : '{IO} MVar a
+  284. io2.MVar.put.impl : MVar a -> a ->{IO} Either Failure ()
+  285. io2.MVar.read.impl : MVar a ->{IO} Either Failure a
+  286. io2.MVar.swap.impl : MVar a -> a ->{IO} Either Failure a
+  287. io2.MVar.take.impl : MVar a ->{IO} Either Failure a
+  288. io2.MVar.tryPut.impl : MVar a
                               -> a
                               ->{IO} Either Failure Boolean
-  288. io2.MVar.tryRead.impl : MVar a
+  289. io2.MVar.tryRead.impl : MVar a
                                ->{IO} Either
                                  Failure (Optional a)
-  289. io2.MVar.tryTake : MVar a ->{IO} Optional a
-  290. builtin type io2.ProcessHandle
-  291. builtin type io2.Promise
-  292. io2.Promise.new : '{IO} Promise a
-  293. io2.Promise.read : Promise a ->{IO} a
-  294. io2.Promise.tryRead : Promise a ->{IO} Optional a
-  295. io2.Promise.write : Promise a -> a ->{IO} Boolean
-  296. io2.Ref.cas : Ref {IO} a -> Ticket a -> a ->{IO} Boolean
-  297. io2.Ref.readForCas : Ref {IO} a ->{IO} Ticket a
-  298. builtin type io2.Ref.Ticket
-  299. io2.Ref.Ticket.read : Ticket a -> a
-  300. unique type io2.RuntimeFailure
-  301. unique type io2.SeekMode
-  302. io2.SeekMode.AbsoluteSeek : SeekMode
-  303. io2.SeekMode.RelativeSeek : SeekMode
-  304. io2.SeekMode.SeekFromEnd : SeekMode
-  305. builtin type io2.Socket
-  306. unique type io2.StdHandle
-  307. io2.StdHandle.StdErr : StdHandle
-  308. io2.StdHandle.StdIn : StdHandle
-  309. io2.StdHandle.StdOut : StdHandle
-  310. builtin type io2.STM
-  311. io2.STM.atomically : '{STM} a ->{IO} a
-  312. io2.STM.retry : '{STM} a
-  313. unique type io2.STMFailure
-  314. builtin type io2.ThreadId
-  315. unique type io2.ThreadKilledFailure
-  316. builtin type io2.Tls
-  317. builtin type io2.Tls.Cipher
-  318. builtin type io2.Tls.ClientConfig
-  319. io2.Tls.ClientConfig.certificates.set : [SignedCert]
+  290. io2.MVar.tryTake : MVar a ->{IO} Optional a
+  291. builtin type io2.ProcessHandle
+  292. builtin type io2.Promise
+  293. io2.Promise.new : '{IO} Promise a
+  294. io2.Promise.read : Promise a ->{IO} a
+  295. io2.Promise.tryRead : Promise a ->{IO} Optional a
+  296. io2.Promise.write : Promise a -> a ->{IO} Boolean
+  297. io2.Ref.cas : Ref {IO} a -> Ticket a -> a ->{IO} Boolean
+  298. io2.Ref.readForCas : Ref {IO} a ->{IO} Ticket a
+  299. builtin type io2.Ref.Ticket
+  300. io2.Ref.Ticket.read : Ticket a -> a
+  301. unique type io2.RuntimeFailure
+  302. unique type io2.SeekMode
+  303. io2.SeekMode.AbsoluteSeek : SeekMode
+  304. io2.SeekMode.RelativeSeek : SeekMode
+  305. io2.SeekMode.SeekFromEnd : SeekMode
+  306. builtin type io2.Socket
+  307. unique type io2.StdHandle
+  308. io2.StdHandle.StdErr : StdHandle
+  309. io2.StdHandle.StdIn : StdHandle
+  310. io2.StdHandle.StdOut : StdHandle
+  311. builtin type io2.STM
+  312. io2.STM.atomically : '{STM} a ->{IO} a
+  313. io2.STM.retry : '{STM} a
+  314. unique type io2.STMFailure
+  315. builtin type io2.ThreadId
+  316. unique type io2.ThreadKilledFailure
+  317. builtin type io2.Tls
+  318. builtin type io2.Tls.Cipher
+  319. builtin type io2.Tls.ClientConfig
+  320. io2.Tls.ClientConfig.certificates.set : [SignedCert]
                                                -> ClientConfig
                                                -> ClientConfig
-  320. io2.TLS.ClientConfig.ciphers.set : [Cipher]
+  321. io2.TLS.ClientConfig.ciphers.set : [Cipher]
                                           -> ClientConfig
                                           -> ClientConfig
-  321. io2.Tls.ClientConfig.default : Text
+  322. io2.Tls.ClientConfig.default : Text
                                       -> Bytes
                                       -> ClientConfig
-  322. io2.Tls.ClientConfig.versions.set : [Version]
+  323. io2.Tls.ClientConfig.versions.set : [Version]
                                            -> ClientConfig
                                            -> ClientConfig
-  323. io2.Tls.decodeCert.impl : Bytes
+  324. io2.Tls.decodeCert.impl : Bytes
                                  -> Either Failure SignedCert
-  324. io2.Tls.decodePrivateKey : Bytes -> [PrivateKey]
-  325. io2.Tls.encodeCert : SignedCert -> Bytes
-  326. io2.Tls.encodePrivateKey : PrivateKey -> Bytes
-  327. io2.Tls.handshake.impl : Tls ->{IO} Either Failure ()
-  328. io2.Tls.newClient.impl : ClientConfig
+  325. io2.Tls.decodePrivateKey : Bytes -> [PrivateKey]
+  326. io2.Tls.encodeCert : SignedCert -> Bytes
+  327. io2.Tls.encodePrivateKey : PrivateKey -> Bytes
+  328. io2.Tls.handshake.impl : Tls ->{IO} Either Failure ()
+  329. io2.Tls.newClient.impl : ClientConfig
                                 -> Socket
                                 ->{IO} Either Failure Tls
-  329. io2.Tls.newServer.impl : ServerConfig
+  330. io2.Tls.newServer.impl : ServerConfig
                                 -> Socket
                                 ->{IO} Either Failure Tls
-  330. builtin type io2.Tls.PrivateKey
-  331. io2.Tls.receive.impl : Tls ->{IO} Either Failure Bytes
-  332. io2.Tls.send.impl : Tls -> Bytes ->{IO} Either Failure ()
-  333. builtin type io2.Tls.ServerConfig
-  334. io2.Tls.ServerConfig.certificates.set : [SignedCert]
+  331. builtin type io2.Tls.PrivateKey
+  332. io2.Tls.receive.impl : Tls ->{IO} Either Failure Bytes
+  333. io2.Tls.send.impl : Tls -> Bytes ->{IO} Either Failure ()
+  334. builtin type io2.Tls.ServerConfig
+  335. io2.Tls.ServerConfig.certificates.set : [SignedCert]
                                                -> ServerConfig
                                                -> ServerConfig
-  335. io2.Tls.ServerConfig.ciphers.set : [Cipher]
+  336. io2.Tls.ServerConfig.ciphers.set : [Cipher]
                                           -> ServerConfig
                                           -> ServerConfig
-  336. io2.Tls.ServerConfig.default : [SignedCert]
+  337. io2.Tls.ServerConfig.default : [SignedCert]
                                       -> PrivateKey
                                       -> ServerConfig
-  337. io2.Tls.ServerConfig.versions.set : [Version]
+  338. io2.Tls.ServerConfig.versions.set : [Version]
                                            -> ServerConfig
                                            -> ServerConfig
-  338. builtin type io2.Tls.SignedCert
-  339. io2.Tls.terminate.impl : Tls ->{IO} Either Failure ()
-  340. builtin type io2.Tls.Version
-  341. unique type io2.TlsFailure
-  342. builtin type io2.TVar
-  343. io2.TVar.new : a ->{STM} TVar a
-  344. io2.TVar.newIO : a ->{IO} TVar a
-  345. io2.TVar.read : TVar a ->{STM} a
-  346. io2.TVar.readIO : TVar a ->{IO} a
-  347. io2.TVar.swap : TVar a -> a ->{STM} a
-  348. io2.TVar.write : TVar a -> a ->{STM} ()
-  349. io2.validateSandboxed : [Term] -> a -> Boolean
-  350. unique type IsPropagated
-  351. IsPropagated.IsPropagated : IsPropagated
-  352. unique type IsTest
-  353. IsTest.IsTest : IsTest
-  354. unique type Link
-  355. builtin type Link.Term
-  356. Link.Term : Term -> Link
-  357. Link.Term.toText : Term -> Text
-  358. builtin type Link.Type
-  359. Link.Type : Type -> Link
-  360. builtin type List
-  361. List.++ : [a] -> [a] -> [a]
-  362. List.+: : a -> [a] -> [a]
-  363. List.:+ : [a] -> a -> [a]
-  364. List.at : Nat -> [a] -> Optional a
-  365. List.cons : a -> [a] -> [a]
-  366. List.drop : Nat -> [a] -> [a]
-  367. List.empty : [a]
-  368. List.size : [a] -> Nat
-  369. List.snoc : [a] -> a -> [a]
-  370. List.take : Nat -> [a] -> [a]
-  371. metadata.isPropagated : IsPropagated
-  372. metadata.isTest : IsTest
-  373. builtin type MutableArray
-  374. MutableArray.copyTo! : MutableArray g a
+  339. builtin type io2.Tls.SignedCert
+  340. io2.Tls.terminate.impl : Tls ->{IO} Either Failure ()
+  341. builtin type io2.Tls.Version
+  342. unique type io2.TlsFailure
+  343. builtin type io2.TVar
+  344. io2.TVar.new : a ->{STM} TVar a
+  345. io2.TVar.newIO : a ->{IO} TVar a
+  346. io2.TVar.read : TVar a ->{STM} a
+  347. io2.TVar.readIO : TVar a ->{IO} a
+  348. io2.TVar.swap : TVar a -> a ->{STM} a
+  349. io2.TVar.write : TVar a -> a ->{STM} ()
+  350. io2.validateSandboxed : [Term] -> a -> Boolean
+  351. unique type IsPropagated
+  352. IsPropagated.IsPropagated : IsPropagated
+  353. unique type IsTest
+  354. IsTest.IsTest : IsTest
+  355. unique type Link
+  356. builtin type Link.Term
+  357. Link.Term : Term -> Link
+  358. Link.Term.toText : Term -> Text
+  359. builtin type Link.Type
+  360. Link.Type : Type -> Link
+  361. builtin type List
+  362. List.++ : [a] -> [a] -> [a]
+  363. List.+: : a -> [a] -> [a]
+  364. List.:+ : [a] -> a -> [a]
+  365. List.at : Nat -> [a] -> Optional a
+  366. List.cons : a -> [a] -> [a]
+  367. List.drop : Nat -> [a] -> [a]
+  368. List.empty : [a]
+  369. List.size : [a] -> Nat
+  370. List.snoc : [a] -> a -> [a]
+  371. List.take : Nat -> [a] -> [a]
+  372. metadata.isPropagated : IsPropagated
+  373. metadata.isTest : IsTest
+  374. builtin type MutableArray
+  375. MutableArray.copyTo! : MutableArray g a
                               -> Nat
                               -> MutableArray g a
                               -> Nat
                               -> Nat
                               ->{g, Exception} ()
-  375. MutableArray.freeze : MutableArray g a
+  376. MutableArray.freeze : MutableArray g a
                              -> Nat
                              -> Nat
                              ->{g} ImmutableArray a
-  376. MutableArray.freeze! : MutableArray g a
+  377. MutableArray.freeze! : MutableArray g a
                               ->{g} ImmutableArray a
-  377. MutableArray.read : MutableArray g a
+  378. MutableArray.read : MutableArray g a
                            -> Nat
                            ->{g, Exception} a
-  378. MutableArray.size : MutableArray g a -> Nat
-  379. MutableArray.write : MutableArray g a
+  379. MutableArray.size : MutableArray g a -> Nat
+  380. MutableArray.write : MutableArray g a
                             -> Nat
                             -> a
                             ->{g, Exception} ()
-  380. builtin type MutableByteArray
-  381. MutableByteArray.copyTo! : MutableByteArray g
+  381. builtin type MutableByteArray
+  382. MutableByteArray.copyTo! : MutableByteArray g
                                   -> Nat
                                   -> MutableByteArray g
                                   -> Nat
                                   -> Nat
                                   ->{g, Exception} ()
-  382. MutableByteArray.freeze : MutableByteArray g
+  383. MutableByteArray.freeze : MutableByteArray g
                                  -> Nat
                                  -> Nat
                                  ->{g} ImmutableByteArray
-  383. MutableByteArray.freeze! : MutableByteArray g
+  384. MutableByteArray.freeze! : MutableByteArray g
                                   ->{g} ImmutableByteArray
-  384. MutableByteArray.read16be : MutableByteArray g
+  385. MutableByteArray.read16be : MutableByteArray g
                                    -> Nat
                                    ->{g, Exception} Nat
-  385. MutableByteArray.read24be : MutableByteArray g
+  386. MutableByteArray.read24be : MutableByteArray g
                                    -> Nat
                                    ->{g, Exception} Nat
-  386. MutableByteArray.read32be : MutableByteArray g
+  387. MutableByteArray.read32be : MutableByteArray g
                                    -> Nat
                                    ->{g, Exception} Nat
-  387. MutableByteArray.read40be : MutableByteArray g
+  388. MutableByteArray.read40be : MutableByteArray g
                                    -> Nat
                                    ->{g, Exception} Nat
-  388. MutableByteArray.read64be : MutableByteArray g
+  389. MutableByteArray.read64be : MutableByteArray g
                                    -> Nat
                                    ->{g, Exception} Nat
-  389. MutableByteArray.read8 : MutableByteArray g
+  390. MutableByteArray.read8 : MutableByteArray g
                                 -> Nat
                                 ->{g, Exception} Nat
-  390. MutableByteArray.size : MutableByteArray g -> Nat
-  391. MutableByteArray.write16be : MutableByteArray g
+  391. MutableByteArray.size : MutableByteArray g -> Nat
+  392. MutableByteArray.write16be : MutableByteArray g
                                     -> Nat
                                     -> Nat
                                     ->{g, Exception} ()
-  392. MutableByteArray.write32be : MutableByteArray g
+  393. MutableByteArray.write32be : MutableByteArray g
                                     -> Nat
                                     -> Nat
                                     ->{g, Exception} ()
-  393. MutableByteArray.write64be : MutableByteArray g
+  394. MutableByteArray.write64be : MutableByteArray g
                                     -> Nat
                                     -> Nat
                                     ->{g, Exception} ()
-  394. MutableByteArray.write8 : MutableByteArray g
+  395. MutableByteArray.write8 : MutableByteArray g
                                  -> Nat
                                  -> Nat
                                  ->{g, Exception} ()
-  395. builtin type Nat
-  396. Nat.* : Nat -> Nat -> Nat
-  397. Nat.+ : Nat -> Nat -> Nat
-  398. Nat./ : Nat -> Nat -> Nat
-  399. Nat.and : Nat -> Nat -> Nat
-  400. Nat.complement : Nat -> Nat
-  401. Nat.drop : Nat -> Nat -> Nat
-  402. Nat.eq : Nat -> Nat -> Boolean
-  403. Nat.fromText : Text -> Optional Nat
-  404. Nat.gt : Nat -> Nat -> Boolean
-  405. Nat.gteq : Nat -> Nat -> Boolean
-  406. Nat.increment : Nat -> Nat
-  407. Nat.isEven : Nat -> Boolean
-  408. Nat.isOdd : Nat -> Boolean
-  409. Nat.leadingZeros : Nat -> Nat
-  410. Nat.lt : Nat -> Nat -> Boolean
-  411. Nat.lteq : Nat -> Nat -> Boolean
-  412. Nat.mod : Nat -> Nat -> Nat
-  413. Nat.or : Nat -> Nat -> Nat
-  414. Nat.popCount : Nat -> Nat
-  415. Nat.pow : Nat -> Nat -> Nat
-  416. Nat.shiftLeft : Nat -> Nat -> Nat
-  417. Nat.shiftRight : Nat -> Nat -> Nat
-  418. Nat.sub : Nat -> Nat -> Int
-  419. Nat.toFloat : Nat -> Float
-  420. Nat.toInt : Nat -> Int
-  421. Nat.toText : Nat -> Text
-  422. Nat.trailingZeros : Nat -> Nat
-  423. Nat.xor : Nat -> Nat -> Nat
-  424. structural type Optional a
-  425. Optional.None : Optional a
-  426. Optional.Some : a -> Optional a
-  427. builtin type Pattern
-  428. Pattern.capture : Pattern a -> Pattern a
-  429. Pattern.isMatch : Pattern a -> a -> Boolean
-  430. Pattern.join : [Pattern a] -> Pattern a
-  431. Pattern.many : Pattern a -> Pattern a
-  432. Pattern.or : Pattern a -> Pattern a -> Pattern a
-  433. Pattern.replicate : Nat -> Nat -> Pattern a -> Pattern a
-  434. Pattern.run : Pattern a -> a -> Optional ([a], a)
-  435. builtin type Ref
-  436. Ref.read : Ref g a ->{g} a
-  437. Ref.write : Ref g a -> a ->{g} ()
-  438. builtin type Request
-  439. builtin type Scope
-  440. Scope.array : Nat ->{Scope s} MutableArray (Scope s) a
-  441. Scope.arrayOf : a
+  396. builtin type Nat
+  397. Nat.* : Nat -> Nat -> Nat
+  398. Nat.+ : Nat -> Nat -> Nat
+  399. Nat./ : Nat -> Nat -> Nat
+  400. Nat.and : Nat -> Nat -> Nat
+  401. Nat.complement : Nat -> Nat
+  402. Nat.drop : Nat -> Nat -> Nat
+  403. Nat.eq : Nat -> Nat -> Boolean
+  404. Nat.fromText : Text -> Optional Nat
+  405. Nat.gt : Nat -> Nat -> Boolean
+  406. Nat.gteq : Nat -> Nat -> Boolean
+  407. Nat.increment : Nat -> Nat
+  408. Nat.isEven : Nat -> Boolean
+  409. Nat.isOdd : Nat -> Boolean
+  410. Nat.leadingZeros : Nat -> Nat
+  411. Nat.lt : Nat -> Nat -> Boolean
+  412. Nat.lteq : Nat -> Nat -> Boolean
+  413. Nat.mod : Nat -> Nat -> Nat
+  414. Nat.or : Nat -> Nat -> Nat
+  415. Nat.popCount : Nat -> Nat
+  416. Nat.pow : Nat -> Nat -> Nat
+  417. Nat.shiftLeft : Nat -> Nat -> Nat
+  418. Nat.shiftRight : Nat -> Nat -> Nat
+  419. Nat.sub : Nat -> Nat -> Int
+  420. Nat.toFloat : Nat -> Float
+  421. Nat.toInt : Nat -> Int
+  422. Nat.toText : Nat -> Text
+  423. Nat.trailingZeros : Nat -> Nat
+  424. Nat.xor : Nat -> Nat -> Nat
+  425. structural type Optional a
+  426. Optional.None : Optional a
+  427. Optional.Some : a -> Optional a
+  428. builtin type Pattern
+  429. Pattern.capture : Pattern a -> Pattern a
+  430. Pattern.isMatch : Pattern a -> a -> Boolean
+  431. Pattern.join : [Pattern a] -> Pattern a
+  432. Pattern.many : Pattern a -> Pattern a
+  433. Pattern.or : Pattern a -> Pattern a -> Pattern a
+  434. Pattern.replicate : Nat -> Nat -> Pattern a -> Pattern a
+  435. Pattern.run : Pattern a -> a -> Optional ([a], a)
+  436. builtin type Ref
+  437. Ref.read : Ref g a ->{g} a
+  438. Ref.write : Ref g a -> a ->{g} ()
+  439. builtin type Request
+  440. builtin type Scope
+  441. Scope.array : Nat ->{Scope s} MutableArray (Scope s) a
+  442. Scope.arrayOf : a
                        -> Nat
                        ->{Scope s} MutableArray (Scope s) a
-  442. Scope.bytearray : Nat
+  443. Scope.bytearray : Nat
                          ->{Scope s} MutableByteArray (Scope s)
-  443. Scope.bytearrayOf : Nat
+  444. Scope.bytearrayOf : Nat
                            -> Nat
                            ->{Scope s} MutableByteArray
                              (Scope s)
-  444. Scope.ref : a ->{Scope s} Ref {Scope s} a
-  445. Scope.run : (∀ s. '{g, Scope s} r) ->{g} r
-  446. structural type SeqView a b
-  447. SeqView.VElem : a -> b -> SeqView a b
-  448. SeqView.VEmpty : SeqView a b
-  449. Socket.toText : Socket -> Text
-  450. unique type Test.Result
-  451. Test.Result.Fail : Text -> Result
-  452. Test.Result.Ok : Text -> Result
-  453. builtin type Text
-  454. Text.!= : Text -> Text -> Boolean
-  455. Text.++ : Text -> Text -> Text
-  456. Text.drop : Nat -> Text -> Text
-  457. Text.empty : Text
-  458. Text.eq : Text -> Text -> Boolean
-  459. Text.fromCharList : [Char] -> Text
-  460. Text.fromUtf8.impl : Bytes -> Either Failure Text
-  461. Text.gt : Text -> Text -> Boolean
-  462. Text.gteq : Text -> Text -> Boolean
-  463. Text.lt : Text -> Text -> Boolean
-  464. Text.lteq : Text -> Text -> Boolean
-  465. Text.patterns.anyChar : Pattern Text
-  466. Text.patterns.char : Class -> Pattern Text
-  467. Text.patterns.charIn : [Char] -> Pattern Text
-  468. Text.patterns.charRange : Char -> Char -> Pattern Text
-  469. Text.patterns.digit : Pattern Text
-  470. Text.patterns.eof : Pattern Text
-  471. Text.patterns.letter : Pattern Text
-  472. Text.patterns.literal : Text -> Pattern Text
-  473. Text.patterns.notCharIn : [Char] -> Pattern Text
-  474. Text.patterns.notCharRange : Char -> Char -> Pattern Text
-  475. Text.patterns.punctuation : Pattern Text
-  476. Text.patterns.space : Pattern Text
-  477. Text.repeat : Nat -> Text -> Text
-  478. Text.reverse : Text -> Text
-  479. Text.size : Text -> Nat
-  480. Text.take : Nat -> Text -> Text
-  481. Text.toCharList : Text -> [Char]
-  482. Text.toLowercase : Text -> Text
-  483. Text.toUppercase : Text -> Text
-  484. Text.toUtf8 : Text -> Bytes
-  485. Text.uncons : Text -> Optional (Char, Text)
-  486. Text.unsnoc : Text -> Optional (Text, Char)
-  487. ThreadId.toText : ThreadId -> Text
-  488. todo : a -> b
-  489. structural type Tuple a b
-  490. Tuple.Cons : a -> b -> Tuple a b
-  491. structural type Unit
-  492. Unit.Unit : ()
-  493. Universal.< : a -> a -> Boolean
-  494. Universal.<= : a -> a -> Boolean
-  495. Universal.== : a -> a -> Boolean
-  496. Universal.> : a -> a -> Boolean
-  497. Universal.>= : a -> a -> Boolean
-  498. Universal.compare : a -> a -> Int
-  499. Universal.murmurHash : a -> Nat
-  500. unsafe.coerceAbilities : (a ->{e1} b) -> a ->{e2} b
-  501. builtin type Value
-  502. Value.dependencies : Value -> [Term]
-  503. Value.deserialize : Bytes -> Either Text Value
-  504. Value.load : Value ->{IO} Either [Term] a
-  505. Value.serialize : Value -> Bytes
-  506. Value.value : a -> Value
+  445. Scope.ref : a ->{Scope s} Ref {Scope s} a
+  446. Scope.run : (∀ s. '{g, Scope s} r) ->{g} r
+  447. structural type SeqView a b
+  448. SeqView.VElem : a -> b -> SeqView a b
+  449. SeqView.VEmpty : SeqView a b
+  450. Socket.toText : Socket -> Text
+  451. unique type Test.Result
+  452. Test.Result.Fail : Text -> Result
+  453. Test.Result.Ok : Text -> Result
+  454. builtin type Text
+  455. Text.!= : Text -> Text -> Boolean
+  456. Text.++ : Text -> Text -> Text
+  457. Text.drop : Nat -> Text -> Text
+  458. Text.empty : Text
+  459. Text.eq : Text -> Text -> Boolean
+  460. Text.fromCharList : [Char] -> Text
+  461. Text.fromUtf8.impl : Bytes -> Either Failure Text
+  462. Text.gt : Text -> Text -> Boolean
+  463. Text.gteq : Text -> Text -> Boolean
+  464. Text.lt : Text -> Text -> Boolean
+  465. Text.lteq : Text -> Text -> Boolean
+  466. Text.patterns.anyChar : Pattern Text
+  467. Text.patterns.char : Class -> Pattern Text
+  468. Text.patterns.charIn : [Char] -> Pattern Text
+  469. Text.patterns.charRange : Char -> Char -> Pattern Text
+  470. Text.patterns.digit : Pattern Text
+  471. Text.patterns.eof : Pattern Text
+  472. Text.patterns.letter : Pattern Text
+  473. Text.patterns.literal : Text -> Pattern Text
+  474. Text.patterns.notCharIn : [Char] -> Pattern Text
+  475. Text.patterns.notCharRange : Char -> Char -> Pattern Text
+  476. Text.patterns.punctuation : Pattern Text
+  477. Text.patterns.space : Pattern Text
+  478. Text.repeat : Nat -> Text -> Text
+  479. Text.reverse : Text -> Text
+  480. Text.size : Text -> Nat
+  481. Text.take : Nat -> Text -> Text
+  482. Text.toCharList : Text -> [Char]
+  483. Text.toLowercase : Text -> Text
+  484. Text.toUppercase : Text -> Text
+  485. Text.toUtf8 : Text -> Bytes
+  486. Text.uncons : Text -> Optional (Char, Text)
+  487. Text.unsnoc : Text -> Optional (Text, Char)
+  488. ThreadId.toText : ThreadId -> Text
+  489. todo : a -> b
+  490. structural type Tuple a b
+  491. Tuple.Cons : a -> b -> Tuple a b
+  492. structural type Unit
+  493. Unit.Unit : ()
+  494. Universal.< : a -> a -> Boolean
+  495. Universal.<= : a -> a -> Boolean
+  496. Universal.== : a -> a -> Boolean
+  497. Universal.> : a -> a -> Boolean
+  498. Universal.>= : a -> a -> Boolean
+  499. Universal.compare : a -> a -> Int
+  500. Universal.murmurHash : a -> Nat
+  501. unsafe.coerceAbilities : (a ->{e1} b) -> a ->{e2} b
+  502. builtin type Value
+  503. Value.dependencies : Value -> [Term]
+  504. Value.deserialize : Bytes -> Either Text Value
+  505. Value.load : Value ->{IO} Either [Term] a
+  506. Value.serialize : Value -> Bytes
+  507. Value.value : a -> Value
   
 
 .builtin> alias.many 94-104 .mylib
@@ -699,14 +700,14 @@ Let's try it!
     1.  structural type Either a b
     2.  structural ability Exception
     3.  builtin type Float
-    4.  Either.Left     : a -> Either a b
-    5.  Doc.Link        : Link -> Doc
-    6.  Either.Right    : b -> Either a b
-    7.  Doc.Signature   : Term -> Doc
-    8.  Doc.Source      : Link -> Doc
-    9.  Exception.raise : Failure ->{Exception} x
-    10. Float.*         : Float -> Float -> Float
-    11. Float.+         : Float -> Float -> Float
+    4.  Doc.Join        : [Doc] -> Doc
+    5.  Either.Left     : a -> Either a b
+    6.  Doc.Link        : Link -> Doc
+    7.  Either.Right    : b -> Either a b
+    8.  Doc.Signature   : Term -> Doc
+    9.  Doc.Source      : Link -> Doc
+    10. Exception.raise : Failure ->{Exception} x
+    11. Float.*         : Float -> Float -> Float
   
   Tip: You can use `undo` or `reflog` to undo this change.
 
@@ -766,17 +767,17 @@ I want to incorporate a few more from another namespace:
 
 .mylib> find
 
-  1.  Doc.Link : Link -> Doc
-  2.  Doc.Signature : Term -> Doc
-  3.  Doc.Source : Link -> Doc
-  4.  structural type Either a b
-  5.  Either.Left : a -> Either a b
-  6.  Either.Right : b -> Either a b
-  7.  structural ability Exception
-  8.  Exception.raise : Failure ->{Exception} x
-  9.  builtin type Float
-  10. Float.* : Float -> Float -> Float
-  11. Float.+ : Float -> Float -> Float
+  1.  Doc.Join : [Doc] -> Doc
+  2.  Doc.Link : Link -> Doc
+  3.  Doc.Signature : Term -> Doc
+  4.  Doc.Source : Link -> Doc
+  5.  structural type Either a b
+  6.  Either.Left : a -> Either a b
+  7.  Either.Right : b -> Either a b
+  8.  structural ability Exception
+  9.  Exception.raise : Failure ->{Exception} x
+  10. builtin type Float
+  11. Float.* : Float -> Float -> Float
   12. List.adjacentPairs : [a] -> [(a, a)]
   13. List.all : (a ->{g} Boolean) -> [a] ->{g} Boolean
   14. List.any : (a ->{g} Boolean) -> [a] ->{g} Boolean

--- a/unison-src/transcripts/builtins-merge.output.md
+++ b/unison-src/transcripts/builtins-merge.output.md
@@ -73,7 +73,7 @@ The `builtins.merge` command adds the known builtins to a `builtin` subnamespace
   62. Value               (builtin type)
   63. Value/              (5 terms)
   64. bug                 (a -> b)
-  65. crypto/             (12 terms, 1 type)
+  65. crypto/             (13 terms, 1 type)
   66. io2/                (131 terms, 32 types)
   67. metadata/           (2 terms)
   68. todo                (a -> b)

--- a/unison-src/transcripts/emptyCodebase.output.md
+++ b/unison-src/transcripts/emptyCodebase.output.md
@@ -23,7 +23,7 @@ Technically, the definitions all exist, but they have no names. `builtins.merge`
 
 .foo> ls
 
-  1. builtin/ (440 terms, 66 types)
+  1. builtin/ (441 terms, 66 types)
 
 ```
 And for a limited time, you can get even more builtin goodies:
@@ -35,7 +35,7 @@ And for a limited time, you can get even more builtin goodies:
 
 .foo> ls
 
-  1. builtin/ (612 terms, 84 types)
+  1. builtin/ (613 terms, 84 types)
 
 ```
 More typically, you'd start out by pulling `base.

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -113,13 +113,13 @@ it's still in the `history` of the parent namespace and can be resurrected at an
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #9k2k834edc
+  ⊙ 1. #nkba2hklaj
   
     - Deletes:
     
       feature1.y
   
-  ⊙ 2. #d9u1nnu62h
+  ⊙ 2. #5rvucutrqs
   
     + Adds / updates:
     
@@ -130,26 +130,26 @@ it's still in the `history` of the parent namespace and can be resurrected at an
       Original name New name(s)
       feature1.y    master.y
   
-  ⊙ 3. #8ir51a10kg
+  ⊙ 3. #s37mv81ocj
   
     + Adds / updates:
     
       feature1.y
   
-  ⊙ 4. #v03np1853n
+  ⊙ 4. #9lpfbm6ug1
   
     > Moves:
     
       Original name New name
       x             master.x
   
-  ⊙ 5. #1fnkqqd2ae
+  ⊙ 5. #i9jun1cl1a
   
     + Adds / updates:
     
       x
   
-  □ 6. #b3jsb4pjcl (start of history)
+  □ 6. #rcu3lukmgn (start of history)
 
 ```
 To resurrect an old version of a namespace, you can learn its hash via the `history` command, then use `fork #namespacehash .newname`.

--- a/unison-src/transcripts/move-namespace.output.md
+++ b/unison-src/transcripts/move-namespace.output.md
@@ -269,7 +269,7 @@ I should be able to move the root into a sub-namespace
 
 .> ls
 
-  1. root/ (617 terms, 85 types)
+  1. root/ (618 terms, 85 types)
 
 .> history
 
@@ -278,13 +278,13 @@ I should be able to move the root into a sub-namespace
   
   
   
-  □ 1. #j17hvtt1rm (start of history)
+  □ 1. #59k30lbgtv (start of history)
 
 ```
 ```ucm
 .> ls .root.at.path
 
-  1. builtin/  (612 terms, 84 types)
+  1. builtin/  (613 terms, 84 types)
   2. existing/ (1 term)
   3. happy/    (3 terms, 1 type)
   4. history/  (1 term)
@@ -294,7 +294,7 @@ I should be able to move the root into a sub-namespace
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #epknijg4pk
+  ⊙ 1. #3fqubj2dfq
   
     - Deletes:
     
@@ -305,7 +305,7 @@ I should be able to move the root into a sub-namespace
       Original name      New name
       existing.a.termInA existing.b.termInA
   
-  ⊙ 2. #pmecta5so9
+  ⊙ 2. #4oifqrjksd
   
     + Adds / updates:
     
@@ -317,26 +317,26 @@ I should be able to move the root into a sub-namespace
       happy.b.termInA   existing.a.termInA
       history.b.termInA existing.a.termInA
   
-  ⊙ 3. #lc7lsqgcmo
+  ⊙ 3. #vmtrlijaub
   
     + Adds / updates:
     
       existing.a.termInA existing.b.termInB
   
-  ⊙ 4. #j36gjaovv9
+  ⊙ 4. #qp72kiv6qv
   
     > Moves:
     
       Original name     New name
       history.a.termInA history.b.termInA
   
-  ⊙ 5. #domisg9f2n
+  ⊙ 5. #rgcqdg78el
   
     - Deletes:
     
       history.b.termInB
   
-  ⊙ 6. #69vk74hidq
+  ⊙ 6. #3ep162o7o5
   
     + Adds / updates:
     
@@ -347,13 +347,13 @@ I should be able to move the root into a sub-namespace
       Original name   New name(s)
       happy.b.termInA history.a.termInA
   
-  ⊙ 7. #hslilthrkd
+  ⊙ 7. #icou0jar0d
   
     + Adds / updates:
     
       history.a.termInA history.b.termInB
   
-  ⊙ 8. #ap9o8u4m1a
+  ⊙ 8. #utbaohifbg
   
     > Moves:
     
@@ -363,7 +363,7 @@ I should be able to move the root into a sub-namespace
       happy.a.T.T2    happy.b.T.T2
       happy.a.termInA happy.b.termInA
   
-  ⊙ 9. #tpka2u10nq
+  ⊙ 9. #3tgqm3g16k
   
     + Adds / updates:
     
@@ -373,7 +373,7 @@ I should be able to move the root into a sub-namespace
     
       happy.a.T.T
   
-  ⊙ 10. #ebk6c1po2f
+  ⊙ 10. #5f0h338k67
   
     + Adds / updates:
     
@@ -385,7 +385,7 @@ I should be able to move the root into a sub-namespace
   
   ⠇
   
-  ⊙ 11. #c5i2vql0hi
+  ⊙ 11. #u0kujjj8n2
   
 
 ```

--- a/unison-src/transcripts/name-selection.output.md
+++ b/unison-src/transcripts/name-selection.output.md
@@ -308,139 +308,140 @@ d = c + 10
     142. builtin.crypto.HashAlgorithm.Blake2b_256      : HashAlgorithm
     143. builtin.crypto.HashAlgorithm.Blake2b_512      : HashAlgorithm
     144. builtin.crypto.HashAlgorithm.Blake2s_256      : HashAlgorithm
-    145. builtin.crypto.HashAlgorithm.Sha1             : HashAlgorithm
-    146. builtin.crypto.HashAlgorithm.Sha2_256         : HashAlgorithm
-    147. builtin.crypto.HashAlgorithm.Sha2_512         : HashAlgorithm
-    148. builtin.crypto.HashAlgorithm.Sha3_256         : HashAlgorithm
-    149. builtin.crypto.HashAlgorithm.Sha3_512         : HashAlgorithm
-    150. builtin.Float.abs                             : Float
+    145. builtin.crypto.HashAlgorithm.Md5              : HashAlgorithm
+    146. builtin.crypto.HashAlgorithm.Sha1             : HashAlgorithm
+    147. builtin.crypto.HashAlgorithm.Sha2_256         : HashAlgorithm
+    148. builtin.crypto.HashAlgorithm.Sha2_512         : HashAlgorithm
+    149. builtin.crypto.HashAlgorithm.Sha3_256         : HashAlgorithm
+    150. builtin.crypto.HashAlgorithm.Sha3_512         : HashAlgorithm
+    151. builtin.Float.abs                             : Float
                                                        -> Float
-    151. builtin.Float.acos                            : Float
+    152. builtin.Float.acos                            : Float
                                                        -> Float
-    152. builtin.Float.acosh                           : Float
+    153. builtin.Float.acosh                           : Float
                                                        -> Float
-    153. builtin.Char.Class.alphanumeric               : Class
-    154. builtin.Char.Class.and                        : Class
+    154. builtin.Char.Class.alphanumeric               : Class
+    155. builtin.Char.Class.and                        : Class
                                                        -> Class
                                                        -> Class
-    155. builtin.Int.and                               : Int
+    156. builtin.Int.and                               : Int
                                                        -> Int
                                                        -> Int
-    156. builtin.Nat.and                               : Nat
+    157. builtin.Nat.and                               : Nat
                                                        -> Nat
                                                        -> Nat
-    157. builtin.Char.Class.any                        : Class
-    158. builtin.Text.patterns.anyChar                 : Pattern
+    158. builtin.Char.Class.any                        : Class
+    159. builtin.Text.patterns.anyChar                 : Pattern
                                                          Text
-    159. builtin.Char.Class.anyOf                      : [Char]
+    160. builtin.Char.Class.anyOf                      : [Char]
                                                        -> Class
-    160. builtin.io2.IO.array                          : Nat
+    161. builtin.io2.IO.array                          : Nat
                                                        ->{IO} MutableArray
                                                          {IO} a
-    161. builtin.Scope.array                           : Nat
+    162. builtin.Scope.array                           : Nat
                                                        ->{Scope
                                                          s} MutableArray
                                                          (Scope
                                                            s)
                                                          a
-    162. builtin.io2.IO.arrayOf                        : a
+    163. builtin.io2.IO.arrayOf                        : a
                                                        -> Nat
                                                        ->{IO} MutableArray
                                                          {IO} a
-    163. builtin.Scope.arrayOf                         : a
+    164. builtin.Scope.arrayOf                         : a
                                                        -> Nat
                                                        ->{Scope
                                                          s} MutableArray
                                                          (Scope
                                                            s)
                                                          a
-    164. builtin.Float.asin                            : Float
+    165. builtin.Float.asin                            : Float
                                                        -> Float
-    165. builtin.Float.asinh                           : Float
+    166. builtin.Float.asinh                           : Float
                                                        -> Float
-    166. builtin.Bytes.at                              : Nat
+    167. builtin.Bytes.at                              : Nat
                                                        -> Bytes
                                                        -> Optional
                                                          Nat
-    167. builtin.List.at                               : Nat
+    168. builtin.List.at                               : Nat
                                                        -> [a]
                                                        -> Optional
                                                          a
-    168. builtin.Float.atan                            : Float
+    169. builtin.Float.atan                            : Float
                                                        -> Float
-    169. builtin.Float.atan2                           : Float
+    170. builtin.Float.atan2                           : Float
                                                        -> Float
                                                        -> Float
-    170. builtin.Float.atanh                           : Float
+    171. builtin.Float.atanh                           : Float
                                                        -> Float
-    171. builtin.io2.STM.atomically                    : '{STM} a
+    172. builtin.io2.STM.atomically                    : '{STM} a
                                                        ->{IO} a
-    172. builtin.bug                                   : a -> b
-    173. builtin.io2.IO.bytearray                      : Nat
+    173. builtin.bug                                   : a -> b
+    174. builtin.io2.IO.bytearray                      : Nat
                                                        ->{IO} MutableByteArray
                                                          {IO}
-    174. builtin.Scope.bytearray                       : Nat
+    175. builtin.Scope.bytearray                       : Nat
                                                        ->{Scope
                                                          s} MutableByteArray
                                                          (Scope
                                                            s)
-    175. builtin.io2.IO.bytearrayOf                    : Nat
+    176. builtin.io2.IO.bytearrayOf                    : Nat
                                                        -> Nat
                                                        ->{IO} MutableByteArray
                                                          {IO}
-    176. builtin.Scope.bytearrayOf                     : Nat
+    177. builtin.Scope.bytearrayOf                     : Nat
                                                        -> Nat
                                                        ->{Scope
                                                          s} MutableByteArray
                                                          (Scope
                                                            s)
-    177. ┌ c#gjmq673r1v                                : Nat
-    178. └ long.name.but.shortest.suffixification      : Nat
-    179. builtin.Code.cache_                           : [( Term,
+    178. ┌ c#gjmq673r1v                                : Nat
+    179. └ long.name.but.shortest.suffixification      : Nat
+    180. builtin.Code.cache_                           : [( Term,
                                                          Code)]
                                                        ->{IO} [Term]
-    180. builtin.io2.IO.process.call                   : Text
+    181. builtin.io2.IO.process.call                   : Text
                                                        -> [Text]
                                                        ->{IO} Nat
-    181. builtin.Pattern.capture                       : Pattern
+    182. builtin.Pattern.capture                       : Pattern
                                                          a
                                                        -> Pattern
                                                          a
-    182. builtin.io2.Ref.cas                           : Ref
+    183. builtin.io2.Ref.cas                           : Ref
                                                          {IO} a
                                                        -> Ticket
                                                          a
                                                        -> a
                                                        ->{IO} Boolean
-    183. builtin.Float.ceiling                         : Float
+    184. builtin.Float.ceiling                         : Float
                                                        -> Int
-    184. builtin.Text.patterns.char                    : Class
+    185. builtin.Text.patterns.char                    : Class
                                                        -> Pattern
                                                          Text
-    185. builtin.Text.patterns.charIn                  : [Char]
+    186. builtin.Text.patterns.charIn                  : [Char]
                                                        -> Pattern
                                                          Text
-    186. builtin.Text.patterns.charRange               : Char
+    187. builtin.Text.patterns.charRange               : Char
                                                        -> Char
                                                        -> Pattern
                                                          Text
-    187. builtin.unsafe.coerceAbilities                : (a
+    188. builtin.unsafe.coerceAbilities                : (a
                                                        ->{e1} b)
                                                        -> a
                                                        ->{e2} b
-    188. builtin.Universal.compare                     : a
+    189. builtin.Universal.compare                     : a
                                                        -> a
                                                        -> Int
-    189. builtin.Int.complement                        : Int
+    190. builtin.Int.complement                        : Int
                                                        -> Int
-    190. builtin.Nat.complement                        : Nat
+    191. builtin.Nat.complement                        : Nat
                                                        -> Nat
-    191. builtin.Bytes.gzip.compress                   : Bytes
+    192. builtin.Bytes.gzip.compress                   : Bytes
                                                        -> Bytes
-    192. builtin.Bytes.zlib.compress                   : Bytes
+    193. builtin.Bytes.zlib.compress                   : Bytes
                                                        -> Bytes
-    193. builtin.Char.Class.control                    : Class
-    194. builtin.ImmutableArray.copyTo!                : MutableArray
+    194. builtin.Char.Class.control                    : Class
+    195. builtin.ImmutableArray.copyTo!                : MutableArray
                                                          g a
                                                        -> Nat
                                                        -> ImmutableArray
@@ -449,7 +450,7 @@ d = c + 10
                                                        -> Nat
                                                        ->{g,
                                                        Exception} ()
-    195. builtin.ImmutableByteArray.copyTo!            : MutableByteArray
+    196. builtin.ImmutableByteArray.copyTo!            : MutableByteArray
                                                          g
                                                        -> Nat
                                                        -> ImmutableByteArray
@@ -457,7 +458,7 @@ d = c + 10
                                                        -> Nat
                                                        ->{g,
                                                        Exception} ()
-    196. builtin.MutableArray.copyTo!                  : MutableArray
+    197. builtin.MutableArray.copyTo!                  : MutableArray
                                                          g a
                                                        -> Nat
                                                        -> MutableArray
@@ -466,7 +467,7 @@ d = c + 10
                                                        -> Nat
                                                        ->{g,
                                                        Exception} ()
-    197. builtin.MutableByteArray.copyTo!              : MutableByteArray
+    198. builtin.MutableByteArray.copyTo!              : MutableByteArray
                                                          g
                                                        -> Nat
                                                        -> MutableByteArray
@@ -475,979 +476,979 @@ d = c + 10
                                                        -> Nat
                                                        ->{g,
                                                        Exception} ()
-    198. builtin.Float.cos                             : Float
+    199. builtin.Float.cos                             : Float
                                                        -> Float
-    199. builtin.Float.cosh                            : Float
+    200. builtin.Float.cosh                            : Float
                                                        -> Float
-    200. builtin.Bytes.decodeNat16be                   : Bytes
+    201. builtin.Bytes.decodeNat16be                   : Bytes
                                                        -> Optional
                                                          ( Nat,
                                                            Bytes)
-    201. builtin.Bytes.decodeNat16le                   : Bytes
+    202. builtin.Bytes.decodeNat16le                   : Bytes
                                                        -> Optional
                                                          ( Nat,
                                                            Bytes)
-    202. builtin.Bytes.decodeNat32be                   : Bytes
+    203. builtin.Bytes.decodeNat32be                   : Bytes
                                                        -> Optional
                                                          ( Nat,
                                                            Bytes)
-    203. builtin.Bytes.decodeNat32le                   : Bytes
+    204. builtin.Bytes.decodeNat32le                   : Bytes
                                                        -> Optional
                                                          ( Nat,
                                                            Bytes)
-    204. builtin.Bytes.decodeNat64be                   : Bytes
+    205. builtin.Bytes.decodeNat64be                   : Bytes
                                                        -> Optional
                                                          ( Nat,
                                                            Bytes)
-    205. builtin.Bytes.decodeNat64le                   : Bytes
+    206. builtin.Bytes.decodeNat64le                   : Bytes
                                                        -> Optional
                                                          ( Nat,
                                                            Bytes)
-    206. builtin.io2.Tls.decodePrivateKey              : Bytes
+    207. builtin.io2.Tls.decodePrivateKey              : Bytes
                                                        -> [PrivateKey]
-    207. builtin.Bytes.gzip.decompress                 : Bytes
+    208. builtin.Bytes.gzip.decompress                 : Bytes
                                                        -> Either
                                                          Text
                                                          Bytes
-    208. builtin.Bytes.zlib.decompress                 : Bytes
+    209. builtin.Bytes.zlib.decompress                 : Bytes
                                                        -> Either
                                                          Text
                                                          Bytes
-    209. builtin.io2.Tls.ClientConfig.default          : Text
+    210. builtin.io2.Tls.ClientConfig.default          : Text
                                                        -> Bytes
                                                        -> ClientConfig
-    210. builtin.io2.Tls.ServerConfig.default          : [SignedCert]
+    211. builtin.io2.Tls.ServerConfig.default          : [SignedCert]
                                                        -> PrivateKey
                                                        -> ServerConfig
-    211. builtin.Code.dependencies                     : Code
+    212. builtin.Code.dependencies                     : Code
                                                        -> [Term]
-    212. builtin.Value.dependencies                    : Value
+    213. builtin.Value.dependencies                    : Value
                                                        -> [Term]
-    213. builtin.Code.deserialize                      : Bytes
+    214. builtin.Code.deserialize                      : Bytes
                                                        -> Either
                                                          Text
                                                          Code
-    214. builtin.Value.deserialize                     : Bytes
+    215. builtin.Value.deserialize                     : Bytes
                                                        -> Either
                                                          Text
                                                          Value
-    215. builtin.Text.patterns.digit                   : Pattern
+    216. builtin.Text.patterns.digit                   : Pattern
                                                          Text
-    216. builtin.Code.display                          : Text
+    217. builtin.Code.display                          : Text
                                                        -> Code
                                                        -> Text
-    217. builtin.Bytes.drop                            : Nat
+    218. builtin.Bytes.drop                            : Nat
                                                        -> Bytes
                                                        -> Bytes
-    218. builtin.List.drop                             : Nat
+    219. builtin.List.drop                             : Nat
                                                        -> [a]
                                                        -> [a]
-    219. builtin.Nat.drop                              : Nat
+    220. builtin.Nat.drop                              : Nat
                                                        -> Nat
                                                        -> Nat
-    220. builtin.Text.drop                             : Nat
+    221. builtin.Text.drop                             : Nat
                                                        -> Text
                                                        -> Text
-    221. builtin.Bytes.empty                           : Bytes
-    222. builtin.List.empty                            : [a]
-    223. builtin.Text.empty                            : Text
-    224. builtin.io2.Tls.encodeCert                    : SignedCert
+    222. builtin.Bytes.empty                           : Bytes
+    223. builtin.List.empty                            : [a]
+    224. builtin.Text.empty                            : Text
+    225. builtin.io2.Tls.encodeCert                    : SignedCert
                                                        -> Bytes
-    225. builtin.Bytes.encodeNat16be                   : Nat
+    226. builtin.Bytes.encodeNat16be                   : Nat
                                                        -> Bytes
-    226. builtin.Bytes.encodeNat16le                   : Nat
+    227. builtin.Bytes.encodeNat16le                   : Nat
                                                        -> Bytes
-    227. builtin.Bytes.encodeNat32be                   : Nat
+    228. builtin.Bytes.encodeNat32be                   : Nat
                                                        -> Bytes
-    228. builtin.Bytes.encodeNat32le                   : Nat
+    229. builtin.Bytes.encodeNat32le                   : Nat
                                                        -> Bytes
-    229. builtin.Bytes.encodeNat64be                   : Nat
+    230. builtin.Bytes.encodeNat64be                   : Nat
                                                        -> Bytes
-    230. builtin.Bytes.encodeNat64le                   : Nat
+    231. builtin.Bytes.encodeNat64le                   : Nat
                                                        -> Bytes
-    231. builtin.io2.Tls.encodePrivateKey              : PrivateKey
+    232. builtin.io2.Tls.encodePrivateKey              : PrivateKey
                                                        -> Bytes
-    232. builtin.Text.patterns.eof                     : Pattern
+    233. builtin.Text.patterns.eof                     : Pattern
                                                          Text
-    233. builtin.Float.eq                              : Float
+    234. builtin.Float.eq                              : Float
                                                        -> Float
                                                        -> Boolean
-    234. builtin.Int.eq                                : Int
+    235. builtin.Int.eq                                : Int
                                                        -> Int
                                                        -> Boolean
-    235. builtin.Nat.eq                                : Nat
+    236. builtin.Nat.eq                                : Nat
                                                        -> Nat
                                                        -> Boolean
-    236. builtin.Text.eq                               : Text
+    237. builtin.Text.eq                               : Text
                                                        -> Text
                                                        -> Boolean
-    237. builtin.io2.IO.process.exitCode               : ProcessHandle
+    238. builtin.io2.IO.process.exitCode               : ProcessHandle
                                                        ->{IO} Optional
                                                          Nat
-    238. builtin.Float.exp                             : Float
+    239. builtin.Float.exp                             : Float
                                                        -> Float
-    239. builtin.Bytes.flatten                         : Bytes
+    240. builtin.Bytes.flatten                         : Bytes
                                                        -> Bytes
-    240. builtin.Float.floor                           : Float
+    241. builtin.Float.floor                           : Float
                                                        -> Int
-    241. builtin.io2.IO.forkComp                       : '{IO} a
+    242. builtin.io2.IO.forkComp                       : '{IO} a
                                                        ->{IO} ThreadId
-    242. builtin.MutableArray.freeze                   : MutableArray
+    243. builtin.MutableArray.freeze                   : MutableArray
                                                          g a
                                                        -> Nat
                                                        -> Nat
                                                        ->{g} ImmutableArray
                                                          a
-    243. builtin.MutableByteArray.freeze               : MutableByteArray
+    244. builtin.MutableByteArray.freeze               : MutableByteArray
                                                          g
                                                        -> Nat
                                                        -> Nat
                                                        ->{g} ImmutableByteArray
-    244. builtin.MutableArray.freeze!                  : MutableArray
+    245. builtin.MutableArray.freeze!                  : MutableArray
                                                          g a
                                                        ->{g} ImmutableArray
                                                          a
-    245. builtin.MutableByteArray.freeze!              : MutableByteArray
+    246. builtin.MutableByteArray.freeze!              : MutableByteArray
                                                          g
                                                        ->{g} ImmutableByteArray
-    246. builtin.Bytes.fromBase16                      : Bytes
+    247. builtin.Bytes.fromBase16                      : Bytes
                                                        -> Either
                                                          Text
                                                          Bytes
-    247. builtin.Bytes.fromBase32                      : Bytes
+    248. builtin.Bytes.fromBase32                      : Bytes
                                                        -> Either
                                                          Text
                                                          Bytes
-    248. builtin.Bytes.fromBase64                      : Bytes
+    249. builtin.Bytes.fromBase64                      : Bytes
                                                        -> Either
                                                          Text
                                                          Bytes
-    249. builtin.Bytes.fromBase64UrlUnpadded           : Bytes
+    250. builtin.Bytes.fromBase64UrlUnpadded           : Bytes
                                                        -> Either
                                                          Text
                                                          Bytes
-    250. builtin.Text.fromCharList                     : [Char]
+    251. builtin.Text.fromCharList                     : [Char]
                                                        -> Text
-    251. builtin.Bytes.fromList                        : [Nat]
+    252. builtin.Bytes.fromList                        : [Nat]
                                                        -> Bytes
-    252. builtin.Char.fromNat                          : Nat
+    253. builtin.Char.fromNat                          : Nat
                                                        -> Char
-    253. builtin.Float.fromRepresentation              : Nat
+    254. builtin.Float.fromRepresentation              : Nat
                                                        -> Float
-    254. builtin.Int.fromRepresentation                : Nat
+    255. builtin.Int.fromRepresentation                : Nat
                                                        -> Int
-    255. builtin.Float.fromText                        : Text
+    256. builtin.Float.fromText                        : Text
                                                        -> Optional
                                                          Float
-    256. builtin.Int.fromText                          : Text
+    257. builtin.Int.fromText                          : Text
                                                        -> Optional
                                                          Int
-    257. builtin.Nat.fromText                          : Text
+    258. builtin.Nat.fromText                          : Text
                                                        -> Optional
                                                          Nat
-    258. builtin.Float.gt                              : Float
+    259. builtin.Float.gt                              : Float
                                                        -> Float
                                                        -> Boolean
-    259. builtin.Int.gt                                : Int
+    260. builtin.Int.gt                                : Int
                                                        -> Int
                                                        -> Boolean
-    260. builtin.Nat.gt                                : Nat
+    261. builtin.Nat.gt                                : Nat
                                                        -> Nat
                                                        -> Boolean
-    261. builtin.Text.gt                               : Text
+    262. builtin.Text.gt                               : Text
                                                        -> Text
                                                        -> Boolean
-    262. builtin.Float.gteq                            : Float
+    263. builtin.Float.gteq                            : Float
                                                        -> Float
                                                        -> Boolean
-    263. builtin.Int.gteq                              : Int
+    264. builtin.Int.gteq                              : Int
                                                        -> Int
                                                        -> Boolean
-    264. builtin.Nat.gteq                              : Nat
+    265. builtin.Nat.gteq                              : Nat
                                                        -> Nat
                                                        -> Boolean
-    265. builtin.Text.gteq                             : Text
+    266. builtin.Text.gteq                             : Text
                                                        -> Text
                                                        -> Boolean
-    266. builtin.crypto.hash                           : HashAlgorithm
+    267. builtin.crypto.hash                           : HashAlgorithm
                                                        -> a
                                                        -> Bytes
-    267. builtin.crypto.hashBytes                      : HashAlgorithm
+    268. builtin.crypto.hashBytes                      : HashAlgorithm
                                                        -> Bytes
                                                        -> Bytes
-    268. builtin.crypto.hmac                           : HashAlgorithm
+    269. builtin.crypto.hmac                           : HashAlgorithm
                                                        -> Bytes
                                                        -> a
                                                        -> Bytes
-    269. builtin.crypto.hmacBytes                      : HashAlgorithm
+    270. builtin.crypto.hmacBytes                      : HashAlgorithm
                                                        -> Bytes
                                                        -> Bytes
                                                        -> Bytes
-    270. builtin.io2.IO.clientSocket.impl              : Text
+    271. builtin.io2.IO.clientSocket.impl              : Text
                                                        -> Text
                                                        ->{IO} Either
                                                          Failure
                                                          Socket
-    271. builtin.io2.IO.closeFile.impl                 : Handle
+    272. builtin.io2.IO.closeFile.impl                 : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    272. builtin.io2.IO.closeSocket.impl               : Socket
+    273. builtin.io2.IO.closeSocket.impl               : Socket
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    273. builtin.io2.IO.createDirectory.impl           : Text
+    274. builtin.io2.IO.createDirectory.impl           : Text
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    274. builtin.io2.IO.createTempDirectory.impl       : Text
+    275. builtin.io2.IO.createTempDirectory.impl       : Text
                                                        ->{IO} Either
                                                          Failure
                                                          Text
-    275. builtin.io2.Tls.decodeCert.impl               : Bytes
+    276. builtin.io2.Tls.decodeCert.impl               : Bytes
                                                        -> Either
                                                          Failure
                                                          SignedCert
-    276. builtin.io2.IO.delay.impl                     : Nat
+    277. builtin.io2.IO.delay.impl                     : Nat
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    277. builtin.io2.IO.directoryContents.impl         : Text
+    278. builtin.io2.IO.directoryContents.impl         : Text
                                                        ->{IO} Either
                                                          Failure
                                                          [Text]
-    278. builtin.io2.IO.fileExists.impl                : Text
+    279. builtin.io2.IO.fileExists.impl                : Text
                                                        ->{IO} Either
                                                          Failure
                                                          Boolean
-    279. builtin.Text.fromUtf8.impl                    : Bytes
+    280. builtin.Text.fromUtf8.impl                    : Bytes
                                                        -> Either
                                                          Failure
                                                          Text
-    280. builtin.io2.IO.getArgs.impl                   : '{IO} Either
+    281. builtin.io2.IO.getArgs.impl                   : '{IO} Either
                                                          Failure
                                                          [Text]
-    281. builtin.io2.IO.getBuffering.impl              : Handle
+    282. builtin.io2.IO.getBuffering.impl              : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          BufferMode
-    282. builtin.io2.IO.getBytes.impl                  : Handle
+    283. builtin.io2.IO.getBytes.impl                  : Handle
                                                        -> Nat
                                                        ->{IO} Either
                                                          Failure
                                                          Bytes
-    283. builtin.io2.IO.getChar.impl                   : Handle
+    284. builtin.io2.IO.getChar.impl                   : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          Char
-    284. builtin.io2.IO.getCurrentDirectory.impl       : '{IO} Either
+    285. builtin.io2.IO.getCurrentDirectory.impl       : '{IO} Either
                                                          Failure
                                                          Text
-    285. builtin.io2.IO.getEcho.impl                   : Handle
+    286. builtin.io2.IO.getEcho.impl                   : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          Boolean
-    286. builtin.io2.IO.getEnv.impl                    : Text
+    287. builtin.io2.IO.getEnv.impl                    : Text
                                                        ->{IO} Either
                                                          Failure
                                                          Text
-    287. builtin.io2.IO.getFileSize.impl               : Text
+    288. builtin.io2.IO.getFileSize.impl               : Text
                                                        ->{IO} Either
                                                          Failure
                                                          Nat
-    288. builtin.io2.IO.getFileTimestamp.impl          : Text
+    289. builtin.io2.IO.getFileTimestamp.impl          : Text
                                                        ->{IO} Either
                                                          Failure
                                                          Nat
-    289. builtin.io2.IO.getLine.impl                   : Handle
+    290. builtin.io2.IO.getLine.impl                   : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          Text
-    290. builtin.io2.IO.getSomeBytes.impl              : Handle
+    291. builtin.io2.IO.getSomeBytes.impl              : Handle
                                                        -> Nat
                                                        ->{IO} Either
                                                          Failure
                                                          Bytes
-    291. builtin.io2.IO.getTempDirectory.impl          : '{IO} Either
+    292. builtin.io2.IO.getTempDirectory.impl          : '{IO} Either
                                                          Failure
                                                          Text
-    292. builtin.io2.IO.handlePosition.impl            : Handle
+    293. builtin.io2.IO.handlePosition.impl            : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          Nat
-    293. builtin.io2.Tls.handshake.impl                : Tls
+    294. builtin.io2.Tls.handshake.impl                : Tls
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    294. builtin.io2.IO.isDirectory.impl               : Text
+    295. builtin.io2.IO.isDirectory.impl               : Text
                                                        ->{IO} Either
                                                          Failure
                                                          Boolean
-    295. builtin.io2.IO.isFileEOF.impl                 : Handle
+    296. builtin.io2.IO.isFileEOF.impl                 : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          Boolean
-    296. builtin.io2.IO.isFileOpen.impl                : Handle
+    297. builtin.io2.IO.isFileOpen.impl                : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          Boolean
-    297. builtin.io2.IO.isSeekable.impl                : Handle
+    298. builtin.io2.IO.isSeekable.impl                : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          Boolean
-    298. builtin.io2.IO.kill.impl                      : ThreadId
+    299. builtin.io2.IO.kill.impl                      : ThreadId
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    299. builtin.io2.IO.listen.impl                    : Socket
+    300. builtin.io2.IO.listen.impl                    : Socket
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    300. builtin.io2.Tls.newClient.impl                : ClientConfig
+    301. builtin.io2.Tls.newClient.impl                : ClientConfig
                                                        -> Socket
                                                        ->{IO} Either
                                                          Failure
                                                          Tls
-    301. builtin.io2.Tls.newServer.impl                : ServerConfig
+    302. builtin.io2.Tls.newServer.impl                : ServerConfig
                                                        -> Socket
                                                        ->{IO} Either
                                                          Failure
                                                          Tls
-    302. builtin.io2.IO.openFile.impl                  : Text
+    303. builtin.io2.IO.openFile.impl                  : Text
                                                        -> FileMode
                                                        ->{IO} Either
                                                          Failure
                                                          Handle
-    303. builtin.io2.MVar.put.impl                     : MVar a
+    304. builtin.io2.MVar.put.impl                     : MVar a
                                                        -> a
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    304. builtin.io2.IO.putBytes.impl                  : Handle
+    305. builtin.io2.IO.putBytes.impl                  : Handle
                                                        -> Bytes
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    305. builtin.io2.MVar.read.impl                    : MVar a
+    306. builtin.io2.MVar.read.impl                    : MVar a
                                                        ->{IO} Either
                                                          Failure
                                                          a
-    306. builtin.io2.IO.ready.impl                     : Handle
+    307. builtin.io2.IO.ready.impl                     : Handle
                                                        ->{IO} Either
                                                          Failure
                                                          Boolean
-    307. builtin.io2.Tls.receive.impl                  : Tls
+    308. builtin.io2.Tls.receive.impl                  : Tls
                                                        ->{IO} Either
                                                          Failure
                                                          Bytes
-    308. builtin.io2.IO.removeDirectory.impl           : Text
+    309. builtin.io2.IO.removeDirectory.impl           : Text
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    309. builtin.io2.IO.removeFile.impl                : Text
+    310. builtin.io2.IO.removeFile.impl                : Text
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    310. builtin.io2.IO.renameDirectory.impl           : Text
+    311. builtin.io2.IO.renameDirectory.impl           : Text
                                                        -> Text
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    311. builtin.io2.IO.renameFile.impl                : Text
+    312. builtin.io2.IO.renameFile.impl                : Text
                                                        -> Text
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    312. builtin.io2.IO.seekHandle.impl                : Handle
+    313. builtin.io2.IO.seekHandle.impl                : Handle
                                                        -> SeekMode
                                                        -> Int
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    313. builtin.io2.Tls.send.impl                     : Tls
+    314. builtin.io2.Tls.send.impl                     : Tls
                                                        -> Bytes
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    314. builtin.io2.IO.serverSocket.impl              : Optional
+    315. builtin.io2.IO.serverSocket.impl              : Optional
                                                          Text
                                                        -> Text
                                                        ->{IO} Either
                                                          Failure
                                                          Socket
-    315. builtin.io2.IO.setBuffering.impl              : Handle
+    316. builtin.io2.IO.setBuffering.impl              : Handle
                                                        -> BufferMode
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    316. builtin.io2.IO.setCurrentDirectory.impl       : Text
+    317. builtin.io2.IO.setCurrentDirectory.impl       : Text
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    317. builtin.io2.IO.setEcho.impl                   : Handle
+    318. builtin.io2.IO.setEcho.impl                   : Handle
                                                        -> Boolean
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    318. builtin.io2.IO.socketAccept.impl              : Socket
+    319. builtin.io2.IO.socketAccept.impl              : Socket
                                                        ->{IO} Either
                                                          Failure
                                                          Socket
-    319. builtin.io2.IO.socketPort.impl                : Socket
+    320. builtin.io2.IO.socketPort.impl                : Socket
                                                        ->{IO} Either
                                                          Failure
                                                          Nat
-    320. builtin.io2.IO.socketReceive.impl             : Socket
+    321. builtin.io2.IO.socketReceive.impl             : Socket
                                                        -> Nat
                                                        ->{IO} Either
                                                          Failure
                                                          Bytes
-    321. builtin.io2.IO.socketSend.impl                : Socket
+    322. builtin.io2.IO.socketSend.impl                : Socket
                                                        -> Bytes
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    322. builtin.io2.MVar.swap.impl                    : MVar a
+    323. builtin.io2.MVar.swap.impl                    : MVar a
                                                        -> a
                                                        ->{IO} Either
                                                          Failure
                                                          a
-    323. builtin.io2.IO.systemTime.impl                : '{IO} Either
+    324. builtin.io2.IO.systemTime.impl                : '{IO} Either
                                                          Failure
                                                          Nat
-    324. builtin.io2.MVar.take.impl                    : MVar a
+    325. builtin.io2.MVar.take.impl                    : MVar a
                                                        ->{IO} Either
                                                          Failure
                                                          a
-    325. builtin.io2.Tls.terminate.impl                : Tls
+    326. builtin.io2.Tls.terminate.impl                : Tls
                                                        ->{IO} Either
                                                          Failure
                                                          ()
-    326. builtin.io2.MVar.tryPut.impl                  : MVar a
+    327. builtin.io2.MVar.tryPut.impl                  : MVar a
                                                        -> a
                                                        ->{IO} Either
                                                          Failure
                                                          Boolean
-    327. builtin.io2.MVar.tryRead.impl                 : MVar a
+    328. builtin.io2.MVar.tryRead.impl                 : MVar a
                                                        ->{IO} Either
                                                          Failure
                                                          (Optional
                                                            a)
-    328. builtin.Int.increment                         : Int
+    329. builtin.Int.increment                         : Int
                                                        -> Int
-    329. builtin.Nat.increment                         : Nat
+    330. builtin.Nat.increment                         : Nat
                                                        -> Nat
-    330. builtin.Char.Class.is                         : Class
+    331. builtin.Char.Class.is                         : Class
                                                        -> Char
                                                        -> Boolean
-    331. builtin.io2.MVar.isEmpty                      : MVar a
+    332. builtin.io2.MVar.isEmpty                      : MVar a
                                                        ->{IO} Boolean
-    332. builtin.Int.isEven                            : Int
+    333. builtin.Int.isEven                            : Int
                                                        -> Boolean
-    333. builtin.Nat.isEven                            : Nat
+    334. builtin.Nat.isEven                            : Nat
                                                        -> Boolean
-    334. builtin.Pattern.isMatch                       : Pattern
+    335. builtin.Pattern.isMatch                       : Pattern
                                                          a
                                                        -> a
                                                        -> Boolean
-    335. builtin.Code.isMissing                        : Term
+    336. builtin.Code.isMissing                        : Term
                                                        ->{IO} Boolean
-    336. builtin.Int.isOdd                             : Int
+    337. builtin.Int.isOdd                             : Int
                                                        -> Boolean
-    337. builtin.Nat.isOdd                             : Nat
+    338. builtin.Nat.isOdd                             : Nat
                                                        -> Boolean
-    338. builtin.metadata.isPropagated                 : IsPropagated
-    339. builtin.metadata.isTest                       : IsTest
-    340. builtin.Pattern.join                          : [Pattern
+    339. builtin.metadata.isPropagated                 : IsPropagated
+    340. builtin.metadata.isTest                       : IsTest
+    341. builtin.Pattern.join                          : [Pattern
                                                          a]
                                                        -> Pattern
                                                          a
-    341. builtin.io2.IO.process.kill                   : ProcessHandle
+    342. builtin.io2.IO.process.kill                   : ProcessHandle
                                                        ->{IO} ()
-    342. builtin.Int.leadingZeros                      : Int
+    343. builtin.Int.leadingZeros                      : Int
                                                        -> Nat
-    343. builtin.Nat.leadingZeros                      : Nat
+    344. builtin.Nat.leadingZeros                      : Nat
                                                        -> Nat
-    344. builtin.Char.Class.letter                     : Class
-    345. builtin.Text.patterns.letter                  : Pattern
+    345. builtin.Char.Class.letter                     : Class
+    346. builtin.Text.patterns.letter                  : Pattern
                                                          Text
-    346. builtin.Text.patterns.literal                 : Text
+    347. builtin.Text.patterns.literal                 : Text
                                                        -> Pattern
                                                          Text
-    347. builtin.Value.load                            : Value
+    348. builtin.Value.load                            : Value
                                                        ->{IO} Either
                                                          [Term]
                                                          a
-    348. builtin.Float.log                             : Float
+    349. builtin.Float.log                             : Float
                                                        -> Float
-    349. builtin.Float.logBase                         : Float
+    350. builtin.Float.logBase                         : Float
                                                        -> Float
                                                        -> Float
-    350. builtin.Code.lookup                           : Term
+    351. builtin.Code.lookup                           : Term
                                                        ->{IO} Optional
                                                          Code
-    351. builtin.Char.Class.lower                      : Class
-    352. builtin.Float.lt                              : Float
+    352. builtin.Char.Class.lower                      : Class
+    353. builtin.Float.lt                              : Float
                                                        -> Float
                                                        -> Boolean
-    353. builtin.Int.lt                                : Int
+    354. builtin.Int.lt                                : Int
                                                        -> Int
                                                        -> Boolean
-    354. builtin.Nat.lt                                : Nat
+    355. builtin.Nat.lt                                : Nat
                                                        -> Nat
                                                        -> Boolean
-    355. builtin.Text.lt                               : Text
+    356. builtin.Text.lt                               : Text
                                                        -> Text
                                                        -> Boolean
-    356. builtin.Float.lteq                            : Float
+    357. builtin.Float.lteq                            : Float
                                                        -> Float
                                                        -> Boolean
-    357. builtin.Int.lteq                              : Int
+    358. builtin.Int.lteq                              : Int
                                                        -> Int
                                                        -> Boolean
-    358. builtin.Nat.lteq                              : Nat
+    359. builtin.Nat.lteq                              : Nat
                                                        -> Nat
                                                        -> Boolean
-    359. builtin.Text.lteq                             : Text
+    360. builtin.Text.lteq                             : Text
                                                        -> Text
                                                        -> Boolean
-    360. builtin.Pattern.many                          : Pattern
+    361. builtin.Pattern.many                          : Pattern
                                                          a
                                                        -> Pattern
                                                          a
-    361. builtin.Char.Class.mark                       : Class
-    362. builtin.Float.max                             : Float
+    362. builtin.Char.Class.mark                       : Class
+    363. builtin.Float.max                             : Float
                                                        -> Float
                                                        -> Float
-    363. builtin.Float.min                             : Float
+    364. builtin.Float.min                             : Float
                                                        -> Float
                                                        -> Float
-    364. builtin.Int.mod                               : Int
+    365. builtin.Int.mod                               : Int
                                                        -> Int
                                                        -> Int
-    365. builtin.Nat.mod                               : Nat
+    366. builtin.Nat.mod                               : Nat
                                                        -> Nat
                                                        -> Nat
-    366. builtin.io2.Clock.internals.monotonic         : '{IO} Either
+    367. builtin.io2.Clock.internals.monotonic         : '{IO} Either
                                                          Failure
                                                          TimeSpec
-    367. builtin.Universal.murmurHash                  : a
+    368. builtin.Universal.murmurHash                  : a
                                                        -> Nat
-    368. builtin.Int.negate                            : Int
+    369. builtin.Int.negate                            : Int
                                                        -> Int
-    369. builtin.io2.MVar.new                          : a
+    370. builtin.io2.MVar.new                          : a
                                                        ->{IO} MVar
                                                          a
-    370. builtin.io2.Promise.new                       : '{IO} Promise
+    371. builtin.io2.Promise.new                       : '{IO} Promise
                                                          a
-    371. builtin.io2.TVar.new                          : a
+    372. builtin.io2.TVar.new                          : a
                                                        ->{STM} TVar
                                                          a
-    372. builtin.io2.MVar.newEmpty                     : '{IO} MVar
+    373. builtin.io2.MVar.newEmpty                     : '{IO} MVar
                                                          a
-    373. builtin.io2.TVar.newIO                        : a
+    374. builtin.io2.TVar.newIO                        : a
                                                        ->{IO} TVar
                                                          a
-    374. builtin.Boolean.not                           : Boolean
+    375. builtin.Boolean.not                           : Boolean
                                                        -> Boolean
-    375. builtin.Char.Class.not                        : Class
+    376. builtin.Char.Class.not                        : Class
                                                        -> Class
-    376. builtin.Text.patterns.notCharIn               : [Char]
+    377. builtin.Text.patterns.notCharIn               : [Char]
                                                        -> Pattern
                                                          Text
-    377. builtin.Text.patterns.notCharRange            : Char
+    378. builtin.Text.patterns.notCharRange            : Char
                                                        -> Char
                                                        -> Pattern
                                                          Text
-    378. builtin.io2.Clock.internals.nsec              : TimeSpec
+    379. builtin.io2.Clock.internals.nsec              : TimeSpec
                                                        -> Nat
-    379. builtin.Char.Class.number                     : Class
-    380. builtin.Char.Class.or                         : Class
+    380. builtin.Char.Class.number                     : Class
+    381. builtin.Char.Class.or                         : Class
                                                        -> Class
                                                        -> Class
-    381. builtin.Int.or                                : Int
+    382. builtin.Int.or                                : Int
                                                        -> Int
                                                        -> Int
-    382. builtin.Nat.or                                : Nat
+    383. builtin.Nat.or                                : Nat
                                                        -> Nat
                                                        -> Nat
-    383. builtin.Pattern.or                            : Pattern
+    384. builtin.Pattern.or                            : Pattern
                                                          a
                                                        -> Pattern
                                                          a
                                                        -> Pattern
                                                          a
-    384. builtin.Int.popCount                          : Int
+    385. builtin.Int.popCount                          : Int
                                                        -> Nat
-    385. builtin.Nat.popCount                          : Nat
+    386. builtin.Nat.popCount                          : Nat
                                                        -> Nat
-    386. builtin.Float.pow                             : Float
+    387. builtin.Float.pow                             : Float
                                                        -> Float
                                                        -> Float
-    387. builtin.Int.pow                               : Int
+    388. builtin.Int.pow                               : Int
                                                        -> Nat
                                                        -> Int
-    388. builtin.Nat.pow                               : Nat
+    389. builtin.Nat.pow                               : Nat
                                                        -> Nat
                                                        -> Nat
-    389. builtin.Char.Class.printable                  : Class
-    390. builtin.io2.Clock.internals.processCPUTime    : '{IO} Either
+    390. builtin.Char.Class.printable                  : Class
+    391. builtin.io2.Clock.internals.processCPUTime    : '{IO} Either
                                                          Failure
                                                          TimeSpec
-    391. builtin.Char.Class.punctuation                : Class
-    392. builtin.Text.patterns.punctuation             : Pattern
+    392. builtin.Char.Class.punctuation                : Class
+    393. builtin.Text.patterns.punctuation             : Pattern
                                                          Text
-    393. builtin.Char.Class.range                      : Char
+    394. builtin.Char.Class.range                      : Char
                                                        -> Char
                                                        -> Class
-    394. builtin.ImmutableArray.read                   : ImmutableArray
+    395. builtin.ImmutableArray.read                   : ImmutableArray
                                                          a
                                                        -> Nat
                                                        ->{Exception} a
-    395. builtin.MutableArray.read                     : MutableArray
+    396. builtin.MutableArray.read                     : MutableArray
                                                          g a
                                                        -> Nat
                                                        ->{g,
                                                        Exception} a
-    396. builtin.io2.Promise.read                      : Promise
+    397. builtin.io2.Promise.read                      : Promise
                                                          a
                                                        ->{IO} a
-    397. builtin.Ref.read                              : Ref g a
+    398. builtin.Ref.read                              : Ref g a
                                                        ->{g} a
-    398. builtin.io2.TVar.read                         : TVar a
+    399. builtin.io2.TVar.read                         : TVar a
                                                        ->{STM} a
-    399. builtin.io2.Ref.Ticket.read                   : Ticket
+    400. builtin.io2.Ref.Ticket.read                   : Ticket
                                                          a
                                                        -> a
-    400. builtin.ImmutableByteArray.read16be           : ImmutableByteArray
+    401. builtin.ImmutableByteArray.read16be           : ImmutableByteArray
                                                        -> Nat
                                                        ->{Exception} Nat
-    401. builtin.MutableByteArray.read16be             : MutableByteArray
+    402. builtin.MutableByteArray.read16be             : MutableByteArray
                                                          g
                                                        -> Nat
                                                        ->{g,
                                                        Exception} Nat
-    402. builtin.ImmutableByteArray.read24be           : ImmutableByteArray
+    403. builtin.ImmutableByteArray.read24be           : ImmutableByteArray
                                                        -> Nat
                                                        ->{Exception} Nat
-    403. builtin.MutableByteArray.read24be             : MutableByteArray
+    404. builtin.MutableByteArray.read24be             : MutableByteArray
                                                          g
                                                        -> Nat
                                                        ->{g,
                                                        Exception} Nat
-    404. builtin.ImmutableByteArray.read32be           : ImmutableByteArray
+    405. builtin.ImmutableByteArray.read32be           : ImmutableByteArray
                                                        -> Nat
                                                        ->{Exception} Nat
-    405. builtin.MutableByteArray.read32be             : MutableByteArray
+    406. builtin.MutableByteArray.read32be             : MutableByteArray
                                                          g
                                                        -> Nat
                                                        ->{g,
                                                        Exception} Nat
-    406. builtin.ImmutableByteArray.read40be           : ImmutableByteArray
+    407. builtin.ImmutableByteArray.read40be           : ImmutableByteArray
                                                        -> Nat
                                                        ->{Exception} Nat
-    407. builtin.MutableByteArray.read40be             : MutableByteArray
+    408. builtin.MutableByteArray.read40be             : MutableByteArray
                                                          g
                                                        -> Nat
                                                        ->{g,
                                                        Exception} Nat
-    408. builtin.ImmutableByteArray.read64be           : ImmutableByteArray
+    409. builtin.ImmutableByteArray.read64be           : ImmutableByteArray
                                                        -> Nat
                                                        ->{Exception} Nat
-    409. builtin.MutableByteArray.read64be             : MutableByteArray
+    410. builtin.MutableByteArray.read64be             : MutableByteArray
                                                          g
                                                        -> Nat
                                                        ->{g,
                                                        Exception} Nat
-    410. builtin.ImmutableByteArray.read8              : ImmutableByteArray
+    411. builtin.ImmutableByteArray.read8              : ImmutableByteArray
                                                        -> Nat
                                                        ->{Exception} Nat
-    411. builtin.MutableByteArray.read8                : MutableByteArray
+    412. builtin.MutableByteArray.read8                : MutableByteArray
                                                          g
                                                        -> Nat
                                                        ->{g,
                                                        Exception} Nat
-    412. builtin.io2.Ref.readForCas                    : Ref
+    413. builtin.io2.Ref.readForCas                    : Ref
                                                          {IO} a
                                                        ->{IO} Ticket
                                                          a
-    413. builtin.io2.TVar.readIO                       : TVar a
+    414. builtin.io2.TVar.readIO                       : TVar a
                                                        ->{IO} a
-    414. builtin.io2.Clock.internals.realtime          : '{IO} Either
+    415. builtin.io2.Clock.internals.realtime          : '{IO} Either
                                                          Failure
                                                          TimeSpec
-    415. builtin.io2.IO.ref                            : a
+    416. builtin.io2.IO.ref                            : a
                                                        ->{IO} Ref
                                                          {IO} a
-    416. builtin.Scope.ref                             : a
+    417. builtin.Scope.ref                             : a
                                                        ->{Scope
                                                          s} Ref
                                                          {Scope
                                                            s}
                                                          a
-    417. builtin.Text.repeat                           : Nat
+    418. builtin.Text.repeat                           : Nat
                                                        -> Text
                                                        -> Text
-    418. builtin.Pattern.replicate                     : Nat
+    419. builtin.Pattern.replicate                     : Nat
                                                        -> Nat
                                                        -> Pattern
                                                          a
                                                        -> Pattern
                                                          a
-    419. builtin.io2.STM.retry                         : '{STM} a
-    420. builtin.Text.reverse                          : Text
+    420. builtin.io2.STM.retry                         : '{STM} a
+    421. builtin.Text.reverse                          : Text
                                                        -> Text
-    421. builtin.Float.round                           : Float
+    422. builtin.Float.round                           : Float
                                                        -> Int
-    422. builtin.Pattern.run                           : Pattern
+    423. builtin.Pattern.run                           : Pattern
                                                          a
                                                        -> a
                                                        -> Optional
                                                          ( [a],
                                                            a)
-    423. builtin.Scope.run                             : (∀ s.
+    424. builtin.Scope.run                             : (∀ s.
                                                          '{g,
                                                          Scope s} r)
                                                        ->{g} r
-    424. builtin.io2.Clock.internals.sec               : TimeSpec
+    425. builtin.io2.Clock.internals.sec               : TimeSpec
                                                        -> Int
-    425. builtin.Char.Class.separator                  : Class
-    426. builtin.Code.serialize                        : Code
+    426. builtin.Char.Class.separator                  : Class
+    427. builtin.Code.serialize                        : Code
                                                        -> Bytes
-    427. builtin.Value.serialize                       : Value
+    428. builtin.Value.serialize                       : Value
                                                        -> Bytes
-    428. builtin.io2.Tls.ClientConfig.certificates.set : [SignedCert]
+    429. builtin.io2.Tls.ClientConfig.certificates.set : [SignedCert]
                                                        -> ClientConfig
                                                        -> ClientConfig
-    429. builtin.io2.Tls.ServerConfig.certificates.set : [SignedCert]
+    430. builtin.io2.Tls.ServerConfig.certificates.set : [SignedCert]
                                                        -> ServerConfig
                                                        -> ServerConfig
-    430. builtin.io2.TLS.ClientConfig.ciphers.set      : [Cipher]
+    431. builtin.io2.TLS.ClientConfig.ciphers.set      : [Cipher]
                                                        -> ClientConfig
                                                        -> ClientConfig
-    431. builtin.io2.Tls.ServerConfig.ciphers.set      : [Cipher]
+    432. builtin.io2.Tls.ServerConfig.ciphers.set      : [Cipher]
                                                        -> ServerConfig
                                                        -> ServerConfig
-    432. builtin.io2.Tls.ClientConfig.versions.set     : [Version]
+    433. builtin.io2.Tls.ClientConfig.versions.set     : [Version]
                                                        -> ClientConfig
                                                        -> ClientConfig
-    433. builtin.io2.Tls.ServerConfig.versions.set     : [Version]
+    434. builtin.io2.Tls.ServerConfig.versions.set     : [Version]
                                                        -> ServerConfig
                                                        -> ServerConfig
-    434. builtin.Int.shiftLeft                         : Int
+    435. builtin.Int.shiftLeft                         : Int
                                                        -> Nat
                                                        -> Int
-    435. builtin.Nat.shiftLeft                         : Nat
+    436. builtin.Nat.shiftLeft                         : Nat
                                                        -> Nat
                                                        -> Nat
-    436. builtin.Int.shiftRight                        : Int
+    437. builtin.Int.shiftRight                        : Int
                                                        -> Nat
                                                        -> Int
-    437. builtin.Nat.shiftRight                        : Nat
+    438. builtin.Nat.shiftRight                        : Nat
                                                        -> Nat
                                                        -> Nat
-    438. builtin.Int.signum                            : Int
+    439. builtin.Int.signum                            : Int
                                                        -> Int
-    439. builtin.Float.sin                             : Float
+    440. builtin.Float.sin                             : Float
                                                        -> Float
-    440. builtin.Float.sinh                            : Float
+    441. builtin.Float.sinh                            : Float
                                                        -> Float
-    441. builtin.Bytes.size                            : Bytes
+    442. builtin.Bytes.size                            : Bytes
                                                        -> Nat
-    442. builtin.ImmutableArray.size                   : ImmutableArray
+    443. builtin.ImmutableArray.size                   : ImmutableArray
                                                          a
                                                        -> Nat
-    443. builtin.ImmutableByteArray.size               : ImmutableByteArray
+    444. builtin.ImmutableByteArray.size               : ImmutableByteArray
                                                        -> Nat
-    444. builtin.List.size                             : [a]
+    445. builtin.List.size                             : [a]
                                                        -> Nat
-    445. builtin.MutableArray.size                     : MutableArray
+    446. builtin.MutableArray.size                     : MutableArray
                                                          g a
                                                        -> Nat
-    446. builtin.MutableByteArray.size                 : MutableByteArray
+    447. builtin.MutableByteArray.size                 : MutableByteArray
                                                          g
                                                        -> Nat
-    447. builtin.Text.size                             : Text
+    448. builtin.Text.size                             : Text
                                                        -> Nat
-    448. builtin.Text.patterns.space                   : Pattern
+    449. builtin.Text.patterns.space                   : Pattern
                                                          Text
-    449. builtin.Float.sqrt                            : Float
+    450. builtin.Float.sqrt                            : Float
                                                        -> Float
-    450. builtin.io2.IO.process.start                  : Text
+    451. builtin.io2.IO.process.start                  : Text
                                                        -> [Text]
                                                        ->{IO} ( Handle,
                                                          Handle,
                                                          Handle,
                                                          ProcessHandle)
-    451. builtin.io2.IO.stdHandle                      : StdHandle
+    452. builtin.io2.IO.stdHandle                      : StdHandle
                                                        -> Handle
-    452. builtin.Nat.sub                               : Nat
+    453. builtin.Nat.sub                               : Nat
                                                        -> Nat
                                                        -> Int
-    453. builtin.io2.TVar.swap                         : TVar a
+    454. builtin.io2.TVar.swap                         : TVar a
                                                        -> a
                                                        ->{STM} a
-    454. builtin.Char.Class.symbol                     : Class
-    455. builtin.io2.IO.systemTimeMicroseconds         : '{IO} Int
-    456. builtin.Bytes.take                            : Nat
+    455. builtin.Char.Class.symbol                     : Class
+    456. builtin.io2.IO.systemTimeMicroseconds         : '{IO} Int
+    457. builtin.Bytes.take                            : Nat
                                                        -> Bytes
                                                        -> Bytes
-    457. builtin.List.take                             : Nat
+    458. builtin.List.take                             : Nat
                                                        -> [a]
                                                        -> [a]
-    458. builtin.Text.take                             : Nat
+    459. builtin.Text.take                             : Nat
                                                        -> Text
                                                        -> Text
-    459. builtin.Float.tan                             : Float
+    460. builtin.Float.tan                             : Float
                                                        -> Float
-    460. builtin.Float.tanh                            : Float
+    461. builtin.Float.tanh                            : Float
                                                        -> Float
-    461. builtin.io2.Clock.internals.threadCPUTime     : '{IO} Either
+    462. builtin.io2.Clock.internals.threadCPUTime     : '{IO} Either
                                                          Failure
                                                          TimeSpec
-    462. builtin.Bytes.toBase16                        : Bytes
+    463. builtin.Bytes.toBase16                        : Bytes
                                                        -> Bytes
-    463. builtin.Bytes.toBase32                        : Bytes
+    464. builtin.Bytes.toBase32                        : Bytes
                                                        -> Bytes
-    464. builtin.Bytes.toBase64                        : Bytes
+    465. builtin.Bytes.toBase64                        : Bytes
                                                        -> Bytes
-    465. builtin.Bytes.toBase64UrlUnpadded             : Bytes
+    466. builtin.Bytes.toBase64UrlUnpadded             : Bytes
                                                        -> Bytes
-    466. builtin.Text.toCharList                       : Text
+    467. builtin.Text.toCharList                       : Text
                                                        -> [Char]
-    467. builtin.Int.toFloat                           : Int
+    468. builtin.Int.toFloat                           : Int
                                                        -> Float
-    468. builtin.Nat.toFloat                           : Nat
+    469. builtin.Nat.toFloat                           : Nat
                                                        -> Float
-    469. builtin.Nat.toInt                             : Nat
+    470. builtin.Nat.toInt                             : Nat
                                                        -> Int
-    470. builtin.Bytes.toList                          : Bytes
+    471. builtin.Bytes.toList                          : Bytes
                                                        -> [Nat]
-    471. builtin.Text.toLowercase                      : Text
+    472. builtin.Text.toLowercase                      : Text
                                                        -> Text
-    472. builtin.Char.toNat                            : Char
+    473. builtin.Char.toNat                            : Char
                                                        -> Nat
-    473. builtin.Float.toRepresentation                : Float
+    474. builtin.Float.toRepresentation                : Float
                                                        -> Nat
-    474. builtin.Int.toRepresentation                  : Int
+    475. builtin.Int.toRepresentation                  : Int
                                                        -> Nat
-    475. builtin.Char.toText                           : Char
+    476. builtin.Char.toText                           : Char
                                                        -> Text
-    476. builtin.Debug.toText                          : a
+    477. builtin.Debug.toText                          : a
                                                        -> Optional
                                                          (Either
                                                            Text
                                                            Text)
-    477. builtin.Float.toText                          : Float
+    478. builtin.Float.toText                          : Float
                                                        -> Text
-    478. builtin.Handle.toText                         : Handle
+    479. builtin.Handle.toText                         : Handle
                                                        -> Text
-    479. builtin.Int.toText                            : Int
+    480. builtin.Int.toText                            : Int
                                                        -> Text
-    480. builtin.Nat.toText                            : Nat
+    481. builtin.Nat.toText                            : Nat
                                                        -> Text
-    481. builtin.Socket.toText                         : Socket
+    482. builtin.Socket.toText                         : Socket
                                                        -> Text
-    482. builtin.Link.Term.toText                      : Term
+    483. builtin.Link.Term.toText                      : Term
                                                        -> Text
-    483. builtin.ThreadId.toText                       : ThreadId
+    484. builtin.ThreadId.toText                       : ThreadId
                                                        -> Text
-    484. builtin.Text.toUppercase                      : Text
+    485. builtin.Text.toUppercase                      : Text
                                                        -> Text
-    485. builtin.Text.toUtf8                           : Text
+    486. builtin.Text.toUtf8                           : Text
                                                        -> Bytes
-    486. builtin.todo                                  : a -> b
-    487. builtin.Debug.trace                           : Text
+    487. builtin.todo                                  : a -> b
+    488. builtin.Debug.trace                           : Text
                                                        -> a
                                                        -> ()
-    488. builtin.Int.trailingZeros                     : Int
+    489. builtin.Int.trailingZeros                     : Int
                                                        -> Nat
-    489. builtin.Nat.trailingZeros                     : Nat
+    490. builtin.Nat.trailingZeros                     : Nat
                                                        -> Nat
-    490. builtin.Float.truncate                        : Float
+    491. builtin.Float.truncate                        : Float
                                                        -> Int
-    491. builtin.Int.truncate0                         : Int
+    492. builtin.Int.truncate0                         : Int
                                                        -> Nat
-    492. builtin.io2.IO.tryEval                        : '{IO} a
+    493. builtin.io2.IO.tryEval                        : '{IO} a
                                                        ->{IO,
                                                        Exception} a
-    493. builtin.io2.Promise.tryRead                   : Promise
+    494. builtin.io2.Promise.tryRead                   : Promise
                                                          a
                                                        ->{IO} Optional
                                                          a
-    494. builtin.io2.MVar.tryTake                      : MVar a
+    495. builtin.io2.MVar.tryTake                      : MVar a
                                                        ->{IO} Optional
                                                          a
-    495. builtin.Text.uncons                           : Text
+    496. builtin.Text.uncons                           : Text
                                                        -> Optional
                                                          ( Char,
                                                            Text)
-    496. builtin.Any.unsafeExtract                     : Any
+    497. builtin.Any.unsafeExtract                     : Any
                                                        -> a
-    497. builtin.Text.unsnoc                           : Text
+    498. builtin.Text.unsnoc                           : Text
                                                        -> Optional
                                                          ( Text,
                                                            Char)
-    498. builtin.Char.Class.upper                      : Class
-    499. builtin.Code.validate                         : [( Term,
+    499. builtin.Char.Class.upper                      : Class
+    500. builtin.Code.validate                         : [( Term,
                                                          Code)]
                                                        ->{IO} Optional
                                                          Failure
-    500. builtin.io2.validateSandboxed                 : [Term]
+    501. builtin.io2.validateSandboxed                 : [Term]
                                                        -> a
                                                        -> Boolean
-    501. builtin.Value.value                           : a
+    502. builtin.Value.value                           : a
                                                        -> Value
-    502. builtin.io2.IO.process.wait                   : ProcessHandle
+    503. builtin.io2.IO.process.wait                   : ProcessHandle
                                                        ->{IO} Nat
-    503. builtin.Debug.watch                           : Text
+    504. builtin.Debug.watch                           : Text
                                                        -> a
                                                        -> a
-    504. builtin.Char.Class.whitespace                 : Class
-    505. builtin.MutableArray.write                    : MutableArray
+    505. builtin.Char.Class.whitespace                 : Class
+    506. builtin.MutableArray.write                    : MutableArray
                                                          g a
                                                        -> Nat
                                                        -> a
                                                        ->{g,
                                                        Exception} ()
-    506. builtin.io2.Promise.write                     : Promise
+    507. builtin.io2.Promise.write                     : Promise
                                                          a
                                                        -> a
                                                        ->{IO} Boolean
-    507. builtin.Ref.write                             : Ref g a
+    508. builtin.Ref.write                             : Ref g a
                                                        -> a
                                                        ->{g} ()
-    508. builtin.io2.TVar.write                        : TVar a
+    509. builtin.io2.TVar.write                        : TVar a
                                                        -> a
                                                        ->{STM} ()
-    509. builtin.MutableByteArray.write16be            : MutableByteArray
+    510. builtin.MutableByteArray.write16be            : MutableByteArray
                                                          g
                                                        -> Nat
                                                        -> Nat
                                                        ->{g,
                                                        Exception} ()
-    510. builtin.MutableByteArray.write32be            : MutableByteArray
+    511. builtin.MutableByteArray.write32be            : MutableByteArray
                                                          g
                                                        -> Nat
                                                        -> Nat
                                                        ->{g,
                                                        Exception} ()
-    511. builtin.MutableByteArray.write64be            : MutableByteArray
+    512. builtin.MutableByteArray.write64be            : MutableByteArray
                                                          g
                                                        -> Nat
                                                        -> Nat
                                                        ->{g,
                                                        Exception} ()
-    512. builtin.MutableByteArray.write8               : MutableByteArray
+    513. builtin.MutableByteArray.write8               : MutableByteArray
                                                          g
                                                        -> Nat
                                                        -> Nat
                                                        ->{g,
                                                        Exception} ()
-    513. builtin.Int.xor                               : Int
+    514. builtin.Int.xor                               : Int
                                                        -> Int
                                                        -> Int
-    514. builtin.Nat.xor                               : Nat
+    515. builtin.Nat.xor                               : Nat
                                                        -> Nat
                                                        -> Nat
   

--- a/unison-src/transcripts/reflog.output.md
+++ b/unison-src/transcripts/reflog.output.md
@@ -59,17 +59,17 @@ y = 2
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #30tl6rkfqn .old`   to make an old namespace
+    `fork #upgj8h6ju3 .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #30tl6rkfqn`  to reset the root namespace and
+    `reset-root #upgj8h6ju3`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
        When   Root Hash     Action
-  1.   now    #4t4aoo9vnt   add
-  2.   now    #30tl6rkfqn   add
-  3.   now    #mfof2amrm2   builtins.merge
+  1.   now    #58jmfch7o7   add
+  2.   now    #upgj8h6ju3   add
+  3.   now    #acegso70di   builtins.merge
   4.          #sg60bvjo91   history starts here
   
   Tip: Use `diff.namespace 1 7` to compare namespaces between

--- a/unison-src/transcripts/squash.output.md
+++ b/unison-src/transcripts/squash.output.md
@@ -13,7 +13,7 @@ Let's look at some examples. We'll start with a namespace with just the builtins
   
   
   
-  □ 1. #uqucjk22if (start of history)
+  □ 1. #l6nvab7prj (start of history)
 
 .> fork builtin builtin2
 
@@ -42,21 +42,21 @@ Now suppose we `fork` a copy of builtin, then rename `Nat.+` to `frobnicate`, th
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #2g254tkpvt
+  ⊙ 1. #la42o8m5tq
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ 2. #s54qi5ddk7
+  ⊙ 2. #fqkpt5ogt2
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ 3. #uqucjk22if (start of history)
+  □ 3. #l6nvab7prj (start of history)
 
 ```
 If we merge that back into `builtin`, we get that same chain of history:
@@ -71,21 +71,21 @@ If we merge that back into `builtin`, we get that same chain of history:
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #2g254tkpvt
+  ⊙ 1. #la42o8m5tq
   
     > Moves:
     
       Original name  New name
       Nat.frobnicate Nat.+
   
-  ⊙ 2. #s54qi5ddk7
+  ⊙ 2. #fqkpt5ogt2
   
     > Moves:
     
       Original name New name
       Nat.+         Nat.frobnicate
   
-  □ 3. #uqucjk22if (start of history)
+  □ 3. #l6nvab7prj (start of history)
 
 ```
 Let's try again, but using a `merge.squash` (or just `squash`) instead. The history will be unchanged:
@@ -106,7 +106,7 @@ Let's try again, but using a `merge.squash` (or just `squash`) instead. The hist
   
   
   
-  □ 1. #uqucjk22if (start of history)
+  □ 1. #l6nvab7prj (start of history)
 
 ```
 The churn that happened in `mybuiltin` namespace ended up back in the same spot, so the squash merge of that namespace with our original namespace had no effect.
@@ -485,13 +485,13 @@ This checks to see that squashing correctly preserves deletions:
   Note: The most recent namespace hash is immediately below this
         message.
   
-  ⊙ 1. #9ootvo2tgi
+  ⊙ 1. #ae3oc8cikb
   
     - Deletes:
     
       Nat.* Nat.+
   
-  □ 2. #uqucjk22if (start of history)
+  □ 2. #l6nvab7prj (start of history)
 
 ```
 Notice that `Nat.+` and `Nat.*` are deleted by the squash, and we see them deleted in one atomic step in the history.


### PR DESCRIPTION
## Overview

As discussed on Slack, expose Haskell's implementation the same way as the other existing crypto built-ins, and add it to the test transcripts. This is not a cryptographically secure algorithm, but is widely used in other contexts where it is still useful, e.g. checksums.

## Implementation notes

Adds a built-in `crypto.HashAlgorithm.Md5` using the existing `declareHashAlgorithm` machinery in `parser-typechecker`.

## Interesting/controversial decisions

We talked about implementing this in Unison, and I actually started on that ([see here](https://share.unison-lang.org/@chriskrycho/p/code/latest/namespaces/public/md5); some of those pieces may still be worth generalizing in other ways, *especially* wrapping addition for 32-bit natural numbers, and the chunking-and-padding algorithms were fun to implement), but it seems worth having this as a built-in: it’s valuable for it to be correct (and fast!) and having the Haskell implementation covers that better than a Unison-native one.

## Test coverage

Added transcripts! So far this just uses the three base examples from Wikipedia, but that should be sufficient given that the "real" test coverage here comes from the fact that these are just Haskell implementations.

## Loose ends

The one thing that occurs to me is: Should Unison maybe just re-expose the majority of the implementations already present in Haskell?