### PR TITLE
Add an EditorConfig config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# Multi-editor style config: https://EditorConfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+max_line_length = 120
+trim_trailing_whitespace = true


### PR DESCRIPTION
## Overview

https://editorconfig.org/

This provides limited editor-agnostic style information.

## Implementation notes

The only one I care about here is `max_line_length`, since Ormolu doesn’t manage that. It sets up my editor so that comments wrap at the expected place, and gives me a hint when expressions should be split.

The other values just seem like reasonable ones, but they can also be removed (and/or customized for particular file types).