### PR TITLE
implement `clone /branch` syntax

### DIFF
--- a/unison-cli/src/Unison/Cli/ProjectUtils.hs
+++ b/unison-cli/src/Unison/Cli/ProjectUtils.hs
@@ -20,6 +20,7 @@ module Unison.Cli.ProjectUtils
     expectRemoteProjectByName,
     expectRemoteProjectBranchById,
     expectRemoteProjectBranchByName,
+    expectRemoteProjectBranchByNames,
     expectRemoteProjectBranchByTheseNames,
   )
 where
@@ -163,6 +164,13 @@ expectRemoteProjectBranchByName projectAndBranch =
   where
     doesntExist =
       remoteProjectBranchDoesntExist (projectAndBranch & over #project snd)
+
+expectRemoteProjectBranchByNames ::
+  ProjectAndBranch ProjectName ProjectBranchName ->
+  Cli Share.RemoteProjectBranch
+expectRemoteProjectBranchByNames (ProjectAndBranch projectName branchName) = do
+  project <- expectRemoteProjectByName projectName
+  expectRemoteProjectBranchByName (ProjectAndBranch (project ^. #projectId, project ^. #projectName) branchName)
 
 -- Expect a remote project branch by a "these names".
 --

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectClone.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectClone.hs
@@ -82,7 +82,9 @@ cloneBranch remoteBranchName = do
 
   remoteProjectBranch <-
     case maybeRemoteProjectInfo of
-      Nothing -> undefined
+      Nothing ->
+        ProjectUtils.expectRemoteProjectBranchByNames
+          (ProjectAndBranch (localProjectBranch ^. #project) remoteBranchName)
       Just remoteProjectInfo ->
         ProjectUtils.expectRemoteProjectBranchByName (ProjectAndBranch remoteProjectInfo remoteBranchName)
 
@@ -105,10 +107,8 @@ cloneProjectAndBranch remoteProjectAndBranch = do
   void (Cli.runEitherTransaction (assertLocalProjectBranchDoesntExist localProjectBranch))
 
   -- Get the branch of the given project.
-  remoteProjectBranch <- do
-    project <- ProjectUtils.expectRemoteProjectByName remoteProjectName
-    ProjectUtils.expectRemoteProjectBranchByName
-      (ProjectAndBranch (project ^. #projectId, project ^. #projectName) remoteBranchName)
+  remoteProjectBranch <-
+    ProjectUtils.expectRemoteProjectBranchByNames (ProjectAndBranch (localProjectBranch ^. #project) remoteBranchName)
 
   cloneInto localProjectBranch remoteProjectBranch
 


### PR DESCRIPTION
## Overview

This PR implements `clone /branch` syntax, which clones a branch of the current project.

- If the current branch or any of its ancestors have a remote mapping, then `clone /branch` will clone the branch named `branch` in that project.
- Otherwise, we'll fall back to cloning `branch` in the remote project whose name matches the local project. 

## Test coverage

I tested this change manually