### PR TITLE
Fix for doc formatter

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/DeclParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/DeclParser.hs
@@ -11,6 +11,7 @@ import Text.Megaparsec qualified as P
 import Unison.ABT qualified as ABT
 import Unison.DataDeclaration (DataDeclaration, EffectDeclaration)
 import Unison.DataDeclaration qualified as DD
+import Unison.Debug qualified as Debug
 import Unison.Name qualified as Name
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
@@ -150,7 +151,7 @@ dataDeclaration maybeUnresolvedModifier = do
   eq <- reserved "="
   let -- go gives the type of the constructor, given the types of
       -- the constructor arguments, e.g. Cons becomes forall a . a -> List a -> List a
-      go :: L.Token v -> [Type v Ann] -> (Ann, v, Type v Ann)
+      go :: L.Token v -> [Type v Ann] -> (Ann {- Ann spanning the constructor and its args -}, (Ann, v, Type v Ann))
       go ctorName ctorArgs =
         let arrow i o = Type.arrow (ann i <> ann o) i o
             app f arg = Type.app (ann f <> ann arg) f arg
@@ -160,14 +161,16 @@ dataDeclaration maybeUnresolvedModifier = do
             --    or just `Optional a` in the case of `None`
             ctorType = foldr arrow ctorReturnType ctorArgs
             ctorAnn = ann ctorName <> maybe (ann ctorName) ann (lastMay ctorArgs)
