### PR TITLE
Allow forking between projects/branches

### DIFF
--- a/unison-cli/src/Unison/Cli/ProjectUtils.hs
+++ b/unison-cli/src/Unison/Cli/ProjectUtils.hs
@@ -12,6 +12,7 @@ module Unison.Cli.ProjectUtils
     projectBranchPath,
     projectBranchSegment,
     projectBranchPathPrism,
+    branchRelativePathToAbsolute,
 
     -- * Name hydration
     hydrateNames,
@@ -49,11 +50,33 @@ import Unison.Codebase.Editor.Output (Output (LocalProjectBranchDoesntExist))
 import Unison.Codebase.Editor.Output qualified as Output
 import Unison.Codebase.Path (Path')
 import Unison.Codebase.Path qualified as Path
+import Unison.CommandLine.BranchRelativePath (BranchRelativePath)
+import Unison.CommandLine.BranchRelativePath qualified as BranchRelativePath
 import Unison.Prelude
 import Unison.Project (ProjectAndBranch (..), ProjectBranchName, ProjectName)
 import Unison.Project.Util
 import Unison.Sqlite qualified as Sqlite
 import Witch (unsafeFrom)
+
+branchRelativePathToAbsolute :: BranchRelativePath -> Cli Path.Absolute
+branchRelativePathToAbsolute = \case
+  BranchRelativePath.BranchRelative brp -> case brp of
+    These projectBranch path -> do
+      projectBranch <- getIds <$> expectProjectAndBranchByTheseNames (toThese projectBranch)
+      pure (Path.resolve (projectBranchPath projectBranch) path)
+    This projectBranch -> do
+      projectBranch <- getIds <$> expectProjectAndBranchByTheseNames (toThese projectBranch)
+      pure (projectBranchPath projectBranch)
+    That path -> do
+      projectBranch <- expectCurrentProjectIds
+      pure (Path.resolve (projectBranchPath projectBranch) path)
+  BranchRelativePath.LoosePath path -> Cli.resolvePath' path
+  where
+    toThese = \case
+      Left branchName -> That branchName
+      Right (projectName, branchName) -> These projectName branchName
+    getIds = \case
+      ProjectAndBranch project branch -> ProjectAndBranch (view #projectId project) (view #branchId branch)
 
 -- | Get the current project that a user is on.
 getCurrentProject :: Cli (Maybe Sqlite.Project)
@@ -75,6 +98,11 @@ expectCurrentProject = do
 getCurrentProjectIds :: Cli (Maybe (ProjectAndBranch ProjectId ProjectBranchId))
 getCurrentProjectIds =
   fmap fst . preview projectBranchPathPrism <$> Cli.getCurrentPath
+
+-- | Like 'getCurrentProjectIds', but fails with a message if the user is not on a project branch.
+expectCurrentProjectIds :: Cli (ProjectAndBranch ProjectId ProjectBranchId)
+expectCurrentProjectIds =
+  getCurrentProjectIds & onNothingM (Cli.returnEarly Output.NotOnProjectBranch)
 
 -- | Get the current project+branch+branch path that a user is on.
 getCurrentProjectBranch :: Cli (Maybe (ProjectAndBranch Sqlite.Project Sqlite.ProjectBranch, Path.Path))

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -418,20 +418,21 @@ loop e = do
                 Cli.updateRoot newRoot description
                 Cli.respond Success
             ForkLocalBranchI src0 dest0 -> do
-              srcb <-
+              (srcb, branchEmpty) <-
                 case src0 of
-                  Left hash -> Cli.resolveShortCausalHash hash
-                  Right path' -> Cli.expectBranchAtPath' path'
-              Cli.assertNoBranchAtPath' dest0
+                  Left hash -> (, WhichBranchEmptyHash hash) <$> Cli.resolveShortCausalHash hash
+                  Right path' -> do
+                    absPath <- ProjectUtils.branchRelativePathToAbsolute path'
+                    let srcp = Path.convert absPath
+                    srcb <- Cli.expectBranchAtPath' srcp
+                    pure (srcb, WhichBranchEmptyPath srcp)
               description <- inputDescription input
-              dest <- Cli.resolvePath' dest0
+              dest <- ProjectUtils.branchRelativePathToAbsolute dest0
               ok <- Cli.updateAtM description dest (const $ pure srcb)
               Cli.respond
                 if ok
                   then Success
-                  else BranchEmpty case src0 of
-                    Left hash -> WhichBranchEmptyHash hash
-                    Right path -> WhichBranchEmptyPath path
+                  else BranchEmpty branchEmpty
             MergeLocalBranchI src0 dest0 mergeMode -> do
               description <- inputDescription input
               src0 <- ProjectUtils.expectLooseCodeOrProjectBranch src0
@@ -1176,10 +1177,11 @@ loop e = do
 inputDescription :: Input -> Cli Text
 inputDescription input =
   case input of
-    ForkLocalBranchI src0 dest0 -> do
-      src <- hp' src0
-      dest <- p' dest0
-      pure ("fork " <> src <> " " <> dest)
+    SaveExecuteResultI _str -> pure "save-execute-result"
+    ForkLocalBranchI _src0 _dest0 -> do
+      -- src <- hp' src0
+      -- dest <- p' dest0
+      pure ("fork ") -- todo
     MergeLocalBranchI src0 dest0 mode -> do
       src <- looseCodeOrProjectToText src0
       dest <- looseCodeOrProjectToText dest0
@@ -1370,7 +1372,6 @@ inputDescription input =
     PushRemoteBranchI {} -> wat
     QuitI {} -> wat
     ReleaseDraftI {} -> wat
-    SaveExecuteResultI {} -> wat
     ShowDefinitionByPrefixI {} -> wat
     ShowDefinitionI {} -> wat
     ShowReflogI {} -> wat

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -15,6 +15,7 @@ module Unison.Codebase.Editor.Input
     AbsBranchId,
     LooseCodeOrProject,
     parseBranchId,
+    parseBranchId2,
     parseShortCausalHash,
     HashOrHQSplit',
     Insistence (..),
@@ -42,6 +43,7 @@ import Unison.Codebase.ShortCausalHash (ShortCausalHash)
 import Unison.Codebase.ShortCausalHash qualified as SCH
 import Unison.Codebase.SyncMode (SyncMode)
 import Unison.Codebase.Verbosity
+import Unison.CommandLine.BranchRelativePath
 import Unison.HashQualified qualified as HQ
 import Unison.Name (Name)
 import Unison.NameSegment (NameSegment)
@@ -86,6 +88,12 @@ parseBranchId ('#' : s) = case SCH.fromText (Text.pack s) of
   Just h -> pure $ Left h
 parseBranchId s = Right <$> Path.parsePath' s
 
+parseBranchId2 :: String -> Either (P.Pretty P.ColorText) (Either ShortCausalHash BranchRelativePath)
+parseBranchId2 ('#' : s) = case SCH.fromText (Text.pack s) of
+  Nothing -> Left "Invalid hash, expected a base32hex string."
+  Just h -> Right (Left h)
+parseBranchId2 s = Right <$> parseBranchRelativePath s
+
 parseShortCausalHash :: String -> Either String ShortCausalHash
 parseShortCausalHash ('#' : s) | Just sch <- SCH.fromText (Text.pack s) = Right sch
 parseShortCausalHash _ = Left "Invalid hash, expected a base32hex string."
@@ -102,7 +110,7 @@ data Input
     -- directory ops
     -- `Link` must describe a repo and a source path within that repo.
     -- clone w/o merge, error if would clobber
-    ForkLocalBranchI (Either ShortCausalHash Path') Path'
+    ForkLocalBranchI (Either ShortCausalHash BranchRelativePath) BranchRelativePath
   | -- merge first causal into destination
     MergeLocalBranchI LooseCodeOrProject LooseCodeOrProject Branch.MergeMode
   | PreviewMergeLocalBranchI LooseCodeOrProject LooseCodeOrProject

--- a/unison-cli/src/Unison/CommandLine/BranchRelativePath.hs
+++ b/unison-cli/src/Unison/CommandLine/BranchRelativePath.hs
@@ -1,0 +1,74 @@
+module Unison.CommandLine.BranchRelativePath
+  ( BranchRelativePath (..),
+    parseBranchRelativePath,
+    branchRelativePathParser,
+  )
+where
+
+import Data.Char (isSpace)
+import Data.Set qualified as Set
+import Data.Text qualified as Text
+import Data.These (These (..))
+import Text.Megaparsec qualified as Megaparsec
+import Text.Megaparsec.Char qualified as Megaparsec
+import Unison.Codebase.Path qualified as Path
+import Unison.Codebase.Path.Parse qualified as Path
+import Unison.Prelude
+import Unison.Project (ProjectBranchName, ProjectBranchSpecifier (..), ProjectName)
+import Unison.Project qualified as Project
+import Unison.Util.ColorText qualified as CT
+import Unison.Util.Pretty qualified as P
+
+data BranchRelativePath
+  = BranchRelative (These (Either ProjectBranchName (ProjectName, ProjectBranchName)) Path.Relative)
+  | LoosePath Path.Path'
+  deriving stock (Eq, Show)
+
+parseBranchRelativePath :: String -> Either (P.Pretty CT.ColorText) BranchRelativePath
+parseBranchRelativePath str =
+  case Megaparsec.parse branchRelativePathParser "<none>" (Text.pack str) of
+    Left e -> Left (P.string (Megaparsec.errorBundlePretty e))
+    Right x -> Right x
+
+branchRelativePathParser :: Megaparsec.Parsec Void Text BranchRelativePath
+branchRelativePathParser =
+  asum
+    [ LoosePath <$> path',
+      BranchRelative <$> branchRelative
+    ]
+  where
+    branchRelative :: Megaparsec.Parsec Void Text (These (Either ProjectBranchName (ProjectName, ProjectBranchName)) Path.Relative)
+    branchRelative = asum [fullPath, currentBranchRootPath]
+
+    path' = Megaparsec.try do
+      offset <- Megaparsec.getOffset
+      pathStr <- Megaparsec.takeWhile1P (Just "path char") (not . isSpace)
+      case Path.parsePath' (Text.unpack pathStr) of
+        Left err -> failureAt offset err
+        Right x -> pure x
+
+    relPath = do
+      offset <- Megaparsec.getOffset
+      path' >>= \(Path.Path' inner) -> case inner of
+        Left _ -> failureAt offset "Expected a relative path but found an absolute path"
+        Right x -> pure x
+
+    fullPath = do
+      projectAndBranchNames <- do
+        projectBranch <- Project.projectAndBranchNamesParser ProjectBranchSpecifier'Name
+        offset <- Megaparsec.getOffset
+        _ <- Megaparsec.char ':'
+        case projectBranch of
+          This _ -> failureAt offset "Expected a project and branch before the colon (e.g. project/branch:a.path)"
+          That pbn -> pure (Left pbn)
+          These pn pbn -> pure (Right (pn, pbn))
+      optional relPath <&> \case
+        Nothing -> This projectAndBranchNames
+        Just rp -> These projectAndBranchNames rp
+
+    currentBranchRootPath = do
+      _ <- Megaparsec.char ':'
+      That <$> relPath
+
+    failureAt :: forall a. Int -> String -> Megaparsec.Parsec Void Text a
+    failureAt offset str = Megaparsec.parseError (Megaparsec.FancyError offset (Set.singleton (Megaparsec.ErrorFail str)))

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -91,6 +91,7 @@ library
       Unison.Codebase.TranscriptParser
       Unison.Codebase.Watch
       Unison.CommandLine
+      Unison.CommandLine.BranchRelativePath
       Unison.CommandLine.Completion
       Unison.CommandLine.DisplayValues
       Unison.CommandLine.FuzzySelect

--- a/unison-src/transcripts/branch-relative-path.md
+++ b/unison-src/transcripts/branch-relative-path.md
@@ -1,0 +1,31 @@
+```ucm:hide
+.> builtins.merge
+.> project.create-empty p0
+.> project.create-empty p1
+```
+
+```unison
+foo = 5
+foo.bar = 1
+```
+
+```ucm
+p0/main> add
+```
+
+```unison
+bonk = 5
+donk.bonk = 1
+```
+
+```ucm
+p1/main> add
+p1/main> fork p0/main: zzz
+p1/main> find zzz
+p1/main> fork p0/main:foo yyy
+p1/main> find yyy
+p0/main> fork p1/main: p0/main:p1
+p0/main> ls p1
+p0/main> ls p1.zzz
+p0/main> ls p1.yyy
+```

--- a/unison-src/transcripts/branch-relative-path.output.md
+++ b/unison-src/transcripts/branch-relative-path.output.md
@@ -1,0 +1,97 @@
+```unison
+foo = 5
+foo.bar = 1
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      foo     : Nat
+      foo.bar : Nat
+
+```
+```ucm
+p0/main> add
+
+  ⍟ I've added these definitions:
+  
+    foo     : Nat
+    foo.bar : Nat
+
+```
+```unison
+bonk = 5
+donk.bonk = 1
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bonk      : Nat
+        (also named foo)
+      donk.bonk : Nat
+        (also named foo.bar)
+
+```
+```ucm
+p1/main> add
+
+  ⍟ I've added these definitions:
+  
+    bonk      : Nat
+    donk.bonk : Nat
+
+p1/main> fork p0/main: zzz
+
+  Done.
+
+p1/main> find zzz
+
+  1. zzz.foo : Nat
+  2. zzz.foo.bar : Nat
+  
+
+p1/main> fork p0/main:foo yyy
+
+  Done.
+
+p1/main> find yyy
+
+  1. yyy.bar : Nat
+  
+
+p0/main> fork p1/main: p0/main:p1
+
+  Done.
+
+p0/main> ls p1
+
+  1. bonk  (##Nat)
+  2. donk/ (1 term)
+  3. yyy/  (1 term)
+  4. zzz/  (2 terms)
+
+p0/main> ls p1.zzz
+
+  1. foo  (##Nat)
+  2. foo/ (1 term)
+
+p0/main> ls p1.yyy
+
+  1. bar (##Nat)
+
+```


### PR DESCRIPTION
fixes #4423 

## Overview

Adds branch relative paths and updates the fork command to use them. So, you can fork between projects and/or branches. 

## Test coverage

See the new branch-relative-path transcript