### PR TITLE
only use iohk cache on linux

### DIFF
--- a/.github/workflows/nix-dev-cache.yaml
+++ b/.github/workflows/nix-dev-cache.yaml
@@ -21,13 +21,17 @@ jobs:
         os:
           - ubuntu-20.04
           - macOS-12
+          - macOS-14
     steps:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v27
+      if: runner.os == 'Linux'
       with:
         extra_nix_config: |
           extra-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
           extra-substituters = https://cache.iog.io
+    - uses: cachix/install-nix-action@v27
+      if: runner.os != 'Linux'
     - uses: cachix/cachix-action@v15
       with:
         name: unison


### PR DESCRIPTION
enable caching of apple silicon build products on cachix.
this seems to reduce my `nix develop` time to about 2 minutes after a `nix-collect-garbage`.
AND the resulting `stack` actually runs.

disclaimer: I don't actually remember how to find my nix gc roots, so I don't know if everything is being deleted before the timing test.