### PR TITLE
bugtweak: force result of `synthesizeForce` earlier

### DIFF
--- a/unison-cli/src/Unison/Cli/MonadUtils.hs
+++ b/unison-cli/src/Unison/Cli/MonadUtils.hs
@@ -250,7 +250,7 @@ modifyRootBranch f = do
   rootVar <- use #root
   atomically do
     root <- takeTMVar rootVar
-    let newRoot = f root
+    let !newRoot = f root
     putTMVar rootVar newRoot
     pure newRoot
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -28,7 +28,6 @@ import Data.These (These (..))
 import Data.Time (UTCTime)
 import Data.Tuple.Extra (uncurry3)
 import System.Directory (XdgDirectory (..), createDirectoryIfMissing, doesFileExist, getXdgDirectory)
-import System.Environment (withArgs)
 import System.Exit (ExitCode (..))
 import System.FilePath ((</>))
 import System.Process (callProcess, readCreateProcessWithExitCode, shell)
@@ -47,11 +46,10 @@ import Unison.Builtin.Terms qualified as Builtin
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli
-import Unison.Cli.NamesUtils (basicParseNames, displayNames, findHistoricalHQs, getBasicPrettyPrintNames, makeHistoricalParsingNames, makePrintNamesFromLabeled', makeShadowedPrintNamesFromHQ)
+import Unison.Cli.NamesUtils (basicParseNames, displayNames, findHistoricalHQs, getBasicPrettyPrintNames, makeHistoricalParsingNames, makePrintNamesFromLabeled')
 import Unison.Cli.PrettyPrintUtils (currentPrettyPrintEnvDecl, prettyPrintEnvDecl)
 import Unison.Cli.ProjectUtils qualified as ProjectUtils
-import Unison.Cli.TypeCheck (computeTypecheckingEnvironment, typecheckTerm)
-import Unison.Cli.UniqueTypeGuidLookup qualified as Cli
+import Unison.Cli.TypeCheck (typecheckTerm)
 import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch (Branch (..), Branch0 (..))
@@ -70,6 +68,7 @@ import Unison.Codebase.Editor.HandleInput.BranchRename (handleBranchRename)
 import Unison.Codebase.Editor.HandleInput.Branches (handleBranches)
 import Unison.Codebase.Editor.HandleInput.DeleteBranch (handleDeleteBranch)
 import Unison.Codebase.Editor.HandleInput.DeleteProject (handleDeleteProject)
+import Unison.Codebase.Editor.HandleInput.Load (EvalMode (Native, Permissive, Sandboxed), evalUnisonFile, handleLoad, loadUnisonFile)
 import Unison.Codebase.Editor.HandleInput.MetadataUtils (addDefaultMetadata, manageLinks)
 import Unison.Codebase.Editor.HandleInput.MoveAll (handleMoveAll)
 import Unison.Codebase.Editor.HandleInput.MoveBranch (doMoveBranch)
@@ -128,7 +127,6 @@ import Unison.CommandLine.InputPatterns qualified as IP
 import Unison.CommandLine.InputPatterns qualified as InputPatterns
 import Unison.ConstructorReference (GConstructorReference (..))
 import Unison.DataDeclaration qualified as DD
-import Unison.FileParsers qualified as FileParsers
 import Unison.Hash qualified as Hash
 import Unison.HashQualified qualified as HQ
 import Unison.HashQualified' qualified as HQ'
@@ -1025,16 +1023,7 @@ loop e = do
                 ([_], tos, [], []) -> ambiguous to tos
                 ([], [], [_], tos) -> ambiguous to tos
                 (_, _, _, _) -> error "unpossible"
-            LoadI maybePath -> do
-              latestFile <- Cli.getLatestFile
-              path <- (maybePath <|> fst <$> latestFile) & onNothing (Cli.returnEarly NoUnisonFile)
-              Cli.Env {loadSource} <- ask
-              contents <-
-                liftIO (loadSource (Text.pack path)) >>= \case
-                  Cli.InvalidSourceNameError -> Cli.returnEarly $ InvalidSourceName path
-                  Cli.LoadError -> Cli.returnEarly $ SourceLoadFailed path
-                  Cli.LoadSuccess contents -> pure contents
-              loadUnisonFile (Text.pack path) contents
+            LoadI maybePath -> handleLoad maybePath
             ClearI -> Cli.respond ClearScreen
             AddI requestedNames -> do
               description <- inputDescription input
@@ -1267,74 +1256,6 @@ loop e = do
             CloneI remoteNames localNames -> handleClone remoteNames localNames
             ReleaseDraftI semver -> handleReleaseDraft semver
             UpgradeI old new -> handleUpgrade old new
-
-loadUnisonFile :: Text -> Text -> Cli ()
-loadUnisonFile sourceName text = do
-  let lexed = L.lexer (Text.unpack sourceName) (Text.unpack text)
-  unisonFile <- withFile sourceName (text, lexed)
-  currentNames <- Branch.toNames <$> Cli.getCurrentBranch0
-  let sr = Slurp.slurpFile unisonFile mempty Slurp.CheckOp currentNames
-  names <- displayNames unisonFile
-  pped <- prettyPrintEnvDecl names
-  let ppe = PPE.suffixifiedPPE pped
-  Cli.respond $ Typechecked sourceName ppe sr unisonFile
-  (bindings, e) <- evalUnisonFile Permissive ppe unisonFile []
-  let e' = Map.map go e
-      go (ann, kind, _hash, _uneval, eval, isHit) = (ann, kind, eval, isHit)
-  when (not (null e')) do
-    Cli.respond $ Evaluated text ppe bindings e'
-  #latestTypecheckedFile .= Just (Right unisonFile)
-  where
-    withFile ::
-      Text ->
-      (Text, [L.Token L.Lexeme]) ->
-      Cli (TypecheckedUnisonFile Symbol Ann)
-    withFile sourceName (text, tokens) = do
-      let getHQ = \case
-            L.WordyId s (Just sh) -> Just (HQ.HashQualified (Name.unsafeFromString s) sh)
-            L.SymbolyId s (Just sh) -> Just (HQ.HashQualified (Name.unsafeFromString s) sh)
-            L.Hash sh -> Just (HQ.HashOnly sh)
-            _ -> Nothing
-          hqs = Set.fromList . mapMaybe (getHQ . L.payload) $ tokens
-      rootBranch <- Cli.getRootBranch
-      currentPath <- Cli.getCurrentPath
-      let parseNames = Backend.getCurrentParseNames (Backend.Within (Path.unabsolute currentPath)) rootBranch
-      State.modify' \loopState ->
-        loopState
-          & #latestFile .~ Just (Text.unpack sourceName, False)
-          & #latestTypecheckedFile .~ Nothing
-      Cli.Env {codebase, generateUniqueName} <- ask
-      uniqueName <- liftIO generateUniqueName
-      let parsingEnv =
-            Parser.ParsingEnv
-              { uniqueNames = uniqueName,
-                uniqueTypeGuid = Cli.loadUniqueTypeGuid currentPath,
-                names = parseNames
-              }
-      unisonFile <-
-        Cli.runTransaction (Parsers.parseFile (Text.unpack sourceName) (Text.unpack text) parsingEnv)
-          & onLeftM \err -> Cli.returnEarly (ParseErrors text [err])
-      -- set that the file at least parsed (but didn't typecheck)
-      State.modify' (& #latestTypecheckedFile .~ Just (Left unisonFile))
-      typecheckingEnv <-
-        Cli.runTransaction do
-          computeTypecheckingEnvironment (FileParsers.ShouldUseTndr'Yes parsingEnv) codebase [] unisonFile
-      let Result.Result notes maybeTypecheckedUnisonFile = FileParsers.synthesizeFile typecheckingEnv unisonFile
-      maybeTypecheckedUnisonFile & onNothing do
-        ns <- makeShadowedPrintNamesFromHQ hqs (UF.toNames unisonFile)
-        ppe <- suffixifiedPPE ns
-        let tes = [err | Result.TypeError err <- toList notes]
-            cbs =
-              [ bug
-                | Result.CompilerBug (Result.TypecheckerBug bug) <-
-                    toList notes
-              ]
-        when (not (null tes)) do
-          currentPath <- Cli.getCurrentPath
-          Cli.respond (TypeErrors currentPath text ppe tes)
-        when (not (null cbs)) do
-          Cli.respond (CompilerBugs text ppe cbs)
-        Cli.returnEarlyWithoutOutput
 
 magicMainWatcherString :: String
 magicMainWatcherString = "main"
@@ -2965,57 +2886,6 @@ synthesizeForce typeOfFunc = do
             ]
         )
     Identity (Just typ, _) -> typ
-
-data EvalMode = Sandboxed | Permissive | Native
-
--- | Evaluate all watched expressions in a UnisonFile and return
--- their results, keyed by the name of the watch variable. The tuple returned
--- has the form:
---   (hash, (ann, sourceTerm, evaluatedTerm, isCacheHit))
---
--- where
---   `hash` is the hash of the original watch expression definition
---   `ann` gives the location of the watch expression
---   `sourceTerm` is a closed term (no free vars) for the watch expression
---   `evaluatedTerm` is the result of evaluating that `sourceTerm`
---   `isCacheHit` is True if the result was computed by just looking up
---   in a cache
---
--- It's expected that the user of this action might add the
--- `(hash, evaluatedTerm)` mapping to a cache to make future evaluations
--- of the same watches instantaneous.
-evalUnisonFile ::
-  EvalMode ->
-  PPE.PrettyPrintEnv ->
-  TypecheckedUnisonFile Symbol Ann ->
-  [String] ->
-  Cli
-    ( [(Symbol, Term Symbol ())],
-      Map Symbol (Ann, WK.WatchKind, Reference.Id, Term Symbol (), Term Symbol (), Bool)
-    )
-evalUnisonFile mode ppe unisonFile args = do
-  Cli.Env {codebase, runtime, sandboxedRuntime, nativeRuntime} <- ask
-  let theRuntime = case mode of
-        Sandboxed -> sandboxedRuntime
-        Permissive -> runtime
-        Native -> nativeRuntime
-
-  let watchCache :: Reference.Id -> IO (Maybe (Term Symbol ()))
-      watchCache ref = do
-        maybeTerm <- Codebase.runTransaction codebase (Codebase.lookupWatchCache codebase ref)
-        pure (Term.amap (\(_ :: Ann) -> ()) <$> maybeTerm)
-
-  Cli.with_ (withArgs args) do
-    (nts, errs, map) <-
-      Cli.ioE (Runtime.evaluateWatches (Codebase.toCodeLookup codebase) ppe watchCache theRuntime unisonFile) \err -> do
-        Cli.returnEarly (EvaluationFailure err)
-    when (not $ null errs) (RuntimeUtils.displayDecompileErrors errs)
-    for_ (Map.elems map) \(_loc, kind, hash, _src, value, isHit) -> do
-      -- only update the watch cache when there are no errors
-      when (not isHit && null errs) do
-        let value' = Term.amap (\() -> Ann.External) value
-        Cli.runTransaction (Codebase.putWatch kind hash value')
-    pure (nts, map)
 
 -- Hack alert
 --

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1342,7 +1342,6 @@ magicMainWatcherString = "main"
 inputDescription :: Input -> Cli Text
 inputDescription input =
   case input of
-    SaveExecuteResultI _str -> pure "save-execute-result"
     ForkLocalBranchI src0 dest0 -> do
       src <- hp' src0
       dest <- p' dest0
@@ -1549,6 +1548,7 @@ inputDescription input =
     PushRemoteBranchI {} -> wat
     QuitI {} -> wat
     ReleaseDraftI {} -> wat
+    SaveExecuteResultI {} -> wat
     ShowDefinitionByPrefixI {} -> wat
     ShowDefinitionI {} -> wat
     ShowReflogI {} -> wat

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -68,7 +68,7 @@ import Unison.Codebase.Editor.HandleInput.BranchRename (handleBranchRename)
 import Unison.Codebase.Editor.HandleInput.Branches (handleBranches)
 import Unison.Codebase.Editor.HandleInput.DeleteBranch (handleDeleteBranch)
 import Unison.Codebase.Editor.HandleInput.DeleteProject (handleDeleteProject)
-import Unison.Codebase.Editor.HandleInput.Load (EvalMode (Native, Permissive, Sandboxed), evalUnisonFile, handleLoad, loadUnisonFile)
+import Unison.Codebase.Editor.HandleInput.Load (EvalMode (Sandboxed), evalUnisonFile, handleLoad, loadUnisonFile)
 import Unison.Codebase.Editor.HandleInput.MetadataUtils (addDefaultMetadata, manageLinks)
 import Unison.Codebase.Editor.HandleInput.MoveAll (handleMoveAll)
 import Unison.Codebase.Editor.HandleInput.MoveBranch (doMoveBranch)
@@ -102,7 +102,6 @@ import Unison.Codebase.Editor.Slurp qualified as Slurp
 import Unison.Codebase.Editor.SlurpResult qualified as SlurpResult
 import Unison.Codebase.Editor.TodoOutput qualified as TO
 import Unison.Codebase.IntegrityCheck qualified as IntegrityCheck (integrityCheckFullCodebase)
-import Unison.Codebase.MainTerm qualified as MainTerm
 import Unison.Codebase.Metadata qualified as Metadata
 import Unison.Codebase.Patch (Patch (..))
 import Unison.Codebase.Patch qualified as Patch
@@ -186,7 +185,6 @@ import Unison.Type (Type)
 import Unison.Type qualified as Type
 import Unison.Type.Names qualified as Type
 import Unison.Typechecker qualified as Typechecker
-import Unison.Typechecker.TypeLookup qualified as TypeLookup
 import Unison.UnisonFile (TypecheckedUnisonFile)
 import Unison.UnisonFile qualified as UF
 import Unison.UnisonFile.Names qualified as UF
@@ -206,6 +204,7 @@ import Unison.Var (Var)
 import Unison.Var qualified as Var
 import Unison.WatchKind qualified as WK
 import Witch (unsafeFrom)
+import Unison.Codebase.Editor.HandleInput.Run (handleRun)
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Main loop
@@ -1068,7 +1067,7 @@ loop e = do
               scopePath <- Cli.resolvePath' scopePath'
               updated <- propagatePatch description patch scopePath
               when (not updated) (Cli.respond $ NothingToPatch patchPath scopePath')
-            ExecuteI main args -> doExecute False main args
+            ExecuteI main args -> handleRun False main args
             MakeStandaloneI output main -> doCompile False output main
             CompileSchemeI output main -> doCompileScheme output main
             ExecuteSchemeI main args -> doRunAsScheme main args
@@ -1256,9 +1255,6 @@ loop e = do
             CloneI remoteNames localNames -> handleClone remoteNames localNames
             ReleaseDraftI semver -> handleReleaseDraft semver
             UpgradeI old new -> handleUpgrade old new
-
-magicMainWatcherString :: String
-magicMainWatcherString = "main"
 
 inputDescription :: Input -> Cli Text
 inputDescription input =
@@ -2322,30 +2318,6 @@ buildRacket genDir statDir main file =
           (True <$ callProcess "racket" opts)
           (\(_ :: IOException) -> pure False)
 
-doExecute :: Bool -> String -> [String] -> Cli ()
-doExecute native main args = do
-  (unisonFile, mainResType) <- do
-    (sym, term, typ, otyp) <- getTerm main
-    uf <- createWatcherFile sym term typ
-    pure (uf, otyp)
-  ppe <- executePPE unisonFile
-  let mode | native = Native | otherwise = Permissive
-  (_, xs) <- evalUnisonFile mode ppe unisonFile args
-  mainRes :: Term Symbol () <-
-    case lookup magicMainWatcherString (map bonk (Map.toList xs)) of
-      Nothing ->
-        error
-          ( "impossible: we manually added the watcher "
-              <> show magicMainWatcherString
-              <> " with 'createWatcherFile', but it isn't here."
-          )
-      Just x -> pure (stripUnisonFileReferences unisonFile x)
-  #lastRunResult .= Just (Term.amap (\() -> External) mainRes, mainResType, unisonFile)
-  Cli.respond (RunResult ppe mainRes)
-  where
-    bonk (_, (_ann, watchKind, _id, _term0, term1, _isCacheHit)) =
-      (watchKind, term1)
-
 doCompile :: Bool -> String -> HQ.HashQualified Name -> Cli ()
 doCompile native output main = do
   Cli.Env {codebase, runtime, nativeRuntime} <- ask
@@ -2692,11 +2664,6 @@ getTermsIncludingHistorical (p, hq) b = case Set.toList refs of
   where
     refs = BranchUtil.getTerm (p, hq) b
 
-data GetTermResult
-  = NoTermWithThatName
-  | TermHasBadType (Type Symbol Ann)
-  | GetTermSuccess (Symbol, Term Symbol Ann, Type Symbol Ann, Type Symbol Ann)
-
 -- Adds a watch expression of the given name to the file, if
 -- it would resolve to a TLD in the file. Returns the freshened
 -- variable name and the new typechecked file.
@@ -2724,78 +2691,6 @@ addWatch watchName (Just uf) = do
                 (UF.watchComponents uf <> [(WK.RegularWatch, [(v2, ann, Term.var a v, ty)])])
             )
     _ -> addWatch watchName Nothing
-
--- | Look up runnable term with the given name in the codebase or
--- latest typechecked unison file. Return its symbol, term, type, and
--- the type of the evaluated term.
-getTerm :: String -> Cli (Symbol, Term Symbol Ann, Type Symbol Ann, Type Symbol Ann)
-getTerm main =
-  getTerm' main >>= \case
-    NoTermWithThatName -> do
-      mainType <- Runtime.mainType <$> view #runtime
-      basicPrettyPrintNames <- getBasicPrettyPrintNames
-      ppe <- suffixifiedPPE (NamesWithHistory.NamesWithHistory basicPrettyPrintNames mempty)
-      Cli.returnEarly $ NoMainFunction main ppe [mainType]
-    TermHasBadType ty -> do
-      mainType <- Runtime.mainType <$> view #runtime
-      basicPrettyPrintNames <- getBasicPrettyPrintNames
-      ppe <- suffixifiedPPE (NamesWithHistory.NamesWithHistory basicPrettyPrintNames mempty)
-      Cli.returnEarly $ BadMainFunction "run" main ty ppe [mainType]
-    GetTermSuccess x -> pure x
-
-getTerm' :: String -> Cli GetTermResult
-getTerm' mainName =
-  let getFromCodebase = do
-        Cli.Env {codebase, runtime} <- ask
-
-        parseNames <- basicParseNames
-        let loadTypeOfTerm ref = Cli.runTransaction (Codebase.getTypeOfTerm codebase ref)
-        mainToFile
-          =<< MainTerm.getMainTerm loadTypeOfTerm parseNames mainName (Runtime.mainType runtime)
-        where
-          mainToFile (MainTerm.NotAFunctionName _) = pure NoTermWithThatName
-          mainToFile (MainTerm.NotFound _) = pure NoTermWithThatName
-          mainToFile (MainTerm.BadType _ ty) = pure $ maybe NoTermWithThatName TermHasBadType ty
-          mainToFile (MainTerm.Success hq tm typ) =
-            let v = Var.named (HQ.toText hq)
-             in checkType typ \otyp ->
-                  pure (GetTermSuccess (v, tm, typ, otyp))
-      getFromFile uf = do
-        let components = join $ UF.topLevelComponents uf
-        let mainComponent = filter ((\v -> Var.nameStr v == mainName) . view _1) components
-        case mainComponent of
-          [(v, _, tm, ty)] ->
-            checkType ty \otyp ->
-              let runMain = DD.forceTerm a a (Term.var a v)
-                  v2 = Var.freshIn (Set.fromList [v]) v
-                  a = ABT.annotation tm
-               in pure (GetTermSuccess (v2, runMain, ty, otyp))
-          _ -> getFromCodebase
-      checkType :: Type Symbol Ann -> (Type Symbol Ann -> Cli GetTermResult) -> Cli GetTermResult
-      checkType ty f = do
-        Cli.Env {runtime} <- ask
-        case Typechecker.fitsScheme ty (Runtime.mainType runtime) of
-          True -> f (synthesizeForce ty)
-          False -> pure (TermHasBadType ty)
-   in Cli.getLatestTypecheckedFile >>= \case
-        Nothing -> getFromCodebase
-        Just uf -> getFromFile uf
-
--- | Produce a typechecked unison file where the given term is the
--- only watcher, with the watch type set to 'magicMainWatcherString'.
-createWatcherFile :: Symbol -> Term Symbol Ann -> Type Symbol Ann -> Cli (TypecheckedUnisonFile Symbol Ann)
-createWatcherFile v tm typ =
-  Cli.getLatestTypecheckedFile >>= \case
-    Nothing -> pure (UF.typecheckedUnisonFile mempty mempty mempty [(magicMainWatcherString, [(v, External, tm, typ)])])
-    Just uf ->
-      let v2 = Var.freshIn (Set.fromList [v]) v
-       in pure $
-            UF.typecheckedUnisonFile
-              (UF.dataDeclarationsId' uf)
-              (UF.effectDeclarationsId' uf)
-              (UF.topLevelComponents' uf)
-              -- what about main's component? we have dropped them if they existed.
-              [(magicMainWatcherString, [(v2, External, tm, typ)])]
 
 executePPE ::
   (Var v) =>
@@ -2847,69 +2742,6 @@ fuzzySelectNamespace pos searchBranch0 = liftIO do
     Fuzzy.defaultOptions {Fuzzy.allowMultiSelect = False}
     tShow
     inputs
-
--- | synthesize the type of forcing a term
---
--- precondition: @fitsScheme typeOfFunc Runtime.mainType@ is satisfied
-synthesizeForce :: Type Symbol Ann -> Type Symbol Ann
-synthesizeForce typeOfFunc = do
-  let term :: Term Symbol Ann
-      term = Term.ref External ref
-      ref = Reference.DerivedId (Reference.Id (Hash.fromByteString "deadbeef") 0)
-      env =
-        Typechecker.Env
-          { Typechecker._ambientAbilities = [DD.exceptionType External, Type.builtinIO External],
-            Typechecker._typeLookup = tl <> Builtin.typeLookup,
-            Typechecker._termsByShortname = Map.empty
-          }
-      tl =
-        TypeLookup.TypeLookup
-          { TypeLookup.typeOfTerms = Map.singleton ref typeOfFunc,
-            TypeLookup.dataDecls = Map.empty,
-            TypeLookup.effectDecls = Map.empty
-          }
-  case Result.runResultT
-    ( Typechecker.synthesize
-        PPE.empty
-        Typechecker.PatternMatchCoverageCheckAndKindInferenceSwitch'Enabled
-        env
-        (DD.forceTerm External External term)
-    ) of
-    Identity (Nothing, notes) ->
-      error
-        ( unlines
-            [ "synthesizeForce fails although fitsScheme passed",
-              "Input Type:",
-              show typeOfFunc,
-              "Notes:",
-              show notes
-            ]
-        )
-    Identity (Just typ, _) -> typ
-
--- Hack alert
---
--- After we evaluate a term all vars are transformed into references,
--- but we want to feed this result into 'slurpFile' which won't add
--- dependencies that are referenced by hash. The hacky solution for
--- now is to convert all references that match a variable defined
--- within the unison file to variable references. This is hacky both
--- because we needlessly flip-flopping between var and reference
--- representations, and because we might unexpectedly add a term from
--- the local file if it has the same hash as a term in the codebase.
-stripUnisonFileReferences :: TypecheckedUnisonFile Symbol a -> Term Symbol () -> Term Symbol ()
-stripUnisonFileReferences unisonFile term =
-  let refMap :: Map Reference.Id Symbol
-      refMap = Map.fromList . map (\(sym, (_, refId, _, _, _)) -> (refId, sym)) . Map.toList . UF.hashTermsId $ unisonFile
-      alg () = \case
-        ABT.Var x -> ABT.var x
-        ABT.Cycle x -> ABT.cycle x
-        ABT.Abs v x -> ABT.abs v x
-        ABT.Tm t -> case t of
-          Term.Ref ref
-            | Just var <- (\k -> Map.lookup k refMap) =<< Reference.toId ref -> ABT.var var
-          x -> ABT.tm x
-   in ABT.cata alg term
 
 looseCodeOrProjectToPath :: Either Path' (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch) -> Path'
 looseCodeOrProjectToPath = \case

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/AddRun.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/AddRun.hs
@@ -7,6 +7,7 @@ import Control.Lens (use)
 import Control.Monad.Reader (ask)
 import Data.Map qualified as Map
 import Data.Set qualified as Set
+import Data.Text qualified as Text
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli
@@ -21,6 +22,8 @@ import Unison.Codebase.Editor.Output (Output (NoLastRunResult, SaveTermNameConfl
 import Unison.Codebase.Editor.Slurp qualified as Slurp
 import Unison.Codebase.Editor.SlurpResult qualified as SlurpResult
 import Unison.Codebase.Path qualified as Path
+import Unison.CommandLine.InputPattern qualified as InputPattern
+import Unison.CommandLine.InputPatterns qualified as InputPatterns
 import Unison.Name (Name)
 import Unison.Parser.Ann (Ann (External))
 import Unison.Prelude
@@ -32,7 +35,6 @@ import Unison.UnisonFile qualified as UF
 
 handleAddRun :: Input -> Name -> Cli ()
 handleAddRun input resultName = do
-  description <- wundefined -- inputDescription input
   let resultVar = Name.toVar resultName
   uf <- addSavedTermToUnisonFile resultName
   Cli.Env {codebase} <- ask
@@ -44,7 +46,7 @@ handleAddRun input resultName = do
   Cli.runTransaction . Codebase.addDefsToCodebase codebase . SlurpResult.filterUnisonFile sr $ uf
   ppe <- prettyPrintEnvDecl =<< displayNames uf
   addDefaultMetadata adds
-  Cli.syncRoot description
+  Cli.syncRoot (Text.pack (InputPattern.patternName InputPatterns.saveExecuteResult) <> " " <> Name.toText resultName)
   Cli.respond $ SlurpOutput input (PPE.suffixifiedPPE ppe) sr
 
 addSavedTermToUnisonFile :: Name -> Cli (TypecheckedUnisonFile Symbol Ann)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/AddRun.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/AddRun.hs
@@ -1,0 +1,65 @@
+module Unison.Codebase.Editor.HandleInput.AddRun
+  ( handleAddRun,
+  )
+where
+
+import Control.Lens (use)
+import Control.Monad.Reader (ask)
+import Data.Map qualified as Map
+import Data.Set qualified as Set
+import Unison.Cli.Monad (Cli)
+import Unison.Cli.Monad qualified as Cli
+import Unison.Cli.MonadUtils qualified as Cli
+import Unison.Cli.NamesUtils (displayNames)
+import Unison.Cli.PrettyPrintUtils (prettyPrintEnvDecl)
+import Unison.Codebase qualified as Codebase
+import Unison.Codebase.Branch.Names qualified as Branch
+import Unison.Codebase.Editor.HandleInput.MetadataUtils (addDefaultMetadata)
+import Unison.Codebase.Editor.HandleInput.Update (doSlurpAdds)
+import Unison.Codebase.Editor.Input (Input)
+import Unison.Codebase.Editor.Output (Output (NoLastRunResult, SaveTermNameConflict, SlurpOutput))
+import Unison.Codebase.Editor.Slurp qualified as Slurp
+import Unison.Codebase.Editor.SlurpResult qualified as SlurpResult
+import Unison.Codebase.Path qualified as Path
+import Unison.Name (Name)
+import Unison.Parser.Ann (Ann (External))
+import Unison.Prelude
+import Unison.PrettyPrintEnvDecl qualified as PPE
+import Unison.Symbol (Symbol)
+import Unison.Syntax.Name qualified as Name
+import Unison.UnisonFile (TypecheckedUnisonFile)
+import Unison.UnisonFile qualified as UF
+
+handleAddRun :: Input -> Name -> Cli ()
+handleAddRun input resultName = do
+  description <- wundefined -- inputDescription input
+  let resultVar = Name.toVar resultName
+  uf <- addSavedTermToUnisonFile resultName
+  Cli.Env {codebase} <- ask
+  currentPath <- Cli.getCurrentPath
+  currentNames <- Branch.toNames <$> Cli.getCurrentBranch0
+  let sr = Slurp.slurpFile uf (Set.singleton resultVar) Slurp.AddOp currentNames
+  let adds = SlurpResult.adds sr
+  Cli.stepAtNoSync (Path.unabsolute currentPath, doSlurpAdds adds uf)
+  Cli.runTransaction . Codebase.addDefsToCodebase codebase . SlurpResult.filterUnisonFile sr $ uf
+  ppe <- prettyPrintEnvDecl =<< displayNames uf
+  addDefaultMetadata adds
+  Cli.syncRoot description
+  Cli.respond $ SlurpOutput input (PPE.suffixifiedPPE ppe) sr
+
+addSavedTermToUnisonFile :: Name -> Cli (TypecheckedUnisonFile Symbol Ann)
+addSavedTermToUnisonFile resultName = do
+  let resultSymbol = Name.toVar resultName
+  (trm, typ, uf) <-
+    use #lastRunResult >>= \case
+      Nothing -> Cli.returnEarly NoLastRunResult
+      Just x -> pure x
+  case Map.lookup resultSymbol (UF.hashTermsId uf) of
+    Just _ -> Cli.returnEarly (SaveTermNameConflict resultName)
+    Nothing -> pure ()
+  pure $
+    UF.typecheckedUnisonFile
+      (UF.dataDeclarationsId' uf)
+      (UF.effectDeclarationsId' uf)
+      ([(resultSymbol, External, trm, typ)] : UF.topLevelComponents' uf)
+      (UF.watchComponents uf)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/AddRun.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/AddRun.hs
@@ -15,7 +15,6 @@ import Unison.Cli.NamesUtils (displayNames)
 import Unison.Cli.PrettyPrintUtils (prettyPrintEnvDecl)
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch.Names qualified as Branch
-import Unison.Codebase.Editor.HandleInput.MetadataUtils (addDefaultMetadata)
 import Unison.Codebase.Editor.HandleInput.Update (doSlurpAdds)
 import Unison.Codebase.Editor.Input (Input)
 import Unison.Codebase.Editor.Output (Output (NoLastRunResult, SaveTermNameConflict, SlurpOutput))
@@ -45,7 +44,6 @@ handleAddRun input resultName = do
   Cli.stepAtNoSync (Path.unabsolute currentPath, doSlurpAdds adds uf)
   Cli.runTransaction . Codebase.addDefsToCodebase codebase . SlurpResult.filterUnisonFile sr $ uf
   ppe <- prettyPrintEnvDecl =<< displayNames uf
-  addDefaultMetadata adds
   Cli.syncRoot (Text.pack (InputPattern.patternName InputPatterns.saveExecuteResult) <> " " <> Name.toText resultName)
   Cli.respond $ SlurpOutput input (PPE.suffixifiedPPE ppe) sr
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/AddRun.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/AddRun.hs
@@ -5,7 +5,7 @@ where
 
 import Control.Lens (use)
 import Control.Monad.Reader (ask)
-import Data.Map qualified as Map
+import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Text qualified as Text
 import Unison.Cli.Monad (Cli)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Load.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Load.hs
@@ -1,0 +1,181 @@
+module Unison.Codebase.Editor.HandleInput.Load
+  ( handleLoad,
+    loadUnisonFile,
+    EvalMode (..),
+    evalUnisonFile,
+  )
+where
+
+import Control.Lens ((.=), (.~))
+import Control.Monad.Reader (ask)
+import Control.Monad.State.Strict qualified as State
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import Data.Text qualified as Text
+import System.Environment (withArgs)
+import Unison.Cli.Monad (Cli)
+import Unison.Cli.Monad qualified as Cli
+import Unison.Cli.MonadUtils qualified as Cli
+import Unison.Cli.NamesUtils (displayNames, makeShadowedPrintNamesFromHQ)
+import Unison.Cli.PrettyPrintUtils (prettyPrintEnvDecl)
+import Unison.Cli.TypeCheck (computeTypecheckingEnvironment)
+import Unison.Cli.UniqueTypeGuidLookup qualified as Cli
+import Unison.Codebase qualified as Codebase
+import Unison.Codebase.Branch.Names qualified as Branch
+import Unison.Codebase.Editor.HandleInput.RuntimeUtils qualified as RuntimeUtils
+import Unison.Codebase.Editor.Output qualified as Output
+import Unison.Codebase.Editor.Slurp qualified as Slurp
+import Unison.Codebase.Path qualified as Path
+import Unison.Codebase.Runtime qualified as Runtime
+import Unison.FileParsers qualified as FileParsers
+import Unison.HashQualified qualified as HQ
+import Unison.Parser.Ann (Ann)
+import Unison.Parser.Ann qualified as Ann
+import Unison.Parsers qualified as Parsers
+import Unison.Prelude
+import Unison.PrettyPrintEnv qualified as PPE
+import Unison.PrettyPrintEnv.Names qualified as PPE
+import Unison.PrettyPrintEnvDecl qualified as PPE
+import Unison.Reference qualified as Reference
+import Unison.Result qualified as Result
+import Unison.Server.Backend qualified as Backend
+import Unison.Symbol (Symbol)
+import Unison.Syntax.Lexer qualified as L
+import Unison.Syntax.Name qualified as Name
+import Unison.Syntax.Parser qualified as Parser
+import Unison.Term (Term)
+import Unison.Term qualified as Term
+import Unison.UnisonFile (TypecheckedUnisonFile)
+import Unison.UnisonFile.Names qualified as UF
+import Unison.WatchKind qualified as WK
+
+handleLoad :: Maybe FilePath -> Cli ()
+handleLoad maybePath = do
+  latestFile <- Cli.getLatestFile
+  path <- (maybePath <|> fst <$> latestFile) & onNothing (Cli.returnEarly Output.NoUnisonFile)
+  Cli.Env {loadSource} <- ask
+  contents <-
+    liftIO (loadSource (Text.pack path)) >>= \case
+      Cli.InvalidSourceNameError -> Cli.returnEarly $ Output.InvalidSourceName path
+      Cli.LoadError -> Cli.returnEarly $ Output.SourceLoadFailed path
+      Cli.LoadSuccess contents -> pure contents
+  loadUnisonFile (Text.pack path) contents
+
+loadUnisonFile :: Text -> Text -> Cli ()
+loadUnisonFile sourceName text = do
+  let lexed = L.lexer (Text.unpack sourceName) (Text.unpack text)
+  unisonFile <- withFile sourceName (text, lexed)
+  currentNames <- Branch.toNames <$> Cli.getCurrentBranch0
+  let sr = Slurp.slurpFile unisonFile mempty Slurp.CheckOp currentNames
+  names <- displayNames unisonFile
+  pped <- prettyPrintEnvDecl names
+  let ppe = PPE.suffixifiedPPE pped
+  Cli.respond $ Output.Typechecked sourceName ppe sr unisonFile
+  (bindings, e) <- evalUnisonFile Permissive ppe unisonFile []
+  let e' = Map.map go e
+      go (ann, kind, _hash, _uneval, eval, isHit) = (ann, kind, eval, isHit)
+  when (not (null e')) do
+    Cli.respond $ Output.Evaluated text ppe bindings e'
+  #latestTypecheckedFile .= Just (Right unisonFile)
+  where
+    withFile ::
+      Text ->
+      (Text, [L.Token L.Lexeme]) ->
+      Cli (TypecheckedUnisonFile Symbol Ann)
+    withFile sourceName (text, tokens) = do
+      let getHQ = \case
+            L.WordyId s (Just sh) -> Just (HQ.HashQualified (Name.unsafeFromString s) sh)
+            L.SymbolyId s (Just sh) -> Just (HQ.HashQualified (Name.unsafeFromString s) sh)
+            L.Hash sh -> Just (HQ.HashOnly sh)
+            _ -> Nothing
+          hqs = Set.fromList . mapMaybe (getHQ . L.payload) $ tokens
+      rootBranch <- Cli.getRootBranch
+      currentPath <- Cli.getCurrentPath
+      let parseNames = Backend.getCurrentParseNames (Backend.Within (Path.unabsolute currentPath)) rootBranch
+      State.modify' \loopState ->
+        loopState
+          & #latestFile .~ Just (Text.unpack sourceName, False)
+          & #latestTypecheckedFile .~ Nothing
+      Cli.Env {codebase, generateUniqueName} <- ask
+      uniqueName <- liftIO generateUniqueName
+      let parsingEnv =
+            Parser.ParsingEnv
+              { uniqueNames = uniqueName,
+                uniqueTypeGuid = Cli.loadUniqueTypeGuid currentPath,
+                names = parseNames
+              }
+      unisonFile <-
+        Cli.runTransaction (Parsers.parseFile (Text.unpack sourceName) (Text.unpack text) parsingEnv)
+          & onLeftM \err -> Cli.returnEarly (Output.ParseErrors text [err])
+      -- set that the file at least parsed (but didn't typecheck)
+      State.modify' (& #latestTypecheckedFile .~ Just (Left unisonFile))
+      typecheckingEnv <-
+        Cli.runTransaction do
+          computeTypecheckingEnvironment (FileParsers.ShouldUseTndr'Yes parsingEnv) codebase [] unisonFile
+      let Result.Result notes maybeTypecheckedUnisonFile = FileParsers.synthesizeFile typecheckingEnv unisonFile
+      maybeTypecheckedUnisonFile & onNothing do
+        ns <- makeShadowedPrintNamesFromHQ hqs (UF.toNames unisonFile)
+        ppe <- Cli.runTransaction Codebase.hashLength <&> (`PPE.fromSuffixNames` ns)
+        let tes = [err | Result.TypeError err <- toList notes]
+            cbs =
+              [ bug
+                | Result.CompilerBug (Result.TypecheckerBug bug) <-
+                    toList notes
+              ]
+        when (not (null tes)) do
+          currentPath <- Cli.getCurrentPath
+          Cli.respond (Output.TypeErrors currentPath text ppe tes)
+        when (not (null cbs)) do
+          Cli.respond (Output.CompilerBugs text ppe cbs)
+        Cli.returnEarlyWithoutOutput
+
+data EvalMode = Sandboxed | Permissive | Native
+
+-- | Evaluate all watched expressions in a UnisonFile and return
+-- their results, keyed by the name of the watch variable. The tuple returned
+-- has the form:
+--   (hash, (ann, sourceTerm, evaluatedTerm, isCacheHit))
+--
+-- where
+--   `hash` is the hash of the original watch expression definition
+--   `ann` gives the location of the watch expression
+--   `sourceTerm` is a closed term (no free vars) for the watch expression
+--   `evaluatedTerm` is the result of evaluating that `sourceTerm`
+--   `isCacheHit` is True if the result was computed by just looking up
+--   in a cache
+--
+-- It's expected that the user of this action might add the
+-- `(hash, evaluatedTerm)` mapping to a cache to make future evaluations
+-- of the same watches instantaneous.
+evalUnisonFile ::
+  EvalMode ->
+  PPE.PrettyPrintEnv ->
+  TypecheckedUnisonFile Symbol Ann ->
+  [String] ->
+  Cli
+    ( [(Symbol, Term Symbol ())],
+      Map Symbol (Ann, WK.WatchKind, Reference.Id, Term Symbol (), Term Symbol (), Bool)
+    )
+evalUnisonFile mode ppe unisonFile args = do
+  Cli.Env {codebase, runtime, sandboxedRuntime, nativeRuntime} <- ask
+  let theRuntime = case mode of
+        Sandboxed -> sandboxedRuntime
+        Permissive -> runtime
+        Native -> nativeRuntime
+
+  let watchCache :: Reference.Id -> IO (Maybe (Term Symbol ()))
+      watchCache ref = do
+        maybeTerm <- Codebase.runTransaction codebase (Codebase.lookupWatchCache codebase ref)
+        pure (Term.amap (\(_ :: Ann) -> ()) <$> maybeTerm)
+
+  Cli.with_ (withArgs args) do
+    (nts, errs, map) <-
+      Cli.ioE (Runtime.evaluateWatches (Codebase.toCodeLookup codebase) ppe watchCache theRuntime unisonFile) \err -> do
+        Cli.returnEarly (Output.EvaluationFailure err)
+    when (not $ null errs) (RuntimeUtils.displayDecompileErrors errs)
+    for_ (Map.elems map) \(_loc, kind, hash, _src, value, isHit) -> do
+      -- only update the watch cache when there are no errors
+      when (not isHit && null errs) do
+        let value' = Term.amap (\() -> Ann.External) value
+        Cli.runTransaction (Codebase.putWatch kind hash value')
+    pure (nts, map)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Run.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Run.hs
@@ -1,0 +1,209 @@
+module Unison.Codebase.Editor.HandleInput.Run
+  ( handleRun,
+  )
+where
+
+import Control.Lens (view, (.=), _1)
+import Control.Monad.Reader (ask)
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import Unison.ABT qualified as ABT
+import Unison.Builtin.Decls qualified as DD
+import Unison.Cli.Monad (Cli)
+import Unison.Cli.Monad qualified as Cli
+import Unison.Cli.MonadUtils qualified as Cli
+import Unison.Cli.NamesUtils (basicParseNames, displayNames, getBasicPrettyPrintNames)
+import Unison.Codebase qualified as Codebase
+import Unison.Codebase.Editor.HandleInput.Load (EvalMode (Native, Permissive), evalUnisonFile)
+import Unison.Codebase.Editor.Output qualified as Output
+import Unison.Codebase.MainTerm qualified as MainTerm
+import Unison.Codebase.Runtime qualified as Runtime
+import Unison.NamesWithHistory qualified as NamesWithHistory
+import Unison.Parser.Ann (Ann (External))
+import Unison.Prelude
+import Unison.PrettyPrintEnv.Names qualified as PPE
+import Unison.Reference qualified as Reference
+import Unison.Symbol (Symbol)
+import Unison.Syntax.HashQualified qualified as HQ
+import Unison.Term (Term)
+import Unison.Term qualified as Term
+import Unison.Type (Type)
+import Unison.Typechecker qualified as Typechecker
+import Unison.UnisonFile (TypecheckedUnisonFile)
+import Unison.UnisonFile qualified as UF
+import Unison.Var qualified as Var
+import qualified Unison.Hash as Hash
+import qualified Unison.Type as Type
+import qualified Unison.Builtin as Builtin
+import qualified Unison.Typechecker.TypeLookup as TypeLookup
+import qualified Unison.Result as Result
+import qualified Unison.PrettyPrintEnv as PPE
+
+handleRun :: Bool -> String -> [String] -> Cli ()
+handleRun native main args = do
+  (unisonFile, mainResType) <- do
+    (sym, term, typ, otyp) <- getTerm main
+    uf <- createWatcherFile sym term typ
+    pure (uf, otyp)
+  ppe <- do
+    names <- displayNames unisonFile
+    Cli.runTransaction Codebase.hashLength <&> (`PPE.fromSuffixNames` names)
+  let mode | native = Native | otherwise = Permissive
+  (_, xs) <- evalUnisonFile mode ppe unisonFile args
+  mainRes :: Term Symbol () <-
+    case lookup magicMainWatcherString (map bonk (Map.toList xs)) of
+      Nothing ->
+        error
+          ( "impossible: we manually added the watcher "
+              <> show magicMainWatcherString
+              <> " with 'createWatcherFile', but it isn't here."
+          )
+      Just x -> pure (stripUnisonFileReferences unisonFile x)
+  #lastRunResult .= Just (Term.amap (\() -> External) mainRes, mainResType, unisonFile)
+  Cli.respond (Output.RunResult ppe mainRes)
+  where
+    bonk (_, (_ann, watchKind, _id, _term0, term1, _isCacheHit)) =
+      (watchKind, term1)
+
+data GetTermResult
+  = NoTermWithThatName
+  | TermHasBadType (Type Symbol Ann)
+  | GetTermSuccess (Symbol, Term Symbol Ann, Type Symbol Ann, Type Symbol Ann)
+
+-- | Look up runnable term with the given name in the codebase or
+-- latest typechecked unison file. Return its symbol, term, type, and
+-- the type of the evaluated term.
+getTerm :: String -> Cli (Symbol, Term Symbol Ann, Type Symbol Ann, Type Symbol Ann)
+getTerm main =
+  getTerm' main >>= \case
+    NoTermWithThatName -> do
+      mainType <- Runtime.mainType <$> view #runtime
+      basicPrettyPrintNames <- getBasicPrettyPrintNames
+      ppe <- Cli.runTransaction Codebase.hashLength <&> (`PPE.fromSuffixNames` (NamesWithHistory.NamesWithHistory basicPrettyPrintNames mempty))
+      Cli.returnEarly $ Output.NoMainFunction main ppe [mainType]
+    TermHasBadType ty -> do
+      mainType <- Runtime.mainType <$> view #runtime
+      basicPrettyPrintNames <- getBasicPrettyPrintNames
+      ppe <- Cli.runTransaction Codebase.hashLength <&> (`PPE.fromSuffixNames` (NamesWithHistory.NamesWithHistory basicPrettyPrintNames mempty))
+      Cli.returnEarly $ Output.BadMainFunction "run" main ty ppe [mainType]
+    GetTermSuccess x -> pure x
+
+getTerm' :: String -> Cli GetTermResult
+getTerm' mainName =
+  let getFromCodebase = do
+        Cli.Env {codebase, runtime} <- ask
+
+        parseNames <- basicParseNames
+        let loadTypeOfTerm ref = Cli.runTransaction (Codebase.getTypeOfTerm codebase ref)
+        mainToFile
+          =<< MainTerm.getMainTerm loadTypeOfTerm parseNames mainName (Runtime.mainType runtime)
+        where
+          mainToFile (MainTerm.NotAFunctionName _) = pure NoTermWithThatName
+          mainToFile (MainTerm.NotFound _) = pure NoTermWithThatName
+          mainToFile (MainTerm.BadType _ ty) = pure $ maybe NoTermWithThatName TermHasBadType ty
+          mainToFile (MainTerm.Success hq tm typ) =
+            let v = Var.named (HQ.toText hq)
+             in checkType typ \otyp ->
+                  pure (GetTermSuccess (v, tm, typ, otyp))
+      getFromFile uf = do
+        let components = join $ UF.topLevelComponents uf
+        let mainComponent = filter ((\v -> Var.nameStr v == mainName) . view _1) components
+        case mainComponent of
+          [(v, _, tm, ty)] ->
+            checkType ty \otyp ->
+              let runMain = DD.forceTerm a a (Term.var a v)
+                  v2 = Var.freshIn (Set.fromList [v]) v
+                  a = ABT.annotation tm
+               in pure (GetTermSuccess (v2, runMain, ty, otyp))
+          _ -> getFromCodebase
+      checkType :: Type Symbol Ann -> (Type Symbol Ann -> Cli GetTermResult) -> Cli GetTermResult
+      checkType ty f = do
+        Cli.Env {runtime} <- ask
+        case Typechecker.fitsScheme ty (Runtime.mainType runtime) of
+          True -> f (synthesizeForce ty)
+          False -> pure (TermHasBadType ty)
+   in Cli.getLatestTypecheckedFile >>= \case
+        Nothing -> getFromCodebase
+        Just uf -> getFromFile uf
+
+-- | Produce a typechecked unison file where the given term is the
+-- only watcher, with the watch type set to 'magicMainWatcherString'.
+createWatcherFile :: Symbol -> Term Symbol Ann -> Type Symbol Ann -> Cli (TypecheckedUnisonFile Symbol Ann)
+createWatcherFile v tm typ =
+  Cli.getLatestTypecheckedFile >>= \case
+    Nothing -> pure (UF.typecheckedUnisonFile mempty mempty mempty [(magicMainWatcherString, [(v, External, tm, typ)])])
+    Just uf ->
+      let v2 = Var.freshIn (Set.fromList [v]) v
+       in pure $
+            UF.typecheckedUnisonFile
+              (UF.dataDeclarationsId' uf)
+              (UF.effectDeclarationsId' uf)
+              (UF.topLevelComponents' uf)
+              -- what about main's component? we have dropped them if they existed.
+              [(magicMainWatcherString, [(v2, External, tm, typ)])]
+
+-- | synthesize the type of forcing a term
+--
+-- precondition: @fitsScheme typeOfFunc Runtime.mainType@ is satisfied
+synthesizeForce :: Type Symbol Ann -> Type Symbol Ann
+synthesizeForce typeOfFunc = do
+  let term :: Term Symbol Ann
+      term = Term.ref External ref
+      ref = Reference.DerivedId (Reference.Id (Hash.fromByteString "deadbeef") 0)
+      env =
+        Typechecker.Env
+          { Typechecker._ambientAbilities = [DD.exceptionType External, Type.builtinIO External],
+            Typechecker._typeLookup = tl <> Builtin.typeLookup,
+            Typechecker._termsByShortname = Map.empty
+          }
+      tl =
+        TypeLookup.TypeLookup
+          { TypeLookup.typeOfTerms = Map.singleton ref typeOfFunc,
+            TypeLookup.dataDecls = Map.empty,
+            TypeLookup.effectDecls = Map.empty
+          }
+  case Result.runResultT
+    ( Typechecker.synthesize
+        PPE.empty
+        Typechecker.PatternMatchCoverageCheckAndKindInferenceSwitch'Enabled
+        env
+        (DD.forceTerm External External term)
+    ) of
+    Identity (Nothing, notes) ->
+      error
+        ( unlines
+            [ "synthesizeForce fails although fitsScheme passed",
+              "Input Type:",
+              show typeOfFunc,
+              "Notes:",
+              show notes
+            ]
+        )
+    Identity (Just typ, _) -> typ
+
+-- Hack alert
+--
+-- After we evaluate a term all vars are transformed into references,
+-- but we want to feed this result into 'slurpFile' which won't add
+-- dependencies that are referenced by hash. The hacky solution for
+-- now is to convert all references that match a variable defined
+-- within the unison file to variable references. This is hacky both
+-- because we needlessly flip-flopping between var and reference
+-- representations, and because we might unexpectedly add a term from
+-- the local file if it has the same hash as a term in the codebase.
+stripUnisonFileReferences :: TypecheckedUnisonFile Symbol a -> Term Symbol () -> Term Symbol ()
+stripUnisonFileReferences unisonFile term =
+  let refMap :: Map Reference.Id Symbol
+      refMap = Map.fromList . map (\(sym, (_, refId, _, _, _)) -> (refId, sym)) . Map.toList . UF.hashTermsId $ unisonFile
+      alg () = \case
+        ABT.Var x -> ABT.var x
+        ABT.Cycle x -> ABT.cycle x
+        ABT.Abs v x -> ABT.abs v x
+        ABT.Tm t -> case t of
+          Term.Ref ref
+            | Just var <- (\k -> Map.lookup k refMap) =<< Reference.toId ref -> ABT.var var
+          x -> ABT.tm x
+   in ABT.cata alg term
+
+magicMainWatcherString :: String
+magicMainWatcherString = "main"

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Run.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Run.hs
@@ -120,7 +120,7 @@ getTerm' mainName =
       checkType ty f = do
         Cli.Env {runtime} <- ask
         case Typechecker.fitsScheme ty (Runtime.mainType runtime) of
-          True -> f (synthesizeForce ty)
+          True -> f $! synthesizeForce ty
           False -> pure (TermHasBadType ty)
    in Cli.getLatestTypecheckedFile >>= \case
         Nothing -> getFromCodebase

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -52,6 +52,7 @@ import Unison.Util.Pretty qualified as P
 data Event
   = UnisonFileChanged SourceName Source
   | IncomingRootBranch (Set CausalHash)
+  deriving stock (Show)
 
 type Source = Text -- "id x = x\nconst a b = a"
 

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -130,9 +130,9 @@ main ::
 main dir welcome initialPath config initialInputs runtime sbRuntime nRuntime codebase serverBaseUrl ucmVersion notifyBranchChange notifyPathChange shouldWatchFiles = Ki.scoped \scope -> do
   rootVar <- newEmptyTMVarIO
   initialRootCausalHash <- Codebase.runTransaction codebase Operations.expectRootCausalHash
-  _ <- Ki.fork scope $ do
+  _ <- Ki.fork scope do
     root <- Codebase.getRootBranch codebase
-    atomically $ do
+    atomically do
       -- Try putting the root, but if someone else as already written over the root, don't
       -- overwrite it.
       void $ tryPutTMVar rootVar root
@@ -143,7 +143,7 @@ main dir welcome initialPath config initialInputs runtime sbRuntime nRuntime cod
       (UnliftIO.evaluate root)
       (UnliftIO.evaluate IOSource.typecheckedFile) -- IOSource takes a while to compile, we should start compiling it on startup
   let initialState = Cli.loopState0 initialRootCausalHash rootVar initialPath
-  Ki.fork_ scope $ do
+  Ki.fork_ scope do
     let loop lastRoot = do
           -- This doesn't necessarily notify on _every_ update, but the LSP only needs the
           -- most recent version at any given time, so it's fine to skip some intermediate
@@ -246,7 +246,7 @@ main dir welcome initialPath config initialInputs runtime sbRuntime nRuntime cod
         loop0 s0 = do
           let step = do
                 input <- awaitInput s0
-                (result, resultState) <- Cli.runCli env s0 (HandleInput.loop input)
+                (!result, resultState) <- Cli.runCli env s0 (HandleInput.loop input)
                 let sNext = case input of
                       Left _ -> resultState
                       Right inp -> resultState & #lastInput ?~ inp

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -45,6 +45,7 @@ library
       Unison.Cli.UnisonConfigUtils
       Unison.Codebase.Editor.AuthorInfo
       Unison.Codebase.Editor.HandleInput
+      Unison.Codebase.Editor.HandleInput.AddRun
       Unison.Codebase.Editor.HandleInput.AuthLogin
       Unison.Codebase.Editor.HandleInput.Branch
       Unison.Codebase.Editor.HandleInput.Branches

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -52,6 +52,7 @@ library
       Unison.Codebase.Editor.HandleInput.BranchRename
       Unison.Codebase.Editor.HandleInput.DeleteBranch
       Unison.Codebase.Editor.HandleInput.DeleteProject
+      Unison.Codebase.Editor.HandleInput.Load
       Unison.Codebase.Editor.HandleInput.MetadataUtils
       Unison.Codebase.Editor.HandleInput.MoveAll
       Unison.Codebase.Editor.HandleInput.MoveBranch
@@ -67,6 +68,7 @@ library
       Unison.Codebase.Editor.HandleInput.Pull
       Unison.Codebase.Editor.HandleInput.Push
       Unison.Codebase.Editor.HandleInput.ReleaseDraft
+      Unison.Codebase.Editor.HandleInput.Run
       Unison.Codebase.Editor.HandleInput.RuntimeUtils
       Unison.Codebase.Editor.HandleInput.TermResolution
       Unison.Codebase.Editor.HandleInput.Tests

--- a/unison-cli/unison/Main.hs
+++ b/unison-cli/unison/Main.hs
@@ -27,7 +27,7 @@ import ArgParse
 import Compat (defaultInterruptHandler, withInterruptHandler)
 import Control.Concurrent (newEmptyMVar, runInUnboundThread, takeMVar)
 import Control.Concurrent.STM
-import Control.Exception (evaluate)
+import Control.Exception (displayException, evaluate)
 import Data.ByteString.Lazy qualified as BL
 import Data.Configurator.Types (Config)
 import Data.Either.Validation (Validation (..))
@@ -50,7 +50,6 @@ import System.IO.CodePage (withCP65001)
 import System.IO.Error (catchIOError)
 import System.IO.Temp qualified as Temp
 import System.Path qualified as Path
-import Text.Pretty.Simple (pHPrint)
 import U.Codebase.Sqlite.Queries qualified as Queries
 import Unison.Codebase (Codebase, CodebasePath)
 import Unison.Codebase qualified as Codebase
@@ -89,237 +88,259 @@ type Runtimes =
   (RTI.Runtime Symbol, RTI.Runtime Symbol, RTI.Runtime Symbol)
 
 main :: IO ()
-main = withCP65001 . runInUnboundThread . Ki.scoped $ \scope -> do
-  -- Replace the default exception handler with one that pretty-prints.
-  setUncaughtExceptionHandler (pHPrint stderr)
+main = do
+  -- Replace the default exception handler with one complains loudly, because we shouldn't have any uncaught exceptions.
+  -- Sometimes `show` and `displayException` are different strings; in this case, we want to show them both, so this
+  -- issue is easier to debug.
+  setUncaughtExceptionHandler \exception -> do
+    let shown = tShow exception
+    let displayed = Text.pack (displayException exception)
+    let indented = Text.unlines . map ("  " <>) . Text.lines
 
-  interruptHandler <- defaultInterruptHandler
-  withInterruptHandler interruptHandler $ do
-    void $ Ki.fork scope initHTTPClient
-    progName <- getProgName
-    -- hSetBuffering stdout NoBuffering -- cool
-    (renderUsageInfo, globalOptions, command) <- parseCLIArgs progName (Text.unpack Version.gitDescribeWithDate)
-    let GlobalOptions {codebasePathOption = mCodePathOption, exitOption = exitOption} = globalOptions
-    withConfig mCodePathOption \config -> do
-      currentDir <- getCurrentDirectory
-      case command of
-        PrintVersion ->
-          Text.putStrLn $ Text.pack progName <> " version: " <> Version.gitDescribeWithDate
-        Init -> do
-          exitError
-            ( P.lines
-                [ "The Init command has been removed",
-                  P.newline,
-                  P.wrap "Use --codebase-create to create a codebase at a specified location and open it:",
-                  P.indentN 2 (P.hiBlue "$ ucm --codebase-create myNewCodebase"),
-                  "Running UCM without the --codebase-create flag: ",
-                  P.indentN 2 (P.hiBlue "$ ucm"),
-                  P.wrap ("will " <> P.bold "always" <> " create a codebase in your home directory if one does not already exist.")
-                ]
-            )
-        Run (RunFromSymbol mainName) args -> do
-          getCodebaseOrExit mCodePathOption (SC.MigrateAutomatically SC.Backup SC.Vacuum) \(_, _, theCodebase) -> do
-            RTI.withRuntime False RTI.OneOff Version.gitDescribeWithDate \runtime -> do
-              withArgs args (execute theCodebase runtime mainName) >>= \case
-                Left err -> exitError err
-                Right () -> pure ()
-        Run (RunFromFile file mainName) args
-          | not (isDotU file) -> exitError "Files must have a .u extension."
-          | otherwise -> do
-              e <- safeReadUtf8 file
-              case e of
-                Left _ -> exitError "I couldn't find that file or it is for some reason unreadable."
-                Right contents -> do
-                  getCodebaseOrExit mCodePathOption (SC.MigrateAutomatically SC.Backup SC.Vacuum) \(initRes, _, theCodebase) -> do
-                    withRuntimes RTI.OneOff \(rt, sbrt, nrt) -> do
-                      let fileEvent = Input.UnisonFileChanged (Text.pack file) contents
-                      let noOpRootNotifier _ = pure ()
-                      let noOpPathNotifier _ = pure ()
-                      let serverUrl = Nothing
-                      let startPath = Nothing
-                      launch
-                        currentDir
-                        config
-                        rt
-                        sbrt
-                        nrt
-                        theCodebase
-                        [Left fileEvent, Right $ Input.ExecuteI mainName args, Right Input.QuitI]
-                        serverUrl
-                        startPath
-                        initRes
-                        noOpRootNotifier
-                        noOpPathNotifier
-                        CommandLine.ShouldNotWatchFiles
-        Run (RunFromPipe mainName) args -> do
-          e <- safeReadUtf8StdIn
-          case e of
-            Left _ -> exitError "I had trouble reading this input."
-            Right contents -> do
-              getCodebaseOrExit mCodePathOption (SC.MigrateAutomatically SC.Backup SC.Vacuum) \(initRes, _, theCodebase) -> do
-                withRuntimes RTI.OneOff \(rt, sbrt, nrt) -> do
-                  let fileEvent = Input.UnisonFileChanged (Text.pack "<standard input>") contents
-                  let noOpRootNotifier _ = pure ()
-                  let noOpPathNotifier _ = pure ()
-                  let serverUrl = Nothing
-                  let startPath = Nothing
-                  launch
-                    currentDir
-                    config
-                    rt
-                    sbrt
-                    nrt
-                    theCodebase
-                    [Left fileEvent, Right $ Input.ExecuteI mainName args, Right Input.QuitI]
-                    serverUrl
-                    startPath
-                    initRes
-                    noOpRootNotifier
-                    noOpPathNotifier
-                    CommandLine.ShouldNotWatchFiles
-        Run (RunCompiled file) args ->
-          BL.readFile file >>= \bs ->
-            try (evaluate $ RTI.decodeStandalone bs) >>= \case
-              Left (PE _cs err) -> do
-                exitError . P.lines $
-                  [ P.wrap . P.text $
-                      "I was unable to parse this file as a compiled\
-                      \ program. The parser generated the following error:",
-                    "",
-                    P.indentN 2 $ err
-                  ]
-              Right (Left err) ->
-                exitError . P.lines $
-                  [ P.wrap . P.text $
-                      "I was unable to parse this file as a compiled\
-                      \ program. The parser generated the following error:",
-                    "",
-                    P.indentN 2 . P.wrap $ P.string err
-                  ]
-              Left _ -> do
-                exitError . P.wrap . P.text $
-                  "I was unable to parse this file as a compiled\
-                  \ program. The parser generated an unrecognized error."
-              Right (Right (v, rf, w, sto))
-                | not vmatch -> mismatchMsg
-                | otherwise ->
-                    withArgs args (RTI.runStandalone sto w) >>= \case
-                      Left err -> exitError err
-                      Right () -> pure ()
-                where
-                  vmatch = v == Version.gitDescribeWithDate
-                  ws s = P.wrap (P.text s)
-                  ifile
-                    | 'c' : 'u' : '.' : rest <- reverse file = reverse rest
-                    | otherwise = file
-                  mismatchMsg =
-                    PT.putPrettyLn . P.lines $
-                      [ ws
-                          "I can't run this compiled program since \
-                          \it works with a different version of Unison \
-                          \than the one you're running.",
-                        "",
-                        "Compiled file version",
-                        P.indentN 4 $ P.text v,
-                        "",
-                        "Your version",
-                        P.indentN 4 $ P.text Version.gitDescribeWithDate,
-                        "",
-                        P.wrap $
-                          "The program was compiled from hash "
-                            <> (P.text $ "`" <> rf <> "`.")
-                            <> "If you have that hash in your codebase,"
-                            <> "you can do:",
-                        "",
-                        P.indentN 4 $
-                          ".> compile "
-                            <> P.text rf
-                            <> " "
-                            <> P.string ifile,
-                        "",
-                        P.wrap
-                          "to produce a new compiled program \
-                          \that matches your version of Unison."
-                      ]
-        Transcript shouldFork shouldSaveCodebase mrtsStatsFp transcriptFiles -> do
-          let action = runTranscripts Verbosity.Verbose renderUsageInfo shouldFork shouldSaveCodebase mCodePathOption transcriptFiles
-          case mrtsStatsFp of
-            Nothing -> action
-            Just fp -> recordRtsStats fp action
-        Launch isHeadless codebaseServerOpts mayStartingPath shouldWatchFiles -> do
-          getCodebaseOrExit mCodePathOption (SC.MigrateAfterPrompt SC.Backup SC.Vacuum) \(initRes, _, theCodebase) -> do
-            withRuntimes RTI.Persistent \(runtime, sbRuntime, nRuntime) -> do
-              startingPath <- case isHeadless of
-                WithCLI -> do
-                  -- If the user didn't provide a starting path on the command line, put them in the most recent
-                  -- path they cd'd to
-                  case mayStartingPath of
-                    Just startingPath -> pure startingPath
-                    Nothing -> do
-                      segments <- Codebase.runTransaction theCodebase Queries.expectMostRecentNamespace
-                      pure (Path.Absolute (Path.fromList (map NameSegment.NameSegment segments)))
-                Headless -> pure $ fromMaybe defaultInitialPath mayStartingPath
-              rootVar <- newEmptyTMVarIO
-              pathVar <- newTVarIO startingPath
-              let notifyOnRootChanges :: Branch IO -> STM ()
-                  notifyOnRootChanges b = do
-                    isEmpty <- isEmptyTMVar rootVar
-                    if isEmpty
-                      then putTMVar rootVar b
-                      else void $ swapTMVar rootVar b
-              let notifyOnPathChanges :: Path.Absolute -> STM ()
-                  notifyOnPathChanges = writeTVar pathVar
-              -- Unfortunately, the windows IO manager on GHC 8.* is prone to just hanging forever
-              -- when waiting for input on handles, so if we listen for LSP connections it will
-              -- prevent UCM from shutting down properly. Hopefully we can re-enable LSP on
-              -- Windows when we move to GHC 9.*
-              -- https://gitlab.haskell.org/ghc/ghc/-/merge_requests/1224
-              void . Ki.fork scope $ LSP.spawnLsp theCodebase runtime (readTMVar rootVar) (readTVar pathVar)
-              Server.startServer (Backend.BackendEnv {Backend.useNamesIndex = False}) codebaseServerOpts sbRuntime theCodebase $ \baseUrl -> do
-                case exitOption of
-                  DoNotExit -> do
-                    case isHeadless of
-                      Headless -> do
-                        PT.putPrettyLn $
-                          P.lines
-                            [ "I've started the Codebase API server at",
-                              P.text $ Server.urlFor Server.Api baseUrl,
-                              "and the Codebase UI at",
-                              P.text $ Server.urlFor (Server.LooseCodeUI Path.absoluteEmpty Nothing) baseUrl
-                            ]
-                        PT.putPrettyLn $
-                          P.string "Running the codebase manager headless with "
-                            <> P.shown GHC.Conc.numCapabilities
-                            <> " "
-                            <> plural' GHC.Conc.numCapabilities "cpu" "cpus"
-                            <> "."
-                        mvar <- newEmptyMVar
-                        takeMVar mvar
-                      WithCLI -> do
-                        PT.putPrettyLn $ P.string "Now starting the Unison Codebase Manager (UCM)..."
+    Text.hPutStrLn stderr . Text.unlines . fold $
+      [ [ "Uh oh, an unexpected exception brought the process down! That should never happen. Please file a bug report.",
+          "",
+          "Here's a stringy rendering of the exception:",
+          "",
+          indented shown
+        ],
+        if shown /= displayed
+          then
+            [ "And here's a different one, in case it's easier to understand:",
+              "",
+              indented displayed
+            ]
+          else []
+      ]
 
+  withCP65001 . runInUnboundThread . Ki.scoped $ \scope -> do
+    interruptHandler <- defaultInterruptHandler
+    withInterruptHandler interruptHandler $ do
+      void $ Ki.fork scope initHTTPClient
+      progName <- getProgName
+      -- hSetBuffering stdout NoBuffering -- cool
+      (renderUsageInfo, globalOptions, command) <- parseCLIArgs progName (Text.unpack Version.gitDescribeWithDate)
+      let GlobalOptions {codebasePathOption = mCodePathOption, exitOption = exitOption} = globalOptions
+      withConfig mCodePathOption \config -> do
+        currentDir <- getCurrentDirectory
+        case command of
+          PrintVersion ->
+            Text.putStrLn $ Text.pack progName <> " version: " <> Version.gitDescribeWithDate
+          Init -> do
+            exitError
+              ( P.lines
+                  [ "The Init command has been removed",
+                    P.newline,
+                    P.wrap "Use --codebase-create to create a codebase at a specified location and open it:",
+                    P.indentN 2 (P.hiBlue "$ ucm --codebase-create myNewCodebase"),
+                    "Running UCM without the --codebase-create flag: ",
+                    P.indentN 2 (P.hiBlue "$ ucm"),
+                    P.wrap ("will " <> P.bold "always" <> " create a codebase in your home directory if one does not already exist.")
+                  ]
+              )
+          Run (RunFromSymbol mainName) args -> do
+            getCodebaseOrExit mCodePathOption (SC.MigrateAutomatically SC.Backup SC.Vacuum) \(_, _, theCodebase) -> do
+              RTI.withRuntime False RTI.OneOff Version.gitDescribeWithDate \runtime -> do
+                withArgs args (execute theCodebase runtime mainName) >>= \case
+                  Left err -> exitError err
+                  Right () -> pure ()
+          Run (RunFromFile file mainName) args
+            | not (isDotU file) -> exitError "Files must have a .u extension."
+            | otherwise -> do
+                e <- safeReadUtf8 file
+                case e of
+                  Left _ -> exitError "I couldn't find that file or it is for some reason unreadable."
+                  Right contents -> do
+                    getCodebaseOrExit mCodePathOption (SC.MigrateAutomatically SC.Backup SC.Vacuum) \(initRes, _, theCodebase) -> do
+                      withRuntimes RTI.OneOff \(rt, sbrt, nrt) -> do
+                        let fileEvent = Input.UnisonFileChanged (Text.pack file) contents
+                        let noOpRootNotifier _ = pure ()
+                        let noOpPathNotifier _ = pure ()
+                        let serverUrl = Nothing
+                        let startPath = Nothing
                         launch
                           currentDir
                           config
-                          runtime
-                          sbRuntime
-                          nRuntime
+                          rt
+                          sbrt
+                          nrt
                           theCodebase
-                          []
-                          (Just baseUrl)
-                          (Just startingPath)
+                          [Left fileEvent, Right $ Input.ExecuteI mainName args, Right Input.QuitI]
+                          serverUrl
+                          startPath
                           initRes
-                          notifyOnRootChanges
-                          notifyOnPathChanges
-                          shouldWatchFiles
-                  Exit -> do Exit.exitSuccess
+                          noOpRootNotifier
+                          noOpPathNotifier
+                          CommandLine.ShouldNotWatchFiles
+          Run (RunFromPipe mainName) args -> do
+            e <- safeReadUtf8StdIn
+            case e of
+              Left _ -> exitError "I had trouble reading this input."
+              Right contents -> do
+                getCodebaseOrExit mCodePathOption (SC.MigrateAutomatically SC.Backup SC.Vacuum) \(initRes, _, theCodebase) -> do
+                  withRuntimes RTI.OneOff \(rt, sbrt, nrt) -> do
+                    let fileEvent = Input.UnisonFileChanged (Text.pack "<standard input>") contents
+                    let noOpRootNotifier _ = pure ()
+                    let noOpPathNotifier _ = pure ()
+                    let serverUrl = Nothing
+                    let startPath = Nothing
+                    launch
+                      currentDir
+                      config
+                      rt
+                      sbrt
+                      nrt
+                      theCodebase
+                      [Left fileEvent, Right $ Input.ExecuteI mainName args, Right Input.QuitI]
+                      serverUrl
+                      startPath
+                      initRes
+                      noOpRootNotifier
+                      noOpPathNotifier
+                      CommandLine.ShouldNotWatchFiles
+          Run (RunCompiled file) args ->
+            BL.readFile file >>= \bs ->
+              try (evaluate $ RTI.decodeStandalone bs) >>= \case
+                Left (PE _cs err) -> do
+                  exitError . P.lines $
+                    [ P.wrap . P.text $
+                        "I was unable to parse this file as a compiled\
+                        \ program. The parser generated the following error:",
+                      "",
+                      P.indentN 2 $ err
+                    ]
+                Right (Left err) ->
+                  exitError . P.lines $
+                    [ P.wrap . P.text $
+                        "I was unable to parse this file as a compiled\
+                        \ program. The parser generated the following error:",
+                      "",
+                      P.indentN 2 . P.wrap $ P.string err
+                    ]
+                Left _ -> do
+                  exitError . P.wrap . P.text $
+                    "I was unable to parse this file as a compiled\
+                    \ program. The parser generated an unrecognized error."
+                Right (Right (v, rf, w, sto))
+                  | not vmatch -> mismatchMsg
+                  | otherwise ->
+                      withArgs args (RTI.runStandalone sto w) >>= \case
+                        Left err -> exitError err
+                        Right () -> pure ()
+                  where
+                    vmatch = v == Version.gitDescribeWithDate
+                    ws s = P.wrap (P.text s)
+                    ifile
+                      | 'c' : 'u' : '.' : rest <- reverse file = reverse rest
+                      | otherwise = file
+                    mismatchMsg =
+                      PT.putPrettyLn . P.lines $
+                        [ ws
+                            "I can't run this compiled program since \
+                            \it works with a different version of Unison \
+                            \than the one you're running.",
+                          "",
+                          "Compiled file version",
+                          P.indentN 4 $ P.text v,
+                          "",
+                          "Your version",
+                          P.indentN 4 $ P.text Version.gitDescribeWithDate,
+                          "",
+                          P.wrap $
+                            "The program was compiled from hash "
+                              <> (P.text $ "`" <> rf <> "`.")
+                              <> "If you have that hash in your codebase,"
+                              <> "you can do:",
+                          "",
+                          P.indentN 4 $
+                            ".> compile "
+                              <> P.text rf
+                              <> " "
+                              <> P.string ifile,
+                          "",
+                          P.wrap
+                            "to produce a new compiled program \
+                            \that matches your version of Unison."
+                        ]
+          Transcript shouldFork shouldSaveCodebase mrtsStatsFp transcriptFiles -> do
+            let action = runTranscripts Verbosity.Verbose renderUsageInfo shouldFork shouldSaveCodebase mCodePathOption transcriptFiles
+            case mrtsStatsFp of
+              Nothing -> action
+              Just fp -> recordRtsStats fp action
+          Launch isHeadless codebaseServerOpts mayStartingPath shouldWatchFiles -> do
+            getCodebaseOrExit mCodePathOption (SC.MigrateAfterPrompt SC.Backup SC.Vacuum) \(initRes, _, theCodebase) -> do
+              withRuntimes RTI.Persistent \(runtime, sbRuntime, nRuntime) -> do
+                startingPath <- case isHeadless of
+                  WithCLI -> do
+                    -- If the user didn't provide a starting path on the command line, put them in the most recent
+                    -- path they cd'd to
+                    case mayStartingPath of
+                      Just startingPath -> pure startingPath
+                      Nothing -> do
+                        segments <- Codebase.runTransaction theCodebase Queries.expectMostRecentNamespace
+                        pure (Path.Absolute (Path.fromList (map NameSegment.NameSegment segments)))
+                  Headless -> pure $ fromMaybe defaultInitialPath mayStartingPath
+                rootVar <- newEmptyTMVarIO
+                pathVar <- newTVarIO startingPath
+                let notifyOnRootChanges :: Branch IO -> STM ()
+                    notifyOnRootChanges b = do
+                      isEmpty <- isEmptyTMVar rootVar
+                      if isEmpty
+                        then putTMVar rootVar b
+                        else void $ swapTMVar rootVar b
+                let notifyOnPathChanges :: Path.Absolute -> STM ()
+                    notifyOnPathChanges = writeTVar pathVar
+                -- Unfortunately, the windows IO manager on GHC 8.* is prone to just hanging forever
+                -- when waiting for input on handles, so if we listen for LSP connections it will
+                -- prevent UCM from shutting down properly. Hopefully we can re-enable LSP on
+                -- Windows when we move to GHC 9.*
+                -- https://gitlab.haskell.org/ghc/ghc/-/merge_requests/1224
+                void . Ki.fork scope $ LSP.spawnLsp theCodebase runtime (readTMVar rootVar) (readTVar pathVar)
+                Server.startServer (Backend.BackendEnv {Backend.useNamesIndex = False}) codebaseServerOpts sbRuntime theCodebase $ \baseUrl -> do
+                  case exitOption of
+                    DoNotExit -> do
+                      case isHeadless of
+                        Headless -> do
+                          PT.putPrettyLn $
+                            P.lines
+                              [ "I've started the Codebase API server at",
+                                P.text $ Server.urlFor Server.Api baseUrl,
+                                "and the Codebase UI at",
+                                P.text $ Server.urlFor (Server.LooseCodeUI Path.absoluteEmpty Nothing) baseUrl
+                              ]
+                          PT.putPrettyLn $
+                            P.string "Running the codebase manager headless with "
+                              <> P.shown GHC.Conc.numCapabilities
+                              <> " "
+                              <> plural' GHC.Conc.numCapabilities "cpu" "cpus"
+                              <> "."
+                          mvar <- newEmptyMVar
+                          takeMVar mvar
+                        WithCLI -> do
+                          PT.putPrettyLn $ P.string "Now starting the Unison Codebase Manager (UCM)..."
+
+                          launch
+                            currentDir
+                            config
+                            runtime
+                            sbRuntime
+                            nRuntime
+                            theCodebase
+                            []
+                            (Just baseUrl)
+                            (Just startingPath)
+                            initRes
+                            notifyOnRootChanges
+                            notifyOnPathChanges
+                            shouldWatchFiles
+                    Exit -> do Exit.exitSuccess
   where
     -- (runtime, sandboxed runtime)
     withRuntimes :: RTI.RuntimeHost -> (Runtimes -> IO a) -> IO a
     withRuntimes mode action =
       RTI.withRuntime False mode Version.gitDescribeWithDate \runtime -> do
         RTI.withRuntime True mode Version.gitDescribeWithDate \sbRuntime ->
-          action . (runtime, sbRuntime,)
+          action . (runtime,sbRuntime,)
             =<< RTI.startNativeRuntime Version.gitDescribeWithDate
     withConfig :: Maybe CodebasePathOption -> (Config -> IO a) -> IO a
     withConfig mCodePathOption action = do


### PR DESCRIPTION
## Overview

In investigating #4528, I discovered that the actual error occurs earlier (in `run`), but is only observed later (on `add.run`).

This PR contains the following slight behavior changes:

- We now force the result of a `synthesizeForce` call earlier, so that `run` fails instead of `add.run` in certain cases (see #4528 for one such case).
- Similarly, we now force a `Branch` to WHNF before putting it in the root branch TVar. Previously, an impure exception was being put in here, which caused a background thread to crash, which caused the whole application to crash. This was the cause of the same error being printed twice, for the transcript in #4528
- We now have a better uncaught exception handler that explains "you should never see this" along with a `show` and (if different) a `displayException` rendering of the exception. 

And the following refactorings:

- The `load`, `run` and `addRun` handlers were all factored out into separate files.

The diff is best viewed commit-by-commit. Here are the commits that contain changes that aren't just moving code around:

- https://github.com/unisonweb/unison/pull/4530/commits/68a208eec937ef845e7603529b4ace88dfaaf4a6
- https://github.com/unisonweb/unison/pull/4530/commits/0631bfecccc6df16d6c72a668bfaa01b45ca6c57
- https://github.com/unisonweb/unison/pull/4530/commits/00a5f53532bb521265651513c8f8453b8caf5ebc