### PR TITLE
Auto-create project-branches referenced in transcript prompts

### DIFF
--- a/unison-src/transcripts-manual/gen-racket-libs.md
+++ b/unison-src/transcripts-manual/gen-racket-libs.md
@@ -4,7 +4,6 @@ When we start out, `./scheme-libs/racket` contains a bunch of library files that
 Next, we'll download the jit project and generate a few Racket files from it.
 
 ```ucm
-.> project.create-empty jit-setup
 jit-setup/main> lib.install @unison/internal/releases/0.0.17
 ```
 

--- a/unison-src/transcripts/definition-diff-api.md
+++ b/unison-src/transcripts/definition-diff-api.md
@@ -1,10 +1,9 @@
 ```ucm
-.> project.create-empty diffs
 diffs/main> builtins.merge
 ```
 
 ```unison
-term = 
+term =
   _ = "Here's some text"
   1 + 1
 
@@ -17,7 +16,7 @@ diffs/main> branch.create new
 ```
 
 ```unison
-term = 
+term =
   _ = "Here's some different text"
   1 + 2
 

--- a/unison-src/transcripts/definition-diff-api.output.md
+++ b/unison-src/transcripts/definition-diff-api.output.md
@@ -1,27 +1,11 @@
 ```ucm
-.> project.create-empty diffs
-
-  🎉 I've created the project diffs.
-
-  🎨 Type `ui` to explore this project's code in your browser.
-  🔭 Discover libraries at https://share.unison-lang.org
-  📖 Use `help-topic projects` to learn more about projects.
-  
-  Write your first Unison code with UCM:
-  
-    1. Open scratch.u.
-    2. Write some Unison code and save the file.
-    3. In UCM, type `add` to save it to your new project.
-  
-  🎉 🥳 Happy coding!
-
 diffs/main> builtins.merge
 
   Done.
 
 ```
 ```unison
-term = 
+term =
   _ = "Here's some text"
   1 + 1
 
@@ -59,7 +43,7 @@ diffs/main> branch.create new
 
 ```
 ```unison
-term = 
+term =
   _ = "Here's some different text"
   1 + 2
 

--- a/unison-src/transcripts/delete-namespace-dependents-check.md
+++ b/unison-src/transcripts/delete-namespace-dependents-check.md
@@ -5,7 +5,6 @@
 This is a regression test, previously `delete.namespace` allowed a delete as long as the deletions had a name _anywhere_ in your codebase, it should only check the current project branch.
 
 ```ucm:hide
-.> project.create-empty myproject
 myproject/main> builtins.merge
 ```
 

--- a/unison-src/transcripts/delete-project-branch.md
+++ b/unison-src/transcripts/delete-project-branch.md
@@ -2,7 +2,6 @@ Deleting the branch you are on takes you to its parent (though this is impossibl
 your working directory with each command).
 
 ```ucm
-.> project.create-empty foo
 foo/main> branch topic
 foo/topic> delete.branch /topic
 ```

--- a/unison-src/transcripts/delete-project-branch.output.md
+++ b/unison-src/transcripts/delete-project-branch.output.md
@@ -2,22 +2,6 @@ Deleting the branch you are on takes you to its parent (though this is impossibl
 your working directory with each command).
 
 ```ucm
-.> project.create-empty foo
-
-  🎉 I've created the project foo.
-
-  🎨 Type `ui` to explore this project's code in your browser.
-  🔭 Discover libraries at https://share.unison-lang.org
-  📖 Use `help-topic projects` to learn more about projects.
-  
-  Write your first Unison code with UCM:
-  
-    1. Open scratch.u.
-    2. Write some Unison code and save the file.
-    3. In UCM, type `add` to save it to your new project.
-  
-  🎉 🥳 Happy coding!
-
 foo/main> branch topic
 
   Done. I've created the topic branch based off of main.

--- a/unison-src/transcripts/dont-upgrade-refs-that-exist-in-old.md
+++ b/unison-src/transcripts/dont-upgrade-refs-that-exist-in-old.md
@@ -2,7 +2,6 @@ If `foo#old` exists in old, and `foo#new` exists in new, you might think `upgrad
 `#old` with references to `#new`. And it will... !!unless!! `#old` still exists in new.
 
 ```ucm:hide
-.> project.create-empty foo
 foo/main> builtins.merge lib.builtin
 ```
 

