### PR TITLE
remove metadata types from the in-memory branches

### DIFF
--- a/codebase2/codebase-sqlite-hashing-v2/src/Unison/Hashing/V2/Convert2.hs
+++ b/codebase2/codebase-sqlite-hashing-v2/src/Unison/Hashing/V2/Convert2.hs
@@ -117,7 +117,6 @@ v2ToH2Branch V2.Branch {terms, types, patches, children} = do
 v2ToH2MdValues :: V2Branch.MdValues -> H2.MdValues
 v2ToH2MdValues (V2Branch.MdValues mdMap) =
   mdMap
-    & Map.keysSet
     & Set.map v2ToH2Reference
     & H2.MdValues
 

--- a/codebase2/codebase/U/Codebase/Branch/Type.hs
+++ b/codebase2/codebase/U/Codebase/Branch/Type.hs
@@ -29,7 +29,7 @@ type MetadataType = Reference
 
 type MetadataValue = Reference
 
-newtype MdValues = MdValues {unMdValues :: Map MetadataValue MetadataType} deriving (Eq, Ord, Show)
+newtype MdValues = MdValues {unMdValues :: Set MetadataValue} deriving (Eq, Ord, Show)
 
 type CausalBranch m = Causal m CausalHash BranchHash (Branch m) (Branch m)
 

--- a/parser-typechecker/src/Unison/Codebase/Metadata.hs
+++ b/parser-typechecker/src/Unison/Codebase/Metadata.hs
@@ -9,15 +9,15 @@ where
 
 import Data.Map qualified as Map
 import Unison.Prelude
-import Unison.Reference (Reference)
+import Unison.Reference (TermReference)
 import Unison.Util.List qualified as List
 import Unison.Util.Relation qualified as R
 import Unison.Util.Star3 (Star3)
 import Unison.Util.Star3 qualified as Star3
 
-type Type = Reference
+type Type = () -- dummy value, intermediate phase of removing metadata altogether
 
-type Value = Reference
+type Value = TermReference
 
 -- `a` is generally the type of references or hashes
 -- `n` is generally the the type of name associated with the references

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Conversions.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Conversions.hs
@@ -440,8 +440,9 @@ causalbranch1to2 (V1.Branch.Branch c) =
                       Map.fromList
                         [ (referent1to2 r, pure md)
                           | r <- toList . Relation.lookupRan ns $ V1.Star3.d1 s,
-                            let mdrefs1to2 (typeR1, valR1) = (reference1to2 valR1, reference1to2 typeR1)
-                                md = V2.Branch.MdValues . Map.fromList . map mdrefs1to2 . toList . Relation.lookupDom r $ V1.Star3.d3 s
+                            -- throwing away the metadata type reference here as we are trying to phase out metadata completely
+                            let mdrefs1to2 (_typeR1, valR1) = reference1to2 valR1
+                                md = V2.Branch.MdValues . Set.map mdrefs1to2 . Relation.lookupDom r $ V1.Star3.d3 s
                         ]
             ]
 
@@ -454,8 +455,9 @@ causalbranch1to2 (V1.Branch.Branch c) =
                       Map.fromList
                         [ (reference1to2 r, pure md)
                           | r <- toList . Relation.lookupRan ns $ V1.Star3.d1 s,
-                            let mdrefs1to2 (typeR1, valR1) = (reference1to2 valR1, reference1to2 typeR1)
-                                md = V2.Branch.MdValues . Map.fromList . map mdrefs1to2 . toList . Relation.lookupDom r $ V1.Star3.d3 s
+                            -- throwing away the metadata type reference here as we are trying to phase out metadata completely
+                            let mdrefs1to2 (_typeR1, valR1) = reference1to2 valR1
+                                md = V2.Branch.MdValues . Set.map mdrefs1to2 . Relation.lookupDom r $ V1.Star3.d3 s
                         ]
             ]
 
@@ -530,9 +532,9 @@ branch2to1 branchCache lookupCT (V2.Branch.Branch v2terms v2types v2patches v2ch
           let facts = Set.singleton ref
               names = Relation.singleton ref name
               types :: Relation.Relation ref V1.Metadata.Type =
-                Relation.insertManyRan ref (fmap mdref2to1 (Map.elems mdvals)) mempty
+                Relation.insertManyRan ref (fmap (const ()) (Set.toList mdvals)) mempty
               vals :: Relation.Relation ref (V1.Metadata.Type, V1.Metadata.Value) =
-                Relation.insertManyRan ref (fmap (\(v, t) -> (mdref2to1 t, mdref2to1 v)) (Map.toList mdvals)) mempty
+                Relation.insertManyRan ref (fmap (\v -> ((), mdref2to1 v)) (Set.toList mdvals)) mempty
            in star <> V1.Star3.Star3 facts names types vals
 
 -- | Generates a v1 short hash from a v2 referent.

--- a/parser-typechecker/tests/Unison/Test/Codebase/Branch.hs
+++ b/parser-typechecker/tests/Unison/Test/Codebase/Branch.hs
@@ -31,7 +31,7 @@ branch0Tests =
           b0 :: Branch0 Identity =
             Branch.branch0
               mempty
-              (Star3.fromList [(dummy, "b", dummy, (dummy, dummy))])
+              (Star3.fromList [(dummy, "b", (), ((), dummy))])
               Map.empty
               Map.empty
       let -- a.b
@@ -39,7 +39,7 @@ branch0Tests =
           b1 :: Branch0 Identity =
             Branch.branch0
               mempty
-              (Star3.fromList [(dummy, "b", dummy, (dummy, dummy))])
+              (Star3.fromList [(dummy, "b", (), ((), dummy))])
               (Map.singleton "a" (Branch (Causal.one b0)))
               Map.empty
 


### PR DESCRIPTION
## Overview

This pretty hackily resolves #4416, where ucm would crash if a codebase included a term with a builtin associated as metadata, because the types of metadata are needed when loading a branch, but the types of builtins were not available when loading a branch, due to current package boundaries.

Since our long-term plan is to remove metadata altogether, with metadata-related commands and output already having been deleted in #4574, #4428, #4333, it seemed like a poor use of time to reorganize the packages to support this situation, and instead this PR removes "metadata type" from in-memory data structures.

Metadata type is not part of the hashing function of namespaces, so this should not affect anything but make the codebase a bit more skeleton-ish and weird.

## Implementation notes

In `Unison.Codebase.Metadata`, we replace
```haskell
type Type = TypeReference
```
with
```haskell
type Type = ()
```

And then fix up the dependent spots.

I just realized it could have been a smaller diff except I also changed `U.Codebase.Branch.Type` from
```haskell
newtype MdValues = MdValues {unMdValues :: Map MetadataValue MetadataType} deriving (Eq, Ord, Show)
```
to
```haskell
newtype MdValues = MdValues {unMdValues :: Set MetadataValue } deriving (Eq, Ord, Show)
```

## Test coverage

Relying on existing tests to make sure no behaviors have changed.