### PR TITLE
refactor: delete NamesWithHistory

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -1,11 +1,7 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE Rank2Types #-}
-
 module Unison.Builtin
   ( codeLookup,
     constructorType,
     names,
-    names0,
     builtinDataDecls,
     builtinEffectDecls,
     builtinConstructorType,
@@ -37,7 +33,6 @@ import Unison.Hash (Hash)
 import Unison.Hashing.V2.Convert qualified as H
 import Unison.Name (Name)
 import Unison.Names (Names (Names))
-import Unison.NamesWithHistory (NamesWithHistory (..))
 import Unison.Parser.Ann (Ann (..))
 import Unison.Prelude
 import Unison.Reference qualified as R
@@ -55,11 +50,8 @@ type EffectDeclaration = DD.EffectDeclaration Symbol Ann
 
 type Type = Type.Type Symbol ()
 
-names :: NamesWithHistory
-names = NamesWithHistory names0 mempty
-
-names0 :: Names
-names0 = Names terms types
+names :: Names
+names = Names terms types
   where
     terms =
       Rel.mapRan Referent.Ref (Rel.fromMap termNameRefs)

--- a/parser-typechecker/src/Unison/Codebase/MainTerm.hs
+++ b/parser-typechecker/src/Unison/Codebase/MainTerm.hs
@@ -10,7 +10,7 @@ import Unison.Builtin.Decls qualified as DD
 import Unison.HashQualified qualified as HQ
 import Unison.Name (Name)
 import Unison.Names qualified as Names
-import Unison.NamesWithHistory qualified as NamesWithHistory
+import Unison.NamesWithHistory qualified as Names
 import Unison.Parser.Ann (Ann)
 import Unison.Parser.Ann qualified as Parser.Ann
 import Unison.Prelude
@@ -42,7 +42,7 @@ getMainTerm loadTypeOfTerm parseNames mainName mainType =
   case HQ.fromString mainName of
     Nothing -> pure (NotAFunctionName mainName)
     Just hq -> do
-      let refs = NamesWithHistory.lookupHQTerm NamesWithHistory.IncludeSuffixes hq (NamesWithHistory.NamesWithHistory parseNames mempty)
+      let refs = Names.lookupHQTerm Names.IncludeSuffixes hq parseNames
       let a = Parser.Ann.External
       case toList refs of
         [] -> pure (NotFound mainName)

--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -18,7 +18,7 @@ import Unison.Blank qualified as Blank
 import Unison.Builtin qualified as Builtin
 import Unison.Name qualified as Name
 import Unison.Names qualified as Names
-import Unison.NamesWithHistory qualified as NamesWithHistory
+import Unison.NamesWithHistory qualified as Names
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.PrettyPrintEnv.Names qualified as PPE
@@ -90,7 +90,7 @@ computeTypecheckingEnvironment shouldUseTndr ambientAbilities typeLookupf uf =
             _termsByShortname = Map.empty
           }
     ShouldUseTndr'Yes parsingEnv -> do
-      let preexistingNames = NamesWithHistory.currentNames (Parser.names parsingEnv)
+      let preexistingNames = Parser.names parsingEnv
           tm = UF.typecheckingTerm uf
           possibleDeps =
             [ (Name.toText name, Var.name v, r)
@@ -146,7 +146,7 @@ synthesizeFile env0 uf = do
       unisonFilePPE =
         ( PPE.fromNames
             10
-            (NamesWithHistory.shadowing (UF.toNames uf) Builtin.names)
+            (Names.shadowing (UF.toNames uf) Builtin.names)
         )
       Result notes mayType =
         evalStateT (Typechecker.synthesizeAndResolve unisonFilePPE env0) tdnrTerm

--- a/parser-typechecker/src/Unison/Parsers.hs
+++ b/parser-typechecker/src/Unison/Parsers.hs
@@ -2,7 +2,6 @@ module Unison.Parsers where
 
 import Data.Text qualified as Text
 import Unison.Builtin qualified as Builtin
-import Unison.NamesWithHistory qualified as Names
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.PrintError (defaultWidth, prettyParseError)
@@ -79,7 +78,7 @@ unsafeParseFileBuiltinsOnly =
     Parser.ParsingEnv
       { uniqueNames = mempty,
         uniqueTypeGuid = \_ -> pure Nothing,
-        names = Names.NamesWithHistory Builtin.names0 mempty
+        names = Builtin.names
       }
 
 unsafeParseFile :: Monad m => String -> Parser.ParsingEnv m -> m (UnisonFile Symbol Ann)

--- a/parser-typechecker/src/Unison/PrettyPrintEnv/Names.hs
+++ b/parser-typechecker/src/Unison/PrettyPrintEnv/Names.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module Unison.PrettyPrintEnv.Names
   ( fromNames,
     fromSuffixNames,
@@ -13,22 +11,22 @@ import Unison.HashQualified' qualified as HQ'
 import Unison.Name (Name)
 import Unison.Name qualified as Name
 import Unison.Names qualified as Names
-import Unison.NamesWithHistory (NamesWithHistory)
-import Unison.NamesWithHistory qualified as NamesWithHistory
+import Unison.NamesWithHistory qualified as Names
 import Unison.Prelude
 import Unison.PrettyPrintEnv (PrettyPrintEnv (PrettyPrintEnv))
 import Unison.Util.Relation qualified as Rel
+import Unison.Names (Names)
 
-fromNames :: Int -> NamesWithHistory -> PrettyPrintEnv
+fromNames :: Int -> Names -> PrettyPrintEnv
 fromNames len names = PrettyPrintEnv terms' types'
   where
     terms' r =
-      NamesWithHistory.termName len r names
+      Names.termName len r names
         & Set.toList
         & fmap (\n -> (n, n))
         & prioritize
     types' r =
-      NamesWithHistory.typeName len r names
+      Names.typeName len r names
         & Set.toList
         & fmap (\n -> (n, n))
         & prioritize
@@ -45,20 +43,20 @@ prioritize =
     (fqn, HQ'.NameOnly name) -> (Name.isAbsolute name, Nothing, Name.countSegments (HQ'.toName fqn), Name.countSegments name)
     (fqn, HQ'.HashQualified name hash) -> (Name.isAbsolute name, Just hash, Name.countSegments (HQ'.toName fqn), Name.countSegments name)
 
-fromSuffixNames :: Int -> NamesWithHistory -> PrettyPrintEnv
+fromSuffixNames :: Int -> Names -> PrettyPrintEnv
 fromSuffixNames len names = PrettyPrintEnv terms' types'
   where
     terms' r =
-      NamesWithHistory.termName len r names
+      Names.termName len r names
         & Set.toList
         & fmap (\n -> (n, n))
-        & shortestUniqueSuffixes (Names.terms $ NamesWithHistory.currentNames names)
+        & shortestUniqueSuffixes (Names.terms names)
         & prioritize
     types' r =
-      NamesWithHistory.typeName len r names
+      Names.typeName len r names
         & Set.toList
         & fmap (\n -> (n, n))
-        & shortestUniqueSuffixes (Names.types $ NamesWithHistory.currentNames names)
+        & shortestUniqueSuffixes (Names.types names)
         & prioritize
 
 -- | Reduce the provided names to their minimal unique suffix within the scope of the given

--- a/parser-typechecker/src/Unison/PrettyPrintEnvDecl/Names.hs
+++ b/parser-typechecker/src/Unison/PrettyPrintEnvDecl/Names.hs
@@ -2,10 +2,10 @@
 
 module Unison.PrettyPrintEnvDecl.Names where
 
-import Unison.NamesWithHistory (NamesWithHistory)
+import Unison.Names (Names)
 import Unison.PrettyPrintEnv.Names (fromNames, fromSuffixNames)
 import Unison.PrettyPrintEnvDecl (PrettyPrintEnvDecl (PrettyPrintEnvDecl))
 
-fromNamesDecl :: Int -> NamesWithHistory -> PrettyPrintEnvDecl
+fromNamesDecl :: Int -> Names -> PrettyPrintEnvDecl
 fromNamesDecl hashLength names =
   PrettyPrintEnvDecl (fromNames hashLength names) (fromSuffixNames hashLength names)

--- a/parser-typechecker/src/Unison/PrettyPrintEnvDecl/Sqlite.hs
+++ b/parser-typechecker/src/Unison/PrettyPrintEnvDecl/Sqlite.hs
@@ -1,4 +1,7 @@
-module Unison.PrettyPrintEnvDecl.Sqlite where
+module Unison.PrettyPrintEnvDecl.Sqlite
+  ( ppedForReferences,
+  )
+where
 
 import U.Codebase.Sqlite.NameLookups (ReversedName (..))
 import U.Codebase.Sqlite.NamedRef (NamedRef (..))
@@ -12,7 +15,6 @@ import Unison.Name (Name)
 import Unison.Name qualified as Name
 import Unison.NameSegment (NameSegment (..))
 import Unison.Names qualified as Names
-import Unison.NamesWithHistory qualified as NamesWithHistory
 import Unison.Prelude
 import Unison.PrettyPrintEnvDecl qualified as PPED
 import Unison.PrettyPrintEnvDecl.Names qualified as PPED
