### PR TITLE
Add codeowners for github meta files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Require approval from ucm team when editing repository workflows
+# This helps prevent users from sneaking in malicious changes to CI workflows.
+/.github/ @unisonweb/ucm


### PR DESCRIPTION
## Overview

Proposal to add a CODEOWNERS just for our `.github` subdir, which will require that someone on the ucm team reviews any changes to our CI files; hopefully preventing anyone from sneakily adding malicious code wo our builds which would have access to our github tokens and such. This is a recommended measure in [Github Actions' security manual](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-codeowners-to-monitor-changes) 

## Implementation notes

* Specify `@unisonweb/ucm` as the codeowners of `/.github/`

If we want to go ahead with this I think we just need to add `@unisonweb/ucm` as having **write access** to this repo (see error in the diff)

This requires approval from a member of that team (currently myself, Arya and Mitchell) to make changes to that folder.