### PR TITLE
fix package.yaml paths ignore thing in network-uri-orphans-sqlite

### DIFF
--- a/lib/orphans/network-uri-orphans-sqlite/network-uri-orphans-sqlite.cabal
+++ b/lib/orphans/network-uri-orphans-sqlite/network-uri-orphans-sqlite.cabal
@@ -18,8 +18,6 @@ source-repository head
 library
   exposed-modules:
       Network.URI.Orphans.Sqlite
-  other-modules:
-      Paths_network_uri_orphans_sqlite
   hs-source-dirs:
       src
   default-extensions:

--- a/lib/orphans/network-uri-orphans-sqlite/package.yaml
+++ b/lib/orphans/network-uri-orphans-sqlite/package.yaml
@@ -5,7 +5,7 @@ copyright: Copyright (C) 2013-2021 Unison Computing, PBC and contributors
 library:
   when:
     - condition: false
-      other-modules: Paths_network-uri_orphans_sqlite
+      other-modules: Paths_network_uri_orphans_sqlite
   source-dirs: src
 
 dependencies:


### PR DESCRIPTION
## Overview

Typo in `package.yaml` caused unnecessary unregistering/rebuilding by Stack