### PR TITLE
Recall most recent branch for `switch`

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -214,6 +214,7 @@ module U.Codebase.Sqlite.Queries
     addReflogTable,
     addNamespaceStatsTables,
     addProjectTables,
+    addMostRecentBranchTable,
     fixScopedNameLookupTables,
 
     -- ** schema version
@@ -370,7 +371,7 @@ type TextPathSegments = [Text]
 -- * main squeeze
 
 currentSchemaVersion :: SchemaVersion
-currentSchemaVersion = 10
+currentSchemaVersion = 11
 
 createSchema :: Transaction ()
 createSchema = do
@@ -380,6 +381,7 @@ createSchema = do
   addReflogTable
   fixScopedNameLookupTables
   addProjectTables
+  addMostRecentBranchTable
   execute2 insertSchemaVersionSql
   where
     insertSchemaVersionSql =
@@ -407,6 +409,10 @@ fixScopedNameLookupTables =
 addProjectTables :: Transaction ()
 addProjectTables =
   executeFile [hereFile|unison/sql/005-project-tables.sql|]
+
+addMostRecentBranchTable :: Transaction ()
+addMostRecentBranchTable =
+  executeFile [hereFile|unison/sql/006-most-recent-branch-table.sql|]
 
 executeFile :: String -> Transaction ()
 executeFile =

--- a/codebase2/codebase-sqlite/sql/006-most-recent-branch-table.sql
+++ b/codebase2/codebase-sqlite/sql/006-most-recent-branch-table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE most_recent_branch (
+  project_id uuid PRIMARY KEY REFERENCES project (id) ON DELETE CASCADE,
+  branch_id uuid NOT NULL,
+  FOREIGN KEY (project_id, branch_id) REFERENCES project_branch (project_id, branch_id) ON DELETE CASCADE) WITHOUT rowid;
+

--- a/codebase2/codebase-sqlite/unison-codebase-sqlite.cabal
+++ b/codebase2/codebase-sqlite/unison-codebase-sqlite.cabal
@@ -15,6 +15,7 @@ extra-source-files:
     sql/003-namespace-statistics.sql
     sql/004-fix-scoped-name-lookup-tables.sql
     sql/005-project-tables.sql
+    sql/006-most-recent-branch-table.sql
     sql/create.sql
 
 source-repository head

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
@@ -20,6 +20,7 @@ import Unison.Codebase.Init.OpenCodebaseError (OpenCodebaseError (OpenCodebaseUn
 import qualified Unison.Codebase.Init.OpenCodebaseError as Codebase
 import Unison.Codebase.IntegrityCheck (IntegrityResult (..), integrityCheckAllBranches, integrityCheckAllCausals, prettyPrintIntegrityErrors)
 import Unison.Codebase.SqliteCodebase.Migrations.Helpers (abortMigration)
+import Unison.Codebase.SqliteCodebase.Migrations.MigrateSchema10To11 (migrateSchema10To11)
 import Unison.Codebase.SqliteCodebase.Migrations.MigrateSchema1To2 (migrateSchema1To2)
 import Unison.Codebase.SqliteCodebase.Migrations.MigrateSchema2To3 (migrateSchema2To3)
 import Unison.Codebase.SqliteCodebase.Migrations.MigrateSchema3To4 (migrateSchema3To4)
@@ -61,7 +62,8 @@ migrations getDeclType termBuffer declBuffer rootCodebasePath =
       (7, migrateSchema6To7),
       (8, migrateSchema7To8),
       (9, migrateSchema8To9),
-      (10, migrateSchema9To10)
+      (10, migrateSchema9To10),
+      (11, migrateSchema10To11)
     ]
 
 data CodebaseVersionStatus

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema10To11.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema10To11.hs
@@ -1,0 +1,10 @@
+module Unison.Codebase.SqliteCodebase.Migrations.MigrateSchema10To11 (migrateSchema10To11) where
+
+import qualified U.Codebase.Sqlite.Queries as Queries
+import qualified Unison.Sqlite as Sqlite
+
+migrateSchema10To11 :: Sqlite.Transaction ()
+migrateSchema10To11 = do
+  Queries.expectSchemaVersion 10
+  Queries.addMostRecentBranchTable
+  Queries.setSchemaVersion 11

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -75,6 +75,7 @@ library
       Unison.Codebase.SqliteCodebase.GitError
       Unison.Codebase.SqliteCodebase.Migrations
       Unison.Codebase.SqliteCodebase.Migrations.Helpers
+      Unison.Codebase.SqliteCodebase.Migrations.MigrateSchema10To11
       Unison.Codebase.SqliteCodebase.Migrations.MigrateSchema1To2
       Unison.Codebase.SqliteCodebase.Migrations.MigrateSchema1To2.DbHelpers
       Unison.Codebase.SqliteCodebase.Migrations.MigrateSchema2To3

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Branch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Branch.hs
@@ -132,6 +132,7 @@ doCreateBranch createFrom project newBranchName description = do
                         | (sourceBranch ^. #projectId) == projectId -> Just (sourceBranch ^. #branchId)
                       _ -> Nothing
                 }
+            Queries.setMostRecentBranch projectId newBranchId
             pure newBranchId
 
   let newBranchPath = ProjectUtils.projectBranchPath (ProjectAndBranch projectId newBranchId)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectCreate.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectCreate.hs
@@ -63,6 +63,7 @@ projectCreate projectName = do
               name = branchName,
               parentBranchId = Nothing
             }
+        Queries.setMostRecentBranch projectId branchId
         pure (Right ())
       True -> pure (Left (Output.ProjectNameAlreadyExists projectName))
 

--- a/unison-src/transcripts/switch-command.output.md
+++ b/unison-src/transcripts/switch-command.output.md
@@ -88,7 +88,7 @@ It's an error to try to switch to something that doesn't exist, of course.
 ```ucm
 .> switch no-such-project
 
-  no-such-project/main does not exist.
+  no-such-project does not exist.
 
 ```
 ```ucm


### PR DESCRIPTION
## Overview

![ss](https://github.com/unisonweb/unison/assets/1627482/4d719a14-2638-4a4e-b305-463a94d7bc5a)

## Implementation notes

There is a new table, `most_recent_branch`, that stores the most recent branch the user has been on for each project.

## Interesting/controversial decisions

none

## Test coverage

Only manual testing.

## Loose ends

none
