### PR TITLE
testing the `update-transcripts` workflow

### DIFF
--- a/unison-cli/src/Unison/CommandLine.hs
+++ b/unison-cli/src/Unison/CommandLine.hs
@@ -180,7 +180,7 @@ parseInput codebase getRoot currentPath numberedArgs patterns segments = runExce
         P.lines
           [ ( "Sorry, I was expecting an argument for the "
                 <> P.text argDesc
-                <> ", and I couldn't find any to suggest to you. 😅"
+                <> ", and I couldn't find any to suggest to you. 😓"
             )
           ]
 

--- a/unison-src/transcripts/fuzzy-options.output.md
+++ b/unison-src/transcripts/fuzzy-options.output.md
@@ -20,7 +20,7 @@ opening an empty fuzzy-select.
 
 ⚠️
 
-Sorry, I was expecting an argument for the definition to view, and I couldn't find any to suggest to you. 😅
+Sorry, I was expecting an argument for the definition to view, and I couldn't find any to suggest to you. 😓
 
 ```
 ```unison


### PR DESCRIPTION
When you have a PR that fails CI because you forgot to check in transcript output changes, manually trigger the `update-transcripts` workflow for that branch. (Unfortunately we can't select contributor branches when triggering the workflow, but the contributor can do so from their fork.)

CI doesn't run automatically after the `update-transcripts` workflow is complete (that's why I don't want it to happen automatically, same situation as we were in with `ormolu`), but after triggering the manual update, you can trigger CI again manually for the branch too. The results only show up in the Actions pane, so just link to the job in the PR comments after launching.