### PR TITLE
Include constructors in labeled deps of decls rendering docs

### DIFF
--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -374,10 +374,10 @@ typeLookupForDependencies codebase s = do
           getTypeDeclaration codebase id >>= \case
             Just (Left ed) ->
               let z = tl <> TypeLookup mempty mempty (Map.singleton ref ed)
-               in depthFirstAccum z (DD.dependencies $ DD.toDataDecl ed)
+               in depthFirstAccum z (DD.typeDependencies $ DD.toDataDecl ed)
             Just (Right dd) ->
               let z = tl <> TypeLookup mempty (Map.singleton ref dd) mempty
-               in depthFirstAccum z (DD.dependencies dd)
+               in depthFirstAccum z (DD.typeDependencies dd)
             Nothing -> pure tl
     go tl Reference.Builtin {} = pure tl -- codebase isn't consulted for builtins
     unseen :: TL.TypeLookup Symbol a -> Reference -> Bool

--- a/parser-typechecker/src/Unison/Codebase/CodeLookup.hs
+++ b/parser-typechecker/src/Unison/Codebase/CodeLookup.hs
@@ -64,9 +64,9 @@ transitiveDependencies code seen0 rid =
                   foldM
                     (transitiveDependencies code)
                     seen
-                    (getIds $ DD.dependencies (DD.toDataDecl ed))
+                    (getIds $ DD.typeDependencies (DD.toDataDecl ed))
                 Just (Right dd) ->
                   foldM
                     (transitiveDependencies code)
                     seen
-                    (getIds $ DD.dependencies dd)
+                    (getIds $ DD.typeDependencies dd)

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -339,7 +339,7 @@ putTypeDeclaration_ ::
   Transaction ()
 putTypeDeclaration_ declBuffer (Reference.Id h i) decl = do
   BufferEntry size comp missing waiting <- Sqlite.unsafeIO (getBuffer declBuffer h)
-  let declDependencies = Set.toList $ Decl.declDependencies decl
+  let declDependencies = Set.toList $ Decl.declTypeDependencies decl
   let size' = max size (Just $ biggestSelfReference + 1)
         where
           biggestSelfReference =

--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -47,7 +47,7 @@ import Unison.Codebase.MainTerm (builtinMain, builtinTest)
 import Unison.Codebase.Runtime (Error, Runtime (..))
 import Unison.ConstructorReference (ConstructorReference, GConstructorReference (..))
 import Unison.ConstructorReference qualified as RF
-import Unison.DataDeclaration (Decl, declDependencies, declFields)
+import Unison.DataDeclaration (Decl, declFields, declTypeDependencies)
 import Unison.Hashing.V2.Convert qualified as Hashing
 import Unison.LabeledDependency qualified as RF
 import Unison.Parser.Ann (Ann (External))
@@ -161,7 +161,7 @@ recursiveDeclDeps seen0 cl d = do
     _ -> pure mempty
   pure $ (deps, mempty) <> fold rec
   where
-    deps = declDependencies d
+    deps = declTypeDependencies d
     newDeps = Set.filter (\r -> notMember (RF.typeRef r) seen0) deps
     seen = seen0 <> Set.map RF.typeRef deps
 

--- a/parser-typechecker/src/Unison/UnisonFile.hs
+++ b/parser-typechecker/src/Unison/UnisonFile.hs
@@ -286,8 +286,8 @@ termSignatureExternalLabeledDependencies
 -- load information about these dependencies before starting typechecking.
 dependencies :: (Monoid a, Var v) => UnisonFile v a -> Set Reference
 dependencies (UnisonFile ds es ts ws) =
-  foldMap (DD.dependencies . snd) ds
-    <> foldMap (DD.dependencies . DD.toDataDecl . snd) es
+  foldMap (DD.typeDependencies . snd) ds
+    <> foldMap (DD.typeDependencies . DD.toDataDecl . snd) es
     <> foldMap (Term.dependencies . view _3) ts
     <> foldMap (foldMap (Term.dependencies . view _3)) ws
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1904,7 +1904,7 @@ handleDependencies hq = do
               Codebase.getTypeDeclaration codebase i <&> \case
                 Nothing -> error $ "What happened to " ++ show i ++ "?"
                 Just decl ->
-                  Set.map LabeledDependency.TypeReference . Set.delete r . DD.dependencies $
+                  Set.map LabeledDependency.TypeReference . Set.delete r . DD.typeDependencies $
                     DD.asDataDecl decl
             tp _ = pure mempty
             tm r@(Referent.Ref (Reference.DerivedId i)) =

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/NamespaceDependencies.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/NamespaceDependencies.hs
@@ -44,7 +44,7 @@ namespaceDependencies codebase branch = do
     for (Map.toList currentBranchTypeRefs) $ \(typeRef, names) -> fmap (fromMaybe Map.empty) . runMaybeT $ do
       refId <- MaybeT . pure $ Reference.toId typeRef
       decl <- MaybeT $ Codebase.getTypeDeclaration codebase refId
