### PR TITLE
Improve kind error messages

### DIFF
--- a/parser-typechecker/src/Unison/KindInference/Generate.hs
+++ b/parser-typechecker/src/Unison/KindInference/Generate.hs
@@ -241,7 +241,7 @@ declComponentConstraintTree decls = do
     -- Add a kind variable for every datatype
     declKind <- pushType (Type.ref (DD.annotation $ asDataDecl decl) ref)
     pure (ref, decl, declKind)
-  cts <- for decls \(ref, decl, declKind) -> do
+  (declConstraints, constructorConstraints) <- unzip <$> for decls \(ref, decl, declKind) -> do
     let declAnn = DD.annotation $ asDataDecl decl
     let declType = Type.ref declAnn ref
     -- Unify the datatype with @k_1 -> ... -> k_n -> *@ where @n@ is
@@ -275,8 +275,8 @@ declComponentConstraintTree decls = do
     let finalDeclConstraints = case decl of
           Left _effectDecl -> Constraint (IsAbility fullyAppliedKind (Provenance DeclDefinition declAnn)) declConstraints
           Right _dataDecl -> Constraint (IsType fullyAppliedKind (Provenance DeclDefinition declAnn)) declConstraints
-    pure (StrictOrder finalDeclConstraints constructorConstraints)
-  pure (Node cts)
+    pure (finalDeclConstraints, constructorConstraints)
+  pure (Node declConstraints `StrictOrder` Node constructorConstraints)
 
 -- | This is a helper to unify the kind constraints on type variables
 -- across a decl's constructors.

--- a/unison-src/transcripts/fix4397.md
+++ b/unison-src/transcripts/fix4397.md
@@ -1,0 +1,8 @@
+```unison
+structural type Foo f
+  = Foo (f ())
+unique type Baz = Baz (Foo Bar)
+
+unique type Bar 
+  = Bar Baz
+```

--- a/unison-src/transcripts/fix4397.md
+++ b/unison-src/transcripts/fix4397.md
@@ -1,4 +1,4 @@
-```unison
+```unison:error
 structural type Foo f
   = Foo (f ())
 unique type Baz = Baz (Foo Bar)

--- a/unison-src/transcripts/fix4397.output.md
+++ b/unison-src/transcripts/fix4397.output.md
@@ -10,25 +10,9 @@ unique type Bar
 ```ucm
 
   Kind mismatch arising from
-        5 | unique type Bar 
-        6 |   = Bar Baz
+        3 | unique type Baz = Baz (Foo Bar)
     
-    Expected kind: Type
-    Given kind: Type -> Type
+    Foo expects an argument of kind: Type -> Type; however, it
+    is applied to Bar which has kind: Type.
 
 ```
-
-
-
-🛑
-
-The transcript failed due to an error in the stanza above. The error is:
-
-
-  Kind mismatch arising from
-        5 | unique type Bar 
-        6 |   = Bar Baz
-    
-    Expected kind: Type
-    Given kind: Type -> Type
-

--- a/unison-src/transcripts/fix4397.output.md
+++ b/unison-src/transcripts/fix4397.output.md
@@ -1,0 +1,34 @@
+```unison
+structural type Foo f
+  = Foo (f ())
+unique type Baz = Baz (Foo Bar)
+
+unique type Bar 
+  = Bar Baz
+```
+
+```ucm
+
+  Kind mismatch arising from
+        5 | unique type Bar 
+        6 |   = Bar Baz
+    
+    Expected kind: Type
+    Given kind: Type -> Type
+
+```
+
+
+
+🛑
+
+The transcript failed due to an error in the stanza above. The error is:
+
+
+  Kind mismatch arising from
+        5 | unique type Bar 
+        6 |   = Bar Baz
+    
+    Expected kind: Type
+    Given kind: Type -> Type
+


### PR DESCRIPTION
## Overview

Partially addresses #4397.

The code:

```
structural type Foo f
  = Foo (f ())
unique type Baz = Baz (Foo Bar)
unique type Bar 
  = Bar Baz
```

Could give rise to the kind error

![kind-error-old](https://github.com/unisonweb/unison/assets/1627482/64a122a4-c244-4b8b-a678-e8182be17254)


because the constraint generation first emits constraints from Baz's decl and constructors before emitting constraints from Bar's decl and constructors.

This change emits errors from Bar and Baz's decls before emitting constraints from their constructors. This ensures we fail to solve constraints at type applications instead of declarations as in:

![kind-error](https://github.com/unisonweb/unison/assets/1627482/07d51efc-06cb-4e6d-a70a-45b4a9e525b0)

as demonstrated in the transcript.

## Implementation notes

Just a little shuffling in `Unison/KindInference/Generate.hs`.

## Test coverage

The new transcript fix4397 demonstrates the improved error message.