### PR TITLE
bugfix: tweak upgrade to ignore aliases of old things

### DIFF
--- a/parser-typechecker/src/Unison/PrettyPrintEnv/Names.hs
+++ b/parser-typechecker/src/Unison/PrettyPrintEnv/Names.hs
@@ -1,6 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Unison.PrettyPrintEnv.Names (fromNames, fromSuffixNames) where
+module Unison.PrettyPrintEnv.Names
+  ( fromNames,
+    fromSuffixNames,
+    prioritize,
+    shortestUniqueSuffixes,
+  )
+where
 
 import Data.Set qualified as Set
 import Unison.HashQualified' qualified as HQ'
@@ -46,16 +52,16 @@ fromSuffixNames len names = PrettyPrintEnv terms' types'
       NamesWithHistory.termName len r names
         & Set.toList
         & fmap (\n -> (n, n))
-        & shortestUniqueSuffixes r (Names.terms $ NamesWithHistory.currentNames names)
+        & shortestUniqueSuffixes (Names.terms $ NamesWithHistory.currentNames names)
         & prioritize
     types' r =
       NamesWithHistory.typeName len r names
         & Set.toList
         & fmap (\n -> (n, n))
-        & shortestUniqueSuffixes r (Names.types $ NamesWithHistory.currentNames names)
+        & shortestUniqueSuffixes (Names.types $ NamesWithHistory.currentNames names)
         & prioritize
 
 -- | Reduce the provided names to their minimal unique suffix within the scope of the given
 -- relation.
-shortestUniqueSuffixes :: (Ord ref) => ref -> Rel.Relation Name ref -> [(a, HQ'.HashQualified Name)] -> [(a, HQ'.HashQualified Name)]
-shortestUniqueSuffixes ref rel names = names <&> second (fmap (\name -> Name.shortestUniqueSuffix name ref rel))
+shortestUniqueSuffixes :: (Ord ref) => Rel.Relation Name ref -> [(a, HQ'.HashQualified Name)] -> [(a, HQ'.HashQualified Name)]
+shortestUniqueSuffixes rel names = names <&> second (fmap (\name -> Name.shortestUniqueSuffix name rel))

--- a/parser-typechecker/tests/Unison/Core/Test/Name.hs
+++ b/parser-typechecker/tests/Unison/Core/Test/Name.hs
@@ -92,24 +92,24 @@ testSuffixSearch =
         (Name.searchBySuffix (n "map") rel)
       expectEqual'
         (n "List.map")
-        (Name.shortestUniqueSuffix (n "base.List.map") 1 rel)
+        (Name.shortestUniqueSuffix (n "base.List.map") rel)
       expectEqual'
         (n "Set.map")
-        (Name.shortestUniqueSuffix (n "base.Set.map") 2 rel)
+        (Name.shortestUniqueSuffix (n "base.Set.map") rel)
       expectEqual'
         (n "baz")
-        (Name.shortestUniqueSuffix (n "foo.bar.baz") 3 rel)
+        (Name.shortestUniqueSuffix (n "foo.bar.baz") rel)
       expectEqual'
         (n "a.b.c")
-        (Name.shortestUniqueSuffix (n "a.b.c") 3 rel)
+        (Name.shortestUniqueSuffix (n "a.b.c") rel)
       expectEqual'
         (n "a1.b.c")
-        (Name.shortestUniqueSuffix (n "a1.b.c") 3 rel)
+        (Name.shortestUniqueSuffix (n "a1.b.c") rel)
       note . show $ Name.reverseSegments (n ".")
       note . show $ Name.reverseSegments (n "..")
       tests
         [ scope "(.) shortest unique suffix" $
-            expectEqual' (n ".") (Name.shortestUniqueSuffix (n "..") 6 rel),
+            expectEqual' (n ".") (Name.shortestUniqueSuffix (n "..") rel),
           scope "(.) search by suffix" $
             expectEqual' (Set.fromList [6]) (Name.searchBySuffix (n ".") rel)
         ]

--- a/unison-core/src/Unison/Name.hs
+++ b/unison-core/src/Unison/Name.hs
@@ -481,23 +481,23 @@ unqualified :: Name -> Name
 unqualified (Name _ (s :| _)) =
   Name Relative (s :| [])
 
--- Tries to shorten `fqn` to the smallest suffix that still refers
--- to to `r`. Uses an efficient logarithmic lookup in the provided relation.
+-- Tries to shorten `fqn` to the smallest suffix that still refers the same references.
+-- Uses an efficient logarithmic lookup in the provided relation.
 -- The returned `Name` may refer to multiple hashes if the original FQN
 -- did as well.
 --
 -- NB: Only works if the `Ord` instance for `Name` orders based on
 -- `Name.reverseSegments`.
