### PR TITLE
Add helpers for hashing v2 branches

### DIFF
--- a/codebase2/codebase-sqlite-hashing-v2/package.yaml
+++ b/codebase2/codebase-sqlite-hashing-v2/package.yaml
@@ -27,6 +27,7 @@ library:
   source-dirs: src
   exposed-modules:
     - U.Codebase.Sqlite.V2.HashHandle
+    - U.Codebase.Branch.Hashing
   when:
     - condition: false
       other-modules: Paths_unison_codebase_sqlite_hashing_v2

--- a/codebase2/codebase-sqlite-hashing-v2/package.yaml
+++ b/codebase2/codebase-sqlite-hashing-v2/package.yaml
@@ -28,6 +28,7 @@ library:
   exposed-modules:
     - U.Codebase.Sqlite.V2.HashHandle
     - U.Codebase.Branch.Hashing
+    - U.Codebase.Causal.Hashing
   when:
     - condition: false
       other-modules: Paths_unison_codebase_sqlite_hashing_v2

--- a/codebase2/codebase-sqlite-hashing-v2/src/U/Codebase/Branch/Hashing.hs
+++ b/codebase2/codebase-sqlite-hashing-v2/src/U/Codebase/Branch/Hashing.hs
@@ -1,0 +1,10 @@
+module U.Codebase.Branch.Hashing (hashBranch) where
+
+import U.Codebase.Branch (Branch)
+import U.Codebase.HashTags
+import Unison.Hashing.V2 qualified as Hashing
+import Unison.Hashing.V2.Convert2 (v2ToH2Branch)
+
+hashBranch :: forall m. Monad m => Branch m -> m BranchHash
+hashBranch branch =
+  BranchHash . Hashing.contentHash <$> v2ToH2Branch branch

--- a/codebase2/codebase-sqlite-hashing-v2/src/U/Codebase/Causal/Hashing.hs
+++ b/codebase2/codebase-sqlite-hashing-v2/src/U/Codebase/Causal/Hashing.hs
@@ -1,0 +1,14 @@
+module U.Codebase.Causal.Hashing where
+
+import Data.Set
+import Data.Set qualified as Set
+import U.Codebase.HashTags (BranchHash (..), CausalHash (..))
+import Unison.Hashing.V2 qualified as Hashing
+
+hashCausal :: Set CausalHash -> BranchHash -> CausalHash
+hashCausal ancestors branchHash =
+  CausalHash . Hashing.contentHash $
+    Hashing.Causal
+      { Hashing.branchHash = unBranchHash branchHash,
+        Hashing.parents = Set.map unCausalHash ancestors
+      }

--- a/codebase2/codebase-sqlite-hashing-v2/src/Unison/Hashing/V2/Convert2.hs
+++ b/codebase2/codebase-sqlite-hashing-v2/src/Unison/Hashing/V2/Convert2.hs
@@ -3,32 +3,43 @@ module Unison.Hashing.V2.Convert2
   ( v2ToH2Type,
     v2ToH2TypeD,
     h2ToV2Reference,
+    v2ToH2Branch,
   )
 where
 
+import Data.Map qualified as Map
+import Data.Set qualified as Set
+import U.Codebase.Branch qualified as V2
+import U.Codebase.Branch qualified as V2Branch
+import U.Codebase.Causal qualified as Causal
+import U.Codebase.HashTags (CausalHash (..), PatchHash (..))
 import U.Codebase.Kind qualified as V2
 import U.Codebase.Reference qualified as V2
+import U.Codebase.Reference qualified as V2Reference
+import U.Codebase.Referent qualified as V2Referent
 import U.Codebase.Term qualified as V2 (TypeRef)
 import U.Codebase.Type qualified as V2.Type
 import U.Core.ABT qualified as ABT
 import Unison.Hash (Hash)
 import Unison.Hashing.V2 qualified as H2
+import Unison.NameSegment (NameSegment (..))
 import Unison.Prelude
+import Unison.Util.Map qualified as Map
 
-convertId :: Hash -> V2.Id' (Maybe Hash) -> H2.ReferenceId
+convertId :: Hash -> V2Reference.Id' (Maybe Hash) -> H2.ReferenceId
 convertId defaultHash = \case
   V2.Id m p -> H2.ReferenceId (fromMaybe defaultHash m) p
 
-convertReference :: V2.Reference -> H2.Reference
-convertReference = convertReference' (\(V2.Id a b) -> H2.ReferenceId a b)
+v2ToH2Reference :: V2.Reference -> H2.Reference
+v2ToH2Reference = convertReference' (\(V2.Id a b) -> H2.ReferenceId a b)
 
-convertReference' :: (V2.Id' hash -> H2.ReferenceId) -> V2.Reference' Text hash -> H2.Reference
+convertReference' :: (V2Reference.Id' hash -> H2.ReferenceId) -> V2.Reference' Text hash -> H2.Reference
 convertReference' idConv = \case
   V2.ReferenceBuiltin x -> H2.ReferenceBuiltin x
   V2.ReferenceDerived x -> H2.ReferenceDerivedId (idConv x)
 
 v2ToH2Type :: forall v. (Ord v) => V2.Type.TypeR V2.TypeRef v -> H2.Type v ()
