### PR TITLE
feat: add optional argument to `test` command

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -299,6 +299,8 @@ data PushRemoteBranchInput = PushRemoteBranchInput
 data TestInput = TestInput
   { -- | Should we run tests in the `lib` namespace?
     includeLibNamespace :: Bool,
+    -- | Relative path to run the tests in. Ignore if `includeLibNamespace` is True - that means test everything.
+    path :: Path,
     showFailures :: Bool,
     showSuccesses :: Bool
   }

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2395,7 +2395,7 @@ test =
       help =
         P.wrapColumn2
           [ ("`test`", "runs unit tests for the current branch"),
-            ("`test foo`", "runts unit tests for the current branch defined in namespace `foo`")
+            ("`test foo`", "runs unit tests for the current branch defined in namespace `foo`")
           ],
       parse = \args ->
         maybe (Left (I.help test)) Right do

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2393,8 +2393,10 @@ test =
       visibility = I.Visible,
       args = [("namespace", Optional, namespaceArg)],
       help =
-        case wundefined of
-          _ -> "`test` runs unit tests for the current branch.",
+        P.wrapColumn2
+          [ ("`test`", "runs unit tests for the current branch"),
+            ("`test foo`", "runts unit tests for the current branch defined in namespace `foo`")
+          ],
       parse = \args ->
         maybe (Left (I.help test)) Right do
           path <-
@@ -2529,11 +2531,11 @@ ioTestAll =
     { patternName = "io.test.all",
       aliases = ["test.io.all"],
       visibility = I.Visible,
-      args = case wundefined of { _ -> [] },
+      args = [],
       help =
         P.wrapColumn2
           [ ( "`io.test.all`",
-              "Runs all tests which use IO within the scope of the current namespace."
+              "runs unit tests for the current branch that use IO"
             )
           ],
       parse = \case

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2388,20 +2388,29 @@ debugNameDiff =
 test :: InputPattern
 test =
   InputPattern
-    "test"
-    []
-    I.Visible
-    []
-    "`test` runs unit tests for the current branch."
-    ( const $
-        pure $
-          Input.TestI
-            Input.TestInput
-              { includeLibNamespace = False,
-                showFailures = True,
-                showSuccesses = True
-              }
-    )
+    { patternName = "test",
+      aliases = [],
+      visibility = I.Visible,
+      args = [("namespace", Optional, namespaceArg)],
+      help =
+        case wundefined of
+          _ -> "`test` runs unit tests for the current branch.",
+      parse = \args ->
+        maybe (Left (I.help test)) Right do
+          path <-
+            case args of
+              [] -> Just Path.empty
+              [pathString] -> eitherToMaybe $ Path.parsePath pathString
+              _ -> Nothing
+          Just $
+            Input.TestI
+              Input.TestInput
+                { includeLibNamespace = False,
+                  path,
+                  showFailures = True,
+                  showSuccesses = True
+                }
+    }
 
 testAll :: InputPattern
 testAll =
@@ -2416,6 +2425,7 @@ testAll =
           Input.TestI
             Input.TestInput
               { includeLibNamespace = True,
+                path = Path.empty,
                 showFailures = True,
                 showSuccesses = True
               }
@@ -2519,7 +2529,7 @@ ioTestAll =
     { patternName = "io.test.all",
       aliases = ["test.io.all"],
       visibility = I.Visible,
-      args = [],
+      args = case wundefined of { _ -> [] },
       help =
         P.wrapColumn2
           [ ( "`io.test.all`",

--- a/unison-src/transcripts/test-command.md
+++ b/unison-src/transcripts/test-command.md
@@ -9,6 +9,9 @@ The `test` command should run all of the tests in the current directory.
 ```unison
 test1 : [Result]
 test1 = [Ok "test1"]
+
+foo.test2 : [Result]
+foo.test2 = [Ok "test2"]
 ```
 
 ```ucm:hide
@@ -45,4 +48,10 @@ testInLib = [Ok "testInLib"]
 
 ```ucm
 .lib> test
+```
+
+`test` can be given a relative path, in which case it will only run tests found somewhere in that namespace.
+
+```ucm
+.> test foo
 ```

--- a/unison-src/transcripts/test-command.output.md
+++ b/unison-src/transcripts/test-command.output.md
@@ -5,6 +5,9 @@ The `test` command should run all of the tests in the current directory.
 ```unison
 test1 : [Result]
 test1 = [Ok "test1"]
+
+foo.test2 : [Result]
+foo.test2 = [Ok "test2"]
 ```
 
 ```ucm
@@ -17,7 +20,8 @@ test1 = [Ok "test1"]
   
     ⍟ These new definitions are ok to `add`:
     
-      test1 : [Result]
+      foo.test2 : [Result]
+      test1     : [Result]
 
 ```
 ```ucm
@@ -29,13 +33,18 @@ test1 = [Ok "test1"]
 
   
 
+  
+
+  
+
     New test results:
   
-  ◉ test1   test1
+  ◉ foo.test2   test2
+  ◉ test1       test1
   
-  ✅ 1 test(s) passing
+  ✅ 2 test(s) passing
   
-  Tip: Use view test1 to view the source of a test.
+  Tip: Use view foo.test2 to view the source of a test.
 
 ```
 Tests should be cached if unchanged.
@@ -45,11 +54,12 @@ Tests should be cached if unchanged.
 
   Cached test results (`help testcache` to learn more)
   
-  ◉ test1   test1
+  ◉ foo.test2   test2
+  ◉ test1       test1
   
-  ✅ 1 test(s) passing
+  ✅ 2 test(s) passing
   
-  Tip: Use view test1 to view the source of a test.
+  Tip: Use view foo.test2 to view the source of a test.
 
 ```
 `test` won't descend into the `lib` namespace, but `test.all` will.
@@ -77,20 +87,22 @@ testInLib = [Ok "testInLib"]
 
   Cached test results (`help testcache` to learn more)
   
-  ◉ test1   test1
+  ◉ foo.test2   test2
+  ◉ test1       test1
   
-  ✅ 1 test(s) passing
+  ✅ 2 test(s) passing
   
-  Tip: Use view test1 to view the source of a test.
+  Tip: Use view foo.test2 to view the source of a test.
 
 .> test.all
 
     
     Cached test results (`help testcache` to learn more)
     
-    ◉ test1   test1
+    ◉ foo.test2   test2
+    ◉ test1       test1
     
-    ✅ 1 test(s) passing
+    ✅ 2 test(s) passing
     
     ✅  
 
@@ -119,5 +131,19 @@ testInLib = [Ok "testInLib"]
   ✅ 1 test(s) passing
   
   Tip: Use view testInLib to view the source of a test.
+
+```
+`test` can be given a relative path, in which case it will only run tests found somewhere in that namespace.
+
+```ucm
+.> test foo
+
+  Cached test results (`help testcache` to learn more)
+  
+  ◉ foo.test2   test2
+  
+  ✅ 1 test(s) passing
+  
+  Tip: Use view foo.test2 to view the source of a test.
 
 ```


### PR DESCRIPTION
## Overview

Fixes #2190 

This PR adds an optional relative path argument to `test`.

For example,

```
myproject/mybranch> test mynamespace
```

is like

```
myproject/mybranch> test
```

except only tests defined in the `mynamespace` sub-namespace of `myproject/mybranch` are run.
