### PR TITLE
Use a socket to communicate with the jit runtime process

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -471,12 +471,20 @@ jobs:
           echo "jit_dist_exe=$jit_dist_exe" >> $GITHUB_ENV
           echo "ucm=$ucm" >> $GITHUB_ENV
 
-      - name: cache jit binaries
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/get-share-hash.sh
+            scheme-libs
+            unison-src/builtin-tests/jit-tests.tpl.md
+            unison-src/transcripts-using-base/serialized-cases/case-00.v4.ser
+
+      - name: cache/restore jit binaries
         id: cache-jit-binaries
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ${{ env.jit_dist }}
-          key: jit_dist-${{ matrix.os }}.racket_${{ env.racket_version }}.jit_${{ env.jit_version }}
+          key: jit_dist-${{ matrix.os }}.racket_${{ env.racket_version }}.jit_${{ env.jit_version }}-${{hashFiles('**/scheme-libs/**')}}
 
       - name: Cache Racket dependencies
         if: steps.cache-jit-binaries.outputs.cache-hit != 'true'
@@ -495,14 +503,6 @@ jobs:
           variant: CS
           version: ${{env.racket_version}}
 
-      - uses: actions/checkout@v4
-        with:
-          sparse-checkout: |
-            scripts/get-share-hash.sh
-            scheme-libs
-            unison-src/builtin-tests/jit-tests.tpl.md
-            unison-src/transcripts-using-base/serialized-cases/case-00.v4.ser
-
       - name: look up hash for runtime tests
         run: |
           echo "runtime_tests_causalhash=$(scripts/get-share-hash.sh ${{env.runtime_tests_version}})" >> $GITHUB_ENV
@@ -512,7 +512,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{env.jit_test_results}}
-          key: jit-test-results.${{ matrix.os }}.racket_${{ env.racket_version }}.jit_${{ env.jit_version }}.tests_${{env.runtime_tests_causalhash}}
+          key: jit-test-results.${{ matrix.os }}.racket_${{ env.racket_version }}.jit_${{ env.jit_version }}-${{hashFiles('**/scheme-libs/**')}}.tests_${{env.runtime_tests_causalhash}}
 
       - name: install libb2 (linux)
         uses: awalsh128/cache-apt-pkgs-action@latest
@@ -546,6 +546,13 @@ jobs:
           raco pkg install --auto --skip-installed "$jit_src_scheme"/unison
           raco exe --embed-dlls "$jit_src_scheme"/unison-runtime.rkt
           raco distribute "$jit_dist" "$jit_exe"
+
+      - name: cache/save jit binaries
+        if: steps.cache-jit-binaries.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.jit_dist }}
+          key: jit_dist-${{ matrix.os }}.racket_${{ env.racket_version }}.jit_${{ env.jit_version }}-${{hashFiles('**/scheme-libs/**')}}
 
       - name: save jit binary
         uses: actions/upload-artifact@v4

--- a/parser-typechecker/src/Unison/Runtime/ANF/Serialize.hs
+++ b/parser-typechecker/src/Unison/Runtime/ANF/Serialize.hs
@@ -962,8 +962,8 @@ serializeGroupForRehash fops (Derived h _) sg =
     f _ = Nothing
     refrep = Map.fromList . mapMaybe f $ groupTermLinks sg
 
-deserializeValue :: ByteString -> Either String Value
-deserializeValue bs = runGetS (getVersion >>= getValue) bs
+getVersionedValue :: MonadGet m => m Value
+getVersionedValue = getVersion >>= getValue
   where
     getVersion =
       getWord32be >>= \case
@@ -972,6 +972,9 @@ deserializeValue bs = runGetS (getVersion >>= getValue) bs
           | n < 3 -> fail $ "deserializeValue: unsupported version: " ++ show n
           | n <= 4 -> pure n
           | otherwise -> fail $ "deserializeValue: unknown version: " ++ show n
+
+deserializeValue :: ByteString -> Either String Value
+deserializeValue bs = runGetS getVersionedValue bs
 
 serializeValue :: Value -> ByteString
 serializeValue v = runPutS (putVersion *> putValue v)

--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -1223,8 +1223,9 @@ tabulateErrors :: Set DecompError -> Error
 tabulateErrors errs | null errs = mempty
 tabulateErrors errs =
   P.indentN 2 . P.lines $
-    "" : P.wrap "The following errors occured while decompiling:"
-       : (listErrors errs)
+    ""
+      : P.wrap "The following errors occured while decompiling:"
+      : (listErrors errs)
 
 restoreCache :: StoredCache -> IO CCache
 restoreCache (SCache cs crs trs ftm fty int rtm rty sbs) =

