### PR TITLE
key haskell cache by resolver

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,7 @@ jobs:
         if: runner.os != 'Windows'
         with:
           path: ~/.stack
-          key: stack-1_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_short }}-${{hashFiles('**/stack.yaml')}}-${{github.sha}}
+          key: stack-1_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_long }}-${{hashFiles('**/stack.yaml')}}-${{github.sha}}
           # Fall-back to use the most recent cache for the stack.yaml, or failing that the OS
           restore-keys: |
             stack-1_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_long }}-${{hashFiles('**/stack.yaml')}}-
@@ -84,7 +84,7 @@ jobs:
         if: runner.os == 'Windows'
         with:
           path: "C:\\Users\\runneradmin\\AppData\\Roaming\\stack"
-          key: stack-1_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_short }}-${{hashFiles('**/stack.yaml')}}-${{github.sha}}
+          key: stack-1_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_long }}-${{hashFiles('**/stack.yaml')}}-${{github.sha}}
           # Fall-back to use the most recent cache for the stack.yaml, or failing that the OS
           restore-keys: |
             stack-1_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_long }}-${{hashFiles('**/stack.yaml')}}-

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -178,92 +178,95 @@ jobs:
         run: stack --no-terminal build --fast --no-run-tests --test
 
       # Run each test suite (tests and transcripts)
-      - name: unison-cli test
-        run: stack --no-terminal build --fast --test unison-cli
-      - name: unison-core tests
-        run: stack --no-terminal build --fast --test unison-core
-      - name: unison-parser-typechecker tests
-        run: stack --no-terminal build --fast --test unison-parser-typechecker
-      - name: unison-sqlite tests
-        run: stack --no-terminal build --fast --test unison-sqlite
-      - name: unison-syntax tests
-        run: stack --no-terminal build --fast --test unison-syntax
-      - name: unison-util-bytes tests
-        run: stack --no-terminal build --fast --test unison-util-bytes
-      - name: unison-util-cache tests
-        run: stack --no-terminal build --fast --test unison-util-cache
-      - name: unison-util-relation tests
-        run: stack --no-terminal build --fast --test unison-util-relation
-      - name: transcripts
-        run: |
-          stack --no-terminal exec transcripts
-          # Add all changes to the index for when we diff.
-          git add --all
-          # Fail if any transcripts cause git diffs.
-          git diff --cached --ignore-cr-at-eol --exit-code
-      - name: prettyprint-round-trip
-        run: stack --no-terminal exec unison transcript unison-src/transcripts-round-trip/main.md
-      - name: cli-integration-tests
-        run: stack --no-terminal exec cli-integration-tests
+      - name: test
+        steps:
+        - name: unison-cli test
+          run: stack --no-terminal build --fast --test unison-cli
+        - name: unison-core tests
+          run: stack --no-terminal build --fast --test unison-core
+        - name: unison-parser-typechecker tests
+          run: stack --no-terminal build --fast --test unison-parser-typechecker
+        - name: unison-sqlite tests
+          run: stack --no-terminal build --fast --test unison-sqlite
+        - name: unison-syntax tests
+          run: stack --no-terminal build --fast --test unison-syntax
+        - name: unison-util-bytes tests
+          run: stack --no-terminal build --fast --test unison-util-bytes
+        - name: unison-util-cache tests
+          run: stack --no-terminal build --fast --test unison-util-cache
+        - name: unison-util-relation tests
+          run: stack --no-terminal build --fast --test unison-util-relation
+        - name: transcripts
+          run: |
+            stack --no-terminal exec transcripts
+            # Add all changes to the index for when we diff.
+            git add --all
+            # Fail if any transcripts cause git diffs.
+            git diff --cached --ignore-cr-at-eol --exit-code
+        - name: prettyprint-round-trip
+          run: stack --no-terminal exec unison transcript unison-src/transcripts-round-trip/main.md
+        - name: cli-integration-tests
+          run: stack --no-terminal exec cli-integration-tests
+        - name: runtime tests
+          steps:
+            - name: Cache Racket dependencies
+              uses: actions/cache@v2
+              if: runner.os == 'Linux'
+              with:
+                path: |
+                  ~/.cache/racket
+                  ~/.local/share/racket
+                key: ${{ runner.os }}-racket-8.7
 
