### PR TITLE
Generate random project names with no-arg `project.create`

### DIFF
--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -57,6 +57,7 @@ dependencies:
   - pretty-simple
   - process
   - random >= 1.2.0
+  - random-shuffle
   - recover-rtti
   - regex-tdfa
   - semialign

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1637,7 +1637,6 @@ inputDescription input =
       branchId2 <- hp' (input ^. #branchId2)
       patch <- ps' (input ^. #patch)
       pure (Text.unwords ["diff.namespace.to-patch", branchId1, branchId2, patch])
-    ProjectCreateI project -> pure ("project.create " <> into @Text project)
     ClearI {} -> pure "clear"
     DocToMarkdownI name -> pure ("debug.doc-to-markdown " <> Name.toText name)
     --
@@ -1678,6 +1677,7 @@ inputDescription input =
     PreviewAddI {} -> wat
     PreviewMergeLocalBranchI {} -> wat
     PreviewUpdateI {} -> wat
+    ProjectCreateI {} -> wat
     ProjectRenameI {} -> wat
     ProjectSwitchI {} -> wat
     ProjectsI -> wat

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectCreate.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectCreate.hs
@@ -111,8 +111,58 @@ generateRandomProjectNames :: IO [ProjectName]
 generateRandomProjectNames = do
   baseNames <-
     RandomShuffle.shuffleM do
-      adjective <- ["happy", "silly"]
-      noun <- ["giraffe", "gorilla"]
+      adjective <-
+        [ "adorable",
+          "beautiful",
+          "charming",
+          "delightful",
+          "excited",
+          "friendly",
+          "gentle",
+          "helpful",
+          "innocent",
+          "jolly",
+          "kind",
+          "lucky",
+          "magnificent",
+          "nice",
+          "outstanding",
+          "pleasant",
+          "quiet",
+          "responsible",
+          "silly",
+          "thoughtful",
+          "useful",
+          "witty"
+          ]
+      noun <-
+        [ "alpaca",
+          "blobfish",
+          "camel",
+          "donkey",
+          "earwig",
+          "ferret",
+          "gerbil",
+          "hamster",
+          "ibis",
+          "jaguar",
+          "koala",
+          "lemur",
+          "marmot",
+          "narwhal",
+          "ostrich",
+          "puffin",
+          "quahog",
+          "reindeer",
+          "seahorse",
+          "turkey",
+          "urchin",
+          "vole",
+          "walrus",
+          "yak",
+          "zebra"
+          ]
+
       pure (adjective <> "-" <> noun)
 
   let namesWithNumbers = do

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -226,7 +226,7 @@ data Input
   | AuthLoginI
   | VersionI
   | DiffNamespaceToPatchI DiffNamespaceToPatchInput
-  | ProjectCreateI ProjectName
+  | ProjectCreateI (Maybe ProjectName)
   | ProjectRenameI ProjectName
   | ProjectSwitchI ProjectAndBranchNames
   | ProjectsI

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -324,7 +324,7 @@ data Output
   | DisplayDebugCompletions [Completion.Completion]
   | ClearScreen
   | PulledEmptyBranch (ReadRemoteNamespace Share.RemoteProjectBranch)
-  | CreatedProject ProjectName ProjectBranchName
+  | CreatedProject Bool {- randomly-generated name? -} ProjectName
   | CreatedProjectBranch CreatedProjectBranchFrom (ProjectAndBranch ProjectName ProjectBranchName)
   | CreatedRemoteProject URI (ProjectAndBranch ProjectName ProjectBranchName)
   | CreatedRemoteProjectBranch URI (ProjectAndBranch ProjectName ProjectBranchName)

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2400,17 +2400,18 @@ projectCreate =
     { patternName = "project.create",
       aliases = ["create.project"],
       visibility = I.Hidden,
-      argTypes = [(Required, projectNameArg)],
+      argTypes = [],
       help =
         P.wrapColumn2
-          [ ("`project.create foo`", "creates the project foo and switches you to foo/main")
+          [ ("`project.create`", "creates a project with a random name"),
+            ("`project.create foo`", "creates a project named `foo`")
           ],
       parse = \case
         [name] ->
           case tryInto @ProjectName (Text.pack name) of
             Left _ -> Left "Invalid project name."
-            Right name1 -> Right (Input.ProjectCreateI name1)
-        _ -> Left (showPatternHelp projectCreate)
+            Right name1 -> Right (Input.ProjectCreateI (Just name1))
+        _ -> Right (Input.ProjectCreateI Nothing)
     }
 
 projectRenameInputPattern :: InputPattern

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1796,15 +1796,19 @@ notifyUser dir = \case
   PulledEmptyBranch remote ->
     pure . P.warnCallout . P.wrap $
       P.group (prettyReadRemoteNamespace remote) <> "has some history, but is currently empty."
-  CreatedProject projectName branchName ->
+  CreatedProject nameWasRandomlyGenerated projectName ->
     pure $
-      P.wrap
-        ( "I just created project"
-            <> prettyProjectName projectName
-            <> "with branch"
-            <> prettyProjectBranchName branchName
-        )
-        <> "."
+      if nameWasRandomlyGenerated
+        then
+          P.wrap $
+            "🎉 I've created the project with the randomly-chosen name"
+              <> prettyProjectName projectName
+              <> "(use"
+              <> IP.makeExample IP.projectRenameInputPattern ["<new-name>"]
+              <> "to change it)."
+        else
+          P.wrap $
+            "🎉 I've created the project" <> P.group (prettyProjectName projectName <> ".")
   CreatedProjectBranch from projectAndBranch ->
     case from of
       CreatedProjectBranchFrom'LooseCode path ->

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -190,6 +190,7 @@ library
     , pretty-simple
     , process
     , random >=1.2.0
+    , random-shuffle
     , recover-rtti
     , regex-tdfa
     , semialign
@@ -322,6 +323,7 @@ executable cli-integration-tests
     , pretty-simple
     , process
     , random >=1.2.0
+    , random-shuffle
     , recover-rtti
     , regex-tdfa
     , semialign
@@ -448,6 +450,7 @@ executable transcripts
     , pretty-simple
     , process
     , random >=1.2.0
+    , random-shuffle
     , recover-rtti
     , regex-tdfa
     , semialign
@@ -580,6 +583,7 @@ executable unison
     , pretty-simple
     , process
     , random >=1.2.0
+    , random-shuffle
     , recover-rtti
     , regex-tdfa
     , semialign
@@ -718,6 +722,7 @@ test-suite cli-tests
     , pretty-simple
     , process
     , random >=1.2.0
+    , random-shuffle
     , recover-rtti
     , regex-tdfa
     , semialign

--- a/unison-src/transcripts/delete-project-branch.output.md
+++ b/unison-src/transcripts/delete-project-branch.output.md
@@ -4,7 +4,7 @@ your working directory with each command).
 ```ucm
 .> project.create foo
 
-  I just created project foo with branch main.
+  🎉 I've created the project foo.
 
 foo/main> branch topic
 

--- a/unison-src/transcripts/delete-project.output.md
+++ b/unison-src/transcripts/delete-project.output.md
@@ -3,13 +3,13 @@
 ```ucm
 .> project.create foo
 
