### PR TITLE
Implement verified hashing for racket backend, with assorted changes

### DIFF
--- a/scheme-libs/racket/unison/math.rkt
+++ b/scheme-libs/racket/unison/math.rkt
@@ -16,6 +16,7 @@
     builtin-Int.pow
     builtin-Int.trailingZeros
     builtin-Int.popCount
+    builtin-Nat.popCount
     builtin-Float.pow
  (prefix-out unison-POp-
              (combine-out
@@ -74,6 +75,7 @@
 (define-unison (builtin-Int.* n m) (* n m))
 (define-unison (builtin-Int.pow n m) (expt n m))
 (define-unison (builtin-Int.trailingZeros n) (TZRO n))
+(define-unison (builtin-Nat.popCount n) (POPC n))
 (define-unison (builtin-Int.popCount n) (POPC n))
 (define-unison (builtin-Float.pow n m) (expt n m))
 (define (EXPF n) (exp n))

--- a/scheme-libs/racket/unison/primops-generated.rkt
+++ b/scheme-libs/racket/unison/primops-generated.rkt
@@ -176,7 +176,6 @@
      (unison-reference-derived (unison-id-id bs i))]
     [else (raise "termlink->reference: con case")]))
 
-
 (define (group-reference gr)
   (data-case gr
     [0 (r _) r]))
@@ -199,39 +198,6 @@
        (unison-reference-derived
          (unison-id-id h i)))]))
 
