### PR TITLE
Sql query interpolation

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -3272,7 +3272,7 @@ loadRemoteProjectBranchGen loadRemoteBranchFlag pid remoteUri bid =
           depth
         FROM
           t
-        [whereClause]
+        $whereClause
         ORDER BY
           depth
         LIMIT 1
@@ -3282,12 +3282,12 @@ loadRemoteProjectBranchGen loadRemoteBranchFlag pid remoteUri bid =
     whereClause =
       let clauses =
             foldr
-              (\a b -> [sql2| [a] AND [b] |])
+              (\a b -> [sql2| $a AND $b |])
               [sql2| TRUE |]
               [ [sql2| remote_project_id IS NOT NULL |],
                 selfRemoteFilter
               ]
-       in [sql2| WHERE [clauses] |]
+       in [sql2| WHERE $clauses |]
 
     selfRemoteFilter = case loadRemoteBranchFlag of
       IncludeSelfRemote -> [sql2| TRUE |]

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -277,7 +277,6 @@ import Data.String.Here.Uninterpolated (here, hereFile)
 import qualified Data.Text as Text
 import qualified Data.Vector as Vector
 import GHC.Stack (callStack)
-import NeatInterpolation (trimming)
 import Network.URI (URI)
 import U.Codebase.Branch.Type (NamespaceStats (..))
 import qualified U.Codebase.Decl as C

--- a/codebase2/codebase-sqlite/package.yaml
+++ b/codebase2/codebase-sqlite/package.yaml
@@ -22,7 +22,6 @@ dependencies:
   - lens
   - monad-validate
   - mtl
-  - neat-interpolation
   - network-uri
   - network-uri-orphans-sqlite
   - nonempty-containers

--- a/codebase2/codebase-sqlite/unison-codebase-sqlite.cabal
+++ b/codebase2/codebase-sqlite/unison-codebase-sqlite.cabal
@@ -106,7 +106,6 @@ library
     , lens
     , monad-validate
     , mtl
-    , neat-interpolation
     , network-uri
     , network-uri-orphans-sqlite
     , nonempty-containers

--- a/lib/unison-sqlite/src/Unison/Sqlite/Connection.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Connection.hs
@@ -197,14 +197,14 @@ instance Show Query2 where
       ]
 
 -- Will replace `logQuery` when `sql2` replaces `sql` everywhere.
-logQuery2 :: Sql -> [Either Sqlite.SQLData [Sqlite.SQLData]] -> Maybe b -> IO ()
+logQuery2 :: Sql -> [Sqlite.SQLData] -> Maybe b -> IO ()
 logQuery2 sql params result =
   Debug.whenDebug Debug.Sqlite do
     callStack <- currentCallStack
     pTraceShowM
       Query2
         { sql,
-          params = flattenParameters params,
+          params,
           result = anythingToString <$> result,
           callStack
         }
@@ -231,7 +231,7 @@ execute2 conn@(Connection _ _ conn0) (Sql2 s params) = do
       SqliteQueryExceptionInfo
         { connection = conn,
           exception = SomeSqliteExceptionReason exception,
-          params = Just (flattenParameters params),
+          params = Just params,
           sql = Sql s
         }
   where
@@ -350,7 +350,7 @@ queryListRow2 conn@(Connection _ _ conn0) (Sql2 s params) = do
           SqliteQueryExceptionInfo
             { connection = conn,
               exception = SomeSqliteExceptionReason exception,
-              params = Just (flattenParameters params),
+              params = Just params,
               sql = Sql s
             }
   logQuery2 (Sql s) params (Just result)
@@ -472,7 +472,7 @@ gqueryListCheck2 conn s@(Sql2 sql params) check = do
         SqliteQueryExceptionInfo
           { connection = conn,
             exception,
-            params = Just (flattenParameters params),
+            params = Just params,
             sql = Sql sql
           }
     Right result -> pure result
@@ -771,31 +771,16 @@ release conn name =
 -----------------------------------------------------------------------------------------------------------------------
 -- Utils
 
-bindParameters :: Direct.Sqlite.Statement -> [Either Sqlite.SQLData [Sqlite.SQLData]] -> IO ()
+bindParameters :: Direct.Sqlite.Statement -> [Sqlite.SQLData] -> IO ()
 bindParameters statement =
-  loop1 1
+  loop 1
   where
-    loop1 :: Direct.Sqlite.ParamIndex -> [Either Sqlite.SQLData [Sqlite.SQLData]] -> IO ()
-    loop1 !i = \case
+    loop :: Direct.Sqlite.ParamIndex -> [Sqlite.SQLData] -> IO ()
+    loop !i = \case
       [] -> pure ()
