### PR TITLE
Deprecate pushing loose code from UCM

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -394,6 +394,7 @@ data Output
   | UpdateIncompleteConstructorSet UpdateOrUpgrade Name (Map ConstructorId Name) (Maybe Int)
   | UpgradeFailure !FilePath !NameSegment !NameSegment
   | UpgradeSuccess !NameSegment !NameSegment
+  | LooseCodePushDeprecated
 
 data UpdateOrUpgrade = UOUUpdate | UOUUpgrade
 
@@ -622,6 +623,7 @@ isFailure o = case o of
   ProjectHasNoReleases {} -> True
   UpgradeFailure {} -> True
   UpgradeSuccess {} -> False
+  LooseCodePushDeprecated -> True
 
 isNumberedFailure :: NumberedOutput -> Bool
 isNumberedFailure = \case

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2223,8 +2223,16 @@ notifyUser dir = \case
         <> P.group (P.text (NameSegment.toEscapedText new) <> ",")
         <> "and removed"
         <> P.group (P.text (NameSegment.toEscapedText old) <> ".")
-  where
-    _nameChange _cmd _pastTenseCmd _oldName _newName _r = error "todo"
+  LooseCodePushDeprecated ->
+    pure . P.warnCallout $
+      P.lines $
+        [ P.wrap $ "Unison Share's projects are now the new preferred way to store code, and storing code outside of a project has been deprecated.",
+          "",
+          P.wrap $ "Learn how to convert existing code into a project using this guide: ",
+          "https://www.unison-lang.org/docs/tooling/projects-library-migration/",
+          "",
+          "Your non-project code is still available to pull from Share, and you can pull it into a local namespace using `pull myhandle.public`"
+        ]
 
 expectedEmptyPushDest :: WriteRemoteNamespace Void -> Pretty
 expectedEmptyPushDest namespace =


### PR DESCRIPTION
## Overview

Working with Loose Code (i.e. code outside of a project) on Share is a slower, worse-organized experience than projects.

The plan is to gracefully deprecate Loose Code to help simplify pushing code to Share by only having a single preferred way to do it, and to simplify the implementation of Share as well.

We want to make sure that users still have access to their Share code in the meantime, but know that it's time to move it into projects, so this change will provide a nice message to the user when they try to push loose code to Share:

<img width="706" alt="image" src="https://github.com/unisonweb/unison/assets/6439644/2ce8af4b-f255-4f62-99d3-3617d0e44139">

Users can still pull code from loose-code.

Loose code READMEs have been ported to a new 'bio' field on the Share user and Simon will be swapping over the UI to use that ASAP :)

## Implementation notes

* Deletes the implementation of pushing code to Share's loose code, replacing it with a nice deprecation message and instructions on how to move forwards.

## Test coverage

Tried it out locally.

## Loose ends

After this is deployed and out for a bit I'll remove the implementation from Share as well.