### PR TITLE
Force push to avoid keeping tons of old docs

### DIFF
--- a/.github/workflows/haddocks.yaml
+++ b/.github/workflows/haddocks.yaml
@@ -96,5 +96,5 @@ jobs:
           else
             git add .
             git commit -m "Regenerated haddocks based on ${GITHUB_SHA}"
-            git push
+            git push --force origin haddocks
           fi

--- a/.github/workflows/haddocks.yaml
+++ b/.github/workflows/haddocks.yaml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - trunk
-      - "cp/force-push-haddocks"
 
 jobs:
   build:

--- a/.github/workflows/haddocks.yaml
+++ b/.github/workflows/haddocks.yaml
@@ -91,8 +91,9 @@ jobs:
           # Erase any stale files
           cd "$GITHUB_WORKSPACE"/haddocks
           rm -rf ./*
-          git checkout --orphan an-empty-branch
+          git checkout --orphan fresh-haddocks-branch
           cp -r "${docs_root}"/* "$GITHUB_WORKSPACE"/haddocks
           git add .
           git commit -m "Regenerated haddocks based on ${GITHUB_SHA}"
-          git push --force origin haddocks
+          # Push the branch with only a single commit over the remote
+          git push --force origin fresh-haddocks-branch:haddocks

--- a/.github/workflows/haddocks.yaml
+++ b/.github/workflows/haddocks.yaml
@@ -91,11 +91,8 @@ jobs:
           # Erase any stale files
           cd "$GITHUB_WORKSPACE"/haddocks
           rm -rf ./*
+          git checkout --orphan an-empty-branch
           cp -r "${docs_root}"/* "$GITHUB_WORKSPACE"/haddocks
-          if [[ -z "$(git status --porcelain)" ]]; then
-            echo No changes.
-          else
-            git add .
-            git commit -m "Regenerated haddocks based on ${GITHUB_SHA}"
-            git push --force origin haddocks
-          fi
+          git add .
+          git commit -m "Regenerated haddocks based on ${GITHUB_SHA}"
+          git push --force origin haddocks

--- a/.github/workflows/haddocks.yaml
+++ b/.github/workflows/haddocks.yaml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - trunk
+      - "cp/force-push-haddocks"
 
 jobs:
   build:


### PR DESCRIPTION
Old docs commits are bloating the repo size a lot. I've got another approach to not save them in the repo at all here: #4378 , but haven't had time to finish it yet, and this is a trivial update in the meantime.

cc @aryairani 