### PR TITLE
Add history lines AFTER numbered arg and fzf expansion

### DIFF
--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -13,7 +13,9 @@ import Data.IORef
 import Data.Text qualified as Text
 import Data.Text.IO qualified as Text
 import Ki qualified
+import System.Console.Haskeline (Settings (autoAddHistory))
 import System.Console.Haskeline qualified as Line
+import System.Console.Haskeline.History qualified as Line
 import System.IO (hGetEcho, hPutStrLn, hSetEcho, stderr, stdin)
 import System.IO.Error (isDoesNotExistError)
 import U.Codebase.HashTags (CausalHash)
@@ -102,6 +104,9 @@ getUserInput codebase authHTTPClient currentPath numberedArgs =
           ws -> do
             liftIO (parseInput codebase currentPath numberedArgs IP.patternMap ws) >>= \case
               Left msg -> do
+                -- We still add history that failed to parse so the user can easily reload
+                -- the input and fix it.
+                Line.modifyHistory $ Line.addHistoryUnlessConsecutiveDupe $ l
                 liftIO $ putPrettyLn msg
                 go
               Right Nothing -> do
@@ -109,10 +114,17 @@ getUserInput codebase authHTTPClient currentPath numberedArgs =
                 go
               Right (Just (expandedArgs, i)) -> do
                 when (expandedArgs /= ws) $ do
-                  liftIO . putStrLn $ fullPrompt <> unwords expandedArgs
+                  let expandedArgsStr = unwords expandedArgs
+                  Line.modifyHistory $ Line.addHistoryUnlessConsecutiveDupe $ unwords expandedArgs
+                  liftIO . putStrLn $ fullPrompt <> expandedArgsStr
                 pure i
     settings :: Line.Settings IO
-    settings = Line.Settings tabComplete (Just ".unisonHistory") True
+    settings =
+      Line.Settings
+        { complete = tabComplete,
+          historyFile = Just ".unisonHistory",
+          autoAddHistory = False
+        }
     tabComplete = haskelineTabComplete IP.patternMap codebase authHTTPClient currentPath
 
 main ::

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -104,7 +104,6 @@ getUserInput codebase authHTTPClient currentPath numberedArgs =
           ws -> do
             liftIO (parseInput codebase currentPath numberedArgs IP.patternMap ws) >>= \case
               Left msg -> do
-                liftIO . putStrLn $ "Adding to history: " <> l
                 -- We still add history that failed to parse so the user can easily reload
                 -- the input and fix it.
                 Line.modifyHistory $ Line.addHistoryUnlessConsecutiveDupe $ l

--- a/unison-cli/src/Unison/CommandLine/Main.hs
+++ b/unison-cli/src/Unison/CommandLine/Main.hs
@@ -104,6 +104,7 @@ getUserInput codebase authHTTPClient currentPath numberedArgs =
           ws -> do
             liftIO (parseInput codebase currentPath numberedArgs IP.patternMap ws) >>= \case
               Left msg -> do
+                liftIO . putStrLn $ "Adding to history: " <> l
                 -- We still add history that failed to parse so the user can easily reload
                 -- the input and fix it.
                 Line.modifyHistory $ Line.addHistoryUnlessConsecutiveDupe $ l
@@ -113,10 +114,10 @@ getUserInput codebase authHTTPClient currentPath numberedArgs =
                 -- Ctrl-c or some input cancel, re-run the prompt
                 go
               Right (Just (expandedArgs, i)) -> do
+                let expandedArgsStr = unwords expandedArgs
                 when (expandedArgs /= ws) $ do
-                  let expandedArgsStr = unwords expandedArgs
-                  Line.modifyHistory $ Line.addHistoryUnlessConsecutiveDupe $ unwords expandedArgs
                   liftIO . putStrLn $ fullPrompt <> expandedArgsStr
+                Line.modifyHistory $ Line.addHistoryUnlessConsecutiveDupe $ unwords expandedArgs
                 pure i
     settings :: Line.Settings IO
     settings =


### PR DESCRIPTION
## Overview

fixes #4526 

Quick paper-cut fix so to make it so history contains the actual command that was executed after argument expansion (i.e. fzf or numbered args)

This one's for you @ceedubs 😎 

Before:

```ucm
.> ls
  1. foo
  2. bar
.> edit 1-2
<press up>
.> edit 1-2
```

After:
```
.> ls
  1. foo
  2. bar
.> edit 1-2
<press up>
.> edit foo bar
```

## Implementation notes

* Switch to manual haskeline history management
* Add args AFTER expansion to history

## Test coverage

Unfortunately pretty tough to test since there's no way to list history in a transcript 🤷🏼‍♂️ ;
Luckily it's VERY easy to test manually, and the code change is so simple I wouldn't worry much about it.

## Loose ends

Currently numbered args is often extremely verbose, as it fully hash-qualifies results of things like `find`;
I'll fix that in a separate PR in case it requires some discussion :) 
