### PR TITLE
Restructure decompilation

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Decompile.hs
+++ b/parser-typechecker/src/Unison/Runtime/Decompile.hs
@@ -4,17 +4,23 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE ViewPatterns #-}
 
-module Unison.Runtime.Decompile (decompile) where
+module Unison.Runtime.Decompile
+  ( decompile
+  , DecompError (..)
+  , renderDecompError
+  ) where
 
+import Data.Set (singleton)
+import Prelude hiding (lines)
 import Unison.ABT (substs)
 import Unison.Codebase.Runtime (Error)
 import Unison.ConstructorReference (GConstructorReference (..))
 import Unison.Prelude
-import Unison.Reference (Reference)
+import Unison.Reference (Reference, pattern Builtin)
 import Unison.Referent (pattern Ref)
 import Unison.Runtime.ANF (maskTags)
 import Unison.Runtime.Foreign
-  ( Foreign,
+  ( Foreign (..),
     HashAlgorithm (..),
     maybeUnwrapBuiltin,
     maybeUnwrapForeign,
@@ -25,6 +31,7 @@ import Unison.Runtime.Stack
     pattern DataC,
     pattern PApV,
   )
+import Unison.Syntax.NamePrinter (prettyReference)
 import Unison.Term
   ( Term,
     app,
@@ -57,7 +64,7 @@ import Unison.Type
     typeLinkRef,
   )
 import Unison.Util.Bytes qualified as By
-import Unison.Util.Pretty (lit)
+import Unison.Util.Pretty (lit, indentN, lines, wrap, syntaxToColor)
 import Unison.Util.Text qualified as Text
 import Unison.Var (Var)
 import Unsafe.Coerce -- for Int -> Double
@@ -65,18 +72,78 @@ import Unsafe.Coerce -- for Int -> Double
 con :: (Var v) => Reference -> Word64 -> Term v ()
 con rf ct = constructor () (ConstructorReference rf $ fromIntegral ct)
 
-err :: String -> Either Error a
-err = Left . lit . fromString
+bug :: (Var v) => Text -> Term v ()
+bug msg = app () (builtin () "bug") (text () msg)
+
+err :: DecompError -> a -> (Set DecompError, a)
+err err x = (singleton err, x)
+
+data DecompError
+  = BadBool !Word64
+  | BadUnboxed !Reference
+  | BadForeign !Reference
+  | BadData !Reference
+  | BadPAp !Reference
+  | UnkComb !Reference
+  | UnkLocal !Reference !Word64
+  | Cont
+  | Exn
+  deriving (Eq, Ord)
+
+type DecompResult v = (Set DecompError, Term v ())
+
+prf :: Reference -> Error
+prf = syntaxToColor . prettyReference 10
+
+renderDecompError :: DecompError -> Error
+renderDecompError (BadBool n) =
+  lines
+    [ wrap "A boolean value had an unexpected constructor tag:",
+      indentN 2 . lit . fromString $ show n
+    ]
+renderDecompError (BadUnboxed rf) =
+  lines
+    [ wrap "An apparent numeric type had an unrecognized reference:",
+      indentN 2 $ prf rf
+    ]
+renderDecompError (BadForeign rf) =
+  lines
+    [ wrap "A foreign value with no decompiled representation was encountered:",
+      indentN 2 $ prf rf
+    ]
+renderDecompError (BadData rf) =
+  lines
+    [ wrap
+        "A data type with no decompiled representation was encountered:",
+      indentN 2 $ prf rf
+    ]
+renderDecompError (BadPAp rf) =
+  lines
+    [ wrap "A partial function application could not be decompiled: ",
+      indentN 2 $ prf rf
+    ]
+renderDecompError (UnkComb rf) =
+  lines
+    [ wrap "A reference to an unknown function was encountered: ",
+      indentN 2 $ prf rf
+    ]
+renderDecompError (UnkLocal rf n) =
+  lines
+    [ "A reference to an unknown portion to a function was encountered: ",
+      indentN 2 $ "function: " <> prf rf,
+      indentN 2 $ "section: " <> lit (fromString $ show n)
+    ]
+renderDecompError Cont = "A continuation value was encountered"
+renderDecompError Exn = "An exception value was encountered"
 
 decompile ::
   (Var v) =>
   (Reference -> Maybe Reference) ->
   (Word64 -> Word64 -> Maybe (Term v ())) ->
   Closure ->
-  Either Error (Term v ())
+  DecompResult v
 decompile _ _ (DataC rf (maskTags -> ct) [] [])
-  | rf == booleanRef =
-      boolean () <$> tag2bool ct
+  | rf == booleanRef = tag2bool ct
 decompile _ _ (DataC rf (maskTags -> ct) [i] []) =
   decompileUnboxed rf ct i
 decompile backref topTerms (DataC rf _ [] [b])
@@ -85,29 +152,26 @@ decompile backref topTerms (DataC rf _ [] [b])
 decompile backref topTerms (DataC rf (maskTags -> ct) [] bs) =
   apps' (con rf ct) <$> traverse (decompile backref topTerms) bs
 decompile backref topTerms (PApV (CIx rf rt k) [] bs)
+  | rf == Builtin "jumpCont" = err Cont $ bug "<Continuation>"
   | Just t <- topTerms rt k =
       Term.etaReduceEtaVars . substitute t
         <$> traverse (decompile backref topTerms) bs
   | k > 0,
     Just _ <- topTerms rt 0 =
-      err "cannot decompile an application to a local recursive binding"
-  | otherwise =
-      err $ "reference to unknown combinator: " ++ show rf
-decompile _ _ cl@(PAp _ _ _) =
-  err $
-    "cannot decompile a partial application to unboxed values: "
-      ++ show cl
-decompile _ _ (DataC {}) =
-  err "cannot decompile data type with multiple unboxed fields"
-decompile _ _ BlackHole = err "exception"
-decompile _ _ (Captured {}) = err "decompiling a captured continuation"
+      err (UnkLocal rf k) $ bug "<Unknown>"
+  | otherwise = err (UnkComb rf) $ ref () rf
+decompile _ _ (PAp (CIx rf _ _) _ _) =
+  err (BadPAp rf) $ bug "<Unknown>"
+decompile _ _ (DataC rf _ _ _) = err (BadData rf) $ bug "<Data>"
+decompile _ _ BlackHole = err Exn $ bug "<Exception>"
+decompile _ _ (Captured {}) = err Cont $ bug "<Continuation>"
 decompile backref topTerms (Foreign f) =
   decompileForeign backref topTerms f
 
-tag2bool :: Word64 -> Either Error Bool
-tag2bool 0 = Right False
-tag2bool 1 = Right True
-tag2bool _ = err "bad boolean tag"
+tag2bool :: (Var v) => Word64 -> DecompResult v
+tag2bool 0 = pure (boolean () False)
+tag2bool 1 = pure (boolean () True)
+tag2bool n = err (BadBool n) $ con booleanRef n
 
 substitute :: (Var v) => Term v () -> [Term v ()] -> Term v ()
 substitute = align []
@@ -118,35 +182,34 @@ substitute = align []
     align vts tm ts = apps' (substs vts tm) ts
 
 decompileUnboxed ::
-  (Var v) => Reference -> Word64 -> Int -> Either Error (Term v ())
+  (Var v) => Reference -> Word64 -> Int -> DecompResult v
 decompileUnboxed r _ i
   | r == natRef = pure . nat () $ fromIntegral i
   | r == intRef = pure . int () $ fromIntegral i
   | r == floatRef = pure . float () $ unsafeCoerce i
   | r == charRef = pure . char () $ toEnum i
-decompileUnboxed r _ _ =
-  err $ "cannot decompile unboxed data type with reference: " ++ show r
+  | otherwise = err (BadUnboxed r) . nat () $ fromIntegral i
 
 decompileForeign ::
   (Var v) =>
   (Reference -> Maybe Reference) ->
   (Word64 -> Word64 -> Maybe (Term v ())) ->
   Foreign ->
-  Either Error (Term v ())
+  DecompResult v
 decompileForeign backref topTerms f
-  | Just t <- maybeUnwrapBuiltin f = Right $ text () (Text.toText t)
-  | Just b <- maybeUnwrapBuiltin f = Right $ decompileBytes b
-  | Just h <- maybeUnwrapBuiltin f = Right $ decompileHashAlgorithm h
+  | Just t <- maybeUnwrapBuiltin f = pure $ text () (Text.toText t)
+  | Just b <- maybeUnwrapBuiltin f = pure $ decompileBytes b
+  | Just h <- maybeUnwrapBuiltin f = pure $ decompileHashAlgorithm h
   | Just l <- maybeUnwrapForeign termLinkRef f =
-      Right . termLink () $ case l of
+      pure . termLink () $ case l of
         Ref r -> maybe l Ref $ backref r
         _ -> l
   | Just l <- maybeUnwrapForeign typeLinkRef f =
-      Right $ typeLink () l
+      pure $ typeLink () l
   | Just s <- unwrapSeq f =
       list' () <$> traverse (decompile backref topTerms) s
-decompileForeign _ _ f =
-  err $ "cannot decompile Foreign: " ++ show f
+decompileForeign _ _ (Wrap r _) =
+  err (BadForeign r) $ bug "<Foreign>"
 
 decompileBytes :: (Var v) => By.Bytes -> Term v ()
 decompileBytes =

--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -795,8 +795,8 @@ tabulateErrors :: Set DecompError -> Error
 tabulateErrors errs | null errs = "\n"
 tabulateErrors errs =
   P.indentN 2 . P.lines $
-    P.wrap "The following errors occured while decompiling:" :
-      (listErrors errs)
+    P.wrap "The following errors occured while decompiling:"
+      : (listErrors errs)
 
 restoreCache :: StoredCache -> IO CCache
 restoreCache (SCache cs crs trs ftm fty int rtm rty sbs) =

--- a/parser-typechecker/tests/Unison/Test/UnisonSources.hs
+++ b/parser-typechecker/tests/Unison/Test/UnisonSources.hs
@@ -135,7 +135,7 @@ resultTest rt uf filepath = do
       values <- io $ unpack <$> readUtf8 valueFile
       let term = runIdentity (Parsers.parseTerm values parsingEnv)
       let report e = throwIO (userError $ toPlain 10000 e)
-      (bindings, watches) <-
+      (bindings, _, watches) <-
         io $
           either report pure
             =<< evaluateWatches

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -3232,11 +3232,13 @@ evalPureUnison ppe useCache tm = evalUnisonTermE False ppe useCache tm'
 displayDecompileErrors :: [Runtime.Error] -> Cli ()
 displayDecompileErrors errs = Cli.respond (PrintMessage msg)
   where
-  msg = P.lines $
-    [ P.warnCallout "I had trouble decompiling some results."
-    , ""
-    , "The following errors were encountered:"
-    ] ++ fmap (P.indentN 2) errs
+    msg =
+      P.lines $
+        [ P.warnCallout "I had trouble decompiling some results.",
+          "",
+          "The following errors were encountered:"
+        ]
+          ++ fmap (P.indentN 2) errs
 
 -- | Evaluate a single closed definition.
 evalUnisonTermE ::

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -3233,7 +3233,7 @@ displayDecompileErrors :: [Runtime.Error] -> Cli ()
 displayDecompileErrors errs = Cli.respond (PrintMessage msg)
   where
   msg = P.lines $
-    [ "I had trouble decompiling some results."
+    [ P.warnCallout "I had trouble decompiling some results."
     , ""
     , "The following errors were encountered:"
     ] ++ fmap (P.indentN 2) errs

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -976,14 +976,15 @@ evalDocRef rt codebase r = do
         Just (_ : _) -> pure ()
         _ -> do
           case r of
-            Just tmr ->
+            -- don't cache when there were decompile errors
+            Just (errs, tmr) | null errs ->
               Codebase.runTransaction codebase do
                 Codebase.putWatch
                   WK.RegularWatch
                   (Hashing.hashClosedTerm tm)
                   (Term.amap (const mempty) tmr)
-            Nothing -> pure ()
-      pure $ r <&> Term.amap (const mempty)
+            _ -> pure ()
+      pure $ r <&> Term.amap (const mempty) . snd
 
     decls (Reference.DerivedId r) =
       fmap (DD.amap (const ())) <$> Codebase.runTransaction codebase (Codebase.getTypeDeclaration codebase r)

--- a/unison-src/transcripts/watch-expressions.md
+++ b/unison-src/transcripts/watch-expressions.md
@@ -18,3 +18,9 @@ test> pass = [Ok "Passed"]
 .> add
 .> test
 ```
+
+```unison
+> Scope.run do
+    freeze! (Scope.arrayOf 0 0)
+
+```

--- a/unison-src/transcripts/watch-expressions.output.md
+++ b/unison-src/transcripts/watch-expressions.output.md
@@ -67,3 +67,30 @@ test> pass = [Ok "Passed"]
   Tip: Use view pass to view the source of a test.
 
 ```
+```unison
+> Scope.run do
+    freeze! (Scope.arrayOf 0 0)
+
+```
+
+```ucm
+
+  ✅
+  
+  scratch.u changed.
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+  I had trouble decompiling some results.
+  
+  The following errors were encountered:
+      A foreign value with no decompiled representation was
+      encountered:
+        ##ImmutableArray
+
+    1 | > Scope.run do
+          ⧩
+          bug "<Foreign>"
+
+```

--- a/unison-src/transcripts/watch-expressions.output.md
+++ b/unison-src/transcripts/watch-expressions.output.md
@@ -82,6 +82,8 @@ test> pass = [Ok "Passed"]
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.
 
+  ⚠️
+  
   I had trouble decompiling some results.
   
   The following errors were encountered:


### PR DESCRIPTION
The Runtime API has been changed so that 'partial' decompilation is possible. Even if a term result is returned, a set of errors may be yielded indicating that the entire result value could not be decompiled.

In cases with errors, the result will not be cached, although it allows displaying a proper result.

The decompiler in the runtime now takes advantage of this, in spots that it doesn't know how to decompile with calls to `bug`. These should always be valid terms, but obviously won't work correctly, hence the cache avoidance.

I added a test case in the watch expressions test that builds an array. Since there are no array literals, this would have failed before, but now it doesn't cause a hard error, just some warnings.