### PR TITLE
Add pattern match coverage checking for ability handlers

### DIFF
--- a/parser-typechecker/src/Unison/PatternMatchCoverage.hs
+++ b/parser-typechecker/src/Unison/PatternMatchCoverage.hs
@@ -62,23 +62,26 @@ checkMatch ::
   -- | (redundant locations, inaccessible locations, inhabitants of uncovered refinement type)
   m ([loc], [loc], [Pattern ()])
 checkMatch matchLocation scrutineeType cases = do
+  ppe <- getPrettyPrintEnv
   v0 <- fresh
   grdtree0 <- desugarMatch matchLocation scrutineeType v0 cases
+  doDebug (P.hang (title "desugared:") (prettyGrdTree (prettyPmGrd ppe) (\_ -> "<loc>") grdtree0)) (pure ())
   (uncovered, grdtree1) <- uncoverAnnotate (Set.singleton (NC.markDirty v0 $ NC.declVar v0 scrutineeType id NC.emptyNormalizedConstraints)) grdtree0
+  doDebug
+    ( P.sep
+        "\n"
+        [ P.hang (title "annotated:") (prettyGrdTree (NC.prettyDnf ppe) (NC.prettyDnf ppe . fst) grdtree1),
+          P.hang (title "uncovered:") (NC.prettyDnf ppe uncovered)
+        ]
+    )
+    (pure ())
   uncoveredExpanded <- concat . fmap Set.toList <$> traverse (expandSolution v0) (Set.toList uncovered)
+  doDebug (P.hang (title "uncovered expanded:") (NC.prettyDnf ppe (Set.fromList uncoveredExpanded))) (pure ())
   let sols = map (generateInhabitants v0) uncoveredExpanded
   let (_accessible, inaccessible, redundant) = classify grdtree1
-  ppe <- getPrettyPrintEnv
-  let debugOutput =
-        P.sep
-          "\n\n"
-          [ P.hang (title "desugared:") (prettyGrdTree (prettyPmGrd ppe) (\_ -> "<loc>") grdtree0),
-            P.hang (title "annotated:") (prettyGrdTree (NC.prettyDnf ppe) (NC.prettyDnf ppe . fst) grdtree1),
-            P.hang (title "uncovered:") (NC.prettyDnf ppe uncovered),
-            P.hang (title "uncovered expanded:") (NC.prettyDnf ppe (Set.fromList uncoveredExpanded))
-          ]
-      title = P.bold
-      doDebug = case shouldDebug PatternCoverage of
-        True -> trace (P.toAnsiUnbroken debugOutput)
-        False -> id
-  doDebug (pure (redundant, inaccessible, sols))
+  pure (redundant, inaccessible, sols)
+  where
+    title = P.bold
+    doDebug out = case shouldDebug PatternCoverage of
+      True -> trace (P.toAnsiUnbroken out)
+      False -> id

--- a/parser-typechecker/src/Unison/PatternMatchCoverage/Class.hs
+++ b/parser-typechecker/src/Unison/PatternMatchCoverage/Class.hs
@@ -3,11 +3,13 @@
 module Unison.PatternMatchCoverage.Class
   ( Pmc (..),
     EnumeratedConstructors (..),
-    traverseConstructors,
+    traverseConstructorTypes,
   )
 where
 
 import Control.Monad.Fix (MonadFix)
+import Data.Map (Map)
+import qualified Data.Map as Map
 import Unison.ConstructorReference (ConstructorReference)
 import Unison.PatternMatchCoverage.ListPat (ListPat)
 import Unison.PrettyPrintEnv (PrettyPrintEnv)
@@ -30,18 +32,29 @@ class (Ord loc, Var vt, Var v, MonadFix m) => Pmc vt v loc m | m -> vt v loc whe
 
 data EnumeratedConstructors vt v loc
   = ConstructorType [(v, ConstructorReference, Type vt loc)]
+  | AbilityType (Type vt loc) (Map ConstructorReference (v, Type vt loc))
   | SequenceType [(ListPat, [Type vt loc])]
   | BooleanType
   | OtherType
   deriving stock (Show)
 
-traverseConstructors ::
+traverseConstructorTypes ::
   (Applicative f) =>
-  (v -> ConstructorReference -> Type vt loc -> f (v, ConstructorReference, Type vt loc)) ->
+  (v -> ConstructorReference -> Type vt loc -> f (Type vt loc)) ->
   EnumeratedConstructors vt v loc ->
   f (EnumeratedConstructors vt v loc)