-v2ToH2Type = v2ToH2Type' convertReference
+v2ToH2Type = v2ToH2Type' v2ToH2Reference
 
 v2ToH2TypeD :: forall v. (Ord v) => Hash -> V2.Type.TypeD v -> H2.Type v ()
 v2ToH2TypeD defaultHash = v2ToH2Type' (convertReference' (convertId defaultHash))
@@ -56,3 +67,29 @@ h2ToV2Reference :: H2.Reference -> V2.Reference
 h2ToV2Reference = \case
   H2.ReferenceBuiltin txt -> V2.ReferenceBuiltin txt
   H2.ReferenceDerivedId (H2.ReferenceId x y) -> V2.ReferenceDerived (V2.Id x y)
+
+v2ToH2Referent :: V2Referent.Referent -> H2.Referent
+v2ToH2Referent = \case
+  V2Referent.Ref r -> H2.ReferentRef (v2ToH2Reference r)
+  V2Referent.Con r cid -> H2.ReferentCon (v2ToH2Reference r) cid
+
+v2ToH2Branch :: Monad m => V2.Branch m -> m H2.Branch
+v2ToH2Branch V2.Branch {terms, types, patches, children} = do
+  hterms <-
+    traverse sequenceA terms
+      <&> Map.bimap coerce (Map.bimap v2ToH2Referent v2ToH2MdValues)
+  htypes <-
+    traverse sequenceA types
+      <&> Map.bimap coerce (Map.bimap v2ToH2Reference v2ToH2MdValues)
+  let hpatches =
+        patches
+          & Map.bimap coerce (unPatchHash . fst)
+  let hchildren = children & Map.bimap coerce (unCausalHash . Causal.causalHash)
+  pure $ H2.Branch {types = htypes, terms = hterms, patches = hpatches, children = hchildren}
+
+v2ToH2MdValues :: V2Branch.MdValues -> H2.MdValues
+v2ToH2MdValues (V2Branch.MdValues mdMap) =
+  mdMap
+    & Map.keysSet
+    & Set.map v2ToH2Reference
+    & H2.MdValues

--- a/codebase2/codebase-sqlite-hashing-v2/unison-codebase-sqlite-hashing-v2.cabal
+++ b/codebase2/codebase-sqlite-hashing-v2/unison-codebase-sqlite-hashing-v2.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -18,6 +18,8 @@ source-repository head
 library
   exposed-modules:
       U.Codebase.Sqlite.V2.HashHandle
+      U.Codebase.Branch.Hashing
+      U.Codebase.Causal.Hashing
   other-modules:
       Unison.Hashing.V2.Convert2
   hs-source-dirs:

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 


### PR DESCRIPTION
## Overview

I'll need to be able to hash V2 branches in order to implement a more efficient Causal Squash without loading the whole branch into memory, this adds helpers for hashing v2 branches and hashing V2 Causals to allow this.

## Implementation notes

I put these in `codebase-sqlite-hashing-v2`, but if there's a better spot for them please let me know.

## Test coverage

I rigged up a fake migration and ran it on the nimbus codebase (the biggest codebase I know of) to check that every causal and branch hashes the same as the hash we have saved for them.

```
import Control.Lens
import Data.Map qualified as Map
import Data.Set qualified as Set
import U.Codebase.Branch.Hashing (hashBranch)
import U.Codebase.Causal (Causal (..))
import U.Codebase.Causal.Hashing (hashCausal)
import U.Codebase.HashTags (BranchHash (unBranchHash), CausalHash (..))
import U.Codebase.Sqlite.Operations qualified as Ops
import Unison.Hashing.V2 qualified as Hashing
import Unison.Prelude
import Unison.Sqlite

-- Rehash every causal to make sure v2 hashing is good
rehashStuff :: Transaction ()
rehashStuff = do
  causalHashIds <- queryListCol [sql| SELECT self_hash_id from causal |]
  err <- ifor causalHashIds \_i chId -> do
    Causal {causalHash, valueHash, parents, value} <- Ops.expectCausalBranchByCausalHashId chId
    let v2CausalHash = hashCausal (Map.keysSet parents) valueHash
    unsafeIO $ when (v2CausalHash /= causalHash) $ do
      putStrLn $ "ERROR: v2 causal hash mismatch " <> show v2CausalHash <> " /= " <> show causalHash
      putStrLn $ "Saved causal Hash" <> show causalHash
      putStrLn $ "V2 causal Hash" <> show v2CausalHash
      let recomputedTrunkCausalHash = CausalHash . Hashing.contentHash $ Hashing.Causal (unBranchHash valueHash) (Set.map unCausalHash (Map.keysSet parents))
      putStrLn $ "Recomputed trunk causal hash" <> show recomputedTrunkCausalHash
    v2Branch <- value
    v2BranchHash <- hashBranch v2Branch
    unsafeIO $ when (v2BranchHash /= valueHash) $ putStrLn $ "ERROR: v2 branch hash mismatch " <> show v2BranchHash <> " /= " <> show valueHash
    pure $ v2CausalHash /= causalHash || v2BranchHash /= valueHash
  unsafeIO $
    if (or err)
      then putStrLn $ "Rehashing failure"
      else putStrLn $ "Rehashing SUCCESS!"
```

