### PR TITLE
Prefer `do` instead of `'` in pretty-printer

### DIFF
--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -311,7 +311,7 @@ pretty0
             let hang = if soft then PP.softHang else PP.hang
             px <- pretty0 (ac 0 Block im' doc) x
             -- this makes sure we get proper indentation if `px` spills onto
-            -- multiple lines, since `do` introduces layout block 
+            -- multiple lines, since `do` introduces layout block
             let indent = PP.Width (if soft then 2 else 0) + (if soft && p < 3 then 1 else 0)
             pure . paren (p >= 3) $
               fmt S.ControlKeyword "do" `hang` PP.lines (uses <> [PP.indentNAfterNewline indent px])

--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -307,7 +307,7 @@ pretty0
               fmt S.ControlKeyword "do" `hang` px
         | otherwise -> do
             let (im0', uses0) = calcImports im x
-            let allowUses = isLet x || p < 0 
+            let allowUses = isLet x || p < 0
             let im' = if allowUses then im0' else im
             let uses = if allowUses then uses0 else []
             let soft = isSoftHangable x && null uses && p < 3

--- a/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
+++ b/parser-typechecker/src/Unison/Syntax/TermPrinter.hs
@@ -306,7 +306,10 @@ pretty0
             pure . paren (p >= 3) $
               fmt S.ControlKeyword "do" `hang` px
         | otherwise -> do
-            let (im', uses) = calcImports im x
+            let (im0', uses0) = calcImports im x
+            let allowUses = isLet x || p < 0 
+            let im' = if allowUses then im0' else im
+            let uses = if allowUses then uses0 else []
             let soft = isSoftHangable x && null uses && p < 3
             let hang = if soft then PP.softHang else PP.hang
             px <- pretty0 (ac 0 Block im' doc) x

--- a/unison-src/transcripts-round-trip/main.output.md
+++ b/unison-src/transcripts-round-trip/main.output.md
@@ -79,17 +79,15 @@ Abort.toOptional : '{g, Abort} a -> '{g} Optional a
 Abort.toOptional thunk = do toOptional! thunk
 
 Abort.toOptional! : '{g, Abort} a ->{g} Optional a
-Abort.toOptional! thunk = toDefault! None '(Some !thunk)
+Abort.toOptional! thunk = toDefault! None do Some !thunk
 
 catchAll : x -> Nat
 catchAll x = 99
 
 Decode.remainder : '{Ask (Optional Bytes)} Bytes
-Decode.remainder = do
-  use Bytes ++
-  match ask with
-    None   -> Bytes.empty
-    Some b -> b ++ !Decode.remainder
+Decode.remainder = do match ask with
+  None   -> Bytes.empty
+  Some b -> b Bytes.++ !Decode.remainder
 
 ex1 : Nat
 ex1 =
@@ -232,9 +230,10 @@ fix_3110c : ()
 fix_3110c = fix_3110a [1, 2, 3] (x -> ignore (Nat.increment x))
 
 fix_3110d : ()
-fix_3110d = fix_3110a [1, 2, 3] '(x -> do
+fix_3110d = fix_3110a [1, 2, 3] do
+  x -> do
     y = Nat.increment x
-    ())
+    ()
 
 fix_3627 : Nat -> Nat -> Nat
 fix_3627 = cases
@@ -293,15 +292,15 @@ fix_4352 : Doc2
 fix_4352 = {{ `` +1 `` }}
 
 fix_4384 : Doc2
-fix_4384 = {{ {{ docExampleBlock 0 '2 }} }}
+fix_4384 = {{ {{ docExampleBlock 0 do 2 }} }}
 
 fix_4384a : Doc2
 fix_4384a =
   use Nat +
-  {{ {{ docExampleBlock 0 '(1 + 1) }} }}
+  {{ {{ docExampleBlock 0 do 1 + 1 }} }}
 
 fix_4384b : Doc2
-fix_4384b = {{ {{ docExampleBlock 0 '99 }} }}
+fix_4384b = {{ {{ docExampleBlock 0 do 99 }} }}
 
 fix_4384c : Doc2
 fix_4384c =
@@ -317,25 +316,8 @@ fix_4384d : Doc2
 fix_4384d =
   {{
   {{
-  docExampleBlock 0 '[ 1
-    , 2
-    , 3
-    , 4
-    , 5
-    , 6
-    , 7
-    , 8
-    , 9
-    , 10
-    , 11
-    , 12
-    , 13
-    , 14
-    , 15
-    , 16
-    , 17
-    , 18
-    ] }}
+  docExampleBlock 0 do
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18] }}
   }}
 
 fix_4384e : Doc2
@@ -407,8 +389,9 @@ longlines1 =
 longlines2 : (Text, '{g} Bytes)
 longlines2 =
   ( "adsf"
-  , '(toUtf8
-        "adsfsfdgsfdgsdfgsdfgsfdgsfdgsdgsgsgfsfgsgsfdgsgfsfdgsgfsfdgsdgsdfgsgf")
+  , do
+      toUtf8
+        "adsfsfdgsfdgsdfgsdfgsfdgsfdgsdgsgsgfsfgsgsfdgsgfsfdgsgfsfdgsdgsdfgsgf"
   )
 
 longlines_helper : x -> 'x
@@ -640,7 +623,7 @@ stew_issue =
   toText a = a
   Debug : a -> b -> ()
   Debug a b = ()
-  error (Debug None '(Debug "Failed " 42))
+  error (Debug None do Debug "Failed " 42)
 
 stew_issue2 : ()
 stew_issue2 =
@@ -649,7 +632,7 @@ stew_issue2 =
   toText a = a
   Debug : a -> b -> ()
   Debug a b = ()
-  error (Debug None '("Failed " ++ toText 42))
+  error (Debug None do "Failed " ++ toText 42)
 
 stew_issue3 : ()
 stew_issue3 =
@@ -661,8 +644,8 @@ stew_issue3 =
   configPath = 0
   Debug a b = ()
   error
-    (Debug None '("Failed to get timestamp of config file "
-        ++ toText configPath))
+    (Debug None do
+      "Failed to get timestamp of config file " ++ toText configPath)
 
 test3 : '('('r))
 test3 = do
@@ -671,7 +654,7 @@ test3 = do
   runrun = 42
   a = "asldkfj"
   b = "asdflkjasdf"
-  ''(run runrun ''runrun)
+  do do run runrun do do runrun
 
 use_clauses_example : Int -> Text -> Nat
 use_clauses_example oo quaffle =
@@ -689,9 +672,8 @@ UUID.random = do UUID 0 (0, 0)
 
 UUID.randomUUIDBytes : 'Bytes
 UUID.randomUUIDBytes = do
-  use Bytes ++
   (UUID a (b, _)) = !random
-  encodeNat64be a ++ encodeNat64be b
+  encodeNat64be a Bytes.++ encodeNat64be b
 
 (|>) : a -> (a ->{e} b) ->{e} b
 a |> f = f a

--- a/unison-src/transcripts-using-base/doc.output.md
+++ b/unison-src/transcripts-using-base/doc.output.md
@@ -331,14 +331,14 @@ and the rendered output using `display`:
          You can include typechecked code snippets inline, for
          instance:
          
-         * {{ docExample 2 '(f x -> f x + sqr 1) }} - the `2`
+         * {{ docExample 2 do f x -> f x + sqr 1 }} - the `2`
            says to ignore the first two arguments when
            rendering. In richer renderers, the `sqr` link will
            be clickable.
          * If your snippet expression is just a single function
            application, you can put it in double backticks, like
            so: ``sqr x``. This is equivalent to
-           {{ docExample 1 '(x -> sqr x) }}.
+           {{ docExample 1 do x -> sqr x }}.
     }}
 
 .> display includingSource

--- a/unison-src/transcripts/bug-strange-closure.output.md
+++ b/unison-src/transcripts/bug-strange-closure.output.md
@@ -2682,8 +2682,8 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                                                   (Term.Term
                                                     (Any
                                                       (do
-                                                        use Nat +
-                                                        1 + 1)))))
+                                                        1
+                                                          Nat.+ 1)))))
                                           , Lit
                                               ()
                                               (Right (Plain "."))
@@ -3097,10 +3097,7 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                                         [ Term.Term
                                             (Any (do sqr))
                                         , Term.Term
-                                            (Any
-                                              (do
-                                                use Nat +
-                                                (+)))
+                                            (Any (do (Nat.+)))
                                         ])))))
                           , Lit () (Right (Plain "\n"))
                           , Lit () (Right (Plain "\n"))
@@ -3280,13 +3277,12 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                                                               (Term.Term
                                                                 (Any
                                                                   (do
-                                                                    use Nat +
                                                                     f
                                                                     x ->
                                                                       f
                                                                         x
-                                                                        + sqr
-                                                                            1)))))
+                                                                        Nat.+ sqr
+                                                                                1)))))
                                                       , Lit
                                                           ()
                                                           (Right

--- a/unison-src/transcripts/bug-strange-closure.output.md
+++ b/unison-src/transcripts/bug-strange-closure.output.md
@@ -1250,7 +1250,8 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                                                     (Right
                                                       (Term.Term
                                                         (Any
-                                                          'Some)))))
+                                                          (do
+                                                            Some))))))
                                             , Lit
                                                 ()
                                                 (Right
@@ -1569,7 +1570,7 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                                           (SpecialForm.Link
                                             (Right
                                               (Term.Term
-                                                (Any 'lists)))))
+                                                (Any (do lists))))))
                                     ])))
                           ]))))
               , Lit () (Right (Plain "\n"))
