### PR TITLE
[DO NOT MERGE] GHC 964 cabal compilation

### DIFF
--- a/codebase2/codebase-sqlite-hashing-v2/unison-codebase-sqlite-hashing-v2.cabal
+++ b/codebase2/codebase-sqlite-hashing-v2/unison-codebase-sqlite-hashing-v2.cabal
@@ -53,7 +53,6 @@ library
       TupleSections
       TypeApplications
       ViewPatterns
-  ghc-options: -Wall
   build-depends:
       base
     , bytes

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/LocalIds.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/LocalIds.hs
@@ -15,7 +15,7 @@ data LocalIds' t h = LocalIds
   { textLookup :: Vector t,
     defnLookup :: Vector h
   }
-  deriving (Show)
+  deriving (Functor, Show)
 
 type LocalIds = LocalIds' TextId ObjectId
 

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Patch/TermEdit.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Patch/TermEdit.hs
@@ -22,6 +22,12 @@ type Referent' t h = Referent.Referent' (Reference' t h) (Reference' t h)
 data TermEdit' t h = Replace (Referent' t h) Typing | Deprecate
   deriving (Eq, Ord, Show)
 
+instance Functor (TermEdit' t) where
+  fmap :: (a -> b) -> TermEdit' t a -> TermEdit' t b
+  fmap f (Replace (Referent.Ref termRef) typing) = Replace (Referent.Ref (fmap f termRef)) typing
+  fmap f (Replace (Referent.Con typeRef consId) typing) = Replace (Referent.Con (fmap f typeRef) consId) typing
+  fmap _ Deprecate = Deprecate
+
 _Replace :: Prism (TermEdit' t h) (TermEdit' t' h') (Referent' t h, Typing) (Referent' t' h', Typing)
 _Replace = prism embed project
   where

--- a/codebase2/codebase-sqlite/U/Codebase/Sqlite/Patch/TypeEdit.hs
+++ b/codebase2/codebase-sqlite/U/Codebase/Sqlite/Patch/TypeEdit.hs
@@ -17,7 +17,7 @@ type TypeEdit = TypeEdit' Db.TextId Db.ObjectId
 type HashTypeEdit = TypeEdit' Text ComponentHash
 
 data TypeEdit' t h = Replace (Reference' t h) | Deprecate
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Functor, Ord, Show)
 
 _Replace :: Prism (TypeEdit' t h) (TypeEdit' t' h') (Reference' t h) (Reference' t' h')
 _Replace = prism Replace project

--- a/codebase2/codebase/U/Codebase/Referent.hs
+++ b/codebase2/codebase/U/Codebase/Referent.hs
@@ -63,7 +63,7 @@ type Id = Id' Hash Hash
 data Id' hTm hTp
   = RefId (Reference.Id' hTm)
   | ConId (Reference.Id' hTp) ConstructorId
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Functor, Ord, Show)
 
 instance Bifunctor Referent' where
   bimap f g = \case

--- a/codebase2/codebase/U/Codebase/Reflog.hs
+++ b/codebase2/codebase/U/Codebase/Reflog.hs
@@ -13,6 +13,7 @@ data Entry causal text = Entry
     toRootCausalHash :: causal,
     reason :: text
   }
+  deriving (Functor)
 
 instance Bifunctor Entry where
   bimap = bimapDefault

--- a/codebase2/core/U/Codebase/Reference.hs
+++ b/codebase2/core/U/Codebase/Reference.hs
@@ -74,7 +74,7 @@ data ReferenceType = RtTerm | RtType deriving (Eq, Ord, Show)
 data Reference' t h
   = ReferenceBuiltin t
   | ReferenceDerived (Id' h)
-  deriving stock (Eq, Generic, Ord, Show)
+  deriving stock (Eq, Generic, Functor, Ord, Show)
 
 -- | A type declaration reference.
 type TermReference' t h = Reference' t h

--- a/codebase2/core/Unison/Core/Project.hs
+++ b/codebase2/core/Unison/Core/Project.hs
@@ -29,7 +29,7 @@ data ProjectAndBranch a b = ProjectAndBranch
   { project :: a,
     branch :: b
   }
-  deriving stock (Eq, Generic, Show)
+  deriving stock (Eq, Generic, Show, Functor)
 
 instance Bifunctor ProjectAndBranch where
   bimap f g (ProjectAndBranch a b) = ProjectAndBranch (f a) (g b)

--- a/codebase2/util-term/U/Util/Type.hs
+++ b/codebase2/util-term/U/Util/Type.hs
@@ -61,7 +61,7 @@ flattenEffects es = [es]
 generalize :: (Ord v) => [v] -> TypeR r v -> TypeR r v
 generalize vs t = foldr f t vs
   where
-    f v t = if Set.member v (ABT.freeVars t) then forall v t else t
+    f v t = if Set.member v (ABT.freeVars t) then forAll v t else t
 
 -- * Patterns
 
@@ -80,8 +80,8 @@ pattern Effect1' e t <- ABT.Tm' (Effect e t)
 pattern Ref' :: r -> TypeR r v
 pattern Ref' r <- ABT.Tm' (Ref r)
 
-forall :: (Ord v) => v -> TypeR r v -> TypeR r v
-forall v body = ABT.tm () (Forall (ABT.abs () v body))
+forAll :: (Ord v) => v -> TypeR r v -> TypeR r v
+forAll v body = ABT.tm () (Forall (ABT.abs () v body))
 
 unforall' :: TypeR r v -> ([v], TypeR r v)
 unforall' (ForallsNamed' vs t) = (vs, t)

