### PR TITLE
Add Name ToJSONKey instance

### DIFF
--- a/unison-share-api/src/Unison/Server/Orphans.hs
+++ b/unison-share-api/src/Unison/Server/Orphans.hs
@@ -169,6 +169,9 @@ instance ToJSON Name where
   toEncoding = toEncoding . Name.toText
   toJSON = toJSON . Name.toText
 
+instance ToJSONKey Name where
+  toJSONKey = contramap Name.toText (toJSONKey @Text)
+
 instance ToSchema Name where
   declareNamedSchema _ = declareNamedSchema (Proxy @Text)
 


### PR DESCRIPTION
## Overview

Just an Orphan ToJSONKey instance allowing Share to use `Name`s as JSON object keys.

Need it for namespace diffs on Share :D 