### PR TITLE
Improve error message for missing result of block

### DIFF
--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -609,6 +609,21 @@ renderTypeError e env src curPath = case e of
     Pr.hang
       "This case would be ignored because it's already covered by the preceding case(s):"
       (annotatedAsErrorSite src loc)
+  UnknownTerm {..}
+    | Var.typeOf unknownTermV == Var.MissingResult ->
+        mconcat
+          [ "The last statement of a block must be an expression, ",
+            "but this is a definition:\n\n",
+            annotatedAsErrorSite src termSite,
+            "\nI don't know what the result of this block should be.\n",
+            "Did you forget to add an expression at the end of the block?\n",
+            case expectedType of
+              Type.Var' (TypeVar.Existential {}) -> "I don't know what type it should be either."
+              _ ->
+                "It should be of type "
+                  <> style Type1 (renderType' env expectedType)
+                  <> "."
+          ]
   UnknownTerm {..} ->
     let (correct, wrongTypes, wrongNames) =
           foldr sep id suggestions ([], [], [])

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -611,16 +611,16 @@ renderTypeError e env src curPath = case e of
       (annotatedAsErrorSite src loc)
   UnknownTerm {..}
     | Var.typeOf unknownTermV == Var.MissingResult ->
-    Pr.lines [ 
-      Pr.wrap "The last element of a block must be an expression, but this is a definition:", 
-      "",
-      annotatedAsErrorSite src termSite,
-      Pr.wrap $ "Try adding an expression at the end of the block." <> msg
-      ]
-      where
-        msg = case expectedType of
-          Type.Var' (TypeVar.Existential {}) -> mempty
-          _ -> Pr.wrap $ "It should be of type " <> Pr.group (style Type1 (renderType' env expectedType) <> ".")
+        Pr.lines
+          [ Pr.wrap "The last element of a block must be an expression, but this is a definition:",
+            "",
+            annotatedAsErrorSite src termSite,
+            Pr.wrap $ "Try adding an expression at the end of the block." <> msg
+          ]
+    where
+      msg = case expectedType of
+        Type.Var' (TypeVar.Existential {}) -> mempty
+        _ -> Pr.wrap $ "It should be of type " <> Pr.group (style Type1 (renderType' env expectedType) <> ".")
   UnknownTerm {..} ->
     let (correct, wrongTypes, wrongNames) =
           foldr sep id suggestions ([], [], [])

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -611,19 +611,16 @@ renderTypeError e env src curPath = case e of
       (annotatedAsErrorSite src loc)
   UnknownTerm {..}
     | Var.typeOf unknownTermV == Var.MissingResult ->
-        mconcat
-          [ "The last statement of a block must be an expression, ",
-            "but this is a definition:\n\n",
-            annotatedAsErrorSite src termSite,
-            "\nI don't know what the result of this block should be.\n",
-            "Did you forget to add an expression at the end of the block?\n",
-            case expectedType of
-              Type.Var' (TypeVar.Existential {}) -> "I don't know what type it should be either."
-              _ ->
-                "It should be of type "
-                  <> style Type1 (renderType' env expectedType)
-                  <> "."
-          ]
+    Pr.lines [ 
+      Pr.wrap "The last element of a block must be an expression, but this is a definition:", 
+      "",
+      annotatedAsErrorSite src termSite,
+      Pr.wrap $ "Try adding an expression at the end of the block." <> msg
+      ]
+      where
+        msg = case expectedType of
+          Type.Var' (TypeVar.Existential {}) -> mempty
+          _ -> Pr.wrap $ "It should be of type " <> Pr.group (style Type1 (renderType' env expectedType) <> ".")
   UnknownTerm {..} ->
     let (correct, wrongTypes, wrongNames) =
           foldr sep id suggestions ([], [], [])

--- a/parser-typechecker/src/Unison/Typechecker.hs
+++ b/parser-typechecker/src/Unison/Typechecker.hs
@@ -253,7 +253,7 @@ typeDirectedNameResolution ppe oldNotes oldType env = do
     suggest :: [Resolution v loc] -> Result (Notes v loc) ()
     suggest =
       traverse_
-        ( \(Resolution name inferredType loc v suggestions) ->
+        ( \(Resolution _ inferredType loc v suggestions) ->
             typeError $
               Context.ErrorNote
                 (Context.UnknownTerm loc v (dedupe suggestions) inferredType)

--- a/parser-typechecker/src/Unison/Typechecker.hs
+++ b/parser-typechecker/src/Unison/Typechecker.hs
@@ -164,6 +164,7 @@ data Resolution v loc = Resolution
   { resolvedName :: Text,
     inferredType :: Context.Type v loc,
     resolvedLoc :: loc,
+    v :: v,
     suggestions :: [Context.Suggestion v loc]
   }
 
@@ -252,10 +253,10 @@ typeDirectedNameResolution ppe oldNotes oldType env = do
     suggest :: [Resolution v loc] -> Result (Notes v loc) ()
     suggest =
       traverse_
-        ( \(Resolution name inferredType loc suggestions) ->
+        ( \(Resolution name inferredType loc v suggestions) ->
             typeError $
               Context.ErrorNote
-                (Context.UnknownTerm loc (Var.named name) (dedupe suggestions) inferredType)
+                (Context.UnknownTerm loc v (dedupe suggestions) inferredType)
                 []
         )
     guard x a = if x then Just a else Nothing
@@ -266,13 +267,14 @@ typeDirectedNameResolution ppe oldNotes oldType env = do
           name
           _
           loc
+          v
           ( filter Context.isExact ->
               [Context.Suggestion _ _ replacement Context.Exact]
             )
         ) =
         do
           modify (substBlank (Text.unpack name) loc solved)
-          lift . btw $ Context.Decision (Var.named name) loc solved
+          lift . btw $ Context.Decision v loc solved
         where
           solved = either (Term.var loc) (Term.fromReferent loc) replacement
     substSuggestion _ = pure ()
@@ -284,7 +286,7 @@ typeDirectedNameResolution ppe oldNotes oldType env = do
         go t = guard (ABT.annotation t == a) $ ABT.visitPure resolve t
         resolve (Term.Blank' (B.Recorded (B.Resolve loc name)))
           | name == s =
-              Just (const loc <$> r)
+              Just (loc <$ r)
         resolve _ = Nothing
 
     --  Returns Nothing for irrelevant notes
@@ -292,13 +294,15 @@ typeDirectedNameResolution ppe oldNotes oldType env = do
       Env v loc ->
       Context.InfoNote v loc ->
       Result (Notes v loc) (Maybe (Resolution v loc))
-    resolveNote env (Context.SolvedBlank (B.Resolve loc n) _ it) =
-      fmap (Just . Resolution (Text.pack n) it loc . dedupe . join)
+    resolveNote env (Context.SolvedBlank (B.Resolve loc n) v it) =
+      fmap (Just . Resolution (Text.pack n) it loc v . dedupe . join)
         . traverse (resolve it)
         . join
         . maybeToList
         . Map.lookup (Text.pack n)
         $ view termsByShortname env
+    resolveNote _ (Context.SolvedBlank (B.MissingResultPlaceholder loc) v it) =
+      pure . Just $ Resolution "_" it loc v []
     resolveNote _ n = btw n >> pure Nothing
     dedupe :: [Context.Suggestion v loc] -> [Context.Suggestion v loc]
     dedupe = uniqueBy Context.suggestionReplacement

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -1222,7 +1222,10 @@ synthesizeWanted e
   | Term.TermLink' _ <- e = pure (Type.termLink l, [])
   | Term.TypeLink' _ <- e = pure (Type.typeLink l, [])
   | Term.Blank' blank <- e = do
-      v <- freshenVar Var.blank
+      let freshType = case blank of
+            B.Recorded (B.MissingResultPlaceholder _) -> Var.missingResult
+            _ -> Var.blank
+      v <- freshenVar freshType
       appendContext [Var (TypeVar.Existential blank v)]
       pure (existential' l blank v, [])
   | Term.List' v <- e = do

--- a/unison-core/src/Unison/Blank.hs
+++ b/unison-core/src/Unison/Blank.hs
@@ -5,6 +5,7 @@ import Unison.Prelude
 loc :: Recorded loc -> loc
 loc (Placeholder loc _) = loc
 loc (Resolve loc _) = loc
+loc (MissingResultPlaceholder loc) = loc
 
 nameb :: Blank loc -> Maybe String
 nameb (Recorded (Placeholder _ n)) = Just n
@@ -15,7 +16,12 @@ data Recorded loc
   = -- A user-provided named placeholder
     Placeholder loc String
   | -- A name to be resolved with type-directed name resolution.
-    Resolve loc String
+    Resolve
+      loc
+      String
+  | -- A missing result placeholder
+    MissingResultPlaceholder
+      loc
   deriving (Show, Eq, Ord, Functor, Generic)
 
 data Blank loc = Blank | Recorded (Recorded loc)

--- a/unison-core/src/Unison/Blank.hs
+++ b/unison-core/src/Unison/Blank.hs
@@ -19,7 +19,7 @@ data Recorded loc
     Resolve
       loc
       String
-  | -- A missing result placeholder
+  | -- A placeholder for a missing result at the end of a block
     MissingResultPlaceholder
       loc
   deriving (Show, Eq, Ord, Functor, Generic)

--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -218,7 +218,9 @@ prepareTDNR t = fmap fst . ABT.visitPure f $ ABT.annotateBound t
   where
     f (ABT.Term _ (a, bound) (ABT.Var v))
       | Set.notMember v bound =
-          Just $ resolve (a, bound) a (Text.unpack $ Var.name v)
+          if Var.typeOf v == Var.MissingResult
+            then Just $ missingResult (a, bound) a
+            else Just $ resolve (a, bound) a (Text.unpack $ Var.name v)
     f _ = Nothing
 
 amap :: (Ord v) => (a -> a2) -> Term v a -> Term v a2
@@ -801,6 +803,9 @@ placeholder a s = ABT.tm' a . Blank $ B.Recorded (B.Placeholder a s)
 
 resolve :: (Ord v) => at -> ab -> String -> Term2 vt ab ap v at
 resolve at ab s = ABT.tm' at . Blank $ B.Recorded (B.Resolve ab s)
+
+missingResult :: (Ord v) => at -> ab -> Term2 vt ab ap v at
+missingResult at ab = ABT.tm' at . Blank $ B.Recorded (B.MissingResultPlaceholder ab)
 
 constructor :: (Ord v) => a -> ConstructorReference -> Term2 vt at ap v a
 constructor a ref = ABT.tm' a (Constructor ref)
@@ -1589,6 +1594,7 @@ instance (Show v, Show a) => Show (F v a0 p a) where
         B.Blank -> s "_"
         B.Recorded (B.Placeholder _ r) -> s ("_" ++ r)
         B.Recorded (B.Resolve _ r) -> s r
+        B.Recorded (B.MissingResultPlaceholder _) -> s "_"
       go _ (Ref r) = s "Ref(" <> shows r <> s ")"
       go _ (TermLink r) = s "TermLink(" <> shows r <> s ")"
       go _ (TypeLink r) = s "TypeLink(" <> shows r <> s ")"

--- a/unison-hashing-v2/src/Unison/Hashing/V2/Term.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/Term.hs
@@ -162,8 +162,7 @@ instance (Var v) => Hashable1 (TermF v a p) where
                         [tag 1, Hashable.Text (Text.pack s)]
                       B.Recorded (B.Resolve _ s) ->
                         [tag 2, Hashable.Text (Text.pack s)]
-                      B.Recorded (B.MissingResultPlaceholder _) ->
-                        [tag 3, Hashable.Text (Text.pack "_")]
+                      B.Recorded (B.MissingResultPlaceholder _) -> [tag 247]
                   TermRef (ReferenceBuiltin name) -> [tag 2, accumulateToken name]
                   TermApp a a2 -> [tag 3, hashed (hash a), hashed (hash a2)]
                   TermAnn a t -> [tag 4, hashed (hash a), hashed (ABT.hash t)]

--- a/unison-hashing-v2/src/Unison/Hashing/V2/Term.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/Term.hs
@@ -162,7 +162,7 @@ instance (Var v) => Hashable1 (TermF v a p) where
                         [tag 1, Hashable.Text (Text.pack s)]
                       B.Recorded (B.Resolve _ s) ->
                         [tag 2, Hashable.Text (Text.pack s)]
-                      B.Recorded (B.MissingResultPlaceholder _) -> [tag 247]
+                      B.Recorded (B.MissingResultPlaceholder _) -> [tag 3]
                   TermRef (ReferenceBuiltin name) -> [tag 2, accumulateToken name]
                   TermApp a a2 -> [tag 3, hashed (hash a), hashed (hash a2)]
                   TermAnn a t -> [tag 4, hashed (hash a), hashed (ABT.hash t)]

--- a/unison-hashing-v2/src/Unison/Hashing/V2/Term.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/Term.hs
@@ -162,6 +162,8 @@ instance (Var v) => Hashable1 (TermF v a p) where
                         [tag 1, Hashable.Text (Text.pack s)]
                       B.Recorded (B.Resolve _ s) ->
                         [tag 2, Hashable.Text (Text.pack s)]
+                      B.Recorded (B.MissingResultPlaceholder _) ->
+                        [tag 3, Hashable.Text (Text.pack "_")]
                   TermRef (ReferenceBuiltin name) -> [tag 2, accumulateToken name]
                   TermApp a a2 -> [tag 3, hashed (hash a), hashed (hash a2)]
                   TermAnn a t -> [tag 4, hashed (hash a), hashed (ABT.hash t)]

--- a/unison-src/transcripts/errors/missing-result-typed.md
+++ b/unison-src/transcripts/errors/missing-result-typed.md
@@ -1,0 +1,13 @@
+
+### Transcript parser hidden errors
+
+When an error is encountered in a `unison:hide:all` block
+then the transcript parser should print the stanza
+and surface a helpful message.
+
+```unison:hide:all
+a : ##Nat
+a = 
+  b = 24
+```
+

--- a/unison-src/transcripts/errors/missing-result-typed.md
+++ b/unison-src/transcripts/errors/missing-result-typed.md
@@ -5,8 +5,12 @@ When an error is encountered in a `unison:hide:all` block
 then the transcript parser should print the stanza
 and surface a helpful message.
 
+```ucm:hide
+.> builtins.merge
+```
+
 ```unison:hide:all
-a : ##Nat
+a : Nat
 a = 
   b = 24
 ```

--- a/unison-src/transcripts/errors/missing-result-typed.output.md
+++ b/unison-src/transcripts/errors/missing-result-typed.output.md
@@ -6,7 +6,7 @@ then the transcript parser should print the stanza
 and surface a helpful message.
 
 ```unison
-a : ##Nat
+a : Nat
 a = 
   b = 24
 ```
@@ -18,9 +18,11 @@ a =
 The transcript failed due to an error in the stanza above. The error is:
 
 
-  I couldn't find a type for ##Nat.
+  The last statement of a block must be an expression, but this is a definition:
   
-      1 | a : ##Nat
+      3 |   b = 24
   
-  Make sure it's spelled correctly.
+  I don't know what the result of this block should be.
+  Did you forget to add an expression at the end of the block?
+  It should be of type Nat.
 

--- a/unison-src/transcripts/errors/missing-result-typed.output.md
+++ b/unison-src/transcripts/errors/missing-result-typed.output.md
@@ -1,0 +1,26 @@
+
+### Transcript parser hidden errors
+
+When an error is encountered in a `unison:hide:all` block
+then the transcript parser should print the stanza
+and surface a helpful message.
+
+```unison
+a : ##Nat
+a = 
+  b = 24
+```
+
+
+
+🛑
+
+The transcript failed due to an error in the stanza above. The error is:
+
+
+  I couldn't find a type for ##Nat.
+  
+      1 | a : ##Nat
+  
+  Make sure it's spelled correctly.
+

--- a/unison-src/transcripts/errors/missing-result.md
+++ b/unison-src/transcripts/errors/missing-result.md
@@ -10,9 +10,3 @@ x =
   y = 24
 ```
 
-```unison:hide:all
-a : ##Nat
-a = 
-  b = 24
-```
-

--- a/unison-src/transcripts/errors/missing-result.md
+++ b/unison-src/transcripts/errors/missing-result.md
@@ -1,0 +1,12 @@
+
+### Transcript parser hidden errors
+
+When an error is encountered in a `unison:hide:all` block
+then the transcript parser should print the stanza
+and surface a helpful message.
+
+```unison:hide:all
+x = 
+  y = 24
+```
+

--- a/unison-src/transcripts/errors/missing-result.md
+++ b/unison-src/transcripts/errors/missing-result.md
@@ -10,3 +10,9 @@ x =
   y = 24
 ```
 
+```unison:hide:all
+a : ##Nat
+a = 
+  b = 24
+```
+

--- a/unison-src/transcripts/errors/missing-result.output.md
+++ b/unison-src/transcripts/errors/missing-result.output.md
@@ -1,0 +1,27 @@
+
+### Transcript parser hidden errors
+
+When an error is encountered in a `unison:hide:all` block
+then the transcript parser should print the stanza
+and surface a helpful message.
+
+```unison
+x = 
+  y = 24
+```
+
+
+
+🛑
+
+The transcript failed due to an error in the stanza above. The error is:
+
+
+  The last statement of a block must be an expression, but this is a definition:
+  
+      2 |   y = 24
+  
+  I don't know what the result of this block should be.
+  Did you forget to add an expression at the end of the block?
+  I don't know what type it should be either.
+


### PR DESCRIPTION
This PR introduces changes to how the Unison typechecker handles and reports the error case where the user forgets to add an expression to the end of a block.

Fixes #4077 

## File Changes

`parser-typechecker/src/Unison/PrintError.hs`
Improved the error messages that are returned when the last statement of a block is a definition rather than an expression. The message now includes the term causing the error and suggestions on what type it should be.

`parser-typechecker/src/Unison/Typechecker.hs`
Introduced the variable `v` in the Resolution data structure for improved error reporting. The `suggest` and `resolveNote` functions are updated accordingly to handle the new field.

`unison-core/src/Unison/Blank.hs`
Added a new `MissingResultPlaceholder` type to the `Recorded` data structure.

`unison-core/src/Unison/Term.hs`
Included `missingResult` function to generate missing result placeholders and adjusted `prepareTDNR` to account for missing results.

`parser-typechecker/src/Unison/Typechecker/Context.hs`
Adjusted the synthesizeWanted function to consider the possibility of a `MissingResultPlaceholder`.

`unison-hashing-v2/src/Unison/Hashing/V2/Term.hs`
Updated the hashing functionality to consider the new `MissingResultPlaceholder`.

## Justification

These changes improve the clarity of error messages and allow the typechecker to handle cases where the last statement of a block is a definition instead of an expression. This PR improves the user experience by providing more detailed and helpful error messages.

## Tests

No new tests, but a transcript exercises this codepath and will highlight any regression here.

## Documentation

Added comments in the modified sections of the code.