### PR TITLE
Huge speedup to startup time by leveraging branch cache

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -381,7 +381,7 @@ sqliteCodebase debugName root localOrRemote lockOption migrationStrategy action 
                   getTermComponentWithTypes,
                   getRootBranch,
                   putRootBranch,
-                  getBranchForHashImpl = getBranchForHash,
+                  getBranchForHash,
                   putBranch,
                   syncFromDirectory,
                   syncToDirectory,

--- a/parser-typechecker/src/Unison/Codebase/Type.hs
+++ b/parser-typechecker/src/Unison/Codebase/Type.hs
@@ -79,7 +79,7 @@ data Codebase m v a = Codebase
       Text -> -- Reason for the change, will be recorded in the reflog
       Branch m ->
       m (),
-    getBranchForHashImpl :: CausalHash -> m (Maybe (Branch m)),
+    getBranchForHash :: CausalHash -> m (Maybe (Branch m)),
     -- | Put a branch into the codebase, which includes its children, its patches, and the branch itself, if they don't
     -- already exist.
     --

--- a/unison-cli/src/Unison/Cli/MonadUtils.hs
+++ b/unison-cli/src/Unison/Cli/MonadUtils.hs
@@ -258,7 +258,8 @@ modifyRootBranch f = do
 getCurrentBranch :: Cli (Branch IO)
 getCurrentBranch = do
   path <- getCurrentPath
-  getBranchAt path
+  Cli.Env {codebase} <- ask
+  liftIO $ Codebase.getBranchAtPath codebase path
 
 -- | Get the current branch0.
 getCurrentBranch0 :: Cli (Branch0 IO)

--- a/unison-cli/src/Unison/Codebase/TranscriptParser.hs
+++ b/unison-cli/src/Unison/Codebase/TranscriptParser.hs
@@ -49,7 +49,6 @@ import Unison.Cli.MonadUtils qualified as Cli
 import Unison.Cli.ProjectUtils qualified as ProjectUtils
 import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
-import Unison.Codebase.Branch.Type qualified as Branch
 import Unison.Codebase.Editor.HandleInput qualified as HandleInput
 import Unison.Codebase.Editor.Input (Event (UnisonFileChanged), Input (..))
 import Unison.Codebase.Editor.Output qualified as Output
@@ -366,10 +365,8 @@ run verbosity dir stanzas codebase runtime sbRuntime nRuntime config ucmVersion 
                       [] -> awaitInput
                       args -> do
                         liftIO (output ("\n" <> show p <> "\n"))
-                        rootVar <- use #root
                         numberedArgs <- use #numberedArgs
-                        let getRoot = fmap Branch.head . atomically $ readTMVar rootVar
-                        liftIO (parseInput codebase getRoot curPath numberedArgs patternMap args) >>= \case
+                        liftIO (parseInput codebase curPath numberedArgs patternMap args) >>= \case
                           -- invalid command is treated as a failure
                           Left msg -> do
                             liftIO $ writeIORef hasErrors True

--- a/unison-cli/src/Unison/CommandLine.hs
+++ b/unison-cli/src/Unison/CommandLine.hs
@@ -42,6 +42,7 @@ import Data.Vector qualified as Vector
 import System.FilePath (takeFileName)
 import Text.Regex.TDFA ((=~))
 import Unison.Codebase (Codebase)
+import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch (Branch0)
 import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Editor.Input (Event (..), Input (..))
@@ -119,7 +120,6 @@ nothingTodo = emojiNote "😶"
 
 parseInput ::
   Codebase IO Symbol Ann ->
-  IO (Branch0 IO) ->
   -- | Current path from root
   Path.Absolute ->
   -- | Numbered arguments
@@ -131,11 +131,9 @@ parseInput ::
   -- Returns either an error message or the fully expanded arguments list and parsed input.
   -- If the output is `Nothing`, the user cancelled the input (e.g. ctrl-c)
   IO (Either (P.Pretty CT.ColorText) (Maybe ([String], Input)))
