### PR TITLE
Remove project uuids from prompt and empty namespace output

### DIFF
--- a/unison-cli/src/Unison/Cli/ProjectUtils.hs
+++ b/unison-cli/src/Unison/Cli/ProjectUtils.hs
@@ -65,12 +65,7 @@ expectCurrentProject :: Cli Sqlite.Project
 expectCurrentProject = do
   getCurrentProject & onNothingM (Cli.returnEarly Output.NotOnProjectBranch)
 
--- | Get the current project+branch that a user is on.
---
--- Note that if a user has (somehow) cd'd into a namespace *within* a branch, this function will return Nothing; that
--- is, it only returns Just if the user's current namespace is the root of a branch, and no deeper.
---
--- This should be fine: we don't want users to be able to cd around willy-nilly within projects (right?...)
+-- | Get the current project+branch+branch path that a user is on.
 getCurrentProjectBranch :: Cli (Maybe (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch, Path.Path))
 getCurrentProjectBranch = do
   path <- Cli.getCurrentPath
@@ -283,13 +278,13 @@ projectPathPrism =
 -- | The prism between paths like
 --
 -- @
--- .__projects._XX_XX.branches._YY_YY
+-- .__projects._XX_XX.branches._YY_YY.foo.bar
 -- @
 --
--- and the @(project id, branch id)@ pair
+-- and the @(project id, branch id, path)@ triple
 --
 -- @
--- (XX-XX, YY-YY)
+-- (XX-XX, YY-YY, foo.bar)
 -- @
 projectBranchPathPrism :: Prism' Path.Absolute (ProjectAndBranch ProjectId ProjectBranchId, Path.Path)
 projectBranchPathPrism =

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Branch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Branch.hs
@@ -55,7 +55,7 @@ handleBranch sourceI projectAndBranchNames0 = do
       Input.BranchSourceI'CurrentContext ->
         ProjectUtils.getCurrentProjectBranch >>= \case
           Nothing -> CreateFrom'LooseCode <$> Cli.getCurrentPath
