### PR TITLE
Create UCM docker image

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -23,6 +23,14 @@ jobs:
     with:
       ref: ${{ github.ref }}
 
+  build-docker-image:
+    name: build ucm docker image
+    uses: ./.github/workflows/ucm-docker-image.yaml
+    needs:
+      - bundle-ucm
+    with:
+      is_release: false
+
   release:
     name: create release
     runs-on: ubuntu-20.04

--- a/.github/workflows/ucm-docker-image.yaml
+++ b/.github/workflows/ucm-docker-image.yaml
@@ -1,72 +1,30 @@
-name: release
+name: build and push ucm docker image
 
-run-name: release ${{inputs.version}}
-
-defaults:
-  run:
-    shell: bash
+# Build docker image containing ucm executable
+# Push to the github docker image repo (a.k.a. 'packages')
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       version:
-        description: Release version; e.g. `0.5.19`. We'll create tag `release/${version}`.
-        required: true
+        description: Semver version of the release. E.g. 0.5.19
         type: string
+        required: false
+      is_release:
+        description: Whether this is a release build.
+        type: boolean
+        required: false
+        default: false
 
 jobs:
-  bundle-ucm:
-    name: build and bundle ucm
-    uses: ./.github/workflows/bundle-ucm.yaml
-    with:
-      ref: ${{github.ref}}
-
-  build-docker-image:
-    name: build ucm docker image
-    uses: ./.github/workflows/ucm-docker-image.yaml
-    needs:
-      - bundle-ucm
-    with:
-      version: ${{inputs.version}}
-      is_release: true
-
-  release:
-    name: create release
+  docker-image:
+    name: Build and push ucm docker image
     runs-on: ubuntu-20.04
-    needs:
-      - bundle-ucm
-
     steps:
-      - name: make download dir
-        run: mkdir /tmp/ucm
-
-      - name: "download artifacts"
+      - name: Download ucm executable and ucm UI
         uses: actions/download-artifact@v4
         with:
           path: /tmp/ucm
-
-      - name: Create Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          prev_tag="$( \
-            gh release view \
-              --repo unisonweb/unison \
-              --json tagName -t '{{printf .tagName}}' \
-          )"
-          if [ -z "$prev_tag" ]; then echo "No previous release found"; exit 1; fi
-
-          echo "Creating a release from these artifacts:"
-          ls -R /tmp/ucm/**/ucm-*.{zip,tar.gz}
-
-          gh release create "release/${{inputs.version}}" \
-            --repo unisonweb/unison \
-            --target "${{github.ref}}" \
-            --generate-notes \
-            --notes-start-tag "${prev_tag}" \
-            \
-            /tmp/ucm/**/ucm-*.{zip,tar.gz}
-
 
       # Configure Docker's builder,
       # This seems necessary to support docker cache layers.
@@ -87,12 +45,19 @@ jobs:
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: ${{ env.container_registry }}/${{ env.docker_image_name }}
+          flavor: |
+            # We tag latest manually below.
+            latest=false
           tags: |
-            type=schedule
-            type=ref,event=branch
+            type=schedule,pattern={{date 'YYYY-MM-DD'}}
+            type=raw,value=v${{ inputs.version }},enable=${{ github.event.inputs.is_release }}
             type=ref,event=tag
-            type=ref,event=pr
+            type=ref,event=push
             type=sha,format=long
+            type=raw,tag=${{ inputs.image_tag }}
+            # set latest tag for pushes to trunk
+            type=raw,value=latest,enable=${{ github.event.inputs.is_release }}
+            type=raw,value=nightly,enable=${{ !github.event.inputs.is_release }}
 
 
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
@@ -103,14 +68,9 @@ jobs:
         uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
         with:
           context: ./docker/
