### PR TITLE
Improve `ls` with numbered arg behavior

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Path.hs
+++ b/parser-typechecker/src/Unison/Codebase/Path.hs
@@ -22,9 +22,12 @@ module Unison.Codebase.Path
     relativeEmpty',
     currentPath,
     prefix,
+    prefixAbs,
+    prefixRel,
+    maybePrefix,
     unprefix,
-    prefixName,
-    prefixName2,
+    maybePrefixName,
+    prefixNameIfRel,
     unprefixName,
     HQSplit,
     Split,
@@ -62,8 +65,7 @@ module Unison.Codebase.Path
     unsplitAbsolute,
     unsplitHQ,
     unsplitHQ',
-
-    -- * things that could be replaced with `Parse` instances
+    nameFromSplit',
     splitFromName,
     splitFromName',
     hqSplitFromName',
@@ -81,6 +83,7 @@ where
 
 import Control.Lens hiding (cons, snoc, unsnoc, pattern Empty)
 import Control.Lens qualified as Lens
+import Data.Bitraversable (bitraverse)
 import Data.Foldable qualified as Foldable
 import Data.List.Extra (dropPrefix)
 import Data.List.NonEmpty (NonEmpty ((:|)))
@@ -187,16 +190,25 @@ unprefix (Absolute prefix) = \case
   AbsolutePath' abs -> unabsolute abs
   RelativePath' rel -> fromList $ dropPrefix (toList prefix) (toList (unrelative rel))
 
--- too many types
-prefix :: Absolute -> Path' -> Path
-prefix (Absolute (Path prefix)) = \case
-  AbsolutePath' abs -> unabsolute abs
-  RelativePath' rel -> Path $ prefix <> toSeq (unrelative rel)
+prefixAbs :: Absolute -> Relative -> Absolute
+prefixAbs prefix = Absolute . Path . (toSeq (unabsolute prefix) <>) . toSeq . unrelative
 
-prefix2 :: Path -> Path' -> Path
-prefix2 (Path prefix) = \case
-  AbsolutePath' abs -> unabsolute abs
-  RelativePath' rel -> Path $ prefix <> toSeq (unrelative rel)
+prefixRel :: Relative -> Relative -> Relative
+prefixRel prefix = Relative . Path . (toSeq (unrelative prefix) <>) . toSeq . unrelative
+
+-- | This always prefixes, since the secend argument can never be Absolute.
+prefix :: Path' -> Relative -> Path'
+prefix prefix =
+  Path' . case prefix of
+    AbsolutePath' abs -> Left . prefixAbs abs
+    RelativePath' rel -> pure . prefixRel rel
+
+-- | Returns `Nothing` if the second argument is absolute. A common pattern is
+--   @fromMaybe path $ maybePrefix prefix path@ to use the unmodified path in that case.
+maybePrefix :: Path' -> Path' -> Maybe Path'
+maybePrefix pre = \case
+  AbsolutePath' _ -> Nothing
+  RelativePath' rel -> pure $ prefix pre rel
 
 -- | Finds the longest shared path prefix of two paths.
 -- Returns (shared prefix, path to first location from shared prefix, path to second location from shared prefix)
@@ -268,6 +280,11 @@ splitFromName' name =
             seg
           )
 
+nameFromSplit' :: Split' -> Name
+nameFromSplit' (path', seg) = case path' of
+  AbsolutePath' abs -> Name.makeAbsolute . Name.fromReverseSegments $ seg :| reverse (toList $ unabsolute abs)
+  RelativePath' rel -> Name.makeRelative . Name.fromReverseSegments $ seg :| reverse (toList $ unrelative rel)
+
 -- | Remove a path prefix from a name.
 -- Returns 'Nothing' if there are no remaining segments to construct the name from.
 --
@@ -276,11 +293,13 @@ splitFromName' name =
 unprefixName :: Absolute -> Name -> Maybe Name
 unprefixName prefix = toName . unprefix prefix . fromName'
 
