### PR TITLE
Don't completely crash mid-update on missing metadata

### DIFF
--- a/unison-src/transcripts/ambiguous-metadata.output.md
+++ b/unison-src/transcripts/ambiguous-metadata.output.md
@@ -39,4 +39,6 @@ x = 1
   Tip: Try again and supply one of the above definitions
        explicitly.
 
+  I didn't make any changes.
+
 ```


### PR DESCRIPTION
## Overview

Previous behaviour:

If default metadata was missing, it would update the in-memory codebase root, but fail to sync, causing much confusion across the land.

New behaviour:

If we fail to resolve a piece of metadata, print a warning, but carry on without it.

## Implementation notes

I just swapped a `returnEarly` with a `Left`, which is later printed as a message, but without short-circuiting.

## Test coverage

The `ambiguous metadata` transcript changed, showing that the command now completes (without changes) when it previously would short-circuit.