### PR TITLE
Add potentially missing squash_results table

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -237,6 +237,7 @@ module U.Codebase.Sqlite.Queries
     addNameLookupMountTables,
     addMostRecentNamespaceTable,
     addSquashResultTable,
+    addSquashResultTableIfNotExists,
 
     -- ** schema version
     currentSchemaVersion,
@@ -447,6 +448,12 @@ addMostRecentNamespaceTable =
 addSquashResultTable :: Transaction ()
 addSquashResultTable =
   executeStatements (Text.pack [hereFile|unison/sql/009-add-squash-cache-table.sql|])
+
+-- | Added as a fix because 'addSquashResultTable' was missed in the createSchema action
+-- for a portion of time.
+addSquashResultTableIfNotExists :: Transaction ()
+addSquashResultTableIfNotExists =
+  executeStatements (Text.pack [hereFile|unison/sql/010-ensure-squash-cache-table.sql|])
 
 schemaVersion :: Transaction SchemaVersion
 schemaVersion =

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -390,7 +390,7 @@ type TextPathSegments = [Text]
 -- * main squeeze
 
 currentSchemaVersion :: SchemaVersion
-currentSchemaVersion = 14
+currentSchemaVersion = 15
 
 createSchema :: Transaction ()
 createSchema = do
@@ -404,6 +404,7 @@ createSchema = do
   addNameLookupMountTables
   addMostRecentNamespaceTable
   execute insertSchemaVersionSql