-      - name: Cache Racket dependencies
-        uses: actions/cache@v2
-        if: runner.os == 'Linux'
-        with:
-          path: |
-            ~/.cache/racket
-            ~/.local/share/racket
-          key: ${{ runner.os }}-racket-8.7
+            - uses: Bogdanp/setup-racket@v1.10
+              if: runner.os == 'Linux'
+              with:
+                architecture: 'x64'
+                distribution: 'full'
+                variant: 'CS'
+                version: '8.7' # match with cache key above
+            - run: raco pkg install --auto --skip-installed --batch x509-lib
+              if: runner.os == 'Linux'
+            - uses: awalsh128/cache-apt-pkgs-action@latest
+              if: runner.os == 'Linux'
+              with:
+                packages: libb2-dev
+                version: 1.0 # cache key version afaik
 
-      - uses: Bogdanp/setup-racket@v1.10
-        if: runner.os == 'Linux'
-        with:
-          architecture: 'x64'
-          distribution: 'full'
-          variant: 'CS'
-          version: '8.7' # match with cache key above
-      - run: raco pkg install --auto --skip-installed --batch x509-lib
-        if: runner.os == 'Linux'
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        if: runner.os == 'Linux'
-        with:
-          packages: libb2-dev
-          version: 1.0 # cache key version afaik
+            - uses: actions/cache@v3
+              name: cache base.md codebase (unix)
+              if: runner.os == 'Linux'
+              with:
+                path: ~/.cache/unisonlanguage/base.unison
+                key: base.unison_${{hashFiles('**/unison-src/builtin-tests/base.md')}}-${{github.sha}}
+                restore-keys: base.unison_${{hashFiles('**/unison-src/builtin-tests/base.md')}}
 
-      - uses: actions/cache@v3
-        name: cache base.md codebase (unix)
-        if: runner.os == 'Linux'
-        with:
-          path: ~/.cache/unisonlanguage/base.unison
-          key: base.unison_${{hashFiles('**/unison-src/builtin-tests/base.md')}}-${{github.sha}}
-          restore-keys: base.unison_${{hashFiles('**/unison-src/builtin-tests/base.md')}}
+            - name: set up `base` codebase
+              if: runner.os == 'Linux'
+              run: |
+                ./unison-src/builtin-tests/setup-base-codebase.sh
 
-      - name: set up `base` codebase
-        if: runner.os == 'Linux'
-        run: |
-          ./unison-src/builtin-tests/setup-base-codebase.sh
+            - name: jit tests
+              if: runner.os == 'Linux'
+              run: |
+                ./unison-src/builtin-tests/jit-tests.sh
+                cat ./unison-src/builtin-tests/jit-tests.output.md
+                CHANGE=$(git diff unison-src/builtin-tests/jit-tests.output.md)
+                if [ -n "$CHANGE" ]; then
+                  echo "The jit-tests output has changed"
+                  exit 1
+                fi
 
-      - name: jit tests
-        if: runner.os == 'Linux'
-        run: |
-          ./unison-src/builtin-tests/jit-tests.sh
-          cat ./unison-src/builtin-tests/jit-tests.output.md
-          CHANGE=$(git diff unison-src/builtin-tests/jit-tests.output.md)
-          if [ -n "$CHANGE" ]; then
-            echo "The jit-tests output has changed"
-            exit 1
-          fi
-
-      - name: interpreter tests
-        if: runner.os == 'Linux'
-        run: |
-          ./unison-src/builtin-tests/interpreter-tests.sh
-          cat ./unison-src/builtin-tests/interpreter-tests.output.md
-          CHANGE=$(git diff unison-src/builtin-tests/interpreter-tests.output.md)
-          if [ -n "$CHANGE" ]; then
-            echo "The interpreter-tests output has changed"
-            exit 1
-          fi
+            - name: interpreter tests
+              if: runner.os == 'Linux'
+              run: |
+                ./unison-src/builtin-tests/interpreter-tests.sh
+                cat ./unison-src/builtin-tests/interpreter-tests.output.md
+                CHANGE=$(git diff unison-src/builtin-tests/interpreter-tests.output.md)
+                if [ -n "$CHANGE" ]; then
+                  echo "The interpreter-tests output has changed"
+                  exit 1
+                fi
 
       - name: check final stackage cache size
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -249,7 +249,8 @@ jobs:
                 ./unison-src/builtin-tests/setup-base-codebase.sh
 
             - name: jit tests
-              if: runner.os == 'Linux'
+              if: false # temporarily disabled
+              # if: runner.os == 'Linux'
               run: |
                 ./unison-src/builtin-tests/jit-tests.sh
                 cat ./unison-src/builtin-tests/jit-tests.output.md

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -228,6 +228,8 @@ jobs:
             - run: raco pkg install --auto --skip-installed --batch x509-lib
               if: runner.os == 'Linux'
             - uses: awalsh128/cache-apt-pkgs-action@latest
