### PR TITLE
update `update` info messages

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
@@ -97,6 +97,7 @@ handleUpdate2 = do
 
   let ctorNames = forwardCtorNames namesExcludingLibdeps
 
+  Cli.respond Output.UpdateLookingForDependents
   (pped, bigUf) <- Cli.runTransactionWithRollback \_abort -> do
     dependents <-
       Ops.dependentsWithinScope
@@ -110,6 +111,7 @@ handleUpdate2 = do
     pure (pped `PPED.addFallback` tufPped, bigUf)
 
   -- - typecheck it
+  Cli.respond Output.UpdateStartTypechecking
   prettyParseTypecheck bigUf pped >>= \case
     Left prettyUf -> do
       Cli.Env {isTranscript} <- ask

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -385,6 +385,8 @@ data Output
   | FailedToFetchLatestReleaseOfBase
   | HappyCoding
   | ProjectHasNoReleases ProjectName
+  | UpdateLookingForDependents
+  | UpdateStartTypechecking
   | UpdateTypecheckingFailure
   | UpdateTypecheckingSuccess
 
@@ -448,8 +450,10 @@ type SourceFileContents = Text
 
 isFailure :: Output -> Bool
 isFailure o = case o of
-  UpdateTypecheckingFailure{} -> True
-  UpdateTypecheckingSuccess{} -> False
+  UpdateLookingForDependents -> False
+  UpdateStartTypechecking -> False
+  UpdateTypecheckingFailure {} -> True
+  UpdateTypecheckingSuccess {} -> False
   AmbiguousCloneLocal {} -> True
   AmbiguousCloneRemote {} -> True
   ClonedProjectBranch {} -> False

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2174,8 +2174,17 @@ notifyUser dir = \case
         <> P.wrap "🎉 🥳 Happy coding!"
   ProjectHasNoReleases projectName ->
     pure . P.wrap $ prettyProjectName projectName <> "has no releases."
-  UpdateTypecheckingFailure -> pure "Typechecking failed when propagating the update to all the dependents."
-  UpdateTypecheckingSuccess -> pure "I propagated the update and am now saving the results."
+  UpdateLookingForDependents -> pure . P.wrap $ "Okay, I'm searching the branch for code that needs to be updated..."
+  UpdateStartTypechecking -> pure . P.wrap $ "That's done. Now I'm making sure everything typechecks..."
+  UpdateTypecheckingSuccess -> pure . P.wrap $ "Everything typechecks, so I'm saving the results..."
+  UpdateTypecheckingFailure ->
+    pure . P.wrap $
+      "Typechecking failed. I've updated your scratch file with the definitions that need fixing."
+        <> P.newline
+        <> P.newline
+        <> "Once the file is compiling, try"
+        <> makeExample' IP.update
+        <> "again."
   where
     _nameChange _cmd _pastTenseCmd _oldName _newName _r = error "todo"
 

--- a/unison-src/transcripts/addupdatemessages.output.md
+++ b/unison-src/transcripts/addupdatemessages.output.md
@@ -100,7 +100,12 @@ Expected: `x` is now `3` and `X` has constructor `Three`. UCM tells you the old 
 ```ucm
 .> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 
@@ -132,7 +137,12 @@ Expected: `x` is now `2` and `X` is `Two`. UCM says the old definition was also 
 ```ucm
 .> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/cycle-update-1.output.md
+++ b/unison-src/transcripts/cycle-update-1.output.md
@@ -49,7 +49,12 @@ ping _ = !pong + 3
 ```ucm
 .> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/cycle-update-2.output.md
+++ b/unison-src/transcripts/cycle-update-2.output.md
@@ -49,7 +49,12 @@ ping _ = 3
 ```ucm
 .> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/cycle-update-6.output.md
+++ b/unison-src/transcripts/cycle-update-6.output.md
@@ -96,7 +96,12 @@ ping _ = ! #4t465jk908dsue9fgdfi06fihppsme16cvaua29hjm1585de1mvt11dftqrab5chhla3
 ```ucm
 .> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/fix-1381-excess-propagate.output.md
+++ b/unison-src/transcripts/fix-1381-excess-propagate.output.md
@@ -23,7 +23,12 @@ a = "an update"
 ```ucm
 .> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/fix1356.output.md
