### PR TITLE
Flesh out jit universal comparison

### DIFF
--- a/scheme-libs/racket/unison/boot.ss
+++ b/scheme-libs/racket/unison/boot.ss
@@ -545,11 +545,6 @@
     [(unison-termlink-con tyl i)
      (ref-referent-con (typelink->reference tyl) i)]))
 
-(define (list->unison-tuple l)
-  (foldr ref-tuple-pair ref-unit-unit l))
-
-(define (unison-tuple . l) (list->unison-tuple l))
-
 (define (unison-seq . l)
   (vector->chunked-list (list->vector l)))
 

--- a/scheme-libs/racket/unison/concurrent.ss
+++ b/scheme-libs/racket/unison/concurrent.ss
@@ -106,7 +106,6 @@
     (or (exn:fail:contract:divide-by-zero? e)
         (exn:fail:contract:non-fixnum-result? e)))
 
-  ;; TODO Replace strings with proper type links once we have them
   (define (try-eval thunk)
     (with-handlers
       ([exn:break?

--- a/scheme-libs/racket/unison/core.ss
+++ b/scheme-libs/racket/unison/core.ss
@@ -30,6 +30,9 @@
 
   chunked-string-foldMap-chunks
 
+  unison-tuple
+  list->unison-tuple
+
   freeze-bytevector!
   freeze-vector!
   freeze-subvector
@@ -69,6 +72,7 @@
                 build-path
                 path->string
                 match
+                match*
                 for/fold)
           (string-copy! racket-string-copy!)
           (bytes-append bytevector-append)
@@ -184,12 +188,43 @@
          [sfx (if (<= l 10) "" "...")])
     (string-append "32x" (substring s 0 10) sfx)))
 
