### PR TITLE
Updates for Share diffs feature

### DIFF
--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -16,6 +16,7 @@ module Unison.Builtin
     typeOf,
     typeLookup,
     termRefTypes,
+    termRefTypeReferences,
   )
 where
 
@@ -320,13 +321,16 @@ termNameRefs = Map.mapKeys Name.unsafeParseText $ foldl' go mempty (stripVersion
               "tried to alias `" <> r <> "` before it was declared."
           Just t -> Map.insert name t m
 
-termRefTypes :: Map R.Reference Type
+termRefTypes :: Map R.TermReference Type
 termRefTypes = foldl' go mempty builtinsSrc
   where
     go m = \case
       B r t -> Map.insert (R.Builtin r) t m
       D r t -> Map.insert (R.Builtin r) t m
       _ -> m
+
+termRefTypeReferences :: Map R.TermReference R.TypeReference
+termRefTypeReferences = H.typeToReference <$> termRefTypes
 
 typeOf :: a -> (Type -> a) -> R.Reference -> a
 typeOf a f r = maybe a f (Map.lookup r termRefTypes)

--- a/parser-typechecker/src/Unison/Builtin/Decls.hs
+++ b/parser-typechecker/src/Unison/Builtin/Decls.hs
@@ -12,7 +12,7 @@ import Unison.ConstructorType qualified as CT
 import Unison.DataDeclaration (DataDeclaration (..), Modifier (Structural, Unique))
 import Unison.DataDeclaration qualified as DD
 import Unison.DataDeclaration.ConstructorId (ConstructorId)
-import Unison.Hashing.V2.Convert (hashDataDecls)
+import Unison.Hashing.V2.Convert (hashDataDecls, typeToReference)
 import Unison.Pattern qualified as Pattern
 import Unison.Reference (Reference)
 import Unison.Reference qualified as Reference
@@ -46,7 +46,7 @@ pairRef = lookupDeclRef "Tuple"
 optionalRef = lookupDeclRef "Optional"
 eitherRef = lookupDeclRef "Either"
 
-testResultRef, linkRef, docRef, ioErrorRef, stdHandleRef :: Reference
+testResultRef, testResultListRef, linkRef, docRef, ioErrorRef, stdHandleRef :: Reference
 failureRef, ioFailureRef, tlsFailureRef, arrayFailureRef :: Reference
 cryptoFailureRef :: Reference
 exceptionRef, tlsSignedCertRef, tlsPrivateKeyRef :: Reference
@@ -56,6 +56,9 @@ isPropagatedRef = lookupDeclRef "IsPropagated"
 isTestRef = lookupDeclRef "IsTest"
 
 testResultRef = lookupDeclRef "Test.Result"
+
+-- Reference for [Test.Result]
+testResultListRef = typeToReference @Symbol (testResultListType ())
 
 linkRef = lookupDeclRef "Link"
 
@@ -723,7 +726,7 @@ pattern LinkType ty <- Term.App' (Term.Constructor' (ConstructorReference LinkRe
 unitType,
   pairType,
   optionalType,
-  testResultType,
+  testResultListType,
   eitherType,
   ioErrorType,
   fileModeType,
@@ -739,7 +742,7 @@ unitType a = Type.ref a unitRef
 -- used for the type of the argument to force a thunk
 thunkArgType = unitType
 pairType a = Type.ref a pairRef
-testResultType a = Type.app a (Type.list a) (Type.ref a testResultRef)
+testResultListType a = Type.app a (Type.list a) (Type.ref a testResultRef)
 optionalType a = Type.ref a optionalRef
 eitherType a = Type.ref a eitherRef
 ioErrorType a = Type.ref a ioErrorRef

--- a/parser-typechecker/src/Unison/Codebase/MainTerm.hs
+++ b/parser-typechecker/src/Unison/Codebase/MainTerm.hs
@@ -81,4 +81,4 @@ builtinIOTestTypes a =
     )
   where
     delayed = Type.arrow a (Type.ref a DD.unitRef)
-    delayedResultWithEffects es = delayed (Type.effect a es (DD.testResultType a))
+    delayedResultWithEffects es = delayed (Type.effect a es (DD.testResultListType a))

--- a/parser-typechecker/src/Unison/UnisonFile.hs
+++ b/parser-typechecker/src/Unison/UnisonFile.hs
@@ -110,7 +110,7 @@ typecheckingTerm uf =
     bindings =
       terms uf <> testWatches <> watchesOfOtherKinds TestWatch uf
     -- we make sure each test has type Test.Result
-    f w = let wa = ABT.annotation w in Term.ann wa w (DD.testResultType wa)
+    f w = let wa = ABT.annotation w in Term.ann wa w (DD.testResultListType wa)
     testWatches = map (second f) $ watchesOfKind TestWatch uf
 
 -- backwards compatibility with the old data type

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ShowDefinition.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ShowDefinition.hs
@@ -54,7 +54,7 @@ showDefinitions outputLoc pped terms types misses = do
       Cli.respond $ DisplayDefinitions renderedCodePretty
     Just fp -> do
       -- We build an 'isTest' check to prepend "test>" to tests in a scratch file.
