### PR TITLE
Quiet down the transcripts executable and aggregate failures

### DIFF
--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -147,6 +147,7 @@ executables:
       - process
       - shellmet
       - unison-cli
+      - silently
 
   cli-integration-tests:
     when:

--- a/unison-cli/tests/Unison/Test/Ucm.hs
+++ b/unison-cli/tests/Unison/Test/Ucm.hs
@@ -25,6 +25,7 @@ import Unison.Codebase.Init qualified as Codebase.Init
 import Unison.Codebase.Init.CreateCodebaseError (CreateCodebaseError (..))
 import Unison.Codebase.SqliteCodebase qualified as SC
 import Unison.Codebase.TranscriptParser qualified as TR
+import Unison.Codebase.Verbosity qualified as Verbosity
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude (traceM)
 import Unison.PrettyTerminal qualified as PT
@@ -65,7 +66,7 @@ runTranscript :: Codebase -> Transcript -> IO TranscriptOutput
 runTranscript (Codebase codebasePath fmt) transcript = do
   let err e = fail $ "Parse error: \n" <> show e
       cbInit = case fmt of CodebaseFormat2 -> SC.init
-  TR.withTranscriptRunner "Unison.Test.Ucm.runTranscript Invalid Version String" configFile $ \runner -> do
+  TR.withTranscriptRunner Verbosity.Silent "Unison.Test.Ucm.runTranscript Invalid Version String" configFile $ \runner -> do
     result <- Codebase.Init.withOpenCodebase cbInit "transcript" codebasePath SC.DoLock SC.DontMigrate \codebase -> do
       Codebase.runTransaction codebase (Codebase.installUcmDependencies codebase)
       let transcriptSrc = stripMargin . Text.pack $ unTranscript transcript

--- a/unison-cli/transcripts/Transcripts.hs
+++ b/unison-cli/transcripts/Transcripts.hs
@@ -18,6 +18,7 @@ import System.FilePath
     (</>),
   )
 import System.IO.CodePage (withCP65001)
+import System.IO.Silently (silence)
 import Unison.Codebase.Init (withTemporaryUcmCodebase)
 import Unison.Codebase.SqliteCodebase qualified as SC
 import Unison.Codebase.TranscriptParser (TranscriptError (..), withTranscriptRunner)
@@ -38,7 +39,7 @@ testBuilder expectFailure dir prelude transcript = scope transcript $ do
     withTranscriptRunner Verbosity.Silent "TODO: pass version here" Nothing $ \runTranscript -> do
       for files $ \filePath -> do
         transcriptSrc <- readUtf8 filePath
-        out <- runTranscript filePath transcriptSrc (codebasePath, codebase)
+        out <- silence $ runTranscript filePath transcriptSrc (codebasePath, codebase)
         pure (filePath, out)
   for_ outputs $ \case
     (filePath, Left err) -> do

--- a/unison-cli/transcripts/Transcripts.hs
+++ b/unison-cli/transcripts/Transcripts.hs
@@ -24,6 +24,7 @@ import Unison.Codebase.SqliteCodebase qualified as SC
 import Unison.Codebase.TranscriptParser (TranscriptError (..), withTranscriptRunner)
 import Unison.Codebase.Verbosity qualified as Verbosity
 import Unison.Prelude
