### PR TITLE
Check the exit code during native evaluation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -475,7 +475,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.jit_dist }}
-          key: jit_dist-racket_${{ matrix.os }}.${{ env.racket_version }}.jit_${{ env.jit_version }}
+          key: jit_dist-${{ matrix.os }}.racket_${{ env.racket_version }}.jit_${{ env.jit_version }}
 
       - name: Cache Racket dependencies
         if: steps.cache-jit-binaries.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -484,7 +484,7 @@ jobs:
           path: |
             ~/.cache/racket
             ~/.local/share/racket
-          key: ${{ runner.os }}-racket-${{env.racket_version}}
+          key: ${{ matrix.os }}-racket-${{env.racket_version}}
 
       - uses: Bogdanp/setup-racket@v1.11
         if: steps.restore-jit-binaries.outputs.cache-hit != 'true'
@@ -503,7 +503,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{env.jit_test_results}}
-          key: jit-test-results.racket_${{ env.racket_version }}.jit_${{ env.jit_version }}.tests_${{env.runtime_tests_causalhash}}
+          key: jit-test-results.${{ matrix.os }}.racket_${{ env.racket_version }}.jit_${{ env.jit_version }}.tests_${{env.runtime_tests_causalhash}}
 
       - uses: awalsh128/cache-apt-pkgs-action@latest
         if: |
@@ -546,8 +546,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.runtime_tests_codebase }}
-          key: runtime-tests-codebase-${{env.runtime_tests_causalhash}}
-          restore-keys: runtime-tests-codebase-
+          key: runtime-tests-codebase-${{ matrix.os }}-${{env.runtime_tests_causalhash}}
+          restore-keys: runtime-tests-codebase-${{ matrix.os }}-
 
       - name: download ucm
         if: steps.cache-jit-test-results.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -577,7 +577,6 @@ jobs:
           git diff --exit-code unison-src/builtin-tests/jit-tests.output.md
 
       - name: mark jit tests as passing
-        if: success()
         run: |
           echo "passing=true" >> "${{env.jit_test_results}}"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -485,6 +485,7 @@ jobs:
             ~/.cache/racket
             ~/.local/share/racket
           key: ${{ runner.os }}-racket-${{env.racket_version}}
+
       - uses: Bogdanp/setup-racket@v1.11
         if: steps.restore-jit-binaries.outputs.cache-hit != 'true'
         with:
@@ -492,13 +493,29 @@ jobs:
           distribution: full
           variant: CS
           version: ${{env.racket_version}}
+
+      - name: look up hash for runtime tests
+        run: |
+          echo "runtime_tests_causalhash=$(scripts/get-share-hash.sh ${{env.runtime_tests_version}})" >> $GITHUB_ENV
+
+      - name: cache jit test results
+        id: cache-jit-test-results
+        uses: actions/cache@v4
+        with:
+          path: ${{env.jit_test_results}}
+          key: jit-test-results.racket_${{ env.racket_version }}.jit_${{ env.jit_version }}.tests_${{env.runtime_tests_causalhash}}
+
       - uses: awalsh128/cache-apt-pkgs-action@latest
-        if: runner.os == 'Linux' && steps.restore-jit-binaries.outputs.cache-hit != 'true'
+        if: |
+          runner.os == 'Linux'
+            && (steps.restore-jit-binaries.outputs.cache-hit != 'true' \
+                || steps.cache-jit-test-results.outputs.cache-hit != 'true')
         # read this if a package isn't installing correctly
         # https://github.com/awalsh128/cache-apt-pkgs-action#caveats
         with:
           packages: libb2-dev
           version: 1.0 # cache key version afaik
+
       - name: download jit source
         if: steps.restore-jit-binaries.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v4