+++ b/unison-src/transcripts/fix1356.output.md
@@ -69,7 +69,12 @@ Step 4: I add it and expect to see it
 ```ucm
 .trunk> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/fix942.output.md
+++ b/unison-src/transcripts/fix942.output.md
@@ -50,7 +50,12 @@ x = 7
 ```ucm
 .> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -227,7 +227,12 @@ master.frobnicate n = n + 1
 ```ucm
 .> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/move-namespace.output.md
+++ b/unison-src/transcripts/move-namespace.output.md
@@ -53,7 +53,12 @@ unique type a.T = T1 | T2
 ```ucm
 .happy> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 
@@ -143,7 +148,12 @@ b.termInB = 11
 ```ucm
 .history> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 
@@ -234,7 +244,12 @@ b.termInB = 11
 ```ucm
 .existing> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/reset.output.md
+++ b/unison-src/transcripts/reset.output.md
@@ -178,7 +178,12 @@ a = 3
 ```ucm
 foo/main> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/update-ignores-lib-namespace.output.md
+++ b/unison-src/transcripts/update-ignores-lib-namespace.output.md
@@ -48,7 +48,12 @@ foo = 200
 ```ucm
 .> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/update-on-conflict.output.md
+++ b/unison-src/transcripts/update-on-conflict.output.md
@@ -85,7 +85,12 @@ x = 3
 ```ucm
 .merged> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/update-term-aliases-in-different-ways.output.md
+++ b/unison-src/transcripts/update-term-aliases-in-different-ways.output.md
@@ -59,7 +59,12 @@ bar = 7
 ```ucm
 .> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/update-term-to-different-type.output.md
+++ b/unison-src/transcripts/update-term-to-different-type.output.md
@@ -48,7 +48,12 @@ foo = +5
 ```ucm
 .> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/update-term-with-alias.output.md
+++ b/unison-src/transcripts/update-term-with-alias.output.md
@@ -54,7 +54,12 @@ foo = 6
 ```ucm
 .> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/update-term-with-dependent-to-different-type.output.md
+++ b/unison-src/transcripts/update-term-with-dependent-to-different-type.output.md
@@ -53,6 +53,11 @@ foo = +5
 ```ucm
 .> update
 
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
   bar : Nat
   bar =
     use Nat +
@@ -61,6 +66,8 @@ foo = +5
   foo : Int
   foo = +5
 
-  Typechecking failed when propagating the update to all the dependents.
+  Typechecking failed. I've updated your scratch file with the
+  definitions that need fixing. Once the file is compiling, try
+  `update` again.
 
 ```

--- a/unison-src/transcripts/update-term-with-dependent.output.md
+++ b/unison-src/transcripts/update-term-with-dependent.output.md
@@ -53,7 +53,12 @@ foo = 6
 ```ucm
 .> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/update-term.output.md
+++ b/unison-src/transcripts/update-term.output.md
@@ -48,7 +48,12 @@ foo = 6
 ```ucm
 .> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/update-type-add-constructor.output.md
+++ b/unison-src/transcripts/update-type-add-constructor.output.md
@@ -43,7 +43,12 @@ unique type Foo
 ```ucm
 .> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/update-type-add-field.output.md
+++ b/unison-src/transcripts/update-type-add-field.output.md
@@ -40,7 +40,12 @@ unique type Foo = Bar Nat Nat
 ```ucm
 .> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/update-type-add-record-field.output.md
+++ b/unison-src/transcripts/update-type-add-record-field.output.md
@@ -55,7 +55,12 @@ unique type Foo = { bar : Nat, baz : Int }
 ```ucm
 .> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/update-type-constructor-alias.output.md
+++ b/unison-src/transcripts/update-type-constructor-alias.output.md
@@ -46,7 +46,12 @@ Bug: we leave `Foo.BarAlias` in the namespace with a nameless decl.
 ```ucm
 .> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/update-type-delete-constructor-with-dependent.output.md
+++ b/unison-src/transcripts/update-type-delete-constructor-with-dependent.output.md
@@ -50,6 +50,11 @@ unique type Foo
 ```ucm
 .> update
 
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
   foo : Foo -> Nat
   foo = cases
     Bar n   -> n
@@ -57,6 +62,8 @@ unique type Foo
   
   unique type Foo = Bar Nat
 
-  Typechecking failed when propagating the update to all the dependents.
+  Typechecking failed. I've updated your scratch file with the
+  definitions that need fixing. Once the file is compiling, try
+  `update` again.
 
 ```

