### PR TITLE
bug(?)fix: relax lca merge preconditions

### DIFF
--- a/lib/unison-prelude/src/Unison/Util/Map.hs
+++ b/lib/unison-prelude/src/Unison/Util/Map.hs
@@ -5,6 +5,7 @@ module Unison.Util.Map
     bitraverse,
     bitraversed,
     deleteLookup,
+    deleteLookupJust,
     elemsSet,
     foldM,
     foldMapM,
@@ -105,6 +106,11 @@ valuesVector =
 deleteLookup :: (Ord k) => k -> Map k v -> (Maybe v, Map k v)
 deleteLookup =
   Map.alterF (,Nothing)
+
+-- | Like 'deleteLookup', but asserts the value is in the map prior to deletion.
+deleteLookupJust :: (HasCallStack, Ord k) => k -> Map k v -> (v, Map k v)
+deleteLookupJust =
+  Map.alterF (maybe (error (reportBug "E525283" "deleteLookupJust: element not found")) (,Nothing))
 
 -- | Like 'Map.elems', but return the values as a set.
 elemsSet :: Ord v => Map k v -> Set v

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
@@ -43,7 +43,7 @@ import U.Codebase.Sqlite.Project (Project (..))
 import U.Codebase.Sqlite.ProjectBranch (ProjectBranch (..))
 import U.Codebase.Sqlite.Queries qualified as Queries
 import Unison.Builtin.Decls qualified as Builtin.Decls
-import Unison.Cli.MergeTypes (MergeSource (..), MergeSourceOrTarget (..), MergeSourceAndTarget (..))
+import Unison.Cli.MergeTypes (MergeSource (..), MergeSourceAndTarget (..), MergeSourceOrTarget (..))
 import Unison.Cli.Monad (Cli)
 import Unison.Cli.Monad qualified as Cli
 import Unison.Cli.MonadUtils qualified as Cli
@@ -76,7 +76,7 @@ import Unison.HashQualified qualified as HQ
 import Unison.HashQualified' qualified as HQ'
 import Unison.Merge.CombineDiffs (CombinedDiffOp (..), combineDiffs)
 import Unison.Merge.Database (MergeDatabase (..), makeMergeDatabase, referent2to1)
-import Unison.Merge.DeclCoherencyCheck (IncoherentDeclReason (..), checkDeclCoherency)
+import Unison.Merge.DeclCoherencyCheck (IncoherentDeclReason (..), checkDeclCoherency, lenientCheckDeclCoherency)
 import Unison.Merge.DeclNameLookup (DeclNameLookup (..), expectConstructorNames)
 import Unison.Merge.Diff qualified as Merge
 import Unison.Merge.DiffOp (DiffOp (..))
@@ -220,7 +220,7 @@ doMerge info = do
   let aliceBranchNames = ProjectAndBranch info.alice.project.name info.alice.projectBranch.name
   let mergeSource = MergeSourceOrTarget'Source info.bob.source
   let mergeTarget = MergeSourceOrTarget'Target aliceBranchNames
-  let mergeSourceAndTarget = MergeSourceAndTarget { alice = aliceBranchNames, bob = info.bob.source }
+  let mergeSourceAndTarget = MergeSourceAndTarget {alice = aliceBranchNames, bob = info.bob.source}
 
   Cli.Env {codebase} <- ask
 
@@ -267,19 +267,17 @@ doMerge info = do
       Cli.returnEarly (Output.MergeDefnsInLib who)
 
   -- Load Alice/Bob/LCA definitions and decl name lookups
-  (defns3, declNameLookups3) <- do
+  (defns3, declNameLookups, lcaDeclToConstructors) <- do
+    let emptyNametree = Nametree {value = Defns Map.empty Map.empty, children = Map.empty}
+    let loadDefns branch =
+          Cli.runTransaction (loadNamespaceDefinitions (referent2to1 db) branch) & onLeftM \conflictedName ->
+            Cli.returnEarly case conflictedName of
+              ConflictedName'Term name refs -> Output.MergeConflictedTermName name refs
+              ConflictedName'Type name refs -> Output.MergeConflictedTypeName name refs
     let load = \case
-          Nothing ->
-            pure
-              ( Nametree {value = Defns Map.empty Map.empty, children = Map.empty},
-                DeclNameLookup Map.empty Map.empty
-              )
+          Nothing -> pure (emptyNametree, DeclNameLookup Map.empty Map.empty)
           Just (who, branch) -> do
