### PR TITLE
delete `switch` command's ability to make branches

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectSwitch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectSwitch.hs
@@ -4,70 +4,21 @@ module Unison.Codebase.Editor.HandleInput.ProjectSwitch
   )
 where
 
-import Control.Lens (view, (^.))
+import Control.Lens ((^.))
 import Data.These (These (..))
-import qualified Data.UUID.V4 as UUID
-import U.Codebase.Sqlite.DbId
-import qualified U.Codebase.Sqlite.ProjectBranch as Sqlite
 import qualified U.Codebase.Sqlite.Queries as Queries
 import Unison.Cli.Monad (Cli)
 import qualified Unison.Cli.Monad as Cli
-import qualified Unison.Cli.MonadUtils as Cli (getBranchAt, updateAt)
 import qualified Unison.Cli.ProjectUtils as ProjectUtils
-import qualified Unison.Codebase.Branch as Branch (empty)
 import qualified Unison.Codebase.Editor.Output as Output
 import Unison.Prelude
 import Unison.Project (ProjectAndBranch (..), ProjectBranchName, ProjectName)
-import qualified Unison.Sqlite as Sqlite
 
-data SwitchToBranchOutcome
-  = SwitchedToExistingBranch
-  | SwitchedToNewBranch (Maybe Sqlite.ProjectBranch) -- parent
-
--- | Switch to (or create) a project or project branch.
+-- | Switch to an existing project or project branch.
 projectSwitch :: These ProjectName ProjectBranchName -> Cli ()
 projectSwitch projectAndBranchNames0 = do
   projectAndBranchNames@(ProjectAndBranch projectName branchName) <- ProjectUtils.hydrateNames projectAndBranchNames0
-  project <-
-    Cli.runTransaction (Queries.loadProjectByName projectName) & onNothingM do
+  branch <-
+    Cli.runTransaction (Queries.loadProjectBranchByNames projectName branchName) & onNothingM do
       Cli.returnEarly (Output.LocalProjectBranchDoesntExist projectAndBranchNames)
-  let projectId = project ^. #projectId
-  maybeCurrentProject <- ProjectUtils.getCurrentProjectBranch
-  (outcome, branchId) <-
-    Cli.runTransaction do
-      Queries.loadProjectBranchByName projectId branchName >>= \case
-        Just branch -> pure (SwitchedToExistingBranch, branch ^. #branchId)
-        Nothing -> do
-          newBranchId <- Sqlite.unsafeIO (ProjectBranchId <$> UUID.nextRandom)
-          -- If we create a new branch from outside its project, then the new branch is "detached" (no history, no
-          -- parent).
-          let parentBranch = do
-                ProjectAndBranch currentProject currentBranch <- maybeCurrentProject
-                guard (projectId == currentProject ^. #projectId)
-                Just currentBranch
-          Queries.insertProjectBranch
-            Sqlite.ProjectBranch
-              { projectId,
-                branchId = newBranchId,
-                name = branchName,
-                parentBranchId = view #branchId <$> parentBranch
-              }
-          pure (SwitchedToNewBranch parentBranch, newBranchId)
-  let path = ProjectUtils.projectBranchPath (ProjectAndBranch projectId branchId)
-  case outcome of
-    SwitchedToExistingBranch -> pure ()
-    SwitchedToNewBranch maybeFromBranch -> do
-      fromBranchObject <-
-        case maybeFromBranch of
-          Nothing -> pure Branch.empty
-          Just fromBranch ->
-            Cli.getBranchAt (ProjectUtils.projectBranchPath (ProjectAndBranch projectId (fromBranch ^. #branchId)))
-      _ <- Cli.updateAt "project.switch" path (const fromBranchObject)
-      Cli.respond $
-        Output.CreatedProjectBranch
-          ( case maybeFromBranch of
-              Nothing -> Output.CreatedProjectBranchFrom'Nothingness
-              Just fromBranch -> Output.CreatedProjectBranchFrom'ParentBranch (fromBranch ^. #name)
-          )
-          projectAndBranchNames
-  Cli.cd path
+  Cli.cd (ProjectUtils.projectBranchPath (ProjectAndBranch (branch ^. #projectId) (branch ^. #branchId)))

--- a/unison-src/transcripts/switch-command.md
+++ b/unison-src/transcripts/switch-command.md
@@ -1,0 +1,32 @@
+The `switch` command switches to an existing project or branch.
+
+```ucm:hide
+.> builtins.merge
+```
+
+Setup stuff.
+
+```unison
+someterm = 18
+```
+
+```ucm
+.> project.create foo
+foo/main> add
+foo/main> branch topic
+```
+
+Now, the demo.
+
+```ucm
+.> switch foo
+.> switch foo/topic
+```
+
+```ucm:error
+.> switch foo/no-such-branch
+```
+
+```ucm:error
+.> switch no-such-project
+```

--- a/unison-src/transcripts/switch-command.output.md
+++ b/unison-src/transcripts/switch-command.output.md
@@ -1,0 +1,58 @@
+The `switch` command switches to an existing project or branch.
+
+Setup stuff.
+
+```unison
+someterm = 18
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      someterm : Nat
+
+```
+```ucm
+.> project.create foo
+
+  I just created project foo with branch main.
+
+foo/main> add
+
+  ⍟ I've added these definitions:
+  
+    someterm : Nat
+
+foo/main> branch topic
+
+  Done. I've created the topic branch based off of main.
+  
+  Tip: Use `merge /topic /main` to merge your work back into the
+       main branch.
+
+```
+Now, the demo.
+
+```ucm
+.> switch foo
+
+.> switch foo/topic
+
+```
+```ucm
+.> switch foo/no-such-branch
+
+  foo/no-such-branch does not exist.
+
+```
+```ucm
+.> switch no-such-project
+
+  no-such-project/main does not exist.
+
+```


### PR DESCRIPTION
## Overview

This PR finishes off the `switch`/`branch` command refactorings by deleting `switch`'s ability to create branches. We have `branch` and `branch.empty` now, so we don't want `switch` to be a redundant/alternative way to make a branch.

## Test coverage

I added a `switch-command` transcript. You can't really see that it correctly switches in a transcript (since each line sets the working directory), but the transcript at least tests whether or not `switch` errors when given an extant or nonexistent branch.