--- a/unison-src/transcripts/update-type-delete-constructor.output.md
+++ b/unison-src/transcripts/update-type-delete-constructor.output.md
@@ -43,7 +43,12 @@ unique type Foo
 ```ucm
 .> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/update-type-delete-record-field.output.md
+++ b/unison-src/transcripts/update-type-delete-record-field.output.md
@@ -57,6 +57,11 @@ We want the field accessors to go away; but for now they are here, causing the u
 ```ucm
 .> update
 
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
   Foo.baz : Foo -> Int
   Foo.baz = cases Foo _ baz -> baz
   
@@ -68,7 +73,9 @@ We want the field accessors to go away; but for now they are here, causing the u
   
   unique type Foo = { bar : Nat }
 
-  Typechecking failed when propagating the update to all the dependents.
+  Typechecking failed. I've updated your scratch file with the
+  definitions that need fixing. Once the file is compiling, try
+  `update` again.
 
 .> view Foo
 

--- a/unison-src/transcripts/update-type-nested-decl-aliases.output.md
+++ b/unison-src/transcripts/update-type-nested-decl-aliases.output.md
@@ -60,7 +60,12 @@ Long story short, we should reject this update as it violates the "decl coherenc
 ```ucm
 .> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/update-type-no-op-record.output.md
+++ b/unison-src/transcripts/update-type-no-op-record.output.md
@@ -32,7 +32,12 @@ Bug: this no-op update should (of course) succeed.
 ```ucm
 .> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/update-type-stray-constructor-alias.output.md
+++ b/unison-src/transcripts/update-type-stray-constructor-alias.output.md
@@ -46,7 +46,12 @@ Bug: we leave `Stray.BarAlias` in the namespace with a nameless decl.
 ```ucm
 .> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/update-type-turn-constructor-into-smart-constructor.output.md
+++ b/unison-src/transcripts/update-type-turn-constructor-into-smart-constructor.output.md
@@ -49,7 +49,12 @@ Foo.Bar n = internal.Bar n
 ```ucm
 .> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/update-type-turn-non-record-into-record.output.md
+++ b/unison-src/transcripts/update-type-turn-non-record-into-record.output.md
@@ -46,7 +46,12 @@ unique type Foo = { bar : Nat }
 ```ucm
 .> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 

--- a/unison-src/transcripts/update-type-with-dependent-term.output.md
+++ b/unison-src/transcripts/update-type-with-dependent-term.output.md
@@ -45,11 +45,18 @@ unique type Foo = Bar Nat Nat
 ```ucm
 .> update
 
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
   incrFoo : Foo -> Foo
   incrFoo = cases Bar n -> Bar (n Nat.+ 1)
   
   unique type Foo = Bar Nat Nat
 
-  Typechecking failed when propagating the update to all the dependents.
+  Typechecking failed. I've updated your scratch file with the
+  definitions that need fixing. Once the file is compiling, try
+  `update` again.
 
 ```

--- a/unison-src/transcripts/update-type-with-dependent-type-to-different-kind.output.md
+++ b/unison-src/transcripts/update-type-with-dependent-type-to-different-kind.output.md
@@ -43,10 +43,17 @@ unique type Foo a = Bar Nat a
 ```ucm
 .> update
 
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
   unique type Baz = Qux Foo
   
   unique type Foo a = Bar Nat a
 
-  Typechecking failed when propagating the update to all the dependents.
+  Typechecking failed. I've updated your scratch file with the
+  definitions that need fixing. Once the file is compiling, try
+  `update` again.
 
 ```

--- a/unison-src/transcripts/update-type-with-dependent-type.output.md
+++ b/unison-src/transcripts/update-type-with-dependent-type.output.md
@@ -43,7 +43,12 @@ unique type Foo = Bar Nat Nat
 ```ucm
 .> update
 
-  I propagated the update and am now saving the results.
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
 
   Done.
 


### PR DESCRIPTION
Per https://unisonlanguage.slack.com/archives/CLG4P0GSD/p1699714157423269?thread_ts=1699713010.873129&cid=CLG4P0GSD

Later I think it would be nice if we could print fewer messages for small updates.  Like maybe just print extra info if the steps are taking more than 1 second each, otherwise something more concise.