### PR TITLE
Better error messages for generic parser failures

### DIFF
--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -16,6 +16,7 @@ where
 
 import Control.Lens ((%~))
 import Control.Lens.Tuple (_1, _2, _3)
+import Data.Foldable qualified as Foldable
 import Data.Function (on)
 import Data.List (find, intersperse, sortBy)
 import Data.List.Extra (nubOrd)
@@ -1498,19 +1499,42 @@ renderParseErrors s = \case
               "",
               style ErrorSite msg
             ]
-  P.TrivialError errOffset unexpected expected ->
-    let (src, ranges) = case unexpected of
-          Just (P.Tokens (toList -> ts)) -> case ts of
-            [] -> (mempty, [])
-            _ ->
-              let rs = rangeForToken <$> ts
-               in (showSource s $ (\r -> (r, ErrorSite)) <$> rs, rs)
-          _ -> mempty
-        -- Same error that we just pattern matched on, but with a different error component (here Void) - we need one
-        -- with a ShowErrorComponent instance, which our error type doesn't have.
-        sameErr :: P.ParseError Parser.Input Void
-        sameErr = P.TrivialError errOffset unexpected expected
-     in [(fromString (P.parseErrorPretty sameErr) <> src, ranges)]
+  P.TrivialError _errOffset unexpected expected ->
+    let unexpectedTokens :: Maybe (Nel.NonEmpty (L.Token L.Lexeme))
+        unexpectedTokenStrs :: Set String
+        (unexpectedTokens, unexpectedTokenStrs) = case unexpected of
+          Just (P.Tokens ts) ->
+            Foldable.toList ts
+              & fmap (L.displayLexeme . L.payload)
+              & Set.fromList
+              & (Just ts,)
+          Just (P.Label ts) -> (mempty, Set.singleton $ Foldable.toList ts)
+          Just (P.EndOfInput) -> (mempty, Set.singleton "end of input")
+          Nothing -> (mempty, mempty)
+        expectedTokenStrs :: Set String
+        expectedTokenStrs =
+          expected & foldMap \case
+            (P.Tokens ts) ->
+              Foldable.toList ts
+                & fmap (L.displayLexeme . L.payload)
+                & Set.fromList
+            (P.Label ts) -> Set.singleton $ Foldable.toList ts
+            (P.EndOfInput) -> Set.singleton "end of input"
+        ranges = case unexpectedTokens of
+          Nothing -> []
+          Just ts -> rangeForToken <$> Foldable.toList ts
+        excerpt = showSource s ((\r -> (r, ErrorSite)) <$> ranges)
+        msg = L.formatTrivialError _ unexpectedTokenStrs expectedTokenStrs
+     in [ ( Pr.lines
+              [ "I got confused here:",
+                "",
+                excerpt,
+                "",
+                style ErrorSite msg
+              ],
+            ranges
+          )
+        ]
   P.FancyError _sp fancyErrors ->
     (go' <$> Set.toList fancyErrors)
   where

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -1524,7 +1524,7 @@ renderParseErrors s = \case
           Nothing -> []
           Just ts -> rangeForToken <$> Foldable.toList ts
         excerpt = showSource s ((\r -> (r, ErrorSite)) <$> ranges)
-        msg = L.formatTrivialError _ unexpectedTokenStrs expectedTokenStrs
+        msg = L.formatTrivialError unexpectedTokenStrs expectedTokenStrs
      in [ ( Pr.lines
               [ "I got confused here:",
                 "",

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -1490,7 +1490,14 @@ renderParseErrors s = \case
               "",
               excerpt
             ]
-        L.Opaque msg -> style ErrorSite msg
+        L.UnexpectedTokens msg ->
+          Pr.lines
+            [ "I got confused here:",
+              "",
+              excerpt,
+              "",
+              style ErrorSite msg
+            ]
   P.TrivialError errOffset unexpected expected ->
     let (src, ranges) = case unexpected of
           Just (P.Tokens (toList -> ts)) -> case ts of

--- a/unison-src/transcripts/error-messages.output.md
+++ b/unison-src/transcripts/error-messages.output.md
@@ -210,10 +210,16 @@ foo = match 1 with
 
   Loading changes detected in scratch.u.
 
-  offset=8:
-  unexpected <outdent>
-  expecting ",", case match, or pattern guard
+  I got confused here:
+  
       3 | 
+  
+  I was surprised to find an end of section here.
+  I was hoping for one of these instead:
+  
+  * ","
+  * case match
+  * pattern guard
 
 ```
 ```unison
@@ -250,10 +256,19 @@ x = match Some a with
 
   Loading changes detected in scratch.u.
 
-  offset=16:
-  unexpected <outdent>
-  expecting ",", blank, case match, false, pattern guard, or true
+  I got confused here:
+  
       7 | 
+  
+  I was surprised to find an end of section here.
+  I was hoping for one of these instead:
+  
+  * ","
+  * blank
+  * case match
+  * false
+  * pattern guard
+  * true
 
 ```
 ```unison
@@ -268,11 +283,15 @@ x = match Some a with
 
   Loading changes detected in scratch.u.
 
-  offset=12:
-  unexpected ->
-  expecting newline or semicolon
+  I got confused here:
+  
       4 |            -> 2
   
+  
+  I was surprised to find a -> here.
+  I was hoping for one of these instead:
+  
+  * newline or semicolon
 
 ```
 ```unison
@@ -286,11 +305,15 @@ x = match Some a with
 
   Loading changes detected in scratch.u.
 
-  offset=12:
-  unexpected |
-  expecting newline or semicolon
+  I got confused here:
+  
       4 |         | true -> 2
   
+  
+  I was surprised to find a '|' here.
+  I was hoping for one of these instead:
+  
+  * newline or semicolon
 
 ```
 ### Watches

--- a/unison-src/transcripts/error-messages.output.md
+++ b/unison-src/transcripts/error-messages.output.md
@@ -215,7 +215,7 @@ foo = match 1 with
       3 | 
   
   I was surprised to find an end of section here.
-  I was hoping for one of these instead:
+  I was expecting one of these instead:
   
   * ","
   * case match
@@ -261,7 +261,7 @@ x = match Some a with
       7 | 
   
   I was surprised to find an end of section here.
-  I was hoping for one of these instead:
+  I was expecting one of these instead:
   
   * ","
   * blank
@@ -289,7 +289,7 @@ x = match Some a with
   
   
   I was surprised to find a -> here.
-  I was hoping for one of these instead:
+  I was expecting one of these instead:
   
   * newline or semicolon
 
@@ -311,7 +311,7 @@ x = match Some a with
   
   
   I was surprised to find a '|' here.
-  I was hoping for one of these instead:
+  I was expecting one of these instead:
   
   * newline or semicolon
 

--- a/unison-src/transcripts/generic-parse-errors.md
+++ b/unison-src/transcripts/generic-parse-errors.md
@@ -1,0 +1,26 @@
+Just a bunch of random parse errors to test the error formatting.
+
+```unison:error
+x = 
+  foo.123
+```
+
+```unison:error
+namespace.blah = 1
+```
+
+```unison:error
+x = 1 ]
+```
+
+```unison:error
+x = a.#abc
+```
+
+```unison:error
+x = "hi
+```
+
+```unison:error
+y : a 
+```

--- a/unison-src/transcripts/generic-parse-errors.output.md
+++ b/unison-src/transcripts/generic-parse-errors.output.md
@@ -1,0 +1,107 @@
+Just a bunch of random parse errors to test the error formatting.
+
+```unison
+x = 
+  foo.123
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I got confused here:
+  
+      2 |   foo.123
+  
+  
+  I was surprised to find a 1 here.
+  I was hoping for one of these instead:
+  
+  * end of input
+  * hash (ex: #af3sj3)
+  * identifier (ex: abba1, snake_case, .foo.bar#xyz, .foo.++#xyz, or 🌻)
+
+```
+```unison
+namespace.blah = 1
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  The identifier used here isn't allowed to be a reserved keyword: 
+  
+      1 | namespace.blah = 1
+  
+
+```
+```unison
+x = 1 ]
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found a closing ']' here without a matching '['.
+  
+      1 | x = 1 ]
+  
+
+```
+```unison
+x = a.#abc
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I got confused here:
+  
+      1 | x = a.#abc
+  
+  
+  I was surprised to find a '.' here.
+
+```
+```unison
+x = "hi
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I got confused here:
+  
+      2 | 
+  
+  I was surprised to find an end of input here.
+  I was hoping for one of these instead:
+  
+  * "
+  * \s
+  * literal character
+
+```
+```unison
+y : a 
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I got confused here:
+  
+      2 | 
+  
+  I was surprised to find an end of section here.
+  I was hoping for one of these instead:
+  
+  * ->
+  * newline or semicolon
+
+```

--- a/unison-src/transcripts/generic-parse-errors.output.md
+++ b/unison-src/transcripts/generic-parse-errors.output.md
@@ -15,7 +15,7 @@ x =
   
   
   I was surprised to find a 1 here.
-  I was hoping for one of these instead:
+  I was expecting one of these instead:
   
   * end of input
   * hash (ex: #af3sj3)
@@ -79,7 +79,7 @@ x = "hi
       2 | 
   
   I was surprised to find an end of input here.
-  I was hoping for one of these instead:
+  I was expecting one of these instead:
   
   * "
   * \s
@@ -99,7 +99,7 @@ y : a
       2 | 
   
   I was surprised to find an end of section here.
-  I was hoping for one of these instead:
+  I was expecting one of these instead:
   
   * ->
   * newline or semicolon

--- a/unison-syntax/src/Unison/Syntax/NameSegment.hs
+++ b/unison-syntax/src/Unison/Syntax/NameSegment.hs
@@ -152,7 +152,7 @@ wordyP = do
         end <- posP
         P.customFailure (Token word start end)
 
-    wordyMsg = "identifier (ex: abba1, snake_case, .foo.bar#xyz, or 🌻)"
+    wordyMsg = "identifier (ex: abba1, snake_case, .foo.bar#xyz, .foo.++#xyz, or 🌻)"
 
 escapeP :: ParsecT (Token Text) [Char] m a -> ParsecT (Token Text) [Char] m a
 escapeP parser =


### PR DESCRIPTION
## Overview

I'll let the errors speak for themselves:

**Old**

<img width="957" alt="image" src="https://github.com/unisonweb/unison/assets/6439644/3535e39d-a8d4-45c6-a8cc-bb6343c71292">


**New**

<img width="590" alt="image" src="https://github.com/unisonweb/unison/assets/6439644/0a70e7f4-b490-45cd-b4bb-df5d514d4e21">


**Old**

<img width="498" alt="image" src="https://github.com/unisonweb/unison/assets/6439644/13712f2e-6f27-4c1f-9a18-77365f54f010">


**New**

<img width="510" alt="image" src="https://github.com/unisonweb/unison/assets/6439644/5a06fe4a-a001-4abd-8ebe-d55a9c2f93fd">




## Implementation notes

Render the source of the error, catch and re-format the generic parser errors.

## Test coverage

Transcripts
