### PR TITLE
Add a `default` Nix package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -95,6 +95,7 @@
         assert nixpkgs-packages.hpack.version == versions.hpack;
         {
           packages = nixpkgs-packages // {
+            default = haskell-nix-flake.defaultPackage;
             haskell-nix = haskell-nix-flake.packages;
             docker = import ./nix/docker.nix { inherit pkgs; haskell-nix = haskell-nix-flake.packages; };
             build-tools = pkgs.symlinkJoin {


### PR DESCRIPTION
## Overview

development.markdown says to use `nix build` to build the `unison` executable, but it doesn’t work, because there is not a `default` package. This makes the behavior match the docs.