### PR TITLE
Add DECN and EXPF to the jit

### DIFF
--- a/scheme-libs/racket/unison/math.rkt
+++ b/scheme-libs/racket/unison/math.rkt
@@ -1,8 +1,10 @@
 #lang racket/base
 
-(require math/base)
+(require math/base
+         (only-in unison/boot data-case define-unison))
 
 (provide
+    builtin-Float.exp
  (prefix-out unison-POp-
              (combine-out
               ABSF
@@ -18,6 +20,7 @@
               ATN2
               ATNH
               CEIL
+              EXPF
               COSF
               COSH
               DIVF
@@ -29,6 +32,8 @@
               SINF
               ITOF)))
 
+(define-unison (builtin-Float.exp n) (exp n))
+(define (EXPF n) (exp n))
 (define ABSF abs)
 (define ACOS acos)
 (define ACSH acosh)

--- a/scheme-libs/racket/unison/primops.ss
+++ b/scheme-libs/racket/unison/primops.ss
@@ -27,6 +27,7 @@
     builtin-Float.*
     builtin-Float.fromRepresentation
     builtin-Float.toRepresentation
+    builtin-Float.exp
     builtin-Int.+
     builtin-Int.-
     builtin-Int.increment
@@ -231,12 +232,14 @@
     unison-POp-CONS
     unison-POp-DBTX
     unison-POp-DECI
+    unison-POp-DECN
     unison-POp-DIVN
     unison-POp-DRPB
     unison-POp-DRPS
     unison-POp-DRPT
     unison-POp-EQLN
     unison-POp-EQLT
+    unison-POp-EXPF
     unison-POp-LEQT
     unison-POp-EQLU
     unison-POp-EROR
@@ -430,6 +433,7 @@
   (define (unison-POp-COMN n) (fxnot n))
   (define (unison-POp-CONS x xs) (chunked-list-add-first xs x))
   (define (unison-POp-DECI n) (fx1- n))
+  (define (unison-POp-DECN n) (- n 1))
   (define (unison-POp-DIVN m n) (fxdiv m n))
   (define (unison-POp-DRPB n bs) (chunked-bytes-drop bs n))
   (define (unison-POp-DRPS n l) (chunked-list-drop l n))

--- a/unison-src/builtin-tests/jit-tests.output.md
+++ b/unison-src/builtin-tests/jit-tests.output.md
@@ -8,6 +8,8 @@ to `Tests.check` and `Tests.checkEqual`).
 ```ucm
 .> run.native tests
 
+  Scheme evaluation failed.
+
 ```
 ```ucm
 .> run.native tests.jit.only

--- a/unison-src/builtin-tests/jit-tests.output.md
+++ b/unison-src/builtin-tests/jit-tests.output.md
@@ -8,8 +8,6 @@ to `Tests.check` and `Tests.checkEqual`).
 ```ucm
 .> run.native tests
 
-  Scheme evaluation failed.
-
 ```
 ```ucm
 .> run.native tests.jit.only

--- a/unison-src/builtin-tests/math-tests.u
+++ b/unison-src/builtin-tests/math-tests.u
@@ -28,3 +28,6 @@ math.tests = do
     checkEqual "divi" (10 / 4) 2
     checkEqual "eqlf" (1.1 == 1.1) true
     checkEqual "eqlf" (1.1 == 1.2) false
+    checkEqual "decn" (Nat.decrement 10) 9
+    checkEqual "deci" (Int.decrement +10) +9
+    checkCloseEnough "expf" (Float.exp 2.0) 7.3890560989306


### PR DESCRIPTION
not sure actually how to generate `EXPF` -- I though `Float.exp` would do it, but turns out that's also a builtin.