### PR TITLE
Ensure `TVar` values can be compared for equality

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Foreign.hs
+++ b/parser-typechecker/src/Unison/Runtime/Foreign.hs
@@ -20,6 +20,7 @@ module Unison.Runtime.Foreign
 where
 
 import Control.Concurrent (MVar, ThreadId)
+import Control.Concurrent.STM (TVar)
 import Crypto.Hash qualified as Hash
 import Data.IORef (IORef)
 import Data.Primitive (ByteArray, MutableArray, MutableByteArray)
@@ -71,6 +72,10 @@ bytesCmp l r = compare l r
 mvarEq :: MVar () -> MVar () -> Bool
 mvarEq l r = l == r
 {-# NOINLINE mvarEq #-}
+
+tvarEq :: TVar () -> TVar () -> Bool
+tvarEq l r = l == r
+{-# NOINLINE tvarEq #-}
 
 socketEq :: Socket -> Socket -> Bool
 socketEq l r = l == r
@@ -150,6 +155,7 @@ ref2eq r
   -- matter what type the MVar holds.
   | r == Ty.mvarRef = Just $ promote mvarEq
   -- Ditto
+  | r == Ty.tvarRef = Just $ promote tvarEq
   | r == Ty.socketRef = Just $ promote socketEq
   | r == Ty.refRef = Just $ promote refEq
   | r == Ty.threadIdRef = Just $ promote tidEq


### PR DESCRIPTION
## Overview

This change fixes #4221, following the precedent set by `MVar` and others of deferring to the default `Eq` implementation and just checking identity.

## Test coverage

I haven't added any test coverage as part of this change. I don't see a lot in the way of comparable coverage for other types, and this doesn't seem like something that's suuuper likely to regress now that it's fixed, but I'm happy to go add a test somewhere if it's desired.