### PR TITLE
Add `projects` command to list projects

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -2823,7 +2823,6 @@ loadAllProjects =
       FROM project
     |]
 
-
 -- | Insert a `project` row.
 insertProject :: ProjectId -> ProjectName -> Transaction ()
 insertProject uuid name = execute bonk (uuid, name)

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -2821,6 +2821,7 @@ loadAllProjects =
     [sql|
       SELECT id, name
       FROM project
+      ORDER BY name ASC
     |]
 
 -- | Insert a `project` row.

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -105,6 +105,7 @@ module U.Codebase.Sqlite.Queries
     loadProject,
     loadProjectByName,
     expectProject,
+    loadAllProjects,
     insertProject,
 
     -- ** project branches
@@ -2812,6 +2813,16 @@ loadProjectByName name =
         name = ?
     |]
     (Only name)
+
+-- | Load all projects.
+loadAllProjects :: Transaction [Project]
+loadAllProjects =
+  queryListRow_
+    [sql|
+      SELECT id, name
+      FROM project
+    |]
+
 
 -- | Insert a `project` row.
 insertProject :: ProjectId -> ProjectName -> Transaction ()

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -82,7 +82,7 @@ import Unison.Codebase.Editor.HandleInput.NamespaceDiffUtils (diffHelper)
 import Unison.Codebase.Editor.HandleInput.ProjectClone (projectClone)
 import Unison.Codebase.Editor.HandleInput.ProjectCreate (projectCreate)
 import Unison.Codebase.Editor.HandleInput.ProjectSwitch (projectSwitch)
-import qualified Unison.Codebase.Editor.HandleInput.Projects as HandleInput.Projects
+import Unison.Codebase.Editor.HandleInput.Projects (handleProjects)
 import Unison.Codebase.Editor.HandleInput.Pull (doPullRemoteBranch, mergeBranchAndPropagateDefaultPatch, propagatePatch)
 import Unison.Codebase.Editor.HandleInput.Push (handleGist, handlePushRemoteBranch)
 import Unison.Codebase.Editor.HandleInput.TermResolution
@@ -1355,7 +1355,7 @@ loop e = do
             ProjectSwitchI name -> projectSwitch name
             ProjectCloneI name -> projectClone name
             ProjectCreateI name -> projectCreate name
-            ProjectsI -> HandleInput.Projects.projects
+            ProjectsI -> handleProjects
 
 magicMainWatcherString :: String
 magicMainWatcherString = "main"

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -82,6 +82,7 @@ import Unison.Codebase.Editor.HandleInput.NamespaceDiffUtils (diffHelper)
 import Unison.Codebase.Editor.HandleInput.ProjectClone (projectClone)
 import Unison.Codebase.Editor.HandleInput.ProjectCreate (projectCreate)
 import Unison.Codebase.Editor.HandleInput.ProjectSwitch (projectSwitch)
+import qualified Unison.Codebase.Editor.HandleInput.Projects as HandleInput.Projects
 import Unison.Codebase.Editor.HandleInput.Pull (doPullRemoteBranch, mergeBranchAndPropagateDefaultPatch, propagatePatch)
 import Unison.Codebase.Editor.HandleInput.Push (handleGist, handlePushRemoteBranch)
 import Unison.Codebase.Editor.HandleInput.TermResolution
@@ -1354,6 +1355,7 @@ loop e = do
             ProjectSwitchI name -> projectSwitch name
             ProjectCloneI name -> projectClone name
             ProjectCreateI name -> projectCreate name
+            ProjectsI -> HandleInput.Projects.projects
 
 magicMainWatcherString :: String
 magicMainWatcherString = "main"
@@ -1565,6 +1567,7 @@ inputDescription input =
     PreviewAddI {} -> wat
     PreviewMergeLocalBranchI {} -> wat
     PreviewUpdateI {} -> wat
+    ProjectsI -> wat
     PushRemoteBranchI {} -> wat
     QuitI {} -> wat
     ShowDefinitionByPrefixI {} -> wat

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Projects.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Projects.hs
@@ -1,0 +1,11 @@
+-- | @projects@ input handler
+module Unison.Codebase.Editor.HandleInput.Projects
+  ( projects,
+  )
+where
+
+import Unison.Cli.Monad (Cli)
+
+projects :: Cli ()
+projects = do
+  pure ()

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Projects.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Projects.hs
@@ -1,11 +1,15 @@
 -- | @projects@ input handler
 module Unison.Codebase.Editor.HandleInput.Projects
