### PR TITLE
Fix auto-completion's treatment of paths

### DIFF
--- a/unison-cli/src/Unison/LSP/Completion.hs
+++ b/unison-cli/src/Unison/LSP/Completion.hs
@@ -57,15 +57,16 @@ completionHandler m respond =
     (range, prefix) <- VFS.completionPrefix (m ^. params . textDocument . uri) (m ^. params . position)
     ppe <- PPED.suffixifiedPPE <$> lift currentPPED
     codebaseCompletions <- lift getCodebaseCompletions
-    Config {maxCompletions} <- lift getConfig
+    -- Config {maxCompletions} <- lift getConfig
     let defMatches = matchCompletions codebaseCompletions prefix
     let (isIncomplete, defCompletions) =
           defMatches
             & nubOrdOn (\(p, _name, ref) -> (p, ref))
             & fmap (over _1 Path.toText)
-            & case maxCompletions of
-              Nothing -> (False,)
-              Just n -> takeCompletions n
+            & (False,)
+    -- case maxCompletions of
+    -- Nothing -> (False,)
+    -- Just n -> takeCompletions n
     let defCompletionItems =
           defCompletions
             & mapMaybe \(path, fqn, dep) ->
@@ -75,12 +76,13 @@ completionHandler m respond =
     let itemDefaults = Nothing
     pure . CompletionList isIncomplete itemDefaults $ defCompletionItems
   where
-    -- Takes at most the specified number of completions, but also indicates with a boolean
-    -- whether there were more completions remaining so we can pass that along to the client.
-    takeCompletions :: Int -> [a] -> (Bool, [a])
-    takeCompletions 0 xs = (not $ null xs, [])
-    takeCompletions _ [] = (False, [])
-    takeCompletions n (x : xs) = second (x :) $ takeCompletions (pred n) xs
+
+-- Takes at most the specified number of completions, but also indicates with a boolean
+-- whether there were more completions remaining so we can pass that along to the client.
+-- takeCompletions :: Int -> [a] -> (Bool, [a])
+-- takeCompletions 0 xs = (not $ null xs, [])
+-- takeCompletions _ [] = (False, [])
+-- takeCompletions n (x : xs) = second (x :) $ takeCompletions (pred n) xs
 
 mkDefCompletionItem :: Uri -> Range -> Name -> Name -> Text -> Text -> LabeledDependency -> CompletionItem
 mkDefCompletionItem fileUri range relativeName fullyQualifiedName path suffixified dep =

--- a/unison-cli/src/Unison/LSP/VFS.hs
+++ b/unison-cli/src/Unison/LSP/VFS.hs
@@ -84,7 +84,10 @@ identifierSplitAtPosition uri pos = do
   pure (Text.takeWhileEnd isIdentifierChar before, Text.takeWhile isIdentifierChar after)
   where
     isIdentifierChar c =
-      Lexer.wordyIdChar c || Lexer.symbolyIdChar c
+      -- Manually exclude '!' and apostrophe, since those are usually just forces and
+      -- delays, which shouldn't be replaced by auto-complete.
+      (c /= '!' && c /= '\'')
+        && (c == '.' || Lexer.wordyIdChar c || Lexer.symbolyIdChar c)
 
 -- | Returns the prefix of the symbol at the provided location, and the range that prefix
 -- spans.


### PR DESCRIPTION
## Overview

Looks like the removal of `.` as a valid symbol character had the unintended effect of causing auto-complete to only complete based on the final segment.

Closes #4789 

## Implementation notes

* Include `.` in the symbols used to detect the currently auto-completing identifier
* Exclude `'` and `!` from the identifier, it messes up completion for things like `!printLine`.

## Test coverage

Just tested it out with some debug commands
