### PR TITLE
Interleave more output into pull when a merge is detected.

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Pull.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Pull.hs
@@ -85,7 +85,8 @@ doPullRemoteBranch unresolvedSourceAndTarget syncMode pullMode verbosity descrip
         then do
           void $ Cli.updateAtM description targetAbsolutePath (const $ pure remoteBranchObject)
           Cli.respond $ MergeOverEmpty target
-        else
+        else do
+          Cli.respond AboutToMerge
           mergeBranchAndPropagateDefaultPatch
             Branch.RegularMerge
             description
@@ -272,12 +273,14 @@ loadPropagateDiffDefaultPatch ::
   Path.Absolute ->
   Cli ()
 loadPropagateDiffDefaultPatch inputDescription maybeDest0 dest = do
+  Cli.respond Output.AboutToPropagatePatch
   Cli.time "loadPropagateDiffDefaultPatch" do
     original <- Cli.getBranch0At dest
     patch <- liftIO $ Branch.getPatch Cli.defaultPatchNameSegment original
     patchDidChange <- propagatePatch inputDescription patch dest
     when patchDidChange do
       whenJust maybeDest0 \dest0 -> do
+        Cli.respond Output.CalculatingDiff
         patched <- Cli.getBranchAt dest
         let patchPath = Path.Path' (Right (Path.Relative (Path.fromList [Cli.defaultPatchNameSegment])))
         (ppe, diff) <- diffHelper original (Branch.head patched)

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -247,6 +247,7 @@ data Output
   | MetadataMissingType PPE.PrettyPrintEnv Referent
   | TermMissingType Reference
   | MetadataAmbiguous (HQ.HashQualified Name) PPE.PrettyPrintEnv [Referent]
+  | AboutToPropagatePatch
   | -- todo: tell the user to run `todo` on the same patch they just used
     NothingToPatch PatchPath Path'
   | PatchNeedsToBeConflictFree
@@ -260,6 +261,7 @@ data Output
   | PullSuccessful
       (ReadRemoteNamespace Share.RemoteProjectBranch)
       (PullTarget (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch))
+  | AboutToMerge
   | -- | Indicates a trivial merge where the destination was empty and was just replaced.
     MergeOverEmpty (PullTarget (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch))
   | MergeAlreadyUpToDate
@@ -337,6 +339,7 @@ data Output
     NotImplementedYet Text
   | DraftingRelease ProjectBranchName Semver
   | CannotCreateReleaseBranchWithBranchCommand ProjectBranchName Semver
+  | CalculatingDiff
 
 -- | What did we create a project branch from?
 --
@@ -472,6 +475,7 @@ isFailure o = case o of
   MetadataAmbiguous {} -> True
   PatchNeedsToBeConflictFree {} -> True
   PatchInvolvesExternalDependents {} -> True
+  AboutToPropagatePatch {} -> False
   NothingToPatch {} -> False
   WarnIncomingRootBranch {} -> False
   StartOfCurrentPathHistory -> True
@@ -481,6 +485,7 @@ isFailure o = case o of
   NoBranchWithHash {} -> True
   PullAlreadyUpToDate {} -> False
   PullSuccessful {} -> False
+  AboutToMerge {} -> False
   MergeOverEmpty {} -> False
   MergeAlreadyUpToDate {} -> False
   PreviewMergeAlreadyUpToDate {} -> False
@@ -542,6 +547,7 @@ isFailure o = case o of
   UploadedEntities {} -> False
   DraftingRelease {} -> False
   CannotCreateReleaseBranchWithBranchCommand {} -> True
+  CalculatingDiff {} -> False
 
 isNumberedFailure :: NumberedOutput -> Bool
 isNumberedFailure = \case

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1523,6 +1523,7 @@ notifyUser dir = \case
     pure $
       "I could't find a type with hash "
         <> (prettyShortHash sh)
+  AboutToPropagatePatch -> pure "Propagating changes from patch..."
   NothingToPatch _patchPath dest ->
     pure $
       P.callout "😶" . P.wrap $
@@ -1596,6 +1597,7 @@ notifyUser dir = \case
           <> prettyPullTarget dest
           <> "from"
           <> P.group (prettyReadRemoteNamespace ns <> ".")
+  AboutToMerge -> pure "Merging..."
   MergeOverEmpty dest ->
     pure . P.okCallout $
       P.wrap $
@@ -2057,6 +2059,7 @@ notifyUser dir = \case
         <> P.newline
         <> tip ("to draft a new release, try " <> IP.makeExample IP.releaseDraft [prettySemver ver])
         <> "."
+  CalculatingDiff -> pure (P.wrap "Calculating diff...")
   where
     _nameChange _cmd _pastTenseCmd _oldName _newName _r = error "todo"
 

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1523,7 +1523,7 @@ notifyUser dir = \case
     pure $
       "I could't find a type with hash "
         <> (prettyShortHash sh)
