### PR TITLE
Fill out array primops, with tests

### DIFF
--- a/scheme-libs/racket/unison/primops.ss
+++ b/scheme-libs/racket/unison/primops.ss
@@ -100,6 +100,7 @@
     unison-FOp-ImmutableArray.copyTo!
     unison-FOp-ImmutableArray.read
 
+    unison-FOp-MutableArray.copyTo!
     unison-FOp-MutableArray.freeze!
     unison-FOp-MutableArray.freeze
     unison-FOp-MutableArray.read
@@ -124,8 +125,18 @@
     unison-FOp-ImmutableByteArray.read56be
     unison-FOp-ImmutableByteArray.read64be
 
+    unison-FOp-MutableByteArray.copyTo!
     unison-FOp-MutableByteArray.freeze!
     unison-FOp-MutableByteArray.write8
+    unison-FOp-MutableByteArray.write16be
+    unison-FOp-MutableByteArray.write32be
+    unison-FOp-MutableByteArray.write64be
+    unison-FOp-MutableByteArray.read8
+    unison-FOp-MutableByteArray.read16be
+    unison-FOp-MutableByteArray.read24be
+    unison-FOp-MutableByteArray.read32be
+    unison-FOp-MutableByteArray.read40be
+    unison-FOp-MutableByteArray.read64be
 
     unison-FOp-Scope.bytearray
     unison-FOp-Scope.bytearrayOf
@@ -321,7 +332,9 @@
                  string->bytes/utf-8
                  exn:fail:contract?
                  with-handlers
-                 sequence-ref)
+                 sequence-ref
+                 vector-copy!
+                 bytes-copy!)
            (car icar) (cdr icdr))
           (unison bytevector)
           (unison core)
@@ -670,12 +683,14 @@
   (define (unison-FOp-ImmutableArray.copyTo! dst doff src soff n)
     (catch-array
       (lambda ()
-        (let next ([i (fx1- n)])
-          (if (< i 0)
-            (sum 1 #f)
-            (begin
-              (vector-set! dst (+ doff i) (vector-ref src (+ soff i)))
-              (next (fx1- i))))))))
+        (vector-copy! dst doff src soff n)
+        (sum 1))))
+
+  (define (unison-FOp-MutableArray.copyTo! dst doff src soff l)
+    (catch-array
+      (lambda ()
+        (vector-copy! dst doff src soff l)
+        (sum 1))))
 
   (define unison-FOp-MutableArray.freeze! freeze-vector!)
 
@@ -695,13 +710,19 @@
   (define (unison-FOp-ImmutableByteArray.copyTo! dst doff src soff n)
     (catch-array
       (lambda ()
-        (bytevector-copy! src soff dst doff n)
-        (sum 1 #f))))
+        (bytes-copy! dst doff src soff n)
+        (sum 1))))
 
   (define (unison-FOp-ImmutableByteArray.read8 arr i)
     (catch-array
       (lambda ()
         (sum 1 (bytevector-u8-ref arr i)))))
+
+  (define (unison-FOp-MutableByteArray.copyTo! dst doff src soff l)
+    (catch-array
+      (lambda ()
+        (bytes-copy! dst doff src soff l)
+        (sum 1))))
 
   (define unison-FOp-MutableByteArray.freeze! freeze-bytevector!)
 
@@ -710,6 +731,54 @@
       (lambda ()
         (bytevector-u8-set! arr i b)
         (sum 1))))
