### PR TITLE
add `project.rename` command

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -108,6 +108,7 @@ module U.Codebase.Sqlite.Queries
     loadAllProjects,
     loadAllProjectsBeginningWith,
     insertProject,
+    renameProject,
     deleteProject,
 
     -- ** project branches
@@ -2947,6 +2948,18 @@ insertProject uuid name =
     [sql|
       INSERT INTO project (id, name)
       VALUES (:uuid, :name)
+    |]
+
+-- | Rename a `project` row.
+--
+-- Precondition: the new name is available.
+renameProject :: ProjectId -> ProjectName -> Transaction ()
+renameProject projectId name =
+  execute
+    [sql|
+      UPDATE project
+      SET name = :name
+      WHERE id = :projectId
     |]
 
 -- | Does a project branch exist by this name?

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -88,6 +88,7 @@ import Unison.Codebase.Editor.HandleInput.NamespaceDependencies qualified as Nam
 import Unison.Codebase.Editor.HandleInput.NamespaceDiffUtils (diffHelper)
 import Unison.Codebase.Editor.HandleInput.ProjectClone (handleClone)
 import Unison.Codebase.Editor.HandleInput.ProjectCreate (projectCreate)
+import Unison.Codebase.Editor.HandleInput.ProjectRename (handleProjectRename)
 import Unison.Codebase.Editor.HandleInput.ProjectSwitch (projectSwitch)
 import Unison.Codebase.Editor.HandleInput.Projects (handleProjects)
 import Unison.Codebase.Editor.HandleInput.Pull (doPullRemoteBranch, mergeBranchAndPropagateDefaultPatch, propagatePatch)
@@ -1396,6 +1397,7 @@ loop e = do
             DiffNamespaceToPatchI diffNamespaceToPatchInput -> do
               description <- inputDescription input
               handleDiffNamespaceToPatch description diffNamespaceToPatchInput
+            ProjectRenameI name -> handleProjectRename name
             ProjectSwitchI name -> projectSwitch name
             ProjectCreateI name -> projectCreate name
             ProjectsI -> handleProjects
@@ -1608,7 +1610,8 @@ inputDescription input =
     PreviewAddI {} -> wat
     PreviewMergeLocalBranchI {} -> wat
     PreviewUpdateI {} -> wat
-    ProjectSwitchI _ -> wat
+    ProjectRenameI {} -> wat
+    ProjectSwitchI {} -> wat
     ProjectsI -> wat
     PushRemoteBranchI {} -> wat
     QuitI {} -> wat

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectRename.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectRename.hs
@@ -1,0 +1,27 @@
+-- | @project.rename@ input handler
+module Unison.Codebase.Editor.HandleInput.ProjectRename
+  ( handleProjectRename,
+  )
+where
+
+import Control.Lens ((^.))
+import U.Codebase.Sqlite.Queries qualified as Queries
+import Unison.Cli.Monad (Cli)
+import Unison.Cli.Monad qualified as Cli
+import Unison.Cli.ProjectUtils qualified as ProjectUtils
+import Unison.Codebase.Editor.Output qualified as Output
+import Unison.Prelude
+import Unison.Project (ProjectName)
+
+handleProjectRename :: ProjectName -> Cli ()
+handleProjectRename newName = do
+  project <- ProjectUtils.expectCurrentProject
+  let oldName = project ^. #name
+  when (oldName /= newName) do
+    Cli.runEitherTransaction do
+      Queries.loadProjectByName newName >>= \case
+        Just _ -> pure (Left (Output.ProjectNameAlreadyExists newName))
+        Nothing -> do
+          Queries.renameProject (project ^. #projectId) newName
+          pure (Right ())
+  Cli.respond (Output.RenamedProject oldName newName)

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -222,6 +222,7 @@ data Input
   | VersionI
   | DiffNamespaceToPatchI DiffNamespaceToPatchInput
   | ProjectCreateI ProjectName
+  | ProjectRenameI ProjectName
   | ProjectSwitchI ProjectAndBranchNames
   | ProjectsI
   | BranchI BranchSourceI (ProjectAndBranch (Maybe ProjectName) ProjectBranchName)

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -351,6 +351,7 @@ data Output
   | ClonedProjectBranch
       (ProjectAndBranch ProjectName ProjectBranchName)
       (ProjectAndBranch ProjectName ProjectBranchName)
+  | RenamedProject ProjectName ProjectName
 
 -- | What did we create a project branch from?
 --
@@ -563,6 +564,7 @@ isFailure o = case o of
   DraftingRelease {} -> False
   CannotCreateReleaseBranchWithBranchCommand {} -> True
   CalculatingDiff {} -> False
+  RenamedProject {} -> False
 
 isNumberedFailure :: NumberedOutput -> Bool
 isNumberedFailure = \case

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2371,6 +2371,22 @@ projectCreate =
         _ -> Left (showPatternHelp projectCreate)
     }
 
