### PR TITLE
`ls` pretty print scope bug

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -8,7 +8,6 @@ where
 
 -- TODO: Don't import backend
 
-import Control.Concurrent.STM (atomically)
 import qualified Control.Error.Util as ErrorUtil
 import Control.Exception (catch)
 import Control.Lens
@@ -213,7 +212,6 @@ import Unison.Util.TransitiveClosure (transitiveClosure)
 import Unison.Var (Var)
 import qualified Unison.Var as Var
 import qualified Unison.WatchKind as WK
-import qualified UnliftIO.STM as STM
 import Web.Browser (openBrowser)
 
 ------------------------------------------------------------------------------------------------------------------------
@@ -902,14 +900,13 @@ loop e = do
               entries <- liftIO (Backend.lsAtPath codebase Nothing pathArgAbs)
               -- caching the result as an absolute path, for easier jumping around
               #numberedArgs .= fmap entryToHQString entries
-              getRoot <- atomically . STM.readTMVar <$> use #root
+              currentBranch <- Cli.getCurrentBranch
               let buildPPE = do
                     schLength <- Codebase.runTransaction codebase Codebase.branchHashLength
-                    rootBranch <- getRoot
                     pure $
                       Backend.basicSuffixifiedNames
                         schLength
-                        rootBranch
+                        currentBranch
                         (Backend.AllNames (Path.unabsolute pathArgAbs))
               Cli.respond $ ListShallow buildPPE entries
               where

--- a/unison-src/transcripts/ls-pretty-print-scope-bug.md
+++ b/unison-src/transcripts/ls-pretty-print-scope-bug.md
@@ -1,0 +1,44 @@
+```unison
+unique type Foo = Foo
+```
+
+```ucm
+.a.b> add
+.> fork .a.b .c.d.f
+.c.g.f>
+```
+
+```unison
+unique type Foo = Foo
+```
+
+```ucm
+.c.g.f> add
+.c>
+```
+
+```unison
+foo = .d.f.Foo.Foo
+```
+
+```ucm
+.c> add
+```
+
+At this point we have:
+`.a.b.Foo`
+`.c.d.f.Foo` which is equal to `.a.b.Foo`
+`.c.g.f.Foo` which is distinct from the other `Foo` types
+
+```ucm
+.> delete .c.d.f.Foo
+```
+Once `.c.d.f.Foo` is deleted `.c.foo` should have the type `.a.b.Foo`
+when viewed from `.>`, but an unnamed type when viewed from `.c>`,
+since referencing `.a.b.Foo` would reference names outside of the
+namespace rooted at `.c`.
+
+```ucm
+.> ls c
+.c> ls
+```

--- a/unison-src/transcripts/ls-pretty-print-scope-bug.output.md
+++ b/unison-src/transcripts/ls-pretty-print-scope-bug.output.md
@@ -101,7 +101,7 @@ namespace rooted at `.c`.
 .c> ls
 
   1. d/  (1 term)
-  2. foo (b.Foo)
+  2. foo (#uj8oalgadr)
   3. g/  (1 term, 1 type)
 
 ```

--- a/unison-src/transcripts/ls-pretty-print-scope-bug.output.md
+++ b/unison-src/transcripts/ls-pretty-print-scope-bug.output.md
@@ -1,0 +1,107 @@
+```unison
+unique type Foo = Foo
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique type Foo
+
+```
+```ucm
+  ☝️  The namespace .a.b is empty.
+
+.a.b> add
+
+  ⍟ I've added these definitions:
+  
+    unique type Foo
+
+.> fork .a.b .c.d.f
+
+  Done.
+
+  ☝️  The namespace .c.g.f is empty.
+
+```
+```unison
+unique type Foo = Foo
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique type Foo
+
+```
+```ucm
+.c.g.f> add
+
+  ⍟ I've added these definitions:
+  
+    unique type Foo
+
+```
+```unison
+foo = .d.f.Foo.Foo
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      foo : d.f.Foo
+
+```
+```ucm
+.c> add
+
+  ⍟ I've added these definitions:
+  
+    foo : d.f.Foo
+
+```
+At this point we have:
+`.a.b.Foo`
+`.c.d.f.Foo` which is equal to `.a.b.Foo`
+`.c.g.f.Foo` which is distinct from the other `Foo` types
+
+```ucm
+.> delete .c.d.f.Foo
+
+  Done.
+
+```
+Once `.c.d.f.Foo` is deleted `.c.foo` should have the type `.a.b.Foo`
+when viewed from `.>`, but an unnamed type when viewed from `.c>`,
+since referencing `.a.b.Foo` would reference names outside of the
+namespace rooted at `.c`.
+
+```ucm
+.> ls c
+
+  1. d/  (1 term)
+  2. foo (b.Foo)
+  3. g/  (1 term, 1 type)
+
+.c> ls
+
+  1. d/  (1 term)
+  2. foo (b.Foo)
+  3. g/  (1 term, 1 type)
+
+```

--- a/unison-src/transcripts/move-namespace.output.md
+++ b/unison-src/transcripts/move-namespace.output.md
@@ -70,7 +70,7 @@ Should be able to move the namespace, including its types, terms, and sub-namesp
 
   1. T       (type)
   2. T/      (2 terms)
-  3. termInA (Nat)
+  3. termInA (##Nat)
 
 .happy> history b
 


### PR DESCRIPTION
## Overview
`ls` unconditionally builds a pretty print environment from the namespace root, rather than the current path. This allows names outside of the current path to be referenced when running `ls`. This PR demonstrates this bug with a transcript added in the first commit then fixes the bug in the second commit.

## Test coverage

See [this transcript](https://github.com/unisonweb/unison/pull/3965/files#diff-12ff8046106780fa92dd9bd5021ede230b565a911109d2f3631ddc807b71a32aR1)