### PR TITLE
bugfix: make `run` able to run things that don't return builtins

### DIFF
--- a/unison-src/transcripts/fix4528.md
+++ b/unison-src/transcripts/fix4528.md
@@ -1,0 +1,16 @@
+```ucm:hide
+.> project.create-empty foo
+foo/main> builtins.mergeio
+```
+
+```unison
+structural type Foo = MkFoo Nat
+
+main : () -> Foo
+main _ = MkFoo 5
+```
+
+```ucm
+foo/main> add
+foo/main> run main
+```

--- a/unison-src/transcripts/fix4528.output.md
+++ b/unison-src/transcripts/fix4528.output.md
@@ -1,0 +1,32 @@
+```unison
+structural type Foo = MkFoo Nat
+
+main : () -> Foo
+main _ = MkFoo 5
+```
+
+```ucm
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      structural type Foo
+      main : 'Foo
+
+```
+```ucm
+foo/main> add
+
+  ⍟ I've added these definitions:
+  
+    structural type Foo
+    main : 'Foo
+
+foo/main> run main
+
+  MkFoo 5
+
+```


### PR DESCRIPTION
## Overview

Fixes #4528 

This PR fixes a bug in `run` that caused it to crash if given a function that returns a non-builtin.

For example,

```
foo : ##Unit -> ##Nat

.> run foo
```

would work (because `##Unit` and `##Nat` are builtins), whereas

```
foo : ##Unit -> #MyCustomFooType

.> run foo
```

would not (because `#MyCustomFooType` is not a builtin).

The fix is simple: put all dependencies of the term's type in scope for the kind checker.

## Test coverage

Regression transcript added.