### PR TITLE
Convert `ShallowListEntry` in `InputPattern` handlers

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -90,7 +90,7 @@ import Data.Sequence qualified as Seq
 import Data.Text qualified as Text
 import GHC.Exts qualified as GHC
 import Unison.HashQualified' qualified as HQ'
-import Unison.Name (Convert (..), Name, Parse)
+import Unison.Name (Convert (..), Name)
 import Unison.Name qualified as Name
 import Unison.NameSegment (NameSegment)
 import Unison.Prelude hiding (empty, toList)
@@ -244,8 +244,8 @@ fromList = Path . Seq.fromList
 ancestors :: Absolute -> Seq Absolute
 ancestors (Absolute (Path segments)) = Absolute . Path <$> Seq.inits segments
 
-hqSplitFromName' :: Name -> Maybe HQSplit'
-hqSplitFromName' = fmap (fmap HQ'.fromName) . Lens.unsnoc . fromName'
+hqSplitFromName' :: Name -> HQSplit'
+hqSplitFromName' = fmap HQ'.fromName . splitFromName'
 
 -- |
 -- >>> splitFromName "a.b.c"
@@ -546,5 +546,3 @@ instance Convert (path, NameSegment) (path, HQ'.HQSegment) where
 instance (Convert path0 path1) => Convert (path0, name) (path1, name) where
   convert =
     over _1 convert
-
-instance Parse Name HQSplit' where parse = hqSplitFromName'

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -695,7 +695,7 @@ loop e = do
 
               pathArgAbs <- Cli.resolvePath' pathArg
               entries <- liftIO (Backend.lsAtPath codebase Nothing pathArgAbs)
-              Cli.setNumberedArgs $ fmap (SA.ShallowListEntry pathArg) entries
+              Cli.setNumberedArgs $ fmap (SA.ShallowListEntry pathArgAbs) entries
               pped <- Cli.currentPrettyPrintEnvDecl
               let suffixifiedPPE = PPED.suffixifiedPPE pped
               -- This used to be a delayed action which only forced the loading of the root

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/TermResolution.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/TermResolution.hs
@@ -79,7 +79,7 @@ resolveTerm name = do
   case lookupTerm name names of
     [] -> Cli.returnEarly (TermNotFound $ fromJust parsed)
       where
-        parsed = hqSplitFromName' =<< HQ.toName name
+        parsed = hqSplitFromName' <$> HQ.toName name
     [rf] -> pure rf
     rfs ->
       Cli.returnEarly (TermAmbiguous suffixifiedPPE name (fromList rfs))
@@ -92,7 +92,7 @@ resolveCon name = do
   case lookupCon name names of
     ([], _) -> Cli.returnEarly (TermNotFound $ fromJust parsed)
       where
-        parsed = hqSplitFromName' =<< HQ.toName name
+        parsed = hqSplitFromName' <$> HQ.toName name
     ([co], _) -> pure co
     (_, rfts) ->
       Cli.returnEarly (TermAmbiguous suffixifiedPPE name (fromList rfts))
@@ -105,7 +105,7 @@ resolveTermRef name = do
   case lookupTermRefs name names of
     ([], _) -> Cli.returnEarly (TermNotFound $ fromJust parsed)
       where
-        parsed = hqSplitFromName' =<< HQ.toName name
+        parsed = hqSplitFromName' <$> HQ.toName name
     ([rf], _) -> pure rf
     (_, rfts) ->
       Cli.returnEarly (TermAmbiguous suffixifiedPPE name (fromList rfts))

--- a/unison-cli/src/Unison/Codebase/Editor/StructuredArgument.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/StructuredArgument.hs
@@ -3,7 +3,7 @@ module Unison.Codebase.Editor.StructuredArgument where
 import GHC.Generics (Generic)
 import U.Codebase.HashTags (CausalHash)
 import Unison.Codebase.Editor.Input
-import Unison.Codebase.Path (Path, Path')
+import Unison.Codebase.Path (Path)
 import Unison.Codebase.Path qualified as Path
 import Unison.HashQualified qualified as HQ
 import Unison.HashQualified' qualified as HQ'
@@ -24,6 +24,6 @@ data StructuredArgument
   | Namespace CausalHash
   | NameWithBranchPrefix AbsBranchId Name
   | HashQualifiedWithBranchPrefix AbsBranchId (HQ'.HashQualified Name)
-  | ShallowListEntry Path' (ShallowListEntry Symbol Ann)
+  | ShallowListEntry Path.Absolute (ShallowListEntry Symbol Ann)
   | SearchResult (Maybe Path) SearchResult
   deriving (Eq, Generic, Show)

--- a/unison-cli/src/Unison/CommandLine/InputPatterns.hs
+++ b/unison-cli/src/Unison/CommandLine/InputPatterns.hs
@@ -405,7 +405,7 @@ handleHashQualifiedNameArg =
       SA.HashQualifiedWithBranchPrefix mprefix hqname ->
         pure . HQ'.toHQ $ foldr (\prefix -> fmap $ Name.makeAbsolute . Path.prefixName prefix) hqname mprefix
       SA.ShallowListEntry prefix entry ->
-        pure . HQ'.toHQ . fmap (Path.prefixName prefix) $ shallowListEntryToHQ' entry
+        pure . HQ'.toHQ . fmap (Name.makeAbsolute . Path.prefixName prefix) $ shallowListEntryToHQ' entry
       SA.SearchResult mpath result -> pure $ searchResultToHQ mpath result
       otherArgType -> Left $ wrongStructuredArgument "a hash-qualified name" otherArgType
 
@@ -580,7 +580,7 @@ handleHashQualifiedSplit'Arg =
       SA.HashQualifiedWithBranchPrefix (Right prefix) hqname ->
         pure . hq'NameToSplit' $ Name.makeAbsolute . Path.prefixName prefix <$> hqname
       SA.ShallowListEntry prefix entry ->
-        pure . hq'NameToSplit' . fmap (Path.prefixName prefix) $ shallowListEntryToHQ' entry
+        pure . hq'NameToSplit' . fmap (Name.makeAbsolute . Path.prefixName prefix) $ shallowListEntryToHQ' entry
       sr@(SA.SearchResult mpath result) ->
         first (const $ expectedButActually "a name" sr "a hash") . hqNameToSplit' $ searchResultToHQ mpath result
       otherNumArg -> Left $ wrongStructuredArgument "a name" otherNumArg
@@ -626,7 +626,7 @@ handleShortHashOrHQSplit'Arg =
       SA.HashQualifiedWithBranchPrefix (Right prefix) hqname ->
         pure . pure $ hq'NameToSplit' (Name.makeAbsolute . Path.prefixName prefix <$> hqname)
       SA.ShallowListEntry prefix entry ->
-        pure . pure . hq'NameToSplit' . fmap (Path.prefixName prefix) $ shallowListEntryToHQ' entry
+        pure . pure . hq'NameToSplit' . fmap (Name.makeAbsolute . Path.prefixName prefix) $ shallowListEntryToHQ' entry
       SA.SearchResult mpath result -> pure . hqNameToSplit' $ searchResultToHQ mpath result
       otherNumArg -> Left $ wrongStructuredArgument "a hash or name" otherNumArg
 
@@ -651,7 +651,7 @@ handleNameArg =
       SA.HashQualifiedWithBranchPrefix (Right prefix) hqname ->
         pure . Name.makeAbsolute . Path.prefixName prefix $ HQ'.toName hqname
       SA.ShallowListEntry prefix entry ->
-        pure . HQ'.toName . fmap (Path.prefixName prefix) $ shallowListEntryToHQ' entry
+        pure . HQ'.toName . fmap (Name.makeAbsolute . Path.prefixName prefix) $ shallowListEntryToHQ' entry
       SA.SearchResult mpath result ->
         maybe (Left "can’t find a name from the numbered arg") pure . HQ.toName $ searchResultToHQ mpath result
       otherNumArg -> Left $ wrongStructuredArgument "a name" otherNumArg

--- a/unison-src/transcripts/fix5055.md
+++ b/unison-src/transcripts/fix5055.md
@@ -1,5 +1,16 @@
 ```ucm
 .> builtins.merge
-.> ls builtin
+```
+
+```unison
+foo.add x y = x Int.+ y
+
+foo.subtract x y = x Int.- y
+```
+
+```ucm
+.> add
+.> ls foo
 .> view 1
 ```
+

--- a/unison-src/transcripts/fix5055.md
+++ b/unison-src/transcripts/fix5055.md
@@ -1,0 +1,5 @@
+```ucm
+.> builtins.merge
+.> ls builtin
+.> view 1
+```

--- a/unison-src/transcripts/fix5055.output.md
+++ b/unison-src/transcripts/fix5055.output.md
@@ -3,91 +3,45 @@
 
   Done.
 
-.> ls builtin
+```
+```unison
+foo.add x y = x Int.+ y
 
-  1.  Any                 (builtin type)
-  2.  Any/                (2 terms)
-  3.  Boolean             (builtin type)
-  4.  Boolean/            (1 term)
-  5.  Bytes               (builtin type)
-  6.  Bytes/              (34 terms)
-  7.  Char                (builtin type)
-  8.  Char/               (22 terms, 1 type)
-  9.  ClientSockAddr      (builtin type)
-  10. Code                (builtin type)
-  11. Code/               (9 terms)
-  12. Debug/              (3 terms)
-  13. Doc                 (type)
-  14. Doc/                (6 terms)
-  15. Either              (type)
-  16. Either/             (2 terms)
-  17. Exception           (type)
-  18. Exception/          (1 term)
-  19. Float               (builtin type)
-  20. Float/              (38 terms)
-  21. Handle/             (1 term)
-  22. ImmutableArray      (builtin type)
-  23. ImmutableArray/     (3 terms)
-  24. ImmutableByteArray  (builtin type)
-  25. ImmutableByteArray/ (8 terms)
-  26. Int                 (builtin type)
-  27. Int/                (31 terms)
-  28. IsPropagated        (type)
-  29. IsPropagated/       (1 term)
-  30. IsTest              (type)
-  31. IsTest/             (1 term)
-  32. Link                (type)
-  33. Link/               (3 terms, 2 types)
-  34. List                (builtin type)
-  35. List/               (10 terms)
-  36. ListenSocket        (builtin type)
-  37. MutableArray        (builtin type)
-  38. MutableArray/       (6 terms)
-  39. MutableByteArray    (builtin type)
-  40. MutableByteArray/   (14 terms)
-  41. Nat                 (builtin type)
-  42. Nat/                (28 terms)
-  43. Optional            (type)
-  44. Optional/           (2 terms)
-  45. Pattern             (builtin type)
-  46. Pattern/            (9 terms)
-  47. Ref                 (builtin type)
-  48. Ref/                (2 terms)
-  49. Request             (builtin type)
-  50. RewriteCase         (type)
-  51. RewriteCase/        (1 term)
-  52. RewriteSignature    (type)
-  53. RewriteSignature/   (1 term)
-  54. RewriteTerm         (type)
-  55. RewriteTerm/        (1 term)
-  56. Rewrites            (type)
-  57. Rewrites/           (1 term)
-  58. Scope               (builtin type)
-  59. Scope/              (6 terms)
-  60. SeqView             (type)
-  61. SeqView/            (2 terms)
-  62. Socket/             (1 term)
-  63. Test/               (2 terms, 1 type)
-  64. Text                (builtin type)
-  65. Text/               (34 terms)
-  66. ThreadId/           (1 term)
-  67. Tuple               (type)
-  68. Tuple/              (1 term)
-  69. UDPSocket           (builtin type)
-  70. Unit                (type)
-  71. Unit/               (1 term)
-  72. Universal/          (7 terms)
-  73. Value               (builtin type)
-  74. Value/              (5 terms)
-  75. bug                 (a -> b)
-  76. crypto/             (17 terms, 2 types)
-  77. io2/                (146 terms, 32 types)
-  78. metadata/           (2 terms)
-  79. todo                (a -> b)
-  80. unsafe/             (1 term)
+foo.subtract x y = x Int.- y
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      foo.add      : Int -> Int -> Int
+      foo.subtract : Int -> Int -> Int
+
+```
+```ucm
+.> add
+
+  ⍟ I've added these definitions:
+  
+    foo.add      : Int -> Int -> Int
+    foo.subtract : Int -> Int -> Int
+
+.> ls foo
+
+  1. add      (Int -> Int -> Int)
+  2. subtract (Int -> Int -> Int)
 
 .> view 1
 
-  -- builtin.Any is built-in.
+  foo.add : Int -> Int -> Int
+  foo.add x y =
+    use Int +
+    x + y
 
 ```

--- a/unison-src/transcripts/fix5055.output.md
+++ b/unison-src/transcripts/fix5055.output.md
@@ -39,8 +39,8 @@ foo.subtract x y = x Int.- y
 
 .> view 1
 
-  foo.add : Int -> Int -> Int
-  foo.add x y =
+  .foo.add : Int -> Int -> Int
+  .foo.add x y =
     use Int +
     x + y
 

--- a/unison-src/transcripts/fix5055.output.md
+++ b/unison-src/transcripts/fix5055.output.md
@@ -1,0 +1,99 @@
+```ucm
+.> builtins.merge
+
+  Done.
+
+.> ls builtin
+
+  1.  Any                 (builtin type)
+  2.  Any/                (2 terms)
+  3.  Boolean             (builtin type)
+  4.  Boolean/            (1 term)
+  5.  Bytes               (builtin type)
+  6.  Bytes/              (34 terms)
+  7.  Char                (builtin type)
+  8.  Char/               (22 terms, 1 type)
+  9.  ClientSockAddr      (builtin type)
+  10. Code                (builtin type)
+  11. Code/               (9 terms)
+  12. Debug/              (3 terms)
+  13. Doc                 (type)
+  14. Doc/                (6 terms)
+  15. Either              (type)
+  16. Either/             (2 terms)
+  17. Exception           (type)
+  18. Exception/          (1 term)
+  19. Float               (builtin type)
+  20. Float/              (38 terms)
+  21. Handle/             (1 term)
+  22. ImmutableArray      (builtin type)
+  23. ImmutableArray/     (3 terms)
+  24. ImmutableByteArray  (builtin type)
+  25. ImmutableByteArray/ (8 terms)
+  26. Int                 (builtin type)
+  27. Int/                (31 terms)
+  28. IsPropagated        (type)
+  29. IsPropagated/       (1 term)
+  30. IsTest              (type)
+  31. IsTest/             (1 term)
+  32. Link                (type)
+  33. Link/               (3 terms, 2 types)
+  34. List                (builtin type)
+  35. List/               (10 terms)
+  36. ListenSocket        (builtin type)
+  37. MutableArray        (builtin type)
+  38. MutableArray/       (6 terms)
+  39. MutableByteArray    (builtin type)
+  40. MutableByteArray/   (14 terms)
+  41. Nat                 (builtin type)
+  42. Nat/                (28 terms)
+  43. Optional            (type)
+  44. Optional/           (2 terms)
+  45. Pattern             (builtin type)
+  46. Pattern/            (9 terms)
+  47. Ref                 (builtin type)
+  48. Ref/                (2 terms)
+  49. Request             (builtin type)
+  50. RewriteCase         (type)
+  51. RewriteCase/        (1 term)
+  52. RewriteSignature    (type)
+  53. RewriteSignature/   (1 term)
+  54. RewriteTerm         (type)
+  55. RewriteTerm/        (1 term)
+  56. Rewrites            (type)
+  57. Rewrites/           (1 term)
+  58. Scope               (builtin type)
+  59. Scope/              (6 terms)
+  60. SeqView             (type)
+  61. SeqView/            (2 terms)
+  62. Socket/             (1 term)
+  63. Test/               (2 terms, 1 type)
+  64. Text                (builtin type)
+  65. Text/               (34 terms)
+  66. ThreadId/           (1 term)
+  67. Tuple               (type)
+  68. Tuple/              (1 term)
+  69. UDPSocket           (builtin type)
+  70. Unit                (type)
+  71. Unit/               (1 term)
+  72. Universal/          (7 terms)
+  73. Value               (builtin type)
+  74. Value/              (5 terms)
+  75. bug                 (a -> b)
+  76. crypto/             (17 terms, 2 types)
+  77. io2/                (146 terms, 32 types)
+  78. metadata/           (2 terms)
+  79. todo                (a -> b)
+  80. unsafe/             (1 term)
+
+.> view 1
+
+```
+
+
+
+🛑
+
+The transcript failed due to an error in the stanza above. The error is:
+
+Expected a hash-qualified name, but the numbered arg resulted in builtin.Any, which is an annotated symbol.

--- a/unison-src/transcripts/fix5055.output.md
+++ b/unison-src/transcripts/fix5055.output.md
@@ -88,12 +88,6 @@
 
 .> view 1
 
+  -- builtin.Any is built-in.
+
 ```
-
-
-
-🛑
-
-The transcript failed due to an error in the stanza above. The error is:
-
-Expected a hash-qualified name, but the numbered arg resulted in builtin.Any, which is an annotated symbol.


### PR DESCRIPTION
## Overview

`ShallowListEntry` as returned by `ls` weren’t being handled by the new `InputPattern` handlers, and so the results of `ls` couldn’t be used as numbered args. This adds support for `ShallowListEntry` to the handlers.

Fixes #5055.

## Interesting/controversial decisions

This additionally makes `hqSplitFromName'` total, which triggers a few other minor adjustments.

Most uses of `ShallowListEntry` in the handler join the entry with the absolute prefix indicating where the `ls` was performed, however there is one handler that only allows relative paths (and is used by `alias.many`). That handler ignores the prefix and provides just the relative `ls` result.

## Test coverage

There is a new transcript that exercises this as exhibited in #5055.