### PR TITLE
[Ed25519] Wrap the return value of Ed25519.sign and .verify with `Right`

### DIFF
--- a/scheme-libs/racket/unison/crypto.rkt
+++ b/scheme-libs/racket/unison/crypto.rkt
@@ -24,10 +24,12 @@
         HashAlgorithm.Blake2b_256
         HashAlgorithm.Blake2b_512
         hashBytes
-        hmacBytes
-        Ed25519.sign.impl
-        Ed25519.verify.impl
-        )))
+        hmacBytes))
+    (prefix-out builtin-crypto.
+        (combine-out
+            Ed25519.sign.impl
+            Ed25519.verify.impl))
+        )
 
 (define-runtime-path libb2-so '(so "libb2" ("1" #f)))
 

--- a/scheme-libs/racket/unison/crypto.rkt
+++ b/scheme-libs/racket/unison/crypto.rkt
@@ -3,6 +3,7 @@
          ffi/unsafe/define
          racket/exn
          racket/runtime-path
+         (only-in unison/data-info ref-either-left ref-either-right)
          (for-syntax racket/base)
          openssl/libcrypto
          unison/chunked-seq
@@ -226,13 +227,13 @@
           #t)))))
 
 (define (Ed25519.sign.impl seed _ignored_pubkey input)
-    (bytes->chunked-bytes (evpSign-raw (chunked-bytes->bytes seed) (chunked-bytes->bytes input))))
+    (ref-either-right (bytes->chunked-bytes (evpSign-raw (chunked-bytes->bytes seed) (chunked-bytes->bytes input)))))
 
 (define (Ed25519.verify.impl public-key input signature)
-    (evpVerify-raw
+    (ref-either-right (evpVerify-raw
         (chunked-bytes->bytes public-key)
         (chunked-bytes->bytes input)
-        (chunked-bytes->bytes signature)))
+        (chunked-bytes->bytes signature))))
 
 ; This one isn't provided by libcrypto, for some reason
 (define (HashAlgorithm.Blake2b_256) (cons 'blake2b 256))

--- a/scheme-libs/racket/unison/primops.ss
+++ b/scheme-libs/racket/unison/primops.ss
@@ -547,8 +547,8 @@
     unison-FOp-crypto.HashAlgorithm.Blake2s_256
     unison-FOp-crypto.HashAlgorithm.Blake2b_256
     unison-FOp-crypto.HashAlgorithm.Blake2b_512
-    unison-FOp-crypto.Ed25519.sign.impl
-    unison-FOp-crypto.Ed25519.verify.impl
+    builtin-crypto.Ed25519.sign.impl
+    builtin-crypto.Ed25519.verify.impl
 
     unison-FOp-IO.clientSocket.impl.v3
     unison-FOp-IO.closeSocket.impl.v3

--- a/scheme-libs/racket/unison/primops.ss
+++ b/scheme-libs/racket/unison/primops.ss
@@ -547,6 +547,8 @@
     unison-FOp-crypto.HashAlgorithm.Blake2s_256
     unison-FOp-crypto.HashAlgorithm.Blake2b_256
     unison-FOp-crypto.HashAlgorithm.Blake2b_512
+    unison-FOp-crypto.Ed25519.sign.impl
+    unison-FOp-crypto.Ed25519.verify.impl
 
     unison-FOp-IO.clientSocket.impl.v3
     unison-FOp-IO.closeSocket.impl.v3
@@ -1388,7 +1390,7 @@
             (exception->string e)
             ref-unit-unit))])
       (thunk ref-unit-unit)))
-  
+
   (declare-builtin-link builtin-Float.*)
   (declare-builtin-link builtin-Float.fromRepresentation)
   (declare-builtin-link builtin-Float.toRepresentation)


### PR DESCRIPTION
## Summary:
I haven't been able to figure out how to hook my new primops up to the `nativeEvalInContext` pipeline, but it looks like they're all set for `compile.native`. I just needed to wrap the return value in `Right`, and the following tests now pass:


```
zseed = 0xs0000000000000000000000000000000000000000000000000000000000000000
zpublic = 0xs3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29
zsig = 0xs8f895b3cafe2c9506039d0e2a66382568004674fe8d237785092e40d6aaf483e4fc60168705f31f101596138ce21aa357c0d32a064f423dc3ee4aa3abf53f803

ed25519Tests = main do
    checkEqual "Ed25519 Sign" (crypto.Ed25519.sign.impl zseed zpublic 0xs) (Right 0xs8f895b3cafe2c9506039d0e2a66382568004674fe8d237785092e40d6aaf483e4fc60168705f31f101596138ce21aa357c0d32a064f423dc3ee4aa3abf53f803)
    checkEqual "Ed25519 Verify" (crypto.Ed25519.verify.impl zpublic 0xs zsig) (Right true)
```

Issue: XXX-XXXX

## Test plan:
Add the above tests to the workspace, and then do `compile.native ed25519Tests ed-test`.
The file `~/.cache/unisonlanguage/racket-tmp/ed-test.rkt` will then be produced, and running:
`racket ~/.cache/unisonlanguage/racket-tmp/ed-test.rkt` produces a successful test run!