### PR TITLE
feat: allow pulling <project>/releases/latest

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/RemoteRepo.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/RemoteRepo.hs
@@ -111,7 +111,7 @@ data ReadRemoteNamespace a
   | -- | A remote project+branch, specified by name (e.g. @unison/base/main).
     -- Currently assumed to be hosted on Share, though we could include a ShareCodeserver in here, too.
     ReadShare'ProjectBranch !a
-  deriving stock (Eq, Show, Generic)
+  deriving stock (Eq, Functor, Show, Generic)
 
 data ReadGitRemoteNamespace = ReadGitRemoteNamespace
   { repo :: !ReadGitRepo,

--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -68,6 +68,7 @@ dependencies:
   - text-builder
   - text-rope
   - these
+  - these-lens
   - time
   - transformers
   - unison-codebase
@@ -188,6 +189,7 @@ default-extensions:
   - GeneralizedNewtypeDeriving
   - ImportQualifiedPost
   - InstanceSigs
+  - KindSignatures
   - LambdaCase
   - MultiParamTypeClasses
   - MultiWayIf

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -150,6 +150,7 @@ import Unison.PrettyPrintEnv.Names qualified as PPE
 import Unison.PrettyPrintEnvDecl qualified as PPE hiding (biasTo, empty)
 import Unison.PrettyPrintEnvDecl qualified as PPED
 import Unison.PrettyPrintEnvDecl.Names qualified as PPED
+import Unison.Project (ProjectBranchNameOrLatestRelease (..))
 import Unison.Reference (Reference (..), TermReference)
 import Unison.Reference qualified as Reference
 import Unison.Referent (Referent)
@@ -2466,8 +2467,8 @@ doFetchCompiler username branch =
     -- fetching info
     prj =
       These
-        (unsafeFrom $ "@" <> Text.pack username <> "/internal")
-        (unsafeFrom $ Text.pack branch)
+        (unsafeFrom @Text $ "@" <> Text.pack username <> "/internal")
+        (ProjectBranchNameOrLatestRelease'Name . unsafeFrom @Text $ Text.pack branch)
 
     sourceTarget =
       PullSourceTarget2

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -45,7 +45,7 @@ import Unison.HashQualified qualified as HQ
 import Unison.Name (Name)
 import Unison.NameSegment (NameSegment)
 import Unison.Prelude
-import Unison.Project (ProjectAndBranch, ProjectAndBranchNames, ProjectBranchName, ProjectName, Semver)
+import Unison.Project (ProjectAndBranch, ProjectAndBranchNames, ProjectBranchName, ProjectName, Semver, ProjectBranchNameOrLatestRelease)
 import Unison.ShortHash (ShortHash)
 import Unison.Util.Pretty qualified as P
 
@@ -268,8 +268,8 @@ data GistInput = GistInput
 -- | Pull source and target: either neither is specified, or only a source, or both.
 data PullSourceTarget
   = PullSourceTarget0
-  | PullSourceTarget1 (ReadRemoteNamespace (These ProjectName ProjectBranchName))
-  | PullSourceTarget2 (ReadRemoteNamespace (These ProjectName ProjectBranchName)) LooseCodeOrProject
+  | PullSourceTarget1 (ReadRemoteNamespace (These ProjectName ProjectBranchNameOrLatestRelease))
+  | PullSourceTarget2 (ReadRemoteNamespace (These ProjectName ProjectBranchNameOrLatestRelease)) LooseCodeOrProject
   deriving stock (Eq, Show)
 
 data PushSource

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -382,6 +382,7 @@ data Output
   | FetchingLatestReleaseOfBase
   | FailedToFetchLatestReleaseOfBase
   | HappyCoding
+  | ProjectHasNoReleases ProjectName
 
 -- | What did we create a project branch from?
 --
@@ -603,6 +604,7 @@ isFailure o = case o of
   FetchingLatestReleaseOfBase {} -> False
   FailedToFetchLatestReleaseOfBase {} -> True
   HappyCoding {} -> False
+  ProjectHasNoReleases {} -> True
 
 isNumberedFailure :: NumberedOutput -> Bool
 isNumberedFailure = \case

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2163,6 +2163,8 @@ notifyUser dir = \case
         <> P.newline
         <> P.newline
         <> P.wrap "🎉 🥳 Happy coding!"
+  ProjectHasNoReleases projectName ->
+    pure . P.wrap $ prettyProjectName projectName <> "has no releases."
   where
     _nameChange _cmd _pastTenseCmd _oldName _newName _r = error "todo"
 
@@ -2781,7 +2783,7 @@ renderEditConflicts ppe Patch {..} = do
                  then "deprecated and also replaced with"
                  else "replaced with"
              )
-          `P.hang` P.lines replacements
+            `P.hang` P.lines replacements
     formatTermEdits ::
       (Reference.TermReference, Set TermEdit.TermEdit) ->
       Numbered Pretty
@@ -2796,7 +2798,7 @@ renderEditConflicts ppe Patch {..} = do
                  then "deprecated and also replaced with"
                  else "replaced with"
              )