--- a/contrib/cabal.project
+++ b/contrib/cabal.project
@@ -29,6 +29,8 @@ packages:
   parser-typechecker
   unison-core
   unison-cli
+  unison-cli-main
+  unison-merge
   unison-hashing-v2
   unison-share-api
   unison-share-projects-api
@@ -117,6 +119,9 @@ package unison-util-rope
   ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
 package parser-typechecker
+  ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
+
+package unison-merge
   ghc-options: -Wall -Werror -Wno-name-shadowing -Wno-type-defaults -Wno-missing-pattern-synonym-signatures -fprint-expanded-synonyms -fwrite-ide-info
 
 package unison-cli

--- a/contrib/cabal.project
+++ b/contrib/cabal.project
@@ -1,4 +1,5 @@
 packages:
+  ../fuzzyfind
   codebase2/codebase
   codebase2/codebase-sqlite
   codebase2/codebase-sqlite-hashing-v2
@@ -50,7 +51,7 @@ source-repository-package
 constraints:
   fsnotify < 0.4,
   crypton-x509-store <= 1.6.8,
-  servant <= 0.19.1,
+  servant <= 0.20.1,
   optparse-applicative <= 0.17.1.0
 
 -- For now there is no way to apply ghc-options for all local packages

--- a/lib/orphans/network-uri-orphans-sqlite/network-uri-orphans-sqlite.cabal
+++ b/lib/orphans/network-uri-orphans-sqlite/network-uri-orphans-sqlite.cabal
@@ -45,7 +45,7 @@ library
       TupleSections
       TypeApplications
       ViewPatterns
-  ghc-options: -Wall -fno-warn-orphans
+  ghc-options: -Wall -Werror -fno-warn-orphans
   build-depends:
       base
     , network-uri

--- a/lib/orphans/unison-hash-orphans-aeson/unison-hash-orphans-aeson.cabal
+++ b/lib/orphans/unison-hash-orphans-aeson/unison-hash-orphans-aeson.cabal
@@ -45,7 +45,7 @@ library
       TupleSections
       TypeApplications
       ViewPatterns
-  ghc-options: -Wall -fno-warn-orphans
+  ghc-options: -Wall -Werror -fno-warn-orphans
   build-depends:
       aeson
     , base

--- a/lib/orphans/unison-hash-orphans-sqlite/unison-hash-orphans-sqlite.cabal
+++ b/lib/orphans/unison-hash-orphans-sqlite/unison-hash-orphans-sqlite.cabal
@@ -45,7 +45,7 @@ library
       TupleSections
       TypeApplications
       ViewPatterns
-  ghc-options: -Wall -fno-warn-orphans
+  ghc-options: -Wall -Werror -fno-warn-orphans
   build-depends:
       base
     , sqlite-simple

--- a/lib/unison-hashing/unison-hashing.cabal
+++ b/lib/unison-hashing/unison-hashing.cabal
@@ -48,7 +48,7 @@ library
       TypeApplications
       TypeFamilies
       ViewPatterns
-  ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
+  ghc-options: -Wall -Werror -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
   build-depends:
       base
     , unison-hash

--- a/lib/unison-prelude/src/Unison/Util/Tuple.hs
+++ b/lib/unison-prelude/src/Unison/Util/Tuple.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeOperators #-}
 
 -- | Tuple utils.
 module Unison.Util.Tuple

--- a/lib/unison-prelude/unison-prelude.cabal
+++ b/lib/unison-prelude/unison-prelude.cabal
@@ -60,7 +60,6 @@ library
       TypeApplications
       TypeFamilies
       ViewPatterns
-  ghc-options: -Wall
   build-depends:
       base
     , bytestring

--- a/lib/unison-pretty-printer/unison-pretty-printer.cabal
+++ b/lib/unison-pretty-printer/unison-pretty-printer.cabal
@@ -54,7 +54,7 @@ library
       TupleSections
       TypeApplications
       ViewPatterns
-  ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
+  ghc-options: -Wall -Werror -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
   build-depends:
       ListLike
     , ansi-terminal
@@ -100,7 +100,7 @@ executable prettyprintdemo
       TupleSections
       TypeApplications
       ViewPatterns
-  ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
+  ghc-options: -Wall -Werror -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
   build-depends:
       base
     , safe
@@ -141,7 +141,7 @@ test-suite pretty-printer-tests
       TupleSections
       TypeApplications
       ViewPatterns
-  ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -W -threaded -rtsopts "-with-rtsopts=-N -T" -v0
+  ghc-options: -Wall -Werror -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -W -threaded -rtsopts "-with-rtsopts=-N -T" -v0
   build-depends:
       base
     , code-page

--- a/lib/unison-sqlite/src/Unison/Sqlite/Connection.hs
+++ b/lib/unison-sqlite/src/Unison/Sqlite/Connection.hs
@@ -172,9 +172,9 @@ execute conn@(Connection _ _ conn0) sql@(Sql s params) = do
 --
 -- This function does not support parameters, and is mostly useful for executing DDL and migrations.
 executeStatements :: Connection -> Text -> IO ()
-executeStatements conn@(Connection _ _ (Sqlite.Connection database)) sql = do
+executeStatements conn@(Connection _ _ connection) sql = do
   logQuery (Sql sql []) Nothing