-prefixName :: Absolute -> Name -> Name
-prefixName p n = fromMaybe n . toName . prefix p . fromName' $ n
+-- | Returns `Nothing` if the second argument is absolute. A common pattern is
+--   @fromMaybe name $ maybePrefixName prefix name@ to use the unmodified path in that case.
+maybePrefixName :: Path' -> Name -> Maybe Name
+maybePrefixName pre = fmap nameFromSplit' . bitraverse (maybePrefix pre) pure . splitFromName'
 
-prefixName2 :: Path -> Name -> Name
-prefixName2 p n = fromMaybe n . toName . prefix2 p . fromName' $ n
+prefixNameIfRel :: Path' -> Name -> Name
+prefixNameIfRel p name = fromMaybe name $ maybePrefixName p name
 
 singleton :: NameSegment -> Path
 singleton n = fromList [n]

--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput.hs
@@ -695,7 +695,7 @@ loop e = do
 
               pathArgAbs <- Cli.resolvePath' pathArg
               entries <- liftIO (Backend.lsAtPath codebase Nothing pathArgAbs)
-              Cli.setNumberedArgs $ fmap (SA.ShallowListEntry pathArgAbs) entries
+              Cli.setNumberedArgs $ fmap (SA.ShallowListEntry pathArg) entries
               pped <- Cli.currentPrettyPrintEnvDecl
               let suffixifiedPPE = PPED.suffixifiedPPE pped
               -- This used to be a delayed action which only forced the loading of the root
@@ -1181,7 +1181,7 @@ handleFindI isVerbose fscope ws input = do
   Cli.Env {codebase} <- ask
   (pped, names, searchRoot, branch0) <- case fscope of
     FindLocal p -> do
-      searchRoot <- Cli.resolvePath p
+      searchRoot <- Cli.resolvePath' p
       branch0 <- Cli.getBranch0At searchRoot
       let names = Branch.toNames (Branch.withoutLib branch0)
       -- Don't exclude anything from the pretty printer, since the type signatures we print for
@@ -1189,7 +1189,7 @@ handleFindI isVerbose fscope ws input = do
       pped <- Cli.currentPrettyPrintEnvDecl
       pure (pped, names, Just p, branch0)
     FindLocalAndDeps p -> do
-      searchRoot <- Cli.resolvePath p
+      searchRoot <- Cli.resolvePath' p
       branch0 <- Cli.getBranch0At searchRoot
       let names = Branch.toNames (Branch.withoutTransitiveLibs branch0)
       -- Don't exclude anything from the pretty printer, since the type signatures we print for

--- a/unison-cli/src/Unison/Codebase/Editor/Input.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/Input.hs
@@ -284,8 +284,8 @@ data OutputLocation
   deriving (Eq, Show)
 
 data FindScope
-  = FindLocal Path
-  | FindLocalAndDeps Path
+  = FindLocal Path'
+  | FindLocalAndDeps Path'
   | FindGlobal
   deriving stock (Eq, Show)
 

--- a/unison-cli/src/Unison/Codebase/Editor/StructuredArgument.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/StructuredArgument.hs
@@ -3,7 +3,7 @@ module Unison.Codebase.Editor.StructuredArgument where
 import GHC.Generics (Generic)
 import U.Codebase.HashTags (CausalHash)
 import Unison.Codebase.Editor.Input
