### PR TITLE
Add extra help line for delete command

### DIFF
--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -697,8 +697,9 @@ deleteGen suffix target mkTarget =
           (P.sep
             " "
             [ backtick (P.sep " " [P.string cmd, "foo bar"]),
+            "removes the",
             P.string target,
-            "remotes the name `foo` and `bar` from the namespace" ], "")]
+            "name `foo` and `bar` from the namespace" ], "")]
       warn =
         P.sep
           " "

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -686,13 +686,19 @@ deleteGen :: Maybe String -> String -> ([Path.HQSplit'] -> DeleteTarget) -> Inpu
 deleteGen suffix target mkTarget =
   let cmd = maybe "delete" ("delete." <>) suffix
       info =
-        P.sep
+        P.wrapColumn2 [
+          (P.sep
           " "
           [ backtick (P.sep " " [P.string cmd, "foo"]),
             "removes the",
             P.string target,
             "name `foo` from the namespace."
-          ]
+          ], ""),
+          (P.sep
+            " "
+            [ backtick (P.sep " " [P.string cmd, "foo bar"]),
+            P.string target,
+            "name `foo` and `bar` from the namespace" ], "")]
       warn =
         P.sep
           " "

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -698,7 +698,7 @@ deleteGen suffix target mkTarget =
             " "
             [ backtick (P.sep " " [P.string cmd, "foo bar"]),
             P.string target,
-            "name `foo` and `bar` from the namespace" ], "")]
+            "remotes the name `foo` and `bar` from the namespace" ], "")]
       warn =
         P.sep
           " "

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -699,7 +699,7 @@ deleteGen suffix target mkTarget =
             [ backtick (P.sep " " [P.string cmd, "foo bar"]),
             "removes the",
             P.string target,
-            "name `foo` and `bar` from the namespace" ], "")]
+            "name `foo` and `bar` from the namespace." ], "")]
       warn =
         P.sep
           " "


### PR DESCRIPTION
## Overview

Provides one extra help info for the delete command

Before:
```bash
.> help delete

  delete
  `delete foo` removes the term or type name `foo` from the namespace.
```

After: 
```bash
.> help delete

  delete
  `delete foo` removes the term or type name `foo` from the namespace.
  `delete foo bar` removes the term or type name `foo` and `bar` from the namespace
```

## Implementation notes

How does it accomplish it, in broad strokes? i.e. How does it change the Haskell codebase?

## Test coverage
Manual testing