### PR TITLE
Resolve type-references by suffix within scratchfile

### DIFF
--- a/parser-typechecker/src/Unison/PrettyPrintEnv/Util.hs
+++ b/parser-typechecker/src/Unison/PrettyPrintEnv/Util.hs
@@ -3,11 +3,8 @@
 module Unison.PrettyPrintEnv.Util (declarationPPE, declarationPPEDecl) where
 
 import Unison.PrettyPrintEnv (PrettyPrintEnv (..))
-import qualified Unison.PrettyPrintEnv as PPE
-import Unison.PrettyPrintEnvDecl (PrettyPrintEnvDecl (suffixifiedPPE, unsuffixifiedPPE))
+import Unison.PrettyPrintEnvDecl (PrettyPrintEnvDecl (suffixifiedPPE))
 import Unison.Reference (Reference)
-import qualified Unison.Reference as Reference
-import qualified Unison.Referent as Referent
 
 -- declarationPPE uses the full name for references that are
 -- part the same cycle as the input reference, used to ensures
@@ -17,20 +14,23 @@ import qualified Unison.Referent as Referent
 -- and not
 -- foo.bar x = bar x
 declarationPPE :: PrettyPrintEnvDecl -> Reference -> PrettyPrintEnv
-declarationPPE ppe ref = PrettyPrintEnv tm ty
-  where
-    rootH = hash ref
-    hash Reference.Builtin {} = Nothing
-    hash (Reference.Derived h _) = Just h
-    tm r0@(Referent.Ref r)
-      | hash r == rootH = PPE.termNames (unsuffixifiedPPE ppe) r0
-      | otherwise = PPE.termNames (suffixifiedPPE ppe) r0
-    tm r = PPE.termNames (suffixifiedPPE ppe) r
-    ty r
-      | hash r == rootH = PPE.typeNames (unsuffixifiedPPE ppe) r
-      | otherwise = PPE.typeNames (suffixifiedPPE ppe) r
+declarationPPE ppe _ref = suffixifiedPPE ppe
+
+-- PrettyPrintEnv tm ty
+-- where
+--   rootH = hash ref
+--   hash Reference.Builtin {} = Nothing
+--   hash (Reference.Derived h _) = Just h
+--   tm r0@(Referent.Ref r)
+--     | hash r == rootH = PPE.termNames (unsuffixifiedPPE ppe) r0
+--     | otherwise = PPE.termNames (suffixifiedPPE ppe) r0
+--   tm r = PPE.termNames (suffixifiedPPE ppe) r
+--   ty r
+--     | hash r == rootH = PPE.typeNames (unsuffixifiedPPE ppe) r
+--     | otherwise = PPE.typeNames (suffixifiedPPE ppe) r
 
 -- The suffixed names uses the fully-qualified name for `r`
 declarationPPEDecl :: PrettyPrintEnvDecl -> Reference -> PrettyPrintEnvDecl
-declarationPPEDecl ppe r =
-  ppe {suffixifiedPPE = declarationPPE ppe r}
+declarationPPEDecl ppe _r = ppe
+
+-- ppe {suffixifiedPPE = declarationPPE ppe r}

--- a/unison-src/transcripts-manual/benchmarks.output.md
+++ b/unison-src/transcripts-manual/benchmarks.output.md
@@ -1,0 +1,12 @@
+```ucm
+.> pull unison.public.base.releases.M4d base.> pull runarorama.public.sort.data sort
+```
+
+
+🛑
+
+The transcript failed due to an error in the stanza above. The error is:
+
+
+  base/main does not exist.
+

--- a/unison-src/transcripts-manual/scheme.output.md
+++ b/unison-src/transcripts-manual/scheme.output.md
@@ -1,0 +1,15 @@
+This transcript executes very slowly, because the compiler has an
+entire copy of base (and other stuff) within it.
+
+```ucm
+.> builtins.mergeio.> pull.without-history unison.public.base.trunk base
+```
+
+
+🛑
+
+The transcript failed due to an error in the stanza above. The error is:
+
+
+  base/main does not exist.
+

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -18,7 +18,7 @@ x = 1 + 1
   ☝️
   
   I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
+  /Users/cpenner/dev/unison/scratch.u
   
     x : Nat
     x =
@@ -34,16 +34,16 @@ x = 1 + 1
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #c5i2vql0hi .old`   to make an old namespace
+    `fork #u0kujjj8n2 .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #c5i2vql0hi`  to reset the root namespace and
+    `reset-root #u0kujjj8n2`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
        When         Root Hash     Action
-  1.   now          #88srvru2o0   add
-  2.   1 secs ago   #c5i2vql0hi   builtins.mergeio
+  1.   now          #7po6t2j4ji   add
+  2.   1 secs ago   #u0kujjj8n2   builtins.mergeio
   3.                #sg60bvjo91   history starts here
   
   Tip: Use `diff.namespace 1 7` to compare namespaces between
@@ -106,7 +106,7 @@ Without the above stanza, the `edit` will send the definition to the most recent
   ☝️
   
   I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
+  /Users/cpenner/dev/unison/scratch.u
   
     b : Nat
     b = 92384
@@ -120,18 +120,18 @@ Without the above stanza, the `edit` will send the definition to the most recent
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #c5i2vql0hi .old`   to make an old namespace
+    `fork #u0kujjj8n2 .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #c5i2vql0hi`  to reset the root namespace and
+    `reset-root #u0kujjj8n2`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
        When         Root Hash     Action
-  1.   now          #a16i2glj04   add
-  2.   now          #c5i2vql0hi   reset-root #c5i2vql0hi
-  3.   now          #88srvru2o0   add
-  4.   1 secs ago   #c5i2vql0hi   builtins.mergeio
+  1.   now          #jm7d1ujf0n   add
+  2.   now          #u0kujjj8n2   reset-root #u0kujjj8n2
+  3.   now          #7po6t2j4ji   add
+  4.   1 secs ago   #u0kujjj8n2   builtins.mergeio
   5.                #sg60bvjo91   history starts here
   
   Tip: Use `diff.namespace 1 7` to compare namespaces between
