### PR TITLE
download latest version of base on project.create

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -75,6 +75,7 @@ module U.Codebase.Sqlite.Queries
     -- ** causal table
     saveCausal,
     isCausalHash,
+    causalExistsByHash32,
     expectCausal,
     loadCausalHashIdByCausalHash,
     expectCausalHashIdByCausalHash,
@@ -1212,6 +1213,19 @@ isCausalHash hash =
         SELECT 1
         FROM causal
         WHERE self_hash_id = :hash
+      )
+    |]
+
+-- | Return whether or not a causal exists with the given hash32.
+causalExistsByHash32 :: Hash32 -> Transaction Bool
+causalExistsByHash32 hash =
+  queryOneCol
+    [sql|
+      SELECT EXISTS (
+        SELECT 1
+        FROM causal
+        JOIN hash ON causal.self_hash_id = hash.id
+        WHERE hash.base32 = :hash
       )
     |]
 

--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -189,6 +189,7 @@ default-extensions:
   - InstanceSigs
   - LambdaCase
   - MultiParamTypeClasses
+  - MultiWayIf
   - NamedFieldPuns
   - NumericUnderscores
   - OverloadedLabels

--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -57,6 +57,7 @@ dependencies:
   - pretty-simple
   - process
   - random >= 1.2.0
+  - random-shuffle
   - recover-rtti
   - regex-tdfa
   - semialign