+(define (describe-tuple x)
+  (define (format-tuple l)
+    (for/fold
+      ([sep ")"]
+       [bits '()]
+       #:result (apply string-append (cons "(" bits)))
+      ([e l])
+      (values ", " (list* (describe-value e) sep bits))))
+
+  (define (format-non-tuple l)
+    (for/fold
+      ([result #f])
+      ([e l])
+      (let ([de (describe-value e)])
+        (if (not result) de
+          (string-append "Cons (" de ") (" result ")")))))
+
+  (let rec ([acc '()] [tup x])
+    (match tup
+      [(unison-data r t (list x y))
+       #:when (eq? r ref-tuple:typelink)
+       (rec (cons x acc) y)]
+      [(unison-data r t (list))
+       #:when (eq? r ref-unit:typelink)
+       (format-tuple acc)]
+      [else
+       (format-non-tuple (cons tup acc))])))
+
 (define (describe-value x)
   (match x
     [(unison-sum t fs)
      (let ([tt (number->string t)]
            [vs (describe-list-br fs)])
        (string-append "Sum " tt " " vs))]
+    [(unison-data r t fs)
+     #:when (eq? r ref-tuple:typelink)
+     (describe-tuple x)]
     [(unison-data r t fs)
      (let ([tt (number->string t)]
            [rt (describe-ref r)]
@@ -258,62 +293,158 @@
          [else sc]))]))
 
 ; universal-compares two lists of values lexicographically
-(define (lexico-compare ls rs)
+(define (lexico-compare ls rs cmp-ty)
   (let rec ([cls ls] [crs rs])
     (cond
       [(and (null? cls) (null? crs)) '=]
       [else
         (comparisons
-          (universal-compare (car cls) (car crs))
+          (universal-compare (car cls) (car crs) cmp-ty)
           (rec (cdr cls) (cdr crs)))])))
 
-(define (cmp-num l r)
+(define ((comparison e? l?) l r)
   (cond
-    [(= l r) '=]
-    [(< l r) '<]
+    [(e? l r) '=]
+    [(l? l r) '<]
     [else '>]))
 
-(define (compare-char a b)
-  (cond
-    [(char=? a b) '=]
-    [(char<? a b) '<]
-    [else '>]))
+(define compare-num (comparison = <))
+(define compare-char (comparison char=? char<?))
+(define compare-byte (comparison = <))
+(define compare-bytes (comparison bytes=? bytes<?))
+(define compare-string (comparison string=? string<?))
 
-(define (compare-byte a b)
-  (cond
-    [(= a b) '=]
-    [(< a b) '<]
-    [else '>]))
+(define (compare-typelink ll rl)
+  (match ll
+    [(unison-typelink-builtin lnm)
+     (match rl
+       [(unison-typelink-builtin rnm) (compare-string lnm rnm)]
+       [(? unison-typelink-derived?) '<])]
+    [(unison-typelink-derived lh i)
+     (match rl
+       [(unison-typelink-derived rh j)
+        (comparisons
+          (compare-bytes lh rh)
+          (compare-num i j))]
+       [(? unison-typelink-builtin?) '>])]))
 
-(define (universal-compare l r)
+(define (compare-termlink ll rl)
+  (match ll
+    [(unison-termlink-builtin lnm)
+     (match rl
+       [(unison-termlink-builtin rnm)
+        (compare-string lnm rnm)]
+       [else '<])]
+    [(unison-termlink-derived lh i)
+     (match rl
+       [(unison-termlink-derived rh j)
+        (comparisons
+          (compare-bytes lh rh)
+          (compare-num i j))]
+       [(? unison-termlink-builtin?) '>]
+       [else '<])]
+    [(unison-termlink-con lr t)
+     (match rl
+       [(unison-termlink-con rr u)
+        (comparisons
+          (compare-typelink lr rr)
+          (compare-num t u))]
+       [else '>])]))
+
+(define (value->category v)
   (cond
-    [(equal? l r) '=]
-    [(and (number? l) (number? r)) (if (< l r) '< '>)]
-    [(and (char? l) (char? r)) (if (char<? l r) '< '>)]
+    [(procedure? v) 0]
+    [(unison-closure? v) 0]
+    [(number? v) 1]
+    [(char? v) 1]
+    [(boolean? v) 1]
+    [(unison-data? v) 1]
+    [(chunked-list? v) 3]
+    [(chunked-string? v) 3]
+    [(chunked-bytes? v) 3]
+    [(unison-termlink? v) 3]
+    [(unison-typelink? v) 3]
+    [(bytes? v) 5]))
+
+(define (compare-data l r cmp-ty)
+  (match* (l r)
+    [((unison-data lr lt lfs) (unison-data rr rt rfs))
+     (compare-data-stuff lr lt lfs rr rt rfs cmp-ty)]))
+
+(define (compare-data-stuff lr lt lfs rr rt rfs cmp-ty)
+  (define new-cmp-ty (or cmp-ty (eq? lr builtin-any:typelink)))
+  (comparisons
+    (if cmp-ty (compare-typelink lr rr) '=)
+    (compare-num lt rt)
+    (compare-num (length lfs) (length rfs))
+    (lexico-compare lfs rfs new-cmp-ty)))
+
+; gives links to compare values as pseudo- or actual data types.
+; This is how the interpreter works, so this is an attempt to obtain
+; the same ordering.
+(define (pseudo-data-link v)
+  (cond
+    [(boolean? v) builtin-boolean:typelink]
+    [(char? v) builtin-char:typelink]
+    [(flonum? v) builtin-float:typelink]
+    [(and (number? v) (negative? v)) builtin-int:typelink]
+    [(number? v) builtin-nat:typelink]
+    [(unison-data? v) (unison-data-ref v)]))
+
+(define (compare-proc l r cmp-ty)
+  (define (unpack v)
+    (if (procedure? v)
+      (values (lookup-function-link v) '())
+      (values
+        (lookup-function-link (unison-closure-code v))
+        (unison-closure-env v))))
+
+  (define-values (lnl envl) (unpack l))
+
+  (define-values (lnr envr) (unpack r))
+
+  (comparisons
+    (compare-termlink lnl lnr)
+    (lexico-compare envl envr cmp-ty)))
+
+(define (universal-compare l r [cmp-ty #f])
+  (define (u-proc? v)
+    (or (procedure? v) (unison-closure? v)))
+
+  (cond
+    [(eq? l r) '=] ; optimistic equality case
     [(and (boolean? l) (boolean? r)) (if r '< '>)]
-    [(and (chunked-list? l) (chunked-list? r)) (chunked-list-compare/recur l r universal-compare)]
+    [(and (char? l) (char? r)) (if (char<? l r) '< '>)]
+    [(and (number? l) (number? r)) (compare-num l r)]
+    [(and (chunked-list? l) (chunked-list? r))
+     (chunked-list-compare/recur l r universal-compare)]
     [(and (chunked-string? l) (chunked-string? r))
      (chunked-string-compare/recur l r compare-char)]
     [(and (chunked-bytes? l) (chunked-bytes? r))
      (chunked-bytes-compare/recur l r compare-byte)]
-    [(and (bytes? l) (bytes? r))
-     (cond
-       [(bytes=? l r) '=]
-       [(bytes<? l r) '<]
-       [else '>])]
-    [(and (unison-data? l) (unison-data? r))
-     (let ([fls (unison-data-fields l)] [frs (unison-data-fields r)])
-       (comparisons
-         (cmp-num (unison-data-tag l) (unison-data-tag r))
-         (cmp-num (length fls) (length frs))
-         (lexico-compare fls frs)))]
+    [(and (unison-data? l) (unison-data? r)) (compare-data l r cmp-ty)]
+    [(and (bytes? r) (bytes? r)) (compare-bytes l r)]
+    [(and (u-proc? l) (u-proc? r)) (compare-proc l r)]
+    [(and (unison-termlink? l) (unison-termlink? r))
+     (compare-termlink l r)]
+    [(and (unison-typelink? l) (unison-typelink? r))
+     (compare-typelink l r)]
+    [(= 3 (value->category l) (value->category r))
+     (compare-typelink (pseudo-data-link l) (pseudo-data-link r))]
+    [(= (value->category l) (value->category r))
+     (raise
+       (make-exn:bug
+         "unsupported universal comparison of values"
+         (unison-tuple l r)))]
     [else
-      (let ([dl (describe-value l)]
-            [dr (describe-value r)])
-        (raise
-          (format
-            "universal-compare: unimplemented\n~a\n\n~a"
-            dl dr)))]))
+      (compare-num (value->category l) (value->category r))]))
+
+
+(define (list->unison-tuple l)
+  (foldr ref-tuple-pair ref-unit-unit l))
+
+(define (unison-tuple . l) (list->unison-tuple l))
+
 
 (define (chunked-string<? l r) (chunked-string=?/recur l r char<?))
 
@@ -380,11 +511,29 @@
           (vector-set! dst i (vector-ref src (+ off i)))
           (next (fx1- i)))))))
 
-; TODO needs better pretty printing for when it isn't caught
-(struct exn:bug (msg a)
-  #:constructor-name make-exn:bug)
+(define (write-exn:bug ex port mode)
+  (when mode
+    (write-string "<exn:bug " port))
+
+  (let ([recur (case mode
+                 [(#t) write]
+                 [(#f) display]
+                 [else (lambda (v port) (print v port mode))])])
+    (recur (chunked-string->string (exn:bug-msg ex)) port)
+    (if mode (write-string " " port) (newline port))
+    (write-string (describe-value (exn:bug-val ex)) port))
+
+  (when mode
+    (write-string ">")))
+
+(struct exn:bug (msg val)
+  #:constructor-name make-exn:bug
+  #:methods gen:custom-write
+  [(define write-proc write-exn:bug)])
+
+
 (define (exn:bug->exception b)
   (exception
     ref-runtimefailure:typelink
     (exn:bug-msg b)
-    (exn:bug-a b)))
+    (exn:bug-val b)))

--- a/scheme-libs/racket/unison/primops.ss
+++ b/scheme-libs/racket/unison/primops.ss
@@ -909,7 +909,7 @@
     (define (unison-POp-EQLT s t) (bool (equal? s t)))
     (define (unison-POp-LEQT s t) (bool (chunked-string<? s t)))
     (define (unison-POp-EQLU x y) (bool (universal=? x y)))
-    (define (unison-POp-EROR fnm x) ;; TODO raise the correct failure, use display
+    (define (unison-POp-EROR fnm x)
       (let-values ([(p g) (open-string-output-port)])
         (put-string p (chunked-string->string fnm))
         (put-string p ": ")

--- a/scheme-libs/racket/unison/tls.rkt
+++ b/scheme-libs/racket/unison/tls.rkt
@@ -113,8 +113,6 @@
 (define (ClientConfig.certificates.set certs config) ; list tlsSignedCert tlsClientConfig -> tlsClientConfig
   (client-config (client-config-host config) certs))
 
-; TODO: have someone familiar with TLS verify these exception
-; classifications
 (define (handle-errors fn)
   (with-handlers
       [[exn:fail:network?

--- a/unison-src/builtin-tests/interpreter-tests.md
+++ b/unison-src/builtin-tests/interpreter-tests.md
@@ -22,6 +22,11 @@ to `Tests.check` and `Tests.checkEqual`).
 ```
 
 ```ucm:hide
+.> load unison-src/builtin-tests/link-tests.u
+.> add
+```
+
+```ucm:hide
 .> load unison-src/builtin-tests/math-tests.u
 .> add
 ```

--- a/unison-src/builtin-tests/jit-tests.md
+++ b/unison-src/builtin-tests/jit-tests.md
@@ -22,6 +22,11 @@ to `Tests.check` and `Tests.checkEqual`).
 ```
 
 ```ucm:hide
+.> load unison-src/builtin-tests/link-tests.u
+.> add
+```
+
+```ucm:hide
 .> load unison-src/builtin-tests/math-tests.u
 .> add
 ```

--- a/unison-src/builtin-tests/link-tests.u
+++ b/unison-src/builtin-tests/link-tests.u
@@ -1,0 +1,58 @@
+
+linkstuff.termlinks =
+  [ termLink data.Map.adjust
+  , termLink data.Map.alter
+  , termLink data.Map.contains
+  , termLink data.Map.delete
+  , termLink data.Map.difference
+  , termLink data.List.any
+  , termLink data.List.apply
+  , termLink data.List.compare
+  , termLink data.List.contains
+  , termLink data.List.count
+  , termLink data.List.diagonal
+  , termLink data.List.distinct
+  , termLink data.NatSet.alter
+  , termLink data.NatSet.any
+  , termLink data.NatSet.empty
+  , termLink data.NatSet.filter
+  , termLink data.Tuple.at1
+  , termLink data.Tuple.at2
+  , termLink data.Tuple.at3
+  , termLink data.Tuple.bimap
+  , termLink data.Tuple.mapLeft
+  , termLink data.graph.SCC.map
+  ]
+
+linkstuff.typelinks =
+  [ typeLink data.Map
+  , typeLink Nat
+  , typeLink Char
+  , typeLink data.List
+  , typeLink data.NatSet
+  , typeLink data.Tuple
+  ]
+
+linkstuff.tmlpairs =
+  flatMap (l -> map (r -> (l,r)) termlinks) termlinks
+
+linkstuff.tylpairs =
+  flatMap (l -> map (r -> (l,r)) typelinks) typelinks
+
+linkstuff.tests : '{Tests,IO} ()
+linkstuff.tests = do
+  use Universal gteq
+  if all (cases (l,r) -> (l === r) || (l !== r)) tmlpairs
+  then pass "term link equality"
+  else fail "term link equality" ""
+  if all (cases (l,r) -> (l === r) || (l !== r)) tylpairs
+  then pass "type link equality"
+  else fail "type link equality" ""
+
+  if all (cases (l,r) -> gteq l r || gteq r l) tmlpairs
+  then pass "term link comparison"
+  else fail "term link comparison" ""
+  if all (cases (l,r) -> gteq l r || gteq r l) tylpairs
+  then pass "type link comparison"
+  else fail "type link comparison" ""
+

--- a/unison-src/builtin-tests/tests.u
+++ b/unison-src/builtin-tests/tests.u
@@ -17,6 +17,7 @@ tests = Tests.main do
   !array.tests
   !codelookup.tests
   !sandbox.tests
+  !linkstuff.tests
 
 murmur.hash.tests = do
   targets =


### PR DESCRIPTION
This PR adds various cases missing from the universal comparison function in the jit.

- Type and termlinks are now handled
- Partial applications and procedures are now compared based on their references
- It tries to handle different types of values equivalently to the interpreter

Some additional changes are bundled because I tweaked other stuff while debugging the equality. E.G. the `describe-value` code for debug printing will now identify unison tuples and print them in a visually nicer way. I also added more descriptive printing for `bug` errors, which were just opaque before when they bubbled up to the top level.

Tests are included for term/type link comparison, which was the original motivation for this work.