### PR TITLE
Fix toNamespaceGlob on empty namespaces

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -3491,7 +3491,11 @@ toReversedName revSegs = Text.intercalate "." (toList revSegs) <> "."
 --
 -- >>> toNamespaceGlob "foo.bar"
 -- "foo.bar.*"
+--
+-- >>> toNamespaceGlob ""
+-- "*"
 toNamespaceGlob :: Text -> Text
+toNamespaceGlob "" = "*"
 toNamespaceGlob namespace = globEscape namespace <> ".*"
 
 -- | Thrown if we try to get the segments of an empty name, shouldn't ever happen since empty names


### PR DESCRIPTION
## Overview

Found a bug where the precise pretty-printer would fail to find certain names if using an empty perspective. Never got caught because in loose-code the perspective is always `public`, but in projects an empty perspective is the default.

## Implementation notes

When we're prefix searching with a namespace like `lib.base` it turns into `lib.base.*` which is correct, but if the namespace prefix is empty we were getting `.*`, which would match nothing :'(, now it returns `*` for the empty namespace instead.

P.s. I double-checked and the sqlite query planner is smart enough to omit the namespace condition entirely when the glob is `'*'` so that's a nice bonus 😄 

## Testing

Several hours of debugging 😓 

I can't add a transcript here because it depends on the sqlite name lookups, but I'll add one in the enlil PR.
