### PR TITLE
Fix conversion from referent2to1 for Doc fuzzyfind results

### DIFF
--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -277,7 +277,7 @@ data TermEntry v a = TermEntry
   deriving (Eq, Ord, Show, Generic)
 
 termEntryLabeledDependencies :: Ord v => TermEntry v a -> Set LD.LabeledDependency
-termEntryLabeledDependencies TermEntry {termEntryType, termEntryReferent, termEntryTag} =
+termEntryLabeledDependencies TermEntry {termEntryType, termEntryReferent, termEntryTag, termEntryName} =
   foldMap Type.labeledDependencies termEntryType
     <> Set.singleton (LD.TermReferent (Cv.referent2to1UsingCT ct termEntryReferent))
   where
@@ -285,7 +285,8 @@ termEntryLabeledDependencies TermEntry {termEntryType, termEntryReferent, termEn
     ct = case termEntryTag of
       ServerTypes.Constructor ServerTypes.Ability -> V2Referent.EffectConstructor
       ServerTypes.Constructor ServerTypes.Data -> V2Referent.DataConstructor
-      _ -> error "termEntryLabeledDependencies: not a constructor, but one was required"
+      ServerTypes.Doc -> V2Referent.DataConstructor
+      _ -> error $ "termEntryLabeledDependencies: Term is not a constructor, but the referent was a constructor. Tag: " <> show termEntryTag <> " Name: " <> show termEntryName <> " Referent: " <> show termEntryReferent
 
 termEntryDisplayName :: TermEntry v a -> Text
 termEntryDisplayName = HQ'.toTextWith Name.toText . termEntryHQName


### PR DESCRIPTION
## Overview

Searches which match the Unison Doc2 Type or one of its constructors would fail.

https://unisoncomputing.slack.com/archives/C03C18ZAGKU/p1711635601225769

## Implementation notes

There was a case missing for providing the constructor type when determining pretty-print dependencies of constructors which are also considered a Doc (which is only the constructors of the Doc type itself) results in a fuzzy-find result. I've added it, along with better error info for if it happens next time.

## Test coverage

I pulled this base release and tested it locally, failed before the fix, works after :) 

# Loose Ends

Need to pull this into enlil and redeploy after merging