--- a/unison-cli/src/Unison/Cli/ServantClientUtils.hs
+++ b/unison-cli/src/Unison/Cli/ServantClientUtils.hs
@@ -1,0 +1,35 @@
+-- | servant-client utilities
+module Unison.Cli.ServantClientUtils
+  ( ConnectionError (..),
+    classifyConnectionError,
+  )
+where
+
+import Control.Exception (fromException)
+import Network.HTTP.Client qualified as HttpClient
+import System.IO.Error (isDoesNotExistError)
+import Unison.Prelude
+
+data ConnectionError
+  = ConnectionError'Offline
+  | ConnectionError'SomethingElse HttpClient.HttpExceptionContent
+  | ConnectionError'SomethingEntirelyUnexpected SomeException
+
+-- | Given a 'SomeException' from a @servant-client@ 'ClientError', attempt to classify what happened.
+classifyConnectionError :: SomeException -> ConnectionError
+classifyConnectionError exception0 =
+  case fromException exception0 of
+    Just (HttpClient.HttpExceptionRequest _request content) ->
+      fromMaybe (ConnectionError'SomethingElse content) do
+        case content of
+          HttpClient.ConnectionFailure exception1 -> do
+            ioException <- fromException @IOException exception1
+            if
+                | -- This may not be 100% accurate... but if the initial `getAddrInfo` request fails it will indeed throw
+                  -- a "does not exist" error. It seems in order to *know* that `getAddrInfo` was the cause of this
+                  -- exception, we'd have to parse the `show` output, which is preposterous.
+                  isDoesNotExistError ioException ->
+                    Just ConnectionError'Offline
+                | otherwise -> Nothing
+          _ -> Nothing
+    _ -> ConnectionError'SomethingEntirelyUnexpected exception0

--- a/unison-cli/src/Unison/Cli/Share/Projects/Types.hs
+++ b/unison-cli/src/Unison/Cli/Share/Projects/Types.hs
@@ -9,13 +9,14 @@ where
 
 import U.Codebase.Sqlite.DbId (RemoteProjectBranchId (..), RemoteProjectId (..))
 import Unison.Prelude
-import Unison.Project (ProjectBranchName, ProjectName)
+import Unison.Project (ProjectBranchName, ProjectName, Semver)
 import Unison.Share.API.Hash qualified as Share.API
 
 -- | A remote project.
 data RemoteProject = RemoteProject
   { projectId :: RemoteProjectId,
-    projectName :: ProjectName
+    projectName :: ProjectName,
+    latestRelease :: Maybe Semver
   }
   deriving stock (Eq, Generic, Show)
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1472,7 +1472,7 @@ loop e = do
               handleDiffNamespaceToPatch description diffNamespaceToPatchInput
             ProjectRenameI name -> handleProjectRename name
             ProjectSwitchI name -> projectSwitch name
-            ProjectCreateI name -> projectCreate name
+            ProjectCreateI tryDownloadingBase name -> projectCreate tryDownloadingBase name
             ProjectsI -> handleProjects
             BranchI source name -> handleBranch source name
             BranchRenameI name -> handleBranchRename name

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1637,7 +1637,6 @@ inputDescription input =
       branchId2 <- hp' (input ^. #branchId2)
       patch <- ps' (input ^. #patch)
       pure (Text.unwords ["diff.namespace.to-patch", branchId1, branchId2, patch])
-    ProjectCreateI project -> pure ("project.create " <> into @Text project)
     ClearI {} -> pure "clear"
     DocToMarkdownI name -> pure ("debug.doc-to-markdown " <> Name.toText name)
     --
@@ -1678,6 +1677,7 @@ inputDescription input =
     PreviewAddI {} -> wat
     PreviewMergeLocalBranchI {} -> wat
     PreviewUpdateI {} -> wat
+    ProjectCreateI {} -> wat
     ProjectRenameI {} -> wat
     ProjectSwitchI {} -> wat
     ProjectsI -> wat

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectCreate.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectCreate.hs
@@ -111,8 +111,58 @@ generateRandomProjectNames :: IO [ProjectName]
 generateRandomProjectNames = do
   baseNames <-
     RandomShuffle.shuffleM do
-      adjective <- ["happy", "silly"]
-      noun <- ["giraffe", "gorilla"]
+      adjective <-
+        [ "adorable",
+          "beautiful",
+          "charming",
+          "delightful",
+          "excited",
+          "friendly",
+          "gentle",
+          "helpful",
+          "innocent",
+          "jolly",
+          "kind",
+          "lucky",
+          "magnificent",
+          "nice",
+          "outstanding",
+          "pleasant",
+          "quiet",
+          "responsible",
+          "silly",
+          "thoughtful",
+          "useful",
+          "witty"
+          ]
+      noun <-
+        [ "alpaca",
+          "blobfish",
+          "camel",
+          "donkey",
+          "earwig",
+          "ferret",
+          "gerbil",
+          "hamster",
+          "ibis",
+          "jaguar",
+          "koala",
+          "lemur",
+          "marmot",
+          "narwhal",
+          "ostrich",
+          "puffin",
+          "quahog",
+          "reindeer",
+          "seahorse",
+          "turkey",
+          "urchin",
+          "vole",
+          "walrus",
+          "yak",
+          "zebra"
+          ]
+
       pure (adjective <> "-" <> noun)
 
   let namesWithNumbers = do

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -226,7 +226,7 @@ data Input
   | AuthLoginI
   | VersionI
   | DiffNamespaceToPatchI DiffNamespaceToPatchInput
-  | ProjectCreateI ProjectName
+  | ProjectCreateI (Maybe ProjectName)
   | ProjectRenameI ProjectName
   | ProjectSwitchI ProjectAndBranchNames
   | ProjectsI

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -226,7 +226,7 @@ data Input
   | AuthLoginI
   | VersionI
   | DiffNamespaceToPatchI DiffNamespaceToPatchInput
-  | ProjectCreateI (Maybe ProjectName)
+  | ProjectCreateI Bool {- try downloading base? -} (Maybe ProjectName)
   | ProjectRenameI ProjectName
   | ProjectSwitchI ProjectAndBranchNames
   | ProjectsI

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -324,7 +324,7 @@ data Output
   | DisplayDebugCompletions [Completion.Completion]
   | ClearScreen
   | PulledEmptyBranch (ReadRemoteNamespace Share.RemoteProjectBranch)
-  | CreatedProject ProjectName ProjectBranchName
+  | CreatedProject Bool {- randomly-generated name? -} ProjectName
   | CreatedProjectBranch CreatedProjectBranchFrom (ProjectAndBranch ProjectName ProjectBranchName)
   | CreatedRemoteProject URI (ProjectAndBranch ProjectName ProjectBranchName)
   | CreatedRemoteProjectBranch URI (ProjectAndBranch ProjectName ProjectBranchName)

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -374,6 +374,7 @@ data Output
   | RenamedProjectBranch ProjectName ProjectBranchName ProjectBranchName
   | CantRenameBranchTo ProjectBranchName
   | FetchingLatestReleaseOfBase
+  | FailedToFetchLatestReleaseOfBase
   | HappyCoding
 
 -- | What did we create a project branch from?
@@ -591,6 +592,7 @@ isFailure o = case o of
   RenamedProjectBranch {} -> False
   CantRenameBranchTo {} -> True
   FetchingLatestReleaseOfBase {} -> False
+  FailedToFetchLatestReleaseOfBase {} -> True
   HappyCoding {} -> False
 
 isNumberedFailure :: NumberedOutput -> Bool

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -373,6 +373,8 @@ data Output
   | RenamedProject ProjectName ProjectName
   | RenamedProjectBranch ProjectName ProjectBranchName ProjectBranchName
   | CantRenameBranchTo ProjectBranchName
+  | FetchingLatestReleaseOfBase
+  | HappyCoding
 
 -- | What did we create a project branch from?
 --
@@ -588,6 +590,8 @@ isFailure o = case o of
   RenamedProject {} -> False
   RenamedProjectBranch {} -> False
   CantRenameBranchTo {} -> True
+  FetchingLatestReleaseOfBase {} -> False
+  HappyCoding {} -> False
 
 isNumberedFailure :: NumberedOutput -> Bool
 isNumberedFailure = \case

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2431,17 +2431,18 @@ projectCreate =
     { patternName = "project.create",
       aliases = ["create.project"],
       visibility = I.Hidden,
-      argTypes = [(Required, projectNameArg)],
+      argTypes = [],
       help =
         P.wrapColumn2
-          [ ("`project.create foo`", "creates the project foo and switches you to foo/main")
+          [ ("`project.create`", "creates a project with a random name"),
+            ("`project.create foo`", "creates a project named `foo`")
           ],
       parse = \case
         [name] ->
           case tryInto @ProjectName (Text.pack name) of
             Left _ -> Left "Invalid project name."
-            Right name1 -> Right (Input.ProjectCreateI name1)
-        _ -> Left (showPatternHelp projectCreate)
+            Right name1 -> Right (Input.ProjectCreateI (Just name1))
+        _ -> Right (Input.ProjectCreateI Nothing)
     }
 
 projectRenameInputPattern :: InputPattern

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2441,8 +2441,28 @@ projectCreate =
         [name] ->
           case tryInto @ProjectName (Text.pack name) of
             Left _ -> Left "Invalid project name."
-            Right name1 -> Right (Input.ProjectCreateI (Just name1))
-        _ -> Right (Input.ProjectCreateI Nothing)
+            Right name1 -> Right (Input.ProjectCreateI True (Just name1))
+        _ -> Right (Input.ProjectCreateI True Nothing)
+    }
+
+projectCreateEmptyInputPattern :: InputPattern
+projectCreateEmptyInputPattern =
+  InputPattern
+    { patternName = "project.create-empty",
+      aliases = ["create.empty-project"],
+      visibility = I.Hidden,
+      argTypes = [],
+      help =
+        P.wrapColumn2
+          [ ("`project.create-empty`", "creates an empty project with a random name"),
+            ("`project.create-empty foo`", "creates an empty project named `foo`")
+          ],
+      parse = \case
+        [name] ->
+          case tryInto @ProjectName (Text.pack name) of
+            Left _ -> Left "Invalid project name."
+            Right name1 -> Right (Input.ProjectCreateI False (Just name1))
+        _ -> Right (Input.ProjectCreateI False Nothing)
     }
 
 projectRenameInputPattern :: InputPattern
@@ -2711,6 +2731,7 @@ validInputs =
       previewUpdate,
       printVersion,
       projectCreate,
+      projectCreateEmptyInputPattern,
       projectRenameInputPattern,
       projectSwitch,
       projectsInputPattern,

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1796,15 +1796,19 @@ notifyUser dir = \case
   PulledEmptyBranch remote ->
     pure . P.warnCallout . P.wrap $
       P.group (prettyReadRemoteNamespace remote) <> "has some history, but is currently empty."
-  CreatedProject projectName branchName ->
+  CreatedProject nameWasRandomlyGenerated projectName ->
     pure $
-      P.wrap
-        ( "I just created project"
-            <> prettyProjectName projectName
-            <> "with branch"
-            <> prettyProjectBranchName branchName
-        )
-        <> "."
+      if nameWasRandomlyGenerated
+        then
+          P.wrap $
+            "🎉 I've created the project with the randomly-chosen name"
+              <> prettyProjectName projectName
+              <> "(use"
+              <> IP.makeExample IP.projectRenameInputPattern ["<new-name>"]
+              <> "to change it)."
+        else
+          P.wrap $
+            "🎉 I've created the project" <> P.group (prettyProjectName projectName <> ".")
   CreatedProjectBranch from projectAndBranch ->
     case from of
       CreatedProjectBranchFrom'LooseCode path ->

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2102,6 +2102,8 @@ notifyUser dir = \case
   FetchingLatestReleaseOfBase ->
     pure . P.wrap $
       "I'll now fetch the latest version of the base Unison library..."
+  FailedToFetchLatestReleaseOfBase ->
+    pure . P.wrap $ "Sorry something went wrong while fetching the library."
   HappyCoding ->
     pure $
       P.wrap "🎨 Type `ui` to explore this project's code in your browser."

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -190,6 +190,7 @@ library
     , pretty-simple
     , process
     , random >=1.2.0
+    , random-shuffle
     , recover-rtti
     , regex-tdfa
     , semialign
@@ -322,6 +323,7 @@ executable cli-integration-tests
     , pretty-simple
     , process
     , random >=1.2.0
+    , random-shuffle
     , recover-rtti
     , regex-tdfa
     , semialign
@@ -448,6 +450,7 @@ executable transcripts
     , pretty-simple
     , process
     , random >=1.2.0
+    , random-shuffle
     , recover-rtti
     , regex-tdfa
     , semialign
@@ -580,6 +583,7 @@ executable unison
     , pretty-simple
     , process
     , random >=1.2.0
+    , random-shuffle
     , recover-rtti
     , regex-tdfa
     , semialign
@@ -718,6 +722,7 @@ test-suite cli-tests
     , pretty-simple
     , process
     , random >=1.2.0
+    , random-shuffle
     , recover-rtti
     , regex-tdfa
     , semialign

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -37,6 +37,7 @@ library
       Unison.Cli.Pretty
       Unison.Cli.PrettyPrintUtils
       Unison.Cli.ProjectUtils
+      Unison.Cli.ServantClientUtils
       Unison.Cli.Share.Projects
       Unison.Cli.Share.Projects.Types
       Unison.Cli.TypeCheck
@@ -132,6 +133,7 @@ library
       InstanceSigs
       LambdaCase
       MultiParamTypeClasses
+      MultiWayIf
       NamedFieldPuns
       NumericUnderscores
       OverloadedLabels
@@ -261,6 +263,7 @@ executable cli-integration-tests
       InstanceSigs
       LambdaCase
       MultiParamTypeClasses
+      MultiWayIf
       NamedFieldPuns
       NumericUnderscores
       OverloadedLabels
@@ -390,6 +393,7 @@ executable transcripts
       InstanceSigs
       LambdaCase
       MultiParamTypeClasses
+      MultiWayIf
       NamedFieldPuns
       NumericUnderscores
       OverloadedLabels
@@ -523,6 +527,7 @@ executable unison
       InstanceSigs
       LambdaCase
       MultiParamTypeClasses
+      MultiWayIf
       NamedFieldPuns
       NumericUnderscores
       OverloadedLabels
@@ -662,6 +667,7 @@ test-suite cli-tests
       InstanceSigs
       LambdaCase
       MultiParamTypeClasses
+      MultiWayIf
       NamedFieldPuns
       NumericUnderscores
       OverloadedLabels

--- a/unison-src/transcripts/branch-command.md
+++ b/unison-src/transcripts/branch-command.md
@@ -2,8 +2,8 @@ The `branch` command creates a new branch.
 
 ```ucm:hide
 .> builtins.merge
-.> project.create foo
-.> project.create bar
+.> project.create-empty foo
+.> project.create-empty bar
 ```
 
 First, we'll just create a loose code namespace with a term in it for later.

--- a/unison-src/transcripts/delete-project-branch.md
+++ b/unison-src/transcripts/delete-project-branch.md
@@ -2,7 +2,7 @@ Deleting the branch you are on takes you to its parent (though this is impossibl
 your working directory with each command).
 
 ```ucm
-.> project.create foo
+.> project.create-empty foo
 foo/main> branch topic
 foo/topic> delete.branch /topic
 ```

--- a/unison-src/transcripts/delete-project-branch.output.md
+++ b/unison-src/transcripts/delete-project-branch.output.md
@@ -4,7 +4,7 @@ your working directory with each command).
 ```ucm
 .> project.create foo
 
-  I just created project foo with branch main.
+  🎉 I've created the project foo.
 
 foo/main> branch topic
 

--- a/unison-src/transcripts/delete-project-branch.output.md
+++ b/unison-src/transcripts/delete-project-branch.output.md
@@ -2,9 +2,21 @@ Deleting the branch you are on takes you to its parent (though this is impossibl
 your working directory with each command).
 
 ```ucm
