### PR TITLE
refactor: show more info about connection errors in output

### DIFF
--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1960,12 +1960,18 @@ notifyUser dir = \case
   ServantClientError err ->
     pure case err of
       Servant.ConnectionError exception ->
-        P.wrap $
-          fromMaybe "Something went wrong with the connection. Try again?" do
-            case ServantClientUtils.classifyConnectionError exception of
-              ServantClientUtils.ConnectionError'Offline -> Just "You appear to be offline."
-              ServantClientUtils.ConnectionError'SomethingElse _ -> Nothing
-              ServantClientUtils.ConnectionError'SomethingEntirelyUnexpected _ -> Nothing
+        case ServantClientUtils.classifyConnectionError exception of
+          ServantClientUtils.ConnectionError'Offline -> P.wrap "You appear to be offline."
+          ServantClientUtils.ConnectionError'SomethingElse content ->
+            P.wrap "Oops, I encountered an unexpected exception from the server."
+              <> P.newline
+              <> P.newline
+              <> P.indentN 2 (P.pshown content)
+          ServantClientUtils.ConnectionError'SomethingEntirelyUnexpected _ ->
+            P.wrap "Oops, I encountered an unexpected exception from the server."
+              <> P.newline
+              <> P.newline
+              <> P.indentN 2 (P.pshown exception)
       Servant.DecodeFailure message response ->
         P.wrap "Huh, I failed to decode a response from the server."
           <> P.newline
@@ -2700,7 +2706,7 @@ renderEditConflicts ppe Patch {..} = do
                  then "deprecated and also replaced with"
                  else "replaced with"
              )
-          `P.hang` P.lines replacements
+            `P.hang` P.lines replacements
     formatTermEdits ::
       (Reference.TermReference, Set TermEdit.TermEdit) ->
       Numbered Pretty
@@ -2715,7 +2721,7 @@ renderEditConflicts ppe Patch {..} = do
                  then "deprecated and also replaced with"
                  else "replaced with"
              )
-          `P.hang` P.lines replacements
+            `P.hang` P.lines replacements
     formatConflict ::
       Either
         (Reference, Set TypeEdit.TypeEdit)


### PR DESCRIPTION
## Overview

Addresses #4619; I thought it might be find to just print out the whole error for the user, rather than hide it behind a friendlier but less informative "something went wrong".

However, I now see in the bug report that "we don't want to dump out cryptic errors normally". So, this might need more work. Nonetheless I thought I'd throw it up for consideration.