### PR TITLE
Adding "allow-from" option so other web clients could call the api

### DIFF
--- a/unison-cli/unison/ArgParse.hs
+++ b/unison-cli/unison/ArgParse.hs
@@ -157,7 +157,7 @@ codebaseServerOptsFromEnv :: IO CodebaseServerOpts
 codebaseServerOptsFromEnv = do
   token <- lookupEnv Server.ucmTokenVar
   host <- lookupEnv Server.ucmHostVar
-  allowFrom <- lookupEnv Server.ucmAllowFrom
+  allowCorsHost <- lookupEnv Server.ucmAllowCorsHost
   port <- lookupEnv Server.ucmPortVar <&> (>>= readMaybe)
   codebaseUIPath <- lookupEnv Server.ucmUIVar
   pure $ CodebaseServerOpts {..}
@@ -313,14 +313,14 @@ codebaseServerOptsParser envOpts = do
   cliToken <- tokenFlag <|> pure (token envOpts)
   cliHost <- hostFlag <|> pure (host envOpts)
   cliPort <- portFlag <|> pure (port envOpts)
-  cliAllowFrom <- allowFromFlag <|> pure (allowFrom envOpts)
+  cliAllowCorsHost <- allowCorsHostFlag <|> pure (allowCorsHost envOpts)
   cliCodebaseUIPath <- codebaseUIPathFlag <|> pure (codebaseUIPath envOpts)
   pure
     CodebaseServerOpts
       { token = cliToken <|> token envOpts,
         host = cliHost <|> host envOpts,
         port = cliPort <|> port envOpts,
-        allowFrom = cliAllowFrom <|> allowFrom envOpts,
+        allowCorsHost = cliAllowCorsHost <|> allowCorsHost envOpts,
         codebaseUIPath = cliCodebaseUIPath <|> codebaseUIPath envOpts
       }
   where
@@ -342,11 +342,11 @@ codebaseServerOptsParser envOpts = do
           <> metavar "NUMBER"
           <> help "Codebase server port"
           <> noGlobal
-    allowFromFlag =
+    allowCorsHostFlag =
       optional . strOption $
-        long "allow-from"
+        long "allow-cors-host"
           <> metavar "STRING"
-          <> help "Hosts that should be allowed to access api (cors)"
+          <> help "Host that should be allowed to access api (cors)"
           <> noGlobal
     codebaseUIPathFlag =
       optional . strOption $

--- a/unison-cli/unison/ArgParse.hs
+++ b/unison-cli/unison/ArgParse.hs
@@ -157,6 +157,7 @@ codebaseServerOptsFromEnv :: IO CodebaseServerOpts
 codebaseServerOptsFromEnv = do
   token <- lookupEnv Server.ucmTokenVar
   host <- lookupEnv Server.ucmHostVar
+  allowFrom <- lookupEnv Server.ucmAllowFrom
   port <- lookupEnv Server.ucmPortVar <&> (>>= readMaybe)
   codebaseUIPath <- lookupEnv Server.ucmUIVar
   pure $ CodebaseServerOpts {..}
@@ -312,12 +313,14 @@ codebaseServerOptsParser envOpts = do
   cliToken <- tokenFlag <|> pure (token envOpts)
   cliHost <- hostFlag <|> pure (host envOpts)
   cliPort <- portFlag <|> pure (port envOpts)
+  cliAllowFrom <- allowFromFlag <|> pure (allowFrom envOpts)
   cliCodebaseUIPath <- codebaseUIPathFlag <|> pure (codebaseUIPath envOpts)
   pure
     CodebaseServerOpts
       { token = cliToken <|> token envOpts,
         host = cliHost <|> host envOpts,
         port = cliPort <|> port envOpts,
+        allowFrom = cliAllowFrom <|> allowFrom envOpts,
         codebaseUIPath = cliCodebaseUIPath <|> codebaseUIPath envOpts
       }
   where
@@ -338,6 +341,12 @@ codebaseServerOptsParser envOpts = do
         long "port"
           <> metavar "NUMBER"
           <> help "Codebase server port"
+          <> noGlobal
+    allowFromFlag =
+      optional . strOption $
+        long "allow-from"
+          <> metavar "STRING"
+          <> help "Hosts that should be allowed to access api (cors)"
           <> noGlobal
     codebaseUIPathFlag =
       optional . strOption $

--- a/unison-share-api/package.yaml
+++ b/unison-share-api/package.yaml
@@ -59,6 +59,7 @@ dependencies:
   - utf8-string
   - vector
   - wai
+  - wai-cors
   - warp
   - yaml
 

