### PR TITLE
Fix bug where constructors would incorrectly print with a prefix

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/DeclPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/DeclPrinter.hs
@@ -117,7 +117,7 @@ prettyDataDecl (PrettyPrintEnvDecl unsuffixifiedPPE suffixifiedPPE) r name dd =
       Nothing -> prettyPattern unsuffixifiedPPE CT.Data name (ConstructorReference r n)
       Just ts -> case fieldNames unsuffixifiedPPE r name dd of
         Nothing ->
-          P.group . P.hang' (prettyPattern suffixifiedPPE CT.Data name (ConstructorReference r n)) "      " $
+          P.group . P.hang' (prettyPattern unsuffixifiedPPE CT.Data name (ConstructorReference r n)) "      " $
             P.spaced (runPretty suffixifiedPPE (traverse (TypePrinter.prettyRaw Map.empty 10) (init ts)))
         Just fs ->
           P.group $

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -40,6 +40,11 @@ So we can see the pretty-printed output:
     structural type Fix_2392a x y
       = Oog Nat Nat (Nat, Nat)
     
+    structural type foo.Join
+      = Join Boolean
+      | Table
+      | Values [Nat]
+    
     structural type Fully.qualifiedName
       = Dontcare () Nat
     

--- a/unison-src/transcripts-round-trip/reparses-with-same-hash.u
+++ b/unison-src/transcripts-round-trip/reparses-with-same-hash.u
@@ -460,3 +460,9 @@ test3 = do
 (>>>>) : Nat -> Nat -> ()
 (>>>>) n = cases
   _ -> bug ""
+
+-- regression test for https://github.com/unisonweb/unison/issues/4272
+-- where constructors with at least one argument don't get printed correctly
+-- this would previously get printed as `Join.Join`
+structural type foo.Join =
+  Table | Join Boolean | Values [Nat]


### PR DESCRIPTION
This would previously not round trip:

```
structural type foo.Join =
  Table | Join Boolean | Values [Nat]
```

It would print as:

```
structural type foo.Join =
  Table | Join.Join Boolean | Values [Nat]
```

The `DeclPrinter` was incorrectly using the suffixified pretty-print environment to come up with the constructor name. The correct logic is to use the FQN of the type, and the FQN for the constructor, and strip the FQN of the type off from the constructor name. There was a place in `DeclPrinter` where this wasn't being done.

This PR fixes that and adds a regression test.

Thanks to @kristiannotari for reporting!