### PR TITLE
Work around alias parsing bug

### DIFF
--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -803,9 +803,9 @@ These are currently all expected to have different hashes on round trip.
 
   Updates:
   
-    1. sloppyDocEval : Doc2
+    1. sloppyDocEval : builtin.Doc2
        ↓
-    2. sloppyDocEval : Doc2
+    2. sloppyDocEval : builtin.Doc2
 
 ```
 ## Other regression tests not covered by above

--- a/unison-src/transcripts/ambiguous-metadata.output.md
+++ b/unison-src/transcripts/ambiguous-metadata.output.md
@@ -33,7 +33,7 @@ x = 1
   I'm not sure which metadata value you're referring to since
   there are multiple matches:
   
-    doc#7ivmrc4c8v
+    boo.doc#7ivmrc4c8v
     foo.doc
   
   Tip: Try again and supply one of the above definitions

--- a/unison-src/transcripts/command-replace.output.md
+++ b/unison-src/transcripts/command-replace.output.md
@@ -47,7 +47,7 @@ Test that replace works with terms
 
 .scratch> view x
 
-  x : Nat
+  x : builtin.Nat
   x = 2
 
 ```
@@ -79,7 +79,7 @@ Test that replace works with types
 
 .scratch> view X
 
-  structural type X = One Nat Nat
+  structural type X = One builtin.Nat builtin.Nat
 
 ```
 Try with a type/term mismatch

--- a/unison-src/transcripts/create-author.output.md
+++ b/unison-src/transcripts/create-author.output.md
@@ -27,9 +27,9 @@ def2 = 2
 
 .foo> view 2
 
-  metadata.copyrightHolders.alicecoder : CopyrightHolder
+  metadata.copyrightHolders.alicecoder : builtin.CopyrightHolder
   metadata.copyrightHolders.alicecoder =
-    CopyrightHolder guid "Alice McGee"
+    builtin.CopyrightHolder.CopyrightHolder guid "Alice McGee"
 
 .foo> link metadata.authors.alicecoder def1 def2
 

--- a/unison-src/transcripts/diff-namespace.output.md
+++ b/unison-src/transcripts/diff-namespace.output.md
@@ -322,14 +322,14 @@ unique type Y a b = Y a b
   Updates:
   
     1. ns2.f : Nat
-       + 2. c : Nat
+       + 2. ns1.c : Nat
 
 .> link ns2.c ns2.c
 
   Updates:
   
     1. ns2.c : Nat
-       + 2. c : Nat
+       + 2. ns1.c : Nat
 
 .> diff.namespace ns1 ns2
 
@@ -349,7 +349,7 @@ unique type Y a b = Y a b
     7.  b : Text
     
     8.  c : Nat
-        + 9.  c : Nat
+        + 9.  ns1.c : Nat
     
     10. fromJust' : Nat
         ↓
@@ -397,7 +397,7 @@ unique type Y a b = Y a b
     7.  b : Text
     
     8.  c : Nat
-        + 9.  c : Nat
+        + 9.  ns1.c : Nat
     
     10. fromJust' : Nat
         ↓
@@ -619,20 +619,20 @@ a = 555
 
 .nsw> view a b
 
-  a#mdl4vqtu00 : Nat
+  a#mdl4vqtu00 : builtin.Nat
   a#mdl4vqtu00 = 444
   
-  a#vrs8gtkl2t : Nat
+  a#vrs8gtkl2t : builtin.Nat
   a#vrs8gtkl2t = 555
   
-  b#aapqletas7 : Nat
+  b#aapqletas7 : builtin.Nat
   b#aapqletas7 =
-    use Nat +
+    use builtin.Nat +
     a#vrs8gtkl2t + 1
   
-  b#unkqhuu66p : Nat
+  b#unkqhuu66p : builtin.Nat
   b#unkqhuu66p =
-    use Nat +
+    use builtin.Nat +
     a#mdl4vqtu00 + 1
 
 ```

--- a/unison-src/transcripts/fix2254.output.md
+++ b/unison-src/transcripts/fix2254.output.md
@@ -82,26 +82,32 @@ Let's do the update now, and verify that the definitions all look good and there
     | A a
   
   structural type NeedsA a b
