### PR TITLE
[WIP] do Share's hash-validation locally in ucm with `debug.hash-validate`

### DIFF
--- a/lib/unison-hash/src/Unison/Hash32.hs
+++ b/lib/unison-hash/src/Unison/Hash32.hs
@@ -15,6 +15,7 @@ module Unison.Hash32
 
     -- ** Text
     toText,
+    unsafeFromText,
   )
 where
 
@@ -52,6 +53,10 @@ toHash =
 -- | Convert base32hex to a hash32 (asserting that it is a 512-bit hash).
 unsafeFromBase32Hex :: Base32Hex -> Hash32
 unsafeFromBase32Hex =
+  coerce
+
+unsafeFromText :: Text -> Hash32
+unsafeFromText =
   coerce
 
 -- | Convert a hash32 to base32hex.

--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -78,6 +78,7 @@ dependencies:
   - unison-core
   - unison-core1
   - unison-hash
+  - unison-hashing-v2
   - unison-parser-typechecker
   - unison-prelude
   - unison-pretty-printer

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -69,6 +69,7 @@ import Unison.Codebase.Editor.HandleInput.BranchRename (handleBranchRename)
 import Unison.Codebase.Editor.HandleInput.Branches (handleBranches)
 import Unison.Codebase.Editor.HandleInput.DebugDefinition qualified as DebugDefinition
 import Unison.Codebase.Editor.HandleInput.DebugFoldRanges qualified as DebugFoldRanges
+import Unison.Codebase.Editor.HandleInput.DebugHashValidate qualified as DebugHashValidate
 import Unison.Codebase.Editor.HandleInput.DeleteBranch (handleDeleteBranch)
 import Unison.Codebase.Editor.HandleInput.DeleteProject (handleDeleteProject)
 import Unison.Codebase.Editor.HandleInput.EditNamespace (handleEditNamespace)
@@ -135,6 +136,7 @@ import Unison.CommandLine.InputPatterns qualified as InputPatterns
 import Unison.ConstructorReference (GConstructorReference (..))
 import Unison.DataDeclaration qualified as DD
 import Unison.Hash qualified as Hash
+import Unison.Hash32 qualified as Hash32
 import Unison.HashQualified qualified as HQ
 import Unison.HashQualified' qualified as HQ'
 import Unison.HashQualified' qualified as HashQualified
@@ -1150,6 +1152,7 @@ loop e = do
             DebugLSPFoldRangesI -> do
               DebugFoldRanges.debugFoldRanges
             DebugTypeI hqName -> DebugDefinition.debugDecl hqName
+            DebugHashValidateI hash -> DebugHashValidate.debugHashValidate hash
             DebugClearWatchI {} ->
               Cli.runTransaction Codebase.clearWatches
             DebugDoctorI {} -> do
@@ -1368,6 +1371,7 @@ inputDescription input =
         then pure ("debug.term.verbose " <> HQ.toText hqName)
         else pure ("debug.term " <> HQ.toText hqName)
     DebugTypeI hqName -> pure ("debug.type " <> HQ.toText hqName)
+    DebugHashValidateI hash -> pure ("debug.hash-validate " <> Hash32.toText hash)
     DebugLSPFoldRangesI -> pure "debug.lsp.fold-ranges"
     DebugNameDiffI {} -> wat
     DebugNumberedArgsI {} -> wat

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/DebugHashValidate.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/DebugHashValidate.hs
@@ -1,0 +1,13 @@
+module Unison.Codebase.Editor.HandleInput.DebugHashValidate (debugHashValidate) where
+
+import Unison.Cli.Monad (Cli)
+import Unison.Cli.Monad qualified as Cli
+import Unison.Codebase.Editor.Output (Output (HashValidationResult))
+import Unison.Hash32 (Hash32)
+import Unison.Sync.Common (expectEntity)
+import Unison.Sync.EntityValidation qualified as EV
+
+debugHashValidate :: Hash32 -> Cli ()
+debugHashValidate hash = do
+  entity <- Cli.runTransaction $ expectEntity hash
+  Cli.respond . HashValidationResult $ EV.validateEntity hash entity

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/DebugHashValidate.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/DebugHashValidate.hs
@@ -1,13 +1,30 @@
 module Unison.Codebase.Editor.HandleInput.DebugHashValidate (debugHashValidate) where
 
+import Control.Monad.Reader
+import Data.Map qualified as Map
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
-import Unison.Codebase.Editor.Output (Output (HashValidationResult))
+import Unison.Codebase.Type qualified as Codebase
 import Unison.Hash32 (Hash32)
-import Unison.Sync.Common (expectEntity)
-import Unison.Sync.EntityValidation qualified as EV
+import Unison.Hash32 qualified as Hash32
+import Unison.Hashing.V2.Convert (hashTermComponents)
+import Unison.Prelude
+import Unison.Symbol (symbol)
+
+-- debugHashValidate :: Hash32 -> Cli ()
+-- debugHashValidate hash = do
+--   entity <- Cli.runTransaction $ expectEntity hash
+--   Cli.respond . HashValidationResult $ EV.validateEntity hash entity
 
 debugHashValidate :: Hash32 -> Cli ()
 debugHashValidate hash = do
