### PR TITLE
Revert "make `namespace.dependencies` ignore `lib`"

### DIFF
--- a/lib/unison-util-relation/src/Unison/Util/Relation.hs
+++ b/lib/unison-util-relation/src/Unison/Util/Relation.hs
@@ -367,13 +367,13 @@ lookupDom' x r = M.lookup x (domain r)
 lookupRan' :: (Ord b) => b -> Relation a b -> Maybe (Set a)
 lookupRan' y r = M.lookup y (range r)
 
--- | True if the element exists in the domain.
+-- | True if the element @ x @ exists in the domain of @ r @.
 memberDom :: (Ord a) => a -> Relation a b -> Bool
-memberDom x r = M.member x (domain r)
+memberDom x r = isJust $ lookupDom' x r
 
 -- | True if the element exists in the range.
 memberRan :: (Ord b) => b -> Relation a b -> Bool
-memberRan y r = M.member y (range r)
+memberRan y r = isJust $ lookupRan' y r
 
 filterDom :: (Ord a, Ord b) => (a -> Bool) -> Relation a b -> Relation a b
 filterDom f r = S.filter f (dom r) <| r

--- a/unison-cli/src/Unison/Cli/MonadUtils.hs
+++ b/unison-cli/src/Unison/Cli/MonadUtils.hs
@@ -31,7 +31,6 @@ module Unison.Cli.MonadUtils
     getLastSavedRootHash,
     setLastSavedRootHash,
     getMaybeBranchAt,
-    getMaybeBranch0At,
     expectBranchAtPath,
     expectBranchAtPath',
     expectBranch0AtPath,
@@ -291,11 +290,6 @@ getMaybeBranchAt :: Path.Absolute -> Cli (Maybe (Branch IO))
 getMaybeBranchAt path = do
   rootBranch <- getRootBranch
   pure (Branch.getAt (Path.unabsolute path) rootBranch)
-
--- | Get the maybe-branch0 at an absolute path.
-getMaybeBranch0At :: Path.Absolute -> Cli (Maybe (Branch0 IO))
-getMaybeBranch0At path =
-  fmap Branch.head <$> getMaybeBranchAt path
 
 -- | Get the branch at a relative path, or return early if there's no such branch.
 expectBranchAtPath :: Path -> Cli (Branch IO)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -74,7 +74,7 @@ import Unison.Codebase.Editor.HandleInput.MoveAll (handleMoveAll)
 import Unison.Codebase.Editor.HandleInput.MoveBranch (doMoveBranch)
 import Unison.Codebase.Editor.HandleInput.MoveTerm (doMoveTerm)
 import Unison.Codebase.Editor.HandleInput.MoveType (doMoveType)
-import Unison.Codebase.Editor.HandleInput.NamespaceDependencies (handleNamespaceDependencies)
+import Unison.Codebase.Editor.HandleInput.NamespaceDependencies qualified as NamespaceDependencies
 import Unison.Codebase.Editor.HandleInput.NamespaceDiffUtils (diffHelper)
 import Unison.Codebase.Editor.HandleInput.ProjectClone (handleClone)
 import Unison.Codebase.Editor.HandleInput.ProjectCreate (projectCreate)
@@ -1179,7 +1179,16 @@ loop e = do
             PushRemoteBranchI pushRemoteBranchInput -> handlePushRemoteBranch pushRemoteBranchInput
             ListDependentsI hq -> handleDependents hq
             ListDependenciesI hq -> handleDependencies hq
