### PR TITLE
Unison local Definition Diffs API

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/DisplayObject.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/DisplayObject.hs
@@ -4,8 +4,19 @@ module Unison.Codebase.Editor.DisplayObject where
 
 import Data.Bifoldable
 import Data.Bitraversable
+import Data.Set qualified as Set
+import U.Codebase.Reference (TermReference, TypeReference)
+import Unison.DataDeclaration qualified as DD
+import Unison.DataDeclaration.Dependencies qualified as DD
+import Unison.LabeledDependency qualified as LD
+import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.ShortHash (ShortHash)
+import Unison.Symbol (Symbol)
+import Unison.Term (Term)
+import Unison.Term qualified as Term
+import Unison.Type (Type)
+import Unison.Type qualified as Type
 
 data DisplayObject b a = BuiltinObject b | MissingObject ShortHash | UserObject a
   deriving (Eq, Ord, Show, Functor, Generic, Foldable, Traversable)
@@ -27,3 +38,14 @@ toMaybe :: DisplayObject b a -> Maybe a
 toMaybe = \case
   UserObject a -> Just a
   _ -> Nothing
+
+termDisplayObjectLabeledDependencies :: TermReference -> DisplayObject (Type Symbol Ann) (Term Symbol Ann) -> (Set LD.LabeledDependency)
+termDisplayObjectLabeledDependencies termRef displayObject = do
+  displayObject
+    & bifoldMap (Type.labeledDependencies) (Term.labeledDependencies)
+    & Set.insert (LD.TermReference termRef)
+
+typeDisplayObjectLabeledDependencies :: TypeReference -> DisplayObject () (DD.Decl Symbol Ann) -> Set LD.LabeledDependency
+typeDisplayObjectLabeledDependencies typeRef displayObject = do
+  displayObject
+    & foldMap (DD.labeledDeclDependenciesIncludingSelfAndFieldAccessors typeRef)

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -536,11 +536,12 @@ loop e = do
             DocToMarkdownI docName -> do
               names <- Cli.currentNames
               pped <- Cli.prettyPrintEnvDeclFromNames names
-              hqLength <- Cli.runTransaction Codebase.hashLength
-              let nameSearch = NameSearch.makeNameSearch hqLength names
               Cli.Env {codebase, runtime} <- ask
+              docRefs <- Cli.runTransaction do
+                hqLength <- Codebase.hashLength
+                let nameSearch = NameSearch.makeNameSearch hqLength names
+                Backend.docsForDefinitionName codebase nameSearch Names.IncludeSuffixes docName
               mdText <- liftIO $ do
-                docRefs <- Backend.docsForDefinitionName codebase nameSearch Names.IncludeSuffixes docName
                 for docRefs \docRef -> do
                   Identity (_, _, doc, _evalErrs) <- Backend.renderDocRefs pped (Pretty.Width 80) codebase runtime (Identity docRef)
                   pure . Md.toText $ Md.toMarkdown doc

--- a/unison-cli/src/Unison/LSP/Queries.hs
+++ b/unison-cli/src/Unison/LSP/Queries.hs
@@ -389,7 +389,7 @@ markdownDocsForFQN fileUri fqn =
     nameSearch <- lift $ getNameSearch
     Env {codebase, runtime} <- ask
     liftIO $ do
-      docRefs <- Backend.docsForDefinitionName codebase nameSearch ExactName name
+      docRefs <- Codebase.runTransaction codebase $ Backend.docsForDefinitionName codebase nameSearch ExactName name
       for docRefs $ \docRef -> do
         Identity (_, _, doc, _evalErrs) <- Backend.renderDocRefs pped (Pretty.Width 80) codebase runtime (Identity docRef)
         pure . Md.toText $ Md.toMarkdown doc

--- a/unison-share-api/src/Unison/Server/Backend.hs
+++ b/unison-share-api/src/Unison/Server/Backend.hs
@@ -842,14 +842,13 @@ docsForDefinitionName ::
   NameSearch Sqlite.Transaction ->
   Names.SearchType ->
   Name ->
-  IO [TermReference]
+  Sqlite.Transaction [TermReference]
 docsForDefinitionName codebase (NameSearch {termSearch}) searchType name = do
   let potentialDocNames = [name, name Cons.:> "doc"]
-  Codebase.runTransaction codebase do
-    refs <-
-      potentialDocNames & foldMapM \name ->
-        lookupRelativeHQRefs' termSearch searchType (HQ'.NameOnly name)
-    filterForDocs (toList refs)
+  refs <-
+    potentialDocNames & foldMapM \name ->
+      lookupRelativeHQRefs' termSearch searchType (HQ'.NameOnly name)
+  filterForDocs (toList refs)
   where
     filterForDocs :: [Referent] -> Sqlite.Transaction [TermReference]
     filterForDocs rs = do

