### PR TITLE
fixes #3941

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -844,7 +844,7 @@ ioBuiltins =
     ("Tls.terminate.impl.v3", tls --> iof unit),
     ("Tls.ClientConfig.default", text --> bytes --> tlsClientConfig),
     ("Tls.ServerConfig.default", list tlsSignedCert --> tlsPrivateKey --> tlsServerConfig),
-    ("TLS.ClientConfig.ciphers.set", list tlsCipher --> tlsClientConfig --> tlsClientConfig),
+    ("Tls.ClientConfig.ciphers.set", list tlsCipher --> tlsClientConfig --> tlsClientConfig),
     ("Tls.ServerConfig.ciphers.set", list tlsCipher --> tlsServerConfig --> tlsServerConfig),
     ("Tls.ClientConfig.certificates.set", list tlsSignedCert --> tlsClientConfig --> tlsClientConfig),
     ("Tls.ClientConfig.withAuthCert", list tlsSignedCert --> tlsPrivateKey --> tlsClientConfig --> tlsClientConfig),

--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -847,6 +847,7 @@ ioBuiltins =
     ("TLS.ClientConfig.ciphers.set", list tlsCipher --> tlsClientConfig --> tlsClientConfig),
     ("Tls.ServerConfig.ciphers.set", list tlsCipher --> tlsServerConfig --> tlsServerConfig),
     ("Tls.ClientConfig.certificates.set", list tlsSignedCert --> tlsClientConfig --> tlsClientConfig),
+    ("Tls.ClientConfig.withAuthCert", list tlsSignedCert --> tlsPrivateKey --> tlsClientConfig --> tlsClientConfig),
     ("Tls.ServerConfig.certificates.set", list tlsSignedCert --> tlsServerConfig --> tlsServerConfig),
     ("Tls.ClientConfig.versions.set", list tlsVersion --> tlsClientConfig --> tlsClientConfig),
     ("Tls.ServerConfig.versions.set", list tlsVersion --> tlsServerConfig --> tlsServerConfig),

--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -2560,7 +2560,7 @@ declareForeigns = do
        socket :: SYS.Socket
        ) -> TLS.contextNew socket config
     
-  declareForeign Tracked "Tls.ClientConfig.withAuthCert.impl" boxBoxBoxDirect . mkForeign $
+  declareForeign Tracked "Tls.ClientConfig.withAuthCert" boxBoxBoxDirect . mkForeign $
     \(cert :: X.SignedCertificate, key :: X.PrivKey, params :: ClientParams) ->
       let chain = X.CertificateChain [cert] in
       pure $ params

--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -2559,6 +2559,14 @@ declareForeigns = do
     \( config :: TLS.ServerParams,
        socket :: SYS.Socket
        ) -> TLS.contextNew socket config
+    
+  declareForeign Tracked "Tls.ClientConfig.withAuthCert.impl" boxBoxBoxDirect . mkForeign $
+    \(cert :: X.SignedCertificate, key :: X.PrivKey, params :: ClientParams) ->
+      let chain = X.CertificateChain [cert] in
+      pure $ params
+        { clientHooks = (clientHooks params) { onCertificateRequest = const . return $ Just (chain, key) }
+        , clientShared = (clientShared params) { sharedCredentials = Credentials [(chain, key)] }
+        }
 
   declareForeign Tracked "Tls.handshake.impl.v3" boxToEF0 . mkForeignTls $
     \(tls :: TLS.Context) -> TLS.handshake tls


### PR DESCRIPTION
provide a way to use tls certs for client auth

## Overview

Provide a way to do TLS client auth so that users can use a certificate to prove their identity to a server.


## Test coverage

nope, maybe later, right not trying to rush this into @alvaroc1 's hands to test