### PR TITLE
(issue) transcript of issue with record types and user types

### DIFF
--- a/unison-src/transcripts/records.md
+++ b/unison-src/transcripts/records.md
@@ -69,6 +69,27 @@ unique type Record4 =
 .> view Record4
 ```
 
+## Record with user-defined type fields
+
+This record type has two fields whose types are user-defined (`Record4` and `UserType`).
+
+```unison:hide
+unique type UserType = UserType Nat
+
+unique type RecordWithUserType = { a : Text, b : Record4, c : UserType }
+```
+
+```ucm:hide
+.> add
+```
+
+If you `view` or `edit` it, it _should_ be treated as a record type, but it does not (which is a bug)
+
+```ucm
+.> view RecordWithUserType
+```
+
+
 ## Syntax
 
 Trailing commas are allowed.

--- a/unison-src/transcripts/records.output.md
+++ b/unison-src/transcripts/records.output.md
@@ -63,6 +63,25 @@ unique type Record4 =
         g : [Nat] }
 
 ```
+## Record with user-defined type fields
+
+This record type has two fields whose types are user-defined (`Record4` and `UserType`).
+
+```unison
+unique type UserType = UserType Nat
+
+unique type RecordWithUserType = { a : Text, b : Record4, c : UserType }
+```
+
+If you `view` or `edit` it, it _should_ be treated as a record type, but it does not (which is a bug)
+
+```ucm
+.> view RecordWithUserType
+
+  unique type RecordWithUserType
+    = RecordWithUserType Text Record4 UserType
+
+```
 ## Syntax
 
 Trailing commas are allowed.


### PR DESCRIPTION
If a record type has a field that is a user-defined type, `view` no
longer treats the type as a record type. This becomes a big pain because
if you want to `edit` the type you have to search around for the proper
name and order of the fields to recreate what the record type definition
should look like.

**Note**: this is really more of an issue than a PR. I've added a
failing test case in a transcript but not a fix for the issue.