--- a/unison-src/transcripts/edit-namespace.md
+++ b/unison-src/transcripts/edit-namespace.md
@@ -1,5 +1,4 @@
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio lib.builtin
 ```
 

--- a/unison-src/transcripts/fix-ls.md
+++ b/unison-src/transcripts/fix-ls.md
@@ -1,5 +1,4 @@
 ```ucm
-.> project.create-empty test-ls
 test-ls/main> builtins.merge
 ```
 

--- a/unison-src/transcripts/fix-ls.output.md
+++ b/unison-src/transcripts/fix-ls.output.md
@@ -1,20 +1,4 @@
 ```ucm
-.> project.create-empty test-ls
-
-  🎉 I've created the project test-ls.
-
-  🎨 Type `ui` to explore this project's code in your browser.
-  🔭 Discover libraries at https://share.unison-lang.org
-  📖 Use `help-topic projects` to learn more about projects.
-  
-  Write your first Unison code with UCM:
-  
-    1. Open scratch.u.
-    2. Write some Unison code and save the file.
-    3. In UCM, type `add` to save it to your new project.
-  
-  🎉 🥳 Happy coding!
-
 test-ls/main> builtins.merge
 
   Done.

--- a/unison-src/transcripts/fix4482.md
+++ b/unison-src/transcripts/fix4482.md
@@ -1,5 +1,4 @@
 ```ucm:hide
-.> project.create-empty myproj
 myproj/main> builtins.merge
 ```
 

--- a/unison-src/transcripts/fix4515.md
+++ b/unison-src/transcripts/fix4515.md
@@ -1,5 +1,4 @@
 ```ucm:hide
-.> project.create-empty myproject
 myproject/main> builtins.merge
 ```
 

--- a/unison-src/transcripts/fix4528.md
+++ b/unison-src/transcripts/fix4528.md
@@ -1,5 +1,4 @@
 ```ucm:hide
-.> project.create-empty foo
 foo/main> builtins.merge
 ```
 

--- a/unison-src/transcripts/fix5055.md
+++ b/unison-src/transcripts/fix5055.md
@@ -1,5 +1,4 @@
 ```ucm
-.> project.create-empty test-5055
 test-5055/main> builtins.merge
 ```
 

--- a/unison-src/transcripts/fix5055.output.md
+++ b/unison-src/transcripts/fix5055.output.md
@@ -1,20 +1,4 @@
 ```ucm
-.> project.create-empty test-5055
-
-  🎉 I've created the project test-5055.
-
-  🎨 Type `ui` to explore this project's code in your browser.
-  🔭 Discover libraries at https://share.unison-lang.org
-  📖 Use `help-topic projects` to learn more about projects.
-  
-  Write your first Unison code with UCM:
-  
-    1. Open scratch.u.
-    2. Write some Unison code and save the file.
-    3. In UCM, type `add` to save it to your new project.
-  
-  🎉 🥳 Happy coding!
-
 test-5055/main> builtins.merge
 
   Done.

--- a/unison-src/transcripts/fuzzy-options.md
+++ b/unison-src/transcripts/fuzzy-options.md
@@ -40,7 +40,6 @@ Namespace args
 Project Branch args
 
 ```ucm
-.> project.create-empty myproject
 myproject/main> branch mybranch
 .> debug.fuzzy-options switch _
 ```

--- a/unison-src/transcripts/fuzzy-options.output.md
+++ b/unison-src/transcripts/fuzzy-options.output.md
@@ -65,22 +65,6 @@ Namespace args
 Project Branch args
 
 ```ucm
-.> project.create-empty myproject
-
-  🎉 I've created the project myproject.
-
-  🎨 Type `ui` to explore this project's code in your browser.
-  🔭 Discover libraries at https://share.unison-lang.org
-  📖 Use `help-topic projects` to learn more about projects.
-  
-  Write your first Unison code with UCM:
-  
-    1. Open scratch.u.
-    2. Write some Unison code and save the file.
-    3. In UCM, type `add` to save it to your new project.
-  
-  🎉 🥳 Happy coding!
-
 myproject/main> branch mybranch
 
   Done. I've created the mybranch branch based off of main.

