### PR TITLE
Add names to pattern match coverage checker debug output

### DIFF
--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -16,12 +16,14 @@ import qualified Data.Set as Set
 import Data.Text (unpack)
 import qualified Unison.ABT as ABT
 import qualified Unison.Blank as Blank
+import qualified Unison.Builtin as Builtin
 import qualified Unison.Name as Name
 import qualified Unison.Names as Names
 import qualified Unison.NamesWithHistory as NamesWithHistory
 import Unison.Parser.Ann (Ann)
 import qualified Unison.Parsers as Parsers
 import Unison.Prelude
+import qualified Unison.PrettyPrintEnv.Names as PPE
 import Unison.Reference (Reference)
 import qualified Unison.Referent as Referent
 import Unison.Result (CompilerBug (..), Note (..), Result, ResultT, pattern Result)
@@ -155,8 +157,13 @@ synthesizeFile ambient tl fqnsByShortName uf term = do
   let -- substitute Blanks for any remaining free vars in UF body
       tdnrTerm = Term.prepareTDNR term
       env0 = Typechecker.Env ambient tl fqnsByShortName
+      ppe =
+        ( PPE.fromNames
+            10
+            (NamesWithHistory.shadowing (UF.toNames uf) Builtin.names)
+        )
       Result notes mayType =
-        evalStateT (Typechecker.synthesizeAndResolve env0) tdnrTerm
+        evalStateT (Typechecker.synthesizeAndResolve ppe env0) tdnrTerm
   -- If typechecking succeeded, reapply the TDNR decisions to user's term:
   Result (convertNotes notes) mayType >>= \_typ -> do
     let infos = Foldable.toList $ Typechecker.infos notes

--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -157,13 +157,13 @@ synthesizeFile ambient tl fqnsByShortName uf term = do
   let -- substitute Blanks for any remaining free vars in UF body
       tdnrTerm = Term.prepareTDNR term
       env0 = Typechecker.Env ambient tl fqnsByShortName
-      ppe =
+      unisonFilePPE =
         ( PPE.fromNames
             10
             (NamesWithHistory.shadowing (UF.toNames uf) Builtin.names)
         )
       Result notes mayType =
-        evalStateT (Typechecker.synthesizeAndResolve ppe env0) tdnrTerm
+        evalStateT (Typechecker.synthesizeAndResolve unisonFilePPE env0) tdnrTerm
   -- If typechecking succeeded, reapply the TDNR decisions to user's term:
   Result (convertNotes notes) mayType >>= \_typ -> do
     let infos = Foldable.toList $ Typechecker.infos notes

--- a/parser-typechecker/src/Unison/PatternMatchCoverage.hs
+++ b/parser-typechecker/src/Unison/PatternMatchCoverage.hs
@@ -68,15 +68,17 @@ checkMatch matchLocation scrutineeType cases = do
   uncoveredExpanded <- concat . fmap Set.toList <$> traverse (expandSolution v0) (Set.toList uncovered)
   let sols = map (generateInhabitants v0) uncoveredExpanded
   let (_accessible, inaccessible, redundant) = classify grdtree1
+  ppe <- getPrettyPrintEnv
   let debugOutput =
         P.sep