-  AboutToPropagatePatch -> pure "Propagating changes from patch..."
+  AboutToPropagatePatch -> pure "Applying changes from patch..."
   NothingToPatch _patchPath dest ->
     pure $
       P.callout "😶" . P.wrap $

--- a/unison-src/transcripts/ambiguous-metadata.output.md
+++ b/unison-src/transcripts/ambiguous-metadata.output.md
@@ -24,6 +24,8 @@ x = 1
        can use `undo` or `reflog` to undo the results of this
        merge.
 
+  Applying changes from patch...
+
 .> link boo.doc x
 
   ⚠️

--- a/unison-src/transcripts/child-namespace-history-merge.output.md
+++ b/unison-src/transcripts/child-namespace-history-merge.output.md
@@ -138,6 +138,8 @@ For a squash merge, when I squash-merge back into parent, we expect `parent_fork
        can use `undo` or `reflog` to undo the results of this
        merge.
 
+  Applying changes from patch...
+
 .> history parent_squash_base
 
   Note: The most recent namespace hash is immediately below this
@@ -220,6 +222,8 @@ For a standard merge, if I merge back into parent, we expect `parent_fork.child.
        do in this namespace and `test` to run the tests. Or you
        can use `undo` or `reflog` to undo the results of this
        merge.
+
+  Applying changes from patch...
 
 .> history parent_merge_base
 

--- a/unison-src/transcripts/cycle-update-6.output.md
+++ b/unison-src/transcripts/cycle-update-6.output.md
@@ -73,6 +73,8 @@ N.B. The `find.verbose pong` is just to print the hash, for easy copying.
        can use `undo` or `reflog` to undo the results of this
        merge.
 
+  Applying changes from patch...
+
 ```
 ```unison
 ping : 'Nat

--- a/unison-src/transcripts/delete.output.md
+++ b/unison-src/transcripts/delete.output.md
@@ -101,6 +101,8 @@ foo = 2
        can use `undo` or `reflog` to undo the results of this
        merge.
 
+  Applying changes from patch...
+
 ```
 A delete should remove both versions of the term.
 
@@ -175,6 +177,8 @@ structural type Foo = Foo
        do in this namespace and `test` to run the tests. Or you
        can use `undo` or `reflog` to undo the results of this
        merge.
+
+  Applying changes from patch...
 
 ```
 ```ucm

--- a/unison-src/transcripts/diff-namespace.output.md
+++ b/unison-src/transcripts/diff-namespace.output.md
@@ -53,6 +53,8 @@ fslkdjflskdjflksjdf = 663
        can use `undo` or `reflog` to undo the results of this
        merge.
 
+  Applying changes from patch...
+
 .> diff.namespace b1 b2
 
   Resolved name conflicts:
@@ -193,6 +195,8 @@ fromJust = "asldkfjasldkfj"
        do in this namespace and `test` to run the tests. Or you
        can use `undo` or `reflog` to undo the results of this
        merge.
+
+  Applying changes from patch...
 
 ```
 ```unison
@@ -562,6 +566,8 @@ a = 555
        can use `undo` or `reflog` to undo the results of this
        merge.
 
+  Applying changes from patch...
+
 ```
 ```ucm
 .> merge nsz nsw
@@ -587,6 +593,8 @@ a = 555
        do in this namespace and `test` to run the tests. Or you
        can use `undo` or `reflog` to undo the results of this
        merge.
+
+  Applying changes from patch...
 
   I tried to auto-apply the patch, but couldn't because it
   contained contradictory entries.

--- a/unison-src/transcripts/fix2000.output.md
+++ b/unison-src/transcripts/fix2000.output.md
@@ -114,6 +114,8 @@ Merge back into the ancestor.
        can use `undo` or `reflog` to undo the results of this
        merge.
 
+  Applying changes from patch...
+
 .> delete.term.verbose 1
 
   Resolved name conflicts:
@@ -145,6 +147,8 @@ Merge back into the ancestor.
        can use `undo` or `reflog` to undo the results of this
        merge.
 
+  Applying changes from patch...
+
 .> squash y s
 
   Here's what's changed in s after the merge:
@@ -164,6 +168,8 @@ Merge back into the ancestor.
        do in this namespace and `test` to run the tests. Or you
        can use `undo` or `reflog` to undo the results of this
        merge.
+
+  Applying changes from patch...
 
 .s> todo
 

--- a/unison-src/transcripts/fix2004.output.md
+++ b/unison-src/transcripts/fix2004.output.md
@@ -109,6 +109,8 @@ Now we fork `a2` off of `a`. `a` continues on, deleting the terms it added previ
        can use `undo` or `reflog` to undo the results of this
        merge.
 
+  Applying changes from patch...
+
 .a> find
 
   1. dontDelete : Float -> Float -> Float
@@ -162,6 +164,8 @@ Meanwhile, `a2` adds some other unrelated terms, some via merging in namespaces 
        can use `undo` or `reflog` to undo the results of this
        merge.
 
+  Applying changes from patch...
+
 .a2> find
 
   1.  delete1 : Delete4 -> Delete4 -> Delete4
@@ -200,6 +204,8 @@ Meanwhile, `a2` adds some other unrelated terms, some via merging in namespaces 
        can use `undo` or `reflog` to undo the results of this
        merge.
 
+  Applying changes from patch...
+
 .> squash a2 asquash
 
   Here's what's changed in asquash after the merge:
@@ -217,6 +223,8 @@ Meanwhile, `a2` adds some other unrelated terms, some via merging in namespaces 
        do in this namespace and `test` to run the tests. Or you
        can use `undo` or `reflog` to undo the results of this
        merge.
+
+  Applying changes from patch...
 
 ```
 At this point, all the things that `a` has deleted (`delete1`, `delete2`, etc) should be deleted in both the merged and squashed results. Let's verify this:

--- a/unison-src/transcripts/merge.output.md
+++ b/unison-src/transcripts/merge.output.md
@@ -142,6 +142,8 @@ and `quux` namespaces.
        can use `undo` or `reflog` to undo the results of this
        merge.
 
+  Applying changes from patch...
+
 .P0> merge .P2
 
   Here's what's changed in the current namespace after the
@@ -160,6 +162,8 @@ and `quux` namespaces.
        do in this namespace and `test` to run the tests. Or you
        can use `undo` or `reflog` to undo the results of this
        merge.
+
+  Applying changes from patch...
 
 .P0> find
 
@@ -301,6 +305,8 @@ Now merging `c1b` into `c1a` should result in the updated version of `a` and `f`
        do in this namespace and `test` to run the tests. Or you
        can use `undo` or `reflog` to undo the results of this
        merge.
+
+  Applying changes from patch...
 
 .c1a> todo .c1b.patch
 

--- a/unison-src/transcripts/mergeloop.output.md
+++ b/unison-src/transcripts/mergeloop.output.md
@@ -120,9 +120,13 @@ b = 2
 
   Nothing changed as a result of the merge.
 
+  Applying changes from patch...
+
 .> merge y z
 
   Nothing changed as a result of the merge.
+
+  Applying changes from patch...
 
 .> history z
 

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -86,6 +86,8 @@ y = "hello"
        can use `undo` or `reflog` to undo the results of this
        merge.
 
+  Applying changes from patch...
+
 .master> view y
 
   y : Text
@@ -267,6 +269,8 @@ At this point, `master` and `feature2` both have some changes the other doesn't 
        do in this namespace and `test` to run the tests. Or you
        can use `undo` or `reflog` to undo the results of this
        merge.
+
+  Applying changes from patch...
 
 ```
 Notice that `x` is deleted in the merged branch (it was deleted in `feature2` and untouched by `master`):

--- a/unison-src/transcripts/name-selection.output.md
+++ b/unison-src/transcripts/name-selection.output.md
@@ -1457,6 +1457,8 @@ d = c + 10
        can use `undo` or `reflog` to undo the results of this
        merge.
 
+  Applying changes from patch...
+
 ```
 At this point, `a3` is conflicted for symbols `c` and `d`, so those are deprioritized. 
 The original `a2` namespace has an unconflicted definition for `c` and `d`, but since there are multiple 'c's in scope, 

--- a/unison-src/transcripts/project-merge.output.md
+++ b/unison-src/transcripts/project-merge.output.md
@@ -47,6 +47,8 @@ zonk = 0
        can use `undo` or `reflog` to undo the results of this
        merge.
 
+  Applying changes from patch...
+
 ```
 ```unison
 bonk = 2
@@ -90,6 +92,8 @@ bar/main> merge foo/main
        do in this namespace and `test` to run the tests. Or you
        can use `undo` or `reflog` to undo the results of this
        merge.
+
+  Applying changes from patch...
 
 bar/main> branch /topic
 
@@ -135,6 +139,8 @@ bar/topic> merge /main
        can use `undo` or `reflog` to undo the results of this
        merge.
 
+  Applying changes from patch...
+
   ☝️  The namespace .bar is empty.
 
 .bar> merge foo/main
@@ -151,5 +157,7 @@ bar/topic> merge /main
        do in this namespace and `test` to run the tests. Or you
        can use `undo` or `reflog` to undo the results of this
        merge.
