### PR TITLE
Add support for the `controls` attribute in Video

### DIFF
--- a/unison-share-api/src/Unison/Server/Doc/AsHtml.hs
+++ b/unison-share-api/src/Unison/Server/Doc/AsHtml.hs
@@ -468,6 +468,7 @@ toHtml docNamesByRef document =
                           go ("poster", p) = [LB.makeAttribute "poster" p]
                           go ("autoplay", "true") = [LB.makeAttribute "autoplay" "autoplay"]
                           go ("loop", "true") = [loop_ "loop"]
+                          go ("controls", "true") = [loop_ "controls"]
                           go ("muted", "true") = [LB.makeAttribute "muted" "muted"]
                           go _ = []
                    in pure $ video_ attrs' $ mapM_ source sources


### PR DESCRIPTION
## Overview

For Unison Doc videos, we want to allow users to provide the `controls` attribute and have that be passed through to the generated HTML.

cc @alvaroc1 