### PR TITLE
don't `isTest`-check entire `deepTerms` on `view`/`edit`

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1943,11 +1943,8 @@ handleShowDefinition outputLoc showDefinitionScope inputQuery = do
     -- We need an 'isTest' check in the output layer, so it can prepend "test>" to tests in a scratch file. Since we
     -- currently have the whole branch in memory, we just use that to make our predicate, but this could/should get this
     -- information from the database instead, once it's efficient to do so.
-    isTest <- do
-      branch <- Cli.getCurrentBranch0
-      let branchRefs = branch & Branch.deepTerms & Relation.dom & Set.mapMaybe Referent.toTermReferenceId
-      tests <- Cli.runTransaction (Codebase.filterTermsByReferenceIdHavingType codebase (DD.testResultType mempty) branchRefs)
-      pure \r -> Set.member r tests
+    testRefs <- Cli.runTransaction (Codebase.filterTermsByReferenceIdHavingType codebase (DD.testResultType mempty) (Map.keysSet terms & Set.mapMaybe Reference.toId))
+    let isTest r = Set.member r testRefs
 
     Cli.respond $
       DisplayDefinitions


### PR DESCRIPTION
## Overview

Stew mentioned pretty-printing was getting slow, it really was.
Turns out it wasn't pretty-printing at all, we were checking if the definition was a test in a pretty inefficient way (likely hasn't been changed since the view command was written, and people didn't have much code back then).

Anyways, that was pretty easy to fix and `view` and `edit` get a big speedup!

## Implementation notes

`edit` checks whether a definition is a test so that we can render it with `test>` in scratchfiles, fair enough,
however the way it was checking was to load EVERY definition in the entire namespace (including transitive libs), THEN encode and pass that entire set of refs to SQLite, looking at the type of each of them to find which ones are tests.

The new version only loads the terms we're actually viewing/editing, so it's O(n) rather than O(transitive namespace).

## Interesting/controversial decisions

I'm thinking one of these weeks we should just bite the bullet and kill `deepTerms`, it's tempting to use because it's convenient, but it's a huge performance footgun :'(

## Test coverage

Existing transcripts should test this pretty well.

## Loose ends

Nope.