-      Left p : ps -> do
-        Direct.Sqlite.bindSQLData statement i p
-        loop1 (i + 1) ps
-      Right ps : qs -> do
-        j <- loop2 i ps
-        loop1 j qs
-    loop2 :: Direct.Sqlite.ParamIndex -> [Sqlite.SQLData] -> IO Direct.Sqlite.ParamIndex
-    loop2 !i = \case
-      [] -> pure i
       p : ps -> do
         Direct.Sqlite.bindSQLData statement i p
-        loop2 (i + 1) ps
-
--- On happy paths we can just bind all of the parameters in this Either form - no need to pay for flattening. But for
--- logging or reporting exceptions, we flatten.
-flattenParameters :: [Either Sqlite.SQLData [Sqlite.SQLData]] -> [Sqlite.SQLData]
-flattenParameters =
-  foldMap (either pure id)
+        loop (i + 1) ps
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Exceptions

--- a/lib/unison-sqlite/src/Unison/Sqlite/Sql2.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Sql2.hs
@@ -10,7 +10,6 @@ module Unison.Sqlite.Sql2
   )
 where
 
-import Control.Lens (use, (%=), (.=), (<>=))
 import qualified Control.Monad.Trans.State.Strict as State
 import qualified Data.Char as Char
 import Data.Generics.Labels ()
@@ -19,6 +18,7 @@ import qualified Database.SQLite.Simple as Sqlite.Simple
 import qualified Database.SQLite.Simple.ToField as Sqlite.Simple
 import qualified Language.Haskell.TH as TH
 import qualified Language.Haskell.TH.Quote as TH
+import qualified Language.Haskell.TH.Syntax as TH
 import qualified Text.Builder
 import qualified Text.Builder as Text (Builder)
 import qualified Text.Megaparsec as Megaparsec
@@ -83,33 +83,57 @@ sql2QQ :: String -> TH.Q TH.Exp
 sql2QQ input =
   case internalParseSql (Text.pack input) of
     Left err -> fail err
-    Right (query, params0) -> do
-      let params :: [TH.Q TH.Exp]
-          params =
-            map
-              ( \case
-                  FieldParam var ->
-                    TH.lookupValueName (Text.unpack var) >>= \case
-                      Nothing -> fail ("Not in scope: " ++ Text.unpack var)
-                      Just name -> [|Left (Sqlite.Simple.toField $(TH.varE name))|]
-                  RowParam var _count ->
-                    TH.lookupValueName (Text.unpack var) >>= \case
-                      Nothing -> fail ("Not in scope: " ++ Text.unpack var)
-                      Just name -> [|Right (Sqlite.Simple.toRow $(TH.varE name))|]
-              )
-              params0
-      [|Sql2 query $(TH.listE params)|]
+    Right lumps -> do
+      boingo <-
+       for lumps \case
+        Left (s, params) -> do
+          params1 <- traverse ff params
+          s1 <- TH.lift s
+          pure (s1, TH.ListE params1)
+        Right lump2 -> gg lump2
+      let (boingo1, boingo2) = unzip boingo
+      [| Sql2 (fold $(pure (TH.ListE boingo1))) (fold $(pure (TH.ListE boingo2))) |]
+  where
+    ff :: Param -> TH.Q TH.Exp
+    ff = \case
+      FieldParam var ->
+        TH.lookupValueName (Text.unpack var) >>= \case
+          Nothing -> fail ("Not in scope: " ++ Text.unpack var)
+          Just name -> [| Left (Sqlite.Simple.toField $(TH.varE name)) |]
+      RowParam var _count ->
+        TH.lookupValueName (Text.unpack var) >>= \case
+          Nothing -> fail ("Not in scope: " ++ Text.unpack var)
+          Just name -> [| Right (Sqlite.Simple.toRow $(TH.varE name)) |]
 
--- | Parse a SQL string, and return the prettefied SQL string along with the named parameters it contains.
+    gg :: Text -> TH.Q (TH.Exp, TH.Exp)
+    gg var =
+      TH.lookupValueName (Text.unpack var) >>= \case
+        Nothing -> fail ("Not in scope: " ++ Text.unpack var)
+        Just name -> do
+          honk <- [| query $(TH.varE name) |]
+          plonk <- [| params $(TH.varE name) |]
+          pure (honk, plonk)
+
+-- | Parse a SQL string, and return the list of lumps, where each Left is a prettefied SQL string along with the named
+-- parameters it contains, and each Right is the name of a query to be interpolated.
 --
 -- Exported only for testing.
-internalParseSql :: Text -> Either String (Text, [Param])
+internalParseSql :: Text -> Either String [Either (Text, [Param]) Text]
 internalParseSql input =
   case runP (parser <* Megaparsec.eof) (Text.strip input) of
     Left err -> Left (Megaparsec.errorBundlePretty err)
-    Right ((), S {sql, params}) -> Right (Text.Builder.run sql, reverse params)
+    Right ((), lumps) -> Right (map unlump (reverse lumps))
+  where
+    unlump = \case
+      OuterLump sql params -> Left (Text.Builder.run sql, reverse params)
+      InnerLump query -> Right query
 
