### PR TITLE
Fix delete namespace dependents check

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -331,7 +331,7 @@ data DeleteTarget
   = DeleteTarget'TermOrType DeleteOutput [Path.HQSplit']
   | DeleteTarget'Term DeleteOutput [Path.HQSplit']
   | DeleteTarget'Type DeleteOutput [Path.HQSplit']
-  | DeleteTarget'Namespace Insistence (Maybe Path.Split')
+  | DeleteTarget'Namespace Insistence (Maybe Path.Split)
   | DeleteTarget'Patch Path.Split'
   | DeleteTarget'ProjectBranch (ProjectAndBranch (Maybe ProjectName) ProjectBranchName)
   | DeleteTarget'Project ProjectName

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -1239,7 +1239,7 @@ deleteNamespaceParser helpText insistence = \case
       . pure
       $ Input.DeleteI (DeleteTarget'Namespace insistence Nothing)
   [p] -> first P.text do
-    p <- Path.parseSplit' p
+    p <- Path.parseSplit p
     pure $ Input.DeleteI (DeleteTarget'Namespace insistence (Just p))
   _ -> Left helpText
 

--- a/unison-src/transcripts/delete-namespace-dependents-check.md
+++ b/unison-src/transcripts/delete-namespace-dependents-check.md
@@ -15,7 +15,7 @@ sub.dependency = 123
 dependent = dependency + 99
 ```
 
-```ucm
+```ucm:error
 myproject/main> add
 myproject/main> branch /new
 myproject/new> delete.namespace sub

--- a/unison-src/transcripts/delete-namespace-dependents-check.md
+++ b/unison-src/transcripts/delete-namespace-dependents-check.md
@@ -1,0 +1,23 @@
+<!-- https://github.com/unisonweb/unison/issues/4997 -->
+
+# Delete namespace dependents check
+
+This is a regression test, previously `delete.namespace` allowed a delete as long as the deletions had a name _anywhere_ in your codebase, it should only check the current project branch.
+
+```ucm:hide
+.> project.create-empty myproject
+myproject/main> builtins.merge
+```
+
+```unison
+sub.dependency = 123
+
+dependent = dependency + 99
+```
+
+```ucm
+myproject/main> add
+myproject/main> branch /new
+myproject/new> delete.namespace sub
+myproject/new> view dependent
+```

--- a/unison-src/transcripts/delete-namespace-dependents-check.output.md
+++ b/unison-src/transcripts/delete-namespace-dependents-check.output.md
@@ -1,0 +1,53 @@
+<!-- https://github.com/unisonweb/unison/issues/4997 -->
+
+# Delete namespace dependents check
+
+This is a regression test, previously `delete.namespace` allowed a delete as long as the deletions had a name _anywhere_ in your codebase, it should only check the current project branch.
+
+```unison
+sub.dependency = 123
+
+dependent = dependency + 99
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      dependent      : Nat
+      sub.dependency : Nat
+
+```
+```ucm
+myproject/main> add
+
+  ⍟ I've added these definitions:
+  
+    dependent      : Nat
+    sub.dependency : Nat
+
+myproject/main> branch /new
+
+  Done. I've created the new branch based off of main.
+  
+  Tip: To merge your work back into the main branch, first
+       `switch /main` then `merge /new`.
+
+myproject/new> delete.namespace sub
+
+  Done.
+
+myproject/new> view dependent
+
+  dependent : Nat
+  dependent =
+    use Nat +
+    #mllb0u5378 + 99
+
+```

--- a/unison-src/transcripts/delete-namespace-dependents-check.output.md
+++ b/unison-src/transcripts/delete-namespace-dependents-check.output.md
@@ -41,13 +41,22 @@ myproject/main> branch /new
 
 myproject/new> delete.namespace sub
 
-  Done.
+  ⚠️
+  
+  I didn't delete the namespace because the following
+  definitions are still in use.
+  
+  Dependency   Referenced In
+  dependency   1. dependent
+  
+  If you want to proceed anyways and leave those definitions
+  without names, use delete.namespace.force
 
 myproject/new> view dependent
 
   dependent : Nat
   dependent =
     use Nat +
-    #mllb0u5378 + 99
+    dependency + 99
 
 ```

--- a/unison-src/transcripts/empty-namespaces.md
+++ b/unison-src/transcripts/empty-namespaces.md
@@ -45,7 +45,7 @@ stuff.thing = 2
 
 ```ucm:hide
 .> add
-.> delete.namespace .deleted
+.> delete.namespace deleted
 ```
 
 ## fork

--- a/unison-src/transcripts/merges.md
+++ b/unison-src/transcripts/merges.md
@@ -52,7 +52,7 @@ We can also delete the fork if we're done with it. (Don't worry, even though the
 it's still in the `history` of the parent namespace and can be resurrected at any time.)
 
 ```ucm
-.> delete.namespace .feature1
+.> delete.namespace feature1
 .> history .feature1
 .> history
 ```

--- a/unison-src/transcripts/merges.output.md
+++ b/unison-src/transcripts/merges.output.md
@@ -106,7 +106,7 @@ We can also delete the fork if we're done with it. (Don't worry, even though the
 it's still in the `history` of the parent namespace and can be resurrected at any time.)
 
 ```ucm
-.> delete.namespace .feature1
+.> delete.namespace feature1
 
   Done.
 


### PR DESCRIPTION
## Overview

Fixes #4997 

Currently `delete.namespace` just ensures that the deleted refs still have names ANYWHERE in your global codebase, which is incorrect.

Here's a transcript showing it can produce nameless hashes

    ```ucm:hide
    .> project.create-empty myproject
    myproject/main> builtins.merge
    ```

    ```unison
    sub.dependency = 123

    dependent = dependency + 99
    ```

    ```ucm
    myproject/main> add
    myproject/main> branch /new
    myproject/new> delete.namespace sub
    myproject/new> view dependent
    ```


And the output:

     ```unison
    sub.dependency = 123

    dependent = dependency + 99
    ```

    ```ucm

    Loading changes detected in scratch.u.

    I found and typechecked these definitions in scratch.u. If you
    do an `add` or `update`, here's how your codebase would
    change:
    
        ⍟ These new definitions are ok to `add`:
        
        dependent      : Nat
        sub.dependency : Nat

    ```
    ```ucm
    myproject/main> add

    ⍟ I've added these definitions:
    
        dependent      : Nat
        sub.dependency : Nat

    myproject/main> branch /new

    Done. I've created the new branch based off of main.
    
    Tip: Use `merge /new /main` to merge your work back into the
        main branch.

    myproject/new> delete.namespace sub

    Done.

    myproject/new> view dependent

    dependent : Nat
    dependent =
        use Nat +
        #mllb0u5378 + 99

    ```

See the PR for the new transcript output, where it refuses to proceed.

## Implementation notes

* Use the current namespace for dependents check rather than the global root
* Due to this change it no longer makes sense to delete.namespace with absolute paths, because which dependents scope should you use to check in? So I made `delete.namespace` relative path only (except a special-case for `delete.namespace .`)

## Test coverage

Regression transcript, see first commit for the failing transcript output.