-traverseConstructors f = \case
-  ConstructorType xs -> ConstructorType <$> traverse (\(a, b, c) -> f a b c) xs
+traverseConstructorTypes f = \case
+  ConstructorType xs -> ConstructorType <$> traverse (\(a, b, c) -> (a,b,) <$> f a b c) xs
+  AbilityType resultType m ->
+    AbilityType resultType
+      <$> Map.foldrWithKey
+        ( \cr (v, t) b ->
+            let t' = f v cr t
+                newValue = (v,) <$> t'
+             in Map.insert cr <$> newValue <*> b
+        )
+        (pure mempty)
+        m
   SequenceType x -> pure (SequenceType x)
   BooleanType -> pure BooleanType
   OtherType -> pure OtherType

--- a/parser-typechecker/src/Unison/PatternMatchCoverage/EffectHandler.hs
+++ b/parser-typechecker/src/Unison/PatternMatchCoverage/EffectHandler.hs
@@ -1,0 +1,17 @@
+module Unison.PatternMatchCoverage.EffectHandler where
+
+import Unison.ConstructorReference (ConstructorReference)
+import Unison.PatternMatchCoverage.Pretty
+import Unison.Prelude
+import Unison.PrettyPrintEnv (PrettyPrintEnv)
+import Unison.Util.Pretty
+
+data EffectHandler
+  = NoEffect
+  | Effect ConstructorReference
+  deriving stock (Show, Eq, Ord, Generic)
+
+prettyEffectHandler :: PrettyPrintEnv -> EffectHandler -> Pretty ColorText
+prettyEffectHandler ppe = \case
+  NoEffect -> "pure"
+  Effect cr -> prettyConstructorReference ppe cr

--- a/parser-typechecker/src/Unison/PatternMatchCoverage/Literal.hs
+++ b/parser-typechecker/src/Unison/PatternMatchCoverage/Literal.hs
@@ -5,6 +5,7 @@ module Unison.PatternMatchCoverage.Literal
 where
 
 import Unison.ConstructorReference (ConstructorReference)
+import Unison.PatternMatchCoverage.EffectHandler
 import Unison.PatternMatchCoverage.IntervalSet (IntervalSet)
 import Unison.PatternMatchCoverage.PmLit (PmLit, prettyPmLit)
 import qualified Unison.PrettyPrintEnv as PPE
@@ -29,6 +30,13 @@ data Literal vt v loc
   | -- | Negative constraint concerning data type. States that the
     -- given variable must not be the given constructor.
     NegCon v ConstructorReference
+  | -- | Positive constraint regarding data type. States that the
+    -- given variable must be the given constructor, and it also binds
+    -- variables corresponding to constructor arguments.
+    PosEffect v EffectHandler [(v, Type vt loc)]
+  | -- | Negative constraint concerning data type. States that the
+    -- given variable must not be the given constructor.
+    NegEffect v EffectHandler
   | -- | Positive constraint regarding literal
     PosLit v PmLit
   | -- | Negative constraint regarding literal
@@ -68,6 +76,10 @@ prettyLiteral = \case
     let xs = pc con : fmap (\(trm, typ) -> sep " " [pv trm, ":", TypePrinter.pretty PPE.empty typ]) convars ++ ["<-", pv var]
      in sep " " xs
   NegCon var con -> sep " " [pv var, "≠", pc con]
+  PosEffect var con convars ->
+    let xs = pc con : fmap (\(trm, typ) -> sep " " [pv trm, ":", TypePrinter.pretty PPE.empty typ]) convars ++ ["<-", pv var]
+     in sep " " xs
+  NegEffect var con -> sep " " [pv var, "≠", pc con]
   PosLit var lit -> sep " " [prettyPmLit lit, "<-", pv var]
   NegLit var lit -> sep " " [pv var, "≠", prettyPmLit lit]
   PosListHead root n el _ -> sep " " [pv el, "<-", "head", pc n, pv root]

--- a/parser-typechecker/src/Unison/PatternMatchCoverage/PmGrd.hs
+++ b/parser-typechecker/src/Unison/PatternMatchCoverage/PmGrd.hs
@@ -23,6 +23,14 @@ data
       -- ^ Constructor
       [(v, Type vt loc)]
       -- ^ Constructor argument values and types
+  | PmEffect
+      v
+      -- ^ Variable
+      ConstructorReference
+      -- ^ Constructor
+      [(v, Type vt loc)]
+      -- ^ Constructor argument values and types
+  | PmEffectPure v (v, Type vt loc)
   | PmLit v PmLit
   | PmListHead
       v
