### PR TITLE
rename files with `'` in the name

### DIFF
--- a/lib/unison-pretty-printer/src/Unison/Util/SyntaxText.hs
+++ b/lib/unison-pretty-printer/src/Unison/Util/SyntaxText.hs
@@ -4,7 +4,7 @@ import Unison.HashQualified (HashQualified)
 import Unison.Name (Name)
 import Unison.Pattern (SeqOp)
 import Unison.Prelude
-import Unison.GReferent (Referent')
+import Unison.ReferentG (Referent')
 import Unison.Util.AnnotatedText (AnnotatedText (..), annotate, segment)
 
 type SyntaxText' r = AnnotatedText (Element r)

--- a/lib/unison-pretty-printer/src/Unison/Util/SyntaxText.hs
+++ b/lib/unison-pretty-printer/src/Unison/Util/SyntaxText.hs
@@ -4,7 +4,7 @@ import Unison.HashQualified (HashQualified)
 import Unison.Name (Name)
 import Unison.Pattern (SeqOp)
 import Unison.Prelude
-import Unison.Referent' (Referent')
+import Unison.GReferent (Referent')
 import Unison.Util.AnnotatedText (AnnotatedText (..), annotate, segment)
 
 type SyntaxText' r = AnnotatedText (Element r)

--- a/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
+++ b/parser-typechecker/src/Unison/Codebase/BranchUtil.hs
@@ -31,8 +31,8 @@ import qualified Unison.Codebase.Metadata as Metadata
 import Unison.Codebase.Patch (Patch)
 import Unison.Codebase.Path (Path)
 import qualified Unison.Codebase.Path as Path
-import Unison.HashQualified' (HashQualified (HashQualified, NameOnly))
-import qualified Unison.HashQualified' as HQ'
+import Unison.HashQualified2 (HashQualified (HashQualified, NameOnly))
+import qualified Unison.HashQualified2 as HQ'
 import Unison.NameSegment (NameSegment)
 import Unison.Names (Names)
 import qualified Unison.Names as Names

--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -88,7 +88,7 @@ import Data.Sequence (Seq ((:<|), (:|>)))
 import qualified Data.Sequence as Seq
 import qualified Data.Text as Text
 import qualified GHC.Exts as GHC
-import qualified Unison.HashQualified' as HQ'
+import qualified Unison.HashQualified2 as HQ'
 import Unison.Name (Convert (..), Name, Parse)
 import qualified Unison.Name as Name
 import Unison.NameSegment (NameSegment (NameSegment))

--- a/parser-typechecker/src/Unison/Codebase/Path/Parse.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path/Parse.hs
@@ -22,7 +22,7 @@ import Data.Bifunctor (first)
 import Data.List.Extra (stripPrefix)
 import qualified Data.Text as Text
 import Unison.Codebase.Path
-import qualified Unison.HashQualified' as HQ'
+import qualified Unison.HashQualified2 as HQ'
 import Unison.NameSegment (NameSegment (NameSegment))
 import qualified Unison.NameSegment as NameSegment
 import Unison.Prelude hiding (empty, toList)

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema1To2.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema1To2.hs
@@ -72,7 +72,7 @@ import qualified Unison.Pattern as Pattern
 import Unison.Prelude
 import qualified Unison.Reference as Reference
 import qualified Unison.Referent as Referent
-import qualified Unison.Referent' as Referent'
+import qualified Unison.GReferent as Referent'
 import qualified Unison.Sqlite as Sqlite
 import Unison.Symbol (Symbol)
 import qualified Unison.Term as Term

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema1To2.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema1To2.hs
@@ -72,7 +72,7 @@ import qualified Unison.Pattern as Pattern
 import Unison.Prelude
 import qualified Unison.Reference as Reference
 import qualified Unison.Referent as Referent
-import qualified Unison.GReferent as Referent'
+import qualified Unison.ReferentG as Referent'
 import qualified Unison.Sqlite as Sqlite
 import Unison.Symbol (Symbol)
 import qualified Unison.Term as Term

--- a/parser-typechecker/src/Unison/PrettyPrintEnv.hs
+++ b/parser-typechecker/src/Unison/PrettyPrintEnv.hs
@@ -28,7 +28,7 @@ import Unison.ConstructorReference (ConstructorReference)
 import qualified Unison.ConstructorType as CT
 import Unison.HashQualified (HashQualified)
 import qualified Unison.HashQualified as HQ
-import qualified Unison.HashQualified' as HQ'
+import qualified Unison.HashQualified2 as HQ'
 import Unison.LabeledDependency (LabeledDependency)
 import qualified Unison.LabeledDependency as LD
 import Unison.Name (Name)

--- a/parser-typechecker/src/Unison/PrettyPrintEnv/Names.hs
+++ b/parser-typechecker/src/Unison/PrettyPrintEnv/Names.hs
@@ -4,7 +4,7 @@ module Unison.PrettyPrintEnv.Names (fromNames, fromSuffixNames) where
 
 import Data.Bifunctor (second)
 import qualified Data.Set as Set
-import qualified Unison.HashQualified' as HQ'
+import qualified Unison.HashQualified2 as HQ'
 import Unison.Name (Name)
 import qualified Unison.Name as Name
 import qualified Unison.Names as Names

--- a/parser-typechecker/src/Unison/Syntax/NamePrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/NamePrinter.hs
@@ -1,7 +1,7 @@
 module Unison.Syntax.NamePrinter where
 
 import qualified Unison.HashQualified as HQ
-import qualified Unison.HashQualified' as HQ'
+import qualified Unison.HashQualified2 as HQ'
 import Unison.LabeledDependency (LabeledDependency)
 import qualified Unison.LabeledDependency as LD
 import Unison.Name (Name)

--- a/parser-typechecker/tests/Unison/Test/Codebase/Path.hs
+++ b/parser-typechecker/tests/Unison/Test/Codebase/Path.hs
@@ -9,7 +9,7 @@ import Data.Text
 import EasyTest
 import Unison.Codebase.Path
 import Unison.Codebase.Path.Parse
-import qualified Unison.HashQualified' as HQ'
+import qualified Unison.HashQualified2 as HQ'
 import Unison.NameSegment
 import qualified Unison.ShortHash as SH
 

--- a/unison-cli/src/Unison/Cli/MonadUtils.hs
+++ b/unison-cli/src/Unison/Cli/MonadUtils.hs
@@ -98,7 +98,7 @@ import Unison.Codebase.Path (Path, Path' (..))
 import qualified Unison.Codebase.Path as Path
 import Unison.Codebase.ShortCausalHash (ShortCausalHash)
 import qualified Unison.Codebase.ShortCausalHash as SCH
-import qualified Unison.HashQualified' as HQ'
+import qualified Unison.HashQualified2 as HQ'
 import Unison.NameSegment (NameSegment)
 import Unison.Parser.Ann (Ann (..))
 import Unison.Prelude

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -146,8 +146,8 @@ import Unison.Core.Project (ProjectAndBranch (..), ProjectBranchName, ProjectNam
 import qualified Unison.DataDeclaration as DD
 import qualified Unison.Hash as Hash
 import qualified Unison.HashQualified as HQ
-import qualified Unison.HashQualified' as HQ'
-import qualified Unison.HashQualified' as HashQualified
+import qualified Unison.HashQualified2 as HQ'
+import qualified Unison.HashQualified2 as HashQualified
 import qualified Unison.Hashing.V2.Convert as Hashing
 import Unison.LabeledDependency (LabeledDependency)
 import qualified Unison.LabeledDependency as LD
@@ -184,7 +184,7 @@ import qualified Unison.Server.NameSearch.FromNames as NameSearch
 import Unison.Server.QueryResult
 import Unison.Server.SearchResult (SearchResult)
 import qualified Unison.Server.SearchResult as SR
-import qualified Unison.Server.SearchResult' as SR'
+import qualified Unison.Server.SearchResult2 as SR'
 import qualified Unison.Share.Codeserver as Codeserver
 import qualified Unison.ShortHash as SH
 import qualified Unison.Sqlite as Sqlite

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -48,7 +48,7 @@ import Unison.Codebase.Type (GitError)
 import qualified Unison.CommandLine.InputPattern as Input
 import Unison.DataDeclaration (Decl)
 import qualified Unison.HashQualified as HQ
-import qualified Unison.HashQualified' as HQ'
+import qualified Unison.HashQualified2 as HQ'
 import Unison.LabeledDependency (LabeledDependency)
 import Unison.Name (Name)
 import Unison.NameSegment (NameSegment)
@@ -64,7 +64,7 @@ import Unison.Reference (Reference, TermReference)
 import qualified Unison.Reference as Reference
 import Unison.Referent (Referent)
 import Unison.Server.Backend (ShallowListEntry (..))
-import Unison.Server.SearchResult' (SearchResult')
+import Unison.Server.SearchResult2 (SearchResult')
 import qualified Unison.Share.Sync.Types as Sync
 import Unison.ShortHash (ShortHash)
 import Unison.Symbol (Symbol)

--- a/unison-cli/src/Unison/Codebase/Editor/Output/BranchDiff.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output/BranchDiff.hs
@@ -13,7 +13,7 @@ import qualified Unison.Codebase.Metadata as Metadata
 import qualified Unison.Codebase.Patch as P
 import Unison.DataDeclaration (DeclOrBuiltin)
 import qualified Unison.HashQualified as HQ
-import Unison.HashQualified' (HashQualified)
+import Unison.HashQualified2 (HashQualified)
 import Unison.Name (Name)
 import qualified Unison.Name as Name
 import Unison.Names (Names)

--- a/unison-cli/src/Unison/Codebase/Editor/Slurp.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Slurp.hs
@@ -21,7 +21,7 @@ import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.Referent (Referent)
 import qualified Unison.Referent as Referent
-import qualified Unison.Referent' as Referent
+import qualified Unison.GReferent as Referent
 import Unison.Symbol (Symbol)
 import qualified Unison.Syntax.Name as Name (toText, unsafeFromVar)
 import qualified Unison.UnisonFile as UF

--- a/unison-cli/src/Unison/Codebase/Editor/Slurp.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Slurp.hs
@@ -21,7 +21,7 @@ import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.Referent (Referent)
 import qualified Unison.Referent as Referent
-import qualified Unison.GReferent as Referent
+import qualified Unison.ReferentG as Referent
 import Unison.Symbol (Symbol)
 import qualified Unison.Syntax.Name as Name (toText, unsafeFromVar)
 import qualified Unison.UnisonFile as UF

--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -47,7 +47,7 @@ import qualified Unison.Codebase as Codebase
 import qualified Unison.Codebase.Path as Path
 import qualified Unison.Codebase.SqliteCodebase.Conversions as Cv
 import qualified Unison.CommandLine.InputPattern as IP
-import qualified Unison.HashQualified' as HQ'
+import qualified Unison.HashQualified2 as HQ'
 import Unison.NameSegment (NameSegment (NameSegment))
 import qualified Unison.NameSegment as NameSegment
 import Unison.Prelude

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -108,7 +108,7 @@ import qualified Unison.Hash as Hash
 import Unison.Hash32 (Hash32)
 import qualified Unison.Hash32 as Hash32
 import qualified Unison.HashQualified as HQ
-import qualified Unison.HashQualified' as HQ'
+import qualified Unison.HashQualified2 as HQ'
 import Unison.LabeledDependency as LD
 import Unison.Name (Name)
 import qualified Unison.Name as Name
@@ -137,11 +137,11 @@ import Unison.Reference (Reference, TermReference)
 import qualified Unison.Reference as Reference
 import Unison.Referent (Referent)
 import qualified Unison.Referent as Referent
-import qualified Unison.Referent' as Referent
+import qualified Unison.GReferent as Referent
 import qualified Unison.Result as Result
 import Unison.Server.Backend (ShallowListEntry (..), TypeEntry (..))
 import qualified Unison.Server.Backend as Backend
-import qualified Unison.Server.SearchResult' as SR'
+import qualified Unison.Server.SearchResult2 as SR'
 import qualified Unison.Share.Sync as Share
 import Unison.Share.Sync.Types (CodeserverTransportError (..))
 import qualified Unison.ShortHash as SH

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -137,7 +137,7 @@ import Unison.Reference (Reference, TermReference)
 import qualified Unison.Reference as Reference
 import Unison.Referent (Referent)
 import qualified Unison.Referent as Referent
-import qualified Unison.GReferent as Referent
+import qualified Unison.ReferentG as Referent
 import qualified Unison.Result as Result
 import Unison.Server.Backend (ShallowListEntry (..), TypeEntry (..))
 import qualified Unison.Server.Backend as Backend

--- a/unison-cli/src/Unison/LSP/Completion.hs
+++ b/unison-cli/src/Unison/LSP/Completion.hs
@@ -21,7 +21,7 @@ import Language.LSP.Types.Lens
 import Unison.Codebase.Path (Path)
 import qualified Unison.Codebase.Path as Path
 import qualified Unison.HashQualified as HQ
-import qualified Unison.HashQualified' as HQ'
+import qualified Unison.HashQualified2 as HQ'
 import Unison.LSP.FileAnalysis
 import qualified Unison.LSP.Queries as LSPQ
 import Unison.LSP.Types
@@ -40,7 +40,7 @@ import qualified Unison.Reference as Reference
 import qualified Unison.Referent as Referent
 import qualified Unison.Runtime.IOSource as IOSource
 import qualified Unison.Syntax.DeclPrinter as DeclPrinter
-import qualified Unison.Syntax.HashQualified' as HQ' (toText)
+import qualified Unison.Syntax.HashQualified2 as HQ' (toText)
 import qualified Unison.Syntax.Name as Name (fromText, toText)
 import qualified Unison.Syntax.TypePrinter as TypePrinter
 import qualified Unison.Util.Monoid as Monoid

--- a/unison-cli/src/Unison/LSP/FileAnalysis.hs
+++ b/unison-cli/src/Unison/LSP/FileAnalysis.hs
@@ -48,7 +48,7 @@ import Unison.Result (Note)
 import qualified Unison.Result as Result
 import Unison.Symbol (Symbol)
 import qualified Unison.Symbol as Symbol
-import qualified Unison.Syntax.HashQualified' as HQ' (toText)
+import qualified Unison.Syntax.HashQualified2 as HQ' (toText)
 import qualified Unison.Syntax.Lexer as L
 import qualified Unison.Syntax.Parser as Parser
 import qualified Unison.Syntax.TypePrinter as TypePrinter

--- a/unison-core/src/Unison/DataDeclaration.hs
+++ b/unison-core/src/Unison/DataDeclaration.hs
@@ -53,7 +53,7 @@ import Unison.Prelude
 import Unison.Reference (Reference)
 import qualified Unison.Reference as Reference
 import qualified Unison.Referent as Referent
-import qualified Unison.Referent' as Referent'
+import qualified Unison.GReferent as Referent'
 import Unison.Term (Term)
 import qualified Unison.Term as Term
 import Unison.Type (Type)

--- a/unison-core/src/Unison/DataDeclaration.hs
+++ b/unison-core/src/Unison/DataDeclaration.hs
@@ -53,7 +53,7 @@ import Unison.Prelude
 import Unison.Reference (Reference)
 import qualified Unison.Reference as Reference
 import qualified Unison.Referent as Referent
-import qualified Unison.GReferent as Referent'
+import qualified Unison.ReferentG as Referent'
 import Unison.Term (Term)
 import qualified Unison.Term as Term
 import Unison.Type (Type)

--- a/unison-core/src/Unison/GReferent.hs
+++ b/unison-core/src/Unison/GReferent.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 
-module Unison.Referent'
+module Unison.GReferent
   ( Referent' (..),
 
     -- * Basic queries
     isConstructor,
-    Unison.Referent'.fold,
+    Unison.GReferent.fold,
 
     -- * Lenses
     reference_,

--- a/unison-core/src/Unison/HashQualified2.hs
+++ b/unison-core/src/Unison/HashQualified2.hs
@@ -1,4 +1,4 @@
-module Unison.HashQualified' where
+module Unison.HashQualified2 where
 
 import qualified Data.Text as Text
 import qualified Unison.HashQualified as HQ
@@ -14,7 +14,7 @@ import Unison.ShortHash (ShortHash)
 import qualified Unison.ShortHash as SH
 import Prelude hiding (take)
 
--- | Like Unison.HashQualified, but doesn't support a HashOnly variant
+-- | Like Unison.HashQualified2, but doesn't support a HashOnly variant
 data HashQualified n = NameOnly n | HashQualified n ShortHash
   deriving stock (Eq, Functor, Generic, Foldable, Ord, Show, Traversable)
 

--- a/unison-core/src/Unison/Names.hs
+++ b/unison-core/src/Unison/Names.hs
@@ -58,7 +58,7 @@ import qualified Text.FuzzyFind as FZF
 import Unison.ConstructorReference (GConstructorReference (..))
 import qualified Unison.ConstructorType as CT
 import qualified Unison.HashQualified as HQ
-import qualified Unison.HashQualified' as HQ'
+import qualified Unison.HashQualified2 as HQ'
 import Unison.LabeledDependency (LabeledDependency)
 import qualified Unison.LabeledDependency as LD
 import Unison.Name (Name)

--- a/unison-core/src/Unison/NamesWithHistory.hs
+++ b/unison-core/src/Unison/NamesWithHistory.hs
@@ -9,7 +9,7 @@ import Unison.ConstructorReference (ConstructorReference)
 import qualified Unison.ConstructorType as CT
 import Unison.HashQualified (HashQualified)
 import qualified Unison.HashQualified as HQ
-import qualified Unison.HashQualified' as HQ'
+import qualified Unison.HashQualified2 as HQ'
 import Unison.Name (Name)
 import qualified Unison.Name as Name
 import Unison.Names (Names (..))

--- a/unison-core/src/Unison/Referent.hs
+++ b/unison-core/src/Unison/Referent.hs
@@ -38,7 +38,7 @@ import Unison.Prelude hiding (fold)
 import Unison.Reference (Reference, TermReference, TermReferenceId)
 import qualified Unison.Reference as R
 import qualified Unison.Reference as Reference
-import Unison.GReferent (Referent' (..), reference_, toReference')
+import Unison.ReferentG (Referent' (..), reference_, toReference')
 import Unison.ShortHash (ShortHash)
 import qualified Unison.ShortHash as SH
 

--- a/unison-core/src/Unison/Referent.hs
+++ b/unison-core/src/Unison/Referent.hs
@@ -38,7 +38,7 @@ import Unison.Prelude hiding (fold)
 import Unison.Reference (Reference, TermReference, TermReferenceId)
 import qualified Unison.Reference as R
 import qualified Unison.Reference as Reference
-import Unison.Referent' (Referent' (..), reference_, toReference')
+import Unison.GReferent (Referent' (..), reference_, toReference')
 import Unison.ShortHash (ShortHash)
 import qualified Unison.ShortHash as SH
 

--- a/unison-core/src/Unison/ReferentG.hs
+++ b/unison-core/src/Unison/ReferentG.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 
-module Unison.GReferent
+module Unison.ReferentG
   ( Referent' (..),
 
     -- * Basic queries
     isConstructor,
-    Unison.GReferent.fold,
+    Unison.ReferentG.fold,
 
     -- * Lenses
     reference_,

--- a/unison-core/unison-core1.cabal
+++ b/unison-core/unison-core1.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -31,9 +31,10 @@ library
       Unison.DataDeclaration
       Unison.DataDeclaration.ConstructorId
       Unison.DataDeclaration.Names
+      Unison.GReferent
       Unison.Hashable
       Unison.HashQualified
-      Unison.HashQualified'
+      Unison.HashQualified2
       Unison.Kind
       Unison.LabeledDependency
       Unison.Name
@@ -47,7 +48,6 @@ library
       Unison.Project
       Unison.Reference
       Unison.Referent
-      Unison.Referent'
       Unison.Settings
       Unison.ShortHash
       Unison.Symbol

--- a/unison-core/unison-core1.cabal
+++ b/unison-core/unison-core1.cabal
@@ -31,7 +31,7 @@ library
       Unison.DataDeclaration
       Unison.DataDeclaration.ConstructorId
       Unison.DataDeclaration.Names
-      Unison.GReferent
+      Unison.ReferentG
       Unison.Hashable
       Unison.HashQualified
       Unison.HashQualified2

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -138,7 +138,7 @@ import qualified Unison.ConstructorReference as ConstructorReference
 import qualified Unison.ConstructorType as CT
 import qualified Unison.DataDeclaration as DD
 import qualified Unison.HashQualified as HQ
-import qualified Unison.HashQualified' as HQ'
+import qualified Unison.HashQualified2 as HQ'
 import qualified Unison.Hashing.V2.Convert as Hashing
 import qualified Unison.LabeledDependency as LD
 import Unison.Name (Name)
@@ -168,7 +168,7 @@ import Unison.Server.NameSearch.FromNames (makeNameSearch)
 import Unison.Server.NameSearch.Sqlite (termReferentsByShortHash, typeReferencesByShortHash)
 import Unison.Server.QueryResult
 import qualified Unison.Server.SearchResult as SR
-import qualified Unison.Server.SearchResult' as SR'
+import qualified Unison.Server.SearchResult2 as SR'
 import qualified Unison.Server.Syntax as Syntax
 import Unison.Server.Types
 import Unison.ShortHash
@@ -177,7 +177,7 @@ import qualified Unison.Sqlite as Sqlite
 import Unison.Symbol (Symbol)
 import qualified Unison.Syntax.DeclPrinter as DeclPrinter
 import qualified Unison.Syntax.HashQualified as HQ (toText)
-import qualified Unison.Syntax.HashQualified' as HQ' (toText)
+import qualified Unison.Syntax.HashQualified2 as HQ' (toText)
 import Unison.Syntax.Name as Name (toText, unsafeFromText)
 import qualified Unison.Syntax.NamePrinter as NP
 import qualified Unison.Syntax.TermPrinter as TermPrinter

--- a/unison-share-api/src/Unison/Server/NameSearch.hs
+++ b/unison-share-api/src/Unison/Server/NameSearch.hs
@@ -4,7 +4,7 @@ import Control.Lens
 import qualified Data.List as List
 import qualified Data.Set as Set
 import qualified Unison.HashQualified as HQ
-import qualified Unison.HashQualified' as HQ'
+import qualified Unison.HashQualified2 as HQ'
 import Unison.Name (Name)
 import Unison.Prelude
 import Unison.Reference (Reference)

--- a/unison-share-api/src/Unison/Server/NameSearch/FromNames.hs
+++ b/unison-share-api/src/Unison/Server/NameSearch/FromNames.hs
@@ -1,6 +1,6 @@
 module Unison.Server.NameSearch.FromNames where
 
-import qualified Unison.HashQualified' as HQ'
+import qualified Unison.HashQualified2 as HQ'
 import Unison.NamesWithHistory (NamesWithHistory)
 import qualified Unison.NamesWithHistory as NamesWithHistory
 import Unison.Reference (Reference)

--- a/unison-share-api/src/Unison/Server/NameSearch/Sqlite.hs
+++ b/unison-share-api/src/Unison/Server/NameSearch/Sqlite.hs
@@ -18,7 +18,7 @@ import qualified Unison.Codebase as Codebase
 import Unison.Codebase.Path
 import qualified Unison.Codebase.Path as Path
 import qualified Unison.Codebase.SqliteCodebase.Conversions as Cv
-import qualified Unison.HashQualified' as HQ'
+import qualified Unison.HashQualified2 as HQ'
 import qualified Unison.LabeledDependency as LD
 import Unison.Name (Name)
 import qualified Unison.Name as Name

--- a/unison-share-api/src/Unison/Server/Orphans.hs
+++ b/unison-share-api/src/Unison/Server/Orphans.hs
@@ -26,7 +26,7 @@ import Unison.ConstructorType (ConstructorType)
 import Unison.Hash (Hash (..))
 import qualified Unison.Hash as Hash
 import qualified Unison.HashQualified as HQ
-import qualified Unison.HashQualified' as HQ'
+import qualified Unison.HashQualified2 as HQ'
 import Unison.Name (Name)
 import qualified Unison.Name as Name
 import Unison.NameSegment (NameSegment (..))
@@ -37,7 +37,7 @@ import qualified Unison.Referent as Referent
 import Unison.ShortHash (ShortHash)
 import qualified Unison.ShortHash as SH
 import qualified Unison.Syntax.HashQualified as HQ (fromText)
-import qualified Unison.Syntax.HashQualified' as HQ' (fromText)
+import qualified Unison.Syntax.HashQualified2 as HQ' (fromText)
 import qualified Unison.Syntax.Name as Name (fromTextEither, toText)
 import Unison.Util.Pretty (Width (..))
 

--- a/unison-share-api/src/Unison/Server/SearchResult.hs
+++ b/unison-share-api/src/Unison/Server/SearchResult.hs
@@ -2,7 +2,7 @@ module Unison.Server.SearchResult where
 
 import qualified Data.Set as Set
 import Unison.HashQualified (HashQualified)
-import qualified Unison.HashQualified' as HQ'
+import qualified Unison.HashQualified2 as HQ'
 import Unison.Name (Name)
 import qualified Unison.Name as Name
 import Unison.Names (Names (..))

--- a/unison-share-api/src/Unison/Server/SearchResult2.hs
+++ b/unison-share-api/src/Unison/Server/SearchResult2.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE PatternSynonyms #-}
 
-module Unison.Server.SearchResult' where
+module Unison.Server.SearchResult2 where
 
 import qualified Data.Set as Set
 import Unison.Codebase.Editor.DisplayObject (DisplayObject)
@@ -8,7 +8,7 @@ import qualified Unison.Codebase.Editor.DisplayObject as DT
 import Unison.DataDeclaration (Decl)
 import qualified Unison.DataDeclaration as DD
 import qualified Unison.HashQualified as HQ
-import qualified Unison.HashQualified' as HQ'
+import qualified Unison.HashQualified2 as HQ'
 import Unison.LabeledDependency (LabeledDependency)
 import qualified Unison.LabeledDependency as LD
 import Unison.Name (Name)

--- a/unison-share-api/src/Unison/Server/Types.hs
+++ b/unison-share-api/src/Unison/Server/Types.hs
@@ -41,7 +41,7 @@ import Unison.Codebase.Editor.DisplayObject
   )
 import qualified Unison.Hash as Hash
 import qualified Unison.HashQualified as HQ
-import qualified Unison.HashQualified' as HQ'
+import qualified Unison.HashQualified2 as HQ'
 import Unison.Name (Name)
 import Unison.NameSegment (NameSegment)
 import qualified Unison.NameSegment as NameSegment

--- a/unison-share-api/src/Unison/Util/Find.hs
+++ b/unison-share-api/src/Unison/Util/Find.hs
@@ -16,7 +16,7 @@ import qualified Data.Text as Text
 -- https://www.stackage.org/haddock/lts-13.9/regex-tdfa-1.2.3.1/Text-Regex-TDFA.html
 import qualified Text.Regex.TDFA as RE
 import qualified Unison.HashQualified as HQ
-import qualified Unison.HashQualified' as HQ'
+import qualified Unison.HashQualified2 as HQ'
 import Unison.Name (Name)
 import qualified Unison.Name as Name
 import Unison.Names (Names)

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -36,7 +36,7 @@ library
       Unison.Server.Orphans
       Unison.Server.QueryResult
       Unison.Server.SearchResult
-      Unison.Server.SearchResult'
+      Unison.Server.SearchResult2
       Unison.Server.Share.Definitions
       Unison.Server.Share.RenderDoc
       Unison.Server.Syntax

--- a/unison-syntax/src/Unison/Syntax/HashQualified2.hs
+++ b/unison-syntax/src/Unison/Syntax/HashQualified2.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | Syntax-related combinators for HashQualified' (to/from string types).
-module Unison.Syntax.HashQualified'
+module Unison.Syntax.HashQualified2
   ( fromString,
     fromText,
     unsafeFromText,
@@ -11,7 +11,7 @@ module Unison.Syntax.HashQualified'
 where
 
 import qualified Data.Text as Text
-import qualified Unison.HashQualified' as HQ'
+import qualified Unison.HashQualified2' as HQ'
 import Unison.Name (Name, Parse)
 import qualified Unison.Name as Name
 import Unison.Prelude hiding (fromString)

--- a/unison-syntax/src/Unison/Syntax/HashQualified2.hs
+++ b/unison-syntax/src/Unison/Syntax/HashQualified2.hs
@@ -11,7 +11,7 @@ module Unison.Syntax.HashQualified2
 where
 
 import qualified Data.Text as Text
-import qualified Unison.HashQualified2' as HQ'
+import qualified Unison.HashQualified2 as HQ'
 import Unison.Name (Name, Parse)
 import qualified Unison.Name as Name
 import Unison.Prelude hiding (fromString)

--- a/unison-syntax/unison-syntax.cabal
+++ b/unison-syntax/unison-syntax.cabal
@@ -20,7 +20,7 @@ library
       Unison.Lexer.Pos
       Unison.Parser.Ann
       Unison.Syntax.HashQualified
-      Unison.Syntax.HashQualified'
+      Unison.Syntax.HashQualified2
       Unison.Syntax.Lexer
       Unison.Syntax.Name
       Unison.Syntax.Parser


### PR DESCRIPTION
stack + ghc 9.4.5 on windows no longer seems to support object filenames with `'` in them.
<!-- 
**Choose your PR title well:** Your pull request title is what's used to create release notes, so please make it descriptive of the change itself, which may be different from the initial motivation to make the change.

## Overview

What does this change accomplish and why? i.e. How does it change the user experience?

Feel free to include "before and after" examples if appropriate. (You can copy/paste screenshots directly into this editor.)

If relevant, which Github issues does it close? (See [closing-issues-using-keywords](https://help.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords).)

## Implementation notes

How does it accomplish it, in broad strokes? i.e. How does it change the Haskell codebase?

## Interesting/controversial decisions

Include anything that you thought twice about, debated, chose arbitrarily, etc. 
What could have been done differently, but wasn't? And why?

## Test coverage

Have you included tests (which could be a transcript) for this change, or is it somehow covered by existing tests? 

Would you recommend improving the test coverage (either as part of this PR or as a separate issue) or do you think it’s adequate?

If you only tested by hand, because that's all that's practical to do for this change, mention that.

## Loose ends

Link to related issues that address things you didn't get to. Stuff you encountered on the way and decided not to include in this PR.
