### PR TITLE
Toss comments in sql quasi-quoter

### DIFF
--- a/lib/unison-sqlite/src/Unison/Sqlite/Sql2.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Sql2.hs
@@ -108,6 +108,7 @@ internalParseSql input =
 --   2. We can make the query slightly prettier by replacing all runs of 1+ characters of whitespace with a single
 --      space. This lets us write vertically aligned SQL queries at arbitrary indentations in Haskell quasi-quoters,
 --      but not have to look at a bunch of "\n        " in debug logs and such.
+--   3. We strip comments.
 data S = S
   { sql :: !Text.Builder,
     params :: [Text]
@@ -125,6 +126,7 @@ runP p =
 parser :: P ()
 parser = do
   fragmentParser >>= \case
+    Comment -> parser
     NonParam fragment -> do
       #sql <>= fragment
       parser
@@ -181,7 +183,8 @@ parser = do
 -- A parsed query can be reconstructed by simply concatenating all fragments together, with a colon character ':'
 -- prepended to each Param fragment.
 data Fragment
-  = NonParam Text.Builder
+  = Comment -- we toss these, so we don't bother remembering the contents
+  | NonParam Text.Builder
   | Param Text.Builder
   | Whitespace
   | EndOfInput
@@ -189,11 +192,13 @@ data Fragment
 fragmentParser :: P Fragment
 fragmentParser =
   asum
-    [ Whitespace <$ Megaparsec.takeWhile1P (Just "whitepsace") Char.isSpace,
+    [ Whitespace <$ whitespaceP,
       NonParam <$> betwixt "string" '\'',
       NonParam <$> betwixt "identifier" '"',
       NonParam <$> betwixt "identifier" '`',
       NonParam <$> bracketedIdentifierP,
+      Comment <$ lineCommentP,
+      Comment <$ blockCommentP,
       Param <$> paramP,
       NonParam <$> unstructuredP,
       EndOfInput <$ Megaparsec.eof
@@ -211,10 +216,29 @@ fragmentParser =
       z <- char ']'
       pure (x <> Text.Builder.text ys <> z)
 
+    lineCommentP :: P ()
+    lineCommentP = do
+      _ <- Megaparsec.string "--"
+      _ <- Megaparsec.takeWhileP (Just "comment") (/= '\n')
+      -- Eat whitespace after a line comment just so we don't end up with [Whitespace, Comment, Whitespace] fragments,
+      -- which would get serialized as two consecutive spaces
+      whitespaceP
+
+    blockCommentP :: P ()
+    blockCommentP = do
+      _ <- Megaparsec.string "/*"
+      let loop = do
+            _ <- Megaparsec.takeWhileP (Just "comment") (/= '*')
+            Megaparsec.string "*/" <|> (Megaparsec.anySingle >> loop)
+      _ <- loop
+      -- See whitespace-eating comment above
+      whitespaceP
+
     unstructuredP :: P Text.Builder
     unstructuredP = do
+      x <- Megaparsec.anySingle
       xs <-
-        Megaparsec.takeWhile1P
+        Megaparsec.takeWhileP
           (Just "sql")
           \c ->
             not (Char.isSpace c)
@@ -225,7 +249,9 @@ fragmentParser =
               && c /= '$'
               && c /= '`'
               && c /= '['
-      pure (Text.Builder.text xs)
+              && c /= '-'
+              && c /= '/'
+      pure (Text.Builder.char x <> Text.Builder.text xs)
 
     paramP :: P Text.Builder
     paramP = do
@@ -233,6 +259,10 @@ fragmentParser =
       x <- Megaparsec.satisfy (\c -> Char.isAlpha c || c == '_')
       xs <- Megaparsec.takeWhileP (Just "parameter") \c -> Char.isAlphaNum c || c == '_' || c == '\''
       pure (Text.Builder.char x <> Text.Builder.text xs)
+
+    whitespaceP :: P ()
+    whitespaceP = do
+      void (Megaparsec.takeWhile1P (Just "whitepsace") Char.isSpace)
 
 -- @betwixt name c@ parses a @c@-surrounded string of arbitrary characters (naming the parser @name@), where two @c@s
 -- in a row inside the string is the syntax for a single @c@. This is simply how escaping works in SQLite for

--- a/lib/unison-sqlite/test/Main.hs
+++ b/lib/unison-sqlite/test/Main.hs
@@ -11,9 +11,21 @@ main =
 test :: Test ()
 test =
   tests
-    [ scope "internalParseSql" do
-        let sql = "   foo :a\n   'foo''foo' @b\n   \"foo\"\"foo\" $c\n   `foo``foo`   \n[foo] :d  "
-        let expected = Right ("foo ? 'foo''foo' ? \"foo\"\"foo\" ? `foo``foo` [foo] ?", ["a", "b", "c", "d"])
-        let actual = internalParseSql sql
-        expectEqual expected actual
+    [ scope "internalParseSql" . tests $
+        [ do
+            let sql = "   foo :a\n   'foo''foo' @b\n   \"foo\"\"foo\" $c\n   `foo``foo`   \n[foo] :d  "
+            let expected = Right ("foo ? 'foo''foo' ? \"foo\"\"foo\" ? `foo``foo` [foo] ?", ["a", "b", "c", "d"])
+            let actual = internalParseSql sql
+            expectEqual expected actual,
+          scope "strips line comments" do
+            let sql = "foo -- bar \n baz"
+            let expected = Right ("foo baz", [])
+            let actual = internalParseSql sql
+            expectEqual expected actual,
+          scope "strips block comments" do
+            let sql = "foo /* bar baz \n */ qux"
+            let expected = Right ("foo qux", [])
+            let actual = internalParseSql sql
+            expectEqual expected actual
+        ]
     ]


### PR DESCRIPTION
## Overview

This PR fixes a bug in the SQL quasi-quoter: we didn't treat comments specially.

Previously, a SQL query with a line-comment anywhere but the last line would have its meaning changed.

In:

```sql
SELECT foo -- cool comment
FROM /* another cool comment */ bar
```

Out:

```sql
SELECT foo -- cool comment FROM /* another cool comment */ bar
```

Now, we parse and throw away line- and block-comments.

In:

```sql
SELECT foo -- cool comment
FROM /* another cool comment */ bar
```

Out:

```sql
SELECT foo FROM bar
```

## Test coverage

This change is tested.