-      testRefs <- Cli.runTransaction (Codebase.filterTermsByReferenceIdHavingType codebase (DD.testResultType mempty) (Map.keysSet terms & Set.mapMaybe Reference.toId))
+      testRefs <- Cli.runTransaction (Codebase.filterTermsByReferenceIdHavingType codebase (DD.testResultListType mempty) (Map.keysSet terms & Set.mapMaybe Reference.toId))
       let isTest r = Set.member r testRefs
       let isSourceFile = True
       let renderedCodePretty = renderCodePretty pped isSourceFile isTest terms types

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Tests.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Tests.hs
@@ -60,7 +60,7 @@ handleTest :: TestInput -> Cli ()
 handleTest TestInput {includeLibNamespace, showFailures, showSuccesses} = do
   Cli.Env {codebase} <- ask
 
-  testRefs <- findTermsOfTypes codebase includeLibNamespace (NESet.singleton (DD.testResultType mempty))
+  testRefs <- findTermsOfTypes codebase includeLibNamespace (NESet.singleton (DD.testResultListType mempty))
 
   cachedTests <-
     Map.fromList <$> Cli.runTransaction do

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Update2.hs
@@ -310,7 +310,7 @@ addDefinitionsToUnisonFile abort codebase doFindCtorNames (terms, types) =
           Set.fromList [v | (v, _, _) <- uf.terms]
             <> foldMap (\x -> Set.fromList [v | (v, _, _) <- x]) uf.watches
 
-    isTest = Typechecker.isEqual (Decls.testResultType mempty)
+    isTest = Typechecker.isEqual (Decls.testResultListType mempty)
 
     -- given a dependent hash, include that component in the scratch file
     -- todo: wundefined: cut off constructor name prefixes

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -454,7 +454,7 @@ getTermTag codebase r sig = do
   -- A term is a test if it has the type [test.Result]
   let isTest = case sig of
         Just t ->
-          Typechecker.isEqual t (Decls.testResultType mempty)
+          Typechecker.isEqual t (Decls.testResultListType mempty)
         Nothing -> False
   constructorType <- case r of
     V2Referent.Ref {} -> pure Nothing

--- a/unison-share-api/src/Unison/Server/Orphans.hs
+++ b/unison-share-api/src/Unison/Server/Orphans.hs
@@ -173,6 +173,9 @@ instance ToJSONKey Name where
 instance ToSchema Name where
   declareNamedSchema _ = declareNamedSchema (Proxy @Text)
 
+instance ToJSON NameSegment where
+  toJSON = toJSON . NameSegment.toEscapedText
+
 deriving anyclass instance ToParamSchema ShortCausalHash
 
 instance ToParamSchema ShortHash where

--- a/unison-share-api/src/Unison/Server/Orphans.hs
+++ b/unison-share-api/src/Unison/Server/Orphans.hs
@@ -39,7 +39,7 @@ import Unison.ShortHash qualified as SH
 import Unison.Syntax.HashQualified qualified as HQ (parseText)
 import Unison.Syntax.HashQualified' qualified as HQ' (parseText)
 import Unison.Syntax.Name qualified as Name (parseTextEither, toText)
-import Unison.Syntax.NameSegment qualified as NameSegment (toEscapedText)
+import Unison.Syntax.NameSegment qualified as NameSegment
 import Unison.Util.Pretty (Width (..))
 
 instance ToJSON Hash where
@@ -175,6 +175,9 @@ instance ToSchema Name where
 
 instance ToJSON NameSegment where
   toJSON = toJSON . NameSegment.toEscapedText
+
+instance ToJSONKey NameSegment where
+  toJSONKey = contramap NameSegment.toEscapedText (toJSONKey @Text)
 
 deriving anyclass instance ToParamSchema ShortCausalHash
 


### PR DESCRIPTION
## Overview

Some small changes used by Share for surfacing diffs for contributions. 
See https://github.com/unisoncomputing/enlil/pull/422

## Implementation notes

* Exposes a map of all the references for types in the builtins module as `termRefTypeReferences`
  * We were already exposing the types, this just gives us a single place where they're hashed and those hashes will be cached as an immutable value so we're not re-doing it all over the place 😄 
  * This is used in Share now for detecting whether something is a test by checking reference equality to the test result list type ref.
* Renames `testResultType` to `testResultListType` everywhere to be more accurate, since it's actually the type `[Test.Result]`
* Adds `ToJSON` and `ToJSONKey` orphan instances for `NameSegment` using its escaped rendering.


## Test coverage

Existing transcripts cover the renames, the new type references map is tested in transcripts in Share by checking that terms are listed as "tests" when applicable.