### PR TITLE
Allow regenerating name lookups

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -177,6 +177,7 @@ module U.Codebase.Sqlite.Queries
     typeRefsForExactName,
     checkBranchHashNameLookupExists,
     trackNewBranchHashNameLookup,
+    deleteNameLookup,
     termNamesBySuffix,
     typeNamesBySuffix,
     longestMatchingTermNameForSuffixification,
@@ -1707,6 +1708,19 @@ copyScopedNameLookup fromBHId toBHId = do
         INSERT INTO scoped_type_name_lookup(root_branch_hash_id, reversed_name, last_name_segment, namespace, reference_builtin, reference_component_hash, reference_component_index)
         SELECT ?, reversed_name, last_name_segment, namespace, reference_builtin, reference_component_hash, reference_component_index
         FROM scoped_type_name_lookup
+        WHERE root_branch_hash_id = ?
+      |]
+
+-- | Delete the specified name lookup.
+-- This should only be used if you're sure it's unused, or if you're going to re-create it in
+-- the same transaction.
+deleteNameLookup :: BranchHashId -> Transaction ()
+deleteNameLookup bhId = do
+  execute sql (Only bhId)
+  where
+    sql =
+      [here|
+        DELETE FROM name_lookups
         WHERE root_branch_hash_id = ?
       |]
 


### PR DESCRIPTION
## Overview

This will allow Share to rebuild name-lookups from scratch. This isn't typically necessary, but is a helpful admin tool to quickly and easily fix up mistakes that have slipped in for one reason or another. A previous deploy may have left some indexes _slightly_ out of date so I'd like to patch those up.

## Implementation notes

Allows deleting and re-building a name-lookup.

## Test coverage

Tested on local share 👍🏼 