+              # read this if a package isn't installing correctly
+              # https://github.com/awalsh128/cache-apt-pkgs-action#caveats
               if: runner.os == 'Linux'
               with:
                 packages: libb2-dev

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,23 +53,30 @@ jobs:
       # purge one manually.
 
 
+      - id: stackage-resolver
+        name: record stackage resolver
+        # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files
+        # looks for `resolver: nightly-yyyy-mm-dd` or `resolver: lts-xx.yy` in `stack.yaml` and splits it into
+        # `nightly` or `lts-xx`.  the whole resolver string is put into resolver_long as a backup cache key
+        # ${{ steps.stackage-resolver.outputs.resolver_short }}
+        # ${{ steps.stackage-resolver.outputs.resolver_long }}
+        run: |
+          grep resolver stack.yaml | awk '{ x="resolver_short="; if (split($2,a,"-") > 2) print x a[1]; else {split($2,b,"."); print x b[1]}}' >> "$GITHUB_OUTPUT"
+          grep resolver stack.yaml | awk '{print "resolver_long="$2}' >> "$GITHUB_OUTPUT"
       # Cache ~/.stack, keyed by the contents of 'stack.yaml'.
       - uses: actions/cache@v3
         name: cache ~/.stack (unix)
         if: runner.os != 'Windows'
         with:
           path: ~/.stack
-          # Main cache key: commit hash. This should always result in a cache miss...
-          # So when loading a cache we'll always fall back to the restore-keys,
-          # which should load the most recent cache via a prefix search on the most
-          # recent branch cache.
-          # Then it will save a new cache at this commit sha, which should be used by
-          # the next build on this branch.
-          key: stack-0_${{matrix.os}}-${{hashFiles('**/stack.yaml')}}-${{github.sha}}
+          key: stack-1_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_short }}-${{hashFiles('**/stack.yaml')}}-${{github.sha}}
           # Fall-back to use the most recent cache for the stack.yaml, or failing that the OS
           restore-keys: |
-            stack-0_${{matrix.os}}-${{hashFiles('**/stack.yaml')}}
-            stack-0_${{matrix.os}}
+            stack-1_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_long }}-${{hashFiles('**/stack.yaml')}}-
+            stack-1_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_long }}-
+            stack-1_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_short }}-
+            stack-1_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_short }}.
+            stack-1_${{matrix.os}}-
 
       # Cache ~/.stack, keyed by the contents of 'stack.yaml'.
       - uses: actions/cache@v3
@@ -77,17 +84,14 @@ jobs:
         if: runner.os == 'Windows'
         with:
           path: "C:\\Users\\runneradmin\\AppData\\Roaming\\stack"
-          # Main cache key: commit hash. This should always result in a cache miss...
-          # So when loading a cache we'll always fall back to the restore-keys,
-          # which should load the most recent cache via a prefix search on the most
-          # recent branch cache.
-          # Then it will save a new cache at this commit sha, which should be used by
-          # the next build on this branch.
-          key: stack-0_${{matrix.os}}-${{hashFiles('**/stack.yaml')}}-${{github.sha}}
+          key: stack-1_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_short }}-${{hashFiles('**/stack.yaml')}}-${{github.sha}}
           # Fall-back to use the most recent cache for the stack.yaml, or failing that the OS
           restore-keys: |
-            stack-0_${{matrix.os}}-${{hashFiles('**/stack.yaml')}}
-            stack-0_${{matrix.os}}
+            stack-1_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_long }}-${{hashFiles('**/stack.yaml')}}-
+            stack-1_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_long }}-
+            stack-1_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_short }}-
+            stack-1_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_short }}.
+            stack-1_${{matrix.os}}-
 
       # Cache each local package's ~/.stack-work for fast incremental builds in CI.
       - uses: actions/cache@v3
@@ -101,8 +105,13 @@ jobs:
           # recent branch cache.
           # Then it will save a new cache at this commit sha, which should be used by
           # the next build on this branch.
-          key: stack-work-3_${{matrix.os}}-${{github.sha}}
-          restore-keys: stack-work-3_${{matrix.os}}
+          key: stack-work-4_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_short }}-${{hashFiles('**/stack.yaml')}}-${{github.sha}}
+          restore-keys: |
+            stack-work-4_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_long }}-${{hashFiles('**/stack.yaml')}}-
+            stack-work-4_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_long }}-
+            stack-work-4_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_short }}-
+            stack-work-4_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_short }}.
+            stack-work-4_${{matrix.os}}-
 
       # Install stack by downloading the binary from GitHub.
       # The installation process differs by OS.
@@ -141,7 +150,7 @@ jobs:
         run: rm -rf ~/.stack/setup-exe-cache
 
       - run: stack install stack-clean-old
