### PR TITLE
Add a sql quasi-quoter syntax for Haskell values that span multiple SQLite fields

### DIFF
--- a/lib/unison-sqlite/package.yaml
+++ b/lib/unison-sqlite/package.yaml
@@ -51,6 +51,7 @@ ghc-options:
   -Wall
 
 default-extensions:
+  - BangPatterns
   - BlockArguments
   - ConstraintKinds
   - DeriveAnyClass

--- a/lib/unison-sqlite/src/Unison/Sqlite/Connection.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Connection.hs
@@ -1,4 +1,3 @@
--- pTrace
 {-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Unison.Sqlite.Connection
@@ -191,14 +190,14 @@ instance Show Query2 where
       ]
 
 -- Will replace `logQuery` when `sql2` replaces `sql` everywhere.
-logQuery2 :: Sql -> [Sqlite.SQLData] -> Maybe b -> IO ()
+logQuery2 :: Sql -> [Either Sqlite.SQLData [Sqlite.SQLData]] -> Maybe b -> IO ()
 logQuery2 sql params result =
   Debug.whenDebug Debug.Sqlite do
     callStack <- currentCallStack
     pTraceShowM
       Query2
         { sql,
-          params,
+          params = flattenParameters params,
           result = anythingToString <$> result,
           callStack
         }
@@ -225,14 +224,14 @@ execute2 conn@(Connection _ _ conn0) (Sql2 s params) = do
       SqliteQueryExceptionInfo
         { connection = conn,
           exception = SomeSqliteExceptionReason exception,
-          params = Just params,
+          params = Just (foldMap (either pure id) params),
           sql = Sql s
         }
   where
     doExecute :: IO ()
     doExecute =
       Sqlite.withStatement conn0 (coerce s) \(Sqlite.Statement statement) -> do
-        zipWithM_ (Direct.Sqlite.bindSQLData statement) [1 ..] params
+        bindParameters statement params
         void (Direct.Sqlite.step statement)
 
 executeMany :: (Sqlite.ToRow a) => Connection -> Sql -> [a] -> IO ()
@@ -344,7 +343,7 @@ queryListRow2 conn@(Connection _ _ conn0) (Sql2 s params) = do
           SqliteQueryExceptionInfo
             { connection = conn,
               exception = SomeSqliteExceptionReason exception,
-              params = Just params,
+              params = Just (flattenParameters params),
               sql = Sql s
             }
   logQuery2 (Sql s) params (Just result)
@@ -353,7 +352,7 @@ queryListRow2 conn@(Connection _ _ conn0) (Sql2 s params) = do
     doQuery :: IO [a]
     doQuery =
       Sqlite.withStatement conn0 (coerce s) \statement -> do
-        zipWithM_ (Direct.Sqlite.bindSQLData (coerce statement)) [1 ..] params
+        bindParameters (coerce statement) params
         let loop :: [a] -> IO [a]
             loop rows =
               Sqlite.nextRow statement >>= \case
@@ -669,6 +668,35 @@ rollbackTo conn name =
 release :: Connection -> Text -> IO ()
 release conn name =
   execute_ conn (Sql ("RELEASE " <> name))
+
+-----------------------------------------------------------------------------------------------------------------------
+-- Utils
+
+bindParameters :: Direct.Sqlite.Statement -> [Either Sqlite.SQLData [Sqlite.SQLData]] -> IO ()
+bindParameters statement =
+  loop1 1
+  where
+    loop1 :: Direct.Sqlite.ParamIndex -> [Either Sqlite.SQLData [Sqlite.SQLData]] -> IO ()
+    loop1 !i = \case
+      [] -> pure ()
+      Left p : ps -> do
+        Direct.Sqlite.bindSQLData statement i p
+        loop1 (i + 1) ps
+      Right ps : qs -> do
+        j <- loop2 i ps
+        loop1 j qs
+    loop2 :: Direct.Sqlite.ParamIndex -> [Sqlite.SQLData] -> IO Direct.Sqlite.ParamIndex
+    loop2 !i = \case
+      [] -> pure i
+      p : ps -> do
+        Direct.Sqlite.bindSQLData statement i p
+        loop2 (i + 1) ps
+
+-- On happy paths we can just bind all of the parameters in this Either form - no need to pay for flattening. But for
+-- logging or reporting exceptions, we flatten.
+flattenParameters :: [Either Sqlite.SQLData [Sqlite.SQLData]] -> [Sqlite.SQLData]
+flattenParameters =
+  foldMap (either pure id)
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Exceptions

