### PR TITLE
Docs name

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1758,7 +1758,7 @@ displayI outputLoc hq = do
       let ns = UF.addNamesFromTypeCheckedUnisonFile unisonFile names
       doDisplay outputLoc ns tm
 
-docsI :: Path.HQSplit' -> Cli ()
+docsI :: Name -> Cli ()
 docsI src = do
   findInScratchfileByName
   where
@@ -1766,14 +1766,8 @@ docsI src = do
        (fileByName) First check the file for `foo.doc`, and if found do `display foo.doc`
        (codebaseByName) Lastly check for `foo.doc` in the codebase and if found do `display foo.doc`
     -}
-    hq :: HQ.HashQualified Name
-    hq =
-      let hq' :: HQ'.HashQualified Name
-          hq' = Path.unsafeToName' <$> Name.convert src
-       in Name.convert hq'
-
     dotDoc :: HQ.HashQualified Name
-    dotDoc = hq <&> \n -> Name.joinDot n (Name.fromSegment "doc")
+    dotDoc = Name.convert . Name.joinDot src $ Name.fromSegment "doc"
 
     findInScratchfileByName :: Cli ()
     findInScratchfileByName = do

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -174,7 +174,7 @@ data Input
   | -- Display provided definitions.
     DisplayI OutputLocation (NonEmpty (HQ.HashQualified Name))
   | -- Display docs for provided terms.
-    DocsI (NonEmpty Path.HQSplit')
+    DocsI (NonEmpty Name)
   | -- other
     FindI Bool FindScope [String] -- FindI isVerbose findScope query
   | FindShallowI Path'

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -992,7 +992,7 @@ docs =
           "`docs` without arguments invokes a search to select which definition to view documentation for, which requires that `fzf` can be found within your PATH."
         ]
     )
-    $ maybe (Left $ I.help docs) (fmap Input.DocsI . traverse handleHashQualifiedSplit'Arg) . NE.nonEmpty
+    $ maybe (Left $ I.help docs) (fmap Input.DocsI . traverse handleNameArg) . NE.nonEmpty
 
 api :: InputPattern
 api =

--- a/unison-src/transcripts-using-base/fix3939.md
+++ b/unison-src/transcripts-using-base/fix3939.md
@@ -1,0 +1,12 @@
+```unison
+{{
+A simple doc.
+}}
+meh = 9
+```
+
+```ucm
+.> add
+.> find meh
+.> docs 1
+```

--- a/unison-src/transcripts-using-base/fix3939.output.md
+++ b/unison-src/transcripts-using-base/fix3939.output.md
@@ -1,0 +1,56 @@
+```unison
+{{
+A simple doc.
+}}
+meh = 9
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      meh     : Nat
+      meh.doc : Doc2
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    meh     : Nat
+    meh.doc : Doc2
+
+.> find meh
+
+  1. meh : Nat
+  2. meh.doc : Doc2
+  
+
+.> docs 1
+
+  ⚠️
+  
+  The following names were not found in the codebase. Check your spelling.
+    meh.doc#3n6of1k7qmgib9jda9ov1obetubfmladketn40gqifp4pfdea8it6ofa920l1topi2pd32vlsbfu3q41fkbt8coa38akg9eetto09j8
+
+```
+
+
+
+🛑
+
+The transcript failed due to an error in the stanza above. The error is:
+
+
+  ⚠️
+  
+  The following names were not found in the codebase. Check your spelling.
+    meh.doc#3n6of1k7qmgib9jda9ov1obetubfmladketn40gqifp4pfdea8it6ofa920l1topi2pd32vlsbfu3q41fkbt8coa38akg9eetto09j8
+

--- a/unison-src/transcripts-using-base/fix3939.output.md
+++ b/unison-src/transcripts-using-base/fix3939.output.md
@@ -35,22 +35,6 @@ meh = 9
 
 .> docs 1
 
-  ⚠️
-  
-  The following names were not found in the codebase. Check your spelling.
-    meh.doc#3n6of1k7qmgib9jda9ov1obetubfmladketn40gqifp4pfdea8it6ofa920l1topi2pd32vlsbfu3q41fkbt8coa38akg9eetto09j8
+  A simple doc.
 
 ```
-
-
-
-🛑
-
-The transcript failed due to an error in the stanza above. The error is:
-
-
-  ⚠️
-  
-  The following names were not found in the codebase. Check your spelling.
-    meh.doc#3n6of1k7qmgib9jda9ov1obetubfmladketn40gqifp4pfdea8it6ofa920l1topi2pd32vlsbfu3q41fkbt8coa38akg9eetto09j8
-


### PR DESCRIPTION
## Overview

Previously, when given a numbered arg, from some commands (e.g., `find`), it would fail to find the docs because the hash associated with the definition was applied to the `doc`, which then would be incorrect.

This now discards hashes up-front, so it can add the `doc` suffix to the name.

Fixes #3939 and fixes #4133.