### PR TITLE
install linux libb2 on build or test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -475,7 +475,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.jit_dist }}
-          key: jit_dist-racket_${{ matrix.os }}.${{ env.racket_version }}.jit_${{ env.jit_version }}
+          key: jit_dist-${{ matrix.os }}.racket_${{ env.racket_version }}.jit_${{ env.jit_version }}
 
       - name: Cache Racket dependencies
         if: steps.cache-jit-binaries.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -484,7 +484,7 @@ jobs:
           path: |
             ~/.cache/racket
             ~/.local/share/racket
-          key: ${{ runner.os }}-racket-${{env.racket_version}}
+          key: ${{ matrix.os }}-racket-${{env.racket_version}}
 
       - uses: Bogdanp/setup-racket@v1.11
         if: steps.restore-jit-binaries.outputs.cache-hit != 'true'
@@ -503,7 +503,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{env.jit_test_results}}
-          key: jit-test-results.racket_${{ env.racket_version }}.jit_${{ env.jit_version }}.tests_${{env.runtime_tests_causalhash}}
+          key: jit-test-results.${{ matrix.os }}.racket_${{ env.racket_version }}.jit_${{ env.jit_version }}.tests_${{env.runtime_tests_causalhash}}
 
       - uses: awalsh128/cache-apt-pkgs-action@latest
         if: |
@@ -546,8 +546,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.runtime_tests_codebase }}
-          key: runtime-tests-codebase-${{env.runtime_tests_causalhash}}
-          restore-keys: runtime-tests-codebase-
+          key: runtime-tests-codebase-${{ matrix.os }}-${{env.runtime_tests_causalhash}}
+          restore-keys: runtime-tests-codebase-${{ matrix.os }}-
 
       - name: download ucm
         if: steps.cache-jit-test-results.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -577,7 +577,6 @@ jobs:
           git diff --exit-code unison-src/builtin-tests/jit-tests.output.md
 
       - name: mark jit tests as passing
-        if: success()
         run: |
           echo "passing=true" >> "${{env.jit_test_results}}"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -485,6 +485,7 @@ jobs:
             ~/.cache/racket
             ~/.local/share/racket
           key: ${{ runner.os }}-racket-${{env.racket_version}}
+
       - uses: Bogdanp/setup-racket@v1.11
         if: steps.restore-jit-binaries.outputs.cache-hit != 'true'
         with:
@@ -492,13 +493,29 @@ jobs:
           distribution: full
           variant: CS
           version: ${{env.racket_version}}
+
+      - name: look up hash for runtime tests
+        run: |
+          echo "runtime_tests_causalhash=$(scripts/get-share-hash.sh ${{env.runtime_tests_version}})" >> $GITHUB_ENV
+
+      - name: cache jit test results
+        id: cache-jit-test-results
+        uses: actions/cache@v4
+        with:
+          path: ${{env.jit_test_results}}
+          key: jit-test-results.racket_${{ env.racket_version }}.jit_${{ env.jit_version }}.tests_${{env.runtime_tests_causalhash}}
+
       - uses: awalsh128/cache-apt-pkgs-action@latest
-        if: runner.os == 'Linux' && steps.restore-jit-binaries.outputs.cache-hit != 'true'
+        if: |
+          runner.os == 'Linux'
+            && (steps.restore-jit-binaries.outputs.cache-hit != 'true' \
+                || steps.cache-jit-test-results.outputs.cache-hit != 'true')
         # read this if a package isn't installing correctly
         # https://github.com/awalsh128/cache-apt-pkgs-action#caveats
         with:
           packages: libb2-dev
           version: 1.0 # cache key version afaik
+
       - name: download jit source
         if: steps.restore-jit-binaries.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v4
