### PR TITLE
see if this fixes the haddocks workflow

### DIFF
--- a/.github/workflows/haddocks.yaml
+++ b/.github/workflows/haddocks.yaml
@@ -59,7 +59,7 @@ jobs:
             stack-work-2_Linux
 
       - name: install stack
-        uses: ./.github/workflows/actions/install-stack
+        uses: ./unison/.github/workflows/actions/install-stack
 
       # One of the transcripts fails if the user's git name hasn't been set.
       - name: set git user info


### PR DESCRIPTION
haddocks checks out `unison` to a subdir, but called the composite action without taking that into account.
I guess the more reusable actions could go into a separate repo, which would prevent this sort of error.

this can only be tested by merging it 🔥🔥🔥  