### PR TITLE
Remove `Reference` from `StructuredArgument`

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/StructuredArgument.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/StructuredArgument.hs
@@ -10,7 +10,6 @@ import Unison.HashQualified' qualified as HQ'
 import Unison.Name (Name)
 import Unison.Parser.Ann (Ann)
 import Unison.Project (ProjectAndBranch, ProjectBranchName, ProjectName)
-import Unison.Reference (Reference)
 import Unison.Server.Backend (ShallowListEntry)
 import Unison.Server.SearchResult (SearchResult)
 import Unison.Symbol (Symbol)
@@ -22,7 +21,6 @@ data StructuredArgument
   | HashQualified (HQ.HashQualified Name)
   | Project ProjectName
   | ProjectBranch (ProjectAndBranch (Maybe ProjectName) ProjectBranchName)
-  | Ref Reference
   | Namespace CausalHash
   | NameWithBranchPrefix AbsBranchId Name
   | HashQualifiedWithBranchPrefix AbsBranchId (HQ'.HashQualified Name)

--- a/unison-cli/tests/Unison/Test/Cli/Monad.hs
+++ b/unison-cli/tests/Unison/Test/Cli/Monad.hs
@@ -7,7 +7,7 @@ import Control.Lens
 import EasyTest
 import Unison.Cli.Monad qualified as Cli
 import Unison.Codebase.Editor.StructuredArgument qualified as SA
-import Unison.Reference qualified as Reference
+import Unison.Syntax.Name qualified as Name
 
 test :: Test ()
 test =
@@ -18,13 +18,15 @@ test =
             Cli.runCli dummyEnv dummyLoopState do
               Cli.label \goto -> do
                 Cli.label \_ -> do
-                  Cli.setNumberedArgs [SA.Ref $ Reference.ReferenceBuiltin "foo"]
+                  Cli.setNumberedArgs [SA.Name $ Name.unsafeParseText "foo"]
                   goto (1 :: Int)
                 pure 2
         -- test that 'goto' short-circuits, as expected
         expectEqual' (Cli.Success 1) r
         -- test that calling 'goto' doesn't lose state changes made along the way
-        expectEqual' [SA.Ref $ Reference.ReferenceBuiltin "foo"] (state ^. #numberedArgs)
+        expectEqual'
+          [SA.Name $ Name.unsafeParseText "foo"]
+          (state ^. #numberedArgs)
         ok
     ]
 

--- a/unison-src/transcripts/fix4898.md
+++ b/unison-src/transcripts/fix4898.md
@@ -1,0 +1,17 @@
+```ucm
+.> builtins.merge
+```
+
+```unison
+double : Int -> Int
+double x = x + x
+
+redouble : Int -> Int
+redouble x = double x + double x
+```
+
+```ucm
+.> add
+.> dependents double
+.> delete.term 1
+```

--- a/unison-src/transcripts/fix4898.output.md
+++ b/unison-src/transcripts/fix4898.output.md
@@ -1,0 +1,58 @@
+```ucm
+.> builtins.merge
+
+  Done.
+
+```
+```unison
+double : Int -> Int
+double x = x + x
+
+redouble : Int -> Int
+redouble x = double x + double x
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      double   : Int -> Int
+      redouble : Int -> Int
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    double   : Int -> Int
+    redouble : Int -> Int
+
+.> dependents double
+
+  Dependents of: double
+  
+    Terms:
+  
+    1. redouble
+  
+  Tip: Try `view 1` to see the source of any numbered item in
+       the above list.
+
+.> delete.term 1
+
+```
+
+
+
+🛑
+
+The transcript failed due to an error in the stanza above. The error is:
+
+Expected a name, but the numbered arg resulted in #1gupumeruksjs4sb5mg8jcb891dmbufmqrfblfss1sevbl62fr7oud24mpo03jm2qlbdt6ntordsmfj1jovhfsp3mij461odaahfh2g, which is a reference.

--- a/unison-src/transcripts/fix4898.output.md
+++ b/unison-src/transcripts/fix4898.output.md
@@ -47,12 +47,6 @@ redouble x = double x + double x
 
 .> delete.term 1
 
+  Done.
+
 ```
-
-
-
-🛑
-
-The transcript failed due to an error in the stanza above. The error is:
-
-Expected a name, but the numbered arg resulted in #1gupumeruksjs4sb5mg8jcb891dmbufmqrfblfss1sevbl62fr7oud24mpo03jm2qlbdt6ntordsmfj1jovhfsp3mij461odaahfh2g, which is a reference.


### PR DESCRIPTION
## Overview

Almost everywhere we produce a `Reference` for numbered args, we also have a
`HashQualified Name` handy, which is much more consumable by commands.

The only case we don’t have an `HQ` is in the `todo` command output, so that now explicitly builds
a `HQ.HashOnly`.

This also fixes an issue with `StructuredArgument` handling where `alias.term`
and `alias.type` wouldn’t make an alias to a `HQ.HashOnly` `StructuredArgument`.

Fixes #4898.

## Test coverage

There is a new transcript to replicate the reported issue.