### PR TITLE
Delay kind defaulting

### DIFF
--- a/parser-typechecker/src/Unison/KindInference.hs
+++ b/parser-typechecker/src/Unison/KindInference.hs
@@ -28,7 +28,7 @@ import Data.Map.Strict qualified as Map
 import Unison.Codebase.BuiltinAnnotation (BuiltinAnnotation)
 import Unison.DataDeclaration
 import Unison.KindInference.Generate (declComponentConstraints, termConstraints)
-import Unison.KindInference.Solve (KindError, verify, initialState, step)
+import Unison.KindInference.Solve (KindError, verify, initialState, step, defaultUnconstrainedVars)
 import Unison.KindInference.Solve.Monad (Env (..), SolveState, run, runGen)
 import Unison.Prelude
 import Unison.PrettyPrintEnv qualified as PrettyPrintEnv
@@ -76,7 +76,7 @@ inferDecls ppe declMap =
       handleComponents = verify <=< foldlM phi (initialState env)
         where
           phi b a = handleComponent b a
-   in handleComponents components
+   in defaultUnconstrainedVars <$> handleComponents components
 
 -- | Break the decls into strongly connected components in reverse
 -- topological order

--- a/parser-typechecker/src/Unison/KindInference/Solve.hs
+++ b/parser-typechecker/src/Unison/KindInference/Solve.hs
@@ -2,6 +2,7 @@ module Unison.KindInference.Solve
   ( step,
     verify,
     initialState,
+    defaultUnconstrainedVars,
     KindError (..),
     ConstraintConflict (..),
   )
@@ -76,7 +77,7 @@ step e st cs =
    in case unSolve action e st of
         (res, finalState) -> case res of
           Left e -> Left e
-          Right () -> Right (defaultUnconstrainedVars finalState)
+          Right () -> Right finalState
 
 -- | Default any unconstrained vars to *
 defaultUnconstrainedVars :: Var v => SolveState v loc -> SolveState v loc

--- a/unison-src/transcripts/kind-inference.md
+++ b/unison-src/transcripts/kind-inference.md
@@ -54,6 +54,13 @@ unique type T a = T a
 unique type S = S (T Nat)
 ```
 
+Demonstrate kind defaulting by component
+```unison:error
+unique type T a = T
+
+unique type S = S (T Optional)
+```
+
 Catch invalid instantiation of `T`'s `a` parameter in `S`
 ```unison:error
 unique type T a = T a

--- a/unison-src/transcripts/kind-inference.md
+++ b/unison-src/transcripts/kind-inference.md
@@ -54,7 +54,9 @@ unique type T a = T a
 unique type S = S (T Nat)
 ```
 
-Delay kind defaulting until all components are processed
+Delay kind defaulting until all components are processed. Here `S`
+constrains the kind of `T`'s `a` parameter, although `S` is not in
+the same component as `T`.
 ```unison
 unique type T a = T
 

--- a/unison-src/transcripts/kind-inference.md
+++ b/unison-src/transcripts/kind-inference.md
@@ -55,7 +55,7 @@ unique type S = S (T Nat)
 ```
 
 Delay kind defaulting until all components are processed
-```unison:error
+```unison
 unique type T a = T
 
 unique type S = S (T Optional)

--- a/unison-src/transcripts/kind-inference.md
+++ b/unison-src/transcripts/kind-inference.md
@@ -54,7 +54,7 @@ unique type T a = T a
 unique type S = S (T Nat)
 ```
 
-Demonstrate kind defaulting by component
+Delay kind defaulting until all components are processed
 ```unison:error
 unique type T a = T
 

--- a/unison-src/transcripts/kind-inference.output.md
+++ b/unison-src/transcripts/kind-inference.output.md
@@ -120,6 +120,22 @@ unique type S = S (T Nat)
       unique type T a
 
 ```
+Demonstrate kind defaulting by component
+```unison
+unique type T a = T
+
+unique type S = S (T Optional)
+```
+
+```ucm
+
+  Kind mismatch arising from
+        3 | unique type S = S (T Optional)
+    
+    T expects an argument of kind: Type; however, it is applied
+    to Optional which has kind: Type -> Type.
+
+```
 Catch invalid instantiation of `T`'s `a` parameter in `S`
 ```unison
 unique type T a = T a

--- a/unison-src/transcripts/kind-inference.output.md
+++ b/unison-src/transcripts/kind-inference.output.md
@@ -120,7 +120,7 @@ unique type S = S (T Nat)
       unique type T a
 
 ```
-Demonstrate kind defaulting by component
+Delay kind defaulting until all components are processed
 ```unison
 unique type T a = T
 
@@ -129,11 +129,14 @@ unique type S = S (T Optional)
 
 ```ucm
 
-  Kind mismatch arising from
-        3 | unique type S = S (T Optional)
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
     
-    T expects an argument of kind: Type; however, it is applied
-    to Optional which has kind: Type -> Type.
+      unique type S
+      unique type T a
 
 ```
 Catch invalid instantiation of `T`'s `a` parameter in `S`

--- a/unison-src/transcripts/kind-inference.output.md
+++ b/unison-src/transcripts/kind-inference.output.md
@@ -120,7 +120,9 @@ unique type S = S (T Nat)
       unique type T a
 
 ```
-Delay kind defaulting until all components are processed
+Delay kind defaulting until all components are processed. Here `S`
+constrains the kind of `T`'s `a` parameter, although `S` is not in
+the same component as `T`.
 ```unison
 unique type T a = T
 


### PR DESCRIPTION
## Overview

When inferring the kinds of data decls, unconstrained vars are defaulted to kind `Type`. This defaulting normally occurs after processing each strongly connected decl component. 

We have since learned that haskell 98 kinds are not sufficient for the `distributed` package, which expects some unconstrained phantom types to have kind `Ability`. Polymorphic kinds would be an ideal way to accommodate this. A kind signature is another possibility. We don't want to invest the time on polymorphic kinds right now, and we don't want to change the type by adding a kind signature, so this PR provides the desired behavior by delaying kind defaulting until all decls have been processed.

## Interesting/controversial decisions

This change means that the kind of a decl with unconstrained vars may change depending on what dependents are in scope. This is ok for now, especially because we don't persist any kind information at this time. For a more permanent solution, we want to introduce polymorphic kinds.

## Test coverage

There is a new example in the kind-inference transcript.