### PR TITLE
[#4150] truncate argument type error from the front

### DIFF
--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -1061,7 +1061,7 @@ renderTerm :: (IsString s, Var v) => Env -> Term.Term' (TypeVar.TypeVar loc0 v) 
 renderTerm env e =
   let s = Color.toPlain $ TermPrinter.pretty' (Just 80) env (TypeVar.lowerTerm e)
    in if length s > Settings.renderTermMaxLength
-        then fromString (take Settings.renderTermMaxLength s <> "...")
+        then fromString ("..." <> drop (length s - Settings.renderTermMaxLength) s)
         else fromString s
 
 renderPattern :: Env -> Pattern ann -> ColorText

--- a/unison-core/src/Unison/Settings.hs
+++ b/unison-core/src/Unison/Settings.hs
@@ -6,7 +6,7 @@ debugNoteSummary = False
 debugRevealForalls = False
 
 renderTermMaxLength :: Int
-renderTermMaxLength = 20
+renderTermMaxLength = 30
 
 demoHideVarNumber :: Bool
 demoHideVarNumber = False


### PR DESCRIPTION
## Overview

This PR fixes the inconvenience caused while displaying the argument type error.

**[Before]** The type error would be truncate from the end, causing the user to not know exactly which function threw the error.

**[After]** The function will be truncate from the front. Providing readability for user to fix the error more efficiently.

## Implementation notes

Using `drop` instead of `take` and discarding the excess characters from the beginning. 

## Interesting/controversial decisions

Value for the `renderTermMaxLength` could have been increased but didn't see the need of it. 
(let me know if it needs to be updated to an appropriate value)

This PR is raised for the following issue : https://github.com/unisonweb/unison/issues/4150
