### PR TITLE
Term declarations should not allow hashes in the term name (typesig or term definition)

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -76,3 +76,4 @@ The format for this list: name, GitHub handle
 * Mario Bašić (@mabasic)
 * Chris Krycho (@chriskrycho)
 * Hatim Khambati (@hatimkhambati26)
+* Kyle Goetz (@kylegoetz)

--- a/parser-typechecker/src/Unison/Syntax/TermParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermParser.hs
@@ -985,7 +985,7 @@ infixAppOrBooleanOp = chainl1 term4 (or <|> and <|> infixApp)
 typedecl :: (Monad m, Var v) => P v m (L.Token v, Type v Ann)
 typedecl =
   (,)
-    <$> P.try (prefixDefinitionName <* reserved ":")
+    <$> P.try (prefixTermName <* reserved ":")
     <*> TypeParser.valueType
     <* semi
 
@@ -1053,8 +1053,8 @@ binding = label "binding" do
         arg2 <- prefixDefinitionName
         pure (ann arg1, op, [arg1, arg2])
   let prefixLhs = do
-        v <- prefixDefinitionName
-        vs <- many prefixDefinitionName
+        v <- prefixTermName
+        vs <- many prefixTermName
         pure (ann v, v, vs)
   let lhs :: P v m (Ann, L.Token v, [L.Token v])
       lhs = infixLhs <|> prefixLhs

--- a/unison-src/transcripts/no-hash-in-term-declaration.md
+++ b/unison-src/transcripts/no-hash-in-term-declaration.md
@@ -1,0 +1,8 @@
+# No Hashes in Term Declarations
+
+There should not be hashes in the names used in term declarations, either in the type signature or the type definition.
+
+```unison:hide:all:error
+x##Nat : Int -> Int -> Boolean
+x##Nat = 5
+```

--- a/unison-src/transcripts/no-hash-in-term-declaration.output.md
+++ b/unison-src/transcripts/no-hash-in-term-declaration.output.md
@@ -1,0 +1,4 @@
+# No Hashes in Term Declarations
+
+There should not be hashes in the names used in term declarations, either in the type signature or the type definition.
+

--- a/unison-syntax/src/Unison/Syntax/Parser.hs
+++ b/unison-syntax/src/Unison/Syntax/Parser.hs
@@ -31,6 +31,7 @@ module Unison.Syntax.Parser
     peekAny,
     positionalVar,
     prefixDefinitionName,
+    prefixTermName,
     queryToken,
     reserved,
     root,
@@ -299,7 +300,7 @@ prefixDefinitionName =
 
 -- Parse a prefix identifier e.g. Foo or (+), rejecting any hash
 -- This is useful for term declarations, where type signatures and term names should not have hashes.
-prefixTermName :: (Var v) => P v (L.Token v)
+prefixTermName :: (Var v) => P v m (L.Token v)
 prefixTermName = wordyTermName <|> parenthesize symbolyTermName
   where
     wordyTermName = queryToken $ \case

--- a/unison-syntax/src/Unison/Syntax/Parser.hs
+++ b/unison-syntax/src/Unison/Syntax/Parser.hs
@@ -297,6 +297,19 @@ prefixDefinitionName :: (Var v) => P v m (L.Token v)
 prefixDefinitionName =
   wordyDefinitionName <|> parenthesize symbolyDefinitionName
 
+-- Parse a prefix identifier e.g. Foo or (+), rejecting any hash
+-- This is useful for term declarations, where type signatures and term names should not have hashes.
+prefixTermName :: (Var v) => P v (L.Token v)
+prefixTermName = wordyTermName <|> parenthesize symbolyTermName
+  where
+    wordyTermName = queryToken $ \case
+      L.WordyId s Nothing -> Just $ Var.nameds s
+      L.Blank s -> Just $ Var.nameds ("_" <> s)
+      _ -> Nothing
+    symbolyTermName = queryToken $ \case
+      L.SymbolyId s Nothing -> Just $ Var.nameds s
+      _ -> Nothing
+
 -- Parse a wordy identifier e.g. Foo, discarding any hash
 wordyDefinitionName :: (Var v) => P v m (L.Token v)
 wordyDefinitionName = queryToken $ \case


### PR DESCRIPTION
## Overview

This PR fixes issue #4233. Without this, UCM/Unison did not have a problem with code that featured hashes in the names of type signatures and term definition. This PR errors when the same code is attempted.

There is also now a transcript test that verifies this code now results in an error:

```
x##Nat : Int -> Int -> Boolean
x##Nat = 5
```

previously resulted in no error (in, say, `release/M5a`). Now this transcript test fails if you replace `unison:hide:all:error` with just `unison` (which does not hide errors). Previously it would "fail" with a no-error success as no error would have occurred.

This fixes #4233.

## Implementation notes

In `Parser.hs` I created a new function, `prefixTermName :: (Var v) => P v (L.Token v)`, which errors if there is a hash. Then in `TermParser.hs`, I swapped out use of `prefixDefinitionName` for `prefixTermName`. The former merely discarded a hash rather than erroring out on one.

## Interesting/controversial decisions

I could have leveraged the existing `wordyIdString :: (Ord v) => P v m (L.Token String)` and `symbolyIdString :: (Ord v) => P v m (L.Token String)`, which also reject if there's a hash.

However, the type signature of these is `(Ord v) => P v m (L.Token String)`, while the function being replaced in code was type signature `(Var v) => P v (L.Token v)`. Not knowing downstream effects of changing the type signature here, I did not use either of the existing functions in my new `prefixTermName`, which internally uses new `wordyTermName` and `symbolyTermName`.

## Test coverage

I added a transcript test, located at `unison-src/transcripts/no-hash-in-term-declaration.md` plus the corresponding output `md` file.

I think this is adequate. Consider it a regression test, and if code changes to once again allow hashes in this place by mistake, `stack exec transcripts` should fail.