### PR TITLE
Add logic to flip welcome hint message

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -107,6 +107,7 @@ module U.Codebase.Sqlite.Queries
 
     -- * projects
     projectExists,
+    doProjectsExist,
     projectExistsByName,
     loadProject,
     loadProjectByName,
@@ -3223,6 +3224,12 @@ projectExists projectId =
         WHERE id = :projectId
       )
     |]
+
+-- | Check if any projects exist
+doProjectsExist :: Transaction Bool
+doProjectsExist =
+  queryOneCol
+    [sql| SELECT EXISTS (SELECT 1 FROM project) |]
 
 -- | Does a project exist by this name?
 projectExistsByName :: ProjectName -> Transaction Bool

--- a/unison-cli/src/Unison/CommandLine/Welcome.hs
+++ b/unison-cli/src/Unison/CommandLine/Welcome.hs
@@ -15,7 +15,7 @@ import Prelude hiding (readFile, writeFile)
 data Welcome = Welcome
   { onboarding :: Onboarding, -- Onboarding States
     unisonVersion :: Text,
-    welcomeHint :: Bool
+    showWelcomeHint :: Bool
   }
 
 -- Previously Created is different from Previously Onboarded because a user can
@@ -36,11 +36,11 @@ data Onboarding
   deriving (Show, Eq)
 
 welcome :: CodebaseInitStatus -> Text -> Bool -> Welcome
-welcome initStatus unisonVersion welcomeHint =
-  Welcome (Init initStatus) unisonVersion welcomeHint
+welcome initStatus unisonVersion showWelcomeHint =
+  Welcome (Init initStatus) unisonVersion showWelcomeHint
 
 run :: Welcome -> [Either Event Input]
-run Welcome {onboarding = onboarding, unisonVersion = version, welcomeHint = welcomeHint} = do
+run Welcome {onboarding = onboarding, unisonVersion = version, showWelcomeHint = showWelcomeHint} = do
   go onboarding []
   where
     go :: Onboarding -> [Either Event Input] -> [Either Event Input]
@@ -59,8 +59,8 @@ run Welcome {onboarding = onboarding, unisonVersion = version, welcomeHint = wel
           where
             authorMsg = toInput authorSuggestion
         -- These are our two terminal Welcome conditions, at the end we reverse the order of the desired input commands otherwise they come out backwards
-        Finished -> reverse (toInput (getStarted welcomeHint) : acc)
-        PreviouslyOnboarded -> reverse (toInput (getStarted welcomeHint) : acc)
+        Finished -> reverse (toInput (getStarted showWelcomeHint) : acc)
+        PreviouslyOnboarded -> reverse (toInput (getStarted showWelcomeHint) : acc)
 
 toInput :: P.Pretty P.ColorText -> Either Event Input
 toInput pretty =
@@ -112,11 +112,11 @@ authorSuggestion =
       ]
 
 getStarted :: Bool -> P.Pretty P.ColorText
-getStarted welcomeHint =
+getStarted showWelcomeHint =
   P.wrap "📚 Read the official docs at https://www.unison-lang.org/learn/"
     <> P.newline
     <> P.newline
-    <> P.wrap (if welcomeHint
+    <> P.wrap (if showWelcomeHint
               then "Hint: type 'projects' to list all your projects"
               else "Type 'project.create' to get started.")
 

--- a/unison-cli/src/Unison/CommandLine/Welcome.hs
+++ b/unison-cli/src/Unison/CommandLine/Welcome.hs
@@ -117,6 +117,6 @@ getStarted showWelcomeHint =
     <> P.newline
     <> P.newline
     <> P.wrap (if showWelcomeHint
-              then "Hint: type 'projects' to list all your projects"
+              then "Hint: type 'projects' to list all your projects."
               else "Type 'project.create' to get started.")
 

--- a/unison-cli/src/Unison/CommandLine/Welcome.hs
+++ b/unison-cli/src/Unison/CommandLine/Welcome.hs
@@ -14,7 +14,8 @@ import Prelude hiding (readFile, writeFile)
 
 data Welcome = Welcome
   { onboarding :: Onboarding, -- Onboarding States
-    unisonVersion :: Text
+    unisonVersion :: Text,
+    welcomeHint :: Bool
   }
 
 -- Previously Created is different from Previously Onboarded because a user can
@@ -34,12 +35,12 @@ data Onboarding
   | PreviouslyOnboarded
   deriving (Show, Eq)
 
-welcome :: CodebaseInitStatus -> Text -> Welcome
-welcome initStatus unisonVersion =
-  Welcome (Init initStatus) unisonVersion
+welcome :: CodebaseInitStatus -> Text -> Bool -> Welcome
+welcome initStatus unisonVersion welcomeHint =
+  Welcome (Init initStatus) unisonVersion welcomeHint
 
 run :: Welcome -> [Either Event Input]
-run Welcome {onboarding = onboarding, unisonVersion = version} = do
+run Welcome {onboarding = onboarding, unisonVersion = version, welcomeHint = welcomeHint} = do
   go onboarding []
   where
     go :: Onboarding -> [Either Event Input] -> [Either Event Input]
@@ -58,8 +59,8 @@ run Welcome {onboarding = onboarding, unisonVersion = version} = do
           where
             authorMsg = toInput authorSuggestion
         -- These are our two terminal Welcome conditions, at the end we reverse the order of the desired input commands otherwise they come out backwards
-        Finished -> reverse (toInput getStarted : acc)
-        PreviouslyOnboarded -> reverse (toInput getStarted : acc)
+        Finished -> reverse (toInput (getStarted welcomeHint) : acc)
+        PreviouslyOnboarded -> reverse (toInput (getStarted welcomeHint) : acc)
 
 toInput :: P.Pretty P.ColorText -> Either Event Input
 toInput pretty =
@@ -110,9 +111,12 @@ authorSuggestion =
         P.wrap $ P.blue "https://www.unison-lang.org/learn/tooling/configuration/"
       ]
 
