### PR TITLE
add better sql quasi-quoter that allows variable interpolation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -167,6 +167,8 @@ jobs:
         run: stack --no-terminal build --fast --test unison-cli
       - name: unison-parser-typechecker tests
         run: stack --no-terminal build --fast --test unison-parser-typechecker
+      - name: unison-sqlite tests
+        run: stack --no-terminal build --fast --test unison-sqlite
       - name: unison-syntax tests
         run: stack --no-terminal build --fast --test unison-syntax
       - name: unison-util-bytes tests

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -376,11 +376,11 @@ createSchema = do
   addReflogTable
   fixScopedNameLookupTables
   addProjectTables
-  execute insertSchemaVersionSql (Only currentSchemaVersion)
+  execute2 insertSchemaVersionSql
   where
     insertSchemaVersionSql =
-      [here|
-        INSERT INTO schema_version (version) VALUES (?)
+      [sql2|
+        INSERT INTO schema_version (version) VALUES (:currentSchemaVersion)
       |]
 
 addTempEntityTables :: Transaction ()
@@ -2749,15 +2749,14 @@ appendReflog entry = execute sql entry
       |]
 
 getReflog :: Int -> Transaction [Reflog.Entry CausalHashId Text]
-getReflog numEntries = queryListRow sql (Only numEntries)
-  where
-    sql =
-      [here|
-        SELECT time, from_root_causal_id, to_root_causal_id, reason
-          FROM reflog
-          ORDER BY time DESC
-          LIMIT ?
-      |]
+getReflog numEntries =
+  queryListRow2
+    [sql2|
+      SELECT time, from_root_causal_id, to_root_causal_id, reason
+      FROM reflog
+      ORDER BY time DESC
+      LIMIT :numEntries
+    |]
 
 -- | Does a project exist with this id?
 projectExists :: ProjectId -> Transaction Bool

--- a/hie.yaml
+++ b/hie.yaml
@@ -51,6 +51,9 @@ cradle:
     - path: "lib/unison-sqlite/src"
       component: "unison-sqlite:lib"
 
+    - path: "lib/unison-sqlite/test"
+      component: "unison-sqlite:test:tests"
+
     - path: "lib/unison-util-base32hex/src"
       component: "unison-util-base32hex:lib"
 

--- a/lib/unison-sqlite/package.yaml
+++ b/lib/unison-sqlite/package.yaml
@@ -18,6 +18,9 @@ dependencies:
   - base
   - direct-sqlite
   - exceptions
+  - generic-lens
+  - lens
+  - megaparsec
   - mtl
   - neat-interpolation
   - pretty-simple
@@ -26,6 +29,7 @@ dependencies:
   - sqlite-simple
   - template-haskell
   - text
+  - text-builder
   - transformers
   - unison-prelude
   - unliftio
@@ -40,6 +44,7 @@ default-extensions:
   - DeriveAnyClass
   - DeriveFunctor
   - DeriveFoldable
+  - DeriveGeneric
   - DeriveTraversable
   - DerivingStrategies
   - DerivingVia
@@ -54,6 +59,7 @@ default-extensions:
   - MultiParamTypeClasses
   - NamedFieldPuns
   - NumericUnderscores
+  - OverloadedLabels
   - OverloadedStrings
   - PatternSynonyms
   - RankNTypes

--- a/lib/unison-sqlite/package.yaml
+++ b/lib/unison-sqlite/package.yaml
@@ -8,11 +8,11 @@ library:
       other-modules: Paths_unison_sqlite
 
   source-dirs: src
-  other-modules:
-    - Unison.Sqlite.DataVersion
-    - Unison.Sqlite.Exception
-    - Unison.Sqlite.JournalMode
-    - Unison.Sqlite.Sql
+  exposed-modules:
+    - Unison.Sqlite
+    - Unison.Sqlite.Connection
+    - Unison.Sqlite.Internal
+    - Unison.Sqlite.Transaction
 
 dependencies:
   - base

