### PR TITLE
remove irrelevant `changed-files` step from update-transcripts-workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,8 @@ on:
       - trunk
     tags:
       - release/*
+  workflow_dispatch:
+
 
 jobs:
 

--- a/.github/workflows/update-transcripts.yaml
+++ b/.github/workflows/update-transcripts.yaml
@@ -83,21 +83,10 @@ jobs:
           touch /private/tmp/roundtrip.u
           touch /private/tmp/rewrite-tmp.u
           stack --no-terminal exec unison transcript unison-src/transcripts-round-trip/main.md
-          git add unison-src/transcripts-round-trip/main.output.md
-          # Fail if any transcripts cause git diffs.
-          git diff --cached --ignore-cr-at-eol --exit-code
           stack --no-terminal exec unison transcript unison-src/transcripts-manual/rewrites.md
-          git add unison-src/transcripts-manual/rewrites.output.md
-          # Fail if any transcripts cause git diffs.
-          git diff --cached --ignore-cr-at-eol --exit-code
       - name: transcripts
-        run: |
-          stack --no-terminal exec transcripts
-          # Add all changes to the index for when we diff.
-          git add --all
-          # Fail if any transcripts cause git diffs.
-          git diff --cached --ignore-cr-at-eol --exit-code
-      - name: save changes
+        run: stack --no-terminal exec transcripts
+      - name: save transcript changes
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: rerun transcripts and round-trip tests

--- a/.github/workflows/update-transcripts.yaml
+++ b/.github/workflows/update-transcripts.yaml
@@ -1,4 +1,4 @@
-name: update-golden-tests
+name: update-transcripts
 
 on:
   workflow_dispatch:

--- a/.github/workflows/update-transcripts.yaml
+++ b/.github/workflows/update-transcripts.yaml
@@ -77,13 +77,6 @@ jobs:
           git config --global user.email "actions@github.com"
       - name: build
         run: stack --no-terminal build --fast --no-run-tests --test
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v41
-        with:
-          files: |
-            **/*.md
-          separator: "\n"
       - name: round-trip-tests
         run: |
           mkdir -p /private/tmp
@@ -104,7 +97,7 @@ jobs:
           git add --all
           # Fail if any transcripts cause git diffs.
           git diff --cached --ignore-cr-at-eol --exit-code
-      - name: save transcript changes
+      - name: save changes
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: rerun transcripts and round-trip tests


### PR DESCRIPTION
This step was meant to collect arguments for ormolu by looking at changed haskell files, which is irrelevant in this workflow.