### PR TITLE
Adding a message for when ucm started reloading changes

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Load.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Load.hs
@@ -63,7 +63,7 @@ handleLoad maybePath = do
 
 loadUnisonFile :: Text -> Text -> Cli ()
 loadUnisonFile sourceName text = do
-  Cli.respond $ Output.ReloadingFile sourceName
+  Cli.respond $ Output.LoadingFile sourceName
   let lexed = L.lexer (Text.unpack sourceName) (Text.unpack text)
   unisonFile <- withFile sourceName (text, lexed)
   currentNames <- Branch.toNames <$> Cli.getCurrentBranch0

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Load.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Load.hs
@@ -63,6 +63,7 @@ handleLoad maybePath = do
 
 loadUnisonFile :: Text -> Text -> Cli ()
 loadUnisonFile sourceName text = do
+  Cli.respond $ Output.ReloadingFile sourceName
   let lexed = L.lexer (Text.unpack sourceName) (Text.unpack text)
   unisonFile <- withFile sourceName (text, lexed)
   currentNames <- Branch.toNames <$> Cli.getCurrentBranch0

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -250,6 +250,7 @@ data Output
       [(Symbol, Term Symbol ())]
       (Map Symbol (Ann, WK.WatchKind, Term Symbol (), Runtime.IsCacheHit))
   | RunResult PPE.PrettyPrintEnv (Term Symbol ())
+  | ReloadingFile SourceName
   | Typechecked SourceName PPE.PrettyPrintEnv SlurpResult (UF.TypecheckedUnisonFile Symbol Ann)
   | DisplayRendered (Maybe FilePath) (P.Pretty P.ColorText)
   | -- "display" definitions, possibly to a FilePath on disk (e.g. editing)
@@ -527,6 +528,7 @@ isFailure o = case o of
   DisplayConflicts {} -> False
   EvaluationFailure {} -> True
   Evaluated {} -> False
+  ReloadingFile {} -> False
   Typechecked {} -> False
   DisplayDefinitions DisplayDefinitionsOutput {terms, types} -> null terms && null types
   DisplayDefinitionsString {} -> False -- somewhat arbitrary :shrug:

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -250,7 +250,7 @@ data Output
       [(Symbol, Term Symbol ())]
       (Map Symbol (Ann, WK.WatchKind, Term Symbol (), Runtime.IsCacheHit))
   | RunResult PPE.PrettyPrintEnv (Term Symbol ())
-  | ReloadingFile SourceName
+  | LoadingFile SourceName
   | Typechecked SourceName PPE.PrettyPrintEnv SlurpResult (UF.TypecheckedUnisonFile Symbol Ann)
   | DisplayRendered (Maybe FilePath) (P.Pretty P.ColorText)
   | -- "display" definitions, possibly to a FilePath on disk (e.g. editing)
@@ -528,7 +528,7 @@ isFailure o = case o of
   DisplayConflicts {} -> False
   EvaluationFailure {} -> True
   Evaluated {} -> False
-  ReloadingFile {} -> False
+  LoadingFile {} -> False
   Typechecked {} -> False
   DisplayDefinitions DisplayDefinitionsOutput {terms, types} -> null terms && null types
   DisplayDefinitionsString {} -> False -- somewhat arbitrary :shrug:

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1207,6 +1207,9 @@ notifyUser dir = \case
                 "",
                 P.lines [("  " <> prettyName x) | x <- toList things]
               ]
+  ReloadingFile sourceName -> do
+    fileName <- renderFileName $ Text.unpack sourceName
+    pure $ P.wrap $ "Loading changes detected in " <> P.group (fileName <> ".")
   -- TODO: Present conflicting TermEdits and TypeEdits
   -- if we ever allow users to edit hashes directly.
   Typechecked sourceName ppe slurpResult uf -> do
@@ -2918,7 +2921,7 @@ renderEditConflicts ppe Patch {..} = do
                  then "deprecated and also replaced with"
                  else "replaced with"
              )
-          `P.hang` P.lines replacements
+            `P.hang` P.lines replacements
     formatTermEdits ::
       (Reference.TermReference, Set TermEdit.TermEdit) ->
       Numbered Pretty
@@ -2933,7 +2936,7 @@ renderEditConflicts ppe Patch {..} = do
                  then "deprecated and also replaced with"
                  else "replaced with"
              )
-          `P.hang` P.lines replacements
+            `P.hang` P.lines replacements
     formatConflict ::
       Either
         (Reference, Set TypeEdit.TypeEdit)

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1207,7 +1207,7 @@ notifyUser dir = \case
                 "",
                 P.lines [("  " <> prettyName x) | x <- toList things]
               ]
-  ReloadingFile sourceName -> do
+  LoadingFile sourceName -> do
     fileName <- renderFileName $ Text.unpack sourceName
     pure $ P.wrap $ "Loading changes detected in " <> P.group (fileName <> ".")
   -- TODO: Present conflicting TermEdits and TypeEdits

--- a/unison-src/transcripts-manual/rewrites.output.md
+++ b/unison-src/transcripts-manual/rewrites.output.md
@@ -222,6 +222,8 @@ Instead, it should be an unbound free variable, which doesn't typecheck:
 ```ucm
 .> load /private/tmp/rewrites-tmp.u
 
+  Loading changes detected in /private/tmp/rewrites-tmp.u.
+
   I couldn't find any definitions matching the name bar21 inside the namespace .
   
      19 |   bar21
@@ -270,6 +272,8 @@ The `a` introduced will be freshened to not capture the `a` in scope, so it rema
 
 ```ucm
 .> load /private/tmp/rewrites-tmp.u
+
+  Loading changes detected in /private/tmp/rewrites-tmp.u.
 
   I couldn't find any definitions matching the name a1 inside the namespace .
   

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -11,6 +11,8 @@ x = ()
 
 ```ucm
 
+  Loading changes detected in /private/tmp/roundtrip.u.
+
   I found and typechecked these definitions in
   /private/tmp/roundtrip.u. If you do an `add` or `update`,
   here's how your codebase would change:

--- a/unison-src/transcripts-using-base/_base.output.md
+++ b/unison-src/transcripts-using-base/_base.output.md
@@ -41,6 +41,8 @@ testAutoClean _ =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts-using-base/binary-encoding-nats.output.md
+++ b/unison-src/transcripts-using-base/binary-encoding-nats.output.md
@@ -56,6 +56,8 @@ testABunchOfNats _ =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts-using-base/codeops.output.md
+++ b/unison-src/transcripts-using-base/codeops.output.md
@@ -154,6 +154,8 @@ swapped name link =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -316,6 +318,8 @@ badLoad _ =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -427,6 +431,8 @@ codeTests =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -510,6 +516,8 @@ vtests _ =
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts-using-base/doc.output.md
+++ b/unison-src/transcripts-using-base/doc.output.md
@@ -30,6 +30,8 @@ unique type time.DayOfWeek = Sun | Mon | Tue | Wed | Thu | Fri | Sat
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -79,6 +81,9 @@ First, we'll load the `syntax.u` file which has examples of all the syntax:
 
 ```ucm
 .> load ./unison-src/transcripts-using-base/doc.md.files/syntax.u
+
+  Loading changes detected in
+  ./unison-src/transcripts-using-base/doc.md.files/syntax.u.
 
   I found and typechecked these definitions in
   ./unison-src/transcripts-using-base/doc.md.files/syntax.u. If

--- a/unison-src/transcripts-using-base/failure-tests.output.md
+++ b/unison-src/transcripts-using-base/failure-tests.output.md
@@ -20,6 +20,8 @@ test2 = do
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts-using-base/fix1709.output.md
+++ b/unison-src/transcripts-using-base/fix1709.output.md
@@ -8,6 +8,8 @@ id2 x =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -35,6 +37,8 @@ id2 x =
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   ✅
   

