### PR TITLE
Include latest release in get-project response

### DIFF
--- a/unison-share-projects-api/src/Unison/Share/API/Projects.hs
+++ b/unison-share-projects-api/src/Unison/Share/API/Projects.hs
@@ -321,10 +321,22 @@ instance ToJSON SetProjectBranchHeadResponse where
 ------------------------------------------------------------------------------------------------------------------------
 -- Types
 
+-- | A sem-ver release version without a user, project, or "releases/" prefix.
+-- E.g. "1.2.3"
+type ReleaseVersion = Text
+
+-- | A project branch name segment.
+-- Does not contain a project or contributor segment.
+--
+-- E.g. "main"
+type BranchName = Text
+
 -- | A project.
 data Project = Project
   { projectId :: Text,
-    projectName :: Text
+    projectName :: Text,
+    latestRelease :: Maybe ReleaseVersion,
+    defaultBranch :: Maybe BranchName
   }
   deriving stock (Eq, Show, Generic)
 
@@ -333,13 +345,17 @@ instance FromJSON Project where
     withObject "Project" \o -> do
       projectId <- parseField o "project-id"
       projectName <- parseField o "project-name"
-      pure Project {projectId, projectName}
+      latestRelease <- o .:? "latest-release"
+      defaultBranch <- o .:? "default-branch"
+      pure Project {..}
 
 instance ToJSON Project where
-  toJSON (Project projectId projectName) =
+  toJSON (Project projectId projectName latestRelease defaultBranch) =
     object
       [ "project-id" .= projectId,
-        "project-name" .= projectName
+        "project-name" .= projectName,
+        "latest-release" .= latestRelease,
+        "default-branch" .= defaultBranch
       ]
 
 -- | A project branch.


### PR DESCRIPTION
## Overview

Includes the latest release and default branch of a project in UCM's get-project call.

This is a pre-requisite for supporting any sort of `> project.install @unison/base` style flow which would need to find the latest release.

The default branch was trivial to throw on there so I added that too.

This is back-compatible with old UCM clients.

## Implementation notes

Just adds the types, see https://github.com/unisoncomputing/enlil/pull/262 for the Server-side.

