### PR TITLE
switch generic-monoid to semigroups (the two overlapping packages)

### DIFF
--- a/lib/unison-util-nametree/src/Unison/Util/Nametree.hs
+++ b/lib/unison-util-nametree/src/Unison/Util/Nametree.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE PackageImports #-}
-
 module Unison.Util.Nametree
   ( -- * Nametree
     Nametree (..),
@@ -21,6 +19,7 @@ import Data.List.NonEmpty (NonEmpty, pattern (:|))
 import Data.List.NonEmpty qualified as List.NonEmpty
 import Data.Map.Strict qualified as Map
 import Data.Semialign (Semialign (alignWith), Unzip (unzipWith), Zip (zipWith))
+import Data.Semigroup.Generic (GenericSemigroupMonoid (..))
 import Data.These (These (..), these)
 import Unison.Name (Name)
 import Unison.Name qualified as Name
@@ -28,7 +27,6 @@ import Unison.NameSegment
 import Unison.Prelude
 import Unison.Util.BiMultimap (BiMultimap)
 import Unison.Util.BiMultimap qualified as BiMultimap
-import "semigroups" Data.Semigroup.Generic (GenericSemigroupMonoid (..))
 import Prelude hiding (zipWith)
 
 -- | A nametree has a value, and a collection of children nametrees keyed by name segment.

--- a/parser-typechecker/package.yaml
+++ b/parser-typechecker/package.yaml
@@ -53,7 +53,6 @@ dependencies:
   - fuzzyfind
   - free
   - generic-lens
-  - generic-monoid
   - hashable
   - hashtables
   - haskeline
@@ -90,6 +89,7 @@ dependencies:
   - safe
   - safe-exceptions
   - semialign
+  - semigroups
   - servant
   - servant-client
   - servant-docs

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Branch/Dependencies.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Branch/Dependencies.hs
@@ -8,7 +8,7 @@ module Unison.Codebase.SqliteCodebase.Branch.Dependencies where
 import Data.Foldable (toList)
 import Data.Map (Map)
 import Data.Map qualified as Map
-import Data.Monoid.Generic (GenericMonoid (..), GenericSemigroup (..))
+import Data.Semigroup.Generic (GenericSemigroupMonoid (..))
 import Data.Set (Set)
 import Data.Set qualified as Set
 import GHC.Generics (Generic)
@@ -34,8 +34,7 @@ data Dependencies = Dependencies
   }
   deriving (Show)
   deriving (Generic)
-  deriving (Semigroup) via GenericSemigroup Dependencies
-  deriving (Monoid) via GenericMonoid Dependencies
+  deriving (Semigroup, Monoid) via GenericSemigroupMonoid Dependencies
 
 data Dependencies' = Dependencies'
   { patches' :: [PatchHash],
@@ -44,8 +43,7 @@ data Dependencies' = Dependencies'
   }
   deriving (Eq, Show)
   deriving (Generic)
-  deriving (Semigroup) via GenericSemigroup Dependencies'
-  deriving (Monoid) via GenericMonoid Dependencies'
+  deriving (Semigroup, Monoid) via GenericSemigroupMonoid Dependencies'
 
 to' :: Dependencies -> Dependencies'
 to' Dependencies {..} = Dependencies' (toList patches) (toList terms) (toList decls)

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -261,7 +261,6 @@ library
     , free
     , fuzzyfind
     , generic-lens
-    , generic-monoid
     , hashable
     , hashtables
     , haskeline
@@ -298,6 +297,7 @@ library
     , safe
     , safe-exceptions
     , semialign
+    , semigroups
     , servant
     , servant-client
     , servant-docs
@@ -454,7 +454,6 @@ test-suite parser-typechecker-tests
     , free
     , fuzzyfind
     , generic-lens
-    , generic-monoid
     , hashable
     , hashtables
     , haskeline
@@ -491,6 +490,7 @@ test-suite parser-typechecker-tests
     , safe
     , safe-exceptions
     , semialign
+    , semigroups
     , servant
     , servant-client
     , servant-docs


### PR DESCRIPTION
and revert #4453