--- a/unison-share-api/src/Unison/Server/CodebaseServer.hs
+++ b/unison-share-api/src/Unison/Server/CodebaseServer.hs
@@ -31,7 +31,7 @@ import Network.HTTP.Media ((//), (/:))
 import Network.HTTP.Types (HeaderName)
 import Network.HTTP.Types.Status (ok200)
 import qualified Network.URI.Encode as URI
-import Network.Wai (responseLBS)
+import Network.Wai (Middleware, responseLBS)
 import Network.Wai.Handler.Warp
   ( Port,
     defaultSettings,
@@ -41,6 +41,7 @@ import Network.Wai.Handler.Warp
     setPort,
     withApplicationSettings,
   )
+import Network.Wai.Middleware.Cors (cors, corsMethods, corsOrigins, simpleCorsResourcePolicy)
 import Servant
   ( Handler,
     HasServer,
@@ -207,9 +208,10 @@ app ::
   Codebase IO Symbol Ann ->
   FilePath ->
   Strict.ByteString ->
+  Maybe String ->
   Application
-app env rt codebase uiPath expectedToken =
-  serve appAPI $ server env rt codebase uiPath expectedToken
+app env rt codebase uiPath expectedToken allowFrom =
+  corsPolicy allowFrom $ serve appAPI $ server env rt codebase uiPath expectedToken
 
 -- | The Token is used to help prevent multiple users on a machine gain access to
 -- each others codebases.
@@ -242,6 +244,9 @@ ucmPortVar = "UCM_PORT"
 ucmHostVar :: String
 ucmHostVar = "UCM_HOST"
 
+ucmAllowFrom :: String
+ucmAllowFrom = "UCM_ALLOW_FROM"
+
 ucmTokenVar :: String
 ucmTokenVar = "UCM_TOKEN"
 
@@ -249,6 +254,7 @@ data CodebaseServerOpts = CodebaseServerOpts
   { token :: Maybe String,
     host :: Maybe String,
     port :: Maybe Int,
+    allowFrom :: Maybe String,
     codebaseUIPath :: Maybe FilePath
   }
   deriving (Show, Eq)
@@ -259,6 +265,7 @@ defaultCodebaseServerOpts =
     { token = Nothing,
       host = Nothing,
       port = Nothing,
+      allowFrom = Nothing,
       codebaseUIPath = Nothing
     }
 
@@ -282,7 +289,7 @@ startServer env opts rt codebase onStart = do
         defaultSettings
           & maybe id setPort (port opts)
           & maybe id (setHost . fromString) (host opts)
-  let a = app env rt codebase envUI token
+  let a = app env rt codebase envUI token (allowFrom opts)
   case port opts of
     Nothing -> withApplicationSettings settings (pure a) (onStart . baseUrl)
     Just p -> do
@@ -317,6 +324,17 @@ serveIndex path = do
 
 serveUI :: FilePath -> Server WebUI
 serveUI path _ = serveIndex path
+
+-- Apply cors if there is 'allowFrom'
+corsPolicy :: Maybe String -> Middleware
+corsPolicy = maybe id \allowFrom ->
+  cors $
+    const $
+      Just
+        simpleCorsResourcePolicy
+          { corsMethods = ["GET", "POST", "PUT", "OPTIONS"],
+            corsOrigins = Just ([C8.pack allowFrom], True)
+          }
 
 server ::
   BackendEnv ->

--- a/unison-share-api/src/Unison/Server/CodebaseServer.hs
+++ b/unison-share-api/src/Unison/Server/CodebaseServer.hs
@@ -332,7 +332,7 @@ corsPolicy = maybe id \allowFrom ->
     const $
       Just
         simpleCorsResourcePolicy
-          { corsMethods = ["GET", "POST", "PUT", "OPTIONS"],
+          { corsMethods = ["GET", "OPTIONS"],
             corsOrigins = Just ([C8.pack allowFrom], True)
           }
 

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -120,6 +120,7 @@ library
     , utf8-string
     , vector
     , wai
+    , wai-cors
     , warp
     , yaml
   default-language: Haskell2010


### PR DESCRIPTION
## Overview

I was playing with API and the first thing I found out was that due to CORS restrictions it's not possible (without using a proxy or smth) to call the API from a different origin.

So the idea was to add an extra command-line option that would allow an extra origin.
Something like this
`stack exec unison -- headless --port 3344 --token TOKEN --allow-from http://localhost:1234/`

This would also make running a proxying while developing unison ui not necessary: https://github.com/unisonweb/unison-local-ui/blob/b1b76c65cc414497d6a7e6453290508e6bd8f77a/webpack.dev.js#L108

## Implementation notes

It's straightforward, just added cors middleware that gets into action if the allow-from option is present. Otherwise works as before.

## Interesting/controversial decisions

This is the 'lowest hanging fruit' solution. As an alternative it could be a list of allowed origins. And/or an option that would enable cors for any origin and etc.

## Test coverage

Did some manual testing. Would be nice to get it tested with the unison ui. Could do that later :)
UPDATE: Tested locally with unison local-ui

## Loose ends

None