### PR TITLE
Add @lexi-lambda to contributors

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -73,6 +73,7 @@ The format for this list: name, GitHub handle
 * Jesse Looney (@jesselooney)
 * Vlad Posmangiu Luchian (@cstml)
 * Andrii Uvarov (@unorsk)
+* Alexis King (@lexi-lambda)
 * Mario Bašić (@mabasic)
 * Chris Krycho (@chriskrycho)
 * Hatim Khambati (@hatimkhambati26)


### PR DESCRIPTION
@lexi-lambda we forgot to add you to the list! 

I added you based on date of this PR https://github.com/unisonweb/unison/pull/3834 which got rolled into https://github.com/unisonweb/unison/pull/3905

Reason this came up is I'm making a slide for a talk with a big list of contributors to thank and I noticed your name was missing.