### PR TITLE
Readonly Sqlite mode

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
@@ -452,7 +452,7 @@ listWatches k = Q.loadWatchesByWatchKind k >>= traverse h2cReferenceId
 -- | returns Nothing if the expression isn't cached.
 loadWatch :: WatchKind -> C.Reference.Id -> MaybeT Transaction (C.Term Symbol)
 loadWatch k r = do
-  r' <- C.Reference.idH (lift . Q.saveHashHash) r
+  r' <- C.Reference.idH (MaybeT . Q.loadHashIdByHash) r
   S.Term.WatchResult wlids t <- MaybeT (Q.loadWatch k r' decodeWatchResultFormat)
   lift (w2cTerm wlids t)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,7 +98,7 @@ $ UNISON_SHARE_ACCESS_TOKEN="my.token.string" ucm
 
 ### `UNISON_READONLY`
 
-Force ucm to use readonly connections to codebases.
+Force unison to use readonly connections to codebases.
 
 ```sh
 $ UNISON_READONLY="true" ucm

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,6 +96,14 @@ E.g.
 $ UNISON_SHARE_ACCESS_TOKEN="my.token.string" ucm
 ```
 
+### `UNISON_READONLY`
+
+Force ucm to use readonly connections to codebases.
+
+```sh
+$ UNISON_READONLY="true" ucm
+```
+
 ### Local Codebase Server
 
 The port, host and token to be used for the local codebase server can all be configured by providing environment

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -1044,7 +1044,7 @@ evalDocRef rt codebase r = do
       r <- fmap hush . liftIO $ Rt.evaluateTerm' codeLookup cache evalPPE rt tm
       -- Only cache watches when we're not in readonly mode
       Env.lookupEnv "UNISON_READONLY" >>= \case
-        Just (_:_) -> pure ()
+        Just (_ : _) -> pure ()
         _ -> do
           case r of
             Just tmr ->

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -136,7 +136,6 @@ import Unison.ConstructorReference (GConstructorReference (..))
 import Unison.ConstructorReference qualified as ConstructorReference
 import Unison.ConstructorType qualified as CT
 import Unison.DataDeclaration qualified as DD
-import Unison.Debug qualified as Debug
 import Unison.HashQualified qualified as HQ
 import Unison.HashQualified' qualified as HQ'
 import Unison.Hashing.V2.Convert qualified as Hashing
@@ -199,6 +198,7 @@ import Unison.Util.Set qualified as Set
 import Unison.Util.SyntaxText qualified as UST
 import Unison.Var (Var)
 import Unison.WatchKind qualified as WK
+import UnliftIO.Environment qualified as Env
 
 type SyntaxText = UST.SyntaxText' Reference
 


### PR DESCRIPTION
# Overview

We can merge this into trunk, or optionally I can just create a custom build from this whenever we want to stand up a READONLY replica.

Adds support for a `UNISON_READONLY=true` env var which causes the sqlite lib to open all sqlite connections in readonly mode.

We want this so we can still serve traffic from a Share instance during a migration but prevent users from pushing/writing any code to the copy of the codebase while we're migrating it elsewhere.

I tested locally and with these tweaks we can successfully pull code and code-browse in readonly mode.

Any calls to endpoints which write to sqlite will just 500. It might be nice to catch the sqlite errors and respond with some nicer error, but sqlite doesn't seem terribly consistent about which type of error it throws and we'll plan to show some sort of "We're migrating, expect some errors" banner anyways so it's probably not worth the effort.

# Implementation

* Check the `UNISON_READONLY` env var when opening sqlite connections to see if we're in readonly mode, if so, use SQLit's file URI syntax to specify the readonly flag.
* Check the `UNISON_READONLY` env var when evaluating docs to decide whether to save the eval'd doc in the watch cache, since it will fail if we're in READONLY mode.
* Replace a `saveHashHash` in `loadWatch` with `loadHashIdByHash`. If the hash wasn't saved in the DB then the watch expression couldn't possibly be found anyways so this shouldn't be any observable change.

# Testing

I tested it locally.
Transcripts are sufficient for testing that everything works the same with it disabled.
