### PR TITLE
Fix name resolution bug in the parser

### DIFF
--- a/parser-typechecker/src/Unison/UnisonFile/Names.hs
+++ b/parser-typechecker/src/Unison/UnisonFile/Names.hs
@@ -108,7 +108,7 @@ variableCanonicalizer vs =
     suffix <- Name.suffixes n
     pure (Var.named (Name.toText suffix), v)
   where
-    done xs = Map.fromList [ (k, v) | (k, nubOrd -> [v]) <- Map.toList xs ]
+    done xs = Map.fromList [ (k, v) | (k, nubOrd -> [v]) <- Map.toList xs ] <> Map.fromList [(v,v) | v <- vs]
 
 -- This function computes hashes for data and effect declarations, and
 -- also returns a function for resolving strings to (Reference, ConstructorId)

--- a/unison-src/transcripts/fix4415.md
+++ b/unison-src/transcripts/fix4415.md
@@ -1,0 +1,9 @@
+
+```unison
+unique type Foo = Foo
+unique type sub.Foo =
+```
+
+```ucm:error
+.> load
+```

--- a/unison-src/transcripts/fix4415.md
+++ b/unison-src/transcripts/fix4415.md
@@ -4,6 +4,6 @@ unique type Foo = Foo
 unique type sub.Foo =
 ```
 
-```ucm:error
+```ucm
 .> load
 ```

--- a/unison-src/transcripts/fix4415.md
+++ b/unison-src/transcripts/fix4415.md
@@ -3,7 +3,3 @@
 unique type Foo = Foo
 unique type sub.Foo =
 ```
-
-```ucm
-.> load
-```

--- a/unison-src/transcripts/fix4415.output.md
+++ b/unison-src/transcripts/fix4415.output.md
@@ -1,0 +1,43 @@
+
+```unison
+unique type Foo = Foo
+unique type sub.Foo =
+```
+
+```ucm
+
+  
+    ❓
+    
+    I couldn't resolve any of these symbols:
+    
+        1 | unique type Foo = Foo
+    
+    
+    Symbol   Suggestions
+             
+    Foo      No matches
+  
+
+```
+
+
+
+🛑
+
+The transcript failed due to an error in the stanza above. The error is:
+
+
+  
+    ❓
+    
+    I couldn't resolve any of these symbols:
+    
+        1 | unique type Foo = Foo
+    
+    
+    Symbol   Suggestions
+             
+    Foo      No matches
+  
+

--- a/unison-src/transcripts/fix4415.output.md
+++ b/unison-src/transcripts/fix4415.output.md
@@ -16,16 +16,3 @@ unique type sub.Foo =
       unique type sub.Foo
 
 ```
-```ucm
-.> load
-
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-  
-    ⍟ These new definitions are ok to `add`:
-    
-      unique type Foo
-      unique type sub.Foo
-
-```

--- a/unison-src/transcripts/fix4415.output.md
+++ b/unison-src/transcripts/fix4415.output.md
@@ -6,38 +6,26 @@ unique type sub.Foo =
 
 ```ucm
 
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
   
-    ❓
+    ⍟ These new definitions are ok to `add`:
     
-    I couldn't resolve any of these symbols:
-    
-        1 | unique type Foo = Foo
-    
-    
-    Symbol   Suggestions
-             
-    Foo      No matches
-  
+      unique type Foo
+      unique type sub.Foo
 
 ```
+```ucm
+.> load
 
-
-
-🛑
-
-The transcript failed due to an error in the stanza above. The error is:
-
-
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
   
-    ❓
+    ⍟ These new definitions are ok to `add`:
     
-    I couldn't resolve any of these symbols:
-    
-        1 | unique type Foo = Foo
-    
-    
-    Symbol   Suggestions
-             
-    Foo      No matches
-  
+      unique type Foo
+      unique type sub.Foo
 
+```


### PR DESCRIPTION
## Overview

Fixes a bug that arose if the FQN of a decl was a suffix of some other FQN. This would cause the parser would crash, failing to resolve the decl's FQN.

## Implementation notes

See #4415 

## Test coverage

Added a new transcript `fix4415.md` that demonstrates the issue, then followed with a commit that fixes it.