### PR TITLE
Provide mechanism for hashing BranchFormatFull

### DIFF
--- a/codebase2/codebase-sqlite-hashing-v2/src/U/Codebase/Sqlite/V2/HashHandle.hs
+++ b/codebase2/codebase-sqlite-hashing-v2/src/U/Codebase/Sqlite/V2/HashHandle.hs
@@ -3,13 +3,16 @@ module U.Codebase.Sqlite.V2.HashHandle
   )
 where
 
+import Data.Function ((&))
 import Data.Set qualified as Set
 import U.Codebase.Branch.Hashing qualified as H2
 import U.Codebase.Causal.Hashing qualified as H2
+import U.Codebase.HashTags (BranchHash (..))
+import U.Codebase.Sqlite.Branch.Format qualified as BranchFormat
 import U.Codebase.Sqlite.HashHandle
 import U.Util.Type (removeAllEffectVars)
 import Unison.Hashing.V2 qualified as H2
-import Unison.Hashing.V2.Convert2 (h2ToV2Reference, v2ToH2Type, v2ToH2TypeD)
+import Unison.Hashing.V2.Convert2 (h2ToV2Reference, hashBranchFormatToH2Branch, v2ToH2Type, v2ToH2TypeD)
 
 v2HashHandle :: HashHandle
 v2HashHandle =
@@ -19,5 +22,10 @@ v2HashHandle =
       toReferenceDecl = \h -> h2ToV2Reference . H2.typeToReference . v2ToH2TypeD h . removeAllEffectVars,
       toReferenceDeclMentions = \h -> Set.map h2ToV2Reference . H2.typeToReferenceMentions . v2ToH2TypeD h . removeAllEffectVars,
       hashBranch = H2.hashBranch,
-      hashCausal = H2.hashCausal
+      hashCausal = H2.hashCausal,
+      hashBranchFormatFull = \localIds localBranch ->
+        BranchFormat.localToHashBranch localIds localBranch
+          & hashBranchFormatToH2Branch
+          & H2.contentHash
+          & BranchHash
     }

--- a/codebase2/codebase-sqlite-hashing-v2/src/Unison/Hashing/V2/Convert2.hs
+++ b/codebase2/codebase-sqlite-hashing-v2/src/Unison/Hashing/V2/Convert2.hs
@@ -4,6 +4,7 @@ module Unison.Hashing.V2.Convert2
     v2ToH2TypeD,
     h2ToV2Reference,
     v2ToH2Branch,
+    hashBranchFormatToH2Branch,
   )
 where
 
@@ -12,11 +13,12 @@ import Data.Set qualified as Set
 import U.Codebase.Branch qualified as V2
 import U.Codebase.Branch qualified as V2Branch
 import U.Codebase.Causal qualified as Causal
-import U.Codebase.HashTags (CausalHash (..), PatchHash (..))
+import U.Codebase.HashTags
 import U.Codebase.Kind qualified as V2
 import U.Codebase.Reference qualified as V2
 import U.Codebase.Reference qualified as V2Reference
 import U.Codebase.Referent qualified as V2Referent
+import U.Codebase.Sqlite.Branch.Full qualified as Memory.BranchFull
 import U.Codebase.Term qualified as V2 (TypeRef)
 import U.Codebase.Type qualified as V2.Type
 import U.Core.ABT qualified as ABT
@@ -93,3 +95,26 @@ v2ToH2MdValues (V2Branch.MdValues mdMap) =
     & Map.keysSet
     & Set.map v2ToH2Reference
     & H2.MdValues
