### PR TITLE
Update nix flake for GCH 9.2.7

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
@@ -17,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678703398,
-        "narHash": "sha256-Y1mW3dBsoWLHpYm+UIHb5VZ7rx024NNHaF16oZBx++o=",
+        "lastModified": 1684935479,
+        "narHash": "sha256-6QMMsXMr2nhmOPHdti2j3KRHt+bai2zw+LJfdCl97Mk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "67f26c1cfc5d5783628231e776a81c1ade623e0b",
+        "rev": "f91ee3065de91a3531329a674a45ddcb3467a650",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.11",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -35,6 +38,21 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,16 +3,15 @@
 
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 
   outputs = { self, flake-utils, nixpkgs }:
     let
-      ghc-version = "8107";
+      ghc-version = "927";
       systemAttrs = flake-utils.lib.eachDefaultSystem (system:
         let
           pkgs = nixpkgs.legacyPackages."${system}".extend self.overlay;
-          ghc-version = "8107";
           ghc = pkgs.haskell.packages."ghc${ghc-version}";
           nativePackages = pkgs.lib.optionals pkgs.stdenv.isDarwin
             (with pkgs.darwin.apple_sdk.frameworks; [ Cocoa ]);
@@ -53,9 +52,7 @@
             hls = pkgs.unison-hls;
             hls-call-hierarchy-plugin = ghc.hls-call-hierarchy-plugin;
             ormolu = pkgs.ormolu;
-            ghc = pkgs.haskell.compiler."ghc${ghc-version}".override {
-              useLLVM = pkgs.stdenv.isAarch64;
-            };
+            ghc = pkgs.haskell.compiler."ghc${ghc-version}";
             stack = pkgs.unison-stack;
             devShell = self.devShells."${system}".default;
 
@@ -65,67 +62,51 @@
         });
       topLevelAttrs = {
         overlay = final: prev: {
-          ormolu = prev.haskell.lib.justStaticExecutables
-            final.haskell.packages."ghc${ghc-version}".ormolu;
-          haskell = with prev.haskell.lib;
-            prev.haskell // {
-              packages = prev.haskell.packages // {
-                "ghc${ghc-version}" = prev.haskell.packages.ghc8107.extend
-                  (hfinal: hprev: {
-                    mkDerivation = drv:
-                      hprev.mkDerivation (drv // {
-                        doCheck = false;
-                        doHaddock = false;
-                        doBenchmark = false;
-                        enableLibraryProfiling = false;
-                        enableExecutableProfiling = false;
-                      });
-                    aeson = hfinal.aeson_2_1_1_0;
-                    lens-aeson = hfinal.lens-aeson_1_2_2;
-                    Cabal = hfinal.Cabal_3_6_3_0;
-                    ormolu = hfinal.ormolu_0_5_0_1;
-                    ghc-lib-parser = hfinal.ghc-lib-parser_9_2_5_20221107;
-                    # avoid deprecated version https://github.com/Avi-D-coder/implicit-hie/issues/50
-                    implicit-hie = hfinal.callHackageDirect {
-                      pkg = "implicit-hie";
-                      ver = "0.1.4.0";
-                      sha256 =
-                        "15qy9vwm8vbnyv47vh6kd50m09vc4vhqbbrhf8gdifrvlxhad69l";
-                    } { };
-                    haskell-language-server = let
-                      p = prev.haskell.lib.overrideCabal
-                        hprev.haskell-language-server (drv: {
-                          # undo terrible nixpkgs hacks
-                          buildDepends =
-                            prev.lib.filter (x: x != hprev.hls-brittany-plugin)
-                            drv.buildDepends;
-                          configureFlags = drv.configureFlags ++ [
-                            "-f-brittany"
-                            "-f-fourmolu"
-                            "-f-floskell"
-                            "-f-stylishhaskell"
-                            "-f-hlint"
-                          ];
-                        });
-                    in p.overrideScope (lfinal: lprev: {
-                      # undo all of the horrible overrideScope in
-                      # nixpkgs configuration files
-                      ormolu = hfinal.ormolu;
-                      ghc-lib-parser = hfinal.ghc-lib-parser;
-                      ghc-lib-parser-ex = hfinal.ghc-lib-parser-ex;
-                      ghc-paths = hfinal.ghc-paths;
-                      aeson = hfinal.aeson;
-                      lsp-types = hfinal.lsp-types;
-                      # null out some dependencies that we drop with cabal flags
-                      hls-fourmolu-plugin = null;
-                      hls-floskell-plugin = null;
-                      hls-brittany-plugin = hfinal.hls-brittany-plugin;
-                      hls-stylish-haskell-plugin = null;
-                      hls-hlint-plugin = null;
-                    });
-                  });
-              };
-            };
+          #ormolu = prev.haskell.lib.justStaticExecutables
+          #  final.haskell.packages."ghc${ghc-version}".ormolu;
+          #haskell = with prev.haskell.lib;
+          #  prev.haskell // {
+          #    packages = prev.haskell.packages // {
+          #      "ghc${ghc-version}" = prev.haskell.packages."ghc${ghc-version}".extend
+          #        (hfinal: hprev: {
+          #          mkDerivation = drv:
+          #            hprev.mkDerivation (drv // {
+          #              doCheck = false;
+          #              doHaddock = false;
+          #              doBenchmark = false;
+          #              enableLibraryProfiling = false;
+          #              enableExecutableProfiling = false;
+          #            });
+          #          haskell-language-server = let
+          #            p = prev.haskell.lib.overrideCabal
+          #              hprev.haskell-language-server (drv: {
+          #                configureFlags = drv.configureFlags ++ [
+          #                  "-f-brittany"
+          #                  "-f-fourmolu"
+          #                  "-f-floskell"
+          #                  "-f-stylishhaskell"
+          #                  "-f-hlint"
+          #                ];
+          #              });
+          #          in p.overrideScope (lfinal: lprev: {
+          #            # undo all of the horrible overrideScope in
+          #            # nixpkgs configuration files
+          #            ormolu = hfinal.ormolu;
+          #            ghc-lib-parser = hfinal.ghc-lib-parser;
+          #            ghc-lib-parser-ex = hfinal.ghc-lib-parser-ex;
+          #            ghc-paths = hfinal.ghc-paths;
+          #            aeson = hfinal.aeson;
+          #            lsp-types = hfinal.lsp-types;
+          #            # null out some dependencies that we drop with cabal flags
+          #            hls-fourmolu-plugin = null;
+          #            hls-floskell-plugin = null;
+          #            hls-brittany-plugin = hfinal.hls-brittany-plugin;
+          #            hls-stylish-haskell-plugin = null;
+          #            hls-hlint-plugin = null;
+          #          });
+          #        });
+          #    };
+          #  };
           unison-hls = final.haskell-language-server.override {
             haskellPackages = final.haskell.packages."ghc${ghc-version}";
             dynamic = true;


### PR DESCRIPTION
Resolves #4026

I was able to remove some overrides that we were using to get ormolu
0.5.0.1 to build with GHC 8.10.7. It's possible that more cruft can be
removed, but I don't understand it well enough to feel confident in
messing with it. We are no longer explicitly asking for ormolu 0.5.0.1
because I couldn't figure out how to do that, but 0.5.0.1 is the
version in the nixpkgs hash that we are currently locked on.

On my linux box both `stack build && stack test` and HLS support work.