-          Just currentBranch -> pure (CreateFrom'Branch currentBranch)
+          Just (currentBranch, _restPath) -> pure (CreateFrom'Branch currentBranch)
       Input.BranchSourceI'Empty -> pure CreateFrom'Nothingness
       Input.BranchSourceI'LooseCodeOrProject (This sourcePath) -> do
         currentPath <- Cli.getCurrentPath

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/DeleteBranch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/DeleteBranch.hs
@@ -59,7 +59,7 @@ handleDeleteBranch projectAndBranchNames0 = do
   --   1. cd to parent branch, if it exists
   --   2. cd to "main", if it exists
   --   3. cd to loose code path `.`
-  whenJust maybeCurrentBranch \(ProjectAndBranch _currentProject currentBranch) ->
+  whenJust maybeCurrentBranch \(ProjectAndBranch _currentProject currentBranch, _restPath) ->
     when (deletedBranch == currentBranch) do
       newPath <-
         case deletedBranch ^. #parentBranchId of

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectClone.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectClone.hs
@@ -43,7 +43,7 @@ branchClone remoteBranchName = do
   -- TODO: allow user to override this with second argument
   let localBranchName = remoteBranchName
 
-  ProjectAndBranch currentProject currentBranch <- ProjectUtils.expectCurrentProjectBranch
+  (ProjectAndBranch currentProject currentBranch, _restPath) <- ProjectUtils.expectCurrentProjectBranch
   let localProjectBranch = ProjectAndBranch (currentProject ^. #name) localBranchName
 
   -- The current branch or one of its ancestors may be associated with a remote project already. If that's true,

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectSwitch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectSwitch.hs
@@ -28,7 +28,7 @@ projectSwitch = \case
   ProjectAndBranchNames'Ambiguous projectName branchName ->
     ProjectUtils.getCurrentProjectBranch >>= \case
       Nothing -> switchToProjectAndBranchByTheseNames (This projectName)
-      Just (ProjectAndBranch currentProject _currentBranch) -> do
+      Just (ProjectAndBranch currentProject _currentBranch, _restPath) -> do
         let currentProjectName = currentProject ^. #name
         (projectExists, branchExists) <-
           Cli.runTransaction do

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Pull.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Pull.hs
@@ -119,7 +119,7 @@ resolveImplicitSource :: Cli (ReadRemoteNamespace Share.RemoteProjectBranch)
 resolveImplicitSource =
   ProjectUtils.getCurrentProjectBranch >>= \case
     Nothing -> RemoteRepo.writeNamespaceToRead <$> resolveConfiguredUrl PushPull.Pull Path.currentPath
-    Just (ProjectAndBranch localProject localBranch) -> do
+    Just (ProjectAndBranch localProject localBranch, _restPath) -> do
       (remoteProjectId, remoteProjectName, remoteBranchId, remoteBranchName) <-
         Cli.runEitherTransaction do
           let localProjectId = localProject ^. #projectId
@@ -159,7 +159,7 @@ resolveImplicitTarget :: Cli (PullTarget (ProjectAndBranch Sqlite.Project Sqlite
 resolveImplicitTarget =
   ProjectUtils.getCurrentProjectBranch <&> \case
     Nothing -> PullTargetLooseCode Path.currentPath
-    Just projectAndBranch -> PullTargetProject projectAndBranch
+    Just (projectAndBranch, _restPath) -> PullTargetProject projectAndBranch
 
 resolveExplicitTarget ::
   PullTarget (These ProjectName ProjectBranchName) ->

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
@@ -121,7 +121,7 @@ handlePushRemoteBranch PushRemoteBranchInput {sourceTarget, pushBehavior, syncMo
             WriteRemoteNamespaceGit namespace -> pushLooseCodeToGitLooseCode localPath namespace pushBehavior syncMode
             WriteRemoteNamespaceShare namespace -> pushLooseCodeToShareLooseCode localPath namespace pushBehavior
             WriteRemoteProjectBranch v -> absurd v
-        Just localProjectAndBranch -> pushProjectBranchToProjectBranch localProjectAndBranch Nothing
+        Just (localProjectAndBranch, _restPath) -> pushProjectBranchToProjectBranch localProjectAndBranch Nothing
     -- push <implicit> to .some.path (git)
     PushSourceTarget1 (WriteRemoteNamespaceGit namespace) -> do
       localPath <- Cli.getCurrentPath
@@ -137,7 +137,7 @@ handlePushRemoteBranch PushRemoteBranchInput {sourceTarget, pushBehavior, syncMo
           localPath <- Cli.getCurrentPath
           remoteProjectAndBranch <- ProjectUtils.hydrateNames remoteProjectAndBranch0
           pushLooseCodeToProjectBranch localPath remoteProjectAndBranch
-        Just localProjectAndBranch ->
+        Just (localProjectAndBranch, _restPath) ->
           pushProjectBranchToProjectBranch localProjectAndBranch (Just remoteProjectAndBranch0)
     -- push .some.path to .some.path (git)
     PushSourceTarget2 (PathySource localPath0) (WriteRemoteNamespaceGit namespace) -> do

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ReleaseDraft.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ReleaseDraft.hs
@@ -17,7 +17,7 @@ import Witch (unsafeFrom)
 -- | Handle a @release.draft@ command.
 handleReleaseDraft :: Semver -> Cli ()
 handleReleaseDraft ver = do
-  currentProjectAndBranch <- ProjectUtils.expectCurrentProjectBranch
+  currentProjectAndBranch <- fst <$> ProjectUtils.expectCurrentProjectBranch
 
   let branchName = unsafeFrom @Text ("releases/drafts/" <> into @Text ver)
 

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2716,7 +2716,7 @@ projectAndBranchNamesArg =
   ArgumentType
     { typeName = "project-and-branch-names",
       suggestions = \input codebase _httpClient path -> do
-        let currentBranch = preview ProjectUtils.projectBranchPathPrism path
+        let currentBranch = fst <$> preview ProjectUtils.projectBranchPathPrism path
         (branches, projects) <-
           Codebase.runTransaction
             codebase

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -83,7 +83,7 @@ getUserInput codebase authHTTPClient getRoot currentPath numberedArgs =
       promptString <-
         case preview projectBranchPathPrism currentPath of
           Nothing -> pure ((P.green . P.shown) currentPath)
-          Just (ProjectAndBranch projectId branchId) -> do
+          Just (ProjectAndBranch projectId branchId, _restPath) -> do
             lift (Codebase.runTransaction codebase (Queries.loadProjectAndBranchNames projectId branchId)) <&> \case
               -- If the project branch has been deleted from sqlite, just show a borked prompt
               Nothing -> P.red "???"

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -83,12 +83,23 @@ getUserInput codebase authHTTPClient getRoot currentPath numberedArgs =
       promptString <-
         case preview projectBranchPathPrism currentPath of
           Nothing -> pure ((P.green . P.shown) currentPath)
-          Just (ProjectAndBranch projectId branchId, _restPath) -> do
+          Just (ProjectAndBranch projectId branchId, restPath) -> do
             lift (Codebase.runTransaction codebase (Queries.loadProjectAndBranchNames projectId branchId)) <&> \case
               -- If the project branch has been deleted from sqlite, just show a borked prompt
               Nothing -> P.red "???"
               Just (projectName, branchName) ->
-                OutputMessages.prettyProjectAndBranchName (ProjectAndBranch projectName branchName)
+                P.sep
+                  " "
+                  ( catMaybes
+                      [ Just
+                          ( OutputMessages.prettyProjectAndBranchName
+                              (ProjectAndBranch projectName branchName)
+                          ),
+                        case restPath of
+                          Path.Empty -> Nothing
+                          _ -> (Just . P.green . P.shown) restPath
+                      ]
+                  )
       line <- Line.getInputLine (P.toANSI 80 (promptString <> fromString prompt))
       case line of
         Nothing -> pure QuitI

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -50,6 +50,7 @@ import qualified U.Util.Base32Hex as Base32Hex
 import qualified Unison.ABT as ABT
 import qualified Unison.Auth.Types as Auth
 import qualified Unison.Builtin.Decls as DD
+import Unison.Cli.ProjectUtils (projectBranchPathPrism)
 import qualified Unison.Cli.Share.Projects.Types as Share
 import Unison.Codebase.Editor.DisplayObject (DisplayObject (BuiltinObject, MissingObject, UserObject))
 import qualified Unison.Codebase.Editor.Input as Input
@@ -911,7 +912,7 @@ notifyUser dir = \case
       prettyProjectAndBranchName projectAndBranch <> "is empty. There is nothing to push."
   CreatedNewBranch path ->
     pure $
-      "☝️  The namespace " <> P.blue (P.shown path) <> " is empty."
+      "☝️  The namespace " <> prettyAbsoluteStripProject path <> " is empty."
   -- RenameOutput rootPath oldName newName r -> do
   --   nameChange "rename" "renamed" oldName newName r
   -- AliasOutput rootPath existingName newName r -> do
@@ -3740,3 +3741,12 @@ prettyRemoteBranchInfo (host, remoteProject, remoteBranch) =
       prettyProjectAndBranchName (ProjectAndBranch remoteProject remoteBranch)
         <> " on "
         <> P.hiBlack (P.shown host)
+
+stripProjectBranchInfo :: Path.Absolute -> Maybe Path.Path
+stripProjectBranchInfo = fmap snd . preview projectBranchPathPrism
+
+prettyAbsoluteStripProject :: Path.Absolute -> Pretty
+prettyAbsoluteStripProject path =
+  P.blue case stripProjectBranchInfo path of
+    Just p -> P.shown p
+    Nothing -> P.shown path


### PR DESCRIPTION
## Overview

#### Before
![before](https://github.com/unisonweb/unison/assets/1627482/b83028cf-5226-4adf-b97f-8d54d91852ab)

#### After
![after](https://github.com/unisonweb/unison/assets/1627482/25700ca1-689c-47b2-8f4d-d7de696e76d0)


## Implementation notes

`projectBranchPathPrism` and `getCurrentProjectBranch` now return the trailing path that may follow the branch path.

## Interesting/controversial decisions

none

## Test coverage

Manually tested, see screenshots.

## Loose ends

I'm sure there are many other places where we leak project and branch uuids.