-  I just created project foo with branch main.
+  🎉 I've created the project foo.
 
   ☝️  The namespace . is empty.
 
 .> project.create bar
 
-  I just created project bar with branch main.
+  🎉 I've created the project bar.
 
   ☝️  The namespace . is empty.
 

--- a/unison-src/transcripts/project-merge.output.md
+++ b/unison-src/transcripts/project-merge.output.md
@@ -32,7 +32,7 @@ zonk = 0
 
 .> project.create foo
 
-  I just created project foo with branch main.
+  🎉 I've created the project foo.
 
 .> merge foo foo/main
 
@@ -76,7 +76,7 @@ foo/main> add
 ```ucm
 .> project.create bar
 
-  I just created project bar with branch main.
+  🎉 I've created the project bar.
 
 bar/main> merge foo/main
 

--- a/unison-src/transcripts/release-draft-command.output.md
+++ b/unison-src/transcripts/release-draft-command.output.md
@@ -20,7 +20,7 @@ someterm = 18
 ```ucm
 .> project.create foo
 
-  I just created project foo with branch main.
+  🎉 I've created the project foo.
 
 foo/main> add
 

--- a/unison-src/transcripts/reset.output.md
+++ b/unison-src/transcripts/reset.output.md
@@ -101,7 +101,7 @@ foo.a = 5
 ```ucm
 .> project.create foo
 
-  I just created project foo with branch main.
+  🎉 I've created the project foo.
 
 foo/main> history
 

--- a/unison-src/transcripts/switch-command.output.md
+++ b/unison-src/transcripts/switch-command.output.md
@@ -20,11 +20,11 @@ someterm = 18
 ```ucm
 .> project.create foo
 
-  I just created project foo with branch main.
+  🎉 I've created the project foo.
 
 .> project.create bar
 
-  I just created project bar with branch main.
+  🎉 I've created the project bar.
 
 foo/main> add
 


### PR DESCRIPTION
## Overview

Part of #4083 

This PR relaxes `project.create`'s argument from required to optional. If left off, we generate a random project name.

## Implementation notes

There is a hard-coded list of adjectives and nouns, currently just "hungry"/"silly" + "giraffe"/"gorilla".

To generate a random project name, we first shuffle the list of all possible (adjective, noun) pairs, then make that list infinite in size by appending increasing digits starting with 2, then take the first available name from that list.

Here's a screenshot that demonstrates the above:

<img width="893" alt="Screen Shot 2023-06-16 at 10 40 23 AM" src="https://github.com/unisonweb/unison/assets/1074598/5821cd2a-0c7d-4739-aa88-096d63f7928e">

I also tweaked the output message of a one-arg `project.create` to look more like the new no-arg version.

<img width="474" alt="Screen Shot 2023-06-16 at 10 40 45 AM" src="https://github.com/unisonweb/unison/assets/1074598/1802f5cc-7f51-4dd5-8bab-30505c2a63c3">

Here's the help output:

<img width="674" alt="Screen Shot 2023-06-16 at 11 34 26 AM" src="https://github.com/unisonweb/unison/assets/1074598/1941ba62-98f4-4aba-8264-27fb5cb78e45">

## Test coverage

I've tested this change manually, and `project.create` is also used in a number of transcripts.

## Loose ends

~We should probably have a larger supply of random words :) Suggestions welcome.~

Updated the lists to

```
adorable
beautiful
charming
delightful
excited
friendly
gentle
helpful
innocent
jolly
kind
lucky
magnificent
nice
outstanding
pleasant
quiet
responsible
silly
thoughtful
useful
witty
```

```
alpaca
blobfish
camel
donkey
earwig
ferret
gerbil
hamster
ibis
jaguar
koala
lemur
marmot
narwhal
ostrich
puffin
quahog
reindeer
seahorse
turkey
urchin
vole
walrus
yak
zebra
```