+
+hashBranchFormatToH2Branch :: Memory.BranchFull.HashBranch -> H2.Branch
+hashBranchFormatToH2Branch Memory.BranchFull.Branch {terms, types, patches, children} =
+  H2.Branch
+    { terms =
+        terms
+          & Map.bimap H2.NameSegment (Map.bimap cvreferent cvMdValues),
+      types =
+        types
+          & Map.bimap H2.NameSegment (Map.bimap cvreference cvMdValues),
+      patches = patches & Map.bimap H2.NameSegment unPatchHash,
+      children = children & Map.bimap H2.NameSegment (unCausalHash . snd)
+    }
+  where
+    cvMdValues :: Memory.BranchFull.MetadataSetFormat' Text ComponentHash -> H2.MdValues
+    cvMdValues (Memory.BranchFull.Inline refSet) = H2.MdValues $ Set.map cvreference refSet
+    cvreference :: V2Reference.Reference' Text ComponentHash -> H2.Reference
+    cvreference = v2ToH2Reference . second unComponentHash
+    cvreferent :: Memory.BranchFull.Referent'' Text ComponentHash -> H2.Referent
+    cvreferent = \case
+      V2Referent.Ref ref -> (H2.ReferentRef (v2ToH2Reference $ second unComponentHash ref))
+      V2Referent.Con typeRef conId -> do
+        (H2.ReferentCon (v2ToH2Reference $ second unComponentHash typeRef) conId)

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Branch/Format.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Branch/Format.hs
@@ -16,6 +16,7 @@ where
 
 import Data.Vector (Vector)
 import Data.Vector qualified as Vector
+import U.Codebase.HashTags
 import U.Codebase.Sqlite.Branch.Diff (Diff, LocalDiff)
 import U.Codebase.Sqlite.Branch.Diff qualified as Branch.Diff
 import U.Codebase.Sqlite.Branch.Full (DbBranch, HashBranch, LocalBranch)
@@ -27,7 +28,6 @@ import U.Codebase.Sqlite.LocalIds
     LocalPatchObjectId (..),
     LocalTextId (..),
   )
-import Unison.Hash32 (Hash32)
 import Unison.Prelude
 
 -- | A 'BranchFormat' is a deserialized namespace object (@object.bytes@).
@@ -49,7 +49,7 @@ type BranchFormat = BranchFormat' TextId ObjectId PatchObjectId (BranchObjectId,
 
 -- | A BranchFormat which uses Hashes and Text for all its references, no
 -- Ids which are specific to a particular codebase.
-type HashBranchFormat = BranchFormat' Text Hash32 Hash32 (Hash32, Hash32) Hash32
+type HashBranchFormat = BranchFormat' Text ComponentHash PatchHash (BranchHash, CausalHash)
 
 -- = Full BranchLocalIds LocalBranch
 -- \| Diff BranchObjectId BranchLocalIds LocalDiff
@@ -60,7 +60,7 @@ type HashBranchFormat = BranchFormat' Text Hash32 Hash32 (Hash32, Hash32) Hash32
 -- local id 1 corresponds to database text id 74".
 type BranchLocalIds = BranchLocalIds' TextId ObjectId PatchObjectId (BranchObjectId, CausalHashId)
 
-type HashBranchLocalIds = BranchLocalIds' Text Hash32 Hash32 (Hash32, Hash32)
+type HashBranchLocalIds = BranchLocalIds' Text ComponentHash PatchHash (BranchHash, CausalHash)
 
 -- temp_entity
 --  branch #foo

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Branch/Format.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Branch/Format.hs
@@ -1,5 +1,6 @@
 module U.Codebase.Sqlite.Branch.Format