-.> project.create foo
+.> project.create-empty foo
 
   🎉 I've created the project foo.
+
+  🎨 Type `ui` to explore this project's code in your browser.
+  🌏 Discover libraries at https://share.unison-lang.org
+  📖 Use `help-topic projects` to learn more about projects.
+  
+  Write your first Unison code with UCM:
+  
+    1. Open scratch.u.
+    2. Write some Unison code and save the file.
+    3. In UCM, type `add` to save it to your new project.
+  
+  🎉 🥳 Happy coding!
 
 foo/main> branch topic
 

--- a/unison-src/transcripts/delete-project.md
+++ b/unison-src/transcripts/delete-project.md
@@ -1,8 +1,8 @@
 # delete.project
 
 ```ucm
-.> project.create foo
-.> project.create bar
+.> project.create-empty foo
+.> project.create-empty bar
 .> projects
 foo/main> delete.project foo
 .> projects

--- a/unison-src/transcripts/delete-project.output.md
+++ b/unison-src/transcripts/delete-project.output.md
@@ -3,13 +3,13 @@
 ```ucm
 .> project.create foo
 
-  I just created project foo with branch main.
+  🎉 I've created the project foo.
 
   ☝️  The namespace . is empty.
 
 .> project.create bar
 
-  I just created project bar with branch main.
+  🎉 I've created the project bar.
 
   ☝️  The namespace . is empty.
 