@@ -182,7 +182,7 @@ f x = let
   ☝️
   
   I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
+  /Users/cpenner/dev/unison/scratch.u
   
     unique type Blah
       = Blah Boolean Boolean
@@ -199,20 +199,20 @@ f x = let
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #c5i2vql0hi .old`   to make an old namespace
+    `fork #u0kujjj8n2 .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #c5i2vql0hi`  to reset the root namespace and
+    `reset-root #u0kujjj8n2`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
        When         Root Hash     Action
-  1.   now          #8pc9a0uci4   add
-  2.   now          #c5i2vql0hi   reset-root #c5i2vql0hi
-  3.   now          #a16i2glj04   add
-  4.   now          #c5i2vql0hi   reset-root #c5i2vql0hi
-  5.   now          #88srvru2o0   add
-  6.   1 secs ago   #c5i2vql0hi   builtins.mergeio
+  1.   now          #gi14tq4ehs   add
+  2.   now          #u0kujjj8n2   reset-root #u0kujjj8n2
+  3.   now          #jm7d1ujf0n   add
+  4.   now          #u0kujjj8n2   reset-root #u0kujjj8n2
+  5.   now          #7po6t2j4ji   add
+  6.   1 secs ago   #u0kujjj8n2   builtins.mergeio
   7.                #sg60bvjo91   history starts here
   
   Tip: Use `diff.namespace 1 7` to compare namespaces between
@@ -271,7 +271,7 @@ h xs = match xs with
   ☝️
   
   I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
+  /Users/cpenner/dev/unison/scratch.u
   
     f : [()] -> ()
     f = cases
@@ -292,22 +292,22 @@ h xs = match xs with
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #c5i2vql0hi .old`   to make an old namespace
+    `fork #u0kujjj8n2 .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #c5i2vql0hi`  to reset the root namespace and
+    `reset-root #u0kujjj8n2`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
        When         Root Hash     Action
-  1.   now          #psi40d6du2   add
-  2.   now          #c5i2vql0hi   reset-root #c5i2vql0hi
-  3.   now          #8pc9a0uci4   add
-  4.   now          #c5i2vql0hi   reset-root #c5i2vql0hi
-  5.   now          #a16i2glj04   add
-  6.   now          #c5i2vql0hi   reset-root #c5i2vql0hi
-  7.   now          #88srvru2o0   add
-  8.   1 secs ago   #c5i2vql0hi   builtins.mergeio
+  1.   now          #g01qct62s7   add
+  2.   now          #u0kujjj8n2   reset-root #u0kujjj8n2
+  3.   now          #gi14tq4ehs   add
+  4.   now          #u0kujjj8n2   reset-root #u0kujjj8n2
+  5.   now          #jm7d1ujf0n   add
+  6.   now          #u0kujjj8n2   reset-root #u0kujjj8n2
+  7.   now          #7po6t2j4ji   add
+  8.   1 secs ago   #u0kujjj8n2   builtins.mergeio
   9.                #sg60bvjo91   history starts here
   
   Tip: Use `diff.namespace 1 7` to compare namespaces between
@@ -357,7 +357,7 @@ foo n _ = n
   ☝️
   
   I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
+  /Users/cpenner/dev/unison/scratch.u
   
     unique type Foo x y
       = 
@@ -376,24 +376,24 @@ foo n _ = n
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #c5i2vql0hi .old`   to make an old namespace
+    `fork #u0kujjj8n2 .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #c5i2vql0hi`  to reset the root namespace and
+    `reset-root #u0kujjj8n2`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
         When         Root Hash     Action
-  1.    now          #9i8g6b1m8k   add
-  2.    now          #c5i2vql0hi   reset-root #c5i2vql0hi
-  3.    now          #psi40d6du2   add
-  4.    now          #c5i2vql0hi   reset-root #c5i2vql0hi
-  5.    now          #8pc9a0uci4   add
-  6.    now          #c5i2vql0hi   reset-root #c5i2vql0hi
-  7.    now          #a16i2glj04   add
-  8.    now          #c5i2vql0hi   reset-root #c5i2vql0hi
-  9.    now          #88srvru2o0   add
-  10.   1 secs ago   #c5i2vql0hi   builtins.mergeio
+  1.    now          #drsgmfubvu   add
+  2.    now          #u0kujjj8n2   reset-root #u0kujjj8n2
+  3.    now          #g01qct62s7   add
+  4.    now          #u0kujjj8n2   reset-root #u0kujjj8n2
+  5.    now          #gi14tq4ehs   add
+  6.    now          #u0kujjj8n2   reset-root #u0kujjj8n2
+  7.    now          #jm7d1ujf0n   add
+  8.    now          #u0kujjj8n2   reset-root #u0kujjj8n2
+  9.    now          #7po6t2j4ji   add
+  10.   1 secs ago   #u0kujjj8n2   builtins.mergeio
   11.                #sg60bvjo91   history starts here
   
   Tip: Use `diff.namespace 1 7` to compare namespaces between
@@ -440,7 +440,7 @@ foo =
   ☝️
   
   I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
+  /Users/cpenner/dev/unison/scratch.u
   
     foo : Text
     foo =
@@ -459,26 +459,26 @@ foo =
   most recent, along with the command that got us there. Try:
   
     `fork 2 .old`             
-    `fork #c5i2vql0hi .old`   to make an old namespace
+    `fork #u0kujjj8n2 .old`   to make an old namespace
                               accessible again,
                               
-    `reset-root #c5i2vql0hi`  to reset the root namespace and
+    `reset-root #u0kujjj8n2`  to reset the root namespace and
                               its history to that of the
                               specified namespace.
   
         When         Root Hash     Action
