### PR TITLE
put JitInfo into base.md cache key

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -247,8 +247,8 @@ jobs:
         if: runner.os == 'Linux'
         with:
           path: ~/.cache/unisonlanguage/base.unison
-          key: base.unison_${{hashFiles('**/unison-src/builtin-tests/base.md')}}-${{github.sha}}
-          restore-keys: base.unison_${{hashFiles('**/unison-src/builtin-tests/base.md')}}-
+          key: base.unison_${{hashFiles('**/unison-src/builtin-tests/base.md','**/unison-cli/src/Unison/JitInfo.hs')}}-${{github.sha}}
+          restore-keys: base.unison_${{hashFiles('**/unison-src/builtin-tests/base.md','**/unison-cli/src/Unison/JitInfo.hs')}}-
 
       - name: set up `base` codebase
         if: runner.os == 'Linux'


### PR DESCRIPTION
Complementing #4149, this PR incorporates `JitInfo.hs` into the cache key for `base.unison` along with `base.md`.

## Loose ends
I think we want this change, but I am not sure why the jit tests are still so much slower than on my local machine, (8-10 mins vs <1 min).