### PR TITLE
Add `branch` command that creates a branch

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -73,6 +73,7 @@ import Unison.Codebase.Editor.AuthorInfo (AuthorInfo (..))
 import qualified Unison.Codebase.Editor.AuthorInfo as AuthorInfo
 import Unison.Codebase.Editor.DisplayObject
 import Unison.Codebase.Editor.HandleInput.AuthLogin (authLogin)
+import Unison.Codebase.Editor.HandleInput.BranchFork (handleBranchFork)
 import Unison.Codebase.Editor.HandleInput.Branches (handleBranches)
 import Unison.Codebase.Editor.HandleInput.DeleteBranch (handleDeleteBranch)
 import Unison.Codebase.Editor.HandleInput.MetadataUtils (addDefaultMetadata, manageLinks)
@@ -1354,6 +1355,7 @@ loop e = do
             ProjectCreateI name -> projectCreate name
             ProjectsI -> handleProjects
             BranchesI -> handleBranches
+            BranchForkI name -> handleBranchFork name
 
 magicMainWatcherString :: String
 magicMainWatcherString = "main"
@@ -1524,6 +1526,7 @@ inputDescription input =
     --
     ApiI -> wat
     AuthLoginI {} -> wat
+    BranchForkI {} -> wat
     ClearI {} -> pure "clear"
     CreateMessage {} -> wat
     DebugClearWatchI {} -> wat

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -73,7 +73,7 @@ import Unison.Codebase.Editor.AuthorInfo (AuthorInfo (..))
 import qualified Unison.Codebase.Editor.AuthorInfo as AuthorInfo
 import Unison.Codebase.Editor.DisplayObject
 import Unison.Codebase.Editor.HandleInput.AuthLogin (authLogin)
-import Unison.Codebase.Editor.HandleInput.BranchFork (handleBranchFork)
+import Unison.Codebase.Editor.HandleInput.Branch (handleBranch)
 import Unison.Codebase.Editor.HandleInput.Branches (handleBranches)
 import Unison.Codebase.Editor.HandleInput.DeleteBranch (handleDeleteBranch)
 import Unison.Codebase.Editor.HandleInput.MetadataUtils (addDefaultMetadata, manageLinks)
@@ -1355,7 +1355,7 @@ loop e = do
             ProjectCreateI name -> projectCreate name
             ProjectsI -> handleProjects
             BranchesI -> handleBranches
-            BranchForkI name -> handleBranchFork name
+            BranchI name -> handleBranch name
 
 magicMainWatcherString :: String
 magicMainWatcherString = "main"
@@ -1526,7 +1526,7 @@ inputDescription input =
     --
     ApiI -> wat
     AuthLoginI {} -> wat
