### PR TITLE
Fixes to suffix-based name resolution when local file names shadow codebase names

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/FileParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/FileParser.hs
@@ -2,7 +2,6 @@ module Unison.Syntax.FileParser where
 
 import Control.Lens
 import Control.Monad.Reader (asks, local)
-import Data.List.Extra (nubOrd)
 import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Text.Megaparsec qualified as P
@@ -17,7 +16,7 @@ import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.Syntax.DeclParser (declarations)
 import Unison.Syntax.Lexer qualified as L
-import Unison.Syntax.Name qualified as Name (toVar, unsafeFromVar)
+import Unison.Syntax.Name qualified as Name (unsafeFromVar)
 import Unison.Syntax.Parser
 import Unison.Syntax.TermParser qualified as TermParser
 import Unison.Term (Term)
@@ -25,7 +24,7 @@ import Unison.Term qualified as Term
 import Unison.UnisonFile (UnisonFile (..))
 import Unison.UnisonFile qualified as UF
 import Unison.UnisonFile.Env qualified as UF
-import Unison.UnisonFile.Names (environmentFor)
+import Unison.UnisonFile.Names qualified as UFN
 import Unison.Util.List qualified as List
 import Unison.Var (Var)
 import Unison.Var qualified as Var
@@ -41,15 +40,23 @@ file = do
   -- The file may optionally contain top-level imports,
   -- which are parsed and applied to the type decls and term stanzas
   (namesStart, imports) <- TermParser.imports <* optional semi
+  -- todo: I'm guessing parsedAccessors isn't making it into the suffixified names resolution process
   (dataDecls, effectDecls, parsedAccessors) <- declarations
-  env <- case environmentFor (NamesWithHistory.currentNames namesStart) dataDecls effectDecls of
+  env <- case UFN.environmentFor (NamesWithHistory.currentNames namesStart) dataDecls effectDecls of
     Right (Right env) -> pure env
     Right (Left es) -> P.customFailure $ TypeDeclarationErrors es
     Left es -> resolutionFailures (toList es)
+  let accessors :: [[(v, Ann, Term v Ann)]]
+      accessors =
+          [ DD.generateRecordAccessors (toPair <$> fields) (L.payload typ) r
+            | (typ, fields) <- parsedAccessors,
+              Just (r, _) <- [Map.lookup (L.payload typ) (UF.datas env)]
+          ]
+      toPair (tok, typ) = (L.payload tok, ann tok <> ann typ)
   let importNames = [(Name.unsafeFromVar v, Name.unsafeFromVar v2) | (v, v2) <- imports]
   let locals = Names.importing importNames (UF.names env)
   -- At this stage of the file parser, we've parsed all the type and ability
-  -- declarations. The `Names.push (Names.suffixify0 locals)` here has the effect
+  -- declarations. The `push locals` here has the effect
   -- of making suffix-based name resolution prefer type and constructor names coming
   -- from the local file.
   --
@@ -69,6 +76,10 @@ file = do
           Binding ((spanningAnn, v), at) -> ((v, spanningAnn, Term.generalizeTypeSignatures at) : terms, watches)
           Bindings bs -> ([(v, spanningAnn, Term.generalizeTypeSignatures at) | ((spanningAnn, v), at) <- bs] ++ terms, watches)
     let (terms, watches) = (reverse termsr, reverse watchesr)
+        -- All locally declared term variables, running example:
+        --   [foo.alice, bar.alice, zonk.bob]
+        fqLocalTerms :: [v]
+        fqLocalTerms = (stanzas0 >>= getVars) <> (view _1 <$> join accessors) 
     -- suffixified local term bindings shadow any same-named thing from the outer codebase scope
     -- example: `foo.bar` in local file scope will shadow `foo.bar` and `bar` in codebase scope
     let (curNames, resolveLocals) =
@@ -76,51 +87,27 @@ file = do
             resolveLocals
           )
           where