--- a/unison-src/transcripts/delete-project.output.md
+++ b/unison-src/transcripts/delete-project.output.md
@@ -1,15 +1,39 @@
 # delete.project
 
 ```ucm
-.> project.create foo
+.> project.create-empty foo
 
   🎉 I've created the project foo.
 
+  🎨 Type `ui` to explore this project's code in your browser.
+  🌏 Discover libraries at https://share.unison-lang.org
+  📖 Use `help-topic projects` to learn more about projects.
+  
+  Write your first Unison code with UCM:
+  
+    1. Open scratch.u.
+    2. Write some Unison code and save the file.
+    3. In UCM, type `add` to save it to your new project.
+  
+  🎉 🥳 Happy coding!
+
   ☝️  The namespace . is empty.
 
-.> project.create bar
+.> project.create-empty bar
 
   🎉 I've created the project bar.
+
+  🎨 Type `ui` to explore this project's code in your browser.
+  🌏 Discover libraries at https://share.unison-lang.org
+  📖 Use `help-topic projects` to learn more about projects.
+  
+  Write your first Unison code with UCM:
+  
+    1. Open scratch.u.
+    2. Write some Unison code and save the file.
+    3. In UCM, type `add` to save it to your new project.
+  
+  🎉 🥳 Happy coding!
 
   ☝️  The namespace . is empty.
 

--- a/unison-src/transcripts/project-merge.md
+++ b/unison-src/transcripts/project-merge.md
@@ -10,7 +10,7 @@ zonk = 0
 
 ```ucm
 .foo> add
