### PR TITLE
Fix spacing in `create.author` help

### DIFF
--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2474,15 +2474,13 @@ createAuthor =
     []
     I.Visible
     [(Required, noCompletionsArg), (Required, noCompletionsArg)]
-    ( makeExample createAuthor ["alicecoder", "\"Alice McGee\""]
-        <> "creates"
+    ( makeExample createAuthor ["alicecoder", "\"Alice McGee\""] <> " "
+        <> P.wrap (" creates "
         <> backtick "alicecoder"
         <> "values in"
         <> backtick "metadata.authors"
         <> "and"
-        <> backtick "metadata.copyrightHolders"
-        <> "."
-    )
+        <> backtick (P.group ("metadata.copyrightHolders" <> "."))))
     ( \case
         symbolStr : authorStr@(_ : _) -> first fromString $ do
           symbol <- Path.definitionNameSegment symbolStr


### PR DESCRIPTION
Before:

<img width="1327" alt="CleanShot 2023-11-19 at 14 13 54@2x" src="https://github.com/unisonweb/unison/assets/11074/521506f9-65bb-42cb-9055-936c69d82cd0">


After:

<img width="1099" alt="CleanShot 2023-11-19 at 14 11 39@2x" src="https://github.com/unisonweb/unison/assets/11074/39eeb476-c7f3-42c8-a2e4-517359637523">

There used to be a `Pretty.wrap` around all the `help`, which caused havok so it was removed a long time ago, but there were some places like this that were relying on the `wrap` being there to insert spaces properly.