### PR TITLE
Sqlite names perspective fix

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -581,7 +581,7 @@ expectTextCheck h = queryOneColCheck2 (loadTextSql h)
 
 loadTextSql :: TextId -> Sql2
 loadTextSql h =
-  [sql2| 
+  [sql2|
     SELECT text
     FROM text
     WHERE id = :h
@@ -2128,9 +2128,8 @@ longestMatchingTermNameForSuffixification bhId namespaceRoot (NamedRef.NamedRef 
           lift $ queryMaybeRow sql ((bhId, lastSegment, namespaceGlob, suffGlob) :. ref)
         case result of
           Just namedRef ->
-            -- We want to find matches for the _longest_ possible suffix, so we keep going until we
-            -- don't find any more matches.
-            pure (unRow <$> namedRef) <|> loop rest
+            -- Try to find a longer suffix, falling back to the shorter match we've found.
+            loop rest <|> pure (unRow <$> namedRef)
           Nothing ->
             -- If we don't find a match for a suffix, there's no way we could match on an even
             -- longer suffix, so we bail.
@@ -2174,9 +2173,8 @@ longestMatchingTypeNameForSuffixification bhId namespaceRoot (NamedRef.NamedRef 
           lift $ queryMaybeRow sql ((bhId, lastSegment, namespaceGlob, suffGlob) :. ref)
         case result of
           Just namedRef ->
-            -- We want to find matches for the _longest_ possible suffix, so we keep going until we
-            -- don't find any more matches.
-            pure namedRef <|> loop rest
+            -- Try to find a longer suffix, falling back to the shorter match we've found.
+            loop rest <|> pure namedRef
           Nothing ->
             -- If we don't find a match for a suffix, there's no way we could match on an even
             -- longer suffix, so we bail.

--- a/parser-typechecker/src/Unison/PrettyPrintEnv.hs
+++ b/parser-typechecker/src/Unison/PrettyPrintEnv.hs
@@ -19,9 +19,11 @@ module Unison.PrettyPrintEnv
     addFallback,
     union,
     empty,
+    mapNames,
   )
 where
 
+import Data.Bifunctor (second)
 import Data.Ord (Down (Down))
 import Data.Semigroup (Max (Max))
 import Unison.ConstructorReference (ConstructorReference)
@@ -173,3 +175,14 @@ prioritizeBias targets =
         )
       & fromMaybe 0
       & Down -- Sort large common prefixes highest
+
+-- | Allows mapping over the names which will be returned by the pretty-printer.
+--
+-- The FQNs which are used for biasing are unaffected.
+-- Generally you shouldn't need this, but there are special cases where it's useful.
+mapNames :: (HQ'.HashQualified Name -> HQ'.HashQualified Name) -> PrettyPrintEnv -> PrettyPrintEnv
+mapNames f ppe =
+  PrettyPrintEnv
+    { termNames = fmap (second f) . termNames ppe,
+      typeNames = fmap (second f) . typeNames ppe
+    }


### PR DESCRIPTION
## Overview

See https://github.com/unisoncomputing/enlil/issues/208

The pretty-printer prints names for any references that are part of the cycle we're printing **fully-qualified**, since it will fail to parse otherwise if printing the whole cycle to a scratchfile. Example [here](https://share.unison-lang.org/@unison/p/code/latest/namespaces/public/distributed/latest/;/types/Atomic)

**Old version**

![image](https://user-images.githubusercontent.com/6439644/236968881-e872b45d-ed8a-48a7-9174-2a8e44bd35e4.png)

**New one** (ignore 'Ref2', that was me testing something else)

<img width="746" alt="image" src="https://github.com/unisonweb/unison/assets/6439644/dac4dff2-4d0c-425d-b540-e517a6380785">


However, we actually want names to be relative to the project root (or perspective if not in a project) when browsing Share.

## Implementation notes

* Make all names in the share PPE relative to the current project-root (or perspective if not in a project).
* Explicitly re-qualify termNames/typeNames to the project root in the cases where we want that behaviour instead.

## Interesting/controversial decisions

* We can no longer add additional qualifying segments to ambiguous top-level names, but we're already unhappy with the current behaviour here anyways, I think the new behaviour and would probably "look" more correct in most cases. 

Previously, if you had `.project.foo` and `.project.bar.foo` and viewed `foo` from within `.project` it would print as `project.foo` in order to disambiguate from `bar.foo`, but now would simply print as `foo`, which is ambiguous. However unless people copy-paste from the share printout it shouldn't actually be a real-world problem. We may introduce some sort of project-root or current-perspective path symbol to solve this in the future.

Note that this will still fully-qualify types within cycles to the project root, just not to the codebase root.
We may wish to adjust the behaviour here too, but in this case I think we'd need to actually alter the pretty-printer to have a `display` version and a `parseable` version which is probably a bigger conversation we'll want to have.

E.g. if I move `Atomic` to `public.distributed.latest.deeply.nested.Atomic` it will display like this:

<img width="758" alt="image" src="https://github.com/unisonweb/unison/assets/6439644/d19943b4-858c-4859-ba70-259639b49923">


## Test coverage

I'll add some transcript tests in Enlil.