### PR TITLE
updated third-party-facing Slack to Discord refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Other resources:
 
 * [Learn about the big idea behind Unison](https://www.unison-lang.org/learn/the-big-idea/)
 * Check out [the project website](https://unison-lang.org)
-* Say hello or lurk [in the Slack chat](https://unison-lang.org/slack)
+* Say hello or lurk [in the Discord chat](https://discord.gg/unison)
 * Explore [the Unison ecosystem](https://share.unison-lang.org/)
 * [Learn Unison](https://www.unison-lang.org/learn/)
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Other resources:
 
 * [Learn about the big idea behind Unison](https://www.unison-lang.org/learn/the-big-idea/)
 * Check out [the project website](https://unison-lang.org)
-* Say hello or lurk [in the Discord chat](https://discord.gg/unison)
+* Say hello or lurk [in the Discord chat](https://unison-lang.org/discord)
 * Explore [the Unison ecosystem](https://share.unison-lang.org/)
 * [Learn Unison](https://www.unison-lang.org/learn/)
 

--- a/development.markdown
+++ b/development.markdown
@@ -2,7 +2,7 @@ These are commands that will likely be useful during development.
 
 __General:__ `./scripts/test.sh` compiles and builds the Haskell code and runs all tests. Recommended that you run this before pushing any code to a branch that others might be working on.
 
-_Disclaimer_ If you have trouble getting started, please get in touch via [Slack](https://unison-lang.org/community) so we can help.  If you have any fixes to the process, please send us a PR!
+_Disclaimer_ If you have trouble getting started, please get in touch via [Discord](https://discord.gg/unison) so we can help.  If you have any fixes to the process, please send us a PR!
 
 ## Running Unison
 

--- a/development.markdown
+++ b/development.markdown
@@ -2,7 +2,7 @@ These are commands that will likely be useful during development.
 
 __General:__ `./scripts/test.sh` compiles and builds the Haskell code and runs all tests. Recommended that you run this before pushing any code to a branch that others might be working on.
 
-_Disclaimer_ If you have trouble getting started, please get in touch via [Discord](https://discord.gg/unison) so we can help.  If you have any fixes to the process, please send us a PR!
+_Disclaimer_ If you have trouble getting started, please get in touch via [Discord](https://unison-lang.org/discord) so we can help.  If you have any fixes to the process, please send us a PR!
 
 ## Running Unison
 


### PR DESCRIPTION
## Overview

I noticed the `development.markdown` file mentioned Slack, and it is my understanding that the team has migrated to Discord. Running a search on the codebase, there are a couple more links. One more, `README.md`, I updated. I considered these to be "third-party-facing" links.

* `type-declarations.md` also references [a specific Slack thread](https://unisonlanguage.slack.com/archives/CLKV43YE4/p1565135564409000). I left that alone since there likely isn't any equivalent on the Discord server.
* `release-steps.md`, which I left alone because it seems to be for the internal team and I didn't want to touch that kind of instruction. But it says to "Preview the markdown in Slack #general and tag @paul."

This will close issue #4742 

## Implementation notes

I just updated URLs from Slack to the Discord invite URL for the Unison server.


## Loose ends

Need to decide if and how to update the `type-declarations` and `release-steps` references to Slack.