### PR TITLE
Fix many pattern not backtracking

### DIFF
--- a/parser-typechecker/src/Unison/Util/Text/Pattern.hs
+++ b/parser-typechecker/src/Unison/Util/Text/Pattern.hs
@@ -157,7 +157,7 @@ compile (Many p) !_ !success = case p of
   Char cp -> walker (charPatternPred cp)
   p -> go
     where
-      go = compile p success success'
+      go = try "Many" (compile p) success success'
       success' acc rem
         | Text.size rem == 0 = success acc rem
         | otherwise = go acc rem

--- a/unison-src/transcripts/patterns.md
+++ b/unison-src/transcripts/patterns.md
@@ -1,0 +1,11 @@
+```ucm:hide
+.> builtins.merge
+```
+
+Some tests of pattern behavior.
+
+```unison
+p1 = join [literal "blue", literal "frog"]
+
+> Pattern.run (many p1) "bluefrogbluegoat" 
+```

--- a/unison-src/transcripts/patterns.output.md
+++ b/unison-src/transcripts/patterns.output.md
@@ -1,0 +1,28 @@
+Some tests of pattern behavior.
+
+```unison
+p1 = join [literal "blue", literal "frog"]
+
+> Pattern.run (many p1) "bluefrogbluegoat" 
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      p1 : Pattern Text
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    3 | > Pattern.run (many p1) "bluefrogbluegoat" 
+          ⧩
+          Some ([], "bluegoat")
+
+```


### PR DESCRIPTION
Turns out, `Pattern.many` had the same non-backtracking problem as the functions in #3540. This applies the same fix.

This change actually breaks the http library (which was accidentally relying on the erroneous behavior), so it shouldn't be merged yet. I'll let @ceedubs decide when it should be.