### PR TITLE
Fix field accessors not showing up in `view` in some cases

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/DeclPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/DeclPrinter.hs
@@ -175,6 +175,9 @@ fieldNames env r name dd = do
     [(_, typ)] -> Just typ
     _ -> Nothing
   let vars :: [v]
+      -- We add `n` to the end of the variable name as a quick fix to #4752, but we suspect there's a more
+      -- fundamental fix to be made somewhere in the term printer to automatically suffix a var name with its
+      -- freshened id if it would be ambiguous otherwise.
       vars = [Var.freshenId (fromIntegral n) (Var.named ("_" <> Text.pack (show n))) | n <- [0 .. Type.arity typ - 1]]
   hashes <- DD.hashFieldAccessors env (HQ.toVar name) vars r dd
   let names =

--- a/parser-typechecker/src/Unison/Syntax/DeclPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/DeclPrinter.hs
@@ -175,7 +175,7 @@ fieldNames env r name dd = do
     [(_, typ)] -> Just typ
     _ -> Nothing
   let vars :: [v]
-      vars = [Var.freshenId (fromIntegral n) (Var.named "_") | n <- [0 .. Type.arity typ - 1]]
+      vars = [Var.freshenId (fromIntegral n) (Var.named ("_" <> Text.pack (show n))) | n <- [0 .. Type.arity typ - 1]]
   hashes <- DD.hashFieldAccessors env (HQ.toVar name) vars r dd
   let names =
         [ (r, HQ.toText . PPE.termName env . Referent.Ref $ DerivedId r)

--- a/unison-src/transcripts/records.md
+++ b/unison-src/transcripts/records.md
@@ -69,6 +69,42 @@ unique type Record4 =
 .> view Record4
 ```
 
+## Record with many many fields
+
+```unison:hide
+unique type Record5 = {
+  zero : Nat,
+  one : [Nat],
+  two : [[Nat]],
+  three: [[[Nat]]],
+  four: [[[[Nat]]]],
+  five: [[[[[Nat]]]]],
+  six: [[[[[[Nat]]]]]],
+  seven: [[[[[[[Nat]]]]]]],
+  eight: [[[[[[[[Nat]]]]]]]],
+  nine: [[[[[[[[[Nat]]]]]]]]],
+  ten: [[[[[[[[[[Nat]]]]]]]]]],
+  eleven: [[[[[[[[[[[Nat]]]]]]]]]]],
+  twelve: [[[[[[[[[[[[Nat]]]]]]]]]]]],
+  thirteen: [[[[[[[[[[[[[Nat]]]]]]]]]]]]],
+  fourteen: [[[[[[[[[[[[[[Nat]]]]]]]]]]]]]],
+  fifteen: [[[[[[[[[[[[[[[Nat]]]]]]]]]]]]]]],
+  sixteen: [[[[[[[[[[[[[[[[Nat]]]]]]]]]]]]]]]],
+  seventeen: [[[[[[[[[[[[[[[[[Nat]]]]]]]]]]]]]]]]],
+  eighteen: [[[[[[[[[[[[[[[[[[Nat]]]]]]]]]]]]]]]]]],
+  nineteen: [[[[[[[[[[[[[[[[[[[Nat]]]]]]]]]]]]]]]]]]],
+  twenty: [[[[[[[[[[[[[[[[[[[[Nat]]]]]]]]]]]]]]]]]]]]
+}
+```
+
+```ucm:hide
+.> add
+```
+
+```ucm
+.> view Record5
+```
+
 ## Record with user-defined type fields
 
 This record type has two fields whose types are user-defined (`Record4` and `UserType`).

--- a/unison-src/transcripts/records.output.md
+++ b/unison-src/transcripts/records.output.md
@@ -63,6 +63,61 @@ unique type Record4 =
         g : [Nat] }
 
 ```
+## Record with many many fields
+
+```unison
+unique type Record5 = {
+  zero : Nat,
+  one : [Nat],
+  two : [[Nat]],
+  three: [[[Nat]]],
+  four: [[[[Nat]]]],
+  five: [[[[[Nat]]]]],
+  six: [[[[[[Nat]]]]]],
+  seven: [[[[[[[Nat]]]]]]],
+  eight: [[[[[[[[Nat]]]]]]]],
+  nine: [[[[[[[[[Nat]]]]]]]]],
+  ten: [[[[[[[[[[Nat]]]]]]]]]],
+  eleven: [[[[[[[[[[[Nat]]]]]]]]]]],
+  twelve: [[[[[[[[[[[[Nat]]]]]]]]]]]],
+  thirteen: [[[[[[[[[[[[[Nat]]]]]]]]]]]]],
+  fourteen: [[[[[[[[[[[[[[Nat]]]]]]]]]]]]]],
+  fifteen: [[[[[[[[[[[[[[[Nat]]]]]]]]]]]]]]],
+  sixteen: [[[[[[[[[[[[[[[[Nat]]]]]]]]]]]]]]]],
+  seventeen: [[[[[[[[[[[[[[[[[Nat]]]]]]]]]]]]]]]]],
+  eighteen: [[[[[[[[[[[[[[[[[[Nat]]]]]]]]]]]]]]]]]],
+  nineteen: [[[[[[[[[[[[[[[[[[[Nat]]]]]]]]]]]]]]]]]]],
+  twenty: [[[[[[[[[[[[[[[[[[[[Nat]]]]]]]]]]]]]]]]]]]]
+}
+```
+
+```ucm
+.> view Record5
+
+  type Record5
+    = { zero : Nat,
+        one : [Nat],
+        two : [[Nat]],
+        three : [[[Nat]]],
+        four : [[[[Nat]]]],
+        five : [[[[[Nat]]]]],
+        six : [[[[[[Nat]]]]]],
+        seven : [[[[[[[Nat]]]]]]],
+        eight : [[[[[[[[Nat]]]]]]]],
+        nine : [[[[[[[[[Nat]]]]]]]]],
+        ten : [[[[[[[[[[Nat]]]]]]]]]],
+        eleven : [[[[[[[[[[[Nat]]]]]]]]]]],
+        twelve : [[[[[[[[[[[[Nat]]]]]]]]]]]],
+        thirteen : [[[[[[[[[[[[[Nat]]]]]]]]]]]]],
+        fourteen : [[[[[[[[[[[[[[Nat]]]]]]]]]]]]]],
+        fifteen : [[[[[[[[[[[[[[[Nat]]]]]]]]]]]]]]],
+        sixteen : [[[[[[[[[[[[[[[[Nat]]]]]]]]]]]]]]]],
+        seventeen : [[[[[[[[[[[[[[[[[Nat]]]]]]]]]]]]]]]]],
+        eighteen : [[[[[[[[[[[[[[[[[[Nat]]]]]]]]]]]]]]]]]],
+        nineteen : [[[[[[[[[[[[[[[[[[[Nat]]]]]]]]]]]]]]]]]]],
+        twenty : [[[[[[[[[[[[[[[[[[[[Nat]]]]]]]]]]]]]]]]]]]] }
+
+```
 ## Record with user-defined type fields
 
 This record type has two fields whose types are user-defined (`Record4` and `UserType`).
@@ -103,7 +158,6 @@ unique type Record5 =
   
     ⍟ These new definitions are ok to `add`:
     
-      type Record5
       Record5.a        : Record5 -> Text
       Record5.a.modify : (Text ->{g} Text)
                          -> Record5
@@ -114,5 +168,10 @@ unique type Record5 =
                          -> Record5
                          ->{g} Record5
       Record5.b.set    : Int -> Record5 -> Record5
+    
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      type Record5
 
 ```


### PR DESCRIPTION
For some types with lots of field accessors, they show up without field accessors when printed with `edit` or `view`, like this:

```haskell
  type Mail
    = Mail
        [Personalization]
        MailAddress
        (Optional MailAddress)
        [MailAddress]
        Text
        [MailContent]
        (Optional [MailAttachment])
        (Optional Text)
        (Optional Json)
        (Optional (Map Text Text))
        (Optional [Text])
        (Optional Json)
        (Optional Instant)
        (Optional Text)
        (Optional Asm)
        (Optional Text)
        (Optional MailSettings)
        (Optional TrackingSettings)
```

This is caused by `hashFieldAccessors` returning `Nothing` for the first `.set` accessor. This is in turn caused by a type error in `Typechecker.synthesize` for that accessor. The note from the typechecker is:

```
The 2nd argument to `Mail.Mail`

          has type:  lib.base.Optional lib.base.time.Instant
    but I expected:  MailAddress
```

The term that's being typechecked looks like this:

```haskell
(λ (User "_18". (λ (User "mail". (case Var User "mail" of [MatchCase {matchPattern = Constructor ReferenceDerived (Id "9mq7l0pr6foeuis6jujpo7hqcbsm5120lhu2nf70tccdtpuosmdfhr81foq9okme97b8kgd2h7k14pceu0nv9r2qjll416fiu5t06cg" 0) 0 [Unbound,Var,Var,Var,Var,Var,Var,Var,Var,Var,Var,Var,Var,Var,Var,Var,Var,Var], matchGuard = Nothing, matchBody = (User "_"-1. (User "_"-2. (User "_"-3. (User "_"-4. (User "_"-5. (User "_"-6. (User "_"-7. (User "_"-8. (User "_"-9. (User "_"-10. (User "_"-11. (User "_"-12. (User "_"-13. (User "_"-14. (User "_"-15. (User "_"-16. (User "_"-17. ConReferenceDerived (Id "9mq7l0pr6foeuis6jujpo7hqcbsm5120lhu2nf70tccdtpuosmdfhr81foq9okme97b8kgd2h7k14pceu0nv9r2qjll416fiu5t06cg" 0)#0 (Var User "_18") (Var User "_"-1) (Var User "_"-2) (Var User "_"-3) (Var User "_"-4) (Var User "_"-5) (Var User "_"-6) (Var User "_"-7) (Var User "_"-8) (Var User "_"-9) (Var User "_"-10) (Var User "_"-11) (Var User "_"-12) (Var User "_"-13) (Var User "_"-14) (Var User "_"-15) (Var User "_"-16) (Var User "_"-17))))))))))))))))))}])))))
```

This fix adds an ordinal to the variable names of the fields, so `freshen` should in most cases be a no-op.

After this fix the type above is rendered as:

```haskell
  type Mail
    = { personalizations : [Personalization],
        from : MailAddress,
        replyTo : Optional MailAddress,
        replyToList : [MailAddress],
        subject : Text,
        content : [MailContent],
        attachments : Optional [MailAttachment],
        templateId : Optional Text,
        sections : Optional Json,
        headers : Optional (Map Text Text),
        categories : Optional [Text],
        customArgs : Optional Json,
        sendAt : Optional Instant,
        batchId : Optional Text,
        asm : Optional Asm,
        ipPoolName : Optional Text,
        mailSettings : Optional MailSettings,
        trackingSettings : Optional TrackingSettings }
```