### PR TITLE
haddocks workflow: git config needed before commit

### DIFF
--- a/.github/workflows/haddocks.yaml
+++ b/.github/workflows/haddocks.yaml
@@ -42,11 +42,18 @@ jobs:
       - name: Checkout haddocks branch
         uses: actions/checkout@v4
         with:
-          ref: 'haddocks'
-          path: 'haddocks'
+          ref: haddocks
+          path: haddocks
+
+      # Needed for `git commit` below
+      - name: set git user info
+        working-directory: unison
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
 
       - name: Copy haddocks
-        working-directory: 'unison'
+        working-directory: unison
         run: |
           docs_root="$(stack path --local-doc-root)"
           # Erase any stale files


### PR DESCRIPTION
I deleted it earlier because the comment on it had said it was there to support running transcripts, when there are no transcripts in this workflow.