-            defns <-
-              Cli.runTransaction (loadNamespaceDefinitions (referent2to1 db) branch) & onLeftM \conflictedName ->
-                Cli.returnEarly case conflictedName of
-                  ConflictedName'Term name refs -> Output.MergeConflictedTermName name refs
-                  ConflictedName'Type name refs -> Output.MergeConflictedTypeName name refs
+            defns <- loadDefns branch
             declNameLookup <-
               Cli.runTransaction (checkDeclCoherency db.loadDeclNumConstructors defns) & onLeftM \err ->
                 Cli.returnEarly case err of
@@ -291,23 +289,23 @@ doMerge info = do
                   IncoherentDeclReason'StrayConstructor name -> Output.MergeStrayConstructor who name
             pure (defns, declNameLookup)
 
-    (aliceDefns0, aliceDeclNameLookup) <- load (Just (Just mergeTarget, branches.alice))
-    (bobDefns0, bobDeclNameLookup) <- load (Just (Just mergeSource, branches.bob))
-    (lcaDefns0, lcaDeclNameLookup) <- load ((Nothing,) <$> branches.lca)
+    (aliceDefns0, aliceDeclNameLookup) <- load (Just (mergeTarget, branches.alice))
+    (bobDefns0, bobDeclNameLookup) <- load (Just (mergeSource, branches.bob))
+    lcaDefns0 <- maybe (pure emptyNametree) loadDefns branches.lca
+    lcaDeclToConstructors <- Cli.runTransaction (lenientCheckDeclCoherency db.loadDeclNumConstructors lcaDefns0)
 
     let flatten defns = Defns (flattenNametree (view #terms) defns) (flattenNametree (view #types) defns)
     let defns3 = flatten <$> ThreeWay {alice = aliceDefns0, bob = bobDefns0, lca = lcaDefns0}
-    let declNameLookups3 = ThreeWay {alice = aliceDeclNameLookup, bob = bobDeclNameLookup, lca = lcaDeclNameLookup}
+    let declNameLookups = TwoWay {alice = aliceDeclNameLookup, bob = bobDeclNameLookup}
 
-    pure (defns3, declNameLookups3)
+    pure (defns3, declNameLookups, lcaDeclToConstructors)
 
   let defns = ThreeWay.forgetLca defns3
-  let declNameLookups = ThreeWay.forgetLca declNameLookups3
 
-  liftIO (debugFunctions.debugDefns defns3 declNameLookups3)
+  liftIO (debugFunctions.debugDefns defns3 declNameLookups lcaDeclToConstructors)
 
   -- Diff LCA->Alice and LCA->Bob
-  diffs <- Cli.runTransaction (Merge.nameBasedNamespaceDiff db declNameLookups3 defns3)
+  diffs <- Cli.runTransaction (Merge.nameBasedNamespaceDiff db declNameLookups lcaDeclToConstructors defns3)
 
   liftIO (debugFunctions.debugDiffs diffs)
 
@@ -1032,7 +1030,8 @@ data DebugFunctions = DebugFunctions
   { debugCausals :: TwoOrThreeWay (V2.CausalBranch Transaction) -> IO (),
     debugDefns ::
       ThreeWay (Defns (BiMultimap Referent Name) (BiMultimap TypeReference Name)) ->
-      ThreeWay DeclNameLookup ->
+      TwoWay DeclNameLookup ->
+      Map Name [Maybe Name] ->
       IO (),
     debugDiffs :: TwoWay (DefnsF3 (Map Name) DiffOp Synhashed Referent TypeReference) -> IO (),
     debugCombinedDiff :: DefnsF2 (Map Name) CombinedDiffOp Referent TypeReference -> IO (),
@@ -1073,9 +1072,10 @@ realDebugCausals causals = do
 
 realDebugDefns ::
   ThreeWay (Defns (BiMultimap Referent Name) (BiMultimap TypeReference Name)) ->
-  ThreeWay DeclNameLookup ->
+  TwoWay DeclNameLookup ->
+  Map Name [Maybe Name] ->
   IO ()
-realDebugDefns defns declNameLookups = do
+realDebugDefns defns declNameLookups _lcaDeclNameLookup = do
   Text.putStrLn (Text.bold "\n=== Alice definitions ===")
   debugDefns1 (bimap BiMultimap.range BiMultimap.range defns.alice)
 

--- a/unison-cli/src/Unison/Codebase/Editor/Output.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Output.hs
@@ -395,11 +395,11 @@ data Output
   | MergeConflictedTermName !Name !(NESet Referent)
   | MergeConflictedTypeName !Name !(NESet TypeReference)
   | MergeConflictInvolvingBuiltin !Name
-  | MergeConstructorAlias !(Maybe MergeSourceOrTarget) !Name !Name
+  | MergeConstructorAlias !MergeSourceOrTarget !Name !Name
   | MergeDefnsInLib !MergeSourceOrTarget
-  | MergeMissingConstructorName !(Maybe MergeSourceOrTarget) !Name
-  | MergeNestedDeclAlias !(Maybe MergeSourceOrTarget) !Name !Name
-  | MergeStrayConstructor !(Maybe MergeSourceOrTarget) !Name
+  | MergeMissingConstructorName !MergeSourceOrTarget !Name
+  | MergeNestedDeclAlias !MergeSourceOrTarget !Name !Name
+  | MergeStrayConstructor !MergeSourceOrTarget !Name
   | InstalledLibdep !(ProjectAndBranch ProjectName ProjectBranchName) !NameSegment
 
 data UpdateOrUpgrade = UOUUpdate | UOUUpgrade

--- a/unison-cli/src/Unison/CommandLine/OutputMessages.hs
+++ b/unison-cli/src/Unison/CommandLine/OutputMessages.hs
@@ -1488,12 +1488,10 @@ notifyUser dir = \case
       "There's a merge conflict on"
         <> P.group (prettyName name <> ",")
         <> "but it's a builtin on one or both branches. We can't yet handle merge conflicts on builtins."
-  MergeConstructorAlias maybeAliceOrBob name1 name2 ->
+  MergeConstructorAlias aliceOrBob name1 name2 ->
     pure . P.wrap $
       "On"
-        <> case maybeAliceOrBob of
-          Nothing -> "the LCA,"
-          Just aliceOrBob -> P.group (prettyMergeSourceOrTarget aliceOrBob <> ",")
+        <> P.group (prettyMergeSourceOrTarget aliceOrBob <> ",")
         <> prettyName name1
         <> "and"
         <> prettyName name2
@@ -1504,32 +1502,26 @@ notifyUser dir = \case
         <> P.group (prettyMergeSourceOrTarget aliceOrBob <> ",")
         <> "there's a type or term directly in the `lib` namespace, but I expected only library dependencies to be in there."
         <> "Please remove it before merging."
-  MergeMissingConstructorName maybeAliceOrBob name ->
+  MergeMissingConstructorName aliceOrBob name ->
     pure . P.wrap $
       "On"
-        <> case maybeAliceOrBob of
-          Nothing -> "the LCA,"
-          Just aliceOrBob -> P.group (prettyMergeSourceOrTarget aliceOrBob <> ",")
+        <> P.group (prettyMergeSourceOrTarget aliceOrBob <> ",")
         <> "the type"
         <> prettyName name
         <> "is missing a name for one of its constructors. Please add one before merging."
-  MergeNestedDeclAlias maybeAliceOrBob shorterName longerName ->
+  MergeNestedDeclAlias aliceOrBob shorterName longerName ->
     pure . P.wrap $
       "On"
-        <> case maybeAliceOrBob of
-          Nothing -> "the LCA,"
-          Just aliceOrBob -> P.group (prettyMergeSourceOrTarget aliceOrBob <> ",")
+        <> P.group (prettyMergeSourceOrTarget aliceOrBob <> ",")
         <> "the type"
         <> prettyName longerName
         <> "is an alias of"
         <> P.group (prettyName shorterName <> ".")
         <> "Type aliases cannot be nested. Please make them disjoint before merging."
-  MergeStrayConstructor maybeAliceOrBob name ->
+  MergeStrayConstructor aliceOrBob name ->
     pure . P.wrap $
       "On"
-        <> case maybeAliceOrBob of
-          Nothing -> "the LCA,"
-          Just aliceOrBob -> P.group (prettyMergeSourceOrTarget aliceOrBob <> ",")
+        <> P.group (prettyMergeSourceOrTarget aliceOrBob <> ",")
         <> "the constructor"
         <> prettyName name
         <> "is not in a subnamespace of a name of its type."

--- a/unison-core/src/Unison/DataDeclaration.hs
+++ b/unison-core/src/Unison/DataDeclaration.hs
@@ -33,10 +33,11 @@ module Unison.DataDeclaration
     constructors_,
     asDataDecl_,
     declAsDataDecl_,
+    setConstructorNames,
   )
 where
 
-import Control.Lens (Iso', Lens', imap, iso, lens, over, _3)
+import Control.Lens (Iso', Lens', imap, iso, lens, over, set, _2, _3)
 import Control.Monad.State (evalState)
 import Data.Map qualified as Map
 import Data.Set qualified as Set
@@ -163,6 +164,20 @@ constructorVars dd = fst <$> constructors dd
 
 constructorNames :: (Var v) => DataDeclaration v a -> [Text]
 constructorNames dd = Var.name <$> constructorVars dd
+
+-- | Overwrite the constructor names with the given list, given in canonical order, which is assumed to be of the
+-- correct length.
+--
+-- Presumably this is called because the decl was loaded from the database outside of the context of a namespace,
+-- since it's not stored with names there, so we had plugged in dummy names like "Constructor1", "Constructor2", ...
+--
+-- Then, at some point, we discover the constructors' names in a namespace, and now we'd like to combine the two
+-- together to get a Decl structure in memory with good/correct names for constructors.
+setConstructorNames :: [v] -> Decl v a -> Decl v a
+setConstructorNames constructorNames =
+  over
+    (declAsDataDecl_ . constructors_)
+    (zipWith (set _2) constructorNames)
 
 -- This function is unsound, since the `rid` and the `decl` have to match.
 -- It should probably be hashed directly from the Decl, once we have a

--- a/unison-merge/src/Unison/Merge/DeclCoherencyCheck.hs
+++ b/unison-merge/src/Unison/Merge/DeclCoherencyCheck.hs
@@ -82,10 +82,11 @@
 module Unison.Merge.DeclCoherencyCheck
   ( IncoherentDeclReason (..),
     checkDeclCoherency,
+    lenientCheckDeclCoherency,
   )
 where
 
-import Control.Lens (view, (%=), (.=))
+import Control.Lens (over, view, (%=), (.=), _2)
 import Control.Monad.Except (ExceptT)
 import Control.Monad.Except qualified as Except
 import Control.Monad.State.Strict (StateT)
@@ -108,9 +109,8 @@ import Unison.NameSegment (NameSegment)
 import Unison.Prelude
 import Unison.Referent (Referent)
 import Unison.Referent qualified as Referent
-import Unison.Sqlite (Transaction)
 import Unison.Util.Defns (Defns (..), DefnsF)
-import Unison.Util.Map qualified as Map (deleteLookup, upsertF)
+import Unison.Util.Map qualified as Map (deleteLookup, deleteLookupJust, upsertF)
 import Unison.Util.Nametree (Nametree (..))
 
 data IncoherentDeclReason
@@ -129,9 +129,11 @@ data IncoherentDeclReason
   | IncoherentDeclReason'StrayConstructor !Name
 
 checkDeclCoherency ::
-  (TypeReferenceId -> Transaction Int) ->
+  forall m.
+  Monad m =>
+  (TypeReferenceId -> m Int) ->
   Nametree (DefnsF (Map NameSegment) Referent TypeReference) ->
-  Transaction (Either IncoherentDeclReason DeclNameLookup)
+  m (Either IncoherentDeclReason DeclNameLookup)
 checkDeclCoherency loadDeclNumConstructors =
   Except.runExceptT
     . fmap (view #declNameLookup)
@@ -140,10 +142,10 @@ checkDeclCoherency loadDeclNumConstructors =
   where
     go ::
       [NameSegment] ->
-      (Nametree (Defns (Map NameSegment Referent) (Map NameSegment TypeReference))) ->
-      StateT DeclCoherencyCheckState (ExceptT IncoherentDeclReason Transaction) ()
-    go prefix (Nametree Defns {terms, types} children) = do
-      for_ (Map.toList terms) \case
+      (Nametree (DefnsF (Map NameSegment) Referent TypeReference)) ->
+      StateT DeclCoherencyCheckState (ExceptT IncoherentDeclReason m) ()
+    go prefix (Nametree defns children) = do
+      for_ (Map.toList defns.terms) \case
         (_, Referent.Ref _) -> pure ()
         (_, Referent.Con (ConstructorReference (ReferenceBuiltin _) _) _) -> pure ()
         (name, Referent.Con (ConstructorReference (ReferenceDerived typeRef) conId) _) -> do
@@ -152,35 +154,35 @@ checkDeclCoherency loadDeclNumConstructors =
           #expectedConstructors .= expectedConstructors1
           where
             f ::
-              Maybe (Name, IntMap MaybeConstructorName) ->
-              Either IncoherentDeclReason (Name, IntMap MaybeConstructorName)
+              Maybe (Name, IntMap (Maybe Name)) ->
+              Either IncoherentDeclReason (Name, IntMap (Maybe Name))
             f = \case
               Nothing -> Left (IncoherentDeclReason'StrayConstructor (fullName name))
               Just (typeName, expected) -> (typeName,) <$> IntMap.alterF g (fromIntegral @Word64 @Int conId) expected
                 where
-                  g :: Maybe MaybeConstructorName -> Either IncoherentDeclReason (Maybe MaybeConstructorName)
+                  g :: Maybe (Maybe Name) -> Either IncoherentDeclReason (Maybe (Maybe Name))
                   g = \case
                     Nothing -> error "didnt put expected constructor id"
-                    Just NoConstructorNameYet -> Right (Just (YesConstructorName (fullName name)))
-                    Just (YesConstructorName firstName) ->
+                    Just Nothing -> Right (Just (Just (fullName name)))
+                    Just (Just firstName) ->
                       Left (IncoherentDeclReason'ConstructorAlias firstName (fullName name))
 
       childrenWeWentInto <-
-        forMaybe (Map.toList types) \case
+        forMaybe (Map.toList defns.types) \case
           (_, ReferenceBuiltin _) -> pure Nothing
           (name, ReferenceDerived typeRef) -> do
             DeclCoherencyCheckState {expectedConstructors} <- State.get
             whatHappened <- do
               let recordNewDecl ::
-                    Maybe (Name, IntMap MaybeConstructorName) ->
-                    Compose (ExceptT IncoherentDeclReason Transaction) WhatHappened (Name, IntMap MaybeConstructorName)
+                    Maybe (Name, IntMap (Maybe Name)) ->
+                    Compose (ExceptT IncoherentDeclReason m) WhatHappened (Name, IntMap (Maybe Name))
                   recordNewDecl =
                     Compose . \case
                       Just (shorterTypeName, _) -> Except.throwError (IncoherentDeclReason'NestedDeclAlias shorterTypeName typeName)
                       Nothing ->
                         lift (loadDeclNumConstructors typeRef) <&> \case
                           0 -> UninhabitedDecl
-                          n -> InhabitedDecl (typeName, IntMap.fromAscList [(i, NoConstructorNameYet) | i <- [0 .. n - 1]])
+                          n -> InhabitedDecl (typeName, IntMap.fromAscList [(i, Nothing) | i <- [0 .. n - 1]])
               lift (getCompose (Map.upsertF recordNewDecl typeRef expectedConstructors))
             case whatHappened of
               UninhabitedDecl -> do
@@ -197,18 +199,92 @@ checkDeclCoherency loadDeclNumConstructors =
                 let (fromJust -> (_typeName, maybeConstructorNames), expectedConstructors1) =
                       Map.deleteLookup typeRef expectedConstructors
                 constructorNames <-
-                  unMaybeConstructorNames maybeConstructorNames & onNothing do
+                  sequence (IntMap.elems maybeConstructorNames) & onNothing do
                     Except.throwError (IncoherentDeclReason'MissingConstructorName typeName)
                 #expectedConstructors .= expectedConstructors1
-                #declNameLookup %= \declNameLookup ->
-                  DeclNameLookup
-                    { constructorToDecl =
-                        List.foldl'
-                          (\acc constructorName -> Map.insert constructorName typeName acc)
-                          declNameLookup.constructorToDecl
-                          constructorNames,
-                      declToConstructors = Map.insert typeName constructorNames declNameLookup.declToConstructors
-                    }
+                #declNameLookup . #constructorToDecl %= \constructorToDecl ->
+                  List.foldl'
+                    (\acc constructorName -> Map.insert constructorName typeName acc)
+                    constructorToDecl
+                    constructorNames
+                #declNameLookup . #declToConstructors %= Map.insert typeName constructorNames
+                pure (Just name)
+            where
+              typeName = fullName name
+
+      let childrenWeHaventGoneInto = children `Map.withoutKeys` Set.fromList childrenWeWentInto
+      for_ (Map.toList childrenWeHaventGoneInto) \(name, child) -> go (name : prefix) child
+      where
+        fullName name =
+          Name.fromReverseSegments (name :| prefix)
+
+lenientCheckDeclCoherency ::
+  forall m.
+  Monad m =>
+  (TypeReferenceId -> m Int) ->
+  Nametree (DefnsF (Map NameSegment) Referent TypeReference) ->
+  m (Map Name [Maybe Name])
+lenientCheckDeclCoherency loadDeclNumConstructors =
+  fmap (view #declToConstructors)
+    . (`State.execStateT` LenientDeclCoherencyCheckState Map.empty Map.empty)
+    . go []
+  where
+    go ::
+      [NameSegment] ->
+      (Nametree (DefnsF (Map NameSegment) Referent TypeReference)) ->
+      StateT LenientDeclCoherencyCheckState m ()
+    go prefix (Nametree defns children) = do
+      for_ (Map.toList defns.terms) \case
+        (_, Referent.Ref _) -> pure ()
+        (_, Referent.Con (ConstructorReference (ReferenceBuiltin _) _) _) -> pure ()
+        (name, Referent.Con (ConstructorReference (ReferenceDerived typeRef) conId) _) -> do
+          #expectedConstructors %= Map.adjust (Map.map f) typeRef
+          where
+            f :: IntMap (Maybe Name) -> IntMap (Maybe Name)
+            f =
+              IntMap.adjust g (fromIntegral @Word64 @Int conId)
+              where
+                g :: Maybe Name -> Maybe Name
+                g = \case
+                  Nothing -> Just (fullName name)
+                  -- Ignore constructor alias, just keep first name we found
+                  Just firstName -> Just firstName
+
+      childrenWeWentInto <-
+        forMaybe (Map.toList defns.types) \case
+          (_, ReferenceBuiltin _) -> pure Nothing
+          (name, ReferenceDerived typeRef) -> do
+            whatHappened <- do
+              let recordNewDecl :: m (WhatHappened (Map Name (IntMap (Maybe Name))))
+                  recordNewDecl =
+                    loadDeclNumConstructors typeRef <&> \case
+                      0 -> UninhabitedDecl
+                      n -> InhabitedDecl (Map.singleton typeName (IntMap.fromAscList [(i, Nothing) | i <- [0 .. n - 1]]))
+              state <- State.get
+              lift (getCompose (Map.upsertF (\_ -> Compose recordNewDecl) typeRef state.expectedConstructors))
+            case whatHappened of
+              UninhabitedDecl -> do
+                #declToConstructors %= Map.insert typeName []
+                pure Nothing
+              InhabitedDecl expectedConstructors1 -> do
+                let child = Map.findWithDefault (Nametree (Defns Map.empty Map.empty) Map.empty) name children
+                #expectedConstructors .= expectedConstructors1
+                go (name : prefix) child
+                state <- State.get
+                let (maybeConstructorNames, expectedConstructors) =
+                      Map.alterF f typeRef state.expectedConstructors
+                      where
+                        f ::
+                          Maybe (Map Name (IntMap (Maybe Name))) ->
+                          (IntMap (Maybe Name), Maybe (Map Name (IntMap (Maybe Name))))
+                        f =
+                          -- fromJust is safe here because we upserted `typeRef` key above
+                          -- deleteLookupJust is safe here because we upserted `typeName` key above
+                          fromJust
+                            >>> Map.deleteLookupJust typeName
+                            >>> over _2 \m -> if Map.null m then Nothing else Just m
+                #expectedConstructors .= expectedConstructors
+                #declToConstructors %= Map.insert typeName (IntMap.elems maybeConstructorNames)
                 pure (Just name)
             where
               typeName = fullName name
@@ -220,23 +296,16 @@ checkDeclCoherency loadDeclNumConstructors =
           Name.fromReverseSegments (name :| prefix)
 
 data DeclCoherencyCheckState = DeclCoherencyCheckState
-  { expectedConstructors :: !(Map TypeReferenceId (Name, IntMap MaybeConstructorName)),
+  { expectedConstructors :: !(Map TypeReferenceId (Name, IntMap (Maybe Name))),
     declNameLookup :: !DeclNameLookup
   }
   deriving stock (Generic)
 
-data MaybeConstructorName
-  = NoConstructorNameYet
-  | YesConstructorName !Name
-
-unMaybeConstructorNames :: IntMap MaybeConstructorName -> Maybe [Name]
-unMaybeConstructorNames =
-  traverse f . IntMap.elems
-  where
-    f :: MaybeConstructorName -> Maybe Name
-    f = \case
-      NoConstructorNameYet -> Nothing
-      YesConstructorName name -> Just name
+data LenientDeclCoherencyCheckState = LenientDeclCoherencyCheckState
+  { expectedConstructors :: !(Map TypeReferenceId (Map Name (IntMap (Maybe Name)))),
+    declToConstructors :: !(Map Name [Maybe Name])
+  }
+  deriving stock (Generic)
 
 data WhatHappened a
   = UninhabitedDecl

--- a/unison-merge/src/Unison/Merge/DeclCoherencyCheck.hs
+++ b/unison-merge/src/Unison/Merge/DeclCoherencyCheck.hs
@@ -217,6 +217,12 @@ checkDeclCoherency loadDeclNumConstructors =
         fullName name =
           Name.fromReverseSegments (name :| prefix)
 
+-- | A lenient variant of 'checkDeclCoherency' - so lenient it can't even fail! It returns a mapping from decl name to
+-- constructor names, where constructor names can be missing.
+--
+-- This function exists merely to extract a best-effort decl-name-to-constructor-name mapping for the LCA of a merge.
+-- We require Alice and Bob to have coherent decls, but their LCA is out of the user's control and may have incoherent
+-- decls, and whether or not it does, we still need to compute *some* syntactic hash for its decls.
 lenientCheckDeclCoherency ::
   forall m.
   Monad m =>

--- a/unison-merge/src/Unison/Merge/DeclNameLookup.hs
+++ b/unison-merge/src/Unison/Merge/DeclNameLookup.hs
@@ -2,24 +2,13 @@ module Unison.Merge.DeclNameLookup
   ( DeclNameLookup (..),
     expectDeclName,
     expectConstructorNames,
-    setConstructorNames,
   )
 where
 
-import Control.Lens (over)
 import Data.Map.Strict qualified as Map
 import Data.Semigroup.Generic (GenericSemigroupMonoid (..))
-import Unison.DataDeclaration (Decl)
-import Unison.DataDeclaration qualified as DataDeclaration
 import Unison.Name (Name)
-import Unison.NameSegment (NameSegment)
 import Unison.Prelude
-import Unison.Reference (TypeReference)
-import Unison.Referent (Referent)
-import Unison.Syntax.Name qualified as Name
-import Unison.Util.Defns (Defns (..), DefnsF)
-import Unison.Util.Nametree (Nametree (..))
-import Unison.Var (Var)
 
 -- | A lookup from decl-to-constructor name and vice-versa.
 --
@@ -62,22 +51,3 @@ expectConstructorNames DeclNameLookup {declToConstructors} x =
   case Map.lookup x declToConstructors of
     Nothing -> error (reportBug "E077058" ("Expected decl name key " <> show x <> " in decl name lookup"))
     Just y -> y
-
--- | Set the constructor names of a data declaration.
---
--- Presumably this is used because the decl was loaded from the database outside of the context of a namespace, because
--- it's not stored with names there, so we plugged in dummy names like "Constructor1", "Constructor2", ...
---
--- Then, at some point, a `DeclNameLookup` was constructed for the corresponding namespace, and now we'd like to
--- combine the two together to get a Decl structure in memory with good/correct names for constructors.
-setConstructorNames :: forall a v. Var v => DeclNameLookup -> Name -> Decl v a -> Decl v a
-setConstructorNames declNameLookup name =
-  case Map.lookup name declNameLookup.declToConstructors of
-    Nothing -> id
-    Just constructorNames ->
-      over
-        (DataDeclaration.declAsDataDecl_ . DataDeclaration.constructors_)
-        ( zipWith
-            (\realConName (ann, _junkConName, typ) -> (ann, Name.toVar realConName, typ))
-            constructorNames
-        )

--- a/unison-merge/src/Unison/Merge/DeclNameLookup.hs
+++ b/unison-merge/src/Unison/Merge/DeclNameLookup.hs
@@ -12,8 +12,13 @@ import Data.Semigroup.Generic (GenericSemigroupMonoid (..))
 import Unison.DataDeclaration (Decl)
 import Unison.DataDeclaration qualified as DataDeclaration
 import Unison.Name (Name)
+import Unison.NameSegment (NameSegment)
 import Unison.Prelude
+import Unison.Reference (TypeReference)
+import Unison.Referent (Referent)
 import Unison.Syntax.Name qualified as Name
+import Unison.Util.Defns (Defns (..), DefnsF)
+import Unison.Util.Nametree (Nametree (..))
 import Unison.Var (Var)
 
 -- | A lookup from decl-to-constructor name and vice-versa.

--- a/unison-src/transcripts/merge.md
+++ b/unison-src/transcripts/merge.md
@@ -1300,3 +1300,70 @@ project/alice> merge /bob
 ```ucm:hide
 .> project.delete project
 ```
+
+## LCA precondition violations
+
+The LCA is not subject to most precondition violations, which is good, because the user can't easily manipulate it!
+
+Here's an example. We'll delete a constructor name from the LCA and still be able to merge Alice and Bob's stuff
+together.
+
+```ucm:hide
+.> project.create-empty project
+project/main> builtins.mergeio
+```
+
+LCA:
+
+```unison
+structural type Foo = Bar Nat | Baz Nat Nat
+```
+
+```ucm
+project/main> add
+project/main> delete.term Foo.Baz
+```
+
+Alice's branch:
+
+```ucm
+project/main> branch alice
+project/alice> delete.type Foo
+project/alice> delete.term Foo.Bar
+```
+
+```unison
+alice : Nat
+alice = 100
+```
+
+```ucm
+project/alice> add
+```
+
+Bob's branch:
+
+```ucm
+project/main> branch bob
+project/bob> delete.type Foo
+project/bob> delete.term Foo.Bar
+```
+
+```unison
+bob : Nat
+bob = 101
+```
+
+```ucm
+project/bob> add
+```
+
+Now we merge:
+
+```ucm
+project/alice> merge /bob
+```
+
+```ucm:hide
+.> project.delete project
+```

--- a/unison-src/transcripts/merge.output.md
+++ b/unison-src/transcripts/merge.output.md
@@ -1144,3 +1144,139 @@ project/alice> merge /bob
   there. Please remove it before merging.
 
 ```
+## LCA precondition violations
+
+The LCA is not subject to most precondition violations, which is good, because the user can't easily manipulate it!
+
+Here's an example. We'll delete a constructor name from the LCA and still be able to merge Alice and Bob's stuff
+together.
+
+LCA:
+
+```unison
+structural type Foo = Bar Nat | Baz Nat Nat
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      structural type Foo
+
+```
+```ucm
+project/main> add
+
+  ⍟ I've added these definitions:
+  
+    structural type Foo
+
+project/main> delete.term Foo.Baz
+
+  Done.
+
+```
+Alice's branch:
+
+```ucm
+project/main> branch alice
+
+  Done. I've created the alice branch based off of main.
+  
+  Tip: To merge your work back into the main branch, first
+       `switch /main` then `merge /alice`.
+
+project/alice> delete.type Foo
+
+  Done.
+
+project/alice> delete.term Foo.Bar
+
+  Done.
+
+```
+```unison
+alice : Nat
+alice = 100
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      alice : Nat
+
+```
+```ucm
+project/alice> add
+
+  ⍟ I've added these definitions:
+  
+    alice : Nat
+
+```
+Bob's branch:
+
+```ucm
+project/main> branch bob
+
+  Done. I've created the bob branch based off of main.
+  
+  Tip: To merge your work back into the main branch, first
+       `switch /main` then `merge /bob`.
+
+project/bob> delete.type Foo
+
+  Done.
+
+project/bob> delete.term Foo.Bar
+
+  Done.
+
+```
+```unison
+bob : Nat
+bob = 101
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bob : Nat
+
+```
+```ucm
+project/bob> add
+
+  ⍟ I've added these definitions:
+  
+    bob : Nat
+
+```
+Now we merge:
+
+```ucm
+project/alice> merge /bob
+
+  I merged project/bob into project/alice.
+
+```


### PR DESCRIPTION
## Overview

There are a few merge preconditions that (on trunk) even the LCA must satisfy. That was never good, which is to say it was always bad, and this PR relaxes most of them.

The preconditions were put on the LCA because we previously passed in a `DeclNameLookup` (bidirectional mapping between decl name and constructor names) into the main "synhash + diff" function, since constructor names are needed to compute the syntactic hash of decls.

So, the fix we decided on is to simply relax the requirements on the well-formedness of type decls in the LCA, given that the constructor names are only used for computing a syntactic hash:

- An alias for a constructor is ok, just ignore it (using whatever first name we came across)
- A nested decl is ok, it was only problematic because it implies aliases
- A stray constructor is, just ignore it
- A missing constructor name can be worked around: just say all such decls have a sentinel syntactic hash

## Test coverage

I added a test of this code to the existing transcript.