--- a/unison-src/transcripts/merge.md
+++ b/unison-src/transcripts/merge.md
@@ -9,7 +9,6 @@ contains both additions.
 ## Basic merge: two unconflicted adds
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -52,7 +51,6 @@ project/alice> view foo bar
 If Alice and Bob also happen to add the same definition, that's not a conflict.
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 project/main> branch alice
 ```
@@ -94,7 +92,6 @@ project/alice> view foo bar
 Updates that occur in one branch are propagated to the other. In this example, Alice updates `foo`, while Bob adds a new dependent `bar` of the original `foo`. When Bob's branch is merged into Alice's, her update to `foo` is propagated to his `bar`.
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -150,7 +147,6 @@ We classify something as an update if its "syntactic hash"—not its normal Unis
 Let's see an example. We have `foo`, which depends on `bar` and `baz`. Alice updates `bar` (propagating to `foo`), and Bob updates `baz` (propagating to `foo`). When we merge their updates, both updates will be reflected in the final `foo`.
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -215,7 +211,6 @@ project/alice> display foo
 Of course, it's also possible for Alice's update to propagate to one of Bob's updates. In this example, `foo` depends on `bar` which depends on `baz`. Alice updates `baz`, propagating to `bar` and `foo`, while Bob updates `bar` (to something that still depends on `foo`), propagating to `baz`. The merged result will have Alice's update to `foo` incorporated into Bob's updated `bar`, and both updates will propagate to `baz`.
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -286,7 +281,6 @@ project/alice> display foo
 We don't currently consider "update + delete" a conflict like Git does. In this situation, the delete is just ignored, allowing the update to proceed.
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -334,7 +328,6 @@ In a future version, we'd like to give the user a warning at least.
 Library dependencies don't cause merge conflicts, the library dependencies are just unioned together. If two library dependencies have the same name but different namespace hashes, then the merge algorithm makes up two fresh names.
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -389,7 +382,6 @@ project/alice> view foo bar baz
 If Bob is equals Alice, then merging Bob into Alice looks like this.
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -408,7 +400,6 @@ project/alice> merge /bob
 If Bob is behind Alice, then merging Bob into Alice looks like this.
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -437,7 +428,6 @@ project/alice> merge /bob
 If Bob is ahead of Alice, then merging Bob into Alice looks like this.
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -470,7 +460,6 @@ This can cause merge failures due to out-of-scope identifiers, and the user may 
 In this example, Alice deletes `foo`, while Bob adds a new dependent of `foo`.
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -514,7 +503,6 @@ It may be Alice's and Bob's changes merge together cleanly in the sense that the
 In this example, Alice updates a `Text` to a `Nat`, while Bob adds a new dependent of the `Text`. Upon merging, propagating Alice's update to Bob's dependent causes a typechecking failure.
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -564,7 +552,6 @@ Alice and Bob may disagree about the definition of a term. In this case, the con
 are presented to the user to resolve.
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -629,7 +616,6 @@ project/merge-bob-into-alice> view bar baz
 Ditto for types; if the hashes don't match, it's a conflict. In this example, Alice and Bob do different things to the same constructor. However, any explicit changes to the same type will result in a conflict, including changes that could concievably be merged (e.g. Alice and Bob both add a new constructor, or edit different constructors).
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -673,7 +659,6 @@ project/alice> merge /bob
 We model the renaming of a type's constructor as an update, so if Alice updates a type and Bob renames one of its constructors (even without changing its structure), we consider it a conflict.
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -717,7 +702,6 @@ project/alice> merge /bob
 Here is another example demonstrating that constructor renames are modeled as updates.
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -756,7 +740,6 @@ project/alice> merge bob
 A constructor on one side can conflict with a regular term definition on the other.
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -798,7 +781,6 @@ project/alice> merge bob
 Here's a subtle situation where a new type is added on each side of the merge, and an existing term is replaced with a constructor of one of the types.
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -848,7 +830,6 @@ project/alice> merge bob
 Here's a more involved example that demonstrates the same idea.
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -928,7 +909,6 @@ which is a parse error.
 We will resolve this situation automatically in a future version.
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -978,7 +958,6 @@ There are a number of conditions under which we can't perform a merge, and the u
 If `foo` and `bar` are aliases in the nearest common ancestor, but not in Alice's branch, then we don't know whether to update Bob's dependents to Alice's `foo` or Alice's `bar` (and vice-versa).
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -1036,7 +1015,6 @@ conflict involving a builtin, we can't perform a merge.
 One way to fix this in the future would be to introduce a syntax for defining aliases in the scratch file.
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -1075,7 +1053,6 @@ project/alice> merge /bob
 Each naming of a decl may not have more than one name for each constructor, within the decl's namespace.
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -1122,7 +1099,6 @@ project/alice> merge /bob
 Each naming of a decl must have a name for each constructor, within the decl's namespace.
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -1170,7 +1146,6 @@ project/alice> merge /bob
 A decl cannot be aliased within the namespace of another of its aliased.
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -1219,7 +1194,6 @@ project/alice> merge /bob
 Constructors may only exist within the corresponding decl's namespace.
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -1264,7 +1238,6 @@ project/alice> merge bob
 By convention, `lib` can only namespaces; each of these represents a library dependencies. Individual terms and types are not allowed at the top level of `lib`.
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -1309,7 +1282,6 @@ Here's an example. We'll delete a constructor name from the LCA and still be abl
 together.
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 
@@ -1374,7 +1346,6 @@ project/alice> merge /bob
 
 
 ```ucm:hide
