### PR TITLE
Add documentation for NeoVIM LSP Configuration

### DIFF
--- a/docs/language-server.markdown
+++ b/docs/language-server.markdown
@@ -67,8 +67,8 @@ Configuration for [coc-nvim](https://github.com/neoclide/coc.nvim), enter the fo
   }
 ```
 
-For [lspconfig](https://github.com/neovim/nvim-lspconfig) with optional autocomplete [nvim-cmp](https://github.com/hrsh7th/nvim-cmp),
-you can use the following setup function(s):
+For [lspconfig](https://github.com/neovim/nvim-lspconfig) with optional autocomplete [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) for LSP
+[cmp-nvim-lsp](https://github.com/hrsh7th/cmp-nvim-lsp), you can use the following setup function(s):
 
 ```lua
 -- This function is for configuring a buffer when an LSP is attached

--- a/docs/language-server.markdown
+++ b/docs/language-server.markdown
@@ -67,10 +67,65 @@ Configuration for [coc-nvim](https://github.com/neoclide/coc.nvim), enter the fo
   }
 ```
 
-For [lspconfig](https://github.com/neovim/nvim-lspconfig), you can use the following setup function:
+For [lspconfig](https://github.com/neovim/nvim-lspconfig) with optional autocomplete [nvim-cmp](https://github.com/hrsh7th/nvim-cmp),
+you can use the following setup function(s):
 
 ```lua
-require('lspconfig').unison.setup({})
+-- This function is for configuring a buffer when an LSP is attached
+local on_attach = function(client, bufnr)
+  -- Always show the signcolumn, otherwise it would shift the text each time
+  -- diagnostics appear/become resolved
+  vim.o.signcolumn = 'yes'
+
+  -- Update the cursor hover location every 1/4 of a second
+  vim.o.updatetime = 250
+
+  -- Disable appending of the error text at the offending line
+  vim.diagnostic.config({virtual_text=false})
+
+  -- Enable a floating window containing the error text when hovering over an error
+  vim.api.nvim_create_autocmd("CursorHold", {
+    buffer = bufnr,
+    callback = function()
+      local opts = {
+        focusable = false,
+        close_events = { "BufLeave", "CursorMoved", "InsertEnter", "FocusLost" },
+        border = 'rounded',
+        source = 'always',
+        prefix = ' ',
+        scope = 'cursor',
+      }
+      vim.diagnostic.open_float(nil, opts)
+    end
+  })
+
+  -- This setting is to display hover information about the symbol under the cursor
+  vim.keymap.set('n', 'K', vim.lsp.buf.hover)
+
+end
+
+-- Setup the Unison LSP
+require('lspconfig')['unison'].setup{
+    on_attach = on_attach,
+}
+```
+
+```lua
+-- This is NVim Autocompletion support
+local cmp = require 'cmp'
+
+-- This function sets up autocompletion
+cmp.setup {
+
+  -- This mapping affects the autocompletion choices menu
+  mapping = cmp.mapping.preset.insert(),
+
+  -- This table names the sources for autocompletion
+  sources = {
+    { name = 'nvim_lsp' },
+  },
+}
+
 ```
 
 Note that you'll need to start UCM _before_ you try connecting to it in your editor or your editor might give up.


### PR DESCRIPTION
Add documentation to configure NeoVIM LSP (lspconfig) for errors in popup windows, hover information on command, and autocomplete.