### PR TITLE
Add tab-completion and fzf for upgrade command

### DIFF
--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -3006,7 +3006,7 @@ upgrade =
     { patternName = "upgrade",
       aliases = [],
       visibility = I.Visible,
-      args = [],
+      args = [("dependency to upgrade", Required, dependencyArg), ("dependency to upgrade to", Required, dependencyArg)],
       help =
         P.wrap $
           "`upgrade old new` upgrades library dependency `lib.old` to `lib.new`, and, if successful, deletes `lib.old`.",
@@ -3265,6 +3265,17 @@ namespaceOrDefinitionArg =
         pure (List.nubOrd $ namespaces <> termsTypes),
       fzfResolver =
         Just Resolvers.namespaceOrDefinitionResolver
+    }
+
+-- | A dependency name. E.g. if your project has `lib.base`, `base` would be a dependency
+-- name.
+dependencyArg :: ArgumentType
+dependencyArg =
+  ArgumentType
+    { typeName = "project dependency",
+      suggestions = \q cb _http p -> Codebase.runTransaction cb do
+        prefixCompleteNamespace q (p Path.:> Name.libSegment),
+      fzfResolver = Just Resolvers.projectDependencyResolver
     }
 
 -- | Names of child branches of the branch, only gives options for one 'layer' deeper at a time.

--- a/unison-src/transcripts/upgrade-happy-path.md
+++ b/unison-src/transcripts/upgrade-happy-path.md
@@ -10,8 +10,19 @@ lib.new.foo = 18
 thingy = lib.old.foo + 10
 ```
 
+
 ```ucm
 proj/main> add
+```
+
+Test tab completion and fzf options of upgrade command.
+```ucm
+proj/main> debug.tab-complete upgrade ol
+proj/main> debug.fuzzy-options upgrade _
+proj/main> debug.fuzzy-options upgrade old _
+```
+
+```ucm
 proj/main> upgrade old new
 proj/main> ls lib
 proj/main> view thingy

--- a/unison-src/transcripts/upgrade-happy-path.output.md
+++ b/unison-src/transcripts/upgrade-happy-path.output.md
@@ -28,6 +28,29 @@ proj/main> add
     lib.old.foo : Nat
     thingy      : Nat
 
+```
+Test tab completion and fzf options of upgrade command.
+```ucm
+proj/main> debug.tab-complete upgrade ol
+
+   old
+
+proj/main> debug.fuzzy-options upgrade _
+
+  Select a dependency to upgrade:
+    * builtin
+    * new
+    * old
+
+proj/main> debug.fuzzy-options upgrade old _
+
+  Select a dependency to upgrade to:
+    * builtin
+    * new
+    * old
+
+```
+```ucm
 proj/main> upgrade old new
 
   I upgraded old to new, and removed old.


### PR DESCRIPTION
## Overview

The `upgrade` command was added without argument types, so tab-completion and fzf don't work 😢 , now they do 🎉 

## Implementation notes

* Adds required arguments for the `upgrade` command
* Implements a new `projectDependencies` fzf resolver

## Test coverage

Adds completion tests to the upgrade-happy-path transcript