-parseInput codebase getRoot currentPath numberedArgs patterns segments = runExceptT do
+parseInput codebase currentPath numberedArgs patterns segments = runExceptT do
   let getCurrentBranch0 :: IO (Branch0 IO)
-      getCurrentBranch0 = do
-        rootBranch <- getRoot
-        pure $ Branch.getAt0 (Path.unabsolute currentPath) rootBranch
+      getCurrentBranch0 = Branch.head <$> Codebase.getBranchAtPath codebase currentPath
   let projCtx = projectContextFromPath currentPath
 
   case segments of

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -28,7 +28,6 @@ import Unison.Cli.ProjectUtils (projectBranchPathPrism)
 import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch (Branch)
-import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Editor.HandleInput qualified as HandleInput
 import Unison.Codebase.Editor.Input (Event, Input (..))
 import Unison.Codebase.Editor.Output (Output)
@@ -58,11 +57,10 @@ import UnliftIO.STM
 getUserInput ::
   Codebase IO Symbol Ann ->
   AuthenticatedHttpClient ->
-  IO (Branch IO) ->
   Path.Absolute ->
   [String] ->
   IO Input
-getUserInput codebase authHTTPClient getRoot currentPath numberedArgs =
+getUserInput codebase authHTTPClient currentPath numberedArgs =
   Line.runInputT
     settings
     (haskelineCtrlCHandling go)
@@ -101,7 +99,7 @@ getUserInput codebase authHTTPClient getRoot currentPath numberedArgs =
         Just l -> case words l of
           [] -> go
           ws -> do
-            liftIO (parseInput codebase (Branch.head <$> getRoot) currentPath numberedArgs IP.patternMap ws) >>= \case
+            liftIO (parseInput codebase currentPath numberedArgs IP.patternMap ws) >>= \case
               Left msg -> do
                 liftIO $ putPrettyLn msg
                 go
@@ -178,7 +176,6 @@ main dir welcome initialPath config initialInputs runtime sbRuntime nRuntime cod
         getUserInput
           codebase
           authHTTPClient
-          (atomically . readTMVar $ loopState ^. #root)
           (loopState ^. #currentPath)
           (loopState ^. #numberedArgs)
   let loadSourceFile :: Text -> IO Cli.LoadSourceResult


### PR DESCRIPTION
## Overview

Had a shower thought that manifested in a huge start-up time improvement by mostly deleting old _speedup_ code 🙃 

Currently on trunk, most commands need names, which are loaded by:
1. Getting the root branch
2. Getting the child branch at the current path from the root branch
3. Building names from that branch.

This, unfortunately, means we're loading the whole root branch before we can do basically anything.

Really what we'd like, is to just load the current names that we need, but we also want to avoid duplicating work by loading that branch once in the global names and once for each command.

It turns out that the weak-ref driven branch cache I implemented for perf improvements a while ago does all of this for us automatically. Any branches loaded from the codebase are part of the cache, meaning regardless who loads a branch first, it'll only be loaded once.

Now, when fetching the current branch, just load it from the codebase as directly you can (e.g. via path or hash). The branch-cache will ensure it's fetched as efficiently as possible.

## Implementation notes

* No longer get current branches from the root branch in loop state, fetch them from the codebase relying on the branch cache
* Remove old "look in the root branch" optimistic caching since the cache does the same thing much more reliably and doesn't need the root branch to be fully loaded first.

## Interesting/controversial decisions

I think this is a pretty straight-forward improvement :)

## Test coverage

I tested it out, commands that don't need the root branch are much faster on startup. e.g. view, ls, etc.

E.g. `view map` on the `cp/remove-global-names-again` branch takes 8.17s to complete immediately after booting up UCM. On this branch it takes less than a second.

## Loose ends

Ideally we'll eventually remove the root branch from memory entirely, but we're not there quite yet (since project branches are mounted there).

When we DO eventually do that, we'll want to keep the current branch stored in loop-state somewhere instead, the cache uses weak-refs so we need to make sure something is referring to the branches we care about for them to stick around 😄 