### PR TITLE
don't use `deepTermMetadata` for `test`

### DIFF
--- a/codebase2/core/U/Codebase/Reference.hs
+++ b/codebase2/core/U/Codebase/Reference.hs
@@ -10,7 +10,7 @@ module U.Codebase.Reference
     Reference' (..),
     TermReference',
     TypeReference',
-    ReferenceType(..),
+    ReferenceType (..),
     pattern Derived,
     Id,
     Id' (..),
@@ -20,6 +20,7 @@ module U.Codebase.Reference
     t_,
     h_,
     idH,
+    idPos,
     idToHash,
     idToShortHash,
     isBuiltin,
@@ -30,7 +31,7 @@ module U.Codebase.Reference
   )
 where
 
-import Control.Lens (Lens, Prism, Prism', Traversal, lens, preview, prism)
+import Control.Lens (Lens, Lens', Prism, Prism', Traversal, lens, preview, prism)
 import Data.Bifoldable (Bifoldable (..))
 import Data.Bitraversable (Bitraversable (..))
 import Data.Text qualified as Text
@@ -112,15 +113,18 @@ type Pos = Word64
 data Id' h = Id h Pos
   deriving stock (Eq, Ord, Show, Functor, Foldable, Traversable)
 
-t_ :: Traversal (Reference' t h) (Reference' t' h) t t'
-t_ f = \case
-  ReferenceBuiltin t -> ReferenceBuiltin <$> f t
-  ReferenceDerived id -> pure (ReferenceDerived id)
+t_ :: Prism (Reference' t h) (Reference' t' h) t t'
+t_ = prism ReferenceBuiltin \case
+  ReferenceBuiltin t -> Right t
+  ReferenceDerived id -> Left (ReferenceDerived id)
 
 h_ :: Traversal (Reference' t h) (Reference' t h') h h'
 h_ f = \case
   ReferenceBuiltin t -> pure (ReferenceBuiltin t)
   Derived h i -> Derived <$> f h <*> pure i
+
+idPos :: Lens' (Id' h) Pos
+idPos = lens (\(Id _h w) -> w) (\(Id h _w) w -> Id h w)
 
 idH :: Lens (Id' h) (Id' h') h h'
 idH = lens (\(Id h _w) -> h) (\(Id _h w) h -> Id h w)

--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -20,6 +20,8 @@ module Unison.Codebase
 
     -- ** Search
     termsOfType,
+    filterTermsByReferenceIdHavingType,
+    filterTermsByReferentHavingType,
     termsMentioningType,
     SqliteCodebase.Operations.termReferencesByPrefix,
     termReferentsByPrefix,
@@ -155,7 +157,7 @@ import Unison.NameSegment qualified as NameSegment
 import Unison.Parser.Ann (Ann)
 import Unison.Parser.Ann qualified as Parser
 import Unison.Prelude
-import Unison.Reference (Reference)
+import Unison.Reference (Reference, TermReferenceId, TypeReference)
 import Unison.Reference qualified as Reference
 import Unison.Referent qualified as Referent
 import Unison.Runtime.IOSource qualified as IOSource
@@ -460,6 +462,28 @@ termsOfTypeByReference c r =
   Set.union (Rel.lookupDom r Builtin.builtinTermsByType)
     . Set.map (fmap Reference.DerivedId)
     <$> termsOfTypeImpl c r
+
+filterTermsByReferentHavingType :: (Var v) => Codebase m v a -> Type v a -> Set Referent.Referent -> Sqlite.Transaction (Set Referent.Referent)
+filterTermsByReferentHavingType c ty = filterTermsByReferentHavingTypeByReference c $ Hashing.typeToReference ty
+
+filterTermsByReferenceIdHavingType :: (Var v) => Codebase m v a -> Type v a -> Set TermReferenceId -> Sqlite.Transaction (Set TermReferenceId)
+filterTermsByReferenceIdHavingType c ty = filterTermsByReferenceIdHavingTypeImpl c (Hashing.typeToReference ty)
+
+-- | Find the subset of `tms` which match the exact type `r` points to.
+filterTermsByReferentHavingTypeByReference :: Codebase m v a -> TypeReference -> Set Referent.Referent -> Sqlite.Transaction (Set Referent.Referent)
+filterTermsByReferentHavingTypeByReference c r tms = do
+  let (builtins, derived) = partitionEithers . map p $ Set.toList tms
+  let builtins' =
+        Set.intersection
+          (Set.fromList builtins)
+          (Rel.lookupDom r Builtin.builtinTermsByType)
+  derived' <- filterTermsByReferentIdHavingTypeImpl c r (Set.fromList derived)
+  pure $ builtins' <> Set.mapMonotonic Referent.fromId derived'
+  where
+    p :: Referent.Referent -> Either Referent.Referent Referent.Id
+    p r = case Referent.toId r of
+      Just rId -> Right rId
+      Nothing -> Left r
 
 -- | Get the set of terms-or-constructors mention the given type anywhere in their signature.
 termsMentioningType :: (Var v) => Codebase m v a -> Type v a -> Sqlite.Transaction (Set Referent.Referent)

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -71,7 +71,7 @@ import Unison.DataDeclaration (Decl)
 import Unison.Hash (Hash)
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
-import Unison.Reference (Reference)
+import Unison.Reference (Reference, TermReferenceId)
 import Unison.Reference qualified as Reference
 import Unison.Referent qualified as Referent
 import Unison.ShortHash (ShortHash)
@@ -352,6 +352,14 @@ sqliteCodebase debugName root localOrRemote lockOption migrationStrategy action 
             termsOfTypeImpl =
               CodebaseOps.termsOfTypeImpl getDeclType
 
+            filterTermsByReferentIdHavingTypeImpl :: Reference -> Set Referent.Id -> Sqlite.Transaction (Set Referent.Id)
+            filterTermsByReferentIdHavingTypeImpl =
+              CodebaseOps.filterReferentsHavingTypeImpl getDeclType
+
+            filterTermsByReferenceIdHavingTypeImpl :: Reference -> Set TermReferenceId -> Sqlite.Transaction (Set TermReferenceId)
+            filterTermsByReferenceIdHavingTypeImpl =
+              CodebaseOps.filterReferencesHavingTypeImpl
+
             termsMentioningTypeImpl :: Reference -> Sqlite.Transaction (Set Referent.Id)
             termsMentioningTypeImpl =
               CodebaseOps.termsMentioningTypeImpl getDeclType
@@ -382,6 +390,8 @@ sqliteCodebase debugName root localOrRemote lockOption migrationStrategy action 
                   getWatch,
                   termsOfTypeImpl,
                   termsMentioningTypeImpl,
+                  filterTermsByReferenceIdHavingTypeImpl,
+                  filterTermsByReferentIdHavingTypeImpl,
                   termReferentsByPrefix = referentsByPrefix,
                   withConnection = withConn,
                   withConnectionIO = withConnection debugName root

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Conversions.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Conversions.hs
@@ -273,20 +273,16 @@ branchHash2to1 :: forall m. BranchHash -> V1.Branch.NamespaceHash m
 branchHash2to1 = V1.HashFor . unBranchHash
 
 reference2to1 :: V2.Reference -> V1.Reference
-reference2to1 = \case
-  V2.ReferenceBuiltin t -> V1.Reference.Builtin t
-  V2.ReferenceDerived i -> V1.Reference.DerivedId $ referenceid2to1 i
+reference2to1 = id
 
 reference1to2 :: V1.Reference -> V2.Reference
-reference1to2 = \case
-  V1.Reference.Builtin t -> V2.ReferenceBuiltin t
-  V1.Reference.DerivedId i -> V2.ReferenceDerived (referenceid1to2 i)
+reference1to2 = id
 
 referenceid1to2 :: V1.Reference.Id -> V2.Reference.Id
-referenceid1to2 (V1.Reference.Id h i) = V2.Reference.Id h i
+referenceid1to2 = id
 
 referenceid2to1 :: V2.Reference.Id -> V1.Reference.Id
-referenceid2to1 (V2.Reference.Id h i) = V1.Reference.Id h i
+referenceid2to1 = id
 
 rreferent2to1 :: (Applicative m) => Hash -> (V2.Reference -> m CT.ConstructorType) -> V2.ReferentH -> m V1.Referent
 rreferent2to1 h lookupCT = \case
@@ -313,6 +309,11 @@ referent1to2 :: V1.Referent -> V2.Referent
 referent1to2 = \case
   V1.Ref r -> V2.Ref $ reference1to2 r
   V1.Con (V1.ConstructorReference r i) _ct -> V2.Con (reference1to2 r) (fromIntegral i)
+
+referentid1to2 :: V1.Referent.Id -> V2.Referent.Id
+referentid1to2 = \case
+  V1.RefId r -> V2.RefId (referenceid1to2 r)
+  V1.ConId (V1.ConstructorReference r i) _ct -> V2.ConId (referenceid1to2 r) i
 
 referentid2to1 :: (Applicative m) => (V2.Reference -> m CT.ConstructorType) -> V2.Referent.Id -> m V1.Referent.Id
 referentid2to1 lookupCT = \case

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Operations.hs
@@ -503,6 +503,23 @@ termsMentioningTypeImpl doGetDeclType r =
   Ops.termsMentioningType (Cv.reference1to2 r)
     >>= Set.traverse (Cv.referentid2to1 doGetDeclType)
 
+filterReferencesHavingTypeImpl :: Reference -> Set Reference.Id -> Transaction (Set Reference.Id)
+filterReferencesHavingTypeImpl typRef termRefs =
+  Ops.filterTermsByReferenceHavingType (Cv.reference1to2 typRef) (Cv.referenceid1to2 <$> toList termRefs)
+    <&> fmap Cv.referenceid2to1
+    <&> Set.fromList
+
+filterReferentsHavingTypeImpl ::
+  -- | A 'getDeclType'-like lookup, possibly backed by a cache.
+  (C.Reference.Reference -> Transaction CT.ConstructorType) ->
+  Reference ->
+  Set Referent.Id ->
+  Transaction (Set Referent.Id)
+filterReferentsHavingTypeImpl doGetDeclType typRef termRefs =
+  Ops.filterTermsByReferentHavingType (Cv.reference1to2 typRef) (Cv.referentid1to2 <$> toList termRefs)
+    >>= traverse (Cv.referentid2to1 doGetDeclType)
+      <&> Set.fromList
+
 -- | The number of base32 characters needed to distinguish any two references in the codebase.
 hashLength :: Transaction Int
 hashLength = pure 10

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -27,7 +27,7 @@ import Unison.ConstructorType qualified as CT
 import Unison.DataDeclaration (Decl)
 import Unison.Hash (Hash)
 import Unison.Prelude
-import Unison.Reference (Reference)
+import Unison.Reference (Reference, TypeReference)
 import Unison.Reference qualified as Reference
 import Unison.Referent qualified as Referent
 import Unison.ShortHash (ShortHash)
@@ -98,6 +98,10 @@ data Codebase m v a = Codebase
     termsOfTypeImpl :: Reference -> Sqlite.Transaction (Set Referent.Id),
     -- | Get the set of user-defined terms-or-constructors mention the given type anywhere in their signature.
     termsMentioningTypeImpl :: Reference -> Sqlite.Transaction (Set Referent.Id),
+    -- | Return the subset of the given set that has the given type.
+    filterTermsByReferenceIdHavingTypeImpl :: TypeReference -> Set Reference.Id -> Sqlite.Transaction (Set Reference.Id),
+    -- | Return the subset of the given set that has the given type.
+    filterTermsByReferentIdHavingTypeImpl :: TypeReference -> Set Referent.Id -> Sqlite.Transaction (Set Referent.Id),
     -- | Get the set of user-defined terms-or-constructors whose hash matches the given prefix.
     termReferentsByPrefix :: ShortHash -> Sqlite.Transaction (Set Referent.Id),
     -- | Acquire a new connection to the same underlying database file this codebase object connects to.

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -38,6 +38,7 @@ import System.IO.Error (isDoesNotExistError)
 import U.Codebase.Branch (NamespaceStats (..))
 import U.Codebase.Branch.Diff (NameChanges (..))
 import U.Codebase.HashTags (CausalHash (..))
+import U.Codebase.Reference qualified as Reference
 import U.Codebase.Sqlite.DbId (SchemaVersion (SchemaVersion))
 import Unison.ABT qualified as ABT
 import Unison.Auth.Types qualified as Auth
@@ -119,7 +120,7 @@ import Unison.PrintError
     renderCompilerBug,
   )
 import Unison.Project (ProjectAndBranch (..))
-import Unison.Reference (Reference, TermReference)
+import Unison.Reference (Reference, TermReferenceId)
 import Unison.Reference qualified as Reference
 import Unison.Referent (Referent)
 import Unison.Referent qualified as Referent
@@ -798,7 +799,7 @@ notifyUser dir = \case
     putPretty' $
       P.shown (total - n)
         <> " tests left to run, current test: "
-        <> P.syntaxToColor (prettyHashQualified (PPE.termName ppe $ Referent.Ref r))
+        <> P.syntaxToColor (prettyHashQualified (PPE.termName ppe $ Referent.fromTermReferenceId r))
     pure mempty
   TestIncrementalOutputEnd _ppe (_n, _total) _r result -> do
     clearCurrentLine
@@ -2645,7 +2646,7 @@ displayDefinitions DisplayDefinitionsOutput {isTest, outputFile, prettyPrintEnv 
                     <> "to replace the definitions currently in this namespace."
               ]
 
-    code :: (TermReference -> Bool) -> Pretty
+    code :: (TermReferenceId -> Bool) -> Pretty
     code isTest =
       P.syntaxToColor $ P.sep "\n\n" (prettyTypes <> prettyTerms isTest)
 
@@ -2657,13 +2658,13 @@ displayDefinitions DisplayDefinitionsOutput {isTest, outputFile, prettyPrintEnv 
         & List.sortBy (\(n0, _, _) (n1, _, _) -> Name.compareAlphabetical n0 n1)
         & map prettyType
 
-    prettyTerms :: (TermReference -> Bool) -> [P.Pretty SyntaxText]
+    prettyTerms :: (TermReferenceId -> Bool) -> [P.Pretty SyntaxText]
     prettyTerms isTest =
       terms
         & Map.toList
         & map (\(ref, dt) -> (PPE.termName ppeDecl (Referent.Ref ref), ref, dt))
         & List.sortBy (\(n0, _, _) (n1, _, _) -> Name.compareAlphabetical n0 n1)
-        & map (\t -> prettyTerm (isTest (t ^. _2)) t)
+        & map (\t -> prettyTerm (fromMaybe False . fmap isTest . Reference.toId $ (t ^. _2)) t)
 
     prettyTerm ::
       Bool ->
@@ -2735,13 +2736,13 @@ displayDefinitionsString maybePath definitions =
 displayTestResults ::
   Bool -> -- whether to show the tip
   PPE.PrettyPrintEnv ->
-  [(Reference, Text)] ->
-  [(Reference, Text)] ->
+  [(TermReferenceId, Text)] ->
+  [(TermReferenceId, Text)] ->
   Pretty
 displayTestResults showTip ppe oksUnsorted failsUnsorted =
   let oks = Name.sortByText fst [(name r, msg) | (r, msg) <- oksUnsorted]
       fails = Name.sortByText fst [(name r, msg) | (r, msg) <- failsUnsorted]
-      name r = HQ.toText $ PPE.termName ppe (Referent.Ref r)
+      name r = HQ.toText $ PPE.termName ppe (Referent.fromTermReferenceId r)
       okMsg =
         if null oks
           then mempty

--- a/unison-core/src/Unison/Referent.hs
+++ b/unison-core/src/Unison/Referent.hs
@@ -9,9 +9,12 @@ module Unison.Referent
     pattern RefId,
     pattern ConId,
     fold,
+    toId,
     toReference,
     toReferenceId,
     toTermReference,
+    toTermReferenceId,
+    fromId,
     fromTermReference,
     fromTermReferenceId,
     fromText,
@@ -72,6 +75,20 @@ pattern ConId r t = Con' r t
 -- referentToTerm moved to Term.fromReferent
 -- termToReferent moved to Term.toReferent
 
+toId :: Referent -> Maybe Id
+toId = \case
+  Ref (Reference.ReferenceDerived r) ->
+    Just (RefId r)
+  Con (ConstructorReference (Reference.ReferenceDerived r) i) t ->
+    Just (ConId (ConstructorReference r i) t)
+  _ -> Nothing
+
+fromId :: Id -> Referent
+fromId = \case
+  RefId r -> Ref (Reference.ReferenceDerived r)
+  ConId (ConstructorReference r i) t ->
+    Con (ConstructorReference (Reference.ReferenceDerived r) i) t
+
 -- todo: move these to ShortHash module
 toShortHash :: Referent -> ShortHash
 toShortHash = \case
@@ -106,6 +123,9 @@ toTermReference :: Referent -> Maybe TermReference
 toTermReference = \case
   Con' _ _ -> Nothing
   Ref' reference -> Just reference
+
+toTermReferenceId :: Referent -> Maybe TermReferenceId
+toTermReferenceId r = toTermReference r >>= Reference.toId
 
 -- | Inject a Term Reference into a Referent
 fromTermReference :: TermReference -> Referent

--- a/unison-src/transcripts/test-command.md
+++ b/unison-src/transcripts/test-command.md
@@ -32,7 +32,6 @@ test2 = [Ok "test2"]
 
 ```ucm:hide
 .lib> add
-.lib> link .builtin.metadata.isTest test2
 ```
 
 ```ucm
@@ -45,6 +44,7 @@ test2 = [Ok "test2"]
 ```unison
 test3 : [Result]
 test3 = [Ok "test3"]
+test4 = [Ok "test4"]
 ```
 
 ```ucm:hide

--- a/unison-src/transcripts/test-command.output.md
+++ b/unison-src/transcripts/test-command.output.md
@@ -97,6 +97,7 @@ test2 = [Ok "test2"]
 ```unison
 test3 : [Result]
 test3 = [Ok "test3"]
+test4 = [Ok "test4"]
 ```
 
 ```ucm
@@ -108,6 +109,7 @@ test3 = [Ok "test3"]
     ⍟ These new definitions are ok to `add`:
     
       test3 : [Result]
+      test4 : [Result]
 
 ```
 ```ucm
@@ -126,11 +128,16 @@ test3 = [Ok "test3"]
 
   
 
+  
+
+  
+
     New test results:
   
   ◉ hello.lib.test3   test3
+  ◉ hello.lib.test4   test4
   
-  ✅ 1 test(s) passing
+  ✅ 2 test(s) passing
   
   Tip: Use view hello.lib.test3 to view the source of a test.
 


### PR DESCRIPTION
## Overview

Use the type index rather than deepTermMetadata to determine what is a test, both for `test` and for `edit`.

Closes #4406.

## Implementation notes

Adds a sql query and codebase functions that filters a set of `TermReferenceId` according to the type index.
Also adds an untested query that filters a set of `Referent.Id` according to the type index, but the former is used in the `test` command, because constructors won't be tests.

## Interesting/controversial decisions

I thought about trying to remove metadata altogether, but it would've been too big. There is some work in https://github.com/unisonweb/unison/tree/topic/remove-deep-metadata.

I believe the only place `deepTermMetadata`/`deepTypeMetadata` are still used now is for 
* printing namespace diffs where metadata has changed
* [ ] metadata-based checks for docs (in `HandleInput.docsI`), can be removed


## Test coverage

I modified `unison-src/transcripts/test-command.md` to show examples of running tests that don't have `IsTest` metadata.