### PR TITLE
improve project/branch name styling in output messages

### DIFF
--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2376,7 +2376,7 @@ prettyHash32 = prettyBase32Hex# . Hash32.toBase32Hex
 
 prettyProjectName :: ProjectName -> Pretty
 prettyProjectName =
-  P.blue . P.text . into @Text
+  P.green . P.text . into @Text
 
 prettyProjectBranchName :: ProjectBranchName -> Pretty
 prettyProjectBranchName =
@@ -2393,12 +2393,12 @@ prettySemver (Semver x y z) =
 -- Not all project branches are printed such: for example, when listing all branches of a project, we probably don't
 -- need or want to prefix every one with a forward slash.
 prettySlashProjectBranchName :: ProjectBranchName -> Pretty
-prettySlashProjectBranchName =
-  P.blue . P.text . Text.cons '/' . into @Text
+prettySlashProjectBranchName branch =
+  P.group (P.hiBlack "/" <> prettyProjectBranchName branch)
 
 prettyProjectAndBranchName :: ProjectAndBranch ProjectName ProjectBranchName -> Pretty
-prettyProjectAndBranchName names =
-  P.blue (P.text (into @Text names))
+prettyProjectAndBranchName (ProjectAndBranch project branch) =
+  P.group (prettyProjectName project <> P.hiBlack "/" <> prettyProjectBranchName branch)
 
 prettyPathOrProjectAndBranchName :: Either Path.Path' (ProjectAndBranch ProjectName ProjectBranchName) -> Pretty
 prettyPathOrProjectAndBranchName = \case


### PR DESCRIPTION
## Overview

This PR changes the visual style of project and branch names in output messages.

Previously, everything was a flat blue, including the separator `/`, which isn't part of the project or branch name:

<img width="725" alt="Screen Shot 2023-05-03 at 4 44 17 PM" src="https://user-images.githubusercontent.com/1074598/236045176-02774db3-f3e9-4186-80fe-7eef9f653fd6.png">

Now, the project name is one color, the branch name another, and the separator a third:

<img width="725" alt="Screen Shot 2023-05-03 at 4 42 13 PM" src="https://user-images.githubusercontent.com/1074598/236044794-416e3b70-faa2-4588-b3d6-b9561ce1b7db.png">
