### PR TITLE
add "update transcripts" workflow

### DIFF
--- a/.github/workflows/update-transcripts.yaml
+++ b/.github/workflows/update-transcripts.yaml
@@ -104,3 +104,7 @@ jobs:
           git add --all
           # Fail if any transcripts cause git diffs.
           git diff --cached --ignore-cr-at-eol --exit-code
+      - name: save transcript changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: rerun transcripts and round-trip tests

--- a/.github/workflows/update-transcripts.yaml
+++ b/.github/workflows/update-transcripts.yaml
@@ -1,0 +1,106 @@
+name: update-golden-tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update_transcripts:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      matrix:
+        os:
+          - macOS-12
+    steps:
+      - uses: actions/checkout@v4
+      - id: stackage-resolver
+        name: record stackage resolver
+        # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files
+        # looks for `resolver: nightly-yyyy-mm-dd` or `resolver: lts-xx.yy` in `stack.yaml` and splits it into
+        # `nightly` or `lts-xx`.  the whole resolver string is put into resolver_long as a backup cache key
+        # ${{ steps.stackage-resolver.outputs.resolver_short }}
+        # ${{ steps.stackage-resolver.outputs.resolver_long }}
+        run: |
+          grep resolver stack.yaml | awk '{ x="resolver_short="; if (split($2,a,"-") > 2) print x a[1]; else {split($2,b,"."); print x b[1]}}' >> "$GITHUB_OUTPUT"
+          grep resolver stack.yaml | awk '{print "resolver_long="$2}' >> "$GITHUB_OUTPUT"
+      # Cache ~/.stack, keyed by the contents of 'stack.yaml'.
+      - uses: actions/cache@v3
+        name: cache ~/.stack (unix)
+        if: runner.os != 'Windows'
+        with:
+          path: ~/.stack
+          key: stack-1_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_long }}-${{hashFiles('**/stack.yaml')}}-${{github.sha}}
+          # Fall-back to use the most recent cache for the stack.yaml, or failing that the OS
+          restore-keys: |
+            stack-1_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_long }}-${{hashFiles('**/stack.yaml')}}-
+            stack-1_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_long }}-
+            stack-1_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_short }}-
+            stack-1_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_short }}.
+            stack-1_${{matrix.os}}-
+
+      # Cache each local package's ~/.stack-work for fast incremental builds in CI.
+      - uses: actions/cache@v3
+        name: cache .stack-work
+        with:
+          path: |
+            **/.stack-work
+          # Main cache key: commit hash. This should always result in a cache miss...
+          # So when loading a cache we'll always fall back to the restore-keys,
+          # which should load the most recent cache via a prefix search on the most
+          # recent branch cache.
+          # Then it will save a new cache at this commit sha, which should be used by
+          # the next build on this branch.
+          key: stack-work-4_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_short }}-${{hashFiles('**/stack.yaml')}}-${{github.sha}}
+          restore-keys: |
+            stack-work-4_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_long }}-${{hashFiles('**/stack.yaml')}}-
+            stack-work-4_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_long }}-
+            stack-work-4_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_short }}-
+            stack-work-4_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_short }}.
+            stack-work-4_${{matrix.os}}-
+
+      # Install stack by downloading the binary from GitHub.
+      # The installation process differs by OS.
+      - name: install stack (Linux)
+        if: runner.os == 'Linux'
+        working-directory: ${{ runner.temp }}
+        run: |
+          mkdir stack && cd stack
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.9.1/stack-2.9.1-linux-x86_64.tar.gz | tar -xz
+          echo "$PWD/stack-"* >> $GITHUB_PATH
+
+      # One of the transcripts fails if the user's git name hasn't been set.
+      - name: set git user info
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+      - name: build
+        run: stack --no-terminal build --fast --no-run-tests --test
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v41
+        with:
+          files: |
+            **/*.md
+          separator: "\n"
+      - name: round-trip-tests
+        run: |
+          mkdir -p /private/tmp
+          touch /private/tmp/roundtrip.u
+          touch /private/tmp/rewrite-tmp.u
+          stack --no-terminal exec unison transcript unison-src/transcripts-round-trip/main.md
+          git add unison-src/transcripts-round-trip/main.output.md
+          # Fail if any transcripts cause git diffs.
+          git diff --cached --ignore-cr-at-eol --exit-code
+          stack --no-terminal exec unison transcript unison-src/transcripts-manual/rewrites.md
+          git add unison-src/transcripts-manual/rewrites.output.md
+          # Fail if any transcripts cause git diffs.
+          git diff --cached --ignore-cr-at-eol --exit-code
+      - name: transcripts
+        run: |
+          stack --no-terminal exec transcripts
+          # Add all changes to the index for when we diff.
+          git add --all
+          # Fail if any transcripts cause git diffs.
+          git diff --cached --ignore-cr-at-eol --exit-code


### PR DESCRIPTION
It will probably take a few tries to get this right, but the idea is that when a PR is stalled on needing to re-run transcripts, we can do it from Github now. It is not run automatically because manual intervention is needed to re-run the tests after an automatic commit like the one here. I'm not even sure if this implementation strategy makes sense, but we'll run it and see.