### PR TITLE
bugfix: tweak name priority for tdnr

### DIFF
--- a/parser-typechecker/src/Unison/DataDeclaration/Dependencies.hs
+++ b/parser-typechecker/src/Unison/DataDeclaration/Dependencies.hs
@@ -95,9 +95,9 @@ hashFieldAccessors ppe declName vars declRef dd = do
   let typecheckingEnv :: Typechecker.Env v ()
       typecheckingEnv =
         Typechecker.Env
-          { Typechecker._ambientAbilities = mempty,
-            Typechecker._typeLookup = typeLookup,
-            Typechecker._termsByShortname = mempty
+          { ambientAbilities = mempty,
+            typeLookup,
+            termsByShortname = mempty
           }
   accessorsWithTypes :: [(v, Term.Term v (), Type.Type v ())] <-
     for accessors \(v, _a, trm) ->

--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -85,15 +85,15 @@ computeTypecheckingEnvironment shouldUseTndr ambientAbilities typeLookupf uf =
       tl <- typeLookupf (UF.dependencies uf)
       pure
         Typechecker.Env
-          { _ambientAbilities = ambientAbilities,
-            _typeLookup = tl,
-            _termsByShortname = Map.empty
+          { ambientAbilities = ambientAbilities,
+            typeLookup = tl,
+            termsByShortname = Map.empty
           }
     ShouldUseTndr'Yes parsingEnv -> do
       let preexistingNames = Parser.names parsingEnv
           tm = UF.typecheckingTerm uf
           possibleDeps =
-            [ (Name.toText name, Var.name v, r)
+            [ (name, Var.name v, r)
               | (name, r) <- Rel.toList (Names.terms preexistingNames),
                 v <- Set.toList (Term.freeVars tm),
                 name `Name.endsWithReverseSegments` List.NonEmpty.toList (Name.reverseSegments (Name.unsafeParseVar v))
@@ -115,7 +115,7 @@ computeTypecheckingEnvironment shouldUseTndr ambientAbilities typeLookupf uf =
               [ (shortname, nr)
                 | (name, shortname, r) <- possibleDeps,
                   typ <- toList $ TL.typeOfReferent tl r,
-                  let nr = Typechecker.NamedReference name typ (Right r)
+                  let nr = Typechecker.NamedReference (Name.toText name) typ (Context.ReplacementRef r)
               ]
                 <>
                 -- local file TDNR possibilities
@@ -124,13 +124,13 @@ computeTypecheckingEnvironment shouldUseTndr ambientAbilities typeLookupf uf =
                     v <- Set.toList (Term.freeVars tm),
                     name `Name.endsWithReverseSegments` List.NonEmpty.toList (Name.reverseSegments (Name.unsafeParseVar v)),
                     typ <- toList $ TL.typeOfReferent tl r,
-                    let nr = Typechecker.NamedReference (Name.toText name) typ (Right r)
+                    let nr = Typechecker.NamedReference (Name.toText name) typ (Context.ReplacementRef r)
                 ]
       pure
         Typechecker.Env
-          { _ambientAbilities = ambientAbilities,
-            _typeLookup = tl,
-            _termsByShortname = fqnsByShortName
+          { ambientAbilities = ambientAbilities,
+            typeLookup = tl,
+            termsByShortname = fqnsByShortName
           }
 
 synthesizeFile ::

--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -93,10 +93,11 @@ computeTypecheckingEnvironment shouldUseTndr ambientAbilities typeLookupf uf =
       let preexistingNames = Parser.names parsingEnv
           tm = UF.typecheckingTerm uf
           possibleDeps =
-            [ (name, Var.name v, r)
+            [ (name, shortname, r)
               | (name, r) <- Rel.toList (Names.terms preexistingNames),
                 v <- Set.toList (Term.freeVars tm),
-                name `Name.endsWithReverseSegments` List.NonEmpty.toList (Name.reverseSegments (Name.unsafeParseVar v))
+                let shortname = Name.unsafeParseVar v,
+                name `Name.endsWithReverseSegments` List.NonEmpty.toList (Name.reverseSegments shortname)
             ]
           possibleRefs = Referent.toReference . view _3 <$> possibleDeps
       tl <- fmap (UF.declsToTypeLookup uf <>) (typeLookupf (UF.dependencies uf <> Set.fromList possibleRefs))
@@ -119,10 +120,11 @@ computeTypecheckingEnvironment shouldUseTndr ambientAbilities typeLookupf uf =
               ]
                 <>
                 -- local file TDNR possibilities
-                [ (Var.name v, nr)
+                [ (shortname, nr)
                   | (name, r) <- Rel.toList (Names.terms $ UF.toNames uf),
                     v <- Set.toList (Term.freeVars tm),
-                    name `Name.endsWithReverseSegments` List.NonEmpty.toList (Name.reverseSegments (Name.unsafeParseVar v)),
+                    let shortname = Name.unsafeParseVar v,
+                    name `Name.endsWithReverseSegments` List.NonEmpty.toList (Name.reverseSegments shortname),
                     typ <- toList $ TL.typeOfReferent tl r,
                     let nr = Typechecker.NamedReference name typ (Context.ReplacementRef r)
                 ]

--- a/parser-typechecker/src/Unison/FileParsers.hs
+++ b/parser-typechecker/src/Unison/FileParsers.hs
@@ -26,7 +26,7 @@ import Unison.Reference (Reference)
 import Unison.Referent qualified as Referent
 import Unison.Result (CompilerBug (..), Note (..), ResultT, pattern Result)
 import Unison.Result qualified as Result
-import Unison.Syntax.Name qualified as Name (toText, unsafeParseVar)
+import Unison.Syntax.Name qualified as Name (unsafeParseVar)
 import Unison.Syntax.Parser qualified as Parser
 import Unison.Term qualified as Term
 import Unison.Type qualified as Type
@@ -115,7 +115,7 @@ computeTypecheckingEnvironment shouldUseTndr ambientAbilities typeLookupf uf =
               [ (shortname, nr)
                 | (name, shortname, r) <- possibleDeps,
                   typ <- toList $ TL.typeOfReferent tl r,
-                  let nr = Typechecker.NamedReference (Name.toText name) typ (Context.ReplacementRef r)
+                  let nr = Typechecker.NamedReference name typ (Context.ReplacementRef r)
               ]
                 <>
                 -- local file TDNR possibilities
@@ -124,7 +124,7 @@ computeTypecheckingEnvironment shouldUseTndr ambientAbilities typeLookupf uf =
                     v <- Set.toList (Term.freeVars tm),
                     name `Name.endsWithReverseSegments` List.NonEmpty.toList (Name.reverseSegments (Name.unsafeParseVar v)),
                     typ <- toList $ TL.typeOfReferent tl r,
-                    let nr = Typechecker.NamedReference (Name.toText name) typ (Context.ReplacementRef r)
+                    let nr = Typechecker.NamedReference name typ (Context.ReplacementRef r)
                 ]
       pure
         Typechecker.Env

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -48,7 +48,7 @@ import Unison.Prelude
 import Unison.PrettyPrintEnv qualified as PPE
 import Unison.PrettyPrintEnv.Names qualified as PPE
 import Unison.Reference qualified as R
-import Unison.Referent (Referent, toReference, pattern Ref)
+import Unison.Referent (Referent, pattern Ref)
 import Unison.Result (Note (..))
 import Unison.Result qualified as Result
 import Unison.Settings qualified as Settings
@@ -1195,7 +1195,7 @@ renderSuggestion env sug =
   where
     term =
       case C.suggestionReplacement sug of
-        C.ReplacementRef ref -> Term.ref () (toReference ref)
+        C.ReplacementRef ref -> Term.fromReferent () ref
         C.ReplacementVar v -> Term.var () v
 
 spaces :: (IsString a, Monoid a) => (b -> a) -> [b] -> a

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -626,12 +626,7 @@ renderTypeError e env src = case e of
           foldr
             sep
             id
-            ( sortBy
-                ( comparing length <> compare
-                    `on` (Text.splitOn "." . C.suggestionName)
-                )
-                suggestions
-            )
+            (sortBy (comparing length <> compare `on` (Name.segments . C.suggestionName)) suggestions)
             ([], [], [])
         sep s@(C.Suggestion _ _ _ match) r =
           case match of

--- a/parser-typechecker/src/Unison/PrintError.hs
+++ b/parser-typechecker/src/Unison/PrintError.hs
@@ -1187,19 +1187,16 @@ renderType env f t = renderType0 env f (0 :: Int) (cleanup t)
       where
         go = renderType0 env f
 
-renderSuggestion ::
-  (IsString s, Semigroup s, Var v) => Env -> C.Suggestion v loc -> s
+renderSuggestion :: (IsString s, Semigroup s, Var v) => Env -> C.Suggestion v loc -> s
 renderSuggestion env sug =
-  renderTerm
-    env
-    ( case C.suggestionReplacement sug of
-        Right ref -> Term.ref () (toReference ref)
-        Left v -> Term.var () v
-    )
+  renderTerm env term
     <> " : "
-    <> renderType'
-      env
-      (C.suggestionType sug)
+    <> renderType' env (C.suggestionType sug)
+  where
+    term =
+      case C.suggestionReplacement sug of
+        C.ReplacementRef ref -> Term.ref () (toReference ref)
+        C.ReplacementVar v -> Term.var () v
 
 spaces :: (IsString a, Monoid a) => (b -> a) -> [b] -> a
 spaces = intercalateMap " "

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -104,6 +104,7 @@ import Unison.Typechecker.TypeLookup qualified as TL
 import Unison.Typechecker.TypeVar qualified as TypeVar
 import Unison.Var (Var)
 import Unison.Var qualified as Var
+import Unison.Name (Name)
 
 type TypeVar v loc = TypeVar.TypeVar (B.Blank loc) v
 
@@ -330,7 +331,7 @@ data SuggestionMatch = Exact | WrongType | WrongName
   deriving (Ord, Eq, Show)
 
 data Suggestion v loc = Suggestion
-  { suggestionName :: Text,
+  { suggestionName :: Name,
     suggestionType :: Type v loc,
     suggestionReplacement :: Replacement v,
     suggestionMatch :: SuggestionMatch

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -31,6 +31,7 @@ module Unison.Typechecker.Context
     fitsScheme,
     isRedundant,
     Suggestion (..),
+    Replacement (..),
     SuggestionMatch (..),
     isExact,
     typeErrors,
@@ -331,13 +332,18 @@ data SuggestionMatch = Exact | WrongType | WrongName
 data Suggestion v loc = Suggestion
   { suggestionName :: Text,
     suggestionType :: Type v loc,
-    suggestionReplacement :: Either v Referent,
+    suggestionReplacement :: Replacement v,
     suggestionMatch :: SuggestionMatch
   }
-  deriving (Eq, Show)
+  deriving stock (Eq, Show)
 
 isExact :: Suggestion v loc -> Bool
 isExact Suggestion {..} = suggestionMatch == Exact
+
+data Replacement v
+  = ReplacementRef Referent
+  | ReplacementVar v
+  deriving stock (Eq, Ord, Show)
 
 data ErrorNote v loc = ErrorNote
   { cause :: Cause v loc,

--- a/unison-cli/src/Unison/Cli/TypeCheck.hs
+++ b/unison-cli/src/Unison/Cli/TypeCheck.hs
@@ -47,9 +47,9 @@ typecheckTerm codebase tm = do
   typeLookup <- Codebase.typeLookupForDependencies codebase (UF.dependencies file)
   let typecheckingEnv =
         Typechecker.Env
-          { _ambientAbilities = [],
-            _typeLookup = typeLookup,
-            _termsByShortname = Map.empty
+          { ambientAbilities = [],
+            typeLookup,
+            termsByShortname = Map.empty
           }
   pure $ fmap extract $ FileParsers.synthesizeFile typecheckingEnv file
   where

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Run.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Run.hs
@@ -155,9 +155,9 @@ synthesizeForce tl typeOfFunc = do
       ref = Reference.DerivedId (Reference.Id (Hash.fromByteString "deadbeef") 0)
       env =
         Typechecker.Env
-          { Typechecker._ambientAbilities = [DD.exceptionType External, Type.builtinIO External],
-            Typechecker._typeLookup = mempty {TypeLookup.typeOfTerms = Map.singleton ref typeOfFunc} <> tl,
-            Typechecker._termsByShortname = Map.empty
+          { ambientAbilities = [DD.exceptionType External, Type.builtinIO External],
+            typeLookup = mempty {TypeLookup.typeOfTerms = Map.singleton ref typeOfFunc} <> tl,
+            termsByShortname = Map.empty
           }
   case Result.runResultT
     ( Typechecker.synthesize

--- a/unison-cli/src/Unison/LSP/FileAnalysis.hs
+++ b/unison-cli/src/Unison/LSP/FileAnalysis.hs
@@ -341,10 +341,10 @@ analyseNotes fileUri ppe src notes = do
       Context.Suggestion {suggestionName, suggestionType, suggestionMatch} <- sortOn nameResolutionSuggestionPriority suggestions
       let prettyType = TypePrinter.prettyStr Nothing ppe suggestionType
       let ranges = (diags ^.. folded . range)
-      let rca = rangedCodeAction ("Use " <> suggestionName <> " : " <> Text.pack prettyType) diags ranges
+      let rca = rangedCodeAction ("Use " <> Name.toText suggestionName <> " : " <> Text.pack prettyType) diags ranges
       pure $
         rca
-          & includeEdits fileUri suggestionName ranges
+          & includeEdits fileUri (Name.toText suggestionName) ranges
           & codeAction . isPreferred ?~ (suggestionMatch == Context.Exact)
 
     nameResolutionSuggestionPriority (Context.Suggestion {suggestionMatch, suggestionName}) = case suggestionMatch of

--- a/unison-core/src/Unison/Blank.hs
+++ b/unison-core/src/Unison/Blank.hs
@@ -1,4 +1,10 @@
-module Unison.Blank where
+module Unison.Blank
+  ( Blank (..),
+    Recorded (..),
+    loc,
+    nameb,
+  )
+where
 
 import Unison.Prelude
 
@@ -16,17 +22,12 @@ data Recorded loc
   = -- A user-provided named placeholder
     Placeholder loc String
   | -- A name to be resolved with type-directed name resolution.
-    Resolve
-      loc
-      String
+    Resolve loc String
   | -- A placeholder for a missing result at the end of a block
-    MissingResultPlaceholder
-      loc
+    MissingResultPlaceholder loc
   deriving (Show, Eq, Ord, Functor, Generic)
 
--- - Blank is just a dummy annotation.
--- - Recorded indicates that we want to remember the variable's solution
---   for some kind of
+-- | Blank is just a dummy annotation.
 data Blank loc
   = -- | just a dummy annotation
     Blank

--- a/unison-src/transcripts/suffixes.md
+++ b/unison-src/transcripts/suffixes.md
@@ -39,10 +39,9 @@ Type-based search also benefits from this, we can just say `Nat` rather than `.b
 .> find : Nat -> [a] -> [a]
 ```
 
-## Preferring names not in `lib`
+## Preferring names not in `lib.*.lib.*`
 
-Suffix-based resolution prefers names with fewer name segments that are equal to "lib". This
-has the effect of preferring names defined in your project to names from dependencies of your project, and names from indirect dependencies have even lower weight.
+Suffix-based resolution prefers names that are not in an indirect dependency.
 
 ```unison
 cool.abra.cadabra = "my project"
@@ -55,8 +54,11 @@ lib.distributed.lib.baz.qux = "indirect dependency"
 .> add
 ```
 
-```unison
+```unison:error
 > abra.cadabra
+```
+
+```unison
 > baz.qux
 ```
 

--- a/unison-src/transcripts/suffixes.output.md
+++ b/unison-src/transcripts/suffixes.output.md
@@ -57,10 +57,9 @@ Type-based search also benefits from this, we can just say `Nat` rather than `.b
   
 
 ```
-## Preferring names not in `lib`
+## Preferring names not in `lib.*.lib.*`
 
-Suffix-based resolution prefers names with fewer name segments that are equal to "lib". This
-has the effect of preferring names defined in your project to names from dependencies of your project, and names from indirect dependencies have even lower weight.
+Suffix-based resolution prefers names that are not in an indirect dependency.
 
 ```unison
 cool.abra.cadabra = "my project"
@@ -97,7 +96,6 @@ lib.distributed.lib.baz.qux = "indirect dependency"
 
 ```
 ```unison
-> abra.cadabra
 > baz.qux
 ```
 
@@ -112,13 +110,31 @@ lib.distributed.lib.baz.qux = "indirect dependency"
   Now evaluating any watch expressions (lines starting with
   `>`)... Ctrl+C cancels.
 
-    1 | > abra.cadabra
-          ⧩
-          "my project"
-  
-    2 | > baz.qux
+    1 | > baz.qux
           ⧩
           "direct dependency 2"
+
+```
+```unison
+> abra.cadabra
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I couldn't figure out what abra.cadabra refers to here:
+  
+      1 | > abra.cadabra
+  
+  The name abra.cadabra is ambiguous. I couldn't narrow it down
+  by type, as any type would work here.
+  
+  I found some terms in scope that have matching names and
+  types. Maybe you meant one of these:
+  
+  cool.abra.cadabra : Text
+  distributed.abra.cadabra : Text
 
 ```
 ```ucm
@@ -126,6 +142,9 @@ lib.distributed.lib.baz.qux = "indirect dependency"
 
   cool.abra.cadabra : Text
   cool.abra.cadabra = "my project"
+  
+  lib.distributed.abra.cadabra : Text
+  lib.distributed.abra.cadabra = "direct dependency 1"
 
 .> view baz.qux
 

--- a/unison-src/transcripts/suffixes.output.md
+++ b/unison-src/transcripts/suffixes.output.md
@@ -96,26 +96,6 @@ lib.distributed.lib.baz.qux = "indirect dependency"
 
 ```
 ```unison
-> baz.qux
-```
-
-```ucm
-
-  Loading changes detected in scratch.u.
-
-  ✅
-  
-  scratch.u changed.
-  
-  Now evaluating any watch expressions (lines starting with
-  `>`)... Ctrl+C cancels.
-
-    1 | > baz.qux
-          ⧩
-          "direct dependency 2"
-
-```
-```unison
 > abra.cadabra
 ```
 
@@ -135,6 +115,26 @@ lib.distributed.lib.baz.qux = "indirect dependency"
   
   cool.abra.cadabra : Text
   distributed.abra.cadabra : Text
+
+```
+```unison
+> baz.qux
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  ✅
+  
+  scratch.u changed.
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    1 | > baz.qux
+          ⧩
+          "direct dependency 2"
 
 ```
 ```ucm


### PR DESCRIPTION
## Overview

This PR tweaks some name priority logic to put "local definitions" (inside your project, outside `lib`) at the same level as "direct dependencies" (in `lib`, but not in `lib.*.lib.*`).

This affects what we ultimately perform TDNR on. For example, consider a namespace like

```
lib.csslib.CSS.++
my.coolfunction.++
```

Were you to write

```
triple : CSS -> CSSS
triple x = x ++ x ++ x
```

then (on `trunk`) the reference to `++` would fail to resolve to the desired `lib.csslib.CSS.++`, because the existence of `my.coolfunction.++` shadows it entirely.

Also in this PR: a small bugfix to `renderSuggestion` that I noticed along the way: https://github.com/unisonweb/unison/pull/4808/commits/e1fa352f46a50285aad52f4000f4de8d7c5924e5  

## Test coverage

Transcripts updated to reflect the new implementation.