-  ( BranchFormat (..),
+  ( BranchFormat' (..),
+    BranchFormat,
     BranchLocalIds,
     BranchLocalIds' (..),
     SyncBranchFormat,
@@ -28,10 +29,36 @@ import Unison.Prelude
 -- | A 'BranchFormat' is a deserialized namespace object (@object.bytes@).
 --
 -- you can use the exact same `BranchLocalIds` when converting between `Full` and `Diff`
-data BranchFormat
-  = Full BranchLocalIds LocalBranch
-  | Diff BranchObjectId BranchLocalIds LocalDiff
+data
+  BranchFormat'
+    text
+    defRef
+    patchRef
+    childRef
+    branchRef
+    localText
+    localDefRef
+    localPatchRef
+    localChildRef
+  = Full (BranchLocalIds' text defRef patchRef childRef) (Branch.Full.Branch' localText localDefRef localPatchRef localChildRef)
+  | Diff branchRef (BranchLocalIds' text defRef patchRef childRef) (Branch.Diff.Diff' localText localDefRef localPatchRef localChildRef)
   deriving (Show)
+
+-- | The 'BranchFormat'' used to store a branch in Sqlite
+type BranchFormat =
+  BranchFormat'
+    TextId
+    ObjectId
+    PatchObjectId
+    (BranchObjectId, CausalHashId)
+    BranchObjectId
+    LocalTextId
+    LocalDefnId
+    LocalPatchObjectId
+    LocalBranchChildId
+
+-- = Full BranchLocalIds LocalBranch
+-- \| Diff BranchObjectId BranchLocalIds LocalDiff
 
 -- | A 'BranchLocalIds' is a mapping between local ids (local to this object) encoded as offsets, and actual database ids.
 --

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Branch/Format.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Branch/Format.hs
@@ -4,6 +4,7 @@ module U.Codebase.Sqlite.Branch.Format
     HashBranchFormat,
     BranchLocalIds,
     BranchLocalIds' (..),
+    HashBranchLocalIds,
     SyncBranchFormat,
     SyncBranchFormat' (..),
     LocalBranchBytes (..),

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Branch/Full.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Branch/Full.hs
@@ -15,6 +15,7 @@ import U.Codebase.Reference qualified as Reference
 import U.Codebase.Referent (Referent')
 import U.Codebase.Sqlite.DbId (BranchObjectId, CausalHashId, ObjectId, PatchObjectId, TextId)
 import U.Codebase.Sqlite.LocalIds (LocalBranchChildId, LocalDefnId, LocalPatchObjectId, LocalTextId)
+import Unison.Hash32 (Hash32)
 import Unison.Prelude
 import Unison.Util.Map qualified as Map
 import Unison.Util.Set qualified as Set
@@ -40,6 +41,8 @@ type LocalBranch = Branch' LocalTextId LocalDefnId LocalPatchObjectId LocalBranc
 --   }
 -- @
 type DbBranch = Branch' TextId ObjectId PatchObjectId (BranchObjectId, CausalHashId)
+
+type HashBranch = Branch' Text Hash32 Hash32 (Hash32, Hash32)
 
 type Referent'' t h = Referent' (Reference' t h) (Reference' t h)
 

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Branch/Full.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Branch/Full.hs
@@ -10,12 +10,12 @@ module U.Codebase.Sqlite.Branch.Full where
 import Control.Lens
 import Data.Map qualified as Map
 import Data.Set qualified as Set
+import U.Codebase.HashTags
 import U.Codebase.Reference (Reference')
 import U.Codebase.Reference qualified as Reference
 import U.Codebase.Referent (Referent')
 import U.Codebase.Sqlite.DbId (BranchObjectId, CausalHashId, ObjectId, PatchObjectId, TextId)
 import U.Codebase.Sqlite.LocalIds (LocalBranchChildId, LocalDefnId, LocalPatchObjectId, LocalTextId)
-import Unison.Hash32 (Hash32)
 import Unison.Prelude
 import Unison.Util.Map qualified as Map
 import Unison.Util.Set qualified as Set
@@ -42,7 +42,7 @@ type LocalBranch = Branch' LocalTextId LocalDefnId LocalPatchObjectId LocalBranc
 -- @
 type DbBranch = Branch' TextId ObjectId PatchObjectId (BranchObjectId, CausalHashId)
 
-type HashBranch = Branch' Text Hash32 Hash32 (Hash32, Hash32)
+type HashBranch = Branch' Text ComponentHash PatchHash (BranchHash, CausalHash)
 
 type Referent'' t h = Referent' (Reference' t h) (Reference' t h)
 

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/HashHandle.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/HashHandle.hs
@@ -6,6 +6,8 @@ where
 import U.Codebase.Branch.Type (Branch)
 import U.Codebase.HashTags
 import U.Codebase.Reference qualified as C
+import U.Codebase.Sqlite.Branch.Format (HashBranchLocalIds)
+import U.Codebase.Sqlite.Branch.Full (LocalBranch)
 import U.Codebase.Sqlite.Symbol (Symbol)
 import U.Codebase.Term qualified as C.Term
 import U.Codebase.Type qualified as C.Type
@@ -27,5 +29,9 @@ data HashHandle = HashHandle
       BranchHash ->
       -- The causal's parents
       Set CausalHash ->
-      CausalHash
+      CausalHash,
+    hashBranchFormatFull ::
+      HashBranchLocalIds ->
+      LocalBranch ->
+      BranchHash
   }

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -388,6 +388,9 @@ import Unison.Util.FileEmbed (embedProjectStringFile)
 import Unison.Util.Lens qualified as Lens
 import Unison.Util.Map qualified as Map
 
+debug :: Bool
+debug = False
+
 type TextPathSegments = [Text]
 
 -- * main squeeze

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Serialization.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Serialization.hs
@@ -1,6 +1,40 @@
 {-# LANGUAGE RecordWildCards #-}
 
-module U.Codebase.Sqlite.Serialization where
+module U.Codebase.Sqlite.Serialization
+  ( decomposeBranchFormat,
+    decomposeDeclFormat,
+    decomposePatchFormat,
+    decomposeTermFormat,
+    decomposeWatchFormat,
+    getBranchFormat,
+    getDeclElement,
+    getDeclFormat,
+    getPatchFormat,
+    getTempCausalFormat,
+    getTempDeclFormat,
+    getTempNamespaceFormat,
+    getTempPatchFormat,
+    getTempTermFormat,
+    getTermAndType,
+    getTermFormat,
+    getWatchResultFormat,
+    lookupDeclElement,
+    lookupTermElement,
+    lookupTermElementDiscardingTerm,
+    lookupTermElementDiscardingType,
+    putBranchFormat,
+    putDeclFormat,
+    putPatchFormat,
+    putTempEntity,
+    putTermFormat,
+    putWatchResultFormat,
+    recomposeBranchFormat,
+    recomposeDeclFormat,
+    recomposePatchFormat,
+    recomposeTermFormat,
+    recomposeWatchFormat,
+  )
+where
 
 import Data.Bits (Bits)
 import Data.ByteString qualified as BS

--- a/codebase2/core/U/Codebase/HashTags.hs
+++ b/codebase2/core/U/Codebase/HashTags.hs
@@ -2,6 +2,10 @@ module U.Codebase.HashTags where
 
 import Unison.Hash (Hash)
 
+-- | Represents a hash of a type or term component
+newtype ComponentHash = ComponentHash {unComponentHash :: Hash}
+  deriving stock (Eq, Ord, Show)
+
 newtype BranchHash = BranchHash {unBranchHash :: Hash} deriving (Eq, Ord)
 
 -- | Represents a hash of a causal containing values of the provided type.

--- a/unison-share-api/src/Unison/Sync/Types.hs
+++ b/unison-share-api/src/Unison/Sync/Types.hs
@@ -700,9 +700,9 @@ instance FromJSON HashMismatchForEntity where
     Aeson.withObject "HashMismatchForEntity" \obj ->
       HashMismatchForEntity
         <$> obj
-        .: "supplied"
+          .: "supplied"
         <*> obj
-        .: "computed"
+          .: "computed"
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Fast-forward path


### PR DESCRIPTION
## Overview

Pre-req for https://github.com/unisoncomputing/enlil/pull/314;

Generalizes how we deserialize BranchFormat's so I can deserialize entities from the Temp/Sync entity formats BEFORE saving them into the codebase (i.e. before we have object or db IDs)

This will allow Share to correctly validate hashes on branches before storing them into a user's codebase.

## Implementation notes

* Adds `hashBranchFormatFull` to HashHandle which produces a hash for a LocalBranch if provided hash references in a local ID mapping
* Generalizes BranchFormat types over the types in the LocalID mapping so we can talk about the types when they have Hashes there instead of object IDs.
* Adds `hashBranchFormatToH2Branch :: Memory.BranchFull.HashBranch -> HashingV2.Branch` internally to facilitate hashing branch formats.
* Adds a `ComponentHash` hash tag for hashes used in references/referents
* Tagged bytes in the BranchFormats with their encoding; took me a bit of digging to figure out what the bytes were last time, so nice to have that at the type level.

## Interesting/controversial decisions

Include anything that you thought twice about, debated, chose arbitrarily, etc.
What could have been done differently, but wasn't? And why?

## Test coverage

Tested locally as part of https://github.com/unisoncomputing/enlil/pull/314;
