### PR TITLE
Align client timeouts with server-side timeouts

### DIFF
--- a/unison-cli/src/Unison/Cli/Share/Projects.hs
+++ b/unison-cli/src/Unison/Cli/Share/Projects.hs
@@ -34,6 +34,7 @@ where
 import Control.Lens ((^.))
 import Control.Monad.Reader (ask)
 import Data.Proxy
+import Network.HTTP.Client qualified as Http.Client
 import Network.URI (URI)
 import Network.URI qualified as URI
 import Servant.API ((:<|>) (..), (:>))
@@ -255,7 +256,12 @@ servantClientToCli action = do
 
   let clientEnv :: ClientEnv
       clientEnv =
-        mkClientEnv httpManager hardCodedBaseUrl
+        (mkClientEnv httpManager hardCodedBaseUrl)
+          { Servant.makeClientRequest = \url request ->
+              (Servant.defaultMakeClientRequest url request)
+                { Http.Client.responseTimeout = Http.Client.responseTimeoutMicro (60 * 1000 * 1000 {- 60s -})
+                }
+          }
 
   liftIO (runClientM action clientEnv)
 


### PR DESCRIPTION
## Overview

There have been a few cases where UCM tries to push or something like that, Share starts working on it, then the http-client gives up after 30s and tells UCM it failed even though Share is still working on it. The user then tries again, the request hits a PG transaction that the first request conflicts with, so it waits for the lock, then the first request succeeds; but causes that waiting request to fail since the state has changed.

Now the user is very confused, they've gotten two different errors in a row, and think everything has failed horribly, when in reality the very first request succeeded!

The best solution is that the client and Share have similar timeouts so that UCM doesn't hang up before Share has given up, e.g. if the timeout is triggered UCM correctly knows the request has failed, but if Share is still working on it UCM just waits, rather than getting a hang-up from NGINX.

## Implementation notes

Sets the http-client timeout to 60s which is the longest timeout on Share.

## Testing

None, pretty trivial change.