### PR TITLE
Only run ormolu formatter on trunk

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,7 @@ jobs:
   build:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    if: ${{ always() }}
     needs: ormolu
     defaults:
       run:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,10 @@ jobs:
 
   ormolu:
     runs-on: ubuntu-20.04
+    # Only run formatting on trunk commits
+    # This is because the job won't have permission to push back to
+    # contributor forks on contributor PRs.
+    if: github.ref_name == 'trunk'
     steps:
       - uses: actions/checkout@v2
       - name: Get changed files

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,7 @@ jobs:
   build:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    # The 'always()' causes this to build even if the ormolu job is skipped.
     if: ${{ always() }}
     needs: ormolu
     defaults:


### PR DESCRIPTION
## Overview

The ormolu steps fail when they try to commit back to contributor fork repositories.
This is noted in the documentation for the github actions step we're using for this:
![image](https://github.com/unisonweb/unison/assets/6439644/4229bd80-b578-4f76-a950-5813a2880244)

Here's an example of one such failure:
https://github.com/unisonweb/unison/actions/runs/5857360760/job/15879062506?pr=4260

Instead of dealing with those difficulties, we can only run this on trunk, in which case trunk is still always formatted, but we never hold up contributors over something like formatting. It also slightly speeds up the PR CI as a result.

## Implementation notes

Just limited the job to trunk.
