### PR TITLE
Make `delete.branch foo` delete branch `/foo`, not `foo/main`

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/DeleteBranch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/DeleteBranch.hs
@@ -6,7 +6,7 @@ where
 
 import Control.Lens (over, (^.))
 import qualified Data.Map.Strict as Map
-import Data.These (These)
+import Data.These (These (..))
 import qualified U.Codebase.Sqlite.Queries as Queries
 import Unison.Cli.Monad (Cli)
 import qualified Unison.Cli.Monad as Cli
@@ -24,9 +24,13 @@ import Witch (unsafeFrom)
 -- Currently, deleting a branch means deleting its `project_branch` row, then deleting its contents from the namespace.
 -- Its children branches, if any, are reparented to their grandparent, if any. You may delete the only branch in a
 -- project.
-handleDeleteBranch :: These ProjectName ProjectBranchName -> Cli ()
-handleDeleteBranch projectAndBranchTheseNames = do
-  projectAndBranchNames <- ProjectUtils.hydrateNames projectAndBranchTheseNames
+handleDeleteBranch :: ProjectAndBranch (Maybe ProjectName) ProjectBranchName -> Cli ()
+handleDeleteBranch projectAndBranchNames0 = do
+  projectAndBranchNames <-
+    ProjectUtils.hydrateNames
+      case projectAndBranchNames0 of
+        ProjectAndBranch Nothing branch -> That branch
+        ProjectAndBranch (Just project) branch -> These project branch
 
   maybeCurrentBranch <- ProjectUtils.getCurrentProjectBranch
 

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -329,5 +329,5 @@ data DeleteTarget
   | DeleteTarget'Type DeleteOutput [Path.HQSplit']
   | DeleteTarget'Namespace Insistence (Maybe Path.Split')
   | DeleteTarget'Patch Path.Split'
-  | DeleteTarget'ProjectBranch (These ProjectName ProjectBranchName)
+  | DeleteTarget'ProjectBranch (ProjectAndBranch (Maybe ProjectName) ProjectBranchName)
   deriving stock (Eq, Show)

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -718,7 +718,7 @@ deleteBranch =
       help = P.wrap "Delete a project branch.",
       parse = \case
         [name] ->
-          case tryInto @(These ProjectName ProjectBranchName) (Text.pack name) of
+          case tryInto @(ProjectAndBranch (Maybe ProjectName) ProjectBranchName) (Text.pack name) of
             Left _ -> Left (showPatternHelp deleteBranch)
             Right projectAndBranch -> Right (Input.DeleteI (DeleteTarget'ProjectBranch projectAndBranch))
         _ -> Left (showPatternHelp deleteBranch)

--- a/unison-src/transcripts/delete-project-branch.md
+++ b/unison-src/transcripts/delete-project-branch.md
@@ -3,8 +3,22 @@ your working directory with each command).
 
 ```ucm
 .> project.create foo
-foo/main> branch /topic
+foo/main> branch topic
 foo/topic> delete.branch /topic
+```
+
+A branch need not be preceded by a forward slash.
+
+```ucm
+foo/main> branch topic
+foo/topic> delete.branch topic
+```
+
+You can precede the branch name by a project name.
+
+```ucm
+foo/main> branch topic
+.> delete.branch foo/topic
 ```
 
 You can delete the only branch in a project.

--- a/unison-src/transcripts/delete-project-branch.output.md
+++ b/unison-src/transcripts/delete-project-branch.output.md
@@ -6,7 +6,7 @@ your working directory with each command).
 
   I just created project foo with branch main.
 
-foo/main> branch /topic
+foo/main> branch topic
 
   Done. I've created the topic branch based off of main.
   
@@ -14,6 +14,34 @@ foo/main> branch /topic
        main branch.
 
 foo/topic> delete.branch /topic
+
+```
+A branch need not be preceded by a forward slash.
+
+```ucm
+foo/main> branch topic
+
+  Done. I've created the topic branch based off of main.
+  
+  Tip: Use `merge /topic /main` to merge your work back into the
+       main branch.
+
+foo/topic> delete.branch topic
+
+```
+You can precede the branch name by a project name.
+
+```ucm
+foo/main> branch topic
+
+  Done. I've created the topic branch based off of main.
+  
+  Tip: Use `merge /topic /main` to merge your work back into the
+       main branch.
+
+  ☝️  The namespace . is empty.
+
+.> delete.branch foo/topic
 
 ```
 You can delete the only branch in a project.


### PR DESCRIPTION
## Overview

This PR makes the `delete.branch` behavior more intuitive.

Previously, it would accept any of the following:

1. A project name like `delete.branch foo`, meaning `delete.branch foo/main`
2. A branch name preceded by a forward slash, like `delete.branch /foo`
3. A project+branch like `delete.branch foo/topic`

It's (1) that seems like a mistake: it was only implemented that way because at the time we sort of had a uniform way of specifying projects and branches. We want to move to a more intuitive model that allows branches without leading forward slashes.

So, as of this PR, `delete.branch` now accepts the following:

1. A branch name with or without a leading forward slash, like `delete.branch topic` or `delete.branch /topic`
2. A project+branch like `delete.branch foo/topic`

## Test coverage

I updated the transcript.
