### PR TITLE
Unison Local - Search for docs by exact name, not suffix

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/MainTerm.hs
+++ b/parser-typechecker/src/Unison/Codebase/MainTerm.hs
@@ -39,7 +39,7 @@ getMainTerm loadTypeOfTerm parseNames mainName mainType =
   case HQ.fromString mainName of
     Nothing -> pure (NotAFunctionName mainName)
     Just hq -> do
-      let refs = NamesWithHistory.lookupHQTerm hq (NamesWithHistory.NamesWithHistory parseNames mempty)
+      let refs = NamesWithHistory.lookupHQTerm NamesWithHistory.IncludeSuffixes hq (NamesWithHistory.NamesWithHistory parseNames mempty)
       let a = Parser.Ann.External
       case toList refs of
         [] -> pure (NotFound mainName)

--- a/parser-typechecker/src/Unison/Syntax/TypeParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/TypeParser.hs
@@ -41,7 +41,7 @@ typeAtom =
     HQ.NameOnly n -> pure $ Type.var (ann tok) (Name.toVar n)
     hq -> do
       names <- asks names
-      let matches = Names.lookupHQType hq names
+      let matches = Names.lookupHQType Names.IncludeSuffixes hq names
       if Set.size matches /= 1
         then P.customFailure (UnknownType tok matches)
         else pure $ Type.ref (ann tok) (Set.findMin matches)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -560,7 +560,7 @@ loop e = do
               let nameSearch = NameSearch.makeNameSearch hqLength (NamesWithHistory.fromCurrentNames basicPrettyPrintNames)
               Cli.Env {codebase, runtime} <- ask
               mdText <- liftIO $ do
-                docRefs <- Backend.docsForDefinitionName codebase nameSearch docName
+                docRefs <- Backend.docsForDefinitionName codebase nameSearch NamesWithHistory.ExactName docName
                 for docRefs $ \docRef -> do
                   Identity (_, _, doc) <- Backend.renderDocRefs pped (Pretty.Width 80) codebase runtime (Identity docRef)
                   pure . Md.toText $ Md.toMarkdown doc
@@ -937,7 +937,7 @@ loop e = do
               let patchPath' = fromMaybe Cli.defaultPatchPath patchPath
               patch <- Cli.getPatchAt patchPath'
               QueryResult fromMisses' fromHits <- hqNameQuery NamesWithHistory.IncludeSuffixes [from]
-              QueryResult toMisses' toHits <- hqNameQuery NamesWithHistory.IncludeSuffixes [to] 
+              QueryResult toMisses' toHits <- hqNameQuery NamesWithHistory.IncludeSuffixes [to]
               let termsFromRefs = termReferences fromHits
                   termsToRefs = termReferences toHits
                   typesFromRefs = typeReferences fromHits

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -560,7 +560,7 @@ loop e = do
               let nameSearch = NameSearch.makeNameSearch hqLength (NamesWithHistory.fromCurrentNames basicPrettyPrintNames)
               Cli.Env {codebase, runtime} <- ask
               mdText <- liftIO $ do
-                docRefs <- Backend.docsForDefinitionName codebase nameSearch NamesWithHistory.ExactName docName
+                docRefs <- Backend.docsForDefinitionName codebase nameSearch NamesWithHistory.IncludeSuffixes docName
                 for docRefs $ \docRef -> do
                   Identity (_, _, doc) <- Backend.renderDocRefs pped (Pretty.Width 80) codebase runtime (Identity docRef)
                   pure . Md.toText $ Md.toMarkdown doc

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/TermResolution.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/TermResolution.hs
@@ -25,6 +25,7 @@ import Unison.Name (Name)
 import Unison.Names (Names)
 import Unison.NamesWithHistory
   ( NamesWithHistory (..),
+    SearchType (..),
     lookupHQTerm,
   )
 import Unison.Parser.Ann (Ann)
@@ -41,7 +42,7 @@ addHistory :: Names -> NamesWithHistory
 addHistory names = NamesWithHistory names mempty
 
 lookupTerm :: HQ.HashQualified Name -> Names -> [Referent]
-lookupTerm hq parseNames = toList (lookupHQTerm hq hnames)
+lookupTerm hq parseNames = toList (lookupHQTerm IncludeSuffixes hq hnames)
   where
     hnames = addHistory parseNames
 