-.> project.create-empty project
 project/main> builtins.mergeio
 ```
 

--- a/unison-src/transcripts/pull-errors.md
+++ b/unison-src/transcripts/pull-errors.md
@@ -1,6 +1,3 @@
-```ucm
-.> project.create-empty test
-```
 ```ucm:error
 test/main> pull @aryairani/test-almost-empty/main lib.base_latest
 test/main> pull @aryairani/test-almost-empty/main a.b

--- a/unison-src/transcripts/pull-errors.output.md
+++ b/unison-src/transcripts/pull-errors.output.md
@@ -1,22 +1,4 @@
 ```ucm
-.> project.create-empty test
-
-  🎉 I've created the project test.
-
-  🎨 Type `ui` to explore this project's code in your browser.
-  🔭 Discover libraries at https://share.unison-lang.org
-  📖 Use `help-topic projects` to learn more about projects.
-  
-  Write your first Unison code with UCM:
-  
-    1. Open scratch.u.
-    2. Write some Unison code and save the file.
-    3. In UCM, type `add` to save it to your new project.
-  
-  🎉 🥳 Happy coding!
-
-```
-```ucm
 test/main> pull @aryairani/test-almost-empty/main lib.base_latest
 
   The use of `pull` to install libraries is now deprecated.

--- a/unison-src/transcripts/release-draft-command.md
+++ b/unison-src/transcripts/release-draft-command.md
@@ -1,7 +1,6 @@
 The `release.draft` command drafts a release from the current branch.
 
 ```ucm:hide
-.> project.create-empty foo
 foo/main> builtins.merge
 ```
 

--- a/unison-src/transcripts/reset.md
+++ b/unison-src/transcripts/reset.md
@@ -29,7 +29,6 @@ foo.a = 5
 # reset branch
 
 ```ucm
-.> project.create-empty foo
 foo/main> history
 ```
 

--- a/unison-src/transcripts/reset.output.md
+++ b/unison-src/transcripts/reset.output.md
@@ -103,22 +103,6 @@ foo.a = 5
 # reset branch
 
 ```ucm
-.> project.create-empty foo
-
-  🎉 I've created the project foo.
-
-  🎨 Type `ui` to explore this project's code in your browser.
-  🔭 Discover libraries at https://share.unison-lang.org
-  📖 Use `help-topic projects` to learn more about projects.
-  
-  Write your first Unison code with UCM:
-  
-    1. Open scratch.u.
-    2. Write some Unison code and save the file.
-    3. In UCM, type `add` to save it to your new project.
-  
-  🎉 🥳 Happy coding!
-
 foo/main> history
 
   ☝️  The namespace  is empty.

