### PR TITLE
JIT: Added `Code.lookup` function and various supporting code changes

### DIFF
--- a/scheme-libs/racket/unison/boot.ss
+++ b/scheme-libs/racket/unison/boot.ss
@@ -20,6 +20,7 @@
   data
   data-case
 
+  (struct-out unison-data)
   (struct-out unison-termlink)
   (struct-out unison-termlink-con)
   (struct-out unison-termlink-builtin)
@@ -35,6 +36,7 @@
   sum-case
   unison-force
   string->chunked-string
+  empty-chunked-list
 
   identity
 
@@ -47,7 +49,10 @@
   typelink->reference
   termlink->referent
 
-  unison-tuple->list)
+  unison-tuple->list
+  list->unison-tuple
+  unison-tuple
+  unison-seq)
 
 (require
   (for-syntax
@@ -66,7 +71,9 @@
   unison/crypto
   (only-in unison/chunked-seq
            string->chunked-string
-           chunked-string->string))
+           chunked-string->string
+           vector->chunked-list
+           empty-chunked-list))
 
 ; Computes a symbol for automatically generated partial application
 ; cases, based on number of arguments applied. The partial
@@ -548,3 +555,11 @@
      (unison-referent-con
        (typelink->reference tyl)
        i)]))
+
+(define (list->unison-tuple l)
+  (foldr unison-tuple-pair unison-unit-unit l))
+
+(define (unison-tuple . l) (list->unison-tuple l))
+
+(define (unison-seq . l)
+  (vector->chunked-list (list->vector l)))

--- a/scheme-libs/racket/unison/boot.ss
+++ b/scheme-libs/racket/unison/boot.ss
@@ -29,6 +29,7 @@
   (struct-out unison-typelink-builtin)
   (struct-out unison-typelink-derived)
   declare-function-link
+  declare-code
 
   request
   request-case

--- a/scheme-libs/racket/unison/data.ss
+++ b/scheme-libs/racket/unison/data.ss
@@ -7,6 +7,8 @@
   data-number->hash
   declare-function-link
   lookup-function-link
+  declare-code
+  lookup-code
 
   (struct-out unison-data)
   (struct-out unison-sum)
@@ -22,6 +24,8 @@
   (struct-out unison-typelink-derived)
   (struct-out unison-code)
   (struct-out unison-quote)
+
+  define-builtin-link
 
   data
   sum
@@ -64,7 +68,7 @@
   unison-tuple->list)
 
 (require
-  racket/base
+  racket
   racket/fixnum
   (only-in "vector-trie.rkt" ->fx/wraparound))
 
@@ -154,6 +158,24 @@
     [(clo . rest)
      (apply (unison-closure-code clo)
             (append (unison-closure-env clo) rest))]))