--- a/unison-cli/src/Unison/LSP/Queries.hs
+++ b/unison-cli/src/Unison/LSP/Queries.hs
@@ -37,6 +37,7 @@ import Unison.LabeledDependency
 import Unison.LabeledDependency qualified as LD
 import Unison.Lexer.Pos (Pos (..))
 import Unison.Name (Name)
+import Unison.NamesWithHistory (SearchType (..))
 import Unison.Parser.Ann (Ann)
 import Unison.Parser.Ann qualified as Ann
 import Unison.Pattern qualified as Pattern
@@ -386,7 +387,7 @@ markdownDocsForFQN fileUri fqn =
     nameSearch <- lift $ getNameSearch
     Env {codebase, runtime} <- ask
     liftIO $ do
-      docRefs <- Backend.docsForDefinitionName codebase nameSearch name
+      docRefs <- Backend.docsForDefinitionName codebase nameSearch ExactName name
       for docRefs $ \docRef -> do
         Identity (_, _, doc) <- Backend.renderDocRefs pped (Pretty.Width 80) codebase runtime (Identity docRef)
         pure . Md.toText $ Md.toMarkdown doc

--- a/unison-core/src/Unison/NamesWithHistory.hs
+++ b/unison-core/src/Unison/NamesWithHistory.hs
@@ -241,7 +241,7 @@ lookupHQRef searchType which isPrefixOf hq NamesWithHistory {currentNames, oldNa
           Set.filter (isPrefixOf sh) (R.ran ns)
   where
     doSearch = case searchType of
-      IncludeSuffixes -> Name.searchBySuffix
+      IncludeSuffixes -> Name.searchByRankedSuffix
       ExactName -> Relation.lookupDom
     currentRefs = which currentNames
     oldRefs = which oldNames

--- a/unison-core/src/Unison/NamesWithHistory.hs
+++ b/unison-core/src/Unison/NamesWithHistory.hs
@@ -1,6 +1,32 @@
 {-# LANGUAGE RecordWildCards #-}
 
-module Unison.NamesWithHistory where
+module Unison.NamesWithHistory
+  ( NamesWithHistory (..),
+    fromCurrentNames,
+    filterTypes,
+    diff,
+    push,
+    shadowing,
+    lookupHQType,
+    lookupHQType',
+    lookupHQTerm,
+    lookupHQTerm',
+    lookupRelativeHQType,
+    lookupRelativeHQType',
+    lookupRelativeHQTerm,
+    lookupRelativeHQTerm',
+    hasTermNamed,
+    hasTypeNamed,
+    typeName,
+    termNamesByLength,
+    longestTermName,
+    termName,
+    importing,
+    lookupHQPattern,
+    Diff (..),
+    SearchType (..),
+  )
+where
 
 import Data.List.Extra (nubOrd)
 import Data.Map qualified as Map
@@ -21,6 +47,13 @@ import Unison.ShortHash (ShortHash)
 import Unison.Util.List qualified as List
 import Unison.Util.Relation (Relation)
 import Unison.Util.Relation qualified as R
+import Unison.Util.Relation qualified as Relation
+
+-- | Whether to search for exact matches or to find definitions by a suffix of their name.
+data SearchType
+  = IncludeSuffixes
+  | ExactName
+  deriving (Eq, Ord, Show)
 
 -- | NamesWithHistory contains two sets of 'Names',
 -- One represents names which are currently assigned,
@@ -120,63 +153,63 @@ shadowing prio (NamesWithHistory current old) =
 -- Find all types whose name has a suffix matching the provided `HashQualified`,
 -- returning types with relative names if they exist, and otherwise
 -- returning types with absolute names.
-lookupRelativeHQType :: HashQualified Name -> NamesWithHistory -> Set Reference
-lookupRelativeHQType hq ns@NamesWithHistory {..} =
-  let rs = lookupHQType hq ns
+lookupRelativeHQType :: SearchType -> HashQualified Name -> NamesWithHistory -> Set Reference
+lookupRelativeHQType searchType hq ns@NamesWithHistory {..} =
+  let rs = lookupHQType searchType hq ns
       keep r = any (not . Name.isAbsolute) (R.lookupRan r (Names.types currentNames))
    in case Set.filter keep rs of
         rs'
           | Set.null rs' -> rs
           | otherwise -> rs'
 
-lookupRelativeHQType' :: HQ'.HashQualified Name -> NamesWithHistory -> Set Reference
-lookupRelativeHQType' =
-  lookupRelativeHQType . HQ'.toHQ
+lookupRelativeHQType' :: SearchType -> HQ'.HashQualified Name -> NamesWithHistory -> Set Reference
+lookupRelativeHQType' searchType =
+  lookupRelativeHQType searchType . HQ'.toHQ
 
 -- | Find all types whose name has a suffix matching the provided 'HashQualified'.
-lookupHQType :: HashQualified Name -> NamesWithHistory -> Set Reference
-lookupHQType =
-  lookupHQRef Names.types Reference.isPrefixOf
+lookupHQType :: SearchType -> HashQualified Name -> NamesWithHistory -> Set Reference
+lookupHQType searchType =
+  lookupHQRef searchType Names.types Reference.isPrefixOf
 
 -- | Find all types whose name has a suffix matching the provided 'HashQualified''. See 'lookupHQType'.
-lookupHQType' :: HQ'.HashQualified Name -> NamesWithHistory -> Set Reference
-lookupHQType' =
-  lookupHQType . HQ'.toHQ
+lookupHQType' :: SearchType -> HQ'.HashQualified Name -> NamesWithHistory -> Set Reference
+lookupHQType' searchType =
+  lookupHQType searchType . HQ'.toHQ
 
-hasTermNamed :: Name -> NamesWithHistory -> Bool
-hasTermNamed n ns = not (Set.null $ lookupHQTerm (HQ.NameOnly n) ns)
+hasTermNamed :: SearchType -> Name -> NamesWithHistory -> Bool
+hasTermNamed searchType n ns = not (Set.null $ lookupHQTerm searchType (HQ.NameOnly n) ns)
 
-hasTypeNamed :: Name -> NamesWithHistory -> Bool
-hasTypeNamed n ns = not (Set.null $ lookupHQType (HQ.NameOnly n) ns)
+hasTypeNamed :: SearchType -> Name -> NamesWithHistory -> Bool
+hasTypeNamed searchType n ns = not (Set.null $ lookupHQType searchType (HQ.NameOnly n) ns)
 
 -- Find all terms whose name has a suffix matching the provided `HashQualified`,
 -- returning terms with relative names if they exist, and otherwise
 -- returning terms with absolute names.
-lookupRelativeHQTerm :: HashQualified Name -> NamesWithHistory -> Set Referent
-lookupRelativeHQTerm hq ns@NamesWithHistory {..} =
-  let rs = lookupHQTerm hq ns
+lookupRelativeHQTerm :: SearchType -> HashQualified Name -> NamesWithHistory -> Set Referent
+lookupRelativeHQTerm searchType hq ns@NamesWithHistory {..} =
+  let rs = lookupHQTerm searchType hq ns
       keep r = any (not . Name.isAbsolute) (R.lookupRan r (Names.terms currentNames))
    in case Set.filter keep rs of
         rs'
           | Set.null rs' -> rs
           | otherwise -> rs'
 
-lookupRelativeHQTerm' :: HQ'.HashQualified Name -> NamesWithHistory -> Set Referent
-lookupRelativeHQTerm' =
-  lookupRelativeHQTerm . HQ'.toHQ
+lookupRelativeHQTerm' :: SearchType -> HQ'.HashQualified Name -> NamesWithHistory -> Set Referent
+lookupRelativeHQTerm' searchType =
+  lookupRelativeHQTerm searchType . HQ'.toHQ
 
 -- | Find all terms whose name has a suffix matching the provided 'HashQualified'.
 --
 -- If the hash-qualified name does not include a hash, then only current names are searched. Otherwise, old names are
 -- searched, too, if searching current names produces no hits.
-lookupHQTerm :: HashQualified Name -> NamesWithHistory -> Set Referent
-lookupHQTerm =
-  lookupHQRef Names.terms Referent.isPrefixOf
+lookupHQTerm :: SearchType -> HashQualified Name -> NamesWithHistory -> Set Referent
+lookupHQTerm searchType =
+  lookupHQRef searchType Names.terms Referent.isPrefixOf
 
 -- | Find all terms whose name has a suffix matching the provided 'HashQualified''. See 'lookupHQTerm'.
-lookupHQTerm' :: HQ'.HashQualified Name -> NamesWithHistory -> Set Referent
-lookupHQTerm' =
-  lookupHQTerm . HQ'.toHQ
+lookupHQTerm' :: SearchType -> HQ'.HashQualified Name -> NamesWithHistory -> Set Referent
+lookupHQTerm' searchType =
+  lookupHQTerm searchType . HQ'.toHQ
 
 -- Helper that unifies looking up a set of references/referents by a hash-qualified suffix.
 --
@@ -184,6 +217,7 @@ lookupHQTerm' =
 lookupHQRef ::
   forall r.
   (Ord r) =>
+  SearchType ->
   -- | A projection of types or terms from a Names.
   (Names -> Relation Name r) ->
   -- | isPrefixOf, for references or referents
@@ -192,20 +226,23 @@ lookupHQRef ::
   HashQualified Name ->
   NamesWithHistory ->
   Set r
-lookupHQRef which isPrefixOf hq NamesWithHistory {currentNames, oldNames} =
+lookupHQRef searchType which isPrefixOf hq NamesWithHistory {currentNames, oldNames} =
   case hq of
-    HQ.NameOnly n -> Name.searchByRankedSuffix n currentRefs
+    HQ.NameOnly n -> doSearch n currentRefs
     HQ.HashQualified n sh -> matches currentRefs `orIfEmpty` matches oldRefs
       where
         matches :: Relation Name r -> Set r
         matches ns =
-          Set.filter (isPrefixOf sh) (Name.searchByRankedSuffix n ns)
+          Set.filter (isPrefixOf sh) (doSearch n ns)
     HQ.HashOnly sh -> matches currentRefs `orIfEmpty` matches oldRefs
       where
         matches :: Relation Name r -> Set r
         matches ns =
           Set.filter (isPrefixOf sh) (R.ran ns)
   where
+    doSearch = case searchType of
+      IncludeSuffixes -> Name.searchBySuffix
+      ExactName -> Relation.lookupDom
     currentRefs = which currentNames
     oldRefs = which oldNames
 
@@ -261,14 +298,15 @@ termName length r NamesWithHistory {..} =
 -- Set HashQualified -> Branch m -> Command m i v Names
 -- populate historical names
 lookupHQPattern ::
+  SearchType ->
   HQ.HashQualified Name ->
   CT.ConstructorType ->
   NamesWithHistory ->
   Set ConstructorReference
-lookupHQPattern hq ctt names =
+lookupHQPattern searchType hq ctt names =
   Set.fromList
     [ r
-      | Referent.Con r ct <- toList $ lookupHQTerm hq names,
+      | Referent.Con r ct <- toList $ lookupHQTerm searchType hq names,
         ct == ctt
     ]
 

--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -161,14 +161,14 @@ bindNames unsafeVarToName keepFreeTerms ns0 e = do
       -- !_ = trace "bindNames.free type vars: " ()
       -- !_ = traceShow $ fst <$> freeTyVars
       okTm :: (v, a) -> Names.ResolutionResult v a (v, Term v a)
-      okTm (v, a) = case Names.lookupHQTerm (Name.convert $ unsafeVarToName v) ns of
+      okTm (v, a) = case Names.lookupHQTerm Names.IncludeSuffixes (Name.convert $ unsafeVarToName v) ns of
         rs
           | Set.size rs == 1 ->
               pure (v, fromReferent a $ Set.findMin rs)
           | otherwise -> case NES.nonEmptySet rs of
               Nothing -> Left (pure (Names.TermResolutionFailure v a Names.NotFound))
               Just refs -> Left (pure (Names.TermResolutionFailure v a (Names.Ambiguous ns0 refs)))
-      okTy (v, a) = case Names.lookupHQType (Name.convert $ unsafeVarToName v) ns of
+      okTy (v, a) = case Names.lookupHQType Names.IncludeSuffixes (Name.convert $ unsafeVarToName v) ns of
         rs
           | Set.size rs == 1 -> pure (v, Type.ref a $ Set.findMin rs)
           | otherwise -> case NES.nonEmptySet rs of

--- a/unison-core/src/Unison/Type/Names.hs
+++ b/unison-core/src/Unison/Type/Names.hs
@@ -22,7 +22,7 @@ bindNames ::
 bindNames unsafeVarToName keepFree ns0 t =
   let ns = Names.NamesWithHistory ns0 mempty
       fvs = ABT.freeVarOccurrences keepFree t
-      rs = [(v, a, Names.lookupHQType (Name.convert $ unsafeVarToName v) ns) | (v, a) <- fvs]
+      rs = [(v, a, Names.lookupHQType Names.IncludeSuffixes (Name.convert $ unsafeVarToName v) ns) | (v, a) <- fvs]
       ok (v, a, rs) =
         if Set.size rs == 1
           then pure (v, Set.findMin rs)

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -27,7 +27,7 @@ module Unison.Server.Backend
     basicSuffixifiedNames,
     bestNameForTerm,
     bestNameForType,
-    definitionsBySuffixes,
+    definitionsByName,
     displayType,
     docsInBranchToHtmlFiles,
     expandShortCausalHash,
@@ -756,9 +756,10 @@ fixupNamesRelative root names =
 hqNameQuery ::
   Codebase m v Ann ->
   NameSearch Sqlite.Transaction ->
+  NamesWithHistory.SearchType ->
   [HQ.HashQualified Name] ->
   Sqlite.Transaction QueryResult
-hqNameQuery codebase NameSearch {typeSearch, termSearch} hqs = do
+hqNameQuery codebase NameSearch {typeSearch, termSearch} searchType hqs = do
   -- Split the query into hash-only and hash-qualified-name queries.
   let (hashes, hqnames) = partitionEithers (map HQ'.fromHQ2 hqs)
   -- Find the terms with those hashes.
@@ -783,7 +784,7 @@ hqNameQuery codebase NameSearch {typeSearch, termSearch} hqs = do
         (\(sh, tps) -> mkTypeResult sh <$> toList tps) <$> typeRefs
 
   -- Now do the actual name query
-  resultss <- for hqnames (\name -> liftA2 (<>) (applySearch typeSearch name) (applySearch termSearch name))
+  resultss <- for hqnames (\name -> liftA2 (<>) (applySearch typeSearch searchType name) (applySearch termSearch searchType name))
   let (misses, hits) =
         zipWith
           ( \hqname results ->
@@ -1002,8 +1003,7 @@ docsForDefinitionName codebase (NameSearch {termSearch}) name = do
   Codebase.runTransaction codebase do
     refs <-
       potentialDocNames & foldMapM \name ->
-        -- TODO: Should replace this with an exact name lookup.
-        lookupRelativeHQRefs' termSearch (HQ'.NameOnly name)
+        lookupRelativeHQRefs' termSearch NamesWithHistory.ExactName (HQ'.NameOnly name)
     filterForDocs (toList refs)
   where
     filterForDocs :: [Referent] -> Sqlite.Transaction [TermReference]
@@ -1229,14 +1229,15 @@ data IncludeCycles
   = IncludeCycles
   | DontIncludeCycles
 
-definitionsBySuffixes ::
+definitionsByName ::
   Codebase m Symbol Ann ->
   NameSearch Sqlite.Transaction ->
   IncludeCycles ->
+  NamesWithHistory.SearchType ->
   [HQ.HashQualified Name] ->
   Sqlite.Transaction DefinitionResults
-definitionsBySuffixes codebase nameSearch includeCycles query = do
-  QueryResult misses results <- hqNameQuery codebase nameSearch query
+definitionsByName codebase nameSearch includeCycles searchType query = do
+  QueryResult misses results <- hqNameQuery codebase nameSearch searchType query
   -- todo: remember to replace this with getting components directly,
   -- and maybe even remove getComponentLength from Codebase interface altogether
   terms <- Map.foldMapM (\ref -> (ref,) <$> displayTerm codebase ref) (searchResultsToTermRefs results)

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -996,14 +996,15 @@ evalDocRef rt codebase r = do
 docsForDefinitionName ::
   Codebase IO Symbol Ann ->
   NameSearch Sqlite.Transaction ->
+  NamesWithHistory.SearchType ->
   Name ->
   IO [TermReference]
-docsForDefinitionName codebase (NameSearch {termSearch}) name = do
+docsForDefinitionName codebase (NameSearch {termSearch}) searchType name = do
   let potentialDocNames = [name, name Cons.:> "doc"]
   Codebase.runTransaction codebase do
     refs <-
       potentialDocNames & foldMapM \name ->
-        lookupRelativeHQRefs' termSearch NamesWithHistory.ExactName (HQ'.NameOnly name)
+        lookupRelativeHQRefs' termSearch searchType (HQ'.NameOnly name)
     filterForDocs (toList refs)
   where
     filterForDocs :: [Referent] -> Sqlite.Transaction [TermReference]

