### PR TITLE
A couple more miscellaneous JIT issues

### DIFF
--- a/.github/workflows/ci.md
+++ b/.github/workflows/ci.md
@@ -9,7 +9,7 @@ At a high level, the CI process is:
 Some version numbers that are used during CI:
 - `ormolu_version: "0.5.0.1"`
 - `racket_version: "8.7"`
-- `jit_version: "@unison/internal/releases/0.0.16"`
+- `jit_version: "@unison/internal/releases/0.0.17"`
 
 Some cached directories:
   - `ucm_local_bin` a temp path for caching a built `ucm`

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ on:
 env:
   ormolu_version: 0.5.2.0
   ucm_local_bin: ucm-local-bin
-  jit_version: "@unison/internal/releases/0.0.16"
+  jit_version: "@unison/internal/releases/0.0.17"
   jit_src_scheme: unison-jit-src/scheme-libs/racket
   jit_dist: unison-jit-dist
   jit_generator_os: ubuntu-20.04

--- a/scheme-libs/racket/unison/primops-generated.rkt
+++ b/scheme-libs/racket/unison/primops-generated.rkt
@@ -308,7 +308,7 @@
      (let ([bs (map reify-value (chunked-list->list bs0))]
            [tl (reference->typelink rf)])
        (cond
-         [(eqv? tl builtin-boolean:typelink)
+         [(equal? tl builtin-boolean:typelink)
           (cond
             [(not (null? bs))
              (raise

--- a/unison-src/transcripts-manual/gen-racket-libs.md
+++ b/unison-src/transcripts-manual/gen-racket-libs.md
@@ -5,7 +5,7 @@ Next, we'll download the jit project and generate a few Racket files from it.
 
 ```ucm
 .> project.create-empty jit-setup
-jit-setup/main> pull @unison/internal/releases/0.0.16 lib.jit
+jit-setup/main> pull @unison/internal/releases/0.0.17 lib.jit
 ```
 
 ```unison

--- a/unison-src/transcripts-manual/gen-racket-libs.output.md
+++ b/unison-src/transcripts-manual/gen-racket-libs.output.md
@@ -20,7 +20,7 @@ Next, we'll download the jit project and generate a few Racket files from it.
   
   🎉 🥳 Happy coding!
 
-jit-setup/main> pull @unison/internal/releases/0.0.16 lib.jit
+jit-setup/main> pull @unison/internal/releases/0.0.17 lib.jit
 
   Downloaded 15091 entities.
 


### PR DESCRIPTION
This fixes a couple problems I found by making ucm always use the native runtime when evaluating code normally (I.E. not replacing the 'sandboxed' runtime). I think this includes watch expressions and tests. I tried running all the transcripts this way.

Some of the problems cannot be easily fixed, because they are just things that aren't implemented yet, and aren't a priority. Most of the transcripts seem to pass, though.

The fixes are:
- Boolean deserialization wasn't quite working, because testing whether a value was a boolean wasn't quite correct on one end.
- Bytes serialization wasn't actually using the right format, so it was failing to roundtrip correctly, and could also fail to communicate back to ucm. These fixes are in `@unison/internal`.