### PR TITLE
Add conflict warnings to LSP

### DIFF
--- a/unison-cli/src/Unison/LSP/Conversions.hs
+++ b/unison-cli/src/Unison/LSP/Conversions.hs
@@ -1,11 +1,11 @@
 module Unison.LSP.Conversions where
 
+import Control.Lens
 import Data.IntervalMap.Interval qualified as Interval
 import Language.LSP.Types
 import Unison.LSP.Orphans ()
 import Unison.Parser.Ann (Ann)
 import Unison.Parser.Ann qualified as Ann
-import Unison.Prelude
 import Unison.Syntax.Lexer qualified as Lex
 import Unison.Util.Range qualified as Range
 

--- a/unison-cli/src/Unison/LSP/Diagnostics.hs
+++ b/unison-cli/src/Unison/LSP/Diagnostics.hs
@@ -1,4 +1,12 @@
-module Unison.LSP.Diagnostics where
+module Unison.LSP.Diagnostics
+  ( annToRange,
+    uToLspPos,
+    uToLspRange,
+    reportDiagnostics,
+    mkDiagnostic,
+    DiagnosticSeverity (..),
+  )
+where
 
 import Language.LSP.Types
 import Unison.LSP.Types

--- a/unison-cli/src/Unison/LSP/FileAnalysis.hs
+++ b/unison-cli/src/Unison/LSP/FileAnalysis.hs
@@ -241,6 +241,8 @@ analyseFile fileUri srcText notes = do
   (noteDiags, noteActions) <- analyseNotes fileUri pped (Text.unpack srcText) notes
   pure (noteDiags, noteActions)
 
+-- | Returns diagnostics which show a warning diagnostic when editing a term that's conflicted in the
+-- codebase.
 computeConflictWarningDiagnostics :: Uri -> FileSummary -> Lsp [Diagnostic]
 computeConflictWarningDiagnostics fileUri fileSummary@FileSummary {fileNames} = do
   let defLocations = fileDefLocations fileSummary

--- a/unison-cli/src/Unison/LSP/FileAnalysis.hs
+++ b/unison-cli/src/Unison/LSP/FileAnalysis.hs
@@ -263,7 +263,7 @@ computeConflictWarningDiagnostics fileUri fileSummary@FileSummary {fileNames} = 
           & foldMap \(name, locs) ->
             (mapMaybe Cv.annToRange . Set.toList $ locs)
               <&> \range ->
-                let msg = ("`" <> Name.toText name <> "` is conflicted in your codebase")
+                let msg = "There are multiple definitions of `" <> Name.toText name <> "` in your namespace; updating this definition will replace them."
                     newRangeEnd =
                       range ^. LSPTypes.start
                         & LSPTypes.character +~ fromIntegral (Text.length (Name.toText name))
@@ -271,7 +271,7 @@ computeConflictWarningDiagnostics fileUri fileSummary@FileSummary {fileNames} = 
                  in mkDiagnostic
                       fileUri
                       newRange
-                      DsWarning
+                      DsInfo
                       msg
                       mempty
   pure $ toDiagnostics conflictedTermLocations <> toDiagnostics conflictedTypeLocations

--- a/unison-cli/src/Unison/LSP/Queries.hs
+++ b/unison-cli/src/Unison/LSP/Queries.hs
@@ -88,7 +88,7 @@ getTypeOfReferent fileUri ref = do
       case ref of
         Referent.Ref (Reference.Builtin {}) -> empty
         Referent.Ref (Reference.DerivedId termRefId) -> do
-          MaybeT . pure $ (termsByReference ^? ix (Just termRefId) . folded . _2 . _Just)
+          MaybeT . pure $ (termsByReference ^? ix (Just termRefId) . folded . _3 . _Just)
         Referent.Con (ConstructorReference r0 cid) _type -> do
           case r0 of
             Reference.DerivedId r -> do
@@ -344,10 +344,10 @@ nodeAtPosition :: Uri -> Position -> MaybeT Lsp (SourceNode Ann)
 nodeAtPosition uri (lspToUPos -> pos) = do
   (FileSummary {termsBySymbol, testWatchSummary, exprWatchSummary}) <- getFileSummary uri
 
