### PR TITLE
Add required queries to clean up unreachable name lookups

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
@@ -79,6 +79,7 @@ module U.Codebase.Sqlite.Operations
     buildNameLookupForBranchHash,
     longestMatchingTermNameForSuffixification,
     longestMatchingTypeNameForSuffixification,
+    deleteOtherNameLookups,
 
     -- * reflog
     getReflog,
@@ -1249,3 +1250,11 @@ appendReflog :: Reflog.Entry CausalHash Text -> Transaction ()
 appendReflog entry = do
   dbEntry <- (bitraverse Q.saveCausalHash pure) entry
   Q.appendReflog dbEntry
+
+-- | Delete any name lookup that's not in the provided list.
+--
+-- This can be used to garbage collect unreachable name lookups.
+deleteOtherNameLookups :: Set BranchHash -> Transaction ()
+deleteOtherNameLookups reachable = do
+  bhIds <- for (Set.toList reachable) Q.expectBranchHashId
+  Q.deleteOtherNameLookups bhIds

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
@@ -79,7 +79,7 @@ module U.Codebase.Sqlite.Operations
     buildNameLookupForBranchHash,
     longestMatchingTermNameForSuffixification,
     longestMatchingTypeNameForSuffixification,
-    deleteOtherNameLookups,
+    deleteNameLookupsExceptFor,
 
     -- * reflog
     getReflog,
@@ -1254,7 +1254,7 @@ appendReflog entry = do
 -- | Delete any name lookup that's not in the provided list.
 --
 -- This can be used to garbage collect unreachable name lookups.
-deleteOtherNameLookups :: Set BranchHash -> Transaction ()
-deleteOtherNameLookups reachable = do
+deleteNameLookupsExceptFor :: Set BranchHash -> Transaction ()
+deleteNameLookupsExceptFor reachable = do
   bhIds <- for (Set.toList reachable) Q.expectBranchHashId
-  Q.deleteOtherNameLookups bhIds
+  Q.deleteNameLookupsExceptFor bhIds

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -188,7 +188,7 @@ module U.Codebase.Sqlite.Queries
     typeNamesBySuffix,
     longestMatchingTermNameForSuffixification,
     longestMatchingTypeNameForSuffixification,
-    deleteOtherNameLookups,
+    deleteNameLookupsExceptFor,
 
     -- * Reflog
     appendReflog,
@@ -1847,8 +1847,8 @@ checkBranchHashNameLookupExists hashId = do
 -- | Delete any name lookup that's not in the provided list.
 --
 -- This can be used to garbage collect unreachable name lookups.
-deleteOtherNameLookups :: [BranchHashId] -> Transaction ()
-deleteOtherNameLookups hashIds = do
+deleteNameLookupsExceptFor :: [BranchHashId] -> Transaction ()
+deleteNameLookupsExceptFor hashIds = do
   case hashIds of
     [] -> execute [sql| DELETE FROM name_lookups |]
     (x : xs) -> do

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -27,6 +27,7 @@ module U.Codebase.Sqlite.Queries
     expectHashIdByHash,
     saveCausalHash,
     expectCausalHash,
+    expectBranchHashForCausalHash,
     saveBranchHash,
 
     -- * hash_object table
@@ -187,6 +188,7 @@ module U.Codebase.Sqlite.Queries
     typeNamesBySuffix,
     longestMatchingTermNameForSuffixification,
     longestMatchingTypeNameForSuffixification,
+    deleteOtherNameLookups,
 
     -- * Reflog
     appendReflog,
@@ -542,6 +544,11 @@ expectHash32 h =
 
 expectBranchHash :: BranchHashId -> Transaction BranchHash
 expectBranchHash = coerce expectHash
+
+expectBranchHashForCausalHash :: CausalHash -> Transaction BranchHash
+expectBranchHashForCausalHash ch = do
+  (_, bhId)<- expectCausalByCausalHash ch
+  expectBranchHash bhId
 
 saveText :: Text -> Transaction TextId
 saveText t = do
@@ -1836,6 +1843,25 @@ checkBranchHashNameLookupExists hashId = do
         LIMIT 1
       )
     |]
+
+-- | Delete any name lookup that's not in the provided list.
+--
+-- This can be used to garbage collect unreachable name lookups.
+deleteOtherNameLookups :: [BranchHashId] -> Transaction ()
+deleteOtherNameLookups hashIds = do
+  case hashIds of
+    [] -> execute [sql| DELETE FROM name_lookups |]
+    (x : xs) -> do
+      let hashIdValues :: NonEmpty (Only BranchHashId)
+          hashIdValues = coerce (x NonEmpty.:| xs)
+      execute
+        [sql|
+          WITH reachable(branch_hash_id) AS (
+            VALUES :hashIdValues
+          )
+          DELETE FROM name_lookups
+            WHERE root_branch_hash_id NOT IN (SELECT branch_hash_id FROM reachable);
+        |]
 
 -- | Insert the given set of term names into the name lookup table
 insertScopedTermNames :: BranchHashId -> [NamedRef (Referent.TextReferent, Maybe NamedRef.ConstructorType)] -> Transaction ()


### PR DESCRIPTION
## Overview

Because of the append-only nature of name-lookups we've collected a lot of them and they're significantly bloating Share's codebases. This introduces the query I need to be able to clean up unreachable name lookups from Share. 

Running a GC on Stew's 42GB share codebase dropped it to 1.4 GB.

These name lookups make up the majority of the data stored in the codebases on Share at the moment. 

See https://github.com/unisoncomputing/enlil/pull/246 which adds an admin endpoint to run this clean-up on every codebase, by deleting most of the unused ones name lookups in advance I hope to significantly speed up the migration and reduce the amount of down-time we require.

## Implementation notes

Adds `deleteOtherNameLookups` helpers which takes a set of branch hashes which are required and reachable on Share and it deletes name look ups for all the OTHER branch hashes.

## Interesting/controversial decisions

Ideally we'd do some sort of relational query within sqlite, but we can't at the moment because branches and releases are stored in postgres. At the moment no project has more than a dozen branches so it's not an issue at the moment.

The long term plan is to move name-lookups into Postgres so we can run a clean up like this using a single transactional query.

## Test coverage

I'll test this thoroughly locally before running it, it's a pretty safe operation since name-lookups can always be restored if for some reason they get messed up.

## Loose ends

https://github.com/unisoncomputing/enlil/pull/246