-    BranchForkI {} -> wat
+    BranchI {} -> wat
     ClearI {} -> pure "clear"
     CreateMessage {} -> wat
     DebugClearWatchI {} -> wat

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Branch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Branch.hs
@@ -1,6 +1,6 @@
--- | @branch.fork@ input handler
-module Unison.Codebase.Editor.HandleInput.BranchFork
-  ( handleBranchFork,
+-- | @branch@ input handler
+module Unison.Codebase.Editor.HandleInput.Branch
+  ( handleBranch,
   )
 where
 
@@ -19,9 +19,9 @@ import Unison.Prelude
 import Unison.Project (ProjectAndBranch (..), ProjectBranchName, ProjectName)
 import qualified Unison.Sqlite as Sqlite
 
--- | Fork a new project branch from an existing project branch or namespace.
-handleBranchFork :: These ProjectName ProjectBranchName -> Cli ()
-handleBranchFork projectAndBranchNames0 = do
+-- | Create a new project branch from an existing project branch or namespace.
+handleBranch :: These ProjectName ProjectBranchName -> Cli ()
+handleBranch projectAndBranchNames0 = do
   projectAndBranchNames@(ProjectAndBranch projectName newBranchName) <- ProjectUtils.hydrateNames projectAndBranchNames0
 
   maybeCurrentProject <- ProjectUtils.getCurrentProjectBranch

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Branch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Branch.hs
@@ -86,5 +86,5 @@ handleBranch projectAndBranchNames0 = do
       CreatedFrom'OtherBranch otherBranch -> pure (Output.CreatedProjectBranchFrom'OtherBranch otherBranch)
       CreatedFrom'ParentBranch parentBranch ->
         pure (Output.CreatedProjectBranchFrom'ParentBranch (parentBranch ^. #name))
-  Cli.respond (Output.CreatedProjectBranch createdFrom1 newBranchName)
+  Cli.respond (Output.CreatedProjectBranch createdFrom1 projectAndBranchNames)
   Cli.cd path

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/BranchFork.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/BranchFork.hs
@@ -1,0 +1,63 @@
+-- | @branch.fork@ input handler
+module Unison.Codebase.Editor.HandleInput.BranchFork
+  ( handleBranchFork,
+  )
+where
+
+import Control.Lens (view, (^.))
+import Data.These (These (..))
+import qualified Data.UUID.V4 as UUID
+import U.Codebase.Sqlite.DbId
+import qualified U.Codebase.Sqlite.ProjectBranch as Sqlite
+import qualified U.Codebase.Sqlite.Queries as Queries
+import Unison.Cli.Monad (Cli)
+import qualified Unison.Cli.Monad as Cli
+import qualified Unison.Cli.MonadUtils as Cli (getCurrentBranch, updateAt)
+import qualified Unison.Cli.ProjectUtils as ProjectUtils
+import qualified Unison.Codebase.Editor.Output as Output
+import Unison.Prelude
+import Unison.Project (ProjectAndBranch (..), ProjectBranchName, ProjectName)
+import qualified Unison.Sqlite as Sqlite
+
+-- | Fork a new project branch from an existing project branch or namespace.
+handleBranchFork :: These ProjectName ProjectBranchName -> Cli ()
+handleBranchFork projectAndBranchNames0 = do
+  projectAndBranchNames@(ProjectAndBranch projectName newBranchName) <- ProjectUtils.hydrateNames projectAndBranchNames0
+
+  maybeCurrentProject <- ProjectUtils.getCurrentProjectBranch
+
+  (projectId, newBranchId) <-
+    Cli.runEitherTransaction do
+      Queries.loadProjectByName projectName >>= \case
+        Nothing -> pure (Left (Output.LocalProjectBranchDoesntExist projectAndBranchNames))
+        Just project -> do
+          let projectId = project ^. #projectId
+          Queries.projectBranchExistsByName projectId newBranchName >>= \case
+            True -> pure (Left (Output.ProjectAndBranchNameAlreadyExists projectAndBranchNames))
+            False ->
+              -- Here, we are forking to `foo/bar`, where project `foo` does exist, and it does not have a branch named
+              -- `bar`, so the fork will succeed.
+              --
+              -- If we are currently on a different branch of `foo`, we record the current branch as the parent of
+              -- `bar`.
+              fmap Right do
+                newBranchId <- Sqlite.unsafeIO (ProjectBranchId <$> UUID.nextRandom)
+                let parentBranch = do
+                      ProjectAndBranch currentProject currentBranch <- maybeCurrentProject
+                      guard (projectId == currentProject ^. #projectId)
+                      Just currentBranch
+                Queries.insertProjectBranch
+                  Sqlite.ProjectBranch
+                    { projectId,
+                      branchId = newBranchId,
+                      name = newBranchName,
+                      parentBranchId = view #branchId <$> parentBranch
+                    }
+                pure (projectId, newBranchId)
+
+  let path = ProjectUtils.projectBranchPath (ProjectAndBranch projectId newBranchId)
+  currentNamespaceObject <- Cli.getCurrentBranch
+  let description = "branch.fork " <> into @Text (These projectName newBranchName)
+  _ <- Cli.updateAt description path (const currentNamespaceObject)
+  Cli.respond (Output.CreatedProjectBranch Nothing newBranchName)
+  Cli.cd path

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectSwitch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectSwitch.hs
@@ -60,7 +60,14 @@ projectSwitch projectAndBranchNames0 = do
       fromBranchObject <-
         case maybeFromBranch of
           Nothing -> pure Branch.empty
-          Just fromBranch -> Cli.getBranchAt (ProjectUtils.projectBranchPath (ProjectAndBranch projectId (fromBranch ^. #branchId)))
+          Just fromBranch ->
+            Cli.getBranchAt (ProjectUtils.projectBranchPath (ProjectAndBranch projectId (fromBranch ^. #branchId)))
       _ <- Cli.updateAt "project.switch" path (const fromBranchObject)
-      Cli.respond (Output.CreatedProjectBranch (view #name <$> maybeFromBranch) branchName)
+      Cli.respond $
+        Output.CreatedProjectBranch
+          ( case maybeFromBranch of
+              Nothing -> Output.CreatedProjectBranchFrom'Nothingness
+              Just fromBranch -> Output.CreatedProjectBranchFrom'ParentBranch (fromBranch ^. #name)
+          )
+          branchName
   Cli.cd path

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectSwitch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectSwitch.hs
@@ -69,5 +69,5 @@ projectSwitch projectAndBranchNames0 = do
               Nothing -> Output.CreatedProjectBranchFrom'Nothingness
               Just fromBranch -> Output.CreatedProjectBranchFrom'ParentBranch (fromBranch ^. #name)
           )
-          branchName
+          projectAndBranchNames
   Cli.cd path

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -218,7 +218,7 @@ data Input
   | ProjectSwitchI (These ProjectName ProjectBranchName)
   | ProjectsI
   | BranchesI
-  | BranchForkI (These ProjectName ProjectBranchName)
+  | BranchI (These ProjectName ProjectBranchName)
   deriving (Eq, Show)
 
 data DiffNamespaceToPatchInput = DiffNamespaceToPatchInput

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -44,7 +44,7 @@ import qualified Unison.HashQualified as HQ
 import Unison.Name (Name)
 import Unison.NameSegment (NameSegment)
 import Unison.Prelude
-import Unison.Project (ProjectBranchName, ProjectName)
+import Unison.Project (ProjectAndBranch, ProjectBranchName, ProjectName)
 import Unison.ShortHash (ShortHash)
 import qualified Unison.Util.Pretty as P
 
@@ -218,7 +218,7 @@ data Input
   | ProjectSwitchI (These ProjectName ProjectBranchName)
   | ProjectsI
   | BranchesI
-  | BranchI (These ProjectName ProjectBranchName)
+  | BranchI (ProjectAndBranch (Maybe ProjectName) ProjectBranchName)
   deriving (Eq, Show)
 
 data DiffNamespaceToPatchInput = DiffNamespaceToPatchInput

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -218,6 +218,7 @@ data Input
   | ProjectSwitchI (These ProjectName ProjectBranchName)
   | ProjectsI
   | BranchesI
+  | BranchForkI (These ProjectName ProjectBranchName)
   deriving (Eq, Show)
 
 data DiffNamespaceToPatchInput = DiffNamespaceToPatchInput

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -1,5 +1,6 @@
 module Unison.Codebase.Editor.Output
   ( Output (..),
+    CreatedProjectBranchFrom (..),
     DisplayDefinitionsOutput (..),
     WhichBranchEmpty (..),
     NumberedOutput (..),
@@ -298,7 +299,7 @@ data Output
   | ClearScreen
   | PulledEmptyBranch (ReadRemoteNamespace Share.RemoteProjectBranch)
   | CreatedProject ProjectName ProjectBranchName
-  | CreatedProjectBranch (Maybe ProjectBranchName) ProjectBranchName -- parent, child
+  | CreatedProjectBranch CreatedProjectBranchFrom ProjectBranchName -- parent, child
   | CreatedRemoteProject URI (ProjectAndBranch ProjectName ProjectBranchName)
   | CreatedRemoteProjectBranch URI (ProjectAndBranch ProjectName ProjectBranchName)
   | -- We didn't push anything because the remote server is already in the state we want it to be
@@ -326,6 +327,18 @@ data Output
   | UploadedEntities Int
   | -- A generic "not implemented" message, for WIP code that's nonetheless been merged into trunk
     NotImplementedYet Text
+
+-- | What did we create a project branch from?
+--
+--   * Loose code
+--   * Nothingness (we made an empty branch)
+--   * Other branch (in another project)
+--   * Parent branch (in this project)
+data CreatedProjectBranchFrom
+  = CreatedProjectBranchFrom'LooseCode Path.Absolute
+  | CreatedProjectBranchFrom'Nothingness
+  | CreatedProjectBranchFrom'OtherBranch (ProjectAndBranch ProjectName ProjectBranchName)
+  | CreatedProjectBranchFrom'ParentBranch ProjectBranchName
 
 data DisplayDefinitionsOutput = DisplayDefinitionsOutput
   { isTest :: TermReference -> Bool,

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -299,7 +299,7 @@ data Output
   | ClearScreen
   | PulledEmptyBranch (ReadRemoteNamespace Share.RemoteProjectBranch)
   | CreatedProject ProjectName ProjectBranchName
-  | CreatedProjectBranch CreatedProjectBranchFrom ProjectBranchName -- parent, child
+  | CreatedProjectBranch CreatedProjectBranchFrom (ProjectAndBranch ProjectName ProjectBranchName)
   | CreatedRemoteProject URI (ProjectAndBranch ProjectName ProjectBranchName)
   | CreatedRemoteProjectBranch URI (ProjectAndBranch ProjectName ProjectBranchName)
   | -- We didn't push anything because the remote server is already in the state we want it to be

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2364,20 +2364,20 @@ branches =
       parse = \_ -> Right Input.BranchesI
     }
 
-branchFork :: InputPattern
-branchFork =
+branch :: InputPattern
+branch =
   InputPattern
-    { patternName = "branch.fork",
+    { patternName = "branch",
       aliases = [],
       visibility = I.Hidden,
       argTypes = [(Required, projectAndBranchNamesArg)],
-      help = P.wrap "Fork a new branch from an existing branch or namespace.",
+      help = P.wrap "Create a new branch from an existing branch or namespace.",
       parse = \case
         [name] ->
           case tryInto @(These ProjectName ProjectBranchName) (Text.pack name) of
-            Left _ -> Left (showPatternHelp branchFork)
-            Right projectAndBranch -> Right (Input.BranchForkI projectAndBranch)
-        _ -> Left (showPatternHelp branchFork)
+            Left _ -> Left (showPatternHelp branch)
+            Right name -> Right (Input.BranchI name)
+        _ -> Left (showPatternHelp branch)
     }
 
 validInputs :: [InputPattern]
@@ -2391,7 +2391,7 @@ validInputs =
       api,
       authLogin,
       back,
-      branchFork,
+      branch,
       branches,
       cd,
       clear,

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -44,7 +44,7 @@ import qualified Unison.HashQualified as HQ
 import Unison.Name (Name)
 import qualified Unison.NameSegment as NameSegment
 import Unison.Prelude
-import Unison.Project (ProjectBranchName, ProjectName, ProjectAndBranch)
+import Unison.Project (ProjectAndBranch, ProjectBranchName, ProjectName)
 import qualified Unison.Syntax.HashQualified as HQ (fromString)
 import qualified Unison.Syntax.Name as Name (fromText, unsafeFromString)
 import qualified Unison.Util.ColorText as CT

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -44,7 +44,7 @@ import qualified Unison.HashQualified as HQ
 import Unison.Name (Name)
 import qualified Unison.NameSegment as NameSegment
 import Unison.Prelude
-import Unison.Project (ProjectBranchName, ProjectName)
+import Unison.Project (ProjectBranchName, ProjectName, ProjectAndBranch)
 import qualified Unison.Syntax.HashQualified as HQ (fromString)
 import qualified Unison.Syntax.Name as Name (fromText, unsafeFromString)
 import qualified Unison.Util.ColorText as CT
@@ -2374,9 +2374,9 @@ branch =
       help = P.wrap "Create a new branch from an existing branch or namespace.",
       parse = \case
         [name] ->
-          case tryInto @(These ProjectName ProjectBranchName) (Text.pack name) of
+          case tryInto @(ProjectAndBranch (Maybe ProjectName) ProjectBranchName) (Text.pack name) of
             Left _ -> Left (showPatternHelp branch)
-            Right name -> Right (Input.BranchI name)
+            Right projectAndBranch -> Right (Input.BranchI projectAndBranch)
         _ -> Left (showPatternHelp branch)
     }
 

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2364,6 +2364,22 @@ branches =
       parse = \_ -> Right Input.BranchesI
     }
 
+branchFork :: InputPattern
+branchFork =
+  InputPattern
+    { patternName = "branch.fork",
+      aliases = [],
+      visibility = I.Hidden,
+      argTypes = [(Required, projectAndBranchNamesArg)],
+      help = P.wrap "Fork a new branch from an existing branch or namespace.",
+      parse = \case
+        [name] ->
+          case tryInto @(These ProjectName ProjectBranchName) (Text.pack name) of
+            Left _ -> Left (showPatternHelp branchFork)
+            Right projectAndBranch -> Right (Input.BranchForkI projectAndBranch)
+        _ -> Left (showPatternHelp branchFork)
+    }
+
 validInputs :: [InputPattern]
 validInputs =
   sortOn
@@ -2375,6 +2391,7 @@ validInputs =
       api,
       authLogin,
       back,
+      branchFork,
       branches,
       cd,
       clear,

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1829,7 +1829,10 @@ notifyUser dir = \case
     case from of
       CreatedProjectBranchFrom'LooseCode path ->
         pure . P.wrap $
-          "Done. I've created the" <> prettyProjectAndBranchName projectAndBranch <> "branch from the namespace" <> prettyAbsolute path
+          "Done. I've created the"
+            <> prettyProjectAndBranchName projectAndBranch
+            <> "branch from the namespace"
+            <> prettyAbsolute path
       CreatedProjectBranchFrom'Nothingness ->
         pure $
           P.wrap ("Done. I've created an empty branch" <> prettyProjectAndBranchName projectAndBranch)
@@ -1839,7 +1842,9 @@ notifyUser dir = \case
               ( "Use"
                   <> IP.makeExample IP.mergeLocal [prettySlashProjectBranchName (UnsafeProjectBranchName "somebranch")]
                   <> "or"
-                  <> IP.makeExample IP.mergeLocal [prettyAbsolute (Path.Absolute (Path.fromList ["path", "to", "code"]))]
+                  <> IP.makeExample
+                    IP.mergeLocal
+                    [prettyAbsolute (Path.Absolute (Path.fromList ["path", "to", "code"]))]
                   <> "to initialize this branch."
               )
       CreatedProjectBranchFrom'OtherBranch otherProjectAndBranch ->

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2250,8 +2250,7 @@ prettyProjectName =
 
 prettyProjectBranchName :: ProjectBranchName -> Pretty
 prettyProjectBranchName =
-  -- cons '/' because that's the preferred syntax for one (which should be accepted by all commands)
-  P.blue . P.text . Text.cons '/' . into @Text
+  P.blue . P.text . into @Text
 
 prettyProjectAndBranchName :: ProjectAndBranch ProjectName ProjectBranchName -> Pretty
 prettyProjectAndBranchName (ProjectAndBranch projectName branchName) =

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1824,29 +1824,44 @@ notifyUser dir = \case
         <> prettyProjectName projectName
         <> "with branch"
         <> prettyProjectBranchName branchName
-  CreatedProjectBranch from branch ->
+  CreatedProjectBranch from projectAndBranch ->
     case from of
       CreatedProjectBranchFrom'LooseCode path ->
         pure . P.wrap $
-          "This is the message you get when you create"
-            <> prettyProjectBranchName branch
-            <> "from loose code"
-            <> prettyAbsolute path
+          "Done. I've created the" <> prettyProjectAndBranchName projectAndBranch <> "branch from the namespace" <> prettyAbsolute path
       CreatedProjectBranchFrom'Nothingness ->
+        pure $
+          P.wrap ("Done. I've created an empty branch" <> prettyProjectAndBranchName projectAndBranch)
+            <> P.newline
+            <> tip
+              ( "Use"
+                  <> IP.makeExample IP.mergeLocal [wundefined]
+                  <> "or"
+                  <> IP.makeExample IP.mergeLocal [wundefined]
+                  <> "to initialize this branch"
+              )
+      CreatedProjectBranchFrom'OtherBranch otherProjectAndBranch ->
         pure . P.wrap $
-          "This is the message you get when you create" <> prettyProjectBranchName branch <> "from nothingness"
-      CreatedProjectBranchFrom'OtherBranch otherBranch ->
-        pure . P.wrap $
-          "This is the message you get when you create"
-            <> prettyProjectBranchName branch
-            <> "from"
-            <> prettyProjectAndBranchName otherBranch
+          "Done. I've created the"
+            <> prettyProjectAndBranchName projectAndBranch
+            <> "branch based off"
+            <> prettyProjectAndBranchName otherProjectAndBranch
       CreatedProjectBranchFrom'ParentBranch parentBranch ->
-        pure . P.wrap $
-          "This is the message you get when you create"
-            <> prettyProjectBranchName branch
-            <> "from"
-            <> prettyProjectBranchName parentBranch
+        pure $
+          P.wrap
+            ( "Done. I've created the"
+                <> prettyProjectBranchName (projectAndBranch ^. #branch)
+                <> "branch based off of"
+                <> prettyProjectBranchName parentBranch
+            )
+            <> P.newline
+            <> tip
+              ( "Use"
+                  <> IP.makeExample IP.mergeLocal [wundefined]
+                  <> "or"
+                  <> IP.makeExample IP.mergeLocal [wundefined]
+                  <> "to initialize this branch"
+              )
   CreatedRemoteProject host (ProjectAndBranch projectName _) ->
     pure . P.wrap $
       "I just created"

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -43,8 +43,8 @@ library
       Unison.Codebase.Editor.AuthorInfo
       Unison.Codebase.Editor.HandleInput
       Unison.Codebase.Editor.HandleInput.AuthLogin
+      Unison.Codebase.Editor.HandleInput.Branch
       Unison.Codebase.Editor.HandleInput.Branches
-      Unison.Codebase.Editor.HandleInput.BranchFork
       Unison.Codebase.Editor.HandleInput.DeleteBranch
       Unison.Codebase.Editor.HandleInput.MetadataUtils
       Unison.Codebase.Editor.HandleInput.MoveBranch

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -44,6 +44,7 @@ library
       Unison.Codebase.Editor.HandleInput
       Unison.Codebase.Editor.HandleInput.AuthLogin
       Unison.Codebase.Editor.HandleInput.Branches
+      Unison.Codebase.Editor.HandleInput.BranchFork
       Unison.Codebase.Editor.HandleInput.DeleteBranch
       Unison.Codebase.Editor.HandleInput.MetadataUtils
       Unison.Codebase.Editor.HandleInput.MoveBranch

--- a/unison-src/transcripts/branch-command.md
+++ b/unison-src/transcripts/branch-command.md
@@ -1,0 +1,43 @@
+The `branch` command creates a new branch.
+
+```ucm:hide
+.> builtins.merge
+.> project.create foo
+.> project.create bar
+```
+
+First, we'll just create a loose code namespace with a term in it for later.
+
+```unison:hide
+someterm = 18
+```
+
+```ucm
+.some.loose.code> add
+```
+
+Now, the `branch` demo:
+
+`branch` can create a branch from a different branch in the same project.
+
+```ucm
+foo/main> branch topic
+```
+
+`branch` can create a branch from a different branch in a different project.
+
+```ucm
+foo/main> branch bar/topic
+```
+
+`branch` can create a branch from loose code.
+
+```ucm
+.some.loose.code> branch foo/topic2
+```
+
+`switch` can create a branch from nothingness, but this feature is going away soon.
+
+```ucm
+.some.loose.code> switch foo/topic3
+```

--- a/unison-src/transcripts/branch-command.output.md
+++ b/unison-src/transcripts/branch-command.output.md
@@ -1,0 +1,59 @@
+The `branch` command creates a new branch.
+
+First, we'll just create a loose code namespace with a term in it for later.
+
+```unison
+someterm = 18
+```
+
+```ucm
+  ☝️  The namespace .some.loose.code is empty.
+
+.some.loose.code> add
+
+  ⍟ I've added these definitions:
+  
+    someterm : Nat
+
+```
+Now, the `branch` demo:
+
+`branch` can create a branch from a different branch in the same project.
+
+```ucm
+foo/main> branch topic
+
+  Done. I've created the topic branch based off of main
+  
+  Tip: Use `merge /topic /main` to merge your work back into the
+       main branch.
+
+```
+`branch` can create a branch from a different branch in a different project.
+
+```ucm
+foo/main> branch bar/topic
+
+  Done. I've created the bar/topic branch based off foo/main
+
+```
+`branch` can create a branch from loose code.
+
+```ucm
+.some.loose.code> branch foo/topic2
+
+  Done. I've created the foo/topic2 branch from the namespace
+  .some.loose.code
+
+```
+`switch` can create a branch from nothingness, but this feature is going away soon.
+
+```ucm
+.some.loose.code> switch foo/topic3
+
+  Done. I've created an empty branch foo/topic3
+  
+  Tip: Use `merge /somebranch` or `merge .path.to.code` to
+       initialize this branch.
+
+```

--- a/unison-src/transcripts/delete-project-branch.md
+++ b/unison-src/transcripts/delete-project-branch.md
@@ -3,7 +3,7 @@ your working directory with each command).
 
 ```ucm
 .> project.create foo
-foo/main> switch /topic
+foo/main> branch /topic
 foo/topic> delete.branch /topic
 ```
 

--- a/unison-src/transcripts/delete-project-branch.output.md
+++ b/unison-src/transcripts/delete-project-branch.output.md
@@ -6,9 +6,12 @@ your working directory with each command).
 
   I just created project foo with branch main
 
-foo/main> switch /topic
+foo/main> branch /topic
 
-  I just created branch topic from branch main
+  Done. I've created the topic branch based off of main
+  
+  Tip: Use `merge /topic /main` to merge your work back into the
+       main branch.
 
 foo/topic> delete.branch /topic
 

--- a/unison-src/transcripts/project-merge.md
+++ b/unison-src/transcripts/project-merge.md
@@ -25,7 +25,7 @@ foo/main> add
 ```ucm
 .> project.create bar
 bar/main> merge foo/main
-bar/main> switch /topic
+bar/main> branch /topic
 ```
 
 ```unison

--- a/unison-src/transcripts/project-merge.output.md
+++ b/unison-src/transcripts/project-merge.output.md
@@ -91,9 +91,12 @@ bar/main> merge foo/main
        can use `undo` or `reflog` to undo the results of this
        merge.
 
-bar/main> switch /topic
+bar/main> branch /topic
 
-  I just created branch topic from branch main
+  Done. I've created the topic branch based off of main
+  
+  Tip: Use `merge /topic /main` to merge your work back into the
+       main branch.
 
 ```
 ```unison


### PR DESCRIPTION
## Overview

This PR adds a `branch <name>` command that creates a new branch from some existing contents.

Note: ultimately we want `branch` to be able to take two arguments: `branch <source> <name>`. This PR only implements the one-arg variant, `branch <name>`. To adjust `<source>`, you'll have to first `cd` or `switch` there.

Note: `branch` is intended to replace `switch`'s ability to create branches, but `switch` was not changed by this PR.

There are four ways a branch can be created:

1. From another branch in the same project.

    ![Screenshot from 2023-04-06 14-45-06](https://user-images.githubusercontent.com/1074598/230468966-66555bc8-dbf3-4933-8d18-93984ad1d780.png)
    
    The suggested wording for this output message from @pchiusano was:
    
    ```
    foo/main> branch feature1

    Created /feature1 branch based off /main.
  
    Tip: Use `merge /feature1 /main` to merge your work back into `/main` branch.
    ```
    
    However, before copying that in verbatim I wanted to get all four cases down on paper.
    
2. From another branch in some other project.

    ![Screenshot from 2023-04-06 14-45-43](https://user-images.githubusercontent.com/1074598/230469509-36dd65f5-ba88-416e-a625-f88a6428c4b1.png)

3. From loose code.

    ![Screenshot from 2023-04-06 14-47-56](https://user-images.githubusercontent.com/1074598/230469564-3d62db81-f59a-48e4-b957-f0f261bf94b7.png)

4. From nothingness (creating an empty branch). In the current trunk, you can accomplish this by `switch`ing into a new branch from outside the project. That feature is going to be deleted in favor of a `branch.empty` command, but we still need a wording for it before merging this PR.

    ![Screenshot from 2023-04-06 14-48-21](https://user-images.githubusercontent.com/1074598/230469815-31d0b074-07c6-4192-a105-8064dc0351c7.png)

## Test coverage

Transcript incoming