### PR TITLE
Allow Debug.toText usage in tests

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -3178,16 +3178,19 @@ evalUnisonFile sandbox ppe unisonFile args = do
         Cli.runTransaction (Codebase.putWatch kind hash value')
     pure rs
 
-evalPureUnison :: 
+evalPureUnison ::
   PPE.PrettyPrintEnv ->
-  Bool -> 
+  Bool ->
   Term Symbol Ann ->
   Cli (Either Runtime.Error (Term Symbol Ann))
-evalPureUnison ppe useCache tm = evalUnisonTermE False ppe useCache tm' 
+evalPureUnison ppe useCache tm = evalUnisonTermE False ppe useCache tm'
   where
-    tm' = Term.iff a (Term.apps' (Term.builtin a "validateSandboxed") [allow, Term.delay a tm]) 
-                     tm
-                     (Term.app a (Term.builtin a "bug") (Term.text a msg)) 
+    tm' =
+      Term.iff
+        a
+        (Term.apps' (Term.builtin a "validateSandboxed") [allow, Term.delay a tm])
+        tm
+        (Term.app a (Term.builtin a "bug") (Term.text a msg))
     a = ABT.annotation tm
     allow = Term.list a [Term.termLink a (Referent.Ref (Reference.Builtin "Debug.toText"))]
     msg = "pure code can't perform I/O"

--- a/unison-src/transcripts/fix4172.md
+++ b/unison-src/transcripts/fix4172.md
@@ -1,0 +1,31 @@
+
+```ucm:hide
+.> builtins.merge
+```
+
+```unison
+debug a = match Debug.toText a with
+  None -> ""
+  Some (Left a) -> a
+  Some (Right a) -> a
+
+test> t1 = if bool then [Ok "Yay"] 
+           else [Fail (debug [1,2,3])]
+bool = true
+
+allowDebug = debug [1,2,3]
+```
+
+```ucm
+.> add
+.> test
+```
+
+```unison
+bool = false
+```
+
+```ucm:error
+.> update
+.> test
+```

--- a/unison-src/transcripts/fix4172.output.md
+++ b/unison-src/transcripts/fix4172.output.md
@@ -1,0 +1,96 @@
+
+```unison
+debug a = match Debug.toText a with
+  None -> ""
+  Some (Left a) -> a
+  Some (Right a) -> a
+
+test> t1 = if bool then [Ok "Yay"] 
+           else [Fail (debug [1,2,3])]
+bool = true
+
+allowDebug = debug [1,2,3]
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      allowDebug : Text
+      bool       : Boolean
+      debug      : a -> Text
+      t1         : [Result]
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    6 | test> t1 = if bool then [Ok "Yay"] 
+    
+    ✅ Passed Yay
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    allowDebug : Text
+    bool       : Boolean
+    debug      : a -> Text
+    t1         : [Result]
+
+.> test
+
+  Cached test results (`help testcache` to learn more)
+  
+  ◉ t1   Yay
+  
+  ✅ 1 test(s) passing
+  
+  Tip: Use view t1 to view the source of a test.
+
+```
+```unison
+bool = false
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      bool : Boolean
+
+```
+```ucm
+.> update
+
+  ⍟ I've updated these names to your new definition:
+  
+    bool : Boolean
+
+.> test
+
+  ✅  
+
+  
+
+  
+
+    New test results:
+  
+  ✗ t1   [1, 2, 3]
+  
+  🚫 1 test(s) failing
+  
+  Tip: Use view t1 to view the source of a test.
+
+```


### PR DESCRIPTION
Previously, the `test` command couldn't use `Debug.toText` due to that being a sandboxed operation. Which was not great, since the main test runner in base uses `Debug.toText` to print failed results. Thus, you could end up in the situation where you update some code, but can't rerun affected tests due to a failed sandbox check!

`Debug.toText` is safe to call here as it's not doing any I/O. Thus, this PR allows `Debug.toText` in the `test` command and adds a regression transcript.

Aside: We could potentially use the helper function I wrote (`HandleInput.evalPureUnison`) for `display` too. Currently `display` also doesn't allow use of `Debug.toText`, but I was more nervous about touching that codepath since it's used for doc rendering on Share. I think it might be fine, but would want an audit from someone else before changing that.