### PR TITLE
Add missing spaces to `pull` explanation

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -78,3 +78,4 @@ The format for this list: name, GitHub handle
 * Hatim Khambati (@hatimkhambati26)
 * Kyle Goetz (@kylegoetz)
 * Ethan Morgan (@sixfourtwelve)
+* Johan Winther (@JohanWinther)

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1210,11 +1210,11 @@ pullImpl name aliases verbosity pullMode addendum = do
           argTypes = [(Optional, remoteNamespaceArg), (Optional, namespaceArg)],
           help =
             P.lines
-              [ P.wrap
-                  "The "
-                  <> makeExample' self
-                  <> " command merges a remote namespace into a local namespace "
-                  <> addendum,
+              [ P.wrap $
+                  "The"
+                    <> makeExample' self
+                    <> "command merges a remote namespace into a local namespace"
+                    <> addendum,
                 "",
                 P.wrapColumn2
                   [ ( makeExample self ["@unison/base/main"],

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1211,9 +1211,9 @@ pullImpl name aliases verbosity pullMode addendum = do
           help =
             P.lines
               [ P.wrap
-                  "The"
+                  "The "
                   <> makeExample' self
-                  <> "command merges a remote namespace into a local namespace"
+                  <> " command merges a remote namespace into a local namespace "
                   <> addendum,
                 "",
                 P.wrapColumn2


### PR DESCRIPTION
## Overview

Adds missing spaces to the explanation of all the `pull` commands.

Before:
```ucm
@unison/base/main> ? pull

  pull (or pull.silent)
  The`pull`command merges a remote namespace into a local namespacewithout listing the merged entities
```
After:
![image](https://github.com/unisonweb/unison/assets/28558941/a1852b91-946f-4f77-a6b8-8534c5713610)


## Test coverage
No changes to tests needed.
