### PR TITLE
Add -y when calling into racket

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -2651,7 +2651,7 @@ ensureSchemeExists =
         (ExitFailure _, _, _) -> pure False
 
 racketOpts :: FilePath -> FilePath -> [String] -> [String]
-racketOpts gendir statdir args = libs ++ args
+racketOpts gendir statdir args = "-y" : libs ++ args
   where
     includes = [gendir, statdir </> "racket"]
     libs = concatMap (\dir -> ["-S", dir]) includes


### PR DESCRIPTION
This makes the racket compiler check for new versions of modules it already compiled. This should avoid some confusing errors when developing the racket libs. I believe it should make it impossible to have problems with stale object files.