### PR TITLE
Consider empty strings in Text.indexOf

### DIFF
--- a/parser-typechecker/src/Unison/Util/Text.hs
+++ b/parser-typechecker/src/Unison/Util/Text.hs
@@ -122,6 +122,7 @@ toText (Text t) = T.concat (chunkToText <$> unfoldr R.uncons t)
 {-# INLINE toText #-}
 
 indexOf :: Text -> Text -> Maybe Word64
+indexOf "" _ = Just 0
 indexOf needle haystack =
   case TL.breakOn needle' haystack' of
     (_, "") -> Nothing

--- a/unison-src/transcripts/builtins.md
+++ b/unison-src/transcripts/builtins.md
@@ -262,6 +262,7 @@ test> Text.tests.indexOf =
    needle6 = "0c"
    needle7 = haystack
    needle8 = "lopez"
+   needle9 = ""
    checks [
      Text.indexOf needle1 haystack == Some 0,
      Text.indexOf needle2 haystack == Some 2,
@@ -271,6 +272,7 @@ test> Text.tests.indexOf =
      Text.indexOf needle6 haystack == Some 22,
      Text.indexOf needle7 haystack == Some 0,
      Text.indexOf needle8 haystack == None,
+     Text.indexOf needle9 haystack == Some 0,
    ]
    
 test> Text.tests.indexOfEmoji = 

--- a/unison-src/transcripts/builtins.output.md
+++ b/unison-src/transcripts/builtins.output.md
@@ -243,6 +243,7 @@ test> Text.tests.indexOf =
    needle6 = "0c"
    needle7 = haystack
    needle8 = "lopez"
+   needle9 = ""
    checks [
      Text.indexOf needle1 haystack == Some 0,
      Text.indexOf needle2 haystack == Some 2,
@@ -252,6 +253,7 @@ test> Text.tests.indexOf =
      Text.indexOf needle6 haystack == Some 22,
      Text.indexOf needle7 haystack == Some 0,
      Text.indexOf needle8 haystack == None,
+     Text.indexOf needle9 haystack == Some 0,
    ]
    
 test> Text.tests.indexOfEmoji = 


### PR DESCRIPTION
Fixes this bug:

```
> ##Text.indexOf "" "foo"
```
⬇️
```
Encountered exception:
Data.Text.Lazy.breakOn: empty input
CallStack ( from HasCallStack ):
    error
```
  
The empty search string now just always returns the 0 index.