### PR TITLE
Set cloud auth when logging into Share

### DIFF
--- a/unison-cli/src/Unison/Cloud/Codeserver.hs
+++ b/unison-cli/src/Unison/Cloud/Codeserver.hs
@@ -1,0 +1,25 @@
+module Unison.Cloud.Codeserver (defaultCloudAPI) where
+
+import Network.URI (parseURI)
+import System.IO.Unsafe (unsafePerformIO)
+import Unison.Prelude
+import Unison.Share.Types
+import UnliftIO.Environment (lookupEnv)
+
+-- | This is the URI where the cloud API is based.
+defaultCloudAPI :: CodeserverURI
+defaultCloudAPI = unsafePerformIO $ do
+  lookupEnv "UNISON_CLOUD_HOST" <&> \case
+    Nothing ->
+      CodeserverURI
+        { codeserverScheme = Https,
+          codeserverUserInfo = "",
+          codeserverRegName = "api.unison.cloud",
+          codeserverPort = Nothing,
+          codeserverPath = []
+        }
+    Just cloudHost ->
+      fromMaybe (error $ "Cloud Host is not a valid URI: " <> cloudHost) $ do
+        uri <- parseURI cloudHost
+        codeserverFromURI uri
+{-# NOINLINE defaultCloudAPI #-}

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -43,6 +43,7 @@ library
       Unison.Cli.TypeCheck
       Unison.Cli.UniqueTypeGuidLookup
       Unison.Cli.UnisonConfigUtils
+      Unison.Cloud.Codeserver
       Unison.Codebase.Editor.AuthorInfo
       Unison.Codebase.Editor.HandleInput
       Unison.Codebase.Editor.HandleInput.AuthLogin


### PR DESCRIPTION
## Overview

The issue at hand:
We want ucm to be able to authenticate with unison.cloud as easily as possible so that users can cloud.run and such.
Currently Share and Cloud are BOTH hosted within [api.unison-lang.org](http://api.unison-lang.org/) so they share the same credentials; but soon cloud will live at api.unison.cloud instead.
Ideally we won't require users to authenticate against cloud and share separately as that just seems like an unnecessary pain.

---

The approach:

When we go to save the Share token after a successful auth.login we simply save the same token for `api.unison.cloud` as well (or some override location from $UNISON_CLOUD_HOST).

This keep all the authenticated-http-client stuff working fine as-is, and is very easy to change in the future if needed since it still keeps separate credentials for cloud vs share, even though we're setting both of those credentials to the same token.

---

Other approaches considered:

* Require a separate `cloud.login` command or something like it
* Rig up the credentials manager to always hot-swap in the share credentials whenever we call to cloud (this is a bit messier to implement, but wouldn't be too bad)

## Implementation notes

Any time we save share credentials, also save those credentials for whatever the current cloud host is.

## Interesting/controversial decisions

Note that if you only override the cloud host, or the share host but not both you'll get into a bit of a weird credential situation with cloud where either it'll use local creds against production cloud or vice versa. This won't be a problem for any end users unless they're manually overriding these for some strange reason, but something for unison devs to be aware of. Easily fixed by setting the other override and re-authing, or removing all overrides and re-authing.

## Test coverage

* [ ] Test against the new cloud deployment before merging