--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -463,6 +463,8 @@ nativeEval executable ctxVar cl ppe tm = catchInternalErrors $ do
   (ctx, codes) <- loadDeps cl ppe ctx tyrs tmrs
   (ctx, tcodes, base) <- prepareEvaluation ppe tm ctx
   writeIORef ctxVar ctx
+  -- Note: port 0 mean choosing an arbitrary available port.
+  -- We then ask what port was actually chosen.
   listen "127.0.0.1" "0" $ \(serv, _) -> socketPort serv >>= \port ->
     nativeEvalInContext
       executable ppe ctx serv port (codes ++ tcodes) base

--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -1073,7 +1073,7 @@ bugMsg ppe tr name (errs, tm) =
 
 stackTrace :: PrettyPrintEnv -> [(Reference, Int)] -> Pretty ColorText
 stackTrace _ [] = mempty
-stackTrace ppe tr = "Stack trace:\n" <> P.indentN 2 (P.lines $ f <$> tr)
+stackTrace ppe tr = "\nStack trace:\n" <> P.indentN 2 (P.lines $ f <$> tr)
   where
     f (rf, n) = name <> count
       where
@@ -1223,8 +1223,8 @@ tabulateErrors :: Set DecompError -> Error
 tabulateErrors errs | null errs = mempty
 tabulateErrors errs =
   P.indentN 2 . P.lines $
-    P.wrap "The following errors occured while decompiling:"
-      : (listErrors errs)
+    "" : P.wrap "The following errors occured while decompiling:"
+       : (listErrors errs)
 
 restoreCache :: StoredCache -> IO CCache
 restoreCache (SCache cs crs trs ftm fty int rtm rty sbs) =

--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -27,7 +27,7 @@ import Data.Binary.Get (runGetOrFail)
 -- import Data.Bits (shiftL)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BL
-import Data.Bytes.Get (MonadGet, runGetS, getWord8)
+import Data.Bytes.Get (MonadGet, getWord8, runGetS)
 import Data.Bytes.Put (MonadPut, putWord32be, runPutL, runPutS)
 import Data.Bytes.Serial
 import Data.Foldable
@@ -44,7 +44,7 @@ import Data.Set as Set
     (\\),
   )
 import Data.Set qualified as Set
-import Data.Text as Text (isPrefixOf, unpack, pack)
+import Data.Text as Text (isPrefixOf, pack, unpack)
 import GHC.IO.Exception (IOErrorType (NoSuchThing, OtherError, PermissionDenied), IOException (ioe_description, ioe_type))
 import GHC.Stack (callStack)
 import Network.Simple.TCP (Socket, acceptFork, listen, recv, send)
@@ -87,8 +87,8 @@ import Unison.Runtime.ANF as ANF
 import Unison.Runtime.ANF.Rehash as ANF (rehashGroups)
 import Unison.Runtime.ANF.Serialize as ANF
   ( getGroup,
-    putGroup,
     getVersionedValue,
+    putGroup,
     serializeValue,
   )
 import Unison.Runtime.Builtin
@@ -463,9 +463,16 @@ nativeEval executable ctxVar cl ppe tm = catchInternalErrors $ do
   (ctx, codes) <- loadDeps cl ppe ctx tyrs tmrs
   (ctx, tcodes, base) <- prepareEvaluation ppe tm ctx
   writeIORef ctxVar ctx
-  listen "127.0.0.1" "0" $ \(serv, _) -> socketPort serv >>= \port ->
-    nativeEvalInContext
-      executable ppe ctx serv port (codes ++ tcodes) base
+  listen "127.0.0.1" "0" $ \(serv, _) ->
+    socketPort serv >>= \port ->
+      nativeEvalInContext
+        executable
+        ppe
+        ctx
+        serv
+        port
+        (codes ++ tcodes)
+        base
 
 interpEval ::
   ActiveThreads ->
@@ -812,10 +819,12 @@ ucrCompileProc executable args =
     }
 
 receiveAll :: Socket -> IO ByteString
-receiveAll sock = read [] where
-  read acc = recv sock 4096 >>= \case
-    Just chunk -> read (chunk:acc)
-    Nothing -> pure . BS.concat $ reverse acc
+receiveAll sock = read []
+  where
+    read acc =
+      recv sock 4096 >>= \case
+        Just chunk -> read (chunk : acc)
+        Nothing -> pure . BS.concat $ reverse acc
 
 data NativeResult
   = Success Value
@@ -823,13 +832,15 @@ data NativeResult
   | Error Text
 
 deserializeNativeResponse :: ByteString -> NativeResult
-deserializeNativeResponse = run $ getWord8 >>= \case
-  0 -> Success <$> getVersionedValue
-  1 -> Bug <$> getText <*> getVersionedValue
-  2 -> Error <$> getText
-  _ -> pure $ Error "Unexpected result bytes tag"
+deserializeNativeResponse =
+  run $
+    getWord8 >>= \case
+      0 -> Success <$> getVersionedValue
+      1 -> Bug <$> getText <*> getVersionedValue
+      2 -> Error <$> getText
+      _ -> pure $ Error "Unexpected result bytes tag"
   where
