### PR TITLE
autoformat PRs with ormolu

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,5 @@
 **Choose your PR title well:** Your pull request title is what's used to create release notes, so please make it descriptive of the change itself, which may be different from the initial motivation to make the change.
 
-Note: CI will check that all code has been formatted with Ormolu. See [development.markdown](https://github.com/unisonweb/unison/blob/trunk/development.markdown) for details of how to set this up.
-
 ## Overview
 
 What does this change accomplish and why?
@@ -18,12 +16,12 @@ How does it accomplish it, in broad strokes? i.e. How does it change the Haskell
 
 ## Interesting/controversial decisions
 
-Include anything that you thought twice about, debated, chose arbitrarily, etc. 
+Include anything that you thought twice about, debated, chose arbitrarily, etc.
 What could have been done differently, but wasn't? And why?
 
 ## Test coverage
 
-Have you included tests (which could be a transcript) for this change, or is it somehow covered by existing tests? 
+Have you included tests (which could be a transcript) for this change, or is it somehow covered by existing tests?
 
 Would you recommend improving the test coverage (either as part of this PR or as a separate issue) or do you think it’s adequate?
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,9 +24,16 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: unison
-      - uses: mrkkrp/ormolu-action@v11
+      - uses: unisonweb/run-ormolu@8e1437595b4127e368c114cabd1aeedb3b873918
         with:
           version: "0.5.0.1"
+          mode: inplace
+      - name: apply formatting changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        if: ${{ always() }}
+        with:
+          repository: unison
+          commit_message: automatically run ormolu
 
   build:
     name: ${{ matrix.os }}

--- a/development.markdown
+++ b/development.markdown
@@ -18,34 +18,7 @@ On startup, Unison prints a url for the codebase UI. If you did step 3 above, th
 
 ## Autoformatting your code with Ormolu
 
-We use 0.5.0.1 of Ormolu and CI will fail if your code isn't properly formatted. 
-
-```
-ghcup install ghc 9.2.7 # if not already installed
-ghcup install cabal # if not already installed
-cabal unpack ormolu-0.5.0.1
-cd ormolu-0.5.0.1
-cabal install -w ghc-9.2.7
-```
-
-You can then add the following to `.git/hooks/pre-commit` to make sure all your commits get formatted:
-
-```
-#!/bin/bash
-
-set -e
-
-if [[ -z "${SKIP_FORMATTING}" ]]; then
-    ormolu -i $(git diff --cached --name-only | grep '\.hs$')
-    git add $(git diff --cached --name-only)
-fi
-```
-
-If you've got an existing PR that somehow hasn't been formatted correctly, you can install the correct version of Ormolu locally, then do:
-
-```
-ormolu -i $(git ls-files | grep '\.hs$')
-```
+We use 0.5.0.1 of Ormolu and CI will add an extra commit, if needed, to autoformat your code.
 
 Also note that you can always wrap a comment around some code you don't want Ormolu to touch, using:
 


### PR DESCRIPTION
## Overview

Auto-formats new PRs with ormolu, and checks the result into the branch before running CI.

## Implementation notes

It uses a fork of https://github.com/haskell-actions/run-ormolu that which allows us to set `mode: inplace`, and then uses https://github.com/stefanzweifel/git-auto-commit-action to commit those changes to the branch before building and testing.


## Testing / Loose ends

I tested it on one of my own PRs, but I haven't tested what happens when an external contributor opens a PR.

I haven't tested with mergify, but it looks like it will be okay, because mergify doesn't care about the ormolu step per se.

https://github.com/haskell-actions/run-ormolu still fails, which is kind of a bummer, but I ignore the failure and still commit the results. Maybe this could be improved, not failing if the only problem is that formatting has occurred. It would probably still be good if it failed on a parse error or something weird.


