### PR TITLE
Use minimal suffix that's distinct from local var names

### DIFF
--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -377,7 +377,7 @@ So we can see the pretty-printed output:
     fix_525_exampleTerm : Text -> Nat
     fix_525_exampleTerm quaffle =
       use Nat +
-      Fix_525.bar.quaffle + 1
+      bar.quaffle + 1
     
     fix_525_exampleType :
       Id qualifiedName -> Id Fully.qualifiedName
@@ -717,16 +717,13 @@ So we can see the pretty-printed output:
     use_clauses_example : Int -> Text -> Nat
     use_clauses_example oo quaffle =
       use Nat +
-      Fix_525.bar.quaffle + Fix_525.bar.quaffle + 1
+      bar.quaffle + bar.quaffle + 1
     
     use_clauses_example2 : Int -> Nat
     use_clauses_example2 oo =
       use Nat +
       quaffle = "hi"
-      Fix_525.bar.quaffle
-        + Fix_525.bar.quaffle
-        + Fix_525.bar.quaffle
-        + 1
+      bar.quaffle + bar.quaffle + bar.quaffle + 1
     
     UUID.random : 'UUID
     UUID.random = do UUID 0 (0, 0)


### PR DESCRIPTION
## Overview

Fixes: #4480 

When disambiguating suffixified names against local variables, rather than just using the FQN we find the smallest viable suffix. This should JustWork™ on Share too.

## Implementation notes

Starting with the suffixified name, keep adding segments until we find a name that doesn't conflict with anything locally defined. 99.9% of the time this'll just be a single segment, but it'll fall back all the way to the FQN if necessary.

## Interesting/controversial decisions

Nah

## Test coverage

See the updates to the regression test for proof :) 
