### PR TITLE
Type the `main` arg to `execute`

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/MainTerm.hs
+++ b/parser-typechecker/src/Unison/Codebase/MainTerm.hs
@@ -16,7 +16,6 @@ import Unison.Parser.Ann qualified as Parser.Ann
 import Unison.Prelude
 import Unison.Reference (Reference)
 import Unison.Referent qualified as Referent
-import Unison.Syntax.HashQualified qualified as HQ (parseText)
 import Unison.Term (Term)
 import Unison.Term qualified as Term
 import Unison.Type (Type)
@@ -26,37 +25,33 @@ import Unison.Var (Var)
 import Unison.Var qualified as Var
 
 data MainTerm v
-  = NotAFunctionName Text
-  | NotFound Text
-  | BadType Text (Maybe (Type v Ann))
+  = NotFound (HQ.HashQualified Name)
+  | BadType (HQ.HashQualified Name) (Maybe (Type v Ann))
   | Success (HQ.HashQualified Name) (Term v Ann) (Type v Ann)
 
 getMainTerm ::
   (Monad m, Var v) =>
   (Reference -> m (Maybe (Type v Ann))) ->
   Names.Names ->
-  Text ->
+  HQ.HashQualified Name ->
   Type.Type v Ann ->
   m (MainTerm v)
-getMainTerm loadTypeOfTerm parseNames mainName mainType =
-  case HQ.parseText mainName of
-    Nothing -> pure (NotAFunctionName mainName)
-    Just hq -> do
-      let refs = Names.lookupHQTerm Names.IncludeSuffixes hq parseNames
-      let a = Parser.Ann.External
-      case toList refs of
-        [] -> pure (NotFound mainName)
-        [Referent.Ref ref] -> do
-          typ <- loadTypeOfTerm ref
-          case typ of
-            Just typ ->
-              if Typechecker.fitsScheme typ mainType
-                then do
-                  let tm = DD.forceTerm a a (Term.ref a ref)
-                  return (Success hq tm typ)
-                else pure (BadType mainName $ Just typ)
-            _ -> pure (BadType mainName Nothing)
-        _ -> pure (error "multiple matching refs") -- TODO: make a real exception
+getMainTerm loadTypeOfTerm parseNames mainName mainType = do
+  let refs = Names.lookupHQTerm Names.IncludeSuffixes mainName parseNames
+  let a = Parser.Ann.External
+  case toList refs of
+    [] -> pure (NotFound mainName)
+    [Referent.Ref ref] -> do
+      typ <- loadTypeOfTerm ref
+      case typ of
+        Just typ ->
+          if Typechecker.fitsScheme typ mainType
+            then do
+              let tm = DD.forceTerm a a (Term.ref a ref)
+              return (Success mainName tm typ)
+            else pure (BadType mainName $ Just typ)
+        _ -> pure (BadType mainName Nothing)
+    _ -> pure (error "multiple matching refs") -- TODO: make a real exception
 
 -- forall x. '{ io2.IO, Exception } x
 builtinMain :: (Var v) => a -> Type.Type v a

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1061,7 +1061,7 @@ inputDescription input =
       pure ("update.old" <> p)
     Update2I -> pure ("update")
     UndoI {} -> pure "undo"
-    ExecuteI s args -> pure ("execute " <> Text.unwords (s : fmap Text.pack args))
+    ExecuteI s args -> pure ("execute " <> Text.unwords (HQ.toText s : fmap Text.pack args))
     IOTestI hq -> pure ("io.test " <> HQ.toText hq)
     IOTestAllI -> pure "io.test.all"
     UpdateBuiltinsI -> pure "builtins.update"
@@ -1071,7 +1071,7 @@ inputDescription input =
     MergeIOBuiltinsI (Just path) -> ("builtins.mergeio " <>) <$> p path
     MakeStandaloneI out nm -> pure ("compile " <> Text.pack out <> " " <> HQ.toText nm)
     ExecuteSchemeI nm args ->
-      pure $ "run.native " <> Text.unwords (nm : fmap Text.pack args)
+      pure $ "run.native " <> Text.unwords (HQ.toText nm : fmap Text.pack args)
     CompileSchemeI fi nm -> pure ("compile.native " <> HQ.toText nm <> " " <> fi)
     CreateAuthorI id name -> pure ("create.author " <> NameSegment.toEscapedText id <> " " <> name)
     ClearI {} -> pure "clear"

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Run.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Run.hs
@@ -20,6 +20,8 @@ import Unison.Codebase.Editor.Output qualified as Output
 import Unison.Codebase.MainTerm qualified as MainTerm
 import Unison.Codebase.Runtime qualified as Runtime
 import Unison.Hash qualified as Hash
+import Unison.HashQualified qualified as HQ
+import Unison.Name (Name)
 import Unison.Parser.Ann (Ann (External))
 import Unison.Prelude
 import Unison.PrettyPrintEnv qualified as PPE
@@ -40,7 +42,7 @@ import Unison.UnisonFile qualified as UF
 import Unison.UnisonFile.Names qualified as UF
 import Unison.Var qualified as Var
 