--- a/lib/unison-sqlite/package.yaml
+++ b/lib/unison-sqlite/package.yaml
@@ -14,6 +14,18 @@ library:
     - Unison.Sqlite.Internal
     - Unison.Sqlite.Transaction
 
+tests:
+  tests:
+    when:
+      - condition: false
+        other-modules: Paths_unison_sqlite
+    dependencies:
+      - code-page
+      - easytest
+      - unison-sqlite
+    main: Main.hs
+    source-dirs: test
+
 dependencies:
   - base
   - direct-sqlite

--- a/lib/unison-sqlite/src/Unison/Sqlite.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite.hs
@@ -27,6 +27,8 @@ module Unison.Sqlite
     -- * Executing queries
     Sql (..),
     sql,
+    Sql2,
+    sql2,
     Values (..),
     valuesSql,
 
@@ -34,6 +36,7 @@ module Unison.Sqlite
 
     -- *** With parameters
     execute,
+    execute2,
     executeMany,
 
     -- *** Without parameters
@@ -46,7 +49,9 @@ module Unison.Sqlite
     queryStreamRow,
     queryStreamCol,
     queryListRow,
+    queryListRow2,
     queryListCol,
+    queryListCol2,
     queryMaybeRow,
     queryMaybeCol,
     queryOneRow,
@@ -139,6 +144,7 @@ import Unison.Sqlite.Exception
   )
 import Unison.Sqlite.JournalMode (JournalMode (..), SetJournalModeException (..), trySetJournalMode)
 import Unison.Sqlite.Sql (Sql (..), sql)
+import Unison.Sqlite.Sql2 (Sql2, sql2)
 import Unison.Sqlite.Transaction
 import Unison.Sqlite.Values (Values (..), valuesSql)
 

--- a/lib/unison-sqlite/src/Unison/Sqlite/Internal.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Internal.hs
@@ -1,0 +1,4 @@
+-- | Internals exported for testing.
+module Unison.Sqlite.Internal (module X) where
+
+import Unison.Sqlite.Sql2 as X (internalParseSql)

--- a/lib/unison-sqlite/src/Unison/Sqlite/Sql2.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Sql2.hs
@@ -122,7 +122,7 @@ parser = do
       parser
     Param param -> do
       #sql <>= (Text.Builder.char ':' <> param)
-      #params %= ((Text.Builder.run param :) .)
+      #params %= (. (Text.Builder.run param :))
       parser
     Whitespace -> do
       #sql <>= Text.Builder.char ' '

