### PR TITLE
Fix parsing of write-repo git(...)

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/UriParser.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/UriParser.hs
@@ -98,8 +98,8 @@ writeRemoteNamespace =
 
 writeRemoteNamespaceWith :: P a -> P (WriteRemoteNamespace a)
 writeRemoteNamespaceWith projectBranchParser =
-  WriteRemoteProjectBranch <$> projectBranchParser
-    <|> WriteRemoteNamespaceGit <$> writeGitRemoteNamespace
+  WriteRemoteNamespaceGit <$> writeGitRemoteNamespace
+    <|> WriteRemoteProjectBranch <$> projectBranchParser
     <|> WriteRemoteNamespaceShare <$> writeShareRemoteNamespace
 
 -- >>> P.parseMaybe writeShareRemoteNamespace "unisonweb.base._releases.M4"


### PR DESCRIPTION
## Overview

Fixes #3925

This PR fixes a regression in parsing `git(...)` syntax as a write-repo.

Previously, the write-repo parser was written as `project-branch | git-repo | loose-code`; the problem with this ordering is `git` is a valid project name, so that parser was succeeding, leaving `(...)` as unparsed leftovers.

The fix is to permute the parser alternatives to `git-repo | project-branch | loose-code`.

The correct ordering is used in the read-repo parser, which is under test. I amended the URI parser test suites to put the write-repo parser under test, too. It was previously untested.