### PR TITLE
Add V2 squashing and squash-result cache

### DIFF
--- a/codebase2/codebase-sqlite-hashing-v2/package.yaml
+++ b/codebase2/codebase-sqlite-hashing-v2/package.yaml
@@ -27,8 +27,6 @@ library:
   source-dirs: src
   exposed-modules:
     - U.Codebase.Sqlite.V2.HashHandle
-    - U.Codebase.Branch.Hashing
-    - U.Codebase.Causal.Hashing
   when:
     - condition: false
       other-modules: Paths_unison_codebase_sqlite_hashing_v2

--- a/codebase2/codebase-sqlite-hashing-v2/src/U/Codebase/Causal/Hashing.hs
+++ b/codebase2/codebase-sqlite-hashing-v2/src/U/Codebase/Causal/Hashing.hs
@@ -5,8 +5,8 @@ import Data.Set qualified as Set
 import U.Codebase.HashTags (BranchHash (..), CausalHash (..))
 import Unison.Hashing.V2 qualified as Hashing
 
-hashCausal :: Set CausalHash -> BranchHash -> CausalHash
-hashCausal ancestors branchHash =
+hashCausal :: BranchHash -> Set CausalHash -> CausalHash
+hashCausal branchHash ancestors =
   CausalHash . Hashing.contentHash $
     Hashing.Causal
       { Hashing.branchHash = unBranchHash branchHash,

--- a/codebase2/codebase-sqlite-hashing-v2/src/U/Codebase/Sqlite/V2/HashHandle.hs
+++ b/codebase2/codebase-sqlite-hashing-v2/src/U/Codebase/Sqlite/V2/HashHandle.hs
@@ -4,6 +4,8 @@ module U.Codebase.Sqlite.V2.HashHandle
 where
 
 import Data.Set qualified as Set
+import U.Codebase.Branch.Hashing qualified as H2
+import U.Codebase.Causal.Hashing qualified as H2
 import U.Codebase.Sqlite.HashHandle
 import U.Util.Type (removeAllEffectVars)
 import Unison.Hashing.V2 qualified as H2
@@ -15,5 +17,7 @@ v2HashHandle =
     { toReference = h2ToV2Reference . H2.typeToReference . v2ToH2Type . removeAllEffectVars,
       toReferenceMentions = Set.map h2ToV2Reference . H2.typeToReferenceMentions . v2ToH2Type . removeAllEffectVars,
       toReferenceDecl = \h -> h2ToV2Reference . H2.typeToReference . v2ToH2TypeD h . removeAllEffectVars,
-      toReferenceDeclMentions = \h -> Set.map h2ToV2Reference . H2.typeToReferenceMentions . v2ToH2TypeD h . removeAllEffectVars
+      toReferenceDeclMentions = \h -> Set.map h2ToV2Reference . H2.typeToReferenceMentions . v2ToH2TypeD h . removeAllEffectVars,
+      hashBranch = H2.hashBranch,
+      hashCausal = H2.hashCausal
     }

--- a/codebase2/codebase-sqlite-hashing-v2/unison-codebase-sqlite-hashing-v2.cabal
+++ b/codebase2/codebase-sqlite-hashing-v2/unison-codebase-sqlite-hashing-v2.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.1.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -18,9 +18,9 @@ source-repository head
 library
   exposed-modules:
       U.Codebase.Sqlite.V2.HashHandle
+  other-modules:
       U.Codebase.Branch.Hashing
       U.Codebase.Causal.Hashing
-  other-modules:
       Unison.Hashing.V2.Convert2
   hs-source-dirs:
       src

--- a/codebase2/codebase-sqlite/U/Codebase/Causal/Squash.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Causal/Squash.hs
@@ -1,26 +1,24 @@
 module U.Codebase.Causal.Squash (squashCausal) where
 
-import U.Codebase.Branch.Hashing qualified as Branch
 import U.Codebase.Branch.Type
 import U.Codebase.Causal (Causal (..))
-import U.Codebase.Causal.Hashing (hashCausal)
+import U.Codebase.Sqlite.HashHandle qualified as HH
 import U.Codebase.Sqlite.Operations qualified as SqliteOps
-import U.Codebase.Sqlite.V2.HashHandle (v2HashHandle)
 import Unison.Prelude
 import Unison.Sqlite qualified as Sqlite
 
 -- Recursively discards history, resulting in a namespace tree with only single a single
 -- Causal node at every level.
-squashCausal :: CausalBranch Sqlite.Transaction -> Sqlite.Transaction (CausalBranch Sqlite.Transaction)
-squashCausal Causal {valueHash = unsquashedBranchHash, value} = do
+squashCausal :: HH.HashHandle -> CausalBranch Sqlite.Transaction -> Sqlite.Transaction (CausalBranch Sqlite.Transaction)
+squashCausal hashHandle@HH.HashHandle {hashCausal, hashBranch} Causal {valueHash = unsquashedBranchHash, value} = do
   runMaybeT (MaybeT (SqliteOps.tryGetSquashResult unsquashedBranchHash) >>= MaybeT . SqliteOps.loadCausalBranchByCausalHash) >>= \case
     Just cb -> pure cb
     Nothing -> do
       branch@Branch {children} <- value
-      squashedChildren <- traverse squashCausal children
+      squashedChildren <- traverse (squashCausal hashHandle) children
       let squashedBranchHead = branch {children = squashedChildren}
-      squashedBranchHash <- Branch.hashBranch squashedBranchHead
-      let squashedCausalHash = hashCausal mempty squashedBranchHash
+      squashedBranchHash <- hashBranch squashedBranchHead
+      let squashedCausalHash = hashCausal squashedBranchHash mempty
       let squashedCausalBranch =
             Causal
               { causalHash = squashedCausalHash,
@@ -28,6 +26,6 @@ squashCausal Causal {valueHash = unsquashedBranchHash, value} = do
                 parents = mempty,
                 value = pure squashedBranchHead
               }
-      SqliteOps.saveBranch v2HashHandle squashedCausalBranch
+      SqliteOps.saveBranch hashHandle squashedCausalBranch
       SqliteOps.saveSquashResult unsquashedBranchHash squashedCausalHash
       pure squashedCausalBranch

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/HashHandle.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/HashHandle.hs
@@ -3,6 +3,8 @@ module U.Codebase.Sqlite.HashHandle
   )
 where
 
