### PR TITLE
Return evaluation errors rather than just silencing them.

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -558,14 +558,15 @@ loop e = do
               mdText <- liftIO $ do
                 docRefs <- Backend.docsForDefinitionName codebase nameSearch docName
                 for docRefs $ \docRef -> do
-                  Identity (_, _, doc) <- Backend.renderDocRefs pped (Pretty.Width 80) codebase runtime (Identity docRef)
+                  Identity (_, _, doc, _evalErrs) <- Backend.renderDocRefs pped (Pretty.Width 80) codebase runtime (Identity docRef)
                   pure . Md.toText $ Md.toMarkdown doc
               Cli.respond $ Output.MarkdownOut (Text.intercalate "\n---\n" mdText)
             DocsToHtmlI namespacePath' sourceDirectory -> do
               Cli.Env {codebase, sandboxedRuntime} <- ask
               rootBranch <- Cli.getRootBranch
               absPath <- Path.unabsolute <$> Cli.resolvePath' namespacePath'
-              liftIO (Backend.docsInBranchToHtmlFiles sandboxedRuntime codebase rootBranch absPath sourceDirectory)
+              _evalErrs <- liftIO $ (Backend.docsInBranchToHtmlFiles sandboxedRuntime codebase rootBranch absPath sourceDirectory)
+              pure ()
             AliasTermI src' dest' -> do
               Cli.Env {codebase} <- ask
               src <- traverseOf _Right Cli.resolveSplit' src'

--- a/unison-cli/src/Unison/LSP/Queries.hs
+++ b/unison-cli/src/Unison/LSP/Queries.hs
@@ -388,5 +388,5 @@ markdownDocsForFQN fileUri fqn =
     liftIO $ do
       docRefs <- Backend.docsForDefinitionName codebase nameSearch name
       for docRefs $ \docRef -> do
-        Identity (_, _, doc) <- Backend.renderDocRefs pped (Pretty.Width 80) codebase runtime (Identity docRef)
+        Identity (_, _, doc, _evalErrs) <- Backend.renderDocRefs pped (Pretty.Width 80) codebase runtime (Identity docRef)
         pure . Md.toText $ Md.toMarkdown doc

--- a/unison-share-api/src/Unison/Server/Local/Definitions.hs
+++ b/unison-share-api/src/Unison/Server/Local/Definitions.hs
@@ -72,6 +72,8 @@ prettyDefinitionsForHQName perspective shallowRoot renderWidth suffixifyBindings
       docResults name = do
         docRefs <- docsForDefinitionName codebase nameSearch name
         renderDocRefs pped width codebase rt docRefs
+          -- local server currently ignores doc eval errors
+          <&> fmap \(hqn, h, doc, _errs) -> (hqn, h, doc)
 
   let fqnPPE = PPED.unsuffixifiedPPE pped
   typeDefinitions <-

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/NamespaceDetails.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/NamespaceDetails.hs
@@ -71,7 +71,8 @@ namespaceDetails runtime codebase namespacePath mayRoot _mayWidth = do
     (_localNamesOnly, ppe) <- Backend.scopedNamesForBranchHash codebase (Just rootCausal) namespacePath
     let mayReadmeRef = Backend.findDocInBranch readmeNames shallowBranch
     renderedReadme <- for mayReadmeRef \readmeRef -> do
-      eDoc <- liftIO $ evalDocRef runtime codebase readmeRef
+      -- Local server currently ignores eval errors.
+      (eDoc, _evalErrs) <- liftIO $ evalDocRef runtime codebase readmeRef
       pure $ Doc.renderDoc ppe eDoc
     let causalHash = v2CausalBranchToUnisonHash namespaceCausal
     pure $ NamespaceDetails namespacePath causalHash renderedReadme


### PR DESCRIPTION
## Overview

Currently any evaluation errors that occur during doc rendering are currently converted to a generic inline error, such that it's not possible to know what really went wrong.

I'll leave the local server alone, but exposing these errors will allow me to at least log the errors on share in case we need to investigate something.

## Implementation notes

* Return the errors from the doc rendering functions rather than silencing them.
* Ignore the errors on local UI.

## Interesting/controversial decisions

Should we surface these locally somehow? We've just been ignoring them up till now. Printing them out to stdout seems like the only easy option, but that could lead to some really wonky output when converting docs to html and such.

I decided to leave it as it is for now.

## Test coverage

None

## Loose ends

I'll need to import this in Share and log the errors.