+import UnliftIO.STM qualified as STM
 
 data TestConfig = TestConfig
   { matchPrefix :: Maybe String
@@ -33,8 +34,8 @@ data TestConfig = TestConfig
 type TestBuilder = FilePath -> [String] -> String -> Test ()
 
 testBuilder ::
-  Bool -> FilePath -> [String] -> String -> Test ()
-testBuilder expectFailure dir prelude transcript = scope transcript $ do
+  Bool -> ((FilePath, Text) -> IO ()) -> FilePath -> [String] -> String -> Test ()
+testBuilder expectFailure recordFailure dir prelude transcript = scope transcript $ do
   outputs <- io . withTemporaryUcmCodebase SC.init Verbosity.Silent "transcript" SC.DoLock $ \(codebasePath, codebase) -> do
     withTranscriptRunner Verbosity.Silent "TODO: pass version here" Nothing $ \runTranscript -> do
       for files $ \filePath -> do
@@ -46,16 +47,23 @@ testBuilder expectFailure dir prelude transcript = scope transcript $ do
       let outputFile = outputFileForTranscript filePath
       case err of
         TranscriptParseError msg -> do
-          when (not expectFailure) . crash $ "Error parsing " <> filePath <> ": " <> Text.unpack msg
+          when (not expectFailure) $ do
+            let errMsg = "Error parsing " <> filePath <> ": " <> Text.unpack msg
+            io $ recordFailure (filePath, Text.pack errMsg)
+            crash errMsg
         TranscriptRunFailure errOutput -> do
           io $ writeUtf8 outputFile errOutput
           when (not expectFailure) $ do
             io $ Text.putStrLn errOutput
+            io $ recordFailure (filePath, errOutput)
             crash $ "Failure in " <> filePath
     (filePath, Right out) -> do
       let outputFile = outputFileForTranscript filePath
       io $ writeUtf8 outputFile out
-      when expectFailure $ crash "Expected a failure, but transcript was successful."
+      when expectFailure $ do
+        let errMsg = "Expected a failure, but transcript was successful."
+        io $ recordFailure (filePath, Text.pack errMsg)
+        crash errMsg
   ok
   where
     files = fmap (dir </>) (prelude ++ [transcript])
@@ -112,12 +120,23 @@ cleanup = do
 
 test :: TestConfig -> Test ()
 test config = do
-  buildTests config (testBuilder False) $
+  -- We manually aggregate and display failures at the end to it much easier to see
+  -- what went wrong in CI
+  failuresVar <- io $ STM.newTVarIO []
+  let recordFailure failure = STM.atomically $ STM.modifyTVar' failuresVar (failure :)
+  buildTests config (testBuilder False recordFailure) $
     "unison-src" </> "transcripts"
-  buildTests config (testBuilder False) $
+  buildTests config (testBuilder False recordFailure) $
     "unison-src" </> "transcripts-using-base"
-  buildTests config (testBuilder True) $
+  buildTests config (testBuilder True recordFailure) $
     "unison-src" </> "transcripts" </> "errors"
+  failures <- io $ STM.readTVarIO failuresVar
+  -- Print all aggregated failures
+  when (not $ null failures) . io $ Text.putStrLn $ "Failures:"
+  for failures $ \(filepath, msg) -> io $ do
+    Text.putStrLn $ Text.replicate 80 "="
+    Text.putStrLn $ "🚨 " <> Text.pack filepath <> ": "
+    Text.putStrLn msg
   cleanup
 
 handleArgs :: [String] -> TestConfig

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -461,6 +461,7 @@ executable transcripts
     , servant
     , servant-client
     , shellmet
+    , silently
     , stm
     , text
     , text-builder


### PR DESCRIPTION
closes #4145

## Overview

It's annoying and difficult to read output from transcript failures at the moment because failures are spread in amongst a lot of garbage transcript output.

This aspires to make transcript failures easier to read and figure out what's going on.

## Implementation notes

* Add 'verbosity' arg to most transcript running functions allowing us to silence most output when running via the `transcripts` executable. Output is kept verbose when using `ucm transcript`.
* Collect all transcript failures into a TVar in the runner so we can display them all in a row after the tests have completed. Failures are still displayed in-line, but now they're also aggregated at the end.

E.g.


    Randomness seed for this run is 4837502339729989071
    Raw test output to follow ...
    ------------------------------------------------------------

    Searching for transcripts to run in: unison-src/transcripts

    🦄  branch-command.md
    ```ucm
    .> builtins.mergeio

    Done.

    ```
    ```unison
    x = 22
    y 32
    ```

    ```ucm

    This looks like the start of an expression here

        2 | y 32

    but at the file top-level, I expect one of the following:

        - A binding, like y = 42 OR
                        y : Nat
                        y = 42
        - A watch expression, like > y + 1
        - An `ability` declaration, like unique ability Foo where ...
        - A `type` declaration, like structural type Optional a = None | Some a


    ```



    🛑

    The transcript failed due to an error in the stanza above. The error is:


    This looks like the start of an expression here

        2 | y 32

    but at the file top-level, I expect one of the following:

        - A binding, like y = 42 OR
                        y : Nat
                        y = 42
        - A watch expression, like > y + 1
        - An `ability` declaration, like unique ability Foo where ...
        - A `type` declaration, like structural type Optional a = None | Some a



    broken.md FAILURE Failure in unison-src/transcripts/broken.md CallStack (from HasCallStack):
    crash, called at transcripts/Transcripts.hs:59:13 in main:Main

    Searching for transcripts to run in: unison-src/transcripts-using-base

    💥  broken.md

    Searching for transcripts to run in: unison-src/transcripts/errors

    Failures:
    ================================================================================
    🚨 unison-src/transcripts/broken.md:
    ```ucm
    .> builtins.mergeio

    Done.

    ```
    ```unison
    x = 22
    y 32
    ```

    ```ucm

    This looks like the start of an expression here

        2 | y 32

    but at the file top-level, I expect one of the following:

        - A binding, like y = 42 OR
                        y : Nat
                        y = 42



## Interesting/controversial decisions

Maybe it's weird that I print the errors twice; I could suppress the initial error output, but that'd just mean that if you do notice an error in CI transcript output you have to wait for all transcripts to finish before you can read and act on it which seems bad.

I'm using Unison.Codebase.Verbosity everywhere for this, I could define my own verbosity, but it also propagates into Codebase.Init so it seems a bit unnecessary and weird to add another one. If anyone feels strongly about it I can change it.

## Loose ends

Currently it still prints out the little success unicorns for each file; we could silence that too, but that involves messing with easy-test and doesn't seem like a big deal at the moment.
