### PR TITLE
build test and bench dependencies with "build dependencies"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -228,7 +228,7 @@ jobs:
           fi
 
           for (( i = 0; i < $tries; i++ )); do
-              stack build --fast --only-dependencies && break;
+              stack build --fast --only-dependencies --test --bench && break;
           done
 
       - name: build


### PR DESCRIPTION
I noticed that some dependencies were getting built after the "build dependencies" stage, and they are probably test and benchmark depdencies.