### PR TITLE
tweak parsing of pull target to be more like merge

### DIFF
--- a/unison-cli/src/Unison/Cli/Pretty.hs
+++ b/unison-cli/src/Unison/Cli/Pretty.hs
@@ -18,12 +18,11 @@ module Unison.Cli.Pretty
     prettyHumanReadableTime,
     prettyLabeledDependencies,
     prettyPath',
-    prettyPathOrProjectAndBranchName,
     prettyProjectAndBranchName,
     prettyProjectBranchName,
     prettyProjectName,
     prettyProjectNameSlash,
-    prettyPullTarget,
+    prettyNamespaceKey,
     prettyReadGitRepo,
     prettyReadRemoteNamespace,
     prettyReadRemoteNamespaceWith,
@@ -75,6 +74,7 @@ import Unison.Codebase.Editor.RemoteRepo
     shareUserHandleToText,
   )
 import Unison.Codebase.Editor.RemoteRepo qualified as RemoteRepo
+import Unison.Codebase.Path (Path')
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.ShortCausalHash (ShortCausalHash)
 import Unison.Codebase.ShortCausalHash qualified as SCH
@@ -155,10 +155,10 @@ prettyPath' p' =
     then "the current namespace"
     else P.blue (P.shown p')
 
-prettyPullTarget :: Input.PullTarget (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch) -> Pretty
-prettyPullTarget = \case
-  Input.PullTargetLooseCode path -> prettyPath' path
-  Input.PullTargetProject (ProjectAndBranch project branch) ->
+prettyNamespaceKey :: Either Path' (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch) -> Pretty
+prettyNamespaceKey = \case
+  Left path -> prettyPath' path
+  Right (ProjectAndBranch project branch) ->
     prettyProjectAndBranchName (ProjectAndBranch (project ^. #name) (branch ^. #name))
 
 prettyBranchId :: Input.AbsBranchId -> Pretty
@@ -220,11 +220,6 @@ prettySlashProjectBranchName branch =
 prettyProjectAndBranchName :: ProjectAndBranch ProjectName ProjectBranchName -> Pretty
 prettyProjectAndBranchName (ProjectAndBranch project branch) =
   P.group (prettyProjectName project <> P.hiBlack "/" <> prettyProjectBranchName branch)
-
-prettyPathOrProjectAndBranchName :: Either Path.Path' (ProjectAndBranch ProjectName ProjectBranchName) -> Pretty
-prettyPathOrProjectAndBranchName = \case
-  Left x -> prettyPath' x
-  Right x -> prettyProjectAndBranchName x
 
 -- produces:
 -- -- #5v5UtREE1fTiyTsTK2zJ1YNqfiF25SkfUnnji86Lms#0

--- a/unison-cli/src/Unison/Cli/ProjectUtils.hs
+++ b/unison-cli/src/Unison/Cli/ProjectUtils.hs
@@ -19,6 +19,7 @@ module Unison.Cli.ProjectUtils
     expectProjectAndBranchByIds,
     getProjectAndBranchByTheseNames,
     expectProjectAndBranchByTheseNames,
+    expectLooseCodeOrProjectBranch,
 
     -- * Loading remote project info
     expectRemoteProjectByName,
@@ -44,8 +45,10 @@ import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli
 import Unison.Cli.Share.Projects qualified as Share
+import Unison.Codebase.Editor.Input (LooseCodeOrProject)
 import Unison.Codebase.Editor.Output (Output (LocalProjectBranchDoesntExist))
 import Unison.Codebase.Editor.Output qualified as Output
+import Unison.Codebase.Path (Path')
 import Unison.Codebase.Path qualified as Path
 import Unison.NameSegment (NameSegment (..))
 import Unison.Prelude
@@ -158,6 +161,25 @@ expectProjectAndBranchByTheseNames = \case
           pure (ProjectAndBranch project branch)
     maybeProjectAndBranch & onNothing do
       Cli.returnEarly (LocalProjectBranchDoesntExist (ProjectAndBranch projectName branchName))
+
+-- | Expect/resolve a possibly-ambiguous "loose code or project", with the following rules:
+--
+--   1. If we have an unambiguous `/branch` or `project/branch`, look up in the database.
+--   2. If we have an unambiguous `loose.code.path`, just return it.
+--   3. If we have an ambiguous `foo`, *because we do not currently have an unambiguous syntax for relative paths*,
+--      we elect to treat it as a loose code path (because `/branch` can be selected with a leading forward slash).
+expectLooseCodeOrProjectBranch ::
+  These Path' (ProjectAndBranch (Maybe ProjectName) ProjectBranchName) ->
+  Cli (Either Path' (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch))
+expectLooseCodeOrProjectBranch =
+  _Right expectProjectAndBranchByTheseNames . f
+  where
+    f :: LooseCodeOrProject -> Either Path' (These ProjectName ProjectBranchName) -- (Maybe ProjectName, ProjectBranchName)
+    f = \case
+      This path -> Left path
+      That (ProjectAndBranch Nothing branch) -> Right (That branch)
+      That (ProjectAndBranch (Just project) branch) -> Right (These project branch)
+      These path _ -> Left path -- (3) above
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Remote project utils

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -106,12 +106,7 @@ import Unison.Codebase.Editor.Input qualified as Input
 import Unison.Codebase.Editor.Output
 import Unison.Codebase.Editor.Output qualified as Output
 import Unison.Codebase.Editor.Output.DumpNamespace qualified as Output.DN
-import Unison.Codebase.Editor.RemoteRepo
-  ( ReadRemoteNamespace (..),
-    ReadShareLooseCode (..),
-    ShareUserHandle (..),
-    printReadRemoteNamespace,
-  )
+import Unison.Codebase.Editor.RemoteRepo (ReadRemoteNamespace (..), ReadShareLooseCode (..), ShareUserHandle (..))
 import Unison.Codebase.Editor.RemoteRepo qualified as RemoteRepo
 import Unison.Codebase.Editor.Slurp qualified as Slurp
 import Unison.Codebase.Editor.SlurpResult qualified as SlurpResult
@@ -138,12 +133,11 @@ import Unison.Codebase.Verbosity qualified as Verbosity
 import Unison.CommandLine.Completion qualified as Completion
 import Unison.CommandLine.DisplayValues qualified as DisplayValues
 import Unison.CommandLine.FuzzySelect qualified as Fuzzy
-import Unison.CommandLine.InputPattern qualified as InputPattern
 import Unison.CommandLine.InputPatterns qualified as IP
 import Unison.CommandLine.InputPatterns qualified as InputPatterns
 import Unison.ConstructorReference (GConstructorReference (..))
 import Unison.ConstructorType qualified as ConstructorType
-import Unison.Core.Project (ProjectAndBranch (..), ProjectBranchName, ProjectName)
+import Unison.Core.Project (ProjectAndBranch (..))
 import Unison.DataDeclaration qualified as DD
 import Unison.Hash qualified as Hash
 import Unison.HashQualified qualified as HQ
@@ -507,29 +501,28 @@ loop e = do
                     Right path -> WhichBranchEmptyPath path
             MergeLocalBranchI src0 dest0 mergeMode -> do
               description <- inputDescription input
-              src0 <- treatAmbiguousLooseCodeOrProjectAsLooseCode src0
-              dest0 <- treatAmbiguousLooseCodeOrProjectAsLooseCode dest0
+              src0 <- ProjectUtils.expectLooseCodeOrProjectBranch src0
+              dest0 <- ProjectUtils.expectLooseCodeOrProjectBranch dest0
               let srcp = looseCodeOrProjectToPath src0
               let destp = looseCodeOrProjectToPath dest0
               srcb <- Cli.expectBranchAtPath' srcp
               dest <- Cli.resolvePath' destp
               -- todo: fixme: use project and branch names
-              let destNames = projectAndBranchNames <$> dest0
-              let err = Just $ MergeAlreadyUpToDate (projectAndBranchNames <$> src0) destNames
-              mergeBranchAndPropagateDefaultPatch mergeMode description err srcb (Just destNames) dest
+              let err = Just $ MergeAlreadyUpToDate src0 dest0
+              mergeBranchAndPropagateDefaultPatch mergeMode description err srcb (Just dest0) dest
             PreviewMergeLocalBranchI src0 dest0 -> do
               Cli.Env {codebase} <- ask
-              src0 <- treatAmbiguousLooseCodeOrProjectAsLooseCode src0
-              dest0 <- treatAmbiguousLooseCodeOrProjectAsLooseCode dest0
+              src0 <- ProjectUtils.expectLooseCodeOrProjectBranch src0
+              dest0 <- ProjectUtils.expectLooseCodeOrProjectBranch dest0
               srcb <- Cli.expectBranchAtPath' $ looseCodeOrProjectToPath src0
               dest <- Cli.resolvePath' $ looseCodeOrProjectToPath dest0
               destb <- Cli.getBranchAt dest
               merged <- liftIO (Branch.merge'' (Codebase.lca codebase) Branch.RegularMerge srcb destb)
               if merged == destb
-                then Cli.respond (PreviewMergeAlreadyUpToDate (projectAndBranchNames <$> src0) (projectAndBranchNames <$> dest0))
+                then Cli.respond (PreviewMergeAlreadyUpToDate src0 dest0)
                 else do
                   (ppe, diff) <- diffHelper (Branch.head destb) (Branch.head merged)
-                  Cli.respondNumbered (ShowDiffAfterMergePreview (projectAndBranchNames <$> dest0) dest ppe diff)
+                  Cli.respondNumbered (ShowDiffAfterMergePreview dest0 dest ppe diff)
             DiffNamespaceI before after -> do
               absBefore <- traverseOf _Right Cli.resolvePath' before
               absAfter <- traverseOf _Right Cli.resolvePath' after
@@ -1353,9 +1346,7 @@ loop e = do
               patch <- Cli.getPatchAt (fromMaybe Cli.defaultPatchPath maybePath)
               ppe <- suffixifiedPPE =<< makePrintNamesFromLabeled' (Patch.labeledDependencies patch)
               Cli.respondNumbered $ ListEdits patch ppe
-            PullRemoteBranchI sourceTarget sMode pMode verbosity ->
-              inputDescription input
-                >>= doPullRemoteBranch sourceTarget sMode pMode verbosity
+            PullRemoteBranchI sourceTarget sMode pMode verbosity -> doPullRemoteBranch sourceTarget sMode pMode verbosity
             PushRemoteBranchI pushRemoteBranchInput -> handlePushRemoteBranch pushRemoteBranchInput
             ListDependentsI hq -> handleDependents hq
             ListDependenciesI hq -> handleDependencies hq
@@ -1636,24 +1627,6 @@ inputDescription input =
     CompileSchemeI fi nm -> pure ("compile.native " <> HQ.toText nm <> " " <> Text.pack fi)
     GenSchemeLibsI -> pure "compile.native.genlibs"
     FetchSchemeCompilerI name -> pure ("compile.native.fetch" <> Text.pack name)
-    PullRemoteBranchI sourceTarget _syncMode pullMode _verbosity -> do
-      let command =
-            Text.pack . InputPattern.patternName $
-              case pullMode of
-                PullWithoutHistory -> InputPatterns.pullWithoutHistory
-                PullWithHistory -> InputPatterns.pull
-      case sourceTarget of
-        PullSourceTarget0 -> pure command
-        PullSourceTarget1 source0 ->
-          let source = printReadRemoteNamespace (into @Text) source0
-           in pure (command <> " " <> source)
-        PullSourceTarget2 source0 target0 -> do
-          let source = printReadRemoteNamespace (into @Text) source0
-          target <-
-            case target0 of
-              PullTargetLooseCode target1 -> p' target1
-              PullTargetProject target1 -> pure (into @Text target1)
-          pure (command <> " " <> source <> " " <> target)
     CreateAuthorI (NameSegment id) name -> pure ("create.author " <> id <> " " <> name)
     RemoveTermReplacementI src p0 -> do
       p <- opatch p0
@@ -1710,6 +1683,7 @@ inputDescription input =
     ProjectRenameI {} -> wat
     ProjectSwitchI {} -> wat
     ProjectsI -> wat
+    PullRemoteBranchI {} -> wat
     PushRemoteBranchI {} -> wat
     QuitI {} -> wat
     ReleaseDraftI {} -> wat
@@ -2191,23 +2165,6 @@ handleTest TestInput {includeLibNamespace, showFailures, showSuccesses} = do
         "lib" Nel.:| _ : _ -> True
         _ -> False
 
--- Temporary helper: the current `merge` logic treats ambiguous parses (like `foo`) as relative paths, not branch
--- names, so that's what this function does.
---
--- Ideally, `merge` handlers would be extracted to their own module, where helpers like this one would be much easier
--- to find.
-treatAmbiguousLooseCodeOrProjectAsLooseCode ::
-  LooseCodeOrProject ->
-  Cli (Either Path' (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch))
-treatAmbiguousLooseCodeOrProjectAsLooseCode =
-  _Right (ProjectUtils.expectProjectAndBranchByTheseNames . thatOrThese) . f
-  where
-    f :: LooseCodeOrProject -> Either Path' (Maybe ProjectName, ProjectBranchName)
-    f = \case
-      This path -> Left path
-      That (ProjectAndBranch project branch) -> Right (project, branch)
-      These path _ -> Left path
-
 -- todo: compare to `getHQTerms` / `getHQTypes`.  Is one universally better?
 resolveHQToLabeledDependencies :: HQ.HashQualified Name -> Cli (Set LabeledDependency)
 resolveHQToLabeledDependencies = \case
@@ -2483,12 +2440,7 @@ compilerPath = Path.Path' {Path.unPath' = Left abs}
 
 doFetchCompiler :: String -> Cli ()
 doFetchCompiler username =
-  inputDescription pullInput
-    >>= doPullRemoteBranch
-      sourceTarget
-      SyncMode.Complete
-      Input.PullWithoutHistory
-      Verbosity.Silent
+  doPullRemoteBranch sourceTarget SyncMode.Complete Input.PullWithoutHistory Verbosity.Silent
   where
     -- fetching info
     ns =
@@ -2498,14 +2450,7 @@ doFetchCompiler username =
           path =
             Path.fromList $ NameSegment <$> ["public", "internal", "trunk"]
         }
-    sourceTarget = PullSourceTarget2 (ReadShare'LooseCode ns) (PullTargetLooseCode compilerPath)
-
-    pullInput =
-      PullRemoteBranchI
-        sourceTarget
-        SyncMode.Complete
-        Input.PullWithoutHistory
-        Verbosity.Silent
+    sourceTarget = PullSourceTarget2 (ReadShare'LooseCode ns) (This compilerPath)
 
 ensureCompilerExists :: Cli ()
 ensureCompilerExists =
@@ -3305,14 +3250,3 @@ looseCodeOrProjectToPath = \case
               (br ^. #branchId)
           )
       )
-
-projectAndBranchNames ::
-  ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch ->
-  ProjectAndBranch ProjectName ProjectBranchName
-projectAndBranchNames pb =
-  ProjectAndBranch (pb ^. #project . #name) (pb ^. #branch . #name)
-
-thatOrThese :: (Maybe this, that) -> These this that
-thatOrThese (mthis, that) = case mthis of
-  Just this -> These this that
-  Nothing -> That that

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -4,7 +4,6 @@ module Unison.Codebase.Editor.Input
     DiffNamespaceToPatchInput (..),
     GistInput (..),
     PullSourceTarget (..),
-    PullTarget (..),
     PushRemoteBranchInput (..),
     PushSourceTarget (..),
     PushSource (..),
@@ -268,16 +267,8 @@ data GistInput = GistInput
 data PullSourceTarget
   = PullSourceTarget0
   | PullSourceTarget1 (ReadRemoteNamespace (These ProjectName ProjectBranchName))
-  | PullSourceTarget2
-      (ReadRemoteNamespace (These ProjectName ProjectBranchName))
-      (PullTarget (These ProjectName ProjectBranchName))
+  | PullSourceTarget2 (ReadRemoteNamespace (These ProjectName ProjectBranchName)) LooseCodeOrProject
   deriving stock (Eq, Show)
-
--- | Where are we pulling into?
-data PullTarget a
-  = PullTargetLooseCode Path'
-  | PullTargetProject a
-  deriving stock (Eq, Show, Generic)
 
 data PushSource
   = PathySource Path'

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -93,9 +93,22 @@ data NumberedOutput
   | ShowDiffAfterDeleteDefinitions PPE.PrettyPrintEnv (BranchDiffOutput Symbol Ann)
   | ShowDiffAfterDeleteBranch Path.Absolute PPE.PrettyPrintEnv (BranchDiffOutput Symbol Ann)
   | ShowDiffAfterModifyBranch Path.Path' Path.Absolute PPE.PrettyPrintEnv (BranchDiffOutput Symbol Ann)
-  | ShowDiffAfterMerge (Either Path.Path' (ProjectAndBranch ProjectName ProjectBranchName)) Path.Absolute PPE.PrettyPrintEnv (BranchDiffOutput Symbol Ann)
-  | ShowDiffAfterMergePropagate (Either Path.Path' (ProjectAndBranch ProjectName ProjectBranchName)) Path.Absolute Path.Path' PPE.PrettyPrintEnv (BranchDiffOutput Symbol Ann)
-  | ShowDiffAfterMergePreview (Either Path.Path' (ProjectAndBranch ProjectName ProjectBranchName)) Path.Absolute PPE.PrettyPrintEnv (BranchDiffOutput Symbol Ann)
+  | ShowDiffAfterMerge
+      (Either Path' (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch))
+      Path.Absolute
+      PPE.PrettyPrintEnv
+      (BranchDiffOutput Symbol Ann)
+  | ShowDiffAfterMergePropagate
+      (Either Path' (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch))
+      Path.Absolute
+      Path.Path'
+      PPE.PrettyPrintEnv
+      (BranchDiffOutput Symbol Ann)
+  | ShowDiffAfterMergePreview
+      (Either Path' (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch))
+      Path.Absolute
+      PPE.PrettyPrintEnv
+      (BranchDiffOutput Symbol Ann)
   | ShowDiffAfterPull Path.Path' Path.Absolute PPE.PrettyPrintEnv (BranchDiffOutput Symbol Ann)
   | -- <authorIdentifier> <authorPath> <relativeBase>
     ShowDiffAfterCreateAuthor NameSegment Path.Path' Path.Absolute PPE.PrettyPrintEnv (BranchDiffOutput Symbol Ann)
@@ -263,19 +276,19 @@ data Output
   | ShowReflog [(Maybe UTCTime, SCH.ShortCausalHash, Text)]
   | PullAlreadyUpToDate
       (ReadRemoteNamespace Share.RemoteProjectBranch)
-      (PullTarget (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch))
+      (Either Path' (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch))
   | PullSuccessful
       (ReadRemoteNamespace Share.RemoteProjectBranch)
-      (PullTarget (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch))
+      (Either Path' (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch))
   | AboutToMerge
   | -- | Indicates a trivial merge where the destination was empty and was just replaced.
-    MergeOverEmpty (PullTarget (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch))
+    MergeOverEmpty (Either Path' (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch))
   | MergeAlreadyUpToDate
-      (Either Path.Path' (ProjectAndBranch ProjectName ProjectBranchName))
-      (Either Path.Path' (ProjectAndBranch ProjectName ProjectBranchName))
+      (Either Path' (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch))
+      (Either Path' (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch))
   | PreviewMergeAlreadyUpToDate
-      (Either Path.Path' (ProjectAndBranch ProjectName ProjectBranchName))
-      (Either Path.Path' (ProjectAndBranch ProjectName ProjectBranchName))
+      (Either Path' (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch))
+      (Either Path' (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch))
   | -- | No conflicts or edits remain for the current patch.
     NoConflictsOrEdits
   | NotImplemented

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1045,23 +1045,20 @@ reset =
           ("`reset #pvfd222s8n /topic`", "reset the branch `topic` of the current project to the causal `#pvfd222s8n`.")
         ]
     )
-    ( \args -> do
-        case args of
-          arg0 : restArgs -> do
-            arg0 <- branchIdOrProject arg0
-            arg1 <- case restArgs of
-              [] -> pure Nothing
-              arg1 : [] -> do
-                Just <$> first fromString (parseLooseCodeOrProject arg1)
-              _ -> Left (I.help reset)
-            Right (Input.ResetI arg0 arg1)
-          _ -> Left (I.help reset)
+    ( maybeToEither (I.help reset) . \case
+        arg0 : restArgs -> do
+          arg0 <- branchIdOrProject arg0
+          arg1 <- case restArgs of
+            [] -> pure Nothing
+            arg1 : [] -> Just <$> parseLooseCodeOrProject arg1
+            _ -> Nothing
+          Just (Input.ResetI arg0 arg1)
+        _ -> Nothing
     )
   where
     branchIdOrProject ::
       String ->
-      Either
-        (P.Pretty P.ColorText)
+      Maybe
         ( These
             Input.BranchId
             (ProjectAndBranch (Maybe ProjectName) ProjectBranchName)
@@ -1070,10 +1067,10 @@ reset =
       let branchIdRes = Input.parseBranchId str
           projectRes = tryInto @(ProjectAndBranch (Maybe ProjectName) ProjectBranchName) (Text.pack str)
        in case (branchIdRes, projectRes) of
-            (Left _, Left _) -> Left (I.help reset)
-            (Left _, Right pr) -> Right (That pr)
-            (Right bid, Left _) -> Right (This bid)
-            (Right bid, Right pr) -> Right (These bid pr)
+            (Left _, Left _) -> Nothing
+            (Left _, Right pr) -> Just (That pr)
+            (Right bid, Left _) -> Just (This bid)
+            (Right bid, Right pr) -> Just (These bid pr)
 
 -- asBranch = tryInto @(ProjectAndBranch (Maybe ProjectName) ProjectBranchName) (Text.pack inputString)
 
@@ -1122,52 +1119,52 @@ pullImpl name aliases verbosity pullMode addendum = do
   where
     self =
       InputPattern
-        name
-        aliases
-        I.Visible
-        [(Optional, remoteNamespaceArg), (Optional, namespaceArg)]
-        ( P.lines
-            [ P.wrap
-                "The"
-                <> makeExample' self
-                <> "command merges a remote namespace into a local namespace"
-                <> addendum,
-              "",
-              P.wrapColumn2
-                [ ( makeExample self ["remote", "local"],
-                    "merges the remote namespace `remote`"
-                      <> "into the local namespace `local"
-                  ),
-                  ( makeExample self ["remote"],
-                    "merges the remote namespace `remote`"
-                      <> "into the current namespace"
-                  ),
-                  ( makeExample' self,
-                    "merges the remote namespace configured in `.unisonConfig`"
-                      <> "at the key `RemoteMappings.<namespace>` where `<namespace>` is the current namespace,"
-                  )
-                ],
-              "",
-              explainRemote Pull
-            ]
-        )
-        ( \case
-            [] ->
-              Right $ Input.PullRemoteBranchI Input.PullSourceTarget0 SyncMode.ShortCircuit pullMode verbosity
-            [sourceString] -> do
-              source <- parseReadRemoteNamespace "remote-namespace" sourceString
-              Right $ Input.PullRemoteBranchI (Input.PullSourceTarget1 source) SyncMode.ShortCircuit pullMode verbosity
-            [sourceString, targetString] -> do
-              source <- parseReadRemoteNamespace "remote-namespace" sourceString
-              target <- parsePullTarget targetString
-              Right $
-                Input.PullRemoteBranchI
-                  (Input.PullSourceTarget2 source target)
-                  SyncMode.ShortCircuit
-                  pullMode
-                  verbosity
-            _ -> Left (I.help self)
-        )
+        { patternName = name,
+          aliases = aliases,
+          visibility = I.Visible,
+          argTypes = [(Optional, remoteNamespaceArg), (Optional, namespaceArg)],
+          help =
+            P.lines
+              [ P.wrap
+                  "The"
+                  <> makeExample' self
+                  <> "command merges a remote namespace into a local namespace"
+                  <> addendum,
+                "",
+                P.wrapColumn2
+                  [ ( makeExample self ["remote", "local"],
+                      "merges the remote namespace `remote`"
+                        <> "into the local namespace `local"
+                    ),
+                    ( makeExample self ["remote"],
+                      "merges the remote namespace `remote`"
+                        <> "into the current namespace"
+                    ),
+                    ( makeExample' self,
+                      "merges the remote namespace configured in `.unisonConfig`"
+                        <> "at the key `RemoteMappings.<namespace>` where `<namespace>` is the current namespace,"
+                    )
+                  ],
+                "",
+                explainRemote Pull
+              ],
+          parse =
+            maybeToEither (I.help self) . \case
+              [] -> Just $ Input.PullRemoteBranchI Input.PullSourceTarget0 SyncMode.ShortCircuit pullMode verbosity
+              [sourceString] -> do
+                source <- eitherToMaybe (parseReadRemoteNamespace "remote-namespace" sourceString)
+                Just $ Input.PullRemoteBranchI (Input.PullSourceTarget1 source) SyncMode.ShortCircuit pullMode verbosity
+              [sourceString, targetString] -> do
+                source <- eitherToMaybe (parseReadRemoteNamespace "remote-namespace" sourceString)
+                target <- parseLooseCodeOrProject targetString
+                Just $
+                  Input.PullRemoteBranchI
+                    (Input.PullSourceTarget2 source target)
+                    SyncMode.ShortCircuit
+                    pullMode
+                    verbosity
+              _ -> Nothing
+        }
 
 pullExhaustive :: InputPattern
 pullExhaustive =
@@ -1187,32 +1184,32 @@ pullExhaustive =
               <> "versions M1l and earlier.  It may be extra slow!"
         ]
     )
-    ( \case
+    ( maybeToEither (I.help pullExhaustive) . \case
         [] ->
-          Right $
+          Just $
             Input.PullRemoteBranchI
               Input.PullSourceTarget0
               SyncMode.Complete
               Input.PullWithHistory
               Verbosity.Verbose
         [sourceString] -> do
-          source <- parseReadRemoteNamespace "remote-namespace" sourceString
-          Right $
+          source <- eitherToMaybe (parseReadRemoteNamespace "remote-namespace" sourceString)
+          Just $
             Input.PullRemoteBranchI
               (Input.PullSourceTarget1 source)
               SyncMode.Complete
               Input.PullWithHistory
               Verbosity.Verbose
         [sourceString, targetString] -> do
-          source <- parseReadRemoteNamespace "remote-namespace" sourceString
-          target <- parsePullTarget targetString
-          Right $
+          source <- eitherToMaybe (parseReadRemoteNamespace "remote-namespace" sourceString)
+          target <- parseLooseCodeOrProject targetString
+          Just $
             Input.PullRemoteBranchI
               (Input.PullSourceTarget2 source target)
               SyncMode.Complete
               Input.PullWithHistory
               Verbosity.Verbose
-        _ -> Left (I.help pullVerbose)
+        _ -> Nothing
     )
 
 debugTabCompletion :: InputPattern
@@ -1400,24 +1397,25 @@ pushExhaustive =
 squashMerge :: InputPattern
 squashMerge =
   InputPattern
-    "merge.squash"
-    ["squash"]
-    I.Visible
-    [(Required, namespaceArg), (Required, namespaceArg)]
-    ( P.wrap $
-        makeExample squashMerge ["src", "dest"]
-          <> "merges `src` namespace into `dest`,"
-          <> "discarding the history of `src` in the process."
-          <> "The resulting `dest` will have (at most) 1"
-          <> "additional history entry."
-    )
-    ( \case
-        [src, dest] -> first fromString $ do
-          src <- parseLooseCodeOrProject src
-          dest <- parseLooseCodeOrProject dest
-          pure $ Input.MergeLocalBranchI src dest Branch.SquashMerge
-        _ -> Left (I.help squashMerge)
-    )
+    { patternName = "merge.squash",
+      aliases = ["squash"],
+      visibility = I.Visible,
+      argTypes = [(Required, namespaceArg), (Required, namespaceArg)],
+      help =
+        P.wrap $
+          makeExample squashMerge ["src", "dest"]
+            <> "merges `src` namespace into `dest`,"
+            <> "discarding the history of `src` in the process."
+            <> "The resulting `dest` will have (at most) 1"
+            <> "additional history entry.",
+      parse =
+        maybeToEither (I.help squashMerge) . \case
+          [src, dest] -> do
+            src <- parseLooseCodeOrProject src
+            dest <- parseLooseCodeOrProject dest
+            Just $ Input.MergeLocalBranchI src dest Branch.SquashMerge
+          _ -> Nothing
+    }
 
 mergeLocal :: InputPattern
 mergeLocal =
@@ -1449,24 +1447,24 @@ mergeLocal =
           )
         ]
     )
-    ( \case
-        [src] -> first fromString do
+    ( maybeToEither (I.help mergeLocal) . \case
+        [src] -> do
           src <- parseLooseCodeOrProject src
-          pure $ Input.MergeLocalBranchI src (This Path.relativeEmpty') Branch.RegularMerge
-        [src, dest] -> first fromString $ do
+          Just $ Input.MergeLocalBranchI src (This Path.relativeEmpty') Branch.RegularMerge
+        [src, dest] -> do
           src <- parseLooseCodeOrProject src
           dest <- parseLooseCodeOrProject dest
-          pure $ Input.MergeLocalBranchI src dest Branch.RegularMerge
-        _ -> Left (I.help mergeLocal)
+          Just $ Input.MergeLocalBranchI src dest Branch.RegularMerge
+        _ -> Nothing
     )
 
-parseLooseCodeOrProject :: String -> Either String Input.LooseCodeOrProject
+parseLooseCodeOrProject :: String -> Maybe Input.LooseCodeOrProject
 parseLooseCodeOrProject inputString =
   case (asLooseCode, asBranch) of
-    (Right path, Left _) -> Right (This path)
-    (Left _, Right branch) -> Right (That branch)
-    (Right path, Right branch) -> Right (These path branch)
-    (Left _, Left _) -> Left ("Failed to parse " ++ inputString ++ " as a branch or namespace")
+    (Right path, Left _) -> Just (This path)
+    (Left _, Right branch) -> Just (That branch)
+    (Right path, Right branch) -> Just (These path branch)
+    (Left _, Left _) -> Nothing
   where
     asLooseCode = Path.parsePath' inputString
     asBranch = tryInto @(ProjectAndBranch (Maybe ProjectName) ProjectBranchName) (Text.pack inputString)
@@ -1516,15 +1514,15 @@ previewMergeLocal =
           )
         ]
     )
-    ( \case
-        [src] -> first fromString $ do
+    ( maybeToEither (I.help previewMergeLocal) . \case
+        [src] -> do
           src <- parseLooseCodeOrProject src
           pure $ Input.PreviewMergeLocalBranchI src (This Path.relativeEmpty')
-        [src, dest] -> first fromString $ do
+        [src, dest] -> do
           src <- parseLooseCodeOrProject src
           dest <- parseLooseCodeOrProject dest
           pure $ Input.PreviewMergeLocalBranchI src dest
-        _ -> Left (I.help previewMergeLocal)
+        _ -> Nothing
     )
 
 replaceEdit ::
@@ -2494,19 +2492,22 @@ branchInputPattern =
             ("`branch /bar foo`", "forks the branch `bar` of the current project to a new branch `foo`"),
             ("`branch .bar foo`", "forks the path `.bar` of the current project to a new branch `foo`")
           ],
-      parse = \case
-        [source0, name] -> do
-          source <- first (\_ -> showPatternHelp branchInputPattern) (parseLooseCodeOrProject source0)
-          projectAndBranch <-
-            first
-              (\_ -> showPatternHelp branchInputPattern)
-              (tryInto @(ProjectAndBranch (Maybe ProjectName) ProjectBranchName) (Text.pack name))
-          Right (Input.BranchI (Input.BranchSourceI'LooseCodeOrProject source) projectAndBranch)
-        [name] ->
-          first (\_ -> showPatternHelp branchInputPattern) do
-            projectAndBranch <- tryInto @(ProjectAndBranch (Maybe ProjectName) ProjectBranchName) (Text.pack name)
-            Right (Input.BranchI Input.BranchSourceI'CurrentContext projectAndBranch)
-        _ -> Left (showPatternHelp branchInputPattern)
+      parse =
+        maybeToEither (showPatternHelp branchInputPattern) . \case
+          [source0, name] -> do
+            source <- parseLooseCodeOrProject source0
+            projectAndBranch <-
+              Text.pack name
+                & tryInto @(ProjectAndBranch (Maybe ProjectName) ProjectBranchName)
+                & eitherToMaybe
+            Just (Input.BranchI (Input.BranchSourceI'LooseCodeOrProject source) projectAndBranch)
+          [name] -> do
+            projectAndBranch <-
+              Text.pack name
+                & tryInto @(ProjectAndBranch (Maybe ProjectName) ProjectBranchName)
+                & eitherToMaybe
+            Just (Input.BranchI Input.BranchSourceI'CurrentContext projectAndBranch)
+          _ -> Nothing
     }
 
 branchEmptyInputPattern :: InputPattern
@@ -3056,15 +3057,6 @@ projectNameArg =
       suggestions = \_ _ _ _ -> pure [],
       globTargets = Set.empty
     }
-
-parsePullTarget :: String -> Either (P.Pretty CT.ColorText) (Input.PullTarget (These ProjectName ProjectBranchName))
-parsePullTarget targetString =
-  case tryInto @(These ProjectName ProjectBranchName) (Text.pack targetString) of
-    Left _ ->
-      case Path.parsePath' targetString of
-        Left _ -> Left (I.help pull)
-        Right path -> pure (Input.PullTargetLooseCode path)
-    Right project -> pure (Input.PullTargetProject project)
 
 -- | Parse a 'Input.PushSource'.
 parsePushSource :: String -> Either (P.Pretty CT.ColorText) Input.PushSource

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -214,7 +214,7 @@ notifyNumbered = \case
     first
       ( \p ->
           P.lines
-            [ P.wrap $ "Here's what's changed in " <> prettyPathOrProjectAndBranchName dest' <> "after the merge:",
+            [ P.wrap $ "Here's what's changed in " <> prettyNamespaceKey dest' <> "after the merge:",
               "",
               p,
               "",
@@ -239,7 +239,7 @@ notifyNumbered = \case
           P.lines
             [ P.wrap $
                 "Here's what's changed in "
-                  <> prettyPathOrProjectAndBranchName dest'
+                  <> prettyNamespaceKey dest'
                   <> "after applying the patch at "
                   <> P.group (prettyPath' patchPath' <> ":"),
               "",
@@ -247,7 +247,7 @@ notifyNumbered = \case
               "",
               tip $
                 "You can use "
-                  <> IP.makeExample IP.todo [prettyPath' patchPath', prettyPathOrProjectAndBranchName dest']
+                  <> IP.makeExample IP.todo [prettyPath' patchPath', prettyNamespaceKey dest']
                   <> "to see if this generated any work to do in this namespace"
                   <> "and "
                   <> IP.makeExample' IP.test
@@ -264,7 +264,7 @@ notifyNumbered = \case
     first
       ( \p ->
           P.lines
-            [ P.wrap $ "Here's what would change in " <> prettyPathOrProjectAndBranchName dest' <> "after the merge:",
+            [ P.wrap $ "Here's what would change in " <> prettyNamespaceKey dest' <> "after the merge:",
               "",
               p
             ]
@@ -1589,33 +1589,33 @@ notifyUser dir = \case
   PullAlreadyUpToDate ns dest ->
     pure . P.callout "😶" $
       P.wrap $
-        prettyPullTarget dest
+        prettyNamespaceKey dest
           <> "was already up-to-date with"
           <> P.group (prettyReadRemoteNamespace ns <> ".")
   PullSuccessful ns dest ->
     pure . P.okCallout $
       P.wrap $
         "Successfully updated"
-          <> prettyPullTarget dest
+          <> prettyNamespaceKey dest
           <> "from"
           <> P.group (prettyReadRemoteNamespace ns <> ".")
   AboutToMerge -> pure "Merging..."
   MergeOverEmpty dest ->
     pure . P.okCallout $
       P.wrap $
-        "Successfully pulled into " <> P.group (prettyPullTarget dest <> ", which was empty.")
+        "Successfully pulled into " <> P.group (prettyNamespaceKey dest <> ", which was empty.")
   MergeAlreadyUpToDate src dest ->
     pure . P.callout "😶" $
       P.wrap $
-        prettyPathOrProjectAndBranchName dest
+        prettyNamespaceKey dest
           <> "was already up-to-date with"
-          <> P.group (prettyPathOrProjectAndBranchName src <> ".")
+          <> P.group (prettyNamespaceKey src <> ".")
   PreviewMergeAlreadyUpToDate src dest ->
     pure . P.callout "😶" $
       P.wrap $
-        prettyPathOrProjectAndBranchName dest
+        prettyNamespaceKey dest
           <> "is already up-to-date with"
-          <> P.group (prettyPathOrProjectAndBranchName src <> ".")
+          <> P.group (prettyNamespaceKey src <> ".")
   DumpNumberedArgs args -> pure . P.numberedList $ fmap P.string args
   NoConflictsOrEdits ->
     pure (P.okCallout "No conflicts or edits in progress.")

--- a/unison-cli/src/Unison/CommandLine/Welcome.hs
+++ b/unison-cli/src/Unison/CommandLine/Welcome.hs
@@ -1,8 +1,7 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module Unison.CommandLine.Welcome where
 
 import Data.Sequence (singleton)
+import Data.These (These (..))
 import System.Random (randomRIO)
 import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
@@ -62,7 +61,7 @@ pullBase ns =
         PullRemoteBranchI
           ( PullSourceTarget2
               (ReadShare'LooseCode ns)
-              (PullTargetLooseCode (Path.Path' {Path.unPath' = Left abs}))
+              (This (Path.Path' {Path.unPath' = Left abs}))
           )
           SyncMode.Complete
           PullWithHistory


### PR DESCRIPTION
## Overview

Fixes #3953 

This PR tweaks the parsing logic of the second argument of `pull` to be like `merge`.

Slack context: https://unisonlanguage.slack.com/archives/CLUNF0J5S/p1686154477422069

![Screenshot from 2023-06-08 13-50-22](https://github.com/unisonweb/unison/assets/1074598/ea752fe2-cf79-4d7e-a37a-0f2a27acd688)

---

Prior to this PR, the second argument of `pull` could be:

1. A project name `project/`
2. A branch name `/branch`
3. A project and branch name `project/branch`
4. An absoute path `.loose.code`
5. A relative multi-segment path `loose.code`
6. A ambiguous `foo` thing that parses as a valid one-segment relative path, project name, and branch name.

We would treat (6) above as the same as (1).

---

Now, the second argument of `pull` can be:

1. ~~A project name `project/`~~
2. A branch name `/branch`
3. A project and branch name `project/branch`
4. An absoute path `.loose.code`
5. A relative multi-segment path `loose.code`
6. A ambiguous `foo` thing that parses as a valid one-segment relative path, project name, and branch name.

We treat (6) above as the same as (5), because there is no valid syntax for a relative path that disambiguates it from a project branch. Thus, arguments like (2) must have a leading forward slash, which is unfortunate. That's how `merge` currently works, though.

## Test coverage

I've tested this change manually.