@@ -522,17 +539,6 @@ jobs:
         with:
           name: jit-binary-${{ matrix.os }}
           path: ${{ env.jit_dist }}/**
-
-      - name: look up hash for runtime tests
-        run: |
-          echo "runtime_tests_causalhash=$(scripts/get-share-hash.sh ${{env.runtime_tests_version}})" >> $GITHUB_ENV
-
-      - name: cache jit test results
-        id: cache-jit-test-results
-        uses: actions/cache@v4
-        with:
-          path: ${{env.jit_test_results}}
-          key: jit-test-results.racket_${{ env.racket_version }}.jit_${{ env.jit_version }}.tests_${{env.runtime_tests_causalhash}}
 
       - name: cache testing codebase
         id: cache-testing-codebase

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -563,6 +563,7 @@ jobs:
       - name: jit integration test ${{ matrix.os }}
         if: runner.os != 'Windows' && steps.cache-jit-test-results.outputs.cache-hit != 'true'
         run: |
+          if [[ ${{runner.os}} = 'macOS' ]]; then brew install libb2; fi
           envsubst '${runtime_tests_version}' \
             < unison-src/builtin-tests/jit-tests.tpl.md \
             > unison-src/builtin-tests/jit-tests.md

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -470,15 +470,15 @@ jobs:
           echo "jit_dist_exe=$jit_dist_exe" >> $GITHUB_ENV
           echo "ucm=$ucm" >> $GITHUB_ENV
 
-      - name: restore jit binaries
-        id: restore-jit-binaries
+      - name: cache jit binaries
+        id: cache-jit-binaries
         uses: actions/cache@v4
         with:
           path: ${{ env.jit_dist }}
-          key: jit_dist-racket_${{ env.racket_version }}.jit_${{ env.jit_version }}
+          key: jit_dist-racket_${{ matrix.os }}.${{ env.racket_version }}.jit_${{ env.jit_version }}
 
       - name: Cache Racket dependencies
-        if: steps.restore-jit-binaries.outputs.cache-hit != 'true'
+        if: steps.cache-jit-binaries.outputs.cache-hit != 'true'
         uses: actions/cache@v4
         with:
           path: |
@@ -487,7 +487,7 @@ jobs:
           key: ${{ matrix.os }}-racket-${{env.racket_version}}
 
       - uses: Bogdanp/setup-racket@v1.11
-        if: steps.restore-jit-binaries.outputs.cache-hit != 'true'
+        if: steps.cache-jit-binaries.outputs.cache-hit != 'true'
         with:
           architecture: x64
           distribution: full
@@ -531,14 +531,14 @@ jobs:
         run: brew install libb2
 
       - name: download jit source
-        if: steps.restore-jit-binaries.outputs.cache-hit != 'true'
+        if: steps.cache-jit-binaries.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v4
         with:
           name: jit-source
           path: ${{ env.jit_src_scheme }}
 
       - name: build jit binary
-        if: steps.restore-jit-binaries.outputs.cache-hit != 'true'
+        if: steps.cache-jit-binaries.outputs.cache-hit != 'true'
         shell: bash
         run: |
           cp -R scheme-libs/racket/* "$jit_src_scheme"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -500,6 +500,7 @@ jobs:
             scripts/get-share-hash.sh
             scheme-libs
             unison-src/builtin-tests/jit-tests.tpl.md
+            unison-src/transcripts-using-base/serialized-cases/case-00.v4.ser
 
       - name: look up hash for runtime tests
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -577,6 +577,7 @@ jobs:
           git diff --exit-code unison-src/builtin-tests/jit-tests.output.md
 
       - name: mark jit tests as passing
+        if: success()
         run: |
           echo "passing=true" >> "${{env.jit_test_results}}"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
         with:
           commit_message: automatically run ormolu
   build-ucm:
-    name: Build UCM ${{ matrix.os }}
+    name: build ucm
     runs-on: ${{ matrix.os }}
     strategy:
       # Run each build to completion, regardless of if any have failed
@@ -207,7 +207,7 @@ jobs:
           cache-prefix: ci
 
   transcripts:
-    name: Run transcripts
+    name: run transcripts
     needs: build-ucm
     runs-on: ${{ matrix.os }}
     strategy:
@@ -278,7 +278,7 @@ jobs:
           echo "passing=true" >> "${{env.transcript_test_results}}"
 
   interpreter-tests:
-    name: Run interpreter tests
+    name: run interpreter tests
     needs: build-ucm
     runs-on: ${{ matrix.os }}
     strategy:
@@ -348,7 +348,7 @@ jobs:
 
   generate-jit-source:
     if: always() && needs.build-ucm.result == 'success'
-    name: Generate JIT source
+    name: generate jit source
     needs: build-ucm
     runs-on: ubuntu-20.04
     steps:
@@ -434,7 +434,7 @@ jobs:
 
   build-jit-binary:
     if: always() && needs.generate-jit-source.result == 'success'
-    name: Build JIT binary ${{ matrix.os }}
+    name: build jit binary
     needs: generate-jit-source
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -494,6 +494,12 @@ jobs:
           variant: CS
           version: ${{env.racket_version}}
 
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/get-share-hash.sh
+            scheme-libs
+
       - name: look up hash for runtime tests
         run: |
           echo "runtime_tests_causalhash=$(scripts/get-share-hash.sh ${{env.runtime_tests_version}})" >> $GITHUB_ENV
@@ -528,8 +534,6 @@ jobs:
         with:
           name: jit-source
           path: ${{ env.jit_src_scheme }}
-
-      - uses: actions/checkout@v4 # checkout scheme-libs from unison repo
 
       - name: build jit binary
         if: steps.restore-jit-binaries.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -342,6 +342,7 @@ jobs:
           cat unison-src/builtin-tests/interpreter-tests.output.md
           git diff --exit-code unison-src/builtin-tests/interpreter-tests.output.md
       - name: mark interpreter tests as passing
+        if: steps.cache-interpreter-test-results.outputs.cache-hit != 'true'
         run: |
           echo "passing=true" >> "${{env.interpreter_test_results}}"
 
@@ -583,6 +584,7 @@ jobs:
           git diff --exit-code unison-src/builtin-tests/jit-tests.output.md
 
       - name: mark jit tests as passing
+        if: runner.os != 'Windows' && steps.cache-jit-test-results.outputs.cache-hit != 'true'
         run: |
           echo "passing=true" >> "${{env.jit_test_results}}"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -508,7 +508,7 @@ jobs:
       - uses: awalsh128/cache-apt-pkgs-action@latest
         if: |
           runner.os == 'Linux'
-            && (steps.restore-jit-binaries.outputs.cache-hit != 'true' \
+            && (steps.restore-jit-binaries.outputs.cache-hit != 'true'
                 || steps.cache-jit-test-results.outputs.cache-hit != 'true')
         # read this if a package isn't installing correctly
         # https://github.com/awalsh128/cache-apt-pkgs-action#caveats

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -499,6 +499,7 @@ jobs:
           sparse-checkout: |
             scripts/get-share-hash.sh
             scheme-libs
+            unison-src/builtin-tests/jit-tests.tpl.md
 
       - name: look up hash for runtime tests
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -505,16 +505,22 @@ jobs:
           path: ${{env.jit_test_results}}
           key: jit-test-results.${{ matrix.os }}.racket_${{ env.racket_version }}.jit_${{ env.jit_version }}.tests_${{env.runtime_tests_causalhash}}
 
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - name: install libb2 (linux)
+        uses: awalsh128/cache-apt-pkgs-action@latest
         if: |
           runner.os == 'Linux'
-            && (steps.restore-jit-binaries.outputs.cache-hit != 'true'
-                || steps.cache-jit-test-results.outputs.cache-hit != 'true')
+            && steps.cache-jit-test-results.outputs.cache-hit != 'true'
         # read this if a package isn't installing correctly
         # https://github.com/awalsh128/cache-apt-pkgs-action#caveats
         with:
           packages: libb2-dev
           version: 1.0 # cache key version afaik
+
+      - name: install libb2 (macos)
+        if: |
+          runner.os == 'macOS'
+            && steps.cache-jit-test-results.outputs.cache-hit != 'true'
+        run: brew install libb2
 
       - name: download jit source
         if: steps.restore-jit-binaries.outputs.cache-hit != 'true'
@@ -563,7 +569,6 @@ jobs:
       - name: jit integration test ${{ matrix.os }}
         if: runner.os != 'Windows' && steps.cache-jit-test-results.outputs.cache-hit != 'true'
         run: |
-          if [[ ${{runner.os}} = 'macOS' ]]; then brew install libb2; fi
           envsubst '${runtime_tests_version}' \
             < unison-src/builtin-tests/jit-tests.tpl.md \
             > unison-src/builtin-tests/jit-tests.md

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,9 +1,19 @@
 pull_request_rules:
   - name: automatic merge on CI success and review
     conditions:
-      - status-success=ubuntu-20.04
-      - status-success=macOS-12
-      - status-success=windows-2019
+      - check-success=build ucm (ubuntu-20.04)
+      - check-success=build ucm (macOS-12)
+      - check-success=build ucm (windows-2019)
+      - check-success=run transcripts (ubuntu-20.04)
+      - check-success=run transcripts (macOS-12)
+      - check-success=run transcripts (windows-2019)
+      - check-success=run interpreter tests (ubuntu-20.04)
+      - check-success=run interpreter tests (macOS-12)
+      # - check-success=run interpreter tests (windows-2019)
+      - check-success=generate jit source
+      - check-success=build jit binary (ubuntu-20.04)
+      - check-success=build jit binary (macOS-12)
+      - check-success=build jit binary (windows-2019)
       - label=ready-to-merge
       - "#approved-reviews-by>=1"
     actions:

--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -835,8 +835,10 @@ nativeEvalInContext executable _ ctx codes base = do
         UnliftIO.hClose pin
         let unit = Data RF.unitRef 0 [] []
             sunit = Data RF.pairRef 0 [] [unit, unit]
-        waitForProcess ph
-        decodeResult $ Right sunit
+        waitForProcess ph >>= \case
+          ExitSuccess -> decodeResult $ Right sunit
+          ExitFailure _ ->
+            pure . Left $ "native evaluation failed"
       -- TODO: actualy receive output from subprocess
       -- decodeResult . deserializeValue =<< BS.hGetContents pout
       callout _ _ _ _ =


### PR DESCRIPTION
This tweaks the infrastructure for `run.native` to check the exit code of the process, and indicate an error if appropriate. This avoids every `run.native` appearing successful.