-      - run: stack-clean-old list
+      - run: stack exec -- stack-clean-old list
 
       # Build deps, then build local code. Splitting it into two steps just allows us to see how much time each step
       # takes.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,6 +140,9 @@ jobs:
         if: runner.os == 'macOS'
         run: rm -rf ~/.stack/setup-exe-cache
 
+      - run: stack install stack-clean-old
+      - run: stack-clean-old list
+
       # Build deps, then build local code. Splitting it into two steps just allows us to see how much time each step
       # takes.
       - name: build dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,10 +65,10 @@ jobs:
           # recent branch cache.
           # Then it will save a new cache at this commit sha, which should be used by
           # the next build on this branch.
-          key: stack-0_${{matrix.os}}-${{hashFiles('stack.yaml')}}-${{github.sha}}
+          key: stack-0_${{matrix.os}}-${{hashFiles('**/stack.yaml')}}-${{github.sha}}
           # Fall-back to use the most recent cache for the stack.yaml, or failing that the OS
           restore-keys: |
-            stack-0_${{matrix.os}}-${{hashFiles('stack.yaml')}}
+            stack-0_${{matrix.os}}-${{hashFiles('**/stack.yaml')}}
             stack-0_${{matrix.os}}
 
       # Cache ~/.stack, keyed by the contents of 'stack.yaml'.
@@ -83,10 +83,10 @@ jobs:
           # recent branch cache.
           # Then it will save a new cache at this commit sha, which should be used by
           # the next build on this branch.
-          key: stack-0_${{matrix.os}}-${{hashFiles('stack.yaml')}}-${{github.sha}}
+          key: stack-0_${{matrix.os}}-${{hashFiles('**/stack.yaml')}}-${{github.sha}}
           # Fall-back to use the most recent cache for the stack.yaml, or failing that the OS
           restore-keys: |
-            stack-0_${{matrix.os}}-${{hashFiles('stack.yaml')}}
+            stack-0_${{matrix.os}}-${{hashFiles('**/stack.yaml')}}
             stack-0_${{matrix.os}}
 
       # Cache each local package's ~/.stack-work for fast incremental builds in CI.
@@ -208,8 +208,8 @@ jobs:
         if: runner.os == 'Linux'
         with:
           path: ~/.cache/unisonlanguage/base.unison
-          key: base.unison_${{hashfiles('unison-src/builtin-tests/base.md')}}-${{github.sha}}
-          restore-keys: base.unison_${{hashfiles('unison-src/builtin-tests/base.md')}}
+          key: base.unison_${{hashFiles('**/unison-src/builtin-tests/base.md')}}-${{github.sha}}
+          restore-keys: base.unison_${{hashFiles('**/unison-src/builtin-tests/base.md')}}
 
       - name: jit tests
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -211,6 +211,11 @@ jobs:
           key: base.unison_${{hashFiles('**/unison-src/builtin-tests/base.md')}}-${{github.sha}}
           restore-keys: base.unison_${{hashFiles('**/unison-src/builtin-tests/base.md')}}
 
+      - name: set up `base` codebase
+        if: runner.os == 'Linux'
+        run: |
+          ./unison-src/builtin-tests/setup-base-codebase.sh
+
       - name: jit tests
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     needs: ormolu
-    defaults: 
+    defaults:
       run:
         working-directory: unison
         shell: bash
@@ -104,7 +104,7 @@ jobs:
           key: stack-work-3_${{matrix.os}}-${{github.sha}}
           restore-keys: stack-work-3_${{matrix.os}}
 
-      # Install stack by downloading the binary from GitHub. 
+      # Install stack by downloading the binary from GitHub.
       # The installation process differs by OS.
       - name: install stack (Linux)
         if: runner.os == 'Linux'
@@ -204,12 +204,12 @@ jobs:
         if: runner.os == 'Linux'
 
       - uses: actions/cache@v3
-        name: cache ~/.cache/unisonlanguage (unix)
+        name: cache base.md codebase (unix)
         if: runner.os == 'Linux'
         with:
-          path: ~/.cache/unisonlanguage
-          key: stack-0_${{matrix.os}}-${{github.sha}}
-          restore-keys: stack-0_${{matrix.os}}
+          path: ~/.cache/unisonlanguage/base.unison
+          key: base.unison_${{hashfiles('unison-src/builtin-tests/base.md')}}-${{github.sha}}
+          restore-keys: base.unison_${{hashfiles('unison-src/builtin-tests/base.md')}}
 
       - name: jit tests
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,7 +153,9 @@ jobs:
         run: stack install stack-clean-old
       - name: check initial stackage cache size
         run: |
