### PR TITLE
Change urls to use `/docs` instead of `/learn`

### DIFF
--- a/unison-cli/src/Unison/CommandLine/Welcome.hs
+++ b/unison-cli/src/Unison/CommandLine/Welcome.hs
@@ -108,12 +108,12 @@ authorSuggestion =
       [ P.wrap "📜🪶 You might want to set up your author information next.",
         P.wrap "Type" <> P.hiBlue " create.author" <> " to create an author for this codebase",
         P.group (P.newline <> P.wrap "Read about how to link your author to your code at"),
-        P.wrap $ P.blue "https://www.unison-lang.org/learn/tooling/configuration/"
+        P.wrap $ P.blue "https://www.unison-lang.org/docs/tooling/configuration/"
       ]
 
 getStarted :: Bool -> P.Pretty P.ColorText
 getStarted showWelcomeHint =
-  P.wrap "📚 Read the official docs at https://www.unison-lang.org/learn/"
+  P.wrap "📚 Read the official docs at https://www.unison-lang.org/docs/"
     <> P.newline
     <> P.newline
     <> P.wrap (if showWelcomeHint


### PR DESCRIPTION
Both still work but `/docs` is now the canonical URL