@@ -522,17 +539,6 @@ jobs:
         with:
           name: jit-binary-${{ matrix.os }}
           path: ${{ env.jit_dist }}/**
-
-      - name: look up hash for runtime tests
-        run: |
-          echo "runtime_tests_causalhash=$(scripts/get-share-hash.sh ${{env.runtime_tests_version}})" >> $GITHUB_ENV
-
-      - name: cache jit test results
-        id: cache-jit-test-results
-        uses: actions/cache@v4
-        with:
-          path: ${{env.jit_test_results}}
-          key: jit-test-results.racket_${{ env.racket_version }}.jit_${{ env.jit_version }}.tests_${{env.runtime_tests_causalhash}}
 
       - name: cache testing codebase
         id: cache-testing-codebase

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -563,6 +563,7 @@ jobs:
       - name: jit integration test ${{ matrix.os }}
         if: runner.os != 'Windows' && steps.cache-jit-test-results.outputs.cache-hit != 'true'
         run: |
+          if [[ ${{runner.os}} = 'macOS' ]]; then brew install libb2; fi
           envsubst '${runtime_tests_version}' \
             < unison-src/builtin-tests/jit-tests.tpl.md \
             > unison-src/builtin-tests/jit-tests.md

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -470,15 +470,15 @@ jobs:
           echo "jit_dist_exe=$jit_dist_exe" >> $GITHUB_ENV
           echo "ucm=$ucm" >> $GITHUB_ENV
 
-      - name: restore jit binaries
-        id: restore-jit-binaries
+      - name: cache jit binaries
+        id: cache-jit-binaries
         uses: actions/cache@v4
         with:
           path: ${{ env.jit_dist }}
-          key: jit_dist-racket_${{ env.racket_version }}.jit_${{ env.jit_version }}
+          key: jit_dist-racket_${{ matrix.os }}.${{ env.racket_version }}.jit_${{ env.jit_version }}
 
       - name: Cache Racket dependencies
-        if: steps.restore-jit-binaries.outputs.cache-hit != 'true'
+        if: steps.cache-jit-binaries.outputs.cache-hit != 'true'
         uses: actions/cache@v4
         with:
           path: |
@@ -487,7 +487,7 @@ jobs:
           key: ${{ matrix.os }}-racket-${{env.racket_version}}
 
       - uses: Bogdanp/setup-racket@v1.11
-        if: steps.restore-jit-binaries.outputs.cache-hit != 'true'
+        if: steps.cache-jit-binaries.outputs.cache-hit != 'true'
         with:
           architecture: x64
           distribution: full
@@ -531,14 +531,14 @@ jobs:
         run: brew install libb2
 
       - name: download jit source
-        if: steps.restore-jit-binaries.outputs.cache-hit != 'true'
+        if: steps.cache-jit-binaries.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v4
         with:
           name: jit-source
           path: ${{ env.jit_src_scheme }}
 
       - name: build jit binary
-        if: steps.restore-jit-binaries.outputs.cache-hit != 'true'
+        if: steps.cache-jit-binaries.outputs.cache-hit != 'true'
         shell: bash
         run: |
           cp -R scheme-libs/racket/* "$jit_src_scheme"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -500,6 +500,7 @@ jobs:
             scripts/get-share-hash.sh
             scheme-libs
             unison-src/builtin-tests/jit-tests.tpl.md
+            unison-src/transcripts-using-base/serialized-cases/case-00.v4.ser
 
       - name: look up hash for runtime tests
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -577,6 +577,7 @@ jobs:
           git diff --exit-code unison-src/builtin-tests/jit-tests.output.md
 
       - name: mark jit tests as passing
+        if: success()
         run: |
           echo "passing=true" >> "${{env.jit_test_results}}"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -494,6 +494,12 @@ jobs:
           variant: CS
           version: ${{env.racket_version}}
 
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/get-share-hash.sh
+            scheme-libs
+
       - name: look up hash for runtime tests
         run: |
           echo "runtime_tests_causalhash=$(scripts/get-share-hash.sh ${{env.runtime_tests_version}})" >> $GITHUB_ENV
@@ -528,8 +534,6 @@ jobs:
         with:
           name: jit-source
           path: ${{ env.jit_src_scheme }}
-
-      - uses: actions/checkout@v4 # checkout scheme-libs from unison repo
 
       - name: build jit binary
         if: steps.restore-jit-binaries.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -342,6 +342,7 @@ jobs:
           cat unison-src/builtin-tests/interpreter-tests.output.md
           git diff --exit-code unison-src/builtin-tests/interpreter-tests.output.md
       - name: mark interpreter tests as passing
+        if: steps.cache-interpreter-test-results.outputs.cache-hit != 'true'
         run: |
           echo "passing=true" >> "${{env.interpreter_test_results}}"
 
@@ -583,6 +584,7 @@ jobs:
           git diff --exit-code unison-src/builtin-tests/jit-tests.output.md
 
       - name: mark jit tests as passing
+        if: runner.os != 'Windows' && steps.cache-jit-test-results.outputs.cache-hit != 'true'
         run: |
           echo "passing=true" >> "${{env.jit_test_results}}"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -508,7 +508,7 @@ jobs:
       - uses: awalsh128/cache-apt-pkgs-action@latest
         if: |
           runner.os == 'Linux'
-            && (steps.restore-jit-binaries.outputs.cache-hit != 'true' \
+            && (steps.restore-jit-binaries.outputs.cache-hit != 'true'
                 || steps.cache-jit-test-results.outputs.cache-hit != 'true')
         # read this if a package isn't installing correctly
         # https://github.com/awalsh128/cache-apt-pkgs-action#caveats

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -499,6 +499,7 @@ jobs:
           sparse-checkout: |
             scripts/get-share-hash.sh
             scheme-libs
+            unison-src/builtin-tests/jit-tests.tpl.md
 
       - name: look up hash for runtime tests
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -505,16 +505,22 @@ jobs:
           path: ${{env.jit_test_results}}
           key: jit-test-results.${{ matrix.os }}.racket_${{ env.racket_version }}.jit_${{ env.jit_version }}.tests_${{env.runtime_tests_causalhash}}
 
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - name: install libb2 (linux)
+        uses: awalsh128/cache-apt-pkgs-action@latest
         if: |
           runner.os == 'Linux'
-            && (steps.restore-jit-binaries.outputs.cache-hit != 'true'
-                || steps.cache-jit-test-results.outputs.cache-hit != 'true')
+            && steps.cache-jit-test-results.outputs.cache-hit != 'true'
         # read this if a package isn't installing correctly
         # https://github.com/awalsh128/cache-apt-pkgs-action#caveats
         with:
           packages: libb2-dev
           version: 1.0 # cache key version afaik
+
+      - name: install libb2 (macos)
+        if: |
+          runner.os == 'macOS'
+            && steps.cache-jit-test-results.outputs.cache-hit != 'true'
+        run: brew install libb2
 
       - name: download jit source
         if: steps.restore-jit-binaries.outputs.cache-hit != 'true'
@@ -563,7 +569,6 @@ jobs:
       - name: jit integration test ${{ matrix.os }}
         if: runner.os != 'Windows' && steps.cache-jit-test-results.outputs.cache-hit != 'true'
         run: |
-          if [[ ${{runner.os}} = 'macOS' ]]; then brew install libb2; fi
           envsubst '${runtime_tests_version}' \
             < unison-src/builtin-tests/jit-tests.tpl.md \
             > unison-src/builtin-tests/jit-tests.md


### PR DESCRIPTION
In CI, `libb2` was only being installed when building the runtime on Linux, but actually we want it installed whenever running the runtime tests, and also on Mac. (And also on Windows, but I didn't touch that here.)

I also renamed a cache step id to say `cache-` instead of `restore-` because it uses the `cache` plugin and not the `restore` plugin today.

<!--
## Overview

What does this change accomplish and why?
i.e. How does it change the user experience?
i.e. What was the old behavior/API and what is the new behavior/API?

Feel free to include "before and after" examples if appropriate. (You can copy/paste screenshots directly into this editor.)

If relevant, which Github issues does it close? (See [closing-issues-using-keywords](https://help.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords).)

## Implementation notes

How does it accomplish it, in broad strokes? i.e. How does it change the Haskell codebase?

## Interesting/controversial decisions

Include anything that you thought twice about, debated, chose arbitrarily, etc.
What could have been done differently, but wasn't? And why?

## Test coverage

Have you included tests (which could be a transcript) for this change, or is it somehow covered by existing tests?

Would you recommend improving the test coverage (either as part of this PR or as a separate issue) or do you think it’s adequate?

If you only tested by hand, because that's all that's practical to do for this change, mention that.

## Loose ends

Link to related issues that address things you didn't get to. Stuff you encountered on the way and decided not to include in this PR.
i don't actually know if it's needed to build, would be good to know, but a pain to find out.