-  ( projects,
+  ( handleProjects,
   )
 where
 
+import qualified U.Codebase.Sqlite.Queries as Queries
 import Unison.Cli.Monad (Cli)
+import qualified Unison.Cli.Monad as Cli
+import qualified Unison.Codebase.Editor.Output as Output
 
-projects :: Cli ()
-projects = do
-  pure ()
+handleProjects :: Cli ()
+handleProjects = do
+  projects <- Cli.runTransaction Queries.loadAllProjects
+  Cli.respondNumbered (Output.ListProjects projects)

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -223,6 +223,7 @@ data Input
   | ProjectCloneI (These ProjectName ProjectBranchName)
   | ProjectCreateI ProjectName
   | ProjectSwitchI (These ProjectName ProjectBranchName)
+  | ProjectsI
   deriving (Eq, Show)
 
 data DiffNamespaceToPatchInput = DiffNamespaceToPatchInput

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -113,6 +113,7 @@ data NumberedOutput
       [(CausalHash, Names.Diff)]
       HistoryTail -- 'origin point' of this view of history.
   | ListEdits Patch PPE.PrettyPrintEnv
+  | ListProjects [Sqlite.Project]
 
 --  | ShowDiff
 
@@ -537,3 +538,4 @@ isNumberedFailure = \case
   History {} -> False
   DeletedDespiteDependents {} -> False
   ListEdits {} -> False
+  ListProjects {} -> False

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2388,6 +2388,17 @@ projectSwitch =
         _ -> Left (showPatternHelp projectSwitch)
     }
 
+projects :: InputPattern
+projects =
+  InputPattern
+    { patternName = "projects",
+      aliases = [],
+      visibility = I.Hidden,
+      argTypes = [],
+      help = P.wrap "List projects.",
+      parse = \_ -> Right Input.ProjectsI
+    }
+
 validInputs :: [InputPattern]
 validInputs =
   sortOn

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2511,7 +2511,8 @@ validInputs =
       diffNamespaceToPatch,
       projectClone,
       projectCreate,
-      projectSwitch
+      projectSwitch,
+      projects
     ]
 
 -- | A map of all command patterns by pattern name or alias.

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -191,7 +191,7 @@ renderFileName :: FilePath -> IO Pretty
 renderFileName dir = P.group . P.blue . fromString <$> shortenDirectory dir
 
 notifyNumbered :: NumberedOutput -> (Pretty, NumberedArgs)
-notifyNumbered o = case o of
+notifyNumbered = \case
   ShowDiffNamespace oldPrefix newPrefix ppe diffOutput ->
     showDiffNamespace ShowNumbers ppe oldPrefix newPrefix diffOutput
   ShowDiffAfterDeleteDefinitions ppe diff ->
@@ -450,6 +450,10 @@ notifyNumbered o = case o of
       numberedArgsForEndangerments ppeDecl endangerments
     )
   ListEdits patch ppe -> showListEdits patch ppe
+  ListProjects projects ->
+    ( P.numberedList (map (prettyProjectName . view #name) projects),
+      map (Text.unpack . into @Text . view #name) projects
+    )
   where
     absPathToBranchId = Right
 

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -51,6 +51,7 @@ library
       Unison.Codebase.Editor.HandleInput.NamespaceDiffUtils
       Unison.Codebase.Editor.HandleInput.ProjectClone
       Unison.Codebase.Editor.HandleInput.ProjectCreate
+      Unison.Codebase.Editor.HandleInput.Projects
       Unison.Codebase.Editor.HandleInput.ProjectSwitch
       Unison.Codebase.Editor.HandleInput.Pull
       Unison.Codebase.Editor.HandleInput.Push


### PR DESCRIPTION
## Overview

This PR adds a simple `projects` command that displays all local projects in a numbered list.

![Screenshot from 2023-04-03 12-19-41](https://user-images.githubusercontent.com/1074598/229568982-4eb21a52-e0c4-4539-99b5-26e29cab86ff.png)
