### PR TITLE
Pass correct starting path to LSP

### DIFF
--- a/unison-cli/src/Unison/LSP/CodeAction.hs
+++ b/unison-cli/src/Unison/LSP/CodeAction.hs
@@ -18,7 +18,7 @@ import Unison.Prelude
 codeActionHandler :: RequestMessage 'TextDocumentCodeAction -> (Either ResponseError (ResponseResult 'TextDocumentCodeAction) -> Lsp ()) -> Lsp ()
 codeActionHandler m respond =
   respond . maybe (Right mempty) (Right . List . fmap InR) =<< runMaybeT do
-    FileAnalysis {codeActions} <- MaybeT $ getFileAnalysis (m ^. params . textDocument . uri)
+    FileAnalysis {codeActions} <- getFileAnalysis (m ^. params . textDocument . uri)
     let r = m ^. params . range
     let relevantActions = IM.intersecting codeActions (rangeToInterval r)
     Debug.debugM Debug.LSP "All CodeActions" (codeActions)

--- a/unison-cli/src/Unison/LSP/FileAnalysis.hs
+++ b/unison-cli/src/Unison/LSP/FileAnalysis.hs
@@ -36,7 +36,6 @@ import Unison.LSP.Orphans ()
 import Unison.LSP.Types
 import Unison.LSP.Types qualified as LSP
 import Unison.LSP.VFS qualified as VFS
-import Unison.Names (Names)
 import Unison.NamesWithHistory qualified as NamesWithHistory
 import Unison.Parser.Ann (Ann)
 import Unison.Pattern qualified as Pattern
@@ -404,13 +403,13 @@ getFileAnalysis uri = do
 
 getFileSummary :: Uri -> MaybeT Lsp FileSummary
 getFileSummary uri = do
-  FileAnalysis {fileSummary} <- MaybeT $ getFileAnalysis uri
+  FileAnalysis {fileSummary} <- getFileAnalysis uri
   MaybeT . pure $ fileSummary
 
 -- TODO memoize per file
 ppedForFile :: Uri -> Lsp PPED.PrettyPrintEnvDecl
 ppedForFile fileUri = do
-  getFileAnalysis fileUri >>= \case
+  runMaybeT (getFileAnalysis fileUri) >>= \case
     Just (FileAnalysis {typecheckedFile = tf, parsedFile = uf}) ->
       ppedForFileHelper uf tf
     _ -> ppedForFileHelper Nothing Nothing

--- a/unison-cli/src/Unison/LSP/FoldingRange.hs
+++ b/unison-cli/src/Unison/LSP/FoldingRange.hs
@@ -25,7 +25,7 @@ foldingRangesForFile :: Uri -> Lsp [FoldingRange]
 foldingRangesForFile fileUri =
   fromMaybe []
     <$> runMaybeT do
-      FileAnalysis {parsedFile} <- MaybeT $ getFileAnalysis fileUri
+      FileAnalysis {parsedFile} <- getFileAnalysis fileUri
       UnisonFileId {dataDeclarationsId, effectDeclarationsId, terms} <- MaybeT $ pure parsedFile
       let dataFolds = dataDeclarationsId ^.. folded . _2 . to dataDeclSpan
       let abilityFolds = effectDeclarationsId ^.. folded . _2 . to DD.toDataDecl . to dataDeclSpan

--- a/unison-cli/src/Unison/LSP/Types.hs
+++ b/unison-cli/src/Unison/LSP/Types.hs
@@ -82,9 +82,10 @@ data Env = Env
     currentPathCache :: IO Path.Absolute,
     vfsVar :: MVar VFS,
     runtime :: Runtime Symbol,
-    -- The information we have for each file, which may or may not have a valid parse or
-    -- typecheck.
-    checkedFilesVar :: TVar (Map Uri FileAnalysis),
+    -- The information we have for each file.
+    -- The MVar is filled when analysis finishes, and is emptied whenever
+    -- the file has changed (until it's checked again)
+    checkedFilesVar :: TVar (Map Uri (TMVar FileAnalysis)),
     dirtyFilesVar :: TVar (Set Uri),
     -- A map  of request IDs to an action which kills that request.
     cancellationMapVar :: TVar (Map SomeLspId (IO ())),


### PR DESCRIPTION
## Overview

On trunk the LSP starts up thinking it's always in the codebase root, even though ucm might have remembered a previous path and started up there instead. 

This just passes the remembered starting path to the LSP so it starts there instead.

There was also a subtle race condition before where if you run a code-action or get a code hint it might return information from an older file; now we invalidate old results when you make a change and make sure we're always serving results which are up to date with the current state of the file.

## Implementation notes

* Compute the actual starting path before making the TVars for the LSP, and use the computed value as the initial LSP value.
* Switch the File Analysis results to use MVars so that if you ask for a file analysis we can easily get or wait for the results from the most recent file, not just the last one to complete.

## Test coverage

LSP remains tough to test, but I tested it out in comparison with trunk.

closes https://github.com/unisonweb/unison/issues/4125