### PR TITLE
clone tweak: don't fall back on a name comparison for project

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -321,7 +321,7 @@ data Output
   | -- there's no remote project associated with branch, nor any of its parent branches
     NoAssociatedRemoteProject URI (ProjectAndBranch ProjectName ProjectBranchName)
   | -- there's no remote branch associated with branch
-    NoAssociatedRemoteProjectBranch URI (ProjectAndBranch ProjectName ProjectBranchName)
+    NoAssociatedRemoteProjectBranch URI (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch)
   | LocalProjectDoesntExist ProjectName
   | LocalProjectBranchDoesntExist (ProjectAndBranch ProjectName ProjectBranchName)
   | LocalProjectNorProjectBranchExist ProjectName ProjectBranchName

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1848,9 +1848,11 @@ notifyUser dir = \case
   NoAssociatedRemoteProject host projectAndBranch ->
     pure . P.wrap $
       prettyProjectAndBranchName projectAndBranch <> "isn't associated with any project on" <> prettyURI host
-  NoAssociatedRemoteProjectBranch host projectAndBranch ->
+  NoAssociatedRemoteProjectBranch host (ProjectAndBranch project branch) ->
     pure . P.wrap $
-      prettyProjectAndBranchName projectAndBranch <> "isn't associated with any branch on" <> prettyURI host
+      prettyProjectAndBranchName (ProjectAndBranch (project ^. #name) (branch ^. #name))
+        <> "isn't associated with any branch on"
+        <> prettyURI host
   LocalProjectDoesntExist project ->
     pure . P.wrap $
       prettyProjectName project <> "does not exist."


### PR DESCRIPTION
## Overview

This PR fixes up a bit of a misfeature in `clone`.

Previously, when either cloning a `/branch` or when determining how to treat an ambiguous `thing` argument, the logic for identifying the remote project in question was:

1. If this branch has an associated remote branch, use the remote branch's project
2. Else if this branch has an ancestor with an associated remote branch, use the remote branch's project
3. Else use the remote project whose name matches the local project name

As of this PR, it's instead

1. If this branch has an associated remote branch, use the remote branch's project
2. Else if this branch has an ancestor with an associated remote branch, use the remote branch's project
3. ~~Else use the remote project whose name matches the local project name~~

i.e. we don't fall back on a final stringy name comparison. This is more intuitive, and consistent with how `pull` works.

## Test coverage

I tested this change manually.