### PR TITLE
Disallow attempting to create a remote project without a user slug

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
@@ -468,6 +468,12 @@ data WhatAreWePushing
 pushToProjectBranch0 :: WhatAreWePushing -> Hash32 -> ProjectAndBranch ProjectName ProjectBranchName -> Cli UploadPlan
 pushToProjectBranch0 pushing localBranchHead remoteProjectAndBranch = do
   let remoteProjectName = remoteProjectAndBranch ^. #project
+
+  -- Assert that this project name has a user slug before bothering to hit Share
+  _ <-
+    projectNameUserSlug remoteProjectName & onNothing do
+      Cli.returnEarly (Output.ProjectNameRequiresUserSlug remoteProjectName)
+
   Share.getProjectByName remoteProjectName >>= \case
     Nothing -> do
       remoteProject <-


### PR DESCRIPTION
## Overview

This PR asserts client-side that we only try to create remote projects with user slugs in their name. Previously, we would hit Share with these requests and get 400s.

## Test coverage

I tested this change manually.
