### PR TITLE
Run Cabal test-suites as Nix checks

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -139,6 +139,8 @@
           // renameAttrs (name: "cabal-${name}") haskell-nix-flake.devShells
           // {default = self.devShells."${system}".only-tools-nixpkgs;};
 
+        checks = renameAttrs (name: "component-${name}") haskell-nix-flake.checks;
+
         formatter = pkgs.alejandra;
       });
 }


### PR DESCRIPTION
## Overview

`nix flake check` will now ensure both that the flake is valid, and that all tests pass.