### PR TITLE
Link.Term.toText: handle ability constructors

### DIFF
--- a/unison-src/builtin-tests/base.output.md
+++ b/unison-src/builtin-tests/base.output.md
@@ -10,7 +10,7 @@
 
 .> compile.native.fetch
 
-  Downloaded 59168 entities.
+  Downloaded 59222 entities.
 
   ✅
   

--- a/unison-src/builtin-tests/text-tests.u
+++ b/unison-src/builtin-tests/text-tests.u
@@ -6,6 +6,7 @@ text.tests = do
  !text.conversion.tests
  !text.debug.tests
  !text.matching.tests
+ !text.term.tests
  !char.class.tests
 
 text.lit.tests = do
@@ -145,6 +146,12 @@ text.debug.tests = do
     true
 
   checkEqual "Debug.watch" (Debug.watch "Watch" 3) 3
+
+text.term.tests = do
+  check "Link.Term.toText works for ability constructors" do
+    match catchAll '(Link.Term.toText (termLink abort)) with
+      Left f -> false
+      Right _ -> true
 
 text.matching.tests = do
   check "String literal matching: empty" do


### PR DESCRIPTION
Fixes #3938

I wasn't really sure of the right way to test this. I added a test to
`builtin-tests` that was previously failing and now succeeds. I wasn't
sure whether I should include specific ability constructor
hashes/indexes in the test, so I just tested that it doesn't throw an
exception. This test also doesn't seem to run with `stack test` and
needs me to explicitly call
`./unison-src/builtin-tests/interpreter-tests.sh` but it seems like that
is a thing?

Anyway it seems to work:

```
.> cd .tmp        service_calls
.tmp>

  ✅

  ~/code/unison/scratch.u changed.

  Now evaluating any watch expressions (lines starting with `>`)... Ctrl+C cancels.

    1 | > Link.Term.toText (termLink abort)
          ⧩
          "#b589mbg492brf3k3t0lg706d7ob88jqslgmja9gkrimv4137utuittc2r9l1tgvhrl40f71c99m39ch48gubbjhn5vf2pf5evjsinn8#0"

.tmp>

  ✅

  ~/code/unison/scratch.u changed.

  Now evaluating any watch expressions (lines starting with `>`)... Ctrl+C cancels.

    1 | > Link.Term.toText (termLink Store.get)
          ⧩
          "#fmj3l8nggpfuh0ueuhr2rcka4s91ihufqiq6rocn25vsnni3v8rtjjteq79d398shvrfvbmhhoc7amhoh9lmdlghhiirl81sodj3ti0#1"

.tmp>

  ✅

  ~/code/unison/scratch.u changed.

  Now evaluating any watch expressions (lines starting with `>`)... Ctrl+C cancels.

    1 | > Link.Term.toText (termLink Store.put)
          ⧩
          "#fmj3l8nggpfuh0ueuhr2rcka4s91ihufqiq6rocn25vsnni3v8rtjjteq79d398shvrfvbmhhoc7amhoh9lmdlghhiirl81sodj3ti0#0"
```
