### PR TITLE
update workflows for lib.install

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -378,7 +378,7 @@ jobs:
           contents: |
             ```ucm
             .> project.create-empty jit-setup
-            jit-setup/main> pull ${{ env.jit_version }} lib.jit
+            jit-setup/main> lib.install ${{ env.jit_version }}
             ```
             ```unison
             go = generateSchemeBoot "${{ env.jit_generated_src_scheme }}"

--- a/unison-src/transcripts-manual/gen-racket-libs.md
+++ b/unison-src/transcripts-manual/gen-racket-libs.md
@@ -5,7 +5,7 @@ Next, we'll download the jit project and generate a few Racket files from it.
 
 ```ucm
 .> project.create-empty jit-setup
-jit-setup/main> pull @unison/internal/releases/0.0.17 lib.jit
+jit-setup/main> lib.install @unison/internal/releases/0.0.17
 ```
 
 ```unison


### PR DESCRIPTION
## Overview

These two workflows used `pull` to install libraries, which we don't allow anymore; and a caching issue allowed them to slip through CI, but the pre-release workflow was failing unnoticed, which meant that trunk binary builds have not been updating for the past few days.

## Implementation details

I switched from `pull` to `lib.install`. Separately I also updated README to show a badge for the pre-release workflow:

<img width="261" alt="image" src="https://github.com/unisonweb/unison/assets/538571/e365d2fb-919b-4d6d-9862-477fe4ec4145">

Closes #5000 

## Test coverage

I ran a manual pre-release workflow on this branch, which passed. 
https://github.com/unisonweb/unison/actions/runs/9199316292

## Loose ends

This PR fixes the workflows but doesn't fix the caching issue that allowed them to slip through CI.
https://github.com/unisonweb/unison/actions/runs/9197680977 (CI)
https://github.com/unisonweb/unison/actions/runs/9198203478 (pre-release)