### PR TITLE
Allow `single backticks` for inline monospaced text in docs

### DIFF
--- a/unison-src/transcripts-using-base/doc.md.files/syntax.u
+++ b/unison-src/transcripts-using-base/doc.md.files/syntax.u
@@ -6,7 +6,7 @@ basicFormatting = {{
     have a title and 0 or more paragraphs or other section elements.
     
     Text can be **bold**, __italicized__, ~~strikethrough~~, or
-    ''monospaced''.
+    ''monospaced'' (or `monospaced`).
     
     You can link to Unison terms, types, and external URLs:
     

--- a/unison-src/transcripts-using-base/doc.output.md
+++ b/unison-src/transcripts-using-base/doc.output.md
@@ -114,7 +114,7 @@ and the rendered output using `display`:
       section elements.
       
       Text can be **bold**, __italicized__, ~~strikethrough~~,
-      or ''monospaced''.
+      or ''monospaced'' (or ''monospaced'').
       
       You can link to Unison terms, types, and external URLs:
       
@@ -141,7 +141,7 @@ and the rendered output using `display`:
     elements.
   
     Text can be bold, *italicized*, ~~strikethrough~~, or
-    `monospaced`.
+    `monospaced` (or `monospaced`).
   
     You can link to Unison terms, types, and external URLs:
   
@@ -581,7 +581,7 @@ Lastly, it's common to build longer documents including subdocuments via `{{ sub
       section elements.
     
       Text can be bold, *italicized*, ~~strikethrough~~, or
-      `monospaced`.
+      `monospaced` (or `monospaced`).
     
       You can link to Unison terms, types, and external URLs:
     

--- a/unison-src/transcripts/api-doc-rendering.md
+++ b/unison-src/transcripts/api-doc-rendering.md
@@ -45,9 +45,7 @@ Inline code:
 
 `` 1 + 2 ``
 
-`
-"doesn't typecheck" + 1
-`
+`"doesn't typecheck" + 1`
 
 [Link](https://unison-lang.org)
 

--- a/unison-src/transcripts/api-doc-rendering.output.md
+++ b/unison-src/transcripts/api-doc-rendering.output.md
@@ -41,9 +41,7 @@ Inline code:
 
 `` 1 + 2 ``
 
-`
-"doesn't typecheck" + 1
-`
+`"doesn't typecheck" + 1`
 
 [Link](https://unison-lang.org)
 
@@ -111,7 +109,7 @@ term = 42
     
       `1 Nat.+ 2`
     
-      ` "doesn't typecheck" + 1 `
+      `"doesn't typecheck" + 1`
     
       Link
     
@@ -224,7 +222,7 @@ GET /api/getDefinition?names=term
             "termDocs": [
                 [
                     "doc",
-                    "#343l8ugvo7vgp7d1fp4rlnf272k3ea8111m2f97ckuovkutulvmac6jej39kk95s0fdpma0vkhtios6ihh9jo968gb9c5cde0spa9co",
+                    "#99ru4vbnfvg2987fdgv53lufamvm2brb91tkrad3ku9t34nhpui52l3cipv6k97bum07orgp9h5ojjohpkg91vnfc62pfiatr293t18",
                     {
                         "contents": [
                             {
@@ -606,28 +604,11 @@ GET /api/getDefinition?names=term
                                             {
                                                 "contents": [
                                                     {
-                                                        "contents": "`",
-                                                        "tag": "Word"
-                                                    },
-                                                    {
-                                                        "contents": "\"doesn't",
-                                                        "tag": "Word"
-                                                    },
-                                                    {
-                                                        "contents": "typecheck\"",
-                                                        "tag": "Word"
-                                                    },
-                                                    {
-                                                        "contents": "+",
-                                                        "tag": "Word"
-                                                    },
-                                                    {
-                                                        "contents": "1",
-                                                        "tag": "Word"
-                                                    },
-                                                    {
-                                                        "contents": "`",
-                                                        "tag": "Word"
+                                                        "contents": {
+                                                            "contents": "\"doesn't typecheck\" + 1",
+                                                            "tag": "Word"
+                                                        },
+                                                        "tag": "Code"
                                                     }
                                                 ],
                                                 "tag": "Paragraph"

--- a/unison-src/transcripts/bug-strange-closure.output.md
+++ b/unison-src/transcripts/bug-strange-closure.output.md
@@ -13,7 +13,7 @@ We can display the guide before and after adding it to the codebase:
       section elements.
     
       Text can be bold, *italicized*, ~~strikethrough~~, or
-      `monospaced`.
+      `monospaced` (or `monospaced`).
     
       You can link to Unison terms, types, and external URLs:
     
@@ -225,7 +225,7 @@ We can display the guide before and after adding it to the codebase:
       section elements.
     
       Text can be bold, *italicized*, ~~strikethrough~~, or
-      `monospaced`.
+      `monospaced` (or `monospaced`).
     
       You can link to Unison terms, types, and external URLs:
     
@@ -443,7 +443,7 @@ rendered = Pretty.get (docFormatConsole doc.guide)
       section elements.
     
       Text can be bold, *italicized*, ~~strikethrough~~, or
-      `monospaced`.
+      `monospaced` (or `monospaced`).
     
       You can link to Unison terms, types, and external URLs:
     
@@ -648,7 +648,7 @@ rendered = Pretty.get (docFormatConsole doc.guide)
       section elements.
     
       Text can be bold, *italicized*, ~~strikethrough~~, or
-      `monospaced`.
+      `monospaced` (or `monospaced`).
     
       You can link to Unison terms, types, and external URLs:
     
@@ -1094,6 +1094,23 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                                         ()
                                         (Annotated.Append
                                           ()
+                                          [ Lit
+                                              ()
+                                              (Right (Plain "`")),
+                                            Lit
+                                              ()
+                                              (Right
+                                                (Plain
+                                                  "monospaced")),
+                                            Lit
+                                              ()
+                                              (Right (Plain "`")) ]),
+                                      Lit
+                                        () (Right (Plain "(or")),
+                                      Annotated.Group
+                                        ()
+                                        (Annotated.Append
+                                          ()
                                           [ Annotated.Group
                                               ()
                                               (Annotated.Append
@@ -1113,7 +1130,8 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                                                       (Plain "`")) ]),
                                             Lit
                                               ()
-                                              (Right (Plain ".")) ]) ]))),
+                                              (Right
+                                                (Plain ").")) ]) ]))),
                             Lit () (Right (Plain "\n")),
                             Lit () (Right (Plain "\n")),
                             Indent