-.> project.create foo
+.> project.create-empty foo
 .> merge foo foo/main
 ```
 
@@ -23,7 +23,7 @@ foo/main> add
 ```
 
 ```ucm
-.> project.create bar
+.> project.create-empty bar
 bar/main> merge foo/main
 bar/main> branch /topic
 ```

--- a/unison-src/transcripts/project-merge.output.md
+++ b/unison-src/transcripts/project-merge.output.md
@@ -32,7 +32,7 @@ zonk = 0
 
 .> project.create foo
 
-  I just created project foo with branch main.
+  🎉 I've created the project foo.
 
 .> merge foo foo/main
 
@@ -76,7 +76,7 @@ foo/main> add
 ```ucm
 .> project.create bar
 
-  I just created project bar with branch main.
+  🎉 I've created the project bar.
 
 bar/main> merge foo/main
 

--- a/unison-src/transcripts/project-merge.output.md
+++ b/unison-src/transcripts/project-merge.output.md
@@ -30,9 +30,21 @@ zonk = 0
   
     zonk : Nat
 
-.> project.create foo
+.> project.create-empty foo
 
   🎉 I've created the project foo.
+
+  🎨 Type `ui` to explore this project's code in your browser.
+  🌏 Discover libraries at https://share.unison-lang.org
+  📖 Use `help-topic projects` to learn more about projects.
+  
+  Write your first Unison code with UCM:
+  
+    1. Open scratch.u.
+    2. Write some Unison code and save the file.
+    3. In UCM, type `add` to save it to your new project.
+  
+  🎉 🥳 Happy coding!
 
 .> merge foo foo/main
 
@@ -74,9 +86,21 @@ foo/main> add
 
 ```
 ```ucm
-.> project.create bar
+.> project.create-empty bar
 
   🎉 I've created the project bar.
+
+  🎨 Type `ui` to explore this project's code in your browser.
+  🌏 Discover libraries at https://share.unison-lang.org
+  📖 Use `help-topic projects` to learn more about projects.
+  
+  Write your first Unison code with UCM:
+  
+    1. Open scratch.u.
+    2. Write some Unison code and save the file.
+    3. In UCM, type `add` to save it to your new project.
+  
+  🎉 🥳 Happy coding!
 
 bar/main> merge foo/main
 

--- a/unison-src/transcripts/release-draft-command.md
+++ b/unison-src/transcripts/release-draft-command.md
@@ -11,7 +11,7 @@ someterm = 18
 ```
 
 ```ucm
-.> project.create foo
+.> project.create-empty foo
 foo/main> add
 ```
 

