### PR TITLE
Add windows stack build retry on pre-release

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -108,7 +108,16 @@ jobs:
           echo "$PWD/stack-"* >> $GITHUB_PATH
 
       - name: build
-        run: stack --no-terminal build --flag unison-parser-typechecker:optimized
+        # Run up to 5 times in a row before giving up.
+        # Builds sometimes fail due to a race condition on the Windows
+        # file-system API that stack runs into. Since any successful packages are
+        # cached within a single build, it should get further along on each re-start
+        # and should hopefully finish.
+        run: |
+          tries=5
+          for (( i = 0; i < $tries; i++ )); do
+              stack --no-terminal build --flag unison-parser-typechecker:optimized && break;
+          done
 
       - name: fetch latest codebase-ui and package with ucm
         env:


### PR DESCRIPTION
## Overview

Windows pre-release build is failing due to the Windows file system race conditions that stack runs into.
We have it set to retry 5 times on both the ci builds and release builds, it's just pre-release that was missing it.

Annoying that we have to do this, but it's been working on the other builds, so don't fix it if it ain't broke 😎 

## Implementation

* Add the retries to pre-release as well.