-  entity <- Cli.runTransaction $ expectEntity hash
-  Cli.respond . HashValidationResult $ EV.validateEntity hash entity
+  Cli.Env {codebase} <- ask
+  mayComponent <- Cli.runTransaction $ Codebase.getTermComponentWithTypes codebase (Hash32.toHash hash)
+  case mayComponent of
+    Nothing -> liftIO $ putStrLn "No component found"
+    Just component ->
+      zip (symbol . tShow @Int <$> [1 ..]) component
+        & fmap (\(v, (trm, typ)) -> (v, (trm, typ, ())))
+        & Map.fromList
+        & hashTermComponents
+        & liftIO . print

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/DebugHashValidate.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/DebugHashValidate.hs
@@ -1,30 +1,26 @@
 module Unison.Codebase.Editor.HandleInput.DebugHashValidate (debugHashValidate) where
 
-import Control.Monad.Reader
-import Data.Map qualified as Map
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
-import Unison.Codebase.Type qualified as Codebase
+import Unison.Codebase.Editor.Output (Output (..))
 import Unison.Hash32 (Hash32)
-import Unison.Hash32 qualified as Hash32
-import Unison.Hashing.V2.Convert (hashTermComponents)
-import Unison.Prelude
-import Unison.Symbol (symbol)
-
--- debugHashValidate :: Hash32 -> Cli ()
--- debugHashValidate hash = do
---   entity <- Cli.runTransaction $ expectEntity hash
---   Cli.respond . HashValidationResult $ EV.validateEntity hash entity
+import Unison.Sync.Common qualified as Common
+import Unison.Sync.EntityValidation qualified as EV
 
 debugHashValidate :: Hash32 -> Cli ()
 debugHashValidate hash = do
-  Cli.Env {codebase} <- ask
-  mayComponent <- Cli.runTransaction $ Codebase.getTermComponentWithTypes codebase (Hash32.toHash hash)
-  case mayComponent of
-    Nothing -> liftIO $ putStrLn "No component found"
-    Just component ->
-      zip (symbol . tShow @Int <$> [1 ..]) component
-        & fmap (\(v, (trm, typ)) -> (v, (trm, typ, ())))
-        & Map.fromList
-        & hashTermComponents
-        & liftIO . print
+  entity <- Cli.runTransaction $ Common.expectEntity hash
+  Cli.respond . HashValidationResult $ EV.validateEntity hash entity
+
+-- debugHashValidate :: Hash32 -> Cli ()
+-- debugHashValidate hash = do
+--   Cli.Env {codebase} <- ask
+--   mayComponent <- Cli.runTransaction $ Codebase.getTermComponentWithTypes codebase (Hash32.toHash hash)
+--   case mayComponent of
+--     Nothing -> liftIO $ putStrLn "No component found"
+--     Just component ->
+--       zip (symbol . tShow @Int <$> [1 ..]) component
+--         & fmap (\(v, (trm, typ)) -> (v, (trm, typ, ())))
+--         & Map.fromList
+--         & hashTermComponents
+--         & liftIO . pPrint

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -44,6 +44,7 @@ import Unison.Codebase.ShortCausalHash qualified as SCH
 import Unison.Codebase.SyncMode (SyncMode)
 import Unison.Codebase.Verbosity (Verbosity)
 import Unison.CommandLine.BranchRelativePath (BranchRelativePath, parseBranchRelativePath)
+import Unison.Hash32 (Hash32)
 import Unison.HashQualified qualified as HQ
 import Unison.Name (Name)
 import Unison.NameSegment (NameSegment)
@@ -222,6 +223,7 @@ data Input
   | DebugDumpNamespaceSimpleI
   | DebugTermI (Bool {- Verbose mode -}) (HQ.HashQualified Name)
   | DebugTypeI (HQ.HashQualified Name)
+  | DebugHashValidateI Hash32
   | DebugLSPFoldRangesI
   | DebugClearWatchI
   | DebugDoctorI

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -70,7 +70,7 @@ import Unison.Server.SearchResult' (SearchResult')
 import Unison.Share.Sync.Types qualified as Sync
 import Unison.ShortHash (ShortHash)
 import Unison.Symbol (Symbol)
-import Unison.Sync.Types qualified as Share (DownloadEntitiesError, UploadEntitiesError)
+import Unison.Sync.Types qualified as Share (DownloadEntitiesError, EntityValidationError, UploadEntitiesError)
 import Unison.Syntax.Parser qualified as Parser
 import Unison.Term (Term)
 import Unison.Type (Type)