--- Parser state: the SQL parsed so far, and a list of parameter names (in reverse order).
+-- Parser state.
+--
+-- A simple query (without *query* interpolation) is a single "outer lump", which contains:
+--
+--   * The SQL parsed so far
+--   * A list of parameter names in reverse order
 --
 -- For example, if we were partway through parsing the query
 --
@@ -117,12 +141,11 @@ internalParseSql input =
 --   FROM bar
 --   WHERE baz = :bonk AND qux = 'monk'
 --
--- then we would have the state
+-- then we would have an outer lump that looks like
 --
---   S
---     { sql = "SELECT foo FROM bar WHERE baz = ? AND "
---     , params = [FieldParam "bonk"]
---     }
+--   OuterLump
+--     "SELECT foo FROM bar WHERE baz = ? AND "
+--     [FieldParam "bonk"]
 --
 -- There are two ways to specify parameters:
 --
@@ -137,11 +160,29 @@ internalParseSql input =
 --      space. This lets us write vertically aligned SQL queries at arbitrary indentations in Haskell quasi-quoters,
 --      but not have to look at a bunch of "\n        " in debug logs and such.
 --   3. We strip comments.
-data S = S
-  { sql :: !Text.Builder,
-    params :: ![Param]
-  }
-  deriving stock (Generic)
+--
+-- More generally, the full parser state tracks a list of alternating "outer" and "inner" lumps (in reverse order),
+-- where an inner lump is simply a single Haskell variable name, and denotes a sql query to be interpolated into the
+-- query.
+--
+-- Example:
+--
+--   [sql| one [two] :three [four] |]
+--        ^    ^    ^       ^     ^
+--        |    |    |       |     |
+--        |    |    |       |     ` OuterLump " " []
+--        |    |    |       |
+--        |    |    |       ` InnerLump "four"
+--        |    |    |
+--        |    |    ` OuterLump " ? " ["three"]
+--        |    |
+--        |    ` InnerLump "two"
+--        |
+--        ` OuterLump " one " []
+--
+data Lump
+  = OuterLump !Text.Builder ![Param]
+  | InnerLump !Text -- [foo] ==> InnerLump "foo"
 
 data Param
   = FieldParam !Text -- :foo ==> FieldParam "foo"
@@ -149,45 +190,54 @@ data Param
   deriving stock (Eq, Show)
 
 type P a =
-  State.StateT S (Megaparsec.Parsec Void Text) a
+  State.StateT [Lump] (Megaparsec.Parsec Void Text) a
 
-runP :: P a -> Text -> Either (Megaparsec.ParseErrorBundle Text Void) (a, S)
+runP :: P a -> Text -> Either (Megaparsec.ParseErrorBundle Text Void) (a, [Lump])
 runP p =
-  Megaparsec.runParser (State.runStateT p (S mempty [])) ""
+  Megaparsec.runParser (State.runStateT p []) ""
 
 -- Parser for a SQL query (stored in the parser state).
 parser :: P ()
 parser = do
   fragmentParser >>= \case
     Comment -> parser
-    NonParam fragment -> do
-      #sql <>= fragment
-      parser
-    AtParam param -> do
-      #sql <>= Text.Builder.char '?'
-      -- Either we parsed a bare "@", in which case we want to bump the int count of the latest field we walked over (
-      -- which must be a RowField, otherwise the query is invalid as it begins some string of @-params with a bare @),
-      -- or we parsed a new "@foo@ row param
-      let param1 = Text.Builder.run param
-      if Text.null param1
-        then do
-          use #params >>= \case
-            RowParam name count : ps -> #params .= (RowParam name (count + 1) : ps)
-            _ -> fail ("Invalid query: encountered unnamed-@ without a preceding named-@, like `@foo`")
-        else #params %= (RowParam param1 1 :)
-      parser
-    ColonParam param -> do
-      #sql <>= Text.Builder.char '?'
-      #params %= (FieldParam (Text.Builder.run param) :)
-      parser
-    DollarParam param -> do
-      #sql <>= Text.Builder.char '?'
-      #params %= (FieldParam (Text.Builder.run param) :)
-      parser
-    Whitespace -> do
-      #sql <>= Text.Builder.char ' '
-      parser
+    NonParam fragment -> outer fragment pure
+    AtParam param ->
+      outer
+        qmark
+        -- Either we parsed a bare "@", in which case we want to bump the int count of the latest field we walked over
+        -- (which must be a RowField, otherwise the query is invalid as it begins some string of @-params with a bare
+        -- @), or we parsed a new "@foo@ row param
+        let param1 = Text.Builder.run param
+         in if Text.null param1
+              then \case
+                RowParam name count : params -> do
+                  let !count' = count + 1
+                  pure (RowParam name count' : params)
+                _ -> fail ("Invalid query: encountered unnamed-@ without a preceding named-@, like `@foo`")
+              else \params -> pure (RowParam param1 1 : params)
+    ColonParam param -> field param
+    DollarParam param -> field param
+    Whitespace -> outer (Text.Builder.char ' ') pure
     EndOfInput -> pure ()
+  where
+    outer :: Text.Builder -> ([Param] -> P [Param]) -> P ()
+    outer s g = do
+      State.get >>= \case
+        OuterLump sql params : lumps -> do
+          let !sql' = sql <> s
+          params' <- g params
+          State.put (OuterLump sql' params' : lumps)
+        lumps -> do
+          params <- g []
+          State.put (OuterLump s params : lumps)
+      parser
+
+    field :: Text.Builder -> P ()
+    field param =
+      outer qmark \params -> pure (FieldParam (Text.Builder.run param) : params)
+
+    qmark = Text.Builder.char '?'
 
 -- A single fragment, where a list of fragments (always ending in EndOfFile) makes a whole query.
 --

--- a/lib/unison-sqlite/test/Main.hs
+++ b/lib/unison-sqlite/test/Main.hs
@@ -16,15 +16,10 @@ test =
             let sql = "   foo :a\n   'foo''foo' :b\n   \"foo\"\"foo\" $c\n   `foo``foo`   \n[foo] $d  "
             let expected =
                   Right
-                    [ Left
-                        ( "foo ? 'foo''foo' ? \"foo\"\"foo\" ? `foo``foo` ",
-                          [ FieldParam "a",
-                            FieldParam "b",
-                            FieldParam "c"
-                          ]
-                        ),
-                      Right "foo",
-                      Left (" ?", [FieldParam "d"])
+                    [ Left ("foo ? 'foo''foo' ? \"foo\"\"foo\" ", [FieldParam "a", FieldParam "b"]),
+                      Right "c",
+                      Left (" `foo``foo` [foo] ", []),
+                      Right "d"
                     ]
             let actual = internalParseSql sql
             expectEqual expected actual,

--- a/lib/unison-sqlite/test/Main.hs
+++ b/lib/unison-sqlite/test/Main.hs
@@ -16,28 +16,31 @@ test =
             let sql = "   foo :a\n   'foo''foo' :b\n   \"foo\"\"foo\" $c\n   `foo``foo`   \n[foo] $d  "
             let expected =
                   Right
-                    ( "foo ? 'foo''foo' ? \"foo\"\"foo\" ? `foo``foo` [foo] ?",
-                      [ FieldParam "a",
-                        FieldParam "b",
-                        FieldParam "c",
-                        FieldParam "d"
-                      ]
-                    )
+                    [ Left
+                        ( "foo ? 'foo''foo' ? \"foo\"\"foo\" ? `foo``foo` ",
+                          [ FieldParam "a",
+                            FieldParam "b",
+                            FieldParam "c"
+                          ]
+                        ),
+                      Right "foo",
+                      Left (" ?", [FieldParam "d"])
+                    ]
             let actual = internalParseSql sql
             expectEqual expected actual,
           scope "parses @param syntax" do
             let sql = "@foo @bar @"
-            let expected = Right ("? ? ?", [RowParam "foo" 1, RowParam "bar" 2])
+            let expected = Right [Left ("? ? ?", [RowParam "foo" 1, RowParam "bar" 2])]
             let actual = internalParseSql sql
             expectEqual expected actual,
           scope "strips line comments" do
             let sql = "foo -- bar \n baz"
-            let expected = Right ("foo baz", [])
+            let expected = Right [Left ("foo baz", [])]
             let actual = internalParseSql sql
             expectEqual expected actual,
           scope "strips block comments" do
             let sql = "foo /* bar baz \n */ qux"
-            let expected = Right ("foo qux", [])
+            let expected = Right [Left ("foo qux", [])]
             let actual = internalParseSql sql
             expectEqual expected actual
         ]


### PR DESCRIPTION
## Overview

This PR adds query interpolation to our SQL quasi-quoter with `$dollar` syntax.

For example, this query

```haskell
query :: Sql2
query =
  [sql2|
    SELECT $columns
    FROM $table
    WHERE $condition
  |]
  where
    columns = [sql2| foo, bar |]
    table = [sql2| baz |]
    condition = [sql2| qux = 10 |]
```

is equivalent to

```haskell
query :: Sql2
query =
  [sql2|
    SELECT foo, bar
    FROM baz
    WHERE qux = 10
  |]
```

I've rewritten our one SQL query that is composed of multiple little fragments like this (`loadRemoteProjectBranchGen`), and I've also smuggled some minor cleanup into this PR.

## Test coverage

There's an automated test for the parser, and I also tested this manually at the repl.