-handleRun :: Bool -> Text -> [String] -> Cli ()
+handleRun :: Bool -> HQ.HashQualified Name -> [String] -> Cli ()
 handleRun native main args = do
   (unisonFile, mainResType) <- do
     (sym, term, typ, otyp) <- getTerm main
@@ -75,7 +77,7 @@ data GetTermResult
 -- | Look up runnable term with the given name in the codebase or
 -- latest typechecked unison file. Return its symbol, term, type, and
 -- the type of the evaluated term.
-getTerm :: Text -> Cli (Symbol, Term Symbol Ann, Type Symbol Ann, Type Symbol Ann)
+getTerm :: HQ.HashQualified Name -> Cli (Symbol, Term Symbol Ann, Type Symbol Ann, Type Symbol Ann)
 getTerm main =
   getTerm' main >>= \case
     NoTermWithThatName -> do
@@ -90,7 +92,7 @@ getTerm main =
       Cli.returnEarly $ Output.BadMainFunction "run" main ty suffixifiedPPE [mainType]
     GetTermSuccess x -> pure x
 
-getTerm' :: Text -> Cli GetTermResult
+getTerm' :: HQ.HashQualified Name -> Cli GetTermResult
 getTerm' mainName =
   let getFromCodebase = do
         Cli.Env {codebase, runtime} <- ask
@@ -99,7 +101,6 @@ getTerm' mainName =
         mainToFile
           =<< MainTerm.getMainTerm loadTypeOfTerm names mainName (Runtime.mainType runtime)
         where
-          mainToFile (MainTerm.NotAFunctionName _) = pure NoTermWithThatName
           mainToFile (MainTerm.NotFound _) = pure NoTermWithThatName
           mainToFile (MainTerm.BadType _ ty) = pure $ maybe NoTermWithThatName TermHasBadType ty
           mainToFile (MainTerm.Success hq tm typ) =
@@ -108,7 +109,8 @@ getTerm' mainName =
                   pure (GetTermSuccess (v, tm, typ, otyp))
       getFromFile uf = do
         let components = join $ UF.topLevelComponents uf
