### PR TITLE
Fix parser issue caused by virtual semicolons being emitted inside parens

### DIFF
--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -598,6 +598,24 @@ So we can see the pretty-printed output:
             _ -> 2
       go (SomethingUnusuallyLong "one" "two" "three")
     
+    stew_issue : ()
+    stew_issue =
+      error x = ()
+      a ++ b = 0
+      toText a = a
+      Debug : a -> b -> ()
+      Debug a b = ()
+      error (Debug None '(Debug "Failed " 42))
+    
+    stew_issue2 : ()
+    stew_issue2 =
+      error x = ()
+      a ++ b = 0
+      toText a = a
+      Debug : a -> b -> ()
+      Debug a b = ()
+      error (Debug None '("Failed " ++ toText 42))
+    
     test3 : '('('r))
     test3 = do
       run : Nat -> a

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -616,6 +616,19 @@ So we can see the pretty-printed output:
       Debug a b = ()
       error (Debug None '("Failed " ++ toText 42))
     
+    stew_issue3 : ()
+    stew_issue3 =
+      id x = x
+      error x = ()
+      a ++ b = 0
+      blah x y = 99
+      toText a = a
+      configPath = 0
+      Debug a b = ()
+      error
+        (Debug None '("Failed to get timestamp of config file "
+            ++ toText configPath))
+    
     test3 : '('('r))
     test3 = do
       run : Nat -> a

--- a/unison-src/transcripts-round-trip/reparses-with-same-hash.u
+++ b/unison-src/transcripts-round-trip/reparses-with-same-hash.u
@@ -515,3 +515,15 @@ stew_issue2 =
   error
     (Debug None '("Failed " ++ 
            toText 42))
+
+stew_issue3 = 
+  id x = x
+  error x = ()
+  (++) a b = 0
+  blah x y = 99
+  toText a = a
+  configPath = 0
+  Debug a b = ()
+  error
+    (Debug None '("Failed to get timestamp of config file " ++ 
+           toText configPath))

--- a/unison-src/transcripts-round-trip/reparses-with-same-hash.u
+++ b/unison-src/transcripts-round-trip/reparses-with-same-hash.u
@@ -493,3 +493,25 @@ fix_4258 x y z =
   ()
 
 fix_4258_example = fix_4258 1 () 2
+
+-- previously, lexer was emitting virtual semicolons inside parens, which
+-- led to some very odd parse errors in cases like these
+
+stew_issue = 
+  error x = ()
+  (++) a b = 0
+  toText a = a
+  Debug : a -> b -> ()
+  Debug a b = ()
+  error
+    (Debug None '(Debug "Failed " -- virtual semicolon here was tripping up parser 
+                  42))
+stew_issue2 = 
+  error x = ()
+  (++) a b = 0
+  toText a = a
+  Debug : a -> b -> ()
+  Debug a b = ()
+  error
+    (Debug None '("Failed " ++ 
+           toText 42))

--- a/unison-syntax/src/Unison/Syntax/Lexer.hs
+++ b/unison-syntax/src/Unison/Syntax/Lexer.hs
@@ -233,7 +233,7 @@ token'' tok p = do
     pops p = do
       env <- S.get
       let l = layout env
-      if top l == column p
+      if top l == column p && topBlockName l /= Just "(" -- don't emit virtual semis inside parens
         then pure [Token (Semi True) p p]
         else
           if column p > top l || topHasClosePair l


### PR DESCRIPTION
Prior to this PR, the following wouldn't parse:

```
stew_issue = 
  error x = ()
  (++) a b = 0
  toText a = a
  Debug : a -> b -> ()
  Debug a b = ()
  error
    (Debug None '(Debug "Failed " -- virtual semicolon here was tripping up parser 
                  42))
```

The reason is that the lexer was emitting virtual semicolons inside of parens, so the `42` there was immediately preceded by a virtual semicolon, since its starting column is equal to the first column following the opening parens.

What was wild about this is if you just moved the `42` over to the left or the right one column, the semicolon wouldn't get emitted and it would parse fine.

Anyway, we only use virtual semicolons to separate bindings in a block, or operations of an ability declaration. I don't think there's any reason to emit them them inside parens. Fix was a small tweak to the lexer.

Added regression tests.