### PR TITLE
add "IN :param" form to sql quasi-quoter

### DIFF
--- a/lib/unison-sqlite/test/Main.hs
+++ b/lib/unison-sqlite/test/Main.hs
@@ -28,6 +28,11 @@ test =
             let expected = Right [ParsedOuterLump "? ? ?" [RowParam "foo" 1, RowParam "bar" 2]]
             let actual = internalParseSql sql
             expectEqual expected actual,
+          scope "parses IN :param syntax" do
+            let sql = "IN :foo"
+            let expected = Right [ParsedInLump "foo"]
+            let actual = internalParseSql sql
+            expectEqual expected actual,
           scope "parses VALUES :param syntax" do
             let sql = "VALUES :foo"
             let expected = Right [ParsedValuesLump "foo"]


### PR DESCRIPTION
## Overview

This PR adds an `IN :param` form to our SQL quasi-quoter.

From the [SQLite docs](https://www.sqlite.org/lang_expr.html#the_in_and_not_in_operators) on the `IN` expression,

> If the right operand of an IN or NOT IN operator is a list of values, each of those values must be scalars

Thus, `:param` must be a `ToField a => [a]`, and the form expands to `IN (?, ?, ?)` (with one `?` per element in `:param`, of course).

## Test coverage

I added a test for the parser, and also manually experimented at the repl:

```
> let foo = [1::Int,2,3] in [sql| IN :foo |]
Sql {query = "IN (?, ?, ?)", params = [SQLInteger 1,SQLInteger 2,SQLInteger 3]}
```