### PR TITLE
Fix duplicate definitions in jit when using scratch files

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Interface.hs
+++ b/parser-typechecker/src/Unison/Runtime/Interface.hs
@@ -31,6 +31,7 @@ import Data.Bytes.Get (MonadGet, getWord8, runGetS)
 import Data.Bytes.Put (MonadPut, putWord32be, runPutL, runPutS)
 import Data.Bytes.Serial
 import Data.Foldable
+import Data.Function (on)
 import Data.IORef
 import Data.List qualified as L
 import Data.Map.Strict qualified as Map
@@ -473,7 +474,7 @@ nativeEval executable ctxVar cl ppe tm = catchInternalErrors $ do
         ctx
         serv
         port
-        (codes ++ tcodes)
+        (L.nubBy ((==) `on` fst) $ tcodes ++ codes)
         base
 
 interpEval ::


### PR DESCRIPTION
This fixes an error that would cause some definitions to be generated twice when jit evaluating with a scratch file.

Essentially, to encounter the problem you'd need to have a definition already in your codebase, _and_ the same definition in your scratch file. If the scratch file were loaded, then the jit would include both the codebase code _and_ the scratch file code in the list of definitions to be compiled. And this would result in racket throwing an error about duplicate definitions.

So, I'm de-duplicating the lists after concatenating them, preferring the scratch file, although I don't think that should actually matter.

This *might* fix some errors that @stew was seeing. I'm not sure if it can be automatically tested, though, because it requires a definition being duplicated between a codebase _and_ a scratch file.