+          echo global .stack
           stack exec -- stack-clean-old list -G || true
+          echo project .stack-work
           stack exec -- stack-clean-old list -P || true
 
       # Build deps, then build local code. Splitting it into two steps just allows us to see how much time each step
@@ -271,5 +273,7 @@ jobs:
 
       - name: check final stackage cache size
         run: |
+          echo global .stack
           stack exec -- stack-clean-old list -G || true
+          echo project .stack-work
           stack exec -- stack-clean-old list -P || true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,9 @@ jobs:
         name: cache ~/.stack (Windows)
         if: runner.os == 'Windows'
         with:
-          path: "C:\\Users\\runneradmin\\AppData\\Roaming\\stack"
+          path: |
+            C:\Users\runneradmin\AppData\Roaming\stack
+            C:\Users\runneradmin\AppData\Local\Programs\stack
           key: stack-1_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_long }}-${{hashFiles('**/stack.yaml')}}-${{github.sha}}
           # Fall-back to use the most recent cache for the stack.yaml, or failing that the OS
           restore-keys: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -210,7 +210,7 @@ jobs:
           distribution: 'full'
           variant: 'CS'
           version: '8.7' # match with cache key above
-      - run: raco pkg install --deps search-auto --batch x509-lib
+      - run: raco pkg install --auto --skip-installed --batch x509-lib
         if: runner.os == 'Linux'
       - uses: awalsh128/cache-apt-pkgs-action@latest
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -257,7 +257,8 @@ jobs:
           fi
 
       - name: interpreter tests
-        if: runner.os == 'Linux'
+        if: false
+        # if: runner.os == 'Linux'
         run: |
           ./unison-src/builtin-tests/interpreter-tests.sh
           cat ./unison-src/builtin-tests/interpreter-tests.output.md

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,7 +149,8 @@ jobs:
         if: runner.os == 'macOS'
         run: rm -rf ~/.stack/setup-exe-cache
 
-      - run: stack install stack-clean-old
+      - name: install stack-clean-old (to scan or clean up old stackage caches)
+        run: stack install stack-clean-old
       - name: check initial stackage cache size
         run: |
           stack exec -- stack-clean-old list -G || true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -178,98 +178,94 @@ jobs:
         run: stack --no-terminal build --fast --no-run-tests --test
 
       # Run each test suite (tests and transcripts)
-      - name: test
-        steps:
-        - name: unison-cli test
-          run: stack --no-terminal build --fast --test unison-cli
-        - name: unison-core tests
-          run: stack --no-terminal build --fast --test unison-core
-        - name: unison-parser-typechecker tests
-          run: stack --no-terminal build --fast --test unison-parser-typechecker
-        - name: unison-sqlite tests
-          run: stack --no-terminal build --fast --test unison-sqlite
-        - name: unison-syntax tests
-          run: stack --no-terminal build --fast --test unison-syntax
-        - name: unison-util-bytes tests
-          run: stack --no-terminal build --fast --test unison-util-bytes
-        - name: unison-util-cache tests
-          run: stack --no-terminal build --fast --test unison-util-cache
-        - name: unison-util-relation tests
-          run: stack --no-terminal build --fast --test unison-util-relation
-        - name: transcripts
-          run: |
-            stack --no-terminal exec transcripts
-            # Add all changes to the index for when we diff.
-            git add --all
-            # Fail if any transcripts cause git diffs.
-            git diff --cached --ignore-cr-at-eol --exit-code
-        - name: prettyprint-round-trip
-          run: stack --no-terminal exec unison transcript unison-src/transcripts-round-trip/main.md
-        - name: cli-integration-tests
-          run: stack --no-terminal exec cli-integration-tests
-        - name: runtime tests
-          steps:
-            - name: Cache Racket dependencies
-              uses: actions/cache@v2
-              if: runner.os == 'Linux'
-              with:
-                path: |
-                  ~/.cache/racket
-                  ~/.local/share/racket
-                key: ${{ runner.os }}-racket-8.7
+      - name: unison-cli test
+        run: stack --no-terminal build --fast --test unison-cli
+      - name: unison-core tests
+        run: stack --no-terminal build --fast --test unison-core
+      - name: unison-parser-typechecker tests
+        run: stack --no-terminal build --fast --test unison-parser-typechecker
+      - name: unison-sqlite tests
+        run: stack --no-terminal build --fast --test unison-sqlite
+      - name: unison-syntax tests
+        run: stack --no-terminal build --fast --test unison-syntax
+      - name: unison-util-bytes tests
+        run: stack --no-terminal build --fast --test unison-util-bytes
+      - name: unison-util-cache tests
+        run: stack --no-terminal build --fast --test unison-util-cache
+      - name: unison-util-relation tests
+        run: stack --no-terminal build --fast --test unison-util-relation
+      - name: transcripts
+        run: |
+          stack --no-terminal exec transcripts
+          # Add all changes to the index for when we diff.
+          git add --all
+          # Fail if any transcripts cause git diffs.
+          git diff --cached --ignore-cr-at-eol --exit-code
+      - name: prettyprint-round-trip
+        run: stack --no-terminal exec unison transcript unison-src/transcripts-round-trip/main.md
+      - name: cli-integration-tests
+        run: stack --no-terminal exec cli-integration-tests
+      - name: Cache Racket dependencies
+        uses: actions/cache@v2
+        if: runner.os == 'Linux'
+        with:
+          path: |
+            ~/.cache/racket
+            ~/.local/share/racket
+          key: ${{ runner.os }}-racket-8.7
 
