### PR TITLE
Adapt cabal build to lts-20.26

### DIFF
--- a/contrib/cabal.project
+++ b/contrib/cabal.project
@@ -43,7 +43,12 @@ source-repository-package
   location: https://github.com/unisonweb/haskeline.git
   tag: 9275eea7982dabbf47be2ba078ced669ae7ef3d5
 
-constraints: fsnotify < 0.4
+constraints:
+  fsnotify < 0.4,
+  crypton-x509-store <= 1.6.8,
+  lsp < 2.0.0.0,
+  servant <= 0.19.1,
+  optparse-applicative <= 0.17.0.0
 
 -- For now there is no way to apply ghc-options for all local packages
 -- See https://cabal.readthedocs.io/en/latest/cabal-project.html#package-configuration-options
@@ -125,8 +130,9 @@ package unison-hashing-v2
 package unison-share-api
   ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
+-- adding -Wno-deprecations cause jose-0.10 has deprecated Crypto.JWT.addClaim
 package unison-share-projects-api
-  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+  ghc-options: -Wall -Werror -Wno-deprecations -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
 package unison-syntax
   ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info

--- a/contrib/cabal.project
+++ b/contrib/cabal.project
@@ -48,7 +48,7 @@ constraints:
   crypton-x509-store <= 1.6.8,
   lsp < 2.0.0.0,
   servant <= 0.19.1,
-  optparse-applicative <= 0.17.0.0
+  optparse-applicative <= 0.17.1.0
 
 -- For now there is no way to apply ghc-options for all local packages
 -- See https://cabal.readthedocs.io/en/latest/cabal-project.html#package-configuration-options


### PR DESCRIPTION
* Since the recent upgrade of main stack build to lts-20.22 , the default constraints of cabal solver (get the newer versions) makes the build fail
* This pr adds the required constraints, got from https://www.stackage.org/lts-20.22
* It also ignores deprecations for `unison-share-projects-api` cause getting a working version of jose package is very difficult only touching cabal.project due to package revisions

* Tested manually with `cabal build all --project-file .\contrib\cabal.project -w ghc-9.2.8`
* Building with ghc-8.10.7 fails with:

```
[ 6 of 34] Compiling Unison.Position  ( src\Unison\Position.hs, D:\dev\ws\haskell\unison\dist-newstyle\build\x86_64-windows\ghc-8.10.7\unison-core1-0.0.0\build\Unison\Position.o )

src\Unison\Sqlite\Sql.hs:404:3: error:
    • Variable not in scope:
        asum
          :: [State.StateT [Lump] (Megaparsec.Parsec Void Text) Fragment]
             -> P Fragment
    • Perhaps you meant one of these:
        ‘sum’ (imported from Prelude),
        ‘msum’ (imported from Unison.Prelude)
    |
404 |   asum
    |   ^^^^
```
i think it would be not too difficult to workaround that error but i guess that build is unsupported, so 🤷 
