### PR TITLE
Prefer triple backtick syntax during doc source printing, even for old docs

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -1931,7 +1931,7 @@ toDocVerbatim ppe (App' (Ref' r) (toDocWord ppe -> Just txt))
 toDocVerbatim _ _ = Nothing
 
 toDocEval :: (Var v) => PrettyPrintEnv -> Term3 v PrintAnnotation -> Maybe (Term3 v PrintAnnotation)
-toDocEval ppe (App' (Ref' r) (Delay' tm))
+toDocEval ppe (App' (Ref' r) (DDelay' tm))
   | nameEndsWith ppe ".docEval" r = Just tm
   | r == _oldDocEval = Just tm
 toDocEval _ _ = Nothing

--- a/unison-src/transcripts-round-trip/main.md
+++ b/unison-src/transcripts-round-trip/main.md
@@ -80,11 +80,9 @@ x = ()
 .a3_old> delete.namespace.force lib.builtin
 ```
 
-These are currently all expected to have different hashes on round trip, though we'd prefer if they round tripped with the same hash.
+These are currently all expected to have different hashes on round trip.
 
-NOTE, since we don't currently have anything that round trips with a different hash, this fails. If you find an example that reparses with a different hash, add it to `reparses.u` and change this stanza to `ucm` rather than `ucm:error`.
-
-```ucm:error
+```ucm
 .> diff.namespace a3 a3_old
 ```
 

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -641,19 +641,34 @@ x = ()
       Put definitions in here that are expected to
       parse with a different hash after pretty-printing.
       """
+    
+    sloppyDocEval : Doc2
+    sloppyDocEval =
+      use Nat +
+      {{
+      Here's an example of an eval block that's technically a
+      lambda but should print as a backticked block (since old
+      docs in the wild still use this format).
+      
+      ```
+      1 + 1
+      ```
+      }}
   
   You can edit them there, then do `update` to replace the
   definitions currently in this namespace.
 
 ```
-These are currently all expected to have different hashes on round trip, though we'd prefer if they round tripped with the same hash.
-
-NOTE, since we don't currently have anything that round trips with a different hash, this fails. If you find an example that reparses with a different hash, add it to `reparses.u` and change this stanza to `ucm` rather than `ucm:error`.
+These are currently all expected to have different hashes on round trip.
 
 ```ucm
 .> diff.namespace a3 a3_old
 
-  The namespaces are identical.
+  Updates:
+  
+    1. sloppyDocEval : Doc2
+       ↓
+    2. sloppyDocEval : Doc2
 
 ```
 ## Other regression tests not covered by above

--- a/unison-src/transcripts-round-trip/reparses.u
+++ b/unison-src/transcripts-round-trip/reparses.u
@@ -3,3 +3,17 @@ explanationOfThisFile = """
   Put definitions in here that are expected to
   parse with a different hash after pretty-printing.
   """
+
+-- This is expected to round trip with the ``` syntax, 
+-- even though the original didn't use that syntax and
+-- defined the eval block with a lambda rather than a delay.
+sloppyDocEval = 
+  docUntitledSection [ 
+    docParagraph [
+      docWord "Here's an example of an eval block that's",
+      docWord "technically a lambda but should print as a",
+      docWord "backticked block (since old docs in the wild",
+      docWord "still use this format)."
+    ],
+    docEval (_ -> 1 Nat.+ 1)
+  ]


### PR DESCRIPTION
There are old docs in the wild that use a lambda like `(_ -> 1 + 1)` for the delayed block inside triple backticks. Due to an oversight from #4217 (I missed one spot that should be using the `DDelay` pattern), this is currently resulting in rendering like this when viewing old docs:

<img width="363" alt="CleanShot 2023-09-07 at 17 15 57@2x" src="https://github.com/unisonweb/unison/assets/11074/1396b046-fc6c-4e4f-af32-749ab0293a4e">

(Note: this only affects their source, not their rendered form, which still looks fine)

This PR is a 1-character change in the pretty-printer plus a regression test. Thanks to @runarorama for reporting.