### PR TITLE
Allow multiple ignored bindings in a block

### DIFF
--- a/parser-typechecker/src/Unison/Typechecker/Components.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Components.hs
@@ -12,6 +12,7 @@ import Unison.Prelude
 import Unison.Term (Term')
 import Unison.Term qualified as Term
 import Unison.Var (Var)
+import Unison.Var qualified as Var
 
 unordered :: (Var v) => [(v, Term' vt v a)] -> [[(v, Term' vt v a)]]
 unordered = ABT.components
@@ -45,7 +46,10 @@ minimize (Term.LetRecNamedAnnotatedTop' isTop blockAnn bs e) =
           . sortBy
             (compare `on` fst)
       grouped = group bindings
-      dupes = filter ((> 1) . length . snd) grouped
+      dupes = filter ok grouped
+        where 
+          ok (v, as) | Var.name v == "_" = False
+                     | otherwise         = length as > 1
    in if not $ null dupes
         then Left $ Nel.fromList dupes
         else

--- a/unison-src/transcripts/fix3773.md
+++ b/unison-src/transcripts/fix3773.md
@@ -1,0 +1,13 @@
+
+```ucm:hide
+.> builtins.merge
+```
+
+```unison
+foo = 
+  _ = 1
+  _ = 22
+  42
+
+> foo + 20
+```

--- a/unison-src/transcripts/fix3773.output.md
+++ b/unison-src/transcripts/fix3773.output.md
@@ -1,0 +1,28 @@
+
+```unison
+foo = 
+  _ = 1
+  _ = 22
+  42
+
+> foo + 20
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      foo : Nat
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    6 | > foo + 20
+          ⧩
+          62
+
+```


### PR DESCRIPTION
Previously, you couldn't do:

```Haskell
foo = 
  _ = 1
  _ = 22
  42
```

It would complain about duplicate bindings.

Now you can. This PR allows duplicate bindings as long as they're called `_`. There's no syntax for referring to a variable called `_` so this seems to work fine in the typechecker and runtime. Added a regression test.

@dolio tagging you in case you can think of issues with this approach. Like will the bytecode compiler complain or somesuch?

Addendum: also did some manual testing with the `compile` command:

```
foo = do
  _ = 
    printLine "hi"
    1
  _ = 
    printLine "there"
    2
  999 
```

I did a `compile` and then `unison run.compiled foo.uc` and it worked fine. (I thought I'd double check this)