@@ -48,7 +50,7 @@ ppedForReferences namesPerspective refs = do
     pure result
   let allTermNamesToConsider = termNames <> longestTermSuffixMatches
   let allTypeNamesToConsider = typeNames <> longestTypeSuffixMatches
-  pure . PPED.fromNamesDecl hashLen . NamesWithHistory.fromCurrentNames $ Names.fromTermsAndTypes allTermNamesToConsider allTypeNamesToConsider
+  pure . PPED.fromNamesDecl hashLen $ Names.fromTermsAndTypes allTermNamesToConsider allTypeNamesToConsider
   where
     namesForReference :: Ops.NamesPerspective -> LabeledDependency -> Sqlite.Transaction ([(Name, Referent)], [(Name, Reference)])
     namesForReference namesPerspective = \case

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -27,7 +27,6 @@ import Unison.Name (Name)
 import Unison.Name qualified as Name
 import Unison.Names qualified as Names
 import Unison.Names.ResolutionResult qualified as Names
-import Unison.NamesWithHistory qualified as NamesWithHistory
 import Unison.Parser.Ann (Ann (..))
 import Unison.Pattern (Pattern)
 import Unison.Prelude
@@ -1939,8 +1938,8 @@ prettyResolutionFailures s allFailures =
       (Names.TypeResolutionFailure v _ Names.NotFound) -> (v, Nothing)
 
     ppeFromNames :: Names.Names -> PPE.PrettyPrintEnv
-    ppeFromNames names0 =
-      PPE.fromNames PPE.todoHashLength (NamesWithHistory.NamesWithHistory {currentNames = names0, oldNames = mempty})
+    ppeFromNames =
+      PPE.fromNames PPE.todoHashLength
 
     prettyRow :: (v, Maybe (NESet String)) -> [(Pretty ColorText, Pretty ColorText)]
     prettyRow (v, mSet) = case mSet of

--- a/parser-typechecker/src/Unison/Runtime/IOSource.hs
+++ b/parser-typechecker/src/Unison/Runtime/IOSource.hs
@@ -17,7 +17,6 @@ import Unison.ConstructorReference (GConstructorReference (..))
 import Unison.DataDeclaration qualified as DD
 import Unison.DataDeclaration.ConstructorId qualified as DD
 import Unison.FileParsers (ShouldUseTndr (..), computeTypecheckingEnvironment, synthesizeFile)
-import Unison.NamesWithHistory qualified as Names
 import Unison.Parser.Ann (Ann (..))
 import Unison.Parsers qualified as Parsers
 import Unison.Prelude
@@ -43,7 +42,7 @@ parsingEnv =
   Parser.ParsingEnv
     { uniqueNames = mempty,
       uniqueTypeGuid = \_ -> pure Nothing,
-      names = Names.NamesWithHistory Builtin.names0 mempty
+      names = Builtin.names
     }
 
 typecheckingEnv :: Typechecker.Env Symbol Ann

--- a/parser-typechecker/tests/Unison/Test/UnisonSources.hs
+++ b/parser-typechecker/tests/Unison/Test/UnisonSources.hs
@@ -15,7 +15,7 @@ import System.FilePath.Find (always, extension, find, (==?))
 import Unison.Builtin qualified as Builtin
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.Runtime (Runtime, evaluateWatches)
-import Unison.NamesWithHistory qualified as NamesWithHistory
+import Unison.NamesWithHistory qualified as Names
 import Unison.Parser.Ann (Ann)
 import Unison.Parsers qualified as Parsers
 import Unison.Prelude
@@ -105,7 +105,7 @@ decodeResult source (Result notes (Just (Left uf))) =
           source
           ( PPE.fromNames
               Common.hqLength
-              (NamesWithHistory.shadowing errNames Builtin.names)
+              (Names.shadowing errNames Builtin.names)
           )
           notes
 decodeResult _source (Result _notes (Just (Right uf))) =

--- a/unison-cli/src/Unison/Cli/NamesUtils.hs
+++ b/unison-cli/src/Unison/Cli/NamesUtils.hs
@@ -4,7 +4,6 @@ module Unison.Cli.NamesUtils
     basicPrettyPrintNamesA,
     displayNames,
     getBasicPrettyPrintNames,
-    makeHistoricalParsingNames,
     makePrintNamesFromLabeled',
     makeShadowedPrintNamesFromHQ,
   )
@@ -15,8 +14,7 @@ import Unison.Cli.MonadUtils qualified as Cli
 import Unison.Codebase.Path (Path)
 import Unison.Codebase.Path qualified as Path
 import Unison.Names (Names)
-import Unison.NamesWithHistory (NamesWithHistory (..))
-import Unison.NamesWithHistory qualified as NamesWithHistory
+import Unison.NamesWithHistory qualified as Names
 import Unison.Server.Backend qualified as Backend
 import Unison.UnisonFile (TypecheckedUnisonFile)
 import Unison.UnisonFile.Names qualified as UF
@@ -41,7 +39,7 @@ basicNames' nameScoping = do
 displayNames ::
   (Var v) =>
   TypecheckedUnisonFile v a ->
-  Cli NamesWithHistory
+  Cli Names
 displayNames unisonFile =
   -- voodoo
   makeShadowedPrintNamesFromLabeled
@@ -53,23 +51,15 @@ getBasicPrettyPrintNames = do
   currentPath <- Cli.getCurrentPath
   pure (Backend.prettyNamesForBranch rootBranch (Backend.AllNames (Path.unabsolute currentPath)))
 
-makeHistoricalParsingNames :: Cli NamesWithHistory
-makeHistoricalParsingNames = do
-  basicNames <- basicParseNames
-  pure $ NamesWithHistory basicNames mempty
+makePrintNamesFromLabeled' :: Cli Names
+makePrintNamesFromLabeled' =
+  basicPrettyPrintNamesA
 
-makePrintNamesFromLabeled' :: Cli NamesWithHistory
-makePrintNamesFromLabeled' = do
-  basicNames <- basicPrettyPrintNamesA
-  pure $ NamesWithHistory basicNames mempty
-
-makeShadowedPrintNamesFromHQ :: Names -> Cli NamesWithHistory
+makeShadowedPrintNamesFromHQ :: Names -> Cli Names
 makeShadowedPrintNamesFromHQ shadowing = do
   basicNames <- basicPrettyPrintNamesA
-  -- The basic names go into "current", but are shadowed by "shadowing".
-  -- They go again into "historical" as a hack that makes them available HQ-ed.
-  pure $ NamesWithHistory.shadowing shadowing (NamesWithHistory basicNames mempty)
+  pure $ Names.shadowing shadowing basicNames
 
-makeShadowedPrintNamesFromLabeled :: Names -> Cli NamesWithHistory
+makeShadowedPrintNamesFromLabeled :: Names -> Cli Names
 makeShadowedPrintNamesFromLabeled shadowing =
-  NamesWithHistory.shadowing shadowing <$> makePrintNamesFromLabeled'
+  Names.shadowing shadowing <$> makePrintNamesFromLabeled'

--- a/unison-cli/src/Unison/Cli/Pretty.hs
+++ b/unison-cli/src/Unison/Cli/Pretty.hs
@@ -100,7 +100,6 @@ import Unison.Name (Name)
 import Unison.Name qualified as Name
 import Unison.NameSegment (NameSegment (..))
 import Unison.NameSegment qualified as NameSegment
-import Unison.NamesWithHistory qualified as Names
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.PrettyPrintEnv qualified as PPE
@@ -438,7 +437,7 @@ prettyUnisonFile ppe uf@(UF.UnisonFileId datas effects terms watches) =
     sppe = PPED.suffixifiedPPE ppe'
     pb v tm = st $ TermPrinter.prettyBinding sppe v tm
     ppe' = PPED.PrettyPrintEnvDecl dppe dppe `PPED.addFallback` ppe
-    dppe = PPE.fromNames 8 (Names.NamesWithHistory (UF.toNames uf) mempty)
+    dppe = PPE.fromNames 8 (UF.toNames uf)
     rd = Reference.DerivedId
     hqv v = HQ.unsafeFromVar v
 

--- a/unison-cli/src/Unison/Cli/PrettyPrintUtils.hs
+++ b/unison-cli/src/Unison/Cli/PrettyPrintUtils.hs
@@ -12,13 +12,13 @@ import Unison.Cli.MonadUtils qualified as Cli
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Path (Path)
 import Unison.Codebase.Path qualified as Path
-import Unison.NamesWithHistory (NamesWithHistory (..))
+import Unison.Names (Names)
 import Unison.Prelude
 import Unison.PrettyPrintEnvDecl qualified as PPE hiding (biasTo)
 import Unison.PrettyPrintEnvDecl.Names qualified as PPE
 import Unison.Server.Backend qualified as Backend
 
