### PR TITLE
Add build-tools only devShell that doesn't depend on haskell.nix

### DIFF
--- a/.github/workflows/nix-dev-cache.yaml
+++ b/.github/workflows/nix-dev-cache.yaml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
+          - macOS-12
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v22
@@ -32,5 +33,5 @@ jobs:
         name: unison
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - name: build all packages and development shells
-      run: nix -L build --accept-flake-config --no-link --keep-going '.#all'
+      run: nix -L build --accept-flake-config --no-link --keep-going '.#build-tools'
 

--- a/flake.lock
+++ b/flake.lock
@@ -574,6 +574,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable_2": {
+      "locked": {
+        "lastModified": 1699781429,
+        "narHash": "sha256-UYefjidASiLORAjIvVsUHG6WBtRhM67kTjEY4XfZOFs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e44462d6021bfe23dfb24b775cc7c390844f773d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "old-ghc-nix": {
       "flake": false,
       "locked": {
@@ -599,7 +615,8 @@
         "nixpkgs": [
           "haskellNix",
           "nixpkgs-unstable"
-        ]
+        ],
+        "nixpkgs-unstable": "nixpkgs-unstable_2"
       }
     },
     "stackage": {

--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,8 @@
               ghc = unstable.haskell.compiler."ghc${versions.ghc}";
               ormolu = exe hpkgs.ormolu;
               hls = unstable.unison-hls;
-              stack = unstable.stack;
+              stack = unstable.unison-stack;
+              unwrapped-stack = unstable.stack;
               hpack = unstable.hpack;
             };
           nixpkgs-devShells = {
@@ -78,7 +79,7 @@
         in
         assert nixpkgs-packages.ormolu.version == versions.ormolu;
         assert nixpkgs-packages.hls.version == versions.hls;
-        assert nixpkgs-packages.stack.version == versions.stack;
+        assert nixpkgs-packages.unwrapped-stack.version == versions.stack;
         assert nixpkgs-packages.hpack.version == versions.hpack;
         {
           packages = nixpkgs-packages // {

--- a/flake.nix
+++ b/flake.nix
@@ -80,9 +80,8 @@
         assert nixpkgs-packages.hls.version == versions.hls;
         assert nixpkgs-packages.stack.version == versions.stack;
         assert nixpkgs-packages.hpack.version == versions.hpack;
-        haskell-nix-flake // {
-          inherit nixpkgs-packages;
-          packages = haskell-nix-flake.packages // nixpkgs-packages // {
+        {
+          packages = nixpkgs-packages // {
             build-tools = pkgs.symlinkJoin {
               name = "build-tools";
               paths = self.devShells."${system}".only-tools-nixpkgs.buildInputs;
@@ -95,7 +94,6 @@
                   devshell-inputs = builtins.concatMap
                     (devShell: devShell.buildInputs ++ devShell.nativeBuildInputs)
                     [
-                      self.devShells."${system}".only-tools
                       self.devShells."${system}".only-tools-nixpkgs
                     ];
                 in
@@ -103,7 +101,7 @@
             };
           };
 
-          devShells = haskell-nix-flake.devShells // nixpkgs-devShells // {
+          devShells = nixpkgs-devShells // {
             default = self.devShells."${system}".only-tools-nixpkgs;
           };
         });

--- a/flake.nix
+++ b/flake.nix
@@ -9,13 +9,14 @@
   inputs = {
     haskellNix.url = "github:input-output-hk/haskell.nix";
     nixpkgs.follows = "haskellNix/nixpkgs-unstable";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     flake-compat = {
       url = "github:edolstra/flake-compat";
       flake = false;
     };
   };
