### PR TITLE
update to lts-20.26

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -39,12 +39,9 @@ packages:
 - unison-syntax
 - yaks/easytest
 
-resolver: lts-20.22
+resolver: lts-20.26
 
 extra-deps:
-# version in snapshot is too new
-- network-3.1.2.7 # 3.1.3.0 doesn't seem to build in Windows
-
 # broken version in snapshot
 - github: unisonweb/configurator
   commit: e47e9e9fe1f576f8c835183b9def52d73c01327a

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,13 +5,6 @@
 
 packages:
 - completed:
-    hackage: network-3.1.2.7@sha256:9752628bc626e0cad8c53039bea0dc0417f39ca6663232e4d9ac4e35a8925f7d,4911
-    pantry-tree:
-      sha256: aa95093a413ed8306699098159047580e0dc0bda4a862a0264a370b993319b24
-      size: 3971
-  original:
-    hackage: network-3.1.2.7
-- completed:
     name: configurator
     pantry-tree:
       sha256: 90547cd983fd15ebdc803e057d3ef8735fe93a75e29a00f8a74eadc13ee0f6e9
@@ -70,7 +63,7 @@ packages:
     hackage: recover-rtti-0.4.2@sha256:c179a303921126d8d782264e14f386c96e54a270df74be002e4c4ec3c8c7aebd,4529
 snapshots:
 - completed:
-    sha256: dcf4fc28f12d805480ddbe8eb8c370e11db12f0461d0110a4240af27ac88d725
-    size: 650255
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/22.yaml
-  original: lts-20.22
+    sha256: 5a59b2a405b3aba3c00188453be172b85893cab8ebc352b1ef58b0eae5d248a2
+    size: 650475
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/26.yaml
+  original: lts-20.26


### PR DESCRIPTION
ghc 9.2.7 -> 9.2.8, which gives us access to more cached nix artifacts from iog.io
network 3.1.4.0 does build in Windows (3.1.3.0 didn't), so we can remove a version override.
