### PR TITLE
Fixing Invisible text colour on popular themes

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -82,3 +82,4 @@ The format for this list: name, GitHub handle
 * Kyle Goetz (@kylegoetz)
 * Ethan Morgan (@sixfourtwelve)
 * Johan Winther (@JohanWinther)
+* Upendra Upadhyay (@upendra1997)

--- a/lib/unison-pretty-printer/src/Unison/Util/ColorText.hs
+++ b/lib/unison-pretty-printer/src/Unison/Util/ColorText.hs
@@ -173,7 +173,7 @@ defaultColors :: ST.Element r -> Maybe Color
 defaultColors = \case
   ST.NumericLiteral -> Nothing
   ST.TextLiteral -> Nothing
-  ST.BytesLiteral -> Just HiBlack
+  ST.BytesLiteral -> Just HiPurple
   ST.CharLiteral -> Nothing
   ST.BooleanLiteral -> Nothing
   ST.Blank -> Nothing
@@ -182,21 +182,21 @@ defaultColors = \case
   ST.TermReference _ -> Nothing
   ST.Op _ -> Nothing
   ST.Unit -> Nothing
-  ST.AbilityBraces -> Just HiBlack
-  ST.ControlKeyword -> Just Bold
-  ST.LinkKeyword -> Just HiBlack
-  ST.TypeOperator -> Just HiBlack
+  ST.AbilityBraces -> Just HiPurple
+  ST.ControlKeyword -> Just HiCyan
+  ST.LinkKeyword -> Just HiPurple
+  ST.TypeOperator -> Just HiPurple
   ST.BindingEquals -> Nothing
   ST.TypeAscriptionColon -> Just Blue
   ST.DataTypeKeyword -> Nothing
   ST.DataTypeParams -> Nothing
   ST.DataTypeModifier -> Nothing
-  ST.UseKeyword -> Just HiBlack
-  ST.UsePrefix -> Just HiBlack
-  ST.UseSuffix -> Just HiBlack
-  ST.HashQualifier _ -> Just HiBlack
+  ST.UseKeyword -> Just HiPurple
+  ST.UsePrefix -> Just HiPurple
+  ST.UseSuffix -> Just HiPurple
+  ST.HashQualifier _ -> Just HiPurple
   ST.DelayForceChar -> Just Yellow
   ST.DelimiterChar -> Nothing
   ST.Parenthesis -> Nothing
   ST.DocDelimiter -> Just Green
-  ST.DocKeyword -> Just Bold
+  ST.DocKeyword -> Just HiCyan


### PR DESCRIPTION
## Overview

This fixes: #4510 The issue where the some ansi colours are not properly/barely visible, because of having same background colour.

## Implementation notes
It uses `HiCyan` & `HiPurple` instead of `Bold` & `HiDark`.

## Interesting/controversial decisions

Decided to use `HiPurple` for darker shades i.e. `HiBlack`

used `HiCyan` for `Bold`, only because it doesn't look good on gruvbox theme, on rest of the themes it looks good.

Themes tried:
1. Solarized
2. Monokai
3. Gruvbox
4. Nord
5. Dracula
6. Tomorrow Night

## Test coverage
All tests are passing and tested manually by going through few of the themes and seeing if text is properly visible.
<img width="560" alt="Screenshot 2024-05-09 at 1 26 13 AM" src="https://github.com/unisonweb/unison/assets/15128425/a090482f-1a8c-4408-8f12-3a927252a6c4">
<img width="560" alt="Screenshot 2024-05-09 at 1 28 29 AM" src="https://github.com/unisonweb/unison/assets/15128425/22891ebc-8ecd-4b41-a514-44b23f1fdee1">
<img width="560" alt="Screenshot 2024-05-09 at 1 28 11 AM" src="https://github.com/unisonweb/unison/assets/15128425/7238ce70-6d3f-45b7-b40b-921db3b3d60f">
<img width="560" alt="Screenshot 2024-05-09 at 1 27 52 AM" src="https://github.com/unisonweb/unison/assets/15128425/8844fe5c-04f7-40f3-9e51-d60782fa6aaf">
<img width="560" alt="Screenshot 2024-05-09 at 1 27 45 AM" src="https://github.com/unisonweb/unison/assets/15128425/a49ac5cf-955f-49d0-90cb-e54de4a19761">
<img width="560" alt="Screenshot 2024-05-09 at 1 27 26 AM" src="https://github.com/unisonweb/unison/assets/15128425/0dca69b6-6991-4999-9af2-3f261262adc3">
<img width="560" alt="Screenshot 2024-05-09 at 1 26 53 AM" src="https://github.com/unisonweb/unison/assets/15128425/b36ad794-d45f-41f9-b441-a5d6a7da5f51">
<img width="560" alt="Screenshot 2024-05-09 at 1 26 44 AM" src="https://github.com/unisonweb/unison/assets/15128425/0d853b5b-9775-41f1-802c-966fd6381ac2">
<img width="560" alt="Screenshot 2024-05-09 at 1 26 34 AM" src="https://github.com/unisonweb/unison/assets/15128425/3f3493d2-6b56-467b-b977-f869e5fc24ce">
<img width="560" alt="Screenshot 2024-05-09 at 1 26 27 AM" src="https://github.com/unisonweb/unison/assets/15128425/702f66b5-4ff9-4847-b041-0edbc4d4606c">


## Loose ends

I tried to use [getLayerColor](https://hackage.haskell.org/package/ansi-terminal-1.1.1/docs/System-Console-ANSI.html#g:35) `Foreground` and `Background`, to dynamically select color based on existing themes, but I was always getting `Nothing` from the function. 
followed these [examles](https://github.com/UnkindPartition/ansi-terminal/blob/master/ansi-terminal/app/Example.hs#L473) apis for code.
