### PR TITLE
Update pre-release.yaml

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -1,4 +1,5 @@
 name: pre-release
+run-name: pre-release (${{github.ref_name}})
 
 defaults:
   run:


### PR DESCRIPTION
Here, you can sort of see which branch a given run was triggered for
<img width="1056" alt="image" src="https://github.com/unisonweb/unison/assets/538571/652f6918-cde9-489a-8e24-1a4cff2cdb8f">

But here, you can't:
<img width="784" alt="image" src="https://github.com/unisonweb/unison/assets/538571/f4962269-699a-4c20-94b5-acfc4ca84e81">

This PR would add the branch name to the workflow run name at the top, though it will be redundant on the first screen.