-        let mainComponent = filter ((\v -> Var.name v == mainName) . view _1) components
+        -- __TODO__: We shouldn’t need to serialize mainName` for this check
+        let mainComponent = filter ((\v -> Var.name v == HQ.toText mainName) . view _1) components
         case mainComponent of
           [(v, _, tm, ty)] ->
             checkType ty \otyp ->

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/TermResolution.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/TermResolution.hs
@@ -31,7 +31,6 @@ import Unison.PrettyPrintEnvDecl qualified as PPED
 import Unison.Reference (Reference)
 import Unison.Referent (Referent, pattern Con, pattern Ref)
 import Unison.Symbol (Symbol)
-import Unison.Syntax.HashQualified qualified as HQ (toText)
 import Unison.Type (Type)
 import Unison.Typechecker qualified as Typechecker
 
@@ -118,9 +117,8 @@ resolveMainRef main = do
   pped <- Cli.prettyPrintEnvDeclFromNames names
   let suffixifiedPPE = PPED.suffixifiedPPE pped
   let mainType = Runtime.mainType runtime
-      smain = HQ.toText main
   lookupTermRefWithType codebase main >>= \case
     [(rf, ty)]
       | Typechecker.fitsScheme ty mainType -> pure (rf, suffixifiedPPE)
-      | otherwise -> Cli.returnEarly (BadMainFunction "main" smain ty suffixifiedPPE [mainType])
-    _ -> Cli.returnEarly (NoMainFunction smain suffixifiedPPE [mainType])
+      | otherwise -> Cli.returnEarly (BadMainFunction "main" main ty suffixifiedPPE [mainType])
+    _ -> Cli.returnEarly (NoMainFunction main suffixifiedPPE [mainType])

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Tests.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Tests.hs
@@ -28,6 +28,8 @@ import Unison.Codebase.Editor.HandleInput.RuntimeUtils qualified as RuntimeUtils
 import Unison.Codebase.Editor.Input (TestInput (..))
 import Unison.Codebase.Editor.Output
 import Unison.Codebase.Editor.Output qualified as Output
+import Unison.Codebase.Path (Path)
+import Unison.Codebase.Path qualified as Path
 import Unison.Codebase.Runtime qualified as Runtime
 import Unison.ConstructorReference (GConstructorReference (..))
 import Unison.HashQualified qualified as HQ
@@ -38,6 +40,7 @@ import Unison.Parser.Ann (Ann)
 import Unison.Prelude
 import Unison.PrettyPrintEnv qualified as PPE
 import Unison.PrettyPrintEnvDecl qualified as PPED
+import Unison.Reference (TermReferenceId)
 import Unison.Reference qualified as Reference
 import Unison.Referent qualified as Referent
 import Unison.ShortHash qualified as SH
@@ -53,9 +56,6 @@ import Unison.Util.Monoid (foldMapM)
 import Unison.Util.Relation qualified as R
 import Unison.Util.Set qualified as Set
 import Unison.WatchKind qualified as WK
-import Unison.Codebase.Path (Path)
-import Unison.Reference (TermReferenceId)
-import qualified Unison.Codebase.Path as Path
 
 -- | Handle a @test@ command.
 -- Run pure tests in the current subnamespace.
@@ -137,7 +137,7 @@ handleIOTest main = do
   (fails, oks) <-
     refs & foldMapM \(ref, typ) -> do
       when (not $ isIOTest typ) do
-        Cli.returnEarly (BadMainFunction "io.test" (HQ.toText main) typ suffixifiedPPE (Foldable.toList $ Runtime.ioTestTypes runtime))
+        Cli.returnEarly (BadMainFunction "io.test" main typ suffixifiedPPE (Foldable.toList $ Runtime.ioTestTypes runtime))
       runIOTest suffixifiedPPE ref
   Cli.respond $ TestResults Output.NewlyComputed suffixifiedPPE True True oks fails
 

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -156,7 +156,7 @@ data Input
     -- Second `Maybe Int` is cap on diff elements shown, if any
     HistoryI (Maybe Int) (Maybe Int) BranchId
   | -- execute an IO thunk with args
-    ExecuteI Text [String]
+    ExecuteI (HQ.HashQualified Name) [String]
   | -- save the result of a previous Execute
     SaveExecuteResultI Name
   | -- execute an IO [Result]
@@ -166,7 +166,7 @@ data Input
   | -- make a standalone binary file
     MakeStandaloneI String (HQ.HashQualified Name)
   | -- execute an IO thunk using scheme
-    ExecuteSchemeI Text [String]
+    ExecuteSchemeI (HQ.HashQualified Name) [String]
   | -- compile to a scheme file
     CompileSchemeI Text (HQ.HashQualified Name)
   | TestI TestInput

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -157,13 +157,13 @@ data Output
   | InvalidSourceName String
   | SourceLoadFailed String
   | -- No main function, the [Type v Ann] are the allowed types
-    NoMainFunction Text PPE.PrettyPrintEnv [Type Symbol Ann]
+    NoMainFunction (HQ.HashQualified Name) PPE.PrettyPrintEnv [Type Symbol Ann]
   | -- | Function found, but has improper type
     -- Note: the constructor name is misleading here; we weren't necessarily looking for a "main".
     BadMainFunction
       Text
       -- ^ what we were trying to do (e.g. "run", "io.test")
-      Text
+      (HQ.HashQualified Name)
       -- ^ name of function
       (Type Symbol Ann)
       -- ^ bad type of function

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -2708,8 +2708,9 @@ execute =
     )
     $ \case
       main : args ->
-        Input.ExecuteI (Text.pack $ unifyArgument main)
-          <$> traverse (unsupportedStructuredArgument "a command-line argument") args
+        Input.ExecuteI
+          <$> handleHashQualifiedNameArg main
+          <*> traverse (unsupportedStructuredArgument "a command-line argument") args
       _ -> Left $ showPatternHelp execute
 
 saveExecuteResult :: InputPattern
@@ -2799,8 +2800,9 @@ runScheme =
     )
     $ \case
       main : args ->
-        Input.ExecuteSchemeI (Text.pack $ unifyArgument main)
-          <$> traverse (unsupportedStructuredArgument "a command-line argument") args
+        Input.ExecuteSchemeI
+          <$> handleHashQualifiedNameArg main
+          <*> traverse (unsupportedStructuredArgument "a command-line argument") args
       _ -> Left $ showPatternHelp runScheme
 
 compileScheme :: InputPattern

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -739,21 +739,21 @@ notifyUser dir = \case
       P.lines
         [ P.wrap $
             "I looked for a function"
-              <> P.backticked (P.text main)
+              <> P.backticked (P.text $ HQ.toText main)
               <> "in the most recently typechecked file and codebase but couldn't find one. It has to have the type:",
           "",
-          P.indentN 2 $ P.lines [P.text main <> " : " <> TypePrinter.pretty ppe t | t <- ts]
+          P.indentN 2 $ P.lines [P.text (HQ.toText main) <> " : " <> TypePrinter.pretty ppe t | t <- ts]
         ]
   BadMainFunction what main ty ppe ts ->
     pure . P.callout "😶" $
       P.lines
         [ P.string "I found this function:",
           "",
-          P.indentN 2 $ P.text main <> " : " <> TypePrinter.pretty ppe ty,
+          P.indentN 2 $ P.text (HQ.toText main) <> " : " <> TypePrinter.pretty ppe ty,
           "",
           P.wrap $ P.string "but in order for me to" <> P.backticked (P.text what) <> "it needs to be a subtype of:",
           "",
-          P.indentN 2 $ P.lines [P.text main <> " : " <> TypePrinter.pretty ppe t | t <- ts]
+          P.indentN 2 $ P.lines [P.text (HQ.toText main) <> " : " <> TypePrinter.pretty ppe t | t <- ts]
         ]
   NoUnisonFile -> do
     dir' <- canonicalizePath dir


### PR DESCRIPTION
## Overview

This avoids throwing away the type information from `NumberedArgs` and just
generally gets text handling out of the domain logic.

No change to the user, but some round-tripping of print/parse is removed, and remaining parsing is pushed out with other `OptParse` handling.