-  let (trms, typs) = termsBySymbol & foldMap \(_ref, trm, mayTyp) -> ([trm], toList mayTyp)
+  let (trms, typs) = termsBySymbol & foldMap \(_ann, _ref, trm, mayTyp) -> ([trm], toList mayTyp)
   ( altMap (hoistMaybe . findSmallestEnclosingNode pos . removeInferredTypeAnnotations) trms
-      <|> altMap (hoistMaybe . findSmallestEnclosingNode pos . removeInferredTypeAnnotations) (testWatchSummary ^.. folded . _3)
-      <|> altMap (hoistMaybe . findSmallestEnclosingNode pos . removeInferredTypeAnnotations) (exprWatchSummary ^.. folded . _3)
+      <|> altMap (hoistMaybe . findSmallestEnclosingNode pos . removeInferredTypeAnnotations) (testWatchSummary ^.. folded . _4)
+      <|> altMap (hoistMaybe . findSmallestEnclosingNode pos . removeInferredTypeAnnotations) (exprWatchSummary ^.. folded . _4)
       <|> altMap (fmap TypeNode . hoistMaybe . findSmallestEnclosingType pos) typs
     )
   where

--- a/unison-cli/src/Unison/LSP/Types.hs
+++ b/unison-cli/src/Unison/LSP/Types.hs
@@ -138,10 +138,10 @@ data FileSummary = FileSummary
     dataDeclsByReference :: Map Reference.Id (Map Symbol (DD.DataDeclaration Symbol Ann)),
     effectDeclsBySymbol :: Map Symbol (Reference.Id, DD.EffectDeclaration Symbol Ann),
     effectDeclsByReference :: Map Reference.Id (Map Symbol (DD.EffectDeclaration Symbol Ann)),
-    termsBySymbol :: Map Symbol (Maybe Reference.Id, Term Symbol Ann, Maybe (Type Symbol Ann)),
-    termsByReference :: Map (Maybe Reference.Id) (Map Symbol (Term Symbol Ann, Maybe (Type Symbol Ann))),
-    testWatchSummary :: [(Maybe Symbol, Maybe Reference.Id, Term Symbol Ann, Maybe (Type Symbol Ann))],
-    exprWatchSummary :: [(Maybe Symbol, Maybe Reference.Id, Term Symbol Ann, Maybe (Type Symbol Ann))],
+    termsBySymbol :: Map Symbol (Ann, Maybe Reference.Id, Term Symbol Ann, Maybe (Type Symbol Ann)),
+    termsByReference :: Map (Maybe Reference.Id) (Map Symbol (Ann, Term Symbol Ann, Maybe (Type Symbol Ann))),
+    testWatchSummary :: [(Ann, Maybe Symbol, Maybe Reference.Id, Term Symbol Ann, Maybe (Type Symbol Ann))],
+    exprWatchSummary :: [(Ann, Maybe Symbol, Maybe Reference.Id, Term Symbol Ann, Maybe (Type Symbol Ann))],
     fileNames :: Names
   }
   deriving stock (Show)


### PR DESCRIPTION
## Overview

<img width="569" alt="image" src="https://github.com/unisonweb/unison/assets/6439644/1023cb98-2d5c-41ae-876e-2ce93985bb97">


I used a `Warning`, but there are also `Info` and `Hint` diagnostics (I think the only real difference in VS Code is the colour)

@aryairani  requested this, it was pretty easy to whip up when I needed a break from other stuff:

<img width="866" alt="image" src="https://github.com/unisonweb/unison/assets/6439644/0ae364f5-4cac-4e99-868f-b17c5fd549bd">


## Implementation notes

* Compares names in the file to conflicted names in the codebase, if we're editing a conflicted term, use the newly added definitions-span annotations to show an error at the binding site.
* Adds `fileDefLocations` and `getFileDefLocations` helpers for finding the locations of bindings in the file.

## Test coverage

Manual testing
