### PR TITLE
Fix special case for type doc in lexer

### DIFF
--- a/unison-src/transcripts/doc2markdown.md
+++ b/unison-src/transcripts/doc2markdown.md
@@ -92,3 +92,20 @@ Table
 ```ucm
 .> debug.doc-to-markdown fulldoc
 ```
+
+You can add docs to a term or type with a top-level doc literal above the binding:
+
+```unison
+{{ This is a term doc }}
+myTerm = 10
+
+-- Regression tests for https://github.com/unisonweb/unison/issues/4634
+{{ This is a type doc }}
+type MyType = MyType
+
+{{ This is a unique type doc }}
+unique type MyUniqueType = MyUniqueType
+
+{{ This is a structural type doc }}
+structural type MyStructuralType = MyStructuralType
+```

--- a/unison-src/transcripts/doc2markdown.output.md
+++ b/unison-src/transcripts/doc2markdown.output.md
@@ -157,3 +157,41 @@ Table
   
 
 ```
+You can add docs to a term or type with a top-level doc literal above the binding:
+
+```unison
+{{ This is a term doc }}
+myTerm = 10
+
+-- Regression tests for https://github.com/unisonweb/unison/issues/4634
+{{ This is a type doc }}
+type MyType = MyType
+
+{{ This is a unique type doc }}
+unique type MyUniqueType = MyUniqueType
+
+{{ This is a structural type doc }}
+structural type MyStructuralType = MyStructuralType
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      structural type MyStructuralType
+        (also named builtin.Unit)
+      type MyType
+      type MyUniqueType
+      MyStructuralType.doc : Doc2
+      MyType.doc           : Doc2
+      MyUniqueType.doc     : Doc2
+      myTerm               : Nat
+      myTerm.doc           : Doc2
+
+```

--- a/unison-syntax/src/Unison/Syntax/Lexer.hs
+++ b/unison-syntax/src/Unison/Syntax/Lexer.hs
@@ -403,7 +403,7 @@ lexemes' eof =
           let lit' s = lit s <* sp
           let modifier = typeModifiersAlt lit'
           let typeOrAbility' = typeOrAbilityAlt wordyKw
-          _ <- modifier <* typeOrAbility' *> sp
+          _ <- optional modifier *> typeOrAbility' *> sp
           wordyId
         ignore _ _ _ = []
         body = join <$> P.many (sectionElem <* CP.space)


### PR DESCRIPTION
## Overview

Fixes https://github.com/unisonweb/unison/issues/4634

There's a weird special case in the Lexer for handling `{{ }}` comments on types.
AFAICT the hack is there because of the following:

1. The lexer tokens are re-ordered to hoist type declarations before all the bindings (including the docs for those decls)
2. Otherwise the decl parser would have to return term bindings in addition to the decls

Regardless, it was easy to patch the hack.

## Implementation notes

* Make type modifiers optional in the doc2 hack in the lexer.
* Add regression transcript

## Test coverage

Regression transcript

## Loose ends

The lexer hack is pretty unintuitive, but I'm not sure how to avoid it without rewriting the whole parser and lexer; so guess it's gonna stay 🤷🏼‍♂️ 