### PR TITLE
Use explicit 'writeSource' method when writing back to scratch files from UCM

### DIFF
--- a/parser-typechecker/src/Unison/Util/TQueue.hs
+++ b/parser-typechecker/src/Unison/Util/TQueue.hs
@@ -8,7 +8,7 @@ import UnliftIO.STM hiding (TQueue)
 
 data TQueue a = TQueue (TVar (Seq a)) (TVar Word64)
 
-newIO :: (MonadIO m) => m (TQueue a)
+newIO :: forall a m. (MonadIO m) => m (TQueue a)
 newIO = TQueue <$> newTVarIO mempty <*> newTVarIO 0
 
 size :: TQueue a -> STM Int

--- a/unison-cli/src/Unison/Cli/Monad.hs
+++ b/unison-cli/src/Unison/Cli/Monad.hs
@@ -46,7 +46,6 @@ module Unison.Cli.Monad
 
     -- * Misc types
     LoadSourceResult (..),
-    WriteSourceAction (..),
   )
 where
 
@@ -164,7 +163,7 @@ data Env = Env
     -- | How to load source code.
     loadSource :: SourceName -> IO LoadSourceResult,
     -- | How to write source code.
-    writeSource :: SourceName -> WriteSourceAction -> IO (),
+    writeSource :: SourceName -> Text -> IO (),
     -- | What to do with output for the user.
     notify :: Output -> IO (),
     -- | What to do with numbered output for the user.
@@ -252,14 +251,6 @@ data LoadSourceResult
   = InvalidSourceNameError
   | LoadError
   | LoadSuccess Text
-
--- | The result of calling 'loadSource'.
-data WriteSourceAction
-  = -- Append the given text to the source. (include fold, contents)
-    PrependSource Bool Text
-  | -- Overwrite the source with the given text.
-    OverwriteSource Text
-  deriving stock (Eq, Show)
 
 -- | Lift an action of type @IO (Either e a)@, given a continuation for @e@.
 ioE :: IO (Either e a) -> (e -> Cli a) -> Cli a

--- a/unison-cli/src/Unison/Cli/Monad.hs
+++ b/unison-cli/src/Unison/Cli/Monad.hs
@@ -5,6 +5,7 @@ module Unison.Cli.Monad
   ( -- * Cli monad
     Cli,
     ReturnType (..),
+    SourceName,
     runCli,
 
     -- * Envronment
@@ -143,6 +144,9 @@ data ReturnType a
   | HaltRepl
   deriving stock (Eq, Show)
 
+-- | Name used for a source-file/source buffer
+type SourceName = Text
+
 -- | The command-line app monad environment.
 --
 -- Get the environment with 'ask'.
@@ -157,7 +161,9 @@ data Env = Env
     -- information to the terminal to be captured in transcript output.
     isTranscript :: Bool,
     -- | How to load source code.
-    loadSource :: Text -> IO LoadSourceResult,
+    loadSource :: SourceName -> IO LoadSourceResult,
+    -- | How to write source code.
+    writeSource :: SourceName -> Text -> IO (),
     -- | What to do with output for the user.
     notify :: Output -> IO (),
     -- | What to do with numbered output for the user.

--- a/unison-cli/src/Unison/Cli/Monad.hs
+++ b/unison-cli/src/Unison/Cli/Monad.hs
@@ -46,6 +46,7 @@ module Unison.Cli.Monad
 
     -- * Misc types
     LoadSourceResult (..),
+    WriteSourceAction (..),
   )
 where
 
@@ -163,7 +164,7 @@ data Env = Env
     -- | How to load source code.
     loadSource :: SourceName -> IO LoadSourceResult,
     -- | How to write source code.
-    writeSource :: SourceName -> Text -> IO (),
+    writeSource :: SourceName -> WriteSourceAction -> IO (),
     -- | What to do with output for the user.
     notify :: Output -> IO (),
     -- | What to do with numbered output for the user.
@@ -251,6 +252,14 @@ data LoadSourceResult
   = InvalidSourceNameError
   | LoadError
   | LoadSuccess Text
+
+-- | The result of calling 'loadSource'.
+data WriteSourceAction
+  = -- Append the given text to the source. (include fold, contents)
+    PrependSource Bool Text
+  | -- Overwrite the source with the given text.
+    OverwriteSource Text
+  deriving stock (Eq, Show)
 
 -- | Lift an action of type @IO (Either e a)@, given a continuation for @e@.
 ioE :: IO (Either e a) -> (e -> Cli a) -> Cli a

--- a/unison-cli/src/Unison/Cli/Pretty.hs
+++ b/unison-cli/src/Unison/Cli/Pretty.hs
@@ -40,6 +40,7 @@ module Unison.Cli.Pretty
     prettyTypeResultHeader',
     prettyTypeResultHeaderFull',
     prettyURI,
+    prettyUnisonFile,
     prettyWhichBranchEmpty,
     prettyWriteGitRepo,
     prettyWriteRemoteNamespace,
@@ -49,6 +50,9 @@ module Unison.Cli.Pretty
 where
 
 import Control.Lens hiding (at)
