### PR TITLE
move `stack` install to composite action

### DIFF
--- a/.github/workflows/actions/install-stack/action.yaml
+++ b/.github/workflows/actions/install-stack/action.yaml
@@ -1,0 +1,41 @@
+# Reference:
+# https://docs.github.com/en/actions/creating-actions/creating-a-composite-action
+
+name: "Install Stack"
+
+inputs:
+  stack-version:
+    description: "The version of stack to install, e.g. 2.9.1"
+    required: true
+    default: "2.9.1"
+
+runs:
+  using: "composite"
+  steps:
+    - name: install stack
+      shell: bash
+      working-directory: ${{ runner.temp }}
+      run: |
+        if [[ ${{runner.os}} = 'Windows' ]]; then
+          stack_os="windows"
+        elif [[ ${{runner.os}} = 'macOS' ]]; then
+          stack_os="osx"
+        elif [[ ${{runner.os}} = 'Linux' ]]; then
+          stack_os="linux"
+        else
+          echo "Unsupported OS: ${{runner.os}}"
+          exit 1
+        fi
+        if [[ ${{runner.arch}} = 'X64' ]]; then
+          stack_arch="x86_64"
+        elif [[ ${{runner.arch}} = 'ARM64' ]]; then
+          stack_arch="aarch64"
+        else
+          echo "Unsupported architecture: ${{runner.arch}}"
+          exit 1
+        fi
+
+        mkdir stack && cd stack
+        curl -L https://github.com/commercialhaskell/stack/releases/download/v${{inputs.stack-version}}/stack-${{inputs.stack-version}}-${stack_os}-${stack_arch}.tar.gz | tar -xz
+        echo "$PWD/stack-"* >> $GITHUB_PATH
+        echo "stack_path=$PWD/stack-"* >> $GITHUB_ENV

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -168,37 +168,9 @@ jobs:
             stack-work-${{env.stack-work-cache-key-version}}_${{matrix.os}}-${{env.resolver}}-
             stack-work-${{env.stack-work-cache-key-version}}_${{matrix.os}}-
 
-      # Install stack by downloading the binary from GitHub.
-      # The installation process differs by OS.
-      - name: install stack (Linux)
-        if: runner.os == 'Linux' && steps.cache-ucm-binaries.outputs.cache-hit != 'true'
-        working-directory: ${{ runner.temp }}
-        run: |
-          mkdir stack && cd stack
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.9.1/stack-2.9.1-linux-x86_64.tar.gz | tar -xz
-          echo "$PWD/stack-"* >> $GITHUB_PATH
-
-      - name: install stack (macOS)
-        if: runner.os == 'macOS' && steps.cache-ucm-binaries.outputs.cache-hit != 'true'
-        working-directory: ${{ runner.temp }}
-        run: |
-          mkdir stack && cd stack
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.9.1/stack-2.9.1-osx-x86_64.tar.gz | tar -xz
-          echo "$PWD/stack-"* >> $GITHUB_PATH
-
-      - name: install stack (windows)
-        if: runner.os == 'Windows' && steps.cache-ucm-binaries.outputs.cache-hit != 'true'
-        working-directory: ${{ runner.temp }}
-        run: |
-          mkdir stack && cd stack
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.9.1/stack-2.9.1-windows-x86_64.tar.gz | tar -xz
-          echo "$PWD/stack-"* >> $GITHUB_PATH
-          # temporarily print what's in the cached system stack dir
-          echo "C:/Users/runneradmin/AppData/Roaming/stack:"
-          ls C:/Users/runneradmin/AppData/Roaming/stack
-          echo ""
-          echo "C:/Users/runneradmin/AppData/Local/Programs/stack:"
-          ls C:/Users/runneradmin/AppData/Local/Programs/stack
+      - name: install stack
+        if: steps.cache-ucm-binaries.outputs.cache-hit != 'true'
+        uses: ./.github/workflows/actions/install-stack
 
       # One of the transcripts fails if the user's git name hasn't been set.
       - name: set git user info

--- a/.github/workflows/haddocks.yaml
+++ b/.github/workflows/haddocks.yaml
@@ -58,12 +58,8 @@ jobs:
             stack-work-2_Linux-haddocks
             stack-work-2_Linux
 
