### PR TITLE
Clear temp entity tables on login

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -220,6 +220,7 @@ module U.Codebase.Sqlite.Queries
     saveTempEntityInMain,
     expectTempEntity,
     deleteTempEntity,
+    clearTempEntityTables,
 
     -- * elaborate hashes
     elaborateHashes,
@@ -2711,6 +2712,15 @@ deleteTempEntity hash =
       FROM temp_entity
       WHERE hash = :hash
     |]
+
+-- | Clears the `temp_entity` and `temp_entity_missing_dependency` tables.
+-- The hashjwts stored in temp entity tables can sometimes go stale, so we clear them out.
+-- This is safe because temp entities are generally considered ephemeral
+-- except during an active pull.
+clearTempEntityTables :: Transaction ()
+clearTempEntityTables = do
+  execute [sql| DELETE FROM temp_entity_missing_dependency |]
+  execute [sql| DELETE FROM temp_entity |]
 
 -- | "Elaborate" a set of `temp_entity` hashes.
 --


### PR DESCRIPTION
## Overview

Paul noticed that after the recent hmac key cycling he couldn't clone distributed;

Eventually deduced that the issue was that UCM had stored some HashJWTs in the temp entities table signed with the old HMAC key. UCM happily tries to use these even though they're invalid, and doesn't know to clear them when they don't work.

## Implementation notes

Solution:

Before saving new credentials we clear the temp entity caches, this is to handle the case that the user logged into a new user and that they have some hashJWTs for a different user around which won't work against the new user credentials.

It also means that if the server changes signing-keys the user will simply get "unauthenticated", call `auth.login`, and that will clear out any hashjwts signed with the old key.

## Interesting/controversial decisions

This is kind of a sledge-hammer approach to solving this, would be nice to come back and do something a bit smarter, but maybe not worth it since the benefit of keeping temp-entities around outside of an active pull is pretty much zilch; and it's nice to have the default action that users would take in this scenario just fix most of the possible problems.

## Test coverage

Paul and Chris tested that it solves the issue.

## Loose ends

See above, we could possibly be smarter about invalidating HashJWTs if they fail to authenticate.