-  outputs = { self, nixpkgs, flake-utils, haskellNix, flake-compat }:
+  outputs = { self, nixpkgs, flake-utils, haskellNix, flake-compat, nixpkgs-unstable }:
     flake-utils.lib.eachSystem [
       "x86_64-linux"
       "x86_64-darwin"
@@ -23,162 +24,87 @@
     ]
       (system:
         let
+          versions = {
+            ghc = "928";
+            ormolu = "0.5.2.0";
+            hls = "2.4.0.0";
+            stack = "2.13.1";
+            hpack = "0.35.2";
+          };
           overlays = [
             haskellNix.overlay
-            (final: prev: {
-              unison-project = with prev.lib.strings;
-                let
-                  cleanSource = pth:
-                    let
-                      src' = prev.lib.cleanSourceWith {
-                        filter = filt;
-                        src = pth;
-                      };
-                      filt = path: type:
-                        let
-                          bn = baseNameOf path;
-                          isHiddenFile = hasPrefix "." bn;
-                          isFlakeLock = bn == "flake.lock";
-                          isNix = hasSuffix ".nix" bn;
-                        in
-                        !isHiddenFile && !isFlakeLock && !isNix;
-                    in
-                    src';
-                in
-                final.haskell-nix.project' {
-                  src = cleanSource ./.;
-                  projectFileName = "stack.yaml";
-                  modules = [
-                    # enable profiling
-                    {
-                      enableLibraryProfiling = true;
-                      profilingDetail = "none";
-                    }
-                    # remove buggy build tool dependencies
-                    ({ lib, ... }: {
-                      # this component has the build tool
-                      # `unison-cli:unison` and somehow haskell.nix
-                      # decides to add some file sharing package
-                      # `unison` as a build-tool dependency.
-                      packages.unison-cli.components.exes.cli-integration-tests.build-tools =
-                        lib.mkForce [ ];
-                    })
-                  ];
-                  branchMap = {
-                    "https://github.com/unisonweb/configurator.git"."e47e9e9fe1f576f8c835183b9def52d73c01327a" =
-                      "unison";
-                    "https://github.com/unisonweb/shellmet.git"."2fd348592c8f51bb4c0ca6ba4bc8e38668913746" =
-                      "topic/avoid-callCommand";
-                  };
-                };
-            })
-            (final: prev: {
-              unison-stack = prev.symlinkJoin {
-                name = "stack";
-                paths = [ final.stack ];
-                buildInputs = [ final.makeWrapper ];
-                postBuild =
-                  let
-                    flags = [ "--no-nix" "--system-ghc" "--no-install-ghc" ];
-                    add-flags =
-                      "--add-flags '${prev.lib.concatStringsSep " " flags}'";
-                  in
-                  ''
-                    wrapProgram "$out/bin/stack" ${add-flags}
-                  '';
-              };
-            })
+            (import ./nix/haskell-nix-overlay.nix)
+            (import ./nix/unison-overlay.nix)
           ];
           pkgs = import nixpkgs {
             inherit system overlays;
             inherit (haskellNix) config;
           };
-          flake = pkgs.unison-project.flake { };
-
-          commonShellArgs = args:
-            args // {
-              # workaround:
-              # https://github.com/input-output-hk/haskell.nix/issues/1793
-              # https://github.com/input-output-hk/haskell.nix/issues/1885
-              allToolDeps = false;
-              additional = hpkgs: with hpkgs; [ Cabal stm exceptions ghc ghc-heap ];
-              buildInputs =
-                let
-                  native-packages = pkgs.lib.optionals pkgs.stdenv.isDarwin
-                    (with pkgs.darwin.apple_sdk.frameworks; [ Cocoa ]);
-                in
-                (args.buildInputs or [ ]) ++ (with pkgs; [ unison-stack pkg-config zlib glibcLocales ]) ++ native-packages;
-              # workaround for https://gitlab.haskell.org/ghc/ghc/-/issues/11042
-              shellHook = ''
-                export LD_LIBRARY_PATH=${pkgs.zlib}/lib:$LD_LIBRARY_PATH
-              '';
-              tools =
-                let ormolu-ver = "0.5.2.0";
-                in (args.tools or { }) // {
-                  cabal = { };
-                  ormolu = { version = ormolu-ver; };
-                  haskell-language-server = {
-                    version = "latest";
-                    modules = [
-                      {
-                        packages.haskell-language-server.components.exes.haskell-language-server.postInstall = ''
-                          ln -sr "$out/bin/haskell-language-server" "$out/bin/haskell-language-server-wrapper"
-                        '';
-                      }
-                    ];
-                    # specify flags via project file rather than a module override
-                    # https://github.com/input-output-hk/haskell.nix/issues/1509
-                    cabalProject = ''
-                      packages: .
-                      package haskell-language-server
-                        flags: -brittany -fourmolu -stylishhaskell -hlint
-                      constraints: ormolu == ${ormolu-ver}
-                    '';
-                  };
-                };
-            };
-
-          shellFor = args: pkgs.unison-project.shellFor (commonShellArgs args);
-
-          localPackages = with pkgs.lib;
-            filterAttrs (k: v: v.isLocal or false) pkgs.unison-project.hsPkgs;
-          localPackageNames = builtins.attrNames localPackages;
-          devShells =
+          haskell-nix-flake = import ./nix/haskell-nix-flake.nix {
+            inherit pkgs versions;
+            inherit (nixpkgs-packages) stack hpack;
+          };
+          unstable = import nixpkgs-unstable {
+            inherit system;
+            overlays = [
+              (import ./nix/unison-overlay.nix)
+              (import ./nix/nixpkgs-overlay.nix { inherit versions; })
+            ];
+          };
+          nixpkgs-packages =
             let