--- a/lib/unison-sqlite/src/Unison/Sqlite/Internal.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Internal.hs
@@ -1,4 +1,4 @@
 -- | Internals exported for testing.
 module Unison.Sqlite.Internal (module X) where
 
-import Unison.Sqlite.Sql2 as X (internalParseSql)
+import Unison.Sqlite.Sql2 as X (Param (..), internalParseSql)

--- a/lib/unison-sqlite/src/Unison/Sqlite/Sql2.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Sql2.hs
@@ -128,7 +128,7 @@ parser = do
     NonParam fragment -> do
       #sql <>= fragment
       parser
-    Param param -> do
+    FieldParam param -> do
       #sql <>= Text.Builder.char '?'
       #params %= (Text.Builder.run param :)
       parser
@@ -161,7 +161,7 @@ parser = do
 --   , Whitespace
 --   , NonParam "="
 --   , Whitespace
---   , Param "bonk"
+--   , FieldParam "bonk"
 --   , Whitespace
 --   , NonParam "AND"
 --   , Whitespace
@@ -172,17 +172,9 @@ parser = do
 --   , NonParam "'monkey monk'"
 --   , EndOfInput
 --   ]
---
--- Any sequence of consecutive NonParam fragments in such a list is equivalent to a single NonParam fragment with the
--- contents concatenated. How the non-parameter stuff between parameters is turned into 1+ NonParam fragments is just a
--- consequence of how we parse these SQL strings: identify strings and such, but otherwise make no attempt to
--- understand the structure of the query.
---
--- A parsed query can be reconstructed by simply concatenating all fragments together, with a colon character ':'
--- prepended to each Param fragment.
 data Fragment
   = NonParam Text.Builder
-  | Param Text.Builder
+  | FieldParam Text.Builder
   | Whitespace
   | EndOfInput
 
@@ -194,7 +186,7 @@ fragmentParser =
       NonParam <$> betwixt "identifier" '"',
       NonParam <$> betwixt "identifier" '`',
       NonParam <$> bracketedIdentifierP,
-      Param <$> paramP,
+      FieldParam <$> fieldParamP,
       NonParam <$> unstructuredP,
       EndOfInput <$ Megaparsec.eof
     ]
@@ -227,8 +219,8 @@ fragmentParser =
               && c /= '['
       pure (Text.Builder.text xs)
 
-    paramP :: P Text.Builder
-    paramP = do
+    fieldParamP :: P Text.Builder
+    fieldParamP = do
       _ <- Megaparsec.satisfy (\c -> c == ':' || c == '@' || c == '$')
       x <- Megaparsec.satisfy (\c -> Char.isAlpha c || c == '_')
       xs <- Megaparsec.takeWhileP (Just "parameter") \c -> Char.isAlphaNum c || c == '_' || c == '\''

--- a/lib/unison-sqlite/src/Unison/Sqlite/Sql2.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Sql2.hs
@@ -5,6 +5,7 @@ module Unison.Sqlite.Sql2
     sql2,
 
     -- * Exported for testing
+    Param (..),
     internalParseSql,
   )
 where

--- a/lib/unison-sqlite/test/Main.hs
+++ b/lib/unison-sqlite/test/Main.hs
@@ -2,7 +2,7 @@ module Main (main) where
 
 import EasyTest
 import System.IO.CodePage (withCP65001)
