### PR TITLE
When pushing to share, print a link to view it on share

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
@@ -260,11 +260,11 @@ pushLooseCodeToShareLooseCode localPath remote@WriteShareRemoteNamespace {server
             Share.TransportError err -> ShareErrorTransport err
       maybeNumUploaded <- checkAndSetPush (Share.API.hashJWTHash <$> maybeHashJwt)
       whenJust maybeNumUploaded (Cli.respond . Output.UploadedEntities)
-      Cli.respond (ViewOnShare remote)
+      Cli.respond (ViewOnShare (Left remote))
     PushBehavior.RequireEmpty -> do
       maybeNumUploaded <- checkAndSetPush Nothing
       whenJust maybeNumUploaded (Cli.respond . Output.UploadedEntities)
-      Cli.respond (ViewOnShare remote)
+      Cli.respond (ViewOnShare (Left remote))
     PushBehavior.RequireNonEmpty -> do
       let push :: Cli (Either (Share.SyncError Share.FastForwardPushError) (), Int)
           push =
@@ -281,7 +281,7 @@ pushLooseCodeToShareLooseCode localPath remote@WriteShareRemoteNamespace {server
         (Left err, _) -> pushError ShareErrorFastForwardPush err
         (Right (), numUploaded) -> do
           Cli.respond (UploadedEntities numUploaded)
-          Cli.respond (ViewOnShare remote)
+          Cli.respond (ViewOnShare (Left remote))
   where
     pathToSegments :: Path -> [Text]
     pathToSegments =

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
@@ -597,6 +597,8 @@ executeUploadPlan UploadPlan {remoteBranch, causalHash, afterUploadAction} = do
       liftIO getNumUploaded
   Cli.respond (Output.UploadedEntities numUploaded)
   afterUploadAction
+  let ProjectAndBranch projectName branchName = remoteBranch
+  Cli.respond (ViewOnShare (Right (Share.hardCodedUri, projectName, branchName)))
 
 ------------------------------------------------------------------------------------------------------------------------
 -- After upload actions

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -240,7 +240,7 @@ data Output
     BustedBuiltins (Set Reference) (Set Reference)
   | GitError GitError
   | ShareError ShareError
-  | ViewOnShare WriteShareRemoteNamespace
+  | ViewOnShare (Either WriteShareRemoteNamespace (URI, ProjectName, ProjectBranchName))
   | ConfiguredMetadataParseError Path' String (P.Pretty P.ColorText)
   | NoConfiguredRemoteMapping PushPull Path.Absolute
   | ConfiguredRemoteMappingParseError PushPull Path.Absolute Text String

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2788,7 +2788,7 @@ renderEditConflicts ppe Patch {..} = do
                  then "deprecated and also replaced with"
                  else "replaced with"
              )
-          `P.hang` P.lines replacements
+            `P.hang` P.lines replacements
     formatTermEdits ::
       (Reference.TermReference, Set TermEdit.TermEdit) ->
       Numbered Pretty
@@ -2803,7 +2803,7 @@ renderEditConflicts ppe Patch {..} = do
                  then "deprecated and also replaced with"
                  else "replaced with"
              )
-          `P.hang` P.lines replacements
+            `P.hang` P.lines replacements
     formatConflict ::
       Either
         (Reference, Set TypeEdit.TypeEdit)

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -442,21 +442,6 @@ notifyNumbered = \case
         ),
       map (\(branchName, _) -> Text.unpack (into @Text (ProjectAndBranch projectName branchName))) branches
     )
-    where
-      prettyRemoteBranchInfo :: (URI, ProjectName, ProjectBranchName) -> Pretty
-      prettyRemoteBranchInfo (host, remoteProject, remoteBranch) =
-        -- Special-case Unison Share since we know its project branch URLs
-        if URI.uriToString id host "" == "https://api.unison-lang.org"
-          then
-            P.hiBlack . P.text $
-              "https://share.unison-lang.org/"
-                <> into @Text remoteProject
-                <> "/code/"
-                <> into @Text remoteBranch
-          else
-            prettyProjectAndBranchName (ProjectAndBranch remoteProject remoteBranch)
-              <> " on "
-              <> P.hiBlack (P.shown host)
   BothLocalProjectAndProjectBranchExist project (ProjectAndBranch currentProject branch) ->
     ( P.wrap
         ( "I'm not sure if you wanted to switch to the branch"
@@ -1810,9 +1795,11 @@ notifyUser dir = \case
         ]
   PrintVersion ucmVersion -> pure (P.text ucmVersion)
   ShareError shareError -> pure (prettyShareError shareError)
-  ViewOnShare repoPath ->
+  ViewOnShare shareRef ->
     pure $
-      "View it on Unison Share: " <> prettyShareLink repoPath
+      "View it on Unison Share: " <> case shareRef of
+        Left repoPath -> prettyShareLink repoPath
+        Right branchInfo -> prettyRemoteBranchInfo branchInfo
   IntegrityCheck result -> pure $ case result of
     NoIntegrityErrors -> "🎉 No issues detected 🎉"
     IntegrityErrorDetected ns -> prettyPrintIntegrityErrors ns
@@ -2801,7 +2788,7 @@ renderEditConflicts ppe Patch {..} = do
                  then "deprecated and also replaced with"
                  else "replaced with"
              )
-            `P.hang` P.lines replacements
+          `P.hang` P.lines replacements
     formatTermEdits ::
       (Reference.TermReference, Set TermEdit.TermEdit) ->
       Numbered Pretty
@@ -2816,7 +2803,7 @@ renderEditConflicts ppe Patch {..} = do
                  then "deprecated and also replaced with"
                  else "replaced with"
              )
-            `P.hang` P.lines replacements
+          `P.hang` P.lines replacements
     formatConflict ::
       Either
         (Reference, Set TypeEdit.TypeEdit)
@@ -3738,3 +3725,18 @@ prettyHumanReadableTime now time =
 
     dir True = " from now"
     dir False = " ago"
+
+prettyRemoteBranchInfo :: (URI, ProjectName, ProjectBranchName) -> Pretty
+prettyRemoteBranchInfo (host, remoteProject, remoteBranch) =
+  -- Special-case Unison Share since we know its project branch URLs
+  if URI.uriToString id host "" == "https://api.unison-lang.org"
+    then
+      P.hiBlack . P.text $
+        "https://share.unison-lang.org/"
+          <> into @Text remoteProject
+          <> "/code/"
+          <> into @Text remoteBranch
+    else
+      prettyProjectAndBranchName (ProjectAndBranch remoteProject remoteBranch)
+        <> " on "
+        <> P.hiBlack (P.shown host)


### PR DESCRIPTION
## Overview

When pushing to share, print a link to view it on share.
![push](https://github.com/unisonweb/unison/assets/1627482/cb55888b-46d6-41ce-b884-9b48730f33a9)


## Implementation notes

Expand the `ViewOnShare` output message to accept project and branch info.

## Interesting/controversial decisions

none

## Test coverage

I only tested manually.

## Loose ends

none
