### PR TITLE
Exact match on term types when determining whether doc or test.

### DIFF
--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -491,11 +491,11 @@ isDoc codebase ref = do
 
 isDoc' :: (Var v, Monoid loc) => Maybe (Type v loc) -> Bool
 isDoc' typeOfTerm = do
-  -- A term is a dococ if its type conforms to the `Doc` type.
+  -- A term is a doc if its type conforms to the `Doc` type.
   case typeOfTerm of
     Just t ->
-      Typechecker.isSubtype t doc1Type
-        || Typechecker.isSubtype t doc2Type
+      Typechecker.isEqual t doc1Type
+        || Typechecker.isEqual t doc2Type
     Nothing -> False
 
 doc1Type :: (Ord v, Monoid a) => Type v a
@@ -507,7 +507,7 @@ doc2Type = Type.ref mempty DD.doc2Ref
 isTestResultList :: forall v a. (Var v, Monoid a) => Maybe (Type v a) -> Bool
 isTestResultList typ = case typ of
   Nothing -> False
-  Just t -> Typechecker.isSubtype t resultListType
+  Just t -> Typechecker.isEqual t resultListType
 
 resultListType :: (Ord v, Monoid a) => Type v a
 resultListType = Type.app mempty (Type.list mempty) (Type.ref mempty Decls.testResultRef)
@@ -553,15 +553,11 @@ getTermTag ::
   m TermTag
 getTermTag codebase r sig = do
   -- A term is a doc if its type conforms to the `Doc` type.
-  let isDoc = case sig of
-        Just t ->
-          Typechecker.isSubtype t (Type.ref mempty Decls.docRef)
-            || Typechecker.isSubtype t (Type.ref mempty DD.doc2Ref)
-        Nothing -> False
+  let isDoc = isDoc' sig
   -- A term is a test if it has the type [test.Result]
   let isTest = case sig of
         Just t ->
-          Typechecker.isSubtype t (Decls.testResultType mempty)
+          Typechecker.isEqual t (Decls.testResultType mempty)
         Nothing -> False
   constructorType <- case r of
     V2Referent.Ref {} -> pure Nothing
@@ -1012,7 +1008,7 @@ docsForDefinitionName codebase (NameSearch {termSearch}) name = do
         Referent.Ref r ->
           maybe [] (pure . (r,)) <$> Codebase.getTypeOfTerm codebase r
         _ -> pure []
-      pure [r | (r, t) <- rts, Typechecker.isSubtype t (Type.ref mempty DD.doc2Ref)]
+      pure [r | (r, t) <- rts, isDoc' (Just t)]
 
 -- | Evaluate and render the given docs
 renderDocRefs ::


### PR DESCRIPTION
## Overview

Fixes https://github.com/unisonweb/unison/issues/4407

Don't do subtype matching for docs and terms or we'll match fully polymorphic terms.

Docs and types don't have type variables anyways, so we can do a full equality check.

## Implementation notes

Switch to an `isEqual` rather than `isSubtype` check for whether terms are docs or tests.

## Testing

- [x] Tested locally