### PR TITLE
Add docker image to nix outputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -96,6 +96,7 @@
         {
           packages = nixpkgs-packages // {
             haskell-nix = haskell-nix-flake.packages;
+            docker = import ./nix/docker.nix { inherit pkgs; haskell-nix = haskell-nix-flake.packages; };
             build-tools = pkgs.symlinkJoin {
               name = "build-tools";
               paths = self.devShells."${system}".only-tools-nixpkgs.buildInputs;

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -1,16 +1,10 @@
 { pkgs, haskell-nix }:
 
 {
-  ucm = pkgs.dockerTools.buildImage {
+  ucm = pkgs.dockerTools.buildLayeredImage {
     name = "ucm";
     tag = "latest";
-    copyToRoot = pkgs.buildEnv {
-      name = "image-root";
-      paths = [ haskell-nix."unison-cli:exe:unison" ];
-      pathsToLink = [ "/bin" ];
-    };
-    config = {
-      Cmd = [ "/bin/unison" ];
-    };
+    contents = with pkgs; [ cacert fzf ];
+    config.Cmd = [ "${haskell-nix."unison-cli:exe:unison"}/bin/unison" ];
   };
 }

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -1,0 +1,16 @@
+{ pkgs, haskell-nix }:
+
+{
+  ucm = pkgs.dockerTools.buildImage {
+    name = "ucm";
+    tag = "latest";
+    copyToRoot = pkgs.buildEnv {
+      name = "image-root";
+      paths = [ haskell-nix."unison-cli:exe:unison" ];
+      pathsToLink = [ "/bin" ];
+    };
+    config = {
+      Cmd = [ "/bin/unison" ];
+    };
+  };
+}


### PR DESCRIPTION
This adds a nix-based Docker image that includes `ucm` to the outputs of the Nix flake that is already present in this repository. You can build and run it like so:

```
❯ nix build .#docker.ucm

❯ docker load < result
Loaded image: ucm:latest

❯ docker run -it ucm:latest
  I created a new codebase for you at /
  Now starting the Unison Codebase Manager (UCM)...

   _____     _             
  |  |  |___|_|___ ___ ___ 
  |  |  |   | |_ -| . |   |
  |_____|_|_|_|___|___|_|_|
  
  👋 Welcome to Unison!
  
  You are running version: unknown

  📚 Read the official docs at https://www.unison-lang.org/docs/
  
  Type 'project.create' to get started.
.> 

```

@tstat did the initial work and I made a couple of minor changes to add `cacert` (so that fetching base succeeds) and `fzf`. I also made it a layered image, though I'm not sure if that is helpful at all. 