-          "\n"
-          [ P.hang "desugared:" (prettyGrdTree prettyPmGrd (\_ -> "<loc>") grdtree0),
-            P.hang "annotated:" (prettyGrdTree NC.prettyDnf (NC.prettyDnf . fst) grdtree1),
-            P.hang "uncovered:" (NC.prettyDnf uncovered),
-            P.hang "uncovered expanded:" (NC.prettyDnf (Set.fromList uncoveredExpanded))
+          "\n\n"
+          [ P.hang (title "desugared:") (prettyGrdTree (prettyPmGrd ppe) (\_ -> "<loc>") grdtree0),
+            P.hang (title "annotated:") (prettyGrdTree (NC.prettyDnf ppe) (NC.prettyDnf ppe . fst) grdtree1),
+            P.hang (title "uncovered:") (NC.prettyDnf ppe uncovered),
+            P.hang (title "uncovered expanded:") (NC.prettyDnf ppe (Set.fromList uncoveredExpanded))
           ]
+      title = P.bold
       doDebug = case shouldDebug PatternCoverage of
-        True -> trace (P.toPlainUnbroken debugOutput)
+        True -> trace (P.toAnsiUnbroken debugOutput)
         False -> id
   doDebug (pure (redundant, inaccessible, sols))

--- a/parser-typechecker/src/Unison/PatternMatchCoverage/Class.hs
+++ b/parser-typechecker/src/Unison/PatternMatchCoverage/Class.hs
@@ -10,6 +10,7 @@ where
 import Control.Monad.Fix (MonadFix)
 import Unison.ConstructorReference (ConstructorReference)
 import Unison.PatternMatchCoverage.ListPat (ListPat)
+import Unison.PrettyPrintEnv (PrettyPrintEnv)
 import Unison.Type (Type)
 import Unison.Var (Var)
 
@@ -24,6 +25,8 @@ class (Ord loc, Var vt, Var v, MonadFix m) => Pmc vt v loc m | m -> vt v loc whe
 
   -- | Get a fresh variable
   fresh :: m v
+
+  getPrettyPrintEnv :: m PrettyPrintEnv
 
 data EnumeratedConstructors vt v loc
   = ConstructorType [(v, ConstructorReference, Type vt loc)]

--- a/parser-typechecker/src/Unison/PatternMatchCoverage/Constraint.hs
+++ b/parser-typechecker/src/Unison/PatternMatchCoverage/Constraint.hs
@@ -68,7 +68,7 @@ prettyConstraint ppe = \case
   Effectful var -> "!" <> prettyVar var
   Eq v0 v1 -> sep " " [prettyVar v0, "=", prettyVar v1]
   where
-    pany :: Show a => a -> Pretty ColorText
+    pany :: (Show a) => a -> Pretty ColorText
     pany = string . show
 
     pc = prettyConstructorReference ppe

--- a/parser-typechecker/src/Unison/PatternMatchCoverage/PmGrd.hs
+++ b/parser-typechecker/src/Unison/PatternMatchCoverage/PmGrd.hs
@@ -2,6 +2,7 @@ module Unison.PatternMatchCoverage.PmGrd where
 
 import Unison.ConstructorReference (ConstructorReference)
 import Unison.PatternMatchCoverage.PmLit (PmLit, prettyPmLit)
+import Unison.PatternMatchCoverage.Pretty
 import qualified Unison.PrettyPrintEnv as PPE
 import qualified Unison.Syntax.TypePrinter as TypePrinter
 import Unison.Term (Term')
@@ -50,15 +51,16 @@ data
     PmLet v (Term' vt v loc) (Type vt loc)
   deriving stock (Show)
 
-prettyPmGrd :: (Var vt, Var v) => PmGrd vt v loc -> Pretty ColorText
-prettyPmGrd = \case
+prettyPmGrd :: (Var vt, Var v) => PPE.PrettyPrintEnv -> PmGrd vt v loc -> Pretty ColorText
+prettyPmGrd ppe = \case
   PmCon var con convars ->
-    let xs = string (show con) : (formatConVar <$> convars) ++ ["<-", string (show var)]
-        formatConVar (v, t) = sep " " ["(", string (show v), ":", TypePrinter.pretty PPE.empty t, ")"]
+    let xs = pc con : fmap (\(trm, typ) -> sep " " ["(" <> prettyVar trm, ":", TypePrinter.pretty ppe typ <> ")"]) convars ++ ["<-", prettyVar var]
      in sep " " xs
-  PmListHead var n el _ -> sep " " ["Cons", string (show n), string (show el), "<-", string (show var)]
-  PmListTail var n el _ -> sep " " ["Snoc", string (show n), string (show el), "<-", string (show var)]
-  PmListInterval var minLen maxLen -> sep " " ["Interval", string (show (minLen, maxLen)), "<-", string (show var)]
-  PmLit var lit -> sep " " [prettyPmLit lit, "<-", string (show var)]
-  PmBang v -> "!" <> string (show v)
-  PmLet v _expr _ -> sep " " ["let", string (show v), "=", "<expr>"]
+  PmListHead var n el _ -> sep " " ["Cons", string (show n), prettyVar el, "<-", prettyVar var]
+  PmListTail var n el _ -> sep " " ["Snoc", string (show n), prettyVar el, "<-", prettyVar var]
+  PmListInterval var minLen maxLen -> sep " " ["Interval", string (show (minLen, maxLen)), "<-", prettyVar var]
+  PmLit var lit -> sep " " [prettyPmLit lit, "<-", prettyVar var]
+  PmBang v -> "!" <> prettyVar v
+  PmLet v _expr _ -> sep " " ["let", prettyVar v, "=", "<expr>"]
+  where
+    pc = prettyConstructorReference ppe

--- a/parser-typechecker/src/Unison/PatternMatchCoverage/Pretty.hs
+++ b/parser-typechecker/src/Unison/PatternMatchCoverage/Pretty.hs
@@ -10,7 +10,7 @@ import Unison.Util.Pretty
 import qualified Unison.Util.Pretty as P
 import Unison.Var
 
-prettyVar :: Var v => v -> Pretty ColorText
+prettyVar :: (Var v) => v -> Pretty ColorText
 prettyVar v =
   let go x =
         let (d, m) = divMod x 26

--- a/parser-typechecker/src/Unison/PatternMatchCoverage/Pretty.hs
+++ b/parser-typechecker/src/Unison/PatternMatchCoverage/Pretty.hs
@@ -1,0 +1,27 @@
+module Unison.PatternMatchCoverage.Pretty where
+
+import Data.Char
+import Unison.ConstructorReference (ConstructorReference)
+import Unison.PrettyPrintEnv
+import Unison.Symbol
+import qualified Unison.Syntax.TermPrinter as TermPrinter
+import qualified Unison.Term as Term
+import Unison.Util.Pretty
+import qualified Unison.Util.Pretty as P
+import Unison.Var
+
+prettyVar :: Var v => v -> Pretty ColorText
+prettyVar v =
+  let go x =
+        let (d, m) = divMod x 26
+            c = chr (ord 'a' + fromIntegral m)
+         in c : case d of
+              0 -> ""
+              _ -> go d
+   in P.bold $ string (go (freshId v))
+
+prettyConstructorReference :: PrettyPrintEnv -> ConstructorReference -> Pretty ColorText
+prettyConstructorReference ppe cr =
+  let con :: Term.Term Symbol ()
+      con = Term.constructor () cr
+   in TermPrinter.pretty ppe con

--- a/parser-typechecker/src/Unison/PatternMatchCoverage/Solve.hs
+++ b/parser-typechecker/src/Unison/PatternMatchCoverage/Solve.hs
@@ -457,8 +457,9 @@ addConstraint ::
   Constraint vt v loc ->
   NormalizedConstraints vt v loc ->
   m (Maybe (NormalizedConstraints vt v loc))
-addConstraint con0 nc =
-  debugConstraint <$> case con0 of
+addConstraint con0 nc = do
+  ppe <- getPrettyPrintEnv
+  debugConstraint ppe <$> case con0 of
     C.PosLit var pmlit ->
       let updateLiteral pos neg lit
             | Just lit1 <- pos,
@@ -568,13 +569,13 @@ addConstraint con0 nc =
           | otherwise -> pure $ Just $ insertVarInfo var vi {vi_eff = IsEffectful} nc
     C.Eq x y -> union x y nc
   where
-    debugConstraint x =
+    debugConstraint ppe x =
       let debugOutput =
             P.sep
               "\n"
-              [ P.hang (P.red "input constraints: ") (prettyNormalizedConstraints nc),
-                P.hang (P.yellow "additional constraint: ") (C.prettyConstraint con0),
-                P.hang (P.green "resulting constraint: ") (maybe "contradiction" prettyNormalizedConstraints x),
+              [ P.hang (P.red "input constraints: ") (prettyNormalizedConstraints ppe nc),
+                P.hang (P.yellow "additional constraint: ") (C.prettyConstraint ppe con0),
+                P.hang (P.green "resulting constraint: ") (maybe "contradiction" (prettyNormalizedConstraints ppe) x),
                 ""
               ]
        in if shouldDebug PatternCoverageConstraintSolver then trace (P.toAnsiUnbroken debugOutput) x else x

--- a/parser-typechecker/src/Unison/Syntax/DeclPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/DeclPrinter.hs
@@ -75,7 +75,7 @@ prettyGADT env ctorType r name dd =
     constructor (n, (_, _, t)) =
       prettyPattern env ctorType name (ConstructorReference r n)
         <> fmt S.TypeAscriptionColon " :"
-        `P.hang` TypePrinter.prettySyntax env t
+          `P.hang` TypePrinter.prettySyntax env t
     header = prettyEffectHeader name (DD.EffectDeclaration dd) <> fmt S.ControlKeyword " where"
 
 prettyPattern ::
@@ -129,7 +129,7 @@ prettyDataDecl (PrettyPrintEnvDecl unsuffixifiedPPE suffixifiedPPE) r name dd =
       P.group $
         styleHashQualified'' (fmt (S.TypeReference r)) fname
           <> fmt S.TypeAscriptionColon " :"
-          `P.hang` runPretty suffixifiedPPE (TypePrinter.prettyRaw Map.empty (-1) typ)
+            `P.hang` runPretty suffixifiedPPE (TypePrinter.prettyRaw Map.empty (-1) typ)
     header = prettyDataHeader name dd <> fmt S.DelimiterChar (" = " `P.orElse` "\n  = ")
 
 -- Comes up with field names for a data declaration which has the form of a

--- a/parser-typechecker/src/Unison/Syntax/DeclPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/DeclPrinter.hs
@@ -75,7 +75,7 @@ prettyGADT env ctorType r name dd =
     constructor (n, (_, _, t)) =
       prettyPattern env ctorType name (ConstructorReference r n)
         <> fmt S.TypeAscriptionColon " :"
-          `P.hang` TypePrinter.prettySyntax env t
+        `P.hang` TypePrinter.prettySyntax env t
     header = prettyEffectHeader name (DD.EffectDeclaration dd) <> fmt S.ControlKeyword " where"
 
 prettyPattern ::
@@ -128,7 +128,8 @@ prettyDataDecl (PrettyPrintEnvDecl unsuffixifiedPPE suffixifiedPPE) r name dd =
     field (fname, typ) =
       P.group $
         styleHashQualified'' (fmt (S.TypeReference r)) fname
-          <> fmt S.TypeAscriptionColon " :" `P.hang` runPretty suffixifiedPPE (TypePrinter.prettyRaw Map.empty (-1) typ)
+          <> fmt S.TypeAscriptionColon " :"
+          `P.hang` runPretty suffixifiedPPE (TypePrinter.prettyRaw Map.empty (-1) typ)
     header = prettyDataHeader name dd <> fmt S.DelimiterChar (" = " `P.orElse` "\n  = ")
 
 -- Comes up with field names for a data declaration which has the form of a
@@ -176,7 +177,7 @@ fieldNames env r name dd = do
           }
   accessorsWithTypes :: [(v, Term.Term v (), Type.Type v ())] <-
     for accessors \(v, trm) ->
-      case Result.result (Typechecker.synthesize typecheckingEnv trm) of
+      case Result.result (Typechecker.synthesize env typecheckingEnv trm) of
         Nothing -> Nothing
         Just typ -> Just (v, trm, typ)
   let hashes = Hashing.hashTermComponents (Map.fromList . fmap (\(v, trm, typ) -> (v, (trm, typ))) $ accessorsWithTypes)

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -86,9 +86,11 @@ import Unison.DataDeclaration.ConstructorId (ConstructorId)
 import Unison.Pattern (Pattern)
 import qualified Unison.Pattern as Pattern
 import Unison.PatternMatchCoverage (checkMatch)
-import Unison.PatternMatchCoverage.Class (EnumeratedConstructors (..), Pmc (..), traverseConstructors)
+import Unison.PatternMatchCoverage.Class (EnumeratedConstructors (..), Pmc, traverseConstructors)
+import qualified Unison.PatternMatchCoverage.Class as Pmc
 import qualified Unison.PatternMatchCoverage.ListPat as ListPat
 import Unison.Prelude
+import Unison.PrettyPrintEnv (PrettyPrintEnv)
 import qualified Unison.PrettyPrintEnv as PPE
 import Unison.Reference (Reference)
 import qualified Unison.Reference as Reference
@@ -218,6 +220,8 @@ mapErrors f r = case r of
 
 newtype MT v loc f a = MT
   { runM ::
+      -- for debug output
+      PrettyPrintEnv ->
       -- Data declarations in scope
       DataDeclarations v loc ->
       -- Effect declarations in scope
@@ -235,10 +239,10 @@ type M v loc = MT v loc (Result v loc)
 type TotalM v loc = MT v loc (Either (CompilerBug v loc))
 
 liftResult :: Result v loc a -> M v loc a
-liftResult r = MT (\_ _ env -> (,env) <$> r)
+liftResult r = MT (\_ _ _ env -> (,env) <$> r)
 
 liftTotalM :: TotalM v loc a -> M v loc a
-liftTotalM (MT m) = MT $ \datas effects env -> case m datas effects env of
+liftTotalM (MT m) = MT $ \ppe datas effects env -> case m ppe datas effects env of
   Left bug -> CompilerBug bug mempty mempty
   Right a -> Success mempty a
 
@@ -252,7 +256,7 @@ modEnv :: (Env v loc -> Env v loc) -> M v loc ()
 modEnv f = modEnv' $ ((),) . f
 
 modEnv' :: (Env v loc -> (a, Env v loc)) -> M v loc a
-modEnv' f = MT (\_ _ env -> pure . f $ env)
+modEnv' f = MT (\_ _ _ env -> pure . f $ env)
 
 data Unknown = Data | Effect deriving (Show)
 
@@ -415,7 +419,7 @@ scope' p (ErrorNote cause path) = ErrorNote cause (path `mappend` pure p)
 
 -- Add `p` onto the end of the `path` of any `ErrorNote`s emitted by the action
 scope :: PathElement v loc -> M v loc a -> M v loc a
-scope p (MT m) = MT \datas effects env -> mapErrors (scope' p) (m datas effects env)
+scope p (MT m) = MT \ppe datas effects env -> mapErrors (scope' p) (m ppe datas effects env)
 
 newtype Context v loc = Context [(Element v loc, Info v loc)]
 
@@ -726,7 +730,7 @@ extendN ctx es = foldM (flip extend) ctx es
 orElse :: M v loc a -> M v loc a -> M v loc a
 orElse m1 m2 = MT go
   where
-    go datas effects env = runM m1 datas effects env <|> runM m2 datas effects env
+    go ppe datas effects env = runM m1 ppe datas effects env <|> runM m2 ppe datas effects env
     s@(Success _ _) <|> _ = s
     TypeError _ _ <|> r = r
     CompilerBug _ _ _ <|> r = r -- swallowing bugs for now: when checking whether a type annotation
@@ -739,11 +743,14 @@ orElse m1 m2 = MT go
 -- hoistMaybe :: (Maybe a -> Maybe b) -> Result v loc a -> Result v loc b
 -- hoistMaybe f (Result es is a) = Result es is (f a)
 
+getPrettyPrintEnv :: M v loc PrettyPrintEnv
+getPrettyPrintEnv = MT \ppe _ _ env -> pure (ppe, env)
+
 getDataDeclarations :: M v loc (DataDeclarations v loc)
-getDataDeclarations = MT \datas _ env -> pure (datas, env)
+getDataDeclarations = MT \_ datas _ env -> pure (datas, env)
 
 getEffectDeclarations :: M v loc (EffectDeclarations v loc)
-getEffectDeclarations = MT \_ effects env -> pure (effects, env)
+getEffectDeclarations = MT \_ _ effects env -> pure (effects, env)
 
 compilerCrash :: CompilerBug v loc -> M v loc a
 compilerCrash bug = liftResult $ compilerBug bug
@@ -1279,6 +1286,7 @@ data PmcState vt v loc = PmcState
   }
 
 instance (Ord loc, Var v) => Pmc (TypeVar v loc) v loc (StateT (PmcState (TypeVar v loc) v loc) (M v loc)) where
+  getPrettyPrintEnv = lift getPrettyPrintEnv
   getConstructors typ = do
     st@PmcState {constructorCache} <- get
     let f = \case
@@ -1288,7 +1296,7 @@ instance (Ord loc, Var v) => Pmc (TypeVar v loc) v loc (StateT (PmcState (TypeVa
     put st {constructorCache = newCache}
     pure result
   getConstructorVarTypes t cref@(ConstructorReference _r cid) = do
-    getConstructors t >>= \case
+    Pmc.getConstructors t >>= \case
       ConstructorType cs -> case drop (fromIntegral cid) cs of
         [] -> error $ show cref <> " not found in constructor list: " <> show cs
         (_, _, consArgs) : _ -> case consArgs of
@@ -2982,18 +2990,19 @@ verifyDataDeclarations decls = forM_ (Map.toList decls) $ \(_ref, decl) -> do
 -- | public interface to the typechecker
 synthesizeClosed ::
   (Var v, Ord loc) =>
+  PrettyPrintEnv ->
   [Type v loc] ->
   TL.TypeLookup v loc ->
   Term v loc ->
   Result v loc (Type v loc)
-synthesizeClosed abilities lookupType term0 =
+synthesizeClosed ppe abilities lookupType term0 =
   let datas = TL.dataDecls lookupType
       effects = TL.effectDecls lookupType
       term = annotateRefs (TL.typeOfTerm' lookupType) term0
    in case term of
         Left missingRef ->
           compilerCrashResult (UnknownTermReference missingRef)
-        Right term -> run datas effects $ do
+        Right term -> run ppe datas effects $ do
           liftResult $
             verifyDataDeclarations datas
               *> verifyDataDeclarations (DD.toDataDecl <$> effects)
@@ -3032,13 +3041,14 @@ annotateRefs synth = ABT.visit f
 
 run ::
   (Var v, Ord loc, Functor f) =>
+  PrettyPrintEnv ->
   DataDeclarations v loc ->
   EffectDeclarations v loc ->
   MT v loc f a ->
   f a
-run datas effects m =
+run ppe datas effects m =
   fmap fst
-    . runM m datas effects
+    . runM m ppe datas effects
     $ Env 1 context0
 
 synthesizeClosed' ::
@@ -3062,8 +3072,8 @@ synthesizeClosed' abilities term = do
 -- Check if the given typechecking action succeeds.
 succeeds :: M v loc a -> TotalM v loc Bool
 succeeds m =
-  MT \datas effects env ->
-    case runM m datas effects env of
+  MT \ppe datas effects env ->
+    case runM m ppe datas effects env of
       Success _ _ -> Right (True, env)
       TypeError _ _ -> Right (False, env)
       CompilerBug bug _ _ -> Left bug
@@ -3078,7 +3088,7 @@ isSubtype' type1 type2 = succeeds $ do
 
 -- See documentation at 'Unison.Typechecker.fitsScheme'
 fitsScheme :: (Var v, Ord loc) => Type v loc -> Type v loc -> Either (CompilerBug v loc) Bool
-fitsScheme type1 type2 = run Map.empty Map.empty $
+fitsScheme type1 type2 = run PPE.empty Map.empty Map.empty $
   succeeds $ do
     let vars = Set.toList $ Set.union (ABT.freeVars type1) (ABT.freeVars type2)
     reserveAll (TypeVar.underlying <$> vars)
@@ -3119,7 +3129,7 @@ isRedundant userType0 inferredType0 = do
 isSubtype ::
   (Var v, Ord loc) => Type v loc -> Type v loc -> Either (CompilerBug v loc) Bool
 isSubtype t1 t2 =
-  run Map.empty Map.empty (isSubtype' t1 t2)
+  run PPE.empty Map.empty Map.empty (isSubtype' t1 t2)
 
 isEqual ::
   (Var v, Ord loc) => Type v loc -> Type v loc -> Either (CompilerBug v loc) Bool
@@ -3149,22 +3159,22 @@ instance (Ord loc, Var v) => Show (Context v loc) where
 
 instance (Monad f) => Monad (MT v loc f) where
   return = pure
-  m >>= f = MT \datas effects env0 -> do
-    (a, env1) <- runM m datas effects env0
-    runM (f a) datas effects $! env1
+  m >>= f = MT \ppe datas effects env0 -> do
+    (a, env1) <- runM m ppe datas effects env0
+    runM (f a) ppe datas effects $! env1
 
 instance (Monad f) => MonadFail.MonadFail (MT v loc f) where
   fail = error
 
 instance (Monad f) => Applicative (MT v loc f) where
-  pure a = MT (\_ _ env -> pure (a, env))
+  pure a = MT (\_ _ _ env -> pure (a, env))
   (<*>) = ap
 
 instance (Monad f) => MonadState (Env v loc) (MT v loc f) where
-  get = MT \_ _ env -> pure (env, env)
-  put env = MT \_ _ _ -> pure ((), env)
+  get = MT \_ _ _ env -> pure (env, env)
+  put env = MT \_ _ _ _ -> pure ((), env)
 
 instance (MonadFix f) => MonadFix (MT v loc f) where
-  mfix f = MT \a b c ->
-    let res = mfix (\ ~(wubble, _finalenv) -> runM (f wubble) a b c)
+  mfix f = MT \ppe a b c ->
+    let res = mfix (\ ~(wubble, _finalenv) -> runM (f wubble) ppe a b c)
      in res

--- a/parser-typechecker/tests/Unison/Test/Typechecker/Context.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker/Context.hs
@@ -4,6 +4,7 @@ module Unison.Test.Typechecker.Context (test) where
 
 import Data.Foldable (for_)
 import EasyTest
+import qualified Unison.PrettyPrintEnv as PPE
 import Unison.Symbol (Symbol)
 import qualified Unison.Term as Term
 import qualified Unison.Type as Type
@@ -33,7 +34,7 @@ verifyClosedTermTest =
                 ()
                 (Term.ann () (Term.var () a) (Type.var () a'))
                 (Term.ann () (Term.var () b) (Type.var () b'))
-            res = Context.synthesizeClosed [] mempty t
+            res = Context.synthesizeClosed PPE.empty [] mempty t
             errors = Context.typeErrors res
             expectUnknownSymbol (Context.ErrorNote cause _) = case cause of
               Context.UnknownSymbol _ _ -> ok

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -110,6 +110,7 @@ library
       Unison.PatternMatchCoverage.NormalizedConstraints
       Unison.PatternMatchCoverage.PmGrd
       Unison.PatternMatchCoverage.PmLit
+      Unison.PatternMatchCoverage.Pretty
       Unison.PatternMatchCoverage.Solve
       Unison.PatternMatchCoverage.UFMap
       Unison.PrettyPrintEnv

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -3441,7 +3441,7 @@ synthesizeForce typeOfFunc = do
             TypeLookup.dataDecls = Map.empty,
             TypeLookup.effectDecls = Map.empty
           }
-  case Result.runResultT (Typechecker.synthesize env (DD.forceTerm External External term)) of
+  case Result.runResultT (Typechecker.synthesize PPE.empty env (DD.forceTerm External External term)) of
     Identity (Nothing, notes) ->
       error
         ( unlines


### PR DESCRIPTION
## Overview

The pattern match coverage checker has a couple of debug outputs that allow for viewing the constraints at different stages (enabled by `UNISON_DEBUG=PATTERN_COVERAGE` and `UNISON_DEBUG=PATTERN_COVERAGE_CONSTRAINT_SOLVER`). Unfortunately, the typechecking environment doesn't have a `PrettyPrintEnv` to make this output very helpful. This PR passes the PPE down into the pattern match coverage checker to improve the debug output.

Consequently, this change makes the synthesize functions take a PPE that gets piped through the `MT` monad. Let me know if you think that's problematic.


### Debug output example:

input file:
```
unique type T = A | B

test : Optional T -> ()
test = cases
  Some A -> ()
  None -> ()
```

trunk:
![before](https://user-images.githubusercontent.com/1627482/228100018-7f007993-3a64-427f-a532-51252f919496.png)

pmcc-pretty:
![after](https://user-images.githubusercontent.com/1627482/228100068-b9cbb1fa-d13b-41be-b933-649a33b77947.png)
