### PR TITLE
Don't implicitly close transclude blocks

### DIFF
--- a/unison-src/transcripts/fix4592.md
+++ b/unison-src/transcripts/fix4592.md
@@ -1,8 +1,8 @@
 ```ucm:hide
-.> builtins.merge
+.> builtins.mergeio
 ```
 
-```unison:error
+```unison
 doc = {{ {{ bug "bug"
   52 }} }}
 ```

--- a/unison-src/transcripts/fix4592.md
+++ b/unison-src/transcripts/fix4592.md
@@ -1,0 +1,8 @@
+```ucm:hide
+.> builtins.merge
+```
+
+```unison:error
+doc = {{ {{ bug "bug"
+  52 }} }}
+```

--- a/unison-src/transcripts/fix4592.output.md
+++ b/unison-src/transcripts/fix4592.output.md
@@ -1,0 +1,15 @@
+```unison
+doc = {{ {{ bug "bug"
+  52 }} }}
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found a closing '}}' here without a matching 'syntax.docTransclude'.
+  
+      2 |   52 }} }}
+  
+
+```

--- a/unison-src/transcripts/fix4592.output.md
+++ b/unison-src/transcripts/fix4592.output.md
@@ -7,9 +7,12 @@ doc = {{ {{ bug "bug"
 
   Loading changes detected in scratch.u.
 
-  I found a closing '}}' here without a matching 'syntax.docTransclude'.
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
   
-      2 |   52 }} }}
-  
+    ⍟ These new definitions are ok to `add`:
+    
+      doc : Doc2
 
 ```

--- a/unison-syntax/src/Unison/Syntax/Lexer.hs
+++ b/unison-syntax/src/Unison/Syntax/Lexer.hs
@@ -258,7 +258,7 @@ token'' tok p = do
     topHasClosePair :: Layout -> Bool
     topHasClosePair [] = False
     topHasClosePair ((name, _) : _) =
-      name `elem` ["{", "(", "[", "handle", "match", "if", "then"]
+      name `elem` ["syntax.docTransclude", "{", "(", "[", "handle", "match", "if", "then"]
 
 showErrorFancy :: (P.ShowErrorComponent e) => P.ErrorFancy e -> String
 showErrorFancy (P.ErrorFail msg) = msg


### PR DESCRIPTION
fixes #4592

## Overview

I'm not familiar with the lexer, but after some debugging it seems like this is a lexing bug where an additional `Close` lexeme is emitted after the deindent on the `(Draw.toSvg` line (in the code from #4592). Tracking this down, the `Close` lexeme is emitted [from `token` on this line](https://github.com/unisonweb/unison/blob/2ab2ef5142b390e99b2280a4b45b24295f58169f/unison-syntax/src/Unison/Syntax/Lexer.hs#L373) as `token` calls `token''` which may emit closing tokens as seen [here](https://github.com/unisonweb/unison/blob/2ab2ef5142b390e99b2280a4b45b24295f58169f/unison-syntax/src/Unison/Syntax/Lexer.hs#L239-L261).

So, this change instructs `token''` to not implicitly close transclude blocks. Someone more familiar with the lexer should give this list a look though. I don't know how many open block types we have since they are distinguished by strings, so I don't know if this list is complete.

## Test coverage

There is a new transcript