### PR TITLE
Add entity validation on pull.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,6 +8,8 @@
     * [`UNISON_LSP_ENABLED`](#unison_lsp_enabled)
     * [`UNISON_SHARE_HOST`](#unison_share_host)
     * [`UNISON_SHARE_ACCESS_TOKEN`](#unison_share_access_token)
+    * [`UNISON_READONLY`](#unison_readonly)
+    * [`UNISON_ENTITY_VALIDATION`](#unison_entity_validation)
     * [Local Codebase Server](#local-codebase-server)
 * [Codebase Configuration](#codebase-configuration)
 
@@ -102,6 +104,14 @@ Force unison to use readonly connections to codebases.
 
 ```sh
 $ UNISON_READONLY="true" ucm
+```
+
+### `UNISON_ENTITY_VALIDATION`
+
+Enable validation of entities pulled from a codebase server.
+
+```sh
+$ UNISON_ENTITY_VALIDATION="true" ucm
 ```
 
 ### Local Codebase Server

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2210,6 +2210,7 @@ prettyDownloadEntitiesError = \case
   Share.DownloadEntitiesInvalidRepoInfo err repoInfo -> invalidRepoInfo err repoInfo
   Share.DownloadEntitiesUserNotFound userHandle -> shareUserNotFound (Share.RepoInfo userHandle)
   Share.DownloadEntitiesProjectNotFound project -> shareProjectNotFound project
+  Share.DownloadEntitiesEntityValidationFailure err -> prettyEntityValidationError err
 
 prettyFastForwardPathError :: Share.Path -> Share.FastForwardPathError -> Pretty
 prettyFastForwardPathError path = \case
@@ -2306,6 +2307,38 @@ prettyTransportError = \case
     responseRequestId :: Servant.Response -> Maybe Text
     responseRequestId =
       fmap Text.decodeUtf8 . List.lookup "X-RequestId" . Foldable.toList @Seq . Servant.responseHeaders
+
+prettyEntityValidationError :: Share.EntityValidationError -> Pretty
+prettyEntityValidationError = \case
+  Share.EntityHashMismatch typ (Share.HashMismatchForEntity {supplied, computed}) ->
+    P.lines
+      [ P.wrap $ "The hash associated with the given " <> prettyEntityType typ <> " entity is incorrect.",
+        "",
+        P.wrap $ "The associated hash is: " <> prettyHash32 supplied,
+        P.wrap $ "The computed hash is: " <> prettyHash32 computed
+      ]
+  Share.UnsupportedEntityType hash typ ->
+    P.lines
+      [ P.wrap $ "The entity with hash " <> prettyHash32 hash <> " of type " <> prettyEntityType typ <> " is not supported by your version of ucm.",
+        P.wrap $ "Try upgrading to the latest version of ucm."
+      ]
+  Share.InvalidByteEncoding hash typ err ->
+    P.lines
+      [ P.wrap $ "Failed to decode a " <> prettyEntityType typ <> " entity with the hash " <> prettyHash32 hash <> ".",
+        "Please create an issue and report this to the Unison team",
+        "",
+        P.wrap $ "The error was: " <> P.text err
+      ]
+
+prettyEntityType :: Share.EntityType -> Pretty
+prettyEntityType = \case
+  Share.TermComponentType -> "term component"
+  Share.DeclComponentType -> "type component"
+  Share.PatchType -> "patch"
+  Share.PatchDiffType -> "patch diff"
+  Share.NamespaceType -> "namespace"
+  Share.NamespaceDiffType -> "namespace diff"
+  Share.CausalType -> "causal"
 
 invalidRepoInfo :: Text -> Share.RepoInfo -> Pretty
 invalidRepoInfo err repoInfo =

--- a/unison-cli/src/Unison/Share/Sync.hs
+++ b/unison-cli/src/Unison/Share/Sync.hs
@@ -21,6 +21,7 @@ module Unison.Share.Sync
 where
 
 import Control.Concurrent.STM
+import Control.Lens
 import Control.Monad.Except
 import Control.Monad.Reader (ask)
 import Control.Monad.Trans.Reader (ReaderT, runReaderT)
@@ -62,6 +63,7 @@ import Unison.Share.Sync.Types
 import Unison.Sqlite qualified as Sqlite
 import Unison.Sync.API qualified as Share (API)
 import Unison.Sync.Common (causalHashToHash32, entityToTempEntity, expectEntity, hash32ToCausalHash)
+import Unison.Sync.EntityValidation qualified as EV
 import Unison.Sync.Types qualified as Share
 import Unison.Util.Monoid (foldMapM)
 
@@ -428,6 +430,9 @@ downloadEntities unisonShareUrl repoInfo hashJwt downloadedCallback = do
               Left err -> failed (TransportError err)
               Right (Share.DownloadEntitiesFailure err) -> failed (SyncError err)
               Right (Share.DownloadEntitiesSuccess entities) -> pure entities
+          case validateEntities entities of
+            Left err -> failed . SyncError . Share.DownloadEntitiesEntityValidationFailure $ err
+            Right () -> pure ()
           tempEntities <- Cli.runTransaction (insertEntities entities)
           liftIO (downloadedCallback 1)
           pure (NESet.nonEmptySet tempEntities)
@@ -446,12 +451,19 @@ downloadEntities unisonShareUrl repoInfo hashJwt downloadedCallback = do
               tempEntities
       liftIO doCompleteTempEntities & onLeftM \err ->
         failed err
-
     -- Since we may have just inserted and then deleted many temp entities, we attempt to recover some disk space by
     -- vacuuming after each pull. If the vacuum fails due to another open transaction on this connection, that's ok,
     -- we'll try vacuuming again next pull.
     _success <- liftIO (Codebase.withConnection codebase Sqlite.vacuum)
     pure (Right ())
+  where
+    validateEntities :: NEMap Hash32 (Share.Entity Text Hash32 Share.HashJWT) -> Either Share.EntityValidationError ()
+    validateEntities entities =
+      ifor_ (NEMap.toMap entities) \hash entity -> do
+        let entityWithHashes = entity & Share.entityHashes_ %~ Share.hashJWTHash
+        case EV.validateEntity hash entityWithHashes of
+          Nothing -> pure ()
+          Just err -> Left err
 
 type WorkerCount =
   TVar Int

--- a/unison-share-api/package.yaml
+++ b/unison-share-api/package.yaml
@@ -14,6 +14,7 @@ dependencies:
   - async
   - base
   - binary
+  - bytes
   - bytestring
   - containers
   - directory
@@ -42,6 +43,7 @@ dependencies:
   - transformers
   - unison-codebase
   - unison-codebase-sqlite
+  - unison-codebase-sqlite-hashing-v2
   - unison-core
   - unison-core1
   - unison-hash

--- a/unison-share-api/package.yaml
+++ b/unison-share-api/package.yaml
@@ -48,6 +48,7 @@ dependencies:
   - unison-core1
   - unison-hash
   - unison-hash-orphans-aeson
+  - unison-hashing-v2
   - unison-parser-typechecker
   - unison-prelude
   - unison-pretty-printer

--- a/unison-share-api/src/Unison/Sync/EntityValidation.hs
+++ b/unison-share-api/src/Unison/Sync/EntityValidation.hs
@@ -11,8 +11,6 @@ import Data.ByteString qualified as BS
 import Data.Bytes.Get (runGetS)
 import Data.Set qualified as Set
 import Data.Text qualified as Text
-import GHC.IO (unsafePerformIO)
-import System.Environment (lookupEnv)
 import U.Codebase.HashTags
 import U.Codebase.Sqlite.Branch.Format qualified as BranchFormat
 import U.Codebase.Sqlite.Causal qualified as CausalFormat
@@ -31,21 +29,10 @@ import Unison.Prelude
 import Unison.Sync.Common qualified as Share
 import Unison.Sync.Types qualified as Share
 
-validationEnvKey :: String
-validationEnvKey = "UNISON_ENTITY_VALIDATION"
-
-shouldValidateEntities :: Bool
-shouldValidateEntities = unsafePerformIO $ do
-  lookupEnv validationEnvKey <&> \case
-    Just "true" -> True
-    _ -> False
-{-# NOINLINE shouldValidateEntities #-}
-
 -- | Note: We currently only validate Namespace hashes.
 -- We should add more validation as more entities are shared.
 validateEntity :: Hash32 -> Share.Entity Text Hash32 Hash32 -> Maybe Share.EntityValidationError
-validateEntity expectedHash32 entity
-  | shouldValidateEntities = do
+validateEntity expectedHash32 entity = do
       case Share.entityToTempEntity id entity of
         Entity.TC (TermFormat.SyncTerm localComp) -> do
           validateTerm expectedHash localComp
@@ -56,7 +43,6 @@ validateEntity expectedHash32 entity
         Entity.C CausalFormat.SyncCausalFormat {valueHash, parents} -> do
           validateCausal expectedHash32 valueHash (toList parents)
         _ -> Nothing
-  | otherwise = Nothing
   where
     expectedHash :: Hash
     expectedHash = Hash32.toHash expectedHash32

--- a/unison-share-api/src/Unison/Sync/HashValidation.hs
+++ b/unison-share-api/src/Unison/Sync/HashValidation.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+
+-- | Module for validating hashes of entities received/sent via sync.
+module Unison.Sync.HashValidation
+  ( HashValidationError (..),
+    validateEntityHash,
+  )
+where
+
+import Control.Exception
+import Data.ByteString qualified as BS
+import Data.Bytes.Get (runGetS)
+import U.Codebase.HashTags
+import U.Codebase.Sqlite.Branch.Format qualified as BranchFormat
+import U.Codebase.Sqlite.Decode qualified as Decode
+import U.Codebase.Sqlite.Entity qualified as Entity
+import U.Codebase.Sqlite.HashHandle qualified as HH
+import U.Codebase.Sqlite.Orphans ()
+import U.Codebase.Sqlite.Serialization qualified as Serialization
+import U.Codebase.Sqlite.Term.Format qualified as TermFormat
+import U.Codebase.Sqlite.V2.HashHandle (v2HashHandle)
+import Unison.Hash (Hash)
+import Unison.Hash32 (Hash32)
+import Unison.Hash32 qualified as Hash32
+import Unison.Prelude
+import Unison.Sync.Common qualified as Share
+import Unison.Sync.Types qualified as Share
+
+data HashValidationError
+  = MismatchedNamespaceHash (Hash {- expected hash -}) (Hash {- actual hash -})
+  | MismatchedTermHash (Hash {- expected hash -}) (Hash {- actual hash -})
+  | NamespaceDiffsAreUnsupported
+  | InvalidByteEncoding Text
+  deriving stock (Show, Eq, Ord)
+  deriving anyclass (Exception)
+
+data UnexpectedHashMismatch = UnexpectedHashMismatch
+  { providedHash :: ComponentHash,
+    actualHash :: ComponentHash
+  }
+  deriving stock (Show)
+
+-- | Note: We currently only validate Namespace hashes.
+-- We should add more validation as more entities are shared.
+validateEntityHash :: Hash32 -> Share.Entity Text Hash32 Hash32 -> Maybe HashValidationError
+validateEntityHash expectedHash32 entity = do
+  case Share.entityToTempEntity id entity of
+    Entity.TC (TermFormat.SyncTerm localComp) -> do
+      validateTerm expectedHash localComp
+    Entity.N (BranchFormat.SyncDiff {}) -> do
+      (Just NamespaceDiffsAreUnsupported)
+    Entity.N (BranchFormat.SyncFull localIds (BranchFormat.LocalBranchBytes bytes)) -> do
+      validateBranchFull expectedHash localIds bytes
+    _ -> Nothing
+  where
+    expectedHash :: Hash
+    expectedHash = Hash32.toHash expectedHash32
+
+validateBranchFull ::
+  Hash ->
+  BranchFormat.BranchLocalIds' Text Hash32 Hash32 (Hash32, Hash32) ->
+  BS.ByteString ->
+  (Maybe HashValidationError)
+validateBranchFull expectedHash localIds bytes = do
+  case runGetS Serialization.getLocalBranch bytes of
+    Left e -> Just $ InvalidByteEncoding ("Failed to decode local branch bytes: " <> tShow e)
+    Right localBranch -> do
+      let localIds' =
+            localIds
+              { BranchFormat.branchDefnLookup = ComponentHash . Hash32.toHash <$> BranchFormat.branchDefnLookup localIds,
+                BranchFormat.branchPatchLookup = PatchHash . Hash32.toHash <$> BranchFormat.branchPatchLookup localIds,
+                BranchFormat.branchChildLookup =
+                  BranchFormat.branchChildLookup localIds
+                    <&> bimap (BranchHash . Hash32.toHash) (CausalHash . Hash32.toHash)
+              }
+      let actualHash =
+            HH.hashBranchFormatFull v2HashHandle localIds' localBranch
+      if actualHash == BranchHash expectedHash
+        then Nothing
+        else Just $ MismatchedNamespaceHash expectedHash (unBranchHash actualHash)
+
+validateTerm :: Hash -> (TermFormat.SyncLocallyIndexedComponent' Text Hash32) -> (Maybe HashValidationError)
+validateTerm expectedHash syncLocalComp@(TermFormat.SyncLocallyIndexedComponent comps) = do
+  case Decode.unsyncTermComponent syncLocalComp of
+    Left _ -> Just (InvalidByteEncoding $ "Failed to decode term component bytes" <> tShow comps)
+    Right localComp -> do
+      case HH.verifyTermFormatHash v2HashHandle (ComponentHash expectedHash) (TermFormat.Term localComp) of
+        Nothing -> Nothing
+        Just (HH.HashMismatch {expectedHash, actualHash}) -> Just $ MismatchedTermHash expectedHash actualHash

--- a/unison-share-api/src/Unison/Sync/Types.hs
+++ b/unison-share-api/src/Unison/Sync/Types.hs
@@ -62,6 +62,7 @@ module Unison.Sync.Types
     HashMismatchForEntity (..),
     InvalidParentage (..),
     NeedDependencies (..),
+    EntityValidationError (..),
   )
 where
 
@@ -591,6 +592,7 @@ data DownloadEntitiesError
     DownloadEntitiesUserNotFound Text
   | -- | project shorthand
     DownloadEntitiesProjectNotFound Text
+  | DownloadEntitiesEntityValidationFailure EntityValidationError
   deriving stock (Eq, Show)
 
 instance ToJSON DownloadEntitiesResponse where
@@ -600,6 +602,7 @@ instance ToJSON DownloadEntitiesResponse where
     DownloadEntitiesFailure (DownloadEntitiesInvalidRepoInfo msg repoInfo) -> jsonUnion "invalid_repo_info" (msg, repoInfo)
     DownloadEntitiesFailure (DownloadEntitiesUserNotFound userHandle) -> jsonUnion "user_not_found" userHandle
     DownloadEntitiesFailure (DownloadEntitiesProjectNotFound projectShorthand) -> jsonUnion "project_not_found" projectShorthand
+    DownloadEntitiesFailure (DownloadEntitiesEntityValidationFailure err) -> jsonUnion "entity_validation_failure" err
 
 instance FromJSON DownloadEntitiesResponse where
   parseJSON = Aeson.withObject "DownloadEntitiesResponse" \obj ->
@@ -610,6 +613,38 @@ instance FromJSON DownloadEntitiesResponse where
       "user_not_found" -> DownloadEntitiesFailure . DownloadEntitiesUserNotFound <$> obj .: "payload"
       "project_not_found" -> DownloadEntitiesFailure . DownloadEntitiesProjectNotFound <$> obj .: "payload"
       t -> failText $ "Unexpected DownloadEntitiesResponse type: " <> t
+
+-- | The ways in which validating an entity may fail.
+data EntityValidationError
+  = EntityHashMismatch EntityType HashMismatchForEntity
+  | UnsupportedEntityType Hash32 EntityType
+  | InvalidByteEncoding Hash32 EntityType Text {- decoding err msg -}
+  deriving stock (Show, Eq, Ord)
+  deriving anyclass (Exception)
+
+instance ToJSON EntityValidationError where
+  toJSON = \case
+    EntityHashMismatch typ mismatch -> jsonUnion "mismatched_hash" (object ["type" .= typ, "mismatch" .= mismatch])
+    UnsupportedEntityType hash typ -> jsonUnion "unsupported_entity_type" (object ["hash" .= hash, "type" .= typ])
+    InvalidByteEncoding hash typ errMsg -> jsonUnion "invalid_byte_encoding" (object ["hash" .= hash, "type" .= typ, "error" .= errMsg])
+
+instance FromJSON EntityValidationError where
+  parseJSON = Aeson.withObject "EntityValidationError" \obj ->
+    obj .: "type" >>= Aeson.withText "type" \case
+      "mismatched_hash" -> do
+        typ <- obj .: "payload" >>= (.: "type")
+        mismatch <- obj .: "payload" >>= (.: "mismatch")
+        pure (EntityHashMismatch typ mismatch)
+      "unsupported_entity_type" -> do
+        hash <- obj .: "payload" >>= (.: "hash")
+        typ <- obj .: "payload" >>= (.: "type")
+        pure (UnsupportedEntityType hash typ)
+      "invalid_byte_encoding" -> do
+        hash <- obj .: "payload" >>= (.: "hash")
+        typ <- obj .: "payload" >>= (.: "type")
+        errMsg <- obj .: "payload" >>= (.: "error")
+        pure (InvalidByteEncoding hash typ errMsg)
+      t -> failText $ "Unexpected EntityValidationError type: " <> t
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Upload entities

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -121,6 +121,7 @@ library
     , unison-core1
     , unison-hash
     , unison-hash-orphans-aeson
+    , unison-hashing-v2
     , unison-parser-typechecker
     , unison-prelude
     , unison-pretty-printer

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -45,6 +45,7 @@ library
       Unison.Server.Types
       Unison.Sync.API
       Unison.Sync.Common
+      Unison.Sync.HashValidation
       Unison.Sync.Types
       Unison.Util.Find
   hs-source-dirs:
@@ -86,6 +87,7 @@ library
     , async
     , base
     , binary
+    , bytes
     , bytestring
     , containers
     , directory
@@ -114,6 +116,7 @@ library
     , transformers
     , unison-codebase
     , unison-codebase-sqlite
+    , unison-codebase-sqlite-hashing-v2
     , unison-core
     , unison-core1
     , unison-hash

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -45,7 +45,7 @@ library
       Unison.Server.Types
       Unison.Sync.API
       Unison.Sync.Common
-      Unison.Sync.HashValidation
+      Unison.Sync.EntityValidation
       Unison.Sync.Types
       Unison.Util.Find
   hs-source-dirs:


### PR DESCRIPTION
## Overview

<img width="1083" alt="image" src="https://github.com/unisonweb/unison/assets/6439644/6f65085e-69b8-4f52-ba37-f5187f4a4644">

Currently the UCM client doesn't validate the hashes of entities received from Share.
In general Share should be trust-worthy, but it certainly doesn't hurt to double-check, especially since there have been hashing bugs in the past.

This will also actually verify that the server sent us the code we asked for, which is a good protection against middle-man attacks.

Currently this checking will ONLY be enabled if you set `UNISON_ENTITY_VALIDATION=true`, since there are some bad hashes on Share at the moment :'(, it's very helpful to have this for testing and hopefully we can someday enable it on everything :)

## Implementation notes

I copied the Share entity validation into the unison CLI to run in `downloadEntities`.
If anything fails to validate it will fail the pull and print an error.

Note:  This currently only validates Causals, Namespaces, and Term components. We should continue to extend it to the other entity types.

## Interesting/controversial decisions

Leaving it disabled for now isn't ideal, but it would require a re-hash migration across all of share and local clients to fix the bad term hashes and enable it for everything.

We can likely enable it for everything except terms if we wanted, but I'd want to do more testing on Share to be sure.

## Test coverage

I'll be using this build to test new versions of Share, so that should put it through its paces.