-            NamespaceDependenciesI path -> handleNamespaceDependencies path
+            NamespaceDependenciesI namespacePath' -> do
+              Cli.Env {codebase} <- ask
+              path <- maybe Cli.getCurrentPath Cli.resolvePath' namespacePath'
+              Cli.getMaybeBranchAt path >>= \case
+                Nothing -> Cli.respond $ BranchEmpty (WhichBranchEmptyPath (Path.absoluteToPath' path))
+                Just b -> do
+                  externalDependencies <-
+                    Cli.runTransaction (NamespaceDependencies.namespaceDependencies codebase (Branch.head b))
+                  ppe <- PPE.unsuffixifiedPPE <$> currentPrettyPrintEnvDecl Backend.Within
+                  Cli.respondNumbered $ ListNamespaceDependencies ppe path externalDependencies
             DebugNumberedArgsI -> do
               numArgs <- use #numberedArgs
               Cli.respond (DumpNumberedArgs numArgs)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/NamespaceDependencies.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/NamespaceDependencies.hs
@@ -1,48 +1,30 @@
 module Unison.Codebase.Editor.HandleInput.NamespaceDependencies
-  ( handleNamespaceDependencies,
+  ( namespaceDependencies,
   )
 where
 
-import Control.Lens (over)
-import Control.Monad.Reader (ask)
 import Control.Monad.Trans.Maybe
 import Data.Map qualified as Map
 import Data.Set qualified as Set
-import Unison.Cli.Monad qualified as Cli
-import Unison.Cli.MonadUtils qualified as Cli
-import Unison.Cli.PrettyPrintUtils (currentPrettyPrintEnvDecl)
 import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch (Branch0)
 import Unison.Codebase.Branch qualified as Branch
-import Unison.Codebase.Editor.Output qualified as Output
-import Unison.Codebase.Path qualified as Path
 import Unison.DataDeclaration qualified as DD
 import Unison.LabeledDependency (LabeledDependency)
 import Unison.LabeledDependency qualified as LD
 import Unison.Name (Name)
-import Unison.Name qualified as Name
 import Unison.Prelude
-import Unison.PrettyPrintEnvDecl qualified as PPED
+import Unison.Reference (Reference)
 import Unison.Reference qualified as Reference
+import Unison.Referent (Referent)
 import Unison.Referent qualified as Referent
-import Unison.Server.Backend qualified as Backend
 import Unison.Sqlite qualified as Sqlite
 import Unison.Symbol (Symbol)
 import Unison.Term qualified as Term
 import Unison.Util.Relation qualified as Relation
-
-handleNamespaceDependencies :: Maybe Path.Path' -> Cli.Cli ()
-handleNamespaceDependencies namespacePath' = do
-  Cli.Env {codebase} <- ask
-  path <- maybe Cli.getCurrentPath Cli.resolvePath' namespacePath'
-  branch <-
-    Cli.getMaybeBranch0At path & onNothingM do
-      Cli.returnEarly (Output.BranchEmpty (Output.WhichBranchEmptyPath (Path.absoluteToPath' path)))
-  externalDependencies <-
-    Cli.runTransaction (namespaceDependencies codebase branch)
-  ppe <- PPED.unsuffixifiedPPE <$> currentPrettyPrintEnvDecl Backend.Within
-  Cli.respondNumbered $ Output.ListNamespaceDependencies ppe path externalDependencies
+import Unison.Util.Relation3 qualified as Relation3
+import Unison.Util.Relation4 qualified as Relation4
 
 -- | Check the dependencies of all types, terms, and metadata in the current namespace,
 -- returns a map of dependencies which do not have a name within the current namespace,
@@ -59,36 +41,56 @@ handleNamespaceDependencies namespacePath' = do
 namespaceDependencies :: Codebase m Symbol a -> Branch0 m -> Sqlite.Transaction (Map LabeledDependency (Set Name))
 namespaceDependencies codebase branch = do
   typeDeps <-
-    for (Map.toList (Relation.domain (Branch.deepTypes branchWithoutLibdeps))) \(typeRef, names) ->
-      fmap (fromMaybe Map.empty) . runMaybeT $ do
-        refId <- MaybeT . pure $ Reference.toId typeRef
-        decl <- MaybeT $ Codebase.getTypeDeclaration codebase refId
-        let typeDeps = Set.map LD.typeRef $ DD.typeDependencies (DD.asDataDecl decl)
-        pure $ foldMap (`Map.singleton` names) typeDeps
+    for (Map.toList currentBranchTypeRefs) $ \(typeRef, names) -> fmap (fromMaybe Map.empty) . runMaybeT $ do
+      refId <- MaybeT . pure $ Reference.toId typeRef
+      decl <- MaybeT $ Codebase.getTypeDeclaration codebase refId
+      let typeDeps = Set.map LD.typeRef $ DD.typeDependencies (DD.asDataDecl decl)
+      pure $ foldMap (`Map.singleton` names) typeDeps
 
-  termDeps <-
-    for (Map.toList (Relation.domain (Branch.deepTerms branchWithoutLibdeps))) \(termRef, names) ->
-      fmap (fromMaybe Map.empty) . runMaybeT $ do
-        refId <- MaybeT . pure $ Referent.toReferenceId termRef
-        term <- MaybeT $ Codebase.getTerm codebase refId
-        let termDeps = Term.labeledDependencies term
-        pure $ foldMap (`Map.singleton` names) termDeps
+  termDeps <- for (Map.toList currentBranchTermRefs) $ \(termRef, names) -> fmap (fromMaybe Map.empty) . runMaybeT $ do
+    refId <- MaybeT . pure $ Referent.toReferenceId termRef
+    term <- MaybeT $ Codebase.getTerm codebase refId
+    let termDeps = Term.labeledDependencies term
+    pure $ foldMap (`Map.singleton` names) termDeps
 
   let dependenciesToDependents :: Map LabeledDependency (Set Name)
       dependenciesToDependents =
-        Map.unionsWith (<>) (typeDeps ++ termDeps)
-
+        Map.unionsWith (<>) (metadata : typeDeps ++ termDeps)
   let onlyExternalDeps :: Map LabeledDependency (Set Name)
       onlyExternalDeps =
         Map.filterWithKey
           ( \x _ ->
               LD.fold
-                (\k -> not (Relation.memberDom k (Branch.deepTypes branch)))
-                (\k -> not (Relation.memberDom k (Branch.deepTerms branch)))
+                (`Map.notMember` currentBranchTypeRefs)
+                (`Map.notMember` currentBranchTermRefs)
                 x
           )
           dependenciesToDependents
-
   pure onlyExternalDeps
   where
-    branchWithoutLibdeps = branch & over Branch.children (Map.delete Name.libSegment)
+    currentBranchTermRefs :: Map Referent (Set Name)
+    currentBranchTermRefs = Relation.domain (Branch.deepTerms branch)
+    currentBranchTypeRefs :: Map Reference (Set Name)
+    currentBranchTypeRefs = Relation.domain (Branch.deepTypes branch)
+
+    -- Since metadata is only linked by reference, not by name,
+    -- it's possible that the metadata itself is external to the branch.
+    metadata :: Map LabeledDependency (Set Name)
+    metadata =
+      let typeMetadataRefs :: Map LabeledDependency (Set Name)
+          typeMetadataRefs =
+            (Branch.deepTypeMetadata branch)
+              & Relation4.d234 -- Select only the type and value portions of the metadata
+              & \rel ->
+                let types = Map.mapKeys LD.typeRef $ Relation.range (Relation3.d12 rel)
+                    terms = Map.mapKeys LD.termRef $ Relation.range (Relation3.d13 rel)
+                 in Map.unionWith (<>) types terms
+          termMetadataRefs :: Map LabeledDependency (Set Name)
+          termMetadataRefs =
+            (Branch.deepTermMetadata branch)
+              & Relation4.d234 -- Select only the type and value portions of the metadata
+              & \rel ->
+                let types = Map.mapKeys LD.typeRef $ Relation.range (Relation3.d12 rel)
+                    terms = Map.mapKeys LD.termRef $ Relation.range (Relation3.d13 rel)
+                 in Map.unionWith (<>) types terms
+       in Map.unionWith (<>) typeMetadataRefs termMetadataRefs

--- a/unison-src/transcripts-using-base/namespace-dependencies.output.md
+++ b/unison-src/transcripts-using-base/namespace-dependencies.output.md
@@ -39,6 +39,10 @@ hasMetadata = 3
                         3. dependsOnNat
                         4. hasMetadata
                         
+  builtin.Text          4. hasMetadata
+                        
   builtin.Nat.drop      2. dependsOnIntAndNat
+                        
+  metadata.myMetadata   4. hasMetadata
 
 ```


### PR DESCRIPTION
Reverts unisonweb/unison#4509 due to a crash:

```
.> clone @unison/cloud-start
@unison/cloud-start/main> namespace.dependencies
zsh: segmentation fault  stack exec unison -- -C /tmp/4488
```