### PR TITLE
bugfix: make `upgrade` not require a latest-touched file (default to "scratch.u")

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Upgrade.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Upgrade.hs
@@ -150,7 +150,14 @@ handleUpgrade oldDepName newDepName = do
       let temporaryBranchPath = Path.unabsolute (Cli.projectBranchPath (ProjectAndBranch projectId temporaryBranchId))
       Cli.stepAt textualDescriptionOfUpgrade (temporaryBranchPath, \_ -> currentV1BranchWithoutOldDep)
       Cli.Env {isTranscript} <- ask
-      maybePath <- if isTranscript then pure Nothing else Just . fst <$> Cli.expectLatestFile
+      maybePath <-
+        if isTranscript
+          then pure Nothing
+          else do
+            maybeLatestFile <- Cli.getLatestFile
+            case maybeLatestFile of
+              Nothing -> pure (Just "scratch.u")
+              Just (file, _) -> pure (Just file)
       Cli.respond (Output.DisplayDefinitionsString maybePath prettyUnisonFile)
       Cli.respond (Output.UpgradeFailure oldDepName newDepName)
       Cli.returnEarlyWithoutOutput


### PR DESCRIPTION
## Overview

`upgrade` would previously accidentally require the user to have touched some `.u` file before running it, and if they hadn't, it would confusingly make a little progress (including creating a new project branch) before dumping a misleading error message (which is the fault of the output message of `NoUnisonFile` saying something surprising...)