-prettyPrintEnvDecl :: NamesWithHistory -> Cli PPE.PrettyPrintEnvDecl
+prettyPrintEnvDecl :: Names -> Cli PPE.PrettyPrintEnvDecl
 prettyPrintEnvDecl ns =
   Cli.runTransaction Codebase.hashLength <&> (`PPE.fromNamesDecl` ns)
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -46,7 +46,7 @@ import Unison.Builtin.Terms qualified as Builtin
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli
-import Unison.Cli.NamesUtils (basicParseNames, displayNames, getBasicPrettyPrintNames, makeHistoricalParsingNames, makePrintNamesFromLabeled')
+import Unison.Cli.NamesUtils (basicParseNames, displayNames, getBasicPrettyPrintNames, makePrintNamesFromLabeled')
 import Unison.Cli.Pretty qualified as Pretty
 import Unison.Cli.PrettyPrintUtils (currentPrettyPrintEnvDecl, prettyPrintEnvDecl)
 import Unison.Cli.ProjectUtils qualified as ProjectUtils
@@ -144,8 +144,7 @@ import Unison.NameSegment (NameSegment (..))
 import Unison.NameSegment qualified as NameSegment
 import Unison.Names (Names (Names))
 import Unison.Names qualified as Names
-import Unison.NamesWithHistory (NamesWithHistory (..))
-import Unison.NamesWithHistory qualified as NamesWithHistory
+import Unison.NamesWithHistory qualified as Names
 import Unison.Parser.Ann (Ann (..))
 import Unison.Parser.Ann qualified as Ann
 import Unison.Parsers qualified as Parsers
@@ -238,7 +237,7 @@ loop e = do
           doRemoveReplacement from patchPath isTerm = do
             let patchPath' = fromMaybe Cli.defaultPatchPath patchPath
             patch <- Cli.getPatchAt patchPath'
-            QueryResult misses allHits <- hqNameQuery NamesWithHistory.IncludeSuffixes [from]
+            QueryResult misses allHits <- hqNameQuery Names.IncludeSuffixes [from]
             let tpRefs = Set.fromList $ typeReferences allHits
                 tmRefs = Set.fromList $ termReferences allHits
                 (hits, opHits) =
@@ -527,7 +526,7 @@ loop e = do
               history <- liftIO (doHistory schLength 0 branch [])
               Cli.respondNumbered history
               where
-                doHistory :: Int -> Int -> Branch IO -> [(CausalHash, NamesWithHistory.Diff)] -> IO NumberedOutput
+                doHistory :: Int -> Int -> Branch IO -> [(CausalHash, Names.Diff)] -> IO NumberedOutput
                 doHistory schLength !n b acc =
                   if maybe False (n >=) resultsCap
                     then pure (History diffCap schLength acc (PageEnd (Branch.headHash b) n))
@@ -555,13 +554,13 @@ loop e = do
             DocToMarkdownI docName -> do
               basicPrettyPrintNames <- getBasicPrettyPrintNames
               hqLength <- Cli.runTransaction Codebase.hashLength
-              let pped = PPED.fromNamesDecl hqLength (NamesWithHistory.NamesWithHistory basicPrettyPrintNames mempty)
+              let pped = PPED.fromNamesDecl hqLength basicPrettyPrintNames
               basicPrettyPrintNames <- basicParseNames
-              let nameSearch = NameSearch.makeNameSearch hqLength (NamesWithHistory.fromCurrentNames basicPrettyPrintNames)
+              let nameSearch = NameSearch.makeNameSearch hqLength basicPrettyPrintNames
               Cli.Env {codebase, runtime} <- ask
               mdText <- liftIO $ do
-                docRefs <- Backend.docsForDefinitionName codebase nameSearch NamesWithHistory.IncludeSuffixes docName
-                for docRefs $ \docRef -> do
+                docRefs <- Backend.docsForDefinitionName codebase nameSearch Names.IncludeSuffixes docName
+                for docRefs \docRef -> do
                   Identity (_, _, doc, _evalErrs) <- Backend.renderDocRefs pped (Pretty.Width 80) codebase runtime (Identity docRef)
                   pure . Md.toText $ Md.toMarkdown doc
               Cli.respond $ Output.MarkdownOut (Text.intercalate "\n---\n" mdText)
@@ -704,19 +703,19 @@ loop e = do
                 if global || any Name.isAbsolute query
                   then do
                     let root0 = Branch.head root
-                    let names = NamesWithHistory.fromCurrentNames . Names.makeAbsolute $ Branch.toNames root0
+                    let names = Names.makeAbsolute $ Branch.toNames root0
                     -- Use an absolutely qualified ppe for view.global
                     let pped = PPED.fromNamesDecl hqLength names
                     pure (names, pped)
                   else do
                     currentBranch <- Cli.getCurrentBranch0
-                    let currentNames = NamesWithHistory.fromCurrentNames $ Branch.toNames currentBranch
+                    let currentNames = Branch.toNames currentBranch
                     let pped = Backend.getCurrentPrettyNames hqLength (Backend.Within currentPath') root
                     pure (currentNames, pped)
 
               let unsuffixifiedPPE = PPED.unsuffixifiedPPE pped
-                  terms = NamesWithHistory.lookupHQTerm NamesWithHistory.IncludeSuffixes query names
-                  types = NamesWithHistory.lookupHQType NamesWithHistory.IncludeSuffixes query names
+                  terms = Names.lookupHQTerm Names.IncludeSuffixes query names
+                  types = Names.lookupHQType Names.IncludeSuffixes query names
                   terms' :: [(Referent, [HQ'.HashQualified Name])]
                   terms' = map (\r -> (r, PPE.allTermNames unsuffixifiedPPE r)) (Set.toList terms)
                   types' :: [(Reference, [HQ'.HashQualified Name])]
@@ -902,8 +901,8 @@ loop e = do
 
               let patchPath' = fromMaybe Cli.defaultPatchPath patchPath
               patch <- Cli.getPatchAt patchPath'
-              QueryResult fromMisses' fromHits <- hqNameQuery NamesWithHistory.IncludeSuffixes [from]
-              QueryResult toMisses' toHits <- hqNameQuery NamesWithHistory.IncludeSuffixes [to]
+              QueryResult fromMisses' fromHits <- hqNameQuery Names.IncludeSuffixes [from]
+              QueryResult toMisses' toHits <- hqNameQuery Names.IncludeSuffixes [to]
               let termsFromRefs = termReferences fromHits
                   termsToRefs = termReferences toHits
                   typesFromRefs = typeReferences fromHits
@@ -1061,7 +1060,7 @@ loop e = do
               Cli.runTransaction (Codebase.addDefsToCodebase codebase uf)
               -- add the names; note, there are more names than definitions
               -- due to builtin terms; so we don't just reuse `uf` above.
-              let srcb = BranchUtil.fromNames Builtin.names0
+              let srcb = BranchUtil.fromNames Builtin.names
               currentPath <- Cli.getCurrentPath
               _ <- Cli.updateAtM description (currentPath `snoc` "builtin") \destb ->
                 liftIO (Branch.merge'' (Codebase.lca codebase) Branch.RegularMerge srcb destb)
@@ -1084,7 +1083,7 @@ loop e = do
 
               -- add the names; note, there are more names than definitions
               -- due to builtin terms; so we don't just reuse `uf` above.
-              let names0 = Builtin.names0 <> UF.typecheckedToNames IOSource.typecheckedFile'
+              let names0 = Builtin.names <> UF.typecheckedToNames IOSource.typecheckedFile'
               let srcb = BranchUtil.fromNames names0
               currentPath <- Cli.getCurrentPath
               _ <- Cli.updateAtM description (currentPath `snoc` "builtin") \destb ->
@@ -1699,23 +1698,23 @@ handleShowDefinition outputLoc showDefinitionScope inputQuery = do
   (names, unbiasedPPED) <- case (hasAbsoluteQuery, showDefinitionScope) of
     (True, _) -> do
       let namingScope = Backend.AllNames currentPath'
