### PR TITLE
Add `delete.project` command

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -108,6 +108,7 @@ module U.Codebase.Sqlite.Queries
     loadAllProjects,
     loadAllProjectsBeginningWith,
     insertProject,
+    deleteProject,
 
     -- ** project branches
     projectBranchExistsByName,
@@ -3117,6 +3118,29 @@ insertProjectBranch (ProjectBranch projectId branchId branchName maybeParentBran
         INSERT INTO project_branch_parent (project_id, parent_branch_id, branch_id)
           VALUES (:projectId, :parentBranchId, :branchId)
       |]
+
+deleteProject :: ProjectId -> Transaction ()
+deleteProject projectId = do
+  execute2
+    [sql2|
+      DELETE FROM project_branch_remote_mapping
+      WHERE local_project_id = :projectId
+    |]
+  execute2
+    [sql2|
+      DELETE FROM project_branch_parent
+      WHERE project_id = :projectId
+    |]
+  execute2
+    [sql2|
+      DELETE FROM project_branch
+      WHERE project_id = :projectId
+    |]
+  execute2
+    [sql2|
+      DELETE FROM project
+      WHERE id = :projectId
+    |]
 
 -- | Delete a project branch.
 --

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -82,6 +82,7 @@ import Unison.Codebase.Editor.HandleInput.AuthLogin (authLogin)
 import Unison.Codebase.Editor.HandleInput.Branch (handleBranch)
 import Unison.Codebase.Editor.HandleInput.Branches (handleBranches)
 import Unison.Codebase.Editor.HandleInput.DeleteBranch (handleDeleteBranch)
+import Unison.Codebase.Editor.HandleInput.DeleteProject (handleDeleteProject)
 import Unison.Codebase.Editor.HandleInput.MetadataUtils (addDefaultMetadata, manageLinks)
 import Unison.Codebase.Editor.HandleInput.MoveBranch (doMoveBranch)
 import qualified Unison.Codebase.Editor.HandleInput.NamespaceDependencies as NamespaceDependencies
@@ -941,6 +942,7 @@ loop e = do
                     & Branch.modifyAt (Path.singleton childName) \_ -> Branch.empty
                 afterDelete
               DeleteTarget'ProjectBranch name -> handleDeleteBranch name
+              DeleteTarget'Project name -> handleDeleteProject name
             DisplayI outputLoc names' -> do
               currentBranch0 <- Cli.getCurrentBranch0
               basicPrettyPrintNames <- getBasicPrettyPrintNames
@@ -1520,6 +1522,7 @@ inputDescription input =
           path <- ps' path0
           pure ("delete.patch " <> path)
         DeleteTarget'ProjectBranch _ -> wat