+
+  Applying changes from patch...
 
 ```

--- a/unison-src/transcripts/resolve.output.md
+++ b/unison-src/transcripts/resolve.output.md
@@ -155,6 +155,8 @@ Let's now merge these namespaces into `c`:
        can use `undo` or `reflog` to undo the results of this
        merge.
 
+  Applying changes from patch...
+
 ```
 ```ucm
 .example.resolve> merge b c
@@ -176,6 +178,8 @@ Let's now merge these namespaces into `c`:
        do in this namespace and `test` to run the tests. Or you
        can use `undo` or `reflog` to undo the results of this
        merge.
+
+  Applying changes from patch...
 
   I tried to auto-apply the patch, but couldn't because it
   contained contradictory entries.

--- a/unison-src/transcripts/squash.output.md
+++ b/unison-src/transcripts/squash.output.md
@@ -66,6 +66,8 @@ If we merge that back into `builtin`, we get that same chain of history:
 
   Nothing changed as a result of the merge.
 
+  Applying changes from patch...
+
 .> history builtin
 
   Note: The most recent namespace hash is immediately below this
@@ -252,6 +254,8 @@ Alice then squash merges into `trunk`, as does Bob. It's as if Alice and Bob bot
        can use `undo` or `reflog` to undo the results of this
        merge.
 
+  Applying changes from patch...
+
 .> history trunk
 
   Note: The most recent namespace hash is immediately below this
@@ -279,6 +283,8 @@ Alice then squash merges into `trunk`, as does Bob. It's as if Alice and Bob bot
        do in this namespace and `test` to run the tests. Or you
        can use `undo` or `reflog` to undo the results of this
        merge.
+
+  Applying changes from patch...
 
 .> history trunk
 
@@ -357,6 +363,8 @@ This time, we'll first squash Alice and Bob's changes together before squashing 
        can use `undo` or `reflog` to undo the results of this
        merge.
 
+  Applying changes from patch...
+
 .> squash bob trunk
 
   Here's what's changed in trunk after the merge:
@@ -374,6 +382,8 @@ This time, we'll first squash Alice and Bob's changes together before squashing 
        do in this namespace and `test` to run the tests. Or you
        can use `undo` or `reflog` to undo the results of this
        merge.
+
+  Applying changes from patch...
 
 .> history trunk
 
@@ -412,6 +422,8 @@ Another thing we can do is `squash` into an empty namespace. This effectively ma
        do in this namespace and `test` to run the tests. Or you
        can use `undo` or `reflog` to undo the results of this
        merge.
+
+  Applying changes from patch...
 
 .> history nohistoryalice
 
@@ -479,6 +491,8 @@ This checks to see that squashing correctly preserves deletions:
        do in this namespace and `test` to run the tests. Or you
        can use `undo` or `reflog` to undo the results of this
        merge.
+
+  Applying changes from patch...
 
 .delete> history builtin
 

--- a/unison-src/transcripts/todo.output.md
+++ b/unison-src/transcripts/todo.output.md
@@ -103,6 +103,8 @@ structural type MyType = MyType Int
        can use `undo` or `reflog` to undo the results of this
        merge.
 
+  Applying changes from patch...
+
   I tried to auto-apply the patch, but couldn't because it
   contained contradictory entries.
 

--- a/unison-src/transcripts/update-on-conflict.output.md
+++ b/unison-src/transcripts/update-on-conflict.output.md
@@ -42,6 +42,8 @@ Cause a conflict:
        can use `undo` or `reflog` to undo the results of this
        merge.
 
+  Applying changes from patch...
+
 .merged> merge .b
 
   Here's what's changed in the current namespace after the
@@ -58,6 +60,8 @@ Cause a conflict:
        do in this namespace and `test` to run the tests. Or you
        can use `undo` or `reflog` to undo the results of this
        merge.
+
+  Applying changes from patch...
 
 ```
 Updating conflicted definitions works fine, and the associated patch contains two entries.


### PR DESCRIPTION
## Overview

Currently, pull clearly shows progress while it's downloading entities, but when it's finished downloading there are sometimes still time-consuming steps and it may appear to have 'hung' when it's working on them.

Ideally we'd speed up these situations, but this is a quick way to keep the user informed about which step we're currently working on.

<img width="618" alt="Screenshot 2023-05-16 at 3 23 02 PM" src="https://github.com/unisonweb/unison/assets/6439644/53156eda-704d-4e4b-848c-0906eafeb992">

Output for a pull which results in a merge and patch propagation, but no diff

(p.s. I've changed the messaging to: `Propagating changes from patch...` but didn't take another screenshot :P )

## Implementation notes

* Add output for when we start on the merge step, propagate step, and diff calculation.
* These are only displayed when a merge is necessary, a patch propagation is required, or a propagation results in a diff respectively.
* "Applying changes from patch..." will also be displayed in output from the `merge` command now, but this seems like a helpful change too.