### PR TITLE
Fix example.com tests in tls-tests and tcp-tests, and disable until scheme generate escapes \r

### DIFF
--- a/unison-src/builtin-tests/interpreter-tests.sh
+++ b/unison-src/builtin-tests/interpreter-tests.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-#set -ex
+set -ex
 
 ucm=$(stack exec -- which unison)
+echo $ucm
 
 base_codebase=${XDG_CACHE_HOME:-"$HOME/.cache"}/unisonlanguage/base.unison
 
 if [ ! -d $base_codebase ]; then
+    echo !!!! Creating a codebase in $base_codebase
     $ucm transcript -S $base_codebase unison-src/builtin-tests/base.md
 fi
 
@@ -15,5 +17,6 @@ echo $dir
 mkdir -p $dir
 cp -r scheme-libs/* $dir/
 
+echo $ucm transcript.fork -c $base_codebase unison-src/builtin-tests/interpreter-tests.md
 time $ucm transcript.fork -c $base_codebase unison-src/builtin-tests/interpreter-tests.md
 

--- a/unison-src/builtin-tests/jit-tests.output.md
+++ b/unison-src/builtin-tests/jit-tests.output.md
@@ -1,26 +1,13 @@
 
 Note: This should be forked off of the codebase created by base.md
 
+If you want to define more complex tests somewhere other than `tests.u`, just `load my-tests.u` then `add`,
+then reference those tests (which should be of type `'{IO,Exception,Tests} ()`, written using calls
+to `Tests.check` and `Tests.checkEqual`).
+
 ```ucm
-.> compile.native.fetch.> compile.native.genlibs.> load unison-src/builtin-tests/testlib.u.> add
+.> run.native tests
+
+  Scheme evaluation failed.
+
 ```
-
-
-🛑
-
-The transcript failed due to an error in the stanza above. The error is:
-
-
-  ❗️
-  
-  The server sent a 502 that we didn't expect.
-  
-  Response body: <html>
-  <head><title>502 Bad Gateway</title></head>
-  <body>
-  <center><h1>502 Bad Gateway</h1></center>
-  <hr><center>nginx/1.22.1</center>
-  </body>
-  </html>
-  
-

--- a/unison-src/builtin-tests/jit-tests.output.md
+++ b/unison-src/builtin-tests/jit-tests.output.md
@@ -1,11 +1,26 @@
 
 Note: This should be forked off of the codebase created by base.md
 
-If you want to define more complex tests somewhere other than `tests.u`, just `load my-tests.u` then `add`,
-then reference those tests (which should be of type `'{IO,Exception,Tests} ()`, written using calls
-to `Tests.check` and `Tests.checkEqual`).
-
 ```ucm
-.> run.native tests
-
+.> compile.native.fetch.> compile.native.genlibs.> load unison-src/builtin-tests/testlib.u.> add
 ```
+
+
+🛑
+
+The transcript failed due to an error in the stanza above. The error is:
+
+
+  ❗️
+  
+  The server sent a 502 that we didn't expect.
+  
+  Response body: <html>
+  <head><title>502 Bad Gateway</title></head>
+  <body>
+  <center><h1>502 Bad Gateway</h1></center>
+  <hr><center>nginx/1.22.1</center>
+  </body>
+  </html>
+  
+

--- a/unison-src/builtin-tests/tcp-tests.u
+++ b/unison-src/builtin-tests/tcp-tests.u
@@ -6,7 +6,7 @@ shouldFail fn =
 tcp.tests = do
   check "connects to example.com" do
     socket = Socket.client (HostName "example.com") (Port "80")
-    Socket.send socket (toUtf8 "GET /index.html HTTP/1.0\r\n\r\n")
+    Socket.send socket (toUtf8 "GET /index.html HTTP/1.0\r\nHost: example.com\r\n\r\n")
     response = Socket.receive socket
     Socket.close socket
     contains "HTTP/1.0 200 OK" (base.Text.fromUtf8 response)

--- a/unison-src/builtin-tests/tcp-tests.u
+++ b/unison-src/builtin-tests/tcp-tests.u
@@ -4,12 +4,8 @@ shouldFail fn =
   isLeft result
 
 tcp.tests = do
-  check "connects to example.com" do
-    socket = Socket.client (HostName "example.com") (Port "80")
-    Socket.send socket (toUtf8 "GET /index.html HTTP/1.0\r\nHost: example.com\r\n\r\n")
-    response = Socket.receive socket
-    Socket.close socket
-    contains "HTTP/1.0 200 OK" (base.Text.fromUtf8 response)
+  -- -- TODO: Enable this once scheme output correctly escapes \r
+  -- check "connects to example.com" tcp.example.com
   check "rejects invalid port" do shouldFail do Socket.client (HostName "example.com") (Port "what")
   check "no send after close" do shouldFail do
     socket = Socket.client (HostName "example.com") (Port "80")
@@ -19,6 +15,13 @@ tcp.tests = do
     match Socket.server None (Port "0") with
         BoundServerSocket socket -> Socket.send socket (toUtf8 "what")
   !testServerAndClient
+
+tcp.example.com = do
+    socket = Socket.client (HostName "example.com") (Port "80")
+    Socket.send socket (toUtf8 "GET /index.html HTTP/1.0\r\nHost: example.com\r\n\r\n")
+    response = Socket.receive socket
+    Socket.close socket
+    contains "HTTP/1.0 200 OK" (base.Text.fromUtf8 response)
 
 testServerAndClient = do
   setup = catchAll do

--- a/unison-src/builtin-tests/tls-tests.u
+++ b/unison-src/builtin-tests/tls-tests.u
@@ -16,7 +16,7 @@ tls.tests = do
     config = ClientConfig.default (HostName "example.com") ""
     tls = base.IO.net.Tls.newClient config socket
     conn = base.IO.net.Tls.handshake tls
-    TlsSocket.send conn (toUtf8 "GET /index.html HTTP/1.0\r\n\r\n")
+    TlsSocket.send conn (toUtf8 "GET /index.html HTTP/1.0\r\nHost: example.com\r\n\r\n")
     response = TlsSocket.receive conn
     TlsSocket.close conn
     contains "HTTP/1.0 200 OK" (fromUtf8 response)

--- a/unison-src/builtin-tests/tls-tests.u
+++ b/unison-src/builtin-tests/tls-tests.u
@@ -11,15 +11,8 @@ tls.tests = do
   check "decoding an invalid cert should fail" do isLeft (decodeCert (toUtf8 "not a cert"))
   !testConnectSelfSigned
   expectError "self signed wrong host" "NameMismatch" testConnectSelfSignedWrongHost
-  check "connects to example.com over tls" do
-    socket = Socket.client (HostName "example.com") (Port "443")
-    config = ClientConfig.default (HostName "example.com") ""
-    tls = base.IO.net.Tls.newClient config socket
-    conn = base.IO.net.Tls.handshake tls
-    TlsSocket.send conn (toUtf8 "GET /index.html HTTP/1.0\r\nHost: example.com\r\n\r\n")
-    response = TlsSocket.receive conn
-    TlsSocket.close conn
-    contains "HTTP/1.0 200 OK" (fromUtf8 response)
+  -- -- TODO: Enable this once scheme output correctly escapes \r
+  -- check "connects to example.com over tls" tls.example.com
   expectError "wrong host example.com fails" "NameMismatch" do
     socket = Socket.client (HostName "example.com") (Port "443")
     config = ClientConfig.default (HostName "examplez.com") ""
@@ -30,6 +23,16 @@ tls.tests = do
     socket = Socket.client (HostName "example.com") (Port "443")
     Socket.send socket (toUtf8 "GET /index.html HTTP/1.0\r\n\r\n")
     Socket.receive socket
+
+tls.example.com = do
+    socket = Socket.client (HostName "example.com") (Port "443")
+    config = ClientConfig.default (HostName "example.com") ""
+    tls = base.IO.net.Tls.newClient config socket
+    conn = base.IO.net.Tls.handshake tls
+    TlsSocket.send conn (toUtf8 "GET /index.html HTTP/1.0\r\nHost: example.com\r\n\r\n")
+    response = TlsSocket.receive conn
+    TlsSocket.close conn
+    contains "HTTP/1.0 200 OK" (fromUtf8 response)
 
 testConnectSelfSigned = do
   portPromise = Promise.new ()


### PR DESCRIPTION
They work under the interpreter, but not yet in the jit because scheme string escaping doesn't handle `\r`