### PR TITLE
Misc. projects-related cleanup and bugfixes

### DIFF
--- a/unison-cli/src/Unison/Cli/Share/Projects.hs
+++ b/unison-cli/src/Unison/Cli/Share/Projects.hs
@@ -65,7 +65,7 @@ getProjectByName projectName = do
   response <- servantClientToCli (getProject0 Nothing (Just (into @Text projectName)))
   onGetProjectResponse response
 
--- | Create a new project.
+-- | Create a new project. Kinda weird: returns `Nothing` if the user handle part of the project doesn't exist.
 --
 -- On success, update the `remote_project` table.
 createProject :: ProjectName -> Cli (Maybe RemoteProject)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Pull.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Pull.hs
@@ -229,7 +229,7 @@ withEntitiesDownloadedProgressCallback action = do
       result <- action (\n -> atomically (modifyTVar' entitiesDownloadedVar (+ n)))
       entitiesDownloaded <- readTVarIO entitiesDownloadedVar
       Console.Regions.finishConsoleRegion region $
-        "\n  Downloaded " <> tShow entitiesDownloaded <> " entities."
+        "\n  Downloaded " <> tShow entitiesDownloaded <> " entities.\n"
       pure result
 
 -- | supply `dest0` if you want to print diff messages

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Pull.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Pull.hs
@@ -185,18 +185,24 @@ loadRemoteNamespaceIntoMemory syncMode pullMode remoteNamespace = do
       Cli.ioE (Codebase.importRemoteBranch codebase repo syncMode preprocess) \err ->
         Cli.returnEarly (Output.GitError err)
     ReadShare'LooseCode repo -> loadShareLooseCodeIntoMemory repo
-    ReadShare'ProjectBranch remoteBranch ->
+    ReadShare'ProjectBranch remoteBranch -> do
       let repoInfo = Share.RepoInfo (into @Text (These (remoteBranch ^. #projectName) remoteProjectBranchName))
           causalHash = Common.hash32ToCausalHash . Share.hashJWTHash $ causalHashJwt
           causalHashJwt = remoteBranch ^. #branchHead
           remoteProjectBranchName = remoteBranch ^. #branchName
-       in Cli.with withEntitiesDownloadedProgressCallback \downloadedCallback ->
-            Share.downloadEntities Share.hardCodedBaseUrl repoInfo causalHashJwt downloadedCallback >>= \case
-              Left err0 -> do
-                (Cli.returnEarly . Output.ShareError) case err0 of
-                  Share.SyncError err -> Output.ShareErrorDownloadEntities err
-                  Share.TransportError err -> Output.ShareErrorTransport err
-              Right () -> liftIO (Codebase.expectBranchForHash codebase causalHash)
+      (result, numDownloaded) <-
+        Cli.with withEntitiesDownloadedProgressCallback \(downloadedCallback, getNumDownloaded) -> do
+          result <- Share.downloadEntities Share.hardCodedBaseUrl repoInfo causalHashJwt downloadedCallback
+          numDownloaded <- liftIO getNumDownloaded
+          pure (result, numDownloaded)
+      case result of
+        Left err0 ->
+          (Cli.returnEarly . Output.ShareError) case err0 of
+            Share.SyncError err -> Output.ShareErrorDownloadEntities err
+            Share.TransportError err -> Output.ShareErrorTransport err
+        Right () -> do
+          Cli.respond (Output.DownloadedEntities numDownloaded)
+          liftIO (Codebase.expectBranchForHash codebase causalHash)
 
 loadShareLooseCodeIntoMemory :: ReadShareLooseCode -> Cli (Branch IO)
 loadShareLooseCodeIntoMemory rrn@(ReadShareLooseCode {server, repo, path}) = do
@@ -206,16 +212,20 @@ loadShareLooseCodeIntoMemory rrn@(ReadShareLooseCode {server, repo, path}) = do
   when (not $ RemoteRepo.isPublic rrn) . void $ ensureAuthenticatedWithCodeserver codeserver
   let shareFlavoredPath = Share.Path (shareUserHandleToText repo Nel.:| coerce @[NameSegment] @[Text] (Path.toList path))
   Cli.Env {codebase} <- ask
-  causalHash <-
-    Cli.with withEntitiesDownloadedProgressCallback \downloadedCallback ->
-      Share.pull baseURL shareFlavoredPath downloadedCallback & onLeftM \err0 ->
-        (Cli.returnEarly . Output.ShareError) case err0 of
-          Share.SyncError err -> Output.ShareErrorPull err
-          Share.TransportError err -> Output.ShareErrorTransport err
+  (causalHash, numDownloaded) <-
+    Cli.with withEntitiesDownloadedProgressCallback \(downloadedCallback, getNumDownloaded) -> do
+      causalHash <-
+        Share.pull baseURL shareFlavoredPath downloadedCallback & onLeftM \err0 ->
+          (Cli.returnEarly . Output.ShareError) case err0 of
+            Share.SyncError err -> Output.ShareErrorPull err
+            Share.TransportError err -> Output.ShareErrorTransport err
+      numDownloaded <- liftIO getNumDownloaded
+      pure (causalHash, numDownloaded)
+  Cli.respond (Output.DownloadedEntities numDownloaded)
   liftIO (Codebase.expectBranchForHash codebase causalHash)
 
 -- Provide the given action a callback that display to the terminal.
-withEntitiesDownloadedProgressCallback :: ((Int -> IO ()) -> IO a) -> IO a
+withEntitiesDownloadedProgressCallback :: ((Int -> IO (), IO Int) -> IO a) -> IO a
 withEntitiesDownloadedProgressCallback action = do
   entitiesDownloadedVar <- newTVarIO 0
   Console.Regions.displayConsoleRegions do
@@ -226,11 +236,7 @@ withEntitiesDownloadedProgressCallback action = do
           "\n  Downloaded "
             <> tShow entitiesDownloaded
             <> " entities...\n\n"
-      result <- action (\n -> atomically (modifyTVar' entitiesDownloadedVar (+ n)))
-      entitiesDownloaded <- readTVarIO entitiesDownloadedVar
-      Console.Regions.finishConsoleRegion region $
-        "\n  Downloaded " <> tShow entitiesDownloaded <> " entities.\n"
-      pure result
+      action ((\n -> atomically (modifyTVar' entitiesDownloadedVar (+ n))), readTVarIO entitiesDownloadedVar)
 
 -- | supply `dest0` if you want to print diff messages
 --   supply unchangedMessage if you want to display it if merge had no effect

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
@@ -6,7 +6,7 @@ module Unison.Codebase.Editor.HandleInput.Push
 where
 
 import Control.Concurrent.STM (atomically, modifyTVar', newTVarIO, readTVar, readTVarIO)
-import Control.Lens (over, view, (.~), (^.), _1)
+import Control.Lens (over, view, (.~), (^.), _1, _2)
 import Control.Monad.Reader (ask)
 import qualified Data.List.NonEmpty as Nel
 import qualified Data.Set.NonEmpty as Set.NonEmpty
@@ -617,7 +617,7 @@ createBranchAfterUploadAction pushing localBranchHead remoteProjectAndBranch = d
   remoteBranch <-
     Share.createProjectBranch createProjectBranchRequest & onNothingM do
       Cli.returnEarly $
-        Output.RemoteProjectBranchDoesntExist Share.hardCodedUri (over #project snd remoteProjectAndBranch)
+        Output.RemoteProjectDoesntExist Share.hardCodedUri (remoteProjectAndBranch ^. #project . _2)
   case pushing of
     PushingLooseCode -> pure ()
     PushingProjectBranch (ProjectAndBranch localProject localBranch) ->
@@ -691,7 +691,7 @@ withEntitiesUploadedProgressCallback action = do
       result <- action (\n -> atomically (modifyTVar' entitiesUploadedVar (+ n)))
       entitiesUploaded <- readTVarIO entitiesUploadedVar
       Console.Regions.finishConsoleRegion region $
-        "\n  Uploaded " <> tShow entitiesUploaded <> " entities."
+        "\n  Uploaded " <> tShow entitiesUploaded <> " entities.\n"
       pure result
 
 ------------------------------------------------------------------------------------------------------------------------

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
@@ -455,7 +455,7 @@ deriveRemoteBranchName userHandle remoteProjectName localBranchName =
         -- I'm "arya" pushing local branch "main" to "@arya/lens", so don't call it "@arya/main"
         Just projectUserSlug
           | projectUserSlug == userHandle && localBranchName == unsafeFrom @Text "main" ->
-            localBranchName
+              localBranchName
         -- Nothing is a weird unlikely case: project doesn't begin with a user slug? server will likely reject
         _ -> prependUserSlugToProjectBranchName userHandle localBranchName
 

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -299,6 +299,10 @@ data Output
   | PulledEmptyBranch (ReadRemoteNamespace Share.RemoteProjectBranch)
   | CreatedProject ProjectName ProjectBranchName
   | CreatedProjectBranch ProjectBranchName ProjectBranchName -- parent, child
+  | CreatedRemoteProject URI (ProjectAndBranch ProjectName ProjectBranchName)
+  | CreatedRemoteProjectBranch URI (ProjectAndBranch ProjectName ProjectBranchName)
+  | -- We didn't push anything because the remote server is already in the state we want it to be
+    RemoteProjectBranchIsUpToDate URI (ProjectAndBranch ProjectName ProjectBranchName)
   | InvalidProjectName Text
   | InvalidProjectBranchName Text
   | RefusedToCreateProjectBranch (ProjectAndBranch ProjectName ProjectBranchName)
@@ -489,6 +493,8 @@ isFailure o = case o of
   PulledEmptyBranch {} -> False
   CreatedProject {} -> False
   CreatedProjectBranch {} -> False
+  CreatedRemoteProject {} -> False
+  CreatedRemoteProjectBranch {} -> False
   InvalidProjectName {} -> True
   InvalidProjectBranchName {} -> True
   RefusedToCreateProjectBranch {} -> True
@@ -506,6 +512,7 @@ isFailure o = case o of
   ServantClientError {} -> False
   MarkdownOut {} -> False
   NotImplementedYet {} -> True
+  RemoteProjectBranchIsUpToDate {} -> False
 
 isNumberedFailure :: NumberedOutput -> Bool
 isNumberedFailure = \case

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -323,6 +323,8 @@ data Output
   | Unauthorized Text
   | ServantClientError Servant.ClientError
   | MarkdownOut Text
+  | DownloadedEntities Int
+  | UploadedEntities Int
   | -- A generic "not implemented" message, for WIP code that's nonetheless been merged into trunk
     NotImplementedYet Text
 
@@ -509,10 +511,12 @@ isFailure o = case o of
   RemoteProjectBranchDoesntExist {} -> True
   RemoteProjectBranchHeadMismatch {} -> True
   Unauthorized {} -> True
-  ServantClientError {} -> False
+  ServantClientError {} -> True
   MarkdownOut {} -> False
   NotImplementedYet {} -> True
   RemoteProjectBranchIsUpToDate {} -> False
+  DownloadedEntities {} -> False
+  UploadedEntities {} -> False
 
 isNumberedFailure :: NumberedOutput -> Bool
 isNumberedFailure = \case

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1829,6 +1829,17 @@ notifyUser dir = \case
         <> prettyProjectBranchName childBranchName
         <> "from branch"
         <> prettyProjectBranchName parentBranchName
+  CreatedRemoteProject host (ProjectAndBranch projectName _) ->
+    pure . P.wrap $
+      "I just created"
+        <> prettyProjectName projectName
+        <> "on"
+        <> prettyURI host
+  CreatedRemoteProjectBranch host projectAndBranch ->
+    pure . P.wrap $
+      "I just created" <> prettyProjectAndBranchName projectAndBranch <> "on" <> prettyURI host
+  RemoteProjectBranchIsUpToDate host projectAndBranch ->
+    pure (P.wrap (prettyProjectAndBranchName projectAndBranch <> "on" <> prettyURI host <> "is already up-to-date."))
   InvalidProjectName name -> pure (P.wrap (P.text name <> "is not a valid project name."))
   InvalidProjectBranchName name -> pure (P.wrap (P.text name <> "is not a valid branch name."))
   RefusedToCreateProjectBranch projectAndBranch ->

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1924,6 +1924,8 @@ notifyUser dir = \case
           <> P.newline
           <> P.indentN 2 (P.pshown response)
   MarkdownOut md -> pure $ P.text md
+  DownloadedEntities n -> pure (P.wrap ("Downloaded" <> P.num n <> "entities."))
+  UploadedEntities n -> pure (P.wrap ("Uploaded" <> P.num n <> "entities."))
   NotImplementedYet message -> pure (P.wrap ("Not implemented:" <> P.text message))
   where
     _nameChange _cmd _pastTenseCmd _oldName _newName _r = error "todo"


### PR DESCRIPTION
## Overview

- Fixed parsing of paths like `mitchell.public.whatever` in `push`
- Added output messages for when a remote project/branch is created
- Turned "Uploaded/Downloaded X entities" messages into a proper Output message, so they don't end without a newline
- Added output message for when we push to a remote branch that's already up-to-date
- Made a couple output messages that handle failures (like missing user on Share) more accurate