+        DeleteTarget'Project _ -> wat
     ReplaceI src target p0 -> do
       p <- opatch p0
       pure $

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/DeleteProject.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/DeleteProject.hs
@@ -1,0 +1,47 @@
+-- | @delete.project@ input handler
+module Unison.Codebase.Editor.HandleInput.DeleteProject
+  ( handleDeleteProject,
+  )
+where
+
+import Control.Lens (view, (^.))
+import Data.Function (on)
+import qualified U.Codebase.Sqlite.Queries as Queries
+import Unison.Cli.Monad (Cli)
+import qualified Unison.Cli.Monad as Cli
+import qualified Unison.Cli.MonadUtils as Cli
+import qualified Unison.Cli.ProjectUtils as ProjectUtils
+import qualified Unison.Codebase.Branch as Branch
+import qualified Unison.Codebase.Editor.Output as Output
+import qualified Unison.Codebase.Path as Path
+import Unison.Prelude
+import Unison.Project (ProjectAndBranch (..), ProjectName)
+
+-- | Delete a project branch.
+--
+-- Currently, deleting a branch means deleting its `project_branch` row, then deleting its contents from the namespace.
+-- Its children branches, if any, are reparented to their grandparent, if any. You may delete the only branch in a
+-- project.
+handleDeleteProject :: ProjectName -> Cli ()
+handleDeleteProject projectName = do
+  maybeCurrentBranch <- ProjectUtils.getCurrentProjectBranch
+
+  deletedProject <-
+    Cli.runEitherTransaction do
+      Queries.loadProjectByName projectName >>= \case
+        Nothing -> pure (Left (Output.LocalProjectDoesntExist projectName))
+        Just project -> do
+          Queries.deleteProject (project ^. #projectId)
+          pure (Right project)
+
+  let projectId = deletedProject ^. #projectId
+
+  Cli.updateAt
+    ("delete.project " <> into @Text projectName)
+    (ProjectUtils.projectPath projectId)
+    (const Branch.empty)
+
+  -- If the user is on the project that they're deleting, we cd to the root path
+  whenJust maybeCurrentBranch \(ProjectAndBranch currentProject _currentBranch, _restPath) ->
+    when (on (==) (view #projectId) deletedProject currentProject) do
+      Cli.cd (Path.Absolute Path.empty)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/DeleteProject.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/DeleteProject.hs
@@ -17,11 +17,7 @@ import qualified Unison.Codebase.Path as Path
 import Unison.Prelude
 import Unison.Project (ProjectAndBranch (..), ProjectName)
 
--- | Delete a project branch.
---
--- Currently, deleting a branch means deleting its `project_branch` row, then deleting its contents from the namespace.
--- Its children branches, if any, are reparented to their grandparent, if any. You may delete the only branch in a
--- project.
+-- | Delete a project
 handleDeleteProject :: ProjectName -> Cli ()
 handleDeleteProject projectName = do
   maybeCurrentBranch <- ProjectUtils.getCurrentProjectBranch

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -330,4 +330,5 @@ data DeleteTarget
   | DeleteTarget'Namespace Insistence (Maybe Path.Split')
   | DeleteTarget'Patch Path.Split'
   | DeleteTarget'ProjectBranch (ProjectAndBranch (Maybe ProjectName) ProjectBranchName)
+  | DeleteTarget'Project ProjectName
   deriving stock (Eq, Show)

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -320,6 +320,7 @@ data Output
     NoAssociatedRemoteProject URI (ProjectAndBranch ProjectName ProjectBranchName)
   | -- there's no remote branch associated with branch
     NoAssociatedRemoteProjectBranch URI (ProjectAndBranch ProjectName ProjectBranchName)
+  | LocalProjectDoesntExist ProjectName
   | LocalProjectBranchDoesntExist (ProjectAndBranch ProjectName ProjectBranchName)
   | LocalProjectNorProjectBranchExist ProjectName ProjectBranchName
   | RemoteProjectDoesntExist URI ProjectName
@@ -526,6 +527,7 @@ isFailure o = case o of
   NoAssociatedRemoteProject {} -> True
   NoAssociatedRemoteProjectBranch {} -> True
   ProjectAndBranchNameAlreadyExists {} -> True
+  LocalProjectDoesntExist {} -> True
   LocalProjectBranchDoesntExist {} -> True
   LocalProjectNorProjectBranchExist {} -> True
   RemoteProjectDoesntExist {} -> True

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -722,6 +722,21 @@ deleteReplacement isTerm =
         then deleteTermReplacementCommand
         else deleteTypeReplacementCommand
 
+deleteProject :: InputPattern
+deleteProject =
+  InputPattern
+    { patternName = "delete.project",
+      aliases = [],
+      visibility = I.Hidden,
+      argTypes = [(Required, projectNameArg)],
+      help = P.wrap "Delete a project.",
+      parse = \case
+        [name]
+          | Right project <- tryInto @ProjectName (Text.pack name) ->
+              Right (Input.DeleteI (DeleteTarget'Project project))
+        _ -> Left (showPatternHelp deleteProject)
+    }
+
 deleteBranch :: InputPattern
 deleteBranch =
   InputPattern
@@ -2491,6 +2506,7 @@ validInputs =
       debugTabCompletion,
       delete,
       deleteBranch,
+      deleteProject,
       deleteNamespace,
       deleteNamespaceForce,
       deletePatch,

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1932,6 +1932,9 @@ notifyUser dir = \case
   NoAssociatedRemoteProjectBranch host projectAndBranch ->
     pure . P.wrap $
       prettyProjectAndBranchName projectAndBranch <> "isn't associated with any branch on" <> prettyURI host
+  LocalProjectDoesntExist project ->
+    pure . P.wrap $
+      prettyProjectName project <> "does not exist."
   LocalProjectBranchDoesntExist projectAndBranch ->
     pure . P.wrap $
       prettyProjectAndBranchName projectAndBranch <> "does not exist."

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -46,6 +46,7 @@ library
       Unison.Codebase.Editor.HandleInput.Branch
       Unison.Codebase.Editor.HandleInput.Branches
       Unison.Codebase.Editor.HandleInput.DeleteBranch
+      Unison.Codebase.Editor.HandleInput.DeleteProject
       Unison.Codebase.Editor.HandleInput.MetadataUtils
       Unison.Codebase.Editor.HandleInput.MoveBranch
       Unison.Codebase.Editor.HandleInput.NamespaceDependencies

--- a/unison-src/transcripts/delete-project.md
+++ b/unison-src/transcripts/delete-project.md
@@ -1,0 +1,9 @@
+# delete.project
+
+```ucm
+.> project.create foo
+.> project.create bar
+.> projects
+foo/main> delete.project foo
+.> projects
+```

--- a/unison-src/transcripts/delete-project.output.md
+++ b/unison-src/transcripts/delete-project.output.md
@@ -1,0 +1,27 @@
+# delete.project
+
+```ucm
+.> project.create foo
+
+  I just created project foo with branch main.
+
+  ☝️  The namespace . is empty.
+
+.> project.create bar
+
+  I just created project bar with branch main.
+
+  ☝️  The namespace . is empty.
+
+.> projects
+
+  1. bar
+  2. foo
+
+foo/main> delete.project foo
+
+.> projects
+
+  1. bar
+
+```

--- a/unison-src/transcripts/tab-completion.output.md
+++ b/unison-src/transcripts/tab-completion.output.md
@@ -20,6 +20,7 @@ Test that tab completion works as expected.
    delete.namespace
    delete.namespace.force
    delete.patch
+   delete.project
    delete.term
    delete.term-replacement
    delete.term.verbose


### PR DESCRIPTION
## Overview

Adds the `delete.project` command that hard-deletes a project.

## Implementation notes

The handler deletes the project rows from sqlite then removes the project's namespace. If the user is in the project when deleting they are moved the the root namespace.

## Interesting/controversial decisions

none

## Test coverage

There is a transcript in the PR.

## Loose ends

1. We want to support soft-deletes for projects and project branches. 
2. Project related stuff like this is not currently compatible with the reflog/undo. 
3. It would be best to delete the project rows and manipulate the namespace atomically, and I don't see a reason we couldn't do that right now. However, our api for modifying namespaces (`updateAt*`, `stepAt*`, `updateRoot`) doesn't give this control (i.e. doesn't accept a database connection or run in `Transaction`).
