### PR TITLE
Warn on invalid awk version

### DIFF
--- a/scripts/make-release.sh
+++ b/scripts/make-release.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
 if [[ "$1" = "--status" ]]; then
     gh workflow view release --repo unisonweb/unison
     gh workflow view release --repo unisonweb/homebrew-unison
@@ -34,7 +36,7 @@ if ! [[ "$1" =~ ^M[0-9]+[a-z]?$ ]] ; then
 fi
 
 version="${1}"
-prev_version=$(./scripts/previous-tag.sh "$version")
+prev_version=$("${script_dir}/previous-tag.sh" "$version")
 target=${2:-trunk}
 tag="release/${version}"
 

--- a/scripts/previous-tag.sh
+++ b/scripts/previous-tag.sh
@@ -5,6 +5,11 @@
 # ./previous-tag.sh M4a -> M4
 # ./previous-tag.sh M4b -> M4a
 
+if ! (awk --version | grep GNU) >/dev/null 2>&1; then
+   echo "GNU awk is required, install with \`brew install gawk\`"
+   exit 1
+fi
+
 if ! [[ "$1" =~ ^M[0-9]+[a-z]?$ ]] ; then
  echo "Version tag must be of the form 'M4' or 'M4a'. E.g."
  echo "$0 M4a"


### PR DESCRIPTION
## Overview

Warn the user that we require GNU awk rather than mac awk for the release script.

## Implementation notes

Check the awk version for `GNU`, warn otherwise

## Interesting/controversial decisions

There's probably a workaround or something, but only a handful of people need to ever run this script and GNU awk is superior anyways.