-shortestUniqueSuffix :: forall r. (Ord r) => Name -> r -> R.Relation Name r -> Name
-shortestUniqueSuffix fqn r rel =
+shortestUniqueSuffix :: forall r. (Ord r) => Name -> R.Relation Name r -> Name
+shortestUniqueSuffix fqn rel =
   fromMaybe fqn (List.find isOk (suffixes' fqn))
   where
-    allowed :: Set r
-    allowed =
+    allRefs :: Set r
+    allRefs =
       R.lookupDom fqn rel
     isOk :: Name -> Bool
     isOk suffix =
-      (Set.size rs == 1 && Set.findMin rs == r) || rs == allowed
+      Set.size rs == 1 || rs == allRefs
       where
         rs :: Set r
         rs =

--- a/unison-src/transcripts/upgrade-with-old-alias.md
+++ b/unison-src/transcripts/upgrade-with-old-alias.md
@@ -15,4 +15,5 @@ mything = lib.old.foo + 100
 myproject/main> update
 myproject/main> upgrade old new
 myproject/main> view mything
+myproject/main> view bar
 ```

--- a/unison-src/transcripts/upgrade-with-old-alias.md
+++ b/unison-src/transcripts/upgrade-with-old-alias.md
@@ -1,0 +1,18 @@
+```ucm:hide
+.> project.create-empty myproject
+myproject/main> builtins.merge
+myproject/main> move.namespace builtin lib.builtin
+```
+
+```unison
+lib.old.foo = 141
+lib.new.foo = 142
+bar = 141
+mything = lib.old.foo + 100
+```
+
+```ucm
+myproject/main> update
+myproject/main> upgrade old new
+myproject/main> view mything
+```

--- a/unison-src/transcripts/upgrade-with-old-alias.output.md
+++ b/unison-src/transcripts/upgrade-with-old-alias.output.md
@@ -1,0 +1,41 @@
+```unison
+lib.old.foo = 141
+lib.new.foo = 142
+bar = 141
+mything = lib.old.foo + 100
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bar         : Nat
+      lib.new.foo : Nat
+      lib.old.foo : Nat
+      mything     : Nat
+
+```
+```ucm
+myproject/main> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+
+myproject/main> upgrade old new
+
+  I upgraded old to new, and removed old.
+
+myproject/main> view mything
+
+  mything : Nat
+  mything =
+    use Nat +
+    foo + 100
+
+```

--- a/unison-src/transcripts/upgrade-with-old-alias.output.md
+++ b/unison-src/transcripts/upgrade-with-old-alias.output.md
@@ -38,4 +38,9 @@ myproject/main> view mything
     use Nat +
     foo + 100
 
+myproject/main> view bar
+
+  bar : Nat
+  bar = 141
+
 ```


### PR DESCRIPTION
## Overview

This PR fixes an issue that caused `upgrade` to behave unintuitively.

The algorithm essentially works as follows (before and after this PR):

- When upgrading library dependency `old` to `new`, render out to a Unison file all dependents of all terms in `lib.old` (e.g. `lib.old.thingy#oldthingy`), but with the `old` segment swapped out for `new`, then parse and typecheck that.

  For example, consider the namespace:

  ```
  lib.old.thingy#oldthingy = ...
  lib.new.thingy#newthingy = ...
  myfoo = #oldthingy + 100
  ```

  On `upgrade old new`, we render, parse, and typecheck a Unison file like

  ```
  myfoo = lib.new.thingy + 100
  ```

The issue was to do with aliases. Prior to this PR, additional aliases of things in `lib.old.*` would essentially prevent upgrading as follows.

Consider the namespace:

```
lib.old.thingy#oldthingy = ...
lib.new.thingy#newthingy = ...
mythingy#oldthingy = ...
myfoo = #oldthingy + 100
```

The old implementation would render, parse, and typecheck a Unison file like

```
myfoo = mythingy + 100
```

as the "old" reference `#oldthingy` still had a set of names `{ lib.new.thingy, mythingy }` from which we make the pretty-print environment.

This behavior is especially bad considering dependencies' dependencies are actually in scope for developers (something we neglected to think about when implementing the algorithm the first time around).

While in the example above, the user's project code itself has a name for `#oldthingy`, it's probably much more common for `#oldthingy` to be referenced by some _dependency_ that still depends on `old` (which the user is trying to upgrade to `new):

```
lib.old.thingy#oldthingy = ...
lib.someOtherDependency.lib.old.thingy#oldthingy = ...
```

This would also keep `#oldthingy` alive / prevent an upgrade to `#newthingy` in the exact same way.

So, the solution implemented here is simply to pretty-print hashes that are _directly_ referenced by the old dependency, i.e. things at the top level of `lib.old.*` (no matter what's in `lib.old.lib.*`), as `lib.new.*` (appropriately suffixified), no matter if there are any other aliases.