### PR TITLE
make `namespace.dependencies` ignore `lib`

### DIFF
--- a/lib/unison-util-relation/src/Unison/Util/Relation.hs
+++ b/lib/unison-util-relation/src/Unison/Util/Relation.hs
@@ -367,13 +367,13 @@ lookupDom' x r = M.lookup x (domain r)
 lookupRan' :: (Ord b) => b -> Relation a b -> Maybe (Set a)
 lookupRan' y r = M.lookup y (range r)
 
--- | True if the element @ x @ exists in the domain of @ r @.
+-- | True if the element exists in the domain.
 memberDom :: (Ord a) => a -> Relation a b -> Bool
-memberDom x r = isJust $ lookupDom' x r
+memberDom x r = M.member x (domain r)
 
 -- | True if the element exists in the range.
 memberRan :: (Ord b) => b -> Relation a b -> Bool
-memberRan y r = isJust $ lookupRan' y r
+memberRan y r = M.member y (range r)
 
 filterDom :: (Ord a, Ord b) => (a -> Bool) -> Relation a b -> Relation a b
 filterDom f r = S.filter f (dom r) <| r

--- a/unison-cli/src/Unison/Cli/MonadUtils.hs
+++ b/unison-cli/src/Unison/Cli/MonadUtils.hs
@@ -31,6 +31,7 @@ module Unison.Cli.MonadUtils
     getLastSavedRootHash,
     setLastSavedRootHash,
     getMaybeBranchAt,
+    getMaybeBranch0At,
     expectBranchAtPath,
     expectBranchAtPath',
     expectBranch0AtPath,
@@ -290,6 +291,11 @@ getMaybeBranchAt :: Path.Absolute -> Cli (Maybe (Branch IO))
 getMaybeBranchAt path = do
   rootBranch <- getRootBranch
   pure (Branch.getAt (Path.unabsolute path) rootBranch)
+
+-- | Get the maybe-branch0 at an absolute path.
+getMaybeBranch0At :: Path.Absolute -> Cli (Maybe (Branch0 IO))
+getMaybeBranch0At path =
+  fmap Branch.head <$> getMaybeBranchAt path
 
 -- | Get the branch at a relative path, or return early if there's no such branch.
 expectBranchAtPath :: Path -> Cli (Branch IO)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -75,7 +75,7 @@ import Unison.Codebase.Editor.HandleInput.MoveAll (handleMoveAll)
 import Unison.Codebase.Editor.HandleInput.MoveBranch (doMoveBranch)
 import Unison.Codebase.Editor.HandleInput.MoveTerm (doMoveTerm)
 import Unison.Codebase.Editor.HandleInput.MoveType (doMoveType)
-import Unison.Codebase.Editor.HandleInput.NamespaceDependencies qualified as NamespaceDependencies
+import Unison.Codebase.Editor.HandleInput.NamespaceDependencies (handleNamespaceDependencies)
 import Unison.Codebase.Editor.HandleInput.NamespaceDiffUtils (diffHelper)
 import Unison.Codebase.Editor.HandleInput.ProjectClone (handleClone)
 import Unison.Codebase.Editor.HandleInput.ProjectCreate (projectCreate)
@@ -1177,16 +1177,7 @@ loop e = do
             PushRemoteBranchI pushRemoteBranchInput -> handlePushRemoteBranch pushRemoteBranchInput
             ListDependentsI hq -> handleDependents hq
             ListDependenciesI hq -> handleDependencies hq
-            NamespaceDependenciesI namespacePath' -> do
-              Cli.Env {codebase} <- ask
-              path <- maybe Cli.getCurrentPath Cli.resolvePath' namespacePath'
-              Cli.getMaybeBranchAt path >>= \case
-                Nothing -> Cli.respond $ BranchEmpty (WhichBranchEmptyPath (Path.absoluteToPath' path))
-                Just b -> do
-                  externalDependencies <-
-                    Cli.runTransaction (NamespaceDependencies.namespaceDependencies codebase (Branch.head b))
-                  ppe <- PPE.unsuffixifiedPPE <$> currentPrettyPrintEnvDecl Backend.Within
-                  Cli.respondNumbered $ ListNamespaceDependencies ppe path externalDependencies
+            NamespaceDependenciesI path -> handleNamespaceDependencies path
             DebugNumberedArgsI -> do
               numArgs <- use #numberedArgs
               Cli.respond (DumpNumberedArgs numArgs)

--- a/unison-src/transcripts-using-base/namespace-dependencies.output.md
+++ b/unison-src/transcripts-using-base/namespace-dependencies.output.md
@@ -39,10 +39,6 @@ hasMetadata = 3
                         3. dependsOnNat
                         4. hasMetadata
                         
-  builtin.Text          4. hasMetadata
-                        
   builtin.Nat.drop      2. dependsOnIntAndNat
-                        
-  metadata.myMetadata   4. hasMetadata
 
 ```


### PR DESCRIPTION
## Overview

This PR amends `namespace.dependencies` in two ways:

- We don't crawl through `lib` to report its "external" (nameless) dependencies
- We don't bother reporting anything to do with metadata anymore

Fixes #4487
Fixes #4488 