### PR TITLE
Repair the Nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,7 @@ dist-newstyle
 
 # Mac developers
 **/.DS_Store
-
 /libb2.dylib
+
+# Nix
+result

--- a/development.markdown
+++ b/development.markdown
@@ -126,9 +126,9 @@ This is specified with the normal
 
 Some examples:
 ```
-nix build '.#haskell-nix.unison-cli:lib:unison-cli'
-nix build '.#haskell-nix.unison-syntax:test:syntax-tests'
-nix build '.#haskell-nix.unison-cli:exe:transcripts'
+nix build '.#component-unison-cli:lib:unison-cli'
+nix build '.#component-unison-syntax:test:syntax-tests'
+nix build '.#component-unison-cli:exe:transcripts'
 ```
 
 ### Development environments
@@ -154,7 +154,7 @@ all non-local haskell dependencies (including profiling dependencies)
 are provided in the nix shell.
 
 ```
-nix develop '.#haskell-nix.local'
+nix develop '.#cabal-local'
 ```
 
 #### Get into a development environment for building a specific package
@@ -164,17 +164,17 @@ all haskell dependencies of this package are provided by the nix shell
 (including profiling dependencies).
 
 ```
-nix develop '.#haskell-nix.<package-name>'
+nix develop '.#cabal-<package-name>'
 ```
 
 for example:
 
 ```
-nix develop '.#haskell-nix.unison-cli'
+nix develop '.#cabal-unison-cli'
 ```
 or
 ```
-nix develop '.#haskell-nix.unison-parser-typechecker'
+nix develop '.#cabal-unison-parser-typechecker'
 ```
 
 This is useful if you wanted to profile a package. For example, if you
@@ -183,7 +183,7 @@ shells, cd into its directory, then run the program with
 profiling.
 
 ```
-nix develop '.#unison-parser-typechecker'
+nix develop '.#cabal-unison-parser-typechecker'
 cd unison-cli
 cabal run --enable-profiling unison-cli-main:exe:unison -- +RTS -p
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -88,6 +88,10 @@
               '';
             };
           };
+
+          renameAttrs = fn: nixpkgs.lib.mapAttrs' (name: value: {
+            inherit value;
+            name = fn name;});
         in
         assert nixpkgs-packages.ormolu.version == versions.ormolu;
         assert nixpkgs-packages.hls.version == versions.hls;
@@ -96,8 +100,8 @@
         {
           packages =
             nixpkgs-packages
-            // haskell-nix-flake.packages
-            // import ./nix/docker.nix { inherit pkgs; haskell-nix = haskell-nix-flake.packages; }
+            // renameAttrs (name: "component-${name}") haskell-nix-flake.packages
+            // renameAttrs (name: "docker-${name}") (import ./nix/docker.nix { inherit pkgs; haskell-nix = haskell-nix-flake.packages; })
             // {
               default = haskell-nix-flake.defaultPackage;
               build-tools = pkgs.symlinkJoin {
@@ -119,13 +123,13 @@
               };
             };
 
-          apps = haskell-nix-flake.apps // {
-            default = self.apps."${system}"."unison-cli-main:exe:unison";
+          apps = renameAttrs (name: "component-${name}") haskell-nix-flake.apps // {
+            default = self.apps."${system}"."component-unison-cli-main:exe:unison";
           };
 
           devShells =
             nixpkgs-devShells
-            // haskell-nix-flake.devShells
+            // renameAttrs (name: "cabal-${name}") haskell-nix-flake.devShells
             // {
               default = self.devShells."${system}".only-tools-nixpkgs;
             };

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -5,6 +5,6 @@
     name = "ucm";
     tag = "latest";
     contents = with pkgs; [ cacert fzf ];
-    config.Cmd = [ "${haskell-nix."unison-cli:exe:unison"}/bin/unison" ];
+    config.Cmd = [ "${haskell-nix."unison-cli-main:exe:unison"}/bin/unison" ];
   };
 }


### PR DESCRIPTION
## Overview

This does the minimum to get `nix flake check` working.

The primary issue is that the standard flake outputs require flat package sets, and this flake produced nested ones.

Fixes #4940.

## Implementation notes

This merges package sets into a single one rather than making them separate entries in the outputs.

The only other change was to correct the attribute name used for the UCM docker image’s command.

## Interesting/controversial decisions

This currently flattens the package sets and adds prefixes to them, for some conceptual groupings. The prefixes could be removed, though.

Also, if we wanted to maintain some of the nesting, we could use the `legacyPackages` output, but that is (as it says) legacy, and either way it’s breaking the names, so we might as well just adopt the current flat style.