-import Unison.Codebase.Path (Path)
+import Unison.Codebase.Path (Path')
 import Unison.Codebase.Path qualified as Path
 import Unison.HashQualified qualified as HQ
 import Unison.HashQualified' qualified as HQ'
@@ -24,6 +24,6 @@ data StructuredArgument
   | Namespace CausalHash
   | NameWithBranchPrefix AbsBranchId Name
   | HashQualifiedWithBranchPrefix AbsBranchId (HQ'.HashQualified Name)
-  | ShallowListEntry Path.Absolute (ShallowListEntry Symbol Ann)
-  | SearchResult (Maybe Path) SearchResult
+  | ShallowListEntry Path' (ShallowListEntry Symbol Ann)
+  | SearchResult (Maybe Path') SearchResult
   deriving (Eq, Generic, Show)

--- a/unison-share-api/src/Unison/Server/Local.hs
+++ b/unison-share-api/src/Unison/Server/Local.hs
@@ -45,7 +45,7 @@ relocateToNameRoot perspective query rootBranch = do
         (_sharedPrefix, remainder, Path.Empty) -> do
           -- Since the project is higher up, we need to prefix the query
           -- with the remainder of the path
-          pure . Right $ (projectRoot, query <&> Path.prefixName (Path.Absolute remainder))
+          pure $ Right (projectRoot, query <&> Path.prefixNameIfRel (Path.AbsolutePath' $ Path.Absolute remainder))
         -- The namesRoot and project root are disjoint, this shouldn't ever happen.
         (_, _, _) -> pure $ Left (DisjointProjectAndPerspective perspective projectRoot)
 

--- a/unison-share-api/src/Unison/Server/NameSearch/Sqlite.hs
+++ b/unison-share-api/src/Unison/Server/NameSearch/Sqlite.hs
@@ -130,7 +130,8 @@ nameSearchForPerspective codebase namesPerspective@Ops.NamesPerspective {pathToM
 
     -- Fully qualify a name by prepending the current namespace perspective's path
     fullyQualifyName :: Name -> Name
-    fullyQualifyName name = Path.prefixName (Path.Absolute (Path.fromList . coerce $ pathToMountedNameLookup)) name
+    fullyQualifyName =
+      Path.prefixNameIfRel (Path.AbsolutePath' . Path.Absolute . Path.fromList $ coerce pathToMountedNameLookup)
 
 -- | Look up types in the codebase by short hash, and include builtins.
 typeReferencesByShortHash :: SH.ShortHash -> Sqlite.Transaction (Set Reference)

--- a/unison-src/transcripts/fix-ls.md
+++ b/unison-src/transcripts/fix-ls.md
@@ -1,0 +1,16 @@
+```ucm
+.> project.create-empty test-ls
+test-ls/main> builtins.merge
+```
+
+```unison
+foo.bar.add x y = x Int.+ y
+
+foo.bar.subtract x y = x Int.- y
+```
+
+```ucm
+test-ls/main> add
+test-ls/main> ls foo
+test-ls/main> ls 1
+```

--- a/unison-src/transcripts/fix-ls.output.md
+++ b/unison-src/transcripts/fix-ls.output.md
@@ -1,0 +1,65 @@
+```ucm
+.> project.create-empty test-ls
+
+  🎉 I've created the project test-ls.
+
+  🎨 Type `ui` to explore this project's code in your browser.
+  🔭 Discover libraries at https://share.unison-lang.org
+  📖 Use `help-topic projects` to learn more about projects.
+  
+  Write your first Unison code with UCM:
+  
+    1. Open scratch.u.
+    2. Write some Unison code and save the file.
+    3. In UCM, type `add` to save it to your new project.
+  
+  🎉 🥳 Happy coding!
+
+test-ls/main> builtins.merge
+
+  Done.
+
+```
+```unison
+foo.bar.add x y = x Int.+ y
+
+foo.bar.subtract x y = x Int.- y
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      foo.bar.add      : Int -> Int -> Int
+      foo.bar.subtract : Int -> Int -> Int
+
+```
+```ucm
+test-ls/main> add
+
+  ⍟ I've added these definitions:
+  
+    foo.bar.add      : Int -> Int -> Int
+    foo.bar.subtract : Int -> Int -> Int
+
+test-ls/main> ls foo
+
+  1. bar/ (2 terms)
+
+test-ls/main> ls 1
+
+```
+
+
+
+🛑
+
+The transcript failed due to an error in the stanza above. The error is:
+
+Expected a namespace, but the numbered arg resulted in foo.bar, which is a name.

--- a/unison-src/transcripts/fix-ls.output.md
+++ b/unison-src/transcripts/fix-ls.output.md
@@ -54,12 +54,7 @@ test-ls/main> ls foo
 
 test-ls/main> ls 1
 
+  1. add      (Int -> Int -> Int)
+  2. subtract (Int -> Int -> Int)
+
 ```
-
-
-
-🛑
-
-The transcript failed due to an error in the stanza above. The error is:
-
-Expected a namespace, but the numbered arg resulted in foo.bar, which is a name.

--- a/unison-src/transcripts/fix5055.md
+++ b/unison-src/transcripts/fix5055.md
@@ -1,5 +1,6 @@
 ```ucm
-.> builtins.merge
+.> project.create-empty test-5055
+test-5055/main> builtins.merge
 ```
 
 ```unison
@@ -9,8 +10,7 @@ foo.subtract x y = x Int.- y
 ```
 
 ```ucm
-.> add
-.> ls foo
-.> view 1
+test-5055/main> add
+test-5055/main> ls foo
+test-5055/main> view 1
 ```
-

--- a/unison-src/transcripts/fix5055.output.md
+++ b/unison-src/transcripts/fix5055.output.md
@@ -55,10 +55,8 @@ test-5055/main> ls foo
 
 test-5055/main> view 1
 
-  .__projects._8e3f0836_9520_436c_bc83_398857c869a7.branches._6fb370f4_774e_495a_a8ff_caec833fdcc8.foo.add :
-    Int -> Int -> Int
-  .__projects._8e3f0836_9520_436c_bc83_398857c869a7.branches._6fb370f4_774e_495a_a8ff_caec833fdcc8.foo.add
-    x y =
+  foo.add : Int -> Int -> Int
+  foo.add x y =
     use Int +
     x + y
 

--- a/unison-src/transcripts/fix5055.output.md
+++ b/unison-src/transcripts/fix5055.output.md
@@ -1,5 +1,21 @@
 ```ucm
-.> builtins.merge
+.> project.create-empty test-5055
+
+  🎉 I've created the project test-5055.
+
+  🎨 Type `ui` to explore this project's code in your browser.
+  🔭 Discover libraries at https://share.unison-lang.org
+  📖 Use `help-topic projects` to learn more about projects.
+  
+  Write your first Unison code with UCM:
+  
+    1. Open scratch.u.
+    2. Write some Unison code and save the file.
+    3. In UCM, type `add` to save it to your new project.
+  
+  🎉 🥳 Happy coding!
+
+test-5055/main> builtins.merge
 
   Done.
 
@@ -25,22 +41,24 @@ foo.subtract x y = x Int.- y
 
 ```
 ```ucm
-.> add
+test-5055/main> add
 
   ⍟ I've added these definitions:
   
     foo.add      : Int -> Int -> Int
     foo.subtract : Int -> Int -> Int
 
-.> ls foo
+test-5055/main> ls foo
 
   1. add      (Int -> Int -> Int)
   2. subtract (Int -> Int -> Int)
 
-.> view 1
+test-5055/main> view 1
 
-  .foo.add : Int -> Int -> Int
-  .foo.add x y =
+  .__projects._8e3f0836_9520_436c_bc83_398857c869a7.branches._6fb370f4_774e_495a_a8ff_caec833fdcc8.foo.add :
+    Int -> Int -> Int
+  .__projects._8e3f0836_9520_436c_bc83_398857c869a7.branches._6fb370f4_774e_495a_a8ff_caec833fdcc8.foo.add
+    x y =
     use Int +
     x + y
 


### PR DESCRIPTION
## Overview

This fixes a couple issues with `ls` and numbered args. They are illustrated in the two transcripts included in this PR.

The two changes are to avoid `Absolute` paths in `ShallowListEntry` and to convert numbered args representing `Name`s to `Path'` for commands that expect `Path'`s.

## Interesting/controversial decisions

This replaces a number of `Path.prefix*` operations, introducing ones that are more precise in their types (given the existing set of pathy types we have to work with).

## Test coverage

There are two transcripts here that exercise these changes. One is a modification of an existing transcript.

## Loose ends

There should be much more coverage of numbered arg handling in transcripts.
