### PR TITLE
use semver for ucm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release Version (E.g. M4 or M4a)'
+        description: 'Release Version (E.g. M4 or M4a or 0.4.1)'
         required: true
         type: string
       target:

--- a/scripts/make-release.sh
+++ b/scripts/make-release.sh
@@ -17,6 +17,8 @@ usage() {
     echo ""
     echo "E.g."
     echo "$0 M4a"
+    echo ""
+    echo "The latest release is: $(git tag --list 'release/*' | sort -r | head -n 1 | sed 's/release\///')"
 }
 
 if [[ -z "$1" ]] ; then
@@ -29,8 +31,8 @@ if ! command -V "gh" >/dev/null 2>&1; then
    exit 1
 fi
 
-if ! [[ "$1" =~ ^M[0-9]+[a-z]?$ ]] ; then
- echo "Version tag must be of the form 'M4' or 'M4a'"
+if ! [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ; then
+ echo "Version tag must be of the form 'x.y.z' where x, y, and z are nonnegative integers."
  usage
  exit 1
 fi


### PR DESCRIPTION
Changes the release scripts to expect `<x>.<y>.<z>` instead of `M<Y><z>`.

close #4492

## Test coverage

This is untested, but trying to merge ahead of the release so that it falls into the right spot in the release notes.