### PR TITLE
Fix failure to find some docs

### DIFF
--- a/unison-core/src/Unison/Name.hs
+++ b/unison-core/src/Unison/Name.hs
@@ -18,6 +18,7 @@ module Unison.Name
     endsWithReverseSegments,
     endsWithSegments,
     stripReversedPrefix,
+    tryStripReversedPrefix,
     reverseSegments,
     segments,
     suffixes,
@@ -160,17 +161,31 @@ endsWithReverseSegments :: Name -> [NameSegment] -> Bool
 endsWithReverseSegments (Name _ ss0) ss1 =
   List.NonEmpty.isPrefixOf ss1 ss0
 
--- >>> stripReversedPrefix "a.b.c" ["b", "a"]
--- Just c
--- >>> stripReversedPrefix "x.y" ["b", "a"]
+-- >>> stripReversedPrefix (fromReverseSegments ("c" :| ["b", "a"])) ["b", "a"]
+-- Just (Name Relative (NameSegment {toText = "c"} :| []))
+-- >>> stripReversedPrefix (fromReverseSegments ("y" :| ["x"])) ["b", "a"]
 -- Nothing
--- >>> stripReversedPrefix "a.b" ["b", "a"]
--- Nothing
+--
+-- >>> stripReversedPrefix (fromReverseSegments ("c" :| ["b", "a"])) ["b", "a"]
+-- Just (Name Relative (NameSegment {toText = "c"} :| []))
 stripReversedPrefix :: Name -> [NameSegment] -> Maybe Name
 stripReversedPrefix (Name p segs) suffix = do
   stripped <- List.stripSuffix suffix (toList segs)
   nonEmptyStripped <- List.NonEmpty.nonEmpty stripped
   pure $ Name p nonEmptyStripped
+
+-- | Like 'stripReversedPrefix' but if the prefix doesn't match, or if it would strip the
+-- entire name away just return the original name.
+--
+-- >>> tryStripReversedPrefix (fromReverseSegments ("c" :| ["b", "a"])) ["b", "a"]
+-- Name Relative (NameSegment {toText = "c"} :| [])
+-- >>> tryStripReversedPrefix (fromReverseSegments ("y" :| ["x"])) ["b", "a"]
+-- Name Relative (NameSegment {toText = "y"} :| [NameSegment {toText = "x"}])
+--
+-- >>> tryStripReversedPrefix (fromReverseSegments ("c" :| ["b", "a"])) ["b", "a"]
+-- Name Relative (NameSegment {toText = "c"} :| [])
+tryStripReversedPrefix :: Name -> [NameSegment] -> Name
+tryStripReversedPrefix n s = fromMaybe n (stripReversedPrefix n s)
 
 -- | @isPrefixOf x y@ returns whether @x@ is a prefix of (or equivalent to) @y@, which is false if one name is relative
 -- and the other is absolute.

--- a/unison-share-api/src/Unison/Server/Share/Definitions.hs
+++ b/unison-share-api/src/Unison/Server/Share/Definitions.hs
@@ -90,7 +90,9 @@ definitionForHQName perspective rootHash renderWidth suffixifyBindings rt codeba
   let width = mayDefaultWidth renderWidth
   let docResults :: Name -> Backend IO [(HashQualifiedName, UnisonHash, Doc.Doc)]
       docResults name = do
+        Debug.debugM Debug.Server "definitionForHQName: looking up docs for name" name
         docRefs <- liftIO $ docsForDefinitionName codebase nameSearch name
+        Debug.debugM Debug.Server "definitionForHQName: Found these docs" docRefs
         renderDocRefs ppedBuilder width codebase rt docRefs
 
   let drDeps = definitionResultsDependencies dr


### PR DESCRIPTION
## Overview

The doc-search wasn't properly converting FQN into a name local to the current perspective; so when it was searching for the docs for something like `public.project.main.blah` it would actually look for `public.project.main.public.project.main.blah.doc`; and fail to render the doc at all:

E.g. https://share.unison-lang.org/@runarorama/p/code/latest/namespaces/public/codec/latest/;/terms/Decode/alsoBytes

the solution is just to strip the path to the current perspective before running the search.

## Implementation notes

Strip the current mount-path from any fully-qualified queries before searching.

## Test coverage

This was easy to test locally, but I really need to get transcripts for this sort of thing running in enlil. Transcripts in enlil are currently broken and will take a little time to fix, and also don't run in CI. 
Getting those back into shape is fairly high on the todo-list.