### PR TITLE
Fix suffixification bug #4424

### DIFF
--- a/unison-core/src/Unison/NamesWithHistory.hs
+++ b/unison-core/src/Unison/NamesWithHistory.hs
@@ -38,7 +38,7 @@ data NamesWithHistory = NamesWithHistory
 
 instance Semigroup NamesWithHistory where
   NamesWithHistory cur1 old1 <> NamesWithHistory cur2 old2 =
-    NamesWithHistory (cur1 <> old1) (cur2 <> old2)
+    NamesWithHistory (cur1 <> cur2) (old1 <> old2)
 
 instance Monoid NamesWithHistory where
   mempty = NamesWithHistory mempty mempty

--- a/unison-src/transcripts/fix4424.md
+++ b/unison-src/transcripts/fix4424.md
@@ -1,0 +1,55 @@
+```ucm:hide
+.> builtins.merge
+```
+
+Some basics:
+
+```unison:hide
+unique type Cat.Dog = Mouse Nat
+unique type Rat.Dog = Bird
+
+countCat = cases
+  Cat.Dog.Mouse x -> Bird
+```
+
+```ucm
+.> add
+```
+
+Now I want to add a constructor.
+
+```unison:hide
+unique type Rat.Dog = Bird | Mouse
+```
+
+```ucm:error
+.> update
+```
+
+Here's the code that `update` produced:
+
+```unison:error
+countCat : Cat.Dog -> Rat.Dog
+countCat = cases Mouse x -> Bird
+
+unique type Rat.Dog = Bird | Mouse
+```
+
+Okay, hmm. TBH I think this code should have type-checked without user intervention, but the way it printed (`cases Mouse x`) is ambiguous, and UCM assumed `Mouse` meant `Rat.Dog.Mouse` instead of `Cat.Dog.Mouse`, which caused parsing to fail.
+
+I'll fix it by making it explicit:
+
+```unison
+countCat : Cat.Dog -> Rat.Dog
+countCat = cases Cat.Dog.Mouse x -> Bird
+
+unique type Rat.Dog = Bird | Mouse
+```
+
+Ok, all set! Now let's update.
+
+```ucm:error
+.> update
+```
+
+Why is it still printing just `Mouse` and failing?

--- a/unison-src/transcripts/fix4424.md
+++ b/unison-src/transcripts/fix4424.md
@@ -22,34 +22,6 @@ Now I want to add a constructor.
 unique type Rat.Dog = Bird | Mouse
 ```
 
-```ucm:error
+```ucm
 .> update
 ```
-
-Here's the code that `update` produced:
-
-```unison:error
-countCat : Cat.Dog -> Rat.Dog
-countCat = cases Mouse x -> Bird
-
-unique type Rat.Dog = Bird | Mouse
-```
-
-Okay, hmm. TBH I think this code should have type-checked without user intervention, but the way it printed (`cases Mouse x`) is ambiguous, and UCM assumed `Mouse` meant `Rat.Dog.Mouse` instead of `Cat.Dog.Mouse`, which caused parsing to fail.
-
-I'll fix it by making it explicit:
-
-```unison
-countCat : Cat.Dog -> Rat.Dog
-countCat = cases Cat.Dog.Mouse x -> Bird
-
-unique type Rat.Dog = Bird | Mouse
-```
-
-Ok, all set! Now let's update.
-
-```ucm:error
-.> update
-```
-
-Why is it still printing just `Mouse` and failing?

--- a/unison-src/transcripts/fix4424.output.md
+++ b/unison-src/transcripts/fix4424.output.md
@@ -32,80 +32,8 @@ unique type Rat.Dog = Bird | Mouse
 
   That's done. Now I'm making sure everything typechecks...
 
-  countCat : Cat.Dog -> Rat.Dog
-  countCat = cases Mouse x -> Bird
-  
-  unique type Rat.Dog = Bird | Mouse
+  Everything typechecks, so I'm saving the results...
 