It ran on 102056 causals and got the correct answer on all but 2 of them 🤔 ;
I re-hashed those two using both the v1 and v2 hashing functions and those agreed, it's just the hash that they're stored at in SQLite that disagrees.

```
ERROR: v2 causal hash mismatch CausalHash ("8nn80pp45l23i6hnko8uqushhggp32rrh2euf66dtrpqkesa7647sosgoj8ol8rand93sl1a3recdlm9rih9lcm8mmk6f1qm1iulbbo") /= CausalHash ("2ka6lc5suqjp1j323hsqe0bbvg7pnk5bo3d7e5ek22uvpsivormtoj45fh70s2f9odl7d3bvaa5802pd7aai0kid0iit8218752fij8")
Saved causal HashCausalHash ("2ka6lc5suqjp1j323hsqe0bbvg7pnk5bo3d7e5ek22uvpsivormtoj45fh70s2f9odl7d3bvaa5802pd7aai0kid0iit8218752fij8")
V2 causal HashCausalHash ("8nn80pp45l23i6hnko8uqushhggp32rrh2euf66dtrpqkesa7647sosgoj8ol8rand93sl1a3recdlm9rih9lcm8mmk6f1qm1iulbbo")
Recomputed trunk causal hashCausalHash ("8nn80pp45l23i6hnko8uqushhggp32rrh2euf66dtrpqkesa7647sosgoj8ol8rand93sl1a3recdlm9rih9lcm8mmk6f1qm1iulbbo")
ERROR: v2 causal hash mismatch CausalHash ("1rr75t1svnp0likhj027ccolau8l56hnmk4lupt3lm4f5upajsfefbr53so8ldhi0uhsqh8mnjtkqs3d3bqfqk5nlgfkp1v6md2s87o") /= CausalHash ("c311hak51uqhs9ouu7tu9ukjj5qfk1pfismucnq3njjkbbaf8im2bq79cn9ofe04l6j5bjcinuliulcqroav3mk2gvggobs2tj1juno")
Saved causal HashCausalHash ("c311hak51uqhs9ouu7tu9ukjj5qfk1pfismucnq3njjkbbaf8im2bq79cn9ofe04l6j5bjcinuliulcqroav3mk2gvggobs2tj1juno")
V2 causal HashCausalHash ("1rr75t1svnp0likhj027ccolau8l56hnmk4lupt3lm4f5upajsfefbr53so8ldhi0uhsqh8mnjtkqs3d3bqfqk5nlgfkp1v6md2s87o")
Recomputed trunk causal hashCausalHash ("1rr75t1svnp0likhj027ccolau8l56hnmk4lupt3lm4f5upajsfefbr53so8ldhi0uhsqh8mnjtkqs3d3bqfqk5nlgfkp1v6md2s87o")
```

Which AFAICT are just saved with the wrong causal hash...

I loaded them up in UCM to poke around:

```
.> reset-root #2ka6lc5suqjp1j323hsqe0bbvg7pnk5bo3d7e5ek22uvpsivormtoj45fh70s2f9odl7d3bvaa5802pd7aai0kid0iit8218752fij8
.> ls
                                                                                                                                                                                                                                                1. isLeft          (#0o7mf021fo a b -> ##Boolean)                                                                                                                                                                                             2. isRight         (#0o7mf021fo a b -> ##Boolean)                                                                                                                                                                                             3. leftToOptional  (#0o7mf021fo a b -> #nirp5os0q6 a)                                                                                                                                                                                         4. rightToOptional (#0o7mf021fo a b -> #nirp5os0q6 b)                                                                                                                                                                                       
.> history

  Note: The most recent namespace hash is immediately below this message.

  □ 1. #2ka6lc5suq (start of history)

.> reset-root #c311hak51uqhs9ouu7tu9ukjj5qfk1pfismucnq3njjkbbaf8im2bq79cn9ofe04l6j5bjcinuliulcqroav3mk2gvggobs2tj1juno

  Done.

.> ls

  1. product ([##Nat] -> ##Nat)
  2. sum     ([##Nat] -> ##Nat)

.> history
                                                                                                                                                                                                                                                Note: The most recent namespace hash is immediately below this message.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 □ 1. #c311hak51u (start of history)                                                                                                                                                                                                         
```

So they look like relatively standard causals; hopefully they're just really old causals that are still around, but the question would be whether we need to fix them, or can track down where they came from.

Also of note, Share still doesn't validate the hashes of things clients upload, which we should really do at some point, but of course doing that would slow down the already slow sync process...

---

All that to say, the test does confirm that at least we the v2 hashing methods do compute the same hashes as the V1 methods, so I don't think there's any reason to hold this up while we think about what to do with the old bad data.