### PR TITLE
Fix branch.clone/project.clone reflog

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1535,8 +1535,6 @@ inputDescription input =
       branchId2 <- hp' (input ^. #branchId2)
       patch <- ps' (input ^. #patch)
       pure (Text.unwords ["diff.namespace.to-patch", branchId1, branchId2, patch])
-    BranchCloneI projectAndBranch -> pure ("branch.clone " <> into @Text projectAndBranch)
-    ProjectCloneI projectAndBranch -> pure ("project.clone " <> into @Text projectAndBranch)
     ProjectCreateI project -> pure ("project.create " <> into @Text project)
     ProjectSwitchI projectAndBranch -> pure ("project.switch " <> into @Text projectAndBranch)
     ClearI {} -> pure "clear"
@@ -1544,6 +1542,7 @@ inputDescription input =
     --
     ApiI -> wat
     AuthLoginI {} -> wat
+    BranchCloneI _ -> wat
     BranchI {} -> wat
     BranchesI -> wat
     CreateMessage {} -> wat
@@ -1577,6 +1576,7 @@ inputDescription input =
     PreviewAddI {} -> wat
     PreviewMergeLocalBranchI {} -> wat
     PreviewUpdateI {} -> wat
+    ProjectCloneI _ -> wat
     ProjectsI -> wat
     PushRemoteBranchI {} -> wat
     QuitI {} -> wat


### PR DESCRIPTION
## Overview

This PR fixes the reflog entry for `project.clone` and `branch.clone`.

Previously, the entry would just say `"project.clone"`. Now, it distinguishes between `"project.clone"` and `"branch.clone"` (since we have the two separate commands now, although `branch.clone` still needs to be refactored to do what we want), and it also includes the argument.

![image](https://user-images.githubusercontent.com/1074598/235480295-55f18742-ab28-4477-9914-1df207d2d83b.png)

## Test coverage

I tested this change manually.