### PR TITLE
Don't typecheck dependents of unchanged defns in upgrade

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Upgrade.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Upgrade.hs
@@ -72,8 +72,7 @@ handleUpgrade oldDepName newDepName = do
 
   currentV1Branch <- Cli.getBranch0At projectPath
   let currentV1BranchWithoutOldDep = deleteLibdep oldDepName currentV1Branch
-  oldDepV1Branch <- over Branch.children (Map.delete Name.libSegment) <$> Cli.expectBranch0AtPath' oldDepPath
-  let oldDepWithoutItsDeps = over Branch.children (Map.delete Name.libSegment) oldDepV1Branch
+  oldDepWithoutItsDeps <- over Branch.children (Map.delete Name.libSegment) <$> Cli.expectBranch0AtPath' oldDepPath
 
   newDepV1Branch <- Cli.expectBranch0AtPath' newDepPath
 
@@ -143,7 +142,7 @@ handleUpgrade oldDepName newDepName = do
           Operations.dependentsWithinScope
             (Names.referenceIds namesExcludingLibdeps)
             ( filterUnchangedTerms (Branch.deepTerms oldDepWithoutItsDeps)
-                <> filterUnchangedTypes (Branch.deepTypes oldDepV1Branch)
+                <> filterUnchangedTypes (Branch.deepTypes oldDepWithoutItsDeps)
             )
         addDefinitionsToUnisonFile
           abort

--- a/unison-src/transcripts/fix4482.md
+++ b/unison-src/transcripts/fix4482.md
@@ -1,0 +1,18 @@
+```ucm:hide
+.> builtins.merge
+```
+
+```unison
+lib.foo0.lib.bonk1.bar = 203
+lib.foo0.baz = 1
+lib.foo1.zonk = 204
+lib.foo1.lib.bonk2.qux = 1
+mybar = bar + bar
+```
+
+```ucm
+.> project.create myproj
+myproj/main> add
+myproj/main> upgrade foo0 foo1
+myproj/main> view mybar
+```

--- a/unison-src/transcripts/fix4482.md
+++ b/unison-src/transcripts/fix4482.md
@@ -10,9 +10,8 @@ lib.foo1.lib.bonk2.qux = 1
 mybar = bar + bar
 ```
 
-```ucm
+```ucm:error
 .> project.create myproj
 myproj/main> add
 myproj/main> upgrade foo0 foo1
-myproj/main> view mybar
 ```

--- a/unison-src/transcripts/fix4482.output.md
+++ b/unison-src/transcripts/fix4482.output.md
@@ -64,16 +64,3 @@ myproj/main> upgrade foo0 foo1
   I couldn't automatically upgrade foo0 to foo1.
 
 ```
-
-```ucm
-.> project.create myprojmyproj/main> addmyproj/main> upgrade foo0 foo1myproj/main> view mybar
-```
-
-
-🛑
-
-The transcript failed due to an error in the stanza above. The error is:
-
-
-  I couldn't automatically upgrade foo0 to foo1.
-

--- a/unison-src/transcripts/fix4482.output.md
+++ b/unison-src/transcripts/fix4482.output.md
@@ -1,0 +1,79 @@
+```unison
+lib.foo0.lib.bonk1.bar = 203
+lib.foo0.baz = 1
+lib.foo1.zonk = 204
+lib.foo1.lib.bonk2.qux = 1
+mybar = bar + bar
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      lib.foo0.baz           : Nat
+      lib.foo0.lib.bonk1.bar : Nat
+      lib.foo1.lib.bonk2.qux : Nat
+      lib.foo1.zonk          : Nat
+      mybar                  : Nat
+
+```
+```ucm
+.> project.create myproj
+
+  🎉 I've created the project myproj.
+
+  I'll now fetch the latest version of the base Unison
+  library...
+
+  Downloaded 12786 entities.
+
+  🎨 Type `ui` to explore this project's code in your browser.
+  🔭 Discover libraries at https://share.unison-lang.org
+  📖 Use `help-topic projects` to learn more about projects.
+  
+  Write your first Unison code with UCM:
+  
+    1. Open scratch.u.
+    2. Write some Unison code and save the file.
+    3. In UCM, type `add` to save it to your new project.
+  
+  🎉 🥳 Happy coding!
+
+myproj/main> add
+
+  ⍟ I've added these definitions:
+  
+    lib.foo0.baz           : Nat
+    lib.foo0.lib.bonk1.bar : Nat
+    lib.foo1.lib.bonk2.qux : Nat
+    lib.foo1.zonk          : Nat
+    mybar                  : Nat
+
+myproj/main> upgrade foo0 foo1
+
+  mybar : Nat
+  mybar =
+    use Nat +
+    use lib.foo0.lib.bonk1 bar
+    bar + bar
+
+  I couldn't automatically upgrade foo0 to foo1.
+
+```
+
+```ucm
+.> project.create myprojmyproj/main> addmyproj/main> upgrade foo0 foo1myproj/main> view mybar
+```
+
+
+🛑
+
+The transcript failed due to an error in the stanza above. The error is:
+
+
+  I couldn't automatically upgrade foo0 to foo1.
+


### PR DESCRIPTION
## Overview

fixes #4483 
fixes #4482 

## Interesting/controversial decisions

We don't handle conflicted aliases during upgrade on trunk; instead picking a mapping at random (via the PPE). This is wrong, and there isn't really a way for us to handle this correctly. With patches we would refuse to apply such an update.

The logic for determining if the defn is changed leans into the behavior on trunk a bit though: we consider something unchanged if the intersection of the names of a ref on the old dep and the new dep is nonempty. 

## Test coverage

There is a transcript that demonstrates pulling in dependents for transitive deps of "old dep" if they only occur in "old dep" and giving them a name that will fail to resolve.