### PR TITLE
Unique type churn transcript: add case of revert

### DIFF
--- a/unison-src/transcripts/unique-type-churn.md
+++ b/unison-src/transcripts/unique-type-churn.md
@@ -18,3 +18,29 @@ unique type A = A
 unique type B = B C
 unique type C = C B
 ```
+
+If the name stays the same, the churn is even prevented if the type is updated and then reverted to the original form.
+
+```ucm
+.> names A
+```
+
+```unison
+unique type A = A ()
+```
+
+```ucm
+.> update
+.> names A
+```
+
+```unison
+unique type A = A
+```
+
+Note that `A` is back to its original hash.
+
+```ucm
+.> update
+.> names A
+```

--- a/unison-src/transcripts/unique-type-churn.output.md
+++ b/unison-src/transcripts/unique-type-churn.output.md
@@ -44,3 +44,103 @@ unique type C = C B
   file has been previously added to the codebase.
 
 ```
+If the name stays the same, the churn is even prevented if the type is updated and then reverted to the original form.
+
+```ucm
+.> names A
+
+  Type
+  Hash:  #uj8oalgadr
+  Names: A
+  
+  Term
+  Hash:   #uj8oalgadr#0
+  Names:  A.A
+  
+  Tip: Use `names.global` to see more results.
+
+```
+```unison
+unique type A = A ()
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      unique type A
+
+```
+```ucm
+.> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
+
+  Done.
+
+.> names A
+
+  Type
+  Hash:  #ufo5tuc7ho
+  Names: A
+  
+  Term
+  Hash:   #ufo5tuc7ho#0
+  Names:  A.A
+  
+  Tip: Use `names.global` to see more results.
+
+```
+```unison
+unique type A = A
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      unique type A
+
+```
+Note that `A` is back to its original hash.
+
+```ucm
+.> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
+
+  Done.
+
+.> names A
+
+  Type
+  Hash:  #uj8oalgadr
+  Names: A
+  
+  Term
+  Hash:   #uj8oalgadr#0
+  Names:  A.A
+  
+  Tip: Use `names.global` to see more results.
+
+```


### PR DESCRIPTION
The unique type churn transcript now captures that if you revert a type
back to its original form (while keeping the same name), you'll end up
with the original hash again.

This behavior surprised me, but I can't see a reason it's bad, and it
might occasionally be useful. If nothing else we should capture the
current behavior so it doesn't change unintentionally.
