### PR TITLE
docs.to-tml: Add space between Paragraph elements

### DIFF
--- a/unison-share-api/src/Unison/Server/Doc/AsHtml.hs
+++ b/unison-share-api/src/Unison/Server/Doc/AsHtml.hs
@@ -9,11 +9,11 @@ import Control.Monad.Writer.Class qualified as Writer
 import Control.Monad.Writer.Lazy (runWriterT)
 import Data.Char qualified as Char
 import Data.Foldable
+import Data.List (intersperse)
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe
 import Data.Sequence (Seq)
-import Data.List (intersperse)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Lucid
@@ -358,8 +358,8 @@ toHtml docNamesByRef document =
                 [d] ->
                   currentSectionLevelToHtml d
                 ds ->
-                  span_ [class_ "span"] <$>
-                  (renderSequence currentSectionLevelToHtml  (intersperse (Word " ")  (mergeWords " " ds)))
+                  span_ [class_ "span"]
+                    <$> (renderSequence currentSectionLevelToHtml (intersperse (Word " ") (mergeWords " " ds)))
             BulletedList items ->
               let itemToHtml i =
                     li_ [] <$> currentSectionLevelToHtml i

--- a/unison-share-api/src/Unison/Server/Doc/AsHtml.hs
+++ b/unison-share-api/src/Unison/Server/Doc/AsHtml.hs
@@ -13,6 +13,7 @@ import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe
 import Data.Sequence (Seq)
+import Data.List (intersperse)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Lucid
@@ -357,7 +358,8 @@ toHtml docNamesByRef document =
                 [d] ->
                   currentSectionLevelToHtml d
                 ds ->
-                  span_ [class_ "span"] <$> renderSequence currentSectionLevelToHtml (mergeWords " " ds)
+                  span_ [class_ "span"] <$>
+                  (renderSequence currentSectionLevelToHtml  (intersperse (Word " ")  (mergeWords " " ds)))
             BulletedList items ->
               let itemToHtml i =
                     li_ [] <$> currentSectionLevelToHtml i


### PR DESCRIPTION
This fixes an issue where sub elements of a Paragraph doesn't have a literal space between them after using the `mergeWords` function. Previously this was fixed with CSS margin, but that doesn't work well for copy and paste, instead intersperse a space (" ") between the
  elements, similar to the ui-core method.