### PR TITLE
LSP startup time speedup and CWD fix

### DIFF
--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -16,6 +16,7 @@ import Ki qualified
 import System.Console.Haskeline qualified as Line
 import System.IO (hGetEcho, hPutStrLn, hSetEcho, stderr, stdin)
 import System.IO.Error (isDoesNotExistError)
+import U.Codebase.HashTags (CausalHash)
 import U.Codebase.Sqlite.Operations qualified as Operations
 import U.Codebase.Sqlite.Queries qualified as Queries
 import Unison.Auth.CredentialManager (newCredentialManager)
@@ -27,7 +28,7 @@ import Unison.Cli.Pretty (prettyProjectAndBranchName)
 import Unison.Cli.ProjectUtils (projectBranchPathPrism)
 import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
-import Unison.Codebase.Branch (Branch)
+import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Editor.HandleInput qualified as HandleInput
 import Unison.Codebase.Editor.Input (Event, Input (..))
 import Unison.Codebase.Editor.Output (Output)
@@ -126,7 +127,7 @@ main ::
   Codebase IO Symbol Ann ->
   Maybe Server.BaseUrl ->
   UCMVersion ->
-  (Branch IO -> STM ()) ->
+  (CausalHash -> STM ()) ->
   (Path.Absolute -> STM ()) ->
   ShouldWatchFiles ->
   IO ()
@@ -154,7 +155,7 @@ main dir welcome initialPath config initialInputs runtime sbRuntime nRuntime cod
           currentRoot <- atomically do
             currentRoot <- readTMVar rootVar
             guard $ Just currentRoot /= lastRoot
-            notifyBranchChange currentRoot
+            notifyBranchChange (Branch.headHash currentRoot)
             pure (Just currentRoot)
           loop currentRoot
     loop Nothing

--- a/unison-cli/src/Unison/LSP/Completion.hs
+++ b/unison-cli/src/Unison/LSP/Completion.hs
@@ -53,7 +53,7 @@ completionHandler m respond =
   respond . maybe (Right $ InL mempty) (Right . InR . InL) =<< runMaybeT do
     let fileUri = (m ^. params . textDocument . uri)
     (range, prefix) <- VFS.completionPrefix (m ^. params . textDocument . uri) (m ^. params . position)
-    ppe <- PPED.suffixifiedPPE <$> lift globalPPED
+    ppe <- PPED.suffixifiedPPE <$> lift currentPPED
     codebaseCompletions <- lift getCodebaseCompletions
     Config {maxCompletions} <- lift getConfig
     let defMatches = matchCompletions codebaseCompletions prefix

--- a/unison-cli/src/Unison/LSP/FileAnalysis.hs
+++ b/unison-cli/src/Unison/LSP/FileAnalysis.hs
@@ -82,7 +82,7 @@ checkFile doc = runMaybeT do
   currentPath <- lift getCurrentPath
   let fileUri = doc ^. uri
   (fileVersion, contents) <- VFS.getFileContents fileUri
-  parseNames <- lift getParseNames
+  parseNames <- lift getCurrentNames
   let sourceName = getUri $ doc ^. uri
   let lexedSource@(srcText, tokens) = (contents, L.lexer (Text.unpack sourceName) (Text.unpack contents))
   let ambientAbilities = []
@@ -158,7 +158,7 @@ fileAnalysisWorker = forever do
 
 analyseFile :: (Foldable f) => Uri -> Text -> f (Note Symbol Ann) -> Lsp ([Diagnostic], [RangedCodeAction])
 analyseFile fileUri srcText notes = do
-  pped <- PPED.suffixifiedPPE <$> LSP.globalPPED
+  pped <- PPED.suffixifiedPPE <$> LSP.currentPPED
   (noteDiags, noteActions) <- analyseNotes fileUri pped (Text.unpack srcText) notes
   pure (noteDiags, noteActions)
 
@@ -167,7 +167,7 @@ analyseFile fileUri srcText notes = do
 computeConflictWarningDiagnostics :: Uri -> FileSummary -> Lsp [Diagnostic]
 computeConflictWarningDiagnostics fileUri fileSummary@FileSummary {fileNames} = do
   let defLocations = fileDefLocations fileSummary
-  conflictedNames <- Names.conflicts <$> getParseNames
+  conflictedNames <- Names.conflicts <$> getCurrentNames
   let locationForName :: Name -> Set Ann
       locationForName name = fold $ Map.lookup (Name.toVar name) defLocations
   let conflictedTermLocations =
@@ -360,7 +360,7 @@ analyseNotes fileUri ppe src notes = do
       | not (isUserBlank v) = pure []
       | otherwise = do
           Env {codebase} <- ask
-          ppe <- PPED.suffixifiedPPE <$> globalPPED
+          ppe <- PPED.suffixifiedPPE <$> currentPPED
           let cleanedTyp = Context.generalizeAndUnTypeVar typ -- TODO: is this right?
           refs <- liftIO . Codebase.runTransaction codebase $ Codebase.termsOfType codebase cleanedTyp
           forMaybe (toList refs) $ \ref -> runMaybeT $ do
