### PR TITLE
bugfix: `lib.install` couldn't install something from a project with a dash in its name, like `@unison/uri-parser`

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/InstallLib.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/InstallLib.hs
@@ -117,25 +117,22 @@ fresh bump taken x =
 makeDependencyName :: ProjectName -> ProjectBranchName -> NameSegment
 makeDependencyName projectName branchName =
   NameSegment.unsafeParseText $
-    Text.intercalate "_" $
-      fold
-        [ case projectNameToUserProjectSlugs projectName of
-            (user, project) ->
-              fold
-                [ if Text.null user then [] else [user],
-                  [project]
-                ],
-          case classifyProjectBranchName branchName of
-            ProjectBranchNameKind'Contributor user branch -> [user, underscorify branch]
-            ProjectBranchNameKind'DraftRelease ver -> semverSegments ver ++ ["draft"]
-            ProjectBranchNameKind'Release ver -> semverSegments ver
-            ProjectBranchNameKind'NothingSpecial -> [underscorify branchName]
-        ]
+    Text.replace "-" "_" $
+      Text.intercalate "_" $
+        fold
+          [ case projectNameToUserProjectSlugs projectName of
+              (user, project) ->
+                fold
+                  [ if Text.null user then [] else [user],
+                    [project]
+                  ],
+            case classifyProjectBranchName branchName of
+              ProjectBranchNameKind'Contributor user branch -> [user, into @Text branch]
+              ProjectBranchNameKind'DraftRelease ver -> semverSegments ver ++ ["draft"]
+              ProjectBranchNameKind'Release ver -> semverSegments ver
+              ProjectBranchNameKind'NothingSpecial -> [into @Text branchName]
+          ]
   where
     semverSegments :: Semver -> [Text]
     semverSegments (Semver x y z) =
       [tShow x, tShow y, tShow z]
-
-    underscorify :: ProjectBranchName -> Text
-    underscorify =
-      Text.replace "-" "_" . into @Text


### PR DESCRIPTION
## Overview

and now it can. I tested this change manually.