### PR TITLE
building on lts-20.21 (ghc 9.2.6)

### DIFF
--- a/lib/unison-prelude/src/Unison/Prelude.hs
+++ b/lib/unison-prelude/src/Unison/Prelude.hs
@@ -47,7 +47,7 @@ import Data.Coerce as X (Coercible, coerce)
 import Data.Either as X
 import Data.Either.Combinators as X (mapLeft, maybeToRight)
 import Data.Either.Extra (eitherToMaybe, maybeToEither)
-import Data.Foldable as X (asum, fold, foldl', for_, toList, traverse_)
+import Data.Foldable as X (fold, foldl', for_, toList, traverse_)
 import Data.Function as X ((&))
 import Data.Functor as X
 import Data.Functor.Identity as X

--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -101,7 +101,7 @@ dependencies:
   - stm
   - tagged
   - temporary
-  - terminal-size
+  - terminal-size >= 0.3.3
   - text
   - text-short
   - these

--- a/parser-typechecker/src/Unison/PatternMatchCoverage/Solve.hs
+++ b/parser-typechecker/src/Unison/PatternMatchCoverage/Solve.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
 module Unison.PatternMatchCoverage.Solve
   ( uncoverAnnotate,

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -291,7 +291,7 @@ library
     , stm
     , tagged
     , temporary
-    , terminal-size
+    , terminal-size >=0.3.3
     , text
     , text-short
     , these
@@ -482,7 +482,7 @@ test-suite parser-typechecker-tests
     , stm
     , tagged
     , temporary
-    , terminal-size
+    , terminal-size >=0.3.3
     , text
     , text-short
     , these

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,8 +2,6 @@ flags:
   haskeline:
     terminfo: false
 
-allow-newer: true # async package has needlessly strict upper bound
-
 allow-different-user: true
 
 build:
@@ -41,14 +39,11 @@ packages:
 - unison-syntax
 - yaks/easytest
 
-#compiler-check: match-exact
-resolver: lts-18.28
+resolver: lts-20.21
 
 extra-deps:
 - github: unisonweb/configurator
   commit: e47e9e9fe1f576f8c835183b9def52d73c01327a
-- github: unisonweb/shellmet
-  commit: 2fd348592c8f51bb4c0ca6ba4bc8e38668913746
 - github: awkward-squad/ki
   commit: 563e96238dfe392dccf68d93953c8f30fd53bec8
   subdirs:
@@ -57,30 +52,15 @@ extra-deps:
 # If changing the haskeline dependency, please ensure color renders properly in a
 # Windows terminal.
 # https://github.com/judah/haskeline/pull/126
-- github: judah/haskeline
-  commit: d6c2643b0d5c19be7e440615c6f84d603d4bc648
+- github: unisonweb/haskeline
+  commit: 9275eea7982dabbf47be2ba078ced669ae7ef3d5
+
+# not in lts-20.21
+- fuzzyfind-3.0.1
 - guid-0.1.0@sha256:a7c975be473f6f142d5cc1b39bc807a99043d20b1bb0873fdfe7a3ce84d2faf1,1078
-- sandi-0.5@sha256:b278d072ca717706ea38f9bd646e023f7f2576a778fb43565b434f93638849aa,3010
-- fuzzyfind-3.0.0@sha256:d79a5d3ed194dd436c6b839bf187211d880cf773b2febaca456e5ccf93f5ac65,1814
-- monad-validate-1.2.0.0@sha256:9850f408431098b28806dd464b6825a88a0b56c84f380d7fe0454c1df9d6f881,3505
-- NanoID-3.1.0@sha256:9118ab00e8650b5a56a10c90295d357eb77a8057a598b7e56dfedc9c6d53c77d,1524
-# 2.3.27 bundles sqlite >=3.35.0, needed for 'delete returning'
-- direct-sqlite-2.3.27
-# not in lts-18.13
-- recover-rtti-0.4.0.0@sha256:2ce1e031ec0e34d736fa45f0149bbd55026f614939dc90ffd14a9c5d24093ff4,4423
 - lock-file-0.7.0.0@sha256:3ad84b5e454145e1d928063b56abb96db24a99a21b493989520e58fa0ab37b00,4484
-- http-client-0.7.11
-- lsp-1.5.0.0
-- lsp-types-1.5.0.0
-- text-rope-0.2@sha256:53b9b4cef0b278b9c591cd4ca76543acacf64c9d1bfbc06d0d9a88960446d9a7,2087
-- co-log-core-0.3.1.0
-# lts 18.28 provides 0.3.2.1 but we need at least 0.3.3
-- terminal-size-0.3.3
-# lts 18.28 provides 3.1.1.1 but we need at least 3.1.2.7
-- network-3.1.2.7
-# 0.4.18.0 is in lts-18.28, but 0.4.18.2 adds generic
-# implementations of ToRow and FromRow
-- sqlite-simple-0.4.18.2
+- monad-validate-1.2.0.0@sha256:9850f408431098b28806dd464b6825a88a0b56c84f380d7fe0454c1df9d6f881,3505
+- recover-rtti-0.4.2@sha256:c179a303921126d8d782264e14f386c96e54a270df74be002e4c4ec3c8c7aebd,4529
 
 ghc-options:
  # All packages

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,166 +5,78 @@
 
 packages:
 - completed:
+    name: configurator
+    pantry-tree:
+      sha256: 90547cd983fd15ebdc803e057d3ef8735fe93a75e29a00f8a74eadc13ee0f6e9
+      size: 955
+    sha256: d4fd87fb7bfc5d8e9fbc3e4ee7302c6b1500cdc00fdb9b659d0f4849b6ebe2d5
     size: 15989
     url: https://github.com/unisonweb/configurator/archive/e47e9e9fe1f576f8c835183b9def52d73c01327a.tar.gz
-    name: configurator
     version: 0.3.0.0
-    sha256: d4fd87fb7bfc5d8e9fbc3e4ee7302c6b1500cdc00fdb9b659d0f4849b6ebe2d5
-    pantry-tree:
-      size: 955
-      sha256: 90547cd983fd15ebdc803e057d3ef8735fe93a75e29a00f8a74eadc13ee0f6e9
   original:
     url: https://github.com/unisonweb/configurator/archive/e47e9e9fe1f576f8c835183b9def52d73c01327a.tar.gz
 - completed:
-    size: 10460
-    url: https://github.com/unisonweb/shellmet/archive/2fd348592c8f51bb4c0ca6ba4bc8e38668913746.tar.gz
-    name: shellmet
-    version: 0.0.4.0
-    sha256: 6e642163070a217cc3363bdbefde571ff6c1878f4fc3d92e9c910db7fa88eaf2
+    name: ki
     pantry-tree:
-      size: 654
-      sha256: 05a169a7a6b68100630e885054dc1821d31cd06571b0317ec90c75ac2c41aeb7
-  original:
-    url: https://github.com/unisonweb/shellmet/archive/2fd348592c8f51bb4c0ca6ba4bc8e38668913746.tar.gz
-- completed:
+      sha256: c63220c438c076818e09061b117c56055e154f6abb66ea9bc44a3900fcabd654
+      size: 704
+    sha256: a45eb3dbe7333c108aef4afce7f763c7661919b09641ef9d241c7ca4a78bf735
     size: 15840
     subdir: ki
     url: https://github.com/awkward-squad/ki/archive/563e96238dfe392dccf68d93953c8f30fd53bec8.tar.gz
-    name: ki
     version: 1.0.0
-    sha256: a45eb3dbe7333c108aef4afce7f763c7661919b09641ef9d241c7ca4a78bf735
-    pantry-tree:
-      size: 704
-      sha256: c63220c438c076818e09061b117c56055e154f6abb66ea9bc44a3900fcabd654
   original:
     subdir: ki
     url: https://github.com/awkward-squad/ki/archive/563e96238dfe392dccf68d93953c8f30fd53bec8.tar.gz
 - completed:
-    size: 74363
-    url: https://github.com/judah/haskeline/archive/d6c2643b0d5c19be7e440615c6f84d603d4bc648.tar.gz
     name: haskeline
-    version: 0.8.0.0
-    sha256: ef827ea5e8581cd68da9600660b2e584877d4fcdcf1cd2eb4652e0e51d817465
     pantry-tree:
+      sha256: c14fd8b9ad5e9fcf629e50affe26e655d6c4d18c3f77169995b857b5fd32ca44
       size: 3769
-      sha256: e30301b5389893948e25d39978d09948b11479b5b2a3517b978466fde548fc48
+    sha256: 3997e23bacea83e1e6b94098f74378fa54baf99755a0d834d9008bfe7071ed58
+    size: 74277
+    url: https://github.com/unisonweb/haskeline/archive/9275eea7982dabbf47be2ba078ced669ae7ef3d5.tar.gz
+    version: 0.8.0.0
   original:
-    url: https://github.com/judah/haskeline/archive/d6c2643b0d5c19be7e440615c6f84d603d4bc648.tar.gz
+    url: https://github.com/unisonweb/haskeline/archive/9275eea7982dabbf47be2ba078ced669ae7ef3d5.tar.gz
 - completed:
-    hackage: guid-0.1.0@sha256:a7c975be473f6f142d5cc1b39bc807a99043d20b1bb0873fdfe7a3ce84d2faf1,1078
+    hackage: fuzzyfind-3.0.1@sha256:78f89c1d79adf0a15fa2e57c693d42b4765ccfbbe380d0c9d7da6bff9f124f85,1823
     pantry-tree:
-      size: 364
-      sha256: a33838b7b1c54f6ac3e1b436b25674948713a4189658e4d82e639b9a689bc90d
-  original:
-    hackage: guid-0.1.0@sha256:a7c975be473f6f142d5cc1b39bc807a99043d20b1bb0873fdfe7a3ce84d2faf1,1078
-- completed:
-    hackage: sandi-0.5@sha256:b278d072ca717706ea38f9bd646e023f7f2576a778fb43565b434f93638849aa,3010
-    pantry-tree:
-      size: 3455
-      sha256: 5ca7ce4bc22ab9d4427bb149b5e283ab9db43375df14f7131fdfd48775f36350
-  original:
-    hackage: sandi-0.5@sha256:b278d072ca717706ea38f9bd646e023f7f2576a778fb43565b434f93638849aa,3010
-- completed:
-    hackage: fuzzyfind-3.0.0@sha256:d79a5d3ed194dd436c6b839bf187211d880cf773b2febaca456e5ccf93f5ac65,1814
-    pantry-tree:
+      sha256: 46f001ec2725d3172161c993bc8fbcf0514e3ba736f868fe2c2655e1ff49dad1
       size: 542
-      sha256: 0e6c6d4f89083c8385de5adc4f36ad01b2b0ff45261b47f7d90d919969c8b5ed
   original:
-    hackage: fuzzyfind-3.0.0@sha256:d79a5d3ed194dd436c6b839bf187211d880cf773b2febaca456e5ccf93f5ac65,1814
+    hackage: fuzzyfind-3.0.1
 - completed:
-    hackage: monad-validate-1.2.0.0@sha256:9850f408431098b28806dd464b6825a88a0b56c84f380d7fe0454c1df9d6f881,3505
+    hackage: guid-0.1.0@sha256:a7c975be473f6f142d5cc1b39bc807a99043d20b1bb0873fdfe7a3ce84d2faf1,1078
     pantry-tree:
-      size: 713
-      sha256: 8e049bd12ce2bd470909578f2ee8eb80b89d5ff88860afa30e29dd4eafecfa3e
+      sha256: a33838b7b1c54f6ac3e1b436b25674948713a4189658e4d82e639b9a689bc90d
+      size: 364
   original:
-    hackage: monad-validate-1.2.0.0@sha256:9850f408431098b28806dd464b6825a88a0b56c84f380d7fe0454c1df9d6f881,3505
-- completed:
-    hackage: NanoID-3.1.0@sha256:9118ab00e8650b5a56a10c90295d357eb77a8057a598b7e56dfedc9c6d53c77d,1524
-    pantry-tree:
-      size: 363
-      sha256: d33d603a2f0d1a220ff0d5e7edb6273def89120e6bb958c2d836cae89e788334
-  original:
-    hackage: NanoID-3.1.0@sha256:9118ab00e8650b5a56a10c90295d357eb77a8057a598b7e56dfedc9c6d53c77d,1524
-- completed:
-    hackage: direct-sqlite-2.3.27@sha256:94207d3018da3bda84bc6ce00d2c0236ced7edb37afbd726ed2a0bfa236e149b,3771
-    pantry-tree:
-      size: 770
-      sha256: c7f5afe70db567e2cf9f3119b49f4b402705e6bd08ed8ba98747a64a8a0bef41
-  original:
-    hackage: direct-sqlite-2.3.27
-- completed:
-    hackage: recover-rtti-0.4.0.0@sha256:2ce1e031ec0e34d736fa45f0149bbd55026f614939dc90ffd14a9c5d24093ff4,4423
-    pantry-tree:
-      size: 2410
-      sha256: d87d84c3f760c1b2540f74e4a301cd4e8294df891e8e4262e8bdd313bc8e0bfd
-  original:
-    hackage: recover-rtti-0.4.0.0@sha256:2ce1e031ec0e34d736fa45f0149bbd55026f614939dc90ffd14a9c5d24093ff4,4423
+    hackage: guid-0.1.0@sha256:a7c975be473f6f142d5cc1b39bc807a99043d20b1bb0873fdfe7a3ce84d2faf1,1078
 - completed:
     hackage: lock-file-0.7.0.0@sha256:3ad84b5e454145e1d928063b56abb96db24a99a21b493989520e58fa0ab37b00,4484
     pantry-tree:
-      size: 718
       sha256: 3634593ce191e82793ea0e060598ab3cf67f2ef2fe1d65345dc9335ad529d25f
+      size: 718
   original:
     hackage: lock-file-0.7.0.0@sha256:3ad84b5e454145e1d928063b56abb96db24a99a21b493989520e58fa0ab37b00,4484
 - completed:
-    hackage: http-client-0.7.11@sha256:3f59ac8ffe2a3768846cdda040a0d1df2a413960529ba61c839861c948871967,5756
+    hackage: monad-validate-1.2.0.0@sha256:9850f408431098b28806dd464b6825a88a0b56c84f380d7fe0454c1df9d6f881,3505
     pantry-tree:
-      size: 2547
-      sha256: 8372e84e9c710097f4f80f2016ca15a5a0cd7884b8ac5ce70f26b3110f4401bd
+      sha256: 8e049bd12ce2bd470909578f2ee8eb80b89d5ff88860afa30e29dd4eafecfa3e
+      size: 713
   original:
-    hackage: http-client-0.7.11
+    hackage: monad-validate-1.2.0.0@sha256:9850f408431098b28806dd464b6825a88a0b56c84f380d7fe0454c1df9d6f881,3505
 - completed:
-    hackage: lsp-1.5.0.0@sha256:1ad138526f9177965d4b5b01f9074fe0475636b2c563dcc7036fb6908f8e6189,5382
+    hackage: recover-rtti-0.4.2@sha256:c179a303921126d8d782264e14f386c96e54a270df74be002e4c4ec3c8c7aebd,4529
     pantry-tree:
-      size: 1551
-      sha256: 87526822a8ffb514d355975bca3a3f5ceb9a19eaf664cbdcde2f866c4d33878c
+      sha256: ad6f24481ebd25a1456d5dfaf08d48d95394ce83eb82a267e01d87d34f13bb83
+      size: 2488
   original:
-    hackage: lsp-1.5.0.0
-- completed:
-    hackage: lsp-types-1.5.0.0@sha256:7ed97bbc9290ad6ffb9b5a8e082226783c710fff9e4ca2df4c578b065997b1ea,4301
-    pantry-tree:
-      size: 4160
-      sha256: e45ef86a4301beb45ae7ec527e69880944a03c2d959cb0a051bf58dd0a5579f4
-  original:
-    hackage: lsp-types-1.5.0.0
-- completed:
-    hackage: text-rope-0.2@sha256:53b9b4cef0b278b9c591cd4ca76543acacf64c9d1bfbc06d0d9a88960446d9a7,2087
-    pantry-tree:
-      size: 1180
-      sha256: 51b22419f8d9bfd2a8aa3efa16b80a48e4b0c915a1d27fefe5f0b6d2d9e48312
-  original:
-    hackage: text-rope-0.2@sha256:53b9b4cef0b278b9c591cd4ca76543acacf64c9d1bfbc06d0d9a88960446d9a7,2087
-- completed:
-    hackage: co-log-core-0.3.1.0@sha256:9794bdedd1391decd0e22bdfe2b11abcb42e6cff7a4531e1f8882890828f4e63,3816
-    pantry-tree:
-      size: 584
-      sha256: d4cc089c40c5052ee02f91eafa567e0a239908aabc561dfa6080ba3bfc8c25bd
-  original:
-    hackage: co-log-core-0.3.1.0
-- completed:
-    hackage: terminal-size-0.3.3@sha256:bd5f02333982bc8d6017db257b2a0b91870a295b4a37142a0c0525d8f533a48f,1255
-    pantry-tree:
-      size: 580
-      sha256: 2a9669ed392657d34ec2e180ddac68c9ef657e54bf4b5fbc9b9efaa7b1d341be
-  original:
-    hackage: terminal-size-0.3.3
-- completed:
-    hackage: network-3.1.2.7@sha256:e3d78b13db9512aeb106e44a334ab42b7aa48d26c097299084084cb8be5c5568,4888
-    pantry-tree:
-      size: 3971
-      sha256: 1981a732d1917213de7f51d26255af733a61918c59eebb6c6f6ca939856839ef
-  original:
-    hackage: network-3.1.2.7
-- completed:
-    hackage: sqlite-simple-0.4.18.2@sha256:dda1643e723591c880dda8eeba73e93502cfa775078a79da55b5efec4c52ff66,3028
-    pantry-tree:
-      size: 1930
-      sha256: 64443740f279b344aecb3389ec8f69ea04d171916a9ed23f8fa529dd3ae75540
-  original:
-    hackage: sqlite-simple-0.4.18.2
+    hackage: recover-rtti-0.4.2@sha256:c179a303921126d8d782264e14f386c96e54a270df74be002e4c4ec3c8c7aebd,4529
 snapshots:
 - completed:
-    size: 590100
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/28.yaml
-    sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68
-  original: lts-18.28
+    sha256: 401a0e813162ba62f04517f60c7d25e93a0f867f94a902421ebf07d1fb5a8c46
+    size: 650044
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/21.yaml
+  original: lts-20.21

--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -12,7 +12,7 @@ ghc-options: -Wall
 dependencies:
   - IntervalMap
   - ListLike
-  - aeson
+  - aeson >= 2.0.0.0
   - aeson-pretty
   - ansi-terminal
   - async
@@ -42,8 +42,8 @@ dependencies:
   - ki
   - lens
   - lock-file
-  - lsp
-  - lsp-types
+  - lsp >= 1.5.0.0
+  - lsp-types >= 1.5.0.0
   - megaparsec
   - memory
   - mtl

--- a/unison-cli/src/Unison/CommandLine/Welcome.hs
+++ b/unison-cli/src/Unison/CommandLine/Welcome.hs
@@ -168,7 +168,7 @@ authorSuggestion :: P.Pretty P.ColorText
 authorSuggestion =
   P.newline
     <> P.lines
-      [ P.wrap "📜 🪶 You might want to set up your author information next.",
+      [ P.wrap "📜🪶 You might want to set up your author information next.",
         P.wrap "Type" <> P.hiBlue " create.author" <> " to create an author for this codebase",
         P.group (P.newline <> P.wrap "Read about how to link your author to your code at"),
         P.wrap $ P.blue "https://www.unison-lang.org/learn/tooling/configuration/"

--- a/unison-cli/src/Unison/LSP/Types.hs
+++ b/unison-cli/src/Unison/LSP/Types.hs
@@ -13,6 +13,8 @@ import Control.Lens hiding (List, (:<))
 import Control.Monad.Except
 import Control.Monad.Reader
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Aeson.Key
+import qualified Data.Aeson.KeyMap as Aeson.KeyMap
 import qualified Data.ByteString.Lazy.Char8 as BSC
 import qualified Data.HashMap.Strict as HM
 import Data.IntervalMap.Lazy (IntervalMap)
@@ -171,7 +173,7 @@ data Config = Config
 instance Aeson.FromJSON Config where
   parseJSON = Aeson.withObject "Config" \obj -> do
     maxCompletions <- obj Aeson..:! "maxCompletions" Aeson..!= maxCompletions defaultLSPConfig
-    let invalidKeys = Set.fromList (HM.keys obj) `Set.difference` validKeys
+    let invalidKeys = Set.fromList (map Aeson.Key.toText (Aeson.KeyMap.keys obj)) `Set.difference` validKeys
     when (not . null $ invalidKeys) do
       fail . Text.unpack $
         "Unrecognized configuration key(s): "

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -142,7 +142,7 @@ library
   build-depends:
       IntervalMap
     , ListLike
-    , aeson
+    , aeson >=2.0.0.0
     , aeson-pretty
     , ansi-terminal
     , async
@@ -173,8 +173,8 @@ library
     , ki
     , lens
     , lock-file
-    , lsp
-    , lsp-types
+    , lsp >=1.5.0.0
+    , lsp-types >=1.5.0.0
     , megaparsec
     , memory
     , mtl
@@ -271,7 +271,7 @@ executable cli-integration-tests
   build-depends:
       IntervalMap
     , ListLike
-    , aeson
+    , aeson >=2.0.0.0
     , aeson-pretty
     , ansi-terminal
     , async
@@ -304,8 +304,8 @@ executable cli-integration-tests
     , ki
     , lens
     , lock-file
-    , lsp
-    , lsp-types
+    , lsp >=1.5.0.0
+    , lsp-types >=1.5.0.0
     , megaparsec
     , memory
     , mtl
@@ -396,7 +396,7 @@ executable transcripts
   build-depends:
       IntervalMap
     , ListLike
-    , aeson
+    , aeson >=2.0.0.0
     , aeson-pretty
     , ansi-terminal
     , async
@@ -429,8 +429,8 @@ executable transcripts
     , ki
     , lens
     , lock-file
-    , lsp
-    , lsp-types
+    , lsp >=1.5.0.0
+    , lsp-types >=1.5.0.0
     , megaparsec
     , memory
     , mtl
@@ -527,7 +527,7 @@ executable unison
   build-depends:
       IntervalMap
     , ListLike
-    , aeson
+    , aeson >=2.0.0.0
     , aeson-pretty
     , ansi-terminal
     , async
@@ -559,8 +559,8 @@ executable unison
     , ki
     , lens
     , lock-file
-    , lsp
-    , lsp-types
+    , lsp >=1.5.0.0
+    , lsp-types >=1.5.0.0
     , megaparsec
     , memory
     , mtl
@@ -664,7 +664,7 @@ test-suite cli-tests
   build-depends:
       IntervalMap
     , ListLike
-    , aeson
+    , aeson >=2.0.0.0
     , aeson-pretty
     , ansi-terminal
     , async
@@ -697,8 +697,8 @@ test-suite cli-tests
     , ki
     , lens
     , lock-file
-    , lsp
-    , lsp-types
+    , lsp >=1.5.0.0
+    , lsp-types >=1.5.0.0
     , megaparsec
     , memory
     , mtl

--- a/unison-hashing-v2/src/Unison/Hashing/V2/Term.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/Term.hs
@@ -163,8 +163,6 @@ instance (Var v) => Hashable1 (TermF v a p) where
                       B.Recorded (B.Resolve _ s) ->
                         [tag 2, Hashable.Text (Text.pack s)]
                   TermRef (ReferenceBuiltin name) -> [tag 2, accumulateToken name]
-                  TermRef ReferenceDerived {} ->
-                    error "handled above, but GHC can't figure this out"
                   TermApp a a2 -> [tag 3, hashed (hash a), hashed (hash a2)]
                   TermAnn a t -> [tag 4, hashed (hash a), hashed (ABT.hash t)]
                   TermList as ->

--- a/unison-share-api/package.yaml
+++ b/unison-share-api/package.yaml
@@ -10,7 +10,7 @@ library:
 
 dependencies:
   - NanoID
-  - aeson
+  - aeson >= 2.0.0.0
   - async
   - base
   - binary

--- a/unison-share-api/src/Unison/Server/Doc.hs
+++ b/unison-share-api/src/Unison/Server/Doc.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
 module Unison.Server.Doc where
 

--- a/unison-share-api/src/Unison/Server/Doc.hs
+++ b/unison-share-api/src/Unison/Server/Doc.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
 module Unison.Server.Doc where
 
@@ -360,7 +359,9 @@ evalDoc terms typeOf eval types tm =
          in goSignatures rs <&> \s -> ESignature s
       -- SignatureInline Doc2.Term
       DD.Doc2SpecialFormSignatureInline (DD.Doc2Term (Term.Referent' r)) ->
-        goSignatures [r] <&> \[s] -> ESignatureInline s
+        goSignatures [r] <&> \case
+          [s] -> ESignatureInline s
+          _ -> error "impossible error: evalDoc: expected exactly one signature"
       -- Eval Doc2.Term
       DD.Doc2SpecialFormEval (DD.Doc2Term tm) -> do
         result <- eval tm

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -78,7 +78,7 @@ library
   ghc-options: -Wall
   build-depends:
       NanoID
-    , aeson
+    , aeson >=2.0.0.0
     , async
     , base
     , binary

--- a/unison-share-projects-api/src/Unison/Share/API/Hash.hs
+++ b/unison-share-projects-api/src/Unison/Share/API/Hash.hs
@@ -17,8 +17,7 @@ import Control.Lens (folding, ix, (^?))
 import qualified Crypto.JWT as Jose
 import Data.Aeson
 import qualified Data.Aeson as Aeson
-import qualified Data.HashMap.Strict as HashMap
-import qualified Data.Map.Strict as Map
+import qualified Data.Aeson.KeyMap as Aeson.KeyMap
 import qualified Servant.Auth.JWT as Servant.Auth
 import Unison.Hash32 (Hash32)
 import Unison.Hash32.Orphans.Aeson ()
@@ -101,8 +100,7 @@ decodeHashJWTClaims (HashJWT text) =
               & JWT.claims
               & JWT.unregisteredClaims
               & JWT.unClaimsMap
-              & Map.toList
-              & HashMap.fromList
+              & Aeson.KeyMap.fromMapText
               & Aeson.Object
        in case Aeson.fromJSON object of
             Aeson.Error err -> error ("bad JWT: " ++ err)

--- a/unison-share-projects-api/src/Unison/Share/API/Projects.hs
+++ b/unison-share-projects-api/src/Unison/Share/API/Projects.hs
@@ -38,6 +38,7 @@ module Unison.Share.API.Projects
 where
 
 import Data.Aeson
+import qualified Data.Aeson.Key as Aeson.Key
 import qualified Data.Aeson.KeyMap as Aeson.KeyMap
 import Data.Aeson.Types
 import Data.Monoid (Endo (..))
@@ -47,7 +48,6 @@ import Unison.Hash32 (Hash32)
 import Unison.Hash32.Orphans.Aeson ()
 import Unison.Prelude
 import Unison.Share.API.Hash (HashJWT)
-import qualified Data.Aeson.Key as Aeson.Key
 
 type ProjectsAPI =
   GetProjectAPI

--- a/unison-share-projects-api/src/Unison/Share/API/Projects.hs
+++ b/unison-share-projects-api/src/Unison/Share/API/Projects.hs
@@ -38,8 +38,8 @@ module Unison.Share.API.Projects
 where
 
 import Data.Aeson
+import qualified Data.Aeson.KeyMap as Aeson.KeyMap
 import Data.Aeson.Types
-import qualified Data.HashMap.Strict as HashMap
 import Data.Monoid (Endo (..))
 import qualified Data.Text as Text
 import Servant.API
@@ -47,6 +47,7 @@ import Unison.Hash32 (Hash32)
 import Unison.Hash32.Orphans.Aeson ()
 import Unison.Prelude
 import Unison.Share.API.Hash (HashJWT)
+import qualified Data.Aeson.Key as Aeson.Key
 
 type ProjectsAPI =
   GetProjectAPI
@@ -440,14 +441,14 @@ instance FromJSON Unauthorized where
 -- using this combinator.
 objectWithMaybes :: [Pair] -> [Endo Object] -> Value
 objectWithMaybes nonMaybeFields maybeFields =
-  Object (appEndo (fold maybeFields) (HashMap.fromList nonMaybeFields))
+  Object (appEndo (fold maybeFields) (Aeson.KeyMap.fromList nonMaybeFields))
 
 -- | Like ('.='), but omits the key/value pair if the value is Nothing.
 (.=?) :: (ToJSON a) => Text -> Maybe a -> Endo Object
 k .=? mv =
   case mv of
     Nothing -> mempty
-    Just v -> Endo (HashMap.insert k (toJSON v))
+    Just v -> Endo (Aeson.KeyMap.insert (Aeson.Key.fromText k) (toJSON v))
 
 toSumType :: Text -> Value -> Value
 toSumType typ payload =


### PR DESCRIPTION
## Overview

- [ ] open PR to update enlil (wip, could use some help)

Builds on #3304 and #3642 Mitchell's work from December to bring us up to a recent LTS.  The lts version in this PR is currently the newest (20.21). Windows haskeline bugs killed the previous attempt.

closes #3642 (can a PR auto-close a PR?)
closes #3945 (new commit is unisonweb/haskeline@9275eea7982dabbf47be2ba078ced669ae7ef3d5)
closes #3034 (or at least can't repro)

## Implementation notes

To fix Windows haskeline, I took our existing now-off-branch haskeline commit, updated it for the new LTS, and pushed it to https://github.com/unisonweb/haskeline/tree/unison-23-05-20, which is not a very good name, but it's better than no name.
Thing that didn't work last time: Take the latest version of haskeline and apply the patch we thought was needed to make ANSI work. Something new has changed in haskeline to make this insufficient or totally wrong.

## Test coverage

Manually checked the ANSI prompt in Windows (pic is of vscode embedded terminal):
<img width="781" alt="image" src="https://github.com/unisonweb/unison/assets/538571/7aa01192-f0d4-4938-a6b7-99ee252191a2">

## Loose ends

1. I had to turn use `{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}` here and there to build successfully with GHC 9.2.7. Tagging people who last modified the code in question:
* parser-typechecker/src/Unison/PatternMatchCoverage/Solve.hs cc @tstat 
* unison-share-api/src/Unison/Server/Doc.hs cc @ChrisPenner 

2. If we want to update to a newer haskeline than this 8.0.0, we'll have to carefully replay the commits to get there. :-\