@@ -395,7 +395,10 @@ getFileAnalysis uri = do
         writeTVar checkedFilesV $ Map.insert uri mvar checkedFiles
         pure mvar
       Just mvar -> pure mvar
-  atomically (readTMVar tmvar)
+  Debug.debugM Debug.LSP "Waiting on file analysis" uri
+  r <- atomically (readTMVar tmvar)
+  Debug.debugM Debug.LSP "Got file analysis" uri
+  pure r
 
 -- | Build a Names from a file if it's parseable.
 --
@@ -427,7 +430,7 @@ ppedForFile fileUri = do
 
 ppedForFileHelper :: Maybe (UF.UnisonFile Symbol a) -> Maybe (UF.TypecheckedUnisonFile Symbol a) -> Lsp PPED.PrettyPrintEnvDecl
 ppedForFileHelper uf tf = do
-  codebasePPED <- globalPPED
+  codebasePPED <- currentPPED
   hashLen <- asks codebase >>= \codebase -> liftIO (Codebase.runTransaction codebase Codebase.hashLength)
   pure $ case (uf, tf) of
     (Nothing, Nothing) -> codebasePPED

--- a/unison-cli/src/Unison/LSP/UCMWorker.hs
+++ b/unison-cli/src/Unison/LSP/UCMWorker.hs
@@ -21,13 +21,14 @@ import UnliftIO.STM
 
 -- | Watches for state changes in UCM and updates cached LSP state accordingly
 ucmWorker ::
-  TVar PrettyPrintEnvDecl ->
-  TVar Names ->
-  TVar (NameSearch Sqlite.Transaction) ->
+  TMVar PrettyPrintEnvDecl ->
+  TMVar Names ->
+  TMVar (NameSearch Sqlite.Transaction) ->
+  TMVar Path.Absolute ->
   STM CausalHash ->
   STM Path.Absolute ->
   Lsp ()
-ucmWorker ppedVar parseNamesVar nameSearchCacheVar getLatestRoot getLatestPath = do
+ucmWorker ppedVar parseNamesVar nameSearchCacheVar currentPathVar getLatestRoot getLatestPath = do
   Env {codebase, completionsVar} <- ask
   let loop :: (CausalHash, Path.Absolute) -> Lsp a
       loop (currentRoot, currentPath) = do
@@ -37,21 +38,31 @@ ucmWorker ppedVar parseNamesVar nameSearchCacheVar getLatestRoot getLatestPath =
         hl <- liftIO $ Codebase.runTransaction codebase Codebase.hashLength
         let pped = PPED.makePPED (PPE.hqNamer hl parseNames) (PPE.suffixifyByHash parseNames)
         atomically $ do
-          writeTVar parseNamesVar parseNames
-          writeTVar ppedVar pped
-          writeTVar nameSearchCacheVar (NameSearch.makeNameSearch hl parseNames)
+          writeTMVar currentPathVar currentPath
+          writeTMVar parseNamesVar parseNames
+          writeTMVar ppedVar pped
+          writeTMVar nameSearchCacheVar (NameSearch.makeNameSearch hl parseNames)
         -- Re-check everything with the new names and ppe
         VFS.markAllFilesDirty
         atomically do
-          writeTVar completionsVar (namesToCompletionTree parseNames)
+          writeTMVar completionsVar (namesToCompletionTree parseNames)
+        Debug.debugLogM Debug.LSP "LSP Initialized"
         latest <- atomically $ do
           latestRoot <- getLatestRoot
           latestPath <- getLatestPath
           guard $ (currentRoot /= latestRoot || currentPath /= latestPath)
           pure (latestRoot, latestPath)
+        Debug.debugLogM Debug.LSP "LSP Change detected"
         loop latest
   (rootBranch, currentPath) <- atomically $ do
     rootBranch <- getLatestRoot
     currentPath <- getLatestPath
     pure (rootBranch, currentPath)
   loop (rootBranch, currentPath)
+  where
+    -- This is added in stm-2.5.1, remove this if we upgrade.
+    writeTMVar :: TMVar a -> a -> STM ()
+    writeTMVar var a =
+      tryReadTMVar var >>= \case
+        Nothing -> putTMVar var a
+        Just _ -> void $ swapTMVar var a


### PR DESCRIPTION
## Overview

* This applies the UCM start-up time fix from regular UCM to the LSP
* The LSP will no longer report incorrect errors before the server is loaded, it'll just wait until it's ready.
* Fixes an issue where the LSP wasn't always being set to the correct 'current path'

## Implementation notes

Like the UCM speedup, this skips loading the entire root-branch and instead just loads the current branch, which speeds things up a lot.

I swapped TVars which were being initialized with empty values, to TMVars that aren't filled until the LSP is loaded to avoid reporting incorrect errors.

## Interesting/controversial decisions

Nah, straight-forward improvement.

## Test coverage

I tried it out, we can dogfood on trunk for a bit.