### PR TITLE
Add configuration for whether to vacuum after migrating

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Init.hs
+++ b/parser-typechecker/src/Unison/Codebase/Init.hs
@@ -11,6 +11,7 @@ module Unison.Codebase.Init
     SpecifiedCodebase (..),
     MigrationStrategy (..),
     BackupStrategy (..),
+    VacuumStrategy (..),
     Pretty,
     createCodebase,
     initCodebaseAndExit,
@@ -57,11 +58,19 @@ data BackupStrategy
     NoBackup
   deriving stock (Show, Eq, Ord)
 
+data VacuumStrategy
+  = -- Vacuum after migrating. Takes a bit longer but keeps the codebase clean and maybe reduces size.
+    Vacuum
+  | -- Don't vacuum after migrating. Vacuuming is time consuming on large codebases,
+    -- so we don't want to do it during server migrations.
+    NoVacuum
+  deriving stock (Show, Eq, Ord)
+
 data MigrationStrategy
   = -- | Perform a migration immediately if one is required.
-    MigrateAutomatically BackupStrategy
+    MigrateAutomatically BackupStrategy VacuumStrategy
   | -- | Prompt the user that a migration is about to occur, continue after acknownledgment
-    MigrateAfterPrompt BackupStrategy
+    MigrateAfterPrompt BackupStrategy VacuumStrategy
   | -- | Triggers an 'OpenCodebaseRequiresMigration' error instead of migrating
     DontMigrate
   deriving stock (Show, Eq, Ord)

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -50,7 +50,7 @@ import Unison.Codebase.Editor.RemoteRepo
     writeToReadGit,
   )
 import qualified Unison.Codebase.GitError as GitError
-import Unison.Codebase.Init (BackupStrategy (..), VacuumStrategy(..), CodebaseLockOption (..), MigrationStrategy (..))
+import Unison.Codebase.Init (BackupStrategy (..), CodebaseLockOption (..), MigrationStrategy (..), VacuumStrategy (..))
 import qualified Unison.Codebase.Init as Codebase
 import qualified Unison.Codebase.Init.CreateCodebaseError as Codebase1
 import Unison.Codebase.Init.OpenCodebaseError (OpenCodebaseError (..))

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -11,6 +11,7 @@ module Unison.Codebase.SqliteCodebase
     Unison.Codebase.SqliteCodebase.initWithSetup,
     MigrationStrategy (..),
     BackupStrategy (..),
+    VacuumStrategy (..),
     CodebaseLockOption (..),
     copyCodebase,
   )
@@ -49,7 +50,7 @@ import Unison.Codebase.Editor.RemoteRepo
     writeToReadGit,
   )
 import qualified Unison.Codebase.GitError as GitError
-import Unison.Codebase.Init (BackupStrategy (..), CodebaseLockOption (..), MigrationStrategy (..))
+import Unison.Codebase.Init (BackupStrategy (..), VacuumStrategy(..), CodebaseLockOption (..), MigrationStrategy (..))
 import qualified Unison.Codebase.Init as Codebase
 import qualified Unison.Codebase.Init.CreateCodebaseError as Codebase1
 import Unison.Codebase.Init.OpenCodebaseError (OpenCodebaseError (..))
@@ -227,12 +228,12 @@ sqliteCodebase debugName root localOrRemote lockOption migrationStrategy action 
       Migrations.CodebaseRequiresMigration fromSv toSv ->
         case migrationStrategy of
           DontMigrate -> pure $ Left (OpenCodebaseRequiresMigration fromSv toSv)
-          MigrateAfterPrompt backupStrategy -> do
+          MigrateAfterPrompt backupStrategy vacuumStrategy -> do
             let shouldPrompt = True
-            Migrations.ensureCodebaseIsUpToDate localOrRemote root getDeclType termBuffer declBuffer shouldPrompt backupStrategy conn
-          MigrateAutomatically backupStrategy -> do
+            Migrations.ensureCodebaseIsUpToDate localOrRemote root getDeclType termBuffer declBuffer shouldPrompt backupStrategy vacuumStrategy conn
+          MigrateAutomatically backupStrategy vacuumStrategy -> do
             let shouldPrompt = False
-            Migrations.ensureCodebaseIsUpToDate localOrRemote root getDeclType termBuffer declBuffer shouldPrompt backupStrategy conn
+            Migrations.ensureCodebaseIsUpToDate localOrRemote root getDeclType termBuffer declBuffer shouldPrompt backupStrategy vacuumStrategy conn
 
   case result of
     Left err -> pure $ Left err
@@ -595,7 +596,7 @@ viewRemoteBranch' ReadGitRemoteNamespace {repo, sch, path} gitBranchBehavior act
           then throwIO (C.GitSqliteCodebaseError (GitError.NoDatabaseFile repo remotePath))
           else throwIO exception
 
-      result <- sqliteCodebase "viewRemoteBranch.gitCache" remotePath Remote DoLock (MigrateAfterPrompt Codebase.Backup) \codebase -> do
+      result <- sqliteCodebase "viewRemoteBranch.gitCache" remotePath Remote DoLock (MigrateAfterPrompt Codebase.Backup Codebase.Vacuum) \codebase -> do
         -- try to load the requested branch from it
         branch <- time "Git fetch (sch)" $ case sch of
           -- no sub-branch was specified, so use the root.
@@ -645,7 +646,7 @@ pushGitBranch srcConn repo (PushGitBranchOpts behavior _syncMode) action = Unlif
   -- set up the cache dir
   throwEitherMWith C.GitProtocolError . withRepo readRepo Git.CreateBranchIfMissing $ \pushStaging -> do
     newBranchOrErr <- throwEitherMWith (C.GitSqliteCodebaseError . C.gitErrorFromOpenCodebaseError (Git.gitDirToPath pushStaging) readRepo)
-      . withOpenOrCreateCodebase (pure ()) "push.dest" (Git.gitDirToPath pushStaging) Remote DoLock (MigrateAfterPrompt Codebase.Backup)
+      . withOpenOrCreateCodebase (pure ()) "push.dest" (Git.gitDirToPath pushStaging) Remote DoLock (MigrateAfterPrompt Codebase.Backup Codebase.Vacuum)
       $ \(codebaseStatus, destCodebase) -> do
         currentRootBranch <-
           Codebase1.runTransaction destCodebase CodebaseOps.getRootBranchExists >>= \case


### PR DESCRIPTION
## Overview

It turns out that Vacuuming the cloud or unison user's 10GB codebases takes a pretty significant chunk of time, it was making what should otherwise be an instantaneous migration take much longer.

This change allows us to run migrations on share without vacuuming after, which speeds them up **substantially**. If we like we can always go in and manually vacuum things later.

## Implementation notes

* Adds new `VacuumStrategy` when opening a codebase.
* In the CLI, always vacuum after migrating.

## Test coverage

Nah, it's a pretty simple change.