### PR TITLE
refactor: add generic-lens to prelude, export orphan IsLabel instance

### DIFF
--- a/lib/unison-prelude/package.yaml
+++ b/lib/unison-prelude/package.yaml
@@ -14,6 +14,7 @@ dependencies:
   - containers
   - either
   - extra
+  - generic-lens
   - lens
   - mtl
   - pretty-simple

--- a/lib/unison-prelude/src/Unison/Prelude.hs
+++ b/lib/unison-prelude/src/Unison/Prelude.hs
@@ -53,6 +53,7 @@ import Data.Foldable as X (fold, foldl', for_, toList, traverse_)
 import Data.Function as X ((&))
 import Data.Functor as X
 import Data.Functor.Identity as X
+import Data.Generics.Labels () -- #labelSyntax for generics-derived lenses
 import Data.Int as X
 import Data.List as X (foldl1', sortOn)
 import Data.Map as X (Map)

--- a/lib/unison-prelude/unison-prelude.cabal
+++ b/lib/unison-prelude/unison-prelude.cabal
@@ -53,6 +53,7 @@ library
     , containers
     , either
     , extra
+    , generic-lens
     , lens
     , mtl
     , pretty-simple

--- a/lib/unison-sqlite/src/Unison/Sqlite/Sql.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Sql.hs
@@ -13,7 +13,6 @@ where
 
 import Control.Monad.Trans.State.Strict qualified as State
 import Data.Char qualified as Char
-import Data.Generics.Labels ()
 import Data.List.NonEmpty qualified as List (NonEmpty)
 import Data.List.NonEmpty qualified as List.NonEmpty
 import Data.Text qualified as Text

--- a/unison-cli/src/Unison/Cli/Monad.hs
+++ b/unison-cli/src/Unison/Cli/Monad.hs
@@ -54,7 +54,6 @@ import Control.Monad.Reader (MonadReader (..))
 import Control.Monad.State.Strict (MonadState)
 import Control.Monad.State.Strict qualified as State
 import Data.Configurator.Types qualified as Configurator
-import Data.Generics.Labels ()
 import Data.List.NonEmpty qualified as List (NonEmpty)
 import Data.List.NonEmpty qualified as List.NonEmpty
 import Data.Time.Clock (DiffTime, diffTimeToPicoseconds)

--- a/unison-cli/src/Unison/Codebase/Editor/Output/BranchDiff.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output/BranchDiff.hs
@@ -3,7 +3,6 @@
 module Unison.Codebase.Editor.Output.BranchDiff where
 
 import Control.Lens
-import Data.Generics.Labels ()
 import Data.List qualified as List
 import Data.Map qualified as Map
 import Data.Set qualified as Set


### PR DESCRIPTION
## Overview

This PR just adds `import Data.Generics.Label ()` to `unison-prelude`, to get the orphan `IsLabel` instance for generics-derived lenses everywhere.
