### PR TITLE
Allow layout blocks within Doc transclusion

### DIFF
--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -295,6 +295,82 @@ So we can see the pretty-printed output:
     fix_4352 : Doc2
     fix_4352 = {{ `` +1 `` }}
     
+    fix_4384 : Doc2
+    fix_4384 = {{ {{ docExampleBlock 0 '2 }} }}
+    
+    fix_4384a : Doc2
+    fix_4384a =
+      use Nat +
+      {{ {{ docExampleBlock 0 '(1 + 1) }} }}
+    
+    fix_4384b : Doc2
+    fix_4384b = {{ {{ docExampleBlock 0 '99 }} }}
+    
+    fix_4384c : Doc2
+    fix_4384c =
+      use Nat +
+      {{ {{ docExampleBlock 0 do
+        x = 1
+        y = 2
+        x + y }} }}
+    
+    fix_4384d : Doc2
+    fix_4384d =
+      {{
+      {{
+      docExampleBlock 0 '[ 1
+        , 2
+        , 3
+        , 4
+        , 5
+        , 6
+        , 7
+        , 8
+        , 9
+        , 10
+        , 11
+        , 12
+        , 13
+        , 14
+        , 15
+        , 16
+        , 17
+        , 18
+        ] }}
+      }}
+    
+    fix_4384e : Doc2
+    fix_4384e =
+      id : x -> x
+      id x = x
+      {{
+      {{
+      docExampleBlock
+        0
+        (id
+          id
+          id
+          id
+          id
+          id
+          id
+          id
+          id
+          id
+          id
+          id
+          id
+          id
+          id
+          id
+          id
+          id
+          id
+          id
+          id
+          (x -> 0)) }}
+      }}
+    
     Fix_525.bar.quaffle : Nat
     Fix_525.bar.quaffle = 32
     

--- a/unison-src/transcripts-round-trip/reparses-with-same-hash.u
+++ b/unison-src/transcripts-round-trip/reparses-with-same-hash.u
@@ -527,3 +527,19 @@ stew_issue3 =
   error
     (Debug None '("Failed to get timestamp of config file " ++ 
            toText configPath))
+
+fix_4384 = {{ {{ docExampleBlock 0 do 2 }} }}
+fix_4384a = {{ {{ docExampleBlock 0 '(1 + 1) }} }}
+fix_4384b = {{ {{ docExampleBlock 0 '99 }} }}
+fix_4384c = {{ {{ docExampleBlock 0 do
+  x = 1
+  y = 2
+  x + y
+  }} }}
+
+fix_4384d = {{ {{ docExampleBlock 0 '[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18] }} }}
+
+fix_4384e = 
+  id : x -> x
+  id x = x
+  {{ {{ docExampleBlock 0 (id id id id id id id id id id id id id id id id id id id id id (x -> 0) }} }}

--- a/unison-syntax/src/Unison/Syntax/Lexer.hs
+++ b/unison-syntax/src/Unison/Syntax/Lexer.hs
@@ -525,10 +525,7 @@ lexemes' eof =
               ex <- CP.space *> lexemes' end
               pure ex
 
-        -- general idea is these can push onto layout stack
-        -- and pop, 
         docClose = [] <$ lit "}}"
-        -- and this can pop from layout stack
         docOpen = [] <$ lit "{{"
         
         link =

--- a/unison-syntax/src/Unison/Syntax/Lexer.hs
+++ b/unison-syntax/src/Unison/Syntax/Lexer.hs
@@ -547,7 +547,7 @@ lexemes' eof =
                 -- pop items off the layout stack up to the nearest enclosing
                 -- syntax.docTransclude.
                 ts <- lexemes' (P.lookAhead ([] <$ lit "}}"));
-                S.modify (\env -> env { inLayout = inLayout env });
+                S.modify (\env -> env { inLayout = inLayout env0 });
                 pure ts
               }
               <+> close ["syntax.docTransclude"] (lit "}}")

--- a/unison-syntax/src/Unison/Syntax/Lexer.hs
+++ b/unison-syntax/src/Unison/Syntax/Lexer.hs
@@ -360,14 +360,6 @@ lexemes' eof =
         <|> token wordyId
         <|> (asum . map token) [semi, textual, hash]
 
-    wordySep c = isSpace c || not (wordyIdChar c)
-    positioned p = do start <- pos; a <- p; stop <- pos; pure (start, a, stop)
-
-    tok :: P a -> P [Token a]
-    tok p = do
-      (start, a, stop) <- positioned p
-      pure [Token a start stop]
-
     doc2 :: P [Token Lexeme]
     doc2 = do
       let start = token'' ignore (lit "{{")
@@ -533,9 +525,12 @@ lexemes' eof =
               ex <- CP.space *> lexemes' end
               pure ex
 
+        -- general idea is these can push onto layout stack
+        -- and pop, 
         docClose = [] <$ lit "}}"
+        -- and this can pop from layout stack
         docOpen = [] <$ lit "{{"
-
+        
         link =
           P.label "link (examples: {type List}, {Nat.+})" $
             wrap "syntax.docLink" $
@@ -544,8 +539,21 @@ lexemes' eof =
 
         expr =
           P.label "transclusion (examples: {{ doc2 }}, {{ sepBy s [doc1, doc2] }})" $
-            wrap "syntax.docTransclude" $
-              docOpen *> lexemes' docClose
+            openAs "{{" "syntax.docTransclude" 
+              <+> do {
+                env0 <- S.get;
+                -- we re-allow layout within a transclusion, then restore it to its 
+                -- previous state after
+                S.put (env0 { inLayout = True });
+                -- Note: this P.lookAhead ensures the }} isn't consumed,
+                -- so it can be consumed below by the `close` which will
+                -- pop items off the layout stack up to the nearest enclosing
+                -- syntax.docTransclude.
+                ts <- lexemes' (P.lookAhead ([] <$ lit "}}"));
+                S.modify (\env -> env { inLayout = inLayout env });
+                pure ts
+              }
+              <+> close ["syntax.docTransclude"] (lit "}}")
 
         nonNewlineSpace ch = isSpace ch && ch /= '\n' && ch /= '\r'
         nonNewlineSpaces = P.takeWhileP Nothing nonNewlineSpace
@@ -879,9 +887,6 @@ lexemes' eof =
         Nothing -> err start (InvalidShortHash potentialHash)
         Just sh -> pure sh
 
-    separated :: (Char -> Bool) -> P a -> P a
-    separated ok p = P.try $ p <* P.lookAhead (void (P.satisfy ok) <|> P.eof)
-
     numeric = bytes <|> otherbase <|> float <|> intOrNat
       where
         intOrNat = P.try $ num <$> sign <*> LP.decimal
@@ -1073,55 +1078,73 @@ lexemes' eof =
           where
             ok c = isDelayOrForce c || isSpace c || isAlphaNum c || Set.member c delimiters || c == '\"'
 
-        open :: String -> P [Token Lexeme]
-        open b = do
-          (start, _, end) <- positioned $ lit b
-          env <- S.get
-          S.put (env {opening = Just b})
-          pure [Token (Open b) start end]
+separated :: (Char -> Bool) -> P a -> P a
+separated ok p = P.try $ p <* P.lookAhead (void (P.satisfy ok) <|> P.eof)
 
-        openKw :: String -> P [Token Lexeme]
-        openKw s = separated wordySep $ do
-          (pos1, s, pos2) <- positioned $ lit s
-          env <- S.get
-          S.put (env {opening = Just s})
-          pure [Token (Open s) pos1 pos2]
+open :: String -> P [Token Lexeme]
+open b = openAs b b 
 
-        close = close' Nothing
+positioned :: P a -> P (Pos, a, Pos)
+positioned p = do start <- pos; a <- p; stop <- pos; pure (start, a, stop)
 
-        closeKw' :: Maybe String -> [String] -> P String -> P [Token Lexeme]
-        closeKw' reopenBlockname open closeP = close' reopenBlockname open (separated wordySep closeP)
+openAs :: String -> String -> P [Token Lexeme]
+openAs syntax b = do
+  (start, _, end) <- positioned $ lit syntax
+  env <- S.get
+  S.put (env {opening = Just b})
+  pure [Token (Open b) start end]
 
-        blockDelimiter :: [String] -> P String -> P [Token Lexeme]
-        blockDelimiter open closeP = do
-          (pos1, close, pos2) <- positioned $ closeP
-          env <- S.get
-          case findClose open (layout env) of
-            Nothing -> err pos1 (UnexpectedDelimiter (quote close))
-              where
-                quote s = "'" <> s <> "'"
-            Just (_, n) -> do
-              S.put (env {layout = drop (n - 1) (layout env)})
-              let delims = [Token (Reserved close) pos1 pos2]
-              pure $ replicate (n - 1) (Token Close pos1 pos2) ++ delims
+openKw :: String -> P [Token Lexeme]
+openKw s = separated wordySep $ do
+  (pos1, s, pos2) <- positioned $ lit s
+  env <- S.get
+  S.put (env {opening = Just s})
+  pure [Token (Open s) pos1 pos2]
 
-        close' :: Maybe String -> [String] -> P String -> P [Token Lexeme]
-        close' reopenBlockname open closeP = do
-          (pos1, close, pos2) <- positioned $ closeP
-          env <- S.get
-          case findClose open (layout env) of
-            Nothing -> err pos1 (CloseWithoutMatchingOpen msgOpen (quote close))
-              where
-                msgOpen = intercalate " or " (quote <$> open)
-                quote s = "'" <> s <> "'"
-            Just (_, n) -> do
-              S.put (env {layout = drop n (layout env), opening = reopenBlockname})
-              let opens = maybe [] (const $ [Token (Open close) pos1 pos2]) reopenBlockname
-              pure $ replicate n (Token Close pos1 pos2) ++ opens
+wordySep :: Char -> Bool
+wordySep c = isSpace c || not (wordyIdChar c)
 
-        findClose :: [String] -> Layout -> Maybe (String, Int)
-        findClose _ [] = Nothing
-        findClose s ((h, _) : tl) = if h `elem` s then Just (h, 1) else fmap (1 +) <$> findClose s tl
+tok :: P a -> P [Token a]
+tok p = do
+  (start, a, stop) <- positioned p
+  pure [Token a start stop]
+
+blockDelimiter :: [String] -> P String -> P [Token Lexeme]
+blockDelimiter open closeP = do
+  (pos1, close, pos2) <- positioned $ closeP
+  env <- S.get
+  case findClose open (layout env) of
+    Nothing -> err pos1 (UnexpectedDelimiter (quote close))
+      where
+        quote s = "'" <> s <> "'"
+    Just (_, n) -> do
+      S.put (env {layout = drop (n - 1) (layout env)})
+      let delims = [Token (Reserved close) pos1 pos2]
+      pure $ replicate (n - 1) (Token Close pos1 pos2) ++ delims
+
+close :: [String] -> P String -> P [Token Lexeme]
+close = close' Nothing
+
+closeKw' :: Maybe String -> [String] -> P String -> P [Token Lexeme]
+closeKw' reopenBlockname open closeP = close' reopenBlockname open (separated wordySep closeP)
+
+close' :: Maybe String -> [String] -> P String -> P [Token Lexeme]
+close' reopenBlockname open closeP = do
+  (pos1, close, pos2) <- positioned $ closeP
+  env <- S.get
+  case findClose open (layout env) of
+    Nothing -> err pos1 (CloseWithoutMatchingOpen msgOpen (quote close))
+      where
+        msgOpen = intercalate " or " (quote <$> open)
+        quote s = "'" <> s <> "'"
+    Just (_, n) -> do
+      S.put (env {layout = drop n (layout env), opening = reopenBlockname})
+      let opens = maybe [] (const $ [Token (Open close) pos1 pos2]) reopenBlockname
+      pure $ replicate n (Token Close pos1 pos2) ++ opens
+
+findClose :: [String] -> Layout -> Maybe (String, Int)
+findClose _ [] = Nothing
+findClose s ((h, _) : tl) = if h `elem` s then Just (h, 1) else fmap (1 +) <$> findClose s tl
 
 simpleWordyId :: String -> Lexeme
 simpleWordyId = flip WordyId Nothing


### PR DESCRIPTION
Fixes #4384 

Previously, code like this would not parse:

```
fix_4384a = {{ {{ docExampleBlock 0 do 1  }} }}

fix_4384b = {{ {{ docExampleBlock 0 do
  x = 1
  y = 2
  x + y
  }} }}
```

Now it parses fine. The fix was to re-enable layout within a transclusion, and to have `}}` pop layout up to the enclosing `{{`. Prior to this change, layout was incorrectly being entirely disabled within a doc block, even within a nested transclusion which can contain arbitrary Unison code that uses layout.

The diff is actually very small, just one function (see self-review), but I had to move some helper functions out of a where clause to make them available for this change, so the actual diff looks bigger.

## Interesting/controversial decisions

Nothing.

## Test coverage

Added regression tests, including some weird examples I could think of, and existing transcripts cover the doc syntax. I feel pretty confident this can only improve parsing and round trip issues, but after merging to trunk, I'd recommend dogfooding it for a couple days just to make sure there aren't any regressions in weird corner cases I haven't thought of.

cc @stew @runarorama @ceedubs who I know have been affected by this.