### PR TITLE
Add numbered args to namespace dependencies

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1357,7 +1357,7 @@ loop e = do
                   externalDependencies <-
                     Cli.runTransaction (NamespaceDependencies.namespaceDependencies codebase (Branch.head b))
                   ppe <- PPE.unsuffixifiedPPE <$> currentPrettyPrintEnvDecl Backend.Within
-                  Cli.respond $ ListNamespaceDependencies ppe path externalDependencies
+                  Cli.respondNumbered $ ListNamespaceDependencies ppe path externalDependencies
             DebugNumberedArgsI -> do
               numArgs <- use #numberedArgs
               Cli.respond (DumpNumberedArgs numArgs)

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -505,11 +505,11 @@ notifyNumbered = \case
         deps
           & Map.elems
           & List.foldl'
-            ( \(nextInt, (nameToNum, args)) names ->
+            ( \(nextNum, (nameToNum, args)) names ->
                 let unnumberedNames = Set.toList $ Set.difference names (Map.keysSet nameToNum)
-                    newNextNum = nextInt + length unnumberedNames
+                    newNextNum = nextNum + length unnumberedNames
                  in ( newNextNum,
-                      ( nameToNum <> (Map.fromList (zip unnumberedNames [newNextNum ..])),
+                      ( nameToNum <> (Map.fromList (zip unnumberedNames [nextNum ..])),
                         args <> fmap Name.toString unnumberedNames
                       )
                     )

--- a/unison-src/transcripts-using-base/namespace-dependencies.output.md
+++ b/unison-src/transcripts-using-base/namespace-dependencies.output.md
@@ -33,16 +33,16 @@ hasMetadata = 3
 .dependencies> namespace.dependencies
 
   External dependency   Dependents in .dependencies
-  builtin.Int           dependsOnInt
+  builtin.Int           1. dependsOnInt
                         
-  builtin.Nat           dependsOnIntAndNat
-                        dependsOnNat
-                        hasMetadata
+  builtin.Nat           2. dependsOnIntAndNat
+                        3. dependsOnNat
+                        4. hasMetadata
                         
-  builtin.Text          hasMetadata
+  builtin.Text          4. hasMetadata
                         
-  builtin.Nat.drop      dependsOnIntAndNat
+  builtin.Nat.drop      2. dependsOnIntAndNat
                         
-  metadata.myMetadata   hasMetadata
+  metadata.myMetadata   4. hasMetadata
 
 ```


### PR DESCRIPTION
## Overview

Requested by @stew , adds numbers to the dependents listed in namespace.dependencies

## Implementation notes

Move the output type to a numbered one;
Repeat dependents just use the same number as the first time they appear to avoid clutter.


## Test coverage

See transcript

## Loose ends

Does the current 'external -> in-namespace' mapping make sense or should we flip-flip it to 'in-namespace -> external'?