-              mkDevShell = pkgName:
-                shellFor {
-                  packages = hpkgs: [ hpkgs."${pkgName}" ];
-                  withHoogle = true;
-                };
-              localPackageDevShells =
-                pkgs.lib.genAttrs localPackageNames mkDevShell;
+              hpkgs = unstable.haskell.packages.ghcunison;
+              exe = unstable.haskell.lib.justStaticExecutables;
             in
             {
-              default = devShells.only-tools;
-              only-tools = shellFor {
-                packages = _: [ ];
-                withHoogle = false;
-              };
-              local = shellFor {
-                packages = hpkgs: (map (p: hpkgs."${p}") localPackageNames);
-                withHoogle = true;
-              };
-            } // localPackageDevShells;
+              ghc = unstable.haskell.compiler."ghc${versions.ghc}";
+              ormolu = exe hpkgs.ormolu;
+              hls = unstable.unison-hls;
+              stack = unstable.stack;
+              hpack = unstable.hpack;
+            };
+          nixpkgs-devShells = {
+            only-tools-nixpkgs = unstable.mkShellNoCC {
+              name = "only-tools-nixpkgs";
+              buildInputs = with nixpkgs-packages; [
+                ghc
+                ormolu
+                hls
+                stack
+                hpack
+              ];
+            };
+          };
         in
-        flake // {
-          defaultPackage = flake.packages."unison-cli:exe:unison";
-          inherit (pkgs) unison-project;
-          inherit devShells localPackageNames;
-          packages = flake.packages // {
+        assert nixpkgs-packages.ormolu.version == versions.ormolu;
+        assert nixpkgs-packages.hls.version == versions.hls;
+        assert nixpkgs-packages.stack.version == versions.stack;
+        assert nixpkgs-packages.hpack.version == versions.hpack;
+        haskell-nix-flake // {
+          inherit nixpkgs-packages;
+          packages = haskell-nix-flake.packages // nixpkgs-packages // {
+            build-tools = pkgs.symlinkJoin {
+              name = "build-tools";
+              paths = self.devShells."${system}".only-tools-nixpkgs.buildInputs;
+            };
             all = pkgs.symlinkJoin {
-              name = "all-packages";
+              name = "all";
               paths =
                 let
-                  all-other-packages = builtins.attrValues (builtins.removeAttrs self.packages."${system}" [ "all" ]);
-                  devshell-inputs = builtins.concatMap (devShell: devShell.buildInputs ++ devShell.nativeBuildInputs) [ devShells.only-tools ];
+                  all-other-packages = builtins.attrValues (builtins.removeAttrs self.packages."${system}" [ "all" "build-tools" ]);
+                  devshell-inputs = builtins.concatMap
+                    (devShell: devShell.buildInputs ++ devShell.nativeBuildInputs)
+                    [
+                      self.devShells."${system}".only-tools
+                      self.devShells."${system}".only-tools-nixpkgs
+                    ];
                 in
                 all-other-packages ++ devshell-inputs;
             };
+          };
+
+          devShells = haskell-nix-flake.devShells // nixpkgs-devShells // {
+            default = self.devShells."${system}".only-tools-nixpkgs;
           };
         });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -82,6 +82,7 @@
         assert nixpkgs-packages.hpack.version == versions.hpack;
         {
           packages = nixpkgs-packages // {
+            haskell-nix = haskell-nix-flake.packages;
             build-tools = pkgs.symlinkJoin {
               name = "build-tools";
               paths = self.devShells."${system}".only-tools-nixpkgs.buildInputs;
@@ -101,7 +102,7 @@
             };
           };
 
-          devShells = nixpkgs-devShells // {
+          devShells = haskell-nix-flake.devShells // nixpkgs-devShells // {
             default = self.devShells."${system}".only-tools-nixpkgs;
           };
         });

