### PR TITLE
Use gawk if installed

### DIFF
--- a/scripts/previous-tag.sh
+++ b/scripts/previous-tag.sh
@@ -5,7 +5,14 @@
 # ./previous-tag.sh M4a -> M4
 # ./previous-tag.sh M4b -> M4a
 
-if ! (awk --version | grep GNU) >/dev/null 2>&1; then
+awk_exe="awk"
+
+# if gawk exists, use that:
+if command -V "gawk" >/dev/null 2>&1; then
+   awk_exe=gawk
+fi
+
+if ! ("$awk_exe" --version | grep GNU) >/dev/null 2>&1; then
    echo "GNU awk is required, install with \`brew install gawk\`"
    exit 1
 fi
@@ -16,7 +23,7 @@ if ! [[ "$1" =~ ^M[0-9]+[a-z]?$ ]] ; then
  exit 1
 fi
 
-echo "$1" | awk '
+echo "$1" | $awk_exe '
         # This script figures out a previous tag for a given release to make release notes from.
 
         # The previous release of something like M4a is just M4


### PR DESCRIPTION
## Overview

Homebrew installs gnu awk as `gawk`, so use that if it exists, otherwise try `awk` but fail if it's not GNU awk.