### PR TITLE
add optional project name argument to `branches` command

### DIFF
--- a/unison-cli/src/Unison/Cli/ProjectUtils.hs
+++ b/unison-cli/src/Unison/Cli/ProjectUtils.hs
@@ -3,6 +3,7 @@ module Unison.Cli.ProjectUtils
   ( -- * Project/path helpers
     getCurrentProject,
     expectCurrentProject,
+    getCurrentProjectIds,
     getCurrentProjectBranch,
     expectCurrentProjectBranch,
     projectPath,
@@ -66,6 +67,11 @@ getCurrentProject = do
 expectCurrentProject :: Cli Sqlite.Project
 expectCurrentProject = do
   getCurrentProject & onNothingM (Cli.returnEarly Output.NotOnProjectBranch)
+
+-- | Get the current project ids that a user is on.
+getCurrentProjectIds :: Cli (Maybe (ProjectAndBranch ProjectId ProjectBranchId))
+getCurrentProjectIds =
+  fmap fst . preview projectBranchPathPrism <$> Cli.getCurrentPath
 
 -- | Get the current project+branch+branch path that a user is on.
 getCurrentProjectBranch :: Cli (Maybe (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch, Path.Path))

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1400,7 +1400,7 @@ loop e = do
             ProjectCreateI name -> projectCreate name
             ProjectsI -> handleProjects
             BranchI source name -> handleBranch source name
-            BranchesI -> handleBranches
+            BranchesI name -> handleBranches name
             CloneI remoteNames localNames -> handleClone remoteNames localNames
             ReleaseDraftI semver -> handleReleaseDraft semver
 
@@ -1575,7 +1575,7 @@ inputDescription input =
     ApiI -> wat
     AuthLoginI {} -> wat
     BranchI {} -> wat
-    BranchesI -> wat
+    BranchesI {} -> wat
     CloneI {} -> wat
     CreateMessage {} -> wat
     DebugClearWatchI {} -> wat

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Branches.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Branches.hs
@@ -7,18 +7,37 @@ where
 import Control.Lens (mapped, over, (^.), _2)
 import Data.Map.Strict qualified as Map
 import Network.URI (URI)
+import U.Codebase.Sqlite.Project qualified as Sqlite
 import U.Codebase.Sqlite.Queries qualified as Queries
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.ProjectUtils qualified as ProjectUtils
 import Unison.Codebase.Editor.Output qualified as Output
 import Unison.Prelude
-import Unison.Project (ProjectBranchName, ProjectName)
+import Unison.Project (ProjectAndBranch (..), ProjectBranchName, ProjectName)
+import Unison.Sqlite qualified as Sqlite
 
-handleBranches :: Cli ()
-handleBranches = do
-  project <- ProjectUtils.expectCurrentProject
-  branches <- Cli.runTransaction (Queries.loadAllProjectBranchInfo (project ^. #projectId))
+handleBranches :: Maybe ProjectName -> Cli ()
+handleBranches maybeProjectName = do
+  maybeCurrentProjectIds <- ProjectUtils.getCurrentProjectIds
+  (project, branches) <-
+    Cli.runEitherTransaction do
+      let loadProject :: Sqlite.Transaction (Either Output.Output Sqlite.Project)
+          loadProject =
+            case maybeProjectName of
+              Just projectName -> do
+                Queries.loadProjectByName projectName <&> \case
+                  Nothing -> Left (Output.LocalProjectDoesntExist projectName)
+                  Just project -> Right project
+              Nothing ->
+                case maybeCurrentProjectIds of
+                  Just (ProjectAndBranch projectId _) -> Right <$> Queries.expectProject projectId
+                  Nothing -> pure (Left Output.NotOnProjectBranch)
+      loadProject >>= \case
+        Left err -> pure (Left err)
+        Right project -> do
+          branches <- Queries.loadAllProjectBranchInfo (project ^. #projectId)
+          pure (Right (project, branches))
   Cli.respondNumbered (Output.ListBranches (project ^. #name) (f branches))
   where
     f ::

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -225,7 +225,7 @@ data Input
   | ProjectSwitchI ProjectAndBranchNames
   | ProjectsI
   | BranchI BranchSourceI (ProjectAndBranch (Maybe ProjectName) ProjectBranchName)
-  | BranchesI
+  | BranchesI (Maybe ProjectName)
   | CloneI ProjectAndBranchNames (Maybe ProjectAndBranchNames)
   | ReleaseDraftI Semver
   deriving (Eq, Show)

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2410,8 +2410,15 @@ branches =
       aliases = [],
       visibility = I.Hidden,
       argTypes = [],
-      help = P.wrap "List branches.",
-      parse = \_ -> Right Input.BranchesI
+      help =
+        P.wrapColumn2
+          [ ("`branches`", "lists all branches in the current project"),
+            ("`branches foo", "lists all branches in the project `foo`")
+          ],
+      parse = \case
+        [] -> Right (Input.BranchesI Nothing)
+        [nameString] | Right name <- tryFrom (Text.pack nameString) -> Right (Input.BranchesI (Just name))
+        _ -> Left (showPatternHelp branches)
     }
 
 branchInputPattern :: InputPattern


### PR DESCRIPTION
## Overview

This PR adds an optional project name to the `branches` command.

<img width="367" alt="Screen Shot 2023-06-01 at 2 39 13 PM" src="https://github.com/unisonweb/unison/assets/1074598/49ca6f14-f6b1-4ef4-8eb5-d70cca6815cc">

Along the way, I generalized how the project name parser works (so `branches foo/` works), which probably made a couple other commands work a little more intuitively as well. In short, wherever a project name is expected, a trailing forward slash should be accepted.

## Test coverage

I manually tested this