@@ -2680,8 +2681,9 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                                                 (EvalInline
                                                   (Term.Term
                                                     (Any
-                                                      '(1
-                                                          Nat.+ 1)))))
+                                                      (do
+                                                        use Nat +
+                                                        1 + 1)))))
                                           , Lit
                                               ()
                                               (Right (Plain "."))
@@ -2937,7 +2939,7 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                                           )
                                         , ( Right
                                               (Term.Term
-                                                (Any 'sqr))
+                                                (Any (do sqr)))
                                           , []
                                           )
                                         ])))))
@@ -2996,7 +2998,7 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                                           )
                                         , ( Right
                                               (Term.Term
-                                                (Any 'sqr))
+                                                (Any (do sqr)))
                                           , []
                                           )
                                         ])))))
@@ -3045,7 +3047,8 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                                               (Left
                                                 (SignatureInline
                                                   (Term.Term
-                                                    (Any 'sqr))))
+                                                    (Any
+                                                      (do sqr)))))
                                           , Lit
                                               ()
                                               (Right (Plain ","))
@@ -3091,9 +3094,13 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                                     ()
                                     (Left
                                       (SpecialForm.Signature
-                                        [ Term.Term (Any 'sqr)
+                                        [ Term.Term
+                                            (Any (do sqr))
                                         , Term.Term
-                                            (Any '(Nat.+))
+                                            (Any
+                                              (do
+                                                use Nat +
+                                                (+)))
                                         ])))))
                           , Lit () (Right (Plain "\n"))
                           , Lit () (Right (Plain "\n"))
@@ -3129,7 +3136,7 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                                     (Left
                                       (SpecialForm.Signature
                                         [ Term.Term
-                                            (Any 'List.map)
+                                            (Any (do List.map))
                                         ])))))
                           , Lit () (Right (Plain "\n"))
                           , Lit () (Right (Plain "\n"))