--- a/unison-src/transcripts/release-draft-command.output.md
+++ b/unison-src/transcripts/release-draft-command.output.md
@@ -20,7 +20,7 @@ someterm = 18
 ```ucm
 .> project.create foo
 
-  I just created project foo with branch main.
+  🎉 I've created the project foo.
 
 foo/main> add
 

--- a/unison-src/transcripts/release-draft-command.output.md
+++ b/unison-src/transcripts/release-draft-command.output.md
@@ -18,9 +18,21 @@ someterm = 18
 
 ```
 ```ucm
-.> project.create foo
+.> project.create-empty foo
 
   🎉 I've created the project foo.
+
+  🎨 Type `ui` to explore this project's code in your browser.
+  🌏 Discover libraries at https://share.unison-lang.org
+  📖 Use `help-topic projects` to learn more about projects.
+  
+  Write your first Unison code with UCM:
+  
+    1. Open scratch.u.
+    2. Write some Unison code and save the file.
+    3. In UCM, type `add` to save it to your new project.
+  
+  🎉 🥳 Happy coding!
 
 foo/main> add
 

--- a/unison-src/transcripts/reset.md
+++ b/unison-src/transcripts/reset.md
@@ -29,7 +29,7 @@ foo.a = 5
 # reset branch
 
 ```ucm
-.> project.create foo
+.> project.create-empty foo
 foo/main> history
 ```
 

--- a/unison-src/transcripts/reset.output.md
+++ b/unison-src/transcripts/reset.output.md
@@ -99,9 +99,21 @@ foo.a = 5
 # reset branch
 
 ```ucm
-.> project.create foo
+.> project.create-empty foo
 
   🎉 I've created the project foo.
