### PR TITLE
add quotes around path to `ucm`

### DIFF
--- a/.github/workflows/bundle-ucm.yaml
+++ b/.github/workflows/bundle-ucm.yaml
@@ -232,7 +232,7 @@ jobs:
           file: ucm
           content: |
             #!/bin/bash
-            $(dirname "$0")/unison/unison --runtime-path $(dirname "$0")/runtime/bin/unison-runtime "$@"
+            "$(dirname "$0")/unison/unison" --runtime-path "$(dirname "$0")/runtime/bin/unison-runtime" "$@"
       - name: create startup script (Windows)
         if: runner.os == 'Windows'
         uses: 1arp/create-a-file-action@0.4.4


### PR DESCRIPTION
fix #4861 