### PR TITLE
Delete invalid remote mappings on push

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Queries.hs
@@ -149,6 +149,7 @@ module U.Codebase.Sqlite.Queries
     setRemoteProjectBranchName,
     insertBranchRemoteMapping,
     ensureBranchRemoteMapping,
+    deleteBranchRemoteMapping,
 
     -- * indexes
 
@@ -4032,6 +4033,20 @@ ensureBranchRemoteMapping pid bid rpid host rbid =
         local_branch_id,
         remote_host)
         DO NOTHING
+    |]
+
+deleteBranchRemoteMapping ::
+  ProjectId ->
+  ProjectBranchId ->
+  URI ->
+  Transaction ()
+deleteBranchRemoteMapping pid bid host =
+  execute
+    [sql|
+      DELETE FROM project_branch_remote_mapping
+      WHERE local_project_id = :pid
+        AND local_branch_id = :bid
+        AND remote_host = :host
     |]
 
 -- | Convert reversed name segments into glob for searching based on suffix

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
@@ -424,7 +424,7 @@ pushProjectBranchToProjectBranch'InferredProject force localProjectAndBranch loc
                         localBranchId
                         Share.hardCodedUri
                     Cli.returnEarly $
-                      Output.RemoteProjectBranchDoesntExist
+                      Output.RemoteProjectBranchDoesntExist'Push
                         Share.hardCodedUri
                         (ProjectAndBranch remoteProjectName remoteBranchName)
               Share.getProjectBranchById Share.NoSquashedHead (ProjectAndBranch remoteProjectId remoteBranchId) >>= \case

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Push.hs
@@ -417,7 +417,12 @@ pushProjectBranchToProjectBranch'InferredProject force localProjectAndBranch loc
                 (ProjectAndBranch (remoteProjectId, remoteProjectName) remoteBranchName)
             -- "push" with remote mapping for branch
             Just (remoteBranchId, remoteBranchName) -> do
-              let remoteProjectBranchDoesntExist =
+              let remoteProjectBranchDoesntExist = do
+                    Cli.runTransaction $
+                      Queries.deleteBranchRemoteMapping
+                        localProjectId
+                        localBranchId
+                        Share.hardCodedUri
                     Cli.returnEarly $
                       Output.RemoteProjectBranchDoesntExist
                         Share.hardCodedUri

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -350,6 +350,7 @@ data Output
   | LocalProjectNorProjectBranchExist ProjectName ProjectBranchName
   | RemoteProjectDoesntExist URI ProjectName
   | RemoteProjectBranchDoesntExist URI (ProjectAndBranch ProjectName ProjectBranchName)
+  | RemoteProjectBranchDoesntExist'Push URI (ProjectAndBranch ProjectName ProjectBranchName)
   | RemoteProjectReleaseIsDeprecated URI (ProjectAndBranch ProjectName ProjectBranchName)
   | RemoteProjectPublishedReleaseCannotBeChanged URI (ProjectAndBranch ProjectName ProjectBranchName)
   | -- A remote project branch head wasn't in the expected state
@@ -590,6 +591,7 @@ isFailure o = case o of
   LocalProjectNorProjectBranchExist {} -> True
   RemoteProjectDoesntExist {} -> True
   RemoteProjectBranchDoesntExist {} -> True
+  RemoteProjectBranchDoesntExist'Push {} -> True
   RemoteProjectReleaseIsDeprecated {} -> True
   RemoteProjectPublishedReleaseCannotBeChanged {} -> True
   RemoteProjectBranchHeadMismatch {} -> True

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1933,6 +1933,13 @@ notifyUser dir = \case
   RemoteProjectBranchDoesntExist host projectAndBranch ->
     pure . P.wrap $
       prettyProjectAndBranchName projectAndBranch <> "does not exist on" <> prettyURI host
+  RemoteProjectBranchDoesntExist'Push host projectAndBranch ->
+    pure . P.wrap $
+      "Pushing failed because the target"
+        <> prettyProjectAndBranchName projectAndBranch
+        <> "does not exist on"
+        <> P.group (prettyURI host <> ".")
+        <> "This invalid default push target has been removed."
   RemoteProjectBranchHeadMismatch host projectAndBranch ->
     pure . P.wrap $
       prettyProjectAndBranchName projectAndBranch

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1934,12 +1934,16 @@ notifyUser dir = \case
     pure . P.wrap $
       prettyProjectAndBranchName projectAndBranch <> "does not exist on" <> prettyURI host
   RemoteProjectBranchDoesntExist'Push host projectAndBranch ->
-    pure . P.wrap $
-      "Pushing failed because the target"
+    let push = P.group . P.backticked . IP.patternName $ IP.push
+    in pure . P.wrap $
+      "The previous push target named"
         <> prettyProjectAndBranchName projectAndBranch
-        <> "does not exist on"
+        <> "has been deleted from"
         <> P.group (prettyURI host <> ".")
-        <> "This invalid default push target has been removed."
+        <> "I've deleted the invalid push target."
+        <> "Run the"
+        <> push
+        <> "command again to push to a new target."
   RemoteProjectBranchHeadMismatch host projectAndBranch ->
     pure . P.wrap $
       prettyProjectAndBranchName projectAndBranch


### PR DESCRIPTION
## Overview

If a branch remote mapping points to a deleted project or branch then the user needs to update their remote mapping somehow. We currently don't have a way, but it makes sense to drop the existing mapping as it will not be useful. With this change a subsequent push without an explicit target will succeed.

## Test coverage

Manual testing
