### PR TITLE
Increase busy_timeout

### DIFF
--- a/lib/unison-sqlite/src/Unison/Sqlite/Connection.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Connection.hs
@@ -122,7 +122,7 @@ openConnection name file = do
   conn0 <- Sqlite.open file `catch` rethrowAsSqliteConnectException name file
   let conn = Connection {conn = conn0, file, name}
   execute_ conn "PRAGMA foreign_keys = ON"
-  execute_ conn "PRAGMA busy_timeout = 1000"
+  execute_ conn "PRAGMA busy_timeout = 60000"
   pure conn
 
 -- Close a connection opened with 'openConnection'.


### PR DESCRIPTION
## Overview

Share is hitting SQLITE_BUSY errors on occasion, it's likely that increasing the busy timeout will alleviate the issue.

This sets the busy_timeout to 60s, which seems long, but in UCM we keep all of our queries single-threaded for the most part anyways, so shouldn't even be hitting SQLITE_BUSY (and if we do, it's best to just wait for it to clear anyways), and in Share this is by far the easiest way to wait for DB contention to clear up, if it takes too long for SQLITE_BUSY to clear then the request timeout will trigger anyways.