+projectRenameInputPattern :: InputPattern
+projectRenameInputPattern =
+  InputPattern
+    { patternName = "project.rename",
+      aliases = ["rename.project"],
+      visibility = I.Hidden,
+      argTypes = [],
+      help =
+        P.wrapColumn2
+          [ ("`project.rename foo`", "renames the current project to `foo`")
+          ],
+      parse = \case
+        [nameString] | Right name <- tryInto (Text.pack nameString) -> Right (Input.ProjectRenameI name)
+        _ -> Left (showPatternHelp projectRenameInputPattern)
+    }
+
 projectSwitch :: InputPattern
 projectSwitch =
   InputPattern
@@ -2594,6 +2610,7 @@ validInputs =
       previewUpdate,
       printVersion,
       projectCreate,
+      projectRenameInputPattern,
       projectSwitch,
       projects,
       pull,

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2069,7 +2069,7 @@ notifyUser dir = \case
   RenamedProject oldName newName ->
     pure . P.wrap $
       if oldName == newName
-        then "Ok, I didn't rename" <> P.group (prettyProjectName oldName <> ".")
+        then prettyProjectName oldName <> "is already named" <> P.group (prettyProjectName oldName <> "!") <> "😄"
         else "Ok, I renamed" <> prettyProjectName oldName <> "to" <> P.group (prettyProjectName newName <> ".")
   where
     _nameChange _cmd _pastTenseCmd _oldName _newName _r = error "todo"

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2066,6 +2066,11 @@ notifyUser dir = \case
         <> if remote == local
           then P.group (prettyProjectAndBranchName remote <> ".")
           else prettyProjectAndBranchName remote <> "as" <> P.group (prettyProjectAndBranchName local <> ".")
+  RenamedProject oldName newName ->
+    pure . P.wrap $
+      if oldName == newName
+        then "Ok, I didn't rename" <> P.group (prettyProjectName oldName <> ".")
+        else "Ok, I renamed" <> prettyProjectName oldName <> "to" <> P.group (prettyProjectName newName <> ".")
   where
     _nameChange _cmd _pastTenseCmd _oldName _newName _r = error "todo"
 

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -53,6 +53,7 @@ library
       Unison.Codebase.Editor.HandleInput.NamespaceDiffUtils
       Unison.Codebase.Editor.HandleInput.ProjectClone
       Unison.Codebase.Editor.HandleInput.ProjectCreate
+      Unison.Codebase.Editor.HandleInput.ProjectRename
       Unison.Codebase.Editor.HandleInput.Projects
       Unison.Codebase.Editor.HandleInput.ProjectSwitch
       Unison.Codebase.Editor.HandleInput.Pull


### PR DESCRIPTION
## Overview

This PR adds a one-argument `project.rename` command that renames the current project.

<img width="352" alt="Screen Shot 2023-06-01 at 3 20 38 PM" src="https://github.com/unisonweb/unison/assets/1074598/7a6107ec-a521-47ad-8397-cb17cc815089">


Here's what the help output currently says:

<img width="671" alt="Screen Shot 2023-06-01 at 3 24 38 PM" src="https://github.com/unisonweb/unison/assets/1074598/41c246cb-786d-4bb3-b996-10e859fb8c04">

## Test coverage

No automated tests or transcripts; I didn't feel this was complicated enough to need one. I tested manually.