-  1.    now          #mqg8tqk7i6   add
-  2.    now          #c5i2vql0hi   reset-root #c5i2vql0hi
-  3.    now          #9i8g6b1m8k   add
-  4.    now          #c5i2vql0hi   reset-root #c5i2vql0hi
-  5.    now          #psi40d6du2   add
-  6.    now          #c5i2vql0hi   reset-root #c5i2vql0hi
-  7.    now          #8pc9a0uci4   add
-  8.    now          #c5i2vql0hi   reset-root #c5i2vql0hi
-  9.    now          #a16i2glj04   add
-  10.   now          #c5i2vql0hi   reset-root #c5i2vql0hi
-  11.   now          #88srvru2o0   add
-  12.   1 secs ago   #c5i2vql0hi   builtins.mergeio
+  1.    now          #66k3d281ae   add
+  2.    now          #u0kujjj8n2   reset-root #u0kujjj8n2
+  3.    now          #drsgmfubvu   add
+  4.    now          #u0kujjj8n2   reset-root #u0kujjj8n2
+  5.    now          #g01qct62s7   add
+  6.    now          #u0kujjj8n2   reset-root #u0kujjj8n2
+  7.    now          #gi14tq4ehs   add
+  8.    now          #u0kujjj8n2   reset-root #u0kujjj8n2
+  9.    now          #jm7d1ujf0n   add
+  10.   now          #u0kujjj8n2   reset-root #u0kujjj8n2
+  11.   now          #7po6t2j4ji   add
+  12.   1 secs ago   #u0kujjj8n2   builtins.mergeio
   13.                #sg60bvjo91   history starts here
   
   Tip: Use `diff.namespace 1 7` to compare namespaces between
