### PR TITLE
fill out a few more project aliases

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectSwitch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectSwitch.hs
@@ -1,4 +1,4 @@
--- | @project.switch@ input handler
+-- | @switch@ input handler
 module Unison.Codebase.Editor.HandleInput.ProjectSwitch
   ( projectSwitch,
   )

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -725,7 +725,7 @@ deleteProject :: InputPattern
 deleteProject =
   InputPattern
     { patternName = "delete.project",
-      aliases = [],
+      aliases = ["project.delete"],
       visibility = I.Hidden,
       argTypes = [(Required, projectNameArg)],
       help = P.wrap "Delete a project.",
@@ -740,7 +740,7 @@ deleteBranch :: InputPattern
 deleteBranch =
   InputPattern
     { patternName = "delete.branch",
-      aliases = [],
+      aliases = ["branch.delete"],
       visibility = I.Hidden,
       argTypes = [(Required, projectBranchNameWithOptionalProjectNameArg)],
       help = P.wrap "Delete a project branch.",
@@ -2356,7 +2356,7 @@ projectCreate :: InputPattern
 projectCreate =
   InputPattern
     { patternName = "project.create",
-      aliases = ["create"],
+      aliases = ["create.project"],
       visibility = I.Hidden,
       argTypes = [(Required, projectNameArg)],
       help =
@@ -2375,14 +2375,14 @@ projectSwitch :: InputPattern
 projectSwitch =
   InputPattern
     { patternName = "switch",
-      aliases = ["project.switch"],
+      aliases = [],
       visibility = I.Hidden,
       argTypes = [(Required, projectAndBranchNamesArg)],
       help =
         P.wrapColumn2
-          [ ("`project.switch foo/bar`", "switches to the branch `bar` in the project `foo`"),
-            ("`project.switch foo/`", "switches to the last branch you visited in the project `foo`"),
-            ("`project.switch /bar`", "switches to the branch `bar` in the current project")
+          [ ("`switch foo/bar`", "switches to the branch `bar` in the project `foo`"),
+            ("`switch foo/`", "switches to the last branch you visited in the project `foo`"),
+            ("`switch /bar`", "switches to the branch `bar` in the current project")
           ],
       parse = \case
         [name] ->
@@ -2396,7 +2396,7 @@ projects :: InputPattern
 projects =
   InputPattern
     { patternName = "projects",
-      aliases = [],
+      aliases = ["list.project", "ls.project", "project.list"],
       visibility = I.Hidden,
       argTypes = [],
       help = P.wrap "List projects.",
@@ -2407,7 +2407,7 @@ branches :: InputPattern
 branches =
   InputPattern
     { patternName = "branches",
-      aliases = [],
+      aliases = ["list.branch", "ls.branch", "branch.list"],
       visibility = I.Hidden,
       argTypes = [],
       help = P.wrap "List branches.",
@@ -2418,7 +2418,7 @@ branchInputPattern :: InputPattern
 branchInputPattern =
   InputPattern
     { patternName = "branch",
-      aliases = [],
+      aliases = ["branch.create", "create.branch"],
       visibility = I.Hidden,
       argTypes = [],
       help =
@@ -2446,7 +2446,7 @@ branchEmptyInputPattern :: InputPattern
 branchEmptyInputPattern =
   InputPattern
     { patternName = "branch.empty",
-      aliases = [],
+      aliases = ["branch.create-empty", "create.empty-branch"],
       visibility = I.Hidden,
       argTypes = [],
       help = P.wrap "Create a new empty branch.",
@@ -2503,7 +2503,7 @@ releaseDraft :: InputPattern
 releaseDraft =
   InputPattern
     { patternName = "release.draft",
-      aliases = [],
+      aliases = ["draft.release"],
       visibility = I.Hidden,
       argTypes = [],
       help = P.wrap "Draft a release.",


### PR DESCRIPTION
## Overview

This PR adds a few more aliases to project-related commands, moving towards supporting every `noun.verb` and `verb.noun` permutation.

A few of these were judgement calls (e.g. what do we want to do about `branch.empty`, it's a `noun.adjective` :|), so LMK what to tweak from here.

---

| old aliases | removed aliases | added aliases | end result |
| --- | --- | --- | --- |
| `branch` | | `branch.create`<br>`create.branch` | `branch`<br>`branch.create`<br>`create.branch` |
| `branch.empty` | | `branch.create-empty`<br>`create.empty-branch` | `branch.create-empty`<br>`branch.empty`<br>`create.empty-branch` |
| `branches` | | `branch.list`<br>`ls.branch`<br>`list.branch` | `branch.list`<br>`branches`<br>`ls.branch`<br>`list.branch` |
| `create`<br>`project.create` | `create` | `create.project` | `create.project`<br>`project.create` |
| `delete.project` | | `project.delete` | `delete.project`<br>`project.delete`
| `delete.branch` | | `branch.delete ` | `delete.branch`<br>`branch.delete`
| `project.switch`<br>`switch` | `project.switch` | | `switch` |
| `projects` | | `list.project`<br>`ls.project`<br>`project.list` | `list.project`<br>`ls.project`<br>`project.list`<br>`projects` |
| `release.draft` | | `draft.release` | `draft.release`<br>`release.draft` |
