### PR TITLE
Give a more informative error for miscellaneous try-eval

### DIFF
--- a/scheme-libs/racket/unison/concurrent.ss
+++ b/scheme-libs/racket/unison/concurrent.ss
@@ -137,6 +137,6 @@
         (lambda (e)
           (exception
             ref-miscfailure:typelink
-            (string->chunked-string "unknown exception")
+            (exception->string e)
             ref-unit-unit))])
       (right (thunk)))))


### PR DESCRIPTION
Previously the exception was being bundled in the error. But that will run afoul of reflection and serialization. So I have changed the error message to be generated from `exception->string`.