### PR TITLE
rename job in ci-test-jit.yaml

### DIFF
--- a/.github/workflows/ci-test-jit.yaml
+++ b/.github/workflows/ci-test-jit.yaml
@@ -17,7 +17,7 @@ defaults:
     shell: bash
 
 jobs:
-  build-jit-binary:
+  run-jit-tests:
     name: test jit
     strategy:
       fail-fast: false


### PR DESCRIPTION
fixes a copy pasta error