--- a/flake.nix
+++ b/flake.nix
@@ -102,8 +102,9 @@
             };
           };
 
-          devShells = haskell-nix-flake.devShells // nixpkgs-devShells // {
+          devShells = nixpkgs-devShells // {
             default = self.devShells."${system}".only-tools-nixpkgs;
+            haskell-nix = haskell-nix-flake.devShells;
           };
         });
 }

--- a/nix/haskell-nix-flake.nix
+++ b/nix/haskell-nix-flake.nix
@@ -1,0 +1,77 @@
+{ stack, hpack, pkgs, versions }:
+let
+  haskell-nix-flake = pkgs.unison-project.flake { };
+  commonShellArgs = args:
+    args // {
+      # workaround:
+      # https://github.com/input-output-hk/haskell.nix/issues/1793
+      # https://github.com/input-output-hk/haskell.nix/issues/1885
+      allToolDeps = false;
+      additional = hpkgs: with hpkgs; [ Cabal stm exceptions ghc ghc-heap ];
+      buildInputs =
+        let
+          native-packages = pkgs.lib.optionals pkgs.stdenv.isDarwin
+            (with pkgs.darwin.apple_sdk.frameworks; [ Cocoa ]);
+        in
+        (args.buildInputs or [ ]) ++ [ stack hpack pkgs.pkg-config pkgs.zlib pkgs.glibcLocales ] ++ native-packages;
+      # workaround for https://gitlab.haskell.org/ghc/ghc/-/issues/11042
+      shellHook = ''
+        export LD_LIBRARY_PATH=${pkgs.zlib}/lib:$LD_LIBRARY_PATH
+      '';
+      tools =
+        (args.tools or { }) // {
+          cabal = { };
+          ormolu = { version = versions.ormolu; };
+          haskell-language-server = {
+            version = versions.hls;
+            modules = [
+              {
+                packages.haskell-language-server.components.exes.haskell-language-server.postInstall = ''
+                  ln -sr "$out/bin/haskell-language-server" "$out/bin/haskell-language-server-wrapper"
+                '';
+              }
+            ];
+            # specify flags via project file rather than a module override
+            # https://github.com/input-output-hk/haskell.nix/issues/1509
+            cabalProject = ''
+              packages: .
+              package haskell-language-server
+                flags: -brittany -fourmolu -stylishhaskell -hlint
+              constraints: ormolu == ${versions.ormolu}
+            '';
+          };
+        };
+    };
+
+  shellFor = args: pkgs.unison-project.shellFor (commonShellArgs args);
+
+  localPackages = with pkgs.lib;
+    filterAttrs (k: v: v.isLocal or false) pkgs.unison-project.hsPkgs;
+  localPackageNames = builtins.attrNames localPackages;
+  devShells =
+    let
+      mkDevShell = pkgName:
+        shellFor {
+          packages = hpkgs: [ hpkgs."${pkgName}" ];
+          withHoogle = true;
+        };
+      localPackageDevShells =
+        pkgs.lib.genAttrs localPackageNames mkDevShell;
+    in
+    {
+      only-tools = shellFor {
+        packages = _: [ ];
+        withHoogle = false;
+      };
+      local = shellFor {
+        packages = hpkgs: (map (p: hpkgs."${p}") localPackageNames);
+        withHoogle = true;
+      };
+    } // localPackageDevShells;
+in
+haskell-nix-flake // {
+  defaultPackage = haskell-nix-flake.packages."unison-cli:exe:unison";
+  inherit (pkgs) unison-project;
+  inherit devShells localPackageNames;
+  packages = haskell-nix-flake.packages;
+}

--- a/nix/haskell-nix-flake.nix
+++ b/nix/haskell-nix-flake.nix
@@ -73,5 +73,4 @@ haskell-nix-flake // {
   defaultPackage = haskell-nix-flake.packages."unison-cli:exe:unison";
   inherit (pkgs) unison-project;
   inherit devShells localPackageNames;
-  packages = haskell-nix-flake.packages;
 }

