### PR TITLE
Set Max push workers to 1

### DIFF
--- a/unison-cli/src/Unison/Share/Sync.hs
+++ b/unison-cli/src/Unison/Share/Sync.hs
@@ -80,7 +80,7 @@ maxSimultaneousPullDownloaders = 5
 -- Share currently parallelizes on it's own in the backend, and any more than one push worker
 -- just results in serialization conflicts which slow things down.
 maxSimultaneousPushWorkers :: Int
-maxSimultaneousPushWorkers = 5
+maxSimultaneousPushWorkers = 1
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Push


### PR DESCRIPTION
## Overview

- [ ] Wait until PG Share is deployed before merging.

Any more than 1 push worker just causes Postgres serialization conflicts and actually slows down pushing.
The server does its own parallelization on the backend.

## Implementation notes

Update max push workers to 1

## Interesting/controversial decisions

Nah

## Test coverage

I've tested push timings locally.
