### PR TITLE
Allow for jit-only and interpreter-only tests in our builtin-tests

### DIFF
--- a/unison-src/builtin-tests/concurrency-tests.u
+++ b/unison-src/builtin-tests/concurrency-tests.u
@@ -146,3 +146,16 @@ fullTest = do
   result = Ref.read state
   checkEqual "The state of the counter is consistent " result expected
 
+concurrency.interpreter.only = Tests.main do
+  ref = IO.ref None
+  t = fork do
+    match catchAll do sleep_ (400 * millis) with
+      Left (Failure f _ _) -> unsafeRun! do Ref.write ref (Some f)
+      _ -> ()
+  sleep_ (200 * millis)
+  kill_ t
+  sleep_ (300 * millis)
+  v = Ref.read ref
+  expected = Some (typeLink ThreadKilledFailure)
+  checkEqual "Thread killed, finalisers with typeLink" v expected
+

--- a/unison-src/builtin-tests/interpreter-tests.md
+++ b/unison-src/builtin-tests/interpreter-tests.md
@@ -11,6 +11,7 @@ then reference those tests (which should be of type `'{IO,Exception,Tests} ()`, 
 to `Tests.check` and `Tests.checkEqual`).
 
 ```ucm:hide
+.> alias.type #ggh649864d ThreadKilledFailure
 .> load unison-src/builtin-tests/concurrency-tests.u
 .> add
 ```
@@ -57,17 +58,15 @@ TODO remove md5 alias when base is released
 .> add
 ```
 
-```ucm
-.> run tests
-```
-
-TODO remove once jit supports typelinks
 ```ucm:hide
-.> builtins.merge
-.> load unison-src/builtin-tests/thread-killed-typeLink-test.u
+.> load unison-src/builtin-tests/tests-interpreter-only.u
 .> add
 ```
 
 ```ucm
-.> run threadKilledTypeLinkTest
+.> run tests
+```
+
+```ucm
+.> run tests.interpreter.only
 ```

--- a/unison-src/builtin-tests/interpreter-tests.output.md
+++ b/unison-src/builtin-tests/interpreter-tests.output.md
@@ -12,9 +12,8 @@ TODO remove md5 alias when base is released
   ()
 
 ```
-TODO remove once jit supports typelinks
 ```ucm
-.> run threadKilledTypeLinkTest
+.> run tests.interpreter.only
 
   ()
 

--- a/unison-src/builtin-tests/jit-tests.md
+++ b/unison-src/builtin-tests/jit-tests.md
@@ -13,6 +13,7 @@ then reference those tests (which should be of type `'{IO,Exception,Tests} ()`, 
 to `Tests.check` and `Tests.checkEqual`).
 
 ```ucm:hide
+.> alias.type #ggh649864d ThreadKilledFailure
 .> load unison-src/builtin-tests/concurrency-tests.u
 .> add
 ```
@@ -59,6 +60,15 @@ TODO remove md5 alias when base is released
 .> add
 ```
 
+```ucm:hide
+.> load unison-src/builtin-tests/tests-jit-only.u
+.> add
+```
+
 ```ucm
 .> run.native tests
+```
+
+```ucm
+.> run.native tests.jit.only
 ```

--- a/unison-src/builtin-tests/jit-tests.output.md
+++ b/unison-src/builtin-tests/jit-tests.output.md
@@ -10,3 +10,7 @@ TODO remove md5 alias when base is released
 .> run.native tests
 
 ```
+```ucm
+.> run.native tests.jit.only
+
+```

--- a/unison-src/builtin-tests/tests-interpreter-only.u
+++ b/unison-src/builtin-tests/tests-interpreter-only.u
@@ -1,5 +1,4 @@
 tests.interpreter.only : '{IO,Exception} ()
 tests.interpreter.only = Tests.main do
-  check "example interpreter-only test" do true
   !text.interpreter.only
   !concurrency.interpreter.only

--- a/unison-src/builtin-tests/tests-interpreter-only.u
+++ b/unison-src/builtin-tests/tests-interpreter-only.u
@@ -1,0 +1,5 @@
+tests.interpreter.only : '{IO,Exception} ()
+tests.interpreter.only = Tests.main do
+  check "example interpreter-only test" do true
+  !text.interpreter.only
+  !concurrency.interpreter.only

--- a/unison-src/builtin-tests/tests-jit-only.u
+++ b/unison-src/builtin-tests/tests-jit-only.u
@@ -1,0 +1,3 @@
+tests.jit.only : '{IO,Exception} ()
+tests.jit.only = Tests.main do
+  check "example jit-only test" do true

--- a/unison-src/builtin-tests/text-tests.u
+++ b/unison-src/builtin-tests/text-tests.u
@@ -6,9 +6,10 @@ text.tests = do
  !text.conversion.tests
  !text.debug.tests
  !text.matching.tests
--- This is broken under the jit
---  !text.term.tests
  !char.class.tests
+
+text.interpreter.only = do
+ !text.term.tests
 
 text.lit.tests = do
   check "Text empty literal" do


### PR DESCRIPTION
There are some things that are only implemented on one side or the other