-      let parseNames = NamesWithHistory.fromCurrentNames $ Backend.parseNamesForBranch root namingScope
+      let parseNames = Backend.parseNamesForBranch root namingScope
       let ppe = Backend.getCurrentPrettyNames hqLength (Backend.Within currentPath') root
       pure (parseNames, ppe)
     (_, ShowDefinitionGlobal) -> do
-      let names = NamesWithHistory.fromCurrentNames . Names.makeAbsolute $ Branch.toNames root0
+      let names = Names.makeAbsolute $ Branch.toNames root0
       -- Use an absolutely qualified ppe for view.global
       let ppe = PPED.fromNamesDecl hqLength names
       pure (names, ppe)
     (_, ShowDefinitionLocal) -> do
       currentBranch <- Cli.getCurrentBranch0
-      let currentNames = NamesWithHistory.fromCurrentNames $ Branch.toNames currentBranch
+      let currentNames = Branch.toNames currentBranch
       let ppe = Backend.getCurrentPrettyNames hqLength (Backend.Within currentPath') root
       pure (currentNames, ppe)
   let pped = PPED.biasTo (mapMaybe HQ.toName inputQuery) unbiasedPPED
   Backend.DefinitionResults terms types misses <- do
     let nameSearch = NameSearch.makeNameSearch hqLength names
-    Cli.runTransaction (Backend.definitionsByName codebase nameSearch includeCycles NamesWithHistory.IncludeSuffixes query)
+    Cli.runTransaction (Backend.definitionsByName codebase nameSearch includeCycles Names.IncludeSuffixes query)
   outputPath <- getOutputPath
   case outputPath of
     _ | null terms && null types -> pure ()
@@ -1786,7 +1785,7 @@ resolveHQToLabeledDependencies = \case
           pure (terms, types)
       pure $ Set.map LD.referent terms <> Set.map LD.typeRef types
 
-doDisplay :: OutputLocation -> NamesWithHistory -> Term Symbol () -> Cli ()
+doDisplay :: OutputLocation -> Names -> Term Symbol () -> Cli ()
 doDisplay outputLoc names tm = do
   Cli.Env {codebase} <- ask
   loopState <- State.get
@@ -2026,11 +2025,8 @@ searchBranchScored names0 score queries =
               (\score -> (Just score, result)) <$> score qn name
 
 basicPPE :: Cli PPE.PrettyPrintEnv
-basicPPE = do
-  parseNames <-
-    flip NamesWithHistory.NamesWithHistory mempty
-      <$> basicParseNames
-  suffixifiedPPE parseNames
+basicPPE =
+  basicParseNames >>= suffixifiedPPE
 
 compilerPath :: Path.Path'
 compilerPath = Path.Path' {Path.unPath' = Left abs}
@@ -2386,14 +2382,13 @@ displayI ::
   OutputLocation ->
   HQ.HashQualified Name ->
   Cli ()
-displayI prettyPrintNames outputLoc hq = do
+displayI names outputLoc hq = do
   let bias = maybeToList $ HQ.toName hq
   latestTypecheckedFile <- Cli.getLatestTypecheckedFile
   case addWatch (HQ.toString hq) latestTypecheckedFile of
     Nothing -> do
-      let parseNames = (`NamesWithHistory.NamesWithHistory` mempty) prettyPrintNames
-          results = NamesWithHistory.lookupHQTerm NamesWithHistory.IncludeSuffixes hq parseNames
-      pped <- prettyPrintEnvDecl parseNames
+      let results = Names.lookupHQTerm Names.IncludeSuffixes hq names
+      pped <- prettyPrintEnvDecl names
       ref <-
         Set.asSingleton results & onNothing do
           Cli.returnEarly
@@ -2402,7 +2397,7 @@ displayI prettyPrintNames outputLoc hq = do
               else TermAmbiguous (PPE.suffixifiedPPE pped) hq results
       let tm = Term.fromReferent External ref
       tm <- RuntimeUtils.evalUnisonTerm True (PPE.biasTo bias $ PPE.suffixifiedPPE pped) True tm
-      doDisplay outputLoc parseNames (Term.unannotate tm)
+      doDisplay outputLoc names (Term.unannotate tm)
     Just (toDisplay, unisonFile) -> do
       ppe <- PPE.biasTo bias <$> executePPE unisonFile
       (_, watches) <- evalUnisonFile Sandboxed ppe unisonFile []
@@ -2412,7 +2407,7 @@ displayI prettyPrintNames outputLoc hq = do
       doDisplay outputLoc ns tm
 
 docsI :: SrcLoc -> Names -> Path.HQSplit' -> Cli ()
-docsI srcLoc prettyPrintNames src =
+docsI srcLoc names src =
   fileByName
   where
     {- Given `docs foo`, we look for docs in 3 places, in this order:
@@ -2432,13 +2427,11 @@ docsI srcLoc prettyPrintNames src =
     fileByName :: Cli ()
     fileByName = do
       ns <- maybe mempty UF.typecheckedToNames <$> Cli.getLatestTypecheckedFile
-      fnames <- pure $ NamesWithHistory.NamesWithHistory ns mempty
-      case NamesWithHistory.lookupHQTerm NamesWithHistory.IncludeSuffixes dotDoc fnames of
+      case Names.lookupHQTerm Names.IncludeSuffixes dotDoc ns of
         s | Set.size s == 1 -> do
           -- the displayI command expects full term names, so we resolve
           -- the hash back to its full name in the file
-          fname' <- pure $ NamesWithHistory.longestTermName 10 (Set.findMin s) fnames
-          displayI prettyPrintNames ConsoleLocation fname'
+          displayI names ConsoleLocation $ Names.longestTermName 10 (Set.findMin s) ns
         _ -> codebaseByMetadata
 
     codebaseByMetadata :: Cli ()
@@ -2448,7 +2441,6 @@ docsI srcLoc prettyPrintNames src =
         [] -> codebaseByName
         [(_name, ref, _tm)] -> do
           len <- Cli.runTransaction Codebase.branchHashLength
-          let names = NamesWithHistory.NamesWithHistory prettyPrintNames mempty
           let tm = Term.ref External ref
           tm <- RuntimeUtils.evalUnisonTerm True (PPE.fromNames len names) True tm
           doDisplay ConsoleLocation names (Term.unannotate tm)
@@ -2459,9 +2451,9 @@ docsI srcLoc prettyPrintNames src =
     codebaseByName :: Cli ()
     codebaseByName = do
       parseNames <- basicParseNames
-      case NamesWithHistory.lookupHQTerm NamesWithHistory.IncludeSuffixes dotDoc (NamesWithHistory.NamesWithHistory parseNames mempty) of
+      case Names.lookupHQTerm Names.IncludeSuffixes dotDoc parseNames of
         s
-          | Set.size s == 1 -> displayI prettyPrintNames ConsoleLocation dotDoc
+          | Set.size s == 1 -> displayI names ConsoleLocation dotDoc
           | Set.size s == 0 -> Cli.respond $ ListOfLinks PPE.empty []
           -- todo: return a list of links here too
           | otherwise -> Cli.respond $ ListOfLinks PPE.empty []
@@ -2487,13 +2479,13 @@ loadTypeDisplayObject codebase = \case
     maybe (MissingObject $ Reference.idToShortHash id) UserObject
       <$> Codebase.getTypeDeclaration codebase id
 
-lexedSource :: Text -> Text -> Cli (NamesWithHistory, (Text, [L.Token L.Lexeme]))
+lexedSource :: Text -> Text -> Cli (Names, (Text, [L.Token L.Lexeme]))
 lexedSource name src = do
   let tokens = L.lexer (Text.unpack name) (Text.unpack src)
-  parseNames <- makeHistoricalParsingNames
+  parseNames <- basicParseNames
   pure (parseNames, (src, tokens))
 
-suffixifiedPPE :: NamesWithHistory -> Cli PPE.PrettyPrintEnv
+suffixifiedPPE :: Names -> Cli PPE.PrettyPrintEnv
 suffixifiedPPE ns =
   Cli.runTransaction Codebase.hashLength <&> (`PPE.fromSuffixNames` ns)
 
@@ -2508,10 +2500,7 @@ parseType input src = do
   -- `show Input` is the name of the "file" being lexed
   (names0, lexed) <- lexedSource (Text.pack input) (Text.pack src)
   parseNames <- basicParseNames
-  let names =
-        NamesWithHistory.push
-          (NamesWithHistory.currentNames names0)
-          (NamesWithHistory.NamesWithHistory parseNames (NamesWithHistory.oldNames names0))
+  let names = Names.push names0 parseNames
   let parsingEnv =
         Parser.ParsingEnv
           { uniqueNames = mempty,
@@ -2522,7 +2511,7 @@ parseType input src = do
     Parsers.parseType (Text.unpack (fst lexed)) parsingEnv & onLeftM \err ->
       Cli.returnEarly (TypeParseError src err)
 
-  Type.bindNames Name.unsafeFromVar mempty (NamesWithHistory.currentNames names) (Type.generalizeLowercase mempty typ) & onLeft \errs ->
+  Type.bindNames Name.unsafeFromVar mempty names (Type.generalizeLowercase mempty typ) & onLeft \errs ->
     Cli.returnEarly (ParseResolutionFailures src (toList errs))
 
 -- Adds a watch expression of the given name to the file, if
@@ -2560,7 +2549,7 @@ executePPE ::
 executePPE unisonFile =
   suffixifiedPPE =<< displayNames unisonFile
 
-hqNameQuery :: NamesWithHistory.SearchType -> [HQ.HashQualified Name] -> Cli QueryResult
+hqNameQuery :: Names.SearchType -> [HQ.HashQualified Name] -> Cli QueryResult
 hqNameQuery searchType query = do
   Cli.Env {codebase} <- ask
   root' <- Cli.getRootBranch
@@ -2568,7 +2557,7 @@ hqNameQuery searchType query = do
   Cli.runTransaction do
     hqLength <- Codebase.hashLength
     let parseNames = Backend.parseNamesForBranch root' (Backend.AllNames (Path.unabsolute currentPath))
-    let nameSearch = NameSearch.makeNameSearch hqLength (NamesWithHistory.fromCurrentNames parseNames)
+    let nameSearch = NameSearch.makeNameSearch hqLength parseNames
     Backend.hqNameQuery codebase nameSearch searchType query
 
 -- | Select a definition from the given branch.

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/NamespaceDiffUtils.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/NamespaceDiffUtils.hs
@@ -19,7 +19,6 @@ import Unison.Codebase.BranchDiff qualified as BranchDiff
 import Unison.Codebase.Editor.Output.BranchDiff qualified as OBranchDiff
 import Unison.Codebase.Path qualified as Path
 import Unison.DataDeclaration qualified as DD
-import Unison.NamesWithHistory (NamesWithHistory (..))
 import Unison.Parser.Ann (Ann (..))
 import Unison.Prelude
 import Unison.PrettyPrintEnv qualified as PPE
@@ -42,7 +41,7 @@ diffHelper before after =
     hqLength <- Cli.runTransaction Codebase.hashLength
     diff <- liftIO (BranchDiff.diff0 before after)
     let (_parseNames, prettyNames0, _local) = Backend.namesForBranch rootBranch (Backend.AllNames $ Path.unabsolute currentPath)
-    ppe <- PPE.suffixifiedPPE <$> prettyPrintEnvDecl (NamesWithHistory prettyNames0 mempty)
+    ppe <- PPE.suffixifiedPPE <$> prettyPrintEnvDecl prettyNames0
     fmap (ppe,) do
       OBranchDiff.toOutput
         (Cli.runTransaction . Codebase.getTypeOfReferent codebase)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Run.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Run.hs
@@ -19,7 +19,6 @@ import Unison.Codebase.Editor.Output qualified as Output
 import Unison.Codebase.MainTerm qualified as MainTerm
 import Unison.Codebase.Runtime qualified as Runtime
 import Unison.Hash qualified as Hash
-import Unison.NamesWithHistory qualified as NamesWithHistory
 import Unison.Parser.Ann (Ann (External))
 import Unison.Prelude
 import Unison.PrettyPrintEnv qualified as PPE
@@ -79,12 +78,12 @@ getTerm main =
     NoTermWithThatName -> do
       mainType <- Runtime.mainType <$> view #runtime
       basicPrettyPrintNames <- getBasicPrettyPrintNames
-      ppe <- Cli.runTransaction Codebase.hashLength <&> (`PPE.fromSuffixNames` (NamesWithHistory.NamesWithHistory basicPrettyPrintNames mempty))
+      ppe <- Cli.runTransaction Codebase.hashLength <&> (`PPE.fromSuffixNames` basicPrettyPrintNames)
       Cli.returnEarly $ Output.NoMainFunction main ppe [mainType]
     TermHasBadType ty -> do
       mainType <- Runtime.mainType <$> view #runtime
       basicPrettyPrintNames <- getBasicPrettyPrintNames
-      ppe <- Cli.runTransaction Codebase.hashLength <&> (`PPE.fromSuffixNames` (NamesWithHistory.NamesWithHistory basicPrettyPrintNames mempty))
+      ppe <- Cli.runTransaction Codebase.hashLength <&> (`PPE.fromSuffixNames` basicPrettyPrintNames)
       Cli.returnEarly $ Output.BadMainFunction "run" main ty ppe [mainType]
     GetTermSuccess x -> pure x
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/TermResolution.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/TermResolution.hs
@@ -23,11 +23,7 @@ import Unison.ConstructorReference
 import Unison.HashQualified qualified as HQ
 import Unison.Name (Name)
 import Unison.Names (Names)
-import Unison.NamesWithHistory
-  ( NamesWithHistory (..),
-    SearchType (..),
-    lookupHQTerm,
-  )
+import Unison.NamesWithHistory qualified as Names
 import Unison.Parser.Ann (Ann)
 import Unison.PrettyPrintEnv (PrettyPrintEnv)
 import Unison.PrettyPrintEnv.Names (fromSuffixNames)
@@ -38,13 +34,8 @@ import Unison.Syntax.HashQualified qualified as HQ (toString)
 import Unison.Type (Type)
 import Unison.Typechecker qualified as Typechecker
 
-addHistory :: Names -> NamesWithHistory
-addHistory names = NamesWithHistory names mempty
-
 lookupTerm :: HQ.HashQualified Name -> Names -> [Referent]
-lookupTerm hq parseNames = toList (lookupHQTerm IncludeSuffixes hq hnames)
-  where
-    hnames = addHistory parseNames
+lookupTerm hq parseNames = toList (Names.lookupHQTerm Names.IncludeSuffixes hq parseNames)
 
 lookupCon ::
   HQ.HashQualified Name ->
@@ -92,7 +83,7 @@ resolveTerm name = do
       rfs ->
         Cli.returnEarly (TermAmbiguous ppe name (fromList rfs))
         where
-          ppe = fromSuffixNames hashLength (NamesWithHistory nms mempty)
+          ppe = fromSuffixNames hashLength nms
 
 resolveCon :: HQ.HashQualified Name -> Cli ConstructorReference
 resolveCon name = do
@@ -106,7 +97,7 @@ resolveCon name = do
       (_, rfts) ->
         Cli.returnEarly (TermAmbiguous ppe name (fromList rfts))
         where
-          ppe = fromSuffixNames hashLength (NamesWithHistory nms mempty)
+          ppe = fromSuffixNames hashLength nms
 
 resolveTermRef :: HQ.HashQualified Name -> Cli Reference
 resolveTermRef name = do
@@ -120,7 +111,7 @@ resolveTermRef name = do
       (_, rfts) ->
         Cli.returnEarly (TermAmbiguous ppe name (fromList rfts))
         where
-          ppe = fromSuffixNames hashLength (NamesWithHistory nms mempty)
+          ppe = fromSuffixNames hashLength nms
 
 resolveMainRef :: HQ.HashQualified Name -> Cli (Reference, PrettyPrintEnv)
 resolveMainRef main = do
@@ -129,7 +120,7 @@ resolveMainRef main = do
       smain = HQ.toString main
   parseNames <- basicPrettyPrintNamesA
   k <- Cli.runTransaction Codebase.hashLength
-  let ppe = fromSuffixNames k (addHistory parseNames)
+  let ppe = fromSuffixNames k parseNames
   lookupTermRefWithType codebase main >>= \case
     [(rf, ty)]
       | Typechecker.fitsScheme ty mainType -> pure (rf, ppe)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
@@ -60,9 +60,6 @@ import Unison.Name.Forward qualified as ForwardName
 import Unison.NameSegment (NameSegment (NameSegment))
 import Unison.Names (Names)
 import Unison.Names qualified as Names
-import Unison.NamesWithHistory (NamesWithHistory (NamesWithHistory))
-import Unison.NamesWithHistory qualified as Names
-import Unison.NamesWithHistory qualified as NamesWithHistory
 import Unison.Parser.Ann (Ann)
 import Unison.Parser.Ann qualified as Ann
 import Unison.Parsers qualified as Parsers
@@ -119,7 +116,7 @@ handleUpdate2 = do
           shadowNames
             hlen
             (UF.typecheckedToNames tuf)
-            (NamesWithHistory.fromCurrentNames namesIncludingLibdeps)
+            namesIncludingLibdeps
         )
         <$> Codebase.hashLength
 
@@ -186,7 +183,7 @@ makeParsingEnv path names = do
     Parser.ParsingEnv
       { uniqueNames = uniqueName,
         uniqueTypeGuid = Cli.loadUniqueTypeGuid path,
-        names = NamesWithHistory {currentNames = names, oldNames = mempty}
+        names
       }
 
 -- save definitions and namespace
@@ -445,7 +442,7 @@ getTermAndDeclNames tuf =
     keysToNames = Set.map Name.unsafeFromVar . Map.keysSet
     ctorsToNames = Set.fromList . map Name.unsafeFromVar . Decl.constructorVars
 
--- | Combines 'n' and 'nwh' then creates a ppe, but all references to
+-- | Combines 'n' and 'otherNames' then creates a ppe, but all references to
 -- any name in 'n' are printed unqualified.
 --
 -- This is useful with the current update strategy where, for all
@@ -454,10 +451,10 @@ getTermAndDeclNames tuf =
 -- unqualified name.
 --
 -- For this usecase the names from the scratch file are passed as 'n'
--- and the names from the codebase are passed in 'nwh'.
-shadowNames :: Int -> Names -> NamesWithHistory -> PrettyPrintEnvDecl
-shadowNames hashLen n nwh =
-  let PPED.PrettyPrintEnvDecl unsuffixified0 suffixified0 = PPE.fromNamesDecl hashLen (Names.NamesWithHistory n mempty <> nwh)
+-- and the names from the codebase are passed in 'otherNames'.
+shadowNames :: Int -> Names -> Names -> PrettyPrintEnvDecl
+shadowNames hashLen n otherNames =
+  let PPED.PrettyPrintEnvDecl unsuffixified0 suffixified0 = PPE.fromNamesDecl hashLen (n <> otherNames)
       unsuffixified = patchPrettyPrintEnv unsuffixified0
       suffixified = patchPrettyPrintEnv suffixified0
       patchPrettyPrintEnv :: PrettyPrintEnv -> PrettyPrintEnv
@@ -476,12 +473,10 @@ shadowNames hashLen n nwh =
         HQ'.NameOnly b -> HQ'.NameOnly b
       shadowedTermRefs =
         let names = Relation.dom (Names.terms n)
-            NamesWithHistory otherNames _ = nwh
             otherTermNames = Names.terms otherNames
          in Relation.ran (Names.terms n) <> foldMap (\a -> Relation.lookupDom a otherTermNames) names
       shadowedTypeRefs =
         let names = Relation.dom (Names.types n)
-            NamesWithHistory otherNames _ = nwh
             otherTypeNames = Names.types otherNames
          in Relation.ran (Names.types n) <> foldMap (\a -> Relation.lookupDom a otherTypeNames) names
    in PPED.PrettyPrintEnvDecl unsuffixified suffixified

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Upgrade.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Upgrade.hs
@@ -40,7 +40,6 @@ import Unison.NameSegment (NameSegment)
 import Unison.NameSegment qualified as NameSegment
 import Unison.Names (Names (..))
 import Unison.Names qualified as Names
-import Unison.NamesWithHistory qualified as NamesWithHistory
 import Unison.Prelude
 import Unison.PrettyPrintEnv (PrettyPrintEnv (..))
 import Unison.PrettyPrintEnv.Names qualified as PPE.Names
@@ -172,7 +171,7 @@ handleUpgrade oldDepName newDepName = do
           UnisonFile.emptyUnisonFile
       hashLength <- Codebase.hashLength
       let primaryPPE = makeOldDepPPE oldDepName newDepName namesExcludingOldDep oldDep oldDepWithoutDeps newDepWithoutDeps
-      let secondaryPPE = PPED.fromNamesDecl hashLength (NamesWithHistory.fromCurrentNames namesExcludingOldDep)
+      let secondaryPPE = PPED.fromNamesDecl hashLength namesExcludingOldDep
       pure (unisonFile, primaryPPE `PPED.addFallback` secondaryPPE)
 
   parsingEnv <- makeParsingEnv projectPath namesExcludingOldDep

--- a/unison-cli/src/Unison/LSP/FileAnalysis.hs
+++ b/unison-cli/src/Unison/LSP/FileAnalysis.hs
@@ -42,8 +42,6 @@ import Unison.LSP.Types qualified as LSP
 import Unison.LSP.VFS qualified as VFS
 import Unison.Name (Name)
 import Unison.Names qualified as Names
-import Unison.NamesWithHistory qualified as Names
-import Unison.NamesWithHistory qualified as NamesWithHistory
 import Unison.Parser.Ann (Ann)
 import Unison.Parsers qualified as Parsers
 import Unison.Pattern qualified as Pattern
@@ -263,7 +261,7 @@ analyseFile fileUri srcText notes = do
 computeConflictWarningDiagnostics :: Uri -> FileSummary -> Lsp [Diagnostic]
 computeConflictWarningDiagnostics fileUri fileSummary@FileSummary {fileNames} = do
   let defLocations = fileDefLocations fileSummary
-  conflictedNames <- Names.conflicts . Names.currentNames <$> getParseNames
+  conflictedNames <- Names.conflicts <$> getParseNames
   let locationForName :: Name -> Set Ann
       locationForName name = fold $ Map.lookup (Name.toVar name) defLocations
   let conflictedTermLocations =
@@ -514,11 +512,11 @@ ppedForFileHelper uf tf = do
     (Nothing, Nothing) -> codebasePPED
     (_, Just tf) ->
       let fileNames = UF.typecheckedToNames tf
-          filePPED = PPED.fromNamesDecl hashLen (NamesWithHistory.fromCurrentNames fileNames)
+          filePPED = PPED.fromNamesDecl hashLen fileNames
        in filePPED `PPED.addFallback` codebasePPED
     (Just uf, _) ->
       let fileNames = UF.toNames uf
-          filePPED = PPED.fromNamesDecl hashLen (NamesWithHistory.fromCurrentNames fileNames)
+          filePPED = PPED.fromNamesDecl hashLen fileNames
        in filePPED `PPED.addFallback` codebasePPED
 
 mkTypeSignatureHints :: UF.UnisonFile Symbol Ann -> UF.TypecheckedUnisonFile Symbol Ann -> Map Symbol TypeSignatureHint

--- a/unison-cli/src/Unison/LSP/Types.hs
+++ b/unison-cli/src/Unison/LSP/Types.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -35,7 +33,6 @@ import Unison.LabeledDependency (LabeledDependency)
 import Unison.Name (Name)
 import Unison.NameSegment (NameSegment)
 import Unison.Names (Names)
-import Unison.NamesWithHistory (NamesWithHistory)
 import Unison.Parser.Ann
 import Unison.Prelude
 import Unison.PrettyPrintEnvDecl (PrettyPrintEnvDecl)
@@ -74,7 +71,7 @@ data Env = Env
   { -- contains handlers for talking to the client.
     lspContext :: LanguageContextEnv Config,
     codebase :: Codebase IO Symbol Ann,
-    parseNamesCache :: IO NamesWithHistory,
+    parseNamesCache :: IO Names,
     ppedCache :: IO PrettyPrintEnvDecl,
     nameSearchCache :: IO (NameSearch Sqlite.Transaction),
     currentPathCache :: IO Path.Absolute,
@@ -165,7 +162,7 @@ globalPPED = asks ppedCache >>= liftIO
 getNameSearch :: Lsp (NameSearch Sqlite.Transaction)
 getNameSearch = asks nameSearchCache >>= liftIO
 
-getParseNames :: Lsp NamesWithHistory
+getParseNames :: Lsp Names
 getParseNames = asks parseNamesCache >>= liftIO
 
 data Config = Config

--- a/unison-cli/src/Unison/LSP/UCMWorker.hs
+++ b/unison-cli/src/Unison/LSP/UCMWorker.hs
@@ -8,8 +8,7 @@ import Unison.Debug qualified as Debug
 import Unison.LSP.Completion
 import Unison.LSP.Types
 import Unison.LSP.VFS qualified as VFS
-import Unison.NamesWithHistory (NamesWithHistory)
-import Unison.NamesWithHistory qualified as NamesWithHistory
+import Unison.Names (Names)
 import Unison.PrettyPrintEnvDecl
 import Unison.PrettyPrintEnvDecl.Names qualified as PPE
 import Unison.Server.Backend qualified as Backend
@@ -21,7 +20,7 @@ import UnliftIO.STM
 -- | Watches for state changes in UCM and updates cached LSP state accordingly
 ucmWorker ::
   TVar PrettyPrintEnvDecl ->
-  TVar NamesWithHistory ->
+  TVar Names ->
   TVar (NameSearch Sqlite.Transaction) ->
   STM (Branch IO) ->
   STM Path.Absolute ->
@@ -41,7 +40,7 @@ ucmWorker ppeVar parseNamesVar nameSearchCacheVar getLatestRoot getLatestPath = 
         -- Re-check everything with the new names and ppe
         VFS.markAllFilesDirty
         atomically do
-          writeTVar completionsVar (namesToCompletionTree $ NamesWithHistory.currentNames parseNames)
+          writeTVar completionsVar (namesToCompletionTree parseNames)
         latest <- atomically $ do
           latestRoot <- getLatestRoot
           latestPath <- getLatestPath

--- a/unison-core/src/Unison/NamesWithHistory.hs
+++ b/unison-core/src/Unison/NamesWithHistory.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE RecordWildCards #-}
 
+-- FIXME this module used to define a NamesWithHistory type, but does no longer. This API should be moved over to
+-- Unison.Names
+
 module Unison.NamesWithHistory
-  ( NamesWithHistory (..),
-    fromCurrentNames,
-    filterTypes,
-    diff,
+  ( diff,
     push,
     shadowing,
     lookupHQType,
@@ -21,7 +21,6 @@ module Unison.NamesWithHistory
     termNamesByLength,
     longestTermName,
     termName,
-    importing,
     lookupHQPattern,
     Diff (..),
     SearchType (..),
@@ -55,33 +54,6 @@ data SearchType
   | ExactName
   deriving (Eq, Ord, Show)
 
--- | NamesWithHistory contains two sets of 'Names',
--- One represents names which are currently assigned,
--- the other represents names which no longer apply, perhaps they've been deleted, or the term
--- was updated and the name points elsewhere now.
-data NamesWithHistory = NamesWithHistory
-  { -- | currentNames represent references which are named in the current version of the namespace.
-    currentNames :: Names.Names,
-    -- | oldNames represent things which no longer have names in the current version of the
-    -- codebase, but which may have previously had names. This may allow us to show more helpful
-    -- context to users rather than just a hash.
-    oldNames :: Names.Names
-  }
-  deriving (Show)
-
-instance Semigroup NamesWithHistory where
-  NamesWithHistory cur1 old1 <> NamesWithHistory cur2 old2 =
-    NamesWithHistory (cur1 <> cur2) (old1 <> old2)
-
-instance Monoid NamesWithHistory where
-  mempty = NamesWithHistory mempty mempty
-
-fromCurrentNames :: Names -> NamesWithHistory
-fromCurrentNames n = NamesWithHistory {currentNames = n, oldNames = mempty}
-
-filterTypes :: (Name -> Bool) -> Names -> Names
-filterTypes = Names.filterTypes
-
 -- Simple 2 way diff, has the property that:
 --  addedNames (diff0 n1 n2) == removedNames (diff0 n2 n1)
 --
@@ -106,18 +78,10 @@ data Diff = Diff
   }
   deriving (Show)
 
--- Add `n1` to `currentNames`, shadowing anything with the same name and
--- moving shadowed definitions into `oldNames` so they can can still be
--- referenced hash qualified.
-push :: Names -> NamesWithHistory -> NamesWithHistory
-push n0 ns = NamesWithHistory (unionLeft0 n1 cur) (oldNames ns <> shadowed)
+push :: Names -> Names -> Names
+push n0 ns = unionLeft0 n1 ns
   where
     n1 = suffixify0 n0
-    cur = currentNames ns
-    shadowed = Names terms' types'
-      where
-        terms' = R.dom (terms n1) R.<| (terms cur `R.difference` terms n1)
-        types' = R.dom (types n1) R.<| (types cur `R.difference` types n1)
     unionLeft0 :: Names -> Names -> Names
     unionLeft0 n1 n2 = Names terms' types'
       where
@@ -131,9 +95,6 @@ push n0 ns = NamesWithHistory (unionLeft0 n1 cur) (oldNames ns <> shadowed)
     -- onto the list and we could get rid of all this complex logic. The
     -- complexity here is that we have to "bake the shadowing" into a single
     -- Names, taking into account suffix-based name resolution.
-    --
-    -- We currently have `oldNames`, but that controls an unrelated axis, which
-    -- is whether names are hash qualified or not.
     suffixify0 :: Names -> Names
     suffixify0 ns = ns <> suffixNs
       where
@@ -143,71 +104,65 @@ push n0 ns = NamesWithHistory (unionLeft0 n1 cur) (oldNames ns <> shadowed)
         uniqueTerms = [(n, ref) | (n, nubOrd -> [ref]) <- Map.toList terms']
         uniqueTypes = [(n, ref) | (n, nubOrd -> [ref]) <- Map.toList types']
 
--- if I push an existing name, the pushed reference should be the thing
--- if I push a different name for the same thing, i suppose they should coexist
--- thus, `unionLeftName`.
-shadowing :: Names -> NamesWithHistory -> NamesWithHistory
-shadowing prio (NamesWithHistory current old) =
-  NamesWithHistory (prio `Names.unionLeft` current) (current <> old)
+shadowing :: Names -> Names -> Names
+shadowing =
+  Names.unionLeft
 
 -- Find all types whose name has a suffix matching the provided `HashQualified`,
 -- returning types with relative names if they exist, and otherwise
 -- returning types with absolute names.
-lookupRelativeHQType :: SearchType -> HashQualified Name -> NamesWithHistory -> Set Reference
-lookupRelativeHQType searchType hq ns@NamesWithHistory {..} =
+lookupRelativeHQType :: SearchType -> HashQualified Name -> Names -> Set Reference
+lookupRelativeHQType searchType hq ns =
   let rs = lookupHQType searchType hq ns
-      keep r = any (not . Name.isAbsolute) (R.lookupRan r (Names.types currentNames))
+      keep r = any (not . Name.isAbsolute) (R.lookupRan r (Names.types ns))
    in case Set.filter keep rs of
         rs'
           | Set.null rs' -> rs
           | otherwise -> rs'
 
-lookupRelativeHQType' :: SearchType -> HQ'.HashQualified Name -> NamesWithHistory -> Set Reference
+lookupRelativeHQType' :: SearchType -> HQ'.HashQualified Name -> Names -> Set Reference
 lookupRelativeHQType' searchType =
   lookupRelativeHQType searchType . HQ'.toHQ
 
 -- | Find all types whose name has a suffix matching the provided 'HashQualified'.
-lookupHQType :: SearchType -> HashQualified Name -> NamesWithHistory -> Set Reference
+lookupHQType :: SearchType -> HashQualified Name -> Names -> Set Reference
 lookupHQType searchType =
   lookupHQRef searchType Names.types Reference.isPrefixOf
 
 -- | Find all types whose name has a suffix matching the provided 'HashQualified''. See 'lookupHQType'.
-lookupHQType' :: SearchType -> HQ'.HashQualified Name -> NamesWithHistory -> Set Reference
+lookupHQType' :: SearchType -> HQ'.HashQualified Name -> Names -> Set Reference
 lookupHQType' searchType =
   lookupHQType searchType . HQ'.toHQ
 
-hasTermNamed :: SearchType -> Name -> NamesWithHistory -> Bool
+hasTermNamed :: SearchType -> Name -> Names -> Bool
 hasTermNamed searchType n ns = not (Set.null $ lookupHQTerm searchType (HQ.NameOnly n) ns)
 
-hasTypeNamed :: SearchType -> Name -> NamesWithHistory -> Bool
+hasTypeNamed :: SearchType -> Name -> Names -> Bool
 hasTypeNamed searchType n ns = not (Set.null $ lookupHQType searchType (HQ.NameOnly n) ns)
 
 -- Find all terms whose name has a suffix matching the provided `HashQualified`,
 -- returning terms with relative names if they exist, and otherwise
 -- returning terms with absolute names.
-lookupRelativeHQTerm :: SearchType -> HashQualified Name -> NamesWithHistory -> Set Referent
-lookupRelativeHQTerm searchType hq ns@NamesWithHistory {..} =
+lookupRelativeHQTerm :: SearchType -> HashQualified Name -> Names -> Set Referent
+lookupRelativeHQTerm searchType hq ns =
   let rs = lookupHQTerm searchType hq ns
-      keep r = any (not . Name.isAbsolute) (R.lookupRan r (Names.terms currentNames))
+      keep r = any (not . Name.isAbsolute) (R.lookupRan r (Names.terms ns))
    in case Set.filter keep rs of
         rs'
           | Set.null rs' -> rs
           | otherwise -> rs'
 
-lookupRelativeHQTerm' :: SearchType -> HQ'.HashQualified Name -> NamesWithHistory -> Set Referent
+lookupRelativeHQTerm' :: SearchType -> HQ'.HashQualified Name -> Names -> Set Referent
 lookupRelativeHQTerm' searchType =
   lookupRelativeHQTerm searchType . HQ'.toHQ
 
 -- | Find all terms whose name has a suffix matching the provided 'HashQualified'.
---
--- If the hash-qualified name does not include a hash, then only current names are searched. Otherwise, old names are
--- searched, too, if searching current names produces no hits.
-lookupHQTerm :: SearchType -> HashQualified Name -> NamesWithHistory -> Set Referent
+lookupHQTerm :: SearchType -> HashQualified Name -> Names -> Set Referent
 lookupHQTerm searchType =
   lookupHQRef searchType Names.terms Referent.isPrefixOf
 
 -- | Find all terms whose name has a suffix matching the provided 'HashQualified''. See 'lookupHQTerm'.
-lookupHQTerm' :: SearchType -> HQ'.HashQualified Name -> NamesWithHistory -> Set Referent
+lookupHQTerm' :: SearchType -> HQ'.HashQualified Name -> Names -> Set Referent
 lookupHQTerm' searchType =
   lookupHQTerm searchType . HQ'.toHQ
 
@@ -224,17 +179,17 @@ lookupHQRef ::
   (ShortHash -> r -> Bool) ->
   -- | The name to look up
   HashQualified Name ->
-  NamesWithHistory ->
+  Names ->
   Set r
-lookupHQRef searchType which isPrefixOf hq NamesWithHistory {currentNames, oldNames} =
+lookupHQRef searchType which isPrefixOf hq names =
   case hq of
-    HQ.NameOnly n -> doSearch n currentRefs
-    HQ.HashQualified n sh -> matches currentRefs `orIfEmpty` matches oldRefs
+    HQ.NameOnly n -> doSearch n refs
+    HQ.HashQualified n sh -> matches refs
       where
         matches :: Relation Name r -> Set r
         matches ns =
           Set.filter (isPrefixOf sh) (doSearch n ns)
-    HQ.HashOnly sh -> matches currentRefs `orIfEmpty` matches oldRefs
+    HQ.HashOnly sh -> matches refs
       where
         matches :: Relation Name r -> Set r
         matches ns =
@@ -243,31 +198,20 @@ lookupHQRef searchType which isPrefixOf hq NamesWithHistory {currentNames, oldNa
     doSearch = case searchType of
       IncludeSuffixes -> Name.searchByRankedSuffix
       ExactName -> Relation.lookupDom
-    currentRefs = which currentNames
-    oldRefs = which oldNames
+    refs = which names
 
-    -- (xs `orIfEmpty` ys) returns xs if it's non-empty, otherwise ys
-    orIfEmpty :: Set a -> Set a -> Set a
-    orIfEmpty xs ys =
-      if Set.null xs then ys else xs
-
--- If `r` is in "current" names, look up each of its names, and hash-qualify
--- them if they are conflicted names.  If `r` isn't in "current" names, look up
--- each of its "old" names and hash-qualify them.
-typeName :: Int -> Reference -> NamesWithHistory -> Set (HQ'.HashQualified Name)
-typeName length r NamesWithHistory {..} =
-  if R.memberRan r . Names.types $ currentNames
-    then
-      Set.map
-        (\n -> if isConflicted n then hq n else HQ'.fromName n)
-        (R.lookupRan r . Names.types $ currentNames)
-    else Set.map hq (R.lookupRan r . Names.types $ oldNames)
+-- Look up a ref's names, and hash-qualify them if they are conflicted.
+typeName :: Int -> Reference -> Names -> Set (HQ'.HashQualified Name)
+typeName length r names =
+  Set.map
+    (\n -> if isConflicted n then hq n else HQ'.fromName n)
+    (R.lookupRan r . Names.types $ names)
   where
     hq n = HQ'.take length (HQ'.fromNamedReference n r)
-    isConflicted n = R.manyDom n (Names.types currentNames)
+    isConflicted n = R.manyDom n (Names.types names)
 
 -- List of names for a referent, longer names (by number of segments) first.
-termNamesByLength :: Int -> Referent -> NamesWithHistory -> [HQ'.HashQualified Name]
+termNamesByLength :: Int -> Referent -> Names -> [HQ'.HashQualified Name]
 termNamesByLength length r ns =
   sortOn len (toList $ termName length r ns)
   where
@@ -275,23 +219,20 @@ termNamesByLength length r ns =
     len (HQ'.HashQualified n _) = Name.countSegments n
 
 -- The longest term name (by segment count) for a `Referent`.
-longestTermName :: Int -> Referent -> NamesWithHistory -> HQ.HashQualified Name
+longestTermName :: Int -> Referent -> Names -> HQ.HashQualified Name
 longestTermName length r ns =
   case reverse (termNamesByLength length r ns) of
     [] -> HQ.take length (HQ.fromReferent r)
     (h : _) -> Name.convert h
 
-termName :: Int -> Referent -> NamesWithHistory -> Set (HQ'.HashQualified Name)
-termName length r NamesWithHistory {..} =
-  if R.memberRan r . Names.terms $ currentNames
-    then
-      Set.map
-        (\n -> if isConflicted n then hq n else HQ'.fromName n)
-        (R.lookupRan r . Names.terms $ currentNames)
-    else Set.map hq (R.lookupRan r . Names.terms $ oldNames)
+termName :: Int -> Referent -> Names -> Set (HQ'.HashQualified Name)
+termName length r names =
+  Set.map
+    (\n -> if isConflicted n then hq n else HQ'.fromName n)
+    (R.lookupRan r . Names.terms $ names)
   where
     hq n = HQ'.take length (HQ'.fromNamedReferent n r)
-    isConflicted n = R.manyDom n (Names.terms currentNames)
+    isConflicted n = R.manyDom n (Names.terms names)
 
 -- Set HashQualified -> Branch m -> Action' m v Names
 -- Set HashQualified -> Branch m -> Free (Command m i v) Names
@@ -301,7 +242,7 @@ lookupHQPattern ::
   SearchType ->
   HQ.HashQualified Name ->
   CT.ConstructorType ->
-  NamesWithHistory ->
+  Names ->
   Set ConstructorReference
 lookupHQPattern searchType hq ctt names =
   Set.fromList
@@ -309,14 +250,3 @@ lookupHQPattern searchType hq ctt names =
       | Referent.Con r ct <- toList $ lookupHQTerm searchType hq names,
         ct == ctt
     ]
-
--- | Given a mapping from name to qualified name, update a `Names`,
--- so for instance if the input has [(Some, Optional.Some)],
--- and `Optional.Some` is a constructor in the input `Names`,
--- the alias `Some` will map to that same constructor and shadow
--- anything else that is currently called `Some`.
---
--- Only affects `currentNames`.
-importing :: [(Name, Name)] -> NamesWithHistory -> NamesWithHistory
-importing shortToLongName ns =
-  ns {currentNames = Names.importing shortToLongName (currentNames ns)}

--- a/unison-core/src/Unison/Type/Names.hs
+++ b/unison-core/src/Unison/Type/Names.hs
@@ -1,4 +1,7 @@
-module Unison.Type.Names where
+module Unison.Type.Names
+  ( bindNames,
+  )
+where
 
 import Data.Set qualified as Set
 import Data.Set.NonEmpty qualified as NES
@@ -19,14 +22,13 @@ bindNames ::
   Names.Names ->
   Type v a ->
   Names.ResolutionResult v a (Type v a)
-bindNames unsafeVarToName keepFree ns0 t =
-  let ns = Names.NamesWithHistory ns0 mempty
-      fvs = ABT.freeVarOccurrences keepFree t
+bindNames unsafeVarToName keepFree ns t =
+  let fvs = ABT.freeVarOccurrences keepFree t
       rs = [(v, a, Names.lookupHQType Names.IncludeSuffixes (Name.convert $ unsafeVarToName v) ns) | (v, a) <- fvs]
       ok (v, a, rs) =
         if Set.size rs == 1
           then pure (v, Set.findMin rs)
           else case NES.nonEmptySet rs of
             Nothing -> Left (pure (Names.TypeResolutionFailure v a Names.NotFound))
-            Just rs' -> Left (pure (Names.TypeResolutionFailure v a (Names.Ambiguous ns0 rs')))
+            Just rs' -> Left (pure (Names.TypeResolutionFailure v a (Names.Ambiguous ns rs')))
    in List.validate ok rs <&> \es -> bindExternal es t

--- a/unison-share-api/src/Unison/Server/Local/Definitions.hs
+++ b/unison-share-api/src/Unison/Server/Local/Definitions.hs
@@ -11,7 +11,7 @@ import Unison.Codebase.Path (Path)
 import Unison.Codebase.Runtime qualified as Rt
 import Unison.HashQualified qualified as HQ
 import Unison.Name (Name)
-import Unison.NamesWithHistory qualified as NamesWithHistory
+import Unison.NamesWithHistory qualified as Names
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.PrettyPrintEnv qualified as PPE
@@ -64,13 +64,13 @@ prettyDefinitionsForHQName perspective shallowRoot renderWidth suffixifyBindings
   hqLength <- liftIO $ Codebase.runTransaction codebase $ Codebase.hashLength
   (localNamesOnly, unbiasedPPED) <- scopedNamesForBranchHash codebase (Just shallowRoot) namesRoot
   let pped = PPED.biasTo biases unbiasedPPED
-  let nameSearch = makeNameSearch hqLength (NamesWithHistory.fromCurrentNames localNamesOnly)
+  let nameSearch = makeNameSearch hqLength localNamesOnly
   (DefinitionResults terms types misses) <- liftIO $ Codebase.runTransaction codebase do
-    definitionsByName codebase nameSearch DontIncludeCycles NamesWithHistory.ExactName [query]
+    definitionsByName codebase nameSearch DontIncludeCycles Names.ExactName [query]
   let width = mayDefaultWidth renderWidth
   let docResults :: Name -> IO [(HashQualifiedName, UnisonHash, Doc.Doc)]
       docResults name = do
-        docRefs <- docsForDefinitionName codebase nameSearch NamesWithHistory.ExactName name
+        docRefs <- docsForDefinitionName codebase nameSearch Names.ExactName name
         renderDocRefs pped width codebase rt docRefs
           -- local server currently ignores doc eval errors
           <&> fmap \(hqn, h, doc, _errs) -> (hqn, h, doc)

--- a/unison-share-api/src/Unison/Server/NameSearch/FromNames.hs
+++ b/unison-share-api/src/Unison/Server/NameSearch/FromNames.hs
@@ -1,34 +1,34 @@
 module Unison.Server.NameSearch.FromNames where
 
 import Unison.HashQualified' qualified as HQ'
-import Unison.NamesWithHistory (NamesWithHistory)
-import Unison.NamesWithHistory qualified as NamesWithHistory
+import Unison.Names (Names)
+import Unison.NamesWithHistory qualified as Names
 import Unison.Reference (Reference)
 import Unison.Referent (Referent)
 import Unison.Server.NameSearch
 import Unison.Server.SearchResult qualified as SR
 
 -- | Make a type search, given a short hash length and names to search in.
-makeTypeSearch :: (Applicative m) => Int -> NamesWithHistory -> Search m Reference
+makeTypeSearch :: (Applicative m) => Int -> Names -> Search m Reference
 makeTypeSearch len names =
   Search
-    { lookupNames = \ref -> pure $ NamesWithHistory.typeName len ref names,
-      lookupRelativeHQRefs' = \searchType n -> pure $ NamesWithHistory.lookupRelativeHQType' searchType n names,
+    { lookupNames = \ref -> pure $ Names.typeName len ref names,
+      lookupRelativeHQRefs' = \searchType n -> pure $ Names.lookupRelativeHQType' searchType n names,
       matchesNamedRef = HQ'.matchesNamedReference,
       makeResult = \hqname r names -> pure $ SR.typeResult hqname r names
     }
 
 -- | Make a term search, given a short hash length and names to search in.
-makeTermSearch :: (Applicative m) => Int -> NamesWithHistory -> Search m Referent
+makeTermSearch :: (Applicative m) => Int -> Names -> Search m Referent
 makeTermSearch len names =
   Search
-    { lookupNames = \ref -> pure $ NamesWithHistory.termName len ref names,
-      lookupRelativeHQRefs' = \searchType n -> pure $ NamesWithHistory.lookupRelativeHQTerm' searchType n names,
+    { lookupNames = \ref -> pure $ Names.termName len ref names,
+      lookupRelativeHQRefs' = \searchType n -> pure $ Names.lookupRelativeHQTerm' searchType n names,
       matchesNamedRef = HQ'.matchesNamedReferent,
       makeResult = \hqname r names -> pure $ SR.termResult hqname r names
     }
 
-makeNameSearch :: (Applicative m) => Int -> NamesWithHistory -> NameSearch m
+makeNameSearch :: (Applicative m) => Int -> Names -> NameSearch m
 makeNameSearch hashLength names =
   NameSearch
     { typeSearch = makeTypeSearch hashLength names,


### PR DESCRIPTION
## Overview

Fixes #4562 

This PR deletes the now-unused `NamesWithHistory` type.

## Loose ends

I mostly left the `Unison.NamesWithHistory` module alone. It should be deleted and its API moved over to `Unison.Names`.