### PR TITLE
Make `branch.clone` only take a branch

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectClone.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectClone.hs
@@ -34,27 +34,13 @@ import Unison.Sync.Common (hash32ToCausalHash)
 import qualified Unison.Sync.Types as Share
 import Witch (unsafeFrom)
 
--- | Clone a remote project or remote project branch.
-branchClone :: These ProjectName ProjectBranchName -> Cli ()
-branchClone = \case
-  These projectName branchName -> cloneProjectAndBranch "branch.clone" (ProjectAndBranch projectName branchName)
-  This projectName ->
-    cloneProjectAndBranch
-      "branch.clone"
-      ProjectAndBranch
-        { project = projectName,
-          branch = unsafeFrom @Text "main"
-        }
-  That branchName -> cloneBranch branchName
-
--- | Clone a remote project or remote project branch.
-projectClone :: ProjectAndBranch ProjectName (Maybe ProjectBranchName) -> Cli ()
-projectClone projectAndBranch =
-  cloneProjectAndBranch "project.clone" (projectAndBranch & over #branch (fromMaybe (unsafeFrom @Text "main")))
-
--- Clone a branch from the remote project associated with the current project.
-cloneBranch :: ProjectBranchName -> Cli ()
-cloneBranch remoteBranchName = do
+-- | Clone a remote branch from the remote project associated with the current branch.
+--
+-- If there is no associated remote branch, fall back on its nearest ancestor with an associated remote branch, and if
+-- there are none, finally fall back on a name comparison (e.g. trying to clone branch "foo" while in local project
+-- named "@bar/baz" will look for branch "@bar/baz/foo" on the server)
+branchClone :: ProjectBranchName -> Cli ()
+branchClone remoteBranchName = do
   -- TODO: allow user to override this with second argument
   let localBranchName = remoteBranchName
 
@@ -93,8 +79,10 @@ cloneBranch remoteBranchName = do
 
   cloneInto "branch.clone" localProjectBranch remoteProjectBranch
 
-cloneProjectAndBranch :: Text -> ProjectAndBranch ProjectName ProjectBranchName -> Cli ()
-cloneProjectAndBranch command remoteProjectAndBranch = do
+-- | Clone a remote project or remote project branch.
+projectClone :: ProjectAndBranch ProjectName (Maybe ProjectBranchName) -> Cli ()
+projectClone remoteProjectAndBranch0 = do
+  let remoteProjectAndBranch = remoteProjectAndBranch0 & over #branch (fromMaybe (unsafeFrom @Text "main"))
   let remoteProjectName = remoteProjectAndBranch ^. #project
   let remoteBranchName = remoteProjectAndBranch ^. #branch
   -- TODO: allow user to override these with second argument
@@ -110,10 +98,9 @@ cloneProjectAndBranch command remoteProjectAndBranch = do
   void (Cli.runEitherTransaction (assertLocalProjectBranchDoesntExist localProjectBranch))
 
   -- Get the branch of the given project.
-  remoteProjectBranch <-
-    ProjectUtils.expectRemoteProjectBranchByNames (ProjectAndBranch (localProjectBranch ^. #project) remoteBranchName)
+  remoteProjectBranch <- ProjectUtils.expectRemoteProjectBranchByNames remoteProjectAndBranch
 
-  cloneInto command localProjectBranch remoteProjectBranch
+  cloneInto "project.clone" localProjectBranch remoteProjectBranch
 
 -- `cloneInto command local remote` clones `remote` into `local`, which is believed to not exist yet, but may (because
 -- it takes some time to pull the remote). The `command` argument is used in the reflog to indicate whether this was a

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectClone.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectClone.hs
@@ -7,7 +7,6 @@ where
 
 import Control.Lens (over, (^.))
 import Control.Monad.Reader (ask)
-import Data.These (These (..))
 import qualified Data.UUID.V4 as UUID
 import U.Codebase.Sqlite.DbId (ProjectBranchId (..), ProjectId (..))
 import qualified U.Codebase.Sqlite.Project as Sqlite (Project)

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -225,7 +225,7 @@ data Input
   | ProjectCreateI ProjectName
   | ProjectSwitchI (These ProjectName ProjectBranchName)
   | ProjectsI
-  | BranchCloneI (These ProjectName ProjectBranchName)
+  | BranchCloneI ProjectBranchName
   | BranchI BranchSourceI (ProjectAndBranch (Maybe ProjectName) ProjectBranchName)
   | BranchesI
   | ReleaseDraftI Semver

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2379,17 +2379,21 @@ branchClone :: InputPattern
 branchClone =
   InputPattern
     { patternName = "branch.clone",
-      aliases = ["clone"],
+      aliases = [],
       visibility = I.Hidden,
-      argTypes = [(Required, projectAndBranchNamesArg)],
+      argTypes = [(Required, projectBranchNameArg)],
       help = P.wrap "Clone a project branch from a remote server.",
       parse = \case
-        [name] ->
-          case tryInto @(These ProjectName ProjectBranchName) (Text.pack name) of
+        [branchString] ->
+          case tryInto @ProjectBranchName (Text.pack (dropLeadingForwardSlash branchString)) of
             Left _ -> Left (showPatternHelp branchClone)
-            Right projectAndBranch -> Right (Input.BranchCloneI projectAndBranch)
+            Right branch -> Right (Input.BranchCloneI branch)
         _ -> Left (showPatternHelp branchClone)
     }
+  where
+    dropLeadingForwardSlash = \case
+      '/' : xs -> xs
+      xs -> xs
 
 branchInputPattern :: InputPattern
 branchInputPattern =


### PR DESCRIPTION
## Overview

Continuing the `project.clone` changes from #3933, this PR removes some functionality from `branch.clone`.

Previously, you could:

1. `branch.clone project` (default branch)
2. `branch.clone /branch` (current project)
3. `branch.clone project/branch`

Now, you can:

1. `branch.clone branch` (current project)
2. `branch.clone /branch` (current project)

with (1) and (3) above now possible only with `project.clone`.

## Test coverage

I tested this change manually
