### PR TITLE
tweak: make `prependUtf8` create file if it doesn't exist

### DIFF
--- a/lib/unison-prelude/package.yaml
+++ b/lib/unison-prelude/package.yaml
@@ -12,6 +12,7 @@ dependencies:
   - base
   - bytestring
   - containers
+  - directory
   - generic-lens
   - either
   - extra

--- a/lib/unison-prelude/unison-prelude.cabal
+++ b/lib/unison-prelude/unison-prelude.cabal
@@ -65,6 +65,7 @@ library
       base
     , bytestring
     , containers
+    , directory
     , either
     , extra
     , filepath


### PR DESCRIPTION
## Overview

I noticed some commands give you an unpleasant error if you don't have a `scratch.u`:

```
Encountered exception:
/home/mitchell/unison/trunk/scratch.u: withFile: does not exist (No such file or directory)
```

I tracked this down to us calling a `prependUtf8` helper to prepend some text to a scratch file, which failed with this error if the file didn't exist. This PR adjusts `prependUtf8` to also handle the empty-file case.

## Test coverage

I tested this manually.