-    = Zoink Text
-    | NeedsA (A a b Nat Nat)
+    = Zoink builtin.Text
+    | NeedsA (A a b builtin.Nat builtin.Nat)
   
-  f : A Nat Nat Nat Nat -> Nat
+  f :
+    A builtin.Nat builtin.Nat builtin.Nat builtin.Nat
+    -> builtin.Nat
   f = cases
     A n -> n
     _   -> 42
   
-  f2 : A Nat Nat Nat Nat -> Nat
+  f2 :
+    A builtin.Nat builtin.Nat builtin.Nat builtin.Nat
+    -> builtin.Nat
   f2 a =
-    use Nat +
+    use builtin.Nat +
     n = f a
     n + 1
   
-  f3 : NeedsA Nat Nat -> Nat
+  f3 : NeedsA builtin.Nat builtin.Nat -> builtin.Nat
   f3 = cases
-    NeedsA a -> f a Nat.+ 20
+    NeedsA a -> f a builtin.Nat.+ 20
     _        -> 0
   
-  g : A Nat Nat Nat Nat -> Nat
+  g :
+    A builtin.Nat builtin.Nat builtin.Nat builtin.Nat
+    -> builtin.Nat
   g = cases
     D n -> n
     _   -> 43

--- a/unison-src/transcripts/fix2567.output.md
+++ b/unison-src/transcripts/fix2567.output.md
@@ -30,7 +30,10 @@ structural ability Foo where
 .somewhere> view .some.subnamespace.Foo
 
   structural ability .some.subnamespace.Foo where
-    blah : Nat ->{.some.subnamespace.Foo} Nat
-    woot : Nat -> (Nat, Nat) ->{.some.subnamespace.Foo} Nat
+    blah : foo.bar.Nat ->{.some.subnamespace.Foo} foo.bar.Nat
+    woot :
+      foo.bar.Nat
+      -> (foo.bar.Nat, foo.bar.Nat)
+      ->{.some.subnamespace.Foo} foo.bar.Nat
 
 ```

--- a/unison-src/transcripts/fix4556.md
+++ b/unison-src/transcripts/fix4556.md
@@ -1,0 +1,22 @@
+```ucm:hide
+.> builtins.merge
+```
+
+```unison
+thing = 3
+foo.hello = 5 + thing
+bar.hello = 5 + thing
+hey = foo.hello
+```
+
+```ucm
+.> add
+```
+
+```unison
+thing = 2
+```
+
+```ucm:error
+.> update
+```

--- a/unison-src/transcripts/fix4556.md
+++ b/unison-src/transcripts/fix4556.md
@@ -17,6 +17,6 @@ hey = foo.hello
 thing = 2
 ```
 
-```ucm:error
+```ucm
 .> update
 ```

--- a/unison-src/transcripts/fix4556.output.md
+++ b/unison-src/transcripts/fix4556.output.md
@@ -1,0 +1,80 @@
+```unison
+thing = 3
+foo.hello = 5 + thing
+bar.hello = 5 + thing
+hey = foo.hello
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bar.hello : Nat
+      foo.hello : Nat
+      hey       : Nat
+      thing     : Nat
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    bar.hello : Nat
+    foo.hello : Nat
+    hey       : Nat
+    thing     : Nat
+
+```
+```unison
+thing = 2
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      thing : Nat
+
+```
+```ucm
+.> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  hey : Nat
+  hey = hello
+  
+  foo.hello : Nat
+  foo.hello =
+    use Nat +
+    5 + thing
+  
+  bar.hello : Nat
+  bar.hello =
+    use Nat +
+    5 + thing
+  
+  thing = 2
+
+  Typechecking failed. I've updated your scratch file with the
+  definitions that need fixing. Once the file is compiling, try
+  `update` again.
+
+```

--- a/unison-src/transcripts/fix4556.output.md
+++ b/unison-src/transcripts/fix4556.output.md
@@ -58,23 +58,8 @@ thing = 2
 
   That's done. Now I'm making sure everything typechecks...
 
-  hey : Nat
-  hey = hello
-  
-  foo.hello : Nat
-  foo.hello =
-    use Nat +
-    5 + thing
-  
-  bar.hello : Nat
-  bar.hello =
-    use Nat +
-    5 + thing
-  
-  thing = 2
+  Everything typechecks, so I'm saving the results...
 
-  Typechecking failed. I've updated your scratch file with the
-  definitions that need fixing. Once the file is compiling, try
-  `update` again.
+  Done.
 
 ```