-      - name: install stack (Linux)
-        working-directory: ${{ github.workspace }}
-        run: |
-          mkdir stack && cd stack
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.9.1/stack-2.9.1-linux-x86_64.tar.gz | tar -xz
-          echo "$PWD/stack-"* >> $GITHUB_PATH
+      - name: install stack
+        uses: ./.github/workflows/actions/install-stack
 
       # One of the transcripts fails if the user's git name hasn't been set.
       - name: set git user info

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -19,12 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: install stack (Linux)
-        working-directory: ${{ github.workspace }}
-        run: |
-          mkdir stack && cd stack
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.9.1/stack-2.9.1-linux-x86_64.tar.gz | tar -xz
-          echo "$PWD/stack-"* >> $GITHUB_PATH
+      - name: install stack
+        uses: ./.github/workflows/actions/install-stack
 
       # One of the transcripts fails if the user's git name hasn't been set.
       - name: set git user info
@@ -57,12 +53,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: install stack (macOS)
-        working-directory: ${{ github.workspace }}
-        run: |
-          mkdir stack && cd stack
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.9.1/stack-2.9.1-osx-x86_64.tar.gz | tar -xz
-          echo "$PWD/stack-"* >> $GITHUB_PATH
+
+      - name: install stack
+        uses: ./.github/workflows/actions/install-stack
 
       # One of the transcripts fails if the user's git name hasn't been set.
       - name: set git user info
@@ -99,13 +92,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: install stack (windows)
-        working-directory: ${{ github.workspace }}
-        if: runner.os == 'Windows'
-        run: |
-          mkdir stack && cd stack
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.9.1/stack-2.9.1-windows-x86_64.tar.gz | tar -xz
-          echo "$PWD/stack-"* >> $GITHUB_PATH
+      - name: install stack
+        uses: ./.github/workflows/actions/install-stack
 
       - name: build
         # Run up to 5 times in a row before giving up.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -96,12 +96,8 @@ jobs:
           key: stack-work-3_ubuntu-20.04-${{github.sha}}
           restore-keys: stack-work-3_ubuntu-20.04
 
-      - name: install stack (Linux)
-        working-directory: ${{ github.workspace }}
-        run: |
-          mkdir stack && cd stack
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.9.1/stack-2.9.1-linux-x86_64.tar.gz | tar -xz
-          echo "$PWD/stack-"* >> $GITHUB_PATH
+      - name: install stack
+        uses: ./.github/workflows/actions/install-stack
 
       - name: build
         run: |
@@ -166,12 +162,8 @@ jobs:
           key: stack-work-3_macOS-12-${{github.sha}}
           restore-keys: stack-work-3_macOS-12
 
-      - name: install stack (macOS)
-        working-directory: ${{ github.workspace }}
-        run: |
-          mkdir stack && cd stack
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.9.1/stack-2.9.1-osx-x86_64.tar.gz | tar -xz
-          echo "$PWD/stack-"* >> $GITHUB_PATH
+      - name: install stack
+        uses: ./.github/workflows/actions/install-stack
 
       - name: remove ~/.stack/setup-exe-cache on macOS
         run: rm -rf ~/.stack/setup-exe-cache
@@ -239,12 +231,8 @@ jobs:
           key: stack-work-3_windows-2019-${{github.sha}}
           restore-keys: stack-work-3_windows-2019
 
-      - name: install stack (windows)
-        working-directory: ${{ github.workspace }}
-        run: |
-          mkdir stack && cd stack
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.9.1/stack-2.9.1-windows-x86_64.tar.gz | tar -xz
-          echo "$PWD/stack-"* >> $GITHUB_PATH
+      - name: install stack
+        uses: ./.github/workflows/actions/install-stack
 
       - name: build
         run: |

--- a/.github/workflows/update-transcripts.yaml
+++ b/.github/workflows/update-transcripts.yaml
@@ -60,15 +60,8 @@ jobs:
             stack-work-4_${{matrix.os}}-${{ steps.stackage-resolver.outputs.resolver_short }}.
             stack-work-4_${{matrix.os}}-
 
-      # Install stack by downloading the binary from GitHub.
-      # The installation process differs by OS.
-      - name: install stack (Linux)
-        if: runner.os == 'Linux'
-        working-directory: ${{ runner.temp }}
-        run: |
-          mkdir stack && cd stack
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.9.1/stack-2.9.1-linux-x86_64.tar.gz | tar -xz
-          echo "$PWD/stack-"* >> $GITHUB_PATH
+      - name: install stack
+        uses: ./.github/workflows/actions/install-stack
 
       # One of the transcripts fails if the user's git name hasn't been set.
       - name: set git user info


### PR DESCRIPTION
This PR factors out `stack` install code into a separate YAML file, which I'm thinking it might be nice to do in a few places.

Thing I debated:
[In an earlier draft](https://github.com/unisonweb/unison/pull/4715/files), I had factored out the `~/.stack` and `**/.stack-work` caching code into the same composite action that does the installs, but then I worried that it wouldn't be reusable enough that way. I'm still not sure.