### PR TITLE
update the name of the pre-release build again

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -162,7 +162,7 @@ jobs:
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "trunk"
+          automatic_release_tag: "pre-release"
           prerelease: true
           title: "Development Build"
           files: |


### PR DESCRIPTION
`trunk` was a bad name for the release built off of `trunk` (#4508), because it creates a tag / ref name conflict with the branch `trunk`. This PR changes the name to `pre-release`.

