### PR TITLE
Add helper for using Sqlite backup API

### DIFF
--- a/lib/unison-sqlite/src/Unison/Sqlite.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite.hs
@@ -91,6 +91,7 @@ module Unison.Sqlite
     -- * Vacuum
     vacuum,
     vacuumInto,
+    backupInto,
 
     -- * Exceptions
     SomeSqliteException (..),
@@ -120,6 +121,7 @@ import qualified Database.SQLite.Simple as Sqlite.Simple
 import qualified Database.SQLite.Simple.FromField as Sqlite.Simple
 import qualified Database.SQLite.Simple.FromRow as Sqlite.Simple
 import qualified Database.SQLite.Simple.ToField as Sqlite.Simple
+import Unison.Sqlite.Backup (backupInto)
 import Unison.Sqlite.Connection
   ( Connection,
     ExpectedAtMostOneRowException (..),

--- a/lib/unison-sqlite/src/Unison/Sqlite/Backup.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Backup.hs
@@ -1,0 +1,31 @@
+-- | Module for exposing the backup API of SQLite3.
+--
+-- https://www.sqlite.org/backup.html
+-- https://www.sqlite.org/c3ref/backup_finish.html
+module Unison.Sqlite.Backup (backupInto) where
+
+import qualified Data.Text as Text
+import Database.SQLite3 as SQLite3
+import Unison.Prelude
+import qualified UnliftIO
+
+-- | Backup a database to another database.
+backupInto ::
+  -- | Source .sqlite3 file path
+  FilePath ->
+  -- | Destination .sqlite3 file path
+  FilePath ->
+  IO ()
+backupInto (Text.pack -> srcPath) (Text.pack -> destPath) = do
+  UnliftIO.bracket openDBs cleanup $ \(_, _, backup) -> do
+    void $ SQLite3.backupStep backup (-1) -- -1 means copy the whole db at once
+  where
+    openDBs = do
+      srcDb <- SQLite3.open srcPath
+      destDb <- SQLite3.open destPath
+      backup <- SQLite3.backupInit destDb destPath srcDb srcPath
+      return (srcDb, destDb, backup)
+    cleanup (srcDb, destDb, backup) = do
+      SQLite3.backupFinish backup
+      SQLite3.close srcDb
+      SQLite3.close destDb

--- a/lib/unison-sqlite/unison-sqlite.cabal
+++ b/lib/unison-sqlite/unison-sqlite.cabal
@@ -18,6 +18,7 @@ source-repository head
 library
   exposed-modules:
       Unison.Sqlite
+      Unison.Sqlite.Backup
       Unison.Sqlite.Connection
       Unison.Sqlite.Connection.Internal
       Unison.Sqlite.Transaction


### PR DESCRIPTION
## Overview

Currently Share performs migrations by creating copies of every codebase, e.g. from `v9/` -> `v10/`; this makes it easy to roll things back if something goes wrong.

On trunk it does this using a `VACUUM INTO` statement. This works fine, but vacuuming large codebases takes a long time and doesn't actually seem to provide much benefit, since most aspects of codebases are append-only anyways.

This adds a new method which allows Share to use a Sqlite backup instead, which safely copies a database but without trying to re-arrange the tables, which is a bit faster in practice.

Here's a quick test I ran locally on an 8GB codebase from share:

```sh
$ time sqlite3 unison.sqlite3 ".backup './dest/backup.sqlite3'"
sqlite3 unison.sqlite3 ".backup './dest/backup.sqlite3'"  1.66s user 7.61s system 74% cpu 12.437 total
$ time sqlite3 unison.sqlite3 "VACUUM INTO './dest/vacuum.sqlite3'"
sqlite3 unison.sqlite3 "VACUUM INTO './dest/vacuum.sqlite3'"  7.33s user 33.58s system 90% cpu 45.310 total

$ du -sch dest/*
8.1G    dest/backup.sqlite3
8.1G    dest/vacuum.sqlite3
```

So the backup method takes less than a third of the time; which should speed up migrations, and the vacuuming method, despite taking 3 times longer didn't actually reduce the file-size at all.

If at some point in the future we find we need to vacuum our codebases I can easily add an admin endpoint which vacuums each codebase in-place.

## Implementation notes

Note: I left the local UCM migration method alone, it still does a vacuum because time is less of a factor when migrating locally, and space is more important. The backup method will only be used on share.

Adds the `backupTo` method for backing up a codebase to a new location. Unfortunately this method isn't exposed by `sqlite-simple`, but it was easy to wire up using the underlying `direct-sqlite` library.

## Test coverage

- [ ] local testing

If anything goes wrong on the next migration we can still easily roll-back.