@@ -56,6 +64,10 @@ prettyPmGrd ppe = \case
   PmCon var con convars ->
     let xs = pc con : fmap (\(trm, typ) -> sep " " ["(" <> prettyVar trm, ":", TypePrinter.pretty ppe typ <> ")"]) convars ++ ["<-", prettyVar var]
      in sep " " xs
+  PmEffect var con convars ->
+    let xs = pc con : fmap (\(trm, typ) -> sep " " ["(" <> prettyVar trm, ":", TypePrinter.pretty ppe typ <> ")"]) convars ++ ["<-", prettyVar var]
+     in sep " " xs
+  PmEffectPure v (rv, rt) -> sep " " ["pure", "(" <> prettyVar rv, ":", TypePrinter.pretty ppe rt <> ")", "<-", prettyVar v]
   PmListHead var n el _ -> sep " " ["Cons", string (show n), prettyVar el, "<-", prettyVar var]
   PmListTail var n el _ -> sep " " ["Snoc", string (show n), prettyVar el, "<-", prettyVar var]
   PmListInterval var minLen maxLen -> sep " " ["Interval", string (show (minLen, maxLen)), "<-", prettyVar var]

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -103,6 +103,7 @@ library
       Unison.PatternMatchCoverage.Class
       Unison.PatternMatchCoverage.Constraint
       Unison.PatternMatchCoverage.Desugar
+      Unison.PatternMatchCoverage.EffectHandler
       Unison.PatternMatchCoverage.Fix
       Unison.PatternMatchCoverage.GrdTree
       Unison.PatternMatchCoverage.IntervalSet

--- a/unison-core/src/Unison/Type.hs
+++ b/unison-core/src/Unison/Type.hs
@@ -112,6 +112,9 @@ pattern Apps' f args <- (unApps -> Just (f, args))
 pattern Pure' :: (Ord v) => Type v a -> Type v a
 pattern Pure' t <- (unPure -> Just t)
 