@@ -3272,12 +3279,14 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                                                               2
                                                               (Term.Term
                                                                 (Any
-                                                                  '(f
+                                                                  (do
+                                                                    use Nat +
+                                                                    f
                                                                     x ->
                                                                       f
                                                                         x
-                                                                        Nat.+ sqr
-                                                                                1)))))
+                                                                        + sqr
+                                                                            1)))))
                                                       , Lit
                                                           ()
                                                           (Right
@@ -3547,7 +3556,8 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                                                                     1
                                                                     (Term.Term
                                                                       (Any
-                                                                        '(x ->
+                                                                        (do
+                                                                          x ->
                                                                             sqr
                                                                               x)))))
                                                             , Lit
@@ -3589,7 +3599,8 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                                                                     1
                                                                     (Term.Term
                                                                       (Any
-                                                                        '(x ->
+                                                                        (do
+                                                                          x ->
                                                                             sqr
                                                                               x)))))
                                                             , Lit
@@ -3953,15 +3964,16 @@ rendered = Pretty.get (docFormatConsole doc.guide)
                                   (Left
                                     (SpecialForm.Signature
                                       [ Term.Term
-                                          (Any 'docAside)
+                                          (Any (do docAside))
                                       , Term.Term
-                                          (Any 'docCallout)
+                                          (Any (do docCallout))
                                       , Term.Term
-                                          (Any 'docBlockquote)
+                                          (Any
+                                            (do docBlockquote))
                                       , Term.Term
-                                          (Any 'docTooltip)
+                                          (Any (do docTooltip))
                                       , Term.Term
-                                          (Any 'docTable)
+                                          (Any (do docTable))
                                       ]))))
                           , Lit () (Right (Plain "\n"))
                           , Lit () (Right (Plain "\n"))


### PR DESCRIPTION
Before: 

```
fork somewhere '(1 + 1)
```

After: 

```
fork somewhere do 1 + 1
``` 

That is, we would previously avoid using `do blah` unless `blah` was a block rather than a single expression. This PR changes it to use `do` everywhere. It will add parens around the `do` if needed, as in `foo (do 1 + 1) bar`.

This is generally how I write code, it looks nicer to elide the parens in places where that's possible (and it allows more soft-hanging). You can always use `(do 1 + 1)` anywhere you were tempted to do `'(1 + 1)` previously.

This small change gets exercised pretty well by the existing transcripts and round-trip tests, but I'd like @stew or @ceedubs to try it out on nimbus codebase. 

Maybe we put this behind a command line flag to start, so people can experiment with it? It's also easy to back out if we want, it was a small change.