### PR TITLE
Fix representation mismatches with jit `bug` messages

### DIFF
--- a/.github/workflows/ci-build-jit-binary.yaml
+++ b/.github/workflows/ci-build-jit-binary.yaml
@@ -54,13 +54,13 @@ jobs:
         with:
           name: jit-source
           path: ${{ env.jit_src }}
-
+      
       - name: cache/restore jit binaries
         id: cache-jit-binaries
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.jit_dist }}
-          key: jit-dist_${{matrix.os}}.racket_${{env.racket_version}}.jit-src_${{hashFiles(format('{0}/**.rkt',env.jit_src),format('{0}/**.ss',env.jit_src))}}.yaml_${{hashFiles('**/ci-build-jit-binary.yaml')}}
+          key: jit-dist_${{matrix.os}}.racket_${{env.racket_version}}.jit-src_${{hashFiles(format('{0}/**/*.rkt',env.jit_src),format('{0}/**/*.ss',env.jit_src))}}.yaml_${{hashFiles('**/ci-build-jit-binary.yaml')}}
 
       - name: cache racket dependencies
         if: steps.cache-jit-binaries.outputs.cache-hit != 'true'
@@ -81,8 +81,18 @@ jobs:
         if: runner.os == 'macOS' && steps.cache-jit-binaries.outputs.cache-hit != 'true'
         run: |
           brew install libb2
-          racket_lib_dir="$(dirname "$(readlink -f "$(which raco)")")/../lib"
-          ln -s "$(brew --prefix)"/lib/libb2.*.dylib "$racket_lib_dir/"
+          brew_lib_dir=$(brew --prefix)/lib
+          racket_lib_dir=$(dirname $(dirname $(readlink -f $(which raco))))/lib
+
+          # link libb2 if not already present/cached
+          for dll in $brew_lib_dir/libb2.*.dylib; do
+            file=$(basename "$dll")
+            if [ ! -e "$racket_lib_dir/$file" ]; then
+              ln -s "$brew_lib_dir/$file" "$racket_lib_dir/$file"
+            else
+              echo "$racket_lib_dir/$file" already exists.
+            fi
+          done
 
       - name: build jit binary
         if: steps.cache-jit-binaries.outputs.cache-hit != 'true'
@@ -104,7 +114,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ${{ env.jit_dist }}
-          key: jit-dist_${{matrix.os}}.racket_${{env.racket_version}}.jit-src_${{hashFiles(format('{0}/**.rkt',env.jit_src),format('{0}/**.ss',env.jit_src))}}.yaml_${{hashFiles('**/ci-build-jit-binary.yaml')}}
+          key: jit-dist_${{matrix.os}}.racket_${{env.racket_version}}.jit-src_${{hashFiles(format('{0}/**/*.rkt',env.jit_src),format('{0}/**/*.ss',env.jit_src))}}.yaml_${{hashFiles('**/ci-build-jit-binary.yaml')}}
 
       - name: save jit binary
         uses: actions/upload-artifact@v4

--- a/scheme-libs/racket/unison/boot.ss
+++ b/scheme-libs/racket/unison/boot.ss
@@ -607,5 +607,5 @@
 (define (exn:bug->exception b)
   (raise-unison-exception
     ref-runtimefailure:typelink
-    (exn:bug-msg b)
+    (string->chunked-string (exn:bug-msg b))
     (exn:bug-val b)))

--- a/scheme-libs/racket/unison/primops.ss
+++ b/scheme-libs/racket/unison/primops.ss
@@ -902,11 +902,13 @@
     (define (unison-POp-LEQT s t) (bool (chunked-string<? s t)))
     (define (unison-POp-EQLU x y) (bool (universal=? x y)))
     (define (unison-POp-EROR fnm x)
-      (let-values ([(p g) (open-string-output-port)])
-        (put-string p (chunked-string->string fnm))
+      (let-values
+        ([(p g) (open-string-output-port)]
+         [(snm) (chunked-string->string fnm)])
+        (put-string p snm)
         (put-string p ": ")
         (display (describe-value x) p)
-        (raise (make-exn:bug fnm x))))
+        (raise (make-exn:bug snm x))))
     (define (unison-POp-FTOT f)
       (define base (number->string f))
       (define dotted

--- a/unison-src/builtin-tests/jit-tests.output.md
+++ b/unison-src/builtin-tests/jit-tests.output.md
@@ -49,3 +49,18 @@ foo = do
   ()
 
 ```
+This can also only be tested by separately running this test, because
+it is exercising the protocol that ucm uses to talk to the jit during
+an exception.
+
+```ucm
+runtime-tests/selected> run.native testBug
+
+  💔💥
+  
+  I've encountered a call to builtin.bug with the following
+  value:
+  
+    "testing"
+
+```

--- a/unison-src/builtin-tests/jit-tests.tpl.md
+++ b/unison-src/builtin-tests/jit-tests.tpl.md
@@ -34,3 +34,11 @@ foo = do
 .> run.native foo
 .> run.native foo
 ```
+
+This can also only be tested by separately running this test, because
+it is exercising the protocol that ucm uses to talk to the jit during
+an exception.
+
+```ucm:error
+runtime-tests/selected> run.native testBug
+```


### PR DESCRIPTION
This fixes some mismatches in the jit with how error messages in `bug` calls were expected to be represented. Some places thought chunked strings, others thought normal strings. This was causing `bug` calls to error out the jit communication in a more severe way than intended.

Fixes #4914
