### PR TITLE
Disable text.term.tests, which uses TermLinks that are not yet supported by the jit

### DIFF
--- a/unison-src/builtin-tests/text-tests.u
+++ b/unison-src/builtin-tests/text-tests.u
@@ -6,7 +6,8 @@ text.tests = do
  !text.conversion.tests
  !text.debug.tests
  !text.matching.tests
- !text.term.tests
+-- This is broken under the jit
+--  !text.term.tests
  !char.class.tests
 
 text.lit.tests = do


### PR DESCRIPTION
This broke jit-tests