### PR TITLE
timing the jit test for CI debugging purposes

### DIFF
--- a/unison-src/builtin-tests/jit-tests.sh
+++ b/unison-src/builtin-tests/jit-tests.sh
@@ -7,7 +7,7 @@ base_codebase=${XDG_CACHE_HOME:-"$HOME/.cache"}/unisonlanguage/base.unison
 
 if [ ! -d $base_codebase ]; then
     echo !!!! Creating a codebase in $base_codebase
-    $ucm transcript -S $base_codebase unison-src/builtin-tests/base.md
+    UNISON_DEBUG=timing $ucm transcript -S $base_codebase unison-src/builtin-tests/base.md
 fi
 
 dir=${XDG_DATA_HOME:-"$HOME/.local/share"}/unisonlanguage/scheme-libs

--- a/unison-src/builtin-tests/jit-tests.sh
+++ b/unison-src/builtin-tests/jit-tests.sh
@@ -7,7 +7,7 @@ base_codebase=${XDG_CACHE_HOME:-"$HOME/.cache"}/unisonlanguage/base.unison
 
 if [ ! -d $base_codebase ]; then
     echo !!!! Creating a codebase in $base_codebase
-    UNISON_DEBUG=timing $ucm transcript -S $base_codebase unison-src/builtin-tests/base.md
+    $ucm transcript -S $base_codebase unison-src/builtin-tests/base.md
 fi
 
 dir=${XDG_DATA_HOME:-"$HOME/.local/share"}/unisonlanguage/scheme-libs
@@ -16,4 +16,4 @@ echo $dir
 mkdir -p $dir
 cp -r scheme-libs/* $dir/
 
-time $ucm transcript.fork -c $base_codebase unison-src/builtin-tests/jit-tests.md
+UNISON_DEBUG=timing time $ucm transcript.fork -c $base_codebase unison-src/builtin-tests/jit-tests.md


### PR DESCRIPTION
It looks like `.> compile.native.fetch` takes ~2 seconds, after previously having cached that codebase with `base.md`
`.> compile.native.genlibs` takes 312s (5.2 mins)
`.> run.native tests` takes 148s (2.5 mins)
`.> run.native tests.jit.only` takes 24s (0.4 mins)

and this roughly adds up to pretty close to the 8.3 mins we see in CI.

I wonder if `compile.native.genlibs` could be cached in some way that doesn't invalidate the testing?