### PR TITLE
Make rebuilding haddocks a manual process

### DIFF
--- a/.github/workflows/haddocks.yaml
+++ b/.github/workflows/haddocks.yaml
@@ -8,7 +8,7 @@ defaults:
 on:
   push:
     branches:
-      - trunk
+      - haddocks-src
 
 jobs:
   build:
@@ -17,6 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          ref: 'haddocks-src'
           path: unison
 
       # The number towards the beginning of the cache keys allow you to manually avoid using a previous cache.


### PR DESCRIPTION
@tstat  discovered that the `haddocks` branch is inflating the repo and making pulls take much longer than they probably should. Currently we rebuild haddocks on every push to trunk, this would change it so they'll only be rebuilt when the `haddocks-src` branch is manually updated and pushed.

Once this is merged I could also go and wipe out all the history in that branch.

I guess the question would be, does anyone actually use the generated haddocks pages? I thought I would use them more than I do 🤷🏼‍♂️ ; maybe we just delete this workflow all together?