### PR TITLE
pin `base.unison` at `releases.v2_0_0`

### DIFF
--- a/unison-src/builtin-tests/base.md
+++ b/unison-src/builtin-tests/base.md
@@ -5,6 +5,6 @@ Thus, make sure the contents of this file define the contents of the cache
 (e.g. don't pull `latest`.)
 
 ```ucm
-.> pull unison.public.base.latest .base
+.> pull unison.public.base.releases.v2_0_0 .base
 .> compile.native.fetch
 ```

--- a/unison-src/builtin-tests/base.md
+++ b/unison-src/builtin-tests/base.md
@@ -5,6 +5,6 @@ Thus, make sure the contents of this file define the contents of the cache
 (e.g. don't pull `latest`.)
 
 ```ucm
-.> pull unison.public.base.releases.v2_0_0 .base
+.> pull @unison/base/releases/2.0.0 .base
 .> compile.native.fetch
 ```

--- a/unison-src/builtin-tests/base.output.md
+++ b/unison-src/builtin-tests/base.output.md
@@ -5,7 +5,7 @@ Thus, make sure the contents of this file define the contents of the cache
 (e.g. don't pull `latest`.)
 
 ```ucm
-.> pull unison.public.base.releases.v2_0_0 .base
+.> pull @unison/base/releases/2.0.0 .base
 
   Downloaded 11980 entities.
 

--- a/unison-src/builtin-tests/base.output.md
+++ b/unison-src/builtin-tests/base.output.md
@@ -5,7 +5,7 @@ Thus, make sure the contents of this file define the contents of the cache
 (e.g. don't pull `latest`.)
 
 ```ucm
-.> pull unison.public.base.latest .base
+.> pull unison.public.base.releases.v2_0_0 .base
 
   Downloaded 11980 entities.
 


### PR DESCRIPTION
See diff.

#4038 invalidates the `base.unison` cache whenever `base.md` changes, so feel free to update `base.md` with any immutable version of `base`