-getStarted :: P.Pretty P.ColorText
-getStarted =
+getStarted :: Bool -> P.Pretty P.ColorText
+getStarted welcomeHint =
   P.wrap "📚 Read the official docs at https://www.unison-lang.org/learn/"
     <> P.newline
     <> P.newline
-    <> P.wrap "Type 'project.create' to get started."
+    <> P.wrap (if welcomeHint
+              then "Hint: type 'projects' to list all your projects"
+              else "Type 'project.create' to get started.")
+

--- a/unison-cli/src/Unison/CommandLine/Welcome.hs
+++ b/unison-cli/src/Unison/CommandLine/Welcome.hs
@@ -117,6 +117,6 @@ getStarted showWelcomeHint =
     <> P.newline
     <> P.newline
     <> P.wrap (if showWelcomeHint
-              then "Hint: type 'projects' to list all your projects."
+              then "Hint: Type 'projects' to list all your projects, or 'project.create' to start something new."
               else "Type 'project.create' to get started.")
 

--- a/unison-cli/unison/Main.hs
+++ b/unison-cli/unison/Main.hs
@@ -478,13 +478,13 @@ launch ::
   (Path.Absolute -> STM ()) ->
   CommandLine.ShouldWatchFiles ->
   IO ()
-launch dir config runtime sbRuntime codebase inputs serverBaseUrl mayStartingPath initResult notifyRootChange notifyPathChange shouldWatchFiles =
+launch dir config runtime sbRuntime codebase inputs serverBaseUrl mayStartingPath initResult notifyRootChange notifyPathChange shouldWatchFiles = do
+  welcomeHint <- Codebase.runTransaction codebase Queries.doProjectsExist
   let isNewCodebase = case initResult of
         CreatedCodebase -> NewlyCreatedCodebase
         OpenedCodebase -> PreviouslyCreatedCodebase
-
       (ucmVersion, _date) = Version.gitDescribe
-      welcome = Welcome.welcome isNewCodebase ucmVersion
+      welcome = Welcome.welcome isNewCodebase ucmVersion welcomeHint
    in CommandLine.main
         dir
         welcome

--- a/unison-cli/unison/Main.hs
+++ b/unison-cli/unison/Main.hs
@@ -479,12 +479,12 @@ launch ::
   CommandLine.ShouldWatchFiles ->
   IO ()
 launch dir config runtime sbRuntime codebase inputs serverBaseUrl mayStartingPath initResult notifyRootChange notifyPathChange shouldWatchFiles = do
-  welcomeHint <- Codebase.runTransaction codebase Queries.doProjectsExist
+  showWelcomeHint <- Codebase.runTransaction codebase Queries.doProjectsExist
   let isNewCodebase = case initResult of
         CreatedCodebase -> NewlyCreatedCodebase
         OpenedCodebase -> PreviouslyCreatedCodebase
       (ucmVersion, _date) = Version.gitDescribe
-      welcome = Welcome.welcome isNewCodebase ucmVersion welcomeHint
+      welcome = Welcome.welcome isNewCodebase ucmVersion showWelcomeHint
    in CommandLine.main
         dir
         welcome


### PR DESCRIPTION
## Overview
Added some logic to check whether any projects are present in UCM, if so flip a switch and show a hint

Before:
```bash
  👋 Welcome to Unison!

  You are running version: e7b891914


  📚 Read the official docs at https://www.unison-lang.org/learn/

  Type 'project.create' to get started.
```

After:

```bash
  👋 Welcome to Unison!

  You are running version: e7b891914


  📚 Read the official docs at https://www.unison-lang.org/learn/

  Hint: type 'projects' to list all your projects
```

## Test Coverage
Manual testing

Fixes: https://github.com/unisonweb/unison/issues/4266
