### PR TITLE
Add `reset` command

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -398,6 +398,49 @@ loop e = do
                       -- No expectation, either because this is the most recent entry or
                       -- because we're recovering from a discontinuity
                       Nothing -> ((Just time, toRootCausalHash, reason), (rest, Just fromRootCausalHash, moreEntriesToLoad))
+            ResetI newRoot mtarget -> do
+              newRoot <-
+                case newRoot of
+                  Left hash -> Cli.resolveShortCausalHash hash
+                  Right path' -> Cli.expectBranchAtPath' path'
+              target <-
+                case mtarget of
+                  Nothing -> Cli.getCurrentPath
+                  Just looseCodeOrProject -> case looseCodeOrProject of
+                    This path' -> Cli.resolvePath' path'
+                    That (ProjectAndBranch mProjectName branchName) -> do
+                      let arg = case mProjectName of
+                            Nothing -> That branchName
+                            Just projectName -> These projectName branchName
+                      ProjectAndBranch project branch <- ProjectUtils.expectProjectAndBranchByTheseNames arg
+                      pure (ProjectUtils.projectBranchPath (ProjectAndBranch (project ^. #projectId) (branch ^. #branchId)))
+                    These path' (ProjectAndBranch mProjectName branchName) -> do
+                      absPath <- Cli.resolvePath' path'
+                      mrelativePath <-
+                        Cli.getMaybeBranchAt absPath <&> \case
+                          Nothing -> Nothing
+                          Just _ -> preview ProjectUtils.projectBranchPathPrism absPath
+                      projectAndBranch <- do
+                        let arg = case mProjectName of
+                              Nothing -> That branchName
+                              Just projectName -> These projectName branchName
+                        ProjectUtils.getProjectAndBranchByTheseNames arg
+                      case (mrelativePath, projectAndBranch) of
+                        (Nothing, Nothing) ->
+                          ProjectUtils.getCurrentProject >>= \case
+                            Nothing -> pure absPath
+                            Just project ->
+                              Cli.returnEarly (LocalProjectBranchDoesntExist (ProjectAndBranch (project ^. #name) branchName))
+                        (Just (projectAndBranch0, relPath), Just (ProjectAndBranch project branch)) -> do
+                          projectAndBranch0 <- Cli.runTransaction (ProjectUtils.expectProjectAndBranchByIds projectAndBranch0)
+                          Cli.respondNumbered (AmbiguousReset (projectAndBranch0, relPath) (ProjectAndBranch (project ^. #name) (branch ^. #name)))
+                          Cli.returnEarlyWithoutOutput
+                        (Just _relativePath, Nothing) -> pure absPath
+                        (Nothing, Just (ProjectAndBranch project branch)) ->
+                          pure (ProjectUtils.projectBranchPath (ProjectAndBranch (project ^. #projectId) (branch ^. #branchId)))
+              description <- inputDescription input
+              _ <- Cli.updateAt description target (const newRoot)
+              Cli.respond Success
             ResetRootI src0 ->
               Cli.time "reset-root" do
                 newRoot <-
@@ -1427,6 +1470,14 @@ inputDescription input =
               Branch.RegularMerge -> "merge"
               Branch.SquashMerge -> "merge.squash"
       pure (command <> " " <> src <> " " <> dest)
+    ResetI hash tgt -> do
+      hashTxt <- hp' hash
+      tgt <- case tgt of
+        Nothing -> pure ""
+        Just tgt -> do
+          tgt <- looseCodeOrProjectToText tgt
+          pure (" " <> tgt)
+      pure ("reset " <> hashTxt <> tgt)
     ResetRootI src0 -> do
       src <- hp' src0
       pure ("reset-root " <> src)

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -109,7 +109,12 @@ data Input
   | PullRemoteBranchI PullSourceTarget SyncMode PullMode Verbosity
   | PushRemoteBranchI PushRemoteBranchInput
   | ResetRootI (Either ShortCausalHash Path')
-  | ResetI (Either ShortCausalHash Path') (Maybe LooseCodeOrProject)
+  | ResetI
+      ( These
+          (Either ShortCausalHash Path')
+          (ProjectAndBranch (Maybe ProjectName) ProjectBranchName)
+      )
+      (Maybe LooseCodeOrProject)
   | -- todo: Q: Does it make sense to publish to not-the-root of a Github repo?
     --          Does it make sense to fork from not-the-root of a Github repo?
     -- used in Welcome module to give directions to user

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -109,6 +109,7 @@ data Input
   | PullRemoteBranchI PullSourceTarget SyncMode PullMode Verbosity
   | PushRemoteBranchI PushRemoteBranchInput
   | ResetRootI (Either ShortCausalHash Path')
+  | ResetI (Either ShortCausalHash Path') (Maybe LooseCodeOrProject)
   | -- todo: Q: Does it make sense to publish to not-the-root of a Github repo?
     --          Does it make sense to fork from not-the-root of a Github repo?
     -- used in Welcome module to give directions to user

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -116,6 +116,7 @@ data NumberedOutput
   | ListProjects [Sqlite.Project]
   | ListBranches ProjectName [(ProjectBranchName, [(URI, ProjectName, ProjectBranchName)])]
   | AmbiguousSwitch ProjectName (ProjectAndBranch ProjectName ProjectBranchName)
+  | AmbiguousReset (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch, Path.Path) (ProjectAndBranch ProjectName ProjectBranchName)
 
 --  | ShowDiff
 
@@ -572,6 +573,7 @@ isFailure o = case o of
 
 isNumberedFailure :: NumberedOutput -> Bool
 isNumberedFailure = \case
+  AmbiguousReset {} -> True
   AmbiguousSwitch {} -> True
   CantDeleteDefinitions {} -> True
   CantDeleteNamespace {} -> True

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -1,5 +1,6 @@
 module Unison.Codebase.Editor.Output
   ( Output (..),
+    AmbiguousReset'Argument (..),
     CreatedProjectBranchFrom (..),
     DisplayDefinitionsOutput (..),
     WhichBranchEmpty (..),
@@ -116,7 +117,11 @@ data NumberedOutput
   | ListProjects [Sqlite.Project]
   | ListBranches ProjectName [(ProjectBranchName, [(URI, ProjectName, ProjectBranchName)])]
   | AmbiguousSwitch ProjectName (ProjectAndBranch ProjectName ProjectBranchName)
-  | AmbiguousReset (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch, Path.Path) (ProjectAndBranch ProjectName ProjectBranchName)
+  | AmbiguousReset AmbiguousReset'Argument (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch, Path.Path) (ProjectAndBranch ProjectName ProjectBranchName)
+
+data AmbiguousReset'Argument
+  = AmbiguousReset'Hash
+  | AmbiguousReset'Target
 
 --  | ShowDiff
 

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1029,6 +1029,29 @@ forkLocal =
         _ -> Left (I.help forkLocal)
     )
 
+reset :: InputPattern
+reset =
+  InputPattern
+    "reset"
+    []
+    I.Visible
+    [ (Required, namespaceArg),
+      (Optional, namespaceArg)
+    ]
+    ""
+    ( \args -> do
+        case args of
+          arg0 : restArgs -> do
+            arg0 <- first fromString (Input.parseBranchId arg0)
+            arg1 <- case restArgs of
+              [] -> pure Nothing
+              arg1 : [] -> do
+                Just <$> first fromString (parseLooseCodeOrProject arg1)
+              _ -> Left (I.help reset)
+            Right (Input.ResetI arg0 arg1)
+          _ -> Left (I.help reset)
+    )
+
 resetRoot :: InputPattern
 resetRoot =
   InputPattern
@@ -2648,6 +2671,7 @@ validInputs =
       renameTerm,
       renameType,
       replace,
+      reset,
       resetRoot,
       runScheme,
       saveExecuteResult,

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1038,7 +1038,13 @@ reset =
     [ (Required, namespaceArg),
       (Optional, namespaceArg)
     ]
-    ""
+    ( P.wrapColumn2
+        [ ("`reset #pvfd222s8n`", "reset the current namespace to the causal `#pvfd222s8n`"),
+          ("`reset foo`", "reset the current namespace to that of the `foo` namespace."),
+          ("`reset foo bar`", "reset the namespace `bar` to that of the `foo` namespace."),
+          ("`reset #pvfd222s8n /topic`", "reset the branch `topic` of the current project to the causal `#pvfd222s8n`.")
+        ]
+    )
     ( \args -> do
         case args of
           arg0 : restArgs -> do

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -449,11 +449,11 @@ notifyNumbered = \case
     )
     where
       switch = IP.makeExample IP.projectSwitch
-  AmbiguousReset (ProjectAndBranch pn0 bn0, path) (ProjectAndBranch currentProject branch) ->
+  AmbiguousReset sourceOfAmbiguity (ProjectAndBranch pn0 bn0, path) (ProjectAndBranch currentProject branch) ->
     ( P.wrap
-        ( "I'm not sure if you wanted to reset the branch"
+        ( openingLine
             <> prettyProjectAndBranchName (ProjectAndBranch currentProject branch)
-            <> "or the namespace"
+            <> orTheNamespace
             <> relPath0
             <> "in the current branch."
             <> "Could you be more specific?"
@@ -468,9 +468,9 @@ notifyNumbered = \case
         <> P.newline
         <> tip
           ( "use "
-              <> reset ["1"]
+              <> reset (resetArgs ["1"])
               <> " or "
-              <> reset ["2"]
+              <> reset (resetArgs ["2"])
               <> " to pick one of these."
           ),
       [ Text.unpack (Text.cons '/' (into @Text branch)),
@@ -478,6 +478,15 @@ notifyNumbered = \case
       ]
     )
     where
+      openingLine = case sourceOfAmbiguity of
+        E.AmbiguousReset'Hash -> "I'm not sure if you wanted to reset to the branch"
+        E.AmbiguousReset'Target -> "I'm not sure if you wanted to reset the branch"
+      orTheNamespace = case sourceOfAmbiguity of
+        E.AmbiguousReset'Hash -> "or to the namespace"
+        E.AmbiguousReset'Target -> "or the namespace"
+      resetArgs = case sourceOfAmbiguity of
+        E.AmbiguousReset'Hash -> \xs -> xs
+        E.AmbiguousReset'Target -> \xs -> "<some hash>" : xs
       reset = IP.makeExample IP.reset
       relPath0 = prettyPath' (Path.toPath' path)
       absPath0 = review ProjectUtils.projectBranchPathPrism (ProjectAndBranch (pn0 ^. #projectId) (bn0 ^. #branchId), path)

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -42,6 +42,7 @@ import Unison.ABT qualified as ABT
 import Unison.Auth.Types qualified as Auth
 import Unison.Builtin.Decls qualified as DD
 import Unison.Cli.Pretty
+import Unison.Cli.ProjectUtils qualified as ProjectUtils
 import Unison.Codebase.Editor.DisplayObject (DisplayObject (BuiltinObject, MissingObject, UserObject))
 import Unison.Codebase.Editor.Input qualified as Input
 import Unison.Codebase.Editor.Output
@@ -448,6 +449,38 @@ notifyNumbered = \case
     )
     where
       switch = IP.makeExample IP.projectSwitch
+  AmbiguousReset (ProjectAndBranch pn0 bn0, path) (ProjectAndBranch currentProject branch) ->
+    ( P.wrap
+        ( "I'm not sure if you wanted to reset the branch"
+            <> prettyProjectAndBranchName (ProjectAndBranch currentProject branch)
+            <> "or the namespace"
+            <> relPath0
+            <> "in the current branch."
+            <> "Could you be more specific?"
+        )
+        <> P.newline
+        <> P.newline
+        <> P.numberedList
+          [ prettySlashProjectBranchName branch <> " (the branch " <> prettyProjectBranchName branch <> " in the current project)",
+            relPath0 <> " (the relative path " <> relPath0 <> " in the current branch)"
+          ]
+        <> P.newline
+        <> P.newline
+        <> tip
+          ( "use "
+              <> reset ["1"]
+              <> " or "
+              <> reset ["2"]
+              <> " to pick one of these."
+          ),
+      [ Text.unpack (Text.cons '/' (into @Text branch)),
+        Text.unpack (into @Text (show absPath0))
+      ]
+    )
+    where
+      reset = IP.makeExample IP.reset
+      relPath0 = prettyPath' (Path.toPath' path)
+      absPath0 = review ProjectUtils.projectBranchPathPrism (ProjectAndBranch (pn0 ^. #projectId) (bn0 ^. #branchId), path)
   where
     absPathToBranchId = Right
 

--- a/unison-src/transcripts/reset.md
+++ b/unison-src/transcripts/reset.md
@@ -1,0 +1,67 @@
+```ucm:hide
+.> builtins.merge
+```
+
+# reset loose code
+```unison
+a = 5
+```
+
+```ucm
+.> add
+.> history
+.> reset 2
+.> history
+```
+
+```unison
+foo.a = 5
+```
+
+```ucm
+.> add
+.> ls foo
+.> history
+.> reset 1 foo
+.> ls foo.foo
+```
+
+# reset branch
+
+```ucm
+.> project.create foo
+foo/main> history
+```
+
+```unison
+a = 5
+```
+
+```ucm
+foo/main> add
+foo/main> ls
+foo/main> history
+```
+
+```unison
+a = 3
+```
+
+```ucm
+foo/main> update
+foo/main> history
+foo/main> reset 2
+foo/main> history
+```
+
+# ambiguous reset
+
+```unison
+main.a = 3
+```
+
+```ucm:error
+foo/main> add
+foo/main> history
+foo/main> reset 2 main
+```

--- a/unison-src/transcripts/reset.md
+++ b/unison-src/transcripts/reset.md
@@ -39,7 +39,7 @@ a = 5
 
 ```ucm
 foo/main> add
-foo/main> ls
+foo/main> branch topic
 foo/main> history
 ```
 
@@ -49,13 +49,13 @@ a = 3
 
 ```ucm
 foo/main> update
-foo/main> history
-foo/main> reset 2
+foo/main> reset /topic
 foo/main> history
 ```
 
 # ambiguous reset
 
+## ambiguous target
 ```unison
 main.a = 3
 ```
@@ -64,4 +64,16 @@ main.a = 3
 foo/main> add
 foo/main> history
 foo/main> reset 2 main
+```
+
+## ambiguous hash
+
+```unison
+main.a = 3
+```
+
+```ucm:error
+foo/main> switch /topic
+foo/topic> add
+foo/topic> reset main
 ```

--- a/unison-src/transcripts/reset.output.md
+++ b/unison-src/transcripts/reset.output.md
@@ -130,9 +130,12 @@ foo/main> add
   
     a : Nat
 
-foo/main> ls
+foo/main> branch topic
 
-  1. a (##Nat)
+  Done. I've created the topic branch based off of main.
+  
+  Tip: Use `merge /topic /main` to merge your work back into the
+       main branch.
 
 foo/main> history
 
@@ -167,20 +170,7 @@ foo/main> update
   
     a : Nat
 
-foo/main> history
-
-  Note: The most recent namespace hash is immediately below this
-        message.
-  
-  ⊙ 1. #i6aoik7hpt
-  
-    + Adds / updates:
-    
-      a
-  
-  □ 2. #5l94rduvel (start of history)
-
-foo/main> reset 2
+foo/main> reset /topic
 
   Done.
 
@@ -196,6 +186,7 @@ foo/main> history
 ```
 # ambiguous reset
 
+## ambiguous target
 ```unison
 main.a = 3
 ```
@@ -235,6 +226,40 @@ foo/main> reset 2 main
 
   I'm not sure if you wanted to reset the branch foo/main or the
   namespace main in the current branch. Could you be more
+  specific?
+  
+  1. /main (the branch main in the current project)
+  2. main (the relative path main in the current branch)
+  
+  Tip: use `reset <some hash> 1` or `reset <some hash> 2` to
+       pick one of these.
+
+```
+## ambiguous hash
+
+```unison
+main.a = 3
+```
+
+```ucm
+
+  I found and typechecked the definitions in scratch.u. This
+  file has been previously added to the codebase.
+
+```
+```ucm
+foo/main> switch /topic
+
+foo/topic> add
+
+  ⍟ I've added these definitions:
+  
+    main.a : Nat
+
+foo/topic> reset main
+
+  I'm not sure if you wanted to reset to the branch foo/main or
+  to the namespace main in the current branch. Could you be more
   specific?
   
   1. /main (the branch main in the current project)

--- a/unison-src/transcripts/reset.output.md
+++ b/unison-src/transcripts/reset.output.md
@@ -1,0 +1,245 @@
+# reset loose code
+```unison
+a = 5
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      a : Nat
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    a : Nat
+
+.> history
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ 1. #5p3uvmtfif
+  
+    + Adds / updates:
+    
+      a
+  
+  □ 2. #acegso70di (start of history)
+
+.> reset 2
+
+  Done.
+
+.> history
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  
+  
+  □ 1. #acegso70di (start of history)
+
+```
+```unison
+foo.a = 5
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      foo.a : Nat
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    foo.a : Nat
+
+.> ls foo
+
+  1. a (Nat)
+
+.> history
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ 1. #5eud9b5t3r
+  
+    + Adds / updates:
+    
+      foo.a
+  
+  □ 2. #acegso70di (start of history)
+
+.> reset 1 foo
+
+  Done.
+
+.> ls foo.foo
+
+  1. a (Nat)
+
+```
+# reset branch
+
+```ucm
+.> project.create foo
+
+  I just created project foo with branch main.
+
+foo/main> history
+
+  ☝️  The namespace  is empty.
+
+```
+```unison
+a = 5
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      a : Nat
+
+```
+```ucm
+foo/main> add
+
+  ⍟ I've added these definitions:
+  
+    a : Nat
+
+foo/main> ls
+
+  1. a (##Nat)
+
+foo/main> history
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  
+  
+  □ 1. #5l94rduvel (start of history)
+
+```
+```unison
+a = 3
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      a : Nat
+
+```
+```ucm
+foo/main> update
+
+  ⍟ I've updated these names to your new definition:
+  
+    a : Nat
+
+foo/main> history
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ 1. #i6aoik7hpt
+  
+    + Adds / updates:
+    
+      a
+  
+  □ 2. #5l94rduvel (start of history)
+
+foo/main> reset 2
+
+  Done.
+
+foo/main> history
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  
+  
+  □ 1. #5l94rduvel (start of history)
+
+```
+# ambiguous reset
+
+```unison
+main.a = 3
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      main.a : Nat
+
+```
+```ucm
+foo/main> add
+
+  ⍟ I've added these definitions:
+  
+    main.a : Nat
+
+foo/main> history
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ 1. #0i64kpfccl
+  
+    + Adds / updates:
+    
+      main.a
+  
+  □ 2. #5l94rduvel (start of history)
+
+foo/main> reset 2 main
+
+  I'm not sure if you wanted to reset the branch foo/main or the
+  namespace main in the current branch. Could you be more
+  specific?
+  
+  1. /main (the branch main in the current project)
+  2. main (the relative path main in the current branch)
+  
+  Tip: use `reset 1` or `reset 2` to pick one of these.
+
+```


### PR DESCRIPTION
## Overview

Add the `reset` command to reset a namespace or branch to some other causal.

## Test coverage

There is a new transcript: `reset.md`