-            -- All locally declared term variables, running example:
-            --   [foo.alice, bar.alice, zonk.bob]
-            locals0 :: [v]
-            locals0 = stanzas0 >>= getVars
-            -- Groups variables by their suffixes:
-            --   [ (foo.alice, [foo.alice]),
-            --     (bar.alice, [bar.alice])
-            --     (alice, [foo.alice, bar.alice]),
-            --     (zonk.bob, [zonk.bob]),
-            --     (bob, [zonk.bob]) ]
-            varsBySuffix :: Map Name.Name [v]
-            varsBySuffix = List.multimap [(n, v) | v <- locals0, n <- Name.suffixes (Name.unsafeFromVar v)]
-            -- Any unique suffix maps to the corresponding variable. Above, `alice` is not a unique
-            -- suffix, but `bob` is. `foo.alice` and `bob.alice` are both unique suffixes but
-            -- they map to themselves, so we ignore them. In our example, we'll just be left with
-            --   [(bob, Term.var() zonk.bob)]
-            replacements =
-              [ (Name.toVar n, Term.var () v')
-                | (n, nubOrd -> [v']) <- Map.toList varsBySuffix,
-                  Name.toVar n /= v'
-              ]
-            locals = Map.keys varsBySuffix
-            -- This will perform the actual variable replacements for suffixes
-            -- that uniquely identify definitions in the file. It will avoid
-            -- variable capture and respect local shadowing. For example, inside
-            -- `bob -> bob * 42`, `bob` will correctly refer to the lambda parameter.
-            -- and not the `zonk.bob` declared in the file.
+            -- Each unique suffix mapped to its fully qualified name
+            canonicalVars :: Map v v
+            canonicalVars = UFN.variableCanonicalizer fqLocalTerms
+            
+            -- All unique local term name suffixes - these we want to
+            -- avoid resolving to a term that's in the codebase
+            locals :: [Name.Name]
+            locals = (Name.unsafeFromVar <$> Map.keys canonicalVars)
+            
+            -- A function to replace unique local term suffixes with their
+            -- fully qualified name
+            replacements = [ (v, Term.var () v2) | (v,v2) <- Map.toList canonicalVars, v /= v2 ]
             resolveLocals = ABT.substsInheritAnnotation replacements
-    let bindNames = Term.bindSomeNames Name.unsafeFromVar avoid curNames . resolveLocals
-          where
-            avoid = Set.fromList (stanzas0 >>= getVars)
+    let bindNames = Term.bindSomeNames Name.unsafeFromVar (Set.fromList fqLocalTerms) curNames . resolveLocals
     terms <- case List.validate (traverseOf _3 bindNames) terms of
       Left es -> resolutionFailures (toList es)
       Right terms -> pure terms
     watches <- case List.validate (traverseOf (traversed . _3) bindNames) watches of
       Left es -> resolutionFailures (toList es)
       Right ws -> pure ws
-    let toPair (tok, typ) = (L.payload tok, ann tok <> ann typ)
-        accessors :: [[(v, Ann, Term v Ann)]]
-        accessors =
-          [ DD.generateRecordAccessors (toPair <$> fields) (L.payload typ) r
-            | (typ, fields) <- parsedAccessors,
-              Just (r, _) <- [Map.lookup (L.payload typ) (UF.datas env)]
-          ]
-        uf =
+    let uf =
           UnisonFileId
             (UF.datasId env)
             (UF.effectsId env)

--- a/parser-typechecker/src/Unison/Syntax/FileParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/FileParser.hs
@@ -40,7 +40,6 @@ file = do
   -- The file may optionally contain top-level imports,
   -- which are parsed and applied to the type decls and term stanzas
   (namesStart, imports) <- TermParser.imports <* optional semi
-  -- todo: I'm guessing parsedAccessors isn't making it into the suffixified names resolution process
   (dataDecls, effectDecls, parsedAccessors) <- declarations
   env <- case UFN.environmentFor (NamesWithHistory.currentNames namesStart) dataDecls effectDecls of
     Right (Right env) -> pure env

--- a/parser-typechecker/src/Unison/UnisonFile/Names.hs
+++ b/parser-typechecker/src/Unison/UnisonFile/Names.hs
@@ -1,6 +1,7 @@
 module Unison.UnisonFile.Names where
 
 import Control.Lens
+import Data.List.Extra (nubOrd)
 import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Unison.ABT qualified as ABT
@@ -94,9 +95,11 @@ bindNames names (UnisonFileId d e ts ws) = do
 --     , quaffle -> baz.quaffle 
 --     ] 
 -- 
--- This is used to replace variable references in data decl signatures
--- with their canonical fully qualified variables before hashing. 
--- See usage below in `environmentFor`.
+-- This is used to replace variable references with their canonical 
+-- fully qualified variables.
+-- 
+-- It's used below in `environmentFor` and also during the term resolution
+-- process.
 variableCanonicalizer :: forall v . Var v => [v] -> Map v v
 variableCanonicalizer vs =
   done $ List.multimap do
@@ -105,7 +108,7 @@ variableCanonicalizer vs =
     suffix <- Name.suffixes n
     pure (Var.named (Name.toText suffix), v)
   where
-    done xs = Map.fromList [ (k, v) | (k, [v]) <- Map.toList xs ]
+    done xs = Map.fromList [ (k, v) | (k, nubOrd -> [v]) <- Map.toList xs ]
 
 -- This function computes hashes for data and effect declarations, and
 -- also returns a function for resolving strings to (Reference, ConstructorId)

--- a/unison-core/src/Unison/DataDeclaration/Names.hs
+++ b/unison-core/src/Unison/DataDeclaration/Names.hs
@@ -2,6 +2,9 @@
 
 module Unison.DataDeclaration.Names (bindNames, dataDeclToNames', effectDeclToNames') where
 
+import Data.Set qualified as Set
+import Data.Map qualified as Map
+import Unison.ABT qualified as ABT
 import Unison.ConstructorReference (GConstructorReference (..))
 import Unison.ConstructorType qualified as CT
 import Unison.DataDeclaration (DataDeclaration (DataDeclaration), EffectDeclaration)
@@ -12,6 +15,7 @@ import Unison.Names.ResolutionResult qualified as Names
 import Unison.Prelude
 import Unison.Reference qualified as Reference
 import Unison.Referent qualified as Referent
+import Unison.Type qualified as Type
 import Unison.Type.Names qualified as Type.Names
 import Unison.Util.Relation qualified as Rel
 import Unison.Var (Var)
@@ -43,11 +47,14 @@ effectDeclToNames' varToName (v, (r, d)) = effectDeclToNames varToName v r d
 bindNames ::
   (Var v) =>
   (v -> Name.Name) ->
-  Set v ->
+  Map v v ->
   Names ->
   DataDeclaration v a ->
   Names.ResolutionResult v a (DataDeclaration v a)
-bindNames varToName keepFree names (DataDeclaration m a bound constructors) = do
+bindNames varToName localNames names (DataDeclaration m a bound constructors) = do
   constructors <- for constructors $ \(a, v, ty) ->
-    (a,v,) <$> Type.Names.bindNames varToName keepFree names ty
+    (a,v,) <$> Type.Names.bindNames varToName keepFree names (ABT.substsInheritAnnotation subs ty)
   pure $ DataDeclaration m a bound constructors
+  where
+    keepFree = Set.fromList (Map.elems localNames)
+    subs = Map.toList $ Map.map (Type.var ()) localNames

--- a/unison-src/transcripts/fix3759.md
+++ b/unison-src/transcripts/fix3759.md
@@ -1,0 +1,22 @@
+
+```ucm:hide
+.> builtins.merge
+```
+
+```unison:hide
+unique type blah.Foo = Foo
+```
+
+```ucm:hide
+.> add
+```
+
+```unison
+unique type Oog.Foo = Foo Text
+
+unique ability Blah where
+  foo : Foo -> ()
+
+oog = do
+  foo (Foo "hi" : Oog.Foo)
+```

--- a/unison-src/transcripts/fix3759.md
+++ b/unison-src/transcripts/fix3759.md
@@ -4,7 +4,13 @@
 ```
 
 ```unison:hide
-unique type blah.Foo = Foo
+unique type codebase.Foo = Foo
+
+Woot.state : Nat
+Woot.state = 42
+
+Woot.frobnicate : Nat
+Woot.frobnicate = 43
 ```
 
 ```ucm:hide
@@ -17,6 +23,35 @@ unique type Oog.Foo = Foo Text
 unique ability Blah where
   foo : Foo -> ()
 
+unique type Something = { state : Text }
+
 oog = do
   foo (Foo "hi" : Oog.Foo)
+
+ex = do
+  s = Something "hello"
+  state s ++ " world!"
+
+-- check that using locally unique suffix shadows the `Foo` in codebase
+fn1 : Foo -> Foo -> Nat
+fn1 = cases Foo a, Foo b -> Text.size a Nat.+ Text.size b
+
+-- check that using local fully qualified name works fine
+fn2 : Oog.Foo -> Oog.Foo -> Text
+fn2 = cases Foo a, Foo b -> a Text.++ b
+
+-- check that using fully qualified name works fine
+fn3 : codebase.Foo -> codebase.Foo -> Text
+fn3 = cases codebase.Foo.Foo, codebase.Foo.Foo -> "!!!!!!" 
+
+> fn3 codebase.Foo.Foo codebase.Foo.Foo
+
+-- now checking that terms fully qualified names work fine
+blah.frobnicate = "Yay!"
+
+> Something.state (Something "hi")
+> Woot.state + 1
+> Woot.frobnicate + 2 
+> frobnicate Text.++ " 🎉"
+> blah.frobnicate Text.++ " 🎉"
 ```

--- a/unison-src/transcripts/fix3759.output.md
+++ b/unison-src/transcripts/fix3759.output.md
@@ -1,6 +1,12 @@
 
 ```unison
-unique type blah.Foo = Foo
+unique type codebase.Foo = Foo
+
+Woot.state : Nat
+Woot.state = 42
+
+Woot.frobnicate : Nat
+Woot.frobnicate = 43
 ```
 
 ```unison
@@ -9,8 +15,37 @@ unique type Oog.Foo = Foo Text
 unique ability Blah where
   foo : Foo -> ()
 
+unique type Something = { state : Text }
+
 oog = do
   foo (Foo "hi" : Oog.Foo)
+
+ex = do
+  s = Something "hello"
+  state s ++ " world!"
+
+-- check that using locally unique suffix shadows the `Foo` in codebase
+fn1 : Foo -> Foo -> Nat
+fn1 = cases Foo a, Foo b -> Text.size a Nat.+ Text.size b
+
+-- check that using local fully qualified name works fine
+fn2 : Oog.Foo -> Oog.Foo -> Text
+fn2 = cases Foo a, Foo b -> a Text.++ b
+
+-- check that using fully qualified name works fine
+fn3 : codebase.Foo -> codebase.Foo -> Text
+fn3 = cases codebase.Foo.Foo, codebase.Foo.Foo -> "!!!!!!" 
+
+> fn3 codebase.Foo.Foo codebase.Foo.Foo
+
+-- now checking that terms fully qualified names work fine
+blah.frobnicate = "Yay!"
+
+> Something.state (Something "hi")
+> Woot.state + 1
+> Woot.frobnicate + 2 
+> frobnicate Text.++ " 🎉"
+> blah.frobnicate Text.++ " 🎉"
 ```
 
 ```ucm
@@ -23,6 +58,46 @@ oog = do
     
       unique ability Blah
       unique type Oog.Foo
-      oog : '{Blah} ()
+      unique type Something
+      Something.state        : Something -> Text
+      Something.state.modify : (Text ->{g} Text)
+                               -> Something
+                               ->{g} Something
+      Something.state.set    : Text -> Something -> Something
+      blah.frobnicate        : Text
+      ex                     : 'Text
+      fn1                    : Oog.Foo -> Oog.Foo -> Nat
+      fn2                    : Oog.Foo -> Oog.Foo -> Text
+      fn3                    : codebase.Foo
+                               -> codebase.Foo
+                               -> Text
+      oog                    : '{Blah} ()
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    27 | > fn3 codebase.Foo.Foo codebase.Foo.Foo
+           ⧩
+           "!!!!!!"
+  
+    32 | > Something.state (Something "hi")
+           ⧩
+           "hi"
+  
+    33 | > Woot.state + 1
+           ⧩
+           43
+  
+    34 | > Woot.frobnicate + 2 
+           ⧩
+           45
+  
+    35 | > frobnicate Text.++ " 🎉"
+           ⧩
+           "Yay! 🎉"
+  
+    36 | > blah.frobnicate Text.++ " 🎉"
+           ⧩
+           "Yay! 🎉"
 
 ```

--- a/unison-src/transcripts/fix3759.output.md
+++ b/unison-src/transcripts/fix3759.output.md
@@ -1,0 +1,28 @@
+
+```unison
+unique type blah.Foo = Foo
+```
+
+```unison
+unique type Oog.Foo = Foo Text
+
+unique ability Blah where
+  foo : Foo -> ()
+
+oog = do
+  foo (Foo "hi" : Oog.Foo)
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique ability Blah
+      unique type Oog.Foo
+      oog : '{Blah} ()
+
+```


### PR DESCRIPTION
Fixes #3759 which was actually two unrelated bugs.
Closes #3976

The more serious bug here was that type signatures in data declarations wouldn't prefer local names using a unique suffix. So if you had `Foo.Blah` as a type in your codebase and `Oog.Blah` in your file, the type `Blah` would actually resolve to `Foo.Blah`. This could generate serious WTFs especially when doing updates of a type and related functions.

This fixes that, and also an issue where record accessors weren't being considered for local suffix-based name resolution.

I added regression tests for everything. I also confirmed that these regression tests all failed before making the fixes.

## Implementation notes

I added a function `variableCanonicalizer` which, given a set of variables, maps unique suffixes. This logic is sort of fancy and was for some reason just inlined in the file parser. I pulled it out into a function which is now called to deal with type and term suffix resolution.