### PR TITLE
Use a project and versioning for in-unison compiler code on share

### DIFF
--- a/scheme-libs/racket/unison/primops.ss
+++ b/scheme-libs/racket/unison/primops.ss
@@ -36,6 +36,7 @@
     builtin-Int.signum
     builtin-Nat.increment
     builtin-Nat.toFloat
+    builtin-Text.indexOf
 
     unison-FOp-internal.dataTag
     unison-FOp-Char.toText
@@ -350,6 +351,8 @@
                  exn:fail:contract?
                  file-stream-buffer-mode
                  with-handlers
+                 match
+                 regexp-match-positions
                  sequence-ref
                  vector-copy!
                  bytes-copy!)
@@ -357,6 +360,7 @@
           (unison arithmetic)
           (unison bytevector)
           (unison core)
+          (only (unison boot) define-unison)
           (unison data)
           (unison math)
           (unison chunked-seq)
@@ -372,6 +376,16 @@
           (unison gzip)
           (unison zlib)
           (unison concurrent))
+
+  ; NOTE: this is just a temporary stopgap until the real function is
+  ; done. I accidentally pulled in too new a version of base in the
+  ; project version of the unison compiler and it broke the jit tests.
+  (define-unison (builtin-Text.indexOf s t)
+    (let ([ss (chunked-string->string s)]
+          [tt (chunked-string->string t)])
+      (match (regexp-match-positions ss tt)
+        [#f (data 'Optional 1)] ; none
+        [(cons (cons i j) r) (data 'Optional 0 i)]))) ; some
 
   (define (unison-POp-UPKB bs)
     (build-chunked-list

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -138,7 +138,10 @@ import Unison.CommandLine.InputPatterns qualified as InputPatterns
 import Unison.ConstructorReference (GConstructorReference (..))
 import Unison.ConstructorType qualified as ConstructorType
 import Unison.Core.Project
-  (ProjectAndBranch (..), ProjectName (..), ProjectBranchName (..))
+  ( ProjectAndBranch (..),
+    ProjectName (..),
+    ProjectBranchName (..),
+  )
 import Unison.DataDeclaration qualified as DD
 import Unison.Hash qualified as Hash
 import Unison.HashQualified qualified as HQ
@@ -2457,7 +2460,7 @@ doFetchCompiler username branch =
 ensureCompilerExists :: Cli ()
 ensureCompilerExists =
   Cli.branchExistsAtPath' compilerPath
-    >>= flip unless (doFetchCompiler "unison" "0.0.1")
+    >>= flip unless (doFetchCompiler "unison" "releases/0.0.1")
 
 getCacheDir :: Cli String
 getCacheDir = liftIO $ getXdgDirectory XdgCache "unisonlanguage"

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -137,11 +137,7 @@ import Unison.CommandLine.InputPatterns qualified as IP
 import Unison.CommandLine.InputPatterns qualified as InputPatterns
 import Unison.ConstructorReference (GConstructorReference (..))
 import Unison.ConstructorType qualified as ConstructorType
-import Unison.Core.Project
-  ( ProjectAndBranch (..),
-    ProjectBranchName (..),
-    ProjectName (..),
-  )
+import Unison.Core.Project (ProjectAndBranch (..))
 import Unison.DataDeclaration qualified as DD
 import Unison.Hash qualified as Hash
 import Unison.HashQualified qualified as HQ
@@ -219,6 +215,7 @@ import Unison.Var (Var)
 import Unison.Var qualified as Var
 import Unison.WatchKind qualified as WK
 import Web.Browser (openBrowser)
+import Witch (unsafeFrom)
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Main loop
@@ -2449,8 +2446,8 @@ doFetchCompiler username branch =
     -- fetching info
     prj =
       These
-        (UnsafeProjectName $ "@" <> Text.pack username <> "/internal")
-        (UnsafeProjectBranchName $ Text.pack branch)
+        (unsafeFrom $ "@" <> Text.pack username <> "/internal")
+        (unsafeFrom $ Text.pack branch)
 
     sourceTarget =
       PullSourceTarget2

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -144,6 +144,7 @@ import Unison.HashQualified qualified as HQ
 import Unison.HashQualified' qualified as HQ'
 import Unison.HashQualified' qualified as HashQualified
 import Unison.Hashing.V2.Convert qualified as Hashing
+import Unison.JitInfo qualified as JitInfo
 import Unison.LabeledDependency (LabeledDependency)
 import Unison.LabeledDependency qualified as LD
 import Unison.LabeledDependency qualified as LabeledDependency
@@ -2457,7 +2458,7 @@ doFetchCompiler username branch =
 ensureCompilerExists :: Cli ()
 ensureCompilerExists =
   Cli.branchExistsAtPath' compilerPath
-    >>= flip unless (doFetchCompiler "unison" "releases/0.0.1")
+    >>= flip unless (doFetchCompiler "unison" JitInfo.currentRelease)
 
 getCacheDir :: Cli String
 getCacheDir = liftIO $ getXdgDirectory XdgCache "unisonlanguage"

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -139,8 +139,8 @@ import Unison.ConstructorReference (GConstructorReference (..))
 import Unison.ConstructorType qualified as ConstructorType
 import Unison.Core.Project
   ( ProjectAndBranch (..),
-    ProjectName (..),
     ProjectBranchName (..),
+    ProjectName (..),
   )
 import Unison.DataDeclaration qualified as DD
 import Unison.Hash qualified as Hash

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -178,8 +178,8 @@ data Input
     CompileSchemeI String (HQ.HashQualified Name)
   | -- generate scheme libraries
     GenSchemeLibsI
-  | -- fetch scheme compiler from a given username
-    FetchSchemeCompilerI String
+  | -- fetch scheme compiler from a given username and branch
+    FetchSchemeCompilerI String String
   | TestI TestInput
   | -- metadata
     -- `link metadata definitions` (adds metadata to all of `definitions`)

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2341,24 +2341,40 @@ fetchScheme =
     []
     ( P.wrapColumn2
         [ ( makeExample fetchScheme [],
-            "Fetches the unison library for compiling to scheme.\n\n\
-            \This is done automatically when"
-              <> P.group (makeExample compileScheme [])
-              <> "is run\
-                 \ if the library is not already in the standard location\
-                 \ (unison.internal). However, this command will force\
-                 \ a pull even if the library already exists. You can also specify\
-                 \ a username to pull from (the default is `unison`) to use an alternate\
-                 \ implementation of the scheme compiler. It will attempt to fetch\
-                 \ [username].public.internal.trunk for use."
+            P.lines . fmap P.wrap $
+              [ "Fetches the unison library for compiling to scheme.",
+                "This is done automatically when"
+                  <> P.group (makeExample compileScheme [])
+                  <> "is run if the library is not already in the\
+                     \ standard location (unison.internal). However,\
+                     \ this command will force a pull even if the\
+                     \ library already exists.",
+                "You can also specify a user and branch name to pull\
+                \ from in order to use an alternate version of the\
+                \ unison compiler (for development purposes, for\
+                \ example).",
+                "The default user is `unison`. The default branch\
+                \ for the `unison` user is a specified latest\
+                \ version of the compiler for stability. The\
+                \ default branch for other uses is `main`. The\
+                \ command fetches code from a project:",
+                P.indentN 2 ("@user/internal/branch")
+              ]
           )
         ]
     )
     ( \case
-        [] -> pure (Input.FetchSchemeCompilerI "unison")
-        [name] -> pure (Input.FetchSchemeCompilerI name)
+        [] -> pure (Input.FetchSchemeCompilerI "unison" release)
+        [name] -> pure (Input.FetchSchemeCompilerI name branch)
+          where
+          branch
+            | name == "unison" = release
+            | otherwise = "main"
+        [name,branch] -> pure (Input.FetchSchemeCompilerI name branch)
         _ -> Left $ showPatternHelp fetchScheme
     )
+    where
+      release = "releases/0.0.1"
 
 createAuthor :: InputPattern
 createAuthor =

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2367,14 +2367,14 @@ fetchScheme =
         [] -> pure (Input.FetchSchemeCompilerI "unison" release)
         [name] -> pure (Input.FetchSchemeCompilerI name branch)
           where
-          branch
-            | name == "unison" = release
-            | otherwise = "main"
-        [name,branch] -> pure (Input.FetchSchemeCompilerI name branch)
+            branch
+              | name == "unison" = release
+              | otherwise = "main"
+        [name, branch] -> pure (Input.FetchSchemeCompilerI name branch)
         _ -> Left $ showPatternHelp fetchScheme
     )
-    where
-      release = "releases/0.0.1"
+  where
+    release = "releases/0.0.1"
 
 createAuthor :: InputPattern
 createAuthor =

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -46,6 +46,7 @@ import Unison.CommandLine.Globbing qualified as Globbing
 import Unison.CommandLine.InputPattern (ArgumentType (..), InputPattern (InputPattern), IsOptional (..))
 import Unison.CommandLine.InputPattern qualified as I
 import Unison.HashQualified qualified as HQ
+import Unison.JitInfo qualified as JitInfo
 import Unison.Name (Name)
 import Unison.NameSegment qualified as NameSegment
 import Unison.Prelude
@@ -2364,17 +2365,15 @@ fetchScheme =
         ]
     )
     ( \case
-        [] -> pure (Input.FetchSchemeCompilerI "unison" release)
+        [] -> pure (Input.FetchSchemeCompilerI "unison" JitInfo.currentRelease)
         [name] -> pure (Input.FetchSchemeCompilerI name branch)
           where
             branch
-              | name == "unison" = release
+              | name == "unison" = JitInfo.currentRelease
               | otherwise = "main"
         [name, branch] -> pure (Input.FetchSchemeCompilerI name branch)
         _ -> Left $ showPatternHelp fetchScheme
     )
-  where
-    release = "releases/0.0.1"
 
 createAuthor :: InputPattern
 createAuthor =

--- a/unison-cli/src/Unison/JitInfo.hs
+++ b/unison-cli/src/Unison/JitInfo.hs
@@ -1,4 +1,3 @@
-
 module Unison.JitInfo (currentRelease) where
 
 currentRelease :: String

--- a/unison-cli/src/Unison/JitInfo.hs
+++ b/unison-cli/src/Unison/JitInfo.hs
@@ -1,0 +1,5 @@
+
+module Unison.JitInfo (currentRelease) where
+
+currentRelease :: String
+currentRelease = "releases/0.0.1"

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -88,6 +88,7 @@ library
       Unison.CommandLine.OutputMessages
       Unison.CommandLine.Types
       Unison.CommandLine.Welcome
+      Unison.JitInfo
       Unison.LSP
       Unison.LSP.CancelRequest
       Unison.LSP.CodeAction

--- a/unison-src/builtin-tests/base.md
+++ b/unison-src/builtin-tests/base.md
@@ -5,6 +5,6 @@ Thus, make sure the contents of this file define the contents of the cache
 (e.g. don't pull `latest`.)
 
 ```ucm
-.> pull @unison/base/releases/2.0.0 .base
+.> pull @unison/base/releases/2.2.0 .base
 .> compile.native.fetch
 ```

--- a/unison-src/builtin-tests/base.output.md
+++ b/unison-src/builtin-tests/base.output.md
@@ -5,9 +5,9 @@ Thus, make sure the contents of this file define the contents of the cache
 (e.g. don't pull `latest`.)
 
 ```ucm
-.> pull @unison/base/releases/2.0.0 .base
+.> pull @unison/base/releases/2.2.0 .base
 
-  Downloaded 11939 entities.
+  Downloaded 12209 entities.
 
   ✅
   
@@ -15,11 +15,11 @@ Thus, make sure the contents of this file define the contents of the cache
 
 .> compile.native.fetch
 
-  Downloaded 65927 entities.
+  Downloaded 1255 entities.
 
   ✅
   
   Successfully updated .unison.internal from
-  unison.public.internal.trunk.
+  @unison/internal/releases/0.0.1.
 
 ```

--- a/unison-src/builtin-tests/testlib.u
+++ b/unison-src/builtin-tests/testlib.u
@@ -26,6 +26,7 @@ Tests.main suite = do
 
 Tests.run : '{IO,Exception,Tests} () ->{IO,Exception} Boolean
 Tests.run suite =
+  use Nat +
   h passed failed = cases
     { _ } -> (passed, failed) 
     { pass msg -> k } -> 

--- a/unison-src/builtin-tests/tls-chain-tests.u
+++ b/unison-src/builtin-tests/tls-chain-tests.u
@@ -41,7 +41,7 @@ chainClient portPromise toSend =
   tlsock = Tls.handshake tls
   TlsSocket.send tlsock (toUtf8 toSend)
   -- res = fromUtf8 (TlsSocket.receive tlsock)
-  TlsSocket.close tlsock
+  TlsSocket.terminate tlsock
   -- res
 
 -- server receives then sends
@@ -61,7 +61,7 @@ chainServer portPromise toSend =
   tlsock = net.Tls.handshake tls
   res = fromUtf8 (TlsSocket.receive tlsock)
   -- TlsSocket.send tlsock (toUtf8 toSend)
-  TlsSocket.close tlsock
+  TlsSocket.terminate tlsock
   res
 
 tlsChainTest = do

--- a/unison-src/builtin-tests/tls-tests.u
+++ b/unison-src/builtin-tests/tls-tests.u
@@ -66,7 +66,7 @@ tls.example.com = do
     conn = base.IO.net.Tls.handshake tls
     TlsSocket.send conn (toUtf8 "GET /index.html HTTP/1.0\r\nHost: example.com\r\n\r\n")
     response = TlsSocket.receive conn
-    TlsSocket.close conn
+    TlsSocket.terminate conn
     contains "HTTP/1.0 200 OK" (fromUtf8 response)
 
 testConnectSelfSigned = do
@@ -123,7 +123,7 @@ serverThread portPromise toSend =
   tls = Tls.newServer tlsconfig sock'
   tlsock = net.Tls.handshake tls
   TlsSocket.send tlsock (toUtf8 toSend)
-  TlsSocket.close tlsock
+  TlsSocket.terminate tlsock
 
 testClient : Optional SignedCert -> Text -> Promise Nat -> '{IO} Either Failure Text
 testClient cert hostname portVar _ = catch do


### PR DESCRIPTION
This modifies some of the ucm commands to look for the in-unison compiler code in a project on share. It still downloads the compiler to the same 'loose code' location, so that I didn't have to mess with the execution part of compiling code. But we should now be able to use projects to manage development of the compiler.

`compile.native.fetch` now takes up to two arguments. The first argument is an alternate username (default `unison`). The second argument is an alternate branch name (default for the `unison` user is a specific released version; default for everyone else is `main`). The project name is always `internal`. So, you can work on your own copy of the code with your own fork if you want.

Since the default is to fetch `@unison/internal/releases/X.Y.Z`, there should no longer be a race condition with submitting PRs. Just cut the `X.Y.Z` release on share, update `X.Y.Z` in the github PR, and everything should work out any temporary bad states. We also shouldn't have to worry about whether the `main` branch on share introduces breaking changes relative to the code on github.

I think this should allow @aryairani to do better caching he was wanting. I'm not sure how to signal when the cache should be invalidated, though. I just hard coded the `X.Y.Z` right now, and presumably you should change caches whenever that changes. Let me know if you need me to do anything to facilitate that.