-import Unison.Sqlite.Internal (internalParseSql)
+import Unison.Sqlite.Internal (Param (..), internalParseSql)
 
 main :: IO ()
 main =
@@ -13,8 +13,21 @@ test =
   tests
     [ scope "internalParseSql" . tests $
         [ do
-            let sql = "   foo :a\n   'foo''foo' @b\n   \"foo\"\"foo\" $c\n   `foo``foo`   \n[foo] :d  "
-            let expected = Right ("foo ? 'foo''foo' ? \"foo\"\"foo\" ? `foo``foo` [foo] ?", ["a", "b", "c", "d"])
+            let sql = "   foo :a\n   'foo''foo' :b\n   \"foo\"\"foo\" $c\n   `foo``foo`   \n[foo] $d  "
+            let expected =
+                  Right
+                    ( "foo ? 'foo''foo' ? \"foo\"\"foo\" ? `foo``foo` [foo] ?",
+                      [ FieldParam "a",
+                        FieldParam "b",
+                        FieldParam "c",
+                        FieldParam "d"
+                      ]
+                    )
+            let actual = internalParseSql sql
+            expectEqual expected actual,
+          scope "parses @param syntax" do
+            let sql = "@foo @bar @"
+            let expected = Right ("? ? ?", [RowParam "foo" 1, RowParam "bar" 2])
             let actual = internalParseSql sql
             expectEqual expected actual,
           scope "strips line comments" do

--- a/lib/unison-sqlite/unison-sqlite.cabal
+++ b/lib/unison-sqlite/unison-sqlite.cabal
@@ -32,6 +32,7 @@ library
   hs-source-dirs:
       src
   default-extensions:
+      BangPatterns
       BlockArguments
       ConstraintKinds
       DeriveAnyClass
@@ -89,6 +90,7 @@ test-suite tests
   hs-source-dirs:
       test
   default-extensions:
+      BangPatterns
       BlockArguments
       ConstraintKinds
       DeriveAnyClass


### PR DESCRIPTION
- [x] Depends on #3920 
- [x] Depends on #3921 

## Overview

This PR repurposes the `@param` syntax in our SQL quasi-quoter for interpolating variables that span multiple SQLite columns.

For example, a query such as

```haskell
addToTypeIndex :: Reference' TextId HashId -> Referent.Id -> Transaction ()
addToTypeIndex tp tm =
  execute
    [sql|
      INSERT INTO find_type_index (
        type_reference_builtin,
        type_reference_hash_id,
        type_reference_component_index,
        term_referent_object_id,
        term_referent_component_index,
        term_referent_constructor_index
      ) VALUES (?, ?, ?, ?, ?, ?)
      ON CONFLICT DO NOTHING
    |]
    (tp :. tm)
|]
```

can now be written

```haskell
addToTypeIndex :: Reference' TextId HashId -> Referent.Id -> Transaction ()
addToTypeIndex tp tm =
  execute2
    [sql2|
      INSERT INTO find_type_index (
        type_reference_builtin,
        type_reference_hash_id,
        type_reference_component_index,
        term_referent_object_id,
        term_referent_component_index,
        term_referent_constructor_index
      ) VALUES (@tp, @, @, @tm, @, @)
      ON CONFLICT DO NOTHING
    |]
|]
```

Each variable like `@tp` ought to be followed by one or more `@`s; these will each be replaced by a `?` by the quasi-quoter, and we'll call `toRow` on `tp` to get the list of `SQLData` values.

It's a compile-time error to write an unnamed `@` without a preceding named `@` like `@foo`.

It's not a compile-time error to use a named `@` that's not followed by any unnamed `@`s (i.e. expecting a one-field `toRow` instance), but maybe it should be, because you should just use `:` syntax instead for single-column things.

There's no runtime check that the number of `@`s equals the number of values we get out of `toRow`.

## Test coverage

This change is lightly tested and the quasi-quoter appears to generate the right SQL and list of `SQLData`. I also refactored one query to use the new syntax and confirmed manually that it still works properly.