-  run e bs = either (Error . pack) id (runGetS e bs)
+    run e bs = either (Error . pack) id (runGetS e bs)
 
 -- Note: this currently does not support yielding values; instead it
 -- just produces a result appropriate for unitary `run` commands. The
@@ -1059,7 +1070,7 @@ bugMsg ppe tr name (errs, tm) =
     ]
 
 stackTrace :: PrettyPrintEnv -> [(Reference, Int)] -> Pretty ColorText
-stackTrace _   [] = mempty
+stackTrace _ [] = mempty
 stackTrace ppe tr = "Stack trace:\n" <> P.indentN 2 (P.lines $ f <$> tr)
   where
     f (rf, n) = name <> count

--- a/scheme-libs/racket/unison-runtime.rkt
+++ b/scheme-libs/racket/unison-runtime.rkt
@@ -160,10 +160,13 @@
     [("-G" "--generate-file")
        file
        "generate code to <file>"
-       (generate-to file)]))
+       (generate-to file)]
+    #:args remaining
+    (list->vector remaining)))
 
 (begin
-  (handle-command-line)
+  (let ([sub-args (handle-command-line)])
+    (current-command-line-arguments sub-args))
   (cond
     [(show-version) (displayln "unison-runtime version 0.0.11")]
     [(generate-to) (do-generate (generate-to))]

--- a/scheme-libs/racket/unison/boot.ss
+++ b/scheme-libs/racket/unison/boot.ss
@@ -78,7 +78,7 @@
   declare-function-link
   declare-code
 
-  exn:bug?
+  (struct-out exn:bug)
   exn:bug->exception
   exception->string
   raise-unison-exception
@@ -568,7 +568,7 @@
          (let ([disp (describe-value f)])
            (raise
              (make-exn:bug
-               (string->chunked-string "builtin.bug")
+               (string->chunked-string "unhandled top level exception")
                disp))))]]))
 
 (begin-encourage-inline

--- a/scheme-libs/racket/unison/primops-generated.rkt
+++ b/scheme-libs/racket/unison/primops-generated.rkt
@@ -46,6 +46,7 @@
   ; some exports of internal machinery for use elsewhere
   gen-code
   reify-value
+  reflect-value
   termlink->name
 
   add-runtime-code

--- a/unison-cli-integration/integration-tests/IntegrationTests/transcript.output.md
+++ b/unison-cli-integration/integration-tests/IntegrationTests/transcript.output.md
@@ -34,9 +34,9 @@ main = do
   I found and typechecked these definitions in scratch.u. If you
   do an `add` or `update`, here's how your codebase would
   change:
-
+  
     ⍟ These new definitions are ok to `add`:
-
+    
       structural ability Break
       type MyBool
       main   : '{IO, Exception} ()
@@ -47,7 +47,7 @@ main = do
 .> add
 
   ⍟ I've added these definitions:
-
+  
     structural ability Break
     type MyBool
     main   : '{IO, Exception} ()

--- a/unison-src/transcripts-using-base/failure-tests.output.md
+++ b/unison-src/transcripts-using-base/failure-tests.output.md
@@ -52,6 +52,7 @@ test2 = do
       (typeLink IOFailure)
       "Cannot decode byte '\\xee': Data.Text.Internal.Encoding.decodeUtf8: Invalid UTF-8 stream"
       (Any ())
+  
   Stack trace:
     ##raise
 
@@ -64,6 +65,7 @@ test2 = do
   The program halted with an unhandled exception:
   
     Failure (typeLink RuntimeFailure) "builtin.bug" (Any "whoa")
+  
   Stack trace:
     ##raise
 

--- a/unison-src/transcripts-using-base/failure-tests.output.md
+++ b/unison-src/transcripts-using-base/failure-tests.output.md
@@ -52,8 +52,6 @@ test2 = do
       (typeLink IOFailure)
       "Cannot decode byte '\\xee': Data.Text.Internal.Encoding.decodeUtf8: Invalid UTF-8 stream"
       (Any ())
-  
-  
   Stack trace:
     ##raise
 
@@ -66,8 +64,6 @@ test2 = do
   The program halted with an unhandled exception:
   
     Failure (typeLink RuntimeFailure) "builtin.bug" (Any "whoa")
-  
-  
   Stack trace:
     ##raise
 

--- a/unison-src/transcripts-using-base/fix2027.output.md
+++ b/unison-src/transcripts-using-base/fix2027.output.md
@@ -92,6 +92,7 @@ myServer = unsafeRun! '(hello "127.0.0.1" "0")
   value:
   
     Failure (typeLink IOFailure) "problem" (Any ())
+  
   Stack trace:
     bug
     #8ppr1tt4q2

--- a/unison-src/transcripts-using-base/fix2027.output.md
+++ b/unison-src/transcripts-using-base/fix2027.output.md
@@ -92,8 +92,6 @@ myServer = unsafeRun! '(hello "127.0.0.1" "0")
   value:
   
     Failure (typeLink IOFailure) "problem" (Any ())
-  
-  
   Stack trace:
     bug
     #8ppr1tt4q2

--- a/unison-src/transcripts/io.output.md
+++ b/unison-src/transcripts/io.output.md
@@ -615,8 +615,6 @@ Calling our examples with the wrong number of args will error.
   The program halted with an unhandled exception:
   
     Failure (typeLink IOFailure) "called with args" (Any ())
-  
-  
   Stack trace:
     ##raise
 
@@ -629,8 +627,6 @@ Calling our examples with the wrong number of args will error.
   The program halted with an unhandled exception:
   
     Failure (typeLink IOFailure) "called with no args" (Any ())
-  
-  
   Stack trace:
     ##raise
 
@@ -644,8 +640,6 @@ Calling our examples with the wrong number of args will error.
   
     Failure
       (typeLink IOFailure) "called with too many args" (Any ())
-  
-  
   Stack trace:
     ##raise
 
@@ -658,8 +652,6 @@ Calling our examples with the wrong number of args will error.
   The program halted with an unhandled exception:
   
     Failure (typeLink IOFailure) "called with no args" (Any ())
-  
-  
   Stack trace:
     ##raise
 

--- a/unison-src/transcripts/io.output.md
+++ b/unison-src/transcripts/io.output.md
@@ -615,6 +615,7 @@ Calling our examples with the wrong number of args will error.
   The program halted with an unhandled exception:
   
     Failure (typeLink IOFailure) "called with args" (Any ())
+  
   Stack trace:
     ##raise
 
@@ -627,6 +628,7 @@ Calling our examples with the wrong number of args will error.
   The program halted with an unhandled exception:
   
     Failure (typeLink IOFailure) "called with no args" (Any ())
+  
   Stack trace:
     ##raise
 
@@ -640,6 +642,7 @@ Calling our examples with the wrong number of args will error.
   
     Failure
       (typeLink IOFailure) "called with too many args" (Any ())
+  
   Stack trace:
     ##raise
 
@@ -652,6 +655,7 @@ Calling our examples with the wrong number of args will error.
   The program halted with an unhandled exception:
   
     Failure (typeLink IOFailure) "called with no args" (Any ())
+  
   Stack trace:
     ##raise
 

--- a/unison-src/transcripts/todo-bug-builtins.output.md
+++ b/unison-src/transcripts/todo-bug-builtins.output.md
@@ -22,8 +22,6 @@
   value:
   
     "implement me later"
-  
-  
   Stack trace:
     todo
     #qe5e1lcfn8
@@ -50,8 +48,6 @@
   value:
   
     "there's a bug in my code"
-  
-  
   Stack trace:
     bug
     #m67hcdcoda

--- a/unison-src/transcripts/todo-bug-builtins.output.md
+++ b/unison-src/transcripts/todo-bug-builtins.output.md
@@ -22,6 +22,7 @@
   value:
   
     "implement me later"
+  
   Stack trace:
     todo
     #qe5e1lcfn8
@@ -48,6 +49,7 @@
   value:
   
     "there's a bug in my code"
+  
   Stack trace:
     bug
     #m67hcdcoda

--- a/unison-src/transcripts/top-level-exceptions.output.md
+++ b/unison-src/transcripts/top-level-exceptions.output.md
@@ -97,6 +97,7 @@ unique type RuntimeError =
   The program halted with an unhandled exception:
   
     Failure (typeLink RuntimeError) "oh noes!" (Any ())
+  
   Stack trace:
     ##raise
 

--- a/unison-src/transcripts/top-level-exceptions.output.md
+++ b/unison-src/transcripts/top-level-exceptions.output.md
@@ -97,8 +97,6 @@ unique type RuntimeError =
   The program halted with an unhandled exception:
   
     Failure (typeLink RuntimeError) "oh noes!" (Any ())
-  
-  
   Stack trace:
     ##raise
 


### PR DESCRIPTION
This reworks the `run.native` command and the racket backing to use a TCP socket for communication of code and results. This makes it possible for `run.native` execution to make use of standard in (previously was occupied by communication of the code to the runtime) and for actual execution results to be reported by ucm.

A little error message tweaking is included. I noticed that a lot of blank lines were being generated in some situations, so I switched to using `linesNonEmpty`.