### PR TITLE
add expectDeclNumConstructors

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Decode.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Decode.hs
@@ -6,6 +6,7 @@ module U.Codebase.Sqlite.Decode
     decodeBranchFormat,
     decodeComponentLengthOnly,
     decodeDeclElement,
+    decodeDeclElementNumConstructors,
     decodeDeclFormat,
     decodePatchFormat,
     decodeSyncDeclFormat,
@@ -79,6 +80,10 @@ decodeComponentLengthOnly =
 decodeDeclElement :: Word64 -> ByteString -> Either DecodeError (LocalIds, DeclFormat.Decl Symbol)
 decodeDeclElement i =
   getFromBytesOr ("lookupDeclElement " <> tShow i) (Serialization.lookupDeclElement i)
+
+decodeDeclElementNumConstructors :: Word64 -> ByteString -> Either DecodeError Int
+decodeDeclElementNumConstructors i =
+  getFromBytesOr ("lookupDeclElementNumConstructors " <> tShow i) (Serialization.lookupDeclElementNumConstructors i)
 
 decodeDeclFormat :: ByteString -> Either DecodeError DeclFormat.DeclFormat
 decodeDeclFormat =

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Operations.hs
@@ -31,6 +31,7 @@ module U.Codebase.Sqlite.Operations
     loadDeclComponent,
     loadDeclByReference,
     expectDeclByReference,
+    expectDeclNumConstructors,
     expectDeclTypeById,
 
     -- * terms/decls
@@ -538,6 +539,12 @@ expectDeclByReference r@(C.Reference.Id h i) = do
   Q.expectObjectIdForPrimaryHash h
     >>= (\oid -> Q.expectDeclObject oid (decodeDeclElement i))
     >>= uncurry Q.s2cDecl
+
+expectDeclNumConstructors :: C.Reference.Id -> Transaction Int
+expectDeclNumConstructors (C.Reference.Id h i) = do
+  oid <- Q.expectObjectIdForPrimaryHash h
+  Q.expectDeclObject oid (decodeDeclElementNumConstructors i)
+
 
 -- * Branch transformation
 

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Serialization.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Serialization.hs
@@ -498,6 +498,8 @@ lookupDeclElementNumConstructors :: (MonadGet m) => Reference.Pos -> m Int
 lookupDeclElementNumConstructors i =
   lookupDeclElementWith i (skipLocalIds *> getDeclElementNumConstructors)
 
+-- Note: the caller is responsible for either consuming the whole decl, or not
+-- parsing anything after a partially-parsed decl
 lookupDeclElementWith :: (MonadGet m) => Reference.Pos -> m a -> m a
 lookupDeclElementWith i get =
   getWord8 >>= \case

--- a/codebase2/util-serialization/U/Util/Serialization.hs
+++ b/codebase2/util-serialization/U/Util/Serialization.hs
@@ -9,7 +9,7 @@
 module U.Util.Serialization where
 
 import Control.Applicative (Applicative (liftA2), liftA3)
-import Control.Monad (foldM, replicateM, when)
+import Control.Monad (foldM, replicateM, when, replicateM_)
 import Data.Bits (Bits, clearBit, setBit, shiftL, shiftR, testBit, (.|.))
 import Data.ByteString (ByteString, readFile, writeFile)
 import qualified Data.ByteString as BS
@@ -142,13 +142,22 @@ putFoldable putA as = do
 
 getList :: (MonadGet m) => m a -> m [a]
 getList getA = do
-  length <- getVarInt
+  length <- getListLength
   replicateM length getA
+
+getListLength :: (MonadGet m) => m Int
+getListLength =
+  getVarInt
 
 getVector :: (MonadGet m) => m a -> m (Vector a)
 getVector getA = do
   length <- getVarInt
   Vector.replicateM length getA
+
+skipVector :: MonadGet m => m a -> m ()
+skipVector getA = do
+  length <- getVarInt
+  replicateM_ length getA
 
 getSequence :: (MonadGet m) => m a -> m (Seq a)
 getSequence getA = do


### PR DESCRIPTION
## Overview

This PR adds a `expectDeclNumConstructors` query to get the number of constructors in a decl:

```haskell
expectDeclNumConstructors :: TypeReferenceId -> Transaction Int
```

(we use this in the upcoming merge algorithm)