### PR TITLE
Fix up uses of typelinks in the jit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ env:
   ormolu_version: "0.5.2.0"
   racket_version: "8.7"
   ucm_local_bin: "ucm-local-bin"
-  jit_version: "@unison/internal/releases/0.0.11"
+  jit_version: "@unison/internal/releases/0.0.12"
   jit_src_scheme: "unison-jit-src/scheme-libs/racket"
   jit_dist: "unison-jit-dist"
   jit_generator_os: ubuntu-20.04

--- a/scheme-libs/racket/unison-runtime.rkt
+++ b/scheme-libs/racket/unison-runtime.rkt
@@ -67,7 +67,7 @@
 (define (do-evaluate)
   (let-values ([(code main-ref) (decode-input)])
     (add-runtime-code 'unison-main code)
-    (handle ['ref-4n0fgs00] top-exn-handler
+    (handle [unison-exception:typelink] top-exn-handler
             ((termlink->proc main-ref))
             (data 'unit 0))))
 

--- a/scheme-libs/racket/unison/boot.ss
+++ b/scheme-libs/racket/unison/boot.ss
@@ -13,6 +13,7 @@
 #!racket/base
 (provide
   bytevector
+  bytes
   control
   define-unison
   handle
@@ -41,6 +42,10 @@
   (struct-out unison-typelink-derived)
   declare-function-link
   declare-code
+
+  exn:bug?
+  exn:bug->exception
+  exception->string
 
   request
   request-case
@@ -71,7 +76,7 @@
 (require
   (for-syntax
     racket/set
-    (only-in racket partition))
+    (only-in racket partition flatten))
   (rename-in
     (except-in racket false true unit any)
     [make-continuation-prompt-tag make-prompt])
@@ -410,13 +415,11 @@
         [(pure . xs) #t]
         [_ #f]))
 
-    (define (mk-pure scrut ps)
+    (define (mk-pure ps)
       (if (null? ps)
-        #`(pure-val #,scrut)
+        #'((unison-pure v) v)
         (syntax-case (car ps) (pure)
-          [(pure (v) e ...)
-           #`(let ([v (unison-pure-val #,scrut)])
-               e ...)]
+          [(pure (v) e ...) #'((unison-pure v) e ...)]
           [(pure vs e ...)
            (raise-syntax-error
              #f
@@ -424,24 +427,19 @@
              (car ps)
              #'vs)])))
 
-    (define (mk-req scrut-stx)
-      (lambda (stx)
-        (syntax-case stx ()
-          [(t vs e ...)
-           (with-syntax ([scrut scrut-stx])
-             #'((t) (let-values
-                      ([vs (apply values (unison-request-fields scrut))])
-                      e ...)))])))
+    (define (mk-req stx)
+      (syntax-case stx ()
+        [(t (v ...) e ...)
+         #'((t (list v ...)) e ...)]))
 
     (define (mk-abil scrut-stx)
       (lambda (stx)
         (syntax-case stx ()
-          [(t sc ...)
-           (let ([sub (mk-req scrut-stx)])
-             (with-syntax
-               ([(sc ...) (map sub (syntax->list #'(sc ...)))]
-                [scrut scrut-stx])
-               #'((t) (case (unison-request-tag scrut) sc ...))))])))
+          [(a sc ...)
+           #`((unison-request b t vs)
+              #:when (equal? a b)
+              (match* (t vs)
+                #,@(map mk-req (syntax->list #'(sc ...)))))])))
 
     (syntax-case stx ()
       [(request-case scrut c ...)
@@ -453,66 +451,11 @@
              "multiple pure cases in request-case"
              stx)
            (with-syntax
-             ([pc (mk-pure #'scrut ps)]
+             ([pc (mk-pure ps)]
               [(ac ...) (map (mk-abil #'scrut) as)])
 
-             #'(cond
-                 [(unison-pure? scrut) pc]
-                 [else (case (unison-request-ability scrut) ac ...)]))))])))
+             #'(match scrut pc ac ...))))])))
 
-; (define (describe-list n l)
-;   (let rec ([pre "["] [post "[]"] [cur l])
-;     (cond
-;       [(null? cur) post]
-;       [else
-;         (let* ([sx (describe-value-depth (- n 1) (car cur))]
-;                [sxs (rec ", " "]" (cdr cur))])
-;           (string-append pre sx sxs))])))
-;
-; (define (describe-ref r)
-;   (cond
-;     [(symbol? r) (symbol->string r)]
-;     [(data? r)
-;      (data-case r
-;        [0 (s) (string-append "##" s)]
-;        [1 (i)
-;          (data-case i
-;            [0 (bs ix)
-;              (let* ([bd (bytevector->base32-string b32h bs)]
-;                     [td (istring-take 5 bd)]
-;                     [sx (if (>= 0 ix)
-;                           ""
-;                           (string-append "." (number->string ix)))])
-;                (string-append "#" td sx))])])]))
-;
-; (define (describe-bytes bs)
-;   (let* ([s (bytevector->base32-string b32h bs)]
-;          [l (string-length s)]
-;          [sfx (if (<= l 10) "" "...")])
-;     (string-append "32x" (istring-take 10 s) sfx)))
-;
-; (define (describe-value-depth n x) 
-;   (if (< n 0) "..."
-;     (cond
-;       [(sum? x)
-;        (let ([tt (number->string (sum-tag x))]
-;              [vs (describe-list n (sum-fields x))])
-;          (string-append "Sum " tt " " vs))]
-;       [(data? x)
-;        (let ([tt (number->string (data-tag x))]
-;              [rt (describe-ref (data-ref x))]
-;              [vs (describe-list n (data-fields x))])
-;          (string-append "Data " rt " " tt " " vs))]
-;       [(list? x) (describe-list n x)]
-;       [(number? x) (number->string x)]
-;       [(string? x) (string-append "\"" x "\"")]
-;       [(bytevector? x) (describe-bytes x)]
-;       [(procedure? x) (format "~a" x)]
-;       [else
-;         (format "describe-value: unimplemented case: ~a " x)])))
-;
-; (define (describe-value x) (describe-value-depth 20 x))
-;
 (define (decode-value x) '())
 
 (define (reference->termlink rf)
@@ -582,21 +525,18 @@
 ; The in-unison definition was effectively just literal scheme code
 ; represented as a unison data type, with some names generated from
 ; codebase data.
-;
-; Note: the ref-4n0fgs00 stuff is probably not ultimately correct, but
-; is how things work for now.
 (define (top-exn-handler rq)
   (request-case rq
     [pure (x)
       (match x
         [(unison-data r 0 (list))
-         (eq? r unison-unit:link)
+         (eq? r unison-unit:typelink)
          (display "")]
         [else
           (display (describe-value x))])]
-    [ref-4n0fgs00
+    [unison-exception:typelink
       [0 (f)
-       (control 'ref-4n0fgs00 k
+       (control unison-exception:typelink k
          (let ([disp (describe-value f)])
            (raise (make-exn:bug "builtin.bug" disp))))]]))
 

--- a/scheme-libs/racket/unison/boot.ss
+++ b/scheme-libs/racket/unison/boot.ss
@@ -12,6 +12,16 @@
 ; that arity appropriately.
 #!racket/base
 (provide
+  (all-from-out unison/data-info)
+  unison-any:typelink
+  unison-boolean:typelink
+  unison-bytes:typelink
+  unison-char:typelink
+  unison-float:typelink
+  unison-int:typelink
+  unison-nat:typelink
+  unison-text:typelink
+
   bytevector
   bytes
   control

--- a/scheme-libs/racket/unison/concurrent.ss
+++ b/scheme-libs/racket/unison/concurrent.ss
@@ -110,13 +110,33 @@
   (define (try-eval thunk)
     (with-handlers
       ([exn:break?
-        (lambda (e) (exception "ThreadKilledFailure" (string->chunked-string "thread killed") ()))]
+        (lambda (e)
+          (exception
+            unison-threadkilledfailure:typelink
+            (string->chunked-string "thread killed")
+            ()))]
        [exn:io?
          (lambda (e)
-           (exception unison-iofailure:link (exception->string e) ()))]
-       [exn:arith? (lambda (e) (exception "ArithmeticFailure" (exception->string e) ()))]
+           (exception
+             unison-iofailure:typelink
+             (exception->string e) ()))]
+       [exn:arith?
+         (lambda (e)
+           (exception
+             unison-arithfailure:typelink
+             (exception->string e)
+             ()))]
        [exn:bug? (lambda (e) (exn:bug->exception e))]
-       [exn:fail? (lambda (e) (exception "RuntimeFailure" (exception->string e) ()))]
+       [exn:fail?
+         (lambda (e)
+           (exception
+             unison-runtimefailure:typelink
+             (exception->string e)
+             ()))]
        [(lambda (x) #t)
-        (lambda (e) (exception "MiscFailure" (string->chunked-string "unknown exception") e))])
+        (lambda (e)
+          (exception
+            unison-miscfailure:typelink
+            (string->chunked-string "unknown exception")
+            e))])
       (right (thunk)))))

--- a/scheme-libs/racket/unison/core.ss
+++ b/scheme-libs/racket/unison/core.ss
@@ -19,6 +19,12 @@
   (for-syntax raise-syntax-error)
 
   exception->string
+
+  exn:bug
+  make-exn:bug
+  exn:bug?
+  exn:bug->exception
+
   let-marks
   ref-mark
 
@@ -74,6 +80,7 @@
   (only-in racket/fixnum fl->fx fx- fxand fxlshift fxrshift fxior)
   racket/unsafe/ops
   unison/data
+  unison/data-info
   unison/chunked-seq)
 
 (define (fx1- n) (fx- n 1))
@@ -372,3 +379,12 @@
         (begin
           (vector-set! dst i (vector-ref src (+ off i)))
           (next (fx1- i)))))))
+
+; TODO needs better pretty printing for when it isn't caught
+(struct exn:bug (msg a)
+  #:constructor-name make-exn:bug)
+(define (exn:bug->exception b)
+  (exception
+    unison-runtimefailure:typelink
+    (exn:bug-msg b)
+    (exn:bug-a b)))

--- a/scheme-libs/racket/unison/data.ss
+++ b/scheme-libs/racket/unison/data.ss
@@ -52,10 +52,6 @@
   ord
   failure
   exception
-  exn:bug
-  make-exn:bug
-  exn:bug?
-  exn:bug->exception
 
   unison-any:typelink
   unison-any-any:tag
@@ -66,6 +62,13 @@
   unison-boolean-false:tag
   unison-boolean-true
   unison-boolean-false
+
+  unison-bytes:typelink
+  unison-char:typelink
+  unison-float:typelink
+  unison-int:typelink
+  unison-nat:typelink
+  unison-text:typelink
 
   unison-tuple->list)
 
@@ -110,7 +113,8 @@
 
 (struct unison-request
   (ability tag fields)
-  #:constructor-name make-request)
+  #:constructor-name make-request
+  #:transparent)
 
 ; Structures for other unison builtins. Originally the plan was
 ; just to secretly use an in-unison data type representation.
@@ -173,15 +177,43 @@
 
 (struct unison-typelink ()
   #:transparent
-  #:reflection-name 'typelink)
+  #:reflection-name 'typelink
+  #:property prop:equal+hash
+  (let ()
+    (define (equal-proc lnl lnr rec)
+      (match lnl
+        [(unison-typelink-builtin l)
+         (match lnr
+           [(unison-typelink-builtin r)
+            (equal? l r)]
+           [else #f])]
+        [(unison-typelink-derived hl i)
+         (match lnr
+           [(unison-typelink-derived hr j)
+            (and (equal? hl hr) (= i j))]
+           [else #f])]))
+
+    (define ((hash-proc init) ln rec)
+      (match ln
+        [(unison-typelink-builtin n)
+         (fxxor (fx*/wraparound (rec n) 53)
+                (fx*/wraparound init 17))]
+        [(unison-typelink-derived hl i)
+         (fxxor (fx*/wraparound (rec hl) 59)
+                (fx*/wraparound (rec i) 61)
+                (fx*/wraparound init 19))]))
+
+    (list equal-proc (hash-proc 3) (hash-proc 5))))
 
 (struct unison-typelink-builtin unison-typelink
   (name)
-  #:reflection-name 'typelink)
+  #:reflection-name 'typelink
+  #:transparent)
 
 (struct unison-typelink-derived unison-typelink
   (ref ix)
-  #:reflection-name 'typelink)
+  #:reflection-name 'typelink
+  #:transparent)
 
 (struct unison-code (rep))
 (struct unison-quote (val))
@@ -288,6 +320,13 @@
 (define unison-boolean-false
   (data unison-boolean:typelink unison-boolean-false:tag))
 
+(define unison-bytes:typelink (unison-typelink-builtin "Bytes"))
+(define unison-char:typelink (unison-typelink-builtin "Char"))
+(define unison-nat:typelink (unison-typelink-builtin "Nat"))
+(define unison-int:typelink (unison-typelink-builtin "Int"))
+(define unison-float:typelink (unison-typelink-builtin "Float"))
+(define unison-text:typelink (unison-typelink-builtin "Text"))
+
 ; Type -> Text -> Any -> Failure
 (define (failure typeLink msg any)
   (sum 0 typeLink msg any))
@@ -295,12 +334,6 @@
 ; Type -> Text -> a ->{Exception} b
 (define (exception typeLink msg a)
   (failure typeLink msg (unison-any-any a)))
-
-; TODO needs better pretty printing for when it isn't caught
-(struct exn:bug (msg a)
-  #:constructor-name make-exn:bug)
-(define (exn:bug->exception b) (exception "RuntimeFailure" (exn:bug-msg b) (exn:bug-a b)))
-
 
 ; A counter for internally numbering declared data, so that the
 ; entire reference doesn't need to be stored in every data record.

--- a/scheme-libs/racket/unison/gzip.rkt
+++ b/scheme-libs/racket/unison/gzip.rkt
@@ -26,5 +26,9 @@
     (bytes->chunked-bytes (gzip-bytes (chunked-bytes->bytes bytes))))
 
 (define (gzip.decompress bytes)
-    (with-handlers [[exn:fail? (lambda (e) (exception "Gzip data corrupted" (exception->string e) '()))] ]
-        (right (bytes->chunked-bytes (gunzip-bytes (chunked-bytes->bytes bytes))))))
+  (with-handlers
+    [[exn:fail? (lambda (e) (left (exception->string e)))]]
+    (right
+      (bytes->chunked-bytes
+        (gunzip-bytes
+          (chunked-bytes->bytes bytes))))))

--- a/scheme-libs/racket/unison/io-handles.rkt
+++ b/scheme-libs/racket/unison/io-handles.rkt
@@ -54,7 +54,7 @@
     (if (byte-ready? port)
         (unison-either-right #t)
         (if (port-eof? port)
-            (Exception 'IO "EOF" port)
+            (Exception unison-iofailure:typelink "EOF" port)
             (unison-either-right #f))))
 
 (define-unison (getCurrentDirectory.impl.v3 unit)
@@ -78,7 +78,7 @@
                 (set-port-position! handle (+ current amount))
                 (unison-either-right none)))
         (2 ()
-            (Exception 'BadNews "SeekFromEnd not supported" 0))))
+            (Exception unison-iofailure:typelink "SeekFromEnd not supported" 0))))
 
 (define-unison (getLine.impl.v1 handle)
   (let* ([line (read-line handle)])
@@ -90,7 +90,7 @@
 (define-unison (getChar.impl.v1 handle)
   (let* ([char (read-char handle)])
     (if (eof-object? char)
-        (Exception 'isEOFError "End of file reached")
+        (Exception unison-iofailure:typelink "End of file reached")
         (unison-either-right char))))
 
 (define-unison (getSomeBytes.impl.v1 handle bytes)
@@ -108,8 +108,8 @@
                   unison-buffermode-line-buffering)]
         [(block) (unison-either-right
                    unison-buffermode-block-buffering)]
-        [(#f) (Exception 'IO "Unable to determine buffering mode of handle" '())]
-        [else (Exception 'IO "Unexpected response from file-stream-buffer-mode" '())]))
+        [(#f) (Exception unison-iofailure:typelink "Unable to determine buffering mode of handle" '())]
+        [else (Exception unison-iofailure:typelink "Unexpected response from file-stream-buffer-mode" '())]))
 
 (define-unison (setBuffering.impl.v3 handle mode)
     (data-case mode
@@ -123,7 +123,7 @@
             (file-stream-buffer-mode handle 'block)
             (unison-either-right none))
         (3 (size)
-            (Exception 'IO "Sized block buffering not supported" '()))))
+            (Exception unison-iofailure:typelink "Sized block buffering not supported" '()))))
 
 (define (with-buffer-mode port mode)
   (file-stream-buffer-mode port mode)
@@ -142,7 +142,7 @@
 (define-unison (getEcho.impl.v1 handle)
   (if (eq? handle stdin)
       (unison-either-right (get-stdin-echo))
-      (Exception 'IO "getEcho only supported on stdin" '())))
+      (Exception unison-iofailure:typelink "getEcho only supported on stdin" '())))
 
 (define-unison (setEcho.impl.v1 handle echo)
   (if (eq? handle stdin)
@@ -151,7 +151,7 @@
             (system "stty echo")
             (system "stty -echo"))
         (unison-either-right none))
-      (Exception 'IO "setEcho only supported on stdin" '())))
+      (Exception unison-iofailure:typelink "setEcho only supported on stdin" '())))
 
 (define (get-stdin-echo)
   (let ([current (with-output-to-string (lambda () (system "stty -a")))])
@@ -165,7 +165,7 @@
 (define-unison (getEnv.impl.v1 key)
     (let ([value (environment-variables-ref (current-environment-variables) (string->bytes/utf-8 (chunked-string->string key)))])
         (if (false? value)
-            (Exception 'IO "environmental variable not found" key)
+            (Exception unison-iofailure:typelink "environmental variable not found" key)
             (unison-either-right
               (string->chunked-string (bytes->string/utf-8 value))))))
 

--- a/scheme-libs/racket/unison/io.rkt
+++ b/scheme-libs/racket/unison/io.rkt
@@ -46,14 +46,14 @@
     (with-handlers
         [[exn:fail:filesystem?
            (lambda (e)
-             (exception unison-iofailure:link (exception->string e) '()))]]
+             (exception unison-iofailure:typelink (exception->string e) '()))]]
         (right (file-size (chunked-string->string path)))))
 
 (define (getFileTimestamp.impl.v3 path)
     (with-handlers
         [[exn:fail:filesystem?
            (lambda (e)
-             (exception unison-iofailure:link (exception->string e) '()))]]
+             (exception unison-iofailure:typelink (exception->string e) '()))]]
         (right (file-or-directory-modify-seconds (chunked-string->string path)))))
 
 ; in haskell, it's not just file but also directory

--- a/scheme-libs/racket/unison/primops.ss
+++ b/scheme-libs/racket/unison/primops.ss
@@ -24,6 +24,13 @@
 #!r6rs
 (library (unison primops)
   (export
+    builtin-Any:typelink
+    builtin-Char:typelink
+    builtin-Float:typelink
+    builtin-Int:typelink
+    builtin-Nat:typelink
+    builtin-Text:typelink
+
     builtin-Float.*
     builtin-Float.*:termlink
     builtin-Float.>=
@@ -181,6 +188,8 @@
     builtin-TermLink.fromReferent:termlink
     builtin-TermLink.toReferent
     builtin-TermLink.toReferent:termlink
+    builtin-TypeLink.toReference
+    builtin-TypeLink.toReference:termlink
 
     unison-FOp-internal.dataTag
     unison-FOp-Char.toText
@@ -610,6 +619,7 @@
                 define-unison
                 referent->termlink
                 termlink->referent
+                typelink->reference
                 clamp-integer
                 clamp-natural
                 wrap-natural
@@ -634,6 +644,13 @@
           (unison zlib)
           (unison concurrent)
           (racket random))
+
+  (define builtin-Any:typelink unison-any:typelink)
+  (define builtin-Char:typelink unison-char:typelink)
+  (define builtin-Float:typelink unison-float:typelink)
+  (define builtin-Int:typelink unison-int:typelink)
+  (define builtin-Nat:typelink unison-nat:typelink)
+  (define builtin-Text:typelink unison-text:typelink)
 
   (define-builtin-link Float.*)
   (define-builtin-link Float.fromRepresentation)
@@ -701,6 +718,7 @@
   (define-builtin-link Code.toGroup)
   (define-builtin-link TermLink.fromReferent)
   (define-builtin-link TermLink.toReferent)
+  (define-builtin-link TypeLink.toReference)
   (define-builtin-link IO.seekHandle.impl.v3)
   (define-builtin-link IO.getLine.impl.v1)
   (define-builtin-link IO.getSomeBytes.impl.v1)
@@ -752,6 +770,8 @@
       (referent->termlink rf))
     (define-unison (builtin-TermLink.toReferent tl)
       (termlink->referent tl))
+    (define-unison (builtin-TypeLink.toReference tl)
+      (typelink->reference tl))
     (define-unison (builtin-murmurHashBytes bs)
       (murmurhash-bytes (chunked-bytes->bytes bs)))
 
@@ -1107,10 +1127,10 @@
     ;; TODO should we convert Bytes -> Text directly without the intermediate conversions?
     (define (unison-FOp-Text.fromUtf8.impl.v3 b)
       (with-handlers
-        ([exn:fail:contract? ; TODO proper typeLink
+        ([exn:fail:contract?
           (lambda (e)
             (exception
-              unison-iofailure:link
+              unison-iofailure:typelink
               (string->chunked-string
                 (string-append
                   "Invalid UTF-8 stream: "
@@ -1414,6 +1434,7 @@
   (declare-builtin-link builtin-Code.toGroup)
   (declare-builtin-link builtin-TermLink.fromReferent)
   (declare-builtin-link builtin-TermLink.toReferent)
+  (declare-builtin-link builtin-TypeLink.toReference)
   (declare-builtin-link builtin-IO.seekHandle.impl.v3)
   (declare-builtin-link builtin-IO.getLine.impl.v1)
   (declare-builtin-link builtin-IO.getSomeBytes.impl.v1)

--- a/scheme-libs/racket/unison/tcp.rkt
+++ b/scheme-libs/racket/unison/tcp.rkt
@@ -29,9 +29,22 @@
   (with-handlers
       [[exn:fail:network?
          (lambda (e)
-           (exception unison-iofailure:link (exception->string e) '()))]
-       [exn:fail:contract? (lambda (e) (exception "InvalidArguments" (exception->string e) '()))]
-       [(lambda _ #t) (lambda (e) (exception "MiscFailure" (chunked-string->string (format "Unknown exception ~a" (exn->string e))) e))] ]
+           (exception
+             unison-iofailure:typelink
+             (exception->string e) '()))]
+       [exn:fail:contract?
+         (lambda (e)
+           (exception
+             unison-miscfailure:typelink
+             (exception->string e)
+             '()))]
+       [(lambda _ #t)
+        (lambda (e)
+          (exception
+            unison-miscfailure:typelink
+            (chunked-string->string
+              (format "Unknown exception ~a" (exn->string e)))
+            e))]]
     (fn)))
 
 (define (closeSocket.impl.v3 socket)
@@ -52,15 +65,20 @@
 
 (define (socketSend.impl.v3 socket data) ; socket bytes -> ()
   (if (not (socket-pair? socket))
-      (exception "InvalidArguments" "Cannot send on a server socket" '())
+      (exception
+        unison-iofailure:typelink
+        "Cannot send on a server socket"
+        '())
       (begin
         (write-bytes (chunked-bytes->bytes data) (socket-pair-output socket))
         (flush-output (socket-pair-output socket))
-        (right none)))); )
+        (right none))))
 
 (define (socketReceive.impl.v3 socket amt) ; socket int -> bytes
   (if (not (socket-pair? socket))
-      (exception "InvalidArguments" "Cannot receive on a server socket")
+      (exception
+        unison-iofailure:typelink
+        "Cannot receive on a server socket")
       (handle-errors
        (lambda ()
          (begin
@@ -87,9 +105,21 @@
       (with-handlers
           [[exn:fail:network?
              (lambda (e)
-               (exception unison-iofailure:link (exception->string e) '()))]
-           [exn:fail:contract? (lambda (e) (exception "InvalidArguments" (exception->string e) '()))]
-           [(lambda _ #t) (lambda (e) (exception "MiscFailure" (string->chunked-string "Unknown exception") e))] ]
+               (exception
+                 unison-iofailure:typelink
+                 (exception->string e) '()))]
+           [exn:fail:contract?
+             (lambda (e)
+               (exception
+                 unison-iofailure:typelink
+                 (exception->string e)
+                 '()))]
+           [(lambda _ #t)
+            (lambda (e)
+              (exception
+                unison-miscfailure:typelink
+                (string->chunked-string "Unknown exception")
+                e))] ]
         (let ([listener (tcp-listen (string->number port ) 4 #f (if (equal? 0 hostname) #f hostname))])
           (right listener))))))
 
@@ -104,7 +134,10 @@
 
 (define (socketAccept.impl.v3 listener)
   (if (socket-pair? listener)
-      (exception "InvalidArguments" (string->chunked-string "Cannot accept on a non-server socket"))
+      (exception
+        unison-iofailure:typelink
+        (string->chunked-string "Cannot accept on a non-server socket")
+        '())
       (begin
         (let-values ([(input output) (tcp-accept listener)])
           (right (socket-pair input output))))))

--- a/scheme-libs/racket/unison/vector-trie.rkt
+++ b/scheme-libs/racket/unison/vector-trie.rkt
@@ -719,7 +719,7 @@
                      (next-leaf!)
                      (vector-copy! new-leaf leaf-split-i leaf 0 leaf-split-i))]
                   [else
-                   (vector-copy! new-leaf leaf-i leaf first-leaf-start leaf-split-i)])))]
+                   (vector-copy! new-leaf leaf-i leaf first-leaf-start last-leaf-end)])))]
             [else
              (make-node
               (λ (new-node)

--- a/scheme-libs/racket/unison/vector-trie.rkt
+++ b/scheme-libs/racket/unison/vector-trie.rkt
@@ -719,7 +719,7 @@
                      (next-leaf!)
                      (vector-copy! new-leaf leaf-split-i leaf 0 leaf-split-i))]
                   [else
-                   (vector-copy! new-leaf leaf-i leaf first-leaf-start leaf-insert-i)])))]
+                   (vector-copy! new-leaf leaf-i leaf first-leaf-start leaf-split-i)])))]
             [else
              (make-node
               (λ (new-node)

--- a/scheme-libs/racket/unison/zlib.rkt
+++ b/scheme-libs/racket/unison/zlib.rkt
@@ -1,6 +1,7 @@
 ; Zlib
 #lang racket/base
 (require unison/data
+         unison/data-info
          unison/core
          (only-in unison/chunked-seq
             bytes->chunked-bytes
@@ -105,5 +106,14 @@
     (bytes->chunked-bytes (zlib-deflate-bytes (chunked-bytes->bytes bytes))))
 
 (define (zlib.decompress bytes)
-    (with-handlers [[exn:fail? (lambda (e) (exception "Zlib data corrupted" (exception->string e) '()))] ]
-        (right (bytes->chunked-bytes (zlib-inflate-bytes (chunked-bytes->bytes bytes))))))
+  (with-handlers
+    [[exn:fail?
+       (lambda (e)
+         (exception
+           unison-miscfailure:typelink
+           (exception->string e)
+           '()))]]
+  (right
+    (bytes->chunked-bytes
+      (zlib-inflate-bytes
+        (chunked-bytes->bytes bytes))))))

--- a/unison-src/transcripts-manual/gen-racket-libs.md
+++ b/unison-src/transcripts-manual/gen-racket-libs.md
@@ -5,7 +5,7 @@ Next, we'll download the jit project and generate a few Racket files from it.
 
 ```ucm
 .> project.create-empty jit-setup
-jit-setup/main> pull @unison/internal/releases/0.0.11 lib.jit
+jit-setup/main> pull @unison/internal/releases/0.0.12 lib.jit
 ```
 
 ```unison

--- a/unison-src/transcripts-manual/gen-racket-libs.output.md
+++ b/unison-src/transcripts-manual/gen-racket-libs.output.md
@@ -20,9 +20,9 @@ Next, we'll download the jit project and generate a few Racket files from it.
   
   🎉 🥳 Happy coding!
 
-jit-setup/main> pull @unison/internal/releases/0.0.11 lib.jit
+jit-setup/main> pull @unison/internal/releases/0.0.12 lib.jit
 
-  Downloaded 13900 entities.
+  Downloaded 15048 entities.
 
   ✅
   


### PR DESCRIPTION
This PR fixes up some long standing hacks in the jit with regard to use of type links.

When we were first implementing things, we didn't have proper access to all the type link machinery, so we used symbols and strings for ability requests and failure indication. But, now we have access to all the type links. So, I've systematically replaced the symbols and strings with the proper links. Here's an overview of what's changed:

- Systematized the names of typelinks in scheme. Previously some were `:link` and others were `:typelink`. I made them all the latter
- Reworked the `request-case` macro a bit, so that it will work properly with type link names as cases
- Added a pseudo-builtin to for turning a link into a (in-unison type) `Reference`, necessary for some bootstrap modules to work
- Bumped `@unison/internal` version to 0.0.12, which changes some code generation associated with this (e.g. don't newly-generate builtin links used in user code; they should already be defined and imported)
- Some bug fixes and dead code deletion that I ran into while working on all this

This still passes the `jit-tests.md` transcript and all of Arya's tests (from base and whatnot).