### PR TITLE
change pre-release tag name again to `trunk-build`

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -162,7 +162,7 @@ jobs:
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "pre-release"
+          automatic_release_tag: "trunk-build"
           prerelease: true
           title: "Development Build"
           files: |


### PR DESCRIPTION
Apparently I need something that appears alphabetically later than "release", to work around a Github issue. Probably nobody cares, since we should be linking to the latest actual release on the website anyway, e.g. https://github.com/unisonweb/unison/releases/latest/download/ucm-linux.tar.gz

Loose ends: update homebrew formula too, but it's in a different repo.