### PR TITLE
Push type checking through match statements

### DIFF
--- a/unison-src/transcripts/fix4722.md
+++ b/unison-src/transcripts/fix4722.md
@@ -1,0 +1,40 @@
+
+Tests an improvement to type checking related to abilities.
+
+`foo` below typechecks fine as long as all the branches are _checked_
+against their expected type. However, it's annoying to have to
+annotate them. The old code was checking a match by just synthesizing
+and subtyping, but we can instead check a match by pushing the
+expected type into each case, allowing top-level annotations to act
+like annotations on each case.
+
+```ucm:hide
+.> builtins.merge
+```
+
+```unison
+ability X a where yield : {X a} ()
+ability Y where y : ()
+
+type Foo b a = One a
+type Bar a
+  = Leaf a
+  | Branch (Bar a) (Bar a)
+
+f : (a -> ()) -> '{g, X a} () -> '{g, X a} () -> '{g, X a} ()
+f _ x y = y
+
+abra : a -> '{Y, X z} r
+abra = bug ""
+
+cadabra : (y -> z) -> '{g, X y} r -> '{g, X z} r
+cadabra = bug ""
+
+foo : Bar (Optional b) -> '{Y, X (Foo z ('{Y} r))} ()
+foo = cases
+  Leaf a -> match a with
+    None -> abra a
+    Some _ -> cadabra One (abra a)
+  Branch l r ->
+    f (_ -> ()) (foo l) (foo r)
+```

--- a/unison-src/transcripts/fix4722.output.md
+++ b/unison-src/transcripts/fix4722.output.md
@@ -1,0 +1,60 @@
+
+Tests an improvement to type checking related to abilities.
+
+`foo` below typechecks fine as long as all the branches are _checked_
+against their expected type. However, it's annoying to have to
+annotate them. The old code was checking a match by just synthesizing
+and subtyping, but we can instead check a match by pushing the
+expected type into each case, allowing top-level annotations to act
+like annotations on each case.
+
+```unison
+ability X a where yield : {X a} ()
+ability Y where y : ()
+
+type Foo b a = One a
+type Bar a
+  = Leaf a
+  | Branch (Bar a) (Bar a)
+
+f : (a -> ()) -> '{g, X a} () -> '{g, X a} () -> '{g, X a} ()
+f _ x y = y
+
+abra : a -> '{Y, X z} r
+abra = bug ""
+
+cadabra : (y -> z) -> '{g, X y} r -> '{g, X z} r
+cadabra = bug ""
+
+foo : Bar (Optional b) -> '{Y, X (Foo z ('{Y} r))} ()
+foo = cases
+  Leaf a -> match a with
+    None -> abra a
+    Some _ -> cadabra One (abra a)
+  Branch l r ->
+    f (_ -> ()) (foo l) (foo r)
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      type Bar a
+      type Foo b a
+      ability X a
+      ability Y
+      abra    : a -> '{Y, X z} r
+      cadabra : (y ->{h} z) -> '{g, X y} r -> '{g, X z} r
+      f       : (a ->{h} ())
+                -> '{g, X a} ()
+                -> '{g, X a} ()
+                -> '{g, X a} ()
+      foo     : Bar (Optional b) -> '{Y, X (Foo z ('{Y} r))} ()
+
+```

--- a/unison-src/transcripts/fix693.output.md
+++ b/unison-src/transcripts/fix693.output.md
@@ -46,14 +46,16 @@ h0 req = match req with
 
   Loading changes detected in scratch.u.
 
-  I found a value  of type:  Optional a1
-  where I expected to find:  Optional a
+  Each case of a match / with expression need to have the same
+  type.
   
-      1 | h0 : Request {X t} b -> Optional b
-      2 | h0 req = match req with
+  Here, one   is:  Optional b
+  and another is:  Optional a
+  
+  
       3 |   { X.x _ c -> _ } -> handle c with h0
   
-    from right here:
+    from these spots, respectively:
   
       1 | h0 : Request {X t} b -> Optional b
   
@@ -75,14 +77,13 @@ h1 req = match req with
   Each case of a match / with expression need to have the same
   type.
   
-  Here, one   is:  Optional t
-  and another is:  Optional b
+  Here, one   is:  Optional b
+  and another is:  Optional t
   
   
       3 |   { X.x t _ -> _ } -> handle t with h1
-      4 |   { d } -> Some d
   
-    from right here:
+    from these spots, respectively:
   
       1 | h1 : Request {X t} b -> Optional b
   


### PR DESCRIPTION
This PR changes the way type checking works slightly. Previously, checking a `match` or similar would just use the default strategy of inferring and subtyping. Instead, it now will check each case against the expected type of the whole match block. This eliminates some situations where the inference would generate a type that could not be successfully subtyped against the expected type.

Fixes #4722