### PR TITLE
Speed up docs.to-html by not using root-branch

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -560,9 +560,8 @@ loop e = do
               Cli.respond $ Output.MarkdownOut (Text.intercalate "\n---\n" mdText)
             DocsToHtmlI namespacePath' sourceDirectory -> do
               Cli.Env {codebase, sandboxedRuntime} <- ask
-              rootBranch <- Cli.getRootBranch
-              absPath <- Path.unabsolute <$> Cli.resolvePath' namespacePath'
-              _evalErrs <- liftIO $ (Backend.docsInBranchToHtmlFiles sandboxedRuntime codebase rootBranch absPath sourceDirectory)
+              branch <- liftIO $ Codebase.getBranchAtPath codebase absPath
+              _evalErrs <- liftIO $ (Backend.docsInBranchToHtmlFiles sandboxedRuntime codebase branch sourceDirectory)
               pure ()
             AliasTermI src' dest' -> do
               Cli.Env {codebase} <- ask

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -560,6 +560,7 @@ loop e = do
               Cli.respond $ Output.MarkdownOut (Text.intercalate "\n---\n" mdText)
             DocsToHtmlI namespacePath' sourceDirectory -> do
               Cli.Env {codebase, sandboxedRuntime} <- ask
+              absPath <- Cli.resolvePath' namespacePath'
               branch <- liftIO $ Codebase.getBranchAtPath codebase absPath
               _evalErrs <- liftIO $ (Backend.docsInBranchToHtmlFiles sandboxedRuntime codebase branch sourceDirectory)
               pure ()

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -911,13 +911,11 @@ docsInBranchToHtmlFiles ::
   Rt.Runtime Symbol ->
   Codebase IO Symbol Ann ->
   Branch IO ->
-  Path ->
   FilePath ->
   -- Returns any doc evaluation errors which may have occurred.
   -- Note that all docs will still be rendered even if there are errors.
   IO [Rt.Error]
-docsInBranchToHtmlFiles runtime codebase root currentPath directory = do
-  let currentBranch = Branch.getAt' currentPath root
+docsInBranchToHtmlFiles runtime codebase currentBranch directory = do
   let allTerms = (R.toList . Branch.deepTerms . Branch.head) currentBranch
   -- ignores docs inside lib namespace, recursively
   let notLib (_, name) = "lib" `notElem` Name.segments name


### PR DESCRIPTION
## Overview

When investigating a bug for Rebecca earlier today I saw we're loading the root branch unnecessarily in `docs.to-html` and it was a trivial fix. Should speed up the command and also means you don't have to wait for the root branch to load into memory.

## Implementation notes

Rather than loading the root branch, then getting a sub-branch; just load the sub-branch directly. It'll get pulled from the cache if it's already loaded elsewhere in UCM.

## Test coverage

None, it's a pretty trivial change.