### PR TITLE
move stack and unison repo around in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,8 +22,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-        with:
-          path: unison
       - uses: unisonweb/run-ormolu@8e1437595b4127e368c114cabd1aeedb3b873918
         with:
           version: "0.5.0.1"
@@ -32,7 +30,6 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         if: ${{ always() }}
         with:
-          repository: unison
           commit_message: automatically run ormolu
 
   build:
@@ -41,7 +38,6 @@ jobs:
     needs: ormolu
     defaults:
       run:
-        working-directory: unison
         shell: bash
     strategy:
       # Run each build to completion, regardless of if any have failed
@@ -54,8 +50,6 @@ jobs:
           - windows-2019
     steps:
       - uses: actions/checkout@v2
-        with:
-          path: unison
 
       # The number towards the beginning of the cache keys allow you to manually avoid using a previous cache.
       # GitHub will automatically delete caches that haven't been accessed in 7 days, but there is no way to

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,14 +128,14 @@ jobs:
       # The installation process differs by OS.
       - name: install stack (Linux)
         if: runner.os == 'Linux'
-        working-directory: ${{ github.workspace }}
+        working-directory: ${{ runner.temp }}
         run: |
           mkdir stack && cd stack
           curl -L https://github.com/commercialhaskell/stack/releases/download/v2.9.1/stack-2.9.1-linux-x86_64.tar.gz | tar -xz
           echo "$PWD/stack-"* >> $GITHUB_PATH
 
       - name: install stack (macOS)
-        working-directory: ${{ github.workspace }}
+        working-directory: ${{ runner.temp }}
         if: runner.os == 'macOS'
         run: |
           mkdir stack && cd stack
@@ -143,7 +143,7 @@ jobs:
           echo "$PWD/stack-"* >> $GITHUB_PATH
 
       - name: install stack (windows)
-        working-directory: ${{ github.workspace }}
+        working-directory: ${{ runner.temp }}
         if: runner.os == 'Windows'
         run: |
           mkdir stack && cd stack


### PR DESCRIPTION
We currently check out the source code to a nonstandard location (`${{github.workspace}}/unison` instead of `${{github.workspace}}`), presumably because we also were installing `stack` in `${{github.workspace}}`.

Then we tell the rest of our CI steps that the source code is in the nonstandard location `unison` and we were okay, except that unfortunately not every Github Action plugin supports having source code in the nonstandard location (specifically, an interaction between https://github.com/tj-actions/changed-files, https://github.com/haskell-actions/run-ormolu, and https://github.com/actions/toolkit/tree/main/packages/glob).

This PR moves stack from `${{github.workspace}}` to `${{runner.temp}}` and moves our code back from `${{github.workspace}}/unison` to `${{github.workspace}}`

Once it's in place, I can try to tweak the ormolu action to only reformat the changed files instead of all files.
