### PR TITLE
fix condition on ormolu manual workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
 
 env:
-  ormolu_version: "0.5.0.1"
+  ormolu_version: "0.5.2.0"
   racket_version: "8.7"
   ucm_local_bin: "ucm-local-bin"
   jit_version: "@unison/internal/releases/0.0.11"

--- a/.github/workflows/ormolu.yaml
+++ b/.github/workflows/ormolu.yaml
@@ -1,3 +1,6 @@
+# This workflow runs ormolu on all Haskell files in the branch and creates a PR with the result.
+# (The ormolu job in CI.yaml only runs ormolu on Haskell files that have changed in that PR.)
+
 name: ormolu everything
 
 on:
@@ -19,6 +22,6 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           commit_message: automatically run ormolu
-          branch: format/${{github.ref_name}}
-          branch_suffix: random
+          branch: autoformat/${{github.ref_name}}
+          # branch_suffix: random
           title: format `${{github.ref_name}}` with ormolu ${{env.ormolu_version}}

--- a/.github/workflows/ormolu.yaml
+++ b/.github/workflows/ormolu.yaml
@@ -19,8 +19,11 @@ jobs:
         with:
           version: ${{ env.ormolu_version }}
           mode: inplace
-      - name: apply formatting changes
+      - name: create pull request with formatting changes
         uses: peter-evans/create-pull-request@v6
         with:
-          commit_message: automatically run ormolu
-          branch_suffix: random
+          commit_message: ormolu
+          branch: formatting/${{github.ref}}
+          branch_suffix: short-commit-hash
+          title: autoformat ${{github.ref}}
+          body: ''

--- a/.github/workflows/ormolu.yaml
+++ b/.github/workflows/ormolu.yaml
@@ -25,8 +25,6 @@ jobs:
           mode: inplace
       - name: apply formatting changes
         uses: peter-evans/create-pull-request@v6
-        # the previous step will "fail" if it makes any formatting changes
-        if: ${{ failure() }}
         with:
           commit_message: automatically run ormolu
           branch_suffix: random

--- a/.github/workflows/ormolu.yaml
+++ b/.github/workflows/ormolu.yaml
@@ -1,8 +1,4 @@
-name: ormolu
-
-defaults:
-  run:
-    shell: bash
+name: ormolu everything
 
 on:
   workflow_dispatch:
@@ -25,4 +21,4 @@ jobs:
           commit_message: automatically run ormolu
           branch: format/${{github.ref_name}}
           branch_suffix: random
-          title: autoformat ${{github.ref_name}}
+          title: format `${{github.ref_name}}` with ormolu ${{env.ormolu_version}}

--- a/.github/workflows/ormolu.yaml
+++ b/.github/workflows/ormolu.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  ormolu_version: "0.5.0.1"
+  ormolu_version: "0.5.2.0"
 
 jobs:
   ormolu:

--- a/.github/workflows/ormolu.yaml
+++ b/.github/workflows/ormolu.yaml
@@ -13,10 +13,6 @@ env:
 jobs:
   ormolu:
     runs-on: ubuntu-20.04
-    # Only run formatting on trunk commits
-    # This is because the job won't have permission to push back to
-    # contributor forks on contributor PRs.
-    if: github.ref_name == 'trunk'
     steps:
       - uses: actions/checkout@v4
       - uses: haskell-actions/run-ormolu@v15

--- a/.github/workflows/ormolu.yaml
+++ b/.github/workflows/ormolu.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: create pull request with formatting changes
         uses: peter-evans/create-pull-request@v6
         with:
-          commit_message: ormolu
-          branch: formatting/${{github.ref}}
-          branch_suffix: short-commit-hash
-          title: autoformat ${{github.ref}}
+          commit_message: automatically run ormolu
+          branch: format/${{github.ref_name}}
+          branch_suffix: random
+          title: autoformat ${{github.ref_name}}

--- a/.github/workflows/ormolu.yaml
+++ b/.github/workflows/ormolu.yaml
@@ -26,4 +26,3 @@ jobs:
           branch: formatting/${{github.ref}}
           branch_suffix: short-commit-hash
           title: autoformat ${{github.ref}}
-          body: ''


### PR DESCRIPTION
Also updates the ormolu version from 0.5.0.1 to 0.5.2.0, and tweaks the details of the PR creation to be better.

Overview: This (updated) workflow will autoformat all the Haskell files in the repo and creates a PR with the result. (In contrast to the newly re-enabled ormolu step in the CI workflow, which for performance reasons only autoformats the Haskell files that have changed in the corresponding PR, and then typically creates a new commit with the result.) This workflow can also be used on `trunk`, which is protected, because it creates a separate PR, though I could imagine updating CI.yaml to create a separate PR with updates for `trunk` where applicable.

An example of the PR it will create is https://github.com/unisonweb/unison/pull/4784, and we could merge that after this; its merge target is this branch but I didn't want to merge the diffs.

Controversial decisions:
I went back and forth between having subsequent runs of the workflow create new PRs or amend an existing PR if one exists, and ultimately chose the latter. Probably it doesn't matter, and we can always switch it if we turn out to dislike the behavior.

@ChrisPenner I'm confused about it, but I guess everything I said about the failure condition in https://github.com/unisonweb/unison/pull/4776#issuecomment-1989430770 in response to your comment on the first PR was wrong?