-          push: ${{ env.is_published_build }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Use github actions cache for docker image layers
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: |
-            SHARE_COMMIT=${{ github.sha }}
-          # Save image locally for use in tests even if we don't push it.
-          outputs: type=docker,dest=/tmp/share-docker-image.tar # export docker image
-

--- a/.github/workflows/ucm-docker-image.yaml
+++ b/.github/workflows/ucm-docker-image.yaml
@@ -16,15 +16,47 @@ on:
         required: false
         default: false
 
+  push:
+    branches:
+      - cp/test-ucm-docker-image
+
 jobs:
   docker-image:
     name: Build and push ucm docker image
     runs-on: ubuntu-20.04
+
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      # Allow uploading the docker image to the container registry
+      packages: write
+      # Allow creating and updating the artifact attestation
+      attestations: write
+      # Required to get user information for building attestations
+      id-token: write
+
+    env:
+      container_registry: ghcr.io
+      docker_image_name: ${{ github.repository }}
+
+
     steps:
+      - uses: actions/checkout@v4
+
       - name: Download ucm executable and ucm UI
         uses: actions/download-artifact@v4
         with:
-          path: /tmp/ucm
+          name: bundle-linux
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: 8975410616
+          path: ./tmp/downloads
+
+      - name: Unpack ucm bundle tar
+        run: |
+          ls -lah ./tmp/downloads
+          mkdir -p ./tmp/ucm
+          tar -xvf ./tmp/downloads/ucm-*.tar.gz -C ./tmp/ucm
+          ls -lah ./tmp/ucm
 
       # Configure Docker's builder,
       # This seems necessary to support docker cache layers.
@@ -49,15 +81,13 @@ jobs:
             # We tag latest manually below.
             latest=false
           tags: |
-            type=schedule,pattern={{date 'YYYY-MM-DD'}}
-            type=raw,value=v${{ inputs.version }},enable=${{ github.event.inputs.is_release }}
+            type=schedule
+            type=raw,value=v0.5.19,enable=true
             type=ref,event=tag
-            type=ref,event=push
             type=sha,format=long
-            type=raw,tag=${{ inputs.image_tag }}
             # set latest tag for pushes to trunk
-            type=raw,value=latest,enable=${{ github.event.inputs.is_release }}
-            type=raw,value=nightly,enable=${{ !github.event.inputs.is_release }}
+            type=raw,value=latest,enable=true
+            type=raw,value=nightly,enable=false
 
 
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
@@ -67,7 +97,8 @@ jobs:
         id: push
         uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
         with:
-          context: ./docker/
+          context: ./
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,15 +9,14 @@ RUN apt-get update                                           && \
     update-locale LANG=en_US.UTF-8
 
 
-COPY tmp/ucm/ucm /usr/local/bin/ucm
-COPY tmp/ucm/ui  /usr/local/share/ucm
+COPY tmp/ucm/ /usr/local/bin/ucm/
 
 ENV UCM_WEB_UI=/usr/local/share/ucm
 ENV UCM_PORT=8080
 ENV UCM_TOKEN=pub
 
-RUN chmod 555 /usr/local/bin/ucm
+RUN chmod 555 /usr/local/bin/ucm/ucm
 
 EXPOSE 8080
-ENTRYPOINT ["/usr/local/bin/ucm"]
+ENTRYPOINT ["/usr/local/bin/ucm/ucm"]
 CMD ["--codebase-create","/codebase"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ RUN chmod 555 /usr/local/bin/ucm
 
 EXPOSE 8080
 ENTRYPOINT ["/usr/local/bin/ucm"]
-CMD ["--codebase","/unison"]
+CMD ["--codebase-create","/codebase"]


### PR DESCRIPTION
Adds a docker image for folks to quickly and easily try UCM without installing it on their machine.

Unfortunately this isn't working for some reason, when I run the image I get:

```
/usr/local/bin/ucm/ucm: line 2:    15 Killed                  "$(dirname "$0")/unison/unison" --runtime-path "$(dirname "$0")/runtime/bin/unison-runtime" "$@"
```

Not sure if it's a mac codesigning thing or some other arcane thing.

Uploads to our Github Packages repo here:

https://github.com/unisonweb/unison/pkgs/container/unison

TODO:

Once we're happy with it we need to make the image public, which I may need help to do, here's what I see:

<img width="506" alt="image" src="https://github.com/unisonweb/unison/assets/6439644/a7cfff86-cc8f-4220-83ac-4229488f5382">

## Implementation notes

* Adds a new job which builds and pushes a docker image
* Call that job from pre-release and release, assigning `latest`, `vx.y.z`, and `nightly` tags as expected
* It's a multi-platform image, so should work on mac M1

Folks may want to docker run exposing port `8080` so they can use the UI, though I doubt `ucm ui` will work since xdg-open is in the container.

## Test coverage

Nope

## Loose ends