-            - uses: Bogdanp/setup-racket@v1.10
-              if: runner.os == 'Linux'
-              with:
-                architecture: 'x64'
-                distribution: 'full'
-                variant: 'CS'
-                version: '8.7' # match with cache key above
-            - run: raco pkg install --auto --skip-installed --batch x509-lib
-              if: runner.os == 'Linux'
-            - uses: awalsh128/cache-apt-pkgs-action@latest
-              # read this if a package isn't installing correctly
-              # https://github.com/awalsh128/cache-apt-pkgs-action#caveats
-              if: runner.os == 'Linux'
-              with:
-                packages: libb2-dev
-                version: 1.0 # cache key version afaik
+      - uses: Bogdanp/setup-racket@v1.10
+        if: runner.os == 'Linux'
+        with:
+          architecture: 'x64'
+          distribution: 'full'
+          variant: 'CS'
+          version: '8.7' # match with cache key above
+      - run: raco pkg install --auto --skip-installed --batch x509-lib
+        if: runner.os == 'Linux'
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        # read this if a package isn't installing correctly
+        # https://github.com/awalsh128/cache-apt-pkgs-action#caveats
+        if: runner.os == 'Linux'
+        with:
+          packages: libb2-dev
+          version: 1.0 # cache key version afaik
 
-            - uses: actions/cache@v3
-              name: cache base.md codebase (unix)
-              if: runner.os == 'Linux'
-              with:
-                path: ~/.cache/unisonlanguage/base.unison
-                key: base.unison_${{hashFiles('**/unison-src/builtin-tests/base.md')}}-${{github.sha}}
-                restore-keys: base.unison_${{hashFiles('**/unison-src/builtin-tests/base.md')}}
+      - uses: actions/cache@v3
+        name: cache base.md codebase (unix)
+        if: runner.os == 'Linux'
+        with:
+          path: ~/.cache/unisonlanguage/base.unison
+          key: base.unison_${{hashFiles('**/unison-src/builtin-tests/base.md')}}-${{github.sha}}
+          restore-keys: base.unison_${{hashFiles('**/unison-src/builtin-tests/base.md')}}
 
-            - name: set up `base` codebase
-              if: runner.os == 'Linux'
-              run: |
-                ./unison-src/builtin-tests/setup-base-codebase.sh
+      - name: set up `base` codebase
+        if: runner.os == 'Linux'
+        run: |
+          ./unison-src/builtin-tests/setup-base-codebase.sh
 
-            - name: jit tests
-              if: false # temporarily disabled
-              # if: runner.os == 'Linux'
-              run: |
-                ./unison-src/builtin-tests/jit-tests.sh
-                cat ./unison-src/builtin-tests/jit-tests.output.md
-                CHANGE=$(git diff unison-src/builtin-tests/jit-tests.output.md)
-                if [ -n "$CHANGE" ]; then
-                  echo "The jit-tests output has changed"
-                  exit 1
-                fi
+      - name: jit tests
+        if: false # temporarily disabled
+        # if: runner.os == 'Linux'
+        run: |
+          ./unison-src/builtin-tests/jit-tests.sh
+          cat ./unison-src/builtin-tests/jit-tests.output.md
+          CHANGE=$(git diff unison-src/builtin-tests/jit-tests.output.md)
+          if [ -n "$CHANGE" ]; then
+            echo "The jit-tests output has changed"
+            exit 1
+          fi
 
