### PR TITLE
Use full length hashes for jit definition names

### DIFF
--- a/.github/workflows/ci.md
+++ b/.github/workflows/ci.md
@@ -9,7 +9,7 @@ At a high level, the CI process is:
 Some version numbers that are used during CI:
 - `ormolu_version: "0.5.0.1"`
 - `racket_version: "8.7"`
-- `jit_version: "@unison/internal/releases/0.0.15"`
+- `jit_version: "@unison/internal/releases/0.0.16"`
 
 Some cached directories:
   - `ucm_local_bin` a temp path for caching a built `ucm`

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ on:
 env:
   ormolu_version: 0.5.2.0
   ucm_local_bin: ucm-local-bin
-  jit_version: "@unison/internal/releases/0.0.15"
+  jit_version: "@unison/internal/releases/0.0.16"
   jit_src_scheme: unison-jit-src/scheme-libs/racket
   jit_dist: unison-jit-dist
   jit_generator_os: ubuntu-20.04

--- a/scheme-libs/racket/unison/primops-generated.rkt
+++ b/scheme-libs/racket/unison/primops-generated.rkt
@@ -221,10 +221,11 @@
     [(unison-termlink-builtin name)
      (string-append "builtin-" name)]
     [(unison-termlink-derived bs i)
-     (let ([hs (bytevector->base32-string bs #:alphabet 'hex)]
-           [po (if (= i 0) "" (string-append "." (number->string i)))])
+     (let* ([hs (bytevector->base32-string bs #:alphabet 'hex)]
+            [tm (string-trim hs "=" #:repeat? #t)]
+            [po (if (= i 0) "" (string-append "." (number->string i)))])
        (string->symbol
-         (string-append "ref-" (substring hs 0 8) po)))]))
+         (string-append "ref-" tm po)))]))
 
 (define (ref-bytes r)
   (sum-case (decode-ref r)

--- a/unison-src/transcripts-manual/gen-racket-libs.md
+++ b/unison-src/transcripts-manual/gen-racket-libs.md
@@ -5,7 +5,7 @@ Next, we'll download the jit project and generate a few Racket files from it.
 
 ```ucm
 .> project.create-empty jit-setup
-jit-setup/main> pull @unison/internal/releases/0.0.15 lib.jit
+jit-setup/main> pull @unison/internal/releases/0.0.16 lib.jit
 ```
 
 ```unison

--- a/unison-src/transcripts-manual/gen-racket-libs.output.md
+++ b/unison-src/transcripts-manual/gen-racket-libs.output.md
@@ -20,9 +20,9 @@ Next, we'll download the jit project and generate a few Racket files from it.
   
   🎉 🥳 Happy coding!
 
-jit-setup/main> pull @unison/internal/releases/0.0.15 lib.jit
+jit-setup/main> pull @unison/internal/releases/0.0.16 lib.jit
 
-  Downloaded 15060 entities.
+  Downloaded 15091 entities.
 
   ✅
   


### PR DESCRIPTION
This should avoid any possibility of picking conflicting names for distinct functions. I'm not aware of any actual examples of this, but it could in principle happen.

I decided to use the full length hashes because picking just-long-enough names starts to become very cumbersome when doing dynamic loading. You need to keep track of all your past choices, not just the choices for the module you're loading, because the one you're loading could refer to things in previously loaded modules. It would be possible to use shorter names in a compile-time context, since you have all the names up front. But you'd still have to remember _those_ for runtime loading, and it seemed not worth it.

This doesn't include any custom error formatting, because I'd like to see error messages I get randomly before doing anything, but if they're too verbose, it's possible to override the Racket error reporting to produce shorter names there, rather than generating them up front.
