### PR TITLE
Fix various issues with structural find and replace

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/TermParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermParser.hs
@@ -95,7 +95,7 @@ rewriteBlock = do
     rewriteCase = rewriteTermlike "case" DD.rewriteCase
     rewriteType = do
       kw <- quasikeyword "signature"
-      vs <- fromMaybe [] <$> optional (some prefixDefinitionName <* symbolyQuasikeyword ".")
+      vs <- P.try (some prefixDefinitionName <* symbolyQuasikeyword ".") <|> pure []
       lhs <- TypeParser.computationType
       rhs <- openBlockWith "==>" *> TypeParser.computationType <* closeBlock
       pure (DD.rewriteType (ann kw <> ann rhs) (L.payload <$> vs) lhs rhs)

--- a/parser-typechecker/src/Unison/UnisonFile.hs
+++ b/parser-typechecker/src/Unison/UnisonFile.hs
@@ -32,18 +32,21 @@ module Unison.UnisonFile
     topLevelComponents,
     typecheckedUnisonFile,
     Unison.UnisonFile.rewrite,
+    prepareRewrite,
   )
 where
 
 import Control.Lens
 import Data.Map qualified as Map
 import Data.Set qualified as Set
+import Data.Vector qualified as Vector
 import Unison.ABT qualified as ABT
 import Unison.Builtin.Decls qualified as DD
 import Unison.ConstructorReference (GConstructorReference (..))
 import Unison.ConstructorType qualified as CT
 import Unison.DataDeclaration (DataDeclaration, EffectDeclaration (..))
 import Unison.DataDeclaration qualified as DD
+import Unison.Hash qualified as Hash
 import Unison.Hashing.V2.Convert qualified as Hashing
 import Unison.LabeledDependency (LabeledDependency)
 import Unison.LabeledDependency qualified as LD
@@ -59,6 +62,7 @@ import Unison.Typechecker.TypeLookup qualified as TL
 import Unison.UnisonFile.Type (TypecheckedUnisonFile (..), UnisonFile (..), pattern TypecheckedUnisonFile, pattern UnisonFile)
 import Unison.Util.List qualified as List
 import Unison.Var (Var)
+import Unison.Var qualified as Var
 import Unison.WatchKind (WatchKind, pattern TestWatch)
 
 dataDeclarations :: UnisonFile v a -> Map v (Reference, DataDeclaration v a)
@@ -108,6 +112,76 @@ effectDeclarations' = fmap (first Reference.DerivedId) . effectDeclarationsId'
 hashTerms :: TypecheckedUnisonFile v a -> Map v (a, Reference, Maybe WatchKind, Term v a, Type v a)
 hashTerms = fmap (over _2 Reference.DerivedId) . hashTermsId
 