--- a/unison-src/transcripts-using-base/fix2027.output.md
+++ b/unison-src/transcripts-using-base/fix2027.output.md
@@ -48,6 +48,8 @@ myServer = unsafeRun! '(hello "127.0.0.1" "0")
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts-using-base/fix2049.output.md
+++ b/unison-src/transcripts-using-base/fix2049.output.md
@@ -21,6 +21,8 @@ tests _ =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts-using-base/fix2158-1.output.md
+++ b/unison-src/transcripts-using-base/fix2158-1.output.md
@@ -13,6 +13,8 @@ Async.parMap f as =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts-using-base/fix2244.output.md
+++ b/unison-src/transcripts-using-base/fix2244.output.md
@@ -3,6 +3,9 @@ Ensure closing token is emitted by closing brace in doc eval block.
 ```ucm
 .> load ./unison-src/transcripts-using-base/fix2244.u
 
+  Loading changes detected in
+  ./unison-src/transcripts-using-base/fix2244.u.
+
   I found and typechecked these definitions in
   ./unison-src/transcripts-using-base/fix2244.u. If you do an
   `add` or `update`, here's how your codebase would change:

--- a/unison-src/transcripts-using-base/fix2297.output.md
+++ b/unison-src/transcripts-using-base/fix2297.output.md
@@ -27,6 +27,8 @@ wat =  handleTrivial testAction -- Somehow this completely forgets about Excepti
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I expected to see `structural` or `unique` at the start of
   this line:
   

--- a/unison-src/transcripts-using-base/fix2358.output.md
+++ b/unison-src/transcripts-using-base/fix2358.output.md
@@ -11,6 +11,8 @@ timingApp2 _ =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts-using-base/fix3166.output.md
+++ b/unison-src/transcripts-using-base/fix3166.output.md
@@ -33,6 +33,8 @@ increment n = 1 + n
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -82,6 +84,8 @@ foo _ =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -123,6 +127,8 @@ hmm =
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts-using-base/fix3542.output.md
+++ b/unison-src/transcripts-using-base/fix3542.output.md
@@ -16,6 +16,8 @@ arrayList v n = do
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts-using-base/hashing.output.md
+++ b/unison-src/transcripts-using-base/hashing.output.md
@@ -76,6 +76,8 @@ ex5 = crypto.hmac Sha2_256 mysecret f |> hex
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -146,6 +148,8 @@ Note that the universal versions of `hash` and `hmac` are currently unimplemente
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   ✅
   
@@ -365,6 +369,8 @@ test> hmac_sha2_512.tests.ex2 =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -425,6 +431,8 @@ test> md5.tests.ex3 =
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts-using-base/mvar.output.md
+++ b/unison-src/transcripts-using-base/mvar.output.md
@@ -53,6 +53,8 @@ testMvars _ =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts-using-base/nat-coersion.output.md
+++ b/unison-src/transcripts-using-base/nat-coersion.output.md
@@ -34,6 +34,8 @@ test = 'let
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts-using-base/net.output.md
+++ b/unison-src/transcripts-using-base/net.output.md
@@ -93,6 +93,8 @@ testDefaultPort _ =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -177,6 +179,8 @@ testTcpConnect = 'let
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts-using-base/random-deserial.output.md
+++ b/unison-src/transcripts-using-base/random-deserial.output.md
@@ -57,6 +57,8 @@ serialTests = do
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts-using-base/ref-promise.output.md
+++ b/unison-src/transcripts-using-base/ref-promise.output.md
@@ -20,6 +20,8 @@ casTest = do
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -80,6 +82,8 @@ promiseConcurrentTest = do
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -134,6 +138,8 @@ atomicUpdate ref f =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -170,6 +176,8 @@ spawnN n fa =
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -217,6 +225,8 @@ fullTest = do
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts-using-base/serial-test-00.output.md
+++ b/unison-src/transcripts-using-base/serial-test-00.output.md
@@ -69,6 +69,8 @@ mkTestCase = do
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts-using-base/serial-test-01.output.md
+++ b/unison-src/transcripts-using-base/serial-test-01.output.md
@@ -17,6 +17,8 @@ mkTestCase = do
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts-using-base/serial-test-02.output.md
+++ b/unison-src/transcripts-using-base/serial-test-02.output.md
@@ -31,6 +31,8 @@ mkTestCase = do
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts-using-base/serial-test-03.output.md
+++ b/unison-src/transcripts-using-base/serial-test-03.output.md
@@ -45,6 +45,8 @@ mkTestCase = do
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts-using-base/serial-test-04.output.md
+++ b/unison-src/transcripts-using-base/serial-test-04.output.md
@@ -14,6 +14,8 @@ mkTestCase = do
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts-using-base/stm.output.md
+++ b/unison-src/transcripts-using-base/stm.output.md
@@ -29,6 +29,8 @@ body k out v =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -88,6 +90,8 @@ tests = '(map spawn nats)
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts-using-base/test-watch-dependencies.output.md
+++ b/unison-src/transcripts-using-base/test-watch-dependencies.output.md
@@ -17,6 +17,8 @@ test> mytest = checks [x + 1 == 1001]
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -60,6 +62,8 @@ test> useY = checks [y + 1 == 43]
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts-using-base/thread.output.md
+++ b/unison-src/transcripts-using-base/thread.output.md
@@ -18,6 +18,8 @@ testBasicFork = 'let
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -55,6 +57,8 @@ testBasicMultiThreadMVar = 'let
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -125,6 +129,8 @@ testTwoThreads = 'let
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts-using-base/tls.output.md
+++ b/unison-src/transcripts-using-base/tls.output.md
@@ -29,6 +29,8 @@ what_should_work _ = this_should_work ++ this_should_not_work
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -216,6 +218,8 @@ testCNReject _ =
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts-using-base/update-test-to-non-test.output.md
+++ b/unison-src/transcripts-using-base/update-test-to-non-test.output.md
@@ -6,6 +6,8 @@ test> foo = []
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -34,6 +36,8 @@ foo = 1
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts-using-base/utf8.output.md
+++ b/unison-src/transcripts-using-base/utf8.output.md
@@ -23,6 +23,8 @@ ascii = "ABCDE"
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -50,6 +52,8 @@ greek = "ΑΒΓΔΕ"
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -84,6 +88,8 @@ test> greekTest = checkRoundTrip greek
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -116,6 +122,8 @@ greek_bytes = Bytes.fromList [206, 145, 206, 146, 206, 147, 206, 148, 206]
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/abilities.output.md
+++ b/unison-src/transcripts/abilities.output.md
@@ -19,6 +19,8 @@ ha = cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/ability-order-doesnt-affect-hash.output.md
+++ b/unison-src/transcripts/ability-order-doesnt-affect-hash.output.md
@@ -16,6 +16,8 @@ term2 _ = ()
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/ability-term-conflicts-on-update.output.md
+++ b/unison-src/transcripts/ability-term-conflicts-on-update.output.md
@@ -12,6 +12,8 @@ unique ability Channels where
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -47,6 +49,8 @@ thing _ = send 1
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -101,6 +105,8 @@ thing _ = send 1
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -167,6 +173,8 @@ X.x = 1
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -192,6 +200,8 @@ structural ability X where
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/add-run.output.md
+++ b/unison-src/transcripts/add-run.output.md
@@ -15,6 +15,8 @@ is2even = '(even 2)
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -85,6 +87,8 @@ main _ = y
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -118,6 +122,8 @@ inc x = x + 1
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -141,6 +147,8 @@ main _ x = inc x
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -178,6 +186,8 @@ main = 'y
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -200,6 +210,8 @@ x = 50
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -232,6 +244,8 @@ main = '5
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -263,6 +277,8 @@ main = '5
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/addupdatemessages.output.md
+++ b/unison-src/transcripts/addupdatemessages.output.md
@@ -12,6 +12,8 @@ structural type Y = Two Nat Nat
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -47,6 +49,8 @@ structural type Z = One Nat
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -81,6 +85,8 @@ structural type X = Three Nat Nat Nat
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -118,6 +124,8 @@ structural type X = Two Nat Nat
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/anf-tests.output.md
+++ b/unison-src/transcripts/anf-tests.output.md
@@ -26,6 +26,8 @@ foo _ =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/any-extract.output.md
+++ b/unison-src/transcripts/any-extract.output.md
@@ -13,6 +13,8 @@ test> Any.unsafeExtract.works =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/api-find.output.md
+++ b/unison-src/transcripts/api-find.output.md
@@ -9,6 +9,8 @@ joey.yaml.zz = 45
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/api-namespace-details.output.md
+++ b/unison-src/transcripts/api-namespace-details.output.md
@@ -11,6 +11,8 @@ Here's a *README*!
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/api-namespace-list.output.md
+++ b/unison-src/transcripts/api-namespace-list.output.md
@@ -9,6 +9,8 @@ nested.names.readme = {{ I'm a readme! }}
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/block-on-required-update.output.md
+++ b/unison-src/transcripts/block-on-required-update.output.md
@@ -8,6 +8,8 @@ x = 1
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -33,6 +35,8 @@ y = x + 1
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/blocks.output.md
+++ b/unison-src/transcripts/blocks.output.md
@@ -17,6 +17,8 @@ ex thing =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -47,6 +49,8 @@ ex thing =
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -81,6 +85,8 @@ ex thing =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -110,6 +116,8 @@ ex thing =
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -148,6 +156,8 @@ ex n =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -173,6 +183,8 @@ ex n =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -195,6 +207,8 @@ ex n =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   These definitions depend on each other cyclically but aren't guarded by a lambda: pong9
       2 |   pong = ping + 1
       3 |   ping = 42
@@ -211,6 +225,8 @@ ex n =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   These definitions depend on each other cyclically but aren't guarded by a lambda: loop9
       2 |   loop = loop
   
@@ -225,6 +241,8 @@ ex n =
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -253,6 +271,8 @@ ex n =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   The expression in red needs the {SpaceAttack} ability, but this location does not have access to any abilities.
   
       5 |   zap1 = launchMissiles "neptune" + zap2
@@ -274,6 +294,8 @@ ex n =
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -302,6 +324,8 @@ ex n =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -326,6 +350,8 @@ ex n =
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/boolean-op-pretty-print-2819.output.md
+++ b/unison-src/transcripts/boolean-op-pretty-print-2819.output.md
@@ -9,6 +9,8 @@ hangExample =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/bug-fix-4354.output.md
+++ b/unison-src/transcripts/bug-fix-4354.output.md
@@ -10,6 +10,8 @@ bonk x =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/bug-strange-closure.output.md
+++ b/unison-src/transcripts/bug-strange-closure.output.md
@@ -420,6 +420,8 @@ rendered = Pretty.get (docFormatConsole doc.guide)
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -850,6 +852,8 @@ rendered = Pretty.get (docFormatConsole doc.guide)
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/builtins.output.md
+++ b/unison-src/transcripts/builtins.output.md
@@ -363,6 +363,8 @@ test> Any.test2 = checks [(not (Any "hi" == Any 42))]
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -412,6 +414,8 @@ openFile]
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -464,6 +468,8 @@ openFilesIO = do
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -501,6 +507,8 @@ test> Universal.murmurHash.tests = checks [Universal.murmurHash [1,2,3] == Unive
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/bytesFromList.output.md
+++ b/unison-src/transcripts/bytesFromList.output.md
@@ -7,6 +7,8 @@ This should render as `Bytes.fromList [1,2,3,4]`, not `##Bytes.fromSequence [1,2
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   ✅
   
   scratch.u changed.

