### PR TITLE
bugfix: fix upgrade suffixifier

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Upgrade.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Upgrade.hs
@@ -171,7 +171,7 @@ handleUpgrade oldDepName newDepName = do
           UnisonFile.emptyUnisonFile
       hashLength <- Codebase.hashLength
       let primaryPPE = makeOldDepPPE oldDepName newDepName namesExcludingOldDep oldDep oldDepWithoutDeps newDepWithoutDeps
-      let secondaryPPE = PPED.fromNamesSuffixifiedByHash hashLength namesExcludingOldDep
+      let secondaryPPE = PPED.fromNamesSuffixifiedByName hashLength namesExcludingOldDep
       pure (unisonFile, primaryPPE `PPED.addFallback` secondaryPPE)
 
   parsingEnv <- makeParsingEnv projectPath namesExcludingOldDep

--- a/unison-src/transcripts/upgrade-suffixifies-properly.md
+++ b/unison-src/transcripts/upgrade-suffixifies-properly.md
@@ -1,0 +1,24 @@
+```ucm:hide
+.> project.create-empty myproject
+myproject/main> builtins.merge
+myproject/main> move.namespace builtin lib.builtin
+```
+
+```unison
+lib.old.foo = 25
+lib.new.foo = +30
+a.x.x.x.x = 100
+b.x.x.x.x = 100
+c.y.y.y.y = lib.old.foo + 10
+d.y.y.y.y = lib.old.foo + 10
+bar = a.x.x.x.x + c.y.y.y.y
+```
+
+```ucm
+myproject/main> add
+```
+
+```ucm:error
+myproject/main> upgrade old new
+```
+

--- a/unison-src/transcripts/upgrade-suffixifies-properly.output.md
+++ b/unison-src/transcripts/upgrade-suffixifies-properly.output.md
@@ -1,0 +1,68 @@
+```unison
+lib.old.foo = 25
+lib.new.foo = +30
+a.x.x.x.x = 100
+b.x.x.x.x = 100
+c.y.y.y.y = lib.old.foo + 10
+d.y.y.y.y = lib.old.foo + 10
+bar = a.x.x.x.x + c.y.y.y.y
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      a.x.x.x.x   : Nat
+      b.x.x.x.x   : Nat
+      bar         : Nat
+      c.y.y.y.y   : Nat
+      d.y.y.y.y   : Nat
+      lib.new.foo : Int
+      lib.old.foo : Nat
+
+```
+```ucm
+myproject/main> add
+
+  ⍟ I've added these definitions:
+  
+    a.x.x.x.x   : Nat
+    b.x.x.x.x   : Nat
+    bar         : Nat
+    c.y.y.y.y   : Nat
+    d.y.y.y.y   : Nat
+    lib.new.foo : Int
+    lib.old.foo : Nat
+
+```
+```ucm
+myproject/main> upgrade old new
+
+  I couldn't automatically upgrade old to new. However, I've
+  added the definitions that need attention to the top of
+  scratch.u.
+
+```
+```unison:added-by-ucm scratch.u
+bar : Nat
+bar =
+  use Nat +
+  x + y
+
+d.y.y.y.y : Nat
+d.y.y.y.y =
+  use Nat +
+  foo + 10
+
+c.y.y.y.y : Nat
+c.y.y.y.y =
+  use Nat +
+  foo + 10
+```
+

--- a/unison-src/transcripts/upgrade-suffixifies-properly.output.md
+++ b/unison-src/transcripts/upgrade-suffixifies-properly.output.md
@@ -53,7 +53,7 @@ myproject/main> upgrade old new
 bar : Nat
 bar =
   use Nat +
-  x + y
+  a.x.x.x.x + c.y.y.y.y
 
 d.y.y.y.y : Nat
 d.y.y.y.y =


### PR DESCRIPTION
## Overview

#4589 accidentally only fully addressed the issue in `update`, not `upgrade`. This PR fixes the remaining sources of suffixify-by-name in  `upgrade`.

## Test coverage

There's a new transcript that demonstrates the behavior before and after the fix, in different commits.
