### PR TITLE
Update .mergify.yml

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,9 +11,12 @@ pull_request_rules:
       - check-success=run interpreter tests (macOS-12)
       # - check-success=run interpreter tests (windows-2019)
       - check-success=generate jit source
-      - check-success=build jit binary (ubuntu-20.04)
-      - check-success=build jit binary (macOS-12)
-      - check-success=build jit binary (windows-2019)
+      - check-success=build jit binary / build jit binary (ubuntu-20.04)
+      - check-success=build jit binary / build jit binary (macOS-12)
+      - check-success=build jit binary / build jit binary (windows-2019)
+      - check-success=test jit / test jit (ubuntu-20.04)
+      - check-success=test jit / test jit (macOS-12)
+      # - check-success=test jit / test jit (windows-2019)
       - label=ready-to-merge
       - "#approved-reviews-by>=1"
     actions:


### PR DESCRIPTION
Mergify is configured to look for specifically-named checks to complete before auto-merging, but the names of those tests change as I refactored the CI code. This PR tries to bring .mergify.yml in line with the current CI check names.