--- a/unison-share-api/src/Unison/Server/CodebaseServer.hs
+++ b/unison-share-api/src/Unison/Server/CodebaseServer.hs
@@ -109,7 +109,7 @@ import Unison.Server.Local.Endpoints.NamespaceDetails qualified as NamespaceDeta
 import Unison.Server.Local.Endpoints.NamespaceListing qualified as NamespaceListing
 import Unison.Server.Local.Endpoints.Projects (ListProjectBranchesEndpoint, ListProjectsEndpoint, projectBranchListingEndpoint, projectListingEndpoint)
 import Unison.Server.Local.Endpoints.UCM (UCMAPI, ucmServer)
-import Unison.Server.Types (TermDiffResponse, TypeDiffResponse, mungeString, setCacheControl)
+import Unison.Server.Types (TermDefinition (..), TermDiffResponse, TypeDiffResponse, mungeString, setCacheControl)
 import Unison.Share.API.Projects (BranchName)
 import Unison.ShortHash qualified as ShortHash
 import Unison.Symbol (Symbol)
@@ -608,7 +608,9 @@ serveProjectsCodebaseServerAPI codebase rt projectName branchName = do
 
 serveProjectDiffTermsEndpoint :: Codebase m v a -> ProjectName -> BranchName -> BranchName -> Name -> Name -> Backend IO TermDiffResponse
 serveProjectDiffTermsEndpoint projectName oldBranchRef newBranchRef oldTerm newTerm = do
-  undefined
+  oldTerm@(TermDefinition {termDefinition = oldDisplayObj}) <- getTermDefinition authZReceipt project oldShortHand oldTermName `whenNothingM` respondError (EntityMissing (ErrorID "term-not-found") ("Term not found: " <> IDs.toText oldShortHand <> ":" <> Name.toText oldTermName))
+  newTerm@(TermDefinition {termDefinition = newDisplayObj}) <- getTermDefinition authZReceipt project newShortHand newTermName `whenNothingM` respondError (EntityMissing (ErrorID "term-not-found") ("Term not found: " <> IDs.toText newShortHand <> ":" <> Name.toText newTermName))
+  let termDiffDisplayObject = DefinitionDiff.diffDisplayObjects oldDisplayObj newDisplayObj
 
 serveProjectDiffTypesEndpoint :: Codebase m v a -> ProjectName -> BranchName -> BranchName -> Name -> Name -> Backend IO TypeDiffResponse
 serveProjectDiffTypesEndpoint projectName oldBranchRef newBranchRef oldType newType = do