-      let typeDeps = Set.map LD.typeRef $ DD.dependencies (DD.asDataDecl decl)
+      let typeDeps = Set.map LD.typeRef $ DD.typeDependencies (DD.asDataDecl decl)
       pure $ foldMap (`Map.singleton` names) typeDeps
 
   termDeps <- for (Map.toList currentBranchTermRefs) $ \(termRef, names) -> fmap (fromMaybe Map.empty) . runMaybeT $ do

--- a/unison-cli/src/Unison/Codebase/Editor/SlurpComponent.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/SlurpComponent.hs
@@ -113,7 +113,7 @@ closeWithDependencies uf inputs = seenDefns {ctors = constructorDeps}
       dd <-
         fmap snd (Map.lookup v (UF.dataDeclarations' uf))
           <|> fmap (DD.toDataDecl . snd) (Map.lookup v (UF.effectDeclarations' uf))
-      pure $ foldl' typeDeps (Set.insert v seen) (resolveTypes $ DD.dependencies dd)
+      pure $ foldl' typeDeps (Set.insert v seen) (resolveTypes $ DD.typeDependencies dd)
 
     resolveTypes :: Set Reference -> [Symbol]
     resolveTypes rs = [v | r <- Set.toList rs, Just v <- [Map.lookup r typeNames]]

--- a/unison-cli/src/Unison/Codebase/Editor/TodoOutput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/TodoOutput.hs
@@ -50,9 +50,9 @@ labeledDependencies TodoOutput {..} =
            ]
         <>
         -- and decls of type refs
-        [ LD.typeRef r | (_, UserObject d) <- snd todoFrontier, r <- toList (DD.declDependencies d)
+        [ labeledDep | (declRef, UserObject d) <- snd todoFrontier, labeledDep <- toList (DD.labeledDeclDependenciesIncludingSelf declRef d)
         ]
-        <> [ LD.typeRef r | (_, _, UserObject d) <- snd todoFrontierDependents, r <- toList (DD.declDependencies d)
+        <> [ labeledDep | (_, declRef, UserObject d) <- snd todoFrontierDependents, labeledDep <- toList (DD.labeledDeclDependenciesIncludingSelf declRef d)
            ]
     )
     <>

--- a/unison-share-api/src/Unison/Server/Doc.hs
+++ b/unison-share-api/src/Unison/Server/Doc.hs
@@ -504,7 +504,7 @@ dependenciesSpecial = \case
         EvaluatedSrcDecl srcDecl -> case srcDecl of
           MissingDecl ref -> Set.singleton (LD.TypeReference ref)
           BuiltinDecl ref -> Set.singleton (LD.TypeReference ref)
-          FoundDecl ref decl -> Set.singleton (LD.TypeReference ref) <> DD.labeledDeclDependencies decl
+          FoundDecl ref decl -> Set.singleton (LD.TypeReference ref) <> DD.labeledDeclDependenciesIncludingSelf ref decl
         EvaluatedSrcTerm srcTerm -> case srcTerm of
           MissingTerm ref -> Set.singleton (LD.TermReference ref)
           BuiltinTypeSig ref _ -> Set.singleton (LD.TermReference ref)

--- a/unison-share-api/src/Unison/Server/SearchResult'.hs
+++ b/unison-share-api/src/Unison/Server/SearchResult'.hs
@@ -74,4 +74,4 @@ labeledDependencies = \case
   Tm' (TermResult' _ t r _) ->
     Set.insert (LD.referent r) $ maybe mempty (Set.map LD.typeRef . Type.dependencies) t
   Tp' (TypeResult' _ d r _) ->
-    Set.map LD.typeRef . Set.insert r $ maybe mempty DD.declDependencies (DT.toMaybe d)
+    maybe mempty (DD.labeledDeclDependenciesIncludingSelf r) (DT.toMaybe d)


### PR DESCRIPTION
## Overview

Cody discovered decl constructor names on share were rendered with hashes, but only when rendered in docs, e.g. 

<img width="739" alt="image" src="https://github.com/unisonweb/unison/assets/6439644/cd752f47-d497-4d3b-9b5c-43cbbce403c7">

This is because in the doc dependencies calculation we were just calling the combinator that only returned the _type_ dependencies, not the term-level constructors.

While I was at it I renamed some of the combinators to improve clarity and found a couple other spots this mistake was happening in the process.

## Implementation notes

Easy fix, just use the combinator that includes constructors.

# Test coverage

* [ ] Test locally