### PR TITLE
Don't use named parameters in sql2 quasi-quoter

### DIFF
--- a/lib/unison-sqlite/src/Unison/Sqlite/Exception.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Exception.hs
@@ -16,6 +16,7 @@ module Unison.Sqlite.Exception
     isSqliteBusyException,
     SqliteQueryExceptionInfo (..),
     throwSqliteQueryException,
+    throwSqliteQueryException2,
     SomeSqliteExceptionReason (..),
     SqliteExceptionReason,
   )
@@ -147,6 +148,21 @@ throwSqliteQueryException SqliteQueryExceptionInfo {connection, exception, param
     SqliteQueryException
       { sql,
         params = maybe "" anythingToString params,
+        exception,
+        callStack,
+        connection,
+        threadId
+      }
+
+-- Will replace `throwSqliteQueryException` when `sql2` replaces `sql` everywhere.
+throwSqliteQueryException2 :: SqliteQueryExceptionInfo [Sqlite.SQLData] -> IO a
+throwSqliteQueryException2 SqliteQueryExceptionInfo {connection, exception, params, sql} = do
+  threadId <- myThreadId
+  callStack <- currentCallStack
+  throwIO
+    SqliteQueryException
+      { sql,
+        params = show (fromMaybe [] params),
         exception,
         callStack,
         connection,

--- a/lib/unison-sqlite/src/Unison/Sqlite/Sql2.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Sql2.hs
@@ -15,6 +15,7 @@ import qualified Data.Char as Char
 import Data.Generics.Labels ()
 import qualified Data.Text as Text
 import qualified Database.SQLite.Simple as Sqlite.Simple
+import qualified Database.SQLite.Simple.ToField as Sqlite.Simple
 import qualified Language.Haskell.TH as TH
 import qualified Language.Haskell.TH.Quote as TH
 import qualified Text.Builder
@@ -26,7 +27,7 @@ import Unison.Prelude
 -- | A SQL query.
 data Sql2 = Sql2
   { query :: Text,
-    params :: [Sqlite.Simple.NamedParam]
+    params :: [Sqlite.Simple.SQLData]
   }
   deriving stock (Show)
 
@@ -36,6 +37,8 @@ data Sql2 = Sql2
 -- For example, the query
 --
 -- @
+-- let qux = 5 :: Int
+--
 -- [sql2|
 --   SELECT foo
 --   FROM bar
@@ -47,8 +50,8 @@ data Sql2 = Sql2
 --
 -- @
 -- Sql2
---   { query = "SELECT foo FROM bar WHERE baz = :qux"
---   , params = [":qux" := qux]
+--   { query = "SELECT foo FROM bar WHERE baz = ?"
+--   , params = [SQLInteger 5]
 --   }
 -- @
 --
@@ -67,7 +70,7 @@ sql2QQ input =
               ( \var ->
                   TH.lookupValueName (Text.unpack var) >>= \case
                     Nothing -> fail ("Not in scope: " ++ Text.unpack var)
-                    Just name -> [|(Text.cons ':' var) Sqlite.Simple.:= $(TH.varE name)|]
+                    Just name -> [|Sqlite.Simple.toField $(TH.varE name)|]
               )
               params0
       [|Sql2 query $(TH.listE params)|]
@@ -79,9 +82,9 @@ internalParseSql :: Text -> Either String (Text, [Text])
 internalParseSql input =
   case runP (parser <* Megaparsec.eof) (Text.strip input) of
     Left err -> Left (Megaparsec.errorBundlePretty err)
-    Right ((), S {sql, params}) -> Right (Text.Builder.run sql, params [])
+    Right ((), S {sql, params}) -> Right (Text.Builder.run sql, reverse params)
 
--- Parser state: the SQL parsed so far, and a difference list of parameter names.
+-- Parser state: the SQL parsed so far, and a list of parameter names (in reverse order).
 --
 -- For example, if we were partway through parsing the query
 --
@@ -97,12 +100,15 @@ internalParseSql input =
 --     , params = ["bonk"]
 --     }
 --
--- Why keep the SQL parsed so far: so we can make the query slightly prettier by replacing all runs of 1+ characters of
--- whitespace with a single space. This lets us write vertically aligned SQL queries at arbitrary indentations in
--- Haskell quasi-quoters, but not have to look at a bunch of "\n        " in debug logs and such.
+-- Why keep the SQL parsed so far:
+--
+--   1. We need to replace variables with question marks.
+--   2. We can make the query slightly prettier by replacing all runs of 1+ characters of whitespace with a single
+--      space. This lets us write vertically aligned SQL queries at arbitrary indentations in Haskell quasi-quoters,
+--      but not have to look at a bunch of "\n        " in debug logs and such.
 data S = S
   { sql :: !Text.Builder,
-    params :: [Text] -> [Text]
+    params :: [Text]
   }
   deriving stock (Generic)
 
@@ -111,7 +117,7 @@ type P a =
 
 runP :: P a -> Text -> Either (Megaparsec.ParseErrorBundle Text Void) (a, S)
 runP p =
-  Megaparsec.runParser (State.runStateT p (S mempty id)) ""
+  Megaparsec.runParser (State.runStateT p (S mempty [])) ""
 
 -- Parser for a SQL query (stored in the parser state).
 parser :: P ()
@@ -121,8 +127,8 @@ parser = do
       #sql <>= fragment
       parser
     Param param -> do
-      #sql <>= (Text.Builder.char ':' <> param)
-      #params %= (. (Text.Builder.run param :))
+      #sql <>= Text.Builder.char '?'
+      #params %= (Text.Builder.run param :)
       parser
     Whitespace -> do
       #sql <>= Text.Builder.char ' '

--- a/lib/unison-sqlite/test/Main.hs
+++ b/lib/unison-sqlite/test/Main.hs
@@ -12,8 +12,8 @@ test :: Test ()
 test =
   tests
     [ scope "internalParseSql" do
-        let sql = "   foo :a\n   'foo''foo' :b\n   \"foo\"\"foo\" :c\n   `foo``foo`   \n[foo] :d  "
-        let expected = Right ("foo :a 'foo''foo' :b \"foo\"\"foo\" :c `foo``foo` [foo] :d", ["a", "b", "c", "d"])
+        let sql = "   foo :a\n   'foo''foo' @b\n   \"foo\"\"foo\" $c\n   `foo``foo`   \n[foo] :d  "
+        let expected = Right ("foo ? 'foo''foo' ? \"foo\"\"foo\" ? `foo``foo` [foo] ?", ["a", "b", "c", "d"])
         let actual = internalParseSql sql
         expectEqual expected actual
     ]


### PR DESCRIPTION
## Overview

This PR replaces the use of named parameters in our SQL quasi-quoter with raw data and unnamed `?` params, as suggested by @tstat. Now, we have better debug/error messages, and we have a way forward to support full query interpolation. 

Also, an unrelated change in this PR: I expanded the syntax we allow for variable interpolation from just `:foo` to any of `:foo`, `@foo`, and `$foo`, following SQLite.

## Test coverage

This change is tested in `unison-sqlite`'s test suite