### PR TITLE
Generalize `causalHashAtPath` combinators for use in Share

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
@@ -235,7 +235,8 @@ loadRootCausalHash =
   runMaybeT $
     lift . Q.expectCausalHash =<< MaybeT Q.loadNamespaceRoot
 
--- | Load the causal hash at the given path from the root.
+-- | Load the causal hash at the given path from the provided root, if Nothing, use the
+-- codebase root.
 loadCausalHashAtPath :: Maybe CausalHash -> Q.TextPathSegments -> Transaction (Maybe CausalHash)
 loadCausalHashAtPath mayRootCausalHash =
   let go :: Db.CausalHashId -> [Text] -> MaybeT Transaction CausalHash
@@ -252,7 +253,8 @@ loadCausalHashAtPath mayRootCausalHash =
           Just rootCH -> Q.expectCausalHashIdByCausalHash rootCH
         runMaybeT (go hashId path)
 
--- | Expect the causal hash at the given path from the root.
+-- | Expect the causal hash at the given path from the provided root, if Nothing, use the
+-- codebase root.
 expectCausalHashAtPath :: Maybe CausalHash -> Q.TextPathSegments -> Transaction CausalHash
 expectCausalHashAtPath mayRootCausalHash =
   let go :: Db.CausalHashId -> [Text] -> Transaction CausalHash

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
@@ -238,7 +238,7 @@ pushLooseCodeToShareLooseCode localPath remote@WriteShareRemoteNamespace {server
   _ <- ensureAuthenticatedWithCodeserver codeserver
 
   localCausalHash <-
-    Cli.runTransaction (Ops.loadCausalHashAtPath (pathToSegments (Path.unabsolute localPath))) & onNothingM do
+    Cli.runTransaction (Ops.loadCausalHashAtPath Nothing (pathToSegments (Path.unabsolute localPath))) & onNothingM do
       Cli.returnEarly (EmptyLooseCodePush (Path.absoluteToPath' localPath))
 
   let checkAndSetPush :: Maybe Hash32 -> Cli (Maybe Int)
@@ -802,7 +802,7 @@ expectProjectAndBranch (ProjectAndBranch projectId branchId) =
 -- Get the causal hash to push at the given path. Return Nothing if there's no history.
 loadCausalHashToPush :: Path.Absolute -> Sqlite.Transaction (Maybe Hash32)
 loadCausalHashToPush path =
-  Operations.loadCausalHashAtPath segments <&> \case
+  Operations.loadCausalHashAtPath Nothing segments <&> \case
     Nothing -> Nothing
     Just (CausalHash hash) -> Just (Hash32.fromHash hash)
   where


### PR DESCRIPTION
## Overview

Used in https://github.com/unisoncomputing/enlil/pull/298

Everything on Share has now moved to explicitly stating which codebase root to use for a given operation, so most general operators should now allow specifying an alternate code root for convenience, and also to make the caller think about which root they actually want to be using.

## Implementation notes

* Edit `loadCausalHashAtPath` and `expectCausalHashAtPath` to allow specifying an explicit root causal hash if you desire.
* Edit call sites to pass `Nothing` to maintain existing behaviour, which is to use the codebase's namespace root