### PR TITLE
Add Lazy.nvim installation notes

### DIFF
--- a/docs/language-server.markdown
+++ b/docs/language-server.markdown
@@ -54,6 +54,22 @@ or [Plug](https://github.com/junegunn/vim-plug):
 Plug 'unisonweb/unison', { 'branch': 'trunk', 'rtp': 'editor-support/vim' }
 ```
 
+or [Lazy](https://github.com/folke/lazy.nvim/):
+
+```lua
+{
+  "unisonweb/unison",
+  branch = "trunk",
+  config = function(plugin)
+      vim.opt.rtp:append(plugin.dir .. "/editor-support/vim")
+      require("lazy.core.loader").packadd(plugin.dir .. "/editor-support/vim")
+  end,
+  init = function(plugin)
+       require("lazy.core.loader").ftdetect(plugin.dir .. "/editor-support/vim")
+  end,
+}
+```
+
 Configuration for [coc-nvim](https://github.com/neoclide/coc.nvim), enter the following in the relevant place of your CocConfig
 
 ```


### PR DESCRIPTION
## Overview

[lazy.nvim](https://github.com/folke/lazy.nvim/) is the thing for NeoVim these days, but setup is [quite convoluted](https://github.com/folke/lazy.nvim/issues/183#issuecomment-1376469054) due the fact the plugin is in subdirectory. This PR gives the full config snippet. 

## Implementation notes

Just docs.

## Interesting/controversial decisions

I'm also doing the same for website, it misses the whole NeoVim setup section.

## Loose ends

Once https://github.com/vim/vim/pull/12715 is merged, NeoVim will pull those changes and dedicated setup won't be necessary anymore.