+mapTerms :: (Term v a -> Term v a) -> UnisonFile v a -> UnisonFile v a
+mapTerms f (UnisonFileId datas effects terms watches) =
+  UnisonFileId datas effects terms' watches'
+  where
+    terms' = over _3 f <$> terms
+    watches' = fmap (over _3 f) <$> watches
+
+-- | This function should be called in preparation for a call to 
+-- UnisonFile.rewrite. It prevents the possibility of accidental 
+-- variable capture while still allowing the rules to capture variables
+-- where that's the intent. For example:
+-- 
+--   f x = x + 42
+--   ex = List.map (x -> Nat.increment x) [1,2,3] 
+-- 
+--   rule1 f = @rewrite term (x -> f x) ==> f 
+--   rule2 = @rewrite term (x -> f x) ==> f 
+--
+-- Here, `rule1` introduces a variable `f`, which can stand for
+-- any definition. Whereas `rule2` refers to the the top-level `f`
+-- function in the file.
+-- 
+-- This function returns a tuple of: (prepareRule, preparedFile, finish)
+--   `prepareRule` should be called on any `@rewrite` block to do
+--                 prevent accidental capture. It receives the [v] of
+--                 variables bound locally by the rule (`rule1` above binds `f`).
+--   `preparedFile` should be passed to `UnisonFile.rewrite`
+--   `finish` should be called on the result of `UnisonFile.rewrite`
+-- 
+-- Internally, the function works by replacing all free variables in the file
+-- with a unique reference, performing the rewrite using the ABT machinery,
+-- then converting back to a "regular" UnisonFile with free variables in the
+-- terms.
+prepareRewrite :: (Monoid a, Var v) => UnisonFile v a -> ([v] -> Term v a -> Term v a, UnisonFile v a, UnisonFile v a -> UnisonFile v a)
+prepareRewrite uf@(UnisonFileId _datas _effects terms watches) =
+  (freshen, mapTerms substs uf, mapTerms refToVar)
+  where
+    -- fn to replace free vars with unique refs
+    substs = ABT.substsInheritAnnotation varToRef
+    -- fn to replace free variables of a @rewrite block with unique refs
+    --   subtlety: we freshen any vars which are used in the file to avoid
+    --   accidental capture 
+    freshen vs tm = case ABT.freshenWrt Var.bakeId (typecheckingTerm uf) [tm1] of
+      [tm] -> tm
+      _ -> error "prepareRewrite bug (in freshen)"
+      where
+        -- logic to leave alone variables bound by @rewrite block
+        tm0 = ABT.absChain' (repeat (ABT.annotation tm) `zip` vs) tm
+        tm1 = ABT.dropAbs (length vs) (substs tm0)
+    -- An arbitrary, random unique hash, generated via /dev/urandom
+    -- we just need something that won't collide with refs
+    h = Hash.fromByteString "f0dd645e2382aba2035350297fb2a26263d1891965e5f351e19ae69317b1c866"
+    varToRef =
+      [(v, Term.ref () (Reference.Derived h i)) | (v, i) <- vs `zip` [0 ..]]
+      where
+        vs = (view _1 <$> terms) <> (toList watches >>= map (view _1))
+    vars = Vector.fromList (fst <$> varToRef)
+    -- function to convert unique refs back to free variables
+    refToVar = ABT.rebuildUp' go
+      where
+        go tm@(Term.Ref' (Reference.Derived h0 i)) | h == h0 =
+          case vars Vector.!? (fromIntegral i) of
+            Just v -> Term.var (ABT.annotation tm) v
+            Nothing -> error $ "UnisonFile.prepareRewrite bug, index out of bounds: " ++ show i
+        go tm = tm
+
+-- Rewrite a UnisonFile using a function for transforming terms.
+-- The function should return `Nothing` if the term is unchanged.
+-- This function returns what symbols were modified.
+-- The `Set v` is symbols that should be left alone.
 rewrite :: (Var v, Eq a) => Set v -> (Term v a -> Maybe (Term v a)) -> UnisonFile v a -> ([v], UnisonFile v a)
 rewrite leaveAlone rewriteFn (UnisonFileId datas effects terms watches) =
   (rewritten, UnisonFileId datas effects (unEither terms') (unEither <$> watches'))

--- a/parser-typechecker/src/Unison/UnisonFile.hs
+++ b/parser-typechecker/src/Unison/UnisonFile.hs
@@ -119,28 +119,28 @@ mapTerms f (UnisonFileId datas effects terms watches) =
     terms' = over _3 f <$> terms
     watches' = fmap (over _3 f) <$> watches
 
--- | This function should be called in preparation for a call to 
--- UnisonFile.rewrite. It prevents the possibility of accidental 
+-- | This function should be called in preparation for a call to
+-- UnisonFile.rewrite. It prevents the possibility of accidental
 -- variable capture while still allowing the rules to capture variables
 -- where that's the intent. For example:
--- 
+--
 --   f x = x + 42
---   ex = List.map (x -> Nat.increment x) [1,2,3] 
--- 
---   rule1 f = @rewrite term (x -> f x) ==> f 
---   rule2 = @rewrite term (x -> f x) ==> f 
+--   ex = List.map (x -> Nat.increment x) [1,2,3]
+--
+--   rule1 f = @rewrite term (x -> f x) ==> f
+--   rule2 = @rewrite term (x -> f x) ==> f
 --
 -- Here, `rule1` introduces a variable `f`, which can stand for
 -- any definition. Whereas `rule2` refers to the the top-level `f`
 -- function in the file.
--- 
+--
 -- This function returns a tuple of: (prepareRule, preparedFile, finish)
 --   `prepareRule` should be called on any `@rewrite` block to do
 --                 prevent accidental capture. It receives the [v] of
 --                 variables bound locally by the rule (`rule1` above binds `f`).
 --   `preparedFile` should be passed to `UnisonFile.rewrite`
 --   `finish` should be called on the result of `UnisonFile.rewrite`
--- 
+--
 -- Internally, the function works by replacing all free variables in the file
 -- with a unique reference, performing the rewrite using the ABT machinery,
 -- then converting back to a "regular" UnisonFile with free variables in the
@@ -153,7 +153,7 @@ prepareRewrite uf@(UnisonFileId _datas _effects terms watches) =
     substs = ABT.substsInheritAnnotation varToRef
     -- fn to replace free variables of a @rewrite block with unique refs
     --   subtlety: we freshen any vars which are used in the file to avoid
-    --   accidental capture 
+    --   accidental capture
     freshen vs tm = case ABT.freshenWrt Var.bakeId (typecheckingTerm uf) [tm1] of
       [tm] -> tm
       _ -> error "prepareRewrite bug (in freshen)"

--- a/unison-cli/src/Unison/Cli/MonadUtils.hs
+++ b/unison-cli/src/Unison/Cli/MonadUtils.hs
@@ -105,8 +105,8 @@ import Unison.Codebase.ShortCausalHash qualified as SCH
 import Unison.HashQualified qualified as HQ
 import Unison.HashQualified' qualified as HQ'
 import Unison.Name qualified as Name
-import Unison.Names (Names)
 import Unison.NameSegment (NameSegment)
+import Unison.Names (Names)
 import Unison.Parser.Ann (Ann (..))
 import Unison.Prelude
 import Unison.Reference (TypeReference)
@@ -527,7 +527,7 @@ getTermFromLatestParsedFile (HQ.NameOnly n) = do
 getTermFromLatestParsedFile _ = pure Nothing
 
 getNamesFromLatestParsedFile :: Cli Names
-getNamesFromLatestParsedFile = do 
+getNamesFromLatestParsedFile = do
   uf <- getLatestParsedFile
   pure $ case uf of
     Nothing -> mempty

--- a/unison-cli/src/Unison/Cli/MonadUtils.hs
+++ b/unison-cli/src/Unison/Cli/MonadUtils.hs
@@ -69,6 +69,7 @@ module Unison.Cli.MonadUtils
     -- * Latest touched Unison file
     getLatestFile,
     getLatestParsedFile,
+    getNamesFromLatestParsedFile,
     getTermFromLatestParsedFile,
     expectLatestFile,
     expectLatestParsedFile,
@@ -104,6 +105,7 @@ import Unison.Codebase.ShortCausalHash qualified as SCH
 import Unison.HashQualified qualified as HQ
 import Unison.HashQualified' qualified as HQ'
 import Unison.Name qualified as Name
+import Unison.Names (Names)
 import Unison.NameSegment (NameSegment)
 import Unison.Parser.Ann (Ann (..))
 import Unison.Prelude
@@ -115,6 +117,7 @@ import Unison.Syntax.Name qualified as Name (toText)
 import Unison.Term qualified as Term
 import Unison.UnisonFile (TypecheckedUnisonFile, UnisonFile)
 import Unison.UnisonFile qualified as UF
+import Unison.UnisonFile.Names qualified as UFN
 import Unison.Util.Set qualified as Set
 import Unison.Var qualified as Var
 import UnliftIO.STM
@@ -522,6 +525,13 @@ getTermFromLatestParsedFile (HQ.NameOnly n) = do
         Term.LetRecNamed' bs _ -> lookup (Var.named (Name.toText n)) bs
         _ -> Nothing
 getTermFromLatestParsedFile _ = pure Nothing
+
+getNamesFromLatestParsedFile :: Cli Names
+getNamesFromLatestParsedFile = do 
+  uf <- getLatestParsedFile
+  pure $ case uf of
+    Nothing -> mempty
+    Just uf -> UFN.toNames uf
 
 -- | Get the latest typechecked unison file, or return early if there isn't one.
 expectLatestTypecheckedFile :: Cli (TypecheckedUnisonFile Symbol Ann)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1806,10 +1806,10 @@ handleStructuredFindReplaceI rule = do
   (ppe, _ns, rules) <- lookupRewrite InvalidStructuredFindReplace prepare rule
   (dest, _) <- Cli.expectLatestFile
   #latestFile ?= (dest, True)
-  let go n tm [] = if n == (0::Int) then Nothing else Just tm
+  let go n tm [] = if n == (0 :: Int) then Nothing else Just tm
       go n tm ((r, _) : rules) = case r tm of
         Nothing -> go n tm rules
-        Just tm -> go (n+1) tm rules
+        Just tm -> go (n + 1) tm rules
       (vs, uf0') = UF.rewrite (Set.singleton (HQ.toVar rule)) (\tm -> go 0 tm rules) uf
       uf' = (vs, finish uf0')
   #latestTypecheckedFile .= Just (Left . snd $ uf')

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1761,7 +1761,8 @@ lookupRewrite onErr rule = do
   Cli.Env {codebase} <- ask
   currentBranch <- Cli.getCurrentBranch0
   hqLength <- Cli.runTransaction Codebase.hashLength
-  let currentNames = NamesWithHistory.fromCurrentNames $ Branch.toNames currentBranch
+  fileNames <- Cli.getNamesFromLatestParsedFile
+  let currentNames = NamesWithHistory.fromCurrentNames (fileNames <> Branch.toNames currentBranch)
   let ppe = PPED.fromNamesDecl hqLength currentNames
   ot <- Cli.getTermFromLatestParsedFile rule
   ot <- case ot of

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1735,7 +1735,7 @@ inputDescription input =
 handleStructuredFindI :: HQ.HashQualified Name -> Cli ()
 handleStructuredFindI rule = do
   Cli.Env {codebase} <- ask
-  (ppe, names, rules0) <- lookupRewrite InvalidStructuredFind rule
+  (ppe, names, rules0) <- lookupRewrite InvalidStructuredFind (\_ tm -> tm) rule
   let rules = snd <$> rules0
   let fqppe = PPED.unsuffixifiedPPE ppe
   results :: [(HQ.HashQualified Name, Referent)] <- pure $ do
@@ -1756,8 +1756,8 @@ handleStructuredFindI rule = do
   #numberedArgs .= map toNumArgs results
   Cli.respond (ListStructuredFind (fst <$> results))
 
-lookupRewrite :: (HQ.HashQualified Name -> Output) -> HQ.HashQualified Name -> Cli (PPED.PrettyPrintEnvDecl, NamesWithHistory, [(Term Symbol Ann -> Maybe (Term Symbol Ann), Term Symbol Ann -> Bool)])
-lookupRewrite onErr rule = do
+lookupRewrite :: (HQ.HashQualified Name -> Output) -> ([Symbol] -> Term Symbol Ann -> Term Symbol Ann) -> HQ.HashQualified Name -> Cli (PPED.PrettyPrintEnvDecl, NamesWithHistory, [(Term Symbol Ann -> Maybe (Term Symbol Ann), Term Symbol Ann -> Bool)])
+lookupRewrite onErr prepare rule = do
   Cli.Env {codebase} <- ask
   currentBranch <- Cli.getCurrentBranch0
   hqLength <- Cli.runTransaction Codebase.hashLength
@@ -1775,29 +1775,43 @@ lookupRewrite onErr rule = do
               Cli.runTransaction (Codebase.getTerm codebase r)
         s -> Cli.returnEarly (TermAmbiguous (PPE.suffixifiedPPE ppe) rule s)
   tm <- maybe (Cli.returnEarly (TermAmbiguous (PPE.suffixifiedPPE ppe) rule mempty)) pure ot
-  let extract tm = case tm of
-        Term.Ann' tm _typ -> extract tm
-        (DD.RewriteTerm' lhs rhs) -> pure (ABT.rewriteExpression lhs rhs, ABT.containsExpression lhs)
-        (DD.RewriteCase' lhs rhs) -> pure (Term.rewriteCasesLHS lhs rhs, fromMaybe False . Term.containsCaseTerm lhs)
-        (DD.RewriteSignature' _vs lhs rhs) -> pure (Term.rewriteSignatures lhs rhs, Term.containsSignature lhs)
+  let extract vs tm = case tm of
+        Term.Ann' tm _typ -> extract vs tm
+        (DD.RewriteTerm' lhs rhs) ->
+          pure
+            ( ABT.rewriteExpression lhs rhs,
+              ABT.containsExpression lhs
+            )
+        (DD.RewriteCase' lhs rhs) ->
+          pure
+            ( Term.rewriteCasesLHS lhs rhs,
+              fromMaybe False . Term.containsCaseTerm lhs
+            )
+        (DD.RewriteSignature' _vs lhs rhs) ->
+          pure (Term.rewriteSignatures lhs rhs, Term.containsSignature lhs)
         _ -> Cli.returnEarly (onErr rule)
-      extractOuter tm = case tm of
-        Term.Ann' tm _typ -> extractOuter tm
-        Term.LamsNamed' _vs tm -> extractOuter tm
-        DD.Rewrites' rules -> traverse extract rules
-        _ -> Cli.returnEarly (onErr rule)
-  rules <- extractOuter tm
+      extractOuter vs0 tm = case tm of
+        Term.Ann' tm _typ -> extractOuter vs0 tm
+        Term.LamsNamed' vs tm -> extractOuter (vs0 ++ vs) tm
+        tm -> case prepare vs0 tm of
+          DD.Rewrites' rules -> traverse (extract vs0) rules
+          _ -> Cli.returnEarly (onErr rule)
+  rules <- extractOuter [] tm
   pure (ppe, currentNames, rules)
 
 handleStructuredFindReplaceI :: HQ.HashQualified Name -> Cli ()
 handleStructuredFindReplaceI rule = do
-  (ppe, _ns, rules) <- lookupRewrite InvalidStructuredFindReplace rule
-  uf <- Cli.expectLatestParsedFile
+  uf0 <- Cli.expectLatestParsedFile
+  let (prepare, uf, finish) = UF.prepareRewrite uf0
+  (ppe, _ns, rules) <- lookupRewrite InvalidStructuredFindReplace prepare rule
   (dest, _) <- Cli.expectLatestFile
   #latestFile ?= (dest, True)
-  let go _tm0 tm [] = tm
-      go tm0 tm ((r, _) : rules) = go tm0 ((tm <|> tm0) >>= r) rules
-      uf' = UF.rewrite (Set.singleton (HQ.toVar rule)) (\tm -> go (Just tm) Nothing rules) uf
+  let go n tm [] = if n == (0::Int) then Nothing else Just tm
+      go n tm ((r, _) : rules) = case r tm of
+        Nothing -> go n tm rules
+        Just tm -> go (n+1) tm rules
+      (vs, uf0') = UF.rewrite (Set.singleton (HQ.toVar rule)) (\tm -> go 0 tm rules) uf
+      uf' = (vs, finish uf0')
   #latestTypecheckedFile .= Just (Left . snd $ uf')
   let msg = "| Rewrote using: "
   Cli.respond $ OutputRewrittenFile ppe dest (msg <> HQ.toString rule) uf'

--- a/unison-core/src/Unison/ABT.hs
+++ b/unison-core/src/Unison/ABT.hs
@@ -26,6 +26,7 @@ module Unison.ABT
     freshenS,
     freshInBoth,
     freshenBothWrt,
+    freshenWrt,
     visit,
     visit',
     visit_,
@@ -80,6 +81,7 @@ module Unison.ABT
     absr,
     unabs,
     unabsA,
+    dropAbs,
     cycle,
     cycle',
     cycler,
@@ -243,6 +245,11 @@ pattern AbsNA' :: [(a, v)] -> Term f v a -> Term f v a
 pattern AbsNA' avs body <- (unabsA -> (avs, body))
 
 {-# COMPLETE Var', Cycle', Abs'', Tm' #-}
+
+dropAbs :: Int -> Term f v a -> Term f v a
+dropAbs z tm | z <= 0 = tm
+dropAbs n (Term _ _ (Abs _ body)) = dropAbs (n - 1) body
+dropAbs _ tm = tm
 
 unabsA :: Term f v a -> ([(a, v)], Term f v a)
 unabsA (Term _ a (Abs hd body)) =
@@ -507,19 +514,25 @@ reannotateUp g t = case out t of
         ann = g t <> foldMap (snd . annotation) body'
      in tm' (annotation t, ann) body'
 
--- given a list of terms, freshen all their free variables
+-- Given a list of terms, freshen all their free variables
 -- to not overlap with any variables used within `wrt`.
-freshenWrt :: (Var v, Traversable f) => Term f v a -> [Term f v a] -> [Term f v a]
-freshenWrt wrt tms = renames varChanges <$> tms
+-- The `afterFreshen` function is applied to each freshened
+-- variable. It can be the identity function or `Var.bakeId`,
+-- or it can do some other tagging of freshened variables.
+-- 
+-- This is used by structural find and replace to ensure that rules
+-- don't accidentally capture local variables.
+freshenWrt :: (Var v, Traversable f) => (v -> v) -> Term f v a -> [Term f v a] -> [Term f v a]
+freshenWrt afterFreshen wrt tms = renames varChanges <$> tms
   where
     used = Set.fromList (allVars wrt)
     varChanges =
       fst $ foldl go (Map.empty, used) (foldMap freeVars tms)
       where
-        go (m, u) v = let v' = freshIn u v in (Map.insert v v' m, Set.insert v' u)
+        go (m, u) v = let v' = afterFreshen $ freshIn u v in (Map.insert v v' m, Set.insert v' u)
 
 freshenBothWrt :: (Var v, Traversable f) => Term f v a -> Term f v a -> Term f v a -> (Term f v a, Term f v a)
-freshenBothWrt wrt tm1 tm2 = case freshenWrt wrt [tm1, tm2] of
+freshenBothWrt wrt tm1 tm2 = case freshenWrt id wrt [tm1, tm2] of
   [tm1, tm2] -> (tm1, tm2)
   _ -> error "freshenWrt impossible"
 

--- a/unison-core/src/Unison/ABT.hs
+++ b/unison-core/src/Unison/ABT.hs
@@ -519,7 +519,7 @@ reannotateUp g t = case out t of
 -- The `afterFreshen` function is applied to each freshened
 -- variable. It can be the identity function or `Var.bakeId`,
 -- or it can do some other tagging of freshened variables.
--- 
+--
 -- This is used by structural find and replace to ensure that rules
 -- don't accidentally capture local variables.
 freshenWrt :: (Var v, Traversable f) => (v -> v) -> Term f v a -> [Term f v a] -> [Term f v a]

--- a/unison-core/src/Unison/Var.hs
+++ b/unison-core/src/Unison/Var.hs
@@ -2,6 +2,7 @@ module Unison.Var
   ( Var (..),
     Type (..),
     InferenceType (..),
+    bakeId,
     blank,
     freshIn,
     inferAbility,
@@ -58,6 +59,11 @@ freshIn = ABT.freshIn
 
 named :: (Var v) => Text -> v
 named n = typed (User n)
+
+-- This bakes the fresh id into the name portion of the variable
+-- and resets the id to 0.
+bakeId :: Var v => v -> v
+bakeId v = named (name v)
 
 rawName :: Type -> Text
 rawName typ = case typ of

--- a/unison-src/transcripts-manual/rewrites.md
+++ b/unison-src/transcripts-manual/rewrites.md
@@ -107,6 +107,7 @@ foo2 =
 rule = @rewrite
   case None ==> Left "oh no"
   term foo1 ==> foo2
+  case None ==> Left "89899"
 
 sameFileEx = 
   _ = "ex"

--- a/unison-src/transcripts-manual/rewrites.md
+++ b/unison-src/transcripts-manual/rewrites.md
@@ -5,6 +5,10 @@
 .> add
 ```
 
+## Structural find and replace
+
+Here's a scratch file with some rewrite rules: 
+
 ```unison:hide rewrites-tmp.u
 ex1 = List.map (x -> x + 1) [1,2,3,4,5,6,7] 
 
@@ -25,36 +29,65 @@ rule1 f x = @rewrite
   term x + 1 ==> Nat.increment x
   term (a -> f a) ==> f -- eta reduction
 
-d = {{ 
-
-Here's the rewritten source of {ex1}:
-
-  @source{ex1} 
-
-And here's the rewritten source of {Either.mapRight},
-with {type Either} replaced by {type Optional}:
-
-  @source{Either.mapRight}
-
-Lastly, here's the source of the rewrite blocks (demonstrating
-the pretty-printing syntax):
-  
-  @source{rule1, eitherToOptional}
-}}
-
 cleanup = do 
   _ = IO.removeFile.impl "rewrites-tmp.u"
   ()
 ```
 
+Let's rewrite these:
+
 ```ucm
 .> rewrite rule1
 .> rewrite eitherToOptional
+```
+
+```ucm:hide
 .> load rewrites-tmp.u
-.> display d
 .> add
+```
+
+After adding to the codebase, here's the rewritten source:
+
+```ucm
+.> view ex1 Either.mapRight rule1
+```
+
+Another example, showing that we can rewrite to definitions that only exist in the file:
+
+```unison:hide rewrites-tmp.u
+unique ability Woot1 where woot1 : () -> Nat
+unique ability Woot2 where woot2 : () -> Nat
+
+woot1to2 x = @rewrite 
+  term Woot1.woot1 ==> Woot2.woot2
+  signature _ . Woot1 ==> Woot2 
+
+wootEx : Nat ->{Woot1} Nat 
+wootEx a = !woot1
+```
+
+Let's apply the rewrite `woot1to2`:
+
+```ucm
+.> rewrite woot1to2
+```
+
+```ucm:hide
+.> load rewrites-tmp.u
+.> add
+```
+
+After adding the rewritten form to the codebase, here's the rewritten `Woot1` to `Woot2`:
+
+```ucm
+.> view wootEx 
+```
+
+```ucm:hide
 .> run cleanup
 ```
+
+## Structural find
 
 ```unison:hide
 eitherEx = Left ("hello", "there")


### PR DESCRIPTION
This PR fixes all currently known issues with the new structural find and replace feature. See #4198 for details. It also adds docs and regression tests to the existing transcript.

Together these fixes make rewrite rules usable even when they refer to definitions (terms or type declarations) that exist only in the scratch file. There's some subtle logic to avoid accidental variable capture in these situations, while still allowing variable capture when that's the user's intent. The regression tests I added exercise this and the other fixes.

See the comment on the function `UnisonFile.prepareRewrite` if you're curious about the implementation.