### PR TITLE
Decompile partially applied builtin functions

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Decompile.hs
+++ b/parser-typechecker/src/Unison/Runtime/Decompile.hs
@@ -155,6 +155,8 @@ decompile backref topTerms (DataC rf (maskTags -> ct) [] bs) =
   apps' (con rf ct) <$> traverse (decompile backref topTerms) bs
 decompile backref topTerms (PApV (CIx rf rt k) [] bs)
   | rf == Builtin "jumpCont" = err Cont $ bug "<Continuation>"
+  | Builtin nm <- rf =
+      apps' (builtin () nm) <$> traverse (decompile backref topTerms) bs
   | Just t <- topTerms rt k =
       Term.etaReduceEtaVars . substitute t
         <$> traverse (decompile backref topTerms) bs

--- a/unison-src/transcripts/fix4780.md
+++ b/unison-src/transcripts/fix4780.md
@@ -1,0 +1,10 @@
+```ucm:hide
+.> builtins.merge
+```
+
+Just a simple test case to see whether partially applied
+builtins decompile properly.
+
+```unison
+> (+) 2
+```

--- a/unison-src/transcripts/fix4780.output.md
+++ b/unison-src/transcripts/fix4780.output.md
@@ -1,0 +1,23 @@
+Just a simple test case to see whether partially applied
+builtins decompile properly.
+
+```unison
+> (+) 2
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  ✅
+  
+  scratch.u changed.
+  
+  Now evaluating any watch expressions (lines starting with
+  `>`)... Ctrl+C cancels.
+
+    1 | > (+) 2
+          ⧩
+          (Nat.+) 2
+
+```


### PR DESCRIPTION
This adds a missing case in the decompiler for when builtin functions get partially applied. Previously the decompiler could only act on defined functions.

Fixes #4780 