-(define (reify-reference rf)
-  (match rf
-    [(unison-data _ t (list nm))
-     #:when (= t unison-reference-builtin:tag)
-     (unison-typelink-builtin (chunked-string->string nm))]
-    [(unison-data _ t (list id))
-     #:when (= t unison-reference-derived:tag)
-     (match id
-       [(unison-data _ t (list rf i))
-        #:when (= t unison-id-id:tag)
-        (unison-typelink-derived rf i)])]))
-
-(define (reify-termlink-reference rf)
-  (match rf
-    [(unison-data _ t (list nm))
-     #:when (= t unison-reference-builtin:tag)
-     (unison-termlink-builtin nm)]
-    [(unison-data _ t (list id))
-     #:when (= t unison-reference-derived:tag)
-     (match id
-       [(unison-data _ t (list rf i))
-        #:when (= t unison-id-id:tag)
-        (unison-termlink-derived rf i)])]))
-
-(define (reify-referent rn)
-  (match rn
-    [(unison-data _ t (list rf i))
-     #:when (= t unison-referent-con:tag)
-     (unison-termlink-con (reify-reference rf) i)]
-    [(unison-data _ t (list rf))
-     #:when (= t unison-referent-def:tag)
-     (reify-termlink-reference rf)]))
-
 (define (reify-vlit vl)
   (match vl
     [(unison-data _ t (list l))
@@ -239,8 +205,8 @@
        [(= t unison-vlit-bytes:tag) l]
        [(= t unison-vlit-bytearray:tag) l]
        [(= t unison-vlit-text:tag) l]
-       [(= t unison-vlit-typelink:tag) (reify-reference l)]
-       [(= t unison-vlit-termlink:tag) (reify-referent l)]
+       [(= t unison-vlit-typelink:tag) (reference->typelink l)]
+       [(= t unison-vlit-termlink:tag) (referent->termlink l)]
        [(= t unison-vlit-code:tag) (unison-code l)]
        [(= t unison-vlit-quote:tag) (unison-quote l)]
        [(= t unison-vlit-seq:tag)
@@ -257,7 +223,7 @@
      (let ([us (chunked-list->list us0)]
            [bs (map reify-value (chunked-list->list bs0))])
        (cond
-         [(null? us) (make-data (reify-reference rf) rt bs)]
+         [(null? us) (make-data (reference->typelink rf) rt bs)]
          [(and (null? bs) (= 1 (length us))) (car us)]
          [else
            (raise

--- a/scheme-libs/racket/unison/primops.ss
+++ b/scheme-libs/racket/unison/primops.ss
@@ -47,6 +47,7 @@
     builtin-Int.trailingZeros
     builtin-Int.popCount
     builtin-Nat.increment
+    builtin-Nat.popCount
     builtin-Nat.toFloat
     builtin-Text.indexOf
     builtin-Bytes.indexOf

--- a/scheme-libs/racket/unison/primops.ss
+++ b/scheme-libs/racket/unison/primops.ss
@@ -57,6 +57,8 @@
     builtin-Value.fromBuiltin
     builtin-Code.fromGroup
     builtin-Code.toGroup
+    builtin-TermLink.fromReferent
+    builtin-TermLink.toReferent
 
     unison-FOp-internal.dataTag
     unison-FOp-Char.toText
@@ -419,7 +421,10 @@
           (unison arithmetic)
           (unison bytevector)
           (unison core)
-          (only (unison boot) define-unison)
+          (only (unison boot)
+                define-unison
+                referent->termlink
+                termlink->referent)
           (unison data)
           (unison data-info)
           (unison math)
@@ -444,6 +449,10 @@
   (define-unison (builtin-Code.fromGroup sg) (unison-code sg))
   (define-unison (builtin-Code.toGroup co)
     (unison-code-rep co))
+  (define-unison (builtin-TermLink.fromReferent rf)
+    (referent->termlink rf))
+  (define-unison (builtin-TermLink.toReferent tl)
+    (termlink->referent tl))
 
   (define-unison (builtin-IO.randomBytes n)
     (bytes->chunked-bytes (crypto-random-bytes n)))

--- a/scheme-libs/racket/unison/primops.ss
+++ b/scheme-libs/racket/unison/primops.ss
@@ -468,7 +468,7 @@
 
   ; Core implemented primops, upon which primops-in-unison can be built.
   (define (unison-POp-ADDN m n) (fx+ m n))
-  (define (unison-POp-ANDN m n) (fxand m n))
+  (define (unison-POp-ANDN m n) (bitwise-and m n))
   (define unison-POp-BLDS
     (lambda args-list
       (fold-right (lambda (e l) (chunked-list-add-first l e)) empty-chunked-list args-list)))

--- a/unison-cli/src/Unison/JitInfo.hs
+++ b/unison-cli/src/Unison/JitInfo.hs
@@ -1,4 +1,4 @@
 module Unison.JitInfo (currentRelease) where
 
 currentRelease :: String
-currentRelease = "releases/0.0.2"
+currentRelease = "releases/0.0.3"

--- a/unison-src/builtin-tests/array-tests.u
+++ b/unison-src/builtin-tests/array-tests.u
@@ -4,8 +4,8 @@ checkBytesII src larr rarr i =
   if l == r
     then if i > 0 then checkBytesII src larr rarr (l-1) else pass src
     else let
-      tl = Debug.toText l
-      tr = Debug.toText r
+      tl = Debug.evalToText l
+      tr = Debug.evalToText r
       fail src ("`" ++ tl ++ "` is not equal to `" ++ tr ++ "`")
 
 checkBytesMI src marr iarr i =
@@ -14,8 +14,8 @@ checkBytesMI src marr iarr i =
   if l == r
     then if i > 0 then checkBytesMI src marr iarr (l-1) else pass src
     else let
-      tl = Debug.toText l
-      tr = Debug.toText r
+      tl = Debug.evalToText l
+      tr = Debug.evalToText r
       fail src ("`" ++ tl ++ "` is not equal to `" ++ tr ++ "`")
 
 checkBytesMM src larr rarr i =
@@ -24,8 +24,8 @@ checkBytesMM src larr rarr i =
   if l == r
     then if i > 0 then checkBytesMM src larr rarr (l-1) else pass src
     else let
-      tl = Debug.toText l
-      tr = Debug.toText r
+      tl = Debug.evalToText l
+      tr = Debug.evalToText r
       fail src ("`" ++ tl ++ "` is not equal to `" ++ tr ++ "`")
 
 boxarrTests : '{IO,Exception,Tests} ()

--- a/unison-src/builtin-tests/base.md
+++ b/unison-src/builtin-tests/base.md
@@ -5,6 +5,6 @@ Thus, make sure the contents of this file define the contents of the cache
 (e.g. don't pull `latest`.)
 
 ```ucm
-.> pull @unison/base/releases/2.2.0 .base
+.> pull @unison/base/releases/2.5.0 .base
 .> compile.native.fetch
 ```

--- a/unison-src/builtin-tests/bytes-tests.u
+++ b/unison-src/builtin-tests/bytes-tests.u
@@ -1,3 +1,4 @@
+use base.Text toUtf8
 
 bytes.tests = do
   !bytes.lit.tests
@@ -23,7 +24,7 @@ bytes.lit.tests = do
     true
 
 bytes.debug.tests = do
- checkEqual "Debug.toText on Bytes" (Debug.toText 0xs68656c6c6f) "0xs68656c6c6f"
+ checkEqual "Debug.evalToText on Bytes" (Debug.evalToText 0xs68656c6c6f) "0xs68656c6c6f"
 
 bytes.conversion.tests = do
   use base Bytes.fromList Bytes.toList

--- a/unison-src/builtin-tests/concurrency-tests.u
+++ b/unison-src/builtin-tests/concurrency-tests.u
@@ -60,7 +60,7 @@ promiseSequentialTest = do
   checkEqual "Once the Promise is full, tryRead is the same as read" v3 (Some v2)
 
 millis = 1000
-sleep_ n = unsafeRun! do sleep n
+sleep_ n = unsafeRun! do sleepMicroseconds n
 
 promiseConcurrentTest = do
   use Nat eq

--- a/unison-src/builtin-tests/serial-tests.u
+++ b/unison-src/builtin-tests/serial-tests.u
@@ -81,6 +81,12 @@ serial.loadSelfContained name path =
     then pass (name ++ " value roundtrip")
     else fail name "value roundtrip"
 
+    match validateLinks deps with
+      Left [] -> fail name "validateLinks: empty Left"
+      Left _  -> fail name "validateLinks: couldn't rehash"
+      Right [] -> pass (name ++ " links validated")
+      Right _ -> fail name "failed link validation"
+
     _ = cache_ deps
     match Value.load v with
       Left l -> raiseFailure "value missing deps" l

--- a/unison-src/builtin-tests/serial-tests.u
+++ b/unison-src/builtin-tests/serial-tests.u
@@ -101,14 +101,14 @@ serial.runTestCase name =
   handle
     p@(f, i) = loadSelfContained name sfile
     o = fromUtf8 (readFile ofile)
-    -- h = readFile hfile
+    h = readFile hfile
+
+    if toBase32 (crypto.hash Sha3_512 p) === h
+    then pass (name ++ " hash matches")
+    else fail name "hash mismatch"
 
     if f i === o
-    then pass name
-      -- todo: check hashes
-      -- if toBase32 (crypto.hash Sha3_512 p) == h
-      --    then pass name
-      --    else fail name "hash mismatch"
+    then pass (name ++ "value matches")
     else fail name "output mismatch"
   with cases
     { x } -> x

--- a/unison-src/builtin-tests/tcp-tests.u
+++ b/unison-src/builtin-tests/tcp-tests.u
@@ -31,7 +31,7 @@ testServerAndClient = do
 
   match setup with
     Left exn ->
-      Tests.fail "Unable to bind and listen on a socket" (Debug.toText exn)
+      Tests.fail "Unable to bind and listen on a socket" (Debug.evalToText exn)
     Right (socket, port) ->
       serve = do
         sock = Socket.accept socket

--- a/unison-src/builtin-tests/testlib.u
+++ b/unison-src/builtin-tests/testlib.u
@@ -17,7 +17,7 @@ Tests.checkEqual msg a1 a2 =
     Left e -> exception msg e
     Right true -> pass msg
     Right false ->
-      fail msg (Debug.toText a1 ++ " is not equal to: " ++ Debug.toText a2)
+      fail msg (Debug.evalToText a1 ++ " is not equal to: " ++ Debug.evalToText a2)
 
 Tests.main : '{IO,Exception,Tests} () -> '{IO,Exception} ()
 Tests.main suite = do

--- a/unison-src/builtin-tests/text-tests.u
+++ b/unison-src/builtin-tests/text-tests.u
@@ -135,8 +135,8 @@ text.conversion.tests = do
   checkEqual "Text ut8 roundTrip" (fromUtf8 (toUtf8 "Hello, World!")) "Hello, World!"
 
 text.debug.tests = do
-  checkEqual "Debug.toText (1)" (Debug.toText 3) "3"
-  checkEqual "Debug.toText (2)" (Debug.toText "hello") "\"hello\""
+  checkEqual "Debug.evalToText (1)" (Debug.evalToText 3) "3"
+  checkEqual "Debug.evalToText (2)" (Debug.evalToText "hello") "\"hello\""
 
   catchMsg p = match catchAll p with
     Left (Failure tl msg v) -> msg

--- a/unison-src/builtin-tests/tls-chain-tests.u
+++ b/unison-src/builtin-tests/tls-chain-tests.u
@@ -19,7 +19,7 @@ intermediateKey = "-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEArgTsjlGv6JXm
 
 customCertChain = [siteCert, intermediateCert, rootCert]
 
-parseCert text = Either.toException (decodeCert (toUtf8 text))
+parseCert text = Either.toException (decodeCert (Text.toUtf8 text))
 
 defer comp =
   result = Promise.new ()
@@ -39,13 +39,14 @@ chainClient portPromise toSend =
   sock = Socket.client (HostName.HostName ("127" ++ ".0.0.1")) (Port.Port (Nat.toText (Promise.read portPromise)))
   tls = Tls.newClient tlsconfig sock
   tlsock = Tls.handshake tls
-  TlsSocket.send tlsock (toUtf8 toSend)
+  TlsSocket.send tlsock (Text.toUtf8 toSend)
   -- res = fromUtf8 (TlsSocket.receive tlsock)
   TlsSocket.terminate tlsock
   -- res
 
 -- server receives then sends
 chainServer portPromise toSend =
+  use Text toUtf8
   key = Optional.toException "No private key decoded" <| List.head (decodePrivateKey (toUtf8 intermediateKey)) -- siteKey
   tlsconfig = Tls.ServerConfig.default [
     -- parseCert siteKey,

--- a/unison-src/builtin-tests/tls-tests.u
+++ b/unison-src/builtin-tests/tls-tests.u
@@ -1,3 +1,5 @@
+use base.Text toUtf8
+
 tls.tests = do
   check "decoding a cert should work" do isRight (decodeCert (toUtf8 selfSignedCert))
   check "decoding a private key should work" do 1 == List.size (decodePrivateKey (toUtf8 selfSignedKey))


### PR DESCRIPTION
This PR implements the non-unison changes necessary to have verified hashing in the racket backend. This includes:

- Rewriting and fleshing out some primop stuff. Some stuff that was previously defined in a monolithic macro has been broken apart and rewritten using racket's `match` for example. A few new switch-out pseudo-builtins have been implemented that new unison code relies on, too. The dynamic code loading was also not generating all the information expected for subsequently reflecting values.
- Updating test cases to base 2.5.0. Some function names have changed and such. I needed the new version for some graph functionality it has.
- Adding some test cases for the hashing. The dynamic code loading tests now call the `validateLinks` function to check that the code being loaded makes sense. I also added in the hash part of the tests for the serialized code, because the builtins for hashing arbitrary unison values are hooked up now.

I think even though there aren't a lot of test cases, they're actually covering the relevant issues, because I had to fix a bug with sorting the SCCs while working on this (one of the serialized cases has a non-trivial SCC).