### PR TITLE
Update sqlite3 codebase before changing in-app values

### DIFF
--- a/unison-cli/src/Unison/Cli/MonadUtils.hs
+++ b/unison-cli/src/Unison/Cli/MonadUtils.hs
@@ -474,8 +474,8 @@ updateRoot new reason =
     let newHash = Branch.headHash new
     oldHash <- getLastSavedRootHash
     when (oldHash /= newHash) do
-      setRootBranch new
       liftIO (Codebase.putRootBranch codebase reason new)
+      setRootBranch new
       setLastSavedRootHash newHash
 
 ------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Overview

I noticed when working on the auth lib that the LSP seemed to be lagging one full change behind at all times;
I would add a new lib and  try to use it, UCM reported all is well but the LSP didn't know about it.

It turns out that the LSP was being notified and started re-checking AFTER the time when the Haskell branch root was updated, but BEFORE the sqlite transaction went through, meaning it would compute everything using a branch that was one iteration late.

## Implementation notes

I just swapped updating the haskell app until AFTER the change is persisted in the DB. 


## Test coverage

Not really sure how to test the LSP in transcripts and such, since the LSP doesn't actually run during transcripts (and we probably don't want it to)... I'll think on it a bit but let me know if you have any ideas.

## Loose ends

No matter what we have a race-condition here where you can Ctrl-c when either sqlite or Haskell has updated but not the other, which is annoying; but I figure that the better of the two options would be to have the data persisted on disk and not just in memory.

We should maybe just do a quick check whenever we catch a ctrl-c that the in-memory root matches the codebase root just to be sure, and sync them if not. Let me know if you agree on that and if I should add that change as part of this PR or a different one. @aryairani 