-  Typechecking failed. I've updated your scratch file with the
-  definitions that need fixing. Once the file is compiling, try
-  `update` again.
+  Done.
 
 ```
-Here's the code that `update` produced:
-
-```unison
-countCat : Cat.Dog -> Rat.Dog
-countCat = cases Mouse x -> Bird
-
-unique type Rat.Dog = Bird | Mouse
-```
-
-```ucm
-
-  This pattern has the wrong number of arguments
-  
-      2 | countCat = cases Mouse x -> Bird
-  
-  The constructor has type 
-  
-    Rat.Dog
-  
-  but you supplied 1 arguments.
-
-```
-Okay, hmm. TBH I think this code should have type-checked without user intervention, but the way it printed (`cases Mouse x`) is ambiguous, and UCM assumed `Mouse` meant `Rat.Dog.Mouse` instead of `Cat.Dog.Mouse`, which caused parsing to fail.
-
-I'll fix it by making it explicit:
-
-```unison
-countCat : Cat.Dog -> Rat.Dog
-countCat = cases Cat.Dog.Mouse x -> Bird
-
-unique type Rat.Dog = Bird | Mouse
-```
-
-```ucm
-
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-  
-    ⍟ These names already exist. You can `update` them to your
-      new definition:
-    
-      unique type Rat.Dog
-      countCat : Cat.Dog -> Rat.Dog
-
-```
-Ok, all set! Now let's update.
-
-```ucm
-.> update
-
-  Okay, I'm searching the branch for code that needs to be
-  updated...
-
-  That's done. Now I'm making sure everything typechecks...
-
-  countCat : Cat.Dog -> Rat.Dog
-  countCat = cases Mouse x -> Rat.Dog.Bird
-  
-  unique type Rat.Dog = Bird | Mouse
-
-  Typechecking failed. I've updated your scratch file with the
-  definitions that need fixing. Once the file is compiling, try
-  `update` again.
-
-```
-Why is it still printing just `Mouse and failing?

--- a/unison-src/transcripts/fix4424.output.md
+++ b/unison-src/transcripts/fix4424.output.md
@@ -1,0 +1,111 @@
+Some basics:
+
+```unison
+unique type Cat.Dog = Mouse Nat
+unique type Rat.Dog = Bird
+
+countCat = cases
+  Cat.Dog.Mouse x -> Bird
+```
+
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    unique type Cat.Dog
+    unique type Rat.Dog
+    countCat : Cat.Dog -> Rat.Dog
+
+```
+Now I want to add a constructor.
+
+```unison
+unique type Rat.Dog = Bird | Mouse
+```
+
+```ucm
+.> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  countCat : Cat.Dog -> Rat.Dog
+  countCat = cases Mouse x -> Bird
+  
+  unique type Rat.Dog = Bird | Mouse
+
+  Typechecking failed. I've updated your scratch file with the
+  definitions that need fixing. Once the file is compiling, try
+  `update` again.
+
+```
+Here's the code that `update` produced:
+
+```unison
+countCat : Cat.Dog -> Rat.Dog
+countCat = cases Mouse x -> Bird
+
+unique type Rat.Dog = Bird | Mouse
+```
+
+```ucm
+
+  This pattern has the wrong number of arguments
+  
+      2 | countCat = cases Mouse x -> Bird
+  
+  The constructor has type 
+  
+    Rat.Dog
+  
+  but you supplied 1 arguments.
+
+```
+Okay, hmm. TBH I think this code should have type-checked without user intervention, but the way it printed (`cases Mouse x`) is ambiguous, and UCM assumed `Mouse` meant `Rat.Dog.Mouse` instead of `Cat.Dog.Mouse`, which caused parsing to fail.
+
+I'll fix it by making it explicit:
+
+```unison
+countCat : Cat.Dog -> Rat.Dog
+countCat = cases Cat.Dog.Mouse x -> Bird
+
+unique type Rat.Dog = Bird | Mouse
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      unique type Rat.Dog
+      countCat : Cat.Dog -> Rat.Dog
+
+```
+Ok, all set! Now let's update.
+
+```ucm
+.> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  countCat : Cat.Dog -> Rat.Dog
+  countCat = cases Mouse x -> Rat.Dog.Bird
+  
+  unique type Rat.Dog = Bird | Mouse
+
+  Typechecking failed. I've updated your scratch file with the
+  definitions that need fixing. Once the file is compiling, try
+  `update` again.
+
+```
+Why is it still printing just `Mouse and failing?


### PR DESCRIPTION
## Overview

During update we create a unison file containing the updates as well as the dependents of things to be updated. We print both the old and new references updates with the same name then typecheck this constructed file to see if the updated codebase will typecheck.

So, we want both the old and new references of updates to be printed with the same name. This was achieved previously through `addFallback`, which accomplished that goal, but introduced other problems. The problem demonstrated by #4424 is that the two arguments of `addFallback` are suffixified separately, so, if a suffixified name in one arg is a suffix of a name in the other arg, then parsing is ambiguous.

This PR replaces the use of `addFallback` with a new function `shadowNames` that suffixifies the combined names, but ensures that the updated terms are printed unqualified.

Fixes #4424 

## Test coverage

There is a new transcript that demonstrates 4424, followed by a commit that fixes it.