+import Control.Monad.Writer (Writer, mapWriter, runWriter)
+import Data.Map qualified as Map
+import Data.Set qualified as Set
 import Data.Text qualified as Text
 import Data.Time (UTCTime)
 import Data.Time.Format.Human (HumanTimeLocale (..), defaultHumanTimeLocale, humanReadableTimeI18N')
@@ -56,6 +60,7 @@ import Network.URI (URI)
 import Network.URI qualified as URI
 import Network.URI.Encode qualified as URI
 import U.Codebase.HashTags (CausalHash (..))
+import U.Codebase.Reference qualified as Reference
 import U.Codebase.Sqlite.Project qualified as Sqlite
 import U.Codebase.Sqlite.ProjectBranch qualified as Sqlite
 import U.Util.Base32Hex (Base32Hex)
@@ -64,7 +69,7 @@ import Unison.Cli.ProjectUtils (projectBranchPathPrism)
 import Unison.Cli.Share.Projects.Types qualified as Share
 import Unison.Codebase.Editor.DisplayObject (DisplayObject (BuiltinObject, MissingObject, UserObject))
 import Unison.Codebase.Editor.Input qualified as Input
-import Unison.Codebase.Editor.Output (WhichBranchEmpty (..))
+import Unison.Codebase.Editor.Output
 import Unison.Codebase.Editor.RemoteRepo
   ( ReadGitRepo,
     ReadRemoteNamespace,
@@ -81,6 +86,7 @@ import Unison.Codebase.ShortCausalHash (ShortCausalHash)
 import Unison.Codebase.ShortCausalHash qualified as SCH
 import Unison.Core.Project (ProjectBranchName)
 import Unison.DataDeclaration qualified as DD
+import Unison.Debug qualified as Debug
 import Unison.Hash qualified as Hash
 import Unison.Hash32 (Hash32)
 import Unison.Hash32 qualified as Hash32
@@ -90,19 +96,30 @@ import Unison.LabeledDependency as LD
 import Unison.Name (Name)
 import Unison.NameSegment (NameSegment (..))
 import Unison.NameSegment qualified as NameSegment
+import Unison.NamesWithHistory qualified as Names
 import Unison.Prelude
 import Unison.PrettyPrintEnv qualified as PPE
+import Unison.PrettyPrintEnv.Names qualified as PPE
+import Unison.PrettyPrintEnvDecl qualified as PPED
 import Unison.Project (ProjectAndBranch (..), ProjectName, Semver (..))
 import Unison.Reference (Reference)
 import Unison.Reference qualified as Reference
 import Unison.Referent (Referent)
 import Unison.Server.SearchResult' qualified as SR'
 import Unison.Sync.Types qualified as Share
+import Unison.Syntax.DeclPrinter (AccessorName)
 import Unison.Syntax.DeclPrinter qualified as DeclPrinter
+import Unison.Syntax.HashQualified qualified as HQ (unsafeFromVar)
 import Unison.Syntax.NamePrinter (prettyHashQualified, styleHashQualified')
+import Unison.Syntax.TermPrinter qualified as TermPrinter
 import Unison.Syntax.TypePrinter qualified as TypePrinter
+import Unison.Term (Term)
+import Unison.UnisonFile qualified as UF
+import Unison.UnisonFile.Names qualified as UF
 import Unison.Util.Pretty qualified as P
 import Unison.Var (Var)
+import Unison.Var qualified as Var
+import Unison.WatchKind qualified as WK
 
 type Pretty = P.Pretty P.ColorText
 
@@ -371,3 +388,46 @@ prettyLabeledDependencies ppe lds =
     ld = \case
       LD.TermReferent r -> prettyHashQualified (PPE.termNameOrHashOnly ppe r)
       LD.TypeReference r -> "type " <> prettyHashQualified (PPE.typeNameOrHashOnly ppe r)
+
+prettyUnisonFile :: forall v a. (Var v, Ord a) => PPED.PrettyPrintEnvDecl -> UF.UnisonFile v a -> P.Pretty P.ColorText
+prettyUnisonFile ppe uf@(UF.UnisonFileId datas effects terms watches) =
+  P.sep "\n\n" (map snd . sortOn fst $ prettyEffects <> prettyDatas <> catMaybes prettyTerms <> prettyWatches)
+  where
+    prettyEffects = map prettyEffectDecl (Map.toList effects)
+    (prettyDatas, accessorNames) = runWriter $ traverse prettyDataDecl (Map.toList datas)
+    prettyTerms = map (prettyTerm accessorNames) terms
+    prettyWatches = Map.toList watches >>= \(wk, tms) -> map (prettyWatch . (wk,)) tms
+
+    prettyEffectDecl :: (v, (Reference.Id, DD.EffectDeclaration v a)) -> (a, P.Pretty P.ColorText)
+    prettyEffectDecl (n, (r, et)) =
+      (DD.annotation . DD.toDataDecl $ et, st $ DeclPrinter.prettyDecl ppe' (rd r) (hqv n) (Left et))
+    prettyDataDecl :: (v, (Reference.Id, DD.DataDeclaration v a)) -> Writer (Set AccessorName) (a, P.Pretty P.ColorText)
+    prettyDataDecl (n, (r, dt)) =
+      (DD.annotation dt,) . st <$> (mapWriter (second Set.fromList) $ DeclPrinter.prettyDeclW ppe' (rd r) (hqv n) (Right dt))
+    prettyTerm :: Set (AccessorName) -> (v, a, Term v a) -> Maybe (a, P.Pretty P.ColorText)
+    prettyTerm skip (n, a, tm) =
+      if traceMember isMember then Nothing else Just (a, pb hq tm)
+      where
+        traceMember =
+          if Debug.shouldDebug Debug.Update
+            then trace (show hq ++ " -> " ++ if isMember then "skip" else "print")
+            else id
+        isMember = Set.member hq skip
+        hq = hqv n
+    prettyWatch :: (String, (v, a, Term v a)) -> (a, P.Pretty P.ColorText)
+    prettyWatch (wk, (n, a, tm)) = (a, go wk n tm)
+      where
+        go wk v tm = case wk of
+          WK.RegularWatch
+            | Var.UnnamedWatch _ _ <- Var.typeOf v ->
+                "> " <> P.indentNAfterNewline 2 (TermPrinter.pretty sppe tm)
+          WK.RegularWatch -> "> " <> pb (hqv v) tm
+          WK.TestWatch -> "test> " <> st (TermPrinter.prettyBindingWithoutTypeSignature sppe (hqv v) tm)
+          w -> P.string w <> "> " <> pb (hqv v) tm
+    st = P.syntaxToColor
+    sppe = PPED.suffixifiedPPE ppe'
+    pb v tm = st $ TermPrinter.prettyBinding sppe v tm
+    ppe' = PPED.PrettyPrintEnvDecl dppe dppe `PPED.addFallback` ppe
+    dppe = PPE.fromNames 8 (Names.NamesWithHistory (UF.toNames uf) mempty)
+    rd = Reference.DerivedId
+    hqv v = HQ.unsafeFromVar v

--- a/unison-cli/src/Unison/Cli/Pretty.hs
+++ b/unison-cli/src/Unison/Cli/Pretty.hs
@@ -466,7 +466,7 @@ prettyTermDisplayObjects pped isSourceFile isTest terms =
     & Map.toList
     & map (\(ref, dt) -> (PPE.termName unsuffixifiedPPE (Referent.Ref ref), ref, dt))
     & List.sortBy (\(n0, _, _) (n1, _, _) -> Name.compareAlphabetical n0 n1)
-    & map (\t -> prettyTerm pped (fromMaybe False . fmap isTest . Reference.toId $ (t ^. _2)) isSourceFile t)
+    & map (\t -> prettyTerm pped isSourceFile (fromMaybe False . fmap isTest . Reference.toId $ (t ^. _2)) t)
   where
     unsuffixifiedPPE = PPED.unsuffixifiedPPE pped
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1763,14 +1763,13 @@ handleShowDefinition outputLoc showDefinitionScope inputQuery = do
     Cli.runTransaction (Backend.definitionsByName codebase nameSearch includeCycles NamesWithHistory.IncludeSuffixes query)
   outputPath <- getOutputPath
   case outputPath of
-    _ | null types && null terms -> Cli.respond $ DisplayDefinitions Nothing
     Nothing -> do
       -- If we're writing to console we don't add test-watch syntax
       let isTest _ = False
       let isSourceFile = False
       -- No filepath, render code to console.
       let renderedCodePretty = renderCodePretty pped isSourceFile isTest terms types
-      Cli.respond $ DisplayDefinitions (Just renderedCodePretty)
+      Cli.respond $ DisplayDefinitions renderedCodePretty
     Just fp -> do
       -- We need an 'isTest' check in the output layer, so it can prepend "test>" to tests in a scratch file. Since we
       -- currently have the whole branch in memory, we just use that to make our predicate, but this could/should get this

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1783,7 +1783,7 @@ handleShowDefinition outputLoc showDefinitionScope inputQuery = do
       -- are viewing these definitions to a file - this will skip the
       -- next update for that file (which will happen immediately)
       #latestFile ?= (fp, True)
-      liftIO $ writeSource (Text.pack fp) (Cli.PrependSource True renderedCodeText)
+      liftIO $ writeSource (Text.pack fp) renderedCodeText
       Cli.respond $ LoadedDefinitionsToSourceFile fp renderedCodePretty
   when (not (null misses)) (Cli.respond (SearchTermsNotFound misses))
   where

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1724,7 +1724,7 @@ handleDiffNamespaceToPatch description input = do
 -- | Handle a @ShowDefinitionI@ input command, i.e. `view` or `edit`.
 handleShowDefinition :: OutputLocation -> ShowDefinitionScope -> [HQ.HashQualified Name] -> Cli ()
 handleShowDefinition outputLoc showDefinitionScope inputQuery = do
-  Cli.Env {codebase} <- ask
+  Cli.Env {codebase, writeSource} <- ask
   hqLength <- Cli.runTransaction Codebase.hashLength
   -- If the query is empty, run a fuzzy search.
   query <-
@@ -1767,6 +1767,7 @@ handleShowDefinition outputLoc showDefinitionScope inputQuery = do
     testRefs <- Cli.runTransaction (Codebase.filterTermsByReferenceIdHavingType codebase (DD.testResultType mempty) (Map.keysSet terms & Set.mapMaybe Reference.toId))
     let isTest r = Set.member r testRefs
 
+    liftIO $ writeSource (Text.pack <$> outputPath) (Cli.PrependSource True _)
     Cli.respond $
       DisplayDefinitions
         DisplayDefinitionsOutput

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1763,6 +1763,7 @@ handleShowDefinition outputLoc showDefinitionScope inputQuery = do
     Cli.runTransaction (Backend.definitionsByName codebase nameSearch includeCycles NamesWithHistory.IncludeSuffixes query)
   outputPath <- getOutputPath
   case outputPath of
+    _ | null terms && null types -> pure ()
     Nothing -> do
       -- If we're writing to console we don't add test-watch syntax
       let isTest _ = False

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1772,9 +1772,7 @@ handleShowDefinition outputLoc showDefinitionScope inputQuery = do
       let renderedCodePretty = renderCodePretty pped isSourceFile isTest terms types
       Cli.respond $ DisplayDefinitions renderedCodePretty
     Just fp -> do
-      -- We need an 'isTest' check in the output layer, so it can prepend "test>" to tests in a scratch file. Since we
-      -- currently have the whole branch in memory, we just use that to make our predicate, but this could/should get this
-      -- information from the database instead, once it's efficient to do so.
+      -- We build an 'isTest' check to prepend "test>" to tests in a scratch file.
       testRefs <- Cli.runTransaction (Codebase.filterTermsByReferenceIdHavingType codebase (DD.testResultType mempty) (Map.keysSet terms & Set.mapMaybe Reference.toId))
       let isTest r = Set.member r testRefs
       let isSourceFile = True

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/FindAndReplace.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/FindAndReplace.hs
@@ -62,8 +62,7 @@ handleStructuredFindReplaceI rule = do
   #latestTypecheckedFile .= Just (Left . snd $ uf')
   let msg = "| Rewrote using: "
   let rendered = Text.pack . P.toPlain 80 $ renderRewrittenFile ppe msg uf'
-  let addFold = True
-  liftIO $ writeSource (Text.pack dest) (Cli.PrependSource addFold rendered)
+  liftIO $ writeSource (Text.pack dest) rendered
   Cli.respond $ OutputRewrittenFile dest vs
 
 handleStructuredFindI :: HQ.HashQualified Name -> Cli ()

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/FindAndReplace.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/FindAndReplace.hs
@@ -1,0 +1,144 @@
+module Unison.Codebase.Editor.HandleInput.FindAndReplace
+  ( handleStructuredFindReplaceI,
+    handleStructuredFindI,
+  )
+where
+
+import Control.Lens hiding (at)
+import Control.Monad.Reader (ask)
+import Control.Monad.State
+import Data.Set qualified as Set
+import Data.Text qualified as Text
+import Unison.ABT qualified as ABT
+import Unison.Builtin.Decls qualified as DD
+import Unison.Cli.Monad (Cli)
+import Unison.Cli.Monad qualified as Cli
+import Unison.Cli.MonadUtils qualified as Cli
+import Unison.Cli.Pretty qualified as P
+import Unison.Codebase qualified as Codebase
+import Unison.Codebase.Branch.Names qualified as Branch
+import Unison.Codebase.Editor.Output
+import Unison.HashQualified qualified as HQ
+import Unison.HashQualified' qualified as HQ'
+import Unison.Name (Name)
+import Unison.Name qualified as Name
+import Unison.Names qualified as Names
+import Unison.NamesWithHistory (NamesWithHistory (..))
+import Unison.NamesWithHistory qualified as NamesWithHistory
+import Unison.Parser.Ann (Ann (..))
+import Unison.Prelude
+import Unison.PrettyPrintEnv qualified as PPE
+import Unison.PrettyPrintEnvDecl qualified as PPE hiding (biasTo, empty)
+import Unison.PrettyPrintEnvDecl qualified as PPED
+import Unison.PrettyPrintEnvDecl.Names qualified as PPED
+import Unison.Reference qualified as Reference
+import Unison.Referent (Referent)
+import Unison.Referent qualified as Referent
+import Unison.Symbol (Symbol)
+import Unison.Syntax.HashQualified qualified as HQ (toVar)
+import Unison.Term (Term)
+import Unison.Term qualified as Term
+import Unison.UnisonFile qualified as UF
+import Unison.Util.Alphabetical qualified as Alphabetical
+import Unison.Util.Pretty qualified as P
+import Unison.Util.Relation qualified as Relation
+import Unison.Var (Var)
+import Unison.Var qualified as Var
+
+handleStructuredFindReplaceI :: HQ.HashQualified Name -> Cli ()
+handleStructuredFindReplaceI rule = do
+  Cli.Env {writeSource} <- ask
+  uf0 <- Cli.expectLatestParsedFile
+  let (prepare, uf, finish) = UF.prepareRewrite uf0
+  (ppe, _ns, rules) <- lookupRewrite InvalidStructuredFindReplace prepare rule
+  (dest, _) <- Cli.expectLatestFile
+  #latestFile ?= (dest, True)
+  let go n tm [] = if n == (0 :: Int) then Nothing else Just tm
+      go n tm ((r, _) : rules) = case r tm of
+        Nothing -> go n tm rules
+        Just tm -> go (n + 1) tm rules
+      (vs, uf0') = UF.rewrite (Set.singleton (HQ.toVar rule)) (\tm -> go 0 tm rules) uf
+      uf' = (vs, finish uf0')
+  #latestTypecheckedFile .= Just (Left . snd $ uf')
+  let msg = "| Rewrote using: "
+  let rendered = Text.pack . P.toPlain 80 $ renderRewrittenFile ppe msg uf'
+  let addFold = True
+  liftIO $ writeSource (Text.pack dest) (Cli.PrependSource addFold rendered)
+  Cli.respond $ OutputRewrittenFile dest vs
+
+handleStructuredFindI :: HQ.HashQualified Name -> Cli ()
+handleStructuredFindI rule = do
+  Cli.Env {codebase} <- ask
+  (ppe, names, rules0) <- lookupRewrite InvalidStructuredFind (\_ tm -> tm) rule
+  let rules = snd <$> rules0
+  let fqppe = PPED.unsuffixifiedPPE ppe
+  results :: [(HQ.HashQualified Name, Referent)] <- pure $ do
+    r <- Set.toList (Relation.ran $ Names.terms (NamesWithHistory.currentNames names))
+    Just hq <- [PPE.terms fqppe r]
+    fullName <- [HQ'.toName hq]
+    guard (not (Name.beginsWithSegment fullName Name.libSegment))
+    Referent.Ref _ <- pure r
+    Just shortName <- [PPE.terms (PPED.suffixifiedPPE ppe) r]
+    pure (HQ'.toHQ shortName, r)
+  let ok t@(_, Referent.Ref (Reference.DerivedId r)) = do
+        oe <- Cli.runTransaction (Codebase.getTerm codebase r)
+        pure $ (t, maybe False (\e -> any ($ e) rules) oe)
+      ok t = pure (t, False)
+  results0 <- traverse ok results
+  let results = Alphabetical.sortAlphabeticallyOn fst [(hq, r) | ((hq, r), True) <- results0]
+  let toNumArgs = Text.unpack . Reference.toText . Referent.toReference . view _2
+  #numberedArgs .= map toNumArgs results
+  Cli.respond (ListStructuredFind (fst <$> results))
+
+lookupRewrite :: (HQ.HashQualified Name -> Output) -> ([Symbol] -> Term Symbol Ann -> Term Symbol Ann) -> HQ.HashQualified Name -> Cli (PPED.PrettyPrintEnvDecl, NamesWithHistory, [(Term Symbol Ann -> Maybe (Term Symbol Ann), Term Symbol Ann -> Bool)])
+lookupRewrite onErr prepare rule = do
+  Cli.Env {codebase} <- ask
+  currentBranch <- Cli.getCurrentBranch0
+  hqLength <- Cli.runTransaction Codebase.hashLength
+  fileNames <- Cli.getNamesFromLatestParsedFile
+  let currentNames = NamesWithHistory.fromCurrentNames (fileNames <> Branch.toNames currentBranch)
+  let ppe = PPED.fromNamesDecl hqLength currentNames
+  ot <- Cli.getTermFromLatestParsedFile rule
+  ot <- case ot of
+    Just _ -> pure ot
+    Nothing -> do
+      case NamesWithHistory.lookupHQTerm NamesWithHistory.IncludeSuffixes rule currentNames of
+        s
+          | Set.size s == 1,
+            Referent.Ref (Reference.DerivedId r) <- Set.findMin s ->
+              Cli.runTransaction (Codebase.getTerm codebase r)
+        s -> Cli.returnEarly (TermAmbiguous (PPE.suffixifiedPPE ppe) rule s)
+  tm <- maybe (Cli.returnEarly (TermAmbiguous (PPE.suffixifiedPPE ppe) rule mempty)) pure ot
+  let extract vs tm = case tm of
+        Term.Ann' tm _typ -> extract vs tm
+        (DD.RewriteTerm' lhs rhs) ->
+          pure
+            ( ABT.rewriteExpression lhs rhs,
+              ABT.containsExpression lhs
+            )
+        (DD.RewriteCase' lhs rhs) ->
+          pure
+            ( Term.rewriteCasesLHS lhs rhs,
+              fromMaybe False . Term.containsCaseTerm lhs
+            )
+        (DD.RewriteSignature' _vs lhs rhs) ->
+          pure (Term.rewriteSignatures lhs rhs, Term.containsSignature lhs)
+        _ -> Cli.returnEarly (onErr rule)
+      extractOuter vs0 tm = case tm of
+        Term.Ann' tm _typ -> extractOuter vs0 tm
+        Term.LamsNamed' vs tm -> extractOuter (vs0 ++ vs) tm
+        tm -> case prepare vs0 tm of
+          DD.Rewrites' rules -> traverse (extract vs0) rules
+          _ -> Cli.returnEarly (onErr rule)
+  rules <- extractOuter [] tm
+  pure (ppe, currentNames, rules)
+
+renderRewrittenFile :: (Ord a, Var v) => PPED.PrettyPrintEnvDecl -> String -> ([v], UF.UnisonFile v a) -> P.Pretty P.ColorText
+renderRewrittenFile ppe msg (vs, uf) = do
+  let prettyVar = P.text . Var.name
+      modifiedDefs = P.sep " " (P.blue . prettyVar <$> vs)
+      header = "-- " <> P.string msg <> "\n" <> "-- | Modified definition(s): " <> modifiedDefs
+   in (header <> "\n\n" <> P.prettyUnisonFile ppe uf <> foldLine)
+  where
+    foldLine :: (IsString s) => P.Pretty s
+    foldLine = "\n\n---- Anything below this line is ignored by Unison.\n\n"

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
@@ -32,6 +32,7 @@ import Unison.Builtin.Decls qualified as Decls
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli
+import Unison.Cli.Pretty qualified as Pretty
 import Unison.Cli.TypeCheck (computeTypecheckingEnvironment)
 import Unison.Cli.UniqueTypeGuidLookup qualified as Cli
 import Unison.Codebase qualified as Codebase
@@ -44,7 +45,6 @@ import Unison.Codebase.Editor.Output qualified as Output
 import Unison.Codebase.Path (Path)
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.Type (Codebase)
-import Unison.CommandLine.OutputMessages qualified as Output
 import Unison.ConstructorReference (GConstructorReference (ConstructorReference))
 import Unison.DataDeclaration (DataDeclaration, Decl)
 import Unison.DataDeclaration qualified as Decl
@@ -161,7 +161,7 @@ prettyParseTypecheck ::
   Cli (Either (Pretty Pretty.ColorText) (TypecheckedUnisonFile Symbol Ann))
 prettyParseTypecheck bigUf pped parsingEnv = do
   Cli.Env {codebase} <- ask
-  let prettyUf = Output.prettyUnisonFile pped bigUf
+  let prettyUf = Pretty.prettyUnisonFile pped bigUf
   let stringUf = Pretty.toPlain 80 prettyUf
   Debug.whenDebug Debug.Update do
     liftIO do

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -250,7 +250,7 @@ data Output
   | Typechecked SourceName PPE.PrettyPrintEnv SlurpResult (UF.TypecheckedUnisonFile Symbol Ann)
   | DisplayRendered (Maybe FilePath) (P.Pretty P.ColorText)
   | -- "display" definitions, possibly to a FilePath on disk (e.g. editing)
-    DisplayDefinitions (Maybe (P.Pretty P.ColorText))
+    DisplayDefinitions (P.Pretty P.ColorText)
   | -- Like `DisplayDefinitions`, but the definitions are already rendered. `Nothing` means put to the terminal.
     DisplayDefinitionsString !(Maybe FilePath) !(P.Pretty P.ColorText {- rendered definitions -})
   | LoadedDefinitionsToSourceFile FilePath (P.Pretty P.ColorText)
@@ -519,7 +519,7 @@ isFailure o = case o of
   Evaluated {} -> False
   Typechecked {} -> False
   LoadedDefinitionsToSourceFile {} -> False
-  DisplayDefinitions code -> isNothing code
+  DisplayDefinitions {} -> False
   DisplayDefinitionsString {} -> False -- somewhat arbitrary :shrug:
   DisplayRendered {} -> False
   TestIncrementalOutputStart {} -> False

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -381,7 +381,7 @@ data Output
       (ProjectAndBranch ProjectName ProjectBranchName)
       (ProjectAndBranch ProjectName ProjectBranchName)
   | RenamedProject ProjectName ProjectName
-  | OutputRewrittenFile PPE.PrettyPrintEnvDecl FilePath String ([Symbol {- symbols rewritten -}], UF.UnisonFile Symbol Ann)
+  | OutputRewrittenFile FilePath ([Symbol {- symbols rewritten -}])
   | RenamedProjectBranch ProjectName ProjectBranchName ProjectBranchName
   | CantRenameBranchTo ProjectBranchName
   | FetchingLatestReleaseOfBase

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -249,9 +249,9 @@ data Output
   | RunResult PPE.PrettyPrintEnv (Term Symbol ())
   | Typechecked SourceName PPE.PrettyPrintEnv SlurpResult (UF.TypecheckedUnisonFile Symbol Ann)
   | DisplayRendered (Maybe FilePath) (P.Pretty P.ColorText)
-  | -- "display" definitions, possibly to a FilePath on disk (e.g. editing)
+  | -- "display" the provided code to the console.
     DisplayDefinitions (P.Pretty P.ColorText)
-  | -- Like `DisplayDefinitions`, but the definitions are already rendered. `Nothing` means put to the terminal.
+  | -- Like `DisplayDefinitions`, but the definitions are already rendered. `Nothing` means they were output to the terminal.
     DisplayDefinitionsString !(Maybe FilePath) !(P.Pretty P.ColorText {- rendered definitions -})
   | LoadedDefinitionsToSourceFile FilePath (P.Pretty P.ColorText)
   | TestIncrementalOutputStart PPE.PrettyPrintEnv (Int, Int) TermReferenceId

--- a/unison-cli/src/Unison/Codebase/TranscriptParser.hs
+++ b/unison-cli/src/Unison/Codebase/TranscriptParser.hs
@@ -393,7 +393,7 @@ run verbosity dir stanzas codebase runtime sbRuntime nRuntime config ucmVersion 
                     liftIO (output "```ucm\n")
                     atomically . Q.enqueue cmdQueue $ Nothing
                     let sourceName = fromMaybe "scratch.u" filename
-                    liftIO $ writeSourceFile sourceName (Cli.OverwriteSource txt)
+                    liftIO $ writeSourceFile sourceName txt
                     pure $ Left (UnisonFileChanged sourceName txt)
                   API apiRequests -> do
                     liftIO (output "```api\n")
@@ -424,17 +424,9 @@ run verbosity dir stanzas codebase runtime sbRuntime nRuntime config ucmVersion 
             let f = Cli.LoadSuccess <$> readUtf8 (Text.unpack name)
              in f <|> pure Cli.InvalidSourceNameError
 
-      writeSourceFile :: ScratchFileName -> Cli.WriteSourceAction -> IO ()
-      writeSourceFile fp action = do
-        case action of
-          Cli.PrependSource addFold txt -> do
-            let theFold = case addFold of
-                  True -> "\n---\n"
-                  False -> ""
-            let prepend existing = txt <> theFold <> existing
-            liftIO (modifyIORef' unisonFiles (Map.alter (Just . prepend . fromMaybe "") fp))
-          Cli.OverwriteSource txt -> do
-            liftIO (modifyIORef' unisonFiles (Map.insert fp txt))
+      writeSourceFile :: ScratchFileName -> Text -> IO ()
+      writeSourceFile fp contents = do
+        liftIO (modifyIORef' unisonFiles (Map.insert fp contents))
 
       print :: Output.Output -> IO ()
       print o = do

--- a/unison-cli/src/Unison/Codebase/TranscriptParser.hs
+++ b/unison-cli/src/Unison/Codebase/TranscriptParser.hs
@@ -274,7 +274,7 @@ run verbosity dir stanzas codebase runtime sbRuntime nRuntime config ucmVersion 
   seedRef <- newIORef (0 :: Int)
   inputQueue <- Q.newIO
   cmdQueue <- Q.newIO @(Either EndFence UcmLine)
-  unisonFiles <- newIORef Map.empty
+  unisonFiles <- newIORef @(Map Cli.SourceName Text) Map.empty
   out <- newIORef mempty
   hidden <- newIORef Shown
   allowErrors <- newIORef False
@@ -459,6 +459,10 @@ run verbosity dir stanzas codebase runtime sbRuntime nRuntime config ucmVersion 
             let f = Cli.LoadSuccess <$> readUtf8 (Text.unpack name)
              in f <|> pure Cli.InvalidSourceNameError
 
+      writeSourceFile :: Cli.SourceName -> Text -> IO ()
+      writeSourceFile name contents = do
+        modifyIORef' unisonFiles (Map.insert name contents)
+
       print :: Output.Output -> IO ()
       print o = do
         msg <- notifyUser dir o
@@ -533,6 +537,7 @@ run verbosity dir stanzas codebase runtime sbRuntime nRuntime config ucmVersion 
               pure (Parser.uniqueBase32Namegen (Random.drgNewSeed (Random.seedFromInteger (fromIntegral i)))),
             isTranscript = True, -- we are running a transcript
             loadSource = loadPreviousUnisonBlock,
+            writeSource = writeSourceFile,
             notify = print,
             notifyNumbered = printNumbered,
             runtime,

--- a/unison-cli/src/Unison/Codebase/TranscriptParser.hs
+++ b/unison-cli/src/Unison/Codebase/TranscriptParser.hs
@@ -19,6 +19,8 @@ module Unison.Codebase.TranscriptParser
 where
 
 import Control.Lens (use, (?~), (^.))
+import Control.Monad.Reader
+import Control.Monad.State
 import Crypto.Random qualified as Random
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Encode.Pretty qualified as Aeson
@@ -102,6 +104,9 @@ data Hidden = Shown | HideOutput | HideAll
 data UcmLine
   = UcmCommand UcmContext Text
   | UcmComment Text -- Text does not include the '--' prefix.
+
+data EndFence
+  = EndFence FenceType
 
 -- | Where a command is run: either loose code (.foo.bar.baz>) or a project branch (myproject/mybranch>).
 data UcmContext
@@ -268,7 +273,7 @@ run verbosity dir stanzas codebase runtime sbRuntime nRuntime config ucmVersion 
             \_codeserverID -> pure $ Right accessToken
   seedRef <- newIORef (0 :: Int)
   inputQueue <- Q.newIO
-  cmdQueue <- Q.newIO
+  cmdQueue <- Q.newIO @(Either EndFence UcmLine)
   unisonFiles <- newIORef Map.empty
   out <- newIORef mempty
   hidden <- newIORef Shown
@@ -311,21 +316,47 @@ run verbosity dir stanzas codebase runtime sbRuntime nRuntime config ucmVersion 
                 output . (<> "\n") . BL.unpack $ prettyBytes
               Left err -> dieWithMsg ("Error decoding response from " <> Text.unpack path <> ": " <> err)
 
+      -- If we detect programmatic changes to the transcript, output those to a 'unison' fence
+      -- in the transcript output and clear the 'programmatic changes' flag.
+      trackScratchFileChanges :: Cli ()
+      trackScratchFileChanges = do
+        loopState <- get
+        case Cli.latestFile loopState of
+          Just (scratchFilePath, True) -> do
+            getSource <- asks Cli.loadSource
+            liftIO (getSource $ Text.pack scratchFilePath) >>= \case
+              Cli.InvalidSourceNameError ->
+                liftIO $ dieWithMsg ("Couldn't load changes from invalid source name: " <> scratchFilePath)
+              Cli.LoadError ->
+                liftIO $ dieWithMsg ("Failed to load changes from source name: " <> scratchFilePath)
+              Cli.LoadSuccess scratchFileContents -> do
+                let changedScratchFileFence = "\n```scratch-file-update " <> Text.pack scratchFilePath <> "\n" <> scratchFileContents <> "\n```\n"
+                liftIO . output . Text.unpack $ changedScratchFileFence
+                put $ loopState {Cli.latestFile = Just (scratchFilePath, False)}
+          _ -> pure ()
+
       awaitInput :: Cli (Either Event Input)
       awaitInput = do
         cmd <- atomically (Q.tryDequeue cmdQueue)
         case cmd of
           -- end of ucm block
-          Just Nothing -> do
+          Just (Left (EndFence "ucm")) -> do
             liftIO (output "\n```\n")
             -- We clear the file cache after each `ucm` stanza, so
             -- that `load` command can read the file written by `edit`
             -- rather than hitting the cache.
             liftIO (writeIORef unisonFiles Map.empty)
-            liftIO dieUnexpectedSuccess
+            -- Detect whether the UCM stanza we processed had any programmatic changes to the scratch file.
+            -- If so, output those changes to the transcript output.
+            trackScratchFileChanges
+            liftIO dieIfUnexpectedSuccess
+            awaitInput
+          Just (Left {}) -> do
+            liftIO (output "\n```\n")
+            liftIO dieIfUnexpectedSuccess
             awaitInput
           -- ucm command to run
-          Just (Just ucmLine) -> do
+          Just (Right ucmLine) -> do
             case ucmLine of
               p@(UcmComment {}) -> do
                 liftIO (output ("\n" <> show p))
@@ -350,7 +381,7 @@ run verbosity dir stanzas codebase runtime sbRuntime nRuntime config ucmVersion 
                           else Just (ProjectSwitchI (Just $ ProjectAndBranchNames'Unambiguous (These projectName branchName)))
                 case maybeSwitchCommand of
                   Just switchCommand -> do
-                    atomically $ Q.undequeue cmdQueue (Just p)
+                    atomically $ Q.undequeue cmdQueue (Right p)
                     pure (Right switchCommand)
                   Nothing -> do
                     case words . Text.unpack $ lineTxt of
@@ -365,7 +396,7 @@ run verbosity dir stanzas codebase runtime sbRuntime nRuntime config ucmVersion 
                           Left msg -> liftIO (dieWithMsg $ Pretty.toPlain terminalWidth msg)
                           Right input -> pure $ Right input
           Nothing -> do
-            liftIO (dieUnexpectedSuccess)
+            liftIO (dieIfUnexpectedSuccess)
             liftIO (writeIORef hidden Shown)
             liftIO (writeIORef allowErrors False)
             maybeStanza <- atomically (Q.tryDequeue inputQueue)
@@ -395,7 +426,7 @@ run verbosity dir stanzas codebase runtime sbRuntime nRuntime config ucmVersion 
                     liftIO (outputEcho $ show s)
                     liftIO (writeIORef allowErrors errOk)
                     liftIO (output "```ucm\n")
-                    atomically . Q.enqueue cmdQueue $ Nothing
+                    atomically . Q.enqueue cmdQueue $ Left $ EndFence "unison"
                     liftIO (modifyIORef' unisonFiles (Map.insert (fromMaybe "scratch.u" filename) txt))
                     pure $ Left (UnisonFileChanged (fromMaybe "scratch.u" filename) txt)
                   API apiRequests -> do
@@ -408,8 +439,8 @@ run verbosity dir stanzas codebase runtime sbRuntime nRuntime config ucmVersion 
                     liftIO (writeIORef allowErrors errOk)
                     liftIO (writeIORef hasErrors False)
                     liftIO (output "```ucm")
-                    traverse_ (atomically . Q.enqueue cmdQueue . Just) cmds
-                    atomically . Q.enqueue cmdQueue $ Nothing
+                    traverse_ (atomically . Q.enqueue cmdQueue . Right) cmds
+                    atomically . Q.enqueue cmdQueue $ Left $ EndFence "ucm"
                     awaitInput
 
       loadPreviousUnisonBlock name = do
@@ -417,7 +448,8 @@ run verbosity dir stanzas codebase runtime sbRuntime nRuntime config ucmVersion 
         case Map.lookup name ufs of
           Just uf ->
             return (Cli.LoadSuccess uf)
-          Nothing ->
+          Nothing -> do
+            liftIO $ putStrLn ("No previous unison block named " ++ show name)
             -- This lets transcripts use the `load` command, as in:
             --
             -- .> load someFile.u
@@ -474,8 +506,8 @@ run verbosity dir stanzas codebase runtime sbRuntime nRuntime config ucmVersion 
               Text.pack msg
             ]
 
-      dieUnexpectedSuccess :: IO ()
-      dieUnexpectedSuccess = do
+      dieIfUnexpectedSuccess :: IO ()
+      dieIfUnexpectedSuccess = do
         errOk <- readIORef allowErrors
         hasErr <- readIORef hasErrors
         when (errOk && not hasErr) $ do

--- a/unison-cli/src/Unison/Codebase/TranscriptParser.hs
+++ b/unison-cli/src/Unison/Codebase/TranscriptParser.hs
@@ -318,10 +318,6 @@ run verbosity dir stanzas codebase runtime sbRuntime nRuntime config ucmVersion 
           -- end of ucm block
           Just Nothing -> do
             liftIO (output "\n```\n")
-            -- We clear the file cache after each `ucm` stanza, so
-            -- that `load` command can read the file written by `edit`
-            -- rather than hitting the cache.
-            liftIO (writeIORef unisonFiles Map.empty)
             liftIO dieUnexpectedSuccess
             awaitInput
           -- ucm command to run

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -219,6 +219,8 @@ main dir welcome initialPath config initialInputs runtime sbRuntime nRuntime cod
                 writeIORef pageOutput True
                 pure x
 
+  let foldLine :: Text
+      foldLine = "\n\n---- Anything below this line is ignored by Unison.\n\n"
   let prependToFile :: Bool -> Text -> FilePath -> IO ()
       prependToFile addFold contents fp = do
         exists <- Directory.doesFileExist fp
@@ -226,7 +228,7 @@ main dir welcome initialPath config initialInputs runtime sbRuntime nRuntime cod
           if exists
             then readUtf8 fp
             else pure ""
-        let theFold = if addFold then "\n---\n" else ""
+        let theFold = if addFold then foldLine else ""
         writeUtf8 fp (Text.concat [contents, theFold, existingSource])
 
   let writeSourceFile :: Text -> Cli.WriteSourceAction -> IO ()

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -226,6 +226,7 @@ main dir welcome initialPath config initialInputs runtime sbRuntime nRuntime cod
             credentialManager,
             isTranscript = False, -- we are not running a transcript
             loadSource = loadSourceFile,
+            writeSource = \fp contents -> writeUtf8 (Text.unpack fp) contents,
             generateUniqueName = Parser.uniqueBase32Namegen <$> Random.getSystemDRG,
             notify,
             notifyNumbered = \o ->

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -221,22 +221,19 @@ main dir welcome initialPath config initialInputs runtime sbRuntime nRuntime cod
 
   let foldLine :: Text
       foldLine = "\n\n---- Anything below this line is ignored by Unison.\n\n"
-  let prependToFile :: Bool -> Text -> FilePath -> IO ()
-      prependToFile addFold contents fp = do
+  let prependToFile :: Text -> FilePath -> IO ()
+      prependToFile contents fp = do
         exists <- Directory.doesFileExist fp
         existingSource <-
           if exists
             then readUtf8 fp
             else pure ""
-        let theFold = if addFold then foldLine else ""
-        writeUtf8 fp (Text.concat [contents, theFold, existingSource])
+        writeUtf8 fp (Text.concat [contents, foldLine, existingSource])
 
-  let writeSourceFile :: Text -> Cli.WriteSourceAction -> IO ()
-      writeSourceFile fp action = do
+  let writeSourceFile :: Text -> Text -> IO ()
+      writeSourceFile fp contents = do
         path <- Directory.canonicalizePath (Text.unpack fp)
-        case action of
-          Cli.OverwriteSource contents -> writeUtf8 (Text.unpack fp) contents
-          Cli.PrependSource addFold contents -> prependToFile addFold contents path
+        prependToFile contents path
 
   let env =
         Cli.Env

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -773,7 +773,7 @@ notifyUser dir = \case
                 <> makeExample' IP.update
                 <> "to replace the definitions currently in this namespace."
           ]
-  DisplayDefinitions output -> displayDefinitions output
+  DisplayDefinitions code -> pure code
   DisplayDefinitionsString isTranscript definitions -> displayDefinitionsString isTranscript definitions
   OutputRewrittenFile dest vs -> displayOutputRewrittenFile dest vs
   DisplayRendered outputLoc pp ->
@@ -2590,12 +2590,6 @@ displayRendered outputLoc pp =
             "",
             P.indentN 2 pp
           ]
-
-displayDefinitions :: _ -> IO Pretty
-displayDefinitions mayRenderedCode =
-  case mayRenderedCode of
-    Nothing -> pure $ P.callout "😶" "No results to display."
-    Just code -> pure code
 
 displayDefinitionsString :: Maybe FilePath -> Pretty -> IO Pretty
 displayDefinitionsString maybePath definitions =

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -52,6 +52,7 @@ library
       Unison.Codebase.Editor.HandleInput.BranchRename
       Unison.Codebase.Editor.HandleInput.DeleteBranch
       Unison.Codebase.Editor.HandleInput.DeleteProject
+      Unison.Codebase.Editor.HandleInput.FindAndReplace
       Unison.Codebase.Editor.HandleInput.Load
       Unison.Codebase.Editor.HandleInput.MetadataUtils
       Unison.Codebase.Editor.HandleInput.MoveAll

--- a/unison-src/transcripts/edit-command.md
+++ b/unison-src/transcripts/edit-command.md
@@ -1,0 +1,21 @@
+```ucm
+.> builtins.merge
+```
+
+```unison /private/tmp/scratch.u
+foo = 123
+
+bar = 456
+
+mytest = [Ok "ok"]
+```
+
+```ucm
+.> add
+.> edit foo bar
+.> edit mytest
+```
+
+```ucm:error
+.> edit missing
+```

--- a/unison-src/transcripts/edit-command.output.md
+++ b/unison-src/transcripts/edit-command.output.md
@@ -19,6 +19,8 @@ mytest = [Ok "ok"]
 
 ```ucm
 
+  Loading changes detected in /private/tmp/scratch.u.
+
   I found and typechecked these definitions in
   /private/tmp/scratch.u. If you do an `add` or `update`, here's
   how your codebase would change:

--- a/unison-src/transcripts/edit-command.output.md
+++ b/unison-src/transcripts/edit-command.output.md
@@ -1,0 +1,77 @@
+```ucm
+.> builtins.merge
+
+  Done.
+
+```
+```unison
+---
+title: /private/tmp/scratch.u
+---
+foo = 123
+
+bar = 456
+
+mytest = [Ok "ok"]
+
+```
+
+
+```ucm
+
+  I found and typechecked these definitions in
+  /private/tmp/scratch.u. If you do an `add` or `update`, here's
+  how your codebase would change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bar    : Nat
+      foo    : Nat
+      mytest : [Result]
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    bar    : Nat
+    foo    : Nat
+    mytest : [Result]
+
+.> edit foo bar
+
+  ☝️
+  
+  I added these definitions to the top of /private/tmp/scratch.u
+  
+    bar : Nat
+    bar = 456
+    
+    foo : Nat
+    foo = 123
+  
+  You can edit them there, then do `update` to replace the
+  definitions currently in this namespace.
+
+.> edit mytest
+
+  ☝️
+  
+  I added these definitions to the top of /private/tmp/scratch.u
+  
+    test> mytest = [Ok "ok"]
+  
+  You can edit them there, then do `update` to replace the
+  definitions currently in this namespace.
+
+```
+```ucm
+.> edit missing
+
+  ⚠️
+  
+  The following names were not found in the codebase. Check your spelling.
+    missing
+
+```

--- a/unison-src/transcripts/fix4482.md
+++ b/unison-src/transcripts/fix4482.md
@@ -11,7 +11,7 @@ mybar = bar + bar
 ```
 
 ```ucm:error
-.> project.create myproj
+.> project.create-empty myproj
 myproj/main> add
 myproj/main> upgrade foo0 foo1
 ```

--- a/unison-src/transcripts/fix4482.output.md
+++ b/unison-src/transcripts/fix4482.output.md
@@ -22,14 +22,9 @@ mybar = bar + bar
 
 ```
 ```ucm
-.> project.create myproj
+.> project.create-empty myproj
 
   🎉 I've created the project myproj.
-
-  I'll now fetch the latest version of the base Unison
-  library...
-
-  Downloaded 12786 entities.
 
   🎨 Type `ui` to explore this project's code in your browser.
   🔭 Discover libraries at https://share.unison-lang.org
@@ -55,11 +50,10 @@ myproj/main> add
 
 myproj/main> upgrade foo0 foo1
 
-  mybar : Nat
+  mybar : ##Nat
   mybar =
-    use Nat +
     use lib.foo0.lib.bonk1 bar
-    bar + bar
+    ##Nat.+ bar bar
 
   I couldn't automatically upgrade foo0 to foo1.
 


### PR DESCRIPTION
## Overview

In a recent feature I was attempting to alter the transcript parser to detect and record changes to scratch files by UCM commands (e.g. `edit`). This ended up being very difficult to do in a clean way because the transcript runner doesn't watch files with a file-watcher, and additionally it keeps cached values for scratch files in memory which occasionally need to be manually cleared/adjusted.

As a non-sequitur we currently edit scratch files in a very ad-hoc way, specifically we just call `writeUtf8` from within the `OutputMessages.hs` module as a response to calling `respond`. The side-effect of writing to a file in an output message can be a bit surprising.

As a solution to both of these, I added an explicit `writeSource` method to the Cli env which can be called by `edit`. This gives us an easy spot to hook into in Transcripts to detect exactly what & when we're writing to transcripts.

It may be useful to be able to middle-man the filesystem like this when deploying UCM in other locations where we may not want to use the file-system for scratch-files, e.g. in the browser or within a replit or w/e.

## Implementation notes

* Adds `writeSource` (complementing readSource) to `Cli.Env`
* remove all `writeUtf8` calls from the output layer (`OutputMessages.hs`)
* Rewrite some of the output logic since now we need to pretty-print some code in the command itself before the output layer.
* Wire up the caching logic in TranscriptParser to listen for `writeSource` calls and write them to the cache rather than file-system, guaranteeing fresh scratch-files on every transcript run.
* Moved some of the definition pretty-printing logic used by view/edit into a CLI pretty-printing module since it's now used in HandleInput
* Split the `view` and `edit` output message types, it was always a little weird that these were the same IMO and was starting to make the logic more difficult to understand at this point.

## Interesting/controversial decisions

There's a small change to how tests are output in the console, previously if you ran `edit mytest` it would show in the console WITHOUT `test> ...` and would be printed to the file WITH `test> ...`

Now, when calling `edit` on a test it shows in BOTH with `test> ...`, but still prints without it if you run `view`.

It was just easier to write the code this way and arguably the messaging is more accurate since it says:

```
  I added these definitions to the top of /private/tmp/scratch.u
  
    test> mytest = [Ok "ok"]
```

And that's what was actually added. We're talking about removing this output anyways so I didn't worry about it too much.


## Test coverage

* Existing transcripts are unaffected 🎉 

## Loose ends

* I plan to proceed with adding changed-scratch-file output to the transcript runner, but will do that in a separate PR which will make it easier to test commands like `edit`.
