### PR TITLE
bugfix: updating and deleting aliases erroneously tripped "conflicted alias" merge precondition

### DIFF
--- a/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
+++ b/unison-cli/src/Unison/Codebase/Editor/HandleInput/Merge2.hs
@@ -974,6 +974,8 @@ findConflictedAlias defns diff =
             g hashed1 alias =
               case Map.lookup alias diff of
                 Just (DiffOp'Update hashed2) | hashed1 == hashed2.new -> Nothing
+                -- If "foo" was updated but its alias "bar" was deleted, that's ok
+                Just (DiffOp'Delete _) -> Nothing
                 _ -> Just (name, alias)
 
 -- Given a name like "base", try "base__1", then "base__2", etc, until we find a name that doesn't

--- a/unison-src/transcripts/merge.md
+++ b/unison-src/transcripts/merge.md
@@ -1406,7 +1406,7 @@ bob = 101
 project/bob> add
 ```
 
-```ucm:error
+```ucm
 project/alice> merge /bob
 ```
 

--- a/unison-src/transcripts/merge.md
+++ b/unison-src/transcripts/merge.md
@@ -1367,3 +1367,49 @@ project/alice> merge /bob
 ```ucm:hide
 .> project.delete project
 ```
+
+## Regression tests
+
+### Delete one alias and update the other
+
+
+```ucm:hide
+.> project.create-empty project
+project/main> builtins.mergeio
+```
+
+```unison
+foo = 17
+bar = 17
+```
+
+```ucm
+project/main> add
+project/main> branch alice
+project/alice> delete.term bar
+```
+
+```unison
+foo = 18
+```
+
+```ucm
+project/alice> update
+project/main> branch bob
+```
+
+```unison
+bob = 101
+```
+
+```ucm
+project/bob> add
+```
+
+```ucm:error
+project/alice> merge /bob
+```
+
+```ucm:hide
+.> project.delete project
+```

--- a/unison-src/transcripts/merge.output.md
+++ b/unison-src/transcripts/merge.output.md
@@ -1322,3 +1322,126 @@ project/alice> merge /bob
   I merged project/bob into project/alice.
 
 ```
+## Regression tests
+
+### Delete one alias and update the other
+
+
+```unison
+foo = 17
+bar = 17
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bar : Nat
+      foo : Nat
+
+```
+```ucm
+project/main> add
+
+  ⍟ I've added these definitions:
+  
+    bar : Nat
+    foo : Nat
+
+project/main> branch alice
+
+  Done. I've created the alice branch based off of main.
+  
+  Tip: To merge your work back into the main branch, first
+       `switch /main` then `merge /alice`.
+
+project/alice> delete.term bar
+
+  Done.
+
+```
+```unison
+foo = 18
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These names already exist. You can `update` them to your
+      new definition:
+    
+      foo : Nat
+
+```
+```ucm
+project/alice> update
+
+  Okay, I'm searching the branch for code that needs to be
+  updated...
+
+  Done.
+
+project/main> branch bob
+
+  Done. I've created the bob branch based off of main.
+  
+  Tip: To merge your work back into the main branch, first
+       `switch /main` then `merge /bob`.
+
+```
+```unison
+bob = 101
+```
+
+```ucm
+
+  Loading changes detected in scratch.u.
+
+  I found and typechecked these definitions in scratch.u. If you
+  do an `add` or `update`, here's how your codebase would
+  change:
+  
+    ⍟ These new definitions are ok to `add`:
+    
+      bob : Nat
+
+```
+```ucm
+project/bob> add
+
+  ⍟ I've added these definitions:
+  
+    bob : Nat
+
+```
+```ucm
+project/alice> merge /bob
+
+  Sorry, I wasn't able to perform the merge:
+  
+  On the merge ancestor, foo and bar were aliases for the same
+  definition, but on project/alice the names have different
+  definitions currently. I'd need just a single new definition
+  to use in their dependents when I merge.
+  
+  Please fix up project/alice to resolve this. For example,
+  
+    * `update` the definitions to be the same again, so that
+      there's nothing for me to decide.
+    * `move` or `delete` all but one of the definitions; I'll
+      use the remaining name when propagating updates.
+  
+  and then try merging again.
+
+```

--- a/unison-src/transcripts/merge.output.md
+++ b/unison-src/transcripts/merge.output.md
@@ -1428,20 +1428,6 @@ project/bob> add
 ```ucm
 project/alice> merge /bob
 
-  Sorry, I wasn't able to perform the merge:
-  
-  On the merge ancestor, foo and bar were aliases for the same
-  definition, but on project/alice the names have different
-  definitions currently. I'd need just a single new definition
-  to use in their dependents when I merge.
-  
-  Please fix up project/alice to resolve this. For example,
-  
-    * `update` the definitions to be the same again, so that
-      there's nothing for me to decide.
-    * `move` or `delete` all but one of the definitions; I'll
-      use the remaining name when propagating updates.
-  
-  and then try merging again.
+  I merged project/bob into project/alice.
 
 ```


### PR DESCRIPTION
## Overview

Previously, if `foo` and `bar` were aliases in the LCA of a merge, and `foo` was updated while `bar` was deleted, we'd erroneously throw a "conflicted alias" precondition violation.

But this error should only trigger if `foo` and `bar` are both _updated_ to different things. An update+delete is fine.

@runarorama found the bug!

## Test coverage

I've added a test that demonstrates the bug (commit 1) and fixes it (commit 2)