### PR TITLE
Make merge project aware

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -13,6 +13,7 @@ module Unison.Codebase.Editor.Input
     PatchPath,
     BranchId,
     AbsBranchId,
+    LooseCodeOrProject,
     parseBranchId,
     parseShortCausalHash,
     HashOrHQSplit',
@@ -63,6 +64,8 @@ data OptionalPatch = NoPatch | DefaultPatch | UsePatch PatchPath
 
 type BranchId = Either ShortCausalHash Path'
 
+type LooseCodeOrProject = Either Path' (Maybe ProjectName, ProjectBranchName)
+
 type AbsBranchId = Either ShortCausalHash Path.Absolute
 
 type HashOrHQSplit' = Either ShortHash Path.HQSplit'
@@ -95,8 +98,8 @@ data Input
     -- clone w/o merge, error if would clobber
     ForkLocalBranchI (Either ShortCausalHash Path') Path'
   | -- merge first causal into destination
-    MergeLocalBranchI Path' Path' Branch.MergeMode
-  | PreviewMergeLocalBranchI Path' Path'
+    MergeLocalBranchI LooseCodeOrProject LooseCodeOrProject Branch.MergeMode
+  | PreviewMergeLocalBranchI LooseCodeOrProject LooseCodeOrProject
   | DiffNamespaceI BranchId BranchId -- old new
   | PullRemoteBranchI PullSourceTarget SyncMode PullMode Verbosity
   | PushRemoteBranchI PushRemoteBranchInput

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -91,9 +91,9 @@ data NumberedOutput
   | ShowDiffAfterDeleteDefinitions PPE.PrettyPrintEnv (BranchDiffOutput Symbol Ann)
   | ShowDiffAfterDeleteBranch Path.Absolute PPE.PrettyPrintEnv (BranchDiffOutput Symbol Ann)
   | ShowDiffAfterModifyBranch Path.Path' Path.Absolute PPE.PrettyPrintEnv (BranchDiffOutput Symbol Ann)
-  | ShowDiffAfterMerge Path.Path' Path.Absolute PPE.PrettyPrintEnv (BranchDiffOutput Symbol Ann)
-  | ShowDiffAfterMergePropagate Path.Path' Path.Absolute Path.Path' PPE.PrettyPrintEnv (BranchDiffOutput Symbol Ann)
-  | ShowDiffAfterMergePreview Path.Path' Path.Absolute PPE.PrettyPrintEnv (BranchDiffOutput Symbol Ann)
+  | ShowDiffAfterMerge (Either Path.Path' (ProjectAndBranch ProjectName ProjectBranchName)) Path.Absolute PPE.PrettyPrintEnv (BranchDiffOutput Symbol Ann)
+  | ShowDiffAfterMergePropagate (Either Path.Path' (ProjectAndBranch ProjectName ProjectBranchName)) Path.Absolute Path.Path' PPE.PrettyPrintEnv (BranchDiffOutput Symbol Ann)
+  | ShowDiffAfterMergePreview (Either Path.Path' (ProjectAndBranch ProjectName ProjectBranchName)) Path.Absolute PPE.PrettyPrintEnv (BranchDiffOutput Symbol Ann)
   | ShowDiffAfterPull Path.Path' Path.Absolute PPE.PrettyPrintEnv (BranchDiffOutput Symbol Ann)
   | -- <authorIdentifier> <authorPath> <relativeBase>
     ShowDiffAfterCreateAuthor NameSegment Path.Path' Path.Absolute PPE.PrettyPrintEnv (BranchDiffOutput Symbol Ann)
@@ -260,8 +260,12 @@ data Output
       (PullTarget (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch))
   | -- | Indicates a trivial merge where the destination was empty and was just replaced.
     MergeOverEmpty (PullTarget (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch))
-  | MergeAlreadyUpToDate Path' Path'
-  | PreviewMergeAlreadyUpToDate Path' Path'
+  | MergeAlreadyUpToDate
+      (Either Path.Path' (ProjectAndBranch ProjectName ProjectBranchName))
+      (Either Path.Path' (ProjectAndBranch ProjectName ProjectBranchName))
+  | PreviewMergeAlreadyUpToDate
+      (Either Path.Path' (ProjectAndBranch ProjectName ProjectBranchName))
+      (Either Path.Path' (ProjectAndBranch ProjectName ProjectBranchName))
   | -- | No conflicts or edits remain for the current patch.
     NoConflictsOrEdits
   | NotImplemented

--- a/unison-cli/src/Unison/Codebase/TranscriptParser.hs
+++ b/unison-cli/src/Unison/Codebase/TranscriptParser.hs
@@ -332,18 +332,18 @@ run dir stanzas codebase runtime sbRuntime config ucmVersion baseURL = UnliftIO.
                     UcmContextLooseCode path ->
                       if curPath == path
                         then pure Nothing
-                        else do
-                          atomically $ Q.undequeue cmdQueue (Just p)
-                          pure $ Just (SwitchBranchI $ Just (Path.absoluteToPath' path))
+                        else pure $ Just (SwitchBranchI $ Just (Path.absoluteToPath' path))
                     UcmContextProject (ProjectAndBranch projectName branchName) -> do
                       ProjectAndBranch project branch <-
                         ProjectUtils.expectProjectAndBranchByTheseNames (These projectName branchName)
                       let projectAndBranchIds = ProjectAndBranch (project ^. #projectId) (branch ^. #branchId)
                       if curPath == ProjectUtils.projectBranchPath projectAndBranchIds
                         then pure Nothing
-                        else undefined
+                        else pure (Just (ProjectSwitchI (These projectName branchName)))
                 case maybeSwitchCommand of
-                  Just switchCommand -> pure (Right switchCommand)
+                  Just switchCommand -> do
+                    atomically $ Q.undequeue cmdQueue (Just p)
+                    pure (Right switchCommand)
                   Nothing -> do
                     case words . Text.unpack $ lineTxt of
                       [] -> awaitInput

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -11,7 +11,7 @@ import qualified Data.Map as Map
 import Data.Proxy (Proxy (..))
 import qualified Data.Set as Set
 import qualified Data.Text as Text
-import Data.These (These)
+import Data.These (These (..))
 import System.Console.Haskeline.Completion (Completion (Completion))
 import qualified Text.Megaparsec as P
 import qualified Unison.Codebase as Codebase
@@ -1322,8 +1322,8 @@ squashMerge =
     )
     ( \case
         [src, dest] -> first fromString $ do
-          src <- Path.parsePath' src
-          dest <- Path.parsePath' dest
+          src <- parseLooseCodeOrProject src
+          dest <- parseLooseCodeOrProject dest
           pure $ Input.MergeLocalBranchI src dest Branch.SquashMerge
         _ -> Left (I.help squashMerge)
     )
@@ -1343,15 +1343,25 @@ mergeLocal =
         ]
     )
     ( \case
-        [src] -> first fromString $ do
-          src <- Path.parsePath' src
-          pure $ Input.MergeLocalBranchI src Path.relativeEmpty' Branch.RegularMerge
+        [src] -> first fromString do
+          src <- parseLooseCodeOrProject src
+          pure $ Input.MergeLocalBranchI src (Left Path.relativeEmpty') Branch.RegularMerge
         [src, dest] -> first fromString $ do
-          src <- Path.parsePath' src
-          dest <- Path.parsePath' dest
+          src <- parseLooseCodeOrProject src
+          dest <- parseLooseCodeOrProject dest
           pure $ Input.MergeLocalBranchI src dest Branch.RegularMerge
         _ -> Left (I.help mergeLocal)
     )
+
+parseLooseCodeOrProject :: String -> Either String Input.LooseCodeOrProject
+parseLooseCodeOrProject inputString =
+  case tryInto @(These ProjectName ProjectBranchName) (Text.pack inputString) of
+    Right (That branchName) -> Right (Right (Nothing, branchName))
+    Right (These projectName branchName) -> Right (Right (Just projectName, branchName))
+    _ ->
+      case Path.parsePath' inputString of
+        Left _ -> Left ("Failed to parse " ++ inputString ++ " as a project name or namespace path")
+        Right path -> Right (Left path)
 
 diffNamespace :: InputPattern
 diffNamespace =
@@ -1400,11 +1410,11 @@ previewMergeLocal =
     )
     ( \case
         [src] -> first fromString $ do
-          src <- Path.parsePath' src
-          pure $ Input.PreviewMergeLocalBranchI src Path.relativeEmpty'
+          src <- parseLooseCodeOrProject src
+          pure $ Input.PreviewMergeLocalBranchI src (Left Path.relativeEmpty')
         [src, dest] -> first fromString $ do
-          src <- Path.parsePath' src
-          dest <- Path.parsePath' dest
+          src <- parseLooseCodeOrProject src
+          dest <- parseLooseCodeOrProject dest
           pure $ Input.PreviewMergeLocalBranchI src dest
         _ -> Left (I.help previewMergeLocal)
     )

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -235,7 +235,7 @@ notifyNumbered = \case
     first
       ( \p ->
           P.lines
-            [ P.wrap $ "Here's what's changed in " <> prettyPath' dest' <> "after the merge:",
+            [ P.wrap $ "Here's what's changed in " <> prettyPathOrProjectAndBranchName dest' <> "after the merge:",
               "",
               p,
               "",
@@ -260,7 +260,7 @@ notifyNumbered = \case
           P.lines
             [ P.wrap $
                 "Here's what's changed in "
-                  <> prettyPath' dest'
+                  <> prettyPathOrProjectAndBranchName dest'
                   <> "after applying the patch at "
                   <> P.group (prettyPath' patchPath' <> ":"),
               "",
@@ -268,7 +268,7 @@ notifyNumbered = \case
               "",
               tip $
                 "You can use "
-                  <> IP.makeExample IP.todo [prettyPath' patchPath', prettyPath' dest']
+                  <> IP.makeExample IP.todo [prettyPath' patchPath', prettyPathOrProjectAndBranchName dest']
                   <> "to see if this generated any work to do in this namespace"
                   <> "and "
                   <> IP.makeExample' IP.test
@@ -285,7 +285,7 @@ notifyNumbered = \case
     first
       ( \p ->
           P.lines
-            [ P.wrap $ "Here's what would change in " <> prettyPath' dest' <> "after the merge:",
+            [ P.wrap $ "Here's what would change in " <> prettyPathOrProjectAndBranchName dest' <> "after the merge:",
               "",
               p
             ]
@@ -1587,15 +1587,15 @@ notifyUser dir = \case
   MergeAlreadyUpToDate src dest ->
     pure . P.callout "😶" $
       P.wrap $
-        prettyPath' dest
+        prettyPathOrProjectAndBranchName dest
           <> "was already up-to-date with"
-          <> P.group (prettyPath' src <> ".")
+          <> P.group (prettyPathOrProjectAndBranchName src <> ".")
   PreviewMergeAlreadyUpToDate src dest ->
     pure . P.callout "😶" $
       P.wrap $
-        prettyPath' dest
+        prettyPathOrProjectAndBranchName dest
           <> "is already up-to-date with"
-          <> P.group (prettyPath' src <> ".")
+          <> P.group (prettyPathOrProjectAndBranchName src <> ".")
   DumpNumberedArgs args -> pure . P.numberedList $ fmap P.string args
   NoConflictsOrEdits ->
     pure (P.okCallout "No conflicts or edits in progress.")
@@ -2243,6 +2243,11 @@ prettyProjectBranchName =
 prettyProjectAndBranchName :: ProjectAndBranch ProjectName ProjectBranchName -> Pretty
 prettyProjectAndBranchName (ProjectAndBranch projectName branchName) =
   P.blue (P.text (into @Text (These projectName branchName)))
+
+prettyPathOrProjectAndBranchName :: Either Path.Path' (ProjectAndBranch ProjectName ProjectBranchName) -> Pretty
+prettyPathOrProjectAndBranchName = \case
+  Left x -> prettyPath' x
+  Right x -> prettyProjectAndBranchName x
 
 formatMissingStuff ::
   (Show tm, Show typ) =>

--- a/unison-src/transcripts/project-merge.md
+++ b/unison-src/transcripts/project-merge.md
@@ -1,0 +1,39 @@
+# projects merge
+
+```ucm
+.> builtins.merge
+```
+
+```unison
+zonk = 0
+```
+
+```ucm
+.foo> add
+.> project.create foo
+.> merge foo foo/main
+```
+
+```unison
+bonk = 2
+```
+
+```ucm
+foo/main> add
+```
+
+```ucm
+.> project.create bar
+bar/main> merge foo/main
+bar/main> switch /topic
+```
+
+```unison
+xonk = 1
+```
+
+```ucm
+bar/main> add
+bar/topic> merge /main
+.bar> merge foo/main
+```

--- a/unison-src/transcripts/project-merge.output.md
+++ b/unison-src/transcripts/project-merge.output.md
@@ -1,0 +1,152 @@
+# projects merge
+
+```ucm
+.> builtins.merge
+
+  Done.
+
+```
+```unison
+zonk = 0
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      zonk : Nat
+
+```
+```ucm
+  ☝️  The namespace .foo is empty.
+
+.foo> add
+
+  ⍟ I've added these definitions:
+  
+    zonk : Nat
+
+.> project.create foo
+
+  I just created project foo with branch main
+
+.> merge foo foo/main
+
+  Here's what's changed in foo/main after the merge:
+  
+  Added definitions:
+  
+    1. zonk : Nat
+  
+  Tip: You can use `todo` to see if this generated any work to
+       do in this namespace and `test` to run the tests. Or you
+       can use `undo` or `reflog` to undo the results of this
+       merge.
+
+```
+```unison
+bonk = 2
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bonk : Nat
+
+```
+```ucm
+foo/main> add
+
+  ⍟ I've added these definitions:
+  
+    bonk : Nat
+
+```
+```ucm
+.> project.create bar
+
+  I just created project bar with branch main
+
+bar/main> merge foo/main
+
+  Here's what's changed in the current namespace after the
+  merge:
+  
+  Added definitions:
+  
+    1. bonk : Nat
+    2. zonk : Nat
+  
+  Tip: You can use `todo` to see if this generated any work to
+       do in this namespace and `test` to run the tests. Or you
+       can use `undo` or `reflog` to undo the results of this
+       merge.
+
+bar/main> switch /topic
+
+  I just created branch topic from branch main
+
+```
+```unison
+xonk = 1
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      xonk : Nat
+
+```
+```ucm
+bar/main> add
+
+  ⍟ I've added these definitions:
+  
+    xonk : Nat
+
+bar/topic> merge /main
+
+  Here's what's changed in the current namespace after the
+  merge:
+  
+  Added definitions:
+  
+    1. xonk : Nat
+  
+  Tip: You can use `todo` to see if this generated any work to
+       do in this namespace and `test` to run the tests. Or you
+       can use `undo` or `reflog` to undo the results of this
+       merge.
+
+  ☝️  The namespace .bar is empty.
+
+.bar> merge foo/main
+
+  Here's what's changed in the current namespace after the
+  merge:
+  
+  Added definitions:
+  
+    1. bonk : Nat
+    2. zonk : Nat
+  
+  Tip: You can use `todo` to see if this generated any work to
+       do in this namespace and `test` to run the tests. Or you
+       can use `undo` or `reflog` to undo the results of this
+       merge.
+
+```


### PR DESCRIPTION
## Overview

Make merge project aware. Does not accept project shorthand (e.g. `foo` parses as `foo/main`) as that conflicts with the only syntax for relative namespaces.

## Test coverage

See `unison-src/transcripts/project-merge.md`
