### PR TITLE
Disable hoogle in haskell-nix shell

### DIFF
--- a/nix/haskell-nix-flake.nix
+++ b/nix/haskell-nix-flake.nix
@@ -65,7 +65,7 @@ let
       };
       local = shellFor {
         packages = hpkgs: (map (p: hpkgs."${p}") localPackageNames);
-        withHoogle = true;
+        withHoogle = false;
       };
     } // localPackageDevShells;
 in


### PR DESCRIPTION
This takes a while to build and @tstat said that they aren't using it. Not sure if anyone else is?
