### PR TITLE
Add missing dependency crawling for MCode

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/MCode.hs
+++ b/parser-typechecker/src/Unison/Runtime/MCode.hs
@@ -1441,6 +1441,10 @@ sectionDeps :: Section -> [Word64]
 sectionDeps (App _ (Env w _) _) = [w]
 sectionDeps (Call _ w _) = [w]
 sectionDeps (Match _ br) = branchDeps br
+sectionDeps (DMatch _ _ br) = branchDeps br
+sectionDeps (RMatch _ pu br) =
+  sectionDeps pu ++ foldMap branchDeps br
+sectionDeps (NMatch _ _ br) = branchDeps br
 sectionDeps (Ins i s)
   | Name (Env w _) _ <- i = w : sectionDeps s
   | otherwise = sectionDeps s
@@ -1451,6 +1455,10 @@ sectionTypes :: Section -> [Word64]
 sectionTypes (Ins i s) = instrTypes i ++ sectionTypes s
 sectionTypes (Let s _) = sectionTypes s
 sectionTypes (Match _ br) = branchTypes br
+sectionTypes (DMatch _ _ br) = branchTypes br
+sectionTypes (NMatch _ _ br) = branchTypes br
+sectionTypes (RMatch _ pu br) =
+  sectionTypes pu ++ foldMap branchTypes br
 sectionTypes _ = []
 
 instrTypes :: Instr -> [Word64]

--- a/unison-cli/integration-tests/IntegrationTests/transcript.md
+++ b/unison-cli/integration-tests/IntegrationTests/transcript.md
@@ -14,8 +14,28 @@
 ```unison
 use .builtin
 
+unique type MyBool = MyTrue | MyFalse
+
+structural ability Break where
+  break : ()
+
+resume = cases
+  { x } -> id x
+  { break  -> k } ->
+    void 5
+    handle k () with resume
+
 main : '{IO, Exception} ()
-main = '(printLine "Hello, world!")
+main = do
+  match MyTrue with
+    MyTrue -> match 0 with
+      0 ->
+        handle
+          break
+          printLine "Hello, world!"
+        with resume
+      _ -> ()
+    _ -> ()
 ```
 
 ```ucm

--- a/unison-cli/integration-tests/IntegrationTests/transcript.output.md
+++ b/unison-cli/integration-tests/IntegrationTests/transcript.output.md
@@ -3,8 +3,28 @@
 ```unison
 use .builtin
 
+unique type MyBool = MyTrue | MyFalse
+
+structural ability Break where
+  break : ()
+
+resume = cases
+  { x } -> id x
+  { break  -> k } ->
+    void 5
+    handle k () with resume
+
 main : '{IO, Exception} ()
-main = '(printLine "Hello, world!")
+main = do
+  match MyTrue with
+    MyTrue -> match 0 with
+      0 ->
+        handle
+          break
+          printLine "Hello, world!"
+        with resume
+      _ -> ()
+    _ -> ()
 ```
 
 ```ucm
@@ -15,7 +35,10 @@ main = '(printLine "Hello, world!")
   
     ⍟ These new definitions are ok to `add`:
     
-      main : '{IO, Exception} ()
+      structural ability Break
+      unique type MyBool
+      main   : '{IO, Exception} ()
+      resume : Request {g, Break} x -> x
 
 ```
 ```ucm
@@ -23,7 +46,10 @@ main = '(printLine "Hello, world!")
 
   ⍟ I've added these definitions:
   
-    main : '{IO, Exception} ()
+    structural ability Break
+    unique type MyBool
+    main   : '{IO, Exception} ()
+    resume : Request {g, Break} x -> x
 
 .> compile main ./unison-cli/integration-tests/IntegrationTests/main
 


### PR DESCRIPTION
The changes to the the intermediate code formats added additional branching constructs to MCode. But, the code that figures out the dependencies of MCode wasn't updated to take these into account, so any branches using these were treated as having no dependencies (due to the default case).

I added some structure to the integration test for generating a compiled binary to catch this case.

If @stew could test this branch with his cloud code that'd be appreciated. For some reason I'm unable to actually run his compiled binary locally, and I'm not sure why.