### PR TITLE
[Discussion] IO Watch Expressions

### DIFF
--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Orphans.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Orphans.hs
@@ -60,12 +60,14 @@ instance ToField WatchKind where
   toField = \case
     WatchKind.RegularWatch -> SQLInteger 0
     WatchKind.TestWatch -> SQLInteger 1
+    WatchKind.IOWatch -> SQLInteger 2
 
 instance FromField WatchKind where
   fromField =
     fromField @Int8 <&> fmap \case
       0 -> WatchKind.RegularWatch
       1 -> WatchKind.TestWatch
+      2 -> WatchKind.IOWatch
       tag -> error $ "Unknown WatchKind id " ++ show tag
 
 instance ToRow NamespaceStats where

--- a/codebase2/codebase/U/Codebase/WatchKind.hs
+++ b/codebase2/codebase/U/Codebase/WatchKind.hs
@@ -1,3 +1,7 @@
 module U.Codebase.WatchKind where
 
-data WatchKind = RegularWatch | TestWatch deriving (Eq, Ord, Show)
+data WatchKind
+  = RegularWatch
+  | TestWatch
+  | IOWatch
+  deriving (Eq, Ord, Show)

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Conversions.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Conversions.hs
@@ -72,12 +72,14 @@ watchKind1to2 :: V1.WK.WatchKind -> V2.WatchKind
 watchKind1to2 = \case
   V1.WK.RegularWatch -> V2.WatchKind.RegularWatch
   V1.WK.TestWatch -> V2.WatchKind.TestWatch
+  V1.WK.IOWatch -> V2.WatchKind.IOWatch
   other -> error $ "What kind of watchkind is " ++ other ++ "?"
 
 watchKind2to1 :: V2.WatchKind -> V1.WK.WatchKind
 watchKind2to1 = \case
   V2.WatchKind.RegularWatch -> V1.WK.RegularWatch
   V2.WatchKind.TestWatch -> V1.WK.TestWatch
+  V2.WatchKind.IOWatch -> V1.WK.IOWatch
 
 term1to2 :: Hash -> V1.Term.Term V1.Symbol Ann -> V2.Term.Term V2.Symbol
 term1to2 h =

--- a/unison-core/src/Unison/WatchKind.hs
+++ b/unison-core/src/Unison/WatchKind.hs
@@ -22,3 +22,15 @@ pattern RegularWatch = ""
 -- Note: currently test watches don't need to be named by the user, but that "feature" will be removed soon.
 pattern TestWatch :: (Eq a, IsString a) => a
 pattern TestWatch = "test"
+
+-- | A watch expression which runs an expression of type @@'{IO, Exception} a@@, such as
+--
+-- @
+-- io> do
+--   x = readFile "foo.txt"
+--   length x
+-- @
+--
+-- Note: currently test watches don't need to be named by the user, but that "feature" will be removed soon.
+pattern IOWatch :: (Eq a, IsString a) => a
+pattern IOWatch = "io"


### PR DESCRIPTION
This is an old Branch I'm just making a PR for to open the discussion about it since it comes up in Discord quite often.

It proves the concept of `io>` watch expressions isn't too hard to build, it's more a matter of design at this point. Some questions:

* Do we re-run on every save or just when a unison dependency changed?
* Do we block UCM till it's done so we can show the result, or do we just dump the output into UCM's stdout whenever it's done even if you were typing a command?
* If it takes a long time to run (or is a server that doesn't complete) do we kill the old one when you save or do we always wait for a full run to complete?

Certain use-cases require different permutations of these, maybe we can come up with 2 or 3 different types of watch expressions that handle each purpose, but finding good names and explaining how they work isn't trivial.