### PR TITLE
Minor JIT fixes

### DIFF
--- a/scheme-libs/racket/unison/arithmetic.rkt
+++ b/scheme-libs/racket/unison/arithmetic.rkt
@@ -11,6 +11,7 @@
       Float.*
       Float.fromRepresentation
       Float.toRepresentation
+      Float.ceiling
       Int.+
       Int.-
       Int./
@@ -41,6 +42,9 @@
   (define-unison (Float.* x y) (fl* x y))
 
   (define-unison (Nat.toFloat n) (->fl n))
+
+  (define-unison (Float.ceiling f)
+    (clamp-integer (fl->exact-integer (ceiling f))))
 
   ; If someone can suggest a better mechanism for these,
   ; that would be appreciated.

--- a/scheme-libs/racket/unison/core.ss
+++ b/scheme-libs/racket/unison/core.ss
@@ -266,6 +266,18 @@
     [(< l r) '<]
     [else '>]))
 
+(define (compare-char a b)
+  (cond
+    [(char=? a b) '=]
+    [(char<? a b) '<]
+    [else '>]))
+
+(define (compare-byte a b)
+  (cond
+    [(= a b) '=]
+    [(< a b) '<]
+    [else '>]))
+
 (define (universal-compare l r)
   (cond
     [(equal? l r) '=]
@@ -274,9 +286,9 @@
     [(and (boolean? l) (boolean? r)) (if r '< '>)]
     [(and (chunked-list? l) (chunked-list? r)) (chunked-list-compare/recur l r universal-compare)]
     [(and (chunked-string? l) (chunked-string? r))
-     (chunked-string-compare/recur l r (lambda (a b) (if (char<? a b) '< '>)))]
+     (chunked-string-compare/recur l r compare-char)]
     [(and (chunked-bytes? l) (chunked-bytes? r))
-     (chunked-bytes-compare/recur l r (lambda (a b) (if (< a b) '< '>)))]
+     (chunked-bytes-compare/recur l r compare-byte)]
     [(and (bytes? l) (bytes? r))
      (cond
        [(bytes=? l r) '=]

--- a/scheme-libs/racket/unison/primops.ss
+++ b/scheme-libs/racket/unison/primops.ss
@@ -40,6 +40,8 @@
     builtin-Float.fromRepresentation:termlink
     builtin-Float.toRepresentation
     builtin-Float.toRepresentation:termlink
+    builtin-Float.ceiling
+    builtin-Float.ceiling:termlink
     builtin-Float.exp
     builtin-Float.exp:termlink
     builtin-Float.log
@@ -155,6 +157,9 @@
     builtin-Universal.compare
     builtin-Universal.compare:termlink
     builtin-Universal.murmurHash:termlink
+
+    builtin-unsafe.coerceAbilities
+    builtin-unsafe.coerceAbilities:termlink
 
     builtin-List.splitLeft
     builtin-List.splitLeft:termlink
@@ -633,6 +638,7 @@
   (define-builtin-link Float.*)
   (define-builtin-link Float.fromRepresentation)
   (define-builtin-link Float.toRepresentation)
+  (define-builtin-link Float.ceiling)
   (define-builtin-link Float.exp)
   (define-builtin-link Float.log)
   (define-builtin-link Float.max)
@@ -733,6 +739,7 @@
   (define-builtin-link Pattern.isMatch)
   (define-builtin-link Char.Class.is)
   (define-builtin-link Scope.bytearrayOf)
+  (define-builtin-link unsafe.coerceAbilities)
 
   (begin-encourage-inline
     (define-unison (builtin-Value.toBuiltin v) (unison-quote v))
@@ -851,6 +858,8 @@
 
     (define-unison (builtin-Pattern.isMatch p s)
       (pattern-match? p s))
+
+    (define-unison (builtin-unsafe.coerceAbilities f) f)
 
     (define (unison-POp-UPKB bs)
       (build-chunked-list
@@ -1337,10 +1346,12 @@
     (define (unison-FOp-Promise.read promise) (promise-read promise))
     (define (unison-FOp-Promise.tryRead promise) (promise-try-read promise))
     (define (unison-FOp-Promise.write promise a) (promise-write promise a)))
+
   
   (declare-builtin-link builtin-Float.*)
   (declare-builtin-link builtin-Float.fromRepresentation)
   (declare-builtin-link builtin-Float.toRepresentation)
+  (declare-builtin-link builtin-Float.ceiling)
   (declare-builtin-link builtin-Float.exp)
   (declare-builtin-link builtin-Float.log)
   (declare-builtin-link builtin-Float.max)
@@ -1439,4 +1450,5 @@
   (declare-builtin-link builtin-Pattern.isMatch)
   (declare-builtin-link builtin-Scope.bytearrayOf)
   (declare-builtin-link builtin-Char.Class.is)
+  (declare-builtin-link builtin-unsafe.coerceAbilities)
   )


### PR DESCRIPTION
This fixes a couple problems that was causing nimbus to not build on the JIT.

- Universal comparison was broken for strings and bytes, causing some duplicate builtin references to be generated
- `Float.ceiling` and `unsafe.coerceAbilities` builtins were missing

With these changes, `nodeMain` _builds_. No guarantees about running.