### PR TITLE
Add helpers for rendering arbitrary top-level docs.

### DIFF
--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -32,7 +32,7 @@ module Unison.Server.Backend
     displayType,
     docsInBranchToHtmlFiles,
     expandShortCausalHash,
-    findShallowReadmeInBranchAndRender,
+    findDocInBranchAndRender,
     formatSuffixedType,
     getCurrentParseNames,
     getCurrentPrettyNames,
@@ -440,14 +440,15 @@ lsAtPath codebase mayRootBranch absPath = do
   b <- Codebase.runTransaction codebase (Codebase.getShallowBranchAtPath (Path.unabsolute absPath) mayRootBranch)
   lsBranch codebase b
 
-findShallowReadmeInBranchAndRender ::
+findDocInBranchAndRender ::
+  Set NameSegment ->
   Width ->
   Rt.Runtime Symbol ->
   Codebase IO Symbol Ann ->
   PPED.PrettyPrintEnvDecl ->
   V2Branch.Branch m ->
   Backend IO (Maybe Doc.Doc)
-findShallowReadmeInBranchAndRender _width runtime codebase ppe namespaceBranch =
+findDocInBranchAndRender names _width runtime codebase ppe namespaceBranch =
   let renderReadme :: PPED.PrettyPrintEnvDecl -> Reference -> IO Doc.Doc
       renderReadme ppe docReference = do
         doc <- evalDocRef runtime codebase docReference <&> Doc.renderDoc ppe
@@ -455,7 +456,7 @@ findShallowReadmeInBranchAndRender _width runtime codebase ppe namespaceBranch =
 
       -- choose the first term (among conflicted terms) matching any of these names, in this order.
       -- we might later want to return all of them to let the front end decide
-      toCheck = NameSegment <$> ["README", "Readme", "ReadMe", "readme"]
+      toCheck = Set.toList names
       readme :: Maybe Reference
       readme = listToMaybe $ do
         name <- toCheck

--- a/unison-share-api/src/Unison/Server/Share/RenderDoc.hs
+++ b/unison-share-api/src/Unison/Server/Share/RenderDoc.hs
@@ -7,12 +7,12 @@
 {-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Unison.Server.Endpoints.NamespaceDetails where
+-- | Helper for rendering docs within a given namespace
+module Unison.Server.Share.RenderDoc where
 
 import Control.Monad.Except
 import Data.Aeson
 import Data.OpenApi (ToSchema)
-import qualified Data.Set as Set
 import Servant (Capture, QueryParam, (:>))
 import Servant.Docs (DocCapture (..), ToCapture (..), ToSample (..))
 import Servant.OpenApi ()
@@ -36,51 +36,17 @@ import Unison.Server.Types
   )
 import Unison.Symbol (Symbol)
 import Unison.Util.Pretty (Width)
+import Unison.NameSegment (NameSegment)
 
-type NamespaceDetailsAPI =
-  "namespaces"
-    :> Capture "namespace" Path.Path
-    :> QueryParam "rootBranch" ShortCausalHash
-    :> QueryParam "renderWidth" Width
-    :> APIGet NamespaceDetails
-
-instance ToCapture (Capture "namespace" Text) where
-  toCapture _ =
-    DocCapture
-      "namespace"
-      "The fully qualified name of a namespace. The leading `.` is optional."
-
-instance ToSample NamespaceDetails where
-  toSamples _ =
-    [ ( "When no value is provided for `namespace`, the root namespace `.` is "
-          <> "listed by default",
-        NamespaceDetails
-          Path.empty
-          "#gjlk0dna8dongct6lsd19d1o9hi5n642t8jttga5e81e91fviqjdffem0tlddj7ahodjo5"
-          Nothing
-      )
-    ]
-
-data NamespaceDetails = NamespaceDetails
-  { fqn :: Path.Path,
-    hash :: UnisonHash,
-    readme :: Maybe Doc
-  }
-  deriving (Generic, Show)
-
-instance ToJSON NamespaceDetails where
-  toEncoding = genericToEncoding defaultOptions
-
-deriving instance ToSchema NamespaceDetails
-
-namespaceDetails ::
+renderDoc ::
+  Set NameSegment ->
   Rt.Runtime Symbol ->
   Codebase IO Symbol Ann ->
   Path.Path ->
   Maybe (Either ShortCausalHash CausalHash) ->
   Maybe Width ->
-  Backend IO NamespaceDetails
-namespaceDetails runtime codebase namespacePath mayRoot mayWidth =
+  Backend IO (Maybe Doc)
+renderDoc docNames runtime codebase namespacePath mayRoot mayWidth =
   let width = mayDefaultWidth mayWidth
    in do
         (rootCausal, namespaceCausal, shallowBranch) <-
@@ -94,19 +60,13 @@ namespaceDetails runtime codebase namespacePath mayRoot mayWidth =
             namespaceCausal <- lift $ Codebase.getShallowCausalAtPath namespacePath (Just rootCausalHash)
             shallowBranch <- lift $ V2Causal.value namespaceCausal
             pure (rootCausalHash, namespaceCausal, shallowBranch)
