### PR TITLE
Implement custom Word64 delay

### DIFF
--- a/parser-typechecker/src/Unison/Runtime/Builtin.hs
+++ b/parser-typechecker/src/Unison/Runtime/Builtin.hs
@@ -2599,8 +2599,16 @@ declareForeigns = do
 
   declareForeign Tracked "IO.kill.impl.v3" boxToEF0 $ mkForeignIOF killThread
 
+  let mx :: Word64
+      mx = fromIntegral (maxBound :: Int)
+
+      customDelay :: Word64 -> IO ()
+      customDelay n
+        | n < mx = threadDelay (fromIntegral n)
+        | otherwise = threadDelay maxBound >> customDelay (n - mx)
+
   declareForeign Tracked "IO.delay.impl.v3" natToEFUnit $
-    mkForeignIOF threadDelay
+    mkForeignIOF customDelay
 
   declareForeign Tracked "IO.stdHandle" standard'handle
     . mkForeign


### PR DESCRIPTION
The builtin is specified to take a `Nat`, but Haskell's `threadDelay` takes an `Int`. So the previous implementation was erroneously treating large numbers as negatives and not sleeping at all. Instead we split the wait into multiple delays for large numbers (although practically the second delay won't be reached).

Fixes #3957