### PR TITLE
feat: mention the name of the file we put failed upgrades in

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Upgrade.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Upgrade.hs
@@ -193,13 +193,13 @@ handleUpgrade oldDepName newDepName = do
       maybePath <-
         if isTranscript
           then pure Nothing
-          else do
+          else fmap Just do
             maybeLatestFile <- Cli.getLatestFile
-            case maybeLatestFile of
-              Nothing -> pure (Just "scratch.u")
-              Just (file, _) -> pure (Just file)
+            pure case maybeLatestFile of
+              Nothing -> "scratch.u"
+              Just (file, _) -> file
       Cli.respond (Output.DisplayDefinitionsString maybePath prettyUnisonFile)
-      Cli.respond (Output.UpgradeFailure oldDepName newDepName)
+      Cli.respond (Output.UpgradeFailure (fromMaybe "scratch.u" maybePath) oldDepName newDepName)
       Cli.returnEarlyWithoutOutput
 
   branchUpdates <-

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -392,7 +392,7 @@ data Output
   | UpdateTypecheckingFailure
   | UpdateTypecheckingSuccess
   | UpdateIncompleteConstructorSet UpdateOrUpgrade Name (Map ConstructorId Name) (Maybe Int)
-  | UpgradeFailure !NameSegment !NameSegment
+  | UpgradeFailure !FilePath !NameSegment !NameSegment
   | UpgradeSuccess !NameSegment !NameSegment
 
 data UpdateOrUpgrade = UOUUpdate | UOUUpgrade

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2221,12 +2221,20 @@ notifyUser dir = \case
                   <> operationName
                   <> "again."
             ]
-  UpgradeFailure old new ->
-    pure . P.wrap $
-      "I couldn't automatically upgrade"
-        <> P.text (NameSegment.toText old)
-        <> "to"
-        <> P.group (P.text (NameSegment.toText new) <> ".")
+  UpgradeFailure path old new ->
+    pure $
+      P.wrap
+        ( "I couldn't automatically upgrade"
+            <> P.text (NameSegment.toText old)
+            <> "to"
+            <> P.group (P.text (NameSegment.toText new) <> ".")
+        )
+        <> P.newline
+        <> P.newline
+        <> P.wrap
+          ( "I added the problematic definitions to the top of"
+              <> P.group (prettyFilePath path <> ".")
+          )
   UpgradeSuccess old new ->
     pure . P.wrap $
       "I upgraded"

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2222,19 +2222,13 @@ notifyUser dir = \case
                   <> "again."
             ]
   UpgradeFailure path old new ->
-    pure $
-      P.wrap
-        ( "I couldn't automatically upgrade"
-            <> P.text (NameSegment.toText old)
-            <> "to"
-            <> P.group (P.text (NameSegment.toText new) <> ".")
-        )
-        <> P.newline
-        <> P.newline
-        <> P.wrap
-          ( "I added the problematic definitions to the top of"
-              <> P.group (prettyFilePath path <> ".")
-          )
+    pure . P.wrap $
+      "I couldn't automatically upgrade"
+        <> P.text (NameSegment.toText old)
+        <> "to"
+        <> P.group (P.text (NameSegment.toText new) <> ".")
+        <> "However, I've added the definitions that need attention to the top of"
+        <> P.group (prettyFilePath path <> ".")
   UpgradeSuccess old new ->
     pure . P.wrap $
       "I upgraded"

--- a/unison-src/transcripts/fix4482.output.md
+++ b/unison-src/transcripts/fix4482.output.md
@@ -58,5 +58,7 @@ myproj/main> upgrade foo0 foo1
     ##Nat.+ bar bar
 
   I couldn't automatically upgrade foo0 to foo1.
+  
+  I added the problematic definitions to the top of scratch.u.
 
 ```

--- a/unison-src/transcripts/fix4482.output.md
+++ b/unison-src/transcripts/fix4482.output.md
@@ -57,8 +57,8 @@ myproj/main> upgrade foo0 foo1
     use lib.foo0.lib.bonk1 bar
     ##Nat.+ bar bar
 
-  I couldn't automatically upgrade foo0 to foo1.
-  
-  I added the problematic definitions to the top of scratch.u.
+  I couldn't automatically upgrade foo0 to foo1. However, I've
+  added the definitions that need attention to the top of
+  scratch.u.
 
 ```

--- a/unison-src/transcripts/upgrade-sad-path.output.md
+++ b/unison-src/transcripts/upgrade-sad-path.output.md
@@ -37,8 +37,8 @@ proj/main> upgrade old new
     use Nat +
     foo + 10
 
-  I couldn't automatically upgrade old to new.
-  
-  I added the problematic definitions to the top of scratch.u.
+  I couldn't automatically upgrade old to new. However, I've
+  added the definitions that need attention to the top of
+  scratch.u.
 
 ```

--- a/unison-src/transcripts/upgrade-sad-path.output.md
+++ b/unison-src/transcripts/upgrade-sad-path.output.md
@@ -38,5 +38,7 @@ proj/main> upgrade old new
     foo + 10
 
   I couldn't automatically upgrade old to new.
+  
+  I added the problematic definitions to the top of scratch.u.
 
 ```


### PR DESCRIPTION
## Overview

This PR makes `upgrade` tell you what file it puts busted stuff in, if it fails.

Fixes #4473 