### PR TITLE
Port Codebase.getDeclType to be in  Sqlite.Transaction

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -350,10 +350,7 @@ sqliteCodebase debugName root localOrRemote lockOption migrationStrategy action 
                 { getTerm,
                   getTypeOfTermImpl,
                   getTypeDeclaration,
-                  getDeclType =
-                    \r ->
-                      withConn \conn ->
-                        Sqlite.runReadOnlyTransaction conn \run -> run (getDeclType r),
+                  getDeclType,
                   putTerm,
                   putTermComponent,
                   putTypeDeclaration,

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -60,7 +60,7 @@ data Codebase m v a = Codebase
     -- semantics of 'putTypeDeclaration'.
     getTypeDeclaration :: Reference.Id -> Sqlite.Transaction (Maybe (Decl v a)),
     -- | Get the type of a given decl.
-    getDeclType :: V2.Reference -> m CT.ConstructorType,
+    getDeclType :: V2.Reference -> Sqlite.Transaction CT.ConstructorType,
     -- | Enqueue the put of a user-defined term (with its type) into the codebase, if it doesn't already exist. The
     -- implementation may choose to delay the put until all of the term's (and its type's) references are stored as
     -- well.

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -215,8 +215,10 @@ prettyNamesForBranch root = namesForBranch root <&> \(_, n, _) -> n
 
 shallowPPE :: (MonadIO m) => Codebase m v a -> V2Branch.Branch m -> m PPE.PrettyPrintEnv
 shallowPPE codebase b = do
-  hashLength <- Codebase.runTransaction codebase Codebase.hashLength
-  names <- shallowNames codebase b
+  (hashLength, names) <- Codebase.runTransaction codebase do
+    hl <- Codebase.hashLength
+    names <- shallowNames codebase b
+    pure (hl, names)
   pure $ PPED.suffixifiedPPE . PPED.fromNamesDecl hashLength $ NamesWithHistory names mempty
 
 -- | A 'Names' which only includes mappings for things _directly_ accessible from the branch.
@@ -224,7 +226,7 @@ shallowPPE codebase b = do
 -- I.e. names in nested children are omitted.
 -- This should probably live elsewhere, but the package dependency graph makes it hard to find
 -- a good place.
-shallowNames :: forall m v a. (Monad m) => Codebase m v a -> V2Branch.Branch m -> m Names
+shallowNames :: forall m v a. (Monad m) => Codebase m v a -> V2Branch.Branch m -> Sqlite.Transaction Names
 shallowNames codebase b = do
   newTerms <-
     V2Branch.terms b
@@ -412,8 +414,10 @@ termListEntry ::
   ExactName NameSegment V2Referent.Referent ->
   m (TermEntry Symbol Ann)
 termListEntry codebase branch (ExactName nameSegment ref) = do
-  v1Referent <- Cv.referent2to1 (Codebase.getDeclType codebase) ref
-  ot <- Codebase.runTransaction codebase (loadReferentType codebase v1Referent)
+  ot <- Codebase.runTransaction codebase $ do
+    v1Referent <- Cv.referent2to1 (Codebase.getDeclType codebase) ref
+    ot <- loadReferentType codebase v1Referent
+    pure (ot)
   tag <- getTermTag codebase ref ot
   pure $
     TermEntry
@@ -433,7 +437,7 @@ termListEntry codebase branch (ExactName nameSegment ref) = do
         & (> 1)
 
 getTermTag ::
-  (Monad m, Var v) =>
+  (Var v, MonadIO m) =>
   Codebase m v a ->
   V2Referent.Referent ->
   Maybe (Type v Ann) ->
@@ -452,7 +456,7 @@ getTermTag codebase r sig = do
         Nothing -> False
   constructorType <- case r of
     V2Referent.Ref {} -> pure Nothing
-    V2Referent.Con ref _ -> Just <$> Codebase.getDeclType codebase ref
+    V2Referent.Con ref _ -> Just <$> Codebase.runTransaction codebase (Codebase.getDeclType codebase ref)
   pure $
     if
         | isDoc -> Doc


### PR DESCRIPTION
## Overview

Port Codebase.getDeclType to be in Sqlite.Transaction;

We can use `Sqlite.Transaction` in other transactions, but can't use `m` inside transactions.
If you want to run a `Sqlite.Transaction` in `m` you can always call `Codebase.runTransaction`; so this is strictly more flexible.

It also encourages call-sites to use the `getDeclType` from the Codebase object (which uses a cache) rather than the lower-level version from `Unison.Codebase.SqliteCodebase.Operations` which doesn't.

## Implementation

* Change `getDeclType` on the codebase to Sqlite.Transaction rather than the codebase monad
* Fix everywhere that broke.

## Testing
None