-        namespaceDetails <- do
-          (_localNamesOnly, ppe) <- Backend.scopedNamesForBranchHash codebase (Just rootCausal) namespacePath
-          readme <-
-            Backend.findDocInBranchAndRender
-              readmeNames
-              width
-              runtime
-              codebase
-              ppe
-              shallowBranch
-          let causalHash = v2CausalBranchToUnisonHash namespaceCausal
-          pure $ NamespaceDetails namespacePath causalHash readme
-
-        pure $ namespaceDetails
-  where
-    readmeNames = Set.fromList ["README", "Readme", "ReadMe", "readme"]
+        (_localNamesOnly, ppe) <- Backend.scopedNamesForBranchHash codebase (Just rootCausal) namespacePath
+        renderedDoc <-
+          Backend.findDocInBranchAndRender
+            docNames
+            width
+            runtime
+            codebase
+            ppe
+            shallowBranch
+        pure renderedDoc

--- a/unison-share-api/src/Unison/Server/Share/RenderDoc.hs
+++ b/unison-share-api/src/Unison/Server/Share/RenderDoc.hs
@@ -11,10 +11,6 @@
 module Unison.Server.Share.RenderDoc where
 
 import Control.Monad.Except
-import Data.Aeson
-import Data.OpenApi (ToSchema)
-import Servant (Capture, QueryParam, (:>))
-import Servant.Docs (DocCapture (..), ToCapture (..), ToSample (..))
 import Servant.OpenApi ()
 import qualified U.Codebase.Causal as V2Causal
 import U.Codebase.HashTags (CausalHash)
@@ -30,10 +26,7 @@ import Unison.Server.Backend
 import qualified Unison.Server.Backend as Backend
 import Unison.Server.Doc (Doc)
 import Unison.Server.Types
-  ( APIGet,
-    UnisonHash,
-    mayDefaultWidth,
-    v2CausalBranchToUnisonHash,
+  ( mayDefaultWidth,
   )
 import Unison.Symbol (Symbol)
 import Unison.Util.Pretty (Width)
@@ -49,7 +42,7 @@ renderDoc ::
 renderDoc docNames runtime codebase namespacePath mayRoot mayWidth =
   let width = mayDefaultWidth mayWidth
    in do
-        (rootCausal, namespaceCausal, shallowBranch) <-
+        (rootCausal, shallowBranch) <-
           Backend.hoistBackend (Codebase.runTransaction codebase) do
             rootCausalHash <-
               case mayRoot of
@@ -59,7 +52,7 @@ renderDoc docNames runtime codebase namespacePath mayRoot mayWidth =
             -- lift (Backend.resolveCausalHashV2 rootCausalHash)
             namespaceCausal <- lift $ Codebase.getShallowCausalAtPath namespacePath (Just rootCausalHash)
             shallowBranch <- lift $ V2Causal.value namespaceCausal
-            pure (rootCausalHash, namespaceCausal, shallowBranch)
+            pure (rootCausalHash, shallowBranch)
         (_localNamesOnly, ppe) <- Backend.scopedNamesForBranchHash codebase (Just rootCausal) namespacePath
         renderedDoc <-
           Backend.findDocInBranchAndRender

--- a/unison-share-api/src/Unison/Server/Share/RenderDoc.hs
+++ b/unison-share-api/src/Unison/Server/Share/RenderDoc.hs
@@ -23,6 +23,7 @@ import qualified Unison.Codebase as Codebase
 import qualified Unison.Codebase.Path as Path
 import qualified Unison.Codebase.Runtime as Rt
 import Unison.Codebase.ShortCausalHash (ShortCausalHash)
+import Unison.NameSegment (NameSegment)
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.Server.Backend
@@ -36,7 +37,6 @@ import Unison.Server.Types
   )
 import Unison.Symbol (Symbol)
 import Unison.Util.Pretty (Width)
-import Unison.NameSegment (NameSegment)
 
 renderDoc ::
   Set NameSegment ->

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -38,6 +38,7 @@ library
       Unison.Server.SearchResult
       Unison.Server.SearchResult'
       Unison.Server.Share.Definitions
+      Unison.Server.Share.RenderDoc
       Unison.Server.Syntax
       Unison.Server.Types
       Unison.Sync.API


### PR DESCRIPTION
## Overview

Adds a combinator for getting the doc for an arbitrary set of top-level name segments.

This allows me to render Release Notes, Changelog notes, etc. from Enlil instead of JUST the readme.

## Implementation notes

* Generalize `findShallowReadmeInBranchInRender` to `findDocInBranchAndRender`
* Use it to implement a new backend helper for rendering the doc for a provided set of aliases.

## Interesting/controversial decisions

This could be more general and accept several possible names at once, or accept something other than just NameSegments, but it's a bit annoying to implement the most efficient general version, and there'd be questions about how to handle multiple matches, etc. So I'll leave that effort till if/when it's actually needed. 🤷🏼‍♂️ 

## Test coverage

None, should be a simple enough change.

## Loose ends

See https://github.com/unisoncomputing/enlil/pull/210
