### PR TITLE
Implement some pieces of code/value serialization in Scheme

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Foreign.hs
+++ b/parser-typechecker/src/Unison/Runtime/Foreign.hs
@@ -120,6 +120,10 @@ charClassCmp :: CharPattern -> CharPattern -> Ordering
 charClassCmp = compare
 {-# NOINLINE charClassCmp #-}
 
+codeEq :: SuperGroup Symbol -> SuperGroup Symbol -> Bool
+codeEq sg1 sg2 = sg1 == sg2
+{-# NOINLINE codeEq #-}
+
 tylEq :: Reference -> Reference -> Bool
 tylEq r l = r == l
 {-# NOINLINE tylEq #-}
@@ -154,6 +158,7 @@ ref2eq r
   | r == Ty.ibytearrayRef = Just $ promote barrEq
   | r == Ty.patternRef = Just $ promote cpatEq
   | r == Ty.charClassRef = Just $ promote charClassEq
+  | r == Ty.codeRef = Just $ promote codeEq
   | otherwise = Nothing
 
 ref2cmp :: Reference -> Maybe (a -> b -> Ordering)

--- a/scheme-libs/racket/unison/arithmetic.rkt
+++ b/scheme-libs/racket/unison/arithmetic.rkt
@@ -1,0 +1,41 @@
+#!racket/base
+
+(provide
+  (prefix-out
+    builtin-
+    (combine-out
+      Nat.increment
+      Float.fromRepresentation
+      Float.toRepresentation
+      Int.increment
+      Int.fromRepresentation
+      Int.toRepresentation
+      )))
+
+(require unison/boot)
+
+(define-unison (Nat.increment n) (+ n 1))
+(define-unison (Int.increment n) (+ n 1))
+
+; If someone can suggest a better mechanism for these,
+; that would be appreciated.
+(define-unison (Float.toRepresentation fl)
+  (integer-bytes->integer
+    (real->floating-point-bytes fl 8 #t) ; big endian
+    #f ; unsigned
+    #t)) ; big endian
+
+(define-unison (Float.fromRepresentation n)
+  (floating-point-bytes->real
+    (integer->integer-bytes n 8 #f #t) ; unsigned, big endian
+    #t)) ; big endian
+
+(define-unison (Int.toRepresentation i)
+  (integer-bytes->integer
+    (integer->integer-bytes i 8 #t #t) ; signed, big endian
+    #f #t)) ; unsigned, big endian
+
+(define-unison (Int.fromRepresentation n)
+  (integer-bytes->integer
+    (integer->integer-bytes n 8 #f #t) ; unsigned, big endian
+    #t #t)) ; signed, big endian

--- a/scheme-libs/racket/unison/arithmetic.rkt
+++ b/scheme-libs/racket/unison/arithmetic.rkt
@@ -4,18 +4,35 @@
   (prefix-out
     builtin-
     (combine-out
+      Nat.toFloat
       Nat.increment
+      Float.*
       Float.fromRepresentation
       Float.toRepresentation
+      Int.+
+      Int.-
       Int.increment
+      Int.negate
       Int.fromRepresentation
       Int.toRepresentation
+      Int.signum
       )))
 
+(require racket)
+(require racket/fixnum)
+(require racket/flonum)
+(require racket/performance-hint)
 (require unison/boot)
 
-(define-unison (Nat.increment n) (+ n 1))
-(define-unison (Int.increment n) (+ n 1))
+(define-unison (Nat.increment n) (add1 n))
+(define-unison (Int.increment i) (add1 i))
+(define-unison (Int.negate i) (fx- i))
+(define-unison (Int.+ i j) (fx+ i j))
+(define-unison (Int.- i j) (fx- i j))
+(define-unison (Int.signum i) (sgn i))
+(define-unison (Float.* x y) (fl* x y))
+
+(define-unison (Nat.toFloat n) (->fl n))
 
 ; If someone can suggest a better mechanism for these,
 ; that would be appreciated.

--- a/scheme-libs/racket/unison/io.rkt
+++ b/scheme-libs/racket/unison/io.rkt
@@ -1,7 +1,11 @@
 #lang racket/base
 (require unison/data
          unison/chunked-seq
-         unison/core)
+         unison/core
+         racket/flonum
+         (only-in
+           rnrs/arithmetic/flonums-6
+           flmod))
 
 (provide
  (prefix-out
@@ -51,8 +55,9 @@
 (define (monotonic.v1)
     (right (current-inexact-monotonic-milliseconds)))
 
-(define (sec.v1 ts)
-    (inexact->exact (/ ts 1000)))
+; 
+(define (flt f) (fl->exact-integer (fltruncate f)))
 
-(define (nsec.v1 ts)
-    (inexact->exact (* ts 1000000)))
+(define (sec.v1 ts) (flt (/ ts 1000)))
+
+(define (nsec.v1 ts) (flt (* (flmod ts 1000.0) 1000000)))

--- a/scheme-libs/racket/unison/primops.ss
+++ b/scheme-libs/racket/unison/primops.ss
@@ -24,6 +24,13 @@
 #!r6rs
 (library (unison primops)
   (export
+    builtin-Float.fromRepresentation
+    builtin-Float.toRepresentation
+    builtin-Int.increment
+    builtin-Int.fromRepresentation
+    builtin-Int.toRepresentation
+    builtin-Nat.increment
+
     unison-FOp-internal.dataTag
     unison-FOp-Char.toText
     ; unison-FOp-Code.dependencies
@@ -338,6 +345,7 @@
                  vector-copy!
                  bytes-copy!)
            (car icar) (cdr icdr))
+          (unison arithmetic)
           (unison bytevector)
           (unison core)
           (unison data)

--- a/scheme-libs/racket/unison/primops.ss
+++ b/scheme-libs/racket/unison/primops.ss
@@ -24,12 +24,18 @@
 #!r6rs
 (library (unison primops)
   (export
+    builtin-Float.*
     builtin-Float.fromRepresentation
     builtin-Float.toRepresentation
+    builtin-Int.+
+    builtin-Int.-
     builtin-Int.increment
+    builtin-Int.negate
     builtin-Int.fromRepresentation
     builtin-Int.toRepresentation
+    builtin-Int.signum
     builtin-Nat.increment
+    builtin-Nat.toFloat
 
     unison-FOp-internal.dataTag
     unison-FOp-Char.toText

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -2436,7 +2436,7 @@ doGenerateSchemeBoot force mppe = do
   let bootf = dir </> "unison" </> "boot-generated.ss"
       swrapf = dir </> "unison" </> "simple-wrappers.ss"
       binf = dir </> "unison" </> "builtin-generated.ss"
-      cwrapf = dir </> "unison" </> "compund-wrappers.ss"
+      cwrapf = dir </> "unison" </> "compound-wrappers.ss"
       dirTm = Term.text a (Text.pack dir)
   liftIO $ createDirectoryIfMissing True dir
   saveBase <- Term.ref a <$> resolveTermRef sbName

--- a/unison-src/builtin-tests/serial-tests.u
+++ b/unison-src/builtin-tests/serial-tests.u
@@ -36,14 +36,23 @@ serial.shuffle =
   
   pick []
 
+serial.checkCodeRoundtrip : Code ->{Exception,Tests,IO} Boolean
+serial.checkCodeRoundtrip code0 =
+  match Code.deserialize (Code.serialize code0) with
+    Left err -> raiseFailure ("could not roundrip code: " ++ err) code0
+    Right code1 -> code0 === code1
+
 serial.loadValueBytes :
   base.Bytes ->{Exception,IO} ([(Link.Term, Code)], reflection.Value)
 serial.loadValueBytes bs = match Value.deserialize bs with
   Left err ->
     raiseFailure ("could not deserialize value: " ++ err) bs
-  Right sv -> match Value.load sv with
-    Left l -> raiseFailure "could not load value" ()
-    Right v -> v
+  Right sv ->
+    if Value.serialize sv === bs then ()
+    else raiseFailure "reserialized bytes did not match" bs
+    match Value.load sv with
+      Left l -> raiseFailure "could not load value" ()
+      Right v -> v
 
 serial.readFile : FilePath -> base.Bytes
 serial.readFile fp =
@@ -56,13 +65,18 @@ serial.readFile fp =
     else read (acc ++ getBytes h 1024)
   read 0xs
 
-serial.loadSelfContained : FilePath ->{IO, Exception} a
-serial.loadSelfContained path =
+serial.loadSelfContained : Text -> FilePath ->{IO, Tests, Exception} a
+serial.loadSelfContained name path =
   input = readFile path
   match fromBase32 input with
     Left msg -> raiseFailure msg input
     Right bs ->
     (deps, v) = loadValueBytes bs
+
+    if List.all (checkCodeRoundtrip << at2) deps
+    then pass (name ++ " code roundtrip")
+    else fail name "code roundtrip"
+
     _ = cache_ deps
     match Value.load v with
       Left l -> raiseFailure "value missing deps" l
@@ -75,7 +89,7 @@ serial.runTestCase name =
   hfile = directory <+> FilePath (name ++ ".hash")
 
   handle
-    p@(f, i) = loadSelfContained sfile
+    p@(f, i) = loadSelfContained name sfile
     o = fromUtf8 (readFile ofile)
     -- h = readFile hfile
 


### PR DESCRIPTION
This PR provides infrastructure for the `(de)serialize` functions for `Code` and `Value` in Scheme. The actual functions are generated from unison, because the Scheme representations are secretly unison data structures. But the functions require some builtins that were missing.

In addition to the missing builtins, I took the liberty of moving some arithmetic functions to directly implemented builtins rather than involving (vacuous) wrappers. I also fixed a couple miscellaneous bugs I noticed when I was testing this all out.

Note, this doesn't completely implement the capability of sending arbitrary unison values over the wire, because part of that is the step that goes `a -> Value` or `Link.Term -> Code`, which is still not implemented in Scheme (and is considerably more complicated in some cases). This is just the part where you can move between these reified representations and the equivalent `Bytes`.

Some tests are included, piggybacking on the serialized test cases for code loading. The tests now try to re-serialize the `Code` and `Values` to see if they match.