--- a/lib/unison-sqlite/src/Unison/Sqlite/Sql2.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Sql2.hs
@@ -1,0 +1,249 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Unison.Sqlite.Sql2
+  ( Sql2 (..),
+    sql2,
+  )
+where
+
+import Control.Lens ((%=), (<>=))
+import qualified Control.Monad.Trans.State.Strict as State
+import qualified Data.Char as Char
+import Data.Generics.Labels ()
+import qualified Data.Text as Text
+import qualified Database.SQLite.Simple as Sqlite.Simple
+import qualified Language.Haskell.TH as TH
+import qualified Language.Haskell.TH.Quote as TH
+import qualified Text.Builder
+import qualified Text.Builder as Text (Builder)
+import qualified Text.Megaparsec as Megaparsec
+import qualified Text.Megaparsec.Char as Megaparsec
+import Unison.Prelude
+
+-- | A SQL query.
+data Sql2 = Sql2
+  { query :: Text,
+    params :: [Sqlite.Simple.NamedParam]
+  }
+  deriving stock (Show)
+
+-- | A quasi-quoter for producing a 'Sql2' from a SQL query string, using the Haskell variables in scope for each named
+-- parameter.
+--
+-- For example, the query
+--
+-- @
+-- [sql2|
+--   SELECT foo
+--   FROM bar
+--   WHERE baz = :qux
+-- |]
+-- @
+--
+-- would produce a value like
+--
+-- @
+-- Sql2
+--   { query = "SELECT foo\\nFROM bar\\nWHERE baz = :qux"
+--   , params = [":qux" := qux]
+--   }
+-- @
+--
+-- which, of course, will require a @qux@ with a 'Sqlite.Simple.ToField' instance in scope.
+sql2 :: TH.QuasiQuoter
+sql2 = TH.QuasiQuoter sql2QQ undefined undefined undefined
+
+sql2QQ :: String -> TH.Q TH.Exp
+sql2QQ input =
+  case runP (parser <* Megaparsec.eof) (Text.strip (Text.pack input)) of
+    Left err -> fail (Megaparsec.errorBundlePretty err)
+    Right ((), S {sql, variables}) -> do
+      let params :: [TH.Q TH.Exp]
+          params =
+            map
+              ( \var ->
+                  TH.lookupValueName (Text.unpack var) >>= \case
+                    Nothing -> fail ("Not in scope: " ++ Text.unpack var)
+                    Just name -> [|(Text.cons ':' var) Sqlite.Simple.:= $(TH.varE name)|]
+              )
+              (variables [])
+      let query = Text.Builder.run sql
+      [|Sql2 query $(TH.listE params)|]
+
+-- Parser state: the SQL parsed so far, and a difference list of variable names.
+--
+-- For example, if we were partway through parsing the query
+--
+--   SELECT foo
+--   FROM bar
+--   WHERE baz = :bonk AND qux = 'monk'
+--                         ^
+--
+-- then we would have the state
+--
+--   S
+--     { sql = "SELECT foo FROM bar WHERE baz = :bonk AND "
+--     , variables = ["bonk"]
+--     }
+--
+-- Why keep the SQL parsed so far: so we can make the query slightly prettier by replacing all runs of 2+ characters of
+-- whitespace with a single space. This lets us write vertically aligned SQL queries at arbitrary indentations in
+-- Haskell quasi-quoters, but not have to look at a bunch of "\n        " in debug logs and such.
+data S = S
+  { sql :: !Text.Builder,
+    variables :: [Text] -> [Text]
+  }
+  deriving stock (Generic)
+
+type P a =
+  State.StateT S (Megaparsec.Parsec Void Text) a
+
+runP :: P a -> Text -> Either (Megaparsec.ParseErrorBundle Text Void) (a, S)
+runP p =
+  Megaparsec.runParser (State.runStateT p (S mempty id)) ""
+
+-- Parser for a SQL query (stored in the parser state).
+parser :: P ()
+parser = do
+  fragmentParser >>= \case
+    NonVariable fragment -> do
+      #sql <>= fragment
+      parser
+    Variable var -> do
+      #sql <>= (Text.Builder.char ':' <> var)
+      #variables %= ((Text.Builder.run var :) .)
+      parser
+    Whitespace -> do
+      #sql <>= Text.Builder.char ' '
+      parser
+    EndOfInput -> pure ()
+
+-- A single fragment, where a list of fragments (always ending in EndOfFile) makes a whole query.
+--
+-- The query
+--
+--   SELECT foo
+--   FROM   bar
+--   WHERE  baz = :bonk AND qux = 'monkey monk'
+--
+-- corresponds to the fragments
+--
+--   [ NonVariable "SELECT"
+--   , Whitespace
+--   , NonVariable "foo"
+--   , Whitespace
+--   , NonVariable "FROM"
+--   , Whitespace
+--   , NonVariable "bar"
+--   , Whitespace
+--   , NonVariable "WHERE"
+--   , Whitespace
+--   , NonVariable "baz"
+--   , Whitespace
+--   , NonVariable "="
+--   , Whitespace
+--   , Variable "bonk"
+--   , Whitespace
+--   , NonVariable "AND"
+--   , Whitespace
+--   , NonVariable "qux"
+--   , Whitespace
+--   , NonVariable "="
+--   , Whitespace
+--   , NonVariable "'monkey monk'"
+--   , EndOfInput
+--   ]
+--
+-- Any sequence of consecutive NonVariable fragments in such a list is equivalent to a single NonVariable fragment with
+-- the contents concatenated. How the non-variable stuff between variables is turned into 1+ NonVariable fragments is
+-- just a consequence of how we parse these SQL strings: identify strings and such, but otherwise make no attempt to
+-- understand the structure of the query.
+data Fragment
+  = NonVariable Text.Builder
+  | Variable Text.Builder
+  | Whitespace
+  | EndOfInput
+
+fragmentParser :: P Fragment
+fragmentParser =
+  asum
+    [ Whitespace <$ Megaparsec.takeWhile1P (Just "whitepsace") Char.isSpace,
+      NonVariable <$> betwixt "string" '\'',
+      NonVariable <$> betwixt "identifier" '"',
+      NonVariable <$> betwixt "identifier" '`',
+      NonVariable <$> bracketedIdentifierP,
+      Variable <$> variableP,
+      NonVariable <$> unstructuredP,
+      EndOfInput <$ Megaparsec.eof
+    ]
+  where
+    -- It's not clear if there is *no* syntax for escaping a literal ] character from an identifier between brackets
+    -- that looks like [this], but the documentation here doesn't mention any, and (brief) experimentation at the
+    -- sqlite3 repl didn't reveal any.
+    --
+    -- So this parser is simple: left bracket, stuff, right bracket.
+    bracketedIdentifierP :: P Text.Builder
+    bracketedIdentifierP = do
+      x <- char '['
+      ys <- Megaparsec.takeWhile1P (Just "identifier") (/= ']')
+      z <- char ']'
+      pure (x <> Text.Builder.text ys <> z)
+
+    unstructuredP :: P Text.Builder
+    unstructuredP = do
+      xs <-
+        Megaparsec.takeWhile1P
+          (Just "sql")
+          \c ->
+            not (Char.isSpace c)
+              && c /= ':'
+              && c /= '\''
+              && c /= '"'
+              && c /= '`'
+              && c /= '['
+      pure (Text.Builder.text xs)
+
+    variableP :: P Text.Builder
+    variableP = do
+      _ <- Megaparsec.char ':'
+      x <- Megaparsec.satisfy (\c -> Char.isAlpha c || c == '_')
+      xs <- Megaparsec.takeWhileP (Just "variable") \c -> Char.isAlphaNum c || c == '_' || c == '\''
+      pure (Text.Builder.char x <> Text.Builder.text xs)
+
+-- @betwixt name c@ parses a @c@-surrounded string of arbitrary characters (naming the parser @name@), where two @c@s
+-- in a row inside the string is the syntax for a single @c@. This is simply how escaping works in SQLite for
+-- single-quoted things (strings), double-quoted things (usually identifiers, but weirdly, SQLite lets you quote
+-- strings this way sometimes, probably because people don't know about single-quote syntax), and backtick-quoted
+-- things (identifiers).
+--
+-- That is,
+--
+--   - 'foo''bar' denotes the string foo'bar
+--   - "foo""bar" denotes the identifier foo"bar
+--   - `foo``bar` denotes the idetifier foo`bar
+--
+-- This function returns the quoted thing *with* the surrounding quotes, and *retaining* any double-quoted things
+-- within. For example, @betwixt "" '`'@ applied to the string "`foo``bar`" will return the full string "`foo``bar`".
+--
+-- This implementation is stolen from our own Travis Staton's @hasql-interpolate@ package, but tweaked a bit.
+betwixt :: String -> Char -> P Text.Builder
+betwixt name quote = do
+  startQuote <- quoteP
+  let loop sofar = do
+        content <- Megaparsec.takeWhileP (Just name) (/= quote)
+        Megaparsec.notFollowedBy Megaparsec.eof
+        let escapedQuoteAndMore = do
+              escapedQuote <- Megaparsec.try ((<>) <$> quoteP <*> quoteP)
+              loop (sofar <> Text.Builder.text content <> escapedQuote)
+        let allDone = do
+              endQuote <- quoteP
+              pure (sofar <> Text.Builder.text content <> endQuote)
+        escapedQuoteAndMore <|> allDone
+  loop startQuote
+  where
+    quoteP =
+      char quote
+
+char :: Char -> P Text.Builder
+char c =
+  Megaparsec.char c $> Text.Builder.char c

--- a/lib/unison-sqlite/src/Unison/Sqlite/Transaction.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Transaction.hs
@@ -15,6 +15,7 @@ module Unison.Sqlite.Transaction
 
     -- *** With parameters
     execute,
+    execute2,
     executeMany,
 
     -- *** Without parameters
@@ -26,7 +27,9 @@ module Unison.Sqlite.Transaction
     queryStreamRow,
     queryStreamCol,
     queryListRow,
+    queryListRow2,
     queryListCol,
+    queryListCol2,
     queryMaybeRow,
     queryMaybeCol,
     queryOneRow,
@@ -74,6 +77,7 @@ import Unison.Sqlite.Connection (Connection (..))
 import qualified Unison.Sqlite.Connection as Connection
 import Unison.Sqlite.Exception (SqliteExceptionReason, SqliteQueryException, pattern SqliteBusyException)
 import Unison.Sqlite.Sql
+import Unison.Sqlite.Sql2 (Sql2)
 import UnliftIO.Exception (bracketOnError_, catchAny, trySyncOrAsync, uninterruptibleMask)
 
 newtype Transaction a
@@ -201,6 +205,10 @@ execute :: (Sqlite.ToRow a) => Sql -> a -> Transaction ()
 execute s params = do
   Transaction \conn -> Connection.execute conn s params
 
+execute2 :: Sql2 -> Transaction ()
+execute2 s =
+  Transaction \conn -> Connection.execute2 conn s
+
 executeMany :: (Sqlite.ToRow a) => Sql -> [a] -> Transaction ()
 executeMany s params =
   Transaction \conn -> Connection.executeMany conn s params
@@ -246,9 +254,17 @@ queryListRow :: (Sqlite.FromRow a, Sqlite.ToRow b) => Sql -> b -> Transaction [a
 queryListRow s params =
   Transaction \conn -> Connection.queryListRow conn s params
 
+queryListRow2 :: (Sqlite.FromRow a) => Sql2 -> Transaction [a]
+queryListRow2 s =
+  Transaction \conn -> Connection.queryListRow2 conn s
+
 queryListCol :: (Sqlite.FromField a, Sqlite.ToRow b) => Sql -> b -> Transaction [a]
 queryListCol s params =
   Transaction \conn -> Connection.queryListCol conn s params
+
+queryListCol2 :: (Sqlite.FromField a) => Sql2 -> Transaction [a]
+queryListCol2 s =
+  Transaction \conn -> Connection.queryListCol2 conn s
 
 queryMaybeRow :: (Sqlite.FromRow a, Sqlite.ToRow b) => Sql -> b -> Transaction (Maybe a)
 queryMaybeRow s params =

--- a/lib/unison-sqlite/test/Main.hs
+++ b/lib/unison-sqlite/test/Main.hs
@@ -1,0 +1,19 @@
+module Main (main) where
+
+import EasyTest
+import System.IO.CodePage (withCP65001)
+import Unison.Sqlite.Internal (internalParseSql)
+
+main :: IO ()
+main =
+  withCP65001 (run (scope "sqlite" test))
+
+test :: Test ()
+test =
+  tests
+    [ scope "internalParseSql" do
+        let sql = "   foo :a\n   'foo''foo' :b\n   \"foo\"\"foo\" :c\n   `foo``foo`   \n[foo] :d  "
+        let expected = Right ("foo :a 'foo''foo' :b \"foo\"\"foo\" :c `foo``foo` [foo] :d", ["a", "b", "c", "d"])
+        let actual = internalParseSql sql
+        expectEqual expected actual
+    ]

--- a/lib/unison-sqlite/unison-sqlite.cabal
+++ b/lib/unison-sqlite/unison-sqlite.cabal
@@ -82,3 +82,63 @@ library
     , unliftio
     , unliftio-core
   default-language: Haskell2010
+
+test-suite tests
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  hs-source-dirs:
+      test
+  default-extensions:
+      BlockArguments
+      ConstraintKinds
+      DeriveAnyClass
+      DeriveFunctor
+      DeriveFoldable
+      DeriveGeneric
+      DeriveTraversable
+      DerivingStrategies
+      DerivingVia
+      DoAndIfThenElse
+      DuplicateRecordFields
+      FlexibleContexts
+      FlexibleInstances
+      GADTs
+      GeneralizedNewtypeDeriving
+      KindSignatures
+      LambdaCase
+      MultiParamTypeClasses
+      NamedFieldPuns
+      NumericUnderscores
+      OverloadedLabels
+      OverloadedStrings
+      PatternSynonyms
+      RankNTypes
+      ScopedTypeVariables
+      TupleSections
+      TypeApplications
+      ViewPatterns
+  ghc-options: -Wall
+  build-depends:
+      base
+    , code-page
+    , direct-sqlite
+    , easytest
+    , exceptions
+    , generic-lens
+    , lens
+    , megaparsec
+    , mtl
+    , neat-interpolation
+    , pretty-simple
+    , random
+    , recover-rtti
+    , sqlite-simple
+    , template-haskell
+    , text
+    , text-builder
+    , transformers
+    , unison-prelude
+    , unison-sqlite
+    , unliftio
+    , unliftio-core
+  default-language: Haskell2010

--- a/lib/unison-sqlite/unison-sqlite.cabal
+++ b/lib/unison-sqlite/unison-sqlite.cabal
@@ -19,15 +19,16 @@ library
   exposed-modules:
       Unison.Sqlite
       Unison.Sqlite.Connection
-      Unison.Sqlite.Connection.Internal
-      Unison.Sqlite.Sql2
+      Unison.Sqlite.Internal
       Unison.Sqlite.Transaction
-      Unison.Sqlite.Values
   other-modules:
+      Unison.Sqlite.Connection.Internal
       Unison.Sqlite.DataVersion
       Unison.Sqlite.Exception
       Unison.Sqlite.JournalMode
       Unison.Sqlite.Sql
+      Unison.Sqlite.Sql2
+      Unison.Sqlite.Values
   hs-source-dirs:
       src
   default-extensions:

--- a/lib/unison-sqlite/unison-sqlite.cabal
+++ b/lib/unison-sqlite/unison-sqlite.cabal
@@ -20,6 +20,7 @@ library
       Unison.Sqlite
       Unison.Sqlite.Connection
       Unison.Sqlite.Connection.Internal
+      Unison.Sqlite.Sql2
       Unison.Sqlite.Transaction
       Unison.Sqlite.Values
   other-modules:
@@ -35,6 +36,7 @@ library
       DeriveAnyClass
       DeriveFunctor
       DeriveFoldable
+      DeriveGeneric
       DeriveTraversable
       DerivingStrategies
       DerivingVia
@@ -49,6 +51,7 @@ library
       MultiParamTypeClasses
       NamedFieldPuns
       NumericUnderscores
+      OverloadedLabels
       OverloadedStrings
       PatternSynonyms
       RankNTypes
@@ -61,6 +64,9 @@ library
       base
     , direct-sqlite
     , exceptions
+    , generic-lens
+    , lens
+    , megaparsec
     , mtl
     , neat-interpolation
     , pretty-simple
@@ -69,6 +75,7 @@ library
     , sqlite-simple
     , template-haskell
     , text
+    , text-builder
     , transformers
     , unison-prelude
     , unliftio


### PR DESCRIPTION
## Overview

This PR adds a SQL quasi-quoter that interpolates Haskell variables.

SQLite already has [a number of syntaxes](https://www.sqlite.org/c3ref/bind_blob.html) for named parameters. This quasi-quoter steals the `:colon` variant, which requires a `colon` variable in scope with a `ToField` instance.

We can now write queries like

```haskell
execute
  [sql|
    INSERT INTO project_branch_remote_mapping
      ( local_project_id
      , local_branch_id
      , remote_project_id
      , remote_branch_id
      , remote_host
      )
    VALUES (?, ?, ?, ?, ?)
    ON CONFLICT
      ( local_project_id,
      , local_branch_id,
      , remote_host)
      )
    DO NOTHING
  |]
  (pid, bid, rpid, rbid, host)
```

as

```haskell
execute2
  [sql2|
    INSERT INTO project_branch_remote_mapping
      ( local_project_id
      , local_branch_id
      , remote_project_id
      , remote_branch_id
      , remote_host
      )
    VALUES (:pid, :bid, :rpid, :rbid, :host)
    ON CONFLICT
      ( local_project_id,
      , local_branch_id,
      , remote_host)
      )
    DO NOTHING
  |]
```

Note that there is no need for any `?`s in query strings anymore, with the corresponding tuple of parameters provided as a second argument. This should also reduce our query API surface area by about half: no need for separate underscore-variants for queries that take no parameters.

The parser works by only understanding enough of the SQLite syntax to avoid accidentally interpreting variables inside quoted entities. That is, given a query like

```sql
SELECT "foo"
FROM `bar`
WHERE [baz] = :qux AND bazooka = 'boba'
```

our parser will only "think"

```sql
•••••• "foo"
•••• `bar`
••••• [baz] • :qux ••• ••••••• • 'boba'
```

All four string-like constructs (shown above) are supported, but I only suspect we will ever use `'strings'` and sometimes `"identifiers"`. Backticks and brackets are just a couple more weird ways that you can write an identifier that SQLite supports.

In SQLite, to write a `'` literal in a string, you write `''`; ditto for `"` and backtick, mutatis mutandis. These escape syntaxes are all handled properly.

There's one minor regression to how queries appear in debug logs with `UNISON_DEBUG=sqlite`. Because we use `recover-rtti` to make a best-effort display of query parameters (with the advantage that no type class instance is needed), logged queries look like this now:

```haskell
Query
    { sql = "SELECT time, from_root_causal_id, to_root_causal_id, reason FROM reflog ORDER BY time DESC LIMIT :numEntries"
    , params = "[:= <Fun> ":numEntries" 500]"
    , results = "[]"
    }
```

whereas prior to this PR, `params` would look more like a tuple. I think this is fine; the params are still readable, and these are just debug logs. We could also consider requiring `Show`, or a new `ShowInDebugLog` type class, if we really want something prettier here, but those solutions each have disadvantages as well.

## Test coverage

There's a test for the parser.

## Loose ends

I have not refactored many of the existing queries - just a couple, to show the idea. I figured it would be better to get the new functionality in first, then refactor over time, and eventually delete the unused old stuff.

That means we have some not-great names in the interim:

- a new type called `Sql2`, which deprecates `Sql`
- a new quasi-quoter called `sql2`, which deprecates `sql`
- new query functions `execute2`, `queryListRow2`, and `queryListCol2`, with all of the others to be filled out eventually

Additionally, this quasi-quoter does not yet feature query splicing. That would be useful for at least one query we've written, which is currently stitching together query fragments manually with `<>`.