### PR TITLE
Fix parsing bug involving `use` and underscore-prefixed names

### DIFF
--- a/unison-src/transcripts/fix4280.md
+++ b/unison-src/transcripts/fix4280.md
@@ -2,7 +2,7 @@
 .> builtins.merge
 ```
 
-```unison:error
+```unison
 foo.bar._baz = 5
 
 bonk : Nat

--- a/unison-src/transcripts/fix4280.md
+++ b/unison-src/transcripts/fix4280.md
@@ -1,0 +1,12 @@
+```ucm:hide
+.> builtins.merge
+```
+
+```unison:error
+foo.bar._baz = 5
+
+bonk : Nat
+bonk =
+  use foo.bar _baz
+  _baz
+```

--- a/unison-src/transcripts/fix4280.output.md
+++ b/unison-src/transcripts/fix4280.output.md
@@ -1,0 +1,27 @@
+```unison
+foo.bar._baz = 5
+
+bonk : Nat
+bonk =
+  use foo.bar _baz
+  _baz
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found a value  of type:  Nat
+  where I expected to find:  Unit
+  
+      5 |   use foo.bar _baz
+      6 |   _baz
+  
+    from right here:
+  
+      1 | foo.bar._baz = 5
+  
+  Hint: Actions within a block must have type Unit.
+        Use _ = <expr> to ignore a result.
+
+```

--- a/unison-src/transcripts/fix4280.output.md
+++ b/unison-src/transcripts/fix4280.output.md
@@ -11,17 +11,13 @@ bonk =
 
   Loading changes detected in scratch.u.
 
-  I found a value  of type:  Nat
-  where I expected to find:  Unit
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
   
-      5 |   use foo.bar _baz
-      6 |   _baz
-  
-    from right here:
-  
-      1 | foo.bar._baz = 5
-  
-  Hint: Actions within a block must have type Unit.
-        Use _ = <expr> to ignore a result.
+    ⍟ These new definitions are ok to `add`:
+    
+      bonk         : Nat
+      foo.bar._baz : Nat
 
 ```

--- a/unison-syntax/src/Unison/Syntax/Parser.hs
+++ b/unison-syntax/src/Unison/Syntax/Parser.hs
@@ -323,6 +323,7 @@ wordyDefinitionName = queryToken $ \case
 importWordyId :: Ord v => P v m (L.Token Name)
 importWordyId = queryToken \case
   L.WordyId (HQ'.NameOnly n) -> Just n
+  L.Blank s | not (null s) -> Just $ Name.unsafeFromString ("_" <> s)
   _ -> Nothing
 
 -- The `+` in: use Foo.bar + as a Name


### PR DESCRIPTION
## Overview

Fixes #4280 

Seems like `importWordyId` was meant to be identical to `hqWordyId_` except it rejects hashes. It also (unintentionally, I think) rejected blanks. This led to parsing failures for import statement suffixes that are prefixed with an underscore, which would result in a successful parse, but the underscored suffix would be parsed separately, commonly leading to type errors.

## Test coverage

There is a new transcript

## Loose ends

There was some discussion of if we even want to allow prefix-underscored names, or if we want to reserve those strings exclusively for type holes/blanks. So, depending on how that goes, we may want to rip out all of the `Blank` -> `Name` stuff.
