### PR TITLE
Better project-branch completion for many project commands

### DIFF
--- a/parser-typechecker/src/Unison/Project/Util.hs
+++ b/parser-typechecker/src/Unison/Project/Util.hs
@@ -7,6 +7,7 @@ module Unison.Project.Util
     projectBranchPathPrism,
     projectContextFromPath,
     pattern UUIDNameSegment,
+    ProjectContext (..),
   )
 where
 
@@ -126,7 +127,7 @@ projectBranchPathPrism =
 data ProjectContext
   = LooseCodePath Path.Absolute
   | ProjectBranchPath ProjectId ProjectBranchId Path.Path {- path from branch root -}
-  deriving (Eq, Show)
+  deriving stock (Eq, Show)
 
 projectContextFromPath :: Path.Absolute -> ProjectContext
 projectContextFromPath path =

--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -914,7 +914,7 @@ startRuntime sandboxed runtimeHost version = do
         evaluate = interpEval activeThreads cleanupThreads ctxVar,
         compileTo = interpCompile version ctxVar,
         mainType = builtinMain External,
-        ioTestType = builtinTest External
+        ioTestTypes = builtinIOTestTypes External
       }
 
 startNativeRuntime :: Text -> IO (Runtime Symbol)

--- a/unison-cli/src/Unison/CommandLine/InputPattern.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPattern.hs
@@ -12,9 +12,12 @@ module Unison.CommandLine.InputPattern
     -- * Currently Unused
     minArgs,
     maxArgs,
+    unionSuggestions,
+    suggestionFallbacks,
   )
 where
 
+import Data.List.Extra qualified as List
 import System.Console.Haskeline qualified as Line
 import Unison.Auth.HTTPClient (AuthenticatedHttpClient)
 import Unison.Codebase (Codebase)
@@ -23,6 +26,7 @@ import Unison.Codebase.Path as Path
 import Unison.CommandLine.Globbing qualified as Globbing
 import Unison.Prelude
 import Unison.Util.ColorText qualified as CT
+import Unison.Util.Monoid (foldMapM)
 import Unison.Util.Pretty qualified as P
 
 -- InputPatterns accept some fixed number of Required arguments of various
@@ -117,3 +121,51 @@ maxArgs ip@(fmap fst . argTypes -> args) = go args
           <> show (patternName ip)
           <> "): "
           <> show args
+
+-- | Union suggestions from all possible completions
+unionSuggestions ::
+  forall m v a.
+  (MonadIO m) =>
+  [ ( String ->
+      Codebase m v a ->
+      AuthenticatedHttpClient ->
+      Path.Absolute ->
+      m [Line.Completion]
+    )
+  ] ->
+  ( String ->
+    Codebase m v a ->
+    AuthenticatedHttpClient ->
+    Path.Absolute ->
+    m [Line.Completion]
+  )
+unionSuggestions suggesters inp codebase httpClient path = do
+  suggesters & foldMapM \suggester ->
+    suggester inp codebase httpClient path
+      & fmap List.nubOrd
+
+-- | Try the first completer, if it returns no suggestions, try the second, etc.
+suggestionFallbacks ::
+  forall m v a.
+  (MonadIO m) =>
+  [ ( String ->
+      Codebase m v a ->
+      AuthenticatedHttpClient ->
+      Path.Absolute ->
+      m [Line.Completion]
+    )
+  ] ->
+  ( String ->
+    Codebase m v a ->
+    AuthenticatedHttpClient ->
+    Path.Absolute ->
+    m [Line.Completion]
+  )
+suggestionFallbacks suggesters inp codebase httpClient path = go suggesters
+  where
+    go (s : rest) = do
+      suggestions <- s inp codebase httpClient path
+      if null suggestions
+        then go rest
+        else pure suggestions
+    go [] = pure []

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1,7 +1,6 @@
 {-
    This module defines 'InputPattern' values for every supported input command.
 -}
-{-# OPTIONS_GHC -Wno-deferred-out-of-scope-variables #-}
 
 module Unison.CommandLine.InputPatterns where
 

--- a/unison-src/transcripts/tab-completion.md
+++ b/unison-src/transcripts/tab-completion.md
@@ -65,3 +65,25 @@ add b = b
 .> debug.tab-complete delete.type Foo
 .> debug.tab-complete delete.term add
 ```
+
+## Tab complete projects and branches
+
+```ucm
+.> project.create-empty myproject
+myproject/main> branch mybranch
+myproject/main> debug.tab-complete branch.delete /mybr
+myproject/main> debug.tab-complete project.rename my
+```
+
+Commands which complete namespaces OR branches should list both
+
+```unison
+mybranchsubnamespace.term = 1
+```
+
+
+```ucm
+myproject/main> add
+myproject/main> debug.tab-complete merge mybr
+```
+

--- a/unison-src/transcripts/tab-completion.output.md
+++ b/unison-src/transcripts/tab-completion.output.md
@@ -171,3 +171,68 @@ add b = b
   * add
 
 ```
+## Tab complete projects and branches
+
+```ucm
+.> project.create-empty myproject
+
+  🎉 I've created the project myproject.
+
+  🎨 Type `ui` to explore this project's code in your browser.
+  🔭 Discover libraries at https://share.unison-lang.org
+  📖 Use `help-topic projects` to learn more about projects.
+  
+  Write your first Unison code with UCM:
+  
+    1. Open scratch.u.
+    2. Write some Unison code and save the file.
+    3. In UCM, type `add` to save it to your new project.
+  
+  🎉 🥳 Happy coding!
+
+myproject/main> branch mybranch
+
+  Done. I've created the mybranch branch based off of main.
+  
+  Tip: Use `merge /mybranch /main` to merge your work back into
+       the main branch.
+
+myproject/main> debug.tab-complete branch.delete /mybr
+
+   /mybranch
+
+myproject/main> debug.tab-complete project.rename my
+
+   myproject
+
+```
+Commands which complete namespaces OR branches should list both
+
+```unison
+mybranchsubnamespace.term = 1
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      mybranchsubnamespace.term : ##Nat
+
+```
+```ucm
+myproject/main> add
+
+  ⍟ I've added these definitions:
+  
+    mybranchsubnamespace.term : ##Nat
+
+myproject/main> debug.tab-complete merge mybr
+
+   /mybranch
+   mybranchsubnamespace
+
+```


### PR DESCRIPTION
## Overview

A lot of project commands were missing argument types and suggestions. This adds a bunch of those, namely:

* `reset`
* `push` (for local branch source argument)
* `push.create` (for local branch source argument)
* `push.force` (for local branch source argument)
* `push.exhaustive` (for local branch source argument)
* `squash.merge`
* `merge`
* `diff.namespace`
* `merge.preview`
* `project.rename`
* `branches`
* `branch`

Note: doesn't add any completion for remote branches/projects

## Implementation notes

* Generalizes the existing project/branch completer to take a config so we can use it correctly in more commands.
* Adds ability to union or 'fallback' many completion sources
* Adds argument type for 'namespace or project branch'
* Specifies a bunch of missing argument types for commands listed above

## Test coverage

- [x] transcripts