### PR TITLE
Fix a bug in the jit's runtime code caching operation

### DIFF
--- a/scheme-libs/racket/unison/primops-generated.rkt
+++ b/scheme-libs/racket/unison/primops-generated.rkt
@@ -646,25 +646,22 @@
               [fdeps (filter need-dependency? deps)]
               [rdeps (remove* refs fdeps)])
          (cond
-           [(null? fdeps) #f]
+           [(null? fdeps) empty-chunked-list]
            [(null? rdeps)
-            (let ([ndefs (map gen-code udefs)] [sdefs (flatten (map gen-code udefs))]
+            (let ([ndefs (map gen-code udefs)]
+                  [sdefs (flatten (map gen-code udefs))]
                   [mname (or mname0 (generate-module-name tmlinks))])
               (expand-sandbox tmlinks (map-links depss))
               (register-code udefs)
               (add-module-associations tmlinks mname)
               (add-runtime-module mname tylinks tmlinks sdefs)
-              #f)]
+              empty-chunked-list)]
            [else
              (list->chunked-list
                (map reference->termlink rdeps))]))]
-      [else #f])))
+      [else empty-chunked-list])))
 
-(define (unison-POp-CACH dfns0)
-  (let ([result (add-runtime-code #f dfns0)])
-    (if result
-      (sum 1 result)
-      (sum 0 '()))))
+(define (unison-POp-CACH dfns0) (add-runtime-code #f dfns0))
 
 (define (unison-POp-LOAD v0)
   (let* ([val (unison-quote-val v0)]

--- a/unison-src/builtin-tests/serial-tests.u
+++ b/unison-src/builtin-tests/serial-tests.u
@@ -95,7 +95,10 @@ serial.loadSelfContained name path =
       Right [] -> pass (name ++ " links validated")
       Right _ -> fail name "failed link validation"
 
-    _ = cache_ deps
+    match cache_ deps with
+      [] -> ()
+      miss -> raiseFailure "code missing deps" miss
+
     checkCached name deps
     match Value.load v with
       Left l -> raiseFailure "value missing deps" l


### PR DESCRIPTION
The jit's runtime code caching operation was written with the idea that had a return type of `Either [Link.Term] Unit`, but it just returns the list, and lets an empty list indicate success.

This should fix that issue.

Modified the jit tests to do a match on a `cache_` result that would bump into this.