### PR TITLE
implement tab-completion for `switch`

### DIFF
--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2794,32 +2794,35 @@ projectAndBranchNamesArg =
     branchToCompletion :: (ProjectBranchId, ProjectBranchName) -> Completion
     branchToCompletion (_, branchName) =
       Completion
-        { replacement = string,
+        { replacement = '/' : stringBranchName,
           display =
             fold
-              [ Ansi.setSGRCode [Ansi.SetColor Ansi.Foreground Ansi.Dull Ansi.Blue],
-                string,
+              [ Ansi.setSGRCode [Ansi.SetColor Ansi.Foreground Ansi.Vivid Ansi.Black],
+                "/",
+                Ansi.setSGRCode [Ansi.SetColor Ansi.Foreground Ansi.Dull Ansi.Blue],
+                stringBranchName,
                 Ansi.setSGRCode [Ansi.Reset]
               ],
           isFinished = False
         }
       where
-        string = '/' : Text.unpack (into @Text branchName)
+        stringBranchName =
+          Text.unpack (into @Text branchName)
 
     projectToCompletion :: Sqlite.Project -> Completion
     projectToCompletion project =
       Completion
-        { replacement = string,
+        { replacement = stringProjectName,
           display =
             fold
               [ Ansi.setSGRCode [Ansi.SetColor Ansi.Foreground Ansi.Dull Ansi.Green],
-                string,
+                stringProjectName,
                 Ansi.setSGRCode [Ansi.Reset]
               ],
           isFinished = False
         }
       where
-        string = Text.unpack (into @Text (project ^. #name))
+        stringProjectName = Text.unpack (into @Text (project ^. #name))
 
     -- Load branches matching input, throwing away the current branch.
     loadBranches ::


### PR DESCRIPTION
## Overview

This PR implements a rough (but usable) draft of tab-completion for the `switch` command.

`switch` can:

1. switch branches in the current project
2. switch to the default branch of a project
3. switch to a specific project/branch

This PR includes a tab-completer that only suggests entries for (1) and (2), but not (3). That is, if you type

```
> switch someproject/<TAB>
```

you will see no suggestions, though you would ideally see a list of all branches in `someproject`.

Branches and projects are rendered in different colors, and branches have a leading forward slash. The current project and branch (if any) are filtered out of the suggestions.

<img width="406" alt="Screen Shot 2023-05-03 at 1 20 21 PM" src="https://user-images.githubusercontent.com/1074598/235992173-09f042c7-e0d5-4063-87eb-c595f209adf1.png">

It's not necessary to prefix branches with a forward slash before tab-completing. In the project above, typing

```
> switch to<TAB>
```

would tab-complete to

```
> switch /topic
```

(inserting the leading forward-slash and typing the longest common prefix to all matches). A subsequent `<TAB>` would show the options:

<img width="286" alt="Screen Shot 2023-05-03 at 1 22 48 PM" src="https://user-images.githubusercontent.com/1074598/235993121-a1b1d042-7930-4fa0-b507-c341ba6fdfa7.png">

If you do include a leading forward slash, though, you'll get only branch suggestions:

<img width="518" alt="Screen Shot 2023-05-03 at 1 24 44 PM" src="https://user-images.githubusercontent.com/1074598/235993867-8689b5a0-87ac-44b8-8c94-06709a12f23a.png">

If you're outside of a project, only projects are shown (obviously), since there are no other branches:

<img width="264" alt="Screen Shot 2023-05-03 at 1 23 44 PM" src="https://user-images.githubusercontent.com/1074598/235996168-7cf4a443-2c3f-4e7e-9f5e-41caa56b8b22.png">

There's an obnoxious corner-ish case of a name collision between branches and projects, as in the branch/project `"bar"` here:

<img width="518" alt="Screen Shot 2023-05-03 at 1 25 53 PM" src="https://user-images.githubusercontent.com/1074598/235994657-a6f53062-8ab6-49bc-9d9f-096096985c09.png">

In the current implementation, if you tab complete with a prefix shared by both projects and branches, then you'll only get project suggestions:

<img width="205" alt="Screen Shot 2023-05-03 at 1 27 36 PM" src="https://user-images.githubusercontent.com/1074598/235995454-f09ae9e0-b0be-427a-b60f-e3fa633cf2a2.png">

You might hope to see branches that begin with "b" in the screenshot above, too, but I just couldn't get that to work well with haskeline. See the big comment in the PR for details.