+import U.Codebase.Branch.Type (Branch)
+import U.Codebase.HashTags
 import U.Codebase.Reference qualified as C
 import U.Codebase.Sqlite.Symbol (Symbol)
 import U.Codebase.Term qualified as C.Term
@@ -18,5 +20,12 @@ data HashHandle = HashHandle
     -- | Hash the type of a single constructor in a decl component. The provided hash argument is the hash of the decl component.
     toReferenceDecl :: Hash -> C.Type.TypeD Symbol -> C.Reference,
     -- | Hash decl's mentions
-    toReferenceDeclMentions :: Hash -> C.Type.TypeD Symbol -> Set C.Reference
+    toReferenceDeclMentions :: Hash -> C.Type.TypeD Symbol -> Set C.Reference,
+    hashBranch :: forall m. Monad m => Branch m -> m BranchHash,
+    hashCausal ::
+      -- The causal's namespace hash
+      BranchHash ->
+      -- The causal's parents
+      Set CausalHash ->
+      CausalHash
   }

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -2226,9 +2226,9 @@ termNamesForRefWithinNamespace bhId namespaceRoot ref maySuffix = do
           [sql|
         $transitive_dependency_mounts
         SELECT (reversed_name || reversed_mount_path) AS reversed_name
-          FROM all_in_scope_roots
+          FROM transitive_dependency_mounts
             INNER JOIN scoped_term_name_lookup
-            ON scoped_term_name_lookup.root_branch_hash_id = all_in_scope_roots.root_branch_hash_id
+            ON scoped_term_name_lookup.root_branch_hash_id = transitive_dependency_mounts.root_branch_hash_id
         WHERE referent_builtin IS @ref AND referent_component_hash IS @ AND referent_component_index IS @ AND referent_constructor_index IS @
               AND reversed_name GLOB :suffixGlob
         LIMIT 1

--- a/codebase2/codebase-sqlite/sql/009-add-squash-cache-table.sql
+++ b/codebase2/codebase-sqlite/sql/009-add-squash-cache-table.sql
@@ -3,7 +3,7 @@
 CREATE TABLE "squash_results" (
   -- The branch hash of the namespace to be squashed.
   -- There should only ever be one result for each unsquashed value hash.
-  branch_hash_id INTEGER PRIMARY KEY NOT NULL REFERENCES causal(value_hash_id),
+  branch_hash_id INTEGER PRIMARY KEY NOT NULL REFERENCES hash(id),
 
   -- The causal hash id which is the result of squashing the 'branch_hash_id's causal.'
   squashed_causal_hash_id INTEGER NOT NULL REFERENCES causal(self_hash_id)

--- a/codebase2/codebase-sqlite/sql/009-add-squash-cache-table.sql
+++ b/codebase2/codebase-sqlite/sql/009-add-squash-cache-table.sql
@@ -1,0 +1,10 @@
+-- A table for tracking the results of squashes we've performed.
+-- This is used to avoid re-squashing the same branch multiple times.
+CREATE TABLE "squash_results" (
+  -- The branch hash of the namespace to be squashed.
+  -- There should only ever be one result for each unsquashed value hash.
+  branch_hash_id INTEGER PRIMARY KEY NOT NULL REFERENCES causal(value_hash_id),
+
+  -- The causal hash id which is the result of squashing the 'branch_hash_id's causal.'
+  squashed_causal_hash_id INTEGER NOT NULL REFERENCES causal(self_hash_id),
+) WITHOUT ROWID;

--- a/codebase2/codebase-sqlite/sql/009-add-squash-cache-table.sql
+++ b/codebase2/codebase-sqlite/sql/009-add-squash-cache-table.sql
@@ -6,5 +6,5 @@ CREATE TABLE "squash_results" (
   branch_hash_id INTEGER PRIMARY KEY NOT NULL REFERENCES causal(value_hash_id),
 
   -- The causal hash id which is the result of squashing the 'branch_hash_id's causal.'
-  squashed_causal_hash_id INTEGER NOT NULL REFERENCES causal(self_hash_id),
+  squashed_causal_hash_id INTEGER NOT NULL REFERENCES causal(self_hash_id)
 ) WITHOUT ROWID;

--- a/codebase2/codebase-sqlite/unison-codebase-sqlite.cabal
+++ b/codebase2/codebase-sqlite/unison-codebase-sqlite.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.1.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -28,6 +28,7 @@ source-repository head
 library
   exposed-modules:
       U.Codebase.Branch
+      U.Codebase.Causal.Squash
       U.Codebase.Sqlite.Branch.Diff
       U.Codebase.Sqlite.Branch.Format
       U.Codebase.Sqlite.Branch.Full

--- a/codebase2/codebase-sqlite/unison-codebase-sqlite.cabal
+++ b/codebase2/codebase-sqlite/unison-codebase-sqlite.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -18,6 +18,7 @@ extra-source-files:
     sql/006-most-recent-branch-table.sql
     sql/007-add-name-lookup-mounts.sql
     sql/008-add-most-recent-namespace-table.sql
+    sql/009-add-squash-cache-table.sql
     sql/create.sql
 
 source-repository head

--- a/parser-typechecker/src/U/Codebase/Causal/Squash.hs
+++ b/parser-typechecker/src/U/Codebase/Causal/Squash.hs
@@ -1,24 +1,13 @@
 module U.Codebase.Causal.Squash (squashCausal) where
 
-import Data.Set
-import Data.Set qualified as Set
 import U.Codebase.Branch.Hashing qualified as Branch
 import U.Codebase.Branch.Type
 import U.Codebase.Causal (Causal (..))
-import U.Codebase.HashTags (BranchHash (..), CausalHash (..))
+import U.Codebase.Causal.Hashing (hashCausal)
 import U.Codebase.Sqlite.Operations qualified as SqliteOps
 import U.Codebase.Sqlite.V2.HashHandle (v2HashHandle)
-import Unison.Hashing.V2 qualified as Hashing
 import Unison.Prelude
 import Unison.Sqlite qualified as Sqlite
-
-hashCausal :: Set CausalHash -> BranchHash -> CausalHash
-hashCausal ancestors branchHash =
-  CausalHash . Hashing.contentHash $
-    Hashing.Causal
-      { Hashing.branchHash = unBranchHash branchHash,
-        Hashing.parents = Set.map unCausalHash ancestors
-      }
 
 -- Recursively discards history, resulting in a namespace tree with only single a single
 -- Causal node at every level.

--- a/parser-typechecker/src/U/Codebase/Causal/Squash.hs
+++ b/parser-typechecker/src/U/Codebase/Causal/Squash.hs
@@ -1,0 +1,44 @@
+module U.Codebase.Causal.Squash (squashCausal) where
+
+import Data.Set
+import Data.Set qualified as Set
+import U.Codebase.Branch.Hashing qualified as Branch
+import U.Codebase.Branch.Type
+import U.Codebase.Causal (Causal (..))
+import U.Codebase.HashTags (BranchHash (..), CausalHash (..))
+import U.Codebase.Sqlite.Operations qualified as SqliteOps
+import U.Codebase.Sqlite.V2.HashHandle (v2HashHandle)
+import Unison.Hashing.V2 qualified as Hashing
+import Unison.Prelude
+import Unison.Sqlite qualified as Sqlite
+
+hashCausal :: Set CausalHash -> BranchHash -> CausalHash
+hashCausal ancestors branchHash =
+  CausalHash . Hashing.contentHash $
+    Hashing.Causal
+      { Hashing.branchHash = unBranchHash branchHash,
+        Hashing.parents = Set.map unCausalHash ancestors
+      }
+
+-- Recursively discards history, resulting in a namespace tree with only single a single
+-- Causal node at every level.
+squashCausal :: CausalBranch Sqlite.Transaction -> Sqlite.Transaction (CausalBranch Sqlite.Transaction)
+squashCausal Causal {valueHash = unsquashedBranchHash, value} = do
+  runMaybeT (MaybeT (SqliteOps.tryGetSquashResult unsquashedBranchHash) >>= MaybeT . SqliteOps.loadCausalBranchByCausalHash) >>= \case
+    Just cb -> pure cb
+    Nothing -> do
+      branch@Branch {children} <- value
+      squashedChildren <- traverse squashCausal children
+      let squashedBranchHead = branch {children = squashedChildren}
+      squashedBranchHash <- Branch.hashBranch squashedBranchHead
+      let squashedCausalHash = hashCausal mempty squashedBranchHash
+      let squashedCausalBranch =
+            Causal
+              { causalHash = squashedCausalHash,
+                valueHash = squashedBranchHash,
+                parents = mempty,
+                value = pure squashedBranchHead
+              }
+      SqliteOps.saveBranch v2HashHandle squashedCausalBranch
+      SqliteOps.saveSquashResult unsquashedBranchHash squashedCausalHash
+      pure squashedCausalBranch

--- a/parser-typechecker/src/U/Codebase/Causal/Squash.hs
+++ b/parser-typechecker/src/U/Codebase/Causal/Squash.hs
@@ -3,6 +3,7 @@ module U.Codebase.Causal.Squash (squashCausal) where
 import U.Codebase.Branch.Hashing qualified as Branch
 import U.Codebase.Branch.Type
 import U.Codebase.Causal (Causal (..))
+import U.Codebase.Causal.Hashing (hashCausal)
 import U.Codebase.Sqlite.Operations qualified as SqliteOps
 import U.Codebase.Sqlite.V2.HashHandle (v2HashHandle)
 import Unison.Prelude

--- a/parser-typechecker/src/U/Codebase/Causal/Squash.hs
+++ b/parser-typechecker/src/U/Codebase/Causal/Squash.hs
@@ -3,7 +3,6 @@ module U.Codebase.Causal.Squash (squashCausal) where
 import U.Codebase.Branch.Hashing qualified as Branch
 import U.Codebase.Branch.Type
 import U.Codebase.Causal (Causal (..))
-import U.Codebase.Causal.Hashing (hashCausal)
 import U.Codebase.Sqlite.Operations qualified as SqliteOps
 import U.Codebase.Sqlite.V2.HashHandle (v2HashHandle)
 import Unison.Prelude

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
@@ -78,7 +78,8 @@ migrations getDeclType termBuffer declBuffer rootCodebasePath =
       sqlMigration 10 Q.addProjectTables,
       sqlMigration 11 Q.addMostRecentBranchTable,
       (12, migrateSchema11To12),
-      sqlMigration 13 Q.addMostRecentNamespaceTable
+      sqlMigration 13 Q.addMostRecentNamespaceTable,
+      sqlMigration 14 Q.addSquashResultTable
     ]
   where
     sqlMigration :: SchemaVersion -> Sqlite.Transaction () -> (SchemaVersion, Sqlite.Transaction ())

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -28,6 +28,7 @@ flag optimized
 library
   exposed-modules:
       U.Codebase.Branch.Diff
+      U.Codebase.Causal.Squash
       U.Codebase.Projects
       Unison.Builtin
       Unison.Builtin.Decls

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.1.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -28,7 +28,6 @@ flag optimized
 library
   exposed-modules:
       U.Codebase.Branch.Diff
-      U.Codebase.Causal.Squash
       U.Codebase.Projects
       Unison.Builtin
       Unison.Builtin.Decls


### PR DESCRIPTION
## Overview

Depends on https://github.com/unisonweb/unison/pull/4104

Squashing releases on share is far too slow and uses a ton of CPU and memory.
Currently it's just using the V1 branch `discardHistory` combinator which loads the whole branch and crawls through it discarding history and rehashing on every child going up the spine.

This is particularly bad on Share because we won't have the branch loaded into memory already, and when considering transitive dependencies the number of branches we need to squash goes up exponentially.

This PR introduces a new approach which uses the V2 branch types, and uses a 'squash result' table in SQLite to keep track of branches we've previously squashed and just re-uses the previous result.

I ran a squash test on nimbus's main branch to see how the new version compares to the old:

* using `discardHistory` on V1 branches:
  * Initial run: 51.7s
  * Subsequent run 53s (no change expected)
* using V2 squash Causal:
  * Initial run (with a completely empty results table): 5.8s
  * Subsequent run (with the results table populated): 0.1s 

Both got the same results of course 👍🏼 

Note: This alone doesn't speed up any UCM commands, since the only way you can currently squash in UCM is using `squash.merge`, which does a merge at the same time. I think we'd need to implement a V2 merge in order to use this squashing work efficiently there.

## Implementation notes

* Add Migration to schema 14 which adds the squash_results table, which is a simple mapping from a source `branch_hash_id` to the squashed `causal_id`.
* Implements `squashCausal` using V2 causal and branch types, and uses the squash_results table for memoization.

We'd chatted about adding each subtree to the squash cache as a separate transaciton so that if interrupted it can carry on where it left off, but that makes it much tougher to use (since you need to pass around a `(Transaction a -> IO a)`  as an argument and run it in IO rather than a `Transaction`.

It's do-able of course, but given that we've sped it up by an order of magnitude even with a completely empty cache I think we'll probably be okay without that change. We can revisit later if necessary.

## Interesting/controversial decisions

I chose to key the squash results table as `unsquashed_branch_hash_id -> squashed_causal_hash_id`, but one could have alternatively done `unsquashed_causal_hash_id -> squashed_causal_hash_id`.

I chose to use the branch hash because:
* It's the closest to a 'content hash' we have, and since the history of a branch doesn't affect the squashed result it seems most fitting.
* The table will be slightly smaller using `branch_hash` than if we use `causal_hash`, without losing any information. (i.e. if we need the other mapping we can get it with a simple join).
* It's what we already use as a key for name-lookups

## Test coverage

I ran a full re-hash migration on all branches and causals in #4104 ;
I tested the squash locally on nimbus and got the same result as the v1 version.

## Loose ends

-  Need to integrate this into release publishing on Share after merging.