@@ -521,7 +521,7 @@ myDoc = {{ **my text** __my text__ **MY_TEXT** ___MY__TEXT___ ~~MY~TEXT~~ **MY*T
   ☝️
   
   I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
+  /Users/cpenner/dev/unison/scratch.u
   
     myDoc : Doc2
     myDoc =
@@ -604,13 +604,13 @@ x = '(let
   ☝️
   
   I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
+  /Users/cpenner/dev/unison/scratch.u
   
-    structural ability base.Abort where abort : {base.Abort} a
+    structural ability base.Abort where abort : {Abort} a
     
     Abort.toDefault! : a -> '{g, Abort} a ->{g} a
     Abort.toDefault! default thunk =
-      h x = Abort.toDefault! (handler default x) thunk
+      h x = toDefault! (handler default x) thunk
       handle !thunk with h
     
     Abort.toOptional : '{g, Abort} a -> '{g} Optional a
@@ -656,1104 +656,38 @@ x = '(let
 ```ucm
 .> load scratch.u
 
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
   
-    ⍟ These new definitions are ok to `add`:
+    ❓
     
-      structural ability base.Abort
-      Abort.toDefault!  : a -> '{g, Abort} a ->{g} a
-      Abort.toOptional  : '{g, Abort} a -> '{g} Optional a
-      Abort.toOptional! : '{g, Abort} a ->{g} Optional a
-      handler           : a -> Request {Abort} a -> a
-      x                 : 'Optional Nat
-      |>                : a -> (a ->{e} b) ->{e} b
-
-```
-## Line breaks before 'let
-
-Regression test for https://github.com/unisonweb/unison/issues/1536
-
-```unison
-r = 'let
- y = 0
- y
-```
-
-```ucm
-.> add
-
-  ⍟ I've added these definitions:
-  
-    r : 'Nat
-
-.> edit r
-
-  ☝️
-  
-  I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
-  
-    r : 'Nat
-    r = do
-      y = 0
-      y
-  
-  You can edit them there, then do `update` to replace the
-  definitions currently in this namespace.
-
-.> undo
-
-  Here are the changes I undid
-  
-  Added definitions:
-  
-    1. r : 'Nat
-
-```
-```ucm
-.> load scratch.u
-
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-  
-    ⍟ These new definitions are ok to `add`:
+    I couldn't resolve any of these symbols:
     
-      r : 'Nat
-
-```
-## Raw codeblocks add indentation
-
-Regression test for https://github.com/unisonweb/unison/issues/2271
-
-```ucm
-.> load unison-src/transcripts-round-trip/docTest2.u
-
-  I found and typechecked these definitions in
-  unison-src/transcripts-round-trip/docTest2.u. If you do an
-  `add` or `update`, here's how your codebase would change:
-  
-    ⍟ These new definitions are ok to `add`:
+        1 | structural ability base.Abort where abort : {Abort} a
     
-      docTest2 : Doc2
-
-.> add
-
-  ⍟ I've added these definitions:
-  
-    docTest2 : Doc2
-
-```
-```unison
-x = 2
-```
-
-```ucm
-.> edit docTest2
-
-  ☝️
-  
-  I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
-  
-    docTest2 : Doc2
-    docTest2 =
-      {{ # Full doc body indented
-      
-        ``` raw
-        myVal1 = 42 
-        myVal2 = 43
-        myVal4 = 44
-        ```
-        
-        ``` raw
-        indented1= "hi"
-        indented2="this is two indents"
-        ```
-        
-        I am two spaces over }}
-  
-  You can edit them there, then do `update` to replace the
-  definitions currently in this namespace.
-
-```
-```ucm
-.> load scratch.u
-
-  I found and typechecked the definitions in scratch.u. This
-  file has been previously added to the codebase.
-
-.> add
-
-  ⊡ Ignored previously added definitions: docTest2
-
-```
-## Unison Cloud roundtrip issues
-
-Regression tests for  https://github.com/unisonweb/unison/issues/2650
-
-```unison
-broken =
-    addNumbers: 'Nat
-    addNumbers = 'let
-      use Nat +
-      y = 12
-      13 + y
-    !addNumbers
-```
-
-```ucm
-.> add
-
-  ⍟ I've added these definitions:
-  
-    broken : Nat
-
-.> edit broken
-
-  ☝️
-  
-  I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
-  
-    broken : Nat
-    broken =
-      addNumbers : 'Nat
-      addNumbers = do
-        use Nat +
-        y = 12
-        13 + y
-      !addNumbers
-  
-  You can edit them there, then do `update` to replace the
-  definitions currently in this namespace.
-
-.> undo
-
-  Here are the changes I undid
-  
-  Added definitions:
-  
-    1. broken : Nat
-
-```
-```ucm
-.> load scratch.u
-
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-  
-    ⍟ These new definitions are ok to `add`:
     
-      broken : Nat
+    Symbol   Suggestions
+             
+    Abort    No matches
+  
 
 ```
-```unison
-tvarmodify tvar fun = ()
 
-broken tvar =
-  '(tvarmodify tvar (cases
-     Some _ -> "oh boy isn't this a very very very very very very very long string?"
-     None -> ""))
-```
 
-```ucm
-.> add
 
-  ⍟ I've added these definitions:
+🛑
+
+The transcript failed due to an error in the stanza above. The error is:
+
+
   
-    broken     : tvar -> () -> ()
-    tvarmodify : tvar -> fun -> ()
-
-.> edit tvarmodify broken
-
-  ☝️
-  
-  I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
-  
-    broken : tvar -> () -> ()
-    broken tvar =
-      '(tvarmodify
-          tvar
-          (cases
-            Some _ ->
-              "oh boy isn't this a very very very very very very very long string?"
-            None -> ""))
+    ❓
     
-    tvarmodify : tvar -> fun -> ()
-    tvarmodify tvar fun = ()
-  
-  You can edit them there, then do `update` to replace the
-  definitions currently in this namespace.
-
-.> undo
-
-  Here are the changes I undid
-  
-  Added definitions:
-  
-    1. broken     : tvar -> () -> ()
-    2. tvarmodify : tvar -> fun -> ()
-
-```
-```ucm
-.> load scratch.u
-
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-  
-    ⍟ These new definitions are ok to `add`:
+    I couldn't resolve any of these symbols:
     
-      broken     : tvar -> '()
-      tvarmodify : tvar -> fun -> ()
-
-```
-```unison
-broken = cases
-  Some loooooooooooooooooooooooooooooooooooooooooooooooooooooooong | loooooooooooooooooooooooooooooooooooooooooooooooooooooooong == 1 -> ()
-  _ -> ()
-```
-
-```ucm
-.> add
-
-  ⍟ I've added these definitions:
-  
-    broken : Optional Nat -> ()
-
-.> edit broken
-
-  ☝️
-  
-  I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
-  
-    broken : Optional Nat -> ()
-    broken = cases
-      Some
-        loooooooooooooooooooooooooooooooooooooooooooooooooooooooong| loooooooooooooooooooooooooooooooooooooooooooooooooooooooong
-        == 1  ->
-        ()
-      _ -> ()
-  
-  You can edit them there, then do `update` to replace the
-  definitions currently in this namespace.
-
-.> undo
-
-  Here are the changes I undid
-  
-  Added definitions:
-  
-    1. broken : Optional Nat -> ()
-
-```
-```ucm
-.> load scratch.u
-
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-  
-    ⍟ These new definitions are ok to `add`:
+        1 | structural ability base.Abort where abort : {Abort} a
     
-      broken : Optional Nat -> ()
-
-```
-## Guard patterns on long lines
-
-```unison
-structural type SomethingUnusuallyLong = SomethingUnusuallyLong Text Text Text
-
-foo = let
-  go x =
-    'match (a -> a) x with
-      SomethingUnusuallyLong lijaefliejalfijelfj aefilaeifhlei liaehjffeafijij |
-        lijaefliejalfijelfj == aefilaeifhlei -> 0
-      SomethingUnusuallyLong lijaefliejalfijelfj aefilaeifhlei liaehjffeafijij |
-        lijaefliejalfijelfj == liaehjffeafijij -> 1
-      _ -> 2
-  go (SomethingUnusuallyLong "one" "two" "three")
-```
-
-```ucm
-.> add
-
-  ⍟ I've added these definitions:
-  
-    structural type SomethingUnusuallyLong
-    foo : 'Nat
-
-.> edit SomethingUnusuallyLong foo
-
-  ☝️
-  
-  I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
-  
-    structural type SomethingUnusuallyLong
-      = SomethingUnusuallyLong Text Text Text
     
-    foo : 'Nat
-    foo =
-      go x =
-        do
-          match (a -> a) x with
-            SomethingUnusuallyLong
-              lijaefliejalfijelfj aefilaeifhlei liaehjffeafijij
-              | lijaefliejalfijelfj == aefilaeifhlei    -> 0
-              | lijaefliejalfijelfj == liaehjffeafijij  -> 1
-            _ -> 2
-      go (SomethingUnusuallyLong "one" "two" "three")
+    Symbol   Suggestions
+             
+    Abort    No matches
   
-  You can edit them there, then do `update` to replace the
-  definitions currently in this namespace.
 
-.> undo
-
-  Here are the changes I undid
-  
-  Added definitions:
-  
-    1. structural type SomethingUnusuallyLong
-    2. SomethingUnusuallyLong.SomethingUnusuallyLong : Text
-                                                     -> Text
-                                                     -> Text
-                                                     -> #p9dp5r8ff6
-    3. foo                                           : 'Nat
-
-```
-```ucm
-.> load scratch.u
-
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-  
-    ⍟ These new definitions are ok to `add`:
-    
-      structural type SomethingUnusuallyLong
-      foo : 'Nat
-
-```
-## Nested fences
-
-```ucm
-.> load unison-src/transcripts-round-trip/nested.u
-
-  I found and typechecked these definitions in
-  unison-src/transcripts-round-trip/nested.u. If you do an `add`
-  or `update`, here's how your codebase would change:
-  
-    ⍟ These new definitions are ok to `add`:
-    
-      nested : Doc2
-
-.> add
-
-  ⍟ I've added these definitions:
-  
-    nested : Doc2
-
-```
-```ucm
-.> edit nested
-
-  ☝️
-  
-  I added these definitions to the top of
-  /Users/runar/work/unison/unison-src/transcripts-round-trip/nested.u
-  
-    nested : Doc2
-    nested =
-      {{ ```` raw
-      ```unison
-      r = "boopydoo"
-      ```
-      ```` }}
-  
-  You can edit them there, then do `update` to replace the
-  definitions currently in this namespace.
-
-.> undo
-
-  Here are the changes I undid
-  
-  Added definitions:
-  
-    1. nested : Doc2
-
-```
-```ucm
-.> load unison-src/transcripts-round-trip/nested.u
-
-  I found and typechecked these definitions in
-  unison-src/transcripts-round-trip/nested.u. If you do an `add`
-  or `update`, here's how your codebase would change:
-  
-    ⍟ These new definitions are ok to `add`:
-    
-      nested : Doc2
-
-```
-## Multiline expressions in multiliine lists
-
-```unison
-foo a b c d e f g h i j = 42
-
-use Nat +
-x = [ 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
-    , foo 12939233 2102020 329292 429292 522020 62929292 72020202 820202 920202 1020202 ]
-```
-
-```ucm
-.> add
-
-  ⍟ I've added these definitions:
-  
-    foo : a -> b -> c -> d -> e -> f -> g -> h -> i -> j -> Nat
-    x   : [Nat]
-
-.> edit foo x
-
-  ☝️
-  
-  I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
-  
-    foo : a -> b -> c -> d -> e -> f -> g -> h -> i -> j -> Nat
-    foo a b c d e f g h i j = 42
-    
-    x : [Nat]
-    x =
-      use Nat +
-      [ 1
-          + 1
-          + 1
-          + 1
-          + 1
-          + 1
-          + 1
-          + 1
-          + 1
-          + 1
-          + 1
-          + 1
-          + 1
-          + 1
-          + 1
-          + 1
-          + 1
-          + 1
-          + 1,
-        foo
-          12939233
-          2102020
-          329292
-          429292
-          522020
-          62929292
-          72020202
-          820202
-          920202
-          1020202 ]
-  
-  You can edit them there, then do `update` to replace the
-  definitions currently in this namespace.
-
-.> undo
-
-  Here are the changes I undid
-  
-  Added definitions:
-  
-    1. foo : a
-           -> b
-           -> c
-           -> d
-           -> e
-           -> f
-           -> g
-           -> h
-           -> i
-           -> j
-           -> Nat
-    2. x   : [Nat]
-
-```
-```ucm
-.> load scratch.u
-
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-  
-    ⍟ These new definitions are ok to `add`:
-    
-      foo : a
-            -> b
-            -> c
-            -> d
-            -> e
-            -> f
-            -> g
-            -> h
-            -> i
-            -> j
-            -> Nat
-      x   : [Nat]
-
-```
-## Delayed computations passed to a function as the last argument
-
-When a delayed computation block is passed to a function as the last argument
-in a context where the ambient precedence is low enough, we can elide parentheses
-around it and use a "soft hang" to put the `'let` on the same line as the function call.
-This looks nice.
-
-    forkAt usEast do
-      x = thing1
-      y = thing2
-      ...
-
-vs the not as pretty but still correct:
-
-    forkAt
-      usEast
-      (do
-          x = thing1
-          y = thing2
-          ...)
-
-Okay, here's the test, showing that we use the prettier version when possible:
-
-```unison
-(+) a b = ##Nat.+ a b
-
-foo a b = 42
-
-bar0 x = do
-  a = 1
-  b = 2
-  foo a 'let
-    c = 3
-    a + b
-
-bar1 x = do
-  a = 1
-  b = 2
-  foo (100 + 200 + 300 + 400 + 500 + 600 + 700 + 800 + 900 + 1000 + 1100 + 1200 + 1300 + 1400 + 1500) 'let
-    c = 3
-    a + b
-
-bar2 x = do
-  a = 1
-  b = 2
-  1 + foo a do
-    c = 3
-    a + b
-
-bar3 x = do
-  a = 1
-  b = 2
-  c = foo do
-    c = 3
-    a + b
-  c
-```
-
-```ucm
-.> add
-
-  ⍟ I've added these definitions:
-  
-    +    : Nat -> Nat -> Nat
-    bar0 : x -> () -> Nat
-    bar1 : x -> () -> Nat
-    bar2 : x -> () -> Nat
-    bar3 : x -> () -> b -> Nat
-    foo  : a -> b -> Nat
-
-.> edit foo bar0 bar1 bar2 bar3
-
-  ☝️
-  
-  I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
-  
-    bar0 : x -> () -> Nat
-    bar0 x = do
-      a = 1
-      b = 2
-      foo a do
-        c = 3
-        a + b
-    
-    bar1 : x -> () -> Nat
-    bar1 x =
-      do
-        a = 1
-        b = 2
-        foo
-          (100
-            + 200
-            + 300
-            + 400
-            + 500
-            + 600
-            + 700
-            + 800
-            + 900
-            + 1000
-            + 1100
-            + 1200
-            + 1300
-            + 1400
-            + 1500)
-          do
-            c = 3
-            a + b
-    
-    bar2 : x -> () -> Nat
-    bar2 x = do
-      a = 1
-      b = 2
-      1 + (foo a do
-        c = 3
-        a + b)
-    
-    bar3 : x -> () -> b -> Nat
-    bar3 x = do
-      a = 1
-      b = 2
-      c =
-        foo do
-          c = 3
-          a + b
-      c
-    
-    foo : a -> b -> Nat
-    foo a b = 42
-  
-  You can edit them there, then do `update` to replace the
-  definitions currently in this namespace.
-
-.> undo
-
-  Here are the changes I undid
-  
-  Added definitions:
-  
-    1. +    : Nat -> Nat -> Nat
-    2. bar0 : x -> () -> Nat
-    3. bar1 : x -> () -> Nat
-    4. bar2 : x -> () -> Nat
-    5. bar3 : x -> () -> b -> Nat
-    6. foo  : a -> b -> Nat
-
-```
-```ucm
-.> load scratch.u
-
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-  
-    ⍟ These new definitions are ok to `add`:
-    
-      bar0 : x -> 'Nat
-      bar1 : x -> 'Nat
-      bar2 : x -> 'Nat
-      bar3 : x -> '(b -> Nat)
-      foo  : a -> b -> Nat
-
-```
-# Lambda as the last argument where the bound var is not free in the body
-
-If a lambda's argument is not free in the body, the term printer counts this as
-a "delay" instead of a lambda. This test makes sure that detecting this
-condition lines up with the printing, so we don't detect a delay but then
-go ahead and print it as a normal lambda.
-
-```unison
-(+) a b = ##Nat.+ a b
-
-afun x f = f x
-
-roundtripLastLam =
-  afun "foo" (n -> let
-    _ = 1 + 1
-    3
-  )
-```
-
-```ucm
-.> add
-
-  ⍟ I've added these definitions:
-  
-    +                : Nat -> Nat -> Nat
-    afun             : x -> (x ->{g} t) ->{g} t
-    roundtripLastLam : Nat
-
-.> edit roundtripLastLam afun
-
-  ☝️
-  
-  I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
-  
-    afun : x -> (x ->{g} t) ->{g} t
-    afun x f = f x
-    
-    roundtripLastLam : Nat
-    roundtripLastLam =
-      afun "foo" do
-        _ = 1 + 1
-        3
-  
-  You can edit them there, then do `update` to replace the
-  definitions currently in this namespace.
-
-.> undo
-
-  Here are the changes I undid
-  
-  Added definitions:
-  
-    1. +                : Nat -> Nat -> Nat
-    2. afun             : x -> (x ->{g} t) ->{g} t
-    3. roundtripLastLam : Nat
-
-```
-```ucm
-.> load scratch.u
-
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-  
-    ⍟ These new definitions are ok to `add`:
-    
-      afun             : x -> (x ->{g} t) ->{g} t
-      roundtripLastLam : Nat
-
-```
-# Comment out builtins in the edit command
-
-Regression test for https://github.com/unisonweb/unison/pull/3548
-
-```ucm
-.> alias.term ##Nat.+ plus
-
-  Done.
-
-.> edit plus
-
-  ☝️
-  
-  I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
-  
-    -- builtin plus : builtin.Nat -> builtin.Nat -> builtin.Nat
-  
-  You can edit them there, then do `update` to replace the
-  definitions currently in this namespace.
-
-.> undo
-
-  Here are the changes I undid
-  
-  Name changes:
-  
-    Original            Changes
-    1. builtin.Nat.+    2. plus (added)
-
-```
-```ucm
-.> load scratch.u
-
-  I loaded scratch.u and didn't find anything.
-
-```
-# Indent long pattern lists to avoid virtual semicolon
-
-Regression test for https://github.com/unisonweb/unison/issues/3627
-
-```unison
-(+) a b = ##Nat.+ a b
-
-foo = cases
-  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
-   bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-    -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-```
-
-```ucm
-.> add
-
-  ⍟ I've added these definitions:
-  
-    +   : Nat -> Nat -> Nat
-    foo : Nat -> Nat -> Nat
-
-.> edit foo
-
-  ☝️
-  
-  I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
-  
-    foo : Nat -> Nat -> Nat
-    foo = cases
-      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
-        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ->
-        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-          + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-  
-  You can edit them there, then do `update` to replace the
-  definitions currently in this namespace.
-
-.> undo
-
-  Here are the changes I undid
-  
-  Added definitions:
-  
-    1. +   : Nat -> Nat -> Nat
-    2. foo : Nat -> Nat -> Nat
-
-```
-```ucm
-.> load scratch.u
-
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-  
-    ⍟ These new definitions are ok to `add`:
-    
-      foo : Nat -> Nat -> Nat
-
-```
-# Multi-line lambda let
-
-Regression test for #3110 and #3801
-
-```unison
-foreach x f = 
-  _ = List.map f x
-  ()
-
-ignore x = ()
-
-test1 : ()
-test1 =
-  foreach [1, 2, 3] let x -> let
-      y = Nat.increment x
-      ()
-
-test2 = foreach [1, 2, 3] let x -> ignore (Nat.increment x) 
-
-test3 = foreach [1, 2, 3] do x -> do
-  y = Nat.increment x
-  ()
-```
-
-```ucm
-.> add
-
-  ⍟ I've added these definitions:
-  
-    foreach : [a] -> (a ->{e} t) ->{e} ()
-    ignore  : x -> ()
-    test1   : ()
-    test2   : ()
-    test3   : ()
-
-.> edit test1 test2 test3 foreach ignore
-
-  ☝️
-  
-  I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
-  
-    foreach : [a] -> (a ->{e} t) ->{e} ()
-    foreach x f =
-      _ = List.map f x
-      ()
-    
-    ignore : x -> ()
-    ignore x = ()
-    
-    test1 : ()
-    test1 =
-      foreach
-        [1, 2, 3] (x -> let
-          y = Nat.increment x
-          ())
-    
-    test2 : ()
-    test2 = foreach [1, 2, 3] (x -> ignore (Nat.increment x))
-    
-    test3 : ()
-    test3 =
-      foreach
-        [1, 2, 3] '(x -> do
-            y = Nat.increment x
-            ())
-  
-  You can edit them there, then do `update` to replace the
-  definitions currently in this namespace.
-
-.> undo
-
-  Here are the changes I undid
-  
-  Added definitions:
-  
-    1. foreach : [a] -> (a ->{e} t) ->{e} ()
-    2. ignore  : x -> ()
-    3. test1   : ()
-    4. test2   : ()
-    5. test3   : ()
-
-```
-```ucm
-.> load scratch.u
-
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-  
-    ⍟ These new definitions are ok to `add`:
-    
-      foreach : [a] -> (a ->{e} t) ->{e} ()
-      ignore  : x -> ()
-      test1   : ()
-      test2   : ()
-      test3   : ()
-
-```
-# Destructuring bind in delay or lambda
-
-Regression test for https://github.com/unisonweb/unison/issues/3710
-
-```unison
-d1 = do
-  (a,b) = (1,2)
-  (c,d) = (3,4)
-  (e,f) = (5,6)
-  (a,b,c,d,e,f)
-
-d2 = let
-  (a,b) = (1,2)
-  (c,d) = (3,4)
-  (e,f) = (5,6)
-  (a,b,c,d,e,f)
-
-d3 x = let
-  (a,b) = (1,x)
-  (c,d) = (3,4)
-  (e,f) = (5,6)
-  (a,b,c,d,e,f)
-
-d4 x = do
-  (a,b) = (1,x)
-  (c,d) = (3,4)
-  (e,f) = (5,6)
-  (a,b,c,d,e,f)
-
-d5 x = match x with
-  Some x -> x
-  None -> bug "oops"
-```
-
-```ucm
-.> add
-
-  ⍟ I've added these definitions:
-  
-    d1 : '(Nat, Nat, Nat, Nat, Nat, Nat)
-    d2 : (Nat, Nat, Nat, Nat, Nat, Nat)
-    d3 : x -> (Nat, x, Nat, Nat, Nat, Nat)
-    d4 : x -> () -> (Nat, x, Nat, Nat, Nat, Nat)
-    d5 : Optional a -> a
-
-.> edit d1 d2 d3 d4 d5
-
-  ☝️
-  
-  I added these definitions to the top of
-  /Users/runar/work/unison/scratch.u
-  
-    d1 : '(Nat, Nat, Nat, Nat, Nat, Nat)
-    d1 = do
-      (a, b) = (1, 2)
-      (c, d) = (3, 4)
-      (e, f) = (5, 6)
-      (a, b, c, d, e, f)
-    
-    d2 : (Nat, Nat, Nat, Nat, Nat, Nat)
-    d2 =
-      (a, b) = (1, 2)
-      (c, d) = (3, 4)
-      (e, f) = (5, 6)
-      (a, b, c, d, e, f)
-    
-    d3 : x -> (Nat, x, Nat, Nat, Nat, Nat)
-    d3 x =
-      (a, b) = (1, x)
-      (c, d) = (3, 4)
-      (e, f) = (5, 6)
-      (a, b, c, d, e, f)
-    
-    d4 : x -> () -> (Nat, x, Nat, Nat, Nat, Nat)
-    d4 x = do
-      (a, b) = (1, x)
-      (c, d) = (3, 4)
-      (e, f) = (5, 6)
-      (a, b, c, d, e, f)
-    
-    d5 : Optional a -> a
-    d5 = cases
-      Some x -> x
-      None   -> bug "oops"
-  
-  You can edit them there, then do `update` to replace the
-  definitions currently in this namespace.
-
-.> undo
-
-  Here are the changes I undid
-  
-  Added definitions:
-  
-    1. d1 : '(Nat, Nat, Nat, Nat, Nat, Nat)
-    2. d2 : (Nat, Nat, Nat, Nat, Nat, Nat)
-    3. d3 : x -> (Nat, x, Nat, Nat, Nat, Nat)
-    4. d4 : x -> () -> (Nat, x, Nat, Nat, Nat, Nat)
-    5. d5 : Optional a -> a
-
-```
-```ucm
-.> load scratch.u
-
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-  
-    ⍟ These new definitions are ok to `add`:
-    
-      d1 : '(Nat, Nat, Nat, Nat, Nat, Nat)
-      d2 : (Nat, Nat, Nat, Nat, Nat, Nat)
-      d3 : x -> (Nat, x, Nat, Nat, Nat, Nat)
-      d4 : x -> '(Nat, x, Nat, Nat, Nat, Nat)
-      d5 : Optional a -> a
-
-```

--- a/unison-src/transcripts-round-trip/nested.u
+++ b/unison-src/transcripts-round-trip/nested.u
@@ -1,3 +1,13 @@
+nested : Doc2
+nested =
+  {{ ```` raw
+  ```unison
+  r = "boopydoo"
+  ```
+  ```` }}
+
+---- Anything below this line is ignored by Unison.
+
 nested = {{
 
 ````raw

--- a/unison-src/transcripts/docs.output.md
+++ b/unison-src/transcripts/docs.output.md
@@ -11,7 +11,7 @@ Unison documentation is written in Unison. Documentation is a value of the follo
     | Source Link
     | Signature Term
     | Evaluate Term
-    | Join [builtin.Doc]
+    | Join [Doc]
 
 ```
 You can create these `Doc` values with ordinary code, or you can use the special syntax. A value of structural type `Doc` can be created via syntax like:
@@ -147,14 +147,14 @@ Now that documentation is linked to the definition. We can view it if we like:
   
   ## Examples:
   
-    List.take.ex1 : [Nat]
-  List.take.ex1 = builtin.List.take 0 [1, 2, 3, 4, 5]
+    ex1 : [Nat]
+  ex1 = builtin.List.take 0 [1, 2, 3, 4, 5]
     🔽
     ex1 = []
   
   
-    List.take.ex2 : [Nat]
-  List.take.ex2 = builtin.List.take 2 [1, 2, 3, 4, 5]
+    ex2 : [Nat]
+  ex2 = builtin.List.take 2 [1, 2, 3, 4, 5]
     🔽
     ex2 = [1, 2]
   
@@ -172,14 +172,14 @@ Or there's also a convenient function, `docs`, which shows the `Doc` values that
   
   ## Examples:
   
-    List.take.ex1 : [Nat]
-  List.take.ex1 = builtin.List.take 0 [1, 2, 3, 4, 5]
+    ex1 : [Nat]
+  ex1 = builtin.List.take 0 [1, 2, 3, 4, 5]
     🔽
     ex1 = []
   
   
-    List.take.ex2 : [Nat]
-  List.take.ex2 = builtin.List.take 2 [1, 2, 3, 4, 5]
+    ex2 : [Nat]
+  ex2 = builtin.List.take 2 [1, 2, 3, 4, 5]
     🔽
     ex2 = [1, 2]
   

--- a/unison-src/transcripts/fix2567.output.md
+++ b/unison-src/transcripts/fix2567.output.md
@@ -22,15 +22,15 @@ structural ability Foo where
 .> view Foo
 
   structural ability some.subnamespace.Foo where
-    blah : Nat ->{some.subnamespace.Foo} Nat
-    woot : Nat -> (Nat, Nat) ->{some.subnamespace.Foo} Nat
+    blah : Nat ->{Foo} Nat
+    woot : Nat -> (Nat, Nat) ->{Foo} Nat
 
   ☝️  The namespace .somewhere is empty.
 
 .somewhere> view .some.subnamespace.Foo
 
   structural ability .some.subnamespace.Foo where
-    blah : Nat ->{.some.subnamespace.Foo} Nat
-    woot : Nat -> (Nat, Nat) ->{.some.subnamespace.Foo} Nat
+    blah : Nat ->{Foo} Nat
+    woot : Nat -> (Nat, Nat) ->{Foo} Nat
 
 ```

--- a/unison-src/transcripts/in-file-name-resolution.md
+++ b/unison-src/transcripts/in-file-name-resolution.md
@@ -1,0 +1,33 @@
+Unison should resolve types and terms by suffix even if it's a cyclic reference within the same file.
+
+```unison
+structural type deeply.nested.Tree a = 
+  Leaf a
+  | Node (Tree a) (Tree a)
+
+foo.bar x = bar 1
+```
+
+Unison should *not* resolve names to definitions in the codebase if there's a matching name within the file.
+Even if it's ambiguous, the definition in the file should take precedence.
+
+```ucm
+.> add
+```
+
+```unison
+-- We alter the `Tree` type, all of the 'Tree' references should refer to the Tree in the file, not the one in the codebase.
+structural type deeply.nested.Tree a = 
+  Leaf a
+  | Node (Tree a) a (Tree a)
+
+
+-- We alter the foo.bar term. `bar` should refer to the 'foo.bar' within the file.
+foo.bar x = bar 2
+```
+
+```ucm
+.> update
+-- Shouldn't see any hashes here
+.> view deeply.nested.Tree foo.bar
+```

--- a/unison-src/transcripts/in-file-name-resolution.output.md
+++ b/unison-src/transcripts/in-file-name-resolution.output.md
@@ -1,0 +1,47 @@
+Unison should resolve types and terms by suffix even if it's a cyclic reference within the same file.
+
+```unison
+structural type deeply.nested.Tree a = 
+  Leaf a
+  | Node (Tree a) (Tree a)
+
+foo.bar x = bar 1
+```
+
+```ucm
+
+  
+    ❓
+    
+    I couldn't resolve any of these symbols:
+    
+        3 |   | Node (Tree a) (Tree a)
+    
+    
+    Symbol   Suggestions
+             
+    Tree     No matches
+  
+
+```
+
+
+
+🛑
+
+The transcript failed due to an error in the stanza above. The error is:
+
+
+  
+    ❓
+    
+    I couldn't resolve any of these symbols:
+    
+        3 |   | Node (Tree a) (Tree a)
+    
+    
+    Symbol   Suggestions
+             
+    Tree     No matches
+  
+

--- a/unison-src/transcripts/suffixes.output.md
+++ b/unison-src/transcripts/suffixes.output.md
@@ -38,7 +38,7 @@ The `view` and `display` commands also benefit from this:
 ```ucm
 .> view List.drop
 
-  builtin builtin.List.drop : builtin.Nat -> [a] -> [a]
+  builtin builtin.List.drop : Nat -> [a] -> [a]
 
 .> display bar.a
 

--- a/unison-src/transcripts/top-level-exceptions.output.md
+++ b/unison-src/transcripts/top-level-exceptions.output.md
@@ -7,7 +7,7 @@ FYI, here are the `Exception` and `Failure` types:
 .> view Exception Failure
 
   structural ability builtin.Exception where
-    raise : Failure ->{builtin.Exception} x
+    raise : Failure ->{Exception} x
   
   unique type builtin.io2.Failure
     = Failure Type Text Any


### PR DESCRIPTION
Weirdly UCM will resolve-by-suffix for terms within the scratchfile, but not types or abilities, e.g.:

```unison
-- This works
deeply.nested.term x = term x

-- This doesn't
structural type deeply.nested.Tree a
  = Leaf
  | Node (Tree a) a (Tree a)
```

2. Because of this, it's very easy to accidentally break a cycle and refer to the old codebase version of a type if you don't fully qualify the name.

E.g. if you write this:

```unison
structural type deeply.nested.Tree a
  = Leaf
  | Node (deeply.nested.Tree a) a (deeply.nested.Tree a)
```

Then add it, then edit it and add a new constructor, but don't fully qualify it:

```unison
structural type deeply.nested.Tree a
  = Leaf
  | Node (deeply.nested.Tree a) a (deeply.nested.Tree a)
  | Three a (Tree a) (Tree a) (Tree a)
```

Now the Three constructor will refer to the old Tree in the codebase, but Node refers to the one in the file.

UCM doesn't warn you about this and will happily update, even though one of the references will immediately become nameless. If you edit again you see the error of your ways:

```unison
structural type deeply.nested.Tree a
  = Three a (#ikos4v8hvk a) (#ikos4v8hvk a) (#ikos4v8hvk a)
  | Leaf
  | Node (deeply.nested.Tree a) a (deeply.nested.Tree a)
```

## TODO:

* I added a transcript detailing the issue, which should be fixed before merging. Specifically, Unison must be able to refer to types within the file by a suffix of their name, since removing the Utils.hs special case will cause abilities within cycles to be printed fully-suffixified in some cases.
* Once that issue is fixed, we should be able to remove the `PrettyPrintEnv.Utils` module and the special-cases it includes, then fix up any call-sites which were using it.