### PR TITLE
use breakOn instead of indices which for Text.indexOf

### DIFF
--- a/parser-typechecker/src/Unison/Util/Text.hs
+++ b/parser-typechecker/src/Unison/Util/Text.hs
@@ -10,7 +10,6 @@ import Data.String (IsString (..))
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
 import Data.Text.Internal qualified as T
-import Data.Text.Internal.Lazy.Search qualified as TL
 import Data.Text.Lazy qualified as TL
 import Data.Text.Unsafe qualified as T (Iter (..), iter)
 import Data.Word (Word64)
@@ -124,9 +123,9 @@ toText (Text t) = T.concat (chunkToText <$> unfoldr R.uncons t)
 
 indexOf :: Text -> Text -> Maybe Word64
 indexOf needle haystack =
-  case TL.indices needle' haystack' of
-    [] -> Nothing
-    (i : _) -> Just (fromIntegral i)
+  case TL.breakOn needle' haystack' of
+    (_, "") -> Nothing
+    (prefix, _) -> Just (fromIntegral (TL.length prefix))
   where
     needle' = toLazyText needle
     haystack' = toLazyText haystack

--- a/unison-src/transcripts/builtins.md
+++ b/unison-src/transcripts/builtins.md
@@ -271,8 +271,16 @@ test> Text.tests.indexOf =
      Text.indexOf needle6 haystack == Some 22,
      Text.indexOf needle7 haystack == Some 0,
      Text.indexOf needle8 haystack == None,
-
    ]
+   
+test> Text.tests.indexOfEmoji = 
+  haystack = "clap 👏 your 👏 hands 👏 if 👏 you 👏 love 👏 unison"
+  needle1 = "👏"
+  needle2 = "👏 "
+  checks [
+    Text.indexOf needle1 haystack == Some 5,
+    Text.indexOf needle2 haystack == Some 5,
+  ]
 
 ```
 

--- a/unison-src/transcripts/builtins.output.md
+++ b/unison-src/transcripts/builtins.output.md
@@ -252,8 +252,16 @@ test> Text.tests.indexOf =
      Text.indexOf needle6 haystack == Some 22,
      Text.indexOf needle7 haystack == Some 0,
      Text.indexOf needle8 haystack == None,
-
    ]
+   
+test> Text.tests.indexOfEmoji = 
+  haystack = "clap 👏 your 👏 hands 👏 if 👏 you 👏 love 👏 unison"
+  needle1 = "👏"
+  needle2 = "👏 "
+  checks [
+    Text.indexOf needle1 haystack == Some 5,
+    Text.indexOf needle2 haystack == Some 5,
+  ]
 
 ```
 
@@ -486,13 +494,14 @@ Now that all the tests have been added to the codebase, let's view the test repo
   ◉ test.rtjqan7bcs                     Passed
   ◉ Text.tests.alignment                Passed
   ◉ Text.tests.indexOf                  Passed
+  ◉ Text.tests.indexOfEmoji             Passed
   ◉ Text.tests.literalsEq               Passed
   ◉ Text.tests.patterns                 Passed
   ◉ Text.tests.repeat                   Passed
   ◉ Text.tests.takeDropAppend           Passed
   ◉ Universal.murmurHash.tests          Passed
   
-  ✅ 26 test(s) passing
+  ✅ 27 test(s) passing
   
   Tip: Use view Any.test1 to view the source of a test.
 


### PR DESCRIPTION
This reimplements Text.indexOf to use breakOn which will work correctly with text containing multibyte characters.

I added a text to ensure its working correctly