--- a/unison-src/transcripts/switch-command.md
+++ b/unison-src/transcripts/switch-command.md
@@ -1,8 +1,6 @@
 The `switch` command switches to an existing project or branch.
 
 ```ucm:hide
-.> project.create-empty foo
-.> project.create-empty bar
 foo/main> builtins.merge
 bar/main> builtins.merge
 ```

--- a/unison-src/transcripts/tab-completion.md
+++ b/unison-src/transcripts/tab-completion.md
@@ -69,7 +69,6 @@ add b = b
 ## Tab complete projects and branches
 
 ```ucm
-.> project.create-empty myproject
 myproject/main> branch mybranch
 myproject/main> debug.tab-complete branch.delete /mybr
 myproject/main> debug.tab-complete project.rename my

--- a/unison-src/transcripts/tab-completion.output.md
+++ b/unison-src/transcripts/tab-completion.output.md
@@ -173,22 +173,6 @@ add b = b
 ## Tab complete projects and branches
 
 ```ucm
-.> project.create-empty myproject
-
-  🎉 I've created the project myproject.
-
-  🎨 Type `ui` to explore this project's code in your browser.
-  🔭 Discover libraries at https://share.unison-lang.org
-  📖 Use `help-topic projects` to learn more about projects.
-  
-  Write your first Unison code with UCM:
-  
-    1. Open scratch.u.
-    2. Write some Unison code and save the file.
-    3. In UCM, type `add` to save it to your new project.
-  
-  🎉 🥳 Happy coding!
-
 myproject/main> branch mybranch
 
   Done. I've created the mybranch branch based off of main.

--- a/unison-src/transcripts/update-suffixifies-properly.md
+++ b/unison-src/transcripts/update-suffixifies-properly.md
@@ -1,5 +1,4 @@
 ```ucm:hide
-.> project.create-empty myproject
 myproject/main> builtins.merge lib.builtin
 ```
 

--- a/unison-src/transcripts/upgrade-happy-path.md
+++ b/unison-src/transcripts/upgrade-happy-path.md
@@ -1,5 +1,4 @@
 ```ucm:hide
-.> project.create-empty proj
 proj/main> builtins.merge lib.builtin
 ```
 

--- a/unison-src/transcripts/upgrade-sad-path.md
+++ b/unison-src/transcripts/upgrade-sad-path.md
@@ -1,5 +1,4 @@
 ```ucm:hide
-.> project.create-empty proj
 proj/main> builtins.merge lib.builtin
 ```
 

--- a/unison-src/transcripts/upgrade-suffixifies-properly.md
+++ b/unison-src/transcripts/upgrade-suffixifies-properly.md
@@ -1,5 +1,4 @@
 ```ucm:hide
-.> project.create-empty myproject
 myproject/main> builtins.merge lib.builtin
 ```
 

--- a/unison-src/transcripts/upgrade-with-old-alias.md
+++ b/unison-src/transcripts/upgrade-with-old-alias.md
@@ -1,5 +1,4 @@
 ```ucm:hide
-.> project.create-empty myproject
 myproject/main> builtins.merge lib.builtin
 ```
 


### PR DESCRIPTION
## Overview

Transcripts automatically cd to paths mentioned in prompts of UCM blocks, creating the namespace if it's empty.

Now they do the same with project-branches referenced in prompts; so you can just use a project and an empty project-branch will be created if it's missing, or it'll be switched to if one does exist. 

## Implementation notes

* Check if a mentioned project-branch exists, create an empty one by the provided names if one doesn't exist.

## Interesting/controversial decisions

Is this too implicit?
Nah, we don't think so, there's a very minor chance that a typo in the prompt results in creating a new branch you didn't want, but in most cases you'll definitely notice that your transcript isn't behaving as expected when this happens.

## Test coverage

I went ahead and removed redundant calls to `project.create-empty`, so now all of those transcripts are testing the new behaviour :)

## Loose ends

I'll still need to update most transcripts to use a scratch project as part of the move to project-roots. That can be done in a separate change.
