### PR TITLE
Share Project URLs use /code instead of /branches

### DIFF
--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -451,7 +451,7 @@ notifyNumbered = \case
             P.hiBlack . P.text $
               "https://share.unison-lang.org/"
                 <> into @Text remoteProject
-                <> "/branches/"
+                <> "/code/"
                 <> into @Text remoteBranch
           else
             prettyProjectAndBranchName (ProjectAndBranch remoteProject remoteBranch)


### PR DESCRIPTION
Update the output message that mentions a Share Project URL to use /code instead of /branches, which was recently changed in Share.