### PR TITLE
refactor: add export list to Unison.FileParsers and delete unused type alias

### DIFF
--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -1,7 +1,8 @@
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE UnicodeSyntax #-}
-
-module Unison.FileParsers where
+module Unison.FileParsers
+  ( parseAndSynthesizeFile,
+    synthesizeFile',
+  )
+where
 
 import Control.Lens (view, _3)
 import Control.Monad.State (evalStateT)
@@ -47,8 +48,6 @@ type Term v = Term.Term v Ann
 type Type v = Type.Type v Ann
 
 type UnisonFile v = UF.UnisonFile v Ann
-
-type Result' v = Result (Seq (Note v Ann))
 
 debug :: Bool
 debug = False


### PR DESCRIPTION
## Overview

- Adds export list to `Unison.FileParsers`
- Deletes unused type alias