--- a/unison-syntax/src/Unison/Syntax/Lexer.hs
+++ b/unison-syntax/src/Unison/Syntax/Lexer.hs
@@ -499,9 +499,12 @@ lexemes' eof =
                 stop' = maybe stop end (lastMay after)
 
         verbatim =
-          P.label "code (examples: ''**unformatted**'', '''_words_''')" $ do
+          P.label "code (examples: ''**unformatted**'', `words` or '''_words_''')" $ do
             (start, txt, stop) <- positioned $ do
-              quotes <- lit "''" <+> many (P.satisfy (== '\''))
+              -- a single backtick followed by a non-backtick is treated as monospaced
+              let tick = P.try (lit "`" <* P.lookAhead (P.satisfy (/= '`')))
+              -- also two or more ' followed by that number of closing '
+              quotes <- tick <|> (lit "''" <+> many (P.satisfy (== '\'')))
               P.someTill P.anySingle (lit quotes)
             if all isSpace $ takeWhile (/= '\n') txt
               then


### PR DESCRIPTION
This is a very small lexer change to allow a single <code>`</code> to start and end inline monospaced text in a doc, which people are very accustomed to from markdown. Tested in the doc parsing / pretty-printing transcript.

```
d = {{ This is `monospaced` text. }}
```

Previously, single backticks were used for infix function application for an alphanumeric operator, as in:

```haskell
foo `append` bar
```

However we long ago got rid of that syntax since the pretty-printer had no way to know when to use it. 

Thus, the single backtick syntax has been available for a while.

I left the pretty-printer alone in this PR, so it still prefers to use the `''` syntax when pretty-printing. Potentially we could have the pretty-printer use backticks preferentially, that'd be easy to do in a subsequent PR. Note that the `''` syntax is a bit more flexible re: escaping - you can start and end with any number of `''` (2 or more, and the end will require a matching number).

Thus, I see this PR as mostly being about avoiding accidental bad rendering from markdown muscle memory.

## Summarizing various doc syntax

```
''monospaced'' or `monospaced` or '''monospaced text'''
``1 + 1`` -- an inline code example (two backticks, it will be typechecked, and hyperlinked)
```

And then there's fenced code blocks, starting with at least three backticks, ending with the same number of backticks.