### PR TITLE
Add LSP documentation for Emacs

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -82,3 +82,4 @@ The format for this list: name, GitHub handle
 * Kyle Goetz (@kylegoetz)
 * Ethan Morgan (@sixfourtwelve)
 * Johan Winther (@JohanWinther)
+* Greg Pfeil (@sellout)

--- a/docs/language-server.markdown
+++ b/docs/language-server.markdown
@@ -4,9 +4,11 @@
 
 * [Overview](#overview)
 * [Installation and setup](#installation-and-setup)
-  * [Settings](#settings)
   * [NeoVim](#neovim)
   * [VSCode](#vscode)
+  • [Helix Editor](#helix-editor)
+  * [other editors](#other-editors)
+* [Configuration](#configuration)
 
 ## Overview
 
@@ -31,7 +33,7 @@ Note for Windows users: Due to an outstanding issue with GHC's IO manager on Win
 Enabling the LSP on windows can cause UCM to hang on exit and may require the process to be killed by the operating system or via Ctrl-C.
 Note that this doesn't pose any risk of codebase corruption or cause any known issues, it's simply an annoyance.
 
-If you accept this annoyance, you can enable the LSP server on Windows by exporting the `UNISON_LSP_ENABLED=true` environment variable. 
+If you accept this annoyance, you can enable the LSP server on Windows by exporting the `UNISON_LSP_ENABLED=true` environment variable.
 
 You can set this persistently in powershell using:
 
@@ -40,17 +42,6 @@ You can set this persistently in powershell using:
 ```
 
 See [this issue](https://github.com/unisonweb/unison/issues/3487) for more details.
-
-### Settings
-
-Supported settings and their defaults. See information for your language server client about where to provide these.
-
-```json
-{
-  // A suggestion for the formatter about how wide (in columns) to print definitions.
-  "formattingWidth": 80
-}
-```
 
 ### NeoVim
 
@@ -207,6 +198,9 @@ Supported settings and their defaults. See information for your language server 
 
 ```json
 {
+  // A suggestion for the formatter about how wide (in columns) to print definitions.
+  "formattingWidth": 80,
+
   // The number of completions the server should collect and send based on a single query.
   // Increasing this limit will provide more completion results, but at the cost of being slower to respond.
   // If explicitly set to `null` the server will return ALL completions available.

--- a/docs/language-server.markdown
+++ b/docs/language-server.markdown
@@ -209,14 +209,14 @@ Note that some editors require passing the command and arguments as separate par
 
 Supported settings and their defaults. See information for your language server client about where to provide these.
 
+* `formattingWidth`: A suggestion for the formatter about how wide (in columns) to print definitions.
+* `maxCompletions`: The number of completions the server should collect and send based on a single query.  Increasing this limit will provide more completion results, but at the cost of being slower to respond.
+
+    If explicitly set to `null` the server will return ALL completions available.
+
 ```json
 {
-  // A suggestion for the formatter about how wide (in columns) to print definitions.
   "formattingWidth": 80,
-
-  // The number of completions the server should collect and send based on a single query.
-  // Increasing this limit will provide more completion results, but at the cost of being slower to respond.
-  // If explicitly set to `null` the server will return ALL completions available.
   "maxCompletions": 100
 }
 ```

--- a/docs/language-server.markdown
+++ b/docs/language-server.markdown
@@ -196,6 +196,8 @@ In Emacs 29 (or earlier, if you install the [Eglot](https://elpa.gnu.org/package
 
 This requires having either [unison-ts-mode](https://github.com/fmguerreiro/unison-ts-mode) or [unisonlang-mode](https://melpa.org/#/unisonlang-mode) installed. unison-ts-mode is newer, supported, and more complete, but isn’t in [MELPA](https://melpa.org/) yet and requires a couple commands to set up [tree-sitter-unison](https://github.com/kylegoetz/tree-sitter-unison).
 
+You can then use `M-x eglot` in a Unison scratch file buffer. You can also [configure Eglot to start automatically](https://www.gnu.org/software/emacs/manual/html_node/eglot/Starting-Eglot.html).
+
 ### Other Editors
 
 If your editor provides a mechanism for connecting to a host and port, provide a host of `127.0.0.1` and port `5757`.

--- a/docs/language-server.markdown
+++ b/docs/language-server.markdown
@@ -6,7 +6,8 @@
 * [Installation and setup](#installation-and-setup)
   * [NeoVim](#neovim)
   * [VSCode](#vscode)
-  • [Helix Editor](#helix-editor)
+  * [Helix Editor](#helix-editor)
+  * [Emacs](#emacs)
   * [other editors](#other-editors)
 * [Configuration](#configuration)
 
@@ -184,6 +185,16 @@ language-servers = [ "ucm" ]
 
 or follow the instructions for Unison in "[How to install the default language servers](https://github.com/helix-editor/helix/wiki/How-to-install-the-default-language-servers#unison)" wiki page.
 
+### Emacs
+
+In Emacs 29 (or earlier, if you install the [Eglot](https://elpa.gnu.org/packages/eglot.html) package), add the following to your init file:
+
+```elisp
+(push '((unison-ts-mode unisonlang-mode) "127.0.0.1" 5757)
+      eglot-server-programs)
+```
+
+This requires having either [unison-ts-mode](https://github.com/fmguerreiro/unison-ts-mode) or [unisonlang-mode](https://melpa.org/#/unisonlang-mode) installed. unison-ts-mode is newer, supported, and more complete, but isn’t in [MELPA](https://melpa.org/) yet and requires a couple commands to set up [tree-sitter-unison](https://github.com/kylegoetz/tree-sitter-unison).
 
 ### Other Editors
 


### PR DESCRIPTION
## Overview

Documents how to configure Unison LSP on Emacs.

## Interesting/controversial decisions

This only documents Eglot usage, not lsp-mode. Eglot is much simpler and is included with Emacs as of Emacs 29.