+
+  (define (unison-FOp-MutableByteArray.write16be arr i b)
+    (catch-array
+      (lambda ()
+        (bytevector-u16-set! arr i b 'big)
+        (sum 1))))
+
+  (define (unison-FOp-MutableByteArray.write32be arr i b)
+    (catch-array
+      (lambda ()
+        (bytevector-u32-set! arr i b 'big)
+        (sum 1))))
+
+  (define (unison-FOp-MutableByteArray.write64be arr i b)
+    (catch-array
+      (lambda ()
+        (bytevector-u64-set! arr i b 'big)
+        (sum 1))))
+
+  (define (unison-FOp-MutableByteArray.read8 arr i)
+    (catch-array
+      (lambda ()
+        (sum 1 (bytevector-u8-ref arr i)))))
+
+  (define (unison-FOp-MutableByteArray.read16be arr i)
+    (catch-array
+      (lambda ()
+        (sum 1 (bytevector-u16-ref arr i 'big)))))
+
+  (define (unison-FOp-MutableByteArray.read24be arr i)
+    (catch-array
+      (lambda ()
+        (sum 1 (bytevector-u24-ref arr i 'big)))))
+
+  (define (unison-FOp-MutableByteArray.read32be arr i)
+    (catch-array
+      (lambda ()
+        (sum 1 (bytevector-u32-ref arr i 'big)))))
+
+  (define (unison-FOp-MutableByteArray.read40be arr i)
+    (catch-array
+      (lambda ()
+        (sum 1 (bytevector-u40-ref arr i 'big)))))
+
+  (define (unison-FOp-MutableByteArray.read64be arr i)
+    (catch-array
+      (lambda ()
+        (sum 1 (bytevector-u64-ref arr i 'big)))))
 
   (define (unison-FOp-Scope.bytearray n) (make-bytevector n))
   (define (unison-FOp-IO.bytearray n) (make-bytevector n))

--- a/unison-src/builtin-tests/array-tests.u
+++ b/unison-src/builtin-tests/array-tests.u
@@ -1,0 +1,99 @@
+checkBytesII src larr rarr i =
+  l = data.ByteArray.Raw.read8 larr i
+  r = data.ByteArray.Raw.read8 rarr i
+  if l == r
+    then if i > 0 then checkBytesII src larr rarr (l-1) else pass src
+    else let
+      tl = Debug.toText l
+      tr = Debug.toText r
+      fail src ("`" ++ tl ++ "` is not equal to `" ++ tr ++ "`")
+
+checkBytesMI src marr iarr i =
+  l = mutable.ByteArray.Raw.read8 marr i
+  r = data.ByteArray.Raw.read8 iarr i
+  if l == r
+    then if i > 0 then checkBytesMI src marr iarr (l-1) else pass src
+    else let
+      tl = Debug.toText l
+      tr = Debug.toText r
+      fail src ("`" ++ tl ++ "` is not equal to `" ++ tr ++ "`")
+
+checkBytesMM src larr rarr i =
+  l = mutable.ByteArray.Raw.read8 larr i
+  r = mutable.ByteArray.Raw.read8 rarr i
+  if l == r
+    then if i > 0 then checkBytesMM src larr rarr (l-1) else pass src
+    else let
+      tl = Debug.toText l
+      tr = Debug.toText r
+      fail src ("`" ++ tl ++ "` is not equal to `" ++ tr ++ "`")
+
+boxarrTests : '{IO,Exception,Tests} ()
+boxarrTests = do
+  iarr = Scope.run do
+    marr = Scope.Raw.array 1
+    checkEqual "boxed array/msize" (Array.Raw.size marr) 1
+    Array.Raw.write marr 0 "hello"
+    checkEqual "boxed mut read/write" (Array.Raw.read marr 0) "hello"
+    freeze marr 0 1
+  checkEqual "boxed new/size" (Array.Raw.size iarr) 1
+  checkEqual "boxed imm read/write" (Array.Raw.read iarr 0) "hello"
+
+  iarr2 = Scope.run do
+    marr = Scope.Raw.array 1
+    data.Array.Raw.copyTo! marr 0 iarr 0 1
+    checkEqual "immuntable copyTo!" (Raw.read marr 0) "hello"
+    marr2 = Scope.Raw.arrayOf "goodbye" 1
+    mutable.Array.Raw.copyTo! marr2 0 marr 0 1
+    checkEqual "mutable copyTo!" (Raw.read marr 0) "hello"
+    freeze! marr2
+
+  checkEqual "boxed immutable copied" (Raw.read iarr2 0) "hello"
+
+bytearrTests : '{IO,Exception,Tests} ()
+bytearrTests = do
+  iarr = ByteArray.Raw.new! 32 (marr -> let
+    checkEqual "byte new/msize" (ByteArray.Raw.size marr) 32
+    ByteArray.Raw.write64be marr 0  0xffffffff
+    ByteArray.Raw.write32be marr 8  0xffff
+    ByteArray.Raw.write16be marr 12 0xff
+    ByteArray.Raw.write8    marr 14 0xf
+    n64 = mutable.ByteArray.Raw.read64be marr 0
+    n40 = mutable.ByteArray.Raw.read40be marr 0
+    n32 = mutable.ByteArray.Raw.read32be marr 8
+    n24 = mutable.ByteArray.Raw.read24be marr 8
+    n16 = mutable.ByteArray.Raw.read16be marr 12
+    n8  = mutable.ByteArray.Raw.read8    marr 14
+    checkEqual "byte mut read/write 64" n64 0xffffffff
+    checkEqual "byte mut read/write 40" n40 0xff
+    checkEqual "byte mut read/write 32" n32 0xffff
+    checkEqual "byte mut read/write 24" n24 0xff
+    checkEqual "byte mut read/write 16" n16 0xff
+    checkEqual "byte mut read/write 8"  n8  0xf)
+  checkEqual "byte new/size" (ByteArray.Raw.size iarr) 32
+  n64 = data.ByteArray.Raw.read64be iarr 0
+  n40 = data.ByteArray.Raw.read40be iarr 0
+  n32 = data.ByteArray.Raw.read32be iarr 8
+  n24 = data.ByteArray.Raw.read24be iarr 8
+  n16 = data.ByteArray.Raw.read16be iarr 12
+  n8  = data.ByteArray.Raw.read8    iarr 14
+  checkEqual "byte imm read/write 64" n64 0xffffffff
+  checkEqual "byte imm read/write 40" n40 0xff
+  checkEqual "byte imm read/write 32" n32 0xffff
+  checkEqual "byte imm read/write 24" n24 0xff
+  checkEqual "byte imm read/write 16" n16 0xff
+  checkEqual "byte imm read/write 8"  n8  0xf
+
+  iarr2 = Scope.run do
+    marr = Scope.Raw.byteArray 32
+    data.ByteArray.Raw.copyTo! marr 0 iarr 0 32
+    checkBytesMI "byte immutable copyTo!" marr iarr 31
+    marr2 = Scope.Raw.byteArray 32
+    mutable.ByteArray.Raw.copyTo! marr2 0 marr 0 32
+    checkBytesMM "byte mutable copyTo!" marr2 marr 31
+    freeze! marr2
+  checkBytesII "byte immutable copied" iarr iarr2 31
+
+array.tests = do
+  !bytearrTests
+  !boxarrTests

--- a/unison-src/builtin-tests/interpreter-tests.md
+++ b/unison-src/builtin-tests/interpreter-tests.md
@@ -17,6 +17,11 @@ to `Tests.check` and `Tests.checkEqual`).
 ```
 
 ```ucm:hide
+.> load unison-src/builtin-tests/array-tests.u
+.> add
+```
+
+```ucm:hide
 .> load unison-src/builtin-tests/math-tests.u
 .> add
 ```

--- a/unison-src/builtin-tests/jit-tests.md
+++ b/unison-src/builtin-tests/jit-tests.md
@@ -19,6 +19,11 @@ to `Tests.check` and `Tests.checkEqual`).
 ```
 
 ```ucm:hide
+.> load unison-src/builtin-tests/array-tests.u
+.> add
+```
+
+```ucm:hide
 .> load unison-src/builtin-tests/math-tests.u
 .> add
 ```

--- a/unison-src/builtin-tests/tests.u
+++ b/unison-src/builtin-tests/tests.u
@@ -13,6 +13,7 @@ tests = Tests.main do
   !list.tests
   !text.tests
   !bytes.tests
+  !array.tests
 
 
 crypto.hash.tests = do


### PR DESCRIPTION
Adds several missing array primops, and adds tests for them to the jit tests.

Requires an associated unison share push, but I think that won't be as much of a factor with the jit tests temporarily out of CI.