-  Direct.Sqlite.exec database sql `catch` \(exception :: Sqlite.SQLError) ->
+  Direct.Sqlite.exec (Sqlite.connectionHandle connection) sql `catch` \(exception :: Sqlite.SQLError) ->
     throwSqliteQueryException
       SqliteQueryExceptionInfo
         { connection = conn,

--- a/lib/unison-sqlite/unison-sqlite.cabal
+++ b/lib/unison-sqlite/unison-sqlite.cabal
@@ -61,7 +61,6 @@ library
       TupleSections
       TypeApplications
       ViewPatterns
-  ghc-options: -Wall
   build-depends:
       base
     , direct-sqlite
@@ -122,7 +121,6 @@ test-suite tests
       TupleSections
       TypeApplications
       ViewPatterns
-  ghc-options: -Wall
   build-depends:
       base
     , code-page

--- a/lib/unison-sqlite/unison-sqlite.cabal
+++ b/lib/unison-sqlite/unison-sqlite.cabal
@@ -74,7 +74,7 @@ library
     , pretty-simple
     , random
     , recover-rtti
-    , sqlite-simple
+    , sqlite-simple ==0.4.18.2
     , template-haskell
     , text
     , text-builder
@@ -137,7 +137,7 @@ test-suite tests
     , pretty-simple
     , random
     , recover-rtti
-    , sqlite-simple
+    , sqlite-simple ==0.4.18.2
     , template-haskell
     , text
     , text-builder

--- a/lib/unison-util-base32hex/unison-util-base32hex.cabal
+++ b/lib/unison-util-base32hex/unison-util-base32hex.cabal
@@ -44,7 +44,6 @@ library
       TupleSections
       TypeApplications
       ViewPatterns
-  ghc-options: -Wall
   build-depends:
       base
     , base32

--- a/lib/unison-util-bytes/unison-util-bytes.cabal
+++ b/lib/unison-util-bytes/unison-util-bytes.cabal
@@ -50,7 +50,6 @@ library
       TypeApplications
       TypeFamilies
       ViewPatterns
-  ghc-options: -Wall
   build-depends:
       base
     , basement
@@ -102,7 +101,6 @@ test-suite util-bytes-tests
       TypeApplications
       TypeFamilies
       ViewPatterns
-  ghc-options: -Wall
   build-depends:
       base
     , basement

--- a/lib/unison-util-cache/unison-util-cache.cabal
+++ b/lib/unison-util-cache/unison-util-cache.cabal
@@ -50,7 +50,6 @@ library
       TypeApplications
       TypeFamilies
       ViewPatterns
-  ghc-options: -Wall
   build-depends:
       base
     , containers
@@ -92,7 +91,6 @@ test-suite util-cache-tests
       TypeApplications
       TypeFamilies
       ViewPatterns
-  ghc-options: -Wall
   build-depends:
       async
     , base

--- a/lib/unison-util-file-embed/unison-util-file-embed.cabal
+++ b/lib/unison-util-file-embed/unison-util-file-embed.cabal
@@ -36,7 +36,6 @@ library
       TupleSections
       TypeApplications
       ViewPatterns
-  ghc-options: -Wall
   build-depends:
       base
     , file-embed

--- a/lib/unison-util-nametree/src/Unison/Util/Defns.hs
+++ b/lib/unison-util-nametree/src/Unison/Util/Defns.hs
@@ -28,7 +28,7 @@ data Defns terms types = Defns
   { terms :: terms,
     types :: types
   }
-  deriving stock (Generic, Show)
+  deriving stock (Generic, Functor, Show)
   deriving (Monoid, Semigroup) via GenericSemigroupMonoid (Defns terms types)
 
 instance Bifoldable Defns where

--- a/lib/unison-util-nametree/unison-util-nametree.cabal
+++ b/lib/unison-util-nametree/unison-util-nametree.cabal
@@ -53,7 +53,6 @@ library
       TupleSections
       TypeApplications
       ViewPatterns
-  ghc-options: -Wall
   build-depends:
       base
     , containers

--- a/lib/unison-util-relation/unison-util-relation.cabal
+++ b/lib/unison-util-relation/unison-util-relation.cabal
@@ -39,7 +39,6 @@ library
       TupleSections
       TypeApplications
       ViewPatterns
-  ghc-options: -Wall
   build-depends:
       base
     , containers
@@ -70,7 +69,6 @@ test-suite util-relation-tests
       TupleSections
       TypeApplications
       ViewPatterns
-  ghc-options: -Wall
   build-depends:
       base
     , code-page
@@ -105,7 +103,6 @@ benchmark relation
       TupleSections
       TypeApplications
       ViewPatterns
-  ghc-options: -Wall
   build-depends:
       base
     , code-page

--- a/parser-typechecker/src/Unison/Builtin.hs
+++ b/parser-typechecker/src/Unison/Builtin.hs
@@ -985,7 +985,7 @@ refPromiseBuiltins =
 forall1 :: Text -> (Type -> Type) -> Type
 forall1 name body =
   let a = Var.named name
-   in Type.forall () a (body $ Type.var () a)
+   in Type.forAll () a (body $ Type.var () a)
 
 forall2 ::
   Text -> Text -> (Type -> Type -> Type) -> Type

--- a/parser-typechecker/src/Unison/Builtin/Decls.hs
+++ b/parser-typechecker/src/Unison/Builtin/Decls.hs
@@ -596,7 +596,7 @@ builtinEffectDecls =
         Structural
         ()
         []
-        [ ((), v "Exception.raise", Type.forall () (v "x") (failureType () `arr` self (var "x")))
+        [ ((), v "Exception.raise", Type.forAll () (v "x") (failureType () `arr` self (var "x")))
         ]
 
 pattern UnitRef :: Reference

--- a/parser-typechecker/src/Unison/Codebase/Execute.hs
+++ b/parser-typechecker/src/Unison/Codebase/Execute.hs
@@ -6,7 +6,8 @@
 module Unison.Codebase.Execute where
 
 import Control.Exception (finally)
-import Control.Monad.Except
+import Control.Monad.Except (throwError, runExceptT)
+import Control.Monad.IO.Class (liftIO)
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch qualified as Branch
 import Unison.Codebase.Branch.Names qualified as Branch

--- a/parser-typechecker/src/Unison/Codebase/MainTerm.hs
+++ b/parser-typechecker/src/Unison/Codebase/MainTerm.hs
@@ -57,7 +57,7 @@ getMainTerm loadTypeOfTerm parseNames mainName mainType = do
 builtinMain :: (Var v) => a -> Type.Type v a
 builtinMain a =
   let result = Var.named "result"
-   in Type.forall a result (builtinMainWithResultType a (Type.var a result))
+   in Type.forAll a result (builtinMainWithResultType a (Type.var a result))
 
 -- '{io2.IO, Exception} res
 builtinMainWithResultType :: (Var v) => a -> Type.Type v a -> Type.Type v a

--- a/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema6To7.hs
+++ b/parser-typechecker/src/Unison/Codebase/SqliteCodebase/Migrations/MigrateSchema6To7.hs
@@ -4,7 +4,6 @@
 
 module Unison.Codebase.SqliteCodebase.Migrations.MigrateSchema6To7 (migrateSchema6To7) where
 
-import Control.Monad.Except
 import Control.Monad.State
 import U.Codebase.Branch.Type (NamespaceStats)
 import U.Codebase.Sqlite.DbId qualified as DB

--- a/parser-typechecker/src/Unison/KindInference/Solve/Monad.hs
+++ b/parser-typechecker/src/Unison/KindInference/Solve/Monad.hs
@@ -14,6 +14,7 @@ module Unison.KindInference.Solve.Monad
 where
 
 import Control.Lens (Lens', (%%~))
+import Control.Monad.Fix (MonadFix (..))
 import Control.Monad.Reader qualified as M
 import Control.Monad.State.Strict qualified as M
 import Data.Functor.Identity
@@ -64,7 +65,7 @@ newtype Solve v loc a = Solve {unSolve :: Env -> SolveState v loc -> (a, SolveSt
     ( Functor,
       Applicative,
       Monad,
-      M.MonadFix,
+      MonadFix,
       M.MonadReader Env,
       M.MonadState (SolveState v loc)
     )

--- a/parser-typechecker/src/Unison/PatternMatchCoverage/Solve.hs
+++ b/parser-typechecker/src/Unison/PatternMatchCoverage/Solve.hs
@@ -518,12 +518,9 @@ addConstraint con0 nc = do
     C.PosLit var pmlit ->
       let updateLiteral pos neg lit
             | Just lit1 <- pos,
-              lit1 == lit = case lit1 == lit of
-                -- we already have this positive constraint
-                True -> (pure (), Ignore)
-                -- contradicts positive info
-                False -> (contradiction, Ignore)
-            -- the constraint contradicts negative info
+              lit1 == lit =
+                (pure (), Ignore) -- we already have this positive constraint
+                -- the constraint contradicts negative info
             | Set.member lit neg = (contradiction, Ignore)
             | otherwise = (pure (), Update (Just lit, neg))
        in modifyLiteralC var pmlit updateLiteral nc

--- a/parser-typechecker/src/Unison/Runtime/MCode.hs
+++ b/parser-typechecker/src/Unison/Runtime/MCode.hs
@@ -36,7 +36,6 @@ module Unison.Runtime.MCode
   )
 where
 
-import Control.Applicative (liftA2)
 import Data.Bifunctor (bimap, first)
 import Data.Bits (shiftL, shiftR, (.|.))
 import Data.Coerce

--- a/parser-typechecker/src/Unison/Runtime/Serialize.hs
+++ b/parser-typechecker/src/Unison/Runtime/Serialize.hs
@@ -2,7 +2,6 @@
 
 module Unison.Runtime.Serialize where
 
-import Control.Applicative (liftA2)
 import Control.Monad (replicateM)
 import Data.Bits (Bits)
 import Data.ByteString qualified as B

--- a/parser-typechecker/src/Unison/Syntax/TypeParser.hs
+++ b/parser-typechecker/src/Unison/Syntax/TypeParser.hs
@@ -31,7 +31,7 @@ type TypeP v m = P v m (Type v Ann)
 -- the right of a function arrow:
 --   valueType ::= Int | Text | App valueType valueType | Arrow valueType computationType
 valueType :: (Monad m, Var v) => TypeP v m
-valueType = forall type1 <|> type1
+valueType = forAll type1 <|> type1
 
 -- Computation
 -- computationType ::= [{effect*}] valueType
@@ -119,8 +119,8 @@ arrow rec =
    in chainr1 (effect <|> rec) (reserved "->" *> eff)
 
 -- "forall a b . List a -> List b -> Maybe Text"
-forall :: (Var v) => TypeP v m -> TypeP v m
-forall rec = do
+forAll :: (Var v) => TypeP v m -> TypeP v m
+forAll rec = do
   kw <- reserved "forall" <|> reserved "∀"
   vars <- fmap (fmap L.payload) . some $ prefixDefinitionName
   _ <- reserved "."

--- a/parser-typechecker/src/Unison/Typechecker/Context.hs
+++ b/parser-typechecker/src/Unison/Typechecker/Context.hs
@@ -963,7 +963,7 @@ apply' solvedExistentials t = go t
       Type.Ann' v k -> Type.ann a (go v) k
       Type.Effect1' e t -> Type.effect1 a (go e) (go t)
       Type.Effects' es -> Type.effects a (map go es)
-      Type.ForallNamed' v t' -> Type.forall a v (go t')
+      Type.ForallNamed' v t' -> Type.forAll a v (go t')
       Type.IntroOuterNamed' v t' -> Type.introOuter a v (go t')
       _ -> error $ "Match error in Context.apply': " ++ show t
       where
@@ -1059,7 +1059,7 @@ vectorConstructorOfArity loc arity = do
   let elementVar = Var.named "elem"
       args = replicate arity (loc, Type.var loc elementVar)
       resultType = Type.app loc (Type.list loc) (Type.var loc elementVar)
-      vt = Type.forall loc elementVar (Type.arrows args resultType)
+      vt = Type.forAll loc elementVar (Type.arrows args resultType)
   pure vt
 
 generalizeAndUnTypeVar :: (Var v) => Type v a -> Type.Type v a
@@ -1984,7 +1984,7 @@ tweakEffects v0 t0
     rewrite p ty
       | Type.ForallNamed' v t <- ty,
         v0 /= v =
-          second (Type.forall a v) <$> rewrite p t
+          second (Type.forAll a v) <$> rewrite p t
       | Type.Arrow' i o <- ty = do
           (vis, i) <- rewrite (not <$> p) i
           (vos, o) <- rewrite p o
@@ -2097,7 +2097,7 @@ generalizeP p ctx0 ty = foldr gen (applyCtx ctx0 ty) ctx
           -- location of the forall is just the location of the input type
           -- and the location of each quantified variable is just inherited
           -- from its source location
-          Type.forall
+          Type.forAll
             (loc t)
             (TypeVar.Universal v)
             (ABT.substInheritAnnotation tv (universal' () v) t)

--- a/parser-typechecker/tests/Unison/Test/DataDeclaration.hs
+++ b/parser-typechecker/tests/Unison/Test/DataDeclaration.hs
@@ -88,7 +88,7 @@ unhashComponentTest =
     inventedVarsFreshnessTest =
       let var = Type.var ()
           app = Type.app ()
-          forall = Type.forall ()
+          forAll = Type.forall ()
           (-->) = Type.arrow ()
           h = Hash.fromByteString (encodeUtf8 "abcd")
           ref = R.Id h 0
@@ -104,8 +104,8 @@ unhashComponentTest =
                 annotation = (),
                 bound = [],
                 constructors' =
-                  [ ((), nil, forall a (listType `app` var a)),
-                    ((), cons, forall b (var b --> listType `app` var b --> listType `app` var b))
+                  [ ((), nil, forAll a (listType `app` var a)),
+                    ((), cons, forAll b (var b --> listType `app` var b --> listType `app` var b))
                   ]
               }
           component :: Map R.Id (Decl Symbol ())
@@ -120,7 +120,7 @@ unhashComponentTest =
        in tests
             [ -- check that `nil` constructor's type did not collapse to `forall a. a a`,
               -- which would happen if the var invented for `listRef` was simply `Var.refNamed listRef`
-              expectEqual (forall z (listType' `app` var z)) nilType',
+              expectEqual (forAll z (listType' `app` var z)) nilType',
               -- check that the variable assigned to `listRef` is different from `cons`,
               -- which would happen if the var invented for `listRef` was simply `Var.refNamed listRef`
               expectNotEqual cons listVar

--- a/parser-typechecker/tests/Unison/Test/Typechecker.hs
+++ b/parser-typechecker/tests/Unison/Test/Typechecker.hs
@@ -18,12 +18,12 @@ test =
 isSubtypeTest :: Test ()
 isSubtypeTest =
   let symbol i n = Symbol i (Var.User n)
-      forall v t = Type.forall () v t
+      forAll v t = Type.forall () v t
       var v = Type.var () v
 
       a = symbol 0 "a"
       a_ i = symbol i "a"
-      lhs = forall a (var a) -- ∀a. a
+      lhs = forAll a (var a) -- ∀a. a
       rhs_ i = var (a_ i) -- a_i
    in -- check that `∀a. a <: a_i` (used to fail for i = 2, 3)
       tests [expectSubtype lhs (rhs_ i) | i <- [0 .. 5]]

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -220,7 +220,7 @@ library
       TypeApplications
       TypeFamilies
       ViewPatterns
-  ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
+  ghc-options: -Wall -Werror -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures
   build-depends:
       IntervalMap
     , ListLike
@@ -416,7 +416,7 @@ test-suite parser-typechecker-tests
       TypeApplications
       TypeFamilies
       ViewPatterns
-  ghc-options: -Wall -O0 -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -W -threaded -rtsopts "-with-rtsopts=-N -T" -v0
+  ghc-options: -Wall -Werror -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -W -threaded -rtsopts "-with-rtsopts=-N -T" -v0
   build-depends:
       IntervalMap
     , ListLike

--- a/unison-cli-integration/unison-cli-integration.cabal
+++ b/unison-cli-integration/unison-cli-integration.cabal
@@ -58,7 +58,7 @@ executable cli-integration-tests
       TupleSections
       TypeApplications
       ViewPatterns
-  ghc-options: -Wall -W -threaded -rtsopts "-with-rtsopts=-N -T" -v0
+  ghc-options: -Wall -Werror -W -threaded -rtsopts "-with-rtsopts=-N -T" -v0
   build-tool-depends:
       unison-cli-main:unison
   build-depends:

--- a/unison-cli-main/unison-cli-main.cabal
+++ b/unison-cli-main/unison-cli-main.cabal
@@ -60,7 +60,7 @@ executable unison
       TupleSections
       TypeApplications
       ViewPatterns
-  ghc-options: -Wall -threaded -rtsopts "-with-rtsopts=-I0 -N -qn4 -qg1 -T" -optP-Wno-nonportable-include-path
+  ghc-options: -Wall -Werror -threaded -rtsopts "-with-rtsopts=-I0 -N -qn4 -qg1 -T" -optP-Wno-nonportable-include-path
   build-depends:
       base
     , shellmet

--- a/unison-cli/src/Unison/Cli/Share/Projects.hs
+++ b/unison-cli/src/Unison/Cli/Share/Projects.hs
@@ -256,10 +256,9 @@ servantClientToCli action = do
   let clientEnv :: ClientEnv
       clientEnv =
         (mkClientEnv httpManager hardCodedBaseUrl)
-          { Servant.makeClientRequest = \url request ->
-              (Servant.defaultMakeClientRequest url request)
-                { Http.Client.responseTimeout = Http.Client.responseTimeoutMicro (60 * 1000 * 1000 {- 60s -})
-                }
+          { Servant.makeClientRequest = \url request -> do
+              defaultRequest <- (Servant.defaultMakeClientRequest url request)
+              return defaultRequest { Http.Client.responseTimeout = Http.Client.responseTimeoutMicro (60 * 1000 * 1000 {- 60s -}) }
           }
 
   liftIO (runClientM action clientEnv)

--- a/unison-cli/src/Unison/CommandLine/Completion.hs
+++ b/unison-cli/src/Unison/CommandLine/Completion.hs
@@ -196,12 +196,6 @@ completeWithinNamespace compTypes query currentPath = do
     namesInBranch :: Int -> V2Branch.Branch Sqlite.Transaction -> Sqlite.Transaction [(CompletionType, Bool, Text)]
     namesInBranch hashLen b = do
       nonEmptyChildren <- V2Branch.nonEmptyChildren b
-      let textifyHQ :: (NameSegment -> r -> HQ'.HashQualified NameSegment) -> Map NameSegment (Map r metadata) -> [(Bool, Text)]
-          textifyHQ f xs =
-            xs
-              & hashQualifyCompletions f
-              & fmap (HQ'.toTextWith NameSegment.toEscapedText)
-              & fmap (True,)
       pure $
         concat
           [ (NamespaceCompletion,False,) <$> (fmap NameSegment.toEscapedText . Map.keys $ nonEmptyChildren),
@@ -216,6 +210,12 @@ completeWithinNamespace compTypes query currentPath = do
               (fmap ((PatchCompletion,True,) . NameSegment.toEscapedText) . Map.keys $ V2Branch.patches b)
           ]
 
+    textifyHQ :: (NameSegment -> r -> HQ'.HashQualified NameSegment) -> Map NameSegment (Map r metadata) -> [(Bool, Text)]
+    textifyHQ f xs =
+      xs
+        & hashQualifyCompletions f
+        & fmap (HQ'.toTextWith NameSegment.toEscapedText)
+        & fmap (True,)
     -- Regrettably there'shqFromNamedV2Referencenot a great spot to combinators for V2 references and shorthashes right now.
     hqFromNamedV2Referent :: Int -> NameSegment -> Referent.Referent -> HQ'.HashQualified NameSegment
     hqFromNamedV2Referent hashLen n r = HQ'.HashQualified n (Cv.referent2toshorthash1 (Just hashLen) r)

--- a/unison-cli/src/Unison/LSP/CodeLens.hs
+++ b/unison-cli/src/Unison/LSP/CodeLens.hs
@@ -6,7 +6,6 @@
 module Unison.LSP.CodeLens where
 
 import Control.Lens hiding (List)
-import Control.Monad.Except
 import Data.Aeson qualified as Aeson
 import Data.Map qualified as Map
 import Data.Text qualified as Text

--- a/unison-cli/src/Unison/LSP/UCMWorker.hs
+++ b/unison-cli/src/Unison/LSP/UCMWorker.hs
@@ -1,6 +1,9 @@
 module Unison.LSP.UCMWorker where
 
-import Control.Monad.Reader
+import Control.Monad (guard)
+import Control.Monad.State (liftIO)
+import Control.Monad.Reader.Class (ask)
+import Data.Functor (void)
 import U.Codebase.HashTags
 import Unison.Codebase qualified as Codebase
 import Unison.Codebase.Branch qualified as Branch

--- a/unison-cli/src/Unison/Share/Sync.hs
+++ b/unison-cli/src/Unison/Share/Sync.hs
@@ -1051,10 +1051,10 @@ httpUploadEntities ::
       go f (Auth.AuthenticatedHttpClient httpClient) unisonShareUrl req =
         (Servant.mkClientEnv httpClient unisonShareUrl)
           { Servant.makeClientRequest = \url request ->
-              -- Disable client-side timeouts
-              (Servant.defaultMakeClientRequest url request)
-                { Http.Client.responseTimeout = Http.Client.responseTimeoutNone
-                }
+              do
+                -- Disable client-side timeouts
+                defaultRequest <- (Servant.defaultMakeClientRequest url request)
+                return defaultRequest {Http.Client.responseTimeout = Http.Client.responseTimeoutNone}
           }
           & runReaderT (f req)
           & runExceptT

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -180,7 +180,6 @@ library
       TupleSections
       TypeApplications
       ViewPatterns
-  ghc-options: -Wall
   build-depends:
       IntervalMap
     , ListLike
@@ -321,7 +320,7 @@ executable transcripts
       TupleSections
       TypeApplications
       ViewPatterns
-  ghc-options: -Wall -threaded -rtsopts "-with-rtsopts=-I0 -N -qn4 -qg1" -v0
+  ghc-options: -Wall -Werror -threaded -rtsopts "-with-rtsopts=-I0 -N -qn4 -qg1" -v0
   build-depends:
       IntervalMap
     , ListLike
@@ -469,7 +468,6 @@ test-suite cli-tests
       TupleSections
       TypeApplications
       ViewPatterns
-  ghc-options: -Wall
   build-depends:
       IntervalMap
     , ListLike

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -216,7 +216,7 @@ library
     , ki
     , lens
     , lock-file
-    , lsp >=2.2.0.0
+    , lsp ==2.2.0.0
     , lsp-types >=2.0.2.0
     , megaparsec
     , memory
@@ -358,7 +358,7 @@ executable transcripts
     , ki
     , lens
     , lock-file
-    , lsp >=2.2.0.0
+    , lsp ==2.2.0.0
     , lsp-types >=2.0.2.0
     , megaparsec
     , memory
@@ -507,7 +507,7 @@ test-suite cli-tests
     , ki
     , lens
     , lock-file
-    , lsp >=2.2.0.0
+    , lsp ==2.2.0.0
     , lsp-types >=2.0.2.0
     , megaparsec
     , memory

--- a/unison-cli/unison-cli.cabal
+++ b/unison-cli/unison-cli.cabal
@@ -236,7 +236,7 @@ library
     , semialign
     , semigroups
     , servant
-    , servant-client
+    , servant-client >=0.20
     , shellmet
     , stm
     , template-haskell
@@ -378,7 +378,7 @@ executable transcripts
     , semialign
     , semigroups
     , servant
-    , servant-client
+    , servant-client >=0.20
     , shellmet
     , silently
     , stm
@@ -526,7 +526,7 @@ test-suite cli-tests
     , semialign
     , semigroups
     , servant
-    , servant-client
+    , servant-client >=0.20
     , shellmet
     , stm
     , template-haskell

--- a/unison-core/src/Unison/Term.hs
+++ b/unison-core/src/Unison/Term.hs
@@ -397,7 +397,7 @@ substTypeVar vt ty = go Set.empty
                           t2 = ABT.bindInheritAnnotation body (Type.var () v2)
                        in uncapture ((ABT.annotation t, v2) : vs) (renameTypeVar v v2 e) t2
                 uncapture vs e t0 =
-                  let t = foldl (\body (loc, v) -> Type.forall loc v body) t0 vs
+                  let t = foldl (\body (loc, v) -> Type.forAll loc v body) t0 vs
                       bound' = case Type.unForalls (Type.stripIntroOuters t) of
                         Nothing -> bound
                         Just (vs, _) -> bound <> Set.fromList vs

--- a/unison-core/unison-core1.cabal
+++ b/unison-core/unison-core1.cabal
@@ -85,7 +85,7 @@ library
       TupleSections
       TypeApplications
       ViewPatterns
-  ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -funbox-strict-fields
+  ghc-options: -Wall -Werror -fno-warn-name-shadowing -fno-warn-missing-pattern-synonym-signatures -funbox-strict-fields
   build-depends:
       base
     , bytestring

--- a/unison-hashing-v2/src/Unison/Hashing/V2/Type.hs
+++ b/unison-hashing-v2/src/Unison/Hashing/V2/Type.hs
@@ -103,15 +103,15 @@ charRef = ReferenceBuiltin "Char"
 listRef = ReferenceBuiltin "Sequence"
 effectRef = ReferenceBuiltin "Effect"
 
-forall :: (Ord v) => a -> v -> Type v a -> Type v a
-forall a v body = ABT.tm' a (TypeForall (ABT.abs' a v body))
+forAll :: (Ord v) => a -> v -> Type v a -> Type v a
+forAll a v body = ABT.tm' a (TypeForall (ABT.abs' a v body))
 
 -- | Bind the given variables with an outer `forall`, if they are used in `t`.
 generalize :: (Ord v) => [v] -> Type v a -> Type v a
 generalize vs t = foldr f t vs
   where
     f v t =
-      if Set.member v (ABT.freeVars t) then forall (ABT.annotation t) v t else t
+      if Set.member v (ABT.freeVars t) then forAll (ABT.annotation t) v t else t
 
 unforall' :: Type v a -> ([v], Type v a)
 unforall' (ForallsNamed' vs t) = (vs, t)

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/Current.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/Current.hs
@@ -3,7 +3,6 @@
 
 module Unison.Server.Local.Endpoints.Current where
 
-import Control.Monad.Except
 import Data.Aeson
 import Data.OpenApi (ToSchema (..))
 import Servant ((:>))

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/FuzzyFind.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/FuzzyFind.hs
@@ -4,7 +4,6 @@
 
 module Unison.Server.Local.Endpoints.FuzzyFind where
 
-import Control.Monad.Except
 import Data.Aeson
 import Data.OpenApi (ToSchema)
 import Servant

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/NamespaceDetails.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/NamespaceDetails.hs
@@ -4,7 +4,6 @@
 
 module Unison.Server.Local.Endpoints.NamespaceDetails where
 
-import Control.Monad.Except
 import Data.Set qualified as Set
 import Servant (Capture, QueryParam, (:>))
 import Servant.Docs (DocCapture (..), ToCapture (..))

--- a/unison-share-api/src/Unison/Server/Local/Endpoints/NamespaceListing.hs
+++ b/unison-share-api/src/Unison/Server/Local/Endpoints/NamespaceListing.hs
@@ -4,7 +4,6 @@
 
 module Unison.Server.Local.Endpoints.NamespaceListing (serve, NamespaceListingAPI, NamespaceListing (..), NamespaceObject (..), NamedNamespace (..), NamedPatch (..), KindExpression (..)) where
 
-import Control.Monad.Except
 import Data.Aeson
 import Data.OpenApi (ToSchema)
 import Servant

--- a/unison-share-api/src/Unison/Server/Types.hs
+++ b/unison-share-api/src/Unison/Server/Types.hs
@@ -104,7 +104,7 @@ data ExactName name ref = ExactName
   { name :: name,
     ref :: ref
   }
-  deriving stock (Show, Eq, Ord)
+  deriving stock (Show, Eq, Functor, Ord)
 
 instance ToParamSchema (ExactName Name ShortHash) where
   toParamSchema _ =

--- a/unison-share-api/src/Unison/Sync/Types.hs
+++ b/unison-share-api/src/Unison/Sync/Types.hs
@@ -203,7 +203,7 @@ entityDependencies = \case
   C Causal {namespaceHash, parents} -> Set.insert namespaceHash parents
 
 data TermComponent text hash = TermComponent [(LocalIds text hash, ByteString)]
-  deriving stock (Show, Eq, Ord)
+  deriving stock (Show, Eq, Functor, Ord)
 
 instance Bifoldable TermComponent where
   bifoldMap = bifoldMapDefault
@@ -252,7 +252,7 @@ decodeComponentPiece = Aeson.withObject "Component Piece" \obj -> do
   pure (localIDs, bytes)
 
 data DeclComponent text hash = DeclComponent [(LocalIds text hash, ByteString)]
-  deriving stock (Show, Eq, Ord)
+  deriving stock (Show, Eq, Functor, Ord)
 
 instance Bifoldable DeclComponent where
   bifoldMap = bifoldMapDefault
@@ -280,7 +280,7 @@ data LocalIds text hash = LocalIds
   { texts :: [text],
     hashes :: [hash]
   }
-  deriving stock (Show, Eq, Ord)
+  deriving stock (Show, Eq, Functor, Ord)
 
 instance Bifoldable LocalIds where
   bifoldMap = bifoldMapDefault
@@ -381,7 +381,7 @@ data Namespace text hash = Namespace
     childLookup :: [(hash, hash)], -- (namespace hash, causal hash)
     bytes :: LocalBranchBytes
   }
-  deriving stock (Eq, Ord, Show)
+  deriving stock (Eq, Functor, Ord, Show)
 
 instance Bifoldable Namespace where
   bifoldMap = bifoldMapDefault

--- a/unison-share-api/unison-share-api.cabal
+++ b/unison-share-api/unison-share-api.cabal
@@ -81,7 +81,6 @@ library
       TypeOperators
       ViewPatterns
       ImportQualifiedPost
-  ghc-options: -Wall
   build-depends:
       Diff
     , NanoID


### PR DESCRIPTION
## Overview

This is a proof-of-concept PR which has all the changes required to get Unison to compile with Cabal and GHC 964 - Tested only on Nixos and OpenBSD 7.5.

It is not mergeable nor do I really want to merge it .   I would like to split it up and merge the backward compatible bits first instead.  Let me know if you have any ideas on how we should do this :smile: 

Note there's a couple of packages which break backward compatibility
* `lsp` (I've pined to 2.2.0.0 for now)
* `servant` needs to be on 0.20 as 0.19 requires base<4.18 but GHC 964 is on base==4.18

Added self-review comments explaining my changes.

## Testing

* unison executable compiles, runs, serves local UI, auths and pulls from unison-share
* `cabal v2-test --project-file=contrib/cabal.project all` passes

![image](https://github.com/unisonweb/unison/assets/666148/42db2b4d-332b-4e0d-84b8-da8e8d1d3696)

![image](https://github.com/unisonweb/unison/assets/666148/a7a55372-f2d8-4c52-a2c0-68f92f6b193b)

All testing was done by hand.

## Loose ends

Do let me know if this is useful and if so, any thoughts on splitting up by hand.  I can make many small PRs but I'm thinking that might also be tedious to review