### PR TITLE
refactor: replace runEitherTransaction with more ergonomic runTransactionWithRollback

### DIFF
--- a/lib/unison-sqlite/src/Unison/Sqlite.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite.hs
@@ -18,6 +18,7 @@ module Unison.Sqlite
     -- * Transaction interface
     Transaction,
     runTransaction,
+    runTransactionWithRollback,
     runReadOnlyTransaction,
     runWriteTransaction,
     unsafeUnTransaction,

--- a/lib/unison-sqlite/src/Unison/Sqlite/Transaction.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Transaction.hs
@@ -83,7 +83,7 @@ runTransaction conn (Transaction f) = liftIO do
         pure result
 {-# SPECIALIZE runTransaction :: Connection -> Transaction a -> IO a #-}
 
--- An internal exception type that allows powers `runTransactionWithRollback`
+-- An internal exception type that allows `runTransactionWithRollback`
 data RollingBack
   = forall a. RollingBack !Unique !a
   deriving anyclass (Exception)

--- a/lib/unison-sqlite/src/Unison/Sqlite/Transaction.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Transaction.hs
@@ -2,6 +2,7 @@ module Unison.Sqlite.Transaction
   ( -- * Transaction management
     Transaction,
     runTransaction,
+    runTransactionWithRollback,
     runReadOnlyTransaction,
     runWriteTransaction,
     unsafeUnTransaction,
@@ -42,6 +43,7 @@ import Control.Concurrent (threadDelay)
 import Control.Exception (Exception (fromException), onException, throwIO)
 import Control.Monad.Trans.Reader (ReaderT (..))
 import Data.Text qualified as Text
+import Data.Unique (Unique, newUnique)
 import Database.SQLite.Simple qualified as Sqlite
 import Database.SQLite.Simple.FromField qualified as Sqlite
 import System.Random qualified as Random
@@ -51,6 +53,7 @@ import Unison.Sqlite.Connection qualified as Connection
 import Unison.Sqlite.Exception (SqliteExceptionReason, SqliteQueryException, pattern SqliteBusyException)
 import Unison.Sqlite.Sql (Sql)
 import UnliftIO.Exception (bracketOnError_, catchAny, trySyncOrAsync, uninterruptibleMask)
+import Unsafe.Coerce (unsafeCoerce)
 
 newtype Transaction a
   = Transaction (Connection -> IO a)
@@ -79,6 +82,30 @@ runTransaction conn (Transaction f) = liftIO do
         Connection.commit conn
         pure result
 {-# SPECIALIZE runTransaction :: Connection -> Transaction a -> IO a #-}
+
+-- An internal exception type that allows powers `runTransactionWithRollback`
+data RollingBack
+  = forall a. RollingBack !Unique !a
+  deriving anyclass (Exception)
+
+instance Show RollingBack where
+  show _ = ""
+
+-- | Run a transaction on the given connection, providing a function that can short-circuit (and roll back) the
+-- transaction.
+runTransactionWithRollback ::
+  (MonadIO m) =>
+  Connection ->
+  ((forall void. a -> Transaction void) -> Transaction a) ->
+  m a
+runTransactionWithRollback conn transaction = liftIO do
+  token <- newUnique
+  try (runTransaction conn (transaction \x -> unsafeIO (throwIO (RollingBack token x)))) >>= \case
+    Left exception@(RollingBack token2 x)
+      | token == token2 -> pure (unsafeCoerce x)
+      | otherwise -> throwIO exception
+    Right x -> pure x
+{-# SPECIALIZE runTransactionWithRollback :: Connection -> ((forall void. a -> Transaction void) -> Transaction a) -> IO a #-}
 
 -- | Run a transaction that is known to only perform reads.
 --

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -98,6 +98,7 @@ module Unison.Codebase
 
     -- * Direct codebase access
     runTransaction,
+    runTransactionWithRollback,
     withConnection,
     withConnectionIO,
 
@@ -176,6 +177,14 @@ import Unison.WatchKind qualified as WK
 runTransaction :: (MonadIO m) => Codebase m v a -> Sqlite.Transaction b -> m b
 runTransaction Codebase {withConnection} action =
   withConnection \conn -> Sqlite.runTransaction conn action
+
+runTransactionWithRollback ::
+  (MonadIO m) =>
+  Codebase m v a ->
+  ((forall void. b -> Sqlite.Transaction void) -> Sqlite.Transaction b) ->
+  m b
+runTransactionWithRollback Codebase {withConnection} action =
+  withConnection \conn -> Sqlite.runTransactionWithRollback conn action
 
 getShallowCausalFromRoot ::
   -- Optional root branch, if Nothing use the codebase's root branch.

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -14,7 +14,6 @@ import Control.Lens
 import Control.Monad.Reader (ask)
 import Control.Monad.State (StateT)
 import Control.Monad.State qualified as State
-import Control.Monad.Trans.Except (ExceptT (..), runExceptT)
 import Data.Foldable qualified as Foldable
 import Data.List qualified as List
 import Data.List.Extra (nubOrd)
@@ -1903,30 +1902,28 @@ handleDiffNamespaceToPatch description input = do
   absBranchId2 <- Cli.resolveBranchIdToAbsBranchId (input ^. #branchId2)
 
   patch <- do
-    Cli.runEitherTransaction do
-      runExceptT do
-        branch1 <- ExceptT (Cli.resolveAbsBranchIdV2 absBranchId1)
-        branch2 <- ExceptT (Cli.resolveAbsBranchIdV2 absBranchId2)
-        lift do
-          branchDiff <- V2Branch.Diff.diffBranches branch1 branch2 >>= V2Branch.Diff.nameBasedDiff
-          termEdits <-
-            (branchDiff ^. #terms)
-              & Relation.domain
-              & Map.toList
-              & traverse \(oldRef, newRefs) -> makeTermEdit codebase oldRef newRefs
-          pure
-            Patch
-              { _termEdits =
-                  termEdits
-                    & catMaybes
-                    & Relation.fromList,
-                _typeEdits =
-                  (branchDiff ^. #types)
-                    & Relation.domain
-                    & Map.toList
-                    & mapMaybe (\(oldRef, newRefs) -> makeTypeEdit oldRef newRefs)
-                    & Relation.fromList
-              }
+    Cli.runTransactionWithRollback \rollback -> do
+      branch1 <- Cli.resolveAbsBranchIdV2 rollback absBranchId1
+      branch2 <- Cli.resolveAbsBranchIdV2 rollback absBranchId2
+      branchDiff <- V2Branch.Diff.diffBranches branch1 branch2 >>= V2Branch.Diff.nameBasedDiff
+      termEdits <-
+        (branchDiff ^. #terms)
+          & Relation.domain
+          & Map.toList
+          & traverse \(oldRef, newRefs) -> makeTermEdit codebase oldRef newRefs
+      pure
+        Patch
+          { _termEdits =
+              termEdits
+                & catMaybes
+                & Relation.fromList,
+            _typeEdits =
+              (branchDiff ^. #types)
+                & Relation.domain
+                & Map.toList
+                & mapMaybe (\(oldRef, newRefs) -> makeTypeEdit oldRef newRefs)
+                & Relation.fromList
+          }
 
   -- Display the patch that we are about to create.
   ppe <- suffixifiedPPE =<< makePrintNamesFromLabeled' (Patch.labeledDependencies patch)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Branch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Branch.hs
@@ -79,11 +79,10 @@ handleBranch sourceI projectAndBranchNames0 = do
               ProjectAndBranch (Just p) b -> These p b
 
   project <-
-    Cli.runEitherTransaction do
-      Queries.loadProjectByName projectName <&> \case
+    Cli.runTransactionWithRollback \rollback -> do
+      Queries.loadProjectByName projectName & onNothingM do
         -- We can't make the *first* branch of a project with `branch`; the project has to already exist.
-        Nothing -> Left (Output.LocalProjectBranchDoesntExist projectAndBranchNames)
-        Just project -> Right project
+        rollback (Output.LocalProjectBranchDoesntExist projectAndBranchNames)
 
   doCreateBranch createFrom project newBranchName ("branch " <> into @Text projectAndBranchNames)
 
@@ -111,29 +110,27 @@ doCreateBranch :: CreateFrom -> Sqlite.Project -> ProjectBranchName -> Text -> C
 doCreateBranch createFrom project newBranchName description = do
   let projectId = project ^. #projectId
   newBranchId <-
-    Cli.runEitherTransaction do
+    Cli.runTransactionWithRollback \rollback -> do
       Queries.projectBranchExistsByName projectId newBranchName >>= \case
-        True ->
-          pure (Left (Output.ProjectAndBranchNameAlreadyExists (ProjectAndBranch (project ^. #name) newBranchName)))
-        False ->
+        True -> rollback (Output.ProjectAndBranchNameAlreadyExists (ProjectAndBranch (project ^. #name) newBranchName))
+        False -> do
           -- Here, we are forking to `foo/bar`, where project `foo` does exist, and it does not have a branch named
           -- `bar`, so the fork will succeed.
-          fmap Right do
-            newBranchId <- Sqlite.unsafeIO (ProjectBranchId <$> UUID.nextRandom)
-            Queries.insertProjectBranch
-              Sqlite.ProjectBranch
-                { projectId,
-                  branchId = newBranchId,
-                  name = newBranchName,
-                  parentBranchId =
-                    -- If we creating the branch from another branch in the same project, mark its parent
-                    case createFrom of
-                      CreateFrom'Branch (ProjectAndBranch _ sourceBranch)
-                        | (sourceBranch ^. #projectId) == projectId -> Just (sourceBranch ^. #branchId)
-                      _ -> Nothing
-                }
-            Queries.setMostRecentBranch projectId newBranchId
-            pure newBranchId
+          newBranchId <- Sqlite.unsafeIO (ProjectBranchId <$> UUID.nextRandom)
+          Queries.insertProjectBranch
+            Sqlite.ProjectBranch
+              { projectId,
+                branchId = newBranchId,
+                name = newBranchName,
+                parentBranchId =
+                  -- If we creating the branch from another branch in the same project, mark its parent
+                  case createFrom of
+                    CreateFrom'Branch (ProjectAndBranch _ sourceBranch)
+                      | (sourceBranch ^. #projectId) == projectId -> Just (sourceBranch ^. #branchId)
+                    _ -> Nothing
+              }
+          Queries.setMostRecentBranch projectId newBranchId
+          pure newBranchId
 
   let newBranchPath = ProjectUtils.projectBranchPath (ProjectAndBranch projectId newBranchId)
   sourceNamespaceObject <-

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectCreate.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectCreate.hs
@@ -80,12 +80,12 @@ projectCreate tryDownloadingBase maybeProjectName = do
                     True -> loop projectNames
           loop randomProjectNames
       Just projectName -> do
-        Cli.runEitherTransaction do
+        Cli.runTransactionWithRollback \rollback -> do
           Queries.projectExistsByName projectName >>= \case
             False -> do
               insertProjectAndBranch projectId projectName branchId branchName
-              pure (Right projectName)
-            True -> pure (Left (Output.ProjectNameAlreadyExists projectName))
+              pure projectName
+            True -> rollback (Output.ProjectNameAlreadyExists projectName)
 
   let path = projectBranchPath ProjectAndBranch {project = projectId, branch = branchId}
   Cli.respond (Output.CreatedProject (isNothing maybeProjectName) projectName)


### PR DESCRIPTION
## Overview

This PR replaces the somewhat clunky

```haskell
runEitherTransaction :: Transaction (Either Output a) -> Cli a
```

with a more ergonomic

```haskell
runTransactionWithRollback
  :: (forall void. Output -> Transaction void)
  -> Transaction a
  -> Cli a
```

so that you can use a nicer short-circuiting syntax within transactions, rather than reach for `ExceptT`/`lift`.
