### PR TITLE
Edit fzf to ignore lib

### DIFF
--- a/unison-src/transcripts/fuzzy-options.md
+++ b/unison-src/transcripts/fuzzy-options.md
@@ -20,6 +20,10 @@ opening an empty fuzzy-select.
 optionOne = 1
 
 nested.optionTwo = 2
+
+lib.dep.defnInLib = 3
+
+lib.dep.lib.tdep.defnInTransitiveDep = 4
 ```
 
 Definition args
@@ -27,13 +31,12 @@ Definition args
 ```ucm
 .> add
 .> debug.fuzzy-options view _
+.> debug.fuzzy-options edit _
 ```
-
 
 Namespace args
 
 ```ucm
-.> add
 .> debug.fuzzy-options find-in _
 ```
 

--- a/unison-src/transcripts/fuzzy-options.output.md
+++ b/unison-src/transcripts/fuzzy-options.output.md
@@ -27,6 +27,10 @@ Sorry, I was expecting an argument for the definition to view, and I couldn't fi
 optionOne = 1
 
 nested.optionTwo = 2
+
+lib.dep.defnInLib = 3
+
+lib.dep.lib.tdep.defnInTransitiveDep = 4
 ```
 
 Definition args
@@ -38,12 +42,21 @@ Definition args
 
   ⍟ I've added these definitions:
   
-    nested.optionTwo : ##Nat
-    optionOne        : ##Nat
+    lib.dep.defnInLib                    : ##Nat
+    lib.dep.lib.tdep.defnInTransitiveDep : ##Nat
+    nested.optionTwo                     : ##Nat
+    optionOne                            : ##Nat
 
 .> debug.fuzzy-options view _
 
   Select a definition to view:
+    * lib.dep.defnInLib
+    * optionOne
+    * nested.optionTwo
+
+.> debug.fuzzy-options edit _
+
+  Select a definition to edit:
     * optionOne
     * nested.optionTwo
 
@@ -51,14 +64,11 @@ Definition args
 Namespace args
 
 ```ucm
-.> add
-
-  ⊡ Ignored previously added definitions: nested.optionTwo
-    optionOne
-
 .> debug.fuzzy-options find-in _
 
   Select a namespace:
+    * lib
+    * lib.dep
     * nested
 
 ```


### PR DESCRIPTION
## Overview

Opening this as an experiment to try out;

I noticed when using fzf with `edit` that it includes stuff from `lib`, which was making it harder to find what I wanted to edit. I realized I never want to edit things from in lib, so this build removes lib from commands like `edit` and `delete`, but leaves it on for things like `view` where you're more likely to be delving into lib defns.

You can still explicitly type out an `edit` for any defn you like.

## Implementation notes

Adds a param to argument resolvers for whether to include lib in the FZF.

## Test coverage

Updated the fzf transcripts