--- a/unison-share-api/src/Unison/Server/CodebaseServer.hs
+++ b/unison-share-api/src/Unison/Server/CodebaseServer.hs
@@ -161,9 +161,11 @@ type CodebaseServerAPI =
 type ProjectsAPI =
   ListProjectsEndpoint
     :<|> ( Capture "project-name" ProjectName
-             :> "branches"
-             :> ( ListProjectBranchesEndpoint
-                    :<|> (Capture "branch-name" ProjectBranchName :> CodebaseServerAPI)
+             :> ( ( "branches"
+                      :> ( ListProjectBranchesEndpoint
+                             :<|> (Capture "branch-name" ProjectBranchName :> CodebaseServerAPI)
+                         )
+                  )
                     :<|> ( "diff"
                              :> ( "terms" :> ProjectDiffTermsEndpoint
                                     :<|> "types" :> ProjectDiffTypesEndpoint
@@ -668,8 +670,9 @@ serveProjectsAPI :: Codebase IO Symbol Ann -> Rt.Runtime Symbol -> ServerT Proje
 serveProjectsAPI codebase rt =
   projectListingEndpoint codebase
     :<|> ( \projectName ->
-             projectBranchListingEndpoint codebase projectName
-               :<|> serveProjectsCodebaseServerAPI codebase rt projectName
+             ( projectBranchListingEndpoint codebase projectName
+                 :<|> serveProjectsCodebaseServerAPI codebase rt projectName
+             )
                :<|> ( serveProjectDiffTermsEndpoint codebase rt projectName
                         :<|> serveProjectDiffTypesEndpoint codebase rt projectName
                     )

--- a/unison-share-api/src/Unison/Server/Local/Definitions.hs
+++ b/unison-share-api/src/Unison/Server/Local/Definitions.hs
@@ -1,4 +1,9 @@
-module Unison.Server.Local.Definitions (prettyDefinitionsForHQName) where
+module Unison.Server.Local.Definitions
+  ( prettyDefinitionsForHQName,
+    termDefinitionByName,
+    typeDefinitionByName,
+  )
+where
 
 import Control.Lens hiding ((??))
 import Control.Monad.Except

--- a/unison-share-api/src/Unison/Server/Local/Definitions.hs
+++ b/unison-share-api/src/Unison/Server/Local/Definitions.hs
@@ -2,15 +2,21 @@ module Unison.Server.Local.Definitions (prettyDefinitionsForHQName) where
 
 import Control.Lens hiding ((??))
 import Control.Monad.Except
+import Control.Monad.Trans.Maybe (mapMaybeT)
 import Data.Map qualified as Map
+import Data.Set.NonEmpty qualified as NESet
 import U.Codebase.Branch qualified as V2Branch
 import U.Codebase.Causal qualified as V2Causal
+import U.Codebase.Reference (TermReference)
 import Unison.Codebase (Codebase)
 import Unison.Codebase qualified as Codebase
+import Unison.Codebase.Editor.DisplayObject (DisplayObject)
 import Unison.Codebase.Path (Path)
 import Unison.Codebase.Runtime qualified as Rt
 import Unison.HashQualified qualified as HQ
+import Unison.HashQualified' qualified as HQ'
 import Unison.Name (Name)
+import Unison.NamesWithHistory qualified as NS
 import Unison.NamesWithHistory qualified as Names
 import Unison.Parser.Ann (Ann)
 import Unison.Prelude
@@ -19,13 +25,19 @@ import Unison.PrettyPrintEnvDecl qualified as PPED
 import Unison.Reference qualified as Reference
 import Unison.Referent qualified as Referent
 import Unison.Server.Backend
+import Unison.Server.Backend qualified as Backend
 import Unison.Server.Doc qualified as Doc
 import Unison.Server.Local qualified as Local
+import Unison.Server.NameSearch (NameSearch)
+import Unison.Server.NameSearch qualified as NS
+import Unison.Server.NameSearch qualified as NameSearch
 import Unison.Server.NameSearch.FromNames (makeNameSearch)
 import Unison.Server.Types
 import Unison.Sqlite qualified as Sqlite
 import Unison.Symbol (Symbol)
 import Unison.Syntax.HashQualified qualified as HQ (toText)
+import Unison.Term (Term)
+import Unison.Type (Type)
 import Unison.Util.Map qualified as Map
 import Unison.Util.Pretty (Width)
 
@@ -71,7 +83,7 @@ prettyDefinitionsForHQName perspective shallowRoot renderWidth suffixifyBindings
   let width = mayDefaultWidth renderWidth
   let docResults :: Name -> IO [(HashQualifiedName, UnisonHash, Doc.Doc)]
       docResults name = do
-        docRefs <- docsForDefinitionName codebase nameSearch Names.ExactName name
+        docRefs <- Codebase.runTransaction codebase $ docsForDefinitionName codebase nameSearch Names.ExactName name
         renderDocRefs pped width codebase rt docRefs
           -- local server currently ignores doc eval errors
           <&> fmap \(hqn, h, doc, _errs) -> (hqn, h, doc)
@@ -96,3 +108,37 @@ prettyDefinitionsForHQName perspective shallowRoot renderWidth suffixifyBindings
       renderedDisplayTerms
       renderedDisplayTypes
       renderedMisses
+
+-- | Find the term referenced by the given name and return a display object for it.
+termDisplayObjectByName :: Codebase m Symbol Ann -> NameSearch Sqlite.Transaction -> Name -> Sqlite.Transaction (Maybe (TermReference, DisplayObject (Type Symbol Ann) (Term Symbol Ann)))
+termDisplayObjectByName codebase nameSearch name = runMaybeT do
+  refs <- lift $ NameSearch.lookupRelativeHQRefs' (NS.termSearch nameSearch) NS.ExactName (HQ'.NameOnly name)
+  ref <- fmap NESet.findMin . hoistMaybe $ NESet.nonEmptySet refs
+  case ref of
+    Referent.Ref r -> (r,) <$> lift (Backend.displayTerm codebase r)
+    Referent.Con _ _ ->
+      -- TODO: Should we error here or some other sensible thing rather than returning no
+      -- result?
+      empty
+
+termDefinitionByName ::
+  Codebase IO Symbol Ann ->
+  PPED.PrettyPrintEnvDecl ->
+  NameSearch Sqlite.Transaction ->
+  Width ->
+  Rt.Runtime Symbol ->
+  Name ->
+  Backend IO (Maybe TermDefinition)
+termDefinitionByName codebase pped nameSearch width rt name = runMaybeT $ do
+  let biasedPPED = PPED.biasTo [name] pped
+  (ref, displayObject, docRefs) <- mapMaybeT (liftIO . Codebase.runTransaction codebase) $ do
+    (ref, displayObject) <- MaybeT $ termDisplayObjectByName codebase nameSearch name
+    docRefs <- lift $ Backend.docsForDefinitionName codebase nameSearch NS.ExactName name
+    pure (ref, displayObject, docRefs)
+  renderedDocs <-
+    liftIO $
+      renderDocRefs pped width codebase rt docRefs
+        -- local server currently ignores doc eval errors
+        <&> fmap \(hqn, h, doc, _errs) -> (hqn, h, doc)
+  let (_ref, syntaxDO) = Backend.termsToSyntaxOf (Suffixify False) width pped id (ref, displayObject)
+  lift $ Backend.mkTermDefinition codebase biasedPPED width ref renderedDocs syntaxDO

--- a/unison-share-api/src/Unison/Server/Local/Definitions.hs
+++ b/unison-share-api/src/Unison/Server/Local/Definitions.hs
@@ -154,7 +154,7 @@ typeDisplayObjectByName :: Codebase m Symbol Ann -> NameSearch Sqlite.Transactio
 typeDisplayObjectByName codebase nameSearch name = runMaybeT do
   refs <- lift $ NameSearch.lookupRelativeHQRefs' (NS.typeSearch nameSearch) NS.ExactName (HQ'.NameOnly name)
   ref <- fmap NESet.findMin . hoistMaybe $ NESet.nonEmptySet refs
-  fmap (ref,) . lift $ Backend.displayType ref
+  fmap (ref,) . lift $ Backend.displayType codebase ref
 
 typeDefinitionByName ::
   Codebase IO Symbol Ann ->

--- a/unison-share-api/src/Unison/Server/Types.hs
+++ b/unison-share-api/src/Unison/Server/Types.hs
@@ -38,16 +38,16 @@ import U.Codebase.HashTags
 import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Editor.DisplayObject (DisplayObject)
 import Unison.Codebase.Path qualified as Path
+import Unison.Core.Project (ProjectBranchName)
 import Unison.Hash qualified as Hash
 import Unison.HashQualified qualified as HQ
 import Unison.HashQualified' qualified as HQ'
 import Unison.Name (Name)
 import Unison.Prelude
-import Unison.Project (ProjectAndBranch, ProjectBranchName, ProjectName)
+import Unison.Project (ProjectAndBranch, ProjectName)
 import Unison.Server.Doc (Doc)
 import Unison.Server.Orphans ()
 import Unison.Server.Syntax qualified as Syntax
-import Unison.Share.API.Projects (BranchName)
 import Unison.ShortHash (ShortHash)
 import Unison.Syntax.HashQualified qualified as HQ (parseText)
 import Unison.Syntax.Name qualified as Name
@@ -467,8 +467,8 @@ instance Docs.ToCapture (Capture "project-and-branch" ProjectBranchNameParam) wh
 
 data TermDiffResponse = TermDiffResponse
   { project :: ProjectName,
-    oldBranch :: BranchName,
-    newBranch :: BranchName,
+    oldBranch :: ProjectBranchName,
+    newBranch :: ProjectBranchName,
     oldTerm :: TermDefinition,
     newTerm :: TermDefinition,
     diff :: DisplayObjectDiff
@@ -505,8 +505,8 @@ instance ToJSON TermDiffResponse where
 
 data TypeDiffResponse = TypeDiffResponse
   { project :: ProjectName,
-    oldBranch :: BranchName,
-    newBranch :: BranchName,
+    oldBranch :: ProjectBranchName,
+    newBranch :: ProjectBranchName,
     oldType :: TypeDefinition,
     newType :: TypeDefinition,
     diff :: DisplayObjectDiff

--- a/unison-share-api/src/Unison/Server/Types.hs
+++ b/unison-share-api/src/Unison/Server/Types.hs
@@ -47,6 +47,7 @@ import Unison.Project (ProjectAndBranch, ProjectBranchName, ProjectName)
 import Unison.Server.Doc (Doc)
 import Unison.Server.Orphans ()
 import Unison.Server.Syntax qualified as Syntax
+import Unison.Share.API.Projects (BranchName)
 import Unison.ShortHash (ShortHash)
 import Unison.Syntax.HashQualified qualified as HQ (parseText)
 import Unison.Syntax.Name qualified as Name
@@ -258,7 +259,9 @@ data SemanticSyntaxDiff
     SegmentChange (String, String) (Maybe Syntax.Element)
   | -- (shared segment) (fromAnnotation, toAnnotation)
     AnnotationChange String (Maybe Syntax.Element, Maybe Syntax.Element)
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
+
+deriving instance ToSchema SemanticSyntaxDiff
 
 instance ToJSON SemanticSyntaxDiff where
   toJSON = \case
@@ -299,7 +302,9 @@ instance ToJSON SemanticSyntaxDiff where
 data DisplayObjectDiff
   = DisplayObjectDiff (DisplayObject [SemanticSyntaxDiff] [SemanticSyntaxDiff])
   | MismatchedDisplayObjects (DisplayObject Syntax.SyntaxText Syntax.SyntaxText) (DisplayObject Syntax.SyntaxText Syntax.SyntaxText)
-  deriving stock (Show, Eq)
+  deriving stock (Show, Eq, Generic)
+
+deriving instance ToSchema DisplayObjectDiff
 
 data UnisonRef
   = TypeRef UnisonHash
@@ -459,3 +464,79 @@ instance Docs.ToCapture (Capture "project-and-branch" ProjectBranchNameParam) wh
     DocCapture
       "project-and-branch"
       "The name of a project and branch e.g. `@unison%2Fbase%2Fmain` or `@unison%2Fbase%2F@runarorama%2Fmain`"
+
+data TermDiffResponse = TermDiffResponse
+  { project :: ProjectName,
+    oldBranch :: BranchName,
+    newBranch :: BranchName,
+    oldTerm :: TermDefinition,
+    newTerm :: TermDefinition,
+    diff :: DisplayObjectDiff
+  }
+  deriving (Eq, Show, Generic)
+
+deriving instance ToSchema TermDiffResponse
+
+instance Docs.ToSample TermDiffResponse where
+  toSamples _ = []
+
+instance ToJSON TermDiffResponse where
+  toJSON (TermDiffResponse {diff, project, oldBranch, newBranch, oldTerm, newTerm}) =
+    case diff of
+      DisplayObjectDiff dispDiff ->
+        object
+          [ "diff" .= dispDiff,
+            "diffKind" .= ("diff" :: Text),
+            "project" .= project,
+            "oldBranchRef" .= oldBranch,
+            "newBranchRef" .= newBranch,
+            "oldTerm" .= oldTerm,
+            "newTerm" .= newTerm
+          ]
+      MismatchedDisplayObjects {} ->
+        object
+          [ "diffKind" .= ("mismatched" :: Text),
+            "project" .= project,
+            "oldBranchRef" .= oldBranch,
+            "newBranchRef" .= newBranch,
+            "oldTerm" .= oldTerm,
+            "newTerm" .= newTerm
+          ]
+
+data TypeDiffResponse = TypeDiffResponse
+  { project :: ProjectName,
+    oldBranch :: BranchName,
+    newBranch :: BranchName,
+    oldType :: TypeDefinition,
+    newType :: TypeDefinition,
+    diff :: DisplayObjectDiff
+  }
+  deriving (Eq, Show, Generic)
+
+deriving instance ToSchema TypeDiffResponse
+
+instance Docs.ToSample TypeDiffResponse where
+  toSamples _ = []
+
+instance ToJSON TypeDiffResponse where
+  toJSON (TypeDiffResponse {diff, project, oldBranch, newBranch, oldType, newType}) =
+    case diff of
+      DisplayObjectDiff dispDiff ->
+        object
+          [ "diff" .= dispDiff,
+            "diffKind" .= ("diff" :: Text),
+            "project" .= project,
+            "oldBranchRef" .= oldBranch,
+            "newBranchRef" .= newBranch,
+            "oldType" .= oldType,
+            "newType" .= newType
+          ]
+      MismatchedDisplayObjects {} ->
+        object
+          [ "diffKind" .= ("mismatched" :: Text),
+            "project" .= project,
+            "oldBranchRef" .= oldBranch,
+            "newBranchRef" .= newBranch,
+            "oldType" .= oldType,
+            "newType" .= newType
+          ]

--- a/unison-share-projects-api/src/Unison/Share/API/Projects.hs
+++ b/unison-share-projects-api/src/Unison/Share/API/Projects.hs
@@ -34,6 +34,7 @@ module Unison.Share.API.Projects
     ProjectBranchIds (..),
     NotFound (..),
     Unauthorized (..),
+    BranchName,
   )
 where
 

--- a/unison-src/transcripts/definition-diff-api.md
+++ b/unison-src/transcripts/definition-diff-api.md
@@ -1,0 +1,41 @@
+```ucm
+.> project.create-empty diffs
+diffs/main> builtins.merge
+```
+
+```unison
+term = 
+  _ = "Here's some text"
+  1 + 1
+
+type Type = Type Nat
+```
+
+```ucm
+diffs/main> add
+diffs/main> branch.create new
+```
+
+```unison
+term = 
+  _ = "Here's some different text"
+  1 + 2
+
+type Type a = Type a Text
+```
+
+```ucm
+diffs/new> update
+```
+
+Diff terms
+
+```api
+GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=term&newTerm=term
+```
+
+Diff types
+
+```api
+GET /api/projects/diffs/diff/types?oldBranchRef=main&newBranchRef=new&oldType=Type&newType=Type
+```

--- a/unison-src/transcripts/definition-diff-api.output.md
+++ b/unison-src/transcripts/definition-diff-api.output.md
@@ -90,6 +90,8 @@ diffs/new> update
   Done.
 
 ```
+Diff terms
+
 ```api
 GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=term&newTerm=term
 {
@@ -572,7 +574,9 @@ GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=te
     },
     "project": "diffs"
 }
-``````api
+```Diff types
+
+```api
 GET /api/projects/diffs/diff/types?oldBranchRef=main&newBranchRef=new&oldType=Type&newType=Type
 {
     "diff": {

--- a/unison-src/transcripts/definition-diff-api.output.md
+++ b/unison-src/transcripts/definition-diff-api.output.md
@@ -1,0 +1,819 @@
+```ucm
+.> project.create-empty diffs
+
+  🎉 I've created the project diffs.
+
+  🎨 Type `ui` to explore this project's code in your browser.
+  🔭 Discover libraries at https://share.unison-lang.org
+  📖 Use `help-topic projects` to learn more about projects.
+  
+  Write your first Unison code with UCM:
+  
+    1. Open scratch.u.
+    2. Write some Unison code and save the file.
+    3. In UCM, type `add` to save it to your new project.
+  
+  🎉 🥳 Happy coding!
+
+diffs/main> builtins.merge
+
+  Done.
+
+```
+```unison
+term = 
+  _ = "Here's some text"
+  1 + 1
+
+type Type = Type Nat
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      type Type
+      term : Nat
+
+```
+```ucm
+diffs/main> add
+
+  ⍟ I've added these definitions:
+  
+    type Type
+    term : Nat
+
+diffs/main> branch.create new
+
+  Done. I've created the new branch based off of main.
+  
+  Tip: Use `merge /new /main` to merge your work back into the
+       main branch.
+
+```
+```unison
+term = 
+  _ = "Here's some different text"
+  1 + 2
+
+type Type a = Type a Text
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      type Type a
+      term : Nat
+
+```
+```ucm
+diffs/new> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+
+```
+```api
+GET /api/projects/diffs/diff/terms?oldBranchRef=main&newBranchRef=new&oldTerm=term&newTerm=term
+{
+    "diff": {
+        "contents": [
+            {
+                "diffTag": "both",
+                "elements": [
+                    {
+                        "annotation": {
+                            "contents": "term",
+                            "tag": "HashQualifier"
+                        },
+                        "segment": "term"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "TypeAscriptionColon"
+                        },
+                        "segment": " :"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "contents": "##Nat",
+                            "tag": "TypeReference"
+                        },
+                        "segment": "Nat"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "\n"
+                    },
+                    {
+                        "annotation": {
+                            "contents": "term",
+                            "tag": "HashQualifier"
+                        },
+                        "segment": "term"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "BindingEquals"
+                        },
+                        "segment": " ="
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "\n"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "UseKeyword"
+                        },
+                        "segment": "use "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "UsePrefix"
+                        },
+                        "segment": "Nat"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "UseSuffix"
+                        },
+                        "segment": "+"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "\n"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    },
+                    {
+                        "annotation": {
+                            "contents": "_",
+                            "tag": "HashQualifier"
+                        },
+                        "segment": "_"
+                    },
+                    {
+                        "annotation": {
+                            "tag": "BindingEquals"
+                        },
+                        "segment": " ="
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    }
+                ]
+            },
+            {
+                "annotation": {
+                    "tag": "TextLiteral"
+                },
+                "diffTag": "segmentChange",
+                "fromSegment": "\"Here's some text\"",
+                "toSegment": "\"Here's some different text\""
+            },
+            {
+                "diffTag": "both",
+                "elements": [
+                    {
+                        "annotation": null,
+                        "segment": "\n"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": "  "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "NumericLiteral"
+                        },
+                        "segment": "1"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "contents": "##Nat.+",
+                            "tag": "TermReference"
+                        },
+                        "segment": "+"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    }
+                ]
+            },
+            {
+                "annotation": {
+                    "tag": "NumericLiteral"
+                },
+                "diffTag": "segmentChange",
+                "fromSegment": "1",
+                "toSegment": "2"
+            }
+        ],
+        "tag": "UserObject"
+    },
+    "diffKind": "diff",
+    "newBranchRef": "new",
+    "newTerm": {
+        "bestTermName": "term",
+        "defnTermTag": "Plain",
+        "signature": [
+            {
+                "annotation": {
+                    "contents": "##Nat",
+                    "tag": "TypeReference"
+                },
+                "segment": "Nat"
+            }
+        ],
+        "termDefinition": {
+            "contents": [
+                {
+                    "annotation": {
+                        "contents": "term",
+                        "tag": "HashQualifier"
+                    },
+                    "segment": "term"
+                },
+                {
+                    "annotation": {
+                        "tag": "TypeAscriptionColon"
+                    },
+                    "segment": " :"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "##Nat",
+                        "tag": "TypeReference"
+                    },
+                    "segment": "Nat"
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": {
+                        "contents": "term",
+                        "tag": "HashQualifier"
+                    },
+                    "segment": "term"
+                },
+                {
+                    "annotation": {
+                        "tag": "BindingEquals"
+                    },
+                    "segment": " ="
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "tag": "UseKeyword"
+                    },
+                    "segment": "use "
+                },
+                {
+                    "annotation": {
+                        "tag": "UsePrefix"
+                    },
+                    "segment": "Nat"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "UseSuffix"
+                    },
+                    "segment": "+"
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "contents": "_",
+                        "tag": "HashQualifier"
+                    },
+                    "segment": "_"
+                },
+                {
+                    "annotation": {
+                        "tag": "BindingEquals"
+                    },
+                    "segment": " ="
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "TextLiteral"
+                    },
+                    "segment": "\"Here's some different text\""
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "tag": "NumericLiteral"
+                    },
+                    "segment": "1"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "##Nat.+",
+                        "tag": "TermReference"
+                    },
+                    "segment": "+"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "NumericLiteral"
+                    },
+                    "segment": "2"
+                }
+            ],
+            "tag": "UserObject"
+        },
+        "termDocs": [],
+        "termNames": [
+            "term"
+        ]
+    },
+    "oldBranchRef": "main",
+    "oldTerm": {
+        "bestTermName": "term",
+        "defnTermTag": "Plain",
+        "signature": [
+            {
+                "annotation": {
+                    "contents": "##Nat",
+                    "tag": "TypeReference"
+                },
+                "segment": "Nat"
+            }
+        ],
+        "termDefinition": {
+            "contents": [
+                {
+                    "annotation": {
+                        "contents": "term",
+                        "tag": "HashQualifier"
+                    },
+                    "segment": "term"
+                },
+                {
+                    "annotation": {
+                        "tag": "TypeAscriptionColon"
+                    },
+                    "segment": " :"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "##Nat",
+                        "tag": "TypeReference"
+                    },
+                    "segment": "Nat"
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": {
+                        "contents": "term",
+                        "tag": "HashQualifier"
+                    },
+                    "segment": "term"
+                },
+                {
+                    "annotation": {
+                        "tag": "BindingEquals"
+                    },
+                    "segment": " ="
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "tag": "UseKeyword"
+                    },
+                    "segment": "use "
+                },
+                {
+                    "annotation": {
+                        "tag": "UsePrefix"
+                    },
+                    "segment": "Nat"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "UseSuffix"
+                    },
+                    "segment": "+"
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "contents": "_",
+                        "tag": "HashQualifier"
+                    },
+                    "segment": "_"
+                },
+                {
+                    "annotation": {
+                        "tag": "BindingEquals"
+                    },
+                    "segment": " ="
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "TextLiteral"
+                    },
+                    "segment": "\"Here's some text\""
+                },
+                {
+                    "annotation": null,
+                    "segment": "\n"
+                },
+                {
+                    "annotation": null,
+                    "segment": "  "
+                },
+                {
+                    "annotation": {
+                        "tag": "NumericLiteral"
+                    },
+                    "segment": "1"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "##Nat.+",
+                        "tag": "TermReference"
+                    },
+                    "segment": "+"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "NumericLiteral"
+                    },
+                    "segment": "1"
+                }
+            ],
+            "tag": "UserObject"
+        },
+        "termDocs": [],
+        "termNames": [
+            "term"
+        ]
+    },
+    "project": "diffs"
+}
+``````api
+GET /api/projects/diffs/diff/types?oldBranchRef=main&newBranchRef=new&oldType=Type&newType=Type
+{
+    "diff": {
+        "contents": [
+            {
+                "diffTag": "both",
+                "elements": [
+                    {
+                        "annotation": {
+                            "tag": "DataTypeKeyword"
+                        },
+                        "segment": "type"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "contents": "Type",
+                            "tag": "HashQualifier"
+                        },
+                        "segment": "Type"
+                    }
+                ]
+            },
+            {
+                "diffTag": "new",
+                "elements": [
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "tag": "DataTypeParams"
+                        },
+                        "segment": "a"
+                    }
+                ]
+            },
+            {
+                "diffTag": "both",
+                "elements": [
+                    {
+                        "annotation": {
+                            "tag": "DelimiterChar"
+                        },
+                        "segment": " = "
+                    }
+                ]
+            },
+            {
+                "diffTag": "annotationChange",
+                "fromAnnotation": {
+                    "contents": "#0tc9e438eurvtevfa6k9pg04qvv66is75hs8iqejkuoaef140g8vvu92hc1ks4gamgc3i1ukgdn0blchp3038l43vffijpsbjh14igo#d0",
+                    "tag": "TermReference"
+                },
+                "segment": "Type",
+                "toAnnotation": {
+                    "contents": "#mft8mne9i92b6k4m512rn2608rsp6ilq4ejufeof6mbh5aintes4tih1fo93fospmu2t3f0h67uu0mrk2qj75o7k0lj1juefhaidt4g#d0",
+                    "tag": "TermReference"
+                }
+            },
+            {
+                "diffTag": "both",
+                "elements": [
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    }
+                ]
+            },
+            {
+                "diffTag": "old",
+                "elements": [
+                    {
+                        "annotation": {
+                            "contents": "##Nat",
+                            "tag": "TypeReference"
+                        },
+                        "segment": "Nat"
+                    }
+                ]
+            },
+            {
+                "diffTag": "new",
+                "elements": [
+                    {
+                        "annotation": {
+                            "tag": "Var"
+                        },
+                        "segment": "a"
+                    },
+                    {
+                        "annotation": null,
+                        "segment": " "
+                    },
+                    {
+                        "annotation": {
+                            "contents": "##Text",
+                            "tag": "TypeReference"
+                        },
+                        "segment": "Text"
+                    }
+                ]
+            }
+        ],
+        "tag": "UserObject"
+    },
+    "diffKind": "diff",
+    "newBranchRef": "new",
+    "newType": {
+        "bestTypeName": "Type",
+        "defnTypeTag": "Data",
+        "typeDefinition": {
+            "contents": [
+                {
+                    "annotation": {
+                        "tag": "DataTypeKeyword"
+                    },
+                    "segment": "type"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "Type",
+                        "tag": "HashQualifier"
+                    },
+                    "segment": "Type"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "DataTypeParams"
+                    },
+                    "segment": "a"
+                },
+                {
+                    "annotation": {
+                        "tag": "DelimiterChar"
+                    },
+                    "segment": " = "
+                },
+                {
+                    "annotation": {
+                        "contents": "#mft8mne9i92b6k4m512rn2608rsp6ilq4ejufeof6mbh5aintes4tih1fo93fospmu2t3f0h67uu0mrk2qj75o7k0lj1juefhaidt4g#d0",
+                        "tag": "TermReference"
+                    },
+                    "segment": "Type"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "tag": "Var"
+                    },
+                    "segment": "a"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "##Text",
+                        "tag": "TypeReference"
+                    },
+                    "segment": "Text"
+                }
+            ],
+            "tag": "UserObject"
+        },
+        "typeDocs": [],
+        "typeNames": [
+            "Type"
+        ]
+    },
+    "oldBranchRef": "main",
+    "oldType": {
+        "bestTypeName": "Type",
+        "defnTypeTag": "Data",
+        "typeDefinition": {
+            "contents": [
+                {
+                    "annotation": {
+                        "tag": "DataTypeKeyword"
+                    },
+                    "segment": "type"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "Type",
+                        "tag": "HashQualifier"
+                    },
+                    "segment": "Type"
+                },
+                {
+                    "annotation": {
+                        "tag": "DelimiterChar"
+                    },
+                    "segment": " = "
+                },
+                {
+                    "annotation": {
+                        "contents": "#0tc9e438eurvtevfa6k9pg04qvv66is75hs8iqejkuoaef140g8vvu92hc1ks4gamgc3i1ukgdn0blchp3038l43vffijpsbjh14igo#d0",
+                        "tag": "TermReference"
+                    },
+                    "segment": "Type"
+                },
+                {
+                    "annotation": null,
+                    "segment": " "
+                },
+                {
+                    "annotation": {
+                        "contents": "##Nat",
+                        "tag": "TypeReference"
+                    },
+                    "segment": "Nat"
+                }
+            ],
+            "tag": "UserObject"
+        },
+        "typeDocs": [],
+        "typeNames": [
+            "Type"
+        ]
+    },
+    "project": "diffs"
+}
+```


### PR DESCRIPTION
## Overview

Adds definition diff API to Unison Local.



## Implementation notes

Adds `/api/projects/<slug>/diff/terms` and `/api/projects/<slug>/diff/types` which return the same format as Share

## Test coverage

Added a simple transcript test

## Loose ends

Not sure when we'll have time to add this to the UI, but at the very least it serves as a mechanism to add some testing for the feature in `unison` rather than just in `share-api` cc @hojberg 