--- a/unison-src/transcripts/merge.output.md
+++ b/unison-src/transcripts/merge.output.md
@@ -176,19 +176,19 @@ and `quux` namespaces.
 
 .P0> view foo.x foo.y foo.z bar.y quux.y
 
-  bar.y : Nat
+  bar.y : builtin.Nat
   bar.y = 383
   
-  foo.x : Nat
+  foo.x : builtin.Nat
   foo.x = 1
   
-  foo.y : Nat
+  foo.y : builtin.Nat
   foo.y = 2483908
   
-  foo.z : Int
+  foo.z : builtin.Int
   foo.z = +28348
   
-  quux.y : Nat
+  quux.y : builtin.Nat
   quux.y = 333
 
 ```
@@ -324,16 +324,16 @@ Now merging `c1b` into `c1a` should result in the updated version of `a` and `f`
 
 .c1a> view 1-4
 
-  a : Text
+  a : builtin.Text
   a = "hello world!"
   
-  f : Text
+  f : builtin.Text
   f = (x y -> y) a "woot!"
   
-  oog.b : Nat
+  oog.b : builtin.Nat
   oog.b = 230948
   
-  oog.c : Nat
+  oog.c : builtin.Nat
   oog.c = 339249
 
 ```

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -242,14 +242,14 @@ master.frobnicate n = n + 1
 
 .> view master.y
 
-  master.y : Text
+  master.y : master.builtin.Text
   master.y = "updated y"
 
 .> view master.frobnicate
 
-  master.frobnicate : Nat -> Nat
+  master.frobnicate : master.builtin.Nat -> master.builtin.Nat
   master.frobnicate n =
-    use Nat +
+    use master.builtin.Nat +
     n + 1
 
 ```
@@ -262,11 +262,11 @@ At this point, `master` and `feature2` both have some changes the other doesn't 
   
   Added definitions:
   
-    1. z : Nat
+    1. z : feature2.builtin.Nat
   
   Removed definitions:
   
-    2. x : Nat
+    2. x : feature2.builtin.Nat
   
   Tip: You can use `todo` to see if this generated any work to
        do in this namespace and `test` to run the tests. Or you
@@ -292,19 +292,19 @@ And notice that `y` has the most recent value, and that `z` and `frobnicate` bot
 ```ucm
 .> view master.y
 
-  master.y : Text
+  master.y : master.builtin.Text
   master.y = "updated y"
 
 .> view master.z
 
-  master.z : Nat
+  master.z : master.builtin.Nat
   master.z = 99
 
 .> view master.frobnicate
 
-  master.frobnicate : Nat -> Nat
+  master.frobnicate : master.builtin.Nat -> master.builtin.Nat
   master.frobnicate n =
-    use Nat +
+    use master.builtin.Nat +
     n + 1
 
 ```

--- a/unison-src/transcripts/move-all.output.md
+++ b/unison-src/transcripts/move-all.output.md
@@ -183,7 +183,7 @@ bonk.zonk = 5
 
 .a> view zonk.zonk
 
-  zonk.zonk : Nat
+  zonk.zonk : builtin.Nat
   zonk.zonk = 5
 
 ```