@@ -327,6 +327,7 @@ data Output
   | DebugFuzzyOptionsNoResolver
   | DebugTerm (Bool {- verbose mode -}) (Either (Text {- A builtin hash -}) (Term Symbol Ann))
   | DebugDecl (Either (Text {- A builtin hash -}) (DD.Decl Symbol Ann)) (Maybe ConstructorId {- If 'Just' we're debugging a constructor of the given decl -})
+  | HashValidationResult (Maybe Share.EntityValidationError)
   | AnnotatedFoldRanges Text
   | ClearScreen
   | PulledEmptyBranch (ReadRemoteNamespace Share.RemoteProjectBranch)
@@ -575,6 +576,7 @@ isFailure o = case o of
   DebugFuzzyOptionsNoResolver {} -> True
   DebugTerm {} -> False
   DebugDecl {} -> False
+  HashValidationResult err -> isJust err
   AnnotatedFoldRanges {} -> False
   DisplayDebugNameDiff {} -> False
   ClearScreen -> False

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -51,6 +51,7 @@ import Unison.CommandLine.Completion
 import Unison.CommandLine.FZFResolvers qualified as Resolvers
 import Unison.CommandLine.InputPattern (ArgumentType (..), InputPattern (InputPattern), IsOptional (..), unionSuggestions)
 import Unison.CommandLine.InputPattern qualified as I
+import Unison.Hash32 qualified as Hash32
 import Unison.HashQualified qualified as HQ
 import Unison.JitInfo qualified as JitInfo
 import Unison.Name (Name)
@@ -2285,6 +2286,19 @@ debugType =
         _ -> Left (I.help debugType)
     )
 
+debugHashValidate :: InputPattern
+debugHashValidate =
+  InputPattern
+    "debug.hash-validate"
+    []
+    I.Hidden
+    [("full hash of a term in your codebase", Required, definitionQueryArg)]
+    "Validate the hash of a definition or namespace"
+    ( \case
+        [thing] -> Right . Input.DebugHashValidateI . Hash32.unsafeFromText . Text.pack $ thing
+        _ -> Left (I.help debugHashValidate)
+    )
+
 debugLSPFoldRanges :: InputPattern
 debugLSPFoldRanges =
   InputPattern
@@ -3017,6 +3031,7 @@ validInputs =
       debugTerm,
       debugTermVerbose,
       debugType,
+      debugHashValidate,
       debugLSPFoldRanges,
       debugFileHashes,
       debugNameDiff,

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1794,6 +1794,10 @@ notifyUser dir = \case
         <> case typ of
           Left builtinTxt -> "Builtin type: ##" <> P.text builtinTxt
           Right decl -> either (P.text . TL.toStrict . pShowNoColor) (P.text . TL.toStrict . pShowNoColor) decl
+  HashValidationResult mayErr ->
+    pure $ case mayErr of
+      Nothing -> "The hash is valid"
+      Just err -> prettyEntityValidationFailure err
   AnnotatedFoldRanges txt -> pure $ P.text txt
   DisplayDebugNameDiff NameChanges {termNameAdds, termNameRemovals, typeNameAdds, typeNameRemovals} -> do
     let referentText =

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -52,6 +52,7 @@ library
       Unison.Codebase.Editor.HandleInput.BranchRename
       Unison.Codebase.Editor.HandleInput.DebugDefinition
       Unison.Codebase.Editor.HandleInput.DebugFoldRanges
+      Unison.Codebase.Editor.HandleInput.DebugHashValidate
       Unison.Codebase.Editor.HandleInput.DeleteBranch
       Unison.Codebase.Editor.HandleInput.DeleteProject
       Unison.Codebase.Editor.HandleInput.EditNamespace

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -238,6 +238,7 @@ library
     , unison-core
     , unison-core1
     , unison-hash
+    , unison-hashing-v2
     , unison-parser-typechecker
     , unison-prelude
     , unison-pretty-printer
@@ -377,6 +378,7 @@ executable cli-integration-tests
     , unison-core
     , unison-core1
     , unison-hash
+    , unison-hashing-v2
     , unison-parser-typechecker
     , unison-prelude
     , unison-pretty-printer
@@ -511,6 +513,7 @@ executable transcripts
     , unison-core
     , unison-core1
     , unison-hash
+    , unison-hashing-v2
     , unison-parser-typechecker
     , unison-prelude
     , unison-pretty-printer
@@ -651,6 +654,7 @@ executable unison
     , unison-core
     , unison-core1
     , unison-hash
+    , unison-hashing-v2
     , unison-parser-typechecker
     , unison-prelude
     , unison-pretty-printer
@@ -794,6 +798,7 @@ test-suite cli-tests
     , unison-core
     , unison-core1
     , unison-hash
+    , unison-hashing-v2
     , unison-parser-typechecker
     , unison-prelude
     , unison-pretty-printer


### PR DESCRIPTION
cc @aryairani, here's a build you can use to hash validate things locally.

Sorry for the inconvenience but right now it's wired up so you need to pass the FULL hash, e.g.

```
.> debug.hash-validate 1c8qbh3hun65i4t9eiuhjvvukg2vcq1hnq80vkpb9g650r1r85hfjlkc9a042t7hr9s2gr3vlheubkbibtofknr1c8l8961a9r4jd1g
```