### PR TITLE
Add RNDF SQRT TANH TANF TZRO POPC to the jit

### DIFF
--- a/scheme-libs/racket/unison/math.rkt
+++ b/scheme-libs/racket/unison/math.rkt
@@ -127,13 +127,3 @@
         (if (eq? -1 bit)
             64
             bit)))
-
-; (do ((result 0 (+ result 1))
-;      (bits (if (fxnegative? fx)
-;                (fxnot fx)
-;                fx)
-;            (fxarithmetic-shift-right bits 1)))
-;     ((fxzero? bits)
-;      result))
-
-; fxfirst-bit-set

--- a/scheme-libs/racket/unison/math.rkt
+++ b/scheme-libs/racket/unison/math.rkt
@@ -15,6 +15,7 @@
     builtin-Int.*
     builtin-Int.pow
     builtin-Int.trailingZeros
+    builtin-Int.popCount
     builtin-Float.pow
  (prefix-out unison-POp-
              (combine-out
@@ -32,6 +33,7 @@
               TANH
               TANF
               TZRO
+              POPC
               ASNH
               ATAN
               ATN2
@@ -72,6 +74,7 @@
 (define-unison (builtin-Int.* n m) (* n m))
 (define-unison (builtin-Int.pow n m) (expt n m))
 (define-unison (builtin-Int.trailingZeros n) (TZRO n))
+(define-unison (builtin-Int.popCount n) (POPC n))
 (define-unison (builtin-Float.pow n m) (expt n m))
 (define (EXPF n) (exp n))
 (define ABSF abs)
@@ -113,6 +116,11 @@
 (define (EQLF a b) (if (= a b) 1 0))
 (define (LEQF a b) (if (<= a b) 1 0))
 (define (EQLI a b) (if (= a b) 1 0))
+
+(define (POPC n)
+    (if (< n 0)
+        (+ 65 (fxbit-count n))
+        (fxbit-count n)))
 
 (define (TZRO n)
     (let ([bit (fxfirst-bit-set n)])

--- a/scheme-libs/racket/unison/math.rkt
+++ b/scheme-libs/racket/unison/math.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
 (require math/base
+         rnrs/arithmetic/fixnums-6
          (only-in unison/boot data-case define-unison))
 
 (provide
@@ -8,9 +9,12 @@
     builtin-Float.log
     builtin-Float.max
     builtin-Float.min
+    builtin-Float.tan
+    builtin-Float.tanh
     builtin-Float.logBase
     builtin-Int.*
     builtin-Int.pow
+    builtin-Int.trailingZeros
     builtin-Float.pow
  (prefix-out unison-POp-
              (combine-out
@@ -23,6 +27,11 @@
               ASIN
               SINH
               TRNF
+              RNDF
+              SQRT
+              TANH
+              TANF
+              TZRO
               ASNH
               ATAN
               ATN2
@@ -58,8 +67,11 @@
 (define-unison (builtin-Float.log n) (log n))
 (define-unison (builtin-Float.max n m) (max n m))
 (define-unison (builtin-Float.min n m) (min n m))
+(define-unison (builtin-Float.tan n) (tan n))
+(define-unison (builtin-Float.tanh n) (tanh n))
 (define-unison (builtin-Int.* n m) (* n m))
 (define-unison (builtin-Int.pow n m) (expt n m))
+(define-unison (builtin-Int.trailingZeros n) (TZRO n))
 (define-unison (builtin-Float.pow n m) (expt n m))
 (define (EXPF n) (exp n))
 (define ABSF abs)
@@ -88,6 +100,10 @@
 (define FLOR floor)
 (define COSF cos)
 (define TRNF truncate)
+(define RNDF round)
+(define SQRT sqrt)
+(define TANF tan)
+(define TANH tanh)
 (define SINF sin)
 (define SINH sinh)
 (define COSH cosh)
@@ -97,3 +113,19 @@
 (define (EQLF a b) (if (= a b) 1 0))
 (define (LEQF a b) (if (<= a b) 1 0))
 (define (EQLI a b) (if (= a b) 1 0))
+
+(define (TZRO n)
+    (let ([bit (fxfirst-bit-set n)])
+        (if (eq? -1 bit)
+            64
+            bit)))
+
+; (do ((result 0 (+ result 1))
+;      (bits (if (fxnegative? fx)
+;                (fxnot fx)
+;                fx)
+;            (fxarithmetic-shift-right bits 1)))
+;     ((fxzero? bits)
+;      result))
+
+; fxfirst-bit-set

--- a/scheme-libs/racket/unison/primops.ss
+++ b/scheme-libs/racket/unison/primops.ss
@@ -45,6 +45,7 @@
     builtin-Int.toRepresentation
     builtin-Int.signum
     builtin-Int.trailingZeros
+    builtin-Int.popCount
     builtin-Nat.increment
     builtin-Nat.toFloat
     builtin-Text.indexOf
@@ -238,6 +239,7 @@
     unison-POp-TANH
     unison-POp-TANF
     unison-POp-TZRO
+    unison-POp-POPC
     unison-POp-ITOF
 
     unison-POp-ADDN

--- a/scheme-libs/racket/unison/primops.ss
+++ b/scheme-libs/racket/unison/primops.ss
@@ -31,6 +31,8 @@
     builtin-Float.log
     builtin-Float.max
     builtin-Float.min
+    builtin-Float.tan
+    builtin-Float.tanh
     builtin-Float.logBase
     builtin-Float.pow
     builtin-Int.pow
@@ -42,6 +44,7 @@
     builtin-Int.fromRepresentation
     builtin-Int.toRepresentation
     builtin-Int.signum
+    builtin-Int.trailingZeros
     builtin-Nat.increment
     builtin-Nat.toFloat
     builtin-Text.indexOf
@@ -230,6 +233,11 @@
     unison-POp-SINF
     unison-POp-SINH
     unison-POp-TRNF
+    unison-POp-RNDF
+    unison-POp-SQRT
+    unison-POp-TANH
+    unison-POp-TANF
+    unison-POp-TZRO
     unison-POp-ITOF
 
     unison-POp-ADDN

--- a/unison-src/builtin-tests/math-tests.u
+++ b/unison-src/builtin-tests/math-tests.u
@@ -60,3 +60,10 @@ math.tests = do
     checkEqual "TZRO +1" (Int.trailingZeros +1) 0
     checkEqual "TZRO +16777216" (Int.trailingZeros +16777216) 24
     checkEqual "TZRO 2^59" (Int.trailingZeros (Int.pow +2 59)) 59
+    checkEqual "POPC +16777215" (Int.popCount +16777215) 24
+    checkEqual "POPC +5" (Int.popCount +5) 2
+    checkEqual "POPC -5" (Int.popCount -5) 63
+    checkEqual "POPC -1" (Int.popCount -1) 64
+    checkEqual "POPC -1234567891" (Int.popCount -1234567891) 52
+    checkEqual "POPC -1111111111" (Int.popCount -1111111111) 50
+

--- a/unison-src/builtin-tests/math-tests.u
+++ b/unison-src/builtin-tests/math-tests.u
@@ -22,10 +22,13 @@ math.tests = do
     checkCloseEnough "atan 1.0" (atan 1.0) 0.7853981633974483
     checkCloseEnough "atan2 1.0 2.0" (atan2 1.0 2.0) 0.46364760900080615
     checkCloseEnough "atanh 0.5" (atanh 0.5) 0.5493061443340549
+    checkCloseEnough "tan 0.5" (tan 0.5) 0.5463024898437905
+    checkCloseEnough "tanh 0.5" (tanh 0.5) 0.46211715726000974
     checkCloseEnough "ceiling 0.1" (ceiling 0.1) 1.0
     checkCloseEnough "ceiling 0.9" (ceiling 0.9) 1.0
     checkCloseEnough "floor 0.9" (floor 0.9) 0.0
     checkCloseEnough "floor 1.9" (floor 1.9) 1.0
+    checkCloseEnough "rndf" (round 1.9) 2.0
     checkCloseEnough "divf" (1.2 / 3.4) 0.35294117647058826
     checkEqual "maxf" (Float.max 1.2 1.23) 1.23
     checkEqual "minf" (Float.min 1.2 1.23) 1.2
@@ -52,3 +55,8 @@ math.tests = do
     checkEqual "inci" (Int.increment +10) +11
     checkEqual "incn" (Nat.increment 10) 11
     checkCloseEnough "expf" (Float.exp 2.0) 7.3890560989306
+
+    checkEqual "TZRO +0" (Int.trailingZeros +0) 64
+    checkEqual "TZRO +1" (Int.trailingZeros +1) 0
+    checkEqual "TZRO +16777216" (Int.trailingZeros +16777216) 24
+    checkEqual "TZRO 2^59" (Int.trailingZeros (Int.pow +2 59)) 59


### PR DESCRIPTION
## Summary:
While testing TZRO I discovered that racket's fixnums (at least in the version I've got,
v8.7 [cs]) are a lot smaller than than unison's `Int`s.
`(greatest-fixnum)` is `1152921504606846975`
but `Int.maxInt` is `9223372036854775807`