### PR TITLE
Implement two-arg variant of `branch` command

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -64,7 +64,11 @@ data OptionalPatch = NoPatch | DefaultPatch | UsePatch PatchPath
 
 type BranchId = Either ShortCausalHash Path'
 
-type LooseCodeOrProject = Either Path' (Maybe ProjectName, ProjectBranchName)
+-- | A lot of commands can take either a loose code path or a project branch in the same argument slot. Usually, those
+-- have distinct syntaxes, but sometimes it's ambiguous, in which case we'd parse a `These`. The command itself can
+-- decide what to do with the ambiguity.
+type LooseCodeOrProject =
+  These Path' (ProjectAndBranch (Maybe ProjectName) ProjectBranchName)
 
 type AbsBranchId = Either ShortCausalHash Path.Absolute
 
@@ -221,7 +225,7 @@ data Input
   | ProjectSwitchI (These ProjectName ProjectBranchName)
   | ProjectsI
   | BranchesI
-  | BranchI (ProjectAndBranch (Maybe ProjectName) ProjectBranchName)
+  | BranchI (Maybe LooseCodeOrProject) (ProjectAndBranch (Maybe ProjectName) ProjectBranchName)
   deriving (Eq, Show)
 
 data DiffNamespaceToPatchInput = DiffNamespaceToPatchInput

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -341,7 +341,7 @@ data Output
 data CreatedProjectBranchFrom
   = CreatedProjectBranchFrom'LooseCode Path.Absolute
   | CreatedProjectBranchFrom'Nothingness
-  | CreatedProjectBranchFrom'OtherBranch (ProjectAndBranch ProjectName ProjectBranchName)
+  | CreatedProjectBranchFrom'OtherBranch (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch)
   | CreatedProjectBranchFrom'ParentBranch ProjectBranchName
 
 data DisplayDefinitionsOutput = DisplayDefinitionsOutput

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1820,22 +1820,29 @@ notifyUser dir = \case
     pure . P.warnCallout . P.wrap $
       P.group (prettyReadRemoteNamespace remote) <> "has some history, but is currently empty."
   CreatedProject projectName branchName ->
-    pure . P.wrap $
-      "I just created project"
-        <> prettyProjectName projectName
-        <> "with branch"
-        <> prettyProjectBranchName branchName
+    pure $
+      P.wrap
+        ( "I just created project"
+            <> prettyProjectName projectName
+            <> "with branch"
+            <> prettyProjectBranchName branchName
+        )
+        <> "."
   CreatedProjectBranch from projectAndBranch ->
     case from of
       CreatedProjectBranchFrom'LooseCode path ->
-        pure . P.wrap $
-          "Done. I've created the"
-            <> prettyProjectAndBranchName projectAndBranch
-            <> "branch from the namespace"
-            <> prettyAbsolute path
+        pure $
+          P.wrap
+            ( "Done. I've created the"
+                <> prettyProjectAndBranchName projectAndBranch
+                <> "branch from the namespace"
+                <> prettyAbsolute path
+            )
+            <> "."
       CreatedProjectBranchFrom'Nothingness ->
         pure $
           P.wrap ("Done. I've created an empty branch" <> prettyProjectAndBranchName projectAndBranch)
+            <> "."
             <> P.newline
             <> P.newline
             <> tip
@@ -1848,11 +1855,14 @@ notifyUser dir = \case
                   <> "to initialize this branch."
               )
       CreatedProjectBranchFrom'OtherBranch (ProjectAndBranch otherProject otherBranch) ->
