### PR TITLE
Tweak crypto ffi for better dependencies

### DIFF
--- a/scheme-libs/racket/unison/crypto.rkt
+++ b/scheme-libs/racket/unison/crypto.rkt
@@ -21,7 +21,7 @@
         hashBytes
         hmacBytes)))
 
-(define-runtime-path libb2-so '(so "libb2"))
+(define-runtime-path libb2-so '(so "libb2" ("1" #f)))
 
 (define libb2
   (with-handlers [[exn:fail? exn->string]]

--- a/scheme-libs/racket/unison/crypto.rkt
+++ b/scheme-libs/racket/unison/crypto.rkt
@@ -21,16 +21,11 @@
         hashBytes
         hmacBytes)))
 
-(define libcrypto
-    (with-handlers [[exn:fail? exn->string]]
-                   (ffi-lib "libcrypto" openssl-lib-versions)))
-
-(define-runtime-path libb2-so
-  '(so "libb2" ("" "1" #f)))
+(define-runtime-path libb2-so '(so "libb2"))
 
 (define libb2
   (with-handlers [[exn:fail? exn->string]]
-                 (ffi-lib libb2-so)))
+                 (ffi-lib libb2-so '("1" #f))))
 
 (define _EVP-pointer (_cpointer 'EVP))
 


### PR DESCRIPTION
This modifies the jit `crypto.rkt` file a bit w/r/t the dynamic library loading.

- It provides version numbers when calling `ffi-lib` for libb2. I had thought that `define-runtime-path` would yield a result that handles this, because it also takes version numbers. But, it seems that it doesn't.
- I deleted our own `ffi-lib` expression for libcrypto. It _seems_ like it was the same one exported by the racket library we're also depending on, and I _think_ the only problem we had was that not all the functions were imported in the library. The point of this is that hopefully the imported one will correctly use the racket bundled copy of libcrypto instead of any system versions lying around. @aryairani will have to check that, though (because the Linux install just depends on system versions anyway).