--- a/unison-src/transcripts/check763.output.md
+++ b/unison-src/transcripts/check763.output.md
@@ -7,6 +7,8 @@ Regression test for https://github.com/unisonweb/unison/issues/763
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/check873.output.md
+++ b/unison-src/transcripts/check873.output.md
@@ -6,6 +6,8 @@ See [this ticket](https://github.com/unisonweb/unison/issues/873); the point bei
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -28,6 +30,8 @@ baz x = x - 1
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/command-replace.output.md
+++ b/unison-src/transcripts/command-replace.output.md
@@ -12,6 +12,8 @@ structural type Y = Two Nat Nat
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/constructor-applied-to-unit.output.md
+++ b/unison-src/transcripts/constructor-applied-to-unit.output.md
@@ -7,6 +7,8 @@ structural type Zoink a b c = Zoink a b c
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/contrabilities.output.md
+++ b/unison-src/transcripts/contrabilities.output.md
@@ -5,6 +5,8 @@ f x = 42
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/cycle-update-1.output.md
+++ b/unison-src/transcripts/cycle-update-1.output.md
@@ -10,6 +10,8 @@ pong _ = !ping + 2
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -35,6 +37,8 @@ ping _ = !pong + 3
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/cycle-update-2.output.md
+++ b/unison-src/transcripts/cycle-update-2.output.md
@@ -10,6 +10,8 @@ pong _ = !ping + 2
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -35,6 +37,8 @@ ping _ = 3
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/cycle-update-3.output.md
+++ b/unison-src/transcripts/cycle-update-3.output.md
@@ -10,6 +10,8 @@ pong _ = !ping + 2
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -35,6 +37,8 @@ ping = 3
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/cycle-update-4.output.md
+++ b/unison-src/transcripts/cycle-update-4.output.md
@@ -10,6 +10,8 @@ pong _ = !ping + 2
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -38,6 +40,8 @@ clang _ = !pong + 3
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/cycle-update-5.output.md
+++ b/unison-src/transcripts/cycle-update-5.output.md
@@ -10,6 +10,8 @@ pong _ = !inner.ping + 2
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -38,6 +40,8 @@ inner.ping _ = !pong + 3
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/cycle-update-6.output.md
+++ b/unison-src/transcripts/cycle-update-6.output.md
@@ -19,6 +19,8 @@ inner.pong _ = !ping + 3
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -82,6 +84,8 @@ ping _ = ! #4t465jk908dsue9fgdfi06fihppsme16cvaua29hjm1585de1mvt11dftqrab5chhla3
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/debug-name-diffs.output.md
+++ b/unison-src/transcripts/debug-name-diffs.output.md
@@ -11,6 +11,8 @@ structural type a.b.Baz = Boo
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/deleteReplacements.output.md
+++ b/unison-src/transcripts/deleteReplacements.output.md
@@ -6,6 +6,8 @@ x = 1
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -28,6 +30,8 @@ x = 2
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -71,6 +75,8 @@ unique[a] type Foo = Foo
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -93,6 +99,8 @@ unique[b] type Foo = Foo | Bar
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -137,6 +145,8 @@ unique[aa] type bar = Foo
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -161,6 +171,8 @@ unique[bb] type bar = Foo | Bar
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -222,6 +234,8 @@ baz = 0
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -255,6 +269,8 @@ unique type qux = Qux
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/destructuring-binds.output.md
+++ b/unison-src/transcripts/destructuring-binds.output.md
@@ -16,6 +16,8 @@ ex1 tup =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -58,6 +60,8 @@ ex2 tup = match tup with
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -79,6 +83,8 @@ ex4 =
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I couldn't find any definitions matching the name a inside the namespace .
   
@@ -112,6 +118,8 @@ ex5a _ = match (99 + 1, "hi") with
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/diff-namespace.output.md
+++ b/unison-src/transcripts/diff-namespace.output.md
@@ -644,6 +644,8 @@ x = 1
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -668,6 +670,8 @@ y = 2
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/doc-formatting.output.md
+++ b/unison-src/transcripts/doc-formatting.output.md
@@ -11,6 +11,8 @@ foo n =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -37,6 +39,8 @@ escaping = [: Docs look [: like \@this \:] :]
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -67,6 +71,8 @@ commented = [:
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -101,6 +107,8 @@ doc1 = [:   hi   :]
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -130,6 +138,8 @@ doc2 = [: hello
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -167,6 +177,8 @@ Note that because of the special treatment of the first line mentioned above, wh
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -212,6 +224,8 @@ doc4 = [: Here's another example of some paragraphs.
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -245,6 +259,8 @@ doc5 = [:   - foo
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -274,6 +290,8 @@ doc6 = [:
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -305,6 +323,8 @@ expr = foo 1
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -364,6 +384,8 @@ para line lorem ipsum dolor lorem ipsum dolor lorem ipsum dolor lorem ipsum dolo
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -444,6 +466,8 @@ reg1363 = [: `@List.take foo` bar
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -471,6 +495,8 @@ test2 = [:
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/docs.output.md
+++ b/unison-src/transcripts/docs.output.md
@@ -30,6 +30,8 @@ Can link to definitions like @List.drop or @List
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -59,6 +61,8 @@ List.take.ex2 = take 2 [1,2,3,4,5]
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -101,6 +105,8 @@ docs.List.take = [:
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/duplicate-names.output.md
+++ b/unison-src/transcripts/duplicate-names.output.md
@@ -12,6 +12,8 @@ Stream.send _ = ()
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   ❗️
   
   I found multiple bindings with the name Stream.send:
@@ -33,6 +35,8 @@ X.x _ = ()
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   ❗️
   
   I found multiple bindings with the name X.x:
@@ -53,6 +57,8 @@ structural ability X where
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found two types called X:
   
       1 | structural type X = x 
@@ -71,6 +77,8 @@ X.x = ()
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   ❗️
   
@@ -102,6 +110,8 @@ X = ()
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/duplicate-term-detection.output.md
+++ b/unison-src/transcripts/duplicate-term-detection.output.md
@@ -9,6 +9,8 @@ x = 2
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   ❗️
   
   I found multiple bindings with the name x:
@@ -25,6 +27,8 @@ x = 1
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   ❗️
   
@@ -44,6 +48,8 @@ Record.x.modify = 2
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   ❗️
   
@@ -80,6 +86,8 @@ AnAbility.thing = 2
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   ❗️
   

--- a/unison-src/transcripts/error-messages.output.md
+++ b/unison-src/transcripts/error-messages.output.md
@@ -13,6 +13,8 @@ x = 1. -- missing some digits after the decimal
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   This number isn't valid syntax: 
   
       1 | x = 1. -- missing some digits after the decimal
@@ -26,6 +28,8 @@ x = 1e -- missing an exponent
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   This number isn't valid syntax: 
   
@@ -41,6 +45,8 @@ x = 1e- -- missing an exponent
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   This number isn't valid syntax: 
   
       1 | x = 1e- -- missing an exponent
@@ -54,6 +60,8 @@ x = 1E+ -- missing an exponent
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   This number isn't valid syntax: 
   
@@ -71,6 +79,8 @@ x = 0xoogabooga -- invalid hex chars
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   This number isn't valid syntax: 
   
       1 | x = 0xoogabooga -- invalid hex chars
@@ -84,6 +94,8 @@ x = 0o987654321 -- 9 and 8 are not valid octal char
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   This number isn't valid syntax: 
   
@@ -99,6 +111,8 @@ x = 0xsf -- odd number of hex chars in a bytes literal
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   This bytes literal isn't valid syntax: 0xsf
   
       1 | x = 0xsf -- odd number of hex chars in a bytes literal
@@ -112,6 +126,8 @@ x = 0xsnotvalidhexchars -- invalid hex chars in a bytes literal
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   This bytes literal isn't valid syntax: 0xsnotvalidhexchars
   
@@ -129,6 +145,8 @@ foo = else -- not matching if
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found a closing 'else' here without a matching 'then'.
   
       1 | foo = else -- not matching if
@@ -141,6 +159,8 @@ foo = then -- unclosed
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found a closing 'then' here without a matching 'if'.
   
       1 | foo = then -- unclosed
@@ -152,6 +172,8 @@ foo = with -- unclosed
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found a closing 'with' here without a matching 'handle' or 'match'.
   
@@ -167,6 +189,8 @@ foo = match 1 with
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
     😶
     
@@ -184,6 +208,8 @@ foo = match 1 with
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   offset=8:
   unexpected <outdent>
   expecting ",", case match, or pattern guard
@@ -198,6 +224,8 @@ foo = cases
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
     😶
     
@@ -220,6 +248,8 @@ x = match Some a with
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   offset=16:
   unexpected <outdent>
   expecting ",", blank, case match, false, pattern guard, or true
@@ -235,6 +265,8 @@ x = match Some a with
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   offset=12:
   unexpected ->
@@ -252,6 +284,8 @@ x = match Some a with
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   offset=12:
   unexpected |
   expecting newline or semicolon
@@ -268,6 +302,8 @@ x = match Some a with
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I expected a non-empty watch expression and not just ">"
   
       2 | >
@@ -282,6 +318,8 @@ use.keyword.in.namespace = 1
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   The identifier used here isn't allowed to be a reserved keyword: 
   
       1 | use.keyword.in.namespace = 1
@@ -294,6 +332,8 @@ a ! b = 1
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   This looks like the start of an expression here 
   

--- a/unison-src/transcripts/escape-sequences.output.md
+++ b/unison-src/transcripts/escape-sequences.output.md
@@ -6,6 +6,8 @@
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   ✅
   
   scratch.u changed.

--- a/unison-src/transcripts/find-command.output.md
+++ b/unison-src/transcripts/find-command.output.md
@@ -7,6 +7,8 @@ foo.lib.qux = 4
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/find-patch.output.md
+++ b/unison-src/transcripts/find-patch.output.md
@@ -11,6 +11,8 @@ hey = "yello"
 
 ```ucm
 
+  Loading changes detected in test.u.
+
   I found and typechecked these definitions in test.u. If you do
   an `add` or `update`, here's how your codebase would change:
   
@@ -39,6 +41,8 @@ hey = "hello"
 
 
 ```ucm
+
+  Loading changes detected in test.u.
 
   I found and typechecked these definitions in test.u. If you do
   an `add` or `update`, here's how your codebase would change:

--- a/unison-src/transcripts/fix-big-list-crash.output.md
+++ b/unison-src/transcripts/fix-big-list-crash.output.md
@@ -10,6 +10,8 @@ x = [(R,1005),(U,563),(R,417),(U,509),(L,237),(U,555),(R,397),(U,414),(L,490),(U
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix1063.output.md
+++ b/unison-src/transcripts/fix1063.output.md
@@ -10,6 +10,8 @@ noop = not . not
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix1334.output.md
+++ b/unison-src/transcripts/fix1334.output.md
@@ -27,6 +27,8 @@ h = f + 1
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -92,6 +94,8 @@ The value of `h` should have been updated too:
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   ✅
   

--- a/unison-src/transcripts/fix1356.output.md
+++ b/unison-src/transcripts/fix1356.output.md
@@ -8,6 +8,8 @@ x.doc = [: I am the documentation for x:]
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -54,6 +56,8 @@ x.doc = [: I am the documentation for x, and I now look better:]
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/fix1390.output.md
+++ b/unison-src/transcripts/fix1390.output.md
@@ -16,6 +16,8 @@ List.map f =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -53,6 +55,8 @@ List.map2 f =
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/fix1696.output.md
+++ b/unison-src/transcripts/fix1696.output.md
@@ -19,6 +19,8 @@ dialog = Ask.provide 'zoot '("Awesome number: " ++ Nat.toText Ask.ask ++ "!")
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I expected to see `structural` or `unique` at the start of
   this line:
   

--- a/unison-src/transcripts/fix1731.output.md
+++ b/unison-src/transcripts/fix1731.output.md
@@ -15,6 +15,8 @@ repro = cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix1844.output.md
+++ b/unison-src/transcripts/fix1844.output.md
@@ -12,6 +12,8 @@ snoc k aN = match k with
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix1926.output.md
+++ b/unison-src/transcripts/fix1926.output.md
@@ -12,6 +12,8 @@ sq = 2934892384
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -35,6 +37,8 @@ sq = 2934892384
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/fix2000.output.md
+++ b/unison-src/transcripts/fix2000.output.md
@@ -8,6 +8,8 @@ x.a.q = "ef"
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -57,6 +59,8 @@ y.a.p = "fij"
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -79,6 +83,8 @@ y.b.p = "wie"
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/fix2026.output.md
+++ b/unison-src/transcripts/fix2026.output.md
@@ -37,6 +37,8 @@ Exception.unsafeRun! e _ =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix2049.output.md
+++ b/unison-src/transcripts/fix2049.output.md
@@ -50,6 +50,8 @@ Fold.Stream.fold =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix2156.output.md
+++ b/unison-src/transcripts/fix2156.output.md
@@ -11,6 +11,8 @@ sqr n = n * n
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix2167.output.md
+++ b/unison-src/transcripts/fix2167.output.md
@@ -17,6 +17,8 @@ R.near1 region loc = match R.near 42 with
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix2187.output.md
+++ b/unison-src/transcripts/fix2187.output.md
@@ -15,6 +15,8 @@ lexicalScopeEx =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix2231.output.md
+++ b/unison-src/transcripts/fix2231.output.md
@@ -22,6 +22,8 @@ txt = foldl (Text.++) "" ["a", "b", "c"]
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix2238.output.md
+++ b/unison-src/transcripts/fix2238.output.md
@@ -9,6 +9,8 @@ ex = {{ @eval{abort} }}
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   The expression in red needs the {Abort} ability, but this location does not have access to any abilities.
   
       3 | ex = {{ @eval{abort} }}
@@ -19,6 +21,8 @@ This file should also not typecheck - it has a triple backticks block that uses 
 
 ```ucm
 .> load unison-src/transcripts/fix2238.u
+
+  Loading changes detected in unison-src/transcripts/fix2238.u.
 
   The expression in red needs the {Abort} ability, but this location does not have access to any abilities.
   

--- a/unison-src/transcripts/fix2254.output.md
+++ b/unison-src/transcripts/fix2254.output.md
@@ -125,6 +125,8 @@ combine r = uno r + dos r
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -163,6 +165,8 @@ structural type Rec = { uno : Nat, dos : Nat, tres : Text }
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/fix2268.output.md
+++ b/unison-src/transcripts/fix2268.output.md
@@ -17,6 +17,8 @@ test _ =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix2334.output.md
+++ b/unison-src/transcripts/fix2334.output.md
@@ -17,6 +17,8 @@ f = cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix2344.output.md
+++ b/unison-src/transcripts/fix2344.output.md
@@ -19,6 +19,8 @@ sneezy dee _ =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix2350.output.md
+++ b/unison-src/transcripts/fix2350.output.md
@@ -27,6 +27,8 @@ save a = !(save.impl a)
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix2353.output.md
+++ b/unison-src/transcripts/fix2353.output.md
@@ -13,6 +13,8 @@ pure.run a0 a =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix2354.output.md
+++ b/unison-src/transcripts/fix2354.output.md
@@ -11,6 +11,8 @@ x = 'f
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found a value  of type:  (a1 ->{𝕖} a1) ->{𝕖} Nat
   where I expected to find:  (a -> 𝕣1) -> 𝕣
   

--- a/unison-src/transcripts/fix2355.output.md
+++ b/unison-src/transcripts/fix2355.output.md
@@ -22,6 +22,8 @@ example = 'let
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I tried to infer a cyclic ability.
   
   The expression in red was inferred to require the ability: 

--- a/unison-src/transcripts/fix2378.output.md
+++ b/unison-src/transcripts/fix2378.output.md
@@ -41,6 +41,8 @@ x _ = Ex.catch '(C.pure.run '(A.pure.run ex))
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix2423.output.md
+++ b/unison-src/transcripts/fix2423.output.md
@@ -28,6 +28,8 @@ Split.zipSame sa sb _ =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix2474.output.md
+++ b/unison-src/transcripts/fix2474.output.md
@@ -38,6 +38,8 @@ Stream.uncons s =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix2663.output.md
+++ b/unison-src/transcripts/fix2663.output.md
@@ -21,6 +21,8 @@ bad x = match Some (Some x) with
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix2693.output.md
+++ b/unison-src/transcripts/fix2693.output.md
@@ -11,6 +11,8 @@ range = loop []
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -35,6 +37,8 @@ range = loop []
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   ✅
   
@@ -2055,6 +2059,8 @@ Should be cached:
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   ✅
   

--- a/unison-src/transcripts/fix2712.output.md
+++ b/unison-src/transcripts/fix2712.output.md
@@ -7,6 +7,8 @@ mapWithKey f m = Tip
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -39,6 +41,8 @@ naiomi =
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/fix2795.output.md
+++ b/unison-src/transcripts/fix2795.output.md
@@ -5,6 +5,9 @@
 
 .> load unison-src/transcripts/fix2795/docs.u
 
+  Loading changes detected in
+  unison-src/transcripts/fix2795/docs.u.
+
   I found and typechecked these definitions in
   unison-src/transcripts/fix2795/docs.u. If you do an `add` or
   `update`, here's how your codebase would change:

--- a/unison-src/transcripts/fix3037.output.md
+++ b/unison-src/transcripts/fix3037.output.md
@@ -15,6 +15,8 @@ runner = pureRunner
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found an ability mismatch when checking the expression in red
   
       3 | pureRunner : Runner {}
@@ -46,6 +48,8 @@ h _ = ()
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found an ability mismatch when checking the application
   

--- a/unison-src/transcripts/fix3171.output.md
+++ b/unison-src/transcripts/fix3171.output.md
@@ -11,6 +11,8 @@ f x y z _ = x + y * z
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix3196.output.md
+++ b/unison-src/transcripts/fix3196.output.md
@@ -29,6 +29,8 @@ w2 = cases W -> W
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix3215.output.md
+++ b/unison-src/transcripts/fix3215.output.md
@@ -18,6 +18,8 @@ f = cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix3244.output.md
+++ b/unison-src/transcripts/fix3244.output.md
@@ -17,6 +17,8 @@ foo t =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix3265.output.md
+++ b/unison-src/transcripts/fix3265.output.md
@@ -22,6 +22,8 @@ are three cases that need to be 'fixed up.'
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   ✅
   
   scratch.u changed.
@@ -64,6 +66,8 @@ discard its arguments, where `f` also occurs.
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   ✅
   

--- a/unison-src/transcripts/fix3634.output.md
+++ b/unison-src/transcripts/fix3634.output.md
@@ -12,6 +12,8 @@ d = {{
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix3678.output.md
+++ b/unison-src/transcripts/fix3678.output.md
@@ -11,6 +11,8 @@ arr = Scope.run do
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix3759.output.md
+++ b/unison-src/transcripts/fix3759.output.md
@@ -50,6 +50,8 @@ blah.frobnicate = "Yay!"
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix3773.output.md
+++ b/unison-src/transcripts/fix3773.output.md
@@ -10,6 +10,8 @@ foo =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix4172.output.md
+++ b/unison-src/transcripts/fix4172.output.md
@@ -14,6 +14,8 @@ allowDebug = debug [1,2,3]
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -59,6 +61,8 @@ bool = false
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/fix4397.output.md
+++ b/unison-src/transcripts/fix4397.output.md
@@ -9,6 +9,8 @@ unique type Bar
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   Kind mismatch arising from
         3 | unique type Baz = Baz (Foo Bar)
     

--- a/unison-src/transcripts/fix4415.output.md
+++ b/unison-src/transcripts/fix4415.output.md
@@ -6,6 +6,8 @@ unique type sub.Foo =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix4482.output.md
+++ b/unison-src/transcripts/fix4482.output.md
@@ -8,6 +8,8 @@ mybar = bar + bar
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix4498.output.md
+++ b/unison-src/transcripts/fix4498.output.md
@@ -7,6 +7,8 @@ myterm = foo + 2
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix4528.output.md
+++ b/unison-src/transcripts/fix4528.output.md
@@ -7,6 +7,8 @@ main _ = MkFoo 5
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix614.output.md
+++ b/unison-src/transcripts/fix614.output.md
@@ -13,6 +13,8 @@ ex1 = do
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -33,6 +35,8 @@ ex2 = do
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found a value  of type:  a ->{Stream a} Unit
   where I expected to find:  Unit
   
@@ -52,6 +56,8 @@ ex3 = do
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -74,6 +80,8 @@ ex4 =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -93,6 +101,8 @@ ex4 =
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found a value  of type:  [Nat]
   where I expected to find:  Unit

--- a/unison-src/transcripts/fix689.output.md
+++ b/unison-src/transcripts/fix689.output.md
@@ -9,6 +9,8 @@ tomorrow = '(SystemTime.systemTime + 24 * 60 * 60)
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix693.output.md
+++ b/unison-src/transcripts/fix693.output.md
@@ -9,6 +9,8 @@ structural ability Abort where
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -42,6 +44,8 @@ h0 req = match req with
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found a value  of type:  Optional a1
   where I expected to find:  Optional a
   
@@ -65,6 +69,8 @@ h1 req = match req with
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   Each case of a match / with expression need to have the same
   type.
@@ -94,6 +100,8 @@ h2 req = match req with
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   The 1st argument to `k`
   
             has type:  Nat
@@ -114,6 +122,8 @@ h3 = cases
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/fix845.output.md
+++ b/unison-src/transcripts/fix845.output.md
@@ -11,6 +11,8 @@ Text.zonk txt = txt ++ "!! "
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -29,6 +31,8 @@ Now, typecheck a file with a reference to `Blah.zonk` (which doesn't exist in th
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I couldn't find any definitions matching the name Blah.zonk inside the namespace .
   
@@ -61,6 +65,8 @@ ex = baz ++ ", world!"
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -88,6 +94,8 @@ ex = zonk "hi"
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -118,6 +126,8 @@ ex = zonk "hi" -- should resolve to Text.zonk, from the codebase
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/fix849.output.md
+++ b/unison-src/transcripts/fix849.output.md
@@ -9,6 +9,8 @@ x = 42
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/fix942.output.md
+++ b/unison-src/transcripts/fix942.output.md
@@ -8,6 +8,8 @@ z = y + 2
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -36,6 +38,8 @@ x = 7
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -82,6 +86,8 @@ test> t1 = if z == 3 then [Fail "nooo!!!"] else [Ok "great"]
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/fix987.output.md
+++ b/unison-src/transcripts/fix987.output.md
@@ -13,6 +13,8 @@ spaceAttack1 x =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -44,6 +46,8 @@ spaceAttack2 x =
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/hello.output.md
+++ b/unison-src/transcripts/hello.output.md
@@ -34,6 +34,8 @@ x = 42
 
 ```ucm
 
+  Loading changes detected in myfile.u.
+
   I found and typechecked these definitions in myfile.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -82,6 +84,8 @@ hmm = "Not, in fact, a number"
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found a value  of type:  Text
   where I expected to find:  Nat

--- a/unison-src/transcripts/higher-rank.output.md
+++ b/unison-src/transcripts/higher-rank.output.md
@@ -12,6 +12,8 @@ f id = (id 1, id "hi")
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -39,6 +41,8 @@ f id _ =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -64,6 +68,8 @@ Functor.blah = cases Functor f ->
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -106,6 +112,8 @@ Loc.transform2 nt = cases Loc f ->
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/io.output.md
+++ b/unison-src/transcripts/io.output.md
@@ -47,6 +47,8 @@ testCreateRename _ =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -126,6 +128,8 @@ testOpenClose _ =
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -214,6 +218,8 @@ testGetSomeBytes _ =
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -320,6 +326,8 @@ testAppend _ =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -377,6 +385,8 @@ testSystemTime _ =
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/kind-inference.output.md
+++ b/unison-src/transcripts/kind-inference.output.md
@@ -8,6 +8,8 @@ unique type T a = T a (a Nat)
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   Kind mismatch arising from
         1 | unique type T a = T a (a Nat)
     
@@ -22,6 +24,8 @@ unique type T a
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   Kind mismatch arising from
         3 |   | StarStar (a Nat)
@@ -39,6 +43,8 @@ unique type Pong = Pong (Ping Optional)
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -59,6 +65,8 @@ unique type Pong = Pong (Ping Optional)
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   Kind mismatch arising from
         1 | unique type Ping a = Ping a Pong
     
@@ -74,6 +82,8 @@ unique ability Pong a where
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -94,6 +104,8 @@ unique ability Pong a where
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   Kind mismatch arising from
         3 |   pong : Ping Optional -> ()
     
@@ -109,6 +121,8 @@ unique type S = S (T Nat)
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -131,6 +145,8 @@ unique type S = S (T Optional)
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -150,6 +166,8 @@ unique type S = S (T Optional)
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   Kind mismatch arising from
         3 | unique type S = S (T Optional)
     
@@ -167,6 +185,8 @@ test = 0
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   Kind mismatch arising from
         1 | test : Nat Nat
     
@@ -181,6 +201,8 @@ test _ = ()
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   Kind mismatch arising from
         1 | test : Optional -> ()
@@ -198,6 +220,8 @@ test _ = ()
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   Kind mismatch arising from
         3 | test : T Nat -> ()
@@ -220,6 +244,8 @@ test _ =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   Kind mismatch arising from
         6 |   buggo : Star a
     
@@ -240,6 +266,8 @@ test _ = ()
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   Kind mismatch arising from
         4 | test : Foo -> ()
     
@@ -254,6 +282,8 @@ test _ = ()
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   Kind mismatch arising from
         1 | test : {Nat} ()
@@ -271,6 +301,8 @@ unique type T a = T (a a)
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   Cannot construct infinite kind
         1 | unique type T a = T (a a)
     
@@ -284,6 +316,8 @@ unique type T a b = T (a b) (b a)
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   Cannot construct infinite kind
         1 | unique type T a b = T (a b) (b a)
@@ -299,6 +333,8 @@ unique type Pong a = Pong (a Ping)
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   Cannot construct infinite kind
         1 | unique type Ping a = Ping (a Pong)

--- a/unison-src/transcripts/lambdacase.output.md
+++ b/unison-src/transcripts/lambdacase.output.md
@@ -10,6 +10,8 @@ isEmpty x = match x with
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -28,6 +30,8 @@ isEmpty2 = cases
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -88,6 +92,8 @@ merge2 = cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -135,6 +141,8 @@ blorf = cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -173,6 +181,8 @@ merge3 = cases
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -213,6 +223,8 @@ merge4 a b = match (a,b) with
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/link.output.md
+++ b/unison-src/transcripts/link.output.md
@@ -12,6 +12,8 @@ coolFunction.doc = [: This is a cool function. :]
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -58,6 +60,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -125,6 +129,8 @@ myLibrary.h x = x + 3
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/ls-pretty-print-scope-bug.output.md
+++ b/unison-src/transcripts/ls-pretty-print-scope-bug.output.md
@@ -4,6 +4,8 @@ unique type Foo = Foo
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -35,6 +37,8 @@ unique type Foo = Foo
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -57,6 +61,8 @@ foo = .d.f.Foo.Foo
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/mergeloop.output.md
+++ b/unison-src/transcripts/mergeloop.output.md
@@ -10,6 +10,8 @@ a = 1
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -35,6 +37,8 @@ b = 2
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -58,6 +62,8 @@ b = 2
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked the definitions in scratch.u. This
   file has been previously added to the codebase.
 
@@ -77,6 +83,8 @@ a = 1
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -101,6 +109,8 @@ b = 2
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked the definitions in scratch.u. This
   file has been previously added to the codebase.

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -8,6 +8,8 @@ x = 42
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -53,6 +55,8 @@ y = "hello"
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -178,6 +182,8 @@ z = 99
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -213,6 +219,8 @@ master.frobnicate n = n + 1
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/move-all.output.md
+++ b/unison-src/transcripts/move-all.output.md
@@ -13,6 +13,8 @@ unique type Foo.T = T
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -42,6 +44,8 @@ unique type Foo.T = T1 | T2
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -111,6 +115,8 @@ bonk = 5
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -145,6 +151,8 @@ bonk.zonk = 5
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/move-namespace.output.md
+++ b/unison-src/transcripts/move-namespace.output.md
@@ -11,6 +11,8 @@ unique type a.T = T
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -38,6 +40,8 @@ unique type a.T = T1 | T2
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -102,6 +106,8 @@ b.termInB = 10
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -129,6 +135,8 @@ b.termInB = 11
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -194,6 +202,8 @@ b.termInB = 10
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -221,6 +231,8 @@ b.termInB = 11
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/name-selection.output.md
+++ b/unison-src/transcripts/name-selection.output.md
@@ -1558,6 +1558,8 @@ a = 10
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -1598,6 +1600,8 @@ other.value = 20
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/names.output.md
+++ b/unison-src/transcripts/names.output.md
@@ -14,6 +14,8 @@ somewhere.y = 2
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/numbered-args.output.md
+++ b/unison-src/transcripts/numbered-args.output.md
@@ -13,6 +13,8 @@ corge = "corge"
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/old-fold-right.output.md
+++ b/unison-src/transcripts/old-fold-right.output.md
@@ -13,6 +13,8 @@ pecan = 'let
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/pattern-match-coverage.output.md
+++ b/unison-src/transcripts/pattern-match-coverage.output.md
@@ -10,6 +10,8 @@ test = cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   Pattern match doesn't cover all possible cases:
         4 | test = cases
         5 |   A -> ()
@@ -33,6 +35,8 @@ test = cases
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   Pattern match doesn't cover all possible cases:
         4 | test = cases
@@ -60,6 +64,8 @@ test = cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   This case would be ignored because it's already covered by the preceding case(s):
         8 |   _ -> ()
     
@@ -79,6 +85,8 @@ test = cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   This case would be ignored because it's already covered by the preceding case(s):
         9 |   (A, Some A) -> ()
     
@@ -97,6 +105,8 @@ test = cases
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -119,6 +129,8 @@ test0 = cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   This case would be ignored because it's already covered by the preceding case(s):
         5 |   _ -> ()
     
@@ -136,6 +148,8 @@ test = cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   This case would be ignored because it's already covered by the preceding case(s):
         7 |   Some _ -> ()
     
@@ -151,6 +165,8 @@ test = cases
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   Pattern match doesn't cover all possible cases:
         2 | test = cases
@@ -170,6 +186,8 @@ test = cases
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   Pattern match doesn't cover all possible cases:
         2 | test = cases
@@ -193,6 +211,8 @@ test = cases
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -218,6 +238,8 @@ test = cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   Pattern match doesn't cover all possible cases:
         4 | test = cases
         5 |   None -> ()
@@ -239,6 +261,8 @@ test = cases
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   Pattern match doesn't cover all possible cases:
         4 | test = cases
@@ -266,6 +290,8 @@ test = cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   Pattern match doesn't cover all possible cases:
         2 | test = cases
         3 |   0 -> ()
@@ -283,6 +309,8 @@ test = cases
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   Pattern match doesn't cover all possible cases:
         2 | test = cases
@@ -305,6 +333,8 @@ test = cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -323,6 +353,8 @@ test = cases
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -346,6 +378,8 @@ test = cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   This case would be ignored because it's already covered by the preceding case(s):
         4 |   0 -> ()
     
@@ -361,6 +395,8 @@ test = cases
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   This case would be ignored because it's already covered by the preceding case(s):
         5 |   _ -> ()
@@ -378,6 +414,8 @@ test = cases
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -397,6 +435,8 @@ test = cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   Pattern match doesn't cover all possible cases:
         2 | test = cases
         3 |   [] -> ()
@@ -414,6 +454,8 @@ test = cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   Pattern match doesn't cover all possible cases:
         2 | test = cases
         3 |   x +: xs -> ()
@@ -430,6 +472,8 @@ test = cases
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   Pattern match doesn't cover all possible cases:
         2 | test = cases
@@ -449,6 +493,8 @@ test = cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   Pattern match doesn't cover all possible cases:
         2 | test = cases
         3 |   x0 +: (x1 +: xs) -> ()
@@ -467,6 +513,8 @@ test = cases
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   Pattern match doesn't cover all possible cases:
         2 | test = cases
@@ -490,6 +538,8 @@ test = cases
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -520,6 +570,8 @@ test = cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -541,6 +593,8 @@ test = cases
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   This case would be ignored because it's already covered by the preceding case(s):
         6 |   true +: xs -> ()
@@ -564,6 +618,8 @@ test = cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   This case would be ignored because it's already covered by the preceding case(s):
         5 |   _ ++ [true, false, true, false] -> ()
     
@@ -580,6 +636,8 @@ unit2t = cases
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -615,6 +673,8 @@ witht = match unit2t () with
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -632,6 +692,8 @@ evil = bug ""
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -660,6 +722,8 @@ withV = match evil () with
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   This case would be ignored because it's already covered by the preceding case(s):
         3 |   x -> ()
     
@@ -670,6 +734,8 @@ unique type SomeType = A
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -697,6 +763,8 @@ get x = match x with
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -712,6 +780,8 @@ unique type R = { someType : SomeType }
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -742,6 +812,8 @@ result f = handle !f with cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -766,6 +838,8 @@ result f = handle !f with cases
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -796,6 +870,8 @@ result f =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -824,6 +900,8 @@ handleMulti c =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -850,6 +928,8 @@ result f = handle !f with cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   Pattern match doesn't cover all possible cases:
         7 | result f = handle !f with cases
         8 |        { abort -> _ } -> bug "aborted"
@@ -875,6 +955,8 @@ result f = handle !f with cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   Pattern match doesn't cover all possible cases:
         7 | result f = handle !f with cases
         8 |        { A } -> ()
@@ -898,6 +980,8 @@ result f = handle !f with cases
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   Pattern match doesn't cover all possible cases:
         7 | result f = handle !f with cases
@@ -927,6 +1011,8 @@ handleMulti c =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   Pattern match doesn't cover all possible cases:
        10 |   impl xs = cases
        11 |     { r } -> (Some r, xs)
@@ -954,6 +1040,8 @@ result f = handle !f with cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   This case would be ignored because it's already covered by the preceding case(s):
        10 |        { give A -> resume } -> result resume
     
@@ -975,6 +1063,8 @@ result f = handle !f with cases
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -1002,6 +1092,8 @@ result f =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -1027,6 +1119,8 @@ result f = handle !f with cases
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   Pattern match doesn't cover all possible cases:
         7 | result f = handle !f with cases
@@ -1066,6 +1160,8 @@ result f =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   Pattern match doesn't cover all possible cases:
         8 |   impl = cases
         9 |        { x } -> x
@@ -1093,6 +1189,8 @@ result f =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -1118,6 +1216,8 @@ result f =
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -1145,6 +1245,8 @@ result f =
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   This case would be ignored because it's already covered by the preceding case(s):
        11 |        { give2 _ -> resume } -> bug "impossible"
@@ -1174,6 +1276,8 @@ result f =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   This case would be ignored because it's already covered by the preceding case(s):
        15 |        { giveA2 _ -> _ } -> bug "impossible"
     
@@ -1199,6 +1303,8 @@ result f =
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/pattern-pretty-print-2345.output.md
+++ b/unison-src/transcripts/pattern-pretty-print-2345.output.md
@@ -62,6 +62,8 @@ doc = cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/patternMatchTls.output.md
+++ b/unison-src/transcripts/patternMatchTls.output.md
@@ -24,6 +24,8 @@ assertRight = cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/project-merge.output.md
+++ b/unison-src/transcripts/project-merge.output.md
@@ -12,6 +12,8 @@ zonk = 0
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -67,6 +69,8 @@ bonk = 2
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -132,6 +136,8 @@ xonk = 1
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/propagate.output.md
+++ b/unison-src/transcripts/propagate.output.md
@@ -13,6 +13,8 @@ fooToInt _ = +42
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -62,6 +64,8 @@ unique type Foo = Foo | Bar
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -110,6 +114,8 @@ otherTerm y = someTerm y
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -145,6 +151,8 @@ someTerm _ = None
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -206,6 +214,8 @@ otherTerm y = someTerm y
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -245,6 +255,8 @@ someTerm _ = None
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/records.output.md
+++ b/unison-src/transcripts/records.output.md
@@ -95,6 +95,8 @@ unique type Record5 =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/reflog.output.md
+++ b/unison-src/transcripts/reflog.output.md
@@ -7,6 +7,8 @@ x = 1
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -29,6 +31,8 @@ y = 2
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/release-draft-command.output.md
+++ b/unison-src/transcripts/release-draft-command.output.md
@@ -8,6 +8,8 @@ someterm = 18
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/reset.output.md
+++ b/unison-src/transcripts/reset.output.md
@@ -5,6 +5,8 @@ a = 5
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -53,6 +55,8 @@ foo.a = 5
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -126,6 +130,8 @@ a = 5
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -164,6 +170,8 @@ a = 3
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -205,6 +213,8 @@ main.a = 3
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -255,6 +265,8 @@ main.a = 3
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked the definitions in scratch.u. This
   file has been previously added to the codebase.

--- a/unison-src/transcripts/resolution-failures.output.md
+++ b/unison-src/transcripts/resolution-failures.output.md
@@ -24,6 +24,8 @@ two.ambiguousTerm = "term two"
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -73,6 +75,8 @@ separateAmbiguousTypeUsage _ = ()
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   
     ❓
     
@@ -105,6 +109,8 @@ useAmbiguousTerm = ambiguousTerm
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I couldn't find any definitions matching the name ambiguousTerm inside the namespace .example.resolution_failures
   

--- a/unison-src/transcripts/resolve.output.md
+++ b/unison-src/transcripts/resolve.output.md
@@ -18,6 +18,8 @@ a.foo = 42
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -63,6 +65,8 @@ foo = 43
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -92,6 +96,8 @@ foo = 44
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/scope-ref.output.md
+++ b/unison-src/transcripts/scope-ref.output.md
@@ -16,6 +16,8 @@ test = Scope.run 'let
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/suffixes.output.md
+++ b/unison-src/transcripts/suffixes.output.md
@@ -71,6 +71,8 @@ lib.distributed.lib.baz.qux = "indirect dependency"
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -100,6 +102,8 @@ lib.distributed.lib.baz.qux = "indirect dependency"
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   ✅
   
@@ -185,6 +189,8 @@ fn = cases
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/sum-type-update-conflicts.output.md
+++ b/unison-src/transcripts/sum-type-update-conflicts.output.md
@@ -10,6 +10,8 @@ structural type X = x
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -45,6 +47,8 @@ dependsOnX = Text.size X.x
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/switch-command.output.md
+++ b/unison-src/transcripts/switch-command.output.md
@@ -8,6 +8,8 @@ someterm = 18
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/tab-completion.output.md
+++ b/unison-src/transcripts/tab-completion.output.md
@@ -41,6 +41,8 @@ unique type subnamespace.AType = A | B
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -143,6 +145,8 @@ add b = b
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -213,6 +217,8 @@ mybranchsubnamespace.term = 1
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/test-command.output.md
+++ b/unison-src/transcripts/test-command.output.md
@@ -9,6 +9,8 @@ test1 = [Ok "test1"]
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -58,6 +60,8 @@ testInLib = [Ok "testInLib"]
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/text-literals.output.md
+++ b/unison-src/transcripts/text-literals.output.md
@@ -34,6 +34,8 @@ lit2 = """"
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/todo-bug-builtins.output.md
+++ b/unison-src/transcripts/todo-bug-builtins.output.md
@@ -7,6 +7,8 @@
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   ✅
   
   scratch.u changed.
@@ -32,6 +34,8 @@
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   ✅
   
@@ -61,6 +65,8 @@ complicatedMathStuff x = todo "Come back and to something with x here"
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -79,6 +85,8 @@ test = match true with
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/todo.output.md
+++ b/unison-src/transcripts/todo.output.md
@@ -141,6 +141,8 @@ foo = 801
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -163,6 +165,8 @@ foo = 802
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -187,6 +191,8 @@ oldfoo = 801
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -233,6 +239,8 @@ odd = cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -257,6 +265,8 @@ even = 17
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/top-level-exceptions.output.md
+++ b/unison-src/transcripts/top-level-exceptions.output.md
@@ -27,6 +27,8 @@ mytest _ = [Ok "Great"]
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -73,6 +75,8 @@ unique type RuntimeError =
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/transcript-parser-commands.output.md
+++ b/unison-src/transcripts/transcript-parser-commands.output.md
@@ -8,6 +8,8 @@ x = 1
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/type-deps.output.md
+++ b/unison-src/transcripts/type-deps.output.md
@@ -17,6 +17,8 @@ structural type Y = Y Nat
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/type-modifier-required.output.md
+++ b/unison-src/transcripts/type-modifier-required.output.md
@@ -8,6 +8,8 @@ type Abc = Abc
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I expected to see `structural` or `unique` at the start of
   this line:
   
@@ -25,6 +27,8 @@ ability MyAbility where const : a
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I expected to see `structural` or `unique` at the start of
   this line:
@@ -46,6 +50,8 @@ unique ability MyAbilityU where const : a
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/unique-type-churn.output.md
+++ b/unison-src/transcripts/unique-type-churn.output.md
@@ -10,6 +10,8 @@ unique type C = C B
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -40,6 +42,8 @@ unique type C = C B
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked the definitions in scratch.u. This
   file has been previously added to the codebase.
 
@@ -65,6 +69,8 @@ unique type A = A ()
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
@@ -102,6 +108,8 @@ unique type A = A
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/unitnamespace.output.md
+++ b/unison-src/transcripts/unitnamespace.output.md
@@ -4,6 +4,8 @@ foo = "bar"
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/universal-cmp.output.md
+++ b/unison-src/transcripts/universal-cmp.output.md
@@ -13,6 +13,8 @@ threadEyeDeez _ =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -44,6 +46,8 @@ threadEyeDeez _ =
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   ✅
   

--- a/unison-src/transcripts/unsafe-coerce.output.md
+++ b/unison-src/transcripts/unsafe-coerce.output.md
@@ -14,6 +14,8 @@ main _ =
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/update-ignores-lib-namespace.output.md
+++ b/unison-src/transcripts/update-ignores-lib-namespace.output.md
@@ -9,6 +9,8 @@ lib.foo = 100
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -33,6 +35,8 @@ foo = 200
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/update-on-conflict.output.md
+++ b/unison-src/transcripts/update-on-conflict.output.md
@@ -7,6 +7,8 @@ b.x = 2
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -71,6 +73,8 @@ x = 3
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/update-term-aliases-in-different-ways.output.md
+++ b/unison-src/transcripts/update-term-aliases-in-different-ways.output.md
@@ -14,6 +14,8 @@ bar = 5
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -42,6 +44,8 @@ bar = 7
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/update-term-to-different-type.output.md
+++ b/unison-src/transcripts/update-term-to-different-type.output.md
@@ -11,6 +11,8 @@ foo = 5
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -34,6 +36,8 @@ foo = +5
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/update-term-with-alias.output.md
+++ b/unison-src/transcripts/update-term-with-alias.output.md
@@ -14,6 +14,8 @@ bar = 5
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -39,6 +41,8 @@ foo = 6
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/update-term-with-dependent-to-different-type.output.md
+++ b/unison-src/transcripts/update-term-with-dependent-to-different-type.output.md
@@ -14,6 +14,8 @@ bar = foo + 10
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -39,6 +41,8 @@ foo = +5
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/update-term-with-dependent.output.md
+++ b/unison-src/transcripts/update-term-with-dependent.output.md
@@ -14,6 +14,8 @@ bar = foo + 10
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -39,6 +41,8 @@ foo = 6
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/update-term.output.md
+++ b/unison-src/transcripts/update-term.output.md
@@ -11,6 +11,8 @@ foo = 5
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -34,6 +36,8 @@ foo = 6
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/update-test-to-non-test.output.md
+++ b/unison-src/transcripts/update-test-to-non-test.output.md
@@ -10,6 +10,8 @@ test> foo = []
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -45,6 +47,8 @@ foo = 1
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/update-test-watch-roundtrip.output.md
+++ b/unison-src/transcripts/update-test-watch-roundtrip.output.md
@@ -26,6 +26,8 @@ foo n = "hello, world!"
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/update-type-add-constructor.output.md
+++ b/unison-src/transcripts/update-type-add-constructor.output.md
@@ -5,6 +5,8 @@ unique type Foo
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -29,6 +31,8 @@ unique type Foo
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/update-type-add-field.output.md
+++ b/unison-src/transcripts/update-type-add-field.output.md
@@ -4,6 +4,8 @@ unique type Foo = Bar Nat
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -26,6 +28,8 @@ unique type Foo = Bar Nat Nat
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/update-type-add-new-record.output.md
+++ b/unison-src/transcripts/update-type-add-new-record.output.md
@@ -4,6 +4,8 @@ unique type Foo = { bar : Nat }
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/update-type-add-record-field.output.md
+++ b/unison-src/transcripts/update-type-add-record-field.output.md
@@ -4,6 +4,8 @@ unique type Foo = { bar : Nat }
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -32,6 +34,8 @@ unique type Foo = { bar : Nat, baz : Int }
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/update-type-constructor-alias.output.md
+++ b/unison-src/transcripts/update-type-constructor-alias.output.md
@@ -4,6 +4,8 @@ unique type Foo = Bar Nat
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -30,6 +32,8 @@ unique type Foo = Bar Nat Nat
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/update-type-delete-constructor-with-dependent.output.md
+++ b/unison-src/transcripts/update-type-delete-constructor-with-dependent.output.md
@@ -11,6 +11,8 @@ foo = cases
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -36,6 +38,8 @@ unique type Foo
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/update-type-delete-constructor.output.md
+++ b/unison-src/transcripts/update-type-delete-constructor.output.md
@@ -6,6 +6,8 @@ unique type Foo
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -29,6 +31,8 @@ unique type Foo
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/update-type-delete-record-field.output.md
+++ b/unison-src/transcripts/update-type-delete-record-field.output.md
@@ -4,6 +4,8 @@ unique type Foo = { bar : Nat, baz : Int }
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -38,6 +40,8 @@ unique type Foo = { bar : Nat }
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/update-type-missing-constructor.output.md
+++ b/unison-src/transcripts/update-type-missing-constructor.output.md
@@ -4,6 +4,8 @@ unique type Foo = Bar Nat
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -32,6 +34,8 @@ unique type Foo = Bar Nat Nat
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/update-type-nested-decl-aliases.output.md
+++ b/unison-src/transcripts/update-type-nested-decl-aliases.output.md
@@ -7,6 +7,8 @@ structural type A = B.TheOtherAlias Foo
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -33,6 +35,8 @@ unique type Foo = Bar Nat Nat
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/update-type-no-op-record.output.md
+++ b/unison-src/transcripts/update-type-no-op-record.output.md
@@ -4,6 +4,8 @@ unique type Foo = { bar : Nat }
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/update-type-stray-constructor-alias.output.md
+++ b/unison-src/transcripts/update-type-stray-constructor-alias.output.md
@@ -4,6 +4,8 @@ unique type Foo = Bar Nat
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -30,6 +32,8 @@ unique type Foo = Bar Nat Nat
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/update-type-stray-constructor.output.md
+++ b/unison-src/transcripts/update-type-stray-constructor.output.md
@@ -4,6 +4,8 @@ unique type Foo = Bar Nat
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -32,6 +34,8 @@ unique type Foo = Bar Nat Nat
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/update-type-turn-constructor-into-smart-constructor.output.md
+++ b/unison-src/transcripts/update-type-turn-constructor-into-smart-constructor.output.md
@@ -7,6 +7,8 @@ makeFoo n = Bar (n+10)
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -34,6 +36,8 @@ Foo.Bar n = internal.Bar n
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/update-type-turn-non-record-into-record.output.md
+++ b/unison-src/transcripts/update-type-turn-non-record-into-record.output.md
@@ -4,6 +4,8 @@ unique type Foo = Nat
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -26,6 +28,8 @@ unique type Foo = { bar : Nat }
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/update-type-with-dependent-term.output.md
+++ b/unison-src/transcripts/update-type-with-dependent-term.output.md
@@ -7,6 +7,8 @@ incrFoo = cases Bar n -> Bar (n+1)
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -31,6 +33,8 @@ unique type Foo = Bar Nat Nat
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/update-type-with-dependent-type-to-different-kind.output.md
+++ b/unison-src/transcripts/update-type-with-dependent-type-to-different-kind.output.md
@@ -5,6 +5,8 @@ unique type Baz = Qux Foo
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -29,6 +31,8 @@ unique type Foo a = Bar Nat a
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/update-type-with-dependent-type.output.md
+++ b/unison-src/transcripts/update-type-with-dependent-type.output.md
@@ -5,6 +5,8 @@ unique type Baz = Qux Foo
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -29,6 +31,8 @@ unique type Foo = Bar Nat Nat
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would

--- a/unison-src/transcripts/update-watch.output.md
+++ b/unison-src/transcripts/update-watch.output.md
@@ -4,6 +4,8 @@
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   ✅
   
   scratch.u changed.

--- a/unison-src/transcripts/upgrade-happy-path.output.md
+++ b/unison-src/transcripts/upgrade-happy-path.output.md
@@ -6,6 +6,8 @@ thingy = lib.old.foo + 10
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/upgrade-sad-path.output.md
+++ b/unison-src/transcripts/upgrade-sad-path.output.md
@@ -6,6 +6,8 @@ thingy = lib.old.foo + 10
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/upgrade-with-old-alias.output.md
+++ b/unison-src/transcripts/upgrade-with-old-alias.output.md
@@ -7,6 +7,8 @@ mything = lib.old.foo + 100
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:

--- a/unison-src/transcripts/watch-expressions.output.md
+++ b/unison-src/transcripts/watch-expressions.output.md
@@ -10,6 +10,8 @@ test> pass = [Ok "Passed"]
 
 ```ucm
 
+  Loading changes detected in scratch.u.
+
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
@@ -39,6 +41,8 @@ test> pass = [Ok "Passed"]
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   I found and typechecked the definitions in scratch.u. This
   file has been previously added to the codebase.
@@ -74,6 +78,8 @@ test> pass = [Ok "Passed"]
 ```
 
 ```ucm
+
+  Loading changes detected in scratch.u.
 
   ✅
   


### PR DESCRIPTION
## Overview

Addressing this [issue](https://github.com/unisonweb/unison/issues/4532) 

## Implementation notes

The original issue refers to [this bit of ucm code](https://github.com/unisonweb/unison/blob/715cf108b60102ffac9ffb9e71c9b5b53f11e37a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs#L222) and it is indeed relevant, but for what I found it could be probably best to add the message one level deeper, so we could skip printing the message if the event was programmatically generated.

## Interesting/controversial decisions

The change is trivial

## Test coverage

* Updated the transcripts
* Tested manually. ![Screenshot 2023-12-22 at 14 07 49](https://github.com/unisonweb/unison/assets/25188/115bb604-c536-4b33-ad27-bfad6d3691c3)

## Loose ends

None
