### PR TITLE
Bump max queued connections on builtin Socket to 2048

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -2384,7 +2384,7 @@ declareForeigns = do
 
   declareForeign Tracked "IO.listen.impl.v3" boxToEF0
     . mkForeignIOF
-    $ \sk -> SYS.listenSock sk 2
+    $ \sk -> SYS.listenSock sk 2048
 
   declareForeign Tracked "IO.clientSocket.impl.v3" boxBoxToEFBox
     . mkForeignIOF


### PR DESCRIPTION
The `SYS.listenSock` call in `Runtime.Builtin` was setting the max number of queued connections to 2. I'm assuming that's a typo as it seems absurdly low. The docs for `listenSock` suggest using 2048 as a sensible default, so I've set it to that.