### PR TITLE
Attempt to fix mac pre-release builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
         os:
           # While iterating on this file, you can disable one or more of these to speed things up
           - ubuntu-20.04
-          - macOS-11.0
+          - macOS-12
           - windows-2019
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -53,7 +53,7 @@ jobs:
 
   build_macos:
     name: "build_macos"
-    runs-on: macos-10.15
+    runs-on: macos-12
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -132,7 +132,7 @@ jobs:
 
   build_macos:
     name: "build_macos"
-    runs-on: macos-11
+    runs-on: macos-12
     env:
       UNISON_BASE_PATH: "${{inputs.share_base_path}}"
     steps:
@@ -151,11 +151,11 @@ jobs:
           # recent branch cache.
           # Then it will save a new cache at this commit sha, which should be used by
           # the next build on this branch.
-          key: stack-0_macOS-11.0-${{hashFiles('stack.yaml')}}-${{github.sha}}
+          key: stack-0_macOS-12-${{hashFiles('stack.yaml')}}-${{github.sha}}
           # Fall-back to use the most recent cache for the stack.yaml, or failing that the OS
           restore-keys: |
-            stack-0_macOS-11.0-${{hashFiles('stack.yaml')}}
-            stack-0_macOS-11.0
+            stack-0_macOS-12-${{hashFiles('stack.yaml')}}
+            stack-0_macOS-12
 
       # Cache each local package's ~/.stack-work for fast incremental builds in CI.
       - uses: actions/cache@v3
@@ -169,8 +169,8 @@ jobs:
           # recent branch cache.
           # Then it will save a new cache at this commit sha, which should be used by
           # the next build on this branch.
-          key: stack-work-3_macOS-11.0-${{github.sha}}
-          restore-keys: stack-work-3_macOS-11.0
+          key: stack-work-3_macOS-12-${{github.sha}}
+          restore-keys: stack-work-3_macOS-12
 
       - name: install stack (macOS)
         working-directory: ${{ github.workspace }}


### PR DESCRIPTION
The macOS pre-release builds haven't been running recently. I suspect
it's because they were on an older version of macOS (10.15) that GitHub
Actions no longer supports. I updated them to use a newer version (12)
and while I was at it I updated the other jobs from 11 to 12. There were
also some cache keys that had `macos-11.0` in the path, so I changed
those to `macos-12`. Admittedly I have no idea what I'm doing and this
might not work.