-         in ( ann ctorName,
-              Var.namespaced [L.payload name, L.payload ctorName],
-              Type.foralls ctorAnn typeArgVs ctorType
+         in ( ctorAnn,
+              ( ann ctorName,
+                Var.namespaced [L.payload name, L.payload ctorName],
+                Type.foralls ctorAnn typeArgVs ctorType
+              )
             )
       prefixVar = TermParser.verifyRelativeVarName prefixDefinitionName
-      dataConstructor :: P v m (Ann, v, Type v Ann)
+      dataConstructor :: P v m (Ann, (Ann, v, Type v Ann))
       dataConstructor = go <$> prefixVar <*> many TypeParser.valueTypeLeaf
-      record :: P v m ([(Ann, v, Type v Ann)], [(L.Token v, [(L.Token v, Type v Ann)])], Ann)
+      record :: P v m ([(Ann, (Ann, v, Type v Ann))], [(L.Token v, [(L.Token v, Type v Ann)])], Ann)
       record = do
         _ <- openBlockWith "{"
         let field :: P v m [(L.Token v, Type v Ann)]
@@ -185,10 +188,12 @@ dataDeclaration maybeUnresolvedModifier = do
   (constructors, accessors, closingAnn) <-
     msum [Left <$> record, Right <$> sepBy (reserved "|") dataConstructor] <&> \case
       Left (constructors, accessors, closingAnn) -> (constructors, accessors, closingAnn)
-      Right constructors ->
+      Right constructors -> do
         let closingAnn :: Ann
-            closingAnn = NonEmpty.last (ann eq NonEmpty.:| ((\(_, _, t) -> ann t) <$> constructors))
-         in (constructors, [], closingAnn)
+            closingAnn = NonEmpty.last (ann eq NonEmpty.:| ((\(constrSpanAnn, _) -> constrSpanAnn) <$> constructors))
+         in Debug.debug Debug.Temp "inner constructors" $ (constructors, [], closingAnn)
+  Debug.debugM Debug.Temp "constructors" (name, constructors)
+  Debug.debugM Debug.Temp "closingAnn" (name, closingAnn)
   _ <- closeBlock
   case maybeUnresolvedModifier of
     Nothing -> do
@@ -197,7 +202,7 @@ dataDeclaration maybeUnresolvedModifier = do
       let declSpanAnn = ann typeToken <> closingAnn
       pure
         ( L.payload name,
-          DD.mkDataDecl' modifier declSpanAnn typeArgVs constructors,
+          DD.mkDataDecl' modifier declSpanAnn typeArgVs (snd <$> constructors),
           accessors
         )
     Just unresolvedModifier -> do
@@ -207,7 +212,7 @@ dataDeclaration maybeUnresolvedModifier = do
       let declSpanAnn = ann typeToken <> ann modifier <> closingAnn
       pure
         ( L.payload name,
-          DD.mkDataDecl' (L.payload modifier) declSpanAnn typeArgVs constructors,
+          DD.mkDataDecl' (L.payload modifier) declSpanAnn typeArgVs (snd <$> constructors),
           accessors
         )
 

--- a/parser-typechecker/src/Unison/Syntax/DeclParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/DeclParser.hs
@@ -11,7 +11,6 @@ import Text.Megaparsec qualified as P
 import Unison.ABT qualified as ABT
 import Unison.DataDeclaration (DataDeclaration, EffectDeclaration)
 import Unison.DataDeclaration qualified as DD
-import Unison.Debug qualified as Debug
 import Unison.Name qualified as Name
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
@@ -191,9 +190,7 @@ dataDeclaration maybeUnresolvedModifier = do
       Right constructors -> do
         let closingAnn :: Ann
             closingAnn = NonEmpty.last (ann eq NonEmpty.:| ((\(constrSpanAnn, _) -> constrSpanAnn) <$> constructors))
-         in Debug.debug Debug.Temp "inner constructors" $ (constructors, [], closingAnn)
-  Debug.debugM Debug.Temp "constructors" (name, constructors)
-  Debug.debugM Debug.Temp "closingAnn" (name, closingAnn)
+         in (constructors, [], closingAnn)
   _ <- closeBlock
   case maybeUnresolvedModifier of
     Nothing -> do

--- a/parser-typechecker/src/Unison/Syntax/FileParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/FileParser.hs
@@ -215,7 +215,7 @@ stanza = watchExpression <|> unexpectedAction <|> binding
       binding@((_, v), _) <- TermParser.binding
       pure $ case doc of
         Nothing -> Binding binding
-        Just doc -> Bindings [((ann doc, Var.joinDot v (Var.named "doc")), doc), binding]
+        Just (spanAnn, doc) -> Bindings [((spanAnn, Var.joinDot v (Var.named "doc")), doc), binding]
 
 watched :: (Monad m, Var v) => P v m (UF.WatchKind, Text, Ann)
 watched = P.try do

--- a/parser-typechecker/src/Unison/Syntax/TermParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermParser.hs
@@ -493,8 +493,7 @@ termLeaf =
 -- overriding what functions the names `syntax.doc*` correspond to.
 doc2Block :: forall m v. (Monad m, Var v) => P v m (Ann {- Annotation for the whole spanning block -}, Term v Ann)
 doc2Block = do
-  e <- P.lookAhead (openBlockWith "syntax.docUntitledSection") *> elem
-  pure e
+  P.lookAhead (openBlockWith "syntax.docUntitledSection") *> elem
   where
     -- For terms which aren't blocks the spanning annotation is the same as the
     -- term annotation.

--- a/parser-typechecker/src/Unison/Syntax/TermParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermParser.hs
@@ -25,6 +25,7 @@ import Data.Set qualified as Set
 import Data.Text qualified as Text
 import Data.Tuple.Extra qualified as TupleE
 import Text.Megaparsec qualified as P
+import U.Core.ABT qualified as ABT
 import Unison.ABT qualified as ABT
 import Unison.Builtin.Decls qualified as DD
 import Unison.ConstructorReference (ConstructorReference, GConstructorReference (..))
@@ -99,7 +100,7 @@ rewriteBlock = do
     rewriteTermlike kw mk = do
       kw <- quasikeyword kw
       lhs <- term
-      rhs <- block "==>"
+      (_spanAnn, rhs) <- block "==>"
       pure (mk (ann kw <> ann rhs) lhs rhs)
     rewriteTerm = rewriteTermlike "term" DD.rewriteTerm
     rewriteCase = rewriteTermlike "case" DD.rewriteCase
@@ -206,10 +207,10 @@ matchCase = do
             [ Nothing <$ P.try (quasikeyword "otherwise"),
               Just <$> infixAppOrBooleanOp
             ]
-        t <- block "->"
+        (_spanAnn, t) <- block "->"
         pure (guard, t)
   let unguardedBlock = label "case match" do
-        t <- block "->"
+        (_spanAnn, t) <- block "->"
         pure (Nothing, t)
   -- a pattern's RHS is either one or more guards, or a single unguarded block.
   guardsAndBlocks <- guardedBlocks <|> (pure @[] <$> unguardedBlock)
@@ -349,10 +350,10 @@ lam p = label "lambda" $ mkLam <$> P.try (some prefixDefinitionName <* reserved 
     mkLam vs b = Term.lam' (ann (head vs) <> ann b) (map L.payload vs) b
 
 letBlock, handle, ifthen :: (Monad m, Var v) => TermP v m
-letBlock = label "let" $ block "let"
+letBlock = label "let" $ (snd <$> block "let")
 handle = label "handle" do
-  b <- block "handle"
-  handler <- block "with"
+  (_spanAnn, b) <- block "handle"
+  (_spanAnn, handler) <- block "with"
   pure $ Term.handle (ann b) handler b
 
 checkCasesArities :: (Ord v, Annotated a) => NonEmpty (Int, a) -> P v m (Int, NonEmpty a)
@@ -382,9 +383,9 @@ lamCase = do
 
 ifthen = label "if" do
   start <- peekAny
-  c <- block "if"
-  t <- block "then"
-  f <- block "else"
+  (_spanAnn, c) <- block "if"
+  (_spanAnn, t) <- block "then"
+  (_spanAnn, f) <- block "else"
   pure $ Term.iff (ann start <> ann f) c t f
 
 text :: (Var v) => TermP v m
@@ -451,10 +452,10 @@ termLeaf =
       keywordBlock,
       list term,
       delayQuote,
-      delayBlock,
+      (snd <$> delayBlock),
       bang,
       docBlock,
-      doc2Block
+      snd <$> doc2Block
     ]
 
 -- Syntax for documentation v2 blocks, which are surrounded by {{ }}.
@@ -490,41 +491,53 @@ termLeaf =
 -- variables that will be looked up in the environment like anything else. This
 -- means that the documentation syntax can have its meaning changed by
 -- overriding what functions the names `syntax.doc*` correspond to.
-doc2Block :: forall m v. (Monad m, Var v) => TermP v m
+doc2Block :: forall m v. (Monad m, Var v) => P v m (Ann {- Annotation for the whole spanning block -}, Term v Ann)
 doc2Block =
   P.lookAhead (openBlockWith "syntax.docUntitledSection") *> elem
   where
-    elem :: TermP v m
+    -- For terms which aren't blocks the spanning annotation is the same as the
+    -- term annotation.
+    selfAnnotated :: Term v Ann -> (Ann, Term v Ann)
+    selfAnnotated t = (ann t, t)
+    elem :: P v m (Ann {- Annotation for the whole spanning block -}, Term v Ann)
     elem =
-      text <|> do
-        t <- openBlock
+      (selfAnnotated <$> text) <|> do
+        startTok <- openBlock
         let -- here, `t` will be something like `Open "syntax.docWord"`
             -- so `f` will be a term var with the name "syntax.docWord".
-            f = f' t
+            f = f' startTok
             f' t = Term.var (ann t) (Var.nameds (L.payload t))
 
             -- follows are some common syntactic forms used for parsing child elements
 
             -- regular is parsed into `f child1 child2 child3` for however many children
             regular = do
-              cs <- P.many elem <* closeBlock
-              pure $ Term.apps' f cs
+              cs <- P.many (snd <$> elem)
+              endTok <- closeBlock
+              let trm = Term.apps' f cs
+              pure (ann startTok <> ann endTok, trm)
 
             -- variadic is parsed into: `f [child1, child2, ...]`
             variadic = variadic' f
             variadic' f = do
-              cs <- P.many elem <* closeBlock
-              pure $ Term.apps' f [Term.list (ann cs) cs]
+              cs <- P.many (snd <$> elem)
+              endTok <- closeBlock
+              let trm = Term.apps' f [Term.list (ann cs) cs]
+              pure (ann startTok <> ann endTok, trm)
 
             -- sectionLike is parsed into: `f tm [child1, child2, ...]`
             sectionLike = do
-              arg1 <- elem
-              cs <- P.many elem <* closeBlock
-              pure $ Term.apps' f [arg1, Term.list (ann cs) cs]
+              arg1 <- (snd <$> elem)
+              cs <- P.many (snd <$> elem)
+              endTok <- closeBlock
+              let trm = Term.apps' f [arg1, Term.list (ann cs) cs]
+              pure (ann startTok <> ann endTok, trm)
 
             evalLike wrap = do
-              tm <- term <* closeBlock
-              pure $ Term.apps' f [wrap tm]
+              tm <- term
+              endTok <- closeBlock
+              let trm = Term.apps' f [wrap tm]
+              pure (ann startTok <> ann endTok, trm)
 
             -- converts `tm` to `'tm`
             --
@@ -533,8 +546,7 @@ doc2Block =
             -- code which renders documents. (We want the doc display to get
             -- the unevaluated expression `1 + 1` and not `2`)
             addDelay tm = Term.delay (ann tm) tm
-
-        case L.payload t of
+        case L.payload startTok of
           "syntax.docJoin" -> variadic
           "syntax.docUntitledSection" -> variadic
           "syntax.docColumn" -> variadic
@@ -545,33 +557,45 @@ doc2Block =
           "syntax.docBulletedList" -> variadic
           "syntax.docSourceAnnotations" -> variadic
           "syntax.docSourceElement" -> do
-            link <- elem
-            anns <- P.optional $ reserved "@" *> elem
-            closeBlock $> Term.apps' f [link, fromMaybe (Term.list (ann link) mempty) anns]
+            link <- (snd <$> elem)
+            anns <- P.optional $ reserved "@" *> (snd <$> elem)
+            endTok <- closeBlock
+            let trm = Term.apps' f [link, fromMaybe (Term.list (ann link) mempty) anns]
+            pure (ann startTok <> ann endTok, trm)
           "syntax.docNumberedList" -> do
-            nitems@((n, _) : _) <- P.some nitem <* closeBlock
+            nitems@((n, _) : _) <- P.some nitem
+            endTok <- closeBlock
             let items = snd <$> nitems
-            pure $ Term.apps' f [n, Term.list (ann items) items]
+            let trm = Term.apps' f [n, Term.list (ann items) items]
+            pure (ann startTok <> ann endTok, trm)
             where
               nitem = do
                 n <- number
                 t <- openBlockWith "syntax.docColumn"
                 let f = f' ("syntax.docColumn" <$ t)
-                child <- variadic' f
+                (_spanAnn, child) <- variadic' f
                 pure (n, child)
           "syntax.docSection" -> sectionLike
           -- @source{ type Blah, foo, type Bar }
           "syntax.docEmbedTermLink" -> do
             tm <- addDelay <$> (hashQualifiedPrefixTerm <|> hashQualifiedInfixTerm)
-            closeBlock $> Term.apps' f [tm]
+            endTok <- closeBlock
+            let trm = Term.apps' f [tm]
+            pure (ann startTok <> ann endTok, trm)
           "syntax.docEmbedSignatureLink" -> do
             tm <- addDelay <$> (hashQualifiedPrefixTerm <|> hashQualifiedInfixTerm)
-            closeBlock $> Term.apps' f [tm]
+            endTok <- closeBlock
+            let trm = Term.apps' f [tm]
+            pure (ann startTok <> ann endTok, trm)
           "syntax.docEmbedTypeLink" -> do
             r <- typeLink'
-            closeBlock $> Term.apps' f [Term.typeLink (ann r) (L.payload r)]
-          "syntax.docExample" ->
-            (term <* closeBlock) <&> \case
+            endTok <- closeBlock
+            let trm = Term.apps' f [Term.typeLink (ann r) (L.payload r)]
+            pure (ann startTok <> ann endTok, trm)
+          "syntax.docExample" -> do
+            trm <- term
+            endTok <- closeBlock
+            pure . (ann startTok <> ann endTok,) $ case trm of
               tm@(Term.Apps' _ xs) ->
                 let fvs = List.Extra.nubOrd $ concatMap (toList . Term.freeVars) xs
                     n = Term.nat (ann tm) (fromIntegral (length fvs))
@@ -581,11 +605,11 @@ doc2Block =
           "syntax.docTransclude" -> evalLike id
           "syntax.docEvalInline" -> evalLike addDelay
           "syntax.docExampleBlock" -> do
-            tm <- block'' False True "syntax.docExampleBlock" (pure (void t)) closeBlock
-            pure $ Term.apps' f [Term.nat (ann tm) 0, addDelay tm]
+            (spanAnn, tm) <- block'' False True "syntax.docExampleBlock" (pure (void startTok)) closeBlock
+            pure $ (spanAnn, Term.apps' f [Term.nat (ann tm) 0, addDelay tm])
           "syntax.docEval" -> do
-            tm <- block' False "syntax.docEval" (pure (void t)) closeBlock
-            pure $ Term.apps' f [addDelay tm]
+            (spanAnn, tm) <- block' False "syntax.docEval" (pure (void startTok)) closeBlock
+            pure $ (spanAnn, Term.apps' f [addDelay tm])
           _ -> regular
 
 docBlock :: (Monad m, Var v) => TermP v m
@@ -958,10 +982,10 @@ delayQuote = P.label "quote" do
   e <- termLeaf
   pure $ DD.delayTerm (ann start <> ann e) e
 
-delayBlock :: (Monad m, Var v) => TermP v m
+delayBlock :: (Monad m, Var v) => P v m (Ann {- Ann spanning the whole block -}, Term v Ann)
 delayBlock = P.label "do" do
-  b <- block "do"
-  pure $ DD.delayTerm (ann b) b
+  (spanAnn, b) <- block "do"
+  pure $ (spanAnn, DD.delayTerm (ann b) b)
 
 bang :: (Monad m, Var v) => TermP v m
 bang = P.label "bang" do
@@ -1035,7 +1059,7 @@ destructuringBind = do
     let boundVars' = snd <$> boundVars
     P.lookAhead (openBlockWith "=")
     pure (p, boundVars')
-  scrute <- block "=" -- Dwight K. Scrute ("The People's Scrutinee")
+  (_spanAnn, scrute) <- block "=" -- Dwight K. Scrute ("The People's Scrutinee")
   let guard = Nothing
   let absChain vs t = foldr (\v t -> ABT.abs' (ann t) v t) t vs
       thecase t = Term.MatchCase p (fmap (absChain boundVars) guard) $ absChain boundVars t
@@ -1073,10 +1097,10 @@ binding = label "binding" do
     Nothing -> do
       -- we haven't seen a type annotation, so lookahead to '=' before commit
       (lhsLoc, name, args) <- P.try (lhs <* P.lookAhead (openBlockWith "="))
-      body <- block "="
+      (bodySpanAnn, body) <- block "="
       verifyRelativeName' (fmap Name.unsafeFromVar name)
       let binding = mkBinding lhsLoc args body
-      let spanAnn = ann lhsLoc <> ann binding
+      let spanAnn = ann lhsLoc <> bodySpanAnn
       pure $ ((spanAnn, (L.payload name)), binding)
     Just (nameT, typ) -> do
       (lhsLoc, name, args) <- lhs
@@ -1084,9 +1108,9 @@ binding = label "binding" do
       when (L.payload name /= L.payload nameT) $
         customFailure $
           SignatureNeedsAccompanyingBody nameT
-      body <- block "="
+      (bodySpanAnn, body) <- block "="
       let binding = mkBinding lhsLoc args body
-      let spanAnn = ann nameT <> ann binding
+      let spanAnn = ann nameT <> bodySpanAnn
       pure $ ((spanAnn, L.payload name), Term.ann (ann nameT <> ann binding) binding typ)
   where
     mkBinding :: Ann -> [L.Token v] -> Term.Term v Ann -> Term.Term v Ann
@@ -1097,7 +1121,7 @@ binding = label "binding" do
 customFailure :: (P.MonadParsec e s m) => e -> m a
 customFailure = P.customFailure
 
-block :: forall m v. (Monad m, Var v) => String -> TermP v m
+block :: forall m v. (Monad m, Var v) => String -> P v m (Ann, Term v Ann)
 block s = block' False s (openBlockWith s) closeBlock
 
 -- example: use Foo.bar.Baz + ++ x
@@ -1167,25 +1191,32 @@ substImports ns imports =
           Names.hasTypeNamed Names.IncludeSuffixes (Name.unsafeFromVar full) ns
       ]
 
-block' :: (Monad m, Var v) => IsTop -> String -> P v m (L.Token ()) -> P v m (L.Token ()) -> TermP v m
+block' ::
+  (Monad m, Var v) =>
+  IsTop ->
+  String ->
+  P v m (L.Token ()) ->
+  P v m (L.Token ()) ->
+  P v m (Ann {- ann which spans the whole block -}, Term v Ann)
 block' isTop = block'' isTop False
 
 block'' ::
-  forall m v b.
-  (Monad m, Var v) =>
+  forall m v end.
+  (Monad m, Var v, Annotated end) =>
   IsTop ->
   Bool -> -- `True` means insert `()` at end of block if it ends with a statement
   String ->
   P v m (L.Token ()) ->
-  P v m b ->
-  TermP v m
+  P v m end ->
+  P v m (Ann {- ann which spans the whole block -}, Term v Ann)
 block'' isTop implicitUnitAtEnd s openBlock closeBlock = do
   open <- openBlock
   (names, imports) <- imports
   _ <- optional semi
   statements <- local (\e -> e {names = names}) $ sepBy semi statement
-  _ <- closeBlock
-  substImports names imports <$> go open statements
+  end <- closeBlock
+  body <- substImports names imports <$> go open statements
+  pure (ann open <> ann end, body)
   where
     statement = asum [Binding <$> binding, DestructuringBind <$> destructuringBind, Action <$> blockTerm]
     go :: L.Token () -> [BlockElement v] -> P v m (Term v Ann)

--- a/parser-typechecker/src/Unison/Syntax/TermParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermParser.hs
@@ -30,7 +30,6 @@ import Unison.ABT qualified as ABT
 import Unison.Builtin.Decls qualified as DD
 import Unison.ConstructorReference (ConstructorReference, GConstructorReference (..))
 import Unison.ConstructorType qualified as CT
-import Unison.Debug qualified as Debug
 import Unison.HashQualified qualified as HQ
 import Unison.HashQualified' qualified as HQ'
 import Unison.Name (Name)
@@ -495,7 +494,6 @@ termLeaf =
 doc2Block :: forall m v. (Monad m, Var v) => P v m (Ann {- Annotation for the whole spanning block -}, Term v Ann)
 doc2Block = do
   e <- P.lookAhead (openBlockWith "syntax.docUntitledSection") *> elem
-  Debug.debugM Debug.Temp "doc2Block" (fst e)
   pure e
   where
     -- For terms which aren't blocks the spanning annotation is the same as the
@@ -1100,8 +1098,7 @@ binding = label "binding" do
     Nothing -> do
       -- we haven't seen a type annotation, so lookahead to '=' before commit
       (lhsLoc, name, args) <- P.try (lhs <* P.lookAhead (openBlockWith "="))
-      (bodySpanAnn, body) <- block "="
-      Debug.debugM Debug.Temp "binding body span" bodySpanAnn
+      (_bodySpanAnn, body) <- block "="
       verifyRelativeName' (fmap Name.unsafeFromVar name)
       let binding = mkBinding lhsLoc args body
       -- We don't actually use the span annotation from the block (yet) because it

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1086,7 +1086,7 @@ loop e = do
                     Cli.InvalidSourceNameError -> lift $ Cli.returnEarly $ Output.InvalidSourceName filePath
                     Cli.LoadError -> lift $ Cli.returnEarly $ Output.SourceLoadFailed filePath
                     Cli.LoadSuccess contents -> pure contents
-                let updatedSource = Format.applyFormatUpdates updates source
+                let updatedSource = Format.applyTextReplacements updates source
                 liftIO $ writeSource (Text.pack filePath) updatedSource
             DebugDumpNamespacesI -> do
               let seen h = State.gets (Set.member h)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/FormatFile.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/FormatFile.hs
@@ -13,6 +13,7 @@ import Data.Map qualified as Map
 import Data.Text qualified as Text
 import Unison.Codebase.Path qualified as Path
 import Unison.DataDeclaration qualified as Decl
+import Unison.Debug qualified as Debug
 import Unison.HashQualified qualified as HQ
 import Unison.Lexer.Pos qualified as Pos
 import Unison.Name qualified as Name
@@ -73,14 +74,9 @@ formatFile makePPEDForFile formattingWidth currentPath inputParsedFile inputType
             & over _2 Pretty.syntaxToColor
   formattedTerms <-
     (FileSummary.termsBySymbol fileSummary)
-      & Map.filterWithKey
-        ( \sym (tldAnn, _, _, _) ->
-            shouldFormatTLD tldAnn
-              -- TODO: Fix printing of docs using {{  }} syntax.
-              -- For now we just skip them.
-              && (Name.lastSegment <$> Name.fromVar sym) /= Just "doc"
-        )
+      & Map.filter (\(tldAnn, _, _, _) -> shouldFormatTLD tldAnn)
       & itraverse \sym (tldAnn, mayRefId, trm, _typ) -> do
+        Debug.debugM Debug.Temp "format" $ (sym, tldAnn)
         symName <- hoistMaybe (Name.fromVar sym)
         let defNameSegments = NEL.appendr (Path.toList (Path.unabsolute currentPath)) (Name.segments symName)
         let defName = Name.fromSegments defNameSegments

--- a/unison-src/transcripts/formatter.md
+++ b/unison-src/transcripts/formatter.md
@@ -41,7 +41,7 @@ ability Thing where
 {{ 
 A Doc before a type 
 }}
-type Optional   a = More Text 
+structural type Optional   a = More Text 
   | Some 
   | Other   a 
   | None Nat 

--- a/unison-src/transcripts/formatter.md
+++ b/unison-src/transcripts/formatter.md
@@ -2,7 +2,7 @@
 .> builtins.mergeio
 ```
 
-```unison
+```unison:hide
 {{ # Doc
 This is a *doc*! 
 
@@ -46,21 +46,9 @@ structural type Optional   a = More Text
   | Other   a 
   | None Nat 
 
-{{ 
-two 
+{{ A doc before a type with no type-vars 
 }}
-qqq = 2
-
-
-{{ 
-hi 
-}}
-test = 2
-
-
-{{ yo }}
-structural type MyEither = MyEither
-
+type Two = One Nat | Two Text
 ```
 
 ```ucm

--- a/unison-src/transcripts/formatter.md
+++ b/unison-src/transcripts/formatter.md
@@ -33,14 +33,28 @@ Or two
 }}
 -- After
 
+{{ 
+A Doc before a type 
+}}
 type Optional   a = More Text 
   | Some 
   | Other   a 
   | None Nat 
 
+{{ A doc before an ability }}
 ability Thing where
   more  : Nat -> Text -> Nat
   doThing  : Nat -> Int
+```
+
+```ucm
+.> debug.format
+```
+
+Formatter should leave things alone if the file doesn't typecheck.
+
+```unison:error
+brokenDoc = {{ hello }} + 1
 ```
 
 ```ucm

--- a/unison-src/transcripts/formatter.md
+++ b/unison-src/transcripts/formatter.md
@@ -3,14 +3,12 @@
 ```
 
 ```unison
--- TODO: support formatting docs with {{  }} syntax.
--- For now we just skip formatting any .doc terms.
 {{ # Doc
 This is a *doc*! 
 
 term link {x}
 
-type link {type Optional}
+type link {type   Optional}
 
 }}
 x : 
@@ -20,6 +18,20 @@ x y =
     x   =     1 + 1
     x + y
 -- Should keep comments after
+
+-- Test for a previous regression that added extra brackets.
+oneLiner = {{ one liner }}
+-- After
+
+-- Before
+explicit.doc = {{
+# Here's a top-level doc
+
+With a paragraph
+
+Or two
+}}
+-- After
 
 type Optional   a = More Text 
   | Some 

--- a/unison-src/transcripts/formatter.md
+++ b/unison-src/transcripts/formatter.md
@@ -46,13 +46,15 @@ structural type Optional   a = More Text
   | Other   a 
   | None Nat 
 
-
-
-{{ two }}
+{{ 
+two 
+}}
 qqq = 2
 
 
-{{ hi }}
+{{ 
+hi 
+}}
 test = 2
 
 

--- a/unison-src/transcripts/formatter.md
+++ b/unison-src/transcripts/formatter.md
@@ -46,6 +46,19 @@ structural type Optional   a = More Text
   | Other   a 
   | None Nat 
 
+
+
+{{ two }}
+qqq = 2
+
+
+{{ hi }}
+test = 2
+
+
+{{ yo }}
+structural type MyEither = MyEither
+
 ```
 
 ```ucm

--- a/unison-src/transcripts/formatter.md
+++ b/unison-src/transcripts/formatter.md
@@ -46,8 +46,7 @@ structural type Optional   a = More Text
   | Other   a 
   | None Nat 
 
-{{ A doc before a type with no type-vars 
-}}
+{{ A doc before a type with no type-vars }}
 type Two = One Nat | Two Text
 ```
 

--- a/unison-src/transcripts/formatter.md
+++ b/unison-src/transcripts/formatter.md
@@ -33,6 +33,11 @@ Or two
 }}
 -- After
 
+{{ A doc before an ability }}
+ability Thing where
+  more  : Nat -> Text -> Nat
+  doThing  : Nat -> Int
+
 {{ 
 A Doc before a type 
 }}
@@ -41,10 +46,6 @@ type Optional   a = More Text
   | Other   a 
   | None Nat 
 
-{{ A doc before an ability }}
-ability Thing where
-  more  : Nat -> Text -> Nat
-  doThing  : Nat -> Int
 ```
 
 ```ucm

--- a/unison-src/transcripts/formatter.output.md
+++ b/unison-src/transcripts/formatter.output.md
@@ -1,6 +1,4 @@
 ```unison
--- TODO: support formatting docs with {{  }} syntax.
--- For now we just skip formatting any .doc terms.
 {{ # Doc
 This is a *doc*! 
 
@@ -31,11 +29,15 @@ Or two
 }}
 -- After
 
+{{ 
+A Doc before a type 
+}}
 type Optional   a = More Text 
   | Some 
   | Other   a 
   | None Nat 
 
+{{ A doc before an ability }}
 ability Thing where
   more  : Nat -> Text -> Nat
   doThing  : Nat -> Int
@@ -45,57 +47,22 @@ ability Thing where
 
   Loading changes detected in scratch.u.
 
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
+  offset=171:
+  unexpected Optional.doc
+     31 | {{ 
   
-    ⍟ These new definitions are ok to `add`:
-    
-      type Optional a
-      ability Thing
-      explicit.doc : Doc2
-      oneLiner     : Doc2
-      x            : Nat -> Nat
-      x.doc        : Doc2
 
 ```
-```ucm
-.> debug.format
 
-```
-```unison:added-by-ucm scratch.u
--- TODO: support formatting docs with {{  }} syntax.
--- For now we just skip formatting any .doc terms.
-x.doc =
-  {{ # Doc This is a **doc**!
+
+
+🛑
+
+The transcript failed due to an error in the stanza above. The error is:
+
+
+  offset=171:
+  unexpected Optional.doc
+     31 | {{ 
   
-    term link {x}
-    
-    type link {type Optional} }}
-x : Nat -> Nat
-x y =
-  use Nat +
-  x = 1 + 1
-  x + y
--- Should keep comments after
-
--- Test for a previous regression that added extra brackets.
-oneLiner = {{ one liner }}
--- After
-
--- Before
-explicit.doc =
-  {{ # Here's a top-level doc
-  
-    With a paragraph
-    
-    Or two }}
--- After
-
-type Optional a = More Text | Some | Other a | None Nat 
-
-ability Thing where
-  more  : Nat -> Text -> Nat
-  doThing  : Nat -> Int
-```
 

--- a/unison-src/transcripts/formatter.output.md
+++ b/unison-src/transcripts/formatter.output.md
@@ -29,27 +29,26 @@ Or two
 }}
 -- After
 
-{{ 
-A Doc before a type 
-}}
+{{ A doc before an ability }}
+ability Thing where
+  more  : Nat -> Text -> Nat
+  doThing  : Nat -> Int
+
+{{ A Doc before a type }}
 type Optional   a = More Text 
   | Some 
   | Other   a 
   | None Nat 
 
-{{ A doc before an ability }}
-ability Thing where
-  more  : Nat -> Text -> Nat
-  doThing  : Nat -> Int
 ```
 
 ```ucm
 
   Loading changes detected in scratch.u.
 
-  offset=171:
-  unexpected Optional.doc
-     31 | {{ 
+  offset=4:
+  unexpected type
+     37 | type Optional   a = More Text 
   
 
 ```
@@ -61,8 +60,8 @@ ability Thing where
 The transcript failed due to an error in the stanza above. The error is:
 
 
-  offset=171:
-  unexpected Optional.doc
-     31 | {{ 
+  offset=4:
+  unexpected type
+     37 | type Optional   a = More Text 
   
 

--- a/unison-src/transcripts/formatter.output.md
+++ b/unison-src/transcripts/formatter.output.md
@@ -6,7 +6,7 @@ This is a *doc*!
 
 term link {x}
 
-type link {type Optional}
+type link {type   Optional}
 
 }}
 x : 
@@ -16,6 +16,20 @@ x y =
     x   =     1 + 1
     x + y
 -- Should keep comments after
+
+-- Test for a previous regression that added extra brackets.
+oneLiner = {{ one liner }}
+-- After
+
+-- Before
+explicit.doc = {{
+# Here's a top-level doc
+
+With a paragraph
+
+Or two
+}}
+-- After
 
 type Optional   a = More Text 
   | Some 
@@ -39,8 +53,10 @@ ability Thing where
     
       type Optional a
       ability Thing
-      x     : Nat -> Nat
-      x.doc : Doc2
+      explicit.doc : Doc2
+      oneLiner     : Doc2
+      x            : Nat -> Nat
+      x.doc        : Doc2
 
 ```
 ```ucm
@@ -50,20 +66,31 @@ ability Thing where
 ```unison:added-by-ucm scratch.u
 -- TODO: support formatting docs with {{  }} syntax.
 -- For now we just skip formatting any .doc terms.
-{{ # Doc
-This is a *doc*! 
-
-term link {x}
-
-type link {type Optional}
-
-}}
+x.doc =
+  {{ # Doc This is a **doc**!
+  
+    term link {x}
+    
+    type link {type Optional} }}
 x : Nat -> Nat
 x y =
   use Nat +
   x = 1 + 1
   x + y
 -- Should keep comments after
+
+-- Test for a previous regression that added extra brackets.
+oneLiner = {{ one liner }}
+-- After
+
+-- Before
+explicit.doc =
+  {{ # Here's a top-level doc
+  
+    With a paragraph
+    
+    Or two }}
+-- After
 
 type Optional a = More Text | Some | Other a | None Nat 
 

--- a/unison-src/transcripts/formatter.output.md
+++ b/unison-src/transcripts/formatter.output.md
@@ -51,20 +51,17 @@ type Two = One Nat | Two Text
 
 ```
 ```unison:added-by-ucm scratch.u
-{{ # Doc
-This is a *doc*! 
-
-term link {x}
-
-type link {type   Optional}
-
-}}
-x : 
-  Nat 
-  -> Nat
+x.doc =
+  {{ # Doc This is a **doc**!
+  
+    term link {x}
+    
+    type link {type Optional} }}
+x : Nat -> Nat
 x y =
-    x   =     1 + 1
-    x + y
+  use Nat +
+  x = 1 + 1
+  x + y
 -- Should keep comments after
 
 -- Test for a previous regression that added extra brackets.
@@ -72,26 +69,23 @@ oneLiner = {{ one liner }}
 -- After
 
 -- Before
-explicit.doc = {{
-# Here's a top-level doc
-
-With a paragraph
-
-Or two
-}}
+explicit.doc =
+  {{ # Here's a top-level doc
+  
+    With a paragraph
+    
+    Or two }}
 -- After
 
-{{ A doc before an ability }}
+Thing.doc = {{ A doc before an ability }}
 ability Thing where
-  more  : Nat -> Text -> Nat
-  doThing  : Nat -> Int
+  more : Nat -> Text ->{Thing} Nat
+  doThing : Nat ->{Thing} Int
 
-{{ 
-A Doc before a type 
-}}
-structural type Optional a = More Text | Some | Other a | None Nat
 Optional.doc = {{ A Doc before a type }}
- A doc before a type with no type-vars }}
+structural type Optional a = More Text | Some | Other a | None Nat 
+
+Two.doc = {{ A doc before a type with no type-vars }}
 type Two = One Nat | Two Text
 ```
 

--- a/unison-src/transcripts/formatter.output.md
+++ b/unison-src/transcripts/formatter.output.md
@@ -42,100 +42,43 @@ structural type Optional   a = More Text
   | Other   a 
   | None Nat 
 
+
+
+{{ two }}
+qqq = 2
+
+
+{{ hi }}
+test = 2
+
+
+{{ yo }}
+structural type MyEither = MyEither
+
 ```
 
 ```ucm
 
   Loading changes detected in scratch.u.
 
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
+  offset=35:
+  unexpected <virtual semicolon>
+  expecting |
+     46 | {{ two }}
   
-    ⍟ These new definitions are ok to `add`:
-    
-      structural type Optional a
-      ability Thing
-      Optional.doc : Doc2
-      Thing.doc    : Doc2
-      explicit.doc : Doc2
-      oneLiner     : Doc2
-      x            : Nat -> Nat
-      x.doc        : Doc2
 
 ```
-```ucm
-.> debug.format
 
-```
-```unison:added-by-ucm scratch.u
-x.doc =
-  {{ # Doc This is a **doc**!
+
+
+🛑
+
+The transcript failed due to an error in the stanza above. The error is:
+
+
+  offset=35:
+  unexpected <virtual semicolon>
+  expecting |
+     46 | {{ two }}
   
-    term link {x}
-    
-    type link {type Optional} }}
-x : Nat -> Nat
-x y =
-  use Nat +
-  x = 1 + 1
-  x + y
--- Should keep comments after
 
--- Test for a previous regression that added extra brackets.
-oneLiner = {{ one liner }}
--- After
-
--- Before
-explicit.doc =
-  {{ # Here's a top-level doc
-  
-    With a paragraph
-    
-    Or two }}
--- After
-
-Thing.doc = {{ A doc before an ability }}
-ability Thing where
-  more : Nat -> Text ->{Thing} Nat
-  doThing : Nat ->{Thing} Int
-
-Optional.doc = {{ A Doc before a type }}
-structural type Optional a = More Text | Some | Other a | None Nat 
-```
-
-Formatter should leave things alone if the file doesn't typecheck.
-
-```unison
-brokenDoc = {{ hello }} + 1
-```
-
-```ucm
-
-  Loading changes detected in scratch.u.
-
-  I couldn't find any definitions matching the name + inside the namespace .
-  
-      1 | brokenDoc = {{ hello }} + 1
-  
-  Some common causes of this error include:
-    * Your current namespace is too deep to contain the
-      definition in its subtree
-    * The definition is part of a library which hasn't been
-      added to this project
-  
-  To add a library to this project use the command: `fork <.path.to.lib> .lib.<libname>`
-  
-  Whatever it is, its type should conform to Doc2 -> Nat -> o.
-  
-  I found some terms in scope with matching names but different types. If one of these is what you meant, try using the fully qualified name and I might be able to give you a more illuminating error message: 
-  
-    - builtin.Float.+ : Float -> Float -> Float
-    - builtin.Int.+ : Int -> Int -> Int
-    - builtin.Nat.+ : Nat -> Nat -> Nat
-
-```
-```ucm
-.> debug.format
-
-```

--- a/unison-src/transcripts/formatter.output.md
+++ b/unison-src/transcripts/formatter.output.md
@@ -34,8 +34,10 @@ ability Thing where
   more  : Nat -> Text -> Nat
   doThing  : Nat -> Int
 
-{{ A Doc before a type }}
-type Optional   a = More Text 
+{{ 
+A Doc before a type 
+}}
+structural type Optional   a = More Text 
   | Some 
   | Other   a 
   | None Nat 
@@ -46,22 +48,94 @@ type Optional   a = More Text
 
   Loading changes detected in scratch.u.
 
-  offset=4:
-  unexpected type
-     37 | type Optional   a = More Text 
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
   
+    ⍟ These new definitions are ok to `add`:
+    
+      structural type Optional a
+      ability Thing
+      Optional.doc : Doc2
+      Thing.doc    : Doc2
+      explicit.doc : Doc2
+      oneLiner     : Doc2
+      x            : Nat -> Nat
+      x.doc        : Doc2
 
 ```
+```ucm
+.> debug.format
 
-
-
-🛑
-
-The transcript failed due to an error in the stanza above. The error is:
-
-
-  offset=4:
-  unexpected type
-     37 | type Optional   a = More Text 
+```
+```unison:added-by-ucm scratch.u
+x.doc =
+  {{ # Doc This is a **doc**!
   
+    term link {x}
+    
+    type link {type Optional} }}
+x : Nat -> Nat
+x y =
+  use Nat +
+  x = 1 + 1
+  x + y
+-- Should keep comments after
 
+-- Test for a previous regression that added extra brackets.
+oneLiner = {{ one liner }}
+-- After
+
+-- Before
+explicit.doc =
+  {{ # Here's a top-level doc
+  
+    With a paragraph
+    
+    Or two }}
+-- After
+
+Thing.doc = {{ A doc before an ability }}
+ability Thing where
+  more : Nat -> Text ->{Thing} Nat
+  doThing : Nat ->{Thing} Int
+
+Optional.doc = {{ A Doc before a type }}
+structural type Optional a = More Text | Some | Other a | None Nat 
+```
+
+Formatter should leave things alone if the file doesn't typecheck.
+
+```unison
+brokenDoc = {{ hello }} + 1
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I couldn't find any definitions matching the name + inside the namespace .
+  
+      1 | brokenDoc = {{ hello }} + 1
+  
+  Some common causes of this error include:
+    * Your current namespace is too deep to contain the
+      definition in its subtree
+    * The definition is part of a library which hasn't been
+      added to this project
+  
+  To add a library to this project use the command: `fork <.path.to.lib> .lib.<libname>`
+  
+  Whatever it is, its type should conform to Doc2 -> Nat -> o.
+  
+  I found some terms in scope with matching names but different types. If one of these is what you meant, try using the fully qualified name and I might be able to give you a more illuminating error message: 
+  
+    - builtin.Float.+ : Float -> Float -> Float
+    - builtin.Int.+ : Int -> Int -> Int
+    - builtin.Nat.+ : Nat -> Nat -> Nat
+
+```
+```ucm
+.> debug.format
+
+```

--- a/unison-src/transcripts/formatter.output.md
+++ b/unison-src/transcripts/formatter.output.md
@@ -42,50 +42,11 @@ structural type Optional   a = More Text
   | Other   a 
   | None Nat 
 
-{{ 
-two 
+{{ A doc before a type with no type-vars 
 }}
-qqq = 2
-
-
-{{ 
-hi 
-}}
-test = 2
-
-
-{{ yo }}
-structural type MyEither = MyEither
-
+type Two = One Nat | Two Text
 ```
 
-```ucm
-
-  Loading changes detected in scratch.u.
-
-  I found and typechecked these definitions in scratch.u. If you
-  do an `add` or `update`, here's how your codebase would
-  change:
-  
-    ⍟ These new definitions are ok to `add`:
-    
-      structural type MyEither
-        (also named builtin.Unit)
-      structural type Optional a
-      ability Thing
-      MyEither.doc : Doc2
-      Optional.doc : Doc2
-      Thing.doc    : Doc2
-      explicit.doc : Doc2
-      oneLiner     : Doc2
-      qqq          : Nat
-      qqq.doc      : Doc2
-      test         : Nat
-      test.doc     : Doc2
-      x            : Nat -> Nat
-      x.doc        : Doc2
-
-```
 ```ucm
 .> debug.format
 
@@ -125,18 +86,9 @@ ability Thing where
 Optional.doc = {{ A Doc before a type }}
 structural type Optional a = More Text | Some | Other a | None Nat 
 
-{{ 
-two 
+{{ A doc before a type with no type-vars 
 }}
-qqq = 2
-
-
-qqq.doc = {{ two }}
-qqq = 22
-
-
-MyEither.doc = {{ yo }}
-structural type MyEither = MyEither = MyEither
+type Two = One Nat | Two Text
 ```
 
 Formatter should leave things alone if the file doesn't typecheck.

--- a/unison-src/transcripts/formatter.output.md
+++ b/unison-src/transcripts/formatter.output.md
@@ -42,8 +42,7 @@ structural type Optional   a = More Text
   | Other   a 
   | None Nat 
 
-{{ A doc before a type with no type-vars 
-}}
+{{ A doc before a type with no type-vars }}
 type Two = One Nat | Two Text
 ```
 
@@ -52,17 +51,20 @@ type Two = One Nat | Two Text
 
 ```
 ```unison:added-by-ucm scratch.u
-x.doc =
-  {{ # Doc This is a **doc**!
-  
-    term link {x}
-    
-    type link {type Optional} }}
-x : Nat -> Nat
+{{ # Doc
+This is a *doc*! 
+
+term link {x}
+
+type link {type   Optional}
+
+}}
+x : 
+  Nat 
+  -> Nat
 x y =
-  use Nat +
-  x = 1 + 1
-  x + y
+    x   =     1 + 1
+    x + y
 -- Should keep comments after
 
 -- Test for a previous regression that added extra brackets.
@@ -70,24 +72,26 @@ oneLiner = {{ one liner }}
 -- After
 
 -- Before
-explicit.doc =
-  {{ # Here's a top-level doc
-  
-    With a paragraph
-    
-    Or two }}
+explicit.doc = {{
+# Here's a top-level doc
+
+With a paragraph
+
+Or two
+}}
 -- After
 
-Thing.doc = {{ A doc before an ability }}
+{{ A doc before an ability }}
 ability Thing where
-  more : Nat -> Text ->{Thing} Nat
-  doThing : Nat ->{Thing} Int
+  more  : Nat -> Text -> Nat
+  doThing  : Nat -> Int
 
-Optional.doc = {{ A Doc before a type }}
-structural type Optional a = More Text | Some | Other a | None Nat 
-
-{{ A doc before a type with no type-vars 
+{{ 
+A Doc before a type 
 }}
+structural type Optional a = More Text | Some | Other a | None Nat
+Optional.doc = {{ A Doc before a type }}
+ A doc before a type with no type-vars }}
 type Two = One Nat | Two Text
 ```
 

--- a/unison-src/transcripts/formatter.output.md
+++ b/unison-src/transcripts/formatter.output.md
@@ -42,13 +42,15 @@ structural type Optional   a = More Text
   | Other   a 
   | None Nat 
 
-
-
-{{ two }}
+{{ 
+two 
+}}
 qqq = 2
 
 
-{{ hi }}
+{{ 
+hi 
+}}
 test = 2
 
 
@@ -61,24 +63,114 @@ structural type MyEither = MyEither
 
   Loading changes detected in scratch.u.
 
-  offset=35:
-  unexpected <virtual semicolon>
-  expecting |
-     46 | {{ two }}
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
   
+    ⍟ These new definitions are ok to `add`:
+    
+      structural type MyEither
+        (also named builtin.Unit)
+      structural type Optional a
+      ability Thing
+      MyEither.doc : Doc2
+      Optional.doc : Doc2
+      Thing.doc    : Doc2
+      explicit.doc : Doc2
+      oneLiner     : Doc2
+      qqq          : Nat
+      qqq.doc      : Doc2
+      test         : Nat
+      test.doc     : Doc2
+      x            : Nat -> Nat
+      x.doc        : Doc2
 
 ```
+```ucm
+.> debug.format
 
-
-
-🛑
-
-The transcript failed due to an error in the stanza above. The error is:
-
-
-  offset=35:
-  unexpected <virtual semicolon>
-  expecting |
-     46 | {{ two }}
+```
+```unison:added-by-ucm scratch.u
+x.doc =
+  {{ # Doc This is a **doc**!
   
+    term link {x}
+    
+    type link {type Optional} }}
+x : Nat -> Nat
+x y =
+  use Nat +
+  x = 1 + 1
+  x + y
+-- Should keep comments after
 
+-- Test for a previous regression that added extra brackets.
+oneLiner = {{ one liner }}
+-- After
+
+-- Before
+explicit.doc =
+  {{ # Here's a top-level doc
+  
+    With a paragraph
+    
+    Or two }}
+-- After
+
+Thing.doc = {{ A doc before an ability }}
+ability Thing where
+  more : Nat -> Text ->{Thing} Nat
+  doThing : Nat ->{Thing} Int
+
+Optional.doc = {{ A Doc before a type }}
+structural type Optional a = More Text | Some | Other a | None Nat 
+
+{{ 
+two 
+}}
+qqq = 2
+
+
+qqq.doc = {{ two }}
+qqq = 22
+
+
+MyEither.doc = {{ yo }}
+structural type MyEither = MyEither = MyEither
+```
+
+Formatter should leave things alone if the file doesn't typecheck.
+
+```unison
+brokenDoc = {{ hello }} + 1
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I couldn't find any definitions matching the name + inside the namespace .
+  
+      1 | brokenDoc = {{ hello }} + 1
+  
+  Some common causes of this error include:
+    * Your current namespace is too deep to contain the
+      definition in its subtree
+    * The definition is part of a library which hasn't been
+      added to this project
+  
+  To add a library to this project use the command: `fork <.path.to.lib> .lib.<libname>`
+  
+  Whatever it is, its type should conform to Doc2 -> Nat -> o.
+  
+  I found some terms in scope with matching names but different types. If one of these is what you meant, try using the fully qualified name and I might be able to give you a more illuminating error message: 
+  
+    - builtin.Float.+ : Float -> Float -> Float
+    - builtin.Int.+ : Int -> Int -> Int
+    - builtin.Nat.+ : Nat -> Nat -> Nat
+
+```
+```ucm
+.> debug.format
+
+```

--- a/unison-syntax/src/Unison/Syntax/Lexer.hs
+++ b/unison-syntax/src/Unison/Syntax/Lexer.hs
@@ -375,7 +375,7 @@ lexemes' eof =
 
     doc2 :: P [Token Lexeme]
     doc2 = do
-      P.lookAhead (token'' ignore (lit "{{"))
+      P.lookAhead (lit "{{")
       beforeStartToks <- token' ignore (pure ())
       startToks <- token (lit "{{" $> Open "syntax.docUntitledSection")
       env0 <- S.get

--- a/unison-syntax/src/Unison/Syntax/Lexer.hs
+++ b/unison-syntax/src/Unison/Syntax/Lexer.hs
@@ -49,7 +49,6 @@ import Text.Megaparsec.Char qualified as CP
 import Text.Megaparsec.Char.Lexer qualified as LP
 import Text.Megaparsec.Error qualified as EP
 import Text.Megaparsec.Internal qualified as PI
-import Unison.Debug qualified as Debug
 import Unison.HashQualified qualified as HQ
 import Unison.HashQualified' qualified as HQ'
 import Unison.Lexer.Pos (Column, Line, Pos (Pos), column, line)
@@ -391,8 +390,8 @@ lexemes' eof =
       pure $ case (tn, docToks) of
         (Just (WordyId tname), ht : _)
           | isTopLevel ->
-              startToks
-                <> [WordyId (HQ'.fromName (Name.snoc (HQ'.toName tname) (NameSegment "doc"))) <$ ht, Open "=" <$ ht]
+              [WordyId (HQ'.fromName (Name.snoc (HQ'.toName tname) (NameSegment "doc"))) <$ ht, Open "=" <$ ht]
+                <> startToks
                 <> (bodyToks0)
                 <> [Close <$ last closeToks]
                 <> closeToks

--- a/unison-syntax/src/Unison/Syntax/Lexer.hs
+++ b/unison-syntax/src/Unison/Syntax/Lexer.hs
@@ -375,14 +375,20 @@ lexemes' eof =
 
     doc2 :: P [Token Lexeme]
     doc2 = do
+      -- Ensure we're at a doc before we start consuming tokens
       P.lookAhead (lit "{{")
       openStart <- pos
+      -- Produce any layout tokens, such as closing the last open block or virtual semicolons
+      -- We don't use 'token' on "{{" directly because we don't want to duplicate layout
+      -- tokens if we do the rewrite hack for type-docs below.
       beforeStartToks <- token' ignore (pure ())
       void $ lit "{{"
       openEnd <- pos
       CP.space
+      -- Construct the token for opening the doc block.
       let openTok = Token (Open "syntax.docUntitledSection") openStart openEnd
       env0 <- S.get
+      -- Disable layout while parsing the doc block
       (bodyToks0, closeTok) <- local (\env -> env {inLayout = False}) do
         bodyToks <- body
         closeStart <- pos
@@ -390,12 +396,14 @@ lexemes' eof =
         closeEnd <- pos
         pure (bodyToks, Token Close closeStart closeEnd)
       let docToks = beforeStartToks <> [openTok] <> bodyToks0 <> [closeTok]
+      -- Parse any layout tokens after the doc block, e.g. virtual semicolon
       endToks <- token' ignore (pure ())
       -- Hack to allow anonymous doc blocks before type decls
       --   {{ Some docs }}             Foo.doc = {{ Some docs }}
       --   ability Foo where      =>   ability Foo where
       tn <- subsequentTypeName
       pure $ case (tn) of
+        -- If we're followed by a type, we rewrite the doc block to be a named doc block.
         (Just (WordyId tname))
           | isTopLevel ->
               beforeStartToks
@@ -403,6 +411,7 @@ lexemes' eof =
                 <> [openTok]
                 <> bodyToks0
                 <> [closeTok]
+                -- We need an extra 'Close' here because we added an extra Open above.
                 <> [closeTok]
                 <> endToks
           where


### PR DESCRIPTION
## Overview

Fixes a few bugs found in the auto-formatter; fixes https://github.com/unisonweb/unison/issues/4640

## Implementation notes

* Fixes spans for type decls, previously constructor arguments could be left out of the span.
* Fixes spans for `{{ doc }}` literals to include the opening and closing brackets
* Completely rewrites the text-replacement applying engine, the previous version didn't handle the case where updates could chang the number of newlines in the file.

The docs lexer is a bit of a mess, but I added test-cases to the formatting transcript to cover all the cases and possible regressions I could find.

## Test coverage

Transcripts