### PR TITLE
PackageImports to workaround `stack ghci` failure

### DIFF
--- a/lib/unison-util-nametree/src/Unison/Util/Nametree.hs
+++ b/lib/unison-util-nametree/src/Unison/Util/Nametree.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PackageImports #-}
+
 module Unison.Util.Nametree
   ( -- * Nametree
     Nametree (..),
@@ -19,7 +21,6 @@ import Data.List.NonEmpty (NonEmpty, pattern (:|))
 import Data.List.NonEmpty qualified as List.NonEmpty
 import Data.Map.Strict qualified as Map
 import Data.Semialign (Semialign (alignWith), Unzip (unzipWith), Zip (zipWith))
-import Data.Semigroup.Generic (GenericSemigroupMonoid (..))
 import Data.These (These (..), these)
 import Unison.Name (Name)
 import Unison.Name qualified as Name
@@ -27,6 +28,7 @@ import Unison.NameSegment
 import Unison.Prelude
 import Unison.Util.BiMultimap (BiMultimap)
 import Unison.Util.BiMultimap qualified as BiMultimap
+import "semigroups" Data.Semigroup.Generic (GenericSemigroupMonoid (..))
 import Prelude hiding (zipWith)
 
 -- | A nametree has a value, and a collection of children nametrees keyed by name segment.


### PR DESCRIPTION
Before, got this from `stack ghci`:

```
/Users/arya/work/unison/.trunk-pristine/lib/unison-util-nametree/src/Unison/Util/Nametree.hs:22:1: error:
    Ambiguous module name ‘Data.Semigroup.Generic’:
      it was found in multiple packages:
      generic-monoid-0.1.0.1 semigroups-0.20
   |
22 | import Data.Semigroup.Generic (GenericSemigroupMonoid (..))
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```