### PR TITLE
Fix bug in `Bytes.fromBase16` when chunks have an odd size

### DIFF
--- a/lib/unison-util-bytes/src/Unison/Util/Bytes.hs
+++ b/lib/unison-util-bytes/src/Unison/Util/Bytes.hs
@@ -370,13 +370,7 @@ arrayToChunk bs = case BA.convert bs :: Block Word8 of
 chunkFromArray = arrayToChunk
 
 fromBase16 :: Bytes -> Either Text.Text Bytes
-fromBase16 bs = case traverse convert (chunks bs) of
-  Left e -> Left (Text.pack e)
-  Right bs -> Right (fromChunks bs)
-  where
-    convert b =
-      BE.convertFromBase BE.Base16 (chunkToArray @BA.Bytes b)
-        <&> arrayToChunk @BA.Bytes
+fromBase16 = fromBase BE.Base16
 
 toBase32, toBase64, toBase64UrlUnpadded :: Bytes -> Bytes
 toBase32 = toBase BE.Base32


### PR DESCRIPTION
Fixes https://github.com/unisonweb/unison/issues/4527

The implementation was making the assumption that the chunks of the rope backing the `Bytes` were valid input to `ByteArray.convertFromBase`, which they only are if the chunk size is an even number of bytes.

Replaced with an implementation that first flattens the rope and converts the whole array at once.