### PR TITLE
feat: add `lib.install` command

### DIFF
--- a/parser-typechecker/src/Unison/Codebase.hs
+++ b/parser-typechecker/src/Unison/Codebase.hs
@@ -88,8 +88,6 @@ module Unison.Codebase
 
     -- ** Remote sync
     viewRemoteBranch,
-    importRemoteBranch,
-    Preprocessing (..),
     pushGitBranch,
 
     -- * Codebase path
@@ -112,8 +110,6 @@ module Unison.Codebase
   )
 where
 
-import Control.Monad.Except (ExceptT (ExceptT), runExceptT)
-import Control.Monad.Trans.Except (throwE)
 import Data.Map qualified as Map
 import Data.Set qualified as Set
 import U.Codebase.Branch qualified as V2
@@ -128,15 +124,13 @@ import Unison.Codebase.Branch (Branch)
 import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.BuiltinAnnotation (BuiltinAnnotation (builtinAnnotation))
 import Unison.Codebase.CodeLookup qualified as CL
-import Unison.Codebase.Editor.Git (withStatus)
 import Unison.Codebase.Editor.Git qualified as Git
 import Unison.Codebase.Editor.RemoteRepo (ReadGitRemoteNamespace)
-import Unison.Codebase.GitError qualified as GitError
 import Unison.Codebase.Path
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.SqliteCodebase.Conversions qualified as Cv
 import Unison.Codebase.SqliteCodebase.Operations qualified as SqliteCodebase.Operations
-import Unison.Codebase.Type (Codebase (..), GitError (GitCodebaseError))
+import Unison.Codebase.Type (Codebase (..), GitError)
 import Unison.CodebasePath (CodebasePath, getCodebaseDir)
 import Unison.ConstructorReference (ConstructorReference, GConstructorReference (..))
 import Unison.DataDeclaration (Decl)
@@ -160,7 +154,6 @@ import Unison.Typechecker.TypeLookup (TypeLookup (TypeLookup))
 import Unison.Typechecker.TypeLookup qualified as TL
 import Unison.UnisonFile qualified as UF
 import Unison.Util.Relation qualified as Rel
-import Unison.Util.Timing (time)
 import Unison.Var (Var)
 import Unison.WatchKind qualified as WK
 
@@ -474,39 +467,6 @@ isType c r = case r of
   Reference.DerivedId r -> isJust <$> getTypeDeclaration c r
 
 -- * Git stuff
-
--- | An optional preprocessing step to run on branches
--- before they're imported into the local codebase.
-data Preprocessing m
-  = Unmodified
-  | Preprocessed (Branch m -> m (Branch m))
-
--- | Sync elements as needed from a remote git codebase into the local one.
--- If `sch` is supplied, we try to load the specified branch hash;
--- otherwise we try to load the root branch.
-importRemoteBranch ::
-  forall m v a.
-  (MonadUnliftIO m) =>
-  Codebase m v a ->
-  ReadGitRemoteNamespace ->
-  Preprocessing m ->
-  m (Either GitError (Branch m))
-importRemoteBranch codebase ns preprocess = runExceptT $ do
-  branchHash <- ExceptT . viewRemoteBranch' codebase ns Git.RequireExistingBranch $ \(branch, cacheDir) -> do
-    withStatus "Importing downloaded files into local codebase..." $ do
-      processedBranch <- preprocessOp branch
-      time "SyncFromDirectory" $ do
-        syncFromDirectory codebase cacheDir processedBranch
-        pure $ Branch.headHash processedBranch
-  time "load fresh local branch after sync" $ do
-    lift (getBranchForHash codebase branchHash) >>= \case
-      Nothing -> throwE . GitCodebaseError $ GitError.CouldntLoadSyncedBranch ns branchHash
-      Just result -> pure $ result
-  where
-    preprocessOp :: Branch m -> m (Branch m)
-    preprocessOp = case preprocess of
-      Preprocessed f -> f
-      Unmodified -> pure
 
 -- | Pull a git branch and view it from the cache, without syncing into the
 -- local codebase.