-          `P.hang` P.lines replacements
+            `P.hang` P.lines replacements
     formatConflict ::
       Either
         (Reference, Set TypeEdit.TypeEdit)

--- a/unison-cli/tests/Unison/Test/UriParser.hs
+++ b/unison-cli/tests/Unison/Test/UriParser.hs
@@ -12,13 +12,14 @@ import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.ShortCausalHash (ShortCausalHash (..))
 import Unison.Core.Project (ProjectBranchName (..), ProjectName (..))
 import Unison.NameSegment (NameSegment (..))
+import Unison.Project (ProjectBranchSpecifier (..))
 
 test :: Test ()
 test =
   scope "uriparser" . tests $
     [ parserTests
         "repoPath"
-        (UriParser.repoPath <* P.eof)
+        (UriParser.readRemoteNamespaceParser ProjectBranchSpecifier'Name <* P.eof)
         [ ("unisonweb.base._releases.M4", looseR "unisonweb" ["base", "_releases", "M4"]),
           ("project", branchR (This "project")),
           ("/branch", branchR (That "branch")),

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -136,6 +136,7 @@ library
       GeneralizedNewtypeDeriving
       ImportQualifiedPost
       InstanceSigs
+      KindSignatures
       LambdaCase
       MultiParamTypeClasses
       MultiWayIf
@@ -208,6 +209,7 @@ library
     , text-builder
     , text-rope
     , these
+    , these-lens
     , time
     , transformers
     , unison-codebase
@@ -266,6 +268,7 @@ executable cli-integration-tests
       GeneralizedNewtypeDeriving
       ImportQualifiedPost
       InstanceSigs
+      KindSignatures
       LambdaCase
       MultiParamTypeClasses
       MultiWayIf
@@ -343,6 +346,7 @@ executable cli-integration-tests
     , text-builder
     , text-rope
     , these
+    , these-lens
     , time
     , transformers
     , unison-codebase
@@ -396,6 +400,7 @@ executable transcripts
       GeneralizedNewtypeDeriving
       ImportQualifiedPost
       InstanceSigs
+      KindSignatures
       LambdaCase
       MultiParamTypeClasses
       MultiWayIf
@@ -472,6 +477,7 @@ executable transcripts
     , text-builder
     , text-rope
     , these
+    , these-lens
     , time
     , transformers
     , unison-cli
@@ -531,6 +537,7 @@ executable unison
       GeneralizedNewtypeDeriving
       ImportQualifiedPost
       InstanceSigs
+      KindSignatures
       LambdaCase
       MultiParamTypeClasses
       MultiWayIf
@@ -608,6 +615,7 @@ executable unison
     , text-builder
     , text-rope
     , these
+    , these-lens
     , time
     , transformers
     , unison-cli
@@ -670,6 +678,7 @@ test-suite cli-tests
       GeneralizedNewtypeDeriving
       ImportQualifiedPost
       InstanceSigs
+      KindSignatures
       LambdaCase
       MultiParamTypeClasses
       MultiWayIf
@@ -747,6 +756,7 @@ test-suite cli-tests
     , text-builder
     , text-rope
     , these
+    , these-lens
     , time
     , transformers
     , unison-cli

--- a/unison-core/package.yaml
+++ b/unison-core/package.yaml
@@ -65,8 +65,10 @@ default-extensions:
   - DoAndIfThenElse
   - FlexibleContexts
   - FlexibleInstances
+  - GADTs
   - GeneralizedNewtypeDeriving
   - ImportQualifiedPost
+  - KindSignatures
   - LambdaCase
   - MultiParamTypeClasses
   - NamedFieldPuns

--- a/unison-core/src/Unison/Project.hs
+++ b/unison-core/src/Unison/Project.hs
@@ -12,6 +12,8 @@ module Unison.Project
     projectBranchNameUserSlug,
     ProjectBranchNameKind (..),
     classifyProjectBranchName,
+    ProjectBranchNameOrLatestRelease (..),
+    ProjectBranchSpecifier (..),
     ProjectAndBranch (..),
     projectAndBranchNamesParser,
     ProjectAndBranchNames (..),
@@ -23,6 +25,7 @@ module Unison.Project
 where
 
 import Data.Char qualified as Char
+import Data.Kind (Type)
 import Data.Text qualified as Text
 import Data.Text.Read qualified as Text (decimal)
 import Data.These (These (..))
@@ -271,6 +274,19 @@ projectBranchNameUserSlug (UnsafeProjectBranchName branchName) =
     then Just (Text.takeWhile (/= '/') (Text.drop 1 branchName))
     else Nothing
 
+-- | A project branch name, or the latest release of its project.
+data ProjectBranchNameOrLatestRelease
+  = ProjectBranchNameOrLatestRelease'LatestRelease
+  | ProjectBranchNameOrLatestRelease'Name !ProjectBranchName
+  deriving stock (Eq, Show)
+
+-- | How a project branch can be specified.
+data ProjectBranchSpecifier :: Type -> Type where
+  -- | By name.
+  ProjectBranchSpecifier'Name :: ProjectBranchSpecifier ProjectBranchName
+  -- | By name, or "the latest release"
+  ProjectBranchSpecifier'NameOrLatestRelease :: ProjectBranchSpecifier ProjectBranchNameOrLatestRelease
+
 instance From (ProjectAndBranch ProjectName ProjectBranchName) Text where
   from (ProjectAndBranch project branch) =
     Text.Builder.run $
@@ -343,7 +359,7 @@ instance From (These ProjectName ProjectBranchName) Text where
 
 instance TryFrom Text (These ProjectName ProjectBranchName) where
   tryFrom =
-    maybeTryFrom (Megaparsec.parseMaybe projectAndBranchNamesParser)
+    maybeTryFrom (Megaparsec.parseMaybe (projectAndBranchNamesParser ProjectBranchSpecifier'Name))
 
 -- Valid things:
 --
@@ -351,20 +367,33 @@ instance TryFrom Text (These ProjectName ProjectBranchName) where
 --   2. project/
 --   3. project/branch
 --   4. /branch
-projectAndBranchNamesParser :: Megaparsec.Parsec Void Text (These ProjectName ProjectBranchName)
-projectAndBranchNamesParser = do
+projectAndBranchNamesParser ::
+  forall branch.
+  ProjectBranchSpecifier branch ->
+  Megaparsec.Parsec Void Text (These ProjectName branch)
+projectAndBranchNamesParser specifier = do
   optional projectNameParser >>= \case
     Nothing -> do
       _ <- Megaparsec.char '/'
-      branch <- projectBranchNameParser False
+      branch <- branchParser
       pure (That branch)
     Just (project, hasTrailingSlash) ->
       if hasTrailingSlash
         then do
-          optional (projectBranchNameParser False) <&> \case
+          optional branchParser <&> \case
             Nothing -> This project
             Just branch -> These project branch
         else pure (This project)
+  where
+    branchParser :: Megaparsec.Parsec Void Text branch
+    branchParser =
+      case specifier of
+        ProjectBranchSpecifier'Name -> projectBranchNameParser False
+        ProjectBranchSpecifier'NameOrLatestRelease ->
+          asum
+            [ ProjectBranchNameOrLatestRelease'LatestRelease <$ "releases/latest",
+              ProjectBranchNameOrLatestRelease'Name <$> projectBranchNameParser False
+            ]
 
 -- | @project/branch@ syntax, where the branch is optional.
 instance From (ProjectAndBranch ProjectName (Maybe ProjectBranchName)) Text where

--- a/unison-core/unison-core1.cabal
+++ b/unison-core/unison-core1.cabal
@@ -71,8 +71,10 @@ library
       DoAndIfThenElse
       FlexibleContexts
       FlexibleInstances
+      GADTs
       GeneralizedNewtypeDeriving
       ImportQualifiedPost
+      KindSignatures
       LambdaCase
       MultiParamTypeClasses
       NamedFieldPuns
@@ -132,8 +134,10 @@ test-suite tests
       DoAndIfThenElse
       FlexibleContexts
       FlexibleInstances
+      GADTs
       GeneralizedNewtypeDeriving
       ImportQualifiedPost
+      KindSignatures
       LambdaCase
       MultiParamTypeClasses
       NamedFieldPuns


### PR DESCRIPTION
## Overview

This PR tweaks the `pull` command to allow the special branch name `releases/latest` in the source of the pull, as in:

```
> pull @unison/base/releases/latest
> pull /releases/latest
```

<img width="700" alt="Screen Shot 2023-08-29 at 12 04 43 AM" src="https://github.com/unisonweb/unison/assets/1074598/e6457cf7-da13-4f9c-8e3b-987b72b285c5">

The output is a little unimpressive at the moment (inherited from existing `pull` output messages). It seems like at the very least you'd want to see which release "releases/latest" resolved to. But, this is a start :)

## Test coverage

I tested this change manually, and there are existing parser tests that cover much of this code.
