### PR TITLE
Don't replace numbered args list with an empty one.

### DIFF
--- a/unison-cli/src/Unison/Cli/Monad.hs
+++ b/unison-cli/src/Unison/Cli/Monad.hs
@@ -36,6 +36,7 @@ module Unison.Cli.Monad
     -- * Communicating output to the user
     respond,
     respondNumbered,
+    setNumberedArgs,
 
     -- * Debug-timing actions
     time,
@@ -412,6 +413,11 @@ respondNumbered :: NumberedOutput -> Cli ()
 respondNumbered output = do
   Env {notifyNumbered} <- ask
   args <- liftIO (notifyNumbered output)
+  setNumberedArgs args
+
+-- | Updates the numbered args, but only if the new args are non-empty.
+setNumberedArgs :: NumberedArgs -> Cli ()
+setNumberedArgs args = do
   unless (null args) do
     #numberedArgs .= args
 

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/FindAndReplace.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/FindAndReplace.hs
@@ -86,7 +86,7 @@ handleStructuredFindI rule = do
   results0 <- traverse ok results
   let results = Alphabetical.sortAlphabeticallyOn fst [(hq, r) | ((hq, r), True) <- results0]
   let toNumArgs = Text.unpack . Reference.toText . Referent.toReference . view _2
-  #numberedArgs .= map toNumArgs results
+  Cli.setNumberedArgs $ map toNumArgs results
   Cli.respond (ListStructuredFind (fst <$> results))
 
 lookupRewrite ::

--- a/unison-cli/tests/Unison/Test/Cli/Monad.hs
+++ b/unison-cli/tests/Unison/Test/Cli/Monad.hs
@@ -16,7 +16,7 @@ test =
             Cli.runCli dummyEnv dummyLoopState do
               Cli.label \goto -> do
                 Cli.label \_ -> do
-                  #numberedArgs .= ["foo"]
+                  Cli.setNumberedArgs ["foo"]
                   goto (1 :: Int)
                 pure 2
         -- test that 'goto' short-circuits, as expected


### PR DESCRIPTION
## Overview

closes https://github.com/unisonweb/unison/issues/4602
closes #4601 

Some commands, like `dependents`, would clear the numberedArgs list even if they didn't list any new numbers, which was confusing to users.

Now it only replaces the numbers if it has at least one numbered arg in the new list.

## Implementation notes

Replace all `#numberedArgs .= ...` with `Cli.setNumberedArgs` which is a no-op on  `[]`.


## Test coverage

Nah

## Loose Ends

We should maybe just be using `respondNumbered` for these, but that's a lot more work with relatively low additional benefit.