--- a/parser-typechecker/src/Unison/Codebase/GitError.hs
+++ b/parser-typechecker/src/Unison/Codebase/GitError.hs
@@ -1,9 +1,12 @@
-{-# LANGUAGE DeriveAnyClass #-}
+module Unison.Codebase.GitError
+  ( CodebasePath,
+    GitProtocolError (..),
+    GitCodebaseError (..),
+  )
+where
 
-module Unison.Codebase.GitError where
-
-import Unison.Codebase.Editor.RemoteRepo (ReadGitRemoteNamespace, ReadGitRepo, WriteGitRepo)
-import Unison.Codebase.Path
+import Unison.Codebase.Editor.RemoteRepo (ReadGitRepo, WriteGitRepo)
+import Unison.Codebase.Path (Path)
 import Unison.Codebase.ShortCausalHash (ShortCausalHash)
 import Unison.Prelude
 
@@ -30,8 +33,5 @@ data GitProtocolError
 data GitCodebaseError h
   = NoRemoteNamespaceWithHash ReadGitRepo ShortCausalHash
   | RemoteNamespaceHashAmbiguous ReadGitRepo ShortCausalHash (Set h)
-  | CouldntLoadRootBranch ReadGitRepo h
-  | CouldntParseRemoteBranch ReadGitRepo String
-  | CouldntLoadSyncedBranch ReadGitRemoteNamespace h
   | CouldntFindRemoteBranch ReadGitRepo Path
   deriving (Show)

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase.hs
@@ -1,10 +1,5 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE ViewPatterns #-}
 
 module Unison.Codebase.SqliteCodebase
   ( Unison.Codebase.SqliteCodebase.init,
@@ -64,8 +59,7 @@ import Unison.Codebase.SqliteCodebase.Migrations qualified as Migrations
 import Unison.Codebase.SqliteCodebase.Operations qualified as CodebaseOps
 import Unison.Codebase.SqliteCodebase.Paths
 import Unison.Codebase.SqliteCodebase.SyncEphemeral qualified as SyncEphemeral
-import Unison.Codebase.SyncMode (SyncMode)
-import Unison.Codebase.Type (LocalOrRemote (..), PushGitBranchOpts (..))
+import Unison.Codebase.Type (GitPushBehavior, LocalOrRemote (..))
 import Unison.Codebase.Type qualified as C
 import Unison.DataDeclaration (Decl)
 import Unison.Hash (Hash)
@@ -325,8 +319,8 @@ sqliteCodebase debugName root localOrRemote lockOption migrationStrategy action 
               withRunInIO \runInIO ->
                 runInIO (runTransaction (CodebaseOps.putBranch (Branch.transform (Sqlite.unsafeIO . runInIO) branch)))
 
-            syncFromDirectory :: Codebase1.CodebasePath -> SyncMode -> Branch m -> m ()
-            syncFromDirectory srcRoot _syncMode b =
+            syncFromDirectory :: Codebase1.CodebasePath -> Branch m -> m ()
+            syncFromDirectory srcRoot b =
               withConnection (debugName ++ ".sync.src") srcRoot \srcConn ->
                 withConn \destConn -> do
                   progressStateRef <- liftIO (newIORef emptySyncProgressState)
@@ -334,8 +328,8 @@ sqliteCodebase debugName root localOrRemote lockOption migrationStrategy action 
                     Sqlite.runWriteTransaction destConn \runDest -> do
                       syncInternal (syncProgress progressStateRef) runSrc runDest b
 
-            syncToDirectory :: Codebase1.CodebasePath -> SyncMode -> Branch m -> m ()
-            syncToDirectory destRoot _syncMode b =
+            syncToDirectory :: Codebase1.CodebasePath -> Branch m -> m ()
+            syncToDirectory destRoot b =
               withConn \srcConn ->
                 withConnection (debugName ++ ".sync.dest") destRoot \destConn -> do
                   progressStateRef <- liftIO (newIORef emptySyncProgressState)
@@ -635,11 +629,11 @@ pushGitBranch ::
   (MonadUnliftIO m) =>
   Sqlite.Connection ->
   WriteGitRepo ->
-  PushGitBranchOpts ->
+  GitPushBehavior ->
   -- An action which accepts the current root branch on the remote and computes a new branch.
   (Branch m -> m (Either e (Branch m))) ->
   m (Either C.GitError (Either e (Branch m)))
-pushGitBranch srcConn repo (PushGitBranchOpts behavior _syncMode) action = UnliftIO.try do
+pushGitBranch srcConn repo behavior action = UnliftIO.try do
   -- Pull the latest remote into our git cache
   -- Use a local git clone to copy this git repo into a temp-dir
   -- Delete the codebase in our temp-dir

--- a/parser-typechecker/src/Unison/Codebase/SyncMode.hs
+++ b/parser-typechecker/src/Unison/Codebase/SyncMode.hs
@@ -1,3 +1,0 @@
-module Unison.Codebase.SyncMode where
-
-data SyncMode = ShortCircuit | Complete deriving (Eq, Show)

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -85,7 +85,6 @@ library
       Unison.Codebase.SqliteCodebase.Operations
       Unison.Codebase.SqliteCodebase.Paths
       Unison.Codebase.SqliteCodebase.SyncEphemeral
-      Unison.Codebase.SyncMode
       Unison.Codebase.TermEdit
       Unison.Codebase.TermEdit.Typing
       Unison.Codebase.Type

--- a/unison-cli/package.yaml
+++ b/unison-cli/package.yaml
@@ -179,6 +179,7 @@ default-extensions:
   - NamedFieldPuns
   - NumericUnderscores
   - OverloadedLabels
+  - OverloadedRecordDot
   - OverloadedStrings
   - PatternSynonyms
   - RankNTypes

--- a/unison-cli/src/Unison/Cli/DownloadUtils.hs
+++ b/unison-cli/src/Unison/Cli/DownloadUtils.hs
@@ -1,0 +1,139 @@
+-- | Utility functions for downloading remote entities and storing them locally in SQLite.
+--
+-- These are shared by commands like `pull` and `clone`.
+module Unison.Cli.DownloadUtils
+  ( downloadProjectBranchFromShare,
+    downloadLooseCodeFromShare,
+    GitNamespaceHistoryTreatment (..),
+    downloadLooseCodeFromGitRepo,
+  )
+where
+
+import Control.Concurrent.STM (atomically)
+import Control.Concurrent.STM.TVar (modifyTVar', newTVarIO, readTVar, readTVarIO)
+import Data.List.NonEmpty (pattern (:|))
+import System.Console.Regions qualified as Console.Regions
+import U.Codebase.HashTags (CausalHash)
+import U.Codebase.Sqlite.Queries qualified as Queries
+import Unison.Cli.Monad (Cli)
+import Unison.Cli.Monad qualified as Cli
+import Unison.Cli.Share.Projects qualified as Share
+import Unison.Codebase (Codebase)
+import Unison.Codebase qualified as Codebase
+import Unison.Codebase.Branch qualified as Branch
+import Unison.Codebase.Editor.Git qualified as Git
+import Unison.Codebase.Editor.HandleInput.AuthLogin (ensureAuthenticatedWithCodeserver)
+import Unison.Codebase.Editor.Output qualified as Output
+import Unison.Codebase.Editor.RemoteRepo (ReadGitRemoteNamespace, ReadShareLooseCode, shareUserHandleToText)
+import Unison.Codebase.Editor.RemoteRepo qualified as RemoteRepo
+import Unison.Codebase.Path qualified as Path
+import Unison.Codebase.Type (GitError)
+import Unison.Codebase.Type qualified as Codebase (viewRemoteBranch')
+import Unison.Core.Project (ProjectAndBranch (..))
+import Unison.NameSegment qualified as NameSegment
+import Unison.Parser.Ann (Ann)
+import Unison.Prelude
+import Unison.Share.API.Hash qualified as Share
+import Unison.Share.Codeserver qualified as Codeserver
+import Unison.Share.Sync qualified as Share
+import Unison.Share.Sync.Types qualified as Share
+import Unison.Share.Types (codeserverBaseURL)
+import Unison.Symbol (Symbol)
+import Unison.Sync.Common qualified as Sync.Common
+import Unison.Sync.Types qualified as Share
+
+-- | Download a project/branch from Share.
+downloadProjectBranchFromShare ::
+  HasCallStack =>
+  Bool ->
+  Share.RemoteProjectBranch ->
+  Cli (Either Output.ShareError CausalHash)
+downloadProjectBranchFromShare useSquashedIfAvailable branch =
+  Cli.labelE \done -> do
+    let remoteProjectBranchName = branch.branchName
+    let repoInfo = Share.RepoInfo (into @Text (ProjectAndBranch branch.projectName remoteProjectBranchName))
+    causalHashJwt <-
+      if useSquashedIfAvailable
+        then case branch.squashedBranchHead of
+          Nothing -> done Output.ShareExpectedSquashedHead
+          Just squashedHead -> pure squashedHead
+        else pure branch.branchHead
+    exists <- Cli.runTransaction (Queries.causalExistsByHash32 (Share.hashJWTHash causalHashJwt))
+    when (not exists) do
+      (result, numDownloaded) <-
+        Cli.with withEntitiesDownloadedProgressCallback \(downloadedCallback, getNumDownloaded) -> do
+          result <- Share.downloadEntities Share.hardCodedBaseUrl repoInfo causalHashJwt downloadedCallback
+          numDownloaded <- liftIO getNumDownloaded
+          pure (result, numDownloaded)
+      result & onLeft \err0 -> do
+        done case err0 of
+          Share.SyncError err -> Output.ShareErrorDownloadEntities err
+          Share.TransportError err -> Output.ShareErrorTransport err
+      Cli.respond (Output.DownloadedEntities numDownloaded)
+    pure (Sync.Common.hash32ToCausalHash (Share.hashJWTHash causalHashJwt))
+
+-- | Download loose code from Share.
+downloadLooseCodeFromShare :: ReadShareLooseCode -> Cli (Either Output.ShareError CausalHash)
+downloadLooseCodeFromShare namespace = do
+  let codeserver = Codeserver.resolveCodeserver namespace.server
+  let baseURL = codeserverBaseURL codeserver
+
+  -- Auto-login to share if pulling from a non-public path
+  when (not (RemoteRepo.isPublic namespace)) do
+    _userInfo <- ensureAuthenticatedWithCodeserver codeserver
+    pure ()
+
+  let shareFlavoredPath =
+        Share.Path $
+          shareUserHandleToText namespace.repo
+            :| map NameSegment.toUnescapedText (Path.toList namespace.path)
+
+  Cli.labelE \done -> do
+    (causalHash, numDownloaded) <-
+      Cli.with withEntitiesDownloadedProgressCallback \(downloadedCallback, getNumDownloaded) -> do
+        causalHash <-
+          Share.pull baseURL shareFlavoredPath downloadedCallback & onLeftM \err0 ->
+            done case err0 of
+              Share.SyncError err -> Output.ShareErrorPull err
+              Share.TransportError err -> Output.ShareErrorTransport err
+        numDownloaded <- liftIO getNumDownloaded
+        pure (causalHash, numDownloaded)
+    Cli.respond (Output.DownloadedEntities numDownloaded)
+    pure causalHash
+
+-- Provide the given action a callback that display to the terminal.
+withEntitiesDownloadedProgressCallback :: ((Int -> IO (), IO Int) -> IO a) -> IO a
+withEntitiesDownloadedProgressCallback action = do
+  entitiesDownloadedVar <- newTVarIO 0
+  Console.Regions.displayConsoleRegions do
+    Console.Regions.withConsoleRegion Console.Regions.Linear \region -> do
+      Console.Regions.setConsoleRegion region do
+        entitiesDownloaded <- readTVar entitiesDownloadedVar
+        pure $
+          "\n  Downloaded "
+            <> tShow entitiesDownloaded
+            <> " entities...\n\n"
+      action ((\n -> atomically (modifyTVar' entitiesDownloadedVar (+ n))), readTVarIO entitiesDownloadedVar)
+
+data GitNamespaceHistoryTreatment
+  = -- | Don't touch the history
+    GitNamespaceHistoryTreatment'LetAlone
+  | -- | Throw away all history at all levels
+    GitNamespaceHistoryTreatment'DiscardAllHistory
+
+-- | Download loose code that's in a SQLite codebase in a Git repo.
+downloadLooseCodeFromGitRepo ::
+  MonadIO m =>
+  Codebase IO Symbol Ann ->
+  GitNamespaceHistoryTreatment ->
+  ReadGitRemoteNamespace ->
+  m (Either GitError CausalHash)
+downloadLooseCodeFromGitRepo codebase historyTreatment namespace = liftIO do
+  Codebase.viewRemoteBranch' codebase namespace Git.RequireExistingBranch \(branch0, cacheDir) -> do
+    let branch =
+          case historyTreatment of
+            GitNamespaceHistoryTreatment'LetAlone -> branch0
+            GitNamespaceHistoryTreatment'DiscardAllHistory -> Branch.discardHistory branch0
+
+    Codebase.syncFromDirectory codebase cacheDir branch
+    pure (Branch.headHash branch)

--- a/unison-cli/src/Unison/Cli/Monad.hs
+++ b/unison-cli/src/Unison/Cli/Monad.hs
@@ -25,6 +25,7 @@ module Unison.Cli.Monad
 
     -- * Short-circuiting
     label,
+    labelE,
     returnEarly,
     returnEarlyWithoutOutput,
     haltRepl,
@@ -335,6 +336,12 @@ label f =
         | n == m -> k (unsafeCoerce a) s1
         | otherwise -> throwIO err
       Right a -> feed k a
+
+-- | A variant of @label@ for the common case that early-return values are tagged with a Left.
+labelE :: ((forall void. a -> Cli void) -> Cli b) -> Cli (Either a b)
+labelE f =
+  label \goto ->
+    Right <$> f (goto . Left)
 
 -- | Time an action.
 time :: String -> Cli a -> Cli a

--- a/unison-cli/src/Unison/Cli/ProjectUtils.hs
+++ b/unison-cli/src/Unison/Cli/ProjectUtils.hs
@@ -26,6 +26,7 @@ module Unison.Cli.ProjectUtils
     expectLooseCodeOrProjectBranch,
 
     -- * Loading remote project info
+    expectRemoteProjectById,
     expectRemoteProjectByName,
     expectRemoteProjectBranchById,
     loadRemoteProjectBranchByName,
@@ -33,6 +34,7 @@ module Unison.Cli.ProjectUtils
     loadRemoteProjectBranchByNames,
     expectRemoteProjectBranchByNames,
     expectRemoteProjectBranchByTheseNames,
+    expectLatestReleaseBranchName,
   )
 where
 
@@ -54,8 +56,9 @@ import Unison.Codebase.Path (Path')
 import Unison.Codebase.Path qualified as Path
 import Unison.CommandLine.BranchRelativePath (BranchRelativePath, ResolvedBranchRelativePath)
 import Unison.CommandLine.BranchRelativePath qualified as BranchRelativePath
+import Unison.Core.Project (ProjectBranchName (..))
 import Unison.Prelude
-import Unison.Project (ProjectAndBranch (..), ProjectBranchName, ProjectName)
+import Unison.Project (ProjectAndBranch (..), ProjectName)
 import Unison.Project.Util
 import Unison.Sqlite qualified as Sqlite
 import Witch (unsafeFrom)
@@ -230,6 +233,12 @@ expectLooseCodeOrProjectBranch =
 ------------------------------------------------------------------------------------------------------------------------
 -- Remote project utils
 
+-- | Expect a remote project by id. Its latest-known name is also provided, for error messages.
+expectRemoteProjectById :: RemoteProjectId -> ProjectName -> Cli Share.RemoteProject
+expectRemoteProjectById remoteProjectId remoteProjectName = do
+  Share.getProjectById remoteProjectId & onNothingM do
+    Cli.returnEarly (Output.RemoteProjectDoesntExist Share.hardCodedUri remoteProjectName)
+
 expectRemoteProjectByName :: ProjectName -> Cli Share.RemoteProject
 expectRemoteProjectByName remoteProjectName = do
   Share.getProjectByName remoteProjectName & onNothingM do
@@ -324,3 +333,10 @@ expectRemoteProjectBranchByTheseNames includeSquashed = \case
 remoteProjectBranchDoesntExist :: ProjectAndBranch ProjectName ProjectBranchName -> Cli void
 remoteProjectBranchDoesntExist projectAndBranch =
   Cli.returnEarly (Output.RemoteProjectBranchDoesntExist Share.hardCodedUri projectAndBranch)
+
+-- | Expect the given remote project to have a latest release, and return it as a valid branch name.
+expectLatestReleaseBranchName :: Share.RemoteProject -> Cli ProjectBranchName
+expectLatestReleaseBranchName remoteProject =
+  case remoteProject.latestRelease of
+    Nothing -> Cli.returnEarly (Output.ProjectHasNoReleases remoteProject.projectName)
+    Just semver -> pure (UnsafeProjectBranchName ("releases/" <> into @Text semver))

--- a/unison-cli/src/Unison/Cli/Share/Projects.hs
+++ b/unison-cli/src/Unison/Cli/Share/Projects.hs
@@ -96,7 +96,7 @@ data GetProjectBranchResponse
 data IncludeSquashedHead
   = IncludeSquashedHead
   | NoSquashedHead
-  deriving (Show, Eq)
+  deriving stock (Show, Eq)
 
 -- | Get a project branch by id.
 --

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1021,7 +1021,7 @@ loop e = do
               pped <- Cli.currentPrettyPrintEnvDecl
               let suffixifiedPPE = PPED.suffixifiedPPE pped
               Cli.respondNumbered $ ListEdits patch suffixifiedPPE
-            PullRemoteBranchI sourceTarget sMode pMode verbosity -> doPullRemoteBranch sourceTarget sMode pMode verbosity
+            PullRemoteBranchI sourceTarget pMode verbosity -> doPullRemoteBranch sourceTarget pMode verbosity
             PushRemoteBranchI pushRemoteBranchInput -> handlePushRemoteBranch pushRemoteBranchInput
             ListDependentsI hq -> handleDependents hq
             ListDependenciesI hq -> handleDependencies hq

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -64,6 +64,7 @@ import Unison.Codebase.Editor.HandleInput.DeleteProject (handleDeleteProject)
 import Unison.Codebase.Editor.HandleInput.EditNamespace (handleEditNamespace)
 import Unison.Codebase.Editor.HandleInput.FindAndReplace (handleStructuredFindI, handleStructuredFindReplaceI)
 import Unison.Codebase.Editor.HandleInput.FormatFile qualified as Format
+import Unison.Codebase.Editor.HandleInput.InstallLib (handleInstallLib)
 import Unison.Codebase.Editor.HandleInput.Load (EvalMode (Sandboxed), evalUnisonFile, handleLoad, loadUnisonFile)
 import Unison.Codebase.Editor.HandleInput.MoveAll (handleMoveAll)
 import Unison.Codebase.Editor.HandleInput.MoveBranch (doMoveBranch)
@@ -1186,6 +1187,7 @@ loop e = do
             CloneI remoteNames localNames -> handleClone remoteNames localNames
             ReleaseDraftI semver -> handleReleaseDraft semver
             UpgradeI old new -> handleUpgrade old new
+            LibInstallI libdep -> handleInstallLib libdep
 
 inputDescription :: Input -> Cli Text
 inputDescription input =
@@ -1370,6 +1372,7 @@ inputDescription input =
     StructuredFindReplaceI {} -> wat
     GistI {} -> wat
     HistoryI {} -> wat
+    LibInstallI {} -> wat
     ListDependenciesI {} -> wat
     ListDependentsI {} -> wat
     ListEditsI {} -> wat

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -76,7 +76,7 @@ import Unison.Codebase.Editor.HandleInput.ProjectCreate (projectCreate)
 import Unison.Codebase.Editor.HandleInput.ProjectRename (handleProjectRename)
 import Unison.Codebase.Editor.HandleInput.ProjectSwitch (projectSwitch)
 import Unison.Codebase.Editor.HandleInput.Projects (handleProjects)
-import Unison.Codebase.Editor.HandleInput.Pull (doPullRemoteBranch, mergeBranchAndPropagateDefaultPatch, propagatePatch)
+import Unison.Codebase.Editor.HandleInput.Pull (handlePull, mergeBranchAndPropagateDefaultPatch, propagatePatch)
 import Unison.Codebase.Editor.HandleInput.Push (handleGist, handlePushRemoteBranch)
 import Unison.Codebase.Editor.HandleInput.ReleaseDraft (handleReleaseDraft)
 import Unison.Codebase.Editor.HandleInput.Run (handleRun)
@@ -1021,7 +1021,7 @@ loop e = do
               pped <- Cli.currentPrettyPrintEnvDecl
               let suffixifiedPPE = PPED.suffixifiedPPE pped
               Cli.respondNumbered $ ListEdits patch suffixifiedPPE
-            PullRemoteBranchI sourceTarget pMode verbosity -> doPullRemoteBranch sourceTarget pMode verbosity
+            PullRemoteBranchI sourceTarget pMode verbosity -> handlePull sourceTarget pMode verbosity
             PushRemoteBranchI pushRemoteBranchInput -> handlePushRemoteBranch pushRemoteBranchInput
             ListDependentsI hq -> handleDependents hq
             ListDependenciesI hq -> handleDependencies hq

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/InstallLib.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/InstallLib.hs
@@ -1,0 +1,141 @@
+-- | @lib.install@ input handler
+module Unison.Codebase.Editor.HandleInput.InstallLib
+  ( handleInstallLib,
+  )
+where
+
+import Control.Monad.Reader (ask)
+import Data.List qualified as List
+import Data.Map.Strict qualified as Map
+import Data.Maybe (fromJust)
+import Data.Set qualified as Set
+import Data.Text qualified as Text
+import U.Codebase.Sqlite.Project qualified as Sqlite (Project (..))
+import U.Codebase.Sqlite.ProjectBranch qualified as Sqlite (ProjectBranch (..))
+import Unison.Cli.DownloadUtils
+import Unison.Cli.Monad (Cli)
+import Unison.Cli.Monad qualified as Cli
+import Unison.Cli.MonadUtils qualified as Cli
+import Unison.Cli.ProjectUtils qualified as ProjectUtils
+import Unison.Cli.Share.Projects qualified as Share
+import Unison.Codebase qualified as Codebase
+import Unison.Codebase.Branch qualified as Branch
+import Unison.Codebase.Editor.Output qualified as Output
+import Unison.Codebase.Path qualified as Path
+import Unison.Core.Project (ProjectBranchName)
+import Unison.NameSegment (NameSegment)
+import Unison.NameSegment qualified as NameSegment
+import Unison.Prelude
+import Unison.Project
+  ( ProjectAndBranch (..),
+    ProjectBranchNameKind (..),
+    ProjectBranchNameOrLatestRelease (..),
+    ProjectName,
+    Semver (..),
+    classifyProjectBranchName,
+    projectNameToUserProjectSlugs,
+  )
+import Unison.Syntax.NameSegment qualified as NameSegment (unsafeParseText)
+
+handleInstallLib :: ProjectAndBranch ProjectName (Maybe ProjectBranchNameOrLatestRelease) -> Cli ()
+handleInstallLib (ProjectAndBranch libdepProjectName unresolvedLibdepBranchName) = do
+  (currentProjectAndBranch, _path) <- ProjectUtils.expectCurrentProjectBranch
+
+  let currentProjectBranchPath =
+        ProjectUtils.projectBranchPath $
+          ProjectAndBranch
+            currentProjectAndBranch.project.projectId
+            currentProjectAndBranch.branch.branchId
+
+  libdepProject <- ProjectUtils.expectRemoteProjectByName libdepProjectName
+
+  libdepBranchName <-
+    case fromMaybe ProjectBranchNameOrLatestRelease'LatestRelease unresolvedLibdepBranchName of
+      ProjectBranchNameOrLatestRelease'Name name -> pure name
+      ProjectBranchNameOrLatestRelease'LatestRelease -> ProjectUtils.expectLatestReleaseBranchName libdepProject
+
+  let libdepProjectAndBranchNames =
+        ProjectAndBranch libdepProjectName libdepBranchName
+
+  libdepProjectBranch <-
+    ProjectUtils.expectRemoteProjectBranchByName
+      Share.IncludeSquashedHead
+      (ProjectAndBranch (libdepProject.projectId, libdepProjectName) libdepBranchName)
+
+  Cli.Env {codebase} <- ask
+
+  causalHash <-
+    downloadProjectBranchFromShare Share.IncludeSquashedHead libdepProjectBranch
+      & onLeftM (Cli.returnEarly . Output.ShareError)
+
+  remoteBranchObject <- liftIO (Codebase.expectBranchForHash codebase causalHash)
+
+  -- Find the best available dependency name, starting with the best one (e.g. "unison_base_1_0_0"), and tacking on a
+  -- "__2", "__3", etc. suffix.
+  --
+  -- For example, if the best name is "foo", and libdeps "foo" and "foo__2" already exist, then we'll get "foo__3".
+  libdepNameSegment :: NameSegment <- do
+    currentBranchObject <- Cli.getBranch0At currentProjectBranchPath
+    pure $
+      fresh
+        (\i -> NameSegment.unsafeParseText . (<> "__" <> tShow i) . NameSegment.toUnescapedText)
+        ( case Map.lookup NameSegment.libSegment currentBranchObject._children of
+            Nothing -> Set.empty
+            Just libdeps -> Map.keysSet (Branch._children (Branch.head libdeps))
+        )
+        (makeDependencyName libdepProjectName libdepBranchName)
+
+  let libdepPath :: Path.Absolute
+      libdepPath =
+        Path.resolve
+          currentProjectBranchPath
+          (Path.Relative (Path.fromList [NameSegment.libSegment, libdepNameSegment]))
+
+  let reflogDescription = "lib.install " <> into @Text libdepProjectAndBranchNames
+  _didUpdate <- Cli.updateAt reflogDescription libdepPath (\_empty -> remoteBranchObject)
+
+  Cli.respond (Output.InstalledLibdep libdepProjectAndBranchNames libdepNameSegment)
+
+fresh :: Ord a => (Int -> a -> a) -> Set a -> a -> a
+fresh bump taken x =
+  fromJust (List.find (\y -> not (Set.member y taken)) (x : map (\i -> bump i x) [2 ..]))
+
+-- This function mangles the dependency (a project name + a branch name) to a flat string without special characters,
+-- suitable for sticking in the `lib` namespace.
+--
+-- >>> makeDependencyName (unsafeFrom @Text "@unison/base") (unsafeFrom @Text "main")
+-- unison_base_main
+--
+-- >>> makeDependencyName (unsafeFrom @Text "@unison/base") (unsafeFrom @Text "releases/1.0.0")
+-- unison_base_1_0_0
+--
+-- >>> makeDependencyName (unsafeFrom @Text "@unison/base") (unsafeFrom @Text "releases/drafts/1.0.0")
+-- unison_base_1_0_0_draft
+--
+-- >>> makeDependencyName (unsafeFrom @Text "@unison/base") (unsafeFrom @Text "@person/topic")
+-- unison_base_person_topic
+makeDependencyName :: ProjectName -> ProjectBranchName -> NameSegment
+makeDependencyName projectName branchName =
+  NameSegment.unsafeParseText $
+    Text.intercalate "_" $
+      fold
+        [ case projectNameToUserProjectSlugs projectName of
+            (user, project) ->
+              fold
+                [ if Text.null user then [] else [user],
+                  [project]
+                ],
+          case classifyProjectBranchName branchName of
+            ProjectBranchNameKind'Contributor user branch -> [user, underscorify branch]
+            ProjectBranchNameKind'DraftRelease ver -> semverSegments ver ++ ["draft"]
+            ProjectBranchNameKind'Release ver -> semverSegments ver
+            ProjectBranchNameKind'NothingSpecial -> [underscorify branchName]
+        ]
+  where
+    semverSegments :: Semver -> [Text]
+    semverSegments (Semver x y z) =
+      [tShow x, tShow y, tShow z]
+
+    underscorify :: ProjectBranchName -> Text
+    underscorify =
+      Text.replace "-" "_" . into @Text

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectCreate.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectCreate.hs
@@ -114,8 +114,7 @@ projectCreate tryDownloadingBase maybeProjectName = do
                 Share.GetProjectBranchResponseBranchNotFound -> done Nothing
                 Share.GetProjectBranchResponseProjectNotFound -> done Nothing
                 Share.GetProjectBranchResponseSuccess branch -> pure branch
-            let useSquashed = False
-            downloadProjectBranchFromShare useSquashed baseLatestReleaseBranch
+            downloadProjectBranchFromShare Share.NoSquashedHead baseLatestReleaseBranch
               & onLeftM (Cli.returnEarly . Output.ShareError)
             Cli.Env {codebase} <- ask
             baseLatestReleaseBranchObject <-

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectCreate.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/ProjectCreate.hs
@@ -13,6 +13,7 @@ import System.Random.Shuffle qualified as RandomShuffle
 import U.Codebase.Sqlite.DbId
 import U.Codebase.Sqlite.ProjectBranch qualified as Sqlite
 import U.Codebase.Sqlite.Queries qualified as Queries
+import Unison.Cli.DownloadUtils (downloadProjectBranchFromShare)
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli (stepAt)
@@ -20,7 +21,6 @@ import Unison.Cli.ProjectUtils (projectBranchPath)
 import Unison.Cli.Share.Projects qualified as Share
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch qualified as Branch
-import Unison.Codebase.Editor.HandleInput.Pull qualified as Pull
 import Unison.Codebase.Editor.Output qualified as Output
 import Unison.Codebase.Path qualified as Path
 import Unison.NameSegment qualified as NameSegment
@@ -115,7 +115,8 @@ projectCreate tryDownloadingBase maybeProjectName = do
                 Share.GetProjectBranchResponseProjectNotFound -> done Nothing
                 Share.GetProjectBranchResponseSuccess branch -> pure branch
             let useSquashed = False
-            Pull.downloadShareProjectBranch useSquashed baseLatestReleaseBranch
+            downloadProjectBranchFromShare useSquashed baseLatestReleaseBranch
+              & onLeftM (Cli.returnEarly . Output.ShareError)
             Cli.Env {codebase} <- ask
             baseLatestReleaseBranchObject <-
               liftIO $

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Pull.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Pull.hs
@@ -1,37 +1,30 @@
 -- | @pull@ input handler
 module Unison.Codebase.Editor.HandleInput.Pull
-  ( doPullRemoteBranch,
-    loadShareLooseCodeIntoMemory,
+  ( handlePull,
     loadPropagateDiffDefaultPatch,
     mergeBranchAndPropagateDefaultPatch,
     propagatePatch,
-    downloadShareProjectBranch,
-    withEntitiesDownloadedProgressCallback,
   )
 where
 
-import Control.Concurrent.STM (atomically, modifyTVar', newTVarIO, readTVar, readTVarIO)
 import Control.Lens ((^.))
 import Control.Monad.Reader (ask)
-import Data.List.NonEmpty qualified as Nel
 import Data.Text qualified as Text
 import Data.These
-import System.Console.Regions qualified as Console.Regions
 import U.Codebase.Sqlite.Project qualified as Sqlite (Project)
 import U.Codebase.Sqlite.ProjectBranch qualified as Sqlite (ProjectBranch)
 import U.Codebase.Sqlite.Queries qualified as Queries
+import Unison.Cli.DownloadUtils
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli
 import Unison.Cli.ProjectUtils qualified as ProjectUtils
 import Unison.Cli.Share.Projects qualified as Share
 import Unison.Cli.UnisonConfigUtils (resolveConfiguredUrl)
-import Unison.Codebase (Preprocessing (..))
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch (Branch (..))
 import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Branch.Merge qualified as Branch
-import Unison.Codebase.Editor.HandleInput.AuthLogin (ensureAuthenticatedWithCodeserver)
 import Unison.Codebase.Editor.HandleInput.NamespaceDiffUtils (diffHelper)
 import Unison.Codebase.Editor.Input
 import Unison.Codebase.Editor.Input qualified as Input
@@ -39,7 +32,7 @@ import Unison.Codebase.Editor.Output
 import Unison.Codebase.Editor.Output qualified as Output
 import Unison.Codebase.Editor.Output.PushPull qualified as PushPull
 import Unison.Codebase.Editor.Propagate qualified as Propagate
-import Unison.Codebase.Editor.RemoteRepo (ReadRemoteNamespace (..), ReadShareLooseCode (..), ShareUserHandle (..), printReadRemoteNamespace)
+import Unison.Codebase.Editor.RemoteRepo (ReadRemoteNamespace (..), printReadRemoteNamespace)
 import Unison.Codebase.Editor.RemoteRepo qualified as RemoteRepo
 import Unison.Codebase.Patch (Patch (..))
 import Unison.Codebase.Path (Path')
@@ -48,27 +41,34 @@ import Unison.Codebase.Verbosity qualified as Verbosity
 import Unison.CommandLine.InputPattern qualified as InputPattern
 import Unison.CommandLine.InputPatterns qualified as InputPatterns
 import Unison.Core.Project (ProjectBranchName (UnsafeProjectBranchName))
-import Unison.NameSegment (NameSegment (..))
 import Unison.NameSegment qualified as NameSegment
 import Unison.Prelude
 import Unison.Project (ProjectAndBranch (..), ProjectBranchNameOrLatestRelease (..), ProjectName)
-import Unison.Share.API.Hash (HashJWT)
-import Unison.Share.API.Hash qualified as Share
-import Unison.Share.Codeserver qualified as Codeserver
-import Unison.Share.Sync qualified as Share
-import Unison.Share.Sync.Types qualified as Share
-import Unison.Share.Types (codeserverBaseURL)
-import Unison.Sync.Common qualified as Common
-import Unison.Sync.Types qualified as Share
 import Witch (unsafeFrom)
 
-doPullRemoteBranch :: PullSourceTarget -> PullMode -> Verbosity.Verbosity -> Cli ()
-doPullRemoteBranch unresolvedSourceAndTarget pullMode verbosity = do
+handlePull :: PullSourceTarget -> PullMode -> Verbosity.Verbosity -> Cli ()
+handlePull unresolvedSourceAndTarget pullMode verbosity = do
   let includeSquashed = case pullMode of
         Input.PullWithHistory -> Share.NoSquashedHead
         Input.PullWithoutHistory -> Share.IncludeSquashedHead
   (source, target) <- resolveSourceAndTarget includeSquashed unresolvedSourceAndTarget
-  remoteBranchObject <- loadRemoteNamespaceIntoMemory pullMode source
+  remoteBranchObject <- do
+    Cli.Env {codebase} <- ask
+    causalHash <-
+      case source of
+        ReadRemoteNamespaceGit repo -> do
+          downloadLooseCodeFromGitRepo
+            codebase
+            ( case pullMode of
+                Input.PullWithHistory -> GitNamespaceHistoryTreatment'LetAlone
+                Input.PullWithoutHistory -> GitNamespaceHistoryTreatment'DiscardAllHistory
+            )
+            repo
+            & onLeftM (Cli.returnEarly . Output.GitError)
+        ReadShare'LooseCode repo -> downloadLooseCodeFromShare repo & onLeftM (Cli.returnEarly . Output.ShareError)
+        ReadShare'ProjectBranch remoteBranch ->
+          downloadProjectBranchFromShare (pullMode == Input.PullWithoutHistory) remoteBranch & onLeftM (Cli.returnEarly . Output.ShareError)
+    liftIO (Codebase.expectBranchForHash codebase causalHash)
   when (Branch.isEmpty0 (Branch.head remoteBranchObject)) do
     Cli.respond (PulledEmptyBranch source)
   targetAbsolutePath <-
@@ -211,84 +211,6 @@ resolveImplicitTarget =
   ProjectUtils.getCurrentProjectBranch <&> \case
     Nothing -> Left Path.currentPath
     Just (projectAndBranch, _restPath) -> Right projectAndBranch
-
-loadRemoteNamespaceIntoMemory ::
-  PullMode ->
-  ReadRemoteNamespace Share.RemoteProjectBranch ->
-  Cli (Branch IO)
-loadRemoteNamespaceIntoMemory pullMode remoteNamespace = do
-  Cli.Env {codebase} <- ask
-  case remoteNamespace of
-    ReadRemoteNamespaceGit repo -> do
-      let preprocess = case pullMode of
-            Input.PullWithHistory -> Unmodified
-            Input.PullWithoutHistory -> Preprocessed $ pure . Branch.discardHistory
-      Cli.ioE (Codebase.importRemoteBranch codebase repo preprocess) \err ->
-        Cli.returnEarly (Output.GitError err)
-    ReadShare'LooseCode repo -> loadShareLooseCodeIntoMemory repo
-    ReadShare'ProjectBranch remoteBranch -> do
-      projectBranchCausalHashJWT <- downloadShareProjectBranch (pullMode == Input.PullWithoutHistory) remoteBranch
-      let causalHash = Common.hash32ToCausalHash (Share.hashJWTHash projectBranchCausalHashJWT)
-      liftIO (Codebase.expectBranchForHash codebase causalHash)
-
--- | @downloadShareProjectBranch branch@ downloads the given branch.
-downloadShareProjectBranch :: HasCallStack => Bool -> Share.RemoteProjectBranch -> Cli HashJWT
-downloadShareProjectBranch useSquashedIfAvailable branch = do
-  let remoteProjectBranchName = branch ^. #branchName
-  let repoInfo = Share.RepoInfo (into @Text (ProjectAndBranch (branch ^. #projectName) remoteProjectBranchName))
-  causalHashJwt <-
-    if useSquashedIfAvailable
-      then case (branch ^. #squashedBranchHead) of
-        Nothing -> Cli.returnEarly (Output.ShareError ShareExpectedSquashedHead)
-        Just squashedHead -> pure squashedHead
-      else pure (branch ^. #branchHead)
-  exists <- Cli.runTransaction (Queries.causalExistsByHash32 (Share.hashJWTHash causalHashJwt))
-  when (not exists) do
-    (result, numDownloaded) <-
-      Cli.with withEntitiesDownloadedProgressCallback \(downloadedCallback, getNumDownloaded) -> do
-        result <- Share.downloadEntities Share.hardCodedBaseUrl repoInfo causalHashJwt downloadedCallback
-        numDownloaded <- liftIO getNumDownloaded
-        pure (result, numDownloaded)
-    result & onLeft \err0 -> do
-      (Cli.returnEarly . Output.ShareError) case err0 of
-        Share.SyncError err -> Output.ShareErrorDownloadEntities err
-        Share.TransportError err -> Output.ShareErrorTransport err
-    Cli.respond (Output.DownloadedEntities numDownloaded)
-  pure causalHashJwt
-
-loadShareLooseCodeIntoMemory :: ReadShareLooseCode -> Cli (Branch IO)
-loadShareLooseCodeIntoMemory rrn@(ReadShareLooseCode {server, repo, path}) = do
-  let codeserver = Codeserver.resolveCodeserver server
-  let baseURL = codeserverBaseURL codeserver
-  -- Auto-login to share if pulling from a non-public path
-  when (not $ RemoteRepo.isPublic rrn) . void $ ensureAuthenticatedWithCodeserver codeserver
-  let shareFlavoredPath = Share.Path (shareUserHandleToText repo Nel.:| coerce @[NameSegment] @[Text] (Path.toList path))
-  Cli.Env {codebase} <- ask
-  (causalHash, numDownloaded) <-
-    Cli.with withEntitiesDownloadedProgressCallback \(downloadedCallback, getNumDownloaded) -> do
-      causalHash <-
-        Share.pull baseURL shareFlavoredPath downloadedCallback & onLeftM \err0 ->
-          (Cli.returnEarly . Output.ShareError) case err0 of
-            Share.SyncError err -> Output.ShareErrorPull err
-            Share.TransportError err -> Output.ShareErrorTransport err
-      numDownloaded <- liftIO getNumDownloaded
-      pure (causalHash, numDownloaded)
-  Cli.respond (Output.DownloadedEntities numDownloaded)
-  liftIO (Codebase.expectBranchForHash codebase causalHash)
-
--- Provide the given action a callback that display to the terminal.
-withEntitiesDownloadedProgressCallback :: ((Int -> IO (), IO Int) -> IO a) -> IO a
-withEntitiesDownloadedProgressCallback action = do
-  entitiesDownloadedVar <- newTVarIO 0
-  Console.Regions.displayConsoleRegions do
-    Console.Regions.withConsoleRegion Console.Regions.Linear \region -> do
-      Console.Regions.setConsoleRegion region do
-        entitiesDownloaded <- readTVar entitiesDownloadedVar
-        pure $
-          "\n  Downloaded "
-            <> tShow entitiesDownloaded
-            <> " entities...\n\n"
-      action ((\n -> atomically (modifyTVar' entitiesDownloadedVar (+ n))), readTVarIO entitiesDownloadedVar)
 
 -- | supply `dest0` if you want to print diff messages
 --   supply unchangedMessage if you want to display it if merge had no effect

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -41,7 +41,6 @@ import Unison.Codebase.Path.Parse qualified as Path
 import Unison.Codebase.PushBehavior (PushBehavior)
 import Unison.Codebase.ShortCausalHash (ShortCausalHash)
 import Unison.Codebase.ShortCausalHash qualified as SCH
-import Unison.Codebase.SyncMode (SyncMode)
 import Unison.Codebase.Verbosity (Verbosity)
 import Unison.CommandLine.BranchRelativePath (BranchRelativePath, parseBranchRelativePath)
 import Unison.HashQualified qualified as HQ
@@ -115,7 +114,7 @@ data Input
     MergeLocalBranchI LooseCodeOrProject LooseCodeOrProject Branch.MergeMode
   | PreviewMergeLocalBranchI LooseCodeOrProject LooseCodeOrProject
   | DiffNamespaceI BranchId BranchId -- old new
-  | PullRemoteBranchI PullSourceTarget SyncMode PullMode Verbosity
+  | PullRemoteBranchI PullSourceTarget PullMode Verbosity
   | PushRemoteBranchI PushRemoteBranchInput
   | ResetRootI (Either ShortCausalHash Path')
   | ResetI
@@ -291,8 +290,7 @@ data PushSourceTarget
 
 data PushRemoteBranchInput = PushRemoteBranchInput
   { sourceTarget :: PushSourceTarget,
-    pushBehavior :: PushBehavior,
-    syncMode :: SyncMode
+    pushBehavior :: PushBehavior
   }
   deriving stock (Eq, Show)
 

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -241,6 +241,7 @@ data Input
   | ReleaseDraftI Semver
   | UpgradeI !NameSegment !NameSegment
   | EditNamespaceI [Path.Path]
+  | LibInstallI !(ProjectAndBranch ProjectName (Maybe ProjectBranchNameOrLatestRelease))
   deriving (Eq, Show)
 
 -- | The source of a `branch` command: what to make the new branch from.

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -395,6 +395,7 @@ data Output
   | UpgradeFailure !FilePath !NameSegment !NameSegment
   | UpgradeSuccess !NameSegment !NameSegment
   | LooseCodePushDeprecated
+  | InstalledLibdep !(ProjectAndBranch ProjectName ProjectBranchName) !NameSegment
 
 data UpdateOrUpgrade = UOUUpdate | UOUUpgrade
 
@@ -624,6 +625,7 @@ isFailure o = case o of
   UpgradeFailure {} -> True
   UpgradeSuccess {} -> False
   LooseCodePushDeprecated -> True
+  InstalledLibdep {} -> False
 
 isNumberedFailure :: NumberedOutput -> Bool
 isNumberedFailure = \case

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -41,7 +41,6 @@ import Unison.Codebase.Editor.UriParser qualified as UriParser
 import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.Path.Parse qualified as Path
 import Unison.Codebase.PushBehavior qualified as PushBehavior
-import Unison.Codebase.SyncMode qualified as SyncMode
 import Unison.Codebase.Verbosity (Verbosity)
 import Unison.Codebase.Verbosity qualified as Verbosity
 import Unison.CommandLine
@@ -1362,67 +1361,20 @@ pullImpl name aliases verbosity pullMode addendum = do
               ],
           parse =
             maybeToEither (I.help self) . \case
-              [] -> Just $ Input.PullRemoteBranchI Input.PullSourceTarget0 SyncMode.ShortCircuit pullMode verbosity
+              [] -> Just $ Input.PullRemoteBranchI Input.PullSourceTarget0 pullMode verbosity
               [sourceString] -> do
                 source <- parsePullSource (Text.pack sourceString)
-                Just $ Input.PullRemoteBranchI (Input.PullSourceTarget1 source) SyncMode.ShortCircuit pullMode verbosity
+                Just $ Input.PullRemoteBranchI (Input.PullSourceTarget1 source) pullMode verbosity
               [sourceString, targetString] -> do
                 source <- parsePullSource (Text.pack sourceString)
                 target <- parseLooseCodeOrProject targetString
                 Just $
                   Input.PullRemoteBranchI
                     (Input.PullSourceTarget2 source target)
-                    SyncMode.ShortCircuit
                     pullMode
                     verbosity
               _ -> Nothing
         }
-
-pullExhaustive :: InputPattern
-pullExhaustive =
-  InputPattern
-    "debug.pull-exhaustive"
-    []
-    I.Hidden
-    [("remote namespace to pull", Optional, remoteNamespaceArg), ("destination namespace", Optional, namespaceArg)]
-    ( P.lines
-        [ P.wrap $
-            "The "
-              <> makeExample' pullExhaustive
-              <> "command can be used in place of"
-              <> makeExample' pullVerbose
-              <> "to complete namespaces"
-              <> "which were pulled incompletely due to a bug in UCM"
-              <> "versions M1l and earlier.  It may be extra slow!"
-        ]
-    )
-    ( maybeToEither (I.help pullExhaustive) . \case
-        [] ->
-          Just $
-            Input.PullRemoteBranchI
-              Input.PullSourceTarget0
-              SyncMode.Complete
-              Input.PullWithHistory
-              Verbosity.Verbose
-        [sourceString] -> do
-          source <- parsePullSource (Text.pack sourceString)
-          Just $
-            Input.PullRemoteBranchI
-              (Input.PullSourceTarget1 source)
-              SyncMode.Complete
-              Input.PullWithHistory
-              Verbosity.Verbose
-        [sourceString, targetString] -> do
-          source <- parsePullSource (Text.pack sourceString)
-          target <- parseLooseCodeOrProject targetString
-          Just $
-            Input.PullRemoteBranchI
-              (Input.PullSourceTarget2 source target)
-              SyncMode.Complete
-              Input.PullWithHistory
-              Verbosity.Verbose
-        _ -> Nothing
-    )
 
 debugTabCompletion :: InputPattern
 debugTabCompletion =
@@ -1524,8 +1476,7 @@ push =
         Input.PushRemoteBranchI
           Input.PushRemoteBranchInput
             { sourceTarget,
-              pushBehavior = PushBehavior.RequireNonEmpty,
-              syncMode = SyncMode.ShortCircuit
+              pushBehavior = PushBehavior.RequireNonEmpty
             }
   where
     suggestionsConfig =
@@ -1580,8 +1531,7 @@ pushCreate =
         Input.PushRemoteBranchI
           Input.PushRemoteBranchInput
             { sourceTarget,
-              pushBehavior = PushBehavior.RequireEmpty,
-              syncMode = SyncMode.ShortCircuit
+              pushBehavior = PushBehavior.RequireEmpty
             }
   where
     suggestionsConfig =
@@ -1615,8 +1565,7 @@ pushForce =
         Input.PushRemoteBranchI
           Input.PushRemoteBranchInput
             { sourceTarget,
-              pushBehavior = PushBehavior.ForcePush,
-              syncMode = SyncMode.ShortCircuit
+              pushBehavior = PushBehavior.ForcePush
             }
   where
     suggestionsConfig =
@@ -1660,8 +1609,7 @@ pushExhaustive =
         Input.PushRemoteBranchI
           Input.PushRemoteBranchInput
             { sourceTarget,
-              pushBehavior = PushBehavior.RequireNonEmpty,
-              syncMode = SyncMode.Complete
+              pushBehavior = PushBehavior.RequireNonEmpty
             }
   where
     suggestionsConfig =
@@ -3079,7 +3027,6 @@ validInputs =
       projectSwitch,
       projectsInputPattern,
       pull,
-      pullExhaustive,
       pullVerbose,
       pullWithoutHistory,
       push,

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1339,25 +1339,6 @@ notifyUser dir = \case
           push = P.group . P.backticked . IP.patternName $ IP.push
           pull = P.group . P.backticked . IP.patternName $ IP.pull
     GitCodebaseError e -> case e of
-      CouldntParseRemoteBranch repo s ->
-        P.wrap $
-          "I couldn't decode the root branch "
-            <> P.string s
-            <> "from the repository at"
-            <> prettyReadGitRepo repo
-      CouldntLoadRootBranch repo hash ->
-        P.wrap $
-          "I couldn't load the designated root hash"
-            <> P.group ("(" <> P.text (Hash.toBase32HexText $ unCausalHash hash) <> ")")
-            <> "from the repository at"
-            <> prettyReadGitRepo repo
-      CouldntLoadSyncedBranch ns h ->
-        P.wrap $
-          "I just finished importing the branch"
-            <> P.red (P.shown h)
-            <> "from"
-            <> P.red (prettyReadRemoteNamespaceWith absurd (RemoteRepo.ReadRemoteNamespaceGit ns))
-            <> "but now I can't find it."
       CouldntFindRemoteBranch repo path ->
         P.wrap $
           "I couldn't find the remote branch at"

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -2214,6 +2214,12 @@ notifyUser dir = \case
           "",
           "Your non-project code is still available to pull from Share, and you can pull it into a local namespace using `pull myhandle.public`"
         ]
+  InstalledLibdep libdep segment ->
+    pure . P.wrap $
+      "I installed"
+        <> prettyProjectAndBranchName libdep
+        <> "as"
+        <> P.group (P.text (NameSegment.toEscapedText segment) <> ".")
 
 expectedEmptyPushDest :: WriteRemoteNamespace Void -> Pretty
 expectedEmptyPushDest namespace =

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -61,6 +61,7 @@ library
       Unison.Codebase.Editor.HandleInput.EditNamespace
       Unison.Codebase.Editor.HandleInput.FindAndReplace
       Unison.Codebase.Editor.HandleInput.FormatFile
+      Unison.Codebase.Editor.HandleInput.InstallLib
       Unison.Codebase.Editor.HandleInput.Load
       Unison.Codebase.Editor.HandleInput.MoveAll
       Unison.Codebase.Editor.HandleInput.MoveBranch

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -34,6 +34,7 @@ library
       Unison.Auth.Tokens
       Unison.Auth.Types
       Unison.Auth.UserInfo
+      Unison.Cli.DownloadUtils
       Unison.Cli.Monad
       Unison.Cli.MonadUtils
       Unison.Cli.NamesUtils
@@ -165,6 +166,7 @@ library
       NamedFieldPuns
       NumericUnderscores
       OverloadedLabels
+      OverloadedRecordDot
       OverloadedStrings
       PatternSynonyms
       RankNTypes
@@ -303,6 +305,7 @@ executable transcripts
       NamedFieldPuns
       NumericUnderscores
       OverloadedLabels
+      OverloadedRecordDot
       OverloadedStrings
       PatternSynonyms
       RankNTypes
@@ -449,6 +452,7 @@ test-suite cli-tests
       NamedFieldPuns
       NumericUnderscores
       OverloadedLabels
+      OverloadedRecordDot
       OverloadedStrings
       PatternSynonyms
       RankNTypes

--- a/unison-core/src/Unison/Project.hs
+++ b/unison-core/src/Unison/Project.hs
@@ -7,6 +7,7 @@
 module Unison.Project
   ( ProjectName,
     projectNameUserSlug,
+    projectNameToUserProjectSlugs,
     prependUserSlugToProjectName,
     ProjectBranchName,
     projectBranchNameUserSlug,
@@ -81,6 +82,21 @@ projectNameUserSlug (UnsafeProjectName projectName) =
   if Text.head projectName == '@'
     then Just (Text.takeWhile (/= '/') (Text.drop 1 projectName))
     else Nothing
+
+-- | Parse a "@arya/lens" into the "arya" and "lens" parts.
+--
+-- If there's no "arya" part, returns the empty string there.
+--
+-- >>> projectNameToUserProjectSlugs (UnsafeProjectName "@arya/lens")
+-- ("arya","lens")
+--
+-- >>> projectNameToUserProjectSlugs (UnsafeProjectName "lens")
+-- ("","lens")
+projectNameToUserProjectSlugs :: ProjectName -> (Text, Text)
+projectNameToUserProjectSlugs (UnsafeProjectName name) =
+  case Text.span (/= '/') name of
+    (project, "") -> ("", project)
+    (atUser, slashProject) -> (Text.drop 1 atUser, Text.drop 1 slashProject)
 
 -- | Prepend a user slug to a project name, if it doesn't already have one.
 --
@@ -289,6 +305,15 @@ data ProjectBranchSpecifier :: Type -> Type where
   -- | By name, or "the latest release"
   ProjectBranchSpecifier'NameOrLatestRelease :: ProjectBranchSpecifier ProjectBranchNameOrLatestRelease
 
+projectBranchSpecifierParser :: ProjectBranchSpecifier branch -> Megaparsec.Parsec Void Text branch
+projectBranchSpecifierParser = \case
+  ProjectBranchSpecifier'Name -> projectBranchNameParser False
+  ProjectBranchSpecifier'NameOrLatestRelease ->
+    asum
+      [ ProjectBranchNameOrLatestRelease'LatestRelease <$ "releases/latest",
+        ProjectBranchNameOrLatestRelease'Name <$> projectBranchNameParser False
+      ]
+
 instance From (ProjectAndBranch ProjectName ProjectBranchName) Text where
   from (ProjectAndBranch project branch) =
     Text.Builder.run $
@@ -377,25 +402,15 @@ projectAndBranchNamesParser specifier = do
   optional projectNameParser >>= \case
     Nothing -> do
       _ <- Megaparsec.char '/'
-      branch <- branchParser
+      branch <- projectBranchSpecifierParser specifier
       pure (That branch)
     Just (project, hasTrailingSlash) ->
       if hasTrailingSlash
         then do
-          optional branchParser <&> \case
+          optional (projectBranchSpecifierParser specifier) <&> \case
             Nothing -> This project
             Just branch -> These project branch
         else pure (This project)
-  where
-    branchParser :: Megaparsec.Parsec Void Text branch
-    branchParser =
-      case specifier of
-        ProjectBranchSpecifier'Name -> projectBranchNameParser False
-        ProjectBranchSpecifier'NameOrLatestRelease ->
-          asum
-            [ ProjectBranchNameOrLatestRelease'LatestRelease <$ "releases/latest",
-              ProjectBranchNameOrLatestRelease'Name <$> projectBranchNameParser False
-            ]
 
 -- | @project/branch@ syntax, where the branch is optional.
 instance From (ProjectAndBranch ProjectName (Maybe ProjectBranchName)) Text where
@@ -409,25 +424,34 @@ instance From (ProjectAndBranch ProjectName (Maybe ProjectBranchName)) Text wher
 
 instance TryFrom Text (ProjectAndBranch ProjectName (Maybe ProjectBranchName)) where
   tryFrom =
-    maybeTryFrom (Megaparsec.parseMaybe projectWithOptionalBranchParser)
+    maybeTryFrom (Megaparsec.parseMaybe (projectAndOptionalBranchParser ProjectBranchSpecifier'Name))
 
 -- | Attempt to parse a project and branch name from a string where both are required.
 instance TryFrom Text (ProjectAndBranch ProjectName ProjectBranchName) where
   tryFrom =
     maybeTryFrom $ \txt -> do
-      ProjectAndBranch projectName mayBranchName <- Megaparsec.parseMaybe projectWithOptionalBranchParser txt
+      ProjectAndBranch projectName mayBranchName <- Megaparsec.parseMaybe (projectAndOptionalBranchParser ProjectBranchSpecifier'Name) txt
       ProjectAndBranch projectName <$> mayBranchName
+
+instance TryFrom Text (ProjectAndBranch ProjectName (Maybe ProjectBranchNameOrLatestRelease)) where
+  tryFrom =
+    maybeTryFrom (Megaparsec.parseMaybe (projectAndOptionalBranchParser ProjectBranchSpecifier'NameOrLatestRelease))
 
 -- Valid things:
 --
 --   1. project
 --   2. project/
 --   3. project/branch
-projectWithOptionalBranchParser :: Megaparsec.Parsec Void Text (ProjectAndBranch ProjectName (Maybe ProjectBranchName))
-projectWithOptionalBranchParser = do
+projectAndOptionalBranchParser ::
+  forall branch.
+  ProjectBranchSpecifier branch ->
+  Megaparsec.Parsec Void Text (ProjectAndBranch ProjectName (Maybe branch))
+projectAndOptionalBranchParser specifier = do
   (project, hasTrailingSlash) <- projectNameParser
-  branch <- if hasTrailingSlash then optional (projectBranchNameParser False) else pure Nothing
-  pure (ProjectAndBranch project branch)
+  fmap (ProjectAndBranch project) $
+    if hasTrailingSlash
+      then optional (projectBranchSpecifierParser specifier)
+      else pure Nothing
 
 -- | @project/branch@ syntax, where the project is optional. The branch can optionally be preceded by a forward slash.
 instance From (ProjectAndBranch (Maybe ProjectName) ProjectBranchName) Text where


### PR DESCRIPTION
## Overview

![install](https://github.com/unisonweb/unison/assets/1074598/f75504e2-0e9e-4fb0-8e3f-5c9e4ae97280)

Edit: the help now looks like this

![2024-05-15-212736_1281x293_scrot](https://github.com/unisonweb/unison/assets/1074598/fe1eeb97-3258-40a8-a362-948434707527)

This PR adds a `lib.install` (alias: `install.lib`) command to replace `pull` for installing a dependency into `lib`.

It's different than `pull` in a couple ways:

- You don't provide a local name for the dependency; `pull @unison/base/releases/4.0.0 lib.base_4_0_0` just becomes `lib.install @unison/base/releases/4.0.0`, and the name is picked automatically (see screenshot).
- Because the name is picked manually, it always installs into an empty namespace. So, there's never a merge.

## Test coverage

I tested this manually