### PR TITLE
remove cache.iog.io

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,8 @@
 {
   description = "Unison";
   nixConfig = {
-    extra-substituters = [ "https://cache.iog.io" "https://unison.cachix.org" ];
+    extra-substituters = [ "https://unison.cachix.org" ];
     extra-trusted-public-keys = [
-      "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
       "unison.cachix.org-1:i1DUFkisRPVOyLp/vblDsbsObmyCviq/zs6eRuzth3k="
     ];
   };


### PR DESCRIPTION
Some of the packages at https://cache.iog.io have invalid signatures for aarch64 macs. :-\

I opened https://github.com/input-output-hk/haskell.nix/issues/2018 about it.