### PR TITLE
Add `move` command that moves existing namespaces,terms, and types

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveAll.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveAll.hs
@@ -1,0 +1,27 @@
+module Unison.Codebase.Editor.HandleInput.MoveAll (handleMoveAll) where
+
+import Unison.Cli.Monad (Cli)
+import Unison.Cli.Monad qualified as Cli
+import Unison.Cli.MonadUtils qualified as Cli
+import Unison.Codebase.Editor.Output qualified as Output
+import Unison.Codebase.Path qualified as Path
+import Unison.HashQualified' qualified as HQ'
+import Unison.Prelude
+import Unison.Codebase.Editor.HandleInput.MoveBranch (moveBranchFunc)
+import Unison.Codebase.Editor.HandleInput.MoveTerm (moveTermSteps)
+import Unison.Codebase.Editor.HandleInput.MoveType (moveTypeSteps)
+
+handleMoveAll :: Bool -> Path.Path' -> Path.Path' -> Text -> Cli ()
+handleMoveAll hasConfirmed src' dest' description = do
+  moveBranchFunc <- moveBranchFunc hasConfirmed src' dest'
+  moveTermTypeSteps <- case (,) <$> Path.toSplit' src' <*> Path.toSplit' dest' of
+    Nothing -> pure []
+    Just (fmap HQ'.NameOnly -> src, dest) -> do
+      termSteps <- moveTermSteps src dest
+      typeSteps <- moveTypeSteps src dest
+      pure (termSteps ++ typeSteps)
+  case (moveBranchFunc, moveTermTypeSteps) of
+    (Nothing, []) -> Cli.respond (Output.MoveNothingFound src')
+    (mupdates, steps) -> do
+      Cli.updateAndStepAt description (maybeToList mupdates) steps
+      Cli.respond Output.Success

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveBranch.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveBranch.hs
@@ -1,33 +1,42 @@
-module Unison.Codebase.Editor.HandleInput.MoveBranch where
+module Unison.Codebase.Editor.HandleInput.MoveBranch (doMoveBranch, moveBranchFunc) where
 
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli
+import Unison.Codebase.Branch (Branch)
 import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Editor.Output (Output (..))
 import Unison.Codebase.Path qualified as Path
 import Unison.Prelude
 
--- | Moves a branch and its history from one location to another, and saves the new root
--- branch.
-doMoveBranch :: Text -> Bool -> Path.Path' -> Path.Path' -> Cli ()
-doMoveBranch actionDescription hasConfirmed src' dest' = do
+moveBranchFunc :: Bool -> Path.Path' -> Path.Path' -> Cli (Maybe (Path.Absolute, Branch IO -> Branch IO))
+moveBranchFunc hasConfirmed src' dest' = do
   srcAbs <- Cli.resolvePath' src'
   destAbs <- Cli.resolvePath' dest'
   destBranchExists <- Cli.branchExistsAtPath' dest'
   let isRootMove = (Path.isRoot srcAbs || Path.isRoot destAbs)
   when (isRootMove && not hasConfirmed) do
     Cli.returnEarly MoveRootBranchConfirmation
-  srcBranch <- Cli.expectBranchAtPath' src'
+  Cli.getMaybeBranchAt srcAbs >>= traverse \srcBranch -> do
+    -- We want the move to appear as a single step in the root namespace, but we need to make
+    -- surgical changes in both the root and the destination, so we make our modifications at the shared parent of
+    -- those changes such that they appear as a single change in the root.
+    let (changeRootPath, srcLoc, destLoc) = Path.longestPathPrefix (Path.unabsolute srcAbs) (Path.unabsolute destAbs)
+    let doMove changeRoot = 
+          changeRoot
+          & Branch.modifyAt srcLoc (const Branch.empty)
+          & Branch.modifyAt destLoc (const srcBranch)
+    if (destBranchExists && not isRootMove)
+      then Cli.respond (MovedOverExistingBranch dest')
+      else pure ()
+    pure (Path.Absolute changeRootPath, doMove)
 
-  -- We want the move to appear as a single step in the root namespace, but we need to make
-  -- surgical changes in both the root and the destination, so we make our modifications at the shared parent of
-  -- those changes such that they appear as a single change in the root.
-  let (changeRootPath, srcLoc, destLoc) = Path.longestPathPrefix (Path.unabsolute srcAbs) (Path.unabsolute destAbs)
-  Cli.updateAt actionDescription (Path.Absolute changeRootPath) \changeRoot ->
-    changeRoot
-      & Branch.modifyAt srcLoc (const Branch.empty)
-      & Branch.modifyAt destLoc (const srcBranch)
-  if (destBranchExists && not isRootMove)
-    then Cli.respond (MovedOverExistingBranch dest')
-    else Cli.respond Success
+-- | Moves a branch and its history from one location to another, and saves the new root
+-- branch.
+doMoveBranch :: Text -> Bool -> Path.Path' -> Path.Path' -> Cli ()
+doMoveBranch actionDescription hasConfirmed src' dest' = do
+  moveBranchFunc hasConfirmed src' dest' >>= \case
+    Nothing -> Cli.respond (BranchNotFound src')
+    Just (path, func) -> do
+      _ <- Cli.updateAt actionDescription path func
+      Cli.respond Success

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveTerm.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveTerm.hs
@@ -1,4 +1,4 @@
-module Unison.Codebase.Editor.HandleInput.MoveTerm (doMoveTerm) where
+module Unison.Codebase.Editor.HandleInput.MoveTerm (doMoveTerm, moveTermSteps) where
 
 import Control.Lens (over, _2)
 import Data.Set qualified as Set
@@ -6,38 +6,43 @@ import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli
 import Unison.Codebase qualified as Codebase
+import Unison.Codebase.Branch (Branch0)
 import Unison.Codebase.BranchUtil qualified as BranchUtil
 import Unison.Codebase.Editor.Output qualified as Output
-import Unison.Codebase.Path (Path')
+import Unison.Codebase.Path (Path, Path')
 import Unison.Codebase.Path qualified as Path
 import Unison.HashQualified' qualified as HQ'
 import Unison.NameSegment (NameSegment)
 import Unison.Prelude
-import Unison.Util.Set qualified as Set
+
+moveTermSteps :: (Path', HQ'.HQSegment) -> (Path', NameSegment) -> Cli [(Path, Branch0 m -> Branch0 m)]
+moveTermSteps src' dest' = do
+  src <- Cli.resolveSplit' src'
+  srcTerms <- Cli.getTermsAt src
+  case Set.toList srcTerms of
+    [] -> pure []
+    _:_:_ -> do
+      hqLength <- Cli.runTransaction Codebase.hashLength
+      Cli.returnEarly (Output.DeleteNameAmbiguous hqLength src' srcTerms Set.empty)
+    [srcTerm] -> do
+      dest <- Cli.resolveSplit' dest'
+      destTerms <- Cli.getTermsAt (Path.convert dest)
+      when (not (Set.null destTerms)) do
+        Cli.returnEarly (Output.TermAlreadyExists dest' destTerms)
+      let p = Path.convert src
+      srcMetadata <- do
+        root0 <- Cli.getRootBranch0
+        pure (BranchUtil.getTermMetadataAt p srcTerm root0)
+      pure
+        [ -- Mitchell: throwing away any hash-qualification here seems wrong!
+          BranchUtil.makeDeleteTermName (over _2 HQ'.toName p) srcTerm,
+          BranchUtil.makeAddTermName (Path.convert dest) srcTerm srcMetadata
+        ]
 
 doMoveTerm :: (Path', HQ'.HQSegment) -> (Path', NameSegment) -> Text -> Cli ()
 doMoveTerm src' dest' description = do
-  src <- Cli.resolveSplit' src'
-  srcTerms <- Cli.getTermsAt src
-  srcTerm <-
-    Set.asSingleton srcTerms & onNothing do
-      if Set.null srcTerms
-        then Cli.returnEarly (Output.TermNotFound src')
-        else do
-          hqLength <- Cli.runTransaction Codebase.hashLength
-          Cli.returnEarly (Output.DeleteNameAmbiguous hqLength src' srcTerms Set.empty)
-  dest <- Cli.resolveSplit' dest'
-  destTerms <- Cli.getTermsAt (Path.convert dest)
-  when (not (Set.null destTerms)) do
-    Cli.returnEarly (Output.TermAlreadyExists dest' destTerms)
-  let p = Path.convert src
-  srcMetadata <- do
-    root0 <- Cli.getRootBranch0
-    pure (BranchUtil.getTermMetadataAt p srcTerm root0)
-  Cli.stepManyAt
-    description
-    [ -- Mitchell: throwing away any hash-qualification here seems wrong!
-      BranchUtil.makeDeleteTermName (over _2 HQ'.toName p) srcTerm,
-      BranchUtil.makeAddTermName (Path.convert dest) srcTerm srcMetadata
-    ]
+  steps <- moveTermSteps src' dest'
+  when (null steps) do
+    Cli.returnEarly (Output.TermNotFound src')
+  Cli.stepManyAt description steps
   Cli.respond Output.Success

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveTerm.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveTerm.hs
@@ -1,0 +1,43 @@
+module Unison.Codebase.Editor.HandleInput.MoveTerm (doMoveTerm) where
+
+import Control.Lens (over, _2)
+import Data.Set qualified as Set
+import Unison.Cli.Monad (Cli)
+import Unison.Cli.Monad qualified as Cli
+import Unison.Cli.MonadUtils qualified as Cli
+import Unison.Codebase qualified as Codebase
+import Unison.Codebase.BranchUtil qualified as BranchUtil
+import Unison.Codebase.Editor.Output qualified as Output
+import Unison.Codebase.Path (Path')
+import Unison.Codebase.Path qualified as Path
+import Unison.HashQualified' qualified as HQ'
+import Unison.NameSegment (NameSegment)
+import Unison.Prelude
+import Unison.Util.Set qualified as Set
+
+doMoveTerm :: (Path', HQ'.HQSegment) -> (Path', NameSegment) -> Text -> Cli ()
+doMoveTerm src' dest' description = do
+  src <- Cli.resolveSplit' src'
+  srcTerms <- Cli.getTermsAt src
+  srcTerm <-
+    Set.asSingleton srcTerms & onNothing do
+      if Set.null srcTerms
+        then Cli.returnEarly (Output.TermNotFound src')
+        else do
+          hqLength <- Cli.runTransaction Codebase.hashLength
+          Cli.returnEarly (Output.DeleteNameAmbiguous hqLength src' srcTerms Set.empty)
+  dest <- Cli.resolveSplit' dest'
+  destTerms <- Cli.getTermsAt (Path.convert dest)
+  when (not (Set.null destTerms)) do
+    Cli.returnEarly (Output.TermAlreadyExists dest' destTerms)
+  let p = Path.convert src
+  srcMetadata <- do
+    root0 <- Cli.getRootBranch0
+    pure (BranchUtil.getTermMetadataAt p srcTerm root0)
+  Cli.stepManyAt
+    description
+    [ -- Mitchell: throwing away any hash-qualification here seems wrong!
+      BranchUtil.makeDeleteTermName (over _2 HQ'.toName p) srcTerm,
+      BranchUtil.makeAddTermName (Path.convert dest) srcTerm srcMetadata
+    ]
+  Cli.respond Output.Success

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveType.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveType.hs
@@ -1,0 +1,43 @@
+module Unison.Codebase.Editor.HandleInput.MoveType (doMoveType) where
+
+import Control.Lens (over, _2)
+import Data.Set qualified as Set
+import Unison.Cli.Monad (Cli)
+import Unison.Cli.Monad qualified as Cli
+import Unison.Cli.MonadUtils qualified as Cli
+import Unison.Codebase qualified as Codebase
+import Unison.Codebase.BranchUtil qualified as BranchUtil
+import Unison.Codebase.Editor.Output qualified as Output
+import Unison.Codebase.Path (Path')
+import Unison.Codebase.Path qualified as Path
+import Unison.HashQualified' qualified as HQ'
+import Unison.NameSegment (NameSegment)
+import Unison.Prelude
+import Unison.Util.Set qualified as Set
+
+doMoveType :: (Path', HQ'.HQSegment) -> (Path', NameSegment) -> Text -> Cli ()
+doMoveType src' dest' description = do
+  src <- Cli.resolveSplit' src'
+  srcTypes <- Cli.getTypesAt src
+  srcType <-
+    Set.asSingleton srcTypes & onNothing do
+      if Set.null srcTypes
+        then Cli.returnEarly (Output.TypeNotFound src')
+        else do
+          hqLength <- Cli.runTransaction Codebase.hashLength
+          Cli.returnEarly (Output.DeleteNameAmbiguous hqLength src' Set.empty srcTypes)
+  dest <- Cli.resolveSplit' dest'
+  destTypes <- Cli.getTypesAt (Path.convert dest)
+  when (not (Set.null destTypes)) do
+    Cli.returnEarly (Output.TypeAlreadyExists dest' destTypes)
+  let p = Path.convert src
+  srcMetadata <- do
+    root0 <- Cli.getRootBranch0
+    pure (BranchUtil.getTypeMetadataAt p srcType root0)
+  Cli.stepManyAt
+    description
+    [ -- Mitchell: throwing away any hash-qualification here seems wrong!
+      BranchUtil.makeDeleteTypeName (over _2 HQ'.toName p) srcType,
+      BranchUtil.makeAddTypeName (Path.convert dest) srcType srcMetadata
+    ]
+  Cli.respond Output.Success

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveType.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/MoveType.hs
@@ -1,4 +1,4 @@
-module Unison.Codebase.Editor.HandleInput.MoveType (doMoveType) where
+module Unison.Codebase.Editor.HandleInput.MoveType (doMoveType, moveTypeSteps) where
 
 import Control.Lens (over, _2)
 import Data.Set qualified as Set
@@ -6,38 +6,43 @@ import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli
 import Unison.Codebase qualified as Codebase
+import Unison.Codebase.Branch (Branch0)
 import Unison.Codebase.BranchUtil qualified as BranchUtil
 import Unison.Codebase.Editor.Output qualified as Output
-import Unison.Codebase.Path (Path')
+import Unison.Codebase.Path (Path, Path')
 import Unison.Codebase.Path qualified as Path
 import Unison.HashQualified' qualified as HQ'
 import Unison.NameSegment (NameSegment)
 import Unison.Prelude
-import Unison.Util.Set qualified as Set
+
+moveTypeSteps :: (Path', HQ'.HQSegment) -> (Path', NameSegment) -> Cli [(Path, Branch0 m -> Branch0 m)]
+moveTypeSteps src' dest' = do
+  src <- Cli.resolveSplit' src'
+  srcTypes <- Cli.getTypesAt src
+  case Set.toList srcTypes of
+    [] -> pure []
+    _:_:_ -> do
+      hqLength <- Cli.runTransaction Codebase.hashLength
+      Cli.returnEarly (Output.DeleteNameAmbiguous hqLength src' Set.empty srcTypes)
+    [srcType] -> do
+      dest <- Cli.resolveSplit' dest'
+      destTypes <- Cli.getTypesAt (Path.convert dest)
+      when (not (Set.null destTypes)) do
+        Cli.returnEarly (Output.TypeAlreadyExists dest' destTypes)
+      let p = Path.convert src
+      srcMetadata <- do
+        root0 <- Cli.getRootBranch0
+        pure (BranchUtil.getTypeMetadataAt p srcType root0)
+      pure
+        [ -- Mitchell: throwing away any hash-qualification here seems wrong!
+          BranchUtil.makeDeleteTypeName (over _2 HQ'.toName p) srcType,
+          BranchUtil.makeAddTypeName (Path.convert dest) srcType srcMetadata
+        ]
 
 doMoveType :: (Path', HQ'.HQSegment) -> (Path', NameSegment) -> Text -> Cli ()
 doMoveType src' dest' description = do
-  src <- Cli.resolveSplit' src'
-  srcTypes <- Cli.getTypesAt src
-  srcType <-
-    Set.asSingleton srcTypes & onNothing do
-      if Set.null srcTypes
-        then Cli.returnEarly (Output.TypeNotFound src')
-        else do
-          hqLength <- Cli.runTransaction Codebase.hashLength
-          Cli.returnEarly (Output.DeleteNameAmbiguous hqLength src' Set.empty srcTypes)
-  dest <- Cli.resolveSplit' dest'
-  destTypes <- Cli.getTypesAt (Path.convert dest)
-  when (not (Set.null destTypes)) do
-    Cli.returnEarly (Output.TypeAlreadyExists dest' destTypes)
-  let p = Path.convert src
-  srcMetadata <- do
-    root0 <- Cli.getRootBranch0
-    pure (BranchUtil.getTypeMetadataAt p srcType root0)
-  Cli.stepManyAt
-    description
-    [ -- Mitchell: throwing away any hash-qualification here seems wrong!
-      BranchUtil.makeDeleteTypeName (over _2 HQ'.toName p) srcType,
-      BranchUtil.makeAddTypeName (Path.convert dest) srcType srcMetadata
-    ]
+  steps <- moveTypeSteps src' dest'
+  when (null steps) do
+    Cli.returnEarly (Output.TypeNotFound src')
+  Cli.stepManyAt description steps
   Cli.respond Output.Success

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -131,6 +131,7 @@ data Input
   | AliasTermI HashOrHQSplit' Path.Split'
   | AliasTypeI HashOrHQSplit' Path.Split'
   | AliasManyI [Path.HQSplit] Path'
+  | MoveAllI Path.Path' Path.Path'
   | -- Move = Rename; It's an HQSplit' not an HQSplit', meaning the arg has to have a name.
     MoveTermI Path.HQSplit' Path.Split'
   | MoveTypeI Path.HQSplit' Path.Split'

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -195,6 +195,7 @@ data Output
   | PatchNotFound Path.Split'
   | TypeNotFound Path.HQSplit'
   | TermNotFound Path.HQSplit'
+  | MoveNothingFound Path'
   | TypeNotFound' ShortHash
   | TermNotFound' ShortHash
   | TypeTermMismatch (HQ.HashQualified Name) (HQ.HashQualified Name)
@@ -501,6 +502,7 @@ isFailure o = case o of
   TypeNotFound {} -> True
   TypeNotFound' {} -> True
   TermNotFound {} -> True
+  MoveNothingFound {} -> True
   TermNotFound' {} -> True
   TypeTermMismatch {} -> True
   SearchTermsNotFound ts -> not (null ts)

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -678,6 +678,27 @@ renameTerm =
               "`rename.term` takes two arguments, like `rename.term oldname newname`."
     )
 
+moveAll :: InputPattern
+moveAll =
+  InputPattern
+    "move"
+    []
+    I.Visible
+    [ (Required, namespaceOrDefinitionArg),
+      (Required, newNameArg)
+    ]
+    "`move foo bar` renames the term, type, and namespace foo to bar."
+    ( \case
+        [oldName, newName] -> first fromString $ do
+          src <- Path.parsePath' oldName
+          target <- Path.parsePath' newName
+          pure $ Input.MoveAllI src target
+        _ ->
+          Left . P.warnCallout $
+            P.wrap
+              "`move` takes two arguments, like `move oldname newname`."
+    )
+
 renameType :: InputPattern
 renameType =
   InputPattern
@@ -2923,6 +2944,7 @@ validInputs =
       renamePatch,
       renameTerm,
       renameType,
+      moveAll,
       replace,
       reset,
       resetRoot,

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -890,6 +890,8 @@ notifyUser dir = \case
     pure . P.warnCallout $ "I don't know about that term."
   TypeNotFound _ ->
     pure . P.warnCallout $ "I don't know about that type."
+  MoveNothingFound p ->
+    pure . P.warnCallout $ "There is no term, type, or namespace at " <> prettyPath' p <> "."
   TermAlreadyExists _ _ ->
     pure . P.warnCallout $ "A term by that name already exists."
   TypeAlreadyExists _ _ ->

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -52,6 +52,7 @@ library
       Unison.Codebase.Editor.HandleInput.DeleteBranch
       Unison.Codebase.Editor.HandleInput.DeleteProject
       Unison.Codebase.Editor.HandleInput.MetadataUtils
+      Unison.Codebase.Editor.HandleInput.MoveAll
       Unison.Codebase.Editor.HandleInput.MoveBranch
       Unison.Codebase.Editor.HandleInput.MoveTerm
       Unison.Codebase.Editor.HandleInput.MoveType

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -53,6 +53,8 @@ library
       Unison.Codebase.Editor.HandleInput.DeleteProject
       Unison.Codebase.Editor.HandleInput.MetadataUtils
       Unison.Codebase.Editor.HandleInput.MoveBranch
+      Unison.Codebase.Editor.HandleInput.MoveTerm
+      Unison.Codebase.Editor.HandleInput.MoveType
       Unison.Codebase.Editor.HandleInput.NamespaceDependencies
       Unison.Codebase.Editor.HandleInput.NamespaceDiffUtils
       Unison.Codebase.Editor.HandleInput.ProjectClone

--- a/unison-src/transcripts/move-all.md
+++ b/unison-src/transcripts/move-all.md
@@ -1,0 +1,69 @@
+# Tests for `move`
+
+```ucm:hide
+.> builtins.mergeio
+```
+
+## Happy Path - namespace, term, and type
+
+Create a term, type, and namespace with history
+
+```unison
+Foo = 2
+unique type Foo = Foo
+Foo.termInA = 1
+unique type Foo.T = T
+```
+
+```ucm
+.> add
+```
+
+```unison
+Foo.termInA = 2
+unique type Foo.T = T1 | T2
+```
+
+```ucm
+.> update
+```
+
+Should be able to move the term, type, and namespace, including its types, terms, and sub-namespaces.
+
+```ucm
+.> move Foo Bar
+.> ls
+.> ls Bar
+.> history Bar
+```
+
+## Happy Path - Just term
+
+```unison
+bonk = 5
+```
+
+```ucm
+.z> add
+.z> move bonk zonk
+.z> ls
+```
+
+## Happy Path - Just namespace
+
+```unison
+bonk.zonk = 5
+```
+
+```ucm
+.a> add
+.a> move bonk zonk
+.a> ls
+.a> view zonk.zonk
+```
+
+## Sad Path - No term, type, or namespace named src
+
+```ucm:error
+.> move doesntexist foo
+```

--- a/unison-src/transcripts/move-all.output.md
+++ b/unison-src/transcripts/move-all.output.md
@@ -1,0 +1,191 @@
+# Tests for `move`
+
+## Happy Path - namespace, term, and type
+
+Create a term, type, and namespace with history
+
+```unison
+Foo = 2
+unique type Foo = Foo
+Foo.termInA = 1
+unique type Foo.T = T
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      unique type Foo
+      unique type Foo.T
+      Foo         : Nat
+      Foo.termInA : Nat
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    unique type Foo
+    unique type Foo.T
+    Foo         : Nat
+    Foo.termInA : Nat
+
+```
+```unison
+Foo.termInA = 2
+unique type Foo.T = T1 | T2
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      unique type Foo.T
+      Foo.termInA : Nat
+        (also named Foo)
+
+```
+```ucm
+.> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+
+```
+Should be able to move the term, type, and namespace, including its types, terms, and sub-namespaces.
+
+```ucm
+.> move Foo Bar
+
+  Done.
+
+.> ls
+
+  1. Bar      (Nat)
+  2. Bar      (type)
+  3. Bar/     (4 terms, 1 type)
+  4. builtin/ (624 terms, 88 types)
+
+.> ls Bar
+
+  1. Foo     (Bar)
+  2. T       (type)
+  3. T/      (2 terms)
+  4. termInA (Nat)
+
+.> history Bar
+
+  Note: The most recent namespace hash is immediately below this
+        message.
+  
+  ⊙ 1. #o7vuviel4c
+  
+    + Adds / updates:
+    
+      T T.T1 T.T2 termInA
+    
+    - Deletes:
+    
+      T.T
+  
+  □ 2. #c5cggiaumo (start of history)
+
+```
+## Happy Path - Just term
+
+```unison
+bonk = 5
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bonk : Nat
+
+```
+```ucm
+  ☝️  The namespace .z is empty.
+
+.z> add
+
+  ⍟ I've added these definitions:
+  
+    bonk : Nat
+
+.z> move bonk zonk
+
+  Done.
+
+.z> ls
+
+  1. zonk (##Nat)
+
+```
+## Happy Path - Just namespace
+
+```unison
+bonk.zonk = 5
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bonk.zonk : Nat
+        (also named zonk)
+
+```
+```ucm
+  ☝️  The namespace .a is empty.
+
+.a> add
+
+  ⍟ I've added these definitions:
+  
+    bonk.zonk : Nat
+
+.a> move bonk zonk
+
+  Done.
+
+.a> ls
+
+  1. zonk/ (1 term)
+
+.a> view zonk.zonk
+
+  zonk.zonk : Nat
+  zonk.zonk = 5
+
+```
+## Sad Path - No term, type, or namespace named src
+
+```ucm
+.> move doesntexist foo
+
+  ⚠️
+  
+  There is no term, type, or namespace at doesntexist.
+
+```

--- a/unison-src/transcripts/move-all.output.md
+++ b/unison-src/transcripts/move-all.output.md
@@ -76,7 +76,7 @@ Should be able to move the term, type, and namespace, including its types, terms
   1. Bar      (Nat)
   2. Bar      (type)
   3. Bar/     (4 terms, 1 type)
-  4. builtin/ (624 terms, 88 types)
+  4. builtin/ (625 terms, 88 types)
 
 .> ls Bar
 

--- a/unison-src/transcripts/move-namespace.output.md
+++ b/unison-src/transcripts/move-namespace.output.md
@@ -249,6 +249,8 @@ b.termInB = 11
   
   Tip: You can use `undo` or `reflog` to undo this change.
 
+  Done.
+
 ```
 ## Moving the Root 
 


### PR DESCRIPTION
## Overview

Add `move` command which moves namespaces, terms, and types from src to dest.

fixes #3767 

## Implementation notes

Break existing move* code up a bit to be callable from the new move code.

## Test coverage

There is a new transcript named `move-all.md`.

## Loose ends

Moving the namespace and moving the term/type is done in two separate causal steps, where it would preferably be done in one. The central issue is that we want to move the namespace's history from src to dest (as [`modifyAtM`](https://github.com/unisonweb/unison/blob/cbc9d9a6e27d17fda326aca1b3acaec78ce63d5b/parser-typechecker/src/Unison/Codebase/Branch.hs#L594-L609) allows), but moving the term and type is accomplished with [`stepManyAt`](https://github.com/unisonweb/unison/blob/cbc9d9a6e27d17fda326aca1b3acaec78ce63d5b/parser-typechecker/src/Unison/Codebase/Branch.hs#L519-L526) which calls [`consBranchSnapshot`](https://github.com/unisonweb/unison/blob/cbc9d9a6e27d17fda326aca1b3acaec78ce63d5b/parser-typechecker/src/Unison/Codebase/Branch.hs#L744-L780) to manage causal stepping. `consBranchSnapshot` discards child history for namespaces that appear in the updated branch, but not the original branch.