-            - name: interpreter tests
-              if: runner.os == 'Linux'
-              run: |
-                ./unison-src/builtin-tests/interpreter-tests.sh
-                cat ./unison-src/builtin-tests/interpreter-tests.output.md
-                CHANGE=$(git diff unison-src/builtin-tests/interpreter-tests.output.md)
-                if [ -n "$CHANGE" ]; then
-                  echo "The interpreter-tests output has changed"
-                  exit 1
-                fi
+      - name: interpreter tests
+        if: runner.os == 'Linux'
+        run: |
+          ./unison-src/builtin-tests/interpreter-tests.sh
+          cat ./unison-src/builtin-tests/interpreter-tests.output.md
+          CHANGE=$(git diff unison-src/builtin-tests/interpreter-tests.output.md)
+          if [ -n "$CHANGE" ]; then
+            echo "The interpreter-tests output has changed"
+            exit 1
+          fi
 
       - name: check final stackage cache size
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -248,8 +248,8 @@ jobs:
           ./unison-src/builtin-tests/setup-base-codebase.sh
 
       - name: jit tests
-        if: false # temporarily disabled
-        # if: runner.os == 'Linux'
+        # if: false # temporarily disabled
+        if: runner.os == 'Linux'
         run: |
           ./unison-src/builtin-tests/jit-tests.sh
           cat ./unison-src/builtin-tests/jit-tests.output.md
@@ -260,8 +260,8 @@ jobs:
           fi
 
       - name: interpreter tests
-        if: false
-        # if: runner.os == 'Linux'
+        # if: false # temporarily disabled
+        if: runner.os == 'Linux'
         run: |
           ./unison-src/builtin-tests/interpreter-tests.sh
           cat ./unison-src/builtin-tests/interpreter-tests.output.md

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -191,17 +191,29 @@ jobs:
       - name: cli-integration-tests
         run: stack --no-terminal exec cli-integration-tests
 
+      - name: Cache Racket dependencies
+        uses: actions/cache@v2
+        if: runner.os == 'Linux'
+        with:
+          path: |
+            ~/.cache/racket
+            ~/.local/share/racket
+          key: ${{ runner.os }}-racket-8.7
+
       - uses: Bogdanp/setup-racket@v1.10
         if: runner.os == 'Linux'
         with:
           architecture: 'x64'
           distribution: 'full'
           variant: 'CS'
-          version: '8.7'
+          version: '8.7' # match with cache key above
       - run: raco pkg install --deps search-auto --batch x509-lib
         if: runner.os == 'Linux'
-      - run: sudo apt-get -y install libb2-dev
+      - uses: awalsh128/cache-apt-pkgs-action@latest
         if: runner.os == 'Linux'
+        with:
+          packages: libb2-dev
+          version: 1.0 # cache key version afaik
 
       - uses: actions/cache@v3
         name: cache base.md codebase (unix)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,7 +150,11 @@ jobs:
         run: rm -rf ~/.stack/setup-exe-cache
 
       - name: install stack-clean-old (to scan or clean up old stackage caches)
-        run: stack install stack-clean-old
+        run: |
+          if ! stack exec -- which stack-clean-old; then
+            stack install stack-clean-old
+          fi
+
       - name: check initial stackage cache size
         run: |
           echo global .stack
@@ -240,7 +244,7 @@ jobs:
         with:
           path: ~/.cache/unisonlanguage/base.unison
           key: base.unison_${{hashFiles('**/unison-src/builtin-tests/base.md')}}-${{github.sha}}
-          restore-keys: base.unison_${{hashFiles('**/unison-src/builtin-tests/base.md')}}
+          restore-keys: base.unison_${{hashFiles('**/unison-src/builtin-tests/base.md')}}-
 
       - name: set up `base` codebase
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,7 +150,10 @@ jobs:
         run: rm -rf ~/.stack/setup-exe-cache
 
       - run: stack install stack-clean-old
-      - run: stack exec -- stack-clean-old list
+      - name: check initial stackage cache size
+        run: |
+          stack exec -- stack-clean-old list -G
+          stack exec -- stack-clean-old list -P
 
       # Build deps, then build local code. Splitting it into two steps just allows us to see how much time each step
       # takes.
@@ -261,3 +264,8 @@ jobs:
             echo "The interpreter-tests output has changed"
             exit 1
           fi
+
+      - name: check final stackage cache size
+        run: |
+          stack exec -- stack-clean-old list -G
+          stack exec -- stack-clean-old list -P

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -152,8 +152,8 @@ jobs:
       - run: stack install stack-clean-old
       - name: check initial stackage cache size
         run: |
-          stack exec -- stack-clean-old list -G
-          stack exec -- stack-clean-old list -P
+          stack exec -- stack-clean-old list -G || true
+          stack exec -- stack-clean-old list -P || true
 
       # Build deps, then build local code. Splitting it into two steps just allows us to see how much time each step
       # takes.
