### PR TITLE
Add parens to annotation of lexed symboly segments

### DIFF
--- a/unison-src/transcripts/formatter.md
+++ b/unison-src/transcripts/formatter.md
@@ -19,6 +19,15 @@ x y =
     x + y
 -- Should keep comments after
 
+-- symbolyDefinition
+(<|>) : Nat -> Nat -> (Nat, Nat)
+(<|>) a b = (a, b)
+
+symbolyEndOfBlock =
+  use List +:
+  (+:)
+
+
 -- Test for a previous regression that added extra brackets.
 oneLiner = {{ one liner }}
 -- After

--- a/unison-src/transcripts/formatter.md
+++ b/unison-src/transcripts/formatter.md
@@ -24,7 +24,7 @@ x y =
 (<|>) a b = (a, b)
 
 symbolyEndOfBlock =
-  use List +:
+  x = 1
   (+:)
 
 

--- a/unison-src/transcripts/formatter.output.md
+++ b/unison-src/transcripts/formatter.output.md
@@ -15,6 +15,15 @@ x y =
     x + y
 -- Should keep comments after
 
+-- symbolyDefinition
+(<|>) : Nat -> Nat -> (Nat, Nat)
+(<|>) a b = (a, b)
+
+f x y =
+  use List +:
+  (+:)
+
+
 -- Test for a previous regression that added extra brackets.
 oneLiner = {{ one liner }}
 -- After
@@ -93,6 +102,13 @@ x y =
   x = 1 + 1
   x + y
 -- Should keep comments after
+
+-- symbolyDefinition
+(<|>) : Nat -> Nat -> (Nat, Nat)
+a <|> b = (a, b)
+
+f x y = (+:)
+
 
 -- Test for a previous regression that added extra brackets.
 oneLiner = {{ one liner }}

--- a/unison-src/transcripts/formatter.output.md
+++ b/unison-src/transcripts/formatter.output.md
@@ -19,8 +19,8 @@ x y =
 (<|>) : Nat -> Nat -> (Nat, Nat)
 (<|>) a b = (a, b)
 
-f x y =
-  use List +:
+symbolyEndOfBlock =
+  x = 1
   (+:)
 
 
@@ -107,7 +107,9 @@ x y =
 (<|>) : Nat -> Nat -> (Nat, Nat)
 a <|> b = (a, b)
 
-f x y = (+:)
+symbolyEndOfBlock =
+  x = 1
+  (+:)
 
 
 -- Test for a previous regression that added extra brackets.

--- a/unison-syntax/src/Unison/Syntax/Parser.hs
+++ b/unison-syntax/src/Unison/Syntax/Parser.hs
@@ -338,8 +338,16 @@ symbolyDefinitionName = queryToken $ \case
   L.SymbolyId n -> Just $ Name.toVar (HQ'.toName n)
   _ -> Nothing
 
-parenthesize :: (Ord v) => P v m a -> P v m a
-parenthesize p = P.try (openBlockWith "(" *> p) <* closeBlock
+-- | Expect parentheses around a token, includes the parentheses within the start/end
+-- annotations of the resulting token.
+parenthesize :: (Ord v) => P v m (L.Token a) -> P v m (L.Token a)
+parenthesize p = do
+  (start, a) <- P.try do
+    start <- L.start <$> openBlockWith "("
+    a <- p
+    pure (start, a)
+  end <- L.end <$> closeBlock
+  pure (L.Token {payload = L.payload a, start, end})
 
 hqPrefixId, hqInfixId :: (Ord v) => P v m (L.Token (HQ.HashQualified Name))
 hqPrefixId = hqWordyId_ <|> parenthesize hqSymbolyId_


### PR DESCRIPTION

## Overview

Fixes #4682
Fixes #4676

The annotations for operators like `(++)` only span the `++`, so the brackets get duplicated.

Fixed this by just including the span of the parens into the lexer token for symboly names like this.

## Implementation notes

Include the span of the parens in the lexer tokens for symboly names.


## Test coverage

Added cases to the formatter transcript