+  addSquashResultTable
   where
     insertSchemaVersionSql =
       [sql|

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -395,7 +395,7 @@ currentSchemaVersion = 15
 
 createSchema :: Transaction ()
 createSchema = do
-  executeStatements (Text.pack [hereFile|unison/sql/create.sql|])
+  executeStatements [hereFile|unison/sql/create.sql|]
   addTempEntityTables
   addNamespaceStatsTables
   addReflogTable
@@ -415,45 +415,45 @@ createSchema = do
 
 addTempEntityTables :: Transaction ()
 addTempEntityTables =
-  executeStatements (Text.pack [hereFile|unison/sql/001-temp-entity-tables.sql|])
+  executeStatements [hereFile|unison/sql/001-temp-entity-tables.sql|]
 
 addNamespaceStatsTables :: Transaction ()
 addNamespaceStatsTables =
-  executeStatements (Text.pack [hereFile|unison/sql/003-namespace-statistics.sql|])
+  executeStatements [hereFile|unison/sql/003-namespace-statistics.sql|]
 
 addReflogTable :: Transaction ()
 addReflogTable =
-  executeStatements (Text.pack [hereFile|unison/sql/002-reflog-table.sql|])
+  executeStatements [hereFile|unison/sql/002-reflog-table.sql|]
 
 fixScopedNameLookupTables :: Transaction ()
 fixScopedNameLookupTables =
-  executeStatements (Text.pack [hereFile|unison/sql/004-fix-scoped-name-lookup-tables.sql|])
+  executeStatements [hereFile|unison/sql/004-fix-scoped-name-lookup-tables.sql|]
 
 addProjectTables :: Transaction ()
 addProjectTables =
-  executeStatements (Text.pack [hereFile|unison/sql/005-project-tables.sql|])
+  executeStatements [hereFile|unison/sql/005-project-tables.sql|]
 
 addMostRecentBranchTable :: Transaction ()
 addMostRecentBranchTable =
-  executeStatements (Text.pack [hereFile|unison/sql/006-most-recent-branch-table.sql|])
+  executeStatements [hereFile|unison/sql/006-most-recent-branch-table.sql|]
 
 addNameLookupMountTables :: Transaction ()
 addNameLookupMountTables =
-  executeStatements (Text.pack [hereFile|unison/sql/007-add-name-lookup-mounts.sql|])
+  executeStatements [hereFile|unison/sql/007-add-name-lookup-mounts.sql|]
 
 addMostRecentNamespaceTable :: Transaction ()
 addMostRecentNamespaceTable =
-  executeStatements (Text.pack [hereFile|unison/sql/008-add-most-recent-namespace-table.sql|])
+  executeStatements [hereFile|unison/sql/008-add-most-recent-namespace-table.sql|]
 
 addSquashResultTable :: Transaction ()
 addSquashResultTable =
-  executeStatements (Text.pack [hereFile|unison/sql/009-add-squash-cache-table.sql|])
+  executeStatements [hereFile|unison/sql/009-add-squash-cache-table.sql|]
 
 -- | Added as a fix because 'addSquashResultTable' was missed in the createSchema action
 -- for a portion of time.
 addSquashResultTableIfNotExists :: Transaction ()
 addSquashResultTableIfNotExists =
-  executeStatements (Text.pack [hereFile|unison/sql/010-ensure-squash-cache-table.sql|])
+  executeStatements [hereFile|unison/sql/010-ensure-squash-cache-table.sql|]
 
 schemaVersion :: Transaction SchemaVersion
 schemaVersion =

--- a/codebase2/codebase-sqlite/sql/010-ensure-squash-cache-table.sql
+++ b/codebase2/codebase-sqlite/sql/010-ensure-squash-cache-table.sql
@@ -1,0 +1,14 @@
+-- NOTE: This was added in 009-add-squash-cache-table.sql, but it was not
+-- but was mistakenly not added to the 'create-schema' action, so any new 
+-- codebases created on version 14 will be missing it and we need to add it to them.
+
+-- A table for tracking the results of squashes we've performed.
+-- This is used to avoid re-squashing the same branch multiple times.
+CREATE TABLE IF NOT EXISTS "squash_results" (
+  -- The branch hash of the namespace to be squashed.
+  -- There should only ever be one result for each unsquashed value hash.
+  branch_hash_id INTEGER PRIMARY KEY NOT NULL REFERENCES hash(id),
+
+  -- The causal hash id which is the result of squashing the 'branch_hash_id's causal.'
+  squashed_causal_hash_id INTEGER NOT NULL REFERENCES causal(self_hash_id)
+) WITHOUT ROWID;

--- a/codebase2/codebase-sqlite/unison-codebase-sqlite.cabal
+++ b/codebase2/codebase-sqlite/unison-codebase-sqlite.cabal
@@ -19,6 +19,7 @@ extra-source-files:
     sql/007-add-name-lookup-mounts.sql
     sql/008-add-most-recent-namespace-table.sql
     sql/009-add-squash-cache-table.sql
+    sql/010-ensure-squash-cache-table.sql
     sql/create.sql
 
 source-repository head

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations.hs
@@ -79,7 +79,8 @@ migrations getDeclType termBuffer declBuffer rootCodebasePath =
       sqlMigration 11 Q.addMostRecentBranchTable,
       (12, migrateSchema11To12),
       sqlMigration 13 Q.addMostRecentNamespaceTable,
-      sqlMigration 14 Q.addSquashResultTable
+      sqlMigration 14 Q.addSquashResultTable,
+      sqlMigration 15 Q.addSquashResultTableIfNotExists
     ]
   where
     sqlMigration :: SchemaVersion -> Sqlite.Transaction () -> (SchemaVersion, Sqlite.Transaction ())


### PR DESCRIPTION
## Overview

I accidentally added the squash-results table in the v14 migration action but forgot to add it to the `createSchema` action, so any codebases created with the M5 release will be missing it; any upgraded from previous versions will have it.

It won't cause any errors for anyone's local UCM instances since ucm doesn't use it, but it means if we want to use it in the future it may be missing from some codebases, and divergent codebases are not a great thing, so probably best to resolve that for everyone now.

I'll also need to ensure it's added to all new codebases on Share or they'll fail to create releases, so
IMO it's easiest is to add it to createSchema now and add a new codebase migration with the equivalent `CREATE TABLE IF NOT EXISTS ...` in it.

## Implementation notes

* Create the squash_results table in new codebases
* Add the squash_results table to old codebases in a v14 -> v15 migration if it doesn't already exist.

## Test coverage

Tried it locally on both an existing v14 codebase and creating a new codebase.

## Loose ends

This will need a Share migration, should be blazing fast.