+
+  🎨 Type `ui` to explore this project's code in your browser.
+  🌏 Discover libraries at https://share.unison-lang.org
+  📖 Use `help-topic projects` to learn more about projects.
+  
+  Write your first Unison code with UCM:
+  
+    1. Open scratch.u.
+    2. Write some Unison code and save the file.
+    3. In UCM, type `add` to save it to your new project.
+  
+  🎉 🥳 Happy coding!
 
 foo/main> history
 

--- a/unison-src/transcripts/reset.output.md
+++ b/unison-src/transcripts/reset.output.md
@@ -101,7 +101,7 @@ foo.a = 5
 ```ucm
 .> project.create foo
 
-  I just created project foo with branch main.
+  🎉 I've created the project foo.
 
 foo/main> history
 

--- a/unison-src/transcripts/switch-command.md
+++ b/unison-src/transcripts/switch-command.md
@@ -11,8 +11,8 @@ someterm = 18
 ```
 
 ```ucm
-.> project.create foo
-.> project.create bar
+.> project.create-empty foo
+.> project.create-empty bar
 foo/main> add
 foo/main> branch bar
 foo/main> branch topic

--- a/unison-src/transcripts/switch-command.output.md
+++ b/unison-src/transcripts/switch-command.output.md
@@ -20,11 +20,11 @@ someterm = 18
 ```ucm
 .> project.create foo
 
-  I just created project foo with branch main.
+  🎉 I've created the project foo.
 
 .> project.create bar
 
-  I just created project bar with branch main.
+  🎉 I've created the project bar.
 
 foo/main> add
 

--- a/unison-src/transcripts/switch-command.output.md
+++ b/unison-src/transcripts/switch-command.output.md
@@ -18,13 +18,37 @@ someterm = 18
 
 ```
 ```ucm
-.> project.create foo
+.> project.create-empty foo
 
   🎉 I've created the project foo.
 
-.> project.create bar
+  🎨 Type `ui` to explore this project's code in your browser.
+  🌏 Discover libraries at https://share.unison-lang.org
+  📖 Use `help-topic projects` to learn more about projects.
+  
+  Write your first Unison code with UCM:
+  
+    1. Open scratch.u.
+    2. Write some Unison code and save the file.
+    3. In UCM, type `add` to save it to your new project.
+  
+  🎉 🥳 Happy coding!
+
+.> project.create-empty bar
 
   🎉 I've created the project bar.
+
+  🎨 Type `ui` to explore this project's code in your browser.
+  🌏 Discover libraries at https://share.unison-lang.org
+  📖 Use `help-topic projects` to learn more about projects.
+  
+  Write your first Unison code with UCM:
+  
+    1. Open scratch.u.
+    2. Write some Unison code and save the file.
+    3. In UCM, type `add` to save it to your new project.
+  
+  🎉 🥳 Happy coding!
 
 foo/main> add
 


### PR DESCRIPTION
## Overview

This PR makes `project.create` download the latest release of `base`, as described in #4083. Although not explicitly stated, I assumed we'd want to go down a similar code path whether or not the user provided a project name to `project.create` - that is, (try to) pull base into `lib.base`, and display a "happy coding!" blurb.

<img width="650" alt="Screen Shot 2023-06-21 at 1 46 21 PM" src="https://github.com/unisonweb/unison/assets/1074598/ba637635-f430-4c65-b5b9-1628b7825aae">

I also added a `project.create-empty` command to replace to old `project.create` that didn't download base. This is necessary to use in transcripts, otherwise we'll get an unstable "num entities downloaded" output message.

A couple additional miscellaneous things accomplished along the way:

- Previously, we'd print `Something went wrong with the connection. Try again?` whenever an unexpected HTTP connection error occurred. Now, we parse it a little bit, and print a different message if it seems the user if offline: `You appear to be offline.`
- The pull logic was tweaked so we no longer print `Downloaded X entities...` unless `X` is at least 1. I did this because otherwise every single `project.create` after the first would show `Downloaded 0 entities.`, which was annoying.

And a loose end:

- Currently, in the case that the user already has the latest release of `base` locally, there is no visible distinction in the output messages to a user in the case that we did or did not successfully pull the latest release of `base` into `lib.base`, such as when the user is offline. In the latter case, the user will simply end up in an empty project without a `lib.base` namespace.

## Test coverage

I've tested this change locally, and there are transcripts that capture the output messages.