### PR TITLE
Remove Share paths from release flow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,10 +11,6 @@ on:
         description: 'Release Version (E.g. M4 or M4a)'
         required: true
         type: string
-      share_base_path:
-        description: 'Path to base version that UCM should pull by default (E.g. `unison.public.base.releases.M4`)'
-        required: true
-        type: string
       target:
         description: 'Ref to use for this release, defaults to trunk'
         required: true
@@ -61,8 +57,6 @@ jobs:
 
     name: "build_linux"
     runs-on: ubuntu-20.04
-    env:
-      UNISON_BASE_PATH: "${{inputs.share_base_path}}"
     steps:
       - uses: actions/checkout@v2
         with:
@@ -109,7 +103,7 @@ jobs:
 
       - name: build
         run: |
-          # unison-cli checks env vars for which base version to automatically pull,
+          # unison-cli embeds version numbers using TH
           # so it needs to be forced to rebuild to ensure those are updated.
           stack clean unison-cli
           stack --no-terminal build --flag unison-parser-typechecker:optimized
@@ -133,8 +127,6 @@ jobs:
   build_macos:
     name: "build_macos"
     runs-on: macos-12
-    env:
-      UNISON_BASE_PATH: "${{inputs.share_base_path}}"
     steps:
       - uses: actions/checkout@v2
         with:
@@ -184,7 +176,7 @@ jobs:
 
       - name: build
         run: |
-          # unison-cli checks env vars for which base version to automatically pull,
+          # unison-cli embeds version numbers using TH
           # so it needs to be forced to rebuild to ensure those are updated.
           stack clean unison-cli
           stack --no-terminal build --flag unison-parser-typechecker:optimized
@@ -208,9 +200,6 @@ jobs:
   build_windows:
     name: "build_windows"
     runs-on: windows-2019
-    env:
-      UNISON_BASE_PATH: "${{inputs.share_base_path}}"
-
     steps:
       - uses: actions/checkout@v2
         with:
@@ -257,7 +246,7 @@ jobs:
 
       - name: build
         run: |
-          # unison-cli checks env vars for which base version to automatically pull,
+          # unison-cli embeds version numbers using TH
           # so it needs to be forced to rebuild to ensure those are updated.
           stack clean unison-cli
 

--- a/scripts/make-release.sh
+++ b/scripts/make-release.sh
@@ -9,16 +9,15 @@ fi
 
 usage() {
     echo "NOTE: must be run from the root of the project."
-    echo "Usage: $0 VERSION SHARE_BASE_PATH [TARGET]"
+    echo "Usage: $0 VERSION [TARGET]"
     echo "VERSION: The version you're releasing, e.g. M4a"
-    echo "SHARE_BASE_PATH: Which base version to pull from share, e.g. 'unison.public.base.releases.M4'"
     echo "TARGET: The revision to make the release from, defaults to 'trunk'"
     echo ""
     echo "E.g."
     echo "$0 M4a"
 }
 
-if [[ -z "$1" || -z "$2" ]] ; then
+if [[ -z "$1" ]] ; then
   usage
   exit 1
 fi
@@ -36,8 +35,7 @@ fi
 
 version="${1}"
 prev_version=$(./scripts/previous-tag.sh "$version")
-share_base_path=${2}
-target=${3:-trunk}
+target=${2:-trunk}
 tag="release/${version}"
 
 echo "Creating release in unison-local-ui..."
@@ -46,7 +44,7 @@ gh release create "release/${version}" --repo unisonweb/unison-local-ui --target
 echo "Kicking off release workflow in unisonweb/unison"
 git tag "${tag}" "${target}"
 git push origin "${tag}"
-gh workflow run release --repo unisonweb/unison --field "version=${version}" --field "share_base_path=${share_base_path}"
+gh workflow run release --repo unisonweb/unison --field "version=${version}"
 
 echo "Kicking off Homebrew update task"
 gh workflow run release --repo unisonweb/homebrew-unison --field "version=${version}"


### PR DESCRIPTION
## Overview

UCM no longer needs a hard-coded base release, we just use the latest base release on Share.

This cleans up the release script to not require it anymore.

## Implementation notes

* Remove the argument from the script
* Remove the argument from the CI workflow

## Test coverage

I guess it'll be tested next time we need a release, which will probably be me later this week so I'll fix it up then if need be :)