### PR TITLE
Assorted pretty-printing round trip fixes

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -460,8 +460,6 @@ pretty0
                             <> [lhs, arr]
                     go tm = goNormal 10 tm
                 PP.hang kw <$> fmap PP.lines (traverse go rs)
-              -- (Apps' f@(Constructor' _) args, _) ->
-                -- paren (p >= 10) <$> (PP.hang <$> goNormal 9 f <*> PP.spacedTraverse (goNormal 10) args)
               (Bytes' bs, _) ->
                 pure $ fmt S.BytesLiteral "0xs" <> PP.shown (Bytes.fromWord8s (map fromIntegral bs))
               BinaryAppsPred' apps lastArg -> do

--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -566,7 +566,6 @@ pretty0
 
       nonForcePred :: Term3 v PrintAnnotation -> Bool
       nonForcePred = \case
-        Constructor' (ConstructorReference DD.UnitRef 0) -> False
         Constructor' (ConstructorReference DD.DocRef _) -> False
         _ -> True
 

--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -228,7 +228,7 @@ pretty0
         tm' <- pretty0 (ac 10 Normal im doc) tm
         tp' <- TypePrinter.pretty0 im 0 t
         pure . paren (p >= 0) $ tm' <> PP.hang (fmt S.TypeAscriptionColon " :") tp'
-      Int' i -> pure . fmt S.NumericLiteral $ (if i >= 0 then l "+" else mempty) <> l (show i)
+      Int' i -> pure . fmt S.NumericLiteral . l $ (if i >= 0 then ("+" ++ show i) else (show i))
       Nat' u -> pure . fmt S.NumericLiteral . l $ show u
       Float' f -> pure . fmt S.NumericLiteral . l $ show f
       -- TODO How to handle Infinity, -Infinity and NaN?  Parser cannot parse

--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -460,8 +460,8 @@ pretty0
                             <> [lhs, arr]
                     go tm = goNormal 10 tm
                 PP.hang kw <$> fmap PP.lines (traverse go rs)
-              (Apps' f@(Constructor' _) args, _) ->
-                paren (p >= 10) <$> (PP.hang <$> goNormal 9 f <*> PP.spacedTraverse (goNormal 10) args)
+              -- (Apps' f@(Constructor' _) args, _) ->
+                -- paren (p >= 10) <$> (PP.hang <$> goNormal 9 f <*> PP.spacedTraverse (goNormal 10) args)
               (Bytes' bs, _) ->
                 pure $ fmt S.BytesLiteral "0xs" <> PP.shown (Bytes.fromWord8s (map fromIntegral bs))
               BinaryAppsPred' apps lastArg -> do

--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -304,7 +304,7 @@ pretty0
       Delay' x
         | isLet x || p < 0 -> do
             let (im', uses) = calcImports im x
-            let hang = if isSoftHangable x then PP.softHang else PP.hang
+            let hang = if isSoftHangable x && null uses then PP.softHang else PP.hang
             px <- pretty0 (ac 0 Block im' doc) x
             pure . paren (p >= 3) $
               fmt S.ControlKeyword "do" `hang` PP.lines (uses <> [px])

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -50,7 +50,7 @@ So we can see the pretty-printed output:
     structural type Fully.qualifiedName
       = Dontcare () Nat
     
-    unique type HandlerWebSocket x
+    structural type HandlerWebSocket x y z p q
       = HandlerWebSocket x
     
     structural type Id a
@@ -277,13 +277,12 @@ So we can see the pretty-printed output:
       Some x -> x
       None   -> bug "oops"
     
-    fix_4340 : HandlerWebSocket (Nat ->{g, Abort} Text)
+    fix_4340 : HandlerWebSocket (Nat ->{g, Abort} Text) y z p q
     fix_4340 = 
-      HandlerWebSocket
-        (cases
-          1 ->
-            "hi sdflkj sdlfkjsdflkj sldfkj sldkfj sdf asdlkfjs dlfkj sldfkj sdf"
-          _ -> abort)
+      HandlerWebSocket cases
+        1 ->
+          "hi sdflkj sdlfkjsdflkj sldfkj sldkfj sdf asdlkfjs dlfkj sldfkj sdf"
+        _ -> abort
     
     fix_4352 : Doc2
     fix_4352 = {{ `` +1 `` }}
@@ -298,7 +297,7 @@ So we can see the pretty-printed output:
     
     fix_525_exampleType :
       Id qualifiedName -> Id Fully.qualifiedName
-    fix_525_exampleType z = Id (Dontcare () 19)
+    fix_525_exampleType z = Id (!Dontcare 19)
     
     Foo.bar.qux1 : Nat
     Foo.bar.qux1 = 42
@@ -629,19 +628,74 @@ So we can see the pretty-printed output:
   definitions currently in this namespace.
 
 ```
+This diff should be empty if the two namespaces are equivalent. If it's nonempty, the diff will show us the hashes that differ.
+
 ```ucm
-.a2> load /private/tmp/roundtrip.u
+.> diff.namespace a1 a2
+
+  The namespaces are identical.
+
+```
+Now check that definitions in 'reparses.u' at least parse on round trip:
+
+This just makes 'roundtrip.u' the latest scratch file.
+
+```unison
+---
+title: /private/tmp/roundtrip.u
+---
+x = ()
+
 ```
 
 
-🛑
+```ucm
+.a3> edit 1-5000
 
-The transcript failed due to an error in the stanza above. The error is:
-
-
-  offset=1360:
-  unexpected (
-  expecting newline or semicolon
-    246 |   (cases
+  ☝️
   
+  I added these definitions to the top of
+  /private/tmp/roundtrip.u
+  
+    explanationOfThisFile : Text
+    explanationOfThisFile =
+      """
+      Put definitions in here that are expected to
+      parse with a different hash after pretty-printing.
+      """
+    
+    sloppyDocEval : Doc2
+    sloppyDocEval =
+      use Nat +
+      {{
+      Here's an example of an eval block that's technically a
+      lambda but should print as a backticked block (since old
+      docs in the wild still use this format).
+      
+      ```
+      1 + 1
+      ```
+      }}
+  
+  You can edit them there, then do `update` to replace the
+  definitions currently in this namespace.
+
+```
+These are currently all expected to have different hashes on round trip.
+
+```ucm
+.> diff.namespace a3 a3_old
+
+  Updates:
+  
+    1. sloppyDocEval : Doc2
+       ↓
+    2. sloppyDocEval : Doc2
+
+```
+## Other regression tests not covered by above
+
+### Comment out builtins in the edit command
+
+Regression test for https://github.com/unisonweb/unison/pull/3548
 

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -32,6 +32,8 @@ So we can see the pretty-printed output:
   
     structural ability Abort where abort : {Abort} a
     
+    structural ability Ask a where ask : {Ask a} a
+    
     structural type Fix_2337
       = Fix_2337 Boolean Boolean
     
@@ -77,6 +79,13 @@ So we can see the pretty-printed output:
     
     catchAll : x -> Nat
     catchAll x = 99
+    
+    Decode.remainder : '{Ask (Optional Bytes)} Bytes
+    Decode.remainder = do
+      use Bytes ++
+      match ask with
+        None   -> Bytes.empty
+        Some b -> b ++ !Decode.remainder
     
     ex1 : Nat
     ex1 =

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -50,6 +50,9 @@ So we can see the pretty-printed output:
     structural type Fully.qualifiedName
       = Dontcare () Nat
     
+    unique type HandlerWebSocket x
+      = HandlerWebSocket x
+    
     structural type Id a
       = Id a
     
@@ -273,6 +276,14 @@ So we can see the pretty-printed output:
     fix_3710d = cases
       Some x -> x
       None   -> bug "oops"
+    
+    fix_4340 : HandlerWebSocket (Nat ->{g, Abort} Text)
+    fix_4340 = 
+      HandlerWebSocket
+        (cases
+          1 ->
+            "hi sdflkj sdlfkjsdflkj sldfkj sldkfj sdf asdlkfjs dlfkj sldfkj sdf"
+          _ -> abort)
     
     fix_4352 : Doc2
     fix_4352 = {{ `` +1 `` }}
@@ -618,74 +629,19 @@ So we can see the pretty-printed output:
   definitions currently in this namespace.
 
 ```
-This diff should be empty if the two namespaces are equivalent. If it's nonempty, the diff will show us the hashes that differ.
-
 ```ucm
-.> diff.namespace a1 a2
-
-  The namespaces are identical.
-
-```
-Now check that definitions in 'reparses.u' at least parse on round trip:
-
-This just makes 'roundtrip.u' the latest scratch file.
-
-```unison
----
-title: /private/tmp/roundtrip.u
----
-x = ()
-
+.a2> load /private/tmp/roundtrip.u
 ```
 
 
-```ucm
-.a3> edit 1-5000
+🛑
 
-  ☝️
+The transcript failed due to an error in the stanza above. The error is:
+
+
+  offset=1360:
+  unexpected (
+  expecting newline or semicolon
+    246 |   (cases
   
-  I added these definitions to the top of
-  /private/tmp/roundtrip.u
-  
-    explanationOfThisFile : Text
-    explanationOfThisFile =
-      """
-      Put definitions in here that are expected to
-      parse with a different hash after pretty-printing.
-      """
-    
-    sloppyDocEval : Doc2
-    sloppyDocEval =
-      use Nat +
-      {{
-      Here's an example of an eval block that's technically a
-      lambda but should print as a backticked block (since old
-      docs in the wild still use this format).
-      
-      ```
-      1 + 1
-      ```
-      }}
-  
-  You can edit them there, then do `update` to replace the
-  definitions currently in this namespace.
-
-```
-These are currently all expected to have different hashes on round trip.
-
-```ucm
-.> diff.namespace a3 a3_old
-
-  Updates:
-  
-    1. sloppyDocEval : Doc2
-       ↓
-    2. sloppyDocEval : Doc2
-
-```
-## Other regression tests not covered by above
-
-### Comment out builtins in the edit command
-
-Regression test for https://github.com/unisonweb/unison/pull/3548
 

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -283,7 +283,7 @@ So we can see the pretty-printed output:
       ()
     
     fix_4258_example : ()
-    fix_4258_example = (fix_4258 1 ()) 2
+    fix_4258_example = fix_4258 1 () 2
     
     fix_4340 : HandlerWebSocket (Nat ->{g, Abort} Text) y z p q
     fix_4340 = 
@@ -305,7 +305,7 @@ So we can see the pretty-printed output:
     
     fix_525_exampleType :
       Id qualifiedName -> Id Fully.qualifiedName
-    fix_525_exampleType z = Id (!Dontcare 19)
+    fix_525_exampleType z = Id (Dontcare () 19)
     
     Foo.bar.qux1 : Nat
     Foo.bar.qux1 = 42

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -277,6 +277,14 @@ So we can see the pretty-printed output:
       Some x -> x
       None   -> bug "oops"
     
+    fix_4258 : x -> y -> z -> ()
+    fix_4258 x y z =
+      _ = "fix_4258"
+      ()
+    
+    fix_4258_example : ()
+    fix_4258_example = (fix_4258 1 ()) 2
+    
     fix_4340 : HandlerWebSocket (Nat ->{g, Abort} Text) y z p q
     fix_4340 = 
       HandlerWebSocket cases
@@ -339,8 +347,9 @@ So we can see the pretty-printed output:
     longlines1 =
       do
         longlines
-          !(longlines_helper
-             "This has to laksdjf alsdkfj alskdjf asdf be a long enough string to force a line break")
+          (longlines_helper
+            "This has to laksdjf alsdkfj alskdjf asdf be a long enough string to force a line break"
+            ())
     
     longlines2 : (Text, '{g} Bytes)
     longlines2 =

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -265,6 +265,9 @@ So we can see the pretty-printed output:
       Some x -> x
       None   -> bug "oops"
     
+    fix_4352 : Doc2
+    fix_4352 = {{ `` +1 `` }}
+    
     Fix_525.bar.quaffle : Nat
     Fix_525.bar.quaffle = 32
     

--- a/unison-src/transcripts-round-trip/reparses-with-same-hash.u
+++ b/unison-src/transcripts-round-trip/reparses-with-same-hash.u
@@ -466,3 +466,5 @@ test3 = do
 -- this would previously get printed as `Join.Join`
 structural type foo.Join =
   Table | Join Boolean | Values [Nat]
+
+fix_4352 = {{``+1``}}

--- a/unison-src/transcripts-round-trip/reparses-with-same-hash.u
+++ b/unison-src/transcripts-round-trip/reparses-with-same-hash.u
@@ -484,7 +484,12 @@ Decode.remainder = do
 
 structural type HandlerWebSocket x y z p q = HandlerWebSocket x
 
--- socketRouteHandler : Nat ->{Abort} Text
 fix_4340 = HandlerWebSocket cases
   1 -> "hi sdflkj sdlfkjsdflkj sldfkj sldkfj sdf asdlkfjs dlfkj sldfkj sdf"
   _ -> abort
+
+fix_4258 x y z = 
+  _ = "fix_4258"
+  ()
+
+fix_4258_example = fix_4258 1 () 2

--- a/unison-src/transcripts-round-trip/reparses-with-same-hash.u
+++ b/unison-src/transcripts-round-trip/reparses-with-same-hash.u
@@ -481,3 +481,10 @@ Decode.remainder = do
   match ask with
     None -> Bytes.empty
     Some b -> b ++ !Decode.remainder
+
+unique type HandlerWebSocket x = HandlerWebSocket x
+
+-- socketRouteHandler : Nat ->{Abort} Text
+fix_4340 = HandlerWebSocket cases
+  1 -> "hi sdflkj sdlfkjsdflkj sldfkj sldkfj sdf asdlkfjs dlfkj sldfkj sdf"
+  _ -> abort

--- a/unison-src/transcripts-round-trip/reparses-with-same-hash.u
+++ b/unison-src/transcripts-round-trip/reparses-with-same-hash.u
@@ -482,7 +482,7 @@ Decode.remainder = do
     None -> Bytes.empty
     Some b -> b ++ !Decode.remainder
 
-unique type HandlerWebSocket x = HandlerWebSocket x
+structural type HandlerWebSocket x y z p q = HandlerWebSocket x
 
 -- socketRouteHandler : Nat ->{Abort} Text
 fix_4340 = HandlerWebSocket cases

--- a/unison-src/transcripts-round-trip/reparses-with-same-hash.u
+++ b/unison-src/transcripts-round-trip/reparses-with-same-hash.u
@@ -468,3 +468,16 @@ structural type foo.Join =
   Table | Join Boolean | Values [Nat]
 
 fix_4352 = {{``+1``}}
+
+-- regression test to make sure we don't use soft hang between a `do` and `match`
+-- if there's imports that have been inserted there
+
+structural ability Ask a where 
+  ask : a 
+
+Decode.remainder : '{Ask (Optional Bytes)} Bytes
+Decode.remainder = do 
+  use Bytes ++
+  match ask with
+    None -> Bytes.empty
+    Some b -> b ++ !Decode.remainder


### PR DESCRIPTION
Fixes assorted round trip issues and adds regression tests.

Fixes #4352

Fixes https://github.com/unisonweb/unison/issues/4344

Fixes #4340

Fixes #4258 

<img width="653" alt="CleanShot 2023-11-04 at 10 10 01@2x" src="https://github.com/unisonweb/unison/assets/11074/cee376be-9d93-46f4-be89-417e98599db9">

What's going on here is it is attempting to do a soft hang, for instance `foo = do match blah with` would be fine, but when there's an intervening `use` clause insertion, it should render as

```
foo = do 
   use blah oog
   match xyz with ...
```

and now it does as of this PR.

