### PR TITLE
Fix an issue with rehashing and scratch files

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -363,6 +363,7 @@ performRehash rgrp0 ctx =
     irs = remap $ intermedRemap ctx
     f b r
       | not b,
+        r `Map.notMember` rgrp0,
         r <- Map.findWithDefault r r frs,
         Just r <- Map.lookup r irs =
           r
@@ -757,7 +758,8 @@ prepareEvaluation ppe tm ctx = do
   pure (backrefAdd rbkr ctx', rgrp, rmn)
   where
     (rmn0, frem, rgrp0, rbkr) = intermediateTerm ppe ctx tm
-    int b r = if b then r else toIntermed ctx r
+    int b r | b || Map.member r rgrp0 = r
+            | otherwise = toIntermed ctx r
     (ctx', rrefs, rgrp) =
       performRehash
         ((fmap . overGroupLinks) int rgrp0)

--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -758,8 +758,9 @@ prepareEvaluation ppe tm ctx = do
   pure (backrefAdd rbkr ctx', rgrp, rmn)
   where
     (rmn0, frem, rgrp0, rbkr) = intermediateTerm ppe ctx tm
-    int b r | b || Map.member r rgrp0 = r
-            | otherwise = toIntermed ctx r
+    int b r
+      | b || Map.member r rgrp0 = r
+      | otherwise = toIntermed ctx r
     (ctx', rrefs, rgrp) =
       performRehash
         ((fmap . overGroupLinks) int rgrp0)

--- a/unison-src/builtin-tests/jit-tests.md
+++ b/unison-src/builtin-tests/jit-tests.md
@@ -103,3 +103,17 @@ to `Tests.check` and `Tests.checkEqual`).
 ```ucm
 .> run.native tests.jit.only
 ```
+
+```unison
+foo = do
+  go : Nat ->{Exception} ()
+  go = cases
+    0 -> ()
+    n -> go (decrement n)
+  go 1000
+```
+
+```ucm
+.> run.native foo
+.> run.native foo
+```

--- a/unison-src/builtin-tests/jit-tests.output.md
+++ b/unison-src/builtin-tests/jit-tests.output.md
@@ -17,3 +17,35 @@ to `Tests.check` and `Tests.checkEqual`).
   ()
 
 ```
+```unison
+foo = do
+  go : Nat ->{Exception} ()
+  go = cases
+    0 -> ()
+    n -> go (decrement n)
+  go 1000
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      foo : '{Exception} ()
+
+```
+```ucm
+.> run.native foo
+
+  ()
+
+.> run.native foo
+
+  ()
+
+```


### PR DESCRIPTION
This fixes an issue with calculating the verifiable hashes of scratch file terms that was affecting the jit.

The code we send from the scratch file to the jit runtime is rebuilt every time `run.native` is called. However, after the first time, we will already have a mapping from the codebase hash to the verifiable hash stored. If you substitute this into the terms, like you would for dependencies, then  you will break _recursive_ functions from the scratch file, because they'll be recursively calling something other than themselves. They'll also yield a different hash, of course.

So, this fix just checks if the references are in the binding group we're generating hashes for, and doesn't substitute for them.

I'm pretty sure this wouldn't affect the interpreter, because after the first time, it will know that the code is already cached, so it never did anything with the bogus values.

Fixes a bug @stew was encountering.