--- a/unison-src/transcripts/name-selection.output.md
+++ b/unison-src/transcripts/name-selection.output.md
@@ -28,7 +28,9 @@ Will add `a` and `b` to the codebase and give `b` a longer (in terms of segment 
 .a> view a
 
   a : Nat
-  a = b + 1
+  a =
+    use Nat +
+    b + 1
 
 .> cd .
 
@@ -1528,21 +1530,21 @@ The original `a2` namespace has an unconflicted definition for `c` and `d`, but 
     use Nat +
     0 + 1
   
-  a2.c : Nat
+  a2.c : a2.builtin.Nat
   a2.c = 1
   
-  a2.d : Nat
+  a2.d : a2.builtin.Nat
   a2.d =
-    use Nat +
+    use a2.builtin.Nat +
     a2.c + 10
   
-  a3.c#dcgdua2lj6 : Nat
+  a3.c#dcgdua2lj6 : a3.builtin.Nat
   a3.c#dcgdua2lj6 = 2
   
-  a3.d#9ivhgvhthc : Nat
+  a3.d#9ivhgvhthc : a3.builtin.Nat
   a3.d#9ivhgvhthc =
-    use Nat +
-    c#dcgdua2lj6 + 10
+    use a3.builtin.Nat +
+    a3.c#dcgdua2lj6 + 10
 
 ```
 ## Name biasing

--- a/unison-src/transcripts/numbered-args.output.md
+++ b/unison-src/transcripts/numbered-args.output.md
@@ -74,7 +74,7 @@ We can ask to `view` the second element of this list:
 
 .temp> view 2
 
-  baz : Text
+  baz : builtin.Text
   baz = "baz"
 
 ```
@@ -93,13 +93,13 @@ And we can `view` multiple elements by separating with spaces:
 
 .temp> view 2 3 5
 
-  baz : Text
+  baz : builtin.Text
   baz = "baz"
   
-  corge : Text
+  corge : builtin.Text
   corge = "corge"
   
-  quux : Text
+  quux : builtin.Text
   quux = "quux"
 
 ```
@@ -118,13 +118,13 @@ We can also ask for a range:
 
 .temp> view 2-4
 
-  baz : Text
+  baz : builtin.Text
   baz = "baz"
   
-  corge : Text
+  corge : builtin.Text
   corge = "corge"
   
-  foo : Text
+  foo : builtin.Text
   foo = "foo"
 
 ```
@@ -143,22 +143,22 @@ And we can ask for multiple ranges and use mix of ranges and numbers:
 
 .temp> view 1-3 4 5-6
 
-  bar : Text
+  bar : builtin.Text
   bar = "bar"
   
-  baz : Text
+  baz : builtin.Text
   baz = "baz"
   
-  corge : Text
+  corge : builtin.Text
   corge = "corge"
   
-  foo : Text
+  foo : builtin.Text
   foo = "foo"
   
-  quux : Text
+  quux : builtin.Text
   quux = "quux"
   
-  qux : Text
+  qux : builtin.Text
   qux = "qux"
 
 ```

--- a/unison-src/transcripts/propagate.output.md
+++ b/unison-src/transcripts/propagate.output.md
@@ -52,7 +52,7 @@ And then we add it.
 
 .subpath> view fooToInt
 
-  fooToInt : Foo -> Int
+  fooToInt : Foo -> builtin.Int
   fooToInt _ = +42
 
 ```
@@ -91,7 +91,7 @@ and update the codebase to use the new type `Foo`...
 ```ucm
 .subpath> view fooToInt
 
-  fooToInt : Foo -> Int
+  fooToInt : Foo -> builtin.Int
   fooToInt _ = +42
 
 .> cd .
@@ -181,12 +181,12 @@ type of `otherTerm` should remain the same.
 ```ucm
 .subpath.preserve> view someTerm
 
-  someTerm : Optional x -> Optional x
-  someTerm _ = None
+  someTerm : builtin.Optional x -> builtin.Optional x
+  someTerm _ = builtin.Optional.None
 
 .subpath.preserve> view otherTerm
 
-  otherTerm : Optional baz -> Optional baz
+  otherTerm : builtin.Optional baz -> builtin.Optional baz
   otherTerm y = someTerm y
 
 ```
@@ -282,7 +282,7 @@ The other namespace should be left alone.
 ```ucm
 .subpath.two> view someTerm
 
-  someTerm : Optional foo -> Optional foo
+  someTerm : builtin.Optional foo -> builtin.Optional foo
   someTerm x = x
 
 ```

--- a/unison-src/transcripts/squash.output.md
+++ b/unison-src/transcripts/squash.output.md
@@ -245,9 +245,9 @@ Alice then squash merges into `trunk`, as does Bob. It's as if Alice and Bob bot
   
   Added definitions:
   
-    1. bodaciousNumero   : Nat
+    1. bodaciousNumero   : builtin.Nat
     2. productionReadyId : x -> x
-    3. superRadNumber    : Nat
+    3. superRadNumber    : builtin.Nat
   
   Tip: You can use `todo` to see if this generated any work to
        do in this namespace and `test` to run the tests. Or you
@@ -275,9 +275,9 @@ Alice then squash merges into `trunk`, as does Bob. It's as if Alice and Bob bot
   
   Added definitions:
   
-    1. babyDon'tHurtMe : Text
+    1. babyDon'tHurtMe : builtin.Text
     2. no              : more -> r
-    3. whatIsLove      : Text
+    3. whatIsLove      : builtin.Text
   
   Tip: You can use `todo` to see if this generated any work to
        do in this namespace and `test` to run the tests. Or you
@@ -354,9 +354,9 @@ This time, we'll first squash Alice and Bob's changes together before squashing 
   
   Added definitions:
   
-    1. bodaciousNumero   : Nat
+    1. bodaciousNumero   : builtin.Nat
     2. productionReadyId : x -> x
-    3. superRadNumber    : Nat
+    3. superRadNumber    : builtin.Nat
   
   Tip: You can use `todo` to see if this generated any work to
        do in this namespace and `test` to run the tests. Or you
@@ -371,12 +371,12 @@ This time, we'll first squash Alice and Bob's changes together before squashing 
   
   Added definitions:
   
-    1. babyDon'tHurtMe   : Text
-    2. bodaciousNumero   : Nat
+    1. babyDon'tHurtMe   : builtin.Text
+    2. bodaciousNumero   : builtin.Nat
     3. no                : more -> r
     4. productionReadyId : x -> x
-    5. superRadNumber    : Nat
-    6. whatIsLove        : Text
+    5. superRadNumber    : builtin.Nat
+    6. whatIsLove        : builtin.Text
   
   Tip: You can use `todo` to see if this generated any work to
        do in this namespace and `test` to run the tests. Or you
@@ -413,10 +413,10 @@ Another thing we can do is `squash` into an empty namespace. This effectively ma
   
   Added definitions:
   
-    1. bodaciousNumero   : Nat
+    1. bodaciousNumero   : builtin.Nat
     2. productionReadyId : x -> x
-    3. superRadNumber    : Nat
-    4. x                 : Nat
+    3. superRadNumber    : builtin.Nat
+    4. x                 : builtin.Nat
   
   Tip: You can use `todo` to see if this generated any work to
        do in this namespace and `test` to run the tests. Or you
@@ -484,8 +484,8 @@ This checks to see that squashing correctly preserves deletions:
   
   Removed definitions:
   
-    1. Nat.* : Nat -> Nat -> Nat
-    2. Nat.+ : Nat -> Nat -> Nat
+    1. Nat.* : builtin.Nat -> builtin.Nat -> builtin.Nat
+    2. Nat.+ : builtin.Nat -> builtin.Nat -> builtin.Nat
   
   Tip: You can use `todo` to see if this generated any work to
        do in this namespace and `test` to run the tests. Or you

--- a/unison-src/transcripts/view.output.md
+++ b/unison-src/transcripts/view.output.md
@@ -18,7 +18,7 @@ b.thing = "b"
 -- Should be local to namespace
 .a> view thing
 
-  thing : Text
+  thing : builtin.Text
   thing = "a"
 
 -- view.global should search globally and be absolutely qualified
@@ -33,7 +33,7 @@ b.thing = "b"
 -- Should support absolute paths outside of current namespace
 .a> view .b.thing
 
-  .b.thing : Text
+  .b.thing : builtin.Text
   .b.thing = "b"
 
 ```


### PR DESCRIPTION
## Overview

Works around #4556 by printing enough segments to disambiguate aliases.

## Test coverage

A new transcript has been added

## Loose ends

This PR makes PPEs worse by printing more segments than before to work around a bug that is only present for aliases defined in a scratch file (rather than aliases in the codebase). So, we plan to follow this up with a PR that only prints these additional segments when printing names for terms/types defined in update/upgrade.