+pattern Request' :: [Type v a] -> Type v a -> Type v a
+pattern Request' ets res <- Apps' (Ref' ((== effectRef) -> True)) [(flattenEffects -> ets), res]
+
 pattern Effects' :: [ABT.Term F v a] -> ABT.Term F v a
 pattern Effects' es <- ABT.Tm' (Effects es)
 

--- a/unison-src/tests/console1.u
+++ b/unison-src/tests/console1.u
@@ -15,6 +15,7 @@ snd = cases Tuple.Cons _ (Tuple.Cons b _) -> b
 
 simulate : Request Console a -> {State ([Text], [Text])} a
 simulate = cases
+  { pure } -> pure
   {Console.read -> k} -> handle
       io = State.get
       ins = fst io

--- a/unison-src/tests/methodical/abilities.u
+++ b/unison-src/tests/methodical/abilities.u
@@ -50,10 +50,12 @@ structural ability C where
 f = cases
   { r } -> r
   { i -> _ } -> 5
+  { n -> _ } -> 7
 
 g = cases
   { i -> _ } -> 6
   { n -> _ } -> 7
+  { r } -> r
 
 x = 'let
   j = i

--- a/unison-src/transcripts/pattern-match-coverage.md
+++ b/unison-src/transcripts/pattern-match-coverage.md
@@ -386,6 +386,21 @@ result f =
   handle !f with impl
 ```
 
+```unison
+structural ability Abort where
+  abort : {Abort} a
+  
+structural ability Stream a where
+  emit : a -> {Stream a} Unit
+  
+handleMulti : '{Stream a, Abort} r -> (Optional r, [a])
+handleMulti c =
+  impl xs = cases
+    { r } -> (Some r, xs)
+    { emit x -> resume } -> handle !resume with impl (xs :+ x)
+    { abort -> _ } -> (None, xs)
+  handle !c with impl []
+```
 
 ## Non-exhaustive ability handlers are rejected
 
@@ -422,6 +437,22 @@ result : '{e, Give T} r -> {e} r
 result f = handle !f with cases
        { x } -> x
        { give A -> resume } -> result resume
+```
+
+```unison:error
+structural ability Abort where
+  abort : {Abort} a
+  
+structural ability Stream a where
+  emit : a -> {Stream a} Unit
+  
+handleMulti : '{Stream a, Abort} r -> (Optional r, [a])
+handleMulti c =
+  impl : [a] -> Request {Stream a, Abort} r -> (Optional r, [a])
+  impl xs = cases
+    { r } -> (Some r, xs)
+    { emit x -> resume } -> handle !resume with impl (xs :+ x)
+  handle !c with impl []
 ```
 
 ## Redundant handler cases are rejected

--- a/unison-src/transcripts/pattern-match-coverage.md
+++ b/unison-src/transcripts/pattern-match-coverage.md
@@ -409,6 +409,33 @@ result f = handle !f with cases
        { give A -> resume } -> result resume
 ```
 
+## Redundant handler cases are rejected
+
+```unison:error
+unique ability Give a where
+  give : a -> {Give a} Unit
+
+unique type T = A | B
+
+result : '{e, Give T} r -> {e} r
+result f = handle !f with cases
+       { x } -> x
+       { give _ -> resume } -> result resume
+       { give A -> resume } -> result resume
+```
+
+```unison:error
+unique ability Give a where
+  give : a -> {Give a} Unit
+
+unique type V =
+
+result : '{e, Give V} r -> {e} r
+result f = handle !f with cases
+       { x } -> x
+       { give _ -> resume } -> result resume
+```
+
 ## Exhaustive ability reinterpretations are accepted
 
 ```unison

--- a/unison-src/transcripts/pattern-match-coverage.md
+++ b/unison-src/transcripts/pattern-match-coverage.md
@@ -372,6 +372,21 @@ result f = handle !f with cases
        { abort -> _ } -> bug "aborted"
 ```
 
+```unison
+structural ability Abort where
+  abort : {Abort} a
+
+unique type V =
+
+result : '{e, Abort} V -> {e} V
+result f = 
+  impl : Request {Abort} V -> V
+  impl = cases
+       { abort -> _ } -> bug "aborted"
+  handle !f with impl
+```
+
+
 ## Non-exhaustive ability handlers are rejected
 
 ```unison:error
@@ -394,17 +409,6 @@ unique type T = A | B
 result : '{e, Abort} T -> {e} ()
 result f = handle !f with cases
        { A } -> ()
-       { abort -> _ } -> bug "aborted"
-```
-
-```unison:error
-structural ability Abort where
-  abort : {Abort} a
-
-unique type V =
-
-result : '{e, Abort} V -> {e} V
-result f = handle !f with cases
        { abort -> _ } -> bug "aborted"
 ```
 

--- a/unison-src/transcripts/pattern-match-coverage.output.md
+++ b/unison-src/transcripts/pattern-match-coverage.output.md
@@ -833,6 +833,28 @@ result f = handle !f with cases
 
 ```
 ```unison
+structural ability Abort where
+  abort : {Abort} a
+
+unique type V =
+
+result : '{e, Abort} V -> {e} V
+result f = handle !f with cases
+       { abort -> _ } -> bug "aborted"
+```
+
+```ucm
+
+  Pattern match doesn't cover all possible cases:
+        7 | result f = handle !f with cases
+        8 |        { abort -> _ } -> bug "aborted"
+    
+  
+  Patterns not matched:
+   * { _ }
+
+```
+```unison
 unique ability Give a where
   give : a -> {Give a} Unit
 
@@ -878,25 +900,6 @@ result f = handle !f with cases
     
 
 ```
-```unison
-unique ability Give a where
-  give : a -> {Give a} Unit
-
-unique type V =
-
-result : '{e, Give V} r -> {e} r
-result f = handle !f with cases
-       { x } -> x
-       { give _ -> resume } -> result resume
-```
-
-```ucm
-
-  This case would be ignored because it's already covered by the preceding case(s):
-        9 |        { give _ -> resume } -> result resume
-    
-
-```
 ## Exhaustive ability reinterpretations are accepted
 
 ```unison
@@ -924,6 +927,39 @@ result f = handle !f with cases
       result : '{e, Abort} a ->{e, Abort} a
 
 ```
+```unison
+structural ability Abort a where
+  abort : {Abort a} r
+  abortWithMessage : a -> {Abort a} r
+
+unique type V =
+
+result : '{e, Abort V} a -> {e, Abort V} a
+result f = 
+  impl : Request {Abort V} r -> {Abort V} r
+  impl = cases
+       { x } -> x
+       { abort -> _ } -> abort
+  handle !f with impl
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      structural ability Abort a
+      result : '{e, Abort V} a ->{e, Abort V} a
+    
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      unique type V
+
+```
 ## Non-exhaustive ability reinterpretations are rejected
 
 ```unison
@@ -948,5 +984,205 @@ result f = handle !f with cases
   
   Patterns not matched:
    * {abort -> _}
+
+```
+## Hacky workaround for uninhabited abilities
+
+Although all of the constructors of an ability might be uninhabited,
+the typechecker requires at least one be specified so that it can
+determine that the ability should be discharged. So, the default
+pattern match coverage checking behavior of prohibiting covering any
+of the cases is problematic. Instead, the pattern match coverage
+checker will require that at least one constructor be given, even if
+they are all uninhabited.
+
+The messages here aren't the best, but I don't think uninhabited
+abilities will come up and get handlers written for them often.
+
+```unison
+unique ability Give a where
+  give : a -> {Give a} Unit
+  give2 : a -> {Give a} Unit
+
+unique type V =
+
+result : '{e, Give V} r -> {e} r
+result f = 
+  impl : Request {Give V} r -> {} r
+  impl = cases
+       { x } -> x
+  handle !f with impl
+```
+
+```ucm
+
+  Pattern match doesn't cover all possible cases:
+       10 |   impl = cases
+       11 |        { x } -> x
+    
+  
+  Patterns not matched:
+  
+    * {give _ -> _}
+    * {give2 _ -> _}
+
+```
+```unison
+unique ability Give a where
+  give : a -> {Give a} Unit
+  give2 : a -> {Give a} Unit
+
+unique type V =
+
+result : '{e, Give V} r -> {e} r
+result f = 
+  impl : Request {Give V} r -> {} r
+  impl = cases
+       { x } -> x
+       { give _ -> resume } -> bug "impossible"
+  handle !f with impl
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique ability Give a
+      result : '{e, Give V} r ->{e} r
+    
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      unique type V
+
+```
+```unison
+unique ability Give a where
+  give : a -> {Give a} Unit
+  give2 : a -> {Give a} Unit
+
+unique type V =
+
+result : '{e, Give V} r -> {e} r
+result f = 
+  impl : Request {Give V} r -> {} r
+  impl = cases
+       { x } -> x
+       { give2 _ -> resume } -> bug "impossible"
+  handle !f with impl
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique ability Give a
+      result : '{e, Give V} r ->{e} r
+    
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      unique type V
+
+```
+```unison
+unique ability Give a where
+  give : a -> {Give a} Unit
+  give2 : a -> {Give a} Unit
+
+unique type V =
+
+result : '{e, Give V} r -> {e} r
+result f = 
+  impl : Request {Give V} r -> {} r
+  impl = cases
+       { x } -> x
+       { give _ -> resume } -> bug "impossible"
+       { give2 _ -> resume } -> bug "impossible"
+  handle !f with impl
+```
+
+```ucm
+
+  This case would be ignored because it's already covered by the preceding case(s):
+       13 |        { give2 _ -> resume } -> bug "impossible"
+    
+
+```
+```unison
+unique ability GiveA a where
+  giveA : a -> {GiveA a} Unit
+  giveA2 : a -> {GiveA a} Unit
+
+unique ability GiveB a where
+  giveB : a -> {GiveB a} Unit
+  giveB2 : a -> {GiveB a} Unit
+
+unique type V =
+
+result : '{e, GiveA V, GiveB V} r -> {e} r
+result f = 
+  impl : Request {GiveA V, GiveB V} r -> {} r
+  impl = cases
+       { x } -> x
+       { giveA _ -> _ } -> bug "impossible"
+       { giveA2 _ -> _ } -> bug "impossible"
+       { giveB _ -> _ } -> bug "impossible"
+       { giveB2 _ -> _ } -> bug "impossible"
+  handle !f with impl
+```
+
+```ucm
+
+  This case would be ignored because it's already covered by the preceding case(s):
+       17 |        { giveA2 _ -> _ } -> bug "impossible"
+    
+
+```
+```unison
+unique ability GiveA a where
+  giveA : a -> {GiveA a} Unit
+  giveA2 : a -> {GiveA a} Unit
+
+unique ability GiveB a where
+  giveB : a -> {GiveB a} Unit
+  giveB2 : a -> {GiveB a} Unit
+
+unique type V =
+
+result : '{e, GiveA V, GiveB V} r -> {e} r
+result f = 
+  impl : Request {GiveA V, GiveB V} r -> {} r
+  impl = cases
+       { x } -> x
+       { giveA2 _ -> _ } -> bug "impossible"
+       { giveB _ -> _ } -> bug "impossible"
+  handle !f with impl
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique ability GiveA a
+      unique ability GiveB a
+      result : '{e, GiveB V, GiveA V} r ->{e} r
+    
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      unique type V
 
 ```

--- a/unison-src/transcripts/pattern-match-coverage.output.md
+++ b/unison-src/transcripts/pattern-match-coverage.output.md
@@ -782,6 +782,37 @@ result f = handle !f with cases
       unique type T
 
 ```
+```unison
+structural ability Abort where
+  abort : {Abort} a
+
+unique type V =
+
+result : '{e, Abort} V -> {e} V
+result f = 
+  impl : Request {Abort} V -> V
+  impl = cases
+       { abort -> _ } -> bug "aborted"
+  handle !f with impl
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      structural ability Abort
+      result : '{e, Abort} V ->{e} V
+    
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      unique type V
+
+```
 ## Non-exhaustive ability handlers are rejected
 
 ```unison
@@ -830,28 +861,6 @@ result f = handle !f with cases
   
   Patterns not matched:
    * { B }
-
-```
-```unison
-structural ability Abort where
-  abort : {Abort} a
-
-unique type V =
-
-result : '{e, Abort} V -> {e} V
-result f = handle !f with cases
-       { abort -> _ } -> bug "aborted"
-```
-
-```ucm
-
-  Pattern match doesn't cover all possible cases:
-        7 | result f = handle !f with cases
-        8 |        { abort -> _ } -> bug "aborted"
-    
-  
-  Patterns not matched:
-   * { _ }
 
 ```
 ```unison

--- a/unison-src/transcripts/pattern-match-coverage.output.md
+++ b/unison-src/transcripts/pattern-match-coverage.output.md
@@ -856,6 +856,47 @@ result f = handle !f with cases
    * {give B -> _}
 
 ```
+## Redundant handler cases are rejected
+
+```unison
+unique ability Give a where
+  give : a -> {Give a} Unit
+
+unique type T = A | B
+
+result : '{e, Give T} r -> {e} r
+result f = handle !f with cases
+       { x } -> x
+       { give _ -> resume } -> result resume
+       { give A -> resume } -> result resume
+```
+
+```ucm
+
+  This case would be ignored because it's already covered by the preceding case(s):
+       10 |        { give A -> resume } -> result resume
+    
+
+```
+```unison
+unique ability Give a where
+  give : a -> {Give a} Unit
+
+unique type V =
+
+result : '{e, Give V} r -> {e} r
+result f = handle !f with cases
+       { x } -> x
+       { give _ -> resume } -> result resume
+```
+
+```ucm
+
+  This case would be ignored because it's already covered by the preceding case(s):
+        9 |        { give _ -> resume } -> result resume
+    
+
+```
 ## Exhaustive ability reinterpretations are accepted
 
 ```unison

--- a/unison-src/transcripts/pattern-pretty-print-2345.md
+++ b/unison-src/transcripts/pattern-pretty-print-2345.md
@@ -53,6 +53,7 @@ tremulous = cases
 
 throaty = cases
   { Ab.a a -> k } -> ()
+  { _ } -> ()
   
 agitated = cases
   a | a == 2 -> ()

--- a/unison-src/transcripts/pattern-pretty-print-2345.output.md
+++ b/unison-src/transcripts/pattern-pretty-print-2345.output.md
@@ -49,6 +49,7 @@ tremulous = cases
 
 throaty = cases
   { Ab.a a -> k } -> ()
+  { _ } -> ()
   
 agitated = cases
   a | a == 2 -> ()
@@ -181,7 +182,9 @@ doc = cases
 .> view throaty
 
   throaty : Request {g, Ab} x -> ()
-  throaty = cases {a a -> k} -> ()
+  throaty = cases
+    {a a -> k} -> ()
+    { _ }      -> ()
 
 .> view agitated
 


### PR DESCRIPTION
## Overview

Adds pattern match coverage checking for ability handlers. 


## Interesting/controversial decisions

Although all of the constructors of an ability might be uninhabited, the typechecker requires at least one be specified so that it can
determine which ability to discharge. So, the default pattern match coverage checking behavior of prohibiting covering any
of these (uninhabited) cases is problematic. Instead, the current hack is to require that at least one constructor be given, even if they are all uninhabited.

The messages in this case aren't the best, but I don't think uninhabited abilities will get handlers written for them often.


## Test coverage

See [this transcript](https://github.com/unisonweb/unison/blob/travis/ability-handler-pmcc/unison-src/transcripts/pattern-match-coverage.output.md#ability-handlers)