--- a/unison-share-api/src/Unison/Server/Local/Definitions.hs
+++ b/unison-share-api/src/Unison/Server/Local/Definitions.hs
@@ -66,7 +66,7 @@ prettyDefinitionsForHQName perspective shallowRoot renderWidth suffixifyBindings
   let pped = PPED.biasTo biases unbiasedPPED
   let nameSearch = makeNameSearch hqLength (NamesWithHistory.fromCurrentNames localNamesOnly)
   (DefinitionResults terms types misses) <- liftIO $ Codebase.runTransaction codebase do
-    definitionsBySuffixes codebase nameSearch DontIncludeCycles [query]
+    definitionsByName codebase nameSearch DontIncludeCycles NamesWithHistory.ExactName [query]
   let width = mayDefaultWidth renderWidth
   let docResults :: Name -> IO [(HashQualifiedName, UnisonHash, Doc.Doc)]
       docResults name = do

--- a/unison-share-api/src/Unison/Server/Local/Definitions.hs
+++ b/unison-share-api/src/Unison/Server/Local/Definitions.hs
@@ -70,7 +70,7 @@ prettyDefinitionsForHQName perspective shallowRoot renderWidth suffixifyBindings
   let width = mayDefaultWidth renderWidth
   let docResults :: Name -> IO [(HashQualifiedName, UnisonHash, Doc.Doc)]
       docResults name = do