-        pure . P.wrap $
-          "Done. I've created the"
-            <> prettyProjectAndBranchName projectAndBranch
-            <> "branch based off"
-            <> prettyProjectAndBranchName (ProjectAndBranch (otherProject ^. #name) (otherBranch ^. #name))
+        pure $
+          P.wrap
+            ( "Done. I've created the"
+                <> prettyProjectAndBranchName projectAndBranch
+                <> "branch based off"
+                <> prettyProjectAndBranchName (ProjectAndBranch (otherProject ^. #name) (otherBranch ^. #name))
+            )
+            <> "."
       CreatedProjectBranchFrom'ParentBranch parentBranch ->
         pure $
           P.wrap
@@ -1861,6 +1871,7 @@ notifyUser dir = \case
                 <> "branch based off of"
                 <> prettyProjectBranchName parentBranch
             )
+            <> "."
             <> P.newline
             <> P.newline
             <> tip

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1847,12 +1847,12 @@ notifyUser dir = \case
                     [prettyAbsolute (Path.Absolute (Path.fromList ["path", "to", "code"]))]
                   <> "to initialize this branch."
               )
-      CreatedProjectBranchFrom'OtherBranch otherProjectAndBranch ->
+      CreatedProjectBranchFrom'OtherBranch (ProjectAndBranch otherProject otherBranch) ->
         pure . P.wrap $
           "Done. I've created the"
             <> prettyProjectAndBranchName projectAndBranch
             <> "branch based off"
-            <> prettyProjectAndBranchName otherProjectAndBranch
+            <> prettyProjectAndBranchName (ProjectAndBranch (otherProject ^. #name) (otherBranch ^. #name))
       CreatedProjectBranchFrom'ParentBranch parentBranch ->
         pure $
           P.wrap

--- a/unison-src/transcripts/branch-command.md
+++ b/unison-src/transcripts/branch-command.md
@@ -18,26 +18,36 @@ someterm = 18
 
 Now, the `branch` demo:
 
-`branch` can create a branch from a different branch in the same project.
+`branch` can create a branch from a different branch in the same project, from a different branch in a different
+project, or from loose code.
 
 ```ucm
-foo/main> branch topic
-```
+foo/main> branch topic1
+foo/main> branch /topic2
+foo/main> branch foo/topic3
+foo/main> branch main topic4
+foo/main> branch main /topic5
+foo/main> branch main foo/topic6
+foo/main> branch /main topic7
+foo/main> branch /main /topic8
+foo/main> branch /main foo/topic9
+foo/main> branch foo/main topic10
+foo/main> branch foo/main /topic11
+.> branch foo/main foo/topic12
 
-`branch` can create a branch from a different branch in a different project.
-
-```ucm
 foo/main> branch bar/topic
-```
+bar/main> branch foo/main topic2
+bar/main> branch foo/main /topic3
+.> branch foo/main bar/topic4
 
-`branch` can create a branch from loose code.
-
-```ucm
-.some.loose.code> branch foo/topic2
+.some.loose.code> branch foo/topic13
+foo/main> branch .some.loose.code topic14
+foo/main> branch .some.loose.code /topic15
+.> branch .some.loose.code foo/topic16
 ```
 
 `switch` can create a branch from nothingness, but this feature is going away soon.
 
 ```ucm
-.some.loose.code> switch foo/topic3
+.some.loose.code> switch foo/empty
 ```

--- a/unison-src/transcripts/branch-command.output.md
+++ b/unison-src/transcripts/branch-command.output.md
@@ -24,123 +24,123 @@ project, or from loose code.
 ```ucm
 foo/main> branch topic1
 
-  Done. I've created the topic1 branch based off of main
+  Done. I've created the topic1 branch based off of main.
   
   Tip: Use `merge /topic1 /main` to merge your work back into
        the main branch.
 
 foo/main> branch /topic2
 
-  Done. I've created the topic2 branch based off of main
+  Done. I've created the topic2 branch based off of main.
   
   Tip: Use `merge /topic2 /main` to merge your work back into
        the main branch.
 
 foo/main> branch foo/topic3
 
-  Done. I've created the topic3 branch based off of main
+  Done. I've created the topic3 branch based off of main.
   
   Tip: Use `merge /topic3 /main` to merge your work back into
        the main branch.
 
 foo/main> branch main topic4
 
-  Done. I've created the topic4 branch based off of main
+  Done. I've created the topic4 branch based off of main.
   
   Tip: Use `merge /topic4 /main` to merge your work back into
        the main branch.
 
 foo/main> branch main /topic5
 
-  Done. I've created the topic5 branch based off of main
+  Done. I've created the topic5 branch based off of main.
   
   Tip: Use `merge /topic5 /main` to merge your work back into
        the main branch.
 
 foo/main> branch main foo/topic6
 
-  Done. I've created the topic6 branch based off of main
+  Done. I've created the topic6 branch based off of main.
   
   Tip: Use `merge /topic6 /main` to merge your work back into
        the main branch.
 
 foo/main> branch /main topic7
 
-  Done. I've created the topic7 branch based off of main
+  Done. I've created the topic7 branch based off of main.
   
   Tip: Use `merge /topic7 /main` to merge your work back into
        the main branch.
 
 foo/main> branch /main /topic8
 
-  Done. I've created the topic8 branch based off of main
+  Done. I've created the topic8 branch based off of main.
   
   Tip: Use `merge /topic8 /main` to merge your work back into
        the main branch.
 
 foo/main> branch /main foo/topic9
 
-  Done. I've created the topic9 branch based off of main
+  Done. I've created the topic9 branch based off of main.
   
   Tip: Use `merge /topic9 /main` to merge your work back into
        the main branch.
 
 foo/main> branch foo/main topic10
 
-  Done. I've created the topic10 branch based off of main
+  Done. I've created the topic10 branch based off of main.
   
   Tip: Use `merge /topic10 /main` to merge your work back into
        the main branch.
 
 foo/main> branch foo/main /topic11
 
-  Done. I've created the topic11 branch based off of main
+  Done. I've created the topic11 branch based off of main.
   
   Tip: Use `merge /topic11 /main` to merge your work back into
        the main branch.
 
 .> branch foo/main foo/topic12
 
-  Done. I've created the topic12 branch based off of main
+  Done. I've created the topic12 branch based off of main.
   
   Tip: Use `merge /topic12 /main` to merge your work back into
        the main branch.
 
 foo/main> branch bar/topic
 
-  Done. I've created the bar/topic branch based off foo/main
+  Done. I've created the bar/topic branch based off foo/main.
 
 bar/main> branch foo/main topic2
 
-  Done. I've created the bar/topic2 branch based off foo/main
+  Done. I've created the bar/topic2 branch based off foo/main.
 
 bar/main> branch foo/main /topic3
 
-  Done. I've created the bar/topic3 branch based off foo/main
+  Done. I've created the bar/topic3 branch based off foo/main.
 
 .> branch foo/main bar/topic4
 
-  Done. I've created the bar/topic4 branch based off foo/main
+  Done. I've created the bar/topic4 branch based off foo/main.
 
 .some.loose.code> branch foo/topic13
 
   Done. I've created the foo/topic13 branch from the namespace
-  .some.loose.code
+  .some.loose.code.
 
 foo/main> branch .some.loose.code topic14
 
   Done. I've created the foo/topic14 branch from the namespace
-  .some.loose.code
+  .some.loose.code.
 
 foo/main> branch .some.loose.code /topic15
 
   Done. I've created the foo/topic15 branch from the namespace
-  .some.loose.code
+  .some.loose.code.
 
 .> branch .some.loose.code foo/topic16
 
   Done. I've created the foo/topic16 branch from the namespace
-  .some.loose.code
+  .some.loose.code.
 
 ```
 `switch` can create a branch from nothingness, but this feature is going away soon.
@@ -148,7 +148,7 @@ foo/main> branch .some.loose.code /topic15
 ```ucm
 .some.loose.code> switch foo/empty
 
-  Done. I've created an empty branch foo/empty
+  Done. I've created an empty branch foo/empty.
   
   Tip: Use `merge /somebranch` or `merge .path.to.code` to
        initialize this branch.

--- a/unison-src/transcripts/branch-command.output.md
+++ b/unison-src/transcripts/branch-command.output.md
@@ -18,40 +18,137 @@ someterm = 18
 ```
 Now, the `branch` demo:
 
-`branch` can create a branch from a different branch in the same project.
+`branch` can create a branch from a different branch in the same project, from a different branch in a different
+project, or from loose code.
 
 ```ucm
-foo/main> branch topic
+foo/main> branch topic1
 
-  Done. I've created the topic branch based off of main
+  Done. I've created the topic1 branch based off of main
   
-  Tip: Use `merge /topic /main` to merge your work back into the
-       main branch.
+  Tip: Use `merge /topic1 /main` to merge your work back into
+       the main branch.
 
-```
-`branch` can create a branch from a different branch in a different project.
+foo/main> branch /topic2
 
-```ucm
+  Done. I've created the topic2 branch based off of main
+  
+  Tip: Use `merge /topic2 /main` to merge your work back into
+       the main branch.
+
+foo/main> branch foo/topic3
+
+  Done. I've created the topic3 branch based off of main
+  
+  Tip: Use `merge /topic3 /main` to merge your work back into
+       the main branch.
+
+foo/main> branch main topic4
+
+  Done. I've created the topic4 branch based off of main
+  
+  Tip: Use `merge /topic4 /main` to merge your work back into
+       the main branch.
+
+foo/main> branch main /topic5
+
+  Done. I've created the topic5 branch based off of main
+  
+  Tip: Use `merge /topic5 /main` to merge your work back into
+       the main branch.
+
+foo/main> branch main foo/topic6
+
+  Done. I've created the topic6 branch based off of main
+  
+  Tip: Use `merge /topic6 /main` to merge your work back into
+       the main branch.
+
+foo/main> branch /main topic7
+
+  Done. I've created the topic7 branch based off of main
+  
+  Tip: Use `merge /topic7 /main` to merge your work back into
+       the main branch.
+
+foo/main> branch /main /topic8
+
+  Done. I've created the topic8 branch based off of main
+  
+  Tip: Use `merge /topic8 /main` to merge your work back into
+       the main branch.
+
+foo/main> branch /main foo/topic9
+
+  Done. I've created the topic9 branch based off of main
+  
+  Tip: Use `merge /topic9 /main` to merge your work back into
+       the main branch.
+
+foo/main> branch foo/main topic10
+
+  Done. I've created the topic10 branch based off of main
+  
+  Tip: Use `merge /topic10 /main` to merge your work back into
+       the main branch.
+
+foo/main> branch foo/main /topic11
+
+  Done. I've created the topic11 branch based off of main
+  
+  Tip: Use `merge /topic11 /main` to merge your work back into
+       the main branch.
+
+.> branch foo/main foo/topic12
+
+  Done. I've created the topic12 branch based off of main
+  
+  Tip: Use `merge /topic12 /main` to merge your work back into
+       the main branch.
+
 foo/main> branch bar/topic
 
   Done. I've created the bar/topic branch based off foo/main
 
-```
-`branch` can create a branch from loose code.
+bar/main> branch foo/main topic2
 
-```ucm
-.some.loose.code> branch foo/topic2
+  Done. I've created the bar/topic2 branch based off foo/main
 
-  Done. I've created the foo/topic2 branch from the namespace
+bar/main> branch foo/main /topic3
+
+  Done. I've created the bar/topic3 branch based off foo/main
+
+.> branch foo/main bar/topic4
+
+  Done. I've created the bar/topic4 branch based off foo/main
+
+.some.loose.code> branch foo/topic13
+
+  Done. I've created the foo/topic13 branch from the namespace
+  .some.loose.code
+
+foo/main> branch .some.loose.code topic14
+
+  Done. I've created the foo/topic14 branch from the namespace
+  .some.loose.code
+
+foo/main> branch .some.loose.code /topic15
+
+  Done. I've created the foo/topic15 branch from the namespace
+  .some.loose.code
+
+.> branch .some.loose.code foo/topic16
+
+  Done. I've created the foo/topic16 branch from the namespace
   .some.loose.code
 
 ```
 `switch` can create a branch from nothingness, but this feature is going away soon.
 
 ```ucm
-.some.loose.code> switch foo/topic3
+.some.loose.code> switch foo/empty
 
-  Done. I've created an empty branch foo/topic3
+  Done. I've created an empty branch foo/empty
   
   Tip: Use `merge /somebranch` or `merge .path.to.code` to
        initialize this branch.

--- a/unison-src/transcripts/delete-project-branch.output.md
+++ b/unison-src/transcripts/delete-project-branch.output.md
@@ -4,11 +4,11 @@ your working directory with each command).
 ```ucm
 .> project.create foo
 
-  I just created project foo with branch main
+  I just created project foo with branch main.
 
 foo/main> branch /topic
 
-  Done. I've created the topic branch based off of main
+  Done. I've created the topic branch based off of main.
   
   Tip: Use `merge /topic /main` to merge your work back into the
        main branch.

--- a/unison-src/transcripts/project-merge.output.md
+++ b/unison-src/transcripts/project-merge.output.md
@@ -32,7 +32,7 @@ zonk = 0
 
 .> project.create foo
 
-  I just created project foo with branch main
+  I just created project foo with branch main.
 
 .> merge foo foo/main
 
@@ -74,7 +74,7 @@ foo/main> add
 ```ucm
 .> project.create bar
 
-  I just created project bar with branch main
+  I just created project bar with branch main.
 
 bar/main> merge foo/main
 
@@ -93,7 +93,7 @@ bar/main> merge foo/main
 
 bar/main> branch /topic
 
-  Done. I've created the topic branch based off of main
+  Done. I've created the topic branch based off of main.
   
   Tip: Use `merge /topic /main` to merge your work back into the
        main branch.


### PR DESCRIPTION
## Overview

This PR implements the two-argument variant of `branch`:

```
branch source destination
```

where `source` can be:

- A relative loose code path
- An absolute loose code path
- A project branch written as `branch` (requires the user to be on a branch)
- A project branch written as `/branch` (requires the user to be on a branch)
- A project branch written as `project/branch`

and `destination` (as in the one-argument variant) can be:

- A project branch written as `branch` (requires the user to be on a branch)
- A project branch written as `/branch` (requires the user to be on a branch)
- A project branch written as `project/branch`

As is standard for commands like this, these two variants can be ambiguous with our current syntax:

- A relative loose code path
- A project branch written as `branch` (requires the user to be on a branch)

In this PR, the `branch` command always treats such parses as the latter, as that seems far more common. A future PR could make `branch` smarter by treating such parses as loose code (when such a namespace exists, but no such branch), or a branch (when such a branch exists, but no such namespace), or reject (when both or neither exist).

Note: the current implementation doesn't check to see if a namespace provided is empty or not. For example, this will succeed:

```
branch .non.existent.empty.namespace /topic
```

and it will create an empty `topic` branch. If that is undesirable, it's easy to change. I just wasn't sure what we wanted.

## Test coverage

The `create-branch` transcript has been updated.