@@ -269,5 +269,5 @@ jobs:
 
       - name: check final stackage cache size
         run: |
-          stack exec -- stack-clean-old list -G
-          stack exec -- stack-clean-old list -P
+          stack exec -- stack-clean-old list -G || true
+          stack exec -- stack-clean-old list -P || true

--- a/unison-src/builtin-tests/base.md
+++ b/unison-src/builtin-tests/base.md
@@ -1,6 +1,9 @@
 When this file is modified, CI will create a new codebase and re-run this;
 otherwise it may reuse a previously cached codebase.
 
+Thus, make sure the contents of this file define the contents of the cache
+(e.g. don't pull `latest`.)
+
 ```ucm
 .> pull unison.public.base.releases.v1_1_1 .base
 .> compile.native.fetch

--- a/unison-src/builtin-tests/base.md
+++ b/unison-src/builtin-tests/base.md
@@ -5,6 +5,6 @@ Thus, make sure the contents of this file define the contents of the cache
 (e.g. don't pull `latest`.)
 
 ```ucm
-.> pull unison.public.base.releases.v1_1_1 .base
+.> pull unison.public.base.latest .base
 .> compile.native.fetch
 ```

--- a/unison-src/builtin-tests/base.md
+++ b/unison-src/builtin-tests/base.md
@@ -1,5 +1,7 @@
+When this file is modified, CI will create a new codebase and re-run this;
+otherwise it may reuse a previously cached codebase.
 
 ```ucm
-.> pull unison.public.base.latest .base
+.> pull unison.public.base.releases.v1_1_1 .base
 .> compile.native.fetch
 ```

--- a/unison-src/builtin-tests/base.output.md
+++ b/unison-src/builtin-tests/base.output.md
@@ -1,6 +1,11 @@
+When this file is modified, CI will create a new codebase and re-run this;
+otherwise it may reuse a previously cached codebase.
+
+Thus, make sure the contents of this file define the contents of the cache
+(e.g. don't pull `latest`.)
 
 ```ucm
-.> pull unison.public.base.latest .base
+.> pull unison.public.base.releases.v1_1_1 .base
 
   Downloaded 11580 entities.
 

--- a/unison-src/builtin-tests/base.output.md
+++ b/unison-src/builtin-tests/base.output.md
@@ -5,7 +5,7 @@ Thus, make sure the contents of this file define the contents of the cache
 (e.g. don't pull `latest`.)
 
 ```ucm
-.> pull unison.public.base.releases.v1_1_1 .base
+.> pull unison.public.base.latest .base
 
   Downloaded 11580 entities.
 

--- a/unison-src/builtin-tests/jit-tests.sh
+++ b/unison-src/builtin-tests/jit-tests.sh
@@ -6,6 +6,7 @@ ucm=$(stack exec -- which unison)
 base_codebase=${XDG_CACHE_HOME:-"$HOME/.cache"}/unisonlanguage/base.unison
 
 if [ ! -d $base_codebase ]; then
+    echo !!!! Creating a codebase in $base_codebase
     $ucm transcript -S $base_codebase unison-src/builtin-tests/base.md
 fi
 
@@ -16,4 +17,3 @@ mkdir -p $dir
 cp -r scheme-libs/* $dir/
 
 time $ucm transcript.fork -c $base_codebase unison-src/builtin-tests/jit-tests.md
-

--- a/unison-src/builtin-tests/setup-base-codebase.sh
+++ b/unison-src/builtin-tests/setup-base-codebase.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -ex
+
+ucm=$(stack exec -- which unison)
+
+base_codebase=${XDG_CACHE_HOME:-"$HOME/.cache"}/unisonlanguage/base.unison
+
+if [ ! -d $base_codebase ]; then
+    # -S specificies the output codebase (-C specifies the input codebase)
+    $ucm transcript -S $base_codebase unison-src/builtin-tests/base.md
+fi


### PR DESCRIPTION
* For `~/.stack`, the initial cache will be keyed by: the commit hash, `stack.yaml`, stackage resolver (major+minor, major only), os name; in that order until something matches
* Same for `**/.stack-work`
* For `base.unison`: the commit hash, `base.md` (the PR splits the execution of base.md into a separate step for timing)
* For Racket: os name + manual version number 
* For apt pkgs: managed by https://github.com/awalsh128/cache-apt-pkgs-action

Also adds some output from `stack-clean-old` to CI to let us know how big the stackage caches are getting.

## Interesting decisions
Why bother with the commit hash in the key? It should always miss; but is it useful to know which commit wrote the cache last?

## Loose ends:
~`base.md` still doesn't pin a version of `base`, but this PR adds a note about the importance of doing so :P~ done in #4040 