### PR TITLE
Allow multi-line bold, italics, and strikethrough

### DIFF
--- a/unison-src/transcripts/formatter.md
+++ b/unison-src/transcripts/formatter.md
@@ -48,6 +48,21 @@ structural type Optional   a = More Text
 
 {{ A doc before a type with no type-vars }}
 type Two = One Nat | Two Text
+
+-- Regression for https://github.com/unisonweb/unison/issues/4669
+
+multilineBold = {{
+
+**This paragraph is really really really really really long and spans multiple lines 
+with a strike-through block**
+
+_This paragraph is really really really really really long and spans multiple lines 
+with a strike-through block_
+
+~This paragraph is really really really really really long and spans multiple lines 
+with a strike-through block~
+
+}}
 ```
 
 ```ucm

--- a/unison-src/transcripts/formatter.output.md
+++ b/unison-src/transcripts/formatter.output.md
@@ -44,6 +44,21 @@ structural type Optional   a = More Text
 
 {{ A doc before a type with no type-vars }}
 type Two = One Nat | Two Text
+
+-- Regression for https://github.com/unisonweb/unison/issues/4669
+
+multilineBold = {{
+
+**This paragraph is really really really really really long and spans multiple lines 
+with a strike-through block**
+
+_This paragraph is really really really really really long and spans multiple lines 
+with a strike-through block_
+
+~This paragraph is really really really really really long and spans multiple lines 
+with a strike-through block~
+
+}}
 ```
 
 ```ucm
@@ -91,6 +106,20 @@ structural type Optional a = More Text | Some | Other a | None Nat
 
 Two.doc = {{ A doc before a type with no type-vars }}
 type Two = One Nat | Two Text
+
+-- Regression for https://github.com/unisonweb/unison/issues/4669
+
+multilineBold =
+  {{
+  **This paragraph is really really really really really long and spans
+  multiple lines with a strike-through block**
+  
+  __This paragraph is really really really really really long and spans
+  multiple lines with a strike-through block__
+  
+  ~~This paragraph is really really really really really long and spans
+  multiple lines with a strike-through block~~
+  }}
 ```
 
 Formatter should leave things alone if the file doesn't typecheck.

--- a/unison-syntax/src/Unison/Syntax/Lexer.hs
+++ b/unison-syntax/src/Unison/Syntax/Lexer.hs
@@ -587,6 +587,14 @@ lexemes' eof =
         nonNewlineSpace ch = isSpace ch && ch /= '\n' && ch /= '\r'
         nonNewlineSpaces = P.takeWhileP Nothing nonNewlineSpace
 
+        -- Allows whitespace or a newline, but not more than two newlines in a row.
+        whitespaceWithoutParagraphBreak :: P ()
+        whitespaceWithoutParagraphBreak = void do
+          void nonNewlineSpaces
+          optional newline >>= \case
+            Just _ -> void nonNewlineSpaces
+            Nothing -> pure ()
+
         fencedBlock =
           P.label "block eval (syntax: a fenced code block)" $
             evalUnison <|> exampleBlock <|> other
@@ -651,7 +659,7 @@ lexemes' eof =
           wrap (name end) . wrap "syntax.docParagraph" $
             join
               <$> P.someTill
-                (leafy (closing <|> (void $ lit end)) <* nonNewlineSpaces)
+                (leafy (closing <|> (void $ lit end)) <* whitespaceWithoutParagraphBreak)
                 (lit end)
 
         externalLink =


### PR DESCRIPTION
## Overview

fixes https://github.com/unisonweb/unison/issues/4669

The formatter will break up bold, italic, and strikethrough sections over multiple lines, but the lexer doesn't parse multi-line sections like that.

I changed it so the parser can handle multiline bold, italics and strikethroughs as long as they're part of the same paragraph.

## Implementation notes

* Adds `whitespaceWithoutParagraphBreak` helper which parses a block of whitespace with at most 1 newline.
* Use the new whitespace helper when parsing more docs within a bold, italic, or strikethrough.

## Test coverage

* Added regression test to doc formatter
