### PR TITLE
tests: Add simple test cases for Text.indexOf and Bytes.indexOf

### DIFF
--- a/unison-src/builtin-tests/bytes-tests.u
+++ b/unison-src/builtin-tests/bytes-tests.u
@@ -110,6 +110,11 @@ bytes.ops.tests = do
   checkEqual "Bytes.at (3)" (Bytes.at 1 0xs) None
   checkEqual "Bytes.at (4)" (Bytes.at 5 0xs010203) None
 
+  checkEqual "Bytes.indexOf (1)" (Bytes.indexOf 0xs 0xs0102030304) (Some 0)
+  checkEqual "Bytes.indexOf (2)" (Bytes.indexOf 0xs03 0xs0102030304) (Some 2)
+  checkEqual "Bytes.indexOf (3)" (Bytes.indexOf 0xs0304 0xs0102030304) (Some 3)
+  checkEqual "Bytes.indexOf (3)" (Bytes.indexOf 0xs020304 0xs0102030304) None
+
 -- Haskell and Racket produce slightly different byte output
 -- for gzip compress (in the header, racket reports the OS as "unix"
 -- while Haskell for some reason claims to be Acorn RISCOS),

--- a/unison-src/builtin-tests/text-tests.u
+++ b/unison-src/builtin-tests/text-tests.u
@@ -91,6 +91,11 @@ text.ops.tests = do
   checkEqual "Text.toLowercase (1)" (Text.toLowercase "") ""
   checkEqual "Text.toLowercase (2)" (Text.toLowercase "abcABC123{({})}.") "abcabc123{({})}."
 
+  checkEqual "Text.indexOf (1)" (Text.indexOf "" "hello") (Some 0)
+  checkEqual "Text.indexOf (2)" (Text.indexOf "l" "hello") (Some 2)
+  checkEqual "Text.indexOf (3)" (Text.indexOf "lo" "hello") (Some 3)
+  checkEqual "Text.indexOf (3)" (Text.indexOf "elo" "hello") None
+
 text.conversion.tests = do
   checkEqual "Nat.toText (1)" (Nat.toText 0) "0"
   checkEqual "Nat.toText (2)" (Nat.toText 10) "10"


### PR DESCRIPTION
This is a follow-up to #4183 which just adds some simple Unison test cases for `Text.indexOf` and `Bytes.indexOf`, since those didn’t already exist.