+
+(define-syntax (define-builtin-link stx)
+  (syntax-case stx ()
+    [(_ name)
+     (identifier? #'name)
+     (let* ([sym (syntax-e #'name)]
+            [txt (symbol->string sym)]
+            [dname (datum->syntax stx
+                     (string->symbol
+                       (string-append txt ":termlink")))])
+       #`(define #,dname
+           (unison-termlink-builtin #,(datum->syntax stx txt))))]))
+    ; [(_ _)
+    ;   (raise-syntax-error #f
+    ;     "define-builtin-link called with non-identifier")]
+    ; [_
+    ;   (raise-syntax-error #f
+    ;     "define-builtin link called with wrong arguments")]))
 
 (define (partial-app f . args) (unison-closure f args))
 
@@ -252,7 +274,7 @@
 (define data-number-hashes (make-hash))
 
 ; Adds a hash to the known set of data types, allocating an
-; internal numbe for it.
+; internal number for it.
 (define (declare-unison-data-hash bs)
   (let ([n (fresh-data-number)])
     (hash-set! data-hash-numberings bs n)
@@ -271,6 +293,17 @@
 
 (define (lookup-function-link f)
   (hash-ref function-associations f))
+
+(define code-associations (make-hash))
+
+(define (declare-code hs co)
+  (hash-set! code-associations hs co))
+
+(define (lookup-code hs)
+  (let ([mco (hash-ref code-associations hs #f)])
+    (if (eq? mco #f)
+      (sum 0)
+      (sum 1 mco))))
 
 (define (unison-tuple->list t)
   (let ([fs (unison-data-fields t)])

--- a/scheme-libs/racket/unison/data.ss
+++ b/scheme-libs/racket/unison/data.ss
@@ -170,12 +170,6 @@
                        (string-append txt ":termlink")))])
        #`(define #,dname
            (unison-termlink-builtin #,(datum->syntax stx txt))))]))
-    ; [(_ _)
-    ;   (raise-syntax-error #f
-    ;     "define-builtin-link called with non-identifier")]
-    ; [_
-    ;   (raise-syntax-error #f
-    ;     "define-builtin link called with wrong arguments")]))
 
 (define (partial-app f . args) (unison-closure f args))
 

--- a/scheme-libs/racket/unison/io-handles.rkt
+++ b/scheme-libs/racket/unison/io-handles.rkt
@@ -104,11 +104,11 @@
 
 (define-unison (getBuffering.impl.v3 handle)
     (case (file-stream-buffer-mode handle)
-        [(none) (unison-either-right (unison-buffermode-no-buffering))]
+        [(none) (unison-either-right unison-buffermode-no-buffering)]
         [(line) (unison-either-right
-                  (unison-buffermode-line-buffering))]
+                  unison-buffermode-line-buffering)]
         [(block) (unison-either-right
-                   (unison-buffermode-block-buffering))]
+                   unison-buffermode-block-buffering)]
         [(#f) (Exception 'IO "Unable to determine buffering mode of handle" '())]
         [else (Exception 'IO "Unexpected response from file-stream-buffer-mode" '())]))
 

--- a/scheme-libs/racket/unison/math.rkt
+++ b/scheme-libs/racket/unison/math.rkt
@@ -15,6 +15,7 @@
     builtin-Int.*
     builtin-Int.pow
     builtin-Int.trailingZeros
+    builtin-Nat.trailingZeros
     builtin-Int.popCount
     builtin-Nat.popCount
     builtin-Float.pow
@@ -75,6 +76,7 @@
 (define-unison (builtin-Int.* n m) (* n m))
 (define-unison (builtin-Int.pow n m) (expt n m))
 (define-unison (builtin-Int.trailingZeros n) (TZRO n))
+(define-unison (builtin-Nat.trailingZeros n) (TZRO n))
 (define-unison (builtin-Nat.popCount n) (POPC n))
 (define-unison (builtin-Int.popCount n) (POPC n))
 (define-unison (builtin-Float.pow n m) (expt n m))

--- a/scheme-libs/racket/unison/primops.ss
+++ b/scheme-libs/racket/unison/primops.ss
@@ -88,6 +88,9 @@
     builtin-List.splitRight
     builtin-List.splitRight:termlink
 
+    builtin-Link.Term.toText
+    builtin-Link.Term.toText:termlink
+
     builtin-Value.toBuiltin
     builtin-Value.toBuiltin:termlink
     builtin-Value.fromBuiltin
@@ -601,6 +604,38 @@
     (match (unison-POp-SPLR n s)
       [(unison-sum 0 fs) unison-seqview-empty]
       [(unison-sum 1 (list l r)) (unison-seqview-elem l r)]))
+
+  (define (hash-string hs)
+    (string-append "#" (bytevector->base32-string b32h hs)))
+
+  (define (ix-string i)
+    (if (= i 0)
+      ""
+      (string-append "." (number->string i))))
+
+  (define (typelink->string ln)
+    (match ln
+      [(unison-typelink-builtin name)
+       (string-append "##" name)]
+      [(unison-typelink-derived hs i)
+       (string-append (hash-string hs) (ix-string i))]))
+
+  (define-builtin-link builtin-Link.Type.toText)
+  (define-unison (builtin-Link.Type.toText ln)
+    (string->chunked-string (typelink->string ln)))
+
+  (define (termlink->string ln)
+    (match ln
+      [(unison-termlink-builtin name)
+       (string-append "##" name)]
+      [(unison-termlink-derived hs i)
+       (string-append (hash-string hs) (ix-string i))]
+      [(unison-termlink-con rf t)
+       (string-append (typelink->string rf) "#" (number->string t))]))
+
+  (define-builtin-link builtin-Link.Term.toText)
+  (define-unison (builtin-Link.Term.toText ln)
+    (string->chunked-string (termlink->string ln)))
 
   (define (unison-POp-UPKB bs)
     (build-chunked-list

--- a/scheme-libs/racket/unison/primops.ss
+++ b/scheme-libs/racket/unison/primops.ss
@@ -25,43 +25,79 @@
 (library (unison primops)
   (export
     builtin-Float.*
+    builtin-Float.*:termlink
     builtin-Float.fromRepresentation
+    builtin-Float.fromRepresentation:termlink
     builtin-Float.toRepresentation
+    builtin-Float.toRepresentation:termlink
     builtin-Float.exp
+    builtin-Float.exp:termlink
     builtin-Float.log
+    builtin-Float.log:termlink
     builtin-Float.max
+    builtin-Float.max:termlink
     builtin-Float.min
+    builtin-Float.min:termlink
     builtin-Float.tan
+    builtin-Float.tan:termlink
     builtin-Float.tanh
+    builtin-Float.tanh:termlink
     builtin-Float.logBase
+    builtin-Float.logBase:termlink
     builtin-Float.pow
+    builtin-Float.pow:termlink
     builtin-Int.pow
+    builtin-Int.pow:termlink
     builtin-Int.*
+    builtin-Int.*:termlink
     builtin-Int.+
+    builtin-Int.+:termlink
     builtin-Int.-
+    builtin-Int.-:termlink
     builtin-Int.increment
+    builtin-Int.increment:termlink
     builtin-Int.negate
+    builtin-Int.negate:termlink
     builtin-Int.fromRepresentation
+    builtin-Int.fromRepresentation:termlink
     builtin-Int.toRepresentation
+    builtin-Int.toRepresentation:termlink
     builtin-Int.signum
+    builtin-Int.signum:termlink
     builtin-Int.trailingZeros
+    builtin-Int.trailingZeros:termlink
     builtin-Int.popCount
+    builtin-Int.popCount:termlink
     builtin-Nat.increment
+    builtin-Nat.increment:termlink
     builtin-Nat.popCount
+    builtin-Nat.popCount:termlink
     builtin-Nat.toFloat
+    builtin-Nat.toFloat:termlink
     builtin-Text.indexOf
+    builtin-Text.indexOf:termlink
     builtin-Bytes.indexOf
+    builtin-Bytes.indexOf:termlink
     builtin-IO.randomBytes
+    builtin-IO.randomBytes:termlink
 
     builtin-List.splitLeft
+    builtin-List.splitLeft:termlink
     builtin-List.splitRight
+    builtin-List.splitRight:termlink
 
     builtin-Value.toBuiltin
+    builtin-Value.toBuiltin:termlink
     builtin-Value.fromBuiltin
+    builtin-Value.fromBuiltin:termlink
     builtin-Code.fromGroup
+    builtin-Code.fromGroup:termlink
     builtin-Code.toGroup
+    builtin-Code.toGroup:termlink
     builtin-TermLink.fromReferent
+    builtin-TermLink.fromReferent:termlink
     builtin-TermLink.toReferent
+    builtin-TermLink.toReferent:termlink
 
     unison-FOp-internal.dataTag
     unison-FOp-Char.toText
@@ -73,31 +109,55 @@
     unison-FOp-IO.putBytes.impl.v3
     unison-FOp-IO.getBytes.impl.v3
     builtin-IO.seekHandle.impl.v3
+    builtin-IO.seekHandle.impl.v3:termlink
     builtin-IO.getLine.impl.v1
+    builtin-IO.getLine.impl.v1:termlink
     builtin-IO.getSomeBytes.impl.v1
+    builtin-IO.getSomeBytes.impl.v1:termlink
     builtin-IO.setBuffering.impl.v3
+    builtin-IO.setBuffering.impl.v3:termlink
     builtin-IO.getBuffering.impl.v3
+    builtin-IO.getBuffering.impl.v3:termlink
     builtin-IO.setEcho.impl.v1
+    builtin-IO.setEcho.impl.v1:termlink
     builtin-IO.isFileOpen.impl.v3
+    builtin-IO.isFileOpen.impl.v3:termlink
     builtin-IO.ready.impl.v1
+    builtin-IO.ready.impl.v1:termlink
     builtin-IO.process.call
+    builtin-IO.process.call:termlink
     builtin-IO.getEcho.impl.v1
+    builtin-IO.getEcho.impl.v1:termlink
     builtin-IO.getArgs.impl.v1
+    builtin-IO.getArgs.impl.v1:termlink
     builtin-IO.getEnv.impl.v1
+    builtin-IO.getEnv.impl.v1:termlink
     builtin-IO.getChar.impl.v1
-    builtin-IO.ready.impl.v1
+    builtin-IO.getChar.impl.v1:termlink
     builtin-IO.getCurrentDirectory.impl.v3
+    builtin-IO.getCurrentDirectory.impl.v3:termlink
     builtin-IO.removeDirectory.impl.v3
+    builtin-IO.removeDirectory.impl.v3:termlink
     builtin-IO.renameFile.impl.v3
+    builtin-IO.renameFile.impl.v3:termlink
     builtin-IO.createTempDirectory.impl.v3
+    builtin-IO.createTempDirectory.impl.v3:termlink
     builtin-IO.createDirectory.impl.v3
+    builtin-IO.createDirectory.impl.v3:termlink
     builtin-IO.setCurrentDirectory.impl.v3
+    builtin-IO.setCurrentDirectory.impl.v3:termlink
     builtin-IO.renameDirectory.impl.v3
+    builtin-IO.renameDirectory.impl.v3:termlink
     builtin-IO.isDirectory.impl.v3
+    builtin-IO.isDirectory.impl.v3:termlink
     builtin-IO.isSeekable.impl.v3
+    builtin-IO.isSeekable.impl.v3:termlink
     builtin-IO.handlePosition.impl.v3
+    builtin-IO.handlePosition.impl.v3:termlink
     builtin-IO.systemTime.impl.v3
+    builtin-IO.systemTime.impl.v3:termlink
     builtin-IO.systemTimeMicroseconds.impl.v3
+    builtin-IO.systemTimeMicroseconds.impl.v3:termlink
     unison-FOp-IO.getFileSize.impl.v3
     unison-FOp-IO.getFileTimestamp.impl.v3
     unison-FOp-IO.fileExists.impl.v3
@@ -453,6 +513,68 @@
           (unison concurrent)
           (racket random))
 
+  (define-builtin-link builtin-Float.*)
+  (define-builtin-link builtin-Float.fromRepresentation)
+  (define-builtin-link builtin-Float.toRepresentation)
+  (define-builtin-link builtin-Float.exp)
+  (define-builtin-link builtin-Float.log)
+  (define-builtin-link builtin-Float.max)
+  (define-builtin-link builtin-Float.min)
+  (define-builtin-link builtin-Float.tan)
+  (define-builtin-link builtin-Float.tanh)
+  (define-builtin-link builtin-Float.logBase)
+  (define-builtin-link builtin-Float.pow)
+  (define-builtin-link builtin-Int.pow)
+  (define-builtin-link builtin-Int.*)
+  (define-builtin-link builtin-Int.+)
+  (define-builtin-link builtin-Int.-)
+  (define-builtin-link builtin-Int.increment)
+  (define-builtin-link builtin-Int.negate)
+  (define-builtin-link builtin-Int.fromRepresentation)
+  (define-builtin-link builtin-Int.toRepresentation)
+  (define-builtin-link builtin-Int.signum)
+  (define-builtin-link builtin-Int.trailingZeros)
+  (define-builtin-link builtin-Int.popCount)
+  (define-builtin-link builtin-Nat.increment)
+  (define-builtin-link builtin-Nat.popCount)
+  (define-builtin-link builtin-Nat.toFloat)
+  (define-builtin-link builtin-Text.indexOf)
+  (define-builtin-link builtin-Bytes.indexOf)
+  (define-builtin-link builtin-IO.randomBytes)
+  (define-builtin-link builtin-List.splitLeft)
+  (define-builtin-link builtin-List.splitRight)
+  (define-builtin-link builtin-Value.toBuiltin)
+  (define-builtin-link builtin-Value.fromBuiltin)
+  (define-builtin-link builtin-Code.fromGroup)
+  (define-builtin-link builtin-Code.toGroup)
+  (define-builtin-link builtin-TermLink.fromReferent)
+  (define-builtin-link builtin-TermLink.toReferent)
+  (define-builtin-link builtin-IO.seekHandle.impl.v3)
+  (define-builtin-link builtin-IO.getLine.impl.v1)
+  (define-builtin-link builtin-IO.getSomeBytes.impl.v1)
+  (define-builtin-link builtin-IO.setBuffering.impl.v3)
+  (define-builtin-link builtin-IO.getBuffering.impl.v3)
+  (define-builtin-link builtin-IO.setEcho.impl.v1)
+  (define-builtin-link builtin-IO.isFileOpen.impl.v3)
+  (define-builtin-link builtin-IO.ready.impl.v1)
+  (define-builtin-link builtin-IO.process.call)
+  (define-builtin-link builtin-IO.getEcho.impl.v1)
+  (define-builtin-link builtin-IO.getArgs.impl.v1)
+  (define-builtin-link builtin-IO.getEnv.impl.v1)
+  (define-builtin-link builtin-IO.getChar.impl.v1)
+  (define-builtin-link builtin-IO.getCurrentDirectory.impl.v3)
+  (define-builtin-link builtin-IO.removeDirectory.impl.v3)
+  (define-builtin-link builtin-IO.renameFile.impl.v3)
+  (define-builtin-link builtin-IO.createTempDirectory.impl.v3)
+  (define-builtin-link builtin-IO.createDirectory.impl.v3)
+  (define-builtin-link builtin-IO.setCurrentDirectory.impl.v3)
+  (define-builtin-link builtin-IO.renameDirectory.impl.v3)
+  (define-builtin-link builtin-IO.isDirectory.impl.v3)
+  (define-builtin-link builtin-IO.isSeekable.impl.v3)
+  (define-builtin-link builtin-IO.handlePosition.impl.v3)
+  (define-builtin-link builtin-IO.systemTime.impl.v3)
+  (define-builtin-link builtin-IO.systemTimeMicroseconds.impl.v3)
+
   (define-unison (builtin-Value.toBuiltin v) (unison-quote v))
   (define-unison (builtin-Value.fromBuiltin v)
     (unison-quote-val v))
@@ -469,12 +591,12 @@
 
   (define-unison (builtin-List.splitLeft n s)
     (match (unison-POp-SPLL n s)
-      [(unison-sum 0 fs) (unison-seqview-empty)]
+      [(unison-sum 0 fs) unison-seqview-empty]
       [(unison-sum 1 (list l r)) (unison-seqview-elem l r)]))
 
   (define-unison (builtin-List.splitRight n s)
     (match (unison-POp-SPLR n s)
-      [(unison-sum 0 fs) (unison-seqview-empty)]
+      [(unison-sum 0 fs) unison-seqview-empty]
       [(unison-sum 1 (list l r)) (unison-seqview-elem l r)]))
 
   (define (unison-POp-UPKB bs)
@@ -565,7 +687,7 @@
   (define (->optional v)
     (if v
         (unison-optional-some v)
-        (unison-optional-none)))
+        unison-optional-none))
 
   (define-unison (builtin-Text.indexOf n h)
     (->optional (chunked-string-index-of h n)))

--- a/scheme-libs/racket/unison/primops.ss
+++ b/scheme-libs/racket/unison/primops.ss
@@ -74,6 +74,8 @@
     builtin-Nat.popCount:termlink
     builtin-Nat.toFloat
     builtin-Nat.toFloat:termlink
+    builtin-Nat.trailingZeros
+    builtin-Nat.trailingZeros:termlink
     builtin-Text.indexOf
     builtin-Text.indexOf:termlink
     builtin-Bytes.indexOf
@@ -538,6 +540,7 @@
   (define-builtin-link builtin-Nat.increment)
   (define-builtin-link builtin-Nat.popCount)
   (define-builtin-link builtin-Nat.toFloat)
+  (define-builtin-link builtin-Nat.trailingZeros)
   (define-builtin-link builtin-Text.indexOf)
   (define-builtin-link builtin-Bytes.indexOf)
   (define-builtin-link builtin-IO.randomBytes)

--- a/unison-cli/src/Unison/JitInfo.hs
+++ b/unison-cli/src/Unison/JitInfo.hs
@@ -1,4 +1,4 @@
 module Unison.JitInfo (currentRelease) where
 
 currentRelease :: String
-currentRelease = "releases/0.0.5"
+currentRelease = "releases/0.0.6"

--- a/unison-cli/src/Unison/JitInfo.hs
+++ b/unison-cli/src/Unison/JitInfo.hs
@@ -1,4 +1,4 @@
 module Unison.JitInfo (currentRelease) where
 
 currentRelease :: String
-currentRelease = "releases/0.0.6"
+currentRelease = "releases/0.0.7"

--- a/unison-src/builtin-tests/code-lookup.u
+++ b/unison-src/builtin-tests/code-lookup.u
@@ -1,0 +1,31 @@
+
+codelookup.links =
+  [ termLink data.Map.adjust
+  , termLink data.Map.alter
+  , termLink data.Map.contains
+  , termLink data.Map.delete
+  , termLink data.Map.difference
+  , termLink data.List.any
+  , termLink data.List.apply
+  , termLink data.List.compare
+  , termLink data.List.contains
+  , termLink data.List.count
+  , termLink data.List.diagonal
+  , termLink data.List.distinct
+  , termLink data.NatSet.alter
+  , termLink data.NatSet.any
+  , termLink data.NatSet.empty
+  , termLink data.NatSet.filter
+  , termLink data.Tuple.at1
+  , termLink data.Tuple.at2
+  , termLink data.Tuple.at3
+  , termLink data.Tuple.bimap
+  , termLink data.Tuple.mapLeft
+  , termLink data.graph.SCC.map
+  ]
+
+codelookup.tests : '{Tests,IO} ()
+codelookup.tests = do
+  foreach codelookup.links (l -> match Code.lookup l with
+    None -> fail "codelookup" ("missing code for: " ++ toText l)
+    Some _ -> pass ("codelookup " ++ toText l))

--- a/unison-src/builtin-tests/interpreter-tests.md
+++ b/unison-src/builtin-tests/interpreter-tests.md
@@ -70,6 +70,11 @@ to `Tests.check` and `Tests.checkEqual`).
 ```
 
 ```ucm:hide
+.> load unison-src/builtin-tests/code-lookup.u
+.> add
+```
+
+```ucm:hide
 .> load unison-src/builtin-tests/tests.u
 .> add
 ```

--- a/unison-src/builtin-tests/jit-tests.md
+++ b/unison-src/builtin-tests/jit-tests.md
@@ -72,6 +72,11 @@ to `Tests.check` and `Tests.checkEqual`).
 ```
 
 ```ucm:hide
+.> load unison-src/builtin-tests/code-lookup.u
+.> add
+```
+
+```ucm:hide
 .> load unison-src/builtin-tests/tests.u
 .> add
 ```

--- a/unison-src/builtin-tests/serial-tests.u
+++ b/unison-src/builtin-tests/serial-tests.u
@@ -65,6 +65,14 @@ serial.readFile fp =
     else read (acc ++ getBytes h 1024)
   read 0xs
 
+checkCached name = cases
+  [] -> pass (name ++ " code cached")
+  (ln, co0) +: rest -> match Code.lookup ln with
+    None -> fail name "code cache missing"
+    Some co1
+      | co0 === co1 -> checkCached name rest
+      | otherwise -> fail name "code cache mismatch"
+
 serial.loadSelfContained : Text -> FilePath ->{IO, Tests, Exception} a
 serial.loadSelfContained name path =
   input = readFile path
@@ -88,6 +96,7 @@ serial.loadSelfContained name path =
       Right _ -> fail name "failed link validation"
 
     _ = cache_ deps
+    checkCached name deps
     match Value.load v with
       Left l -> raiseFailure "value missing deps" l
       Right x -> x

--- a/unison-src/builtin-tests/tests.u
+++ b/unison-src/builtin-tests/tests.u
@@ -14,6 +14,7 @@ tests = Tests.main do
   !text.tests
   !bytes.tests
   !array.tests
+  !codelookup.tests
 
 
 crypto.hash.tests = do


### PR DESCRIPTION
This PR contains updates related to looking up code at runtime

- Added a code cache in the unison/data module that associates the term links with their intermediate code.
- Added a macro for defining termlinks for builtin functions, for builtins that are implemented direclty in scheme.
- Declared termlinks for directly implemented builtins
- Nullary unison data constructors have been changed to not be procedures, so various replacements like:
        `(unison-optional-none) ==> unison-optional-none`
- Implemented code lookup builtin/primop
- Modified the serialized tests to check code lookup of dynamically added code

I'll add some tests that look up statically generated code. Right now the tests only look up code that is added to the cache dynamically, and that's an almost completely different code path.