### PR TITLE
split off ormolu task

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,8 +72,6 @@ jobs:
   build-ucm:
     name: Build UCM ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    if: always()
-    needs: ormolu
     strategy:
       # Run each build to completion, regardless of if any have failed
       fail-fast: false


### PR DESCRIPTION
This just lets the rest of the CI builds proceed while ormolu runs in parallel instead of waiting.

The ormolu job may still trigger another commit, but that can happen in parallel.
The jobs don't share a filesystem, so the rest of the CI jobs aren't waiting for updated formatting from the ormolu job.

Thanks @ChrisPenner for catching this.

Controversial decisions:
I removed the `always()` condition, which had been added to ensure that we tried to validate the code even if it was misformatted. Now I don't think it's adding anything