### PR TITLE
add `update-in` command

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -937,7 +937,7 @@ loop e = do
               let sr = Slurp.slurpFile uf vars Slurp.AddOp currentNames
               previewResponse sourceName sr uf
             UpdateI optionalPatch requestedNames -> handleUpdate input optionalPatch requestedNames
-            Update2I -> handleUpdate2
+            Update2I optionalPath -> handleUpdate2 optionalPath
             PreviewUpdateI requestedNames -> do
               (sourceName, _) <- Cli.expectLatestFile
               uf <- Cli.expectLatestTypecheckedFile
@@ -1295,7 +1295,8 @@ inputDescription input =
           DefaultPatch -> (" " <>) <$> ps' Cli.defaultPatchPath
           UsePatch p0 -> (" " <>) <$> ps' p0
       pure ("update.old" <> p)
-    Update2I -> pure ("update")
+    Update2I Nothing -> pure ("update")
+    Update2I (Just path) -> ("update-in " <>) <$> p' path
     PropagatePatchI p0 scope0 -> do
       p <- ps' p0
       scope <- p' scope0

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -156,7 +156,7 @@ data Input
   | AddI (Set Name)
   | PreviewAddI (Set Name)
   | UpdateI OptionalPatch (Set Name)
-  | Update2I
+  | Update2I (Maybe Path')
   | PreviewUpdateI (Set Name)
   | TodoI (Maybe PatchPath) Path'
   | PropagatePatchI PatchPath Path'

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -244,8 +244,28 @@ update =
             <> "for your review.",
       parse =
         maybeToEither (I.help update) . \case
-          [] -> Just Input.Update2I
+          [] -> Just (Input.Update2I Nothing)
           _ -> Nothing
+    }
+
+updateIn :: InputPattern
+updateIn =
+  InputPattern
+    { patternName = "update-in",
+      aliases = [],
+      visibility = I.Visible,
+      args = [("namespace", Required, namespaceArg)],
+      help =
+        P.wrap $
+          "Adds everything in the most recently typechecked file to the specified namespace,"
+            <> "replacing existing definitions having the same name, and attempts to update all the existing dependents accordingly. If the process"
+            <> "can't be completed automatically, the dependents will be added back to the scratch file"
+            <> "for your review.",
+      parse = \case
+        [p] -> first P.text do
+          p <- Path.parsePath' p
+          pure . Input.Update2I $ Just p
+        _ -> Left (I.help updateIn)
     }
 
 updateOldNoPatch :: InputPattern
@@ -3043,6 +3063,7 @@ validInputs =
       undo,
       up,
       update,
+      updateIn,
       updateBuiltins,
       updateOld,
       updateOldNoPatch,

--- a/unison-src/transcripts/update-in.md
+++ b/unison-src/transcripts/update-in.md
@@ -1,0 +1,26 @@
+```ucm
+.> project.create-empty update-in
+update-in/main> builtins.merge
+update-in/main> move.namespace builtin lib.builtin
+```
+
+```unison
+foo.x = "five"
+foo.y = x ++ "ty"
+```
+
+```ucm
+update-in/main> add
+```
+
+```unison
+x = "six"
+```
+
+```ucm
+update-in/main> update-in foo
+```
+
+```unison
+> y
+```

--- a/unison-src/transcripts/update-in.md
+++ b/unison-src/transcripts/update-in.md
@@ -1,7 +1,6 @@
 ```ucm
 .> project.create-empty update-in
-update-in/main> builtins.merge
-update-in/main> move.namespace builtin lib.builtin
+update-in/main> builtins.merge lib.builtin
 ```
 
 ```unison

--- a/unison-src/transcripts/update-in.output.md
+++ b/unison-src/transcripts/update-in.output.md
@@ -1,0 +1,104 @@
+```ucm
+.> project.create-empty update-in
+
+  🎉 I've created the project update-in.
+
+  🎨 Type `ui` to explore this project's code in your browser.
+  🔭 Discover libraries at https://share.unison-lang.org
+  📖 Use `help-topic projects` to learn more about projects.
+  
+  Write your first Unison code with UCM:
+  
+    1. Open scratch.u.
+    2. Write some Unison code and save the file.
+    3. In UCM, type `add` to save it to your new project.
+  
+  🎉 🥳 Happy coding!
+
+update-in/main> builtins.merge
+
+  Done.
+
+update-in/main> move.namespace builtin lib.builtin
+
+  Done.
+
+```
+```unison
+foo.x = "five"
+foo.y = x ++ "ty"
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      foo.x : Text
+      foo.y : Text
+
+```
+```ucm
+update-in/main> add
+
+  ⍟ I've added these definitions:
+  
+    foo.x : Text
+    foo.y : Text
+
+```
+```unison
+x = "six"
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      x : Text
+
+```
+```ucm
+update-in/main> update-in foo
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  That's done. Now I'm making sure everything typechecks...
+
+  Everything typechecks, so I'm saving the results...
+
+  Done.
+
+```
+```unison
+> y
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  ✅
+  
+  scratch.u changed.
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    1 | > y
+          ⧩
+          "sixty"
+
+```

--- a/unison-src/transcripts/update-in.output.md
+++ b/unison-src/transcripts/update-in.output.md
@@ -15,11 +15,7 @@
   
   🎉 🥳 Happy coding!
 
-update-in/main> builtins.merge
-
-  Done.
-
-update-in/main> move.namespace builtin lib.builtin
+update-in/main> builtins.merge lib.builtin
 
   Done.
 


### PR DESCRIPTION
## Overview

Adds an `update-in <subnamespace>` command which can be used for saving the scratch file somewhere lower than the current namespace. This is helpful after #4883 which removes the ability to typecheck in one namespace and save definitions in another.

## Implementation notes

It just adds an optional relative path arg to the `Update2I` command.  It's admittedly tricky code, so although I hope I got it right, I could use an audit by @mitchellwrosen.

## Interesting/controversial decisions

## Test coverage

I added a basic transcript, which could be consolidated into a single `update.md` transcript later if we decide to keep this functionality.

## Loose ends

- [x] In creating the transcript, I also wanted a version of `builtins.merge` that takes a destination namespace arg. I have a PR for it, but it's based on trunk so need one more tweak to incorporate it here.