### PR TITLE
Neglected to update ci.yaml for jit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ env:
   ormolu_version: "0.5.2.0"
   racket_version: "8.7"
   ucm_local_bin: "ucm-local-bin"
-  jit_version: "@unison/internal/releases/0.0.12"
+  jit_version: "@unison/internal/releases/0.0.13"
   jit_src_scheme: "unison-jit-src/scheme-libs/racket"
   jit_dist: "unison-jit-dist"
   jit_generator_os: ubuntu-20.04


### PR DESCRIPTION
This is an oversight from the last PR. I forgot to update `ci.yaml` with the latest unison share version.