### PR TITLE
Don't require leading forward slash in `switch /branch`

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/RemoteRepo.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/RemoteRepo.hs
@@ -3,7 +3,6 @@ module Unison.Codebase.Editor.RemoteRepo where
 import Control.Lens (Lens')
 import qualified Control.Lens as Lens
 import qualified Data.Text as Text
-import Data.These (These (..))
 import Data.Void (absurd)
 import Unison.Codebase.Path (Path)
 import qualified Unison.Codebase.Path as Path
@@ -98,7 +97,7 @@ printWriteRemoteNamespace = \case
     printWriteGitRepo repo <> maybePrintPath path
   WriteRemoteNamespaceShare (WriteShareRemoteNamespace {server, repo, path}) ->
     displayShareCodeserver server repo path
-  WriteRemoteProjectBranch (ProjectAndBranch project branch) -> into @Text (These project branch)
+  WriteRemoteProjectBranch projectAndBranch -> into @Text projectAndBranch
 
 maybePrintPath :: Path -> Text
 maybePrintPath path =

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1455,7 +1455,7 @@ inputDescription input =
         DeleteTarget'Patch path0 -> do
           path <- ps' path0
           pure ("delete.patch " <> path)
-        DeleteTarget'ProjectBranch projectAndBranch -> pure ("delete.branch " <> into @Text projectAndBranch)
+        DeleteTarget'ProjectBranch _ -> wat
     ReplaceI src target p0 -> do
       p <- opatch p0
       pure $
@@ -1536,7 +1536,6 @@ inputDescription input =
       patch <- ps' (input ^. #patch)
       pure (Text.unwords ["diff.namespace.to-patch", branchId1, branchId2, patch])
     ProjectCreateI project -> pure ("project.create " <> into @Text project)
-    ProjectSwitchI projectAndBranch -> pure ("project.switch " <> into @Text projectAndBranch)
     ClearI {} -> pure "clear"
     DocToMarkdownI name -> pure ("debug.doc-to-markdown " <> Name.toText name)
     --
@@ -1577,6 +1576,7 @@ inputDescription input =
     PreviewMergeLocalBranchI {} -> wat
     PreviewUpdateI {} -> wat
     ProjectCloneI _ -> wat
+    ProjectSwitchI _ -> wat
     ProjectsI -> wat
     PushRemoteBranchI {} -> wat
     QuitI {} -> wat

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Branch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Branch.hs
@@ -85,7 +85,7 @@ handleBranch sourceI projectAndBranchNames0 = do
         Nothing -> Left (Output.LocalProjectBranchDoesntExist projectAndBranchNames)
         Just project -> Right project
 
-  doCreateBranch createFrom project newBranchName ("branch " <> into @Text (These projectName newBranchName))
+  doCreateBranch createFrom project newBranchName ("branch " <> into @Text projectAndBranchNames)
 
   Cli.respond $
     Output.CreatedProjectBranch

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/DeleteBranch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/DeleteBranch.hs
@@ -41,7 +41,7 @@ handleDeleteBranch projectAndBranchTheseNames = do
   let projectId = deletedBranch ^. #projectId
 
   Cli.stepAt
-    "project.delete-branch"
+    ("delete.branch " <> into @Text projectAndBranchNames)
     ( Path.unabsolute (ProjectUtils.projectBranchesPath projectId),
       \branchObject ->
         branchObject

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectClone.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectClone.hs
@@ -130,7 +130,7 @@ cloneInto command localProjectBranch remoteProjectBranch = do
       result <-
         Share.downloadEntities
           Share.hardCodedBaseUrl
-          (Share.RepoInfo (into @Text (These remoteProjectName remoteBranchName)))
+          (Share.RepoInfo (into @Text (ProjectAndBranch remoteProjectName remoteBranchName)))
           remoteBranchHeadJwt
           downloadedCallback
       numDownloaded <- liftIO getNumDownloaded
@@ -179,7 +179,7 @@ cloneInto command localProjectBranch remoteProjectBranch = do
   theBranch <- liftIO (Codebase.expectBranchForHash codebase branchHead)
   let path = projectBranchPath localProjectAndBranch
   Cli.stepAt
-    (command <> " " <> into @Text (These remoteProjectName remoteBranchName))
+    (command <> " " <> into @Text (ProjectAndBranch remoteProjectName remoteBranchName))
     (Path.unabsolute path, const (Branch.head theBranch))
   Cli.cd path
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectSwitch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectSwitch.hs
@@ -38,7 +38,7 @@ projectSwitch = \case
           (False, False) -> Cli.respond (Output.LocalProjectNorProjectBranchExist projectName branchName)
           (False, True) -> switchToProjectAndBranchByTheseNames (These (currentProject ^. #name) branchName)
           (True, False) -> switchToProjectAndBranchByTheseNames (This projectName)
-          (True, True) -> Cli.respond (Output.BothLocalProjectAndProjectBranchExist projectName branchName)
+          (True, True) -> Cli.respondNumbered (Output.BothLocalProjectAndProjectBranchExist projectName branchName)
   ProjectAndBranchNames'Unambiguous projectAndBranchNames0 ->
     switchToProjectAndBranchByTheseNames projectAndBranchNames0
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectSwitch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectSwitch.hs
@@ -12,11 +12,39 @@ import qualified Unison.Cli.Monad as Cli
 import qualified Unison.Cli.ProjectUtils as ProjectUtils
 import qualified Unison.Codebase.Editor.Output as Output
 import Unison.Prelude
-import Unison.Project (ProjectAndBranch (..), ProjectBranchName, ProjectName)
+import Unison.Project (ProjectAndBranch (..), ProjectAndBranchNames (..), ProjectBranchName, ProjectName)
 
--- | Switch to an existing project or project branch.
-projectSwitch :: These ProjectName ProjectBranchName -> Cli ()
-projectSwitch projectAndBranchNames0 = do
+-- | Switch to an existing project or project branch, with a flexible syntax that does not require prefixing branch
+-- names with forward slashes (though doing so makes the command unambiguous).
+--
+-- When the argument is ambiguous, when outside of a project, "switch foo" means switch to project "foo", not branch
+-- "foo" (since there is no current project). And when inside a project, "switch foo" means one of:
+--
+--   1. Switch to project "foo", since there isn't a branch "foo" in the current project
+--   2. Switch to branch "foo", since there isn't a project "foo"
+--   3. Complain, because there's both a project "foo" and a branch "foo" in the current project
+projectSwitch :: ProjectAndBranchNames -> Cli ()
+projectSwitch = \case
+  ProjectAndBranchNames'Ambiguous projectName branchName ->
+    ProjectUtils.getCurrentProjectBranch >>= \case
+      Nothing -> switchToProjectAndBranchByTheseNames (This projectName)
+      Just (ProjectAndBranch currentProject _currentBranch) -> do
+        (projectExists, branchExists) <-
+          Cli.runTransaction do
+            (,)
+              <$> Queries.projectExistsByName projectName
+              <*> Queries.projectBranchExistsByName (currentProject ^. #projectId) branchName
+        case (projectExists, branchExists) of
+          (False, False) -> Cli.respond (Output.LocalProjectNorProjectBranchExist projectName branchName)
+
+          (False, True) -> switchToProjectAndBranchByTheseNames (These (currentProject ^. #name) branchName)
+          (True, False) -> switchToProjectAndBranchByTheseNames (This projectName)
+          (True, True) -> Cli.respond (Output.BothLocalProjectAndProjectBranchExist projectName branchName)
+  ProjectAndBranchNames'Unambiguous projectAndBranchNames0 ->
+    switchToProjectAndBranchByTheseNames projectAndBranchNames0
+
+switchToProjectAndBranchByTheseNames :: These ProjectName ProjectBranchName -> Cli ()
+switchToProjectAndBranchByTheseNames projectAndBranchNames0 = do
   projectAndBranchNames@(ProjectAndBranch projectName branchName) <- ProjectUtils.hydrateNames projectAndBranchNames0
   branch <-
     Cli.runTransaction (Queries.loadProjectBranchByNames projectName branchName) & onNothingM do

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectSwitch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectSwitch.hs
@@ -36,7 +36,6 @@ projectSwitch = \case
               <*> Queries.projectBranchExistsByName (currentProject ^. #projectId) branchName
         case (projectExists, branchExists) of
           (False, False) -> Cli.respond (Output.LocalProjectNorProjectBranchExist projectName branchName)
-
           (False, True) -> switchToProjectAndBranchByTheseNames (These (currentProject ^. #name) branchName)
           (True, False) -> switchToProjectAndBranchByTheseNames (This projectName)
           (True, True) -> Cli.respond (Output.BothLocalProjectAndProjectBranchExist projectName branchName)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Pull.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Pull.hs
@@ -186,7 +186,7 @@ loadRemoteNamespaceIntoMemory syncMode pullMode remoteNamespace = do
         Cli.returnEarly (Output.GitError err)
     ReadShare'LooseCode repo -> loadShareLooseCodeIntoMemory repo
     ReadShare'ProjectBranch remoteBranch -> do
-      let repoInfo = Share.RepoInfo (into @Text (These (remoteBranch ^. #projectName) remoteProjectBranchName))
+      let repoInfo = Share.RepoInfo (into @Text (ProjectAndBranch (remoteBranch ^. #projectName) remoteProjectBranchName))
           causalHash = Common.hash32ToCausalHash . Share.hashJWTHash $ causalHashJwt
           causalHashJwt = remoteBranch ^. #branchHead
           remoteProjectBranchName = remoteBranch ^. #branchName

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
@@ -587,7 +587,7 @@ executeUploadPlan UploadPlan {remoteBranch, causalHash, afterUploadAction} = do
               (codeserverBaseURL Codeserver.defaultCodeserver)
               -- On the wire, the remote branch is encoded as e.g.
               --   { "repo_info": "@unison/base/@arya/topic", ... }
-              (Share.RepoInfo (into @Text (These (remoteBranch ^. #project) (remoteBranch ^. #branch))))
+              (Share.RepoInfo (into @Text (ProjectAndBranch (remoteBranch ^. #project) (remoteBranch ^. #branch))))
               (Set.NonEmpty.singleton causalHash)
               uploadedCallback
       upload & onLeftM \err0 -> do

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -46,7 +46,7 @@ import qualified Unison.HashQualified as HQ
 import Unison.Name (Name)
 import Unison.NameSegment (NameSegment)
 import Unison.Prelude
-import Unison.Project (ProjectAndBranch, ProjectBranchName, ProjectName, Semver)
+import Unison.Project (ProjectAndBranch, ProjectBranchName, ProjectName, Semver, ProjectAndBranchNames)
 import Unison.ShortHash (ShortHash)
 import qualified Unison.Util.Pretty as P
 
@@ -223,7 +223,7 @@ data Input
   | DiffNamespaceToPatchI DiffNamespaceToPatchInput
   | ProjectCloneI (ProjectAndBranch ProjectName (Maybe ProjectBranchName))
   | ProjectCreateI ProjectName
-  | ProjectSwitchI (These ProjectName ProjectBranchName)
+  | ProjectSwitchI ProjectAndBranchNames
   | ProjectsI
   | BranchCloneI (These ProjectName ProjectBranchName)
   | BranchI BranchSourceI (ProjectAndBranch (Maybe ProjectName) ProjectBranchName)

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -46,7 +46,7 @@ import qualified Unison.HashQualified as HQ
 import Unison.Name (Name)
 import Unison.NameSegment (NameSegment)
 import Unison.Prelude
-import Unison.Project (ProjectAndBranch, ProjectBranchName, ProjectName, Semver, ProjectAndBranchNames)
+import Unison.Project (ProjectAndBranch, ProjectAndBranchNames, ProjectBranchName, ProjectName, Semver)
 import Unison.ShortHash (ShortHash)
 import qualified Unison.Util.Pretty as P
 

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -115,6 +115,7 @@ data NumberedOutput
   | ListEdits Patch PPE.PrettyPrintEnv
   | ListProjects [Sqlite.Project]
   | ListBranches ProjectName [(ProjectBranchName, [(URI, ProjectName, ProjectBranchName)])]
+  | BothLocalProjectAndProjectBranchExist ProjectName ProjectBranchName
 
 --  | ShowDiff
 
@@ -321,7 +322,6 @@ data Output
     NoAssociatedRemoteProjectBranch URI (ProjectAndBranch ProjectName ProjectBranchName)
   | LocalProjectBranchDoesntExist (ProjectAndBranch ProjectName ProjectBranchName)
   | LocalProjectNorProjectBranchExist ProjectName ProjectBranchName
-  | BothLocalProjectAndProjectBranchExist ProjectName ProjectBranchName
   | RemoteProjectDoesntExist URI ProjectName
   | RemoteProjectBranchDoesntExist URI (ProjectAndBranch ProjectName ProjectBranchName)
   | RemoteProjectReleaseIsDeprecated URI (ProjectAndBranch ProjectName ProjectBranchName)
@@ -528,7 +528,6 @@ isFailure o = case o of
   ProjectAndBranchNameAlreadyExists {} -> True
   LocalProjectBranchDoesntExist {} -> True
   LocalProjectNorProjectBranchExist {} -> True
-  BothLocalProjectAndProjectBranchExist {} -> True
   RemoteProjectDoesntExist {} -> True
   RemoteProjectBranchDoesntExist {} -> True
   RemoteProjectReleaseIsDeprecated {} -> True
@@ -546,21 +545,22 @@ isFailure o = case o of
 
 isNumberedFailure :: NumberedOutput -> Bool
 isNumberedFailure = \case
-  ShowDiffNamespace {} -> False
-  ShowDiffAfterDeleteDefinitions {} -> False
-  ShowDiffAfterDeleteBranch {} -> False
-  ShowDiffAfterModifyBranch {} -> False
-  ShowDiffAfterMerge {} -> False
-  ShowDiffAfterMergePropagate {} -> False
-  ShowDiffAfterMergePreview {} -> False
-  ShowDiffAfterUndo {} -> False
-  ShowDiffAfterPull {} -> False
-  ShowDiffAfterCreateAuthor {} -> False
-  TodoOutput _ todo -> TO.todoScore todo > 0 || not (TO.noConflicts todo)
+  BothLocalProjectAndProjectBranchExist {} -> True
   CantDeleteDefinitions {} -> True
   CantDeleteNamespace {} -> True
-  History {} -> False
   DeletedDespiteDependents {} -> False
+  History {} -> False
+  ListBranches {} -> False
   ListEdits {} -> False
   ListProjects {} -> False
-  ListBranches {} -> False
+  ShowDiffAfterCreateAuthor {} -> False
+  ShowDiffAfterDeleteBranch {} -> False
+  ShowDiffAfterDeleteDefinitions {} -> False
+  ShowDiffAfterMerge {} -> False
+  ShowDiffAfterMergePreview {} -> False
+  ShowDiffAfterMergePropagate {} -> False
+  ShowDiffAfterModifyBranch {} -> False
+  ShowDiffAfterPull {} -> False
+  ShowDiffAfterUndo {} -> False
+  ShowDiffNamespace {} -> False
+  TodoOutput _ todo -> TO.todoScore todo > 0 || not (TO.noConflicts todo)

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -320,6 +320,8 @@ data Output
   | -- there's no remote branch associated with branch
     NoAssociatedRemoteProjectBranch URI (ProjectAndBranch ProjectName ProjectBranchName)
   | LocalProjectBranchDoesntExist (ProjectAndBranch ProjectName ProjectBranchName)
+  | LocalProjectNorProjectBranchExist ProjectName ProjectBranchName
+  | BothLocalProjectAndProjectBranchExist ProjectName ProjectBranchName
   | RemoteProjectDoesntExist URI ProjectName
   | RemoteProjectBranchDoesntExist URI (ProjectAndBranch ProjectName ProjectBranchName)
   | RemoteProjectReleaseIsDeprecated URI (ProjectAndBranch ProjectName ProjectBranchName)
@@ -525,6 +527,8 @@ isFailure o = case o of
   NoAssociatedRemoteProjectBranch {} -> True
   ProjectAndBranchNameAlreadyExists {} -> True
   LocalProjectBranchDoesntExist {} -> True
+  LocalProjectNorProjectBranchExist {} -> True
+  BothLocalProjectAndProjectBranchExist {} -> True
   RemoteProjectDoesntExist {} -> True
   RemoteProjectBranchDoesntExist {} -> True
   RemoteProjectReleaseIsDeprecated {} -> True

--- a/unison-cli/src/Unison/Codebase/TranscriptParser.hs
+++ b/unison-cli/src/Unison/Codebase/TranscriptParser.hs
@@ -65,7 +65,7 @@ import Unison.CommandLine.Welcome (asciiartUnison)
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.PrettyTerminal
-import Unison.Project (ProjectAndBranch (..), ProjectBranchName, ProjectName)
+import Unison.Project (ProjectAndBranch (..), ProjectAndBranchNames (ProjectAndBranchNames'Unambiguous), ProjectBranchName, ProjectName)
 import qualified Unison.Runtime.Interface as RTI
 import qualified Unison.Server.Backend as Backend
 import qualified Unison.Server.CodebaseServer as Server
@@ -337,9 +337,10 @@ run dir stanzas codebase runtime sbRuntime config ucmVersion baseURL = UnliftIO.
                       ProjectAndBranch project branch <-
                         ProjectUtils.expectProjectAndBranchByTheseNames (These projectName branchName)
                       let projectAndBranchIds = ProjectAndBranch (project ^. #projectId) (branch ^. #branchId)
-                      if curPath == ProjectUtils.projectBranchPath projectAndBranchIds
-                        then pure Nothing
-                        else pure (Just (ProjectSwitchI (These projectName branchName)))
+                      pure
+                        if curPath == ProjectUtils.projectBranchPath projectAndBranchIds
+                          then Nothing
+                          else Just (ProjectSwitchI (ProjectAndBranchNames'Unambiguous (These projectName branchName)))
                 case maybeSwitchCommand of
                   Just switchCommand -> do
                     atomically $ Q.undequeue cmdQueue (Just p)

--- a/unison-cli/src/Unison/Codebase/TranscriptParser.hs
+++ b/unison-cli/src/Unison/Codebase/TranscriptParser.hs
@@ -128,7 +128,7 @@ instance Show UcmLine where
     where
       showContext = \case
         UcmContextLooseCode path -> show path
-        UcmContextProject (ProjectAndBranch project branch) -> Text.unpack (into @Text (These project branch))
+        UcmContextProject projectAndBranch -> Text.unpack (into @Text projectAndBranch)
 
 instance Show Stanza where
   show s = case s of

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -44,7 +44,7 @@ import qualified Unison.HashQualified as HQ
 import Unison.Name (Name)
 import qualified Unison.NameSegment as NameSegment
 import Unison.Prelude
-import Unison.Project (ProjectAndBranch (..), ProjectBranchName, ProjectName, Semver)
+import Unison.Project (ProjectAndBranch (..), ProjectBranchName, ProjectName, Semver, ProjectAndBranchNames)
 import qualified Unison.Syntax.HashQualified as HQ (fromString)
 import qualified Unison.Syntax.Name as Name (fromText, unsafeFromString)
 import qualified Unison.Util.ColorText as CT
@@ -2347,7 +2347,7 @@ projectSwitch =
       help = P.wrap "Switch to a project or project branch.",
       parse = \case
         [name] ->
-          case tryInto @(These ProjectName ProjectBranchName) (Text.pack name) of
+          case tryInto @ProjectAndBranchNames (Text.pack name) of
             Left _ -> Left (showPatternHelp projectSwitch)
             Right projectAndBranch -> Right (Input.ProjectSwitchI projectAndBranch)
         _ -> Left (showPatternHelp projectSwitch)

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2340,8 +2340,8 @@ projectCreate =
 projectSwitch :: InputPattern
 projectSwitch =
   InputPattern
-    { patternName = "project.switch",
-      aliases = ["switch"],
+    { patternName = "switch",
+      aliases = ["project.switch"],
       visibility = I.Hidden,
       argTypes = [(Required, projectAndBranchNamesArg)],
       help = P.wrap "Switch to a project or project branch.",

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -44,7 +44,7 @@ import qualified Unison.HashQualified as HQ
 import Unison.Name (Name)
 import qualified Unison.NameSegment as NameSegment
 import Unison.Prelude
-import Unison.Project (ProjectAndBranch (..), ProjectBranchName, ProjectName, Semver, ProjectAndBranchNames)
+import Unison.Project (ProjectAndBranch (..), ProjectAndBranchNames, ProjectBranchName, ProjectName, Semver)
 import qualified Unison.Syntax.HashQualified as HQ (fromString)
 import qualified Unison.Syntax.Name as Name (fromText, unsafeFromString)
 import qualified Unison.Util.ColorText as CT

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -13,7 +13,6 @@ import Data.Configurator.Types (Config)
 import Data.IORef
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy.IO as Text.Lazy
-import Data.These (These (..))
 import qualified Ki
 import qualified System.Console.Haskeline as Line
 import System.IO (hGetEcho, hPutStrLn, hSetEcho, stderr, stdin)
@@ -87,7 +86,7 @@ getUserInput codebase authHTTPClient getRoot currentPath numberedArgs =
             lift (Codebase.runTransaction codebase (Queries.loadProjectAndBranchNames projectId branchId)) <&> \case
               -- If the project branch has been deleted from sqlite, just show a borked prompt
               Nothing -> P.red "???"
-              Just (projectName, branchName) -> P.purple (P.text (into @Text (These projectName branchName)))
+              Just (projectName, branchName) -> P.purple (P.text (into @Text (ProjectAndBranch projectName branchName)))
       line <- Line.getInputLine (P.toANSI 80 (promptString <> fromString prompt))
       case line of
         Nothing -> pure QuitI

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -457,6 +457,35 @@ notifyNumbered = \case
             prettyProjectAndBranchName (ProjectAndBranch remoteProject remoteBranch)
               <> " on "
               <> P.hiBlack (P.shown host)
+  BothLocalProjectAndProjectBranchExist project branch ->
+    ( P.wrap
+        ( "Project"
+            <> prettyProjectName project
+            <> "and branch"
+            <> prettySlashProjectBranchName branch
+            <> "both exist. Did you mean:"
+        )
+        <> P.newline
+        <> P.newline
+        <> P.numberedList
+          [ switch [prettySlashProjectBranchName branch],
+            switch [prettyProjectAndBranchName (ProjectAndBranch project (UnsafeProjectBranchName "main"))]
+          ]
+        <> P.newline
+        <> P.newline
+        <> tip
+          ( "use "
+              <> switch ["1"]
+              <> " or "
+              <> switch ["2"]
+              <> " to pick one of these."
+          ),
+      [ Text.unpack (Text.cons '/' (into @Text branch)),
+        Text.unpack (into @Text (ProjectAndBranch project (UnsafeProjectBranchName "main")))
+      ]
+    )
+    where
+      switch = IP.makeExample IP.projectSwitch
   where
     absPathToBranchId = Right
 
@@ -1925,13 +1954,6 @@ notifyUser dir = \case
         <> "nor branch"
         <> prettySlashProjectBranchName branch
         <> "exist."
-  BothLocalProjectAndProjectBranchExist project branch ->
-    pure . P.wrap $
-      "Project"
-        <> prettyProjectName project
-        <> "and branch"
-        <> prettySlashProjectBranchName branch
-        <> "both exist."
   RemoteProjectDoesntExist host project ->
     pure . P.wrap $
       prettyProjectName project <> "does not exist on" <> prettyURI host

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -22,7 +22,6 @@ import qualified Data.Set as Set
 import Data.Set.NonEmpty (NESet)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
-import Data.These (These (..))
 import Data.Time (UTCTime, getCurrentTime)
 import Data.Time.Format.Human (HumanTimeLocale (..), defaultHumanTimeLocale, humanReadableTimeI18N')
 import Data.Tuple (swap)
@@ -441,7 +440,7 @@ notifyNumbered = \case
                 ]
                   : map (\branch -> ["", "", prettyRemoteBranchInfo branch]) remoteBranches
         ),
-      map (\(branchName, _) -> Text.unpack (into @Text (These projectName branchName))) branches
+      map (\(branchName, _) -> Text.unpack (into @Text (ProjectAndBranch projectName branchName))) branches
     )
     where
       prettyRemoteBranchInfo :: (URI, ProjectName, ProjectBranchName) -> Pretty
@@ -569,7 +568,7 @@ prettyURI = P.bold . P.blue . P.shown
 prettyReadRemoteNamespace :: ReadRemoteNamespace Share.RemoteProjectBranch -> Pretty
 prettyReadRemoteNamespace =
   prettyReadRemoteNamespaceWith \remoteProjectBranch ->
-    into @Text (These (remoteProjectBranch ^. #projectName) (remoteProjectBranch ^. #branchName))
+    into @Text (ProjectAndBranch (remoteProjectBranch ^. #projectName) (remoteProjectBranch ^. #branchName))
 
 prettyReadRemoteNamespaceWith :: (a -> Text) -> ReadRemoteNamespace a -> Pretty
 prettyReadRemoteNamespaceWith printProject =
@@ -2357,8 +2356,8 @@ prettySlashProjectBranchName =
   P.blue . P.text . Text.cons '/' . into @Text
 
 prettyProjectAndBranchName :: ProjectAndBranch ProjectName ProjectBranchName -> Pretty
-prettyProjectAndBranchName (ProjectAndBranch projectName branchName) =
-  P.blue (P.text (into @Text (These projectName branchName)))
+prettyProjectAndBranchName names =
+  P.blue (P.text (into @Text names))
 
 prettyPathOrProjectAndBranchName :: Either Path.Path' (ProjectAndBranch ProjectName ProjectBranchName) -> Pretty
 prettyPathOrProjectAndBranchName = \case

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1953,7 +1953,7 @@ notifyUser dir = \case
         <> prettyProjectName project
         <> "nor branch"
         <> prettySlashProjectBranchName branch
-        <> "exist."
+        <> "exists."
   RemoteProjectDoesntExist host project ->
     pure . P.wrap $
       prettyProjectName project <> "does not exist on" <> prettyURI host

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2048,8 +2048,8 @@ notifyUser dir = \case
         <> tip
           ( "if you get pulled away from drafting your release, you can always get back to it with "
               <> IP.makeExample IP.projectSwitch [prettySlashProjectBranchName branch]
-              <> "."
           )
+        <> "."
   CannotCreateReleaseBranchWithBranchCommand branch ver ->
     pure $
       P.wrap ("Branch names like" <> prettyProjectBranchName branch <> "are reserved for releases.")

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1918,6 +1918,20 @@ notifyUser dir = \case
   LocalProjectBranchDoesntExist projectAndBranch ->
     pure . P.wrap $
       prettyProjectAndBranchName projectAndBranch <> "does not exist."
+  LocalProjectNorProjectBranchExist project branch ->
+    pure . P.wrap $
+      "Neither project"
+        <> prettyProjectName project
+        <> "nor branch"
+        <> prettySlashProjectBranchName branch
+        <> "exist."
+  BothLocalProjectAndProjectBranchExist project branch ->
+    pure . P.wrap $
+      "Project"
+        <> prettyProjectName project
+        <> "and branch"
+        <> prettySlashProjectBranchName branch
+        <> "both exist."
   RemoteProjectDoesntExist host project ->
     pure . P.wrap $
       prettyProjectName project <> "does not exist on" <> prettyURI host

--- a/unison-src/transcripts/release-draft-command.output.md
+++ b/unison-src/transcripts/release-draft-command.output.md
@@ -47,7 +47,7 @@ foo/main> release.draft 1.2.3
   
   Tip: if you get pulled away from drafting your release, you
        can always get back to it with
-       `project.switch /releases/drafts/1.2.3` .
+       `switch /releases/drafts/1.2.3` .
 
 ```
 It's an error to try to create a `releases/drafts/x.y.z` branch that already exists.

--- a/unison-src/transcripts/release-draft-command.output.md
+++ b/unison-src/transcripts/release-draft-command.output.md
@@ -47,7 +47,7 @@ foo/main> release.draft 1.2.3
   
   Tip: if you get pulled away from drafting your release, you
        can always get back to it with
-       `switch /releases/drafts/1.2.3` .
+       `switch /releases/drafts/1.2.3`.
 
 ```
 It's an error to try to create a `releases/drafts/x.y.z` branch that already exists.

--- a/unison-src/transcripts/switch-command.md
+++ b/unison-src/transcripts/switch-command.md
@@ -12,16 +12,29 @@ someterm = 18
 
 ```ucm
 .> project.create foo
+.> project.create bar
 foo/main> add
+foo/main> branch bar
 foo/main> branch topic
 ```
 
-Now, the demo.
+Now, the demo. When unambiguous, `switch` switches to either a project or a branch in the current project. A branch in
+the current project can be preceded by a forward slash (which makes it unambiguous).
 
 ```ucm
 .> switch foo
 .> switch foo/topic
+foo/main> switch topic
+foo/main> switch /topic
 ```
+
+It's an error to try to switch to something ambiguous.
+
+```ucm:error
+foo/main> switch bar
+```
+
+It's an error to try to switch to something that doesn't exist, of course.
 
 ```ucm:error
 .> switch foo/no-such-branch
@@ -29,4 +42,8 @@ Now, the demo.
 
 ```ucm:error
 .> switch no-such-project
+```
+
+```ucm:error
+foo/main> switch no-such-project-or-branch
 ```

--- a/unison-src/transcripts/switch-command.output.md
+++ b/unison-src/transcripts/switch-command.output.md
@@ -65,7 +65,12 @@ It's an error to try to switch to something ambiguous.
 ```ucm
 foo/main> switch bar
 
-  Project bar and branch /bar both exist.
+  Project bar and branch /bar both exist. Did you mean:
+  
+  1. `switch /bar`
+  2. `switch bar/main`
+  
+  Tip: use `switch 1` or `switch 2` to pick one of these.
 
 ```
 It's an error to try to switch to something that doesn't exist, of course.

--- a/unison-src/transcripts/switch-command.output.md
+++ b/unison-src/transcripts/switch-command.output.md
@@ -22,11 +22,22 @@ someterm = 18
 
   I just created project foo with branch main.
 
+.> project.create bar
+
+  I just created project bar with branch main.
+
 foo/main> add
 
   ⍟ I've added these definitions:
   
     someterm : Nat
+
+foo/main> branch bar
+
+  Done. I've created the bar branch based off of main.
+  
+  Tip: Use `merge /bar /main` to merge your work back into the
+       main branch.
 
 foo/main> branch topic
 
@@ -36,14 +47,29 @@ foo/main> branch topic
        main branch.
 
 ```
-Now, the demo.
+Now, the demo. When unambiguous, `switch` switches to either a project or a branch in the current project. A branch in
+the current project can be preceded by a forward slash (which makes it unambiguous).
 
 ```ucm
 .> switch foo
 
 .> switch foo/topic
 
+foo/main> switch topic
+
+foo/main> switch /topic
+
 ```
+It's an error to try to switch to something ambiguous.
+
+```ucm
+foo/main> switch bar
+
+  Project bar and branch /bar both exist.
+
+```
+It's an error to try to switch to something that doesn't exist, of course.
+
 ```ucm
 .> switch foo/no-such-branch
 
@@ -54,5 +80,12 @@ Now, the demo.
 .> switch no-such-project
 
   no-such-project/main does not exist.
+
+```
+```ucm
+foo/main> switch no-such-project-or-branch
+
+  Neither project no-such-project-or-branch nor branch
+  /no-such-project-or-branch exist.
 
 ```

--- a/unison-src/transcripts/switch-command.output.md
+++ b/unison-src/transcripts/switch-command.output.md
@@ -91,6 +91,6 @@ It's an error to try to switch to something that doesn't exist, of course.
 foo/main> switch no-such-project-or-branch
 
   Neither project no-such-project-or-branch nor branch
-  /no-such-project-or-branch exist.
+  /no-such-project-or-branch exists.
 
 ```


### PR DESCRIPTION
## Overview

This PR begins the effort of making the input type of commands that can take a project or branch name more flexible, starting with `switch`.

Prior to this PR, `switch` would accept one of the following:

1. A project name, like `switch foo` (meaning `switch foo/main`)
2. A branch name with a leading forward slash, like `switch /topic`) (meaning switch to `topic` in the current project)
3. A project and branch name, like `switch @unison/base/main`

Now, the parser is more flexible, allowing (2) above without a leading forward slash:

![Screenshot from 2023-05-01 13-37-39](https://user-images.githubusercontent.com/1074598/235498876-7a5f682f-4d48-4303-a44d-3bb43f3570c9.png)

It's still possible to switch to a project with the same syntax as before:

![image](https://user-images.githubusercontent.com/1074598/235499069-32c0c945-fb73-4a1c-abfd-70a0b32192c1.png)

... unless there's also a branch in the current project with that name (I think this error message needs work):

![image](https://user-images.githubusercontent.com/1074598/235499164-07709a2c-2fad-4799-84b8-967bb51ae00d.png)

There's also a new output message for when neither a project nor branch with the given name exist:

![image](https://user-images.githubusercontent.com/1074598/235499309-92e4db7d-cc2a-455f-99db-c9c6657b2bc6.png)

When switching from outside any project, though, `switch x` can only switch to project `x`, so we don't complain about no such branch in that case (as before).

![image](https://user-images.githubusercontent.com/1074598/235500419-ea39331f-c0eb-451a-9edc-a8dc7d9f6416.png)

## Test coverage

I wrote tests for the new parser and updated the `switch-command.md` transcript.

---

@tstat The `ProjectAndBranchNames` parser felt a little weird (https://github.com/unisonweb/unison/pull/3951/files#diff-a5d5ae8e194d9895050d15165d7d16024e13ccf523472cdc84df1d559f0534b2R294-R326). 

Perhaps you could take a look and suggest any improvements. Otherwise, there's not a lot of interesting stuff going on in this PR.