### PR TITLE
Add github action to populate nix development cache

### DIFF
--- a/.github/workflows/nix-dev-cache.yaml
+++ b/.github/workflows/nix-dev-cache.yaml
@@ -1,0 +1,33 @@
+name: Nix development cache
+
+on:
+  # Build on every pull request (and new PR commit)
+  pull_request:
+  # Build on new pushes to trunk (E.g. Merge commits)
+  # Without the branch filter, each commit on a branch with a PR is triggered twice.
+  # See: https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662
+  push:
+    branches:
+      - trunk
+
+jobs:
+  nix:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Run each build to completion, regardless of if any have failed
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-20.04
+          - macOS-12
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v22
+    - uses: cachix/cachix-action@v12
+      with:
+        name: unison
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - name: build all packages and development shells
+      run: nix -L build --accept-flake-config --no-link --keep-going '.#all'
+

--- a/flake.nix
+++ b/flake.nix
@@ -163,5 +163,16 @@
           defaultPackage = flake.packages."unison-cli:exe:unison";
           inherit (pkgs) unison-project;
           inherit devShells localPackageNames;
+          packages = flake.packages // {
+            all = pkgs.symlinkJoin {
+              name = "all-packages";
+              paths =
+                let
+                  all-other-packages = builtins.attrValues (builtins.removeAttrs self.packages."${system}" [ "all" ]);
+                  devshell-inputs = builtins.concatMap (devShell: devShell.buildInputs ++ devShell.nativeBuildInputs) [ devShells.only-tools ];
+                in
+                all-other-packages ++ devshell-inputs;
+            };
+          };
         });
 }


### PR DESCRIPTION
## Overview

It's all in the title I think. Users of nix won't have to build things that CI has built.

## Loose ends

There aren't github action runners for aarch64-darwin right now, so only x86_64-linux and x86_64-darwin are built.

We should consider moving more github actions into a nix workflow in the future so that we don't duplicate building effort and we can simplify our action caching.