-        docRefs <- docsForDefinitionName codebase nameSearch name
+        docRefs <- docsForDefinitionName codebase nameSearch NamesWithHistory.ExactName name
         renderDocRefs pped width codebase rt docRefs
 
   let fqnPPE = PPED.unsuffixifiedPPE pped

--- a/unison-share-api/src/Unison/Server/NameSearch.hs
+++ b/unison-share-api/src/Unison/Server/NameSearch.hs
@@ -6,6 +6,7 @@ import Data.Set qualified as Set
 import Unison.HashQualified qualified as HQ
 import Unison.HashQualified' qualified as HQ'
 import Unison.Name (Name)
+import Unison.NamesWithHistory (SearchType)
 import Unison.Prelude
 import Unison.Reference (Reference)
 import Unison.Referent (Referent)
@@ -21,7 +22,7 @@ import Unison.Server.SearchResult qualified as SR
 -- You can use the individual methods of a name search or can use 'applySearch'.
 data Search m r = Search
   { lookupNames :: r -> m (Set (HQ'.HashQualified Name)),
-    lookupRelativeHQRefs' :: HQ'.HashQualified Name -> m (Set r),
+    lookupRelativeHQRefs' :: SearchType -> HQ'.HashQualified Name -> m (Set r),
     makeResult :: HQ.HashQualified Name -> r -> Set (HQ'.HashQualified Name) -> m SR.SearchResult,
     matchesNamedRef :: Name -> r -> HQ'.HashQualified Name -> Bool
   }
@@ -32,9 +33,9 @@ data NameSearch m = NameSearch
   }
 
 -- | Interpret a 'Search' as a function from name to search results.
-applySearch :: (Show r, Monad m) => Search m r -> HQ'.HashQualified Name -> m [SR.SearchResult]
-applySearch Search {lookupNames, lookupRelativeHQRefs', makeResult, matchesNamedRef} query = do
-  refs <- (lookupRelativeHQRefs' query)
+applySearch :: (Show r, Monad m) => Search m r -> SearchType -> HQ'.HashQualified Name -> m [SR.SearchResult]
+applySearch Search {lookupNames, lookupRelativeHQRefs', makeResult, matchesNamedRef} searchType query = do
+  refs <- (lookupRelativeHQRefs' searchType query)
   -- a bunch of references will match a HQ ref.
   for (toList refs) \ref -> do
     let -- Precondition: the input set is non-empty

--- a/unison-share-api/src/Unison/Server/NameSearch/FromNames.hs
+++ b/unison-share-api/src/Unison/Server/NameSearch/FromNames.hs
@@ -13,7 +13,7 @@ makeTypeSearch :: (Applicative m) => Int -> NamesWithHistory -> Search m Referen
 makeTypeSearch len names =
   Search
     { lookupNames = \ref -> pure $ NamesWithHistory.typeName len ref names,
-      lookupRelativeHQRefs' = \n -> pure $ NamesWithHistory.lookupRelativeHQType' NamesWithHistory.ExactName n names,
+      lookupRelativeHQRefs' = \searchType n -> pure $ NamesWithHistory.lookupRelativeHQType' searchType n names,
       matchesNamedRef = HQ'.matchesNamedReference,
       makeResult = \hqname r names -> pure $ SR.typeResult hqname r names
     }
@@ -23,7 +23,7 @@ makeTermSearch :: (Applicative m) => Int -> NamesWithHistory -> Search m Referen
 makeTermSearch len names =
   Search
     { lookupNames = \ref -> pure $ NamesWithHistory.termName len ref names,
-      lookupRelativeHQRefs' = \n -> pure $ NamesWithHistory.lookupRelativeHQTerm' NamesWithHistory.ExactName n names,
+      lookupRelativeHQRefs' = \searchType n -> pure $ NamesWithHistory.lookupRelativeHQTerm' searchType n names,
       matchesNamedRef = HQ'.matchesNamedReferent,
       makeResult = \hqname r names -> pure $ SR.termResult hqname r names
     }

--- a/unison-share-api/src/Unison/Server/NameSearch/FromNames.hs
+++ b/unison-share-api/src/Unison/Server/NameSearch/FromNames.hs
@@ -13,7 +13,7 @@ makeTypeSearch :: (Applicative m) => Int -> NamesWithHistory -> Search m Referen
 makeTypeSearch len names =
   Search
     { lookupNames = \ref -> pure $ NamesWithHistory.typeName len ref names,
-      lookupRelativeHQRefs' = pure . (`NamesWithHistory.lookupRelativeHQType'` names),
+      lookupRelativeHQRefs' = \n -> pure $ NamesWithHistory.lookupRelativeHQType' NamesWithHistory.ExactName n names,
       matchesNamedRef = HQ'.matchesNamedReference,
       makeResult = \hqname r names -> pure $ SR.typeResult hqname r names
     }
@@ -23,7 +23,7 @@ makeTermSearch :: (Applicative m) => Int -> NamesWithHistory -> Search m Referen
 makeTermSearch len names =
   Search
     { lookupNames = \ref -> pure $ NamesWithHistory.termName len ref names,
-      lookupRelativeHQRefs' = pure . (`NamesWithHistory.lookupRelativeHQTerm'` names),
+      lookupRelativeHQRefs' = \n -> pure $ NamesWithHistory.lookupRelativeHQTerm' NamesWithHistory.ExactName n names,
       matchesNamedRef = HQ'.matchesNamedReferent,
       makeResult = \hqname r names -> pure $ SR.termResult hqname r names
     }

--- a/unison-src/transcripts/api-getDefinition.md
+++ b/unison-src/transcripts/api-getDefinition.md
@@ -14,7 +14,7 @@ nested.names.x = 42
 ```
 
 ```api
--- Should find names by suffix
+-- Should NOT find names by suffix
 GET /api/non-project-code/getDefinition?names=x
 
 -- Term names should strip relativeTo prefix.

--- a/unison-src/transcripts/api-getDefinition.output.md
+++ b/unison-src/transcripts/api-getDefinition.output.md
@@ -6,194 +6,22 @@ nested.names.x = 42
 ```
 
 ```api
---  Should find names by suffix
+--  Should NOT find names by suffix
 GET /api/non-project-code/getDefinition?names=x
 {
-    "missingDefinitions": [],
-    "termDefinitions": {
-        "#qkhkl0n238s1eqibd1ecb8605sqj1m4hpoaag177cu572otqlaf1u28c8suuuqgljdtthsjtr07rv04np05o6oa27ml9105k7uas0t8": {
-            "bestTermName": "x",
-            "defnTermTag": "Plain",
-            "signature": [
-                {
-                    "annotation": {
-                        "contents": "##Nat",
-                        "tag": "TypeReference"
-                    },
-                    "segment": "Nat"
-                }
-            ],
-            "termDefinition": {
-                "contents": [
-                    {
-                        "annotation": {
-                            "contents": "x",
-                            "tag": "HashQualifier"
-                        },
-                        "segment": "x"
-                    },
-                    {
-                        "annotation": {
-                            "tag": "TypeAscriptionColon"
-                        },
-                        "segment": " :"
-                    },
-                    {
-                        "annotation": null,
-                        "segment": " "
-                    },
-                    {
-                        "annotation": {
-                            "contents": "##Nat",
-                            "tag": "TypeReference"
-                        },
-                        "segment": "Nat"
-                    },
-                    {
-                        "annotation": null,
-                        "segment": "\n"
-                    },
-                    {
-                        "annotation": {
-                            "contents": "x",
-                            "tag": "HashQualifier"
-                        },
-                        "segment": "x"
-                    },
-                    {
-                        "annotation": {
-                            "tag": "BindingEquals"
-                        },
-                        "segment": " ="
-                    },
-                    {
-                        "annotation": null,
-                        "segment": " "
-                    },
-                    {
-                        "annotation": {
-                            "tag": "NumericLiteral"
-                        },
-                        "segment": "42"
-                    }
-                ],
-                "tag": "UserObject"
-            },
-            "termDocs": [
-                [
-                    "doc",
-                    "#ulr9f75rpcrv79d7sfo2ep2tvbntu3e360lfomird2bdpj4bnea230e8o5j0b9our8vggocpa7eck3pus14fcfajlttat1bg71t6rbg",
-                    {
-                        "contents": [
-                            {
-                                "contents": "Documentation",
-                                "tag": "Word"
-                            }
-                        ],
-                        "tag": "Paragraph"
-                    }
-                ]
-            ],
-            "termNames": [
-                "nested.names.x"
-            ]
-        }
-    },
+    "missingDefinitions": [
+        "x"
+    ],
+    "termDefinitions": {},
     "typeDefinitions": {}
 }
 --  Term names should strip relativeTo prefix.
 GET /api/non-project-code/getDefinition?names=x&relativeTo=nested
 {
-    "missingDefinitions": [],
-    "termDefinitions": {
-        "#qkhkl0n238s1eqibd1ecb8605sqj1m4hpoaag177cu572otqlaf1u28c8suuuqgljdtthsjtr07rv04np05o6oa27ml9105k7uas0t8": {
-            "bestTermName": "x",
-            "defnTermTag": "Plain",
-            "signature": [
-                {
-                    "annotation": {
-                        "contents": "##Nat",
-                        "tag": "TypeReference"
-                    },
-                    "segment": "Nat"
-                }
-            ],
-            "termDefinition": {
-                "contents": [
-                    {
-                        "annotation": {
-                            "contents": "x",
-                            "tag": "HashQualifier"
-                        },
-                        "segment": "x"
-                    },
-                    {
-                        "annotation": {
-                            "tag": "TypeAscriptionColon"
-                        },
-                        "segment": " :"
-                    },
-                    {
-                        "annotation": null,
-                        "segment": " "
-                    },
-                    {
-                        "annotation": {
-                            "contents": "##Nat",
-                            "tag": "TypeReference"
-                        },
-                        "segment": "Nat"
-                    },
-                    {
-                        "annotation": null,
-                        "segment": "\n"
-                    },
-                    {
-                        "annotation": {
-                            "contents": "x",
-                            "tag": "HashQualifier"
-                        },
-                        "segment": "x"
-                    },
-                    {
-                        "annotation": {
-                            "tag": "BindingEquals"
-                        },
-                        "segment": " ="
-                    },
-                    {
-                        "annotation": null,
-                        "segment": " "
-                    },
-                    {
-                        "annotation": {
-                            "tag": "NumericLiteral"
-                        },
-                        "segment": "42"
-                    }
-                ],
-                "tag": "UserObject"
-            },
-            "termDocs": [
-                [
-                    "doc",
-                    "#ulr9f75rpcrv79d7sfo2ep2tvbntu3e360lfomird2bdpj4bnea230e8o5j0b9our8vggocpa7eck3pus14fcfajlttat1bg71t6rbg",
-                    {
-                        "contents": [
-                            {
-                                "contents": "Documentation",
-                                "tag": "Word"
-                            }
-                        ],
-                        "tag": "Paragraph"
-                    }
-                ]
-            ],
-            "termNames": [
-                "names.x"
-            ]
-        }
-    },
+    "missingDefinitions": [
+        "x"
+    ],
+    "termDefinitions": {},
     "typeDefinitions": {}
 }
 --  Should find definitions by hash, names should be relative


### PR DESCRIPTION
## Overview

Fixes #4277 

The local ui would often show the docs for the wrong term if the term-name was a valid suffix of some other definition in your lib (or elsewhere in the project).

Now it doesn't 🎉 

## Implementation notes

Adds the requirement to specify what kind of search you want when looking up HQ names from a `NamesWithHistory`. It used to ALWAYS do a suffix search, but sometimes you know exactly what you want 👍🏼 

Share already has the correct behaviour here, but here's the fix for Local.

## Test coverage

Tested the reproduction from #4277 against both and it now behaves correctly when:

* local definition doesn't have a doc, but the lib definition does (doesn't show any doc)
* local definition has a doc (shows that doc)

## Controversial opinions

It's _slightly_ more annoying to specify what kind of search you want in all these spots, but I think we'll see even more bugs like this pop up unless we make the caller choose.

Side benefit that it's more performant to look up by the exact name if you know you have it.

## Loose ends

None