### PR TITLE
Build unison packages with nix

### DIFF
--- a/development.markdown
+++ b/development.markdown
@@ -137,3 +137,80 @@ More context at: https://stackoverflow.com/a/59761201/310162
 ### I get an error about `removeDirectoryRecursive`/`removeContentsRecursive`/`removePathRecursive`/`permission denied (Access is denied.)`
 
 Stack doesn't work deterministically in Windows due to mismatched expectations about how file deletion works. If you get this error, you can just retry the build and it will probably make more progress than the last time.
+
+## Building with Nix
+
+## Building package components with nix
+
+### Build the unison executable
+```
+nix build
+```
+
+### Build a specific component
+This is specified with the normal
+`<package>:<component-type>:<component-name>` triple.
+
+Some examples:
+```
+nix build '.#unison-cli:lib:unison-cli'
+nix build '.#unison-syntax:test:syntax-tests'
+nix build '.#unison-cli:exe:transcripts'
+```
+
+### Development environments
+
+#### Get into a development environment for building with stack
+This gets you into a development environment with the preferred
+versions of the compiler and other development tools. These
+include:
+
+- ghc
+- stack
+- ormolu
+- haskell-language-server
+
+```
+nix develop
+```
+
+#### Get into a development environment for building with cabal
+This gets you into a development environment with the preferred
+versions of the compiler and other development tools. Additionally,
+all non-local haskell dependencies (including profiling dependencies)
+are provided in the nix shell.
+
+```
+nix develop '.#local'
+```
+
+#### Get into a development environment for building a specific package
+This gets you into a development environment with the preferred
+versions of the compiler and other development tools. Additionally,
+all haskell dependencies of this package are provided by the nix shell
+(including profiling dependencies).
+
+```
+nix develop '.#<package-name>'
+```
+
+for example:
+
+```
+nix develop '.#unison-cli'
+```
+or
+```
+nix develop '.#unison-parser-typechecker'
+```
+
+This is useful if you wanted to profile a package. For example, if you
+want to profile `unison-cli:exe:unison` then you could get into one of these
+shells, cd into its directory, then run the program with
+profiling.
+
+```
+nix develop '.#unison-parser-typechecker'
+cd unison-cli
+cabal run --enable-profiling unison-cli:exe:unison -- +RTS -p
+```

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1685492843,
-        "narHash": "sha256-X8dNs5Gfc2ucfaWAgZ1VmkpBB4Cb44EQZu0b7tkvz2Y=",
+        "lastModified": 1688689629,
+        "narHash": "sha256-hNkTA2oaMSnhkvSFnOc76yN0CUl+EyHbxLXFPOJhOlk=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "e7407bab324eb2445bda58c5ffac393e80dda1e4",
+        "rev": "902793475a701a03a31411381ee17a6885b76c0b",
         "type": "github"
       },
       "original": {
@@ -195,6 +195,7 @@
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
         "hackage": "hackage",
         "hls-1.10": "hls-1.10",
+        "hls-2.0": "hls-2.0",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
@@ -213,11 +214,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1685510895,
-        "narHash": "sha256-Wur0uukVJotEyi8f3AhPFXqsK6XINjj+54u/1jlBC9o=",
+        "lastModified": 1688713029,
+        "narHash": "sha256-bK2RwnBLaJgtXYwPfpWL3XQJwlRkOimhsieg13Ve5bM=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "4835f2bd3c244436ce1140151936ea1b7c7f13e1",
+        "rev": "f629a8abac1bbb2168c1c763b9a80effef7156ea",
         "type": "github"
       },
       "original": {
@@ -239,6 +240,23 @@
       "original": {
         "owner": "haskell",
         "ref": "1.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.0": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1684398654,
+        "narHash": "sha256-RW44up2BIyBBYN6tZur5f9kDDR3kr0Rd+TgPbLTfwB4=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "20c6d1e731cd9c0beef7338e2fc7a8126ba9b6fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.0.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -511,11 +529,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1685491814,
-        "narHash": "sha256-OQX+h5hcDptW6HVrYkBL7dtgqiaiz9zn6iMYv+0CDzc=",
+        "lastModified": 1688688652,
+        "narHash": "sha256-HHTZ2N1qLL029/ucCidOeSNW61khhesMa062bYWBKCU=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "678b4297ccef8bbcd83294e47e1a9042034bdbd0",
+        "rev": "e00911e5f687ee2fa69cba203881e31d3dedd888",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,121 @@
 {
   "nodes": {
+    "HTTP": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "cabal-32": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-34": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645834128,
+        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669081697,
+        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cardano-shell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672831974,
+        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "hkm/gitlab-fix",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -18,26 +134,394 @@
         "type": "github"
       }
     },
-    "nixpkgs": {
+    "flake-utils_2": {
       "locked": {
-        "lastModified": 1684935479,
-        "narHash": "sha256-6QMMsXMr2nhmOPHdti2j3KRHt+bai2zw+LJfdCl97Mk=",
+        "lastModified": 1679360468,
+        "narHash": "sha256-LGnza3cfXF10Biw3ZTg0u9o9t7s680Ww200t5KkHTh8=",
+        "owner": "hamishmack",
+        "repo": "flake-utils",
+        "rev": "e1ea268ff47ad475443dbabcd54744b4e5b9d4f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hamishmack",
+        "ref": "hkm/nested-hydraJobs",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "ghc-8.6.5-iohk": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
+        "type": "github"
+      }
+    },
+    "hackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1685492843,
+        "narHash": "sha256-X8dNs5Gfc2ucfaWAgZ1VmkpBB4Cb44EQZu0b7tkvz2Y=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "e7407bab324eb2445bda58c5ffac393e80dda1e4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "haskellNix": {
+      "inputs": {
+        "HTTP": "HTTP",
+        "cabal-32": "cabal-32",
+        "cabal-34": "cabal-34",
+        "cabal-36": "cabal-36",
+        "cardano-shell": "cardano-shell",
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_2",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
+        "hackage": "hackage",
+        "hls-1.10": "hls-1.10",
+        "hpc-coveralls": "hpc-coveralls",
+        "hydra": "hydra",
+        "iserv-proxy": "iserv-proxy",
+        "nixpkgs": [
+          "haskellNix",
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-2003": "nixpkgs-2003",
+        "nixpkgs-2105": "nixpkgs-2105",
+        "nixpkgs-2111": "nixpkgs-2111",
+        "nixpkgs-2205": "nixpkgs-2205",
+        "nixpkgs-2211": "nixpkgs-2211",
+        "nixpkgs-2305": "nixpkgs-2305",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "old-ghc-nix": "old-ghc-nix",
+        "stackage": "stackage"
+      },
+      "locked": {
+        "lastModified": 1685510895,
+        "narHash": "sha256-Wur0uukVJotEyi8f3AhPFXqsK6XINjj+54u/1jlBC9o=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "4835f2bd3c244436ce1140151936ea1b7c7f13e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "hls-1.10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1680000865,
+        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "1.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "hydra": {
+      "inputs": {
+        "nix": "nix",
+        "nixpkgs": [
+          "haskellNix",
+          "hydra",
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1671755331,
+        "narHash": "sha256-hXsgJj0Cy0ZiCiYdW2OdBz5WmFyOMKuw4zyxKpgUKm4=",
         "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f91ee3065de91a3531329a674a45ddcb3467a650",
+        "repo": "hydra",
+        "rev": "f48f00ee6d5727ae3e488cbf9ce157460853fea8",
+        "type": "github"
+      },
+      "original": {
+        "id": "hydra",
+        "type": "indirect"
+      }
+    },
+    "iserv-proxy": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1670983692,
+        "narHash": "sha256-avLo34JnI9HNyOuauK5R69usJm+GfW3MlyGlYxZhTgY=",
+        "ref": "hkm/remote-iserv",
+        "rev": "50d0abb3317ac439a4e7495b185a64af9b7b9300",
+        "revCount": 10,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+      },
+      "original": {
+        "ref": "hkm/remote-iserv",
+        "type": "git",
+        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+      }
+    },
+    "lowdown-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "lowdown-src": "lowdown-src",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
+      "locked": {
+        "lastModified": 1661606874,
+        "narHash": "sha256-9+rpYzI+SmxJn+EbYxjGv68Ucp22bdFUSy/4LkHkkDQ=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "11e45768b34fdafdcf019ddbd337afa16127ff0f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "2.11.0",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1657693803,
+        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
+        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2003": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-20.03-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2105": {
+      "locked": {
+        "lastModified": 1659914493,
+        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2111": {
+      "locked": {
+        "lastModified": 1659446231,
+        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2205": {
+      "locked": {
+        "lastModified": 1682600000,
+        "narHash": "sha256-ha4BehR1dh8EnXSoE1m/wyyYVvHI9txjW4w5/oxsW5Y=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "50fc86b75d2744e1ab3837ef74b53f103a9b55a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2211": {
+      "locked": {
+        "lastModified": 1685314633,
+        "narHash": "sha256-8LXBPqTQXl5ofkjpJ18JcbmLJ/lWDoMxtUwiDYv0wro=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c8a17ce7abc03c50cd072e9e6c9b389c5f61836b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2305": {
+      "locked": {
+        "lastModified": 1685338297,
+        "narHash": "sha256-+Aq4O0Jn1W1q927ZHc3Zn6RO7bwQGmb6O8xYoGy0KrM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6287b47dbfabbb8bfbb9b1b53d198ad58a774de4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1685347552,
+        "narHash": "sha256-9woSppRyUFo26yUffORTzttJ+apOt8MmCv6RxpPNTU4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f2f1ec390714d303cf84ba086e34e45b450dd8c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "old-ghc-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "haskellNix": "haskellNix",
+        "nixpkgs": [
+          "haskellNix",
+          "nixpkgs-unstable"
+        ]
+      }
+    },
+    "stackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1685491814,
+        "narHash": "sha256-OQX+h5hcDptW6HVrYkBL7dtgqiaiz9zn6iMYv+0CDzc=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "678b4297ccef8bbcd83294e47e1a9042034bdbd0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -102,7 +102,7 @@
               # https://github.com/input-output-hk/haskell.nix/issues/1793
               # https://github.com/input-output-hk/haskell.nix/issues/1885
               allToolDeps = false;
-              buildInputs = (args.buildInputs or [ ]) ++ (with pkgs; [ unison-stack ]);
+              buildInputs = (args.buildInputs or [ ]) ++ (with pkgs; [ unison-stack pkg-config zlib ]);
               # workaround for https://gitlab.haskell.org/ghc/ghc/-/issues/11042
               shellHook = ''
                 export LD_LIBRARY_PATH=${pkgs.zlib}/lib:$LD_LIBRARY_PATH

--- a/flake.nix
+++ b/flake.nix
@@ -102,7 +102,12 @@
               # https://github.com/input-output-hk/haskell.nix/issues/1793
               # https://github.com/input-output-hk/haskell.nix/issues/1885
               allToolDeps = false;
-              buildInputs = (args.buildInputs or [ ]) ++ (with pkgs; [ unison-stack pkg-config zlib ]);
+              buildInputs =
+                let
+                  native-packages = pkgs.lib.optionals pkgs.stdenv.isDarwin
+                    (with pkgs.darwin.apple_sdk.frameworks; [ Cocoa ]);
+                in
+                (args.buildInputs or [ ]) ++ (with pkgs; [ unison-stack pkg-config zlib ]) ++ native-packages;
               # workaround for https://gitlab.haskell.org/ghc/ghc/-/issues/11042
               shellHook = ''
                 export LD_LIBRARY_PATH=${pkgs.zlib}/lib:$LD_LIBRARY_PATH

--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,6 @@
                 in
                 final.haskell-nix.project' {
                   src = cleanSource ./.;
-                  compiler-nix-name = "ghc928";
                   projectFileName = "stack.yaml";
                   modules = [
                     # enable profiling

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,15 @@
 {
   description = "Unison";
   nixConfig = {
-    extra-substituters = [ "https://cache.iog.io" ];
+    extra-substituters = [
+      "https://cache.iog.io"
+      "https://unison.cachix.org"
+    ];
     extra-trusted-public-keys =
-      [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];
+      [
+        "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
+        "unison.cachix.org-1:gFuvOrYJX5lXoSoYm6Na3xwUbb9q+S5JFL+UAsWbmzQ="
+      ];
   };
   inputs = {
     haskellNix.url = "github:input-output-hk/haskell.nix";

--- a/flake.nix
+++ b/flake.nix
@@ -102,6 +102,7 @@
               # https://github.com/input-output-hk/haskell.nix/issues/1793
               # https://github.com/input-output-hk/haskell.nix/issues/1885
               allToolDeps = false;
+              additional = hpkgs: with hpkgs; [ Cabal stm exceptions ghc ghc-heap ];
               buildInputs =
                 let
                   native-packages = pkgs.lib.optionals pkgs.stdenv.isDarwin

--- a/flake.nix
+++ b/flake.nix
@@ -1,86 +1,81 @@
 {
-  description = "A common environment for unison development";
-
-  inputs = {
-    flake-utils.url = "github:numtide/flake-utils";
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  description = "Unison";
+  nixConfig = {
+    extra-substituters = [ "https://cache.iog.io" ];
+    extra-trusted-public-keys =
+      [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];
   };
-
-  outputs = { self, flake-utils, nixpkgs }:
-    let
-      ghc-version = "927";
-      systemAttrs = flake-utils.lib.eachDefaultSystem (system:
-        let
-          pkgs = nixpkgs.legacyPackages."${system}".extend self.overlay;
-          ghc = pkgs.haskell.packages."ghc${ghc-version}";
-          nativePackages = pkgs.lib.optionals pkgs.stdenv.isDarwin
-            (with pkgs.darwin.apple_sdk.frameworks; [ Cocoa ]);
-
-          unison-env = pkgs.mkShell {
-            packages = let exports = self.packages."${system}";
-            in with pkgs;
-            [
-              exports.stack
-              exports.hls
-              exports.ormolu
-              exports.ghc
-              pkg-config
-              zlib
-              glibcLocales
-            ] ++ nativePackages;
-            # workaround for https://gitlab.haskell.org/ghc/ghc/-/issues/11042
-            shellHook = ''
-              export LD_LIBRARY_PATH=${pkgs.zlib}/lib:$LD_LIBRARY_PATH
-            '';
-          };
-        in {
-
-          apps.repl = flake-utils.lib.mkApp {
-            drv =
-              nixpkgs.legacyPackages."${system}".writeShellScriptBin "repl" ''
-                confnix=$(mktemp)
-                echo "builtins.getFlake (toString $(git rev-parse --show-toplevel))" >$confnix
-                trap "rm $confnix" EXIT
-                nix repl $confnix
-              '';
-          };
-
-          pkgs = pkgs;
-
-          devShells.default = unison-env;
-
-          packages = {
-            hls = pkgs.unison-hls;
-            hls-call-hierarchy-plugin = ghc.hls-call-hierarchy-plugin;
-            ormolu = pkgs.ormolu;
-            ghc = pkgs.haskell.compiler."ghc${ghc-version}";
-            stack = pkgs.unison-stack;
-            devShell = self.devShells."${system}".default;
-
-          };
-
-          defaultPackage = self.packages."${system}".devShell;
-        });
-      topLevelAttrs = {
-        overlay = final: prev: {
-          unison-hls = final.haskell-language-server.override {
-            haskellPackages = final.haskell.packages."ghc${ghc-version}";
-            dynamic = true;
-            supportedGhcVersions = [ ghc-version ];
-          };
-          unison-stack = prev.symlinkJoin {
-            name = "stack";
-            paths = [ final.stack ];
-            buildInputs = [ final.makeWrapper ];
-            postBuild = let
-              flags = [ "--no-nix" "--system-ghc" "--no-install-ghc" ];
-              add-flags =
-                "--add-flags '${prev.lib.concatStringsSep " " flags}'";
-            in ''
-              wrapProgram "$out/bin/stack" ${add-flags}
-            '';
-          };
+  inputs = {
+    haskellNix.url = "github:input-output-hk/haskell.nix";
+    nixpkgs.follows = "haskellNix/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+  };
+  outputs = { self, nixpkgs, flake-utils, haskellNix, flake-compat }:
+    flake-utils.lib.eachSystem [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ] (system:
+      let
+        overlays = [
+          haskellNix.overlay
+          (final: prev: {
+            unison-project = with prev.lib.strings;
+              let
+                cleanSource = pth:
+                  let
+                    src' = prev.lib.cleanSourceWith {
+                      filter = filt;
+                      src = pth;
+                    };
+                    filt = path: type:
+                      let
+                        bn = baseNameOf path;
+                        isHiddenFile = hasPrefix "." bn;
+                        isFlakeLock = bn == "flake.lock";
+                        isNix = hasSuffix ".nix" bn;
+                      in !isHiddenFile && !isFlakeLock && !isNix;
+                  in src';
+              in final.haskell-nix.project' {
+                src = cleanSource ./.;
+                compiler-nix-name = "ghc928";
+                projectFileName = "stack.yaml";
+                shell = {
+                  buildInputs = with pkgs; [ ];
+                  tools = let ormolu-ver = "0.5.2.0";
+                  in {
+                    cabal = { };
+                    ormolu = { version = ormolu-ver; };
+                    haskell-language-server = {
+                      version = "latest";
+                      # specify flags via project file rather than a module override
+                      # https://github.com/input-output-hk/haskell.nix/issues/1509
+                      cabalProject = ''
+                        packages: .
+                        package haskell-language-server
+                          flags: -brittany -fourmolu -stylishhaskell -hlint
+                        constraints: ormolu == ${ormolu-ver}
+                      '';
+                    };
+                  };
+                };
+                branchMap = {
+                  "https://github.com/unisonweb/configurator.git"."e47e9e9fe1f576f8c835183b9def52d73c01327a" =
+                    "unison";
+                  "https://github.com/unisonweb/shellmet.git"."2fd348592c8f51bb4c0ca6ba4bc8e38668913746" =
+                    "topic/avoid-callCommand";
+                };
+              };
+          })
+        ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+          inherit (haskellNix) config;
         };
-      };
-    in systemAttrs // topLevelAttrs;
+        flake = pkgs.unison-project.flake { };
+      in flake // { defaultPackage = flake.packages."unison-cli:exe:unison"; });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -73,6 +73,22 @@
                   };
                 };
             })
+            (final: prev: {
+              unison-stack = prev.symlinkJoin {
+                name = "stack";
+                paths = [ final.stack ];
+                buildInputs = [ final.makeWrapper ];
+                postBuild =
+                  let
+                    flags = [ "--no-nix" "--system-ghc" "--no-install-ghc" ];
+                    add-flags =
+                      "--add-flags '${prev.lib.concatStringsSep " " flags}'";
+                  in
+                  ''
+                    wrapProgram "$out/bin/stack" ${add-flags}
+                  '';
+              };
+            })
           ];
           pkgs = import nixpkgs {
             inherit system overlays;
@@ -86,7 +102,7 @@
               # https://github.com/input-output-hk/haskell.nix/issues/1793
               # https://github.com/input-output-hk/haskell.nix/issues/1885
               allToolDeps = false;
-              buildInputs = (args.buildInputs or [ ]) ++ (with pkgs; [ stack ]);
+              buildInputs = (args.buildInputs or [ ]) ++ (with pkgs; [ unison-stack ]);
               # workaround for https://gitlab.haskell.org/ghc/ghc/-/issues/11042
               shellHook = ''
                 export LD_LIBRARY_PATH=${pkgs.zlib}/lib:$LD_LIBRARY_PATH

--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,10 @@
               # https://github.com/input-output-hk/haskell.nix/issues/1885
               allToolDeps = false;
               buildInputs = (args.buildInputs or [ ]) ++ (with pkgs; [ stack ]);
+              # workaround for https://gitlab.haskell.org/ghc/ghc/-/issues/11042
+              shellHook = ''
+                export LD_LIBRARY_PATH=${pkgs.zlib}/lib:$LD_LIBRARY_PATH
+              '';
               tools =
                 let ormolu-ver = "0.5.2.0";
                 in (args.tools or { }) // {

--- a/flake.nix
+++ b/flake.nix
@@ -107,7 +107,7 @@
                   native-packages = pkgs.lib.optionals pkgs.stdenv.isDarwin
                     (with pkgs.darwin.apple_sdk.frameworks; [ Cocoa ]);
                 in
-                (args.buildInputs or [ ]) ++ (with pkgs; [ unison-stack pkg-config zlib ]) ++ native-packages;
+                (args.buildInputs or [ ]) ++ (with pkgs; [ unison-stack pkg-config zlib glibcLocales ]) ++ native-packages;
               # workaround for https://gitlab.haskell.org/ghc/ghc/-/issues/11042
               shellHook = ''
                 export LD_LIBRARY_PATH=${pkgs.zlib}/lib:$LD_LIBRARY_PATH

--- a/flake.nix
+++ b/flake.nix
@@ -19,63 +19,118 @@
       "x86_64-linux"
       "x86_64-darwin"
       "aarch64-darwin"
-    ] (system:
-      let
-        overlays = [
-          haskellNix.overlay
-          (final: prev: {
-            unison-project = with prev.lib.strings;
-              let
-                cleanSource = pth:
-                  let
-                    src' = prev.lib.cleanSourceWith {
-                      filter = filt;
-                      src = pth;
-                    };
-                    filt = path: type:
-                      let
-                        bn = baseNameOf path;
-                        isHiddenFile = hasPrefix "." bn;
-                        isFlakeLock = bn == "flake.lock";
-                        isNix = hasSuffix ".nix" bn;
-                      in !isHiddenFile && !isFlakeLock && !isNix;
-                  in src';
-              in final.haskell-nix.project' {
-                src = cleanSource ./.;
-                compiler-nix-name = "ghc928";
-                projectFileName = "stack.yaml";
-                shell = {
-                  buildInputs = with pkgs; [ ];
-                  tools = let ormolu-ver = "0.5.2.0";
-                  in {
-                    cabal = { };
-                    ormolu = { version = ormolu-ver; };
-                    haskell-language-server = {
-                      version = "latest";
-                      # specify flags via project file rather than a module override
-                      # https://github.com/input-output-hk/haskell.nix/issues/1509
-                      cabalProject = ''
-                        packages: .
-                        package haskell-language-server
-                          flags: -brittany -fourmolu -stylishhaskell -hlint
-                        constraints: ormolu == ${ormolu-ver}
-                      '';
-                    };
+    ]
+      (system:
+        let
+          overlays = [
+            haskellNix.overlay
+            (final: prev: {
+              unison-project = with prev.lib.strings;
+                let
+                  cleanSource = pth:
+                    let
+                      src' = prev.lib.cleanSourceWith {
+                        filter = filt;
+                        src = pth;
+                      };
+                      filt = path: type:
+                        let
+                          bn = baseNameOf path;
+                          isHiddenFile = hasPrefix "." bn;
+                          isFlakeLock = bn == "flake.lock";
+                          isNix = hasSuffix ".nix" bn;
+                        in
+                        !isHiddenFile && !isFlakeLock && !isNix;
+                    in
+                    src';
+                in
+                final.haskell-nix.project' {
+                  src = cleanSource ./.;
+                  compiler-nix-name = "ghc928";
+                  projectFileName = "stack.yaml";
+                  modules = [
+                    # enable profiling
+                    {
+                      enableLibraryProfiling = true;
+                      profilingDetail = "none";
+                    }
+                    # remove buggy build tool dependencies
+                    ({ lib, ... }: {
+                      # this component has the build tool
+                      # `unison-cli:unison` and somehow haskell.nix
+                      # decides to add some file sharing package
+                      # `unison` as a build-tool dependency.
+                      packages.unison-cli.components.exes.cli-integration-tests.build-tools = lib.mkForce [ ];
+                    })
+                  ];
+                  branchMap = {
+                    "https://github.com/unisonweb/configurator.git"."e47e9e9fe1f576f8c835183b9def52d73c01327a" =
+                      "unison";
+                    "https://github.com/unisonweb/shellmet.git"."2fd348592c8f51bb4c0ca6ba4bc8e38668913746" =
+                      "topic/avoid-callCommand";
                   };
                 };
-                branchMap = {
-                  "https://github.com/unisonweb/configurator.git"."e47e9e9fe1f576f8c835183b9def52d73c01327a" =
-                    "unison";
-                  "https://github.com/unisonweb/shellmet.git"."2fd348592c8f51bb4c0ca6ba4bc8e38668913746" =
-                    "topic/avoid-callCommand";
+            })
+          ];
+          pkgs = import nixpkgs {
+            inherit system overlays;
+            inherit (haskellNix) config;
+          };
+          flake = pkgs.unison-project.flake { };
+
+          commonShellArgs = args: args // {
+            # workaround:
+            # https://github.com/input-output-hk/haskell.nix/issues/1793
+            # https://github.com/input-output-hk/haskell.nix/issues/1885
+            allToolDeps = false;
+            buildInputs = (args.buildInputs or [ ]) ++ (with pkgs; [ stack ]);
+            tools =
+              let ormolu-ver = "0.5.2.0";
+              in (args.tools or { }) // {
+                cabal = { };
+                ormolu = { version = ormolu-ver; };
+                haskell-language-server = {
+                  version = "latest";
+                  # specify flags via project file rather than a module override
+                  # https://github.com/input-output-hk/haskell.nix/issues/1509
+                  cabalProject = ''
+                    packages: .
+                    package haskell-language-server
+                      flags: -brittany -fourmolu -stylishhaskell -hlint
+                    constraints: ormolu == ${ormolu-ver}
+                  '';
                 };
               };
-          })
-        ];
-        pkgs = import nixpkgs {
-          inherit system overlays;
-          inherit (haskellNix) config;
-        };
-        flake = pkgs.unison-project.flake { };
-      in flake // { defaultPackage = flake.packages."unison-cli:exe:unison"; });
+          };
+
+          shellFor = args: pkgs.unison-project.shellFor (commonShellArgs args);
+
+          localPackages = with pkgs.lib;
+            filterAttrs (k: v: v.isLocal or false) pkgs.unison-project.hsPkgs;
+          localPackageNames = builtins.attrNames localPackages;
+          devShells =
+            let
+              mkDevShell = pkgName: shellFor
+                {
+                  packages = hpkgs: [ hpkgs."${pkgName}" ];
+                  withHoogle = true;
+                };
+              localPackageDevShells = pkgs.lib.genAttrs localPackageNames mkDevShell;
+            in
+            {
+              default = devShells.only-tools;
+              only-tools = shellFor {
+                packages = _: [ ];
+                withHoogle = false;
+              };
+              local = shellFor {
+                packages = hpkgs: (map (p: hpkgs."${p}") localPackageNames);
+                withHoogle = true;
+              };
+            } // localPackageDevShells;
+        in
+        flake // {
+          defaultPackage = flake.packages."unison-cli:exe:unison"; inherit (pkgs) unison-project;
+          inherit devShells localPackageNames;
+        });
 }


### PR DESCRIPTION
## Overview

This updates our nix flake so that each cabal component is a nix derivation. This is accomplished by deriving our nix derivations from the `stack.yaml` file, so our `stack.yaml` file remains the source of truth. This change affords us some new capabilities:

We now have the option to use nix to build our packages and run our tests in CI. This would allow us to let nix handle caching of build products rather than manually attempting to accomplish this by caching the relevant stack directories. Additionally, since nix derivations are fully keyed by all of their inputs, we don't have to deal with cache invalidation like we do with our current arrangement. That is, there would be no need to have separate caches for each PR, or separate caches for long-lived branches. Another benefit: a nix build will pull only the dependencies it needs for that build from the cache, and will only push builds that the cache doesn't have.

If we use nix in CI then we may freely pull from this cache in our development environments. So, those who use nix development environments need not build things that CI has built. This could include our build tools used in development environments (e.g. the correct version of ghc, cabal, stack, ormolu, and hls) as well as our haskell dependencies (non-local and local). 

These benefits may be reaped in different ways depending on the local build tools used:

If you simply want to test an executable from a PR then no compilation is necessary. For example, a `nix build` on the PR branch would download the unison executable that CI built for that PR.

If cabal is used along with a cabal.project file, then there will not be a need to compile non-local haskell packages, as those can be downloaded from the CI cache. This is accomplished by nix providing a haskell package database with all of the non-local dependencies of our cabal.project file. I'm not as familiar with stack, so I don't know if or how you can instruct it to use the global package database.

It is also possible to have nix provide all dependencies of a package (local and non-local), then iterate on that package with cabal. This is especially appealing to me when profiling as profiling with stack is troublesome, primarily because it forces `-fprof-auto` on all transitive dependencies, and there doesn't seem to be a way to disable this behavior, but also because of cache invalidation when enabling and disabling profiling with stack.

## Implementation notes

This uses [haskell.nix](https://github.com/input-output-hk/haskell.nix) to turn our stack yaml into nix derivations.

## Test coverage

Manual testing by me with x86_64-linux. I think @ceedubs will be testing with aarch64-darwin soon.
