### PR TITLE
Upgrade jit share dependency to fix link validation

### DIFF
--- a/.github/workflows/ci.md
+++ b/.github/workflows/ci.md
@@ -9,7 +9,7 @@ At a high level, the CI process is:
 Some version numbers that are used during CI:
 - `ormolu_version: "0.5.0.1"`
 - `racket_version: "8.7"`
-- `jit_version: "@unison/internal/releases/0.0.14"`
+- `jit_version: "@unison/internal/releases/0.0.15"`
 
 Some cached directories:
   - `ucm_local_bin` a temp path for caching a built `ucm`

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ env:
   ormolu_version: "0.5.2.0"
   racket_version: "8.7"
   ucm_local_bin: "ucm-local-bin"
-  jit_version: "@unison/internal/releases/0.0.14"
+  jit_version: "@unison/internal/releases/0.0.15"
   jit_src_scheme: "unison-jit-src/scheme-libs/racket"
   jit_dist: "unison-jit-dist"
   jit_generator_os: ubuntu-20.04

--- a/unison-src/transcripts-manual/gen-racket-libs.md
+++ b/unison-src/transcripts-manual/gen-racket-libs.md
@@ -5,7 +5,7 @@ Next, we'll download the jit project and generate a few Racket files from it.
 
 ```ucm
 .> project.create-empty jit-setup
-jit-setup/main> pull @unison/internal/releases/0.0.14 lib.jit
+jit-setup/main> pull @unison/internal/releases/0.0.15 lib.jit
 ```
 
 ```unison

--- a/unison-src/transcripts-manual/gen-racket-libs.output.md
+++ b/unison-src/transcripts-manual/gen-racket-libs.output.md
@@ -20,9 +20,9 @@ Next, we'll download the jit project and generate a few Racket files from it.
   
   🎉 🥳 Happy coding!
 
-jit-setup/main> pull @unison/internal/releases/0.0.14 lib.jit
+jit-setup/main> pull @unison/internal/releases/0.0.15 lib.jit
 
-  Downloaded 15053 entities.
+  Downloaded 15060 entities.
 
   ✅
   


### PR DESCRIPTION
This changes the share dependency for the jit to 0.0.15, which modifies the code the jit uses to validate links for code loading.

The older code had a faulty detection of when it actually had all the information necessary to recompute the links, so instead of telling you that you needed to include more link-code pairs, it would just do the rehash and tell you that some of the links were wrong. The new code correctly reports the actual problem.