--- a/nix/haskell-nix-overlay.nix
+++ b/nix/haskell-nix-overlay.nix
@@ -1,0 +1,47 @@
+final: prev: {
+  unison-project = with prev.lib.strings;
+    let
+      cleanSource = pth:
+        let
+          src' = prev.lib.cleanSourceWith {
+            filter = filt;
+            src = pth;
+          };
+          filt = path: type:
+            let
+              bn = baseNameOf path;
+              isHiddenFile = hasPrefix "." bn;
+              isFlakeLock = bn == "flake.lock";
+              isNix = hasSuffix ".nix" bn;
+            in
+            !isHiddenFile && !isFlakeLock && !isNix;
+        in
+        src';
+    in
+    final.haskell-nix.project' {
+      src = cleanSource ./..;
+      projectFileName = "stack.yaml";
+      modules = [
+        # enable profiling
+        {
+          enableLibraryProfiling = true;
+          profilingDetail = "none";
+        }
+        # remove buggy build tool dependencies
+        ({ lib, ... }: {
+          # this component has the build tool
+          # `unison-cli:unison` and somehow haskell.nix
+          # decides to add some file sharing package
+          # `unison` as a build-tool dependency.
+          packages.unison-cli.components.exes.cli-integration-tests.build-tools =
+            lib.mkForce [ ];
+        })
+      ];
+      branchMap = {
+        "https://github.com/unisonweb/configurator.git"."e47e9e9fe1f576f8c835183b9def52d73c01327a" =
+          "unison";
+        "https://github.com/unisonweb/shellmet.git"."2fd348592c8f51bb4c0ca6ba4bc8e38668913746" =
+          "topic/avoid-callCommand";
+      };
+    };
+}

--- a/nix/nixpkgs-overlay.nix
+++ b/nix/nixpkgs-overlay.nix
@@ -1,0 +1,43 @@
+{ versions }:
+final: prev: {
+  unison-hls = final.haskell-language-server.override {
+    # build with our overridden haskellPackages that have our pinned
+    # version of ormolu and hls
+    haskellPackages = final.haskell.packages."ghc${versions.ghc}";
+    dynamic = true;
+    supportedGhcVersions = [ versions.ghc ];
+  };
+  haskell = prev.haskell // {
+    packages = prev.haskell.packages // {
+      ghcunison = prev.haskell.packages."ghc${versions.ghc}".extend (hfinal: hprev:
+        let inherit (prev.haskell.lib) overrideCabal; in {
+          # dependency overrides for ormolu 0.5.2.0
+          haskell-language-server =
+            let
+              p = hfinal.callHackageDirect
+                {
+                  pkg = "haskell-language-server";
+                  ver = versions.hls;
+                  sha256 = "0kp586yc162raljyd5arsxm5ndcx5zfw9v94v27bkjg7x0hp1s8b";
+                }
+                {
+                  hls-fourmolu-plugin = null;
+                  hls-stylish-haskell-plugin = null;
+                  hls-hlint-plugin = null;
+                  hls-floskell-plugin = null;
+                };
+              override = drv: {
+                doCheck = false;
+                configureFlags = (drv.configureFlags or [ ]) ++ [
+                  "-f-fourmolu"
+                  "-f-stylishhaskell"
+                  "-f-hlint"
+                  "-f-floskell"
+                ];
+              };
+            in
+            overrideCabal p override;
+        });
+    };
+  };
+}

--- a/nix/unison-overlay.nix
+++ b/nix/unison-overlay.nix
@@ -1,0 +1,18 @@
+final: prev: {
+  # a wrapped version of stack that passes the necessary flags to use
+  # the nix provided ghc.
+  unison-stack = prev.symlinkJoin {
+    name = "stack";
+    paths = [ final.stack ];
+    buildInputs = [ final.makeWrapper ];
+    postBuild =
+      let
+        flags = [ "--no-nix" "--system-ghc" "--no-install-ghc" ];
+        add-flags =
+          "--add-flags '${prev.lib.concatStringsSep " " flags}'";
+      in
+      ''
+        wrapProgram "$out/bin/stack" ${add-flags}
+      '';
+  };
+}


### PR DESCRIPTION
## Overview

Most of the team uses nix to provide build tools only and haskell.nix doesn't add much value for them. Haskell.nix does pull in many dependencies and using the associated cache is required to avoid very long build times when we bump our haskell.nix dep. This is exacerbated by the bad signature issue for the aarch64-darwin iohk cache.

To avoid these issues, this PR adds a new devShell that provides build tools from nixpkgs, using the official nixos cache. Specifically the new shell provides: ghc, stack, hpack, ormolu, and hls with our company-wide pinned versions. 

This new devShell is the default, so `nix develop` will no longer rely on haskell.nix.